### PR TITLE
Examples: Remove redundant color space settings.

### DIFF
--- a/examples/games_fps.html
+++ b/examples/games_fps.html
@@ -77,7 +77,6 @@
 			renderer.setSize( window.innerWidth, window.innerHeight );
 			renderer.shadowMap.enabled = true;
 			renderer.shadowMap.type = THREE.VSMShadowMap;
-			renderer.outputColorSpace = THREE.SRGBColorSpace;
 			renderer.toneMapping = THREE.ACESFilmicToneMapping;
 			container.appendChild( renderer.domElement );
 

--- a/examples/misc_controls_arcball.html
+++ b/examples/misc_controls_arcball.html
@@ -102,7 +102,6 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.toneMapping = THREE.ReinhardToneMapping;
 				renderer.toneMappingExposure = 3;
 				renderer.domElement.style.background = 'linear-gradient( 180deg, rgba( 0,0,0,1 ) 0%, rgba( 128,128,255,1 ) 100% )';

--- a/examples/misc_exporter_collada.html
+++ b/examples/misc_exporter_collada.html
@@ -86,7 +86,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( canvasWidth, canvasHeight );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				container.appendChild( renderer.domElement );
 
 				// EVENTS

--- a/examples/misc_exporter_gltf.html
+++ b/examples/misc_exporter_gltf.html
@@ -442,7 +442,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				renderer.toneMappingExposure = 1;
 

--- a/examples/misc_exporter_obj.html
+++ b/examples/misc_exporter_obj.html
@@ -50,7 +50,6 @@
 			function init() {
 
 				renderer = new THREE.WebGLRenderer();
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				document.body.appendChild( renderer.domElement );

--- a/examples/misc_exporter_ply.html
+++ b/examples/misc_exporter_ply.html
@@ -105,7 +105,6 @@
 				//
 
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.shadowMap.enabled = true;

--- a/examples/misc_exporter_usdz.html
+++ b/examples/misc_exporter_usdz.html
@@ -69,7 +69,6 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				document.body.appendChild( renderer.domElement );
 
 				camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 0.25, 20 );

--- a/examples/physics_ammo_instancing.html
+++ b/examples/physics_ammo_instancing.html
@@ -125,7 +125,6 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.shadowMap.enabled = true;
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				document.body.appendChild( renderer.domElement );
 
 				stats = new Stats();

--- a/examples/physics_oimo_instancing.html
+++ b/examples/physics_oimo_instancing.html
@@ -124,7 +124,6 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.shadowMap.enabled = true;
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				document.body.appendChild( renderer.domElement );
 
 				stats = new Stats();

--- a/examples/webaudio_orientation.html
+++ b/examples/webaudio_orientation.html
@@ -154,7 +154,6 @@
 			renderer = new THREE.WebGLRenderer( { antialias: true } );
 			renderer.setSize( window.innerWidth, window.innerHeight );
 			renderer.setPixelRatio( window.devicePixelRatio );
-			renderer.outputColorSpace = THREE.SRGBColorSpace;
 			renderer.shadowMap.enabled = true;
 			container.appendChild( renderer.domElement );
 

--- a/examples/webgl_animation_keyframes.html
+++ b/examples/webgl_animation_keyframes.html
@@ -63,7 +63,6 @@
 			const renderer = new THREE.WebGLRenderer( { antialias: true } );
 			renderer.setPixelRatio( window.devicePixelRatio );
 			renderer.setSize( window.innerWidth, window.innerHeight );
-			renderer.outputColorSpace = THREE.SRGBColorSpace;
 			container.appendChild( renderer.domElement );
 
 			const pmremGenerator = new THREE.PMREMGenerator( renderer );

--- a/examples/webgl_animation_multiple.html
+++ b/examples/webgl_animation_multiple.html
@@ -111,7 +111,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.shadowMap.enabled = true;
 				document.body.appendChild( renderer.domElement );
 

--- a/examples/webgl_animation_skinning_additive_blending.html
+++ b/examples/webgl_animation_skinning_additive_blending.html
@@ -159,7 +159,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.shadowMap.enabled = true;
 				container.appendChild( renderer.domElement );
 

--- a/examples/webgl_animation_skinning_blending.html
+++ b/examples/webgl_animation_skinning_blending.html
@@ -137,7 +137,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.shadowMap.enabled = true;
 				container.appendChild( renderer.domElement );
 

--- a/examples/webgl_animation_skinning_ik.html
+++ b/examples/webgl_animation_skinning_ik.html
@@ -77,7 +77,6 @@
 			renderer = new THREE.WebGLRenderer( { antialias: true, logarithmicDepthBuffer: true } );
 			renderer.setPixelRatio( window.devicePixelRatio );
 			renderer.setSize( window.innerWidth, window.innerHeight );
