### PR TITLE
Add normals to BufferGeometry docs example

### DIFF
--- a/docs/api/en/core/BufferGeometry.html
+++ b/docs/api/en/core/BufferGeometry.html
@@ -32,9 +32,21 @@
 			-1.0,  1.0,  1.0,
 			-1.0, -1.0,  1.0
 		] );
-
+		// define normals for each vertex - in this case the square is facing us.
+		// normals are required for mesh materials to render visibly
+		const normals = new Float32Array( [
+			0, 0, 1,
+			0, 0, 1,
+			0, 0, 1,
+			
+			0, 0, 1,
+			0, 0, 1,
+			0, 0, 1,
+		] );
+			
 		// itemSize = 3 because there are 3 values (components) per vertex
 		geometry.setAttribute( 'position', new THREE.BufferAttribute( vertices, 3 ) );
+		geometry.setAttribute( 'normal', new THREE.BufferAttribute( normals, 3 ) );
 		const material = new THREE.MeshBasicMaterial( { color: 0xff0000 } );
 		const mesh = new THREE.Mesh( geometry, material );
 		</code>


### PR DESCRIPTION
I was confused by this for a while because the example doesn't actually render. Eventually I found a more complete example and worked out that the missing piece was normals. I think including normals in the example can help more people like me with a working example to start with.

