### PR TITLE
TransformControls: Improve gizmo rendering with orthographic cameras.

### DIFF
--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -205,7 +205,15 @@ class TransformControls extends Object3D {
 		this.camera.updateMatrixWorld();
 		this.camera.matrixWorld.decompose( this.cameraPosition, this.cameraQuaternion, this._cameraScale );
 
-		this.eye.copy( this.cameraPosition ).sub( this.worldPosition ).normalize();
+		if ( this.camera.isOrthographicCamera ) {
+
+			this.camera.getWorldDirection( this.eye );
+
+		} else {
+
+			this.eye.copy( this.cameraPosition ).sub( this.worldPosition ).normalize();
+
+		}
 
 		super.updateMatrixWorld( this );
 


### PR DESCRIPTION
Fixed #24208.

**Description**

This PR implements the suggestion of https://github.com/mrdoob/three.js/issues/24208#issuecomment-1153165586 to mitigate the issue of disappearing gizmos when using `TransformControls` with orthographic cameras.
