### PR TITLE
Tests: Tune Console Output

### DIFF
--- a/test/unit/src/extras/DataUtils.tests.js
+++ b/test/unit/src/extras/DataUtils.tests.js
@@ -2,6 +2,8 @@
 
 import * as DataUtils from '../../../../src/extras/DataUtils.js';
 
+import { CONSOLE_LEVEL } from '../../utils/console-wrapper.js';
+
 export default QUnit.module( 'Extras', () => {
 
 	QUnit.module( 'DataUtils', () => {
@@ -10,8 +12,15 @@ export default QUnit.module( 'Extras', () => {
 		QUnit.test( 'toHalfFloat', ( assert ) => {
 
 			assert.ok( DataUtils.toHalfFloat( 0 ) === 0, 'Passed!' );
+
+			// surpress the following console message during testing
+			// THREE.DataUtils.toHalfFloat(): Value out of range.
+
+			console.level = CONSOLE_LEVEL.OFF;
 			assert.ok( DataUtils.toHalfFloat( 100000 ) === 31743, 'Passed!' );
 			assert.ok( DataUtils.toHalfFloat( - 100000 ) === 64511, 'Passed!' );
+			console.level = CONSOLE_LEVEL.DEFAULT;
+
 			assert.ok( DataUtils.toHalfFloat( 65504 ) === 31743, 'Passed!' );
 			assert.ok( DataUtils.toHalfFloat( - 65504 ) === 64511, 'Passed!' );
 			assert.ok( DataUtils.toHalfFloat( Math.PI ) === 16968, 'Passed!' );

--- a/test/unit/src/loaders/ImageBitmapLoader.tests.js
+++ b/test/unit/src/loaders/ImageBitmapLoader.tests.js
@@ -3,6 +3,7 @@
 import { ImageBitmapLoader } from '../../../../src/loaders/ImageBitmapLoader.js';
 
 import { Loader } from '../../../../src/loaders/Loader.js';
+import { CONSOLE_LEVEL } from '../../utils/console-wrapper.js';
 
 export default QUnit.module( 'Loaders', () => {
 
@@ -11,7 +12,13 @@ export default QUnit.module( 'Loaders', () => {
 		// INHERITANCE
 		QUnit.test( 'Extending', ( assert ) => {
 
+			// surpress the following console message when testing
+			// THREE.ImageBitmapLoader: createImageBitmap() not supported.
+
+			console.level = CONSOLE_LEVEL.OFF;
 			const object = new ImageBitmapLoader();
+			console.level = CONSOLE_LEVEL.DEFAULT;
+
 			assert.strictEqual(
 				object instanceof Loader, true,
 				'ImageBitmapLoader extends from Loader'
@@ -29,7 +36,13 @@ export default QUnit.module( 'Loaders', () => {
 		// PROPERTIES
 		QUnit.test( 'options', ( assert ) => {
 
+			// surpress the following console message when testing in node
+			// THREE.ImageBitmapLoader: createImageBitmap() not supported.
+
+			console.level = CONSOLE_LEVEL.OFF;
 			const actual = new ImageBitmapLoader().options;
+			console.level = CONSOLE_LEVEL.DEFAULT;
+
 			const expected = { premultiplyAlpha: 'none' };
 			assert.deepEqual( actual, expected, 'ImageBitmapLoader defines options.' );
 
@@ -38,7 +51,13 @@ export default QUnit.module( 'Loaders', () => {
 		// PUBLIC
 		QUnit.test( 'isImageBitmapLoader', ( assert ) => {
 
+			// surpress the following console message when testing in node
+			// THREE.ImageBitmapLoader: createImageBitmap() not supported.
+
+			console.level = CONSOLE_LEVEL.OFF;
 			const object = new ImageBitmapLoader();
+			console.level = CONSOLE_LEVEL.DEFAULT;
+
 			assert.ok(
 				object.isImageBitmapLoader,
 				'ImageBitmapLoader.isImageBitmapLoader should be true'

--- a/test/unit/src/renderers/webgl/WebGLExtensions.tests.js
+++ b/test/unit/src/renderers/webgl/WebGLExtensions.tests.js
@@ -2,6 +2,8 @@
 
 import { WebGLExtensions } from '../../../../../src/renderers/webgl/WebGLExtensions.js';
 
+import { CONSOLE_LEVEL } from '../../../utils/console-wrapper.js';
+
 const WebglContextMock = function ( supportedExtensions ) {
 
 	this.supportedExtensions = supportedExtensions || [];
@@ -65,7 +67,13 @@ export default QUnit.module( 'Renderers', () => {
 				assert.ok( extensions.get( 'Extension1' ) );
 				assert.ok( extensions.get( 'Extension2' ) );
 				assert.ok( extensions.get( 'Extension1' ) );
+
+				// surpress the following console message when testing
+				// THREE.WebGLRenderer: NonExistingExtension extension not supported.
+
+				console.level = CONSOLE_LEVEL.OFF;
 				assert.notOk( extensions.get( 'NonExistingExtension' ) );
+				console.level = CONSOLE_LEVEL.DEFAULT;
 
 			} );
 
@@ -75,8 +83,15 @@ export default QUnit.module( 'Renderers', () => {
 				const extensions = new WebGLExtensions( gl );
 				assert.ok( extensions.get( 'WEBGL_depth_texture' ) );
 				assert.ok( extensions.get( 'WEBKIT_WEBGL_depth_texture' ) );
+
+				// surpress the following console message when testing
+				// THREE.WebGLRenderer: EXT_texture_filter_anisotropic extension not supported.
+				// THREE.WebGLRenderer: NonExistingExtension extension not supported.
+
+				console.level = CONSOLE_LEVEL.OFF;
 				assert.notOk( extensions.get( 'EXT_texture_filter_anisotropic' ) );
 				assert.notOk( extensions.get( 'NonExistingExtension' ) );
+				console.level = CONSOLE_LEVEL.DEFAULT;
 
 			} );
 


### PR DESCRIPTION
Related issue: none.

Description

This tunes the console output so only unit test status and genuine unit test failure messages are displayed.
