### PR TITLE
Quaternion: Add toJSON().

### DIFF
--- a/docs/api/en/math/Color.html
+++ b/docs/api/en/math/Color.html
@@ -322,6 +322,11 @@ const color7 = new THREE.Color( 1, 0, 0 );
 		Returns an array of the form [ r, g, b ].
 		</p>
 
+		<h3>[method:Number toJSON]()</h3>
+		<p>
+		This methods defines the serialization result of [name]. Returns the color as a hexadecimal value.
+		</p>
+
 		<h2>Source</h2>
 
 		<p>

--- a/docs/api/en/math/Quaternion.html
+++ b/docs/api/en/math/Quaternion.html
@@ -218,6 +218,11 @@
 		Returns the numerical elements of this quaternion in an array of format [x, y, z, w].
 		</p>
 
+		<h3>[method:Array toJSON]()</h3>
+		<p>
+		This methods defines the serialization result of [name]. Returns the numerical elements of this quaternion in an array of format [x, y, z, w].
+		</p>
+
 		<h3>[method:this fromBufferAttribute]( [param:BufferAttribute attribute], [param:Integer index] )</h3>
 		<p>
 		[page:BufferAttribute attribute] - the source attribute.<br />

--- a/docs/api/it/math/Color.html
+++ b/docs/api/it/math/Color.html
@@ -319,6 +319,11 @@ const color7 = new THREE.Color( 1, 0, 0 );
 		Restituisce un array della forma [ r, g, b ].
 		</p>
 
+		<h3>[method:Number toJSON]()</h3>
+		<p>
+		This methods defines the serialization result of [name]. Returns the color as a hexadecimal value.
+		</p>
+
 		<h2>Source</h2>
 
 		<p>

--- a/docs/api/it/math/Quaternion.html
+++ b/docs/api/it/math/Quaternion.html
@@ -218,6 +218,11 @@
 		Restituisce gli elementi numerici di questo quaternione in un array del formato [x, y, z, w].
 		</p>
 
+		<h3>[method:Array toJSON]()</h3>
+		<p>
+		This methods defines the serialization result of [name]. Restituisce gli elementi numerici di questo quaternione in un array del formato [x, y, z, w].
+		</p>
+
 		<h3>[method:this fromBufferAttribute]( [param:BufferAttribute attribute], [param:Integer index] )</h3>
 		<p>
 		[page:BufferAttribute attribute] - l'attributo sorgente.<br />

--- a/docs/api/zh/math/Color.html
+++ b/docs/api/zh/math/Color.html
@@ -315,6 +315,11 @@
 		返回一个格式为[ r, g, b ] 数组。
 		</p>
 
+		<h3>[method:Number toJSON]()</h3>
+		<p>
+		This methods defines the serialization result of [name]. Returns the color as a hexadecimal value.
+		</p>
+
 		<h2>源码（Source）</h2>
 
 		<p>

--- a/docs/api/zh/math/Quaternion.html
+++ b/docs/api/zh/math/Quaternion.html
@@ -203,6 +203,11 @@
 		在形如[x, y, z, w]的数组中，返回四元数中的数字元素。
 		</p>
 
+		<h3>[method:Array toJSON]()</h3>
+		<p>
+		This methods defines the serialization result of [name]. 在形如[x, y, z, w]的数组中，返回四元数中的数字元素。
+		</p>
+
 		<h3>[method:this fromBufferAttribute]( [param:BufferAttribute attribute], [param:Integer index] )</h3>
 		<p>
 		[page:BufferAttribute attribute] - 源 attribute。<br />

--- a/examples/webgl_geometry_cube.html
+++ b/examples/webgl_geometry_cube.html
@@ -33,6 +33,8 @@
 
 			function init() {
 
+				console.log( JSON.stringify( new THREE.Quaternion() ) );
+
 				camera = new THREE.PerspectiveCamera( 70, window.innerWidth / window.innerHeight, 1, 1000 );
 				camera.position.z = 400;
 

--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -654,6 +654,12 @@ class Quaternion {
 
 	}
 
+	toJSON() {
+
+		return this.toArray();
+
+	}
+
 	_onChange( callback ) {
 
 		this._onChangeCallback = callback;

--- a/test/unit/src/math/Quaternion.tests.js
+++ b/test/unit/src/math/Quaternion.tests.js
@@ -857,6 +857,17 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
+		QUnit.test( 'toJSON', ( assert ) => {
+
+			const q = new Quaternion( 0, 0.5, 0.7, 1 );
+			const array = q.toJSON();
+			assert.strictEqual( array[ 0 ], 0, 'Quaternion is serializable.' );
+			assert.strictEqual( array[ 1 ], 0.5, 'Quaternion is serializable.' );
+			assert.strictEqual( array[ 2 ], 0.7, 'Quaternion is serializable.' );
+			assert.strictEqual( array[ 3 ], 1, 'Quaternion is serializable.' );
+
+		} );
+
 		QUnit.test( 'iterable', ( assert ) => {
 
 			const q = new Quaternion( 0, 0.5, 0.7, 1 );


### PR DESCRIPTION
Fixed #25424.

**Description**

This PR overwrites the default serialization behavior of `Quaternion`. Instead of an object exposing the private variables it just produces an array.

The PR adds the missing documentation for `Color.toJSON()`.
