### PR TITLE
Fixed issue with pointer location offset when placed within child HTML element

### DIFF
--- a/examples/jsm/interactive/InteractiveGroup.js
+++ b/examples/jsm/interactive/InteractiveGroup.js
@@ -27,8 +27,8 @@ class InteractiveGroup extends Group {
 
 			event.stopPropagation();
 
-			_pointer.x = ( event.clientX / element.clientWidth ) * 2 - 1;
-			_pointer.y = - ( event.clientY / element.clientHeight ) * 2 + 1;
+			_pointer.x = ( (event.clientX - renderer.domElement.offsetLeft)/ element.clientWidth ) * 2 - 1;
+			_pointer.y = - ( (event.clientY - renderer.domElement.offsetTop)/ element.clientHeight ) * 2 + 1;
 
 			raycaster.setFromCamera( _pointer, camera );
 


### PR DESCRIPTION
When the renderer is placed in a child HTML element that is offset from the top left of the page the pointer locations returned on the click event listener are wrong and offset by the relative location of the renderer element on the page. 


