### PR TITLE
Minimize glActiveTexture calls

### DIFF
--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -913,6 +913,37 @@ function WebGLState( gl, extensions, capabilities ) {
 
 	}
 
+	function bindTextureToSlot( webglSlot, webglType, webglTexture ) {
+
+		if ( webglSlot === undefined ) webglSlot = gl.TEXTURE0 + maxTextures - 1;
+
+		let boundTexture = currentBoundTextures[ webglSlot ];
+
+		if ( boundTexture === undefined ) {
+
+			boundTexture = { type: undefined, texture: undefined };
+			currentBoundTextures[ webglSlot ] = boundTexture;
+
+		}
+
+		if ( boundTexture.type !== webglType || boundTexture.texture !== webglTexture ) {
+
+			if ( currentTextureSlot !== webglSlot ) {
+
+				gl.activeTexture( webglSlot );
+				currentTextureSlot = webglSlot;
+
+			}
+
+			gl.bindTexture( webglType, webglTexture || emptyTextures[ webglType ] );
+
+			boundTexture.type = webglType;
+			boundTexture.texture = webglTexture;
+
+		}
+
+	}
+
 	function unbindTexture() {
 
 		const boundTexture = currentBoundTextures[ currentTextureSlot ];
@@ -1186,6 +1217,7 @@ function WebGLState( gl, extensions, capabilities ) {
 
 		activeTexture: activeTexture,
 		bindTexture: bindTexture,
+		bindTextureToSlot: bindTextureToSlot,
 		unbindTexture: unbindTexture,
 		compressedTexImage2D: compressedTexImage2D,
 		texImage2D: texImage2D,

--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -885,37 +885,21 @@ function WebGLState( gl, extensions, capabilities ) {
 
 	}
 
-	function bindTexture( webglType, webglTexture ) {
+	function bindTexture( webglType, webglTexture, webglSlot ) {
 
-		if ( currentTextureSlot === null ) {
+		if ( webglSlot === undefined ) {
 
-			activeTexture();
+			if ( currentTextureSlot === null ) {
 
-		}
+				webglSlot = gl.TEXTURE0 + maxTextures - 1;
 
-		let boundTexture = currentBoundTextures[ currentTextureSlot ];
+			} else {
 
-		if ( boundTexture === undefined ) {
+				webglSlot = currentTextureSlot;
 
-			boundTexture = { type: undefined, texture: undefined };
-			currentBoundTextures[ currentTextureSlot ] = boundTexture;
-
-		}
-
-		if ( boundTexture.type !== webglType || boundTexture.texture !== webglTexture ) {
-
-			gl.bindTexture( webglType, webglTexture || emptyTextures[ webglType ] );
-
-			boundTexture.type = webglType;
-			boundTexture.texture = webglTexture;
+			}
 
 		}
-
-	}
-
-	function bindTextureToSlot( webglSlot, webglType, webglTexture ) {
-
-		if ( webglSlot === undefined ) webglSlot = gl.TEXTURE0 + maxTextures - 1;
 
 		let boundTexture = currentBoundTextures[ webglSlot ];
 
@@ -1217,7 +1201,6 @@ function WebGLState( gl, extensions, capabilities ) {
 
 		activeTexture: activeTexture,
 		bindTexture: bindTexture,
-		bindTextureToSlot: bindTextureToSlot,
 		unbindTexture: unbindTexture,
 		compressedTexImage2D: compressedTexImage2D,
 		texImage2D: texImage2D,

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -681,6 +681,8 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		if ( source.version !== source.__currentVersion || forceUpload === true ) {
 
+			state.activeTexture( _gl.TEXTURE0 + slot );
+
 			_gl.pixelStorei( _gl.UNPACK_FLIP_Y_WEBGL, texture.flipY );
 			_gl.pixelStorei( _gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, texture.premultiplyAlpha );
 			_gl.pixelStorei( _gl.UNPACK_ALIGNMENT, texture.unpackAlignment );
@@ -1038,6 +1040,8 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 		state.bindTextureToSlot( _gl.TEXTURE0 + slot, _gl.TEXTURE_CUBE_MAP, textureProperties.__webglTexture );
 
 		if ( source.version !== source.__currentVersion || forceUpload === true ) {
+
+			state.activeTexture( _gl.TEXTURE0 + slot );
 
 			_gl.pixelStorei( _gl.UNPACK_FLIP_Y_WEBGL, texture.flipY );
 			_gl.pixelStorei( _gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, texture.premultiplyAlpha );

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -460,7 +460,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		}
 
-		state.bindTextureToSlot( _gl.TEXTURE0 + slot, _gl.TEXTURE_2D, textureProperties.__webglTexture );
+		state.bindTexture( _gl.TEXTURE_2D, textureProperties.__webglTexture, _gl.TEXTURE0 + slot );
 
 	}
 
@@ -475,7 +475,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		}
 
-		state.bindTextureToSlot( _gl.TEXTURE0 + slot, _gl.TEXTURE_2D_ARRAY, textureProperties.__webglTexture );
+		state.bindTexture( _gl.TEXTURE_2D_ARRAY, textureProperties.__webglTexture, _gl.TEXTURE0 + slot );
 
 	}
 
@@ -490,7 +490,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		}
 
-		state.bindTextureToSlot( _gl.TEXTURE0 + slot, _gl.TEXTURE_3D, textureProperties.__webglTexture );
+		state.bindTexture( _gl.TEXTURE_3D, textureProperties.__webglTexture, _gl.TEXTURE0 + slot );
 
 	}
 
@@ -505,7 +505,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		}
 
-		state.bindTextureToSlot( _gl.TEXTURE0 + slot, _gl.TEXTURE_CUBE_MAP, textureProperties.__webglTexture );
+		state.bindTexture( _gl.TEXTURE_CUBE_MAP, textureProperties.__webglTexture, _gl.TEXTURE0 + slot );
 
 	}
 
