### PR TITLE
Fix OperatorNode

### DIFF
--- a/examples/jsm/nodes/core/NodeBuilder.js
+++ b/examples/jsm/nodes/core/NodeBuilder.js
@@ -365,6 +365,8 @@ class NodeBuilder {
 
 		type = this.getVectorType( type );
 
+		if ( type === 'float' || type === 'bool' || type === 'int' || type === 'uint' ) return type;
+
 		const componentType = /(b|i|u|)(vec|mat)([2-4])/.exec( type );
 
 		if ( componentType === null ) return null;
@@ -386,9 +388,11 @@ class NodeBuilder {
 
 	}
 
-	getTypeFromLength( length ) {
+	getTypeFromLength( length, componentType = 'float' ) {
 
-		return typeFromLength.get( length );
+		const baseType = typeFromLength.get( length );
+		const prefix = componentType === 'float' ? '' : componentType[ 0 ];
+		return prefix + baseType;
 
 	}
 
@@ -409,6 +413,22 @@ class NodeBuilder {
 	getVectorFromMatrix( type ) {
 
 		return type.replace( 'mat', 'vec' );
+
+	}
+
+	changeComponentType( type, newComponentType ) {
+
+		return this.getTypeFromLength( this.getTypeLength( type ), newComponentType );
+
+	}
+
+	getIntegerType( type ) {
+
+		const componentType = this.getComponentType( type );
+
+		if ( componentType === 'int' || componentType === 'uint' ) return type;
+
+		return this.changeComponentType( type, 'int' );
 
 	}
 

--- a/examples/jsm/nodes/core/NodeBuilder.js
+++ b/examples/jsm/nodes/core/NodeBuilder.js
@@ -13,7 +13,6 @@ export const shaderStages = [ ...defaultShaderStages, 'compute' ];
 export const vector = [ 'x', 'y', 'z', 'w' ];
 
 const typeFromLength = new Map();
-typeFromLength.set( 1, 'float' );
 typeFromLength.set( 2, 'vec2' );
 typeFromLength.set( 3, 'vec3' );
 typeFromLength.set( 4, 'vec4' );
@@ -390,6 +389,7 @@ class NodeBuilder {
 
 	getTypeFromLength( length, componentType = 'float' ) {
 
+		if ( length === 1 ) return componentType;
 		const baseType = typeFromLength.get( length );
 		const prefix = componentType === 'float' ? '' : componentType[ 0 ];
 		return prefix + baseType;

--- a/examples/jsm/nodes/math/OperatorNode.js
+++ b/examples/jsm/nodes/math/OperatorNode.js
@@ -47,7 +47,7 @@ class OperatorNode extends TempNode {
 
 		} else if ( op === '&' || op === '|' || op === '^' || op === '>>' || op === '<<' ) {
 
-			return 'int';
+			return builder.getIntegerType( typeA );
 
 		} else if ( op === '==' || op === '&&' || op === '||' || op === '^^' ) {
 
@@ -123,6 +123,11 @@ class OperatorNode extends TempNode {
 					typeA = typeB = 'float';
 
 				}
+
+			} else if ( op === '>>' || op === '<<' ) {
+
+				typeA = type;
+				typeB = builder.changeComponentType( typeB, 'uint' );
 
 			} else if ( builder.isMatrix( typeA ) && builder.isVector( typeB ) ) {
 


### PR DESCRIPTION
Related issue: -

**Description**

Fix usages of `shiftRight` and `shiftLeft` in WGSL - otherwise they do not work because WGSL requires the second argument to be `u32` or `vecN<u32>`.