### PR TITLE
PolarGridHelper: Allow zero radials or zero circles

### DIFF
--- a/docs/api/en/helpers/PolarGridHelper.html
+++ b/docs/api/en/helpers/PolarGridHelper.html
@@ -36,8 +36,8 @@
 		<h3>[name]( [param:Number radius], [param:Number radials], [param:Number circles], [param:Number divisions], [param:Color color1], [param:Color color2] )</h3>
 		<p>
 		radius -- The radius of the polar grid. This can be any positive number. Default is 10.<br />
-		radials -- The number of radial lines. This can be any positive integer. Default is 16.<br />
-		circles -- The number of circles. This can be any positive integer. Default is 8.<br />
+		radials -- The number of radial lines. This can be any positive integer including 0. Default is 16.<br />
+		circles -- The number of circles. This can be any positive integer including 0. Default is 8.<br />
 		divisions -- The number of line segments used for each circle. This can be any positive integer that is 3 or greater. Default is 64.<br />
 		color1 -- The first color used for grid elements. This can be a [page:Color], a hexadecimal value and an CSS-Color name. Default is 0x444444 <br />
 		color2 -- The second color used for grid elements. This can be a [page:Color], a hexadecimal value and an CSS-Color name. Default is 0x888888

--- a/docs/api/en/helpers/PolarGridHelper.html
+++ b/docs/api/en/helpers/PolarGridHelper.html
@@ -17,11 +17,11 @@
 
 		<code>
 		const radius = 10;
-		const radials = 16;
-		const circles = 8;
+		const sectors = 16;
+		const rings = 8;
 		const divisions = 64;
 
-		const helper = new THREE.PolarGridHelper( radius, radials, circles, divisions );
+		const helper = new THREE.PolarGridHelper( radius, sectors, rings, divisions );
 		scene.add( helper );
 		</code>
 
@@ -33,17 +33,17 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [param:Number radius], [param:Number radials], [param:Number circles], [param:Number divisions], [param:Color color1], [param:Color color2] )</h3>
+		<h3>[name]( [param:Number radius], [param:Number sectors], [param:Number rings], [param:Number divisions], [param:Color color1], [param:Color color2] )</h3>
 		<p>
 		radius -- The radius of the polar grid. This can be any positive number. Default is 10.<br />
-		radials -- The number of radial lines. This can be any positive integer including 0. Default is 16.<br />
-		circles -- The number of circles. This can be any positive integer including 0. Default is 8.<br />
+		sectors -- The number of sectors the grid will be divided into. This can be any positive integer. Default is 16.<br />
+		rings -- The number of rings. This can be any positive integer. Default is 8.<br />
 		divisions -- The number of line segments used for each circle. This can be any positive integer that is 3 or greater. Default is 64.<br />
 		color1 -- The first color used for grid elements. This can be a [page:Color], a hexadecimal value and an CSS-Color name. Default is 0x444444 <br />
 		color2 -- The second color used for grid elements. This can be a [page:Color], a hexadecimal value and an CSS-Color name. Default is 0x888888
 		</p>
 		<p>
-		Creates a new [name] of radius 'radius' with 'radials' number of radials and 'circles' number of circles, where each circle is smoothed into 'divisions' number of line segments. Colors are optional.
+		Creates a new [name] of radius 'radius' with 'sectors' number of sectors and 'rings' number of rings, where each circle is smoothed into 'divisions' number of line segments. Colors are optional.
 		</p>
 
 		<h2>Source</h2>

--- a/src/helpers/PolarGridHelper.js
+++ b/src/helpers/PolarGridHelper.js
@@ -6,7 +6,7 @@ import { Color } from '../math/Color.js';
 
 class PolarGridHelper extends LineSegments {
 
-	constructor( radius = 10, radials = 16, circles = 8, divisions = 64, color1 = 0x444444, color2 = 0x888888 ) {
+	constructor( radius = 10, sectors = 16, rings = 8, divisions = 64, color1 = 0x444444, color2 = 0x888888 ) {
 
 		color1 = new Color( color1 );
 		color2 = new Color( color2 );
@@ -14,32 +14,34 @@ class PolarGridHelper extends LineSegments {
 		const vertices = [];
 		const colors = [];
 
-		// create the radials
+		// create the sectors
 
-		for ( let i = 0; i < radials; i ++ ) {
+		if (sectors > 1) {
+			for ( let i = 0; i < sectors; i ++ ) {
 
-			const v = ( i / radials ) * ( Math.PI * 2 );
+				const v = ( i / sectors ) * ( Math.PI * 2 );
 
-			const x = Math.sin( v ) * radius;
-			const z = Math.cos( v ) * radius;
+				const x = Math.sin( v ) * radius;
+				const z = Math.cos( v ) * radius;
 
-			vertices.push( 0, 0, 0 );
-			vertices.push( x, 0, z );
+				vertices.push( 0, 0, 0 );
+				vertices.push( x, 0, z );
 
-			const color = ( i & 1 ) ? color1 : color2;
+				const color = ( i & 1 ) ? color1 : color2;
 
-			colors.push( color.r, color.g, color.b );
-			colors.push( color.r, color.g, color.b );
+				colors.push( color.r, color.g, color.b );
+				colors.push( color.r, color.g, color.b );
 
+			}
 		}
 
-		// create the circles
+		// create the rings
 
-		for ( let i = 0; i < circles; i ++ ) {
+		for ( let i = 0; i < rings; i ++ ) {
 
 			const color = ( i & 1 ) ? color1 : color2;
 
-			const r = radius - ( radius / circles * i );
+			const r = radius - ( radius / rings * i );
 
 			for ( let j = 0; j < divisions; j ++ ) {
 

--- a/src/helpers/PolarGridHelper.js
+++ b/src/helpers/PolarGridHelper.js
@@ -16,7 +16,8 @@ class PolarGridHelper extends LineSegments {
 
 		// create the sectors
 
-		if (sectors > 1) {
+		if ( sectors > 1 ) {
+
 			for ( let i = 0; i < sectors; i ++ ) {
 
 				const v = ( i / sectors ) * ( Math.PI * 2 );
@@ -33,6 +34,7 @@ class PolarGridHelper extends LineSegments {
 				colors.push( color.r, color.g, color.b );
 
 			}
+
 		}
 
 		// create the rings

--- a/src/helpers/PolarGridHelper.js
+++ b/src/helpers/PolarGridHelper.js
@@ -16,7 +16,7 @@ class PolarGridHelper extends LineSegments {
 
 		// create the radials
 
-		for ( let i = 0; i <= radials; i ++ ) {
+		for ( let i = 0; i < radials; i ++ ) {
 
 			const v = ( i / radials ) * ( Math.PI * 2 );
 
@@ -35,7 +35,7 @@ class PolarGridHelper extends LineSegments {
 
 		// create the circles
 
-		for ( let i = 0; i <= circles; i ++ ) {
+		for ( let i = 0; i < circles; i ++ ) {
 
 			const color = ( i & 1 ) ? color1 : color2;
 


### PR DESCRIPTION
Prevents from getting NaN values when 0 radials or 0 circles are used.

Related issue: none

**Description**

Previously, if a `PolarGridHelper` is created with 0 radials or 0 circles, we get the following error: 
```
THREE.BufferGeometry.computeBoundingSphere(): Computed radius is NaN. The "position" attribute is likely to have NaN values. 
```
The NaN values come from the for-loops doing an iteration for 0 wich causes a 0/0 division resulting in a NaN.

By changing the looping condition to a "less than", no iterations are done so no NaN is created, allowing for a polar grid with no radials or no circles without getting an error.
