### PR TITLE
fix: `withCredentials` not set in `TextureLoader`

### DIFF
--- a/src/loaders/TextureLoader.js
+++ b/src/loaders/TextureLoader.js
@@ -17,6 +17,7 @@ class TextureLoader extends Loader {
 		const loader = new ImageLoader( this.manager );
 		loader.setCrossOrigin( this.crossOrigin );
 		loader.setPath( this.path );
+		loader.setWithCredentials( this.withCredentials );
 
 		loader.load( url, function ( image ) {
 


### PR DESCRIPTION
Fixes: https://github.com/google/model-viewer/issues/4083#issuecomment-1432694855