### PR TITLE
WebGLRenderer: call setTextureCube and setTexture3D on initTexture

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2176,7 +2176,31 @@ function WebGLRenderer( parameters = {} ) {
 
 	this.initTexture = function ( texture ) {
 
-		textures.setTexture2D( texture, 0 );
+		if ( texture.isCubeTexture ) {
+
+			textures.setTextureCube( texture, 0 );
+
+		} else {
+
+			if ( texture.isData3DTexture ) {
+
+				texture.setTexture3D( texture, 0 );
+
+			} else {
+
+				if ( texture.isDataArrayTexture ) {
+
+					texture.setTexture2DArray( texture, 0 );
+
+				} else {
+
+					textures.setTexture2D( texture, 0 );
+
+				}
+
+			}
+
+		}
 
 		state.unbindTexture();
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2180,25 +2180,17 @@ function WebGLRenderer( parameters = {} ) {
 
 			textures.setTextureCube( texture, 0 );
 
+		} else if ( texture.isData3DTexture ) {
+
+			textures.setTexture3D( texture, 0 );
+
+		} else if ( texture.isDataArrayTexture ) {
+
+			textures.setTexture2DArray( texture, 0 );
+
 		} else {
 
-			if ( texture.isData3DTexture ) {
-
-				texture.setTexture3D( texture, 0 );
-
-			} else {
-
-				if ( texture.isDataArrayTexture ) {
-
-					texture.setTexture2DArray( texture, 0 );
-
-				} else {
-
-					textures.setTexture2D( texture, 0 );
-
-				}
-
-			}
+			textures.setTexture2D( texture, 0 );
 
 		}
 


### PR DESCRIPTION
**Description**

Expose setTextureCube and setTexture3D functions at the WebGLRenderer initTexture.
So CubeTextures and Data3DTextures can be loaded on memory at the setup.

Same logic, usability and functionality as the former initTexture but allowing environment maps to also be properly pre-loaded.
