### PR TITLE
WebGPURenderer: Make work without three/nodes

### DIFF
--- a/examples/jsm/renderers/webgpu/WebGPUBackground.js
+++ b/examples/jsm/renderers/webgpu/WebGPUBackground.js
@@ -1,6 +1,6 @@
 import { GPULoadOp, GPUStoreOp } from './constants.js';
 import { Color, Mesh, BoxGeometry, BackSide } from 'three';
-import { context, positionWorldDirection, MeshBasicNodeMaterial } from 'three/nodes';
+import { context, positionWorldDirection, MeshBasicNodeMaterial } from '../../nodes/Nodes.js';
 
 let _clearAlpha;
 const _clearColor = new Color();

--- a/examples/jsm/renderers/webgpu/WebGPURenderStates.js
+++ b/examples/jsm/renderers/webgpu/WebGPURenderStates.js
@@ -1,5 +1,5 @@
 import WebGPUWeakMap from './WebGPUWeakMap.js';
-import { lights } from 'three/nodes';
+import { lights } from '../../nodes/Nodes.js';
 
 class WebGPURenderState {
 

--- a/examples/jsm/renderers/webgpu/nodes/WebGPUNodeBuilder.js
+++ b/examples/jsm/renderers/webgpu/nodes/WebGPUNodeBuilder.js
@@ -12,7 +12,7 @@ import { getVectorLength, getStrideLength } from '../WebGPUBufferUtils.js';
 
 import WebGPURenderTarget from '../WebGPURenderTarget.js';
 
-import { NodeBuilder, WGSLNodeParser, CodeNode, NodeMaterial } from 'three/nodes';
+import { NodeBuilder, WGSLNodeParser, CodeNode, NodeMaterial } from '../../../nodes/Nodes.js';
 
 const gpuShaderStageLib = {
 	'vertex': GPUShaderStage.VERTEX,

--- a/examples/jsm/renderers/webgpu/nodes/WebGPUNodes.js
+++ b/examples/jsm/renderers/webgpu/nodes/WebGPUNodes.js
@@ -1,6 +1,6 @@
 import WebGPUNodeBuilder from './WebGPUNodeBuilder.js';
 import { NoToneMapping, EquirectangularReflectionMapping, EquirectangularRefractionMapping } from 'three';
-import { NodeFrame, cubeTexture, texture, rangeFog, densityFog, reference, toneMapping, positionWorld, modelWorldMatrix, transformDirection, equirectUV, viewportBottomLeft } from 'three/nodes';
+import { NodeFrame, cubeTexture, texture, rangeFog, densityFog, reference, toneMapping, positionWorld, modelWorldMatrix, transformDirection, equirectUV, viewportBottomLeft } from '../../../nodes/Nodes.js';
 
 class WebGPUNodes {
 

--- a/examples/webgpu_loader_gltf.html
+++ b/examples/webgpu_loader_gltf.html
@@ -23,8 +23,7 @@
 			{
 				"imports": {
 					"three": "../build/three.module.js",
-					"three/addons/": "./jsm/",
-					"three/nodes": "./jsm/nodes/Nodes.js"
+					"three/addons/": "./jsm/"
 				}
 			}
 		</script>


### PR DESCRIPTION
**Description**

It makes `WebGPURenderer` work without `three/nodes` bare import specifiers.

/cc @mrdoob 