### PR TITLE
OBJLoader: Clarify comment skips.

### DIFF
--- a/examples/jsm/loaders/OBJLoader.js
+++ b/examples/jsm/loaders/OBJLoader.js
@@ -515,7 +515,8 @@ class OBJLoader extends Loader {
 			const lineFirstChar = line.charAt( 0 );
 
 			// @todo invoke passed in handler if any
-			if ( lineFirstChar === '#' ) continue;
+			const thisLineIsAComment = lineFirstChar === '#';
+			if ( thisLineIsAComment ) continue;
 
 			if ( lineFirstChar === 'v' ) {
 

--- a/examples/jsm/loaders/OBJLoader.js
+++ b/examples/jsm/loaders/OBJLoader.js
@@ -515,8 +515,7 @@ class OBJLoader extends Loader {
 			const lineFirstChar = line.charAt( 0 );
 
 			// @todo invoke passed in handler if any
-			const thisLineIsAComment = lineFirstChar === '#';
-			if ( thisLineIsAComment ) continue;
+			if ( lineFirstChar === '#' ) continue; // skip comments
 
 			if ( lineFirstChar === 'v' ) {
 


### PR DESCRIPTION
**Description**

This change might help newer developers more easily understand why we `continue` if `lineFirstChar === '#'`.