### PR TITLE
TessellateModifier dispose intermediate geometry

### DIFF
--- a/examples/jsm/modifiers/TessellateModifier.js
+++ b/examples/jsm/modifiers/TessellateModifier.js
@@ -21,7 +21,9 @@ class TessellateModifier {
 
 	modify( geometry ) {
 
-		if ( geometry.index !== null ) {
+		const gotIndexGeometry = geometry.index !== null;
+
+		if ( gotIndexGeometry ) {
 
 			geometry = geometry.toNonIndexed();
 
@@ -295,6 +297,12 @@ class TessellateModifier {
 		if ( hasUV2s ) {
 
 			geometry2.setAttribute( 'uv2', new Float32BufferAttribute( uv2s2, 2 ) );
+
+		}
+
+		if ( gotIndexGeometry ) {
+
+			geometry.dispose();
 
 		}
 

--- a/examples/jsm/modifiers/TessellateModifier.js
+++ b/examples/jsm/modifiers/TessellateModifier.js
@@ -21,9 +21,9 @@ class TessellateModifier {
 
 	modify( geometry ) {
 
-		const gotIndexGeometry = geometry.index !== null;
+		const gotIndexedGeometry = geometry.index !== null;
 
-		if ( gotIndexGeometry ) {
+		if ( gotIndexedGeometry ) {
 
 			geometry = geometry.toNonIndexed();
 
@@ -300,7 +300,7 @@ class TessellateModifier {
 
 		}
 
-		if ( gotIndexGeometry ) {
+		if ( gotIndexedGeometry ) {
 
 			geometry.dispose();
 


### PR DESCRIPTION
Related issue: #XXXX

When TessellateModifier receives an Indexed geometry it is converted to an intermediate non-indexed geometry.
That BufferGeometry is never disposed.
This PR makes sure we dispose of it.