### PR TITLE
ShapePath: Remove noHoles parameter.

### DIFF
--- a/docs/api/en/extras/core/ShapePath.html
+++ b/docs/api/en/extras/core/ShapePath.html
@@ -71,14 +71,13 @@
 		<p>Connects a new [page:SplineCurve] onto the [page:ShapePath.currentPath currentPath].</p>
 
 
-		<h3>[method:Array toShapes]( [param:Boolean isCCW], [param:Boolean noHoles] )</h3>
+		<h3>[method:Array toShapes]( [param:Boolean isCCW] )</h3>
 		<p>
-		isCCW -- Changes how solids and holes are generated<br/>
-		noHoles -- Whether or not to generate holes
+		isCCW -- Changes how solids and holes are generated
 		</p>
 		<p>
 		Converts the [page:ShapePath.subPaths subPaths] array into an array of Shapes. By default solid shapes are defined clockwise (CW) and holes are defined counterclockwise (CCW). If isCCW is set to true,
-		then those are flipped. If the parameter noHoles is set to true then all paths are set as solid shapes and isCCW is ignored.
+		then those are flipped.
 		<br/>
 
 		</p>

--- a/docs/api/ko/extras/core/ShapePath.html
+++ b/docs/api/ko/extras/core/ShapePath.html
@@ -64,15 +64,13 @@
 		<p>[page:ShapePath.currentPath currentPath] 위에 새 [page:SplineCurve]를 연결합니다.</p>
 
 
-		<h3>[method:Array toShapes]( [param:Boolean isCCW], [param:Boolean noHoles] )</h3>
+		<h3>[method:Array toShapes]( [param:Boolean isCCW] )</h3>
 		<p>
-		isCCW -- solids와 holes가 생성되는 방식을 변경합니다<br/>
-		noHoles -- holes를 생성할지 안 할지를 설정합니다.
+		isCCW -- solids와 holes가 생성되는 방식을 변경합니다
 		</p>
 		<p>
 		[page:ShapePath.subPaths subPaths] 배열을 Shapes 배열로 변환합니다. 기본값으로 solid shapes는 시계방향(CW)이고 holes는 반시계방향(CCW)입니다.
 		isCCW가 true면, 이 값들이 반대가 됩니다.
-		noHoles 파라미터가 true면 모든 path들은 solid shapes로 설정되고 isCCW는 무시됩니다.
 		<br/>
 
 		</p>

--- a/docs/api/zh/extras/core/ShapePath.html
+++ b/docs/api/zh/extras/core/ShapePath.html
@@ -67,14 +67,13 @@
 			连接一个新的[page:SplineCurve]（样条曲线）到[page:ShapePath.currentPath currentPath]（当前路径）。</p>
 
 
-		<h3>[method:Array toShapes]( [param:Boolean isCCW], [param:Boolean noHoles] )</h3>
+		<h3>[method:Array toShapes]( [param:Boolean isCCW] )</h3>
 		<p>
-		isCCW -- 更改实体形状和孔洞的生成方式。<br/>
-		noHoles -- 是否创建孔洞。
+		isCCW -- 更改实体形状和孔洞的生成方式。
 		</p>
 		<p>
 		将[page:ShapePath.subPaths subPaths]数组转换为到Shapes数组。默认情况下，实体形状按照顺时针（CW）来定义，孔洞按照逆时针（CCW）来定义。
-		如果isCCW被设置为true，则孔洞和实体形状的定义将被反转。如果noHoles参数设置为true，则所有路径将被设置为实体形状，isCCW将被忽略。
+		如果isCCW被设置为true，则孔洞和实体形状的定义将被反转。
 		<br/>
 
 		</p>

--- a/src/extras/core/ShapePath.js
+++ b/src/extras/core/ShapePath.js
@@ -58,7 +58,7 @@ class ShapePath {
 
 	}
 
-	toShapes( isCCW, noHoles ) {
+	toShapes( isCCW ) {
 
 		function toShapesNoHoles( inSubpaths ) {
 
@@ -143,9 +143,6 @@ class ShapePath {
 
 		const subPaths = this.subPaths;
 		if ( subPaths.length === 0 ) return [];
-
-		if ( noHoles === true )	return	toShapesNoHoles( subPaths );
-
 
 		let solid, tmpPath, tmpShape;
 		const shapes = [];


### PR DESCRIPTION
Related issue: -

**Description**

`ShapePath.toShapes()` has some limitations (#16950) and `SVGLoader.createShapes()` provides a better implementation. I think it makes sense to replace the implementation of `ShapePath.toShapes()` in future releases with the more robust code from `SVGLoader.createShapes()`.

As a preparation, I suggest to remove the `noHoles` parameter from `ShapePath.toShapes()`. The contour/hole definitions should solely depend on the path definitions like in `SVGLoader.createShapes()` and not be configurable.

It seems the code base did not use the `noHoles` parameter anyway and I doubt it has a relevance in user level code.
