### PR TITLE
GLTFLoader: Remove special case for normalized skin weights

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -3568,10 +3568,9 @@ class GLTFParser {
 						? new SkinnedMesh( geometry, material )
 						: new Mesh( geometry, material );
 
-					if ( mesh.isSkinnedMesh === true && ! mesh.geometry.attributes.skinWeight.normalized ) {
+					if ( mesh.isSkinnedMesh === true ) {
 
-						// we normalize floating point skin weight array to fix malformed assets (see #15319)
-						// it's important to skip this for non-float32 data since normalizeSkinWeights assumes non-normalized inputs
+						// normalize skin weights to fix malformed assets (see #15319)
 						mesh.normalizeSkinWeights();
 
 					}


### PR DESCRIPTION
Related:

- #15319

GLTFLoader currently normalizes skin weights only for float32 `skinWeight` attributes, because SkinnedMesh.normalizeSkinWeights previously didn't support normalized vertex attributes. With recent changes (#22874) it now does, so we don't need that exception.