### PR TITLE
FileLoader: Add response to error object.

### DIFF
--- a/src/loaders/FileLoader.js
+++ b/src/loaders/FileLoader.js
@@ -278,4 +278,4 @@ class FileLoader extends Loader {
 }
 
 
-export { FileLoader, HttpError };
+export { FileLoader };

--- a/src/loaders/FileLoader.js
+++ b/src/loaders/FileLoader.js
@@ -3,6 +3,17 @@ import { Loader } from './Loader.js';
 
 const loading = {};
 
+class HttpError extends Error {
+
+	constructor( message, response ) {
+
+		super( message );
+		this.response = response;
+
+	}
+
+}
+
 class FileLoader extends Loader {
 
 	constructor( manager ) {
@@ -146,7 +157,7 @@ class FileLoader extends Loader {
 
 				} else {
 
-					throw Error( `fetch for "${response.url}" responded with ${response.status}: ${response.statusText}` );
+					throw new HttpError( `fetch for "${response.url}" responded with ${response.status}: ${response.statusText}`, response );
 
 				}
 
@@ -267,4 +278,4 @@ class FileLoader extends Loader {
 }
 
 
-export { FileLoader };
+export { FileLoader, HttpError };


### PR DESCRIPTION
Fixed #24295

**Description**

If a non-200 HTTP status is received in the FileLoader, I would like to have a safer way to check that then checking the error message text.

I added a custom HttpError type that adds an extra property to include the fetch Response object in the Error object. This seems like the best way to let devs do as they wish when this happens.

This is backwards compatible, and I tested by linking my local branch of three to my project

Also I ran lint-fix on everything hence the changes in the extra files.