### PR TITLE
Puppeteer E2E test: Set timeout to 15 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
   e2e:
     name: "E2E testing"
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/25500#issuecomment-1429286328

**Description**

The default is 6 hours.