### PR TITLE
Examples: Add clipping at horizon to sky example

### DIFF
--- a/examples/jsm/objects/Sky.js
+++ b/examples/jsm/objects/Sky.js
@@ -69,6 +69,8 @@ Sky.SkyShader = {
 		varying vec3 vBetaM;
 		varying float vSunE;
 
+		#include <clipping_planes_pars_vertex>
+
 		// constants for atmospheric scattering
 		const float e = 2.71828182845904523536028747135266249775724709369995957;
 		const float pi = 3.141592653589793238462643383279502884197169;
@@ -107,7 +109,10 @@ Sky.SkyShader = {
 			vec4 worldPosition = modelMatrix * vec4( position, 1.0 );
 			vWorldPosition = worldPosition.xyz;
 
-			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+			#include <begin_vertex>
+			#include <project_vertex>
+			#include <clipping_planes_vertex>
+
 			gl_Position.z = gl_Position.w; // set z to camera.far
 
 			vSunDirection = normalize( sunPosition );
@@ -137,6 +142,8 @@ Sky.SkyShader = {
 
 		uniform float mieDirectionalG;
 		uniform vec3 up;
+
+		#include <clipping_planes_pars_fragment>
 
 		const vec3 cameraPos = vec3( 0.0, 0.0, 0.0 );
 
@@ -168,6 +175,8 @@ Sky.SkyShader = {
 		}
 
 		void main() {
+
+			#include <clipping_planes_fragment>
 
 			vec3 direction = normalize( vWorldPosition - cameraPos );
 
@@ -211,7 +220,6 @@ Sky.SkyShader = {
 
 			#include <tonemapping_fragment>
 			#include <encodings_fragment>
-
 		}`
 
 };

--- a/examples/webgl_shaders_sky.html
+++ b/examples/webgl_shaders_sky.html
@@ -44,6 +44,12 @@
 				// Add Sky
 				sky = new Sky();
 				sky.scale.setScalar( 450000 );
+				// Clip at the horizon
+				sky.material.clippingPlanes = [
+					new THREE.Plane( new THREE.Vector3( 0, 1, 0 ), 0 )
+				];
+				// This must be set, otherwise the clipping won't work
+				sky.material.clipping = true;
 				scene.add( sky );
 
 				sun = new THREE.Vector3();
@@ -57,7 +63,8 @@
 					mieDirectionalG: 0.7,
 					elevation: 2,
 					azimuth: 180,
-					exposure: renderer.toneMappingExposure
+					exposure: renderer.toneMappingExposure,
+					clipped: false
 				};
 
 				function guiChanged() {
@@ -76,6 +83,7 @@
 					uniforms[ 'sunPosition' ].value.copy( sun );
 
 					renderer.toneMappingExposure = effectController.exposure;
+					renderer.localClippingEnabled = effectController.clipped;
 					renderer.render( scene, camera );
 
 				}
@@ -86,9 +94,10 @@
 				gui.add( effectController, 'rayleigh', 0.0, 4, 0.001 ).onChange( guiChanged );
 				gui.add( effectController, 'mieCoefficient', 0.0, 0.1, 0.001 ).onChange( guiChanged );
 				gui.add( effectController, 'mieDirectionalG', 0.0, 1, 0.001 ).onChange( guiChanged );
-				gui.add( effectController, 'elevation', 0, 90, 0.1 ).onChange( guiChanged );
+				gui.add( effectController, 'elevation', - 5, 90, 0.1 ).onChange( guiChanged );
 				gui.add( effectController, 'azimuth', - 180, 180, 0.1 ).onChange( guiChanged );
 				gui.add( effectController, 'exposure', 0, 1, 0.0001 ).onChange( guiChanged );
+				gui.add( effectController, 'clipped', false ).onChange( guiChanged );
 
 				guiChanged();
 
@@ -110,6 +119,7 @@
 				renderer.outputEncoding = THREE.sRGBEncoding;
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				renderer.toneMappingExposure = 0.5;
+				renderer.localClippingEnabled = true;
 				document.body.appendChild( renderer.domElement );
 
 				const controls = new OrbitControls( camera, renderer.domElement );


### PR DESCRIPTION
Signed-off-by: Jonathan Stichbury <2533428+nzjony@users.noreply.github.com>

**Description**

Adds clipping at the horizon boundary. We use the Sky object in an internal project and we would like to clip at the horizon boundary.

<img width="990" alt="Screenshot 2022-11-10 at 3 31 30 PM" src="https://user-images.githubusercontent.com/2533428/201118689-6d1b2376-0a1c-4735-afa3-40818c402cd5.png">


