### PR TITLE
Add Mesh.getVertexPosition

### DIFF
--- a/docs/api/en/objects/Mesh.html
+++ b/docs/api/en/objects/Mesh.html
@@ -72,7 +72,7 @@
 		<h3>[method:Mesh clone]()</h3>
 		<p>Returns a clone of this [name] object and its descendants.</p>
 
-    <h3>[method:Vector3 getUpdatedVertex]( [param:Integer vert], [param:Vector3 target] )</h3>
+    <h3>[method:Vector3 getVertexPosition]( [param:Integer vert], [param:Vector3 target] )</h3>
 		<p>
 		Get the current position of the indicated vertex, taking into account the
 		current animation state of both morph targets and skinning.

--- a/docs/api/en/objects/Mesh.html
+++ b/docs/api/en/objects/Mesh.html
@@ -74,7 +74,7 @@
 
     <h3>[method:Vector3 getVertexPosition]( [param:Integer vert], [param:Vector3 target] )</h3>
 		<p>
-		Get the current position of the indicated vertex, taking into account the
+		Get the current position of the indicated vertex in local space, taking into account the
 		current animation state of both morph targets and skinning.
 		</p>
 

--- a/docs/api/en/objects/Mesh.html
+++ b/docs/api/en/objects/Mesh.html
@@ -72,6 +72,12 @@
 		<h3>[method:Mesh clone]()</h3>
 		<p>Returns a clone of this [name] object and its descendants.</p>
 
+    <h3>[method:Vector3 getUpdatedVertex]( [param:Integer vert], [param:Vector3 target] )</h3>
+		<p>
+		Get the current position of the indicated vertex, taking into account the
+		current animation state of both morph targets and skinning.
+		</p>
+
 		<h3>[method:undefined raycast]( [param:Raycaster raycaster], [param:Array intersects] )</h3>
 		<p>
 		Get intersections between a casted ray and this mesh.

--- a/docs/examples/en/utils/SceneUtils.html
+++ b/docs/examples/en/utils/SceneUtils.html
@@ -42,14 +42,14 @@
 
     <h3>[method:T reduceVertices]( [param:Object3D object], [param:function func], [param:T initialValue] )</h3>
 		<p>
-		object -- The object to traverse (uses traverseVisible internally). <br />
+		object -- The object to traverse (uses [page:Object3D.traverseVisible traverseVisible] internally). <br />
 		func -- The binary function applied for the reduction. Must have the signature: (value: T, vertex: Vector3): T. <br />
     initialValue -- The value to initialize the reduction with. This is required
     as it also sets the reduction type, which is not required to be Vector3.
 		</p>
 		<p>
 		Akin to Array.prototype.reduce(), but operating on the vertices of all the
-		visible descendant objects. Additionally, it can operate as a
+		visible descendant objects, in world space. Additionally, it can operate as a
 		transform-reduce, returning a different type T than the Vector3 input. This
 		can be useful for e.g. fitting a viewing frustum to the scene.
 		</p>

--- a/docs/examples/en/utils/SceneUtils.html
+++ b/docs/examples/en/utils/SceneUtils.html
@@ -40,6 +40,20 @@
 		This is mostly useful for objects that need both a material and a wireframe implementation.
 		</p>
 
+    <h3>[method:T reduceVertices]( [param:Object3D object], [param:function func], [param:T initialValue] )</h3>
+		<p>
+		object -- The object to traverse (uses traverseVisible internally). <br />
+		func -- The binary function applied for the reduction. Must have the signature: (value: T, vertex: Vector3): T. <br />
+    initialValue -- The value to initialize the reduction with. This is required
+    as it also sets the reduction type, which is not required to be Vector3.
+		</p>
+		<p>
+		Akin to Array.prototype.reduce(), but operating on the vertices of all the
+		visible descendant objects. Additionally, it can operate as a
+		transform-reduce, returning a different type T than the Vector3 input. This
+		can be useful for e.g. fitting a viewing frustum to the scene.
+		</p>
+
 		<h3>[method:undefined sortInstancedMesh]( [param:InstancedMesh mesh], [param:Function compareFn] )</h3>
 		<p>
 		mesh -- InstancedMesh in which instances will be sorted. <br />

