### PR TITLE
PCDLoader: Remove unnecessary escape character.

### DIFF
--- a/examples/jsm/loaders/PCDLoader.js
+++ b/examples/jsm/loaders/PCDLoader.js
@@ -123,7 +123,7 @@ class PCDLoader extends Loader {
 
 			// remove comments
 
-			PCDheader.str = PCDheader.str.replace( /\#.*/gi, '' );
+			PCDheader.str = PCDheader.str.replace( /#.*/gi, '' );
 
 			// parse
 


### PR DESCRIPTION
PCDLoader.js

"message": "Unnecessary escape character: \\#."