### PR TITLE
DragControls has recursive raycasting option

### DIFF
--- a/docs/examples/en/controls/DragControls.html
+++ b/docs/examples/en/controls/DragControls.html
@@ -90,13 +90,18 @@
 		<p>
 			Whether or not the controls are enabled.
 		</p>
+	
+	        <h3>[property:Boolean recursive]</h3>
+		<p>
+			Whether the drag controls makes children of the objects draggable. Default is `true`.
+		</p>
 
 		<h3>[property:Boolean transformGroup]</h3>
 		<p>
 			This option only works if the [page:DragControls.objects] array contains a single draggable group object.
 			If set to `true`, [name] does not transform individual objects but the entire group. Default is `false`.
 		</p>
-
+	
 		<h2>Methods</h2>
 
 		<p>See the base [page:EventDispatcher] class for common methods.</p>

--- a/examples/jsm/controls/DragControls.js
+++ b/examples/jsm/controls/DragControls.js
@@ -99,7 +99,7 @@ class DragControls extends EventDispatcher {
 				_intersections.length = 0;
 
 				_raycaster.setFromCamera( _pointer, _camera );
-				_raycaster.intersectObjects( _objects, true, _intersections );
+				_raycaster.intersectObjects( _objects, scope.recursive, _intersections );
 
 				if ( _intersections.length > 0 ) {
 
@@ -151,7 +151,7 @@ class DragControls extends EventDispatcher {
 			_intersections.length = 0;
 
 			_raycaster.setFromCamera( _pointer, _camera );
-			_raycaster.intersectObjects( _objects, true, _intersections );
+			_raycaster.intersectObjects( _objects, scope.recursive, _intersections );
 
 			if ( _intersections.length > 0 ) {
 
@@ -206,6 +206,7 @@ class DragControls extends EventDispatcher {
 
 		this.enabled = true;
 		this.transformGroup = false;
+		this.recursive = true;
 
 		this.activate = activate;
 		this.deactivate = deactivate;


### PR DESCRIPTION
Related issue: #24915

**Description**

Drag controls currently enforces a recursive raycasting option when deciding which object should be dragged.

In some scene graphs the users want to make the ancestor nodes draggable while their children stay non-draggable. 

Further explanation in related issue linked above.