### PR TITLE
WebGPURenderer: Move .init() to private and added .setAnimationLoop()

### DIFF
--- a/examples/jsm/renderers/webgpu/WebGPUAnimation.js
+++ b/examples/jsm/renderers/webgpu/WebGPUAnimation.js
@@ -1,0 +1,58 @@
+class WebGPUAnimation {
+
+	constructor() {
+
+		this.nodes = null;
+
+		this.animationLoop = null;
+		this.requestId = null;
+
+		this.isAnimating = false;
+
+		this.context = self;
+
+	}
+
+	start() {
+
+		if ( this.isAnimating === true || this.animationLoop === null || this.nodes === null ) return;
+
+		this.isAnimating = true;
+
+		const update = ( time, frame ) => {
+
+			this.requestId = self.requestAnimationFrame( update );
+
+			this.animationLoop( time, frame );
+
+			this.nodes.updateFrame();
+
+		};
+
+		this.requestId = self.requestAnimationFrame( update );
+
+	}
+
+	stop() {
+
+		self.cancelAnimationFrame( this.requestId );
+
+		this.isAnimating = false;
+
+	}
+
+	setAnimationLoop( callback ) {
+
+		this.animationLoop = callback;
+
+	}
+
+	setNodes( nodes ) {
+
+		this.nodes = nodes;
+
+	}
+
+}
+
+export default WebGPUAnimation;

