### PR TITLE
MeshDistanceMaterial: Remove light related properties.

### DIFF
--- a/docs/api/en/materials/MeshDistanceMaterial.html
+++ b/docs/api/en/materials/MeshDistanceMaterial.html
@@ -84,11 +84,6 @@
 			Without a displacement map set, this value is not applied. Default is 0.
 		</p>
 
-		<h3>[property:Float farDistance]</h3>
-		<p>
-			The far value of the point light's internal shadow camera.
-		</p>
-
 		<h3>[property:Boolean fog]</h3>
 		<p>Whether the material is affected by fog. Default is `false`.</p>
 
@@ -96,16 +91,6 @@
 		<p>
 			The color map. May optionally include an alpha channel, typically combined with
 			[page:Material.transparent .transparent] or [page:Material.alphaTest .alphaTest]. Default is null.
-		</p>
-
-		<h3>[property:Float nearDistance]</h3>
-		<p>
-			The near value of the point light's internal shadow camera.
-		</p>
-
-		<h3>[property:Vector3 referencePosition]</h3>
-		<p>
-			The position of the point light in world space.
 		</p>
 
 		<h2>Methods</h2>

--- a/docs/api/fr/materials/MeshDistanceMaterial.html
+++ b/docs/api/fr/materials/MeshDistanceMaterial.html
@@ -85,11 +85,6 @@
 			Sans ensemble de cartes de déplacement, cette valeur n'est pas appliquée. La valeur par défaut est 0.
 		</p>
 
-		<h3>[property:Float farDistance]</h3>
-		<p>
-			La valeur lointaine de la caméra d'ombre interne de la lumière ponctuelle.
-		</p>
-
 		<h3>[property:Boolean fog]</h3>
 		<p>Si le matériau est affecté par le brouillard (fog) La valeur par défaut est `false`.</p>
 
@@ -97,16 +92,6 @@
 		<p>
 			La carte des couleurs. Peut éventuellement inclure un canal alpha, généralement combiné avec
 			[page:Material.transparent .transparent] ou [page:Material.alphaTest .alphaTest]. La valeur par défaut est null.
-		</p>
-
-		<h3>[property:Float nearDistance]</h3>
-		<p>
-			La valeur proche de la caméra d'ombre interne de la lumière ponctuelle.
-		</p>
-
-		<h3>[property:Vector3 referencePosition]</h3>
-		<p>
-			La position du point lumineux dans le repère monde.
 		</p>
 
 		<h2>Méthodes</h2>

--- a/docs/api/it/materials/MeshDistanceMaterial.html
+++ b/docs/api/it/materials/MeshDistanceMaterial.html
@@ -87,11 +87,6 @@
 			non viene applicato. Il valore predefinito è 0.
 		</p>
 
-		<h3>[property:Float farDistance]</h3>
-		<p>
-			Il valore far della telecamera d'ombra interna della luce puntiforme.
-		</p>
-
 		<h3>[property:Boolean fog]</h3>
 		<p>Indica se il materiale è influenzato dalla nebbia. Il valore predefinito è `false`.</p>
 
@@ -99,16 +94,6 @@
 		<p>
 			La mappa colore. Può includere facoltativamente un canale alfa, tipicamente combinato con 
 			[page:Material.transparent .transparent] o [page:Material.alphaTest .alphaTest]. Il valore predefinito è `null`.
-		</p>
-
-		<h3>[property:Float nearDistance]</h3>
-		<p>
-			Il valore near della telecamera d'obra interna della luce puntiforme.
-		</p>
-
-		<h3>[property:Vector3 referencePosition]</h3>
-		<p>
-			La posizione della luce puntiforme nello spazio world.
 		</p>
 
 		<h2>Metodi</h2>

--- a/docs/api/zh/materials/MeshDistanceMaterial.html
+++ b/docs/api/zh/materials/MeshDistanceMaterial.html
@@ -73,25 +73,10 @@
 		<p> 位移贴图在网格顶点上的偏移量。如果没有设置位移贴图，则不会应用此值。默认值为0。
 		</p>
 
-		<h3>[property:Float farDistance]</h3>
-		<p>
-			The far value of the point light's internal shadow camera.
-		</p>
-
 		<h3>[property:Texture map]</h3>
 		<p>
 			颜色贴图。可以选择包括一个alpha通道，通常与[page:Material.transparent .transparent]
 			或[page:Material.alphaTest .alphaTest]。默认为null。
-		</p>
-
-		<h3>[property:Float nearDistance]</h3>
-		<p>
-			The near value of the point light's internal shadow camera.
-		</p>
-
-		<h3>[property:Vector3 referencePosition]</h3>
-		<p>
-			The position of the point light in world space.
 		</p>
 
 		<h2>方法(Methods)</h2>

