### PR TITLE
Examples: Dispose of render targets in ocean demo.

### DIFF
--- a/examples/webgl_shaders_ocean.html
+++ b/examples/webgl_shaders_ocean.html
@@ -111,6 +111,7 @@
 				};
 
 				const pmremGenerator = new THREE.PMREMGenerator( renderer );
+				let renderTarget;
 
 				function updateSun() {
 
@@ -122,7 +123,11 @@
 					sky.material.uniforms[ 'sunPosition' ].value.copy( sun );
 					water.material.uniforms[ 'sunDirection' ].value.copy( sun ).normalize();
 
-					scene.environment = pmremGenerator.fromScene( sky ).texture;
+					if ( renderTarget !== undefined ) renderTarget.dispose();
+
+					renderTarget = pmremGenerator.fromScene( sky );
+
+					scene.environment = renderTarget.texture;
 
 				}
 


### PR DESCRIPTION
Fixed #24326.

**Description**

Ensures `dispose()` is called on render targets generated with `PMREMGenerator.fromScene()`.