### PR TITLE
Puppeteer E2E test: Download latest stable-channel Chromium

### DIFF
--- a/test/e2e/puppeteer.js
+++ b/test/e2e/puppeteer.js
@@ -55,7 +55,7 @@ const PLATFORMS = {
 };
 const OMAHA_PROXY = 'https://omahaproxy.appspot.com/all.json';
 
-const chromiumChannel = 'dev'; // stable -> beta -> dev -> canary (Mac and Windows) -> canary_asan (Windows)
+const chromiumChannel = 'stable'; // stable -> beta -> dev -> canary (Mac and Windows) -> canary_asan (Windows)
 
 const port = 1234;
 const pixelThreshold = 0.1; // threshold error in one pixel

--- a/test/e2e/puppeteer.js
+++ b/test/e2e/puppeteer.js
@@ -210,8 +210,9 @@ async function downloadLatestChromium() {
 	const os = PLATFORMS[ browserFetcher.platform() ];
 
 	const revisions = await ( await fetch( OMAHA_PROXY ) ).json();
-	let revision = revisions.find( revs => revs.os === os ).versions.find( version => version.channel === chromiumChannel ).branch_base_position;
+	const omahaRevisionInfo = revisions.find( revs => revs.os === os ).versions.find( version => version.channel === chromiumChannel );
 
+	let revision = omahaRevisionInfo.branch_base_position;
 	while ( ! ( await browserFetcher.canDownload( revision ) ) ) {
 
 		revision = String( revision - 1 );
@@ -230,6 +231,7 @@ async function downloadLatestChromium() {
 		console.log( 'Downloaded.' );
 
 	}
+	console.log( `Using Chromium ${ omahaRevisionInfo.current_version } (revision ${ revision }, ${ revisionInfo.url }), ${ chromiumChannel } channel on ${ os }` );
 	return revisionInfo;
 
 }

--- a/test/e2e/puppeteer.js
+++ b/test/e2e/puppeteer.js
@@ -210,7 +210,13 @@ async function downloadLatestChromium() {
 	const os = PLATFORMS[ browserFetcher.platform() ];
 
 	const revisions = await ( await fetch( OMAHA_PROXY ) ).json();
-	const revision = revisions.find( revs => revs.os === os ).versions.find( version => version.channel === chromiumChannel ).branch_base_position;
+	let revision = revisions.find( revs => revs.os === os ).versions.find( version => version.channel === chromiumChannel ).branch_base_position;
+
+	while ( ! ( await browserFetcher.canDownload( revision ) ) ) {
+
+		revision = String( revision - 1 );
+
+	}
 
 	let revisionInfo = browserFetcher.revisionInfo( revision );
 	if ( revisionInfo.local === true ) {

--- a/test/e2e/puppeteer.js
+++ b/test/e2e/puppeteer.js
@@ -46,13 +46,16 @@ const exceptionList = [
 
 /* CONFIG VARIABLES END */
 
-const LAST_REVISION_URLS = {
-	linux: 'https://storage.googleapis.com/chromium-browser-snapshots/Linux_x64/LAST_CHANGE',
-	mac: 'https://storage.googleapis.com/chromium-browser-snapshots/Mac/LAST_CHANGE',
-	mac_arm: 'https://storage.googleapis.com/chromium-browser-snapshots/Mac_Arm/LAST_CHANGE',
-	win32: 'https://storage.googleapis.com/chromium-browser-snapshots/Win/LAST_CHANGE',
-	win64: 'https://storage.googleapis.com/chromium-browser-snapshots/Win_x64/LAST_CHANGE'
+const PLATFORMS = {
+	linux: 'linux',
+	mac: 'mac',
+	mac_arm: 'mac_am64',
+	win32: 'win',
+	win64: 'win64'
 };
+const OMAHA_PROXY = 'https://omahaproxy.appspot.com/all.json';
+
+const chromiumChannel = 'dev'; // stable -> beta -> dev -> canary (Mac and Windows) -> canary_asan (Windows)
 
 const port = 1234;
 const pixelThreshold = 0.1; // threshold error in one pixel
@@ -204,8 +207,10 @@ async function downloadLatestChromium() {
 
 	const browserFetcher = new BrowserFetcher( { path: 'test/e2e/chromium' } );
 
-	const lastRevisionURL = LAST_REVISION_URLS[ browserFetcher.platform() ];
-	const revision = await ( await fetch( lastRevisionURL ) ).text();
+	const os = PLATFORMS[ browserFetcher.platform() ];
+
+	const revisions = await ( await fetch( OMAHA_PROXY ) ).json();
+	const revision = revisions.find( revs => revs.os === os ).versions.find( version => version.channel === chromiumChannel ).branch_base_position;
 
 	let revisionInfo = browserFetcher.revisionInfo( revision );
 	if ( revisionInfo.local === true ) {


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/25386#discussion_r1091839775

**Description**

Make Puppeteer download the Chromium revision got from OmahaProxy.
