### PR TITLE
LDrawLoader: Fix incorrect normals on double sided faces

### DIFF
--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -782,6 +782,7 @@ class LDrawParsedCache {
 
 		// final results
 		const faces = [];
+		const backSideFaces = [];
 		const lineSegments = [];
 		const conditionalSegments = [];
 		const subobjects = [];
@@ -1147,7 +1148,7 @@ class LDrawParsedCache {
 
 					if ( doubleSided === true ) {
 
-						faces.push( {
+						backSideFaces.push( {
 							material: material,
 							colorCode: colorCode,
 							faceNormal: null,
@@ -1197,7 +1198,7 @@ class LDrawParsedCache {
 
 					if ( doubleSided === true ) {
 
-						faces.push( {
+						backSideFaces.push( {
 							material: material,
 							colorCode: colorCode,
 							faceNormal: null,
@@ -1225,6 +1226,7 @@ class LDrawParsedCache {
 
 		return {
 			faces,
+			backSideFaces,
 			conditionalSegments,
 			lineSegments,
 			type,
@@ -1515,6 +1517,12 @@ class LDrawPartsGeometryCache {
 		// Add the primitive objects and metadata.
 		const group = info.group;
 		if ( info.faces.length > 0 ) {
+
+			if ( info.backSideFaces && info.backSideFaces.length > 0 ) {
+
+				info.faces.push(...info.backSideFaces);
+
+			}
 
 			group.add( createObject( info.faces, 3, false, info.totalFaces ) );
 


### PR DESCRIPTION
Related issue: mrdoob#24635

Description
The function `smoothNormals` in LDrawLoader.js got incorrect normals while the model is not bfcCertified incorrectly.
The issue happens with the Triangles or Quadrilateral which need double sides.

<img width="714" alt="iShot_2022-09-13_12 02 48" src="https://user-images.githubusercontent.com/29625655/189918752-9056dadd-fdae-4a98-a4bf-3e6fe5e41953.png">
<img width="681" alt="iShot_2022-09-13_12 03 07" src="https://user-images.githubusercontent.com/29625655/189918776-bb318923-adff-4b0b-8017-b9ee975a16bb.png">

In LDrawLoader.js:

Lines 1139-1150 / 1189-1200, pushes a reversed vertices to the variable faces array.
```
if ( doubleSided === true ) {
  faces.push( {
	material: material,
	colorCode: colorCode,
	faceNormal: null,
	vertices: [ v3, v2, v1, v0 ],
	normals: [ null, null, null, null ],
  } );
  totalFaces += 2;
}
```
And in the function `smoothNormals` finds RESERVED vertices, at the lines 421 &422, and it causes the final computed normal values are an array with Zero Vectors.
```
const reverseHash = hashEdge( v1, v0 );
const otherInfo = halfEdgeList[ reverseHash ];
```
There are conflicts about RESERVED vertices, so introduce a new array to store the 'back side faces' and merge it to the origin faces array after invoking the function smoothNormals.

1. Refactor the function `LDrawParsedCache.parse`:
```
const faces = [];
const backSideFaces = []; // Define the array which stores the 'back side faces' at line 783

...

// Add the back side face of triangle to backSideFaces instead of faces
if ( doubleSided === true ) {
  backSideFaces.push( {     // Line 1142
	material: material,
	colorCode: colorCode,
	faceNormal: null,
	vertices: [ v2, v1, v0 ],
	normals: [ null, null, null, null ],
  } );
  totalFaces += 2;
}

...

// Add the back side face of quadrilateral
if ( doubleSided === true ) {
  backSideFaces.push( {     // Line 1192
	material: material,
	colorCode: colorCode,
	faceNormal: null,
	vertices: [ v3, v2, v1, v0 ],
	normals: [ null, null, null, null ],
  } );
  totalFaces += 2;
}

...

return {
  faces,
  backSideFaces,   // Export the property
  ...
};
```

2. Refactor the function `LDrawPartsGeometryCache.processIntoMesh`:
```
// Start at line 1504 
if ( info.faces.length > 0 ) {

	if ( info.backSideFaces && info.backSideFaces.length > 0 ) {
	   info.faces.push( ...info.backSideFaces );   // Append info.backSideFaces to info.faces
	}
   group.add( createObject( info.faces, 3, false, info.totalFaces ) );

}
```

<img width="708" alt="iShot_2022-09-13_15 27 02" src="https://user-images.githubusercontent.com/29625655/189918370-ba15803c-b6e5-4836-8725-15b3f408f1f6.png">
<img width="713" alt="iShot_2022-09-13_15 28 00" src="https://user-images.githubusercontent.com/29625655/189918381-19d0c4ef-9f9b-45e0-9fde-09b169259974.png">
