### PR TITLE
Editor: Improve "compute vertex normals" button.

### DIFF
--- a/editor/js/Sidebar.Geometry.Modifiers.js
+++ b/editor/js/Sidebar.Geometry.Modifiers.js
@@ -1,6 +1,8 @@
-import { UIDiv, UIButton } from './libs/ui.js';
+import { UIDiv, UIButton, UIRow } from './libs/ui.js';
 
 function SidebarGeometryModifiers( editor, object ) {
+
+	const strings = editor.strings;
 
 	const signals = editor.signals;
 
@@ -10,7 +12,7 @@ function SidebarGeometryModifiers( editor, object ) {
 
 	// Compute Vertex Normals
 
-	const button = new UIButton( 'Compute Vertex Normals' );
+	const button = new UIButton( strings.getKey( 'sidebar/geometry/show_vertex_normals' ) );
 	button.onClick( function () {
 
 		geometry.computeVertexNormals();
@@ -21,7 +23,10 @@ function SidebarGeometryModifiers( editor, object ) {
 
 	} );
 
-	container.add( button );
+	const row = new UIRow();
+	row.add( button );
+
+	container.add( row );
 
 	//
 

--- a/editor/js/Strings.js
+++ b/editor/js/Strings.js
@@ -134,6 +134,7 @@ function Strings( config ) {
 			'sidebar/geometry/name': 'Name',
 			'sidebar/geometry/bounds': 'Bounds',
 			'sidebar/geometry/show_vertex_normals': 'Show Vertex Normals',
+			'sidebar/geometry/compute_vertex_normals': 'Compute Vertex Normals',
 
 			'sidebar/geometry/box_geometry/width': 'Width',
 			'sidebar/geometry/box_geometry/height': 'Height',
@@ -476,6 +477,7 @@ function Strings( config ) {
 			'sidebar/geometry/name': 'Nom',
 			'sidebar/geometry/bounds': 'Limites',
 			'sidebar/geometry/show_vertex_normals': 'Afficher normales',
+			'sidebar/geometry/compute_vertex_normals': 'Compute Vertex Normals',
 
 			'sidebar/geometry/box_geometry/width': 'Largeur',
 			'sidebar/geometry/box_geometry/height': 'Hauteur',
@@ -813,6 +815,7 @@ function Strings( config ) {
 			'sidebar/geometry/name': '名称',
 			'sidebar/geometry/bounds': '界限',
 			'sidebar/geometry/show_vertex_normals': '显示顶点法线',
+			'sidebar/geometry/compute_vertex_normals': 'Compute Vertex Normals',
 
 			'sidebar/geometry/box_geometry/width': '宽度',
 			'sidebar/geometry/box_geometry/height': '高度',


### PR DESCRIPTION
Related issue: -

**Description**

- Adds i18n support to the "compute vertex normals" button.
- Fixed its style by putting it in an instance of `UIRow`.