### PR TITLE
Add normal map type constants to documentation

### DIFF
--- a/docs/api/en/constants/Materials.html
+++ b/docs/api/en/constants/Materials.html
@@ -126,6 +126,18 @@
 		[page:Materials InvertStencilOp] will perform a bitwise inversion of the current stencil value.<br />
 		</p>
 
+		<h2>Normal map type</h2>
+		<code>
+		THREE.TangentSpaceNormalMap
+		THREE.ObjectSpaceNormalMap
+		</code>
+		<p>
+		Defines the type of the normal map. 
+		For TangentSpaceNormalMap, the information is relative to the underlying surface. 
+		For ObjectSpaceNormalMap, the information is relative to the object orientation.
+		Default is [page:Constant TangentSpaceNormalMap].
+		</p>
+
 		<h2>Source</h2>
 
 		<p>


### PR DESCRIPTION
Related issue: #24418

**Description**

This PR adds normal map type constants to documentation and some more information.
