### PR TITLE
Update GLTFExporter.html

### DIFF
--- a/docs/examples/en/exporters/GLTFExporter.html
+++ b/docs/examples/en/exporters/GLTFExporter.html
@@ -30,6 +30,12 @@
 		<ul>
 			<li>KHR_lights_punctual</li>
 			<li>KHR_materials_unlit</li>
+			<li>KHR_materials_clearcoat</li>
+			<li>KHR_materials_iridescence</li>
+			<li>KHR_materials_transmission</li>
+			<li>KHR_materials_volume</li>
+			<li>KHR_materials_ior</li>
+			<li>KHR_materials_specular</li>
 			<li>KHR_texture_transform</li>
 		</ul>
 
@@ -120,7 +126,6 @@
 			<li>binary - bool. Export in binary (.glb) format, returning an ArrayBuffer. Default is false.</li>
 			<li>maxTextureSize - int. Restricts the image maximum size (both width and height) to the given value. Default is Infinity.</li>
 			<li>animations - Array<[page:AnimationClip AnimationClip]>. List of animations to be included in the export.</li>
-			<li>forceIndices - bool. Generate indices for non-index geometry and export with them. Default is false.</li>
 			<li>includeCustomExtensions - bool. Export custom glTF extensions defined on an object's `userData.gltfExtensions` property. Default is false.</li>
 		</ul>
 		</p>


### PR DESCRIPTION
Update supported glTF 2.0 extensions.  forceIndices is not an export option.

Related issue: none.

**Description**

Update documentation to reflect the capabilities and standards support of GLTFExporter.  Remove options parameter "forceIndices" as it does not exist in the code.
