### PR TITLE
TransformControls: Add conditional object transforms.

### DIFF
--- a/examples/js/controls/TransformControls.js
+++ b/examples/js/controls/TransformControls.js
@@ -35,6 +35,7 @@
 			}
 
 			this.isTransformControls = true;
+			this.beforeTransform = ( matrix, matrixWorld ) => true;
 			this.visible = false;
 			this.domElement = domElement;
 			this.domElement.style.touchAction = 'none'; // disable touch scroll
@@ -188,6 +189,22 @@
 			super.updateMatrixWorld( this );
 
 		}
+
+		// calculate the matrix and matrixWorld that should happen to the object
+		getNewMatrixAndMatrixWorld( object, position, quaternion, scale ) {
+
+			let tempMatrix = object.matrix.clone().compose( position, quaternion, scale );
+			let tempMatrixWorld = tempMatrix.clone();
+
+			if ( object.parent !== null ) {
+
+				tempMatrixWorld.multiplyMatrices( object.parent.matrixWorld, tempMatrix );
+
+			}
+
+			return { tempMatrix, tempMatrixWorld };
+
+		}
 		pointerHover( pointer ) {
 
 			if ( this.object === undefined || this.dragging === true ) return;
@@ -275,7 +292,7 @@
 
 				}
 
-				object.position.copy( this._offset ).add( this._positionStart );
+				let positionResult = this._offset.clone().add( this._positionStart );
 
 				// Apply translation snap
 
@@ -283,26 +300,27 @@
 
 					if ( space === 'local' ) {
 
-						object.position.applyQuaternion( _tempQuaternion.copy( this._quaternionStart ).invert() );
+						positionResult.applyQuaternion( _tempQuaternion.copy( this._quaternionStart ).invert() );
+
 						if ( axis.search( 'X' ) !== - 1 ) {
 
-							object.position.x = Math.round( object.position.x / this.translationSnap ) * this.translationSnap;
+							positionResult.x = Math.round( object.position.x / this.translationSnap ) * this.translationSnap;
 
 						}
 
 						if ( axis.search( 'Y' ) !== - 1 ) {
 
-							object.position.y = Math.round( object.position.y / this.translationSnap ) * this.translationSnap;
+							positionResult.y = Math.round( object.position.y / this.translationSnap ) * this.translationSnap;
 
 						}
 
 						if ( axis.search( 'Z' ) !== - 1 ) {
 
-							object.position.z = Math.round( object.position.z / this.translationSnap ) * this.translationSnap;
+							positionResult.z = Math.round( object.position.z / this.translationSnap ) * this.translationSnap;
 
 						}
 
-						object.position.applyQuaternion( this._quaternionStart );
+						positionResult.applyQuaternion( this._quaternionStart );
 
 					}
 
@@ -310,35 +328,43 @@
 
 						if ( object.parent ) {
 
-							object.position.add( _tempVector.setFromMatrixPosition( object.parent.matrixWorld ) );
+							positionResult.add( _tempVector.setFromMatrixPosition( object.parent.matrixWorld ) );
 
 						}
 
 						if ( axis.search( 'X' ) !== - 1 ) {
 
-							object.position.x = Math.round( object.position.x / this.translationSnap ) * this.translationSnap;
+							positionResult.x = Math.round( object.position.x / this.translationSnap ) * this.translationSnap;
 
 						}
 
 						if ( axis.search( 'Y' ) !== - 1 ) {
 
-							object.position.y = Math.round( object.position.y / this.translationSnap ) * this.translationSnap;
+							positionResult.y = Math.round( object.position.y / this.translationSnap ) * this.translationSnap;
 
 						}
 
 						if ( axis.search( 'Z' ) !== - 1 ) {
 
-							object.position.z = Math.round( object.position.z / this.translationSnap ) * this.translationSnap;
+							positionResult.z = Math.round( object.position.z / this.translationSnap ) * this.translationSnap;
 
 						}
 
 						if ( object.parent ) {
 
-							object.position.sub( _tempVector.setFromMatrixPosition( object.parent.matrixWorld ) );
+							positionResult.sub( _tempVector.setFromMatrixPosition( object.parent.matrixWorld ) );
 
 						}
 
 					}
+
+				}
+
+				const { tempMatrix, tempMatrixWorld } = this.getNewMatrixAndMatrixWorld( object, positionResult, object.quaternion, object.scale );
+
+				if ( this.beforeTransform !== undefined && this.beforeTransform( tempMatrix, tempMatrixWorld ) ) {
+
+					object.position.copy( positionResult );
 
 				}
 
