### PR TITLE
Docs: Improve Audio page.

### DIFF
--- a/docs/api/ar/audio/Audio.html
+++ b/docs/api/ar/audio/Audio.html
@@ -89,7 +89,7 @@
 		<h3>[property:Number duration]</h3>
 		<p>يتجاوز مدة الصوت. مثل المعلمة *duration* لـ[link:https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/start AudioBufferSourceNode.start](). الافتراضي هو *undefined* لتشغيل المخزن المؤقت بالكامل.</p>
 
-		<h3>[property:String source]</h3>
+		<h3>[property:AudioNode source]</h3>
 		<p>[link:https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode AudioBufferSourceNode]  تم إنشاؤها باستخدام [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/createBufferSource AudioContext.createBufferSource]().</p>
 
 		<h3>[property:String sourceType]</h3>

--- a/docs/api/en/audio/Audio.html
+++ b/docs/api/en/audio/Audio.html
@@ -91,7 +91,7 @@
 		<h3>[property:Number duration]</h3>
 		<p>Overrides the duration of the audio. Same as the `duration` parameter of [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/start AudioBufferSourceNode.start](). Default is `undefined` to play the whole buffer.</p>
 
-		<h3>[property:String source]</h3>
+		<h3>[property:AudioNode source]</h3>
 		<p>An [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode AudioBufferSourceNode] created
 		using [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/createBufferSource AudioContext.createBufferSource]().</p>
 

--- a/docs/api/fr/audio/Audio.html
+++ b/docs/api/fr/audio/Audio.html
@@ -91,7 +91,7 @@
 		<h3>[property:Number duration]</h3>
 		<p>Écrase la durée de l'audio. Équivalent au paramètre `duration` de [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/start AudioBufferSourceNode.start](). La valeur par défaut est `undefined` afin de jour le buffer entier.</p>
 
-		<h3>[property:String source]</h3>
+		<h3>[property:AudioNode source]</h3>
 		<p>Un [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode AudioBufferSourceNode] créé
 		en utilisant [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/createBufferSource AudioContext.createBufferSource]().</p>
 

--- a/docs/api/it/audio/Audio.html
+++ b/docs/api/it/audio/Audio.html
@@ -107,7 +107,7 @@
       Il valore predefinito è `undefined` per riprodurre l'intero buffer.
     </p>
 
-		<h3>[property:String source]</h3>
+		<h3>[property:AudioNode source]</h3>
 		<p>
       Un [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode AudioBufferSourceNode] creato
       usando [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/createBufferSource AudioContext.createBufferSource]().

--- a/docs/api/ko/audio/Audio.html
+++ b/docs/api/ko/audio/Audio.html
@@ -89,7 +89,7 @@
 		<h3>[property:Number duration]</h3>
 		<p>오디오 길이를 오버라이드합니다. [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/start AudioBufferSourceNode.start]()의 *duration* 파라미터와 동일. 전체 버퍼 재생을 위한 기본값은 *undefined*입니다.</p>
 
-		<h3>[property:String source]</h3>
+		<h3>[property:AudioNode source]</h3>
 		<p>
 			[link:https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/createBufferSource AudioContext.createBufferSource]()로 생성된
 			[link:https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode AudioBufferSourceNode]입니다.

--- a/docs/api/pt-br/audio/Audio.html
+++ b/docs/api/pt-br/audio/Audio.html
@@ -91,7 +91,7 @@
 		<h3>[property:Number duration]</h3>
 		<p>Substitui a duração do áudio. O mesmo que o parâmetro `duration` do [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/start AudioBufferSourceNode.start](). O padrão é `undefined` para reproduzir todo o buffer.</p>
 
-		<h3>[property:String source]</h3>
+		<h3>[property:AudioNode source]</h3>
 		<p>Um [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode AudioBufferSourceNode] criado
 		usando [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/createBufferSource AudioContext.createBufferSource]().</p>
 

--- a/docs/api/zh/audio/Audio.html
+++ b/docs/api/zh/audio/Audio.html
@@ -89,7 +89,7 @@
 		<h3>[property:Number duration]</h3>
 		<p>覆盖音频的持续时间。与[link:https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/start AudioBufferSourceNode.start]()中的*duration*属性相同。默认为*undefined*，以用于播放整个buffer。</p>
 
-		<h3>[property:String source]</h3>
+		<h3>[property:AudioNode source]</h3>
 		<p>使用 [link:https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/createBufferSource AudioContext.createBufferSource]()创建的[link:https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode AudioBufferSourceNode].</p>
 
 		<h3>[property:String sourceType]</h3>


### PR DESCRIPTION
Fixed #25342.

**Description**

Fixes the type of `Audio.source`.