### PR TITLE
CopyPass: Assume premultipliedAlpha is set to true.

### DIFF
--- a/examples/jsm/postprocessing/AdaptiveToneMappingPass.js
+++ b/examples/jsm/postprocessing/AdaptiveToneMappingPass.js
@@ -45,8 +45,8 @@ class AdaptiveToneMappingPass extends Pass {
 			vertexShader: copyShader.vertexShader,
 			fragmentShader: copyShader.fragmentShader,
 			blending: NoBlending,
-			depthTest: false
-
+			depthTest: false,
+			premultipliedAlpha: true
 		} );
 
 		if ( LuminosityShader === undefined )

--- a/examples/jsm/postprocessing/CopyPass.js
+++ b/examples/jsm/postprocessing/CopyPass.js
@@ -1,0 +1,16 @@
+import { ShaderPass } from './ShaderPass.js';
+import { CopyShader } from '../shaders/CopyShader.js';
+
+class CopyPass extends ShaderPass {
+
+	constructor() {
+
+		super( CopyShader );
+
+		this.material.premultipliedAlpha = true;
+
+	}
+
+}
+
+export { CopyPass };

--- a/examples/jsm/postprocessing/EffectComposer.js
+++ b/examples/jsm/postprocessing/EffectComposer.js
@@ -62,6 +62,7 @@ class EffectComposer {
 		}
 
 		this.copyPass = new ShaderPass( CopyShader );
+		this.copyPass.material.premultipliedAlpha = true;
 
 		this.clock = new Clock();
 

--- a/examples/jsm/postprocessing/OutlinePass.js
+++ b/examples/jsm/postprocessing/OutlinePass.js
@@ -105,7 +105,8 @@ class OutlinePass extends Pass {
 			blending: NoBlending,
 			depthTest: false,
 			depthWrite: false,
-			transparent: true
+			transparent: true,
+			premultipliedAlpha: true
 		} );
 
 		this.enabled = true;

--- a/examples/jsm/postprocessing/SAOPass.js
+++ b/examples/jsm/postprocessing/SAOPass.js
@@ -156,7 +156,8 @@ class SAOPass extends Pass {
 			uniforms: UniformsUtils.clone( CopyShader.uniforms ),
 			vertexShader: CopyShader.vertexShader,
 			fragmentShader: CopyShader.fragmentShader,
-			blending: NoBlending
+			blending: NoBlending,
+			premultipliedAlpha: true
 		} );
 		this.materialCopy.transparent = true;
 		this.materialCopy.depthTest = false;

--- a/examples/jsm/postprocessing/SSAARenderPass.js
+++ b/examples/jsm/postprocessing/SSAARenderPass.js
@@ -44,6 +44,7 @@ class SSAARenderPass extends Pass {
 			uniforms: this.copyUniforms,
 			vertexShader: copyShader.vertexShader,
 			fragmentShader: copyShader.fragmentShader,
+			premultipliedAlpha: true,
 			transparent: true,
 			blending: AdditiveBlending,
 			depthTest: false,

--- a/examples/jsm/postprocessing/SSAOPass.js
+++ b/examples/jsm/postprocessing/SSAOPass.js
@@ -151,7 +151,8 @@ class SSAOPass extends Pass {
 			blendEquation: AddEquation,
 			blendSrcAlpha: DstAlphaFactor,
 			blendDstAlpha: ZeroFactor,
-			blendEquationAlpha: AddEquation
+			blendEquationAlpha: AddEquation,
+			premultipliedAlpha: true
 		} );
 
 		this.fsQuad = new FullScreenQuad( null );

--- a/examples/jsm/postprocessing/SSRPass.js
+++ b/examples/jsm/postprocessing/SSRPass.js
@@ -309,7 +309,7 @@ class SSRPass extends Pass {
 			blendSrcAlpha: SrcAlphaFactor,
 			blendDstAlpha: OneMinusSrcAlphaFactor,
 			blendEquationAlpha: AddEquation,
-			// premultipliedAlpha:true,
+			premultipliedAlpha: true
 		} );
 
 		this.fsQuad = new FullScreenQuad( null );

--- a/examples/jsm/postprocessing/SavePass.js
+++ b/examples/jsm/postprocessing/SavePass.js
@@ -24,7 +24,8 @@ class SavePass extends Pass {
 
 			uniforms: this.uniforms,
 			vertexShader: shader.vertexShader,
-			fragmentShader: shader.fragmentShader
+			fragmentShader: shader.fragmentShader,
+			premultipliedAlpha: true
 
 		} );
 

