### PR TITLE
Texture: Use default value for image setter.

### DIFF
--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -83,7 +83,7 @@ class Texture extends EventDispatcher {
 
 	}
 
-	set image( value ) {
+	set image( value = null ) {
 
 		this.source.data = value;
 


### PR DESCRIPTION
If "data" is "undefined ", "serializeImage(data)" will report an error
