### PR TITLE
WebXRManager: Honor WebXR native layer scaling.

### DIFF
--- a/docs/api/en/renderers/webxr/WebXRManager.html
+++ b/docs/api/en/renderers/webxr/WebXRManager.html
@@ -103,6 +103,8 @@
 		<p>
 		[page:Float framebufferScaleFactor] — The framebuffer scale factor to set.<br /><br />
 
+		[page:String limited] — Whether the framebuffer scale factor should be reduced to the native limit if the value ends up being higher than the device's capabilities. Default is `false`.<br /><br />
+
 		Specifies the scaling factor to use when determining the size of the framebuffer when rendering to a XR device.
 		The value is relative to the default XR device display resolution. Default is `1`. A value of `0.5` would specify
 		a framebuffer with 50% of the display's native resolution.

--- a/docs/api/en/renderers/webxr/WebXRManager.html
+++ b/docs/api/en/renderers/webxr/WebXRManager.html
@@ -99,11 +99,10 @@
 		Specifies the amount of foveation used by the XR compositor for the layer. Must be a value between `0` and `1`.
 		</p>
 
-		<h3>[method:undefined setFramebufferScaleFactor]( [param:Float framebufferScaleFactor] )</h3>
+		<h3>[method:undefined setFramebufferScaleFactor]( [param:Float framebufferScaleFactor], [param:Boolean limited] )</h3>
 		<p>
-		[page:Float framebufferScaleFactor] — The framebuffer scale factor to set.<br /><br />
-
-		[page:String limited] — Whether the framebuffer scale factor should be reduced to the native limit if the value ends up being higher than the device's capabilities. Default is `false`.<br /><br />
+		[page:Float factor] — The framebuffer scale factor to set.<br />
+		[page:Boolean limited] — Whether the framebuffer scale factor should be reduced to the native limit if the value ends up being higher than the device's capabilities. Default is `false`.<br /><br />
 
 		Specifies the scaling factor to use when determining the size of the framebuffer when rendering to a XR device.
 		The value is relative to the default XR device display resolution. Default is `1`. A value of `0.5` would specify

--- a/docs/api/en/renderers/webxr/WebXRManager.html
+++ b/docs/api/en/renderers/webxr/WebXRManager.html
@@ -99,7 +99,7 @@
 		Specifies the amount of foveation used by the XR compositor for the layer. Must be a value between `0` and `1`.
 		</p>
 
-		<h3>[method:undefined setFramebufferScaleFactor]( [param:Float framebufferScaleFactor], [param:Boolean limited] )</h3>
+		<h3>[method:undefined setFramebufferScaleFactor]( [param:Float factor], [param:Boolean limited] )</h3>
 		<p>
 		[page:Float factor] — The framebuffer scale factor to set.<br />
 		[page:Boolean limited] — Whether the framebuffer scale factor should be reduced to the native limit if the value ends up being higher than the device's capabilities. Default is `false`.<br /><br />

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -26,6 +26,7 @@ class WebXRManager extends EventDispatcher {
 
 		let session = null;
 		let framebufferScaleFactor = 1.0;
+		let limitWithNativeFramebufferScaleFactor = false;
 
 		let referenceSpace = null;
 		let referenceSpaceType = 'local-floor';
@@ -182,9 +183,10 @@ class WebXRManager extends EventDispatcher {
 
 		}
 
-		this.setFramebufferScaleFactor = function ( value ) {
+		this.setFramebufferScaleFactor = function ( value, limited = false ) {
 
 			framebufferScaleFactor = value;
+			limitWithNativeFramebufferScaleFactor = limited;
 
 			if ( scope.isPresenting === true ) {
 
@@ -262,6 +264,18 @@ class WebXRManager extends EventDispatcher {
 				if ( attributes.xrCompatible !== true ) {
 
 					await gl.makeXRCompatible();
+
+				}
+
+				if ( limitWithNativeFramebufferScaleFactor && XRWebGLLayer.getNativeFramebufferScaleFactor ) {
+
+					const nativeFramebufferScaleFactor = XRWebGLLayer.getNativeFramebufferScaleFactor( session );
+
+					if ( nativeFramebufferScaleFactor < framebufferScaleFactor ) {
+
+						framebufferScaleFactor = nativeFramebufferScaleFactor;
+
+					}
 
 				}
 

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -267,7 +267,7 @@ class WebXRManager extends EventDispatcher {
 
 				}
 
-				if ( limitWithNativeFramebufferScaleFactor && XRWebGLLayer.getNativeFramebufferScaleFactor ) {
+				if ( limitWithNativeFramebufferScaleFactor === true && XRWebGLLayer.getNativeFramebufferScaleFactor ) {
 
 					const nativeFramebufferScaleFactor = XRWebGLLayer.getNativeFramebufferScaleFactor( session );
 


### PR DESCRIPTION
**Description**

If native WebGL layer scaling retrieval function exists ( https://developer.mozilla.org/en-US/docs/Web/API/XRWebGLLayer/getNativeFramebufferScaleFactor ), use it to update the scaling value on initialization.

![Untitled drawing (3)](https://user-images.githubusercontent.com/294042/198940907-b5d9a949-9f95-4e6f-8868-f68bf87fe91e.png)

