### PR TITLE
SVGLoader: Fix parsing of 'points' attribute

### DIFF
--- a/examples/jsm/loaders/SVGLoader.js
+++ b/examples/jsm/loaders/SVGLoader.js
@@ -866,7 +866,7 @@ class SVGLoader extends Loader {
 
 			}
 
-			const regex = /(-?[\d\.?]+)[,|\s](-?[\d\.?]+)/g;
+			const regex = /([+-]?\d*\.?\d+(?:e[+-]?\d+)?)(?:,|\s)([+-]?\d*\.?\d+(?:e[+-]?\d+)?)/g;
 
 			const path = new ShapePath();
 
@@ -901,7 +901,7 @@ class SVGLoader extends Loader {
 
 			}
 
-			const regex = /(-?[\d\.?]+)[,|\s](-?[\d\.?]+)/g;
+			const regex = /([+-]?\d*\.?\d+(?:e[+-]?\d+)?)(?:,|\s)([+-]?\d*\.?\d+(?:e[+-]?\d+)?)/g;
 
 			const path = new ShapePath();
 


### PR DESCRIPTION
**Description**

`SVGLoader()` parses the values of `points` attribute of `<polyline>`/`<polygon>` wrongly.
For example, it parses `1e2,50` to a pair of `2` and `50`, not `100` and `50`; the problem is that the value of the attribute is defined to be a list of `<number>+` [^1], which allows numerals in the exponential notation[^2], but `SVGLoader()`'s regex does not. 

Demo: <https://stackblitz.com/edit/js-ulgby6?devToolsHeight=33&file=index.js>

This is caused by the following regex in `SVGLoader.js` for parsing `<polyline>`/`<polygon>`. This PR fixes the regex accordingly.

https://github.com/mrdoob/three.js/blob/4fa01465053d3d95e5c6e05fee701b1b217878aa/examples/jsm/loaders/SVGLoader.js#L869

https://github.com/mrdoob/three.js/blob/4fa01465053d3d95e5c6e05fee701b1b217878aa/examples/jsm/loaders/SVGLoader.js#L904


[^1]: https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/points
[^2]: https://developer.mozilla.org/en-US/docs/Web/SVG/Content_type#number
