### PR TITLE
LDrawLoader: 2 bugs and 7 improvements

### DIFF
--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -28,10 +28,10 @@ const FINISH_TYPE_METAL = 5;
 
 // State machine to search a subobject path.
 // The LDraw standard establishes these various possible subfolders.
-const FILE_LOCATION_AS_IS = 0;
-const FILE_LOCATION_TRY_PARTS = 1;
-const FILE_LOCATION_TRY_P = 2;
-const FILE_LOCATION_TRY_MODELS = 3;
+const FILE_LOCATION_TRY_PARTS = 0;
+const FILE_LOCATION_TRY_P = 1;
+const FILE_LOCATION_TRY_MODELS = 2;
+const FILE_LOCATION_AS_IS = 3;
 const FILE_LOCATION_TRY_RELATIVE = 4;
 const FILE_LOCATION_TRY_ABSOLUTE = 5;
 const FILE_LOCATION_NOT_FOUND = 6;
@@ -688,7 +688,9 @@ class LDrawParsedCache {
 		result.type = original.type;
 		result.category = original.category;
 		result.keywords = original.keywords;
+		result.author = original.author;
 		result.subobjects = original.subobjects;
+		result.fileName = original.fileName;
 		result.totalFaces = original.totalFaces;
 		result.startingConstructionStep = original.startingConstructionStep;
 		result.materials = original.materials;
@@ -700,7 +702,7 @@ class LDrawParsedCache {
 	async fetchData( fileName ) {
 
 		let triedLowerCase = false;
-		let locationState = FILE_LOCATION_AS_IS;
+		let locationState = FILE_LOCATION_TRY_PARTS;
 		while ( locationState !== FILE_LOCATION_NOT_FOUND ) {
 
 			let subobjectURL = fileName;
@@ -743,7 +745,7 @@ class LDrawParsedCache {
 						fileName = fileName.toLowerCase();
 						subobjectURL = fileName;
 						triedLowerCase = true;
-						locationState = FILE_LOCATION_AS_IS;
+						locationState = FILE_LOCATION_TRY_PARTS;
 
 					}
 
@@ -794,6 +796,7 @@ class LDrawParsedCache {
 		let type = 'Model';
 		let category = null;
 		let keywords = null;
+		let author = null;
 		let totalFaces = 0;
 
 		// split into lines
@@ -992,6 +995,12 @@ class LDrawParsedCache {
 							case 'STEP':
 
 								startingConstructionStep = true;
+
+								break;
+
+							case 'Author:':
+
+								author = lp.getToken();
 
 								break;
 
@@ -1221,6 +1230,7 @@ class LDrawParsedCache {
 			type,
 			category,
 			keywords,
+			author,
 			subobjects,
 			totalFaces,
 			startingConstructionStep,
@@ -1356,6 +1366,9 @@ class LDrawPartsGeometryCache {
 			const group = new Group();
 			group.userData.category = info.category;
 			group.userData.keywords = info.keywords;
+			group.userData.author = info.author;
+			group.userData.type = info.type;
+			group.userData.fileName = info.fileName;
 			info.group = group;
 
 			const subobjectInfos = await Promise.all( promises );
@@ -1380,6 +1393,7 @@ class LDrawPartsGeometryCache {
 					subobjectGroup.name = subobject.fileName;
 
 					loader.applyMaterialsToMesh( subobjectGroup, subobject.colorCode, info.materials );
+					subobjectGroup.userData.colorCode = subobject.colorCode;
 
 					group.add( subobjectGroup );
 					continue;
@@ -1473,6 +1487,7 @@ class LDrawPartsGeometryCache {
 			if ( subobject ) {
 
 				loader.applyMaterialsToMesh( group, subobject.colorCode, info.materials );
+				group.userData.colorCode = subobject.colorCode;
 
 			}
 
@@ -1883,6 +1898,11 @@ class LDrawLoader extends Loader {
 		// The path to load parts from the LDraw parts library from.
 		this.partsLibraryPath = '';
 
+		// Material assigned to not available colors for meshes and edges
+		this.missingColorMaterial = new MeshStandardMaterial( { color: 0xFF00FF, roughness: 0.3, metalness: 0 } );
+		this.missingEdgeColorMaterial = new LineBasicMaterial( { color: 0xFF00FF } );
+		this.missingConditionalEdgeColorMaterial = new LDrawConditionalLineMaterial( { fog: true, color: 0xFF00FF } );
+
 	}
 
 	setPartsLibraryPath( path ) {
@@ -1949,7 +1969,9 @@ class LDrawLoader extends Loader {
 			.parseModel( text, this.materialLibrary )
 			.then( group => {
 
+				this.applyMaterialsToMesh( group, MAIN_COLOUR_CODE, this.materialLibrary, true );<<<<
 				this.computeConstructionSteps( group );
+				group.userData.fileName = "";
 				onLoad( group );
 
 			} );
@@ -2080,8 +2102,24 @@ class LDrawLoader extends Loader {
 				material = loader.getMaterial( colorCode );
 				if ( material === null ) {
 
-					// otherwise throw an error if this is final opportunity to set the material
-					throw new Error( `LDrawLoader: Material properties for code ${ colorCode } not available.` );
+					// otherwise throw a warning if this is final opportunity to set the material
+					console.warn( `LDrawLoader: Material properties for code ${ colorCode } not available.` );
+
+					// And return the 'missing color' material
+					material = loader.missingColorMaterial.clone();
+					material.name = "Missing material for color code '" + colorCode + "'";
+					material.userData.code = colorCode;
+
+					const edgeMat = loader.missingEdgeColorMaterial.clone();
+					edgeMat.name = "Missing material for color code '" + colorCode + "' - Edge";
+					edgeMat.userData.code = colorCode;
+
+					const condEdgeMat = loader.missingConditionalEdgeColorMaterial.clone();
+					condEdgeMat.name = "Missing material for color code '" + colorCode + "' - Edge";
+					condEdgeMat.userData.code = colorCode;
+
+					material.userData.edgeMaterial = edgeMat;
+					material.userData.edgeMaterial.userData.conditionalEdgeMaterial = condEdgeMat;
 
 				}
 
@@ -2118,8 +2156,7 @@ class LDrawLoader extends Loader {
 
 	getMainEdgeMaterial() {
 
-		const mainMat = this.getMainMaterial();
-		return mainMat && mainMat.userData ? mainMat.userData.edgeMaterial : null;
+		return this.getMaterial( MAIN_EDGE_COLOUR_CODE );
 
 	}
 
@@ -2162,113 +2199,113 @@ class LDrawLoader extends Loader {
 
 			}
 
-			switch ( token.toUpperCase() ) {
+			if ( ! parseLuminance( token ) ) {
 
-				case 'CODE':
+				switch ( token.toUpperCase() ) {
 
-					code = lineParser.getToken();
-					break;
+					case 'CODE':
 
-				case 'VALUE':
+						code = lineParser.getToken();
+						break;
 
-					color = lineParser.getToken();
-					if ( color.startsWith( '0x' ) ) {
+					case 'VALUE':
 
-						color = '#' + color.substring( 2 );
+						color = lineParser.getToken();
+						if ( color.startsWith( '0x' ) ) {
 
-					} else if ( ! color.startsWith( '#' ) ) {
+							color = '#' + color.substring( 2 );
 
-						throw new Error( 'LDrawLoader: Invalid color while parsing material' + lineParser.getLineNumberString() + '.' );
+						} else if ( ! color.startsWith( '#' ) ) {
 
-					}
-
-					break;
-
-				case 'EDGE':
-
-					edgeColor = lineParser.getToken();
-					if ( edgeColor.startsWith( '0x' ) ) {
-
-						edgeColor = '#' + edgeColor.substring( 2 );
-
-					} else if ( ! edgeColor.startsWith( '#' ) ) {
-
-						// Try to see if edge color is a color code
-						edgeMaterial = this.getMaterial( edgeColor );
-						if ( ! edgeMaterial ) {
-
-							throw new Error( 'LDrawLoader: Invalid edge color while parsing material' + lineParser.getLineNumberString() + '.' );
+							throw new Error( 'LDrawLoader: Invalid color while parsing material' + lineParser.getLineNumberString() + '.' );
 
 						}
 
-						// Get the edge material for this triangle material
-						edgeMaterial = edgeMaterial.userData.edgeMaterial;
+						break;
 
-					}
+					case 'EDGE':
 
-					break;
+						edgeColor = lineParser.getToken();
+						if ( edgeColor.startsWith( '0x' ) ) {
 
-				case 'ALPHA':
+							edgeColor = '#' + edgeColor.substring( 2 );
 
-					alpha = parseInt( lineParser.getToken() );
+						} else if ( ! edgeColor.startsWith( '#' ) ) {
 
-					if ( isNaN( alpha ) ) {
+							// Try to see if edge color is a color code
+							edgeMaterial = this.getMaterial( edgeColor );
+							if ( ! edgeMaterial ) {
 
-						throw new Error( 'LDrawLoader: Invalid alpha value in material definition' + lineParser.getLineNumberString() + '.' );
+								throw new Error( 'LDrawLoader: Invalid edge color while parsing material' + lineParser.getLineNumberString() + '.' );
 
-					}
+							}
 
-					alpha = Math.max( 0, Math.min( 1, alpha / 255 ) );
+							// Get the edge material for this triangle material
+							edgeMaterial = edgeMaterial.userData.edgeMaterial;
 
-					if ( alpha < 1 ) {
+						}
 
-						isTransparent = true;
+						break;
 
-					}
+					case 'ALPHA':
 
-					break;
+						alpha = parseInt( lineParser.getToken() );
 
-				case 'LUMINANCE':
+						if ( isNaN( alpha ) ) {
 
-					luminance = parseInt( lineParser.getToken() );
+							throw new Error( 'LDrawLoader: Invalid alpha value in material definition' + lineParser.getLineNumberString() + '.' );
 
-					if ( isNaN( luminance ) ) {
+						}
 
-						throw new Error( 'LDrawLoader: Invalid luminance value in material definition' + LineParser.getLineNumberString() + '.' );
+						alpha = Math.max( 0, Math.min( 1, alpha / 255 ) );
 
-					}
+						if ( alpha < 1 ) {
 
-					luminance = Math.max( 0, Math.min( 1, luminance / 255 ) );
+							isTransparent = true;
 
-					break;
+						}
 
-				case 'CHROME':
-					finishType = FINISH_TYPE_CHROME;
-					break;
+						break;
 
-				case 'PEARLESCENT':
-					finishType = FINISH_TYPE_PEARLESCENT;
-					break;
+					case 'LUMINANCE':
 
-				case 'RUBBER':
-					finishType = FINISH_TYPE_RUBBER;
-					break;
+						if ( ! parseLuminance( lineParser.getToken() ) ) {
 
-				case 'MATTE_METALLIC':
-					finishType = FINISH_TYPE_MATTE_METALLIC;
-					break;
+							throw new Error( 'LDrawLoader: Invalid luminance value in material definition' + LineParser.getLineNumberString() + '.' );
 
-				case 'METAL':
-					finishType = FINISH_TYPE_METAL;
-					break;
+						}
 
-				case 'MATERIAL':
-					// Not implemented
-					lineParser.setToEnd();
-					break;
+						break;
 
-				default:
-					throw new Error( 'LDrawLoader: Unknown token "' + token + '" while parsing material' + lineParser.getLineNumberString() + '.' );
+					case 'CHROME':
+						finishType = FINISH_TYPE_CHROME;
+						break;
+
+					case 'PEARLESCENT':
+						finishType = FINISH_TYPE_PEARLESCENT;
+						break;
+
+					case 'RUBBER':
+						finishType = FINISH_TYPE_RUBBER;
+						break;
+
+					case 'MATTE_METALLIC':
+						finishType = FINISH_TYPE_MATTE_METALLIC;
+						break;
+
+					case 'METAL':
+						finishType = FINISH_TYPE_METAL;
+						break;
+
+					case 'MATERIAL':
+						// Not implemented
+						lineParser.setToEnd();
+						break;
+
+					default:
+						throw new Error( 'LDrawLoader: Unknown token "' + token + '" while parsing material' + lineParser.getLineNumberString() + '.' );
+
+				}
 
 			}
 
@@ -2358,6 +2395,8 @@ class LDrawLoader extends Loader {
 
 			} );
 			edgeMaterial.userData.conditionalEdgeMaterial.color.convertSRGBToLinear();
+			edgeMaterial.userData.conditionalEdgeMaterial.userData.code = code;
+			edgeMaterial.userData.conditionalEdgeMaterial.name = name + ' - Conditional Edge';
 
 		}
 
@@ -2369,6 +2408,35 @@ class LDrawLoader extends Loader {
 		this.addMaterial( material );
 
 		return material;
+
+		function parseLuminance( token ) {
+
+			// Returns success
+
+			let lum;
+
+			if ( token.startsWith( "LUMINANCE" ) ) {
+
+				lum = parseInt( token.substring( 9 ) );
+
+			}
+			else {
+
+				lum = parseInt( token );
+
+			}
+
+			if ( isNaN( lum ) ) {
+
+				return false;
+
+			}
+
+			luminance = Math.max( 0, Math.min( 1, lum / 255 ) );
+
+			return true;
+
+		}
 
 	}
 

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -2106,7 +2106,7 @@ class LDrawLoader extends Loader {
 					console.warn( `LDrawLoader: Material properties for code ${ colorCode } not available.` );
 
 					// And return the 'missing color' material
-					material = loader.missingColorMaterial.clone();
+					material = loader.missingColorMaterial;
 					material.name = "Missing material for color code '" + colorCode + "'";
 					material.userData.code = colorCode;
 
@@ -2415,7 +2415,7 @@ class LDrawLoader extends Loader {
 
 			let lum;
 
-			if ( token.startsWith( "LUMINANCE" ) ) {
+			if ( token.startsWith( 'LUMINANCE' ) ) {
 
 				lum = parseInt( token.substring( 9 ) );
 

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -2119,7 +2119,7 @@ class LDrawLoader extends Loader {
 					condEdgeMat.userData.code = colorCode;
 
 					material.userData.edgeMaterial = edgeMat;
-					material.userData.edgeMaterial.userData.conditionalEdgeMaterial = condEdgeMat;
+					edgeMat.userData.conditionalEdgeMaterial = condEdgeMat;
 
 				}
 

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -2149,7 +2149,8 @@ class LDrawLoader extends Loader {
 
 	getMainEdgeMaterial() {
 
-		return this.getMaterial( MAIN_EDGE_COLOUR_CODE ).userData.edgeMaterial;
+		const mat = this.getMaterial( MAIN_EDGE_COLOUR_CODE );
+		return mat ? mat.userData.edgeMaterial : null;
 
 	}
 

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -1969,7 +1969,7 @@ class LDrawLoader extends Loader {
 			.parseModel( text, this.materialLibrary )
 			.then( group => {
 
-				this.applyMaterialsToMesh( group, MAIN_COLOUR_CODE, this.materialLibrary, true );<<<<
+				this.applyMaterialsToMesh( group, MAIN_COLOUR_CODE, this.materialLibrary, true );
 				this.computeConstructionSteps( group );
 				group.userData.fileName = "";
 				onLoad( group );

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -2149,7 +2149,7 @@ class LDrawLoader extends Loader {
 
 	getMainEdgeMaterial() {
 
-		return this.getMaterial( MAIN_EDGE_COLOUR_CODE );
+		return this.getMaterial( MAIN_EDGE_COLOUR_CODE ).userData.edgeMaterial;
 
 	}
 

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -1900,11 +1900,13 @@ class LDrawLoader extends Loader {
 
 		// Material assigned to not available colors for meshes and edges
 		this.missingColorMaterial = new MeshStandardMaterial( { color: 0xFF00FF, roughness: 0.3, metalness: 0 } );
-		this.missingColorMaterial.name = 'Missing material";
+		this.missingColorMaterial.name = 'Missing material';
 		this.missingEdgeColorMaterial = new LineBasicMaterial( { color: 0xFF00FF } );
-		this.missingEdgeColorMaterial.name = 'Missing material - Edge";
+		this.missingEdgeColorMaterial.name = 'Missing material - Edge';
 		this.missingConditionalEdgeColorMaterial = new LDrawConditionalLineMaterial( { fog: true, color: 0xFF00FF } );
-		this.missingConditionalEdgeColorMaterial.name = 'Missing material - Conditional Edge";
+		this.missingConditionalEdgeColorMaterial.name = 'Missing material - Conditional Edge';
+		this.missingColorMaterial.userData.edgeMaterial = this.missingEdgeColorMaterial;
+		this.missingEdgeColorMaterial.userData.conditionalEdgeMaterial = this.missingConditionalEdgeColorMaterial;
 
 	}
 
@@ -2110,16 +2112,6 @@ class LDrawLoader extends Loader {
 
 					// And return the 'missing color' material
 					material = loader.missingColorMaterial;
-					material.userData.code = colorCode;
-
-					const edgeMat = loader.missingEdgeColorMaterial.clone();
-					edgeMat.userData.code = colorCode;
-
-					const condEdgeMat = loader.missingConditionalEdgeColorMaterial;
-					condEdgeMat.userData.code = colorCode;
-
-					material.userData.edgeMaterial = edgeMat;
-					edgeMat.userData.conditionalEdgeMaterial = condEdgeMat;
 
 				}
 

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -1959,6 +1959,7 @@ class LDrawLoader extends Loader {
 
 					this.applyMaterialsToMesh( group, MAIN_COLOUR_CODE, this.materialLibrary, true );
 					this.computeConstructionSteps( group );
+					group.userData.fileName = url;
 					onLoad( group );
 
 				} )

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -1900,8 +1900,11 @@ class LDrawLoader extends Loader {
 
 		// Material assigned to not available colors for meshes and edges
 		this.missingColorMaterial = new MeshStandardMaterial( { color: 0xFF00FF, roughness: 0.3, metalness: 0 } );
+		this.missingColorMaterial.name = 'Missing material";
 		this.missingEdgeColorMaterial = new LineBasicMaterial( { color: 0xFF00FF } );
+		this.missingEdgeColorMaterial.name = 'Missing material - Edge";
 		this.missingConditionalEdgeColorMaterial = new LDrawConditionalLineMaterial( { fog: true, color: 0xFF00FF } );
+		this.missingConditionalEdgeColorMaterial.name = 'Missing material - Conditional Edge";
 
 	}
 
@@ -1971,7 +1974,7 @@ class LDrawLoader extends Loader {
 
 				this.applyMaterialsToMesh( group, MAIN_COLOUR_CODE, this.materialLibrary, true );
 				this.computeConstructionSteps( group );
-				group.userData.fileName = "";
+				group.userData.fileName = '';
 				onLoad( group );
 
 			} );
@@ -2107,15 +2110,12 @@ class LDrawLoader extends Loader {
 
 					// And return the 'missing color' material
 					material = loader.missingColorMaterial;
-					material.name = "Missing material for color code '" + colorCode + "'";
 					material.userData.code = colorCode;
 
 					const edgeMat = loader.missingEdgeColorMaterial.clone();
-					edgeMat.name = "Missing material for color code '" + colorCode + "' - Edge";
 					edgeMat.userData.code = colorCode;
 
-					const condEdgeMat = loader.missingConditionalEdgeColorMaterial.clone();
-					condEdgeMat.name = "Missing material for color code '" + colorCode + "' - Edge";
+					const condEdgeMat = loader.missingConditionalEdgeColorMaterial;
 					condEdgeMat.userData.code = colorCode;
 
 					material.userData.edgeMaterial = edgeMat;


### PR DESCRIPTION
@gkjohnson

Related issue: None

Solved two bugs and made 7 improvements to LDrawLoader.
Bugs:
 - In parse(), missing call to applyMaterialsToMesh()
 - Missing assignment of userData.colorCode in conditional edge material.
 
Improvements:
 - Changed the order of search of files in the defaults directories, which improves load time.
 - Added 4 fields to userData: Author, fileName, type and colorCode.
 - If a color is not found, instead of giving error, give a warning and return a pink material.
 - Luminance parsing improvement (when the value is in the token, i.e. ```LUMINANCE15```)

I'm sorry I made it separated by commits but I lost that repository. It is all in one commit.