### PR TITLE
WebGPURenderer: Remove `return` on lines 258 and 626

### DIFF
--- a/examples/jsm/renderers/webgpu/WebGPURenderer.js
+++ b/examples/jsm/renderers/webgpu/WebGPURenderer.js
@@ -623,7 +623,7 @@ class WebGPURenderer {
 
 	async compute( ...computeNodes ) {
 
-		if ( this._initialized === false ) return await this.init();
+		if ( this._initialized === false ) await this.init();
 
 		const device = this._device;
 		const computePipelines = this._computePipelines;

--- a/examples/jsm/renderers/webgpu/WebGPURenderer.js
+++ b/examples/jsm/renderers/webgpu/WebGPURenderer.js
@@ -255,7 +255,7 @@ class WebGPURenderer {
 
 	async render( scene, camera ) {
 
-		if ( this._initialized === false ) return await this.init();
+		if ( this._initialized === false ) await this.init();
 
 		//
 


### PR DESCRIPTION
Related issue: -

**Description**

It is sometimes useful to initialize the renderer on the first render. This change makes WebGPURenderer initialize itself on a render if it was not initialized; as an alternative the error could be removed from line 181 and `await renderer.init(); await renderer.render()` be used in animation loop (this can be more clear because in such case it is clearer that `renderer.init()` can take some time).