### PR TITLE
Remove Blender JSON exporter readme.

### DIFF
--- a/utils/exporters/blender/README.md
+++ b/utils/exporters/blender/README.md
@@ -1,5 +1,0 @@
-# Three.js Blender Export
-
-> **NOTICE:** The Blender exporter for the Three.js JSON format has been removed, to focus on better support for the glTF workflow. For recommended alternatives, see [Loading 3D Models](https://threejs.org/docs/#manual/introduction/Loading-3D-models). The Three.js Object/Scene JSON format is still fully supported for use with [Object3D.toJSON](https://threejs.org/docs/#api/core/Object3D.toJSON), the [Editor](https://threejs.org/editor/) and [THREE.ObjectLoader](https://threejs.org/docs/#api/loaders/ObjectLoader).
->
-> If you really need the Blender Exporter you can [go back in time to r92](https://github.com/mrdoob/three.js/tree/r92).


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/24286#issuecomment-1170941776

**Description**

Remove Blender JSON exporter readme.
