### PR TITLE
TransformControls: Don't reset axis on pointer up.

### DIFF
--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -495,7 +495,6 @@
 			}
 
 			this.dragging = false;
-			this.axis = null;
 
 		}
 

--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -533,7 +533,6 @@ class TransformControls extends Object3D {
 		}
 
 		this.dragging = false;
-		this.axis = null;
 
 	}
 


### PR DESCRIPTION
**Description**

Currently the `TransformControls` always trigger an `axis-changed` event when releasing the mouse button in the `pointerUp` method, because the `axis` is reset to `null`. However, only releasing the mouse button doesn't mean that the `axis` actually was changed, this adjustment will be handled automatically by the `pointerHover` callback.
Simply removing the corresponding line solves this issue.