### PR TITLE
ColladaLoader: Fix line rendering with incompatible materials.

### DIFF
--- a/examples/jsm/loaders/ColladaLoader.js
+++ b/examples/jsm/loaders/ColladaLoader.js
@@ -3764,6 +3764,34 @@ class ColladaLoader extends Loader {
 
 				}
 
+				// Collada allows to use phong and lambert materials with lines. Replacing these cases with LineBasicMaterial.
+
+				if ( type === 'lines' || type === 'linestrips' ) {
+
+					for ( let i = 0, l = materials.length; i < l; i ++ ) {
+
+						const material = materials[ i ];
+
+						if ( material.isMeshPhongMaterial === true || material.isMeshLambertMaterial === true ) {
+
+							const lineMaterial = new LineBasicMaterial();
+
+							// copy compatible properties
+
+							lineMaterial.color.copy( material.color );
+							lineMaterial.opacity = material.opacity;
+							lineMaterial.transparent = material.transparent;
+
+							// replace material
+
+							materials[ i ] = lineMaterial;
+
+						}
+
+					}
+
+				}
+
 				// regard skinning
 
 				const skinning = ( geometry.data.attributes.skinIndex !== undefined );


### PR DESCRIPTION
Related issue: -

**Description**

Collada allows to use phong and lambert materials with lines. The PR ensures line definitions rely on `LineBasicMaterial`.