### PR TITLE
LineBasicMaterial: Add support for `map`.

### DIFF
--- a/docs/api/en/materials/LineBasicMaterial.html
+++ b/docs/api/en/materials/LineBasicMaterial.html
@@ -90,6 +90,11 @@
 			property and it is ignored by the [page:WebGLRenderer WebGL] renderer.
 		</p>
 
+		<h3>[property:Texture map]</h3>
+		<p>
+			Sets the color of the lines using data from a [page:Texture].
+		</p>
+
 		<h2>Methods</h2>
 		<p>See the base [page:Material] class for common methods.</p>
 

--- a/docs/api/fr/materials/LineBasicMaterial.html
+++ b/docs/api/fr/materials/LineBasicMaterial.html
@@ -90,6 +90,11 @@
 			et est ignorée par le moteur de rendu [page:WebGLRenderer WebGL].
 		</p>
 
+		<h3>[property:Texture map]</h3>
+		<p>
+			Sets the color of the lines using data from a [page:Texture].
+		</p>
+
 		<h2>Méthodes</h2>
 		<p>Voir la classe [page:Material] pour les méthodes communes.</p>
 

--- a/docs/api/it/materials/LineBasicMaterial.html
+++ b/docs/api/it/materials/LineBasicMaterial.html
@@ -90,6 +90,11 @@
 			e viene ignorata dal renderer [page:WebGLRenderer WebGL].
 		</p>
 
+		<h3>[property:Texture map]</h3>
+		<p>
+			Sets the color of the lines using data from a [page:Texture].
+		</p>
+
 		<h2>Metodi</h2>
 		<p>Vedi la classe base [page:Material] per i metodi comuni.</p>
 

--- a/docs/api/zh/materials/LineBasicMaterial.html
+++ b/docs/api/zh/materials/LineBasicMaterial.html
@@ -79,6 +79,11 @@
 			并且会被[page:WebGLRenderer WebGL]渲染器忽略。
 		</p>
 
+		<h3>[property:Texture map]</h3>
+		<p>
+			Sets the color of the lines using data from a [page:Texture].
+		</p>
+
 		<h2>方法(Methods)</h2>
 		<p>共有方法请参见其基类[page:Material]。</p>
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -3206,6 +3206,7 @@ class GLTFParser {
 				lineMaterial = new LineBasicMaterial();
 				Material.prototype.copy.call( lineMaterial, material );
 				lineMaterial.color.copy( material.color );
+				lineMaterial.map = material.map;
 
 				this.cache.add( cacheKey, lineMaterial );
 

--- a/src/materials/LineBasicMaterial.js
+++ b/src/materials/LineBasicMaterial.js
@@ -13,6 +13,8 @@ class LineBasicMaterial extends Material {
 
 		this.color = new Color( 0xffffff );
 
+		this.map = null;
+
 		this.linewidth = 1;
 		this.linecap = 'round';
 		this.linejoin = 'round';
@@ -29,6 +31,8 @@ class LineBasicMaterial extends Material {
 		super.copy( source );
 
 		this.color.copy( source.color );
+
+		this.map = source.map;
 
 		this.linewidth = source.linewidth;
 		this.linecap = source.linecap;

--- a/src/renderers/shaders/ShaderLib/linedashed.glsl.js
+++ b/src/renderers/shaders/ShaderLib/linedashed.glsl.js
@@ -5,6 +5,7 @@ attribute float lineDistance;
 varying float vLineDistance;
 
 #include <common>
+#include <uv_pars_vertex>
 #include <color_pars_vertex>
 #include <fog_pars_vertex>
 #include <morphtarget_pars_vertex>
@@ -15,6 +16,7 @@ void main() {
 
 	vLineDistance = scale * lineDistance;
 
+	#include <uv_vertex>
 	#include <color_vertex>
 	#include <morphcolor_vertex>
 	#include <begin_vertex>
@@ -38,6 +40,8 @@ varying float vLineDistance;
 
 #include <common>
 #include <color_pars_fragment>
+#include <uv_pars_fragment>
+#include <map_pars_fragment>
 #include <fog_pars_fragment>
 #include <logdepthbuf_pars_fragment>
 #include <clipping_planes_pars_fragment>
@@ -56,6 +60,7 @@ void main() {
 	vec4 diffuseColor = vec4( diffuse, opacity );
 
 	#include <logdepthbuf_fragment>
+	#include <map_fragment>
 	#include <color_fragment>
 
 	outgoingLight = diffuseColor.rgb; // simple shader

--- a/src/renderers/webgl/WebGLMaterials.js
+++ b/src/renderers/webgl/WebGLMaterials.js
@@ -367,6 +367,20 @@ function WebGLMaterials( renderer, properties ) {
 		uniforms.diffuse.value.copy( material.color );
 		uniforms.opacity.value = material.opacity;
 
+		if ( material.map ) {
+
+			uniforms.map.value = material.map;
+
+			if ( material.map.matrixAutoUpdate === true ) {
+
+				material.map.updateMatrix();
+
+			}
+
+			uniforms.uvTransform.value.copy( material.map.matrix );
+
+		}
+
 	}
 
 	function refreshUniformsDash( uniforms, material ) {


### PR DESCRIPTION
Fixed #17511.

**Description**

This PR makes `LineBasicMaterial` more glTF conform so lines can sample color values from a texture. The `005.glb` asset from #17511 is now rendered as expected.

<img width="1701" alt="image" src="https://user-images.githubusercontent.com/12612165/227899018-e2aa66e9-9129-440d-b5cb-02a493ff38b2.png">
