### PR TITLE
SVGLoader: Fix float precision in round join computation.

### DIFF
--- a/examples/js/loaders/SVGLoader.js
+++ b/examples/js/loaders/SVGLoader.js
@@ -2089,7 +2089,7 @@
 					tempV2_3.normalize();
 					const dot = Math.abs( normal1.dot( tempV2_3 ) ); // If path is straight, don't create join
 
-					if ( dot !== 0 ) {
+					if ( dot > Number.EPSILON ) {
 
 						// Compute inner and outer segment intersections
 						const miterSide = strokeWidth2 / dot;

--- a/examples/jsm/loaders/SVGLoader.js
+++ b/examples/jsm/loaders/SVGLoader.js
@@ -2313,7 +2313,7 @@ class SVGLoader extends Loader {
 				const dot = Math.abs( normal1.dot( tempV2_3 ) );
 
 				// If path is straight, don't create join
-				if ( dot !== 0 ) {
+				if ( dot > Number.EPSILON ) {
 
 					// Compute inner and outer segment intersections
 					const miterSide = strokeWidth2 / dot;

--- a/examples/models/svg/tests/roundJoinPrecisionIssue.svg
+++ b/examples/models/svg/tests/roundJoinPrecisionIssue.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Calque_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="5032.201px" height="2480.432px" viewBox="0 0 5032.201 2480.432"
+	 xml:space="preserve">
+<g id="COUPÉ_2_" transform="scale(0.1)">
+	<g id="SPLINE_149_">
+		<path fill="none" stroke="#010101" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="M434.099,631.724
+			c0,7,0,14.001,0,21.001c-7.001,0-14.001,0-21.001,0c0-7,0-14.001,0-21.001C420.099,631.724,427.099,631.724,434.099,631.724z"/>
+	</g>
+	<g id="SPLINE_142_">
+		<path fill="none" stroke="#010101" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="M4598.102,631.724
+			c0,7,0,14.001,0,21.001c7,0,14,0,21,0c0-7,0-14.001,0-21.001C4612.102,631.724,4605.102,631.724,4598.102,631.724z"/>
+	</g>
+</g>
+</svg>

--- a/examples/webgl_loader_svg.html
+++ b/examples/webgl_loader_svg.html
@@ -117,7 +117,9 @@
 					'Style CSS inside defs': 'models/svg/style-css-inside-defs.svg',
 					'Multiple CSS classes': 'models/svg/multiple-css-classes.svg',
 					'Zero Radius': 'models/svg/zero-radius.svg',
-					'Styles in svg tag': 'models/svg/tests/styles.svg'
+					'Styles in svg tag': 'models/svg/tests/styles.svg',
+					'Round join': 'models/svg/tests/roundJoinPrecisionIssue.svg'
+
 
 				} ).name( 'SVG File' ).onChange( update );
 


### PR DESCRIPTION
**Description**

Detection of straight path in SVG Loader could be wrong in case of floating point precision issue. In that case an invalid join with a very large miter length was created.

