### PR TITLE
Update English documentation on Object3D updateMatrixWorld() on force behaviour

### DIFF
--- a/docs/api/en/core/Object3D.html
+++ b/docs/api/en/core/Object3D.html
@@ -470,7 +470,13 @@
 		<p>Updates the local transform.</p>
 
 		<h3>[method:undefined updateMatrixWorld]( [param:Boolean force] )</h3>
-		<p>Updates the global transform of the object and its descendants.</p>
+		<p>
+		force - A boolean that can be used to bypass [page:.matrixWorldAutoUpdate],
+		to recalculate the world matrix of the object and descendants on the current frame.
+		Useful if you cannot wait for the renderer to update it on the next frame (assuming [page:.matrixWorldAutoUpdate] set to true).<br /><br />
+
+		Updates the global transform of the object and its descendants if the world matrix needs update ([page:.matrixWorldNeedsUpdate] set to true) or if the force boolean parameter is set to true.
+		</p>
 
 		<h3>[method:undefined updateWorldMatrix]( [param:Boolean updateParents], [param:Boolean updateChildren] )</h3>
 		<p>


### PR DESCRIPTION
Fixed #24725

**Description**

The force parameter was not documented on the `updateMatrixWorld()`. I tried to clarify the priors to this method and the relation between the method and others properties of the Object3D method (like matrixWorldNeedsUpdate), that I found hard to understand when I first encountered this method.
