### PR TITLE
MMDToonMaterial: Removed unnecessary `envMap` shader chunks.

### DIFF
--- a/examples/jsm/shaders/MMDToonShader.js
+++ b/examples/jsm/shaders/MMDToonShader.js
@@ -83,7 +83,16 @@ const MMDToonShader = {
 		ShaderLib.matcap.uniforms,
 	] ),
 
-	vertexShader: ShaderLib.phong.vertexShader,
+	vertexShader:
+		ShaderLib.phong.vertexShader
+			.replace(
+				'#include <envmap_pars_vertex>',
+				''
+			)
+			.replace(
+				'#include <envmap_vertex>',
+				''
+			),
 
 	fragmentShader:
 		ShaderLib.phong.fragmentShader
@@ -101,8 +110,11 @@ const MMDToonShader = {
 				'#include <envmap_common_pars_fragment>',
 				`
 					#include <gradientmap_pars_fragment>
-					#include <envmap_common_pars_fragment>
 				`
+			)
+			.replace(
+				'#include <envmap_pars_fragment>',
+				''
 			)
 			.replace(
 				'#include <lights_phong_pars_fragment>',
@@ -111,10 +123,9 @@ const MMDToonShader = {
 			.replace(
 				'#include <envmap_fragment>',
 				`
-					#include <envmap_fragment>
 					${mmd_toon_matcap_fragment}
 				`
-			),
+			)
 
 };
 


### PR DESCRIPTION
... as proposed in https://github.com/mrdoob/three.js/pull/25117#issuecomment-1345775852.

/ping @takahirox 