### PR TITLE
Material: Infer texture color space (WIP)

### DIFF
--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -1,5 +1,5 @@
 import { EventDispatcher } from '../core/EventDispatcher.js';
-import { FrontSide, NormalBlending, LessEqualDepth, AddEquation, OneMinusSrcAlphaFactor, SrcAlphaFactor, AlwaysStencilFunc, KeepStencilOp } from '../constants.js';
+import { FrontSide, NormalBlending, LessEqualDepth, AddEquation, OneMinusSrcAlphaFactor, SrcAlphaFactor, AlwaysStencilFunc, KeepStencilOp, UnsignedByteType, SRGBColorSpace, NoColorSpace, LinearSRGBColorSpace } from '../constants.js';
 import * as MathUtils from '../math/MathUtils.js';
 
 let materialId = 0;
@@ -147,6 +147,17 @@ class Material extends EventDispatcher {
 			}
 
 		}
+
+	}
+
+	assignTextureColorSpace( texture ) {
+
+		// Infers color space of a texture already known to contain only color data. This method
+		// should _not_ be passed non-color textures.
+
+		if ( texture.colorSpace !== NoColorSpace ) return;
+
+		texture.colorSpace = texture.type === UnsignedByteType ? SRGBColorSpace : LinearSRGBColorSpace;
 
 	}
 

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -1,7 +1,6 @@
 import { EventDispatcher } from '../core/EventDispatcher.js';
-import { FrontSide, NormalBlending, LessEqualDepth, AddEquation, OneMinusSrcAlphaFactor, SrcAlphaFactor, AlwaysStencilFunc, KeepStencilOp, UnsignedByteType, SRGBColorSpace, NoColorSpace, LinearSRGBColorSpace } from '../constants.js';
+import { FrontSide, NormalBlending, LessEqualDepth, AddEquation, OneMinusSrcAlphaFactor, SrcAlphaFactor, AlwaysStencilFunc, KeepStencilOp } from '../constants.js';
 import * as MathUtils from '../math/MathUtils.js';
-import { ColorManagement } from '../math/ColorManagement.js';
 
 let materialId = 0;
 

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -1,6 +1,7 @@
 import { EventDispatcher } from '../core/EventDispatcher.js';
 import { FrontSide, NormalBlending, LessEqualDepth, AddEquation, OneMinusSrcAlphaFactor, SrcAlphaFactor, AlwaysStencilFunc, KeepStencilOp, UnsignedByteType, SRGBColorSpace, NoColorSpace, LinearSRGBColorSpace } from '../constants.js';
 import * as MathUtils from '../math/MathUtils.js';
+import { ColorManagement } from '../math/ColorManagement.js';
 
 let materialId = 0;
 
@@ -147,17 +148,6 @@ class Material extends EventDispatcher {
 			}
 
 		}
