### PR TITLE
Add a faster particle system library to three.js plugin docs

### DIFF
--- a/docs/manual/en/introduction/Libraries-and-Plugins.html
+++ b/docs/manual/en/introduction/Libraries-and-Plugins.html
@@ -71,6 +71,7 @@
 		<h3>Particle Systems</h3>
 
 		<ul>
+			<li>[link:https://github.com/Alchemist0823/three.quarks three.quarks]</li>
 			<li>[link:https://github.com/creativelifeform/three-nebula three-nebula]</li>
 		</ul>
 		

--- a/docs/manual/ja/introduction/Libraries-and-Plugins.html
+++ b/docs/manual/ja/introduction/Libraries-and-Plugins.html
@@ -71,6 +71,7 @@
     <h3>Particle Systems</h3>
 
     <ul>
+        <li>[link:https://github.com/Alchemist0823/three.quarks three.quarks]</li>
         <li>[link:https://github.com/creativelifeform/three-nebula three-nebula]</li>
     </ul>
 


### PR DESCRIPTION
**Description**

This diff adds a particle system library to three.js plugin docs

Based on a bunch of benchmark that needle.tools and our customer does on three.quarks and three-nebula. because three.quarks batch instance of particle system in a single draw it perform much better in complicate user cases. it also has a web particle system and VFX comes with it.

