### PR TITLE
Fix wireframe toggle not being respected in md2 loader example

### DIFF
--- a/examples/webgl_loader_md2.html
+++ b/examples/webgl_loader_md2.html
@@ -246,7 +246,7 @@
 					return function () {
 
 						character.setWeapon( index );
-						character.setWireframe(playbackConfig.wireframe)
+						character.setWireframe( playbackConfig.wireframe );
 
 					};
 

--- a/examples/webgl_loader_md2.html
+++ b/examples/webgl_loader_md2.html
@@ -246,6 +246,7 @@
 					return function () {
 
 						character.setWeapon( index );
+						character.setWireframe(playbackConfig.wireframe)
 
 					};
 


### PR DESCRIPTION
Related issue: none

**Description**

When checking the wireframe option you can see the wireframe of the model. If the user changes the weapon this newly selected weapon model won't respect the wireframe option. Example:

https://user-images.githubusercontent.com/22588915/232128128-eb037a53-3d34-4e6d-b97d-79c74d9c7ddf.mp4

<hr/>

This change ensures the wireframe option is respected. Example:

https://user-images.githubusercontent.com/22588915/232128120-e10aed57-33e8-4295-a0db-caf0a67b6a74.mp4
