### PR TITLE
Add triangle draw Modes to documentation

### DIFF
--- a/docs/api/en/constants/Renderer.html
+++ b/docs/api/en/constants/Renderer.html
@@ -56,6 +56,18 @@
 
 		</p>
 
+		<h2>Triangle draw Modes</h2>
+		<code>
+		THREE.TrianglesDrawMode
+		THREE.TriangleStripDrawMode
+		THREE.TriangleFanDrawMode
+		</code>
+		<p>
+		[page:constant TrianglesDrawMode] is the mode to draw a series of separate triangles. <th></th><br />
+		[page:constant TriangleStripDrawMode] is the mode to draw a series of connected triangles in strip fashion. Every triangle (except the first)starts with the 2 last vertice of the previous triangle.<br />
+		[page:constant TriangleFanDrawMode] is the mode to draw a series of connected triangles sharing the first vertex in a fan-like fashion.<br />
+		</p>
+
 
 		<h2>Source</h2>
 


### PR DESCRIPTION
Related issue: #24418

**Description**

This adds the triangle draw Modes to documentation.
