### PR TITLE
fix: fbxLoader cause error when modelNodes sometimes like [undefined]

### DIFF
--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -1548,7 +1548,9 @@ class GeometryParser {
 
 			return fbxTree.Objects.Model[ parent.ID ];
 
-		} );
+		} ).filter( i => i !== undefined );
+		// filter items such as [undefined], it will cause error when using modelNodes[0] later
+		// eg: if('some property' in modelNode) will cause error
 
 		// don't create geometry if it is not associated with any models
 		if ( modelNodes.length === 0 ) return;

--- a/examples/jsm/loaders/NRRDLoader.js
+++ b/examples/jsm/loaders/NRRDLoader.js
@@ -473,10 +473,10 @@ class NRRDLoader extends Loader {
 
 		volume.inverseMatrix = new Matrix4();
 		volume.inverseMatrix.copy( volume.matrix ).invert();
-		
+
 		volume.RASDimensions = [
-			Math.floor( volume.xLength * spacingX ), 
-			Math.floor( volume.yLength * spacingY ), 
+			Math.floor( volume.xLength * spacingX ),
+			Math.floor( volume.yLength * spacingY ),
 			Math.floor( volume.zLength * spacingZ )
 		];
 

--- a/examples/jsm/misc/Volume.js
+++ b/examples/jsm/misc/Volume.js
@@ -343,13 +343,14 @@ class Volume {
 
 		let iLength, jLength;
 
-		if( ! this.segmentation ) {
+		if ( ! this.segmentation ) {
 
 			firstDirection.applyMatrix4( volume.inverseMatrix ).normalize();
 			secondDirection.applyMatrix4( volume.inverseMatrix ).normalize();
 			axisInIJK.applyMatrix4( volume.inverseMatrix ).normalize();
 
 		}
+
 		firstDirection.arglet = 'i';
 		secondDirection.arglet = 'j';
 		iLength = Math.floor( Math.abs( firstDirection.dot( dimensions ) ) );


### PR DESCRIPTION
Related issue: #XXXX

**Description**
when loading a fbx model as below:
``` js
const loader = new FBXLoader();
const data = await loader.loadAsync(model);
```
maybe my model has some problem, it caused the error:
```
caught (in promise) TypeError: Cannot use 'in' operator to search for 'RotationOrder' in undefined
    at GeometryParser.parseMeshGeometry (FBXLoader.js:1582:8)
    at GeometryParser.parseGeometry (FBXLoader.js:1530:17)
    at GeometryParser.parse (FBXLoader.js:1504:22)
    at FBXTreeParser.parse (FBXLoader.js:167:44)
    at FBXLoader.parse (FBXLoader.js:143:59)
    at Object.onLoad (FBXLoader.js:91:19)
    at three.module.js:41311:38
```

just logged the `modelNodes` like this: 
```
🚀 ~ modelNodes: [{…}]
🚀 ~ modelNodes: [undefined]
```
there is a modelNodes [undefined], so it caused error ` Cannot use 'in' operator to search for 'RotationOrder' in undefined`.

i  add a filter to modelNodes to fix it:
```js
const modelNodes = relationships.parents.map( function ( parent ) {
	return fbxTree.Objects.Model[ parent.ID ];
} ).filter( i => i !== undefined );
```