### PR TITLE
docs: Describe `DEFAULT_MATRIX_WORLD_AUTO_UPDATE` in Object3D.html

### DIFF
--- a/docs/api/en/core/Object3D.html
+++ b/docs/api/en/core/Object3D.html
@@ -86,8 +86,9 @@
 
 		<h3>[property:Boolean matrixWorldAutoUpdate]</h3>
 		<p>
-		Default is true. If set, then the renderer checks every frame if the object and its children need matrix updates.
+		If set, then the renderer checks every frame if the object and its children need matrix updates.
 		When it isn't, then you have to maintain all matrices in the object and its children yourself.
+		Default is [page:Object3D.DEFAULT_MATRIX_WORLD_AUTO_UPDATE] (true).
 		</p>
 
 		<h3>[property:Boolean matrixWorldNeedsUpdate]</h3>
@@ -212,6 +213,10 @@
 
 		</p>
 
+		<h3>[property:Boolean DEFAULT_MATRIX_WORLD_AUTO_UPDATE]</h3>
+		<p>
+			The default setting for [page:.matrixWorldAutoUpdate matrixWorldAutoUpdate] for newly created Object3Ds.<br />
+		</p>
 
 		<h2>Methods</h2>
 


### PR DESCRIPTION
Related: https://github.com/mrdoob/three.js/pull/25188

**Description**

- Default value of `matrixWorldAutoUpdate` is `DEFAULT_MATRIX_WORLD_AUTO_UPDATE` instead of `true`
- `DEFAULT_MATRIX_WORLD_AUTO_UPDATE` is not documented while `DEFAULT_MATRIX_AUTO_UPDATE` is
