### PR TITLE
Shaders: remove unnecessary shader chunks

### DIFF
--- a/examples/jsm/utils/PackedPhongMaterial.js
+++ b/examples/jsm/utils/PackedPhongMaterial.js
@@ -189,7 +189,6 @@ class PackedPhongMaterial extends MeshPhongMaterial {
 			ShaderChunk.emissivemap_pars_fragment,
 			ShaderChunk.envmap_common_pars_fragment,
 			ShaderChunk.envmap_pars_fragment,
-			ShaderChunk.cube_uv_reflection_fragment,
 			ShaderChunk.fog_pars_fragment,
 			ShaderChunk.bsdfs,
 			ShaderChunk.lights_pars_begin,

--- a/src/renderers/shaders/ShaderLib/meshbasic.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshbasic.glsl.js
@@ -63,7 +63,6 @@ uniform float opacity;
 #include <lightmap_pars_fragment>
 #include <envmap_common_pars_fragment>
 #include <envmap_pars_fragment>
-#include <cube_uv_reflection_fragment>
 #include <fog_pars_fragment>
 #include <specularmap_pars_fragment>
 #include <logdepthbuf_pars_fragment>

--- a/src/renderers/shaders/ShaderLib/meshlambert.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshlambert.glsl.js
@@ -79,7 +79,6 @@ varying vec3 vIndirectFront;
 #include <emissivemap_pars_fragment>
 #include <envmap_common_pars_fragment>
 #include <envmap_pars_fragment>
-#include <cube_uv_reflection_fragment>
 #include <bsdfs>
 #include <lights_pars_begin>
 #include <fog_pars_fragment>

--- a/src/renderers/shaders/ShaderLib/meshphong.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshphong.glsl.js
@@ -72,7 +72,6 @@ uniform float opacity;
 #include <emissivemap_pars_fragment>
 #include <envmap_common_pars_fragment>
 #include <envmap_pars_fragment>
-#include <cube_uv_reflection_fragment>
 #include <fog_pars_fragment>
 #include <bsdfs>
 #include <lights_pars_begin>


### PR DESCRIPTION
As suggested in https://github.com/mrdoob/three.js/issues/24469#issuecomment-1208507525.

`MMDToonShader`, `Basic`, `Lambert`, and `Phong` do not support PMREM environment maps, so <cube_uv_reflection_fragment> can be removed.



