### PR TITLE
WebGLState: Fix setting of `NeverDepth`.

### DIFF
--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -103,59 +103,51 @@ function WebGLState( gl, extensions, capabilities ) {
 
 				if ( currentDepthFunc !== depthFunc ) {
 
-					if ( depthFunc ) {
+					switch ( depthFunc ) {
 
-						switch ( depthFunc ) {
+						case NeverDepth:
 
-							case NeverDepth:
+							gl.depthFunc( gl.NEVER );
+							break;
 
-								gl.depthFunc( gl.NEVER );
-								break;
+						case AlwaysDepth:
 
-							case AlwaysDepth:
+							gl.depthFunc( gl.ALWAYS );
+							break;
 
-								gl.depthFunc( gl.ALWAYS );
-								break;
+						case LessDepth:
 
-							case LessDepth:
+							gl.depthFunc( gl.LESS );
+							break;
 
-								gl.depthFunc( gl.LESS );
-								break;
+						case LessEqualDepth:
 
-							case LessEqualDepth:
+							gl.depthFunc( gl.LEQUAL );
+							break;
 
-								gl.depthFunc( gl.LEQUAL );
-								break;
+						case EqualDepth:
 
-							case EqualDepth:
+							gl.depthFunc( gl.EQUAL );
+							break;
 
-								gl.depthFunc( gl.EQUAL );
-								break;
+						case GreaterEqualDepth:
 
-							case GreaterEqualDepth:
+							gl.depthFunc( gl.GEQUAL );
+							break;
 
-								gl.depthFunc( gl.GEQUAL );
-								break;
+						case GreaterDepth:
 
-							case GreaterDepth:
+							gl.depthFunc( gl.GREATER );
+							break;
 
-								gl.depthFunc( gl.GREATER );
-								break;
+						case NotEqualDepth:
 
-							case NotEqualDepth:
+							gl.depthFunc( gl.NOTEQUAL );
+							break;
 
-								gl.depthFunc( gl.NOTEQUAL );
-								break;
+						default:
 
-							default:
-
-								gl.depthFunc( gl.LEQUAL );
-
-						}
-
-					} else {
-
-						gl.depthFunc( gl.LEQUAL );
+							gl.depthFunc( gl.LEQUAL );
 
 					}
 


### PR DESCRIPTION
**Description**

While trying different options of `depthFunc` I noticed that setting it to `NeverDepth` didn't yield the expected result. Instead of it always failing depth testing and not rendering anything, it rendered "as normal". Looking into the code reveals that there's an if statement, presumably checking if the passed `depthFunc` value is "valid". However, the `NeverDepth` constant has the value `0` and thus fails this check. As such `NeverDepth` ends up being the same as the default `LessEqualDepth`.

This PR simply removes that if statement and associated else clause, as the else clauses matches the default case in the switch statement. This allows `NeverDepth` to be properly set and, unless I'm missing something obvious, behaves the same otherwise.

(Note: the diff makes it look like a lot has changed, but only the if statement and corresponding else clause have been removed, and the indentation level of the switch reduced by one)

*This contribution is funded by [Fern Solutions](https://fern.solutions)*
