### PR TITLE
Add class names to CSS2DObjects

### DIFF
--- a/examples/jsm/renderers/CSS2DRenderer.js
+++ b/examples/jsm/renderers/CSS2DRenderer.js
@@ -118,7 +118,9 @@ class CSS2DRenderer {
 
 				const visible = ( object.visible === true ) && ( _vector.z >= - 1 && _vector.z <= 1 ) && ( object.layers.test( camera.layers ) === true );
 				object.element.style.display = ( visible === true ) ? '' : 'none';
-
+				object.element.classList.add('css-object');
+				object.element.classList.toggle('visible', visible);
+	  
 				if ( visible === true ) {
 
 					object.onBeforeRender( _this, scene, camera );


### PR DESCRIPTION
### **Description**

**The problem:** CSS2DObjects are currently hidden/shown using `display: none` with no alternatives for custom css animations.

**The solution:** Adding a class attribute will allow developers to override with css transitions if necessary.

```
.css-object {
  display: block !important;
  pointer-events: none;
  opacity: 0;
  transition: 500ms opacity;

  &.visible {
    opacity: 1;
    pointer-events: all;
  }
}
```