### PR TITLE
Allow skip auto update in the render

### DIFF
--- a/docs/api/en/renderers/WebGLRenderer.html
+++ b/docs/api/en/renderers/WebGLRenderer.html
@@ -399,10 +399,11 @@
 		<p>For reading out a [page:WebGLCubeRenderTarget WebGLCubeRenderTarget] use the optional parameter activeCubeFaceIndex to determine which face should be read.</p>
 
 
-		<h3>[method:undefined render]( [param:Object3D scene], [param:Camera camera] )</h3>
+		<h3>[method:undefined render]( [param:Object3D scene], [param:Camera camera], [param:Boolean skipSceneAutoUpdateMatrixWorld] )</h3>
 		<p>
 			Render a [page:Scene scene] or another type of [page:Object3D object] using a [page:Camera camera].<br />
-
+			[page:Boolean skipSceneAutoUpdateMatrixWorld] — if true, [page:Scene.autoUpdate] will be ignored. Useful when using multiple renders per render frame loop, avoid multiple calls to [page:Object3D.updateMatrixWorld] for all obeject tree. Default is false.<br />
+			<br />
 			The render is done to a previously specified [page:WebGLRenderTarget renderTarget] set by calling [page:WebGLRenderer.setRenderTarget .setRenderTarget] or to the canvas as usual.<br />
 
 			By default render buffers are cleared before rendering but you can prevent this by setting the property [page:WebGLRenderer.autoClear autoClear] to false.

--- a/docs/examples/en/renderers/CSS2DRenderer.html
+++ b/docs/examples/en/renderers/CSS2DRenderer.html
@@ -45,9 +45,10 @@
 			Returns an object containing the width and height of the renderer.
 		</p>
 
-		<h3>[method:undefined render]( [param:Scene scene], [param:Camera camera] )</h3>
+		<h3>[method:undefined render]( [param:Scene scene], [param:Camera camera], [param:Boolean skipSceneAutoUpdateMatrixWorld]  )</h3>
 		<p>
 			Renders a [page:Scene scene] using a [page:Camera camera].<br />
+			[page:Boolean skipSceneAutoUpdateMatrixWorld] — if true, [page:Scene.autoUpdate] will be ignored. Useful when using multiple renders per render frame loop, avoid multiple calls to [page:Object3D.updateMatrixWorld] for all obeject tree. Default is false.
 		</p>
 
 		<h3>[method:undefined setSize]([param:Number width], [param:Number height])</h3>

--- a/docs/examples/en/renderers/CSS3DRenderer.html
+++ b/docs/examples/en/renderers/CSS3DRenderer.html
@@ -56,9 +56,10 @@
 			Returns an object containing the width and height of the renderer.
 		</p>
 
-		<h3>[method:undefined render]( [param:Scene scene], [param:PerspectiveCamera camera] )</h3>
+		<h3>[method:undefined render]( [param:Scene scene], [param:PerspectiveCamera camera], [param:Boolean skipSceneAutoUpdateMatrixWorld]  )</h3>
 		<p>
 			Renders a [page:Scene scene] using a [page:PerspectiveCamera perspective camera].<br />
+			[page:Boolean skipSceneAutoUpdateMatrixWorld] — if true, [page:Scene.autoUpdate] will be ignored. Useful when using multiple renders per render frame loop, avoid multiple calls to [page:Object3D.updateMatrixWorld] for all obeject tree. Default is false.
 		</p>
 
 		<h3>[method:undefined setSize]([param:Number width], [param:Number height])</h3>

--- a/docs/examples/en/renderers/SVGRenderer.html
+++ b/docs/examples/en/renderers/SVGRenderer.html
@@ -63,9 +63,10 @@
 			Returns an object containing the width and height of the renderer.
 		</p>
 
-		<h3>[method:undefined render]( [param:Scene scene], [param:Camera camera] )</h3>
+		<h3>[method:undefined render]( [param:Scene scene], [param:Camera camera], [param:Boolean skipSceneAutoUpdateMatrixWorld] )</h3>
 		<p>
-			Renders a [page:Scene scene] using a [page:Camera camera].
+			Renders a [page:Scene scene] using a [page:Camera camera].<br/>
+			[page:Boolean skipSceneAutoUpdateMatrixWorld] — if true, [page:Scene.autoUpdate] will be ignored. Useful when using multiple renders per render frame loop, avoid multiple calls to [page:Object3D.updateMatrixWorld] for all obeject tree. Default is false.
 		</p>
 
 		<h3>[method:undefined setClearColor]( [param:Color color], [param:number alpha] )</h3>

