### PR TITLE
OrbitControls: Add `stopListenToKeyEvents()`.

### DIFF
--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -124,7 +124,7 @@ class OrbitControls extends EventDispatcher {
 
 		};
 
-		this.removeKeyEvents = function () {
+		this.unlistenToKeyEvents = function () {
 
 			this._domElementKeyEvents.removeEventListener( 'keydown', onKeyDown );
 			this._domElementKeyEvents = null;

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -126,7 +126,7 @@ class OrbitControls extends EventDispatcher {
 
 		this.removeKeyEvents = function () {
 
-			domElement.removeEventListener( 'keydown', onKeyDown );
+			this._domElementKeyEvents.removeEventListener( 'keydown', onKeyDown );
 			this._domElementKeyEvents = null;
 
 		};        

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -124,7 +124,7 @@ class OrbitControls extends EventDispatcher {
 
 		};
 
-		this.unlistenToKeyEvents = function () {
+		this.stopListenToKeyEvents = function () {
 
 			this._domElementKeyEvents.removeEventListener( 'keydown', onKeyDown );
 			this._domElementKeyEvents = null;

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -124,6 +124,13 @@ class OrbitControls extends EventDispatcher {
 
 		};
 
+		this.removeKeyEvents = function () {
+
+			domElement.removeEventListener( 'keydown', onKeyDown );
+			this._domElementKeyEvents = null;
+
+		};        
+
 		this.saveState = function () {
 
 			scope.target0.copy( scope.target );

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -311,6 +311,7 @@ class OrbitControls extends EventDispatcher {
 			if ( scope._domElementKeyEvents !== null ) {
 
 				scope._domElementKeyEvents.removeEventListener( 'keydown', onKeyDown );
+				scope._domElementKeyEvents = null;
 
 			}
 


### PR DESCRIPTION
If I called listenToKeyEvents(), sometimes I want to remove this event listener, temporarily or otherwise.