### PR TITLE
Fix small bug in crossFade animation example

### DIFF
--- a/examples/webgl_animation_skinning_additive_blending.html
+++ b/examples/webgl_animation_skinning_additive_blending.html
@@ -274,6 +274,8 @@
 
 			function prepareCrossFade( startAction, endAction, duration ) {
 
+				if ( startAction === endAction ) return;
+
 				// If the current action is 'idle', execute the crossfade immediately;
 				// else wait until the current action has finished its current loop
 
@@ -319,8 +321,6 @@
 			}
 
 			function synchronizeCrossFade( startAction, endAction, duration ) {
-
-				if ( startAction === endAction ) return;
 
 				mixer.addEventListener( 'loop', onLoopFinished );
 

--- a/examples/webgl_animation_skinning_additive_blending.html
+++ b/examples/webgl_animation_skinning_additive_blending.html
@@ -320,7 +320,7 @@
 
 			function synchronizeCrossFade( startAction, endAction, duration ) {
 
-      	if ( startAction === endAction ) return;
+				if ( startAction === endAction ) return;
 
 				mixer.addEventListener( 'loop', onLoopFinished );
 

--- a/examples/webgl_animation_skinning_additive_blending.html
+++ b/examples/webgl_animation_skinning_additive_blending.html
@@ -203,7 +203,11 @@
 						const currentAction = currentSettings ? currentSettings.action : null;
 						const action = settings ? settings.action : null;
 
-						prepareCrossFade( currentAction, action, 0.35 );
+						if ( currentAction !== action ) { 
+						
+							prepareCrossFade( currentAction, action, 0.35 );
+						
+						}
 
 					};
 
@@ -273,8 +277,6 @@
 			}
 
 			function prepareCrossFade( startAction, endAction, duration ) {
-
-				if ( startAction === endAction ) return;
 
 				// If the current action is 'idle', execute the crossfade immediately;
 				// else wait until the current action has finished its current loop

--- a/examples/webgl_animation_skinning_additive_blending.html
+++ b/examples/webgl_animation_skinning_additive_blending.html
@@ -320,6 +320,8 @@
 
 			function synchronizeCrossFade( startAction, endAction, duration ) {
 
+      	if ( startAction === endAction ) return;
+
 				mixer.addEventListener( 'loop', onLoopFinished );
 
 				function onLoopFinished( event ) {


### PR DESCRIPTION
Related issue: #XXXX

**Description**

I found a small bug in crossFade animation example on threejs.org website:
https://threejs.org/examples/#webgl_animation_skinning_additive_blending

BUG: When you click again on the active animation (for example run or walk), the character first put hands in T position, then continue with the same animation.

My pull request solves it and the animation is smooth now.
