### PR TITLE
USDZExporter: Add camera support.

### DIFF
--- a/examples/jsm/exporters/USDZExporter.js
+++ b/examples/jsm/exporters/USDZExporter.js
@@ -51,6 +51,10 @@ class USDZExporter {
 
 				}
 
+			} else if ( object.isCamera ) {
+				
+				output += buildCamera( object );
+
 			}
 
 		} );
@@ -552,6 +556,53 @@ function buildColor( color ) {
 function buildVector2( vector ) {
 
 	return `(${ vector.x }, ${ vector.y })`;
+
+}
+
+
+function buildCamera( camera ) {
+
+	const name = camera.name ? camera.name : 'Object_' + camera.id;
+
+	const transform = buildMatrix( camera.matrixWorld );
+
+	if ( camera.matrixWorld.determinant() < 0 ) {
+
+		console.warn( 'THREE.USDZExporter: USDZ does not support negative scales', camera );
+
+	}
+
+	if (camera.isOrthographicCamera) {
+		return `def Camera "${name}"
+		{
+			matrix4d xformOp:transform = ${ transform }
+			uniform token[] xformOpOrder = ["xformOp:transform"]
+	
+			float2 clippingRange = (${camera.near}, ${camera.far})
+			float horizontalAperture = ${(Math.abs(camera.left) + Math.abs(camera.right)) * 10}
+			float verticalAperture = ${(Math.abs(camera.top) + Math.abs(camera.bottom)) * 10}
+			token projection = "orthographic"
+		}
+	
+	`;
+	} else {
+		return `def Camera "${name}"
+		{
+			matrix4d xformOp:transform = ${ transform }
+			uniform token[] xformOpOrder = ["xformOp:transform"]
+	
+			float2 clippingRange = (${camera.near}, ${camera.far})
+			float focalLength = ${camera.getFocalLength()}
+			float focusDistance = ${camera.focus}
+			float horizontalAperture = ${camera.getFilmWidth()}
+			token projection = "perspective"
+			float verticalAperture = ${camera.getFilmHeight()}
+		}
+	
+	`;
+	}
+
+
 
 }
 

--- a/examples/jsm/exporters/USDZExporter.js
+++ b/examples/jsm/exporters/USDZExporter.js
@@ -562,7 +562,7 @@ function buildVector2( vector ) {
 
 function buildCamera( camera ) {
 
-	const name = camera.name ? camera.name : 'Object_' + camera.id;
+	const name = camera.name ? camera.name : 'Camera_' + camera.id;
 
 	const transform = buildMatrix( camera.matrixWorld );
 
@@ -601,8 +601,6 @@ function buildCamera( camera ) {
 	
 	`;
 	}
-
-
 
 }
 

--- a/examples/misc_exporter_usdz.html
+++ b/examples/misc_exporter_usdz.html
@@ -32,6 +32,7 @@
 		</div>
 
 		<a id="link" rel="ar" href="" download="asset.usdz">
+			Download
 			<img id="button" width="100" src="files/arkit.png">
 		</a>
 
@@ -80,6 +81,7 @@
 				scene = new THREE.Scene();
 				scene.background = new THREE.Color( 0xf0f0f0 );
 				scene.environment = pmremGenerator.fromScene( new RoomEnvironment(), 0.04 ).texture;
+				scene.add(camera);
 
 				const loader = new GLTFLoader().setPath( 'models/gltf/DamagedHelmet/glTF/' );
 				loader.load( 'DamagedHelmet.gltf', async function ( gltf ) {
@@ -97,7 +99,7 @@
 					// USDZ
 
 					const exporter = new USDZExporter();
-					const arraybuffer = await exporter.parse( gltf.scene );
+					const arraybuffer = await exporter.parse( scene );
 					const blob = new Blob( [ arraybuffer ], { type: 'application/octet-stream' } );
 
 					const link = document.getElementById( 'link' );

--- a/examples/misc_exporter_usdz.html
+++ b/examples/misc_exporter_usdz.html
@@ -32,7 +32,6 @@
 		</div>
 
 		<a id="link" rel="ar" href="" download="asset.usdz">
-			Download
 			<img id="button" width="100" src="files/arkit.png">
 		</a>
 
@@ -81,7 +80,7 @@
 				scene = new THREE.Scene();
 				scene.background = new THREE.Color( 0xf0f0f0 );
 				scene.environment = pmremGenerator.fromScene( new RoomEnvironment(), 0.04 ).texture;
-				scene.add(camera);
+				scene.add( camera );
 
 				const loader = new GLTFLoader().setPath( 'models/gltf/DamagedHelmet/glTF/' );
 				loader.load( 'DamagedHelmet.gltf', async function ( gltf ) {


### PR DESCRIPTION
**Description**

Adding support for perspective and orthographic cameras *added to the scene* to be exported.

**Discussion**

This requires the camera to be explicitly added to the scene to be picked up, useful when there are multiple cameras, but potentially confusing for basic examples, as adding a camera to the scene is not common Three.js practice. Happy to discuss if there is a better way to allow this.