### PR TITLE
WebGLUniformsGroups: Fix programs sharing multiple ubo and support array uniforms

### DIFF
--- a/examples/webgl2_ubo.html
+++ b/examples/webgl2_ubo.html
@@ -88,23 +88,30 @@
 
 		<script id="vertexShader2" type="x-shader/x-vertex">
 
-			uniform ViewData {
+			layout(std140) uniform ViewData {
 				mat4 projectionMatrix;
 				mat4 viewMatrix;
 			};
 
 			uniform mat4 modelMatrix;
+			uniform mat3 normalMatrix;
 
 			in vec3 position;
+			in vec3 normal;
 			in vec2 uv;
 
+			out vec3 vPositionEye;
+			out vec3 vNormalEye;
 			out vec2 vUv;
 
 			void main()	{
 
-				vUv = uv;
+				vec4 vertexPositionEye = viewMatrix * modelMatrix * vec4( position, 1.0 );
 
-				gl_Position = projectionMatrix * viewMatrix * modelMatrix * vec4( position, 1.0 );
+				vPositionEye = vertexPositionEye.xyz;
+				vNormalEye = normalMatrix * normal;
+				vUv = uv;
+				gl_Position = projectionMatrix * vertexPositionEye;
 
 			}
 
@@ -117,12 +124,38 @@
 			uniform sampler2D diffuseMap;
 
 			in vec2 vUv;
-
+			in vec3 vPositionEye;
+			in vec3 vNormalEye;
 			out vec4 fragColor;
+
+			uniform LightingData {
+				vec3 position;
+				vec3 ambientColor;
+				vec3 diffuseColor;
+				vec3 specularColor;
+				float shininess;
+			} Light;
 
 			void main()	{
 
-				fragColor = texture( diffuseMap, vUv );
+
+				// a very basic lighting equation (Phong reflection model) for testing
+
+				vec3 l = normalize( Light.position - vPositionEye );
+				vec3 n = normalize( vNormalEye );
+				vec3 e = - normalize( vPositionEye );
+				vec3 r = normalize( reflect( - l, n ) );
+
+				float diffuseLightWeighting = max( dot( n, l ), 0.0 );
+				float specularLightWeighting = max( dot( r, e ), 0.0 );
+
+				specularLightWeighting = pow( specularLightWeighting, Light.shininess );
+
+				vec3 lightWeighting = Light.ambientColor +
+					Light.diffuseColor * diffuseLightWeighting +
+					Light.specularColor * specularLightWeighting;
+
+				fragColor = vec4( texture( diffuseMap, vUv ).rgb * lightWeighting.rgb, 1.0 );
 
 			}
 
@@ -242,7 +275,7 @@
 
 						mesh = new THREE.Mesh( geometry2, material2.clone() );
 
-						mesh.material.uniformsGroups = [ cameraUniformsGroup ];
+						mesh.material.uniformsGroups = [ cameraUniformsGroup, lightingUniformsGroup ];
 						mesh.material.uniforms.modelMatrix.value = mesh.matrixWorld;
 						mesh.material.uniforms.diffuseMap.value = texture;
 

--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -307,7 +307,7 @@ function WebGLState( gl, extensions, capabilities ) {
 	const stencilBuffer = new StencilBuffer();
 
 	const uboBindings = new WeakMap();
-	const uboProgamMap = new WeakMap();
+	const uboProgramMap = new WeakMap();
 
 	let enabledCapabilities = {};
 
@@ -1104,13 +1104,13 @@ function WebGLState( gl, extensions, capabilities ) {
 
 	function updateUBOMapping( uniformsGroup, program ) {
 
-		let mapping = uboProgamMap.get( program );
+		let mapping = uboProgramMap.get( program );
 
 		if ( mapping === undefined ) {
 
 			mapping = new WeakMap();
 
-			uboProgamMap.set( program, mapping );
+			uboProgramMap.set( program, mapping );
 
 		}
 
@@ -1128,16 +1128,15 @@ function WebGLState( gl, extensions, capabilities ) {
 
 	function uniformBlockBinding( uniformsGroup, program ) {
 
-		const mapping = uboProgamMap.get( program );
+		const mapping = uboProgramMap.get( program );
 		const blockIndex = mapping.get( uniformsGroup );
 
-		if ( uboBindings.get( uniformsGroup ) !== blockIndex ) {
+		if ( uboBindings.get( program ) !== blockIndex ) {
 
 			// bind shader specific block index to global block point
-
 			gl.uniformBlockBinding( program, blockIndex, uniformsGroup.__bindingPointIndex );
 
-			uboBindings.set( uniformsGroup, blockIndex );
+			uboBindings.set( program, blockIndex );
 
 		}
 


### PR DESCRIPTION
This PR fixes the fact that the UBO cache system was previously based per block and not per program which was breaking as soon as more than one UBO was used (wrong index). I updated the example by adding the lights UBO on the second material, to reproduce the issue just set back the old cache system in `WebGLState.js`:
`uboBindings.get( program )` => `uboBindings.get( uniformsGroup )` and you will see that the programs fail based randomly.

It seems that with multiple UBOs attached this change will trigger `uniformBlockBinding` per frame, I wonder about the performance implication of this call.


The PR also introduces the support for uniform array structure. For example:
```
struct PointLight {
	vec4 position;
	vec4 color;
};

layout(std140) uniform LightingData {
	PointLight pointLight[40];
};
```

Also, it might be interesting to add a note that it is necessary to only use vec4 with UBO and std140.

Most GPUs (Apple for example) do not render a correct result if a non-vec4 is being used when using a uniform array and std140.
