### PR TITLE
Update deprecation comments clearly stating when deprecated

### DIFF
--- a/src/Three.Legacy.js
+++ b/src/Three.Legacy.js
@@ -18,9 +18,7 @@ import { TorusGeometry } from './geometries/TorusGeometry.js';
 import { TorusKnotGeometry } from './geometries/TorusKnotGeometry.js';
 import { TubeGeometry } from './geometries/TubeGeometry.js';
 
-// r144
-
-export class BoxBufferGeometry extends BoxGeometry {
+export class BoxBufferGeometry extends BoxGeometry { // @deprecated, r144
 
 	constructor( width, height, depth, widthSegments, heightSegments, depthSegments ) {
 
@@ -32,9 +30,7 @@ export class BoxBufferGeometry extends BoxGeometry {
 
 }
 
-// r144
-
-export class CapsuleBufferGeometry extends CapsuleGeometry {
+export class CapsuleBufferGeometry extends CapsuleGeometry { // @deprecated, r144
 
 	constructor( radius, length, capSegments, radialSegments ) {
 
@@ -45,9 +41,7 @@ export class CapsuleBufferGeometry extends CapsuleGeometry {
 
 }
 
-// r144
-
-export class CircleBufferGeometry extends CircleGeometry {
+export class CircleBufferGeometry extends CircleGeometry { // @deprecated, r144
 
 	constructor( radius, segments, thetaStart, thetaLength ) {
 
@@ -58,9 +52,7 @@ export class CircleBufferGeometry extends CircleGeometry {
 
 }
 
-// r144
-
-export class ConeBufferGeometry extends ConeGeometry {
+export class ConeBufferGeometry extends ConeGeometry { // @deprecated, r144
 
 	constructor( radius, height, radialSegments, heightSegments, openEnded, thetaStart, thetaLength ) {
 
@@ -71,9 +63,7 @@ export class ConeBufferGeometry extends ConeGeometry {
 
 }
 
-// r144
-
-export class CylinderBufferGeometry extends CylinderGeometry {
+export class CylinderBufferGeometry extends CylinderGeometry { // @deprecated, r144
 
 	constructor( radiusTop, radiusBottom, height, radialSegments, heightSegments, openEnded, thetaStart, thetaLength ) {
 
@@ -84,9 +74,7 @@ export class CylinderBufferGeometry extends CylinderGeometry {
 
 }
 
-// r144
-
-export class DodecahedronBufferGeometry extends DodecahedronGeometry {
+export class DodecahedronBufferGeometry extends DodecahedronGeometry { // @deprecated, r144
 
 	constructor( radius, detail ) {
 
@@ -97,9 +85,7 @@ export class DodecahedronBufferGeometry extends DodecahedronGeometry {
 
 }
 
-// r144
-
-export class ExtrudeBufferGeometry extends ExtrudeGeometry {
+export class ExtrudeBufferGeometry extends ExtrudeGeometry { // @deprecated, r144
 
 	constructor( shapes, options ) {
 
@@ -110,9 +96,7 @@ export class ExtrudeBufferGeometry extends ExtrudeGeometry {
 
 }
 
-// r144
-
-export class IcosahedronBufferGeometry extends IcosahedronGeometry {
+export class IcosahedronBufferGeometry extends IcosahedronGeometry { // @deprecated, r144
 
 	constructor( radius, detail ) {
 
@@ -123,9 +107,7 @@ export class IcosahedronBufferGeometry extends IcosahedronGeometry {
 
 }
 
-// r144
-
-export class LatheBufferGeometry extends LatheGeometry {
+export class LatheBufferGeometry extends LatheGeometry { // @deprecated, r144
 
 	constructor( points, segments, phiStart, phiLength ) {
 
@@ -136,9 +118,7 @@ export class LatheBufferGeometry extends LatheGeometry {
 
 }
 
-// r144
-
-export class OctahedronBufferGeometry extends OctahedronGeometry {
+export class OctahedronBufferGeometry extends OctahedronGeometry { // @deprecated, r144
 
 	constructor( radius, detail ) {
 
@@ -149,9 +129,7 @@ export class OctahedronBufferGeometry extends OctahedronGeometry {
 
 }
 
-// r144
-
-export class PlaneBufferGeometry extends PlaneGeometry {
+export class PlaneBufferGeometry extends PlaneGeometry { // @deprecated, r144
 
 	constructor( width, height, widthSegments, heightSegments ) {
 
@@ -162,9 +140,7 @@ export class PlaneBufferGeometry extends PlaneGeometry {
 
 }
 
-// r144
-
-export class PolyhedronBufferGeometry extends PolyhedronGeometry {
+export class PolyhedronBufferGeometry extends PolyhedronGeometry { // @deprecated, r144
 
 	constructor( vertices, indices, radius, detail ) {
 
@@ -175,9 +151,7 @@ export class PolyhedronBufferGeometry extends PolyhedronGeometry {
 
 }
 
-// r144
-
-export class RingBufferGeometry extends RingGeometry {
+export class RingBufferGeometry extends RingGeometry { // @deprecated, r144
 
 	constructor( innerRadius, outerRadius, thetaSegments, phiSegments, thetaStart, thetaLength ) {
 
@@ -188,9 +162,7 @@ export class RingBufferGeometry extends RingGeometry {
 
 }
 
-// r144
-
-export class ShapeBufferGeometry extends ShapeGeometry {
+export class ShapeBufferGeometry extends ShapeGeometry { // @deprecated, r144
 
 	constructor( shapes, curveSegments ) {
 
@@ -201,9 +173,7 @@ export class ShapeBufferGeometry extends ShapeGeometry {
 
 }
 
-// r144
-
-export class SphereBufferGeometry extends SphereGeometry {
+export class SphereBufferGeometry extends SphereGeometry { // @deprecated, r144
 
 	constructor( radius, widthSegments, heightSegments, phiStart, phiLength, thetaStart, thetaLength ) {
 
@@ -214,9 +184,7 @@ export class SphereBufferGeometry extends SphereGeometry {
 
 }
 
-// r144
-
-export class TetrahedronBufferGeometry extends TetrahedronGeometry {
+export class TetrahedronBufferGeometry extends TetrahedronGeometry { // @deprecated, r144
 
 	constructor( radius, detail ) {
 
@@ -227,9 +195,7 @@ export class TetrahedronBufferGeometry extends TetrahedronGeometry {
 
 }
 
-// r144
-
-export class TorusBufferGeometry extends TorusGeometry {
+export class TorusBufferGeometry extends TorusGeometry { // @deprecated, r144
 
 	constructor( radius, tube, radialSegments, tubularSegments, arc ) {
 
@@ -240,9 +206,7 @@ export class TorusBufferGeometry extends TorusGeometry {
 
 }
 
-// r144
-
-export class TorusKnotBufferGeometry extends TorusKnotGeometry {
+export class TorusKnotBufferGeometry extends TorusKnotGeometry { // @deprecated, r144
 
 	constructor( radius, tube, tubularSegments, radialSegments, p, q ) {
 
@@ -253,9 +217,7 @@ export class TorusKnotBufferGeometry extends TorusKnotGeometry {
 
 }
 
-// r144
-
-export class TubeBufferGeometry extends TubeGeometry {
+export class TubeBufferGeometry extends TubeGeometry { // @deprecated, r144
 
 	constructor( path, tubularSegments, radius, radialSegments, closed ) {
 
@@ -265,5 +227,3 @@ export class TubeBufferGeometry extends TubeGeometry {
 	}
 
 }
-
-

--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -344,27 +344,25 @@ class BufferAttribute {
 
 	}
 
-	// @deprecated
-
-	copyColorsArray() {
+	copyColorsArray() { // @deprecated, r144
 
 		console.error( 'THREE.BufferAttribute: copyColorsArray() was removed in r144.' );
 
 	}
 
-	copyVector2sArray() {
+	copyVector2sArray() { // @deprecated, r144
 
 		console.error( 'THREE.BufferAttribute: copyVector2sArray() was removed in r144.' );
 
 	}
 
-	copyVector3sArray() {
+	copyVector3sArray() { // @deprecated, r144
 
 		console.error( 'THREE.BufferAttribute: copyVector3sArray() was removed in r144.' );
 
 	}
 
-	copyVector4sArray() {
+	copyVector4sArray() { // @deprecated, r144
 
 		console.error( 'THREE.BufferAttribute: copyVector4sArray() was removed in r144.' );
 

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -726,9 +726,7 @@ class BufferGeometry extends EventDispatcher {
 
 	}
 
-	// @deprecated since r144
-
-	merge() {
+	merge() { // @deprecated, r144
 
 		console.error( 'THREE.BufferGeometry.merge() has been removed. Use THREE.BufferGeometryUtils.mergeBufferGeometries() instead.' );
 		return this;

--- a/src/math/Triangle.js
+++ b/src/math/Triangle.js
@@ -83,11 +83,11 @@ class Triangle {
 
 	}
 
-	static getUV( point, p1, p2, p3, uv1, uv2, uv3, target ) {
+	static getUV( point, p1, p2, p3, uv1, uv2, uv3, target ) { // @deprecated, r151
 
 		if ( warnedGetUV === false ) {
 
-			console.warn( 'THREE.Triangle.getUV() has been renamed to THREE.Triangle.getInterpolation().' ); // @deprecated since r151
+			console.warn( 'THREE.Triangle.getUV() has been renamed to THREE.Triangle.getInterpolation().' );
 
 			warnedGetUV = true;
 
@@ -199,11 +199,11 @@ class Triangle {
 
 	}
 
-	getUV( point, uv1, uv2, uv3, target ) {
+	getUV( point, uv1, uv2, uv3, target ) { // @deprecated, r151
 
 		if ( warnedGetUV === false ) {
 
-			console.warn( 'THREE.Triangle.getUV() has been renamed to THREE.Triangle.getInterpolation().' ); // @deprecated since r151
+			console.warn( 'THREE.Triangle.getUV() has been renamed to THREE.Triangle.getInterpolation().' );
 
 			warnedGetUV = true;
 

--- a/src/objects/SkinnedMesh.js
+++ b/src/objects/SkinnedMesh.js
@@ -200,9 +200,7 @@ class SkinnedMesh extends Mesh {
 
 	}
 
-	// @deprecated
-
-	boneTransform( index, vector ) {
+	boneTransform( index, vector ) { // @deprecated, r151
 
 		console.warn( 'THREE.SkinnedMesh: .boneTransform() was renamed to .applyBoneTransform() in r151.' );
 		return this.applyBoneTransform( index, vector );

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2288,18 +2288,14 @@ class WebGLRenderer {
 
 	}
 
-	// @deprecated since r150
-
-	get physicallyCorrectLights() {
+	get physicallyCorrectLights() { // @deprecated, r150
 
 		console.warn( 'THREE.WebGLRenderer: the property .physicallyCorrectLights has been removed. Set renderer.useLegacyLights instead.' );
 		return ! this.useLegacyLights;
 
 	}
 
-	// @deprecated since r150
-
-	set physicallyCorrectLights( value ) {
+	set physicallyCorrectLights( value ) { // @deprecated, r150
 
 		console.warn( 'THREE.WebGLRenderer: the property .physicallyCorrectLights has been removed. Set renderer.useLegacyLights instead.' );
 		this.useLegacyLights = ! value;

--- a/src/scenes/Scene.js
+++ b/src/scenes/Scene.js
@@ -58,16 +58,14 @@ class Scene extends Object3D {
 
 	}
 
-	// @deprecated
-
-	get autoUpdate() {
+	get autoUpdate() { // @deprecated, r144
 
 		console.warn( 'THREE.Scene: autoUpdate was renamed to matrixWorldAutoUpdate in r144.' );
 		return this.matrixWorldAutoUpdate;
 
 	}
 
-	set autoUpdate( value ) {
+	set autoUpdate( value ) { // @deprecated, r144
 
 		console.warn( 'THREE.Scene: autoUpdate was renamed to matrixWorldAutoUpdate in r144.' );
 		this.matrixWorldAutoUpdate = value;

--- a/utils/build/rollup.config.js
+++ b/utils/build/rollup.config.js
@@ -310,7 +310,7 @@ const builds = [
 			}
 		]
 	},
-	{
+	{ // @deprecated, r150
 		input: 'src/Three.js',
 		plugins: [
 			addons(),
@@ -327,7 +327,7 @@ const builds = [
 			}
 		]
 	},
-	{
+	{ // @deprecated, r150
 		input: 'src/Three.js',
 		plugins: [
 			addons(),


### PR DESCRIPTION
Related issue: -

**Description**

Update deprecation comments clearly stating when deprecated (so that, for example, one could just do `grep -r '@deprecated, r144' .` in r155).