### PR TITLE
BufferGeometry: Overwrite `copy()` in generators.

### DIFF
--- a/examples/jsm/geometries/ParametricGeometry.js
+++ b/examples/jsm/geometries/ParametricGeometry.js
@@ -124,6 +124,16 @@ class ParametricGeometry extends BufferGeometry {
 
 	}
 
+	copy( source ) {
+
+		super.copy( source );
+
+		this.parameters = Object.assign( {}, source.parameters );
+
+		return this;
+
+	}
+
 }
 
 export { ParametricGeometry };

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -1073,10 +1073,6 @@ class BufferGeometry extends EventDispatcher {
 
 		this.userData = source.userData;
 
-		// geometry generator parameters
-
-		if ( source.parameters !== undefined ) this.parameters = Object.assign( {}, source.parameters );
-
 		return this;
 
 	}

--- a/src/geometries/BoxGeometry.js
+++ b/src/geometries/BoxGeometry.js
@@ -159,6 +159,16 @@ class BoxGeometry extends BufferGeometry {
 
 	}
 
+	copy( source ) {
+
+		super.copy( source );
+
+		this.parameters = Object.assign( {}, source.parameters );
+
+		return this;
+
+	}
+
 	static fromJSON( data ) {
 
 		return new BoxGeometry( data.width, data.height, data.depth, data.widthSegments, data.heightSegments, data.depthSegments );

--- a/src/geometries/CircleGeometry.js
+++ b/src/geometries/CircleGeometry.js
@@ -79,6 +79,16 @@ class CircleGeometry extends BufferGeometry {
 
 	}
 
+	copy( source ) {
+
+		super.copy( source );
+
+		this.parameters = Object.assign( {}, source.parameters );
+
+		return this;
+
+	}
+
 	static fromJSON( data ) {
 
 		return new CircleGeometry( data.radius, data.segments, data.thetaStart, data.thetaLength );

--- a/src/geometries/CylinderGeometry.js
+++ b/src/geometries/CylinderGeometry.js
@@ -264,6 +264,16 @@ class CylinderGeometry extends BufferGeometry {
 
 	}
 
+	copy( source ) {
+
+		super.copy( source );
+
+		this.parameters = Object.assign( {}, source.parameters );
+
+		return this;
+
+	}
+
 	static fromJSON( data ) {
 
 		return new CylinderGeometry( data.radiusTop, data.radiusBottom, data.height, data.radialSegments, data.heightSegments, data.openEnded, data.thetaStart, data.thetaLength );

--- a/src/geometries/EdgesGeometry.js
+++ b/src/geometries/EdgesGeometry.js
@@ -137,6 +137,16 @@ class EdgesGeometry extends BufferGeometry {
 
 	}
 
+	copy( source ) {
+
+		super.copy( source );
+
+		this.parameters = Object.assign( {}, source.parameters );
+
+		return this;
+
+	}
+
 }
 
 export { EdgesGeometry };

--- a/src/geometries/ExtrudeGeometry.js
+++ b/src/geometries/ExtrudeGeometry.js
@@ -677,6 +677,16 @@ class ExtrudeGeometry extends BufferGeometry {
 
 	}
 
+	copy( source ) {
+
+		super.copy( source );
+
+		this.parameters = Object.assign( {}, source.parameters );
+
+		return this;
+
+	}
+
 	toJSON() {
 
 		const data = super.toJSON();

--- a/src/geometries/LatheGeometry.js
+++ b/src/geometries/LatheGeometry.js
@@ -167,6 +167,16 @@ class LatheGeometry extends BufferGeometry {
 
 	}
 
+	copy( source ) {
+
+		super.copy( source );
+
+		this.parameters = Object.assign( {}, source.parameters );
+
+		return this;
+
+	}
+
 	static fromJSON( data ) {
 
 		return new LatheGeometry( data.points, data.segments, data.phiStart, data.phiLength );

--- a/src/geometries/PlaneGeometry.js
+++ b/src/geometries/PlaneGeometry.js
@@ -77,6 +77,16 @@ class PlaneGeometry extends BufferGeometry {
 
 	}
 
+	copy( source ) {
+
+		super.copy( source );
+
+		this.parameters = Object.assign( {}, source.parameters );
+
+		return this;
+
+	}
+
 	static fromJSON( data ) {
 
 		return new PlaneGeometry( data.width, data.height, data.widthSegments, data.heightSegments );

--- a/src/geometries/PolyhedronGeometry.js
+++ b/src/geometries/PolyhedronGeometry.js
@@ -298,6 +298,16 @@ class PolyhedronGeometry extends BufferGeometry {
 
 	}
 
+	copy( source ) {
+
+		super.copy( source );
+
+		this.parameters = Object.assign( {}, source.parameters );
+
+		return this;
+
+	}
+
 	static fromJSON( data ) {
 
 		return new PolyhedronGeometry( data.vertices, data.indices, data.radius, data.details );

--- a/src/geometries/RingGeometry.js
+++ b/src/geometries/RingGeometry.js
@@ -106,6 +106,16 @@ class RingGeometry extends BufferGeometry {
 
 	}
 
+	copy( source ) {
+
+		super.copy( source );
+
+		this.parameters = Object.assign( {}, source.parameters );
+
+		return this;
+
+	}
+
 	static fromJSON( data ) {
 
 		return new RingGeometry( data.innerRadius, data.outerRadius, data.thetaSegments, data.phiSegments, data.thetaStart, data.thetaLength );

--- a/src/geometries/ShapeGeometry.js
+++ b/src/geometries/ShapeGeometry.js
@@ -130,6 +130,16 @@ class ShapeGeometry extends BufferGeometry {
 
 	}
 
+	copy( source ) {
+
+		super.copy( source );
+
+		this.parameters = Object.assign( {}, source.parameters );
+
+		return this;
+
+	}
+
 	toJSON() {
 
 		const data = super.toJSON();

--- a/src/geometries/SphereGeometry.js
+++ b/src/geometries/SphereGeometry.js
@@ -116,6 +116,16 @@ class SphereGeometry extends BufferGeometry {
 
 	}
 
+	copy( source ) {
+
+		super.copy( source );
+
+		this.parameters = Object.assign( {}, source.parameters );
+
+		return this;
+
+	}
+
 	static fromJSON( data ) {
 
 		return new SphereGeometry( data.radius, data.widthSegments, data.heightSegments, data.phiStart, data.phiLength, data.thetaStart, data.thetaLength );

--- a/src/geometries/TorusGeometry.js
+++ b/src/geometries/TorusGeometry.js
@@ -99,6 +99,16 @@ class TorusGeometry extends BufferGeometry {
 
 	}
 
+	copy( source ) {
+
+		super.copy( source );
+
+		this.parameters = Object.assign( {}, source.parameters );
+
+		return this;
+
+	}
+
 	static fromJSON( data ) {
 
 		return new TorusGeometry( data.radius, data.tube, data.radialSegments, data.tubularSegments, data.arc );

--- a/src/geometries/TorusKnotGeometry.js
+++ b/src/geometries/TorusKnotGeometry.js
@@ -146,6 +146,16 @@ class TorusKnotGeometry extends BufferGeometry {
 
 	}
 
+	copy( source ) {
+
+		super.copy( source );
+
+		this.parameters = Object.assign( {}, source.parameters );
+
+		return this;
+
+	}
+
 	static fromJSON( data ) {
 
 		return new TorusKnotGeometry( data.radius, data.tube, data.tubularSegments, data.radialSegments, data.p, data.q );

--- a/src/geometries/TubeGeometry.js
+++ b/src/geometries/TubeGeometry.js
@@ -163,6 +163,16 @@ class TubeGeometry extends BufferGeometry {
 
 	}
 
+	copy( source ) {
+
+		super.copy( source );
+
+		this.parameters = Object.assign( {}, source.parameters );
+
+		return this;
+
+	}
+
 	toJSON() {
 
 		const data = super.toJSON();

--- a/src/geometries/WireframeGeometry.js
+++ b/src/geometries/WireframeGeometry.js
@@ -112,6 +112,16 @@ class WireframeGeometry extends BufferGeometry {
 
 	}
 
+	copy( source ) {
+
+		super.copy( source );
+
+		this.parameters = Object.assign( {}, source.parameters );
+
+		return this;
+
+	}
+
 }
 
 function isUniqueEdge( start, end, edges ) {


### PR DESCRIPTION
Fixed #25345.

**Description**

This PR introduces `copy()` in geometry generators so `parameters` isn't copied in `BufferGeometry` anymore. That fixes the unexpected behavior of the library described in #25345.

Although this PR introduces some redundancy, it is still the more clean design since `BufferGeometry` really shouldn't access properties from derived classes. `three.js` already use this pattern for the `copy()` methods of materials.