### PR TITLE
WebGPURenderer: make `.getArrayFromBuffer` return ArrayBuffer instead of Float32Array, rename to `.getArrayBuffer`

### DIFF
--- a/examples/jsm/renderers/webgpu/WebGPUAttributes.js
+++ b/examples/jsm/renderers/webgpu/WebGPUAttributes.js
@@ -110,7 +110,7 @@ class WebGPUAttributes {
 
 		const arrayBuffer = gpuReadBuffer.getMappedRange();
 
-		return new Float32Array( arrayBuffer );
+		return arrayBuffer;
 
 	}
 

--- a/examples/jsm/renderers/webgpu/WebGPURenderer.js
+++ b/examples/jsm/renderers/webgpu/WebGPURenderer.js
@@ -387,7 +387,7 @@ class WebGPURenderer {
 
 	}
 
-	async getArrayFromBuffer( attribute ) {
+	async getArrayBuffer( attribute ) {
 
 		return await this._attributes.getArrayBuffer( attribute );
 

--- a/examples/webgpu_audio_processing.html
+++ b/examples/webgpu_audio_processing.html
@@ -61,7 +61,7 @@
 
 				renderer.compute( computeNode );
 
-				const waveArray = await renderer.getArrayFromBuffer( waveGPUBuffer );
+				const waveArray = new Float32Array( await renderer.getArrayBuffer( waveGPUBuffer ) );
 
 				// play result
 


### PR DESCRIPTION
Related issue: -

**Description**

Make `WebGPURenderer.getArrayFromBuffer` return ArrayBuffer instead of Float32Array and also rename it to `.getArrayBuffer` for consistency with WebGPUAttributes.