### PR TITLE
Actions: Clean up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,14 +16,13 @@ permissions:
   contents: read
 
 jobs:
-
   lint:
-    name: "Linting"
+    name: "Lint testing"
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
         uses: actions/checkout@v2
-      - name: Install node
+      - name: Install Node
         uses: actions/setup-node@v2
         with:
           node-version: 16
@@ -31,7 +30,7 @@ jobs:
       - name: Install packages
         run: npm ci
 
-      - name: === Linting ===
+      - name: === Lint testing ===
         run: npm run lint
 
   unit:
@@ -40,7 +39,7 @@ jobs:
     steps:
       - name: Git checkout
         uses: actions/checkout@v2
-      - name: Install node
+      - name: Install Node
         uses: actions/setup-node@v2
         with:
           node-version: 16
@@ -59,6 +58,7 @@ jobs:
     name: "E2E testing"
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         CI: [ 0, 1, 2, 3, 4, 5, 6, 7 ]
     env:
@@ -67,7 +67,7 @@ jobs:
     steps:
       - name: Git checkout
         uses: actions/checkout@v2
-      - name: Install node
+      - name: Install Node
         uses: actions/setup-node@v2
         with:
           node-version: 16
@@ -76,20 +76,19 @@ jobs:
         run: |
           npm ci
           npm ci --prefix test
-          sudo apt-get install xvfb
       - name: Build
         run: npm run build
 
       - name: === E2E testing ===
-        run: xvfb-run --auto-servernum npm run test-e2e
+        run: npm run test-e2e
 
   e2e-cov:
-    name: "Ready for release"
+    name: "Examples ready for release"
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
         uses: actions/checkout@v2
-      - name: Install node
+      - name: Install Node
         uses: actions/setup-node@v2
         with:
           node-version: 16
@@ -97,5 +96,5 @@ jobs:
       - name: Install packages
         run: npm ci
 
-      - name: === Ready for release ===
+      - name: === Examples ready for release ===
         run: npm run test-e2e-cov


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/24109#issuecomment-1398621694

**Description**

Slightly clean up the actions. Also add `fail-fast: false` to the E2E test (it stops subtests from cancelling if one of them has failed) and remove `xvfb` (I think it was needed when the test ran on Travis, but it is not needed for GitHub Actions -- and without it the test seems to be slightly faster).