### PR TITLE
Color: Update the default color space settings

### DIFF
--- a/src/math/Color.js
+++ b/src/math/Color.js
@@ -1,6 +1,6 @@
 import { clamp, euclideanModulo, lerp } from './MathUtils.js';
 import { ColorManagement, SRGBToLinear, LinearToSRGB } from './ColorManagement.js';
-import { SRGBColorSpace, LinearSRGBColorSpace } from '../constants.js';
+import { SRGBColorSpace } from '../constants.js';
 
 const _colorKeywords = { 'aliceblue': 0xF0F8FF, 'antiquewhite': 0xFAEBD7, 'aqua': 0x00FFFF, 'aquamarine': 0x7FFFD4, 'azure': 0xF0FFFF,
 	'beige': 0xF5F5DC, 'bisque': 0xFFE4C4, 'black': 0x000000, 'blanchedalmond': 0xFFEBCD, 'blue': 0x0000FF, 'blueviolet': 0x8A2BE2,
@@ -117,7 +117,7 @@ class Color {
 
 	}
 
-	setRGB( r, g, b, colorSpace = LinearSRGBColorSpace ) {
+	setRGB( r, g, b, colorSpace = ColorManagement.workingColorSpace ) {
 
 		this.r = r;
 		this.g = g;
@@ -129,7 +129,7 @@ class Color {
 
 	}
 
-	setHSL( h, s, l, colorSpace = LinearSRGBColorSpace ) {
+	setHSL( h, s, l, colorSpace = ColorManagement.workingColorSpace ) {
 
 		// h,s,l ranges are in 0.0 - 1.0
 		h = euclideanModulo( h, 1 );
@@ -369,7 +369,7 @@ class Color {
 
 	}
 
-	getHSL( target, colorSpace = LinearSRGBColorSpace ) {
+	getHSL( target, colorSpace = ColorManagement.workingColorSpace ) {
 
 		// h,s,l ranges are in 0.0 - 1.0
 
@@ -414,7 +414,7 @@ class Color {
 
 	}
 
-	getRGB( target, colorSpace = LinearSRGBColorSpace ) {
+	getRGB( target, colorSpace = ColorManagement.workingColorSpace ) {
 
 		ColorManagement.fromWorkingColorSpace( toComponents( this, _rgb ), colorSpace );
 


### PR DESCRIPTION
For certain methods, the default color space was hardwired to `LinearSRGBColorSpace`.

I think the default should be the current working color space.

/ping @donmccurdy 