### PR TITLE
Editor: Enable centering geometries.

### DIFF
--- a/editor/js/Sidebar.Geometry.Modifiers.js
+++ b/editor/js/Sidebar.Geometry.Modifiers.js
@@ -12,21 +12,34 @@ function SidebarGeometryModifiers( editor, object ) {
 
 	// Compute Vertex Normals
 
-	const button = new UIButton( strings.getKey( 'sidebar/geometry/compute_vertex_normals' ) );
-	button.onClick( function () {
+	const computeVertexNormalsButton = new UIButton( strings.getKey( 'sidebar/geometry/compute_vertex_normals' ) );
+	computeVertexNormalsButton.onClick( function () {
 
 		geometry.computeVertexNormals();
-
-		geometry.attributes.normal.needsUpdate = true;
 
 		signals.geometryChanged.dispatch( object );
 
 	} );
 
-	const row = new UIRow();
-	row.add( button );
+	const computeVertexNormalsRow = new UIRow();
+	computeVertexNormalsRow.add( computeVertexNormalsButton );
+	container.add( computeVertexNormalsRow );
 
-	container.add( row );
+
+	// Center Geometry
+
+	const centerButton = new UIButton( strings.getKey( 'sidebar/geometry/center' ) );
+	centerButton.onClick( function () {
+
+		geometry.center();
+
+		signals.geometryChanged.dispatch( object );
+
+	} );
+
+	const centerRow = new UIRow();
+	centerRow.add( centerButton );
+	container.add( centerRow );
 
 	//
 

--- a/editor/js/Strings.js
+++ b/editor/js/Strings.js
@@ -135,6 +135,7 @@ function Strings( config ) {
 			'sidebar/geometry/bounds': 'Bounds',
 			'sidebar/geometry/show_vertex_normals': 'Show Vertex Normals',
 			'sidebar/geometry/compute_vertex_normals': 'Compute Vertex Normals',
+			'sidebar/geometry/center': 'Center',
 
 			'sidebar/geometry/box_geometry/width': 'Width',
 			'sidebar/geometry/box_geometry/height': 'Height',
@@ -478,6 +479,7 @@ function Strings( config ) {
 			'sidebar/geometry/bounds': 'Limites',
 			'sidebar/geometry/show_vertex_normals': 'Afficher normales',
 			'sidebar/geometry/compute_vertex_normals': 'Compute Vertex Normals',
+			'sidebar/geometry/center': 'Center',
 
 			'sidebar/geometry/box_geometry/width': 'Largeur',
 			'sidebar/geometry/box_geometry/height': 'Hauteur',
@@ -816,6 +818,7 @@ function Strings( config ) {
 			'sidebar/geometry/bounds': '界限',
 			'sidebar/geometry/show_vertex_normals': '显示顶点法线',
 			'sidebar/geometry/compute_vertex_normals': '计算顶点法线',
+			'sidebar/geometry/center': 'Center',
 
 			'sidebar/geometry/box_geometry/width': '宽度',
 			'sidebar/geometry/box_geometry/height': '高度',


### PR DESCRIPTION
Related issue: -

**Description**

This PR enhances `Sidebar.Geometry.Modifiers` so it's possible to trigger `BufferGeometry.center()`.
