### PR TITLE
Set stencilBuffer property of WebGLRenderTarget in WebXRManager

### DIFF
--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -285,7 +285,8 @@ class WebXRManager extends EventDispatcher {
 						{
 							format: RGBAFormat,
 							type: UnsignedByteType,
-							encoding: renderer.outputEncoding
+							encoding: renderer.outputEncoding,
+							stencilBuffer: attributes.stencil
 						}
 					);
 


### PR DESCRIPTION
**Description**

In case a browser doesn't implement the WebXR Layers API, the `WebXRManager` doesn't set the `stencilBuffer` property on the render target. The underlying framebuffer, however, can have a stencil buffer. Functionally the stencil buffer seems to work for as far as I could test, but the render target incorrectly reports that it doesn't have one.

This PR simply ensures the `stencilBuffer` property is set accordingly. This is in line with the way it's done in the code path for browsers that _do_ implement the WebXR Layers API ([line 325](https://github.com/mrdoob/three.js/blob/dev/src/renderers/webxr/WebXRManager.js#L325)).