### PR TITLE
HTMLMesh: Add image support.

### DIFF
--- a/examples/jsm/interactive/HTMLMesh.js
+++ b/examples/jsm/interactive/HTMLMesh.js
@@ -273,6 +273,12 @@ function html2canvas( element ) {
 			context.drawImage( element, 0, 0 );
 			context.restore();
 
+		} else if ( element instanceof HTMLImageElement ) {
+
+			if ( element.style.display === 'none' ) return;
+
+			context.drawImage( element, 0, 0, element.width, element.height );
+
 		} else {
 
 			if ( element.style.display === 'none' ) return;


### PR DESCRIPTION
Fixed #25655.

**Description**

Instances of `HTMLImageElement` are now honored by `HTMLMesh`.
