### PR TITLE
Docs: Remove dead links.

### DIFF
--- a/docs/manual/ar/introduction/Useful-links.html
+++ b/docs/manual/ar/introduction/Useful-links.html
@@ -53,9 +53,6 @@
 		 <li>
 			[Link:https://aerotwist.com/tutorials/ Aerotwist] tutorials by [link:https://github.com/paullewis/ Paul Lewis].
 		 </li>
-			 <li>
-			 [link:http://learningthreejs.com/ Learning Three.js] – مدونة تحتوي على مقالات مخصصة لتدريس three.js
-		 </li>
 		 <li>
 			 [link:https://discourse.threejs.org/t/three-js-bookshelf/2468 Three.js Bookshelf] - هل تبحث عن مزيد من الموارد حول three.js أو رسومات الكمبيوتر بشكل عام؟ تحقق من اختيار الأدبيات التي أوصى بها مجتمع المكتبة.
 		 </li>

--- a/docs/manual/en/introduction/Useful-links.html
+++ b/docs/manual/en/introduction/Useful-links.html
@@ -61,9 +61,6 @@
 		 <li>
 			[Link:https://aerotwist.com/tutorials/ Aerotwist] tutorials by [link:https://github.com/paullewis/ Paul Lewis].
 		 </li>
-			 <li>
-			 [link:http://learningthreejs.com/ Learning Three.js] – a blog with articles dedicated to teaching three.js
-		 </li>
 		 <li>
 			 [link:https://discourse.threejs.org/t/three-js-bookshelf/2468 Three.js Bookshelf] - Looking for more resources about three.js or computer graphics in general?
 			 Check out the selection of literature recommended by the community.

--- a/docs/manual/ja/introduction/Useful-links.html
+++ b/docs/manual/ja/introduction/Useful-links.html
@@ -56,9 +56,6 @@
 		 <li>
 			[Link:https://aerotwist.com/tutorials/ Aerotwist] tutorials by [link:https://github.com/paullewis/ Paul Lewis].
 		 </li>
-			 <li>
-			 [link:http://learningthreejs.com/ Learning Three.js] – a blog with articles dedicated to teaching three.js
-		 </li>
 		 <li>
 			 [link:https://discourse.threejs.org/t/three-js-bookshelf/2468 Three.js Bookshelf] - Looking for more resources about three.js or computer graphics in general?
 			 Check out the selection of literature recommended by the community.

--- a/docs/manual/ko/introduction/Useful-links.html
+++ b/docs/manual/ko/introduction/Useful-links.html
@@ -57,9 +57,6 @@
 		 <li>
 			[Link:https://aerotwist.com/tutorials/ Aerotwist] tutorials by [link:https://github.com/paullewis/ Paul Lewis].
 		 </li>
-			 <li>
-			 [link:http://learningthreejs.com/ Learning Three.js] – a blog with articles dedicated to teaching three.js
-		 </li>
 		 <li>
 			 [link:https://discourse.threejs.org/t/three-js-bookshelf/2468 Three.js Bookshelf] - Looking for more resources about three.js or computer graphics in general?
 			 Check out the selection of literature recommended by the community.

--- a/docs/manual/zh/introduction/Useful-links.html
+++ b/docs/manual/zh/introduction/Useful-links.html
@@ -60,9 +60,6 @@
 		 <li>
 			[Link:https://aerotwist.com/tutorials/ Aerotwist] tutorials by [link:https://github.com/paullewis/ Paul Lewis].
 		 </li>
-			 <li>
-			 [link:http://learningthreejs.com/ Learning Three.js] – a blog with articles dedicated to teaching three.js
-		 </li>
 		 <li>
 			 [link:https://discourse.threejs.org/t/three-js-bookshelf/2468 Three.js Bookshelf] - Looking for more resources about three.js or computer graphics in general?
 			 Check out the selection of literature recommended by the community.


### PR DESCRIPTION
Fixed #24444.

**Description**

Removes dead links in the `Useful links` pages.
