### PR TITLE
USDZExporter: Guard against missing image data in textures

### DIFF
--- a/examples/jsm/exporters/USDZExporter.js
+++ b/examples/jsm/exporters/USDZExporter.js
@@ -461,7 +461,7 @@ function buildMaterial( material, textures ) {
 
 	}
 
-	if ( material.map !== null ) {
+	if ( material.map?.image ) {
 
 		inputs.push( `${ pad }color3f inputs:diffuseColor.connect = </Materials/Material_${ material.id }/Texture_${ material.map.id }_diffuse.outputs:rgb>` );
 
@@ -484,7 +484,7 @@ function buildMaterial( material, textures ) {
 
 	}
 
-	if ( material.emissiveMap !== null ) {
+	if ( material.emissiveMap?.image ) {
 
 		inputs.push( `${ pad }color3f inputs:emissiveColor.connect = </Materials/Material_${ material.id }/Texture_${ material.emissiveMap.id }_emissive.outputs:rgb>` );
 
@@ -496,7 +496,7 @@ function buildMaterial( material, textures ) {
 
 	}
 
-	if ( material.normalMap !== null ) {
+	if ( material.normalMap?.image ) {
 
 		inputs.push( `${ pad }normal3f inputs:normal.connect = </Materials/Material_${ material.id }/Texture_${ material.normalMap.id }_normal.outputs:rgb>` );
 
@@ -504,7 +504,7 @@ function buildMaterial( material, textures ) {
 
 	}
 
-	if ( material.aoMap !== null ) {
+	if ( material.aoMap?.image ) {
 
 		inputs.push( `${ pad }float inputs:occlusion.connect = </Materials/Material_${ material.id }/Texture_${ material.aoMap.id }_occlusion.outputs:r>` );
 
@@ -512,7 +512,7 @@ function buildMaterial( material, textures ) {
 
 	}
 
-	if ( material.roughnessMap !== null && material.roughness === 1 ) {
+	if ( material.roughnessMap?.image && material.roughness === 1 ) {
 
 		inputs.push( `${ pad }float inputs:roughness.connect = </Materials/Material_${ material.id }/Texture_${ material.roughnessMap.id }_roughness.outputs:g>` );
 
@@ -524,7 +524,7 @@ function buildMaterial( material, textures ) {
 
 	}
 
-	if ( material.metalnessMap !== null && material.metalness === 1 ) {
+	if ( material.metalnessMap?.image && material.metalness === 1 ) {
 
 		inputs.push( `${ pad }float inputs:metallic.connect = </Materials/Material_${ material.id }/Texture_${ material.metalnessMap.id }_metallic.outputs:b>` );
 
@@ -536,7 +536,7 @@ function buildMaterial( material, textures ) {
 
 	}
 
-	if ( material.alphaMap !== null ) {
+	if ( material.alphaMap?.image ) {
 
 		inputs.push( `${pad}float inputs:opacity.connect = </Materials/Material_${material.id}/Texture_${material.alphaMap.id}_opacity.outputs:r>` );
 		inputs.push( `${pad}float inputs:opacityThreshold = 0.0001` );


### PR DESCRIPTION
Related issue: #25020

**Description**

Fixes exception on USDZ export when any map is an empty Texture (without image data).

*This contribution is funded by [Needle](https://needle.tools)*