-
-	}
-
-	assignTextureColorSpace( texture ) {
-
-		// Infers color space of a texture already known to contain only color data. This method
-		// should _not_ be passed non-color textures.
-
-		if ( ! texture || texture.colorSpace !== NoColorSpace ) return;
-
-		texture.colorSpace = texture.type === UnsignedByteType ? SRGBColorSpace : LinearSRGBColorSpace;
 
 	}
 

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -155,7 +155,7 @@ class Material extends EventDispatcher {
 		// Infers color space of a texture already known to contain only color data. This method
 		// should _not_ be passed non-color textures.
 
-		if ( texture.colorSpace !== NoColorSpace ) return;
+		if ( ! texture || texture.colorSpace !== NoColorSpace ) return;
 
 		texture.colorSpace = texture.type === UnsignedByteType ? SRGBColorSpace : LinearSRGBColorSpace;
 

--- a/src/materials/MeshBasicMaterial.js
+++ b/src/materials/MeshBasicMaterial.js
@@ -14,7 +14,7 @@ class MeshBasicMaterial extends Material {
 
 		this.color = new Color( 0xffffff ); // emissive
 
-		this.map = null;
+		this._map = null;
 
 		this.lightMap = null;
 		this.lightMapIntensity = 1.0;
@@ -39,6 +39,20 @@ class MeshBasicMaterial extends Material {
 		this.fog = true;
 
 		this.setValues( parameters );
+
+	}
+
+	get map() {
+
+		return this._map;
+
+	}
+
+	set map( map ) {
+
+		this.assignTextureColorSpace( map );
+
+		this._map = map;
 
 	}
 

--- a/src/materials/MeshBasicMaterial.js
+++ b/src/materials/MeshBasicMaterial.js
@@ -1,6 +1,7 @@
 import { Material } from './Material.js';
 import { MultiplyOperation } from '../constants.js';
 import { Color } from '../math/Color.js';
+import { ColorManagement } from '../math/ColorManagement.js';
 
 class MeshBasicMaterial extends Material {
 
@@ -50,7 +51,7 @@ class MeshBasicMaterial extends Material {
 
 	set map( map ) {
 
-		this.assignTextureColorSpace( map );
+		ColorManagement.assignTextureColorSpace( map );
 
 		this._map = map;
 

--- a/src/materials/MeshStandardMaterial.js
+++ b/src/materials/MeshStandardMaterial.js
@@ -2,6 +2,7 @@ import { TangentSpaceNormalMap } from '../constants.js';
 import { Material } from './Material.js';
 import { Vector2 } from '../math/Vector2.js';
 import { Color } from '../math/Color.js';
+import { ColorManagement } from '../math/ColorManagement.js';
 
 class MeshStandardMaterial extends Material {
 
@@ -72,7 +73,7 @@ class MeshStandardMaterial extends Material {
 
 	set map( map ) {
 
-		this.assignTextureColorSpace( map );
+		ColorManagement.assignTextureColorSpace( map );
 
 		this._map = map;
 
@@ -86,7 +87,7 @@ class MeshStandardMaterial extends Material {
 
 	set emissiveMap( emissiveMap ) {
 
-		this.assignTextureColorSpace( emissiveMap );
+		ColorManagement.assignTextureColorSpace( emissiveMap );
 
 		this._emissiveMap = emissiveMap;
 

--- a/src/materials/MeshStandardMaterial.js
+++ b/src/materials/MeshStandardMaterial.js
@@ -19,7 +19,7 @@ class MeshStandardMaterial extends Material {
 		this.roughness = 1.0;
 		this.metalness = 0.0;
 
-		this.map = null;
+		this._map = null;
 
 		this.lightMap = null;
 		this.lightMapIntensity = 1.0;
@@ -29,7 +29,7 @@ class MeshStandardMaterial extends Material {
 
 		this.emissive = new Color( 0x000000 );
 		this.emissiveIntensity = 1.0;
-		this.emissiveMap = null;
+		this._emissiveMap = null;
 
 		this.bumpMap = null;
 		this.bumpScale = 1;
@@ -61,6 +61,34 @@ class MeshStandardMaterial extends Material {
 		this.fog = true;
 
 		this.setValues( parameters );
+
+	}
+
+	get map() {
+
+		return this._map;
+
+	}
+
+	set map( map ) {
+
+		this.assignTextureColorSpace( map );
+
+		this._map = map;
+
+	}
+
+	get emissiveMap() {
+
+		return this._emissiveMap;
+
+	}
+
+	set emissiveMap( emissiveMap ) {
+
+		this.assignTextureColorSpace( emissiveMap );
+
+		this._emissiveMap = emissiveMap;
 
 	}
 

--- a/src/math/ColorManagement.js
+++ b/src/math/ColorManagement.js
@@ -1,4 +1,4 @@
-import { SRGBColorSpace, LinearSRGBColorSpace, DisplayP3ColorSpace, NoColorSpace } from '../constants.js';
+import { SRGBColorSpace, LinearSRGBColorSpace, DisplayP3ColorSpace, NoColorSpace, UnsignedByteType } from '../constants.js';
 import { Matrix3 } from './Matrix3.js';
 
 export function SRGBToLinear( c ) {
@@ -135,9 +135,11 @@ export const ColorManagement = {
 		// Infers color space of a texture already known to contain only color
 		// data. This method should _not_ be passed non-color textures.
 
-		if ( this.enabled === false || ! texture || texture.colorSpace !== NoColorSpace ) return;
+		if ( this.enabled && texture && texture.colorSpace === NoColorSpace ) {
 
-		texture.colorSpace = texture.type === UnsignedByteType ? SRGBColorSpace : LinearSRGBColorSpace;
+			texture.colorSpace = texture.type === UnsignedByteType ? SRGBColorSpace : LinearSRGBColorSpace;
+
+		}
 
 	},
 

--- a/src/math/ColorManagement.js
+++ b/src/math/ColorManagement.js
@@ -1,4 +1,4 @@
-import { SRGBColorSpace, LinearSRGBColorSpace, DisplayP3ColorSpace, } from '../constants.js';
+import { SRGBColorSpace, LinearSRGBColorSpace, DisplayP3ColorSpace, NoColorSpace } from '../constants.js';
 import { Matrix3 } from './Matrix3.js';
 
 export function SRGBToLinear( c ) {
@@ -127,6 +127,17 @@ export const ColorManagement = {
 	toWorkingColorSpace: function ( color, sourceColorSpace ) {
 
 		return this.convert( color, sourceColorSpace, this.workingColorSpace );
+
+	},
+
+	assignTextureColorSpace( texture ) {
+
+		// Infers color space of a texture already known to contain only color
+		// data. This method should _not_ be passed non-color textures.
+
+		if ( this.enabled === false || ! texture || texture.colorSpace !== NoColorSpace ) return;
+
+		texture.colorSpace = texture.type === UnsignedByteType ? SRGBColorSpace : LinearSRGBColorSpace;
 
 	},
 


### PR DESCRIPTION
Related issue: 

- #23614 

**Description**

Updates THREE.MeshBasicMaterial and THREE.MeshStandardMaterial to infer the color space of assigned textures. This is possible based on a couple of assumptions:

1. Textures assigned to material slots like .map and .emissiveMap MUST contain color data
2. When a texture containing color data has `.colorSpace === THREE.NoColorSpace` (default), THREE.NoColorSpace can safely be interpreted as "unknown" or "unspecified"
3. In that case, we can infer sRGB vs. Linear-sRGB based on the texture's `.type` property

There are limitations to this approach:

- We cannot infer wide-gamut color spaces like Display P3, they must be specified
- We cannot infer color spaces for NodeMaterial when a texture is connected only indirectly to a material input
- We cannot infer color spaces for ShaderMaterial

***

Just an idea — I don't yet feel confident enough about this to include it in r152 with the other color management changes.

