### PR TITLE
GLTFLoader: Prevent load exception for assets that animation.target.node is undefined

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -3776,6 +3776,7 @@ class GLTFParser {
 		const json = this.json;
 
 		const animationDef = json.animations[ animationIndex ];
+		const animationName = animationDef.name ? animationDef.name : 'animation_' + animationIndex;
 
 		const pendingNodes = [];
 		const pendingInputAccessors = [];
@@ -3791,6 +3792,8 @@ class GLTFParser {
 			const name = target.node;
 			const input = animationDef.parameters !== undefined ? animationDef.parameters[ sampler.input ] : sampler.input;
 			const output = animationDef.parameters !== undefined ? animationDef.parameters[ sampler.output ] : sampler.output;
+
+			if ( target.node === undefined ) continue;
 
 			pendingNodes.push( this.getDependency( 'node', name ) );
 			pendingInputAccessors.push( this.getDependency( 'accessor', input ) );
@@ -3929,9 +3932,7 @@ class GLTFParser {
 
 			}
 
-			const name = animationDef.name ? animationDef.name : 'animation_' + animationIndex;
-
-			return new AnimationClip( name, undefined, tracks );
+			return new AnimationClip( animationName, undefined, tracks );
 
 		} );
 


### PR DESCRIPTION
Related issue: #24108

**Description**

Unfortunately there hasn't been much movement on merging my PRs for `KHR_animation_pointer` (#24252, #24193 in preparation for #24108). In the meantime, people have starting using the extension and are bringing files to three.js that then fail with an exception.

This PR fixes the exception and makes sure people can at least load files that have `KHR_animation_pointer` marked as optional extension (according to glTF spec: when an extension is marked as optional implementations are fine to ignore it but should still display the rest of the file).

An open question would be whether to return "null" AnimationClips, thus potentially breaking external code that assumes that whenever an animation is loaded an AnimationClip is returned, or returning a clip with no tracks:
```
return new AnimationClip( animationName, undefined, [] );
```

I went with the latter here. There will be a log in the console that the extension isn't supported and people get empty tracks back instead of the current exception that looks like this:
![image](https://user-images.githubusercontent.com/2693840/194841196-418e984f-9034-4b20-8254-e4e8c06caf68.png)

My preference would definitely be KHR_animation_pointer support in three but in the meantime at least it shouldn't crash anymore for people.

*This contribution is funded by [Needle](https://needle.tools)*