### PR TITLE
Animation StartAt should keep in account the clampwhenfinished property

### DIFF
--- a/src/animation/AnimationAction.js
+++ b/src/animation/AnimationAction.js
@@ -340,14 +340,15 @@ class AnimationAction {
 			const timeRunning = ( time - startTime ) * timeDirection;
 			if ( timeRunning < 0 || timeDirection === 0 ) {
 
-				return; // yet to come / don't decide when delta = 0
+				deltaTime = 0;
+
+			} else {
+
+
+				this._startTime = null; // unschedule
+				deltaTime = timeDirection * timeRunning;
 
 			}
-
-			// start
-
-			this._startTime = null; // unschedule
-			deltaTime = timeDirection * timeRunning;
 
 		}
 

--- a/test/unit/src/animation/AnimationAction.tests.js
+++ b/test/unit/src/animation/AnimationAction.tests.js
@@ -444,6 +444,53 @@ export default QUnit.module( 'Animation', () => {
 
 		} );
 
+		QUnit.test( 'StartAt when already executed once', ( assert ) => {
+			var root = new Object3D();
+			var mixer = new AnimationMixer( root );
+			var track = new NumberKeyframeTrack( '.rotation[x]', [ 0, 750 ], [ 0, 270 ] );
+			var clip = new AnimationClip( 'clip1', 750, [ track ] );
+		
+			var animationAction = mixer.clipAction( clip );
+			animationAction.setLoop( LoopOnce );
+			animationAction.clampWhenFinished = true;
+			animationAction.play();
+			mixer.addEventListener('finished', () => {
+				console.log(mixer.time);
+				animationAction.timeScale*=-1;
+				animationAction.paused=false;
+				animationAction.startAt(mixer.time+2000).play();
+
+			});
+
+			mixer.update( 250 );
+			assert.equal( root.rotation.x, 90, 'first' );
+			mixer.update( 250 );
+			assert.equal( root.rotation.x, 180, 'first' );
+			mixer.update( 250 );
+			assert.equal( root.rotation.x, 270, 'first' );
+			//first loop done
+			mixer.update( 2000 );
+			// startAt Done
+			assert.equal( root.rotation.x, 270, 'third' );
+			mixer.update( 250 );
+			assert.equal( root.rotation.x, 180, 'fourth' );
+			mixer.update( 250 );
+			assert.equal( root.rotation.x, 90, 'fourth' );
+			mixer.update( 250 );
+			assert.equal( root.rotation.x, 0, 'sixth' );
+			mixer.update( 1 );
+			assert.equal( root.rotation.x, 0, 'seventh' );
+			mixer.update( 1000 );
+			assert.equal( root.rotation.x, 0, 'seventh' );
+			mixer.update( 1000 );
+			assert.equal( root.rotation.x, 0, 'seventh' );
+			mixer.update( 250 );
+			assert.equal( root.rotation.x, 90, 'seventh' );
+			mixer.update( 250 );
+			assert.equal( root.rotation.x, 180, 'seventh' );
+			//console.log(mixer.time);
+		});
+
 	} );
 
 } );

--- a/test/unit/src/animation/AnimationAction.tests.js
+++ b/test/unit/src/animation/AnimationAction.tests.js
@@ -455,7 +455,6 @@ export default QUnit.module( 'Animation', () => {
 			animationAction.clampWhenFinished = true;
 			animationAction.play();
 			mixer.addEventListener('finished', () => {
-				console.log(mixer.time);
 				animationAction.timeScale*=-1;
 				animationAction.paused=false;
 				animationAction.startAt(mixer.time+2000).play();


### PR DESCRIPTION
Related issue: #22402

**Description**

When an animation is started again at a future date. It should keep into account the time the animation already has run and not revert to the standard pose.
I've also added a small unit test to make sure that everything keeps working.