### PR TITLE
CI: Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,6 @@ jobs:
           cache: 'npm'
       - name: Install packages
         run: npm ci
-      - name: Build
-        run: npm run build
 
       - name: === Unit testing ===
         run: npm run test-unit


### PR DESCRIPTION
Related issue: none.

**Description**

Update the CI commands for Unit Tests.  Removes the build command in the unit test setup.

Unit tests run off of the source, they don't use the build.  Like the linting commands, save time on checks by omitting this unused step.
