### PR TITLE
Examples: Clean up.

### DIFF
--- a/examples/webgl_simple_gi.html
+++ b/examples/webgl_simple_gi.html
@@ -56,7 +56,7 @@
 				scene.updateMatrixWorld( true );
 
 				let clone = scene.clone();
-				clone.autoUpdate = false;
+				clone.matrixWorldAutoUpdate = false;
 
 				const rt = new THREE.WebGLRenderTarget( SIZE, SIZE );
 
@@ -139,7 +139,7 @@
 					if ( currentVertex >= totalVertex ) {
 
 						clone = scene.clone();
-						clone.autoUpdate = false;
+						clone.matrixWorldAutoUpdate = false;
 
 						bounces ++;
 						currentVertex = 0;


### PR DESCRIPTION
Related issue: -

**Description**

`Scene.autoUpdate` was renamed to `Scene.matrixWorldAutoUpdate`.