### PR TITLE
Docs: Fix typo.

### DIFF
--- a/docs/api/en/animation/AnimationMixer.html
+++ b/docs/api/en/animation/AnimationMixer.html
@@ -81,7 +81,7 @@
 		<p>
 			Advances the global mixer time and updates the animation.<br /><br />
 
-			This is usually done in the render loop, passing [page:Clock.getDelta clock.getDelta] scaled by the mixer's [page:.timeScale timeScale]).
+			This is usually done in the render loop, passing [page:Clock.getDelta clock.getDelta] scaled by the mixer's [page:.timeScale timeScale].
 		</p>
 
 		<h3>[method:this setTime]([param:Number timeInSeconds]) </h3>


### PR DESCRIPTION
**Description**
Fixed a typo in the AnimationMixer 

![image](https://user-images.githubusercontent.com/77806612/187096189-2f4f64be-9f98-4368-a756-468d2009bf44.png)
