### PR TITLE
ColorManagement: Add Linear P3 transforms

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -151,6 +151,7 @@ export const NoColorSpace = '';
 export const SRGBColorSpace = 'srgb';
 export const LinearSRGBColorSpace = 'srgb-linear';
 export const DisplayP3ColorSpace = 'display-p3';
+export const LinearDisplayP3ColorSpace = 'display-p3-linear';
 
 export const ZeroStencilOp = 0;
 export const KeepStencilOp = 7680;

--- a/src/constants.js
+++ b/src/constants.js
@@ -151,7 +151,7 @@ export const NoColorSpace = '';
 export const SRGBColorSpace = 'srgb';
 export const LinearSRGBColorSpace = 'srgb-linear';
 export const DisplayP3ColorSpace = 'display-p3';
-export const LinearDisplayP3ColorSpace = 'display-p3-linear';
+export const LinearP3ColorSpace = 'p3-linear';
 
 export const ZeroStencilOp = 0;
 export const KeepStencilOp = 7680;

--- a/src/math/ColorManagement.js
+++ b/src/math/ColorManagement.js
@@ -58,7 +58,7 @@ function LinearRec709ToLinearP3( color ) {
 }
 
 // Conversions from <source> to Linear-sRGB reference space.
-const TO_LINEAR = {
+const TO_REFERENCE = {
 	[ LinearSRGBColorSpace ]: ( color ) => color,
 	[ SRGBColorSpace ]: ( color ) => color.convertSRGBToLinear(),
 	[ LinearP3ColorSpace ]: ( color ) => LinearP3ToLinearRec709( color ),
@@ -66,7 +66,7 @@ const TO_LINEAR = {
 };
 
 // Conversions from Linear-sRGB reference space to <target>.
-const FROM_LINEAR = {
+const FROM_REFERENCE = {
 	[ LinearSRGBColorSpace ]: ( color ) => color,
 	[ SRGBColorSpace ]: ( color ) => color.convertLinearToSRGB(),
 	[ LinearP3ColorSpace ]: ( color ) => LinearRec709ToLinearP3( color ),
@@ -113,16 +113,16 @@ export const ColorManagement = {
 
 		}
 
-		const sourceToLinear = TO_LINEAR[ sourceColorSpace ];
-		const targetFromLinear = FROM_LINEAR[ targetColorSpace ];
+		const sourceToReference = TO_REFERENCE[ sourceColorSpace ];
+		const referenceToTarget = FROM_REFERENCE[ targetColorSpace ];
 
-		if ( sourceToLinear === undefined || targetFromLinear === undefined ) {
+		if ( sourceToReference === undefined || referenceToTarget === undefined ) {
 
 			throw new Error( `Unsupported color space conversion, "${ sourceColorSpace }" to "${ targetColorSpace }".` );
 
 		}
 
-		return targetFromLinear( sourceToLinear( color ) );
+		return referenceToTarget( sourceToReference( color ) );
 
 	},
 

--- a/src/math/ColorManagement.js
+++ b/src/math/ColorManagement.js
@@ -1,4 +1,4 @@
-import { SRGBColorSpace, LinearSRGBColorSpace, DisplayP3ColorSpace, LinearDisplayP3ColorSpace } from '../constants.js';
+import { SRGBColorSpace, LinearSRGBColorSpace, DisplayP3ColorSpace, LinearP3ColorSpace } from '../constants.js';
 import { Matrix3 } from './Matrix3.js';
 import { Vector3 } from './Vector3.js';
 
@@ -27,13 +27,13 @@ export function LinearToSRGB( c ) {
  * - http://www.russellcottrell.com/photo/matrixCalculator.htm
  */
 
-const LINEAR_SRGB_TO_LINEAR_DISPLAY_P3 = new Matrix3().fromArray( [
+const LINEAR_REC709_TO_LINEAR_P3 = new Matrix3().fromArray( [
 	0.8224621, 0.0331941, 0.0170827,
 	0.1775380, 0.9668058, 0.0723974,
 	- 0.0000001, 0.0000001, 0.9105199
 ] );
 
-const LINEAR_DISPLAY_P3_TO_LINEAR_SRGB = new Matrix3().fromArray( [
+const LINEAR_P3_TO_LINEAR_REC709 = new Matrix3().fromArray( [
 	1.2249401, - 0.0420569, - 0.0196376,
 	- 0.2249404, 1.0420571, - 0.0786361,
 	0.0000001, 0.0000000, 1.0982735
@@ -41,17 +41,17 @@ const LINEAR_DISPLAY_P3_TO_LINEAR_SRGB = new Matrix3().fromArray( [
 
 const _vector = new Vector3();
 
-function LinearDisplayP3ToLinearSRGB( color ) {
+function LinearP3ToLinearRec709( color ) {
 
-	_vector.set( color.r, color.g, color.b ).applyMatrix3( LINEAR_DISPLAY_P3_TO_LINEAR_SRGB );
+	_vector.set( color.r, color.g, color.b ).applyMatrix3( LINEAR_P3_TO_LINEAR_REC709 );
 
 	return color.setRGB( _vector.x, _vector.y, _vector.z );
 
 }
 
-function LinearSRGBToLinearDisplayP3( color ) {
+function LinearRec709ToLinearP3( color ) {
 
-	_vector.set( color.r, color.g, color.b ).applyMatrix3( LINEAR_SRGB_TO_LINEAR_DISPLAY_P3 );
+	_vector.set( color.r, color.g, color.b ).applyMatrix3( LINEAR_REC709_TO_LINEAR_P3 );
 
 	return color.setRGB( _vector.x, _vector.y, _vector.z );
 
@@ -61,16 +61,16 @@ function LinearSRGBToLinearDisplayP3( color ) {
 const TO_LINEAR = {
 	[ LinearSRGBColorSpace ]: ( color ) => color,
 	[ SRGBColorSpace ]: ( color ) => color.convertSRGBToLinear(),
-	[ LinearDisplayP3ColorSpace ]: ( color ) => LinearDisplayP3ToLinearSRGB( color ),
-	[ DisplayP3ColorSpace ]: ( color ) => LinearDisplayP3ToLinearSRGB( color.convertSRGBToLinear() ),
+	[ LinearP3ColorSpace ]: ( color ) => LinearP3ToLinearRec709( color ),
+	[ DisplayP3ColorSpace ]: ( color ) => LinearP3ToLinearRec709( color.convertSRGBToLinear() ),
 };
 
 // Conversions from Linear-sRGB reference space to <target>.
 const FROM_LINEAR = {
 	[ LinearSRGBColorSpace ]: ( color ) => color,
 	[ SRGBColorSpace ]: ( color ) => color.convertLinearToSRGB(),
-	[ LinearDisplayP3ColorSpace ]: ( color ) => LinearSRGBToLinearDisplayP3( color ),
-	[ DisplayP3ColorSpace ]: ( color ) => LinearSRGBToLinearDisplayP3( color ).convertLinearToSRGB(),
+	[ LinearP3ColorSpace ]: ( color ) => LinearRec709ToLinearP3( color ),
+	[ DisplayP3ColorSpace ]: ( color ) => LinearRec709ToLinearP3( color ).convertLinearToSRGB(),
 };
 
 export const ColorManagement = {

--- a/src/math/ColorManagement.js
+++ b/src/math/ColorManagement.js
@@ -1,4 +1,4 @@
-import { SRGBColorSpace, LinearSRGBColorSpace, DisplayP3ColorSpace, } from '../constants.js';
+import { SRGBColorSpace, LinearSRGBColorSpace, DisplayP3ColorSpace, LinearDisplayP3ColorSpace } from '../constants.js';
 import { Matrix3 } from './Matrix3.js';
 import { Vector3 } from './Vector3.js';
 
@@ -41,9 +41,7 @@ const LINEAR_DISPLAY_P3_TO_LINEAR_SRGB = new Matrix3().fromArray( [
 
 const _vector = new Vector3();
 
-function DisplayP3ToLinearSRGB( color ) {
-
-	color.convertSRGBToLinear();
+function LinearDisplayP3ToLinearSRGB( color ) {
 
 	_vector.set( color.r, color.g, color.b ).applyMatrix3( LINEAR_DISPLAY_P3_TO_LINEAR_SRGB );
 
@@ -51,11 +49,11 @@ function DisplayP3ToLinearSRGB( color ) {
 
 }
 
-function LinearSRGBToDisplayP3( color ) {
+function LinearSRGBToLinearDisplayP3( color ) {
 
 	_vector.set( color.r, color.g, color.b ).applyMatrix3( LINEAR_SRGB_TO_LINEAR_DISPLAY_P3 );
 
-	return color.setRGB( _vector.x, _vector.y, _vector.z ).convertLinearToSRGB();
+	return color.setRGB( _vector.x, _vector.y, _vector.z );
 
 }
 
@@ -63,14 +61,16 @@ function LinearSRGBToDisplayP3( color ) {
 const TO_LINEAR = {
 	[ LinearSRGBColorSpace ]: ( color ) => color,
 	[ SRGBColorSpace ]: ( color ) => color.convertSRGBToLinear(),
-	[ DisplayP3ColorSpace ]: DisplayP3ToLinearSRGB,
+	[ LinearDisplayP3ColorSpace ]: ( color ) => LinearDisplayP3ToLinearSRGB( color ),
+	[ DisplayP3ColorSpace ]: ( color ) => LinearDisplayP3ToLinearSRGB( color.convertSRGBToLinear() ),
 };
 
-// Conversions to <target> from Linear-sRGB reference space.
+// Conversions from Linear-sRGB reference space to <target>.
 const FROM_LINEAR = {
 	[ LinearSRGBColorSpace ]: ( color ) => color,
 	[ SRGBColorSpace ]: ( color ) => color.convertLinearToSRGB(),
-	[ DisplayP3ColorSpace ]: LinearSRGBToDisplayP3,
+	[ LinearDisplayP3ColorSpace ]: ( color ) => LinearSRGBToLinearDisplayP3( color ),
+	[ DisplayP3ColorSpace ]: ( color ) => LinearSRGBToLinearDisplayP3( color ).convertLinearToSRGB(),
 };
 
 export const ColorManagement = {

--- a/test/unit/src/math/Color.tests.js
+++ b/test/unit/src/math/Color.tests.js
@@ -4,7 +4,7 @@ import { Color } from '../../../../src/math/Color.js';
 import { ColorManagement } from '../../../../src/math/ColorManagement.js';
 import { eps } from '../../utils/math-constants.js';
 import { CONSOLE_LEVEL } from '../../utils/console-wrapper.js';
-import { DisplayP3ColorSpace, SRGBColorSpace } from '../../../../src/constants.js';
+import { DisplayP3ColorSpace, SRGBColorSpace, LinearP3ColorSpace } from '../../../../src/constants.js';
 
 export default QUnit.module( 'Maths', () => {
 
@@ -307,6 +307,12 @@ export default QUnit.module( 'Maths', () => {
 			assert.equal( t.r.toFixed( 3 ), 0.831, 'r (display-p3)' );
 			assert.equal( t.g.toFixed( 3 ), 0.637, 'g (display-p3)' );
 			assert.equal( t.b.toFixed( 3 ), 0.852, 'b (display-p3)' );
+
+			c.getRGB( t, LinearP3ColorSpace );
+
+			assert.equal( t.r.toFixed( 3 ), 0.657, 'r (p3-linear)' );
+			assert.equal( t.g.toFixed( 3 ), 0.364, 'g (p3-linear)' );
+			assert.equal( t.b.toFixed( 3 ), 0.696, 'b (p3-linear)' );
 
 		} );
 


### PR DESCRIPTION
Related:

- #25520 
- #23614 

Terminology:

- **Rec. 709:** Primaries for the sRGB-Rec709-D65 ("sRGB") color space
- **P3:** Primaries for the sRGB-P3-D65 ("Display P3") wide gamut color space
- **Display P3:** Color space defined by sRGB transfer functions, P3 primaries, and D65 white point
- **Linear P3:** Color space defined by linear transfer functions, P3 primaries, and D65 white point

Note that "Linear Display P3" is not a thing — Display implies sRGB transfer functions, which a linear color space does not have. So the terms "display-p3" vs. "p3-linear" are intentional, and reflect W3C naming as well to my understanding.

This should be considered experimental — use of a wide-gamut working color space is going to take some deeper investigation, and we may decide that p3-linear is not necessary. But it is considerably easier to test than rec2020-linear or acescg, under current browser support.

***

/cc @WestLangley 

