### PR TITLE
Remove deprecated for 11 releases code

### DIFF
--- a/examples/jsm/utils/BufferGeometryUtils.js
+++ b/examples/jsm/utils/BufferGeometryUtils.js
@@ -11,12 +11,6 @@ import {
 	Vector3,
 } from 'three';
 
-function computeTangents() { // @deprecated, r140
-
-	throw new Error( 'BufferGeometryUtils: computeTangents renamed to computeMikkTSpaceTangents.' );
-
-}
-
 function computeMikkTSpaceTangents( geometry, MikkTSpace, negateSign = true ) {
 
 	if ( ! MikkTSpace || ! MikkTSpace.isReady ) {
@@ -1325,7 +1319,6 @@ function toCreasedNormals( geometry, creaseAngle = Math.PI / 3 /* 60 degrees */ 
 }
 
 export {
-	computeTangents,
 	computeMikkTSpaceTangents,
 	mergeBufferGeometries,
 	mergeBufferAttributes,


### PR DESCRIPTION
Related issue: -

**Description**

Remove deprecated for 11 releases code.

(Maybe we can automate this removal somehow?)