### PR TITLE
OutlinePass: Fix shader compilation error.

### DIFF
--- a/examples/jsm/postprocessing/OutlinePass.js
+++ b/examples/jsm/postprocessing/OutlinePass.js
@@ -448,9 +448,13 @@ class OutlinePass extends Pass {
 					vPosition = mvPosition;
 
 					vec4 worldPosition = vec4( transformed, 1.0 );
+
 					#ifdef USE_INSTANCING
+
 						worldPosition = instanceMatrix * worldPosition;
+
 					#endif
+					
 					worldPosition = modelMatrix * worldPosition;
 
 					projTexCoord = textureMatrix * worldPosition;

--- a/examples/jsm/postprocessing/OutlinePass.js
+++ b/examples/jsm/postprocessing/OutlinePass.js
@@ -444,9 +444,15 @@ class OutlinePass extends Pass {
 					#include <morphtarget_vertex>
 					#include <skinning_vertex>
 					#include <project_vertex>
-					#include <worldpos_vertex>
 
 					vPosition = mvPosition;
+
+					vec4 worldPosition = vec4( transformed, 1.0 );
+					#ifdef USE_INSTANCING
+						worldPosition = instanceMatrix * worldPosition;
+					#endif
+					worldPosition = modelMatrix * worldPosition;
+
 					projTexCoord = textureMatrix * worldPosition;
 
 				}`,


### PR DESCRIPTION
Fix for bug in outline pass reported here https://github.com/mrdoob/three.js/pull/24440#issuecomment-1254502214


