### PR TITLE
spot light map without shadow map

### DIFF
--- a/examples/webgl_lights_spotlight.html
+++ b/examples/webgl_lights_spotlight.html
@@ -33,7 +33,7 @@
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 
-			let renderer, scene, camera;
+			let renderer, scene, camera, material;
 
 			let spotLight, lightHelper, shadowCameraHelper;
 
@@ -104,7 +104,7 @@
 
 				//
 
-				let material = new THREE.MeshPhongMaterial( { color: 0x808080, dithering: true } );
+				material = new THREE.MeshPhongMaterial( { color: 0x808080, dithering: true } );
 
 				let geometry = new THREE.PlaneGeometry( 2000, 2000 );
 
@@ -116,11 +116,11 @@
 
 				//
 
-				material = new THREE.MeshPhongMaterial( { color: 0x4080ff, dithering: true } );
+				let material2 = new THREE.MeshPhongMaterial( { color: 0x4080ff, dithering: true } );
 
 				geometry = new THREE.CylinderGeometry( 5, 5, 2, 32, 1, false );
 
-				mesh = new THREE.Mesh( geometry, material );
+				mesh = new THREE.Mesh( geometry, material2 );
 				mesh.position.set( 0, 5, 0 );
 				mesh.castShadow = true;
 				scene.add( mesh );
@@ -165,7 +165,8 @@
 					decay: spotLight.decay,
 					focus: spotLight.shadow.focus,
 					map: 'none',
-					'shadow camera': false
+					'shadow camera': false,
+					'enable shadows': true
 				};
 
 				gui.addColor( params, 'light color' ).onChange( function ( val ) {
@@ -228,6 +229,15 @@
 				gui.add( params, 'shadow camera' ).onChange( function ( val ) {
 
 					shadowCameraHelper.visible = val;
+					render();
+
+				} );
+
+
+				gui.add( params, 'enable shadows' ).onChange( function ( val ) {
+
+					renderer.shadowMap.enabled = val
+					material.needsUpdate = true;
 					render();
 
 				} );

--- a/src/renderers/shaders/ShaderChunk/shadowmap_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/shadowmap_vertex.glsl.js
@@ -1,7 +1,7 @@
 export default /* glsl */`
-#if defined( USE_SHADOWMAP )
+#if defined( USE_SHADOWMAP ) || ( NUM_SPOT_LIGHT_COORDS > 0 )
 
-	#if NUM_DIR_LIGHT_SHADOWS > 0 || NUM_SPOT_LIGHT_SHADOWS > 0 || NUM_POINT_LIGHT_SHADOWS > 0
+	#if NUM_DIR_LIGHT_SHADOWS > 0 || NUM_SPOT_LIGHT_COORDS > 0 || NUM_POINT_LIGHT_SHADOWS > 0
 
 		// Offsetting the position used for querying occlusion along the world normal can be used to reduce shadow acne.
 		vec3 shadowWorldNormal = inverseTransformDirection( transformedNormal, viewMatrix );
@@ -22,13 +22,13 @@ export default /* glsl */`
 
 	#endif
 
-	#if NUM_SPOT_LIGHT_SHADOWS > 0
+	#if NUM_SPOT_LIGHT_COORDS > 0
 
 	#pragma unroll_loop_start
-	for ( int i = 0; i < NUM_SPOT_LIGHT_SHADOWS; i ++ ) {
+	for ( int i = 0; i < NUM_SPOT_LIGHT_COORDS; i ++ ) {
 
 		shadowWorldPosition = worldPosition;
-		#if ( UNROLLED_LOOP_INDEX < NUM_SPOT_LIGHT_SHADOWS )
+		#if ( defined( USE_SHADOWMAP ) && UNROLLED_LOOP_INDEX < NUM_SPOT_LIGHT_SHADOWS )
 			shadowWorldPosition.xyz += shadowWorldNormal * spotLightShadows[ i ].shadowNormalBias;
 		#endif
 		vSpotLightCoord[ i ] = spotLightMatrix[ i ] * shadowWorldPosition;

--- a/src/renderers/shaders/ShaderChunk/worldpos_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/worldpos_vertex.glsl.js
@@ -1,5 +1,5 @@
 export default /* glsl */`
-#if defined( USE_ENVMAP ) || defined( DISTANCE ) || defined ( USE_SHADOWMAP ) || defined ( USE_TRANSMISSION )
+#if defined( USE_ENVMAP ) || defined( DISTANCE ) || defined ( USE_SHADOWMAP ) || defined ( USE_TRANSMISSION ) || NUM_SPOT_LIGHT_COORDS > 0
 
 	vec4 worldPosition = vec4( transformed, 1.0 );
 


### PR DESCRIPTION
Related issues: #21944 #24558

**Description**

This PR enables the use of spotlight maps when `renderer.shadowMap.enabled = false;`

After:
![image](https://user-images.githubusercontent.com/7373521/187473439-e08694a1-0607-4050-addd-127196a33cc8.png)

Before:
![image](https://user-images.githubusercontent.com/7373521/187473932-d890e5c5-85ea-4d37-b9ac-34d94bb13230.png)
