### PR TITLE
Fix typo in en/fundamentals.html

### DIFF
--- a/manual/en/fundamentals.html
+++ b/manual/en/fundamentals.html
@@ -177,7 +177,7 @@ cube, prism, frustum.</p>
 <p><img src="../resources/frustum-3d.svg" width="500" class="threejs_center"></p>
 <p>The height of the near and far planes are determined by the field of view.
 The width of both planes is determined by the field of view and the aspect.</p>
-<p>Anything inside the defined frustum will be be drawn. Anything outside
+<p>Anything inside the defined frustum will be drawn. Anything outside
 will not.</p>
 <p>The camera defaults to looking down the -Z axis with +Y up. We'll put our cube
 at the origin so we need to move the camera back a little from the origin


### PR DESCRIPTION
Word `be` was repeated.


Edited with the GitHub editor, looks like it added a newline at the bottom...