### PR TITLE
CSMShader: Fix shadows with spotlights.

### DIFF
--- a/examples/jsm/csm/CSMShader.js
+++ b/examples/jsm/csm/CSMShader.js
@@ -58,7 +58,7 @@ IncidentLight directLight;
 
 		#if defined( USE_SHADOWMAP ) && ( UNROLLED_LOOP_INDEX < NUM_SPOT_LIGHT_SHADOWS )
 		spotLightShadow = spotLightShadows[ i ];
-		directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadow( spotShadowMap[ i ], spotLightShadow.shadowMapSize, spotLightShadow.shadowBias, spotLightShadow.shadowRadius, vSpotShadowCoord[ i ] ) : 1.0;
+		directLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadow( spotShadowMap[ i ], spotLightShadow.shadowMapSize, spotLightShadow.shadowBias, spotLightShadow.shadowRadius, vSpotLightCoord[ i ] ) : 1.0;
 		#endif
 
 		RE_Direct( directLight, geometry, material, reflectedLight );


### PR DESCRIPTION
vSpotShadowCoord seems to have been replaced with vSpotLightCoord in r147. CSMShader.js needed to be updated.

Spotlights under CSM fail without this update.
