### PR TITLE
WebXRManager exchangeable

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -55,6 +55,12 @@ function createCanvasElement() {
 
 }
 
+function createWebXRManager( renderer, gl ) {
+
+	return new WebXRManager( renderer, gl );
+
+}
+
 function WebGLRenderer( parameters = {} ) {
 
 	this.isWebGLRenderer = true;
@@ -68,7 +74,8 @@ function WebGLRenderer( parameters = {} ) {
 		_premultipliedAlpha = parameters.premultipliedAlpha !== undefined ? parameters.premultipliedAlpha : true,
 		_preserveDrawingBuffer = parameters.preserveDrawingBuffer !== undefined ? parameters.preserveDrawingBuffer : false,
 		_powerPreference = parameters.powerPreference !== undefined ? parameters.powerPreference : 'default',
-		_failIfMajorPerformanceCaveat = parameters.failIfMajorPerformanceCaveat !== undefined ? parameters.failIfMajorPerformanceCaveat : false;
+		_failIfMajorPerformanceCaveat = parameters.failIfMajorPerformanceCaveat !== undefined ? parameters.failIfMajorPerformanceCaveat : false,
+		_xrFactory = parameters.xrFactory !== undefined ? parameters.xrFactory : createWebXRManager;
 
 	let _alpha;
 
@@ -338,7 +345,7 @@ function WebGLRenderer( parameters = {} ) {
 
 	// xr
 
-	const xr = new WebXRManager( _this, _gl );
+	const xr = _xrFactory( _this, _gl );
 
 	this.xr = xr;
 


### PR DESCRIPTION
**Description**

For the use case of WebXR multi-users, I would like to have full control over the state regarding WebXR. However, the WebXRManager implementation is stateful and abstracts low-level access to WebXR-related events.

In this PR, I implemented a parameter for the WebXRRenderer to overwrite the WebXRManager. This change is minimal and should not affect the current behavior.

However, I believe a cleaner approach could be making a `setAnimation` function to overwrite the animation and completely remove the WebXRManager from the renderer. For abstracting the WebXRManager out of the WebXRRenderer, it would also be necessary to generically influence the camera from the outside, which I am currently not sure how to solve best:

```js
if ( xr.enabled === true && xr.isPresenting === true ) {
  if ( xr.cameraAutoUpdate === true ) xr.updateCamera( camera );
  camera = xr.getCamera(); // use XR camera for rendering
}
```

If there is an alternative way to give me more freedom in handling WebXR events & state, I am happy to take it :)
Thanks in advance!

*This contribution is funded by [CoconutXR](https://coconut-xr.com)*
