### PR TITLE
Fixed FontLoader Example Code

### DIFF
--- a/docs/examples/en/loaders/FontLoader.html
+++ b/docs/examples/en/loaders/FontLoader.html
@@ -22,6 +22,9 @@
 		<h2>Code Example</h2>
 
 		<code>
+		// FontLoader is not part of the core library anymore since r133
+		import { FontLoader } from 'three/examples/jsm/loaders/FontLoader.js';
+		
 		const loader = new FontLoader();
 		const font = loader.load(
 			// resource URL


### PR DESCRIPTION
Description

Changed FontLoader Example Code to include an import from 'three/examples/jsm/loaders/FontLoader.js' instead of new THREE.FontLoader().

Solution found from (https://stackoverflow.com/questions/71272396/three-fontloader-doesnt-work-in-three-js)

