### PR TITLE
Box2: Ensure that empty intersections in `.intersect()` result in fully empty boxes.

### DIFF
--- a/src/math/Box2.js
+++ b/src/math/Box2.js
@@ -170,6 +170,8 @@ class Box2 {
 		this.min.max( box.min );
 		this.max.min( box.max );
 
+		if ( this.isEmpty() ) this.makeEmpty();
+
 		return this;
 
 	}

--- a/test/unit/src/math/Box2.tests.js
+++ b/test/unit/src/math/Box2.tests.js
@@ -349,6 +349,11 @@ export default QUnit.module( 'Maths', () => {
 			assert.ok( b.clone().intersect( c ).equals( b ), 'Passed!' );
 			assert.ok( c.clone().intersect( c ).equals( c ), 'Passed!' );
 
+			const d = new Box2( one2.clone().negate(), zero2.clone() );
+			const e = new Box2( one2.clone(), two2.clone() ).intersect( d );
+
+			assert.ok( e.min.equals( posInf2 ) && e.max.equals( negInf2 ), 'Infinite empty' );
+
 		} );
 
 		QUnit.test( 'union', ( assert ) => {


### PR DESCRIPTION
as if box3, ensures returned empty box has inf. bounds if there's no intersections; otherwise, subsequent set ops broke, e.g:

<img width="227" alt="box2 intersect" src="https://user-images.githubusercontent.com/1063018/220619844-58049ffc-b8ac-4d73-8fb3-2108d5799a40.png">


Expected: `A.intersect(B).union(C).equals(C)`
Actual: `A.intersect(B).union(C).equals(D)`