### PR TITLE
update computeVertexNormals() to check for length

### DIFF
--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -643,7 +643,7 @@ class BufferGeometry extends EventDispatcher {
 
 			let normalAttribute = this.getAttribute( 'normal' );
 
-			if ( normalAttribute === undefined || positionAttribute.count !== normalAttribute.count) {
+			if ( normalAttribute === undefined || positionAttribute.count !== normalAttribute.count ) {
 
 				normalAttribute = new BufferAttribute( new Float32Array( positionAttribute.count * 3 ), 3 );
 				this.setAttribute( 'normal', normalAttribute );

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -643,7 +643,7 @@ class BufferGeometry extends EventDispatcher {
 
 			let normalAttribute = this.getAttribute( 'normal' );
 
-			if ( normalAttribute === undefined ) {
+			if ( normalAttribute === undefined || positionAttribute.count !== normalAttribute.count) {
 
 				normalAttribute = new BufferAttribute( new Float32Array( positionAttribute.count * 3 ), 3 );
 				this.setAttribute( 'normal', normalAttribute );


### PR DESCRIPTION


Related issue: #XXXX

**Description**

If one want to reuse Mesh and BufferGeometry objects it is possible the positions-attribute changes. In that case the normal-attribute needs to be initiated again. The provided code will check for matching count if normal-attribute is present.
