### PR TITLE
Fix sourcemaps in dev builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "eslint-plugin-import": "^2.27.5",
         "failonlyreporter": "^1.0.0",
         "jimp": "^0.22.7",
+        "magic-string": "^0.30.0",
         "pixelmatch": "^5.3.0",
         "puppeteer-core": "^19.8.1",
         "qunit": "^2.19.4",
@@ -4144,6 +4145,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
+      "integrity": "sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.13"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/make-fetch-happen": {
@@ -10239,6 +10252,15 @@
       "dev": true,
       "requires": {
         "yallist": "^4.0.0"
+      }
+    },
+    "magic-string": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
+      "integrity": "sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/sourcemap-codec": "^1.4.13"
       }
     },
     "make-fetch-happen": {

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "eslint-plugin-import": "^2.27.5",
     "failonlyreporter": "^1.0.0",
     "jimp": "^0.22.7",
+    "magic-string": "^0.30.0",
     "pixelmatch": "^5.3.0",
     "puppeteer-core": "^19.8.1",
     "qunit": "^2.19.4",

--- a/utils/build/rollup.config.js
+++ b/utils/build/rollup.config.js
@@ -1,4 +1,5 @@
 import terser from '@rollup/plugin-terser';
+import MagicString from 'magic-string';
 
 function addons() {
 
@@ -8,11 +9,13 @@ function addons() {
 
 			if ( /\/examples\/jsm\//.test( id ) === false ) return;
 
-			code = code.replace( 'build/three.module.js', 'src/Three.js' );
+			code = new MagicString( code );
+
+			code.replace( 'build/three.module.js', 'src/Three.js' );
 
 			return {
-				code: code,
-				map: null
+				code: code.toString(),
+				map: code.generateMap().toString()
 			};
 
 		}
@@ -29,7 +32,9 @@ export function glsl() {
 
 			if ( /\.glsl.js$/.test( id ) === false ) return;
 
-			code = code.replace( /\/\* glsl \*\/\`(.*?)\`/sg, function ( match, p1 ) {
+			code = new MagicString( code );
+
+			code.replace( /\/\* glsl \*\/\`(.*?)\`/sg, function ( match, p1 ) {
 
 				return JSON.stringify(
 					p1
@@ -43,8 +48,8 @@ export function glsl() {
 			} );
 
 			return {
-				code: code,
-				map: null
+				code: code.toString(),
+				map: code.generateMap().toString()
 			};
 
 		}
@@ -59,12 +64,18 @@ function header() {
 
 		renderChunk( code ) {
 
-			return `/**
+			code = new MagicString( code );
+
+			code.prepend(`/**
  * @license
  * Copyright 2010-2023 Three.js Authors
  * SPDX-License-Identifier: MIT
- */
-${ code }`;
+ */\n`);
+
+			return {
+				code: code.toString(),
+				map: code.generateMap().toString()
+			};
 
 		}
 
@@ -78,8 +89,14 @@ function deprecationWarning() {
 
 		renderChunk( code ) {
 
-			return `console.warn( 'Scripts "build/three.js" and "build/three.min.js" are deprecated with r150+, and will be removed with r160. Please use ES Modules or alternatives: https://threejs.org/docs/index.html#manual/en/introduction/Installation' );
-${ code }`;
+			code = new MagicString( code );
+
+			code.prepend(`console.warn( 'Scripts "build/three.js" and "build/three.min.js" are deprecated with r150+, and will be removed with r160. Please use ES Modules or alternatives: https://threejs.org/docs/index.html#manual/en/introduction/Installation' );\n`);
+
+			return {
+				code: code.toString(),
+				map: code.generateMap().toString()
+			};
 
 		}
 

--- a/utils/build/rollup.config.js
+++ b/utils/build/rollup.config.js
@@ -66,11 +66,11 @@ function header() {
 
 			code = new MagicString( code );
 
-			code.prepend(`/**
+			code.prepend( `/**
  * @license
  * Copyright 2010-2023 Three.js Authors
  * SPDX-License-Identifier: MIT
- */\n`);
+ */\n` );
 
 			return {
 				code: code.toString(),
@@ -91,7 +91,7 @@ function deprecationWarning() {
 
 			code = new MagicString( code );
 
-			code.prepend(`console.warn( 'Scripts "build/three.js" and "build/three.min.js" are deprecated with r150+, and will be removed with r160. Please use ES Modules or alternatives: https://threejs.org/docs/index.html#manual/en/introduction/Installation' );\n`);
+			code.prepend( `console.warn( 'Scripts "build/three.js" and "build/three.min.js" are deprecated with r150+, and will be removed with r160. Please use ES Modules or alternatives: https://threejs.org/docs/index.html#manual/en/introduction/Installation' );\n` );
 
 			return {
 				code: code.toString(),


### PR DESCRIPTION
Sourcemaps have been broken in development builds since we began using custom Rollup plugins, as far as I can tell.  This PR updates our existing Rollup plugins to preserve source maps, so that we can set debug points in source files (rather than `three.module.js`) during development.

The update requires npm package [`magic-string`](https://www.npmjs.com/package/magic-string) as a dev dependency, 6.4kb minzipped, by the author of Rollup.

Related:

- https://github.com/mrdoob/three.js/pull/20389#issuecomment-696589097
- https://github.com/mrdoob/three.js/issues/9941