### PR TITLE
ShaderChunk: Fixed crash when using spotlight.map with renderer.shadowMap not enabled

### DIFF
--- a/src/renderers/shaders/ShaderChunk/shadowmap_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/shadowmap_vertex.glsl.js
@@ -1,7 +1,7 @@
 export default /* glsl */`
-#if defined( USE_SHADOWMAP ) || ( NUM_SPOT_LIGHT_COORDS > 0 )
+#if defined( USE_SHADOWMAP )
 
-	#if NUM_DIR_LIGHT_SHADOWS > 0 || NUM_SPOT_LIGHT_COORDS > 0 || NUM_POINT_LIGHT_SHADOWS > 0
+	#if NUM_DIR_LIGHT_SHADOWS > 0 || NUM_SPOT_LIGHT_SHADOWS > 0 || NUM_POINT_LIGHT_SHADOWS > 0
 
 		// Offsetting the position used for querying occlusion along the world normal can be used to reduce shadow acne.
 		vec3 shadowWorldNormal = inverseTransformDirection( transformedNormal, viewMatrix );
@@ -22,10 +22,10 @@ export default /* glsl */`
 
 	#endif
 
-	#if NUM_SPOT_LIGHT_COORDS > 0
+	#if NUM_SPOT_LIGHT_SHADOWS > 0
 
 	#pragma unroll_loop_start
-	for ( int i = 0; i < NUM_SPOT_LIGHT_COORDS; i ++ ) {
+	for ( int i = 0; i < NUM_SPOT_LIGHT_SHADOWS; i ++ ) {
 
 		shadowWorldPosition = worldPosition;
 		#if ( UNROLLED_LOOP_INDEX < NUM_SPOT_LIGHT_SHADOWS )

--- a/src/renderers/shaders/ShaderChunk/worldpos_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/worldpos_vertex.glsl.js
@@ -1,5 +1,5 @@
 export default /* glsl */`
-#if defined( USE_ENVMAP ) || defined( DISTANCE ) || defined ( USE_SHADOWMAP ) || defined ( USE_TRANSMISSION ) || NUM_SPOT_LIGHT_MAPS > 0
+#if defined( USE_ENVMAP ) || defined( DISTANCE ) || defined ( USE_SHADOWMAP ) || defined ( USE_TRANSMISSION )
 
 	vec4 worldPosition = vec4( transformed, 1.0 );
 


### PR DESCRIPTION
Related issues: #21944

**Description**

This PR fixes a shader compiler crash when using `spointlight.map` without setting `renderer.shadowMap.enabled = true`.

<img width="1252" alt="Screen Shot 2022-08-29 at 6 46 00 PM" src="https://user-images.githubusercontent.com/97088/187330013-00d17788-0ac4-401e-b6b9-b6f1089dbdb0.png">

I suspect I broke a specific case though...
I'll continue refactoring and cleaning up the code tomorrow.

/cc @mbredif 