### PR TITLE
FBXLoader: Simplify polygon check.

### DIFF
--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -1943,6 +1943,8 @@ class GeometryParser {
 
 			if ( endOfFace ) {
 
+				if ( faceLength > 4 ) console.warn( 'THREE.FBXLoader: Polygons with more than four sides are not supported. Make sure to triangulate the geometry during export.' );
+
 				scope.genFace( buffers, geoInfo, facePositionIndexes, materialIndex, faceNormals, faceColors, faceUVs, faceWeights, faceWeightIndices, faceLength );
 
 				polygonIndex ++;

--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -1786,7 +1786,6 @@ class GeometryParser {
 
 		let polygonIndex = 0;
 		let faceLength = 0;
-		let polygonSides = 0;
 		let displayedWeightsWarning = false;
 
 		// these will hold data for a single face
@@ -1814,14 +1813,6 @@ class GeometryParser {
 
 				vertexIndex = vertexIndex ^ - 1; // equivalent to ( x * -1 ) - 1
 				endOfFace = true;
-
-				if ( polygonSides > 3 ) console.warn( 'THREE.FBXLoader: Polygons with more than three sides are not supported. Make sure to triangulate the geometry during export.' );
-
-				polygonSides = 0;
-
-			} else {
-
-				polygonSides ++;
 
 			}
 


### PR DESCRIPTION
Related issue: #25030

**Description**

#25030 can be actually implemented a bit simpler by reusing an existing variable. 

Also quads are actually supported which is not correctly mentioned in the warning.
