### PR TITLE
WebXRManager: Fix hand joints not being initialized when hand connected.

### DIFF
--- a/src/renderers/webxr/WebXRController.js
+++ b/src/renderers/webxr/WebXRController.js
@@ -90,6 +90,48 @@ class WebXRController {
 
 	}
 
+	getHandJoint( hand, inputjoint ) {
+
+		if ( hand.joints[ inputjoint.jointName ] === undefined ) {
+
+			const joint = new Group();
+			joint.matrixAutoUpdate = false;
+			joint.visible = false;
+			hand.joints[ inputjoint.jointName ] = joint;
+
+			hand.add( joint );
+
+		}
+
+		return hand.joints[ inputjoint.jointName ];
+
+	}
+
+	connect( inputSource ) {
+
+		if ( inputSource && inputSource.hand ) {
+
+			const hand = this._hand;
+
+			if ( hand ) {
+
+				for ( const inputjoint of inputSource.hand.values() ) {
+
+					// Initialize hand with joints when connected
+					this.getHandJoint( hand, inputjoint );
+
+				}
+
+			}
+
+		}
+
+		this.dispatchEvent( { type: 'connected', data: inputSource } );
+
+		return this;
+
+	}
+
 	disconnect( inputSource ) {
 
 		this.dispatchEvent( { type: 'disconnected', data: inputSource } );
@@ -137,19 +179,8 @@ class WebXRController {
 					// Update the joints groups with the XRJoint poses
 					const jointPose = frame.getJointPose( inputjoint, referenceSpace );
 
-					if ( hand.joints[ inputjoint.jointName ] === undefined ) {
-
-						// The transform of this joint will be updated with the joint pose on each frame
-						const joint = new Group();
-						joint.matrixAutoUpdate = false;
-						joint.visible = false;
-						hand.joints[ inputjoint.jointName ] = joint;
-						// ??
-						hand.add( joint );
-
-					}
-
-					const joint = hand.joints[ inputjoint.jointName ];
+					// The transform of this joint will be updated with the joint pose on each frame
+					const joint = this.getHandJoint( hand, inputjoint );
 
 					if ( jointPose !== null ) {
 

--- a/src/renderers/webxr/WebXRController.js
+++ b/src/renderers/webxr/WebXRController.js
@@ -90,23 +90,6 @@ class WebXRController {
 
 	}
 
-	getHandJoint( hand, inputjoint ) {
-
-		if ( hand.joints[ inputjoint.jointName ] === undefined ) {
-
-			const joint = new Group();
-			joint.matrixAutoUpdate = false;
-			joint.visible = false;
-			hand.joints[ inputjoint.jointName ] = joint;
-
-			hand.add( joint );
-
-		}
-
-		return hand.joints[ inputjoint.jointName ];
-
-	}
-
 	connect( inputSource ) {
 
 		if ( inputSource && inputSource.hand ) {
@@ -118,7 +101,7 @@ class WebXRController {
 				for ( const inputjoint of inputSource.hand.values() ) {
 
 					// Initialize hand with joints when connected
-					this.getHandJoint( hand, inputjoint );
+					this._getHandJoint( hand, inputjoint );
 
 				}
 
@@ -180,7 +163,7 @@ class WebXRController {
 					const jointPose = frame.getJointPose( inputjoint, referenceSpace );
 
 					// The transform of this joint will be updated with the joint pose on each frame
-					const joint = this.getHandJoint( hand, inputjoint );
+					const joint = this._getHandJoint( hand, inputjoint );
 
 					if ( jointPose !== null ) {
 
@@ -329,6 +312,25 @@ class WebXRController {
 		}
 
 		return this;
+
+	}
+
+	// private method
+
+	_getHandJoint( hand, inputjoint ) {
+
+		if ( hand.joints[ inputjoint.jointName ] === undefined ) {
+
+			const joint = new Group();
+			joint.matrixAutoUpdate = false;
+			joint.visible = false;
+			hand.joints[ inputjoint.jointName ] = joint;
+
+			hand.add( joint );
+
+		}
+
+		return hand.joints[ inputjoint.jointName ];
 
 	}
 

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -364,7 +364,7 @@ class WebXRManager extends EventDispatcher {
 				if ( index >= 0 ) {
 
 					controllerInputSources[ index ] = null;
-					controllers[ index ].dispatchEvent( { type: 'disconnected', data: inputSource } );
+					controllers[ index ].disconnect( inputSource );
 
 				}
 
@@ -410,7 +410,7 @@ class WebXRManager extends EventDispatcher {
 
 				if ( controller ) {
 
-					controller.dispatchEvent( { type: 'connected', data: inputSource } );
+					controller.connect( inputSource );
 
 				}
 


### PR DESCRIPTION
Fixed #24826

**Description**

WebXRController did not initialize the hand joints Object when hand first starts getting tracked ("connected" event). This led hand.joints being `{}` when accessed in the `connected` Event Listener. This MR fixes it by adding the initialization code to controller connect event and calling it from `WebXRManager`.
