### PR TITLE
Docs: Improve Materials Constant page.

### DIFF
--- a/docs/api/en/constants/Materials.html
+++ b/docs/api/en/constants/Materials.html
@@ -138,6 +138,12 @@
 		Default is [page:Constant TangentSpaceNormalMap].
 		</p>
 
+		<h2>GLSL Version</h2>
+		<code>
+		THREE.GLSL1
+		THREE.GLSL3
+		</code>
+
 		<h2>Source</h2>
 
 		<p>

--- a/docs/api/ko/constants/Materials.html
+++ b/docs/api/ko/constants/Materials.html
@@ -128,6 +128,12 @@
 		[page:Materials InvertStencilOp]는 현재 스텐실 값의 비트값 반전을 수행합니다.<br />
 		</p>
 
+		<h2>GLSL Version</h2>
+		<code>
+		THREE.GLSL1
+		THREE.GLSL3
+		</code>
+
 		<h2>소스 코드</h2>
 
 		<p>

--- a/docs/api/zh/constants/Materials.html
+++ b/docs/api/zh/constants/Materials.html
@@ -125,6 +125,12 @@
 		[page:Materials InvertStencilOp] 将当前模板值按位反转.<br />
 		</p>
 
+		<h2>GLSL Version</h2>
+		<code>
+		THREE.GLSL1
+		THREE.GLSL3
+		</code>
+
 		<h2>源代码</h2>
 
 		<p>


### PR DESCRIPTION
Related issue: #24432

**Description**

Adds the missing GLSL version constants to the documentation.
