### PR TITLE
Examples: add license for nurbs.fbx (#23089)

### DIFF
--- a/examples/models/fbx/README.md
+++ b/examples/models/fbx/README.md
@@ -1,0 +1,5 @@
+## License of the files in this directory
+
+### nurbs.fbx
+
+License: Public domain ([CC0](https://creativecommons.org/publicdomain/zero/1.0/))


### PR DESCRIPTION
Related issue: #23089

**Description**

Add a license for https://github.com/mrdoob/three.js/blob/dev/examples/models/fbx/nurbs.fbx 