### PR TITLE
WebGPURenderer: Set label to WebGPU textures

### DIFF
--- a/examples/jsm/renderers/webgpu/WebGPUTextures.js
+++ b/examples/jsm/renderers/webgpu/WebGPUTextures.js
@@ -218,8 +218,10 @@ class WebGPUTextures {
 			const width = renderTarget.width;
 			const height = renderTarget.height;
 			const colorTextureFormat = this._getFormat( renderTarget.texture );
+			const label = renderTarget.texture.name ? '_' + renderTarget.texture.name : '';
 
 			const colorTextureGPU = device.createTexture( {
+				label: 'renderTarget' + label,
 				size: {
 					width: width,
 					height: height,
@@ -248,6 +250,7 @@ class WebGPUTextures {
 				const depthTextureFormat = GPUTextureFormat.Depth24PlusStencil8; // @TODO: Make configurable
 
 				const depthTextureGPU = device.createTexture( {
+					label: 'renderTarget' + label + '_depthBuffer',
 					size: {
 						width: width,
 						height: height,
@@ -368,6 +371,7 @@ class WebGPUTextures {
 		}
 
 		const textureGPUDescriptor = {
+			label: texture.name,
 			size: {
 				width: width,
 				height: height,


### PR DESCRIPTION
**Description**

This PR is a follow up PR to #25773

This PR sets label to WebGPU textures

![image](https://user-images.githubusercontent.com/7637832/230532444-d32a137c-58df-457a-a5c1-9a4380ccfdc7.png)
