### PR TITLE
GPUComputationRenderer: update to work correctly with webXR

### DIFF
--- a/examples/jsm/misc/GPUComputationRenderer.js
+++ b/examples/jsm/misc/GPUComputationRenderer.js
@@ -3,6 +3,7 @@ import {
 	ClampToEdgeWrapping,
 	DataTexture,
 	FloatType,
+	LinearEncoding,
 	Mesh,
 	NearestFilter,
 	NoToneMapping,
@@ -396,21 +397,27 @@ class GPUComputationRenderer {
 
 			const currentRenderTarget = renderer.getRenderTarget();
 
-			const currentToneMapping = renderer.toneMapping;
 			const currentXrEnabled = renderer.xr.enabled;
+			const currentShadowAutoUpdate = renderer.shadowMap.autoUpdate;
+			const currentOutputEncoding = renderer.outputEncoding;
+			const currentToneMapping = renderer.toneMapping;
 
+			renderer.xr.enabled = false; // Avoid camera modification
+			renderer.shadowMap.autoUpdate = false; // Avoid re-computing shadows
+			renderer.outputEncoding = LinearEncoding;
 			renderer.toneMapping = NoToneMapping;
-			renderer.xr.enabled = false;
 
 			mesh.material = material;
 			renderer.setRenderTarget( output );
 			renderer.render( scene, camera );
 			mesh.material = passThruShader;
 
-			renderer.setRenderTarget( currentRenderTarget );
-
-			renderer.toneMapping = currentToneMapping;
 			renderer.xr.enabled = currentXrEnabled;
+			renderer.shadowMap.autoUpdate = currentShadowAutoUpdate;
+			renderer.outputEncoding = currentOutputEncoding;
+			renderer.toneMapping = currentToneMapping;
+
+			renderer.setRenderTarget( currentRenderTarget );
 
 		};
 

--- a/examples/jsm/misc/GPUComputationRenderer.js
+++ b/examples/jsm/misc/GPUComputationRenderer.js
@@ -5,6 +5,7 @@ import {
 	FloatType,
 	Mesh,
 	NearestFilter,
+	NoToneMapping,
 	PlaneGeometry,
 	RGBAFormat,
 	Scene,
@@ -395,12 +396,21 @@ class GPUComputationRenderer {
 
 			const currentRenderTarget = renderer.getRenderTarget();
 
+			const currentToneMapping = renderer.toneMapping
+			const currentXrEnabled = renderer.xr.enabled
+
+			renderer.toneMapping = NoToneMapping
+			renderer.xr.enabled = false
+
 			mesh.material = material;
 			renderer.setRenderTarget( output );
 			renderer.render( scene, camera );
 			mesh.material = passThruShader;
 
 			renderer.setRenderTarget( currentRenderTarget );
+
+			renderer.toneMapping = currentToneMapping
+			renderer.xr.enabled = currentXrEnabled
 
 		};
 

--- a/examples/jsm/misc/GPUComputationRenderer.js
+++ b/examples/jsm/misc/GPUComputationRenderer.js
@@ -396,11 +396,11 @@ class GPUComputationRenderer {
 
 			const currentRenderTarget = renderer.getRenderTarget();
 
-			const currentToneMapping = renderer.toneMapping
-			const currentXrEnabled = renderer.xr.enabled
+			const currentToneMapping = renderer.toneMapping;
+			const currentXrEnabled = renderer.xr.enabled;
 
-			renderer.toneMapping = NoToneMapping
-			renderer.xr.enabled = false
+			renderer.toneMapping = NoToneMapping;
+			renderer.xr.enabled = false;
 
 			mesh.material = material;
 			renderer.setRenderTarget( output );
@@ -409,8 +409,8 @@ class GPUComputationRenderer {
 
 			renderer.setRenderTarget( currentRenderTarget );
 
-			renderer.toneMapping = currentToneMapping
-			renderer.xr.enabled = currentXrEnabled
+			renderer.toneMapping = currentToneMapping;
+			renderer.xr.enabled = currentXrEnabled;
 
 		};
 


### PR DESCRIPTION
GPUComputationRenderer will act strangely when viewing in WebXR mode when the viewer looks away from the mesh bounding box. In my example particle positons are reset when looking away.

This PR fixes the issue using the same method seen in CubeCamera.js by disabling webXR before rendering to the rendertarget and then re-enabling webXR:
https://github.com/mrdoob/three.js/blob/8de7680efd897a088efb443ad136b9379ccd5bef/src/cameras/CubeCamera.js#L70

Cubecamera.js also disabling tonemapping while rendering to the rendertarget so that functionality has been added here too.

Here is an example using the updated GPUComputationRenderer code: https://codesandbox.io/s/gpgpu-dust-devil-webxr-4zmvc?file=/src/index.js