### PR TITLE
WebGLRenderer: Fix shadow map shader regression.

### DIFF
--- a/src/renderers/shaders/ShaderChunk/shadowmap_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/shadowmap_vertex.glsl.js
@@ -1,6 +1,6 @@
 export default /* glsl */`
 
-#if ( defined( USE_SHADOWMAP ) && ( ( NUM_DIR_LIGHT_SHADOWS > 0 ) || ( NUM_POINT_LIGHT_SHADOWS > 0 ) ) ) || ( NUM_SPOT_LIGHT_COORDS > 0 )
+#if ( defined( USE_SHADOWMAP ) && ( NUM_DIR_LIGHT_SHADOWS > 0 || NUM_POINT_LIGHT_SHADOWS > 0 ) ) || ( NUM_SPOT_LIGHT_COORDS > 0 )
 
 	// Offsetting the position used for querying occlusion along the world normal can be used to reduce shadow acne.
 	vec3 shadowWorldNormal = inverseTransformDirection( transformedNormal, viewMatrix );
@@ -8,18 +8,45 @@ export default /* glsl */`
 
 #endif
 
-#if defined( USE_SHADOWMAP ) && ( NUM_DIR_LIGHT_SHADOWS > 0 )
+#if defined( USE_SHADOWMAP )
 
-	#pragma unroll_loop_start
-	for ( int i = 0; i < NUM_DIR_LIGHT_SHADOWS; i ++ ) {
+	#if NUM_DIR_LIGHT_SHADOWS > 0
 
-		shadowWorldPosition = worldPosition + vec4( shadowWorldNormal * directionalLightShadows[ i ].shadowNormalBias, 0 );
-		vDirectionalShadowCoord[ i ] = directionalShadowMatrix[ i ] * shadowWorldPosition;
+		#pragma unroll_loop_start
+		for ( int i = 0; i < NUM_DIR_LIGHT_SHADOWS; i ++ ) {
 
-	}
-	#pragma unroll_loop_end
+			shadowWorldPosition = worldPosition + vec4( shadowWorldNormal * directionalLightShadows[ i ].shadowNormalBias, 0 );
+			vDirectionalShadowCoord[ i ] = directionalShadowMatrix[ i ] * shadowWorldPosition;
+
+		}
+		#pragma unroll_loop_end
+
+	#endif
+
+	#if NUM_POINT_LIGHT_SHADOWS > 0
+
+		#pragma unroll_loop_start
+		for ( int i = 0; i < NUM_POINT_LIGHT_SHADOWS; i ++ ) {
+
+			shadowWorldPosition = worldPosition + vec4( shadowWorldNormal * pointLightShadows[ i ].shadowNormalBias, 0 );
+			vPointShadowCoord[ i ] = pointShadowMatrix[ i ] * shadowWorldPosition;
+
+		}
+		#pragma unroll_loop_end
+
+	#endif
+
+	/*
+	#if NUM_RECT_AREA_LIGHTS > 0
+
+		// TODO (abelnation): update vAreaShadowCoord with area light info
+
+	#endif
+	*/
 
 #endif
+
+// spot lights can be evaluated without active shadow mapping (when SpotLight.map is used)
 
 #if NUM_SPOT_LIGHT_COORDS > 0
 
@@ -37,24 +64,5 @@ export default /* glsl */`
 
 #endif
 
-#if defined( USE_SHADOWMAP ) && ( NUM_POINT_LIGHT_SHADOWS > 0 )
 
-	#pragma unroll_loop_start
-	for ( int i = 0; i < NUM_POINT_LIGHT_SHADOWS; i ++ ) {
-
-		shadowWorldPosition = worldPosition + vec4( shadowWorldNormal * pointLightShadows[ i ].shadowNormalBias, 0 );
-		vPointShadowCoord[ i ] = pointShadowMatrix[ i ] * shadowWorldPosition;
-
-	}
-	#pragma unroll_loop_end
-
-#endif
-
-/*
-#if defined( USE_SHADOWMAP ) && ( NUM_RECT_AREA_LIGHTS > 0 )
-
-	// TODO (abelnation): update vAreaShadowCoord with area light info
-
-#endif
-*/
 `;

--- a/src/renderers/shaders/ShaderChunk/shadowmap_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/shadowmap_vertex.glsl.js
@@ -1,15 +1,14 @@
 export default /* glsl */`
-#if defined( USE_SHADOWMAP ) || ( NUM_SPOT_LIGHT_COORDS > 0 )
 
-	#if NUM_DIR_LIGHT_SHADOWS > 0 || NUM_SPOT_LIGHT_COORDS > 0 || NUM_POINT_LIGHT_SHADOWS > 0
+#if ( defined( USE_SHADOWMAP ) && ( ( NUM_DIR_LIGHT_SHADOWS > 0 ) || ( NUM_POINT_LIGHT_SHADOWS > 0 ) ) ) || ( NUM_SPOT_LIGHT_COORDS > 0 )
 
-		// Offsetting the position used for querying occlusion along the world normal can be used to reduce shadow acne.
-		vec3 shadowWorldNormal = inverseTransformDirection( transformedNormal, viewMatrix );
-		vec4 shadowWorldPosition;
+	// Offsetting the position used for querying occlusion along the world normal can be used to reduce shadow acne.
+	vec3 shadowWorldNormal = inverseTransformDirection( transformedNormal, viewMatrix );
+	vec4 shadowWorldPosition;
 
-	#endif
+#endif
 
-	#if NUM_DIR_LIGHT_SHADOWS > 0
+#if defined( USE_SHADOWMAP ) && ( NUM_DIR_LIGHT_SHADOWS > 0 )
 
 	#pragma unroll_loop_start
 	for ( int i = 0; i < NUM_DIR_LIGHT_SHADOWS; i ++ ) {
@@ -20,9 +19,9 @@ export default /* glsl */`
 	}
 	#pragma unroll_loop_end
 
-	#endif
+#endif
 
-	#if NUM_SPOT_LIGHT_COORDS > 0
+#if NUM_SPOT_LIGHT_COORDS > 0
 
 	#pragma unroll_loop_start
 	for ( int i = 0; i < NUM_SPOT_LIGHT_COORDS; i ++ ) {
@@ -36,9 +35,9 @@ export default /* glsl */`
 	}
 	#pragma unroll_loop_end
 
-	#endif
+#endif
 
-	#if NUM_POINT_LIGHT_SHADOWS > 0
+#if defined( USE_SHADOWMAP ) && ( NUM_POINT_LIGHT_SHADOWS > 0 )
 
 	#pragma unroll_loop_start
 	for ( int i = 0; i < NUM_POINT_LIGHT_SHADOWS; i ++ ) {
@@ -49,15 +48,13 @@ export default /* glsl */`
 	}
 	#pragma unroll_loop_end
 
-	#endif
+#endif
 
-	/*
-	#if NUM_RECT_AREA_LIGHTS > 0
+/*
+#if defined( USE_SHADOWMAP ) && ( NUM_RECT_AREA_LIGHTS > 0 )
 
-		// TODO (abelnation): update vAreaShadowCoord with area light info
-
-	#endif
-	*/
+	// TODO (abelnation): update vAreaShadowCoord with area light info
 
 #endif
+*/
 `;


### PR DESCRIPTION
Fixed #25247.

**Description**

The if statements in `shadowmap_vertex` need a different organization to avoid the compilation error mentioned in #25247.
