### PR TITLE
Fix perf penalty when setting morphTargetsTextureSize

### DIFF
--- a/src/renderers/webgl/WebGLMorphtargets.js
+++ b/src/renderers/webgl/WebGLMorphtargets.js
@@ -191,7 +191,7 @@ function WebGLMorphtargets( gl, capabilities, textures ) {
 			program.getUniforms().setValue( gl, 'morphTargetInfluences', objectInfluences );
 
 			program.getUniforms().setValue( gl, 'morphTargetsTexture', entry.texture, textures );
-			program.getUniforms().setValue( gl, 'morphTargetsTextureSize', entry.size );
+			program.getUniforms().setValue( gl, 'morphTargetsTextureSize', [ entry.size.x, entry.size.y ] );
 
 
 		} else {


### PR DESCRIPTION
**Description**

I was recently looking at some CPU profiles of a scene with a handful of meshes with morph targets, and gl.uniform2iv was taking up ~25% of the cpu time each frame.  This seemed off, and i looked into it and discovered that it all came from the line in this PR.  Turns out this was passing a vector2 to setValueV2i, instead of a flat array (which the function expected).  The vector2 DOES properly coerce into an array in uniform2iv, so the value gets set properly by the function (though it's pretty slow). However, the cache does NOT work because it doesnt' have an array of equal length.  Thus, the values are never cached and for a scene with the same morph target mesh used, you pay a big perf penalty. 

By passing the value as an array, everything works as expected and the uniform2iv drops to the bottom of our profiles.

*This contribution is funded by [Meta](https://meta.com)*
