### PR TITLE
Examples: webgl_multiple_elements_text fix animation speed on >60hz screens

### DIFF
--- a/examples/webgl_multiple_elements_text.html
+++ b/examples/webgl_multiple_elements_text.html
@@ -100,6 +100,8 @@
 
 			const scenes = [];
 
+			const clock = new THREE.Clock();
+
 			let views, t, canvas, renderer;
 
 			window.onload = init;
@@ -219,10 +221,7 @@
 
 			}
 
-			let lastFrame = performance.now();
 			function render() {
-				const delta = (performance.now() - lastFrame) / 1000;
-				lastFrame = performance.now(); 
 
 				updateSize();
 
@@ -278,7 +277,7 @@
 
 				} );
 
-				t += delta * 30;
+				t += clock.getDelta() * 30;
 
 			}
 

--- a/examples/webgl_multiple_elements_text.html
+++ b/examples/webgl_multiple_elements_text.html
@@ -277,7 +277,7 @@
 
 				} );
 
-				t += clock.getDelta() * 30;
+				t += clock.getDelta() * 60;
 
 			}
 

--- a/examples/webgl_multiple_elements_text.html
+++ b/examples/webgl_multiple_elements_text.html
@@ -219,7 +219,10 @@
 
 			}
 
+			let lastFrame = performance.now();
 			function render() {
+				const delta = (performance.now() - lastFrame) / 1000;
+				lastFrame = performance.now(); 
 
 				updateSize();
 
@@ -275,7 +278,7 @@
 
 				} );
 
-				t ++;
+				t += delta * 30;
 
 			}
 


### PR DESCRIPTION
Related issue: none

**Description**

Example webgl_multiple_elements_text increased the time variable by a set amount per-frame causing unsettlingly fast animations on >60hz screens, this switches it over to use the time between frames instead of a constant increment.
