### PR TITLE
GLTFLoader: Fill bone matrixWorld with bind pose

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -4243,6 +4243,8 @@ function buildNodeHierarchy( nodeId, parentObject, json, parser ) {
 
 						}
 
+						jointNode.matrixWorld.copy(mat).invert()
+
 						boneInverses.push( mat );
 
 					} else {

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -4243,7 +4243,7 @@ function buildNodeHierarchy( nodeId, parentObject, json, parser ) {
 
 						}
 
-						jointNode.matrixWorld.copy(mat).invert()
+						jointNode.matrixWorld.copy( mat ).invert()
 
 						boneInverses.push( mat );
 


### PR DESCRIPTION
Fixes: #24772

**Description**

This fills the bind pose matrix data (which is currently passed directly to the `Skeleton()` constructor) into `bone.matrixWorld` to ensure proper output of `Skeleton.pose()` and `Group.clone()`

Demo with fix: https://jsfiddle.net/mattrossman/8p5t6acd/3/

