### PR TITLE
Remove `WebGL2ComputeRenderingContext`

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     },
     "globals": {
       "__THREE_DEVTOOLS__": "readonly",
-      "WebGL2ComputeRenderingContext": "readonly",
       "potpack": "readonly",
       "fflate": "readonly",
       "OIMO": "readonly",

--- a/src/renderers/webgl/WebGLCapabilities.js
+++ b/src/renderers/webgl/WebGLCapabilities.js
@@ -52,8 +52,7 @@ function WebGLCapabilities( gl, extensions, parameters ) {
 
 	}
 
-	const isWebGL2 = ( typeof WebGL2RenderingContext !== 'undefined' && gl instanceof WebGL2RenderingContext ) ||
-		( typeof WebGL2ComputeRenderingContext !== 'undefined' && gl instanceof WebGL2ComputeRenderingContext );
+	const isWebGL2 = typeof WebGL2RenderingContext !== 'undefined' && gl instanceof WebGL2RenderingContext;
 
 	let precision = parameters.precision !== undefined ? parameters.precision : 'highp';
 	const maxPrecision = getMaxPrecision( precision );


### PR DESCRIPTION
Related issue: -

**Description**

`WebGL2ComputeRenderingContext`'s [specification](https://registry.khronos.org/webgl/specs/latest/2.0-compute/) never went out of draft stage, it is not currently available in any major browser (for some time was enabled behind a flag in Google Chrome and Microsoft Edge), and its development is long-halted (in favor of WebGPU).