### PR TITLE
Fix `NodeBuilder.format()`

### DIFF
--- a/examples/jsm/nodes/core/NodeBuilder.js
+++ b/examples/jsm/nodes/core/NodeBuilder.js
@@ -386,9 +386,11 @@ class NodeBuilder {
 
 	}
 
-	getTypeFromLength( length ) {
+	getTypeFromLength( length, componentType = 'float' ) {
 
-		return typeFromLength.get( length );
+		const baseType = typeFromLength.get( length );
+		const prefix = componentType === 'float' ? '' : componentType[ 0 ];
+		return prefix + baseType;
 
 	}
 
@@ -800,15 +802,19 @@ class NodeBuilder {
 
 		}
 
+		const fromTypeComponentType = this.getComponentType( fromType );
+
 		if ( toTypeLength === 4 ) { // toType is vec4-like
 
-			return `${ this.getType( toType ) }( ${ this.format( snippet, fromType, 'vec3' ) }, 1.0 )`;
+			const vec3Like = this.getTypeFromLength( 3, fromTypeComponentType );
+			return `${ this.getType( toType ) }( ${ this.format( snippet, fromType, vec3Like ) }, 1.0 )`;
 
 		}
 
 		if ( fromTypeLength === 2 ) { // fromType is vec2-like and toType is vec3-like
 
-			return `${ this.getType( toType ) }( ${ this.format( snippet, fromType, 'vec2' ) }, 0.0 )`;
+			const vec2Like = this.getTypeFromLength( 2, fromTypeComponentType );
+			return `${ this.getType( toType ) }( ${ this.format( snippet, fromType, vec2Like ) }, 0.0 )`;
 
 		}
 

--- a/examples/jsm/nodes/core/NodeBuilder.js
+++ b/examples/jsm/nodes/core/NodeBuilder.js
@@ -365,6 +365,8 @@ class NodeBuilder {
 
 		type = this.getVectorType( type );
 
+		if ( type === 'float' || type === 'bool' || type === 'int' || type === 'uint' ) return type;
+
 		const componentType = /(b|i|u|)(vec|mat)([2-4])/.exec( type );
 
 		if ( componentType === null ) return null;


### PR DESCRIPTION
Related issue: -

**Description**

~~Fix `NodeBuilder.format()` by using proper formats instead of `vec2` and `vec3` - otherwise things like `vec4( instanceIndex )` break in WGSL.~~ No, that just seems to be a mistake in my code.

/ping @sunag 
