### PR TITLE
Use cubeUV_ prefix in cube_uv_reflection_fragment defines

### DIFF
--- a/src/renderers/shaders/ShaderChunk/cube_uv_reflection_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/cube_uv_reflection_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default /* glsl */`
+export default /* glsl */ `
 #ifdef ENVMAP_TYPE_CUBE_UV
 
 	#define cubeUV_minMipLevel 4.0
@@ -118,41 +118,41 @@ export default /* glsl */`
 
 	// These defines must match with PMREMGenerator
 
-	#define r0 1.0
-	#define v0 0.339
-	#define m0 - 2.0
-	#define r1 0.8
-	#define v1 0.276
-	#define m1 - 1.0
-	#define r4 0.4
-	#define v4 0.046
-	#define m4 2.0
-	#define r5 0.305
-	#define v5 0.016
-	#define m5 3.0
-	#define r6 0.21
-	#define v6 0.0038
-	#define m6 4.0
+	#define cubeUV_r0 1.0
+	#define cubeUV_v0 0.339
+	#define cubeUV_m0 - 2.0
+	#define cubeUV_r1 0.8
+	#define cubeUV_v1 0.276
+	#define cubeUV_m1 - 1.0
+	#define cubeUV_r4 0.4
+	#define cubeUV_v4 0.046
+	#define cubeUV_m4 2.0
+	#define cubeUV_r5 0.305
+	#define cubeUV_v5 0.016
+	#define cubeUV_m5 3.0
+	#define cubeUV_r6 0.21
+	#define cubeUV_v6 0.0038
+	#define cubeUV_m6 4.0
 
 	float roughnessToMip( float roughness ) {
 
 		float mip = 0.0;
 
-		if ( roughness >= r1 ) {
+		if ( roughness >= cubeUV_r1 ) {
 
-			mip = ( r0 - roughness ) * ( m1 - m0 ) / ( r0 - r1 ) + m0;
+			mip = ( cubeUV_r0 - roughness ) * ( cubeUV_m1 - cubeUV_m0 ) / ( cubeUV_r0 - cubeUV_r1 ) + cubeUV_m0;
 
-		} else if ( roughness >= r4 ) {
+		} else if ( roughness >= cubeUV_r4 ) {
 
-			mip = ( r1 - roughness ) * ( m4 - m1 ) / ( r1 - r4 ) + m1;
+			mip = ( cubeUV_r1 - roughness ) * ( cubeUV_m4 - cubeUV_m1 ) / ( cubeUV_r1 - cubeUV_r4 ) + cubeUV_m1;
 
-		} else if ( roughness >= r5 ) {
+		} else if ( roughness >= cubeUV_r5 ) {
 
-			mip = ( r4 - roughness ) * ( m5 - m4 ) / ( r4 - r5 ) + m4;
+			mip = ( cubeUV_r4 - roughness ) * ( cubeUV_m5 - cubeUV_m4 ) / ( cubeUV_r4 - cubeUV_r5 ) + cubeUV_m4;
 
-		} else if ( roughness >= r6 ) {
+		} else if ( roughness >= cubeUV_r6 ) {
 
-			mip = ( r5 - roughness ) * ( m6 - m5 ) / ( r5 - r6 ) + m5;
+			mip = ( cubeUV_r5 - roughness ) * ( cubeUV_m6 - cubeUV_m5 ) / ( cubeUV_r5 - cubeUV_r6 ) + cubeUV_m5;
 
 		} else {
 
@@ -165,7 +165,7 @@ export default /* glsl */`
 
 	vec4 textureCubeUV( sampler2D envMap, vec3 sampleDir, float roughness ) {
 
-		float mip = clamp( roughnessToMip( roughness ), m0, CUBEUV_MAX_MIP );
+		float mip = clamp( roughnessToMip( roughness ), cubeUV_m0, CUBEUV_MAX_MIP );
 
 		float mipF = fract( mip );
 

--- a/src/renderers/shaders/ShaderChunk/cube_uv_reflection_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/cube_uv_reflection_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default /* glsl */ `
+export default /* glsl */`
 #ifdef ENVMAP_TYPE_CUBE_UV
 
 	#define cubeUV_minMipLevel 4.0


### PR DESCRIPTION
Fixed #24469

**Description**

Renames short defines such as `v0` and `v1` of [cube_uv_reflection_fragment](https://github.com/mrdoob/three.js/blob/9e5512f067e3a0de8d4069217d20903c1725edf7/src/renderers/shaders/ShaderChunk/cube_uv_reflection_fragment.glsl.js#L119) to follow the `cubeUV_*` pattern and minimize clashing with built-ins such as [bsdfs](https://github.com/mrdoob/three.js/blob/9e5512f067e3a0de8d4069217d20903c1725edf7/src/renderers/shaders/ShaderChunk/bsdfs.glsl.js#L150).
