### PR TITLE
PropertyBinding: fix map property binding regression introduced in #24537

### DIFF
--- a/src/animation/PropertyBinding.js
+++ b/src/animation/PropertyBinding.js
@@ -498,6 +498,13 @@ class PropertyBinding {
 
 				case 'map':
 
+					if ( 'map' in targetObject ) {
+
+						targetObject = targetObject.map;
+						break;
+
+					}
+
 					if ( ! targetObject.material ) {
 
 						console.error( 'THREE.PropertyBinding: Can not bind to material as node does not have a material.', this );


### PR DESCRIPTION
Related issue: 
- #24537

**Description**

The change to allow `map` as target object unfortunately broke traversal for general objects, such as what KHR_animation_pointer (#24108) requires for animating materials – while `NodeName.map.repeat` works it broke `MaterialName.map.repeat` for animated materials since a material doesn't have a `.material` property...

This PR fixes that by checking if the animated object already has a `map` property, because then the indirection to `.material.map` isn't needed.

cc @Mugen87 

**Note**  

My preferred way to fix this would be a broader change in bind() to ensure that when an objectName is found in targetObject that is always used – but that's a separate discussion I think:   

```js
if ( objectName && objectName in targetObject ) {

	targetObject = targetObject[ objectName ];

} else if ( objectName ) {

	let objectIndex = parsedPath.objectIndex;
        .... existing special cases ...
```