### PR TITLE
CSM.remove() removes the targets, too

### DIFF
--- a/examples/jsm/csm/CSM.js
+++ b/examples/jsm/csm/CSM.js
@@ -343,6 +343,7 @@ export class CSM {
 
 		for ( let i = 0; i < this.lights.length; i ++ ) {
 
+			this.parent.remove( this.lights[ i ].target );
 			this.parent.remove( this.lights[ i ] );
 
 		}


### PR DESCRIPTION
Fixed #24653

**Description**

CSM.createLights() adds the DirectionalLight and its target to its parent but the counterpart .remove only removes only the light and leaves the orphaned target.