### PR TITLE
LineSegments2 : Fix raytracing when the mesh has a transformation applied.

### DIFF
--- a/examples/jsm/lines/LineSegments2.js
+++ b/examples/jsm/lines/LineSegments2.js
@@ -51,10 +51,14 @@ function getWorldSpaceHalfWidth( camera, distance, resolution ) {
 
 function raycastWorldUnits( lineSegments, intersects ) {
 
+	const matrixWorld = lineSegments.matrixWorld;
+
 	for ( let i = 0, l = _instanceStart.count; i < l; i ++ ) {
 
 		_line.start.fromBufferAttribute( _instanceStart, i );
 		_line.end.fromBufferAttribute( _instanceEnd, i );
+
+		_line.applyMatrix4( matrixWorld );
 
 		const pointOnLine = new Vector3();
 		const point = new Vector3();


### PR DESCRIPTION
**Description**

The `LineSegments2` mesh has support for raytracing in "world units" mode. However, when checking for intersection with each line segment, the segments do not have the world matrix transformation applied. Therefore, the raytracing does not behave correctly if the mesh has any transformation applied to it. This PR fixes this by applying the world matrix to each line segment before checking for an intersection with the ray.

The behavior before and after can be reproduced by applying a transformation in the `Line2` ray tracing example (`/examples/#webgl_lines_fat_raycasting`). Here is an example patch that can be used:
```
diff --git a/examples/webgl_lines_fat_raycasting.html b/examples/webgl_lines_fat_raycasting.html
index f923378abd..3067935181 100644
--- a/examples/webgl_lines_fat_raycasting.html
+++ b/examples/webgl_lines_fat_raycasting.html
@@ -327,7 +327,8 @@
                                        'visualize threshold': matThresholdLine.visible,
                                        'width': matLine.linewidth,
                                        'alphaToCoverage': matLine.alphaToCoverage,
-                                       'threshold': raycaster.params.Line2.threshold
+                                       'threshold': raycaster.params.Line2.threshold,
+                                       'translation': raycaster.params.Line2.threshold
                                };

                                gui.add( param, 'line type', { 'LineGeometry': 0, 'LineSegmentsGeometry': 1 } ).onChange( function ( val ) {
@@ -371,6 +372,14 @@

                                } );

+                               gui.add( param, 'translation', 0, 10 ).onChange( function ( val ) {
+
+                                       segments.position.x = val;
+                                       segments.updateMatrix();
+                                       segments.updateMatrixWorld();
+
+                               } );
+
                        }

                </script>
```
