### PR TITLE
Docs: Fix Rhino3dmLoader import.

### DIFF
--- a/docs/examples/en/loaders/3DMLoader.html
+++ b/docs/examples/en/loaders/3DMLoader.html
@@ -25,7 +25,7 @@
 		</p>
 
 		<code>
-			import { 3DMLoader } from 'three/addons/loaders/3DMLoader.js';
+			import { Rhino3dmLoader } from 'three/addons/loaders/3DMLoader.js';
 		</code>
 
 		<h2>Supported Conversions</h2>


### PR DESCRIPTION
Related issue: no related issue

**Description**

Update the import. `3DMLoader` is not exported from that file. It also is is an invalid variable name 😅. The only exported thing according to the `@types` package is `Rhino3dmLoader`.
