### PR TITLE
fixed: Consider marking event handler as 'passive' to make the page more responsive

### DIFF
--- a/editor/js/EditorControls.js
+++ b/editor/js/EditorControls.js
@@ -347,8 +347,8 @@ class EditorControls extends THREE.EventDispatcher {
 
 		}
 
-		domElement.addEventListener( 'touchstart', touchStart );
-		domElement.addEventListener( 'touchmove', touchMove );
+		domElement.addEventListener( 'touchstart', touchStart, { passive: false } );
+		domElement.addEventListener( 'touchmove', touchMove, { passive: false } );
 
 	}
 

--- a/editor/js/EditorControls.js
+++ b/editor/js/EditorControls.js
@@ -258,7 +258,7 @@ class EditorControls extends THREE.EventDispatcher {
 
 		domElement.addEventListener( 'contextmenu', contextmenu );
 		domElement.addEventListener( 'dblclick', onMouseUp );
-		domElement.addEventListener( 'wheel', onMouseWheel );
+		domElement.addEventListener( 'wheel', onMouseWheel, { passive: false } );
 
 		domElement.addEventListener( 'pointerdown', onPointerDown );
 

--- a/editor/js/Viewport.js
+++ b/editor/js/Viewport.js
@@ -279,7 +279,7 @@ function Viewport( editor ) {
 	}
 
 	container.dom.addEventListener( 'mousedown', onMouseDown );
-	container.dom.addEventListener( 'touchstart', onTouchStart );
+	container.dom.addEventListener( 'touchstart', onTouchStart, { passive: false } );
 	container.dom.addEventListener( 'dblclick', onDoubleClick );
 
 	// controls need to be added *after* main logic,

--- a/editor/js/libs/codemirror/codemirror.js
+++ b/editor/js/libs/codemirror/codemirror.js
@@ -533,7 +533,7 @@
 
   var on = function(emitter, type, f) {
     if (emitter.addEventListener) {
-      emitter.addEventListener(type, f, false);
+      emitter.addEventListener(type, f, { passive: false });
     } else if (emitter.attachEvent) {
       emitter.attachEvent("on" + type, f);
     } else {

--- a/editor/js/libs/ui.js
+++ b/editor/js/libs/ui.js
@@ -694,7 +694,7 @@ class UINumber extends UIElement {
 
 		this.dom.addEventListener( 'keydown', onKeyDown );
 		this.dom.addEventListener( 'mousedown', onMouseDown );
-		this.dom.addEventListener( 'touchstart', onTouchStart );
+		this.dom.addEventListener( 'touchstart', onTouchStart, { passive: false } );
 		this.dom.addEventListener( 'change', onChange );
 		this.dom.addEventListener( 'focus', onFocus );
 		this.dom.addEventListener( 'blur', onBlur );


### PR DESCRIPTION
**Description**

https://threejs.org/editor/

in Chrome - Console :

```
[Violation] Added non-passive event listener to a scroll-blocking <some> event. Consider marking event handler as 'passive' to make the page more responsive. See <URL>
```

The reason for this is the same as https://github.com/mrdoob/three.js/pull/21642

