### PR TITLE
USDZExporter: Throw exception when processing textures with no image data.

### DIFF
--- a/examples/jsm/exporters/USDZExporter.js
+++ b/examples/jsm/exporters/USDZExporter.js
@@ -163,19 +163,9 @@ function imageToCanvas( image, color ) {
 
 		return canvas;
 
-	} else if ( image === null ) {
-
-		console.warn( 'THREE.USDZExporter: Texture with no image data detected. Deserialize fallback data instead.' );
-
-		const canvas = document.createElement( 'canvas' );
-		canvas.width = 1;
-		canvas.height = 1;
-
-		return canvas;
-
 	} else {
 
-		console.error( 'THREE.USDZExporter: Unable to deserialize image data.' );
+		throw new Error( 'THREE.USDZExporter: No image data found. Unable to process texture.' );
 
 	}
 

--- a/examples/jsm/exporters/USDZExporter.js
+++ b/examples/jsm/exporters/USDZExporter.js
@@ -165,7 +165,7 @@ function imageToCanvas( image, color ) {
 
 	} else {
 
-		throw new Error( 'THREE.USDZExporter: No image data found. Unable to process texture.' );
+		throw new Error( 'THREE.USDZExporter: No valid image data found. Unable to process texture.' );
 
 	}
 

--- a/examples/jsm/exporters/USDZExporter.js
+++ b/examples/jsm/exporters/USDZExporter.js
@@ -163,6 +163,20 @@ function imageToCanvas( image, color ) {
 
 		return canvas;
 
+	} else if ( image === null ) {
+
+		console.warn( 'THREE.USDZExporter: Texture with no image data detected. Deserialize fallback data instead.' );
+
+		const canvas = document.createElement( 'canvas' );
+		canvas.width = 1;
+		canvas.height = 1;
+
+		return canvas;
+
+	} else {
+
+		console.error( 'THREE.USDZExporter: Unable to deserialize image data.' );
+
 	}
 
 }


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/25022#discussion_r1033259372

**Description**

`USDZExporter` reports a warning now when users try to export an asset with textures holding no image data (`image=null`).