### PR TITLE
Fix typo in WebGLRenderer docs

### DIFF
--- a/docs/api/en/renderers/WebGLRenderer.html
+++ b/docs/api/en/renderers/WebGLRenderer.html
@@ -407,7 +407,7 @@
 
 			By default render buffers are cleared before rendering but you can prevent this by setting the property [page:WebGLRenderer.autoClear autoClear] to false.
 			If you want to prevent only certain buffers being cleared you can set either the [page:WebGLRenderer.autoClearColor autoClearColor], [page:WebGLRenderer.autoClearStencil autoClearStencil] or
-			[page:WebGLRenderer.autoClearDepth autoClearDepth] properties to false. To forcibly clear one ore more buffers call [page:WebGLRenderer.clear .clear].
+			[page:WebGLRenderer.autoClearDepth autoClearDepth] properties to false. To forcibly clear one or more buffers call [page:WebGLRenderer.clear .clear].
 		</p>
 
 		<h3>[method:undefined resetState]()</h3>


### PR DESCRIPTION
**Description**

Fixes a small typo in the api docs of the `.render` method of the `WebGLRenderer`