### PR TITLE
FBXLoader: Remove workaround for Safari 9.

### DIFF
--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -3811,19 +3811,15 @@ class BinaryReader {
 
 	getString( size ) {
 
-		// note: safari 9 doesn't support Uint8Array.indexOf; create intermediate array instead
-		let a = [];
+		const start = this.offset;
+		let a = new Uint8Array( this.dv.buffer, start, size );
 
-		for ( let i = 0; i < size; i ++ ) {
-
-			a[ i ] = this.getUint8();
-
-		}
+		this.skip( size );
 
 		const nullByte = a.indexOf( 0 );
-		if ( nullByte >= 0 ) a = a.slice( 0, nullByte );
+		if ( nullByte >= 0 ) a = new Uint8Array( this.dv.buffer, start, nullByte );
 
-		return this._textDecoder.decode( new Uint8Array( a ) );
+		return this.textDecoder.decode( a );
 
 	}
 

--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -3819,7 +3819,7 @@ class BinaryReader {
 		const nullByte = a.indexOf( 0 );
 		if ( nullByte >= 0 ) a = new Uint8Array( this.dv.buffer, start, nullByte );
 
-		return this.textDecoder.decode( a );
+		return this._textDecoder.decode( a );
 
 	}
 


### PR DESCRIPTION
**Description**

Remove workaround for missing TypedArray.prototype.indexOf() method in Safari 9.

Supported in all browsers post Safari 9.1
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/indexOf 