### PR TITLE
GLTFLoader: fix exception when a texture can't be fetched/created

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -3013,6 +3013,8 @@ class GLTFParser {
 
 		return this.getDependency( 'texture', mapDef.index ).then( function ( texture ) {
 
+			if ( ! texture ) return null;
+
 			// Materials sample aoMap from UV set 1 and other maps from UV set 0 - this can't be configured
 			// However, we will copy UV set 0 to UV set 1 on demand for aoMap
 			if ( mapDef.texCoord !== undefined && mapDef.texCoord != 0 && ! ( mapName === 'aoMap' && mapDef.texCoord == 1 ) ) {
@@ -3035,7 +3037,7 @@ class GLTFParser {
 
 			}
 
-			if ( encoding !== undefined && texture ) {
+			if ( encoding !== undefined ) {
 
 				texture.encoding = encoding;
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -3035,7 +3035,7 @@ class GLTFParser {
 
 			}
 
-			if ( encoding !== undefined ) {
+			if ( encoding !== undefined && texture ) {
 
 				texture.encoding = encoding;
 


### PR DESCRIPTION
**Description**

When loading user-provided models, we ran into the issue that when any texture inside the model is corrupt / not reachable, the entire model doesn't load. This PR simply prevents a null reference that caused that. The result is that models load, but the affected textures aren't there, which I think is preferrable to an exception.

Here's a simple case to reproduce:
```js
new GLTFLoader().load("https://dl.polyhaven.org/file/ph-assets/Models/gltf/4k/hand_plane_no4/hand_plane_no4_4k.gltf", gltf => {
	scene.add(gltf.scene);
});
```