### PR TITLE
DRACOLoader: Revoke workerSourceURL.

### DIFF
--- a/examples/jsm/loaders/DRACOLoader.js
+++ b/examples/jsm/loaders/DRACOLoader.js
@@ -351,6 +351,12 @@ class DRACOLoader extends Loader {
 
 		this.workerPool.length = 0;
 
+		if ( this.workerSourceURL !== '' ) {
+
+			URL.revokeObjectURL( this.workerSourceURL );
+
+		}
+
 		return this;
 
 	}


### PR DESCRIPTION
Related issue: https://discourse.threejs.org/t/dracoloader-object-url-not-disposed/46103

**Description**

Revokes `workerSourceURL` in `dispose()`.
