### PR TITLE
LWOLoader: Remove workaround for Safari 9.

### DIFF
--- a/examples/jsm/loaders/lwo/IFFParser.js
+++ b/examples/jsm/loaders/lwo/IFFParser.js
@@ -1065,35 +1065,38 @@ DataViewReader.prototype = {
 
 		if ( size === 0 ) return;
 
-		// note: safari 9 doesn't support Uint8Array.indexOf; create intermediate array instead
-		var a = [];
+		const start = this.offset;
+
+		let result;
+		let length;
 
 		if ( size ) {
 
-			for ( var i = 0; i < size; i ++ ) {
-
-				a[ i ] = this.getUint8();
-
-			}
+			length = size;
+			result = this._textDecoder.decode( new Uint8Array( this.dv.buffer, start, size ) );
 
 		} else {
 
-			var currentChar;
-			var len = 0;
+			const bytes = new Uint8Array( this.dv.buffer, start );
+			length = bytes.indexOf( 0 );
 
-			while ( currentChar !== 0 ) {
+			result = this._textDecoder.decode( new Uint8Array( this.dv.buffer, start, length ) );
 
-				currentChar = this.getUint8();
-				if ( currentChar !== 0 ) a.push( currentChar );
-				len ++;
+			// account for null byte in length
+			length++;
+
+			if ( length % 2 !== 0 ) {
+
+				// if string with terminating nullbyte is uneven, extra nullbyte is added
+				length++;
 
 			}
 
-			if ( ! isEven( len + 1 ) ) this.getUint8(); // if string with terminating nullbyte is uneven, extra nullbyte is added
-
 		}
 
-		return this._textDecoder.decode( new Uint8Array( a ) );
+		this.skip( length );
+
+		return result;
 
 	},
 

--- a/examples/jsm/loaders/lwo/IFFParser.js
+++ b/examples/jsm/loaders/lwo/IFFParser.js
@@ -908,6 +908,7 @@ function DataViewReader( buffer ) {
 	this.dv = new DataView( buffer );
 	this.offset = 0;
 	this._textDecoder = new TextDecoder();
+	this._bytes = new Uint8Array( buffer );
 
 }
 
@@ -1077,15 +1078,15 @@ DataViewReader.prototype = {
 
 		} else {
 
-			const bytes = new Uint8Array( this.dv.buffer, start );
-			length = bytes.indexOf( 0 );
+			// use 1:1 mapping of buffer to avoid redundant new array creation.
+			length = this._bytes.indexOf( 0, start ) - start;
 
 			result = this._textDecoder.decode( new Uint8Array( this.dv.buffer, start, length ) );
 
 			// account for null byte in length
 			length++;
 
-			// if string with terminating nullbyte is uneven, extra nullbyte is added
+			// if string with terminating nullbyte is uneven, extra nullbyte is added, skip that too
 			length += length % 2;
 
 		}

--- a/examples/jsm/loaders/lwo/IFFParser.js
+++ b/examples/jsm/loaders/lwo/IFFParser.js
@@ -1085,12 +1085,8 @@ DataViewReader.prototype = {
 			// account for null byte in length
 			length++;
 
-			if ( length % 2 !== 0 ) {
-
-				// if string with terminating nullbyte is uneven, extra nullbyte is added
-				length++;
-
-			}
+			// if string with terminating nullbyte is uneven, extra nullbyte is added
+			length += length % 2;
 
 		}
 


### PR DESCRIPTION
**Description**

Remove workaround for missing TypedArray.prototype.indexOf() method in Safari 9.

Supported in all browsers post Safari 9.1
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/indexOf

Note: the help function isEven() previously used here results in 0 if even and 1 if odd which is counterintuitive. 