### PR TITLE
Allow webgl contexts to be GC'd sooner in Chrome.

### DIFF
--- a/docs/api/en/renderers/WebGLRenderer.html
+++ b/docs/api/en/renderers/WebGLRenderer.html
@@ -309,9 +309,12 @@
 		<h3>[method:undefined copyTextureToTexture3D]( [param:Box3 sourceBox], [param:Vector3 position], [param:Texture srcTexture], [param:Texture dstTexture], [param:Number level] )</h3>
 		<p>Copies the pixels of a texture in the bounds '[page:Box3 sourceBox]' in the destination texture starting from the given position. Enables access to [link:https://developer.mozilla.org/en-US/docs/Web/API/WebGL2RenderingContext/texSubImage3D WebGL2RenderingContext.texSubImage3D].</p>
 
-		<h3>[method:undefined dispose]( )</h3>
+		<h3>[method:undefined dispose]( [param:boolean forceContextLoss] )</h3>
 		<p>
 		Frees the GPU-related resources allocated by this instance. Call this method whenever this instance is no longer used in your app.
+
+		[page:boolean forceContextLoss] — When `true` forces the webgl context to be lost without calling event handlers. When `false` it will not force webgl context loss, which is useful if the context still needs to be used separately after the renderer is disposed (for example with other WebGL rendering libs). Default is `true`.<br /><br />
+
 		</p>
 
 		<h3>[method:undefined forceContextLoss]()</h3>

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -571,11 +571,17 @@ class WebGLRenderer {
 
 		//
 
-		this.dispose = function () {
+		this.dispose = function ( forceContextLoss = true ) {
 
 			canvas.removeEventListener( 'webglcontextlost', onContextLost, false );
 			canvas.removeEventListener( 'webglcontextrestored', onContextRestore, false );
 			canvas.removeEventListener( 'webglcontextcreationerror', onContextCreationError, false );
+
+			// Allow webgl contexts to be GC'd sooner in Chrome.
+
+			if ( forceContextLoss ) this.forceContextLoss();
+
+			//
 
 			renderLists.dispose();
 			renderStates.dispose();

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -577,7 +577,7 @@ class WebGLRenderer {
 			canvas.removeEventListener( 'webglcontextrestored', onContextRestore, false );
 			canvas.removeEventListener( 'webglcontextcreationerror', onContextCreationError, false );
 
-			// Allow webgl contexts to be GC'd sooner in Chrome.
+			// Allow webgl contexts to be GC'd sooner in some browsers.
 
 			if ( forceContextLoss ) this.forceContextLoss();
 


### PR DESCRIPTION
**Description**

Allow webgl contexts to be GC'd sooner in Chrome.

We found that in Chrome, canvases can remain uncollected for a while, causing the 32-context limit to be reached over time

An example of this is switching tabs in an app: if each tab view renders 16 webgl contexts, then on the 3rd tab switch errors will start happening even if we've let go of canvases (or maybe some modern DOM component systems cache elements for a while).

With this change to `WebGLRenderer.dispose()`, lost contexts do not count towards the limit, and the tab switching example works (as long as each tab/view uses less than 32 contexts at once).

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Lume](https://lume.io).*
