### PR TITLE
Improved doc on BufferGeometry.dispose()

### DIFF
--- a/docs/api/en/core/BufferGeometry.html
+++ b/docs/api/en/core/BufferGeometry.html
@@ -222,7 +222,9 @@
 		<h3>[method:undefined dispose]()</h3>
 		<p>
 		Disposes the object from memory. <br />
-		You need to call this when you want the BufferGeometry removed while the application is running.
+		When the geometry is rendered it allocates WebGL resources which are not implicitly freed.
+		You need to call this when you want the BufferGeometry removed while the application is running. <br />
+		For more details read: [link:https://threejs.org/docs/index.html#manual/en/introduction/How-to-dispose-of-objects How to dispose of objects]
 		</p>
 
 		<h3>[method:BufferAttribute getAttribute]( [param:String name] )</h3>

--- a/docs/api/en/core/BufferGeometry.html
+++ b/docs/api/en/core/BufferGeometry.html
@@ -221,10 +221,8 @@
 
 		<h3>[method:undefined dispose]()</h3>
 		<p>
-		Disposes the object from memory. <br />
-		When the geometry is rendered it allocates WebGL resources which are not implicitly freed.
-		You need to call this when you want the BufferGeometry removed while the application is running. <br />
-		For more details read: [link:https://threejs.org/docs/index.html#manual/en/introduction/How-to-dispose-of-objects How to dispose of objects]
+		When a BufferGeometry is rendered, it allocates WebGL resources which can only be disposed of by calling this method.
+		For more details read: [link:https://threejs.org/docs/index.html#manual/en/introduction/How-to-dispose-of-objects How to dispose of objects].
 		</p>
 
 		<h3>[method:BufferAttribute getAttribute]( [param:String name] )</h3>


### PR DESCRIPTION
Related issue: #24607

Improved documentation on `BufferGeometry.dispose()` with a link to the separate page on objects disposing.
Hopefully this will better explain when `dispose()` is needed and when it can be avoided.
Example of a scenario that wasn't understood from the previous doc: when a geometry is not rendered, it doesn't have to be disposed.