### PR TITLE
Object3D: Added getObjectsByProperty()

### DIFF
--- a/docs/api/en/core/Object3D.html
+++ b/docs/api/en/core/Object3D.html
@@ -277,7 +277,7 @@
 		Searches through an object and its children, starting with the object itself, and returns the first with a property that matches the value given.
 		</p>
 
-		<h3>[method:Object3D getAllObjectsByProperty]( [param:String name], [param:Any value] )</h3>
+		<h3>[method:Object3D getObjectsByProperty]( [param:String name], [param:Any value] )</h3>
 		<p>
 		name -- the property name to search for. <br />
 		value -- value of the given property. <br /><br />

--- a/docs/api/en/core/Object3D.html
+++ b/docs/api/en/core/Object3D.html
@@ -277,6 +277,14 @@
 		Searches through an object and its children, starting with the object itself, and returns the first with a property that matches the value given.
 		</p>
 
+		<h3>[method:Object3D getAllObjectsByProperty]( [param:String name], [param:Any value] )</h3>
+		<p>
+		name -- the property name to search for. <br />
+		value -- value of the given property. <br /><br />
+
+		Searches through an object and its children, starting with the object itself, and returns all the objects with a property that matches the value given.
+		</p>
+
 		<h3>[method:Vector3 getWorldPosition]( [param:Vector3 target] )</h3>
 		<p>
 		[page:Vector3 target] — the result will be copied into this Vector3. <br /><br />

--- a/docs/api/it/core/Object3D.html
+++ b/docs/api/it/core/Object3D.html
@@ -281,6 +281,14 @@
       Cerca in un oggetto e nei suoi figli, partendo dall'oggetto stesso, e restituisce il primo con la proprietà che corrisponde al valore passato.
 		</p>
 
+		<h3>[method:Object3D getAllObjectsByProperty]( [param:String name], [param:Any value] )</h3>
+		<p>
+		  name -- il nome della proprietà da cercare. <br />
+		  value -- il valore della proprietà data. <br /><br />
+
+      Cerca in un oggetto e nei suoi figli, partendo dall'oggetto stesso, e restituisce tutti gli oggetti con la proprietà che corrisponde al valore passato.
+		</p>
+
 		<h3>[method:Vector3 getWorldPosition]( [param:Vector3 target] )</h3>
 		<p>
 		  [page:Vector3 target] — il risultato verrà copiato in questo Vector3. <br /><br />

--- a/docs/api/it/core/Object3D.html
+++ b/docs/api/it/core/Object3D.html
@@ -281,7 +281,7 @@
       Cerca in un oggetto e nei suoi figli, partendo dall'oggetto stesso, e restituisce il primo con la proprietà che corrisponde al valore passato.
 		</p>
 
-		<h3>[method:Object3D getAllObjectsByProperty]( [param:String name], [param:Any value] )</h3>
+		<h3>[method:Object3D getObjectsByProperty]( [param:String name], [param:Any value] )</h3>
 		<p>
 		  name -- il nome della proprietà da cercare. <br />
 		  value -- il valore della proprietà data. <br /><br />

--- a/docs/api/ko/core/Object3D.html
+++ b/docs/api/ko/core/Object3D.html
@@ -266,6 +266,14 @@
 		객체 자신부터 시작하여 객체와 객체 자식 항목을 검색하고 일치하는 값의 첫 번째 항목을 리턴합니다.
 		</p>
 
+		<h3>[method:Object3D getAllObjectsByProperty]( [param:String name], [param:Any value] )</h3>
+		<p>
+		name -- 검색하고자하는 이름 프로퍼티. <br />
+		value -- 프로퍼티의 값. <br /><br />
+
+		개체 자체부터 시작하여 개체와 해당 자식을 검색하고 일치하는 값의 모든 개체를 반환합니다.
+		</p>
+
 		<h3>[method:Vector3 getWorldPosition]( [param:Vector3 target] )</h3>
 		<p>
 		[page:Vector3 target] — 결과값은 이 Vector3에 복제됩니다. <br /><br />

--- a/docs/api/ko/core/Object3D.html
+++ b/docs/api/ko/core/Object3D.html
@@ -266,7 +266,7 @@
 		객체 자신부터 시작하여 객체와 객체 자식 항목을 검색하고 일치하는 값의 첫 번째 항목을 리턴합니다.
 		</p>
 
-		<h3>[method:Object3D getAllObjectsByProperty]( [param:String name], [param:Any value] )</h3>
+		<h3>[method:Object3D getObjectsByProperty]( [param:String name], [param:Any value] )</h3>
 		<p>
 		name -- 검색하고자하는 이름 프로퍼티. <br />
 		value -- 프로퍼티의 값. <br /><br />

