### PR TITLE
Note the plane ordering when using Frustum.setFromProjectionMatrix

### DIFF
--- a/docs/api/en/math/Frustum.html
+++ b/docs/api/en/math/Frustum.html
@@ -96,7 +96,7 @@
 		<h3>[method:this setFromProjectionMatrix]( [param:Matrix4 matrix] )</h3>
 		<p>
 		[page:Matrix4 matrix] - Projection [page:Matrix4] used to set the [page:.planes planes]<br /><br />
-		Sets the frustum planes from the projection matrix.
+		Sets the frustum planes from the projection matrix. The plane order will be: right, left, bottom, top, far, near.
 		</p>
 
 


### PR DESCRIPTION
**Description**

Assuming my maths are correct, calling `Frustum.setFromProjectionMatrix()` will always set the plane order to `right, left, bottom, top, far, near` respective to the `planes` array. This information is useful to anyone who wants to pick a certain plane.