### PR TITLE
OutlinePass: correct gaussian probability density function input

### DIFF
--- a/examples/jsm/postprocessing/OutlinePass.js
+++ b/examples/jsm/postprocessing/OutlinePass.js
@@ -555,12 +555,14 @@ class OutlinePass extends Pass {
 
 				void main() {
 					vec2 invSize = 1.0 / texSize;
-					float weightSum = gaussianPdf(0.0, kernelRadius);
+					float sigma = kernelRadius/2.0;
+					float weightSum = gaussianPdf(0.0, sigma);
 					vec4 diffuseSum = texture2D( colorTexture, vUv) * weightSum;
 					vec2 delta = direction * invSize * kernelRadius/float(MAX_RADIUS);
 					vec2 uvOffset = delta;
 					for( int i = 1; i <= MAX_RADIUS; i ++ ) {
-						float w = gaussianPdf(uvOffset.x, kernelRadius);
+						float x = kernelRadius * float(i) / float(MAX_RADIUS);
+						float w = gaussianPdf(x, sigma);
 						vec4 sample1 = texture2D( colorTexture, vUv + uvOffset);
 						vec4 sample2 = texture2D( colorTexture, vUv - uvOffset);
 						diffuseSum += ((sample1 + sample2) * w);


### PR DESCRIPTION
OutlinePass' blur material uses too small step when they calculate weighted sum. As a consequence it becomes practically a box filter. As you can see when you thicken the outline, the pointy parts' outline resembles a box.
![before](https://user-images.githubusercontent.com/3048481/174978469-4e10912c-4b61-4dfa-a3eb-bccf3bfd98ab.png)

I think they meant to step discretely( e.i by 1, instead of like 1/1024 ) so I corrected it. Now you can see the pointy parts resembles a circle (the shape of gaussian kernel).
![step-sigma](https://user-images.githubusercontent.com/3048481/174978611-b1fe507a-6959-4b41-8eda-9ed8ed526ecb.png)

