### PR TITLE
Tests: Refinements and Additions

### DIFF
--- a/test/unit/src/math/ColorManagement.tests.js
+++ b/test/unit/src/math/ColorManagement.tests.js
@@ -11,8 +11,8 @@ export default QUnit.module( 'Maths', () => {
 		// PROPERTIES
 		QUnit.test( 'enabled', ( assert ) => {
 
-			assert.ok(
-				ColorManagement.enabled == false,
+			assert.strictEqual(
+				ColorManagement.enabled, false,
 				'ColorManagement.enabled is false by default.'
 			);
 
@@ -24,7 +24,7 @@ export default QUnit.module( 'Maths', () => {
 			// THREE.ColorManagement: .legacyMode=false renamed to .enabled=true in r150.
 
 			console.level = CONSOLE_LEVEL.OFF;
-			const expected = ColorManagement.legacyMode == true;
+			const expected = ColorManagement.legacyMode === true;
 			console.level = CONSOLE_LEVEL.DEFAULT;
 
 			assert.ok(

--- a/test/unit/src/renderers/WebGL1Renderer.tests.js
+++ b/test/unit/src/renderers/WebGL1Renderer.tests.js
@@ -20,9 +20,10 @@ export default QUnit.module( 'Renderers', () => {
 		} );
 
 		// INSTANCING
-		QUnit.todo( 'Instancing', ( assert ) => {
+		QUnit.test( 'Instancing', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const renderer = new WebGL1Renderer();
+			assert.ok( renderer, 'Can instantiate a WebGL1Renderer.' );
 
 		} );
 

--- a/test/unit/src/renderers/WebGL3DRenderTarget.tests.js
+++ b/test/unit/src/renderers/WebGL3DRenderTarget.tests.js
@@ -20,9 +20,10 @@ export default QUnit.module( 'Renderers', () => {
 		} );
 
 		// INSTANCING
-		QUnit.todo( 'Instancing', ( assert ) => {
+		QUnit.test( 'Instancing', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const object = new WebGL3DRenderTarget();
+			assert.ok( object, 'Can instantiate a WebGL3DRenderTarget.' );
 
 		} );
 

--- a/test/unit/src/renderers/WebGLArrayRenderTarget.tests.js
+++ b/test/unit/src/renderers/WebGLArrayRenderTarget.tests.js
@@ -20,9 +20,10 @@ export default QUnit.module( 'Renderers', () => {
 		} );
 
 		// INSTANCING
-		QUnit.todo( 'Instancing', ( assert ) => {
+		QUnit.test( 'Instancing', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const object = new WebGLArrayRenderTarget();
+			assert.ok( object, 'Can instantiate a WebGLArrayRenderTarget.' );
 
 		} );
 

--- a/test/unit/src/renderers/WebGLCubeRenderTarget.tests.js
+++ b/test/unit/src/renderers/WebGLCubeRenderTarget.tests.js
@@ -20,9 +20,10 @@ export default QUnit.module( 'Renderers', () => {
 		} );
 
 		// INSTANCING
-		QUnit.todo( 'Instancing', ( assert ) => {
+		QUnit.test( 'Instancing', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const object = new WebGLCubeRenderTarget();
+			assert.ok( object, 'Can instantiate a WebGLCubeRenderTarget.' );
 
 		} );
 

--- a/test/unit/src/renderers/WebGLMultipleRenderTargets.tests.js
+++ b/test/unit/src/renderers/WebGLMultipleRenderTargets.tests.js
@@ -20,9 +20,10 @@ export default QUnit.module( 'Renderers', () => {
 		} );
 
 		// INSTANCING
-		QUnit.todo( 'Instancing', ( assert ) => {
+		QUnit.test( 'Instancing', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const object = new WebGLMultipleRenderTargets();
+			assert.ok( object, 'Can instantiate a WebGLMultipleRenderTargets.' );
 
 		} );
 

--- a/test/unit/src/renderers/WebGLRenderer.tests.js
+++ b/test/unit/src/renderers/WebGLRenderer.tests.js
@@ -10,7 +10,7 @@ export default QUnit.module( 'Renderers', () => {
 		QUnit.test( 'Instancing', ( assert ) => {
 
 			const renderer = new WebGLRenderer();
-			assert.ok( renderer, 'Can instantiate a renderer.' );
+			assert.ok( renderer, 'Can instantiate a WebGLRenderer.' );
 
 		} );
 

--- a/test/unit/src/scenes/Fog.tests.js
+++ b/test/unit/src/scenes/Fog.tests.js
@@ -7,9 +7,21 @@ export default QUnit.module( 'Scenes', () => {
 	QUnit.module( 'Fog', () => {
 
 		// INSTANCING
-		QUnit.todo( 'Instancing', ( assert ) => {
+		QUnit.test( 'Instancing', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			// Fog( color, near = 1, far = 1000 )
+
+			// no params
+			const object = new Fog();
+			assert.ok( object, 'Can instantiate a Fog.' );
+
+			// color
+			const object_color = new Fog( 0xffffff );
+			assert.ok( object_color, 'Can instantiate a Fog with color.' );
+
+			// color, near, far
+			const object_all = new Fog( 0xffffff, 0.015, 100 );
+			assert.ok( object_all, 'Can instantiate a Fog with color, near, far.' );
 
 		} );
 

--- a/test/unit/src/scenes/FogExp2.tests.js
+++ b/test/unit/src/scenes/FogExp2.tests.js
@@ -7,9 +7,21 @@ export default QUnit.module( 'Scenes', () => {
 	QUnit.module( 'FoxExp2', () => {
 
 		// INSTANCING
-		QUnit.todo( 'Instancing', ( assert ) => {
+		QUnit.test( 'Instancing', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			// FoxExp2( color, density = 0.00025 )
+
+			// no params
+			const object = new FogExp2();
+			assert.ok( object, 'Can instantiate a FogExp2.' );
+
+			// color
+			const object_color = new FogExp2( 0xffffff );
+			assert.ok( object_color, 'Can instantiate a FogExp2 with color.' );
+
+			// color, density
+			const object_all = new FogExp2( 0xffffff, 0.00030 );
+			assert.ok( object_all, 'Can instantiate a FogExp2 with color, density.' );
 
 		} );
 

--- a/test/unit/src/textures/CompressedArrayTexture.tests.js
+++ b/test/unit/src/textures/CompressedArrayTexture.tests.js
@@ -2,7 +2,7 @@
 
 import { CompressedArrayTexture } from '../../../../src/textures/CompressedArrayTexture.js';
 
-import { Texture } from '../../../../src/textures/Texture.js';
+import { CompressedTexture } from '../../../../src/textures/CompressedTexture.js';
 
 export default QUnit.module( 'Textures', () => {
 
@@ -13,8 +13,8 @@ export default QUnit.module( 'Textures', () => {
 
 			const object = new CompressedArrayTexture();
 			assert.strictEqual(
-				object instanceof Texture, true,
-				'CompressedArrayTexture extends from Texture'
+				object instanceof CompressedTexture, true,
+				'CompressedArrayTexture extends from CompressedTexture'
 			);
 
 		} );

--- a/test/unit/src/textures/CompressedArrayTexture.tests.js
+++ b/test/unit/src/textures/CompressedArrayTexture.tests.js
@@ -29,6 +29,7 @@ export default QUnit.module( 'Textures', () => {
 		// PROPERTIES
 		QUnit.todo( 'image.depth', ( assert ) => {
 
+			// { width: width, height: height, depth: depth }
 			assert.ok( false, 'everything\'s gonna be alright' );
 
 		} );

--- a/test/unit/src/textures/CompressedTexture.tests.js
+++ b/test/unit/src/textures/CompressedTexture.tests.js
@@ -29,6 +29,7 @@ export default QUnit.module( 'Textures', () => {
 		// PROPERTIES
 		QUnit.todo( 'image', ( assert ) => {
 
+			// { width: width, height: height }
 			assert.ok( false, 'everything\'s gonna be alright' );
 
 		} );


### PR DESCRIPTION
Related issue: none.

**Description**

Adds "webonly" tests for the various renderers, tests for Fog, some refinements. 

#### Relating to: As pointed out in: https://github.com/mrdoob/three.js/pull/25453#discussion_r1098128369

Use correct check in ColorManagement

#### Relating to: https://github.com/mrdoob/three.js/issues/25437#issuecomment-1421532676

Can instantiate a Fog.
Can instantiate a Fog with color.
Can instantiate a Fog with color, near, far.

Can instantiate a FogExp2.
Can instantiate a FogExp2 with color.
Can instantiate a FogExp2 with color, density.
