### PR TITLE
Docs: Clarify morph attributes usage.

### DIFF
--- a/docs/api/en/core/BufferGeometry.html
+++ b/docs/api/en/core/BufferGeometry.html
@@ -139,6 +139,7 @@
 		<h3>[property:Object morphAttributes]</h3>
 		<p>
 			Hashmap of [page:BufferAttribute]s holding details of the geometry's morph targets.
+			After the initial use of morph attributes, their data cannot be updated anymore. You have to call [page:.dispose]() and create a new instance of [name].
 		</p>
 
 		<h3>[property:Boolean morphTargetsRelative]</h3>

--- a/docs/api/ko/core/BufferGeometry.html
+++ b/docs/api/ko/core/BufferGeometry.html
@@ -135,6 +135,7 @@
 		<h3>[property:Object morphAttributes]</h3>
 		<p>
 			[page:BufferAttribute]의 해쉬맵은 기하학의 모프 타겟에 대한 세부정보를 담고 있습니다.
+			After the initial use of morph attributes, their data cannot be updated anymore. You have to call [page:.dispose]() and create a new instance of [name].
 		</p>
 
 		<h3>[property:Boolean morphTargetsRelative]</h3>

--- a/docs/api/zh/core/BufferGeometry.html
+++ b/docs/api/zh/core/BufferGeometry.html
@@ -131,6 +131,7 @@
 		<h3>[property:Object morphAttributes]</h3>
 		<p>
 			存储 [page:BufferAttribute] 的 Hashmap，存储了几何体 morph targets 的细节信息。
+			After the initial use of morph attributes, their data cannot be updated anymore. You have to call [page:.dispose]() and create a new instance of [name].
 		</p>
 
 		<h3>[property:Boolean morphTargetsRelative]</h3>


### PR DESCRIPTION
Fixed #24243.

**Description**

Clarify the usage of  morph attributes in the `BufferGeometry` page.