### PR TITLE
Benchmarks: Update world transforms / updateMatrixWorld() - improve benchmark realism

### DIFF
--- a/test/benchmark/core/UpdateMatrixWorld.js
+++ b/test/benchmark/core/UpdateMatrixWorld.js
@@ -64,7 +64,7 @@
 
 		child.position.copy( position );
 		child.scale.copy( scale );
-		child.quaternion.copy( rotation );
+		child.rotation.copy( rotation );
 		return child;
 
 	};

--- a/test/benchmark/core/UpdateMatrixWorld.js
+++ b/test/benchmark/core/UpdateMatrixWorld.js
@@ -8,7 +8,8 @@
 	rotation.setFromAxisAngle( new THREE.Vector3( 0, 1, 0 ), Math.PI / 8 );
 	var createLocallyOffsetChild = function (type) {
 
-		let child 
+		let child;
+		let choice;
 
 		switch (type) {
 			case "Object3D":
@@ -17,18 +18,18 @@
 
 			case "Polymorphic":
 				child = new THREE.Object3D();
-				var choice = Math.random();
+				choice = Math.random();
 				if (choice < 0.2) {
-					child.extra1 = "test-polymorphism"
+					child.extra1 = "test-polymorphism";
 				}
 				else if (choice < 0.4) {
-					child.extra2 = "test-polymorphism"
+					child.extra2 = "test-polymorphism";
 				}
 				else if (choice < 0.6) {
-					child.extra3 = "test-polymorphism"
+					child.extra3 = "test-polymorphism";
 				}
 				else if (choice < 0.8) {
-					child.extra4 = "test-polymorphism"
+					child.extra4 = "test-polymorphism";
 				}
 				break;
 
@@ -41,7 +42,7 @@
 				break; 
 
 			case "Realistic":
-				var choice = Math.random();
+				choice = Math.random();
 				if (choice < 0.05) {
 					child = new THREE.InstancedMesh();
 				}

--- a/test/benchmark/core/UpdateMatrixWorld.js
+++ b/test/benchmark/core/UpdateMatrixWorld.js
@@ -6,9 +6,61 @@
 	var scale = new THREE.Vector3( 2, 1, 0.5 );
 	var rotation = new THREE.Quaternion();
 	rotation.setFromAxisAngle( new THREE.Vector3( 0, 1, 0 ), Math.PI / 8 );
-	var createLocallyOffsetChild = function () {
+	var createLocallyOffsetChild = function (type) {
 
-		var child = new THREE.Object3D();
+		let child 
+
+		switch (type) {
+			case "Object3D":
+				child = new THREE.Object3D();
+				break; 
+
+			case "Polymorphic":
+				child = new THREE.Object3D();
+				var choice = Math.random();
+				if (choice < 0.2) {
+					child.extra1 = "test-polymorphism"
+				}
+				else if (choice < 0.4) {
+					child.extra2 = "test-polymorphism"
+				}
+				else if (choice < 0.6) {
+					child.extra3 = "test-polymorphism"
+				}
+				else if (choice < 0.8) {
+					child.extra4 = "test-polymorphism"
+				}
+				break;
+
+			case "Mesh":
+				child = new THREE.Mesh();
+				break; 
+
+			case "Skinned":
+				child = new THREE.SkinnedMesh();
+				break; 
+
+			case "Realistic":
+				var choice = Math.random();
+				if (choice < 0.05) {
+					child = new THREE.InstancedMesh();
+				}
+				else if (choice < 0.1) {
+					child = new THREE.SkinnedMesh();
+				}
+				else if (choice < 0.6) {
+					child = new THREE.Mesh();
+				}
+				else {
+					child = new THREE.Group();
+				}
+				break; 
+
+			default:
+				console.error("Unexpected test type:", type)
+				break;
+		}
+
 		child.position.copy( position );
 		child.scale.copy( scale );
 		child.quaternion.copy( rotation );
@@ -16,40 +68,15 @@
 
 	};
 
-	var createLocallyOffsetVariedChild = function () {
-
-		var child
-		
-		var choice = Math.random();
-		if (choice < 0.05) {
-			child = new THREE.InstancedMesh();
-		}
-		else if (choice < 0.1) {
-			child = new THREE.SkinnedMesh();
-		}
-		else if (choice < 0.6) {
-			child = new THREE.Mesh();
-		}
-		else {
-			child = new THREE.Group();
-		}
-		
-		child.position.copy( position );
-		child.scale.copy( scale );
-		child.quaternion.copy( rotation );
-		return child;
-
-	};
-
-	var generateSceneGraph = function ( root, depth, breadth, initObject ) {
+	var generateSceneGraph = function ( root, depth, breadth, initObject, type ) {
 
 		if ( depth > 0 ) {
 
 			for ( var i = 0; i < breadth; i ++ ) {
 
-				var child = initObject();
+				var child = initObject(type);
 				root.add( child );
-				generateSceneGraph( child, depth - 1, breadth, initObject );
+				generateSceneGraph( child, depth - 1, breadth, initObject, type );
 
 			}
 
@@ -69,31 +96,49 @@
 
 	};
 
-	var rootA = generateSceneGraph( new THREE.Object3D(), 100, 1, createLocallyOffsetChild );
-	var rootB = generateSceneGraph( new THREE.Object3D(), 3, 10, createLocallyOffsetChild );
-	var rootC = generateSceneGraph( new THREE.Object3D(), 9, 3, createLocallyOffsetChild );
-	var rootD = generateSceneGraph( new THREE.Object3D(), 9, 3, createLocallyOffsetVariedChild );
+	var rootA = generateSceneGraph( new THREE.Object3D(), 100, 1, createLocallyOffsetChild, "Object3D" );
+	var rootB = generateSceneGraph( new THREE.Object3D(), 3, 10, createLocallyOffsetChild, "Object3D" );
+	var rootC = generateSceneGraph( new THREE.Object3D(), 9, 3, createLocallyOffsetChild, "Object3D" );
+	var rootD = generateSceneGraph( new THREE.Object3D(), 9, 3, createLocallyOffsetChild, "Polymorphic" );
+	var rootE = generateSceneGraph( new THREE.Object3D(), 9, 3, createLocallyOffsetChild, "Mesh" );
+	var rootF = generateSceneGraph( new THREE.Object3D(), 9, 3, createLocallyOffsetChild, "Skinned" );
+	var rootG = generateSceneGraph( new THREE.Object3D(), 9, 3, createLocallyOffsetChild, "Realistic" );
 
 	var s = Bench.newSuite( 'Update world transforms' );
 
-	s.add( 'Update graph depth=100, breadth=1 (' + nodeCount( rootA ) + ' nodes)', function () {
+	s.add( 'Update graph depth=100, breadth=1, monomorphic Object3D (' + nodeCount( rootA ) + ' nodes)', function () {
 
 		rootA.updateMatrixWorld( true );
 
 	} );
-	s.add( 'Update graph depth=3, breadth=10 (' + nodeCount( rootB ) + ' nodes)', function () {
+	s.add( 'Update graph depth=3, breadth=10, monomorphic Object3D (' + nodeCount( rootB ) + ' nodes)', function () {
 
 		rootB.updateMatrixWorld( true );
 
 	} );
-	s.add( 'Update graph depth=9, breadth=3 (' + nodeCount( rootC ) + ' nodes)', function () {
+	s.add( 'Update graph depth=9, breadth=3, monomorphic Object3D (' + nodeCount( rootC ) + ' nodes)', function () {
 
 		rootC.updateMatrixWorld( true );
 
 	} );
-	s.add( 'Update graph depth=9, breadth=3, varied Object3D types (' + nodeCount( rootD ) + ' nodes)', function () {
+	s.add( 'Update graph depth=9, breadth=3, polymorphic (' + nodeCount( rootD ) + ' nodes)', function () {
 
 		rootD.updateMatrixWorld( true );
+
+	} );
+	s.add( 'Update graph depth=9, breadth=3, monomorphic Mesh (' + nodeCount( rootE ) + ' nodes)', function () {
+
+		rootE.updateMatrixWorld( true );
+
+	} );
+	s.add( 'Update graph depth=9, breadth=3, monomorphic SkinnedMesh (' + nodeCount( rootF ) + ' nodes)', function () {
+
+		rootF.updateMatrixWorld( true );
+
+	} );
+	s.add( 'Update graph depth=9, breadth=3, realistic blend (' + nodeCount( rootG ) + ' nodes)', function () {
+
+		rootG.updateMatrixWorld( true );
 
 	} );
 

--- a/test/benchmark/core/UpdateMatrixWorld.js
+++ b/test/benchmark/core/UpdateMatrixWorld.js
@@ -16,6 +16,31 @@
 
 	};
 
+	var createLocallyOffsetVariedChild = function () {
+
+		var child
+		
+		var choice = Math.random();
+		if (choice < 0.05) {
+			child = new THREE.InstancedMesh();
+		}
+		else if (choice < 0.1) {
+			child = new THREE.SkinnedMesh();
+		}
+		else if (choice < 0.6) {
+			child = new THREE.Mesh();
+		}
+		else {
+			child = new THREE.Group();
+		}
+		
+		child.position.copy( position );
+		child.scale.copy( scale );
+		child.quaternion.copy( rotation );
+		return child;
+
+	};
+
 	var generateSceneGraph = function ( root, depth, breadth, initObject ) {
 
 		if ( depth > 0 ) {
@@ -47,6 +72,7 @@
 	var rootA = generateSceneGraph( new THREE.Object3D(), 100, 1, createLocallyOffsetChild );
 	var rootB = generateSceneGraph( new THREE.Object3D(), 3, 10, createLocallyOffsetChild );
 	var rootC = generateSceneGraph( new THREE.Object3D(), 9, 3, createLocallyOffsetChild );
+	var rootD = generateSceneGraph( new THREE.Object3D(), 9, 3, createLocallyOffsetVariedChild );
 
 	var s = Bench.newSuite( 'Update world transforms' );
 
@@ -63,6 +89,11 @@
 	s.add( 'Update graph depth=9, breadth=3 (' + nodeCount( rootC ) + ' nodes)', function () {
 
 		rootC.updateMatrixWorld( true );
+
+	} );
+	s.add( 'Update graph depth=9, breadth=3, varied Object3D types (' + nodeCount( rootD ) + ' nodes)', function () {
+
+		rootD.updateMatrixWorld( true );
 
 	} );
 

--- a/test/benchmark/core/UpdateMatrixWorld.js
+++ b/test/benchmark/core/UpdateMatrixWorld.js
@@ -11,7 +11,7 @@
 		var child = new THREE.Object3D();
 		child.position.copy( position );
 		child.scale.copy( scale );
-		child.rotation.copy( rotation );
+		child.quaternion.copy( rotation );
 		return child;
 
 	};


### PR DESCRIPTION
Related issue: #25115

**Description**

See related issue for full background.

This PR addresses an issue with the existing Benchmark tests for updateMatrixWorld()

The issue is that the benhmark test generates a completely homogeneous set of Object3Ds, which results in the code iterating over a monomorphic set of objects - which will result in very flattering performance vs. real world usage.

Evidence that this is a real issue is provided by observing that the benchmark added in this PR, with a randomized, heterogeneous set of Object3Ds performs 50% slower than the equivalent homegeneous benchmark.

I don't expect this PR to be merged in its current state.

It's intended to share the code for the new "real world" benchmark test, to highlight the substantial performance gap between homegeneous & heterogeneous benchmark tests, and to open a discussion about what the best parameters would be for a Benchmark test that is representative of real-world use-cases for Three.js.

PR #25114 is related and offers a prototype fix that significantly improves performance on the new benchmark added by this PR.
