### PR TITLE
WebGPUTextures: Support more depth texture types.

### DIFF
--- a/examples/jsm/renderers/webgpu/WebGPUTextures.js
+++ b/examples/jsm/renderers/webgpu/WebGPUTextures.js
@@ -2,7 +2,7 @@ import { GPUTextureFormat, GPUAddressMode, GPUFilterMode, GPUTextureDimension } 
 import { VideoTexture, CubeTexture, Texture, NearestFilter, NearestMipmapNearestFilter, NearestMipmapLinearFilter, LinearFilter, RepeatWrapping, MirroredRepeatWrapping, RGB_ETC2_Format, RGBA_ETC2_EAC_Format,
 	RGBAFormat, RedFormat, RGFormat, RGBA_S3TC_DXT1_Format, RGBA_S3TC_DXT3_Format, RGBA_S3TC_DXT5_Format, UnsignedByteType, FloatType, HalfFloatType, SRGBColorSpace, DepthFormat, DepthTexture,
 	RGBA_ASTC_4x4_Format, RGBA_ASTC_5x4_Format, RGBA_ASTC_5x5_Format, RGBA_ASTC_6x5_Format, RGBA_ASTC_6x6_Format, RGBA_ASTC_8x5_Format, RGBA_ASTC_8x6_Format, RGBA_ASTC_8x8_Format, RGBA_ASTC_10x5_Format,
-	RGBA_ASTC_10x6_Format, RGBA_ASTC_10x8_Format, RGBA_ASTC_10x10_Format, RGBA_ASTC_12x10_Format, RGBA_ASTC_12x12_Format
+	RGBA_ASTC_10x6_Format, RGBA_ASTC_10x8_Format, RGBA_ASTC_10x10_Format, RGBA_ASTC_12x10_Format, RGBA_ASTC_12x12_Format, UnsignedIntType, UnsignedShortType
 } from 'three';
 import WebGPUTextureUtils from './WebGPUTextureUtils.js';
 
@@ -806,7 +806,26 @@ class WebGPUTextures {
 					break;
 
 				case DepthFormat:
-					formatGPU = GPUTextureFormat.Depth32Float;
+
+					switch ( type ) {
+
+						case UnsignedShortType:
+							formatGPU = GPUTextureFormat.Depth16Unorm;
+							break;
+
+						case UnsignedIntType:
+							formatGPU = GPUTextureFormat.Depth24Plus;
+							break;
+
+						case FloatType:
+							formatGPU = GPUTextureFormat.Depth32Float;
+							break;
+
+						default:
+							console.error( 'WebGPURenderer: Unsupported texture type with DepthFormat.', type );
+
+					}
+
 					break;
 
 				default:

--- a/examples/jsm/renderers/webgpu/constants.js
+++ b/examples/jsm/renderers/webgpu/constants.js
@@ -138,6 +138,10 @@ export const GPUTextureFormat = {
 	Depth24PlusStencil8: 'depth24plus-stencil8',
 	Depth32Float: 'depth32float',
 
+	// 'depth32float-stencil8' extension
+
+	Depth32FloatStencil8: 'depth32float-stencil8',
+
 	// BC compressed formats usable if 'texture-compression-bc' is both
 	// supported by the device/user agent and enabled in requestDevice.
 
@@ -201,14 +205,6 @@ export const GPUTextureFormat = {
 	ASTC12x10UnormSRGB: 'astc-12x10-unorm-srgb',
 	ASTC12x12Unorm: 'astc-12x12-unorm',
 	ASTC12x12UnormSRGB: 'astc-12x12-unorm-srgb',
-
-	// 'depth24unorm-stencil8' extension
-
-	Depth24UnormStencil8: 'depth24unorm-stencil8',
-
-	// 'depth32float-stencil8' extension
-
-	Depth32FloatStencil8: 'depth32float-stencil8',
 
 };
 

--- a/examples/webgpu_depth_texture.html
+++ b/examples/webgpu_depth_texture.html
@@ -26,7 +26,7 @@
 		<script type="module">
 
 			import * as THREE from 'three';
-			import { smoothstep, positionView, texture, MeshBasicNodeMaterial } from 'three/nodes';
+			import { texture, MeshBasicNodeMaterial } from 'three/nodes';
 
 			import WebGPU from 'three/addons/capabilities/WebGPU.js';
 			import WebGPURenderer from 'three/addons/renderers/webgpu/WebGPURenderer.js';


### PR DESCRIPTION
Related issue: -

**Description**

This PR ensures the existing depth texture configurations from WebGL are supported with WebGPU when using `DepthFormat`. 