### PR TITLE
Exporting package.json in package.json to help rollup

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     },
     "./examples/fonts/*": "./examples/fonts/*",
     "./examples/jsm/*": "./examples/jsm/*",
-    "./src/*": "./src/*"
+    "./src/*": "./src/*",
+    "./package.json": "./package.json" 
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Description**

Projects using rollup and Three.js display a warning on each build:

```
[rollup-plugin-svelte] The following packages did not export their `package.json` file so we could not check the "svelte" field. If you had difficulties importing svelte components from a package, then please contact the author and ask them to export the package.json file.

- three
```

The warning text is pretty clear, we just need to add "./package.json" to the "export" section of package.json, like this PR does.
