### PR TITLE
OBJLoader: Cleanup

### DIFF
--- a/examples/jsm/loaders/OBJLoader.js
+++ b/examples/jsm/loaders/OBJLoader.js
@@ -548,13 +548,12 @@ class OBJLoader extends Loader {
 
 			} else if ( lineFirstChar === 'f' ) {
 
-				const lineData = line.slice( 1 ).trim();
-				const vertexData = lineData.split( _face_vertex_data_separator_pattern );
+				const vertexData = line.split( _face_vertex_data_separator_pattern );
 				const faceVertices = [];
 
 				// Parse the face vertex data into an easy to work with format
 
-				for ( let j = 0, jl = vertexData.length; j < jl; j ++ ) {
+				for ( let j = 1, jl = vertexData.length; j < jl; j ++ ) {
 
 					const vertex = vertexData[ j ];
 

--- a/examples/jsm/loaders/OBJLoader.js
+++ b/examples/jsm/loaders/OBJLoader.js
@@ -488,27 +488,9 @@ class OBJLoader extends Loader {
 	parse( text ) {
 
 		const state = new ParserState();
-
-		if ( text.indexOf( '\r\n' ) !== - 1 ) {
-
-			// This is faster than String.split with regex that splits on both
-			text = text.replace( /\r\n/g, '\n' );
-
-		}
-
-		if ( text.indexOf( '\\\n' ) !== - 1 ) {
-
-			// join lines separated by a line continuation character (\)
-			text = text.replace( /\\\n/g, '' );
-
-		}
-
-		const lines = text.split( '\n' );
 		let result = [];
 
-		for ( let i = 0, l = lines.length; i < l; i ++ ) {
-
-			const line = lines[ i ].trimStart();
+		for ( const line of lines( text ) ) {
 
 			if ( line.length === 0 ) continue;
 
@@ -899,6 +881,26 @@ class OBJLoader extends Loader {
 		return container;
 
 	}
+
+}
+
+function* lines( text ) {
+
+	let beginI = 0;
+
+	for ( let currentI = 0, textLength = text.length; currentI < textLength; currentI ++ ) {
+
+		if ( text.charAt( currentI ) === '\n' ) {
+
+			yield text.substring( beginI, currentI ).trim();
+
+			beginI = currentI + 1; // + 1 because of current newline
+
+		}
+
+	}
+
+	yield text.substring( beginI ).trim(); // Last line
 
 }
 

--- a/examples/jsm/loaders/OBJLoader.js
+++ b/examples/jsm/loaders/OBJLoader.js
@@ -488,6 +488,14 @@ class OBJLoader extends Loader {
 	parse( text ) {
 
 		const state = new ParserState();
+
+		if ( text.indexOf( '\\\n' ) !== - 1 ) {
+
+			// join lines separated by a line continuation character (\)
+			text = text.replace( /\\\r?\n/g, '' );
+
+		}
+
 		let result = [];
 
 		for ( const line of lines( text ) ) {


### PR DESCRIPTION
Related issue: ---

**Description**

8f1dc58: This commit changes how lines are processed: Instead of pre-splitting the whole text it uses a generator function for iterating the lines. This has 2 benefits:
- Avoids allocating a huge array for long texts.
- Removes the need to walk the whole text an additional time for checking the '\r\n' pattern.

f448ce985e: This commit removes '.slice( 1 ).trim()' calls while processing face elements.
- The .slice( 1 ) was used for getting rid of the 'f' line prefix. Instead we now skip the first index of the array later.
- The .trim() was used to clean up the line's start & end. This is already done by the new lines iterator earlier.