### PR TITLE
GLTFLoader: Honor extras in light definitions.

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -576,6 +576,8 @@ class GLTFLightsExtension {
 
 		lightNode.decay = 2;
 
+		assignExtrasToUserData( lightNode, lightDef );
+
 		if ( lightDef.intensity !== undefined ) lightNode.intensity = lightDef.intensity;
 
 		lightNode.name = parser.createUniqueName( lightDef.name || ( 'light_' + lightIndex ) );


### PR DESCRIPTION
Fixed #24839.

**Description**

Ensures `GLTFLoader` honors the `extras` field and assign the respective data to the light's `userData` property.
