### PR TITLE
WebGPUNodes: Fix equirectUV background

### DIFF
--- a/examples/jsm/renderers/webgpu/nodes/WebGPUNodes.js
+++ b/examples/jsm/renderers/webgpu/nodes/WebGPUNodes.js
@@ -1,6 +1,6 @@
 import WebGPUNodeBuilder from './WebGPUNodeBuilder.js';
 import { NoToneMapping, EquirectangularReflectionMapping, EquirectangularRefractionMapping } from 'three';
-import { NodeFrame, vec2, cubeTexture, texture, rangeFog, densityFog, reference, toneMapping, positionWorld, modelWorldMatrix, transformDirection, equirectUV, oneMinus, viewportBottomLeft } from 'three/nodes';
+import { NodeFrame, cubeTexture, texture, rangeFog, densityFog, reference, toneMapping, positionWorld, modelWorldMatrix, transformDirection, equirectUV, viewportBottomLeft } from 'three/nodes';
 
 class WebGPUNodes {
 
@@ -145,10 +145,7 @@ class WebGPUNodes {
 
 					if ( background.mapping === EquirectangularReflectionMapping || background.mapping === EquirectangularRefractionMapping ) {
 
-						const dirNode = transformDirection( positionWorld, modelWorldMatrix );
-
-						nodeUV = equirectUV( dirNode );
-						nodeUV = vec2( nodeUV.x, oneMinus( nodeUV.y ) );
+						nodeUV = equirectUV();
 
 					} else {
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/25822

**Description**

There was a simplification made to `positionWorldDirection` that we can use here.

