### PR TITLE
OrbitControls: Enable keyboard rotation with modifier keys.

### DIFF
--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -601,22 +601,42 @@ class OrbitControls extends EventDispatcher {
 			switch ( event.code ) {
 
 				case scope.keys.UP:
-					pan( 0, scope.keyPanSpeed );
+					if ( event.ctrlKey || event.metaKey || event.shiftKey ) {
+						rotateUp( 2 * Math.PI * scope.rotateSpeed /
+								  scope.domElement.clientHeight );
+					} else {
+						pan( 0, scope.keyPanSpeed );
+					}
 					needsUpdate = true;
 					break;
 
 				case scope.keys.BOTTOM:
-					pan( 0, - scope.keyPanSpeed );
+					if ( event.ctrlKey || event.metaKey || event.shiftKey ) {
+						rotateUp( -2 * Math.PI * scope.rotateSpeed /
+								  scope.domElement.clientHeight );
+					} else {					
+						pan( 0, - scope.keyPanSpeed );
+					}
 					needsUpdate = true;
 					break;
 
 				case scope.keys.LEFT:
-					pan( scope.keyPanSpeed, 0 );
+					if ( event.ctrlKey || event.metaKey || event.shiftKey ) {
+						rotateLeft( 2 * Math.PI * scope.rotateSpeed /
+								  scope.domElement.clientHeight );
+					} else {					
+						pan( scope.keyPanSpeed, 0 );
+					}
 					needsUpdate = true;
 					break;
 
 				case scope.keys.RIGHT:
-					pan( - scope.keyPanSpeed, 0 );
+					if ( event.ctrlKey || event.metaKey || event.shiftKey ) {
+						rotateLeft( -2 * Math.PI * scope.rotateSpeed /
+								  scope.domElement.clientHeight );
+					} else {					
+						pan( - scope.keyPanSpeed, 0 );
+					}
 					needsUpdate = true;
 					break;
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -601,42 +601,62 @@ class OrbitControls extends EventDispatcher {
 			switch ( event.code ) {
 
 				case scope.keys.UP:
+
 					if ( event.ctrlKey || event.metaKey || event.shiftKey ) {
-						rotateUp( 2 * Math.PI * scope.rotateSpeed /
-								  scope.domElement.clientHeight );
+
+						rotateUp( 2 * Math.PI * scope.rotateSpeed / scope.domElement.clientHeight );
+
 					} else {
+
 						pan( 0, scope.keyPanSpeed );
+
 					}
+
 					needsUpdate = true;
 					break;
 
 				case scope.keys.BOTTOM:
+
 					if ( event.ctrlKey || event.metaKey || event.shiftKey ) {
-						rotateUp( -2 * Math.PI * scope.rotateSpeed /
-								  scope.domElement.clientHeight );
-					} else {					
+
+						rotateUp( - 2 * Math.PI * scope.rotateSpeed / scope.domElement.clientHeight );
+
+					} else {
+
 						pan( 0, - scope.keyPanSpeed );
+
 					}
+
 					needsUpdate = true;
 					break;
 
 				case scope.keys.LEFT:
+
 					if ( event.ctrlKey || event.metaKey || event.shiftKey ) {
-						rotateLeft( 2 * Math.PI * scope.rotateSpeed /
-								  scope.domElement.clientHeight );
-					} else {					
+
+						rotateLeft( 2 * Math.PI * scope.rotateSpeed / scope.domElement.clientHeight );
+
+					} else {
+
 						pan( scope.keyPanSpeed, 0 );
+
 					}
+
 					needsUpdate = true;
 					break;
 
 				case scope.keys.RIGHT:
+
 					if ( event.ctrlKey || event.metaKey || event.shiftKey ) {
-						rotateLeft( -2 * Math.PI * scope.rotateSpeed /
-								  scope.domElement.clientHeight );
-					} else {					
+
+						rotateLeft( - 2 * Math.PI * scope.rotateSpeed / scope.domElement.clientHeight );
+
+					} else {
+
 						pan( - scope.keyPanSpeed, 0 );
+
 					}
+
 					needsUpdate = true;
 					break;
 


### PR DESCRIPTION
This implements camera rotation via keyboard control, when either CTRL, Shift, or Alt are pressed, similar to how the left mouse button can be used to pan with modifier keys.