### PR TITLE
Examples: Hide scrollbars in `webgl_effects_ascii`.

### DIFF
--- a/examples/jsm/effects/AsciiEffect.js
+++ b/examples/jsm/effects/AsciiEffect.js
@@ -59,8 +59,8 @@ class AsciiEffect {
 
 		function initAsciiSize() {
 
-			iWidth = Math.round( width * fResolution );
-			iHeight = Math.round( height * fResolution );
+			iWidth = Math.floor( width * fResolution );
+			iHeight = Math.floor( height * fResolution );
 
 			oCanvas.width = iWidth;
 			oCanvas.height = iHeight;
@@ -81,9 +81,6 @@ class AsciiEffect {
 			oAscii.cellPadding = 0;
 
 			const oStyle = oAscii.style;
-			oStyle.display = 'inline';
-			oStyle.width = Math.round( iWidth / fResolution * iScale ) + 'px';
-			oStyle.height = Math.round( iHeight / fResolution * iScale ) + 'px';
 			oStyle.whiteSpace = 'pre';
 			oStyle.margin = '0px';
 			oStyle.padding = '0px';
@@ -251,7 +248,7 @@ class AsciiEffect {
 
 			}
 
-			oAscii.innerHTML = '<tr><td>' + strChars + '</td></tr>';
+			oAscii.innerHTML = `<tr><td style="display:block;width:${width}px;height:${height}px;overflow:hidden">${strChars}</td></tr>`;
 
 			// console.timeEnd('rendering');
 

--- a/examples/webgl_effects_ascii.html
+++ b/examples/webgl_effects_ascii.html
@@ -6,7 +6,7 @@
 		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
 		<link type="text/css" rel="stylesheet" href="main.css">
 		<style>
-			body { overflow: hidden; }
+			body { overflow: hidden; } /* hide scrollbars produced by AsciiEffect */
 		</style>
 	</head>
 

--- a/examples/webgl_effects_ascii.html
+++ b/examples/webgl_effects_ascii.html
@@ -31,7 +31,7 @@
 			import * as THREE from 'three';
 
 			import { AsciiEffect } from 'three/addons/effects/AsciiEffect.js';
-			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import { TrackballControls } from 'three/addons/controls/TrackballControls.js';
 
 			let camera, controls, scene, renderer, effect;
 
@@ -82,7 +82,7 @@
 
 				document.body.appendChild( effect.domElement );
 
-				controls = new OrbitControls( camera, effect.domElement );
+				controls = new TrackballControls( camera, effect.domElement );
 
 				//
 

--- a/examples/webgl_effects_ascii.html
+++ b/examples/webgl_effects_ascii.html
@@ -5,9 +5,6 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
 		<link type="text/css" rel="stylesheet" href="main.css">
-		<style>
-			body { overflow: hidden; } /* hide scrollbars produced by AsciiEffect */
-		</style>
 	</head>
 
 	<body>

--- a/examples/webgl_effects_ascii.html
+++ b/examples/webgl_effects_ascii.html
@@ -5,6 +5,9 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
 		<link type="text/css" rel="stylesheet" href="main.css">
+		<style>
+			body { overflow: hidden; }
+		</style>
 	</head>
 
 	<body>
@@ -28,7 +31,7 @@
 			import * as THREE from 'three';
 
 			import { AsciiEffect } from 'three/addons/effects/AsciiEffect.js';
-			import { TrackballControls } from 'three/addons/controls/TrackballControls.js';
+			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 
 			let camera, controls, scene, renderer, effect;
 
@@ -79,7 +82,7 @@
 
 				document.body.appendChild( effect.domElement );
 
-				controls = new TrackballControls( camera, effect.domElement );
+				controls = new OrbitControls( camera, effect.domElement );
 
 				//
 


### PR DESCRIPTION
Related issue: #XXXX

**Description**

1. Add CSS to hidden the scrollbar for `body`.

| Before | After  |
|  ----  | ----  |
| ![image](https://user-images.githubusercontent.com/23699926/204856132-e03e2594-571c-4ede-8eaa-e440b187967c.png)  | ![image](https://user-images.githubusercontent.com/23699926/204856714-18859819-9b0f-4f3b-be6a-b3cfc6ebddd0.png) |


2. Used `OrbitControls` to replace `TrackballControls`.

I feel `OrbitControls` is easier to use than `TrackballControls`.
TBH, I rarely use `TrackballControls`.
If there is a problem, I will cancel the second change.

