### PR TITLE
Puppeteer E2E test: Switch to Chromium beta channel

### DIFF
--- a/test/e2e/puppeteer.js
+++ b/test/e2e/puppeteer.js
@@ -106,7 +106,7 @@ const PLATFORMS = {
 };
 const OMAHA_PROXY = 'https://omahaproxy.appspot.com/all.json';
 
-const chromiumChannel = 'stable'; // stable -> beta -> dev -> canary (Mac and Windows) -> canary_asan (Windows)
+const chromiumChannel = 'beta'; // stable -> beta -> dev -> canary (Mac and Windows) -> canary_asan (Windows)
 
 const port = 1234;
 const pixelThreshold = 0.1; // threshold error in one pixel


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/25503#issuecomment-1429385067

**Description**

OmahaProxy started to return incorrect results for stable Chromium channel.