### PR TITLE
TransformControls: Fix position of AXIS handle.

### DIFF
--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -1197,7 +1197,6 @@ class TransformControlsGizmo extends Object3D {
 
 				if ( handle.name === 'AXIS' ) {
 
-					handle.position.copy( this.worldPositionStart );
 					handle.visible = !! this.axis;
 
 					if ( this.axis === 'X' ) {


### PR DESCRIPTION
Fixed: #25063

**Description**

The axis handle already has the right position since it's a child element of the transformed 3D object.
