### PR TITLE
Editor: Fix broken material tab when `Texture.image` is null.

### DIFF
--- a/editor/js/libs/ui.three.js
+++ b/editor/js/libs/ui.three.js
@@ -146,7 +146,7 @@ class UITexture extends UISpan {
 
 			const image = texture.image;
 
-			if ( image !== undefined && image.width > 0 ) {
+			if ( image !== undefined && image !== null && image.width > 0 ) {
 
 				canvas.title = texture.sourceFile;
 				const scale = canvas.width / image.width;


### PR DESCRIPTION
Fixed #25699.

**Description**

Ensures the material tab in the editor does not break when textures with `null` as their image value is loaded.