--- a/examples/jsm/postprocessing/TexturePass.js
+++ b/examples/jsm/postprocessing/TexturePass.js
@@ -25,6 +25,7 @@ class TexturePass extends Pass {
 			uniforms: this.uniforms,
 			vertexShader: shader.vertexShader,
 			fragmentShader: shader.fragmentShader,
+			premultipliedAlpha: true,
 			depthTest: false,
 			depthWrite: false
 

--- a/examples/jsm/postprocessing/UnrealBloomPass.js
+++ b/examples/jsm/postprocessing/UnrealBloomPass.js
@@ -139,7 +139,8 @@ class UnrealBloomPass extends Pass {
 			blending: AdditiveBlending,
 			depthTest: false,
 			depthWrite: false,
-			transparent: true
+			transparent: true,
+			premultipliedAlpha: true
 		} );
 
 		this.enabled = true;

--- a/examples/jsm/shaders/BlendShader.js
+++ b/examples/jsm/shaders/BlendShader.js
@@ -38,8 +38,7 @@ const BlendShader = {
 
 			vec4 texel1 = texture2D( tDiffuse1, vUv );
 			vec4 texel2 = texture2D( tDiffuse2, vUv );
-			gl_FragColor = mix( texel1, texel2, mixRatio );
-			gl_FragColor.a *= opacity;
+			gl_FragColor = opacity * mix( texel1, texel2, mixRatio );
 
 		}`
 

--- a/examples/jsm/shaders/CopyShader.js
+++ b/examples/jsm/shaders/CopyShader.js
@@ -32,9 +32,8 @@ const CopyShader = {
 
 		void main() {
 
-			gl_FragColor = texture2D( tDiffuse, vUv );
-			gl_FragColor.a *= opacity;
-
+			vec4 texel = texture2D( tDiffuse, vUv );
+			gl_FragColor = opacity * texel;
 
 		}`
 

--- a/examples/webgl2_multisampled_renderbuffers.html
+++ b/examples/webgl2_multisampled_renderbuffers.html
@@ -51,8 +51,7 @@
 
 			import { EffectComposer } from './jsm/postprocessing/EffectComposer.js';
 			import { RenderPass } from './jsm/postprocessing/RenderPass.js';
-			import { ShaderPass } from './jsm/postprocessing/ShaderPass.js';
-			import { CopyShader } from './jsm/shaders/CopyShader.js';
+			import { CopyPass } from './jsm/postprocessing/CopyPass.js';
 			import WebGL from './jsm/capabilities/WebGL.js';
 
 			let camera, renderer, clock, group, container;
@@ -130,7 +129,7 @@
 				const renderTarget = new THREE.WebGLRenderTarget( size.width, size.height, { samples: 4 } );
 
 				const renderPass = new RenderPass( scene, camera );
-				const copyPass = new ShaderPass( CopyShader );
+				const copyPass = new CopyPass();
 
 				//
 

--- a/examples/webgl_materials_video.html
+++ b/examples/webgl_materials_video.html
@@ -41,9 +41,8 @@
 
 			import { EffectComposer } from './jsm/postprocessing/EffectComposer.js';
 			import { RenderPass } from './jsm/postprocessing/RenderPass.js';
-			import { ShaderPass } from './jsm/postprocessing/ShaderPass.js';
 			import { BloomPass } from './jsm/postprocessing/BloomPass.js';
-			import { CopyShader } from './jsm/shaders/CopyShader.js';
+			import { CopyPass } from './jsm/postprocessing/CopyPass.js';
 
 			let container;
 
@@ -170,7 +169,7 @@
 
 				const renderModel = new RenderPass( scene, camera );
 				const effectBloom = new BloomPass( 1.3 );
-				const effectCopy = new ShaderPass( CopyShader );
+				const effectCopy = new CopyPass();
 
 				composer = new EffectComposer( renderer );
 

--- a/examples/webgl_postprocessing_backgrounds.html
+++ b/examples/webgl_postprocessing_backgrounds.html
@@ -37,9 +37,8 @@
 			import { RenderPass } from './jsm/postprocessing/RenderPass.js';
 			import { TexturePass } from './jsm/postprocessing/TexturePass.js';
 			import { CubeTexturePass } from './jsm/postprocessing/CubeTexturePass.js';
-			import { ShaderPass } from './jsm/postprocessing/ShaderPass.js';
+			import { CopyPass } from './jsm/postprocessing/CopyPass.js';
 			import { ClearPass } from './jsm/postprocessing/ClearPass.js';
-			import { CopyShader } from './jsm/shaders/CopyShader.js';
 			import { OrbitControls } from './jsm/controls/OrbitControls.js';
 
 			let scene, renderer, composer;
@@ -185,7 +184,7 @@
 				renderPass.clear = false;
 				composer.addPass( renderPass );
 
-				const copyPass = new ShaderPass( CopyShader );
+				const copyPass = new CopyPass();
 				composer.addPass( copyPass );
 
 				const controls = new OrbitControls( cameraP, renderer.domElement );

--- a/examples/webgl_postprocessing_fxaa.html
+++ b/examples/webgl_postprocessing_fxaa.html
@@ -52,7 +52,7 @@
 			import { EffectComposer } from './jsm/postprocessing/EffectComposer.js';
 			import { RenderPass } from './jsm/postprocessing/RenderPass.js';
 			import { ShaderPass } from './jsm/postprocessing/ShaderPass.js';
