### PR TITLE
Remove CSS2DObject from CSS2DRender when Object3D is Removed

### DIFF
--- a/examples/jsm/renderers/CSS2DRenderer.js
+++ b/examples/jsm/renderers/CSS2DRenderer.js
@@ -22,7 +22,7 @@ class CSS2DObject extends Object3D {
 		const _this = this;
 		this.addEventListener( 'added', function() {
 			
-			_this.parent.addEventListener('removed', function() {
+			_this.parent.addEventListener( 'removed', function() {
 				
 				_this.removeFromParent();
 

--- a/examples/jsm/renderers/CSS2DRenderer.js
+++ b/examples/jsm/renderers/CSS2DRenderer.js
@@ -11,12 +11,12 @@ class CSS2DObject extends Object3D {
 		super();
 
 		this.isCSS2DObject = true;
-		
+
 		this.element = element;
-		
+
 		this.element.style.position = 'absolute';
 		this.element.style.userSelect = 'none';
-		
+
 		this.element.setAttribute( 'draggable', false );
 		
 		const _this = this;

--- a/examples/jsm/renderers/CSS2DRenderer.js
+++ b/examples/jsm/renderers/CSS2DRenderer.js
@@ -11,13 +11,24 @@ class CSS2DObject extends Object3D {
 		super();
 
 		this.isCSS2DObject = true;
-
+		
 		this.element = element;
-
+		
 		this.element.style.position = 'absolute';
 		this.element.style.userSelect = 'none';
-
+		
 		this.element.setAttribute( 'draggable', false );
+		
+		const _this = this;
+		this.addEventListener( 'added', function() {
+			
+			_this.parent.addEventListener('removed', function() {
+				
+				_this.removeFromParent();
+
+			});
+
+		});
 
 		this.addEventListener( 'removed', function () {
 


### PR DESCRIPTION
## Description

**The Problem**: When Object3D objects are removed, their child CSS2DObject types are not removed from the CSS2DRenderer.

**The Solution**: CSS2DObject types will now be removed when the parent Object3D type is removed. The CSS2DObject "removed" event is safely invoked after it is added to the parent Object3D.

Use cases:
```
// The child CSS2DObject will now be removed
moon.removeFromParent();

// This will also remove the child CSS2DObject(s)
scene.clear(); 
```

