### PR TITLE
Defaulting material roughness to 0.0

### DIFF
--- a/docs/api/en/materials/MeshStandardMaterial.html
+++ b/docs/api/en/materials/MeshStandardMaterial.html
@@ -225,7 +225,7 @@
 
 		<h3>[property:Float roughness]</h3>
 		<p>
-			How rough the material appears. 0.0 means a smooth mirror reflection, 1.0 means fully diffuse. Default is 1.0.
+			How rough the material appears. 0.0 means a smooth mirror reflection, 1.0 means fully diffuse. Default is 0.0.
 			If roughnessMap is also provided, both values are multiplied.
 		</p>
 

--- a/docs/api/it/materials/MeshStandardMaterial.html
+++ b/docs/api/it/materials/MeshStandardMaterial.html
@@ -234,7 +234,7 @@
 		<h3>[property:Float roughness]</h3>
 		<p>
 			Quanto ruvido appare il materiale. 0.0 un riflesso speculare uniforme, 1.0 significa completamente diffuso.
-			Il valore predefinito è 1.0. Se viene fornita anche roughnessMap, entrambi i valori vengono moltiplicati.
+			Il valore predefinito è 0.0. Se viene fornita anche roughnessMap, entrambi i valori vengono moltiplicati.
 		</p>
 
 		<h3>[property:Texture roughnessMap]</h3>

--- a/docs/api/zh/materials/MeshStandardMaterial.html
+++ b/docs/api/zh/materials/MeshStandardMaterial.html
@@ -192,7 +192,7 @@
 		</p>
 
 		<h3>[property:Float roughness]</h3>
-		<p> 材质的粗糙程度。0.0表示平滑的镜面反射，1.0表示完全漫反射。默认值为1.0。如果还提供roughnessMap，则两个值相乘。
+		<p> 材质的粗糙程度。0.0表示平滑的镜面反射，1.0表示完全漫反射。默认值为0.0。如果还提供roughnessMap，则两个值相乘。
 		</p>
 
 		<h3>[property:Texture roughnessMap]</h3>

