### PR TITLE
WebGPURenderer: Introduce `hasFeature()`.

### DIFF
--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -114,13 +114,11 @@ class KTX2Loader extends Loader {
 
 		if ( renderer.isWebGPURenderer === true ) {
 
-			const adapter = renderer._adapter;
-
 			this.workerConfig = {
-				astcSupported: adapter.features.has( 'texture-compression-astc' ),
+				astcSupported: renderer.hasFeature( 'texture-compression-astc' ),
 				etc1Supported: false,
-				etc2Supported: adapter.features.has( 'texture-compression-etc2' ),
-				dxtSupported: adapter.features.has( 'texture-compression-bc' ),
+				etc2Supported: renderer.hasFeature( 'texture-compression-etc2' ),
+				dxtSupported: renderer.hasFeature( 'texture-compression-bc' ),
 				bptcSupported: false,
 				pvrtcSupported: false
 			};

--- a/examples/jsm/renderers/webgpu/WebGPURenderer.js
+++ b/examples/jsm/renderers/webgpu/WebGPURenderer.js
@@ -721,6 +721,31 @@ class WebGPURenderer {
 
 	}
 
+	hasFeature( name ) {
+
+		if ( this._initialized === false ) {
+
+			console.warn( 'THREE.WebGPURenderer: Renderer must be initialized before testing features.' );
+			return false;
+
+		}
+
+		//
+
+		const features = Object.values( GPUFeatureName );
+
+		if ( features.includes( name ) === false ) {
+
+			throw new Error( 'THREE.WebGPURenderer: Unknown WebGPU GPU feature: ' + name );
+
+		}
+
+		//
+
+		return this._adapter.features.has( name );
+
+	}
+
 	_projectObject( object, camera, groupOrder ) {
 
 		const currentRenderList = this._currentRenderList;

--- a/examples/jsm/renderers/webgpu/WebGPURenderer.js
+++ b/examples/jsm/renderers/webgpu/WebGPURenderer.js
@@ -725,8 +725,7 @@ class WebGPURenderer {
 
 		if ( this._initialized === false ) {
 
-			console.warn( 'THREE.WebGPURenderer: Renderer must be initialized before testing features.' );
-			return false;
+			throw new Error( 'THREE.WebGPURenderer: Renderer must be initialized before testing features.' );
 
 		}
 


### PR DESCRIPTION
Related issue: -

**Description**

This PR introduces `hasFeature()` which makes the GPU feature testing a bit more robust.
