### PR TITLE
GLTFLoader: Prevents set data uri in texture.name.

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2992,7 +2992,7 @@ class GLTFParser {
 
 			if ( texture.name === '' && sourceDef.uri && sourceDef.uri.startsWith( 'data:image/' ) === false ) {
 
-				texture.name = sourceDef.uri;
+				texture.name = sourceDef.uri || '';
 
 			}
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2990,9 +2990,9 @@ class GLTFParser {
 
 			texture.name = textureDef.name || sourceDef.name || '';
 
-			if ( texture.name === '' && sourceDef.uri && sourceDef.uri.startsWith( 'data:image/' ) === false ) {
+			if ( texture.name === '' && typeof sourceDef.uri === 'string' && sourceDef.uri.startsWith( 'data:image/' ) === false ) {
 
-				texture.name = sourceDef.uri || '';
+				texture.name = sourceDef.uri;
 
 			}
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2988,7 +2988,13 @@ class GLTFParser {
 
 			texture.flipY = false;
 
-			texture.name = textureDef.name || sourceDef.name || sourceDef.uri || '';
+			texture.name = textureDef.name || sourceDef.name || '';
+
+			if ( texture.name === '' && sourceDef.uri.length > 0 && sourceDef.uri.startsWith( 'data:image/' ) === false ) {
+
+				texture.name = sourceDef.uri;
+
+			}
 
 			const samplers = json.samplers || {};
 			const sampler = samplers[ textureDef.sampler ] || {};

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2990,7 +2990,7 @@ class GLTFParser {
 
 			texture.name = textureDef.name || sourceDef.name || '';
 
-			if ( texture.name === '' && sourceDef.uri.length > 0 && sourceDef.uri.startsWith( 'data:image/' ) === false ) {
+			if ( texture.name === '' && sourceDef.uri && sourceDef.uri.startsWith( 'data:image/' ) === false ) {
 
 				texture.name = sourceDef.uri;
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/25664#issuecomment-1467237351