### PR TITLE
WebGPURenderer: Set label to GPUShaderModules

### DIFF
--- a/examples/jsm/renderers/webgpu/WebGPUProgrammableStage.js
+++ b/examples/jsm/renderers/webgpu/WebGPUProgrammableStage.js
@@ -11,7 +11,7 @@ class WebGPUProgrammableStage {
 		this.usedTimes = 0;
 
 		this.stage = {
-			module: device.createShaderModule( { code } ),
+			module: device.createShaderModule( { code, label: type } ),
 			entryPoint: 'main'
 		};
 

--- a/examples/jsm/renderers/webgpu/WebGPUTextureUtils.js
+++ b/examples/jsm/renderers/webgpu/WebGPUTextureUtils.js
@@ -82,10 +82,12 @@ fn main( @location( 0 ) vTex : vec2<f32> ) -> @location( 0 ) vec4<f32> {
 		this.pipelines = {};
 
 		this.mipmapVertexShaderModule = device.createShaderModule( {
+			label: 'mipmapVertex',
 			code: mipmapVertexSource
 		} );
 
 		this.mipmapFragmentShaderModule = device.createShaderModule( {
+			label: 'mipmapFragment',
 			code: mipmapFragmentSource
 		} );
 


### PR DESCRIPTION
**Description**

This PR is a follow up PR to #25773

This PR sets label to GPUShaderModules.

![image](https://user-images.githubusercontent.com/7637832/230792709-a8f4aef7-2740-4107-9397-5b6a1b21e8ad.png)

Labels will be 'vertex', 'fragment', 'compute', 'mipmapVertex', or 'mipmapFragment'. They can be more meaningful for example by getting something meaning information from Material node builder. Please feel free to make a follow up PR to improve the names.
