### PR TITLE
PLYLoader: Fix for linesplitting on universal newlines

### DIFF
--- a/examples/js/loaders/PLYLoader.js
+++ b/examples/js/loaders/PLYLoader.js
@@ -81,7 +81,7 @@
 
 			function parseHeader( data ) {
 
-				const patternHeader = /^ply([\s\S]*)end_header\r?\n/;
+				const patternHeader = /^ply([\s\S]*)end_header(\r\n|\r|\n)/;
 				let headerText = '';
 				let headerLength = 0;
 				const result = patternHeader.exec( data );
@@ -99,7 +99,7 @@
 					headerLength: headerLength,
 					objInfo: ''
 				};
-				const lines = headerText.split( '\n' );
+				const lines = headerText.split( /\r\n|\r|\n/ );
 				let currentElement;
 
 				function make_ply_element_property( propertValues, propertyNameMapping ) {
@@ -269,7 +269,7 @@
 
 				}
 
-				const lines = body.split( '\n' );
+				const lines = body.split( /\r\n|\r|\n/ );
 				let currentElement = 0;
 				let currentElementCount = 0;
 

--- a/examples/jsm/loaders/PLYLoader.js
+++ b/examples/jsm/loaders/PLYLoader.js
@@ -90,7 +90,7 @@ class PLYLoader extends Loader {
 
 		function parseHeader( data ) {
 
-			const patternHeader = /^ply([\s\S]*)end_header\r?\n/;
+			const patternHeader = /^ply([\s\S]*)end_header(\r\n|\r|\n)/;
 			let headerText = '';
 			let headerLength = 0;
 			const result = patternHeader.exec( data );
@@ -109,7 +109,7 @@ class PLYLoader extends Loader {
 				objInfo: ''
 			};
 
-			const lines = headerText.split( '\n' );
+			const lines = headerText.split( /\r\n|\r|\n/ );
 			let currentElement;
 
 			function make_ply_element_property( propertValues, propertyNameMapping ) {
@@ -283,7 +283,7 @@ class PLYLoader extends Loader {
 
 			}
 
-			const lines = body.split( '\n' );
+			const lines = body.split( /\r\n|\r|\n/ );
 			let currentElement = 0;
 			let currentElementCount = 0;
 


### PR DESCRIPTION
**Description**

* PLYLoader would split lines successfully if they were `\r\n` or `\n` but not `\r`.
* Some .ply files can be encoded with `\r`
* [The spec is quite ambiguous here](http://paulbourke.net/dataformats/ply/). So supporting universal newlines looks like the best thing to do.

This PR fixes the problem by allowing line splitting on `\r` characters too, so the PLYLoader should now support universal newlines.
