### PR TITLE
ColorManagement: Add Display P3 transforms

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -150,6 +150,7 @@ export const ObjectSpaceNormalMap = 1;
 export const NoColorSpace = '';
 export const SRGBColorSpace = 'srgb';
 export const LinearSRGBColorSpace = 'srgb-linear';
+export const DisplayP3ColorSpace = 'display-p3';
 
 export const ZeroStencilOp = 0;
 export const KeepStencilOp = 7680;

--- a/src/extras/ImageUtils.js
+++ b/src/extras/ImageUtils.js
@@ -1,5 +1,5 @@
 import { createElementNS } from '../utils.js';
-import { SRGBToLinear } from '../math/Color.js';
+import { SRGBToLinear } from '../math/ColorManagement.js';
 
 let _canvas;
 

--- a/src/math/Color.js
+++ b/src/math/Color.js
@@ -27,7 +27,6 @@ const _colorKeywords = { 'aliceblue': 0xF0F8FF, 'antiquewhite': 0xFAEBD7, 'aqua'
 	'springgreen': 0x00FF7F, 'steelblue': 0x4682B4, 'tan': 0xD2B48C, 'teal': 0x008080, 'thistle': 0xD8BFD8, 'tomato': 0xFF6347, 'turquoise': 0x40E0D0,
 	'violet': 0xEE82EE, 'wheat': 0xF5DEB3, 'white': 0xFFFFFF, 'whitesmoke': 0xF5F5F5, 'yellow': 0xFFFF00, 'yellowgreen': 0x9ACD32 };
 
-const _rgb = { r: 0, g: 0, b: 0 };
 const _hslA = { h: 0, s: 0, l: 0 };
 const _hslB = { h: 0, s: 0, l: 0 };
 
@@ -39,16 +38,6 @@ function hue2rgb( p, q, t ) {
 	if ( t < 1 / 2 ) return q;
 	if ( t < 2 / 3 ) return p + ( q - p ) * 6 * ( 2 / 3 - t );
 	return p;
-
-}
-
-function toComponents( source, target ) {
-
-	target.r = source.r;
-	target.g = source.g;
-	target.b = source.b;
-
-	return target;
 
 }
 
