### PR TITLE
DRACOLoader, DRACOExporter: Convert vertex colors to/from Linear-sRGB

### DIFF
--- a/editor/js/Loader.js
+++ b/editor/js/Loader.js
@@ -200,7 +200,7 @@ function Loader( editor ) {
 
 					const loader = new DRACOLoader();
 					loader.setDecoderPath( '../examples/jsm/libs/draco/' );
-					loader.decodeDracoFile( contents, function ( geometry ) {
+					loader.parse( contents, function ( geometry ) {
 
 						let object;
 


### PR DESCRIPTION
Related issue: 

- https://github.com/mrdoob/three.js/issues/23283

While .drc files do not specify colorspace, the only 'official' tooling is the Draco library's PLY and OBJ converters, which use sRGB. We'll assume sRGB is expected for .drc files, but note that Draco buffers embedded in glTF files will be Linear-sRGB instead. This change ensures that when using the .load() or .parse() methods of DRACOLoader, we use the appropriate color spaces for .drc files. GLTFLoader uses an internal API instead and will not be affected.

