### PR TITLE
BufferGeometry: Account for PRIMITIVE_RESTART_FIXED_INDEX in setIndex().

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -36,7 +36,7 @@ function arrayNeedsUint32( array ) {
 
 	for ( let i = array.length - 1; i >= 0; -- i ) {
 
-		if ( array[ i ] > 65535 ) return true;
+		if ( array[ i ] >= 65535 ) return true; // account for PRIMITIVE_RESTART_FIXED_INDEX, #24565
 
 	}
 


### PR DESCRIPTION
Fixed #24565.

**Description**

`BufferGeometry.setIndex()` now honors `PRIMITIVE_RESTART_FIXED_INDEX`.