### PR TITLE
GLTFLoader: Texture URI as name.

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2988,7 +2988,7 @@ class GLTFParser {
 
 			texture.flipY = false;
 
-			texture.name = textureDef.name || sourceDef.name || '';
+			texture.name = textureDef.name || sourceDef.name || sourceDef.uri || '';
 
 			const samplers = json.samplers || {};
 			const sampler = samplers[ textureDef.sampler ] || {};


### PR DESCRIPTION
**Description**

Assumes a URI as the name if the other options are not available.

Example getting from `DamagedHelmet.gltf` file:

![image](https://user-images.githubusercontent.com/502810/224627858-f99442fb-ce09-4c26-b591-7c9bbf5b221f.png)

/ping @donmccurdy  @Mugen87