--- a/src/materials/MeshDistanceMaterial.js
+++ b/src/materials/MeshDistanceMaterial.js
@@ -1,5 +1,4 @@
 import { Material } from './Material.js';
-import { Vector3 } from '../math/Vector3.js';
 
 class MeshDistanceMaterial extends Material {
 
@@ -10,10 +9,6 @@ class MeshDistanceMaterial extends Material {
 		this.isMeshDistanceMaterial = true;
 
 		this.type = 'MeshDistanceMaterial';
-
-		this.referencePosition = new Vector3();
-		this.nearDistance = 1;
-		this.farDistance = 1000;
 
 		this.map = null;
 
@@ -30,10 +25,6 @@ class MeshDistanceMaterial extends Material {
 	copy( source ) {
 
 		super.copy( source );
-
-		this.referencePosition.copy( source.referencePosition );
-		this.nearDistance = source.nearDistance;
-		this.farDistance = source.farDistance;
 
 		this.map = source.map;
 

--- a/src/renderers/webgl/WebGLMaterials.js
+++ b/src/renderers/webgl/WebGLMaterials.js
@@ -662,9 +662,11 @@ function WebGLMaterials( renderer, properties ) {
 
 	function refreshUniformsDistance( uniforms, material ) {
 
-		uniforms.referencePosition.value.copy( material.referencePosition );
-		uniforms.nearDistance.value = material.nearDistance;
-		uniforms.farDistance.value = material.farDistance;
+		const light = properties.get( material ).light;
+
+		uniforms.referencePosition.value.setFromMatrixPosition( light.matrixWorld );
+		uniforms.nearDistance.value = light.shadow.camera.near;
+		uniforms.farDistance.value = light.shadow.camera.far;
 
 	}
 

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -226,7 +226,7 @@ function WebGLShadowMap( _renderer, _objects, _capabilities ) {
 
 	}
 
-	function getDepthMaterial( object, material, light, shadowCameraNear, shadowCameraFar, type ) {
+	function getDepthMaterial( object, material, light, type ) {
 
 		let result = null;
 
@@ -304,9 +304,8 @@ function WebGLShadowMap( _renderer, _objects, _capabilities ) {
 
 		if ( light.isPointLight === true && result.isMeshDistanceMaterial === true ) {
 
-			result.referencePosition.setFromMatrixPosition( light.matrixWorld );
-			result.nearDistance = shadowCameraNear;
-			result.farDistance = shadowCameraFar;
+			const materialProperties = _renderer.properties.get( result );
+			materialProperties.light = light;
 
 		}
 
@@ -340,7 +339,7 @@ function WebGLShadowMap( _renderer, _objects, _capabilities ) {
 
 						if ( groupMaterial && groupMaterial.visible ) {
 
-							const depthMaterial = getDepthMaterial( object, groupMaterial, light, shadowCamera.near, shadowCamera.far, type );
+							const depthMaterial = getDepthMaterial( object, groupMaterial, light, type );
 
 							_renderer.renderBufferDirect( shadowCamera, null, geometry, depthMaterial, object, group );
 
@@ -350,7 +349,7 @@ function WebGLShadowMap( _renderer, _objects, _capabilities ) {
 
 				} else if ( material.visible ) {
 
-					const depthMaterial = getDepthMaterial( object, material, light, shadowCamera.near, shadowCamera.far, type );
+					const depthMaterial = getDepthMaterial( object, material, light, type );
 
 					_renderer.renderBufferDirect( shadowCamera, null, geometry, depthMaterial, object, null );
 

--- a/test/unit/src/materials/MeshDistanceMaterial.tests.js
+++ b/test/unit/src/materials/MeshDistanceMaterial.tests.js
@@ -38,24 +38,6 @@ export default QUnit.module( 'Materials', () => {
 
 		} );
 
-		QUnit.todo( 'referencePosition', ( assert ) => {
-
-			assert.ok( false, 'everything\'s gonna be alright' );
-
-		} );
-
-		QUnit.todo( 'nearDistance', ( assert ) => {
-
-			assert.ok( false, 'everything\'s gonna be alright' );
-
-		} );
-
-		QUnit.todo( 'farDistance', ( assert ) => {
-
-			assert.ok( false, 'everything\'s gonna be alright' );
-
-		} );
-
 		QUnit.todo( 'map', ( assert ) => {
 
 			assert.ok( false, 'everything\'s gonna be alright' );


### PR DESCRIPTION
Related issue: #25096

**Description**

This PR removes light related properties from `MeshDistanceMaterial`. 

The near and far values of a point light's shadow camera as well as its position in world space  are required in `refreshUniformsDistance()` so they were previously stored in the material for convenience. However, it's confusing to store them in the material since they are not supposed to set by the user.

The code in `WebGLShadowMap` and `WebGLMaterials` has slightly been refactored. The point light itself is now stored in an internal material properties object (similar to environment maps) and then used when setting up the uniforms.   