### PR TITLE
Examples: Clean up

### DIFF
--- a/examples/webgl_materials_envmaps.html
+++ b/examples/webgl_materials_envmaps.html
@@ -50,11 +50,6 @@
 
 				scene = new THREE.Scene();
 
-				// Lights
-
-				const ambient = new THREE.AmbientLight( 0xffffff );
-				scene.add( ambient );
-
 				// Textures
 
 				const loader = new THREE.CubeTextureLoader();
@@ -74,7 +69,7 @@
 				//
 
 				const geometry = new THREE.IcosahedronGeometry( 400, 15 );
-				sphereMaterial = new THREE.MeshLambertMaterial( { envMap: textureCube } );
+				sphereMaterial = new THREE.MeshBasicMaterial( { envMap: textureCube } );
 				sphereMesh = new THREE.Mesh( geometry, sphereMaterial );
 				scene.add( sphereMesh );
 


### PR DESCRIPTION
Another option would be to use `MeshStandardMaterial`, with no ambient light.
