### PR TITLE
WebGLBackground: Don't tone map sRGB backgrounds.

### DIFF
--- a/src/renderers/webgl/WebGLBackground.js
+++ b/src/renderers/webgl/WebGLBackground.js
@@ -1,4 +1,4 @@
-import { BackSide, FrontSide, CubeUVReflectionMapping } from '../../constants.js';
+import { BackSide, FrontSide, CubeUVReflectionMapping, LinearEncoding } from '../../constants.js';
 import { BoxGeometry } from '../../geometries/BoxGeometry.js';
 import { PlaneGeometry } from '../../geometries/PlaneGeometry.js';
 import { ShaderMaterial } from '../../materials/ShaderMaterial.js';
@@ -108,6 +108,7 @@ function WebGLBackground( renderer, cubemaps, cubeuvmaps, state, objects, alpha,
 			boxMesh.material.uniforms.flipEnvMap.value = ( background.isCubeTexture && background.isRenderTargetTexture === false ) ? - 1 : 1;
 			boxMesh.material.uniforms.backgroundBlurriness.value = scene.backgroundBlurriness;
 			boxMesh.material.uniforms.backgroundIntensity.value = scene.backgroundIntensity;
+      boxMesh.material.toneMapped = background.encoding === LinearEncoding;
 
 			if ( currentBackground !== background ||
 				currentBackgroundVersion !== background.version ||
@@ -163,6 +164,7 @@ function WebGLBackground( renderer, cubemaps, cubeuvmaps, state, objects, alpha,
 
 			planeMesh.material.uniforms.t2D.value = background;
 			planeMesh.material.uniforms.backgroundIntensity.value = scene.backgroundIntensity;
+      planeMesh.material.toneMapped = background.encoding === LinearEncoding;
 
 			if ( background.matrixAutoUpdate === true ) {
 

--- a/src/renderers/webgl/WebGLBackground.js
+++ b/src/renderers/webgl/WebGLBackground.js
@@ -1,4 +1,4 @@
-import { BackSide, FrontSide, CubeUVReflectionMapping, LinearEncoding } from '../../constants.js';
+import { BackSide, FrontSide, CubeUVReflectionMapping, sRGBEncoding } from '../../constants.js';
 import { BoxGeometry } from '../../geometries/BoxGeometry.js';
 import { PlaneGeometry } from '../../geometries/PlaneGeometry.js';
 import { ShaderMaterial } from '../../materials/ShaderMaterial.js';
@@ -108,7 +108,7 @@ function WebGLBackground( renderer, cubemaps, cubeuvmaps, state, objects, alpha,
 			boxMesh.material.uniforms.flipEnvMap.value = ( background.isCubeTexture && background.isRenderTargetTexture === false ) ? - 1 : 1;
 			boxMesh.material.uniforms.backgroundBlurriness.value = scene.backgroundBlurriness;
 			boxMesh.material.uniforms.backgroundIntensity.value = scene.backgroundIntensity;
-			boxMesh.material.toneMapped = background.encoding === LinearEncoding;
+			boxMesh.material.toneMapped = ( background.encoding === sRGBEncoding ) ? false : true;
 
 			if ( currentBackground !== background ||
 				currentBackgroundVersion !== background.version ||
@@ -164,7 +164,7 @@ function WebGLBackground( renderer, cubemaps, cubeuvmaps, state, objects, alpha,
 
 			planeMesh.material.uniforms.t2D.value = background;
 			planeMesh.material.uniforms.backgroundIntensity.value = scene.backgroundIntensity;
-			planeMesh.material.toneMapped = background.encoding === LinearEncoding;
+			planeMesh.material.toneMapped = ( background.encoding === sRGBEncoding ) ? false : true;
 
 			if ( background.matrixAutoUpdate === true ) {
 

--- a/src/renderers/webgl/WebGLBackground.js
+++ b/src/renderers/webgl/WebGLBackground.js
@@ -108,7 +108,7 @@ function WebGLBackground( renderer, cubemaps, cubeuvmaps, state, objects, alpha,
 			boxMesh.material.uniforms.flipEnvMap.value = ( background.isCubeTexture && background.isRenderTargetTexture === false ) ? - 1 : 1;
 			boxMesh.material.uniforms.backgroundBlurriness.value = scene.backgroundBlurriness;
 			boxMesh.material.uniforms.backgroundIntensity.value = scene.backgroundIntensity;
-      boxMesh.material.toneMapped = background.encoding === LinearEncoding;
+			boxMesh.material.toneMapped = background.encoding === LinearEncoding;
 
 			if ( currentBackground !== background ||
 				currentBackgroundVersion !== background.version ||
@@ -164,7 +164,7 @@ function WebGLBackground( renderer, cubemaps, cubeuvmaps, state, objects, alpha,
 
 			planeMesh.material.uniforms.t2D.value = background;
 			planeMesh.material.uniforms.backgroundIntensity.value = scene.backgroundIntensity;
-      planeMesh.material.toneMapped = background.encoding === LinearEncoding;
+			planeMesh.material.toneMapped = background.encoding === LinearEncoding;
 
 			if ( background.matrixAutoUpdate === true ) {
 


### PR DESCRIPTION
Related issue: https://github.com/google/model-viewer/discussions/3953#discussioncomment-4217690

**Description**

An eagle-eyed user correctly identified that we were applying tone mapping to the background image (see screenshots in the link above). I've fixed this by disabling tone mapping for the background material when the texture's encoding is `sRGBEncoding`. My rationale for this is that an sRGB texture is expected to be displayed 1:1 (as is already true for background colors), while tone mapping only makes sense for colors that go past 1, for which `LinearEncoding` is always used. 

Verified locally with model-viewer and the user-supplied background. 