### PR TITLE
PropertyBinding: Allow `map` as target object.

### DIFF
--- a/src/animation/PropertyBinding.js
+++ b/src/animation/PropertyBinding.js
@@ -32,7 +32,7 @@ const _trackRe = new RegExp( ''
 	+ '$'
 );
 
-const _supportedObjectNames = [ 'material', 'materials', 'bones' ];
+const _supportedObjectNames = [ 'material', 'materials', 'bones', 'map' ];
 
 class Composite {
 
@@ -494,6 +494,25 @@ class PropertyBinding {
 
 					}
 
+					break;
+
+				case 'map':
+
+					if ( ! targetObject.material ) {
+
+						console.error( 'THREE.PropertyBinding: Can not bind to material as node does not have a material.', this );
+						return;
+
+					}
+
+					if ( ! targetObject.material.map ) {
+
+						console.error( 'THREE.PropertyBinding: Can not bind to material.map as node.material does not have a map.', this );
+						return;
+
+					}
+
+					targetObject = targetObject.material.map;
 					break;
 
 				default:


### PR DESCRIPTION
Related issue: -

**Description**

It should be possible to animate the texture properties `offset` or `rotation` like in this fiddle: https://jsfiddle.net/37mfsugc/2/

However, since `map` is no part of the supported object names in `PropertyBinding`, it does not work if the animation is played in context of a 3D object. 

The workaround would be to change the root object of the animation mixer to the texture which is problematic since animations are usually registered for 3D objects.

This PR has no effect on existing animations.