### PR TITLE
SVGLoader: properly handle missing y-value in translate transform

### DIFF
--- a/examples/jsm/loaders/SVGLoader.js
+++ b/examples/jsm/loaders/SVGLoader.js
@@ -1459,7 +1459,7 @@ class SVGLoader extends Loader {
 								if ( array.length >= 1 ) {
 
 									const tx = array[ 0 ];
-									let ty = tx;
+									let ty = 0;
 
 									if ( array.length >= 2 ) {
 


### PR DESCRIPTION
There’s a bug in SVG loader if an element uses `translate(x)` transform omitting the `y` value.

Here’s how an SVG renders in a browser:

![image](https://user-images.githubusercontent.com/146383/181513895-5177edb4-a1e1-4e00-b208-16d8c6258e6d.png)

The same in an app that uses SVGLoader (note the text offset):

![image](https://user-images.githubusercontent.com/146383/181514169-7e913c77-037f-487f-9dc7-7a9e209623b8.png)


After fix applied:

![image](https://user-images.githubusercontent.com/146383/181514043-e6cabc67-b722-4a1c-ac80-be8adb2a73bd.png)

## Root cause

The standard [says](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/transform#translate):

> If y is not provided, it is assumed to be 0.

But the current implementation sets it to be equal to `x` value which is incorrect.