### PR TITLE
Update webgl_loader_md2.html

### DIFF
--- a/examples/webgl_loader_md2.html
+++ b/examples/webgl_loader_md2.html
@@ -320,8 +320,6 @@
 					playbackConfig[ clip.name ] = generateCallback( clip );
 					guiItems[ i ] = folder.add( playbackConfig, clip.name, clip.name );
 
-					i ++;
-
 				}
 
 			}


### PR DESCRIPTION
Double index increment preventing all animations to be set in UI.

Related issue: #XXXX

**Description**

Not all MD2 animations could be displayed.