### PR TITLE
BufferAttribute: Remove type specific copy methods.

### DIFF
--- a/docs/api/en/core/BufferAttribute.html
+++ b/docs/api/en/core/BufferAttribute.html
@@ -142,18 +142,6 @@
 		<h3>[method:this copyAt] ( [param:Integer index1], [param:BufferAttribute bufferAttribute], [param:Integer index2] ) </h3>
 		<p>Copy a vector from bufferAttribute[index2] to [page:BufferAttribute.array array][index1].</p>
 
-		<h3>[method:this copyColorsArray]( [param:Array colors] ) </h3>
-		<p>Copy an array representing RGB color values into [page:BufferAttribute.array array].</p>
-
-		<h3>[method:this copyVector2sArray]( [param:Array vectors] ) </h3>
-		<p>Copy an array representing [page:Vector2]s into [page:BufferAttribute.array array].</p>
-
-		<h3>[method:this copyVector3sArray]( [param:Array vectors] ) </h3>
-		<p>Copy an array representing [page:Vector3]s into [page:BufferAttribute.array array].</p>
-
-		<h3>[method:this copyVector4sArray]( [param:Array vectors] ) </h3>
-		<p>Copy an array representing [page:Vector4]s into [page:BufferAttribute.array array].</p>
-
 		<h3>[method:Number getX]( [param:Integer index] ) </h3>
 		<p>Returns the x component of the vector at the given index.</p>
 

--- a/docs/api/it/core/BufferAttribute.html
+++ b/docs/api/it/core/BufferAttribute.html
@@ -153,18 +153,6 @@
 		<h3>[method:this copyAt] ( [param:Integer index1], [param:BufferAttribute bufferAttribute], [param:Integer index2] ) </h3>
 		<p>Copia un vettore da bufferAttribute[index2] a [page:BufferAttribute.array array][index1].</p>
 
-		<h3>[method:this copyColorsArray]( [param:Array colors] ) </h3>
-		<p>Copia un array che rappresenta i valori dei colori RGB nell'[page:BufferAttribute.array array].</p>
-
-		<h3>[method:this copyVector2sArray]( [param:Array vectors] ) </h3>
-		<p>Copia un array che rappresenta [page:Vector2]s nell'[page:BufferAttribute.array array].</p>
-
-		<h3>[method:this copyVector3sArray]( [param:Array vectors] ) </h3>
-		<p>Copia un array che rappresenta [page:Vector3]s nell'[page:BufferAttribute.array array].</p>
-
-		<h3>[method:this copyVector4sArray]( [param:Array vectors] ) </h3>
-		<p>Copia un array che rappresenta [page:Vector4]s nell'[page:BufferAttribute.array array].</p>
-
 		<h3>[method:Number getX]( [param:Integer index] ) </h3>
 		<p>Restituisce il componente x del vettore in corrispondenza dell'indice specificato.</p>
 

--- a/docs/api/ko/core/BufferAttribute.html
+++ b/docs/api/ko/core/BufferAttribute.html
@@ -139,18 +139,6 @@
 		<h3>[method:this copyAt] ( [param:Integer index1], [param:BufferAttribute bufferAttribute], [param:Integer index2] ) </h3>
 		<p>bufferAttribute[index2]의 벡터를 [page:BufferAttribute.array array][index1]에 복사합니다.</p>
 
-		<h3>[method:this copyColorsArray]( [param:Array colors] ) </h3>
-		<p>RGB 색상 값을 나타내는 배열을 [page:BufferAttribute.array array]에 복사합니다.</p>
-
-		<h3>[method:this copyVector2sArray]( [param:Array vectors] ) </h3>
-		<p>[page:Vector2]값을 나타내는 배열을 [page:BufferAttribute.array array]에 복사합니다.</p>
-
-		<h3>[method:this copyVector3sArray]( [param:Array vectors] ) </h3>
-		<p>[page:Vector3]값을 나타내는 배열을 [page:BufferAttribute.array array]에 복사합니다.</p>
-
-		<h3>[method:this copyVector4sArray]( [param:Array vectors] ) </h3>
-		<p>[page:Vector4]값을 나타내는 배열을 [page:BufferAttribute.array array]에 복사합니다.</p>
-
 		<h3>[method:Number getX]( [param:Integer index] ) </h3>
 		<p>해당 index의 벡터의 x 컴포넌트 값을 리턴합니다.</p>
 

