### PR TITLE
FBXLoader: Add warning about unsupported polygons.

### DIFF
--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -1786,6 +1786,7 @@ class GeometryParser {
 
 		let polygonIndex = 0;
 		let faceLength = 0;
+		let polygonSides = 0;
 		let displayedWeightsWarning = false;
 
 		// these will hold data for a single face
@@ -1813,6 +1814,14 @@ class GeometryParser {
 
 				vertexIndex = vertexIndex ^ - 1; // equivalent to ( x * -1 ) - 1
 				endOfFace = true;
+
+				if ( polygonSides > 3 ) console.warn( 'THREE.FBXLoader: Polygons with more than three sides are not supported. Make sure to triangulate the geometry during export.' );
+
+				polygonSides = 0;
+
+			} else {
+
+				polygonSides ++;
 
 			}
 


### PR DESCRIPTION
Related issue: #15211

**Description**

I've encountered a FBX asset that couldn't be displayed correctly. After some research I've realized I stumbled across #15211.

This PR adds a warning like suggested in https://github.com/mrdoob/three.js/issues/15211#issuecomment-509492088 to inform the users what's going on.
