### PR TITLE
LDraw Loader: Include building step count in model (assemble multiple parts per step)

### DIFF
--- a/docs/examples/en/loaders/LDrawLoader.html
+++ b/docs/examples/en/loaders/LDrawLoader.html
@@ -62,7 +62,7 @@
 				// Optionally, use LDrawUtils.mergeObject() from
 				// 'examples/jsm/utils/LDrawUtils.js' to merge all
 				// geometries by material (it gives better runtime
-				// performance, but construction steps are lost)
+				// performance, but building steps are lost)
 				// group = LDrawUtils.mergeObject( group );
 
 				scene.add( group );
@@ -103,14 +103,9 @@
 		type, its .userData member will contain the following members: <br />
 		In a [page:Group], the userData member will contain: <br />
 		<ul>
-			<li>.numConstructionSteps: Only in the root [page:Group], Indicates total number of construction steps in
-			the model. These can be used to set visibility of objects to show different construction steps, which is
+			<li>.numBuildingSteps: Only in the root [page:Group], Indicates total number of building steps in
+			the model. These can be used to set visibility of objects to show different building steps, which is
 			done in the example.</li>
-			<li>.constructionStep: Indicates the construction index of this step.</li>
-			<li>.numBuildingSteps: Only in the root [page:Group], Indicates total number of building steps in the model.
-			This represents building steps as you would see in assembly instructions, where multiple objects are added
-			together in one step (as segmented by STEP commands in the LDraw model file). This can be used to set
-			visibility of objects to show different building steps.</li>
 			<li>.buildingStep: Indicates the building index of this step.</li>
 			<li>.category: Contains, if not null, the [page:String] category for this piece or model.</li>
 			<li>.keywords: Contains, if not null, an array of [page:String] keywords for this piece or model.</li>

--- a/docs/examples/en/loaders/LDrawLoader.html
+++ b/docs/examples/en/loaders/LDrawLoader.html
@@ -107,6 +107,11 @@
 			the model. These can be used to set visibility of objects to show different construction steps, which is
 			done in the example.</li>
 			<li>.constructionStep: Indicates the construction index of this step.</li>
+			<li>.numBuildingSteps: Only in the root [page:Group], Indicates total number of building steps in the model.
+			This represents building steps as you would see in assembly instructions, where multiple objects are added
+			together in one step (as segmented by STEP commands in the LDraw model file). This can be used to set
+			visibility of objects to show different building steps.</li>
+			<li>.buildingStep: Indicates the building index of this step.</li>
 			<li>.category: Contains, if not null, the [page:String] category for this piece or model.</li>
 			<li>.keywords: Contains, if not null, an array of [page:String] keywords for this piece or model.</li>
 		</ul>

--- a/examples/js/loaders/LDrawLoader.js
+++ b/examples/js/loaders/LDrawLoader.js
@@ -748,6 +748,7 @@
 			let bfcInverted = false;
 			let bfcCull = true;
 			let startingConstructionStep = false;
+			let buildingStep = 0;
 
 			// Parse all line commands
 			for ( let lineIndex = 0; lineIndex < numLines; lineIndex ++ ) {
@@ -887,6 +888,7 @@
 									break;
 								case 'STEP':
 									startingConstructionStep = true;
+									buildingStep ++;
 									break;
 								case 'Author:':
 									author = lp.getToken();
@@ -945,7 +947,8 @@
 							matrix: matrix,
 							fileName: fileName,
 							inverted: bfcInverted,
-							startingConstructionStep: startingConstructionStep
+							startingConstructionStep: startingConstructionStep,
+							buildingStep: buildingStep
 						} );
 						bfcInverted = false;
 						break;
@@ -1247,6 +1250,7 @@
 						const subobjectGroup = subobjectInfo;
 						subobject.matrix.decompose( subobjectGroup.position, subobjectGroup.quaternion, subobjectGroup.scale );
 						subobjectGroup.userData.startingConstructionStep = subobject.startingConstructionStep;
+						subobjectGroup.userData.buildingStep = subobject.buildingStep;
 						subobjectGroup.name = subobject.fileName;
 						loader.applyMaterialsToMesh( subobjectGroup, subobject.colorCode, info.materials );
 						subobjectGroup.userData.colorCode = subobject.colorCode;
