### PR TITLE
Fix line thresold on line raycast.

### DIFF
--- a/src/objects/Line.js
+++ b/src/objects/Line.js
@@ -1,8 +1,5 @@
 import { Sphere } from '../math/Sphere.js';
-import { Ray } from '../math/Ray.js';
-import { Matrix4 } from '../math/Matrix4.js';
 import { Object3D } from '../core/Object3D.js';
-import { Quaternion } from '../math/Quaternion.js';
 import { Vector3 } from '../math/Vector3.js';
 import { LineBasicMaterial } from '../materials/LineBasicMaterial.js';
 import { BufferGeometry } from '../core/BufferGeometry.js';
@@ -10,8 +7,6 @@ import { Float32BufferAttribute } from '../core/BufferAttribute.js';
 
 const _start = /*@__PURE__*/ new Vector3();
 const _end = /*@__PURE__*/ new Vector3();
-const _inverseMatrix = /*@__PURE__*/ new Matrix4();
-const _ray = /*@__PURE__*/ new Ray();
 const _sphere = /*@__PURE__*/ new Sphere();
 
 class Line extends Object3D {
@@ -102,8 +97,7 @@ class Line extends Object3D {
 
 		const index = geometry.index;
 		const attributes = geometry.attributes;
-		const positionAttribute = attributes.position.clone();
-		positionAttribute.applyMatrix4( matrixWorld );
+		const positionAttribute = attributes.position;
 
 		if ( index !== null ) {
 
@@ -115,8 +109,8 @@ class Line extends Object3D {
 				const a = index.getX( i );
 				const b = index.getX( i + 1 );
 
-				vStart.fromBufferAttribute( positionAttribute, a );
-				vEnd.fromBufferAttribute( positionAttribute, b );
+				vStart.fromBufferAttribute( positionAttribute, a ).applyMatrix4( matrixWorld );
+				vEnd.fromBufferAttribute( positionAttribute, b ).applyMatrix4( matrixWorld );
 
 				const distSq = raycaster.ray.distanceSqToSegment( vStart, vEnd, interRay, interSegment );
 
@@ -148,8 +142,8 @@ class Line extends Object3D {
 
 			for ( let i = start, l = end - 1; i < l; i += step ) {
 
-				vStart.fromBufferAttribute( positionAttribute, i );
-				vEnd.fromBufferAttribute( positionAttribute, i + 1 );
+				vStart.fromBufferAttribute( positionAttribute, i ).applyMatrix4( matrixWorld );
+				vEnd.fromBufferAttribute( positionAttribute, i + 1 ).applyMatrix4( matrixWorld );
 
 				const distSq = raycaster.ray.distanceSqToSegment( vStart, vEnd, interRay, interSegment );
 

--- a/src/objects/Line.js
+++ b/src/objects/Line.js
@@ -2,6 +2,7 @@ import { Sphere } from '../math/Sphere.js';
 import { Ray } from '../math/Ray.js';
 import { Matrix4 } from '../math/Matrix4.js';
 import { Object3D } from '../core/Object3D.js';
+import { Quaternion } from '../math/Quaternion.js';
 import { Vector3 } from '../math/Vector3.js';
 import { LineBasicMaterial } from '../materials/LineBasicMaterial.js';
 import { BufferGeometry } from '../core/BufferGeometry.js';
@@ -12,6 +13,10 @@ const _end = /*@__PURE__*/ new Vector3();
 const _inverseMatrix = /*@__PURE__*/ new Matrix4();
 const _ray = /*@__PURE__*/ new Ray();
 const _sphere = /*@__PURE__*/ new Sphere();
+
+const _position = /*@__PURE__*/ new Vector3();
+const _scale = /*@__PURE__*/ new Vector3();
+const _quaternion = /*@__PURE__*/ new Quaternion();
 
 class Line extends Object3D {
 
@@ -96,7 +101,8 @@ class Line extends Object3D {
 		_inverseMatrix.copy( matrixWorld ).invert();
 		_ray.copy( raycaster.ray ).applyMatrix4( _inverseMatrix );
 
-		const localThreshold = threshold / ( ( this.scale.x + this.scale.y + this.scale.z ) / 3 );
+		matrixWorld.decompose( _position, _quaternion, _scale );
+		const localThreshold = threshold / ( ( _scale.x + _scale.y + _scale.z ) / 3 );
 		const localThresholdSq = localThreshold * localThreshold;
 
 		const vStart = new Vector3();

--- a/src/objects/Line.js
+++ b/src/objects/Line.js
@@ -100,7 +100,8 @@ class Line extends Object3D {
 
 		const index = geometry.index;
 		const attributes = geometry.attributes;
-		const positionAttribute = attributes.position;
+		const positionAttribute = attributes.position.clone();
+		positionAttribute.applyMatrix4( matrixWorld );
 
 		if ( index !== null ) {
 
@@ -112,8 +113,8 @@ class Line extends Object3D {
 				const a = index.getX( i );
 				const b = index.getX( i + 1 );
 
-				vStart.fromBufferAttribute( positionAttribute, a ).applyMatrix4(matrixWorld);
-				vEnd.fromBufferAttribute( positionAttribute, b ).applyMatrix4(matrixWorld);
+				vStart.fromBufferAttribute( positionAttribute, a );
+				vEnd.fromBufferAttribute( positionAttribute, b );
 
 				const distSq = raycaster.ray.distanceSqToSegment( vStart, vEnd, interRay, interSegment );
 
@@ -145,8 +146,8 @@ class Line extends Object3D {
 
 			for ( let i = start, l = end - 1; i < l; i += step ) {
 
-				vStart.fromBufferAttribute( positionAttribute, i ).applyMatrix4(matrixWorld);
-				vEnd.fromBufferAttribute( positionAttribute, i + 1 ).applyMatrix4(matrixWorld);
+				vStart.fromBufferAttribute( positionAttribute, i );
+				vEnd.fromBufferAttribute( positionAttribute, i + 1 );
 
 				const distSq = raycaster.ray.distanceSqToSegment( vStart, vEnd, interRay, interSegment );
 

--- a/src/objects/Line.js
+++ b/src/objects/Line.js
@@ -92,6 +92,8 @@ class Line extends Object3D {
 
 		if ( raycaster.ray.intersectsSphere( _sphere ) === false ) return;
 
+		const thresholdSq = threshold * threshold;
+
 		const vStart = new Vector3();
 		const vEnd = new Vector3();
 		const interSegment = new Vector3();
@@ -118,7 +120,7 @@ class Line extends Object3D {
 
 				const distSq = raycaster.ray.distanceSqToSegment( vStart, vEnd, interRay, interSegment );
 
-				if ( distSq > threshold ) continue;
+				if ( distSq > thresholdSq ) continue;
 
 				const distance = raycaster.ray.origin.distanceTo( interRay );
 
@@ -151,7 +153,7 @@ class Line extends Object3D {
 
 				const distSq = raycaster.ray.distanceSqToSegment( vStart, vEnd, interRay, interSegment );
 
-				if ( distSq > threshold ) continue;
+				if ( distSq > thresholdSq ) continue;
 
 				const distance = raycaster.ray.origin.distanceTo( interRay );
 

--- a/src/objects/Line.js
+++ b/src/objects/Line.js
@@ -14,10 +14,6 @@ const _inverseMatrix = /*@__PURE__*/ new Matrix4();
 const _ray = /*@__PURE__*/ new Ray();
 const _sphere = /*@__PURE__*/ new Sphere();
 
-const _position = /*@__PURE__*/ new Vector3();
-const _scale = /*@__PURE__*/ new Vector3();
-const _quaternion = /*@__PURE__*/ new Quaternion();
-
 class Line extends Object3D {
 
 	constructor( geometry = new BufferGeometry(), material = new LineBasicMaterial() ) {
@@ -96,15 +92,6 @@ class Line extends Object3D {
 
 		if ( raycaster.ray.intersectsSphere( _sphere ) === false ) return;
 
-		//
-
-		_inverseMatrix.copy( matrixWorld ).invert();
-		_ray.copy( raycaster.ray ).applyMatrix4( _inverseMatrix );
-
-		matrixWorld.decompose( _position, _quaternion, _scale );
-		const localThreshold = threshold / ( ( _scale.x + _scale.y + _scale.z ) / 3 );
-		const localThresholdSq = localThreshold * localThreshold;
-
 		const vStart = new Vector3();
 		const vEnd = new Vector3();
 		const interSegment = new Vector3();
@@ -125,14 +112,12 @@ class Line extends Object3D {
 				const a = index.getX( i );
 				const b = index.getX( i + 1 );
 
-				vStart.fromBufferAttribute( positionAttribute, a );
-				vEnd.fromBufferAttribute( positionAttribute, b );
+				vStart.fromBufferAttribute( positionAttribute, a ).applyMatrix4(matrixWorld);
+				vEnd.fromBufferAttribute( positionAttribute, b ).applyMatrix4(matrixWorld);
 
-				const distSq = _ray.distanceSqToSegment( vStart, vEnd, interRay, interSegment );
+				const distSq = raycaster.ray.distanceSqToSegment( vStart, vEnd, interRay, interSegment );
 
-				if ( distSq > localThresholdSq ) continue;
-
-				interRay.applyMatrix4( this.matrixWorld ); //Move back to world space for distance calculation
+				if ( distSq > threshold ) continue;
 
 				const distance = raycaster.ray.origin.distanceTo( interRay );
 
@@ -143,7 +128,7 @@ class Line extends Object3D {
 					distance: distance,
 					// What do we want? intersection point on the ray or on the segment??
 					// point: raycaster.ray.at( distance ),
-					point: interSegment.clone().applyMatrix4( this.matrixWorld ),
+					point: interSegment.clone(),
 					index: i,
 					face: null,
 					faceIndex: null,
@@ -160,14 +145,12 @@ class Line extends Object3D {
 
 			for ( let i = start, l = end - 1; i < l; i += step ) {
 
-				vStart.fromBufferAttribute( positionAttribute, i );
-				vEnd.fromBufferAttribute( positionAttribute, i + 1 );
+				vStart.fromBufferAttribute( positionAttribute, i ).applyMatrix4(matrixWorld);
+				vEnd.fromBufferAttribute( positionAttribute, i + 1 ).applyMatrix4(matrixWorld);
 
-				const distSq = _ray.distanceSqToSegment( vStart, vEnd, interRay, interSegment );
+				const distSq = raycaster.ray.distanceSqToSegment( vStart, vEnd, interRay, interSegment );
 
-				if ( distSq > localThresholdSq ) continue;
-
-				interRay.applyMatrix4( this.matrixWorld ); //Move back to world space for distance calculation
+				if ( distSq > threshold ) continue;
 
 				const distance = raycaster.ray.origin.distanceTo( interRay );
 
@@ -178,7 +161,7 @@ class Line extends Object3D {
 					distance: distance,
 					// What do we want? intersection point on the ray or on the segment??
 					// point: raycaster.ray.at( distance ),
-					point: interSegment.clone().applyMatrix4( this.matrixWorld ),
+					point: interSegment.clone(),
 					index: i,
 					face: null,
 					faceIndex: null,

--- a/src/objects/Points.js
+++ b/src/objects/Points.js
@@ -1,19 +1,11 @@
 import { Sphere } from '../math/Sphere.js';
-import { Ray } from '../math/Ray.js';
-import { Matrix4 } from '../math/Matrix4.js';
 import { Object3D } from '../core/Object3D.js';
-import { Quaternion } from '../math/Quaternion.js';
 import { Vector3 } from '../math/Vector3.js';
 import { PointsMaterial } from '../materials/PointsMaterial.js';
 import { BufferGeometry } from '../core/BufferGeometry.js';
 
-const _inverseMatrix = /*@__PURE__*/ new Matrix4();
-const _ray = /*@__PURE__*/ new Ray();
 const _sphere = /*@__PURE__*/ new Sphere();
 const _position = /*@__PURE__*/ new Vector3();
-
-const _scale = /*@__PURE__*/ new Vector3();
-const _quaternion = /*@__PURE__*/ new Quaternion();
 
 class Points extends Object3D {
 
@@ -60,14 +52,7 @@ class Points extends Object3D {
 
 		if ( raycaster.ray.intersectsSphere( _sphere ) === false ) return;
 
-		//
-
-		_inverseMatrix.copy( matrixWorld ).invert();
-		_ray.copy( raycaster.ray ).applyMatrix4( _inverseMatrix );
-
-		matrixWorld.decompose( _position, _quaternion, _scale );
-		const localThreshold = threshold / ( ( _scale.x + _scale.y + _scale.z ) / 3 );
-		const localThresholdSq = localThreshold * localThreshold;
+		const thresholdSq = threshold * threshold;
 
 		const index = geometry.index;
 		const attributes = geometry.attributes;
@@ -82,9 +67,9 @@ class Points extends Object3D {
 
 				const a = index.getX( i );
 
-				_position.fromBufferAttribute( positionAttribute, a );
+				_position.fromBufferAttribute( positionAttribute, a ).applyMatrix4( matrixWorld );
 
-				testPoint( _position, a, localThresholdSq, matrixWorld, raycaster, intersects, this );
+				testPoint( _position, a, thresholdSq, raycaster, intersects, this );
 
 			}
 
@@ -95,9 +80,9 @@ class Points extends Object3D {
 
 			for ( let i = start, l = end; i < l; i ++ ) {
 
-				_position.fromBufferAttribute( positionAttribute, i );
+				_position.fromBufferAttribute( positionAttribute, i ).applyMatrix4( matrixWorld );
 
-				testPoint( _position, i, localThresholdSq, matrixWorld, raycaster, intersects, this );
+				testPoint( _position, i, thresholdSq, raycaster, intersects, this );
 
 			}
 
@@ -138,16 +123,15 @@ class Points extends Object3D {
 
 }
 
-function testPoint( point, index, localThresholdSq, matrixWorld, raycaster, intersects, object ) {
+function testPoint( point, index, thresholdSq, raycaster, intersects, object ) {
 
-	const rayPointDistanceSq = _ray.distanceSqToPoint( point );
+	const rayPointDistanceSq = raycaster.ray.distanceSqToPoint( point );
 
-	if ( rayPointDistanceSq < localThresholdSq ) {
+	if ( rayPointDistanceSq < thresholdSq ) {
 
 		const intersectPoint = new Vector3();
 
-		_ray.closestPointToPoint( point, intersectPoint );
-		intersectPoint.applyMatrix4( matrixWorld );
+		raycaster.ray.closestPointToPoint( point, intersectPoint );
 
 		const distance = raycaster.ray.origin.distanceTo( intersectPoint );
 

--- a/src/objects/Points.js
+++ b/src/objects/Points.js
@@ -2,6 +2,7 @@ import { Sphere } from '../math/Sphere.js';
 import { Ray } from '../math/Ray.js';
 import { Matrix4 } from '../math/Matrix4.js';
 import { Object3D } from '../core/Object3D.js';
+import { Quaternion } from '../math/Quaternion.js';
 import { Vector3 } from '../math/Vector3.js';
 import { PointsMaterial } from '../materials/PointsMaterial.js';
 import { BufferGeometry } from '../core/BufferGeometry.js';
@@ -10,6 +11,9 @@ const _inverseMatrix = /*@__PURE__*/ new Matrix4();
 const _ray = /*@__PURE__*/ new Ray();
 const _sphere = /*@__PURE__*/ new Sphere();
 const _position = /*@__PURE__*/ new Vector3();
+
+const _scale = /*@__PURE__*/ new Vector3();
+const _quaternion = /*@__PURE__*/ new Quaternion();
 
 class Points extends Object3D {
 
@@ -61,7 +65,8 @@ class Points extends Object3D {
 		_inverseMatrix.copy( matrixWorld ).invert();
 		_ray.copy( raycaster.ray ).applyMatrix4( _inverseMatrix );
 
-		const localThreshold = threshold / ( ( this.scale.x + this.scale.y + this.scale.z ) / 3 );
+		matrixWorld.decompose( _position, _quaternion, _scale );
+		const localThreshold = threshold / ( ( _scale.x + _scale.y + _scale.z ) / 3 );
 		const localThresholdSq = localThreshold * localThreshold;
 
 		const index = geometry.index;


### PR DESCRIPTION
**Description**

There is no matrixWorld for calculating local threshold in the ray casting function of line, so the ray calculation result and the threshold are not compared with the same scale. 

This can be fixed by decomposing matrixWorld, get the proper scale, then calculate the local threshold with the same scale.