### PR TITLE
Color: Warn more specifically on bad color specification.

### DIFF
--- a/src/math/Color.js
+++ b/src/math/Color.js
@@ -174,7 +174,7 @@ class Color {
 
 		let m;
 
-		if ( m = /^((?:rgb|hsl)a?)\(([^\)]*)\)/.exec( style ) ) {
+		if ( m = /^(\w+)\(([^\)]*)\)/.exec( style ) ) {
 
 			// rgb / hsl
 
@@ -237,6 +237,10 @@ class Color {
 
 					break;
 
+				default:
+
+					console.warn( 'THREE.Color: Unknown color model ' + style );
+
 			}
 
 		} else if ( m = /^\#([A-Fa-f\d]+)$/.exec( style ) ) {
@@ -268,11 +272,13 @@ class Color {
 
 				return this;
 
+			} else {
+
+				console.warn( 'THREE.Color: Invalid hex color ' + style );
+
 			}
 
-		}
-
-		if ( style && style.length > 0 ) {
+		} else if ( style && style.length > 0 ) {
 
 			return this.setColorName( style, colorSpace );
 


### PR DESCRIPTION
**Description**

If you create a color incorrectly, the error is not very general.

Now the "Unknown color ..." message only applies if the color appears to not be a HEX or CSS-function style color.

e.g. `new THREE.Color("#ff")` previously warned "Unknown color #ee" and now gives "Invalid hex color #ee".

e.g. `new THREE.Color("lab(1,1,1)")` previously warned "Unknown color lab(1,1,1)" and now warns "Unknown color model lab(1,1,1)"