@@ -1796,6 +1800,7 @@
 
 					this.applyMaterialsToMesh( group, MAIN_COLOUR_CODE, this.materialLibrary, true );
 					this.computeConstructionSteps( group );
+					this.computeBuildingSteps( group );
 					group.userData.fileName = url;
 					onLoad( group );
 
@@ -1810,6 +1815,7 @@
 
 				this.applyMaterialsToMesh( group, MAIN_COLOUR_CODE, this.materialLibrary, true );
 				this.computeConstructionSteps( group );
+				this.computeBuildingSteps( group );
 				group.userData.fileName = '';
 				onLoad( group );
 
@@ -2253,6 +2259,15 @@
 			} );
 			model.userData.numConstructionSteps = stepNumber + 1;
 
+		}
+		computeBuildingSteps( model ) {
+			
+			// Sets userData.numBuildingSteps number in the root THREE.Group object based on the userdata.buildingStep number in THREE.Group objects.
+			model.userData.buildingStep = model.children[0].userData.buildingStep;
+	
+			// Add one if zero-based
+			model.userData.numBuildingSteps = model.children[model.children.length - 1].userData.buildingStep + (1 - model.userData.buildingStep);
+		
 		}
 
 	}

--- a/examples/js/loaders/LDrawLoader.js
+++ b/examples/js/loaders/LDrawLoader.js
@@ -2234,7 +2234,7 @@
 		}
 		computeBuildingSteps( model ) {
 
-			// Sets userdata.buildingSteps number in THREE.Group objects and userData.numBuildingSteps number in the root THREE.Group object.
+			// Sets userdata.buildingStep number in THREE.Group objects and userData.numBuildingSteps number in the root THREE.Group object.
 
 			let stepNumber = 0;
 			model.traverse( c => {
@@ -2247,7 +2247,7 @@
 
 					}
 
-					c.userData.buildingSteps = stepNumber;
+					c.userData.buildingStep = stepNumber;
 
 				}
 

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -820,6 +820,7 @@ class LDrawParsedCache {
 		let bfcCull = true;
 
 		let startingConstructionStep = false;
+		let buildingStep = 0;
 
 		// Parse all line commands
 		for ( let lineIndex = 0; lineIndex < numLines; lineIndex ++ ) {
@@ -995,6 +996,7 @@ class LDrawParsedCache {
 							case 'STEP':
 
 								startingConstructionStep = true;
+								buildingStep ++;
 
 								break;
 
@@ -1068,7 +1070,8 @@ class LDrawParsedCache {
 						matrix: matrix,
 						fileName: fileName,
 						inverted: bfcInverted,
-						startingConstructionStep: startingConstructionStep
+						startingConstructionStep: startingConstructionStep,
+						buildingStep: buildingStep
 					} );
 
 					bfcInverted = false;
@@ -1390,6 +1393,7 @@ class LDrawPartsGeometryCache {
 					const subobjectGroup = subobjectInfo;
 					subobject.matrix.decompose( subobjectGroup.position, subobjectGroup.quaternion, subobjectGroup.scale );
 					subobjectGroup.userData.startingConstructionStep = subobject.startingConstructionStep;
+					subobjectGroup.userData.buildingStep = subobject.buildingStep;
 					subobjectGroup.name = subobject.fileName;
 
 					loader.applyMaterialsToMesh( subobjectGroup, subobject.colorCode, info.materials );
@@ -1959,6 +1963,7 @@ class LDrawLoader extends Loader {
 
 					this.applyMaterialsToMesh( group, MAIN_COLOUR_CODE, this.materialLibrary, true );
 					this.computeConstructionSteps( group );
+					this.computeBuildingSteps( group );
 					group.userData.fileName = url;
 					onLoad( group );
 
@@ -1977,6 +1982,7 @@ class LDrawLoader extends Loader {
 
 				this.applyMaterialsToMesh( group, MAIN_COLOUR_CODE, this.materialLibrary, true );
 				this.computeConstructionSteps( group );
+				this.computeBuildingSteps( group );
 				group.userData.fileName = '';
 				onLoad( group );
 
@@ -2457,6 +2463,15 @@ class LDrawLoader extends Loader {
 
 		model.userData.numConstructionSteps = stepNumber + 1;
 
+	}
+	computeBuildingSteps( model ) {
+
+		// Sets userData.numBuildingSteps number in the root THREE.Group object based on the userdata.buildingStep number in THREE.Group objects.
+		model.userData.buildingStep = model.children[0].userData.buildingStep;
+
+		// Add one if zero-based
+		model.userData.numBuildingSteps = model.children[model.children.length - 1].userData.buildingStep + (1 - model.userData.buildingStep);
+	
 	}
 
 }

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -2436,7 +2436,7 @@ class LDrawLoader extends Loader {
 
 	computeBuildingSteps( model ) {
 
-		// Sets userdata.buildingSteps number in Group objects and userData.numBuildingSteps number in the root Group object.
+		// Sets userdata.buildingStep number in Group objects and userData.numBuildingSteps number in the root Group object.
 
 		let stepNumber = 0;
 
@@ -2450,7 +2450,7 @@ class LDrawLoader extends Loader {
 
 				}
 
-				c.userData.buildingSteps = stepNumber;
+				c.userData.buildingStep = stepNumber;
 
 			}
 

--- a/examples/webgl_loader_ldraw.html
+++ b/examples/webgl_loader_ldraw.html
@@ -110,8 +110,8 @@
 					displayLines: true,
 					conditionalLines: true,
 					smoothNormals: true,
-					constructionStep: 0,
-					noConstructionSteps: 'No steps.',
+					buildingStep: 0,
+					noBuildingSteps: 'No steps.',
 					flatColors: false,
 					mergeModel: false
 				};
@@ -153,8 +153,8 @@
 
 					} else if ( c.isGroup ) {
 
-						// Hide objects with construction step > gui setting
-						c.visible = c.userData.constructionStep <= guiData.constructionStep;
+						// Hide objects with building step > gui setting
+						c.visible = c.userData.buildingStep <= guiData.buildingStep;
 
 					}
 
@@ -237,7 +237,7 @@
 
 						scene.add( model );
 
-						guiData.constructionStep = model.userData.numConstructionSteps - 1;
+						guiData.buildingStep = model.userData.numBuildingSteps - 1;
 
 						updateObjectsVisibility();
 
@@ -300,13 +300,13 @@
 
 				} );
 
-				if ( model.userData.numConstructionSteps > 1 ) {
+				if ( model.userData.numBuildingSteps > 1 ) {
 
-					gui.add( guiData, 'constructionStep', 0, model.userData.numConstructionSteps - 1 ).step( 1 ).name( 'Construction step' ).onChange( updateObjectsVisibility );
+					gui.add( guiData, 'buildingStep', 0, model.userData.numBuildingSteps - 1 ).step( 1 ).name( 'Building step' ).onChange( updateObjectsVisibility );
 
 				} else {
 
-					gui.add( guiData, 'noConstructionSteps' ).name( 'Construction step' ).onChange( updateObjectsVisibility );
+					gui.add( guiData, 'noBuildingSteps' ).name( 'Building step' ).onChange( updateObjectsVisibility );
 
 				}
 


### PR DESCRIPTION
Adds building steps to the LDraw Loader.

`numBuildingSteps` and `buildingStep` properties are included in the model to count and index the `STEP` commands in the LDraw model file. This allows 'assembling' multiple parts together in one step, as you would see in an instruction booklet. The visibility of objects could be changed this way instead of with construction steps, which seem to represent each object as a separate step.

Example for _car.ldr_Packed.mpd_:

```
userData: {
   buildingStep: 0
   category: null
   constructionStep: 0
   keywords: null
   numBuildingSteps: 8
   numConstructionSteps: 57
}
```

In CAD software for editing LDraw models, '_building step_' appears to be the common name for this. Sources:
[http://www.holly-wood.it/mlcad/basic6-en.html](http://www.holly-wood.it/mlcad/basic6-en.html)
[http://www.melkert.net/LDCad/docs/basicEdit](http://www.melkert.net/LDCad/docs/basicEdit)
[https://www.leocad.org/docs/tutorial1.html](https://www.leocad.org/docs/tutorial1.html)
