### PR TITLE
Add `three/nodes` export to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "./examples/fonts/*": "./examples/fonts/*",
     "./examples/jsm/*": "./examples/jsm/*",
     "./addons/*": "./examples/jsm/*",
-    "./src/*": "./src/*"
+    "./src/*": "./src/*",
+    "./nodes": "./examples/jsm/nodes/Nodes.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes https://github.com/mrdoob/three.js/issues/24659

**Description**

Add the `three/nodes` export to the package.json.