### PR TITLE
WebGPURenderer: Fix binding size

### DIFF
--- a/examples/jsm/renderers/webgpu/WebGPUUniformsGroup.js
+++ b/examples/jsm/renderers/webgpu/WebGPUUniformsGroup.js
@@ -90,7 +90,7 @@ class WebGPUUniformsGroup extends WebGPUUniformBuffer {
 
 		}
 
-		return offset;
+		return Math.ceil( offset / GPUChunkSize ) * GPUChunkSize;
 
 	}
 


### PR DESCRIPTION
**Description**

The last update of WebGPU check if the binding size follows the STD140.
This PR adds a check in final size to add some extra bytes if needed.

By the way, this recently WebGPU update broken the current examples (without this fix),
maybe a cherry picker of this commit can be necessary to master?

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Google](https://google.com)*
