### PR TITLE
Docs: Clean up

### DIFF
--- a/docs/api/zh/math/Euler.html
+++ b/docs/api/zh/math/Euler.html
@@ -145,14 +145,6 @@
 		返回一个数组：[[page:.x x], [page:.y y], [page:.z z], [page:.order order ]]。
 		</p>
 
-		<h3>[method:Vector3 toVector3]( [param:Vector3 optionalResult] )</h3>
-		<p>
-			[page:Vector3 optionalResult] — (可选参数) 如果指定了该参数结果将会被复制给该参数，否者会创建一个新的 Vector3 <br /><br />
-
-			以 [page:Vector3] 的形式返回欧拉角的 [page:.x x], [page:.y y] 和 [page:.z z]。
-		</p>
-
-
 		<h2>源码（Source）</h2>
 
 		<p>


### PR DESCRIPTION
## Description
Remove the description of toVector3 from Euler's Chinese document.

## Reason
Euler's toVector3 method has been removed (#23494), but the Chinese document still retains the description of the API.
