### PR TITLE
WebGLUtils: Move `RedFormat` to WebGL 2 section.

### DIFF
--- a/docs/api/en/constants/Textures.html
+++ b/docs/api/en/constants/Textures.html
@@ -156,7 +156,9 @@
 
 		[page:constant AlphaFormat] discards the red, green and blue components and reads just the alpha component.<br /><br />
 
-		[page:constant RedFormat] discards the green and blue components and reads just the red component.<br /><br />
+		[page:constant RedFormat] discards the green and blue components and reads just the red component.
+		(can only be used with a WebGL 2 rendering context).
+		<br /><br />
 
 		[page:constant RedIntegerFormat] discards the green and blue components and reads just the red component.
 		The texels are read as integers instead of floating point.

--- a/src/renderers/webgl/WebGLUtils.js
+++ b/src/renderers/webgl/WebGLUtils.js
@@ -43,7 +43,6 @@ function WebGLUtils( gl, extensions, capabilities ) {
 		if ( p === LuminanceAlphaFormat ) return gl.LUMINANCE_ALPHA;
 		if ( p === DepthFormat ) return gl.DEPTH_COMPONENT;
 		if ( p === DepthStencilFormat ) return gl.DEPTH_STENCIL;
-		if ( p === RedFormat ) return gl.RED;
 
 		// @deprecated since r137
 
@@ -74,6 +73,7 @@ function WebGLUtils( gl, extensions, capabilities ) {
 
 		// WebGL2 formats.
 
+		if ( p === RedFormat ) return gl.RED;
 		if ( p === RedIntegerFormat ) return gl.RED_INTEGER;
 		if ( p === RGFormat ) return gl.RG;
 		if ( p === RGIntegerFormat ) return gl.RG_INTEGER;


### PR DESCRIPTION
Related issue: -

**Description**

`RedFormat` [is only available in WebGL2](https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/Constants#additional_constants_defined_webgl_2).