### PR TITLE
VertexNormalsHelper now updates [line] buffer sizes for objects that change their contents

### DIFF
--- a/examples/jsm/helpers/VertexNormalsHelper.js
+++ b/examples/jsm/helpers/VertexNormalsHelper.js
@@ -37,6 +37,15 @@ class VertexNormalsHelper extends LineSegments {
 	}
 
 	update() {
+		
+		//	remake buffer if capacity changes
+		if ( this.object.geometry.attributes.normal.count != this.geometry.attributes.position.length*2*3 )
+		{
+			const object = this.object;
+			const nNormals = object.geometry.attributes.normal.count;
+			const positions = new Float32BufferAttribute( nNormals * 2 * 3, 3 );
+			this.geometry.setAttribute( 'position', positions );
+		}
 
 		this.object.updateMatrixWorld( true );
 


### PR DESCRIPTION
I have a [derived] `THREE.Mesh` class which changes the contents of it's `.geometry`, so the initial capacity for rendering normals wasn't enough for subsequent frames.

This re-allocates the attribute buffer to grow on ~demand~`update()`

There's a lot of magic numbers, but followed the existing code, rather than refactoring it to get rid of various assumptions of stride etc