### PR TITLE
KTX2Loader: Return LODs through DataTexture's mipmaps field.

### DIFF
--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -732,8 +732,8 @@ const COLOR_SPACE_MAP = {
 async function createDataTexture( container, levelIndex = 0 ) {
 
 	const { vkFormat, pixelDepth } = container;
-	const pixelWidth = container.pixelWidth / ( 2 ** levelIndex );
-	const pixelHeight = container.pixelHeight / ( 2 ** levelIndex );
+	const pixelWidth = Math.max( 1, container.pixelWidth >> levelIndex );
+	const pixelHeight = Math.max( 1, container.pixelHeight >> levelIndex );
 
 	if ( FORMAT_MAP[ vkFormat ] === undefined ) {
 

--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -287,15 +287,15 @@ class KTX2Loader extends Loader {
 
 			await Promise.all( pendings );
 
-			const texture = mipmaps[0];
-			texture.mipmaps = mipmaps.map(dt => {
+			const texture = mipmaps[ 0 ];
+			texture.mipmaps = mipmaps.map( dt => {
 				return {
 					data: dt.source.data,
 					width: dt.source.data.width,
 					height: dt.source.data.height,
 					depth: dt.source.data.depth
 				};
-			});
+			} );
 			return texture;
 
 		}

--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -731,9 +731,10 @@ const COLOR_SPACE_MAP = {
 
 async function createDataTexture( container, levelIndex = 0 ) {
 
-	const { vkFormat, pixelDepth } = container;
+	const { vkFormat } = container;
 	const pixelWidth = Math.max( 1, container.pixelWidth >> levelIndex );
 	const pixelHeight = Math.max( 1, container.pixelHeight >> levelIndex );
+	const pixelDepth = Math.max( 1, container.pixelDepth >> levelIndex );
 
 	if ( FORMAT_MAP[ vkFormat ] === undefined ) {
 

--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -279,7 +279,11 @@ class KTX2Loader extends Loader {
 
 				pendings.push( createDataTexture( container, levelIndex ).then( function ( dataTexture ) {
 
-					mipmaps[ levelIndex ] = dataTexture;
+					mipmaps[ levelIndex ] = {
+						data: dataTexture.image.data,
+						width: dataTexture.image.width,
+						height: dataTexture.image.height
+					};
 
 				} ) );
 

--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -291,8 +291,9 @@ class KTX2Loader extends Loader {
 			texture.mipmaps = mipmaps.map(dt => {
 				return {
 					data: dt.source.data,
-					width: dt.source.width,
-					height: dt.source.height
+					width: dt.source.data.width,
+					height: dt.source.data.height,
+					depth: dt.source.data.depth
 				};
 			});
 			return texture;

--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -279,11 +279,7 @@ class KTX2Loader extends Loader {
 
 				pendings.push( createDataTexture( container, levelIndex ).then( function ( dataTexture ) {
 
-					mipmaps[ levelIndex ] = {
-						data: dataTexture.image.data,
-						width: dataTexture.image.width,
-						height: dataTexture.image.height
-					};
+					mipmaps[ levelIndex ] = dataTexture;
 
 				} ) );
 
@@ -291,8 +287,14 @@ class KTX2Loader extends Loader {
 
 			await Promise.all( pendings );
 
-			const texture = mipmaps.shift();
-			texture.mipmaps = mipmaps;
+			const texture = mipmaps[0];
+			texture.mipmaps = mipmaps.map(dt => {
+				return {
+					data: dt.source.data,
+					width: dt.source.width,
+					height: dt.source.height
+				};
+			});
 			return texture;
 
 		}


### PR DESCRIPTION
**Description**

Currently, the KTX2Loader is hardcoded to only process the first level. This backwards-compatible PR processes any additional levels and attaches them to the `mipmaps` field of the returned DataTexture.