### PR TITLE
Docs/Examples/Manual: Keep focus when clear search input.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -29,7 +29,7 @@
 			<div id="contentWrapper">
 				<div id="inputWrapper">
 					<input placeholder="" type="text" id="filterInput" autocorrect="off" autocapitalize="off" spellcheck="false" />
-					<div id="exitSearchButton"></div>
+					<div id="clearSearchButton"></div>
 					<select id="language">
 						<option value="en">en</option>
 						<option value="ar">ar</option>
@@ -54,7 +54,7 @@
 		const panel = document.getElementById( 'panel' );
 		const content = document.getElementById( 'content' );
 		const expandButton = document.getElementById( 'expandButton' );
-		const exitSearchButton = document.getElementById( 'exitSearchButton' );
+		const clearSearchButton = document.getElementById( 'clearSearchButton' );
 		const panelScrim = document.getElementById( 'panelScrim' );
 		const filterInput = document.getElementById( 'filterInput' );
 		let iframe = document.querySelector( 'iframe' );
@@ -165,7 +165,7 @@
 
 			};
 
-			exitSearchButton.onclick = function () {
+			clearSearchButton.onclick = function () {
 
 				filterInput.value = '';
 				updateFilter();

--- a/docs/index.html
+++ b/docs/index.html
@@ -169,7 +169,7 @@
 
 				filterInput.value = '';
 				updateFilter();
-				panel.classList.remove( 'searchFocused' );
+				filterInput.focus();
 
 			};
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -157,7 +157,7 @@
 
 				filterInput.value = '';
 				updateFilter( files, tags );
-				panel.classList.remove( 'searchFocused' );
+				filterInput.focus();
 
 			};
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -29,7 +29,7 @@
 
 				<div id="inputWrapper">
 					<input placeholder="" type="text" id="filterInput" autocorrect="off" autocapitalize="off" spellcheck="false" />
-					<div id="exitSearchButton"></div>
+					<div id="clearSearchButton"></div>
 				</div>
 
 				<div id="content">
@@ -49,7 +49,7 @@
 		const content = document.getElementById( 'content' );
 		const viewer = document.getElementById( 'viewer' );
 		const filterInput = document.getElementById( 'filterInput' );
-		const exitSearchButton = document.getElementById( 'exitSearchButton' );
+		const clearSearchButton = document.getElementById( 'clearSearchButton' );
 		const expandButton = document.getElementById( 'expandButton' );
 		const viewSrcButton = document.getElementById( 'button' );
 		const panelScrim = document.getElementById( 'panelScrim' );
@@ -153,7 +153,7 @@
 
 			};
 
-			exitSearchButton.onclick = function ( ) {
+			clearSearchButton.onclick = function ( ) {
 
 				filterInput.value = '';
 				updateFilter( files, tags );

--- a/files/main.css
+++ b/files/main.css
@@ -138,7 +138,7 @@ h1 a {
 	transition: 0s 0s height;
 }
 
-	#panel #exitSearchButton {
+	#panel #clearSearchButton {
 		width: 48px;
 		height: 48px;
 		display: none;
@@ -154,7 +154,7 @@ h1 a {
 		margin-right: 0px;
 	}
 
-	#panel.searchFocused #exitSearchButton {
+	#panel.searchFocused #clearSearchButton {
 		display: block;
 	}
 

--- a/manual/index.html
+++ b/manual/index.html
@@ -28,7 +28,7 @@
 			<div id="contentWrapper">
 				<div id="inputWrapper">
 					<input placeholder="" type="text" id="filterInput" autocorrect="off" autocapitalize="off" spellcheck="false" />
-					<div id="exitSearchButton"></div>
+					<div id="clearSearchButton"></div>
 					<select id="language">
 						<option value="en">en</option>
 						<option value="fr">fr</option>
@@ -51,7 +51,7 @@
 		const panel = document.querySelector( '#panel' );
 		const content = document.querySelector( '#content' );
 		const expandButton = document.querySelector( '#expandButton' );
-		const exitSearchButton = document.querySelector( '#exitSearchButton' );
+		const clearSearchButton = document.querySelector( '#clearSearchButton' );
 		const panelScrim = document.querySelector( '#panelScrim' );
 		const filterInput = document.querySelector( '#filterInput' );
 		let iframe = document.querySelector( 'iframe' );
@@ -141,7 +141,7 @@
 
 			};
 
-			exitSearchButton.onclick = function () {
+			clearSearchButton.onclick = function () {
 
 				filterInput.value = '';
 				updateFilter();

--- a/manual/index.html
+++ b/manual/index.html
@@ -145,7 +145,7 @@
 
 				filterInput.value = '';
 				updateFilter();
-				panel.classList.remove( 'searchFocused' );
+				filterInput.focus();
 
 			};
 


### PR DESCRIPTION
This was constantly annoying me, especially on mobile[^1]...
[^1]: especially on mobile because we cannot `ctrl+a` easily with the virtual keyboard. But tbh loosing focus was also annoying me on desktop if using the `X` button

BEFORE: In the search field, when clearing my query (with the `X` button), I lost the focus and **have to click on the field again** (at 00:07 in the 1st screencast) to type another query

https://user-images.githubusercontent.com/76580/209435321-b43b99a1-da6a-4653-8fc3-bf3f67f726e0.mp4

AFTER: I keep the focus and can continue typing a different query

https://user-images.githubusercontent.com/76580/209435347-d4ed24f8-4c5e-4d2c-8239-0e98ed77e0aa.mp4

NB: I've renamed (in a separate commit) the `X` button from `exitSearchButton` to `clearSearchButton` just to better reflect what it is now doing