### PR TITLE
Shaders: Force `highp` for uv computation in `bilinearCubeUV()`.

### DIFF
--- a/src/renderers/shaders/ShaderChunk/cube_uv_reflection_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/cube_uv_reflection_fragment.glsl.js
@@ -85,7 +85,7 @@ export default /* glsl */`
 
 		float faceSize = exp2( mipInt );
 
-		highp vec2 uv = getUV( direction, face ) * ( faceSize - 2.0 ) + 1.0;
+		highp vec2 uv = getUV( direction, face ) * ( faceSize - 2.0 ) + 1.0; // #25071
 
 		if ( face > 2.0 ) {
 

--- a/src/renderers/shaders/ShaderChunk/cube_uv_reflection_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/cube_uv_reflection_fragment.glsl.js
@@ -85,7 +85,7 @@ export default /* glsl */`
 
 		float faceSize = exp2( mipInt );
 
-		vec2 uv = getUV( direction, face ) * ( faceSize - 2.0 ) + 1.0;
+		highp vec2 uv = getUV( direction, face ) * ( faceSize - 2.0 ) + 1.0;
 
 		if ( face > 2.0 ) {
 


### PR DESCRIPTION
Fixed #25071

**Description**

This PR forces `highp` in `bilinearCubeUV()` when the uv coordinates are computed. This fix avoids breakage when `mediump` is globally defined.