### PR TITLE
NodeLoader: Deserialize sub-properties and fixes.

### DIFF
--- a/examples/jsm/nodes/core/Node.js
+++ b/examples/jsm/nodes/core/Node.js
@@ -293,6 +293,16 @@ class Node {
 
 					this[ property ] = inputArray;
 
+				} else if ( typeof json.inputNodes[ property ] === 'object' ) {
+
+					for ( const subProperty in json.inputNodes[ property ] ) {
+
+						const uuid = json.inputNodes[ property ][ subProperty ];
+					
+						this[ property ][ subProperty ] = nodes[ uuid ];
+					
+					}					
+
 				} else {
 
 					const uuid = json.inputNodes[ property ];

--- a/examples/jsm/nodes/core/Node.js
+++ b/examples/jsm/nodes/core/Node.js
@@ -295,13 +295,17 @@ class Node {
 
 				} else if ( typeof json.inputNodes[ property ] === 'object' ) {
 
+					const inputObject = {};
+
 					for ( const subProperty in json.inputNodes[ property ] ) {
 
 						const uuid = json.inputNodes[ property ][ subProperty ];
 					
-						this[ property ][ subProperty ] = nodes[ uuid ];
+						inputObject[ subProperty ] = nodes[ uuid ];
 					
-					}					
+					}
+
+					this[ property ] = inputObject;
 
 				} else {
 

--- a/examples/jsm/nodes/loaders/NodeLoader.js
+++ b/examples/jsm/nodes/loaders/NodeLoader.js
@@ -80,7 +80,7 @@ class NodeLoader extends Loader {
 
 	parse( json ) {
 
-		const node = nodeObject( createNodeFromType( type ) );
+		const node = nodeObject( createNodeFromType( json.type ) );
 		node.uuid = json.uuid;
 
 		const nodes = this.parseNodes( json.nodes );

--- a/examples/jsm/nodes/utils/ConvertNode.js
+++ b/examples/jsm/nodes/utils/ConvertNode.js
@@ -31,6 +31,22 @@ class ConvertNode extends Node {
 
 	}
 
+	serialize( data ) {
+
+		super.serialize( data );
+
+		data.convertTo = this.convertTo;
+
+	}
+
+	deserialize( data ) {
+
+		super.deserialize( data );
+
+		this.convertTo = data.convertTo;
+
+	}
+
 	generate( builder, output ) {
 
 		const node = this.node;


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/25553

**Description**

- [Node: Deserialize sub-properties.](https://github.com/mrdoob/three.js/commit/0965854b45f363c0c2554e7e190a9ca17a8d0f3a) / [Node: New inputObject to deserialize().](https://github.com/mrdoob/three.js/commit/6751b304db317c57a7437f77d976bb25eb516e1e)
- [NodeLoader: Fix get json.type.](https://github.com/mrdoob/three.js/commit/865c9d58ee792f964cb2bac487b866e1cfab5dd1)
- [ConvertNode: Fix serialize .convertTo property.](https://github.com/mrdoob/three.js/commit/7d23558de4e0b56da834e9bd6f465a859b175991)

