### PR TITLE
Add RGBA_BPTC_Format Constant to documentation

### DIFF
--- a/docs/api/en/constants/Textures.html
+++ b/docs/api/en/constants/Textures.html
@@ -271,8 +271,17 @@
 		THREE.RGBA_ASTC_12x12_Format
 		</code>
 		<p>
-		For use with a [page:CompressedTexture CompressedTexture]'s [page:Texture.format format]	property,
+		For use with a [page:CompressedTexture CompressedTexture]'s [page:Texture.format format] property,
 		these require support for the [link:https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_astc/ WEBGL_compressed_texture_astc] extension. <br /><br />
+		</p>
+
+		<h2>BPTC Compressed Texture Format</h2>
+		<code>
+		THREE.RGBA_BPTC_Format
+		</code>
+		<p>
+		For use with a [page:CompressedTexture CompressedTexture]'s [page:Texture.format format] property,
+		these require support for the [link:https://www.khronos.org/registry/webgl/extensions/EXT_texture_compression_bptc/ EXT_texture_compression_bptc] extension. <br /><br />
 		</p>
 
 		<h2>Internal Formats</h2>


### PR DESCRIPTION
Related issue: #24418

**Description**

This adds RGBA_BPTC_Format Constant to documentation

