### PR TITLE
Update UnitTests.html

### DIFF
--- a/test/unit/UnitTests.html
+++ b/test/unit/UnitTests.html
@@ -3,14 +3,14 @@
 	<head>
 		<meta charset="utf-8">
 		<title>ThreeJS Unit Tests - Using Files in /src</title>
-		<link rel="stylesheet" href="../node_modules/qunit/qunit/qunit.css">
+		<link rel="stylesheet" href="../../node_modules/qunit/qunit/qunit.css">
 	</head>
 	<body>
 
 		<div id="qunit"></div>
 		<div id="qunit-fixture"></div>
 
-		<script src="../node_modules/qunit/qunit/qunit.js"></script>
+		<script src="../../node_modules/qunit/qunit/qunit.js"></script>
 
 		<script type="importmap">
 			{
@@ -24,3 +24,4 @@
 		<script src="./three.source.unit.js" type="module"></script>
 	</body>
 </html>
+


### PR DESCRIPTION
Qunit node module now found in base since PR #25380

Related issue: forgot to raise issue.

**Description**

Qunit node_modules install is now in the base package.  The web based test file was still pointing to the `tests/node_modules` which has since been removed.

Updated the HTML page to use the new home for Qunit in this repo.  The issue might not show up right away for existing developers because the `tests/node_modules` folder may linger around until someone resets their development environment.
