### PR TITLE
enable camera view offset in CSS3DRenderer

### DIFF
--- a/examples/css3d_orthographic.html
+++ b/examples/css3d_orthographic.html
@@ -178,37 +178,37 @@
 						folder1.children[ 6 ].enable().setValue( window.innerHeight );
 
 					},
-					'fullWidth': NaN,
-					'fullHeight': NaN,
-					'offsetX': NaN,
-					'offsetY': NaN,
-					'width': NaN,
-					'height': NaN,
+					'fullWidth': 0,
+					'fullHeight': 0,
+					'offsetX': 0,
+					'offsetY': 0,
+					'width': 0,
+					'height': 0,
 					'clearViewOffset'() {
 
-						folder1.children[ 1 ].setValue( NaN ).disable();
-						folder1.children[ 2 ].setValue( NaN ).disable();
-						folder1.children[ 3 ].setValue( NaN ).disable();
-						folder1.children[ 4 ].setValue( NaN ).disable();
-						folder1.children[ 5 ].setValue( NaN ).disable();
-						folder1.children[ 6 ].setValue( NaN ).disable();
+						folder1.children[ 1 ].setValue( 0 ).disable();
+						folder1.children[ 2 ].setValue( 0 ).disable();
+						folder1.children[ 3 ].setValue( 0 ).disable();
+						folder1.children[ 4 ].setValue( 0 ).disable();
+						folder1.children[ 5 ].setValue( 0 ).disable();
+						folder1.children[ 6 ].setValue( 0 ).disable();
 						camera.clearViewOffset();
 
 					}
 				};
 
 				folder1.add( settings, 'setViewOffset' );
-				folder1.add( settings, 'fullWidth', window.screen.width / 2, window.screen.width * 2, 1 ).onChange( ( val ) => updateCameraViewOffset( { fullWidth: val } ) ).disable();
-				folder1.add( settings, 'fullHeight', window.screen.height / 2, window.screen.height * 2, 1 ).onChange( ( val ) => updateCameraViewOffset( { fullHeight: val } ) ).disable();
+				folder1.add( settings, 'fullWidth', window.screen.width / 4, window.screen.width * 2, 1 ).onChange( ( val ) => updateCameraViewOffset( { fullWidth: val } ) ).disable();
+				folder1.add( settings, 'fullHeight', window.screen.height / 4, window.screen.height * 2, 1 ).onChange( ( val ) => updateCameraViewOffset( { fullHeight: val } ) ).disable();
 				folder1.add( settings, 'offsetX', 0, 256, 1 ).onChange( ( val ) => updateCameraViewOffset( { x: val } ) ).disable();
 				folder1.add( settings, 'offsetY', 0, 256, 1 ).onChange( ( val ) => updateCameraViewOffset( { y: val } ) ).disable();
-				folder1.add( settings, 'width', window.screen.width / 2, window.screen.width * 2, 1 ).onChange( ( val ) => updateCameraViewOffset( { width: val } ) ).disable();
-				folder1.add( settings, 'height', window.screen.height / 2, window.screen.height * 2, 1 ).onChange( ( val ) => updateCameraViewOffset( { height: val } ) ).disable();
+				folder1.add( settings, 'width', window.screen.width / 4, window.screen.width * 2, 1 ).onChange( ( val ) => updateCameraViewOffset( { width: val } ) ).disable();
+				folder1.add( settings, 'height', window.screen.height / 4, window.screen.height * 2, 1 ).onChange( ( val ) => updateCameraViewOffset( { height: val } ) ).disable();
 				folder1.add( settings, 'clearViewOffset' );
 
-				}
+			}
 