--- a/docs/api/zh/core/BufferAttribute.html
+++ b/docs/api/zh/core/BufferAttribute.html
@@ -130,18 +130,6 @@
 		<h3>[method:this copyAt] ( [param:Integer index1], [param:BufferAttribute bufferAttribute], [param:Integer index2] ) </h3>
 		<p>将一个矢量从 bufferAttribute[index2] 拷贝到 [page:BufferAttribute.array array][index1] 中。</p>
 
-		<h3>[method:this copyColorsArray]( [param:Array colors] ) </h3>
-		<p>将一个存储 RGB 颜色值的队列拷贝到 [page:BufferAttribute.array array] 中。</p>
-
-		<h3>[method:this copyVector2sArray]( [param:Array vectors] ) </h3>
-		<p>将一个存储 [page:Vector2] 的队列拷贝到 [page:BufferAttribute.array array] 中。</p>
-
-		<h3>[method:this copyVector3sArray]( [param:Array vectors] ) </h3>
-		<p>将一个存储 [page:Vector3] 的队列拷贝到 [page:BufferAttribute.array array] 中。</p>
-
-		<h3>[method:this copyVector4sArray]( [param:Array vectors] ) </h3>
-		<p>将一个存储 [page:Vector4] 的队列拷贝到 [page:BufferAttribute.array array] 中。</p>
-
 		<h3>[method:Number getX]( [param:Integer index] ) </h3>
 		<p>获取给定索引的矢量的第一维元素 （即 X 值）。</p>
 

--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -1,7 +1,5 @@
-import { Vector4 } from '../math/Vector4.js';
 import { Vector3 } from '../math/Vector3.js';
 import { Vector2 } from '../math/Vector2.js';
-import { Color } from '../math/Color.js';
 import { denormalize, normalize } from '../math/MathUtils.js';
 import { StaticDrawUsage } from '../constants.js';
 
@@ -87,147 +85,27 @@ class BufferAttribute {
 
 	}
 
