### PR TITLE
Docs: Improve CameraHelper page.

### DIFF
--- a/docs/api/en/helpers/CameraHelper.html
+++ b/docs/api/en/helpers/CameraHelper.html
@@ -12,8 +12,8 @@
 		<h1>[name]</h1>
 
 		<p class="desc">
-		This helps with visualizing what a camera contains in its frustum.<br />
-		It visualizes the frustum of a camera using a [page:LineSegments].
+		This helps with visualizing what a camera contains in its frustum. It visualizes the frustum of a camera using a [page:LineSegments].<br /><br />
+		[name] must be a child of the scene.
 		</p>
 
 		<h2>Code Example</h2>

--- a/docs/api/it/helpers/CameraHelper.html
+++ b/docs/api/it/helpers/CameraHelper.html
@@ -12,8 +12,8 @@
 		<h1>[name]</h1>
 
 		<p class="desc">
-      Questa classe aiuta a visualizzare ciò che una telecamera contiene nel suo frustum.<br />
-      Visualizza il frustum di una telecamera utilizzando un [page:LineSegments].
+		Questa classe aiuta a visualizzare ciò che una telecamera contiene nel suo frustum. Visualizza il frustum di una telecamera utilizzando un [page:LineSegments].<br /><br />
+		[name] must be a child of the scene.
 		</p>
 
 		<h2>Codice di Esempio</h2>

--- a/docs/api/zh/helpers/CameraHelper.html
+++ b/docs/api/zh/helpers/CameraHelper.html
@@ -12,8 +12,8 @@
 		<h1>[name]</h1>
 
 		<p class="desc">
-		用于模拟相机视锥体的辅助对象.<br />
-		它使用 [page:LineSegments] 来模拟相机视锥体.
+		用于模拟相机视锥体的辅助对象.它使用 [page:LineSegments] 来模拟相机视锥体.<br /><br />
+		[name] must be a child of the scene.
 		</p>
 
 		<h2>代码示例</h2>


### PR DESCRIPTION
Related issue: #15342, https://discourse.threejs.org/t/camerahelper-can-render-at-false-positions-when-not-in-root-of-scene/46343/2

**Description**

Adds a note to the `CameraHelper` page that the helper must be a child of the scene.
