### PR TITLE
WebGLTextures: Fix warning when using 3D Textures.

### DIFF
--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -1269,7 +1269,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 			multisampledRTTExt.framebufferTexture2DMultisampleEXT( _gl.FRAMEBUFFER, attachment, textureTarget, properties.get( texture ).__webglTexture, 0, getRenderTargetSamples( renderTarget ) );
 
-		} else if ( textureTarget !== _gl.TEXTURE_3D && textureTarget !== _gl.TEXTURE_2D_ARRAY ) {
+		} else if ( textureTarget === _gl.TEXTURE_2D || ( textureTarget >= _gl.TEXTURE_CUBE_MAP_POSITIVE_X && textureTarget <= _gl.TEXTURE_CUBE_MAP_NEGATIVE_Z ) ) {
 
 			_gl.framebufferTexture2D( _gl.FRAMEBUFFER, attachment, textureTarget, properties.get( texture ).__webglTexture, 0 );
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -1269,7 +1269,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 			multisampledRTTExt.framebufferTexture2DMultisampleEXT( _gl.FRAMEBUFFER, attachment, textureTarget, properties.get( texture ).__webglTexture, 0, getRenderTargetSamples( renderTarget ) );
 
-		} else if ( textureTarget === _gl.TEXTURE_2D || ( textureTarget >= _gl.TEXTURE_CUBE_MAP_POSITIVE_X && textureTarget <= _gl.TEXTURE_CUBE_MAP_NEGATIVE_Z ) ) {
+		} else if ( textureTarget === _gl.TEXTURE_2D || ( textureTarget >= _gl.TEXTURE_CUBE_MAP_POSITIVE_X && textureTarget <= _gl.TEXTURE_CUBE_MAP_NEGATIVE_Z ) ) { // see #24753
 
 			_gl.framebufferTexture2D( _gl.FRAMEBUFFER, attachment, textureTarget, properties.get( texture ).__webglTexture, 0 );
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -1269,7 +1269,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 			multisampledRTTExt.framebufferTexture2DMultisampleEXT( _gl.FRAMEBUFFER, attachment, textureTarget, properties.get( texture ).__webglTexture, 0, getRenderTargetSamples( renderTarget ) );
 
-		} else {
+		} else if ( textureTarget !== _gl.TEXTURE_3D && textureTarget !== _gl.TEXTURE_2D_ARRAY ) {
 
 			_gl.framebufferTexture2D( _gl.FRAMEBUFFER, attachment, textureTarget, properties.get( texture ).__webglTexture, 0 );
 


### PR DESCRIPTION
Hi all,

I am working on a 3D volumetric renderer and came across a warning today that I thought was an error. After fixing it, I realized that the reason why I wasn't seeing anything was in my code, not in three.js, but my solution contained a one-line fix for a _real_, albeit inconsequential, issue with this great library that I thought I'd might as well share.

**Description**

Previously, calling `WebGLRenderer.setRenderTarget(texture3D, layer)` would cause a warning **framebufferTexture2D: Bad 'imageTarget': 0x806f** (where `0x806f` translates to `TEXTURE_3D`).

This fix simply checks whether the `textureTarget` argument is valid or not _before_ calling `framebufferTexture2D`. If it is not valid, the call is skipped - which is the same behavior that we have right now minus the annoying warning.

Tests and linting succeeds :+1: 

Let me know if you need any more info or whatnot.

Cheers,
 - Clemens