### PR TITLE
GLTFLoader: Add loadNode hook

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2540,7 +2540,11 @@ class GLTFParser {
 					break;
 
 				case 'node':
-					dependency = this.loadNode( index );
+					dependency = this._invokeOne( function ( ext ) {
+
+						return ext.loadNode && ext.loadNode( index );
+
+					} );
 					break;
 
 				case 'mesh':


### PR DESCRIPTION
**Description**

This PR adds `loadNode` hook to `GLTFParser`. /cc @donmccurdy 

Use case:

This hook is needed for glTF LOD extensions ([`MSFT_lod`](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Vendor/MSFT_lod) or [`EXT_node_lod`](https://github.com/KhronosGroup/glTF/pull/2228))

```javascript
// LOD extension plugin
loadNode(nodeIndex) {
    // Some set up here
    ...
    //

    const lod = new LOD();
    const pending = [];
    pending.push(parser.loadNode(nodeIndex));
    for (let i = 0; i < extensionDef.lods.length; i++) {
        pending.push(parser.getDependency('node', extensionDef.lods[i].node));
    }
    return Promise.all(pending).then(nodes => {
        for (let i = 0; i < nodes.length; i++) {
            lod.addLevel(node, coverages[i]);
        }
        return lod;
    });
}
```