### PR TITLE
BufferGeometry: Remove merge().

### DIFF
--- a/docs/api/en/core/BufferGeometry.html
+++ b/docs/api/en/core/BufferGeometry.html
@@ -247,9 +247,6 @@
 		Use [page:Object3D.lookAt] for typical real-time mesh usage.
 		</p>
 
-		<h3>[method:this merge]( [param:BufferGeometry bufferGeometry], [param:Integer offset] )</h3>
-		<p>Merge in another BufferGeometry with an optional offset of where to start merging in.</p>
-
 		<h3>[method:undefined normalizeNormals]()</h3>
 		<p>
 		Every normal vector in a geometry will have a magnitude of 1.

--- a/docs/api/ko/core/BufferGeometry.html
+++ b/docs/api/ko/core/BufferGeometry.html
@@ -239,9 +239,6 @@
 		일반적인 리얼타임 메쉬 사용은 [page:Object3D.lookAt] 을 사용하세요.
 		</p>
 
-		<h3>[method:this merge]( [param:BufferGeometry bufferGeometry], [param:Integer offset] )</h3>
-		<p>병합을 시작할 지점인 임의의 오프셋으로 다른 BufferGeometry에 병합합니다.</p>
-
 		<h3>[method:undefined normalizeNormals]()</h3>
 		<p>
 		기하학의 모든 법선 벡터는 1의 크기를 갖습니다.

--- a/docs/api/zh/core/BufferGeometry.html
+++ b/docs/api/zh/core/BufferGeometry.html
@@ -232,9 +232,6 @@
 			旋转几何体朝向控件中的一点。该过程通常在一次处理中完成，不会循环处理。典型的用法是过通过调用 [page:Object3D.lookAt] 实时改变 mesh 朝向。
 		</p>
 
-		<h3>[method:this merge]( [param:BufferGeometry bufferGeometry], [param:Integer offset] )</h3>
-		<p>同参数指定的 BufferGeometry 进行合并。可以通过可选参数指定，从哪个偏移位置开始进行 merge。</p>
-
 		<h3>[method:undefined normalizeNormals]()</h3>
 		<p>
 			几何体中的每个法向量长度将会为 1。这样操作会更正光线在表面的效果。

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -726,49 +726,11 @@ class BufferGeometry extends EventDispatcher {
 
 	}
 
-	merge( geometry, offset ) {
+	// @deprecated since r144
 
-		if ( ! ( geometry && geometry.isBufferGeometry ) ) {
+	merge() {
 
-			console.error( 'THREE.BufferGeometry.merge(): geometry not an instance of THREE.BufferGeometry.', geometry );
-			return;
-
-		}
-
-		if ( offset === undefined ) {
-
-			offset = 0;
-
-			console.warn(
-				'THREE.BufferGeometry.merge(): Overwriting original geometry, starting at offset=0. '
-				+ 'Use BufferGeometryUtils.mergeBufferGeometries() for lossless merge.'
-			);
-
-		}
-
-		const attributes = this.attributes;
-
-		for ( const key in attributes ) {
-
-			if ( geometry.attributes[ key ] === undefined ) continue;
-
-			const attribute1 = attributes[ key ];
-			const attributeArray1 = attribute1.array;
-
-			const attribute2 = geometry.attributes[ key ];
-			const attributeArray2 = attribute2.array;
-
-			const attributeOffset = attribute2.itemSize * offset;
-			const length = Math.min( attributeArray2.length, attributeArray1.length - attributeOffset );
-
-			for ( let i = 0, j = attributeOffset; i < length; i ++, j ++ ) {
-
-				attributeArray1[ j ] = attributeArray2[ i ];
-
-			}
-
-		}
-
+		console.error( 'THREE.BufferGeometry.merge() has been removed. Use THREE.BufferGeometryUtils.mergeBufferGeometries() instead.' );
 		return this;
 
 	}

--- a/test/unit/src/core/BufferGeometry.tests.js
+++ b/test/unit/src/core/BufferGeometry.tests.js
@@ -449,33 +449,6 @@ export default QUnit.module( 'Core', () => {
 
 		} );
 
-		QUnit.test( 'merge', ( assert ) => {
-
-			var geometry1 = new BufferGeometry();
-			geometry1.setAttribute( 'attrName', new BufferAttribute( new Float32Array( [ 1, 2, 3, 0, 0, 0 ] ), 3 ) );
-
-			var geometry2 = new BufferGeometry();
-			geometry2.setAttribute( 'attrName', new BufferAttribute( new Float32Array( [ 4, 5, 6 ] ), 3 ) );
-
-			var attr = geometry1.attributes.attrName.array;
-
-			geometry1.merge( geometry2, 1 );
-
-			// merged array should be 1, 2, 3, 4, 5, 6
-			for ( var i = 0; i < attr.length; i ++ ) {
-
-				assert.ok( attr[ i ] === i + 1, '' );
-
-			}
-
-			console.level = CONSOLE_LEVEL.ERROR;
-			geometry1.merge( geometry2 );
-			console.level = CONSOLE_LEVEL.DEFAULT;
-
-			assert.ok( attr[ 0 ] === 4 && attr[ 1 ] === 5 && attr[ 2 ] === 6, 'copied the 3 attributes without offset' );
-
-		} );
-
 		QUnit.todo( 'normalizeNormals', ( assert ) => {
 
 			assert.ok( false, 'everything\'s gonna be alright' );

--- a/test/unit/src/core/BufferGeometry.tests.js
+++ b/test/unit/src/core/BufferGeometry.tests.js
@@ -11,7 +11,6 @@ import { Matrix4 } from '../../../../src/math/Matrix4.js';
 import { Quaternion } from '../../../../src/math/Quaternion.js';
 import { Sphere } from '../../../../src/math/Sphere.js';
 import { x, y, z } from '../math/Constants.tests.js';
-import { CONSOLE_LEVEL } from '../../utils/console-wrapper.js';
 
 var DegToRad = Math.PI / 180;
 


### PR DESCRIPTION
Fixed #24443

**Description**

Based on the discussion in #24443, this PR removes `BufferGeometry.merge()`. Users are advised to merge their geometry data via `BufferGeometryUtils` instead (for instance `mergeBufferGeometries()`).

I have not restored the logic of  `BufferGeometry.merge()` as a `setBufferAt()` method since I think we should move the development towards more generic APIs and avoid user level code that performs direct array access (e.g. `attribute.getX()` vs. `attribute.array`) or requires knowledge about the data structure (interleaved vs non-interleaved data).