### PR TITLE
Ray: Improve readability in intersectBox().

### DIFF
--- a/src/math/Ray.js
+++ b/src/math/Ray.js
@@ -356,12 +356,9 @@ class Ray {
 
 		if ( ( tmin > tymax ) || ( tymin > tmax ) ) return null;
 
-		// These lines also handle the case where tmin or tmax is NaN
-		// (result of 0 * Infinity). x !== x returns true if x is NaN
+		if ( tymin > tmin || isNaN( tmin ) ) tmin = tymin;
 
-		if ( tymin > tmin || tmin !== tmin ) tmin = tymin;
-
-		if ( tymax < tmax || tmax !== tmax ) tmax = tymax;
+		if ( tymax < tmax || isNaN( tmax ) ) tmax = tymax;
 
 		if ( invdirz >= 0 ) {
 


### PR DESCRIPTION
Related issue: #24789

**Description**

The explicit usage of `isNaN()` should make the code more readable.
