### PR TITLE
Added zooming to cursor position in OrbitControls

### DIFF
--- a/docs/examples/en/controls/OrbitControls.html
+++ b/docs/examples/en/controls/OrbitControls.html
@@ -171,6 +171,11 @@ controls.keys = {
 			How far you can orbit vertically, upper limit. Range is 0 to Math.PI radians, and default is Math.PI.
 		</p>
 
+		<h3>[property:Float maxTargetDistanceFromOrigin]</h3>
+		<p>
+			How far you can target be from origin, default is `Infinity`. This is mainly used with [page:.enableZoomToCursor] and MapControls to prevent target from moving to huge coordinates while zooming to cursor.
+		</p>
+
 		<h3>[property:Float maxZoom]</h3>
 		<p>
 			How far you can zoom out ( [page:OrthographicCamera] only ). Default is Infinity.

--- a/docs/examples/en/controls/OrbitControls.html
+++ b/docs/examples/en/controls/OrbitControls.html
@@ -133,6 +133,11 @@
 			Enable or disable zooming (dollying) of the camera.
 		</p>
 
+		<h3>[property:Boolean enableZoomToCursor]</h3>
+		<p>
+			Set to `true`, camera is zoomed to mouse cursor (or touch pinch on mobile) position. Set to `false`, zoom as dolly. Default is `false`.
+		</p>
+
 		<h3>[property:Float keyPanSpeed]</h3>
 		<p>
 			How fast to pan the camera when the keyboard is used. Default is 7.0 pixels per keypress.

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -1296,8 +1296,8 @@ class OrbitControls extends EventDispatcher {
 			if(!scope.enableZoomToCursor) return;
 			scope.cursorScreen.copy(
 				new Vector3(
-					((event.clientX - scope.domElement.offsetLeft + window.scrollX) / scope.domElement.clientWidth) * 2 - 1,
-					- ((event.clientY - scope.domElement.offsetTop + window.scrollY) / scope.domElement.clientHeight) * 2 + 1,
+					((event.clientX - scope.domElement.getBoundingClientRect().left) / scope.domElement.clientWidth) * 2 - 1,
+					- ((event.clientY - scope.domElement.getBoundingClientRect().top) / scope.domElement.clientHeight) * 2 + 1,
 					scope.target.clone().project(scope.object).z
 				)
 			);
@@ -1316,8 +1316,8 @@ class OrbitControls extends EventDispatcher {
 			if(touch !== undefined){
 				scope.cursorScreen.copy(
 					new Vector3(
-						((touch.x - scope.domElement.offsetLeft + window.scrollX) / scope.domElement.clientWidth) * 2 - 1,
-						- ((touch.y - scope.domElement.offsetTop + window.scrollY) / scope.domElement.clientHeight) * 2 + 1,
+						((touch.x - scope.domElement.getBoundingClientRect().left) / scope.domElement.clientWidth) * 2 - 1,
+						- ((touch.y - scope.domElement.getBoundingClientRect().top) / scope.domElement.clientHeight) * 2 + 1,
 						scope.target.clone().project(scope.object).z
 					)
 				);	

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -95,8 +95,29 @@ class OrbitControls extends EventDispatcher {
 		// the target DOM element for key events
 		this._domElementKeyEvents = null;
 
+		// ZOOM-TO-CURSOR
+		this.cursorScreen = new Vector3();
+		this.cursorWorld = new Vector3();
+		this.enableZoomToCursor = false;
+		this.adjustmentAfterZoomNeeded = false;
+		//
+
 		//
 		// public methods
+		//
+
+		// ZOOM-TO-CURSOR
+		this.adjustAfterZoom = function () {
+			const newCursorWorld = new Vector3(scope.cursorScreen.x, scope.cursorScreen.y, scope.target.clone().project(scope.object).z).clone().unproject(scope.object);
+			const delta = new Vector3().subVectors(scope.cursorWorld, newCursorWorld);
+		
+			scope.object.position.add(delta);
+			scope.target.add(delta);
+		}
+
+		this.setCursorWorld = function () {
+			scope.cursorWorld.copy(new Vector3(scope.cursorScreen.x, scope.cursorScreen.y, scope.target.clone().project(scope.object).z).unproject(scope.object));
+		}
 		//
 
 		this.getPolarAngle = function () {
@@ -274,6 +295,13 @@ class OrbitControls extends EventDispatcher {
 					8 * ( 1 - lastQuaternion.dot( scope.object.quaternion ) ) > EPS ) {
 
 					scope.dispatchEvent( _changeEvent );
+
+					// ZOOM-TO-CURSOR
+					if(scope.enableZoomToCursor && scope.adjustmentAfterZoomNeeded){
+						scope.adjustmentAfterZoomNeeded = false;
+						this.adjustAfterZoom();
+					}
+					//
 
 					lastPosition.copy( scope.object.position );
 					lastQuaternion.copy( scope.object.quaternion );
@@ -461,6 +489,9 @@ class OrbitControls extends EventDispatcher {
 		}();
 
 		function dollyOut( dollyScale ) {
+			// ZOOM-TO-CURSOR
+			if(scope.enableZoomToCursor) scope.setCursorWorld();
+			//
 
 			if ( scope.object.isPerspectiveCamera ) {
 
@@ -479,9 +510,18 @@ class OrbitControls extends EventDispatcher {
 
 			}
 
+			// ZOOM-TO-CURSOR
+			if(scope.enableZoomToCursor){
+				if( scope.object.isOrthographicCamera) scope.adjustAfterZoom();
+				else if(scope.object.isPerspectiveCamera) scope.adjustmentAfterZoomNeeded = true;
+			}
+			//
 		}
 
 		function dollyIn( dollyScale ) {
+			// ZOOM-TO-CURSOR
+			if(scope.enableZoomToCursor) scope.setCursorWorld();
+			//
 
 			if ( scope.object.isPerspectiveCamera ) {
 
@@ -500,6 +540,12 @@ class OrbitControls extends EventDispatcher {
 
 			}
 
+			// ZOOM-TO-CURSOR
+			if(scope.enableZoomToCursor){
+				if( scope.object.isOrthographicCamera) scope.adjustAfterZoom();
+				else if(scope.object.isPerspectiveCamera) scope.adjustmentAfterZoomNeeded = true;
+			}
+			//
 		}
 
 		//
@@ -1208,6 +1254,43 @@ class OrbitControls extends EventDispatcher {
 		scope.domElement.addEventListener( 'pointerdown', onPointerDown );
 		scope.domElement.addEventListener( 'pointercancel', onPointerCancel );
 		scope.domElement.addEventListener( 'wheel', onMouseWheel, { passive: false } );
+
+		// ZOOM-TO-CURSOR
+		scope.domElement.addEventListener( 'mousemove', event => {
+			if(!scope.enableZoomToCursor) return;
+			scope.cursorScreen.copy(
+				new Vector3(
+					((event.clientX) / scope.domElement.clientWidth) * 2 - 1,
+					- ((event.clientY) / scope.domElement.clientHeight) * 2 + 1,
+					scope.target.clone().project(scope.object).z
+				)
+			);
+		});
+
+		const handleTouch = event => {
+			const touches = event.touches;
+			let touch;
+			if(touches.length === 1){
+				touch = new Vector2(touches[0].clientX, touches[0].clientY);		
+			}
+			else if(touches.length === 2){
+				touch = new Vector2((touches[0].clientX + touches[1].clientX) / 2, (touches[0].clientY + touches[1].clientY) / 2);
+			}
+
+			if(touch !== undefined){
+				scope.cursorScreen.copy(
+					new Vector3(
+						((touch.x) / scope.domElement.clientWidth) * 2 - 1,
+						- ((touch.y) / scope.domElement.clientHeight) * 2 + 1,
+						scope.target.clone().project(scope.object).z
+					)
+				);	
+			}
+		};
+
+		scope.domElement.addEventListener( 'touchstart', handleTouch);
+		scope.domElement.addEventListener( 'touchmove', handleTouch);
+		//
 
 		// force an update at start
 

--- a/examples/misc_controls_map.html
+++ b/examples/misc_controls_map.html
@@ -120,6 +120,7 @@
 
 				const gui = new GUI();
 				gui.add( controls, 'screenSpacePanning' );
+				gui.add( controls, 'enableZoomToCursor' );
 
 			}
 

--- a/examples/misc_controls_orbit.html
+++ b/examples/misc_controls_orbit.html
@@ -39,6 +39,8 @@
 
 			import * as THREE from 'three';
 
+			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
+
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 
 			let camera, controls, scene, renderer;
@@ -111,6 +113,10 @@
 				//
 
 				window.addEventListener( 'resize', onWindowResize );
+
+
+				const gui = new GUI();
+				gui.add( controls, 'enableZoomToCursor' );
 
 			}
 


### PR DESCRIPTION
Related #17145

Proposing solution for zooming to mouse cursor/mobile touch pinch position in OrbitControls.

I know about #17145, but it seems to have some problems and limitations, don't know why it is still not implemented.

Working both for PerspectiveCamera and OrthographicCamera.
Working for both OrbitControls and MapControls.
Working both for mouse and touch events.
Working with and withount damping enabled.
No problem with division by 0.

No need to limit maxPolarAngle to Math.PI / 3

To enable zooming to cursor: controls.enableZoomToCursor = true, default is false.