### PR TITLE
Puppeteer E2E test: Run on multiple OSes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,11 +56,12 @@ jobs:
 
   e2e:
     name: "E2E testing"
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        CI: [ 0, 1, 2, 3, 4, 5, 6, 7 ]
+        CI: [ 0, 1, 2, 3, 4, 5 ]
+        os: [ windows-latest, ubuntu-latest, macos-latest ]
     env:
       CI: ${{ matrix.CI }}
       FORCE_COLOR: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        CI: [ 0, 1, 2, 3, 4, 5 ]
+        CI: [ 0, 1, 2, 3, 4, 5, 6, 7 ]
         os: [ windows-latest, ubuntu-latest, macos-latest ]
     env:
       CI: ${{ matrix.CI }}

--- a/test/e2e/puppeteer.js
+++ b/test/e2e/puppeteer.js
@@ -54,7 +54,7 @@ const renderTimeout = 1.5; // 1.5 seconds, set to 0 to disable
 
 const numAttempts = 3; // perform 3 progressive attempts before failing
 
-const numCIJobs = 6; // GitHub Actions run the script in 6 threads
+const numCIJobs = 8; // GitHub Actions run the script in 8 threads
 
 const width = 400;
 const height = 250;

--- a/test/e2e/puppeteer.js
+++ b/test/e2e/puppeteer.js
@@ -54,7 +54,7 @@ const renderTimeout = 1.5; // 1.5 seconds, set to 0 to disable
 
 const numAttempts = 3; // perform 3 progressive attempts before failing
 
-const numCIJobs = 8; // GitHub Actions run the script in 8 threads
+const numCIJobs = 6; // GitHub Actions run the script in 6 threads
 
 const width = 400;
 const height = 250;


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/24109

**Description**

Make Puppeteer test examples on different OSes (Windows, Ubuntu, and Mac). Also reduced the number of threads from 8 to 6 to reduce the number of jobs (I will file a PR for multi-page in-browser parallelism soon, which wouldn't require multi-threading anymore -- but it is quite unstable)