### PR TITLE
InstancedMesh: Optimize `raycast()`.

### DIFF
--- a/src/objects/InstancedMesh.js
+++ b/src/objects/InstancedMesh.js
@@ -136,6 +136,17 @@ class InstancedMesh extends Mesh {
 
 		if ( _mesh.material === undefined ) return;
 
+		// test with bounding sphere first
+
+		if ( this.boundingSphere === null ) this.computeBoundingSphere();
+
+		_sphere.copy( this.boundingSphere );
+		_sphere.applyMatrix4( matrixWorld );
+
+		if ( raycaster.ray.intersectsSphere( _sphere ) === false ) return;
+
+		// now test each instance
+
 		for ( let instanceId = 0; instanceId < raycastTimes; instanceId ++ ) {
 
 			// calculate the world matrix for each instance


### PR DESCRIPTION
Related issue: #25591

**Description**

This PR optimizes `InstancedMesh.raycast()` a bit by checking the bounding sphere first before testing individual instances.