--- a/examples/css2d_label.html
+++ b/examples/css2d_label.html
@@ -207,7 +207,7 @@
 				moon.position.set( Math.sin( elapsed ) * 5, 0, Math.cos( elapsed ) * 5 );
 
 				renderer.render( scene, camera );
-				labelRenderer.render( scene, camera );
+				labelRenderer.render( scene, camera, true );
 
 			}
 

--- a/examples/css3d_orthographic.html
+++ b/examples/css3d_orthographic.html
@@ -155,7 +155,7 @@
 				requestAnimationFrame( animate );
 
 				renderer.render( scene, camera );
-				renderer2.render( scene2, camera );
+				renderer2.render( scene2, camera, true );
 
 			}
 

--- a/examples/css3d_orthographic.html
+++ b/examples/css3d_orthographic.html
@@ -155,7 +155,7 @@
 				requestAnimationFrame( animate );
 
 				renderer.render( scene, camera );
-				renderer2.render( scene2, camera, true );
+				renderer2.render( scene2, camera );
 
 			}
 

--- a/examples/js/renderers/CSS2DRenderer.js
+++ b/examples/js/renderers/CSS2DRenderer.js
@@ -73,9 +73,9 @@
 
 			};
 
-			this.render = function ( scene, camera ) {
+			this.render = function ( scene, camera, skipSceneAutoUpdateMatrixWorld ) {
 
-				if ( scene.autoUpdate === true ) scene.updateMatrixWorld();
+				if ( ! skipSceneAutoUpdateMatrixWorld && scene.autoUpdate === true ) scene.updateMatrixWorld();
 				if ( camera.parent === null ) camera.updateMatrixWorld();
 
 				_viewMatrix.copy( camera.matrixWorldInverse );

--- a/examples/js/renderers/CSS3DRenderer.js
+++ b/examples/js/renderers/CSS3DRenderer.js
@@ -106,7 +106,7 @@
 
 			};
 
-			this.render = function ( scene, camera ) {
+			this.render = function ( scene, camera, skipSceneAutoUpdateMatrixWorld ) {
 
 				const fov = camera.projectionMatrix.elements[ 5 ] * _heightHalf;
 
@@ -117,7 +117,7 @@
 
 				}
 
-				if ( scene.autoUpdate === true ) scene.updateMatrixWorld();
+				if ( ! skipSceneAutoUpdateMatrixWorld && scene.autoUpdate === true ) scene.updateMatrixWorld();
 				if ( camera.parent === null ) camera.updateMatrixWorld();
 				let tx, ty;
 

--- a/examples/js/renderers/Projector.js
+++ b/examples/js/renderers/Projector.js
@@ -393,13 +393,13 @@
 
 			}
 
-			this.projectScene = function ( scene, camera, sortObjects, sortElements ) {
+			this.projectScene = function ( scene, camera, sortObjects, sortElements, skipSceneAutoUpdateMatrixWorld ) {
 
 				_faceCount = 0;
 				_lineCount = 0;
 				_spriteCount = 0;
 				_renderData.elements.length = 0;
-				if ( scene.autoUpdate === true ) scene.updateMatrixWorld();
+				if ( ! skipSceneAutoUpdateMatrixWorld && scene.autoUpdate === true ) scene.updateMatrixWorld();
 				if ( camera.parent === null ) camera.updateMatrixWorld();
 
 				_viewMatrix.copy( camera.matrixWorldInverse );

--- a/examples/js/renderers/SVGRenderer.js
+++ b/examples/js/renderers/SVGRenderer.js
@@ -148,7 +148,7 @@
 
 			};
 
-			this.render = function ( scene, camera ) {
+			this.render = function ( scene, camera, skipSceneAutoUpdateMatrixWorld ) {
 
 				if ( camera instanceof THREE.Camera === false ) {
 
@@ -177,7 +177,7 @@
 
 				_viewProjectionMatrix.multiplyMatrices( camera.projectionMatrix, _viewMatrix );
 
-				_renderData = _projector.projectScene( scene, camera, this.sortObjects, this.sortElements );
+				_renderData = _projector.projectScene( scene, camera, this.sortObjects, this.sortElements, skipSceneAutoUpdateMatrixWorld );
 				_elements = _renderData.elements;
 				_lights = _renderData.lights;
 

--- a/examples/jsm/renderers/CSS2DRenderer.js
+++ b/examples/jsm/renderers/CSS2DRenderer.js
@@ -83,9 +83,9 @@ class CSS2DRenderer {
 
 		};
 
-		this.render = function ( scene, camera ) {
+		this.render = function ( scene, camera, skipSceneAutoUpdateMatrixWorld ) {
 
-			if ( scene.autoUpdate === true ) scene.updateMatrixWorld();
+			if ( ! skipSceneAutoUpdateMatrixWorld && scene.autoUpdate === true ) scene.updateMatrixWorld();
 			if ( camera.parent === null ) camera.updateMatrixWorld();
 
 			_viewMatrix.copy( camera.matrixWorldInverse );

--- a/examples/jsm/renderers/CSS3DRenderer.js
+++ b/examples/jsm/renderers/CSS3DRenderer.js
@@ -121,7 +121,7 @@ class CSS3DRenderer {
 
 		};
 
-		this.render = function ( scene, camera ) {
+		this.render = function ( scene, camera, skipSceneAutoUpdateMatrixWorld ) {
 
 			const fov = camera.projectionMatrix.elements[ 5 ] * _heightHalf;
 
@@ -132,7 +132,7 @@ class CSS3DRenderer {
 
 			}
 
-			if ( scene.autoUpdate === true ) scene.updateMatrixWorld();
+			if ( ! skipSceneAutoUpdateMatrixWorld && scene.autoUpdate === true ) scene.updateMatrixWorld();
 			if ( camera.parent === null ) camera.updateMatrixWorld();
 
 			let tx, ty;

--- a/examples/jsm/renderers/Projector.js
+++ b/examples/jsm/renderers/Projector.js
@@ -425,7 +425,7 @@ class Projector {
 
 		}
 
-		this.projectScene = function ( scene, camera, sortObjects, sortElements ) {
+		this.projectScene = function ( scene, camera, sortObjects, sortElements, skipSceneAutoUpdateMatrixWorld ) {
 
 			_faceCount = 0;
 			_lineCount = 0;
@@ -433,7 +433,7 @@ class Projector {
 
 			_renderData.elements.length = 0;
 
-			if ( scene.autoUpdate === true ) scene.updateMatrixWorld();
+			if ( ! skipSceneAutoUpdateMatrixWorld && scene.autoUpdate === true ) scene.updateMatrixWorld();
 			if ( camera.parent === null ) camera.updateMatrixWorld();
 
 			_viewMatrix.copy( camera.matrixWorldInverse );

--- a/examples/jsm/renderers/SVGRenderer.js
+++ b/examples/jsm/renderers/SVGRenderer.js
@@ -159,7 +159,7 @@ class SVGRenderer {
 
 		};
 
-		this.render = function ( scene, camera ) {
+		this.render = function ( scene, camera, skipSceneAutoUpdateMatrixWorld ) {
 
 			if ( camera instanceof Camera === false ) {
 
@@ -187,7 +187,7 @@ class SVGRenderer {
 			_viewMatrix.copy( camera.matrixWorldInverse );
 			_viewProjectionMatrix.multiplyMatrices( camera.projectionMatrix, _viewMatrix );
 
-			_renderData = _projector.projectScene( scene, camera, this.sortObjects, this.sortElements );
+			_renderData = _projector.projectScene( scene, camera, this.sortObjects, this.sortElements, skipSceneAutoUpdateMatrixWorld );
 			_elements = _renderData.elements;
 			_lights = _renderData.lights;
 

--- a/examples/webgl_loader_pdb.html
+++ b/examples/webgl_loader_pdb.html
@@ -259,7 +259,7 @@
 			function render() {
 
 				renderer.render( scene, camera );
-				labelRenderer.render( scene, camera );
+				labelRenderer.render( scene, camera, true );
 
 			}
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -939,7 +939,7 @@ function WebGLRenderer( parameters = {} ) {
 
 	// Rendering
 
-	this.render = function ( scene, camera ) {
+	this.render = function ( scene, camera, skipSceneAutoUpdateMatrixWorld ) {
 
 		if ( camera !== undefined && camera.isCamera !== true ) {
 
@@ -952,7 +952,7 @@ function WebGLRenderer( parameters = {} ) {
 
 		// update scene graph
 
-		if ( scene.autoUpdate === true ) scene.updateMatrixWorld();
+		if ( ! skipSceneAutoUpdateMatrixWorld && scene.autoUpdate === true ) scene.updateMatrixWorld();
 
 		// update camera matrices and frustum
 


### PR DESCRIPTION
Related issue: #24521, using solution 1

**Description**

Adds a new `skipSceneAutoUpdateMatrixWorld` param to all `render` methods for all renderers, allowing the developer tells the render to ignore the `scene.autoUpdate`. That is useful when you have many renderers in the same pipeline and you want no unnecessary call to `scene.updateMatrixWorld()` object tree.


_This will conflict withe PR #24028_