### PR TITLE
Fix typos in fundamentals.html

### DIFF
--- a/manual/en/fundamentals.html
+++ b/manual/en/fundamentals.html
@@ -210,7 +210,7 @@ be specified using standard CSS style 6 digit hex color values.</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">const material = new THREE.MeshBasicMaterial({color: 0x44aa88});
 </pre>
 <p>We then create a <a href="/docs/#api/en/objects/Mesh"><code class="notranslate" translate="no">Mesh</code></a>. A <a href="/docs/#api/en/objects/Mesh"><code class="notranslate" translate="no">Mesh</code></a> in three represents the combination
-of a three things</p>
+of three things</p>
 <ol>
 <li>A <code class="notranslate" translate="no">Geometry</code> (the shape of the object)</li>
 <li>A <a href="/docs/#api/en/materials/Material"><code class="notranslate" translate="no">Material</code></a> (how to draw the object, shiny or flat, what color, what texture(s) to apply. Etc.)</li>

--- a/manual/en/fundamentals.html
+++ b/manual/en/fundamentals.html
@@ -177,7 +177,7 @@ cube, prism, frustum.</p>
 <p><img src="../resources/frustum-3d.svg" width="500" class="threejs_center"></p>
 <p>The height of the near and far planes are determined by the field of view.
 The width of both planes is determined by the field of view and the aspect.</p>
-<p>Anything inside the defined frustum will be be drawn. Anything outside
+<p>Anything inside the defined frustum will be drawn. Anything outside
 will not.</p>
 <p>The camera defaults to looking down the -Z axis with +Y up. We'll put our cube
 at the origin so we need to move the camera back a little from the origin


### PR DESCRIPTION
Fixes 2 typos in the manual

(edited with the GH editor, apologies for the extra newline at the end)