### PR TITLE
ShaderNode: luminance(), lumaCoeffs

### DIFF
--- a/examples/jsm/nodes/display/ColorAdjustmentNode.js
+++ b/examples/jsm/nodes/display/ColorAdjustmentNode.js
@@ -1,5 +1,5 @@
 import TempNode from '../core/TempNode.js';
-import { ShaderNode, vec3, mat3, add, sub, mul, max, div, dot, float, mix, cos, sin, atan2, sqrt, luminance } from '../shadernode/ShaderNodeBaseElements.js';
+import { ShaderNode, vec3, mat3, add, sub, mul, max, div, float, mix, cos, sin, atan2, sqrt, luminance } from '../shadernode/ShaderNodeBaseElements.js';
 
 const saturationNode = new ShaderNode( ( { color, adjustment } ) => {
 

--- a/examples/jsm/nodes/display/ColorAdjustmentNode.js
+++ b/examples/jsm/nodes/display/ColorAdjustmentNode.js
@@ -1,19 +1,9 @@
 import TempNode from '../core/TempNode.js';
-import { ShaderNode, vec3, mat3, add, sub, mul, max, div, dot, float, mix, cos, sin, atan2, sqrt } from '../shadernode/ShaderNodeBaseElements.js';
-
-const luminanceNode = new ShaderNode( ( { color } ) => {
-
-	const LUMA = vec3( 0.2125, 0.7154, 0.0721 );
-
-	return dot( color, LUMA );
-
-} );
+import { ShaderNode, vec3, mat3, add, sub, mul, max, div, dot, float, mix, cos, sin, atan2, sqrt, luminance } from '../shadernode/ShaderNodeBaseElements.js';
 
 const saturationNode = new ShaderNode( ( { color, adjustment } ) => {
 
-	const intensityNode = luminanceNode.call( { color } );
-
-	return mix( intensityNode, color, adjustment );
+	return mix( luminance( color ), color, adjustment );
 
 } );
 

--- a/examples/jsm/nodes/shadernode/ShaderNodeBaseElements.js
+++ b/examples/jsm/nodes/shadernode/ShaderNodeBaseElements.js
@@ -289,6 +289,9 @@ export const element = nodeProxy( ArrayElementNode );
 
 // miscellaneous
 
-export const difference = ( a, b ) => nodeObject( abs( sub( a, b ) ) );
+export const lumaCoeffs = vec3( 0.2125, 0.7154, 0.0721 );
+
+export const luminance = ( color, luma = lumaCoeffs ) => dot( color, luma );
+export const difference = ( a, b ) => abs( sub( a, b ) );
 export const dotNV = clamp( dot( transformedNormalView, positionViewDirection ) );
 export const TBNViewMatrix = mat3( tangentView, bitangentView, normalView );


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/24674

## ShaderNode
- [x] Added `luminance( rgb )`
- [x] Added `lumaCoeffs = vec3( 0.2125, 0.7154, 0.0721 );`

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Google](https://google.com)*
