### PR TITLE
PropertyBinding: Remove fallback to root node on incorrect path names.

### DIFF
--- a/src/animation/PropertyBinding.js
+++ b/src/animation/PropertyBinding.js
@@ -107,7 +107,7 @@ class PropertyBinding {
 		this.path = path;
 		this.parsedPath = parsedPath || PropertyBinding.parseTrackName( path );
 
-		this.node = PropertyBinding.findNode( rootNode, this.parsedPath.nodeName ) || rootNode;
+		this.node = PropertyBinding.findNode( rootNode, this.parsedPath.nodeName );
 
 		this.rootNode = rootNode;
 
@@ -423,7 +423,7 @@ class PropertyBinding {
 
 		if ( ! targetObject ) {
 
-			targetObject = PropertyBinding.findNode( this.rootNode, parsedPath.nodeName ) || this.rootNode;
+			targetObject = PropertyBinding.findNode( this.rootNode, parsedPath.nodeName );
 
 			this.node = targetObject;
 


### PR DESCRIPTION
Related issue: 
- Fixes #25286

**Description**

Currently, incorrect path names in property bindings can lead to confusing results, as ALL properties that can't be matched are instead applied to the root of the animation. This PR removes the fallbacks for that; instead, an error will be logged (as before) for those specific tracks but remaining tracks will work fine.

*This contribution is funded by [Needle](https://needle.tools)*
