### PR TITLE
Examples: bump pathtracer, bvh versions

### DIFF
--- a/examples/webgl_raycaster_bvh.html
+++ b/examples/webgl_raycaster_bvh.html
@@ -33,7 +33,7 @@
 				"imports": {
 					"three": "../build/three.module.js",
 					"three/addons/": "./jsm/",
-					"three-mesh-bvh": "https://unpkg.com/three-mesh-bvh@^0.5.10/build/index.module.js"
+					"three-mesh-bvh": "https://unpkg.com/three-mesh-bvh@^0.5.21/build/index.module.js"
 				}
 			}
 		</script>

--- a/examples/webgl_renderer_pathtracer.html
+++ b/examples/webgl_renderer_pathtracer.html
@@ -48,8 +48,8 @@
 					"three": "../build/three.module.js",
 					"three/addons/": "./jsm/",
 					"three/examples/": "./",
-					"three-gpu-pathtracer": "https://unpkg.com/three-gpu-pathtracer@0.0.7/build/index.module.js",
-					"three-mesh-bvh": "https://unpkg.com/three-mesh-bvh@^0.5.10/build/index.module.js"
+					"three-gpu-pathtracer": "https://unpkg.com/three-gpu-pathtracer@0.0.11/build/index.module.js",
+					"three-mesh-bvh": "https://unpkg.com/three-mesh-bvh@^0.5.21/build/index.module.js"
 				}
 			}
 		</script>
@@ -66,7 +66,7 @@
 			import { LDrawUtils } from 'three/addons/utils/LDrawUtils.js';
 			import { FullScreenQuad } from 'three/addons/postprocessing/Pass.js';
 
-			import { PhysicalPathTracingMaterial, PathTracingRenderer, MaterialReducer, BlurredEnvMapGenerator, PathTracingSceneGenerator } from 'three-gpu-pathtracer';
+			import { PhysicalPathTracingMaterial, PathTracingRenderer, MaterialReducer, BlurredEnvMapGenerator, PathTracingSceneGenerator, GradientEquirectTexture } from 'three-gpu-pathtracer';
 
 			let progressBarDiv, samplesEl;
 			let camera, scene, renderer, controls, gui;
@@ -114,10 +114,14 @@
 				pathTracer.alpha = true;
 				pathTracer.tiles.set( params.tiles, params.tiles );
 				pathTracer.material = new PhysicalPathTracingMaterial();
-				pathTracer.material.setDefine( 'FEATURE_GRADIENT_BG', 1 );
 				pathTracer.material.setDefine( 'FEATURE_MIS', 1 );
-				pathTracer.material.bgGradientTop.set( 0xeeeeee );
-				pathTracer.material.bgGradientBottom.set( 0xeaeaea );
+
+				const gradientMap = new GradientEquirectTexture();
+				gradientMap.topColor.set( 0xeeeeee );
+				gradientMap.bottomColor.set( 0xeaeaea );
+				gradientMap.update();
+
+				pathTracer.material.backgroundMap = gradientMap;
 				pathTracer.camera = camera;
 
 				fsQuad = new FullScreenQuad( new THREE.MeshBasicMaterial( {
@@ -260,11 +264,13 @@
 				const material = pathTracer.material;
 
 				material.bvh.updateFrom( bvh );
-				material.normalAttribute.updateFrom( geometry.attributes.normal );
-				material.tangentAttribute.updateFrom( geometry.attributes.tangent );
-				material.uvAttribute.updateFrom( geometry.attributes.uv );
+				material.attributesArray.updateFrom(
+					geometry.attributes.normal,
+					geometry.attributes.tangent,
+					geometry.attributes.uv,
+					geometry.attributes.color,
+				);
 				material.materialIndexAttribute.updateFrom( geometry.attributes.materialIndex );
-				// material.colorAttribute.updateFrom( geometry.attributes.color );
 				material.textures.setTextures( renderer, 2048, 2048, textures );
 				material.materials.updateFrom( materials, textures );
 				pathTracer.material.envMapInfo.updateFrom( envMap );


### PR DESCRIPTION
Related issue: --

**Description**

Bump the path tracer and bvh library versions in the examples