### PR TITLE
Tests: Unit Tests for Loaders

### DIFF
--- a/test/unit/src/loaders/AnimationLoader.tests.js
+++ b/test/unit/src/loaders/AnimationLoader.tests.js
@@ -1,10 +1,23 @@
 /* global QUnit */
 
-// import { AnimationLoader } from '../../../../src/loaders/AnimationLoader.js';
+import { AnimationLoader } from '../../../../src/loaders/AnimationLoader.js';
+
+import { Loader } from '../../../../src/loaders/Loader.js';
 
 export default QUnit.module( 'Loaders', () => {
 
 	QUnit.module( 'AnimationLoader', () => {
+
+		// INHERITANCE
+		QUnit.test( 'Extending', ( assert ) => {
+
+			const object = new AnimationLoader();
+			assert.strictEqual(
+				object instanceof Loader, true,
+				'AnimationLoader extends from Loader'
+			);
+
+		} );
 
 		// INSTANCING
 		QUnit.todo( 'Instancing', ( assert ) => {
@@ -13,7 +26,7 @@ export default QUnit.module( 'Loaders', () => {
 
 		} );
 
-		// PUBLIC STUFF
+		// PUBLIC
 		QUnit.todo( 'load', ( assert ) => {
 
 			assert.ok( false, 'everything\'s gonna be alright' );
@@ -22,6 +35,7 @@ export default QUnit.module( 'Loaders', () => {
 
 		QUnit.todo( 'parse', ( assert ) => {
 
+			// parse( json )
 			assert.ok( false, 'everything\'s gonna be alright' );
 
 		} );

--- a/test/unit/src/loaders/AudioLoader.tests.js
+++ b/test/unit/src/loaders/AudioLoader.tests.js
@@ -1,10 +1,23 @@
 /* global QUnit */
 
-// import { AudioLoader } from '../../../../src/loaders/AudioLoader.js';
+import { AudioLoader } from '../../../../src/loaders/AudioLoader.js';
+
+import { Loader } from '../../../../src/loaders/Loader.js';
 
 export default QUnit.module( 'Loaders', () => {
 
 	QUnit.module( 'AudioLoader', () => {
+
+		// INHERITANCE
+		QUnit.test( 'Extending', ( assert ) => {
+
+			const object = new AudioLoader();
+			assert.strictEqual(
+				object instanceof Loader, true,
+				'AudioLoader extends from Loader'
+			);
+
+		} );
 
 		// INSTANCING
 		QUnit.todo( 'Instancing', ( assert ) => {
@@ -13,7 +26,7 @@ export default QUnit.module( 'Loaders', () => {
 
 		} );
 
-		// PUBLIC STUFF
+		// PUBLIC
 		QUnit.todo( 'load', ( assert ) => {
 
 			assert.ok( false, 'everything\'s gonna be alright' );

--- a/test/unit/src/loaders/BufferGeometryLoader.tests.js
+++ b/test/unit/src/loaders/BufferGeometryLoader.tests.js
@@ -1,13 +1,26 @@
 /* global QUnit */
 
+import { BufferGeometryLoader } from '../../../../src/loaders/BufferGeometryLoader.js';
+
 import { BufferAttribute } from '../../../../src/core/BufferAttribute.js';
 import { BufferGeometry } from '../../../../src/core/BufferGeometry.js';
-import { BufferGeometryLoader } from '../../../../src/loaders/BufferGeometryLoader.js';
 import { DynamicDrawUsage } from '../../../../src/constants.js';
+import { Loader } from '../../../../src/loaders/Loader.js';
 
 export default QUnit.module( 'Loaders', () => {
 
 	QUnit.module( 'BufferGeometryLoader', () => {
+
+		// INHERITANCE
+		QUnit.test( 'Extending', ( assert ) => {
+
+			const object = new BufferGeometryLoader();
+			assert.strictEqual(
+				object instanceof Loader, true,
+				'BufferGeometryLoader extends from Loader'
+			);
+
+		} );
 
 		// INSTANCING
 		QUnit.todo( 'Instancing', ( assert ) => {
@@ -16,7 +29,7 @@ export default QUnit.module( 'Loaders', () => {
 
 		} );
 
-		// PUBLIC STUFF
+		// PUBLIC
 		QUnit.todo( 'load', ( assert ) => {
 
 			assert.ok( false, 'everything\'s gonna be alright' );
@@ -29,6 +42,7 @@ export default QUnit.module( 'Loaders', () => {
 
 		} );
 
+		// OTHERS
 		QUnit.test( 'parser - attributes - circlable', ( assert ) => {
 
 			const loader = new BufferGeometryLoader();

--- a/test/unit/src/loaders/Cache.tests.js
+++ b/test/unit/src/loaders/Cache.tests.js
@@ -1,26 +1,46 @@
 /* global QUnit */
 
-// import { Cache } from '../../../../src/loaders/Cache.js';
+import { Cache } from '../../../../src/loaders/Cache.js';
 
 export default QUnit.module( 'Loaders', () => {
 
 	QUnit.module( 'Cache', () => {
 
-		// PUBLIC STUFF
+		// PROPERTIES
+		QUnit.test( 'enabled', ( assert ) => {
+
+			const actual = Cache.enabled;
+			const expected = false;
+			assert.strictEqual( actual, expected, 'Cache defines enabled.' );
+
+		} );
+
+		QUnit.test( 'files', ( assert ) => {
+
+			const actual = Cache.files;
+			const expected = {};
+			assert.deepEqual( actual, expected, 'Cache defines files.' );
+
+		} );
+
+		// PUBLIC
 		QUnit.todo( 'add', ( assert ) => {
 
+			// function ( key, file )
 			assert.ok( false, 'everything\'s gonna be alright' );
 
 		} );
 
 		QUnit.todo( 'get', ( assert ) => {
 
+			// function ( key )
 			assert.ok( false, 'everything\'s gonna be alright' );
 
 		} );
 
 		QUnit.todo( 'remove', ( assert ) => {
 
+			// function ( key )
 			assert.ok( false, 'everything\'s gonna be alright' );
 
 		} );

--- a/test/unit/src/loaders/CompressedTextureLoader.tests.js
+++ b/test/unit/src/loaders/CompressedTextureLoader.tests.js
@@ -1,10 +1,23 @@
 /* global QUnit */
 
-// import { CompressedTextureLoader } from '../../../../src/loaders/CompressedTextureLoader.js';
+import { CompressedTextureLoader } from '../../../../src/loaders/CompressedTextureLoader.js';
+
+import { Loader } from '../../../../src/loaders/Loader.js';
 
 export default QUnit.module( 'Loaders', () => {
 
 	QUnit.module( 'CompressedTextureLoader', () => {
+
+		// INHERITANCE
+		QUnit.test( 'Extending', ( assert ) => {
+
+			const object = new CompressedTextureLoader();
+			assert.strictEqual(
+				object instanceof Loader, true,
+				'CompressedTextureLoader extends from Loader'
+			);
+
+		} );
 
 		// INSTANCING
 		QUnit.todo( 'Instancing', ( assert ) => {
@@ -13,14 +26,8 @@ export default QUnit.module( 'Loaders', () => {
 
 		} );
 
-		// PUBLIC STUFF
+		// PUBLIC
 		QUnit.todo( 'load', ( assert ) => {
-
-			assert.ok( false, 'everything\'s gonna be alright' );
-
-		} );
-
-		QUnit.todo( 'setPath', ( assert ) => {
 
 			assert.ok( false, 'everything\'s gonna be alright' );
 

--- a/test/unit/src/loaders/CubeTextureLoader.tests.js
+++ b/test/unit/src/loaders/CubeTextureLoader.tests.js
@@ -1,10 +1,23 @@
 /* global QUnit */
 
-// import { CubeTextureLoader } from '../../../../src/loaders/CubeTextureLoader.js';
+import { CubeTextureLoader } from '../../../../src/loaders/CubeTextureLoader.js';
+
+import { Loader } from '../../../../src/loaders/Loader.js';
 
 export default QUnit.module( 'Loaders', () => {
 
 	QUnit.module( 'CubeTextureLoader', () => {
+
+		// INHERITANCE
+		QUnit.test( 'Extending', ( assert ) => {
+
+			const object = new CubeTextureLoader();
+			assert.strictEqual(
+				object instanceof Loader, true,
+				'CubeTextureLoader extends from Loader'
+			);
+
+		} );
 
 		// INSTANCING
 		QUnit.todo( 'Instancing', ( assert ) => {
@@ -13,20 +26,8 @@ export default QUnit.module( 'Loaders', () => {
 
 		} );
 
-		// PUBLIC STUFF
+		// PUBLIC
 		QUnit.todo( 'load', ( assert ) => {
-
-			assert.ok( false, 'everything\'s gonna be alright' );
-
-		} );
-
-		QUnit.todo( 'setCrossOrigin', ( assert ) => {
-
-			assert.ok( false, 'everything\'s gonna be alright' );
-
-		} );
-
-		QUnit.todo( 'setPath', ( assert ) => {
 
 			assert.ok( false, 'everything\'s gonna be alright' );
 

--- a/test/unit/src/loaders/DataTextureLoader.tests.js
+++ b/test/unit/src/loaders/DataTextureLoader.tests.js
@@ -1,10 +1,23 @@
 /* global QUnit */
 
-// import { DataTextureLoader } from '../../../../src/loaders/DataTextureLoader.js';
+import { DataTextureLoader } from '../../../../src/loaders/DataTextureLoader.js';
+
+import { Loader } from '../../../../src/loaders/Loader.js';
 
 export default QUnit.module( 'Loaders', () => {
 
 	QUnit.module( 'DataTextureLoader', () => {
+
+		// INHERITANCE
+		QUnit.test( 'Extending', ( assert ) => {
+
+			const object = new DataTextureLoader();
+			assert.strictEqual(
+				object instanceof Loader, true,
+				'DataTextureLoader extends from Loader'
+			);
+
+		} );
 
 		// INSTANCING
 		QUnit.todo( 'Instancing', ( assert ) => {
@@ -13,7 +26,7 @@ export default QUnit.module( 'Loaders', () => {
 
 		} );
 
-		// PUBLIC STUFF
+		// PUBLIC
 		QUnit.todo( 'load', ( assert ) => {
 
 			assert.ok( false, 'everything\'s gonna be alright' );

--- a/test/unit/src/loaders/FileLoader.tests.js
+++ b/test/unit/src/loaders/FileLoader.tests.js
@@ -1,10 +1,23 @@
 /* global QUnit */
 
-// import { FileLoader } from '../../../../src/loaders/FileLoader.js';
+import { FileLoader } from '../../../../src/loaders/FileLoader.js';
+
+import { Loader } from '../../../../src/loaders/Loader.js';
 
 export default QUnit.module( 'Loaders', () => {
 
 	QUnit.module( 'FileLoader', () => {
+
+		// INHERITANCE
+		QUnit.test( 'Extending', ( assert ) => {
+
+			const object = new FileLoader();
+			assert.strictEqual(
+				object instanceof Loader, true,
+				'FileLoader extends from Loader'
+			);
+
+		} );
 
 		// INSTANCING
 		QUnit.todo( 'Instancing', ( assert ) => {
@@ -13,14 +26,8 @@ export default QUnit.module( 'Loaders', () => {
 
 		} );
 
-		// PUBLIC STUFF
+		// PUBLIC
 		QUnit.todo( 'load', ( assert ) => {
-
-			assert.ok( false, 'everything\'s gonna be alright' );
-
-		} );
-
-		QUnit.todo( 'setPath', ( assert ) => {
 
 			assert.ok( false, 'everything\'s gonna be alright' );
 
@@ -32,19 +39,7 @@ export default QUnit.module( 'Loaders', () => {
 
 		} );
 
-		QUnit.todo( 'setWithCredentials', ( assert ) => {
-
-			assert.ok( false, 'everything\'s gonna be alright' );
-
-		} );
-
 		QUnit.todo( 'setMimeType', ( assert ) => {
-
-			assert.ok( false, 'everything\'s gonna be alright' );
-
-		} );
-
-		QUnit.todo( 'setRequestHeader', ( assert ) => {
 
 			assert.ok( false, 'everything\'s gonna be alright' );
 

--- a/test/unit/src/loaders/ImageBitmapLoader.tests.js
+++ b/test/unit/src/loaders/ImageBitmapLoader.tests.js
@@ -1,0 +1,65 @@
+/* global QUnit */
+
+import { ImageBitmapLoader } from '../../../../src/loaders/ImageBitmapLoader.js';
+
+import { Loader } from '../../../../src/loaders/Loader.js';
+
+export default QUnit.module( 'Loaders', () => {
+
+	QUnit.module( 'ImageBitmapLoader', () => {
+
+		// INHERITANCE
+		QUnit.test( 'Extending', ( assert ) => {
+
+			const object = new ImageBitmapLoader();
+			assert.strictEqual(
+				object instanceof Loader, true,
+				'ImageBitmapLoader extends from Loader'
+			);
+
+		} );
+
+		// INSTANCING
+		QUnit.todo( 'Instancing', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		// PROPERTIES
+		QUnit.test( 'options', ( assert ) => {
+
+			const actual = new ImageBitmapLoader().options;
+			const expected = { premultiplyAlpha: 'none' };
+			assert.deepEqual( actual, expected, 'ImageBitmapLoader defines options.' );
+
+		} );
+
+		// PUBLIC
+		QUnit.test( 'isImageBitmapLoader', ( assert ) => {
+
+			const object = new ImageBitmapLoader();
+			assert.ok(
+				object.isImageBitmapLoader,
+				'ImageBitmapLoader.isImageBitmapLoader should be true'
+			);
+
+		} );
+
+		QUnit.todo( 'setOptions', ( assert ) => {
+
+			// setOptions( options )
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'load', ( assert ) => {
+
+			// load( url, onLoad, onProgress, onError )
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+	} );
+
+} );

--- a/test/unit/src/loaders/ImageLoader.tests.js
+++ b/test/unit/src/loaders/ImageLoader.tests.js
@@ -1,10 +1,23 @@
 /* global QUnit */
 
-// import { ImageLoader } from '../../../../src/loaders/ImageLoader.js';
+import { ImageLoader } from '../../../../src/loaders/ImageLoader.js';
+
+import { Loader } from '../../../../src/loaders/Loader.js';
 
 export default QUnit.module( 'Loaders', () => {
 
 	QUnit.module( 'ImageLoader', () => {
+
+		// INHERITANCE
+		QUnit.test( 'Extending', ( assert ) => {
+
+			const object = new ImageLoader();
+			assert.strictEqual(
+				object instanceof Loader, true,
+				'ImageLoader extends from Loader'
+			);
+
+		} );
 
 		// INSTANCING
 		QUnit.todo( 'Instancing', ( assert ) => {
@@ -13,20 +26,8 @@ export default QUnit.module( 'Loaders', () => {
 
 		} );
 
-		// PUBLIC STUFF
+		// PUBLIC
 		QUnit.todo( 'load', ( assert ) => {
-
-			assert.ok( false, 'everything\'s gonna be alright' );
-
-		} );
-
-		QUnit.todo( 'setCrossOrigin', ( assert ) => {
-
-			assert.ok( false, 'everything\'s gonna be alright' );
-
-		} );
-
-		QUnit.todo( 'setPath', ( assert ) => {
 
 			assert.ok( false, 'everything\'s gonna be alright' );
 

--- a/test/unit/src/loaders/Loader.tests.js
+++ b/test/unit/src/loaders/Loader.tests.js
@@ -1,11 +1,116 @@
 /* global QUnit */
 
+import { Loader } from '../../../../src/loaders/Loader.js';
+
+import { LoadingManager } from '../../../../src/loaders/LoadingManager.js';
+
 export default QUnit.module( 'Loaders', () => {
 
 	QUnit.module( 'Loader', () => {
 
 		// INSTANCING
 		QUnit.todo( 'Instancing', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		// PROPERTIES
+		QUnit.test( 'manager', ( assert ) => {
+
+			// uses default LoadingManager if not supplied in constructor
+			const object = new Loader().manager;
+			assert.strictEqual(
+				object instanceof LoadingManager, true,
+				'Loader defines a default manager if not supplied in constructor.'
+			);
+
+		} );
+
+		QUnit.test( 'crossOrigin', ( assert ) => {
+
+			const actual = new Loader().crossOrigin;
+			const expected = 'anonymous';
+			assert.strictEqual( actual, expected, 'Loader defines crossOrigin.' );
+
+		} );
+
+		QUnit.test( 'withCredentials', ( assert ) => {
+
+			const actual = new Loader().withCredentials;
+			const expected = false;
+			assert.strictEqual( actual, expected, 'Loader defines withCredentials.' );
+
+		} );
+
+		QUnit.test( 'path', ( assert ) => {
+
+			const actual = new Loader().path;
+			const expected = '';
+			assert.strictEqual( actual, expected, 'Loader defines path.' );
+
+		} );
+
+		QUnit.test( 'resourcePath', ( assert ) => {
+
+			const actual = new Loader().resourcePath;
+			const expected = '';
+			assert.strictEqual( actual, expected, 'Loader defines resourcePath.' );
+
+		} );
+
+		QUnit.test( 'requestHeader', ( assert ) => {
+
+			const actual = new Loader().requestHeader;
+			const expected = {};
+			assert.deepEqual( actual, expected, 'Loader defines requestHeader.' );
+
+		} );
+
+		// PUBLIC
+		QUnit.todo( 'load', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'loadAsync', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'parse', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'setCrossOrigin', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'setWithCredentials', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'setPath', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'setResourcePath', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'setRequestHeader', ( assert ) => {
 
 			assert.ok( false, 'everything\'s gonna be alright' );
 

--- a/test/unit/src/loaders/LoaderUtils.tests.js
+++ b/test/unit/src/loaders/LoaderUtils.tests.js
@@ -6,7 +6,7 @@ export default QUnit.module( 'Loaders', () => {
 
 	QUnit.module( 'LoaderUtils', () => {
 
-		// INSTANCING
+		// STATIC
 		QUnit.test( 'decodeText', ( assert ) => {
 
 			var jsonArray = new Uint8Array( [ 123, 34, 106, 115, 111, 110, 34, 58, 32, 116, 114, 117, 101, 125 ] );
@@ -22,6 +22,13 @@ export default QUnit.module( 'Loaders', () => {
 			assert.equal( '/path/to/', LoaderUtils.extractUrlBase( '/path/to/model.glb' ) );
 			assert.equal( './', LoaderUtils.extractUrlBase( 'model.glb' ) );
 			assert.equal( '/', LoaderUtils.extractUrlBase( '/model.glb' ) );
+
+		} );
+
+		QUnit.todo( 'resolveURL', ( assert ) => {
+
+			// static resolveURL( url, path )
+			assert.ok( false, 'everything\'s gonna be alright' );
 
 		} );
 

--- a/test/unit/src/loaders/LoadingManager.tests.js
+++ b/test/unit/src/loaders/LoadingManager.tests.js
@@ -1,6 +1,7 @@
 /* global QUnit */
 
 import { LoadingManager } from '../../../../src/loaders/LoadingManager.js';
+
 import { Loader } from '../../../../src/loaders/Loader.js';
 
 export default QUnit.module( 'Loaders', () => {
@@ -10,13 +11,16 @@ export default QUnit.module( 'Loaders', () => {
 		// INSTANCING
 		QUnit.todo( 'Instancing', ( assert ) => {
 
+			// constructor( onLoad, onProgress, onError )
 			assert.ok( false, 'everything\'s gonna be alright' );
 
 		} );
 
-		// PUBLIC STUFF
+		// PUBLIC
 		QUnit.todo( 'onStart', ( assert ) => {
 
+			// Refer to #5689 for the reason why we don't set .onStart
+			// in the constructor
 			assert.ok( false, 'everything\'s gonna be alright' );
 
 		} );
@@ -57,7 +61,42 @@ export default QUnit.module( 'Loaders', () => {
 
 		} );
 
-		QUnit.test( 'getHandler', ( assert ) => {
+		QUnit.todo( 'resolveURL', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'setURLModifier', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'addHandler', ( assert ) => {
+
+			// addHandler( regex, loader )
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'removeHandler', ( assert ) => {
+
+			// removeHandler( regex )
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+
+		QUnit.todo( 'getHandler', ( assert ) => {
+
+			// getHandler( file )
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		// OTHERS
+		QUnit.test( 'addHandler/getHandler/removeHandler', ( assert ) => {
 
 			const loadingManager = new LoadingManager();
 			const loader = new Loader();

--- a/test/unit/src/loaders/MaterialLoader.tests.js
+++ b/test/unit/src/loaders/MaterialLoader.tests.js
@@ -1,10 +1,32 @@
 /* global QUnit */
 
-// import { MaterialLoader } from '../../../../src/loaders/MaterialLoader.js';
+import { MaterialLoader } from '../../../../src/loaders/MaterialLoader.js';
+
+import { Loader } from '../../../../src/loaders/Loader.js';
 
 export default QUnit.module( 'Loaders', () => {
 
 	QUnit.module( 'MaterialLoader', () => {
+
+		// INHERITANCE
+		QUnit.test( 'Extending', ( assert ) => {
+
+			const object = new MaterialLoader();
+			assert.strictEqual(
+				object instanceof Loader, true,
+				'MaterialLoader extends from Loader'
+			);
+
+		} );
+
+		// PROPERTIES
+		QUnit.test( 'textures', ( assert ) => {
+
+			const actual = new MaterialLoader().textures;
+			const expected = {};
+			assert.deepEqual( actual, expected, 'MaterialLoader defines textures.' );
+
+		} );
 
 		// INSTANCING
 		QUnit.todo( 'Instancing', ( assert ) => {
@@ -13,8 +35,14 @@ export default QUnit.module( 'Loaders', () => {
 
 		} );
 
-		// PUBLIC STUFF
+		// PUBLIC
 		QUnit.todo( 'load', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'parse', ( assert ) => {
 
 			assert.ok( false, 'everything\'s gonna be alright' );
 
@@ -26,8 +54,10 @@ export default QUnit.module( 'Loaders', () => {
 
 		} );
 
-		QUnit.todo( 'parse', ( assert ) => {
+		// STATIC
+		QUnit.todo( 'createMaterialFromType', ( assert ) => {
 
+			// static createMaterialFromType( type )
 			assert.ok( false, 'everything\'s gonna be alright' );
 
 		} );

--- a/test/unit/src/loaders/ObjectLoader.tests.js
+++ b/test/unit/src/loaders/ObjectLoader.tests.js
@@ -1,10 +1,23 @@
 /* global QUnit */
 
-// import { ObjectLoader } from '../../../../src/loaders/ObjectLoader.js';
+import { ObjectLoader } from '../../../../src/loaders/ObjectLoader.js';
+
+import { Loader } from '../../../../src/loaders/Loader.js';
 
 export default QUnit.module( 'Loaders', () => {
 
 	QUnit.module( 'ObjectLoader', () => {
+
+		// INHERITANCE
+		QUnit.test( 'Extending', ( assert ) => {
+
+			const object = new ObjectLoader();
+			assert.strictEqual(
+				object instanceof Loader, true,
+				'ObjectLoader extends from Loader'
+			);
+
+		} );
 
 		// INSTANCING
 		QUnit.todo( 'Instancing', ( assert ) => {
@@ -13,27 +26,43 @@ export default QUnit.module( 'Loaders', () => {
 
 		} );
 
-		// PUBLIC STUFF
+		// PUBLIC
 		QUnit.todo( 'load', ( assert ) => {
 
 			assert.ok( false, 'everything\'s gonna be alright' );
 
 		} );
 
-		QUnit.todo( 'setTexturePath', ( assert ) => {
+		QUnit.todo( 'loadAsync', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
-
-		} );
-
-		QUnit.todo( 'setCrossOrigin', ( assert ) => {
-
+			// async loadAsync( url, onProgress )
 			assert.ok( false, 'everything\'s gonna be alright' );
 
 		} );
 
 		QUnit.todo( 'parse', ( assert ) => {
 
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'parseAsync', ( assert ) => {
+
+			// async parseAsync( json )
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'parseShapes', ( assert ) => {
+
+			// parseShapes( json )
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'parseSkeletons', ( assert ) => {
+
+			// parseSkeletons( json, object )
 			assert.ok( false, 'everything\'s gonna be alright' );
 
 		} );
@@ -62,6 +91,13 @@ export default QUnit.module( 'Loaders', () => {
 
 		} );
 
+		QUnit.todo( 'parseImagesAsync', ( assert ) => {
+
+			// async parseImagesAsync( json )
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
 		QUnit.todo( 'parseTextures', ( assert ) => {
 
 			assert.ok( false, 'everything\'s gonna be alright' );
@@ -70,6 +106,13 @@ export default QUnit.module( 'Loaders', () => {
 
 		QUnit.todo( 'parseObject', ( assert ) => {
 
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'bindSkeletons', ( assert ) => {
+
+			// bindSkeletons( object, skeletons )
 			assert.ok( false, 'everything\'s gonna be alright' );
 
 		} );

--- a/test/unit/src/loaders/TextureLoader.tests.js
+++ b/test/unit/src/loaders/TextureLoader.tests.js
@@ -1,10 +1,23 @@
 /* global QUnit */
 
-// import { TextureLoader } from '../../../../src/loaders/TextureLoader.js';
+import { TextureLoader } from '../../../../src/loaders/TextureLoader.js';
+
+import { Loader } from '../../../../src/loaders/Loader.js';
 
 export default QUnit.module( 'Loaders', () => {
 
 	QUnit.module( 'TextureLoader', () => {
+
+		// INHERITANCE
+		QUnit.test( 'Extending', ( assert ) => {
+
+			const object = new TextureLoader();
+			assert.strictEqual(
+				object instanceof Loader, true,
+				'TextureLoader extends from Loader'
+			);
+
+		} );
 
 		// INSTANCING
 		QUnit.todo( 'Instancing', ( assert ) => {
@@ -13,20 +26,8 @@ export default QUnit.module( 'Loaders', () => {
 
 		} );
 
-		// PUBLIC STUFF
+		// PUBLIC
 		QUnit.todo( 'load', ( assert ) => {
-
-			assert.ok( false, 'everything\'s gonna be alright' );
-
-		} );
-
-		QUnit.todo( 'setCrossOrigin', ( assert ) => {
-
-			assert.ok( false, 'everything\'s gonna be alright' );
-
-		} );
-
-		QUnit.todo( 'setPath', ( assert ) => {
 
 			assert.ok( false, 'everything\'s gonna be alright' );
 

--- a/test/unit/three.source.unit.js
+++ b/test/unit/three.source.unit.js
@@ -144,6 +144,7 @@ import './src/loaders/CompressedTextureLoader.tests.js';
 import './src/loaders/CubeTextureLoader.tests.js';
 import './src/loaders/DataTextureLoader.tests.js';
 import './src/loaders/FileLoader.tests.js';
+import './src/loaders/ImageBitmapLoader.tests.js';
 import './src/loaders/ImageLoader.tests.js';
 import './src/loaders/Loader.tests.js';
 import './src/loaders/LoaderUtils.tests.js';


### PR DESCRIPTION
Related issue: none.

**Description**

This cleans up the unit tests for Loaders.
Adds missing unit test file, fills in some unit tests, populates the missing member tests with stubs. Removes tests for base class methods which are not redfined in the child class.