### PR TITLE
InteractiveGroup: Use getBoundingClientRect() when computing pointer.

### DIFF
--- a/examples/jsm/interactive/InteractiveGroup.js
+++ b/examples/jsm/interactive/InteractiveGroup.js
@@ -27,7 +27,7 @@ class InteractiveGroup extends Group {
 
 			event.stopPropagation();
 
-			const rect = renderer .domElement.getBoundingClientRect();
+			const rect = renderer.domElement.getBoundingClientRect();
 			
 			_pointer.x = ( event.clientX - rect.left ) / rect.width * 2 - 1;
 			_pointer.y = - ( event.clientY - rect.top ) / rect.height * 2 + 1;

--- a/examples/jsm/interactive/InteractiveGroup.js
+++ b/examples/jsm/interactive/InteractiveGroup.js
@@ -27,8 +27,10 @@ class InteractiveGroup extends Group {
 
 			event.stopPropagation();
 
-			_pointer.x = ( event.clientX / element.clientWidth ) * 2 - 1;
-			_pointer.y = - ( event.clientY / element.clientHeight ) * 2 + 1;
+			const rect = renderer .domElement.getBoundingClientRect();
+			
+			_pointer.x = ( event.clientX - rect.left ) / rect.width * 2 - 1;
+			_pointer.y = - ( event.clientY - rect.top ) / rect.height * 2 + 1;
 
 			raycaster.setFromCamera( _pointer, camera );
 


### PR DESCRIPTION
When the renderer is placed in a child HTML element that is offset from the top left of the page the pointer locations returned on the click event listener are wrong and offset by the relative location of the renderer element on the page.
