### PR TITLE
Object3D: Add `twoPassTransparentRendering`.

### DIFF
--- a/docs/api/en/core/Object3D.html
+++ b/docs/api/en/core/Object3D.html
@@ -166,6 +166,11 @@
 		The object's local scale. Default is [page:Vector3]( 1, 1, 1 ).
 		</p>
 
+		<h3>[property:Boolean twoPassTransparentRendering]</h3>
+		<p>
+			Whether or not double-sided, transparent objects should be rendered with two passes or not. Default is `true`.
+		</p>
+
 		<h3>[property:Vector3 up]</h3>
 		<p>
 		This is used by the [page:.lookAt lookAt] method, for example, to determine the orientation of the result.<br />

--- a/docs/api/it/core/Object3D.html
+++ b/docs/api/it/core/Object3D.html
@@ -170,6 +170,12 @@
       La scala locale dell'oggetto. Il valore predefinito è [page:Vector3]( 1, 1, 1 ).
 		</p>
 
+		<h3>[property:Boolean twoPassTransparentRendering]</h3>
+		<p>
+			Whether or not double-sided, transparent objects should be rendered with two passes or not. Default is `true`.
+		</p>
+
+
 		<h3>[property:Vector3 up]</h3>
 		<p>
       Questa proprietà viene utilizzata dal metodo [page:.lookAt lookAt], per esempio, per determinare l'orientamento del risultato.<br />

--- a/docs/api/ko/core/Object3D.html
+++ b/docs/api/ko/core/Object3D.html
@@ -160,6 +160,12 @@
 		객체의 로컬 스케일입니다. 기본값은 [page:Vector3]( 1, 1, 1 )입니다.
 		</p>
 
+		<h3>[property:Boolean twoPassTransparentRendering]</h3>
+		<p>
+			Whether or not double-sided, transparent objects should be rendered with two passes or not. Default is `true`.
+		</p>
+
+
 		<h3>[property:Vector3 up]</h3>
 		<p>
 		[page:.lookAt lookAt] 메서드에서 사용되며, 결과의 방향을 결정합니다.<br />

--- a/docs/api/zh/core/Object3D.html
+++ b/docs/api/zh/core/Object3D.html
@@ -159,6 +159,12 @@
 		物体的局部缩放。默认值是[page:Vector3]( 1, 1, 1 )。
 	</p>
 
+	<h3>[property:Boolean twoPassTransparentRendering]</h3>
+	<p>
+		Whether or not double-sided, transparent objects should be rendered with two passes or not. Default is `true`.
+	</p>
+
+
 	<h3>[property:Vector3 up]</h3>
 	<p>
 		这个属性由[page:.lookAt lookAt]方法所使用，例如，来决定结果的朝向。

