### PR TITLE
Core: Use `structuredClone()` when available.

### DIFF
--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -1071,7 +1071,7 @@ class BufferGeometry extends EventDispatcher {
 
 		// user data
 
-		this.userData = source.userData;
+		this.userData = typeof structuredClone === 'function' ? structuredClone( source.userData ) : JSON.parse( JSON.stringify( source.userData ) );
 
 		// geometry generator parameters
 

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -8,7 +8,7 @@ import { Object3D } from './Object3D.js';
 import { Matrix4 } from '../math/Matrix4.js';
 import { Matrix3 } from '../math/Matrix3.js';
 import * as MathUtils from '../math/MathUtils.js';
-import { arrayNeedsUint32 } from '../utils.js';
+import { arrayNeedsUint32, deepClone } from '../utils.js';
 
 let _id = 0;
 
@@ -1071,7 +1071,7 @@ class BufferGeometry extends EventDispatcher {
 
 		// user data
 
-		this.userData = typeof structuredClone === 'function' ? structuredClone( source.userData ) : JSON.parse( JSON.stringify( source.userData ) );
+		this.userData = deepClone( source.userData );
 
 		// geometry generator parameters
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -944,7 +944,7 @@ class Object3D extends EventDispatcher {
 		this.frustumCulled = source.frustumCulled;
 		this.renderOrder = source.renderOrder;
 
-		this.userData = JSON.parse( JSON.stringify( source.userData ) );
+		this.userData = typeof structuredClone === 'function' ? structuredClone( source.userData ) : JSON.parse( JSON.stringify( source.userData ) );
 
 		if ( recursive === true ) {
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -6,6 +6,7 @@ import { Euler } from '../math/Euler.js';
 import { Layers } from './Layers.js';
 import { Matrix3 } from '../math/Matrix3.js';
 import * as MathUtils from '../math/MathUtils.js';
+import { deepClone } from '../utils.js';
 
 let _object3DId = 0;
 
@@ -944,7 +945,7 @@ class Object3D extends EventDispatcher {
 		this.frustumCulled = source.frustumCulled;
 		this.renderOrder = source.renderOrder;
 
-		this.userData = typeof structuredClone === 'function' ? structuredClone( source.userData ) : JSON.parse( JSON.stringify( source.userData ) );
+		this.userData = deepClone( source.userData );
 
 		if ( recursive === true ) {
 

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -1,6 +1,7 @@
 import { EventDispatcher } from '../core/EventDispatcher.js';
 import { FrontSide, NormalBlending, LessEqualDepth, AddEquation, OneMinusSrcAlphaFactor, SrcAlphaFactor, AlwaysStencilFunc, KeepStencilOp } from '../constants.js';
 import * as MathUtils from '../math/MathUtils.js';
+import { deepClone } from '../utils.js';
 
 let materialId = 0;
 
@@ -473,7 +474,7 @@ class Material extends EventDispatcher {
 
 		this.toneMapped = source.toneMapped;
 
-		this.userData = typeof structuredClone === 'function' ? structuredClone( source.userData ) : JSON.parse( JSON.stringify( source.userData ) );
+		this.userData = deepClone( source.userData );
 
 		return this;
 

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -473,7 +473,7 @@ class Material extends EventDispatcher {
 
 		this.toneMapped = source.toneMapped;
 
-		this.userData = JSON.parse( JSON.stringify( source.userData ) );
+		this.userData = typeof structuredClone === 'function' ? structuredClone( source.userData ) : JSON.parse( JSON.stringify( source.userData ) );
 
 		return this;
 

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -136,7 +136,7 @@ class Texture extends EventDispatcher {
 		this.unpackAlignment = source.unpackAlignment;
 		this.encoding = source.encoding;
 
-		this.userData = JSON.parse( JSON.stringify( source.userData ) );
+		this.userData = typeof structuredClone === 'function' ? structuredClone( source.userData ) : JSON.parse( JSON.stringify( source.userData ) );
 
 		this.needsUpdate = true;
 

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -14,6 +14,7 @@ import * as MathUtils from '../math/MathUtils.js';
 import { Vector2 } from '../math/Vector2.js';
 import { Matrix3 } from '../math/Matrix3.js';
 import { Source } from './Source.js';
+import { deepClone } from '../utils.js';
 
 let textureId = 0;
 
@@ -136,7 +137,7 @@ class Texture extends EventDispatcher {
 		this.unpackAlignment = source.unpackAlignment;
 		this.encoding = source.encoding;
 
-		this.userData = typeof structuredClone === 'function' ? structuredClone( source.userData ) : JSON.parse( JSON.stringify( source.userData ) );
+		this.userData = deepClone( source.userData );
 
 		this.needsUpdate = true;
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -68,4 +68,16 @@ function createElementNS( name ) {
 
 }
 
-export { arrayMin, arrayMax, arrayNeedsUint32, getTypedArray, createElementNS };
+function deepClone( value ) {
+
+	if ( typeof structuredClone === 'function' ) {
+
+		return structuredClone( value );
+
+	}
+
+	return JSON.parse( JSON.stringify( value ) );
+
+}
+
+export { arrayMin, arrayMax, arrayNeedsUint32, getTypedArray, createElementNS, deepClone };


### PR DESCRIPTION
**Description**

At the moment, you can't clone 3D objects when userData has a circular structure.

This is because internally, user data is converted to JSON as a quick way to clone it, but the JSON format can't handle circular structures.

This PR uses `structuredClone` instead of `Json.parse(Json.stringify(userData))` when available, which is faster and supports cloning circular structures.

You can see the error that this PR will fix here: https://codesandbox.io/s/suspicious-monad-wq6d3i?file=/src/index.js

```js
import { Object3D } from "three";

const dataA = {};
const dataB = { dataA };
dataA.dataB = dataB;

const obj = new Object3D();
obj.userData = dataA;

obj.clone();
```