-				function updateCameraViewOffset( { fullWidth, fullHeight, x, y, width, height } ) {
+			function updateCameraViewOffset( { fullWidth, fullHeight, x, y, width, height } ) {
 
 				if ( ! camera.view ) {
 

--- a/examples/css3d_orthographic.html
+++ b/examples/css3d_orthographic.html
@@ -39,6 +39,7 @@
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { CSS3DRenderer, CSS3DObject } from 'three/addons/renderers/CSS3DRenderer.js';
+			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 
 			let camera, scene, renderer;
 
@@ -131,6 +132,7 @@
 				}
 
 				window.addEventListener( 'resize', onWindowResize );
+				createPanel();
 
 			}
 
@@ -157,6 +159,66 @@
 
 				renderer.render( scene, camera );
 				renderer2.render( scene2, camera );
+
+			}
+
+			function createPanel() {
+
+				const panel = new GUI();
+				const folder1 = panel.addFolder( 'camera setViewOffset' ).close();
+
+				const settings = {
+					'setViewOffset'() {
+
+						folder1.children[ 1 ].enable().setValue( window.innerWidth );
+						folder1.children[ 2 ].enable().setValue( window.innerHeight );
+						folder1.children[ 3 ].enable().setValue( 0 );
+						folder1.children[ 4 ].enable().setValue( 0 );
+						folder1.children[ 5 ].enable().setValue( window.innerWidth );
+						folder1.children[ 6 ].enable().setValue( window.innerHeight );
+
+					},
+					'fullWidth': NaN,
+					'fullHeight': NaN,
+					'offsetX': NaN,
+					'offsetY': NaN,
+					'width': NaN,
+					'height': NaN,
+					'clearViewOffset'() {
+
+						folder1.children[ 1 ].setValue( NaN ).disable();
+						folder1.children[ 2 ].setValue( NaN ).disable();
+						folder1.children[ 3 ].setValue( NaN ).disable();
+						folder1.children[ 4 ].setValue( NaN ).disable();
+						folder1.children[ 5 ].setValue( NaN ).disable();
+						folder1.children[ 6 ].setValue( NaN ).disable();
+						camera.clearViewOffset();
+
+					}
+				};
+
+				folder1.add( settings, 'setViewOffset' );
+				folder1.add( settings, 'fullWidth', window.screen.width / 2, window.screen.width * 2, 1 ).onChange( ( val ) => updateCameraViewOffset( { fullWidth: val } ) ).disable();
+				folder1.add( settings, 'fullHeight', window.screen.height / 2, window.screen.height * 2, 1 ).onChange( ( val ) => updateCameraViewOffset( { fullHeight: val } ) ).disable();
+				folder1.add( settings, 'offsetX', 0, 256, 1 ).onChange( ( val ) => updateCameraViewOffset( { x: val } ) ).disable();
+				folder1.add( settings, 'offsetY', 0, 256, 1 ).onChange( ( val ) => updateCameraViewOffset( { y: val } ) ).disable();
+				folder1.add( settings, 'width', window.screen.width / 2, window.screen.width * 2, 1 ).onChange( ( val ) => updateCameraViewOffset( { width: val } ) ).disable();
+				folder1.add( settings, 'height', window.screen.height / 2, window.screen.height * 2, 1 ).onChange( ( val ) => updateCameraViewOffset( { height: val } ) ).disable();
+				folder1.add( settings, 'clearViewOffset' );
+
+				}
+
+				function updateCameraViewOffset( { fullWidth, fullHeight, x, y, width, height } ) {
+
+				if ( ! camera.view ) {
+
+					camera.setViewOffset( fullWidth || window.innerWidth, fullHeight || window.innerHeight, x || 0, y || 0, width || window.innerWidth, height || window.innerHeight );
+
+				} else {
+
+					camera.setViewOffset( fullWidth || camera.view.fullWidth, fullHeight || camera.view.fullHeight, x || camera.view.offsetX, y || camera.view.offsetY, width || camera.view.width, height || camera.view.height );
+
+				}
 
 			}
 

--- a/examples/css3d_sandbox.html
+++ b/examples/css3d_sandbox.html
@@ -35,6 +35,7 @@
 
 			import { TrackballControls } from 'three/addons/controls/TrackballControls.js';
 			import { CSS3DRenderer, CSS3DObject } from 'three/addons/renderers/CSS3DRenderer.js';
+			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 
 			let camera, scene, renderer;
 
@@ -103,6 +104,7 @@
 				controls = new TrackballControls( camera, renderer2.domElement );
 
 				window.addEventListener( 'resize', onWindowResize );
+				createPanel();
 
 			}
 
@@ -126,6 +128,66 @@
 
 				renderer.render( scene, camera );
 				renderer2.render( scene2, camera );
