### PR TITLE
Editor: Add support for `Scene.backgroundIntensity`.

### DIFF
--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -137,6 +137,7 @@ Editor.prototype = {
 		this.scene.environment = scene.environment;
 		this.scene.fog = scene.fog;
 		this.scene.backgroundBlurriness = scene.backgroundBlurriness;
+		this.scene.backgroundIntensity = scene.backgroundIntensity;
 
 		this.scene.userData = JSON.parse( JSON.stringify( scene.userData ) );
 

--- a/editor/js/Sidebar.Scene.js
+++ b/editor/js/Sidebar.Scene.js
@@ -192,7 +192,7 @@ function SidebarScene( editor ) {
 	const backgroundBlurriness = new UINumber( 0 ).setWidth( '40px' ).setRange( 0, 1 ).onChange( onBackgroundChanged );
 	backgroundEquirectRow.add( backgroundBlurriness );
 
-	const backgroundIntensity = new UINumber( 1 ).setWidth( '40px' ).setRange( 0, 10 ).onChange( onBackgroundChanged );
+	const backgroundIntensity = new UINumber( 1 ).setWidth( '40px' ).setRange( 0, Infinity ).onChange( onBackgroundChanged );
 	backgroundEquirectRow.add( backgroundIntensity );
 
 	container.add( backgroundEquirectRow );

--- a/editor/js/Sidebar.Scene.js
+++ b/editor/js/Sidebar.Scene.js
@@ -192,6 +192,9 @@ function SidebarScene( editor ) {
 	const backgroundBlurriness = new UINumber( 0 ).setWidth( '40px' ).setRange( 0, 1 ).onChange( onBackgroundChanged );
 	backgroundEquirectRow.add( backgroundBlurriness );
 
+	const backgroundIntensity = new UINumber( 1 ).setWidth( '40px' ).setRange( 0, 10 ).onChange( onBackgroundChanged );
+	backgroundEquirectRow.add( backgroundIntensity );
+
 	container.add( backgroundEquirectRow );
 
 	function onBackgroundChanged() {
@@ -201,7 +204,8 @@ function SidebarScene( editor ) {
 			backgroundColor.getHexValue(),
 			backgroundTexture.getValue(),
 			backgroundEquirectangularTexture.getValue(),
-			backgroundBlurriness.getValue()
+			backgroundBlurriness.getValue(),
+			backgroundIntensity.getValue()
 		);
 
 	}
@@ -396,6 +400,7 @@ function SidebarScene( editor ) {
 					backgroundType.setValue( 'Equirectangular' );
 					backgroundEquirectangularTexture.setValue( scene.background );
 					backgroundBlurriness.setValue( scene.backgroundBlurriness );
+					backgroundIntensity.setValue( scene.backgroundIntensity );
 
 				} else {
 

--- a/editor/js/Viewport.js
+++ b/editor/js/Viewport.js
@@ -481,7 +481,7 @@ function Viewport( editor ) {
 
 	// background
 
-	signals.sceneBackgroundChanged.add( function ( backgroundType, backgroundColor, backgroundTexture, backgroundEquirectangularTexture, backgroundBlurriness ) {
+	signals.sceneBackgroundChanged.add( function ( backgroundType, backgroundColor, backgroundTexture, backgroundEquirectangularTexture, backgroundBlurriness, backgroundIntensity ) {
 
 		switch ( backgroundType ) {
 
@@ -514,6 +514,7 @@ function Viewport( editor ) {
 					backgroundEquirectangularTexture.mapping = THREE.EquirectangularReflectionMapping;
 					scene.background = backgroundEquirectangularTexture;
 					scene.backgroundBlurriness = backgroundBlurriness;
+					scene.backgroundIntensity = backgroundIntensity;
 
 				}
 

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -784,6 +784,7 @@ class ObjectLoader extends Loader {
 				}
 
 				if ( data.backgroundBlurriness !== undefined ) object.backgroundBlurriness = data.backgroundBlurriness;
+				if ( data.backgroundIntensity !== undefined ) object.backgroundIntensity = data.backgroundIntensity;
 
 				break;
 


### PR DESCRIPTION
Related issue: #24876

**Description**

Adds `Scene.backgroundIntensity` to the editor.

The PR starts with environment maps although normal textured backgrounds can also configure a background intensity.
