### PR TITLE
WebGLTextures: Only use anistropic filtering with certain `minFilter`/`magFilter` combinations.

### DIFF
--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -570,10 +570,12 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		}
 
-		if ( texture.magFilter !== NearestFilter && extensions.has( 'EXT_texture_filter_anisotropic' ) === true ) {
+		if ( extensions.has( 'EXT_texture_filter_anisotropic' ) === true ) {
 
 			const extension = extensions.get( 'EXT_texture_filter_anisotropic' );
 
+			if ( texture.magFilter === NearestFilter ) return;
+			if ( texture.minFilter !== NearestMipmapLinearFilter && texture.minFilter !== LinearMipmapLinearFilter ) return;
 			if ( texture.type === FloatType && extensions.has( 'OES_texture_float_linear' ) === false ) return; // verify extension for WebGL 1 and WebGL 2
 			if ( isWebGL2 === false && ( texture.type === HalfFloatType && extensions.has( 'OES_texture_half_float_linear' ) === false ) ) return; // verify extension for WebGL 1 only
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -570,7 +570,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		}
 
-		if ( extensions.has( 'EXT_texture_filter_anisotropic' ) === true ) {
+		if ( texture.magFilter !== NearestFilter && extensions.has( 'EXT_texture_filter_anisotropic' ) === true ) {
 
 			const extension = extensions.get( 'EXT_texture_filter_anisotropic' );
 


### PR DESCRIPTION
Fixed #25067

**Description**

Fixes the above mentioned issue by not setting anisotropy if the texture has NEAREST magFilter.

I'm not sure: would this need to be applied on the new WebGPURenderer and so on as well?

*This contribution is funded by [Needle](https://needle.tools)*
