### PR TITLE
WebGLRenderTarget: Use default parameters for dimensions.

### DIFF
--- a/docs/api/en/renderers/WebGL3DRenderTarget.html
+++ b/docs/api/en/renderers/WebGL3DRenderTarget.html
@@ -19,9 +19,9 @@
 
 		<h3>[name]( [param:Number width], [param:Number height], [param:Number depth] )</h3>
 		<p>
-		[page:Number width] - the width of the render target, in pixels.<br />
-		[page:Number height] - the height of the render target, in pixels.<br />
-		[page:Number depth] - the depth of the render target.<br /><br />
+		[page:Number width] - the width of the render target, in pixels. Default is `1`.<br />
+		[page:Number height] - the height of the render target, in pixels. Default is `1`.<br />
+		[page:Number depth] - the depth of the render target. Default is `1`.<br /><br />
 
 		Creates a new [name].
 		</p>

--- a/docs/api/en/renderers/WebGLArrayRenderTarget.html
+++ b/docs/api/en/renderers/WebGLArrayRenderTarget.html
@@ -25,9 +25,9 @@
 
 		<h3>[name]( [param:Number width], [param:Number height], [param:Number depth] )</h3>
 		<p>
-		[page:Number width] - the width of the render target, in pixels.<br />
-		[page:Number height] - the height of the render target, in pixels.<br />
-		[page:Number depth] - the depth/layer count of the render target.<br /><br />
+		[page:Number width] - the width of the render target, in pixels. Default is `1`.<br />
+		[page:Number height] - the height of the render target, in pixels. Default is `1`.<br />
+		[page:Number depth] - the depth/layer count of the render target. Default is `1`.<br /><br />
 
 		Creates a new [name].
 		</p>

--- a/docs/api/en/renderers/WebGLCubeRenderTarget.html
+++ b/docs/api/en/renderers/WebGLCubeRenderTarget.html
@@ -25,7 +25,7 @@
 
 		<h3>[name]([param:Number size], [param:Object options])</h3>
 		<p>
-		[page:Float size] - the size, in pixels. <br />
+		[page:Float size] - the size, in pixels. Default is `1`.<br />
 		options - (optional) object that holds texture parameters for an auto-generated target
 		texture and depthBuffer/stencilBuffer booleans.
 

--- a/docs/api/en/renderers/WebGLMultipleRenderTargets.html
+++ b/docs/api/en/renderers/WebGLMultipleRenderTargets.html
@@ -30,9 +30,9 @@
 		<h3>[name]([param:Number width], [param:Number height], [param:Number count], [param:Object options])</h3>
 
 		<p>