-			renderer.outputColorSpace = THREE.SRGBColorSpace;
 			renderer.useLegacyLights = false;
 			document.body.appendChild( renderer.domElement );
 

--- a/examples/webgl_animation_skinning_morph.html
+++ b/examples/webgl_animation_skinning_morph.html
@@ -119,7 +119,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				container.appendChild( renderer.domElement );
 
 				window.addEventListener( 'resize', onWindowResize );

--- a/examples/webgl_buffergeometry.html
+++ b/examples/webgl_buffergeometry.html
@@ -171,7 +171,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 
 				container.appendChild( renderer.domElement );
 

--- a/examples/webgl_buffergeometry_drawrange.html
+++ b/examples/webgl_buffergeometry_drawrange.html
@@ -178,7 +178,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 
 				container.appendChild( renderer.domElement );
 

--- a/examples/webgl_buffergeometry_lines.html
+++ b/examples/webgl_buffergeometry_lines.html
@@ -94,7 +94,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 
 				container.appendChild( renderer.domElement );
 

--- a/examples/webgl_buffergeometry_lines_indexed.html
+++ b/examples/webgl_buffergeometry_lines_indexed.html
@@ -199,7 +199,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 
 				container.appendChild( renderer.domElement );
 

--- a/examples/webgl_buffergeometry_uint.html
+++ b/examples/webgl_buffergeometry_uint.html
@@ -170,7 +170,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 
 				container.appendChild( renderer.domElement );
 

--- a/examples/webgl_geometry_teapot.html
+++ b/examples/webgl_geometry_teapot.html
@@ -76,7 +76,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( canvasWidth, canvasHeight );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				container.appendChild( renderer.domElement );
 
 				// EVENTS

--- a/examples/webgl_instancing_performance.html
+++ b/examples/webgl_instancing_performance.html
@@ -259,7 +259,6 @@
 			renderer = new THREE.WebGLRenderer( { antialias: true } );
 			renderer.setPixelRatio( window.devicePixelRatio );
 			renderer.setSize( width, height );
-			renderer.outputColorSpace = THREE.SRGBColorSpace;
 
 			container = document.getElementById( 'container' );
 			container.appendChild( renderer.domElement );

--- a/examples/webgl_lensflares.html
+++ b/examples/webgl_lensflares.html
@@ -128,7 +128,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				container.appendChild( renderer.domElement );
 
 				//

--- a/examples/webgl_lightningstrike.html
+++ b/examples/webgl_lightningstrike.html
@@ -67,7 +67,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 
 				container.appendChild( renderer.domElement );
 

--- a/examples/webgl_lightprobe.html
+++ b/examples/webgl_lightprobe.html
@@ -61,7 +61,6 @@
 				// tone mapping
 				renderer.toneMapping = THREE.NoToneMapping;
 
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 
 				// scene
 				scene = new THREE.Scene();

--- a/examples/webgl_lightprobe_cubecamera.html
+++ b/examples/webgl_lightprobe_cubecamera.html
@@ -46,7 +46,6 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				document.body.appendChild( renderer.domElement );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 
 				// scene
 				scene = new THREE.Scene();

--- a/examples/webgl_lights_hemisphere.html
+++ b/examples/webgl_lights_hemisphere.html
@@ -201,7 +201,6 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				container.appendChild( renderer.domElement );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.shadowMap.enabled = true;
 
 				// STATS

--- a/examples/webgl_lights_physical.html
+++ b/examples/webgl_lights_physical.html
@@ -232,7 +232,6 @@
 
 				renderer = new THREE.WebGLRenderer();
 				renderer.useLegacyLights = false;
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.shadowMap.enabled = true;
 				renderer.toneMapping = THREE.ReinhardToneMapping;
 				renderer.setPixelRatio( window.devicePixelRatio );

--- a/examples/webgl_lights_rectarealight.html
+++ b/examples/webgl_lights_rectarealight.html
@@ -47,7 +47,6 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setAnimationLoop( animation );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				document.body.appendChild( renderer.domElement );
 
 				camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 1, 1000 );

--- a/examples/webgl_lights_spotlight.html
+++ b/examples/webgl_lights_spotlight.html
@@ -50,7 +50,6 @@
 				renderer.shadowMap.enabled = true;
 				renderer.shadowMap.type = THREE.PCFSoftShadowMap;
 
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				renderer.toneMappingExposure = 1;

--- a/examples/webgl_lights_spotlights.html
+++ b/examples/webgl_lights_spotlights.html
@@ -63,7 +63,6 @@
 
 				renderer.shadowMap.enabled = true;
 				renderer.shadowMap.type = THREE.PCFSoftShadowMap;
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 
 				camera.position.set( 46, 22, - 21 );
 

