### PR TITLE
CCDIKSolver: Make `.createHelper()` compatible with generic `SkinnedMesh`.

### DIFF
--- a/examples/jsm/animation/CCDIKSolver.js
+++ b/examples/jsm/animation/CCDIKSolver.js
@@ -217,7 +217,8 @@ class CCDIKSolver {
 	 */
 	createHelper() {
 
-		return new CCDIKHelper( this.mesh, this.mesh.geometry.userData.MMD.iks );
+		const iks = this.mesh.geometry.userData.MMD?.iks ?? this.iks;
+		return new CCDIKHelper( this.mesh, iks );
 
 	}
 

--- a/examples/jsm/animation/CCDIKSolver.js
+++ b/examples/jsm/animation/CCDIKSolver.js
@@ -217,8 +217,7 @@ class CCDIKSolver {
 	 */
 	createHelper() {
 
-		const iks = this.mesh.geometry.userData.MMD?.iks ?? this.iks;
-		return new CCDIKHelper( this.mesh, iks );
+		return new CCDIKHelper( this.mesh, this.iks );
 
 	}
 


### PR DESCRIPTION
`CCDIKSolver.createHelper()` fallbacks to `this.iks` if no MMD

Related issue: [#23404](https://github.com/mrdoob/three.js/pull/23404)
