### PR TITLE
GLTFExporter: guard against missing image data in textures

### DIFF
--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -1285,9 +1285,11 @@ class GLTFWriter {
 		}
 
 		// pbrMetallicRoughness.metallicRoughnessTexture
-		if ( material.metalnessMap || material.roughnessMap ) {
+		const metalnessMap = material.metalnessMap?.image ? material.metalnessMap : undefined;
+		const roughnessMap = material.roughnessMap?.image ? material.roughnessMap : undefined;
+		if ( metalnessMap || roughnessMap ) {
 
-			const metalRoughTexture = this.buildMetalRoughTexture( material.metalnessMap, material.roughnessMap );
+			const metalRoughTexture = this.buildMetalRoughTexture( metalnessMap, roughnessMap );
 
 			const metalRoughMapDef = { index: this.processTexture( metalRoughTexture ) };
 			this.applyTextureTransform( metalRoughMapDef, metalRoughTexture );
@@ -1296,7 +1298,7 @@ class GLTFWriter {
 		}
 
 		// pbrMetallicRoughness.baseColorTexture or pbrSpecularGlossiness diffuseTexture
-		if ( material.map ) {
+		if ( material.map && material.map.image ) {
 
 			const baseColorMapDef = { index: this.processTexture( material.map ) };
 			this.applyTextureTransform( baseColorMapDef, material.map );
@@ -1325,7 +1327,7 @@ class GLTFWriter {
 			}
 
 			// emissiveTexture
-			if ( material.emissiveMap ) {
+			if ( material.emissiveMap && material.emissiveMap.image ) {
 
 				const emissiveMapDef = { index: this.processTexture( material.emissiveMap ) };
 				this.applyTextureTransform( emissiveMapDef, material.emissiveMap );
@@ -1336,7 +1338,7 @@ class GLTFWriter {
 		}
 
 		// normalTexture
-		if ( material.normalMap ) {
+		if ( material.normalMap && material.normalMap.image ) {
 
 			const normalMapDef = { index: this.processTexture( material.normalMap ) };
 
@@ -1354,7 +1356,7 @@ class GLTFWriter {
 		}
 
 		// occlusionTexture
-		if ( material.aoMap ) {
+		if ( material.aoMap && material.aoMap.image ) {
 
 			const occlusionMapDef = {
 				index: this.processTexture( material.aoMap ),

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -1298,7 +1298,7 @@ class GLTFWriter {
 		}
 
 		// pbrMetallicRoughness.baseColorTexture or pbrSpecularGlossiness diffuseTexture
-		if ( material.map && material.map.image ) {
+		if ( material.map?.image ) {
 
 			const baseColorMapDef = { index: this.processTexture( material.map ) };
 			this.applyTextureTransform( baseColorMapDef, material.map );
@@ -1327,7 +1327,7 @@ class GLTFWriter {
 			}
 
 			// emissiveTexture
-			if ( material.emissiveMap && material.emissiveMap.image ) {
+			if ( material.emissiveMap?.image ) {
 
 				const emissiveMapDef = { index: this.processTexture( material.emissiveMap ) };
 				this.applyTextureTransform( emissiveMapDef, material.emissiveMap );
@@ -1338,7 +1338,7 @@ class GLTFWriter {
 		}
 
 		// normalTexture
-		if ( material.normalMap && material.normalMap.image ) {
+		if ( material.normalMap?.image ) {
 
 			const normalMapDef = { index: this.processTexture( material.normalMap ) };
 
@@ -1356,7 +1356,7 @@ class GLTFWriter {
 		}
 
 		// occlusionTexture
-		if ( material.aoMap && material.aoMap.image ) {
+		if ( material.aoMap?.image ) {
 
 			const occlusionMapDef = {
 				index: this.processTexture( material.aoMap ),


### PR DESCRIPTION
Related issue: #25020

**Description**

Fixes exception on export when any map is an empty Texture (without image data).

*This contribution is funded by [Needle](https://needle.tools)*