### PR TITLE
Target bone objects directly in BVHLoader keyframe tracks

### DIFF
--- a/examples/jsm/loaders/BVHLoader.js
+++ b/examples/jsm/loaders/BVHLoader.js
@@ -385,13 +385,13 @@ class BVHLoader extends Loader {
 
 				if ( scope.animateBonePositions ) {
 
-					tracks.push( new VectorKeyframeTrack( '.bones[' + bone.name + '].position', times, positions ) );
+					tracks.push( new VectorKeyframeTrack( bone.name + '.position', times, positions ) );
 
 				}
 
 				if ( scope.animateBoneRotations ) {
 
-					tracks.push( new QuaternionKeyframeTrack( '.bones[' + bone.name + '].quaternion', times, rotations ) );
+					tracks.push( new QuaternionKeyframeTrack( bone.name + '.quaternion', times, rotations ) );
 
 				}
 

--- a/examples/webgl_loader_bvh.html
+++ b/examples/webgl_loader_bvh.html
@@ -54,19 +54,13 @@
 			const loader = new BVHLoader();
 			loader.load( 'models/bvh/pirouette.bvh', function ( result ) {
 
-				const skinnedMesh = new THREE.SkinnedMesh();
-				skinnedMesh.visible = false; // dummy skinned mesh for animating the skeleton
+				const skeletonHelper = new THREE.SkeletonHelper( result.skeleton.bones[ 0 ] );
 
-				skinnedMesh.add( result.skeleton.bones[ 0 ] );
-				skinnedMesh.bind( result.skeleton );
-
-				const skeletonHelper = new THREE.SkeletonHelper( skinnedMesh );
-
-				scene.add( skinnedMesh );
+				scene.add( result.skeleton.bones[ 0 ] );
 				scene.add( skeletonHelper );
 
 				// play animation
-				mixer = new THREE.AnimationMixer( skinnedMesh );
+				mixer = new THREE.AnimationMixer( result.skeleton.bones[ 0 ] );
 				mixer.clipAction( result.clip ).play();
 
 			} );


### PR DESCRIPTION
Related discussion: #25763

**Description**

The above PR adds a dummy SkinnedMesh in order to animate the BVH skeleton, as the loader creates tracks that expect a `.bones[ ... ]` property. This PR updates BVHLoader to instead target the bones directly, similar to how tracks are created in GLTFLoader [(relevant lines)](https://github.com/mrdoob/three.js/blob/17cde661d11a76d663c92d5489fd1b83df36ae35/examples/jsm/loaders/GLTFLoader.js#L3897-L3902). This means so you can pass any ancestor of the bones to the AnimationMixer and it will animate. It also updates the example to remove the dummy SkinnedMesh. I believe this is a backwards compatible change.

Live example: https://rawcdn.githack.com/mrdoob/three.js/cf03ebfe9f0590a88a9e6637b23d0e4be486c97e/examples/webgl_loader_bvh.html

