### PR TITLE
Examples: Fix order of FXAA pass.

### DIFF
--- a/examples/webgl_materials_normalmap.html
+++ b/examples/webgl_materials_normalmap.html
@@ -133,8 +133,8 @@
 
 				const effectBleach = new ShaderPass( BleachBypassShader );
 				const effectColor = new ShaderPass( ColorCorrectionShader );
-				effectFXAA = new ShaderPass( FXAAShader );
 				const gammaCorrection = new ShaderPass( GammaCorrectionShader );
+				effectFXAA = new ShaderPass( FXAAShader );
 
 				effectFXAA.uniforms[ 'resolution' ].value.set( 1 / window.innerWidth, 1 / window.innerHeight );
 
@@ -148,10 +148,10 @@
 				composer = new EffectComposer( renderer, renderTarget );
 
 				composer.addPass( renderModel );
-				composer.addPass( effectFXAA );
 				composer.addPass( effectBleach );
 				composer.addPass( effectColor );
 				composer.addPass( gammaCorrection );
+				composer.addPass( effectFXAA );
 
 				// EVENTS
 


### PR DESCRIPTION
Related issue: -

**Description**

The pass chain order in `webgl_materials_normalmap` isn' right. FXAA must be the last pass. From the [Nvidia docs](https://developer.download.nvidia.com/assets/gamedev/files/sdk/11/FXAA_WhitePaper.pdf):

> FXAA is engineered to be applied towards the end of engine post processing after conversion to low dynamic range and conversion to the sRGB color space for display.

