### PR TITLE
GLTFLoader: loadNode() dependency request optimization

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -3883,7 +3883,7 @@ class GLTFParser {
 
 		return ( function () {
 
-			const pending = [];
+			const objectPending = [];
 
 			const meshPromise = parser._invokeOne( function ( ext ) {
 
@@ -3893,13 +3893,13 @@ class GLTFParser {
 
 			if ( meshPromise ) {
 
-				pending.push( meshPromise );
+				objectPending.push( meshPromise );
 
 			}
 
 			if ( nodeDef.camera !== undefined ) {
 
-				pending.push( parser.getDependency( 'camera', nodeDef.camera ).then( function ( camera ) {
+				objectPending.push( parser.getDependency( 'camera', nodeDef.camera ).then( function ( camera ) {
 
 					return parser._getNodeRef( parser.cameraCache, nodeDef.camera, camera );
 
@@ -3913,13 +3913,34 @@ class GLTFParser {
 
 			} ).forEach( function ( promise ) {
 
-				pending.push( promise );
+				objectPending.push( promise );
 
 			} );
 
-			return Promise.all( pending );
+			const childPending = [];
+			const childrenDef = nodeDef.children || [];
 
-		}() ).then( function ( objects ) {
+			for ( let i = 0, il = childrenDef.length; i < il; i ++ ) {
+
+				childPending.push( parser.getDependency( 'node', childrenDef[ i ] ) );
+
+			}
+
+			const skeletonPending = nodeDef.skin === undefined
+				? Promise.resolve( null )
+				: parser.getDependency( 'skin', nodeDef.skin );
+
+			return Promise.all( [
+				Promise.all( objectPending ),
+				Promise.all( childPending ),
+				skeletonPending
+			] );
+
+		}() ).then( function ( results ) {
+
+			const objects = results[ 0 ];
+			const children = results[ 1 ];
+			const skeleton = results[ 2 ];
 
 			let node;
 
@@ -3999,9 +4020,7 @@ class GLTFParser {
 
 			parser.associations.get( node ).nodes = nodeIndex;
 
-			if ( nodeDef.skin === undefined ) return node;
-
-			return parser.getDependency( 'skin', nodeDef.skin ).then( function ( skeleton ) {
+			if ( skeleton !== null ) {
 
 				// This full traverse should be fine because
 				// child glTF nodes have not been added to this node yet.
@@ -4013,34 +4032,15 @@ class GLTFParser {
 
 				} );
 
-				return node;
+			}
 
-			} );
+			for ( let i = 0, il = children.length; i < il; i ++ ) {
 
-		} ).then( function ( node ) {
-
-			if ( nodeDef.children === undefined ) return node;
-
-			const pending = [];
-			const childrenDef = nodeDef.children;
-
-			for ( let i = 0, il = childrenDef.length; i < il; i ++ ) {
-
-				pending.push( parser.getDependency( 'node', childrenDef[ i ] ) );
+				node.add( children[ i ] );
 
 			}
 
-			return Promise.all( pending ).then( function ( children ) {
-
-				for ( let i = 0, il = children.length; i < il; i ++ ) {
-
-					node.add( children[ i ] );
-
-				}
-
-				return node;
-
-			} );
+			return node;
 
 		} );
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/25058#issue-1472216221

**Description**

Currently `loadNode()` first requests the object dependencies for a node, and then it requests skin dependency whey the object dependencies are resolved, and then requests child node dependencies when the skin dependency is resolved. This chain can be long and the response time from the loader can be long. (The problem has been originally mentioned at https://github.com/mrdoob/three.js/pull/15587#issuecomment-454485222)

This PR optimizes the dependency requests in `loadNode()`. Start all the dependency requests for a node at the beginning of `loadNode()`. Shorter response time can be expected because of the better use of download parallelism.

Note: This change doesn't have an effect to Three.js scene graph order.

**Additional context**

Honestly I don't have a test glTF asset. I'd be happy if someone would test and check how much this change can improve the response time.