### PR TITLE
Docs: PointLight.castShadow property was missing

### DIFF
--- a/docs/api/en/lights/PointLight.html
+++ b/docs/api/en/lights/PointLight.html
@@ -51,6 +51,13 @@ scene.add( light );
 		<p>
 			See the base [page:Light Light] class for common properties.
 		</p>
+		
+		<h3>[property:Boolean castShadow]</h3>
+		<p>
+			If set to `true` light will cast dynamic shadows. *Warning*: This is expensive and
+			requires tweaking to get shadows looking right. See the [page:PointLightShadow] for details.
+			The default is `false`.
+		</p>
 
 		<h3>[property:Float decay]</h3>
 		<p>


### PR DESCRIPTION
**Description**
PointLight.castShadow property was missing from the docs. I copied the description from the SpotLight page, but with a link to PointLightShadow instead.

Related issue: This omission was pointed out by a user in the Discourse forum: https://discourse.threejs.org/t/why-is-there-no-pointlight-castshadow-property/45718