### PR TITLE
Sphere Fix: Handle empty cases in Sphere.union

### DIFF
--- a/src/math/Sphere.js
+++ b/src/math/Sphere.js
@@ -187,6 +187,18 @@ class Sphere {
 
 	union( sphere ) {
 
+		// handle empty sphere cases
+		if ( sphere.isEmpty() ) {
+
+			return;
+
+		} else if ( this.isEmpty() ) {
+
+			this.copy( sphere );
+			return;
+
+		}
+
 		// from https://github.com/juj/MathGeoLib/blob/2940b99b99cfe575dd45103ef20f4019dee15b54/src/Geometry/Sphere.cpp#L759-L769
 
 		// To enclose another sphere into this sphere, we only need to enclose two points:


### PR DESCRIPTION
Related issue: #24694

**Description**

Handle cases where the spheres are empty in Sphere.union. Here is the behavior before and after.

```js
s1 = new THREE.Sphere();
s2 = new THREE.Sphere();

s1.center.set( 1, 0, 0 );
s1.radius = 0.1;
s2.makeEmpty();

s1.union( s2 );
console.log( s1.center, s1.radius );
// BEFORE: "( 0.050000000000000044, 0, 0 )" "1.05"
// AFTER: "( 1, 0, 0 )" "0.1"

s1.makeEmpty();
s2.center.set( 1, 0, 0 );
s2.radius = 0.1;

s1.union( s2 );
console.log( s1.center, s1.radius );
// BEFORE: "( 1, 0, 0 )" "0.10000000000000003"
// AFTER: "( 1, 0, 0 )" "0.1"
```