### PR TITLE
Docs: Improve WebGLRenderer page.

### DIFF
--- a/docs/api/en/renderers/WebGLRenderer.html
+++ b/docs/api/en/renderers/WebGLRenderer.html
@@ -214,10 +214,9 @@
 		<h3>[property:Boolean localClippingEnabled]</h3>
 		<p>Defines whether the renderer respects object-level clipping planes. Default is `false`.</p>
 
-		<h3>[property:Boolean physicallyCorrectLights]</h3>
+		<h3>[property:Boolean useLegacyLights]</h3>
 		<p>
-		Whether to use physically correct lighting mode. Default is `false`.
-		See the [example:webgl_lights_physical lights / physical] example.
+		Whether to use the legacy lighting mode or not. Default is `true`.
 		</p>
 
 		<h3>[property:Object properties]</h3>

--- a/docs/api/it/renderers/WebGLRenderer.html
+++ b/docs/api/it/renderers/WebGLRenderer.html
@@ -223,10 +223,9 @@
 		<h3>[property:Boolean localClippingEnabled]</h3>
 		<p>Definisce se il render rispetta i piani di taglio a livello di oggetto. Il valore predefinito è `false`.</p>
 
-		<h3>[property:Boolean physicallyCorrectLights]</h3>
+		<h3>[property:Boolean useLegacyLights]</h3>
 		<p>
-			Indica se utilizzare la modalità di illuminazione fisicamente corretta. Il valore predefinito è `false`.
-			Vedi l'esempio [example:webgl_lights_physical lights / physical].
+		Whether to use the legacy lighting mode or not. Il valore predefinito è `true`.
 		</p>
 
 		<h3>[property:Object properties]</h3>

--- a/docs/api/zh/renderers/WebGLRenderer.html
+++ b/docs/api/zh/renderers/WebGLRenderer.html
@@ -192,10 +192,9 @@
 		<h3>[property:Boolean localClippingEnabled]</h3>
 		<p>定义渲染器是否考虑对象级剪切平面。 默认为*false*.</p>
 
-		<h3>[property:Boolean physicallyCorrectLights]</h3>
+		<h3>[property:Boolean useLegacyLights]</h3>
 		<p>
-		是否使用物理上正确的光照模式。 默认是*false*。
-		示例：[example:webgl_lights_physical lights / physical]
+		Whether to use the legacy lighting mode or not. 默认是*true*。
 		</p>
 
 		<h3>[property:Object properties]</h3>


### PR DESCRIPTION
Fixed #25744.

**Description**

Adds the missing documentation for `WebGLRenderer.useLegacyLights`.
