### PR TITLE
Add twoPassTransparentRendering option to Material

### DIFF
--- a/docs/api/en/materials/Material.html
+++ b/docs/api/en/materials/Material.html
@@ -278,6 +278,13 @@
 		Default is `false`.
 		</p>
 
+		<h3>[property:Boolean twoPassTransparentRendering]</h3>
+		<p>
+		Controls whether the two pass rendering algorithm will be used in case the material is
+		transparent and double sided. If used, the algorithm first renders all back-facing
+		triangles, then all front-facing ones. Default is `true`.
+		</p>
+
 		<h3>[property:String type]</h3>
 		<p>
 		Value is the string 'Material'. This shouldn't be changed, and can be used to

--- a/src/loaders/MaterialLoader.js
+++ b/src/loaders/MaterialLoader.js
@@ -118,6 +118,7 @@ class MaterialLoader extends Loader {
 		if ( json.shadowSide !== undefined ) material.shadowSide = json.shadowSide;
 		if ( json.opacity !== undefined ) material.opacity = json.opacity;
 		if ( json.transparent !== undefined ) material.transparent = json.transparent;
+		if ( json.twoPassTransparentRendering !== undefined ) material.twoPassTransparentRendering = json.twoPassTransparentRendering;
 		if ( json.alphaTest !== undefined ) material.alphaTest = json.alphaTest;
 		if ( json.depthTest !== undefined ) material.depthTest = json.depthTest;
 		if ( json.depthWrite !== undefined ) material.depthWrite = json.depthWrite;

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -316,6 +316,8 @@ class Material extends EventDispatcher {
 		if ( this.opacity < 1 ) data.opacity = this.opacity;
 		if ( this.transparent === true ) data.transparent = this.transparent;
 
+		if ( this.twoPassTransparentRendering === false ) data.twoPassTransparentRendering = this.twoPassTransparentRendering;
+
 		data.depthFunc = this.depthFunc;
 		data.depthTest = this.depthTest;
 		data.depthWrite = this.depthWrite;
@@ -411,6 +413,8 @@ class Material extends EventDispatcher {
 
 		this.opacity = source.opacity;
 		this.transparent = source.transparent;
+
+		this.twoPassTransparentRendering = source.twoPassTransparentRendering;
 
 		this.blendSrc = source.blendSrc;
 		this.blendDst = source.blendDst;

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -26,6 +26,8 @@ class Material extends EventDispatcher {
 		this.opacity = 1;
 		this.transparent = false;
 
+		this.twoPassTransparentRendering = true;
+
 		this.blendSrc = SrcAlphaFactor;
 		this.blendDst = OneMinusSrcAlphaFactor;
 		this.blendEquation = AddEquation;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -849,7 +849,7 @@ function WebGLRenderer( parameters = {} ) {
 
 		function prepare( material, scene, object ) {
 
-			if ( material.transparent === true && material.side === DoubleSide ) {
+			if ( material.transparent === true && material.side === DoubleSide && material.twoPassTransparentRendering ) {
 
 				material.side = BackSide;
 				material.needsUpdate = true;
@@ -1331,7 +1331,7 @@ function WebGLRenderer( parameters = {} ) {
 
 		material.onBeforeRender( _this, scene, camera, geometry, object, group );
 
-		if ( material.transparent === true && material.side === DoubleSide ) {
+		if ( material.transparent === true && material.side === DoubleSide && material.twoPassTransparentRendering ) {
 
 			material.side = BackSide;
 			material.needsUpdate = true;


### PR DESCRIPTION
Fixed #24711

**Description**

As discussed in https://github.com/mrdoob/three.js/issues/24711, an option to circumvent two-pass rendering of double-sided transparent objects was added.