### PR TITLE
HTMLMesh: Fix canvas cache usage.

### DIFF
--- a/examples/js/interactive/HTMLMesh.js
+++ b/examples/js/interactive/HTMLMesh.js
@@ -430,17 +430,14 @@
 		}
 
 		const offset = element.getBoundingClientRect();
-		let canvas;
+		let canvas = canvases.get( element );
 
-		if ( canvases.has( element ) ) {
-
-			canvas = canvases.get( element );
-
-		} else {
+		if ( canvas === undefined ) {
 
 			canvas = document.createElement( 'canvas' );
 			canvas.width = offset.width;
 			canvas.height = offset.height;
+			canvases.set( element, canvas );
 
 		}
 

--- a/examples/jsm/interactive/HTMLMesh.js
+++ b/examples/jsm/interactive/HTMLMesh.js
@@ -469,17 +469,14 @@ function html2canvas( element ) {
 
 	const offset = element.getBoundingClientRect();
 
-	let canvas;
+	let canvas = canvases.get( element );
 
-	if ( canvases.has( element ) ) {
-
-		canvas = canvases.get( element );
-
-	} else {
+	if ( canvas === undefined ) {
 
 		canvas = document.createElement( 'canvas' );
 		canvas.width = offset.width;
 		canvas.height = offset.height;
+		canvases.set( element, canvas );
 
 	}
 


### PR DESCRIPTION
Related issue: #22098

**Description**

- Fix only reading, but not updating the canvas cache
- Avoid double lookups when reading from the canvas cache