### PR TITLE
Reflector/Refractor: Change render target setups.

### DIFF
--- a/examples/jsm/objects/ReflectorForSSRPass.js
+++ b/examples/jsm/objects/ReflectorForSSRPass.js
@@ -11,7 +11,8 @@ import {
 	DepthTexture,
 	UnsignedShortType,
 	NearestFilter,
-	Plane
+	Plane,
+	HalfFloatType
 } from 'three';
 
 class ReflectorForSSRPass extends Mesh {
@@ -104,6 +105,7 @@ class ReflectorForSSRPass extends Mesh {
 
 		const parameters = {
 			depthTexture: useDepthTexture ? depthTexture : null,
+			type: HalfFloatType
 		};
 
 		const renderTarget = new WebGLRenderTarget( textureWidth, textureHeight, parameters );
@@ -197,10 +199,6 @@ class ReflectorForSSRPass extends Mesh {
 			textureMatrix.multiply( virtualCamera.projectionMatrix );
 			textureMatrix.multiply( virtualCamera.matrixWorldInverse );
 			textureMatrix.multiply( scope.matrixWorld );
-
-			// Render
-
-			renderTarget.texture.encoding = renderer.outputEncoding;
 
 			// scope.visible = false;
 


### PR DESCRIPTION
Fixed #24384.

**Description**

This PR improves HDR support for `Reflector`, `Refractor` and `ReflectorForSSRPass` and makes the internal render target and shader setups more consistent.

- The internal render targets are now of type half float, and in linear color space. They are not tone mapped.
- The fragment shaders of `Reflector`, `Refractor` and `ReflectorForSSRPass` now properly support color space conversion and tone mapping according to the renderer settings.

Since half float textures are supported on all WebGL 2 devices, it should be a safe default. Just want to highlight that there is a small performance loss when using FP16 instead of UINT8. Not all apps are going to require FP16 but I think it's still an appropriate default.