### PR TITLE
Nodes: .getCacheKey()

### DIFF
--- a/examples/jsm/nodes/core/Node.js
+++ b/examples/jsm/nodes/core/Node.js
@@ -1,5 +1,5 @@
 import { NodeUpdateType } from './constants.js';
-import { getNodesKeys } from './NodeUtils.js';
+import { getNodesKeys, getCacheKey } from './NodeUtils.js';
 import { MathUtils } from 'three';
 
 let _nodeId = 0;
@@ -55,6 +55,12 @@ class Node {
 		}
 
 		return children;
+
+	}
+
+	getCacheKey() {
+
+		return getCacheKey( this );
 
 	}
 

--- a/examples/jsm/nodes/core/NodeUtils.js
+++ b/examples/jsm/nodes/core/NodeUtils.js
@@ -4,15 +4,13 @@ export const getCacheKey = ( object ) => {
 
 	let cacheKey = '{';
 
-	if ( object.isNode ) {
+	if ( object.isNode === true ) {
 
 		cacheKey += `uuid:"${ object.uuid }",`;
 
 	}
 
-	const nodeKeys = getNodesKeys( object );
-
-	for ( const property of nodeKeys ) {
+	for ( const property of getNodesKeys( object ) ) {
 
 		cacheKey += `${ property }:${ object[ property ].getCacheKey() },`;
 

--- a/examples/jsm/nodes/core/NodeUtils.js
+++ b/examples/jsm/nodes/core/NodeUtils.js
@@ -1,5 +1,29 @@
 import { Color, Matrix3, Matrix4, Vector2, Vector3, Vector4 } from 'three';
 
+export const getCacheKey = ( object ) => {
+
+	let cacheKey = '{';
+
+	if ( object.isNode ) {
+
+		cacheKey += `uuid:"${ object.uuid }",`;
+
+	}
+
+	const nodeKeys = getNodesKeys( object );
+
+	for ( const property of nodeKeys ) {
+
+		cacheKey += `${ property }:${ object[ property ].getCacheKey() },`;
+
+	}
+
+	cacheKey += '}';
+
+	return cacheKey;
+
+};
+
 export const getNodesKeys = ( object ) => {
 
 	const props = [];

--- a/examples/jsm/nodes/materials/NodeMaterial.js
+++ b/examples/jsm/nodes/materials/NodeMaterial.js
@@ -1,5 +1,5 @@
 import { Material, ShaderMaterial } from 'three';
-import { getNodesKeys } from '../core/NodeUtils.js';
+import { getNodesKeys, getCacheKey } from '../core/NodeUtils.js';
 import ExpressionNode from '../core/ExpressionNode.js';
 import {
 	float, vec3, vec4,
@@ -37,7 +37,7 @@ class NodeMaterial extends ShaderMaterial {
 
 	customProgramCacheKey() {
 
-		return this.uuid + '-' + this.version;
+		return getCacheKey( this );
 
 	}
 


### PR DESCRIPTION
**Description**

Used mainly in `.customProgramCacheKey()`. `NodeMaterial` programs can be shared on `WebGLRenderer`.

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Google via Igalia](https://igalia.com)*
