### PR TITLE
CubeCamera: small fix, code in wrong place

### DIFF
--- a/src/cameras/CubeCamera.js
+++ b/src/cameras/CubeCamera.js
@@ -88,10 +88,10 @@ class CubeCamera extends Object3D {
 		renderer.setRenderTarget( renderTarget, 4 );
 		renderer.render( scene, cameraPZ );
 
-		renderTarget.texture.generateMipmaps = generateMipmaps;
-
 		renderer.setRenderTarget( renderTarget, 5 );
 		renderer.render( scene, cameraNZ );
+
+		renderTarget.texture.generateMipmaps = generateMipmaps;
 
 		renderer.setRenderTarget( currentRenderTarget );
 


### PR DESCRIPTION
I think I noticed a small error in the cubecamera.js file, re-setting the `renderTarget.texture.generateMipmaps` variable to its previous state is taking place before rendering the final side of the cube.