### PR TITLE
fix computeVertexNormals description (en)

### DIFF
--- a/docs/api/en/core/BufferGeometry.html
+++ b/docs/api/en/core/BufferGeometry.html
@@ -211,7 +211,7 @@
 		</p>
 
 		<h3>[method:undefined computeVertexNormals]()</h3>
-		<p>Computes vertex normals by averaging face normals.</p>
+		<p>Sets vertex normals to face normals.</p>
 
 		<h3>[method:this copy]( [param:BufferGeometry bufferGeometry] )</h3>
 		<p>Copies another BufferGeometry to this BufferGeometry.</p>


### PR DESCRIPTION
see [here](https://github.com/mrdoob/three.js/blob/master/src/core/BufferGeometry.js#L671-L697) - it no longer does any averaging.