### PR TITLE
ArcballControls: Use dispose() in makeGizmos().

### DIFF
--- a/examples/jsm/controls/ArcballControls.js
+++ b/examples/jsm/controls/ArcballControls.js
@@ -2279,7 +2279,7 @@ class ArcballControls extends EventDispatcher {
 		this._gizmoMatrixState0.identity().setPosition( tbCenter );
 		this._gizmoMatrixState.copy( this._gizmoMatrixState0 );
 
-		if ( this.camera.zoom != 1 ) {
+		if ( this.camera.zoom !== 1 ) {
 
 			//adapt gizmos size to camera zoom
 			const size = 1 / this.camera.zoom;
@@ -2294,7 +2294,22 @@ class ArcballControls extends EventDispatcher {
 
 		this._gizmoMatrixState.decompose( this._gizmos.position, this._gizmos.quaternion, this._gizmos.scale );
 
+		//
+
+		this._gizmos.traverse( function( object ) {
+
+			if ( object.isLine ) {
+		
+				object.geometry.dispose();
+				object.material.dispose();
+		
+			}
+		
+		} );
+
 		this._gizmos.clear();
+
+		//
 
 		this._gizmos.add( gizmoX );
 		this._gizmos.add( gizmoY );


### PR DESCRIPTION
Related issue: https://discourse.threejs.org/t/arcballcontrols-gizmos-leaking-geometries/39281

**Description**

A user (@Vlad-Apostolov) in the forum noticed that `makeGizmos()` does not properly remove objects from the scene. 
