### PR TITLE
Fix the Chinese translation of MeshToonMaterial

### DIFF
--- a/docs/api/zh/materials/MeshToonMaterial.html
+++ b/docs/api/zh/materials/MeshToonMaterial.html
@@ -11,7 +11,7 @@
 
 		<h1>[name]</h1>
 
-		<div class="desc">A material implementing toon shading.</div>
+		<div class="desc">一种实现卡通着色的材质。</div>
 
 		<iframe id="scene" src="scenes/material-browser.html#MeshToonMaterial"></iframe>
 
@@ -36,162 +36,134 @@
 			[example:webgl_materials_variations_toon materials / variations / toon]
 		</p>
 
-		<h2>Constructor</h2>
+		<h2>构造函数(Constructor)</h2>
 
 		<h3>[name]( [param:Object parameters] )</h3>
 		<p>
-			[page:Object parameters] - (optional) an object with one or more properties defining the material's appearance.
-			Any property of the material (including any property inherited from [page:Material]) can be passed in here.<br /><br />
+			[page:Object parameters] - (可选) 具有定义材料外观的一个或多个属性的对象。材料的任何属性（包括从Material继承的任何属性）都可以在这里传递.<br /><br />
 
-			The exception is the property [page:Hexadecimal color], which can be passed in as a hexadecimal
-			string and is *0xffffff* (white) by default. [page:Color.set]( color ) is called internally.
+			例外是属性[page:Hexadecimal color]，它可以作为十六进制字符串传入，默认为0xffffff（白色）。[page:Color.set]Color.set ( color ) 在内部被调用。
 		</p>
 
-		<h2>Properties</h2>
-		<p>See the base [page:Material] class for common properties.</p>
+		<h2>属性(Properties)</h2>
+		<p>请参阅基础Material[page:Material]类以了解常见属性。</p>
 
 		<h3>[property:Texture alphaMap]</h3>
-		<p>The alpha map is a grayscale texture that controls the opacity across the surface
-			(black: fully transparent; white: fully opaque). Default is null.<br /><br />
+		<p>alpha 贴图是一种灰度纹理，可控制整个表面的不透明度（黑色：完全透明；白色：完全不透明）。默认为空。<br /><br />
 
-			Only the color of the texture is used, ignoring the alpha channel if one exists.
-			For RGB and RGBA textures, the [page:WebGLRenderer WebGL] renderer will use the
-			green channel when sampling this texture due to the extra bit of precision provided
-			for green in DXT-compressed and uncompressed RGB 565 formats. Luminance-only and
-			luminance/alpha textures will also still work as expected.
+			仅使用纹理的颜色，如果存在则忽略alpha通道。对于RGB和RGBA纹理，由于在DXT压缩和未压缩的RGB565格式中为绿色提供了额外的精度，[page:WebGLRenderer WebGL]渲染器将在对该纹理进行采样时使用绿色通道。仅亮度和亮度/alpha纹理也将按预期工作。
 		</p>
 
 		<h3>[property:Texture aoMap]</h3>
-		<p>The red channel of this texture is used as the ambient occlusion map. Default is null.
-		The aoMap requires a second set of UVs.</p>
+		<p>该纹理的红色通道用作环境遮挡贴图。默认为空。aoMap需要第二组UV。</p>
 
 		<h3>[property:Float aoMapIntensity]</h3>
-		<p>Intensity of the ambient occlusion effect. Default is 1. Zero is no occlusion effect.</p>
+		<p>环境遮挡效果的强度。默认值为1。零表示没有遮挡效果。</p>
 
 		<h3>[property:Texture bumpMap]</h3>
 		<p>
-			The texture to create a bump map. The black and white values map to the perceived depth in relation to the lights.
-			Bump doesn't actually affect the geometry of the object, only the lighting. If a normal map is defined this will
-			be ignored.
+			创建凹凸贴图的纹理。黑色和白色值映射到与灯光相关的感知深度。凹凸实际上不会影响对象的几何形状，只会影响光照。如果定义了法线贴图，这将被忽略。
 		</p>
 
 		<h3>[property:Float bumpScale]</h3>
-		<p>How much the bump map affects the material. Typical ranges are 0-1. Default is 1.</p>
+		<p>凹凸贴图对材质的影响程度。典型范围是0-1。默认值为1。</p>
 
 
 		<h3>[property:Color color]</h3>
