### PR TITLE
Examples: Remove dependency checks from postprocessing.

### DIFF
--- a/examples/jsm/postprocessing/AdaptiveToneMappingPass.js
+++ b/examples/jsm/postprocessing/AdaptiveToneMappingPass.js
@@ -33,8 +33,6 @@ class AdaptiveToneMappingPass extends Pass {
 		this.previousLuminanceRT = null;
 		this.currentLuminanceRT = null;
 
-		if ( CopyShader === undefined ) console.error( 'THREE.AdaptiveToneMappingPass relies on CopyShader' );
-
 		const copyShader = CopyShader;
 
 		this.copyUniforms = UniformsUtils.clone( copyShader.uniforms );
@@ -48,9 +46,6 @@ class AdaptiveToneMappingPass extends Pass {
 			depthTest: false
 
 		} );
-
-		if ( LuminosityShader === undefined )
-			console.error( 'THREE.AdaptiveToneMappingPass relies on LuminosityShader' );
 
 		this.materialLuminance = new ShaderMaterial( {
 
@@ -118,9 +113,6 @@ class AdaptiveToneMappingPass extends Pass {
 			defines: Object.assign( {}, this.adaptLuminanceShader.defines ),
 			blending: NoBlending
 		} );
-
-		if ( ToneMapShader === undefined )
-			console.error( 'THREE.AdaptiveToneMappingPass relies on ToneMapShader' );
 
 		this.materialToneMap = new ShaderMaterial( {
 

--- a/examples/jsm/postprocessing/AfterimagePass.js
+++ b/examples/jsm/postprocessing/AfterimagePass.js
@@ -14,8 +14,6 @@ class AfterimagePass extends Pass {
 
 		super();
 
-		if ( AfterimageShader === undefined ) console.error( 'THREE.AfterimagePass relies on AfterimageShader' );
-
 		this.shader = AfterimageShader;
 
 		this.uniforms = UniformsUtils.clone( this.shader.uniforms );

--- a/examples/jsm/postprocessing/BloomPass.js
+++ b/examples/jsm/postprocessing/BloomPass.js
@@ -39,8 +39,6 @@ class BloomPass extends Pass {
 
 		// convolution material
 
-		if ( ConvolutionShader === undefined ) console.error( 'THREE.BloomPass relies on ConvolutionShader' );
-
 		const convolutionShader = ConvolutionShader;
 
 		this.convolutionUniforms = UniformsUtils.clone( convolutionShader.uniforms );

--- a/examples/jsm/postprocessing/BokehPass.js
+++ b/examples/jsm/postprocessing/BokehPass.js
@@ -46,12 +46,6 @@ class BokehPass extends Pass {
 
 		// bokeh material
 
-		if ( BokehShader === undefined ) {
-
-			console.error( 'THREE.BokehPass relies on BokehShader' );
-
-		}
-
 		const bokehShader = BokehShader;
 		const bokehUniforms = UniformsUtils.clone( bokehShader.uniforms );
 

--- a/examples/jsm/postprocessing/DotScreenPass.js
+++ b/examples/jsm/postprocessing/DotScreenPass.js
@@ -11,8 +11,6 @@ class DotScreenPass extends Pass {
 
 		super();
 
-		if ( DotScreenShader === undefined ) console.error( 'THREE.DotScreenPass relies on DotScreenShader' );
-
 		const shader = DotScreenShader;
 
 		this.uniforms = UniformsUtils.clone( shader.uniforms );

--- a/examples/jsm/postprocessing/EffectComposer.js
+++ b/examples/jsm/postprocessing/EffectComposer.js
@@ -1,9 +1,5 @@
 import {
-	BufferGeometry,
 	Clock,
-	Float32BufferAttribute,
-	Mesh,
-	OrthographicCamera,
 	Vector2,
 	WebGLRenderTarget
 } from 'three';
@@ -46,20 +42,6 @@ class EffectComposer {
 		this.renderToScreen = true;
 
 		this.passes = [];
-
-		// dependencies
-
-		if ( CopyShader === undefined ) {
-
-			console.error( 'THREE.EffectComposer relies on CopyShader' );
-
-		}
-
-		if ( ShaderPass === undefined ) {
-
-			console.error( 'THREE.EffectComposer relies on ShaderPass' );
-
-		}
 
 		this.copyPass = new ShaderPass( CopyShader );
 
@@ -243,77 +225,4 @@ class EffectComposer {
 
 }
 
-
-class Pass {
-
-	constructor() {
-
-		// if set to true, the pass is processed by the composer
-		this.enabled = true;
-
-		// if set to true, the pass indicates to swap read and write buffer after rendering
-		this.needsSwap = true;
-
-		// if set to true, the pass clears its buffer before rendering
-		this.clear = false;
-
-		// if set to true, the result of the pass is rendered to screen. This is set automatically by EffectComposer.
-		this.renderToScreen = false;
-
-	}
-
-	setSize( /* width, height */ ) {}
-
-	render( /* renderer, writeBuffer, readBuffer, deltaTime, maskActive */ ) {
-
-		console.error( 'THREE.Pass: .render() must be implemented in derived pass.' );
-
-	}
-
-}
-
-// Helper for passes that need to fill the viewport with a single quad.
-
-const _camera = new OrthographicCamera( - 1, 1, 1, - 1, 0, 1 );
-
-// https://github.com/mrdoob/three.js/pull/21358
-
-const _geometry = new BufferGeometry();
-_geometry.setAttribute( 'position', new Float32BufferAttribute( [ - 1, 3, 0, - 1, - 1, 0, 3, - 1, 0 ], 3 ) );
-_geometry.setAttribute( 'uv', new Float32BufferAttribute( [ 0, 2, 0, 0, 2, 0 ], 2 ) );
-
-class FullScreenQuad {
-
-	constructor( material ) {
-
-		this._mesh = new Mesh( _geometry, material );
-
-	}
-
-	dispose() {
-
-		this._mesh.geometry.dispose();
-
-	}
-
-	render( renderer ) {
-
-		renderer.render( this._mesh, _camera );
-
-	}
-
-	get material() {
-
-		return this._mesh.material;
-
-	}
-
-	set material( value ) {
-
-		this._mesh.material = value;
-
-	}
-
-}
-
-export { EffectComposer, Pass, FullScreenQuad };
+export { EffectComposer };

--- a/examples/jsm/postprocessing/FilmPass.js
+++ b/examples/jsm/postprocessing/FilmPass.js
@@ -11,8 +11,6 @@ class FilmPass extends Pass {
 
 		super();
 
-		if ( FilmShader === undefined ) console.error( 'THREE.FilmPass relies on FilmShader' );
-
 		const shader = FilmShader;
 
 		this.uniforms = UniformsUtils.clone( shader.uniforms );

--- a/examples/jsm/postprocessing/GlitchPass.js
+++ b/examples/jsm/postprocessing/GlitchPass.js
@@ -16,8 +16,6 @@ class GlitchPass extends Pass {
 
 		super();
 
-		if ( DigitalGlitch === undefined ) console.error( 'THREE.GlitchPass relies on DigitalGlitch' );
-
 		const shader = DigitalGlitch;
 
 		this.uniforms = UniformsUtils.clone( shader.uniforms );

--- a/examples/jsm/postprocessing/HalftonePass.js
+++ b/examples/jsm/postprocessing/HalftonePass.js
@@ -15,12 +15,6 @@ class HalftonePass extends Pass {
 
 		super();
 
-	 	if ( HalftoneShader === undefined ) {
-
-	 		console.error( 'THREE.HalftonePass requires HalftoneShader' );
-
-	 	}
-
 	 	this.uniforms = UniformsUtils.clone( HalftoneShader.uniforms );
 	 	this.material = new ShaderMaterial( {
 	 		uniforms: this.uniforms,

--- a/examples/jsm/postprocessing/OutlinePass.js
+++ b/examples/jsm/postprocessing/OutlinePass.js
@@ -91,7 +91,6 @@ class OutlinePass extends Pass {
 		this.overlayMaterial = this.getOverlayMaterial();
 
 		// copy material
-		if ( CopyShader === undefined ) console.error( 'THREE.OutlinePass relies on CopyShader' );
 
 		const copyShader = CopyShader;
 

--- a/examples/jsm/postprocessing/SAOPass.js
+++ b/examples/jsm/postprocessing/SAOPass.js
@@ -91,12 +91,6 @@ class SAOPass extends Pass {
 		this.normalMaterial = new MeshNormalMaterial();
 		this.normalMaterial.blending = NoBlending;
 
-		if ( SAOShader === undefined ) {
-
-			console.error( 'THREE.SAOPass relies on SAOShader' );
-
-		}
-
 		this.saoMaterial = new ShaderMaterial( {
 			defines: Object.assign( {}, SAOShader.defines ),
 			fragmentShader: SAOShader.fragmentShader,
@@ -113,12 +107,6 @@ class SAOPass extends Pass {
 		this.saoMaterial.uniforms[ 'cameraInverseProjectionMatrix' ].value.copy( this.camera.projectionMatrixInverse );
 		this.saoMaterial.uniforms[ 'cameraProjectionMatrix' ].value = this.camera.projectionMatrix;
 		this.saoMaterial.blending = NoBlending;
-
-		if ( DepthLimitedBlurShader === undefined ) {
-
-			console.error( 'THREE.SAOPass relies on DepthLimitedBlurShader' );
-
-		}
 
 		this.vBlurMaterial = new ShaderMaterial( {
 			uniforms: UniformsUtils.clone( DepthLimitedBlurShader.uniforms ),
@@ -146,12 +134,6 @@ class SAOPass extends Pass {
 		this.hBlurMaterial.uniforms[ 'size' ].value.set( this.resolution.x, this.resolution.y );
 		this.hBlurMaterial.blending = NoBlending;
 
-		if ( CopyShader === undefined ) {
-
-			console.error( 'THREE.SAOPass relies on CopyShader' );
-
-		}
-
 		this.materialCopy = new ShaderMaterial( {
 			uniforms: UniformsUtils.clone( CopyShader.uniforms ),
 			vertexShader: CopyShader.vertexShader,
@@ -168,12 +150,6 @@ class SAOPass extends Pass {
 		this.materialCopy.blendSrcAlpha = DstAlphaFactor;
 		this.materialCopy.blendDstAlpha = ZeroFactor;
 		this.materialCopy.blendEquationAlpha = AddEquation;
-
-		if ( UnpackDepthRGBAShader === undefined ) {
-
-			console.error( 'THREE.SAOPass relies on UnpackDepthRGBAShader' );
-
-		}
 
 		this.depthCopy = new ShaderMaterial( {
 			uniforms: UniformsUtils.clone( UnpackDepthRGBAShader.uniforms ),

--- a/examples/jsm/postprocessing/SMAAPass.js
+++ b/examples/jsm/postprocessing/SMAAPass.js
@@ -67,12 +67,6 @@ class SMAAPass extends Pass {
 
 		// materials - pass 1
 
-		if ( SMAAEdgesShader === undefined ) {
-
-			console.error( 'THREE.SMAAPass relies on SMAAShader' );
-
-		}
-
 		this.uniformsEdges = UniformsUtils.clone( SMAAEdgesShader.uniforms );
 
 		this.uniformsEdges[ 'resolution' ].value.set( 1 / width, 1 / height );

--- a/examples/jsm/postprocessing/SSAARenderPass.js
+++ b/examples/jsm/postprocessing/SSAARenderPass.js
@@ -35,8 +35,6 @@ class SSAARenderPass extends Pass {
 		this.clearAlpha = ( clearAlpha !== undefined ) ? clearAlpha : 0;
 		this._oldClearColor = new Color();
 
-		if ( CopyShader === undefined ) console.error( 'THREE.SSAARenderPass relies on CopyShader' );
-
 		const copyShader = CopyShader;
 		this.copyUniforms = UniformsUtils.clone( copyShader.uniforms );
 

--- a/examples/jsm/postprocessing/SSAOPass.js
+++ b/examples/jsm/postprocessing/SSAOPass.js
@@ -83,12 +83,6 @@ class SSAOPass extends Pass {
 
 		// ssao material
 
-		if ( SSAOShader === undefined ) {
-
-			console.error( 'THREE.SSAOPass: The pass relies on SSAOShader.' );
-
-		}
-
 		this.ssaoMaterial = new ShaderMaterial( {
 			defines: Object.assign( {}, SSAOShader.defines ),
 			uniforms: UniformsUtils.clone( SSAOShader.uniforms ),
@@ -376,12 +370,6 @@ class SSAOPass extends Pass {
 	generateRandomKernelRotations() {
 
 		const width = 4, height = 4;
-
-		if ( SimplexNoise === undefined ) {
-
-			console.error( 'THREE.SSAOPass: The pass relies on SimplexNoise.' );
-
-		}
 
 		const simplex = new SimplexNoise();
 

--- a/examples/jsm/postprocessing/SSRPass.js
+++ b/examples/jsm/postprocessing/SSRPass.js
@@ -202,12 +202,6 @@ class SSRPass extends Pass {
 
 		// ssr material
 
-		if ( SSRShader === undefined ) {
-
-			console.error( 'THREE.SSRPass: The pass relies on SSRShader.' );
-
-		}
-
 		this.ssrMaterial = new ShaderMaterial( {
 			defines: Object.assign( {}, SSRShader.defines, {
 				MAX_STEP: Math.sqrt( this.width * this.width + this.height * this.height )

--- a/examples/jsm/postprocessing/SavePass.js
+++ b/examples/jsm/postprocessing/SavePass.js
@@ -12,8 +12,6 @@ class SavePass extends Pass {
 
 		super();
 
-		if ( CopyShader === undefined ) console.error( 'THREE.SavePass relies on CopyShader' );
-
 		const shader = CopyShader;
 
 		this.textureID = 'tDiffuse';

--- a/examples/jsm/postprocessing/TexturePass.js
+++ b/examples/jsm/postprocessing/TexturePass.js
@@ -11,8 +11,6 @@ class TexturePass extends Pass {
 
 		super();
 
-		if ( CopyShader === undefined ) console.error( 'THREE.TexturePass relies on CopyShader' );
-
 		const shader = CopyShader;
 
 		this.map = map;

--- a/examples/jsm/postprocessing/UnrealBloomPass.js
+++ b/examples/jsm/postprocessing/UnrealBloomPass.js
@@ -70,9 +70,6 @@ class UnrealBloomPass extends Pass {
 
 		// luminosity high pass material
 
-		if ( LuminosityHighPassShader === undefined )
-			console.error( 'THREE.UnrealBloomPass relies on LuminosityHighPassShader' );
-
 		const highPassShader = LuminosityHighPassShader;
 		this.highPassUniforms = UniformsUtils.clone( highPassShader.uniforms );
 
@@ -121,11 +118,6 @@ class UnrealBloomPass extends Pass {
 		this.compositeMaterial.uniforms[ 'bloomTintColors' ].value = this.bloomTintColors;
 
 		// copy material
-		if ( CopyShader === undefined ) {
-
-			console.error( 'THREE.UnrealBloomPass relies on CopyShader' );
-
-		}
 
 		const copyShader = CopyShader;
 


### PR DESCRIPTION
Related issue: #25043

**Description**

The modules in `postprocessing` have many checks to inform `example/js` users if they have missed to include a dependency.

After removing `example/js`, these checks are not necessary anymore since ES6 modules automatically load their dependencies.

I've also removed the embedded `Pass` and `FullScreenQuad` definitions in `EffectComposer`. They were only added for the `examples/js` version of `EffectComposer`.
