### PR TITLE
Fix WebGPUTextures

### DIFF
--- a/examples/jsm/renderers/webgpu/WebGPUTextures.js
+++ b/examples/jsm/renderers/webgpu/WebGPUTextures.js
@@ -399,7 +399,7 @@ class WebGPUTextures {
 		const data = image.data;
 
 		const bytesPerTexel = this._getBytesPerTexel( format );
-		const bytesPerRow = Math.ceil( image.width * bytesPerTexel / 256 ) * 256;
+		const bytesPerRow = image.width * bytesPerTexel;
 
 		this.device.queue.writeTexture(
 			{


### PR DESCRIPTION
Related issue: -

**Description**

Without this fix small DataTextures render white in WebGPU. Example: https://jsfiddle.net/3jb9eka0/ (compare to WebGL version: https://jsfiddle.net/3jb9eka0/1/) -- the texture should render green but renders white. With this PR it renders red (see https://jsfiddle.net/3jb9eka0/2/) due to another bug -- I will file an issue for it after this PR will be merged.

They produce the following error:
```
Required size for texture data layout (264) exceeds the linear data size (16) with offset (0).
    at ValidateLinearTextureData (..\..\third_party\dawn\src\dawn\native\CommandValidation.cpp:257)
    at ValidateWriteTexture (..\..\third_party\dawn\src\dawn\native\Queue.cpp:517)
    at WriteTextureInternal (..\..\third_party\dawn\src\dawn\native\Queue.cpp:323)
```

I think it occurs due to miscalculation of `bytesPerRow` (and therefore required buffer size, see https://gpuweb.github.io/gpuweb/#abstract-opdef-validating-linear-texture-data). Not sure why this formula was used instead of more simpler and (I think) more correct one? (It was introduced in https://github.com/mrdoob/three.js/commit/317bd1ca00d98a6df198871d93efcb98bb1e2788 with the support for DataTextures in WebGPU.)

/ping @sunag @Mugen87 