### PR TITLE
Triangle: Warn about `getUV()` only once.

### DIFF
--- a/src/math/Triangle.js
+++ b/src/math/Triangle.js
@@ -12,6 +12,8 @@ const _vap = /*@__PURE__*/ new Vector3();
 const _vbp = /*@__PURE__*/ new Vector3();
 const _vcp = /*@__PURE__*/ new Vector3();
 
+let warnedGetUV = false;
+
 class Triangle {
 
 	constructor( a = new Vector3(), b = new Vector3(), c = new Vector3() ) {
@@ -83,7 +85,13 @@ class Triangle {
 
 	static getUV( point, p1, p2, p3, uv1, uv2, uv3, target ) {
 
-		console.warn( 'THREE.Triangle.getUV() has been renamed to THREE.Triangle.getInterpolation().' ); // r151
+		if ( warnedGetUV === false ) {
+
+			console.warn( 'THREE.Triangle.getUV() has been renamed to THREE.Triangle.getInterpolation().' ); // r151
+
+			warnedGetUV = true;
+
+		}
 
 		return this.getInterpolation( point, p1, p2, p3, uv1, uv2, uv3, target );
 
@@ -193,7 +201,13 @@ class Triangle {
 
 	getUV( point, uv1, uv2, uv3, target ) {
 
-		console.warn( 'Triangle.getUV() has been renamed to Triangle.getInterpolation().' ); // r151
+		if ( warnedGetUV === false ) {
+
+			console.warn( 'THREE.Triangle.getUV() has been renamed to THREE.Triangle.getInterpolation().' ); // r151
+
+			warnedGetUV = true;
+
+		}
 
 		return Triangle.getInterpolation( point, this.a, this.b, this.c, uv1, uv2, uv3, target );
 

--- a/src/math/Triangle.js
+++ b/src/math/Triangle.js
@@ -87,7 +87,7 @@ class Triangle {
 
 		if ( warnedGetUV === false ) {
 
-			console.warn( 'THREE.Triangle.getUV() has been renamed to THREE.Triangle.getInterpolation().' ); // r151
+			console.warn( 'THREE.Triangle.getUV() has been renamed to THREE.Triangle.getInterpolation().' ); // @deprecated since r151
 
 			warnedGetUV = true;
 
@@ -203,7 +203,7 @@ class Triangle {
 
 		if ( warnedGetUV === false ) {
 
-			console.warn( 'THREE.Triangle.getUV() has been renamed to THREE.Triangle.getInterpolation().' ); // r151
+			console.warn( 'THREE.Triangle.getUV() has been renamed to THREE.Triangle.getInterpolation().' ); // @deprecated since r151
 
 			warnedGetUV = true;
 


### PR DESCRIPTION
Related issue: #25566

**Description**

As suggested in https://github.com/mrdoob/three.js/pull/25566#issuecomment-1461090038, the deprecation warning about `getUV()` is now only logged once to avoid spamming the browser console.