### PR TITLE
FileLoader: Allow HTTP Range requests

### DIFF
--- a/src/loaders/FileLoader.js
+++ b/src/loaders/FileLoader.js
@@ -30,7 +30,10 @@ class FileLoader extends Loader {
 
 		url = this.manager.resolveURL( url );
 
-		const cached = Cache.get( url );
+		const isRangeRequest = this.requestHeader.Range !== undefined;
+		const key = url + ( isRangeRequest ? `:${this.requestHeader.Range}` : '' );
+
+		const cached = Cache.get( key );
 
 		if ( cached !== undefined ) {
 
@@ -50,9 +53,9 @@ class FileLoader extends Loader {
 
 		// Check if request is duplicate
 
-		if ( loading[ url ] !== undefined ) {
+		if ( loading[ key ] !== undefined ) {
 
-			loading[ url ].push( {
+			loading[ key ].push( {
 
 				onLoad: onLoad,
 				onProgress: onProgress,
@@ -65,9 +68,9 @@ class FileLoader extends Loader {
 		}
 
 		// Initialise array for duplicate requests
-		loading[ url ] = [];
+		loading[ key ] = [];
 
-		loading[ url ].push( {
+		loading[ key ].push( {
 			onLoad: onLoad,
 			onProgress: onProgress,
 			onError: onError,
@@ -88,7 +91,7 @@ class FileLoader extends Loader {
 		fetch( req )
 			.then( response => {
 
-				if ( response.status === 200 || response.status === 0 ) {
+				if ( response.status === 200 || response.status === 206 || response.status === 0 ) {
 
 					// Some browsers return HTTP Status 0 when using non-http protocol
 					// e.g. 'file://' or 'data://'. Handle as success.
@@ -96,6 +99,12 @@ class FileLoader extends Loader {
 					if ( response.status === 0 ) {
 
 						console.warn( 'THREE.FileLoader: HTTP Status 0 received.' );
+
+					}
+
+					if ( isRangeRequest && response.status === 200 ) {
+
+						throw new HttpError( `range request fetch for "${response.url}" responded with ${response.status}: ${response.statusText}`, response );
 
 					}
 
@@ -107,7 +116,7 @@ class FileLoader extends Loader {
 
 					}
 
-					const callbacks = loading[ url ];
+					const callbacks = loading[ key ];
 					const reader = response.body.getReader();
 					const contentLength = response.headers.get( 'Content-Length' );
 					const total = contentLength ? parseInt( contentLength ) : 0;
@@ -212,10 +221,10 @@ class FileLoader extends Loader {
 
 				// Add to cache only on HTTP success, so that we do not cache
 				// error response bodies as proper responses to requests.
-				Cache.add( url, data );
+				Cache.add( key, data );
 
-				const callbacks = loading[ url ];
-				delete loading[ url ];
+				const callbacks = loading[ key ];
+				delete loading[ key ];
 
 				for ( let i = 0, il = callbacks.length; i < il; i ++ ) {
 
@@ -229,7 +238,7 @@ class FileLoader extends Loader {
 
 				// Abort errors and other errors are handled the same
 
-				const callbacks = loading[ url ];
+				const callbacks = loading[ key ];
 
 				if ( callbacks === undefined ) {
 
@@ -239,7 +248,7 @@ class FileLoader extends Loader {
 
 				}
 
-				delete loading[ url ];
+				delete loading[ key ];
 
 				for ( let i = 0, il = callbacks.length; i < il; i ++ ) {
 


### PR DESCRIPTION
Fixed #24485

**Update:** The proposed API has been updated. See https://github.com/mrdoob/three.js/pull/24580#issuecomment-1247199031

**Description**

This PR introduces [HTTP range requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests) to `FileLoader`.

It is helpful to save network usage by downloading only needed part of a file.

Proposed API

```
const loader = new FileLoader();
loader.setRange(8 /* offset in bytes */, 16 /* length in bytes */); 
loader.load(url, data => { ... });
```

**Changes**

* Accept [HTTP response status 206 Partial Content](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/206)
* Add `FileLoader.setRange(offsetInBytes, lengthInBytes)` method.
  * Range request header can be set even with `FileLoader.setRequestHeader()` but `FileLoader` want to know the range because of the following items so having a new clear method would be simpler (by avoiding to use regex for `this.requestHeader.Range`)
* Take into account the range in the key for `Cache` (for fetched data cache) and `loading` (for duplicated requests management).
  * Otherwise, different range requests to the same url can be wrongly handled as the same request.
* Add fallback for servers not supporing range requests.
  * [They can respond with 200 and the full body content](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests#partial_request_responses). If it happens, `.slice()` for `arraybuffer` and `blob` response types, and throw an error for other types because of the complexity to rescue them. Another option may be throw an error regardless of response types and ask users for fallback in their `onError` callback.

**Example use case**

glB bundle + glTF LOD extension + progressive loading. First load the lowest levels and then progressively load higher levels on demand.

Currently `FileLoader` and `GLTFLoader` don't support HTTP range requests so they load the entire content. With HTTP range request they will be able to partially load files so can save network usage.

Codes
* https://github.com/mrdoob/three.js/compare/dev...takahirox:three.js:RangedRequestGLTFLoader
* https://github.com/takahirox/three-gltf-extensions/blob/main/loaders/MSFT_lod/MSFT_lod.js

**Additional context**

[When previously HTTP range requests support is discussed](https://github.com/mrdoob/three.js/pull/13082#issuecomment-357242253), (if I understand correctly) there seems to be a chance that content length in `onProgress` callback can't be computable if servers support gzip Content-Encoding.

But the recent `FileLoader` already checks if the content length is computable and it's notified to the callback. So, non-computable content length may not be a big deal (?).

https://github.com/mrdoob/three.js/blob/f5e2d49247143b69778a9bbe0077041d5b92c37e/src/loaders/FileLoader.js#L112-L114
