### PR TITLE
Remove duplicated text in installation page

### DIFF
--- a/docs/manual/ar/introduction/Installation.html
+++ b/docs/manual/ar/introduction/Installation.html
@@ -96,11 +96,6 @@
 		&lt;/script>
 		</code>
 
-		<p>
-			ليست كل المزايا يمكن الوصول لها عبر وحدة <em>build/three.module.js</em>. بعض المكونات الأخرى من المكتبة - مثل الضوابط (controls) وعناصر التحميل (loaders) وتأثيرات ما بعد المعالجة (post-processing effects) - يجب إستدعائهم من الملفات الثانوية [link:https://github.com/mrdoob/three.js/tree/dev/examples/jsm examples/jsm].
-		</p>
-
-
 		<h2>أمثلة</h2>
 
 		<p>

--- a/docs/manual/en/introduction/Installation.html
+++ b/docs/manual/en/introduction/Installation.html
@@ -88,9 +88,6 @@
 		</code>
 
 		<p>
-			Not all features are accessed through the <em>three</em> entrypoint. Other popular parts of the library — such as controls, loaders, and post-processing effects — must be imported from the [link:https://github.com/mrdoob/three.js/tree/dev/examples/jsm examples/jsm] subfolder. To learn more, see <em>Examples</em> below.
-		</p>
-		<p>
 			Since Import maps are not yet supported by all browsers, it is necessary to add the polyfill *es-module-shims.js*.
 		</p>
 

--- a/docs/manual/ja/introduction/Installation.html
+++ b/docs/manual/ja/introduction/Installation.html
@@ -80,11 +80,6 @@
 		&lt;/script>
 		</code>
 
-    <p>
-        すべての機能が <em>build/three.module.js</em> モジュールからアクセスできるわけではありません。コントロール、ローダー、エフェクトの前処理など、ライブラリの他の一般的な部分は、[link:https://github.com/mrdoob/three.js/tree/dev/examples/jsm examples/jsm] サブフォルダからインポートする必要があります。詳細については、以下の<em>Examples</em>を参照してください。
-    </p>
-
-
     <h2>Examples</h2>
 
     <p>

--- a/docs/manual/ko/introduction/Installation.html
+++ b/docs/manual/ko/introduction/Installation.html
@@ -88,12 +88,6 @@
 		&lt;/script>
 		</code>
 
-    <p>
-        모든 속성들이 <em>build/three.module.js</em> 모듈을 통해 접근하는 것은 아닙니다.  다른 자주 쓰이는 라이브러리들, controls, loaders, post-processing effects 같은 것들은
-        [link:https://github.com/mrdoob/three.js/tree/dev/examples/jsm examples/jsm] 의 하위폴더에서 불러와야 합니다. 더 자세한 내용을 알아보려면, 아래 <em>예제</em>를 참고하세요.
-    </p>
-
-
     <h2>예제</h2>
 
     <p>

--- a/docs/manual/zh/introduction/Installation.html
+++ b/docs/manual/zh/introduction/Installation.html
@@ -78,11 +78,6 @@
 		&lt;/script>
 		</code>
 
-		<p>
-			并非所有功能都可以通过 <em>build/three.module.js</em> 模块来直接访问。three.js 中其它较为流行的部分 —— 如控制器（control）、加载器（loader）以及后期处理效果（post-processing effect） —— 必须从 [link:https://github.com/mrdoob/three.js/tree/dev/examples/jsm examples/jsm] 子目录下导入。了解更多信息，请参阅下方的<em>示例</em>。
-		</p>
-
-
 		<h2>示例</h2>
 
 		<p>


### PR DESCRIPTION
Fixed #24404

**Description**

Removed duplicated text in the second paragraph in the Install from CDN or static hosting section on the Installation page for all translations.


