### PR TITLE
Build: Specify Minimum Node Environment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,9 @@
         "rollup-plugin-filesize": "^9.1.2",
         "rollup-plugin-visualizer": "^5.9.0",
         "servez": "^1.14.1"
+      },
+      "engines": {
+        "node": ">=16.19.0"
       }
     },
     "node_modules/@babel/runtime": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,9 @@
   "browserslist": [
     "> 1%, not dead, not ie 11, not op_mini all"
   ],
+  "engines": {
+    "node": ">=16.19.0"
+  },
   "scripts": {
     "start": "npm run dev",
     "test": "npm run lint && npm run test-unit",


### PR DESCRIPTION
Related issue: hard to tell. Partially discussed in https://github.com/mrdoob/three.js/pull/25504

**Description**

This simple setting specifies the minimum node version at least equal to what is being used in the build CI to check every pull request.

- "node": ">=16.19.0"

The goal is to introduce a "non blocking" warning when a developers' node environment does not meet the minimum requirements.  This helps to ensure that issues with linting, e2e, unit, etc are not due to an outdated node environment.  In short, remove old node environments as the cause for issues.

Here's an example.  Note, I've had to change node versions to produce the warning message when running `npm install`

<img width="509" alt="example-npm-engine" src="https://user-images.githubusercontent.com/347224/219908564-66ab096c-69fe-421c-8ce5-4bac5fc3d6db.PNG">
