### PR TITLE
Examples: Fixed NodeMaterial not import error.

### DIFF
--- a/examples/webgl_nodes_loader_gltf_sheen.html
+++ b/examples/webgl_nodes_loader_gltf_sheen.html
@@ -36,6 +36,8 @@
 
 			import * as THREE from 'three';
 
+			import { NodeMaterial, uv, mul, mix, color, checker } from 'three/nodes';
+
 			import { nodeFrame } from 'three/addons/renderers/webgl/nodes/WebGLNodes.js';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';


### PR DESCRIPTION
Related commit: https://github.com/mrdoob/three.js/commit/3f0b691445939a3e0657a93036dc9eddca0e1004

**Description**

As the title.

Error info:

```
webgl_nodes_loader_gltf_sheen.html:71 
        
       Uncaught (in promise) ReferenceError: NodeMaterial is not defined
    at webgl_nodes_loader_gltf_sheen.html:71:24
    at GLTFLoader.js:220:6
    at GLTFLoader.js:2461:5
```

