### PR TITLE
Docs: Remove IE11 references.

### DIFF
--- a/docs/examples/en/loaders/DRACOLoader.html
+++ b/docs/examples/en/loaders/DRACOLoader.html
@@ -78,12 +78,7 @@
 
 		<h2>Browser compatibility</h2>
 
-		<p>DRACOLoader relies on ES6 [link:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise Promises],
-		which are not supported in IE11. To use the loader in IE11, you must
-		[link:https://github.com/stefanpenner/es6-promise include a polyfill]
-		providing a Promise replacement. DRACOLoader will automatically use
-		either the JS or the WASM decoding library, based on browser
-		capabilities.</p>
+		<p>DRACOLoader will automatically use either the JS or the WASM decoding library, based on browser capabilities.</p>
 
 		<br>
 		<hr>

--- a/docs/examples/en/loaders/GLTFLoader.html
+++ b/docs/examples/en/loaders/GLTFLoader.html
@@ -123,13 +123,6 @@
 			[example:webgl_loader_gltf]
 		</p>
 
-		<h2>Browser compatibility</h2>
-
-		<p>GLTFLoader relies on ES6 [link:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise Promises],
-		which are not supported in IE11. To use the loader in IE11, you must
-		[link:https://github.com/stefanpenner/es6-promise include a polyfill]
-		providing a Promise replacement.</p>
-
 		<h2>Textures</h2>
 
 		<p>Textures containing color information (.map, .emissiveMap, and .specularMap) always use sRGB colorspace in

--- a/docs/examples/en/loaders/KTX2Loader.html
+++ b/docs/examples/en/loaders/KTX2Loader.html
@@ -57,8 +57,7 @@
 		<h2>Browser compatibility</h2>
 
 		<p>
-			See notes for [page:BasisTextureLoader]. This loader relies on ES6 Promises and Web Assembly, which are not
-			supported in IE11.
+			This loader relies on Web Assembly which is not supported older borwsers.
 		</p>
 
 		<br>

--- a/docs/examples/en/loaders/KTX2Loader.html
+++ b/docs/examples/en/loaders/KTX2Loader.html
@@ -57,7 +57,7 @@
 		<h2>Browser compatibility</h2>
 
 		<p>
-			This loader relies on Web Assembly which is not supported older borwsers.
+			This loader relies on Web Assembly which is not supported in older browsers.
 		</p>
 
 		<br>

--- a/docs/examples/zh/loaders/DRACOLoader.html
+++ b/docs/examples/zh/loaders/DRACOLoader.html
@@ -73,12 +73,7 @@
 
 		<h2>Browser compatibility</h2>
 
-		<p>DRACOLoader relies on ES6 [link:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise Promises],
-		which are not supported in IE11. To use the loader in IE11, you must
-		[link:https://github.com/stefanpenner/es6-promise include a polyfill]
-		providing a Promise replacement. DRACOLoader will automatically use
-		either the JS or the WASM decoding library, based on browser
-		capabilities.</p>
+		<p>DRACOLoader will automatically use either the JS or the WASM decoding library, based on browser capabilities.</p>
 
 		<br>
 		<hr>

--- a/docs/examples/zh/loaders/GLTFLoader.html
+++ b/docs/examples/zh/loaders/GLTFLoader.html
@@ -122,12 +122,6 @@
 			[example:webgl_loader_gltf]
 		</p>
 
-		<h2>浏览器兼容性</h2>
-
-		<p>GLTFLoader 依赖 ES6 [link:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise Promises]，
-		这一特性不支持IE11。若要在IE11中使用该加载器，你必须引入polyfill（[link:https://github.com/stefanpenner/es6-promise include a polyfill]）
-		来提供一个Promise的替代方案。</p>
-
 		<h2>纹理</h2>
 
 		<p>纹理中包含的颜色信息（.map, .emissiveMap, 和 .specularMap）在glTF中总是使用sRGB颜色空间，而顶点颜色和材质属性（.color, .emissive, .specular）


### PR DESCRIPTION
Related issue: -

**Description**

`three.js` does not support IE11 anymore so we can safely remove all remaining references in the documentation.