--- a/editor/js/Sidebar.Object.js
+++ b/editor/js/Sidebar.Object.js
@@ -359,6 +359,16 @@ function SidebarObject( editor ) {
 
 	container.add( objectRenderOrderRow );
 
+	// twoPassTransparentRendering
+
+	const objectTwoPassTransparentRenderingRow = new UIRow();
+	const objectTwoPassTransparentRendering = new UICheckbox().onChange( update );
+
+	objectTwoPassTransparentRenderingRow.add( new UIText( strings.getKey( 'sidebar/object/twoPassTransparentRendering' ) ).setWidth( '90px' ) );
+	objectTwoPassTransparentRenderingRow.add( objectTwoPassTransparentRendering );
+
+	container.add( objectTwoPassTransparentRenderingRow );
+
 	// user data
 
 	const objectUserDataRow = new UIRow();
@@ -530,6 +540,12 @@ function SidebarObject( editor ) {
 			if ( object.renderOrder !== objectRenderOrder.getValue() ) {
 
 				editor.execute( new SetValueCommand( editor, object, 'renderOrder', objectRenderOrder.getValue() ) );
+
+			}
+
+			if ( object.twoPassTransparentRendering !== objectTwoPassTransparentRendering.getValue() ) {
+
+				editor.execute( new SetValueCommand( editor, object, 'twoPassTransparentRendering', objectTwoPassTransparentRendering.getValue() ) );
 
 			}
 
@@ -823,6 +839,7 @@ function SidebarObject( editor ) {
 		objectVisible.setValue( object.visible );
 		objectFrustumCulled.setValue( object.frustumCulled );
 		objectRenderOrder.setValue( object.renderOrder );
+		objectTwoPassTransparentRendering.setValue( object.twoPassTransparentRendering );
 
 		try {
 

--- a/editor/js/Strings.js
+++ b/editor/js/Strings.js
@@ -126,6 +126,7 @@ function Strings( config ) {
 			'sidebar/object/visible': 'Visible',
 			'sidebar/object/frustumcull': 'Frustum Cull',
 			'sidebar/object/renderorder': 'Render Order',
+			'sidebar/object/twoPassTransparentRendering': 'Two Pass Transparent Rendering',
 			'sidebar/object/userdata': 'User data',
 
 			'sidebar/geometry/type': 'Type',
@@ -477,6 +478,7 @@ function Strings( config ) {
 			'sidebar/object/visible': 'Visible',
 			'sidebar/object/frustumcull': 'Culling',
 			'sidebar/object/renderorder': 'Ordre de rendus',
+			'sidebar/object/twoPassTransparentRendering': 'Two Pass Transparent Rendering',
 			'sidebar/object/userdata': 'Données utilisateur',
 
 			'sidebar/geometry/type': 'Type',
@@ -828,6 +830,7 @@ function Strings( config ) {
 			'sidebar/object/visible': '可见性',
 			'sidebar/object/frustumcull': '视锥体裁剪',
 			'sidebar/object/renderorder': '渲染次序',
+			'sidebar/object/twoPassTransparentRendering': 'Two Pass Transparent Rendering',
 			'sidebar/object/userdata': '自定义数据',
 
 			'sidebar/geometry/type': '类型',

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -110,6 +110,7 @@ class Object3D extends EventDispatcher {
 
 		this.frustumCulled = true;
 		this.renderOrder = 0;
+		this.twoPassTransparentRendering = true;
 
 		this.animations = [];
 
@@ -691,6 +692,7 @@ class Object3D extends EventDispatcher {
 		if ( this.visible === false ) object.visible = false;
 		if ( this.frustumCulled === false ) object.frustumCulled = false;
 		if ( this.renderOrder !== 0 ) object.renderOrder = this.renderOrder;
+		if ( this.twoPassTransparentRendering === false ) object.twoPassTransparentRendering = this.twoPassTransparentRendering;
 		if ( Object.keys( this.userData ).length > 0 ) object.userData = this.userData;
 
 		object.layers = this.layers.mask;
@@ -921,6 +923,7 @@ class Object3D extends EventDispatcher {
 
 		this.frustumCulled = source.frustumCulled;
 		this.renderOrder = source.renderOrder;
+		this.twoPassTransparentRendering = source.twoPassTransparentRendering;
 
 		this.userData = JSON.parse( JSON.stringify( source.userData ) );
 

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -977,6 +977,7 @@ class ObjectLoader extends Loader {
 		if ( data.visible !== undefined ) object.visible = data.visible;
 		if ( data.frustumCulled !== undefined ) object.frustumCulled = data.frustumCulled;
 		if ( data.renderOrder !== undefined ) object.renderOrder = data.renderOrder;
+		if ( data.twoPassTransparentRendering !== undefined ) object.twoPassTransparentRendering = data.twoPassTransparentRendering;
 		if ( data.userData !== undefined ) object.userData = data.userData;
 		if ( data.layers !== undefined ) object.layers.mask = data.layers;
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -828,7 +828,7 @@ function WebGLRenderer( parameters = {} ) {
 
 		function prepare( material, scene, object ) {
 
-			if ( material.transparent === true && material.side === DoubleSide ) {
+			if ( object.twoPassTransparentRendering === true && ( material.transparent === true && material.side === DoubleSide ) ) {
 
 				material.side = BackSide;
 				material.needsUpdate = true;
@@ -1310,7 +1310,7 @@ function WebGLRenderer( parameters = {} ) {
 
 		material.onBeforeRender( _this, scene, camera, geometry, object, group );
 
-		if ( material.transparent === true && material.side === DoubleSide ) {
+		if ( object.twoPassTransparentRendering === true && ( material.transparent === true && material.side === DoubleSide ) ) {
 
 			material.side = BackSide;
 			material.needsUpdate = true;


### PR DESCRIPTION
Fixed #24711.
Fixed #25149.

**Description**

Introduces `Object3D.twoPassTransparentRendering` which controls whether double-sided, transparent objects should be rendered with two passes or not.

#21967 introduces two pass rendering for fixing transparency artifacts. However, since then we received multiple reports where users complain about performance degradations. The two pass rendering also breaks the evaluation of `gl_FrontFacing` in a certain use case, see #25149.
