### PR TITLE
HTMLMesh: Render image at the correct position

### DIFF
--- a/examples/jsm/interactive/HTMLMesh.js
+++ b/examples/jsm/interactive/HTMLMesh.js
@@ -277,7 +277,14 @@ function html2canvas( element ) {
 
 			if ( element.style.display === 'none' ) return;
 
-			context.drawImage( element, 0, 0, element.width, element.height );
+			const rect = element.getBoundingClientRect();
+
+			x = rect.left - offset.left - 0.5;
+			y = rect.top - offset.top - 0.5;
+			width = rect.width + 0.5;
+			height = rect.height + 0.5;
+
+			context.drawImage( element, x, y, width, height );
 
 		} else {
 


### PR DESCRIPTION
Related issue: #25655

**Description**

PR #25660 introduced image support for HTMLMesh but it renders all images at the top left because of the `0, 0`.
This is definitely not the desired behavior for my use case of having a wrist UI to change the texture of a furniture in VR.
My PR is calculating the x, y from `element.getBoundingClientRect()` like it's done for text element.

Here is the screenshot from chrome, but that's exactly the same render in VR:
![Capture d’écran du 2023-04-24 16-55-47](https://user-images.githubusercontent.com/112249/234043107-853b0f03-17af-4990-baff-546134d9bdb3.png)
