### PR TITLE
Examples: Fix a few typos.

### DIFF
--- a/examples/jsm/loaders/ColladaLoader.js
+++ b/examples/jsm/loaders/ColladaLoader.js
@@ -962,7 +962,7 @@ class ColladaLoader extends Loader {
 
 			let i, j, l;
 
-			// procces skin data for each vertex
+			// process skin data for each vertex
 
 			for ( i = 0, l = vcount.length; i < l; i ++ ) {
 

--- a/examples/jsm/loaders/SVGLoader.js
+++ b/examples/jsm/loaders/SVGLoader.js
@@ -2384,7 +2384,7 @@ class SVGLoader extends Loader {
 
 	static pointsToStroke( points, style, arcDivisions, minDistance ) {
 
-		// Generates a stroke with some witdh around the given path.
+		// Generates a stroke with some width around the given path.
 		// The path can be open or closed (last point equals to first point)
 		// Param points: Array of Vector2D (the path). Minimum 2 points.
 		// Param style: Object with SVG properties as returned by SVGLoader.getStrokeStyle(), or SVGLoader.parse() in the path.userData.style object


### PR DESCRIPTION
There are small typos in:
- examples/jsm/loaders/ColladaLoader.js
- examples/jsm/loaders/SVGLoader.js

Fixes:
- Should read `width` rather than `witdh`.
- Should read `process` rather than `procces`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md