### PR TITLE
Sphere Fix: Add branch for empty condition in expandByPoint function

### DIFF
--- a/src/math/Sphere.js
+++ b/src/math/Sphere.js
@@ -165,6 +165,7 @@ class Sphere {
 
 			this.center.copy( point );
 			this.radius = 0;
+			return;
 
 		}
 

--- a/src/math/Sphere.js
+++ b/src/math/Sphere.js
@@ -161,6 +161,13 @@ class Sphere {
 
 	expandByPoint( point ) {
 
+		if ( this.isEmpty() ) {
+
+			this.center.copy( point );
+			this.radius = 0;
+
+		}
+
 		// from https://github.com/juj/MathGeoLib/blob/2940b99b99cfe575dd45103ef20f4019dee15b54/src/Geometry/Sphere.cpp#L649-L671
 
 		_toPoint.subVectors( point, this.center );


### PR DESCRIPTION
Related issue: --

**Description**

Currently when calling "Sphere.expandByPoint" on an "empty" sphere with a point that is < 1.0 distance from the sphere center nothing will happen because the radius is squared before checking if the point is already encapsulated:

```js
sphere = new THREE.Sphere();
sphere.makeEmpty();

point = new THREE.Vector3( 0.5, 0, 0 );
sphere.expandByPoint( point );

console.log( sphere.radius ); // still - 1
```

cc @WestLangley 