### PR TITLE
unwanted `<h3>` removed

### DIFF
--- a/docs/manual/en/introduction/Installation.html
+++ b/docs/manual/en/introduction/Installation.html
@@ -222,7 +222,7 @@ npm install --save-dev vite
 				<li>[link:https://atom.io/packages/atom-live-server Live Server] for Atom</li>
 			</ul>
 
-			<h3>
+
 		</details>
 
 		<h3>Production</h3>


### PR DESCRIPTION
removed an irrelevant and useless `<h3>` tag in the example page.

And... why are the HTML pages in  `docs/manual/en/introduction/*.html` and in many more html pages code is so ugly?? should i run prettier on them?