### PR TITLE
TransformControls: Fix eye vector computation.

### DIFF
--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -207,7 +207,7 @@ class TransformControls extends Object3D {
 
 		if ( this.camera.isOrthographicCamera ) {
 
-			this.camera.getWorldDirection( this.eye );
+			this.camera.getWorldDirection( this.eye ).negate();
 
 		} else {
 


### PR DESCRIPTION
Fixed #24571.

**Description**

`TransformControls` assumes the eye vector should look towards the camera not the other way around.