### PR TITLE
Examples: Improve post processing in normalmap demo.

### DIFF
--- a/examples/webgl_materials_normalmap.html
+++ b/examples/webgl_materials_normalmap.html
@@ -143,7 +143,9 @@
 				effectColor.uniforms[ 'powRGB' ].value.set( 1.4, 1.45, 1.45 );
 				effectColor.uniforms[ 'mulRGB' ].value.set( 1.1, 1.1, 1.1 );
 
-				composer = new EffectComposer( renderer );
+				const renderTarget = new THREE.WebGLRenderTarget( window.innerWidth, window.innerHeight, { type: THREE.HalfFloatType, depthTexture: new THREE.DepthTexture() } );
+
+				composer = new EffectComposer( renderer, renderTarget );
 
 				composer.addPass( renderModel );
 				composer.addPass( effectFXAA );


### PR DESCRIPTION
Related issue: -

**Description**

When updating `webgl_materials_normalmap`, I have noticed some visual glitches. The ears flicker (looks like z-fighting) and the unsigned byte type of the render target causes color banding when applying `GammaCorrectionShader`.

Both issues can be fixed by using a depth texture and half float render targets instead.