--- a/examples/jsm/renderers/webgpu/WebGPURenderer.js
+++ b/examples/jsm/renderers/webgpu/WebGPURenderer.js
@@ -173,7 +173,11 @@ class WebGPURenderer {
 
 	async init() {
 
-		if ( this._initialized === true ) return;
+		if ( this._initialized === true ) {
+
+			throw new Error( 'WebGPURenderer: Device has already been initialized.' );
+
+		}
 
 		const parameters = this._parameters;
 

--- a/examples/webgpu_compute.html
+++ b/examples/webgpu_compute.html
@@ -46,9 +46,9 @@
 			const pointerVector = new THREE.Vector2( - 10.0, - 10.0 ); // Out of bounds first
 			const scaleVector = new THREE.Vector2( 1, 1 );
 
-			init().then( animate ).catch( error );
+			init();
 
-			async function init() {
+			function init() {
 
 				if ( WebGPU.isAvailable() === false ) {
 
@@ -150,6 +150,7 @@
 				renderer = new WebGPURenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
+				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				window.addEventListener( 'resize', onWindowResize );
@@ -161,8 +162,6 @@
 
 				gui.add( scaleVector, 'x', 0, 1, 0.01 );
 				gui.add( scaleVector, 'y', 0, 1, 0.01 );
-
-				return renderer.init();
 
 			}
 
@@ -191,16 +190,8 @@
 
 			function animate() {
 
-				requestAnimationFrame( animate );
-
 				renderer.compute( computeNode );
 				renderer.render( scene, camera );
-
-			}
-
-			function error( error ) {
-
-				console.error( error );
 
 			}
 

--- a/examples/webgpu_cubemap_adjustments.html
+++ b/examples/webgpu_cubemap_adjustments.html
@@ -47,9 +47,9 @@
 
 			let camera, scene, renderer;
 
-			init().then( render ).catch( error );
+			init();
 
-			async function init() {
+			function init() {
 
 				if ( WebGPU.isAvailable() === false ) {
 
@@ -136,8 +136,6 @@
 
 					scene.add( gltf.scene );
 
-					render();
-
 				} );
 
 				const sphereGeometry = new THREE.SphereGeometry( .5, 64, 32 );
@@ -158,6 +156,7 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.toneMappingNode = new Nodes.ToneMappingNode( THREE.LinearToneMapping, 1 );
 				renderer.outputEncoding = THREE.sRGBEncoding;
+				renderer.setAnimationLoop( render );
 				container.appendChild( renderer.domElement );
 
 				const controls = new OrbitControls( camera, renderer.domElement );
@@ -191,8 +190,6 @@
 				gui.add( adjustments, 'hue', 0, Math.PI * 2, 0.01 );
 				gui.add( adjustments, 'saturation', 0, 2, 0.01 );
 
-				return renderer.init();
-
 			}
 
 			function onWindowResize() {
@@ -208,15 +205,7 @@
 
 			function render() {
 
-				requestAnimationFrame( render );
-
 				renderer.render( scene, camera );
-
-			}
-
-			function error( error ) {
-
-				console.error( error );
 
 			}
 

--- a/examples/webgpu_cubemap_mix.html
+++ b/examples/webgpu_cubemap_mix.html
@@ -45,9 +45,9 @@
 
 			let camera, scene, renderer;
 
-			init().then( render ).catch( error );
+			init();
 
-			async function init() {
+			function init() {
 
 				if ( WebGPU.isAvailable() === false ) {
 
@@ -93,8 +93,6 @@
 
 					scene.add( gltf.scene );
 
-					render();
-
 				} );
 
 				renderer = new WebGPURenderer();
@@ -103,6 +101,7 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.toneMappingNode = new Nodes.ToneMappingNode( THREE.LinearToneMapping, 1 );
 				renderer.outputEncoding = THREE.sRGBEncoding;
+				renderer.setAnimationLoop( render );
 				container.appendChild( renderer.domElement );
 
 				const controls = new OrbitControls( camera, renderer.domElement );
@@ -110,8 +109,6 @@
 				controls.maxDistance = 10;
 
 				window.addEventListener( 'resize', onWindowResize );
-
-				if ( renderer.init ) return renderer.init();
 
 			}
 
@@ -128,15 +125,7 @@
 
 			function render() {
 
-				requestAnimationFrame( render );
-
 				renderer.render( scene, camera );
-
-			}
-
-			function error( error ) {
-
-				console.error( error );
 
 			}
 

--- a/examples/webgpu_depth_texture.html
+++ b/examples/webgpu_depth_texture.html
@@ -42,9 +42,10 @@
 
 			const dpr = window.devicePixelRatio;
 
-			init().then( animate ).catch( error );
+			init();
+			animate();
 
-			async function init() {
+			function init() {
 
 				if ( WebGPU.isAvailable() === false ) {
 
@@ -121,10 +122,6 @@
 				controls = new OrbitControls( camera, renderer.domElement );
 				controls.enableDamping = true;
 
-				//
-
-				return renderer.init();
-
 			}
 
 			function onWindowResize() {
@@ -143,12 +140,6 @@
 
 				textureRenderer.render( scene, camera );
 				renderer.render( sceneFX, cameraFX );
-
-			}
-
-			function error( error ) {
-
-				console.error( error );
 
 			}
 

--- a/examples/webgpu_depth_texture.html
+++ b/examples/webgpu_depth_texture.html
@@ -43,7 +43,6 @@
 			const dpr = window.devicePixelRatio;
 
 			init();
-			animate();
 
 			function init() {
 
@@ -95,6 +94,7 @@
 				renderer = new WebGPURenderer();
 				renderer.setPixelRatio( dpr );
 				renderer.setSize( window.innerWidth, window.innerHeight );
+				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				textureRenderer = new WebGPUTextureRenderer( renderer );
@@ -135,8 +135,6 @@
 			}
 
 			function animate() {
-
-				requestAnimationFrame( animate );
 
 				textureRenderer.render( scene, camera );
 				renderer.render( sceneFX, cameraFX );

--- a/examples/webgpu_instance_mesh.html
+++ b/examples/webgpu_instance_mesh.html
@@ -43,9 +43,10 @@
 			const count = Math.pow( amount, 3 );
 			const dummy = new THREE.Object3D();
 
-			init().then( animate ).catch( error );
+			init();
+			animate();
 
-			async function init() {
+			function init() {
 
 				if ( WebGPU.isAvailable() === false ) {
 
@@ -99,8 +100,6 @@
 				//
 
 				window.addEventListener( 'resize', onWindowResize );
-
-				return renderer.init();
 
 			}
 
@@ -160,12 +159,6 @@
 				}
 
 				renderer.render( scene, camera );
-
-			}
-
-			function error( error ) {
-
-				console.error( error );
 
 			}
 

--- a/examples/webgpu_instance_mesh.html
+++ b/examples/webgpu_instance_mesh.html
@@ -44,7 +44,6 @@
 			const dummy = new THREE.Object3D();
 
 			init();
-			animate();
 
 			function init() {
 
@@ -90,6 +89,7 @@
 				renderer = new WebGPURenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
+				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				//
@@ -116,15 +116,13 @@
 
 			function animate() {
 
-				requestAnimationFrame( animate );
-
 				render();
 
 				stats.update();
 
 			}
 
-			function render() {
+			async function render() {
 
 				if ( mesh ) {
 
@@ -158,7 +156,7 @@
 
 				}
 
-				renderer.render( scene, camera );
+				await renderer.render( scene, camera );
 
 			}
 

--- a/examples/webgpu_instance_uniform.html
+++ b/examples/webgpu_instance_uniform.html
@@ -75,9 +75,10 @@
 
 			const objects = [];
 
-			init().then( animate ).catch( error );
+			init();
+			animate();
 
-			async function init() {
+			function init() {
 
 				if ( WebGPU.isAvailable() === false ) {
 
@@ -155,8 +156,6 @@
 
 				window.addEventListener( 'resize', onWindowResize );
 
-				return renderer.init();
-
 			}
 
 			function addMesh( geometry, material ) {
@@ -210,12 +209,6 @@
 				}
 
 				renderer.render( scene, camera );
-
-			}
-
-			function error( error ) {
-
-				console.error( error );
 
 			}
 

--- a/examples/webgpu_instance_uniform.html
+++ b/examples/webgpu_instance_uniform.html
@@ -76,7 +76,6 @@
 			const objects = [];
 
 			init();
-			animate();
 
 			function init() {
 
@@ -139,6 +138,7 @@
 				renderer = new WebGPURenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
+				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				//
@@ -190,15 +190,6 @@
 
 			function animate() {
 
-				requestAnimationFrame( animate );
-
-				render();
-				stats.update();
-
-			}
-
-			function render() {
-
 				for ( let i = 0, l = objects.length; i < l; i ++ ) {
 
 					const object = objects[ i ];
@@ -209,6 +200,8 @@
 				}
 
 				renderer.render( scene, camera );
+
+				stats.update();
 
 			}
 

--- a/examples/webgpu_lights_custom.html
+++ b/examples/webgpu_lights_custom.html
@@ -38,7 +38,6 @@
 			let light1, light2, light3;
 
 			init();
-			animate();
 
 			function init() {
 
@@ -123,6 +122,7 @@
 				renderer = new WebGPURenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
+				renderer.setAnimationLoop( animate );
 				renderer.toneMappingNode = new Nodes.ToneMappingNode( THREE.LinearToneMapping, 1 );
 				renderer.outputEncoding = THREE.sRGBEncoding;
 				document.body.appendChild( renderer.domElement );
@@ -149,8 +149,6 @@
 			}
 
 			function animate() {
-
-				requestAnimationFrame( animate );
 
 				const time = Date.now() * 0.0005;
 				const scale = .5;

--- a/examples/webgpu_lights_custom.html
+++ b/examples/webgpu_lights_custom.html
@@ -37,9 +37,10 @@
 
 			let light1, light2, light3;
 
-			init().then( animate ).catch( error );
+			init();
+			animate();
 
-			async function init() {
+			function init() {
 
 				if ( WebGPU.isAvailable() === false ) {
 
@@ -136,10 +137,6 @@
 
 				window.addEventListener( 'resize', onWindowResize );
 
-				//
-
-				return renderer.init();
-
 			}
 
 			function onWindowResize() {
@@ -171,12 +168,6 @@
 				light3.position.z = Math.sin( time * 0.5 ) * scale;
 
 				renderer.render( scene, camera );
-
-			}
-
-			function error( error ) {
-
-				console.error( error );
 
 			}
 

--- a/examples/webgpu_lights_selective.html
+++ b/examples/webgpu_lights_selective.html
@@ -47,7 +47,6 @@
 				stats, controls;
 
 			init();
-			animate();
 
 			function init() {
 
@@ -139,6 +138,7 @@
 				renderer = new WebGPURenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
+				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 				renderer.outputEncoding = THREE.sRGBEncoding;
 				renderer.toneMappingNode = new Nodes.ToneMappingNode( THREE.LinearToneMapping, 100 );
@@ -176,15 +176,6 @@
 
 			function animate() {
 
-				requestAnimationFrame( animate );
-
-				render();
-				stats.update();
-
-			}
-
-			function render() {
-
 				const time = performance.now() / 1000;
 				const lightTime = time * 0.5;
 
@@ -212,6 +203,8 @@
 				if ( time > 3.5 && light4.parent === null ) scene.add( light4 );
 */
 				renderer.render( scene, camera );
+
+				stats.update();
 
 			}
 

--- a/examples/webgpu_lights_selective.html
+++ b/examples/webgpu_lights_selective.html
@@ -46,9 +46,10 @@
 				light1, light2, light3, light4,
 				stats, controls;
 
-			init().then( animate ).catch( error );
+			init();
+			animate();
 
-			async function init() {
+			function init() {
 
 				if ( WebGPU.isAvailable() === false ) {
 
@@ -162,8 +163,6 @@
 				gui.add( centerObject.material, 'roughness', 0, 1, 0.01 );
 				gui.add( centerObject.material, 'metalness', 0, 1, 0.01 );
 
-				return renderer.init();
-
 			}
 
 			function onWindowResize() {
@@ -213,12 +212,6 @@
 				if ( time > 3.5 && light4.parent === null ) scene.add( light4 );
 */
 				renderer.render( scene, camera );
-
-			}
-
-			function error( error ) {
-
-				console.error( error );
 
 			}
 

--- a/examples/webgpu_loader_gltf.html
+++ b/examples/webgpu_loader_gltf.html
@@ -113,6 +113,7 @@
 
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
+				renderer.setAnimationLoop( render );
 				renderer.toneMappingNode = new Nodes.ToneMappingNode( THREE.LinearToneMapping, 1 );
 				renderer.outputEncoding = THREE.sRGBEncoding;
 				container.appendChild( renderer.domElement );
@@ -137,8 +138,6 @@
 			//
 
 			function render() {
-
-				requestAnimationFrame( render );
 
 				renderer.render( scene, camera );
 

--- a/examples/webgpu_loader_gltf.html
+++ b/examples/webgpu_loader_gltf.html
@@ -44,9 +44,10 @@
 
 			let camera, scene, renderer;
 
-			init().then( render ).catch( error );
+			init();
+			render();
 
-			async function init() {
+			function init() {
 
 				if ( WebGPU.isAvailable() === false ) {
 
@@ -122,8 +123,6 @@
 
 				window.addEventListener( 'resize', onWindowResize );
 
-				if ( renderer.init ) return renderer.init();
-
 			}
 
 			function onWindowResize() {
@@ -142,12 +141,6 @@
 				requestAnimationFrame( render );
 
 				renderer.render( scene, camera );
-
-			}
-
-			function error( error ) {
-
-				console.error( error );
 
 			}
 

--- a/examples/webgpu_materials.html
+++ b/examples/webgpu_materials.html
@@ -45,7 +45,6 @@
 			const objects = [], materials = [];
 
 			init();
-			animate();
 
 			function init() {
 
@@ -200,6 +199,7 @@
 				renderer = new WebGPURenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
+				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				//
@@ -243,15 +243,6 @@
 
 			function animate() {
 
-				requestAnimationFrame( animate );
-
-				render();
-				stats.update();
-
-			}
-
-			function render() {
-
 				const timer = 0.0001 * Date.now();
 
 				camera.position.x = Math.cos( timer ) * 1000;
@@ -270,11 +261,7 @@
 
 				renderer.render( scene, camera );
 
-			}
-
-			function error( error ) {
-
-				console.error( error );
+				stats.update();
 
 			}
 

--- a/examples/webgpu_materials.html
+++ b/examples/webgpu_materials.html
@@ -44,9 +44,10 @@
 
 			const objects = [], materials = [];
 
-			init().then( animate ).catch( error );
+			init();
+			animate();
 
-			async function init() {
+			function init() {
 
 				if ( WebGPU.isAvailable() === false ) {
 
@@ -209,8 +210,6 @@
 				//
 
 				window.addEventListener( 'resize', onWindowResize );
-
-				return renderer.init();
 
 			}
 

--- a/examples/webgpu_nodes_playground.html
+++ b/examples/webgpu_nodes_playground.html
@@ -73,9 +73,10 @@
 			let model;
 			let nodeEditor;
 
-			init().then( animate ).catch( error => console.error( error ) );
+			init();
+			animate();
 
-			async function init() {
+			function init() {
 
 				if ( WebGPU.isAvailable() === false ) {
 
@@ -121,8 +122,6 @@
 				initEditor();
 
 				onWindowResize();
-
-				return renderer.init();
 
 			}
 

--- a/examples/webgpu_nodes_playground.html
+++ b/examples/webgpu_nodes_playground.html
@@ -74,7 +74,6 @@
 			let nodeEditor;
 
 			init();
-			animate();
 
 			function init() {
 
@@ -105,9 +104,10 @@
 				renderer = new WebGPURenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				document.body.appendChild( renderer.domElement );
+				renderer.setAnimationLoop( render );
 				renderer.outputEncoding = THREE.sRGBEncoding;
 				renderer.toneMappingNode = new Nodes.ToneMappingNode( THREE.LinearToneMapping, 4000 );
+				document.body.appendChild( renderer.domElement );
 
 				renderer.domElement.className = 'renderer';
 
@@ -203,19 +203,11 @@
 
 			//
 
-			function animate() {
-
-				requestAnimationFrame( animate );
-
-				nodeFrame.update();
-
-				render();
-
-			}
-
 			function render() {
 
 				//if ( model ) model.rotation.y = performance.now() / 5000;
+
+				nodeFrame.update();
 
 				renderer.render( scene, camera );
 

--- a/examples/webgpu_particles.html
+++ b/examples/webgpu_particles.html
@@ -40,9 +40,10 @@
 			let camera, scene, renderer;
 			let controls;
 
-			init().then( animate ).catch( error );
+			init();
+			animate();
 
-			async function init() {
+			function init() {
 
 				if ( WebGPU.isAvailable() === false ) {
 
@@ -152,8 +153,6 @@
 
 				gui.add( timer, 'scale', 0, 1, 0.01 ).name( 'speed' );
 
-				return renderer.init();
-
 			}
 
 			function onWindowResize() {
@@ -177,12 +176,6 @@
 			function render() {
 
 				renderer.render( scene, camera );
-
-			}
-
-			function error( error ) {
-
-				console.error( error );
 
 			}
 

--- a/examples/webgpu_particles.html
+++ b/examples/webgpu_particles.html
@@ -41,7 +41,6 @@
 			let controls;
 
 			init();
-			animate();
 
 			function init() {
 
@@ -134,6 +133,7 @@
 				renderer = new WebGPURenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
+				renderer.setAnimationLoop( render );
 				document.body.appendChild( renderer.domElement );
 
 				//
@@ -163,13 +163,6 @@
 				camera.updateProjectionMatrix();
 
 				renderer.setSize( innerWidth, innerHeight );
-
-			}
-
-			function animate() {
-
-				requestAnimationFrame( animate );
-				render();
 
 			}
 

--- a/examples/webgpu_rtt.html
+++ b/examples/webgpu_rtt.html
@@ -41,9 +41,10 @@
 
 			const dpr = window.devicePixelRatio;
 
-			init().then( animate ).catch( error );
+			init();
+			animate();
 
-			async function init() {
+			function init() {
 
 				if ( WebGPU.isAvailable() === false ) {
 
@@ -103,10 +104,6 @@
 				const quad = new THREE.Mesh( geometryFX, materialFX );
 				sceneFX.add( quad );
 
-				//
-
-				return renderer.init();
-
 			}
 
 			function onWindowMouseMove( e ) {
@@ -135,12 +132,6 @@
 
 				textureRenderer.render( scene, camera );
 				renderer.render( sceneFX, cameraFX );
-
-			}
-
-			function error( error ) {
-
-				console.error( error );
 
 			}
 

--- a/examples/webgpu_sandbox.html
+++ b/examples/webgpu_sandbox.html
@@ -38,7 +38,6 @@
 			let box;
 
 			init();
-			animate();
 
 			function init() {
 
@@ -180,6 +179,7 @@
 				renderer = new WebGPURenderer( { requiredFeatures: [ 'texture-compression-bc' ] } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
+				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				window.addEventListener( 'resize', onWindowResize );
@@ -196,8 +196,6 @@
 			}
 
 			function animate() {
-
-				requestAnimationFrame( animate );
 
 				box.rotation.x += 0.01;
 				box.rotation.y += 0.02;

--- a/examples/webgpu_sandbox.html
+++ b/examples/webgpu_sandbox.html
@@ -37,9 +37,10 @@
 
 			let box;
 
-			init().then( animate ).catch( error );
+			init();
+			animate();
 
-			async function init() {
+			function init() {
 
 				if ( WebGPU.isAvailable() === false ) {
 
@@ -183,8 +184,6 @@
 
 				window.addEventListener( 'resize', onWindowResize );
 
-				return renderer.init();
-
 			}
 
 			function onWindowResize() {
@@ -235,12 +234,6 @@
 				const texture = new THREE.DataTexture( data, width, height, THREE.RGBAFormat );
 				texture.needsUpdate = true;
 				return texture;
-
-			}
-
-			function error( error ) {
-
-				console.error( error );
 
 			}
 

--- a/examples/webgpu_skinning.html
+++ b/examples/webgpu_skinning.html
@@ -39,7 +39,6 @@
 			let mixer, clock;
 
 			init();
-			animate();
 
 			function init() {
 
@@ -93,6 +92,7 @@
 				renderer = new WebGPURenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
+				renderer.setAnimationLoop( animate );
 				renderer.outputEncoding = THREE.sRGBEncoding;
 				renderer.toneMappingNode = new Nodes.ToneMappingNode( THREE.LinearToneMapping, 800 );
 				document.body.appendChild( renderer.domElement );
@@ -111,8 +111,6 @@
 			}
 
 			function animate() {
-
-				requestAnimationFrame( animate );
 
 				const delta = clock.getDelta();
 

--- a/examples/webgpu_skinning.html
+++ b/examples/webgpu_skinning.html
@@ -38,9 +38,10 @@
 
 			let mixer, clock;
 
-			init().then( animate ).catch( error );
+			init();
+			animate();
 
-			async function init() {
+			function init() {
 
 				if ( WebGPU.isAvailable() === false ) {
 
@@ -98,8 +99,6 @@
 
 				window.addEventListener( 'resize', onWindowResize );
 
-				return renderer.init();
-
 			}
 
 			function onWindowResize() {
@@ -120,12 +119,6 @@
 				if ( mixer ) mixer.update( delta );
 
 				renderer.render( scene, camera );
-
-			}
-
-			function error( error ) {
-
-				console.error( error );
 
 			}
 

--- a/examples/webgpu_skinning_instancing.html
+++ b/examples/webgpu_skinning_instancing.html
@@ -40,9 +40,9 @@
 
 			let mixer, clock;
 
-			init().then( animate ).catch( error );
+			init();
 
-			async function init() {
+			function init() {
 
 				if ( WebGPU.isAvailable() === false ) {
 
@@ -127,13 +127,12 @@
 				renderer = new WebGPURenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
+				renderer.setAnimationLoop( animate );
 				renderer.outputEncoding = THREE.sRGBEncoding;
 				renderer.toneMappingNode = new Nodes.ToneMappingNode( THREE.LinearToneMapping, 800 );
 				document.body.appendChild( renderer.domElement );
 
 				window.addEventListener( 'resize', onWindowResize );
-
-				return renderer.init();
 
 			}
 
@@ -148,19 +147,11 @@
 
 			function animate() {
 
-				requestAnimationFrame( animate );
-
 				const delta = clock.getDelta();
 
 				if ( mixer ) mixer.update( delta );
 
 				renderer.render( scene, camera );
-
-			}
-
-			function error( error ) {
-
-				console.error( error );
 
 			}
 

--- a/examples/webgpu_skinning_points.html
+++ b/examples/webgpu_skinning_points.html
@@ -39,7 +39,6 @@
 			let mixer, clock;
 
 			init();
-			animate();
 
 			function init() {
 
@@ -93,6 +92,7 @@
 				renderer = new WebGPURenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
+				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				window.addEventListener( 'resize', onWindowResize );
@@ -109,8 +109,6 @@
 			}
 
 			function animate() {
-
-				requestAnimationFrame( animate );
 
 				const delta = clock.getDelta();
 

--- a/examples/webgpu_skinning_points.html
+++ b/examples/webgpu_skinning_points.html
@@ -38,9 +38,10 @@
 
 			let mixer, clock;
 
-			init().then( animate ).catch( error );
+			init();
+			animate();
 
-			async function init() {
+			function init() {
 
 				if ( WebGPU.isAvailable() === false ) {
 
@@ -96,8 +97,6 @@
 
 				window.addEventListener( 'resize', onWindowResize );
 
-				return renderer.init();
-
 			}
 
 			function onWindowResize() {
@@ -118,12 +117,6 @@
 				if ( mixer ) mixer.update( delta );
 
 				renderer.render( scene, camera );
-
-			}
-
-			function error( error ) {
-
-				console.error( error );
 
 			}
 

--- a/examples/webgpu_sprites.html
+++ b/examples/webgpu_sprites.html
@@ -41,9 +41,10 @@
 
 			let imageWidth = 1, imageHeight = 1;
 
-			init().then( animate ).catch( error );
+			init();
+			animate();
 
-			async function init() {
+			function init() {
 
 				if ( WebGPU.isAvailable() === false ) {
 
@@ -116,8 +117,6 @@
 
 				window.addEventListener( 'resize', onWindowResize );
 
-				return renderer.init();
-
 			}
 
 			function onWindowResize() {
@@ -158,12 +157,6 @@
 				group.rotation.z = time * 1.0;
 
 				renderer.render( scene, camera );
-
-			}
-
-			function error( error ) {
-
-				console.error( error );
 
 			}
 

--- a/examples/webgpu_sprites.html
+++ b/examples/webgpu_sprites.html
@@ -42,7 +42,6 @@
 			let imageWidth = 1, imageHeight = 1;
 
 			init();
-			animate();
 
 			function init() {
 
@@ -113,6 +112,7 @@
 				renderer = new WebGPURenderer( { requiredFeatures: [ 'texture-compression-bc' ] } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
+				renderer.setAnimationLoop( render );
 				document.body.appendChild( renderer.domElement );
 
 				window.addEventListener( 'resize', onWindowResize );
@@ -128,13 +128,6 @@
 				camera.updateProjectionMatrix();
 
 				renderer.setSize( window.innerWidth, window.innerHeight );
-
-			}
-
-			function animate() {
-
-				requestAnimationFrame( animate );
-				render();
 
 			}
 


### PR DESCRIPTION
**Description**

This is one of the part to maintain backward compatibility between `WebGLRenderer` and `WebGPURenderer`.

After initializing the WebGPU Device it will call the `setAnimationLoop()` callback, but as there are legacy projects that don't use `.setAnimationLoop()`, the `.render()` and `.compute()` function makes a test to verify if the device is available.

```js
const renderer = new WebGPURenderer();

// recommended approach
renderer.setAnimationLoop( animate );

// legacy approach
requestAnimationFrame( animate )
```

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Google](https://google.com)*
