### PR TITLE
PLYLoader: Bug fix.

### DIFF
--- a/examples/jsm/loaders/PLYLoader.js
+++ b/examples/jsm/loaders/PLYLoader.js
@@ -307,7 +307,7 @@ class PLYLoader extends Loader {
 
 					const name = names[ i ];
 
-					if ( name in elementNames ) return name;
+					if ( elementNames.includes( name ) ) return name;
 
 				}
 


### PR DESCRIPTION
Related issue: #25210 

**Description**

Bug caused by using original code that expected an array indexed by name, rather than an array of names. normal and color attributes now working. Oops.