### PR TITLE
Update JSFiddle links in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,8 +28,8 @@ Steps to reproduce the behavior:
 
 ***Live example***
 
-* [jsfiddle-latest-release](https://jsfiddle.net/hbfpj2wv/2/)
-* [jsfiddle-dev](https://jsfiddle.net/086yzvgc/)
+* [jsfiddle-latest-release](https://jsfiddle.net/g3atw6k5/)
+* [jsfiddle-dev](https://jsfiddle.net/eL7gqyhd/)
 
 **Expected behavior**
 


### PR DESCRIPTION
Related issue: -

**Description**

Update JSFiddle links in the issue template, including changing `var` to `let` and `const` and using `three/addons` import.