### PR TITLE
GLTFLoader: Expose `GLTFParser`.

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -4557,4 +4557,4 @@ function toTrianglesDrawMode( geometry, drawMode ) {
 
 }
 
-export { GLTFLoader };
+export { GLTFLoader, GLTFParser };


### PR DESCRIPTION
I want to utilize GLTFParser without needing to clone the script in my own project since threejs' typescript exports it where the script does not.