### PR TITLE
Fix jpeg-js properly (override for all packages)

### DIFF
--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "failonlyreporter": "^1.0.0",
-        "jimp": "^0.16.1",
+        "jimp": "^0.16.0",
         "pixelmatch": "^5.3.0",
         "puppeteer": "^15.2.0",
         "qunit": "^2.19.1",
@@ -1014,9 +1014,9 @@
       }
     },
     "node_modules/jpeg-js": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.2.tgz",
-      "integrity": "sha512-+az2gi/hvex7eLTMTlbRLOhH6P6WFdk2ITI8HJsaH2VqYO0I594zXSYEP+tf4FW+8Cy68ScDXoAsQdyQanv3sw==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
       "dev": true
     },
     "node_modules/load-bmfont": {
@@ -1795,7 +1795,7 @@
       "requires": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.16.1",
-        "jpeg-js": "0.4.2"
+        "jpeg-js": "^0.4.4"
       }
     },
     "@jimp/plugin-blit": {
@@ -2482,9 +2482,9 @@
       }
     },
     "jpeg-js": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.2.tgz",
-      "integrity": "sha512-+az2gi/hvex7eLTMTlbRLOhH6P6WFdk2ITI8HJsaH2VqYO0I594zXSYEP+tf4FW+8Cy68ScDXoAsQdyQanv3sw==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
       "dev": true
     },
     "load-bmfont": {

--- a/test/package.json
+++ b/test/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "failonlyreporter": "^1.0.0",
-    "jimp": "^0.16.1",
+    "jimp": "^0.16.0",
     "pixelmatch": "^5.3.0",
     "puppeteer": "^15.2.0",
     "qunit": "^2.19.1",
@@ -20,8 +20,6 @@
     "three": "file:.."
   },
   "overrides": {
-    "jimp": {
-      "jpeg-js": "^0.4.4"
-    }
+    "jpeg-js": "^0.4.4"
   }
 }


### PR DESCRIPTION
#24638 continued, this time `npm audit` is green in the test folder.
