### PR TITLE
Examples: Add setSize() to more post-processing passes.

### DIFF
--- a/examples/jsm/postprocessing/BloomPass.js
+++ b/examples/jsm/postprocessing/BloomPass.js
@@ -10,15 +10,15 @@ import { ConvolutionShader } from '../shaders/ConvolutionShader.js';
 
 class BloomPass extends Pass {
 
-	constructor( strength = 1, kernelSize = 25, sigma = 4, resolution = 256 ) {
+	constructor( strength = 1, kernelSize = 25, sigma = 4 ) {
 
 		super();
 
 		// render targets
 
-		this.renderTargetX = new WebGLRenderTarget( resolution, resolution );
+		this.renderTargetX = new WebGLRenderTarget( 1, 1 );
 		this.renderTargetX.texture.name = 'BloomPass.x';
-		this.renderTargetY = new WebGLRenderTarget( resolution, resolution );
+		this.renderTargetY = new WebGLRenderTarget( 1, 1 );
 		this.renderTargetY.texture.name = 'BloomPass.y';
 
 		// combine material
@@ -102,6 +102,13 @@ class BloomPass extends Pass {
 		renderer.setRenderTarget( readBuffer );
 		if ( this.clear ) renderer.clear();
 		this.fsQuad.render( renderer );
+
+	}
+
+	setSize( width, height ) {
+
+		this.renderTargetX.setSize( width, height );
+		this.renderTargetY.setSize( width, height );
 
 	}
 

--- a/examples/jsm/postprocessing/BloomPass.js
+++ b/examples/jsm/postprocessing/BloomPass.js
@@ -16,9 +16,9 @@ class BloomPass extends Pass {
 
 		// render targets
 
-		this.renderTargetX = new WebGLRenderTarget( 1, 1 );
+		this.renderTargetX = new WebGLRenderTarget( 1, 1 ); // will be resized later
 		this.renderTargetX.texture.name = 'BloomPass.x';
-		this.renderTargetY = new WebGLRenderTarget( 1, 1 );
+		this.renderTargetY = new WebGLRenderTarget( 1, 1 ); // will be resized later
 		this.renderTargetY.texture.name = 'BloomPass.y';
 
 		// combine material

--- a/examples/jsm/postprocessing/BokehPass.js
+++ b/examples/jsm/postprocessing/BokehPass.js
@@ -31,10 +31,7 @@ class BokehPass extends Pass {
 
 		// render targets
 
-		const width = params.width || window.innerWidth || 1;
-		const height = params.height || window.innerHeight || 1;
-
-		this.renderTargetDepth = new WebGLRenderTarget( width, height, {
+		this.renderTargetDepth = new WebGLRenderTarget( 1, 1, {
 			minFilter: NearestFilter,
 			magFilter: NearestFilter
 		} );
@@ -123,6 +120,12 @@ class BokehPass extends Pass {
 		renderer.setClearColor( this._oldClearColor );
 		renderer.setClearAlpha( oldClearAlpha );
 		renderer.autoClear = oldAutoClear;
+
+	}
+
+	setSize( width, height ) {
+
+		this.renderTargetDepth.setSize( width, height );
 
 	}
 

--- a/examples/jsm/postprocessing/BokehPass.js
+++ b/examples/jsm/postprocessing/BokehPass.js
@@ -31,7 +31,7 @@ class BokehPass extends Pass {
 
 		// render targets
 
-		this.renderTargetDepth = new WebGLRenderTarget( 1, 1, {
+		this.renderTargetDepth = new WebGLRenderTarget( 1, 1, { // will be resized later
 			minFilter: NearestFilter,
 			magFilter: NearestFilter
 		} );

--- a/examples/jsm/postprocessing/SavePass.js
+++ b/examples/jsm/postprocessing/SavePass.js
@@ -32,7 +32,7 @@ class SavePass extends Pass {
 
 		if ( this.renderTarget === undefined ) {
 
-			this.renderTarget = new WebGLRenderTarget( 1, 1 );
+			this.renderTarget = new WebGLRenderTarget( 1, 1 ); // will be resized later
 			this.renderTarget.texture.name = 'SavePass.rt';
 
 		}

--- a/examples/jsm/postprocessing/SavePass.js
+++ b/examples/jsm/postprocessing/SavePass.js
@@ -32,7 +32,7 @@ class SavePass extends Pass {
 
 		if ( this.renderTarget === undefined ) {
 
-			this.renderTarget = new WebGLRenderTarget( window.innerWidth, window.innerHeight );
+			this.renderTarget = new WebGLRenderTarget( 1, 1 );
 			this.renderTarget.texture.name = 'SavePass.rt';
 
 		}
@@ -54,6 +54,12 @@ class SavePass extends Pass {
 		renderer.setRenderTarget( this.renderTarget );
 		if ( this.clear ) renderer.clear();
 		this.fsQuad.render( renderer );
+
+	}
+
+	setSize( width, height ) {
+
+		this.renderTarget.setSize( width, height );
 
 	}
 

--- a/examples/webgl_postprocessing_dof.html
+++ b/examples/webgl_postprocessing_dof.html
@@ -207,10 +207,7 @@
 				const bokehPass = new BokehPass( scene, camera, {
 					focus: 1.0,
 					aperture: 0.025,
-					maxblur: 0.01,
-
-					width: width,
-					height: height
+					maxblur: 0.01
 				} );
 
 				const composer = new EffectComposer( renderer );


### PR DESCRIPTION
Related issue: -

**Description**

This PR adds some missing `setSize()` methods to post-processing passes.

BTW: There is some redundant code in the post-processing passes since it is actually not always necessary to apply the dimensions of the pass at creation time. When a pass is added to the pass chain, the pass is automatically resized by the width and height of the composer. So as long as `setSize()` is properly implemented, internal render targets can be defined with a default (1,1) resolution.