### PR TITLE
Editor: Set ColorManagement.legacyMode = false

### DIFF
--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -7,6 +7,8 @@ import { Strings } from './Strings.js';
 import { Storage as _Storage } from './Storage.js';
 import { Selector } from './Viewport.Selector.js';
 
+THREE.ColorManagement.legacyMode = false;
+
 var _DEFAULT_CAMERA = new THREE.PerspectiveCamera( 50, 1, 0.01, 1000 );
 _DEFAULT_CAMERA.name = 'Camera';
 _DEFAULT_CAMERA.position.set( 0, 5, 10 );

--- a/editor/js/libs/app/index.html
+++ b/editor/js/libs/app/index.html
@@ -27,6 +27,8 @@
 			window.THREE = THREE; // Used by APP Scripts.
 			window.VRButton = VRButton; // Used by APP Scripts.
 
+			THREE.ColorManagement.legacyMode = false;
+
 			var loader = new THREE.FileLoader();
 			loader.load( 'app.json', function ( text ) {
 


### PR DESCRIPTION
The `<input type="color">` HTML element provides an [_sRGB_ color picker](https://html.spec.whatwg.org/multipage/input.html#attr-input-type-keywords)<sup>1</sup>, and the preview swatches shown in the picker reflect that, but the Editor does not. I think it would be best to account for the color space when working in the Editor. This allows, for example, setting `#1A7FEB` anywhere in the Editor and seeing the color consistently in the HTML picker, MeshBasicMaterial color, Fog color, and so on.

Related:

- https://discord.com/channels/685241246557667386/1059601330211131402/1059601330211131402

***

<sup>1</sup> By default in Safari and Firefox, and with no other options in Chrome. The option to reach Linear-sRGB ("Rec. ITU-R BT.709-5") in Safari and Firefox is pretty hard to find, and I doubt we can expect users to do so. That option does not affect the value returned to the page, which appears to be sRGB in any case.