+
+			}
+
+			function createPanel() {
+
+				const panel = new GUI();
+				const folder1 = panel.addFolder( 'camera setViewOffset' ).close();
+
+				const settings = {
+					'setViewOffset'() {
+
+						folder1.children[ 1 ].enable().setValue( window.innerWidth );
+						folder1.children[ 2 ].enable().setValue( window.innerHeight );
+						folder1.children[ 3 ].enable().setValue( 0 );
+						folder1.children[ 4 ].enable().setValue( 0 );
+						folder1.children[ 5 ].enable().setValue( window.innerWidth );
+						folder1.children[ 6 ].enable().setValue( window.innerHeight );
+
+					},
+					'fullWidth': NaN,
+					'fullHeight': NaN,
+					'offsetX': NaN,
+					'offsetY': NaN,
+					'width': NaN,
+					'height': NaN,
+					'clearViewOffset'() {
+
+						folder1.children[ 1 ].setValue( NaN ).disable();
+						folder1.children[ 2 ].setValue( NaN ).disable();
+						folder1.children[ 3 ].setValue( NaN ).disable();
+						folder1.children[ 4 ].setValue( NaN ).disable();
+						folder1.children[ 5 ].setValue( NaN ).disable();
+						folder1.children[ 6 ].setValue( NaN ).disable();
+						camera.clearViewOffset();
+
+					}
+				};
+
+				folder1.add( settings, 'setViewOffset' );
+				folder1.add( settings, 'fullWidth', window.screen.width / 2, window.screen.width * 2, 1 ).onChange( ( val ) => updateCameraViewOffset( { fullWidth: val } ) ).disable();
+				folder1.add( settings, 'fullHeight', window.screen.height / 2, window.screen.height * 2, 1 ).onChange( ( val ) => updateCameraViewOffset( { fullHeight: val } ) ).disable();
+				folder1.add( settings, 'offsetX', 0, 256, 1 ).onChange( ( val ) => updateCameraViewOffset( { x: val } ) ).disable();
+				folder1.add( settings, 'offsetY', 0, 256, 1 ).onChange( ( val ) => updateCameraViewOffset( { y: val } ) ).disable();
+				folder1.add( settings, 'width', window.screen.width / 2, window.screen.width * 2, 1 ).onChange( ( val ) => updateCameraViewOffset( { width: val } ) ).disable();
+				folder1.add( settings, 'height', window.screen.height / 2, window.screen.height * 2, 1 ).onChange( ( val ) => updateCameraViewOffset( { height: val } ) ).disable();
+				folder1.add( settings, 'clearViewOffset' );
+
+			}
+
+			function updateCameraViewOffset( { fullWidth, fullHeight, x, y, width, height } ) {
+
+				if ( ! camera.view ) {
+
+					camera.setViewOffset( fullWidth || window.innerWidth, fullHeight || window.innerHeight, x || 0, y || 0, width || window.innerWidth, height || window.innerHeight );
+
+				} else {
+
+					camera.setViewOffset( fullWidth || camera.view.fullWidth, fullHeight || camera.view.fullHeight, x || camera.view.offsetX, y || camera.view.offsetY, width || camera.view.width, height || camera.view.height );
+
+				}
 
 			}
 

--- a/examples/css3d_sandbox.html
+++ b/examples/css3d_sandbox.html
@@ -147,32 +147,32 @@
 						folder1.children[ 6 ].enable().setValue( window.innerHeight );
 
 					},
-					'fullWidth': NaN,
-					'fullHeight': NaN,
-					'offsetX': NaN,
-					'offsetY': NaN,
-					'width': NaN,
-					'height': NaN,
+					'fullWidth': 0,
+					'fullHeight': 0,
+					'offsetX': 0,
+					'offsetY': 0,
+					'width': 0,
+					'height': 0,
 					'clearViewOffset'() {
 
-						folder1.children[ 1 ].setValue( NaN ).disable();
-						folder1.children[ 2 ].setValue( NaN ).disable();
-						folder1.children[ 3 ].setValue( NaN ).disable();
-						folder1.children[ 4 ].setValue( NaN ).disable();
-						folder1.children[ 5 ].setValue( NaN ).disable();
-						folder1.children[ 6 ].setValue( NaN ).disable();
+						folder1.children[ 1 ].setValue( 0 ).disable();
+						folder1.children[ 2 ].setValue( 0 ).disable();
+						folder1.children[ 3 ].setValue( 0 ).disable();
+						folder1.children[ 4 ].setValue( 0 ).disable();
+						folder1.children[ 5 ].setValue( 0 ).disable();
+						folder1.children[ 6 ].setValue( 0 ).disable();
 						camera.clearViewOffset();
 
 					}
 				};
 
 				folder1.add( settings, 'setViewOffset' );
