### PR TITLE
InstancedMesh: use renderable instanceMatrix default

### DIFF
--- a/src/objects/InstancedMesh.js
+++ b/src/objects/InstancedMesh.js
@@ -25,9 +25,9 @@ class InstancedMesh extends Mesh {
 
 		this.frustumCulled = false;
 
-		for ( let i = 0; i < count; i++ ) {
+		for ( let i = 0; i < count; i ++ ) {
 
-			this.setMatrixAt(i, _identity)
+			this.setMatrixAt( i, _identity );
 
 		}
 

--- a/src/objects/InstancedMesh.js
+++ b/src/objects/InstancedMesh.js
@@ -7,6 +7,7 @@ const _instanceWorldMatrix = /*@__PURE__*/ new Matrix4();
 
 const _instanceIntersects = [];
 
+const _identity = /*@__PURE__*/ new Matrix4();
 const _mesh = /*@__PURE__*/ new Mesh();
 
 class InstancedMesh extends Mesh {
@@ -23,6 +24,12 @@ class InstancedMesh extends Mesh {
 		this.count = count;
 
 		this.frustumCulled = false;
+
+		for ( let i = 0; i < count; i++ ) {
+
+			this.setMatrixAt(i, _identity)
+
+		}
 
 	}
 


### PR DESCRIPTION
**Description**

This PR populates `InstanceMesh.instanceMatrix` with identity matrices so it is renderable by default.

It's a common gotcha I see with new users to render an untransformed `InstanceMesh` and see nothing onscreen because `instanceMatrix` is zeroed by default.