### PR TITLE
Math: Add convenience methods

### DIFF
--- a/docs/api/en/math/Color.html
+++ b/docs/api/en/math/Color.html
@@ -98,11 +98,6 @@ const color7 = new THREE.Color( 1, 0, 0 );
 		Blue channel value between 0 and 1. Default is 1.
 		</p>
 
-
-
-
-
-
 		<h2>Methods</h2>
 
 		<h3>[method:this add]( [param:Color color] ) </h3>
@@ -113,6 +108,9 @@ const color7 = new THREE.Color( 1, 0, 0 );
 
 		<h3>[method:this addScalar]( [param:Number s] ) </h3>
 		<p>Adds [page:Number s] to the RGB values of this color.</p>
+
+		<h3>[method:this applyMatrix3]( [param:Matrix3 m] )</h3>
+		<p>Applies the transform [page:Matrix3 m] to this color's RGB components.</p>
 
 		<h3>[method:Color clone]() </h3>
 		<p>Returns a new Color with the same [page:.r r], [page:.g g] and [page:.b b] values as this one.</p>
@@ -246,6 +244,11 @@ const color7 = new THREE.Color( 1, 0, 0 );
 
 		See the Constructor above for full details of what [page:Color_Hex_or_String value] can be.
 		Delegates to [page:.copy], [page:.setStyle], or [page:.setHex] depending on input type.
+		</p>
+
+		<h3>[method:this setFromVector3]( [param:Vector3 vector] )</h3>
+		<p>
+		Sets this colors's [page:.r r], [page:.g g] and [page:.b b] components from the x, y, and z components of the specified [page:Vector3 vector].
 		</p>
 
 		<h3>[method:this setHex]( [param:Integer hex], [param:string colorSpace] = SRGBColorSpace ) </h3>

--- a/docs/api/en/math/Vector3.html
+++ b/docs/api/en/math/Vector3.html
@@ -111,7 +111,7 @@
 
 		<h3>[method:this applyMatrix4]( [param:Matrix4 m] )</h3>
 		<p>
-		Multiplies this vector (with an implicit 1 in the 4th dimension) and m, and divides by perspective.
+		Multiplies this vector (with an implicit 1 in the 4th dimension) by m, and divides by perspective.
 		</p>
 
 		<h3>[method:this applyNormalMatrix]( [param:Matrix3 m] )</h3>
@@ -352,6 +352,11 @@
 		If index equals 0 set [page:.x x] to [page:Float value].<br />
 		If index equals 1 set [page:.y y] to [page:Float value].<br />
 		If index equals 2 set [page:.z z] to [page:Float value]
+		</p>
+
+		<h3>[method:this setFromColor]( [param:Color color] )</h3>
+		<p>
+		Sets this vector's [page:.x x], [page:.y y] and [page:.z z] components from the r, g, and b components of the specified [page:Color color].
 		</p>
 
 		<h3>[method:this setFromCylindrical]( [param:Cylindrical c] )</h3>

--- a/src/math/Color.js
+++ b/src/math/Color.js
@@ -538,6 +538,29 @@ class Color {
 
 	}
 
+	setFromVector3( v ) {
+
+		this.r = v.x;
+		this.g = v.y;
+		this.b = v.z;
+
+		return this;
+
+	}
+
+	applyMatrix3( m ) {
+
+		const r = this.r, g = this.g, b = this.b;
+		const e = m.elements;
+
+		this.r = e[ 0 ] * r + e[ 3 ] * g + e[ 6 ] * b;
+		this.g = e[ 1 ] * r + e[ 4 ] * g + e[ 7 ] * b;
+		this.b = e[ 2 ] * r + e[ 5 ] * g + e[ 8 ] * b;
+
+		return this;
+
+	}
+
 	equals( c ) {
 
 		return ( c.r === this.r ) && ( c.g === this.g ) && ( c.b === this.b );

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -637,6 +637,16 @@ class Vector3 {
 
 	}
 
+	setFromColor( c ) {
+
+		this.x = c.r;
+		this.y = c.g;
+		this.z = c.b;
+
+		return this;
+
+	}
+
 	equals( v ) {
 
 		return ( ( v.x === this.x ) && ( v.y === this.y ) && ( v.z === this.z ) );


### PR DESCRIPTION
In `ColorManagement.js` this pattern is used:

https://github.com/mrdoob/three.js/blob/820b3bfd0245236d515193ac762486e0b96dcfb2/src/math/ColorManagement.js#L48-L50

This PR adds convenience methods to simplify these calculations:

```js
Vector3.setFromColor( c )
Color.setFromVector3( v )
Color.applyMatrix3( m )
```
/ping @donmccurdy 