### PR TITLE
ColladaLoader: Change file version printing to debug rather than log level

### DIFF
--- a/examples/jsm/loaders/ColladaLoader.js
+++ b/examples/jsm/loaders/ColladaLoader.js
@@ -4019,7 +4019,7 @@ class ColladaLoader extends Loader {
 		// metadata
 
 		const version = collada.getAttribute( 'version' );
-		console.log( 'THREE.ColladaLoader: File version', version );
+		console.debug( 'THREE.ColladaLoader: File version', version );
 
 		const asset = parseAsset( getElementsByTagName( collada, 'asset' )[ 0 ] );
 		const textureLoader = new TextureLoader( this.manager );


### PR DESCRIPTION
At present, every time a new instance is created for parsing/loading a file, the version info is printed out. Would it be acceptable to move this to the debug level? When needed it can always be retrieved by changing the log level of the developer tools