### PR TITLE
Add CustomToneMapping to the documentation 

### DIFF
--- a/docs/api/en/constants/Renderer.html
+++ b/docs/api/en/constants/Renderer.html
@@ -51,10 +51,12 @@
 		<p>
 		These define the WebGLRenderer's [page:WebGLRenderer.toneMapping toneMapping] property.
 		This is used to approximate the appearance of high dynamic range (HDR) on the
-		low dynamic range medium of a standard computer monitor or mobile device's screen.<br /><br />
-
+		low dynamic range medium of a standard computer monitor or mobile device's screen.
+		</p>
+		<p>
+		THREE.LinearToneMapping, THREE.ReinhardToneMapping, THREE.CineonToneMapping and THREE.ACESFilmicToneMapping are specific implementations of tonemapping.
+		THREE.CustomToneMapping expects an implementation be added as glsl fragment.   
 		See the [example:webgl_tonemapping WebGL / tonemapping] example.
-
 		</p>
 
 

--- a/docs/api/en/constants/Renderer.html
+++ b/docs/api/en/constants/Renderer.html
@@ -54,8 +54,8 @@
 		low dynamic range medium of a standard computer monitor or mobile device's screen.
 		</p>
 		<p>
-		THREE.LinearToneMapping, THREE.ReinhardToneMapping, THREE.CineonToneMapping and THREE.ACESFilmicToneMapping are specific implementations of tonemapping.
-		THREE.CustomToneMapping expects an implementation be added as glsl fragment.   
+		THREE.LinearToneMapping, THREE.ReinhardToneMapping, THREE.CineonToneMapping and THREE.ACESFilmicToneMapping are built-in implementations of tone mapping.
+		THREE.CustomToneMapping expects a custom implementation by modyfing GLSL code of the material's fragment shader.   
 		See the [example:webgl_tonemapping WebGL / tonemapping] example.
 		</p>
 

--- a/docs/api/en/constants/Renderer.html
+++ b/docs/api/en/constants/Renderer.html
@@ -46,6 +46,7 @@
 		THREE.ReinhardToneMapping
 		THREE.CineonToneMapping
 		THREE.ACESFilmicToneMapping
+		THREE.CustomToneMapping
 		</code>
 		<p>
 		These define the WebGLRenderer's [page:WebGLRenderer.toneMapping toneMapping] property.


### PR DESCRIPTION
Related issue: #24418

**Description**

This PR adds CustomToneMapping to the documentation and gives a bit of an explanation

