### PR TITLE
TrackballControls: Fix multi-touch in `onTouchEnd()`.

### DIFF
--- a/examples/jsm/controls/TrackballControls.js
+++ b/examples/jsm/controls/TrackballControls.js
@@ -702,13 +702,18 @@ class TrackballControls extends EventDispatcher {
 					_state = STATE.TOUCH_ZOOM_PAN;
 
 					for ( let i = 0; i < _pointers.length; i ++ ) {
-						if ( _pointers[ i ].pointerId != event.pointerId ) {
-							let position = _pointerPositions[ _pointers[ i ].pointerId ];
+
+						if ( _pointers[ i ].pointerId !== event.pointerId ) {
+
+							const position = _pointerPositions[ _pointers[ i ].pointerId ];
 							_moveCurr.copy( getMouseOnCircle( position.x, position.y ) );
 							_movePrev.copy( _moveCurr );
 							break;
+
 						}
+
 					}
+
 					break;
 
 			}

--- a/examples/jsm/controls/TrackballControls.js
+++ b/examples/jsm/controls/TrackballControls.js
@@ -700,8 +700,15 @@ class TrackballControls extends EventDispatcher {
 
 				case 2:
 					_state = STATE.TOUCH_ZOOM_PAN;
-					_moveCurr.copy( getMouseOnCircle( event.pageX - _movePrev.x, event.pageY - _movePrev.y ) );
-					_movePrev.copy( _moveCurr );
+
+					for ( let i = 0; i < _pointers.length; i ++ ) {
+						if ( _pointers[ i ].pointerId != event.pointerId ) {
+							let position = _pointerPositions[ _pointers[ i ].pointerId ];
+							_moveCurr.copy( getMouseOnCircle( position.x, position.y ) );
+							_movePrev.copy( _moveCurr );
+							break;
+						}
+					}
 					break;
 
 			}


### PR DESCRIPTION
Related issue: (Didn't raise an issue yet)

**Description**

When using trackball control on my mobile app, I discovered that camera position will suddenly change a lot after zoom/pan multi-touch gesture, this can be reproduced by running trackball sample on iOS or Android touch screen devices and perform a zoom/pan gesture with two fingers.

As diff shows, when lifting first finger, the `_moveCurr` and `_movePrev` position was assigned to the lifted finger, if move event is detected on the other finger, the camera position will change as user swipe from lifted position to other finger's position. I addressed it by assigning two position variables with other finger's position instead.

I'm not a professional JS developer, so please feel free to edit / give me any suggestions : )
