### PR TITLE
Texture: Honor `internalFormat` in `toJSON()` and `ObjectLoader`.

### DIFF
--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -652,6 +652,7 @@ class ObjectLoader extends Loader {
 				}
 
 				if ( data.format !== undefined ) texture.format = data.format;
+				if ( data.internalFormat !== undefined ) texture.internalFormat = data.internalFormat;
 				if ( data.type !== undefined ) texture.type = data.type;
 				if ( data.encoding !== undefined ) texture.encoding = data.encoding;
 

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -177,6 +177,7 @@ class Texture extends EventDispatcher {
 			wrap: [ this.wrapS, this.wrapT ],
 
 			format: this.format,
+			internalFormat: this.internalFormat,
 			type: this.type,
 			encoding: this.encoding,
 


### PR DESCRIPTION
Related issue: https://discourse.threejs.org/t/how-to-use-integer-texture/47840/6

**Description**

This PR ensures `Texture.internalFormat` can be properly serialized/deserialized.
