### PR TITLE
Nodes: fix atan2

### DIFF
--- a/examples/jsm/renderers/webgl/nodes/WebGLNodeBuilder.js
+++ b/examples/jsm/renderers/webgl/nodes/WebGLNodeBuilder.js
@@ -6,6 +6,7 @@ import WebGLPhysicalContextNode from './WebGLPhysicalContextNode.js';
 
 import { PerspectiveCamera, ShaderChunk, ShaderLib, UniformsUtils, UniformsLib,
 	LinearEncoding, RGBAFormat, UnsignedByteType, sRGBEncoding } from 'three';
+import MathNode from '../../../nodes/math/MathNode.js';
 
 const nodeFrame = new NodeFrame();
 nodeFrame.camera = new PerspectiveCamera();
@@ -16,6 +17,10 @@ const nodeShaderLib = {
 	PointsNodeMaterial: ShaderLib.points,
 	MeshStandardNodeMaterial: ShaderLib.standard,
 	MeshPhysicalMaterial: ShaderLib.physical
+};
+
+const glslMethods = {
+	[ MathNode.ATAN2 ]: 'atan'
 };
 
 function getIncludeSnippet( name ) {
@@ -40,6 +45,12 @@ class WebGLNodeBuilder extends NodeBuilder {
 		this.slots = { vertex: [], fragment: [] };
 
 		this._parseObject();
+
+	}
+
+	getMethod( method ) {
+
+		return glslMethods[ method ] || method;
 
 	}
 


### PR DESCRIPTION
**Description**

I noticed that `atan2` doesn't work in WebGL, I am getting following error:

```
FRAGMENT
ERROR: 0:1199: 'atan2' : no matching overloaded function found
```

Example:
```
import { AttributeNode, ShaderNode, nodeObject, atan2, MeshStandardNodeMaterial } from "three/examples/jsm/nodes/Nodes";

export const SomeShaderNode = new ShaderNode( ( {uv} ) => {
    return atan2(uv.x, uv.y)
} );

const material = new MeshStandardNodeMaterial();
material.colorNode = SomeShaderNode.call({uv: new AttributeNode('uv')})
```

This is an attempt to correct this error.
