### PR TITLE
BufferAttribute: Skip denormalization in set()

### DIFF
--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -311,12 +311,8 @@ class BufferAttribute {
 
 	set( value, offset = 0 ) {
 
-		const array = this.array;
-		const normalized = this.normalized;
-
-		if ( normalized ) value = value.map( v => normalize( v, array ) );
-
-		array.set( value, offset );
+		// Matching BufferAttribute constructor, do not normalize the array.
+		this.array.set( value, offset );
 
 		return this;
 


### PR DESCRIPTION
Related issue: 

- #22874
- #24511
- #24512

Context: https://github.com/mrdoob/three.js/pull/24511#issuecomment-1220107648

/cc @gkjohnson @Mugen87 