### PR TITLE
SVGLoader: Gracefully handle empty paths.

### DIFF
--- a/examples/jsm/loaders/SVGLoader.js
+++ b/examples/jsm/loaders/SVGLoader.js
@@ -218,6 +218,8 @@ class SVGLoader extends Loader {
 
 			const d = node.getAttribute( 'd' );
 
+			if ( d === '' || d === 'none' ) return null;
+
 			// console.log( d );
 
 			const commands = d.match( /[a-df-z][^a-df-z]*/ig );

--- a/examples/models/svg/emptyPath.svg
+++ b/examples/models/svg/emptyPath.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <path d=""/>
+</svg>

--- a/examples/webgl_loader_svg.html
+++ b/examples/webgl_loader_svg.html
@@ -124,6 +124,7 @@
 					'singlePointTest': 'models/svg/singlePointTest.svg',
 					'singlePointTest2': 'models/svg/singlePointTest2.svg',
 					'singlePointTest3': 'models/svg/singlePointTest3.svg',
+					'emptyPath': 'models/svg/emptyPath.svg',
 
 				} ).name( 'SVG File' ).onChange( update );
 


### PR DESCRIPTION
Fixed #25548.

**Description**

Ensures the loader properly handles empty path definitions. From the spec:

> Note that the EBNF allows the path data string in the [d](https://www.w3.org/TR/SVG/paths.html#DProperty) property to be empty. This is not an error, instea[d](https://www.w3.org/TR/SVG/paths.html#DProperty) it disables rendering of the path. Rendering is also disabled when the d property has the value none.