--- a/examples/webgl_loader_3dm.html
+++ b/examples/webgl_loader_3dm.html
@@ -67,7 +67,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				document.body.appendChild( renderer.domElement );
 
 				camera = new THREE.PerspectiveCamera( 60, window.innerWidth / window.innerHeight, 1, 1000 );

--- a/examples/webgl_loader_3ds.html
+++ b/examples/webgl_loader_3ds.html
@@ -78,7 +78,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				container.appendChild( renderer.domElement );
 
 				controls = new TrackballControls( camera, renderer.domElement );

--- a/examples/webgl_loader_3mf_materials.html
+++ b/examples/webgl_loader_3mf_materials.html
@@ -111,7 +111,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.shadowMap.enabled = true;
 				renderer.shadowMap.type = THREE.PCFSoftShadowMap;
 				document.body.appendChild( renderer.domElement );

--- a/examples/webgl_loader_collada.html
+++ b/examples/webgl_loader_collada.html
@@ -82,7 +82,6 @@
 				//
 
 				renderer = new THREE.WebGLRenderer();
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				container.appendChild( renderer.domElement );

--- a/examples/webgl_loader_collada_kinematics.html
+++ b/examples/webgl_loader_collada_kinematics.html
@@ -101,7 +101,6 @@
 				particleLight.add( pointLight );
 
 				renderer = new THREE.WebGLRenderer();
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				container.appendChild( renderer.domElement );

--- a/examples/webgl_loader_collada_skinning.html
+++ b/examples/webgl_loader_collada_skinning.html
@@ -85,7 +85,6 @@
 				//
 
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				container.appendChild( renderer.domElement );

--- a/examples/webgl_loader_draco.html
+++ b/examples/webgl_loader_draco.html
@@ -93,7 +93,6 @@
 			renderer = new THREE.WebGLRenderer( { antialias: true } );
 			renderer.setPixelRatio( window.devicePixelRatio );
 			renderer.setSize( window.innerWidth, window.innerHeight );
-			renderer.outputColorSpace = THREE.SRGBColorSpace;
 			renderer.shadowMap.enabled = true;
 			container.appendChild( renderer.domElement );
 

--- a/examples/webgl_loader_fbx.html
+++ b/examples/webgl_loader_fbx.html
@@ -111,7 +111,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.shadowMap.enabled = true;
 				container.appendChild( renderer.domElement );
 

--- a/examples/webgl_loader_fbx_nurbs.html
+++ b/examples/webgl_loader_fbx_nurbs.html
@@ -78,7 +78,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				container.appendChild( renderer.domElement );
 
 				const controls = new OrbitControls( camera, renderer.domElement );

--- a/examples/webgl_loader_gltf.html
+++ b/examples/webgl_loader_gltf.html
@@ -80,7 +80,6 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				renderer.toneMappingExposure = 1;
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				container.appendChild( renderer.domElement );
 
 				const controls = new OrbitControls( camera, renderer.domElement );

--- a/examples/webgl_loader_gltf_avif.html
+++ b/examples/webgl_loader_gltf_avif.html
@@ -78,7 +78,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				document.body.appendChild( renderer.domElement );
 
 				const controls = new OrbitControls( camera, renderer.domElement );

--- a/examples/webgl_loader_gltf_compressed.html
+++ b/examples/webgl_loader_gltf_compressed.html
@@ -53,7 +53,6 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				renderer.toneMappingExposure = 1;
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				container.appendChild( renderer.domElement );
 
 				camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 1, 2000 );

--- a/examples/webgl_loader_gltf_instancing.html
+++ b/examples/webgl_loader_gltf_instancing.html
@@ -80,7 +80,6 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				renderer.toneMappingExposure = 1;
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				container.appendChild( renderer.domElement );
 
 				const controls = new OrbitControls( camera, renderer.domElement );

--- a/examples/webgl_loader_gltf_iridescence.html
+++ b/examples/webgl_loader_gltf_iridescence.html
@@ -48,7 +48,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				document.body.appendChild( renderer.domElement );
 

--- a/examples/webgl_loader_gltf_lights.html
+++ b/examples/webgl_loader_gltf_lights.html
@@ -77,7 +77,6 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				renderer.toneMappingExposure = 1;
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.useLegacyLights = false;
 				container.appendChild( renderer.domElement );
 

--- a/examples/webgl_loader_gltf_sheen.html
+++ b/examples/webgl_loader_gltf_sheen.html
@@ -78,7 +78,6 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				renderer.toneMappingExposure = 1;
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				container.appendChild( renderer.domElement );
 
 				const environment = new RoomEnvironment();

--- a/examples/webgl_loader_gltf_transmission.html
+++ b/examples/webgl_loader_gltf_transmission.html
@@ -83,7 +83,6 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				renderer.toneMappingExposure = 1;
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				container.appendChild( renderer.domElement );
 
 				controls = new OrbitControls( camera, renderer.domElement );

