### PR TITLE
added minified versions of .module and .cjs, reduced build size by 50%

### DIFF
--- a/utils/build/rollup.config.js
+++ b/utils/build/rollup.config.js
@@ -298,6 +298,22 @@ const builds = [
 		input: 'src/Three.js',
 		plugins: [
 			addons(),
+			glconstants(),
+			glsl(),
+			terser(),
+			header()
+		],
+		output: [
+			{
+				format: 'esm',
+				file: 'build/three.module.min.js'
+			}
+		]
+	},
+	{
+		input: 'src/Three.js',
+		plugins: [
+			addons(),
 			glsl(),
 			header()
 		],
@@ -306,6 +322,24 @@ const builds = [
 				format: 'cjs',
 				name: 'THREE',
 				file: 'build/three.cjs',
+				indent: '\t'
+			}
+		]
+	},
+
+	{
+		input: 'src/Three.js',
+		plugins: [
+			addons(),
+			glsl(),
+			terser(),
+			header()
+		],
+		output: [
+			{
+				format: 'cjs',
+				name: 'THREE',
+				file: 'build/three.min.cjs',
 				indent: '\t'
 			}
 		]


### PR DESCRIPTION
Added `three.module.min.js` and `three.min.cjs` for users serving over import-maps (no tree-shaking). 

| Type | Regular Size | Minified Size |
|------|--------------|---------------|
| esm  | 1.13mb       | 600kb         |
| cjs  | 1.15mb       | 607kb         |

This can slightly improve load times in low-network areas, and is useful for production code.