### PR TITLE
Deprecate THREE.NoColorSpace, use 'null' instead

### DIFF
--- a/docs/api/en/constants/Core.html
+++ b/docs/api/en/constants/Core.html
@@ -21,11 +21,9 @@ THREE.REVISION
 
 		<h2>Color Spaces</h2>
 		<code>
-THREE.NoColorSpace 
-THREE.SRGBColorSpace 
-THREE.LinearSRGBColorSpace
+THREE.SRGBColorSpace = "srgb"
+THREE.LinearSRGBColorSpace = "srgb-linear"
 		</code>
-		<p>[page:NoColorSpace] defines no specific color space.</p>
 		<p>
 			[page:SRGBColorSpace] (“srgb”) refers to the color space defined by the
 			Rec. 709 primaries, D65 white point, and nonlinear sRGB transfer

--- a/docs/api/en/constants/Textures.html
+++ b/docs/api/en/constants/Textures.html
@@ -601,10 +601,8 @@
 
 		<h2>Color Space</h2>
 		<code>
-		THREE.NoColorSpace 
-		THREE.SRGBColorSpace 
-		THREE.LinearSRGBColorSpace
-		THREE.DisplayP3ColorSpace
+		THREE.SRGBColorSpace = "srgb"
+		THREE.LinearSRGBColorSpace = "srgb-linear"
 		</code>
 		<p>
 			Used to define the color space of textures (and the output color space of

--- a/docs/api/en/renderers/WebGLCubeRenderTarget.html
+++ b/docs/api/en/renderers/WebGLCubeRenderTarget.html
@@ -42,7 +42,7 @@
 			[page:Constant type] - default is [page:Textures UnsignedByteType]. <br />
 			[page:Number anisotropy] - default is `1`. See
 			[page:Texture.anisotropy]<br />
-			[page:Constant colorSpace] - default is [page:Textures NoColorSpace].
+			[page:Constant colorSpace] - default is `null`.
 			<br />
 			[page:Boolean depthBuffer] - default is `true`.<br />
 			[page:Boolean stencilBuffer] - default is `false`.<br /><br />

--- a/docs/api/en/renderers/WebGLRenderTarget.html
+++ b/docs/api/en/renderers/WebGLRenderTarget.html
@@ -45,7 +45,7 @@
 			[page:Constant type] - default is [page:Textures UnsignedByteType]. <br />
 			[page:Number anisotropy] - default is `1`. See
 			[page:Texture.anisotropy]<br />
-			[page:Constant colorSpace] - default is [page:Textures NoColorSpace].
+			[page:Constant colorSpace] - default is `null`.
 			<br />
 			[page:Boolean depthBuffer] - default is `true`. <br />
 			[page:Boolean stencilBuffer] - default is `false`.<br />

--- a/docs/api/en/textures/CompressedTexture.html
+++ b/docs/api/en/textures/CompressedTexture.html
@@ -69,7 +69,7 @@
 			renderer.getMaxAnisotropy() to find the maximum valid anisotropy value for
 			the GPU; this value is usually a power of 2.<br />
 
-			[page:Constant colorSpace] -- The default is [page:Textures THREE.NoColorSpace]. 
+			[page:Constant colorSpace] -- The default is `null`.
 			See [page:Textures color space constants] for other
 			choices.<br /><br />
 		</p>

--- a/docs/api/en/textures/Texture.html
+++ b/docs/api/en/textures/Texture.html
@@ -255,7 +255,7 @@
 
 		<h3>[property:string colorSpace]</h3>
 		<p>
-			[page:Textures THREE.NoColorSpace] is the default. Textures containing color data should be
+			`null` is the default. Textures containing color data should be
 			annotated with [page:Textures THREE.SRGBColorSpace] or
 			[page:Textures THREE.LinearSRGBColorSpace].
 		</p>

--- a/docs/api/fr/constants/Core.html
+++ b/docs/api/fr/constants/Core.html
@@ -21,13 +21,9 @@ THREE.REVISION
 
 		<h2>Espaces colorimétriques</h2>
 		<code>
-THREE.NoColorSpace			
-THREE.SRGBColorSpace
-THREE.LinearSRGBColorSpace
+THREE.SRGBColorSpace = "srgb"
+THREE.LinearSRGBColorSpace = "srgb-linear"
 		</code>
-		<p>
-			[page:NoColorSpace] ne définit aucun espace colorimétrique spécifique. 
-		</p>
 		<p>
 			[page:SRGBColorSpace] (“srgb”) fait référence à l'espace colorimétrique défini par la Rec. 709 primaires, D65
 			point blanc et fonctions de transfert sRGB non linéaires. sRGB est l'espace colorimétrique par défaut dans

--- a/docs/api/fr/constants/Textures.html
+++ b/docs/api/fr/constants/Textures.html
@@ -545,10 +545,8 @@
 
 		<h2>Color Space</h2>
 		<code>
-		THREE.NoColorSpace
-		THREE.SRGBColorSpace
-		THREE.LinearSRGBColorSpace
-		THREE.DisplayP3ColorSpace
+		THREE.SRGBColorSpace = "srgb"
+		THREE.LinearSRGBColorSpace = "srgb-linear"
 		</code>
 		<p>
 		Used to define the color space of textures (and the output color space of the renderer).<br /><br />

--- a/docs/api/it/constants/Core.html
+++ b/docs/api/it/constants/Core.html
@@ -21,13 +21,9 @@ THREE.REVISION
 
 		<h2>Spazi Colore</h2>
 		<code>
-THREE.NoColorSpace			
-THREE.SRGBColorSpace
-THREE.LinearSRGBColorSpace
+THREE.SRGBColorSpace = "srgb"
+THREE.LinearSRGBColorSpace = "srgb-linear"
 		</code>
-		<p>
-			[page:NoColorSpace] non definisce uno spazio colore specifico. 
-		</p>
 		<p>
 			[page:SRGBColorSpace] (“srgb”) si riferisce allo spazio colore definito dal Rec. 709
       primari, punto di bianco D65 e funzioni di trasferimento sRGB non lineare. sRGB è lo spazio

--- a/docs/api/it/constants/Textures.html
+++ b/docs/api/it/constants/Textures.html
@@ -545,10 +545,8 @@
 
 		<h2>Color Space</h2>
 		<code>
-		THREE.NoColorSpace
-		THREE.SRGBColorSpace
-		THREE.LinearSRGBColorSpace
-		THREE.DisplayP3ColorSpace
+		THREE.SRGBColorSpace = "srgb"
+		THREE.LinearSRGBColorSpace = "srgb-linear"
 		</code>
 		<p>
 		Used to define the color space of textures (and the output color space of the renderer).<br /><br />

--- a/docs/api/it/renderers/WebGLCubeRenderTarget.html
+++ b/docs/api/it/renderers/WebGLCubeRenderTarget.html
@@ -40,7 +40,7 @@
 		[page:Constant format] - Il valore predefinito è [page:Textures RGBAFormat]. <br />
 		[page:Constant type] - Il valore predefinito è [page:Textures UnsignedByteType]. <br />
 		[page:Number anisotropy] - Il valore predefinito è `1`. Vedi [page:Texture.anisotropy]<br />
-		[page:Constant colorSpace] - Il valore predefinito è [page:Textures NoColorSpace]. <br />
+		[page:Constant colorSpace] - Il valore predefinito è `null`. <br />
 		[page:Boolean depthBuffer] - Il valore predefinito è `true`.<br />
 		[page:Boolean stencilBuffer] - Il valore predefinito è `false`.<br /><br />
 

--- a/docs/api/it/renderers/WebGLRenderTarget.html
+++ b/docs/api/it/renderers/WebGLRenderTarget.html
@@ -39,7 +39,7 @@
 		[page:Constant format] - il valore predefinito è [page:Textures RGBAFormat]. <br />
 		[page:Constant type] - il valore predefinito è [page:Textures UnsignedByteType]. <br />
 		[page:Number anisotropy] - il valore predefinito è `1`. Vedi [page:Texture.anisotropy]<br />
-		[page:Constant colorSpace] - il valore predefinito è [page:Textures NoColorSpace]. <br />
+		[page:Constant colorSpace] - il valore predefinito è `null`. <br />
 		[page:Boolean depthBuffer] - il valore predefinito è `true`. <br />
 		[page:Boolean stencilBuffer] - il valore predefinito è `false`.<br />
 		[page:Number samples] - il valore predefinito è 0.<br /><br />

--- a/docs/api/it/textures/CompressedTexture.html
+++ b/docs/api/it/textures/CompressedTexture.html
@@ -58,7 +58,7 @@
 		a costo di utilizzare più campioni di texture. Usa [page:WebGLrenderer.getMaxAnisotropy renderer.getMaxAnisotropy]() 
 		per trovare il valore di anisotropia massimo valido per la GPU; questo valore è solitamente una potenza di 2.<br />
 
-		[page:Constant colorSpace] -- The default is [page:Textures THREE.NoColorSpace].
+		[page:Constant colorSpace] -- The default is `null`.
 		See [page:Textures color space constants] for other choices.<br /><br />
 		</p>
 

--- a/docs/api/it/textures/Texture.html
+++ b/docs/api/it/textures/Texture.html
@@ -227,8 +227,8 @@
 
 		<h3>[property:string colorSpace]</h3>
 		<p>
-		[page:Textures THREE.NoColorSpace] è l'impostazione predefinita.
-		Vedi la pagina [page:Textures texture constants] per i dettagli su altri formati.
+			`null` è l'impostazione predefinita.
+			Vedi la pagina [page:Textures texture constants] per i dettagli su altri formati.
 		</p>
 
 		<h3>[property:Integer version]</h3>

--- a/docs/api/ko/constants/Textures.html
+++ b/docs/api/ko/constants/Textures.html
@@ -533,10 +533,8 @@
 
 		<h2>Color Space</h2>
 		<code>
-		THREE.NoColorSpace
-		THREE.SRGBColorSpace
-		THREE.LinearSRGBColorSpace
-		THREE.DisplayP3ColorSpace
+		THREE.SRGBColorSpace = "srgb"
+		THREE.LinearSRGBColorSpace = "srgb-linear"
 		</code>
 		<p>
 		Used to define the color space of textures (and the output color space of the renderer).<br /><br />

--- a/docs/api/pt-br/constants/Core.html
+++ b/docs/api/pt-br/constants/Core.html
@@ -21,13 +21,9 @@ THREE.REVISION
 
 		<h2>Espaço de Cores</h2>
 		<code>
-THREE.NoColorSpace			
-THREE.SRGBColorSpace
-THREE.LinearSRGBColorSpace
+THREE.SRGBColorSpace = "srgb"
+THREE.LinearSRGBColorSpace = "srgb-linear"
 		</code>
-		<p>
-			[page:NoColorSpace] não define nenhum espaço de cor específico.
-		</p>
 		<p>
 			[page:SRGBColorSpace] (“srgb”) refere-se ao espaço de cores definido pelo Rec. 709 primárias, D65
 			ponto branco e funções de transferência sRGB não lineares. sRGB é o espaço de cor padrão em

--- a/docs/api/pt-br/constants/Textures.html
+++ b/docs/api/pt-br/constants/Textures.html
@@ -545,10 +545,8 @@
 
 		<h2>Color Space</h2>
 		<code>
-		THREE.NoColorSpace
-		THREE.SRGBColorSpace
-		THREE.LinearSRGBColorSpace
-		THREE.DisplayP3ColorSpace
+		THREE.SRGBColorSpace = "srgb"
+		THREE.LinearSRGBColorSpace = "srgb-linear"
 		</code>
 		<p>
 		Used to define the color space of textures (and the output color space of the renderer).<br /><br />

--- a/docs/api/zh/constants/Textures.html
+++ b/docs/api/zh/constants/Textures.html
@@ -528,10 +528,8 @@
 
 	<h2>Color Space</h2>
 	<code>
-	THREE.NoColorSpace
-	THREE.SRGBColorSpace
-	THREE.LinearSRGBColorSpace
-	THREE.DisplayP3ColorSpace
+	THREE.SRGBColorSpace = "srgb"
+	THREE.LinearSRGBColorSpace = "srgb-linear"
 	</code>
 	<p>
 	Used to define the color space of textures (and the output color space of the renderer).<br /><br />

--- a/docs/api/zh/renderers/WebGLCubeRenderTarget.html
+++ b/docs/api/zh/renderers/WebGLCubeRenderTarget.html
@@ -37,7 +37,7 @@
 		[page:Constant format] - 默认是[page:Textures RGBAFormat]. <br />
 		[page:Constant type] - 默认是[page:Textures UnsignedByteType]. <br />
 		[page:Number anisotropy] - 默认是 *1*. 参见[page:Texture.anisotropy]<br />
-		[page:Constant colorSpace] - 默认是[page:Textures NoColorSpace]. <br />
+		[page:Constant colorSpace] - 默认是*null*. <br />
 		[page:Boolean depthBuffer] - 默认是*true*.<br />
 		[page:Boolean stencilBuffer] - default is *false*.<br /><br />
 

--- a/docs/api/zh/renderers/WebGLRenderTarget.html
+++ b/docs/api/zh/renderers/WebGLRenderTarget.html
@@ -35,7 +35,7 @@
 		[page:Constant format] - 默认是[page:Textures RGBAFormat]. <br />
 		[page:Constant type] - 默认是[page:Textures UnsignedByteType]. <br />
 		[page:Number anisotropy] - 默认是`1`. 参见[page:Texture.anisotropy]<br />
-		[page:Constant colorSpace] - 默认是[page:Textures NoColorSpace]. <br />
+		[page:Constant colorSpace] - 默认是`null`. <br />
 		[page:Boolean depthBuffer] - 默认是`true`.<br />
 		[page:Boolean stencilBuffer] - 默认是`false`.<br />
 		[page:Number samples] - 默认是`0`.<br /><br />

--- a/docs/api/zh/textures/CompressedTexture.html
+++ b/docs/api/zh/textures/CompressedTexture.html
@@ -57,7 +57,7 @@
 		默认情况下，这个值为1。设置一个较高的值将会产生比基本的mipmap更清晰的效果，代价是需要使用更多纹理样本。
 		使用[page:WebGLrenderer.getMaxAnisotropy renderer.getMaxAnisotropy]() 来查询GPU中各向异性的最大有效值；这个值通常是2的幂。<br />
 
-		[page:Constant colorSpace] -- The default is [page:Textures THREE.NoColorSpace].
+		[page:Constant colorSpace] -- The default is `null`.
 		See [page:Textures color space constants] for other choices.<br /><br />
 		</p>
 

--- a/docs/api/zh/textures/Texture.html
+++ b/docs/api/zh/textures/Texture.html
@@ -211,7 +211,7 @@
 
 		<h3>[property:string colorSpace]</h3>
 		<p>
-		默认值为[page:Textures THREE.NoColorSpace]。
+		默认值为*null*。
 		请参阅[page:Textures texture constants]来了解其他格式的详细信息。
 		</p>
 

--- a/docs/manual/en/introduction/Color-management.html
+++ b/docs/manual/en/introduction/Color-management.html
@@ -119,8 +119,8 @@
 	</ul>
 
 	<p>
-		Consider two very common color spaces: [page:SRGBColorSpace] ("sRGB") and
-		[page:LinearSRGBColorSpace] ("Linear-sRGB"). Both use the same primaries and white point,
+		Consider two very common color spaces: [page:SRGBColorSpace] ("srgb") and
+		[page:LinearSRGBColorSpace] ("srgb-linear"). Both use the same primaries and white point,
 		and therefore have the same color gamut. Both use the RGB color model. They differ only in
 		the transfer functions — Linear-sRGB is linear with respect to physical light intensity.
 		sRGB uses the nonlinear sRGB transfer functions, and more closely resembles the way that
@@ -184,8 +184,7 @@ THREE.ColorManagement.enabled = true;
 		<li>
 			<b>Non-color textures:</b> Textures that do not store color information (like .normalMap
 			or .roughnessMap) do not have an associated color space, and generally use the (default) texture
-			annotation of <i>texture.colorSpace = NoColorSpace</i>. In rare cases, non-color data
-			may be represented with other nonlinear encodings for technical reasons.
+			annotation of <i>texture.colorSpace = null</i>.
 		</li>
 	</ul>
 

--- a/docs/manual/fr/introduction/Color-management.html
+++ b/docs/manual/fr/introduction/Color-management.html
@@ -184,8 +184,7 @@ THREE.ColorManagement.enabled = true;
 		<li>
 			<b>Textures non-colorées:</b> Les textures qui ne stockent aucune information de couleur (comme .normalMap
 			ou .roughnessMap) n'ont pas d'espace colorimétrique associé, et utilisent généralement l'annotation de texture (par défaut)
-			<i>texture.colorSpace = NoColorSpace</i>. Dans de rares cas, les données ne concernant pas la couleur
-			peuvent être représentées par d'autres encodages non-linéaires pour des raisons techniques.
+			<i>texture.colorSpace = null</i>.
 		</li>
 	</ul>
 

--- a/docs/manual/it/introduction/Color-management.html
+++ b/docs/manual/it/introduction/Color-management.html
@@ -221,9 +221,7 @@
 				<b>Texture non a colori:</b> Le texture che non memorizzano informazioni
 				relative ai colori (come .normalMap o .roughnessMap) non hanno associato
 				uno spazio colore, e generalmente usano l'annotazione (predefinita)
-				<i>texture.colorSpace = NoColorSpace</i>. In rari casi, i dati non a
-				colori possono essere rappresentati con altre codifiche non lineari per
-				motivi tecnici.
+				<i>texture.colorSpace = null</i>.
 			</li>
 		</ul>
 

--- a/docs/manual/pt-br/introduction/Color-management.html
+++ b/docs/manual/pt-br/introduction/Color-management.html
@@ -184,8 +184,7 @@ THREE.ColorManagement.enabled = true;
 		<li>
 			<b>Texturas não coloridas:</b> Texturas que não armazenam informações de cores (como .normalMap
 			ou .roughnessMap) não têm um espaço de cores associado e geralmente usam a textura (padrão)
-			como <i>texture.colorSpace = NoColorSpace</i>. Em casos raros, dados sem cor
-			podem ser representados com outras codificações não lineares por motivos técnicos.
+			como <i>texture.colorSpace = null</i>.
 		</li>
 	</ul>
 

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -5,7 +5,6 @@ import {
 	DoubleSide,
 	InterpolateDiscrete,
 	InterpolateLinear,
-	NoColorSpace,
 	LinearFilter,
 	LinearMipmapLinearFilter,
 	LinearMipmapNearestFilter,
@@ -876,7 +875,7 @@ class GLTFWriter {
 		const texture = reference.clone();
 
 		texture.source = new Source( canvas );
-		texture.colorSpace = NoColorSpace;
+		texture.colorSpace = null;
 		texture.channel = ( metalnessMap || roughnessMap ).channel;
 
 		if ( metalnessMap && roughnessMap && metalnessMap.channel !== roughnessMap.channel ) {

--- a/examples/jsm/exporters/KTX2Exporter.js
+++ b/examples/jsm/exporters/KTX2Exporter.js
@@ -46,49 +46,49 @@ const VK_FORMAT_MAP = {
 
 	[ RGBAFormat ]: {
 		[ FloatType ]: {
-			[ null ]: VK_FORMAT_R32G32B32A32_SFLOAT,
 			[ LinearSRGBColorSpace ]: VK_FORMAT_R32G32B32A32_SFLOAT,
+			null: VK_FORMAT_R32G32B32A32_SFLOAT,
 		},
 		[ HalfFloatType ]: {
-			[ null ]: VK_FORMAT_R16G16B16A16_SFLOAT,
 			[ LinearSRGBColorSpace ]: VK_FORMAT_R16G16B16A16_SFLOAT,
+			null: VK_FORMAT_R16G16B16A16_SFLOAT,
 		},
 		[ UnsignedByteType ]: {
-			[ null ]: VK_FORMAT_R8G8B8A8_UNORM,
 			[ LinearSRGBColorSpace ]: VK_FORMAT_R8G8B8A8_UNORM,
 			[ SRGBColorSpace ]: VK_FORMAT_R8G8B8A8_SRGB,
+			null: VK_FORMAT_R8G8B8A8_UNORM,
 		},
 	},
 
 	[ RGFormat ]: {
 		[ FloatType ]: {
-			[ null ]: VK_FORMAT_R32G32_SFLOAT,
 			[ LinearSRGBColorSpace ]: VK_FORMAT_R32G32_SFLOAT,
+			null: VK_FORMAT_R32G32_SFLOAT,
 		},
 		[ HalfFloatType ]: {
-			[ null ]: VK_FORMAT_R16G16_SFLOAT,
 			[ LinearSRGBColorSpace ]: VK_FORMAT_R16G16_SFLOAT,
+			null: VK_FORMAT_R16G16_SFLOAT,
 		},
 		[ UnsignedByteType ]: {
-			[ null ]: VK_FORMAT_R8G8_UNORM,
 			[ LinearSRGBColorSpace ]: VK_FORMAT_R8G8_UNORM,
 			[ SRGBColorSpace ]: VK_FORMAT_R8G8_SRGB,
+			null: VK_FORMAT_R8G8_UNORM,
 		},
 	},
 
 	[ RedFormat ]: {
 		[ FloatType ]: {
-			[ null ]: VK_FORMAT_R32_SFLOAT,
 			[ LinearSRGBColorSpace ]: VK_FORMAT_R32_SFLOAT,
+			null: VK_FORMAT_R32_SFLOAT,
 		},
 		[ HalfFloatType ]: {
-			[ null ]: VK_FORMAT_R16_SFLOAT,
 			[ LinearSRGBColorSpace ]: VK_FORMAT_R16_SFLOAT,
+			null: VK_FORMAT_R16_SFLOAT,
 		},
 		[ UnsignedByteType ]: {
-			[ null ]: VK_FORMAT_R8_UNORM,
 			[ LinearSRGBColorSpace ]: VK_FORMAT_R8_UNORM,
 			[ SRGBColorSpace ]: VK_FORMAT_R8_SRGB,
+			null: VK_FORMAT_R8_UNORM,
 		},
 	},
 

--- a/examples/jsm/exporters/KTX2Exporter.js
+++ b/examples/jsm/exporters/KTX2Exporter.js
@@ -7,7 +7,6 @@ import {
 	RGIntegerFormat,
 	RedFormat,
 	RedIntegerFormat,
-	NoColorSpace,
 	LinearSRGBColorSpace,
 	SRGBColorSpace,
 	DataTexture,
@@ -47,15 +46,15 @@ const VK_FORMAT_MAP = {
 
 	[ RGBAFormat ]: {
 		[ FloatType ]: {
-			[ NoColorSpace ]: VK_FORMAT_R32G32B32A32_SFLOAT,
+			[ null ]: VK_FORMAT_R32G32B32A32_SFLOAT,
 			[ LinearSRGBColorSpace ]: VK_FORMAT_R32G32B32A32_SFLOAT,
 		},
 		[ HalfFloatType ]: {
-			[ NoColorSpace ]: VK_FORMAT_R16G16B16A16_SFLOAT,
+			[ null ]: VK_FORMAT_R16G16B16A16_SFLOAT,
 			[ LinearSRGBColorSpace ]: VK_FORMAT_R16G16B16A16_SFLOAT,
 		},
 		[ UnsignedByteType ]: {
-			[ NoColorSpace ]: VK_FORMAT_R8G8B8A8_UNORM,
+			[ null ]: VK_FORMAT_R8G8B8A8_UNORM,
 			[ LinearSRGBColorSpace ]: VK_FORMAT_R8G8B8A8_UNORM,
 			[ SRGBColorSpace ]: VK_FORMAT_R8G8B8A8_SRGB,
 		},
@@ -63,15 +62,15 @@ const VK_FORMAT_MAP = {
 
 	[ RGFormat ]: {
 		[ FloatType ]: {
-			[ NoColorSpace ]: VK_FORMAT_R32G32_SFLOAT,
+			[ null ]: VK_FORMAT_R32G32_SFLOAT,
 			[ LinearSRGBColorSpace ]: VK_FORMAT_R32G32_SFLOAT,
 		},
 		[ HalfFloatType ]: {
-			[ NoColorSpace ]: VK_FORMAT_R16G16_SFLOAT,
+			[ null ]: VK_FORMAT_R16G16_SFLOAT,
 			[ LinearSRGBColorSpace ]: VK_FORMAT_R16G16_SFLOAT,
 		},
 		[ UnsignedByteType ]: {
-			[ NoColorSpace ]: VK_FORMAT_R8G8_UNORM,
+			[ null ]: VK_FORMAT_R8G8_UNORM,
 			[ LinearSRGBColorSpace ]: VK_FORMAT_R8G8_UNORM,
 			[ SRGBColorSpace ]: VK_FORMAT_R8G8_SRGB,
 		},
@@ -79,15 +78,15 @@ const VK_FORMAT_MAP = {
 
 	[ RedFormat ]: {
 		[ FloatType ]: {
-			[ NoColorSpace ]: VK_FORMAT_R32_SFLOAT,
+			[ null ]: VK_FORMAT_R32_SFLOAT,
 			[ LinearSRGBColorSpace ]: VK_FORMAT_R32_SFLOAT,
 		},
 		[ HalfFloatType ]: {
-			[ NoColorSpace ]: VK_FORMAT_R16_SFLOAT,
+			[ null ]: VK_FORMAT_R16_SFLOAT,
 			[ LinearSRGBColorSpace ]: VK_FORMAT_R16_SFLOAT,
 		},
 		[ UnsignedByteType ]: {
-			[ NoColorSpace ]: VK_FORMAT_R8_UNORM,
+			[ null ]: VK_FORMAT_R8_UNORM,
 			[ LinearSRGBColorSpace ]: VK_FORMAT_R8_UNORM,
 			[ SRGBColorSpace ]: VK_FORMAT_R8_SRGB,
 		},
@@ -107,7 +106,7 @@ const KHR_DF_CHANNEL_MAP = {
 const ERROR_INPUT = 'THREE.KTX2Exporter: Supported inputs are DataTexture, Data3DTexture, or WebGLRenderer and WebGLRenderTarget.';
 const ERROR_FORMAT = 'THREE.KTX2Exporter: Supported formats are RGBAFormat, RGFormat, or RedFormat.';
 const ERROR_TYPE = 'THREE.KTX2Exporter: Supported types are FloatType, HalfFloatType, or UnsignedByteType."';
-const ERROR_COLOR_SPACE = 'THREE.KTX2Exporter: Supported color spaces are SRGBColorSpace (UnsignedByteType only), LinearSRGBColorSpace, or NoColorSpace.';
+const ERROR_COLOR_SPACE = 'THREE.KTX2Exporter: Supported color spaces are SRGBColorSpace (UnsignedByteType only), LinearSRGBColorSpace, or null.';
 
 export class KTX2Exporter {
 
@@ -169,7 +168,7 @@ export class KTX2Exporter {
 		const basicDesc = container.dataFormatDescriptor[ 0 ];
 
 		basicDesc.colorModel = KHR_DF_MODEL_RGBSDA;
-		basicDesc.colorPrimaries = texture.colorSpace === NoColorSpace
+		basicDesc.colorPrimaries = texture.colorSpace === null
 			? KHR_DF_PRIMARIES_UNSPECIFIED
 			: KHR_DF_PRIMARIES_BT709;
 		basicDesc.transferFunction = texture.colorSpace === SRGBColorSpace
@@ -188,7 +187,7 @@ export class KTX2Exporter {
 
 			let channelType = KHR_DF_CHANNEL_MAP[ i ];
 
-			if ( texture.colorSpace === LinearSRGBColorSpace || texture.colorSpace === NoColorSpace ) {
+			if ( texture.colorSpace === LinearSRGBColorSpace || texture.colorSpace === null ) {
 
 				channelType |= KHR_DF_SAMPLE_DATATYPE_LINEAR;
 

--- a/examples/jsm/lights/LightProbeGenerator.js
+++ b/examples/jsm/lights/LightProbeGenerator.js
@@ -4,8 +4,7 @@ import {
 	LinearSRGBColorSpace,
 	SphericalHarmonics3,
 	Vector3,
-	SRGBColorSpace,
-	NoColorSpace
+	SRGBColorSpace
 } from 'three';
 
 class LightProbeGenerator {
@@ -234,7 +233,7 @@ function convertColorToLinear( color, colorSpace ) {
 			break;
 
 		case LinearSRGBColorSpace:
-		case NoColorSpace:
+		case null:
 
 			break;
 

--- a/examples/jsm/loaders/EXRLoader.js
+++ b/examples/jsm/loaders/EXRLoader.js
@@ -3,7 +3,6 @@ import {
 	DataUtils,
 	FloatType,
 	HalfFloatType,
-	NoColorSpace,
 	LinearFilter,
 	LinearSRGBColorSpace,
 	RedFormat,
@@ -2210,7 +2209,7 @@ class EXRLoader extends DataTextureLoader {
 			} else {
 
 				EXRDecoder.format = RedFormat;
-				EXRDecoder.colorSpace = NoColorSpace;
+				EXRDecoder.colorSpace = null;
 
 			}
 

--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -19,7 +19,6 @@ import {
 	FileLoader,
 	FloatType,
 	HalfFloatType,
-	NoColorSpace,
 	LinearFilter,
 	LinearMipmapLinearFilter,
 	Loader,
@@ -267,8 +266,8 @@ class KTX2Loader extends Loader {
 		texture.generateMipmaps = false;
 
 		texture.needsUpdate = true;
-		// TODO: Detect NoColorSpace vs. LinearSRGBColorSpace based on primaries.
-		texture.colorSpace = dfdTransferFn === KHR_DF_TRANSFER_SRGB ? SRGBColorSpace : NoColorSpace;
+		// TODO: Detect null vs. LinearSRGBColorSpace based on primaries.
+		texture.colorSpace = dfdTransferFn === KHR_DF_TRANSFER_SRGB ? SRGBColorSpace : null;
 		texture.premultiplyAlpha = !! ( dfdFlags & KHR_DF_FLAG_ALPHA_PREMULTIPLIED );
 
 		return texture;
@@ -794,7 +793,7 @@ async function createDataTexture( container ) {
 
 	texture.type = TYPE_MAP[ vkFormat ];
 	texture.format = FORMAT_MAP[ vkFormat ];
-	texture.colorSpace = COLOR_SPACE_MAP[ vkFormat ] || NoColorSpace;
+	texture.colorSpace = COLOR_SPACE_MAP[ vkFormat ] || null;
 
 	texture.needsUpdate = true;
 

--- a/examples/jsm/nodes/core/NodeBuilder.js
+++ b/examples/jsm/nodes/core/NodeBuilder.js
@@ -7,7 +7,7 @@ import NodeKeywords from './NodeKeywords.js';
 import NodeCache from './NodeCache.js';
 import { NodeUpdateType, defaultBuildStages, shaderStages } from './constants.js';
 
-import { REVISION, NoColorSpace, LinearEncoding, sRGBEncoding, SRGBColorSpace, Color, Vector2, Vector3, Vector4 } from 'three';
+import { REVISION, LinearEncoding, sRGBEncoding, SRGBColorSpace, Color, Vector2, Vector3, Vector4 } from 'three';
 
 import { stack } from './StackNode.js';
 import { maxMipLevel } from '../utils/MaxMipLevelNode.js';
@@ -374,7 +374,7 @@ class NodeBuilder {
 
 		} else {
 
-			colorSpace = NoColorSpace;
+			colorSpace = null;
 
 		}
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -140,7 +140,7 @@ export const AdditiveAnimationBlendMode = 2501;
 export const TrianglesDrawMode = 0;
 export const TriangleStripDrawMode = 1;
 export const TriangleFanDrawMode = 2;
-/** @deprecated Use LinearSRGBColorSpace or NoColorSpace in three.js r152+. */
+/** @deprecated Use LinearSRGBColorSpace or *null* in three.js r152+. */
 export const LinearEncoding = 3000;
 /** @deprecated Use SRGBColorSpace in three.js r152+. */
 export const sRGBEncoding = 3001;
@@ -150,7 +150,8 @@ export const TangentSpaceNormalMap = 0;
 export const ObjectSpaceNormalMap = 1;
 
 // Color space string identifiers, matching CSS Color Module Level 4 and WebGPU names where available.
-export const NoColorSpace = '';
+/** @deprecated Use *null* in three.js r152+. */
+export const NoColorSpace = null;
 export const SRGBColorSpace = 'srgb';
 export const LinearSRGBColorSpace = 'srgb-linear';
 export const DisplayP3ColorSpace = 'display-p3';

--- a/src/renderers/WebGLCubeRenderTarget.js
+++ b/src/renderers/WebGLCubeRenderTarget.js
@@ -1,4 +1,4 @@
-import { BackSide, LinearFilter, LinearMipmapLinearFilter, NoBlending, NoColorSpace, SRGBColorSpace, sRGBEncoding } from '../constants.js';
+import { BackSide, LinearFilter, LinearMipmapLinearFilter, NoBlending, SRGBColorSpace, sRGBEncoding } from '../constants.js';
 import { Mesh } from '../objects/Mesh.js';
 import { BoxGeometry } from '../geometries/BoxGeometry.js';
 import { ShaderMaterial } from '../materials/ShaderMaterial.js';
@@ -23,7 +23,7 @@ class WebGLCubeRenderTarget extends WebGLRenderTarget {
 
 			// @deprecated, r152
 			warnOnce( 'THREE.WebGLCubeRenderTarget: option.encoding has been replaced by option.colorSpace.' );
-			options.colorSpace = options.encoding === sRGBEncoding ? SRGBColorSpace : NoColorSpace;
+			options.colorSpace = options.encoding === sRGBEncoding ? SRGBColorSpace : null;
 
 		}
 

--- a/src/renderers/WebGLRenderTarget.js
+++ b/src/renderers/WebGLRenderTarget.js
@@ -1,6 +1,6 @@
 import { EventDispatcher } from '../core/EventDispatcher.js';
 import { Texture } from '../textures/Texture.js';
-import { LinearFilter, NoColorSpace, SRGBColorSpace, sRGBEncoding } from '../constants.js';
+import { LinearFilter, SRGBColorSpace, sRGBEncoding } from '../constants.js';
 import { Vector4 } from '../math/Vector4.js';
 import { Source } from '../textures/Source.js';
 import { warnOnce } from '../utils.js';
@@ -33,7 +33,7 @@ class WebGLRenderTarget extends EventDispatcher {
 
 			// @deprecated, r152
 			warnOnce( 'THREE.WebGLRenderTarget: option.encoding has been replaced by option.colorSpace.' );
-			options.colorSpace = options.encoding === sRGBEncoding ? SRGBColorSpace : NoColorSpace;
+			options.colorSpace = options.encoding === sRGBEncoding ? SRGBColorSpace : null;
 
 		}
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -1,4 +1,4 @@
-import { LinearFilter, LinearMipmapLinearFilter, LinearMipmapNearestFilter, NearestFilter, NearestMipmapLinearFilter, NearestMipmapNearestFilter, RGBAFormat, DepthFormat, DepthStencilFormat, UnsignedShortType, UnsignedIntType, UnsignedInt248Type, FloatType, HalfFloatType, MirroredRepeatWrapping, ClampToEdgeWrapping, RepeatWrapping, UnsignedByteType, _SRGBAFormat, NoColorSpace, LinearSRGBColorSpace, SRGBColorSpace } from '../../constants.js';
+import { LinearFilter, LinearMipmapLinearFilter, LinearMipmapNearestFilter, NearestFilter, NearestMipmapLinearFilter, NearestMipmapNearestFilter, RGBAFormat, DepthFormat, DepthStencilFormat, UnsignedShortType, UnsignedIntType, UnsignedInt248Type, FloatType, HalfFloatType, MirroredRepeatWrapping, ClampToEdgeWrapping, RepeatWrapping, UnsignedByteType, _SRGBAFormat, LinearSRGBColorSpace, SRGBColorSpace } from '../../constants.js';
 import * as MathUtils from '../../math/MathUtils.js';
 import { ImageUtils } from '../../extras/ImageUtils.js';
 import { createElementNS } from '../../utils.js';
@@ -1926,7 +1926,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		if ( texture.isCompressedTexture === true || texture.format === _SRGBAFormat ) return image;
 
-		if ( colorSpace !== LinearSRGBColorSpace && colorSpace !== NoColorSpace ) {
+		if ( colorSpace !== LinearSRGBColorSpace && colorSpace !== null ) {
 
 			// sRGB
 

--- a/src/renderers/webgl/WebGLUtils.js
+++ b/src/renderers/webgl/WebGLUtils.js
@@ -1,10 +1,10 @@
-import { RGBA_ASTC_4x4_Format, RGBA_ASTC_5x4_Format, RGBA_ASTC_5x5_Format, RGBA_ASTC_6x5_Format, RGBA_ASTC_6x6_Format, RGBA_ASTC_8x5_Format, RGBA_ASTC_8x6_Format, RGBA_ASTC_8x8_Format, RGBA_ASTC_10x5_Format, RGBA_ASTC_10x6_Format, RGBA_ASTC_10x8_Format, RGBA_ASTC_10x10_Format, RGBA_ASTC_12x10_Format, RGBA_ASTC_12x12_Format, RGB_ETC1_Format, RGB_ETC2_Format, RGBA_ETC2_EAC_Format, RGBA_PVRTC_2BPPV1_Format, RGBA_PVRTC_4BPPV1_Format, RGB_PVRTC_2BPPV1_Format, RGB_PVRTC_4BPPV1_Format, RGBA_S3TC_DXT5_Format, RGBA_S3TC_DXT3_Format, RGBA_S3TC_DXT1_Format, RGB_S3TC_DXT1_Format, DepthFormat, DepthStencilFormat, LuminanceAlphaFormat, LuminanceFormat, RedFormat, RGBAFormat, AlphaFormat, RedIntegerFormat, RGFormat, RGIntegerFormat, RGBAIntegerFormat, HalfFloatType, FloatType, UnsignedIntType, IntType, UnsignedShortType, ShortType, ByteType, UnsignedInt248Type, UnsignedShort5551Type, UnsignedShort4444Type, UnsignedByteType, RGBA_BPTC_Format, _SRGBAFormat, RED_RGTC1_Format, SIGNED_RED_RGTC1_Format, RED_GREEN_RGTC2_Format, SIGNED_RED_GREEN_RGTC2_Format, SRGBColorSpace, NoColorSpace } from '../../constants.js';
+import { RGBA_ASTC_4x4_Format, RGBA_ASTC_5x4_Format, RGBA_ASTC_5x5_Format, RGBA_ASTC_6x5_Format, RGBA_ASTC_6x6_Format, RGBA_ASTC_8x5_Format, RGBA_ASTC_8x6_Format, RGBA_ASTC_8x8_Format, RGBA_ASTC_10x5_Format, RGBA_ASTC_10x6_Format, RGBA_ASTC_10x8_Format, RGBA_ASTC_10x10_Format, RGBA_ASTC_12x10_Format, RGBA_ASTC_12x12_Format, RGB_ETC1_Format, RGB_ETC2_Format, RGBA_ETC2_EAC_Format, RGBA_PVRTC_2BPPV1_Format, RGBA_PVRTC_4BPPV1_Format, RGB_PVRTC_2BPPV1_Format, RGB_PVRTC_4BPPV1_Format, RGBA_S3TC_DXT5_Format, RGBA_S3TC_DXT3_Format, RGBA_S3TC_DXT1_Format, RGB_S3TC_DXT1_Format, DepthFormat, DepthStencilFormat, LuminanceAlphaFormat, LuminanceFormat, RedFormat, RGBAFormat, AlphaFormat, RedIntegerFormat, RGFormat, RGIntegerFormat, RGBAIntegerFormat, HalfFloatType, FloatType, UnsignedIntType, IntType, UnsignedShortType, ShortType, ByteType, UnsignedInt248Type, UnsignedShort5551Type, UnsignedShort4444Type, UnsignedByteType, RGBA_BPTC_Format, _SRGBAFormat, RED_RGTC1_Format, SIGNED_RED_RGTC1_Format, RED_GREEN_RGTC2_Format, SIGNED_RED_GREEN_RGTC2_Format, SRGBColorSpace } from '../../constants.js';
 
 function WebGLUtils( gl, extensions, capabilities ) {
 
 	const isWebGL2 = capabilities.isWebGL2;
 
-	function convert( p, colorSpace = NoColorSpace ) {
+	function convert( p, colorSpace = null ) {
 
 		let extension;
 

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -10,7 +10,6 @@ import {
 	UVMapping,
 	sRGBEncoding,
 	SRGBColorSpace,
-	NoColorSpace,
 	LinearEncoding
 } from '../constants.js';
 import * as MathUtils from '../math/MathUtils.js';
@@ -23,7 +22,7 @@ let textureId = 0;
 
 class Texture extends EventDispatcher {
 
-	constructor( image = Texture.DEFAULT_IMAGE, mapping = Texture.DEFAULT_MAPPING, wrapS = ClampToEdgeWrapping, wrapT = ClampToEdgeWrapping, magFilter = LinearFilter, minFilter = LinearMipmapLinearFilter, format = RGBAFormat, type = UnsignedByteType, anisotropy = Texture.DEFAULT_ANISOTROPY, colorSpace = NoColorSpace ) {
+	constructor( image = Texture.DEFAULT_IMAGE, mapping = Texture.DEFAULT_MAPPING, wrapS = ClampToEdgeWrapping, wrapT = ClampToEdgeWrapping, magFilter = LinearFilter, minFilter = LinearMipmapLinearFilter, format = RGBAFormat, type = UnsignedByteType, anisotropy = Texture.DEFAULT_ANISOTROPY, colorSpace = null ) {
 
 		super();
 
@@ -66,14 +65,14 @@ class Texture extends EventDispatcher {
 		this.flipY = true;
 		this.unpackAlignment = 4;	// valid values: 1, 2, 4, 8 (see http://www.khronos.org/opengles/sdk/docs/man/xhtml/glPixelStorei.xml)
 
-		if ( typeof colorSpace === 'string' ) {
+		if ( typeof colorSpace === 'string' || colorSpace === null ) {
 
 			this.colorSpace = colorSpace;
 
 		} else { // @deprecated, r152
 
 			warnOnce( 'THREE.Texture: Property .encoding has been replaced by .colorSpace.' );
-			this.colorSpace = colorSpace === sRGBEncoding ? SRGBColorSpace : NoColorSpace;
+			this.colorSpace = colorSpace === sRGBEncoding ? SRGBColorSpace : null;
 
 		}
 
@@ -325,7 +324,7 @@ class Texture extends EventDispatcher {
 	set encoding( encoding ) { // @deprecated, r152
 
 		warnOnce( 'THREE.Texture: Property .encoding has been replaced by .colorSpace.' );
-		this.colorSpace = encoding === sRGBEncoding ? SRGBColorSpace : NoColorSpace;
+		this.colorSpace = encoding === sRGBEncoding ? SRGBColorSpace : null;
 
 	}
 

--- a/test/unit/src/constants.tests.js
+++ b/test/unit/src/constants.tests.js
@@ -165,7 +165,6 @@ export default QUnit.module( 'Constants', () => {
 		assert.equal( Constants.TangentSpaceNormalMap, 0, 'TangentSpaceNormalMap is equal to 0' );
 		assert.equal( Constants.ObjectSpaceNormalMap, 1, 'ObjectSpaceNormalMap is equal to 1' );
 
-		assert.equal( Constants.NoColorSpace, '', 'NoColorSpace is equal to ""' );
 		assert.equal( Constants.SRGBColorSpace, 'srgb', 'SRGBColorSpace is equal to srgb' );
 		assert.equal( Constants.LinearSRGBColorSpace, 'srgb-linear', 'LinearSRGBColorSpace is equal to srgb-linear' );
 		assert.equal( Constants.DisplayP3ColorSpace, 'display-p3', 'DisplayP3ColorSpace is equal to display-p3' );


### PR DESCRIPTION
Related:

- #23614 
- https://github.com/mrdoob/three.js/pull/25857#issuecomment-1515712218

While cleaning up docs, I'm also trying to mention the CSS Color Module Level 4 strings ("srgb", "srgb-linear") where appropriate, to clarify the mappings to CSS. I've left DisplayP3ColorSpace undocumented for now, as it's not ready for use.