### PR TITLE
WebGLRenderer: Move transmission properties to Material struct

### DIFF
--- a/src/renderers/shaders/ShaderChunk/lights_physical_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_physical_fragment.glsl.js
@@ -11,6 +11,8 @@ material.roughness = min( material.roughness, 1.0 );
 
 #ifdef IOR
 
+	material.ior = ior;
+
 	#ifdef SPECULAR
 
 		float specularIntensityFactor = specularIntensity;
@@ -38,7 +40,7 @@ material.roughness = min( material.roughness, 1.0 );
 
 	#endif
 
-	material.specularColor = mix( min( pow2( ( ior - 1.0 ) / ( ior + 1.0 ) ) * specularColorFactor, vec3( 1.0 ) ) * specularIntensityFactor, diffuseColor.rgb, metalnessFactor );
+	material.specularColor = mix( min( pow2( ( material.ior - 1.0 ) / ( material.ior + 1.0 ) ) * specularColorFactor, vec3( 1.0 ) ) * specularIntensityFactor, diffuseColor.rgb, metalnessFactor );
 
 #else
 

--- a/src/renderers/shaders/ShaderChunk/lights_physical_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_physical_pars_fragment.glsl.js
@@ -26,6 +26,18 @@ struct PhysicalMaterial {
 		float sheenRoughness;
 	#endif
 
+	#ifdef IOR
+		float ior;
+	#endif
+
+	#ifdef USE_TRANSMISSION
+		float transmission;
+		float transmissionAlpha;
+		float thickness;
+		float attenuationDistance;
+		vec3 attenuationColor;
+	#endif
+
 };
 
 // temporary
@@ -35,7 +47,7 @@ vec3 sheenSpecular = vec3( 0.0 );
 // This is a curve-fit approxmation to the "Charlie sheen" BRDF integrated over the hemisphere from 
 // Estevez and Kulla 2017, "Production Friendly Microfacet Sheen BRDF". The analysis can be found
 // in the Sheen section of https://drive.google.com/file/d/1T0D1VSyR4AllqIJTQAraEIzjlb5h4FKH/view?usp=sharing
-float IBLSheenBRDF( const in vec3 normal, const in vec3 viewDir, const in float roughness) {
+float IBLSheenBRDF( const in vec3 normal, const in vec3 viewDir, const in float roughness ) {
 
 	float dotNV = saturate( dot( normal, viewDir ) );
 

--- a/src/renderers/shaders/ShaderChunk/output_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/output_fragment.glsl.js
@@ -5,7 +5,7 @@ diffuseColor.a = 1.0;
 
 // https://github.com/mrdoob/three.js/pull/22425
 #ifdef USE_TRANSMISSION
-diffuseColor.a *= transmissionAlpha + 0.1;
+diffuseColor.a *= material.transmissionAlpha + 0.1;
 #endif
 
 gl_FragColor = vec4( outgoingLight, diffuseColor.a );

--- a/src/renderers/shaders/ShaderChunk/transmission_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/transmission_fragment.glsl.js
@@ -1,19 +1,21 @@
 export default /* glsl */`
 #ifdef USE_TRANSMISSION
 
-	float transmissionAlpha = 1.0;
-	float transmissionFactor = transmission;
-	float thicknessFactor = thickness;
+	material.transmissionAlpha = 1.0;
+	material.transmission = transmission;
+	material.thickness = thickness;
+	material.attenuationDistance = attenuationDistance;
+	material.attenuationColor = attenuationColor;
 
 	#ifdef USE_TRANSMISSIONMAP
 
-		transmissionFactor *= texture2D( transmissionMap, vUv ).r;
+		material.transmission *= texture2D( transmissionMap, vUv ).r;
 
 	#endif
 
 	#ifdef USE_THICKNESSMAP
 
-		thicknessFactor *= texture2D( thicknessMap, vUv ).g;
+		material.thickness *= texture2D( thicknessMap, vUv ).g;
 
 	#endif
 
@@ -23,10 +25,12 @@ export default /* glsl */`
 
 	vec4 transmission = getIBLVolumeRefraction(
 		n, v, roughnessFactor, material.diffuseColor, material.specularColor, material.specularF90,
-		pos, modelMatrix, viewMatrix, projectionMatrix, ior, thicknessFactor,
-		attenuationColor, attenuationDistance );
+		pos, modelMatrix, viewMatrix, projectionMatrix, material.ior, material.thickness,
+		material.attenuationColor, material.attenuationDistance );
 
-	totalDiffuse = mix( totalDiffuse, transmission.rgb, transmissionFactor );
-	transmissionAlpha = mix( transmissionAlpha, transmission.a, transmissionFactor );
+	material.transmissionAlpha = mix( material.transmissionAlpha, transmission.a, material.transmission );
+
+	totalDiffuse = mix( totalDiffuse, transmission.rgb, material.transmission );
+
 #endif
 `;

--- a/src/renderers/shaders/ShaderChunk/transmission_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/transmission_fragment.glsl.js
@@ -1,8 +1,8 @@
 export default /* glsl */`
 #ifdef USE_TRANSMISSION
 
-	material.transmissionAlpha = 1.0;
 	material.transmission = transmission;
+	material.transmissionAlpha = 1.0;
 	material.thickness = thickness;
 	material.attenuationDistance = attenuationDistance;
 	material.attenuationColor = attenuationColor;


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/24385

**Description**

I could just put some more `*Factor` variables but I think this implementation is more organized, it follows similarly to the implementation of `sheen` and `clearcoat`.

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Google via Igalia](https://igalia.com)*
