### PR TITLE
GLTFExporter: Only set KHR_materials_volume attenuation properties if attenuationDistance > 0

### DIFF
--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -2544,8 +2544,12 @@ class GLTFMaterialsVolumeExtension {
 
 		}
 
-		extensionDef.attenuationDistance = material.attenuationDistance;
-		extensionDef.attenuationColor = material.attenuationColor.toArray();
+		if ( material.attenuationDistance > 0 ) {
+
+			extensionDef.attenuationDistance = material.attenuationDistance;
+			extensionDef.attenuationColor = material.attenuationColor.toArray();
+			
+		}
 
 		materialDef.extensions = materialDef.extensions || {};
 		materialDef.extensions[ this.name ] = extensionDef;

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -2527,7 +2527,7 @@ class GLTFMaterialsVolumeExtension {
 
 	writeMaterial( material, materialDef ) {
 
-		if ( ! material.isMeshPhysicalMaterial || material.transmission === 0 ) return;
+		if ( ! material.isMeshPhysicalMaterial || material.transmission === 0 || material.thickness === 0 ) return;
 
 		const writer = this.writer;
 		const extensionsUsed = writer.extensionsUsed;


### PR DESCRIPTION
Related issue: N/A

**Description**

The default `attenuationDistance` in `MeshPhysicalMaterial` is `0.0`, which is functionally equivalent to Infinity (c.f. https://github.com/mrdoob/three.js/blob/f160d03a91b77cb711bdef561a8dd960a7c9cc47/src/renderers/shaders/ShaderChunk/transmission_pars_fragment.glsl.js#L74 )

The KHR_materials_volume spec requires that attenuationDistance be _greater than zero_ if present. It defaults to Infinity if not present. (c.f. https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_volume/README.md#properties )

The current GTLFExporter produces incorrect gltf files for `MeshPhysicalMaterial` if `transmission` is set greater than zero, but `attenuationDistance` is set to the default of zero. These incorrect files cannot be read in some popular GLTF software (like Blender 3.3 GLTF Importer)

This PR causes GLTFExporter to produce correct gltf files for this case, while preserving the expected behavior, which is that the attenuation distance is functionally Infinity.


_Note:_ I've included `attenuationColor` in the conditional as well to try to best match the behavior of the three.js rendering (If `attenuationDistance` is 0, then no `attenuationColor` is applied), as well as to avoid confusing importers that may not be well written enough to check both properties. However I can take that out if it would be better to have the color property set no matter what.

For an alternative approach, see https://github.com/mrdoob/three.js/pull/24622

_Note:_ Only one of https://github.com/mrdoob/three.js/pull/24622 or this PR should be accepted. They are different approaches to the same problem.