### PR TITLE
Upgrade pathtracer to 0.0.14

### DIFF
--- a/examples/webgl_renderer_pathtracer.html
+++ b/examples/webgl_renderer_pathtracer.html
@@ -48,7 +48,7 @@
 					"three": "../build/three.module.js",
 					"three/addons/": "./jsm/",
 					"three/examples/": "./",
-					"three-gpu-pathtracer": "https://unpkg.com/three-gpu-pathtracer@0.0.11/build/index.module.js",
+					"three-gpu-pathtracer": "https://unpkg.com/three-gpu-pathtracer@0.0.14/build/index.module.js",
 					"three-mesh-bvh": "https://unpkg.com/three-mesh-bvh@^0.5.21/build/index.module.js"
 				}
 			}


### PR DESCRIPTION
Related issue: --

**Description**

Main reason for the upgrade is to include a workaround from v0.0.12 that fixes a shader crash on Windows machines.
