### PR TITLE
MeshPhysicalMaterial: Match behavior of attenuationDistance to KHR_materials_volume

### DIFF
--- a/docs/api/en/materials/MeshPhysicalMaterial.html
+++ b/docs/api/en/materials/MeshPhysicalMaterial.html
@@ -86,7 +86,7 @@
 
 		<h3>[property:Float attenuationDistance]</h3>
 		<p>
-		Density of the medium given as the average distance that light travels in the medium before interacting with a particle. The value is given in world space. Default is `0`.
+		Density of the medium given as the average distance that light travels in the medium before interacting with a particle. The value is given in world space. Default is `Infinity`.
 		</p>
 
 		<h3>[property:Float clearcoat]</h3>

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -1044,7 +1044,7 @@ class GLTFMaterialsVolumeExtension {
 
 		}
 
-		materialParams.attenuationDistance = extension.attenuationDistance || 0;
+		materialParams.attenuationDistance = extension.attenuationDistance || Infinity;
 
 		const colorArray = extension.attenuationColor || [ 1, 1, 1 ];
 		materialParams.attenuationColor = new Color( colorArray[ 0 ], colorArray[ 1 ], colorArray[ 2 ] );

--- a/src/materials/MeshPhysicalMaterial.js
+++ b/src/materials/MeshPhysicalMaterial.js
@@ -55,7 +55,7 @@ class MeshPhysicalMaterial extends MeshStandardMaterial {
 
 		this.thickness = 0;
 		this.thicknessMap = null;
-		this.attenuationDistance = 0.0;
+		this.attenuationDistance = Infinity;
 		this.attenuationColor = new Color( 1, 1, 1 );
 
 		this.specularIntensity = 1.0;

--- a/src/renderers/shaders/ShaderChunk/transmission_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/transmission_pars_fragment.glsl.js
@@ -71,9 +71,9 @@ export default /* glsl */`
 
 	vec3 applyVolumeAttenuation( const in vec3 radiance, const in float transmissionDistance, const in vec3 attenuationColor, const in float attenuationDistance ) {
 
-		if ( attenuationDistance == 0.0 ) {
+		if ( isinf( attenuationDistance ) ) {
 
-			// Attenuation distance is +∞ (which we indicate by zero), i.e. the transmitted color is not attenuated at all.
+			// Attenuation distance is +∞, i.e. the transmitted color is not attenuated at all.
 			return radiance;
 
 		} else {


### PR DESCRIPTION
Related issue: N/A

**Description**

**This is an alternative approach to https://github.com/mrdoob/three.js/pull/24620 See also https://github.com/mrdoob/three.js/pull/24620#issuecomment-1242754206**


The default `attenuationDistance` in `MeshPhysicalMaterial` is `0.0`, which is functionally equivalent to Infinity (c.f. https://github.com/mrdoob/three.js/blob/f160d03a91b77cb711bdef561a8dd960a7c9cc47/src/renderers/shaders/ShaderChunk/transmission_pars_fragment.glsl.js#L74 )

The KHR_materials_volume spec requires that attenuationDistance be _greater than zero_ if present. It defaults to Infinity if not present. (c.f. https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_volume/README.md#properties )

The current GTLFExporter produces incorrect gltf files for `MeshPhysicalMaterial` if `transmission` is set greater than zero, but `attenuationDistance` is set to the default of zero. These incorrect files cannot be read in some popular GLTF software (like Blender 3.3 GLTF Importer)

This PR changes the default value of `attenuationDistance` to `Infinity`, and the behavior of `0` and `Infinity` to more closely align with the KHR_materials_volume specification.

_Note:_ Only one of https://github.com/mrdoob/three.js/pull/24620 or this PR should be accepted. They are different approaches to the same problem.