### PR TITLE
WebGLRenderer: only account for pixel ratio when applying scissor, viewport to canvas

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -462,7 +462,16 @@ function WebGLRenderer( parameters = {} ) {
 
 		}
 
-		state.viewport( _currentViewport.copy( _viewport ).multiplyScalar( _pixelRatio ).floor() );
+		_currentViewport.copy( _viewport );
+
+		// pixel ratio only applies to the canvas
+		if ( _currentRenderTarget === null ) {
+
+			_currentViewport.multiplyScalar( _pixelRatio );
+
+		}
+
+		state.viewport( _currentViewport.floor() );
 
 	};
 
@@ -484,7 +493,16 @@ function WebGLRenderer( parameters = {} ) {
 
 		}
 
-		state.scissor( _currentScissor.copy( _scissor ).multiplyScalar( _pixelRatio ).floor() );
+		_currentScissor.copy( _scissor );
+
+		// pixel ratio only applies to the canvas
+		if ( _currentRenderTarget === null ) {
+
+			_currentScissor.multiplyScalar( _pixelRatio );
+
+		}
+
+		state.scissor( _currentScissor.floor() );
 
 	};
 


### PR DESCRIPTION
Related issue: --

**Description**

Untested and made for discussion - the scissor and viewport functions both multiply in `pixelRatio` even when render targets are used which pixel ratio does not apply to. This PR only applies pixel ratio when rendering to the canvas.

I'm also seeing that render targets have their own `viewport` and `scissor` fields which is confusing to me. I expected that scissor and viewport were only properties of the renderer since if you change either after the target has been set the fields and state are out of sync.
