### PR TITLE
Docs: Add id attribute to old manual's header tags

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -519,12 +519,13 @@
 					const beforeSubHash = splitHash[0].slice(0, subHash);
 					const afterSubHash = splitHash[0].slice(subHash);
 					src = `${beforeSubHash}.html${afterSubHash}${splitHash[ 1 ]}`;
+					subtitle = titles[ beforeSubHash ] + splitHash[ 1 ] + ' – ';
 				} else {
 					src = splitHash[ 0 ] + '.html' + splitHash[ 1 ];
+					subtitle = titles[ splitHash[ 0 ] ] + splitHash[ 1 ] + ' – ';
 				}
 
 				iframe.src = src;  // lgtm[js/client-side-unvalidated-url-redirection]
-				subtitle = titles[ splitHash[ 0 ] ] + splitHash[ 1 ] + ' – ';
 				iframe.style.display = 'unset';
 
 			} else {

--- a/docs/index.html
+++ b/docs/index.html
@@ -506,9 +506,24 @@
 			const oldIframe = iframe;
 			iframe = oldIframe.cloneNode();
 
-			if ( hash && titles[ splitHash[ 0 ] ] ) {
+			if ( hash ) {
 
-				iframe.src = splitHash[ 0 ] + '.html' + splitHash[ 1 ];
+				// We can have 2 hashes. One for the main page, one for the page it's referencing
+				// In other words
+				//	 #manual/en/someSection/somePage#someSectionOfPage
+
+				const subHash = splitHash[0].indexOf('#');
+				let src;
+
+				if (subHash >= 0) {
+					const beforeSubHash = splitHash[0].slice(0, subHash);
+					const afterSubHash = splitHash[0].slice(subHash);
+					src = `${beforeSubHash}.html${afterSubHash}${splitHash[ 1 ]}`;
+				} else {
+					src = splitHash[ 0 ] + '.html' + splitHash[ 1 ];
+				}
+
+				iframe.src = src;  // lgtm[js/client-side-unvalidated-url-redirection]
 				subtitle = titles[ splitHash[ 0 ] ] + splitHash[ 1 ] + ' – ';
 				iframe.style.display = 'unset';
 

--- a/docs/manual/en/buildTools/Testing-with-NPM.html
+++ b/docs/manual/en/buildTools/Testing-with-NPM.html
@@ -15,7 +15,7 @@
 			CI tools like [link:https://travis-ci.org/ Travis].
 		</p>
 
-		<h2 id="the-short-version">The short version</h2>
+		<h2 id="the-short-version">The short version<a href="#manual/en/buildTools/Testing-with-NPM#the-short-version" class="heading-link">#</a></h2>
 
 		<p>
 			If you're comfortable with node and npm,
@@ -29,13 +29,13 @@
 			to your test.
 		</p>
 
-		<h2 id="create-a-testable-project-from-scratch">Create a testable project from scratch</h2>
+		<h2 id="create-a-testable-project-from-scratch">Create a testable project from scratch<a href="#manual/en/buildTools/Testing-with-NPM#create-a-testable-project-from-scratch" class="heading-link">#</a></h2>
 		<p>
 			If you're not familiar with these tools, here's a quick guide (for linux, the installation process
 			will be slightly different using windows, but the NPM commands are identical).
 		</p>
 
-		<h3 id="basic-setup">Basic setup</h3>
+		<h3 id="basic-setup">Basic setup<a href="#manual/en/buildTools/Testing-with-NPM#basic-setup" class="heading-link">#</a></h3>
 		<div>
 			<ol>
 				<li>
@@ -78,7 +78,7 @@ $ npm test
 			</ol>
 		</div>
 
-		<h2 id="add-mocha">Add mocha</h2>
+		<h2 id="add-mocha">Add mocha<a href="#manual/en/buildTools/Testing-with-NPM#add-mocha" class="heading-link">#</a></h2>
 		<div>
 			We're going to use [link:https://mochajs.org/ mocha].
 
@@ -115,7 +115,7 @@ $ npm install mocha --save-dev
 			</ol>
 		</div>
 
-		<h2 id="add-threejs">Add three.js</h2>
+		<h2 id="add-threejs">Add three.js<a href="#manual/en/buildTools/Testing-with-NPM#add-threejs" class="heading-link">#</a></h2>
 		<div>
 			<ol>
 				<li>
@@ -179,7 +179,7 @@ The THREE object should be able to construct a Vector3 with default of x=0: 0ms
 			</ol>
 		</div>
 
-		<h2 id="add-your-own-code">Add your own code</h2>
+		<h2 id="add-your-own-code">Add your own code<a href="#manual/en/buildTools/Testing-with-NPM#add-your-own-code" class="heading-link">#</a></h2>
 		<div>
 			You need to do three things:
 
@@ -214,7 +214,7 @@ if (typeof exports !== 'undefined')
 			</code>
 		</div>
 
-		<h2 id="dealing-with-dependencies">Dealing with dependencies</h2>
+		<h2 id="dealing-with-dependencies">Dealing with dependencies<a href="#manual/en/buildTools/Testing-with-NPM#dealing-with-dependencies" class="heading-link">#</a></h2>
 		<div>
 			<p>
 				If you're already using something clever like require.js or browserify, skip this part.

--- a/docs/manual/en/buildTools/Testing-with-NPM.html
+++ b/docs/manual/en/buildTools/Testing-with-NPM.html
@@ -15,7 +15,7 @@
 			CI tools like [link:https://travis-ci.org/ Travis].
 		</p>
 
-		<h2 id="the-short-version">The short version<a href="#manual/en/buildTools/Testing-with-NPM#the-short-version" class="heading-link">#</a></h2>
+		<h2 id="the-short-version">The short version<a href="#manual/en/buildTools/Testing-with-NPM#the-short-version" target="_parent" class="heading-link">#</a></h2>
 
 		<p>
 			If you're comfortable with node and npm,
@@ -29,13 +29,13 @@
 			to your test.
 		</p>
 
-		<h2 id="create-a-testable-project-from-scratch">Create a testable project from scratch<a href="#manual/en/buildTools/Testing-with-NPM#create-a-testable-project-from-scratch" class="heading-link">#</a></h2>
+		<h2 id="create-a-testable-project-from-scratch">Create a testable project from scratch<a href="#manual/en/buildTools/Testing-with-NPM#create-a-testable-project-from-scratch" target="_parent" class="heading-link">#</a></h2>
 		<p>
 			If you're not familiar with these tools, here's a quick guide (for linux, the installation process
 			will be slightly different using windows, but the NPM commands are identical).
 		</p>
 
-		<h3 id="basic-setup">Basic setup<a href="#manual/en/buildTools/Testing-with-NPM#basic-setup" class="heading-link">#</a></h3>
+		<h3 id="basic-setup">Basic setup<a href="#manual/en/buildTools/Testing-with-NPM#basic-setup" target="_parent" class="heading-link">#</a></h3>
 		<div>
 			<ol>
 				<li>
@@ -78,7 +78,7 @@ $ npm test
 			</ol>
 		</div>
 
-		<h2 id="add-mocha">Add mocha<a href="#manual/en/buildTools/Testing-with-NPM#add-mocha" class="heading-link">#</a></h2>
+		<h2 id="add-mocha">Add mocha<a href="#manual/en/buildTools/Testing-with-NPM#add-mocha" target="_parent" class="heading-link">#</a></h2>
 		<div>
 			We're going to use [link:https://mochajs.org/ mocha].
 
@@ -115,7 +115,7 @@ $ npm install mocha --save-dev
 			</ol>
 		</div>
 
-		<h2 id="add-threejs">Add three.js<a href="#manual/en/buildTools/Testing-with-NPM#add-threejs" class="heading-link">#</a></h2>
+		<h2 id="add-threejs">Add three.js<a href="#manual/en/buildTools/Testing-with-NPM#add-threejs" target="_parent" class="heading-link">#</a></h2>
 		<div>
 			<ol>
 				<li>
@@ -179,7 +179,7 @@ The THREE object should be able to construct a Vector3 with default of x=0: 0ms
 			</ol>
 		</div>
 
-		<h2 id="add-your-own-code">Add your own code<a href="#manual/en/buildTools/Testing-with-NPM#add-your-own-code" class="heading-link">#</a></h2>
+		<h2 id="add-your-own-code">Add your own code<a href="#manual/en/buildTools/Testing-with-NPM#add-your-own-code" target="_parent" class="heading-link">#</a></h2>
 		<div>
 			You need to do three things:
 
@@ -214,7 +214,7 @@ if (typeof exports !== 'undefined')
 			</code>
 		</div>
 
-		<h2 id="dealing-with-dependencies">Dealing with dependencies<a href="#manual/en/buildTools/Testing-with-NPM#dealing-with-dependencies" class="heading-link">#</a></h2>
+		<h2 id="dealing-with-dependencies">Dealing with dependencies<a href="#manual/en/buildTools/Testing-with-NPM#dealing-with-dependencies" target="_parent" class="heading-link">#</a></h2>
 		<div>
 			<p>
 				If you're already using something clever like require.js or browserify, skip this part.

--- a/docs/manual/en/buildTools/Testing-with-NPM.html
+++ b/docs/manual/en/buildTools/Testing-with-NPM.html
@@ -15,7 +15,7 @@
 			CI tools like [link:https://travis-ci.org/ Travis].
 		</p>
 
-		<h2>The short version</h2>
+		<h2 id="the-short-version">The short version</h2>
 
 		<p>
 			If you're comfortable with node and npm,
@@ -29,13 +29,13 @@
 			to your test.
 		</p>
 
-		<h2>Create a testable project from scratch</h2>
+		<h2 id="create-a-testable-project-from-scratch">Create a testable project from scratch</h2>
 		<p>
 			If you're not familiar with these tools, here's a quick guide (for linux, the installation process
 			will be slightly different using windows, but the NPM commands are identical).
 		</p>
 
-		<h3>Basic setup</h3>
+		<h3 id="basic-setup">Basic setup</h3>
 		<div>
 			<ol>
 				<li>
@@ -78,7 +78,7 @@ $ npm test
 			</ol>
 		</div>
 
-		<h2>Add mocha</h2>
+		<h2 id="add-mocha">Add mocha</h2>
 		<div>
 			We're going to use [link:https://mochajs.org/ mocha].
 
@@ -115,7 +115,7 @@ $ npm install mocha --save-dev
 			</ol>
 		</div>
 
-		<h2>Add three.js</h2>
+		<h2 id="add-threejs">Add three.js</h2>
 		<div>
 			<ol>
 				<li>
@@ -179,7 +179,7 @@ The THREE object should be able to construct a Vector3 with default of x=0: 0ms
 			</ol>
 		</div>
 
-		<h2>Add your own code</h2>
+		<h2 id="add-your-own-code">Add your own code</h2>
 		<div>
 			You need to do three things:
 
@@ -214,7 +214,7 @@ if (typeof exports !== 'undefined')
 			</code>
 		</div>
 
-		<h2>Dealing with dependencies</h2>
+		<h2 id="dealing-with-dependencies">Dealing with dependencies</h2>
 		<div>
 			<p>
 				If you're already using something clever like require.js or browserify, skip this part.

--- a/docs/manual/en/introduction/Animation-system.html
+++ b/docs/manual/en/introduction/Animation-system.html
@@ -9,7 +9,7 @@
 	<body>
 		<h1>[name]</h1>
 
-		<h2 id="overview">Overview</h2>
+		<h2 id="overview">Overview<a href="#manual/en/introduction/Animation-system#overview" class="heading-link">#</a></h2>
 
 		<p class="desc">
 			Within the three.js animation system you can animate various properties of your models:
@@ -28,7 +28,7 @@
 
 		</p>
 
-		<h3 id="animation-clips">Animation Clips</h3>
+		<h3 id="animation-clips">Animation Clips<a href="#manual/en/introduction/Animation-system#animation-clips" class="heading-link">#</a></h3>
 
 		<p class="desc">
 
@@ -45,7 +45,7 @@
 
 		</p>
 
-		<h3 id="keyframe-tracks">Keyframe Tracks</h3>
+		<h3 id="keyframe-tracks">Keyframe Tracks<a href="#manual/en/introduction/Animation-system#keyframe-tracks" class="heading-link">#</a></h3>
 
 		<p class="desc">
 
@@ -63,7 +63,7 @@
 
 		</p>
 
-		<h3 id="animation-mixer">Animation Mixer</h3>
+		<h3 id="animation-mixer">Animation Mixer<a href="#manual/en/introduction/Animation-system#animation-mixer" class="heading-link">#</a></h3>
 
 		<p class="desc">
 
@@ -74,7 +74,7 @@
 
 		</p>
 
-		<h3 id="animation-actions">Animation Actions</h3>
+		<h3 id="animation-actions">Animation Actions<a href="#manual/en/introduction/Animation-system#animation-actions" class="heading-link">#</a></h3>
 
 		<p class="desc">
 
@@ -87,7 +87,7 @@
 
 		</p>
 
-		<h3 id="animation-object-groups">Animation Object Groups</h3>
+		<h3 id="animation-object-groups">Animation Object Groups<a href="#manual/en/introduction/Animation-system#animation-object-groups" class="heading-link">#</a></h3>
 
 		<p class="desc">
 
@@ -96,7 +96,7 @@
 
 		</p>
 
-		<h3 id="supported-formats-and-loaders">Supported Formats and Loaders</h3>
+		<h3 id="supported-formats-and-loaders">Supported Formats and Loaders<a href="#manual/en/introduction/Animation-system#supported-formats-and-loaders" class="heading-link">#</a></h3>
 
 		<p class="desc">
 			Note that not all model formats include animation (OBJ notably does not), and that only some
@@ -118,7 +118,7 @@
 			on the same timeline) directly to a single file.
 		</p>
 
-		<h2 id="example">Example</h2>
+		<h2 id="example">Example<a href="#manual/en/introduction/Animation-system#example" class="heading-link">#</a></h2>
 
 		<code>
 		let mesh;

--- a/docs/manual/en/introduction/Animation-system.html
+++ b/docs/manual/en/introduction/Animation-system.html
@@ -9,7 +9,7 @@
 	<body>
 		<h1>[name]</h1>
 
-		<h2>Overview</h2>
+		<h2 id="overview">Overview</h2>
 
 		<p class="desc">
 			Within the three.js animation system you can animate various properties of your models:
@@ -28,7 +28,7 @@
 
 		</p>
 
-		<h3>Animation Clips</h3>
+		<h3 id="animation-clips">Animation Clips</h3>
 
 		<p class="desc">
 
@@ -45,7 +45,7 @@
 
 		</p>
 
-		<h3>Keyframe Tracks</h3>
+		<h3 id="keyframe-tracks">Keyframe Tracks</h3>
 
 		<p class="desc">
 
@@ -63,7 +63,7 @@
 
 		</p>
 
-		<h3>Animation Mixer</h3>
+		<h3 id="animation-mixer">Animation Mixer</h3>
 
 		<p class="desc">
 
@@ -74,7 +74,7 @@
 
 		</p>
 
-		<h3>Animation Actions</h3>
+		<h3 id="animation-actions">Animation Actions</h3>
 
 		<p class="desc">
 
@@ -87,7 +87,7 @@
 
 		</p>
 
-		<h3>Animation Object Groups</h3>
+		<h3 id="animation-object-groups">Animation Object Groups</h3>
 
 		<p class="desc">
 
@@ -96,7 +96,7 @@
 
 		</p>
 
-		<h3>Supported Formats and Loaders</h3>
+		<h3 id="supported-formats-and-loaders">Supported Formats and Loaders</h3>
 
 		<p class="desc">
 			Note that not all model formats include animation (OBJ notably does not), and that only some
@@ -118,7 +118,7 @@
 			on the same timeline) directly to a single file.
 		</p>
 
-		<h2>Example</h2>
+		<h2 id="example">Example</h2>
 
 		<code>
 		let mesh;

--- a/docs/manual/en/introduction/Animation-system.html
+++ b/docs/manual/en/introduction/Animation-system.html
@@ -9,7 +9,7 @@
 	<body>
 		<h1>[name]</h1>
 
-		<h2 id="overview">Overview<a href="#manual/en/introduction/Animation-system#overview" class="heading-link">#</a></h2>
+		<h2 id="overview">Overview<a href="#manual/en/introduction/Animation-system#overview" target="_parent" class="heading-link">#</a></h2>
 
 		<p class="desc">
 			Within the three.js animation system you can animate various properties of your models:
@@ -28,7 +28,7 @@
 
 		</p>
 
-		<h3 id="animation-clips">Animation Clips<a href="#manual/en/introduction/Animation-system#animation-clips" class="heading-link">#</a></h3>
+		<h3 id="animation-clips">Animation Clips<a href="#manual/en/introduction/Animation-system#animation-clips" target="_parent" class="heading-link">#</a></h3>
 
 		<p class="desc">
 
@@ -45,7 +45,7 @@
 
 		</p>
 
-		<h3 id="keyframe-tracks">Keyframe Tracks<a href="#manual/en/introduction/Animation-system#keyframe-tracks" class="heading-link">#</a></h3>
+		<h3 id="keyframe-tracks">Keyframe Tracks<a href="#manual/en/introduction/Animation-system#keyframe-tracks" target="_parent" class="heading-link">#</a></h3>
 
 		<p class="desc">
 
@@ -63,7 +63,7 @@
 
 		</p>
 
-		<h3 id="animation-mixer">Animation Mixer<a href="#manual/en/introduction/Animation-system#animation-mixer" class="heading-link">#</a></h3>
+		<h3 id="animation-mixer">Animation Mixer<a href="#manual/en/introduction/Animation-system#animation-mixer" target="_parent" class="heading-link">#</a></h3>
 
 		<p class="desc">
 
@@ -74,7 +74,7 @@
 
 		</p>
 
-		<h3 id="animation-actions">Animation Actions<a href="#manual/en/introduction/Animation-system#animation-actions" class="heading-link">#</a></h3>
+		<h3 id="animation-actions">Animation Actions<a href="#manual/en/introduction/Animation-system#animation-actions" target="_parent" class="heading-link">#</a></h3>
 
 		<p class="desc">
 
@@ -87,7 +87,7 @@
 
 		</p>
 
-		<h3 id="animation-object-groups">Animation Object Groups<a href="#manual/en/introduction/Animation-system#animation-object-groups" class="heading-link">#</a></h3>
+		<h3 id="animation-object-groups">Animation Object Groups<a href="#manual/en/introduction/Animation-system#animation-object-groups" target="_parent" class="heading-link">#</a></h3>
 
 		<p class="desc">
 
@@ -96,7 +96,7 @@
 
 		</p>
 
-		<h3 id="supported-formats-and-loaders">Supported Formats and Loaders<a href="#manual/en/introduction/Animation-system#supported-formats-and-loaders" class="heading-link">#</a></h3>
+		<h3 id="supported-formats-and-loaders">Supported Formats and Loaders<a href="#manual/en/introduction/Animation-system#supported-formats-and-loaders" target="_parent" class="heading-link">#</a></h3>
 
 		<p class="desc">
 			Note that not all model formats include animation (OBJ notably does not), and that only some
@@ -118,7 +118,7 @@
 			on the same timeline) directly to a single file.
 		</p>
 
-		<h2 id="example">Example<a href="#manual/en/introduction/Animation-system#example" class="heading-link">#</a></h2>
+		<h2 id="example">Example<a href="#manual/en/introduction/Animation-system#example" target="_parent" class="heading-link">#</a></h2>
 
 		<code>
 		let mesh;

--- a/docs/manual/en/introduction/Color-management.html
+++ b/docs/manual/en/introduction/Color-management.html
@@ -53,7 +53,7 @@
 <body>
 	<h1>[name]</h1>
 
-	<h2 id="what-is-a-color-space">What is a color space?</h2>
+	<h2 id="what-is-a-color-space">What is a color space?<a href="#manual/en/introduction/Color-management#what-is-a-color-space" class="heading-link">#</a></h2>
 
 	<p>
 		Every color space is a collection of several design decisions, chosen together to support a
@@ -143,7 +143,7 @@
 		</p>
 	</blockquote>
 
-	<h2 id="roles-of-color-spaces">Roles of color spaces</h2>
+	<h2 id="roles-of-color-spaces">Roles of color spaces<a href="#manual/en/introduction/Color-management#roles-of-color-spaces" class="heading-link">#</a></h2>
 
 	<p>
 		Linear workflows — required for modern rendering methods — generally involve more than
@@ -151,7 +151,7 @@
 		appropriate for different roles, explained below.
 	</p>
 
-	<h3 id="input-color-space">Input color space</h3>
+	<h3 id="input-color-space">Input color space<a href="#manual/en/introduction/Color-management#input-color-space" class="heading-link">#</a></h3>
 
 	<p>
 		Colors supplied to three.js — from color pickers, textures, 3D models, and other sources —
@@ -206,7 +206,7 @@ THREE.ColorManagement.legacyMode = false;
 		</p>
 	</blockquote>
 
-	<h3 id="working-color-space">Working color space</h3>
+	<h3 id="working-color-space">Working color space<a href="#manual/en/introduction/Color-management#working-color-space" class="heading-link">#</a></h3>
 
 	<p>
 		Rendering, interpolation, and many other operations must be performed in an open domain
@@ -214,7 +214,7 @@ THREE.ColorManagement.legacyMode = false;
 		illumination. In three.js, the working color space is Linear-sRGB.
 	</p>
 
-	<h3 id="output-color-space">Output color space</h3>
+	<h3 id="output-color-space">Output color space<a href="#manual/en/introduction/Color-management#output-color-space" class="heading-link">#</a></h3>
 
 	<p>
 		Output to a display device, image, or video may involve conversion from the open domain
@@ -250,7 +250,7 @@ renderer.outputEncoding = THREE.sRGBEncoding; // optional with post-processing
 		</p>
 	</blockquote>
 
-	<h2 id="working-with-three-color-instances">Working with THREE.Color instances</h2>
+	<h2 id="working-with-three-color-instances">Working with THREE.Color instances<a href="#manual/en/introduction/Color-management#working-with-three-color-instances" class="heading-link">#</a></h2>
 
 	<p>
 		Methods reading or modifying [page:Color] instances assume data is already in the
@@ -295,7 +295,7 @@ renderer.outputEncoding = THREE.sRGBEncoding; // optional with post-processing
 		console.log( color.getHex( SRGBColorSpace ) ); // → 0xBCBCBC
 	</code>
 
-	<h2 id="common-mistakes">Common mistakes</h2>
+	<h2 id="common-mistakes">Common mistakes<a href="#manual/en/introduction/Color-management#common-mistakes" class="heading-link">#</a></h2>
 
 	<p>
 		When an individual color or texture is misconfigured, it will appear darker or lighter than
@@ -314,7 +314,7 @@ renderer.outputEncoding = THREE.sRGBEncoding; // optional with post-processing
 		("display referred").
 	</p>
 
-	<h2 id="further-reading">Further reading</h2>
+	<h2 id="further-reading">Further reading<a href="#manual/en/introduction/Color-management#further-reading" class="heading-link">#</a></h2>
 
 	<ul>
 		<li>

--- a/docs/manual/en/introduction/Color-management.html
+++ b/docs/manual/en/introduction/Color-management.html
@@ -53,7 +53,7 @@
 <body>
 	<h1>[name]</h1>
 
-	<h2 id="what-is-a-color-space">What is a color space?<a href="#manual/en/introduction/Color-management#what-is-a-color-space" class="heading-link">#</a></h2>
+	<h2 id="what-is-a-color-space">What is a color space?<a href="#manual/en/introduction/Color-management#what-is-a-color-space" target="_parent" class="heading-link">#</a></h2>
 
 	<p>
 		Every color space is a collection of several design decisions, chosen together to support a
@@ -143,7 +143,7 @@
 		</p>
 	</blockquote>
 
-	<h2 id="roles-of-color-spaces">Roles of color spaces<a href="#manual/en/introduction/Color-management#roles-of-color-spaces" class="heading-link">#</a></h2>
+	<h2 id="roles-of-color-spaces">Roles of color spaces<a href="#manual/en/introduction/Color-management#roles-of-color-spaces" target="_parent" class="heading-link">#</a></h2>
 
 	<p>
 		Linear workflows — required for modern rendering methods — generally involve more than
@@ -151,7 +151,7 @@
 		appropriate for different roles, explained below.
 	</p>
 
-	<h3 id="input-color-space">Input color space<a href="#manual/en/introduction/Color-management#input-color-space" class="heading-link">#</a></h3>
+	<h3 id="input-color-space">Input color space<a href="#manual/en/introduction/Color-management#input-color-space" target="_parent" class="heading-link">#</a></h3>
 
 	<p>
 		Colors supplied to three.js — from color pickers, textures, 3D models, and other sources —
@@ -206,7 +206,7 @@ THREE.ColorManagement.legacyMode = false;
 		</p>
 	</blockquote>
 
-	<h3 id="working-color-space">Working color space<a href="#manual/en/introduction/Color-management#working-color-space" class="heading-link">#</a></h3>
+	<h3 id="working-color-space">Working color space<a href="#manual/en/introduction/Color-management#working-color-space" target="_parent" class="heading-link">#</a></h3>
 
 	<p>
 		Rendering, interpolation, and many other operations must be performed in an open domain
@@ -214,7 +214,7 @@ THREE.ColorManagement.legacyMode = false;
 		illumination. In three.js, the working color space is Linear-sRGB.
 	</p>
 
-	<h3 id="output-color-space">Output color space<a href="#manual/en/introduction/Color-management#output-color-space" class="heading-link">#</a></h3>
+	<h3 id="output-color-space">Output color space<a href="#manual/en/introduction/Color-management#output-color-space" target="_parent" class="heading-link">#</a></h3>
 
 	<p>
 		Output to a display device, image, or video may involve conversion from the open domain
@@ -250,7 +250,7 @@ renderer.outputEncoding = THREE.sRGBEncoding; // optional with post-processing
 		</p>
 	</blockquote>
 
-	<h2 id="working-with-three-color-instances">Working with THREE.Color instances<a href="#manual/en/introduction/Color-management#working-with-three-color-instances" class="heading-link">#</a></h2>
+	<h2 id="working-with-three-color-instances">Working with THREE.Color instances<a href="#manual/en/introduction/Color-management#working-with-three-color-instances" target="_parent" class="heading-link">#</a></h2>
 
 	<p>
 		Methods reading or modifying [page:Color] instances assume data is already in the
@@ -295,7 +295,7 @@ renderer.outputEncoding = THREE.sRGBEncoding; // optional with post-processing
 		console.log( color.getHex( SRGBColorSpace ) ); // → 0xBCBCBC
 	</code>
 
-	<h2 id="common-mistakes">Common mistakes<a href="#manual/en/introduction/Color-management#common-mistakes" class="heading-link">#</a></h2>
+	<h2 id="common-mistakes">Common mistakes<a href="#manual/en/introduction/Color-management#common-mistakes" target="_parent" class="heading-link">#</a></h2>
 
 	<p>
 		When an individual color or texture is misconfigured, it will appear darker or lighter than
@@ -314,7 +314,7 @@ renderer.outputEncoding = THREE.sRGBEncoding; // optional with post-processing
 		("display referred").
 	</p>
 
-	<h2 id="further-reading">Further reading<a href="#manual/en/introduction/Color-management#further-reading" class="heading-link">#</a></h2>
+	<h2 id="further-reading">Further reading<a href="#manual/en/introduction/Color-management#further-reading" target="_parent" class="heading-link">#</a></h2>
 
 	<ul>
 		<li>

--- a/docs/manual/en/introduction/Color-management.html
+++ b/docs/manual/en/introduction/Color-management.html
@@ -53,7 +53,7 @@
 <body>
 	<h1>[name]</h1>
 
-	<h2>What is a color space?</h2>
+	<h2 id="what-is-a-color-space">What is a color space?</h2>
 
 	<p>
 		Every color space is a collection of several design decisions, chosen together to support a
@@ -143,7 +143,7 @@
 		</p>
 	</blockquote>
 
-	<h2>Roles of color spaces</h2>
+	<h2 id="roles-of-color-spaces">Roles of color spaces</h2>
 
 	<p>
 		Linear workflows — required for modern rendering methods — generally involve more than
@@ -151,7 +151,7 @@
 		appropriate for different roles, explained below.
 	</p>
 
-	<h3>Input color space</h3>
+	<h3 id="input-color-space">Input color space</h3>
 
 	<p>
 		Colors supplied to three.js — from color pickers, textures, 3D models, and other sources —
@@ -206,7 +206,7 @@ THREE.ColorManagement.legacyMode = false;
 		</p>
 	</blockquote>
 
-	<h3>Working color space</h3>
+	<h3 id="working-color-space">Working color space</h3>
 
 	<p>
 		Rendering, interpolation, and many other operations must be performed in an open domain
@@ -214,7 +214,7 @@ THREE.ColorManagement.legacyMode = false;
 		illumination. In three.js, the working color space is Linear-sRGB.
 	</p>
 
-	<h3>Output color space</h3>
+	<h3 id="output-color-space">Output color space</h3>
 
 	<p>
 		Output to a display device, image, or video may involve conversion from the open domain
@@ -250,7 +250,7 @@ renderer.outputEncoding = THREE.sRGBEncoding; // optional with post-processing
 		</p>
 	</blockquote>
 
-	<h2>Working with THREE.Color instances</h2>
+	<h2 id="working-with-three-color-instances">Working with THREE.Color instances</h2>
 
 	<p>
 		Methods reading or modifying [page:Color] instances assume data is already in the
@@ -295,7 +295,7 @@ renderer.outputEncoding = THREE.sRGBEncoding; // optional with post-processing
 		console.log( color.getHex( SRGBColorSpace ) ); // → 0xBCBCBC
 	</code>
 
-	<h2>Common mistakes</h2>
+	<h2 id="common-mistakes">Common mistakes</h2>
 
 	<p>
 		When an individual color or texture is misconfigured, it will appear darker or lighter than
@@ -314,7 +314,7 @@ renderer.outputEncoding = THREE.sRGBEncoding; // optional with post-processing
 		("display referred").
 	</p>
 
-	<h2>Further reading</h2>
+	<h2 id="further-reading">Further reading</h2>
 
 	<ul>
 		<li>

--- a/docs/manual/en/introduction/Creating-a-scene.html
+++ b/docs/manual/en/introduction/Creating-a-scene.html
@@ -11,7 +11,7 @@
 
 		<p>The goal of this section is to give a brief introduction to three.js. We will start by setting up a scene, with a spinning cube. A working example is provided at the bottom of the page in case you get stuck and need help.</p>
 
-		<h2 id="before-we-start">Before we start</h2>
+		<h2 id="before-we-start">Before we start<a href="#manual/en/introduction/Creating-a-scene#before-we-start" class="heading-link">#</a></h2>
 
 		<p>Before you can use three.js, you need somewhere to display it. Save the following HTML to a file on your computer, along with a copy of [link:https://threejs.org/build/three.js three.js] in the js/ directory, and open it in your browser.</p>
 
@@ -36,7 +36,7 @@
 
 		<p>That's all. All the code below goes into the empty &lt;script&gt; tag.</p>
 
-		<h2 id="creating-the-scene">Creating the scene</h2>
+		<h2 id="creating-the-scene">Creating the scene<a href="#manual/en/introduction/Creating-a-scene#creating-the-scene" class="heading-link">#</a></h2>
 
 		<p>To actually be able to display anything with three.js, we need three things: scene, camera and renderer, so that we can render the scene with camera.</p>
 
@@ -86,7 +86,7 @@
 
 		<p>By default, when we call `scene.add()`, the thing we add will be added to the coordinates `(0,0,0)`. This would cause both the camera and the cube to be inside each other. To avoid this, we simply move the camera out a bit.</p>
 
-		<h2 id="rendering-the-scene">Rendering the scene</h2>
+		<h2 id="rendering-the-scene">Rendering the scene<a href="#manual/en/introduction/Creating-a-scene#rendering-the-scene" class="heading-link">#</a></h2>
 
 		<p>If you copied the code from above into the HTML file we created earlier, you wouldn't be able to see anything. This is because we're not actually rendering anything yet. For that, we need what's called a `render or animate loop`.</p>
 
@@ -100,7 +100,7 @@
 
 		<p>This will create a loop that causes the renderer to draw the scene every time the screen is refreshed (on a typical screen this means 60 times per second). If you're new to writing games in the browser, you might say <em>"why don't we just create a setInterval ?"</em> The thing is - we could, but `requestAnimationFrame` has a number of advantages. Perhaps the most important one is that it pauses when the user navigates to another browser tab, hence not wasting their precious processing power and battery life.</p>
 
-		<h2 id="animating-the-cube">Animating the cube</h2>
+		<h2 id="animating-the-cube">Animating the cube<a href="#manual/en/introduction/Creating-a-scene#animating-the-cube" class="heading-link">#</a></h2>
 
 		<p>If you insert all the code above into the file you created before we began, you should see a green box. Let's make it all a little more interesting by rotating it.</p>
 
@@ -113,7 +113,7 @@
 
 		<p>This will be run every frame (normally 60 times per second), and give the cube a nice rotation animation. Basically, anything you want to move or change while the app is running has to go through the animate loop. You can of course call other functions from there, so that you don't end up with an `animate` function that's hundreds of lines.</p>
 
-		<h2 id="the-result">The result</h2>
+		<h2 id="the-result">The result<a href="#manual/en/introduction/Creating-a-scene#the-result" class="heading-link">#</a></h2>
 		<p>Congratulations! You have now completed your first three.js application. It's simple, but you have to start somewhere.</p>
 
 		<p>The full code is available below and as an editable [link:https://jsfiddle.net/fxurzeb4/ live example]. Play around with it to get a better understanding of how it works.</p>

--- a/docs/manual/en/introduction/Creating-a-scene.html
+++ b/docs/manual/en/introduction/Creating-a-scene.html
@@ -11,7 +11,7 @@
 
 		<p>The goal of this section is to give a brief introduction to three.js. We will start by setting up a scene, with a spinning cube. A working example is provided at the bottom of the page in case you get stuck and need help.</p>
 
-		<h2 id="before-we-start">Before we start<a href="#manual/en/introduction/Creating-a-scene#before-we-start" class="heading-link">#</a></h2>
+		<h2 id="before-we-start">Before we start<a href="#manual/en/introduction/Creating-a-scene#before-we-start" target="_parent" class="heading-link">#</a></h2>
 
 		<p>Before you can use three.js, you need somewhere to display it. Save the following HTML to a file on your computer, along with a copy of [link:https://threejs.org/build/three.js three.js] in the js/ directory, and open it in your browser.</p>
 
@@ -36,7 +36,7 @@
 
 		<p>That's all. All the code below goes into the empty &lt;script&gt; tag.</p>
 
-		<h2 id="creating-the-scene">Creating the scene<a href="#manual/en/introduction/Creating-a-scene#creating-the-scene" class="heading-link">#</a></h2>
+		<h2 id="creating-the-scene">Creating the scene<a href="#manual/en/introduction/Creating-a-scene#creating-the-scene" target="_parent" class="heading-link">#</a></h2>
 
 		<p>To actually be able to display anything with three.js, we need three things: scene, camera and renderer, so that we can render the scene with camera.</p>
 
@@ -86,7 +86,7 @@
 
 		<p>By default, when we call `scene.add()`, the thing we add will be added to the coordinates `(0,0,0)`. This would cause both the camera and the cube to be inside each other. To avoid this, we simply move the camera out a bit.</p>
 
-		<h2 id="rendering-the-scene">Rendering the scene<a href="#manual/en/introduction/Creating-a-scene#rendering-the-scene" class="heading-link">#</a></h2>
+		<h2 id="rendering-the-scene">Rendering the scene<a href="#manual/en/introduction/Creating-a-scene#rendering-the-scene" target="_parent" class="heading-link">#</a></h2>
 
 		<p>If you copied the code from above into the HTML file we created earlier, you wouldn't be able to see anything. This is because we're not actually rendering anything yet. For that, we need what's called a `render or animate loop`.</p>
 
@@ -100,7 +100,7 @@
 
 		<p>This will create a loop that causes the renderer to draw the scene every time the screen is refreshed (on a typical screen this means 60 times per second). If you're new to writing games in the browser, you might say <em>"why don't we just create a setInterval ?"</em> The thing is - we could, but `requestAnimationFrame` has a number of advantages. Perhaps the most important one is that it pauses when the user navigates to another browser tab, hence not wasting their precious processing power and battery life.</p>
 
-		<h2 id="animating-the-cube">Animating the cube<a href="#manual/en/introduction/Creating-a-scene#animating-the-cube" class="heading-link">#</a></h2>
+		<h2 id="animating-the-cube">Animating the cube<a href="#manual/en/introduction/Creating-a-scene#animating-the-cube" target="_parent" class="heading-link">#</a></h2>
 
 		<p>If you insert all the code above into the file you created before we began, you should see a green box. Let's make it all a little more interesting by rotating it.</p>
 
@@ -113,7 +113,7 @@
 
 		<p>This will be run every frame (normally 60 times per second), and give the cube a nice rotation animation. Basically, anything you want to move or change while the app is running has to go through the animate loop. You can of course call other functions from there, so that you don't end up with an `animate` function that's hundreds of lines.</p>
 
-		<h2 id="the-result">The result<a href="#manual/en/introduction/Creating-a-scene#the-result" class="heading-link">#</a></h2>
+		<h2 id="the-result">The result<a href="#manual/en/introduction/Creating-a-scene#the-result" target="_parent" class="heading-link">#</a></h2>
 		<p>Congratulations! You have now completed your first three.js application. It's simple, but you have to start somewhere.</p>
 
 		<p>The full code is available below and as an editable [link:https://jsfiddle.net/fxurzeb4/ live example]. Play around with it to get a better understanding of how it works.</p>

--- a/docs/manual/en/introduction/Creating-a-scene.html
+++ b/docs/manual/en/introduction/Creating-a-scene.html
@@ -11,7 +11,7 @@
 
 		<p>The goal of this section is to give a brief introduction to three.js. We will start by setting up a scene, with a spinning cube. A working example is provided at the bottom of the page in case you get stuck and need help.</p>
 
-		<h2>Before we start</h2>
+		<h2 id="before-we-start">Before we start</h2>
 
 		<p>Before you can use three.js, you need somewhere to display it. Save the following HTML to a file on your computer, along with a copy of [link:https://threejs.org/build/three.js three.js] in the js/ directory, and open it in your browser.</p>
 
@@ -36,7 +36,7 @@
 
 		<p>That's all. All the code below goes into the empty &lt;script&gt; tag.</p>
 
-		<h2>Creating the scene</h2>
+		<h2 id="creating-the-scene">Creating the scene</h2>
 
 		<p>To actually be able to display anything with three.js, we need three things: scene, camera and renderer, so that we can render the scene with camera.</p>
 
@@ -86,7 +86,7 @@
 
 		<p>By default, when we call `scene.add()`, the thing we add will be added to the coordinates `(0,0,0)`. This would cause both the camera and the cube to be inside each other. To avoid this, we simply move the camera out a bit.</p>
 
-		<h2>Rendering the scene</h2>
+		<h2 id="rendering-the-scene">Rendering the scene</h2>
 
 		<p>If you copied the code from above into the HTML file we created earlier, you wouldn't be able to see anything. This is because we're not actually rendering anything yet. For that, we need what's called a `render or animate loop`.</p>
 
@@ -100,7 +100,7 @@
 
 		<p>This will create a loop that causes the renderer to draw the scene every time the screen is refreshed (on a typical screen this means 60 times per second). If you're new to writing games in the browser, you might say <em>"why don't we just create a setInterval ?"</em> The thing is - we could, but `requestAnimationFrame` has a number of advantages. Perhaps the most important one is that it pauses when the user navigates to another browser tab, hence not wasting their precious processing power and battery life.</p>
 
-		<h2>Animating the cube</h2>
+		<h2 id="animating-the-cube">Animating the cube</h2>
 
 		<p>If you insert all the code above into the file you created before we began, you should see a green box. Let's make it all a little more interesting by rotating it.</p>
 
@@ -113,7 +113,7 @@
 
 		<p>This will be run every frame (normally 60 times per second), and give the cube a nice rotation animation. Basically, anything you want to move or change while the app is running has to go through the animate loop. You can of course call other functions from there, so that you don't end up with an `animate` function that's hundreds of lines.</p>
 
-		<h2>The result</h2>
+		<h2 id="the-result">The result</h2>
 		<p>Congratulations! You have now completed your first three.js application. It's simple, but you have to start somewhere.</p>
 
 		<p>The full code is available below and as an editable [link:https://jsfiddle.net/fxurzeb4/ live example]. Play around with it to get a better understanding of how it works.</p>

--- a/docs/manual/en/introduction/Creating-text.html
+++ b/docs/manual/en/introduction/Creating-text.html
@@ -15,7 +15,7 @@
 			</p>
 		</div>
 
-		<h2 id="dom-css">1. DOM + CSS<a href="#manual/en/introduction/Creating-text#dom-css" class="heading-link">#</a></h2>
+		<h2 id="dom-css">1. DOM + CSS<a href="#manual/en/introduction/Creating-text#dom-css" target="_parent" class="heading-link">#</a></h2>
 		<div>
 			<p>
 				Using HTML is generally the easiest and fastest manner to add text. This is the method
@@ -43,7 +43,7 @@
 		</div>
 
 		
-		<h2 id="use-css2drenderer-or-css3drenderer">2. Use [page:CSS2DRenderer] or [page:CSS3DRenderer]<a href="#manual/en/introduction/Creating-text#use-css2drenderer-or-css3drenderer" class="heading-link">#</a></h2>
+		<h2 id="use-css2drenderer-or-css3drenderer">2. Use [page:CSS2DRenderer] or [page:CSS3DRenderer]<a href="#manual/en/introduction/Creating-text#use-css2drenderer-or-css3drenderer" target="_parent" class="heading-link">#</a></h2>
 		<div>
 			<p>
 				Use these renderers to draw high-quality text contained in DOM elements to your three.js scene.
@@ -52,19 +52,19 @@
 		</div>
 		
 
-		<h2 id="draw-text-to-canvas-and-use-as-a-texture">3. Draw text to canvas and use as a [page:Texture]<a href="#manual/en/introduction/Creating-text#draw-text-to-canvas-and-use-as-a-texture" class="heading-link">#</a></h2>
+		<h2 id="draw-text-to-canvas-and-use-as-a-texture">3. Draw text to canvas and use as a [page:Texture]<a href="#manual/en/introduction/Creating-text#draw-text-to-canvas-and-use-as-a-texture" target="_parent" class="heading-link">#</a></h2>
 		<div>
 			<p>Use this method if you wish to draw text easily on a plane in your three.js scene.</p>
 		</div>
 
 
-		<h2 id="create-a-model-in-your-favourite-3d-application-and-export-to-threejs">4. Create a model in your favourite 3D application and export to three.js<a href="#manual/en/introduction/Creating-text#create-a-model-in-your-favourite-3d-application-and-export-to-threejs" class="heading-link">#</a></h2>
+		<h2 id="create-a-model-in-your-favourite-3d-application-and-export-to-threejs">4. Create a model in your favourite 3D application and export to three.js<a href="#manual/en/introduction/Creating-text#create-a-model-in-your-favourite-3d-application-and-export-to-threejs" target="_parent" class="heading-link">#</a></h2>
 		<div>
 			<p>Use this method if you prefer working with your 3d applications and importing the models to three.js.</p>
 		</div>
 
 
-		<h2 id="procedural-text-geometry">5. Procedural Text Geometry<a href="#manual/en/introduction/Creating-text#procedural-text-geometry" class="heading-link">#</a></h2>
+		<h2 id="procedural-text-geometry">5. Procedural Text Geometry<a href="#manual/en/introduction/Creating-text#procedural-text-geometry" target="_parent" class="heading-link">#</a></h2>
 		<div>
 			<p>
 				If you prefer to work purely in THREE.js or to create procedural and dynamic 3D
@@ -81,7 +81,7 @@
 				accepted parameter, and a list of the JSON fonts that come with the THREE.js distribution itself.
 			</p>
 
-			<h3 id="procedural-text-geometry-examples">Examples<a href="#manual/en/introduction/Creating-text#procedural-text-geometry-examples" class="heading-link">#</a></h3>
+			<h3 id="procedural-text-geometry-examples">Examples<a href="#manual/en/introduction/Creating-text#procedural-text-geometry-examples" target="_parent" class="heading-link">#</a></h3>
 
 			<p>
 				[example:webgl_geometry_text WebGL / geometry / text]<br />
@@ -97,7 +97,7 @@
 		</div>
 
 
-		<h2 id="bitmap-fonts">6. Bitmap Fonts<a href="#manual/en/introduction/Creating-text#bitmap-fonts" class="heading-link">#</a></h2>
+		<h2 id="bitmap-fonts">6. Bitmap Fonts<a href="#manual/en/introduction/Creating-text#bitmap-fonts" target="_parent" class="heading-link">#</a></h2>
 		<div>
 			<p>
 				BMFonts (bitmap fonts) allow batching glyphs into a single BufferGeometry. BMFont rendering
@@ -121,7 +121,7 @@
 		</div>
 
 
-		<h2 id="troika-text">7. Troika Text<a href="#manual/en/introduction/Creating-text#troika-text" class="heading-link">#</a></h2>
+		<h2 id="troika-text">7. Troika Text<a href="#manual/en/introduction/Creating-text#troika-text" target="_parent" class="heading-link">#</a></h2>
 		<div>
 			<p>
 				The [link:https://www.npmjs.com/package/troika-three-text troika-three-text] package renders 

--- a/docs/manual/en/introduction/Creating-text.html
+++ b/docs/manual/en/introduction/Creating-text.html
@@ -15,7 +15,7 @@
 			</p>
 		</div>
 
-		<h2>1. DOM + CSS</h2>
+		<h2 id="dom-css">1. DOM + CSS</h2>
 		<div>
 			<p>
 				Using HTML is generally the easiest and fastest manner to add text. This is the method
@@ -43,7 +43,7 @@
 		</div>
 
 		
-		<h2>2. Use [page:CSS2DRenderer] or [page:CSS3DRenderer]</h2>
+		<h2 id="use-css2drenderer-or-css3drenderer">2. Use [page:CSS2DRenderer] or [page:CSS3DRenderer]</h2>
 		<div>
 			<p>
 				Use these renderers to draw high-quality text contained in DOM elements to your three.js scene.
@@ -52,19 +52,19 @@
 		</div>
 		
 
-		<h2>3. Draw text to canvas and use as a [page:Texture]</h2>
+		<h2 id="draw-text-to-canvas-and-use-as-a-texture">3. Draw text to canvas and use as a [page:Texture]</h2>
 		<div>
 			<p>Use this method if you wish to draw text easily on a plane in your three.js scene.</p>
 		</div>
 
 
-		<h2>4. Create a model in your favourite 3D application and export to three.js</h2>
+		<h2 id="create-a-model-in-your-favourite-3d-application-and-export-to-threejs">4. Create a model in your favourite 3D application and export to three.js</h2>
 		<div>
 			<p>Use this method if you prefer working with your 3d applications and importing the models to three.js.</p>
 		</div>
 
 
-		<h2>5. Procedural Text Geometry</h2>
+		<h2 id="procedural-text-geometry">5. Procedural Text Geometry</h2>
 		<div>
 			<p>
 				If you prefer to work purely in THREE.js or to create procedural and dynamic 3D
@@ -81,7 +81,7 @@
 				accepted parameter, and a list of the JSON fonts that come with the THREE.js distribution itself.
 			</p>
 
-			<h3>Examples</h3>
+			<h3 id="procedural-text-geometry-examples">Examples</h3>
 
 			<p>
 				[example:webgl_geometry_text WebGL / geometry / text]<br />
@@ -97,7 +97,7 @@
 		</div>
 
 
-		<h2>6. Bitmap Fonts</h2>
+		<h2 id="bitmap-fonts">6. Bitmap Fonts</h2>
 		<div>
 			<p>
 				BMFonts (bitmap fonts) allow batching glyphs into a single BufferGeometry. BMFont rendering
@@ -121,7 +121,7 @@
 		</div>
 
 
-		<h2>7. Troika Text</h2>
+		<h2 id="troika-text">7. Troika Text</h2>
 		<div>
 			<p>
 				The [link:https://www.npmjs.com/package/troika-three-text troika-three-text] package renders 

--- a/docs/manual/en/introduction/Creating-text.html
+++ b/docs/manual/en/introduction/Creating-text.html
@@ -15,7 +15,7 @@
 			</p>
 		</div>
 
-		<h2 id="dom-css">1. DOM + CSS</h2>
+		<h2 id="dom-css">1. DOM + CSS<a href="#manual/en/introduction/Creating-text#dom-css" class="heading-link">#</a></h2>
 		<div>
 			<p>
 				Using HTML is generally the easiest and fastest manner to add text. This is the method
@@ -43,7 +43,7 @@
 		</div>
 
 		
-		<h2 id="use-css2drenderer-or-css3drenderer">2. Use [page:CSS2DRenderer] or [page:CSS3DRenderer]</h2>
+		<h2 id="use-css2drenderer-or-css3drenderer">2. Use [page:CSS2DRenderer] or [page:CSS3DRenderer]<a href="#manual/en/introduction/Creating-text#use-css2drenderer-or-css3drenderer" class="heading-link">#</a></h2>
 		<div>
 			<p>
 				Use these renderers to draw high-quality text contained in DOM elements to your three.js scene.
@@ -52,19 +52,19 @@
 		</div>
 		
 
-		<h2 id="draw-text-to-canvas-and-use-as-a-texture">3. Draw text to canvas and use as a [page:Texture]</h2>
+		<h2 id="draw-text-to-canvas-and-use-as-a-texture">3. Draw text to canvas and use as a [page:Texture]<a href="#manual/en/introduction/Creating-text#draw-text-to-canvas-and-use-as-a-texture" class="heading-link">#</a></h2>
 		<div>
 			<p>Use this method if you wish to draw text easily on a plane in your three.js scene.</p>
 		</div>
 
 
-		<h2 id="create-a-model-in-your-favourite-3d-application-and-export-to-threejs">4. Create a model in your favourite 3D application and export to three.js</h2>
+		<h2 id="create-a-model-in-your-favourite-3d-application-and-export-to-threejs">4. Create a model in your favourite 3D application and export to three.js<a href="#manual/en/introduction/Creating-text#create-a-model-in-your-favourite-3d-application-and-export-to-threejs" class="heading-link">#</a></h2>
 		<div>
 			<p>Use this method if you prefer working with your 3d applications and importing the models to three.js.</p>
 		</div>
 
 
-		<h2 id="procedural-text-geometry">5. Procedural Text Geometry</h2>
+		<h2 id="procedural-text-geometry">5. Procedural Text Geometry<a href="#manual/en/introduction/Creating-text#procedural-text-geometry" class="heading-link">#</a></h2>
 		<div>
 			<p>
 				If you prefer to work purely in THREE.js or to create procedural and dynamic 3D
@@ -81,7 +81,7 @@
 				accepted parameter, and a list of the JSON fonts that come with the THREE.js distribution itself.
 			</p>
 
-			<h3 id="procedural-text-geometry-examples">Examples</h3>
+			<h3 id="procedural-text-geometry-examples">Examples<a href="#manual/en/introduction/Creating-text#procedural-text-geometry-examples" class="heading-link">#</a></h3>
 
 			<p>
 				[example:webgl_geometry_text WebGL / geometry / text]<br />
@@ -97,7 +97,7 @@
 		</div>
 
 
-		<h2 id="bitmap-fonts">6. Bitmap Fonts</h2>
+		<h2 id="bitmap-fonts">6. Bitmap Fonts<a href="#manual/en/introduction/Creating-text#bitmap-fonts" class="heading-link">#</a></h2>
 		<div>
 			<p>
 				BMFonts (bitmap fonts) allow batching glyphs into a single BufferGeometry. BMFont rendering
@@ -121,7 +121,7 @@
 		</div>
 
 
-		<h2 id="troika-text">7. Troika Text</h2>
+		<h2 id="troika-text">7. Troika Text<a href="#manual/en/introduction/Creating-text#troika-text" class="heading-link">#</a></h2>
 		<div>
 			<p>
 				The [link:https://www.npmjs.com/package/troika-three-text troika-three-text] package renders 

--- a/docs/manual/en/introduction/FAQ.html
+++ b/docs/manual/en/introduction/FAQ.html
@@ -9,7 +9,7 @@
 	<body>
 		<h1>[name]</h1>
 
-		<h2 id="which-3d-model-format-is-best-supported">Which 3D model format is best supported?</h2>
+		<h2 id="which-3d-model-format-is-best-supported">Which 3D model format is best supported?<a href="#manual/en/introduction/FAQ#which-3d-model-format-is-best-supported" class="heading-link">#</a></h2>
 		<div>
 			<p>
 				The recommended format for importing and exporting assets is glTF (GL Transmission Format). Because glTF is focused on runtime asset delivery, it is compact to transmit and fast to load.
@@ -19,7 +19,7 @@
 			</p>
 		</div>
 
-		<h2 id="why-are-there-meta-viewport-tags-in-examples">Why are there meta viewport tags in examples?</h2>
+		<h2 id="why-are-there-meta-viewport-tags-in-examples">Why are there meta viewport tags in examples?<a href="#manual/en/introduction/FAQ#why-are-there-meta-viewport-tags-in-examples" class="heading-link">#</a></h2>
 		<div>
 				<code>&lt;meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0"&gt;</code>
 
@@ -30,7 +30,7 @@
 				<p>[link:https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag MDN: Using the viewport meta tag]</p>
 		</div>
 
-		<h2 id="how-can-scene-scale-be-preserved-on-resize">How can scene scale be preserved on resize?</h2>
+		<h2 id="how-can-scene-scale-be-preserved-on-resize">How can scene scale be preserved on resize?<a href="#manual/en/introduction/FAQ#how-can-scene-scale-be-preserved-on-resize" class="heading-link">#</a></h2>
 		<p>
 			We want all objects, regardless of their distance from the camera, to appear the same size, even as the window is resized.
 
@@ -46,13 +46,13 @@ visible_height = 2 * Math.tan( ( Math.PI / 180 ) * camera.fov / 2 ) * distance_f
 			[link:http://jsfiddle.net/Q4Jpu/ Example].
 		</p>
 
-		<h2 id="why-is-part-of-my-object-invisible">Why is part of my object invisible?</h2>
+		<h2 id="why-is-part-of-my-object-invisible">Why is part of my object invisible?<a href="#manual/en/introduction/FAQ#why-is-part-of-my-object-invisible" class="heading-link">#</a></h2>
 		<p>
 			This could be because of face culling. Faces have an orientation that decides which side is which. And the culling removes the backside in normal circumstances. To see if this is your problem, change the material side to THREE.DoubleSide.
 			<code>material.side = THREE.DoubleSide</code>
 		</p>
 
-		<h2 id="why-does-threejs-sometimes-return-strange-results-for-invalid-inputs">Why does three.js sometimes return strange results for invalid inputs?</h2>
+		<h2 id="why-does-threejs-sometimes-return-strange-results-for-invalid-inputs">Why does three.js sometimes return strange results for invalid inputs?<a href="#manual/en/introduction/FAQ#why-does-threejs-sometimes-return-strange-results-for-invalid-inputs" class="heading-link">#</a></h2>
 		<p>
 			For performance reasons, three.js doesn't validate inputs in most cases. It's your app's responsibility to make sure that all inputs are valid.
 		</p>

--- a/docs/manual/en/introduction/FAQ.html
+++ b/docs/manual/en/introduction/FAQ.html
@@ -9,7 +9,7 @@
 	<body>
 		<h1>[name]</h1>
 
-		<h2>Which 3D model format is best supported?</h2>
+		<h2 id="which-3d-model-format-is-best-supported">Which 3D model format is best supported?</h2>
 		<div>
 			<p>
 				The recommended format for importing and exporting assets is glTF (GL Transmission Format). Because glTF is focused on runtime asset delivery, it is compact to transmit and fast to load.
@@ -19,7 +19,7 @@
 			</p>
 		</div>
 
-		<h2>Why are there meta viewport tags in examples?</h2>
+		<h2 id="why-are-there-meta-viewport-tags-in-examples">Why are there meta viewport tags in examples?</h2>
 		<div>
 				<code>&lt;meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0"&gt;</code>
 
@@ -30,7 +30,7 @@
 				<p>[link:https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag MDN: Using the viewport meta tag]</p>
 		</div>
 
-		<h2>How can scene scale be preserved on resize?</h2>
+		<h2 id="how-can-scene-scale-be-preserved-on-resize">How can scene scale be preserved on resize?</h2>
 		<p>
 			We want all objects, regardless of their distance from the camera, to appear the same size, even as the window is resized.
 
@@ -46,13 +46,13 @@ visible_height = 2 * Math.tan( ( Math.PI / 180 ) * camera.fov / 2 ) * distance_f
 			[link:http://jsfiddle.net/Q4Jpu/ Example].
 		</p>
 
-		<h2>Why is part of my object invisible?</h2>
+		<h2 id="why-is-part-of-my-object-invisible">Why is part of my object invisible?</h2>
 		<p>
 			This could be because of face culling. Faces have an orientation that decides which side is which. And the culling removes the backside in normal circumstances. To see if this is your problem, change the material side to THREE.DoubleSide.
 			<code>material.side = THREE.DoubleSide</code>
 		</p>
 
-		<h2>Why does three.js sometimes return strange results for invalid inputs?</h2>
+		<h2 id="why-does-threejs-sometimes-return-strange-results-for-invalid-inputs">Why does three.js sometimes return strange results for invalid inputs?</h2>
 		<p>
 			For performance reasons, three.js doesn't validate inputs in most cases. It's your app's responsibility to make sure that all inputs are valid.
 		</p>

--- a/docs/manual/en/introduction/FAQ.html
+++ b/docs/manual/en/introduction/FAQ.html
@@ -9,7 +9,7 @@
 	<body>
 		<h1>[name]</h1>
 
-		<h2 id="which-3d-model-format-is-best-supported">Which 3D model format is best supported?<a href="#manual/en/introduction/FAQ#which-3d-model-format-is-best-supported" class="heading-link">#</a></h2>
+		<h2 id="which-3d-model-format-is-best-supported">Which 3D model format is best supported?<a href="#manual/en/introduction/FAQ#which-3d-model-format-is-best-supported" target="_parent" class="heading-link">#</a></h2>
 		<div>
 			<p>
 				The recommended format for importing and exporting assets is glTF (GL Transmission Format). Because glTF is focused on runtime asset delivery, it is compact to transmit and fast to load.
@@ -19,7 +19,7 @@
 			</p>
 		</div>
 
-		<h2 id="why-are-there-meta-viewport-tags-in-examples">Why are there meta viewport tags in examples?<a href="#manual/en/introduction/FAQ#why-are-there-meta-viewport-tags-in-examples" class="heading-link">#</a></h2>
+		<h2 id="why-are-there-meta-viewport-tags-in-examples">Why are there meta viewport tags in examples?<a href="#manual/en/introduction/FAQ#why-are-there-meta-viewport-tags-in-examples" target="_parent" class="heading-link">#</a></h2>
 		<div>
 				<code>&lt;meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0"&gt;</code>
 
@@ -30,7 +30,7 @@
 				<p>[link:https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag MDN: Using the viewport meta tag]</p>
 		</div>
 
-		<h2 id="how-can-scene-scale-be-preserved-on-resize">How can scene scale be preserved on resize?<a href="#manual/en/introduction/FAQ#how-can-scene-scale-be-preserved-on-resize" class="heading-link">#</a></h2>
+		<h2 id="how-can-scene-scale-be-preserved-on-resize">How can scene scale be preserved on resize?<a href="#manual/en/introduction/FAQ#how-can-scene-scale-be-preserved-on-resize" target="_parent" class="heading-link">#</a></h2>
 		<p>
 			We want all objects, regardless of their distance from the camera, to appear the same size, even as the window is resized.
 
@@ -46,13 +46,13 @@ visible_height = 2 * Math.tan( ( Math.PI / 180 ) * camera.fov / 2 ) * distance_f
 			[link:http://jsfiddle.net/Q4Jpu/ Example].
 		</p>
 
-		<h2 id="why-is-part-of-my-object-invisible">Why is part of my object invisible?<a href="#manual/en/introduction/FAQ#why-is-part-of-my-object-invisible" class="heading-link">#</a></h2>
+		<h2 id="why-is-part-of-my-object-invisible">Why is part of my object invisible?<a href="#manual/en/introduction/FAQ#why-is-part-of-my-object-invisible" target="_parent" class="heading-link">#</a></h2>
 		<p>
 			This could be because of face culling. Faces have an orientation that decides which side is which. And the culling removes the backside in normal circumstances. To see if this is your problem, change the material side to THREE.DoubleSide.
 			<code>material.side = THREE.DoubleSide</code>
 		</p>
 
-		<h2 id="why-does-threejs-sometimes-return-strange-results-for-invalid-inputs">Why does three.js sometimes return strange results for invalid inputs?<a href="#manual/en/introduction/FAQ#why-does-threejs-sometimes-return-strange-results-for-invalid-inputs" class="heading-link">#</a></h2>
+		<h2 id="why-does-threejs-sometimes-return-strange-results-for-invalid-inputs">Why does three.js sometimes return strange results for invalid inputs?<a href="#manual/en/introduction/FAQ#why-does-threejs-sometimes-return-strange-results-for-invalid-inputs" target="_parent" class="heading-link">#</a></h2>
 		<p>
 			For performance reasons, three.js doesn't validate inputs in most cases. It's your app's responsibility to make sure that all inputs are valid.
 		</p>

--- a/docs/manual/en/introduction/How-to-create-VR-content.html
+++ b/docs/manual/en/introduction/How-to-create-VR-content.html
@@ -16,7 +16,7 @@
 		made with three.js.
 	</p>
 
-	<h2 id="workflow">Workflow</h2>
+	<h2 id="workflow">Workflow<a href="#manual/en/introduction/How-to-create-VR-content#workflow" class="heading-link">#</a></h2>
 
 	<p>
 		First, you have to include [link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/webxr/VRButton.js VRButton.js]
@@ -59,7 +59,7 @@ renderer.setAnimationLoop( function () {
 } );
 	</code>
 
-	<h2 id="next-steps">Next Steps</h2>
+	<h2 id="next-steps">Next Steps<a href="#manual/en/introduction/How-to-create-VR-content#next-steps" class="heading-link">#</a></h2>
 
 	<p>
 		Have a look at one of the official WebVR examples to see this workflow in action.<br /><br />

--- a/docs/manual/en/introduction/How-to-create-VR-content.html
+++ b/docs/manual/en/introduction/How-to-create-VR-content.html
@@ -16,7 +16,7 @@
 		made with three.js.
 	</p>
 
-	<h2 id="workflow">Workflow<a href="#manual/en/introduction/How-to-create-VR-content#workflow" class="heading-link">#</a></h2>
+	<h2 id="workflow">Workflow<a href="#manual/en/introduction/How-to-create-VR-content#workflow" target="_parent" class="heading-link">#</a></h2>
 
 	<p>
 		First, you have to include [link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/webxr/VRButton.js VRButton.js]
@@ -59,7 +59,7 @@ renderer.setAnimationLoop( function () {
 } );
 	</code>
 
-	<h2 id="next-steps">Next Steps<a href="#manual/en/introduction/How-to-create-VR-content#next-steps" class="heading-link">#</a></h2>
+	<h2 id="next-steps">Next Steps<a href="#manual/en/introduction/How-to-create-VR-content#next-steps" target="_parent" class="heading-link">#</a></h2>
 
 	<p>
 		Have a look at one of the official WebVR examples to see this workflow in action.<br /><br />

--- a/docs/manual/en/introduction/How-to-create-VR-content.html
+++ b/docs/manual/en/introduction/How-to-create-VR-content.html
@@ -16,7 +16,7 @@
 		made with three.js.
 	</p>
 
-	<h2>Workflow</h2>
+	<h2 id="workflow">Workflow</h2>
 
 	<p>
 		First, you have to include [link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/webxr/VRButton.js VRButton.js]
@@ -59,7 +59,7 @@ renderer.setAnimationLoop( function () {
 } );
 	</code>
 
-	<h2>Next Steps</h2>
+	<h2 id="next-steps">Next Steps</h2>
 
 	<p>
 		Have a look at one of the official WebVR examples to see this workflow in action.<br /><br />

--- a/docs/manual/en/introduction/How-to-dispose-of-objects.html
+++ b/docs/manual/en/introduction/How-to-dispose-of-objects.html
@@ -19,7 +19,7 @@
 		This guide provides a brief overview about how this API is used and what objects are relevant in this context.
 	</p>
 
-	<h2 id="geometries">Geometries</h2>
+	<h2 id="geometries">Geometries<a href="#manual/en/introduction/How-to-dispose-of-objects#geometries" class="heading-link">#</a></h2>
 
 	<p>
 		A geometry usually represents vertex information defined as a collection of attributes. *three.js* internally creates an object of type [link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLBuffer WebGLBuffer]
@@ -27,7 +27,7 @@
 		execute the method to free all related resources.
 	</p>
 
-	<h2 id="materials">Materials</h2>
+	<h2 id="materials">Materials<a href="#manual/en/introduction/How-to-dispose-of-objects#materials" class="heading-link">#</a></h2>
 
 	<p>
 		A material defines how objects are rendered. *three.js* uses the information of a material definition in order to construct a shader program for rendering.
@@ -36,7 +36,7 @@
 		executing [page:Material.dispose]().
 	</p>
 
-	<h2 id="textures">Textures</h2>
+	<h2 id="textures">Textures<a href="#manual/en/introduction/How-to-dispose-of-objects#textures" class="heading-link">#</a></h2>
 
 	<p>
 		The disposal of a material has no effect on textures. They are handled separately since a single texture can be used by multiple materials at the same time.
@@ -49,7 +49,7 @@
 		An automated call of `ImageBitmap.close()` in [page:Texture.dispose]() is not possible, since the image bitmap becomes unusable, and the engine has no way of knowing if the image bitmap is used elsewhere.
 	</p>
 
-	<h2 id="render-targets">Render Targets</h2>
+	<h2 id="render-targets">Render Targets<a href="#manual/en/introduction/How-to-dispose-of-objects#render-targets" class="heading-link">#</a></h2>
 
 	<p>
 		Objects of type [page:WebGLRenderTarget] not only allocate an instance of [link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLTexture WebGLTexture] but also
@@ -57,16 +57,16 @@
 		for realizing custom rendering destinations. These objects are only deallocated by executing [page:WebGLRenderTarget.dispose]().
 	</p>
 
-	<h2 id="miscellaneous">Miscellaneous</h2>
+	<h2 id="miscellaneous">Miscellaneous<a href="#manual/en/introduction/How-to-dispose-of-objects#miscellaneous" class="heading-link">#</a></h2>
 
 	<p>
 		There are other classes from the examples directory like controls or post processing passes which provide `dispose()` methods in order to remove internal event listeners
 		or render targets. In general, it's recommended to check the API or documentation of a class and watch for `dispose()`. If present, you should use it when cleaning things up.
 	</p>
 
-	<h2 id="faq">FAQ</h2>
+	<h2 id="faq">FAQ<a href="#manual/en/introduction/How-to-dispose-of-objects#faq" class="heading-link">#</a></h2>
 
-	<h3 id="why-cant-threejs-dispose-objects-automatically">Why can't *three.js* dispose objects automatically?</h3>
+	<h3 id="why-cant-threejs-dispose-objects-automatically">Why can't *three.js* dispose objects automatically?<a href="#manual/en/introduction/How-to-dispose-of-objects#why-cant-threejs-dispose-objects-automatically" class="heading-link">#</a></h3>
 
 	<p>
 		This question was asked many times by the community so it's important to clarify this matter. Fact is that *three.js* does not know the lifetime or scope
@@ -75,13 +75,13 @@
 		`dispose()` method.
 	</p>
 
-	<h3 id="does-removing-a-mesh-from-the-scene-also-dispose-its-geometry-and-material">Does removing a mesh from the scene also dispose its geometry and material?</h3>
+	<h3 id="does-removing-a-mesh-from-the-scene-also-dispose-its-geometry-and-material">Does removing a mesh from the scene also dispose its geometry and material?<a href="#manual/en/introduction/How-to-dispose-of-objects#does-removing-a-mesh-from-the-scene-also-dispose-its-geometry-and-material" class="heading-link">#</a></h3>
 
 	<p>
 		No, you have to explicitly dispose the geometry and material via *dispose()*. Keep in mind that geometries and materials can be shared among 3D objects like meshes.
 	</p>
 
-	<h3 id="does-threejs-provide-information-about-the-amount-of-cached-objects">Does *three.js* provide information about the amount of cached objects?</h3>
+	<h3 id="does-threejs-provide-information-about-the-amount-of-cached-objects">Does *three.js* provide information about the amount of cached objects?<a href="#manual/en/introduction/How-to-dispose-of-objects#does-threejs-provide-information-about-the-amount-of-cached-objects" class="heading-link">#</a></h3>
 
 	<p>
 		Yes. It's possible to evaluate [page:WebGLRenderer.info], a special property of the renderer with a series of statistical information about the graphics board memory
@@ -89,21 +89,21 @@
 		in your application, it's a good idea to debug this property in order to easily identify a memory leak.
 	</p>
 
-	<h3 id="what-happens-when-you-call-dispose-on-a-texture-but-the-image-is-not-loaded-yet">What happens when you call `dispose()` on a texture but the image is not loaded yet?</h3>
+	<h3 id="what-happens-when-you-call-dispose-on-a-texture-but-the-image-is-not-loaded-yet">What happens when you call `dispose()` on a texture but the image is not loaded yet?<a href="#manual/en/introduction/How-to-dispose-of-objects#what-happens-when-you-call-dispose-on-a-texture-but-the-image-is-not-loaded-yet" class="heading-link">#</a></h3>
 
 	<p>
 		Internal resources for a texture are only allocated if the image has fully loaded. If you dispose a texture before the image was loaded,
 		nothing happens. No resources were allocated so there is also no need for clean up.
 	</p>
 
-	<h3 id="what-happens-when-i-call-dispose-and-then-use-the-respective-object-at-a-later-point">What happens when I call `dispose()` and then use the respective object at a later point?</h3>
+	<h3 id="what-happens-when-i-call-dispose-and-then-use-the-respective-object-at-a-later-point">What happens when I call `dispose()` and then use the respective object at a later point?<a href="#manual/en/introduction/How-to-dispose-of-objects#what-happens-when-i-call-dispose-and-then-use-the-respective-object-at-a-later-point" class="heading-link">#</a></h3>
 
 	<p>
 		The deleted internal resources will be created again by the engine. So no runtime error will occur but you might notice a negative performance impact for the current frame,
 		especially when shader programs have to be compiled.
 	</p>
 
-	<h3 id="how-should-i-manage-threejs-objects-in-my-app">How should I manage *three.js* objects in my app? When do I know how to dispose things?</h3>
+	<h3 id="how-should-i-manage-threejs-objects-in-my-app">How should I manage *three.js* objects in my app? When do I know how to dispose things?<a href="#manual/en/introduction/How-to-dispose-of-objects#how-should-i-manage-threejs-objects-in-my-app" class="heading-link">#</a></h3>
 
 	<p>
 		In general, there is no definite recommendation for this. It highly depends on the specific use case when calling `dispose()` is appropriate. It's important to highlight that
@@ -112,7 +112,7 @@
 		produce a runtime error if you dispose an object that is actually still in use. The worst thing that can happen is performance drop for a single frame.
 	</p>
 
-	<h2 id="dispose-usage-examples">Examples that demonstrate the usage of dispose()</h2>
+	<h2 id="dispose-usage-examples">Examples that demonstrate the usage of dispose()<a href="#manual/en/introduction/How-to-dispose-of-objects#dispose-usage-examples" class="heading-link">#</a></h2>
 
 	<p>
 		[example:webgl_test_memory WebGL / test / memory]<br />

--- a/docs/manual/en/introduction/How-to-dispose-of-objects.html
+++ b/docs/manual/en/introduction/How-to-dispose-of-objects.html
@@ -19,7 +19,7 @@
 		This guide provides a brief overview about how this API is used and what objects are relevant in this context.
 	</p>
 
-	<h2>Geometries</h2>
+	<h2 id="geometries">Geometries</h2>
 
 	<p>
 		A geometry usually represents vertex information defined as a collection of attributes. *three.js* internally creates an object of type [link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLBuffer WebGLBuffer]
@@ -27,7 +27,7 @@
 		execute the method to free all related resources.
 	</p>
 
-	<h2>Materials</h2>
+	<h2 id="materials">Materials</h2>
 
 	<p>
 		A material defines how objects are rendered. *three.js* uses the information of a material definition in order to construct a shader program for rendering.
@@ -36,7 +36,7 @@
 		executing [page:Material.dispose]().
 	</p>
 
-	<h2>Textures</h2>
+	<h2 id="textures">Textures</h2>
 
 	<p>
 		The disposal of a material has no effect on textures. They are handled separately since a single texture can be used by multiple materials at the same time.
@@ -49,7 +49,7 @@
 		An automated call of `ImageBitmap.close()` in [page:Texture.dispose]() is not possible, since the image bitmap becomes unusable, and the engine has no way of knowing if the image bitmap is used elsewhere.
 	</p>
 
-	<h2>Render Targets</h2>
+	<h2 id="render-targets">Render Targets</h2>
 
 	<p>
 		Objects of type [page:WebGLRenderTarget] not only allocate an instance of [link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLTexture WebGLTexture] but also
@@ -57,16 +57,16 @@
 		for realizing custom rendering destinations. These objects are only deallocated by executing [page:WebGLRenderTarget.dispose]().
 	</p>
 
-	<h2>Miscellaneous</h2>
+	<h2 id="miscellaneous">Miscellaneous</h2>
 
 	<p>
 		There are other classes from the examples directory like controls or post processing passes which provide `dispose()` methods in order to remove internal event listeners
 		or render targets. In general, it's recommended to check the API or documentation of a class and watch for `dispose()`. If present, you should use it when cleaning things up.
 	</p>
 
-	<h2>FAQ</h2>
+	<h2 id="faq">FAQ</h2>
 
-	<h3>Why can't *three.js* dispose objects automatically?</h3>
+	<h3 id="why-cant-threejs-dispose-objects-automatically">Why can't *three.js* dispose objects automatically?</h3>
 
 	<p>
 		This question was asked many times by the community so it's important to clarify this matter. Fact is that *three.js* does not know the lifetime or scope
@@ -75,13 +75,13 @@
 		`dispose()` method.
 	</p>
 
-	<h3>Does removing a mesh from the scene also dispose its geometry and material?</h3>
+	<h3 id="does-removing-a-mesh-from-the-scene-also-dispose-its-geometry-and-material">Does removing a mesh from the scene also dispose its geometry and material?</h3>
 
 	<p>
 		No, you have to explicitly dispose the geometry and material via *dispose()*. Keep in mind that geometries and materials can be shared among 3D objects like meshes.
 	</p>
 
-	<h3>Does *three.js* provide information about the amount of cached objects?</h3>
+	<h3 id="does-threejs-provide-information-about-the-amount-of-cached-objects">Does *three.js* provide information about the amount of cached objects?</h3>
 
 	<p>
 		Yes. It's possible to evaluate [page:WebGLRenderer.info], a special property of the renderer with a series of statistical information about the graphics board memory
@@ -89,21 +89,21 @@
 		in your application, it's a good idea to debug this property in order to easily identify a memory leak.
 	</p>
 
-	<h3>What happens when you call `dispose()` on a texture but the image is not loaded yet?</h3>
+	<h3 id="what-happens-when-you-call-dispose-on-a-texture-but-the-image-is-not-loaded-yet">What happens when you call `dispose()` on a texture but the image is not loaded yet?</h3>
 
 	<p>
 		Internal resources for a texture are only allocated if the image has fully loaded. If you dispose a texture before the image was loaded,
 		nothing happens. No resources were allocated so there is also no need for clean up.
 	</p>
 
-	<h3>What happens when I call `dispose()` and then use the respective object at a later point?</h3>
+	<h3 id="what-happens-when-i-call-dispose-and-then-use-the-respective-object-at-a-later-point">What happens when I call `dispose()` and then use the respective object at a later point?</h3>
 
 	<p>
 		The deleted internal resources will be created again by the engine. So no runtime error will occur but you might notice a negative performance impact for the current frame,
 		especially when shader programs have to be compiled.
 	</p>
 
-	<h3>How should I manage *three.js* objects in my app? When do I know how to dispose things?</h3>
+	<h3 id="how-should-i-manage-threejs-objects-in-my-app">How should I manage *three.js* objects in my app? When do I know how to dispose things?</h3>
 
 	<p>
 		In general, there is no definite recommendation for this. It highly depends on the specific use case when calling `dispose()` is appropriate. It's important to highlight that
@@ -112,7 +112,7 @@
 		produce a runtime error if you dispose an object that is actually still in use. The worst thing that can happen is performance drop for a single frame.
 	</p>
 
-	<h2>Examples that demonstrate the usage of dispose()</h2>
+	<h2 id="dispose-usage-examples">Examples that demonstrate the usage of dispose()</h2>
 
 	<p>
 		[example:webgl_test_memory WebGL / test / memory]<br />

--- a/docs/manual/en/introduction/How-to-dispose-of-objects.html
+++ b/docs/manual/en/introduction/How-to-dispose-of-objects.html
@@ -19,7 +19,7 @@
 		This guide provides a brief overview about how this API is used and what objects are relevant in this context.
 	</p>
 
-	<h2 id="geometries">Geometries<a href="#manual/en/introduction/How-to-dispose-of-objects#geometries" class="heading-link">#</a></h2>
+	<h2 id="geometries">Geometries<a href="#manual/en/introduction/How-to-dispose-of-objects#geometries" target="_parent" class="heading-link">#</a></h2>
 
 	<p>
 		A geometry usually represents vertex information defined as a collection of attributes. *three.js* internally creates an object of type [link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLBuffer WebGLBuffer]
@@ -27,7 +27,7 @@
 		execute the method to free all related resources.
 	</p>
 
-	<h2 id="materials">Materials<a href="#manual/en/introduction/How-to-dispose-of-objects#materials" class="heading-link">#</a></h2>
+	<h2 id="materials">Materials<a href="#manual/en/introduction/How-to-dispose-of-objects#materials" target="_parent" class="heading-link">#</a></h2>
 
 	<p>
 		A material defines how objects are rendered. *three.js* uses the information of a material definition in order to construct a shader program for rendering.
@@ -36,7 +36,7 @@
 		executing [page:Material.dispose]().
 	</p>
 
-	<h2 id="textures">Textures<a href="#manual/en/introduction/How-to-dispose-of-objects#textures" class="heading-link">#</a></h2>
+	<h2 id="textures">Textures<a href="#manual/en/introduction/How-to-dispose-of-objects#textures" target="_parent" class="heading-link">#</a></h2>
 
 	<p>
 		The disposal of a material has no effect on textures. They are handled separately since a single texture can be used by multiple materials at the same time.
@@ -49,7 +49,7 @@
 		An automated call of `ImageBitmap.close()` in [page:Texture.dispose]() is not possible, since the image bitmap becomes unusable, and the engine has no way of knowing if the image bitmap is used elsewhere.
 	</p>
 
-	<h2 id="render-targets">Render Targets<a href="#manual/en/introduction/How-to-dispose-of-objects#render-targets" class="heading-link">#</a></h2>
+	<h2 id="render-targets">Render Targets<a href="#manual/en/introduction/How-to-dispose-of-objects#render-targets" target="_parent" class="heading-link">#</a></h2>
 
 	<p>
 		Objects of type [page:WebGLRenderTarget] not only allocate an instance of [link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLTexture WebGLTexture] but also
@@ -57,16 +57,16 @@
 		for realizing custom rendering destinations. These objects are only deallocated by executing [page:WebGLRenderTarget.dispose]().
 	</p>
 
-	<h2 id="miscellaneous">Miscellaneous<a href="#manual/en/introduction/How-to-dispose-of-objects#miscellaneous" class="heading-link">#</a></h2>
+	<h2 id="miscellaneous">Miscellaneous<a href="#manual/en/introduction/How-to-dispose-of-objects#miscellaneous" target="_parent" class="heading-link">#</a></h2>
 
 	<p>
 		There are other classes from the examples directory like controls or post processing passes which provide `dispose()` methods in order to remove internal event listeners
 		or render targets. In general, it's recommended to check the API or documentation of a class and watch for `dispose()`. If present, you should use it when cleaning things up.
 	</p>
 
-	<h2 id="faq">FAQ<a href="#manual/en/introduction/How-to-dispose-of-objects#faq" class="heading-link">#</a></h2>
+	<h2 id="faq">FAQ<a href="#manual/en/introduction/How-to-dispose-of-objects#faq" target="_parent" class="heading-link">#</a></h2>
 
-	<h3 id="why-cant-threejs-dispose-objects-automatically">Why can't *three.js* dispose objects automatically?<a href="#manual/en/introduction/How-to-dispose-of-objects#why-cant-threejs-dispose-objects-automatically" class="heading-link">#</a></h3>
+	<h3 id="why-cant-threejs-dispose-objects-automatically">Why can't *three.js* dispose objects automatically?<a href="#manual/en/introduction/How-to-dispose-of-objects#why-cant-threejs-dispose-objects-automatically" target="_parent" class="heading-link">#</a></h3>
 
 	<p>
 		This question was asked many times by the community so it's important to clarify this matter. Fact is that *three.js* does not know the lifetime or scope
@@ -75,13 +75,13 @@
 		`dispose()` method.
 	</p>
 
-	<h3 id="does-removing-a-mesh-from-the-scene-also-dispose-its-geometry-and-material">Does removing a mesh from the scene also dispose its geometry and material?<a href="#manual/en/introduction/How-to-dispose-of-objects#does-removing-a-mesh-from-the-scene-also-dispose-its-geometry-and-material" class="heading-link">#</a></h3>
+	<h3 id="does-removing-a-mesh-from-the-scene-also-dispose-its-geometry-and-material">Does removing a mesh from the scene also dispose its geometry and material?<a href="#manual/en/introduction/How-to-dispose-of-objects#does-removing-a-mesh-from-the-scene-also-dispose-its-geometry-and-material" target="_parent" class="heading-link">#</a></h3>
 
 	<p>
 		No, you have to explicitly dispose the geometry and material via *dispose()*. Keep in mind that geometries and materials can be shared among 3D objects like meshes.
 	</p>
 
-	<h3 id="does-threejs-provide-information-about-the-amount-of-cached-objects">Does *three.js* provide information about the amount of cached objects?<a href="#manual/en/introduction/How-to-dispose-of-objects#does-threejs-provide-information-about-the-amount-of-cached-objects" class="heading-link">#</a></h3>
+	<h3 id="does-threejs-provide-information-about-the-amount-of-cached-objects">Does *three.js* provide information about the amount of cached objects?<a href="#manual/en/introduction/How-to-dispose-of-objects#does-threejs-provide-information-about-the-amount-of-cached-objects" target="_parent" class="heading-link">#</a></h3>
 
 	<p>
 		Yes. It's possible to evaluate [page:WebGLRenderer.info], a special property of the renderer with a series of statistical information about the graphics board memory
@@ -89,21 +89,21 @@
 		in your application, it's a good idea to debug this property in order to easily identify a memory leak.
 	</p>
 
-	<h3 id="what-happens-when-you-call-dispose-on-a-texture-but-the-image-is-not-loaded-yet">What happens when you call `dispose()` on a texture but the image is not loaded yet?<a href="#manual/en/introduction/How-to-dispose-of-objects#what-happens-when-you-call-dispose-on-a-texture-but-the-image-is-not-loaded-yet" class="heading-link">#</a></h3>
+	<h3 id="what-happens-when-you-call-dispose-on-a-texture-but-the-image-is-not-loaded-yet">What happens when you call `dispose()` on a texture but the image is not loaded yet?<a href="#manual/en/introduction/How-to-dispose-of-objects#what-happens-when-you-call-dispose-on-a-texture-but-the-image-is-not-loaded-yet" target="_parent" class="heading-link">#</a></h3>
 
 	<p>
 		Internal resources for a texture are only allocated if the image has fully loaded. If you dispose a texture before the image was loaded,
 		nothing happens. No resources were allocated so there is also no need for clean up.
 	</p>
 
-	<h3 id="what-happens-when-i-call-dispose-and-then-use-the-respective-object-at-a-later-point">What happens when I call `dispose()` and then use the respective object at a later point?<a href="#manual/en/introduction/How-to-dispose-of-objects#what-happens-when-i-call-dispose-and-then-use-the-respective-object-at-a-later-point" class="heading-link">#</a></h3>
+	<h3 id="what-happens-when-i-call-dispose-and-then-use-the-respective-object-at-a-later-point">What happens when I call `dispose()` and then use the respective object at a later point?<a href="#manual/en/introduction/How-to-dispose-of-objects#what-happens-when-i-call-dispose-and-then-use-the-respective-object-at-a-later-point" target="_parent" class="heading-link">#</a></h3>
 
 	<p>
 		The deleted internal resources will be created again by the engine. So no runtime error will occur but you might notice a negative performance impact for the current frame,
 		especially when shader programs have to be compiled.
 	</p>
 
-	<h3 id="how-should-i-manage-threejs-objects-in-my-app">How should I manage *three.js* objects in my app? When do I know how to dispose things?<a href="#manual/en/introduction/How-to-dispose-of-objects#how-should-i-manage-threejs-objects-in-my-app" class="heading-link">#</a></h3>
+	<h3 id="how-should-i-manage-threejs-objects-in-my-app">How should I manage *three.js* objects in my app? When do I know how to dispose things?<a href="#manual/en/introduction/How-to-dispose-of-objects#how-should-i-manage-threejs-objects-in-my-app" target="_parent" class="heading-link">#</a></h3>
 
 	<p>
 		In general, there is no definite recommendation for this. It highly depends on the specific use case when calling `dispose()` is appropriate. It's important to highlight that
@@ -112,7 +112,7 @@
 		produce a runtime error if you dispose an object that is actually still in use. The worst thing that can happen is performance drop for a single frame.
 	</p>
 
-	<h2 id="dispose-usage-examples">Examples that demonstrate the usage of dispose()<a href="#manual/en/introduction/How-to-dispose-of-objects#dispose-usage-examples" class="heading-link">#</a></h2>
+	<h2 id="dispose-usage-examples">Examples that demonstrate the usage of dispose()<a href="#manual/en/introduction/How-to-dispose-of-objects#dispose-usage-examples" target="_parent" class="heading-link">#</a></h2>
 
 	<p>
 		[example:webgl_test_memory WebGL / test / memory]<br />

--- a/docs/manual/en/introduction/How-to-run-things-locally.html
+++ b/docs/manual/en/introduction/How-to-run-things-locally.html
@@ -14,7 +14,7 @@
 			should appear working in the browser (you'll see <em>file:///yourFile.html</em> in the address bar).
 		</p>
 
-		<h2 id="content-loaded-from-external-files">Content loaded from external files</h2>
+		<h2 id="content-loaded-from-external-files">Content loaded from external files<a href="#manual/en/introduction/How-to-run-things-locally#content-loaded-from-external-files" class="heading-link">#</a></h2>
 		<div>
 			<p>
 				If you load models or textures from external files, due to browsers' [link:http://en.wikipedia.org/wiki/Same_origin_policy same origin policy]
@@ -38,7 +38,7 @@
 		</div>
 
 
-		<h2 id="run-a-local-server">Run a local server</h2>
+		<h2 id="run-a-local-server">Run a local server<a href="#manual/en/introduction/How-to-run-things-locally#run-a-local-server" class="heading-link">#</a></h2>
 		<div>
 			<p>
 				Many programming languages have simple HTTP servers built in. They are not as full featured as
@@ -46,7 +46,7 @@
 				three.js application.
 			</p>
 
-			<h3 id="plugins-for-popular-code-editors">Plugins for popular code editors</h3>
+			<h3 id="plugins-for-popular-code-editors">Plugins for popular code editors<a href="#manual/en/introduction/How-to-run-things-locally#plugins-for-popular-code-editors" class="heading-link">#</a></h3>
 			<div>
 				<p>Some code editors have plugins which will spawn a simple server on demand.</p>
 				<ul>
@@ -56,14 +56,14 @@
 				</ul>
 			</div>
 
-			<h3 id="servez">Servez</h3>
+			<h3 id="servez">Servez<a href="#manual/en/introduction/How-to-run-things-locally#servez" class="heading-link">#</a></h3>
 			<div>
 				<p>
 					[link:https://greggman.github.io/servez Servez] is a simple server with a GUI.
 				</p>
 			</div>
 
-			<h3 id="nodejs-five-server">Node.js five-server</h3>
+			<h3 id="nodejs-five-server">Node.js five-server<a href="#manual/en/introduction/How-to-run-things-locally#nodejs-five-server" class="heading-link">#</a></h3>
 			<div>
 				<p>Development server with live reload capability. To install:</p>
 				<code>
@@ -81,7 +81,7 @@ npm -g i five-server@latest
 				<code>five-server . -p 8000</code>
 			</div>
 
-			<h3 id="nodejs-http-server">Node.js http-server</h3>
+			<h3 id="nodejs-http-server">Node.js http-server<a href="#manual/en/introduction/How-to-run-things-locally#nodejs-http-server" class="heading-link">#</a></h3>
 			<div>
 				<p>Node.js has a simple HTTP server package. To install:</p>
 				<code>npm install http-server -g</code>
@@ -90,7 +90,7 @@ npm -g i five-server@latest
 				<code>http-server . -p 8000</code>
 			</div>
 
-			<h3 id="python-server">Python server</h3>
+			<h3 id="python-server">Python server<a href="#manual/en/introduction/How-to-run-things-locally#python-server" class="heading-link">#</a></h3>
 			<div>
 				<p>
 					If you have [link:http://python.org/ Python] installed, it should be enough to run this
@@ -109,7 +109,7 @@ python -m http.server
 				<code>http://localhost:8000/</code>
 			</div>
 
-			<h3 id="ruby-server">Ruby server</h3>
+			<h3 id="ruby-server">Ruby server<a href="#manual/en/introduction/How-to-run-things-locally#ruby-server" class="heading-link">#</a></h3>
 			<div>
 				<p>If you have Ruby installed, you can get the same result running this instead:</p>
 				<code>
@@ -117,13 +117,13 @@ ruby -r webrick -e "s = WEBrick::HTTPServer.new(:Port => 8000, :DocumentRoot => 
 				</code>
 			</div>
 
-			<h3 id="php-server">PHP server</h3>
+			<h3 id="php-server">PHP server<a href="#manual/en/introduction/How-to-run-things-locally#php-server" class="heading-link">#</a></h3>
 			<div>
 				<p>PHP also has a built-in web server, starting with php 5.4.0:</p>
 				<code>php -S localhost:8000</code>
 			</div>
 
-			<h3 id="lighttpd">Lighttpd</h3>
+			<h3 id="lighttpd">Lighttpd<a href="#manual/en/introduction/How-to-run-things-locally#lighttpd" class="heading-link">#</a></h3>
 			<div>
 				<p>
 					Lighttpd is a very lightweight general purpose webserver. We'll cover installing it on OSX with
@@ -153,7 +153,7 @@ ruby -r webrick -e "s = WEBrick::HTTPServer.new(:Port => 8000, :DocumentRoot => 
 					</li>
 				</ol>
 			</div>
-			<h3 id="iis">IIS</h3>
+			<h3 id="iis">IIS<a href="#manual/en/introduction/How-to-run-things-locally#iis" class="heading-link">#</a></h3>
 			<div>
 				<p>If you are using Microsoft IIS as web server. Please add a MIME type settings regarding .fbx extension before loading.</p>
 				<code>File name extension: fbx        MIME Type: text/plain</code>

--- a/docs/manual/en/introduction/How-to-run-things-locally.html
+++ b/docs/manual/en/introduction/How-to-run-things-locally.html
@@ -14,7 +14,7 @@
 			should appear working in the browser (you'll see <em>file:///yourFile.html</em> in the address bar).
 		</p>
 
-		<h2 id="content-loaded-from-external-files">Content loaded from external files<a href="#manual/en/introduction/How-to-run-things-locally#content-loaded-from-external-files" class="heading-link">#</a></h2>
+		<h2 id="content-loaded-from-external-files">Content loaded from external files<a href="#manual/en/introduction/How-to-run-things-locally#content-loaded-from-external-files" target="_parent" class="heading-link">#</a></h2>
 		<div>
 			<p>
 				If you load models or textures from external files, due to browsers' [link:http://en.wikipedia.org/wiki/Same_origin_policy same origin policy]
@@ -38,7 +38,7 @@
 		</div>
 
 
-		<h2 id="run-a-local-server">Run a local server<a href="#manual/en/introduction/How-to-run-things-locally#run-a-local-server" class="heading-link">#</a></h2>
+		<h2 id="run-a-local-server">Run a local server<a href="#manual/en/introduction/How-to-run-things-locally#run-a-local-server" target="_parent" class="heading-link">#</a></h2>
 		<div>
 			<p>
 				Many programming languages have simple HTTP servers built in. They are not as full featured as
@@ -46,7 +46,7 @@
 				three.js application.
 			</p>
 
-			<h3 id="plugins-for-popular-code-editors">Plugins for popular code editors<a href="#manual/en/introduction/How-to-run-things-locally#plugins-for-popular-code-editors" class="heading-link">#</a></h3>
+			<h3 id="plugins-for-popular-code-editors">Plugins for popular code editors<a href="#manual/en/introduction/How-to-run-things-locally#plugins-for-popular-code-editors" target="_parent" class="heading-link">#</a></h3>
 			<div>
 				<p>Some code editors have plugins which will spawn a simple server on demand.</p>
 				<ul>
@@ -56,14 +56,14 @@
 				</ul>
 			</div>
 
-			<h3 id="servez">Servez<a href="#manual/en/introduction/How-to-run-things-locally#servez" class="heading-link">#</a></h3>
+			<h3 id="servez">Servez<a href="#manual/en/introduction/How-to-run-things-locally#servez" target="_parent" class="heading-link">#</a></h3>
 			<div>
 				<p>
 					[link:https://greggman.github.io/servez Servez] is a simple server with a GUI.
 				</p>
 			</div>
 
-			<h3 id="nodejs-five-server">Node.js five-server<a href="#manual/en/introduction/How-to-run-things-locally#nodejs-five-server" class="heading-link">#</a></h3>
+			<h3 id="nodejs-five-server">Node.js five-server<a href="#manual/en/introduction/How-to-run-things-locally#nodejs-five-server" target="_parent" class="heading-link">#</a></h3>
 			<div>
 				<p>Development server with live reload capability. To install:</p>
 				<code>
@@ -81,7 +81,7 @@ npm -g i five-server@latest
 				<code>five-server . -p 8000</code>
 			</div>
 
-			<h3 id="nodejs-http-server">Node.js http-server<a href="#manual/en/introduction/How-to-run-things-locally#nodejs-http-server" class="heading-link">#</a></h3>
+			<h3 id="nodejs-http-server">Node.js http-server<a href="#manual/en/introduction/How-to-run-things-locally#nodejs-http-server" target="_parent" class="heading-link">#</a></h3>
 			<div>
 				<p>Node.js has a simple HTTP server package. To install:</p>
 				<code>npm install http-server -g</code>
@@ -90,7 +90,7 @@ npm -g i five-server@latest
 				<code>http-server . -p 8000</code>
 			</div>
 
-			<h3 id="python-server">Python server<a href="#manual/en/introduction/How-to-run-things-locally#python-server" class="heading-link">#</a></h3>
+			<h3 id="python-server">Python server<a href="#manual/en/introduction/How-to-run-things-locally#python-server" target="_parent" class="heading-link">#</a></h3>
 			<div>
 				<p>
 					If you have [link:http://python.org/ Python] installed, it should be enough to run this
@@ -109,7 +109,7 @@ python -m http.server
 				<code>http://localhost:8000/</code>
 			</div>
 
-			<h3 id="ruby-server">Ruby server<a href="#manual/en/introduction/How-to-run-things-locally#ruby-server" class="heading-link">#</a></h3>
+			<h3 id="ruby-server">Ruby server<a href="#manual/en/introduction/How-to-run-things-locally#ruby-server" target="_parent" class="heading-link">#</a></h3>
 			<div>
 				<p>If you have Ruby installed, you can get the same result running this instead:</p>
 				<code>
@@ -117,13 +117,13 @@ ruby -r webrick -e "s = WEBrick::HTTPServer.new(:Port => 8000, :DocumentRoot => 
 				</code>
 			</div>
 
-			<h3 id="php-server">PHP server<a href="#manual/en/introduction/How-to-run-things-locally#php-server" class="heading-link">#</a></h3>
+			<h3 id="php-server">PHP server<a href="#manual/en/introduction/How-to-run-things-locally#php-server" target="_parent" class="heading-link">#</a></h3>
 			<div>
 				<p>PHP also has a built-in web server, starting with php 5.4.0:</p>
 				<code>php -S localhost:8000</code>
 			</div>
 
-			<h3 id="lighttpd">Lighttpd<a href="#manual/en/introduction/How-to-run-things-locally#lighttpd" class="heading-link">#</a></h3>
+			<h3 id="lighttpd">Lighttpd<a href="#manual/en/introduction/How-to-run-things-locally#lighttpd" target="_parent" class="heading-link">#</a></h3>
 			<div>
 				<p>
 					Lighttpd is a very lightweight general purpose webserver. We'll cover installing it on OSX with
@@ -153,7 +153,7 @@ ruby -r webrick -e "s = WEBrick::HTTPServer.new(:Port => 8000, :DocumentRoot => 
 					</li>
 				</ol>
 			</div>
-			<h3 id="iis">IIS<a href="#manual/en/introduction/How-to-run-things-locally#iis" class="heading-link">#</a></h3>
+			<h3 id="iis">IIS<a href="#manual/en/introduction/How-to-run-things-locally#iis" target="_parent" class="heading-link">#</a></h3>
 			<div>
 				<p>If you are using Microsoft IIS as web server. Please add a MIME type settings regarding .fbx extension before loading.</p>
 				<code>File name extension: fbx        MIME Type: text/plain</code>

--- a/docs/manual/en/introduction/How-to-run-things-locally.html
+++ b/docs/manual/en/introduction/How-to-run-things-locally.html
@@ -14,7 +14,7 @@
 			should appear working in the browser (you'll see <em>file:///yourFile.html</em> in the address bar).
 		</p>
 
-		<h2>Content loaded from external files</h2>
+		<h2 id="content-loaded-from-external-files">Content loaded from external files</h2>
 		<div>
 			<p>
 				If you load models or textures from external files, due to browsers' [link:http://en.wikipedia.org/wiki/Same_origin_policy same origin policy]
@@ -38,7 +38,7 @@
 		</div>
 
 
-		<h2>Run a local server</h2>
+		<h2 id="run-a-local-server">Run a local server</h2>
 		<div>
 			<p>
 				Many programming languages have simple HTTP servers built in. They are not as full featured as
@@ -46,7 +46,7 @@
 				three.js application.
 			</p>
 
-			<h3>Plugins for popular code editors</h3>
+			<h3 id="plugins-for-popular-code-editors">Plugins for popular code editors</h3>
 			<div>
 				<p>Some code editors have plugins which will spawn a simple server on demand.</p>
 				<ul>
@@ -56,14 +56,14 @@
 				</ul>
 			</div>
 
-			<h3>Servez</h3>
+			<h3 id="servez">Servez</h3>
 			<div>
 				<p>
 					[link:https://greggman.github.io/servez Servez] is a simple server with a GUI.
 				</p>
 			</div>
 
-			<h3>Node.js five-server</h3>
+			<h3 id="nodejs-five-server">Node.js five-server</h3>
 			<div>
 				<p>Development server with live reload capability. To install:</p>
 				<code>
@@ -81,7 +81,7 @@ npm -g i five-server@latest
 				<code>five-server . -p 8000</code>
 			</div>
 
-			<h3>Node.js http-server</h3>
+			<h3 id="nodejs-http-server">Node.js http-server</h3>
 			<div>
 				<p>Node.js has a simple HTTP server package. To install:</p>
 				<code>npm install http-server -g</code>
@@ -90,7 +90,7 @@ npm -g i five-server@latest
 				<code>http-server . -p 8000</code>
 			</div>
 
-			<h3>Python server</h3>
+			<h3 id="python-server">Python server</h3>
 			<div>
 				<p>
 					If you have [link:http://python.org/ Python] installed, it should be enough to run this
@@ -109,7 +109,7 @@ python -m http.server
 				<code>http://localhost:8000/</code>
 			</div>
 
-			<h3>Ruby server</h3>
+			<h3 id="ruby-server">Ruby server</h3>
 			<div>
 				<p>If you have Ruby installed, you can get the same result running this instead:</p>
 				<code>
@@ -117,13 +117,13 @@ ruby -r webrick -e "s = WEBrick::HTTPServer.new(:Port => 8000, :DocumentRoot => 
 				</code>
 			</div>
 
-			<h3>PHP server</h3>
+			<h3 id="php-server">PHP server</h3>
 			<div>
 				<p>PHP also has a built-in web server, starting with php 5.4.0:</p>
 				<code>php -S localhost:8000</code>
 			</div>
 
-			<h3>Lighttpd</h3>
+			<h3 id="lighttpd">Lighttpd</h3>
 			<div>
 				<p>
 					Lighttpd is a very lightweight general purpose webserver. We'll cover installing it on OSX with
@@ -153,7 +153,7 @@ ruby -r webrick -e "s = WEBrick::HTTPServer.new(:Port => 8000, :DocumentRoot => 
 					</li>
 				</ol>
 			</div>
-			<h3>IIS</h3>
+			<h3 id="iis">IIS</h3>
 			<div>
 				<p>If you are using Microsoft IIS as web server. Please add a MIME type settings regarding .fbx extension before loading.</p>
 				<code>File name extension: fbx        MIME Type: text/plain</code>

--- a/docs/manual/en/introduction/How-to-update-things.html
+++ b/docs/manual/en/introduction/How-to-update-things.html
@@ -31,7 +31,7 @@ object.matrixAutoUpdate = false;
 object.updateMatrix();
 		</code>
 
-		<h2 id="buffergeometry">BufferGeometry<a href="#manual/en/introduction/How-to-update-things#buffergeometry" class="heading-link">#</a></h2>
+		<h2 id="buffergeometry">BufferGeometry<a href="#manual/en/introduction/How-to-update-things#buffergeometry" target="_parent" class="heading-link">#</a></h2>
 		<div>
 			<p>
 				BufferGeometries store information (such as vertex positions, face indices, normals, colors,
@@ -124,7 +124,7 @@ line.geometry.computeBoundingSphere();
 				[link:https://jsfiddle.net/t4m85pLr/1/ Here is a fiddle] showing an animated line which you can adapt to your use case.
 			</p>
 
-			<h3 id="buffergeometry-examples">Examples<a href="#manual/en/introduction/How-to-update-things#buffergeometry-examples" class="heading-link">#</a></h3>
+			<h3 id="buffergeometry-examples">Examples<a href="#manual/en/introduction/How-to-update-things#buffergeometry-examples" target="_parent" class="heading-link">#</a></h3>
 
 			<p>
 				[example:webgl_custom_attributes WebGL / custom / attributes]<br />
@@ -133,7 +133,7 @@ line.geometry.computeBoundingSphere();
 
 		</div>
 
-		<h2 id="materials">Materials<a href="#manual/en/introduction/How-to-update-things#materials" class="heading-link">#</a></h2>
+		<h2 id="materials">Materials<a href="#manual/en/introduction/How-to-update-things#materials" target="_parent" class="heading-link">#</a></h2>
 		<div>
 			<p>All uniforms values can be changed freely (e.g. colors, textures, opacity, etc), values are sent to the shader every frame.</p>
 
@@ -164,12 +164,12 @@ line.geometry.computeBoundingSphere();
 
 			<p>You can freely change the material used for geometry chunks, however you cannot change how an object is divided into chunks (according to face materials). </p>
 
-			<h3 id="if-you-need-to-have-different-configurations-of-materials-during-runtime">If you need to have different configurations of materials during runtime:<a href="#manual/en/introduction/How-to-update-things#if-you-need-to-have-different-configurations-of-materials-during-runtime" class="heading-link">#</a></h3>
+			<h3 id="if-you-need-to-have-different-configurations-of-materials-during-runtime">If you need to have different configurations of materials during runtime:<a href="#manual/en/introduction/How-to-update-things#if-you-need-to-have-different-configurations-of-materials-during-runtime" target="_parent" class="heading-link">#</a></h3>
 			<p>If the number of materials / chunks is small, you could pre-divide the object beforehand (e.g. hair / face / body / upper clothes / trousers for a human, front / sides / top / glass / tire / interior for a car). </p>
 
 			<p>If the number is large (e.g. each face could be potentially different), consider a different solution, such as using attributes / textures to drive different per-face look.</p>
 
-			<h3 id="materials-examples">Examples<a href="#manual/en/introduction/How-to-update-things#materials-examples" class="heading-link">#</a></h3>
+			<h3 id="materials-examples">Examples<a href="#manual/en/introduction/How-to-update-things#materials-examples" target="_parent" class="heading-link">#</a></h3>
 			<p>
 				[example:webgl_materials_car WebGL / materials / car]<br />
 				[example:webgl_postprocessing_dof WebGL / webgl_postprocessing / dof]
@@ -177,7 +177,7 @@ line.geometry.computeBoundingSphere();
 		</div>
 
 
-		<h2 id="textures">Textures<a href="#manual/en/introduction/How-to-update-things#textures" class="heading-link">#</a></h2>
+		<h2 id="textures">Textures<a href="#manual/en/introduction/How-to-update-things#textures" target="_parent" class="heading-link">#</a></h2>
 		<div>
 			<p>Image, canvas, video and data textures need to have the following flag set if they are changed:</p>
 			<code>
@@ -185,7 +185,7 @@ line.geometry.computeBoundingSphere();
 			</code>
 			<p>Render targets update automatically.</p>
 
-			<h3 id="textures-examples">Examples<a href="#manual/en/introduction/How-to-update-things#textures-examples" class="heading-link">#</a></h3>
+			<h3 id="textures-examples">Examples<a href="#manual/en/introduction/How-to-update-things#textures-examples" target="_parent" class="heading-link">#</a></h3>
 			<p>
 				[example:webgl_materials_video WebGL / materials / video]<br />
 				[example:webgl_rtt WebGL / rtt]
@@ -194,7 +194,7 @@ line.geometry.computeBoundingSphere();
 		</div>
 
 
-		<h2 id="cameras">Cameras<a href="#manual/en/introduction/How-to-update-things#cameras" class="heading-link">#</a></h2>
+		<h2 id="cameras">Cameras<a href="#manual/en/introduction/How-to-update-things#cameras" target="_parent" class="heading-link">#</a></h2>
 		<div>
 			<p>A camera's position and target is updated automatically. If you need to change</p>
 			<ul>

--- a/docs/manual/en/introduction/How-to-update-things.html
+++ b/docs/manual/en/introduction/How-to-update-things.html
@@ -31,7 +31,7 @@ object.matrixAutoUpdate = false;
 object.updateMatrix();
 		</code>
 
-		<h2>BufferGeometry</h2>
+		<h2 id="buffergeometry">BufferGeometry</h2>
 		<div>
 			<p>
 				BufferGeometries store information (such as vertex positions, face indices, normals, colors,
@@ -124,7 +124,7 @@ line.geometry.computeBoundingSphere();
 				[link:https://jsfiddle.net/t4m85pLr/1/ Here is a fiddle] showing an animated line which you can adapt to your use case.
 			</p>
 
-			<h3>Examples</h3>
+			<h3 id="buffergeometry-examples">Examples</h3>
 
 			<p>
 				[example:webgl_custom_attributes WebGL / custom / attributes]<br />
@@ -133,7 +133,7 @@ line.geometry.computeBoundingSphere();
 
 		</div>
 
-		<h2>Materials</h2>
+		<h2 id="materials">Materials</h2>
 		<div>
 			<p>All uniforms values can be changed freely (e.g. colors, textures, opacity, etc), values are sent to the shader every frame.</p>
 
@@ -164,12 +164,12 @@ line.geometry.computeBoundingSphere();
 
 			<p>You can freely change the material used for geometry chunks, however you cannot change how an object is divided into chunks (according to face materials). </p>
 
-			<h3>If you need to have different configurations of materials during runtime:</h3>
+			<h3 id="if-you-need-to-have-different-configurations-of-materials-during-runtime">If you need to have different configurations of materials during runtime:</h3>
 			<p>If the number of materials / chunks is small, you could pre-divide the object beforehand (e.g. hair / face / body / upper clothes / trousers for a human, front / sides / top / glass / tire / interior for a car). </p>
 
 			<p>If the number is large (e.g. each face could be potentially different), consider a different solution, such as using attributes / textures to drive different per-face look.</p>
 
-			<h3>Examples</h3>
+			<h3 id="materials-examples">Examples</h3>
 			<p>
 				[example:webgl_materials_car WebGL / materials / car]<br />
 				[example:webgl_postprocessing_dof WebGL / webgl_postprocessing / dof]
@@ -177,7 +177,7 @@ line.geometry.computeBoundingSphere();
 		</div>
 
 
-		<h2>Textures</h2>
+		<h2 id="textures">Textures</h2>
 		<div>
 			<p>Image, canvas, video and data textures need to have the following flag set if they are changed:</p>
 			<code>
@@ -185,7 +185,7 @@ line.geometry.computeBoundingSphere();
 			</code>
 			<p>Render targets update automatically.</p>
 
-			<h3>Examples</h3>
+			<h3 id="textures-examples">Examples</h3>
 			<p>
 				[example:webgl_materials_video WebGL / materials / video]<br />
 				[example:webgl_rtt WebGL / rtt]
@@ -194,7 +194,7 @@ line.geometry.computeBoundingSphere();
 		</div>
 
 
-		<h2>Cameras</h2>
+		<h2 id="cameras">Cameras</h2>
 		<div>
 			<p>A camera's position and target is updated automatically. If you need to change</p>
 			<ul>

--- a/docs/manual/en/introduction/How-to-update-things.html
+++ b/docs/manual/en/introduction/How-to-update-things.html
@@ -31,7 +31,7 @@ object.matrixAutoUpdate = false;
 object.updateMatrix();
 		</code>
 
-		<h2 id="buffergeometry">BufferGeometry</h2>
+		<h2 id="buffergeometry">BufferGeometry<a href="#manual/en/introduction/How-to-update-things#buffergeometry" class="heading-link">#</a></h2>
 		<div>
 			<p>
 				BufferGeometries store information (such as vertex positions, face indices, normals, colors,
@@ -124,7 +124,7 @@ line.geometry.computeBoundingSphere();
 				[link:https://jsfiddle.net/t4m85pLr/1/ Here is a fiddle] showing an animated line which you can adapt to your use case.
 			</p>
 
-			<h3 id="buffergeometry-examples">Examples</h3>
+			<h3 id="buffergeometry-examples">Examples<a href="#manual/en/introduction/How-to-update-things#buffergeometry-examples" class="heading-link">#</a></h3>
 
 			<p>
 				[example:webgl_custom_attributes WebGL / custom / attributes]<br />
@@ -133,7 +133,7 @@ line.geometry.computeBoundingSphere();
 
 		</div>
 
-		<h2 id="materials">Materials</h2>
+		<h2 id="materials">Materials<a href="#manual/en/introduction/How-to-update-things#materials" class="heading-link">#</a></h2>
 		<div>
 			<p>All uniforms values can be changed freely (e.g. colors, textures, opacity, etc), values are sent to the shader every frame.</p>
 
@@ -164,12 +164,12 @@ line.geometry.computeBoundingSphere();
 
 			<p>You can freely change the material used for geometry chunks, however you cannot change how an object is divided into chunks (according to face materials). </p>
 
-			<h3 id="if-you-need-to-have-different-configurations-of-materials-during-runtime">If you need to have different configurations of materials during runtime:</h3>
+			<h3 id="if-you-need-to-have-different-configurations-of-materials-during-runtime">If you need to have different configurations of materials during runtime:<a href="#manual/en/introduction/How-to-update-things#if-you-need-to-have-different-configurations-of-materials-during-runtime" class="heading-link">#</a></h3>
 			<p>If the number of materials / chunks is small, you could pre-divide the object beforehand (e.g. hair / face / body / upper clothes / trousers for a human, front / sides / top / glass / tire / interior for a car). </p>
 
 			<p>If the number is large (e.g. each face could be potentially different), consider a different solution, such as using attributes / textures to drive different per-face look.</p>
 
-			<h3 id="materials-examples">Examples</h3>
+			<h3 id="materials-examples">Examples<a href="#manual/en/introduction/How-to-update-things#materials-examples" class="heading-link">#</a></h3>
 			<p>
 				[example:webgl_materials_car WebGL / materials / car]<br />
 				[example:webgl_postprocessing_dof WebGL / webgl_postprocessing / dof]
@@ -177,7 +177,7 @@ line.geometry.computeBoundingSphere();
 		</div>
 
 
-		<h2 id="textures">Textures</h2>
+		<h2 id="textures">Textures<a href="#manual/en/introduction/How-to-update-things#textures" class="heading-link">#</a></h2>
 		<div>
 			<p>Image, canvas, video and data textures need to have the following flag set if they are changed:</p>
 			<code>
@@ -185,7 +185,7 @@ line.geometry.computeBoundingSphere();
 			</code>
 			<p>Render targets update automatically.</p>
 
-			<h3 id="textures-examples">Examples</h3>
+			<h3 id="textures-examples">Examples<a href="#manual/en/introduction/How-to-update-things#textures-examples" class="heading-link">#</a></h3>
 			<p>
 				[example:webgl_materials_video WebGL / materials / video]<br />
 				[example:webgl_rtt WebGL / rtt]
@@ -194,7 +194,7 @@ line.geometry.computeBoundingSphere();
 		</div>
 
 
-		<h2 id="cameras">Cameras</h2>
+		<h2 id="cameras">Cameras<a href="#manual/en/introduction/How-to-update-things#cameras" class="heading-link">#</a></h2>
 		<div>
 			<p>A camera's position and target is updated automatically. If you need to change</p>
 			<ul>

--- a/docs/manual/en/introduction/How-to-use-post-processing.html
+++ b/docs/manual/en/introduction/How-to-use-post-processing.html
@@ -20,7 +20,7 @@
 			three.js provides a complete post-processing solution via [page:EffectComposer] to implement such a workflow.
 		</p>
 
-		<h2>Workflow</h2>
+		<h2 id="workflow">Workflow</h2>
 
 		<p>
 			The first step in the process is to import all necessary files from the examples directory. The guide assumes you are using the official
@@ -77,14 +77,14 @@
 			to see it in action.
 		</p>
 
-		<h2>Built-in Passes</h2>
+		<h2 id="built-in-passes">Built-in Passes</h2>
 
 		<p>
 			You can use a wide range of pre-defined post-processing passes provided by the engine. They are located in the
 			[link:https://github.com/mrdoob/three.js/tree/dev/examples/jsm/postprocessing postprocessing] directory.
 		</p>
 
-		<h2>Custom Passes</h2>
+		<h2 id="custom-passes">Custom Passes</h2>
 
 		<p>
 			Sometimes you want to write a custom post-processing shader and include it into the chain of post-processing passes. For this scenario,

--- a/docs/manual/en/introduction/How-to-use-post-processing.html
+++ b/docs/manual/en/introduction/How-to-use-post-processing.html
@@ -20,7 +20,7 @@
 			three.js provides a complete post-processing solution via [page:EffectComposer] to implement such a workflow.
 		</p>
 
-		<h2 id="workflow">Workflow</h2>
+		<h2 id="workflow">Workflow<a href="#manual/en/introduction/How-to-use-post-processing#workflow" class="heading-link">#</a></h2>
 
 		<p>
 			The first step in the process is to import all necessary files from the examples directory. The guide assumes you are using the official
@@ -77,14 +77,14 @@
 			to see it in action.
 		</p>
 
-		<h2 id="built-in-passes">Built-in Passes</h2>
+		<h2 id="built-in-passes">Built-in Passes<a href="#manual/en/introduction/How-to-use-post-processing#built-in-passes" class="heading-link">#</a></h2>
 
 		<p>
 			You can use a wide range of pre-defined post-processing passes provided by the engine. They are located in the
 			[link:https://github.com/mrdoob/three.js/tree/dev/examples/jsm/postprocessing postprocessing] directory.
 		</p>
 
-		<h2 id="custom-passes">Custom Passes</h2>
+		<h2 id="custom-passes">Custom Passes<a href="#manual/en/introduction/How-to-use-post-processing#custom-passes" class="heading-link">#</a></h2>
 
 		<p>
 			Sometimes you want to write a custom post-processing shader and include it into the chain of post-processing passes. For this scenario,

--- a/docs/manual/en/introduction/How-to-use-post-processing.html
+++ b/docs/manual/en/introduction/How-to-use-post-processing.html
@@ -20,7 +20,7 @@
 			three.js provides a complete post-processing solution via [page:EffectComposer] to implement such a workflow.
 		</p>
 
-		<h2 id="workflow">Workflow<a href="#manual/en/introduction/How-to-use-post-processing#workflow" class="heading-link">#</a></h2>
+		<h2 id="workflow">Workflow<a href="#manual/en/introduction/How-to-use-post-processing#workflow" target="_parent" class="heading-link">#</a></h2>
 
 		<p>
 			The first step in the process is to import all necessary files from the examples directory. The guide assumes you are using the official
@@ -77,14 +77,14 @@
 			to see it in action.
 		</p>
 
-		<h2 id="built-in-passes">Built-in Passes<a href="#manual/en/introduction/How-to-use-post-processing#built-in-passes" class="heading-link">#</a></h2>
+		<h2 id="built-in-passes">Built-in Passes<a href="#manual/en/introduction/How-to-use-post-processing#built-in-passes" target="_parent" class="heading-link">#</a></h2>
 
 		<p>
 			You can use a wide range of pre-defined post-processing passes provided by the engine. They are located in the
 			[link:https://github.com/mrdoob/three.js/tree/dev/examples/jsm/postprocessing postprocessing] directory.
 		</p>
 
-		<h2 id="custom-passes">Custom Passes<a href="#manual/en/introduction/How-to-use-post-processing#custom-passes" class="heading-link">#</a></h2>
+		<h2 id="custom-passes">Custom Passes<a href="#manual/en/introduction/How-to-use-post-processing#custom-passes" target="_parent" class="heading-link">#</a></h2>
 
 		<p>
 			Sometimes you want to write a custom post-processing shader and include it into the chain of post-processing passes. For this scenario,

--- a/docs/manual/en/introduction/Installation.html
+++ b/docs/manual/en/introduction/Installation.html
@@ -21,7 +21,7 @@
 			All methods of installing three.js depend on ES modules (see [link:https://eloquentjavascript.net/10_modules.html#h_hF2FmOVxw7 Eloquent JavaScript: ECMAScript Modules]), which allow you to include only the parts of the library needed in the final project.
 		</p>
 
-		<h2>Install from npm</h2>
+		<h2 id="install-from-npm">Install from npm</h2>
 
 		<p>
 			To install the [link:https://www.npmjs.com/package/three three] npm module, open a terminal window in your project folder and run:
@@ -60,7 +60,7 @@
 			Learn more about npm modules from [link:https://eloquentjavascript.net/20_node.html#h_J6hW/SmL/a Eloquent JavaScript: Installing with npm].
 		</p>
 
-		<h2>Install from CDN or static hosting</h2>
+		<h2 id="install-from-cdn-or-static-hosting">Install from CDN or static hosting</h2>
 
 		<p>
 			The three.js library can be used without any build system, either by uploading files to your own web server or by using an existing CDN. Because the library relies on ES modules, any script that references it must use <em>type="module"</em> as shown below.
@@ -91,7 +91,7 @@
 			Since Import maps are not yet supported by all browsers, it is necessary to add the polyfill *es-module-shims.js*.
 		</p>
 
-		<h2>Examples</h2>
+		<h2 id="examples">Examples</h2>
 
 		<p>
 			The core of three.js is focused on the most important components of a 3D engine. Many other useful components — such as controls, loaders, and post-processing effects — are part of the [link:https://github.com/mrdoob/three.js/tree/dev/examples/jsm examples/jsm] directory. They are referred to as "examples," because while you can use them off the shelf, they're also meant to be remixed and customized. These components are always kept in sync with the core library, whereas similar third-party packages on npm are maintained by different people and may not be up to date.
@@ -126,15 +126,15 @@
 			It's important that all files use the same version. Do not import different examples from different versions, or use examples from a different version than the three.js library itself.
 		</p>
 
-		<h2>Compatibility</h2>
+		<h2 id="compatibility">Compatibility</h2>
 
-		<h3>CommonJS imports</h3>
+		<h3 id="commonjs-imports">CommonJS imports</h3>
 
 		<p>
 			While most modern JavaScript bundlers now support ES modules by default, some older build tools might not. In those cases you can likely configure the bundler to understand ES modules: [link:http://browserify.org/ Browserify] just needs the [link:https://github.com/babel/babelify babelify] plugin, for example.
 		</p>
 
-		<h3>Node.js</h3>
+		<h3 id="nodejs">Node.js</h3>
 
 		<p>
 			Because three.js is built for the web, it depends on browser and DOM APIs that don't always exist in Node.js. Some of these issues can be resolved by using shims like [link:https://github.com/stackgl/headless-gl headless-gl], or by replacing components like [page:TextureLoader] with custom alternatives. Other DOM APIs may be deeply intertwined with the code that uses them, and will be harder to work around. We welcome simple and maintainable pull requests to improve Node.js support, but recommend opening an issue to discuss your improvements first.

--- a/docs/manual/en/introduction/Installation.html
+++ b/docs/manual/en/introduction/Installation.html
@@ -21,7 +21,7 @@
 			All methods of installing three.js depend on ES modules (see [link:https://eloquentjavascript.net/10_modules.html#h_hF2FmOVxw7 Eloquent JavaScript: ECMAScript Modules]), which allow you to include only the parts of the library needed in the final project.
 		</p>
 
-		<h2 id="install-from-npm">Install from npm<a href="#manual/en/introduction/Installation#install-from-npm" class="heading-link">#</a></h2>
+		<h2 id="install-from-npm">Install from npm<a href="#manual/en/introduction/Installation#install-from-npm" target="_parent" class="heading-link">#</a></h2>
 
 		<p>
 			To install the [link:https://www.npmjs.com/package/three three] npm module, open a terminal window in your project folder and run:
@@ -60,7 +60,7 @@
 			Learn more about npm modules from [link:https://eloquentjavascript.net/20_node.html#h_J6hW/SmL/a Eloquent JavaScript: Installing with npm].
 		</p>
 
-		<h2 id="install-from-cdn-or-static-hosting">Install from CDN or static hosting<a href="#manual/en/introduction/Installation#install-from-cdn-or-static-hosting" class="heading-link">#</a></h2>
+		<h2 id="install-from-cdn-or-static-hosting">Install from CDN or static hosting<a href="#manual/en/introduction/Installation#install-from-cdn-or-static-hosting" target="_parent" class="heading-link">#</a></h2>
 
 		<p>
 			The three.js library can be used without any build system, either by uploading files to your own web server or by using an existing CDN. Because the library relies on ES modules, any script that references it must use <em>type="module"</em> as shown below.
@@ -91,7 +91,7 @@
 			Since Import maps are not yet supported by all browsers, it is necessary to add the polyfill *es-module-shims.js*.
 		</p>
 
-		<h2 id="examples">Examples<a href="#manual/en/introduction/Installation#examples" class="heading-link">#</a></h2>
+		<h2 id="examples">Examples<a href="#manual/en/introduction/Installation#examples" target="_parent" class="heading-link">#</a></h2>
 
 		<p>
 			The core of three.js is focused on the most important components of a 3D engine. Many other useful components — such as controls, loaders, and post-processing effects — are part of the [link:https://github.com/mrdoob/three.js/tree/dev/examples/jsm examples/jsm] directory. They are referred to as "examples," because while you can use them off the shelf, they're also meant to be remixed and customized. These components are always kept in sync with the core library, whereas similar third-party packages on npm are maintained by different people and may not be up to date.
@@ -126,15 +126,15 @@
 			It's important that all files use the same version. Do not import different examples from different versions, or use examples from a different version than the three.js library itself.
 		</p>
 
-		<h2 id="compatibility">Compatibility<a href="#manual/en/introduction/Installation#compatibility" class="heading-link">#</a></h2>
+		<h2 id="compatibility">Compatibility<a href="#manual/en/introduction/Installation#compatibility" target="_parent" class="heading-link">#</a></h2>
 
-		<h3 id="commonjs-imports">CommonJS imports<a href="#manual/en/introduction/Installation#commonjs-imports" class="heading-link">#</a></h3>
+		<h3 id="commonjs-imports">CommonJS imports<a href="#manual/en/introduction/Installation#commonjs-imports" target="_parent" class="heading-link">#</a></h3>
 
 		<p>
 			While most modern JavaScript bundlers now support ES modules by default, some older build tools might not. In those cases you can likely configure the bundler to understand ES modules: [link:http://browserify.org/ Browserify] just needs the [link:https://github.com/babel/babelify babelify] plugin, for example.
 		</p>
 
-		<h3 id="nodejs">Node.js<a href="#manual/en/introduction/Installation#nodejs" class="heading-link">#</a></h3>
+		<h3 id="nodejs">Node.js<a href="#manual/en/introduction/Installation#nodejs" target="_parent" class="heading-link">#</a></h3>
 
 		<p>
 			Because three.js is built for the web, it depends on browser and DOM APIs that don't always exist in Node.js. Some of these issues can be resolved by using shims like [link:https://github.com/stackgl/headless-gl headless-gl], or by replacing components like [page:TextureLoader] with custom alternatives. Other DOM APIs may be deeply intertwined with the code that uses them, and will be harder to work around. We welcome simple and maintainable pull requests to improve Node.js support, but recommend opening an issue to discuss your improvements first.

--- a/docs/manual/en/introduction/Installation.html
+++ b/docs/manual/en/introduction/Installation.html
@@ -21,7 +21,7 @@
 			All methods of installing three.js depend on ES modules (see [link:https://eloquentjavascript.net/10_modules.html#h_hF2FmOVxw7 Eloquent JavaScript: ECMAScript Modules]), which allow you to include only the parts of the library needed in the final project.
 		</p>
 
-		<h2 id="install-from-npm">Install from npm</h2>
+		<h2 id="install-from-npm">Install from npm<a href="#manual/en/introduction/Installation#install-from-npm" class="heading-link">#</a></h2>
 
 		<p>
 			To install the [link:https://www.npmjs.com/package/three three] npm module, open a terminal window in your project folder and run:
@@ -60,7 +60,7 @@
 			Learn more about npm modules from [link:https://eloquentjavascript.net/20_node.html#h_J6hW/SmL/a Eloquent JavaScript: Installing with npm].
 		</p>
 
-		<h2 id="install-from-cdn-or-static-hosting">Install from CDN or static hosting</h2>
+		<h2 id="install-from-cdn-or-static-hosting">Install from CDN or static hosting<a href="#manual/en/introduction/Installation#install-from-cdn-or-static-hosting" class="heading-link">#</a></h2>
 
 		<p>
 			The three.js library can be used without any build system, either by uploading files to your own web server or by using an existing CDN. Because the library relies on ES modules, any script that references it must use <em>type="module"</em> as shown below.
@@ -91,7 +91,7 @@
 			Since Import maps are not yet supported by all browsers, it is necessary to add the polyfill *es-module-shims.js*.
 		</p>
 
-		<h2 id="examples">Examples</h2>
+		<h2 id="examples">Examples<a href="#manual/en/introduction/Installation#examples" class="heading-link">#</a></h2>
 
 		<p>
 			The core of three.js is focused on the most important components of a 3D engine. Many other useful components — such as controls, loaders, and post-processing effects — are part of the [link:https://github.com/mrdoob/three.js/tree/dev/examples/jsm examples/jsm] directory. They are referred to as "examples," because while you can use them off the shelf, they're also meant to be remixed and customized. These components are always kept in sync with the core library, whereas similar third-party packages on npm are maintained by different people and may not be up to date.
@@ -126,15 +126,15 @@
 			It's important that all files use the same version. Do not import different examples from different versions, or use examples from a different version than the three.js library itself.
 		</p>
 
-		<h2 id="compatibility">Compatibility</h2>
+		<h2 id="compatibility">Compatibility<a href="#manual/en/introduction/Installation#compatibility" class="heading-link">#</a></h2>
 
-		<h3 id="commonjs-imports">CommonJS imports</h3>
+		<h3 id="commonjs-imports">CommonJS imports<a href="#manual/en/introduction/Installation#commonjs-imports" class="heading-link">#</a></h3>
 
 		<p>
 			While most modern JavaScript bundlers now support ES modules by default, some older build tools might not. In those cases you can likely configure the bundler to understand ES modules: [link:http://browserify.org/ Browserify] just needs the [link:https://github.com/babel/babelify babelify] plugin, for example.
 		</p>
 
-		<h3 id="nodejs">Node.js</h3>
+		<h3 id="nodejs">Node.js<a href="#manual/en/introduction/Installation#nodejs" class="heading-link">#</a></h3>
 
 		<p>
 			Because three.js is built for the web, it depends on browser and DOM APIs that don't always exist in Node.js. Some of these issues can be resolved by using shims like [link:https://github.com/stackgl/headless-gl headless-gl], or by replacing components like [page:TextureLoader] with custom alternatives. Other DOM APIs may be deeply intertwined with the code that uses them, and will be harder to work around. We welcome simple and maintainable pull requests to improve Node.js support, but recommend opening an issue to discuss your improvements first.

--- a/docs/manual/en/introduction/Libraries-and-Plugins.html
+++ b/docs/manual/en/introduction/Libraries-and-Plugins.html
@@ -15,7 +15,7 @@
 			to be up to date. If you'd like to update this list make PR!
 		</p>
 
-		<h3 id="physics">Physics<a href="#manual/en/introduction/Libraries-and-Plugins#physics" class="heading-link">#</a></h3>
+		<h3 id="physics">Physics<a href="#manual/en/introduction/Libraries-and-Plugins#physics" target="_parent" class="heading-link">#</a></h3>
 
 		<ul>
 			<li>[link:https://github.com/lo-th/Oimo.js/ Oimo.js]</li>
@@ -24,7 +24,7 @@
 			<li>[link:https://github.com/pmndrs/cannon-es cannon-es]</li>
 		</ul>
 
-		<h3 id="postprocessing">Postprocessing<a href="#manual/en/introduction/Libraries-and-Plugins#postprocessing" class="heading-link">#</a></h3>
+		<h3 id="postprocessing">Postprocessing<a href="#manual/en/introduction/Libraries-and-Plugins#postprocessing" target="_parent" class="heading-link">#</a></h3>
 
 		<p>
 			In addition to the [link:https://github.com/mrdoob/three.js/tree/dev/examples/jsm/postprocessing official three.js postprocessing effects],
@@ -35,19 +35,19 @@
 			<li>[link:https://github.com/vanruesc/postprocessing postprocessing]</li>
 		</ul>
 
-		<h3 id="intersection-and-raycast-performance">Intersection and Raycast Performance<a href="#manual/en/introduction/Libraries-and-Plugins#intersection-and-raycast-performance" class="heading-link">#</a></h3>
+		<h3 id="intersection-and-raycast-performance">Intersection and Raycast Performance<a href="#manual/en/introduction/Libraries-and-Plugins#intersection-and-raycast-performance" target="_parent" class="heading-link">#</a></h3>
 
 		<ul>
 			<li>[link:https://github.com/gkjohnson/three-mesh-bvh three-mesh-bvh]</li>
 		</ul>
 
-		<h3 id="path-tracing">Path Tracing<a href="#manual/en/introduction/Libraries-and-Plugins#path-tracing" class="heading-link">#</a></h3>
+		<h3 id="path-tracing">Path Tracing<a href="#manual/en/introduction/Libraries-and-Plugins#path-tracing" target="_parent" class="heading-link">#</a></h3>
 		
 		<ul>
 			<li>[link:https://github.com/gkjohnson/three-gpu-pathtracer three-gpu-pathtracer]</li>
 		</ul>
 		
-		<h3 id="file-formats">File Formats<a href="#manual/en/introduction/Libraries-and-Plugins#file-formats" class="heading-link">#</a></h3>
+		<h3 id="file-formats">File Formats<a href="#manual/en/introduction/Libraries-and-Plugins#file-formats" target="_parent" class="heading-link">#</a></h3>
 
 		<p>
 			In addition to the [link:https://github.com/mrdoob/three.js/tree/dev/examples/jsm/loaders official three.js loaders],
@@ -61,26 +61,26 @@
 			<li>[link:https://github.com/IFCjs/web-ifc-three IFC.js]</li>
 		</ul>
 
-		<h3 id="geometry">Geometry<a href="#manual/en/introduction/Libraries-and-Plugins#geometry" class="heading-link">#</a></h3>
+		<h3 id="geometry">Geometry<a href="#manual/en/introduction/Libraries-and-Plugins#geometry" target="_parent" class="heading-link">#</a></h3>
 
 		<ul>
 			<li>[link:https://github.com/spite/THREE.MeshLine THREE.MeshLine]</li>
 		</ul>
 
-		<h3 id="3d-text-and-layout">3D Text and Layout<a href="#manual/en/introduction/Libraries-and-Plugins#3d-text-and-layout" class="heading-link">#</a></h3>
+		<h3 id="3d-text-and-layout">3D Text and Layout<a href="#manual/en/introduction/Libraries-and-Plugins#3d-text-and-layout" target="_parent" class="heading-link">#</a></h3>
 
 		<ul>
 			<li>[link:https://github.com/protectwise/troika/tree/master/packages/troika-three-text troika-three-text]</li>
 			<li>[link:https://github.com/felixmariotto/three-mesh-ui three-mesh-ui]</li>
 		</ul>
 
-		<h3 id="particle-systems">Particle Systems<a href="#manual/en/introduction/Libraries-and-Plugins#particle-systems" class="heading-link">#</a></h3>
+		<h3 id="particle-systems">Particle Systems<a href="#manual/en/introduction/Libraries-and-Plugins#particle-systems" target="_parent" class="heading-link">#</a></h3>
 
 		<ul>
 			<li>[link:https://github.com/creativelifeform/three-nebula three-nebula]</li>
 		</ul>
 
-		<h3 id="inverse-kinematics">Inverse Kinematics<a href="#manual/en/introduction/Libraries-and-Plugins#inverse-kinematics" class="heading-link">#</a></h3>
+		<h3 id="inverse-kinematics">Inverse Kinematics<a href="#manual/en/introduction/Libraries-and-Plugins#inverse-kinematics" target="_parent" class="heading-link">#</a></h3>
 
 		<ul>
 			<li>[link:https://github.com/jsantell/THREE.IK THREE.IK]</li>
@@ -88,14 +88,14 @@
 			<li>[link:https://github.com/gkjohnson/closed-chain-ik-js closed-chain-ik]</li>
 		</ul>
 
-		<h3 id="game-ai">Game AI<a href="#manual/en/introduction/Libraries-and-Plugins#game-ai" class="heading-link">#</a></h3>
+		<h3 id="game-ai">Game AI<a href="#manual/en/introduction/Libraries-and-Plugins#game-ai" target="_parent" class="heading-link">#</a></h3>
 
 		<ul>
 			<li>[link:https://mugen87.github.io/yuka/ yuka]</li>
 			<li>[link:https://github.com/donmccurdy/three-pathfinding three-pathfinding]</li>
 		</ul>
 
-		<h3 id="wrappers-and-frameworks">Wrappers and Frameworks<a href="#manual/en/introduction/Libraries-and-Plugins#wrappers-and-frameworks" class="heading-link">#</a></h3>
+		<h3 id="wrappers-and-frameworks">Wrappers and Frameworks<a href="#manual/en/introduction/Libraries-and-Plugins#wrappers-and-frameworks" target="_parent" class="heading-link">#</a></h3>
 
 		<ul>
 			<li>[link:https://aframe.io/ A-Frame]</li>

--- a/docs/manual/en/introduction/Libraries-and-Plugins.html
+++ b/docs/manual/en/introduction/Libraries-and-Plugins.html
@@ -15,7 +15,7 @@
 			to be up to date. If you'd like to update this list make PR!
 		</p>
 
-		<h3 id="physics">Physics</h3>
+		<h3 id="physics">Physics<a href="#manual/en/introduction/Libraries-and-Plugins#physics" class="heading-link">#</a></h3>
 
 		<ul>
 			<li>[link:https://github.com/lo-th/Oimo.js/ Oimo.js]</li>
@@ -24,7 +24,7 @@
 			<li>[link:https://github.com/pmndrs/cannon-es cannon-es]</li>
 		</ul>
 
-		<h3 id="postprocessing">Postprocessing</h3>
+		<h3 id="postprocessing">Postprocessing<a href="#manual/en/introduction/Libraries-and-Plugins#postprocessing" class="heading-link">#</a></h3>
 
 		<p>
 			In addition to the [link:https://github.com/mrdoob/three.js/tree/dev/examples/jsm/postprocessing official three.js postprocessing effects],
@@ -35,19 +35,19 @@
 			<li>[link:https://github.com/vanruesc/postprocessing postprocessing]</li>
 		</ul>
 
-		<h3 id="intersection-and-raycast-performance">Intersection and Raycast Performance</h3>
+		<h3 id="intersection-and-raycast-performance">Intersection and Raycast Performance<a href="#manual/en/introduction/Libraries-and-Plugins#intersection-and-raycast-performance" class="heading-link">#</a></h3>
 
 		<ul>
 			<li>[link:https://github.com/gkjohnson/three-mesh-bvh three-mesh-bvh]</li>
 		</ul>
 
-		<h3 id="path-tracing">Path Tracing</h3>
+		<h3 id="path-tracing">Path Tracing<a href="#manual/en/introduction/Libraries-and-Plugins#path-tracing" class="heading-link">#</a></h3>
 		
 		<ul>
 			<li>[link:https://github.com/gkjohnson/three-gpu-pathtracer three-gpu-pathtracer]</li>
 		</ul>
 		
-		<h3 id="file-formats">File Formats</h3>
+		<h3 id="file-formats">File Formats<a href="#manual/en/introduction/Libraries-and-Plugins#file-formats" class="heading-link">#</a></h3>
 
 		<p>
 			In addition to the [link:https://github.com/mrdoob/three.js/tree/dev/examples/jsm/loaders official three.js loaders],
@@ -61,26 +61,26 @@
 			<li>[link:https://github.com/IFCjs/web-ifc-three IFC.js]</li>
 		</ul>
 
-		<h3 id="geometry">Geometry</h3>
+		<h3 id="geometry">Geometry<a href="#manual/en/introduction/Libraries-and-Plugins#geometry" class="heading-link">#</a></h3>
 
 		<ul>
 			<li>[link:https://github.com/spite/THREE.MeshLine THREE.MeshLine]</li>
 		</ul>
 
-		<h3 id="3d-text-and-layout">3D Text and Layout</h3>
+		<h3 id="3d-text-and-layout">3D Text and Layout<a href="#manual/en/introduction/Libraries-and-Plugins#3d-text-and-layout" class="heading-link">#</a></h3>
 
 		<ul>
 			<li>[link:https://github.com/protectwise/troika/tree/master/packages/troika-three-text troika-three-text]</li>
 			<li>[link:https://github.com/felixmariotto/three-mesh-ui three-mesh-ui]</li>
 		</ul>
 
-		<h3 id="particle-systems">Particle Systems</h3>
+		<h3 id="particle-systems">Particle Systems<a href="#manual/en/introduction/Libraries-and-Plugins#particle-systems" class="heading-link">#</a></h3>
 
 		<ul>
 			<li>[link:https://github.com/creativelifeform/three-nebula three-nebula]</li>
 		</ul>
 
-		<h3 id="inverse-kinematics">Inverse Kinematics</h3>
+		<h3 id="inverse-kinematics">Inverse Kinematics<a href="#manual/en/introduction/Libraries-and-Plugins#inverse-kinematics" class="heading-link">#</a></h3>
 
 		<ul>
 			<li>[link:https://github.com/jsantell/THREE.IK THREE.IK]</li>
@@ -88,14 +88,14 @@
 			<li>[link:https://github.com/gkjohnson/closed-chain-ik-js closed-chain-ik]</li>
 		</ul>
 
-		<h3 id="game-ai">Game AI</h3>
+		<h3 id="game-ai">Game AI<a href="#manual/en/introduction/Libraries-and-Plugins#game-ai" class="heading-link">#</a></h3>
 
 		<ul>
 			<li>[link:https://mugen87.github.io/yuka/ yuka]</li>
 			<li>[link:https://github.com/donmccurdy/three-pathfinding three-pathfinding]</li>
 		</ul>
 
-		<h3 id="wrappers-and-frameworks">Wrappers and Frameworks</h3>
+		<h3 id="wrappers-and-frameworks">Wrappers and Frameworks<a href="#manual/en/introduction/Libraries-and-Plugins#wrappers-and-frameworks" class="heading-link">#</a></h3>
 
 		<ul>
 			<li>[link:https://aframe.io/ A-Frame]</li>

--- a/docs/manual/en/introduction/Libraries-and-Plugins.html
+++ b/docs/manual/en/introduction/Libraries-and-Plugins.html
@@ -15,7 +15,7 @@
 			to be up to date. If you'd like to update this list make PR!
 		</p>
 
-		<h3>Physics</h3>
+		<h3 id="physics">Physics</h3>
 
 		<ul>
 			<li>[link:https://github.com/lo-th/Oimo.js/ Oimo.js]</li>
@@ -24,7 +24,7 @@
 			<li>[link:https://github.com/pmndrs/cannon-es cannon-es]</li>
 		</ul>
 
-		<h3>Postprocessing</h3>
+		<h3 id="postprocessing">Postprocessing</h3>
 
 		<p>
 			In addition to the [link:https://github.com/mrdoob/three.js/tree/dev/examples/jsm/postprocessing official three.js postprocessing effects],
@@ -35,19 +35,19 @@
 			<li>[link:https://github.com/vanruesc/postprocessing postprocessing]</li>
 		</ul>
 
-		<h3>Intersection and Raycast Performance</h3>
+		<h3 id="intersection-and-raycast-performance">Intersection and Raycast Performance</h3>
 
 		<ul>
 			<li>[link:https://github.com/gkjohnson/three-mesh-bvh three-mesh-bvh]</li>
 		</ul>
 
-		<h3>Path Tracing</h3>
+		<h3 id="path-tracing">Path Tracing</h3>
 		
 		<ul>
 			<li>[link:https://github.com/gkjohnson/three-gpu-pathtracer three-gpu-pathtracer]</li>
 		</ul>
 		
-		<h3>File Formats</h3>
+		<h3 id="file-formats">File Formats</h3>
 
 		<p>
 			In addition to the [link:https://github.com/mrdoob/three.js/tree/dev/examples/jsm/loaders official three.js loaders],
@@ -61,26 +61,26 @@
 			<li>[link:https://github.com/IFCjs/web-ifc-three IFC.js]</li>
 		</ul>
 
-		<h3>Geometry</h3>
+		<h3 id="geometry">Geometry</h3>
 
 		<ul>
 			<li>[link:https://github.com/spite/THREE.MeshLine THREE.MeshLine]</li>
 		</ul>
 
-		<h3>3D Text and Layout</h3>
+		<h3 id="3d-text-and-layout">3D Text and Layout</h3>
 
 		<ul>
 			<li>[link:https://github.com/protectwise/troika/tree/master/packages/troika-three-text troika-three-text]</li>
 			<li>[link:https://github.com/felixmariotto/three-mesh-ui three-mesh-ui]</li>
 		</ul>
 
-		<h3>Particle Systems</h3>
+		<h3 id="particle-systems">Particle Systems</h3>
 
 		<ul>
 			<li>[link:https://github.com/creativelifeform/three-nebula three-nebula]</li>
 		</ul>
 
-		<h3>Inverse Kinematics</h3>
+		<h3 id="inverse-kinematics">Inverse Kinematics</h3>
 
 		<ul>
 			<li>[link:https://github.com/jsantell/THREE.IK THREE.IK]</li>
@@ -88,14 +88,14 @@
 			<li>[link:https://github.com/gkjohnson/closed-chain-ik-js closed-chain-ik]</li>
 		</ul>
 
-		<h3>Game AI</h3>
+		<h3 id="game-ai">Game AI</h3>
 
 		<ul>
 			<li>[link:https://mugen87.github.io/yuka/ yuka]</li>
 			<li>[link:https://github.com/donmccurdy/three-pathfinding three-pathfinding]</li>
 		</ul>
 
-		<h3>Wrappers and Frameworks</h3>
+		<h3 id="wrappers-and-frameworks">Wrappers and Frameworks</h3>
 
 		<ul>
 			<li>[link:https://aframe.io/ A-Frame]</li>

--- a/docs/manual/en/introduction/Loading-3D-models.html
+++ b/docs/manual/en/introduction/Loading-3D-models.html
@@ -26,7 +26,7 @@
 		for what to try if things don't go as expected.
 	</p>
 
-	<h2 id="before-we-start">Before we start</h2>
+	<h2 id="before-we-start">Before we start<a href="#manual/en/introduction/Loading-3D-models#before-we-start" class="heading-link">#</a></h2>
 
 	<p>
 		If you're new to running a local server, begin with
@@ -35,7 +35,7 @@
 		correctly.
 	</p>
 
-	<h2 id="recommended-workflow">Recommended workflow</h2>
+	<h2 id="recommended-workflow">Recommended workflow<a href="#manual/en/introduction/Loading-3D-models#recommended-workflow" class="heading-link">#</a></h2>
 
 	<p>
 		Where possible, we recommend using glTF (GL Transmission Format). Both
@@ -76,7 +76,7 @@
 		are also available and regularly maintained.
 	</p>
 
-	<h2 id="loading">Loading</h2>
+	<h2 id="loading">Loading<a href="#manual/en/introduction/Loading-3D-models#loading" class="heading-link">#</a></h2>
 
 	<p>
 		Only a few loaders (e.g. [page:ObjectLoader]) are included by default with
@@ -111,7 +111,7 @@
 		See [page:GLTFLoader GLTFLoader documentation] for further details.
 	</p>
 
-	<h2 id="troubleshooting">Troubleshooting</h2>
+	<h2 id="troubleshooting">Troubleshooting<a href="#manual/en/introduction/Loading-3D-models#troubleshooting" class="heading-link">#</a></h2>
 
 	<p>
 		You've spent hours modeling an artisanal masterpiece, you load it into
@@ -150,7 +150,7 @@
 		</li>
 	</ol>
 
-	<h2 id="asking-for-help">Asking for help</h2>
+	<h2 id="asking-for-help">Asking for help<a href="#manual/en/introduction/Loading-3D-models#asking-for-help" class="heading-link">#</a></h2>
 
 	<p>
 		If you've gone through the troubleshooting process above and your model

--- a/docs/manual/en/introduction/Loading-3D-models.html
+++ b/docs/manual/en/introduction/Loading-3D-models.html
@@ -26,7 +26,7 @@
 		for what to try if things don't go as expected.
 	</p>
 
-	<h2 id="before-we-start">Before we start<a href="#manual/en/introduction/Loading-3D-models#before-we-start" class="heading-link">#</a></h2>
+	<h2 id="before-we-start">Before we start<a href="#manual/en/introduction/Loading-3D-models#before-we-start" target="_parent" class="heading-link">#</a></h2>
 
 	<p>
 		If you're new to running a local server, begin with
@@ -35,7 +35,7 @@
 		correctly.
 	</p>
 
-	<h2 id="recommended-workflow">Recommended workflow<a href="#manual/en/introduction/Loading-3D-models#recommended-workflow" class="heading-link">#</a></h2>
+	<h2 id="recommended-workflow">Recommended workflow<a href="#manual/en/introduction/Loading-3D-models#recommended-workflow" target="_parent" class="heading-link">#</a></h2>
 
 	<p>
 		Where possible, we recommend using glTF (GL Transmission Format). Both
@@ -76,7 +76,7 @@
 		are also available and regularly maintained.
 	</p>
 
-	<h2 id="loading">Loading<a href="#manual/en/introduction/Loading-3D-models#loading" class="heading-link">#</a></h2>
+	<h2 id="loading">Loading<a href="#manual/en/introduction/Loading-3D-models#loading" target="_parent" class="heading-link">#</a></h2>
 
 	<p>
 		Only a few loaders (e.g. [page:ObjectLoader]) are included by default with
@@ -111,7 +111,7 @@
 		See [page:GLTFLoader GLTFLoader documentation] for further details.
 	</p>
 
-	<h2 id="troubleshooting">Troubleshooting<a href="#manual/en/introduction/Loading-3D-models#troubleshooting" class="heading-link">#</a></h2>
+	<h2 id="troubleshooting">Troubleshooting<a href="#manual/en/introduction/Loading-3D-models#troubleshooting" target="_parent" class="heading-link">#</a></h2>
 
 	<p>
 		You've spent hours modeling an artisanal masterpiece, you load it into
@@ -150,7 +150,7 @@
 		</li>
 	</ol>
 
-	<h2 id="asking-for-help">Asking for help<a href="#manual/en/introduction/Loading-3D-models#asking-for-help" class="heading-link">#</a></h2>
+	<h2 id="asking-for-help">Asking for help<a href="#manual/en/introduction/Loading-3D-models#asking-for-help" target="_parent" class="heading-link">#</a></h2>
 
 	<p>
 		If you've gone through the troubleshooting process above and your model

--- a/docs/manual/en/introduction/Loading-3D-models.html
+++ b/docs/manual/en/introduction/Loading-3D-models.html
@@ -26,7 +26,7 @@
 		for what to try if things don't go as expected.
 	</p>
 
-	<h2>Before we start</h2>
+	<h2 id="before-we-start">Before we start</h2>
 
 	<p>
 		If you're new to running a local server, begin with
@@ -35,7 +35,7 @@
 		correctly.
 	</p>
 
-	<h2>Recommended workflow</h2>
+	<h2 id="recommended-workflow">Recommended workflow</h2>
 
 	<p>
 		Where possible, we recommend using glTF (GL Transmission Format). Both
@@ -76,7 +76,7 @@
 		are also available and regularly maintained.
 	</p>
 
-	<h2>Loading</h2>
+	<h2 id="loading">Loading</h2>
 
 	<p>
 		Only a few loaders (e.g. [page:ObjectLoader]) are included by default with
@@ -111,7 +111,7 @@
 		See [page:GLTFLoader GLTFLoader documentation] for further details.
 	</p>
 
-	<h2>Troubleshooting</h2>
+	<h2 id="troubleshooting">Troubleshooting</h2>
 
 	<p>
 		You've spent hours modeling an artisanal masterpiece, you load it into
@@ -150,7 +150,7 @@
 		</li>
 	</ol>
 
-	<h2>Asking for help</h2>
+	<h2 id="asking-for-help">Asking for help</h2>
 
 	<p>
 		If you've gone through the troubleshooting process above and your model

--- a/docs/manual/en/introduction/Matrix-transformations.html
+++ b/docs/manual/en/introduction/Matrix-transformations.html
@@ -13,7 +13,7 @@
 		Three.js uses `matrices` to encode 3D transformations---translations (position), rotations, and scaling. Every instance of [page:Object3D] has a [page:Object3D.matrix matrix] which stores that object's position, rotation, and scale. This page describes how to update an object's transformation.
 		</p>
 
-		<h2 id="convenience-properties-and-matrixautoupdate">Convenience properties and `matrixAutoUpdate`<a href="#manual/en/introduction/Matrix-transformations#convenience-properties-and-matrixautoupdate" class="heading-link">#</a></h2>
+		<h2 id="convenience-properties-and-matrixautoupdate">Convenience properties and `matrixAutoUpdate`<a href="#manual/en/introduction/Matrix-transformations#convenience-properties-and-matrixautoupdate" target="_parent" class="heading-link">#</a></h2>
 
 		<p>
 			There are two ways to update an object's transformation:
@@ -47,7 +47,7 @@ object.matrixAutoUpdate = false;
 			</li>
 		</ol>
 
-		<h2 id="object-and-world-matrices">Object and world matrices<a href="#manual/en/introduction/Matrix-transformations#object-and-world-matrices" class="heading-link">#</a></h2>
+		<h2 id="object-and-world-matrices">Object and world matrices<a href="#manual/en/introduction/Matrix-transformations#object-and-world-matrices" target="_parent" class="heading-link">#</a></h2>
 		<p>
 		An object's [page:Object3D.matrix matrix] stores the object's transformation <em>relative</em> to the object's [page:Object3D.parent parent]; to get the object's transformation in <em>world</em> coordinates, you must access the object's [page:Object3D.matrixWorld].
 		</p>
@@ -55,7 +55,7 @@ object.matrixAutoUpdate = false;
 		When either the parent or the child object's transformation changes, you can request that the child object's [page:Object3D.matrixWorld matrixWorld] be updated by calling [page:Object3D.updateMatrixWorld updateMatrixWorld]().
 		</p>
 
-		<h2 id="rotation-and-quaternion">Rotation and Quaternion<a href="#manual/en/introduction/Matrix-transformations#rotation-and-quaternion" class="heading-link">#</a></h2>
+		<h2 id="rotation-and-quaternion">Rotation and Quaternion<a href="#manual/en/introduction/Matrix-transformations#rotation-and-quaternion" target="_parent" class="heading-link">#</a></h2>
 		<p>
 		Three.js provides two ways of representing 3D rotations: [page:Euler Euler angles] and [page:Quaternion Quaternions], as well as methods for converting between the two. Euler angles are subject to a problem called "gimbal lock," where certain configurations can lose a degree of freedom (preventing the object from being rotated about one axis). For this reason, object rotations are <em>always</em> stored in the object's [page:Object3D.quaternion quaternion].
 		</p>

--- a/docs/manual/en/introduction/Matrix-transformations.html
+++ b/docs/manual/en/introduction/Matrix-transformations.html
@@ -13,7 +13,7 @@
 		Three.js uses `matrices` to encode 3D transformations---translations (position), rotations, and scaling. Every instance of [page:Object3D] has a [page:Object3D.matrix matrix] which stores that object's position, rotation, and scale. This page describes how to update an object's transformation.
 		</p>
 
-		<h2 id="convenience-properties-and-matrixautoupdate">Convenience properties and `matrixAutoUpdate`</h2>
+		<h2 id="convenience-properties-and-matrixautoupdate">Convenience properties and `matrixAutoUpdate`<a href="#manual/en/introduction/Matrix-transformations#convenience-properties-and-matrixautoupdate" class="heading-link">#</a></h2>
 
 		<p>
 			There are two ways to update an object's transformation:
@@ -47,7 +47,7 @@ object.matrixAutoUpdate = false;
 			</li>
 		</ol>
 
-		<h2 id="object-and-world-matrices">Object and world matrices</h2>
+		<h2 id="object-and-world-matrices">Object and world matrices<a href="#manual/en/introduction/Matrix-transformations#object-and-world-matrices" class="heading-link">#</a></h2>
 		<p>
 		An object's [page:Object3D.matrix matrix] stores the object's transformation <em>relative</em> to the object's [page:Object3D.parent parent]; to get the object's transformation in <em>world</em> coordinates, you must access the object's [page:Object3D.matrixWorld].
 		</p>
@@ -55,7 +55,7 @@ object.matrixAutoUpdate = false;
 		When either the parent or the child object's transformation changes, you can request that the child object's [page:Object3D.matrixWorld matrixWorld] be updated by calling [page:Object3D.updateMatrixWorld updateMatrixWorld]().
 		</p>
 
-		<h2 id="rotation-and-quaternion">Rotation and Quaternion</h2>
+		<h2 id="rotation-and-quaternion">Rotation and Quaternion<a href="#manual/en/introduction/Matrix-transformations#rotation-and-quaternion" class="heading-link">#</a></h2>
 		<p>
 		Three.js provides two ways of representing 3D rotations: [page:Euler Euler angles] and [page:Quaternion Quaternions], as well as methods for converting between the two. Euler angles are subject to a problem called "gimbal lock," where certain configurations can lose a degree of freedom (preventing the object from being rotated about one axis). For this reason, object rotations are <em>always</em> stored in the object's [page:Object3D.quaternion quaternion].
 		</p>

--- a/docs/manual/en/introduction/Matrix-transformations.html
+++ b/docs/manual/en/introduction/Matrix-transformations.html
@@ -13,7 +13,7 @@
 		Three.js uses `matrices` to encode 3D transformations---translations (position), rotations, and scaling. Every instance of [page:Object3D] has a [page:Object3D.matrix matrix] which stores that object's position, rotation, and scale. This page describes how to update an object's transformation.
 		</p>
 
-		<h2>Convenience properties and `matrixAutoUpdate`</h2>
+		<h2 id="convenience-properties-and-matrixautoupdate">Convenience properties and `matrixAutoUpdate`</h2>
 
 		<p>
 			There are two ways to update an object's transformation:
@@ -47,7 +47,7 @@ object.matrixAutoUpdate = false;
 			</li>
 		</ol>
 
-		<h2>Object and world matrices</h2>
+		<h2 id="object-and-world-matrices">Object and world matrices</h2>
 		<p>
 		An object's [page:Object3D.matrix matrix] stores the object's transformation <em>relative</em> to the object's [page:Object3D.parent parent]; to get the object's transformation in <em>world</em> coordinates, you must access the object's [page:Object3D.matrixWorld].
 		</p>
@@ -55,7 +55,7 @@ object.matrixAutoUpdate = false;
 		When either the parent or the child object's transformation changes, you can request that the child object's [page:Object3D.matrixWorld matrixWorld] be updated by calling [page:Object3D.updateMatrixWorld updateMatrixWorld]().
 		</p>
 
-		<h2>Rotation and Quaternion</h2>
+		<h2 id="rotation-and-quaternion">Rotation and Quaternion</h2>
 		<p>
 		Three.js provides two ways of representing 3D rotations: [page:Euler Euler angles] and [page:Quaternion Quaternions], as well as methods for converting between the two. Euler angles are subject to a problem called "gimbal lock," where certain configurations can lose a degree of freedom (preventing the object from being rotated about one axis). For this reason, object rotations are <em>always</em> stored in the object's [page:Object3D.quaternion quaternion].
 		</p>

--- a/docs/manual/en/introduction/Useful-links.html
+++ b/docs/manual/en/introduction/Useful-links.html
@@ -19,15 +19,15 @@
 			check the browser console for warnings or errors. Also check the relevant docs pages.
 		</p>
 
-		<h2>Help forums</h2>
+		<h2 id="help-forums">Help forums</h2>
 		<p>
 			Three.js officially uses the [link:https://discourse.threejs.org/ forum] and [link:http://stackoverflow.com/tags/three.js/info Stack Overflow] for help requests.
 			If you need assistance with something, that's the place to go. Do NOT open an issue on Github for help requests.
 		</p>
 
-		<h2>Tutorials and courses</h2>
+		<h2 id="tutorials-and-courses">Tutorials and courses</h2>
 
-		<h3>Getting started with three.js</h3>
+		<h3 id="getting-started-with-threejs">Getting started with three.js</h3>
 		<ul>
 			<li>
 				[link:https://threejs.org/manual/#en/fundamentals Three.js Fundamentals starting lesson]
@@ -40,7 +40,7 @@
 			</li>
 		</ul>
 
-		<h3>More extensive / advanced articles and courses</h3>
+		<h3 id="more-extensive-advanced-articles-and-courses">More extensive / advanced articles and courses</h3>
 		<ul>
 			<li>
 				[link:https://threejs-journey.com/ Three Journey] Course by [link:https://bruno-simon.com/ Bruno Simon] - Teaches beginners how to use Three.js step by step
@@ -67,7 +67,7 @@
 		 </li>
 		</ul>
 
-		<h2>News and Updates</h2>
+		<h2 id="news-and-updates">News and Updates</h2>
 		<ul>
 			<li>
 				[link:https://twitter.com/hashtag/threejs Three.js on Twitter]
@@ -80,7 +80,7 @@
 			</li>
 		</ul>
 
-		<h2>Examples</h2>
+		<h2 id="examples">Examples</h2>
 		<ul>
 			<li>
 				[link:https://github.com/edwinwebb/three-seed/ three-seed] - three.js starter project with ES6 and Webpack
@@ -100,7 +100,7 @@
 			</li>
 		</ul>
 
-	<h2>Tools</h2>
+	<h2 id="tools">Tools</h2>
 	<ul>
 		<li>
 			[link:https://github.com/tbensky/physgl physgl.org] - JavaScript front-end with wrappers to three.js, to bring WebGL
@@ -125,14 +125,14 @@
 		</li>
 	</ul>
 
-	<h2>WebGL References</h2>
+	<h2 id="webgl-references">WebGL References</h2>
 		<ul>
 			<li>
 			[link:https://www.khronos.org/files/webgl/webgl-reference-card-1_0.pdf webgl-reference-card.pdf] - Reference of all WebGL and GLSL keywords, terminology, syntax and definitions.
 			</li>
 		</ul>
 
-	<h2>Old Links</h2>
+	<h2 id="old-links">Old Links</h2>
 	<p>
 		These links are kept for historical purposes - you may still find them useful, but be warned that
 		they may have information relating to very old versions of three.js.

--- a/docs/manual/en/introduction/Useful-links.html
+++ b/docs/manual/en/introduction/Useful-links.html
@@ -19,15 +19,15 @@
 			check the browser console for warnings or errors. Also check the relevant docs pages.
 		</p>
 
-		<h2 id="help-forums">Help forums</h2>
+		<h2 id="help-forums">Help forums<a href="#manual/en/introduction/Useful-links#help-forums" class="heading-link">#</a></h2>
 		<p>
 			Three.js officially uses the [link:https://discourse.threejs.org/ forum] and [link:http://stackoverflow.com/tags/three.js/info Stack Overflow] for help requests.
 			If you need assistance with something, that's the place to go. Do NOT open an issue on Github for help requests.
 		</p>
 
-		<h2 id="tutorials-and-courses">Tutorials and courses</h2>
+		<h2 id="tutorials-and-courses">Tutorials and courses<a href="#manual/en/introduction/Useful-links#tutorials-and-courses" class="heading-link">#</a></h2>
 
-		<h3 id="getting-started-with-threejs">Getting started with three.js</h3>
+		<h3 id="getting-started-with-threejs">Getting started with three.js<a href="#manual/en/introduction/Useful-links#getting-started-with-threejs" class="heading-link">#</a></h3>
 		<ul>
 			<li>
 				[link:https://threejs.org/manual/#en/fundamentals Three.js Fundamentals starting lesson]
@@ -40,7 +40,7 @@
 			</li>
 		</ul>
 
-		<h3 id="more-extensive-advanced-articles-and-courses">More extensive / advanced articles and courses</h3>
+		<h3 id="more-extensive-advanced-articles-and-courses">More extensive / advanced articles and courses<a href="#manual/en/introduction/Useful-links#more-extensive-advanced-articles-and-courses" class="heading-link">#</a></h3>
 		<ul>
 			<li>
 				[link:https://threejs-journey.com/ Three Journey] Course by [link:https://bruno-simon.com/ Bruno Simon] - Teaches beginners how to use Three.js step by step
@@ -67,7 +67,7 @@
 		 </li>
 		</ul>
 
-		<h2 id="news-and-updates">News and Updates</h2>
+		<h2 id="news-and-updates">News and Updates<a href="#manual/en/introduction/Useful-links#news-and-updates" class="heading-link">#</a></h2>
 		<ul>
 			<li>
 				[link:https://twitter.com/hashtag/threejs Three.js on Twitter]
@@ -80,7 +80,7 @@
 			</li>
 		</ul>
 
-		<h2 id="examples">Examples</h2>
+		<h2 id="examples">Examples<a href="#manual/en/introduction/Useful-links#examples" class="heading-link">#</a></h2>
 		<ul>
 			<li>
 				[link:https://github.com/edwinwebb/three-seed/ three-seed] - three.js starter project with ES6 and Webpack
@@ -100,7 +100,7 @@
 			</li>
 		</ul>
 
-	<h2 id="tools">Tools</h2>
+	<h2 id="tools">Tools<a href="#manual/en/introduction/Useful-links#tools" class="heading-link">#</a></h2>
 	<ul>
 		<li>
 			[link:https://github.com/tbensky/physgl physgl.org] - JavaScript front-end with wrappers to three.js, to bring WebGL
@@ -125,14 +125,14 @@
 		</li>
 	</ul>
 
-	<h2 id="webgl-references">WebGL References</h2>
+	<h2 id="webgl-references">WebGL References<a href="#manual/en/introduction/Useful-links#webgl-references" class="heading-link">#</a></h2>
 		<ul>
 			<li>
 			[link:https://www.khronos.org/files/webgl/webgl-reference-card-1_0.pdf webgl-reference-card.pdf] - Reference of all WebGL and GLSL keywords, terminology, syntax and definitions.
 			</li>
 		</ul>
 
-	<h2 id="old-links">Old Links</h2>
+	<h2 id="old-links">Old Links<a href="#manual/en/introduction/Useful-links#old-links" class="heading-link">#</a></h2>
 	<p>
 		These links are kept for historical purposes - you may still find them useful, but be warned that
 		they may have information relating to very old versions of three.js.

--- a/docs/manual/en/introduction/Useful-links.html
+++ b/docs/manual/en/introduction/Useful-links.html
@@ -19,15 +19,15 @@
 			check the browser console for warnings or errors. Also check the relevant docs pages.
 		</p>
 
-		<h2 id="help-forums">Help forums<a href="#manual/en/introduction/Useful-links#help-forums" class="heading-link">#</a></h2>
+		<h2 id="help-forums">Help forums<a href="#manual/en/introduction/Useful-links#help-forums" target="_parent" class="heading-link">#</a></h2>
 		<p>
 			Three.js officially uses the [link:https://discourse.threejs.org/ forum] and [link:http://stackoverflow.com/tags/three.js/info Stack Overflow] for help requests.
 			If you need assistance with something, that's the place to go. Do NOT open an issue on Github for help requests.
 		</p>
 
-		<h2 id="tutorials-and-courses">Tutorials and courses<a href="#manual/en/introduction/Useful-links#tutorials-and-courses" class="heading-link">#</a></h2>
+		<h2 id="tutorials-and-courses">Tutorials and courses<a href="#manual/en/introduction/Useful-links#tutorials-and-courses" target="_parent" class="heading-link">#</a></h2>
 
-		<h3 id="getting-started-with-threejs">Getting started with three.js<a href="#manual/en/introduction/Useful-links#getting-started-with-threejs" class="heading-link">#</a></h3>
+		<h3 id="getting-started-with-threejs">Getting started with three.js<a href="#manual/en/introduction/Useful-links#getting-started-with-threejs" target="_parent" class="heading-link">#</a></h3>
 		<ul>
 			<li>
 				[link:https://threejs.org/manual/#en/fundamentals Three.js Fundamentals starting lesson]
@@ -40,7 +40,7 @@
 			</li>
 		</ul>
 
-		<h3 id="more-extensive-advanced-articles-and-courses">More extensive / advanced articles and courses<a href="#manual/en/introduction/Useful-links#more-extensive-advanced-articles-and-courses" class="heading-link">#</a></h3>
+		<h3 id="more-extensive-advanced-articles-and-courses">More extensive / advanced articles and courses<a href="#manual/en/introduction/Useful-links#more-extensive-advanced-articles-and-courses" target="_parent" class="heading-link">#</a></h3>
 		<ul>
 			<li>
 				[link:https://threejs-journey.com/ Three Journey] Course by [link:https://bruno-simon.com/ Bruno Simon] - Teaches beginners how to use Three.js step by step
@@ -67,7 +67,7 @@
 		 </li>
 		</ul>
 
-		<h2 id="news-and-updates">News and Updates<a href="#manual/en/introduction/Useful-links#news-and-updates" class="heading-link">#</a></h2>
+		<h2 id="news-and-updates">News and Updates<a href="#manual/en/introduction/Useful-links#news-and-updates" target="_parent" class="heading-link">#</a></h2>
 		<ul>
 			<li>
 				[link:https://twitter.com/hashtag/threejs Three.js on Twitter]
@@ -80,7 +80,7 @@
 			</li>
 		</ul>
 
-		<h2 id="examples">Examples<a href="#manual/en/introduction/Useful-links#examples" class="heading-link">#</a></h2>
+		<h2 id="examples">Examples<a href="#manual/en/introduction/Useful-links#examples" target="_parent" class="heading-link">#</a></h2>
 		<ul>
 			<li>
 				[link:https://github.com/edwinwebb/three-seed/ three-seed] - three.js starter project with ES6 and Webpack
@@ -100,7 +100,7 @@
 			</li>
 		</ul>
 
-	<h2 id="tools">Tools<a href="#manual/en/introduction/Useful-links#tools" class="heading-link">#</a></h2>
+	<h2 id="tools">Tools<a href="#manual/en/introduction/Useful-links#tools" target="_parent" class="heading-link">#</a></h2>
 	<ul>
 		<li>
 			[link:https://github.com/tbensky/physgl physgl.org] - JavaScript front-end with wrappers to three.js, to bring WebGL
@@ -125,14 +125,14 @@
 		</li>
 	</ul>
 
-	<h2 id="webgl-references">WebGL References<a href="#manual/en/introduction/Useful-links#webgl-references" class="heading-link">#</a></h2>
+	<h2 id="webgl-references">WebGL References<a href="#manual/en/introduction/Useful-links#webgl-references" target="_parent" class="heading-link">#</a></h2>
 		<ul>
 			<li>
 			[link:https://www.khronos.org/files/webgl/webgl-reference-card-1_0.pdf webgl-reference-card.pdf] - Reference of all WebGL and GLSL keywords, terminology, syntax and definitions.
 			</li>
 		</ul>
 
-	<h2 id="old-links">Old Links<a href="#manual/en/introduction/Useful-links#old-links" class="heading-link">#</a></h2>
+	<h2 id="old-links">Old Links<a href="#manual/en/introduction/Useful-links#old-links" target="_parent" class="heading-link">#</a></h2>
 	<p>
 		These links are kept for historical purposes - you may still find them useful, but be warned that
 		they may have information relating to very old versions of three.js.

--- a/docs/page.css
+++ b/docs/page.css
@@ -248,18 +248,18 @@ a.param:hover {
 	color: var(--text-color);
 }
 
-h2 > a.heading-link {
+h2 > a.heading-link, h3 > a.heading-link {
 	display: none;
 	color: var(--text-color);
-	padding-left: 8px;
 	transition: color .16s linear;
 }
 
+h2 > a.heading-link {
+	padding-left: 8px;
+}
+
 h3 > a.heading-link {
-	display: none;
-	color: var(--text-color);
 	padding-left: 6px;
-	transition: color .16s linear;
 }
 
 a.heading-link:hover, a.heading-link:active {

--- a/docs/page.css
+++ b/docs/page.css
@@ -248,6 +248,28 @@ a.param:hover {
 	color: var(--text-color);
 }
 
+h2 > a.heading-link {
+	display: none;
+	color: var(--text-color);
+	padding-left: 8px;
+	transition: color .16s linear;
+}
+
+h3 > a.heading-link {
+	display: none;
+	color: var(--text-color);
+	padding-left: 6px;
+	transition: color .16s linear;
+}
+
+a.heading-link:hover, a.heading-link:active {
+	color: var(--color-blue);
+}
+
+h2:hover a.heading-link, h2:active a.heading-link, h3:hover a.heading-link, h3:active a.heading-link {
+	display: inline-block;
+}
+
 
 @media all and ( min-width: 1700px ) {
 


### PR DESCRIPTION
Related issue: #23225

**Description**

This pull request adds the requested `id` attributes to the header tags (`<h2>` and `<h3>`) in the old manual.

Additional note: I figured that this should be done incrementally to avoid a huge list of changes that is harder to review. I will work on adding the corresponding `id` attributes to the [API reference docs](https://github.com/mrdoob/three.js/tree/dev/docs/api/en) and [examples](https://github.com/mrdoob/three.js/tree/dev/docs/examples/en) in separate PRs.