### PR TITLE
Examples: remove unused TWEEN animation from example

### DIFF
--- a/examples/css3d_periodictable.html
+++ b/examples/css3d_periodictable.html
@@ -408,11 +408,6 @@
 						.easing( TWEEN.Easing.Exponential.InOut )
 						.start();
 
-					new TWEEN.Tween( object.rotation )
-						.to( { x: target.rotation.x, y: target.rotation.y, z: target.rotation.z }, Math.random() * duration + duration )
-						.easing( TWEEN.Easing.Exponential.InOut )
-						.start();
-
 				}
 
 				new TWEEN.Tween( this )


### PR DESCRIPTION
Related issue: #XXXX

**Description**

A clear and concise description of what the problem was and how this pull request solves it.

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Example](https://example.com)*
