### PR TITLE
Corrected simplify example title

### DIFF
--- a/examples/webgl_modifier_simplifier.html
+++ b/examples/webgl_modifier_simplifier.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 	<head>
-		<title>three.js webgl - modifier - Subdivisions using Loop Subdivision Scheme</title>
+		<title>three.js webgl - modifier - simplify modifier</title>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
 		<link type="text/css" rel="stylesheet" href="main.css">


### PR DESCRIPTION
Related issue: #XXXX

**Description**

Looks like example was originally copied from subdivision modifier (deprecated). Changed title to match example, lowercase title matches title format of curve modifier example (https://github.com/mrdoob/three.js/blob/master/examples/webgl_modifier_curve.html).
