### PR TITLE
Create renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,7 @@
     "config:base",
     ":disableDependencyDashboard"
   ],
-  "timezone": "America/Los_Angeles",
+  "timezone": "Asia/Tokyo",
   "schedule": ["after 1am and before 7am every monday"],
   "packageRules": [
     {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,16 @@
+{
+  "extends": [
+    "config:base",
+    ":disableDependencyDashboard"
+  ],
+  "timezone": "America/Los_Angeles",
+  "schedule": ["after 1am and before 7am every monday"],
+  "packageRules": [
+    {
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["patch", "minor", "pin", "digest"],
+      "groupName": "devDependencies (non-major)",
+      "automerge": true
+    }
+  ]
+}


### PR DESCRIPTION
Adds configuration for the Renovate bot (https://docs.renovatebot.com/), initially set to update dependencies every Monday morning, U.S. Pacific Time. Major version increments will be separate PRs for testing. Non-major version increments will be bundled into a single PR, and automatically merged if the CI passes.

Additional steps required:

- [x] Enable renovate bot (https://docs.renovatebot.com/getting-started/installing-onboarding/)
- [x] Disable dependabot