### PR TITLE
WebGLShaderCache: Avoid multiple map lookups.

### DIFF
--- a/src/renderers/webgl/WebGLShaderCache.js
+++ b/src/renderers/webgl/WebGLShaderCache.js
@@ -77,29 +77,32 @@ class WebGLShaderCache {
 	_getShaderCacheForMaterial( material ) {
 
 		const cache = this.materialCache;
+		let set = cache.get( material );
 
-		if ( cache.has( material ) === false ) {
+		if ( set == undefined ) {
 
-			cache.set( material, new Set() );
+			set = new Set();
+			cache.set( material, set );
 
 		}
 
-		return cache.get( material );
+		return set;
 
 	}
 
 	_getShaderStage( code ) {
 
 		const cache = this.shaderCache;
+		let stage = cache.get( code );
 
-		if ( cache.has( code ) === false ) {
+		if ( stage == undefined ) {
 
-			const stage = new WebGLShaderStage( code );
+			stage = new WebGLShaderStage( code );
 			cache.set( code, stage );
 
 		}
 
-		return cache.get( code );
+		return stage;
 
 	}
 

--- a/src/renderers/webgl/WebGLShaderCache.js
+++ b/src/renderers/webgl/WebGLShaderCache.js
@@ -79,7 +79,7 @@ class WebGLShaderCache {
 		const cache = this.materialCache;
 		let set = cache.get( material );
 
-		if ( set == undefined ) {
+		if ( set === undefined ) {
 
 			set = new Set();
 			cache.set( material, set );
@@ -95,7 +95,7 @@ class WebGLShaderCache {
 		const cache = this.shaderCache;
 		let stage = cache.get( code );
 
-		if ( stage == undefined ) {
+		if ( stage === undefined ) {
 
 			stage = new WebGLShaderStage( code );
 			cache.set( code, stage );


### PR DESCRIPTION
**Description**

Partial fix for https://github.com/mrdoob/three.js/issues/24451 by reducing the number of `Map` lookups with large string keys made per frame.

*This contribution is funded by [Foxglove](https://foxglove.dev/)*