--- a/src/materials/MeshStandardMaterial.js
+++ b/src/materials/MeshStandardMaterial.js
@@ -1,22 +1,20 @@
-import { TangentSpaceNormalMap } from '../constants.js';
-import { Material } from './Material.js';
-import { Vector2 } from '../math/Vector2.js';
-import { Color } from '../math/Color.js';
+import { TangentSpaceNormalMap } from "../constants.js";
+import { Material } from "./Material.js";
+import { Vector2 } from "../math/Vector2.js";
+import { Color } from "../math/Color.js";
 
 class MeshStandardMaterial extends Material {
-
-	constructor( parameters ) {
-
+	constructor(parameters) {
 		super();
 
 		this.isMeshStandardMaterial = true;
 
-		this.defines = { 'STANDARD': '' };
+		this.defines = { STANDARD: "" };
 
-		this.type = 'MeshStandardMaterial';
+		this.type = "MeshStandardMaterial";
 
-		this.color = new Color( 0xffffff ); // diffuse
-		this.roughness = 1.0;
+		this.color = new Color(0xffffff); // diffuse
+		this.roughness = 0.0;
 		this.metalness = 0.0;
 
 		this.map = null;
@@ -27,7 +25,7 @@ class MeshStandardMaterial extends Material {
 		this.aoMap = null;
 		this.aoMapIntensity = 1.0;
 
-		this.emissive = new Color( 0x000000 );
+		this.emissive = new Color(0x000000);
 		this.emissiveIntensity = 1.0;
 		this.emissiveMap = null;
 
@@ -36,7 +34,7 @@ class MeshStandardMaterial extends Material {
 
 		this.normalMap = null;
 		this.normalMapType = TangentSpaceNormalMap;
-		this.normalScale = new Vector2( 1, 1 );
+		this.normalScale = new Vector2(1, 1);
 
 		this.displacementMap = null;
 		this.displacementScale = 1;
@@ -53,24 +51,22 @@ class MeshStandardMaterial extends Material {
 
 		this.wireframe = false;
 		this.wireframeLinewidth = 1;
-		this.wireframeLinecap = 'round';
-		this.wireframeLinejoin = 'round';
+		this.wireframeLinecap = "round";
+		this.wireframeLinejoin = "round";
 
 		this.flatShading = false;
 
 		this.fog = true;
 
-		this.setValues( parameters );
-
+		this.setValues(parameters);
 	}
 
-	copy( source ) {
+	copy(source) {
+		super.copy(source);
 
-		super.copy( source );
+		this.defines = { STANDARD: "" };
 
-		this.defines = { 'STANDARD': '' };
-
-		this.color.copy( source.color );
+		this.color.copy(source.color);
 		this.roughness = source.roughness;
 		this.metalness = source.metalness;
 
@@ -82,7 +78,7 @@ class MeshStandardMaterial extends Material {
 		this.aoMap = source.aoMap;
 		this.aoMapIntensity = source.aoMapIntensity;
 
-		this.emissive.copy( source.emissive );
+		this.emissive.copy(source.emissive);
 		this.emissiveMap = source.emissiveMap;
 		this.emissiveIntensity = source.emissiveIntensity;
 
@@ -91,7 +87,7 @@ class MeshStandardMaterial extends Material {
 
 		this.normalMap = source.normalMap;
 		this.normalMapType = source.normalMapType;
-		this.normalScale.copy( source.normalScale );
+		this.normalScale.copy(source.normalScale);
 
 		this.displacementMap = source.displacementMap;
 		this.displacementScale = source.displacementScale;
@@ -116,9 +112,7 @@ class MeshStandardMaterial extends Material {
 		this.fog = source.fog;
 
 		return this;
-
 	}
-
 }
 
 export { MeshStandardMaterial };

--- a/src/renderers/shaders/ShaderLib.js
+++ b/src/renderers/shaders/ShaderLib.js
@@ -1,32 +1,28 @@
-import { ShaderChunk } from './ShaderChunk.js';
-import { mergeUniforms } from './UniformsUtils.js';
-import { Vector2 } from '../../math/Vector2.js';
-import { Vector3 } from '../../math/Vector3.js';
-import { UniformsLib } from './UniformsLib.js';
-import { Color } from '../../math/Color.js';
-import { Matrix3 } from '../../math/Matrix3.js';
+import { ShaderChunk } from "./ShaderChunk.js";
+import { mergeUniforms } from "./UniformsUtils.js";
+import { Vector2 } from "../../math/Vector2.js";
+import { Vector3 } from "../../math/Vector3.js";
+import { UniformsLib } from "./UniformsLib.js";
+import { Color } from "../../math/Color.js";
+import { Matrix3 } from "../../math/Matrix3.js";
 
 const ShaderLib = {
-
 	basic: {
-
-		uniforms: /*@__PURE__*/ mergeUniforms( [
+		uniforms: /*@__PURE__*/ mergeUniforms([
 			UniformsLib.common,
 			UniformsLib.specularmap,
 			UniformsLib.envmap,
 			UniformsLib.aomap,
 			UniformsLib.lightmap,
-			UniformsLib.fog
-		] ),
+			UniformsLib.fog,
+		]),
 
 		vertexShader: ShaderChunk.meshbasic_vert,
-		fragmentShader: ShaderChunk.meshbasic_frag
-
+		fragmentShader: ShaderChunk.meshbasic_frag,
 	},
 
 	lambert: {
-
-		uniforms: /*@__PURE__*/ mergeUniforms( [
+		uniforms: /*@__PURE__*/ mergeUniforms([
 			UniformsLib.common,
 			UniformsLib.specularmap,
 			UniformsLib.envmap,
@@ -39,18 +35,16 @@ const ShaderLib = {
 			UniformsLib.fog,
 			UniformsLib.lights,
 			{
-				emissive: { value: /*@__PURE__*/ new Color( 0x000000 ) }
-			}
-		] ),
+				emissive: { value: /*@__PURE__*/ new Color(0x000000) },
+			},
+		]),
 
 		vertexShader: ShaderChunk.meshlambert_vert,
-		fragmentShader: ShaderChunk.meshlambert_frag
-
+		fragmentShader: ShaderChunk.meshlambert_frag,
 	},
 
 	phong: {
-
-		uniforms: /*@__PURE__*/ mergeUniforms( [
+		uniforms: /*@__PURE__*/ mergeUniforms([
 			UniformsLib.common,
 			UniformsLib.specularmap,
 			UniformsLib.envmap,
@@ -63,20 +57,18 @@ const ShaderLib = {
 			UniformsLib.fog,
 			UniformsLib.lights,
 			{
-				emissive: { value: /*@__PURE__*/ new Color( 0x000000 ) },
-				specular: { value: /*@__PURE__*/ new Color( 0x111111 ) },
-				shininess: { value: 30 }
-			}
-		] ),
+				emissive: { value: /*@__PURE__*/ new Color(0x000000) },
+				specular: { value: /*@__PURE__*/ new Color(0x111111) },
+				shininess: { value: 30 },
+			},
+		]),
 
 		vertexShader: ShaderChunk.meshphong_vert,
-		fragmentShader: ShaderChunk.meshphong_frag
-
+		fragmentShader: ShaderChunk.meshphong_frag,
 	},
 
 	standard: {
-
-		uniforms: /*@__PURE__*/ mergeUniforms( [
+		uniforms: /*@__PURE__*/ mergeUniforms([
 			UniformsLib.common,
 			UniformsLib.envmap,
 			UniformsLib.aomap,
@@ -90,21 +82,19 @@ const ShaderLib = {
 			UniformsLib.fog,
 			UniformsLib.lights,
 			{
-				emissive: { value: /*@__PURE__*/ new Color( 0x000000 ) },
-				roughness: { value: 1.0 },
+				emissive: { value: /*@__PURE__*/ new Color(0x000000) },
+				roughness: { value: 0.0 },
 				metalness: { value: 0.0 },
-				envMapIntensity: { value: 1 } // temporary
-			}
-		] ),
+				envMapIntensity: { value: 1 }, // temporary
+			},
+		]),
 
 		vertexShader: ShaderChunk.meshphysical_vert,
-		fragmentShader: ShaderChunk.meshphysical_frag
-
+		fragmentShader: ShaderChunk.meshphysical_frag,
 	},
 
 	toon: {
-
-		uniforms: /*@__PURE__*/ mergeUniforms( [
+		uniforms: /*@__PURE__*/ mergeUniforms([
 			UniformsLib.common,
 			UniformsLib.aomap,
 			UniformsLib.lightmap,
@@ -116,199 +106,172 @@ const ShaderLib = {
 			UniformsLib.fog,
 			UniformsLib.lights,
 			{
-				emissive: { value: /*@__PURE__*/ new Color( 0x000000 ) }
-			}
-		] ),
+				emissive: { value: /*@__PURE__*/ new Color(0x000000) },
+			},
+		]),
 
 		vertexShader: ShaderChunk.meshtoon_vert,
-		fragmentShader: ShaderChunk.meshtoon_frag
-
+		fragmentShader: ShaderChunk.meshtoon_frag,
 	},
 
 	matcap: {
-
-		uniforms: /*@__PURE__*/ mergeUniforms( [
+		uniforms: /*@__PURE__*/ mergeUniforms([
 			UniformsLib.common,
 			UniformsLib.bumpmap,
 			UniformsLib.normalmap,
 			UniformsLib.displacementmap,
 			UniformsLib.fog,
 			{
-				matcap: { value: null }
-			}
-		] ),
+				matcap: { value: null },
+			},
+		]),
 
 		vertexShader: ShaderChunk.meshmatcap_vert,
-		fragmentShader: ShaderChunk.meshmatcap_frag
-
+		fragmentShader: ShaderChunk.meshmatcap_frag,
 	},
 
 	points: {
-
-		uniforms: /*@__PURE__*/ mergeUniforms( [
+		uniforms: /*@__PURE__*/ mergeUniforms([
 			UniformsLib.points,
-			UniformsLib.fog
-		] ),
+			UniformsLib.fog,
+		]),
 
 		vertexShader: ShaderChunk.points_vert,
-		fragmentShader: ShaderChunk.points_frag
-
+		fragmentShader: ShaderChunk.points_frag,
 	},
 
 	dashed: {
-
-		uniforms: /*@__PURE__*/ mergeUniforms( [
+		uniforms: /*@__PURE__*/ mergeUniforms([
 			UniformsLib.common,
 			UniformsLib.fog,
 			{
 				scale: { value: 1 },
 				dashSize: { value: 1 },
-				totalSize: { value: 2 }
-			}
-		] ),
+				totalSize: { value: 2 },
+			},
+		]),
 
 		vertexShader: ShaderChunk.linedashed_vert,
-		fragmentShader: ShaderChunk.linedashed_frag
-
+		fragmentShader: ShaderChunk.linedashed_frag,
 	},
 
 	depth: {
-
-		uniforms: /*@__PURE__*/ mergeUniforms( [
+		uniforms: /*@__PURE__*/ mergeUniforms([
 			UniformsLib.common,
-			UniformsLib.displacementmap
-		] ),
+			UniformsLib.displacementmap,
+		]),
 
 		vertexShader: ShaderChunk.depth_vert,
-		fragmentShader: ShaderChunk.depth_frag
-
+		fragmentShader: ShaderChunk.depth_frag,
 	},
 
 	normal: {
-
-		uniforms: /*@__PURE__*/ mergeUniforms( [
+		uniforms: /*@__PURE__*/ mergeUniforms([
 			UniformsLib.common,
 			UniformsLib.bumpmap,
 			UniformsLib.normalmap,
 			UniformsLib.displacementmap,
 			{
-				opacity: { value: 1.0 }
-			}
-		] ),
+				opacity: { value: 1.0 },
+			},
+		]),
 
 		vertexShader: ShaderChunk.meshnormal_vert,
-		fragmentShader: ShaderChunk.meshnormal_frag
-
+		fragmentShader: ShaderChunk.meshnormal_frag,
 	},
 
 	sprite: {
-
-		uniforms: /*@__PURE__*/ mergeUniforms( [
+		uniforms: /*@__PURE__*/ mergeUniforms([
 			UniformsLib.sprite,
-			UniformsLib.fog
-		] ),
+			UniformsLib.fog,
+		]),
 
 		vertexShader: ShaderChunk.sprite_vert,
-		fragmentShader: ShaderChunk.sprite_frag
-
+		fragmentShader: ShaderChunk.sprite_frag,
 	},
 
 	background: {
-
 		uniforms: {
 			uvTransform: { value: /*@__PURE__*/ new Matrix3() },
 			t2D: { value: null },
-			backgroundIntensity: { value: 1 }
+			backgroundIntensity: { value: 1 },
 		},
 
 		vertexShader: ShaderChunk.background_vert,
-		fragmentShader: ShaderChunk.background_frag
-
+		fragmentShader: ShaderChunk.background_frag,
 	},
 
 	backgroundCube: {
-
 		uniforms: {
 			envMap: { value: null },
-			flipEnvMap: { value: - 1 },
+			flipEnvMap: { value: -1 },
 			backgroundBlurriness: { value: 0 },
-			backgroundIntensity: { value: 1 }
+			backgroundIntensity: { value: 1 },
 		},
 
 		vertexShader: ShaderChunk.backgroundCube_vert,
-		fragmentShader: ShaderChunk.backgroundCube_frag
-
+		fragmentShader: ShaderChunk.backgroundCube_frag,
 	},
 
 	cube: {
-
 		uniforms: {
 			tCube: { value: null },
-			tFlip: { value: - 1 },
-			opacity: { value: 1.0 }
+			tFlip: { value: -1 },
+			opacity: { value: 1.0 },
 		},
 
 		vertexShader: ShaderChunk.cube_vert,
-		fragmentShader: ShaderChunk.cube_frag
-
+		fragmentShader: ShaderChunk.cube_frag,
 	},
 
 	equirect: {
-
 		uniforms: {
 			tEquirect: { value: null },
 		},
 
 		vertexShader: ShaderChunk.equirect_vert,
-		fragmentShader: ShaderChunk.equirect_frag
-
+		fragmentShader: ShaderChunk.equirect_frag,
 	},
 
 	distanceRGBA: {
-
-		uniforms: /*@__PURE__*/ mergeUniforms( [
+		uniforms: /*@__PURE__*/ mergeUniforms([
 			UniformsLib.common,
 			UniformsLib.displacementmap,
 			{
 				referencePosition: { value: /*@__PURE__*/ new Vector3() },
 				nearDistance: { value: 1 },
-				farDistance: { value: 1000 }
-			}
-		] ),
+				farDistance: { value: 1000 },
+			},
+		]),
 
 		vertexShader: ShaderChunk.distanceRGBA_vert,
-		fragmentShader: ShaderChunk.distanceRGBA_frag
-
+		fragmentShader: ShaderChunk.distanceRGBA_frag,
 	},
 
 	shadow: {
-
-		uniforms: /*@__PURE__*/ mergeUniforms( [
+		uniforms: /*@__PURE__*/ mergeUniforms([
 			UniformsLib.lights,
 			UniformsLib.fog,
 			{
-				color: { value: /*@__PURE__*/ new Color( 0x00000 ) },
-				opacity: { value: 1.0 }
+				color: { value: /*@__PURE__*/ new Color(0x00000) },
+				opacity: { value: 1.0 },
 			},
-		] ),
+		]),
 
 		vertexShader: ShaderChunk.shadow_vert,
-		fragmentShader: ShaderChunk.shadow_frag
-
-	}
-
+		fragmentShader: ShaderChunk.shadow_frag,
+	},
 };
 
 ShaderLib.physical = {
-
-	uniforms: /*@__PURE__*/ mergeUniforms( [
+	uniforms: /*@__PURE__*/ mergeUniforms([
 		ShaderLib.standard.uniforms,
 		{
 			clearcoat: { value: 0 },
 			clearcoatMap: { value: null },
 			clearcoatRoughness: { value: 0 },
 			clearcoatRoughnessMap: { value: null },
-			clearcoatNormalScale: { value: /*@__PURE__*/ new Vector2( 1, 1 ) },
+			clearcoatNormalScale: { value: /*@__PURE__*/ new Vector2(1, 1) },
 			clearcoatNormalMap: { value: null },
 			iridescence: { value: 0 },
 			iridescenceMap: { value: null },
@@ -317,7 +280,7 @@ ShaderLib.physical = {
 			iridescenceThicknessMaximum: { value: 400 },
 			iridescenceThicknessMap: { value: null },
 			sheen: { value: 0 },
-			sheenColor: { value: /*@__PURE__*/ new Color( 0x000000 ) },
+			sheenColor: { value: /*@__PURE__*/ new Color(0x000000) },
 			sheenColorMap: { value: null },
 			sheenRoughness: { value: 1 },
 			sheenRoughnessMap: { value: null },
@@ -328,18 +291,16 @@ ShaderLib.physical = {
 			thickness: { value: 0 },
 			thicknessMap: { value: null },
 			attenuationDistance: { value: 0 },
-			attenuationColor: { value: /*@__PURE__*/ new Color( 0x000000 ) },
+			attenuationColor: { value: /*@__PURE__*/ new Color(0x000000) },
 			specularIntensity: { value: 1 },
 			specularIntensityMap: { value: null },
-			specularColor: { value: /*@__PURE__*/ new Color( 1, 1, 1 ) },
+			specularColor: { value: /*@__PURE__*/ new Color(1, 1, 1) },
 			specularColorMap: { value: null },
-		}
-	] ),
+		},
+	]),
 
 	vertexShader: ShaderChunk.meshphysical_vert,
-	fragmentShader: ShaderChunk.meshphysical_frag
-
+	fragmentShader: ShaderChunk.meshphysical_frag,
 };
-
 
 export { ShaderLib };


### PR DESCRIPTION
**Description**

The Three.js MeshStandardMaterial property `roughness` defaults to 1.0. For those of us building material configuration editors, this means we always have to override this value if we want users to see metalness / transmission. Roughess of 1.0 essentially fully blurs the other effects, masking them.

For me personally, a default value of 0.0 for roughness is more intuitive, because it doesn't mask other effects. It also makes it easier for new users to immediately see the output of the transmission and metalness properties. When creating a material, if you set either of these without decreasing roughness, you will get an unexpected result, unless you happen to know roughness defaults to 1 and basically cancels out these effects.

For a slightly more convenient API, I propose this change to default roughness to 0.0