### PR TITLE
Docs: Update DataArrayTexture.html

### DIFF
--- a/docs/api/en/textures/DataArrayTexture.html
+++ b/docs/api/en/textures/DataArrayTexture.html
@@ -11,7 +11,10 @@
 
 		<h1>[name]</h1>
 
-		<p class="desc">Creates an array of textures directly from raw data, width and height and depth. This type of texture can only be used with a WebGL 2 rendering context.</p>
+		<p class="desc">
+			Creates an array of textures directly from raw data, width and height and depth. 
+			This type of texture can only be used with a WebGL 2 rendering context.
+		</p>
 
 
 		<h2>Constructor</h2>
@@ -74,23 +77,72 @@
 
 		<p>
 			[example:webgl2_materials_texture2darray WebGL2 / materials / texture2darray]
+			[example:webgl2_rendertarget_texture2darray WebGL2 / rendertarget / texture2darray]
 		</p>
 
 		<h2>Properties</h2>
 
 		<p>
-		See the base [page:Texture Texture] class for common properties.
+			See the base [page:Texture Texture] class for common properties.
+		</p>
+
+		<h3>[property:Boolean flipY]</h3>
+		<p>
+			Whether the texture is flipped along the Y axis when uploaded to the GPU. Default is `false`.
+		</p>
+	
+		<h3>[property:Boolean generateMipmaps]</h3>
+		<p>
+			Whether to generate mipmaps (if possible) for the texture. Default is `false`.
 		</p>
 
 		<h3>[property:Image image]</h3>
 		<p>
-		Overridden with a record type holding data, width and height and depth.
+			Overridden with a record type holding data, width and height and depth.
+		</p>
+
+		<h3>[property:Boolean isDataArrayTexture]</h3>
+		<p>
+			Read-only flag to check if a given object is of type [name].
+		</p>
+
+		<h3>[property:number magFilter]</h3>
+		<p>
+			How the texture is sampled when a texel covers more than one pixel. The default is
+		 	[page:Textures THREE.NearestFilter], which uses the value of the closest texel.<br /><br />
+		 
+			See the [page:Textures texture constants] page for details.
+		</p>
+
+		<h3>[property:number minFilter]</h3>
+		<p>
+			How the texture is sampled when a texel covers less than one pixel. The default is
+			[page:Textures THREE.NearestFilter], which uses the value of the closest texel.<br /><br />
+
+			See the [page:Textures texture constants] page for details.
+		</p>
+
+		<h3>[property:number unpackAlignment]</h3>
+		<p>
+			1 by default. Specifies the alignment requirements for the start of each pixel row in memory.
+			The allowable values are 1 (byte-alignment), 2 (rows aligned to even-numbered bytes),
+			4 (word-alignment), and 8 (rows start on double-word boundaries).
+			See [link:https://registry.khronos.org/OpenGL-Refpages/es3.0/html/glPixelStorei.xhtml glPixelStorei]
+			for more information.
+		</p>
+
+		<h3>[property:number wrapR]</h3>
+		<p>
+			This defines how the texture is wrapped in the depth direction.<br />
+			The default is [page:Textures THREE.ClampToEdgeWrapping], where the edge is clamped to the outer edge texels.
+			The other two choices are [page:Textures THREE.RepeatWrapping] and [page:Textures THREE.MirroredRepeatWrapping].
+			See the [page:Textures texture constants] page for details.
 		</p>
 
 		<h2>Methods</h2>
 
 		<p>
-		See the base [page:Texture Texture] class for common methods.
+			See the base [page:Texture Texture] class for common methods.
 		</p>
 
 		<h2>Source</h2>


### PR DESCRIPTION
Related issue: none.

Description

Update the "en" version of the DataArrayTexture API documentation.

Add full list of examples.
Document properties as they differ from the base class. Consistent formatting of html.