### PR TITLE
WebGLAttributes: Call `onUploadCallback()` again after updating a buffer.

### DIFF
--- a/src/renderers/webgl/WebGLAttributes.js
+++ b/src/renderers/webgl/WebGLAttributes.js
@@ -112,6 +112,8 @@ function WebGLAttributes( gl, capabilities ) {
 
 		}
 
+		attribute.onUploadCallback();
+
 	}
 
 	//


### PR DESCRIPTION
When a `BufferAttribute` is updated (using `needsUpdate = true`) it is uploaded to VRAM a second time. This PR calls `onUploadCallback` for each upload. Previously, it was only called after the first initial upload.