### PR TITLE
Examples: Disable ColorManagement on examples requiring further changes

### DIFF
--- a/examples/games_fps.html
+++ b/examples/games_fps.html
@@ -42,6 +42,8 @@
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			const clock = new THREE.Clock();
 
 			const scene = new THREE.Scene();

--- a/examples/misc_controls_fly.html
+++ b/examples/misc_controls_fly.html
@@ -51,6 +51,8 @@
 			import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
 			import { FilmPass } from 'three/addons/postprocessing/FilmPass.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			const radius = 6371;
 			const tilt = 0.41;
 			const rotationSpeed = 0.02;

--- a/examples/misc_exporter_gltf.html
+++ b/examples/misc_exporter_gltf.html
@@ -32,6 +32,8 @@
 			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			function exportGLTF( input ) {
 
 				const gltfExporter = new GLTFExporter();

--- a/examples/misc_exporter_ply.html
+++ b/examples/misc_exporter_ply.html
@@ -32,6 +32,8 @@
 			import { PLYExporter } from 'three/addons/exporters/PLYExporter.js';
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let scene, camera, renderer, exporter, mesh;
 
 			const params = {

--- a/examples/physics_ammo_instancing.html
+++ b/examples/physics_ammo_instancing.html
@@ -34,6 +34,8 @@
 			import { AmmoPhysics } from 'three/addons/physics/AmmoPhysics.js';
 			import Stats from 'three/addons/libs/stats.module.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let camera, scene, renderer, stats;
 			let physics, position;
 

--- a/examples/physics_oimo_instancing.html
+++ b/examples/physics_oimo_instancing.html
@@ -33,6 +33,8 @@
 			import { OimoPhysics } from 'three/addons/physics/OimoPhysics.js';
 			import Stats from 'three/addons/libs/stats.module.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let camera, scene, renderer, stats;
 			let physics, position;
 

--- a/examples/svg_sandbox.html
+++ b/examples/svg_sandbox.html
@@ -34,6 +34,8 @@
 
 			import { SVGRenderer, SVGObject } from 'three/addons/renderers/SVGRenderer.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let camera, scene, renderer, stats;
 
 			let group;

--- a/examples/webaudio_orientation.html
+++ b/examples/webaudio_orientation.html
@@ -42,6 +42,8 @@
 		import { PositionalAudioHelper } from 'three/addons/helpers/PositionalAudioHelper.js';
 		import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 
+		THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 		let scene, camera, renderer;
 
 		const startButton = document.getElementById( 'startButton' );

--- a/examples/webgl2_multiple_rendertargets.html
+++ b/examples/webgl2_multiple_rendertargets.html
@@ -123,6 +123,8 @@
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let camera, scene, renderer, controls;
 			let renderTarget;
 			let postScene, postCamera;

--- a/examples/webgl2_multisampled_renderbuffers.html
+++ b/examples/webgl2_multisampled_renderbuffers.html
@@ -56,6 +56,8 @@
 			import { CopyShader } from 'three/addons/shaders/CopyShader.js';
 			import WebGL from 'three/addons/capabilities/WebGL.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let camera, renderer, clock, group, container;
 
 			let composer1, composer2;

--- a/examples/webgl2_ubo.html
+++ b/examples/webgl2_ubo.html
@@ -182,6 +182,8 @@
 
 			import WebGL from 'three/addons/capabilities/WebGL.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let camera, scene, renderer, clock;
 
 			init();

--- a/examples/webgl_animation_multiple.html
+++ b/examples/webgl_animation_multiple.html
@@ -32,6 +32,8 @@
 			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 			import * as SkeletonUtils from 'three/addons/utils/SkeletonUtils.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let camera, scene, renderer;
 			let clock;
 

--- a/examples/webgl_animation_skinning_additive_blending.html
+++ b/examples/webgl_animation_skinning_additive_blending.html
@@ -43,6 +43,8 @@
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let scene, renderer, camera, stats;
 			let model, skeleton, mixer, clock;
 

--- a/examples/webgl_animation_skinning_morph.html
+++ b/examples/webgl_animation_skinning_morph.html
@@ -56,6 +56,8 @@
 
 			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let container, stats, clock, gui, mixer, actions, activeAction, previousAction;
 			let camera, scene, renderer, model, face;
 

--- a/examples/webgl_buffergeometry.html
+++ b/examples/webgl_buffergeometry.html
@@ -30,6 +30,8 @@
 
 			import Stats from 'three/addons/libs/stats.module.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let container, stats;
 
 			let camera, scene, renderer;

--- a/examples/webgl_buffergeometry_drawrange.html
+++ b/examples/webgl_buffergeometry_drawrange.html
@@ -36,6 +36,8 @@
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let group;
 			let container, stats;
 			const particlesData = [];

--- a/examples/webgl_buffergeometry_uint.html
+++ b/examples/webgl_buffergeometry_uint.html
@@ -30,6 +30,8 @@
 
 			import Stats from 'three/addons/libs/stats.module.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let container, stats;
 
 			let camera, scene, renderer;

--- a/examples/webgl_camera_cinematic.html
+++ b/examples/webgl_camera_cinematic.html
@@ -43,6 +43,8 @@
 
 			import { CinematicCamera } from 'three/addons/cameras/CinematicCamera.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let camera, scene, raycaster, renderer, stats;
 
 			const mouse = new THREE.Vector2();

--- a/examples/webgl_effects_peppersghost.html
+++ b/examples/webgl_effects_peppersghost.html
@@ -32,6 +32,8 @@
 
 			import { PeppersGhostEffect } from 'three/addons/effects/PeppersGhostEffect.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let container;
 
 			let camera, scene, renderer, effect;

--- a/examples/webgl_geometry_teapot.html
+++ b/examples/webgl_geometry_teapot.html
@@ -34,6 +34,8 @@
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { TeapotGeometry } from 'three/addons/geometries/TeapotGeometry.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let camera, scene, renderer;
 			let cameraControls;
 			let effectController;

--- a/examples/webgl_gpgpu_birds.html
+++ b/examples/webgl_gpgpu_birds.html
@@ -319,6 +319,8 @@
 
 			import { GPUComputationRenderer } from 'three/addons/misc/GPUComputationRenderer.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			/* TEXTURE WIDTH FOR SIMULATION */
 			const WIDTH = 32;
 

--- a/examples/webgl_lightningstrike.html
+++ b/examples/webgl_lightningstrike.html
@@ -38,6 +38,8 @@
 			import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
 			import { OutlinePass } from 'three/addons/postprocessing/OutlinePass.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let container, stats;
 
 			let scene, renderer, composer, gui;

--- a/examples/webgl_lights_rectarealight.html
+++ b/examples/webgl_lights_rectarealight.html
@@ -36,6 +36,8 @@
 			import { RectAreaLightHelper } from 'three/addons/helpers/RectAreaLightHelper.js';
 			import { RectAreaLightUniformsLib } from 'three/addons/lights/RectAreaLightUniformsLib.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let renderer, scene, camera;
 			let stats;
 

--- a/examples/webgl_lights_spotlight.html
+++ b/examples/webgl_lights_spotlight.html
@@ -34,6 +34,8 @@
 			import { PLYLoader } from 'three/addons/loaders/PLYLoader.js';
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let renderer, scene, camera;
 
 			let spotLight, lightHelper;

--- a/examples/webgl_loader_3mf_materials.html
+++ b/examples/webgl_loader_3mf_materials.html
@@ -37,6 +37,8 @@
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { ThreeMFLoader } from 'three/addons/loaders/3MFLoader.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let camera, scene, renderer;
 
 			init();

--- a/examples/webgl_loader_collada_kinematics.html
+++ b/examples/webgl_loader_collada_kinematics.html
@@ -34,6 +34,8 @@
 			import TWEEN from 'three/addons/libs/tween.module.js';
 			import { ColladaLoader } from 'three/addons/loaders/ColladaLoader.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let container, stats;
 
 			let camera, scene, renderer;

--- a/examples/webgl_loader_collada_skinning.html
+++ b/examples/webgl_loader_collada_skinning.html
@@ -36,6 +36,8 @@
 			import { ColladaLoader } from 'three/addons/loaders/ColladaLoader.js';
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let container, stats, clock, controls;
 			let camera, scene, renderer, mixer;
 

--- a/examples/webgl_loader_draco.html
+++ b/examples/webgl_loader_draco.html
@@ -32,6 +32,8 @@
 
 		import { DRACOLoader } from 'three/addons/loaders/DRACOLoader.js';
 
+		THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 		let camera, scene, renderer;
 
 		const container = document.querySelector( '#container' );

--- a/examples/webgl_loader_kmz.html
+++ b/examples/webgl_loader_kmz.html
@@ -32,6 +32,8 @@
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { KMZLoader } from 'three/addons/loaders/KMZLoader.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let camera, scene, renderer;
 
 			init();

--- a/examples/webgl_loader_ldraw.html
+++ b/examples/webgl_loader_ldraw.html
@@ -45,6 +45,8 @@
 			import { LDrawLoader } from 'three/addons/loaders/LDrawLoader.js';
 			import { LDrawUtils } from 'three/addons/utils/LDrawUtils.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let container, progressBarDiv;
 
 			let camera, scene, renderer, controls, gui, guiData;

--- a/examples/webgl_loader_lwo.html
+++ b/examples/webgl_loader_lwo.html
@@ -35,6 +35,8 @@
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { LWOLoader } from 'three/addons/loaders/LWOLoader.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let camera, scene, renderer;
 
 			init();

--- a/examples/webgl_loader_md2_control.html
+++ b/examples/webgl_loader_md2_control.html
@@ -45,6 +45,8 @@
 			import { MD2CharacterComplex } from 'three/addons/misc/MD2CharacterComplex.js';
 			import { Gyroscope } from 'three/addons/misc/Gyroscope.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let SCREEN_WIDTH = window.innerWidth;
 			let SCREEN_HEIGHT = window.innerHeight;
 

--- a/examples/webgl_loader_ply.html
+++ b/examples/webgl_loader_ply.html
@@ -34,6 +34,8 @@
 
 			import { PLYLoader } from 'three/addons/loaders/PLYLoader.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let container, stats;
 
 			let camera, cameraTarget, scene, renderer;

--- a/examples/webgl_loader_stl.html
+++ b/examples/webgl_loader_stl.html
@@ -34,6 +34,8 @@
 
 			import { STLLoader } from 'three/addons/loaders/STLLoader.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let container, stats;
 
 			let camera, cameraTarget, scene, renderer;

--- a/examples/webgl_loader_svg.html
+++ b/examples/webgl_loader_svg.html
@@ -39,6 +39,8 @@
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { SVGLoader } from 'three/addons/loaders/SVGLoader.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let renderer, scene, camera, gui, guiData;
 
 			init();

--- a/examples/webgl_loader_usdz.html
+++ b/examples/webgl_loader_usdz.html
@@ -40,6 +40,8 @@
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { USDZLoader } from 'three/addons/loaders/USDZLoader.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let camera, scene, renderer;
 
 			init();

--- a/examples/webgl_marchingcubes.html
+++ b/examples/webgl_marchingcubes.html
@@ -39,6 +39,8 @@
 		import { MarchingCubes } from 'three/addons/objects/MarchingCubes.js';
 		import { ToonShader1, ToonShader2, ToonShaderHatching, ToonShaderDotted } from 'three/addons/shaders/ToonShader.js';
 
+		THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 		let container, stats;
 
 		let camera, scene, renderer;

--- a/examples/webgl_materials_bumpmap.html
+++ b/examples/webgl_materials_bumpmap.html
@@ -34,6 +34,8 @@
 
 			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			const statsEnabled = true;
 
 			let container, stats, loader;

--- a/examples/webgl_materials_displacementmap.html
+++ b/examples/webgl_materials_displacementmap.html
@@ -36,9 +36,10 @@
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { OBJLoader } from 'three/addons/loaders/OBJLoader.js';
-			let stats;
 
-			let camera, scene, renderer, controls;
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
+			let camera, scene, renderer, controls, stats;
 			const settings = {
 				metalness: 1.0,
 				roughness: 0.4,

--- a/examples/webgl_materials_displacementmap.html
+++ b/examples/webgl_materials_displacementmap.html
@@ -39,7 +39,10 @@
 
 			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
 
-			let camera, scene, renderer, controls, stats;
+			let stats;
+
+			let camera, scene, renderer, controls;
+
 			const settings = {
 				metalness: 1.0,
 				roughness: 0.4,

--- a/examples/webgl_materials_displacementmap.html
+++ b/examples/webgl_materials_displacementmap.html
@@ -40,7 +40,6 @@
 			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
 
 			let stats;
-
 			let camera, scene, renderer, controls;
 
 			const settings = {

--- a/examples/webgl_materials_lightmap.html
+++ b/examples/webgl_materials_lightmap.html
@@ -34,6 +34,8 @@
 			import { MeshBasicNodeMaterial, vec4, color, positionLocal, mix } from 'three/nodes';
 			import { nodeFrame } from 'three/addons/renderers/webgl/nodes/WebGLNodes.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let container, stats;
 			let camera, scene, renderer;
 

--- a/examples/webgl_materials_normalmap.html
+++ b/examples/webgl_materials_normalmap.html
@@ -41,6 +41,8 @@
 			import { FXAAShader } from 'three/addons/shaders/FXAAShader.js';
 			import { GammaCorrectionShader } from 'three/addons/shaders/GammaCorrectionShader.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let container, stats, loader;
 
 			let camera, scene, renderer;

--- a/examples/webgl_materials_subsurface_scattering.html
+++ b/examples/webgl_materials_subsurface_scattering.html
@@ -37,6 +37,8 @@
 		import { SubsurfaceScatteringShader } from 'three/addons/shaders/SubsurfaceScatteringShader.js';
 		import { FBXLoader } from 'three/addons/loaders/FBXLoader.js';
 
+		THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 		let container, stats;
 		let camera, scene, renderer;
 		let model;

--- a/examples/webgl_materials_variations_lambert.html
+++ b/examples/webgl_materials_variations_lambert.html
@@ -34,6 +34,8 @@
 			import { FontLoader } from 'three/addons/loaders/FontLoader.js';
 			import { TextGeometry } from 'three/addons/geometries/TextGeometry.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let container, stats;
 
 			let camera, scene, renderer;

--- a/examples/webgl_materials_variations_phong.html
+++ b/examples/webgl_materials_variations_phong.html
@@ -34,6 +34,8 @@
 			import { FontLoader } from 'three/addons/loaders/FontLoader.js';
 			import { TextGeometry } from 'three/addons/geometries/TextGeometry.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let container, stats;
 
 			let camera, scene, renderer;

--- a/examples/webgl_materials_variations_standard.html
+++ b/examples/webgl_materials_variations_standard.html
@@ -36,6 +36,8 @@
 			import { FontLoader } from 'three/addons/loaders/FontLoader.js';
 			import { TextGeometry } from 'three/addons/geometries/TextGeometry.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let container, stats;
 
 			let camera, scene, renderer;

--- a/examples/webgl_materials_variations_toon.html
+++ b/examples/webgl_materials_variations_toon.html
@@ -35,6 +35,8 @@
 			import { FontLoader } from 'three/addons/loaders/FontLoader.js';
 			import { TextGeometry } from 'three/addons/geometries/TextGeometry.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let container, stats;
 
 			let camera, scene, renderer, effect;

--- a/examples/webgl_points_dynamic.html
+++ b/examples/webgl_points_dynamic.html
@@ -42,6 +42,8 @@
 			import { FocusShader } from 'three/addons/shaders/FocusShader.js';
 			import { OBJLoader } from 'three/addons/loaders/OBJLoader.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let camera, scene, renderer, mesh;
 
 			let parent;

--- a/examples/webgl_postprocessing.html
+++ b/examples/webgl_postprocessing.html
@@ -32,6 +32,8 @@
 			import { RGBShiftShader } from 'three/addons/shaders/RGBShiftShader.js';
 			import { DotScreenShader } from 'three/addons/shaders/DotScreenShader.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let camera, renderer, composer;
 			let object;
 

--- a/examples/webgl_postprocessing_advanced.html
+++ b/examples/webgl_postprocessing_advanced.html
@@ -53,6 +53,8 @@
 
 			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let container, stats;
 
 			let composerScene, composer1, composer2, composer3, composer4;

--- a/examples/webgl_postprocessing_fxaa.html
+++ b/examples/webgl_postprocessing_fxaa.html
@@ -56,6 +56,8 @@
 			import { CopyShader } from 'three/addons/shaders/CopyShader.js';
 			import { FXAAShader } from 'three/addons/shaders/FXAAShader.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let camera, scene, renderer, clock, group, container;
 
 			let composer1, composer2, fxaaPass;

--- a/examples/webgl_postprocessing_glitch.html
+++ b/examples/webgl_postprocessing_glitch.html
@@ -41,6 +41,8 @@
 			import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
 			import { GlitchPass } from 'three/addons/postprocessing/GlitchPass.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let camera, scene, renderer, composer;
 			let object, light;
 

--- a/examples/webgl_postprocessing_pixel.html
+++ b/examples/webgl_postprocessing_pixel.html
@@ -38,6 +38,8 @@
 		import { RenderPixelatedPass } from 'three/addons/postprocessing/RenderPixelatedPass.js';
 		import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 
+		THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 		let camera, scene, renderer, composer, crystalMesh, clock;
 		let gui, params;
 

--- a/examples/webgl_postprocessing_rgb_halftone.html
+++ b/examples/webgl_postprocessing_rgb_halftone.html
@@ -37,6 +37,8 @@
 			import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
 			import { HalftonePass } from 'three/addons/postprocessing/HalftonePass.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let renderer, clock, camera, stats;
 
 			const rotationSpeed = Math.PI / 64;

--- a/examples/webgl_postprocessing_ssao.html
+++ b/examples/webgl_postprocessing_ssao.html
@@ -39,6 +39,8 @@
 			import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
 			import { SSAOPass } from 'three/addons/postprocessing/SSAOPass.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let container, stats;
 			let camera, scene, renderer;
 			let composer;

--- a/examples/webgl_postprocessing_ssr.html
+++ b/examples/webgl_postprocessing_ssr.html
@@ -46,6 +46,8 @@
 
 		import { DRACOLoader } from 'three/addons/loaders/DRACOLoader.js';
 
+		THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 		const params = {
 			enableSSR: true,
 			autoRotate: true,

--- a/examples/webgl_read_float_buffer.html
+++ b/examples/webgl_read_float_buffer.html
@@ -77,6 +77,8 @@
 
 			import Stats from 'three/addons/libs/stats.module.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let container, stats;
 
 			let cameraRTT, sceneRTT, sceneScreen, renderer, zmesh1, zmesh2;

--- a/examples/webgl_shadowmap_pcss.html
+++ b/examples/webgl_shadowmap_pcss.html
@@ -139,6 +139,8 @@
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let stats;
 			let camera, scene, renderer;
 

--- a/examples/webgl_shadowmap_performance.html
+++ b/examples/webgl_shadowmap_performance.html
@@ -38,6 +38,8 @@
 			import { FontLoader } from 'three/addons/loaders/FontLoader.js';
 			import { TextGeometry } from 'three/addons/geometries/TextGeometry.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			const SHADOW_MAP_WIDTH = 2048, SHADOW_MAP_HEIGHT = 1024;
 
 			let SCREEN_WIDTH = window.innerWidth;

--- a/examples/webxr_vr_handinput.html
+++ b/examples/webxr_vr_handinput.html
@@ -34,6 +34,8 @@
 			import { XRControllerModelFactory } from 'three/addons/webxr/XRControllerModelFactory.js';
 			import { XRHandModelFactory } from 'three/addons/webxr/XRHandModelFactory.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let container;
 			let camera, scene, renderer;
 			let hand1, hand2;

--- a/examples/webxr_vr_handinput_cubes.html
+++ b/examples/webxr_vr_handinput_cubes.html
@@ -34,6 +34,8 @@
 			import { XRControllerModelFactory } from 'three/addons/webxr/XRControllerModelFactory.js';
 			import { XRHandModelFactory } from 'three/addons/webxr/XRHandModelFactory.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let container;
 			let camera, scene, renderer;
 			let hand1, hand2;

--- a/examples/webxr_vr_handinput_pointerclick.html
+++ b/examples/webxr_vr_handinput_pointerclick.html
@@ -39,6 +39,8 @@
 
 		import { World, System, Component, TagComponent, Types } from 'three/addons/libs/ecsy.module.js';
 
+		THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 		class Object3D extends Component { }
 
 		Object3D.schema = {

--- a/examples/webxr_vr_handinput_pointerdrag.html
+++ b/examples/webxr_vr_handinput_pointerdrag.html
@@ -39,6 +39,8 @@
 
 		import { World, System, Component, TagComponent, Types } from 'three/addons/libs/ecsy.module.js';
 
+		THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 		class Object3D extends Component { }
 
 		Object3D.schema = {

--- a/examples/webxr_vr_handinput_pressbutton.html
+++ b/examples/webxr_vr_handinput_pressbutton.html
@@ -38,6 +38,8 @@
 
 		import { World, System, Component, TagComponent, Types } from 'three/addons/libs/ecsy.module.js';
 
+		THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 		class Object3D extends Component { }
 
 		Object3D.schema = {

--- a/examples/webxr_vr_handinput_profiles.html
+++ b/examples/webxr_vr_handinput_profiles.html
@@ -34,6 +34,8 @@
 			import { XRControllerModelFactory } from 'three/addons/webxr/XRControllerModelFactory.js';
 			import { XRHandModelFactory } from 'three/addons/webxr/XRHandModelFactory.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let container;
 			let camera, scene, renderer;
 			let hand1, hand2;

--- a/examples/webxr_vr_teleport.html
+++ b/examples/webxr_vr_teleport.html
@@ -33,6 +33,8 @@
 			import { VRButton } from 'three/addons/webxr/VRButton.js';
 			import { XRControllerModelFactory } from 'three/addons/webxr/XRControllerModelFactory.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let camera, scene, raycaster, renderer;
 			let controller1, controller2;
 			let controllerGrip1, controllerGrip2;

--- a/examples/webxr_xr_ballshooter.html
+++ b/examples/webxr_xr_ballshooter.html
@@ -33,6 +33,8 @@
 			import { XRButton } from 'three/addons/webxr/XRButton.js';
 			import { XRControllerModelFactory } from 'three/addons/webxr/XRControllerModelFactory.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let camera, scene, renderer;
 			let controller1, controller2;
 			let controllerGrip1, controllerGrip2;

--- a/examples/webxr_xr_cubes.html
+++ b/examples/webxr_xr_cubes.html
@@ -33,6 +33,8 @@
 			import { XRButton } from 'three/addons/webxr/XRButton.js';
 			import { XRControllerModelFactory } from 'three/addons/webxr/XRControllerModelFactory.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			const clock = new THREE.Clock();
 
 			let container;

--- a/examples/webxr_xr_dragging.html
+++ b/examples/webxr_xr_dragging.html
@@ -32,6 +32,8 @@
 			import { XRButton } from 'three/addons/webxr/XRButton.js';
 			import { XRControllerModelFactory } from 'three/addons/webxr/XRControllerModelFactory.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let container;
 			let camera, scene, renderer;
 			let controller1, controller2;

--- a/examples/webxr_xr_haptics.html
+++ b/examples/webxr_xr_haptics.html
@@ -32,6 +32,8 @@
 			import { XRButton } from 'three/addons/webxr/XRButton.js';
 			import { XRControllerModelFactory } from 'three/addons/webxr/XRControllerModelFactory.js';
 
+			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+
 			let container;
 			let camera, scene, renderer;
 			let controller1, controller2;


### PR DESCRIPTION
Disables ColorManagement explicitly in examples requiring further updates, as a prerequisite to enabling it by default. Suggested next steps would be to merge this PR, then merge #25830 (which should then have no effect on examples), then continue updating the remaining examples.

Related issue: 

- #23614 

_NOTE: I merged a few previous PRs, but will keep this one open for normal review._