### PR TITLE
Examples: Disable THREE.ColorManagement on remaining legacy examples

### DIFF
--- a/examples/webgl_framebuffer_texture.html
+++ b/examples/webgl_framebuffer_texture.html
@@ -55,6 +55,8 @@
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import * as GeometryUtils from 'three/addons/utils/GeometryUtils.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			let camera, scene, renderer;
 			let line, sprite, texture;
 

--- a/examples/webgl_geometry_colors_lookuptable.html
+++ b/examples/webgl_geometry_colors_lookuptable.html
@@ -46,6 +46,8 @@
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { Lut } from 'three/addons/math/Lut.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			let container;
 
 			let perpCamera, orthoCamera, renderer, lut;

--- a/examples/webgl_geometry_extrude_shapes2.html
+++ b/examples/webgl_geometry_extrude_shapes2.html
@@ -38,6 +38,8 @@
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			// From d3-threeD.js
 			/* This Source Code Form is subject to the terms of the Mozilla Public
 			 * License, v. 2.0. If a copy of the MPL was not distributed with this file,

--- a/examples/webgl_geometry_minecraft.html
+++ b/examples/webgl_geometry_minecraft.html
@@ -43,6 +43,8 @@
 			import { ImprovedNoise } from 'three/addons/math/ImprovedNoise.js';
 			import * as BufferGeometryUtils from 'three/addons/utils/BufferGeometryUtils.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			let container, stats;
 
 			let camera, controls, scene, renderer;

--- a/examples/webgl_geometry_text.html
+++ b/examples/webgl_geometry_text.html
@@ -36,6 +36,7 @@
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 
 			THREE.Cache.enabled = true;
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
 
 			let container;
 

--- a/examples/webgl_gpgpu_birds_gltf.html
+++ b/examples/webgl_gpgpu_birds_gltf.html
@@ -228,6 +228,8 @@
 			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 			import { GPUComputationRenderer } from 'three/addons/misc/GPUComputationRenderer.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			/* TEXTURE WIDTH FOR SIMULATION */
 			const WIDTH = 64;
 			const BIRDS = WIDTH * WIDTH;

--- a/examples/webgl_gpgpu_protoplanet.html
+++ b/examples/webgl_gpgpu_protoplanet.html
@@ -251,6 +251,8 @@
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { GPUComputationRenderer } from 'three/addons/misc/GPUComputationRenderer.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			// Texture width for simulation (each texel is a debris particle)
 			const WIDTH = 64;
 

--- a/examples/webgl_gpgpu_water.html
+++ b/examples/webgl_gpgpu_water.html
@@ -267,6 +267,8 @@
 			import { GPUComputationRenderer } from 'three/addons/misc/GPUComputationRenderer.js';
 			import { SimplexNoise } from 'three/addons/math/SimplexNoise.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			// Texture width for simulation
 			const WIDTH = 128;
 

