### PR TITLE
CubeCamera: Orient cameras right-side-up.

### DIFF
--- a/src/cameras/CubeCamera.js
+++ b/src/cameras/CubeCamera.js
@@ -2,7 +2,8 @@ import { NoToneMapping } from '../constants.js';
 import { Object3D } from '../core/Object3D.js';
 import { PerspectiveCamera } from './PerspectiveCamera.js';
 
-const fov = 90, aspect = 1;
+const fov = - 90; // negative fov is not an error
+const aspect = 1;
 
 class CubeCamera extends Object3D {
 
@@ -16,37 +17,37 @@ class CubeCamera extends Object3D {
 
 		const cameraPX = new PerspectiveCamera( fov, aspect, near, far );
 		cameraPX.layers = this.layers;
-		cameraPX.up.set( 0, - 1, 0 );
+		cameraPX.up.set( 0, 1, 0 );
 		cameraPX.lookAt( 1, 0, 0 );
 		this.add( cameraPX );
 
 		const cameraNX = new PerspectiveCamera( fov, aspect, near, far );
 		cameraNX.layers = this.layers;
-		cameraNX.up.set( 0, - 1, 0 );
+		cameraNX.up.set( 0, 1, 0 );
 		cameraNX.lookAt( - 1, 0, 0 );
 		this.add( cameraNX );
 
 		const cameraPY = new PerspectiveCamera( fov, aspect, near, far );
 		cameraPY.layers = this.layers;
-		cameraPY.up.set( 0, 0, 1 );
+		cameraPY.up.set( 0, 0, - 1 );
 		cameraPY.lookAt( 0, 1, 0 );
 		this.add( cameraPY );
 
 		const cameraNY = new PerspectiveCamera( fov, aspect, near, far );
 		cameraNY.layers = this.layers;
-		cameraNY.up.set( 0, 0, - 1 );
+		cameraNY.up.set( 0, 0, 1 );
 		cameraNY.lookAt( 0, - 1, 0 );
 		this.add( cameraNY );
 
 		const cameraPZ = new PerspectiveCamera( fov, aspect, near, far );
 		cameraPZ.layers = this.layers;
-		cameraPZ.up.set( 0, - 1, 0 );
+		cameraPZ.up.set( 0, 1, 0 );
 		cameraPZ.lookAt( 0, 0, 1 );
 		this.add( cameraPZ );
 
 		const cameraNZ = new PerspectiveCamera( fov, aspect, near, far );
 		cameraNZ.layers = this.layers;
-		cameraNZ.up.set( 0, - 1, 0 );
+		cameraNZ.up.set( 0, 1, 0 );
 		cameraNZ.lookAt( 0, 0, - 1 );
 		this.add( cameraNZ );
 


### PR DESCRIPTION
Fixes #3702, based on [this](https://github.com/mrdoob/three.js/issues/3702#issuecomment-1261505718) suggestion.

`CubeCamera` currently sets its cameras "upside down", by setting a negative up-axis prior to calling `camera.lookAt()`.

https://github.com/mrdoob/three.js/blob/6671e7c4b7544207bc4e6c7bc9fcf5fc88bbb4e6/src/cameras/CubeCamera.js#L17-L20

Doing so results in a mirroring of the rendered output in both the x-axis and y-axis.

This mirroring is required to accommodate the WebGL texture cube handedness and texture-origin conventions.

However, the same mirroring effect can be achieved by setting a negative `fov`.

The advantage of applying a negative `fov` instead of rotating the camera is that sprites rendered by a `CubeCamera` will now render right-side-up.

Sprites which have `rotation` of zero always render right-side-up in camera space.

//

Note: There will always be artifacts when a sprite straddles an edge of the top or bottom cube face. This is unavoidable.