--- a/examples/webgl_loader_gltf_variants.html
+++ b/examples/webgl_loader_gltf_variants.html
@@ -100,7 +100,6 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				renderer.toneMappingExposure = 1;
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				container.appendChild( renderer.domElement );
 
 				const controls = new OrbitControls( camera, renderer.domElement );

--- a/examples/webgl_loader_kmz.html
+++ b/examples/webgl_loader_kmz.html
@@ -57,7 +57,6 @@
 				scene.add( grid );
 
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				document.body.appendChild( renderer.domElement );

--- a/examples/webgl_loader_ldraw.html
+++ b/examples/webgl_loader_ldraw.html
@@ -89,7 +89,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				container.appendChild( renderer.domElement );
 

--- a/examples/webgl_loader_lwo.html
+++ b/examples/webgl_loader_lwo.html
@@ -82,7 +82,6 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setAnimationLoop( animation );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				container.appendChild( renderer.domElement );
 

--- a/examples/webgl_loader_md2.html
+++ b/examples/webgl_loader_md2.html
@@ -129,7 +129,6 @@
 
 				//
 
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.shadowMap.enabled = true;
 
 				// STATS

--- a/examples/webgl_loader_md2_control.html
+++ b/examples/webgl_loader_md2_control.html
@@ -138,7 +138,6 @@
 
 				//
 
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.shadowMap.enabled = true;
 				renderer.shadowMap.type = THREE.PCFSoftShadowMap;
 

--- a/examples/webgl_loader_obj_mtl.html
+++ b/examples/webgl_loader_obj_mtl.html
@@ -97,7 +97,6 @@
 				//
 
 				renderer = new THREE.WebGLRenderer();
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				container.appendChild( renderer.domElement );

--- a/examples/webgl_loader_ply.html
+++ b/examples/webgl_loader_ply.html
@@ -122,7 +122,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 
 				renderer.shadowMap.enabled = true;
 

--- a/examples/webgl_loader_stl.html
+++ b/examples/webgl_loader_stl.html
@@ -158,7 +158,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 
 				renderer.shadowMap.enabled = true;
 

--- a/examples/webgl_loader_svg.html
+++ b/examples/webgl_loader_svg.html
@@ -59,7 +59,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				container.appendChild( renderer.domElement );
 
 				//

--- a/examples/webgl_loader_texture_exr.html
+++ b/examples/webgl_loader_texture_exr.html
@@ -52,7 +52,6 @@
 				renderer.toneMapping = THREE.ReinhardToneMapping;
 				renderer.toneMappingExposure = params.exposure;
 
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 
 				scene = new THREE.Scene();
 

--- a/examples/webgl_loader_texture_hdr.html
+++ b/examples/webgl_loader_texture_hdr.html
@@ -52,7 +52,6 @@
 				renderer.toneMapping = THREE.ReinhardToneMapping;
 				renderer.toneMappingExposure = params.exposure;
 
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 
 				scene = new THREE.Scene();
 

--- a/examples/webgl_loader_texture_ktx2.html
+++ b/examples/webgl_loader_texture_ktx2.html
@@ -45,7 +45,6 @@
 
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setSize( width, height );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				document.body.appendChild( renderer.domElement );
 
 				window.addEventListener( 'resize', onWindowResize );

--- a/examples/webgl_loader_texture_logluv.html
+++ b/examples/webgl_loader_texture_logluv.html
@@ -51,7 +51,6 @@
 				renderer.toneMapping = THREE.ReinhardToneMapping;
 				renderer.toneMappingExposure = params.exposure;
 
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 
 				scene = new THREE.Scene();
 

--- a/examples/webgl_loader_texture_rgbm.html
+++ b/examples/webgl_loader_texture_rgbm.html
@@ -51,7 +51,6 @@
 				renderer.toneMapping = THREE.ReinhardToneMapping;
 				renderer.toneMappingExposure = params.exposure;
 
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 
 				scene = new THREE.Scene();
 

--- a/examples/webgl_loader_usdz.html
+++ b/examples/webgl_loader_usdz.html
@@ -66,7 +66,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				document.body.appendChild( renderer.domElement );
 
 				const controls = new OrbitControls( camera, renderer.domElement );

--- a/examples/webgl_marchingcubes.html
+++ b/examples/webgl_marchingcubes.html
@@ -106,7 +106,6 @@
 			// RENDERER
 
 			renderer = new THREE.WebGLRenderer();
-			renderer.outputColorSpace = THREE.SRGBColorSpace;
 			renderer.setPixelRatio( window.devicePixelRatio );
 			renderer.setSize( window.innerWidth, window.innerHeight );
 			container.appendChild( renderer.domElement );

