### PR TITLE
Core: Vector, Matrix, Quaternion and Color instanceof

### DIFF
--- a/editor/js/Sidebar.Scene.js
+++ b/editor/js/Sidebar.Scene.js
@@ -373,7 +373,7 @@ function SidebarScene( editor ) {
 
 		if ( scene.background ) {
 
-			if ( scene.background.isColor ) {
+			if ( scene.background instanceof THREE.Color ) {
 
 				backgroundType.setValue( 'Color' );
 				backgroundColor.setHexValue( scene.background.getHex() );

--- a/examples/js/controls/FirstPersonControls.js
+++ b/examples/js/controls/FirstPersonControls.js
@@ -204,7 +204,7 @@
 
 			this.lookAt = function ( x, y, z ) {
 
-				if ( x.isVector3 ) {
+				if ( x instanceof THREE.Vector3 ) {
 
 					_target.copy( x );
 

--- a/examples/js/renderers/SVGRenderer.js
+++ b/examples/js/renderers/SVGRenderer.js
@@ -159,7 +159,7 @@
 
 				const background = scene.background;
 
-				if ( background && background.isColor ) {
+				if ( background instanceof THREE.Color ) {
 
 					removeChildNodes();
 					_svg.style.backgroundColor = background.getStyle();

--- a/examples/jsm/controls/FirstPersonControls.js
+++ b/examples/jsm/controls/FirstPersonControls.js
@@ -187,7 +187,7 @@ class FirstPersonControls {
 
 		this.lookAt = function ( x, y, z ) {
 
-			if ( x.isVector3 ) {
+			if ( x instanceof Vector3 ) {
 
 				_target.copy( x );
 

--- a/examples/jsm/nodes/core/NodeUtils.js
+++ b/examples/jsm/nodes/core/NodeUtils.js
@@ -30,27 +30,27 @@ export const getValueType = ( value ) => {
 
 		return 'bool';
 
-	} else if ( value?.isVector2 === true ) {
+	} else if ( value instanceof Vector2 ) {
 
 		return 'vec2';
 
-	} else if ( value?.isVector3 === true ) {
+	} else if ( value instanceof Vector3 ) {
 
 		return 'vec3';
 
-	} else if ( value?.isVector4 === true ) {
+	} else if ( value instanceof Vector4 ) {
 
 		return 'vec4';
 
-	} else if ( value?.isMatrix3 === true ) {
+	} else if ( value instanceof Matrix3 ) {
 
 		return 'mat3';
 
-	} else if ( value?.isMatrix4 === true ) {
+	} else if ( value instanceof Matrix4 ) {
 
 		return 'mat4';
 
-	} else if ( value?.isColor === true ) {
+	} else if ( value instanceof Color ) {
 
 		return 'color';
 

--- a/examples/jsm/nodes/geometry/RangeNode.js
+++ b/examples/jsm/nodes/geometry/RangeNode.js
@@ -1,6 +1,6 @@
 import Node from '../core/Node.js';
 import { attribute, float } from '../shadernode/ShaderNodeBaseElements.js';
-import { MathUtils, InstancedBufferAttribute } from 'three';
+import { Color, Vector2, Vector3, Vector4, MathUtils, InstancedBufferAttribute } from 'three';
 
 class RangeNode extends Node {
 
@@ -19,10 +19,10 @@ class RangeNode extends Node {
 
 		let length = 1;
 
-		if ( min.isVector2 ) length = 2;
-		else if ( min.isVector3 ) length = 3;
-		else if ( min.isVector4 ) length = 4;
-		else if ( min.isColor ) length = 3;
+		if ( min instanceof Vector2 ) length = 2;
+		else if ( min instanceof Vector3 ) length = 3;
+		else if ( min instanceof Vector4 ) length = 4;
+		else if ( min instanceof Color ) length = 3;
 
 		return length;
 
@@ -61,7 +61,7 @@ class RangeNode extends Node {
 
 					}
 
-				} else if ( min.isColor ) {
+				} else if ( min instanceof Color ) {
 
 					for ( let i = 0; i < length; i += 3 ) {
 

--- a/examples/jsm/nodes/materials/SpriteNodeMaterial.js
+++ b/examples/jsm/nodes/materials/SpriteNodeMaterial.js
@@ -1,5 +1,5 @@
 import NodeMaterial from './NodeMaterial.js';
-import { SpriteMaterial } from 'three';
+import { Vector2, SpriteMaterial } from 'three';
 import {
 	vec2, vec3, vec4,
 	uniform, add, mul, sub,
@@ -59,7 +59,7 @@ class SpriteNodeMaterial extends NodeMaterial {
 
 		let alignedPosition = vertex.xy;
 
-		if ( builder.object.center?.isVector2 === true ) {
+		if ( builder.object.center instanceof Vector2 ) {
 
 			alignedPosition = sub( alignedPosition, sub( uniform( builder.object.center ), vec2( 0.5 ) ) );
 

--- a/examples/jsm/renderers/SVGRenderer.js
+++ b/examples/jsm/renderers/SVGRenderer.js
@@ -7,6 +7,7 @@ import {
 	Object3D,
 	Vector3
 } from 'three';
+
 import { Projector } from '../renderers/Projector.js';
 import { RenderableFace } from '../renderers/Projector.js';
 import { RenderableLine } from '../renderers/Projector.js';
@@ -170,7 +171,7 @@ class SVGRenderer {
 
 			const background = scene.background;
 
-			if ( background && background.isColor ) {
+			if ( background instanceof Color ) {
 
 				removeChildNodes();
 				_svg.style.backgroundColor = background.getStyle();

--- a/examples/jsm/renderers/webgpu/WebGPUBackground.js
+++ b/examples/jsm/renderers/webgpu/WebGPUBackground.js
@@ -38,7 +38,7 @@ class WebGPUBackground {
 			_clearColor.copy( renderer._clearColor );
 			_clearAlpha = renderer._clearAlpha;
 
-		} else if ( background.isColor === true ) {
+		} else if ( background instanceof Color ) {
 
 			// background is an opaque color
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -1,10 +1,11 @@
-import { Quaternion } from '../math/Quaternion.js';
-import { Vector3 } from '../math/Vector3.js';
-import { Matrix4 } from '../math/Matrix4.js';
 import { EventDispatcher } from './EventDispatcher.js';
-import { Euler } from '../math/Euler.js';
 import { Layers } from './Layers.js';
+import { Color } from '../math/Color.js';
+import { Vector3 } from '../math/Vector3.js';
 import { Matrix3 } from '../math/Matrix3.js';
+import { Matrix4 } from '../math/Matrix4.js';
+import { Quaternion } from '../math/Quaternion.js';
+import { Euler } from '../math/Euler.js';
 import * as MathUtils from '../math/MathUtils.js';
 
 let _object3DId = 0;
@@ -259,7 +260,7 @@ class Object3D extends EventDispatcher {
 
 		// This method does not support objects having non-uniformly-scaled parent(s)
 
-		if ( x.isVector3 ) {
+		if ( x instanceof Vector3 ) {
 
 			_target.copy( x );
 
@@ -709,7 +710,7 @@ class Object3D extends EventDispatcher {
 
 			if ( this.background ) {
 
-				if ( this.background.isColor ) {
+				if ( this.background instanceof Color ) {
 
 					object.background = this.background.toJSON();
 

--- a/src/extras/PMREMGenerator.js
+++ b/src/extras/PMREMGenerator.js
@@ -1,13 +1,14 @@
 import {
+	BackSide,
 	CubeReflectionMapping,
 	CubeRefractionMapping,
 	CubeUVReflectionMapping,
+	HalfFloatType,
 	LinearEncoding,
 	LinearFilter,
-	NoToneMapping,
 	NoBlending,
-	RGBAFormat,
-	HalfFloatType
+	NoToneMapping,
+	RGBAFormat
 } from '../constants.js';
 
 import { BufferAttribute } from '../core/BufferAttribute.js';
@@ -16,12 +17,11 @@ import { Mesh } from '../objects/Mesh.js';
 import { OrthographicCamera } from '../cameras/OrthographicCamera.js';
 import { PerspectiveCamera } from '../cameras/PerspectiveCamera.js';
 import { ShaderMaterial } from '../materials/ShaderMaterial.js';
-import { Vector3 } from '../math/Vector3.js';
-import { Color } from '../math/Color.js';
 import { WebGLRenderTarget } from '../renderers/WebGLRenderTarget.js';
 import { MeshBasicMaterial } from '../materials/MeshBasicMaterial.js';
 import { BoxGeometry } from '../geometries/BoxGeometry.js';
-import { BackSide } from '../constants.js';
+import { Color } from '../math/Color.js';
+import { Vector3 } from '../math/Vector3.js';
 
 const LOD_MIN = 4;
 
@@ -319,7 +319,7 @@ class PMREMGenerator {
 
 		if ( background ) {
 
-			if ( background.isColor ) {
+			if ( background instanceof Color ) {
 
 				backgroundMaterial.color.copy( background );
 				scene.background = null;

--- a/src/extras/core/Curve.js
+++ b/src/extras/core/Curve.js
@@ -1,7 +1,7 @@
-import * as MathUtils from '../../math/MathUtils.js';
 import { Vector2 } from '../../math/Vector2.js';
 import { Vector3 } from '../../math/Vector3.js';
 import { Matrix4 } from '../../math/Matrix4.js';
+import * as MathUtils from '../../math/MathUtils.js';
 
 /**
  * Extensible curve object.
@@ -242,7 +242,7 @@ class Curve {
 		const pt1 = this.getPoint( t1 );
 		const pt2 = this.getPoint( t2 );
 
-		const tangent = optionalTarget || ( ( pt1.isVector2 ) ? new Vector2() : new Vector3() );
+		const tangent = optionalTarget || ( ( pt1 instanceof Vector2 ) ? new Vector2() : new Vector3() );
 
 		tangent.copy( pt2 ).sub( pt1 ).normalize();
 

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -1,5 +1,18 @@
+import {
+	AddEquation,
+	AlwaysStencilFunc,
+	FlatShading,
+	FrontSide,
+	KeepStencilOp,
+	LessEqualDepth,
+	NormalBlending,
+	OneMinusSrcAlphaFactor,
+	SrcAlphaFactor
+} from '../constants.js';
+
 import { EventDispatcher } from '../core/EventDispatcher.js';
-import { FrontSide, FlatShading, NormalBlending, LessEqualDepth, AddEquation, OneMinusSrcAlphaFactor, SrcAlphaFactor, AlwaysStencilFunc, KeepStencilOp } from '../constants.js';
+import { Color } from '../math/Color.js';
+import { Vector3 } from '../math/Vector3.js';
 import * as MathUtils from '../math/MathUtils.js';
 
 let materialId = 0;
@@ -140,11 +153,11 @@ class Material extends EventDispatcher {
 
 			}
 
-			if ( currentValue && currentValue.isColor ) {
+			if ( currentValue instanceof Color ) {
 
 				currentValue.set( newValue );
 
-			} else if ( ( currentValue && currentValue.isVector3 ) && ( newValue && newValue.isVector3 ) ) {
+			} else if ( ( currentValue instanceof Vector3 ) && ( newValue && newValue instanceof Vector3 ) ) {
 
 				currentValue.copy( newValue );
 
@@ -185,20 +198,20 @@ class Material extends EventDispatcher {
 
 		if ( this.name !== '' ) data.name = this.name;
 
-		if ( this.color && this.color.isColor ) data.color = this.color.getHex();
+		if ( this.color instanceof Color ) data.color = this.color.getHex();
 
 		if ( this.roughness !== undefined ) data.roughness = this.roughness;
 		if ( this.metalness !== undefined ) data.metalness = this.metalness;
 
 		if ( this.sheen !== undefined ) data.sheen = this.sheen;
-		if ( this.sheenColor && this.sheenColor.isColor ) data.sheenColor = this.sheenColor.getHex();
+		if ( this.sheenColor instanceof Color ) data.sheenColor = this.sheenColor.getHex();
 		if ( this.sheenRoughness !== undefined ) data.sheenRoughness = this.sheenRoughness;
-		if ( this.emissive && this.emissive.isColor ) data.emissive = this.emissive.getHex();
+		if ( this.emissive instanceof Color ) data.emissive = this.emissive.getHex();
 		if ( this.emissiveIntensity && this.emissiveIntensity !== 1 ) data.emissiveIntensity = this.emissiveIntensity;
 
-		if ( this.specular && this.specular.isColor ) data.specular = this.specular.getHex();
+		if ( this.specular instanceof Color ) data.specular = this.specular.getHex();
 		if ( this.specularIntensity !== undefined ) data.specularIntensity = this.specularIntensity;
-		if ( this.specularColor && this.specularColor.isColor ) data.specularColor = this.specularColor.getHex();
+		if ( this.specularColor instanceof Color ) data.specularColor = this.specularColor.getHex();
 		if ( this.shininess !== undefined ) data.shininess = this.shininess;
 		if ( this.clearcoat !== undefined ) data.clearcoat = this.clearcoat;
 		if ( this.clearcoatRoughness !== undefined ) data.clearcoatRoughness = this.clearcoatRoughness;

--- a/src/materials/ShaderMaterial.js
+++ b/src/materials/ShaderMaterial.js
@@ -1,4 +1,10 @@
 import { Material } from './Material.js';
+import { Color } from '../math/Color.js';
+import { Vector2 } from '../math/Vector2.js';
+import { Vector3 } from '../math/Vector3.js';
+import { Vector4 } from '../math/Vector4.js';
+import { Matrix3 } from '../math/Matrix3.js';
+import { Matrix4 } from '../math/Matrix4.js';
 import { cloneUniforms, cloneUniformsGroups } from '../renderers/shaders/UniformsUtils.js';
 
 import default_vertex from '../renderers/shaders/ShaderChunk/default_vertex.glsl.js';
@@ -110,42 +116,42 @@ class ShaderMaterial extends Material {
 					value: value.toJSON( meta ).uuid
 				};
 
-			} else if ( value && value.isColor ) {
+			} else if ( value instanceof Color ) {
 
 				data.uniforms[ name ] = {
 					type: 'c',
 					value: value.getHex()
 				};
 
-			} else if ( value && value.isVector2 ) {
+			} else if ( value instanceof Vector2 ) {
 
 				data.uniforms[ name ] = {
 					type: 'v2',
 					value: value.toArray()
 				};
 
-			} else if ( value && value.isVector3 ) {
+			} else if ( value instanceof Vector3 ) {
 
 				data.uniforms[ name ] = {
 					type: 'v3',
 					value: value.toArray()
 				};
 
-			} else if ( value && value.isVector4 ) {
+			} else if ( value instanceof Vector4 ) {
 
 				data.uniforms[ name ] = {
 					type: 'v4',
 					value: value.toArray()
 				};
 
-			} else if ( value && value.isMatrix3 ) {
+			} else if ( value instanceof Matrix3 ) {
 
 				data.uniforms[ name ] = {
 					type: 'm3',
 					value: value.toArray()
 				};
 
-			} else if ( value && value.isMatrix4 ) {
+			} else if ( value instanceof Matrix4 ) {
 
 				data.uniforms[ name ] = {
 					type: 'm4',

--- a/src/math/Color.js
+++ b/src/math/Color.js
@@ -56,7 +56,8 @@ class Color {
 
 	constructor( r, g, b ) {
 
-		this.isColor = true;
+		// @deprecated
+		Object.defineProperty( this, 'isColor', { value: true } );
 
 		this.r = 1;
 		this.g = 1;
@@ -75,7 +76,7 @@ class Color {
 
 	set( value ) {
 
-		if ( value && value.isColor ) {
+		if ( value instanceof Color ) {
 
 			this.copy( value );
 

--- a/src/math/Matrix3.js
+++ b/src/math/Matrix3.js
@@ -2,7 +2,8 @@ class Matrix3 {
 
 	constructor() {
 
-		Matrix3.prototype.isMatrix3 = true;
+		// @deprecated
+		Object.defineProperty( this, 'isMatrix3', { value: true } );
 
 		this.elements = [
 

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -4,7 +4,8 @@ class Matrix4 {
 
 	constructor() {
 
-		Matrix4.prototype.isMatrix4 = true;
+		// @deprecated
+		Object.defineProperty( this, 'isMatrix4', { value: true } );
 
 		this.elements = [
 
@@ -463,7 +464,7 @@ class Matrix4 {
 
 		const te = this.elements;
 
-		if ( x.isVector3 ) {
+		if ( x instanceof Vector3 ) {
 
 			te[ 12 ] = x.x;
 			te[ 13 ] = x.y;

--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -4,7 +4,8 @@ class Quaternion {
 
 	constructor( x = 0, y = 0, z = 0, w = 1 ) {
 
-		this.isQuaternion = true;
+		// @deprecated
+		Object.defineProperty( this, 'isQuaternion', { value: true } );
 
 		this._x = x;
 		this._y = y;

--- a/src/math/Vector2.js
+++ b/src/math/Vector2.js
@@ -2,7 +2,8 @@ class Vector2 {
 
 	constructor( x = 0, y = 0 ) {
 
-		Vector2.prototype.isVector2 = true;
+		// @deprecated
+		Object.defineProperty( this, 'isVector2', { value: true } );
 
 		this.x = x;
 		this.y = y;

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -5,7 +5,8 @@ class Vector3 {
 
 	constructor( x = 0, y = 0, z = 0 ) {
 
-		Vector3.prototype.isVector3 = true;
+		// @deprecated
+		Object.defineProperty( this, 'isVector3', { value: true } );
 
 		this.x = x;
 		this.y = y;

--- a/src/math/Vector4.js
+++ b/src/math/Vector4.js
@@ -2,7 +2,8 @@ class Vector4 {
 
 	constructor( x = 0, y = 0, z = 0, w = 1 ) {
 
-		Vector4.prototype.isVector4 = true;
+		// @deprecated
+		Object.defineProperty( this, 'isVector4', { value: true } );
 
 		this.x = x;
 		this.y = y;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1,22 +1,17 @@
 import {
-	REVISION,
 	BackSide,
 	DoubleSide,
-	FrontSide,
-	RGBAFormat,
-	HalfFloatType,
 	FloatType,
-	UnsignedByteType,
+	FrontSide,
+	HalfFloatType,
 	LinearEncoding,
+	LinearMipmapLinearFilter,
 	NoToneMapping,
-	LinearMipmapLinearFilter
+	REVISION,
+	RGBAFormat,
+	UnsignedByteType
 } from '../constants.js';
-import { floorPowerOfTwo } from '../math/MathUtils.js';
-import { Frustum } from '../math/Frustum.js';
-import { Matrix4 } from '../math/Matrix4.js';
-import { Vector2 } from '../math/Vector2.js';
-import { Vector3 } from '../math/Vector3.js';
-import { Vector4 } from '../math/Vector4.js';
+
 import { WebGLAnimation } from './webgl/WebGLAnimation.js';
 import { WebGLAttributes } from './webgl/WebGLAttributes.js';
 import { WebGLBackground } from './webgl/WebGLBackground.js';
@@ -45,6 +40,12 @@ import { WebGLUtils } from './webgl/WebGLUtils.js';
 import { WebXRManager } from './webxr/WebXRManager.js';
 import { WebGLMaterials } from './webgl/WebGLMaterials.js';
 import { WebGLUniformsGroups } from './webgl/WebGLUniformsGroups.js';
+import { Vector2 } from '../math/Vector2.js';
+import { Vector3 } from '../math/Vector3.js';
+import { Vector4 } from '../math/Vector4.js';
+import { Matrix4 } from '../math/Matrix4.js';
+import { Frustum } from '../math/Frustum.js';
+import { floorPowerOfTwo } from '../math/MathUtils.js';
 import { createElementNS } from '../utils.js';
 
 function createCanvasElement() {
@@ -474,7 +475,7 @@ function WebGLRenderer( parameters = {} ) {
 
 	this.setViewport = function ( x, y, width, height ) {
 
-		if ( x.isVector4 ) {
+		if ( x instanceof Vector4 ) {
 
 			_viewport.set( x.x, x.y, x.z, x.w );
 
@@ -496,7 +497,7 @@ function WebGLRenderer( parameters = {} ) {
 
 	this.setScissor = function ( x, y, width, height ) {
 
-		if ( x.isVector4 ) {
+		if ( x instanceof Vector4 ) {
 
 			_scissor.set( x.x, x.y, x.z, x.w );
 

--- a/src/renderers/shaders/UniformsUtils.js
+++ b/src/renderers/shaders/UniformsUtils.js
@@ -1,3 +1,11 @@
+import { Color } from '../../math/Color.js';
+import { Vector2 } from '../../math/Vector2.js';
+import { Vector3 } from '../../math/Vector3.js';
+import { Vector4 } from '../../math/Vector4.js';
+import { Matrix3 } from '../../math/Matrix3.js';
+import { Matrix4 } from '../../math/Matrix4.js';
+import { Quaternion } from '../../math/Quaternion.js';
+
 /**
  * Uniform Utilities
  */
@@ -14,10 +22,10 @@ export function cloneUniforms( src ) {
 
 			const property = src[ u ][ p ];
 
-			if ( property && ( property.isColor ||
-				property.isMatrix3 || property.isMatrix4 ||
-				property.isVector2 || property.isVector3 || property.isVector4 ||
-				property.isTexture || property.isQuaternion ) ) {
+			if ( property && ( property instanceof Color ||
+				property instanceof Vector2 || property instanceof Vector3 || property instanceof Vector4 ||
+				property instanceof Matrix3 || property instanceof Matrix4 ||
+				property instanceof Quaternion || property.isTexture ) ) {
 
 				dst[ u ][ p ] = property.clone();
 

--- a/src/renderers/webgl/WebGLBackground.js
+++ b/src/renderers/webgl/WebGLBackground.js
@@ -1,11 +1,16 @@
-import { BackSide, FrontSide, CubeUVReflectionMapping } from '../../constants.js';
+import {
+	BackSide,
+	CubeUVReflectionMapping,
+	FrontSide
+} from '../../constants.js';
+
 import { BoxGeometry } from '../../geometries/BoxGeometry.js';
 import { PlaneGeometry } from '../../geometries/PlaneGeometry.js';
 import { ShaderMaterial } from '../../materials/ShaderMaterial.js';
-import { Color } from '../../math/Color.js';
 import { Mesh } from '../../objects/Mesh.js';
 import { ShaderLib } from '../shaders/ShaderLib.js';
 import { cloneUniforms } from '../shaders/UniformsUtils.js';
+import { Color } from '../../math/Color.js';
 
 function WebGLBackground( renderer, cubemaps, state, objects, alpha, premultipliedAlpha ) {
 
@@ -46,7 +51,7 @@ function WebGLBackground( renderer, cubemaps, state, objects, alpha, premultipli
 
 			setClear( clearColor, clearAlpha );
 
-		} else if ( background && background.isColor ) {
+		} else if ( background instanceof Color ) {
 
 			setClear( background, 1 );
 			forceClear = true;

--- a/src/renderers/webgl/WebGLUniformsGroups.js
+++ b/src/renderers/webgl/WebGLUniformsGroups.js
@@ -1,3 +1,10 @@
+import { Color } from '../../math/Color.js';
+import { Vector2 } from '../../math/Vector2.js';
+import { Vector3 } from '../../math/Vector3.js';
+import { Vector4 } from '../../math/Vector4.js';
+import { Matrix3 } from '../../math/Matrix3.js';
+import { Matrix4 } from '../../math/Matrix4.js';
+
 function WebGLUniformsGroups( gl, info, capabilities, state ) {
 
 	let buffers = {};
@@ -112,7 +119,7 @@ function WebGLUniformsGroups( gl, info, capabilities, state ) {
 
 				} else {
 
-					if ( uniform.value.isMatrix3 ) {
+					if ( uniform.value instanceof Matrix3 ) {
 
 						// manually converting 3x3 to 3x4
 
@@ -278,35 +285,35 @@ function WebGLUniformsGroups( gl, info, capabilities, state ) {
 			info.boundary = 4;
 			info.storage = 4;
 
-		} else if ( value.isVector2 ) {
+		} else if ( value instanceof Vector2 ) {
 
 			// vec2
 
 			info.boundary = 8;
 			info.storage = 8;
 
-		} else if ( value.isVector3 || value.isColor ) {
+		} else if ( value instanceof Vector3 || value instanceof Color ) {
 
 			// vec3
 
 			info.boundary = 16;
 			info.storage = 12; // evil: vec3 must start on a 16-byte boundary but it only consumes 12 bytes
 
-		} else if ( value.isVector4 ) {
+		} else if ( value instanceof Vector4 ) {
 
 			// vec4
 
 			info.boundary = 16;
 			info.storage = 16;
 
-		} else if ( value.isMatrix3 ) {
+		} else if ( value instanceof Matrix3 ) {
 
 			// mat3 (in STD140 a 3x3 matrix is represented as 3x4)
 
 			info.boundary = 48;
 			info.storage = 48;
 
-		} else if ( value.isMatrix4 ) {
+		} else if ( value instanceof Matrix4 ) {
 
 			// mat4
 


### PR DESCRIPTION
Related issues: #24219 #24199 #24167 https://github.com/mrdoob/three.js/issues/24199#issuecomment-1149546022

**Description**

Defining `.prototype.is*` inside the constructor is a bit of a hack, really the `.prototype.*` properties should be defined outside the classes once like in the rest of the library for consistency. 🙄

> this wins the most-weird-thing-in-the-library award imho 😁

Given that, I've gone ahead and trying the `instanceof` method here, in my opinion I think using `instanceof` with tree-shaking is fine, because really you do need all those classes if you have code referencing them. Especially for core classes that are needed anyways, and many classes are already importing the classes used with their respective `.is*` properties anyways.

The syntax for using `instanceof` is often simpler as well without the need for checking the value first or use of optional chaining.

The epic #9310 from @Rich-Harris I would argue is a stopgap solution, it is possible to write a tree-shakeable library with `instanceof`, it's more of a design problem with the renderer, thus the stopgap solution. For example in [OGL](https://github.com/oframe/ogl) the renderer there only needs a `Vec3`.

https://github.com/oframe/ogl/blob/master/src/core/Renderer.js

This is a much larger discussion for a different issue, but wanted to mention it here as it's related to the use of `instanceof`. Though for comparison OGL doesn't use any `instanceof`'s either.

Note I didn't do `.isTexture`, I feel like I'm opening Pandora's box here, so let's see what everyone thinks of this change first.

Also if we were to completely remove the `.is*` properties it would be a breaking change, they are used in the examples, tests, docs and more than likely other people are using them.

It's up for debate on whether this actually has any performance improvement or not. 😊

Finally, if `instanceof` doesn't work-out, I would at-least prefer setting the non-enumerable property with `Object.defineProperty/ies()` inside the constructor instead, as is done with [`LOD`](https://github.com/mrdoob/three.js/blob/3a76bc7d212557422abe33525d2f3e44f79fb406/src/objects/LOD.js#L17
) and `NodeCode` already.

https://github.com/mrdoob/three.js/blob/3a76bc7d212557422abe33525d2f3e44f79fb406/examples/jsm/nodes/core/NodeCode.js#L9

```js
.isColor instanceof Color/THREE.Color
.isVector2 instanceof Vector2/THREE.Vector2
.isVector3 instanceof Vector3/THREE.Vector3
.isVector4 instanceof Vector4/THREE.Vector4
.isMatrix3 instanceof Matrix3/THREE.Matrix3
.isMatrix4 instanceof Matrix4/THREE.Matrix4
.isQuaternion instanceof Quaternion/THREE.Quaternion
```
