### PR TITLE
Examples: Clean up.

### DIFF
--- a/examples/webgl_worker_offscreencanvas.html
+++ b/examples/webgl_worker_offscreencanvas.html
@@ -68,6 +68,15 @@
 		<!-- Remove this when import maps will be widely supported -->
 		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
 
+		<script type="importmap">
+			{
+				"imports": {
+					"three": "../build/three.module.js",
+					"three/addons/": "./jsm/"
+				}
+			}
+		</script>
+
 		<script type="module">
 
 			import initJank from 'three/addons/offscreen/jank.js';


### PR DESCRIPTION
Fixed #24685.

**Description**

Added the missing import map to `webgl_worker_offscreencanvas.html`.