### PR TITLE
SVGLoader: Make createShapes() usable for other modules.

### DIFF
--- a/examples/jsm/loaders/SVGLoader.js
+++ b/examples/jsm/loaders/SVGLoader.js
@@ -2107,7 +2107,7 @@ class SVGLoader extends Loader {
 		simplePaths = simplePaths.filter( sp => sp.points.length > 1 );
 
 		// check if path is solid or a hole
-		const isAHole = simplePaths.map( p => isHoleTo( p, simplePaths, scanlineMinX, scanlineMaxX, shapePath.userData.style.fillRule ) );
+		const isAHole = simplePaths.map( p => isHoleTo( p, simplePaths, scanlineMinX, scanlineMaxX, shapePath.userData?.style.fillRule ) );
 
 
 		const shapesToReturn = [];


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/24291#issuecomment-1170971120

**Description**

`SVGLoader.createShapes()` assumes `userData.style` is defined at a certain place. This breaks the usage of the method outside of the loader (e.g. in context of `Font`).
