### PR TITLE
WebGLRenderer: Add `debug.onShaderError()`.

### DIFF
--- a/docs/api/en/renderers/WebGLRenderer.html
+++ b/docs/api/en/renderers/WebGLRenderer.html
@@ -97,11 +97,15 @@
 		<h3>[property:Object debug]</h3>
 		<p>
 		- [page:Boolean checkShaderErrors]:
-		  If it is true, defines whether material shader programs are checked
+			If it is true, defines whether material shader programs are checked
 			for errors during compilation and linkage process. It may be useful to disable this check in production for performance gain.
 			It is strongly recommended to keep these checks enabled during development.
 			If the shader does not compile and link - it will not work and associated material will not render.
-			Default is `true`.
+			Default is `true`.</br>
+		- [page:Function onShaderError]( gl, program, glVertexShader, glFragmentShader ):
+			A callback function that can be used for custom error reporting. The callback receives the WebGL context, an instance of WebGLProgram as well 
+			two instances of WebGLShader representing the vertex and fragment shader. Assigning a custom function disables the default error reporting. 
+			Default is `null`.
 		</p>
 
 		<h3>[property:Object capabilities]</h3>

--- a/docs/api/it/renderers/WebGLRenderer.html
+++ b/docs/api/it/renderers/WebGLRenderer.html
@@ -103,7 +103,11 @@
 			Può essere utile disabilitare questo controllo in produzione per aumentare le prestazioni.
 			È fortemente raccomandato mantenere questi controlli attivi durante lo sviluppo.
 			Se lo shader non si compila e non si collega - non funzionerà e il materiale associato non verrà visualizzato.
-			Il valore predefinito è `true`.
+			Il valore predefinito è `true`.</br>
+		- [page:Function onShaderError]( gl, program, glVertexShader, glFragmentShader ):
+			A callback function that can be used for custom error reporting. The callback receives the WebGL context, an instance of WebGLProgram as well 
+			two instances of WebGLShader representing the vertex and fragment shader. Assigning a custom function disables the default error reporting. 
+			Default is `null`.
 		</p>
 
 		<h3>[property:Object capabilities]</h3>

--- a/docs/api/zh/renderers/WebGLRenderer.html
+++ b/docs/api/zh/renderers/WebGLRenderer.html
@@ -89,7 +89,11 @@
 			编译和链接过程中的错误。 禁用此检查生产以获得性能增益可能很有用。
 			强烈建议在开发期间保持启用这些检查。
 			如果着色器没有编译和链接 - 它将无法工作，并且相关材料将不会呈现。
-			默认是*true*
+			默认是*true*</br>
+		- [page:Function onShaderError]( gl, program, glVertexShader, glFragmentShader ):
+			A callback function that can be used for custom error reporting. The callback receives the WebGL context, an instance of WebGLProgram as well 
+			two instances of WebGLShader representing the vertex and fragment shader. Assigning a custom function disables the default error reporting. 
+			Default is `null`.
 		</p>
 
 		<h3>[property:Object capabilities]</h3>

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -104,7 +104,12 @@ class WebGLRenderer {
 			 * Enables error checking and reporting when shader programs are being compiled
 			 * @type {boolean}
 			 */
-			checkShaderErrors: true
+			checkShaderErrors: true,
+			/**
+			 * Callback for custom error reporting.
+			 * @type {?Function}
+			 */
+			onShaderError: null
 		};
 
 		// clearing

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -783,16 +783,26 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 
 			runnable = false;
 
-			const vertexErrors = getShaderErrors( gl, glVertexShader, 'vertex' );
-			const fragmentErrors = getShaderErrors( gl, glFragmentShader, 'fragment' );
+			if ( typeof renderer.debug.onShaderError === 'function' ) {
 
-			console.error(
-				'THREE.WebGLProgram: Shader Error ' + gl.getError() + ' - ' +
-				'VALIDATE_STATUS ' + gl.getProgramParameter( program, gl.VALIDATE_STATUS ) + '\n\n' +
-				'Program Info Log: ' + programLog + '\n' +
-				vertexErrors + '\n' +
-				fragmentErrors
-			);
+				renderer.debug.onShaderError( gl, program, glVertexShader, glFragmentShader );
+
+			} else {
+
+				// default error reporting
+
+				const vertexErrors = getShaderErrors( gl, glVertexShader, 'vertex' );
+				const fragmentErrors = getShaderErrors( gl, glFragmentShader, 'fragment' );
+
+				console.error(
+					'THREE.WebGLProgram: Shader Error ' + gl.getError() + ' - ' +
+					'VALIDATE_STATUS ' + gl.getProgramParameter( program, gl.VALIDATE_STATUS ) + '\n\n' +
+					'Program Info Log: ' + programLog + '\n' +
+					vertexErrors + '\n' +
+					fragmentErrors
+				);
+
+			}
 
 		} else if ( programLog !== '' ) {
 


### PR DESCRIPTION
Related issue: #25092

**Description**

This PR is an alternative to #25092. It introduces a new callback  `WebGLRenderer.debug.onShaderError()` that can be used to implement a custom error reporting when shader compilation fails.

To make the callback more generic, it receives raw WebGL entities so the processing and formatting of errors is up to the application.
