### PR TITLE
Material: use class properties

### DIFF
--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -6,6 +6,8 @@ let materialId = 0;
 
 class Material extends EventDispatcher {
 
+	#alphaTest = 0;
+
 	constructor() {
 
 		super();
@@ -73,25 +75,23 @@ class Material extends EventDispatcher {
 
 		this.version = 0;
 
-		this._alphaTest = 0;
-
 	}
 
 	get alphaTest() {
 
-		return this._alphaTest;
+		return this.#alphaTest;
 
 	}
 
 	set alphaTest( value ) {
 
-		if ( this._alphaTest > 0 !== value > 0 ) {
+		if ( this.#alphaTest > 0 !== value > 0 ) {
 
 			this.version ++;
 
 		}
 
-		this._alphaTest = value;
+		this.#alphaTest = value;
 
 	}
 


### PR DESCRIPTION
Related issue: #22437

**Description**

1 year has passed since last time we tried. Maybe it's time to test the waters again? 🤓

[create-react-app has since released version 5](https://github.com/facebook/create-react-app/releases/tag/v5.0.0), which uses Webpack 5. So it doesn't error there anymore.