### PR TITLE
SkeletonUtils: add extractRootMotion(...)

### DIFF
--- a/examples/jsm/utils/SkeletonUtils.js
+++ b/examples/jsm/utils/SkeletonUtils.js
@@ -613,11 +613,13 @@ function extractRootMotion( rootNode, targetClip, targetVelocity ) {
 	const endTime = track.times[ track.times.length - 1 ]
 	const duration = endTime - startTime;
 
-	const valueSize = track.getValueSize(); // 3 (default), or 9 (cubicspline)
-	const values = new BufferAttribute( track.values, valueSize );
+	const values = new BufferAttribute( track.values, 3 );
+	const valuesPerKeyframe = track.getValueSize() / 3; // 1 (value), or 3 (inTan,value,outTan)
+	const valueOffset = valuesPerKeyframe === 3 ? 1 : 0;
 
-	const startPosition = new Vector3().fromBufferAttribute( values, 0 );
-	const endPosition = new Vector3().fromBufferAttribute( values, values.count - 1 );
+	const startPosition = new Vector3().fromBufferAttribute( values, valueOffset );
+	const endPositionIndex = values.count - valuesPerKeyframe + valueOffset;
+	const endPosition = new Vector3().fromBufferAttribute( values, endPositionIndex );
 
 	targetVelocity
 		.copy( endPosition )
@@ -630,11 +632,11 @@ function extractRootMotion( rootNode, targetClip, targetVelocity ) {
 
 		const dt = track.times[ i ] - startTime;
 
-		position.fromBufferAttribute( values, i );
+		position.fromBufferAttribute( values, i + valueOffset );
 		position.x -= targetVelocity.x * dt;
 		position.y -= targetVelocity.y * dt;
 		position.z -= targetVelocity.z * dt;
-		values.setXYZ( i, position.x, position.y, position.z );
+		values.setXYZ( i + valueOffset, position.x, position.y, position.z );
 
 	}
 

--- a/examples/jsm/utils/SkeletonUtils.js
+++ b/examples/jsm/utils/SkeletonUtils.js
@@ -614,11 +614,11 @@ function extractRootMotion( rootNode, targetClip, targetVelocity ) {
 	const duration = endTime - startTime;
 
 	const values = new BufferAttribute( track.values, 3 );
-	const valuesPerKeyframe = track.getValueSize() / 3; // 1 (value), or 3 (inTan,value,outTan)
-	const valueOffset = valuesPerKeyframe === 3 ? 1 : 0;
+	const itemsPerKeyframe = track.getValueSize() / 3; // 1 (value), or 3 (inTan,value,outTan)
+	const itemOffset = itemsPerKeyframe === 3 ? 1 : 0;
 
-	const startPosition = new Vector3().fromBufferAttribute( values, valueOffset );
-	const endPositionIndex = values.count - valuesPerKeyframe + valueOffset;
+	const startPosition = new Vector3().fromBufferAttribute( values, itemOffset );
+	const endPositionIndex = values.count - itemsPerKeyframe + itemOffset;
 	const endPosition = new Vector3().fromBufferAttribute( values, endPositionIndex );
 
 	targetVelocity
@@ -632,11 +632,11 @@ function extractRootMotion( rootNode, targetClip, targetVelocity ) {
 
 		const dt = track.times[ i ] - startTime;
 
-		position.fromBufferAttribute( values, i + valueOffset );
+		position.fromBufferAttribute( values, i + itemOffset );
 		position.x -= targetVelocity.x * dt;
 		position.y -= targetVelocity.y * dt;
 		position.z -= targetVelocity.z * dt;
-		values.setXYZ( i + valueOffset, position.x, position.y, position.z );
+		values.setXYZ( i + itemOffset, position.x, position.y, position.z );
 
 	}
 


### PR DESCRIPTION
Related discussion: 

- https://discourse.threejs.org/t/looping-skinned-mesh-animation-with-root-motion/5116/7

**Description**

Adds a utility function intended to help with SkinnedMesh animations relying on the "root motion" technique. 

Usage:

```javascript
import { extractRootMotion } from 'three/addons/utils/SkeletonUtils.js';

const velocity = new Vector3();

extractRootMotion( object, clip, velocity );
```

Effect:

1. Computes average velocity of the root bone, over the duration of the clip
2. Subtracts that motion from root bone's position keyframe track
3. Returns average velocity as a vector

This may be helpful for chaining complex animations (e.g. leaping over a wall). I am still hoping for feedback on the right API, or a simple enough example that we can test and include. It doesn't seem appropriate for the AnimationMixer, AnimationAction, and other animation classes (which aren't specific to SkinnedMesh playback) to have logic dedicated to root motion, but rather to leave that to an application's character controller. It's likely that root motion should also consider rotation, but I'm hoping to make sure I'm solving the right problem first.

The model below was provided in the forums, and I've tested with it so far.

[SprintToWallClimb.fbx.zip](https://github.com/mrdoob/three.js/files/10291150/SprintToWallClimb.fbx.zip)

***

References:
- [Root Motion | Unreal Engine](https://docs.unrealengine.com/4.27/en-US/AnimatingObjects/SkeletalMeshAnimation/RootMotion/)
- [Root Motion | Unity](https://docs.unity3d.com/Manual/RootMotion.html)