### PR TITLE
Not add a crossorigin attribute when string is empty

### DIFF
--- a/src/loaders/ImageLoader.js
+++ b/src/loaders/ImageLoader.js
@@ -73,7 +73,7 @@ class ImageLoader extends Loader {
 
 		if ( url.slice( 0, 5 ) !== 'data:' ) {
 
-			if ( this.crossOrigin !== undefined ) image.crossOrigin = this.crossOrigin;
+			if ( this.crossOrigin !== undefined && this.crossOrigin != null ) image.crossOrigin = this.crossOrigin;
 
 		}
 


### PR DESCRIPTION
Related issue:[ #4971](https://discourse.threejs.org/t/cross-origin-request-blocked/4971)

**Description**
This adds capability of not setting the cross origin tag when loading texture. 

**Symptoms**

It can be reproduced for the image when creating TextureLoader while setting crossOrigin='' tag causes error, 
But creating <img> tag works. 


In ThreeJS, property crossOrigin has default value 'anonymous', and has a logic of when it's undefined
it will set to 'anonymous'. 

In texture loader, 
```
var textureLoader = new THREE.TextureLoader();
textureLoader.crossOrigin = '';
textureLoader.load( url )
```

will cause error for some browser. since it it's set to anonymouse. 
[**Referenced W3C standard**](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin)
```
Setting the attribute name to an empty value, like crossorigin or crossorigin="", is the same as anonymous.

```

This feature adds availability to implicitly not set the tag. Just like <img> tag for the example case mentioned above. 
 
