### PR TITLE
webgl_shadowmap_pointlight: customDistanceMaterial is no longer required

### DIFF
--- a/examples/webgl_shadowmap_pointlight.html
+++ b/examples/webgl_shadowmap_pointlight.html
@@ -80,13 +80,6 @@
 					sphere.receiveShadow = true;
 					light.add( sphere );
 
-					// custom distance material
-					const distanceMaterial = new THREE.MeshDistanceMaterial( {
-						alphaMap: material.alphaMap,
-						alphaTest: material.alphaTest
-					} );
-					sphere.customDistanceMaterial = distanceMaterial;
-
 					return light;
 
 				}


### PR DESCRIPTION
Related: #25000

What would be nice is an example where a custom distance material, or depth material,  _is_ required.