### PR TITLE
Fix Audio stop()

### DIFF
--- a/src/audio/Audio.js
+++ b/src/audio/Audio.js
@@ -169,7 +169,7 @@ class Audio extends Object3D {
 
 		this._progress = 0;
 
-		if ( this.source ) {
+		if ( this.source !== null ) {
 
 			this.source.stop();
 			this.source.onended = null;

--- a/src/audio/Audio.js
+++ b/src/audio/Audio.js
@@ -169,8 +169,13 @@ class Audio extends Object3D {
 
 		this._progress = 0;
 
-		this.source.stop();
-		this.source.onended = null;
+		if ( this.source ) {
+
+			this.source.stop();
+			this.source.onended = null;
+
+		}
+
 		this.isPlaying = false;
 
 		return this;


### PR DESCRIPTION
**Related issue:**
- Fix #25337 

**Description**

Fix a bug appears when calling stop() without a source. If the source is null, an Exception is thrown.
``Uncaught TypeError: Cannot read properties of null (reading 'stop')``