-				folder1.add( settings, 'fullWidth', window.screen.width / 2, window.screen.width * 2, 1 ).onChange( ( val ) => updateCameraViewOffset( { fullWidth: val } ) ).disable();
-				folder1.add( settings, 'fullHeight', window.screen.height / 2, window.screen.height * 2, 1 ).onChange( ( val ) => updateCameraViewOffset( { fullHeight: val } ) ).disable();
+				folder1.add( settings, 'fullWidth', window.screen.width / 4, window.screen.width * 2, 1 ).onChange( ( val ) => updateCameraViewOffset( { fullWidth: val } ) ).disable();
+				folder1.add( settings, 'fullHeight', window.screen.height / 4, window.screen.height * 2, 1 ).onChange( ( val ) => updateCameraViewOffset( { fullHeight: val } ) ).disable();
 				folder1.add( settings, 'offsetX', 0, 256, 1 ).onChange( ( val ) => updateCameraViewOffset( { x: val } ) ).disable();
 				folder1.add( settings, 'offsetY', 0, 256, 1 ).onChange( ( val ) => updateCameraViewOffset( { y: val } ) ).disable();
-				folder1.add( settings, 'width', window.screen.width / 2, window.screen.width * 2, 1 ).onChange( ( val ) => updateCameraViewOffset( { width: val } ) ).disable();
-				folder1.add( settings, 'height', window.screen.height / 2, window.screen.height * 2, 1 ).onChange( ( val ) => updateCameraViewOffset( { height: val } ) ).disable();
+				folder1.add( settings, 'width', window.screen.width / 4, window.screen.width * 2, 1 ).onChange( ( val ) => updateCameraViewOffset( { width: val } ) ).disable();
+				folder1.add( settings, 'height', window.screen.height / 4, window.screen.height * 2, 1 ).onChange( ( val ) => updateCameraViewOffset( { height: val } ) ).disable();
 				folder1.add( settings, 'clearViewOffset' );
 
 			}
@@ -182,10 +182,14 @@
 				if ( ! camera.view ) {
 
 					camera.setViewOffset( fullWidth || window.innerWidth, fullHeight || window.innerHeight, x || 0, y || 0, width || window.innerWidth, height || window.innerHeight );
+					camera.aspect = window.innerWidth / window.innerHeight;
+					camera.updateProjectionMatrix();
 
 				} else {
 
 					camera.setViewOffset( fullWidth || camera.view.fullWidth, fullHeight || camera.view.fullHeight, x || camera.view.offsetX, y || camera.view.offsetY, width || camera.view.width, height || camera.view.height );
+					camera.aspect = window.innerWidth / window.innerHeight;
+					camera.updateProjectionMatrix();
 
 				}
 

--- a/examples/jsm/renderers/CSS3DRenderer.js
+++ b/examples/jsm/renderers/CSS3DRenderer.js
@@ -177,9 +177,14 @@ class CSS3DRenderer {
 
 			}
 
+			const scaleByViewOffset =
+				! camera.view || ! camera.view.enabled ? 1 :
+					camera.isOrthographicCamera ? camera.view.height / camera.view.fullHeight :
+						camera.isPerspectiveCamera ? camera.view.height / _height : 1;
+
 			const cameraCSSMatrix = camera.isOrthographicCamera ?
-				'scale(' + fov + ')' + ` scale( ${ 1 / ( camera.view && camera.view.enabled ? camera.view.fullHeight / camera.view.height : 1 ) } )` + 'translate(' + epsilon( tx ) + 'px,' + epsilon( ty ) + 'px)' + getCameraCSSMatrix( camera.matrixWorldInverse ) :
-				'translateZ(' + fov + 'px)' + getCameraCSSMatrix( camera.matrixWorldInverse );
+				'scale(' + fov + ')' + `scale( ${ scaleByViewOffset } )` + 'translate(' + epsilon( tx ) + 'px,' + epsilon( ty ) + 'px)' + getCameraCSSMatrix( camera.matrixWorldInverse ) :
+				`scale( ${ scaleByViewOffset } )` + 'translateZ(' + fov + 'px)' + getCameraCSSMatrix( camera.matrixWorldInverse );
 
 			const style = cameraCSSMatrix +
 				'translate(' + _widthHalf + 'px,' + _heightHalf + 'px)';

