### PR TITLE
Puppeteer E2E test: Bug fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os: [ windows-latest, ubuntu-latest ]
         CI: [ 0, 1, 2, 3, 4, 5, 6, 7 ]
-        os: [ windows-latest, ubuntu-latest, macos-latest ]
     env:
       CI: ${{ matrix.CI }}
       FORCE_COLOR: 1

--- a/test/e2e/puppeteer.js
+++ b/test/e2e/puppeteer.js
@@ -248,7 +248,15 @@ async function preparePage( page, injection, build, errorMessages ) {
 
 		}
 
-		let text = ( await Promise.all( msg.args().map( arg => arg.executionContext().evaluate( arg => arg instanceof Error ? arg.message : arg, arg ) ) ) ).join( ' ' ); // https://github.com/puppeteer/puppeteer/issues/3397#issuecomment-434970058
+		const args = await Promise.all( msg.args().map( async arg => {
+			try {
+				return await arg.executionContext().evaluate( arg => arg instanceof Error ? arg.message : arg, arg );
+			} catch (e) { // Execution context might have been already destroyed
+				return arg;
+			}
+		} ) );
+
+		let text = args.join( ' ' ); // https://github.com/puppeteer/puppeteer/issues/3397#issuecomment-434970058
 
 		text = text.trim();
 		if ( text === '' ) return;


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/25386

**Description**

Fix the "Execution context was destroyed" error introduced in https://github.com/mrdoob/three.js/pull/25382.