### PR TITLE
Cleanup: lint-addons and lint-examples

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,6 +33,7 @@
     "GPUShaderStage": "readonly",
     "GPUBufferUsage": "readonly",
     "GPUTextureUsage": "readonly",
+    "GPUTexture": "readonly",
     "GPUMapMode": "readonly",
     "QUnit": "readonly",
     "Ammo": "readonly",

--- a/examples/jsm/controls/TrackballControls.js
+++ b/examples/jsm/controls/TrackballControls.js
@@ -209,13 +209,13 @@ class TrackballControls extends EventDispatcher {
 
 				} else if ( scope.object.isOrthographicCamera ) {
 
-						scope.object.zoom = MathUtils.clamp( scope.object.zoom / factor, scope.minZoom, scope.maxZoom );
-						
-						if ( lastZoom !== scope.object.zoom ) {
+					scope.object.zoom = MathUtils.clamp( scope.object.zoom / factor, scope.minZoom, scope.maxZoom );
 
-							scope.object.updateProjectionMatrix();
-							
-						}
+					if ( lastZoom !== scope.object.zoom ) {
+
+						scope.object.updateProjectionMatrix();
+
+					}
 
 				} else {
 
@@ -236,11 +236,11 @@ class TrackballControls extends EventDispatcher {
 					} else if ( scope.object.isOrthographicCamera ) {
 
 						scope.object.zoom = MathUtils.clamp( scope.object.zoom / factor, scope.minZoom, scope.maxZoom );
-						
+
 						if ( lastZoom !== scope.object.zoom ) {
 
 							scope.object.updateProjectionMatrix();
-							
+
 						}
 
 					} else {

--- a/examples/jsm/loaders/DRACOLoader.js
+++ b/examples/jsm/loaders/DRACOLoader.js
@@ -82,7 +82,7 @@ class DRACOLoader extends Loader {
 
 	}
 
-	parse ( buffer, onLoad, onError ) {
+	parse( buffer, onLoad, onError ) {
 
 		this.decodeDracoFile( buffer, onLoad, null, null, SRGBColorSpace ).catch( onError );
 

--- a/examples/jsm/loaders/NRRDLoader.js
+++ b/examples/jsm/loaders/NRRDLoader.js
@@ -388,7 +388,7 @@ class NRRDLoader extends Loader {
 			const yIndex = headerObject.vectors.findIndex( vector => vector[ 1 ] !== 0 );
 			const zIndex = headerObject.vectors.findIndex( vector => vector[ 2 ] !== 0 );
 
-			let axisOrder = [];
+			const axisOrder = [];
 
 			if ( xIndex !== yIndex && xIndex !== zIndex && yIndex !== zIndex ) {
 

--- a/examples/jsm/renderers/CSS2DRenderer.js
+++ b/examples/jsm/renderers/CSS2DRenderer.js
@@ -130,7 +130,7 @@ class CSS2DRenderer {
 
 					const element = object.element;
 
-					element.style.transform = 'translate(' + ( - 100 * object.center.x ) + '%,' + ( - 100 * object.center.y ) + '%)' +  'translate(' + ( _vector.x * _widthHalf + _widthHalf ) + 'px,' + ( - _vector.y * _heightHalf + _heightHalf ) + 'px)';
+					element.style.transform = 'translate(' + ( - 100 * object.center.x ) + '%,' + ( - 100 * object.center.y ) + '%)' + 'translate(' + ( _vector.x * _widthHalf + _widthHalf ) + 'px,' + ( - _vector.y * _heightHalf + _heightHalf ) + 'px)';
 
 					if ( element.parentNode !== domElement ) {
 

--- a/examples/webgl_geometry_spline_editor.html
+++ b/examples/webgl_geometry_spline_editor.html
@@ -369,7 +369,7 @@
 				onUpPosition.y = event.clientY;
 
 				if ( onDownPosition.distanceTo( onUpPosition ) === 0 ) {
-					
+
 					transformControl.detach();
 					render();
 

--- a/examples/webgpu_skinning_points.html
+++ b/examples/webgpu_skinning_points.html
@@ -51,10 +51,10 @@
 				}
 
 				camera = new THREE.PerspectiveCamera( 50, window.innerWidth / window.innerHeight, 1, 1000 );
-				camera.position.set( 0, 300, -85 );
+				camera.position.set( 0, 300, - 85 );
 
 				scene = new THREE.Scene();
-				camera.lookAt( 0, 0, -85 );
+				camera.lookAt( 0, 0, - 85 );
 
 				clock = new THREE.Clock();
 


### PR DESCRIPTION
**Description**

I'm using npm run `lint-addons` to check for linting errors. For a while, that has produced ~14 errors across files, and some for `lint-examples`.

This PR brings the errors down to 2 (which I don't know how to fix).

Remaining linter errors:
```
three\examples\jsm\loaders\LDrawLoader.js
767:12  error  Parsing error: Unexpected token {
(which is just `} catch {`)

three\examples\jsm\nodes\Nodes.js
34:10  error  Parsing error: Unexpected token as
(which is just `export * as NodeUtils from './core/NodeUtils.js';`)
```