### PR TITLE
Fix the import in the WebGL compatibility documentation

### DIFF
--- a/docs/manual/en/introduction/WebGL-compatibility-check.html
+++ b/docs/manual/en/introduction/WebGL-compatibility-check.html
@@ -15,7 +15,7 @@
 		</p>
 
 		<code>
-		import { WebGL } from 'three/addons/capabilities/WebGL.js';
+		import WebGL from 'three/addons/capabilities/WebGL.js';
 
 		if ( WebGL.isWebGLAvailable() ) {
 


### PR DESCRIPTION
Fix #25760

**Description**

The import was broken in the WebGL compatibility page due to default export in the WebGL.js file, so I changed to the correct import (see the issue for more details)