--- a/examples/webgl_materials_bumpmap.html
+++ b/examples/webgl_materials_bumpmap.html
@@ -115,7 +115,6 @@
 				container.appendChild( renderer.domElement );
 
 				renderer.shadowMap.enabled = true;
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 
 				//
 

--- a/examples/webgl_materials_car.html
+++ b/examples/webgl_materials_car.html
@@ -73,7 +73,6 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setAnimationLoop( render );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				renderer.toneMappingExposure = 0.85;
 				container.appendChild( renderer.domElement );

--- a/examples/webgl_materials_cubemap_dynamic.html
+++ b/examples/webgl_materials_cubemap_dynamic.html
@@ -53,7 +53,6 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setAnimationLoop( animation );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				document.body.appendChild( renderer.domElement );
 

--- a/examples/webgl_materials_displacementmap.html
+++ b/examples/webgl_materials_displacementmap.html
@@ -119,7 +119,6 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				container.appendChild( renderer.domElement );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 
 				//
 

--- a/examples/webgl_materials_envmaps.html
+++ b/examples/webgl_materials_envmaps.html
@@ -79,7 +79,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				document.body.appendChild( renderer.domElement );
 
 				//

--- a/examples/webgl_materials_envmaps_exr.html
+++ b/examples/webgl_materials_envmaps_exr.html
@@ -68,7 +68,6 @@
 				container.appendChild( renderer.domElement );
 
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 
 				//
 

--- a/examples/webgl_materials_envmaps_groundprojected.html
+++ b/examples/webgl_materials_envmaps_groundprojected.html
@@ -133,7 +133,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 
 				//

--- a/examples/webgl_materials_envmaps_hdr.html
+++ b/examples/webgl_materials_envmaps_hdr.html
@@ -143,7 +143,6 @@
 				container.appendChild( renderer.domElement );
 
 				//renderer.toneMapping = ReinhardToneMapping;
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 
 				stats = new Stats();
 				container.appendChild( stats.dom );

--- a/examples/webgl_materials_lightmap.html
+++ b/examples/webgl_materials_lightmap.html
@@ -85,7 +85,6 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( innerWidth, innerHeight );
 				container.appendChild( renderer.domElement );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 
 				// CONTROLS
 

--- a/examples/webgl_materials_matcap.html
+++ b/examples/webgl_materials_matcap.html
@@ -56,7 +56,6 @@
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 			 	renderer.toneMappingExposure = API.exposure;
 
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 
 				// scene
 				scene = new THREE.Scene();

--- a/examples/webgl_materials_normalmap_object_space.html
+++ b/examples/webgl_materials_normalmap_object_space.html
@@ -46,7 +46,6 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				document.body.appendChild( renderer.domElement );
 
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 
 				// scene
 				scene = new THREE.Scene();

--- a/examples/webgl_materials_physical_clearcoat.html
+++ b/examples/webgl_materials_physical_clearcoat.html
@@ -190,7 +190,6 @@
 
 				//
 
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 
 				//
 

--- a/examples/webgl_materials_physical_reflectivity.html
+++ b/examples/webgl_materials_physical_reflectivity.html
@@ -156,7 +156,6 @@
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				container.appendChild( renderer.domElement );
 
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 
 				stats = new Stats();
 				container.appendChild( stats.dom );

--- a/examples/webgl_materials_physical_transmission.html
+++ b/examples/webgl_materials_physical_transmission.html
@@ -73,7 +73,6 @@
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				renderer.toneMappingExposure = params.exposure;
 
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 
 				scene = new THREE.Scene();
 

--- a/examples/webgl_materials_standard.html
+++ b/examples/webgl_materials_standard.html
@@ -56,7 +56,6 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				container.appendChild( renderer.domElement );
 
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.toneMapping = THREE.ReinhardToneMapping;
 				renderer.toneMappingExposure = 3;
 

--- a/examples/webgl_materials_subsurface_scattering.html
+++ b/examples/webgl_materials_subsurface_scattering.html
@@ -80,7 +80,6 @@
 			renderer.setPixelRatio( window.devicePixelRatio );
 			renderer.setSize( window.innerWidth, window.innerHeight );
 			container.appendChild( renderer.domElement );
-			renderer.outputColorSpace = THREE.SRGBColorSpace;
 
 			//
 

--- a/examples/webgl_materials_variations_basic.html
+++ b/examples/webgl_materials_variations_basic.html
@@ -160,7 +160,6 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				container.appendChild( renderer.domElement );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 
 				//
 

--- a/examples/webgl_materials_variations_lambert.html
+++ b/examples/webgl_materials_variations_lambert.html
@@ -160,7 +160,6 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				container.appendChild( renderer.domElement );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 
 				//
 

