### PR TITLE
SkeletonUtils: Update documentation

### DIFF
--- a/docs/examples/en/utils/SkeletonUtils.html
+++ b/docs/examples/en/utils/SkeletonUtils.html
@@ -21,7 +21,7 @@
 		</p>
 
 		<code>
-			import { SkeletonUtils } from 'three/addons/utils/SkeletonUtils.js';
+			import * as SkeletonUtils from 'three/addons/utils/SkeletonUtils.js';
 		</code>
 
 		<h2>Methods</h2>


### PR DESCRIPTION
Related issue: None
**Description**

I tried to import SkeletonUtils as described in the documentation:

`import { SkeletonUtils } from 'three/addons/utils/SkeletonUtils.js';
`

But looks like API changed and we should use import all as SkeletonUtils now:

`import * as SkeletonUtils from 'three/addons/utils/SkeletonUtils.js';
`