### PR TITLE
BufferAttribute: Make normalize() and denormalize() internal functions

### DIFF
--- a/examples/jsm/utils/BufferGeometryUtils.js
+++ b/examples/jsm/utils/BufferGeometryUtils.js
@@ -5,7 +5,6 @@ import {
 	InstancedBufferAttribute,
 	InterleavedBuffer,
 	InterleavedBufferAttribute,
-	MathUtils,
 	TriangleFanDrawMode,
 	TriangleStripDrawMode,
 	TrianglesDrawMode,
@@ -36,17 +35,16 @@ function computeMikkTSpaceTangents( geometry, MikkTSpace, negateSign = true ) {
 
 		if ( attribute.normalized || attribute.isInterleavedBufferAttribute ) {
 
-			const srcArray = attribute.isInterleavedBufferAttribute ? attribute.data.array : attribute.array;
 			const dstArray = new Float32Array( attribute.getCount() * attribute.itemSize );
 
 			for ( let i = 0, j = 0; i < attribute.getCount(); i ++ ) {
 
-				dstArray[ j ++ ] = MathUtils.intToFloat( attribute.getX( i ), srcArray );
-				dstArray[ j ++ ] = MathUtils.intToFloat( attribute.getY( i ), srcArray );
+				dstArray[ j ++ ] = attribute.getX( i );
+				dstArray[ j ++ ] = attribute.getY( i );
 
 				if ( attribute.itemSize > 2 ) {
 
-					dstArray[ j ++ ] = MathUtils.intToFloat( attribute.getZ( i ), srcArray );
+					dstArray[ j ++ ] = attribute.getZ( i );
 
 				}
 

--- a/examples/jsm/utils/BufferGeometryUtils.js
+++ b/examples/jsm/utils/BufferGeometryUtils.js
@@ -41,12 +41,12 @@ function computeMikkTSpaceTangents( geometry, MikkTSpace, negateSign = true ) {
 
 			for ( let i = 0, j = 0; i < attribute.getCount(); i ++ ) {
 
-				dstArray[ j ++ ] = MathUtils.denormalize( attribute.getX( i ), srcArray );
-				dstArray[ j ++ ] = MathUtils.denormalize( attribute.getY( i ), srcArray );
+				dstArray[ j ++ ] = MathUtils.intToFloat( attribute.getX( i ), srcArray );
+				dstArray[ j ++ ] = MathUtils.intToFloat( attribute.getY( i ), srcArray );
 
 				if ( attribute.itemSize > 2 ) {
 
-					dstArray[ j ++ ] = MathUtils.denormalize( attribute.getZ( i ), srcArray );
+					dstArray[ j ++ ] = MathUtils.intToFloat( attribute.getZ( i ), srcArray );
 
 				}
 

--- a/src/Three.js
+++ b/src/Three.js
@@ -98,7 +98,19 @@ export { InstancedInterleavedBuffer } from './core/InstancedInterleavedBuffer.js
 export { InterleavedBuffer } from './core/InterleavedBuffer.js';
 export { InstancedBufferAttribute } from './core/InstancedBufferAttribute.js';
 export { GLBufferAttribute } from './core/GLBufferAttribute.js';
-export * from './core/BufferAttribute.js';
+export {
+	Float64BufferAttribute,
+	Float32BufferAttribute,
+	Float16BufferAttribute,
+	Uint32BufferAttribute,
+	Int32BufferAttribute,
+	Uint16BufferAttribute,
+	Int16BufferAttribute,
+	Uint8ClampedBufferAttribute,
+	Uint8BufferAttribute,
+	Int8BufferAttribute,
+	BufferAttribute
+} from './core/BufferAttribute.js';
 export { Object3D } from './core/Object3D.js';
 export { Raycaster } from './core/Raycaster.js';
 export { Layers } from './core/Layers.js';

--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -2,7 +2,7 @@ import { Vector4 } from '../math/Vector4.js';
 import { Vector3 } from '../math/Vector3.js';
 import { Vector2 } from '../math/Vector2.js';
 import { Color } from '../math/Color.js';
-import { denormalize, normalize } from '../math/MathUtils.js';
+import { intToFloat, floatToInt } from '../math/MathUtils.js';
 import { StaticDrawUsage } from '../constants.js';
 
 const _vector = /*@__PURE__*/ new Vector3();
@@ -105,9 +105,9 @@ class BufferAttribute {
 
 			if ( this.normalized ) {
 
-				array[ offset ++ ] = normalize( color.r, array );
-				array[ offset ++ ] = normalize( color.g, array );
-				array[ offset ++ ] = normalize( color.b, array );
+				array[ offset ++ ] = floatToInt( color.r, array );
+				array[ offset ++ ] = floatToInt( color.g, array );
+				array[ offset ++ ] = floatToInt( color.b, array );
 
 			} else {
 
@@ -141,8 +141,8 @@ class BufferAttribute {
 
 			if ( this.normalized ) {
 
-				array[ offset ++ ] = normalize( vector.x, array );
-				array[ offset ++ ] = normalize( vector.y, array );
+				array[ offset ++ ] = floatToInt( vector.x, array );
+				array[ offset ++ ] = floatToInt( vector.y, array );
 
 			} else {
 
@@ -175,9 +175,9 @@ class BufferAttribute {
 
 			if ( this.normalized ) {
 
-				array[ offset ++ ] = normalize( vector.x, array );
-				array[ offset ++ ] = normalize( vector.y, array );
-				array[ offset ++ ] = normalize( vector.z, array );
+				array[ offset ++ ] = floatToInt( vector.x, array );
+				array[ offset ++ ] = floatToInt( vector.y, array );
+				array[ offset ++ ] = floatToInt( vector.z, array );
 
 			} else {
 
@@ -211,10 +211,10 @@ class BufferAttribute {
 
 			if ( this.normalized ) {
 
-				array[ offset ++ ] = normalize( vector.x, array );
-				array[ offset ++ ] = normalize( vector.y, array );
-				array[ offset ++ ] = normalize( vector.z, array );
-				array[ offset ++ ] = normalize( vector.w, array );
+				array[ offset ++ ] = floatToInt( vector.x, array );
+				array[ offset ++ ] = floatToInt( vector.y, array );
+				array[ offset ++ ] = floatToInt( vector.z, array );
+				array[ offset ++ ] = floatToInt( vector.w, array );
 
 			} else {
 
@@ -311,7 +311,7 @@ class BufferAttribute {
 
 	set( value, offset = 0 ) {
 
-		if ( this.normalized ) value = normalize( value, this.array );
+		if ( this.normalized ) value = floatToInt( value, this.array );
 
 		this.array.set( value, offset );
 
@@ -323,7 +323,7 @@ class BufferAttribute {
 
 		let x = this.array[ index * this.itemSize ];
 
-		if ( this.normalized ) x = denormalize( x, this.array );
+		if ( this.normalized ) x = intToFloat( x, this.array );
 
 		return x;
 
@@ -331,7 +331,7 @@ class BufferAttribute {
 
 	setX( index, x ) {
 
-		if ( this.normalized ) x = normalize( x, this.array );
+		if ( this.normalized ) x = floatToInt( x, this.array );
 
 		this.array[ index * this.itemSize ] = x;
 
@@ -343,7 +343,7 @@ class BufferAttribute {
 
 		let y = this.array[ index * this.itemSize + 1 ];
 
-		if ( this.normalized ) y = denormalize( y, this.array );
+		if ( this.normalized ) y = intToFloat( y, this.array );
 
 		return y;
 
@@ -351,7 +351,7 @@ class BufferAttribute {
 
 	setY( index, y ) {
 
-		if ( this.normalized ) y = normalize( y, this.array );
+		if ( this.normalized ) y = floatToInt( y, this.array );
 
 		this.array[ index * this.itemSize + 1 ] = y;
 
@@ -363,7 +363,7 @@ class BufferAttribute {
 
 		let z = this.array[ index * this.itemSize + 2 ];
 
-		if ( this.normalized ) z = denormalize( z, this.array );
+		if ( this.normalized ) z = intToFloat( z, this.array );
 
 		return z;
 
@@ -371,7 +371,7 @@ class BufferAttribute {
 
 	setZ( index, z ) {
 
-		if ( this.normalized ) z = normalize( z, this.array );
+		if ( this.normalized ) z = floatToInt( z, this.array );
 
 		this.array[ index * this.itemSize + 2 ] = z;
 
@@ -383,7 +383,7 @@ class BufferAttribute {
 
 		let w = this.array[ index * this.itemSize + 3 ];
 
-		if ( this.normalized ) w = denormalize( w, this.array );
+		if ( this.normalized ) w = intToFloat( w, this.array );
 
 		return w;
 
@@ -391,7 +391,7 @@ class BufferAttribute {
 
 	setW( index, w ) {
 
-		if ( this.normalized ) w = normalize( w, this.array );
+		if ( this.normalized ) w = floatToInt( w, this.array );
 
 		this.array[ index * this.itemSize + 3 ] = w;
 
@@ -405,8 +405,8 @@ class BufferAttribute {
 
 		if ( this.normalized ) {
 
-			x = normalize( x, this.array );
-			y = normalize( y, this.array );
+			x = floatToInt( x, this.array );
+			y = floatToInt( y, this.array );
 
 		}
 
@@ -423,9 +423,9 @@ class BufferAttribute {
 
 		if ( this.normalized ) {
 
-			x = normalize( x, this.array );
-			y = normalize( y, this.array );
-			z = normalize( z, this.array );
+			x = floatToInt( x, this.array );
+			y = floatToInt( y, this.array );
+			z = floatToInt( z, this.array );
 
 		}
 
@@ -443,10 +443,10 @@ class BufferAttribute {
 
 		if ( this.normalized ) {
 
-			x = normalize( x, this.array );
-			y = normalize( y, this.array );
-			z = normalize( z, this.array );
-			w = normalize( w, this.array );
+			x = floatToInt( x, this.array );
+			y = floatToInt( y, this.array );
+			z = floatToInt( z, this.array );
+			w = floatToInt( w, this.array );
 
 		}
 

--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -2,8 +2,7 @@ import { Vector4 } from '../math/Vector4.js';
 import { Vector3 } from '../math/Vector3.js';
 import { Vector2 } from '../math/Vector2.js';
 import { Color } from '../math/Color.js';
-import { intToFloat, floatToInt } from '../math/MathUtils.js';
-import { StaticDrawUsage } from '../constants.js';
+import { ByteType, FloatType, IntType, ShortType, StaticDrawUsage, UnsignedByteType, UnsignedIntType, UnsignedShortType } from '../constants.js';
 
 const _vector = /*@__PURE__*/ new Vector3();
 const _vector2 = /*@__PURE__*/ new Vector2();
@@ -26,6 +25,8 @@ class BufferAttribute {
 		this.itemSize = itemSize;
 		this.count = array !== undefined ? array.length / itemSize : 0;
 		this.normalized = normalized === true;
+
+		this.type = getArrayType( array );
 
 		this.usage = StaticDrawUsage;
 		this.updateRange = { offset: 0, count: - 1 };
@@ -57,6 +58,8 @@ class BufferAttribute {
 		this.itemSize = source.itemSize;
 		this.count = source.count;
 		this.normalized = source.normalized;
+
+		this.type = source.type;
 
 		this.usage = source.usage;
 
@@ -105,9 +108,9 @@ class BufferAttribute {
 
 			if ( this.normalized ) {
 
-				array[ offset ++ ] = floatToInt( color.r, array );
-				array[ offset ++ ] = floatToInt( color.g, array );
-				array[ offset ++ ] = floatToInt( color.b, array );
+				array[ offset ++ ] = denormalize( color.r, this.type );
+				array[ offset ++ ] = denormalize( color.g, this.type );
+				array[ offset ++ ] = denormalize( color.b, this.type );
 
 			} else {
 
@@ -141,8 +144,8 @@ class BufferAttribute {
 
 			if ( this.normalized ) {
 
-				array[ offset ++ ] = floatToInt( vector.x, array );
-				array[ offset ++ ] = floatToInt( vector.y, array );
+				array[ offset ++ ] = denormalize( vector.x, this.type );
+				array[ offset ++ ] = denormalize( vector.y, this.type );
 
 			} else {
 
@@ -175,9 +178,9 @@ class BufferAttribute {
 
 			if ( this.normalized ) {
 
-				array[ offset ++ ] = floatToInt( vector.x, array );
-				array[ offset ++ ] = floatToInt( vector.y, array );
-				array[ offset ++ ] = floatToInt( vector.z, array );
+				array[ offset ++ ] = denormalize( vector.x, this.type );
+				array[ offset ++ ] = denormalize( vector.y, this.type );
+				array[ offset ++ ] = denormalize( vector.z, this.type );
 
 			} else {
 
@@ -211,10 +214,10 @@ class BufferAttribute {
 
 			if ( this.normalized ) {
 
-				array[ offset ++ ] = floatToInt( vector.x, array );
-				array[ offset ++ ] = floatToInt( vector.y, array );
-				array[ offset ++ ] = floatToInt( vector.z, array );
-				array[ offset ++ ] = floatToInt( vector.w, array );
+				array[ offset ++ ] = denormalize( vector.x, this.type );
+				array[ offset ++ ] = denormalize( vector.y, this.type );
+				array[ offset ++ ] = denormalize( vector.z, this.type );
+				array[ offset ++ ] = denormalize( vector.w, this.type );
 
 			} else {
 
@@ -311,7 +314,11 @@ class BufferAttribute {
 
 	set( value, offset = 0 ) {
 
-		if ( this.normalized ) value = floatToInt( value, this.array );
+		if ( this.normalized && Array.isArray( value ) ) {
+
+			throw new TypeError( 'THREE.BufferAttribute: array should be a Typed Array.' );
+
+		}
 
 		this.array.set( value, offset );
 
@@ -323,7 +330,7 @@ class BufferAttribute {
 
 		let x = this.array[ index * this.itemSize ];
 
-		if ( this.normalized ) x = intToFloat( x, this.array );
+		if ( this.normalized ) x = normalize( x, this.type );
 
 		return x;
 
@@ -331,7 +338,7 @@ class BufferAttribute {
 
 	setX( index, x ) {
 
-		if ( this.normalized ) x = floatToInt( x, this.array );
+		if ( this.normalized ) x = denormalize( x, this.type );
 
 		this.array[ index * this.itemSize ] = x;
 
@@ -343,7 +350,7 @@ class BufferAttribute {
 
 		let y = this.array[ index * this.itemSize + 1 ];
 
-		if ( this.normalized ) y = intToFloat( y, this.array );
+		if ( this.normalized ) y = normalize( y, this.type );
 
 		return y;
 
@@ -351,7 +358,7 @@ class BufferAttribute {
 
 	setY( index, y ) {
 
-		if ( this.normalized ) y = floatToInt( y, this.array );
+		if ( this.normalized ) y = denormalize( y, this.type );
 
 		this.array[ index * this.itemSize + 1 ] = y;
 
@@ -363,7 +370,7 @@ class BufferAttribute {
 
 		let z = this.array[ index * this.itemSize + 2 ];
 
-		if ( this.normalized ) z = intToFloat( z, this.array );
+		if ( this.normalized ) z = normalize( z, this.type );
 
 		return z;
 
@@ -371,7 +378,7 @@ class BufferAttribute {
 
 	setZ( index, z ) {
 
-		if ( this.normalized ) z = floatToInt( z, this.array );
+		if ( this.normalized ) z = denormalize( z, this.type );
 
 		this.array[ index * this.itemSize + 2 ] = z;
 
@@ -383,7 +390,7 @@ class BufferAttribute {
 
 		let w = this.array[ index * this.itemSize + 3 ];
 
-		if ( this.normalized ) w = intToFloat( w, this.array );
+		if ( this.normalized ) w = normalize( w, this.type );
 
 		return w;
 
@@ -391,7 +398,7 @@ class BufferAttribute {
 
 	setW( index, w ) {
 
-		if ( this.normalized ) w = floatToInt( w, this.array );
+		if ( this.normalized ) w = denormalize( w, this.type );
 
 		this.array[ index * this.itemSize + 3 ] = w;
 
@@ -405,8 +412,8 @@ class BufferAttribute {
 
 		if ( this.normalized ) {
 
-			x = floatToInt( x, this.array );
-			y = floatToInt( y, this.array );
+			x = denormalize( x, this.type );
+			y = denormalize( y, this.type );
 
 		}
 
@@ -423,9 +430,9 @@ class BufferAttribute {
 
 		if ( this.normalized ) {
 
-			x = floatToInt( x, this.array );
-			y = floatToInt( y, this.array );
-			z = floatToInt( z, this.array );
+			x = denormalize( x, this.type );
+			y = denormalize( y, this.type );
+			z = denormalize( z, this.type );
 
 		}
 
@@ -443,10 +450,10 @@ class BufferAttribute {
 
 		if ( this.normalized ) {
 
-			x = floatToInt( x, this.array );
-			y = floatToInt( y, this.array );
-			z = floatToInt( z, this.array );
-			w = floatToInt( w, this.array );
+			x = denormalize( x, this.type );
+			y = denormalize( y, this.type );
+			z = denormalize( z, this.type );
+			w = denormalize( w, this.type );
 
 		}
 
@@ -599,6 +606,114 @@ class Float64BufferAttribute extends BufferAttribute {
 
 //
 
+function getArrayType( array ) {
+
+	switch ( array.constructor ) {
+
+		case Uint32Array:
+
+			return UnsignedIntType;
+
+		case Uint16Array:
+
+			return UnsignedShortType;
+
+		case Uint8Array:
+		case Uint8ClampedArray:
+
+			return UnsignedByteType;
+
+		case Int32Array:
+
+			return IntType;
+
+		case Int16Array:
+
+			return ShortType;
+
+		case Int8Array:
+
+			return ByteType;
+
+		case Float32Array:
+		case Float64Array:
+
+			return FloatType;
+
+		default:
+
+			throw new Error( 'THREE.BufferAttribute: Invalid type.' );
+
+	}
+
+}
+
+function normalize( value, type ) {
+
+	switch ( type ) {
+
+		case FloatType:
+
+			return value;
+
+		case UnsignedShortType:
+
+			return value / 65535.0;
+
+		case UnsignedByteType:
+
+			return value / 255.0;
+
+		case ShortType:
+
+			return Math.max( value / 32767.0, - 1.0 );
+
+		case ByteType:
+
+			return Math.max( value / 127.0, - 1.0 );
+
+		default:
+
+			throw new Error( 'THREE.BufferAttribute: Invalid type.' );
+
+	}
+
+}
+
+function denormalize( value, type ) {
+
+	switch ( type ) {
+
+		case FloatType:
+
+			return value;
+
+		case UnsignedShortType:
+
+			return Math.round( value * 65535.0 );
+
+		case UnsignedByteType:
+
+			return Math.round( value * 255.0 );
+
+		case ShortType:
+
+			return Math.round( value * 32767.0 );
+
+		case ByteType:
+
+			return Math.round( value * 127.0 );
+
+		default:
+
+			throw new Error( 'THREE.BufferAttribute: Invalid type.' );
+
+	}
+
+}
+
+//
+
 export {
 	Float64BufferAttribute,
 	Float32BufferAttribute,
@@ -610,5 +725,8 @@ export {
 	Uint8ClampedBufferAttribute,
 	Uint8BufferAttribute,
 	Int8BufferAttribute,
-	BufferAttribute
+	BufferAttribute,
+	normalize,
+	denormalize,
+	getArrayType
 };

--- a/src/core/InterleavedBufferAttribute.js
+++ b/src/core/InterleavedBufferAttribute.js
@@ -1,6 +1,6 @@
 import { Vector3 } from '../math/Vector3.js';
 import { BufferAttribute } from './BufferAttribute.js';
-import { denormalize, normalize } from '../math/MathUtils.js';
+import { intToFloat, floatToInt } from '../math/MathUtils.js';
 
 const _vector = /*@__PURE__*/ new Vector3();
 
@@ -88,7 +88,7 @@ class InterleavedBufferAttribute {
 
 	setX( index, x ) {
 
-		if ( this.normalized ) x = normalize( x, this.array );
+		if ( this.normalized ) x = floatToInt( x, this.array );
 
 		this.data.array[ index * this.data.stride + this.offset ] = x;
 
@@ -98,7 +98,7 @@ class InterleavedBufferAttribute {
 
 	setY( index, y ) {
 
-		if ( this.normalized ) y = normalize( y, this.array );
+		if ( this.normalized ) y = floatToInt( y, this.array );
 
 		this.data.array[ index * this.data.stride + this.offset + 1 ] = y;
 
@@ -108,7 +108,7 @@ class InterleavedBufferAttribute {
 
 	setZ( index, z ) {
 
-		if ( this.normalized ) z = normalize( z, this.array );
+		if ( this.normalized ) z = floatToInt( z, this.array );
 
 		this.data.array[ index * this.data.stride + this.offset + 2 ] = z;
 
@@ -118,7 +118,7 @@ class InterleavedBufferAttribute {
 
 	setW( index, w ) {
 
-		if ( this.normalized ) w = normalize( w, this.array );
+		if ( this.normalized ) w = floatToInt( w, this.array );
 
 		this.data.array[ index * this.data.stride + this.offset + 3 ] = w;
 
@@ -130,7 +130,7 @@ class InterleavedBufferAttribute {
 
 		let x = this.data.array[ index * this.data.stride + this.offset ];
 
-		if ( this.normalized ) x = denormalize( x, this.array );
+		if ( this.normalized ) x = intToFloat( x, this.array );
 
 		return x;
 
@@ -140,7 +140,7 @@ class InterleavedBufferAttribute {
 
 		let y = this.data.array[ index * this.data.stride + this.offset + 1 ];
 
-		if ( this.normalized ) y = denormalize( y, this.array );
+		if ( this.normalized ) y = intToFloat( y, this.array );
 
 		return y;
 
@@ -150,7 +150,7 @@ class InterleavedBufferAttribute {
 
 		let z = this.data.array[ index * this.data.stride + this.offset + 2 ];
 
-		if ( this.normalized ) z = denormalize( z, this.array );
+		if ( this.normalized ) z = intToFloat( z, this.array );
 
 		return z;
 
@@ -160,7 +160,7 @@ class InterleavedBufferAttribute {
 
 		let w = this.data.array[ index * this.data.stride + this.offset + 3 ];
 
-		if ( this.normalized ) w = denormalize( w, this.array );
+		if ( this.normalized ) w = intToFloat( w, this.array );
 
 		return w;
 
@@ -172,8 +172,8 @@ class InterleavedBufferAttribute {
 
 		if ( this.normalized ) {
 
-			x = normalize( x, this.array );
-			y = normalize( y, this.array );
+			x = floatToInt( x, this.array );
+			y = floatToInt( y, this.array );
 
 		}
 
@@ -190,9 +190,9 @@ class InterleavedBufferAttribute {
 
 		if ( this.normalized ) {
 
-			x = normalize( x, this.array );
-			y = normalize( y, this.array );
-			z = normalize( z, this.array );
+			x = floatToInt( x, this.array );
+			y = floatToInt( y, this.array );
+			z = floatToInt( z, this.array );
 
 		}
 
@@ -210,10 +210,10 @@ class InterleavedBufferAttribute {
 
 		if ( this.normalized ) {
 
-			x = normalize( x, this.array );
-			y = normalize( y, this.array );
-			z = normalize( z, this.array );
-			w = normalize( w, this.array );
+			x = floatToInt( x, this.array );
+			y = floatToInt( y, this.array );
+			z = floatToInt( z, this.array );
+			w = floatToInt( w, this.array );
 
 		}
 

--- a/src/core/InterleavedBufferAttribute.js
+++ b/src/core/InterleavedBufferAttribute.js
@@ -1,6 +1,5 @@
 import { Vector3 } from '../math/Vector3.js';
-import { BufferAttribute } from './BufferAttribute.js';
-import { intToFloat, floatToInt } from '../math/MathUtils.js';
+import { BufferAttribute, getArrayType, normalize, denormalize } from './BufferAttribute.js';
 
 const _vector = /*@__PURE__*/ new Vector3();
 
@@ -17,6 +16,8 @@ class InterleavedBufferAttribute {
 		this.offset = offset;
 
 		this.normalized = normalized === true;
+
+		this.type = getArrayType( this.array );
 
 	}
 
@@ -88,7 +89,7 @@ class InterleavedBufferAttribute {
 
 	setX( index, x ) {
 
-		if ( this.normalized ) x = floatToInt( x, this.array );
+		if ( this.normalized ) x = denormalize( x, this.type );
 
 		this.data.array[ index * this.data.stride + this.offset ] = x;
 
@@ -98,7 +99,7 @@ class InterleavedBufferAttribute {
 
 	setY( index, y ) {
 
-		if ( this.normalized ) y = floatToInt( y, this.array );
+		if ( this.normalized ) y = denormalize( y, this.type );
 
 		this.data.array[ index * this.data.stride + this.offset + 1 ] = y;
 
@@ -108,7 +109,7 @@ class InterleavedBufferAttribute {
 
 	setZ( index, z ) {
 
-		if ( this.normalized ) z = floatToInt( z, this.array );
+		if ( this.normalized ) z = denormalize( z, this.type );
 
 		this.data.array[ index * this.data.stride + this.offset + 2 ] = z;
 
@@ -118,7 +119,7 @@ class InterleavedBufferAttribute {
 
 	setW( index, w ) {
 
-		if ( this.normalized ) w = floatToInt( w, this.array );
+		if ( this.normalized ) w = denormalize( w, this.type );
 
 		this.data.array[ index * this.data.stride + this.offset + 3 ] = w;
 
@@ -130,7 +131,7 @@ class InterleavedBufferAttribute {
 
 		let x = this.data.array[ index * this.data.stride + this.offset ];
 
-		if ( this.normalized ) x = intToFloat( x, this.array );
+		if ( this.normalized ) x = normalize( x, this.type );
 
 		return x;
 
@@ -140,7 +141,7 @@ class InterleavedBufferAttribute {
 
 		let y = this.data.array[ index * this.data.stride + this.offset + 1 ];
 
-		if ( this.normalized ) y = intToFloat( y, this.array );
+		if ( this.normalized ) y = normalize( y, this.type );
 
 		return y;
 
@@ -150,7 +151,7 @@ class InterleavedBufferAttribute {
 
 		let z = this.data.array[ index * this.data.stride + this.offset + 2 ];
 
-		if ( this.normalized ) z = intToFloat( z, this.array );
+		if ( this.normalized ) z = normalize( z, this.type );
 
 		return z;
 
@@ -160,7 +161,7 @@ class InterleavedBufferAttribute {
 
 		let w = this.data.array[ index * this.data.stride + this.offset + 3 ];
 
-		if ( this.normalized ) w = intToFloat( w, this.array );
+		if ( this.normalized ) w = normalize( w, this.type );
 
 		return w;
 
@@ -172,8 +173,8 @@ class InterleavedBufferAttribute {
 
 		if ( this.normalized ) {
 
-			x = floatToInt( x, this.array );
-			y = floatToInt( y, this.array );
+			x = denormalize( x, this.type );
+			y = denormalize( y, this.type );
 
 		}
 
@@ -190,9 +191,9 @@ class InterleavedBufferAttribute {
 
 		if ( this.normalized ) {
 
-			x = floatToInt( x, this.array );
-			y = floatToInt( y, this.array );
-			z = floatToInt( z, this.array );
+			x = denormalize( x, this.type );
+			y = denormalize( y, this.type );
+			z = denormalize( z, this.type );
 
 		}
 
@@ -210,10 +211,10 @@ class InterleavedBufferAttribute {
 
 		if ( this.normalized ) {
 
-			x = floatToInt( x, this.array );
-			y = floatToInt( y, this.array );
-			z = floatToInt( z, this.array );
-			w = floatToInt( w, this.array );
+			x = denormalize( x, this.type );
+			y = denormalize( y, this.type );
+			z = denormalize( z, this.type );
+			w = denormalize( w, this.type );
 
 		}
 

--- a/src/math/MathUtils.js
+++ b/src/math/MathUtils.js
@@ -227,101 +227,6 @@ function setQuaternionFromProperEuler( q, a, b, c, order ) {
 
 }
 
-function intToFloat( value, array ) {
-
-	switch ( array.constructor ) {
-
-		case Float32Array:
-
-			return value;
-
-		case Uint16Array:
-
-			return value / 65535.0;
-
-		case Uint8Array:
-
-			return value / 255.0;
-
-		case Int16Array:
-
-			return Math.max( value / 32767.0, - 1.0 );
-
-		case Int8Array:
-
-			return Math.max( value / 127.0, - 1.0 );
-
-		default:
-
-			throw new Error( 'Invalid component type.' );
-
-	}
-
-}
-
-function floatToInt( value, array ) {
-
-	switch ( array.constructor ) {
-
-		case Float32Array:
-
-			return value;
-
-		case Uint16Array:
-
-			return Math.round( value * 65535.0 );
-
-		case Uint8Array:
-
-			return Math.round( value * 255.0 );
-
-		case Int16Array:
-
-			return Math.round( value * 32767.0 );
-
-		case Int8Array:
-
-			return Math.round( value * 127.0 );
-
-		default:
-
-			throw new Error( 'Invalid component type.' );
-
-	}
-
-}
-
-let _didIntToFloatWarning = false;
-let _didFloatToIntWarning = false;
-
-function normalize( value, array ) {
-
-	if ( _didFloatToIntWarning === false ) {
-
-		console.warn( 'THREE.MathUtils: normalize() renamed floatToInt()' );
-
-		_didFloatToIntWarning = true;
-
-	}
-
-	return floatToInt( value, array );
-
-}
-
-function denormalize( value, array ) {
-
-	if ( _didIntToFloatWarning === false ) {
-
-		console.warn( 'THREE.MathUtils: denormalize() renamed intToFloat()' );
-
-		_didIntToFloatWarning = true;
-
-	}
-
-	return intToFloat( value, array );
-
-}
-
 export {
 	DEG2RAD,
 	RAD2DEG,
@@ -344,9 +249,5 @@ export {
 	isPowerOfTwo,
 	ceilPowerOfTwo,
 	floorPowerOfTwo,
-	setQuaternionFromProperEuler,
-	normalize,
-	denormalize,
-	floatToInt,
-	intToFloat
+	setQuaternionFromProperEuler
 };

--- a/src/math/MathUtils.js
+++ b/src/math/MathUtils.js
@@ -227,7 +227,7 @@ function setQuaternionFromProperEuler( q, a, b, c, order ) {
 
 }
 
-function denormalize( value, array ) {
+function intToFloat( value, array ) {
 
 	switch ( array.constructor ) {
 
@@ -259,7 +259,7 @@ function denormalize( value, array ) {
 
 }
 
-function normalize( value, array ) {
+function floatToInt( value, array ) {
 
 	switch ( array.constructor ) {
 
@@ -291,7 +291,36 @@ function normalize( value, array ) {
 
 }
 
+let _didIntToFloatWarning = false;
+let _didFloatToIntWarning = false;
 
+function normalize( value, array ) {
+
+	if ( _didFloatToIntWarning === false ) {
+
+		console.warn( 'THREE.MathUtils: normalize() renamed floatToInt()' );
+
+		_didFloatToIntWarning = true;
+
+	}
+
+	return floatToInt( value, array );
+
+}
+
+function denormalize( value, array ) {
+
+	if ( _didIntToFloatWarning === false ) {
+
+		console.warn( 'THREE.MathUtils: denormalize() renamed intToFloat()' );
+
+		_didIntToFloatWarning = true;
+
+	}
+
+	return intToFloat( value, array );
+
+}
 
 export {
 	DEG2RAD,
@@ -318,4 +347,6 @@ export {
 	setQuaternionFromProperEuler,
 	normalize,
 	denormalize,
+	floatToInt,
+	intToFloat
 };


### PR DESCRIPTION
Related: 

- #22874
- #23716

As pointed out by @WestLangley, vertex attribute "normalization" refers to the int-to-float conversion done by the graphics API when reading integer values in a vertex shader and converting them to floats. In `MathUtils.normalize()` we currently mean the opposite — converting floats to integers that will be stored in a "normalized" vertex attribute.

~~If we use the term as the graphics APIs do, then moving data from a `type = f32, normalized = false` attribute to a `type = u8, normalized = true` attribute, you would actually call _`MathUtils.denormalize`_. That will probably be confusing, so I've replaced them with more explicit `intToFloat()` and `floatToInt()` methods here.~~

This PR reverses the naming, and makes both functions _internal_ APIs of BufferAttribute to limit confusion here. I've also added a `type` argument to both functions (UnsignedByteType, FloatType, ...) instead of passing the array. This requires the addition of a `getArrayType(array)` function but feels cleaner, happy to go either way on this.

The original methods were added in r139, so we don't necessarily need to rename them in the same release as #22874 if we need more time.

/cc @WestLangley @gkjohnson 