### PR TITLE
ShaderChunk: Modulate spotlight's map with cone and penumbra

### DIFF
--- a/src/renderers/shaders/ShaderChunk/lights_fragment_begin.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_fragment_begin.glsl.js
@@ -110,9 +110,7 @@ IncidentLight directLight;
 			spotLightCoord = vSpotLightCoord[ i ].xyz / vSpotLightCoord[ i ].w;
 			inSpotLightMap = all( lessThan( abs( spotLightCoord * 2. - 1. ), vec3( 1.0 ) ) );
 			spotColor = texture2D( spotLightMap[ SPOT_LIGHT_MAP_INDEX ], spotLightCoord.xy );
-			inSpotLightMap = inSpotLightMap && ( spotColor.a > 0. );
-			directLight.visible = directLight.visible || inSpotLightMap;
-			directLight.color = inSpotLightMap ? mix( directLight.color, spotLight.color * spotColor.rgb, spotColor.a ) : directLight.color;
+			directLight.color = inSpotLightMap ? directLight.color * spotLight.color * spotColor.rgb : directLight.color;
 		#endif
 
 		#undef SPOT_LIGHT_MAP_INDEX


### PR DESCRIPTION
Related issues: #21944 #24539

**Description**

Before:

<img width="840" alt="Screen Shot 2022-08-29 at 6 22 25 PM" src="https://user-images.githubusercontent.com/97088/187327273-1cfa168f-18d5-4678-8d49-6b107034f096.png">

After:

<img width="840" alt="Screen Shot 2022-08-29 at 6 22 05 PM" src="https://user-images.githubusercontent.com/97088/187327258-50187454-45e8-496d-842f-c9db91137f84.png">
