### PR TITLE
CI: Fix report-size.yml execution

### DIFF
--- a/.github/workflows/read-size.yml
+++ b/.github/workflows/read-size.yml
@@ -42,7 +42,7 @@ jobs:
           TREESHAKEN_GZIP=$(stat --format=%s test/treeshake/index.bundle.min.js.gz)
 
           # write the output in a json file to upload it as artifact
-          node -pe "JSON.stringify({ filesize: $FILESIZE, gzip: $FILESIZE_GZIP, treeshaken: $TREESHAKEN, treeshakenGzip: $TREESHAKEN_GZIP })" > sizes.json
+          node -pe "JSON.stringify({ filesize: $FILESIZE, gzip: $FILESIZE_GZIP, treeshaken: $TREESHAKEN, treeshakenGzip: $TREESHAKEN_GZIP, pr: ${{ github.event.pull_request.number }} })" > sizes.json
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/report-size.yml
+++ b/.github/workflows/report-size.yml
@@ -21,6 +21,11 @@ jobs:
     if: github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success'
     steps:
+      - name: Log GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
+
       # Using actions/download-artifact doesn't work here
       # https://github.com/actions/download-artifact/issues/60
       - name: Download artifact
@@ -101,13 +106,13 @@ jobs:
         uses: peter-evans/find-comment@v2
         id: find-comment
         with:
-          issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          issue-number: ${{ fromJSON(steps.download-artifact.outputs.result).pr }}
           comment-author: 'github-actions[bot]'
           body-includes: Bundle size
       - name: Comment on PR
         uses: peter-evans/create-or-update-comment@v2
         with:
-          issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          issue-number: ${{ fromJSON(steps.download-artifact.outputs.result).pr }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           edit-mode: replace
           body: |


### PR DESCRIPTION
Related issue: #25615

**Description**

There seems to be an error in the `report-size.yml` action, it can't access the PR number. 
Fixed it by including it in the artifacts.
Also added a log to check better.

https://github.com/mrdoob/three.js/actions/runs/4345259527/jobs/7589714941
<img width="461" alt="image" src="https://user-images.githubusercontent.com/7217420/223166951-9d324c81-08cb-458b-ac40-d63959b93ded.png">
