### PR TITLE
Change other geometry defaults to match blender

### DIFF
--- a/docs/api/en/geometries/CircleGeometry.html
+++ b/docs/api/en/geometries/CircleGeometry.html
@@ -50,7 +50,7 @@
 		<h3>[name]([param:Float radius], [param:Integer segments], [param:Float thetaStart], [param:Float thetaLength])</h3>
 		<p>
 		radius — Radius of the circle, default = 1.<br />
-		segments — Number of segments (triangles), minimum = 3, default = 8.<br />
+		segments — Number of segments (triangles), minimum = 3, default = 32.<br />
 		thetaStart — Start angle for first segment, default = 0 (three o'clock position).<br />
 		thetaLength — The central angle, often called theta, of the circular sector. The default is 2*Pi, which makes for a complete circle.
 		</p>

--- a/docs/api/en/geometries/ConeGeometry.html
+++ b/docs/api/en/geometries/ConeGeometry.html
@@ -45,7 +45,7 @@
 		<p>
 		radius — Radius of the cone base. Default is 1.<br />
 		height — Height of the cone. Default is 1.<br />
-		radialSegments — Number of segmented faces around the circumference of the cone. Default is 8<br />
+		radialSegments — Number of segmented faces around the circumference of the cone. Default is 32<br />
 		heightSegments — Number of rows of faces along the height of the cone. Default is 1.<br />
 		openEnded — A Boolean indicating whether the base of the cone is open or capped. Default is false, meaning capped.<br />
 		thetaStart — Start angle for first segment, default = 0 (three o'clock position).<br />

--- a/docs/api/en/geometries/CylinderGeometry.html
+++ b/docs/api/en/geometries/CylinderGeometry.html
@@ -46,7 +46,7 @@
 		radiusTop — Radius of the cylinder at the top. Default is 1.<br />
 		radiusBottom — Radius of the cylinder at the bottom. Default is 1.<br />
 		height — Height of the cylinder. Default is 1.<br />
-		radialSegments — Number of segmented faces around the circumference of the cylinder. Default is 8<br />
+		radialSegments — Number of segmented faces around the circumference of the cylinder. Default is 32<br />
 		heightSegments — Number of rows of faces along the height of the cylinder. Default is 1.<br />
 		openEnded — A Boolean indicating whether the ends of the cylinder are open or capped. Default is false, meaning capped.<br />
 		thetaStart — Start angle for first segment, default = 0 (three o'clock position).<br />

--- a/docs/api/en/geometries/RingGeometry.html
+++ b/docs/api/en/geometries/RingGeometry.html
@@ -45,7 +45,7 @@
 		<p>
 		innerRadius — Default is 0.5. <br />
 		outerRadius — Default is 1. <br />
-		thetaSegments — Number of segments.  A higher number means the ring will be more round.  Minimum is 3.  Default is 8. <br />
+		thetaSegments — Number of segments.  A higher number means the ring will be more round.  Minimum is 3.  Default is 32. <br />
 		phiSegments — Minimum is 1.  Default is 1.<br />
 		thetaStart — Starting angle. Default is 0. <br />
 		thetaLength — Central angle.  Default is Math.PI * 2.

--- a/docs/api/en/geometries/TorusGeometry.html
+++ b/docs/api/en/geometries/TorusGeometry.html
@@ -45,8 +45,8 @@
 		<p>
 		radius - Radius of the torus, from the center of the torus to the center of the tube. Default is 1. <br />
 		tube — Radius of the tube.  Default is 0.4. <br />
-		radialSegments — Default is 8 <br />
-		tubularSegments — Default is 6. <br />
+		radialSegments — Default is 12 <br />
+		tubularSegments — Default is 48. <br />
 		arc — Central angle.  Default is Math.PI * 2.
 		</p>
 

--- a/docs/api/fr/geometries/CircleGeometry.html
+++ b/docs/api/fr/geometries/CircleGeometry.html
@@ -50,7 +50,7 @@
 		<h3>[name]([param:Float radius], [param:Integer segments], [param:Float thetaStart], [param:Float thetaLength])</h3>
 		<p>
 		radius — Rayon du cercle, par défaut = 1.<br />
-		segments — Nombre de segments (triangles), minimum = 3, défaut = 8.<br />
+		segments — Nombre de segments (triangles), minimum = 3, défaut = 32.<br />
 		thetaStart — Angle de départ pour le premier segment, par défaut = 0 (position trois heures).<br />
 		thetaLength — L'angle central, souvent appelé thêta, du secteur circulaire. La valeur par défaut est 2*Pi, ce qui fait un cercle complet.
 		</p>

--- a/docs/api/fr/geometries/ConeGeometry.html
+++ b/docs/api/fr/geometries/ConeGeometry.html
@@ -45,7 +45,7 @@
 		<p>
 		radius — Rayon de la base du cône. La valeur par défaut est 1.<br />
 		height — Hauteur du cône. La valeur par défaut est 1.<br />
-		radialSegments — Nombre de faces segmentées autour de la circonférence du cône. La valeur par défaut est 8.<br />
+		radialSegments — Nombre de faces segmentées autour de la circonférence du cône. La valeur par défaut est 32.<br />
 		heightSegments — Nombre de rangées de faces sur la hauteur du cône. La valeur par défaut est 1.<br />
 		openEnded — Un booléen indiquant si la base du cône est ouverte ou fermée. La valeur par défaut est false, ce qui signifie fermée.<br />
 		thetaStart — Angle de départ pour le premier segment, par défaut = 0 (position trois heures).<br />

--- a/docs/api/fr/geometries/CylinderGeometry.html
+++ b/docs/api/fr/geometries/CylinderGeometry.html
@@ -46,7 +46,7 @@
 		radiusTop — Rayon du cylindre supérieur. La valeur par défaut est 1.<br />
 		radiusBottom — Rayon du cylindre inférieur. La valeur par défaut est 1.<br />
 		height — Hauteur du cylindre. La valeur par défaut est 1.<br />
-		radialSegments — Nombre de faces segmentées autour de la circonférence du cylindre. La valeur par défaut est 8.<br />
+		radialSegments — Nombre de faces segmentées autour de la circonférence du cylindre. La valeur par défaut est 32.<br />
 		heightSegments — Nombre de rangées de faces sur la hauteur du cylindre. La valeur par défaut est 1.<br />
 		openEnded — Un booléen indiquant si les extrémités du cylindre sont ouvertes ou fermées. La valeur par défaut est false, ce qui signifie fermées.<br />
 		thetaStart — Angle de départ pour le premier segment, par défaut = 0 (position trois heures).<br />

--- a/docs/api/fr/geometries/RingGeometry.html
+++ b/docs/api/fr/geometries/RingGeometry.html
@@ -45,7 +45,7 @@
 		<p>
 		innerRadius — La valeur par défaut est 0.5.<br />
 		outerRadius — La valeur par défaut est 1. <br />
-		thetaSegments — Nombre de segments. Un nombre plus élevé signifie que l'anneau sera plus rond. Le minimum est 3. La valeur par défaut est 8. <br />
+		thetaSegments — Nombre de segments. Un nombre plus élevé signifie que l'anneau sera plus rond. Le minimum est 3. La valeur par défaut est 32. <br />
 		phiSegments — Le minimum est 1. La valeur par défaut est 1.<br />
 		thetaStart —  Angle de départ. La valeur par défaut est 0.<br />
 		thetaLength — Angle central. La valeur par défaut est Math.PI * 2.

--- a/docs/api/fr/geometries/TorusGeometry.html
+++ b/docs/api/fr/geometries/TorusGeometry.html
@@ -45,8 +45,8 @@
 		<p>
 		radius - Rayon du tore, du centre du tore au centre du tube. La valeur par défaut est 1.<br />
 		tube — Rayon du tube. La valeur par défaut est 0,4.<br />
-		radialSegments — La valeur par défaut est 8 <br />
-		tubularSegments — La valeur par défaut est 6. <br />
+		radialSegments — La valeur par défaut est 12 <br />
+		tubularSegments — La valeur par défaut est 48. <br />
 		arc — Angle central. La valeur par défaut est Math.PI * 2.
 		</p>
 

--- a/docs/api/it/geometries/CircleGeometry.html
+++ b/docs/api/it/geometries/CircleGeometry.html
@@ -50,7 +50,7 @@
 		<h3>[name]([param:Float radius], [param:Integer segments], [param:Float thetaStart], [param:Float thetaLength])</h3>
 		<p>
 		radius — Raggio del cerchio. Il valore predefinito è 1.<br />
-		segments — Numero di segmenti (triangoli). Il valore minimo è 3. Il valore predefinito è 8.<br />
+		segments — Numero di segmenti (triangoli). Il valore minimo è 3. Il valore predefinito è 32.<br />
 		thetaStart — Angolo iniziale per il primo segmento. Il valore predefinito è 0 (posizione ore tre).<br />
 		thetaLength — L'angolo centrale, spesso chiamato theta, del settore circolare. Il valore predefinito è 2*Pi, che crea un cerchio completo.
 		</p>

--- a/docs/api/it/geometries/ConeGeometry.html
+++ b/docs/api/it/geometries/ConeGeometry.html
@@ -45,7 +45,7 @@
 		<p>
 		radius — Raggio della base del cono. Il valore predefinito è 1.<br />
 		height — Altezza del cono. Il valore predefinito è 1.<br />
-		radialSegments — Numero di facce segmentate intorno alla circonferenza del cono. Il valore predefinito è 8.<br />
+		radialSegments — Numero di facce segmentate intorno alla circonferenza del cono. Il valore predefinito è 32.<br />
 		heightSegments — Numero di file di facce lungo l'altezza del cono. Il valore predefinito è 1.<br />
 		openEnded — Un booleano che indica se la base del cono è aperta o chiusa. Il valore predefinito è false, significa chiusa.<br />
 		thetaStart — Angolo iniziale per il primo segmento. Il valore predefinito è 0 (posizione ore tre).<br />

--- a/docs/api/it/geometries/CylinderGeometry.html
+++ b/docs/api/it/geometries/CylinderGeometry.html
@@ -46,7 +46,7 @@
 		radiusTop — Raggio del cilindro nella parte superiore. Il valore predefinito è 1.<br />
 		radiusBottom — Raggio del cilindro nella parte inferiore. Il valore predefinito è 1.<br />
 		height — Altezza del cilindro. Il valore predefinito è 1.<br />
-		radialSegments — Numero di facce segmentate intorno alla circonferenza del cilindro. Il valore predefinito è 8<br />
+		radialSegments — Numero di facce segmentate intorno alla circonferenza del cilindro. Il valore predefinito è 32<br />
 		heightSegments — Numero di file delle facce lungo l'altezza del cilindro. Il valore predefinito è 1.<br />
 		openEnded — Un booleano che indica se le estremità del cilindro sono aperte o chiuse. Il valore predefinito è false, significa chiuse.<br />
 		thetaStart — L'angolo di partenza del primo segmento. Il valore predefinito è 0 (posizione ore tre).<br />

--- a/docs/api/it/geometries/RingGeometry.html
+++ b/docs/api/it/geometries/RingGeometry.html
@@ -45,7 +45,7 @@
 		<p>
 		innerRadius — Il valore predefinito è 0.5.<br />
 		outerRadius — Il valore predefinito è 1.<br />
-		thetaSegments — Numero di segmenti. Un numero alto significa che l'anello sarà più rotondo. Il valore minimo è 3. Il valore predefinito è 8.<br />
+		thetaSegments — Numero di segmenti. Un numero alto significa che l'anello sarà più rotondo. Il valore minimo è 3. Il valore predefinito è 32.<br />
 		phiSegments — Il valore minimo è 1. Il valore predefinito è 1.<br />
 		thetaStart — Angolo di partenza. Il valore predefinito è 0. <br />
 		thetaLength — Angolo centrale. Il valore predefinito è Math.PI * 2.

--- a/docs/api/it/geometries/TorusKnotGeometry.html
+++ b/docs/api/it/geometries/TorusKnotGeometry.html
@@ -47,8 +47,8 @@
 			<ul>
 				<li>radius - Raggio del toro. Il valore predefinito è 1.</li>
 				<li>tube — Raggio del tubo. Il valore predefinito è 0.4.</li>
-				<li>tubularSegments — Il valore predefinito è 64.</li>
-				<li>radialSegments — Il valore predefinito è 8.</li>
+				<li>tubularSegments — Il valore predefinito è 12.</li>
+				<li>radialSegments — Il valore predefinito è 48.</li>
 				<li>p — Questo valore determina, quante volte la geometria si avvolge attorno al suo asse di simmetria rotazionale. Il valore predefinito è 2.</li>
 				<li>q — Questo valore determina, quante volte la geometria si avvolge attorno ad un cerchio all'interno del toro. Il valore predefinito è 3.</li>
 			</ul>

--- a/docs/api/zh/geometries/CircleGeometry.html
+++ b/docs/api/zh/geometries/CircleGeometry.html
@@ -45,7 +45,7 @@
 		<h3>[name]([param:Float radius], [param:Integer segments], [param:Float thetaStart], [param:Float thetaLength])</h3>
 		<p>
 		radius — 圆形的半径，默认值为1<br />
-		segments — 分段（三角面）的数量，最小值为3，默认值为8。<br />
+		segments — 分段（三角面）的数量，最小值为3，默认值为32。<br />
 		thetaStart — 第一个分段的起始角度，默认为0。（three o'clock position）<br />
 		thetaLength — 圆形扇区的中心角，通常被称为“θ”（西塔）。默认值是2*Pi，这使其成为一个完整的圆。
 		</p>

--- a/docs/api/zh/geometries/ConeGeometry.html
+++ b/docs/api/zh/geometries/ConeGeometry.html
@@ -45,7 +45,7 @@
 		<p>
 		radius — 圆锥底部的半径，默认值为1。<br />
 		height — 圆锥的高度，默认值为1。<br />
-		radialSegments —  圆锥侧面周围的分段数，默认为8。<br />
+		radialSegments —  圆锥侧面周围的分段数，默认为32。<br />
 		heightSegments — 圆锥侧面沿着其高度的分段数，默认值为1。<br />
 		openEnded — 一个Boolean值，指明该圆锥的底面是开放的还是封顶的。默认值为false，即其底面默认是封顶的。<br />
 		thetaStart — 第一个分段的起始角度，默认为0。（three o'clock position）<br />

--- a/docs/api/zh/geometries/CylinderGeometry.html
+++ b/docs/api/zh/geometries/CylinderGeometry.html
@@ -46,7 +46,7 @@
 		radiusTop — 圆柱的顶部半径，默认值是1。<br />
 		radiusBottom — 圆柱的底部半径，默认值是1。<br />
 		height — 圆柱的高度，默认值是1。<br />
-		radialSegments —  圆柱侧面周围的分段数，默认为8。<br />
+		radialSegments —  圆柱侧面周围的分段数，默认为32。<br />
 		heightSegments — 圆柱侧面沿着其高度的分段数，默认值为1。<br />
 		openEnded — 一个Boolean值，指明该圆锥的底面是开放的还是封顶的。默认值为false，即其底面默认是封顶的。<br />
 		thetaStart — 第一个分段的起始角度，默认为0。（three o'clock position）<br />

--- a/docs/api/zh/geometries/RingGeometry.html
+++ b/docs/api/zh/geometries/RingGeometry.html
@@ -45,7 +45,7 @@
 		<p>
 			innerRadius — 内部半径，默认值为0.5。 <br />
 			outerRadius — 外部半径，默认值为1。<br />
-			thetaSegments — 圆环的分段数。这个值越大，圆环就越圆。最小值为3，默认值为8。<br />
+			thetaSegments — 圆环的分段数。这个值越大，圆环就越圆。最小值为3，默认值为32。<br />
 			phiSegments — 最小值为1，默认值为8。<br />
 			thetaStart — 起始角度，默认值为0。<br />
 			thetaLength — 圆心角，默认值为Math.PI * 2。

--- a/docs/api/zh/geometries/TorusGeometry.html
+++ b/docs/api/zh/geometries/TorusGeometry.html
@@ -45,8 +45,8 @@
 		<p>
 				radius - 环面的半径，从环面的中心到管道横截面的中心。默认值是1。<br />
 				tube — 管道的半径，默认值为0.4。<br />
-				radialSegments — 管道横截面的分段数，默认值为8。<br />
-				tubularSegments — 管道的分段数，默认值为6。<br />
+				radialSegments — 管道横截面的分段数，默认值为12。<br />
+				tubularSegments — 管道的分段数，默认值为48。<br />
 				arc — 圆环的圆心角（单位是弧度），默认值为Math.PI * 2。
 				</p>
 

--- a/editor/js/Menubar.Add.js
+++ b/editor/js/Menubar.Add.js
@@ -79,7 +79,7 @@ function MenubarAdd( editor ) {
 	option.setTextContent( strings.getKey( 'menubar/add/circle' ) );
 	option.onClick( function () {
 
-		const geometry = new THREE.CircleGeometry( 1, 8, 0, Math.PI * 2 );
+		const geometry = new THREE.CircleGeometry( 1, 32, 0, Math.PI * 2 );
 		const mesh = new THREE.Mesh( geometry, new THREE.MeshStandardMaterial() );
 		mesh.name = 'Circle';
 
@@ -95,7 +95,7 @@ function MenubarAdd( editor ) {
 	option.setTextContent( strings.getKey( 'menubar/add/cylinder' ) );
 	option.onClick( function () {
 
-		const geometry = new THREE.CylinderGeometry( 1, 1, 1, 8, 1, false, 0, Math.PI * 2 );
+		const geometry = new THREE.CylinderGeometry( 1, 1, 1, 32, 1, false, 0, Math.PI * 2 );
 		const mesh = new THREE.Mesh( geometry, new THREE.MeshStandardMaterial() );
 		mesh.name = 'Cylinder';
 
@@ -192,7 +192,7 @@ function MenubarAdd( editor ) {
 	option.setTextContent( strings.getKey( 'menubar/add/ring' ) );
 	option.onClick( function () {
 
-		const geometry = new THREE.RingGeometry( 0.5, 1, 8, 1, 0, Math.PI * 2 );
+		const geometry = new THREE.RingGeometry( 0.5, 1, 32, 1, 0, Math.PI * 2 );
 		const mesh = new THREE.Mesh( geometry, new THREE.MeshStandardMaterial() );
 		mesh.name = 'Ring';
 
@@ -255,7 +255,7 @@ function MenubarAdd( editor ) {
 	option.setTextContent( strings.getKey( 'menubar/add/torus' ) );
 	option.onClick( function () {
 
-		const geometry = new THREE.TorusGeometry( 1, 0.4, 8, 6, Math.PI * 2 );
+		const geometry = new THREE.TorusGeometry( 1, 0.4, 12, 48, Math.PI * 2 );
 		const mesh = new THREE.Mesh( geometry, new THREE.MeshStandardMaterial() );
 		mesh.name = 'Torus';
 

--- a/src/geometries/CircleGeometry.js
+++ b/src/geometries/CircleGeometry.js
@@ -5,7 +5,7 @@ import { Vector2 } from '../math/Vector2.js';
 
 class CircleGeometry extends BufferGeometry {
 
-	constructor( radius = 1, segments = 8, thetaStart = 0, thetaLength = Math.PI * 2 ) {
+	constructor( radius = 1, segments = 32, thetaStart = 0, thetaLength = Math.PI * 2 ) {
 
 		super();
 

--- a/src/geometries/ConeGeometry.js
+++ b/src/geometries/ConeGeometry.js
@@ -2,7 +2,7 @@ import { CylinderGeometry } from './CylinderGeometry.js';
 
 class ConeGeometry extends CylinderGeometry {
 
-	constructor( radius = 1, height = 1, radialSegments = 8, heightSegments = 1, openEnded = false, thetaStart = 0, thetaLength = Math.PI * 2 ) {
+	constructor( radius = 1, height = 1, radialSegments = 32, heightSegments = 1, openEnded = false, thetaStart = 0, thetaLength = Math.PI * 2 ) {
 
 		super( 0, radius, height, radialSegments, heightSegments, openEnded, thetaStart, thetaLength );
 

--- a/src/geometries/CylinderGeometry.js
+++ b/src/geometries/CylinderGeometry.js
@@ -5,7 +5,7 @@ import { Vector2 } from '../math/Vector2.js';
 
 class CylinderGeometry extends BufferGeometry {
 
-	constructor( radiusTop = 1, radiusBottom = 1, height = 1, radialSegments = 8, heightSegments = 1, openEnded = false, thetaStart = 0, thetaLength = Math.PI * 2 ) {
+	constructor( radiusTop = 1, radiusBottom = 1, height = 1, radialSegments = 32, heightSegments = 1, openEnded = false, thetaStart = 0, thetaLength = Math.PI * 2 ) {
 
 		super();
 

--- a/src/geometries/RingGeometry.js
+++ b/src/geometries/RingGeometry.js
@@ -5,7 +5,7 @@ import { Vector3 } from '../math/Vector3.js';
 
 class RingGeometry extends BufferGeometry {
 
-	constructor( innerRadius = 0.5, outerRadius = 1, thetaSegments = 8, phiSegments = 1, thetaStart = 0, thetaLength = Math.PI * 2 ) {
+	constructor( innerRadius = 0.5, outerRadius = 1, thetaSegments = 32, phiSegments = 1, thetaStart = 0, thetaLength = Math.PI * 2 ) {
 
 		super();
 

--- a/src/geometries/TorusGeometry.js
+++ b/src/geometries/TorusGeometry.js
@@ -4,7 +4,7 @@ import { Vector3 } from '../math/Vector3.js';
 
 class TorusGeometry extends BufferGeometry {
 
-	constructor( radius = 1, tube = 0.4, radialSegments = 8, tubularSegments = 6, arc = Math.PI * 2 ) {
+	constructor( radius = 1, tube = 0.4, radialSegments = 12, tubularSegments = 48, arc = Math.PI * 2 ) {
 
 		super();
 


### PR DESCRIPTION
Related Pull Request: #22141

**Description**
All other geometries that had blender defaults were changed to match those defaults. The changes are as follows (SphereGeometry included just for consistency):
SphereGeometry: 8 width, 6 height -> 32 width, 16 height
CircleGeometry: 8 radial -> 32 radial
RingGeometry: 8 radial -> 32 radial
CylinderGeometry: 8 radial -> 32 radial
ConeGeometry: 8 radial -> 32 radial
TorusGeometry: 8 radial, 6 tube -> 12 radial, 48 tube