### PR TITLE
Editor: Fix usage of USDZExporter.

### DIFF
--- a/editor/js/Menubar.File.js
+++ b/editor/js/Menubar.File.js
@@ -390,7 +390,7 @@ function MenubarFile( editor ) {
 
 		const exporter = new USDZExporter();
 
-		saveArrayBuffer( await exporter.parse( editor.scene, { binary: true } ), 'model.usdz' );
+		saveArrayBuffer( await exporter.parse( editor.scene ), 'model.usdz' );
 
 	} );
 	options.add( option );


### PR DESCRIPTION
Related issue: -

**Description**

The editor applies an invalid `options` parameter to the exporter which breaks the current usage.
