### PR TITLE
Editor: Remove `UIListbox` namespace from `ListboxItem`. 

### DIFF
--- a/editor/js/libs/ui.js
+++ b/editor/js/libs/ui.js
@@ -1189,7 +1189,7 @@ class UIListbox extends UIDiv {
 
 			const item = this.items[ i ];
 
-			const listitem = new UIListbox.ListboxItem( this );
+			const listitem = new ListboxItem( this );
 			listitem.setId( item.id || `Listbox-${i}` );
 			listitem.setTextContent( item.name || item.type );
 			this.add( listitem );


### PR DESCRIPTION
I get an error when I use `UIListbox` .

```
Uncaught TypeError: UIListbox.ListboxItem is not a constructor
at UIListbox.render (ui.js:1213:30)
```


https://github.com/mrdoob/three.js/blob/dev/editor/js/libs/ui.js

```
class UIListbox extends UIDiv { ... }

class ListboxItem extends UIDiv { ... }
```

You can see that: `UIListbox` and `ListboxItem`, they are independent of each other.

So `UIListbox.ListboxItem` is wrong.

```diff
- const listitem = new UIListbox.ListboxItem(this);
+ const listitem = new ListboxItem(this);
```

