### PR TITLE
Add Animation Blend modes constants to documentation

### DIFF
--- a/docs/api/en/constants/Animation.html
+++ b/docs/api/en/constants/Animation.html
@@ -31,6 +31,12 @@ THREE.ZeroSlopeEnding
 THREE.WrapAroundEnding
     </code>
 
+	<h2>Animation Blend Modes</h2>
+    <code>
+THREE.NormalAnimationBlendMode
+THREE.AdditiveAnimationBlendMode
+    </code>
+
 		<h2>Source</h2>
 
 		<p>


### PR DESCRIPTION
Related issue: #24418

**Description**

This PR adds Animation Blend modes constants to documentation.
