### PR TITLE
WebGPURenderer: Set labels of some WebGPU objects

### DIFF
--- a/examples/jsm/renderers/webgpu/WebGPUAttributes.js
+++ b/examples/jsm/renderers/webgpu/WebGPUAttributes.js
@@ -81,6 +81,7 @@ class WebGPUAttributes {
 		if ( gpuReadBuffer === null ) {
 
 			gpuReadBuffer = device.createBuffer( {
+				label: attribute.name,
 				size,
 				usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
 			} );
@@ -120,6 +121,7 @@ class WebGPUAttributes {
 		const size = array.byteLength + ( ( 4 - ( array.byteLength % 4 ) ) % 4 ); // ensure 4 byte alignment, see #20441
 
 		const buffer = this.device.createBuffer( {
+			label: attribute.name,
 			size,
 			usage: usage | GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
 			mappedAtCreation: true

--- a/examples/jsm/renderers/webgpu/WebGPUBindings.js
+++ b/examples/jsm/renderers/webgpu/WebGPUBindings.js
@@ -189,6 +189,7 @@ class WebGPUBindings {
 					const byteLength = binding.getByteLength();
 
 					binding.bufferGPU = this.device.createBuffer( {
+						label: 'bindingBuffer',
 						size: byteLength,
 						usage: binding.usage
 					} );

--- a/examples/jsm/renderers/webgpu/WebGPURenderer.js
+++ b/examples/jsm/renderers/webgpu/WebGPURenderer.js
@@ -940,6 +940,7 @@ class WebGPURenderer {
 			if ( this._colorBuffer ) this._colorBuffer.destroy();
 
 			this._colorBuffer = this._device.createTexture( {
+				label: 'colorBuffer',
 				size: {
 					width: Math.floor( this._width * this._pixelRatio ),
 					height: Math.floor( this._height * this._pixelRatio ),
@@ -963,6 +964,7 @@ class WebGPURenderer {
 			if ( this._depthBuffer ) this._depthBuffer.destroy();
 
 			this._depthBuffer = this._device.createTexture( {
+				label: 'depthBuffer',
 				size: {
 					width: Math.floor( this._width * this._pixelRatio ),
 					height: Math.floor( this._height * this._pixelRatio ),


### PR DESCRIPTION
**Description**

This PR sets labels of some WebGPU objects for helping debug.

[WebGPU allows to set label to WebGPU objects.](https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label)

The label can be used by the browser, OS, or other tools to help identify the underlying [internal object](https://gpuweb.github.io/gpuweb/#internal-object) to the developer.

For example error message on browser console will be easier to understand to know which WebGPU resource is related. Or WebGPU tools, like my [WebGPU devtools](https://github.com/takahirox/webgpu-devtools), may show more helpful info.

![image](https://user-images.githubusercontent.com/7637832/229980062-8252e537-ab7f-4059-810e-4d0e323e656d.png)

So, I would like to suggest to set label to WebGPU objects to help debugging. In this PR, we set labels only for WebGPU objects that were easy to name.. If my suggestion sounds ok, I hope we can discuss how we can name other objects and make follow up PRs.