### PR TITLE
Support rotating equirectangular environment map

### DIFF
--- a/docs/api/en/renderers/WebGLCubeRenderTarget.html
+++ b/docs/api/en/renderers/WebGLCubeRenderTarget.html
@@ -56,10 +56,11 @@
 
 		<h3>See [page:WebGLRenderTarget] for inherited methods</h3>
 
-		<h3>[method:this fromEquirectangularTexture]( [param:WebGLRenderer renderer], [param:Texture texture] )</h3>
+		<h3>[method:this fromEquirectangularTexture]( [param:WebGLRenderer renderer], [param:Texture texture], [param:float theta] )</h3>
 		<p>
-			[page:WebGLRenderer renderer] — the renderer.<br/>
-			[page:Texture texture] — the equirectangular texture.
+			[page:WebGLRenderer renderer] - the renderer.<br />
+			[page:Texture texture] - the equirectangular texture.<br />
+			theta - the angle to rotate the equirectangular texture, in radians - default is 0.
 		</p>
 		<p>
 			Use this method if you want to convert an equirectangular panorama to the cubemap format.

--- a/src/renderers/WebGLCubeRenderTarget.js
+++ b/src/renderers/WebGLCubeRenderTarget.js
@@ -35,7 +35,7 @@ class WebGLCubeRenderTarget extends WebGLRenderTarget {
 
 	}
 
-	fromEquirectangularTexture( renderer, texture ) {
+	fromEquirectangularTexture( renderer, texture, theta = 0 ) {
 
 		this.texture.type = texture.type;
 		this.texture.encoding = texture.encoding;
@@ -48,9 +48,12 @@ class WebGLCubeRenderTarget extends WebGLRenderTarget {
 
 			uniforms: {
 				tEquirect: { value: null },
+				theta: 0
 			},
 
 			vertexShader: /* glsl */`
+
+				uniform float theta;
 
 				varying vec3 vWorldDirection;
 
@@ -63,6 +66,13 @@ class WebGLCubeRenderTarget extends WebGLRenderTarget {
 				void main() {
 
 					vWorldDirection = transformDirection( position, modelMatrix );
+
+					float c = cos( theta );
+					float s = sin( theta );
+
+					mat3 m = mat3( c, 0, - s, 0, 1, 0, s, 0, c );
+
+					vWorldDirection = m * vWorldDirection;
 
 					#include <begin_vertex>
 					#include <project_vertex>
@@ -105,6 +115,7 @@ class WebGLCubeRenderTarget extends WebGLRenderTarget {
 		} );
 
 		material.uniforms.tEquirect.value = texture;
+		material.uniforms.theta.value = theta;
 
 		const mesh = new Mesh( geometry, material );
 
@@ -124,6 +135,8 @@ class WebGLCubeRenderTarget extends WebGLRenderTarget {
 		return this;
 
 	}
+
+//
 
 	clear( renderer, color, depth, stencil ) {
 

--- a/src/renderers/WebGLCubeRenderTarget.js
+++ b/src/renderers/WebGLCubeRenderTarget.js
@@ -136,8 +136,6 @@ class WebGLCubeRenderTarget extends WebGLRenderTarget {
 
 	}
 
-//
-
 	clear( renderer, color, depth, stencil ) {
 
 		const currentRenderTarget = renderer.getRenderTarget();


### PR DESCRIPTION
This PR adds support for rotating an equirectangular environment map when it is loaded.

If this is acceptable, we should be able to do something similar for cube environment maps.

Note: An alternate approach would be to apply a rotation to each reflection direction in the shaders -- per-pixel, per frame. That approach proved to be considerably more complex than what is proposed here.
