### PR TITLE
Flow.js: Remove unnecessary constructor arguments.

### DIFF
--- a/playground/libs/flow.module.js
+++ b/playground/libs/flow.module.js
@@ -3074,7 +3074,7 @@ class ContextMenu extends Menu {
 
 	constructor( target = null ) {
 
-		super( 'context', target );
+		super( 'context' );
 
 		this.events.context = [];
 
@@ -3264,9 +3264,9 @@ class ContextMenu extends Menu {
 
 class CircleMenu extends Menu {
 
-	constructor( target = null ) {
+	constructor() {
 
-		super( 'circle', target );
+		super( 'circle' );
 
 	}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/25500#issuecomment-1491861583

**Description**

Remove unnecessary constructor arguments.
