### PR TITLE
ObjectLoader: Call `onError()` if no metadata found in JSON.

### DIFF
--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -101,7 +101,7 @@ class ObjectLoader extends Loader {
 
 			if ( metadata === undefined || metadata.type === undefined || metadata.type.toLowerCase() === 'geometry' ) {
 
-				if ( onError !== undefined ) onError( new Error('THREE.ObjectLoader: Can\'t load ' + url) );
+				if ( onError !== undefined ) onError( new Error( 'THREE.ObjectLoader: Can\'t load ' + url ) );
 
 				console.error( 'THREE.ObjectLoader: Can\'t load ' + url );
 				return;

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -101,6 +101,8 @@ class ObjectLoader extends Loader {
 
 			if ( metadata === undefined || metadata.type === undefined || metadata.type.toLowerCase() === 'geometry' ) {
 
+				if ( onError !== undefined ) onError( new Error('THREE.ObjectLoader: Can\'t load ' + url) );
+
 				console.error( 'THREE.ObjectLoader: Can\'t load ' + url );
 				return;
 


### PR DESCRIPTION
**Description**

While the ObjectLoader calls onError if the json parsing has failed, it does not if no metadata has been found in the json.

It does print out an error in the console, but that cannot still be caught at the application level.

So for instance in Polygonjs's node editor, if someone tries loads a .json that was not exported from a threejs scene, no error can be displayed.


