### PR TITLE
Examples: Remove remaining dependency checks.

### DIFF
--- a/examples/jsm/geometries/ConvexGeometry.js
+++ b/examples/jsm/geometries/ConvexGeometry.js
@@ -15,12 +15,6 @@ class ConvexGeometry extends BufferGeometry {
 		const vertices = [];
 		const normals = [];
 
-		if ( ConvexHull === undefined ) {
-
-			console.error( 'THREE.ConvexGeometry: ConvexGeometry relies on ConvexHull' );
-
-		}
-
 		const convexHull = new ConvexHull().setFromPoints( points );
 
 		// generate vertices and normals

--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -2271,13 +2271,6 @@ class GeometryParser {
 	// Generate a NurbGeometry from a node in FBXTree.Objects.Geometry
 	parseNurbsGeometry( geoNode ) {
 
-		if ( NURBSCurve === undefined ) {
-
-			console.error( 'THREE.FBXLoader: The loader relies on NURBSCurve for any nurbs present in the model. Nurbs will show up as empty geometry.' );
-			return new BufferGeometry();
-
-		}
-
 		const order = parseInt( geoNode.Order );
 
 		if ( isNaN( order ) ) {


### PR DESCRIPTION
Related issue: #25051

**Description**

Same like #25051 only for `ConvexGeometry` and `FBXLoader`.
