### PR TITLE
GLTFLoader: Make `navigator` access more robust.

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2262,17 +2262,18 @@ class GLTFParser {
 
 		// Use an ImageBitmapLoader if imageBitmaps are supported. Moves much of the
 		// expensive work of uploading a texture to the GPU off the main thread.
+		
+		let isSafari = false;
+		let isFirefox = false;
+		let firefoxVersion = - 1;
 
-        let isSafari = false;
-        let isFirefox = false;
-        let firefoxVersion = -1;
+		if ( typeof navigator !== 'undefined' ) {
 
-        if( typeof navigator !== 'undefined' ) {
+			isSafari = /^((?!chrome|android).)*safari/i.test( navigator.userAgent ) === true;
+			isFirefox = navigator.userAgent.indexOf( 'Firefox' ) > - 1;
+			firefoxVersion = isFirefox ? navigator.userAgent.match( /Firefox\/([0-9]+)\./ )[ 1 ] : - 1;
 
-            isSafari = /^((?!chrome|android).)*safari/i.test( navigator.userAgent ) === true;
-            isFirefox = navigator.userAgent.indexOf( 'Firefox' ) > - 1;
-            firefoxVersion = isFirefox ? navigator.userAgent.match( /Firefox\/([0-9]+)\./ )[ 1 ] : - 1;
-        }
+		}
 
 		if ( typeof createImageBitmap === 'undefined' || isSafari || ( isFirefox && firefoxVersion < 98 ) ) {
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2263,9 +2263,16 @@ class GLTFParser {
 		// Use an ImageBitmapLoader if imageBitmaps are supported. Moves much of the
 		// expensive work of uploading a texture to the GPU off the main thread.
 
-		const isSafari = /^((?!chrome|android).)*safari/i.test( navigator.userAgent ) === true;
-		const isFirefox = navigator.userAgent.indexOf( 'Firefox' ) > - 1;
-		const firefoxVersion = isFirefox ? navigator.userAgent.match( /Firefox\/([0-9]+)\./ )[ 1 ] : - 1;
+        let isSafari = false;
+        let isFirefox = false;
+        let firefoxVersion = -1;
+
+        if( typeof navigator !== 'undefined' ) {
+
+            isSafari = /^((?!chrome|android).)*safari/i.test( navigator.userAgent ) === true;
+            isFirefox = navigator.userAgent.indexOf( 'Firefox' ) > - 1;
+            firefoxVersion = isFirefox ? navigator.userAgent.match( /Firefox\/([0-9]+)\./ )[ 1 ] : - 1;
+        }
 
 		if ( typeof createImageBitmap === 'undefined' || isSafari || ( isFirefox && firefoxVersion < 98 ) ) {
 


### PR DESCRIPTION
**Description**
This pull request will only request navigator if it is defined, as GLTFLoader attempts to retrieve navigator, but this will throw an error for headless gltf support.

