### PR TITLE
Fixed typo documentation in Triangle

### DIFF
--- a/docs/api/en/math/Triangle.html
+++ b/docs/api/en/math/Triangle.html
@@ -118,7 +118,7 @@
 		[page:Vector3 point] - The point on the triangle.<br />
 		[page:Vector2 uv1] - The uv coordinate of the triangle's first vertex.<br />
 		[page:Vector2 uv2] - The uv coordinate of the triangle's second vertex.<br />
-		[page:Vector2 uv2] - The uv coordinate of the triangle's third vertex.<br />
+		[page:Vector2 uv3] - The uv coordinate of the triangle's third vertex.<br />
 		[page:Vector2 target] — the result will be copied into this Vector2.<br /><br />
 
 		Returns the uv coordinates for the given point on the triangle.

--- a/docs/api/it/math/Triangle.html
+++ b/docs/api/it/math/Triangle.html
@@ -116,7 +116,7 @@
 		[page:Vector3 point] - Il punto sul triangolo.<br />
 		[page:Vector2 uv1] - La coordinata uv del primo vertice del triangolo.<br />
 		[page:Vector2 uv2] - La coordinata uv del secondo vertice del triangolo.<br />
-		[page:Vector2 uv2] - La coordinata uv del terzo vertice del triangolo.<br />
+		[page:Vector2 uv3] - La coordinata uv del terzo vertice del triangolo.<br />
 		[page:Vector2 target] — il risultato sarà copiato in questo Vector2.<br /><br />
 
 		Restituisce le coordinate uv per il punto specificato sul triangolo.


### PR DESCRIPTION
**Description**
```uv3``` instead of ```uv2``` in [```.getUV```](https://threejs.org/docs/#api/en/math/Triangle.getUV) method

