### PR TITLE
PMREMGenerator: Fix replacing render targets with different heights

### DIFF
--- a/src/extras/PMREMGenerator.js
+++ b/src/extras/PMREMGenerator.js
@@ -261,7 +261,7 @@ class PMREMGenerator {
 
 		const cubeUVRenderTarget = _createRenderTarget( width, height, params );
 
-		if ( this._pingPongRenderTarget === null || this._pingPongRenderTarget.width !== width ) {
+		if ( this._pingPongRenderTarget === null || this._pingPongRenderTarget.width !== width || this._pingPongRenderTarget.height !== height ) {
 
 			if ( this._pingPongRenderTarget !== null ) {
 


### PR DESCRIPTION
Related PR: https://github.com/mrdoob/three.js/pull/23322

**Description**

When calling `fromEquirectangular` (or `_fromTexture` in general) without a render target (default `null`) for a second time with a texture with a different height than the texture for the first call, but the same width, the `_pingPongRenderTarget` is not replaced. After which the lighting from setting the `Scene.environment` to the render target texture fails, in two different ways, depending on the order (larger or smaller height first/second).

