### PR TITLE
Add a warning on Raycasting if world matrix is not up-to-date

### DIFF
--- a/docs/api/en/core/Raycaster.html
+++ b/docs/api/en/core/Raycaster.html
@@ -155,6 +155,7 @@
 		</p>
 		<p>
 		Updates the ray with a new origin and direction.
+		*Note* that this method relies on the camera world matrix. If you intend to use it on the same frame as a change of position/rotation/scale for the camera, it is highly recommended to update the world matrix on this frame before calling setFromCamera.
 		</p>
 
 		<h3>[method:Array intersectObject]( [param:Object3D object], [param:Boolean recursive], [param:Array optionalTarget] )</h3>
@@ -183,7 +184,8 @@
 		`Raycaster` delegates to the [page:Object3D.raycast raycast] method of the passed object, when evaluating whether the ray intersects the object or not. This allows [page:Mesh meshes] to respond differently to ray casting than [page:Line lines] and [page:Points pointclouds].
 		</p>
 		<p>
-		*Note* that for meshes, faces must be pointed towards the origin of the [page:.ray ray] in order to be detected; intersections of the ray passing through the back of a face will not be detected. To raycast against both faces of an object, you'll want to set the [page:Mesh.material material]'s [page:Material.side side] property to `THREE.DoubleSide`.
+		*Note* that for meshes, faces must be pointed towards the origin of the [page:.ray ray] in order to be detected; intersections of the ray passing through the back of a face will not be detected. To raycast against both faces of an object, you'll want to set the [page:Mesh.material material]'s [page:Material.side side] property to `THREE.DoubleSide`.<br /><br />
+		*Note also* that some implementation of the [page:Object3D.raycast raycast] method rely on the object's world matrix. For instance, it is the case for [page:Mesh] or [page:InstancedMesh]. If you intend to raycast on the frame where a change in position, scale or rotation occurred without updating world matrix, you could hit the mesh where it is not anymore or not hit the mesh where it is now.
 		</p>
 
 		<h3>[method:Array intersectObjects]( [param:Array objects], [param:Boolean recursive], [param:Array optionalTarget] )</h3>

--- a/docs/api/en/objects/LOD.html
+++ b/docs/api/en/objects/LOD.html
@@ -108,7 +108,9 @@
 		<h3>[method:Array raycast]( [param:Raycaster raycaster], [param:Array intersects] )</h3>
 		<p>
 		Get intersections between a casted [page:Ray] and this LOD.
-		[page:Raycaster.intersectObject] will call this method.
+		[page:Raycaster.intersectObject] will call this method.<br /><br />
+
+		*Note*: Be sure that the world matrix is up-to-date at the considered frame for the raycasting to work properly.
 		</p>
 
 

--- a/docs/api/en/objects/Mesh.html
+++ b/docs/api/en/objects/Mesh.html
@@ -76,6 +76,7 @@
 		<p>
 		Get intersections between a casted ray and this mesh.
 		[page:Raycaster.intersectObject] will call this method, but the results are not ordered.<br /><br />
+
 		*Note*: Be sure that the world matrix is up-to-date at the considered frame for the raycasting to work properly.
 		</p>
 

--- a/docs/api/en/objects/Mesh.html
+++ b/docs/api/en/objects/Mesh.html
@@ -75,7 +75,8 @@
 		<h3>[method:undefined raycast]( [param:Raycaster raycaster], [param:Array intersects] )</h3>
 		<p>
 		Get intersections between a casted ray and this mesh.
-		[page:Raycaster.intersectObject] will call this method, but the results are not ordered.
+		[page:Raycaster.intersectObject] will call this method, but the results are not ordered.<br /><br />
+		*Note*: Be sure that the world matrix is up-to-date at the considered frame for the raycasting to work properly.
 		</p>
 
 		<h3>[method:undefined updateMorphTargets]()</h3>


### PR DESCRIPTION
…or the world matrix to be up-to-date before raycasting

Related issue: #24727

**Description**

I added some clarification on the prerequisite of raycasting for Mesh, LOD, and on the Raycaster itself.
I had trouble figure out why my raycasting was not working, and it was just because my world matrix was not up-to-date, so I think it could save some troubles to others.