### PR TITLE
GLTFLoader: add getDependency( type, index ) implementation

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -578,6 +578,14 @@ class GLTFLightsExtension {
 
 	}
 
+	getDependency( type, index ) {	
+
+		if ( type !== 'light' ) return;
+
+		return this._loadLight( index );
+
+	}
+
 	createNodeAttachment( nodeIndex ) {
 
 		const self = this;

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2750,16 +2750,20 @@ class GLTFParser {
 					dependency = this.loadCamera( index );
 					break;
 
-				case 'light':
+				default:
 					dependency = this._invokeOne( function ( ext ) {
 
-						return ext._loadLight && ext._loadLight( index );
+						return ext != this && ext.getDependency && ext.getDependency( type, index );
 
 					} );
-					break;
 
-				default:
-					throw new Error( 'Unknown type: ' + type );
+					if ( ! dependency ) {
+
+						throw new Error( 'Unknown type: ' + type );
+
+					}
+
+					break;
 
 			}
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2750,6 +2750,14 @@ class GLTFParser {
 					dependency = this.loadCamera( index );
 					break;
 
+				case 'light':
+					dependency = this._invokeOne( function ( ext ) {
+
+						return ext._loadLight && ext._loadLight( index );
+
+					} );
+					break;
+
 				default:
 					throw new Error( 'Unknown type: ' + type );
 


### PR DESCRIPTION
**Description**

@takahirox requested that the `getDependency('light')` implementation should be a separate PR, so here it is.
This is in preparation for supporting the KHR_animation_pointer glTF extension in three.js.

This PR adds a new way for extensions to implement `getDependency( type, index )` for custom types; targets for implementation are right now `light` and `audio`.  

**Related:**
- #24193
- #24108