--- a/examples/jsm/utils/SceneUtils.js
+++ b/examples/jsm/utils/SceneUtils.js
@@ -143,13 +143,17 @@ function reduceVertices( object, func, initialValue ) {
 
 				for ( let i = 0, l = position.count; i < l; i ++ ) {
 
-					vertex.fromBufferAttribute( position, i );
+          if ( child.isMesh ) {
 
-					if ( child.isSkinnedMesh ) {
+            child.getUpdatedVertex( i, vertex );
 
-						child.boneTransform( i, vertex );
+          } else {
 
-					} else {
+            vertex.fromBufferAttribute( position, i );
+
+          }
+
+					if ( !child.isSkinnedMesh ) {
 
 						vertex.applyMatrix4( child.matrixWorld );
 

--- a/examples/jsm/utils/SceneUtils.js
+++ b/examples/jsm/utils/SceneUtils.js
@@ -145,7 +145,7 @@ function reduceVertices( object, func, initialValue ) {
 
           if ( child.isMesh ) {
 
-            child.getUpdatedVertex( i, vertex );
+            child.getVertexPosition( i, vertex );
 
           } else {
 

--- a/examples/jsm/utils/SceneUtils.js
+++ b/examples/jsm/utils/SceneUtils.js
@@ -143,17 +143,17 @@ function reduceVertices( object, func, initialValue ) {
 
 				for ( let i = 0, l = position.count; i < l; i ++ ) {
 
-          if ( child.isMesh ) {
+					if ( child.isMesh ) {
 
-            child.getVertexPosition( i, vertex );
+						child.getVertexPosition( i, vertex );
 
-          } else {
+					} else {
 
-            vertex.fromBufferAttribute( position, i );
+						vertex.fromBufferAttribute( position, i );
 
-          }
+					}
 
-					if ( !child.isSkinnedMesh ) {
+					if ( ! child.isSkinnedMesh ) {
 
 						vertex.applyMatrix4( child.matrixWorld );
 

--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -18,12 +18,7 @@ const _vB = /*@__PURE__*/ new Vector3();
 const _vC = /*@__PURE__*/ new Vector3();
 
 const _tempA = /*@__PURE__*/ new Vector3();
-const _tempB = /*@__PURE__*/ new Vector3();
-const _tempC = /*@__PURE__*/ new Vector3();
-
 const _morphA = /*@__PURE__*/ new Vector3();
-const _morphB = /*@__PURE__*/ new Vector3();
-const _morphC = /*@__PURE__*/ new Vector3();
 
 const _uvA = /*@__PURE__*/ new Vector2();
 const _uvB = /*@__PURE__*/ new Vector2();
@@ -103,55 +98,55 @@ class Mesh extends Object3D {
 
 	}
 
-  getUpdatedVertex( vert, target ) {
+	getVertexPosition( vert, target ) {
 
-    const geometry = this.geometry;
-    const position = geometry.attributes.position;
+		const geometry = this.geometry;
+		const position = geometry.attributes.position;
 		const morphPosition = geometry.morphAttributes.position;
 		const morphTargetsRelative = geometry.morphTargetsRelative;
 
-    target.fromBufferAttribute( position, vert );
+		target.fromBufferAttribute( position, vert );
 
-    const morphInfluences = this.morphTargetInfluences;
+		const morphInfluences = this.morphTargetInfluences;
 
-    if ( morphPosition && morphInfluences ) {
+		if ( morphPosition && morphInfluences ) {
 
-      _morphA.set( 0, 0, 0 );
+			_morphA.set( 0, 0, 0 );
 
-      for ( let i = 0, il = morphPosition.length; i < il; i ++ ) {
+			for ( let i = 0, il = morphPosition.length; i < il; i ++ ) {
 
-        const influence = morphInfluences[ i ];
-        const morphAttribute = morphPosition[ i ];
+				const influence = morphInfluences[ i ];
+				const morphAttribute = morphPosition[ i ];
 
-        if ( influence === 0 ) continue;
+				if ( influence === 0 ) continue;
 
-        _tempA.fromBufferAttribute( morphAttribute, vert );
+				_tempA.fromBufferAttribute( morphAttribute, vert );
 
-        if ( morphTargetsRelative ) {
+				if ( morphTargetsRelative ) {
 
-          _morphA.addScaledVector( _tempA, influence );
+					_morphA.addScaledVector( _tempA, influence );
 
-        } else {
+				} else {
 
-          _morphA.addScaledVector( _tempA.sub( target ), influence );
+					_morphA.addScaledVector( _tempA.sub( target ), influence );
 
-        }
+				}
 
-      }
+			}
 
-      target.add( _morphA );
+			target.add( _morphA );
 
-    }
+		}
 
-    if ( this.isSkinnedMesh ) {
+		if ( this.isSkinnedMesh ) {
 
-      this.boneTransform( vert, target );
+			this.boneTransform( vert, target );
 
-    }
+		}
 
-    return target;
+		return target;
 
-  }
+	}
 
 	raycast( raycaster, intersects ) {
 
@@ -347,9 +342,9 @@ function checkIntersection( object, material, raycaster, ray, pA, pB, pC, point 
 
 function checkBufferGeometryIntersection( object, material, raycaster, ray, uv, uv2, a, b, c ) {
 
-  object.getUpdatedVertex( a, _vA );
-  object.getUpdatedVertex( b, _vB );
-  object.getUpdatedVertex( c, _vC );
+	object.getVertexPosition( a, _vA );
+	object.getVertexPosition( b, _vB );
+	object.getVertexPosition( c, _vC );
 
 	const intersection = checkIntersection( object, material, raycaster, ray, _vA, _vB, _vC, _intersectionPoint );
 


### PR DESCRIPTION
Somewhat related issues: #18334, #14499

**Description**

I'm implementing dynamic hotspots for model-viewer, which requires me to find the current position of a vertex in a possibly animated mesh. Three.js does this internally for raycasting, but doesn't expose the method. I've refactored slightly to expose it and slightly simplify the raycasting code. I'm pretty sure I've seen forum discussions where this feature was asked for, so hopefully I'm not the only user. I have tested this (and the updated `reduceVertices`) on my dynamic hotspots branch of model-viewer and it's all working properly, handling morph targets, skinned meshes, etc. 
