### PR TITLE
Editor: Do not call `.update()` for skeleton helpers.

### DIFF
--- a/editor/js/Viewport.js
+++ b/editor/js/Viewport.js
@@ -450,9 +450,11 @@ function Viewport( editor ) {
 
 		}
 
-		if ( editor.helpers[ object.id ] !== undefined ) {
+		const helper = editor.helpers[ object.id ];
 
-			editor.helpers[ object.id ].update();
+		if ( helper !== undefined && helper.isSkeletonHelper !== true ) {
+
+			helper.update();
 
 		}
 


### PR DESCRIPTION
Fixed #24529.

**Description**

This PR ensures to not call `update()` for skeleton helpers.