### PR TITLE
WebGPU & Nodes: FogExp2 and revision

### DIFF
--- a/examples/jsm/nodes/Nodes.js
+++ b/examples/jsm/nodes/Nodes.js
@@ -112,6 +112,7 @@ import CheckerNode from './procedural/CheckerNode.js';
 // fog
 import FogNode from './fog/FogNode.js';
 import FogRangeNode from './fog/FogRangeNode.js';
+import FogExp2Node from './fog/FogExp2Node.js';
 
 // core
 export * from './core/constants.js';
@@ -234,6 +235,7 @@ const nodeLib = {
 	// fog
 	FogNode,
 	FogRangeNode,
+	FogExp2Node,
 
 	// loaders
 	NodeLoader,
@@ -358,6 +360,7 @@ export {
 	// fog
 	FogNode,
 	FogRangeNode,
+	FogExp2Node,
 
 	// loaders
 	NodeLoader,

--- a/examples/jsm/nodes/fog/FogExp2Node.js
+++ b/examples/jsm/nodes/fog/FogExp2Node.js
@@ -1,0 +1,27 @@
+import FogNode from './FogNode.js';
+import { sub, exp, mul, negate, positionView } from '../shadernode/ShaderNodeBaseElements.js';
+
+class FogExp2Node extends FogNode {
+
+	constructor( colorNode, densityNode ) {
+
+		super( colorNode );
+
+		this.isFogExp2Node = true;
+
+		this.densityNode = densityNode;
+
+	}
+
+	construct() {
+
+		const depthNode = negate( positionView.z );
+		const densityNode = this.densityNode;
+
+		this.factorNode = sub( 1.0, exp( mul( negate( densityNode ), densityNode, depthNode, depthNode ) ) );
+
+	}
+
+}
+
+export default FogExp2Node;

--- a/examples/jsm/nodes/fog/FogRangeNode.js
+++ b/examples/jsm/nodes/fog/FogRangeNode.js
@@ -14,11 +14,9 @@ class FogRangeNode extends FogNode {
 
 	}
 
-	generate( builder ) {
+	construct() {
 
 		this.factorNode = smoothstep( this.nearNode, this.farNode, negate( positionView.z ) );
-
-		return super.generate( builder );
 
 	}
 

--- a/examples/jsm/nodes/materials/NodeMaterial.js
+++ b/examples/jsm/nodes/materials/NodeMaterial.js
@@ -5,7 +5,7 @@ import {
 	float, vec3, vec4,
 	assign, label, mul, bypass, attribute,
 	positionLocal, skinning, instance, modelViewProjection, lightingContext, colorSpace,
-	materialAlphaTest, materialColor, materialOpacity
+	materialAlphaTest, materialColor, materialOpacity, reference, rangeFog, exp2Fog
 } from '../shadernode/ShaderNodeElements.js';
 
 class NodeMaterial extends ShaderMaterial {
@@ -140,7 +140,29 @@ class NodeMaterial extends ShaderMaterial {
 
 		// FOG
 
-		if ( builder.fogNode ) outputNode = vec4( vec3( builder.fogNode.mix( outputNode ) ), outputNode.w );
+		let fogNode = builder.fogNode;
+
+		if ( fogNode?.isNode !== true && builder.scene.fog ) {
+
+			const fog = builder.scene.fog;
+
+			if ( fog.isFogExp2 ) {
+
+				fogNode = exp2Fog( reference( 'color', 'color', fog ), reference( 'density', 'float', fog ) );
+
+			} else if ( fog.isFog ) {
+
+				fogNode = rangeFog( reference( 'color', 'color', fog ), reference( 'near', 'float', fog ), reference( 'far', 'float', fog ) );
+
+			} else {
+
+				console.warn( `NodeMaterial: Fog "${ fog.constructor.name }" is not compatible.` );
+
+			}
+			
+		}
+
+		if ( fogNode ) outputNode = vec4( vec3( fogNode.mix( outputNode ) ), outputNode.w );
 
 		// RESULT
 

--- a/examples/jsm/nodes/materials/NodeMaterial.js
+++ b/examples/jsm/nodes/materials/NodeMaterial.js
@@ -156,7 +156,7 @@ class NodeMaterial extends ShaderMaterial {
 
 			} else {
 
-				console.warn( `NodeMaterial: Fog "${ fog.constructor.name }" is not compatible.` );
+				console.error( 'NodeMaterial: Unsupported fog configuration.', fog );
 
 			}
 			

--- a/examples/jsm/nodes/shadernode/ShaderNodeElements.js
+++ b/examples/jsm/nodes/shadernode/ShaderNodeElements.js
@@ -38,6 +38,7 @@ import CheckerNode from '../procedural/CheckerNode.js';
 // fog
 import FogNode from '../fog/FogNode.js';
 import FogRangeNode from '../fog/FogRangeNode.js';
+import FogExp2Node from '../fog/FogExp2Node.js';
 
 // shader node utils
 import { nodeObject, nodeProxy, nodeImmutable } from './ShaderNode.js';
@@ -147,3 +148,4 @@ export const checker = nodeProxy( CheckerNode );
 
 export const fog = nodeProxy( FogNode );
 export const rangeFog = nodeProxy( FogRangeNode );
+export const exp2Fog = nodeProxy( FogExp2Node );


### PR DESCRIPTION
**Description**

Backward compatible of `THREE.Fog` and `THREE.FogExp2` for `WebGPURenderer`.

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Example](https://example.com)*
