### PR TITLE
Tests: Fill in unit "is" tests

### DIFF
--- a/test/unit/src/scenes/Fog.tests.js
+++ b/test/unit/src/scenes/Fog.tests.js
@@ -1,6 +1,6 @@
 /* global QUnit */
 
-// import { Fog } from '../../../../src/scenes/Fog.js';
+import { Fog } from '../../../../src/scenes/Fog.js';
 
 export default QUnit.module( 'Scenes', () => {
 
@@ -39,9 +39,13 @@ export default QUnit.module( 'Scenes', () => {
 		} );
 
 		// PUBLIC
-		QUnit.todo( 'isFog', ( assert ) => {
+		QUnit.test( 'isFog', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const object = new Fog();
+			assert.ok(
+				object.isFog,
+				'Fog.isFog should be true'
+			);
 
 		} );
 

--- a/test/unit/src/scenes/FogExp2.tests.js
+++ b/test/unit/src/scenes/FogExp2.tests.js
@@ -1,6 +1,6 @@
 /* global QUnit */
 
-// import { FogExp2 } from '../../../../src/scenes/FogExp2.js';
+import { FogExp2 } from '../../../../src/scenes/FogExp2.js';
 
 export default QUnit.module( 'Scenes', () => {
 
@@ -33,9 +33,13 @@ export default QUnit.module( 'Scenes', () => {
 		} );
 
 		// PUBLIC STUFF
-		QUnit.todo( 'isFogExp2', ( assert ) => {
+		QUnit.test( 'isFogExp2', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const object = new FogExp2();
+			assert.ok(
+				object.isFogExp2,
+				'FogExp2.isFogExp2 should be true'
+			);
 
 		} );
 

--- a/test/unit/src/scenes/Scene.tests.js
+++ b/test/unit/src/scenes/Scene.tests.js
@@ -68,9 +68,13 @@ export default QUnit.module( 'Scenes', () => {
 		} );
 
 		// PUBLIC
-		QUnit.todo( 'isScene', ( assert ) => {
+		QUnit.test( 'isScene', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const object = new Scene();
+			assert.ok(
+				object.isScene,
+				'Scene.isScene should be true'
+			);
 
 		} );
 

--- a/test/unit/src/textures/CanvasTexture.tests.js
+++ b/test/unit/src/textures/CanvasTexture.tests.js
@@ -32,9 +32,13 @@ export default QUnit.module( 'Textures', () => {
 		} );
 
 		// PUBLIC
-		QUnit.todo( 'isCanvasTexture', ( assert ) => {
+		QUnit.test( 'isCanvasTexture', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const object = new CanvasTexture();
+			assert.ok(
+				object.isCanvasTexture,
+				'CanvasTexture.isCanvasTexture should be true'
+			);
 
 		} );
 

--- a/test/unit/src/textures/CompressedArrayTexture.tests.js
+++ b/test/unit/src/textures/CompressedArrayTexture.tests.js
@@ -38,9 +38,13 @@ export default QUnit.module( 'Textures', () => {
 		} );
 
 		// PUBLIC
-		QUnit.todo( 'isCompressedArrayTexture', ( assert ) => {
+		QUnit.test( 'isCompressedArrayTexture', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const object = new CompressedArrayTexture();
+			assert.ok(
+				object.isCompressedArrayTexture,
+				'CompressedArrayTexture.isCompressedArrayTexture should be true'
+			);
 
 		} );
 

--- a/test/unit/src/textures/CompressedTexture.tests.js
+++ b/test/unit/src/textures/CompressedTexture.tests.js
@@ -50,9 +50,13 @@ export default QUnit.module( 'Textures', () => {
 		} );
 
 		// PUBLIC
-		QUnit.todo( 'isCompressedTexture', ( assert ) => {
+		QUnit.test( 'isCompressedTexture', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const object = new CompressedTexture();
+			assert.ok(
+				object.isCompressedTexture,
+				'CompressedTexture.isCompressedTexture should be true'
+			);
 
 		} );
 

--- a/test/unit/src/textures/CubeTexture.tests.js
+++ b/test/unit/src/textures/CubeTexture.tests.js
@@ -38,9 +38,13 @@ export default QUnit.module( 'Textures', () => {
 		} );
 
 		// PUBLIC
-		QUnit.todo( 'isCubeTexture', ( assert ) => {
+		QUnit.test( 'isCubeTexture', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const object = new CubeTexture();
+			assert.ok(
+				object.isCubeTexture,
+				'CubeTexture.isCubeTexture should be true'
+			);
 
 		} );
 

--- a/test/unit/src/textures/Data3DTexture.tests.js
+++ b/test/unit/src/textures/Data3DTexture.tests.js
@@ -68,9 +68,13 @@ export default QUnit.module( 'Textures', () => {
 		} );
 
 		// PUBLIC
-		QUnit.todo( 'isData3DTexture', ( assert ) => {
+		QUnit.test( 'isData3DTexture', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const object = new Data3DTexture();
+			assert.ok(
+				object.isData3DTexture,
+				'Data3DTexture.isData3DTexture should be true'
+			);
 
 		} );
 

--- a/test/unit/src/textures/DataArrayTexture.tests.js
+++ b/test/unit/src/textures/DataArrayTexture.tests.js
@@ -68,9 +68,13 @@ export default QUnit.module( 'Textures', () => {
 		} );
 
 		// PUBLIC
-		QUnit.todo( 'isDataArrayTexture', ( assert ) => {
+		QUnit.test( 'isDataArrayTexture', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const object = new DataArrayTexture();
+			assert.ok(
+				object.isDataArrayTexture,
+				'DataArrayTexture.isDataArrayTexture should be true'
+			);
 
 		} );
 

--- a/test/unit/src/textures/DataTexture.tests.js
+++ b/test/unit/src/textures/DataTexture.tests.js
@@ -50,9 +50,13 @@ export default QUnit.module( 'Textures', () => {
 		} );
 
 		// PUBLIC
-		QUnit.todo( 'isDataTexture', ( assert ) => {
+		QUnit.test( 'isDataTexture', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const object = new DataTexture();
+			assert.ok(
+				object.isDataTexture,
+				'DataTexture.isDataTexture should be true'
+			);
 
 		} );
 

--- a/test/unit/src/textures/DepthTexture.tests.js
+++ b/test/unit/src/textures/DepthTexture.tests.js
@@ -56,9 +56,13 @@ export default QUnit.module( 'Textures', () => {
 		} );
 
 		// PUBLIC
-		QUnit.todo( 'isDepthTexture', ( assert ) => {
+		QUnit.test( 'isDepthTexture', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const object = new DepthTexture();
+			assert.ok(
+				object.isDepthTexture,
+				'DepthTexture.isDepthTexture should be true'
+			);
 
 		} );
 

--- a/test/unit/src/textures/FramebufferTexture.tests.js
+++ b/test/unit/src/textures/FramebufferTexture.tests.js
@@ -56,9 +56,13 @@ export default QUnit.module( 'Textures', () => {
 		} );
 
 		// PUBLIC
-		QUnit.todo( 'isFramebufferTexture', ( assert ) => {
+		QUnit.test( 'isFramebufferTexture', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const object = new FramebufferTexture();
+			assert.ok(
+				object.isFramebufferTexture,
+				'FramebufferTexture.isFramebufferTexture should be true'
+			);
 
 		} );
 

--- a/test/unit/src/textures/Source.tests.js
+++ b/test/unit/src/textures/Source.tests.js
@@ -1,6 +1,6 @@
 /* global QUnit */
 
-// import { Source } from '../../../../src/textures/Source.js';
+import { Source } from '../../../../src/textures/Source.js';
 
 export default QUnit.module( 'Textures', () => {
 
@@ -39,9 +39,13 @@ export default QUnit.module( 'Textures', () => {
 		} );
 
 		// PUBLIC
-		QUnit.todo( 'isSource', ( assert ) => {
+		QUnit.test( 'isSource', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const object = new Source();
+			assert.ok(
+				object.isSource,
+				'Source.isSource should be true'
+			);
 
 		} );
 

--- a/test/unit/src/textures/Texture.tests.js
+++ b/test/unit/src/textures/Texture.tests.js
@@ -206,9 +206,13 @@ export default QUnit.module( 'Textures', () => {
 		} );
 
 		// PUBLIC
-		QUnit.todo( 'isTexture', ( assert ) => {
+		QUnit.test( 'isTexture', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const object = new Texture();
+			assert.ok(
+				object.isTexture,
+				'Texture.isTexture should be true'
+			);
 
 		} );
 

--- a/test/unit/src/textures/VideoTexture.tests.js
+++ b/test/unit/src/textures/VideoTexture.tests.js
@@ -46,9 +46,16 @@ export default QUnit.module( 'Textures', () => {
 		} );
 
 		// PUBLIC STUFF
-		QUnit.todo( 'isVideoTexture', ( assert ) => {
+		QUnit.test( 'isVideoTexture', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const videoDocumentElement = {};
+
+			const object = new VideoTexture( videoDocumentElement );
+
+			assert.ok(
+				object.isVideoTexture,
+				'VideoTexture.isVideoTexture should be true'
+			);
 
 		} );
 


### PR DESCRIPTION
Related issue: none.

**Description**

Converts test todo to test done.  Specifically, this fills in the "isXXX" unit tests stubbed in previous commits and PRs.