### PR TITLE
Editor: Remove glTF1 alert.

### DIFF
--- a/editor/js/Loader.js
+++ b/editor/js/Loader.js
@@ -298,24 +298,14 @@ function Loader( editor ) {
 
 					const contents = event.target.result;
 
-					let loader, dracoLoader;
+					const { DRACOLoader } = await import( 'three/addons/loaders/DRACOLoader.js' );
+					const { GLTFLoader } = await import( 'three/addons/loaders/GLTFLoader.js' );
 
-					if ( isGLTF1( contents ) ) {
+					const dracoLoader = new DRACOLoader();
+					dracoLoader.setDecoderPath( '../examples/jsm/libs/draco/gltf/' );
 
-						alert( 'Import of glTF asset not possible. Only versions >= 2.0 are supported. Please try to upgrade the file to glTF 2.0 using glTF-Pipeline.' );
-
-					} else {
-
-						const { DRACOLoader } = await import( 'three/addons/loaders/DRACOLoader.js' );
-						const { GLTFLoader } = await import( 'three/addons/loaders/GLTFLoader.js' );
-
-						dracoLoader = new DRACOLoader();
-						dracoLoader.setDecoderPath( '../examples/jsm/libs/draco/gltf/' );
-
-						loader = new GLTFLoader( manager );
-						loader.setDRACOLoader( dracoLoader );
-
-					}
+					const loader = new GLTFLoader( manager );
+					loader.setDRACOLoader( dracoLoader );
 
 					loader.parse( contents, '', function ( result ) {
 
@@ -1010,41 +1000,6 @@ function Loader( editor ) {
 			}
 
 		}
-
-	}
-
-	function isGLTF1( contents ) {
-
-		let resultContent;
-
-		if ( typeof contents === 'string' ) {
-
-			// contents is a JSON string
-			resultContent = contents;
-
-		} else {
-
-			const magic = THREE.LoaderUtils.decodeText( new Uint8Array( contents, 0, 4 ) );
-
-			if ( magic === 'glTF' ) {
-
-				// contents is a .glb file; extract the version
-				const version = new DataView( contents ).getUint32( 4, true );
-
-				return version < 2;
-
-			} else {
-
-				// contents is a .gltf file
-				resultContent = THREE.LoaderUtils.decodeText( new Uint8Array( contents ) );
-
-			}
-
-		}
-
-		const json = JSON.parse( resultContent );
-
-		return ( json.asset != undefined && json.asset.version[ 0 ] < 2 );
 
 	}
 


### PR DESCRIPTION
Related issue: -

**Description**

This PR removes the legacy glTF version check from the editor which should be appropriate at this point. `GLTFLoader` still checks the version number so an informative error is visible in the browser console when legacy assets are imported.
