### PR TITLE
Account for existing groups in BufferGeometryUtils.mergeBufferGeometries

### DIFF
--- a/examples/jsm/utils/BufferGeometryUtils.js
+++ b/examples/jsm/utils/BufferGeometryUtils.js
@@ -128,10 +128,13 @@ function mergeBufferGeometries( geometries, useGroups = false ) {
 
 	let offset = 0;
 
+	let nextGroupIndex = 0;
+
 	for ( let i = 0; i < geometries.length; ++ i ) {
 
 		const geometry = geometries[ i ];
 		let attributesCount = 0;
+		let groupIndex = nextGroupIndex;
 
 		// ensure that all geometries are indexed, or none
 
@@ -218,8 +221,25 @@ function mergeBufferGeometries( geometries, useGroups = false ) {
 
 			}
 
-			mergedGeometry.addGroup( offset, count, i );
+			if ( geometry.groups.length > 0 ) {
 
+				// Keep existing groups
+
+				for ( let group of geometry.groups ) {
+
+					let offsetMaterialIndex = groupIndex + group.materialIndex;
+					mergedGeometry.addGroup( offset + group.start, Math.min( group.count, count ), offsetMaterialIndex );
+					nextGroupIndex = Math.max( nextGroupIndex, offsetMaterialIndex );
+
+				}
+
+			} else {
+
+				mergedGeometry.addGroup( offset, count, groupIndex );
+
+			}
+
+			++ nextGroupIndex;
 			offset += count;
 
 		}


### PR DESCRIPTION
Related issue: N/A

**Description**

Currently, when merging BufferGeometries that already have groups, `BufferGeometryUtils.mergeBufferGeometries` will totally ignore the existing groups, even if `useGroups` is set to `true`. This can be quite annoying, especially if you string together multiple calls to mergeBufferGeometries, since each time you will lose the groups created by the previous call (and of course any pre-existing groups.)

This PR changes the behavior of `mergeBufferGeometries` to preserve existing groups, but offset the material index for each geometry. If none of the geometries have groups, then the behavior is unchanged.

**Example**

Say you have geometry **A** and **B**, something like:

**A** groups:

```js
{ offset: 0, count: 5, materialIndex: 0 }
{ offset: 5, count: 5, materialIndex: 1 }
```

**B** groups:

```js
{ offset: 0, count: 3, materialIndex: 0 }
{ offset: 3, count: 3, materialIndex: 0 }
{ offset: 6, count: 3, materialIndex: 1 }
```

The current behavior results in the following groups for the merged geometry:

```js
{ offset: 0, count: 10, materialIndex: 0}
{ offset: 10, count 9, materialIndex: 1}
```

With this PR, the groups for the merged geometry would instead be:

```js
{ offset: 0, count: 5, materialIndex: 0 }
{ offset: 5, count: 5, materialIndex: 1 }
{ offset: 10, count: 3, materialIndex: 2 }
{ offset: 13, count: 3, materialIndex: 2 }
{ offset: 13, count: 3, materialIndex: 3 }
```
