### PR TITLE
Docs: Improve `Material` page.

### DIFF
--- a/docs/api/en/materials/Material.html
+++ b/docs/api/en/materials/Material.html
@@ -298,6 +298,7 @@
 		<h3>[property:Boolean vertexColors]</h3>
 		<p>
 		Defines whether vertex coloring is used. Default is `false`.
+		The engine supports RGB and RGBA vertex colors depending on whether a three (RGB) or four (RGBA) component color buffer attribute is used.
 		</p>
 
 		<h3>[property:Boolean visible]</h3>

--- a/docs/api/it/materials/Material.html
+++ b/docs/api/it/materials/Material.html
@@ -315,6 +315,7 @@
 		<h3>[property:Boolean vertexColors]</h3>
 		<p>
 			Definisce se viene utilizzata la colorazione dei vertici. Il valore predefinito è `false`.
+			The engine supports RGB and RGBA vertex colors depending on whether a three (RGB) or four (RGBA) component color buffer attribute is used.
 		</p>
 
 		<h3>[property:Boolean visible]</h3>

--- a/docs/api/zh/materials/Material.html
+++ b/docs/api/zh/materials/Material.html
@@ -258,6 +258,7 @@
 <h3>[property:Boolean vertexColors]</h3>
 <p>
 是否使用顶点着色。默认值为false。
+The engine supports RGB and RGBA vertex colors depending on whether a three (RGB) or four (RGBA) component color buffer attribute is used.
 </p>
 
 <h3>[property:Boolean visible]</h3>


### PR DESCRIPTION
Related issue: https://discourse.threejs.org/t/add-opacity-to-vertice-colors-and-instanced-geometry/26298/11

**Description**

It was suggested in the forum to improve the documentation of vertex colors so it becomes more clear that vertex colors with alphas are supported.