--- a/docs/api/zh/core/Object3D.html
+++ b/docs/api/zh/core/Object3D.html
@@ -263,7 +263,7 @@
 		从该对象开始，搜索一个对象及其子级，返回第一个给定的属性中包含有匹配的值的子对象。
 	</p>
 
-	<h3>[method:Object3D getAllObjectsByProperty]( [param:String name], [param:Any value] )</h3>
+	<h3>[method:Object3D getObjectsByProperty]( [param:String name], [param:Any value] )</h3>
 	<p>
 		name —— 将要用于查找的属性的名称。<br />
 		value —— 给定的属性的值。 <br /><br />

--- a/docs/api/zh/core/Object3D.html
+++ b/docs/api/zh/core/Object3D.html
@@ -263,6 +263,13 @@
 		从该对象开始，搜索一个对象及其子级，返回第一个给定的属性中包含有匹配的值的子对象。
 	</p>
 
+	<h3>[method:Object3D getAllObjectsByProperty]( [param:String name], [param:Any value] )</h3>
+	<p>
+		name —— 将要用于查找的属性的名称。<br />
+		value —— 给定的属性的值。 <br /><br />
+		从此对象开始，搜索一个对象及其子对象，返回包含给定属性的匹配值的所有子对象。
+	</p>
+
 	<h3>[method:Vector3 getWorldPosition]( [param:Vector3 target] )</h3>
 	<p>
 		[page:Vector3 target] — 结果将被复制到这个Vector3中。<br /><br />

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -468,7 +468,7 @@ class Object3D extends EventDispatcher {
 
 	getObjectsByProperty( name, value ) {
 
-		let result = [ ];
+		let result = [];
 
 		if ( this[ name ] === value ) result.push( this );
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -466,6 +466,23 @@ class Object3D extends EventDispatcher {
 
 	}
 
+	getAllObjectsByProperty( name, value ) {
+		let result = [];
+
+		if ( this[ name ] === value )
+			result.push(this);
+	
+		for ( let i = 0, l = this.children.length; i < l; i ++ ) {
+	
+			const object = this.children[i].getAllObjectsByProperty( name, value );
+	
+			if ( object.length > 0 ) {
+				result = result.concat(object);
+			}
+		}
+		return result;
+	}
+
 	getWorldPosition( target ) {
 
 		this.updateWorldMatrix( true, false );

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -467,20 +467,25 @@ class Object3D extends EventDispatcher {
 	}
 
 	getAllObjectsByProperty( name, value ) {
-		let result = [];
 
-		if ( this[ name ] === value )
-			result.push(this);
-	
+		let result = [ ];
+
+		if ( this[ name ] === value ) result.push( this );
+
 		for ( let i = 0, l = this.children.length; i < l; i ++ ) {
-	
-			const object = this.children[i].getAllObjectsByProperty( name, value );
-	
-			if ( object.length > 0 ) {
-				result = result.concat(object);
+
+			const childResult = this.children[ i ].getAllObjectsByProperty( name, value );
+
+			if ( childResult.length > 0 ) {
+
+				result = result.concat( childResult );
+
 			}
+
 		}
+
 		return result;
+
 	}
 
 	getWorldPosition( target ) {

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -466,7 +466,7 @@ class Object3D extends EventDispatcher {
 
 	}
 
-	getAllObjectsByProperty( name, value ) {
+	getObjectsByProperty( name, value ) {
 
 		let result = [ ];
 
@@ -474,7 +474,7 @@ class Object3D extends EventDispatcher {
 
 		for ( let i = 0, l = this.children.length; i < l; i ++ ) {
 
-			const childResult = this.children[ i ].getAllObjectsByProperty( name, value );
+			const childResult = this.children[ i ].getObjectsByProperty( name, value );
 
 			if ( childResult.length > 0 ) {
 

--- a/test/unit/src/core/Object3D.tests.js
+++ b/test/unit/src/core/Object3D.tests.js
@@ -530,11 +530,10 @@ export default QUnit.module( 'Core', () => {
 
 		} );
 
-		QUnit.test( 'getObjectById/getObjectByName/getObjectsByProperty', ( assert ) => {
+		QUnit.test( 'getObjectsByProperty', ( assert ) => {
 
 			var parent = new Object3D();
 			var childName = new Object3D();
-			var childId = new Object3D(); // id = parent.id + 2
 			var childNothing = new Object3D();
 			var childName2 = new Object3D();
 			var childName3 = new Object3D();
@@ -545,7 +544,7 @@ export default QUnit.module( 'Core', () => {
 			childName3.name = 'foo';
 			childName2.add( childName3 );
 			childName.add( childName2 );
-			parent.add( childName, childId, childNothing );
+			parent.add( childName, childNothing );
 
 			assert.strictEqual( parent.getObjectsByProperty( 'name', 'foo' ).length, 3, 'Get amount of all childs by name "foo"' );
 			assert.strictEqual( parent.getObjectsByProperty( 'name', 'foo' ).some(obj => obj.name !== 'foo') , false, 'Get all childs by name "foo"' );

--- a/test/unit/src/core/Object3D.tests.js
+++ b/test/unit/src/core/Object3D.tests.js
@@ -547,8 +547,8 @@ export default QUnit.module( 'Core', () => {
 			childName.add( childName2 );
 			parent.add( childName, childId, childNothing );
 
-			assert.strictEqual( parent.getAllObjectsByProperty( 'foo' ).length, 3, 'Get amount of all childs by name "foo"' );
-			assert.strictEqual( parent.getAllObjectsByProperty( 'foo' ).some(obj => obj.name !== 'foo') , false, 'Get all childs by name "foo"' );
+			assert.strictEqual( parent.getAllObjectsByProperty( 'name', 'foo' ).length, 3, 'Get amount of all childs by name "foo"' );
+			assert.strictEqual( parent.getAllObjectsByProperty( 'name', 'foo' ).some(obj => obj.name !== 'foo') , false, 'Get all childs by name "foo"' );
 
 		} );
 

--- a/test/unit/src/core/Object3D.tests.js
+++ b/test/unit/src/core/Object3D.tests.js
@@ -530,6 +530,28 @@ export default QUnit.module( 'Core', () => {
 
 		} );
 
+		QUnit.test( 'getObjectById/getObjectByName/getAllObjectsByProperty', ( assert ) => {
+
+			var parent = new Object3D();
+			var childName = new Object3D();
+			var childId = new Object3D(); // id = parent.id + 2
+			var childNothing = new Object3D();
+			var childName2 = new Object3D();
+			var childName3 = new Object3D();
+
+			parent.prop = true;
+			childName.name = 'foo';
+			childName2.name = 'foo';
+			childName3.name = 'foo';
+			childName2.add( childName3 );
+			childName.add( childName2 );
+			parent.add( childName, childId, childNothing );
+
+			assert.strictEqual( parent.getAllObjectsByProperty( 'foo' ).length, 3, 'Get amount of all childs by name "foo"' );
+			assert.strictEqual( parent.getAllObjectsByProperty( 'foo' ).some(obj => obj.name !== 'foo') , false, 'Get all childs by name "foo"' );
+
+		} );
+
 		QUnit.test( 'getWorldPosition', ( assert ) => {
 
 			var a = new Object3D();

--- a/test/unit/src/core/Object3D.tests.js
+++ b/test/unit/src/core/Object3D.tests.js
@@ -530,7 +530,7 @@ export default QUnit.module( 'Core', () => {
 
 		} );
 
-		QUnit.test( 'getObjectById/getObjectByName/getAllObjectsByProperty', ( assert ) => {
+		QUnit.test( 'getObjectById/getObjectByName/getObjectsByProperty', ( assert ) => {
 
 			var parent = new Object3D();
 			var childName = new Object3D();
@@ -547,8 +547,8 @@ export default QUnit.module( 'Core', () => {
 			childName.add( childName2 );
 			parent.add( childName, childId, childNothing );
 
-			assert.strictEqual( parent.getAllObjectsByProperty( 'name', 'foo' ).length, 3, 'Get amount of all childs by name "foo"' );
-			assert.strictEqual( parent.getAllObjectsByProperty( 'name', 'foo' ).some(obj => obj.name !== 'foo') , false, 'Get all childs by name "foo"' );
+			assert.strictEqual( parent.getObjectsByProperty( 'name', 'foo' ).length, 3, 'Get amount of all childs by name "foo"' );
+			assert.strictEqual( parent.getObjectsByProperty( 'name', 'foo' ).some(obj => obj.name !== 'foo') , false, 'Get all childs by name "foo"' );
 
 		} );
 


### PR DESCRIPTION

**Description**

A clear and concise description of what the problem was and how this pull request solves it.

Problem:

Sometimes, as it's common when using a 3D engine, a programmer would want to select all Objects with a property,
The function that would allow to do so, doesn't currently exists in Three.js, so developers will need to re-implement this basic function each time they want to do so.

Solution:

A recursive version of the `Object3D.getObjectByProperty()` function, named `getAllObjectsByProperty`
that gives all matching objects, instead of just the first.

Updated documentation ✔
Linting✔
Test passed✔