### PR TITLE
Loaders: Remove use of `LoaderUtils.decodeText()`.

### DIFF
--- a/examples/jsm/loaders/3MFLoader.js
+++ b/examples/jsm/loaders/3MFLoader.js
@@ -9,7 +9,6 @@ import {
 	LinearFilter,
 	LinearMipmapLinearFilter,
 	Loader,
-	LoaderUtils,
 	Matrix4,
 	Mesh,
 	MeshPhongMaterial,
@@ -104,6 +103,8 @@ class ThreeMFLoader extends Loader {
 			const printTicketParts = {};
 			const texturesParts = {};
 
+			const textDecoder = new TextDecoder();
+
 			try {
 
 				zip = fflate.unzipSync( new Uint8Array( data ) );
@@ -144,7 +145,7 @@ class ThreeMFLoader extends Loader {
 			//
 
 			const relsView = zip[ relsName ];
-			const relsFileText = LoaderUtils.decodeText( relsView );
+			const relsFileText = textDecoder.decode( relsView );
 			const rels = parseRelsXml( relsFileText );
 
 			//
@@ -152,7 +153,7 @@ class ThreeMFLoader extends Loader {
 			if ( modelRelsName ) {
 
 				const relsView = zip[ modelRelsName ];
-				const relsFileText = LoaderUtils.decodeText( relsView );
+				const relsFileText = textDecoder.decode( relsView );
 				modelRels = parseRelsXml( relsFileText );
 
 			}
@@ -164,7 +165,7 @@ class ThreeMFLoader extends Loader {
 				const modelPart = modelPartNames[ i ];
 				const view = zip[ modelPart ];
 
-				const fileText = LoaderUtils.decodeText( view );
+				const fileText = textDecoder.decode( view );
 				const xmlData = new DOMParser().parseFromString( fileText, 'application/xml' );
 
 				if ( xmlData.documentElement.nodeName.toLowerCase() !== 'model' ) {

--- a/examples/jsm/loaders/AMFLoader.js
+++ b/examples/jsm/loaders/AMFLoader.js
@@ -5,7 +5,6 @@ import {
 	Float32BufferAttribute,
 	Group,
 	Loader,
-	LoaderUtils,
 	Mesh,
 	MeshPhongMaterial
 } from 'three';
@@ -114,7 +113,7 @@ class AMFLoader extends Loader {
 
 			}
 
-			const fileText = LoaderUtils.decodeText( view );
+			const fileText = new TextDecoder().decode( view );
 			const xmlData = new DOMParser().parseFromString( fileText, 'application/xml' );
 
 			if ( xmlData.documentElement.nodeName.toLowerCase() !== 'amf' ) {

--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -3592,7 +3592,7 @@ class BinaryReader {
 		this.dv = new DataView( buffer );
 		this.offset = 0;
 		this.littleEndian = ( littleEndian !== undefined ) ? littleEndian : true;
-		this.textDecoder = new TextDecoder();
+		this._textDecoder = new TextDecoder();
 
 	}
 
@@ -3823,7 +3823,7 @@ class BinaryReader {
 		const nullByte = a.indexOf( 0 );
 		if ( nullByte >= 0 ) a = a.slice( 0, nullByte );
 
-		return this.textDecoder.decode( new Uint8Array( a ) );
+		return this._textDecoder.decode( new Uint8Array( a ) );
 
 	}
 

--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -3592,6 +3592,7 @@ class BinaryReader {
 		this.dv = new DataView( buffer );
 		this.offset = 0;
 		this.littleEndian = ( littleEndian !== undefined ) ? littleEndian : true;
+		this.textDecoder = new TextDecoder();
 
 	}
 
@@ -3822,7 +3823,7 @@ class BinaryReader {
 		const nullByte = a.indexOf( 0 );
 		if ( nullByte >= 0 ) a = a.slice( 0, nullByte );
 
-		return LoaderUtils.decodeText( new Uint8Array( a ) );
+		return this.textDecoder.decode( new Uint8Array( a ) );
 
 	}
 
@@ -4104,7 +4105,7 @@ function convertArrayBufferToString( buffer, from, to ) {
 	if ( from === undefined ) from = 0;
 	if ( to === undefined ) to = buffer.byteLength;
 
-	return LoaderUtils.decodeText( new Uint8Array( buffer, from, to ) );
+	return new TextDecoder().decode( new Uint8Array( buffer, from, to ) );
 
 }
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -286,6 +286,7 @@ class GLTFLoader extends Loader {
 		let json;
 		const extensions = {};
 		const plugins = {};
+		const textDecoder = new TextDecoder();
 
 		if ( typeof data === 'string' ) {
 
@@ -293,7 +294,7 @@ class GLTFLoader extends Loader {
 
 		} else if ( data instanceof ArrayBuffer ) {
 
-			const magic = LoaderUtils.decodeText( new Uint8Array( data, 0, 4 ) );
+			const magic = textDecoder.decode( new Uint8Array( data, 0, 4 ) );
 
 			if ( magic === BINARY_EXTENSION_HEADER_MAGIC ) {
 
@@ -312,7 +313,7 @@ class GLTFLoader extends Loader {
 
 			} else {
 
-				json = JSON.parse( LoaderUtils.decodeText( new Uint8Array( data ) ) );
+				json = JSON.parse( textDecoder.decode( data ) );
 
 			}
 
@@ -1566,9 +1567,10 @@ class GLTFBinaryExtension {
 		this.body = null;
 
 		const headerView = new DataView( data, 0, BINARY_EXTENSION_HEADER_LENGTH );
+		const textDecoder = new TextDecoder();
 
 		this.header = {
-			magic: LoaderUtils.decodeText( new Uint8Array( data.slice( 0, 4 ) ) ),
+			magic: textDecoder.decode( new Uint8Array( data.slice( 0, 4 ) ) ),
 			version: headerView.getUint32( 4, true ),
 			length: headerView.getUint32( 8, true )
 		};
@@ -1598,7 +1600,7 @@ class GLTFBinaryExtension {
 			if ( chunkType === BINARY_EXTENSION_CHUNK_TYPES.JSON ) {
 
 				const contentArray = new Uint8Array( data, BINARY_EXTENSION_HEADER_LENGTH + chunkIndex, chunkLength );
-				this.content = LoaderUtils.decodeText( contentArray );
+				this.content = textDecoder.decode( contentArray );
 
 			} else if ( chunkType === BINARY_EXTENSION_CHUNK_TYPES.BIN ) {
 

--- a/examples/jsm/loaders/PCDLoader.js
+++ b/examples/jsm/loaders/PCDLoader.js
@@ -4,7 +4,6 @@ import {
 	Float32BufferAttribute,
 	Int32BufferAttribute,
 	Loader,
-	LoaderUtils,
 	Points,
 	PointsMaterial
 } from 'three';
@@ -219,7 +218,7 @@ class PCDLoader extends Loader {
 
 		}
 
-		const textData = LoaderUtils.decodeText( new Uint8Array( data ) );
+		const textData = new TextDecoder().decode( data );
 
 		// parse header (always ascii format)
 

--- a/examples/jsm/loaders/PLYLoader.js
+++ b/examples/jsm/loaders/PLYLoader.js
@@ -3,7 +3,6 @@ import {
 	FileLoader,
 	Float32BufferAttribute,
 	Loader,
-	LoaderUtils,
 	Color
 } from 'three';
 
@@ -652,7 +651,7 @@ class PLYLoader extends Loader {
 
 			if ( header.format === 'ascii' ) {
 
-				const text = LoaderUtils.decodeText( bytes );
+				const text = new TextDecoder().decode( bytes );
 
 				geometry = parseASCII( text, header );
 

--- a/examples/jsm/loaders/STLLoader.js
+++ b/examples/jsm/loaders/STLLoader.js
@@ -4,7 +4,6 @@ import {
 	FileLoader,
 	Float32BufferAttribute,
 	Loader,
-	LoaderUtils,
 	Vector3
 } from 'three';
 
@@ -357,7 +356,7 @@ class STLLoader extends Loader {
 
 			if ( typeof buffer !== 'string' ) {
 
-				return LoaderUtils.decodeText( new Uint8Array( buffer ) );
+				return new TextDecoder().decode( buffer );
 
 			}
 

--- a/examples/jsm/loaders/VTKLoader.js
+++ b/examples/jsm/loaders/VTKLoader.js
@@ -3,8 +3,7 @@ import {
 	BufferGeometry,
 	FileLoader,
 	Float32BufferAttribute,
-	Loader,
-	LoaderUtils
+	Loader
 } from 'three';
 import * as fflate from '../libs/fflate.module.js';
 
@@ -1130,16 +1129,18 @@ class VTKLoader extends Loader {
 
 		}
 
+		const textDecoder = new TextDecoder();
+
 		// get the 5 first lines of the files to check if there is the key word binary
-		const meta = LoaderUtils.decodeText( new Uint8Array( data, 0, 250 ) ).split( '\n' );
+		const meta = textDecoder.decode( new Uint8Array( data, 0, 250 ) ).split( '\n' );
 
 		if ( meta[ 0 ].indexOf( 'xml' ) !== - 1 ) {
 
-			return parseXML( LoaderUtils.decodeText( data ) );
+			return parseXML( textDecoder.decode( data ) );
 
 		} else if ( meta[ 2 ].includes( 'ASCII' ) ) {
 
-			return parseASCII( LoaderUtils.decodeText( data ) );
+			return parseASCII( textDecoder.decode( data ) );
 
 		} else {
 

--- a/examples/jsm/loaders/lwo/IFFParser.js
+++ b/examples/jsm/loaders/lwo/IFFParser.js
@@ -907,7 +907,7 @@ function DataViewReader( buffer ) {
 
 	this.dv = new DataView( buffer );
 	this.offset = 0;
-	this.textDecoder = new TextDecoder();
+	this._textDecoder = new TextDecoder();
 
 }
 
@@ -1093,7 +1093,7 @@ DataViewReader.prototype = {
 
 		}
 
-		return this.textDecoder.decode( new Uint8Array( a ) );
+		return this._textDecoder.decode( new Uint8Array( a ) );
 
 	},
 

--- a/examples/jsm/loaders/lwo/IFFParser.js
+++ b/examples/jsm/loaders/lwo/IFFParser.js
@@ -32,7 +32,6 @@
  *
  **/
 
-import { LoaderUtils } from 'three';
 import { LWO2Parser } from './LWO2Parser.js';
 import { LWO3Parser } from './LWO3Parser.js';
 
@@ -908,6 +907,7 @@ function DataViewReader( buffer ) {
 
 	this.dv = new DataView( buffer );
 	this.offset = 0;
+	this.textDecoder = new TextDecoder();
 
 }
 
@@ -1093,7 +1093,7 @@ DataViewReader.prototype = {
 
 		}
 
-		return LoaderUtils.decodeText( new Uint8Array( a ) );
+		return this.textDecoder.decode( new Uint8Array( a ) );
 
 	},
 
@@ -1211,7 +1211,7 @@ function stringOffset( string ) {
 // printBuffer( this.reader.dv.buffer, this.reader.offset, length );
 function printBuffer( buffer, from, to ) {
 
-	console.log( LoaderUtils.decodeText( new Uint8Array( buffer, from, to ) ) );
+	console.log( new TextDecoder().decode( new Uint8Array( buffer, from, to ) ) );
 
 }
 


### PR DESCRIPTION
**Description**

TextDecoder() is now supported by modern browsers and supported versions of node.

This removes all use of LoaderUtils.decodeText() from examples, which can then be deprecated. In some loaders this also reduces the number of new TextDecoder instances created.

