### PR TITLE
WebGPU Particles: Change Sprite to Mesh like Emitter

### DIFF
--- a/examples/webgpu_particles.html
+++ b/examples/webgpu_particles.html
@@ -95,7 +95,7 @@
 				smokeNodeMaterial.depthWrite = false;
 				smokeNodeMaterial.transparent = true;
 
-				const smokeInstancedSprite = new THREE.Sprite( smokeNodeMaterial );
+				const smokeInstancedSprite = new THREE.Mesh( new THREE.PlaneGeometry( 1, 1 ), smokeNodeMaterial );
 				smokeInstancedSprite.scale.setScalar( 400 );
 				smokeInstancedSprite.isInstancedMesh = true;
 				smokeInstancedSprite.count = 2000;
@@ -112,7 +112,7 @@
 				fireNodeMaterial.transparent = true;
 				fireNodeMaterial.depthWrite = false;
 
-				const fireInstancedSprite = new THREE.Sprite( fireNodeMaterial );
+				const fireInstancedSprite = new THREE.Mesh( new THREE.PlaneGeometry( 1, 1 ), fireNodeMaterial );
 				fireInstancedSprite.scale.setScalar( 400 );
 				fireInstancedSprite.isInstancedMesh = true;
 				fireInstancedSprite.count = 100;


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/24109#issuecomment-1165755908, https://github.com/mrdoob/three.js/pull/24247

**Description**

It seems that is not possible to dispose a geometry on renderer process without generate `WebGPU` warning. 
It fix this issue working with `Mesh` like `Emitter`. I think that this approach is better too because no overload the `Sprite Geometry`.

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Google via Igalia](https://igalia.com)*
