### PR TITLE
WebGLRenderTarget: Honor scissor properties in `copy()`.

### DIFF
--- a/src/renderers/WebGLMultipleRenderTargets.js
+++ b/src/renderers/WebGLMultipleRenderTargets.js
@@ -56,8 +56,10 @@ class WebGLMultipleRenderTargets extends WebGLRenderTarget {
 		this.height = source.height;
 		this.depth = source.depth;
 
-		this.viewport.copy( source.viewport );
 		this.scissor.copy( source.scissor );
+		this.scissorTest = source.scissorTest;
+
+		this.viewport.copy( source.viewport );
 
 		this.depthBuffer = source.depthBuffer;
 		this.stencilBuffer = source.stencilBuffer;

--- a/src/renderers/WebGLRenderTarget.js
+++ b/src/renderers/WebGLRenderTarget.js
@@ -87,6 +87,9 @@ class WebGLRenderTarget extends EventDispatcher {
 		this.height = source.height;
 		this.depth = source.depth;
 
+		this.scissor.copy( source.scissor );
+		this.scissorTest = source.scissorTest;
+
 		this.viewport.copy( source.viewport );
 
 		this.texture = source.texture.clone();


### PR DESCRIPTION
Related issue: #25803

**Description**

Ensures `scissor` and `scissorTest` are copied in `WebGLRenderTarget.copy()`. Also `scissorTest` is now copied in `WebGLMultipleRenderTargets.copy()`.