-		[page:Number width] - The width of the render target. <br />
-		[page:Number height] - The height of the render target.<br />
-		[page:Number count] - The number of render targets.<br />
+		[page:Number width] - The width of the render target. Default is `1`.<br />
+		[page:Number height] - The height of the render target. Default is `1`.<br />
+		[page:Number count] - The number of render targets. Default is `1`.<br />
 
 		options - (optional object that holds texture parameters for an auto-generated target
 		texture and depthBuffer/stencilBuffer booleans.

--- a/docs/api/en/renderers/WebGLRenderTarget.html
+++ b/docs/api/en/renderers/WebGLRenderTarget.html
@@ -23,8 +23,8 @@
 		<h3>[name]([param:Number width], [param:Number height], [param:Object options])</h3>
 
 		<p>
-		[page:Float width] - The width of the renderTarget. <br />
-		[page:Float height] - The height of the renderTarget.<br />
+		[page:Float width] - The width of the renderTarget. Default is `1`.<br />
+		[page:Float height] - The height of the renderTarget. Default is `1`.<br />
 		options - optional object that holds texture parameters for an auto-generated target
 		texture and depthBuffer/stencilBuffer booleans.
 

--- a/docs/api/zh/renderers/WebGLCubeRenderTarget.html
+++ b/docs/api/zh/renderers/WebGLCubeRenderTarget.html
@@ -25,7 +25,7 @@
 
 		<h3>[name]([param:Number size], [param:Object options])</h3>
 		<p>
-		[page:Float size] - the size, in pixels. <br />
+		[page:Float size] - the size, in pixels. Default is `1`.<br />
 		options - (可选)一个保存着自动生成的目标纹理的纹理参数以及表示是否使用深度缓存/模板缓存的布尔值的对象。
 		有关纹理参数的说明，请参阅[page:Texture Texture]. 以下是合理选项：<br /><br />
 

--- a/docs/api/zh/renderers/WebGLMultipleRenderTargets.html
+++ b/docs/api/zh/renderers/WebGLMultipleRenderTargets.html
@@ -30,9 +30,9 @@
 		<h3>[name]([param:Number width], [param:Number height], [param:Number count])</h3>
 
 		<p>
-		[page:Number width] - The width of the render target. <br />
-		[page:Number height] - The height of the render target.<br />
-		[page:Number count] - The number of render targets.
+		[page:Number width] - The width of the render target. Default is `1`.<br />
+		[page:Number height] - The height of the render target. Default is `1`.<br />
+		[page:Number count] - The number of render targets. Default is `1`.
 		</p>
 
 		<h2>Properties</h2>

--- a/docs/api/zh/renderers/WebGLRenderTarget.html
+++ b/docs/api/zh/renderers/WebGLRenderTarget.html
@@ -22,8 +22,8 @@
 		<h3>[name]([param:Number width], [param:Number height], [param:Object options])</h3>
 
 		<p>
-		[page:Float width] -renderTarget的宽度 <br />
-		[page:Float height] - renderTarget的高度 <br />
+		[page:Float width] -renderTarget的宽度. Default is `1`.<br />
+		[page:Float height] - renderTarget的高度. Default is `1`.<br />
 		options - (可选)一个保存着自动生成的目标纹理的纹理参数以及表示是否使用深度缓存/模板缓存的布尔值的对象
 		以下是一些合法选项：<br /><br />
 

--- a/examples/jsm/postprocessing/BloomPass.js
+++ b/examples/jsm/postprocessing/BloomPass.js
@@ -16,9 +16,9 @@ class BloomPass extends Pass {
 
 		// render targets
 
-		this.renderTargetX = new WebGLRenderTarget( 1, 1 ); // will be resized later
+		this.renderTargetX = new WebGLRenderTarget(); // will be resized later
 		this.renderTargetX.texture.name = 'BloomPass.x';
-		this.renderTargetY = new WebGLRenderTarget( 1, 1 ); // will be resized later
+		this.renderTargetY = new WebGLRenderTarget(); // will be resized later
 		this.renderTargetY.texture.name = 'BloomPass.y';
 
 		// combine material

--- a/examples/jsm/postprocessing/SavePass.js
+++ b/examples/jsm/postprocessing/SavePass.js
@@ -32,7 +32,7 @@ class SavePass extends Pass {
 
 		if ( this.renderTarget === undefined ) {
 
-			this.renderTarget = new WebGLRenderTarget( 1, 1 ); // will be resized later
+			this.renderTarget = new WebGLRenderTarget(); // will be resized later
 			this.renderTarget.texture.name = 'SavePass.rt';
 
 		}

--- a/src/renderers/WebGL3DRenderTarget.js
+++ b/src/renderers/WebGL3DRenderTarget.js
@@ -3,7 +3,7 @@ import { Data3DTexture } from '../textures/Data3DTexture.js';
 
 class WebGL3DRenderTarget extends WebGLRenderTarget {
 
-	constructor( width, height, depth ) {
+	constructor( width = 1, height = 1, depth = 1 ) {
 
 		super( width, height );
 

--- a/src/renderers/WebGLArrayRenderTarget.js
+++ b/src/renderers/WebGLArrayRenderTarget.js
@@ -3,7 +3,7 @@ import { DataArrayTexture } from '../textures/DataArrayTexture.js';
 
 class WebGLArrayRenderTarget extends WebGLRenderTarget {
 
-	constructor( width, height, depth ) {
+	constructor( width = 1, height = 1, depth = 1 ) {
 
 		super( width, height );
 

--- a/src/renderers/WebGLCubeRenderTarget.js
+++ b/src/renderers/WebGLCubeRenderTarget.js
@@ -9,7 +9,7 @@ import { CubeTexture } from '../textures/CubeTexture.js';
 
 class WebGLCubeRenderTarget extends WebGLRenderTarget {
 
-	constructor( size, options = {} ) {
+	constructor( size = 1, options = {} ) {
 
 		super( size, size, options );
 

--- a/src/renderers/WebGLMultipleRenderTargets.js
+++ b/src/renderers/WebGLMultipleRenderTargets.js
@@ -2,7 +2,7 @@ import { WebGLRenderTarget } from './WebGLRenderTarget.js';
 
 class WebGLMultipleRenderTargets extends WebGLRenderTarget {
 
-	constructor( width, height, count, options = {} ) {
+	constructor( width = 1, height = 1, count = 1, options = {} ) {
 
 		super( width, height, options );
 

--- a/src/renderers/WebGLRenderTarget.js
+++ b/src/renderers/WebGLRenderTarget.js
@@ -11,7 +11,7 @@ import { Source } from '../textures/Source.js';
 */
 class WebGLRenderTarget extends EventDispatcher {
 
-	constructor( width, height, options = {} ) {
+	constructor( width = 1, height = 1, options = {} ) {
 
 		super();
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/24744#discussion_r987209732

**Description**

This PR introduces default parameters for the dimensions of render targets. 
