### PR TITLE
Docs: Improve OrbitControls page.

### DIFF
--- a/docs/examples/en/controls/OrbitControls.html
+++ b/docs/examples/en/controls/OrbitControls.html
@@ -96,6 +96,7 @@
 		<p>
 			The damping inertia used if [page:.enableDamping] is set to true.<br> Note that for this to work, you must
 			call [page:.update] () in your animation loop.
+			Default is 0.05. 
 		</p>
 
 		<h3>[property:HTMLDOMElement domElement]</h3>


### PR DESCRIPTION


Related issue: #XXXX

**Description**

after having a hard time searching for a good value to start fine-tuning  the dumping factor I found that the default value is 0.05, I was using way higher numbers. Hope this value in the documentation saves people time

