### PR TITLE
Tests: Update Unit Test Readme

### DIFF
--- a/test/unit/README.md
+++ b/test/unit/README.md
@@ -1,10 +1,25 @@
 ## Setup
 
-- Execute `npm i --prefix test` from root folder
+- Execute `npm install` from the root folder
 
 ## Run
 
 You can run the unit tests in two environments:
 
-- Node.js: Execute `npm run test-unit` from root folder
-- Browser: Execute `npm start` (or run any other local web sever) from root folder and access `http://localhost:8080/test/unit/UnitTests.html` on web browser. (See [How to run things locally](https://threejs.org/docs/#manual/introduction/How-to-run-things-locally))
+- Node.js: Execute `npm run test-unit` from the root folder
+- Browser: Execute `npx servez -p 8080 --ssl` (or run any other local web sever) from the root folder and access `https://localhost:8080/test/unit/UnitTests.html` in a web browser. 
+
+See [How to run things locally](https://threejs.org/docs/#manual/introduction/How-to-run-things-locally) for more information.
+
+## Notes
+
+Some tests can only be run in a browser environment.
+
+For browser tests, futher changes to the library will not be reflected until the page is refreshed.
+
+When adding or updating tests, the cost common cause of test failure is forgetting to change `QUnit.todo` to `QUnit.test` when the test is ready.
+
+## Debugging
+
+To debug a test, add `debugger;` to the test code. Then, run the test in a browser and open the developer tools. The test will stop at the `debugger` statement and you can inspect the code.
+

--- a/test/unit/src/math/ColorManagement.tests.js
+++ b/test/unit/src/math/ColorManagement.tests.js
@@ -24,11 +24,13 @@ export default QUnit.module( 'Maths', () => {
 			// THREE.ColorManagement: .legacyMode=false renamed to .enabled=true in r150.
 
 			console.level = CONSOLE_LEVEL.OFF;
+			const expected = ColorManagement.legacyMode == true;
+			console.level = CONSOLE_LEVEL.DEFAULT;
+
 			assert.ok(
-				ColorManagement.legacyMode == true,
+				expected,
 				'ColorManagement.legacyMode is true by default.'
 			);
-			console.level = CONSOLE_LEVEL.DEFAULT;
 
 		} );
 

--- a/test/unit/src/math/ColorManagement.tests.js
+++ b/test/unit/src/math/ColorManagement.tests.js
@@ -2,17 +2,33 @@
 
 import { ColorManagement } from '../../../../src/math/ColorManagement.js';
 
+import { CONSOLE_LEVEL } from '../../utils/console-wrapper.js';
+
 export default QUnit.module( 'Maths', () => {
 
 	QUnit.module( 'ColorManagement', () => {
 
 		// PROPERTIES
+		QUnit.test( 'enabled', ( assert ) => {
+
+			assert.ok(
+				ColorManagement.enabled == false,
+				'ColorManagement.enabled is false by default.'
+			);
+
+		} );
+
 		QUnit.test( 'legacyMode', ( assert ) => {
 
+			// surpress the following console message during testing
+			// THREE.ColorManagement: .legacyMode=false renamed to .enabled=true in r150.
+
+			console.level = CONSOLE_LEVEL.OFF;
 			assert.ok(
 				ColorManagement.legacyMode == true,
 				'ColorManagement.legacyMode is true by default.'
 			);
+			console.level = CONSOLE_LEVEL.DEFAULT;
 
 		} );
 


### PR DESCRIPTION
Related issue :#25380

**Description**

Update unit test readme to reflect changes since #25380 

Avoid building the library and flagging the files as changed (tests run off source) 
Add notes to help people running unit tests.
ColorManagement.enabled is false by default. #24940
Tune logging so only test failure messages are displayed. 581c70b8214d6e62d33036c25039ece5dda2eff8
