### PR TITLE
Examples: Updated webgl2_texture2darray_compressed.html

### DIFF
--- a/examples/webgl2_texture2darray_compressed.html
+++ b/examples/webgl2_texture2darray_compressed.html
@@ -6,42 +6,6 @@
 		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
 		<link type="text/css" rel="stylesheet" href="main.css">
 	</head>
-	<script id="vs" type="x-shader/x-vertex">
-	uniform vec2 size;
-	out vec2 vUv;
-
-	void main() {
-
-		gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
-
-		// Convert position.xy to 1.0-0.0
-
-		vUv.xy = position.xy / size + 0.5;
-		vUv.y = 1.0 - vUv.y; // original data is upside down
-
-	}
-	</script>
-
-	<script id="fs" type="x-shader/x-fragment">
-	precision highp float;
-	precision highp int;
-	precision highp sampler2DArray;
-
-	uniform sampler2DArray diffuse;
-	in vec2 vUv;
-	uniform int depth;
-
-	out vec4 outColor;
-
-	void main() {
-
-		vec4 color = texture( diffuse, vec3( vUv, depth ) );
-
-		// lighten a bit
-		outColor = vec4( color.rgb + .2, 1.0 );
-
-	}
-	</script>
 	<body>
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - 2D Compressed Texture Array<br />
@@ -85,7 +49,6 @@
 			let depthStep = 1;
 
 			init();
-			animate();
 
 			function init() {
 
@@ -96,8 +59,6 @@
 				camera.position.z = 70;
 
 				scene = new THREE.Scene();
-
-				//
 				clock = new THREE.Clock();
 
 				renderer = new THREE.WebGLRenderer();
@@ -119,8 +80,41 @@
 							depth: { value: 55 },
 							size: { value: new THREE.Vector2( planeWidth, planeHeight ) }
 						},
-						vertexShader: document.getElementById( 'vs' ).textContent.trim(),
-						fragmentShader: document.getElementById( 'fs' ).textContent.trim(),
+						vertexShader: /* glsl */`
+							uniform vec2 size;
+							out vec2 vUv;
+
+							void main() {
+
+								gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+
+								// Convert position.xy to 1.0-0.0
+
+								vUv.xy = position.xy / size + 0.5;
+								vUv.y = 1.0 - vUv.y; // original data is upside down
+
+							}
+						`,
+						fragmentShader: /* glsl */`
+							precision highp float;
+							precision highp int;
+							precision highp sampler2DArray;
+
+							uniform sampler2DArray diffuse;
+							in vec2 vUv;
+							uniform int depth;
+
+							out vec4 outColor;
+
+							void main() {
+
+								vec4 color = texture( diffuse, vec3( vUv, depth ) );
+
+								// lighten a bit
+								outColor = vec4( color.rgb + .2, 1.0 );
+
+							}
+						`,
 						glslVersion: THREE.GLSL3
 					} );
 
@@ -129,6 +123,8 @@
 					mesh = new THREE.Mesh( geometry, material );
 
 					scene.add( mesh );
+
+					animate();
 
 				} );
 
@@ -153,17 +149,13 @@
 
 				requestAnimationFrame( animate );
 
-				if ( mesh ) {
+				const delta = clock.getDelta() * 10;
 
-					const delta = clock.getDelta() * 10;
+				depthStep += delta;
 
-					depthStep += delta;
+				const value = depthStep % 5;
 
-					const value = depthStep % 5;
-
-					mesh.material.uniforms[ 'depth' ].value = value;
-
-				}
+				mesh.material.uniforms[ 'depth' ].value = value;
 
 				render();
 				stats.update();

--- a/examples/webgl2_texture2darray_compressed.html
+++ b/examples/webgl2_texture2darray_compressed.html
@@ -6,6 +6,42 @@
 		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
 		<link type="text/css" rel="stylesheet" href="main.css">
 	</head>
+	<script id="vs" type="x-shader/x-vertex">
+	uniform vec2 size;
+	out vec2 vUv;
+
+	void main() {
+
+		gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+
+		// Convert position.xy to 1.0-0.0
+
+		vUv.xy = position.xy / size + 0.5;
+		vUv.y = 1.0 - vUv.y; // original data is upside down
+
+	}
+	</script>
+
+	<script id="fs" type="x-shader/x-fragment">
+	precision highp float;
+	precision highp int;
+	precision highp sampler2DArray;
+
+	uniform sampler2DArray diffuse;
+	in vec2 vUv;
+	uniform int depth;
+
+	out vec4 outColor;
+
+	void main() {
+
+		vec4 color = texture( diffuse, vec3( vUv, depth ) );
+
+		// lighten a bit
+		outColor = vec4( color.rgb + .2, 1.0 );
+
+	}
+	</script>
 	<body>
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - 2D Compressed Texture Array<br />
@@ -80,41 +116,8 @@
 							depth: { value: 55 },
 							size: { value: new THREE.Vector2( planeWidth, planeHeight ) }
 						},
-						vertexShader: /* glsl */`
-							uniform vec2 size;
-							out vec2 vUv;
-
-							void main() {
-
-								gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
-
-								// Convert position.xy to 1.0-0.0
-
-								vUv.xy = position.xy / size + 0.5;
-								vUv.y = 1.0 - vUv.y; // original data is upside down
-
-							}
-						`,
-						fragmentShader: /* glsl */`
-							precision highp float;
-							precision highp int;
-							precision highp sampler2DArray;
-
-							uniform sampler2DArray diffuse;
-							in vec2 vUv;
-							uniform int depth;
-
-							out vec4 outColor;
-
-							void main() {
-
-								vec4 color = texture( diffuse, vec3( vUv, depth ) );
-
-								// lighten a bit
-								outColor = vec4( color.rgb + .2, 1.0 );
-
-							}
-						`,
+						vertexShader: document.getElementById( 'vs' ).textContent.trim(),
+						fragmentShader: document.getElementById( 'fs' ).textContent.trim(),
 						glslVersion: THREE.GLSL3
 					} );
 


### PR DESCRIPTION
Related issue: #XXXX

**Description**

~~Add `glsl` highlight tag for `ShaderMaterial`.~~

Call `animate` function after loaded `.ktx2` file.