### PR TITLE
Color: Simplifes hex notation parsing in `.setStyle()`

### DIFF
--- a/src/math/Color.js
+++ b/src/math/Color.js
@@ -242,24 +242,17 @@ class Color {
 			if ( size === 3 ) {
 
 				// #ff0
-				this.r = parseInt( hex.charAt( 0 ) + hex.charAt( 0 ), 16 ) / 255;
-				this.g = parseInt( hex.charAt( 1 ) + hex.charAt( 1 ), 16 ) / 255;
-				this.b = parseInt( hex.charAt( 2 ) + hex.charAt( 2 ), 16 ) / 255;
-
-				ColorManagement.toWorkingColorSpace( this, colorSpace );
-
-				return this;
+				return this.setRGB(
+					parseInt( hex.charAt( 0 ), 16 ) / 15,
+					parseInt( hex.charAt( 1 ), 16 ) / 15,
+					parseInt( hex.charAt( 2 ), 16 ) / 15,
+					colorSpace
+				);
 
 			} else if ( size === 6 ) {
 
 				// #ff0000
-				this.r = parseInt( hex.charAt( 0 ) + hex.charAt( 1 ), 16 ) / 255;
-				this.g = parseInt( hex.charAt( 2 ) + hex.charAt( 3 ), 16 ) / 255;
-				this.b = parseInt( hex.charAt( 4 ) + hex.charAt( 5 ), 16 ) / 255;
-
-				ColorManagement.toWorkingColorSpace( this, colorSpace );
-
-				return this;
+				return this.setHex( parseInt( hex, 16 ), colorSpace );
 
 			} else {
 


### PR DESCRIPTION
This PR simplifies hex to rgb in `.setStyle()`

when parsing 3digit hex: its safe to skip expansion (R -> RR etc) bc step size in ratio is always 1/15

```
before expansion: 15 steps (0x0,0x1,0x2,...,0xf), stepsize is 1, stepsize in ratio is 1/15
after expansion : 15 steps (0x00,0x11,0x22,...,0xff), stepsize is 17, stepsize in ratio is 17/255, also 1/15
```

when parsing 6digit hex: w/ `.setHex()`, hex str can be parsed just once
