### PR TITLE
Add whole build folder to files field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,11 +22,7 @@
   },
   "sideEffects": false,
   "files": [
-    "build/three.js",
-    "build/three.cjs",
-    "build/three.min.js",
-    "build/three.module.js",
-    "build/three.module.min.js",
+    "build",
     "examples/jsm",
     "examples/fonts",
     "LICENSE",


### PR DESCRIPTION
Related issue: #25778

**Description**

It's better to add the whole `build` folder to the npm published files, it will avoid having to remember to update it manually in the future like in #25778