@@ -363,9 +352,9 @@ class Color {
 
 	getHex( colorSpace = SRGBColorSpace ) {
 
-		ColorManagement.fromWorkingColorSpace( toComponents( this, _rgb ), colorSpace );
+		ColorManagement.fromWorkingColorSpace( _color.copy( this ), colorSpace );
 
-		return clamp( _rgb.r * 255, 0, 255 ) << 16 ^ clamp( _rgb.g * 255, 0, 255 ) << 8 ^ clamp( _rgb.b * 255, 0, 255 ) << 0;
+		return clamp( _color.r * 255, 0, 255 ) << 16 ^ clamp( _color.g * 255, 0, 255 ) << 8 ^ clamp( _color.b * 255, 0, 255 ) << 0;
 
 	}
 
@@ -379,9 +368,9 @@ class Color {
 
 		// h,s,l ranges are in 0.0 - 1.0
 
-		ColorManagement.fromWorkingColorSpace( toComponents( this, _rgb ), colorSpace );
+		ColorManagement.fromWorkingColorSpace( _color.copy( this ), colorSpace );
 
-		const r = _rgb.r, g = _rgb.g, b = _rgb.b;
+		const r = _color.r, g = _color.g, b = _color.b;
 
 		const max = Math.max( r, g, b );
 		const min = Math.min( r, g, b );
@@ -422,11 +411,11 @@ class Color {
 
 	getRGB( target, colorSpace = ColorManagement.workingColorSpace ) {
 
-		ColorManagement.fromWorkingColorSpace( toComponents( this, _rgb ), colorSpace );
+		ColorManagement.fromWorkingColorSpace( _color.copy( this ), colorSpace );
 
-		target.r = _rgb.r;
-		target.g = _rgb.g;
-		target.b = _rgb.b;
+		target.r = _color.r;
+		target.g = _color.g;
+		target.b = _color.b;
 
 		return target;
 
@@ -434,16 +423,16 @@ class Color {
 
 	getStyle( colorSpace = SRGBColorSpace ) {
 
-		ColorManagement.fromWorkingColorSpace( toComponents( this, _rgb ), colorSpace );
+		ColorManagement.fromWorkingColorSpace( _color.copy( this ), colorSpace );
 
 		if ( colorSpace !== SRGBColorSpace ) {
 
 			// Requires CSS Color Module Level 4 (https://www.w3.org/TR/css-color-4/).
-			return `color(${ colorSpace } ${ _rgb.r } ${ _rgb.g } ${ _rgb.b })`;
+			return `color(${ colorSpace } ${ _color.r } ${ _color.g } ${ _color.b })`;
 
 		}
 
-		return `rgb(${( _rgb.r * 255 ) | 0},${( _rgb.g * 255 ) | 0},${( _rgb.b * 255 ) | 0})`;
+		return `rgb(${( _color.r * 255 ) | 0},${( _color.g * 255 ) | 0},${( _color.b * 255 ) | 0})`;
 
 	}
 
@@ -606,6 +595,8 @@ class Color {
 
 }
 
+const _color = new Color();
+
 Color.NAMES = _colorKeywords;
 
-export { Color, SRGBToLinear };
+export { Color };

--- a/src/math/Color.js
+++ b/src/math/Color.js
@@ -425,14 +425,16 @@ class Color {
 
 		ColorManagement.fromWorkingColorSpace( _color.copy( this ), colorSpace );
 
+		const r = _color.r, g = _color.g, b = _color.b;
+
 		if ( colorSpace !== SRGBColorSpace ) {
 
 			// Requires CSS Color Module Level 4 (https://www.w3.org/TR/css-color-4/).
-			return `color(${ colorSpace } ${ _color.r } ${ _color.g } ${ _color.b })`;
+			return `color(${ colorSpace } ${ r.toFixed( 3 ) } ${ g.toFixed( 3 ) } ${ b.toFixed( 3 ) })`;
 
 		}
 
-		return `rgb(${( _color.r * 255 ) | 0},${( _color.g * 255 ) | 0},${( _color.b * 255 ) | 0})`;
+		return `rgb(${( r * 255 ) | 0},${( g * 255 ) | 0},${( b * 255 ) | 0})`;
 
 	}
 

--- a/src/math/ColorManagement.js
+++ b/src/math/ColorManagement.js
@@ -88,7 +88,7 @@ const FROM_LINEAR = {
 	[ LinearSRGBColorSpace ]: ( color ) => color,
 	[ SRGBColorSpace ]: ( color ) => color.convertLinearToSRGB(),
 	[ DisplayP3ColorSpace ]: LinearSRGBToDisplayP3,
-}
+};
 
 export const ColorManagement = {
 

--- a/src/math/ColorManagement.js
+++ b/src/math/ColorManagement.js
@@ -1,4 +1,4 @@
-import { SRGBColorSpace, LinearSRGBColorSpace, DisplayP3ColorSpace, NoColorSpace, } from '../constants.js';
+import { SRGBColorSpace, LinearSRGBColorSpace, DisplayP3ColorSpace, } from '../constants.js';
 import { Matrix3 } from './Matrix3.js';
 import { Vector3 } from './Vector3.js';
 
@@ -27,9 +27,9 @@ export function LinearToSRGB( c ) {
 const SRGB_TO_DISPLAY_P3 = new Matrix3().multiplyMatrices(
 	// XYZ to Display P3
 	new Matrix3().set(
-		2.4039840, -0.9899069, -0.3976415,
-		-0.8422229, 1.7988437, 0.0160354,
-		0.0482059, -0.0974068, 1.2740049,
+		2.4039840, - 0.9899069, - 0.3976415,
+		- 0.8422229, 1.7988437, 0.0160354,
+		0.0482059, - 0.0974068, 1.2740049,
 	),
 	// sRGB to XYZ
 	new Matrix3().set(
@@ -42,15 +42,15 @@ const SRGB_TO_DISPLAY_P3 = new Matrix3().multiplyMatrices(
 const DISPLAY_P3_TO_SRGB = new Matrix3().multiplyMatrices(
 	// XYZ to sRGB
 	new Matrix3().set(
-		3.1341864, -1.6172090, -0.4906941,
-		-0.9787485, 1.9161301, 0.0334334,
-		0.0719639, -0.2289939, 1.4057537,
+		3.1341864, - 1.6172090, - 0.4906941,
+		- 0.9787485, 1.9161301, 0.0334334,
+		0.0719639, - 0.2289939, 1.4057537,
 	),
 	// Display P3 to XYZ
 	new Matrix3().set(
 		0.5151187, 0.2919778, 0.1571035,
 		0.2411892, 0.6922441, 0.0665668,
-		-0.0010505, 0.0418791, 0.7840713,
+		- 0.0010505, 0.0418791, 0.7840713,
 	),
 );
 

--- a/src/math/ColorManagement.js
+++ b/src/math/ColorManagement.js
@@ -56,7 +56,7 @@ const DISPLAY_P3_TO_SRGB = new Matrix3().multiplyMatrices(
 
 const _vector = new Vector3();
 
-function DisplayP3ToLinear( color ) {
+function DisplayP3ToLinearSRGB( color ) {
 
 	_vector.set( color.r, color.g, color.b ).applyMatrix3( DISPLAY_P3_TO_SRGB );
 
@@ -66,7 +66,7 @@ function DisplayP3ToLinear( color ) {
 
 }
 
-function LinearToDisplayP3( color ) {
+function LinearSRGBToDisplayP3( color ) {
 
 	color.convertLinearToSRGB();
 
@@ -80,14 +80,14 @@ function LinearToDisplayP3( color ) {
 const TO_LINEAR = {
 	[ LinearSRGBColorSpace ]: ( color ) => color,
 	[ SRGBColorSpace ]: ( color ) => color.convertSRGBToLinear(),
-	[ DisplayP3ColorSpace ]: DisplayP3ToLinear,
+	[ DisplayP3ColorSpace ]: DisplayP3ToLinearSRGB,
 };
 
 // Conversions to <target> from Linear-sRGB reference space.
 const FROM_LINEAR = {
 	[ LinearSRGBColorSpace ]: ( color ) => color,
 	[ SRGBColorSpace ]: ( color ) => color.convertLinearToSRGB(),
-	[ DisplayP3ColorSpace ]: LinearToDisplayP3,
+	[ DisplayP3ColorSpace ]: LinearSRGBToDisplayP3,
 }
 
 export const ColorManagement = {

--- a/src/math/ColorManagement.js
+++ b/src/math/ColorManagement.js
@@ -58,21 +58,19 @@ const _vector = new Vector3();
 
 function DisplayP3ToLinearSRGB( color ) {
 
+	color.convertSRGBToLinear();
+
 	_vector.set( color.r, color.g, color.b ).applyMatrix3( DISPLAY_P3_TO_SRGB );
 
-	color.setRGB( _vector.x, _vector.y, _vector.z );
-
-	return color.convertSRGBToLinear();
+	return color.setRGB( _vector.x, _vector.y, _vector.z );
 
 }
 
 function LinearSRGBToDisplayP3( color ) {
 
-	color.convertLinearToSRGB();
-
 	_vector.set( color.r, color.g, color.b ).applyMatrix3( SRGB_TO_DISPLAY_P3 );
 
-	return color.setRGB( _vector.x, _vector.y, _vector.z );
+	return color.setRGB( _vector.x, _vector.y, _vector.z ).convertLinearToSRGB();
 
 }
 

--- a/test/unit/src/math/Color.tests.js
+++ b/test/unit/src/math/Color.tests.js
@@ -1,6 +1,7 @@
 /* global QUnit */
 
 import { Color } from '../../../../src/math/Color.js';
+import { ColorManagement } from '../../../../src/math/ColorManagement.js';
 import { eps } from '../../utils/math-constants.js';
 import { CONSOLE_LEVEL } from '../../utils/console-wrapper.js';
 
@@ -260,9 +261,16 @@ export default QUnit.module( 'Maths', () => {
 
 		QUnit.test( 'getStyle', ( assert ) => {
 
+			ColorManagement.enabled = true;
+
 			const c = new Color( 'plum' );
-			const res = c.getStyle();
-			assert.ok( res == 'rgb(221,160,221)', 'style: ' + res );
+
+			assert.equal( c.getStyle(), 'rgb(221,160,221)', 'style: srgb' );
+
+			// Close, but currently off by a few decimals...
+			// assert.equal( c.getStyle( 'display-p3' ), 'color(display-p3 0.831 0.637 0.852)', 'style: display-p3' );
+
+			ColorManagement.enabled = false;
 
 		} );
 

--- a/test/unit/src/math/Color.tests.js
+++ b/test/unit/src/math/Color.tests.js
@@ -4,6 +4,7 @@ import { Color } from '../../../../src/math/Color.js';
 import { ColorManagement } from '../../../../src/math/ColorManagement.js';
 import { eps } from '../../utils/math-constants.js';
 import { CONSOLE_LEVEL } from '../../utils/console-wrapper.js';
+import { DisplayP3ColorSpace, SRGBColorSpace } from '../../../../src/constants.js';
 
 export default QUnit.module( 'Maths', () => {
 
@@ -93,11 +94,33 @@ export default QUnit.module( 'Maths', () => {
 
 		QUnit.test( 'setRGB', ( assert ) => {
 
+			ColorManagement.enabled = true;
+
 			const c = new Color();
+
 			c.setRGB( 0.3, 0.5, 0.7 );
-			assert.ok( c.r == 0.3, 'Red: ' + c.r );
-			assert.ok( c.g == 0.5, 'Green: ' + c.g );
-			assert.ok( c.b == 0.7, 'Blue: ' + c.b );
+
+			assert.equal( c.r, 0.3, 'Red: ' + c.r + ' (srgb-linear)' );
+			assert.equal( c.g, 0.5, 'Green: ' + c.g + ' (srgb-linear)' );
+			assert.equal( c.b, 0.7, 'Blue: ' + c.b + ' (srgb-linear)' );
+
+			c.setRGB( 0.3, 0.5, 0.7, SRGBColorSpace );
+
+			assert.equal( c.r.toFixed( 3 ), 0.073, 'Red: ' + c.r + ' (srgb)' );
+			assert.equal( c.g.toFixed( 3 ), 0.214, 'Green: ' + c.g + ' (srgb)' );
+			assert.equal( c.b.toFixed( 3 ), 0.448, 'Blue: ' + c.b + ' (srgb)' );
+
+			c.setRGB( 0.614, 0.731, 0.843, DisplayP3ColorSpace );
+
+			assert.numEqual( c.r.toFixed( 2 ), 0.3, 'Red: ' + c.r + ' (display-p3, in gamut)' );
+			assert.numEqual( c.g.toFixed( 2 ), 0.5, 'Green: ' + c.g + ' (display-p3, in gamut)' );
+			assert.numEqual( c.b.toFixed( 2 ), 0.7, 'Blue: ' + c.b + ' (display-p3, in gamut)' );
+
+			c.setRGB( 1.0, 0.5, 0.0, DisplayP3ColorSpace );
+
+			assert.numEqual( c.r.toFixed( 3 ), 1.179, 'Red: ' + c.r + ' (display-p3, out of gamut)' );
+			assert.numEqual( c.g.toFixed( 3 ), 0.181, 'Green: ' + c.g + ' (display-p3, out of gamut)' );
+			assert.numEqual( c.b.toFixed( 3 ), - 0.036, 'Blue: ' + c.b + ' (display-p3, out of gamut)' );
 
 		} );
 
@@ -260,10 +283,30 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
-		QUnit.todo( 'getRGB', ( assert ) => {
+		QUnit.test( 'getRGB', ( assert ) => {
 
-			// getRGB( target, colorSpace = ColorManagement.workingColorSpace )
-			assert.ok( false, 'everything\'s gonna be alright' );
+			ColorManagement.enabled = true;
+
+			const c = new Color( 'plum' );
+			const t = { r: 0, g: 0, b: 0 };
+
+			c.getRGB( t );
+
+			assert.equal( t.r.toFixed( 3 ), 0.723, 'r (srgb-linear)' );
+			assert.equal( t.g.toFixed( 3 ), 0.352, 'g (srgb-linear)' );
+			assert.equal( t.b.toFixed( 3 ), 0.723, 'b (srgb-linear)' );
+
+			c.getRGB( t, SRGBColorSpace );
+
+			assert.equal( t.r.toFixed( 3 ), ( 221 / 255 ).toFixed( 3 ), 'r (srgb)' );
+			assert.equal( t.g.toFixed( 3 ), ( 160 / 255 ).toFixed( 3 ), 'g (srgb)' );
+			assert.equal( t.b.toFixed( 3 ), ( 221 / 255 ).toFixed( 3 ), 'b (srgb)' );
+
+			c.getRGB( t, DisplayP3ColorSpace );
+
+			assert.equal( t.r.toFixed( 3 ), 0.831, 'r (display-p3)' );
+			assert.equal( t.g.toFixed( 3 ), 0.637, 'g (display-p3)' );
+			assert.equal( t.b.toFixed( 3 ), 0.852, 'b (display-p3)' );
 
 		} );
 
@@ -274,9 +317,7 @@ export default QUnit.module( 'Maths', () => {
 			const c = new Color( 'plum' );
 
 			assert.equal( c.getStyle(), 'rgb(221,160,221)', 'style: srgb' );
-
-			// Close, but currently off by a few decimals...
-			// assert.equal( c.getStyle( 'display-p3' ), 'color(display-p3 0.831 0.637 0.852)', 'style: display-p3' );
+			assert.equal( c.getStyle( DisplayP3ColorSpace ), 'color(display-p3 0.831 0.637 0.852)', 'style: display-p3' );
 
 		} );
 

--- a/test/unit/src/math/Color.tests.js
+++ b/test/unit/src/math/Color.tests.js
@@ -9,6 +9,14 @@ export default QUnit.module( 'Maths', () => {
 
 	QUnit.module( 'Color', () => {
 
+		const colorManagementEnabled = ColorManagement.enabled;
+
+		QUnit.testDone( () => {
+
+			ColorManagement.enabled = colorManagementEnabled;
+
+		} );
+
 		// INSTANCING
 		QUnit.test( 'Instancing', ( assert ) => {
 
@@ -269,8 +277,6 @@ export default QUnit.module( 'Maths', () => {
 
 			// Close, but currently off by a few decimals...
 			// assert.equal( c.getStyle( 'display-p3' ), 'color(display-p3 0.831 0.637 0.852)', 'style: display-p3' );
-
-			ColorManagement.enabled = false;
 
 		} );
 


### PR DESCRIPTION
Related issue:

- #23614 

**Description**

Adds `THREE.DisplayP3ColorSpace` constant, and related CPU-side transforms in THREE.ColorManagement. No rendering code is affected — the only direct effect is that `color.getStyle( 'display-p3' )` will now apply a conversion.

No gamut mapping is applied. Given a Display P3 input that is out-of-gamut for sRGB, conversion to sRGB will yield RGB values outside the range [0, 1]. That is the only lossless choice, which I think is important here, and users can use [Color.js](https://colorjs.io/) or other libraries to select an appropriate gamut mapping method if necessary.

/cc @WestLangley 