### PR TITLE
FBXLoader: Handle invalid material indices.

### DIFF
--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -1897,6 +1897,13 @@ class GeometryParser {
 
 				materialIndex = getData( polygonVertexIndex, polygonIndex, vertexIndex, geoInfo.material )[ 0 ];
 
+				if ( materialIndex < 0 ) {
+
+					console.warn( 'THREE.FBXLoader: Invalid material index:', materialIndex );
+					materialIndex = 0;
+
+				}
+
 			}
 
 			if ( geoInfo.uv ) {


### PR DESCRIPTION
Fixed #24357.

**Description**

It seems there are exporters like the one from Cinema4D which might export FBX assets with negative material indices. I have found no official documentation about valid values of the FBX field `LayerElementMaterial.Materials.a`. However, negative values are not supported in `three.js`.

The loader now reports a warning when negative material indices are detected and uses `0` instead. 

Just want to note that an asset with missing material definitions is a model authoring error and should be fixed in a DCC tool.