### PR TITLE
Add GLSL Version to documentation

### DIFF
--- a/docs/api/en/constants/Renderer.html
+++ b/docs/api/en/constants/Renderer.html
@@ -9,6 +9,12 @@
 	<body>
 		<h1>WebGLRenderer Constants</h1>
 
+		<h2>GLSL Version</h2>
+		<code>
+		THREE.GLSL1
+		THREE.GLSL3
+		</code>
+
 		<h2>Cull Face Modes</h2>
 		<code>
 		THREE.CullFaceNone


### PR DESCRIPTION
Related issue: #24418

**Description**

This PR adds the GLSL versions to the documentation.

