### PR TITLE
WebXRManager: Remove input source on XR session end

### DIFF
--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -153,6 +153,8 @@ class WebXRManager extends EventDispatcher {
 
 				if ( inputSource === null ) continue;
 
+				controllerInputSources[ i ] = null;
+
 				controllers[ i ].disconnect( inputSource );
 
 			}


### PR DESCRIPTION
Fixes error being thrown when entering AR for a second time:
``Uncaught DOMException: Failed to execute 'getPose' on 'XRFrame': XRSpace and XRFrame sessions do not match.``

**Description**

When exiting XR session on mobile AR the ``controllerInputSources`` array still has cached input sources. When entering AR twice it sends the still cached input source to the ``WebXRController.update`` function. This PR sets the cached input sources to null in ``onSessionEnd``

Error that is being fixed:
![image](https://user-images.githubusercontent.com/5083203/175339219-2981edef-9908-42e2-917e-362cde684f22.png)

STRP:

1. enter AR on mobile
2. touch on the screen
3. exit AR on mobile
4. enter AR again - screen stays black, error shown above is thrown

Issue was introduced in https://github.com/mrdoob/three.js/pull/23188

*This contribution is funded by 🌵 [needle](https://needle.tools)*
