### PR TITLE
Add three.quarks particle system to plugin docs

### DIFF
--- a/docs/manual/en/introduction/Libraries-and-Plugins.html
+++ b/docs/manual/en/introduction/Libraries-and-Plugins.html
@@ -77,6 +77,7 @@
 		<h3>Particle Systems</h3>
 
 		<ul>
+			<li>[link:https://github.com/Alchemist0823/three.quarks three.quarks]</li>
 			<li>[link:https://github.com/creativelifeform/three-nebula three-nebula]</li>
 		</ul>
 

--- a/docs/manual/ja/introduction/Libraries-and-Plugins.html
+++ b/docs/manual/ja/introduction/Libraries-and-Plugins.html
@@ -71,6 +71,7 @@
     <h3>Particle Systems</h3>
 
     <ul>
+        <li>[link:https://github.com/Alchemist0823/three.quarks three.quarks]</li>
         <li>[link:https://github.com/creativelifeform/three-nebula three-nebula]</li>
     </ul>
 

--- a/docs/manual/zh/introduction/Useful-links.html
+++ b/docs/manual/zh/introduction/Useful-links.html
@@ -115,6 +115,9 @@
 			[link:http://idflood.github.io/ThreeNodes.js/ ThreeNodes.js].
 		</li>
 		<li>
+			[link:https://github.com/Alchemist0823/three.quarks three.quarks] - 针对 three.js 高速粒子特效系统
+		</li>
+		<li>
 			[link:https://marketplace.visualstudio.com/items?itemName=slevesque.shader vscode shader] - Syntax highlighter for shader language.
 			<br />
 			[link:https://marketplace.visualstudio.com/items?itemName=bierner.comment-tagged-templates vscode comment-tagged-templates] - Syntax highlighting for tagged template strings using comments to shader language, like: glsl.js.


### PR DESCRIPTION
**Description**

This diff adds a particle system library - three.quarks to three.js plugin docs

Based on a bunch of benchmark that needle.tools and our customer does on three.quarks and three-nebula. because three.quarks batch instances of particle system in a single draw when texture and settings matches. it performs much better in complicate user cases. it also has a web particle system and VFX Editor comes with it.