### PR TITLE
HTMLMesh: added textNode wrapping

### DIFF
--- a/examples/jsm/interactive/HTMLMesh.js
+++ b/examples/jsm/interactive/HTMLMesh.js
@@ -205,33 +205,38 @@ function html2canvas( element ) {
 
 	function getLines( element, text, maxWidth ) {
 
-	    const words = text.split( " " );
-	    const lines = [];
-	    let currentLine = words[ 0 ];
+		const words = text.split( " " );
+		const lines = [];
+		let currentLine = words[ 0 ];
 
-	    for ( let i = 1; i < words.length; i ++ ) {
-	    	// Somehow, the textnode width in pixels differs from the parent element width.
-	    	// Using the range instead of the context to compute the wrapping width fixes this problem.
-	        const word = words[ i ];
-	        range.setStart( element, 0 );
+		for ( let i = 1; i < words.length; i ++ ) {
 
-	        const newLine = currentLine + " " + word;
+			// Somehow, the textnode width in pixels differs from the parent element width.
+			// Using the range instead of the context to compute the wrapping width fixes this problem.
+
+			const word = words[ i ];
+			range.setStart( element, 0 );
+
+			const newLine = currentLine + " " + word;
 			range.setEnd( element, newLine.length );
 
-	        const width = range.getBoundingClientRect().width;
+			const width = range.getBoundingClientRect().width;
 
-	        if ( width < maxWidth ) currentLine = newLine;
-	        else {
+			if ( width < maxWidth ) {
+		
+				currentLine = newLine;
 
-	            lines.push( currentLine );
-	            currentLine = word;
+			} else {
 
-	        }
+				lines.push( currentLine );
+				currentLine = word;
 
-	    }
+			}
+			
+		}
 
-	    lines.push( currentLine );
-	    return lines;
+		lines.push( currentLine );
+		return lines;
 
 	}
 
@@ -312,12 +317,11 @@ function html2canvas( element ) {
 
 				}
 
+			} else {
+			
+				drawText( style, x, y, text );
 
-			} else drawText( style, x, y, text );
-
-
-
-
+			}
 
 		} else if ( element.nodeType === Node.COMMENT_NODE ) {
 

--- a/examples/jsm/interactive/HTMLMesh.js
+++ b/examples/jsm/interactive/HTMLMesh.js
@@ -300,12 +300,14 @@ function html2canvas( element ) {
  				const parentWidth = parentEl.offsetWidth;
 
  				//set to nowrap so that range doesn't warp in the getLines function
+				const whiteSpaceValue = parentEl.style.whiteSpace;
  				parentEl.style.whiteSpace = "nowrap";
 
 				const lineHeight = range.getBoundingClientRect().height;
 				const lines = getLines( element, text, parentWidth );
 
- 				parentEl.style.whiteSpace = null;
+ 				parentEl.style.whiteSpace = whiteSpaceValue;
+				
 
 				range.selectNode( element );
 


### PR DESCRIPTION
**Description**

If you look at the video on #24779 , the textNode doesn't wrap properly. This PR fixes that.
![image](https://user-images.githubusercontent.com/46798391/195240230-d066bbba-d06e-4d42-9d4a-0c8356dc98a7.png)

PS my pico neo isn't able to run the 360 video- I hope that webxr layers will solve that (my headset is a pico neo 3 so haven't been able to test that..)