### PR TITLE
Puppeteer E2E test: Show actual and difference screenshots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,7 @@ jobs:
         with:
           name: Output screenshots
           path: test/e2e/output-screenshots
+          if-no-files-found: ignore
 
   e2e-cov:
     name: "Examples ready for release"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,11 @@ jobs:
 
       - name: === E2E testing ===
         run: npm run test-e2e
+      - name: Upload output screenshots
+        uses: actions/upload-artifact@v3
+        with:
+          name: Output screenshots
+          path: test/e2e/output-screenshots
 
   e2e-cov:
     name: "Examples ready for release"

--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,6 @@ test/treeshake/index.bundle.min.js
 test/treeshake/index-src.bundle.min.js
 test/treeshake/stats.html
 test/e2e/chromium
+test/e2e/output-screenshots
 
 **/node_modules

--- a/test/e2e/puppeteer.js
+++ b/test/e2e/puppeteer.js
@@ -91,8 +91,8 @@ async function main() {
 
 	/* Create output directories */
 
-	try { await fs.rm( 'test/e2e/output-screenshots', { recursive: true, force: true } ) } catch {}
-	try { await fs.mkdir( 'test/e2e/output-screenshots' ) } catch {}
+	try { await fs.rm( 'test/e2e/output-screenshots', { recursive: true, force: true } ); } catch {}
+	try { await fs.mkdir( 'test/e2e/output-screenshots' ); } catch {}
 
 	/* Find files */
 

--- a/test/e2e/puppeteer.js
+++ b/test/e2e/puppeteer.js
@@ -89,6 +89,11 @@ process.on( 'SIGINT', () => close() );
 
 async function main() {
 
+	/* Create output directories */
+
+	try { await fs.rm( 'test/e2e/output-screenshots', { recursive: true, force: true } ) } catch {}
+	try { await fs.mkdir( 'test/e2e/output-screenshots' ) } catch {}
+
 	/* Find files */
 
 	const isMakeScreenshot = process.argv[ 2 ] === '--make';
@@ -438,10 +443,11 @@ async function makeAttempt( page, failedScreenshots, cleanPage, isMakeScreenshot
 
 			try {
 
-				expected = await jimp.read( `examples/screenshots/${ file }.jpg` );
+				expected = ( await jimp.read( `examples/screenshots/${ file }.jpg` ) ).quality( jpgQuality );
 
 			} catch {
 
+				await screenshot.writeAsync( `test/e2e/output-screenshots/${ file }-actual.jpg` );
 				throw new Error( `Screenshot does not exist: ${ file }` );
 
 			}
@@ -462,6 +468,8 @@ async function makeAttempt( page, failedScreenshots, cleanPage, isMakeScreenshot
 
 			} catch {
 
+				await screenshot.writeAsync( `test/e2e/output-screenshots/${ file }-actual.jpg` );
+				await expected.writeAsync( `test/e2e/output-screenshots/${ file }-expected.jpg` );
 				throw new Error( `Image sizes does not match in file: ${ file }` );
 
 			}
@@ -478,6 +486,9 @@ async function makeAttempt( page, failedScreenshots, cleanPage, isMakeScreenshot
 
 			} else {
 
+				await screenshot.writeAsync( `test/e2e/output-screenshots/${ file }-actual.jpg` );
+				await expected.writeAsync( `test/e2e/output-screenshots/${ file }-expected.jpg` );
+				await diff.writeAsync( `test/e2e/output-screenshots/${ file }-diff.jpg` );
 				throw new Error( `Diff wrong in ${ percFailedPixels.toFixed( 1 ) }% of pixels in file: ${ file }` );
 
 			}


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/24109

**Description**

Make Puppeteer show actual and difference screenshots. This is useful while debugging to "understand" what Puppeteer job running on GitHub Actions really sees, and how it differs from the screenshot in `examples/screenshots` or a local screenshot.