### PR TITLE
FBXLoader: Allow usage of custom texture loader via `LoadingManager`.

### DIFF
--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -450,7 +450,17 @@ class FBXTreeParser {
 
 		} else {
 
-			texture = this.textureLoader.load( fileName );
+			let loader = this.manager.getHandler( fileName );
+
+			if ( loader === null ) {
+
+				loader = this.textureLoader;
+
+			}
+
+			loader.setPath( currentPath );
+			loader.setCrossOrigin( this.crossOrigin );
+			texture = loader.load( fileName );
 
 		}
 


### PR DESCRIPTION
## Problem
I defined a custom loader to load textures for the FBXLoader.
It sends an HTTP request with the Authorization request header to load textures.
However, The FBX Loader doesn't use the custom loader.

## Cause
The FBXLoader always uses the default TextureLoader to load textures except for .tga files.

## How to fix
Use loaders added to the loading manager.