### PR TITLE
WebGLRenderer - Implemented setSortOverride.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -183,6 +183,7 @@ function WebGLRenderer( parameters = {} ) {
 	let _pixelRatio = 1;
 	let _opaqueSort = null;
 	let _transparentSort = null;
+	let _sortOverride = null;
 
 	const _viewport = new Vector4( 0, 0, _width, _height );
 	const _scissor = new Vector4( 0, 0, _width, _height );
@@ -531,6 +532,12 @@ function WebGLRenderer( parameters = {} ) {
 	this.setTransparentSort = function ( method ) {
 
 		_transparentSort = method;
+
+	};
+
+	this.setSortOverride = function ( method ) {
+
+		_sortOverride = method;
 
 	};
 
@@ -1016,7 +1023,7 @@ function WebGLRenderer( parameters = {} ) {
 
 		if ( _this.sortObjects === true ) {
 
-			currentRenderList.sort( _opaqueSort, _transparentSort );
+			currentRenderList.sort( _opaqueSort, _transparentSort, _sortOverride );
 
 		}
 

--- a/src/renderers/webgl/WebGLRenderLists.js
+++ b/src/renderers/webgl/WebGLRenderLists.js
@@ -144,7 +144,14 @@ function WebGLRenderList() {
 
 	}
 
-	function sort( customOpaqueSort, customTransparentSort ) {
+	function sort( customOpaqueSort, customTransparentSort, sortOverride ) {
+
+		if ( sortOverride ) {
+
+			sortOverride( opaque, transmissive, transparent, customOpaqueSort || painterSortStable, customTransparentSort || reversePainterSortStable );
+			return;
+
+		}
 
 		if ( opaque.length > 1 ) opaque.sort( customOpaqueSort || painterSortStable );
 		if ( transmissive.length > 1 ) transmissive.sort( customTransparentSort || reversePainterSortStable );


### PR DESCRIPTION
Related issue: #24811

**Description**

There are many sorting use-cases that aren't possible to implement with only a custom Javascript sort comparison function (via `WebGLRenderer.setTransparentSort` and `WebGLRenderer.setOpaqueSort`). This PR allows the entire sort method in WebGLRenderList to be overridden with a callback that accepts parameters for all object lists and the sorting methods (either the default methods, or the custom sorting methods specified in WebGLRenderer).

A quick example use-case is logical grouping. Perhaps objects should be grouped by some condition and then sorted independently as a group by a certain sorting algorithm. Then, all groups should be sorted against each other by some other algorithm, like z-distance to the camera.