-		<p>[page:Color] of the material, by default set to white (0xffffff).</p>
+		<p>材质的颜色[page:Color]，默认设置为白色 (0xffffff)。</p>
 
 		<h3>[property:Texture displacementMap]</h3>
 		<p>
-			The displacement map affects the position of the mesh's vertices. Unlike other maps
-			which only affect the light and shade of the material the displaced vertices can cast shadows,
-			block other objects, and otherwise act as real geometry. The displacement texture is
-			an image where the value of each pixel (white being the highest) is mapped against,
-			and repositions, the vertices of the mesh.
+			置换贴图影响网格顶点的位置。
+			与其他仅影响材质明暗的贴图不同，置换的顶点可以投射阴影、阻挡其他对象，并以其他方式充当真实几何体。
+			位移纹理是一个图像，其中每个像素的值（白色为最高）映射到网格的顶点并重新定位。
 		</p>
 
 		<h3>[property:Float displacementScale]</h3>
 		<p>
-			How much the displacement map affects the mesh (where black is no displacement,
-			and white is maximum displacement). Without a displacement map set, this value is not applied.
-			 Default is 1.
+			置换贴图对网格的影响程度（黑色表示无置换，白色表示最大置换）。如果没有置换贴图集，则不会应用此值。默认值为1。
 		</p>
 
 		<h3>[property:Float displacementBias]</h3>
 		<p>
-			The offset of the displacement map's values on the mesh's vertices.
-			Without a displacement map set, this value is not applied. Default is 0.
+			置换贴图值在网格顶点上的偏移量。如果没有置换贴图集，则不会应用此值。默认为0。
 		</p>
 
 		<h3>[property:Color emissive]</h3>
 		<p>
-		Emissive (light) color of the material, essentially a solid color unaffected by other lighting.
-		Default is black.
+			材料的发射（光）颜色，本质上是一种不受其他光照影响的纯色。默认为黑色。
 		</p>
 
 		<h3>[property:Texture emissiveMap]</h3>
 		<p>
-		Set emissive (glow) map. Default is null. The emissive map color is modulated by
-		the emissive color and the emissive intensity. If you have an emissive map, be sure to
-		set the emissive color to something other than black.
+			设置发射（发光）贴图。默认为空。发射贴图颜色由发射颜色和发射强度调制。如果您有自发光贴图，请务必将自发光颜色设置为黑色以外的颜色。
 		</p>
 
 		<h3>[property:Float emissiveIntensity]</h3>
-		<p>Intensity of the emissive light. Modulates the emissive color. Default is 1.</p>
+		<p>发射光的强度。调制发光颜色。默认值为1。</p>
 
 		<h3>[property:Boolean fog]</h3>
 		<p>材质是否受雾影响。默认为*true*。</p>
 
 		<h3>[property:Texture gradientMap]</h3>
-		<p>Gradient map for toon shading. It's required to set [page:Texture.minFilter] and [page:Texture.magFilter] to
-			[page:Textures THREE.NearestFilter] when using this type of texture. Default is *null*.</p>
+		<p>卡通着色的渐变贴图。使用此类纹理时，需要将Texture.minFilter[page:Texture.minFilter]和Texture.magFilter[page:Texture.magFilter]设置为[page:Textures THREE.NearestFilter]。默认为空。
+			</p>
 
 		<h3>[property:Texture lightMap]</h3>
-		<p>The light map. Default is null. The lightMap requires a second set of UVs.</p>
+		<p>光照贴图。默认为空。lightMap需要第二组UV。</p>
 
 		<h3>[property:Float lightMapIntensity]</h3>
-		<p>Intensity of the baked light. Default is 1.</p>
+		<p>烘焙光的强度。默认值为1。</p>
 
 		<h3>[property:Texture map]</h3>
 		<p>
-			The color map. May optionally include an alpha channel, typically combined with
-			[page:Material.transparent .transparent] or [page:Material.alphaTest .alphaTest]. Default is null.
-			The texture map color is modulated by the diffuse [page:.color].
+			彩色地图。可以选择包含一个alpha通道，通常与[page:Material.transparent .transparent]或[page:Material.alphaTest .alphaTest]结合使用。默认为空。纹理贴图颜色由漫反射.color[page:.color]调制。
 		</p>
 
 		<h3>[property:Texture normalMap]</h3>
 		<p>
