### PR TITLE
SkeletonUtils: Simplify module.

### DIFF
--- a/docs/examples/en/utils/SkeletonUtils.html
+++ b/docs/examples/en/utils/SkeletonUtils.html
@@ -34,30 +34,6 @@
 			reference.
 		</p>
 
-		<h3>[method:Object findBoneTrackData]( [param:String name], [param:Array tracks] )</h3>
-		<p></p>
-
-		<h3>[method:Bone getBoneByName]( [param:String name], [param:Skeleton skeleton] )</h3>
-		<p></p>
-
-		<h3>[method:Array getBones]( [param:Skeleton skeleton] )</h3>
-		<p></p>
-
-		<h3>[method:Array getEqualsBonesNames]( [param:Skeleton skeleton], [param:Skeleton targetSkeleton] )</h3>
-		<p></p>
-
-		<h3>[method:SkeletonHelper getHelperFromSkeleton]( [param:Skeleton skeleton] )</h3>
-		<p></p>
-
-		<h3>[method:Bone getNearestBone]( [param:Bone bone], [param:Array names] )</h3>
-		<p></p>
-
-		<h3>[method:Object getSkeletonOffsets]( [param:SkeletonHelper target], [param:SkeletonHelper source], [param:Object options] )</h3>
-		<p></p>
-
-		<h3>[method:this renameBones]( [param:Skeleton skeleton], [param:Array names] )</h3>
-		<p></p>
-
 		<h3>[method:undefined retarget]( [param:SkeletonHelper target], [param:SkeletonHelper source], [param:Object options] )</h3>
 		<p></p>
 

--- a/docs/examples/zh/utils/SkeletonUtils.html
+++ b/docs/examples/zh/utils/SkeletonUtils.html
@@ -29,30 +29,6 @@
 		克隆给定对象及其后代，确保任何 [page:SkinnedMesh] 实例都与其骨骼正确关联。同时，骨骼也会被克隆，且必须是传递给此方法的物体的后代。而其他数据，如几何形状和材料，是通过引用来实现重复使用的。
 		</p>
 
-		<h3>[method:Object findBoneTrackData]( [param:String name], [param:Array tracks] )</h3>
-		<p></p>
-
-		<h3>[method:Bone getBoneByName]( [param:String name], [param:Skeleton skeleton] )</h3>
-		<p></p>
-
-		<h3>[method:Array getBones]( [param:Skeleton skeleton] )</h3>
-		<p></p>
-
-		<h3>[method:Array getEqualsBonesNames]( [param:Skeleton skeleton], [param:Skeleton targetSkeleton] )</h3>
-		<p></p>
-
-		<h3>[method:SkeletonHelper getHelperFromSkeleton]( [param:Skeleton skeleton] )</h3>
-		<p></p>
-
-		<h3>[method:Bone getNearestBone]( [param:Bone bone], [param:Array names] )</h3>
-		<p></p>
-
-		<h3>[method:Object getSkeletonOffsets]( [param:SkeletonHelper target], [param:SkeletonHelper source], [param:Object options] )</h3>
-		<p></p>
-
-		<h3>[method:this renameBones]( [param:Skeleton skeleton], [param:Array names] )</h3>
-		<p></p>
-
 		<h3>[method:undefined retarget]( [param:SkeletonHelper target], [param:SkeletonHelper source], [param:Object options] )</h3>
 		<p></p>
 


### PR DESCRIPTION
Related issue: #25751

**Description**

This PR simplifies `SkeletonUtils` by making certain functions internal (they are only relevant for the retargeting logic) and also removes some unused, very specialized helpers (`getEqualsBonesNames()`, `renameBones()`, `findBoneTrackData()`, `getSkeletonOffsets()`, `getNearestBone()`). 

`SkeletonUtils` only has three public functions now: `clone()`, `retarget()` and `retargetClip()`. We can use #25751 to design the last two more accessible with some example code. 