### PR TITLE
USDZExporter: Fix import.

### DIFF
--- a/examples/jsm/exporters/USDZExporter.js
+++ b/examples/jsm/exporters/USDZExporter.js
@@ -1,3 +1,7 @@
+import {
+	DoubleSide
+} from 'three';
+
 import * as fflate from '../libs/fflate.module.js';
 
 class USDZExporter {
@@ -408,7 +412,7 @@ function buildMaterial( material, textures ) {
 	}
 
 
-	if ( material.side === THREE.DoubleSide ) {
+	if ( material.side === DoubleSide ) {
 
 		console.warn( 'THREE.USDZExporter: USDZ does not support double sided materials', material );
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/24214#issuecomment-1188371289

**Description**

This PR properly imports `DoubleSide` from `three` instead of using the `THREE` namespace.
