### PR TITLE
PLYLoader: Ignore lines in the body

### DIFF
--- a/examples/jsm/loaders/PLYLoader.js
+++ b/examples/jsm/loaders/PLYLoader.js
@@ -243,22 +243,24 @@ class PLYLoader extends Loader {
 
 		}
 
-		function parseASCIIElement( properties, line ) {
-
-			const values = line.split( /\s+/ );
+		function parseASCIIElement( properties, tokens ) {
 
 			const element = {};
 
 			for ( let i = 0; i < properties.length; i ++ ) {
 
+				if ( tokens.empty() ) return null;
+
 				if ( properties[ i ].type === 'list' ) {
 
 					const list = [];
-					const n = parseASCIINumber( values.shift(), properties[ i ].countType );
+					const n = parseASCIINumber( tokens.next(), properties[ i ].countType );
 
 					for ( let j = 0; j < n; j ++ ) {
 
-						list.push( parseASCIINumber( values.shift(), properties[ i ].itemType ) );
+						if ( tokens.empty() ) return null;
+
+						list.push( parseASCIINumber( tokens.next(), properties[ i ].itemType ) );
 
 					}
 
@@ -266,7 +268,7 @@ class PLYLoader extends Loader {
 
 				} else {
 
-					element[ properties[ i ].name ] = parseASCIINumber( values.shift(), properties[ i ].type );
+					element[ properties[ i ].name ] = parseASCIINumber( tokens.next(), properties[ i ].type );
 
 				}
 
@@ -341,47 +343,30 @@ class PLYLoader extends Loader {
 
 			const buffer = createBuffer();
 
-			let result;
+			const patternBody = /end_header\s+(\S[\s\S]*\S|\S)\s*$/;
+			let body, matches;
 
-			const patternBody = /end_header\s([\s\S]*)$/;
-			let body = '';
-			if ( ( result = patternBody.exec( data ) ) !== null ) {
+			if ( ( matches = patternBody.exec( data ) ) !== null )
+				body = matches[ 1 ].split( /\s+/ );
+			else
+				body = [ ];
 
-				body = result[ 1 ];
+			const tokens = new ArrayStream( body );
 
-			}
+			loop: for ( let i = 0; i < header.elements.length; i ++ ) {
 
-			const lines = body.split( /\r\n|\r|\n/ );
-			let currentElement = 0;
-			let currentElementCount = 0;
-			let elementDesc = header.elements[ currentElement ];
-			let attributeMap = mapElementAttributes( elementDesc.properties );
+				const elementDesc = header.elements[ i ];
+				const attributeMap = mapElementAttributes( elementDesc.properties );
 
-			for ( let i = 0; i < lines.length; i ++ ) {
+				for ( let j = 0; j < elementDesc.count; j ++ ) {
 
-				let line = lines[ i ];
-				line = line.trim();
-				if ( line === '' ) {
+					const element = parseASCIIElement( elementDesc.properties, tokens );
 
-					continue;
+					if ( ! element ) break loop;
 
-				}
-
-				if ( currentElementCount >= elementDesc.count ) {
-
-					currentElement ++;
-					currentElementCount = 0;
-					elementDesc = header.elements[ currentElement ];
-
-					attributeMap = mapElementAttributes( elementDesc.properties );
+					handleElement( buffer, elementDesc.name, element, attributeMap );
 
 				}
-
-				const element = parseASCIIElement( elementDesc.properties, line );
-
-				handleElement( buffer, elementDesc.name, element, attributeMap );
-
-				currentElementCount ++;
 
 			}
 
@@ -728,6 +713,29 @@ class PLYLoader extends Loader {
 		}
 
 		return geometry;
+
+	}
+
+}
+
+class ArrayStream {
+
+	constructor( arr ) {
+
+		this.arr = arr;
+		this.i = 0;
+
+	}
+
+	empty() {
+
+		return this.i >= this.arr.length;
+
+	}
+
+	next() {
+
+		return this.arr[ this.i ++ ];
 
 	}
 

--- a/examples/jsm/loaders/PLYLoader.js
+++ b/examples/jsm/loaders/PLYLoader.js
@@ -346,10 +346,15 @@ class PLYLoader extends Loader {
 			const patternBody = /end_header\s+(\S[\s\S]*\S|\S)\s*$/;
 			let body, matches;
 
-			if ( ( matches = patternBody.exec( data ) ) !== null )
+			if ( ( matches = patternBody.exec( data ) ) !== null ) {
+
 				body = matches[ 1 ].split( /\s+/ );
-			else
+
+			} else {
+
 				body = [ ];
+
+			}
 
 			const tokens = new ArrayStream( body );
 


### PR DESCRIPTION
From the commit:
```
Instead of assuming that each line describes one object,
simply split the body at whitespaces and consume the resulting
token stream with no regard to line boundaries.

This is needed because, for example, some ply files exported
by librealsense use multiple lines to describe a single object[0].

[0]: https://github.com/IntelRealSense/librealsense/blob/e9f05c55f88f6876633bd59fd1cb3848da64b699/include/librealsense2/hpp/rs_export.hpp#L240
```

Side note: I have not seen much infrastructure for reporting errors, so premature EOF is simply silently ignored (and if there is a partial object, that is dropped).

---

<details>

<summary>librealsense code</summary>

```cpp
                for (size_t i = 0; i <new_verts.size(); ++i)
                {
                    out << new_verts[i].x << " ";
                    out << new_verts[i].y << " ";
                    out << new_verts[i].z << " ";
                    out << "\n";

                    if (mesh && use_normals)
                    {
                        out << normals[i].x << " ";
                        out << normals[i].y << " ";
                        out << normals[i].z << " ";
                        out << "\n";
                    }

                    if (use_texcoords)
                    {
                        out << unsigned(new_tex[i][0]) << " ";
                        out << unsigned(new_tex[i][1]) << " ";
                        out << unsigned(new_tex[i][2]) << " ";
                        out << "\n";
                    }
                }
```

</details>

<details>

<summary>sample from an exported file</summary>

```ply
ply
format ascii 1.0
comment pointcloud saved from Realsense Viewer
element vertex 163192
property float32 x
property float32 y
property float32 z
property float32 nx
property float32 ny
property float32 nz
property uchar red
property uchar green
property uchar blue
element face 311396
property list uchar int vertex_indices
end_header
-1.10254 0.844727 -1.55176
0.995526 0.0935393 -0.0133628
136 107 97
```

</details>