### PR TITLE
VRMLLoader: Process Anchor node as grouping node.

### DIFF
--- a/examples/jsm/loaders/VRMLLoader.js
+++ b/examples/jsm/loaders/VRMLLoader.js
@@ -625,6 +625,7 @@ class VRMLLoader extends Loader {
 
 			switch ( nodeName ) {
 
+				case 'Anchor':
 				case 'Group':
 				case 'Transform':
 				case 'Collision':
@@ -706,7 +707,6 @@ class VRMLLoader extends Loader {
 					build = buildWorldInfoNode( node );
 					break;
 
-				case 'Anchor':
 				case 'Billboard':
 
 				case 'Inline':
@@ -794,7 +794,15 @@ class VRMLLoader extends Loader {
 						parseFieldChildren( fieldValues, object );
 						break;
 
+					case 'description':
+						// field not supported
+						break;
+
 					case 'collide':
+						// field not supported
+						break;
+
+					case 'parameter':
 						// field not supported
 						break;
 
@@ -817,6 +825,10 @@ class VRMLLoader extends Loader {
 						break;
 
 					case 'proxy':
+						// field not supported
+						break;
+
+					case 'url':
 						// field not supported
 						break;
 


### PR DESCRIPTION
Fixed #24644.

**Description**

`VRMLLoader` now processes nodes of type `Anchor` as ordinary grouping nodes. `url` fields and the respective fetch of resources is not supported.

@XMZOVO This change ensures the yellow spheres are rendered. The error of `computeBoundingSphere()` is caused by invalid line definitions of your asset. It seems Geant4 export lines with just one vertex which does not seem to make sense. It's probably best if you ask for a fix for their exporter. In the meanwhile, traverse through the loaded VRML asset and remove the problematic line segments from your scene.
