### PR TITLE
MaterialLoader: Honor `clipping` and `lights` properties.

### DIFF
--- a/src/loaders/MaterialLoader.js
+++ b/src/loaders/MaterialLoader.js
@@ -238,6 +238,9 @@ class MaterialLoader extends Loader {
 
 		}
 
+		if ( json.lights !== undefined ) material.lights = json.lights;
+		if ( json.clipping !== undefined ) material.clipping = json.clipping;
+
 		// for PointsMaterial
 
 		if ( json.size !== undefined ) material.size = json.size;

--- a/src/materials/ShaderMaterial.js
+++ b/src/materials/ShaderMaterial.js
@@ -165,6 +165,9 @@ class ShaderMaterial extends Material {
 		data.vertexShader = this.vertexShader;
 		data.fragmentShader = this.fragmentShader;
 
+		data.lights = this.lights;
+		data.clipping = this.clipping;
+
 		const extensions = {};
 
 		for ( const key in this.extensions ) {


### PR DESCRIPTION

`MaterialLoade.parse()` did not honor the `lights` and `clipping` properties of `ShaderMaterial`.
