### PR TITLE
Tests: Unit Tests for Textures

### DIFF
--- a/docs/api/en/textures/FramebufferTexture.html
+++ b/docs/api/en/textures/FramebufferTexture.html
@@ -15,7 +15,34 @@
 			This class can only be used in combination with [page:WebGLRenderer.copyFramebufferToTexture]().
 		</p>
 
+		<code>
+			const pixelRatio = window.devicePixelRatio;
+			const textureSize = 128 * pixelRatio;
+
+			// instantiate a framebuffer texture
+			const frameTexture = new FramebufferTexture( textureSize, textureSize, RGBAFormat );
+	
+			// calculate start position for copying part of the frame data
+			const vector = new Vector2();
+			vector.x = ( window.innerWidth * pixelRatio / 2 ) - ( textureSize / 2 );
+			vector.y = ( window.innerHeight * pixelRatio / 2 ) - ( textureSize / 2 );
+
+			// render the scene
+			renderer.clear();
+			renderer.render( scene, camera );
+
+			// copy part of the rendered frame into the framebuffer texture
+			renderer.copyFramebufferToTexture( vector, frameTexture );
+		</code>
+
+		<h2>Examples</h2>
+
+		<p>
+			[example:webgl_framebuffer_texture]
+		</p>
+
 		<h2>Constructor</h2>
+
 		<h3>[name]( [param:Number width], [param:Number height], [param:Constant format] )</h3>
 		<p>
 		[page:Number width] -- The width of the texture.<br />
@@ -30,6 +57,11 @@
 		<h2>Properties</h2>
 
 		<p>See the base [page:Texture Texture] class for common properties.</p>
+
+		<h3>[property:Boolean generateMipmaps]</h3>
+		<p>
+			Whether to generate mipmaps for the [name]. Default value is `false`.
+		</p>
 
 		<h3>[property:Boolean isFramebufferTexture]</h3>
 		<p>

--- a/docs/api/en/textures/FramebufferTexture.html
+++ b/docs/api/en/textures/FramebufferTexture.html
@@ -36,6 +36,24 @@
 			Read-only flag to check if a given object is of type [name].
 		</p>
 
+		<h3>[property:number magFilter]</h3>
+		<p>
+			How the texture is sampled when a texel covers more than one pixel. The default is
+			[page:Textures THREE.NearestFilter], which uses the value of the closest texel.
+			<br /><br />
+			
+			See [page:Textures texture constants] for details.
+		</p>
+
+		<h3>[property:number minFilter]</h3>
+		<p>
+			How the texture is sampled when a texel covers less than one pixel. The default is
+			[page:Textures THREE.NearestFilter], which uses the value of the closest texel. 
+			<br /><br />
+
+			See [page:Textures texture constants] for details.
+		</p>
+
 		<h3>[property:Boolean needsUpdate]</h3>
 
 		<p>

--- a/test/unit/src/textures/CanvasTexture.tests.js
+++ b/test/unit/src/textures/CanvasTexture.tests.js
@@ -1,15 +1,19 @@
 /* global QUnit */
 
