### PR TITLE
Builds: Add deprecation warning to `build/three.js` and `build/three.min.js`.

### DIFF
--- a/build/three.js
+++ b/build/three.js
@@ -1,3 +1,4 @@
+console.warn( 'This build file will be removed with r160. Have a look at the Installation guide for alternative three.js setups: https://threejs.org/docs/index.html#manual/en/introduction/Installation' );
 /**
  * @license
  * Copyright 2010-2023 Three.js Authors

--- a/build/three.js
+++ b/build/three.js
@@ -1,4 +1,4 @@
-console.warn( 'This build file will be removed with r160. Have a look at the Installation guide for alternative three.js setups: https://threejs.org/docs/index.html#manual/en/introduction/Installation' );
+console.warn( 'Scripts "build/three.js" and "build/three.min.js" are deprecated with r150+, and will be removed with r160. Please use ES Modules or alternatives: https://threejs.org/docs/index.html#manual/en/introduction/Installation' );
 /**
  * @license
  * Copyright 2010-2023 Three.js Authors

--- a/build/three.min.js
+++ b/build/three.min.js
@@ -1,3 +1,4 @@
+console.warn( 'This build file will be removed with r160. Have a look at the Installation guide for alternative three.js setups: https://threejs.org/docs/index.html#manual/en/introduction/Installation' );
 /**
  * @license
  * Copyright 2010-2023 Three.js Authors

--- a/build/three.min.js
+++ b/build/three.min.js
@@ -1,4 +1,4 @@
-console.warn( 'This build file will be removed with r160. Have a look at the Installation guide for alternative three.js setups: https://threejs.org/docs/index.html#manual/en/introduction/Installation' );
+console.warn( 'Scripts "build/three.js" and "build/three.min.js" are deprecated with r150+, and will be removed with r160. Please use ES Modules or alternatives: https://threejs.org/docs/index.html#manual/en/introduction/Installation' );
 /**
  * @license
  * Copyright 2010-2023 Three.js Authors

--- a/utils/build/rollup.config.js
+++ b/utils/build/rollup.config.js
@@ -269,7 +269,7 @@ function deprecationWarning() {
 
 		renderChunk( code ) {
 
-			return `console.warn( 'This build file will be removed with r160. Have a look at the Installation guide for alternative three.js setups: https://threejs.org/docs/index.html#manual/en/introduction/Installation' );
+			return `console.warn( 'Scripts "build/three.js" and "build/three.min.js" are deprecated with r150+, and will be removed with r160. Please use ES Modules or alternatives: https://threejs.org/docs/index.html#manual/en/introduction/Installation' );
 ${ code }`;
 
 		}

--- a/utils/build/rollup.config.js
+++ b/utils/build/rollup.config.js
@@ -263,6 +263,21 @@ ${ code }`;
 
 }
 
+function deprecationWarning() {
+
+	return {
+
+		renderChunk( code ) {
+
+			return `console.warn( 'This build file will be removed with r160. Have a look at the Installation guide for alternative three.js setups: https://threejs.org/docs/index.html#manual/en/introduction/Installation' );
+${ code }`;
+
+		}
+
+	};
+
+}
+
 const builds = [
 	{
 		input: 'src/Three.js',
@@ -288,12 +303,6 @@ const builds = [
 		],
 		output: [
 			{
-				format: 'umd',
-				name: 'THREE',
-				file: 'build/three.js',
-				indent: '\t'
-			},
-			{
 				format: 'cjs',
 				name: 'THREE',
 				file: 'build/three.cjs',
@@ -305,10 +314,28 @@ const builds = [
 		input: 'src/Three.js',
 		plugins: [
 			addons(),
+			glsl(),
+			header(),
+			deprecationWarning()
+		],
+		output: [
+			{
+				format: 'umd',
+				name: 'THREE',
+				file: 'build/three.js',
+				indent: '\t'
+			}
+		]
+	},
+	{
+		input: 'src/Three.js',
+		plugins: [
+			addons(),
 			glconstants(),
 			glsl(),
 			terser(),
-			header()
+			header(),
+			deprecationWarning()
 		],
 		output: [
 			{


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/25435#issuecomment-1420622940

**Description**

Like suggested in https://github.com/mrdoob/three.js/pull/25435#issuecomment-1420622940, this PR adds a deprecation warning to `build/three.js` and `build/three.min.js`.

Right now, the warning mentioned r160 is the release where the builds are going to be removed and guides towards the [Installation](https://threejs.org/docs/index.html#manual/en/introduction/Installation) guide for alternatives setups.

I'm not sure we want to recommend the `window.THREE = THREE;` pattern since it is somewhat a hack. Ideally, users decide for an ESM workflow or a build tool.
