### PR TITLE
fixed spelling error

### DIFF
--- a/docs/api/en/animation/AnimationAction.html
+++ b/docs/api/en/animation/AnimationAction.html
@@ -13,7 +13,7 @@
 			AnimationActions schedule the performance of the animations which are stored in
 			[page:AnimationClip AnimationClips].<br /><br />
 
-			Note: Most of AnimationAction's methods can be chained.<br /><br />
+			Note: Most of AnimationActions methods can be chained.<br /><br />
 
 			For an overview of the different elements of the three.js animation system see the
 			"Animation System" article in the "Next Steps" section of the manual.


### PR DESCRIPTION
spelling error

**Description**

I believe that it would be correct if the comma gets removed, if not sorry about that

