### PR TITLE
HTMLMesh: Delete canvas from internal weak map in `dispose()`.

### DIFF
--- a/examples/jsm/interactive/HTMLMesh.js
+++ b/examples/jsm/interactive/HTMLMesh.js
@@ -36,6 +36,8 @@ class HTMLMesh extends Mesh {
 			material.dispose();
 
 			material.map.dispose();
+			
+			canvases.delete( dom );
 
 			this.removeEventListener( 'mousedown', onEvent );
 			this.removeEventListener( 'mousemove', onEvent );


### PR DESCRIPTION
Maybe Related https://github.com/mrdoob/three.js/pull/23662

**Description**

I have an HTMLMesh that changes sizes when you interact with it. 

I decided the only way to handle that with the current code is to dispose of the old mesh to create a new HTMLMesh once the size has changed. However the mesh always kept the same size.

https://user-images.githubusercontent.com/46798391/195200744-4bcac066-55e0-48d0-bd30-9e017b7c89cc.mp4

It took me a long time to figure out that the canvas is saved to a canvas map. Adding a delete function to the canvas map solved the problem for me, not sure if this is the best approach. Another approach would be to add a check for size changes on the mutation observer, as suggested by other PR? 



