### PR TITLE
ColorManagement: renamed `.legacyMode` to `.enabled`

### DIFF
--- a/docs/manual/en/introduction/Color-management.html
+++ b/docs/manual/en/introduction/Color-management.html
@@ -158,11 +158,11 @@
 		each have an associated color space. Those not already in the Linear-sRGB working color
 		space must be converted, and textures be given the correct <i>texture.encoding</i> assignment.
 		Certain conversions (for hexadecimal and CSS colors in sRGB) can be made automatically if
-		the legacy color management mode is disabled before initializing colors:
+		color management is enabled before initializing colors:
 	</p>
 
 	<code>
-THREE.ColorManagement.legacyMode = false;
+THREE.ColorManagement.enabled = true;
 	</code>
 
 	<ul>
@@ -272,7 +272,7 @@ renderer.outputEncoding = THREE.sRGBEncoding; // optional with post-processing
 	</code>
 
 	<p>
-		With <i>ColorManagement.legacyMode = false</i> set (recommended), certain conversions
+		With <i>ColorManagement.enabled = true</i> set (recommended), certain conversions
 		are made automatically. Because hexadecimal and CSS colors are generally sRGB, [page:Color]
 		methods will automatically convert these inputs from sRGB to Linear-sRGB in setters, or
 		convert from Linear-sRGB to sRGB when returning hexadecimal or CSS output from getters.

--- a/src/math/ColorManagement.js
+++ b/src/math/ColorManagement.js
@@ -21,7 +21,7 @@ const FN = {
 
 export const ColorManagement = {
 
-	legacyMode: true,
+	enabled: false,
 
 	get workingColorSpace() {
 
@@ -37,7 +37,7 @@ export const ColorManagement = {
 
 	convert: function ( color, sourceColorSpace, targetColorSpace ) {
 
-		if ( this.legacyMode || sourceColorSpace === targetColorSpace || ! sourceColorSpace || ! targetColorSpace ) {
+		if ( ! this.enabled || sourceColorSpace === targetColorSpace || ! sourceColorSpace || ! targetColorSpace ) {
 
 			return color;
 


### PR DESCRIPTION
The current API is as follows:	
```js
THREE.ColorManagement.legacyMode = false; // false means enabled
```
This PR changes the API to:
```js
THREE.ColorManagement.enabled = true;
```