--- a/examples/jsm/renderers/CSS3DRenderer.js
+++ b/examples/jsm/renderers/CSS3DRenderer.js
@@ -138,26 +138,11 @@ class CSS3DRenderer {
 
 			if ( camera.view && camera.view.enabled ) {
 
-				if ( camera.isPerspectiveCamera ) {
+				// view offset
+				viewElement.style.transform = `translate( ${ - camera.view.offsetX * ( _width / camera.view.width ) }px, ${ - camera.view.offsetY * ( _height / camera.view.height ) }px )`;
 
-					// view offset
-					viewElement.style.transform = `translate( ${ - camera.view.offsetX * ( _width / camera.view.width ) }px, ${ - camera.view.offsetY * ( _height / camera.view.height ) }px )`;
-
-					// view width and height
-					viewElement.style.transform += `scale( ${ _width / camera.view.width }, ${ _height / camera.view.height } )`;
-
-					// view fullWidth and fullHeight
-					viewElement.style.transform += `translate( ${ ( camera.view.fullWidth - _width ) * .5 }px, ${ ( camera.view.fullHeight - _height ) * .5 }px )`;
-
-				} else if ( camera.isOrthographicCamera ) {
-
-					// view offset
-					viewElement.style.transform = `translate( ${ - camera.view.offsetX * ( _width / camera.view.width ) }px, ${ - camera.view.offsetY * ( _height / camera.view.height ) }px )`;
-
-					// view fullWidth and fullHeight, view width and height
-					viewElement.style.transform += `scale( ${ camera.view.fullWidth / camera.view.width }, ${ camera.view.fullHeight / camera.view.height } )`;
-
-				}
+				// view fullWidth and fullHeight, view width and height
+				viewElement.style.transform += `scale( ${ camera.view.fullWidth / camera.view.width }, ${ camera.view.fullHeight / camera.view.height } )`;
 
 			} else {
 
@@ -177,13 +162,9 @@ class CSS3DRenderer {
 
 			}
 
-			const scaleByViewOffset =
-				! camera.view || ! camera.view.enabled ? 1 :
-					camera.isOrthographicCamera ? camera.view.height / camera.view.fullHeight :
-						camera.isPerspectiveCamera ? camera.view.height / _height : 1;
-
+			const scaleByViewOffset = camera.view && camera.view.enabled ? camera.view.height / camera.view.fullHeight : 1;
 			const cameraCSSMatrix = camera.isOrthographicCamera ?
-				'scale(' + fov + ')' + `scale( ${ scaleByViewOffset } )` + 'translate(' + epsilon( tx ) + 'px,' + epsilon( ty ) + 'px)' + getCameraCSSMatrix( camera.matrixWorldInverse ) :
+				`scale( ${ scaleByViewOffset } )` + 'scale(' + fov + ')' + 'translate(' + epsilon( tx ) + 'px,' + epsilon( ty ) + 'px)' + getCameraCSSMatrix( camera.matrixWorldInverse ) :
 				`scale( ${ scaleByViewOffset } )` + 'translateZ(' + fov + 'px)' + getCameraCSSMatrix( camera.matrixWorldInverse );
 
 			const style = cameraCSSMatrix +


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/21723

**Description**

Currently, CSS3DRenderer ignores `camera.setViewOffset()`.
This PR is for enabling camera's viewOffset in CSS3DRenderer for both PerspectiveCamera and OrthographicCamera.

Also, I added viewOffset controls into:
- examples/css3d_orthographic.html
- examples/css3d_sandbox.html

<video src="https://user-images.githubusercontent.com/212837/218791632-1ccb9b2c-c6c8-4084-909c-7f0bb330ffa1.mp4"></video>

<video src="https://user-images.githubusercontent.com/212837/218791720-9db10975-b162-4551-aed4-111b8498df77.mp4"></video>