### PR TITLE
allow optimizations in Object3D.add() and Object3D.copy()

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -322,6 +322,15 @@ class Object3D extends EventDispatcher {
 
 		if ( object && object.isObject3D ) {
 
+			// the object already belongs to the parent
+			if ( object.parent === this ) {
+
+				// dispatch as if we did the work
+				object.dispatchEvent( _addedEvent );
+				return;
+
+			}
+
 			if ( object.parent !== null ) {
 
 				object.parent.remove( object );
@@ -884,6 +893,12 @@ class Object3D extends EventDispatcher {
 
 	}
 
+	onCopyUserData( userData ) {
+
+		return JSON.parse( JSON.stringify( userData ) );
+
+	}
+
 	clone( recursive ) {
 
 		return new this.constructor().copy( this, recursive );
@@ -918,7 +933,7 @@ class Object3D extends EventDispatcher {
 		this.frustumCulled = source.frustumCulled;
 		this.renderOrder = source.renderOrder;
 
-		this.userData = JSON.parse( JSON.stringify( source.userData ) );
+		this.userData = this.onCopyUserData( source.userData );
 
 		if ( recursive === true ) {
 


### PR DESCRIPTION
**Description**

There are two additions to Object3D here, one more important than the other. 

`onCopyUserData` allows users to opt out of the expensive `JSON.parse(JSON.stringify())` cloning. This was especially painful when using `SkeletonUtils.clone()` which depends on `Object3D.clone()`. 

The second item simply avoids doing work in `Object.remove()` by short circuiting in `Object.add()` if it already belongs to the parent.

