### PR TITLE
Scene: Fix serialization of background properties.

### DIFF
--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -136,6 +136,7 @@ Editor.prototype = {
 		this.scene.background = scene.background;
 		this.scene.environment = scene.environment;
 		this.scene.fog = scene.fog;
+		this.scene.backgroundBlurriness = scene.backgroundBlurriness;
 
 		this.scene.userData = JSON.parse( JSON.stringify( scene.userData ) );
 

--- a/editor/js/Sidebar.Scene.js
+++ b/editor/js/Sidebar.Scene.js
@@ -395,6 +395,7 @@ function SidebarScene( editor ) {
 
 					backgroundType.setValue( 'Equirectangular' );
 					backgroundEquirectangularTexture.setValue( scene.background );
+					backgroundBlurriness.setValue( scene.backgroundBlurriness );
 
 				} else {
 

--- a/src/scenes/Scene.js
+++ b/src/scenes/Scene.js
@@ -51,8 +51,8 @@ class Scene extends Object3D {
 		const data = super.toJSON( meta );
 
 		if ( this.fog !== null ) data.object.fog = this.fog.toJSON();
-		if ( this.backgroundBlurriness > 0 ) data.backgroundBlurriness = this.backgroundBlurriness;
-		if ( this.backgroundIntensity !== 1 ) data.backgroundIntensity = this.backgroundIntensity;
+		if ( this.backgroundBlurriness > 0 ) data.object.backgroundBlurriness = this.backgroundBlurriness;
+		if ( this.backgroundIntensity !== 1 ) data.object.backgroundIntensity = this.backgroundIntensity;
 
 		return data;
 


### PR DESCRIPTION
Related issue: https://discourse.threejs.org/t/r146-editor-scene-background-add-backgroundblurriness-in-not-rendering-on-play/46398

**Description**

`Scene.toJSON()` did not save `backgroundBlurriness` and `backgroundIntensity` at the right place in the JSON.

Besides, the editor did not properly read the saved blurriness and refreshed the UI.
