### PR TITLE
Example: webgl_nodes_materialx_noise fix tabs

### DIFF
--- a/examples/webgl_nodes_materialx_noise.html
+++ b/examples/webgl_nodes_materialx_noise.html
@@ -69,7 +69,7 @@
 				new HDRCubeTextureLoader()
 					.setPath( 'textures/cube/pisaHDR/' )
 					.load( [ 'px.hdr', 'nx.hdr', 'py.hdr', 'ny.hdr', 'pz.hdr', 'nz.hdr' ],
-						  function ( hdrTexture ) {
+						function ( hdrTexture ) {
 
 							const geometry = new THREE.SphereGeometry( 80, 64, 32 );
 
@@ -123,7 +123,7 @@
 
 						}
 
-						 );
+					);
 
 				// LIGHTS
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/24504

**Description**

Fix code tabs.
