### PR TITLE
MeshLambertMaterial: convert to per-fragment shading

### DIFF
--- a/src/materials/MeshLambertMaterial.js
+++ b/src/materials/MeshLambertMaterial.js
@@ -1,5 +1,6 @@
+import { MultiplyOperation, TangentSpaceNormalMap } from '../constants.js';
 import { Material } from './Material.js';
-import { MultiplyOperation } from '../constants.js';
+import { Vector2 } from '../math/Vector2.js';
 import { Color } from '../math/Color.js';
 
 class MeshLambertMaterial extends Material {
@@ -26,6 +27,17 @@ class MeshLambertMaterial extends Material {
 		this.emissiveIntensity = 1.0;
 		this.emissiveMap = null;
 
+		this.bumpMap = null;
+		this.bumpScale = 1;
+
+		this.normalMap = null;
+		this.normalMapType = TangentSpaceNormalMap;
+		this.normalScale = new Vector2( 1, 1 );
+
+		this.displacementMap = null;
+		this.displacementScale = 1;
+		this.displacementBias = 0;
+
 		this.specularMap = null;
 
 		this.alphaMap = null;
@@ -39,6 +51,8 @@ class MeshLambertMaterial extends Material {
 		this.wireframeLinewidth = 1;
 		this.wireframeLinecap = 'round';
 		this.wireframeLinejoin = 'round';
+
+		this.flatShading = false;
 
 		this.fog = true;
 
@@ -64,6 +78,17 @@ class MeshLambertMaterial extends Material {
 		this.emissiveMap = source.emissiveMap;
 		this.emissiveIntensity = source.emissiveIntensity;
 
+		this.bumpMap = source.bumpMap;
+		this.bumpScale = source.bumpScale;
+
+		this.normalMap = source.normalMap;
+		this.normalMapType = source.normalMapType;
+		this.normalScale.copy( source.normalScale );
+
+		this.displacementMap = source.displacementMap;
+		this.displacementScale = source.displacementScale;
+		this.displacementBias = source.displacementBias;
+
 		this.specularMap = source.specularMap;
 
 		this.alphaMap = source.alphaMap;
@@ -77,6 +102,8 @@ class MeshLambertMaterial extends Material {
 		this.wireframeLinewidth = source.wireframeLinewidth;
 		this.wireframeLinecap = source.wireframeLinecap;
 		this.wireframeLinejoin = source.wireframeLinejoin;
+
+		this.flatShading = source.flatShading;
 
 		this.fog = source.fog;
 

--- a/src/renderers/shaders/ShaderChunk.js
+++ b/src/renderers/shaders/ShaderChunk.js
@@ -38,7 +38,8 @@ import fog_pars_fragment from './ShaderChunk/fog_pars_fragment.glsl.js';
 import gradientmap_pars_fragment from './ShaderChunk/gradientmap_pars_fragment.glsl.js';
 import lightmap_fragment from './ShaderChunk/lightmap_fragment.glsl.js';
 import lightmap_pars_fragment from './ShaderChunk/lightmap_pars_fragment.glsl.js';
-import lights_lambert_vertex from './ShaderChunk/lights_lambert_vertex.glsl.js';
+import lights_lambert_fragment from './ShaderChunk/lights_lambert_fragment.glsl.js';
+import lights_lambert_pars_fragment from './ShaderChunk/lights_lambert_pars_fragment.glsl.js';
 import lights_pars_begin from './ShaderChunk/lights_pars_begin.glsl.js';
 import envmap_physical_pars_fragment from './ShaderChunk/envmap_physical_pars_fragment.glsl.js';
 import lights_toon_fragment from './ShaderChunk/lights_toon_fragment.glsl.js';
@@ -163,7 +164,8 @@ export const ShaderChunk = {
 	gradientmap_pars_fragment: gradientmap_pars_fragment,
 	lightmap_fragment: lightmap_fragment,
 	lightmap_pars_fragment: lightmap_pars_fragment,
-	lights_lambert_vertex: lights_lambert_vertex,
+	lights_lambert_fragment: lights_lambert_fragment,
+	lights_lambert_pars_fragment: lights_lambert_pars_fragment,
 	lights_pars_begin: lights_pars_begin,
 	lights_toon_fragment: lights_toon_fragment,
 	lights_toon_pars_fragment: lights_toon_pars_fragment,

--- a/src/renderers/shaders/ShaderChunk/envmap_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/envmap_pars_fragment.glsl.js
@@ -3,7 +3,7 @@ export default /* glsl */`
 
 	uniform float reflectivity;
 
-	#if defined( USE_BUMPMAP ) || defined( USE_NORMALMAP ) || defined( PHONG )
+	#if defined( USE_BUMPMAP ) || defined( USE_NORMALMAP ) || defined( PHONG ) || defined( LAMBERT )
 
 		#define ENV_WORLDPOS
 

--- a/src/renderers/shaders/ShaderChunk/envmap_pars_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/envmap_pars_vertex.glsl.js
@@ -1,7 +1,7 @@
 export default /* glsl */`
 #ifdef USE_ENVMAP
 
-	#if defined( USE_BUMPMAP ) || defined( USE_NORMALMAP ) ||defined( PHONG )
+	#if defined( USE_BUMPMAP ) || defined( USE_NORMALMAP ) || defined( PHONG ) || defined( LAMBERT )
 
 		#define ENV_WORLDPOS
 

--- a/src/renderers/shaders/ShaderChunk/lights_lambert_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_lambert_fragment.glsl.js
@@ -1,0 +1,5 @@
+export default /* glsl */`
+LambertMaterial material;
+material.diffuseColor = diffuseColor.rgb;
+material.specularStrength = specularStrength;
+`;

--- a/src/renderers/shaders/ShaderChunk/lights_lambert_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_lambert_pars_fragment.glsl.js
@@ -1,0 +1,30 @@
+export default /* glsl */`
+varying vec3 vViewPosition;
+
+struct LambertMaterial {
+
+	vec3 diffuseColor;
+	float specularStrength;
+
+};
+
+void RE_Direct_Lambert( const in IncidentLight directLight, const in GeometricContext geometry, const in LambertMaterial material, inout ReflectedLight reflectedLight ) {
+
+	float dotNL = saturate( dot( geometry.normal, directLight.direction ) );
+	vec3 irradiance = dotNL * directLight.color;
+
+	reflectedLight.directDiffuse += irradiance * BRDF_Lambert( material.diffuseColor );
+
+}
+
+void RE_IndirectDiffuse_Lambert( const in vec3 irradiance, const in GeometricContext geometry, const in LambertMaterial material, inout ReflectedLight reflectedLight ) {
+
+	reflectedLight.indirectDiffuse += irradiance * BRDF_Lambert( material.diffuseColor );
+
+}
+
+#define RE_Direct				RE_Direct_Lambert
+#define RE_IndirectDiffuse		RE_IndirectDiffuse_Lambert
+
+#define Material_LightProbeLOD( material )	(0)
+`;

--- a/src/renderers/shaders/ShaderLib.js
+++ b/src/renderers/shaders/ShaderLib.js
@@ -33,6 +33,9 @@ const ShaderLib = {
 			UniformsLib.aomap,
 			UniformsLib.lightmap,
 			UniformsLib.emissivemap,
+			UniformsLib.bumpmap,
+			UniformsLib.normalmap,
+			UniformsLib.displacementmap,
 			UniformsLib.fog,
 			UniformsLib.lights,
 			{

--- a/src/renderers/shaders/ShaderLib/meshlambert.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshlambert.glsl.js
@@ -1,22 +1,16 @@
 export const vertex = /* glsl */`
 #define LAMBERT
 
-varying vec3 vLightFront;
-varying vec3 vIndirectFront;
-
-#ifdef DOUBLE_SIDED
-	varying vec3 vLightBack;
-	varying vec3 vIndirectBack;
-#endif
+varying vec3 vViewPosition;
 
 #include <common>
 #include <uv_pars_vertex>
 #include <uv2_pars_vertex>
+#include <displacementmap_pars_vertex>
 #include <envmap_pars_vertex>
-#include <bsdfs>
-#include <lights_pars_begin>
 #include <color_pars_vertex>
 #include <fog_pars_vertex>
+#include <normal_pars_vertex>
 #include <morphtarget_pars_vertex>
 #include <skinning_pars_vertex>
 #include <shadowmap_pars_vertex>
@@ -35,35 +29,32 @@ void main() {
 	#include <skinbase_vertex>
 	#include <skinnormal_vertex>
 	#include <defaultnormal_vertex>
+	#include <normal_vertex>
 
 	#include <begin_vertex>
 	#include <morphtarget_vertex>
 	#include <skinning_vertex>
+	#include <displacementmap_vertex>
 	#include <project_vertex>
 	#include <logdepthbuf_vertex>
 	#include <clipping_planes_vertex>
 
+	vViewPosition = - mvPosition.xyz;
+
 	#include <worldpos_vertex>
 	#include <envmap_vertex>
-	#include <lights_lambert_vertex>
 	#include <shadowmap_vertex>
 	#include <fog_vertex>
+
 }
 `;
 
 export const fragment = /* glsl */`
+#define LAMBERT
+
 uniform vec3 diffuse;
 uniform vec3 emissive;
 uniform float opacity;
-
-varying vec3 vLightFront;
-varying vec3 vIndirectFront;
-
-#ifdef DOUBLE_SIDED
-	varying vec3 vLightBack;
-	varying vec3 vIndirectBack;
-#endif
-
 
 #include <common>
 #include <packing>
@@ -79,12 +70,15 @@ varying vec3 vIndirectFront;
 #include <emissivemap_pars_fragment>
 #include <envmap_common_pars_fragment>
 #include <envmap_pars_fragment>
-#include <cube_uv_reflection_fragment>
+/* include <cube_uv_reflection_fragment> why is this in lambert and phong? */
+#include <fog_pars_fragment>
 #include <bsdfs>
 #include <lights_pars_begin>
-#include <fog_pars_fragment>
+#include <normal_pars_fragment>
+#include <lights_lambert_pars_fragment>
 #include <shadowmap_pars_fragment>
-#include <shadowmask_pars_fragment>
+#include <bumpmap_pars_fragment>
+#include <normalmap_pars_fragment>
 #include <specularmap_pars_fragment>
 #include <logdepthbuf_pars_fragment>
 #include <clipping_planes_pars_fragment>
@@ -103,49 +97,28 @@ void main() {
 	#include <alphamap_fragment>
 	#include <alphatest_fragment>
 	#include <specularmap_fragment>
+	#include <normal_fragment_begin>
+	#include <normal_fragment_maps>
 	#include <emissivemap_fragment>
 
 	// accumulation
-
-	#ifdef DOUBLE_SIDED
-
-		reflectedLight.indirectDiffuse += ( gl_FrontFacing ) ? vIndirectFront : vIndirectBack;
-
-	#else
-
-		reflectedLight.indirectDiffuse += vIndirectFront;
-
-	#endif
-
-	#include <lightmap_fragment>
-
-	reflectedLight.indirectDiffuse *= BRDF_Lambert( diffuseColor.rgb );
-
-	#ifdef DOUBLE_SIDED
-
-		reflectedLight.directDiffuse = ( gl_FrontFacing ) ? vLightFront : vLightBack;
-
-	#else
-
-		reflectedLight.directDiffuse = vLightFront;
-
-	#endif
-
-	reflectedLight.directDiffuse *= BRDF_Lambert( diffuseColor.rgb ) * getShadowMask();
+	#include <lights_lambert_fragment>
+	#include <lights_fragment_begin>
+	#include <lights_fragment_maps>
+	#include <lights_fragment_end>
 
 	// modulation
-
 	#include <aomap_fragment>
 
 	vec3 outgoingLight = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse + totalEmissiveRadiance;
 
 	#include <envmap_fragment>
-
 	#include <output_fragment>
 	#include <tonemapping_fragment>
 	#include <encodings_fragment>
 	#include <fog_fragment>
 	#include <premultiplied_alpha_fragment>
 	#include <dithering_fragment>
+
 }
 `;

--- a/src/renderers/shaders/ShaderLib/meshlambert.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshlambert.glsl.js
@@ -70,7 +70,6 @@ uniform float opacity;
 #include <emissivemap_pars_fragment>
 #include <envmap_common_pars_fragment>
 #include <envmap_pars_fragment>
-/* include <cube_uv_reflection_fragment> why is this in lambert and phong? */
 #include <fog_pars_fragment>
 #include <bsdfs>
 #include <lights_pars_begin>


### PR DESCRIPTION
This PR converts `MeshLambertMaterial` from Gouraud (per-vertex) shading to per-fragment shading.

1. `MeshLambertMaterial` now supports:
	- normal maps
	- object-space normal maps
	- bump maps
	- displacement maps
	- tangents
	- flat-shading using screen-space derivatives

2. Shadows are now correctly modeled as the absence of light, just as the other built-in materials that respond to light. The `shadowMask` approximation, which results in solid-black shadows, is no longer needed. 

3. No features have been removed. In particular, the legacy `specularMap` is still supported.

4. It remains to see if per-vertex shading has a detrimental effect on mobile performance.

5. As suggested by @mrdoob offline, I will create a custom `ShaderMaterial` that uses Lambert illumination and Gouraud (per-vertex) shading, and add it to the `/examples/jsm/materials/` directory. It will have the same feature set as the legacy version of `MeshLambertMaterial`.
