### PR TITLE
Examples: Fix webgl_geometry_spline_editor.html

### DIFF
--- a/examples/webgl_geometry_spline_editor.html
+++ b/examples/webgl_geometry_spline_editor.html
@@ -368,7 +368,12 @@
 				onUpPosition.x = event.clientX;
 				onUpPosition.y = event.clientY;
 
-				if ( onDownPosition.distanceTo( onUpPosition ) === 0 ) transformControl.detach();
+				if ( onDownPosition.distanceTo( onUpPosition ) === 0 ) {
+					
+					transformControl.detach();
+					render();
+
+				}
 
 			}
 


### PR DESCRIPTION
Call render() after detach so that the tooltip disappears when clicking away from the selected helper point, as one would expect.

Possibly caused in #22616

**Description**

A point does not appear to be deselected by clicking away in [the example](https://threejs.org/examples/?q=spline#webgl_geometry_spline_editor). Resolved by adding call to render.