-			The texture to create a normal map. The RGB values affect the surface normal for each pixel fragment and change
-			the way the color is lit. Normal maps do not change the actual shape of the surface, only the lighting.
-			In case the material has a normal map authored using the left handed convention, the y component of normalScale
-			should be negated to compensate for the different handedness.
+			创建法线贴图的纹理。RGB值影响每个像素片段的表面法线并改变颜色的点亮方式。法线贴图不会改变表面的实际形状，只会改变光照。如果材质具有使用左手惯例创作的法线贴图，则应取反normalScale的y分量以补偿不同的手性。
 		</p>
 
 		<h3>[property:Integer normalMapType]</h3>
 		<p>
-			The type of normal map.<br /><br />
+			法线贴图的类型。<br /><br />
 
-			Options are [page:constant THREE.TangentSpaceNormalMap] (default), and [page:constant THREE.ObjectSpaceNormalMap].
+			选项为[page:constant THREE.TangentSpaceNormalMap]（默认）和[page:constant THREE.ObjectSpaceNormalMap]。
 		</p>
 
 		<h3>[property:Vector2 normalScale]</h3>
 		<p>
-			How much the normal map affects the material. Typical ranges are 0-1.
-			Default is a [page:Vector2] set to (1,1).
+			法线贴图对材质的影响有多大。典型范围是0-1。默认是设置为(1,1)的二维向量[page:Vector2]。
 		</p>
 
 		<h3>[property:Boolean wireframe]</h3>
-		<p>Render geometry as wireframe. Default is *false* (i.e. render as flat polygons).</p>
+		<p>将几何渲染为线框。默认为false（即呈现为平面多边形）。</p>
 
 		<h3>[property:String wireframeLinecap]</h3>
 		<p>
-			Define appearance of line ends. Possible values are "butt", "round" and "square". Default is 'round'.<br /><br />
+			定义线端的外观。可能的值为“butt”、“round”和“square”。默认为“圆形”。<br /><br />
 
-			This corresponds to the [link:https://developer.mozilla.org/en/docs/Web/API/CanvasRenderingContext2D/lineCap 2D Canvas lineCap]
-			property and it is ignored by the [page:WebGLRenderer WebGL] renderer.
+			这对应于[link:https://developer.mozilla.org/en/docs/Web/API/CanvasRenderingContext2D/lineCap 2DCanvas]的lineCap属性，它会被[page:WebGLRenderer WebGL]渲染器忽略。
 		</p>
 
 		<h3>[property:String wireframeLinejoin]</h3>
 		<p>
-			Define appearance of line joints. Possible values are "round", "bevel" and "miter". Default is 'round'.<br /><br />
+			定义线接头的外观。可能的值是“round”、“bevel”和“miter”。默认为“圆形”。<br /><br />
 
-			This corresponds to the [link:https://developer.mozilla.org/en/docs/Web/API/CanvasRenderingContext2D/lineJoin 2D Canvas lineJoin]
-			property and it is ignored by the [page:WebGLRenderer WebGL] renderer.
+			这对应于[link:https://developer.mozilla.org/en/docs/Web/API/CanvasRenderingContext2D/lineCap 2DCanvas]的lineCap属性，它会被[page:WebGLRenderer WebGL]渲染器忽略。
 		</p>
 
 		<h3>[property:Float wireframeLinewidth]</h3>
-		<p>Controls wireframe thickness. Default is 1.<br /><br />
+		<p>控制线框厚度。默认值为1。<br /><br />
 
-		Due to limitations of the [link:https://www.khronos.org/registry/OpenGL/specs/gl/glspec46.core.pdf OpenGL Core Profile]
-		with the [page:WebGLRenderer WebGL] renderer on most platforms linewidth will
-		always be 1 regardless of the set value.
+			由于[link:https://www.khronos.org/registry/OpenGL/specs/gl/glspec46.core.pdf OpenGL Core Profile]与[page:WebGLRenderer WebGL]渲染器在大多数平台上的限制，无论设置值如何，线宽始终为1。
 		</p>
 
-		<h2>Methods</h2>
-		<p>See the base [page:Material] class for common methods.</p>
+		<h2>方法(Methods)</h2>
+		<p>有关常用方法，请参见Material[page:Material]类。</p>
 
-		<h2>Source</h2>
+		<h2>源码(Source)</h2>
 
 		<p>
 			[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]


### PR DESCRIPTION
update docs/api/zh/materials/MeshToonMaterial.html translation

**Description**

In the original version, the Chinese translation of MeshToonMaterial documents did not work properly. This update aims to fix this error

<!-- Remove the line below if is not relevant -->
