### PR TITLE
PLYLoader: Fix comments.

### DIFF
--- a/examples/jsm/loaders/PLYLoader.js
+++ b/examples/jsm/loaders/PLYLoader.js
@@ -31,12 +31,12 @@ import {
  * } );
  *
  * Custom properties outside of the defaults for position, uv, normal
- * and color attributes can be added using the setCustomPropertyMapping method.
+ * and color attributes can be added using the setCustomPropertyNameMapping method.
  * For example, the following maps the element properties “custom_property_a”
  * and “custom_property_b” to an attribute “customAttribute” with an item size of 2.
  * Attribute item sizes are set from the number of element properties in the property array.
  *
- * loader.setCustomPropertyMapping( {
+ * loader.setCustomPropertyNameMapping( {
  *	customAttribute: ['custom_property_a', 'custom_property_b'],
  * } );
  *


### PR DESCRIPTION
PLYLoader: Update a code comment.

**Description**

This PR updates a code comment that was causing confusion regarding the use of setCustomPropertyMapping. The comment suggested that this method was used with PLYLoader, but PLYLoader does not have a setCustomPropertyMapping method. Instead, setCustomPropertyNameMapping can be used with PLYLoader to set custom property name mappings.

To address this issue, the comment has been updated to clarify the usage of setCustomPropertyNameMapping.


