### PR TITLE
Nodes: Triplanar Texture Mapping

### DIFF
--- a/examples/jsm/nodes/Nodes.js
+++ b/examples/jsm/nodes/Nodes.js
@@ -88,6 +88,7 @@ import RotateUVNode from './utils/RotateUVNode.js';
 import SplitNode from './utils/SplitNode.js';
 import SpriteSheetUVNode from './utils/SpriteSheetUVNode.js';
 import TimerNode from './utils/TimerNode.js';
+import TriplanarTexturesNode from './utils/TriplanarTexturesNode.js';
 
 // loaders
 import NodeLoader from './loaders/NodeLoader.js';
@@ -211,6 +212,7 @@ const nodeLib = {
 	SplitNode,
 	SpriteSheetUVNode,
 	TimerNode,
+	TriplanarTexturesNode,
 
 	// procedural
 	CheckerNode,
@@ -327,6 +329,7 @@ export {
 	SplitNode,
 	SpriteSheetUVNode,
 	TimerNode,
+	TriplanarTexturesNode,
 
 	// procedural
 	CheckerNode,

--- a/examples/jsm/nodes/shadernode/ShaderNodeElements.js
+++ b/examples/jsm/nodes/shadernode/ShaderNodeElements.js
@@ -24,6 +24,7 @@ import RemapNode from '../utils/RemapNode.js';
 import RotateUVNode from '../utils/RotateUVNode.js';
 import SpriteSheetUVNode from '../utils/SpriteSheetUVNode.js';
 import TimerNode from '../utils/TimerNode.js';
+import TriplanarTexturesNode from '../utils/TriplanarTexturesNode.js';
 
 // geometry
 import RangeNode from '../geometry/RangeNode.js';
@@ -116,6 +117,9 @@ export const timerLocal = ( timeScale, value = 0 ) => nodeObject( new TimerNode(
 export const timerGlobal = ( timeScale, value = 0 ) => nodeObject( new TimerNode( TimerNode.GLOBAL, timeScale, value ) );
 export const timerDelta = ( timeScale, value = 0 ) => nodeObject( new TimerNode( TimerNode.DELTA, timeScale, value ) );
 export const frameId = nodeImmutable( TimerNode, TimerNode.FRAME );
+
+export const triplanarTextures = nodeProxy( TriplanarTexturesNode );
+export const triplanarTexture = ( texture, ...params ) => triplanarTextures( texture, texture, texture, ...params );
 
 // geometry
 

--- a/examples/jsm/nodes/utils/TriplanarTexturesNode.js
+++ b/examples/jsm/nodes/utils/TriplanarTexturesNode.js
@@ -1,0 +1,51 @@
+import Node from '../core/Node.js';
+import { float, vec3, add, mul, div, dot, normalize, abs, texture, positionWorld, normalWorld } from '../shadernode/ShaderNodeBaseElements.js';
+
+class TriplanarTexturesNode extends Node {
+
+	constructor( textureXNode, textureYNode = null, textureZNode = null, scaleNode = float( 1 ), positionNode = positionWorld, normalNode = normalWorld ) {
+
+		super( 'vec4' );
+
+		this.textureXNode = textureXNode;
+		this.textureYNode = textureYNode;
+		this.textureZNode = textureZNode;
+
+		this.scaleNode = scaleNode;
+
+		this.positionNode = positionNode;
+		this.normalNode = normalNode;
+
+	}
+
+	construct() {
+
+		const { textureXNode, textureYNode, textureZNode, scaleNode, positionNode, normalNode } = this;
+
+		// Ref: https://github.com/keijiro/StandardTriplanar
+
+		// Blending factor of triplanar mapping
+		let bf = normalize( abs( normalNode ) );
+		bf = div( bf, dot( bf, vec3( 1.0 ) ) );
+
+		// Triplanar mapping
+		const tx = mul( positionNode.yz, scaleNode );
+		const ty = mul( positionNode.zx, scaleNode );
+		const tz = mul( positionNode.xy, scaleNode );
+
+		// Base color
+		const textureX = textureXNode.value;
+		const textureY = textureYNode !== null ? textureYNode.value : textureX;
+		const textureZ = textureZNode !== null ? textureZNode.value : textureX;
+
+		const cx = mul( texture( textureX, tx ), bf.x );
+		const cy = mul( texture( textureY, ty ), bf.y );
+		const cz = mul( texture( textureZ, tz ), bf.z );
+
+		return add( cx, cy, cz );
+
+	}
+
+}
+
+export default TriplanarTexturesNode;

--- a/examples/webgpu_materials.html
+++ b/examples/webgpu_materials.html
@@ -34,7 +34,7 @@
 
 			import { TeapotGeometry } from 'three/addons/geometries/TeapotGeometry.js';
 
-			import { ShaderNode, vec3, dot } from 'three/nodes';
+			import { ShaderNode, vec3, dot, triplanarTexture } from 'three/nodes';
 
 			import Stats from 'three/addons/libs/stats.module.js';
 
@@ -175,6 +175,11 @@
 
 				material = new Nodes.MeshBasicNodeMaterial();
 				material.colorNode = getWGSLTextureSample.call( { tex: textureNode, tex_sampler: textureNode, uv: new Nodes.UVNode() } );
+				materials.push( material );
+
+				// Triplanar Texture Mapping
+				material = new Nodes.MeshBasicNodeMaterial();
+				material.colorNode = triplanarTexture( new Nodes.TextureNode( texture ) );
 				materials.push( material );
 
 				//


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/15048, https://github.com/mrdoob/three.js/issues/24674

**Description**

Added `Triplanar Texture Mapping` for new `Node Material System`, it works in `WebGL` and `WebGPU` backends.

Example:
```js
import { texture, triplanarTexture } from 'three/nodes';

...
material = new Nodes.MeshBasicNodeMaterial();

material.colorNode = triplanarTexture( texture( diffuseMap ) );
// or
material.colorNode = triplanarTextures( texture( diffuseMap ), texture( diffuseMap ), texture( diffuseMap ) );

```

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Google](https://google.com)*
