### PR TITLE
BufferAttribute: Fix the behavior of ".set" function

### DIFF
--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -311,9 +311,12 @@ class BufferAttribute {
 
 	set( value, offset = 0 ) {
 
-		if ( this.normalized ) value = normalize( value, this.array );
+		const array = this.array;
+		const normalized = this.normalized;
 
-		this.array.set( value, offset );
+		if ( normalized ) value = value.map( v => normalize( v, array ) );
+
+		array.set( value, offset );
 
 		return this;
 


### PR DESCRIPTION
Related issue: #22874

**Description**

The `BufferAttribute.set` function takes an array not a scalar value.

cc @donmccurdy 