### PR TITLE
Fix BufferGeometry computeBoundingSphere() with `NaN`

### DIFF
--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -424,6 +424,8 @@ class BufferGeometry extends EventDispatcher {
 			for ( let i = 0, il = position.count; i < il; i ++ ) {
 
 				_vector.fromBufferAttribute( position, i );
+				
+				if ( isNaN( _vector.x ) || isNaN( _vector.y ) || isNaN( _vector.z ) ) continue;
 
 				maxRadiusSq = Math.max( maxRadiusSq, center.distanceToSquared( _vector ) );
 


### PR DESCRIPTION
Related issue: #18515

Today I used `PCDLoader` to load `xx.pcd`, I got this error:

```
react_devtools_backend.js:4026 THREE.BufferGeometry.computeBoundingSphere(): Computed radius is NaN. The "position" attribute is likely to have NaN values. 
```

After searching, I found the problem.

```
//PCDLoader.js
{
    ...
    geometry.computeBoundingSphere();
    ...
}


//BufferGeometry.js
computeBoundingSphere() {
    ...
    
    for (let i = 0, il = position.count; i < il; i++) {
        _vector.fromBufferAttribute(position, i); // <-- please note here!!!
        maxRadiusSq = Math.max(maxRadiusSq, center.distanceToSquared(_vector));
    }
    
    ...
    this.boundingSphere.radius = Math.sqrt(maxRadiusSq);
    if (isNaN(this.boundingSphere.radius)) {
        console.error('THREE.BufferGeometry.computeBoundingSphere(): Computed radius is NaN. The "position" attribute is likely to have NaN values.', this);
    }
}
```



<br>

Uh-oh...

```
_vector.fromBufferAttribute(position, i);
```

**We know there may be some `nan point` in `xx.pcd`**

**So, `_vector`  may be is  `new Vector3( NaN, NaN, NaN )`**

```
maxRadiusSq = Math.max(maxRadiusSq, center.distanceToSquared(_vector));
...
this.boundingSphere.radius = Math.sqrt(maxRadiusSq);
```

* `center.distanceToSquared(_vector)` value may be `NaN`
* Math.sqrt(maxRadiusSq) .. `NaN`
* this.boundingSphere.radius ... `NaN`
* console.error('THREE.BufferGeo...



<br>

**Can I modify `BufferGeometry.js` to avoid this?**

```diff
//BufferGeometry.js

for (let i = 0, il = position.count; i < il; i++) {
    _vector.fromBufferAttribute(position, i);
+   if (isNaN(_vector.x) || isNaN(_vector.y) || isNaN(_vector.z)) continue;
    maxRadiusSq = Math.max(maxRadiusSq, center.distanceToSquared(_vector));
}
```

