### PR TITLE
WebGLRenderer: Allow custom function for shader compilation error reporting.

### DIFF
--- a/docs/api/en/renderers/WebGLRenderer.html
+++ b/docs/api/en/renderers/WebGLRenderer.html
@@ -97,10 +97,11 @@
 		<h3>[property:Object debug]</h3>
 		<p>
 		- [page:Boolean checkShaderErrors]:
-		  If it is true, defines whether material shader programs are checked
+			If set to true or a function, defines whether material shader programs are checked
 			for errors during compilation and linkage process. It may be useful to disable this check in production for performance gain.
 			It is strongly recommended to keep these checks enabled during development.
 			If the shader does not compile and link - it will not work and associated material will not render.
+			Setting to a function calls function with the error, and setting to true will log to `console.error`.
 			Default is `true`.
 		</p>
 

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -786,13 +786,31 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 			const vertexErrors = getShaderErrors( gl, glVertexShader, 'vertex' );
 			const fragmentErrors = getShaderErrors( gl, glFragmentShader, 'fragment' );
 
-			console.error(
-				'THREE.WebGLProgram: Shader Error ' + gl.getError() + ' - ' +
-				'VALIDATE_STATUS ' + gl.getProgramParameter( program, gl.VALIDATE_STATUS ) + '\n\n' +
+			const glError = gl.getError();
+			const validateStatus = gl.getProgramParameter( program, gl.VALIDATE_STATUS );
+			const error = (
+				'THREE.WebGLProgram: Shader Error ' + glError + ' - ' +
+				'VALIDATE_STATUS ' + validateStatus + '\n\n' +
 				'Program Info Log: ' + programLog + '\n' +
 				vertexErrors + '\n' +
 				fragmentErrors
 			);
+			if ( renderer.debug.checkShaderErrors instanceof Function ) {
+
+				renderer.debug.checkShaderErrors(
+					error,
+					glError,
+					validateStatus,
+					programLog,
+					vertexErrors,
+					fragmentErrors
+				);
+
+			} else {
+
+				console.error( error );
+
+			}
 
 		} else if ( programLog !== '' ) {
 


### PR DESCRIPTION
### Description

**Problem**: I'd like to override the error reporting for shader errors with a custom callback. 

**Solution**: This allows `WebGLRenderer.debug.checkShaderErrors` to also be a function, which is called instead of `console.error`