@@ -677,7 +677,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 		const forceUpload = initTexture( textureProperties, texture );
 		const source = texture.source;
 
-		state.bindTextureToSlot( _gl.TEXTURE0 + slot, textureType, textureProperties.__webglTexture );
+		state.bindTexture( textureType, textureProperties.__webglTexture, _gl.TEXTURE0 + slot );
 
 		if ( source.version !== source.__currentVersion || forceUpload === true ) {
 
@@ -1037,7 +1037,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 		const forceUpload = initTexture( textureProperties, texture );
 		const source = texture.source;
 
-		state.bindTextureToSlot( _gl.TEXTURE0 + slot, _gl.TEXTURE_CUBE_MAP, textureProperties.__webglTexture );
+		state.bindTexture( _gl.TEXTURE_CUBE_MAP, textureProperties.__webglTexture, _gl.TEXTURE0 + slot );
 
 		if ( source.version !== source.__currentVersion || forceUpload === true ) {
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -460,8 +460,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		}
 
-		state.activeTexture( _gl.TEXTURE0 + slot );
-		state.bindTexture( _gl.TEXTURE_2D, textureProperties.__webglTexture );
+		state.bindTextureToSlot( _gl.TEXTURE0 + slot, _gl.TEXTURE_2D, textureProperties.__webglTexture );
 
 	}
 
@@ -476,8 +475,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		}
 
-		state.activeTexture( _gl.TEXTURE0 + slot );
-		state.bindTexture( _gl.TEXTURE_2D_ARRAY, textureProperties.__webglTexture );
+		state.bindTextureToSlot( _gl.TEXTURE0 + slot, _gl.TEXTURE_2D_ARRAY, textureProperties.__webglTexture );
 
 	}
 
@@ -492,8 +490,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		}
 
-		state.activeTexture( _gl.TEXTURE0 + slot );
-		state.bindTexture( _gl.TEXTURE_3D, textureProperties.__webglTexture );
+		state.bindTextureToSlot( _gl.TEXTURE0 + slot, _gl.TEXTURE_3D, textureProperties.__webglTexture );
 
 	}
 
@@ -508,8 +505,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		}
 
-		state.activeTexture( _gl.TEXTURE0 + slot );
-		state.bindTexture( _gl.TEXTURE_CUBE_MAP, textureProperties.__webglTexture );
+		state.bindTextureToSlot( _gl.TEXTURE0 + slot, _gl.TEXTURE_CUBE_MAP, textureProperties.__webglTexture );
 
 	}
 
@@ -681,8 +677,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 		const forceUpload = initTexture( textureProperties, texture );
 		const source = texture.source;
 
-		state.activeTexture( _gl.TEXTURE0 + slot );
-		state.bindTexture( textureType, textureProperties.__webglTexture );
+		state.bindTextureToSlot( _gl.TEXTURE0 + slot, textureType, textureProperties.__webglTexture );
 
 		if ( source.version !== source.__currentVersion || forceUpload === true ) {
 
@@ -1040,8 +1035,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 		const forceUpload = initTexture( textureProperties, texture );
 		const source = texture.source;
 
-		state.activeTexture( _gl.TEXTURE0 + slot );
-		state.bindTexture( _gl.TEXTURE_CUBE_MAP, textureProperties.__webglTexture );
+		state.bindTextureToSlot( _gl.TEXTURE0 + slot, _gl.TEXTURE_CUBE_MAP, textureProperties.__webglTexture );
 
 		if ( source.version !== source.__currentVersion || forceUpload === true ) {
 


### PR DESCRIPTION
**Description**

When running spector.js captures of a complex scene, I noticed a number of calls to glActiveTexture that were followed immediately by a separate call to glActiveTexture.  This change checks to see if a texture will be bound (or uploaded) before calling ActiveTexture, improving performance by removing these useless gl calls.

*This contribution is funded by [Meta](https://meta.com)*
