### PR TITLE
GLBufferAttribute: Add `name` property.

### DIFF
--- a/docs/api/en/core/GLBufferAttribute.html
+++ b/docs/api/en/core/GLBufferAttribute.html
@@ -84,6 +84,11 @@
 			Read-only. Always `true`.
 		</p>
 
+		<h3>[property:String name]</h3>
+		<p>
+		  Optional name for this attribute instance. Default is an empty string.
+		</p>
+
 		<h2>Methods</h2>
 
 		<h3>[method:this setBuffer]( buffer ) </h3>

--- a/src/core/GLBufferAttribute.js
+++ b/src/core/GLBufferAttribute.js
@@ -4,6 +4,8 @@ class GLBufferAttribute {
 
 		this.isGLBufferAttribute = true;
 
+		this.name = '';
+
 		this.buffer = buffer;
 		this.type = type;
 		this.itemSize = itemSize;


### PR DESCRIPTION
**Description**

This change simply initializes a `name` field in `GLBufferAttribute` constructor to an empty string. This matches what is done in `BufferAttribute` and `InterleavedBufferAttribute`. The reason for this small change is to have a common `name` field for all buffer attributes in the corresponding TS types (see https://github.com/three-types/three-ts-types/pull/295#discussion_r1056740559).