### PR TITLE
GLTFExporter: Add `MAT3` accessor support.

### DIFF
--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -1095,6 +1095,7 @@ class GLTFWriter {
 			2: 'VEC2',
 			3: 'VEC3',
 			4: 'VEC4',
+			9: 'MAT3',
 			16: 'MAT4'
 
 		};


### PR DESCRIPTION
GLTFExporter generates invalid GLTFs if the source scene contains glTF models with MAT3 accessor type. 

These type of accessors are generated by Houdini for example. GLTFImporter does know this type but the GLTFExporter does not and it will omit the accessor type from the generated glTF. The generated file will not open in any known 3d software like Blender, Houdini and so on.

This small PR will fix the issue.