### PR TITLE
update Request Header for match upper/lower case

### DIFF
--- a/src/loaders/FileLoader.js
+++ b/src/loaders/FileLoader.js
@@ -75,7 +75,7 @@ class FileLoader extends Loader {
 
 		// create request
 		const req = new Request( url, {
-			headers: new Headers( this.requestHeader ),
+			headers: this.requestHeader,
 			credentials: this.withCredentials ? 'include' : 'same-origin',
 			// An abort controller could be added within a future PR
 		} );


### PR DESCRIPTION
**Description**

Hi~ when I use OBJLoader `setRequestHeader`, the header be like `{'AuthAk': xxx}`, but FileLoader use `new Headers` in this case header ignore upper case letter. So I update the FileLoader.
