### PR TITLE
WebGLRenderer: Improve WebGL 2 detection in iframes.

### DIFF
--- a/src/renderers/webgl/WebGLCapabilities.js
+++ b/src/renderers/webgl/WebGLCapabilities.js
@@ -52,7 +52,7 @@ function WebGLCapabilities( gl, extensions, parameters ) {
 
 	}
 
-const isWebGL2 = typeof WebGL2RenderingContext !== 'undefined' && gl.constructor.name === 'WebGL2RenderingContext';
+	const isWebGL2 = typeof WebGL2RenderingContext !== 'undefined' && gl.constructor.name === 'WebGL2RenderingContext';
 
 	let precision = parameters.precision !== undefined ? parameters.precision : 'highp';
 	const maxPrecision = getMaxPrecision( precision );

--- a/src/renderers/webgl/WebGLCapabilities.js
+++ b/src/renderers/webgl/WebGLCapabilities.js
@@ -52,7 +52,7 @@ function WebGLCapabilities( gl, extensions, parameters ) {
 
 	}
 
-	const isWebGL2 = typeof WebGL2RenderingContext !== 'undefined' && gl instanceof WebGL2RenderingContext;
+const isWebGL2 = typeof WebGL2RenderingContext !== 'undefined' && gl.constructor.name === 'WebGL2RenderingContext';
 
 	let precision = parameters.precision !== undefined ? parameters.precision : 'highp';
 	const maxPrecision = getMaxPrecision( precision );


### PR DESCRIPTION
Related issue: #25638

**Description**

This PR fixes an issue I encountered when using Three.js inside an iframe, specifically within the WordPress editor which has recently implemented an iframe wrapper. This was causing my 3D plugin (https://3ov.xyz) to error when using things like `meshStandardMaterial`

Prior discussion on what I found was documented here: https://github.com/mrdoob/three.js/issues/25638.

The problem occurs because the current `isWebGL2` check in Three.js relies on the `instanceof` operator, which can fail in complex iframe configs.

```javascript
const isWebGL2 = typeof WebGL2RenderingContext !== 'undefined' && gl instanceof WebGL2RenderingContext;
```
I found this causes Three.js to default to WebGL1 behaviors, even when WebGL2 is supported and available.

I think this change will be useful to others (pending testing that this logically matches prior logic.) The PR modifies the isWebGL2 check to use gl.constructor.name instead of the instanceof operator, which restores the render of my app:

```javascript
const isWebGL2 = typeof WebGL2RenderingContext !== 'undefined' && gl.constructor.name === 'WebGL2RenderingContext';`


