### PR TITLE
Docs: Fix typos

### DIFF
--- a/docs/api/en/materials/Material.html
+++ b/docs/api/en/materials/Material.html
@@ -292,7 +292,7 @@
 
 		<h3>[property:Integer version]</h3>
 		<p>
-		This starts at `0` and counts how many times [property:Boolean needsUpdate] is set to `true`.
+		This starts at `0` and counts how many times [page:Material.needsUpdate .needsUpdate] is set to `true`.
 		</p>
 
 		<h3>[property:Boolean vertexColors]</h3>

--- a/docs/api/en/textures/Source.html
+++ b/docs/api/en/textures/Source.html
@@ -40,7 +40,7 @@
 
 		<h3>[property:Integer version]</h3>
 		<p>
-		This starts at `0` and counts how many times [property:Boolean needsUpdate] is set to `true`.
+		This starts at `0` and counts how many times [page:Source.needsUpdate .needsUpdate] is set to `true`.
 		</p>
 
 		<h2>Methods</h2>

--- a/docs/api/en/textures/Texture.html
+++ b/docs/api/en/textures/Texture.html
@@ -253,7 +253,7 @@
 
 		<h3>[property:Integer version]</h3>
 		<p>
-		This starts at `0` and counts how many times [property:Boolean needsUpdate] is set to `true`.
+		This starts at `0` and counts how many times [page:Texture.needsUpdate .needsUpdate] is set to `true`.
 		</p>
 
 		<h3>[property:Function onUpdate]</h3>
@@ -292,7 +292,7 @@
 		<h3>[method:Texture clone]()</h3>
 		<p>
 		Make copy of the texture. Note this is not a "deep copy", the image is shared.
-		Besides, cloning a texture does not automatically mark it for a texture upload. You have to set [page:Texture.needsUpdate] to true as soon as its image property (the data source) is fully loaded or ready.
+		Besides, cloning a texture does not automatically mark it for a texture upload. You have to set [page:Texture.needsUpdate .needsUpdate] to true as soon as its image property (the data source) is fully loaded or ready.
 		</p>
 
 		<h3>[method:Object toJSON]( [param:Object meta] )</h3>

--- a/docs/api/en/textures/VideoTexture.html
+++ b/docs/api/en/textures/VideoTexture.html
@@ -90,7 +90,7 @@
 
 		<h3>[method:undefined update]()</h3>
 		<p>
-		This is called automatically and sets [property:Boolean needsUpdate] to `true` every time
+		This is called automatically and sets [page:VideoTexture.needsUpdate .needsUpdate] to `true` every time
 		a new frame is available.
 		</p>
 

--- a/docs/api/zh/textures/Source.html
+++ b/docs/api/zh/textures/Source.html
@@ -40,7 +40,7 @@
 
 		<h3>[property:Integer version]</h3>
 		<p>
-		This starts at *0* and counts how many times [property:Boolean needsUpdate] is set to *true*.
+		This starts at *0* and counts how many times [page:Source.needsUpdate .needsUpdate] is set to *true*.
 		</p>
 
 		<h2>Methods</h2>


### PR DESCRIPTION
Related issue: -

**Description**

Replaces a few `[property: ...]` tags with `[page: ...]` tags.