### PR TITLE
LineCurve/LineCurve3: Override `getTangent()` and `getTangentAt()`.

### DIFF
--- a/src/extras/curves/LineCurve.js
+++ b/src/extras/curves/LineCurve.js
@@ -44,7 +44,7 @@ class LineCurve extends Curve {
 
 	getTangent( _t, optionalTarget = new Vector2() ) {
 
-		return optionalTarget.copy( this.v2 ).sub( this.v1 ).normalize();
+		return optionalTarget.subVectors( this.v2, this.v1 ).normalize();
 
 	}
 

--- a/src/extras/curves/LineCurve.js
+++ b/src/extras/curves/LineCurve.js
@@ -42,13 +42,15 @@ class LineCurve extends Curve {
 
 	}
 
-	getTangent( t, optionalTarget ) {
+	getTangent( _t, optionalTarget = new Vector2() ) {
 
-		const tangent = optionalTarget || new Vector2();
+		return optionalTarget.copy( this.v2 ).sub( this.v1 ).normalize();
 
-		tangent.copy( this.v2 ).sub( this.v1 ).normalize();
+	}
 
-		return tangent;
+	getTangentAt( u, optionalTarget ) {
+
+		return this.getTangent( u, optionalTarget );
 
 	}
 

--- a/src/extras/curves/LineCurve.js
+++ b/src/extras/curves/LineCurve.js
@@ -42,7 +42,7 @@ class LineCurve extends Curve {
 
 	}
 
-	getTangent( _t, optionalTarget = new Vector2() ) {
+	getTangent( t, optionalTarget = new Vector2() ) {
 
 		return optionalTarget.subVectors( this.v2, this.v1 ).normalize();
 

--- a/src/extras/curves/LineCurve3.js
+++ b/src/extras/curves/LineCurve3.js
@@ -39,6 +39,19 @@ class LineCurve3 extends Curve {
 		return this.getPoint( u, optionalTarget );
 
 	}
+
+	getTangent( _t, optionalTarget = new Vector3() ) {
+
+		return optionalTarget.copy( this.v2 ).sub( this.v1 ).normalize();
+
+	}
+
+	getTangentAt( u, optionalTarget ) {
+
+		return this.getTangent( u, optionalTarget );
+
+	}
+
 	copy( source ) {
 
 		super.copy( source );

--- a/src/extras/curves/LineCurve3.js
+++ b/src/extras/curves/LineCurve3.js
@@ -42,7 +42,7 @@ class LineCurve3 extends Curve {
 
 	getTangent( _t, optionalTarget = new Vector3() ) {
 
-		return optionalTarget.copy( this.v2 ).sub( this.v1 ).normalize();
+		return optionalTarget.subVectors( this.v2, this.v1 ).normalize();
 
 	}
 

--- a/src/extras/curves/LineCurve3.js
+++ b/src/extras/curves/LineCurve3.js
@@ -40,7 +40,7 @@ class LineCurve3 extends Curve {
 
 	}
 
-	getTangent( _t, optionalTarget = new Vector3() ) {
+	getTangent( t, optionalTarget = new Vector3() ) {
 
 		return optionalTarget.subVectors( this.v2, this.v1 ).normalize();
 

--- a/test/unit/src/extras/curves/LineCurve.tests.js
+++ b/test/unit/src/extras/curves/LineCurve.tests.js
@@ -106,7 +106,7 @@ export default QUnit.module( 'Extras', () => {
 
 			} );
 
-			QUnit.test( 'getTangent', ( assert ) => {
+			QUnit.test( 'getTangent/getTangentAt', ( assert ) => {
 
 				const curve = _curve;
 				const tangent = new Vector2();
@@ -116,6 +116,11 @@ export default QUnit.module( 'Extras', () => {
 
 				assert.numEqual( tangent.x, expectedTangent, 'tangent.x correct' );
 				assert.numEqual( tangent.y, expectedTangent, 'tangent.y correct' );
+
+				curve.getTangentAt( 0, tangent );
+
+				assert.numEqual( tangent.x, expectedTangent, 'tangentAt.x correct' );
+				assert.numEqual( tangent.y, expectedTangent, 'tangentAt.y correct' );
 
 			} );
 


### PR DESCRIPTION
LineCurve's unit tangent is always "norm(line.v2-line.v1)", the parametric terms aren't involved

this PR 
- overrides getTangentAt to skip UtoTmapping procedure; and
- ~~use `_t` in getTangent ...to reflect its an unused param~~