### PR TITLE
HalfEdge export from ConvexHull.js

### DIFF
--- a/examples/jsm/math/ConvexHull.js
+++ b/examples/jsm/math/ConvexHull.js
@@ -1268,4 +1268,4 @@ class VertexList {
 
 }
 
-export { ConvexHull };
+export { ConvexHull, Face, HalfEdge, VertexNode, VertexList };


### PR DESCRIPTION
Related issue: #24360

On [ConvexHull.js](https://github.com/mrdoob/three.js/blob/master/examples/jsm/math/ConvexHull.js) there are a few classes that are described on the [documentation](https://github.com/mrdoob/three.js/blob/master/examples/jsm/math/ConvexHull.js) but not exposed for external usage.

This PR exports the inner classes: [Face](https://threejs.org/docs/examples/en/math/convexhull/Face.html), [HalfEdge](https://threejs.org/docs/examples/en/math/convexhull/HalfEdge.html), [VertexNode](https://threejs.org/docs/examples/en/math/convexhull/VertexNode.html) and [VertexList](https://threejs.org/docs/examples/en/math/convexhull/VertexList.html).
