### PR TITLE
LineSegments2: Fix raytracing when the geometry has `instanceCount` set.

### DIFF
--- a/examples/jsm/lines/LineSegments2.js
+++ b/examples/jsm/lines/LineSegments2.js
@@ -52,11 +52,15 @@ function getWorldSpaceHalfWidth( camera, distance, resolution ) {
 function raycastWorldUnits( lineSegments, intersects ) {
 
 	const matrixWorld = lineSegments.matrixWorld;
+	const geometry = lineSegments.geometry;
+	const instanceStart = geometry.attributes.instanceStart;
+	const instanceEnd = geometry.attributes.instanceEnd;
+	const segmentCount = Math.min( geometry.instanceCount, instanceStart.count );
 
-	for ( let i = 0, l = _instanceStart.count; i < l; i ++ ) {
+	for ( let i = 0, l = segmentCount; i < l; i ++ ) {
 
-		_line.start.fromBufferAttribute( _instanceStart, i );
-		_line.end.fromBufferAttribute( _instanceEnd, i );
+		_line.start.fromBufferAttribute( instanceStart, i );
+		_line.end.fromBufferAttribute( instanceEnd, i );
 
 		_line.applyMatrix4( matrixWorld );
 
@@ -95,6 +99,7 @@ function raycastScreenSpace( lineSegments, camera, intersects ) {
 	const geometry = lineSegments.geometry;
 	const instanceStart = geometry.attributes.instanceStart;
 	const instanceEnd = geometry.attributes.instanceEnd;
+	const segmentCount = Math.min( geometry.instanceCount, instanceStart.count );
 
 	const near = - camera.near;
 
@@ -120,7 +125,7 @@ function raycastScreenSpace( lineSegments, camera, intersects ) {
 
 	_mvMatrix.multiplyMatrices( camera.matrixWorldInverse, matrixWorld );
 
-	for ( let i = 0, l = instanceStart.count; i < l; i ++ ) {
+	for ( let i = 0, l = segmentCount; i < l; i ++ ) {
 
 		_start4.fromBufferAttribute( instanceStart, i );
 		_end4.fromBufferAttribute( instanceEnd, i );

--- a/examples/jsm/lines/LineSegments2.js
+++ b/examples/jsm/lines/LineSegments2.js
@@ -29,7 +29,7 @@ const _box = new Box3();
 const _sphere = new Sphere();
 const _clipToWorldVector = new Vector4();
 
-let _ray, _instanceStart, _instanceEnd, _lineWidth;
+let _ray, _lineWidth;
 
 // Returns the margin required to expand by in world space given the distance from the camera,
 // line width, resolution, and camera projection
@@ -283,9 +283,6 @@ class LineSegments2 extends Mesh {
 		const material = this.material;
 
 		_lineWidth = material.linewidth + threshold;
-
-		_instanceStart = geometry.attributes.instanceStart;
-		_instanceEnd = geometry.attributes.instanceEnd;
 
 		// check if we intersect the sphere bounds
 		if ( geometry.boundingSphere === null ) {


### PR DESCRIPTION
**Description**

The `LineSegments2` mesh has support for raytracing. However, all segments are evaluated when checking for intersections, even if the geometry's `instanceCount` has been set to a lower value than the total segment count. Therefore, intersections are still detected with the non-visible line segments. This PR fixes this by considering the `instanceCount` when setting the iteration count during ray tracing.

The bounding box/sphere methods still do not consider the `instanceCount`, but this is a more challenging problem to solve correctly and does not affect the correctness of the ray tracing results.

The behavior before and after can be reproduced by applying a transformation in the `Line2` ray tracing example (`/examples/#webgl_lines_fat_raycasting`). Here is an example patch that can be used:
```
diff --git a/examples/webgl_lines_fat_raycasting.html b/examples/webgl_lines_fat_raycasting.html
index 232623c744..a830a533a8 100644
--- a/examples/webgl_lines_fat_raycasting.html
+++ b/examples/webgl_lines_fat_raycasting.html
@@ -162,6 +162,7 @@
 				segments.scale.set( 1, 1, 1 );
 				scene.add( segments );
 				segments.visible = false;
+				segmentsGeometry.instanceCount = 50;

 				thresholdSegments = new LineSegments2( segmentsGeometry, matThresholdLine );
 				thresholdSegments.computeLineDistances();
```