@@ -379,26 +405,35 @@
 
 				// Apply scale
 
-				object.scale.copy( this._scaleStart ).multiply( _tempVector2 );
+				let scaleResult = this._scaleStart.clone().multiply( _tempVector2 );
+
 				if ( this.scaleSnap ) {
 
 					if ( axis.search( 'X' ) !== - 1 ) {
 
-						object.scale.x = Math.round( object.scale.x / this.scaleSnap ) * this.scaleSnap || this.scaleSnap;
+						scaleResult.x = Math.round( scaleResult.x / this.scaleSnap ) * this.scaleSnap || this.scaleSnap;
 
 					}
 
 					if ( axis.search( 'Y' ) !== - 1 ) {
 
-						object.scale.y = Math.round( object.scale.y / this.scaleSnap ) * this.scaleSnap || this.scaleSnap;
+						scaleResult.y = Math.round( scaleResult.y / this.scaleSnap ) * this.scaleSnap || this.scaleSnap;
 
 					}
 
 					if ( axis.search( 'Z' ) !== - 1 ) {
 
-						object.scale.z = Math.round( object.scale.z / this.scaleSnap ) * this.scaleSnap || this.scaleSnap;
+						scaleResult.z = Math.round( scaleResult.z / this.scaleSnap ) * this.scaleSnap || this.scaleSnap;
 
 					}
+
+				}
+
+				const { tempMatrix, tempMatrixWorld } = this.getNewMatrixAndMatrixWorld( object, object.position, object.quaternion, scaleResult );
+
+				if ( this.beforeTransform !== undefined && this.beforeTransform( tempMatrix, tempMatrixWorld ) ) {
+
+					object.scale.copy( scaleResult );
 
 				}
 
@@ -412,7 +447,8 @@
 					this.rotationAngle = this.pointEnd.angleTo( this.pointStart );
 					this._startNorm.copy( this.pointStart ).normalize();
 					this._endNorm.copy( this.pointEnd ).normalize();
-					this.rotationAngle *= this._endNorm.cross( this._startNorm ).dot( this.eye ) < 0 ? 1 : - 1;
+
+					this.rotationAngle *= ( this._endNorm.cross( this._startNorm ).dot( this.eye ) < 0 ? 1 : - 1 );
 
 				} else if ( axis === 'XYZE' ) {
 
@@ -437,17 +473,28 @@
 
 				if ( this.rotationSnap ) this.rotationAngle = Math.round( this.rotationAngle / this.rotationSnap ) * this.rotationSnap;
 
+				let rotateResult;
+
 				// Apply rotate
 				if ( space === 'local' && axis !== 'E' && axis !== 'XYZE' ) {
 
-					object.quaternion.copy( this._quaternionStart );
-					object.quaternion.multiply( _tempQuaternion.setFromAxisAngle( this.rotationAxis, this.rotationAngle ) ).normalize();
+					rotateResult = this._quaternionStart.clone()
+						.multiply( _tempQuaternion.setFromAxisAngle( this.rotationAxis, this.rotationAngle ) ).normalize();
 
 				} else {
 
 					this.rotationAxis.applyQuaternion( this._parentQuaternionInv );
-					object.quaternion.copy( _tempQuaternion.setFromAxisAngle( this.rotationAxis, this.rotationAngle ) );
-					object.quaternion.multiply( this._quaternionStart ).normalize();
+
+					rotateResult = _tempQuaternion.setFromAxisAngle( this.rotationAxis, this.rotationAngle )
+						.multiply( this._quaternionStart ).normalize();
+
+				}
+
+				const { tempMatrix, tempMatrixWorld } = this.getNewMatrixAndMatrixWorld( object, object.position, rotateResult, object.scale );
+
+				if ( this.beforeTransform !== undefined && this.beforeTransform( tempMatrix, tempMatrixWorld ) ) {
+
+					object.quaternion.copy( rotateResult );
 
 				}
 


### PR DESCRIPTION
To check whether a transform is ok, I define a `beforeTransform` function, which returns `true` as default. The function can be accessed and replaced by: `transformControls.beforeTransform = ( matrix, matrixWorld ) => { ... }`. This function will be called before applying the transform matrix to the object.

Related issue: #25038

**Description**

When transforming an object using the TransformControls, an objectChange event will be dispatched after the object been transformed. However, it seems impossible when I want to check if such transforms should be performed at first. For example, when dragging an object and it is not allowed to collide with other objects, the developer should check whether the transform result will produce collisions, and then apply (or not apply) the transform to the object being dragged.


