### PR TITLE
(WIP) KTX2Loader: Replace manual transcoder path with dynamic imports

### DIFF
--- a/examples/js/libs/basis/basis_transcoder.js
+++ b/examples/js/libs/basis/basis_transcoder.js
@@ -13,9 +13,4 @@ var Module=typeof BASIS!=="undefined"?BASIS:{};var readyPromiseResolve,readyProm
 }
 );
 })();
-if (typeof exports === 'object' && typeof module === 'object')
-  module.exports = BASIS;
-else if (typeof define === 'function' && define['amd'])
-  define([], function() { return BASIS; });
-else if (typeof exports === 'object')
-  exports["BASIS"] = BASIS;
+export { BASIS };

--- a/examples/webgl_loader_texture_ktx2.html
+++ b/examples/webgl_loader_texture_ktx2.html
@@ -76,9 +76,7 @@
 			};
 
 			// Samples: sample_etc1s.ktx2, sample_uastc.ktx2, sample_uastc_zstd.ktx2
-			const loader = new KTX2Loader()
-				.setTranscoderPath( 'js/libs/basis/' )
-				.detectSupport( renderer );
+			const loader = new KTX2Loader().detectSupport( renderer );
 
 			animate();
 


### PR DESCRIPTION
**Related**

- https://github.com/mrdoob/three.js/issues/24729

**Description**

This is a "proof-of-concept", removing the requirement for users to configure DRACOLoader and KTX2Loader with static decoder paths. Instead, we'd use dynamic imports. This approach _does not work_ within `three/examples/js`, and so this would be blocked on the move to `three/addons` / `three/examples/jsm`.

To my understanding, modern browsers and bundlers now support dynamic imports of ES Modules pretty well. That solves part of the problem. But we also need to import the `.wasm` binaries, and it appears browsers and bundlers diverge on how to do that:

- Browsers require us to load WASM with fetch() ([MDN](https://developer.mozilla.org/en-US/docs/WebAssembly/Loading_and_running))
- Bundlers expect us to load WASM with import() ([parcel](https://en.parceljs.org/webAssembly.html), [webpack](https://webpack.js.org/api/module-methods/), [vite](https://vitejs.dev/guide/features.html#webassembly))

Perhaps that's not a problem, as long as we can detect which case we're in? I'm not sure how to do that yet.

The goal would be — From a CDN, relative paths should be resolved automatically. For developers copying files around manually on disk, they'll need to specify a path. For developers who are using a bundler, the presence of (even conditional) dynamic imports should cause the bundler to put the JS and WASM in the correct place within the final build. Or that's the hope ... the next step would be testing this against major bundlers, if we want to go down this path.

/cc @gkjohnson 