### PR TITLE
PCDLoader: Add support for `intensity` field.

### DIFF
--- a/examples/jsm/loaders/PCDLoader.js
+++ b/examples/jsm/loaders/PCDLoader.js
@@ -229,6 +229,7 @@ class PCDLoader extends Loader {
 		const position = [];
 		const normal = [];
 		const color = [];
+		const intensity = [];
 
 		// ascii
 
@@ -285,6 +286,13 @@ class PCDLoader extends Loader {
 
 				}
 
+				if ( offset.intensity !== undefined ) {
+
+					const value = parseFloat( line[ offset.intensity ] ) / 255;
+					intensity.push( value, value, value );
+
+				}
+
 			}
 
 		}
@@ -338,6 +346,14 @@ class PCDLoader extends Loader {
 
 				}
 
+				if ( offset.intensity !== undefined ) {
+
+					const intensityIndex = PCDheader.fields.indexOf( 'intensity' );
+					const value = dataview.getUint8( PCDheader.points * offset.intensity + PCDheader.size[ intensityIndex ] * i ) / 255;
+					intensity.push( value, value, value );
+
+				}
+
 			}
 
 		}
@@ -375,6 +391,13 @@ class PCDLoader extends Loader {
 
 				}
 
+				if ( offset.intensity !== undefined ) {
+
+					const value = dataview.getUint8( row + offset.intensity ) / 255;
+					intensity.push( value, value, value );
+
+				}
+
 			}
 
 		}
@@ -386,6 +409,7 @@ class PCDLoader extends Loader {
 		if ( position.length > 0 ) geometry.setAttribute( 'position', new Float32BufferAttribute( position, 3 ) );
 		if ( normal.length > 0 ) geometry.setAttribute( 'normal', new Float32BufferAttribute( normal, 3 ) );
 		if ( color.length > 0 ) geometry.setAttribute( 'color', new Float32BufferAttribute( color, 3 ) );
+		if ( intensity.length > 0 ) geometry.setAttribute( 'color', new Float32BufferAttribute( intensity, 3 ) );
 
 		geometry.computeBoundingSphere();
 
@@ -393,7 +417,7 @@ class PCDLoader extends Loader {
 
 		const material = new PointsMaterial( { size: 0.005 } );
 
-		if ( color.length > 0 ) {
+		if ( color.length > 0 || intensity.length > 0 ) {
 
 			material.vertexColors = true;
 


### PR DESCRIPTION
Related issue: #24253

**Description**

This PR revisits #24253 and adds `intensity` to `PCDLoader`.

After some investigation, it seems that LiDAR PCD's often hold an `intensity` field. The idea is to use this field as alternative source for vertex colors meaning you treat it like a grayscale value. So instead of having XYZRGB the format is XYZI.

The implementation assumes the intensity value has a range between 0 and 255 so it is processed similar to normal color values.

A PCD file can hold XYZRGB _or_ XYZI data. I've not seen XYZRGBI while investigating the topic.

| prod   |      with intensity      | 
|----------|:-------------:|
| <img width="677" alt="image" src="https://user-images.githubusercontent.com/12612165/178524869-a1898a5a-98ff-42b2-953c-ffc78cfb6fc9.png"> | <img width="652" alt="image" src="https://user-images.githubusercontent.com/12612165/178524809-015d9878-28aa-48c5-9cce-9da9614e737d.png">|

I could not add the above test file since I have used one from another GitHub issue: https://github.com/isl-org/Open3D/issues/125


