### PR TITLE
WebGLState: assign boolean to `currentPremultipledAlpha`

### DIFF
--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -718,7 +718,7 @@ function WebGLState( gl, extensions, capabilities ) {
 		}
 
 		currentBlending = blending;
-		currentPremultipledAlpha = null;
+		currentPremultipledAlpha = false;
 
 	}
 


### PR DESCRIPTION
should assign false, instead of null, to `currentPremultipledAlpha` bc its strictly inequality checked against a bool

https://github.com/mrdoob/three.js/blob/ac30ce09d328ebc398840947718f8d9fff536466/src/renderers/webgl/WebGLState.js#L613-L615



