### PR TITLE
Docs: Improve `Updating resources` guide.

### DIFF
--- a/docs/manual/ar/introduction/How-to-update-things.html
+++ b/docs/manual/ar/introduction/How-to-update-things.html
@@ -72,20 +72,17 @@ scene.add( line );
 				بعد ذلك سنضيف نقاطًا بشكل عشوائي إلى الخط باستخدام نمط مثل:
 			</p>
 			<code>
-const positions = line.geometry.attributes.position.array;
+const positionAttribute = line.geometry.getAttribute( 'position' );
 
-let x, y, z, index;
-x = y = z = index = 0;
+let x = 0, y = 0, z = 0;
 
-for ( let i = 0, l = MAX_POINTS; i < l; i ++ ) {
+for ( let i = 0; i < positionAttribute.count; i ++ ) {
 
-    positions[ index ++ ] = x;
-    positions[ index ++ ] = y;
-    positions[ index ++ ] = z;
+	positionAttribute.setXYZ( i, x, y, z );
 
-    x += ( Math.random() - 0.5 ) * 30;
-    y += ( Math.random() - 0.5 ) * 30;
-    z += ( Math.random() - 0.5 ) * 30;
+	x += ( Math.random() - 0.5 ) * 30;
+	y += ( Math.random() - 0.5 ) * 30;
+	z += ( Math.random() - 0.5 ) * 30;
 
 }
 			</code>
@@ -99,7 +96,7 @@ line.geometry.setDrawRange( 0, newValue );
 				إذا كنت تريد تغيير قيم بيانات الموضع بعد العرض الأول ، فأنت بحاجة إلى تعيين علامة needsUpdate على النحو التالي:
 			</p>
 			<code>
-line.geometry.attributes.position.needsUpdate = true; // required after the first render
+positionAttribute.needsUpdate = true; // required after the first render
 			</code>
 
 			<p>

--- a/docs/manual/en/introduction/How-to-update-things.html
+++ b/docs/manual/en/introduction/How-to-update-things.html
@@ -80,16 +80,13 @@ scene.add( line );
 				Next we'll randomly add points to the line using a pattern like:
 			</p>
 			<code>
-const positions = line.geometry.attributes.position.array;
+const positionAttribute = line.geometry.getAttribute( 'position' );
 
-let x, y, z, index;
-x = y = z = index = 0;
+let x = 0, y = 0, z = 0;
 
-for ( let i = 0, l = MAX_POINTS; i < l; i ++ ) {
+for ( let i = 0; i < positionAttribute.count; i ++ ) {
 
-    positions[ index ++ ] = x;
-    positions[ index ++ ] = y;
-    positions[ index ++ ] = z;
+	positionAttribute.setXYZ( i, x, y, z );
 
     x += ( Math.random() - 0.5 ) * 30;
     y += ( Math.random() - 0.5 ) * 30;
@@ -108,7 +105,7 @@ line.geometry.setDrawRange( 0, newValue );
 				set the needsUpdate flag like so:
 			</p>
 			<code>
-line.geometry.attributes.position.needsUpdate = true; // required after the first render
+positionAttribute.needsUpdate = true; // required after the first render
 			</code>
 
 			<p>

--- a/docs/manual/fr/introduction/How-to-update-things.html
+++ b/docs/manual/fr/introduction/How-to-update-things.html
@@ -80,20 +80,17 @@ scene.add( line );
 				Ensuite nous ajouterons aléatoirement des points à l'aide d'un pattern comme:
 			</p>
 			<code>
-const positions = line.geometry.attributes.position.array;
+const positionAttribute = line.geometry.getAttribute( 'position' );
 
-let x, y, z, index;
-x = y = z = index = 0;
+let x = 0, y = 0, z = 0;
 
-for ( let i = 0, l = MAX_POINTS; i < l; i ++ ) {
+for ( let i = 0; i < positionAttribute.count; i ++ ) {
 
-    positions[ index ++ ] = x;
-    positions[ index ++ ] = y;
-    positions[ index ++ ] = z;
+	positionAttribute.setXYZ( i, x, y, z );
 
-    x += ( Math.random() - 0.5 ) * 30;
-    y += ( Math.random() - 0.5 ) * 30;
-    z += ( Math.random() - 0.5 ) * 30;
+	x += ( Math.random() - 0.5 ) * 30;
+	y += ( Math.random() - 0.5 ) * 30;
+	z += ( Math.random() - 0.5 ) * 30;
 
 }
 			</code>
@@ -108,7 +105,7 @@ line.geometry.setDrawRange( 0, newValue );
 				set the needsUpdate flag like so:
 			</p>
 			<code>
-line.geometry.attributes.position.needsUpdate = true; // required after the first render
+positionAttribute.needsUpdate = true; // required after the first render
 			</code>
 
 			<p>

--- a/docs/manual/it/introduction/How-to-update-things.html
+++ b/docs/manual/it/introduction/How-to-update-things.html
@@ -79,20 +79,17 @@ scene.add( line );
         Quindi, aggiungeremo punti alla linea in maniera random usando un pattern come questo:
 			</p>
 			<code>
-const positions = line.geometry.attributes.position.array;
+const positionAttribute = line.geometry.getAttribute( 'position' );
 
-let x, y, z, index;
-x = y = z = index = 0;
+let x = 0, y = 0, z = 0;
 
-for ( let i = 0, l = MAX_POINTS; i < l; i ++ ) {
+for ( let i = 0; i < positionAttribute.count; i ++ ) {
 
-    positions[ index ++ ] = x;
-    positions[ index ++ ] = y;
-    positions[ index ++ ] = z;
+	positionAttribute.setXYZ( i, x, y, z );
 
-    x += ( Math.random() - 0.5 ) * 30;
-    y += ( Math.random() - 0.5 ) * 30;
-    z += ( Math.random() - 0.5 ) * 30;
+	x += ( Math.random() - 0.5 ) * 30;
+	y += ( Math.random() - 0.5 ) * 30;
+	z += ( Math.random() - 0.5 ) * 30;
 
 }
 			</code>
@@ -107,7 +104,7 @@ line.geometry.setDrawRange( 0, newValue );
         impostare il flag di needsUpdate come segue:
 			</p>
 			<code>
-line.geometry.attributes.position.needsUpdate = true; // required after the first render
+positionAttribute.needsUpdate = true; // required after the first render
 			</code>
 
 			<p>

--- a/docs/manual/ja/introduction/How-to-update-things.html
+++ b/docs/manual/ja/introduction/How-to-update-things.html
@@ -76,16 +76,13 @@ scene.add( line );
             次に以下のようにして、線上にランダムに点を追加してみましょう。
         </p>
         <code>
-const positions = line.geometry.attributes.position.array;
+const positionAttribute = line.geometry.getAttribute( 'position' );
 
-let x, y, z, index;
-x = y = z = index = 0;
+let x = 0, y = 0, z = 0;
 
-for ( let i = 0, l = MAX_POINTS; i < l; i ++ ) {
+for ( let i = 0; i < positionAttribute.count; i ++ ) {
 
-    positions[ index ++ ] = x;
-    positions[ index ++ ] = y;
-    positions[ index ++ ] = z;
+    positionAttribute.setXYZ( i, x, y, z );
 
     x += ( Math.random() - 0.5 ) * 30;
     y += ( Math.random() - 0.5 ) * 30;
@@ -103,7 +100,7 @@ line.geometry.setDrawRange( 0, newValue );
             最初の描画以降に位置データの値を変更したい場合は、needsUpdateをtrueにセットする必要があります。
         </p>
         <code>
-line.geometry.attributes.position.needsUpdate = true; // required after the first render
+positionAttribute.needsUpdate = true; // required after the first render
 			</code>
 
         <p>

--- a/docs/manual/ko/introduction/How-to-update-things.html
+++ b/docs/manual/ko/introduction/How-to-update-things.html
@@ -77,20 +77,17 @@ scene.add( line );
 				그 다음, 아래와 같은 패턴으로 무작위로 선에 점을 생성해 줄 것입니다:
 			</p>
 			<code>
-const positions = line.geometry.attributes.position.array;
+const positionAttribute = line.geometry.getAttribute( 'position' );
 
-let x, y, z, index;
-x = y = z = index = 0;
+let x = 0, y = 0, z = 0;
 
-for ( let i = 0, l = MAX_POINTS; i < l; i ++ ) {
+for ( let i = 0; i < positionAttribute.count; i ++ ) {
 
-    positions[ index ++ ] = x;
-    positions[ index ++ ] = y;
-    positions[ index ++ ] = z;
+	positionAttribute.setXYZ( i, x, y, z );
 
-    x += ( Math.random() - 0.5 ) * 30;
-    y += ( Math.random() - 0.5 ) * 30;
-    z += ( Math.random() - 0.5 ) * 30;
+	x += ( Math.random() - 0.5 ) * 30;
+	y += ( Math.random() - 0.5 ) * 30;
+	z += ( Math.random() - 0.5 ) * 30;
 
 }
 			</code>
@@ -104,7 +101,7 @@ line.geometry.setDrawRange( 0, newValue );
 				첫 렌더링 이후에 position 데이터 수치를 변경하고 싶다면, needsUpdate 플래그를 다음과 같이 설정해야 합니다:
 			</p>
 			<code>
-line.geometry.attributes.position.needsUpdate = true; // required after the first render
+positionAttribute.needsUpdate = true; // required after the first render
 			</code>
 
 			<p>

--- a/docs/manual/pt-br/introduction/How-to-update-things.html
+++ b/docs/manual/pt-br/introduction/How-to-update-things.html
@@ -84,20 +84,17 @@ scene.add( line );
 				Em seguida, adicionaremos aleatoriamente pontos à linha usando um padrão como:
 			</p>
 			<code>
-const positions = line.geometry.attributes.position.array;
+const positionAttribute = line.geometry.getAttribute( 'position' );
 
-let x, y, z, index;
-x = y = z = index = 0;
+let x = 0, y = 0, z = 0;
 
-for ( let i = 0, l = MAX_POINTS; i < l; i ++ ) {
+for ( let i = 0; i < positionAttribute.count; i ++ ) {
 
-    positions[ index ++ ] = x;
-    positions[ index ++ ] = y;
-    positions[ index ++ ] = z;
+	positionAttribute.setXYZ( i, x, y, z );
 
-    x += ( Math.random() - 0.5 ) * 30;
-    y += ( Math.random() - 0.5 ) * 30;
-    z += ( Math.random() - 0.5 ) * 30;
+	x += ( Math.random() - 0.5 ) * 30;
+	y += ( Math.random() - 0.5 ) * 30;
+	z += ( Math.random() - 0.5 ) * 30;
 
 }
 			</code>
@@ -112,7 +109,7 @@ line.geometry.setDrawRange( 0, newValue );
 				definir a propriedade needsUpdate assim:
 			</p>
 			<code>
-line.geometry.attributes.position.needsUpdate = true; // required after the first render
+positionAttribute.needsUpdate = true; // required after the first render
 			</code>
 
 			<p>

--- a/docs/manual/zh/introduction/How-to-update-things.html
+++ b/docs/manual/zh/introduction/How-to-update-things.html
@@ -76,20 +76,17 @@ scene.add( line );
 				然后我们随机增加顶点到line中，以这样的一种方式：
 			</p>
 			<code>
-const positions = line.geometry.attributes.position.array;
+const positionAttribute = line.geometry.getAttribute( 'position' );
 
-let x, y, z, index;
-x = y = z = index = 0;
+let x = 0, y = 0, z = 0;
 
-for ( let i = 0, l = MAX_POINTS; i < l; i ++ ) {
+for ( let i = 0; i < positionAttribute.count; i ++ ) {
 
-    positions[ index ++ ] = x;
-    positions[ index ++ ] = y;
-    positions[ index ++ ] = z;
+	positionAttribute.setXYZ( i, x, y, z );
 
-    x += ( Math.random() - 0.5 ) * 30;
-    y += ( Math.random() - 0.5 ) * 30;
-    z += ( Math.random() - 0.5 ) * 30;
+	x += ( Math.random() - 0.5 ) * 30;
+	y += ( Math.random() - 0.5 ) * 30;
+	z += ( Math.random() - 0.5 ) * 30;
 
 }
 			</code>
@@ -103,7 +100,7 @@ line.geometry.setDrawRange( 0, newValue );
 				如果要在第一次渲染后更改position数值，则需要像这样设置needsUpdate标志：
 			</p>
 			<code>
-line.geometry.attributes.position.needsUpdate = true; // 需要加在第一次渲染之后
+positionAttribute.needsUpdate = true; // required after the first render // 需要加在第一次渲染之后
 			</code>
 
 			<p>


### PR DESCRIPTION
Related issue: https://discourse.threejs.org/t/how-to-set-values-for-bufferattribute-documentation-examples-produce-ts-errors/50159

**Description**

The `Updating resources` guide shows code that operates on the raw buffer data instead of the dedicated `BufferAttribute` interface.