### PR TITLE
intersectSphere: Moved calculation of tca to after the first possible…

### DIFF
--- a/src/math/Ray.js
+++ b/src/math/Ray.js
@@ -220,12 +220,13 @@ class Ray {
 	intersectSphere( sphere, target ) {
 
 		_vector.subVectors( sphere.center, this.origin );
-		const tca = _vector.dot( this.direction );
+
 		const d2 = _vector.dot( _vector ) - tca * tca;
 		const radius2 = sphere.radius * sphere.radius;
 
 		if ( d2 > radius2 ) return null;
 
+		const tca = _vector.dot( this.direction );
 		const thc = Math.sqrt( radius2 - d2 );
 
 		// t0 = first intersect point - entrance on front of sphere


### PR DESCRIPTION
… early return

Just good practice to avoid a few (or a lot of) small, unnecessary dot product calculations.

Related issue: #XXXX

**Description**

A clear and concise description of what the problem was and how this pull request solves it.

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Example](https://example.com)*
