### PR TITLE
GLTFExporter: Added ior and specular support

### DIFF
--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -54,13 +54,13 @@ class GLTFExporter {
 
 		} );
 
-	this.register( function ( writer ) {
+		this.register( function ( writer ) {
 
 			return new GLTFMaterialsIorExtension( writer );
 
 		} );
 
-	this.register( function ( writer ) {
+		this.register( function ( writer ) {
 
 			return new GLTFMaterialsSpecularExtension( writer );
 

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -1,6 +1,7 @@
 import {
 	BufferAttribute,
 	ClampToEdgeWrapping,
+  Color,
 	DoubleSide,
 	InterpolateDiscrete,
 	InterpolateLinear,
@@ -50,6 +51,18 @@ class GLTFExporter {
 		this.register( function ( writer ) {
 
 			return new GLTFMaterialsVolumeExtension( writer );
+
+		} );
+
+    this.register( function ( writer ) {
+
+			return new GLTFMaterialsIorExtension( writer );
+
+		} );
+
+    this.register( function ( writer ) {
+
+			return new GLTFMaterialsSpecularExtension( writer );
 
 		} );
 
@@ -179,6 +192,8 @@ const PATH_PROPERTIES = {
 	quaternion: 'rotation',
 	morphTargetInfluences: 'weights'
 };
+
+const DEFAULT_SPECULAR_COLOR = new Color(1, 1, 1);
 
 // GLB constants
 // https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md#glb-file-format-specification
@@ -2313,7 +2328,7 @@ class GLTFMaterialsClearcoatExtension {
 
 	writeMaterial( material, materialDef ) {
 
-		if ( ! material.isMeshPhysicalMaterial ) return;
+		if ( ! material.isMeshPhysicalMaterial || material.clearcoat === 0 ) return;
 
 		const writer = this.writer;
 		const extensionsUsed = writer.extensionsUsed;
@@ -2374,7 +2389,7 @@ class GLTFMaterialsIridescenceExtension {
 
 	writeMaterial( material, materialDef ) {
 
-		if ( ! material.isMeshPhysicalMaterial ) return;
+		if ( ! material.isMeshPhysicalMaterial || material.iridescence === 0 ) return;
 
 		const writer = this.writer;
 		const extensionsUsed = writer.extensionsUsed;
@@ -2489,6 +2504,93 @@ class GLTFMaterialsVolumeExtension {
 
 		extensionDef.attenuationDistance = material.attenuationDistance;
 		extensionDef.attenuationColor = material.attenuationColor.toArray();
+
+		materialDef.extensions = materialDef.extensions || {};
+		materialDef.extensions[ this.name ] = extensionDef;
+
+		extensionsUsed[ this.name ] = true;
+
+	}
+
+}
+
+/**
+ * Materials ior Extension
+ *
+ * Specification: https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_materials_ior
+ */
+class GLTFMaterialsIorExtension {
+
+	constructor( writer ) {
+
+		this.writer = writer;
+		this.name = 'KHR_materials_ior';
+
+	}
+
+	writeMaterial( material, materialDef ) {
+
+		if ( ! material.isMeshPhysicalMaterial || material.ior === 1.5 ) return;
+
+		const writer = this.writer;
+		const extensionsUsed = writer.extensionsUsed;
+
+		const extensionDef = {};
+
+		extensionDef.ior = material.ior;
+
+		materialDef.extensions = materialDef.extensions || {};
+		materialDef.extensions[ this.name ] = extensionDef;
+
+		extensionsUsed[ this.name ] = true;
+
+	}
+
+}
+
+/**
+ * Materials specular Extension
+ *
+ * Specification: https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_materials_specular
+ */
+class GLTFMaterialsSpecularExtension {
+
+	constructor( writer ) {
+
+		this.writer = writer;
+		this.name = 'KHR_materials_specular';
+
+	}
+
+	writeMaterial( material, materialDef ) {
+
+		if ( ! material.isMeshPhysicalMaterial || ( material.specularIntensity === 1.0 && 
+      material.specularColor.equals(DEFAULT_SPECULAR_COLOR) && 
+      !material.specularIntensityMap && !material.specularColorTexture ) ) return;
+
+		const writer = this.writer;
+		const extensionsUsed = writer.extensionsUsed;
+
+		const extensionDef = {};
+
+		if ( material.specularIntensityMap ) {
+
+			const specularIntensityMapDef = { index: writer.processTexture( material.specularIntensityMap ) };
+			writer.applyTextureTransform( specularIntensityMapDef, material.specularIntensityMap );
+			extensionDef.specularTexture = specularIntensityMapDef;
+
+		}
+
+    if ( material.specularColorMap ) {
+
+			const specularColorMapDef = { index: writer.processTexture( material.specularColorMap ) };
+			writer.applyTextureTransform( specularColorMapDef, material.specularColorMap );
+			extensionDef.specularColorTexture = specularColorMapDef;
+
+		}
+
+		extensionDef.specularFactor = material.specularIntensity;
+		extensionDef.specularColorFactor = material.specularColor.toArray();
 
 		materialDef.extensions = materialDef.extensions || {};
 		materialDef.extensions[ this.name ] = extensionDef;

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -1,7 +1,7 @@
 import {
 	BufferAttribute,
 	ClampToEdgeWrapping,
-  Color,
+	Color,
 	DoubleSide,
 	InterpolateDiscrete,
 	InterpolateLinear,
@@ -54,13 +54,13 @@ class GLTFExporter {
 
 		} );
 
-    this.register( function ( writer ) {
+	this.register( function ( writer ) {
 
 			return new GLTFMaterialsIorExtension( writer );
 
 		} );
 
-    this.register( function ( writer ) {
+	this.register( function ( writer ) {
 
 			return new GLTFMaterialsSpecularExtension( writer );
 
@@ -2565,8 +2565,8 @@ class GLTFMaterialsSpecularExtension {
 	writeMaterial( material, materialDef ) {
 
 		if ( ! material.isMeshPhysicalMaterial || ( material.specularIntensity === 1.0 && 
-      material.specularColor.equals(DEFAULT_SPECULAR_COLOR) && 
-      !material.specularIntensityMap && !material.specularColorTexture ) ) return;
+		       material.specularColor.equals( DEFAULT_SPECULAR_COLOR ) && 
+		     ! material.specularIntensityMap && ! material.specularColorTexture ) ) return;
 
 		const writer = this.writer;
 		const extensionsUsed = writer.extensionsUsed;
@@ -2581,7 +2581,7 @@ class GLTFMaterialsSpecularExtension {
 
 		}
 
-    if ( material.specularColorMap ) {
+		if ( material.specularColorMap ) {
 
 			const specularColorMapDef = { index: writer.processTexture( material.specularColorMap ) };
 			writer.applyTextureTransform( specularColorMapDef, material.specularColorMap );

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -193,7 +193,7 @@ const PATH_PROPERTIES = {
 	morphTargetInfluences: 'weights'
 };
 
-const DEFAULT_SPECULAR_COLOR = new Color(1, 1, 1);
+const DEFAULT_SPECULAR_COLOR = new Color();
 
 // GLB constants
 // https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md#glb-file-format-specification


### PR DESCRIPTION
Fixes: #25334

**Description**

Added glTF specular and ior extension export, and fixed clearcoat and iridescence so they only add those extensions if needed.