### PR TITLE
GLTFLoader: Fix node parse

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -3616,7 +3616,7 @@ class GLTFParser {
 
 		for ( let i = 0, il = skinDef.joints.length; i < il; i ++ ) {
 
-			pending.push( this._loadNode( skinDef.joints[ i ] ) );
+			pending.push( this._loadNodeShallow( skinDef.joints[ i ] ) );
 
 		}
 
@@ -3637,7 +3637,6 @@ class GLTFParser {
 
 			// Note that bones (joint nodes) may or may not be in the
 			// scene graph at this time.
-			// Child nodes are added in .loadNode() (no '_' prefix).
 
 			const bones = [];
 			const boneInverses = [];
@@ -3894,7 +3893,7 @@ class GLTFParser {
 
 		return ( function () {
 
-			const nodePending = parser._loadNode( nodeIndex );
+			const nodePending = parser._loadNodeShallow( nodeIndex );
 
 			const childPending = [];
 			const childrenDef = nodeDef.children || [];
@@ -3947,9 +3946,9 @@ class GLTFParser {
 
 	}
 
-	// ._loadNode() parses a single node.
+	// ._loadNodeShallow() parses a single node.
 	// skin and child nodes are created and added in .loadNode() (no '_' prefix).
-	_loadNode( nodeIndex ) {
+	_loadNodeShallow( nodeIndex ) {
 
 		const json = this.json;
 		const extensions = this.extensions;


### PR DESCRIPTION
Fixed #25332.

**Description**

This commit fixes a `GLTFLoader` node parse bug that can cause an infinite loop in node parse - skin parse - node parse.

The solution is adding `._loadNode()` that parses a single node without child nodes or skin to the parser. `.loadNode()` and `.loadSkin()` call `._loadNode()` to get dependent nodes. `._loadNode()` doesn't have dependency with other nodes so infinite loop can be avoided.

`._loadNode()` caches created nodes to avoid duplication because it is called from two different methods, `.loadNode()` and `.loadSkin()`.

/cc @donmccurdy 