### PR TITLE
Revert "Use a custom loader to load textures in FBXLoader (#25730)"

### DIFF
--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -450,17 +450,7 @@ class FBXTreeParser {
 
 		} else {
 
-			let loader = this.manager.getHandler( fileName );
-
-			if ( loader === null ) {
-
-				loader = this.textureLoader;
-
-			}
-
-			loader.setPath( currentPath );
-			loader.setCrossOrigin( this.crossOrigin );
-			texture = loader.load( fileName );
+			texture = this.textureLoader.load( fileName );
 
 		}
 


### PR DESCRIPTION
This reverts commit f327b7a0f7aefafe23068b3987d3787dff7248d9.

Related issue: https://discourse.threejs.org/t/three-r151-fbxloader-failing-to-load-embedded-textures/49855
**Description**

#25730 introduces a regression (it does not handle blobs correctly anymore).
