### PR TITLE
InstancedBufferGeometry: Remove unused argument from `super.toJSON()`

### DIFF
--- a/src/core/InstancedBufferGeometry.js
+++ b/src/core/InstancedBufferGeometry.js
@@ -31,7 +31,7 @@ class InstancedBufferGeometry extends BufferGeometry {
 
 	toJSON() {
 
-		const data = super.toJSON( this );
+		const data = super.toJSON();
 
 		data.instanceCount = this.instanceCount;
 


### PR DESCRIPTION
Its base class `.toJSON()` takes no argument:

https://github.com/mrdoob/three.js/blob/735d376fc58a3b78d58fdb8dacd47bd6fd4b2d69/src/core/BufferGeometry.js#L856-L867