-			import { CopyShader } from './jsm/shaders/CopyShader.js';
+			import { CopyPass } from './jsm/postprocessing/CopyPass.js';
 			import { FXAAShader } from './jsm/shaders/FXAAShader.js';
 
 			let camera, scene, renderer, clock, group, container;
@@ -128,8 +128,8 @@
 
 				fxaaPass = new ShaderPass( FXAAShader );
 
-				const copyPass = new ShaderPass( CopyShader );
-
+				const copyPass = new CopyPass();
+			
 				composer1 = new EffectComposer( renderer );
 				composer1.addPass( renderPass );
 				composer1.addPass( copyPass );

--- a/examples/webgl_postprocessing_fxaa.html
+++ b/examples/webgl_postprocessing_fxaa.html
@@ -129,7 +129,7 @@
 				fxaaPass = new ShaderPass( FXAAShader );
 
 				const copyPass = new CopyPass();
-			
+
 				composer1 = new EffectComposer( renderer );
 				composer1.addPass( renderPass );
 				composer1.addPass( copyPass );

--- a/examples/webgl_postprocessing_masking.html
+++ b/examples/webgl_postprocessing_masking.html
@@ -27,11 +27,10 @@
 			import * as THREE from 'three';
 
 			import { EffectComposer } from './jsm/postprocessing/EffectComposer.js';
-			import { ShaderPass } from './jsm/postprocessing/ShaderPass.js';
+			import { CopyPass } from './jsm/postprocessing/CopyPass.js';
 			import { TexturePass } from './jsm/postprocessing/TexturePass.js';
 			import { ClearPass } from './jsm/postprocessing/ClearPass.js';
 			import { MaskPass, ClearMaskPass } from './jsm/postprocessing/MaskPass.js';
-			import { CopyShader } from './jsm/shaders/CopyShader.js';
 
 			let camera, composer, renderer;
 			let box, torus;
@@ -76,7 +75,7 @@
 				const texturePass1 = new TexturePass( texture1 );
 				const texturePass2 = new TexturePass( texture2 );
 
-				const outputPass = new ShaderPass( CopyShader );
+				const outputPass = new CopyPass();
 
 				const parameters = {
 					stencilBuffer: true

--- a/examples/webgl_postprocessing_ssaa.html
+++ b/examples/webgl_postprocessing_ssaa.html
@@ -35,9 +35,8 @@
 			import { GUI } from './jsm/libs/lil-gui.module.min.js';
 
 			import { EffectComposer } from './jsm/postprocessing/EffectComposer.js';
-			import { ShaderPass } from './jsm/postprocessing/ShaderPass.js';
+			import { CopyPass } from './jsm/postprocessing/CopyPass.js';
 			import { SSAARenderPass } from './jsm/postprocessing/SSAARenderPass.js';
-			import { CopyShader } from './jsm/shaders/CopyShader.js';
 
 			let scene, renderer, composer, copyPass;
 			let cameraP, ssaaRenderPassP;
@@ -173,7 +172,7 @@
 				composer.addPass( ssaaRenderPassP );
 				ssaaRenderPassO = new SSAARenderPass( scene, cameraO );
 				composer.addPass( ssaaRenderPassO );
-				copyPass = new ShaderPass( CopyShader );
+				copyPass = new CopyPass();
 				composer.addPass( copyPass );
 
 				window.addEventListener( 'resize', onWindowResize );

--- a/examples/webgl_postprocessing_taa.html
+++ b/examples/webgl_postprocessing_taa.html
@@ -37,9 +37,8 @@
 
 			import { EffectComposer } from './jsm/postprocessing/EffectComposer.js';
 			import { RenderPass } from './jsm/postprocessing/RenderPass.js';
-			import { ShaderPass } from './jsm/postprocessing/ShaderPass.js';
+			import { CopyPass } from './jsm/postprocessing/CopyPass.js';
 			import { TAARenderPass } from './jsm/postprocessing/TAARenderPass.js';
-			import { CopyShader } from './jsm/shaders/CopyShader.js';
 
 			let camera, scene, renderer, composer, copyPass, taaRenderPass, renderPass;
 			let gui, stats;
@@ -143,7 +142,7 @@
 				renderPass.enabled = false;
 				composer.addPass( renderPass );
 
-				copyPass = new ShaderPass( CopyShader );
+				copyPass = new CopyPass();
 				composer.addPass( copyPass );
 
 				window.addEventListener( 'resize', onWindowResize );


### PR DESCRIPTION
Fixed #19531.

**Description**

Reverts #23671 and ensures copy materials always set `premultipliedAlpha` to `true`.  The PR also introduces `CopyPass` for an easier usage on app level.

Motivation of this change is outlined here: https://github.com/mrdoob/three.js/issues/19531#issuecomment-1166349252
