### PR TITLE
Tests: Unit Tests for Math

### DIFF
--- a/test/unit/src/animation/AnimationMixer.tests.js
+++ b/test/unit/src/animation/AnimationMixer.tests.js
@@ -4,7 +4,7 @@ import { AnimationMixer } from '../../../../src/animation/AnimationMixer.js';
 import { AnimationClip } from '../../../../src/animation/AnimationClip.js';
 import { VectorKeyframeTrack } from '../../../../src/animation/tracks/VectorKeyframeTrack.js';
 import { Object3D } from '../../../../src/core/Object3D.js';
-import { zero3, one3, two3 } from '../math/Constants.tests.js';
+import { zero3, one3, two3 } from '../../utils/math-constants.js';
 
 function getClips( pos1, pos2, scale1, scale2, dur ) {
 

--- a/test/unit/src/core/BufferGeometry.tests.js
+++ b/test/unit/src/core/BufferGeometry.tests.js
@@ -10,7 +10,7 @@ import { Vector3 } from '../../../../src/math/Vector3.js';
 import { Matrix4 } from '../../../../src/math/Matrix4.js';
 import { Quaternion } from '../../../../src/math/Quaternion.js';
 import { Sphere } from '../../../../src/math/Sphere.js';
-import { x, y, z } from '../math/Constants.tests.js';
+import { x, y, z } from '../../utils/math-constants.js';
 
 var DegToRad = Math.PI / 180;
 

--- a/test/unit/src/core/Object3D.tests.js
+++ b/test/unit/src/core/Object3D.tests.js
@@ -11,7 +11,7 @@ import {
 	z,
 	w,
 	eps
-} from '../math/Constants.tests.js';
+} from '../../utils/math-constants.js';
 import { EventDispatcher } from '../../../../src/core/EventDispatcher.js';
 
 const matrixEquals4 = ( a, b ) => {

--- a/test/unit/src/core/Uniform.tests.js
+++ b/test/unit/src/core/Uniform.tests.js
@@ -6,7 +6,7 @@ import {
 	x,
 	y,
 	z
-} from '../math/Constants.tests.js';
+} from '../../utils/math-constants.js';
 
 export default QUnit.module( 'Core', () => {
 

--- a/test/unit/src/math/Box2.tests.js
+++ b/test/unit/src/math/Box2.tests.js
@@ -9,7 +9,7 @@ import {
 	zero2,
 	one2,
 	two2
-} from './Constants.tests.js';
+} from '../../utils/math-constants.js';
 
 export default QUnit.module( 'Maths', () => {
 

--- a/test/unit/src/math/Box2.tests.js
+++ b/test/unit/src/math/Box2.tests.js
@@ -33,6 +33,16 @@ export default QUnit.module( 'Maths', () => {
 		} );
 
 		// PUBLIC STUFF
+		QUnit.test( 'isBox2', ( assert ) => {
+
+			var a = new Box2();
+			assert.ok( a.isBox2 === true, 'Passed!' );
+
+			var b = new Object();
+			assert.ok( ! b.isBox2, 'Passed!' );
+
+		} );
+
 		QUnit.test( 'set', ( assert ) => {
 
 			var a = new Box2();

--- a/test/unit/src/math/Box3.tests.js
+++ b/test/unit/src/math/Box3.tests.js
@@ -18,7 +18,7 @@ import {
 	zero3,
 	one3,
 	two3
-} from './Constants.tests.js';
+} from '../../utils/math-constants.js';
 
 function compareBox( a, b, threshold ) {
 

--- a/test/unit/src/math/Color.tests.js
+++ b/test/unit/src/math/Color.tests.js
@@ -251,6 +251,13 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
+		QUnit.todo( 'getRGB', ( assert ) => {
+
+			// getRGB( target, colorSpace = ColorManagement.workingColorSpace )
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
 		QUnit.test( 'getStyle', ( assert ) => {
 
 			var c = new Color( 'plum' );
@@ -344,24 +351,6 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
-		QUnit.test( 'copyHex', ( assert ) => {
-
-			var c = new Color();
-			var c2 = new Color( 0xF5FFFA );
-			c.copy( c2 );
-			assert.ok( c.getHex() == c2.getHex(), 'Hex c: ' + c.getHex() + ' Hex c2: ' + c2.getHex() );
-
-		} );
-
-		QUnit.test( 'copyColorString', ( assert ) => {
-
-			var c = new Color();
-			var c2 = new Color( 'ivory' );
-			c.copy( c2 );
-			assert.ok( c.getHex() == c2.getHex(), 'Hex c: ' + c.getHex() + ' Hex c2: ' + c2.getHex() );
-
-		} );
-
 		QUnit.test( 'lerp', ( assert ) => {
 
 			var c = new Color();
@@ -371,6 +360,20 @@ export default QUnit.module( 'Maths', () => {
 			assert.ok( c.r == 0.2, 'Red: ' + c.r );
 			assert.ok( c.g == 0.2, 'Green: ' + c.g );
 			assert.ok( c.b == 0.2, 'Blue: ' + c.b );
+
+		} );
+
+		QUnit.todo( 'lerpColors', ( assert ) => {
+
+			// lerpColors( color1, color2, alpha )
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'lerpHSL', ( assert ) => {
+
+			// lerpHSL( color, alpha )
+			assert.ok( false, 'everything\'s gonna be alright' );
 
 		} );
 
@@ -438,6 +441,13 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
+		QUnit.todo( 'fromBufferAttribute', ( assert ) => {
+
+			// fromBufferAttribute( attribute, index )
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
 		QUnit.test( 'toJSON', ( assert ) => {
 
 			var a = new Color( 0.0, 0.0, 0.0 );
@@ -452,7 +462,25 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
-		// OTHERS
+		// OTHERS - FUNCTIONAL
+		QUnit.test( 'copyHex', ( assert ) => {
+
+			var c = new Color();
+			var c2 = new Color( 0xF5FFFA );
+			c.copy( c2 );
+			assert.ok( c.getHex() == c2.getHex(), 'Hex c: ' + c.getHex() + ' Hex c2: ' + c2.getHex() );
+
+		} );
+
+		QUnit.test( 'copyColorString', ( assert ) => {
+
+			var c = new Color();
+			var c2 = new Color( 'ivory' );
+			c.copy( c2 );
+			assert.ok( c.getHex() == c2.getHex(), 'Hex c: ' + c.getHex() + ' Hex c2: ' + c2.getHex() );
+
+		} );
+
 		QUnit.test( 'setWithNum', ( assert ) => {
 
 			var c = new Color();

--- a/test/unit/src/math/Color.tests.js
+++ b/test/unit/src/math/Color.tests.js
@@ -1,7 +1,7 @@
 /* global QUnit */
 
 import { Color } from '../../../../src/math/Color.js';
-import { eps } from './Constants.tests.js';
+import { eps } from '../../utils/math-constants.js';
 import { CONSOLE_LEVEL } from '../../utils/console-wrapper.js';
 
 export default QUnit.module( 'Maths', () => {

--- a/test/unit/src/math/ColorManagement.tests.js
+++ b/test/unit/src/math/ColorManagement.tests.js
@@ -1,0 +1,59 @@
+/* global QUnit */
+
+import { ColorManagement } from '../../../../src/math/ColorManagement.js';
+
+export default QUnit.module( 'Maths', () => {
+
+	QUnit.module( 'ColorManagement', () => {
+
+		// PROPERTIES
+		QUnit.test( 'legacyMode', ( assert ) => {
+
+			assert.ok(
+				ColorManagement.legacyMode == true,
+				'ColorManagement.legacyMode is true by default.'
+			);
+
+		} );
+
+		QUnit.todo( 'workingColorSpace', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		// PUBLIC
+		QUnit.todo( 'convert', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'fromWorkingColorSpace', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'toWorkingColorSpace', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		// EXPORTED FUNCTIONS
+		QUnit.todo( 'SRGBToLinear', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'LinearToSRGB', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+	} );
+
+} );

--- a/test/unit/src/math/Cylindrical.tests.js
+++ b/test/unit/src/math/Cylindrical.tests.js
@@ -27,7 +27,7 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
-		// PUBLIC STUFF
+		// PUBLIC
 		QUnit.test( 'set', ( assert ) => {
 
 			var a = new Cylindrical();
@@ -88,6 +88,13 @@ export default QUnit.module( 'Maths', () => {
 			assert.ok( Math.abs( a.radius - expected.radius ) <= eps, 'Normal vector: check radius' );
 			assert.ok( Math.abs( a.theta - expected.theta ) <= eps, 'Normal vector: check theta' );
 			assert.ok( Math.abs( a.y - expected.y ) <= eps, 'Normal vector: check y' );
+
+		} );
+
+		QUnit.todo( 'setFromCartesianCoords', ( assert ) => {
+
+			// setFromCartesianCoords( x, y, z )
+			assert.ok( false, 'everything\'s gonna be alright' );
 
 		} );
 

--- a/test/unit/src/math/Cylindrical.tests.js
+++ b/test/unit/src/math/Cylindrical.tests.js
@@ -2,7 +2,7 @@
 
 import { Cylindrical } from '../../../../src/math/Cylindrical.js';
 import { Vector3 } from '../../../../src/math/Vector3.js';
-import { eps } from './Constants.tests.js';
+import { eps } from '../../utils/math-constants.js';
 
 export default QUnit.module( 'Maths', () => {
 

--- a/test/unit/src/math/Euler.tests.js
+++ b/test/unit/src/math/Euler.tests.js
@@ -208,7 +208,7 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
-		QUnit.test( 'Quaternion.setFromEuler/Euler.fromQuaternion', ( assert ) => {
+		QUnit.test( 'Quaternion.setFromEuler/Euler.setFromQuaternion', ( assert ) => {
 
 			var testValues = [ eulerZero, eulerAxyz, eulerAzyx ];
 			for ( var i = 0; i < testValues.length; i ++ ) {
@@ -224,7 +224,7 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
-		QUnit.test( 'Matrix4.setFromEuler/Euler.fromRotationMatrix', ( assert ) => {
+		QUnit.test( 'Matrix4.makeRotationFromEuler/Euler.setFromRotationMatrix', ( assert ) => {
 
 			var testValues = [ eulerZero, eulerAxyz, eulerAzyx ];
 			for ( var i = 0; i < testValues.length; i ++ ) {
@@ -237,6 +237,13 @@ export default QUnit.module( 'Maths', () => {
 				assert.ok( matrixEquals4( m, m2, 0.0001 ), 'Passed!' );
 
 			}
+
+		} );
+
+		QUnit.todo( 'Euler.setFromVector3', ( assert ) => {
+
+			// setFromVector3( v, order = this._order )
+			assert.ok( false, 'everything\'s gonna be alright' );
 
 		} );
 

--- a/test/unit/src/math/Euler.tests.js
+++ b/test/unit/src/math/Euler.tests.js
@@ -4,7 +4,7 @@ import { Euler } from '../../../../src/math/Euler.js';
 import { Matrix4 } from '../../../../src/math/Matrix4.js';
 import { Quaternion } from '../../../../src/math/Quaternion.js';
 import { Vector3 } from '../../../../src/math/Vector3.js';
-import { x, y, z } from './Constants.tests.js';
+import { x, y, z } from '../../utils/math-constants.js';
 
 const eulerZero = new Euler( 0, 0, 0, 'XYZ' );
 const eulerAxyz = new Euler( 1, 0, 0, 'XYZ' );

--- a/test/unit/src/math/Frustum.tests.js
+++ b/test/unit/src/math/Frustum.tests.js
@@ -49,7 +49,7 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
-		// PUBLIC STUFF
+		// PUBLIC
 		QUnit.test( 'set', ( assert ) => {
 
 			var a = new Frustum();
@@ -247,7 +247,8 @@ export default QUnit.module( 'Maths', () => {
 			intersects = a.intersectsBox( box );
 			assert.notOk( intersects, 'No intersection' );
 
-			// add eps so that we prevent box touching the frustum, which might intersect depending on floating point numerics
+			// add eps so that we prevent box touching the frustum,
+			// which might intersect depending on floating point numerics
 			box.translate( new Vector3( - 1 - eps, - 1 - eps, - 1 - eps ) );
 
 			intersects = a.intersectsBox( box );

--- a/test/unit/src/math/Frustum.tests.js
+++ b/test/unit/src/math/Frustum.tests.js
@@ -9,7 +9,7 @@ import { Matrix4 } from '../../../../src/math/Matrix4.js';
 import { Box3 } from '../../../../src/math/Box3.js';
 import { Mesh } from '../../../../src/objects/Mesh.js';
 import { BoxGeometry } from '../../../../src/geometries/BoxGeometry.js';
-import { zero3, one3, eps } from './Constants.tests.js';
+import { zero3, one3, eps } from '../../utils/math-constants.js';
 
 const unit3 = new Vector3( 1, 0, 0 );
 

--- a/test/unit/src/math/Interpolant.tests.js
+++ b/test/unit/src/math/Interpolant.tests.js
@@ -57,7 +57,11 @@ export default QUnit.module( 'Maths', () => {
 		QUnit.test( 'Instancing', ( assert ) => {
 
 			var interpolant = new Mock( null, [ 1, 11, 2, 22, 3, 33 ], 2, [] );
-			assert.ok( interpolant !== undefined, 'instanced.' );
+
+			assert.strictEqual(
+				interpolant instanceof Interpolant, true,
+				'Mock extends from Interpolant'
+			);
 
 		} );
 

--- a/test/unit/src/math/Interpolant.tests.js
+++ b/test/unit/src/math/Interpolant.tests.js
@@ -54,20 +54,52 @@ export default QUnit.module( 'Maths', () => {
 		// Tests
 
 		// INSTANCING
-		QUnit.todo( 'Instancing', ( assert ) => {
+		QUnit.test( 'Instancing', ( assert ) => {
+
+			var interpolant = new Mock( null, [ 1, 11, 2, 22, 3, 33 ], 2, [] );
+			assert.ok( interpolant !== undefined, 'instanced.' );
+
+		} );
+
+		// PROPERTIES
+		QUnit.todo( 'parameterPositions', ( assert ) => {
 
 			assert.ok( false, 'everything\'s gonna be alright' );
 
 		} );
 
-		// PUBLIC STUFF
+		QUnit.todo( 'resultBuffer', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'sampleValues', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'valueSize', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'settings', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		// PUBLIC
 		QUnit.todo( 'evaluate', ( assert ) => {
 
 			assert.ok( false, 'everything\'s gonna be alright' );
 
 		} );
 
-		// PRIVATE STUFF
+		// PRIVATE
 		QUnit.test( 'copySampleValue_', ( assert ) => {
 
 			var interpolant = new Mock( null, [ 1, 11, 2, 22, 3, 33 ], 2, [] );

--- a/test/unit/src/math/Line3.tests.js
+++ b/test/unit/src/math/Line3.tests.js
@@ -11,7 +11,7 @@ import {
 	zero3,
 	one3,
 	two3
-} from './Constants.tests.js';
+} from '../../utils/math-constants.js';
 
 export default QUnit.module( 'Maths', () => {
 

--- a/test/unit/src/math/MathUtils.tests.js
+++ b/test/unit/src/math/MathUtils.tests.js
@@ -69,6 +69,14 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
+		QUnit.test( 'pingpong', ( assert ) => {
+
+			assert.strictEqual( MathUtils.pingpong( 2.5 ), 0.5, 'Value at 2.5 is 0.5' );
+			assert.strictEqual( MathUtils.pingpong( 2.5, 2 ), 1.5, 'Value at 2.5 with length of 2 is 1.5' );
+			assert.strictEqual( MathUtils.pingpong( - 1.5 ), 0.5, 'Value at -1.5 is 0.5' );
+
+		} );
+
 		QUnit.test( 'smoothstep', ( assert ) => {
 
 			assert.strictEqual( MathUtils.smoothstep( - 1, 0, 2 ), 0, 'Value lower than minimum' );
@@ -122,6 +130,13 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
+		QUnit.todo( 'seededRandom', ( assert ) => {
+
+			// seededRandom( s ) // interval [ 0, 1 ]
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
 		QUnit.test( 'degToRad', ( assert ) => {
 
 			assert.strictEqual( MathUtils.degToRad( 0 ), 0, '0 degrees' );
@@ -166,12 +181,24 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
+		QUnit.todo( 'setQuaternionFromProperEuler', ( assert ) => {
 
-		QUnit.test( 'pingpong', ( assert ) => {
+			// setQuaternionFromProperEuler( q, a, b, c, order )
+			assert.ok( false, 'everything\'s gonna be alright' );
 
-			assert.strictEqual( MathUtils.pingpong( 2.5 ), 0.5, 'Value at 2.5 is 0.5' );
-			assert.strictEqual( MathUtils.pingpong( 2.5, 2 ), 1.5, 'Value at 2.5 with length of 2 is 1.5' );
-			assert.strictEqual( MathUtils.pingpong( - 1.5 ), 0.5, 'Value at -1.5 is 0.5' );
+		} );
+
+		QUnit.todo( 'denormalize', ( assert ) => {
+
+			// denormalize( value, array )
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'normalize', ( assert ) => {
+
+			// normalize( value, array )
+			assert.ok( false, 'everything\'s gonna be alright' );
 
 		} );
 

--- a/test/unit/src/math/Matrix3.tests.js
+++ b/test/unit/src/math/Matrix3.tests.js
@@ -147,6 +147,13 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
+		QUnit.todo( 'extractBasis', ( assert ) => {
+
+			// extractBasis( xAxis, yAxis, zAxis )
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
 		QUnit.test( 'setFromMatrix4', ( assert ) => {
 
 
@@ -425,6 +432,27 @@ export default QUnit.module( 'Maths', () => {
 
 			a.translate( 3, 7 );
 			assert.ok( matrixEquals3( a, expected ), 'Check translation result' );
+
+		} );
+
+		QUnit.todo( 'makeTranslation', ( assert ) => {
+
+			// makeTranslation( x, y )
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'makeRotation', ( assert ) => {
+
+			// makeRotation( theta ) // counterclockwise
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'makeScale', ( assert ) => {
+
+			// makeScale( x, y )
+			assert.ok( false, 'everything\'s gonna be alright' );
 
 		} );
 

--- a/test/unit/src/math/Matrix4.tests.js
+++ b/test/unit/src/math/Matrix4.tests.js
@@ -164,7 +164,7 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
-		QUnit.test( 'setFromMatrix4', ( assert ) => {
+		QUnit.test( 'setFromMatrix3', ( assert ) => {
 
 			var a = new Matrix3().set(
 				0, 1, 2,
@@ -264,6 +264,13 @@ export default QUnit.module( 'Maths', () => {
 				assert.ok( eulerEquals( v, v3, eps ), 'extractRotation #' + i + ': original and extracted Eulers are equal' );
 
 			}
+
+		} );
+
+		QUnit.todo( 'makeRotationFromQuaternion', ( assert ) => {
+
+			// makeRotationFromQuaternion( q )
+			assert.ok( false, 'everything\'s gonna be alright' );
 
 		} );
 

--- a/test/unit/src/math/Matrix4.tests.js
+++ b/test/unit/src/math/Matrix4.tests.js
@@ -6,7 +6,7 @@ import { Vector3 } from '../../../../src/math/Vector3.js';
 import { Euler } from '../../../../src/math/Euler.js';
 import { Quaternion } from '../../../../src/math/Quaternion.js';
 import * as MathUtils from '../../../../src/math/MathUtils.js';
-import { eps } from './Constants.tests.js';
+import { eps } from '../../utils/math-constants.js';
 
 
 function matrixEquals4( a, b, tolerance ) {

--- a/test/unit/src/math/Plane.tests.js
+++ b/test/unit/src/math/Plane.tests.js
@@ -220,7 +220,7 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
-		QUnit.test( 'isInterestionLine/intersectLine', ( assert ) => {
+		QUnit.test( 'intersectLine', ( assert ) => {
 
 			var a = new Plane( new Vector3( 1, 0, 0 ), 0 );
 			var point = new Vector3();
@@ -232,6 +232,13 @@ export default QUnit.module( 'Maths', () => {
 			var a = new Plane( new Vector3( 1, 0, 0 ), - 3 );
 			a.intersectLine( l1, point );
 			assert.ok( point.equals( new Vector3( 3, 0, 0 ) ), 'Passed!' );
+
+		} );
+
+		QUnit.todo( 'intersectsLine', ( assert ) => {
+
+			// intersectsLine( line ) // - boolean variant of above
+			assert.ok( false, 'everything\'s gonna be alright' );
 
 		} );
 

--- a/test/unit/src/math/Plane.tests.js
+++ b/test/unit/src/math/Plane.tests.js
@@ -13,7 +13,7 @@ import {
 	w,
 	zero3,
 	one3
-} from './Constants.tests.js';
+} from '../../utils/math-constants.js';
 
 function comparePlane( a, b, threshold ) {
 

--- a/test/unit/src/math/Quaternion.tests.js
+++ b/test/unit/src/math/Quaternion.tests.js
@@ -338,6 +338,13 @@ export default QUnit.module( 'Maths', () => {
 		} );
 
 		// PUBLIC STUFF
+		QUnit.test( 'isQuaternion', ( assert ) => {
+
+			const object = new Quaternion();
+			assert.ok( object.isQuaternion, 'Quaternion.isQuaternion should be true' );
+
+		} );
+
 		QUnit.test( 'set', ( assert ) => {
 
 			var a = new Quaternion();

--- a/test/unit/src/math/Quaternion.tests.js
+++ b/test/unit/src/math/Quaternion.tests.js
@@ -12,7 +12,7 @@ import {
 	z,
 	w,
 	eps
-} from './Constants.tests.js';
+} from '../../utils/math-constants.js';
 
 const orders = [ 'XYZ', 'YXZ', 'ZXY', 'ZYX', 'YZX', 'XZY' ];
 const eulerAngles = new Euler( 0.1, - 0.3, 0.25 );

--- a/test/unit/src/math/Ray.tests.js
+++ b/test/unit/src/math/Ray.tests.js
@@ -31,13 +31,7 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
-		// PUBLIC STUFF
-		QUnit.todo( 'isRay', ( assert ) => {
-
-			assert.ok( false, 'everything\'s gonna be alright' );
-
-		} );
-
+		// PUBLIC
 		QUnit.test( 'set', ( assert ) => {
 
 			var a = new Ray();

--- a/test/unit/src/math/Ray.tests.js
+++ b/test/unit/src/math/Ray.tests.js
@@ -12,7 +12,7 @@ import {
 	two3,
 	eps,
 	posInf3
-} from './Constants.tests.js';
+} from '../../utils/math-constants.js';
 
 export default QUnit.module( 'Maths', () => {
 

--- a/test/unit/src/math/Sphere.tests.js
+++ b/test/unit/src/math/Sphere.tests.js
@@ -29,13 +29,7 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
-		// PUBLIC STUFF
-		QUnit.todo( 'isSphere', ( assert ) => {
-
-			assert.ok( false, 'everything\'s gonna be alright' );
-
-		} );
-
+		// PUBLIC
 		QUnit.test( 'set', ( assert ) => {
 
 			var a = new Sphere();

--- a/test/unit/src/math/Sphere.tests.js
+++ b/test/unit/src/math/Sphere.tests.js
@@ -10,7 +10,7 @@ import {
 	one3,
 	two3,
 	eps
-} from './Constants.tests.js';
+} from '../../utils/math-constants.js';
 
 export default QUnit.module( 'Maths', () => {
 

--- a/test/unit/src/math/Spherical.tests.js
+++ b/test/unit/src/math/Spherical.tests.js
@@ -4,7 +4,7 @@ import { Spherical } from '../../../../src/math/Spherical.js';
 import { Vector3 } from '../../../../src/math/Vector3.js';
 import {
 	eps
-} from './Constants.tests.js';
+} from '../../utils/math-constants.js';
 
 export default QUnit.module( 'Maths', () => {
 

--- a/test/unit/src/math/Spherical.tests.js
+++ b/test/unit/src/math/Spherical.tests.js
@@ -30,12 +30,6 @@ export default QUnit.module( 'Maths', () => {
 		} );
 
 		// PUBLIC STUFF
-		QUnit.todo( 'isSpherical', ( assert ) => {
-
-			assert.ok( false, 'everything\'s gonna be alright' );
-
-		} );
-
 		QUnit.test( 'set', ( assert ) => {
 
 			var a = new Spherical();
@@ -114,6 +108,23 @@ export default QUnit.module( 'Maths', () => {
 			assert.strictEqual( a.theta, 0, 'Zero-length vector: check theta' );
 
 			a.setFromVector3( c );
+			assert.ok( Math.abs( a.radius - expected.radius ) <= eps, 'Normal vector: check radius' );
+			assert.ok( Math.abs( a.phi - expected.phi ) <= eps, 'Normal vector: check phi' );
+			assert.ok( Math.abs( a.theta - expected.theta ) <= eps, 'Normal vector: check theta' );
+
+		} );
+
+		QUnit.test( 'setFromCartesianCoords', ( assert ) => {
+
+			var a = new Spherical( 1, 1, 1 );
+			var expected = new Spherical( 4.554032147688322, 1.3494066171539107, 2.356194490192345 );
+
+			a.setFromCartesianCoords( 0, 0, 0 );
+			assert.strictEqual( a.radius, 0, 'Zero-length vector: check radius' );
+			assert.strictEqual( a.phi, 0, 'Zero-length vector: check phi' );
+			assert.strictEqual( a.theta, 0, 'Zero-length vector: check theta' );
+
+			a.setFromCartesianCoords( Math.PI, 1, - Math.PI );
 			assert.ok( Math.abs( a.radius - expected.radius ) <= eps, 'Normal vector: check radius' );
 			assert.ok( Math.abs( a.phi - expected.phi ) <= eps, 'Normal vector: check phi' );
 			assert.ok( Math.abs( a.theta - expected.theta ) <= eps, 'Normal vector: check theta' );

--- a/test/unit/src/math/SphericalHarmonics3.tests.js
+++ b/test/unit/src/math/SphericalHarmonics3.tests.js
@@ -1,0 +1,121 @@
+/* global QUnit */
+
+import { SphericalHarmonics3 } from '../../../../src/math/SphericalHarmonics3.js';
+
+export default QUnit.module( 'Maths', () => {
+
+	QUnit.module( 'SphericalHarmonics3', () => {
+
+		// INSTANCING
+		QUnit.todo( 'Instancing', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		// PROPERTIES
+		QUnit.todo( 'coefficients', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		// PUBLIC
+		QUnit.test( 'isSphericalHarmonics3', ( assert ) => {
+
+			const object = new SphericalHarmonics3();
+			assert.ok(
+				object.isSphericalHarmonics3,
+				'SphericalHarmonics3.isSphericalHarmonics3 should be true'
+			);
+
+		} );
+
+		QUnit.todo( 'set', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'zero', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'getAt', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'getIrradianceAt', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'add', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'addScaledSH', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'scale', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'lerp', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'equals', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'copy', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'clone', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'fromArray', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'toArray', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		// PUBLIC - STATIC
+		QUnit.todo( 'getBasisAt', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+	} );
+
+} );

--- a/test/unit/src/math/Triangle.tests.js
+++ b/test/unit/src/math/Triangle.tests.js
@@ -30,7 +30,7 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
-		// STATIC STUFF
+		// STATIC
 		QUnit.todo( 'getNormal', ( assert ) => {
 
 			assert.ok( false, 'everything\'s gonna be alright' );
@@ -49,7 +49,23 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
-		// PUBLIC STUFF
+		QUnit.todo( 'getUV', ( assert ) => {
+
+			// static version of class member below
+			// getUV( point, p1, p2, p3, uv1, uv2, uv3, target )
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'isFrontFacing', ( assert ) => {
+
+			// static version of class member below
+			// isFrontFacing( a, b, c, direction )
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		// PUBLIC
 		QUnit.test( 'set', ( assert ) => {
 
 			var a = new Triangle();
@@ -229,6 +245,14 @@ export default QUnit.module( 'Maths', () => {
 			assert.ok( barycoord.equals( new Vector3( 0, 0, 1 ) ), 'Passed!' );
 			a.getBarycoord( midpoint, barycoord );
 			assert.ok( barycoord.distanceTo( new Vector3( 1 / 3, 1 / 3, 1 / 3 ) ) < 0.0001, 'Passed!' );
+
+		} );
+
+		QUnit.todo( 'getUV', ( assert ) => {
+
+			// class member version
+			// getUV( point, uv1, uv2, uv3, target )
+			assert.ok( false, 'everything\'s gonna be alright' );
 
 		} );
 

--- a/test/unit/src/math/Triangle.tests.js
+++ b/test/unit/src/math/Triangle.tests.js
@@ -9,7 +9,7 @@ import {
 	zero3,
 	one3,
 	two3
-} from './Constants.tests.js';
+} from '../../utils/math-constants.js';
 
 export default QUnit.module( 'Maths', () => {
 

--- a/test/unit/src/math/Vector2.tests.js
+++ b/test/unit/src/math/Vector2.tests.js
@@ -55,9 +55,10 @@ export default QUnit.module( 'Maths', () => {
 		} );
 
 		// PUBLIC STUFF
-		QUnit.todo( 'isVector2', ( assert ) => {
+		QUnit.test( 'isVector2', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const object = new Vector2();
+			assert.ok( object.isVector2, 'Vector2.isVector2 should be true' );
 
 		} );
 
@@ -500,6 +501,7 @@ export default QUnit.module( 'Maths', () => {
 			assert.ok( a.y == y, 'Passed!' );
 
 		} );
+
 		QUnit.test( 'setComponent,getComponent', ( assert ) => {
 
 			var a = new Vector2();
@@ -512,6 +514,7 @@ export default QUnit.module( 'Maths', () => {
 			assert.ok( a.getComponent( 1 ) == 2, 'Passed!' );
 
 		} );
+
 		QUnit.test( 'multiply/divide', ( assert ) => {
 
 			var a = new Vector2( x, y );
@@ -534,6 +537,7 @@ export default QUnit.module( 'Maths', () => {
 			assert.ok( b.y == - y, 'Passed!' );
 
 		} );
+
 		QUnit.test( 'min/max/clamp', ( assert ) => {
 
 			var a = new Vector2( x, y );
@@ -559,6 +563,7 @@ export default QUnit.module( 'Maths', () => {
 			assert.equal( c.y, x, 'scalar clamp y' );
 
 		} );
+
 		QUnit.test( 'rounding', ( assert ) => {
 
 			assert.deepEqual( new Vector2( - 0.1, 0.1 ).floor(), new Vector2( - 1, 0 ), 'floor .1' );
@@ -581,6 +586,7 @@ export default QUnit.module( 'Maths', () => {
 			assert.deepEqual( new Vector2( - 1.9, 1.9 ).roundToZero(), new Vector2( - 1, 1 ), 'roundToZero 1.9' );
 
 		} );
+
 		QUnit.test( 'length/lengthSq', ( assert ) => {
 
 			var a = new Vector2( x, 0 );
@@ -599,6 +605,7 @@ export default QUnit.module( 'Maths', () => {
 			assert.ok( a.lengthSq() == ( x * x + y * y ), 'Passed!' );
 
 		} );
+
 		QUnit.test( 'distanceTo/distanceToSquared', ( assert ) => {
 
 			var a = new Vector2( x, 0 );
@@ -612,6 +619,7 @@ export default QUnit.module( 'Maths', () => {
 			assert.ok( b.distanceToSquared( c ) == y * y, 'Passed!' );
 
 		} );
+
 		QUnit.test( 'lerp/clone', ( assert ) => {
 
 			var a = new Vector2( x, 0 );
@@ -628,6 +636,7 @@ export default QUnit.module( 'Maths', () => {
 			assert.ok( a.clone().lerp( b, 1 ).equals( b ), 'Passed!' );
 
 		} );
+
 		QUnit.test( 'setComponent/getComponent exceptions', ( assert ) => {
 
 			var a = new Vector2( 0, 0 );
@@ -652,6 +661,7 @@ export default QUnit.module( 'Maths', () => {
 			);
 
 		} );
+
 		QUnit.test( 'setScalar/addScalar/subScalar', ( assert ) => {
 
 			var a = new Vector2( 1, 1 );
@@ -670,6 +680,7 @@ export default QUnit.module( 'Maths', () => {
 			assert.strictEqual( a.y, 0, 'subScalar: check y' );
 
 		} );
+
 		QUnit.test( 'multiply/divide', ( assert ) => {
 
 			var a = new Vector2( x, y );
@@ -686,6 +697,7 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
+		// OTHERS
 		QUnit.test( 'iterable', ( assert ) => {
 
 			var v = new Vector2( 0, 1 );

--- a/test/unit/src/math/Vector2.tests.js
+++ b/test/unit/src/math/Vector2.tests.js
@@ -7,7 +7,7 @@ import {
 	x,
 	y,
 	eps
-} from './Constants.tests.js';
+} from '../../utils/math-constants.js';
 
 export default QUnit.module( 'Maths', () => {
 

--- a/test/unit/src/math/Vector3.tests.js
+++ b/test/unit/src/math/Vector3.tests.js
@@ -16,7 +16,7 @@ import {
 	z,
 	w,
 	eps
-} from './Constants.tests.js';
+} from '../../utils/math-constants.js';
 
 export default QUnit.module( 'Maths', () => {
 

--- a/test/unit/src/math/Vector3.tests.js
+++ b/test/unit/src/math/Vector3.tests.js
@@ -38,9 +38,10 @@ export default QUnit.module( 'Maths', () => {
 		} );
 
 		// PUBLIC STUFF
-		QUnit.todo( 'isVector3', ( assert ) => {
+		QUnit.test( 'isVector3', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const object = new Vector3();
+			assert.ok( object.isVector3, 'Vector3.isVector3 should be true' );
 
 		} );
 
@@ -249,6 +250,13 @@ export default QUnit.module( 'Maths', () => {
 			assert.strictEqual( a.x, 33, 'Check x' );
 			assert.strictEqual( a.y, 99, 'Check y' );
 			assert.strictEqual( a.z, 183, 'Check z' );
+
+		} );
+
+		QUnit.todo( 'applyNormalMatrix', ( assert ) => {
+
+			// applyNormalMatrix( m )
+			assert.ok( false, 'everything\'s gonna be alright' );
 
 		} );
 
@@ -638,6 +646,13 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
+		QUnit.todo( 'setFromSphericalCoords', ( assert ) => {
+
+			// setFromSphericalCoords( radius, phi, theta )
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
 		QUnit.test( 'setFromCylindrical', ( assert ) => {
 
 			var a = new Vector3();
@@ -648,6 +663,13 @@ export default QUnit.module( 'Maths', () => {
 			assert.ok( Math.abs( a.x - expected.x ) <= eps, 'Check x' );
 			assert.ok( Math.abs( a.y - expected.y ) <= eps, 'Check y' );
 			assert.ok( Math.abs( a.z - expected.z ) <= eps, 'Check z' );
+
+		} );
+
+		QUnit.todo( 'setFromCylindricalCoords', ( assert ) => {
+
+			// setFromCylindricalCoords( radius, theta, y )
+			assert.ok( false, 'everything\'s gonna be alright' );
 
 		} );
 
@@ -690,6 +712,20 @@ export default QUnit.module( 'Maths', () => {
 			assert.strictEqual( a.x, 5, 'Index 2: check x' );
 			assert.strictEqual( a.y, 17, 'Index 2: check y' );
 			assert.strictEqual( a.z, 31, 'Index 2: check z' );
+
+		} );
+
+		QUnit.todo( 'setFromMatrix3Column', ( assert ) => {
+
+			// setFromMatrix3Column( mat3, index )
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'setFromEuler', ( assert ) => {
+
+			// setFromEuler( e )
+			assert.ok( false, 'everything\'s gonna be alright' );
 
 		} );
 
@@ -773,6 +809,30 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
+		QUnit.todo( 'random', ( assert ) => {
+
+			// random()
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.test( 'randomDirection', ( assert ) => {
+
+			var vec = new Vector3();
+
+			vec.randomDirection();
+
+			var zero = new Vector3();
+			assert.notDeepEqual(
+				vec,
+				zero,
+				'randomizes at least one component of the vector'
+			);
+
+			assert.ok( ( 1 - vec.length() ) <= Number.EPSILON, 'produces a unit vector' );
+
+		} );
+
 		// TODO (Itee) refactor/split
 		QUnit.test( 'setX,setY,setZ', ( assert ) => {
 
@@ -790,6 +850,7 @@ export default QUnit.module( 'Maths', () => {
 			assert.ok( a.z == z, 'Passed!' );
 
 		} );
+
 		QUnit.test( 'setComponent,getComponent', ( assert ) => {
 
 			var a = new Vector3();
@@ -805,6 +866,7 @@ export default QUnit.module( 'Maths', () => {
 			assert.ok( a.getComponent( 2 ) == 3, 'Passed!' );
 
 		} );
+
 		QUnit.test( 'setComponent/getComponent exceptions', ( assert ) => {
 
 			var a = new Vector3();
@@ -829,6 +891,7 @@ export default QUnit.module( 'Maths', () => {
 			);
 
 		} );
+
 		QUnit.test( 'min/max/clamp', ( assert ) => {
 
 			var a = new Vector3( x, y, z );
@@ -852,6 +915,7 @@ export default QUnit.module( 'Maths', () => {
 			assert.ok( c.z == - z, 'Passed!' );
 
 		} );
+
 		QUnit.test( 'distanceTo/distanceToSquared', ( assert ) => {
 
 			var a = new Vector3( x, 0, 0 );
@@ -869,6 +933,7 @@ export default QUnit.module( 'Maths', () => {
 			assert.ok( c.distanceToSquared( d ) == z * z, 'Passed!' );
 
 		} );
+
 		QUnit.test( 'setScalar/addScalar/subScalar', ( assert ) => {
 
 			var a = new Vector3();
@@ -890,6 +955,7 @@ export default QUnit.module( 'Maths', () => {
 			assert.strictEqual( a.z, 0, 'subScalar: check z' );
 
 		} );
+
 		QUnit.test( 'multiply/divide', ( assert ) => {
 
 			var a = new Vector3( x, y, z );
@@ -907,6 +973,7 @@ export default QUnit.module( 'Maths', () => {
 			assert.ok( Math.abs( b.z - 0.5 ) <= eps, 'divide: check z' );
 
 		} );
+
 		QUnit.test( 'multiply/divide', ( assert ) => {
 
 			var a = new Vector3( x, y, z );
@@ -933,6 +1000,7 @@ export default QUnit.module( 'Maths', () => {
 			assert.ok( b.z == - z, 'Passed!' );
 
 		} );
+
 		QUnit.test( 'project/unproject', ( assert ) => {
 
 			var a = new Vector3( x, y, z );
@@ -950,6 +1018,7 @@ export default QUnit.module( 'Maths', () => {
 			assert.ok( Math.abs( a.z - z ) <= eps, 'unproject: check z' );
 
 		} );
+
 		QUnit.test( 'length/lengthSq', ( assert ) => {
 
 			var a = new Vector3( x, 0, 0 );
@@ -971,6 +1040,7 @@ export default QUnit.module( 'Maths', () => {
 			assert.ok( a.lengthSq() == ( x * x + y * y + z * z ), 'Passed!' );
 
 		} );
+
 		QUnit.test( 'lerp/clone', ( assert ) => {
 
 			var a = new Vector3( x, 0, z );
@@ -989,23 +1059,7 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
-		QUnit.test( 'randomDirection', ( assert ) => {
-
-			var vec = new Vector3();
-
-			vec.randomDirection();
-
-			var zero = new Vector3();
-			assert.notDeepEqual(
-				vec,
-				zero,
-				'randomizes at least one component of the vector'
-			);
-
-			assert.ok( ( 1 - vec.length() ) <= Number.EPSILON, 'produces a unit vector' );
-
-		} );
-
+		// OTHERS
 		QUnit.test( 'iterable', ( assert ) => {
 
 			var v = new Vector3( 0, 0.5, 1 );

--- a/test/unit/src/math/Vector4.tests.js
+++ b/test/unit/src/math/Vector4.tests.js
@@ -33,9 +33,10 @@ export default QUnit.module( 'Maths', () => {
 		} );
 
 		// PUBLIC STUFF
-		QUnit.todo( 'isVector4', ( assert ) => {
+		QUnit.test( 'isVector4', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const object = new Vector4();
+			assert.ok( object.isVector4, 'Vector4.isVector4 should be true' );
 
 		} );
 
@@ -61,27 +62,43 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
-		QUnit.todo( 'setX', ( assert ) => {
+		QUnit.test( 'setX', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			var a = new Vector4();
+			assert.ok( a.x == 0, 'Passed!' );
 
-		} );
-
-		QUnit.todo( 'setY', ( assert ) => {
-
-			assert.ok( false, 'everything\'s gonna be alright' );
+			a.setX( x );
+			assert.ok( a.x == x, 'Passed!' );
 
 		} );
 
-		QUnit.todo( 'setZ', ( assert ) => {
+		QUnit.test( 'setY', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			var a = new Vector4();
+			assert.ok( a.y == 0, 'Passed!' );
+
+			a.setY( y );
+			assert.ok( a.y == y, 'Passed!' );
 
 		} );
 
-		QUnit.todo( 'setW', ( assert ) => {
+		QUnit.test( 'setZ', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			var a = new Vector4();
+			assert.ok( a.z == 0, 'Passed!' );
+
+			a.setZ( z );
+			assert.ok( a.z == z, 'Passed!' );
+
+		} );
+
+		QUnit.test( 'setW', ( assert ) => {
+
+			var a = new Vector4();
+			assert.ok( a.w == 1, 'Passed!' );
+
+			a.setW( w );
+			assert.ok( a.w == w, 'Passed!' );
 
 		} );
 
@@ -126,20 +143,14 @@ export default QUnit.module( 'Maths', () => {
 
 		QUnit.test( 'add', ( assert ) => {
 
-			var a = new Vector4( x, y, z, w );
-			var b = new Vector4( - x, - y, - z, - w );
+			const a = new Vector4( x, y, z, w );
+			const b = new Vector4( - x, - y, - z, - w );
 
 			a.add( b );
 			assert.ok( a.x == 0, 'Passed!' );
 			assert.ok( a.y == 0, 'Passed!' );
 			assert.ok( a.z == 0, 'Passed!' );
 			assert.ok( a.w == 0, 'Passed!' );
-
-			var c = new Vector4().addVectors( b, b );
-			assert.ok( c.x == - 2 * x, 'Passed!' );
-			assert.ok( c.y == - 2 * y, 'Passed!' );
-			assert.ok( c.z == - 2 * z, 'Passed!' );
-			assert.ok( c.w == - 2 * w, 'Passed!' );
 
 		} );
 
@@ -149,9 +160,15 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
-		QUnit.todo( 'addVectors', ( assert ) => {
+		QUnit.test( 'addVectors', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const b = new Vector4( - x, - y, - z, - w );
+			const c = new Vector4().addVectors( b, b );
+
+			assert.ok( c.x == - 2 * x, 'Passed!' );
+			assert.ok( c.y == - 2 * y, 'Passed!' );
+			assert.ok( c.z == - 2 * z, 'Passed!' );
+			assert.ok( c.w == - 2 * w, 'Passed!' );
 
 		} );
 
@@ -171,20 +188,14 @@ export default QUnit.module( 'Maths', () => {
 
 		QUnit.test( 'sub', ( assert ) => {
 
-			var a = new Vector4( x, y, z, w );
-			var b = new Vector4( - x, - y, - z, - w );
+			const a = new Vector4( x, y, z, w );
+			const b = new Vector4( - x, - y, - z, - w );
 
 			a.sub( b );
 			assert.ok( a.x == 2 * x, 'Passed!' );
 			assert.ok( a.y == 2 * y, 'Passed!' );
 			assert.ok( a.z == 2 * z, 'Passed!' );
 			assert.ok( a.w == 2 * w, 'Passed!' );
-
-			var c = new Vector4().subVectors( a, a );
-			assert.ok( c.x == 0, 'Passed!' );
-			assert.ok( c.y == 0, 'Passed!' );
-			assert.ok( c.z == 0, 'Passed!' );
-			assert.ok( c.w == 0, 'Passed!' );
 
 		} );
 
@@ -194,7 +205,18 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
-		QUnit.todo( 'subVectors', ( assert ) => {
+		QUnit.test( 'subVectors', ( assert ) => {
+
+			const a = new Vector4( x, y, z, w );
+			const c = new Vector4().subVectors( a, a );
+			assert.ok( c.x == 0, 'Passed!' );
+			assert.ok( c.y == 0, 'Passed!' );
+			assert.ok( c.z == 0, 'Passed!' );
+			assert.ok( c.w == 0, 'Passed!' );
+
+		} );
+
+		QUnit.todo( 'multiply', ( assert ) => {
 
 			assert.ok( false, 'everything\'s gonna be alright' );
 
@@ -552,6 +574,7 @@ export default QUnit.module( 'Maths', () => {
 			assert.ok( a.w == w, 'Passed!' );
 
 		} );
+
 		QUnit.test( 'setComponent,getComponent', ( assert ) => {
 
 			var a = new Vector4();
@@ -570,6 +593,7 @@ export default QUnit.module( 'Maths', () => {
 			assert.ok( a.getComponent( 3 ) == 4, 'Passed!' );
 
 		} );
+
 		QUnit.test( 'setComponent/getComponent exceptions', ( assert ) => {
 
 			var a = new Vector4();
@@ -594,6 +618,7 @@ export default QUnit.module( 'Maths', () => {
 			);
 
 		} );
+
 		QUnit.test( 'setScalar/addScalar/subScalar', ( assert ) => {
 
 			var a = new Vector4();
@@ -618,7 +643,8 @@ export default QUnit.module( 'Maths', () => {
 			assert.strictEqual( a.w, 0, 'subScalar: check w' );
 
 		} );
-		QUnit.test( 'multiply/divide', ( assert ) => {
+
+		QUnit.test( 'multiplyScalar/divideScalar', ( assert ) => {
 
 			var a = new Vector4( x, y, z, w );
 			var b = new Vector4( - x, - y, - z, - w );
@@ -648,6 +674,7 @@ export default QUnit.module( 'Maths', () => {
 			assert.ok( b.w == - w, 'Passed!' );
 
 		} );
+
 		QUnit.test( 'min/max/clamp', ( assert ) => {
 
 			var a = new Vector4( x, y, z, w );
@@ -674,6 +701,7 @@ export default QUnit.module( 'Maths', () => {
 			assert.ok( c.w == w, 'Passed!' );
 
 		} );
+
 		QUnit.test( 'length/lengthSq', ( assert ) => {
 
 			var a = new Vector4( x, 0, 0, 0 );
@@ -698,6 +726,7 @@ export default QUnit.module( 'Maths', () => {
 			assert.ok( a.lengthSq() == ( x * x + y * y + z * z + w * w ), 'Passed!' );
 
 		} );
+
 		QUnit.test( 'lerp/clone', ( assert ) => {
 
 			var a = new Vector4( x, 0, z, 0 );
@@ -717,6 +746,7 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
+		// OTHERS
 		QUnit.test( 'iterable', ( assert ) => {
 
 			var v = new Vector4( 0, 0.3, 0.7, 1 );

--- a/test/unit/src/math/Vector4.tests.js
+++ b/test/unit/src/math/Vector4.tests.js
@@ -9,7 +9,7 @@ import {
 	z,
 	w,
 	eps
-} from './Constants.tests.js';
+} from '../../utils/math-constants.js';
 
 export default QUnit.module( 'Maths', () => {
 

--- a/test/unit/src/math/interpolants/CubicInterpolant.tests.js
+++ b/test/unit/src/math/interpolants/CubicInterpolant.tests.js
@@ -1,6 +1,8 @@
 /* global QUnit */
 
-// import { CubicInterpolant } from '../../../../../src/math/interpolants/CubicInterpolant.js';
+import { CubicInterpolant } from '../../../../../src/math/interpolants/CubicInterpolant.js';
+
+import { Interpolant } from '../../../../../src/math/Interpolant.js';
 
 export default QUnit.module( 'Maths', () => {
 
@@ -9,15 +11,36 @@ export default QUnit.module( 'Maths', () => {
 		QUnit.module( 'CubicInterpolant', () => {
 
 			// INHERITANCE
-			QUnit.todo( 'Extending', ( assert ) => {
+			QUnit.test( 'Extending', ( assert ) => {
 
-				assert.ok( false, 'everything\'s gonna be alright' );
+				var object = new CubicInterpolant( null, [ 1, 11, 2, 22, 3, 33 ], 2, [] );
+
+				assert.strictEqual(
+					object instanceof Interpolant, true,
+					'CubicInterpolant extends from Interpolant'
+				);
 
 			} );
 
 			// INSTANCING
 			QUnit.todo( 'Instancing', ( assert ) => {
 
+				assert.ok( false, 'everything\'s gonna be alright' );
+
+			} );
+
+			// PRIVATE - TEMPLATE METHODS
+			QUnit.todo( 'intervalChanged_', ( assert ) => {
+
+				// intervalChanged_( i1, t0, t1 )
+				assert.ok( false, 'everything\'s gonna be alright' );
+
+			} );
+
+			QUnit.todo( 'interpolate_', ( assert ) => {
+
+				// interpolate_( i1, t0, t, t1 )
+				// return equal to base class Interpolant.resultBuffer after call
 				assert.ok( false, 'everything\'s gonna be alright' );
 
 			} );

--- a/test/unit/src/math/interpolants/DiscreteInterpolant.tests.js
+++ b/test/unit/src/math/interpolants/DiscreteInterpolant.tests.js
@@ -1,6 +1,8 @@
 /* global QUnit */
 
-// import { DiscreteInterpolant } from '../../../../../src/math/interpolants/DiscreteInterpolant.js';
+import { DiscreteInterpolant } from '../../../../../src/math/interpolants/DiscreteInterpolant.js';
+
+import { Interpolant } from '../../../../../src/math/Interpolant.js';
 
 export default QUnit.module( 'Maths', () => {
 
@@ -9,15 +11,29 @@ export default QUnit.module( 'Maths', () => {
 		QUnit.module( 'DiscreteInterpolant', () => {
 
 			// INHERITANCE
-			QUnit.todo( 'Extending', ( assert ) => {
+			QUnit.test( 'Extending', ( assert ) => {
 
-				assert.ok( false, 'everything\'s gonna be alright' );
+				var object = new DiscreteInterpolant( null, [ 1, 11, 2, 22, 3, 33 ], 2, [] );
+
+				assert.strictEqual(
+					object instanceof Interpolant, true,
+					'DiscreteInterpolant extends from Interpolant'
+				);
 
 			} );
 
 			// INSTANCING
 			QUnit.todo( 'Instancing', ( assert ) => {
 
+				assert.ok( false, 'everything\'s gonna be alright' );
+
+			} );
+
+			// PRIVATE - TEMPLATE METHODS
+			QUnit.todo( 'interpolate_', ( assert ) => {
+
+				// interpolate_( i1 /*, t0, t, t1 */ )
+				// return equal to base class Interpolant.resultBuffer after call
 				assert.ok( false, 'everything\'s gonna be alright' );
 
 			} );

--- a/test/unit/src/math/interpolants/LinearInterpolant.tests.js
+++ b/test/unit/src/math/interpolants/LinearInterpolant.tests.js
@@ -1,6 +1,8 @@
 /* global QUnit */
 
-// import { LinearInterpolant } from '../../../../../src/math/interpolants/LinearInterpolant.js';
+import { LinearInterpolant } from '../../../../../src/math/interpolants/LinearInterpolant.js';
+
+import { Interpolant } from '../../../../../src/math/Interpolant.js';
 
 export default QUnit.module( 'Maths', () => {
 
@@ -9,15 +11,29 @@ export default QUnit.module( 'Maths', () => {
 		QUnit.module( 'LinearInterpolant', () => {
 
 			// INHERITANCE
-			QUnit.todo( 'Extending', ( assert ) => {
+			QUnit.test( 'Extending', ( assert ) => {
 
-				assert.ok( false, 'everything\'s gonna be alright' );
+				var object = new LinearInterpolant( null, [ 1, 11, 2, 22, 3, 33 ], 2, [] );
+
+				assert.strictEqual(
+					object instanceof Interpolant, true,
+					'LinearInterpolant extends from Interpolant'
+				);
 
 			} );
 
 			// INSTANCING
 			QUnit.todo( 'Instancing', ( assert ) => {
 
+				assert.ok( false, 'everything\'s gonna be alright' );
+
+			} );
+
+			// PRIVATE - TEMPLATE METHODS
+			QUnit.todo( 'interpolate_', ( assert ) => {
+
+				// interpolate_( i1, t0, t, t1 )
+				// return equal to base class Interpolant.resultBuffer after call
 				assert.ok( false, 'everything\'s gonna be alright' );
 
 			} );

--- a/test/unit/src/math/interpolants/QuaternionLinearInterpolant.tests.js
+++ b/test/unit/src/math/interpolants/QuaternionLinearInterpolant.tests.js
@@ -1,6 +1,8 @@
 /* global QUnit */
 
-// import { QuaternionLinearInterpolant } from '../../../../../src/math/interpolants/QuaternionLinearInterpolant.js';
+import { QuaternionLinearInterpolant } from '../../../../../src/math/interpolants/QuaternionLinearInterpolant.js';
+
+import { Interpolant } from '../../../../../src/math/Interpolant.js';
 
 export default QUnit.module( 'Maths', () => {
 
@@ -9,15 +11,29 @@ export default QUnit.module( 'Maths', () => {
 		QUnit.module( 'QuaternionLinearInterpolant', () => {
 
 			// INHERITANCE
-			QUnit.todo( 'Extending', ( assert ) => {
+			QUnit.test( 'Extending', ( assert ) => {
 
-				assert.ok( false, 'everything\'s gonna be alright' );
+				var object = new QuaternionLinearInterpolant( null, [ 1, 11, 2, 22, 3, 33 ], 2, [] );
+
+				assert.strictEqual(
+					object instanceof Interpolant, true,
+					'QuaternionLinearInterpolant extends from Interpolant'
+				);
 
 			} );
 
 			// INSTANCING
 			QUnit.todo( 'Instancing', ( assert ) => {
 
+				assert.ok( false, 'everything\'s gonna be alright' );
+
+			} );
+
+			// PRIVATE - TEMPLATE METHODS
+			QUnit.todo( 'interpolate_', ( assert ) => {
+
+				// interpolate_( i1, t0, t, t1 )
+				// return equal to base class Interpolant.resultBuffer after call
 				assert.ok( false, 'everything\'s gonna be alright' );
 
 			} );

--- a/test/unit/three.source.unit.js
+++ b/test/unit/three.source.unit.js
@@ -177,6 +177,7 @@ import './src/materials/SpriteMaterial.tests.js';
 import './src/math/Box2.tests.js';
 import './src/math/Box3.tests.js';
 import './src/math/Color.tests.js';
+import './src/math/ColorManagement.tests.js';
 import './src/math/Cylindrical.tests.js';
 import './src/math/Euler.tests.js';
 import './src/math/Frustum.tests.js';

--- a/test/unit/three.source.unit.js
+++ b/test/unit/three.source.unit.js
@@ -191,6 +191,7 @@ import './src/math/Quaternion.tests.js';
 import './src/math/Ray.tests.js';
 import './src/math/Sphere.tests.js';
 import './src/math/Spherical.tests.js';
+import './src/math/SphericalHarmonics3.tests.js';
 import './src/math/Triangle.tests.js';
 import './src/math/Vector2.tests.js';
 import './src/math/Vector3.tests.js';

--- a/test/unit/utils/math-constants.js
+++ b/test/unit/utils/math-constants.js
@@ -1,5 +1,5 @@
-import { Vector2 } from '../../../../src/math/Vector2.js';
-import { Vector3 } from '../../../../src/math/Vector3.js';
+import { Vector2 } from '../../../src/math/Vector2.js';
+import { Vector3 } from '../../../src/math/Vector3.js';
 
 export const x = 2;
 export const y = 3;


### PR DESCRIPTION
Related issue: #XXXX

**Description**

This cleans up the unit tests for Math.
Adds missing unit test files, fills in some unit tests, populates the missing member tests with stubs.

A test fixture, 'math/Constants.tests.js' wasnt a test file but a set of fixures used by:

animation/AnimationMixer.tests.js
core/BufferGeometry.tests.js
core/Object3D.tests.js
core/Uniform.tests.js
math/Box2.tests.js
math/Box3.tests.js
math/Color.tests.js
math/Cylindrical.tests.js
math/Euler.tests.js
math/Frustum.tests.js
math/Line3.tests.js
math/Matrix4.tests.js
math/Plane.tests.js
math/Quaternion.tests.js
math/Ray.tests.js
math/Sphere.tests.js
math/Spherical.tests.js
math/Triangle.tests.js
math/Vector2.tests.js
math/Vector3.tests.js
math/Vector4.tests.js

Shared math constants for tests moved to utils.  Only tests in test source.  This also removes the confusion with the actual 'Constants.tests.js' file in the parent directory.