### PR TITLE
Build: Update package locks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "three",
-  "version": "0.148.0",
+  "version": "0.149.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "three",
-      "version": "0.148.0",
+      "version": "0.149.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^15.0.1",

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -21,7 +21,8 @@
       }
     },
     "..": {
-      "version": "0.148.0",
+      "name": "three",
+      "version": "0.149.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^15.0.1",


### PR DESCRIPTION
Related issue: none.

**Description**

Package lock files for 149 were not updated to 149.  Will look at build script to remove this chore.  I'm looking at tree-shaking and this is coming up every time I reset my environment.
