### PR TITLE
GLTFExporter: Throw exception when processing textures with no image data.

### DIFF
--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -1077,112 +1077,120 @@ class GLTFWriter {
 	 */
 	processImage( image, format, flipY, mimeType = 'image/png' ) {
 
-		const writer = this;
-		const cache = writer.cache;
-		const json = writer.json;
-		const options = writer.options;
-		const pending = writer.pending;
+		if ( image !== null ) {
 
-		if ( ! cache.images.has( image ) ) cache.images.set( image, {} );
+			const writer = this;
+			const cache = writer.cache;
+			const json = writer.json;
+			const options = writer.options;
+			const pending = writer.pending;
 
-		const cachedImages = cache.images.get( image );
+			if ( ! cache.images.has( image ) ) cache.images.set( image, {} );
 
-		const key = mimeType + ':flipY/' + flipY.toString();
+			const cachedImages = cache.images.get( image );
 
-		if ( cachedImages[ key ] !== undefined ) return cachedImages[ key ];
+			const key = mimeType + ':flipY/' + flipY.toString();
 
-		if ( ! json.images ) json.images = [];
+			if ( cachedImages[ key ] !== undefined ) return cachedImages[ key ];
 
-		const imageDef = { mimeType: mimeType };
+			if ( ! json.images ) json.images = [];
 
-		const canvas = getCanvas();
+			const imageDef = { mimeType: mimeType };
 
-		canvas.width = Math.min( image.width, options.maxTextureSize );
-		canvas.height = Math.min( image.height, options.maxTextureSize );
+			const canvas = getCanvas();
 
-		const ctx = canvas.getContext( '2d' );
+			canvas.width = Math.min( image.width, options.maxTextureSize );
+			canvas.height = Math.min( image.height, options.maxTextureSize );
 
-		if ( flipY === true ) {
+			const ctx = canvas.getContext( '2d' );
 
-			ctx.translate( 0, canvas.height );
-			ctx.scale( 1, - 1 );
+			if ( flipY === true ) {
 
-		}
-
-		if ( image.data !== undefined ) { // THREE.DataTexture
-
-			if ( format !== RGBAFormat ) {
-
-				console.error( 'GLTFExporter: Only RGBAFormat is supported.' );
+				ctx.translate( 0, canvas.height );
+				ctx.scale( 1, - 1 );
 
 			}
 
-			if ( image.width > options.maxTextureSize || image.height > options.maxTextureSize ) {
+			if ( image.data !== undefined ) { // THREE.DataTexture
 
-				console.warn( 'GLTFExporter: Image size is bigger than maxTextureSize', image );
+				if ( format !== RGBAFormat ) {
 
-			}
+					console.error( 'GLTFExporter: Only RGBAFormat is supported.' );
 
-			const data = new Uint8ClampedArray( image.height * image.width * 4 );
+				}
 
-			for ( let i = 0; i < data.length; i += 4 ) {
+				if ( image.width > options.maxTextureSize || image.height > options.maxTextureSize ) {
 
-				data[ i + 0 ] = image.data[ i + 0 ];
-				data[ i + 1 ] = image.data[ i + 1 ];
-				data[ i + 2 ] = image.data[ i + 2 ];
-				data[ i + 3 ] = image.data[ i + 3 ];
+					console.warn( 'GLTFExporter: Image size is bigger than maxTextureSize', image );
 
-			}
+				}
 
-			ctx.putImageData( new ImageData( data, image.width, image.height ), 0, 0 );
+				const data = new Uint8ClampedArray( image.height * image.width * 4 );
 
-		} else {
+				for ( let i = 0; i < data.length; i += 4 ) {
 
-			ctx.drawImage( image, 0, 0, canvas.width, canvas.height );
+					data[ i + 0 ] = image.data[ i + 0 ];
+					data[ i + 1 ] = image.data[ i + 1 ];
+					data[ i + 2 ] = image.data[ i + 2 ];
+					data[ i + 3 ] = image.data[ i + 3 ];
 
-		}
+				}
 
-		if ( options.binary === true ) {
-
-			pending.push(
-
-				getToBlobPromise( canvas, mimeType )
-					.then( blob => writer.processBufferViewImage( blob ) )
-					.then( bufferViewIndex => {
-
-						imageDef.bufferView = bufferViewIndex;
-
-					} )
-
-			);
-
-		} else {
-
-			if ( canvas.toDataURL !== undefined ) {
-
-				imageDef.uri = canvas.toDataURL( mimeType );
+				ctx.putImageData( new ImageData( data, image.width, image.height ), 0, 0 );
 
 			} else {
+
+				ctx.drawImage( image, 0, 0, canvas.width, canvas.height );
+
+			}
+
+			if ( options.binary === true ) {
 
 				pending.push(
 
 					getToBlobPromise( canvas, mimeType )
-						.then( blob => new FileReader().readAsDataURL( blob ) )
-						.then( dataURL => {
+						.then( blob => writer.processBufferViewImage( blob ) )
+						.then( bufferViewIndex => {
 
-							imageDef.uri = dataURL;
+							imageDef.bufferView = bufferViewIndex;
 
 						} )
 
 				);
 
+			} else {
+
+				if ( canvas.toDataURL !== undefined ) {
+
+					imageDef.uri = canvas.toDataURL( mimeType );
+
+				} else {
+
+					pending.push(
+
+						getToBlobPromise( canvas, mimeType )
+							.then( blob => new FileReader().readAsDataURL( blob ) )
+							.then( dataURL => {
+
+								imageDef.uri = dataURL;
+
+							} )
+
+					);
+
+				}
+
 			}
 
-		}
+			const index = json.images.push( imageDef ) - 1;
+			cachedImages[ key ] = index;
+			return index;
 
-		const index = json.images.push( imageDef ) - 1;
-		cachedImages[ key ] = index;
-		return index;
+		} else {
+
+			throw new Error( 'THREE.GLTFExporter: No valid image data found. Unable to process texture.' );
+
+		}
 
 	}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/25093

**Description**

Adds the same change for `USDZExporter` to `GLTFExporter`.
