### PR TITLE
NRRDLoader: Fix loading 16-bits file with custom axes.

### DIFF
--- a/examples/jsm/loaders/NRRDLoader.js
+++ b/examples/jsm/loaders/NRRDLoader.js
@@ -54,9 +54,11 @@ class NRRDLoader extends Loader {
 	 *
 	 * @param {boolean} segmentation is a option for user to choose
    	 */
-    setSegmentation(segmentation) {
+	setSegmentation( segmentation ) {
+
 	    this.segmentation = segmentation;
-    }
+
+	}
 
 	parse( data ) {
 
@@ -387,13 +389,18 @@ class NRRDLoader extends Loader {
 			const zIndex = headerObject.vectors.findIndex( vector => vector[ 2 ] !== 0 );
 
 			let axisOrder = [];
-			if (xIndex !== yIndex && xIndex !== zIndex && yIndex !== zIndex) {
-				axisOrder[xIndex] = 'x';
-				axisOrder[yIndex] = 'y';
-				axisOrder[zIndex] = 'z';
-			}else {
-        		axisOrder = ["x", "y", "z"];
-      		}
+			if ( xIndex !== yIndex && xIndex !== zIndex && yIndex !== zIndex ) {
+
+				axisOrder[ xIndex ] = 'x';
+				axisOrder[ yIndex ] = 'y';
+				axisOrder[ zIndex ] = 'z';
+
+			} else {
+
+				axisOrder = [ 'x', 'y', 'z' ];
+
+			}
+
 			volume.axisOrder = axisOrder;
 
 		} else {

--- a/examples/jsm/loaders/NRRDLoader.js
+++ b/examples/jsm/loaders/NRRDLoader.js
@@ -389,6 +389,7 @@ class NRRDLoader extends Loader {
 			const zIndex = headerObject.vectors.findIndex( vector => vector[ 2 ] !== 0 );
 
 			let axisOrder = [];
+
 			if ( xIndex !== yIndex && xIndex !== zIndex && yIndex !== zIndex ) {
 
 				axisOrder[ xIndex ] = 'x';
@@ -397,7 +398,9 @@ class NRRDLoader extends Loader {
 
 			} else {
 
-				axisOrder = [ 'x', 'y', 'z' ];
+				axisOrder[ 0 ] = 'x';
+				axisOrder[ 1 ] = 'y';
+				axisOrder[ 2 ] = 'z';
 
 			}
 

--- a/examples/jsm/loaders/NRRDLoader.js
+++ b/examples/jsm/loaders/NRRDLoader.js
@@ -50,6 +50,14 @@ class NRRDLoader extends Loader {
 
 	}
 
+	/**
+	 *
+	 * @param {boolean} segmentation is a option for user to choose
+   	 */
+    setSegmentation(segmentation) {
+	    this.segmentation = segmentation;
+    }
+
 	parse( data ) {
 
 		// this parser is largely inspired from the XTK NRRD parser : https://github.com/xtk/X
@@ -378,10 +386,14 @@ class NRRDLoader extends Loader {
 			const yIndex = headerObject.vectors.findIndex( vector => vector[ 1 ] !== 0 );
 			const zIndex = headerObject.vectors.findIndex( vector => vector[ 2 ] !== 0 );
 
-			const axisOrder = [];
-			axisOrder[ xIndex ] = 'x';
-			axisOrder[ yIndex ] = 'y';
-			axisOrder[ zIndex ] = 'z';
+			let axisOrder = [];
+			if (xIndex !== yIndex && xIndex !== zIndex && yIndex !== zIndex) {
+				axisOrder[xIndex] = 'x';
+				axisOrder[yIndex] = 'y';
+				axisOrder[zIndex] = 'z';
+			}else {
+        		axisOrder = ["x", "y", "z"];
+      		}
 			volume.axisOrder = axisOrder;
 
 		} else {
@@ -423,7 +435,7 @@ class NRRDLoader extends Loader {
 		}
 
 
-		if ( ! headerObject.vectors ) {
+		if ( ! headerObject.vectors || this.segmentation ) {
 
 			volume.matrix.set(
 				1, 0, 0, 0,


### PR DESCRIPTION
Related issue: #24501 

**Description**

The key issue for this issue is that some 16-bit NRRD files do have not standard vectors. 
So using the old if judgment statement cannot get a good result for loading them.

issue code: 
```js
const xIndex = headerObject.vectors.findIndex((vector) => vector[0] !== 0);
const yIndex = headerObject.vectors.findIndex((vector) => vector[1] !== 0);
const zIndex = headerObject.vectors.findIndex((vector) => vector[2] !== 0);
```
The 16-bit NRRD files vectors are like this below:
```js
const vectors = [
  [0.803031719442651, -1.6481526752133598e-10, 0.02944583724545901],
  [1.647045751213251e-10, 0.80357140302658, 6.039481950867172e-12],
  [-0.04030796800931726, -5.359717066245572e-17, 1.0992581595808804],
];
```
Thus under this if statement, it will always get xIndex=yIndex=zIndex=0
Then for the axis array we always get only direction ["z"]. Not the ["x","y","z"].

So I add a new if statement inside this if to solve this issue:
```js
let axisOrder = [];
if (xIndex !== yIndex && xIndex !== zIndex && yIndex !== zIndex) {
	axisOrder[xIndex] = "x";
	axisOrder[yIndex] = "y";
	axisOrder[zIndex] = "z";
} else {
	axisOrder = ["x", "y", "z"];
}
```
Instead
```js
let axisOrder = [];
axisOrder[xIndex] = "x";
axisOrder[yIndex] = "y";
axisOrder[zIndex] = "z";
```

Then, as for the segmentation purpose, I also add a setSegementation() function.

```js
        /**
	 *
	 * @param {boolean} segmentation is a option for user to choose
	 */
	setSegmentation(segmentation) {
		this.segmentation = segmentation;
	}

       ...

      if (!headerObject.vectors || this.segmentation) {
          volume.matrix.set(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);
      }
```
If the user use loader.setSegementation(true) outside, we can get the NRRD Original size slices/images, not the RASDimention one size.

- Reset the code format