### PR TITLE
Box3: preserves emptiness on `getBoundingSphere()`

### DIFF
--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -404,13 +404,13 @@ class Box3 {
 
 	getBoundingSphere( target ) {
 
-		this.getCenter( target.center );
-
 		if ( this.isEmpty() ) {
 
-			target.radius = - 1;
+			target.makeEmpty();
 
 		} else {
+
+			this.getCenter( target.center );
 
 			target.radius = this.getSize( _vector ).length() * 0.5;
 

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -406,7 +406,15 @@ class Box3 {
 
 		this.getCenter( target.center );
 
-		target.radius = this.getSize( _vector ).length() * 0.5;
+		if ( this.isEmpty() ) {
+
+			target.radius = - 1;
+
+		} else {
+
+			target.radius = this.getSize( _vector ).length() * 0.5;
+
+		}
 
 		return target;
 

--- a/test/unit/src/math/Box3.tests.js
+++ b/test/unit/src/math/Box3.tests.js
@@ -550,6 +550,9 @@ export default QUnit.module( 'Maths', () => {
 			assert.ok( b.getBoundingSphere( sphere ).equals( new Sphere( one3.clone().multiplyScalar( 0.5 ), Math.sqrt( 3 ) * 0.5 ) ), 'Passed!' );
 			assert.ok( c.getBoundingSphere( sphere ).equals( new Sphere( zero3, Math.sqrt( 12 ) * 0.5 ) ), 'Passed!' );
 
+			const d = new Box3().makeEmpty();
+			assert.ok( d.getBoundingSphere( sphere ).radius < 0, 'Empty box\'s bounding sphere is empty' );
+
 		} );
 
 		QUnit.test( 'intersect', ( assert ) => {

--- a/test/unit/src/math/Box3.tests.js
+++ b/test/unit/src/math/Box3.tests.js
@@ -551,7 +551,7 @@ export default QUnit.module( 'Maths', () => {
 			assert.ok( c.getBoundingSphere( sphere ).equals( new Sphere( zero3, Math.sqrt( 12 ) * 0.5 ) ), 'Passed!' );
 
 			const d = new Box3().makeEmpty();
-			assert.ok( d.getBoundingSphere( sphere ).radius < 0, 'Empty box\'s bounding sphere is empty' );
+			assert.ok( d.getBoundingSphere( sphere ).isEmpty(), 'Empty box\'s bounding sphere is empty' );
 
 		} );
 


### PR DESCRIPTION
bounding sphere should be empty for empty box