### PR TITLE
USDZLoader: Fix loading files exported with USDZExporter

### DIFF
--- a/examples/jsm/loaders/USDZLoader.js
+++ b/examples/jsm/loaders/USDZLoader.js
@@ -577,7 +577,7 @@ class USDZLoader extends Loader {
 			const geometry = buildGeometry( findMeshGeometry( data ) );
 			const material = buildMaterial( findMeshMaterial( data ) );
 
-			const mesh = geometry && material ? new Mesh( geometry, material ) : new Object3D();
+			const mesh = geometry ? new Mesh( geometry, material ) : new Object3D();
 
 			if ( 'matrix4d xformOp:transform' in data ) {
 


### PR DESCRIPTION
**Description**

Since https://github.com/mrdoob/three.js/pull/22854 added a "Scope" wrapper object for the exported USDZ, and the USDZLoader so far was only able to load flat hierarchies, USDZLoader couldn't load the files exported with USDZExporter anymore.

This PR fixes that by introducing very basic hierarchy support on import, enough to support these files again.

Note: we (Needle) already have USDZExporter hierarchy support in our three.js fork, hope I get to make a PR soon.

*This contribution is funded by [Needle](https://needle.tools/)*