### PR TITLE
Fix blending equation in SSAARenderPass

### DIFF
--- a/examples/jsm/postprocessing/SSAARenderPass.js
+++ b/examples/jsm/postprocessing/SSAARenderPass.js
@@ -1,5 +1,8 @@
 import {
-	AdditiveBlending,
+	CustomBlending,
+	OneFactor,
+	AddEquation,
+	SrcAlphaFactor,
 	Color,
 	ShaderMaterial,
 	UniformsUtils,
@@ -43,9 +46,16 @@ class SSAARenderPass extends Pass {
 			vertexShader: copyShader.vertexShader,
 			fragmentShader: copyShader.fragmentShader,
 			transparent: true,
-			blending: AdditiveBlending,
 			depthTest: false,
-			depthWrite: false
+			depthWrite: false,
+
+			// do not use AdditiveBlending because it mixes the alpha channel instead of adding
+			blending: CustomBlending,
+			blendEquation: AddEquation,
+			blendDst: OneFactor,
+			blendDstAlpha: OneFactor,
+			blendSrc: SrcAlphaFactor,
+			blendSrcAlpha: OneFactor
 		} );
 
 		this.fsQuad = new FullScreenQuad( this.copyMaterial );


### PR DESCRIPTION
**Description**

SSAARenderPass currently uses the wrong blending equation to average out several subrenders, this results in opaque objects having less than 1 alpha. This can be seen by adding a red css background to the canvas in the example (https://threejs.org/examples/webgl_postprocessing_ssaa.html).

This PR changes the blending equation to correctly sum the alpha channel instead of repeatedly mixing it.

![image](https://user-images.githubusercontent.com/7593843/205971191-e629fd42-b061-460e-8719-8651896917c1.png)
