### PR TITLE
Introduce intersectsFrustum so that objects can override it

### DIFF
--- a/examples/jsm/renderers/Projector.js
+++ b/examples/jsm/renderers/Projector.js
@@ -365,7 +365,7 @@ class Projector {
 			} else if ( object.isMesh || object.isLine || object.isPoints ) {
 
 				if ( object.material.visible === false ) return;
-				if ( object.frustumCulled === true && _frustum.intersectsObject( object ) === false ) return;
+				if ( object.frustumCulled === true && object.intersectsFrustum( _frustum ) === false ) return;
 
 				addObject( object );
 

--- a/examples/jsm/renderers/webgpu/WebGPURenderer.js
+++ b/examples/jsm/renderers/webgpu/WebGPURenderer.js
@@ -727,7 +727,7 @@ class WebGPURenderer {
 
 			} else if ( object.isMesh || object.isLine || object.isPoints ) {
 
-				if ( ! object.frustumCulled || _frustum.intersectsObject( object ) ) {
+				if ( ! object.frustumCulled || object.intersectsFrustum( _frustum ) ) {
 
 					if ( this.sortObjects === true ) {
 

--- a/src/Three.js
+++ b/src/Three.js
@@ -21,6 +21,7 @@ export { Skeleton } from './objects/Skeleton.js';
 export { Bone } from './objects/Bone.js';
 export { Mesh } from './objects/Mesh.js';
 export { InstancedMesh } from './objects/InstancedMesh.js';
+export { InstancedMeshCulled } from './objects/InstancedMeshCulled.js';
 export { LineSegments } from './objects/LineSegments.js';
 export { LineLoop } from './objects/LineLoop.js';
 export { Line } from './objects/Line.js';

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -532,6 +532,12 @@ class Object3D extends EventDispatcher {
 
 	raycast( /* raycaster, intersects */ ) {}
 
+	intersectsFrustum( frustum ) {
+
+		return frustum.intersectsObject( this );
+
+	}
+
 	traverse( callback ) {
 
 		callback( this );

--- a/src/objects/InstancedMeshCulled.js
+++ b/src/objects/InstancedMeshCulled.js
@@ -1,0 +1,64 @@
+import { InstancedMesh } from './InstancedMesh.js';
+import { Sphere } from '../math/Sphere.js';
+import { Vector3 } from '../math/Vector3.js';
+
+
+class InstancedMeshCulled extends InstancedMesh {
+
+	constructor( geometry, material, count ) {
+
+		super( geometry, material, count );
+
+		this.frustumCulled = true;
+		this.boundingSphere = null;
+
+	}
+
+	computeBoundingSphere() {
+
+		if ( this.geometry.boundingSphere === null ) this.geometry.computeBoundingSphere();
+
+		const min = new Vector3( Infinity, Infinity, Infinity );
+		const max = new Vector3( - Infinity, - Infinity, - Infinity );
+		const position = new Vector3();
+
+		for ( let m = 0; m < this.count; m ++ ) {
+
+			const x = this.instanceMatrix[ m * 16 + 12 ];
+			const y = this.instanceMatrix[ m * 16 + 13 ];
+			const z = this.instanceMatrix[ m * 16 + 14 ];
+			position.set( x, y, z );
+			min.min( position );
+			max.max( position );
+
+		}
+
+		let radius = 0;
+		const center = new Vector3().addVectors( min, max ).multiply( 0.5 );
+		for ( let m = 0; m < this.count; m ++ ) {
+
+			const x = this.instanceMatrix[ m * 16 + 12 ];
+			const y = this.instanceMatrix[ m * 16 + 13 ];
+			const z = this.instanceMatrix[ m * 16 + 14 ];
+			position.set( x, y, z );
+			const distance = position.distanceTo( center );
+			// note: we assume no scaling - computing scale from instance matrix is not trivial
+			const r = distance + this.geometry.boundingSphere.radius;
+			if ( r > radius ) radius = r;
+
+		}
+
+		this.boundingSphere = new Sphere( center, radius );
+
+	}
+
+	intersectsFrustum( frustum ) {
+
+		if ( this.boundingSphere === null ) this.computeBoundingSphere();
+		frustum.intersectsSphere( this.boundingSphere );
+
+	}
+
+}
+
+export { InstancedMeshCulled };

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1149,7 +1149,7 @@ function WebGLRenderer( parameters = {} ) {
 
 				}
 
-				if ( ! object.frustumCulled || _frustum.intersectsObject( object ) ) {
+				if ( ! object.frustumCulled || object.intersectsFrustum( _frustum ) ) {
 
 					if ( sortObjects ) {
 

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -322,7 +322,7 @@ function WebGLShadowMap( _renderer, _objects, _capabilities ) {
 
 		if ( visible && ( object.isMesh || object.isLine || object.isPoints ) ) {
 
-			if ( ( object.castShadow || ( object.receiveShadow && type === VSMShadowMap ) ) && ( ! object.frustumCulled || _frustum.intersectsObject( object ) ) ) {
+			if ( ( object.castShadow || ( object.receiveShadow && type === VSMShadowMap ) ) && ( ! object.frustumCulled || object.intersectsFrustum( _frustum ) ) ) {
 
 				object.modelViewMatrix.multiplyMatrices( shadowCamera.matrixWorldInverse, object.matrixWorld );
 


### PR DESCRIPTION
**Description**

Introduce a method `intersectsFrustum` into `Object3D` so that objects can customize it. The intended use is to implement frustum culling for `InstancedMesh`, but it could be used for other purposes as well, e.g. some objects might prefer culling against box instead of sphere, or implement some other culling implementations based on its internal knowledge.

The PR is inspired by https://discourse.threejs.org/t/how-to-do-frustum-culling-with-instancedmesh/22633/6, but attempts to be more flexible.

If you are willing to compute the bounding sphere on your own, culling is easy:

```
class InstancedMeshCulled extends InstancedMesh {
	constructor( geometry, material, count ) {

		super(geometry, material, count);

		this.frustumCulled = true;
	}

	intersectsFrustum( frustum ) {
		frustum.intersectsSphere( this.boundingSphere );
	}
}
```

I will provide a function to compute the `boundingSphere` for `InstancedMesh` later.
