### PR TITLE
FileLoader: Add `X-File-Size` header support.

### DIFF
--- a/src/loaders/FileLoader.js
+++ b/src/loaders/FileLoader.js
@@ -109,7 +109,9 @@ class FileLoader extends Loader {
 
 					const callbacks = loading[ url ];
 					const reader = response.body.getReader();
-					// Extra header added because of: https://serverfault.com/questions/482875/why-does-nginx-remove-content-length-header-for-chunked-content
+
+					// Nginx needs X-File-Size check
+					// https://serverfault.com/questions/482875/why-does-nginx-remove-content-length-header-for-chunked-content
 					const contentLength = response.headers.get( 'Content-Length' ) || response.headers.get( 'X-File-Size' );
 					const total = contentLength ? parseInt( contentLength ) : 0;
 					const lengthComputable = total !== 0;

--- a/src/loaders/FileLoader.js
+++ b/src/loaders/FileLoader.js
@@ -109,7 +109,8 @@ class FileLoader extends Loader {
 
 					const callbacks = loading[ url ];
 					const reader = response.body.getReader();
-					const contentLength = response.headers.get( 'Content-Length' );
+					// Extra header added because of: https://serverfault.com/questions/482875/why-does-nginx-remove-content-length-header-for-chunked-content
+					const contentLength = response.headers.get( 'Content-Length' ) || response.headers.get( 'X-File-Size' );
 					const total = contentLength ? parseInt( contentLength ) : 0;
 					const lengthComputable = total !== 0;
 					let loaded = 0;


### PR DESCRIPTION
Fixed #24962 

**Description**

The PR adds _X-File-Size_ header support to FileLoader. This header is used if _Content-Length_ is stripped by a proxy/server . For example: https://serverfault.com/questions/482875/why-does-nginx-remove-content-length-header-for-chunked-content

