### PR TITLE
WebGLMultipleRenderTargets: Copy viewport/scissor from source.

### DIFF
--- a/src/renderers/WebGLMultipleRenderTargets.js
+++ b/src/renderers/WebGLMultipleRenderTargets.js
@@ -56,8 +56,8 @@ class WebGLMultipleRenderTargets extends WebGLRenderTarget {
 		this.height = source.height;
 		this.depth = source.depth;
 
-		this.viewport.set( 0, 0, this.width, this.height );
-		this.scissor.set( 0, 0, this.width, this.height );
+		this.viewport.copy( source.viewport );
+		this.scissor.copy( source.scissor );
 
 		this.depthBuffer = source.depthBuffer;
 		this.stencilBuffer = source.stencilBuffer;


### PR DESCRIPTION
The PR fixes a misprint.

It looks like we have to copy source.viewport/source.scissor instead of cleaning this.viewport/this.scissor: 

```js

		this.viewport.set( 0, 0, this.width, this.height );
		this.scissor.set( 0, 0, this.width, this.height );
```