### PR TITLE
Workaround bug in firefox.

### DIFF
--- a/manual/examples/resources/editor.js
+++ b/manual/examples/resources/editor.js
@@ -1711,7 +1711,9 @@ async function openInStackBlitz() {
 
 		g.setPosition = false;
 		const url = getSourceBlobFromEditor();
-		g.iframe.src = url;
+		// g.iframe.src = url;
+		// work around firefox bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1828286
+		g.iframe.contentWindow.location.replace(url);
 
 	}
 


### PR DESCRIPTION
**Description**

Without this change, each editor adds to the browser's history and you have to click the back button once for each editor

