### PR TITLE
Revert "Material: use class properties"

### DIFF
--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -6,8 +6,6 @@ let materialId = 0;
 
 class Material extends EventDispatcher {
 
-	#alphaTest = 0;
-
 	constructor() {
 
 		super();
@@ -75,23 +73,25 @@ class Material extends EventDispatcher {
 
 		this.version = 0;
 
+		this._alphaTest = 0;
+
 	}
 
 	get alphaTest() {
 
-		return this.#alphaTest;
+		return this._alphaTest;
 
 	}
 
 	set alphaTest( value ) {
 
-		if ( this.#alphaTest > 0 !== value > 0 ) {
+		if ( this._alphaTest > 0 !== value > 0 ) {
 
 			this.version ++;
 
 		}
 
-		this.#alphaTest = value;
+		this._alphaTest = value;
 
 	}
 


### PR DESCRIPTION
Reverts mrdoob/three.js#24237

see https://github.com/mrdoob/three.js/pull/24237#issuecomment-1361857892

Let's avoid the usage of class properties until Webpack 5 is more widespread. 

I also think we should remove all JS syntax > ES2018 from the project in general (e.g. nullish coalescing) and wait with the introduction.