### PR TITLE
explicitly use 'event' in onPointerUp

### DIFF
--- a/examples/webgl_geometry_spline_editor.html
+++ b/examples/webgl_geometry_spline_editor.html
@@ -363,7 +363,7 @@
 
 			}
 
-			function onPointerUp() {
+			function onPointerUp( event ) {
 
 				onUpPosition.x = event.clientX;
 				onUpPosition.y = event.clientY;


### PR DESCRIPTION
The onPointerUp function did not explicitly require the event to be passed.
While it still was set at runtime, this patch clarifies the functions intent, asserts the local scope of the event variable, prevents future errors and satifies typescript checking.
