### PR TITLE
GLTFLoader: Update comment

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2843,7 +2843,7 @@ class GLTFParser {
 	/**
 	 * Specification: https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#textures
 	 * @param {number} textureIndex
-	 * @return {Promise<THREE.Texture>}
+	 * @return {Promise<THREE.Texture|null>}
 	 */
 	loadTexture( textureIndex ) {
 


### PR DESCRIPTION
**Description**

This PR updates a comment in `GLTFLoader` to match the comment, `loadTexture()` can return `Promise<null>` if loading texture image fails.
