### PR TITLE
ShaderChunk: Cleanup transmission_pars_fragment.

### DIFF
--- a/src/renderers/shaders/ShaderChunk/transmission_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/transmission_pars_fragment.glsl.js
@@ -82,7 +82,7 @@ export default /* glsl */`
 
 	}
 
-	vec4 bicubic( sampler2D tex, vec2 uv, vec4 texelSize, vec2 fullSize, float lod ) {
+	vec4 bicubic( sampler2D tex, vec2 uv, vec4 texelSize, float lod ) {
 
 		uv = uv * texelSize.zw + 0.5;
 
@@ -100,8 +100,6 @@ export default /* glsl */`
 		vec2 p1 = ( vec2( iuv.x + h1x, iuv.y + h0y ) - 0.5 ) * texelSize.xy;
 		vec2 p2 = ( vec2( iuv.x + h0x, iuv.y + h1y ) - 0.5 ) * texelSize.xy;
 		vec2 p3 = ( vec2( iuv.x + h1x, iuv.y + h1y ) - 0.5 ) * texelSize.xy;
-		
-		vec2 lodFudge = pow( 1.95, lod ) / fullSize;
 
 		return g0( fuv.y ) * ( g0x * textureLod( tex, p0, lod ) + g1x * textureLod( tex, p1, lod ) ) +
 			g1( fuv.y ) * ( g0x * textureLod( tex, p2, lod ) + g1x * textureLod( tex, p3, lod ) );
@@ -114,9 +112,8 @@ export default /* glsl */`
 		vec2 cLodSize = vec2( textureSize( sampler, int( lod + 1.0 ) ) );
 		vec2 fLodSizeInv = 1.0 / fLodSize;
 		vec2 cLodSizeInv = 1.0 / cLodSize;
-		vec2 fullSize = vec2( textureSize( sampler, 0 ) );
-		vec4 fSample = bicubic( sampler, uv, vec4( fLodSizeInv, fLodSize ), fullSize, floor( lod ) );
-		vec4 cSample = bicubic( sampler, uv, vec4( cLodSizeInv, cLodSize ), fullSize, ceil( lod ) );
+		vec4 fSample = bicubic( sampler, uv, vec4( fLodSizeInv, fLodSize ), floor( lod ) );
+		vec4 cSample = bicubic( sampler, uv, vec4( cLodSizeInv, cLodSize ), ceil( lod ) );
 		return mix( fSample, cSample, fract( lod ) );
 
 	}


### PR DESCRIPTION
**Description**

Variables `lodFudge` and `fullSize` unused.