### PR TITLE
module location fix

### DIFF
--- a/docs/manual/en/introduction/WebGL-compatibility-check.html
+++ b/docs/manual/en/introduction/WebGL-compatibility-check.html
@@ -15,7 +15,7 @@
 		</p>
 
 		<code>
-		import WebGL from 'three/addons/capabilities/WebGL.js';
+		import WebGL from 'three/examples/jsm/capabilities/WebGL';
 
 		if ( WebGL.isWebGLAvailable() ) {
 


### PR DESCRIPTION
There was mistake in location of WebGL.js location, maybe it wasn't updated.

Related issue: #XXXX

**Description**

A clear and concise description of what the problem was and how this pull request solves it.
the WebGL was being imported from 'three/addons/capabilities/WebGL.js' in docs
while it was located at 'three/examples/jsm/capabilities/WebGL.js'
