### PR TITLE
Docs: Improve VideoTexture page.

### DIFF
--- a/docs/api/en/textures/VideoTexture.html
+++ b/docs/api/en/textures/VideoTexture.html
@@ -12,9 +12,11 @@
 		<h1>[name]</h1>
 
 		<p class="desc">
-		Creates a texture for use with a video texture.<br /><br />
+		Creates a texture for use with a video.
+		</p>
 
-		This is almost the same as the base [page:Texture Texture] class, except that it continuously sets [page:Texture.needsUpdate needsUpdate] to `true` so that the texture is updated as the video plays. Automatic creation of [page:Texture.mipmaps mipmaps] is also disabled.
+		<p>
+			Note: After the initial use of a texture, the video cannot be changed. Instead, call [page:.dispose]() on the texture and instantiate a new one.
 		</p>
 
 		<h2>Code Example</h2>
@@ -27,7 +29,13 @@
 
 		<h2>Examples</h2>
 
-		<p>[example:webgl_materials_video materials / video ]</p>
+		<p>
+			[example:webgl_materials_video materials / video]<br />
+			[example:webgl_materials_video_webcam materials / video / webcam]<br />
+			[example:webgl_video_kinect video / kinect]<br />
+			[example:webgl_video_panorama_equirectangular video / panorama / equirectangular]<br />
+			[example:webxr_vr_video vr / video]
+		</p>
 
 		<h2>Constructor</h2>
 		<h3>[name]( [param:Video video], [param:Constant mapping], [param:Constant wrapS], [param:Constant wrapT], [param:Constant magFilter], [param:Constant minFilter], [param:Constant format], [param:Constant type], [param:Number anisotropy] )</h3>
@@ -47,7 +55,7 @@
 		The default is [page:Textures THREE.LinearFilter]. See [page:Textures magnification filter constants] for other choices.<br />
 
 		[page:Constant minFilter] -- How the texture is sampled when a texel covers less than one pixel.
-		The default is [page:Textures THREE.LinearMipmapLinearFilter]. See [page:Textures minification filter constants] for other choices.<br />
+		The default is [page:Textures THREE.LinearFilter]. See [page:Textures minification filter constants] for other choices.<br />
 
 		[page:Constant format] -- The default is [page:Textures THREE.RGBAFormat].
 		See [page:Textures format constants] for other choices.<br />
@@ -69,7 +77,7 @@
 
 		<h3>[property:Boolean generateMipmaps]</h3>
 		<p>
-		Whether to generate mipmaps. False by default.
+		Whether to generate mipmaps. `false` by default.
 		</p>
 
 		<h3>[property:Boolean isVideoTexture]</h3>
@@ -79,7 +87,7 @@
 
 		<h3>[property:Boolean needsUpdate]</h3>
 		<p>
-		You will not need to set this manually here as it is handled by the [page:VideoTexture.update update] method.
+		You will not need to set this manually here as it is handled by the [page:VideoTexture.update update]() method.
 		</p>
 
 		<h2>Methods</h2>

--- a/docs/api/zh/textures/VideoTexture.html
+++ b/docs/api/zh/textures/VideoTexture.html
@@ -12,9 +12,11 @@
 		<h1>视频纹理（[name]）</h1>
 
 		<p class="desc">
-		创建一个使用视频来作为贴图的纹理对象。<br /><br />
+		创建一个使用视频来作为贴图的纹理对象。
+		</p>
 
-		它和其基类[page:Texture Texture]几乎是相同的，除了它总是将[page:Texture.needsUpdate needsUpdate]设置为*true*，以便使得贴图能够在视频播放时进行更新。自动创建[page:Texture.mipmaps mipmaps]也会被禁用。
+		<p>
+			Note: After the initial use of a texture, the video cannot be changed. Instead, call [page:.dispose]() on the texture and instantiate a new one.
 		</p>
 
 		<h2>代码示例</h2>
@@ -27,7 +29,13 @@ const texture = new THREE.VideoTexture( video );
 
 		<h2>例子</h2>
 
-		<p>[example:webgl_materials_video materials / video ]</p>
+		<p>
+			[example:webgl_materials_video materials / video]<br />
+			[example:webgl_materials_video_webcam materials / video / webcam]<br />
+			[example:webgl_video_kinect video / kinect]<br />
+			[example:webgl_video_panorama_equirectangular video / panorama / equirectangular]<br />
+			[example:webxr_vr_video vr / video]
+		</p>
 
 		<h2>构造函数</h2>
 		<h3>[name]( [param:Video video], [param:Constant mapping], [param:Constant wrapS], [param:Constant wrapT], [param:Constant magFilter], [param:Constant minFilter], [param:Constant format], [param:Constant type], [param:Number anisotropy] )</h3>
@@ -47,7 +55,7 @@ const texture = new THREE.VideoTexture( video );
 		其默认值为[page:Textures THREE.LinearFilter]。请参阅[page:Textures magnification filter constants]（放大滤镜常量）来了解其它选项。<br />
 
 		[page:Constant minFilter] -- 当一个纹素覆盖小于一个像素时，贴图将如何采样。
-		其默认值为[page:Textures THREE.LinearMipmapLinearFilter]。请参阅[page:Textures minification filter constants]（缩小滤镜常量）来了解其它选项。<br />
+		其默认值为[page:Textures THREE.LinearFilter]。请参阅[page:Textures minification filter constants]（缩小滤镜常量）来了解其它选项。<br />
 
 		[page:Constant format] -- The default is [page:Textures THREE.RGBAFormat].
 	 	请参阅[page:Textures format constants]（格式常量）来了解各个选项。<br />
@@ -69,7 +77,7 @@ const texture = new THREE.VideoTexture( video );
 
 		<h3>[property:Boolean generateMipmaps]</h3>
 		<p>
-		Whether to generate mipmaps. False by default.
+		Whether to generate mipmaps. `false` by default.
 		</p>
 
 		<h3>[property:Boolean isVideoTexture]</h3>
@@ -79,7 +87,7 @@ const texture = new THREE.VideoTexture( video );
 
 		<h3>[property:Boolean needsUpdate]</h3>
 		<p>
-		在这里，你不必手动设置这个值，因为它是由[page:VideoTexture.update update]方法来进行控制的。
+		在这里，你不必手动设置这个值，因为它是由[page:VideoTexture.update update]()方法来进行控制的。
 		</p>
 
 		<h2>方法</h2>


### PR DESCRIPTION
Fixed #24757.

**Description**

This PR updates the documentation of `VideoTexture`. It cleans a few things up and states that the video can't be changed after the initial use of the texture.
