### PR TITLE
ColladaExporter: Throw exception when processing textures with no image data.

### DIFF
--- a/examples/jsm/exporters/ColladaExporter.js
+++ b/examples/jsm/exporters/ColladaExporter.js
@@ -124,21 +124,32 @@ class ColladaExporter {
 
 		function imageToData( image, ext ) {
 
-			canvas = canvas || document.createElement( 'canvas' );
-			ctx = ctx || canvas.getContext( '2d' );
+			if ( ( typeof HTMLImageElement !== 'undefined' && image instanceof HTMLImageElement ) ||
+				( typeof HTMLCanvasElement !== 'undefined' && image instanceof HTMLCanvasElement ) ||
+				( typeof OffscreenCanvas !== 'undefined' && image instanceof OffscreenCanvas ) ||
+				( typeof ImageBitmap !== 'undefined' && image instanceof ImageBitmap ) ) {
 
-			canvas.width = image.width;
-			canvas.height = image.height;
+				canvas = canvas || document.createElement( 'canvas' );
+				ctx = ctx || canvas.getContext( '2d' );
 
-			ctx.drawImage( image, 0, 0 );
+				canvas.width = image.width;
+				canvas.height = image.height;
 
-			// Get the base64 encoded data
-			const base64data = canvas
-				.toDataURL( `image/${ ext }`, 1 )
-				.replace( /^data:image\/(png|jpg);base64,/, '' );
+				ctx.drawImage( image, 0, 0 );
 
-			// Convert to a uint8 array
-			return base64ToBuffer( base64data );
+				// Get the base64 encoded data
+				const base64data = canvas
+					.toDataURL( `image/${ ext }`, 1 )
+					.replace( /^data:image\/(png|jpg);base64,/, '' );
+
+				// Convert to a uint8 array
+				return base64ToBuffer( base64data );
+
+			} else {
+
+				throw new Error( 'THREE.ColladaExporter: No valid image data found. Unable to process texture.' );
+
+			}
 
 		}
 
@@ -357,7 +368,8 @@ class ColladaExporter {
 		function processTexture( tex ) {
 
 			let texid = imageMap.get( tex );
-			if ( texid == null ) {
+
+			if ( texid === undefined ) {
 
 				texid = `image-${ libraryImages.length + 1 }`;
 


### PR DESCRIPTION
Related issue: #25093

**Description**

Adds the same change for `USDZExporter` to `ColladaExporter`.
