### PR TITLE
Shaders: Renamed linearToRelativeLuminance() function

### DIFF
--- a/examples/jsm/shaders/LuminosityShader.js
+++ b/examples/jsm/shaders/LuminosityShader.js
@@ -35,7 +35,7 @@ const LuminosityShader = {
 
 			vec4 texel = texture2D( tDiffuse, vUv );
 
-			float l = linearToRelativeLuminance( texel.rgb );
+			float l = luminance( texel.rgb );
 
 			gl_FragColor = vec4( l, l, l, texel.w );
 

--- a/examples/jsm/shaders/ToneMapShader.js
+++ b/examples/jsm/shaders/ToneMapShader.js
@@ -51,7 +51,7 @@ const ToneMapShader = {
 			#endif
 
 			// Calculate the luminance of the current pixel
-			float fLumPixel = linearToRelativeLuminance( vColor );
+			float fLumPixel = luminance( vColor );
 
 			// Apply the modified operator (Eq. 4)
 			float fLumScaled = (fLumPixel * middleGrey) / max( minLuminance, fLumAvg );

--- a/src/renderers/shaders/ShaderChunk/common.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/common.glsl.js
@@ -17,7 +17,7 @@ vec3 pow2( const in vec3 x ) { return x*x; }
 float pow3( const in float x ) { return x*x*x; }
 float pow4( const in float x ) { float x2 = x*x; return x2*x2; }
 float max3( const in vec3 v ) { return max( max( v.x, v.y ), v.z ); }
-float average( const in vec3 color ) { return dot( color, vec3( 0.3333 ) ); }
+float average( const in vec3 v ) { return dot( v, vec3( 0.3333333 ) ); }
 
 // expects values in the range of [0,1]x[0,1], returns values in the [0,1] range.
 // do not collapse into a single function per: http://byteblacksmith.com/improvements-to-the-canonical-one-liner-glsl-rand-for-opengl-es-2-0/
@@ -88,12 +88,13 @@ mat3 transposeMat3( const in mat3 m ) {
 
 }
 
-// https://en.wikipedia.org/wiki/Relative_luminance
-float linearToRelativeLuminance( const in vec3 color ) {
+float luminance( const in vec3 rgb ) {
 
-	vec3 weights = vec3( 0.2126, 0.7152, 0.0722 );
+	// assumes rgb is in linear color space with sRGB primaries and D65 white point
 
-	return dot( weights, color.rgb );
+	const vec3 weights = vec3( 0.2126729, 0.7151522, 0.0721750 );
+
+	return dot( weights, rgb );
 
 }
 


### PR DESCRIPTION
This PR renames the `linearToRelativeLuminance()` function.

We are not computing "relative luminance" here since we are are not normalizing the input. The input is unbounded.

Furthermore, the formula is correct only if the RGB-valued input is in a linear color space with sRGB primaries and D65 white point. If the working color space were to change, then different weights would be required.

Consequently, I renamed the method to `luminance()`, and added an inline comment explaining the assumptions.

Alternatively, the function could be named something more precise, such as `linearSRGBtoLuminance()`, but personally, I think that is overkill for now. My expectation is the three.js working color space is not going to change any time soon -- certainly not until wide-gamut monitors are commonplace -- so the simpler method name seems acceptable to me.

Other opinions welcome.

/ping @donmccurdy 
