### PR TITLE
OutlinePass - Support InstancedMeshes

### DIFF
--- a/examples/jsm/postprocessing/OutlinePass.js
+++ b/examples/jsm/postprocessing/OutlinePass.js
@@ -444,9 +444,9 @@ class OutlinePass extends Pass {
 					#include <morphtarget_vertex>
 					#include <skinning_vertex>
 					#include <project_vertex>
+					#include <worldpos_vertex>
 
 					vPosition = mvPosition;
-					vec4 worldPosition = modelMatrix * vec4( transformed, 1.0 );
 					projTexCoord = textureMatrix * worldPosition;
 
 				}`,


### PR DESCRIPTION
**Description**

The current mask material used in the outline pass does not support instanced meshes as it currently does not consider the instanced matrix, when computing its projected texture coordinates, for use when sampling the depth buffer.  This small change utilises the worldpos_vertex chunk in order to do this. 