### PR TITLE
AudioLoader: Trigger the error callback when decodeAudioData fails

### DIFF
--- a/src/loaders/AudioLoader.js
+++ b/src/loaders/AudioLoader.js
@@ -36,13 +36,13 @@ class AudioLoader extends Loader {
 
 			} catch ( e ) {
 
-				handleError ( e );
+				handleError( e );
 
 			}
 
 		}, onProgress, onError );
 
-		function handleError ( e ) {
+		function handleError( e ) {
 
 			if ( onError ) {
 

--- a/src/loaders/AudioLoader.js
+++ b/src/loaders/AudioLoader.js
@@ -32,25 +32,31 @@ class AudioLoader extends Loader {
 
 					onLoad( audioBuffer );
 
-				} );
+				}, handleError );
 
 			} catch ( e ) {
 
-				if ( onError ) {
-
-					onError( e );
-
-				} else {
-
-					console.error( e );
-
-				}
-
-				scope.manager.itemError( url );
+				handleError ( e );
 
 			}
 
 		}, onProgress, onError );
+
+		function handleError ( e ) {
+
+			if ( onError ) {
+
+				onError( e );
+
+			} else {
+
+				console.error( e );
+
+			}
+
+			scope.manager.itemError( url );
+
+		}
 
 	}
 


### PR DESCRIPTION
Currently, if the call to `context.decodeAudioData` fails for whatever reason, `AudioLoader.load` (and `loadAsync` by extension) will hang forever because there is no error handling for it. This PR adds the extra error handling for that scenario.

Related (but closed and forgotten?): #20301