### PR TITLE
Allow passing `GLTFLoader` into `OculusHandModel`/`XRHandMeshModel`.

### DIFF
--- a/examples/jsm/webxr/OculusHandModel.js
+++ b/examples/jsm/webxr/OculusHandModel.js
@@ -6,13 +6,14 @@ const POINTING_JOINT = 'index-finger-tip';
 
 class OculusHandModel extends Object3D {
 
-	constructor( controller ) {
+	constructor( controller, loader ) {
 
 		super();
 
 		this.controller = controller;
 		this.motionController = null;
 		this.envMap = null;
+		this.loader = loader;
 
 		this.mesh = null;
 
@@ -24,7 +25,7 @@ class OculusHandModel extends Object3D {
 
 				this.xrInputSource = xrInputSource;
 
-				this.motionController = new XRHandMeshModel( this, controller, this.path, xrInputSource.handedness );
+				this.motionController = new XRHandMeshModel( this, controller, this.path, xrInputSource.handedness, this.loader );
 
 			}
 

--- a/examples/jsm/webxr/XRHandMeshModel.js
+++ b/examples/jsm/webxr/XRHandMeshModel.js
@@ -4,14 +4,14 @@ const DEFAULT_HAND_PROFILE_PATH = 'https://cdn.jsdelivr.net/npm/@webxr-input-pro
 
 class XRHandMeshModel {
 
-	constructor( handModel, controller, path, handedness, loader ) {
+	constructor( handModel, controller, path, handedness, loader = null ) {
 
 		this.controller = controller;
 		this.handModel = handModel;
 
 		this.bones = [];
 
-		if ( !loader ) {
+		if ( loader === null ) {
 
 			loader = new GLTFLoader();
 			loader.setPath( path || DEFAULT_HAND_PROFILE_PATH );

--- a/examples/jsm/webxr/XRHandMeshModel.js
+++ b/examples/jsm/webxr/XRHandMeshModel.js
@@ -4,15 +4,20 @@ const DEFAULT_HAND_PROFILE_PATH = 'https://cdn.jsdelivr.net/npm/@webxr-input-pro
 
 class XRHandMeshModel {
 
-	constructor( handModel, controller, path, handedness ) {
+	constructor( handModel, controller, path, handedness, loader ) {
 
 		this.controller = controller;
 		this.handModel = handModel;
 
 		this.bones = [];
 
-		const loader = new GLTFLoader();
-		loader.setPath( path || DEFAULT_HAND_PROFILE_PATH );
+		if ( !loader ) {
+
+			loader = new GLTFLoader();
+			loader.setPath( path || DEFAULT_HAND_PROFILE_PATH );
+
+		}
+
 		loader.load( `${handedness}.glb`, gltf => {
 
 			const object = gltf.scene.children[ 0 ];


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/24857

**Description**

For [Monster Hands](https://monster-hands.needle.tools/), we needed to be able to load custom hand models, and since these can be rather complex we wanted to compress them as usual with etc1s+draco. The embedded GLTFLoader inside `XRHandMeshModel` doesn't have the relevant components for loading compressed meshes, so this PR allows passing an existing / externally created loader in.

If that externally created loader should load the default hand models, users need to set the DEFAULT_HAND_PROFILE_PATH in their code, otherwise it's confusing when explicitly no path is wanted (loading local relative models).

cc @cabanier

*This contribution is funded by [Needle](https://needle.tools)*