### PR TITLE
Don't force node matrixAutoUpdate to true in the gltf animation loader

### DIFF
--- a/examples/js/loaders/GLTFLoader.js
+++ b/examples/js/loaders/GLTFLoader.js
@@ -3481,7 +3481,6 @@
 					const target = targets[ i ];
 					if ( node === undefined ) continue;
 					node.updateMatrix();
-					node.matrixAutoUpdate = true;
 					let TypedKeyframeTrack;
 
 					switch ( PATH_PROPERTIES[ target.path ] ) {

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -3817,7 +3817,6 @@ class GLTFParser {
 				if ( node === undefined ) continue;
 
 				node.updateMatrix();
-				node.matrixAutoUpdate = true;
 
 				let TypedKeyframeTrack;
 


### PR DESCRIPTION
**Description**

The glTF loader was setting matrixAutoUpdate to 'true' on any node that's used as part of an animation.  This ignores the object3d DefaultMatrixAutoUpdate setting, and causes problems if folks are trying to manage their updates themselves.  Removed the line that sets the autoupdate, so instead animation nodes will follow the default setting.

This code doesn't exist in any other loaders.

All the animation samples still work.  Most projects won't be affected because the default auto update setting is 'true'.

*This contribution is funded by [Meta](https://meta.com)*
