### PR TITLE
Fix rotation not work in keyframetrack

### DIFF
--- a/src/animation/PropertyBinding.js
+++ b/src/animation/PropertyBinding.js
@@ -32,7 +32,7 @@ const _trackRe = new RegExp( ''
 	+ '$'
 );
 
-const _supportedObjectNames = [ 'material', 'materials', 'bones', 'map' ];
+const _supportedObjectNames = [ 'material', 'materials', 'bones', 'map', 'rotation' ];
 
 class Composite {
 


### PR DESCRIPTION
Fix rotation not work in keyframetrack

**Description**

I tried to create a rotating frame animation, but the rotation attribute is an Euler angles, I couldn't make it to Float32Array.
If use 'rotation.y' directly, there will be an error say 'rotation.y' wasn't found.
So I add 'rotation' in _supportedObjectNames, now we can use attribute like 'rotation.y' to create a rotating frame animation.
