### PR TITLE
WebGLRenderer: Add the get func of Graphics driver information.

### DIFF
--- a/docs/api/en/renderers/WebGLRenderer.html
+++ b/docs/api/en/renderers/WebGLRenderer.html
@@ -359,6 +359,12 @@
 		Returns the width and height of the renderer's drawing buffer, in pixels.
 		</p>
 
+		<h3>[method:string getRendererInfo]()</h3>
+		<p>Return the renderer string of the graphics driver.</p>
+
+		<h3>[method:string getVendorInfo]()</h3>
+		<p>Return the vendor string of the graphics driver.</p>
+
 		<h3>[method:number getPixelRatio]()</h3>
 		<p>Returns current device pixel ratio used.</p>
 

--- a/docs/api/en/renderers/WebGLRenderer.html
+++ b/docs/api/en/renderers/WebGLRenderer.html
@@ -366,7 +366,7 @@
 		<p>Return the vendor string of the graphics driver.</p>
 
 		<h3>[method:number getPixelRatio]()</h3>
-		<p>Returns current device pixel ratio used.</p>
+		<p>Return current device pixel ratio used.</p>
 
 		<h3>[method:Vector4 getScissor]( [param:Vector4 target] )</h3>
 		<p>

--- a/docs/api/en/renderers/WebGLRenderer.html
+++ b/docs/api/en/renderers/WebGLRenderer.html
@@ -359,10 +359,10 @@
 		Returns the width and height of the renderer's drawing buffer, in pixels.
 		</p>
 
-		<h3>[method:string getRendererInfo]()</h3>
+		<h3>[method:string getGraphicsDriverRenderer]()</h3>
 		<p>Return the renderer string of the graphics driver.</p>
 
-		<h3>[method:string getVendorInfo]()</h3>
+		<h3>[method:string getGraphicsDriverVendor]()</h3>
 		<p>Return the vendor string of the graphics driver.</p>
 
 		<h3>[method:number getPixelRatio]()</h3>

--- a/docs/api/zh/renderers/WebGLRenderer.html
+++ b/docs/api/zh/renderers/WebGLRenderer.html
@@ -324,6 +324,12 @@
 		<h3>[method:number getPixelRatio]()</h3>
 		<p>返回当前使用设备像素比</p>
 
+		<h3>[method:string getVendorInfo]()</h3>
+		<p>返回图形驱动程序的供应商字符串。</p>
+
+		<h3>[method:number getPixelRatio]()</h3>
+		<p>返回图形驱动程序的渲染器（显卡）字符串。</p>
+
 		<h3>[method:Vector2 getSize]( [param:Vector2 target] )</h3>
 		<p>返回包含渲染器输出canvas的宽度和高度(单位像素)的对象。</p>
 

--- a/docs/api/zh/renderers/WebGLRenderer.html
+++ b/docs/api/zh/renderers/WebGLRenderer.html
@@ -324,10 +324,10 @@
 		<h3>[method:number getPixelRatio]()</h3>
 		<p>返回当前使用设备像素比</p>
 
-		<h3>[method:string getVendorInfo]()</h3>
+		<h3>[method:string getGraphicsDriverVendor]()</h3>
 		<p>返回图形驱动程序的供应商字符串。</p>
 
-		<h3>[method:number getPixelRatio]()</h3>
+		<h3>[method:number getGraphicsDriverRenderer]()</h3>
 		<p>返回图形驱动程序的渲染器（显卡）字符串。</p>
 
 		<h3>[method:Vector2 getSize]( [param:Vector2 target] )</h3>

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -392,6 +392,41 @@ function WebGLRenderer( parameters = {} ) {
 
 	};
 
+	this.getVendorInfo = function () {
+
+		const debugInfo = extensions.get( 'WEBGL_debug_renderer_info' );
+		if ( ! debugInfo ) {
+
+			return null;
+
+		} else {
+
+			const vendor = _gl.getParameter( debugInfo.UNMASKED_VENDOR_WEBGL );
+
+			return vendor;
+
+		}
+
+	};
+
+	 this.getRendererInfo = function () {
+
+		const debugInfo = extensions.get( 'WEBGL_debug_renderer_info' );
+
+		if ( ! debugInfo ) {
+
+			return null;
+
+		} else {
+
+			const renderer = _gl.getParameter( debugInfo.UNMASKED_RENDERER_WEBGL );
+
+			return renderer;
+
+		}
+
+	};
+
 	this.getPixelRatio = function () {
 
 		return _pixelRatio;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -392,7 +392,7 @@ function WebGLRenderer( parameters = {} ) {
 
 	};
 
-	this.getVendorInfo = function () {
+	this.getGraphicsDriverVendor = function () {
 
 		const debugInfo = extensions.get( 'WEBGL_debug_renderer_info' );
 		if ( ! debugInfo ) {
@@ -409,7 +409,7 @@ function WebGLRenderer( parameters = {} ) {
 
 	};
 
-	 this.getRendererInfo = function () {
+	 this.getGraphicsDriverRenderer = function () {
 
 		const debugInfo = extensions.get( 'WEBGL_debug_renderer_info' );
 


### PR DESCRIPTION
**Add the get Func of Graphics driver information**

WebGLRenderer adds the get Func of Graphics driver information，which make that we can easily view graphic driver information. 😃 

Take a simple example. If chorme does not turn on hardware acceleration, WebGL will not drive an independent graphics card for rendering, but instead drive an integrated graphics card. However, it is often difficult for people to detect. By viewing the current graphics driven information, they can obtain some information to help judge and find the direction to solve the problem. 


