### PR TITLE
Editor: Use selected camera when playing the scene.

### DIFF
--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -695,7 +695,7 @@ Editor.prototype = {
 				toneMapping: this.config.getKey( 'project/renderer/toneMapping' ),
 				toneMappingExposure: this.config.getKey( 'project/renderer/toneMappingExposure' )
 			},
-			camera: this.camera.toJSON(),
+			camera: this.viewportCamera.toJSON(),
 			scene: this.scene.toJSON(),
 			scripts: this.scripts,
 			history: this.history.toJSON()


### PR DESCRIPTION
Fixed #24642.

**Description**

The editor uses now the selected camera for playing the scene. Previously, a selected camera from the dropdown was ignored and always the main camera used.
