### PR TITLE
Docs: Clean up raycast() return type.

### DIFF
--- a/docs/api/en/core/Object3D.html
+++ b/docs/api/en/core/Object3D.html
@@ -324,7 +324,7 @@
 		This method does not support objects having non-uniformly-scaled parent(s).
 		</p>
 
-		<h3>[method:Array raycast]( [param:Raycaster raycaster], [param:Array intersects] )</h3>
+		<h3>[method:undefined raycast]( [param:Raycaster raycaster], [param:Array intersects] )</h3>
 		<p>
 		Abstract (empty) method to get intersections between a casted ray and this object.
 		Subclasses such as [page:Mesh], [page:Line], and [page:Points] implement this method in order

--- a/docs/api/en/objects/LOD.html
+++ b/docs/api/en/objects/LOD.html
@@ -105,7 +105,7 @@
 		Get a reference to the first [page:Object3D] (mesh) that is greater than [page:Float distance].
 		</p>
 
-		<h3>[method:Array raycast]( [param:Raycaster raycaster], [param:Array intersects] )</h3>
+		<h3>[method:undefined raycast]( [param:Raycaster raycaster], [param:Array intersects] )</h3>
 		<p>
 		Get intersections between a casted [page:Ray] and this LOD.
 		[page:Raycaster.intersectObject] will call this method.

--- a/docs/api/it/core/Object3D.html
+++ b/docs/api/it/core/Object3D.html
@@ -328,7 +328,7 @@
       Questo metodo non supporta oggetti con genitore/i con scalabilità non uniforme.
 		</p>
 
-		<h3>[method:Array raycast]( [param:Raycaster raycaster], [param:Array intersects] )</h3>
+		<h3>[method:undefined raycast]( [param:Raycaster raycaster], [param:Array intersects] )</h3>
 		<p>
       Metodo astratto (vuoto) per ottenere le intersezioni tra un raggio casted e questo oggetto.
       Sottoclassi come [page:Mesh], [page:Line], e [page:Points] implementano questo metodo per 

--- a/docs/api/ko/core/Object3D.html
+++ b/docs/api/ko/core/Object3D.html
@@ -313,7 +313,7 @@
 		이 메서드는 비균일 스케일 부모를 가진 객체들은 지원하지 않습니다.
 		</p>
 
-		<h3>[method:Array raycast]( [param:Raycaster raycaster], [param:Array intersects] )</h3>
+		<h3>[method:undefined raycast]( [param:Raycaster raycaster], [param:Array intersects] )</h3>
 		<p>
 		객체와 레이캐스팅 사이의 인터섹션을 구하는 추상 (빈) 메서드입니다.
 		Subclasses such as [page:Mesh], [page:Line], 및 [page:Points] 같은 서브클래스들은 레이캐스팅을 사용하는 순서에 따라 이 메서드를 실행합니다.

--- a/docs/api/zh/core/Object3D.html
+++ b/docs/api/zh/core/Object3D.html
@@ -304,7 +304,7 @@
 		这一方法不支持其父级被旋转过或者被位移过的物体。
 	</p>
 
-	<h3>[method:Array raycast]( [param:Raycaster raycaster], [param:Array intersects] )</h3>
+	<h3>[method:undefined raycast]( [param:Raycaster raycaster], [param:Array intersects] )</h3>
 	<p>抽象（空方法），在一条被投射出的射线与这个物体之间获得交点。
 		在一些子类，例如[page:Mesh], [page:Line], and [page:Points]实现了这个方法，以用于光线投射。
 	</p>

--- a/docs/api/zh/objects/LOD.html
+++ b/docs/api/zh/objects/LOD.html
@@ -99,7 +99,7 @@
 			获得第一个比[page:Float distance]大的[page:Object3D]（网格）的引用。
 		</p>
 
-		<h3>[method:Array raycast]( [param:Raycaster raycaster], [param:Array intersects] )</h3>
+		<h3>[method:undefined raycast]( [param:Raycaster raycaster], [param:Array intersects] )</h3>
 		<p>
 			在一条投射出去的[page:Ray]（射线）和这个LOD之间获得交互。
 			[page:Raycaster.intersectObject]将会调用这个方法。


### PR DESCRIPTION
Fixed #24740.

**Description**

Makes the documentation of `raycast()` more consistent.
