### PR TITLE
Documentation: Remove exception for fog and background color

### DIFF
--- a/docs/manual/en/introduction/Color-management.html
+++ b/docs/manual/en/introduction/Color-management.html
@@ -191,14 +191,6 @@ THREE.ColorManagement.legacyMode = false;
 
 	<blockquote>
 		<p>
-			⚠️ <i><b>WARNING:</b> [page:Scene.fog], [page:Scene.background], and [page:WebGLRenderer.setClearColor]
-			are exceptions to the rule. These properties are unaffected by [page:WebGLRenderer.outputEncoding]
-			and so must store RGB components in the renderer's <u>output</u> color space.</i>
-		</p>
-	</blockquote>
-
-	<blockquote>
-		<p>
 			⚠️ <i><b>WARNING:</b> Many formats for 3D models do not correctly or consistently
 			define color space information. While three.js attempts to handle most cases, problems
 			are common with older file formats. For best results, use glTF 2.0 ([page:GLTFLoader])

--- a/docs/manual/fr/introduction/Color-management.html
+++ b/docs/manual/fr/introduction/Color-management.html
@@ -191,14 +191,6 @@ THREE.ColorManagement.legacyMode = false;
 
 	<blockquote>
 		<p>
-			⚠️ <i><b>ATTENTION:</b> [page:Scene.fog], [page:Scene.background], et [page:WebGLRenderer.setClearColor]
-			sont des exceptions à la règle. Ces propriétés ne sont pas affectées par [page:WebGLRenderer.outputEncoding]
-			et doivent donc stocker les composantes RGB dans l'espace colorimétrique de <u>sortie</u> du moteur de rendu.</i>
-		</p>
-	</blockquote>
-
-	<blockquote>
-		<p>
 			⚠️ <i><b>ATTENTION:</b> Plusieurs formats de modèles 3D ne définissent par correctement ou de manière cohérente
 			les informations des espaces colorimétriques. Malgré le fait que three.js tente de gérer la plupart des situations, les problèmes
 			sont communs avec les formats de fichiers plus anciens. Pour de meilleurs résultats, utilisez glTF 2.0 ([page:GLTFLoader])

--- a/docs/manual/it/introduction/Color-management.html
+++ b/docs/manual/it/introduction/Color-management.html
@@ -231,19 +231,6 @@
 			<p>
 				⚠️
 				<i
-					><b>ATTENZIONE:</b> [page:Scene.fog], [page:Scene.background], e
-					[page:WebGLRenderer.setClearColor] sono eccezioni alla regola. Queste
-					proprietà non sono interessate da [page:WebGLRenderer.outputEncoding]
-					e quindi devono memorizzare i componenti RGB nello spazio colore di
-					<u>output</u> del renderer.</i
-				>
-			</p>
-		</blockquote>
-
-		<blockquote>
-			<p>
-				⚠️
-				<i
 					><b>ATTENZIONE:</b> Molti formati per modelli 3D non definiscono
 					correttamente o in modo coerente le informazioni sullo spazio colore.
 					Sebbene three.js tenti di gestire la maggior parte dei casi, i

--- a/docs/manual/pt-br/introduction/Color-management.html
+++ b/docs/manual/pt-br/introduction/Color-management.html
@@ -191,14 +191,6 @@ THREE.ColorManagement.legacyMode = false;
 
 	<blockquote>
 		<p>
-			⚠️ <i><b>AVISO:</b> [page:Scene.fog], [page:Scene.background] e [page:WebGLRenderer.setClearColor]
-			são exceções à regra. Essas propriedades não são afetadas por [page:WebGLRenderer.outputEncoding]
-			e, portanto, devem armazenar componentes RGB na <u>saída</u> do renderizador do espaço de cores.</i>
-		</p>
-	</blockquote>
-
-	<blockquote>
-		<p>
 			⚠️ <i><b>AVISO:</b> Muitos formatos para modelos 3D não funcionam de forma correta ou consistente
 			na definição das informações do espaço de cores. Enquanto o three.js tenta lidar com a maioria dos casos, problemas
 			são comuns com formatos de arquivo mais antigos. Para melhores resultados, use glTF 2.0 ([page:GLTFLoader])


### PR DESCRIPTION
Related:

- https://github.com/mrdoob/three.js/pull/23937

**Description**

The *Color Management* guide previously called out fog, background color, and clear color as exceptions to the general rule that three.js APIs accepting `THREE.Color` instances assume RGB components in Linear-sRGB color space. For these properties, the choice had depended on `renderer.outputEncoding` and whether or not post-processing was used. The exception has been resolved with #23937, and these colors are no longer a special case when `ColorManagement.legacyMode = false` is configured (non-default in three.js, default in R3F).
