### PR TITLE
CI: Update versions of used actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,41 +17,41 @@ permissions:
 
 jobs:
   lint:
-    name: "Lint testing"
+    name: Lint testing
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           cache: 'npm'
-      - name: Install packages
+      - name: Install dependencies
         run: npm ci
 
       - name: === Lint testing ===
         run: npm run lint
 
   unit:
-    name: "Unit testing"
+    name: Unit testing
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           cache: 'npm'
-      - name: Install packages
+      - name: Install dependencies
         run: npm ci
 
       - name: === Unit testing ===
         run: npm run test-unit
 
   e2e:
-    name: "E2E testing"
+    name: E2E testing
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     strategy:
@@ -63,13 +63,13 @@ jobs:
       CI: ${{ matrix.CI }}
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           cache: 'npm'
-      - name: Install packages
+      - name: Install dependencies
         run: npm ci
       - name: Build
         run: npm run build
@@ -85,17 +85,17 @@ jobs:
           if-no-files-found: ignore
 
   e2e-cov:
-    name: "Examples ready for release"
+    name: Examples ready for release
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           cache: 'npm'
-      - name: Install packages
+      - name: Install dependencies
         run: npm ci
 
       - name: === Examples ready for release ===


### PR DESCRIPTION
Related issue: -

**Description**
Gets rid of the "outdated" warnings present in the action dashboard and in the action logs:

<img width="500" alt="image" src="https://user-images.githubusercontent.com/7217420/221990738-a05c783a-42fe-4538-a65a-f2019e9ca090.png">

Also we can use Node 18 which is the [latest LTS version](https://nodejs.org/en/).

/cc @LeviPesin 