### PR TITLE
Cleanup code in css3d_molecules example

### DIFF
--- a/examples/css3d_molecules.html
+++ b/examples/css3d_molecules.html
@@ -370,11 +370,7 @@
 
 						//
 
-						bond = document.createElement( 'div' );
-						bond.className = 'bond';
-						bond.style.height = bondLength + 'px';
-
-						const joint = new THREE.Object3D( bond );
+						const joint = new THREE.Object3D();
 						joint.position.copy( start );
 						joint.position.lerp( end, 0.5 );
 
@@ -383,6 +379,10 @@
 
 						joint.matrixAutoUpdate = false;
 						joint.updateMatrix();
+
+						bond = document.createElement( 'div' );
+						bond.className = 'bond';
+						bond.style.height = bondLength + 'px';
 
 						object = new CSS3DObject( bond );
 						object.rotation.y = Math.PI / 2;


### PR DESCRIPTION
Related issue: N/A

**Description**

As far as I can tell, passing an HTML element in an Object3D constructor doesn't do anything.