--- a/examples/webgl_materials_variations_phong.html
+++ b/examples/webgl_materials_variations_phong.html
@@ -167,7 +167,6 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				container.appendChild( renderer.domElement );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 
 				//
 

--- a/examples/webgl_materials_variations_physical.html
+++ b/examples/webgl_materials_variations_physical.html
@@ -169,7 +169,6 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				container.appendChild( renderer.domElement );
 
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				renderer.toneMappingExposure = 0.75;
 

--- a/examples/webgl_materials_variations_standard.html
+++ b/examples/webgl_materials_variations_standard.html
@@ -172,7 +172,6 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				container.appendChild( renderer.domElement );
 
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				renderer.toneMappingExposure = 0.75;
 

--- a/examples/webgl_materials_variations_toon.html
+++ b/examples/webgl_materials_variations_toon.html
@@ -67,7 +67,6 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				container.appendChild( renderer.domElement );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 
 				// Materials
 

--- a/examples/webgl_morphtargets.html
+++ b/examples/webgl_morphtargets.html
@@ -72,7 +72,6 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.useLegacyLights = false;
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.setAnimationLoop( function () {
 
 					renderer.render( scene, camera );

--- a/examples/webgl_morphtargets_face.html
+++ b/examples/webgl_morphtargets_face.html
@@ -68,7 +68,6 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 
 				container.appendChild( renderer.domElement );
 

--- a/examples/webgl_morphtargets_horse.html
+++ b/examples/webgl_morphtargets_horse.html
@@ -98,7 +98,6 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.useLegacyLights = false;
 
 				container.appendChild( renderer.domElement );

--- a/examples/webgl_morphtargets_sphere.html
+++ b/examples/webgl_morphtargets_sphere.html
@@ -95,7 +95,6 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.useLegacyLights = false;
 
 				container.appendChild( renderer.domElement );

--- a/examples/webgl_nodes_loader_gltf_iridescence.html
+++ b/examples/webgl_nodes_loader_gltf_iridescence.html
@@ -52,7 +52,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				renderer.setAnimationLoop( render );
 				document.body.appendChild( renderer.domElement );

--- a/examples/webgl_nodes_loader_gltf_sheen.html
+++ b/examples/webgl_nodes_loader_gltf_sheen.html
@@ -85,7 +85,6 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				renderer.toneMappingExposure = 1;
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				container.appendChild( renderer.domElement );
 
 				const environment = new RoomEnvironment();

--- a/examples/webgl_nodes_loader_gltf_transmission.html
+++ b/examples/webgl_nodes_loader_gltf_transmission.html
@@ -110,7 +110,6 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				renderer.toneMappingExposure = 1;
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				container.appendChild( renderer.domElement );
 
 				controls = new OrbitControls( camera, renderer.domElement );

--- a/examples/webgl_nodes_loader_materialx.html
+++ b/examples/webgl_nodes_loader_materialx.html
@@ -88,7 +88,6 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.toneMapping = THREE.LinearToneMapping;
 				renderer.toneMappingExposure = .5;
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.setAnimationLoop( render );
 				container.appendChild( renderer.domElement );
 

--- a/examples/webgl_nodes_materials_physical_clearcoat.html
+++ b/examples/webgl_nodes_materials_physical_clearcoat.html
@@ -188,7 +188,6 @@
 
 				//
 
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 
 				//
 

--- a/examples/webgl_nodes_materials_standard.html
+++ b/examples/webgl_nodes_materials_standard.html
@@ -58,7 +58,6 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				container.appendChild( renderer.domElement );
 
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.toneMapping = THREE.ReinhardToneMapping;
 				renderer.toneMappingExposure = 3;
 

--- a/examples/webgl_nodes_materialx_noise.html
+++ b/examples/webgl_nodes_materialx_noise.html
@@ -141,7 +141,6 @@
 
 				//
 
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 
 				//
 

--- a/examples/webgl_pmrem_test.html
+++ b/examples/webgl_pmrem_test.html
@@ -54,7 +54,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( width, height );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.useLegacyLights = false;
 
 				// tonemapping

--- a/examples/webgl_raycaster_bvh.html
+++ b/examples/webgl_raycaster_bvh.html
@@ -99,7 +99,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				document.body.appendChild( renderer.domElement );
 
 				stats = new Stats();

--- a/examples/webgl_renderer_pathtracer.html
+++ b/examples/webgl_renderer_pathtracer.html
@@ -104,7 +104,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true, preserveDrawingBuffer: true, premultipliedAlpha: false } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				renderer.setClearColor( 0xdddddd );
 				document.body.appendChild( renderer.domElement );

--- a/examples/webgl_shaders_sky.html
+++ b/examples/webgl_shaders_sky.html
@@ -107,7 +107,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				renderer.toneMappingExposure = 0.5;
 				document.body.appendChild( renderer.domElement );

--- a/examples/webgl_shadowmap.html
+++ b/examples/webgl_shadowmap.html
@@ -111,7 +111,6 @@
 				renderer.setSize( SCREEN_WIDTH, SCREEN_HEIGHT );
 				container.appendChild( renderer.domElement );
 
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.autoClear = false;
 
 				//

--- a/examples/webgl_shadowmap_pcss.html
+++ b/examples/webgl_shadowmap_pcss.html
@@ -255,7 +255,6 @@
 
 				container.appendChild( renderer.domElement );
 
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.shadowMap.enabled = true;
 
 				// controls

--- a/examples/webgl_shadowmap_performance.html
+++ b/examples/webgl_shadowmap_performance.html
@@ -105,7 +105,6 @@
 				renderer.setSize( SCREEN_WIDTH, SCREEN_HEIGHT );
 				container.appendChild( renderer.domElement );
 
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.autoClear = false;
 
 				//

--- a/examples/webgl_tonemapping.html
+++ b/examples/webgl_tonemapping.html
@@ -71,7 +71,6 @@
 				renderer.toneMapping = toneMappingOptions[ params.toneMapping ];
 				renderer.toneMappingExposure = params.exposure;
 
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 
 				// Set CustomToneMapping to Uncharted2
 				// source: http://filmicworlds.com/blog/filmic-tonemapping-operators/

--- a/examples/webgpu_cubemap_adjustments.html
+++ b/examples/webgpu_cubemap_adjustments.html
@@ -153,7 +153,6 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.toneMappingNode = toneMapping( THREE.LinearToneMapping, 1 );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.setAnimationLoop( render );
 				container.appendChild( renderer.domElement );
 

--- a/examples/webgpu_cubemap_mix.html
+++ b/examples/webgpu_cubemap_mix.html
@@ -98,7 +98,6 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.toneMappingNode = toneMapping( THREE.LinearToneMapping, 1 );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.setAnimationLoop( render );
 				container.appendChild( renderer.domElement );
 

--- a/examples/webgpu_lights_custom.html
+++ b/examples/webgpu_lights_custom.html
@@ -124,7 +124,6 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setAnimationLoop( animate );
 				renderer.toneMappingNode = toneMapping( THREE.LinearToneMapping, 1 );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				document.body.appendChild( renderer.domElement );
 
 				// controls

--- a/examples/webgpu_lights_ies_spotlight.html
+++ b/examples/webgpu_lights_ies_spotlight.html
@@ -128,7 +128,6 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setAnimationLoop( render );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				document.body.appendChild( renderer.domElement );
 
 				camera = new THREE.PerspectiveCamera( 35, window.innerWidth / window.innerHeight, .1, 100 );

--- a/examples/webgpu_lights_phong.html
+++ b/examples/webgpu_lights_phong.html
@@ -137,7 +137,6 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				renderer.toneMappingExposure = .2;
 

--- a/examples/webgpu_lights_selective.html
+++ b/examples/webgpu_lights_selective.html
@@ -139,7 +139,6 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				renderer.toneMappingExposure = .2;
 

--- a/examples/webgpu_loader_gltf.html
+++ b/examples/webgpu_loader_gltf.html
@@ -114,7 +114,6 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setAnimationLoop( render );
 				renderer.toneMappingNode = toneMapping( THREE.LinearToneMapping, 1 );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				container.appendChild( renderer.domElement );
 
 				const controls = new OrbitControls( camera, renderer.domElement );

--- a/examples/webgpu_skinning.html
+++ b/examples/webgpu_skinning.html
@@ -85,7 +85,6 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setAnimationLoop( animate );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.toneMappingNode = toneMapping( THREE.LinearToneMapping, .15 );
 				document.body.appendChild( renderer.domElement );
 

--- a/examples/webgpu_skinning_instancing.html
+++ b/examples/webgpu_skinning_instancing.html
@@ -130,7 +130,6 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setAnimationLoop( animate );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.toneMappingNode = toneMapping( THREE.LinearToneMapping, .17 );
 				document.body.appendChild( renderer.domElement );
 

--- a/examples/webgpu_skinning_points.html
+++ b/examples/webgpu_skinning_points.html
@@ -94,7 +94,6 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setAnimationLoop( animate );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				document.body.appendChild( renderer.domElement );
 
 				window.addEventListener( 'resize', onWindowResize );

--- a/examples/webxr_ar_lighting.html
+++ b/examples/webxr_ar_lighting.html
@@ -58,7 +58,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true, alpha: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.useLegacyLights = false;
 				renderer.xr.enabled = true;
 				container.appendChild( renderer.domElement );

--- a/examples/webxr_vr_handinput.html
+++ b/examples/webxr_vr_handinput.html
@@ -84,7 +84,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.shadowMap.enabled = true;
 				renderer.xr.enabled = true;
 

--- a/examples/webxr_vr_handinput_cubes.html
+++ b/examples/webxr_vr_handinput_cubes.html
@@ -97,7 +97,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.shadowMap.enabled = true;
 				renderer.xr.enabled = true;
 

--- a/examples/webxr_vr_handinput_pointerclick.html
+++ b/examples/webxr_vr_handinput_pointerclick.html
@@ -318,7 +318,6 @@
 			renderer = new THREE.WebGLRenderer( { antialias: true } );
 			renderer.setPixelRatio( window.devicePixelRatio );
 			renderer.setSize( window.innerWidth, window.innerHeight );
-			renderer.outputColorSpace = THREE.SRGBColorSpace;
 			renderer.shadowMap.enabled = true;
 			renderer.xr.enabled = true;
 			renderer.xr.cameraAutoUpdate = false;

--- a/examples/webxr_vr_handinput_pointerdrag.html
+++ b/examples/webxr_vr_handinput_pointerdrag.html
@@ -421,7 +421,6 @@
 			renderer = new THREE.WebGLRenderer( { antialias: true } );
 			renderer.setPixelRatio( window.devicePixelRatio );
 			renderer.setSize( window.innerWidth, window.innerHeight );
-			renderer.outputColorSpace = THREE.SRGBColorSpace;
 			renderer.shadowMap.enabled = true;
 			renderer.xr.enabled = true;
 			renderer.xr.cameraAutoUpdate = false;

--- a/examples/webxr_vr_handinput_pressbutton.html
+++ b/examples/webxr_vr_handinput_pressbutton.html
@@ -378,7 +378,6 @@
 			renderer = new THREE.WebGLRenderer( { antialias: true } );
 			renderer.setPixelRatio( window.devicePixelRatio );
 			renderer.setSize( window.innerWidth, window.innerHeight );
-			renderer.outputColorSpace = THREE.SRGBColorSpace;
 			renderer.shadowMap.enabled = true;
 			renderer.xr.enabled = true;
 			renderer.xr.cameraAutoUpdate = false;

--- a/examples/webxr_vr_handinput_profiles.html
+++ b/examples/webxr_vr_handinput_profiles.html
@@ -91,7 +91,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.shadowMap.enabled = true;
 				renderer.xr.enabled = true;
 

--- a/examples/webxr_vr_layers.html
+++ b/examples/webxr_vr_layers.html
@@ -130,7 +130,6 @@
 				renderer.setClearAlpha( 1 );
 				renderer.setClearColor( new THREE.Color( 0 ), 0 );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.xr.enabled = true;
 
 				document.body.appendChild( renderer.domElement );

--- a/examples/webxr_vr_teleport.html
+++ b/examples/webxr_vr_teleport.html
@@ -82,7 +82,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 
 				renderer.xr.addEventListener( 'sessionstart', () => baseReferenceSpace = renderer.xr.getReferenceSpace() );
 				renderer.xr.enabled = true;

--- a/examples/webxr_xr_ballshooter.html
+++ b/examples/webxr_xr_ballshooter.html
@@ -94,7 +94,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.xr.enabled = true;
 				document.body.appendChild( renderer.domElement );
 

--- a/examples/webxr_xr_cubes.html
+++ b/examples/webxr_xr_cubes.html
@@ -103,7 +103,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.xr.enabled = true;
 				container.appendChild( renderer.domElement );
 

--- a/examples/webxr_xr_dragging.html
+++ b/examples/webxr_xr_dragging.html
@@ -126,7 +126,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.shadowMap.enabled = true;
 				renderer.xr.enabled = true;
 				container.appendChild( renderer.domElement );

--- a/examples/webxr_xr_haptics.html
+++ b/examples/webxr_xr_haptics.html
@@ -144,7 +144,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.shadowMap.enabled = true;
 				renderer.xr.enabled = true;
 				container.appendChild( renderer.domElement );

--- a/examples/webxr_xr_paint.html
+++ b/examples/webxr_xr_paint.html
@@ -79,7 +79,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.xr.enabled = true;
 				container.appendChild( renderer.domElement );
 

--- a/examples/webxr_xr_sculpt.html
+++ b/examples/webxr_xr_sculpt.html
@@ -73,7 +73,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.outputColorSpace = THREE.SRGBColorSpace;
 				renderer.xr.enabled = true;
 				container.appendChild( renderer.domElement );
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/23614#issuecomment-1500821175

**Description**

Since `THREE.SRGBColorSpace` is now the new default of `WebGLRenderer.outputColorSpace`, there is no need anymore to explicitly set the value.

As a reminder: To avoid verbose and redundant code, the policy is to not set default values.