### PR TITLE
Puppeteer E2E test: Increase timeout from 15 to 20 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
   e2e:
     name: E2E testing
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Related issue: -

**Description**

Seems like _sometimes_ one of the MacOS tests takes a little longer to complete.