### PR TITLE
Unicode links

### DIFF
--- a/docs/manual/ar/buildTools/Testing-with-NPM.html
+++ b/docs/manual/ar/buildTools/Testing-with-NPM.html
@@ -123,7 +123,7 @@ $ npm install three --save-dev
 							<code>
  $ npm install three@0.84.0 --save
 							</code>
-							(0.84.0 في هذا المثال). - حفظ يجعل هذا تبعية لهذا المشروع ، بدلاً من dev تبعية. انظر المستندات هنا [link:https://docs.npmjs.com/cli/v8/configuring-npm/package-json here] لمزيد من المعلومات.
+							(0.84.0 في هذا المثال). - حفظ يجعل هذا تبعية لهذا المشروع ، بدلاً من dev تبعية. انظر المستندات [link:https://docs.npmjs.com/cli/v8/configuring-npm/package-json هنا] لمزيد من المعلومات.
 						</li>
 					</ul>
 				</li>
@@ -173,12 +173,12 @@ The THREE object should be able to construct a Vector3 with default of x=0: 0ms
 				<li>
 					اكتب اختبارًا للسلوك المتوقع لشفرتك ، وضعه تحت test/.
 					هنا مثال من مشروع حقيقي
-					[link:https://github.com/air/encounter/blob/master/test/Physics-test.js Here].
+					[link:https://github.com/air/encounter/blob/master/test/Physics-test.js هنا].
 				</li>
 
 				<li>
 					قم بتصدير الكود الوظيفي الخاص بك بطريقة يمكن للعقدة js رؤيتها ، لاستخدامها مع طلب.
-					شاهده هنا [link:https://github.com/air/encounter/blob/master/js/Physics.js here].
+					شاهده [link:https://github.com/air/encounter/blob/master/js/Physics.js هنا].
 				</li>
 
 				<li>

--- a/docs/page.css
+++ b/docs/page.css
@@ -76,6 +76,7 @@ body.rtl table {
 }
 body.rtl code {
 	direction: ltr !important;
+	text-align: initial;
 }
 
 a {

--- a/docs/page.js
+++ b/docs/page.js
@@ -70,7 +70,7 @@ function onDocumentLoad() {
 	text = text.replace( /\[param:([\w\.]+) ([\w\.\s]+)\]/gi, '$2 : <a class="param" onclick="window.parent.setUrlFragment(\'$1\')">$1</a>' ); // [param:name title]
 
 	text = text.replace( /\[link:([\w\:\/\.\-\_\(\)\?\#\=\!\~]+)\]/gi, '<a href="$1" target="_blank">$1</a>' ); // [link:url]
-	text = text.replace( /\[link:([\w\:\/\.\-\_\(\)\?\#\=\!\~]+) ([\w\:\/\.\-\_\'\s]+)\]/gi, '<a href="$1" target="_blank">$2</a>' ); // [link:url title]
+	text = text.replace( /\[link:([\w:/.\-_()?#=!~]+) ([\w\p{L}:/.\-_'\s]+)\]/giu, '<a href="$1" target="_blank">$2</a>' ); // [link:url title]
 	text = text.replace( /\*([\w\d\"\-\(][\w\d\ \/\+\-\(\)\=\,\."]*[\w\d\"\)]|\w)\*/gi, '<strong>$1</strong>' ); // *text*
 	text = text.replace( /\`(.*?)\`/gi, '<code class="inline">$1</code>' ); // `code`
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/25098

**Description**
I started working on Hebrew translation to the docs, and noticed some issues with RTL support and links which use non-[a-zA-Z] characters
It's a pretty big change and there are potentially many follow-up tasks such as:
- Decide if to also allow unicode characters in the href part (need to add % and \p{L} there as well)
- Decide whether to carry this change to other templates (I think that's not relevant, unless the URLs of three.js pages would also be localized, which is not a good idea IMO)
- Find and replace all occurrences where the author localized the link and opted to use inline <a> tags ([for example](https://github.com/mrdoob/three.js/blob/dd5d429285590bfe0d547bb806ee90b0b622c44f/docs/manual/zh/buildTools/Testing-with-NPM.html#L133))

The code blocks looks like this currently:
<img width="905" alt="image" src="https://user-images.githubusercontent.com/37291459/206670000-c1ac3e86-e1a7-4f15-bba4-67f9e247aded.png">
The single line blocks are fine, the multi-line blocks and not-unreadable but are not as nice

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Resonai](https://resonai.com)*
