### PR TITLE
Renderers: Deprecate setDrawingBufferSize().

### DIFF
--- a/examples/jsm/renderers/webgpu/WebGPURenderer.js
+++ b/examples/jsm/renderers/webgpu/WebGPURenderer.js
@@ -365,22 +365,6 @@ class WebGPURenderer {
 
 	}
 
-	setDrawingBufferSize( width, height, pixelRatio ) {
-
-		this._width = width;
-		this._height = height;
-
-		this._pixelRatio = pixelRatio;
-
-		this.domElement.width = Math.floor( width * pixelRatio );
-		this.domElement.height = Math.floor( height * pixelRatio );
-
-		this._configureContext();
-		this._setupColorBuffer();
-		this._setupDepthBuffer();
-
-	}
-
 	setSize( width, height, updateStyle = true ) {
 
 		this._width = width;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -446,17 +446,14 @@ function WebGLRenderer( parameters = {} ) {
 
 	};
 
+	// @deprecated since r143
+
 	this.setDrawingBufferSize = function ( width, height, pixelRatio ) {
 
-		_width = width;
-		_height = height;
+		console.warn( 'THREE.WebGLRenderer: .setDrawingBufferSize() has been deprecated. Please use a combination of .setPixelRatio() and .setSize().' );
 
-		_pixelRatio = pixelRatio;
-
-		_canvas.width = Math.floor( width * pixelRatio );
-		_canvas.height = Math.floor( height * pixelRatio );
-
-		this.setViewport( 0, 0, width, height );
+		this.setPixelRatio( pixelRatio );
+		this.setSize( width, height, false );
 
 	};
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -450,7 +450,7 @@ function WebGLRenderer( parameters = {} ) {
 
 	this.setDrawingBufferSize = function ( width, height, pixelRatio ) {
 
-		console.warn( 'THREE.WebGLRenderer: .setDrawingBufferSize() has been deprecated. Please use a combination of .setPixelRatio() and .setSize().' );
+		console.warn( 'THREE.WebGLRenderer: .setDrawingBufferSize() has been deprecated. Use a combination of .setPixelRatio() and .setSize() instead.' );
 
 		this.setPixelRatio( pixelRatio );
 		this.setSize( width, height, false );


### PR DESCRIPTION
Related issue: #23566

**Description**

This PR deprecates `WebGLRenderer.setDrawingBufferSize()` and removes the same method in context of `WebGPURenderer`.
