### PR TITLE
WebGLClipping: Project global clipping planes per camera

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -982,7 +982,7 @@ function WebGLRenderer( parameters = {} ) {
 		_frustum.setFromProjectionMatrix( _projScreenMatrix );
 
 		_localClippingEnabled = this.localClippingEnabled;
-		_clippingEnabled = clipping.init( this.clippingPlanes, _localClippingEnabled, camera );
+		_clippingEnabled = clipping.init( this.clippingPlanes, _localClippingEnabled );
 
 		currentRenderList = renderLists.get( scene, renderListStack.length );
 		currentRenderList.init();
@@ -1210,6 +1210,8 @@ function WebGLRenderer( parameters = {} ) {
 		const transparentObjects = currentRenderList.transparent;
 
 		currentRenderState.setupLightsView( camera );
+
+		if ( _clippingEnabled === true ) clipping.setGlobalState( _this.clippingPlanes, camera );
 
 		if ( transmissiveObjects.length > 0 ) renderTransmissionPass( opaqueObjects, scene, camera );
 

--- a/src/renderers/webgl/WebGLClipping.js
+++ b/src/renderers/webgl/WebGLClipping.js
@@ -19,7 +19,7 @@ function WebGLClipping( properties ) {
 	this.numPlanes = 0;
 	this.numIntersection = 0;
 
-	this.init = function ( planes, enableLocalClipping, camera ) {
+	this.init = function ( planes, enableLocalClipping ) {
 
 		const enabled =
 			planes.length !== 0 ||
@@ -31,7 +31,6 @@ function WebGLClipping( properties ) {
 
 		localClippingEnabled = enableLocalClipping;
 
-		globalState = projectPlanes( planes, camera, 0 );
 		numGlobalPlanes = planes.length;
 
 		return enabled;
@@ -48,7 +47,12 @@ function WebGLClipping( properties ) {
 	this.endShadows = function () {
 
 		renderingShadows = false;
-		resetGlobalState();
+
+	};
+
+	this.setGlobalState = function ( planes, camera ) {
+
+		globalState = projectPlanes( planes, camera, 0 );
 
 	};
 


### PR DESCRIPTION
Fixed #25267 

**Description**

The global clipping planes were projected during the `clipping.init` invocation using the (main) camera. This would result in incorrect clipping planes when using an `ArrayCamera`. This PR moves the projecting out of the `init` method and into a dedicated `setGlobalState` method (analogous to `setState`). This is then called in `renderScene` ensuring it's called exactly once per (sub) camera. Note that for shadow map rendering the global clipping planes aren't used, so it's no problem for them to not be computed at that point.

*This contribution is funded by [Fern Solutions](https://fern.solutions)*
