### PR TITLE
OrbitControls: Register `pointerup` event listener on `window`.

### DIFF
--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -298,7 +298,7 @@ class OrbitControls extends EventDispatcher {
 			scope.domElement.removeEventListener( 'wheel', onMouseWheel );
 
 			scope.domElement.removeEventListener( 'pointermove', onPointerMove );
-			scope.domElement.removeEventListener( 'pointerup', onPointerUp );
+			window.removeEventListener( 'pointerup', onPointerUp );
 
 
 			if ( scope._domElementKeyEvents !== null ) {
@@ -837,7 +837,7 @@ class OrbitControls extends EventDispatcher {
 				scope.domElement.setPointerCapture( event.pointerId );
 
 				scope.domElement.addEventListener( 'pointermove', onPointerMove );
-				scope.domElement.addEventListener( 'pointerup', onPointerUp );
+				window.addEventListener( 'pointerup', onPointerUp );
 
 			}
 
@@ -882,7 +882,7 @@ class OrbitControls extends EventDispatcher {
 		        scope.domElement.releasePointerCapture( event.pointerId );
 
 		        scope.domElement.removeEventListener( 'pointermove', onPointerMove );
-		        scope.domElement.removeEventListener( 'pointerup', onPointerUp );
+		        window.removeEventListener( 'pointerup', onPointerUp );
 
 		    }
 


### PR DESCRIPTION
Fixed https://github.com/mrdoob/three.js/issues/24566

Fixes an edge case bug where user clicks on the scope dom element, before moving the mouse off the dom element and releasing, perhaps as a result of erratic movement while panning around. Registering the pointer up on the scope dom element causes orbit controls to miss the pointer up event, and as the mouse returns over the dom element, orbit controls remains "stuck" as pointer move continues to fire.

The fix is registering pointerup on the window instead of the scope dom element, so the event is never missed no matter where the mouse is.