-// import { CanvasTexture } from '../../../../src/textures/CanvasTexture.js';
+import { CanvasTexture } from '../../../../src/textures/CanvasTexture.js';
+
+import { Texture } from '../../../../src/textures/Texture.js';
 
 export default QUnit.module( 'Textures', () => {
 
 	QUnit.module( 'CanvasTexture', () => {
 
 		// INHERITANCE
-		QUnit.todo( 'Extending', ( assert ) => {
+		QUnit.test( 'Extending', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			var object = new CanvasTexture();
+
+			assert.strictEqual( object instanceof Texture, true, 'CanvasTexture extends from Texture' );
 
 		} );
 
@@ -20,7 +24,14 @@ export default QUnit.module( 'Textures', () => {
 
 		} );
 
-		// PUBLIC STUFF
+		// PROPERTIES
+		QUnit.todo( 'needsUpdate', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		// PUBLIC
 		QUnit.todo( 'isCanvasTexture', ( assert ) => {
 
 			assert.ok( false, 'everything\'s gonna be alright' );

--- a/test/unit/src/textures/CompressedArrayTexture.tests.js
+++ b/test/unit/src/textures/CompressedArrayTexture.tests.js
@@ -1,0 +1,49 @@
+/* global QUnit */
+
+import { CompressedArrayTexture } from '../../../../src/textures/CompressedArrayTexture.js';
+
+import { Texture } from '../../../../src/textures/Texture.js';
+
+export default QUnit.module( 'Textures', () => {
+
+	QUnit.module( 'CompressedArrayTexture', () => {
+
+		// INHERITANCE
+		QUnit.test( 'Extending', ( assert ) => {
+
+			var object = new CompressedArrayTexture();
+
+			assert.strictEqual( object instanceof Texture, true, 'CompressedArrayTexture extends from Texture' );
+
+		} );
+
+		// INSTANCING
+		QUnit.todo( 'Instancing', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		// PROPERTIES
+		QUnit.todo( 'image.depth', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'wrapR', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		// PUBLIC
+		QUnit.todo( 'isCompressedArrayTexture', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+	} );
+
+} );

--- a/test/unit/src/textures/CompressedTexture.tests.js
+++ b/test/unit/src/textures/CompressedTexture.tests.js
@@ -1,15 +1,19 @@
 /* global QUnit */
 
-// import { CompressedTexture } from '../../../../src/textures/CompressedTexture.js';
+import { CompressedTexture } from '../../../../src/textures/CompressedTexture.js';
+
+import { Texture } from '../../../../src/textures/Texture.js';
 
 export default QUnit.module( 'Textures', () => {
 
 	QUnit.module( 'CompressedTexture', () => {
 
 		// INHERITANCE
-		QUnit.todo( 'Extending', ( assert ) => {
+		QUnit.test( 'Extending', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			var object = new CompressedTexture();
+
+			assert.strictEqual( object instanceof Texture, true, 'CompressedTexture extends from Texture' );
 
 		} );
 

--- a/test/unit/src/textures/CompressedTexture.tests.js
+++ b/test/unit/src/textures/CompressedTexture.tests.js
@@ -24,7 +24,32 @@ export default QUnit.module( 'Textures', () => {
 
 		} );
 
-		// PUBLIC STUFF
+		// PROPERTIES
+		QUnit.todo( 'image', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'mipmaps', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'flipY', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'generateMipmaps', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		// PUBLIC
 		QUnit.todo( 'isCompressedTexture', ( assert ) => {
 
 			assert.ok( false, 'everything\'s gonna be alright' );

--- a/test/unit/src/textures/CubeTexture.tests.js
+++ b/test/unit/src/textures/CubeTexture.tests.js
@@ -1,15 +1,19 @@
 /* global QUnit */
 
-// import { CubeTexture } from '../../../../src/textures/CubeTexture.js';
+import { CubeTexture } from '../../../../src/textures/CubeTexture.js';
+
+import { Texture } from '../../../../src/textures/Texture.js';
 
 export default QUnit.module( 'Textures', () => {
 
 	QUnit.module( 'CubeTexture', () => {
 
 		// INHERITANCE
-		QUnit.todo( 'Extending', ( assert ) => {
+		QUnit.test( 'Extending', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			var object = new CubeTexture();
+
+			assert.strictEqual( object instanceof Texture, true, 'CubeTexture extends from Texture' );
 
 		} );
 
@@ -27,7 +31,13 @@ export default QUnit.module( 'Textures', () => {
 
 		} );
 
-		// PUBLIC STUFF
+		QUnit.todo( 'flipY', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		// PUBLIC
 		QUnit.todo( 'isCubeTexture', ( assert ) => {
 
 			assert.ok( false, 'everything\'s gonna be alright' );

--- a/test/unit/src/textures/Data3DTexture.tests.js
+++ b/test/unit/src/textures/Data3DTexture.tests.js
@@ -1,0 +1,79 @@
+/* global QUnit */
+
+import { Data3DTexture } from '../../../../src/textures/Data3DTexture.js';
+
+import { Texture } from '../../../../src/textures/Texture.js';
+
+export default QUnit.module( 'Textures', () => {
+
+	QUnit.module( 'Data3DTexture', () => {
+
+		// INHERITANCE
+		QUnit.test( 'Extending', ( assert ) => {
+
+			var object = new Data3DTexture();
+
+			assert.strictEqual( object instanceof Texture, true, 'Data3DTexture extends from Texture' );
+
+		} );
+
+		// INSTANCING
+		QUnit.todo( 'Instancing', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		// PROPERTIES
+		QUnit.todo( 'image', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'magFilter', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'minFilter', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'wrapR', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'generateMipmaps', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'flipY', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'unpackAlignment', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		// PUBLIC
+		QUnit.todo( 'isData3DTexture', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+	} );
+
+} );

--- a/test/unit/src/textures/DataArrayTexture.tests.js
+++ b/test/unit/src/textures/DataArrayTexture.tests.js
@@ -1,0 +1,79 @@
+/* global QUnit */
+
+import { DataArrayTexture } from '../../../../src/textures/DataArrayTexture.js';
+
+import { Texture } from '../../../../src/textures/Texture.js';
+
+export default QUnit.module( 'Textures', () => {
+
+	QUnit.module( 'DataArrayTexture', () => {
+
+		// INHERITANCE
+		QUnit.test( 'Extending', ( assert ) => {
+
+			var object = new DataArrayTexture();
+
+			assert.strictEqual( object instanceof Texture, true, 'DataArrayTexture extends from Texture' );
+
+		} );
+
+		// INSTANCING
+		QUnit.todo( 'Instancing', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		// PROPERTIES
+		QUnit.todo( 'image', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'magFilter', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'minFilter', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'wrapR', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'generateMipmaps', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'flipY', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'unpackAlignment', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		// PUBLIC
+		QUnit.todo( 'isDataArrayTexture', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+	} );
+
+} );

--- a/test/unit/src/textures/DataTexture.tests.js
+++ b/test/unit/src/textures/DataTexture.tests.js
@@ -1,15 +1,19 @@
 /* global QUnit */
 
-// import { DataTexture } from '../../../../src/textures/DataTexture.js';
+import { DataTexture } from '../../../../src/textures/DataTexture.js';
+
+import { Texture } from '../../../../src/textures/Texture.js';
 
 export default QUnit.module( 'Textures', () => {
 
 	QUnit.module( 'DataTexture', () => {
 
 		// INHERITANCE
-		QUnit.todo( 'Extending', ( assert ) => {
+		QUnit.test( 'Extending', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			var object = new DataTexture();
+
+			assert.strictEqual( object instanceof Texture, true, 'DataTexture extends from Texture' );
 
 		} );
 
@@ -20,7 +24,32 @@ export default QUnit.module( 'Textures', () => {
 
 		} );
 
-		// PUBLIC STUFF
+		// PROPERTIES
+		QUnit.todo( 'image', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'generateMipmaps', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'flipY', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'unpackAlignment', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		// PUBLIC
 		QUnit.todo( 'isDataTexture', ( assert ) => {
 
 			assert.ok( false, 'everything\'s gonna be alright' );

--- a/test/unit/src/textures/DepthTexture.tests.js
+++ b/test/unit/src/textures/DepthTexture.tests.js
@@ -1,15 +1,19 @@
 /* global QUnit */
 
-// import { DepthTexture } from '../../../../src/textures/DepthTexture.js';
+import { DepthTexture } from '../../../../src/textures/DepthTexture.js';
+
+import { Texture } from '../../../../src/textures/Texture.js';
 
 export default QUnit.module( 'Textures', () => {
 
 	QUnit.module( 'DepthTexture', () => {
 
 		// INHERITANCE
-		QUnit.todo( 'Extending', ( assert ) => {
+		QUnit.test( 'Extending', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			var object = new DepthTexture();
+
+			assert.strictEqual( object instanceof Texture, true, 'DepthTexture extends from Texture' );
 
 		} );
 

--- a/test/unit/src/textures/DepthTexture.tests.js
+++ b/test/unit/src/textures/DepthTexture.tests.js
@@ -24,7 +24,38 @@ export default QUnit.module( 'Textures', () => {
 
 		} );
 
-		// PUBLIC STUFF
+		// PROPERTIES
+		QUnit.todo( 'image', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'magFilter', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'minFilter', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'flipY', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'generateMipmaps', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		// PUBLIC
 		QUnit.todo( 'isDepthTexture', ( assert ) => {
 
 			assert.ok( false, 'everything\'s gonna be alright' );

--- a/test/unit/src/textures/FramebufferTexture.tests.js
+++ b/test/unit/src/textures/FramebufferTexture.tests.js
@@ -1,15 +1,19 @@
 /* global QUnit */
 
-// import { FramebufferTexture } from '../../../../src/textures/FramebufferTexture.js';
+import { FramebufferTexture } from '../../../../src/textures/FramebufferTexture.js';
+
+import { Texture } from '../../../../src/textures/Texture.js';
 
 export default QUnit.module( 'Textures', () => {
 
 	QUnit.module( 'FramebufferTexture', () => {
 
 		// INHERITANCE
-		QUnit.todo( 'Extending', ( assert ) => {
+		QUnit.test( 'Extending', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			var object = new FramebufferTexture();
+
+			assert.strictEqual( object instanceof Texture, true, 'FramebufferTexture extends from Texture' );
 
 		} );
 

--- a/test/unit/src/textures/FramebufferTexture.tests.js
+++ b/test/unit/src/textures/FramebufferTexture.tests.js
@@ -1,0 +1,63 @@
+/* global QUnit */
+
+// import { FramebufferTexture } from '../../../../src/textures/FramebufferTexture.js';
+
+export default QUnit.module( 'Textures', () => {
+
+	QUnit.module( 'FramebufferTexture', () => {
+
+		// INHERITANCE
+		QUnit.todo( 'Extending', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		// INSTANCING
+		QUnit.todo( 'Instancing', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		// PROPERTIES
+		QUnit.todo( 'format', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'magFilter', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'minFilter', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'generateMipmaps', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'needsUpdate', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		// PUBLIC
+		QUnit.todo( 'isFramebufferTexture', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+	} );
+
+} );

--- a/test/unit/src/textures/Texture.tests.js
+++ b/test/unit/src/textures/Texture.tests.js
@@ -8,12 +8,19 @@ export default QUnit.module( 'Textures', () => {
 
 	QUnit.module( 'Texture', () => {
 
-		// INSTANCING
+		// INHERITANCE
 		QUnit.test( 'Instancing', ( assert ) => {
 
 			var object = new Texture();
 
 			assert.strictEqual( object instanceof EventDispatcher, true, 'Texture extends from EventDispatcher' );
+
+		} );
+
+		// INSTANCING
+		QUnit.todo( 'Instancing', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
 
 		} );
 

--- a/test/unit/src/textures/Texture.tests.js
+++ b/test/unit/src/textures/Texture.tests.js
@@ -1,27 +1,211 @@
 /* global QUnit */
 
-// import { Texture } from '../../../../src/textures/Texture.js';
+import { Texture } from '../../../../src/textures/Texture.js';
+
+import { EventDispatcher } from '../../../../src/core/EventDispatcher.js';
 
 export default QUnit.module( 'Textures', () => {
 
 	QUnit.module( 'Texture', () => {
 
 		// INSTANCING
-		QUnit.todo( 'Instancing', ( assert ) => {
+		QUnit.test( 'Instancing', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			var object = new Texture();
+
+			assert.strictEqual( object instanceof EventDispatcher, true, 'Texture extends from EventDispatcher' );
 
 		} );
 
 		// PROPERTIES
-		QUnit.todo( 'needsUpdate', ( assert ) => {
+		QUnit.todo( 'image', ( assert ) => {
 
 			assert.ok( false, 'everything\'s gonna be alright' );
 
 		} );
 
-		// PUBLIC STUFF
+		QUnit.todo( 'id', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'uuid', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'name', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'source', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'mipmaps', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'mapping', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'wrapS', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'wrapT', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'magFilter', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'minFilter', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'anisotropy', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'format', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'internalFormat', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'type', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'offset', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'repeat', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'center', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'rotation', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'matrixAutoUpdate', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'matrix', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'generateMipmaps', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'premultiplyAlpha', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'flipY', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'unpackAlignment', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'encoding', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'userData', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'version', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'onUpdate', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'needsPMREMUpdate', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		// PUBLIC
 		QUnit.todo( 'isTexture', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'updateMatrix', ( assert ) => {
 
 			assert.ok( false, 'everything\'s gonna be alright' );
 

--- a/test/unit/src/textures/VideoTexture.tests.js
+++ b/test/unit/src/textures/VideoTexture.tests.js
@@ -1,15 +1,21 @@
 /* global QUnit */
 
-// import { VideoTexture } from '../../../../src/textures/VideoTexture.js';
+import { VideoTexture } from '../../../../src/textures/VideoTexture.js';
+
+import { Texture } from '../../../../src/textures/Texture.js';
 
 export default QUnit.module( 'Textures', () => {
 
 	QUnit.module( 'VideoTexture', () => {
 
 		// INHERITANCE
-		QUnit.todo( 'Extending', ( assert ) => {
+		QUnit.test( 'Extending', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const videoDocumentElement = {};
+
+			const object = new VideoTexture( videoDocumentElement );
+
+			assert.strictEqual( object instanceof Texture, true, 'VideoTexture extends from Texture' );
 
 		} );
 
@@ -20,8 +26,39 @@ export default QUnit.module( 'Textures', () => {
 
 		} );
 
+		// PROPERTIES
+		QUnit.todo( 'minFilter', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'magFilter', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'generateMipmaps', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
 		// PUBLIC STUFF
 		QUnit.todo( 'isVideoTexture', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'clone', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'update', ( assert ) => {
 
 			assert.ok( false, 'everything\'s gonna be alright' );
 

--- a/test/unit/three.source.unit.js
+++ b/test/unit/three.source.unit.js
@@ -259,8 +259,11 @@ import './src/scenes/Scene.tests.js';
 
 //src/textures
 import './src/textures/CanvasTexture.tests.js';
+import './src/textures/CompressedArrayTexture.tests.js';
 import './src/textures/CompressedTexture.tests.js';
 import './src/textures/CubeTexture.tests.js';
+import './src/textures/Data3DTexture.tests.js';
+import './src/textures/DataArrayTexture.tests.js';
 import './src/textures/DataTexture.tests.js';
 import './src/textures/DepthTexture.tests.js';
 import './src/textures/FramebufferTexture.tests.js';

--- a/test/unit/three.source.unit.js
+++ b/test/unit/three.source.unit.js
@@ -263,6 +263,7 @@ import './src/textures/CompressedTexture.tests.js';
 import './src/textures/CubeTexture.tests.js';
 import './src/textures/DataTexture.tests.js';
 import './src/textures/DepthTexture.tests.js';
+import './src/textures/FramebufferTexture.tests.js';
 import './src/textures/Source.tests.js';
 import './src/textures/Texture.tests.js';
 import './src/textures/VideoTexture.tests.js';


### PR DESCRIPTION
Related issue: none

**Description**

Following the second pull request to nail down the process, this cleans up the unit tests for Textures.
It fills in one working unit test for each (up from  0) and populates the missing member tests with stubs.