### PR TITLE
Update KTX2Loader.js

### DIFF
--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -260,13 +260,17 @@ class KTX2Loader extends Loader {
 	 * @return {Promise<CompressedTexture|DataTexture|Data3DTexture>}
 	 */
 	_createTexture( buffer, config = {} ) {
+		try {
+			const container = read( new Uint8Array( buffer ) );
 
-		const container = read( new Uint8Array( buffer ) );
+			if ( container.vkFormat !== VK_FORMAT_UNDEFINED ) {
 
-		if ( container.vkFormat !== VK_FORMAT_UNDEFINED ) {
+				return createDataTexture( container );
 
-			return createDataTexture( container );
-
+			}
+		}
+		catch (error) {
+			return Promise.reject( error );
 		}
 
 		//


### PR DESCRIPTION
Catch exception when use read from ktx-parse.module.js.

**Description**

When read file which is not ktx2, throw a Error. here add the catch procedure.
