### PR TITLE
GLTFLoader: Do not disable frustum culling for `InstancedMesh`.

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -1618,8 +1618,6 @@ class GLTFMeshGpuInstancing {
 				// Just in case
 				Object3D.prototype.copy.call( instancedMesh, mesh );
 
-				// https://github.com/mrdoob/three.js/issues/18334
-				instancedMesh.frustumCulled = false;
 				this.parser.assignFinalMaterial( instancedMesh );
 
 				instancedMeshes.push( instancedMesh );


### PR DESCRIPTION
Related issue: #25591

**Description**

The extensions code for `EXT_MESH_GPU_INSTANCING` does not need to disable frustum culling for `InstancedMesh` anymore.
