### PR TITLE
Color.getHex() and .getStyle(): Fix rounding errors

### DIFF
--- a/src/math/Color.js
+++ b/src/math/Color.js
@@ -94,7 +94,7 @@ class Color {
 
 	setHex( hex, colorSpace = SRGBColorSpace ) {
 
-		hex = Math.round( hex );
+		hex = Math.floor( hex );
 
 		this.r = ( hex >> 16 & 255 ) / 255;
 		this.g = ( hex >> 8 & 255 ) / 255;
@@ -347,7 +347,7 @@ class Color {
 
 		ColorManagement.fromWorkingColorSpace( _color.copy( this ), colorSpace );
 
-		return clamp( _color.r * 255, 0, 255 ) << 16 ^ clamp( _color.g * 255, 0, 255 ) << 8 ^ clamp( _color.b * 255, 0, 255 ) << 0;
+		return Math.round( clamp( _color.r * 255, 0, 255 ) ) << 16 + Math.round( clamp( _color.g * 255, 0, 255 ) ) << 8 + Math.round( clamp( _color.b * 255, 0, 255 ) );
 
 	}
 

--- a/src/math/Color.js
+++ b/src/math/Color.js
@@ -427,7 +427,7 @@ class Color {
 
 		}
 
-		return `rgb(${( r * 255 ) | 0},${( g * 255 ) | 0},${( b * 255 ) | 0})`;
+		return `rgb(${ Math.round( r * 255 ) },${ Math.round( g * 255 ) },${ Math.round( b * 255 ) })`;
 
 	}
 

--- a/src/math/Color.js
+++ b/src/math/Color.js
@@ -347,7 +347,7 @@ class Color {
 
 		ColorManagement.fromWorkingColorSpace( _color.copy( this ), colorSpace );
 
-		return Math.round( clamp( _color.r * 255, 0, 255 ) ) << 16 + Math.round( clamp( _color.g * 255, 0, 255 ) ) << 8 + Math.round( clamp( _color.b * 255, 0, 255 ) );
+		return Math.round( clamp( _color.r * 255, 0, 255 ) ) * 65536 + Math.round( clamp( _color.g * 255, 0, 255 ) ) * 256 + Math.round( clamp( _color.b * 255, 0, 255 ) );
 
 	}
 

--- a/src/math/Color.js
+++ b/src/math/Color.js
@@ -94,7 +94,7 @@ class Color {
 
 	setHex( hex, colorSpace = SRGBColorSpace ) {
 
-		hex = Math.floor( hex );
+		hex = Math.round( hex );
 
 		this.r = ( hex >> 16 & 255 ) / 255;
 		this.g = ( hex >> 8 & 255 ) / 255;

--- a/test/unit/src/math/Color.tests.js
+++ b/test/unit/src/math/Color.tests.js
@@ -511,7 +511,7 @@ export default QUnit.module( 'Maths', () => {
 			const d = new Color( 1.0, 1.0, 1.0 );
 
 			assert.strictEqual( a.toJSON(), 0x000000, 'Check black' );
-			assert.strictEqual( b.toJSON(), 0x007F00, 'Check half-blue' );
+			assert.strictEqual( b.toJSON(), 0x008000, 'Check half-blue' );
 			assert.strictEqual( c.toJSON(), 0xFF0000, 'Check red' );
 			assert.strictEqual( d.toJSON(), 0xFFFFFF, 'Check white' );
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/25830#issuecomment-1506905962 and below

**Description**

This should be the simplest and the most correct fix.