### PR TITLE
BufferAttribute: Add getItem(), setItem()

### DIFF
--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -172,6 +172,34 @@ class BufferAttribute {
 
 	}
 
+	*getItem( index ) {
+
+		for ( let i = 0, l = this.itemSize; i < l; i ++ ) {
+
+			let value = this.array[ index * this.itemSize + i ];
+
+			if ( this.normalized ) value = denormalize( value, this.array );
+
+			yield value;
+
+		}
+
+	}
+
+	setItem( index, ...components ) {
+
+		for ( let i = 0, l = this.itemSize; i < l; i ++ ) {
+
+			let value = components[ i ];
+
+			if ( this.normalized ) value = normalize( value, this.array );
+
+			this.array[ index * this.itemSize + i ] = value;
+
+		}
+
+	}
+
 	getX( index ) {
 
 		let x = this.array[ index * this.itemSize ];

--- a/test/benchmark/benchmarks.html
+++ b/test/benchmark/benchmarks.html
@@ -17,6 +17,7 @@
     <script src="core/Float32Array.js"></script>
     <script src="core/UpdateMatrixWorld.js"></script>
     <script src="core/TriangleClosestPoint.js"></script>
+    <script src="core/BufferAttribute.js"></script>
   </head>
   <body>
     <header>

--- a/test/benchmark/core/BufferAttribute.js
+++ b/test/benchmark/core/BufferAttribute.js
@@ -1,0 +1,51 @@
+( function () {
+
+	const input = new THREE.BufferAttribute( new Float32Array( 10000 * 3 ), 3 );
+
+	for ( let i = 0, il = input.count; i < il; i ++ ) {
+
+		input.setItem( i, Math.random(), Math.random(), Math.random() );
+
+	}
+
+	const s = Bench.newSuite( 'BufferAttribute' );
+
+	s.add( 'getItem', function () {
+
+		let maxX = Infinity;
+		let maxY = Infinity;
+		let maxZ = Infinity;
+
+		for ( let i = 0, il = input.count; i < il; i ++ ) {
+
+			const [ x, y, z ] = input.getItem( i );
+
+			maxX = Math.max( x, maxX );
+			maxY = Math.max( y, maxY );
+			maxZ = Math.max( z, maxZ );
+
+		}
+
+	} );
+
+	s.add( 'getX-getY-getZ', function () {
+
+		let maxX = Infinity;
+		let maxY = Infinity;
+		let maxZ = Infinity;
+
+		for ( let i = 0, il = input.count; i < il; i ++ ) {
+
+			const x = input.getX( i );
+			const y = input.getY( i );
+			const z = input.getZ( i );
+
+			maxX = Math.max( x, maxX );
+			maxY = Math.max( y, maxY );
+			maxZ = Math.max( z, maxZ );
+
+		}
+
+	} );
+
+} )();

--- a/test/benchmark/core/BufferAttribute.js
+++ b/test/benchmark/core/BufferAttribute.js
@@ -2,6 +2,8 @@
 
 	const input = new THREE.BufferAttribute( new Float32Array( 10000 * 3 ), 3 );
 
+	const vector = new THREE.Vector3();
+
 	for ( let i = 0, il = input.count; i < il; i ++ ) {
 
 		input.setItem( i, Math.random(), Math.random(), Math.random() );
@@ -43,6 +45,24 @@
 			maxX = Math.max( x, maxX );
 			maxY = Math.max( y, maxY );
 			maxZ = Math.max( z, maxZ );
+
+		}
+
+	} );
+
+	s.add( 'fromBufferAttribute', function () {
+
+		let maxX = Infinity;
+		let maxY = Infinity;
+		let maxZ = Infinity;
+
+		for ( let i = 0, il = input.count; i < il; i ++ ) {
+
+			vector.fromBufferAttribute( input, i );
+
+			maxX = Math.max( vector.x, maxX );
+			maxY = Math.max( vector.y, maxY );
+			maxZ = Math.max( vector.z, maxZ );
 
 		}
 

--- a/test/unit/src/core/BufferAttribute.tests.js
+++ b/test/unit/src/core/BufferAttribute.tests.js
@@ -103,6 +103,42 @@ export default QUnit.module( 'Core', () => {
 
 		} );
 
+		QUnit.test( 'getItem', ( assert ) => {
+
+			const position = new BufferAttribute( new Float32Array( [ 1, 2, 3, 4, 5, 6 ] ), 3 );
+			const uv = new BufferAttribute( new Uint8Array( [ 0, 0, 85, 127 ] ), 2, true );
+
+			const [ x, y, z ] = position.getItem( 0 );
+			const [ u, v ] = uv.getItem( 1 );
+
+			assert.numEqual( x, 1, 'reads vec3.x' );
+			assert.numEqual( y, 2, 'reads vec3.y' );
+			assert.numEqual( z, 3, 'reads vec3.z' );
+
+			assert.numEqual( u, 0.333, 'reads vec2.u' );
+			assert.numEqual( v, 0.500, 'reads vec2.v' );
+
+		} );
+
+		QUnit.test( 'setItem', ( assert ) => {
+
+			const position = new BufferAttribute( new Float32Array( [ 0, 0, 0, 0, 0, 0 ] ), 3 );
+			const uv = new BufferAttribute( new Uint8Array( [ 0, 0, 0, 0 ] ), 2, true );
+
+			position.setItem( 0, 1.5, 2.5, 3.5 );
+			uv.setItem( 1, 0.333, 0.5 );
+
+			assert.numEqual( position.getX( 0 ), 1.5, 'writes vec3.x' );
+			assert.numEqual( uv.getY( 1 ), 0.5, 'writes vec2.v' );
+
+			const position2 = new BufferAttribute( new Float32Array( [ 1, 2, 3, 4, 5, 6 ] ), 3 );
+
+			position.setItem( 0, ...position2.getItem( 1 ) );
+
+			assert.deepEqual( Array.from( position.getItem( 0 ) ), [ 4, 5, 6 ], 'writes iterators' );
+
+		} );
+
 		QUnit.test( 'set[X, Y, Z, W, XYZ, XYZW]/get[X, Y, Z, W]', ( assert ) => {
 
 			var f32a = new Float32Array( [ 1, 2, 3, 4, 5, 6, 7, 8 ] );


### PR DESCRIPTION
Possible alternative and/or complement to:

- https://github.com/mrdoob/three.js/pull/24515

**Description**

Adds `getItem( index )` and `setItem( index, x, y, ... )` methods to the BufferAttribute class. These are intended to simplify access to the values in the attribute, while requiring fewer workarounds for `itemSize` differences. The `getItem` accessor returns an iterator, and `setItem` accepts either explicit components or an iterator.

Example:

```javascript
const position = geometry.getAttribute( 'position' );

const [ x, y, z ] = position.getItem( index );

position.setItem( index, x, y, z );
position.setItem( index, ...position2.getItem( index ) );
```

***

As @gkjohnson identified some good examples of existing rough edges already ...

> Some examples of current workarounds are [here](https://github.com/gkjohnson/three-mesh-bvh/blob/d2dafbb61e345dc969b40f35c23a2d0f9815ac24/src/utils/StaticGeometryGenerator.js#L59-L63), [here](https://github.com/gkjohnson/three-mesh-bvh/blob/d2dafbb61e345dc969b40f35c23a2d0f9815ac24/src/gpu/VertexAttributeTexture.js#L226-L251), [here](https://github.com/gkjohnson/three-mesh-bvh/pull/452/files/08bf95804dcdc2dd25c8c23853165a76e436b70b#diff-42af296b41e194035195859e259441a551fe57d78f407d9013ec3c35a800dfbd), and [here](https://github.com/mrdoob/three.js/blob/dev/examples/jsm/utils/BufferGeometryUtils.js#L410-L435).

... we can replace this ...

```javascript
for ( let i = 0; i < dst.count; i ++ ) {

  for ( let k = 0; k < dst.itemSize; k ++ ) {

    if ( k === 0 ) dst.setX( i, src.getX( i ) );
    if ( k === 1 ) dst.setY( i, src.getY( i ) );
    if ( k === 2 ) dst.setZ( i, src.getZ( i ) );
    if ( k === 3 ) dst.setW( i, src.getW( i ) );

  }

}
```

... with this ...


```javascript
for ( let i = 0; i < src.count; i ++ ) {

  dst.setItem( i, ...src.getItem( i ) );

}
```

