### PR TITLE
Add alphas channel for instanced meshes. Update example.

### DIFF
--- a/examples/webgl_instancing_raycast.html
+++ b/examples/webgl_instancing_raycast.html
@@ -56,9 +56,9 @@
 				scene.add( light );
 
 				const geometry = new THREE.IcosahedronGeometry( 0.5, 3 );
-				const material = new THREE.MeshPhongMaterial( { color: 0xffffff } );
+				const material = new THREE.MeshPhongMaterial( { color: 0xffffff, transparent: true } );
 
-				mesh = new THREE.InstancedMesh( geometry, material, count );
+				mesh = new THREE.InstancedMesh( geometry, material, count, true );
 
 				let i = 0;
 				const offset = ( amount - 1 ) / 2;
@@ -145,7 +145,7 @@
 
 					if ( color.equals( white ) ) {
 
-						mesh.setColorAt( instanceId, color.setHex( Math.random() * 0xffffff ) );
+						mesh.setColorAt( instanceId, color.setHex( Math.random() * 0xffffff ), Math.random() );
 
 						mesh.instanceColor.needsUpdate = true;
 

--- a/examples/webgl_instancing_raycast.html
+++ b/examples/webgl_instancing_raycast.html
@@ -56,9 +56,9 @@
 				scene.add( light );
 
 				const geometry = new THREE.IcosahedronGeometry( 0.5, 3 );
-				const material = new THREE.MeshPhongMaterial( { color: 0xffffff, transparent: true } );
+				const material = new THREE.MeshPhongMaterial( { color: 0xffffff } );
 
-				mesh = new THREE.InstancedMesh( geometry, material, count, true );
+				mesh = new THREE.InstancedMesh( geometry, material, count );
 
 				let i = 0;
 				const offset = ( amount - 1 ) / 2;
@@ -145,7 +145,7 @@
 
 					if ( color.equals( white ) ) {
 
-						mesh.setColorAt( instanceId, color.setHex( Math.random() * 0xffffff ), Math.random() );
+						mesh.setColorAt( instanceId, color.setHex( Math.random() * 0xffffff ) );
 
 						mesh.instanceColor.needsUpdate = true;
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -726,6 +726,7 @@ class Object3D extends EventDispatcher {
 
 			object.type = 'InstancedMesh';
 			object.count = this.count;
+			object.useAlphas = this.useAlphas;
 			object.instanceMatrix = this.instanceMatrix.toJSON();
 			if ( this.instanceColor !== null ) object.instanceColor = this.instanceColor.toJSON();
 

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -877,10 +877,11 @@ class ObjectLoader extends Loader {
 				geometry = getGeometry( data.geometry );
 				material = getMaterial( data.material );
 				const count = data.count;
+				const useAlphas = data.useAlphas;
 				const instanceMatrix = data.instanceMatrix;
 				const instanceColor = data.instanceColor;
 
-				object = new InstancedMesh( geometry, material, count );
+				object = new InstancedMesh( geometry, material, count, useAlphas );
 				object.instanceMatrix = new InstancedBufferAttribute( new Float32Array( instanceMatrix.array ), 16 );
 				if ( instanceColor !== undefined ) object.instanceColor = new InstancedBufferAttribute( new Float32Array( instanceColor.array ), instanceColor.itemSize );
 

--- a/src/objects/InstancedMesh.js
+++ b/src/objects/InstancedMesh.js
@@ -12,7 +12,7 @@ const _mesh = /*@__PURE__*/ new Mesh();
 
 class InstancedMesh extends Mesh {
 
-	constructor( geometry, material, count ) {
+	constructor( geometry, material, count, useAlphas ) {
 
 		super( geometry, material );
 
@@ -24,6 +24,9 @@ class InstancedMesh extends Mesh {
 		this.count = count;
 
 		this.frustumCulled = false;
+
+		this.useAlphas = useAlphas;
+		this.colorItemsSize = useAlphas ? 4 : 3;
 
 		for ( let i = 0; i < count; i ++ ) {
 
@@ -42,6 +45,8 @@ class InstancedMesh extends Mesh {
 		if ( source.instanceColor !== null ) this.instanceColor = source.instanceColor.clone();
 
 		this.count = source.count;
+		this.useAlphas = source.useAlphas;
+		this.colorItemsSize = source.colorItemsSize;
 
 		return this;
 
@@ -49,7 +54,7 @@ class InstancedMesh extends Mesh {
 
 	getColorAt( index, color ) {
 
-		color.fromArray( this.instanceColor.array, index * 3 );
+		color.fromArray( this.instanceColor.array, index * this.colorItemsSize );
 
 	}
 
@@ -100,15 +105,21 @@ class InstancedMesh extends Mesh {
 
 	}
 
-	setColorAt( index, color ) {
+	setColorAt( index, color, opacity = 1.0 ) {
 
 		if ( this.instanceColor === null ) {
 
-			this.instanceColor = new InstancedBufferAttribute( new Float32Array( this.instanceMatrix.count * 3 ), 3 );
+			this.instanceColor = new InstancedBufferAttribute( new Float32Array( this.instanceMatrix.count * this.colorItemsSize ), this.colorItemsSize );
 
 		}
 
-		color.toArray( this.instanceColor.array, index * 3 );
+		color.toArray( this.instanceColor.array, index * this.colorItemsSize );
+
+		if ( this.useAlphas ) {
+
+			this.instanceColor.array[ index * this.colorItemsSize + 3 ] = opacity;
+
+		}
 
 	}
 

--- a/src/renderers/shaders/ShaderChunk/color_pars_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/color_pars_vertex.glsl.js
@@ -1,5 +1,5 @@
 export default /* glsl */`
-#if defined( USE_COLOR_ALPHA )
+#if defined( USE_COLOR_ALPHA ) || defined( USE_INSTANCING_COLOR_ALPHA )
 
 	varying vec4 vColor;
 

--- a/src/renderers/shaders/ShaderChunk/color_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/color_vertex.glsl.js
@@ -1,5 +1,5 @@
 export default /* glsl */`
-#if defined( USE_COLOR_ALPHA )
+#if defined( USE_COLOR_ALPHA ) || defined( USE_INSTANCING_COLOR_ALPHA )
 
 	vColor = vec4( 1.0 );
 
@@ -17,7 +17,7 @@ export default /* glsl */`
 
 #ifdef USE_INSTANCING_COLOR
 
-	vColor.xyz *= instanceColor.xyz;
+	vColor *= instanceColor;
 
 #endif
 `;

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -453,6 +453,7 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 
 			parameters.instancing ? '#define USE_INSTANCING' : '',
 			parameters.instancingColor ? '#define USE_INSTANCING_COLOR' : '',
+			parameters.instancingColorAlphas ? '#define USE_INSTANCING_COLOR_ALPHA' : '',
 
 			parameters.supportsVertexTextures ? '#define VERTEX_TEXTURES' : '',
 
@@ -535,7 +536,11 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 
 			'#endif',
 
-			'#ifdef USE_INSTANCING_COLOR',
+			'#if defined( USE_INSTANCING_COLOR_ALPHA )',
+
+			'	attribute vec4 instanceColor;',
+
+			'#elif defined( USE_INSTANCING_COLOR )',
 
 			'	attribute vec3 instanceColor;',
 
@@ -657,7 +662,7 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 
 			parameters.vertexTangents ? '#define USE_TANGENT' : '',
 			parameters.vertexColors || parameters.instancingColor ? '#define USE_COLOR' : '',
-			parameters.vertexAlphas ? '#define USE_COLOR_ALPHA' : '',
+			parameters.vertexAlphas || parameters.instancingColorAlphas ? '#define USE_COLOR_ALPHA' : '',
 			parameters.vertexUvs ? '#define USE_UV' : '',
 			parameters.uvsVertexOnly ? '#define UVS_VERTEX_ONLY' : '',
 

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -122,6 +122,7 @@ function WebGLPrograms( renderer, cubemaps, cubeuvmaps, extensions, capabilities
 
 			instancing: object.isInstancedMesh === true,
 			instancingColor: object.isInstancedMesh === true && object.instanceColor !== null,
+			instancingColorAlphas: object.isInstancedMesh === true && object.instanceColor && object.instanceColor.itemSize === 4,
 
 			supportsVertexTextures: vertexTextures,
 			outputEncoding: ( currentRenderTarget === null ) ? renderer.outputEncoding : ( currentRenderTarget.isXRRenderTarget === true ? currentRenderTarget.texture.encoding : LinearEncoding ),


### PR DESCRIPTION
Related issue: https://discourse.threejs.org/t/add-opacity-to-vertice-colors-and-instanced-geometry/26298

Will give you the ability to set the opacity for colors in instanced meshes.