### PR TITLE
KTX2Loader: Make `_createTexture()` async for better error handling.

### DIFF
--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -261,19 +261,11 @@ class KTX2Loader extends Loader {
 	 */
 	async _createTexture( buffer, config = {} ) {
 
-		try {
+		const container = read( new Uint8Array( buffer ) );
 
-			const container = read( new Uint8Array( buffer ) );
+		if ( container.vkFormat !== VK_FORMAT_UNDEFINED ) {
 
-			if ( container.vkFormat !== VK_FORMAT_UNDEFINED ) {
-
-				return createDataTexture( container );
-
-			}
-
-		} catch ( error ) {
-
-			return Promise.reject( error );
+			return createDataTexture( container );
 
 		}
 

--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -259,7 +259,7 @@ class KTX2Loader extends Loader {
 	 * @param {object?} config
 	 * @return {Promise<CompressedTexture|DataTexture|Data3DTexture>}
 	 */
-	_createTexture( buffer, config = {} ) {
+	async _createTexture( buffer, config = {} ) {
 		try {
 			const container = read( new Uint8Array( buffer ) );
 

--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -260,13 +260,17 @@ class KTX2Loader extends Loader {
 	 * @return {Promise<CompressedTexture|DataTexture|Data3DTexture>}
 	 */
 	_createTexture( buffer, config = {} ) {
+		try {
+			const container = read( new Uint8Array( buffer ) );
 
-		const container = read( new Uint8Array( buffer ) );
+			if ( container.vkFormat !== VK_FORMAT_UNDEFINED ) {
 
-		if ( container.vkFormat !== VK_FORMAT_UNDEFINED ) {
+				return createDataTexture( container );
 
-			return createDataTexture( container );
-
+			}
+		}
+		catch (error) {
+			return Promise.reject( error );
 		}
 
 		//

--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -260,7 +260,9 @@ class KTX2Loader extends Loader {
 	 * @return {Promise<CompressedTexture|DataTexture|Data3DTexture>}
 	 */
 	async _createTexture( buffer, config = {} ) {
+
 		try {
+
 			const container = read( new Uint8Array( buffer ) );
 
 			if ( container.vkFormat !== VK_FORMAT_UNDEFINED ) {
@@ -268,9 +270,11 @@ class KTX2Loader extends Loader {
 				return createDataTexture( container );
 
 			}
-		}
-		catch (error) {
+
+		} catch ( error ) {
+
 			return Promise.reject( error );
+
 		}
 
 		//


### PR DESCRIPTION
Related: #24623

Catch exception when use read from ktx-parse.module.js.

Description

When read file which is not ktx2, throw a Error. here add the catch procedure.