### PR TITLE
BufferGeometryUtils: Skip .userData in .mergeBufferGeometries()

### DIFF
--- a/examples/jsm/utils/BufferGeometryUtils.js
+++ b/examples/jsm/utils/BufferGeometryUtils.js
@@ -124,6 +124,14 @@ function mergeBufferGeometries( geometries, useGroups = false ) {
 
 	const mergedGeometry = new BufferGeometry();
 
+	let mergedUserData;
+
+	if ( geometries.some( ( geometry ) => Object.keys( geometry.userData ).length > 0 ) ) {
+
+		mergedUserData = [];
+
+	}
+
 	let offset = 0;
 
 	for ( let i = 0; i < geometries.length; ++ i ) {
@@ -192,10 +200,11 @@ function mergeBufferGeometries( geometries, useGroups = false ) {
 
 		}
 
-		// gather .userData
+		if ( mergedUserData ) {
 
-		mergedGeometry.userData.mergedUserData = mergedGeometry.userData.mergedUserData || [];
-		mergedGeometry.userData.mergedUserData.push( geometry.userData );
+			mergedUserData.push( geometry.userData );
+
+		}
 
 		if ( useGroups ) {
 
@@ -299,6 +308,12 @@ function mergeBufferGeometries( geometries, useGroups = false ) {
 			mergedGeometry.morphAttributes[ name ].push( mergedMorphAttribute );
 
 		}
+
+	}
+
+	if ( mergedUserData ) {
+
+		mergedGeometry.userData.mergedUserData = mergedUserData;
 
 	}
 

--- a/examples/jsm/utils/BufferGeometryUtils.js
+++ b/examples/jsm/utils/BufferGeometryUtils.js
@@ -124,14 +124,6 @@ function mergeBufferGeometries( geometries, useGroups = false ) {
 
 	const mergedGeometry = new BufferGeometry();
 
-	let mergedUserData;
-
-	if ( geometries.some( ( geometry ) => Object.keys( geometry.userData ).length > 0 ) ) {
-
-		mergedUserData = [];
-
-	}
-
 	let offset = 0;
 
 	for ( let i = 0; i < geometries.length; ++ i ) {
@@ -197,12 +189,6 @@ function mergeBufferGeometries( geometries, useGroups = false ) {
 			if ( morphAttributes[ name ] === undefined ) morphAttributes[ name ] = [];
 
 			morphAttributes[ name ].push( geometry.morphAttributes[ name ] );
-
-		}
-
-		if ( mergedUserData ) {
-
-			mergedUserData.push( geometry.userData );
 
 		}
 
@@ -308,12 +294,6 @@ function mergeBufferGeometries( geometries, useGroups = false ) {
 			mergedGeometry.morphAttributes[ name ].push( mergedMorphAttribute );
 
 		}
-
-	}
-
-	if ( mergedUserData ) {
-
-		mergedGeometry.userData.mergedUserData = mergedUserData;
 
 	}
 


### PR DESCRIPTION
Currently .mergeBufferGeometries() adds a bunch of empty data to the `.userData` field, even if the original geometries did not use `.userData` themselves. ~~This change ignores `.userData` if none of the objects have content.~~ With this change we'll skip gathering `.userData` into an array. Since it is application-specific data, users can likely do something more appropriate with it easily. To reproduce the previous behavior, for example:

```
geometry.userData.mergeUserData = geometries.map( ( geometry ) => geometry.userData );
```

From https://threejs.org/examples/webgl_geometry_minecraft.html —

**Before:**
<img width="527" alt="Screen Shot 2022-10-06 at 3 38 49 PM" src="https://user-images.githubusercontent.com/1848368/194414033-f69ed963-0085-4240-a83a-c72c1d06078e.png">


**After:**
<img width="478" alt="Screen Shot 2022-10-06 at 3 36 10 PM" src="https://user-images.githubusercontent.com/1848368/194413606-b844617c-8f98-4722-b376-63c59b3654c6.png">