-	copyColorsArray( colors ) {
+	copyColorsArray() {
 
-		const array = this.array;
-		let offset = 0;
-
-		for ( let i = 0, l = colors.length; i < l; i ++ ) {
-
-			let color = colors[ i ];
-
-			if ( color === undefined ) {
-
-				console.warn( 'THREE.BufferAttribute.copyColorsArray(): color is undefined', i );
-				color = new Color();
-
-			}
-
-			if ( this.normalized ) {
-
-				array[ offset ++ ] = normalize( color.r, array );
-				array[ offset ++ ] = normalize( color.g, array );
-				array[ offset ++ ] = normalize( color.b, array );
-
-			} else {
-
-				array[ offset ++ ] = color.r;
-				array[ offset ++ ] = color.g;
-				array[ offset ++ ] = color.b;
-
-			}
-
-		}
-
-		return this;
+		console.error( 'THREE.BufferAttribute: copyColorsArray() has been removed with r144.' );
 
 	}
 
-	copyVector2sArray( vectors ) {
+	copyVector2sArray() {
 
-		const array = this.array;
-		let offset = 0;
-
-		for ( let i = 0, l = vectors.length; i < l; i ++ ) {
-
-			let vector = vectors[ i ];
-
-			if ( vector === undefined ) {
-
-				console.warn( 'THREE.BufferAttribute.copyVector2sArray(): vector is undefined', i );
-				vector = new Vector2();
-
-			}
-
-			if ( this.normalized ) {
-
-				array[ offset ++ ] = normalize( vector.x, array );
-				array[ offset ++ ] = normalize( vector.y, array );
-
-			} else {
-
-				array[ offset ++ ] = vector.x;
-				array[ offset ++ ] = vector.y;
-
-			}
-
-		}
-
-		return this;
+		console.error( 'THREE.BufferAttribute: copyVector2sArray() has been removed with r144.' );
 
 	}
 
-	copyVector3sArray( vectors ) {
+	copyVector3sArray() {
 
-		const array = this.array;
-		let offset = 0;
-
-		for ( let i = 0, l = vectors.length; i < l; i ++ ) {
-
-			let vector = vectors[ i ];
-
-			if ( vector === undefined ) {
-
-				console.warn( 'THREE.BufferAttribute.copyVector3sArray(): vector is undefined', i );
-				vector = new Vector3();
-
-			}
-
-			if ( this.normalized ) {
-
-				array[ offset ++ ] = normalize( vector.x, array );
-				array[ offset ++ ] = normalize( vector.y, array );
-				array[ offset ++ ] = normalize( vector.z, array );
-
-			} else {
-
-				array[ offset ++ ] = vector.x;
-				array[ offset ++ ] = vector.y;
-				array[ offset ++ ] = vector.z;
-
-			}
-
-		}
-
-		return this;
+		console.error( 'THREE.BufferAttribute: copyVector3sArray() has been removed with r144.' );
 
 	}
 
-	copyVector4sArray( vectors ) {
+	copyVector4sArray() {
 
-		const array = this.array;
-		let offset = 0;
-
-		for ( let i = 0, l = vectors.length; i < l; i ++ ) {
-
-			let vector = vectors[ i ];
-
-			if ( vector === undefined ) {
-
-				console.warn( 'THREE.BufferAttribute.copyVector4sArray(): vector is undefined', i );
-				vector = new Vector4();
-
-			}
-
-			if ( this.normalized ) {
-
-				array[ offset ++ ] = normalize( vector.x, array );
-				array[ offset ++ ] = normalize( vector.y, array );
-				array[ offset ++ ] = normalize( vector.z, array );
-				array[ offset ++ ] = normalize( vector.w, array );
-
-			} else {
-
-				array[ offset ++ ] = vector.x;
-				array[ offset ++ ] = vector.y;
-				array[ offset ++ ] = vector.z;
-				array[ offset ++ ] = vector.w;
-
-			}
-
-		}
-
-		return this;
+		console.error( 'THREE.BufferAttribute: copyVector4sArray() has been removed with r144.' );
 
 	}
 

--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -85,30 +85,6 @@ class BufferAttribute {
 
 	}
 
-	copyColorsArray() {
-
-		console.error( 'THREE.BufferAttribute: copyColorsArray() has been removed with r144.' );
-
-	}
-
-	copyVector2sArray() {
-
-		console.error( 'THREE.BufferAttribute: copyVector2sArray() has been removed with r144.' );
-
-	}
-
-	copyVector3sArray() {
-
-		console.error( 'THREE.BufferAttribute: copyVector3sArray() has been removed with r144.' );
-
-	}
-
-	copyVector4sArray() {
-
-		console.error( 'THREE.BufferAttribute: copyVector4sArray() has been removed with r144.' );
-
-	}
-
 	applyMatrix3( m ) {
 
 		if ( this.itemSize === 2 ) {
@@ -364,6 +340,32 @@ class BufferAttribute {
 		if ( this.updateRange.offset !== 0 || this.updateRange.count !== - 1 ) data.updateRange = this.updateRange;
 
 		return data;
+
+	}
+
+	// @deprecated
+
+	copyColorsArray() {
+
+		console.error( 'THREE.BufferAttribute: copyColorsArray() has been removed with r144.' );
+
+	}
+
+	copyVector2sArray() {
+
+		console.error( 'THREE.BufferAttribute: copyVector2sArray() has been removed with r144.' );
+
+	}
+
+	copyVector3sArray() {
+
+		console.error( 'THREE.BufferAttribute: copyVector3sArray() has been removed with r144.' );
+
+	}
+
+	copyVector4sArray() {
+
+		console.error( 'THREE.BufferAttribute: copyVector4sArray() has been removed with r144.' );
 
 	}
 

--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -347,25 +347,25 @@ class BufferAttribute {
 
 	copyColorsArray() {
 
-		console.error( 'THREE.BufferAttribute: copyColorsArray() has been removed with r144.' );
+		console.error( 'THREE.BufferAttribute: copyColorsArray() was removed in r144.' );
 
 	}
 
 	copyVector2sArray() {
 
-		console.error( 'THREE.BufferAttribute: copyVector2sArray() has been removed with r144.' );
+		console.error( 'THREE.BufferAttribute: copyVector2sArray() was removed in r144.' );
 
 	}
 
 	copyVector3sArray() {
 
-		console.error( 'THREE.BufferAttribute: copyVector3sArray() has been removed with r144.' );
+		console.error( 'THREE.BufferAttribute: copyVector3sArray() was removed in r144.' );
 
 	}
 
 	copyVector4sArray() {
 
-		console.error( 'THREE.BufferAttribute: copyVector4sArray() has been removed with r144.' );
+		console.error( 'THREE.BufferAttribute: copyVector4sArray() was removed in r144.' );
 
 	}
 

--- a/test/unit/src/core/BufferAttribute.tests.js
+++ b/test/unit/src/core/BufferAttribute.tests.js
@@ -1,10 +1,6 @@
 /* global QUnit */
 
 import { BufferAttribute } from '../../../../src/core/BufferAttribute.js';
-import { Color } from '../../../../src/math/Color.js';
-import { Vector2 } from '../../../../src/math/Vector2.js';
-import { Vector3 } from '../../../../src/math/Vector3.js';
-import { Vector4 } from '../../../../src/math/Vector4.js';
 import { DynamicDrawUsage } from '../../../../src/constants.js';
 
 export default QUnit.module( 'Core', () => {
@@ -91,66 +87,6 @@ export default QUnit.module( 'Core', () => {
 			a.copyArray( f32a );
 
 			assert.deepEqual( a.array, f32a, 'Check array has new values' );
-
-		} );
-
-		QUnit.test( 'copyColorsArray', ( assert ) => {
-
-			var attr = new BufferAttribute( new Float32Array( 6 ), 3 );
-
-			attr.copyColorsArray( [
-				new Color( 0, 0.5, 1 ),
-				new Color( 0.25, 1, 0 )
-			] );
-
-			var i = attr.array;
-			assert.ok( i[ 0 ] === 0 && i[ 1 ] === 0.5 && i[ 2 ] === 1, 'first color was copied correctly' );
-			assert.ok( i[ 3 ] === 0.25 && i[ 4 ] === 1 && i[ 5 ] === 0, 'second color was copied correctly' );
-
-		} );
-
-		QUnit.test( 'copyVector2sArray', ( assert ) => {
-
-			var attr = new BufferAttribute( new Float32Array( 4 ), 2 );
-
-			attr.copyVector2sArray( [
-				new Vector2( 1, 2 ),
-				new Vector2( 4, 5 )
-			] );
-
-			var i = attr.array;
-			assert.ok( i[ 0 ] === 1 && i[ 1 ] === 2, 'first vector was copied correctly' );
-			assert.ok( i[ 2 ] === 4 && i[ 3 ] === 5, 'second vector was copied correctly' );
-
-		} );
-
-		QUnit.test( 'copyVector3sArray', ( assert ) => {
-
-			var attr = new BufferAttribute( new Float32Array( 6 ), 2 );
-
-			attr.copyVector3sArray( [
-				new Vector3( 1, 2, 3 ),
-				new Vector3( 10, 20, 30 )
-			] );
-
-			var i = attr.array;
-			assert.ok( i[ 0 ] === 1 && i[ 1 ] === 2 && i[ 2 ] === 3, 'first vector was copied correctly' );
-			assert.ok( i[ 3 ] === 10 && i[ 4 ] === 20 && i[ 5 ] === 30, 'second vector was copied correctly' );
-
-		} );
-
-		QUnit.test( 'copyVector4sArray', ( assert ) => {
-
-			var attr = new BufferAttribute( new Float32Array( 8 ), 2 );
-
-			attr.copyVector4sArray( [
-				new Vector4( 1, 2, 3, 4 ),
-				new Vector4( 10, 20, 30, 40 )
-			] );
-
-			var i = attr.array;
-			assert.ok( i[ 0 ] === 1 && i[ 1 ] === 2 && i[ 2 ] === 3 && i[ 3 ] === 4, 'first vector was copied correctly' );
-			assert.ok( i[ 4 ] === 10 && i[ 5 ] === 20 && i[ 6 ] === 30 && i[ 7 ] === 40, 'second vector was copied correctly' );
 
 		} );
 


### PR DESCRIPTION
Related issue: -

**Description**

This PR removes `copyColorsArray()`, `copyVector2sArray()`, `copyVector3sArray()` and `copyVector4sArray()` from `BufferAttribute`. These specific methods were originally introduced as helper/convenience methods for the `Geometry` to `BufferGeometry` conversion. Since `Geometry` has been removed, these methods should be deleted, too.