### PR TITLE
Object3D: Ensure .localToWorld() uses the updated world matrix

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -247,11 +247,15 @@ class Object3D extends EventDispatcher {
 
 	localToWorld( vector ) {
 
+		this.updateWorldMatrix( true, false );
+
 		return vector.applyMatrix4( this.matrixWorld );
 
 	}
 
 	worldToLocal( vector ) {
+
+		this.updateWorldMatrix( true, false );
 
 		return vector.applyMatrix4( _m1.copy( this.matrixWorld ).invert() );
 


### PR DESCRIPTION
... as in `Object3D.getWorldPosition()`, etc.