### PR TITLE
Controls: Move remaining classes to Pointer Events.

### DIFF
--- a/examples/jsm/controls/FirstPersonControls.js
+++ b/examples/jsm/controls/FirstPersonControls.js
@@ -42,8 +42,8 @@ class FirstPersonControls {
 
 		this.autoSpeedFactor = 0.0;
 
-		this.mouseX = 0;
-		this.mouseY = 0;
+		this.pointerX = 0;
+		this.pointerY = 0;
 
 		this.moveForward = false;
 		this.moveBackward = false;
@@ -76,7 +76,7 @@ class FirstPersonControls {
 
 		};
 
-		this.onMouseDown = function ( event ) {
+		this.onPointerDown = function ( event ) {
 
 			if ( this.domElement !== document ) {
 
@@ -99,7 +99,7 @@ class FirstPersonControls {
 
 		};
 
-		this.onMouseUp = function ( event ) {
+		this.onPointerUp = function ( event ) {
 
 			if ( this.activeLook ) {
 
@@ -116,17 +116,17 @@ class FirstPersonControls {
 
 		};
 
-		this.onMouseMove = function ( event ) {
+		this.onPointerMove = function ( event ) {
 
 			if ( this.domElement === document ) {
 
-				this.mouseX = event.pageX - this.viewHalfX;
-				this.mouseY = event.pageY - this.viewHalfY;
+				this.pointerX = event.pageX - this.viewHalfX;
+				this.pointerY = event.pageY - this.viewHalfY;
 
 			} else {
 
-				this.mouseX = event.pageX - this.domElement.offsetLeft - this.viewHalfX;
-				this.mouseY = event.pageY - this.domElement.offsetTop - this.viewHalfY;
+				this.pointerX = event.pageX - this.domElement.offsetLeft - this.viewHalfX;
+				this.pointerY = event.pageY - this.domElement.offsetTop - this.viewHalfY;
 
 			}
 
@@ -246,8 +246,8 @@ class FirstPersonControls {
 
 				}
 
-				lon -= this.mouseX * actualLookSpeed;
-				if ( this.lookVertical ) lat -= this.mouseY * actualLookSpeed * verticalLookRatio;
+				lon -= this.pointerX * actualLookSpeed;
+				if ( this.lookVertical ) lat -= this.pointerY * actualLookSpeed * verticalLookRatio;
 
 				lat = Math.max( - 85, Math.min( 85, lat ) );
 
@@ -273,25 +273,25 @@ class FirstPersonControls {
 		this.dispose = function () {
 
 			this.domElement.removeEventListener( 'contextmenu', contextmenu );
-			this.domElement.removeEventListener( 'mousedown', _onMouseDown );
-			this.domElement.removeEventListener( 'mousemove', _onMouseMove );
-			this.domElement.removeEventListener( 'mouseup', _onMouseUp );
+			this.domElement.removeEventListener( 'pointerdown', onPointerDown );
+			this.domElement.removeEventListener( 'pointermove', onPointerMove );
+			this.domElement.removeEventListener( 'pointerup', onPointerUp );
 
 			window.removeEventListener( 'keydown', _onKeyDown );
 			window.removeEventListener( 'keyup', _onKeyUp );
 
 		};
 
-		const _onMouseMove = this.onMouseMove.bind( this );
-		const _onMouseDown = this.onMouseDown.bind( this );
-		const _onMouseUp = this.onMouseUp.bind( this );
+		const onPointerMove = this.onPointerMove.bind( this );
+		const onPointerDown = this.onPointerDown.bind( this );
+		const onPointerUp = this.onPointerUp.bind( this );
 		const _onKeyDown = this.onKeyDown.bind( this );
 		const _onKeyUp = this.onKeyUp.bind( this );
 
 		this.domElement.addEventListener( 'contextmenu', contextmenu );
-		this.domElement.addEventListener( 'mousemove', _onMouseMove );
-		this.domElement.addEventListener( 'mousedown', _onMouseDown );
-		this.domElement.addEventListener( 'mouseup', _onMouseUp );
+		this.domElement.addEventListener( 'pointerdown', onPointerDown );
+		this.domElement.addEventListener( 'pointermove', onPointerMove );
+		this.domElement.addEventListener( 'pointerup', onPointerUp );
 
 		window.addEventListener( 'keydown', _onKeyDown );
 		window.addEventListener( 'keyup', _onKeyUp );

--- a/examples/jsm/controls/FirstPersonControls.js
+++ b/examples/jsm/controls/FirstPersonControls.js
@@ -273,25 +273,25 @@ class FirstPersonControls {
 		this.dispose = function () {
 
 			this.domElement.removeEventListener( 'contextmenu', contextmenu );
-			this.domElement.removeEventListener( 'pointerdown', onPointerDown );
-			this.domElement.removeEventListener( 'pointermove', onPointerMove );
-			this.domElement.removeEventListener( 'pointerup', onPointerUp );
+			this.domElement.removeEventListener( 'pointerdown', _onPointerDown );
+			this.domElement.removeEventListener( 'pointermove', _onPointerMove );
+			this.domElement.removeEventListener( 'pointerup', _onPointerUp );
 
 			window.removeEventListener( 'keydown', _onKeyDown );
 			window.removeEventListener( 'keyup', _onKeyUp );
 
 		};
 
-		const onPointerMove = this.onPointerMove.bind( this );
-		const onPointerDown = this.onPointerDown.bind( this );
-		const onPointerUp = this.onPointerUp.bind( this );
+		const _onPointerMove = this.onPointerMove.bind( this );
+		const _onPointerDown = this.onPointerDown.bind( this );
+		const _onPointerUp = this.onPointerUp.bind( this );
 		const _onKeyDown = this.onKeyDown.bind( this );
 		const _onKeyUp = this.onKeyUp.bind( this );
 
 		this.domElement.addEventListener( 'contextmenu', contextmenu );
-		this.domElement.addEventListener( 'pointerdown', onPointerDown );
-		this.domElement.addEventListener( 'pointermove', onPointerMove );
-		this.domElement.addEventListener( 'pointerup', onPointerUp );
+		this.domElement.addEventListener( 'pointerdown', _onPointerDown );
+		this.domElement.addEventListener( 'pointermove', _onPointerMove );
+		this.domElement.addEventListener( 'pointerup', _onPointerUp );
 
 		window.addEventListener( 'keydown', _onKeyDown );
 		window.addEventListener( 'keyup', _onKeyUp );

--- a/examples/jsm/controls/FlyControls.js
+++ b/examples/jsm/controls/FlyControls.js
@@ -36,7 +36,7 @@ class FlyControls extends EventDispatcher {
 
 		this.tmpQuaternion = new Quaternion();
 
-		this.mouseStatus = 0;
+		this.status = 0;
 
 		this.moveState = { up: 0, down: 0, left: 0, right: 0, forward: 0, back: 0, pitchUp: 0, pitchDown: 0, yawLeft: 0, yawRight: 0, rollLeft: 0, rollRight: 0 };
 		this.moveVector = new Vector3( 0, 0, 0 );
@@ -112,11 +112,11 @@ class FlyControls extends EventDispatcher {
 
 		};
 
-		this.mousedown = function ( event ) {
+		this.pointerdown = function ( event ) {
 
 			if ( this.dragToLook ) {
 
-				this.mouseStatus ++;
+				this.status ++;
 
 			} else {
 
@@ -133,9 +133,9 @@ class FlyControls extends EventDispatcher {
 
 		};
 
-		this.mousemove = function ( event ) {
+		this.pointermove = function ( event ) {
 
-			if ( ! this.dragToLook || this.mouseStatus > 0 ) {
+			if ( ! this.dragToLook || this.status > 0 ) {
 
 				const container = this.getContainerDimensions();
 				const halfWidth = container.size[ 0 ] / 2;
@@ -150,11 +150,11 @@ class FlyControls extends EventDispatcher {
 
 		};
 
-		this.mouseup = function ( event ) {
+		this.pointerup = function ( event ) {
 
 			if ( this.dragToLook ) {
 
-				this.mouseStatus --;
+				this.status --;
 
 				this.moveState.yawLeft = this.moveState.pitchDown = 0;
 
@@ -245,26 +245,25 @@ class FlyControls extends EventDispatcher {
 		this.dispose = function () {
 
 			this.domElement.removeEventListener( 'contextmenu', contextmenu );
-			this.domElement.removeEventListener( 'mousedown', _mousedown );
-			this.domElement.removeEventListener( 'mousemove', _mousemove );
-			this.domElement.removeEventListener( 'mouseup', _mouseup );
+			this.domElement.removeEventListener( 'pointerdown', _pointerdown );
+			this.domElement.removeEventListener( 'pointermove', _pointermove );
+			this.domElement.removeEventListener( 'pointerup', _pointerup );
 
 			window.removeEventListener( 'keydown', _keydown );
 			window.removeEventListener( 'keyup', _keyup );
 
 		};
 
-		const _mousemove = this.mousemove.bind( this );
-		const _mousedown = this.mousedown.bind( this );
-		const _mouseup = this.mouseup.bind( this );
+		const _pointermove = this.pointermove.bind( this );
+		const _pointerdown = this.pointerdown.bind( this );
+		const _pointerup = this.pointerup.bind( this );
 		const _keydown = this.keydown.bind( this );
 		const _keyup = this.keyup.bind( this );
 
 		this.domElement.addEventListener( 'contextmenu', contextmenu );
-
-		this.domElement.addEventListener( 'mousemove', _mousemove );
-		this.domElement.addEventListener( 'mousedown', _mousedown );
-		this.domElement.addEventListener( 'mouseup', _mouseup );
+		this.domElement.addEventListener( 'pointerdown', _pointerdown );
+		this.domElement.addEventListener( 'pointermove', _pointermove );
+		this.domElement.addEventListener( 'pointerup', _pointerup );
 
 		window.addEventListener( 'keydown', _keydown );
 		window.addEventListener( 'keyup', _keyup );


### PR DESCRIPTION
Related issue: #20170, #20168

**Description**

This PR moves `FlyControls` and `FirstPersonControls` from mouse to pointer events.

The original PRs were not merged since we were unsure about renaming properties and methods in the public scope. However, the affected entities are no part the actual public API so it is safe to rename them.
