### PR TITLE
Move ShaderNode internals to a Node class

### DIFF
--- a/examples/jsm/nodes/shadernode/ShaderNode.js
+++ b/examples/jsm/nodes/shadernode/ShaderNode.js
@@ -166,9 +166,17 @@ class ShaderNodeInternal extends Node {
 
 	}
 
-	construct( builder ) {
+	build( builder ) {
 
-		return this.call( {}, builder );
+		const output = this.call( {}, builder );
+
+		if ( output === undefined ) {
+
+			return '';
+
+		}
+
+		return output.build( builder );
 
 	}
 

--- a/examples/jsm/nodes/shadernode/ShaderNode.js
+++ b/examples/jsm/nodes/shadernode/ShaderNode.js
@@ -1,3 +1,4 @@
+import Node from '../core/Node.js';
 import ArrayElementNode from '../utils/ArrayElementNode.js';
 import ConvertNode from '../utils/ConvertNode.js';
 import JoinNode from '../utils/JoinNode.js';
@@ -147,31 +148,35 @@ const ShaderNodeImmutable = function ( NodeClass, ...params ) {
 
 };
 
+class ShaderNodeInternal extends Node {
+
+	constructor( jsFunc ) {
+
+		super();
+
+		this._jsFunc = jsFunc;
+
+	}
+
+	call( inputs, builder ) {
+
+		inputs = nodeObjects( inputs );
+
+		return nodeObject( this._jsFunc( inputs, builder ) );
+
+	}
+
+	construct( builder ) {
+
+		return this.call( {}, builder );
+
+	}
+
+}
+
 const ShaderNodeScript = function ( jsFunc ) {
 
-	// @TODO: Move this to Node extended class
-
-	const self = {
-
-		build: ( builder ) => {
-
-			self.call( {}, builder );
-
-			return '';
-
-		},
-
-		call: ( inputs, builder ) => {
-
-			inputs = nodeObjects( inputs );
-
-			return nodeObject( jsFunc( inputs, builder ) );
-
-		}
-
-	};
-
-	return self;
+	return new ShaderNodeInternal( jsFunc );
 
 };
 

--- a/examples/jsm/nodes/shadernode/ShaderNode.js
+++ b/examples/jsm/nodes/shadernode/ShaderNode.js
@@ -166,17 +166,17 @@ class ShaderNodeInternal extends Node {
 
 	}
 
-	build( builder ) {
+	generate( builder, output ) {
 
-		const output = this.call( {}, builder );
+		const nodeCall = this.call( {}, builder );
 
-		if ( output === undefined ) {
+		if ( nodeCall === undefined ) {
 
 			return '';
 
 		}
 
-		return output.build( builder );
+		return builder.format( nodeCall.build( builder ), nodeCall.getNodeType( builder ), output );
 
 	}
 

--- a/examples/webgpu_materials.html
+++ b/examples/webgpu_materials.html
@@ -146,14 +146,14 @@
 
 				// Custom ShaderNode(no inputs) > Approach 2
 
-				const desaturateVoidShaderNode = new ShaderNode( () => {
+				const desaturateNoInputsShaderNode = new ShaderNode( () => {
 
 					return dot( vec3( 0.299, 0.587, 0.114 ), Nodes.texture( texture ).xyz );
 
 				} );
 
 				material = new Nodes.MeshBasicNodeMaterial();
-				material.colorNode = desaturateVoidShaderNode;
+				material.colorNode = desaturateNoInputsShaderNode;
 				materials.push( material );
 
 				// Custom WGSL ( desaturate filter )

--- a/examples/webgpu_materials.html
+++ b/examples/webgpu_materials.html
@@ -144,6 +144,18 @@
 				material.colorNode = desaturateShaderNode.call( { color: new Nodes.TextureNode( texture ) } );
 				materials.push( material );
 
+				// Custom ShaderNode(no inputs) > Approach 2
+
+				const desaturateVoidShaderNode = new ShaderNode( () => {
+
+					return dot( vec3( 0.299, 0.587, 0.114 ), Nodes.texture( texture ).xyz );
+
+				} );
+
+				material = new Nodes.MeshBasicNodeMaterial();
+				material.colorNode = desaturateVoidShaderNode;
+				materials.push( material );
+
 				// Custom WGSL ( desaturate filter )
 
 				const desaturateWGSLNode = new Nodes.FunctionNode( `


### PR DESCRIPTION
Related issue: -

**Description**

Currently something like `material.colorNode = new ShaderNode( ... )` does not work in WebGL nodes (tested that), because `new ShaderNode( ... )` does not have an `isNode` property (and also does not have a cache key implementation).
This PR fixes that and implements the @sunag's suggestion in the comment `// @TODO: Move this to Node extended class`.