### PR TITLE
NodeMaterial: Fix support for extended classes (2)

### DIFF
--- a/examples/jsm/nodes/loaders/NodeMaterialLoader.js
+++ b/examples/jsm/nodes/loaders/NodeMaterialLoader.js
@@ -4,6 +4,7 @@ import {
 	LineBasicNodeMaterial,
 	MeshBasicNodeMaterial,
 	MeshStandardNodeMaterial,
+	MeshPhysicalNodeMaterial,
 	PointsNodeMaterial,
 	SpriteNodeMaterial
 } from '../materials/Materials.js';
@@ -17,8 +18,9 @@ MaterialLoader.createMaterialFromType = function ( type ) {
 		LineBasicNodeMaterial,
 		MeshBasicNodeMaterial,
 		MeshStandardNodeMaterial,
+		MeshPhysicalNodeMaterial,
 		PointsNodeMaterial,
-		SpriteNodeMaterial,
+		SpriteNodeMaterial
 	};
 
 	if ( materialLib[ type ] !== undefined ) {

--- a/examples/jsm/renderers/webgl/nodes/WebGLNodeBuilder.js
+++ b/examples/jsm/renderers/webgl/nodes/WebGLNodeBuilder.js
@@ -73,7 +73,17 @@ class WebGLNodeBuilder extends NodeBuilder {
 
 	_parseShaderLib() {
 
-		const type = this.material.type;
+		const material = this.material;
+
+		let type = material.type;
+
+		// see https://github.com/mrdoob/three.js/issues/23707
+
+		if ( material.isMeshPhysicalNodeMaterial ) type = 'MeshPhysicalNodeMaterial';
+		else if ( material.isMeshStandardNodeMaterial ) type = 'MeshStandardNodeMaterial';
+		else if ( material.isMeshBasicNodeMaterial ) type = 'MeshBasicNodeMaterial';
+		else if ( material.isPointsNodeMaterial ) type = 'PointsNodeMaterial';
+		else if ( material.isLineBasicNodeMaterial ) type = 'LineBasicNodeMaterial';
 
 		// shader lib
 

--- a/examples/webgl_nodes_materials_standard.html
+++ b/examples/webgl_nodes_materials_standard.html
@@ -75,7 +75,7 @@
 
 				scene.add( new THREE.HemisphereLight( 0x443333, 0x222233, 4 ) );
 
-				//
+				// Test Extended Material
 
 				class MeshCustomNodeMaterial extends Nodes.MeshStandardNodeMaterial {
 
@@ -87,7 +87,7 @@
 
 				}
 
-				//
+				// Extends Serialization Material
 
 				const superCreateMaterialFromType = THREE.MaterialLoader.createMaterialFromType;
 

--- a/examples/webgl_nodes_materials_standard.html
+++ b/examples/webgl_nodes_materials_standard.html
@@ -77,7 +77,39 @@
 
 				//
 
-				const material = new Nodes.MeshStandardNodeMaterial();
+				class MeshCustomNodeMaterial extends Nodes.MeshStandardNodeMaterial {
+
+					constructor() {
+
+						super();
+
+					}
+
+				}
+
+				//
+
+				const superCreateMaterialFromType = THREE.MaterialLoader.createMaterialFromType;
+
+				THREE.MaterialLoader.createMaterialFromType = function ( type ) {
+
+					const materialLib = {
+						MeshCustomNodeMaterial
+					};
+
+					if ( materialLib[ type ] !== undefined ) {
+
+						return new materialLib[ type ]();
+
+					}
+
+					return superCreateMaterialFromType.call( this, type );
+
+				};
+
+				//
+
+				const material = new MeshCustomNodeMaterial();
 
 				new OBJLoader()
 					.setPath( 'models/obj/cerberus/' )


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/23707

**Description**

Fix support for extended classes.

@wmcmurray Can you test this fix?

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Google](https://google.com)*
