### PR TITLE
ColladaLoader: Add warning when converting up axis.

### DIFF
--- a/examples/jsm/loaders/ColladaLoader.js
+++ b/examples/jsm/loaders/ColladaLoader.js
@@ -4066,6 +4066,7 @@ class ColladaLoader extends Loader {
 
 		if ( asset.upAxis === 'Z_UP' ) {
 
+			console.warn( 'THREE.ColladaLoader: You are loading an asset with a Z-UP coordinate system. The loader just rotates the asset to transform it into Y-UP. The vertex data are not converted, see #24289.' );
 			scene.quaternion.setFromEuler( new Euler( - Math.PI / 2, 0, 0 ) );
 
 		}


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/24289#issuecomment-1177058748

**Description**

`ColladaLoader` now reports a warning when z-up is converted to y-up.
