### PR TITLE
Matrix3: Added 2D transform methods

### DIFF
--- a/docs/api/en/math/Matrix3.html
+++ b/docs/api/en/math/Matrix3.html
@@ -132,6 +132,65 @@ zAxis = (c, f, i)
 
 		</p>
 
+
+
+
+		<h3>[method:this makeRotation]( [param:Float theta] )</h3>
+		<p>
+		[page:Float theta] — Rotation angle in radians. Positive values rotate counterclockwise.<br /><br />
+
+		Sets this matrix as a 2D rotational transformation by [page:Float theta] radians.
+		The resulting matrix will be:
+		<code>
+cos(&theta;) -sin(&theta;) 0
+sin(&theta;) cos(&theta;)  0
+0      0       1
+		</code>
+		</p>
+
+		<h3>[method:this makeScale]( [param:Float x], [param:Float y] )</h3>
+		<p>
+		[page:Float x] - the amount to scale in the X axis.<br />
+		[page:Float y] - the amount to scale in the Y axis.<br />
+
+		Sets this matrix as a 2D scale transform:
+		<code>
+x, 0, 0,
+0, y, 0,
+0, 0, 1
+		</code>
+		</p>
+
+		<h3>[method:this makeTranslation]( [param:Float x], [param:Float y] )</h3>
+		<p>
+		[page:Float x] - the amount to translate in the X axis.<br />
+		[page:Float y] - the amount to translate in the Y axis.<br />
+
+		Sets this matrix as a 2D translation transform:
+		<code>
+1, 0, x,
+0, 1, y,
+0, 0, 1
+		</code>
+		</p>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 		<h3>[method:this multiply]( [param:Matrix3 m] )</h3>
 		<p>Post-multiplies this matrix by [page:Matrix3 m].</p>
 
@@ -173,7 +232,7 @@ zAxis = (c, f, i)
 		[page:Float ty] - offset y<br />
 		[page:Float sx] - repeat x<br />
 		[page:Float sy] - repeat y<br />
-		[page:Float rotation] - rotation (in radians)<br />
+		[page:Float rotation] - rotation, in radians. Positive values rotate counterclockwise<br />
 		[page:Float cx] - center x of rotation<br />
 		[page:Float cy] - center y of rotation<br /><br />
 

--- a/docs/api/en/math/Matrix3.html
+++ b/docs/api/en/math/Matrix3.html
@@ -129,11 +129,7 @@ zAxis = (c, f, i)
 0, 1, 0
 0, 0, 1
 		</code>
-
 		</p>
-
-
-
 
 		<h3>[method:this makeRotation]( [param:Float theta] )</h3>
 		<p>
@@ -173,23 +169,6 @@ x, 0, 0,
 0, 0, 1
 		</code>
 		</p>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 		<h3>[method:this multiply]( [param:Matrix3 m] )</h3>
 		<p>Post-multiplies this matrix by [page:Matrix3 m].</p>

--- a/src/math/Matrix3.js
+++ b/src/math/Matrix3.js
@@ -231,12 +231,11 @@ class Matrix3 {
 
 	}
 
+	//
+
 	scale( sx, sy ) {
 
-		const te = this.elements;
-
-		te[ 0 ] *= sx; te[ 3 ] *= sx; te[ 6 ] *= sx;
-		te[ 1 ] *= sy; te[ 4 ] *= sy; te[ 7 ] *= sy;
+		this.premultiply( _m3.makeScale( sx, sy ) );
 
 		return this;
 
@@ -244,21 +243,7 @@ class Matrix3 {
 
 	rotate( theta ) {
 
-		const c = Math.cos( theta );
-		const s = Math.sin( theta );
-
-		const te = this.elements;
-
-		const a11 = te[ 0 ], a12 = te[ 3 ], a13 = te[ 6 ];
-		const a21 = te[ 1 ], a22 = te[ 4 ], a23 = te[ 7 ];
-
-		te[ 0 ] = c * a11 + s * a21;
-		te[ 3 ] = c * a12 + s * a22;
-		te[ 6 ] = c * a13 + s * a23;
-
-		te[ 1 ] = - s * a11 + c * a21;
-		te[ 4 ] = - s * a12 + c * a22;
-		te[ 7 ] = - s * a13 + c * a23;
+		this.premultiply( _m3.makeRotation( - theta ) );
 
 		return this;
 
@@ -266,14 +251,62 @@ class Matrix3 {
 
 	translate( tx, ty ) {
 
-		const te = this.elements;
-
-		te[ 0 ] += tx * te[ 2 ]; te[ 3 ] += tx * te[ 5 ]; te[ 6 ] += tx * te[ 8 ];
-		te[ 1 ] += ty * te[ 2 ]; te[ 4 ] += ty * te[ 5 ]; te[ 7 ] += ty * te[ 8 ];
+		this.premultiply( _m3.makeTranslation( tx, ty ) );
 
 		return this;
 
 	}
+
+	// for 2D Transforms
+
+	makeTranslation( x, y ) {
+
+		this.set(
+
+			1, 0, x,
+			0, 1, y,
+			0, 0, 1
+
+		);
+
+		return this;
+
+	}
+
+	makeRotation( theta ) {
+
+		// counterclockwise
+
+		const c = Math.cos( theta );
+		const s = Math.sin( theta );
+
+		this.set(
+
+			c, - s, 0,
+			s, c, 0,
+			0, 0, 1
+
+		);
+
+		return this;
+
+	}
+
+	makeScale( x, y ) {
+
+		this.set(
+
+			x, 0, 0,
+			0, y, 0,
+			0, 0, 1
+
+		);
+
+		return this;
+
+	}
+
+	//
 
 	equals( matrix ) {
 
@@ -329,5 +362,7 @@ class Matrix3 {
 	}
 
 }
+
+const _m3 = /*@__PURE__*/ new Matrix3();
 
 export { Matrix3 };


### PR DESCRIPTION
As suggested in https://github.com/mrdoob/three.js/pull/24733#issuecomment-1319370465.

This PR adds 2D transform methods to `Matrix3`. These methods parallel the similarly-named `Matrix4` methods:

```js
// for 2D Transforms

makeTranslation( x, y )

makeRotation( theta )

makeScale( x, y )
```
