### PR TITLE
Puppeteer E2E test: Enable usage of MacOS ARM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
         run: npm run test-e2e
       - name: Upload output screenshots
         uses: actions/upload-artifact@v3
+        if: always()
         with:
           name: Output screenshots
           path: test/e2e/output-screenshots

--- a/test/e2e/puppeteer.js
+++ b/test/e2e/puppeteer.js
@@ -100,7 +100,7 @@ const exceptionList = [
 const PLATFORMS = {
 	linux: 'linux',
 	mac: 'mac',
-	mac_arm: 'mac_am64',
+	mac_arm: 'mac_arm64',
 	win32: 'win',
 	win64: 'win64'
 };
@@ -268,7 +268,7 @@ async function main() {
 
 async function downloadLatestChromium() {
 
-	const browserFetcher = new BrowserFetcher( { path: 'test/e2e/chromium' } );
+	const browserFetcher = new BrowserFetcher( { path: 'test/e2e/chromium', useMacOSARMBinary: true } ); // ARM binary is experimental
 
 	const os = PLATFORMS[ browserFetcher.platform() ];
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/25450#issuecomment-1419893034 https://github.com/mrdoob/three.js/pull/25450#issuecomment-1419907690

**Description**

Enable Puppeteer to use MacOS ARM binary.