### PR TITLE
Benchmarks: Fix rotation setup in `updateMatrixWorld()` test.

### DIFF
--- a/test/benchmark/core/UpdateMatrixWorld.js
+++ b/test/benchmark/core/UpdateMatrixWorld.js
@@ -11,7 +11,7 @@
 		var child = new THREE.Object3D();
 		child.position.copy( position );
 		child.scale.copy( scale );
-		child.rotation.copy( rotation );
+		child.quaternion.copy( rotation );
 		return child;
 
 	};


### PR DESCRIPTION
Related issue: None raised (I can raise if needed, but it didn't seem necessary for such a small fix).

**Description**

When running the benchmark page at /test/benchmark/benchmarks.html, we see this warning in the browser:
```
three.min.js:6 THREE.Quaternion: .setFromEuler() encountered an unknown order: undefined
```

This is because the code sets up a Quaternion, but copies it into the `rotation` property on the Object3D, which is an Euler, not a Quaternion.

Alternative fix would be to do:

```
child.rotation.setFromQuaternion(rotation)
```

Doesn't make a lot of difference, I went for this one as I believe it's marginally more efficient