--- a/examples/webgl_loader_3mf.html
+++ b/examples/webgl_loader_3mf.html
@@ -40,6 +40,8 @@
 			import { ThreeMFLoader } from 'three/addons/loaders/3MFLoader.js';
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			let camera, scene, renderer, object, loader, controls;
 
 			const params = {

--- a/examples/webgl_loader_ifc.html
+++ b/examples/webgl_loader_ifc.html
@@ -42,6 +42,8 @@
 			import { IFCLoader } from 'web-ifc-three';
 			import { IFCSPACE } from 'web-ifc';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			let scene, camera, renderer;
 
 			async function init() {

--- a/examples/webgl_loader_mmd.html
+++ b/examples/webgl_loader_mmd.html
@@ -52,6 +52,8 @@
 			import { MMDLoader } from 'three/addons/loaders/MMDLoader.js';
 			import { MMDAnimationHelper } from 'three/addons/animation/MMDAnimationHelper.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			let stats;
 
 			let mesh, camera, scene, renderer, effect;

--- a/examples/webgl_loader_mmd_audio.html
+++ b/examples/webgl_loader_mmd_audio.html
@@ -53,6 +53,8 @@
 			import { MMDLoader } from 'three/addons/loaders/MMDLoader.js';
 			import { MMDAnimationHelper } from 'three/addons/animation/MMDAnimationHelper.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			let mesh, camera, scene, renderer, effect;
 			let helper;
 

--- a/examples/webgl_loader_mmd_pose.html
+++ b/examples/webgl_loader_mmd_pose.html
@@ -50,6 +50,8 @@
 			import { MMDLoader } from 'three/addons/loaders/MMDLoader.js';
 			import { MMDAnimationHelper } from 'three/addons/animation/MMDAnimationHelper.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			let camera, scene, renderer, effect;
 			let mesh, helper;
 

--- a/examples/webgl_loader_nrrd.html
+++ b/examples/webgl_loader_nrrd.html
@@ -38,6 +38,8 @@
 			import { NRRDLoader } from 'three/addons/loaders/NRRDLoader.js';
 			import { VTKLoader } from 'three/addons/loaders/VTKLoader.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			let container,
 				stats,
 				camera,

--- a/examples/webgl_loader_ttf.html
+++ b/examples/webgl_loader_ttf.html
@@ -33,6 +33,8 @@
 			import { Font } from 'three/addons/loaders/FontLoader.js';
 			import { TextGeometry } from 'three/addons/geometries/TextGeometry.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			let container;
 			let camera, cameraTarget, scene, renderer;
 			let group, textMesh1, textMesh2, textGeo, material;

--- a/examples/webgl_loader_vrml.html
+++ b/examples/webgl_loader_vrml.html
@@ -35,6 +35,8 @@
 			import { VRMLLoader } from 'three/addons/loaders/VRMLLoader.js';
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			let camera, scene, renderer, stats, controls, loader;
 
 			const params = {

--- a/examples/webgl_materials.html
+++ b/examples/webgl_materials.html
@@ -30,6 +30,8 @@
 
 			import Stats from 'three/addons/libs/stats.module.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			let stats;
 
 			let camera, scene, renderer;

--- a/examples/webgl_materials_blending.html
+++ b/examples/webgl_materials_blending.html
@@ -25,6 +25,8 @@
 
 			import * as THREE from 'three';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			let camera, scene, renderer;
 			let mapBg;
 

--- a/examples/webgl_materials_blending_custom.html
+++ b/examples/webgl_materials_blending_custom.html
@@ -27,6 +27,8 @@
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			let camera, scene, renderer;
 
 			let mapBg;

--- a/examples/webgl_materials_cubemap.html
+++ b/examples/webgl_materials_cubemap.html
@@ -36,6 +36,8 @@
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { OBJLoader } from 'three/addons/loaders/OBJLoader.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			let container, stats;
 
 			let camera, scene, renderer;

--- a/examples/webgl_materials_cubemap_mipmaps.html
+++ b/examples/webgl_materials_cubemap_mipmaps.html
@@ -34,6 +34,8 @@
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			let container;
 
 			let camera, scene, renderer;

--- a/examples/webgl_materials_cubemap_refraction.html
+++ b/examples/webgl_materials_cubemap_refraction.html
@@ -35,6 +35,8 @@
 
 			import { PLYLoader } from 'three/addons/loaders/PLYLoader.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			let container, stats;
 
 			let camera, scene, renderer;

--- a/examples/webgl_materials_texture_filters.html
+++ b/examples/webgl_materials_texture_filters.html
@@ -60,6 +60,8 @@
 
 			import * as THREE from 'three';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			const SCREEN_WIDTH = window.innerWidth;
 			const SCREEN_HEIGHT = window.innerHeight;
 

--- a/examples/webgl_materials_texture_manualmipmap.html
+++ b/examples/webgl_materials_texture_manualmipmap.html
@@ -60,6 +60,8 @@
 
 			import * as THREE from 'three';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			const SCREEN_WIDTH = window.innerWidth;
 			const SCREEN_HEIGHT = window.innerHeight;
 

--- a/examples/webgl_materials_wireframe.html
+++ b/examples/webgl_materials_wireframe.html
@@ -68,6 +68,8 @@
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			const API = {
 				thickness: 1
 			};

--- a/examples/webgl_mirror.html
+++ b/examples/webgl_mirror.html
@@ -40,6 +40,8 @@
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { Reflector } from 'three/addons/objects/Reflector.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			let camera, scene, renderer;
 
 			let cameraControls;

--- a/examples/webgl_modifier_curve.html
+++ b/examples/webgl_modifier_curve.html
@@ -35,6 +35,8 @@
 			import { FontLoader } from 'three/addons/loaders/FontLoader.js';
 			import { TextGeometry } from 'three/addons/geometries/TextGeometry.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			const ACTION_SELECT = 1, ACTION_NONE = 0;
 			const curveHandles = [];
 			const mouse = new THREE.Vector2();

--- a/examples/webgl_modifier_curve_instanced.html
+++ b/examples/webgl_modifier_curve_instanced.html
@@ -35,6 +35,8 @@
 			import { FontLoader } from 'three/addons/loaders/FontLoader.js';
 			import { TextGeometry } from 'three/addons/geometries/TextGeometry.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			const ACTION_SELECT = 1, ACTION_NONE = 0;
 			const curveHandles = [];
 			const mouse = new THREE.Vector2();

--- a/examples/webgl_modifier_edgesplit.html
+++ b/examples/webgl_modifier_edgesplit.html
@@ -32,6 +32,8 @@
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			let renderer, scene, camera;
 			let modifier, mesh, baseGeometry;
 			let map;

--- a/examples/webgl_modifier_simplifier.html
+++ b/examples/webgl_modifier_simplifier.html
@@ -29,6 +29,8 @@
 			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 			import { SimplifyModifier } from 'three/addons/modifiers/SimplifyModifier.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			let renderer, scene, camera;
 
 			init();

--- a/examples/webgl_multiple_canvases_circle.html
+++ b/examples/webgl_multiple_canvases_circle.html
@@ -147,6 +147,8 @@
 	<script type="module">
 		import * as THREE from 'three';
 
+		THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 		const views = [];
 
 		let scene, renderer;

--- a/examples/webgl_multiple_canvases_complex.html
+++ b/examples/webgl_multiple_canvases_complex.html
@@ -65,6 +65,8 @@
 
 			import * as THREE from 'three';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			const views = [];
 
 			let scene, renderer;

--- a/examples/webgl_multiple_canvases_grid.html
+++ b/examples/webgl_multiple_canvases_grid.html
@@ -82,6 +82,8 @@
 
 			import * as THREE from 'three';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			const views = [];
 
 			let scene, renderer;

--- a/examples/webgl_multiple_elements_text.html
+++ b/examples/webgl_multiple_elements_text.html
@@ -98,6 +98,8 @@
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			const scenes = [];
 
 			const clock = new THREE.Clock();

--- a/examples/webgl_multiple_renderers.html
+++ b/examples/webgl_multiple_renderers.html
@@ -36,6 +36,8 @@
 
 			import * as THREE from 'three';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			let camera, scene, renderer1, renderer2;
 
 			let mesh1, mesh2, mesh3;

--- a/examples/webgl_nodes_points.html
+++ b/examples/webgl_nodes_points.html
@@ -41,6 +41,8 @@
 
 			import { nodeFrame } from 'three/addons/renderers/webgl/nodes/WebGLNodes.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			let camera, scene, renderer, stats;
 
 			init();

--- a/examples/webgl_points_billboards.html
+++ b/examples/webgl_points_billboards.html
@@ -33,6 +33,8 @@
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			let camera, scene, renderer, stats, material;
 			let mouseX = 0, mouseY = 0;
 

--- a/examples/webgl_points_sprites.html
+++ b/examples/webgl_points_sprites.html
@@ -34,6 +34,8 @@
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			let camera, scene, renderer, stats, parameters;
 			let mouseX = 0, mouseY = 0;
 

--- a/examples/webgl_portal.html
+++ b/examples/webgl_portal.html
@@ -40,6 +40,8 @@
 			import * as CameraUtils from 'three/addons/utils/CameraUtils.js';
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			let camera, scene, renderer;
 
 			let cameraControls;

--- a/examples/webgl_postprocessing_afterimage.html
+++ b/examples/webgl_postprocessing_afterimage.html
@@ -31,6 +31,8 @@
 			import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
 			import { AfterimagePass } from 'three/addons/postprocessing/AfterimagePass.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			let camera, scene, renderer, composer;
 			let mesh;
 

--- a/examples/webgl_postprocessing_unreal_bloom.html
+++ b/examples/webgl_postprocessing_unreal_bloom.html
@@ -50,6 +50,8 @@
 			import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
 			import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			let camera, stats;
 			let composer, renderer, mixer, clock;
 

--- a/examples/webgl_postprocessing_unreal_bloom_selective.html
+++ b/examples/webgl_postprocessing_unreal_bloom_selective.html
@@ -66,6 +66,8 @@
 			import { ShaderPass } from 'three/addons/postprocessing/ShaderPass.js';
 			import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			const ENTIRE_SCENE = 0, BLOOM_SCENE = 1;
 
 			const bloomLayer = new THREE.Layers();

--- a/examples/webgl_refraction.html
+++ b/examples/webgl_refraction.html
@@ -42,6 +42,8 @@
 			import { Refractor } from 'three/addons/objects/Refractor.js';
 			import { WaterRefractionShader } from 'three/addons/shaders/WaterRefractionShader.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			let camera, scene, renderer, clock;
 
 			let refractor, smallSphere;

--- a/examples/webgl_rtt.html
+++ b/examples/webgl_rtt.html
@@ -74,6 +74,8 @@
 
 			import Stats from 'three/addons/libs/stats.module.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			let container, stats;
 
 			let cameraRTT, camera, sceneRTT, sceneScreen, scene, renderer, zmesh1, zmesh2;

--- a/examples/webgl_shaders_ocean.html
+++ b/examples/webgl_shaders_ocean.html
@@ -37,6 +37,8 @@
 			import { Water } from 'three/addons/objects/Water.js';
 			import { Sky } from 'three/addons/objects/Sky.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			let container, stats;
 			let camera, scene, renderer;
 			let controls, water, sun, mesh;

--- a/examples/webgl_shadowmap_viewer.html
+++ b/examples/webgl_shadowmap_viewer.html
@@ -33,6 +33,8 @@
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { ShadowMapViewer } from 'three/addons/utils/ShadowMapViewer.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			let camera, scene, renderer, clock, stats;
 			let dirLight, spotLight;
 			let torusKnot, cube;

--- a/examples/webgl_shadowmap_vsm.html
+++ b/examples/webgl_shadowmap_vsm.html
@@ -33,6 +33,8 @@
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			let camera, scene, renderer, clock, stats;
 			let dirLight, spotLight;
 			let torusKnot, dirGroup;

--- a/examples/webgl_simple_gi.html
+++ b/examples/webgl_simple_gi.html
@@ -31,6 +31,8 @@
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			class GIMesh extends THREE.Mesh {
 
 				copy( source ) {

--- a/examples/webgl_skinning_simple.html
+++ b/examples/webgl_skinning_simple.html
@@ -34,6 +34,8 @@
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			let stats, mixer, camera, scene, renderer, clock;
 
 			init();

--- a/examples/webgl_sprites.html
+++ b/examples/webgl_sprites.html
@@ -29,6 +29,8 @@
 
 			import * as THREE from 'three';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			let camera, scene, renderer;
 			let cameraOrtho, sceneOrtho;
 

--- a/examples/webgl_tiled_forward.html
+++ b/examples/webgl_tiled_forward.html
@@ -36,6 +36,8 @@
 
 			import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			// Simple form of tiled forward lighting
 			// using texels as bitmasks of 32 lights
 

--- a/examples/webgl_trails.html
+++ b/examples/webgl_trails.html
@@ -26,6 +26,8 @@
 
 			import Stats from 'three/addons/libs/stats.module.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			let stats;
 
 			let camera, scene, renderer, clock;

--- a/examples/webgl_water.html
+++ b/examples/webgl_water.html
@@ -34,6 +34,8 @@
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { Water } from 'three/addons/objects/Water2.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			let scene, camera, clock, renderer, water;
 
 			let torusKnot;

--- a/examples/webgl_water_flowmap.html
+++ b/examples/webgl_water_flowmap.html
@@ -34,6 +34,8 @@
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { Water } from 'three/addons/objects/Water2.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			let scene, camera, renderer, water;
 
 			init();

--- a/examples/webgpu_shadowmap.html
+++ b/examples/webgpu_shadowmap.html
@@ -34,6 +34,8 @@
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			let camera, scene, renderer, clock;
 			let dirLight, spotLight;
 			let torusKnot, dirGroup;

--- a/examples/webxr_vr_sandbox.html
+++ b/examples/webxr_vr_sandbox.html
@@ -36,6 +36,8 @@
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 			import Stats from 'three/addons/libs/stats.module.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
 			let camera, scene, renderer;
 			let reflector;
 			let stats, statsMesh;


### PR DESCRIPTION
Currently about 15% of our examples still output Linear-sRGB. Some of those are correct (e.g. post-processing), others are incorrect. Sorting out which is which, and making the right fixes, is taking a longer for these final 15% of examples, see #25849 and #25844. I'd like to go ahead and get ColorManagement enabled by default *first*, so we can discover any unexpected problems prior to r152, without waiting on the conversion of the remaining examples. To unblock that, I'm disabling THREE.ColorManagement explicitly on the examples that still use `renderer.outputColorSpace = THREE.LinearSRGBColorSpace`, and adding TODOs. 

This PR should not result in any rendering differences.

Related issue:

- #23614 

/cc @WestLangley @Mugen87 