### PR TITLE
Puppeteer E2E test: Log console output

### DIFF
--- a/test/e2e/puppeteer.js
+++ b/test/e2e/puppeteer.js
@@ -224,6 +224,12 @@ async function preparePage( page, injection, build, errorMessages ) {
 
 		}
 
+		if ( text.includes( 'Unable to access the camera/webcam' ) ) {
+
+			return;
+
+		}
+
 		errorMessages.push( text );
 
 		if ( type === 'warning' ) {


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/24109

**Description**

Log console output.

### Current errors and warnings

> webgl_lines_fat: GPUStatsPanel: disjoint_time_query extension not available.
webgl_lines_fat_raycasting: GPUStatsPanel: disjoint_time_query extension not available.

> webgl_loader_collada: THREE.ColladaLoader: You are loading an asset with a Z-UP coordinate system. The loader just rotates the asset to transform it into Y-UP. The vertex data are not converted, see #24289.
webgl_loader_collada_kinematics: THREE.ColladaLoader: You are loading an asset with a Z-UP coordinate system. The loader just rotates the asset to transform it into Y-UP. The vertex data are not converted, see #24289.
webgl_loader_collada_skinning: THREE.ColladaLoader: You are loading an asset with a Z-UP coordinate system. The loader just rotates the asset to transform it into Y-UP. The vertex data are not converted, see #24289.
webgl_loader_kmz: THREE.ColladaLoader: You are loading an asset with a Z-UP coordinate system. The loader just rotates the asset to transform it into Y-UP. The vertex data are not converted, see #24289.

> webgl_loader_gltf_sheen: THREE.GLTFLoader: Custom UV sets in "KHR_texture_transform" extension not yet supported.
webgl_nodes_loader_gltf_sheen: THREE.GLTFLoader: Custom UV sets in "KHR_texture_transform" extension not yet supported.

> webgl_loader_lwo: LWOLoader: polygons with greater than 4 sides are not supported

> webgl_simple_gi: THREE.Scene: autoUpdate was renamed to matrixWorldAutoUpdate in r144.

/ping @mrdoob @Mugen87 