### PR TITLE
E2E: Display percentage of pixels failed

### DIFF
--- a/test/e2e/puppeteer.js
+++ b/test/e2e/puppeteer.js
@@ -310,17 +310,17 @@ const pup = puppeteer.launch( {
 				numFailedPixels /= actual.width * actual.height;
 
 				/* Print results */
-
+				const percFailedPixels = 100 * numFailedPixels;
 				if ( numFailedPixels < maxFailedPixels ) {
 
 					attemptId = maxAttemptId;
-					console.green( `diff: ${ numFailedPixels.toFixed( 3 ) }, file: ${ file }` );
+					console.green( `diff: ${ percFailedPixels.toFixed( 1 ) }%, file: ${ file }` );
 
 				} else {
 
 					if ( ++ attemptId === maxAttemptId ) {
 
-						console.red( `ERROR! Diff wrong in ${ numFailedPixels.toFixed( 3 ) } of pixels in file: ${ file }` );
+						console.red( `ERROR! Diff wrong in ${ percFailedPixels.toFixed( 1 ) }% of pixels in file: ${ file }` );
 						failedScreenshots.push( file );
 						continue;
 


### PR DESCRIPTION
Related issue: #25304

**Description**

In #25304 one of the screenshot failures displayed the following:

> `Diff wrong in 0.406 of pixels in file`

It was unclear whether this mean 0.406% of pixels failed or 40.6% of pixels failed. I've changed the logs to be more specific about the ratio.