### PR TITLE
Examples: Update IFC example to .outputEncoding = sRGBEncoding

### DIFF
--- a/examples/webgl_loader_ifc.html
+++ b/examples/webgl_loader_ifc.html
@@ -37,6 +37,8 @@
 
 			import { IFCLoader } from 'three/addons/loaders/IFCLoader.js';
 
+			THREE.ColorManagement.legacyMode = false;
+
 			let scene, camera, renderer;
 
 			init();
@@ -118,6 +120,7 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true	} );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setPixelRatio( window.devicePixelRatio );
+				renderer.outputEncoding = THREE.sRGBEncoding;
 				document.body.appendChild( renderer.domElement );
 
 				//Controls


### PR DESCRIPTION
Related:

- https://github.com/mrdoob/three.js/issues/23283
- https://github.com/IFCjs/web-ifc-three/pull/148
- https://github.com/three-types/three-ts-types/issues/342

**Description**

For now this PR changes the display of the IFC model in a probably-not-intended way. I believe after the PR above is merged to IFCjs, that should be resolved.