### PR TITLE
blurred reflection in mirror example

### DIFF
--- a/examples/jsm/objects/Reflector.js
+++ b/examples/jsm/objects/Reflector.js
@@ -41,7 +41,7 @@ class Reflector extends Mesh {
 
 		this.blurX = options.blurX || 2;
 		this.blurY = options.blurY || this.blurX;
-		this.depthScale = ( options.depthScale !== undefined ) ? options.depthScale : 3;
+		this.depthScale = ( options.depthScale !== undefined ) ? options.depthScale : 0;
 
 		//
 
@@ -61,8 +61,8 @@ class Reflector extends Mesh {
 		const virtualCamera = this.camera;
 
 		const renderTarget = new WebGLRenderTarget( textureWidth, textureHeight, { samples: multisample, type: HalfFloatType } );
-		const renderTargetBlur = renderTarget.clone();
-		const renderTargetDepth = renderTarget.clone();
+		const renderTargetBlur = new WebGLRenderTarget( Math.min( textureWidth >> 1, 1024 ), Math.min( textureHeight >> 1, 1024 ) );
+		const renderTargetDepth = renderTargetBlur.clone();
 
 		const effectHBlur = new ShaderPass( HorizontalBlurShader );
 		const effectVBlur = new ShaderPass( VerticalBlurShader );

--- a/examples/jsm/objects/Reflector.js
+++ b/examples/jsm/objects/Reflector.js
@@ -66,6 +66,7 @@ class Reflector extends Mesh {
 
 		const effectHBlur = new ShaderPass( HorizontalBlurShader );
 		const effectVBlur = new ShaderPass( VerticalBlurShader );
+		const depthMaterial = new MeshDepthMaterial();
 
 		const material = new ShaderMaterial( {
 			uniforms: UniformsUtils.clone( shader.uniforms ),
@@ -186,7 +187,7 @@ class Reflector extends Mesh {
 				effectVBlur.render( renderer, renderTargetBlur, renderTargetDepth );
 
 				const overrideMaterial = scene.overrideMaterial;
-				scene.overrideMaterial = new MeshDepthMaterial();
+				scene.overrideMaterial = depthMaterial;
 				renderer.setRenderTarget( renderTargetDepth );
 				renderer.render( scene, virtualCamera );
 				scene.overrideMaterial = overrideMaterial;

--- a/examples/jsm/objects/Reflector.js
+++ b/examples/jsm/objects/Reflector.js
@@ -226,6 +226,11 @@ class Reflector extends Mesh {
 		this.dispose = function () {
 
 			renderTarget.dispose();
+			renderTargetBlur.dispose();
+			renderTargetDepth.dispose();
+			depthMaterial.dispose();
+			effectHBlur.dispose();
+			effectVBlur.dispose();
 			scope.material.dispose();
 
 		};

--- a/examples/webgl_mirror.html
+++ b/examples/webgl_mirror.html
@@ -39,6 +39,7 @@
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { Reflector } from 'three/addons/objects/Reflector.js';
+			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 
 			let camera, scene, renderer;
 
@@ -88,6 +89,7 @@
 				geometry = new THREE.CircleGeometry( 40, 64 );
 				groundMirror = new Reflector( geometry, {
 					clipBias: 0.003,
+					depthScale: 0,
 					textureWidth: window.innerWidth * window.devicePixelRatio,
 					textureHeight: window.innerHeight * window.devicePixelRatio,
 					color: 0xb5b5b5
@@ -106,6 +108,12 @@
 				verticalMirror.position.y = 50;
 				verticalMirror.position.z = - 50;
 				scene.add( verticalMirror );
+
+
+				const gui = new GUI();
+				gui.add( verticalMirror, 'blurX' ).min( 1 ).max( 3 );
+				gui.add( verticalMirror, 'blurY' ).min( 1 ).max( 3 );
+				gui.add( verticalMirror, 'depthScale' ).min( 0 ).max( 6 );
 
 
 				sphereGroup = new THREE.Object3D();

--- a/examples/webgl_mirror.html
+++ b/examples/webgl_mirror.html
@@ -40,6 +40,9 @@
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { Reflector } from 'three/addons/objects/Reflector.js';
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
+			import Stats from 'three/addons/libs/stats.module.js';
+
+			let stats;
 
 			let camera, scene, renderer;
 
@@ -65,6 +68,11 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				container.appendChild( renderer.domElement );
 
+				stats = new Stats();
+				stats.domElement.style.position = 'absolute';
+				stats.domElement.style.top = '0px';
+				container.appendChild( stats.domElement );
+
 				// scene
 				scene = new THREE.Scene();
 
@@ -89,7 +97,6 @@
 				geometry = new THREE.CircleGeometry( 40, 64 );
 				groundMirror = new Reflector( geometry, {
 					clipBias: 0.003,
-					depthScale: 0,
 					textureWidth: window.innerWidth * window.devicePixelRatio,
 					textureHeight: window.innerHeight * window.devicePixelRatio,
 					color: 0xb5b5b5
@@ -101,6 +108,7 @@
 				geometry = new THREE.PlaneGeometry( 100, 100 );
 				verticalMirror = new Reflector( geometry, {
 					clipBias: 0.003,
+					depthScale: 3,
 					textureWidth: window.innerWidth * window.devicePixelRatio,
 					textureHeight: window.innerHeight * window.devicePixelRatio,
 					color: 0xc1cbcb
@@ -223,6 +231,8 @@
 				smallSphere.rotation.z = timer * 0.8;
 
 				renderer.render( scene, camera );
+
+				stats.update();
 
 			}
 


### PR DESCRIPTION
This seems to be a popular request, e g it was asked enough times for r3f people to [backport their MeshReflectionMaterial to vanilla 3js](https://vis-prime.github.io/explore-vanilla-drei/?scene=MeshReflectionMaterial), so I thought why not patch Reflector to support it? This PR adds 3 params - blurX/Y and depthScale - and zero depthScale removes rendering overhead (makes Reflector performance same as now). Blur code is based on ShaderPass (I just copied it from some another example).

![Screenshot 2023-04-15 at 04-18-22 three js webgl - mirror](https://user-images.githubusercontent.com/242577/232178671-6b3407cb-cd78-434c-8637-a68616e5472b.png)

[rawgithack](https://raw.githack.com/makc/three.js.fork/reflector-blur/examples/webgl_mirror.html) to try it live