### PR TITLE
Core: More usage of `addScaledVector()`.

### DIFF
--- a/src/geometries/ExtrudeGeometry.js
+++ b/src/geometries/ExtrudeGeometry.js
@@ -170,7 +170,7 @@ class ExtrudeGeometry extends BufferGeometry {
 
 				if ( ! vec ) console.error( 'THREE.ExtrudeGeometry: vec does not exist' );
 
-				return vec.clone().multiplyScalar( size ).add( pt );
+				return pt.clone().addScaledVector( vec, size );
 
 			}
 

--- a/src/math/Plane.js
+++ b/src/math/Plane.js
@@ -101,7 +101,7 @@ class Plane {
 
 	projectPoint( point, target ) {
 
-		return target.copy( this.normal ).multiplyScalar( - this.distanceToPoint( point ) ).add( point );
+		return target.copy( point ).addScaledVector( this.normal, - this.distanceToPoint( point ) );
 
 	}
 
@@ -133,7 +133,7 @@ class Plane {
 
 		}
 
-		return target.copy( direction ).multiplyScalar( t ).add( line.start );
+		return target.copy( line.start ).addScaledVector( direction, t );
 
 	}
 

--- a/src/math/Ray.js
+++ b/src/math/Ray.js
@@ -38,7 +38,7 @@ class Ray {
 
 	at( t, target ) {
 
-		return target.copy( this.direction ).multiplyScalar( t ).add( this.origin );
+		return target.copy( this.origin ).addScaledVector( this.direction, t );
 
 	}
 
@@ -70,7 +70,7 @@ class Ray {
 
 		}
 
-		return target.copy( this.direction ).multiplyScalar( directionDistance ).add( this.origin );
+		return target.copy( this.origin ).addScaledVector( this.direction, directionDistance );
 
 	}
 
@@ -92,7 +92,7 @@ class Ray {
 
 		}
 
-		_vector.copy( this.direction ).multiplyScalar( directionDistance ).add( this.origin );
+		_vector.copy( this.origin ).addScaledVector( this.direction, directionDistance );
 
 		return _vector.distanceToSquared( point );
 
@@ -203,13 +203,13 @@ class Ray {
 
 		if ( optionalPointOnRay ) {
 
-			optionalPointOnRay.copy( this.direction ).multiplyScalar( s0 ).add( this.origin );
+			optionalPointOnRay.copy( this.origin ).addScaledVector( this.direction, s0 );
 
 		}
 
 		if ( optionalPointOnSegment ) {
 
-			optionalPointOnSegment.copy( _segDir ).multiplyScalar( s1 ).add( _segCenter );
+			optionalPointOnSegment.copy( _segCenter ).addScaledVector( _segDir, s1 );
 
 		}
 


### PR DESCRIPTION
Two impls of V=P+tD:
```js
V.copy(D).multiplyScalar(t).add(P) // A
V.copy(P).addScaledVector(D,t)  // B
```
[B is faster by this benchmark](https://stackblitz.com/edit/js-z5gcrw?file=index.js), this PR transforms A to B


