### PR TITLE
Docs: Support links to enum types in signatures

### DIFF
--- a/docs/api/en/math/Color.html
+++ b/docs/api/en/math/Color.html
@@ -185,12 +185,12 @@ const color7 = new THREE.Color( 1, 0, 0 );
 		</p>
 
 		<h3>
-			[method:Integer getHex]( [param:string colorSpace] = SRGBColorSpace )
+			[method:Integer getHex]( [param:ColorSpace colorSpace] = SRGBColorSpace )
 		</h3>
 		<p>Returns the hexadecimal value of this color.</p>
 
 		<h3>
-			[method:String getHexString]( [param:string colorSpace] = SRGBColorSpace )
+			[method:String getHexString]( [param:ColorSpace colorSpace] = SRGBColorSpace )
 		</h3>
 		<p>
 			Returns the hexadecimal value of this color as a string (for example,
@@ -198,7 +198,7 @@ const color7 = new THREE.Color( 1, 0, 0 );
 		</p>
 
 		<h3>
-			[method:Object getHSL]( [param:Object target], [param:string colorSpace] =
+			[method:Object getHSL]( [param:Object target], [param:ColorSpace colorSpace] =
 			LinearSRGBColorSpace )
 		</h3>
 		<p>
@@ -219,7 +219,7 @@ const color7 = new THREE.Color( 1, 0, 0 );
 		</p>
 
 		<h3>
-			[method:Color getRGB]( [param:Color target], [param:string colorSpace] =
+			[method:Color getRGB]( [param:Color target], [param:ColorSpace colorSpace] =
 			SRGBColorSpace )
 		</h3>
 		<p>
@@ -229,7 +229,7 @@ const color7 = new THREE.Color( 1, 0, 0 );
 		</p>
 
 		<h3>
-			[method:String getStyle]( [param:string colorSpace] = SRGBColorSpace )
+			[method:String getStyle]( [param:ColorSpace colorSpace] = SRGBColorSpace )
 		</h3>
 		<p>
 			Returns the value of this color as a CSS style string. Example:
@@ -313,7 +313,7 @@ const color7 = new THREE.Color( 1, 0, 0 );
 		</p>
 
 		<h3>
-			[method:this setHex]( [param:Integer hex], [param:string colorSpace] =
+			[method:this setHex]( [param:Integer hex], [param:ColorSpace colorSpace] =
 			SRGBColorSpace )
 		</h3>
 		<p>
@@ -325,7 +325,7 @@ const color7 = new THREE.Color( 1, 0, 0 );
 
 		<h3>
 			[method:this setHSL]( [param:Float h], [param:Float s], [param:Float l],
-			[param:string colorSpace] = LinearSRGBColorSpace )
+			[param:ColorSpace colorSpace] = LinearSRGBColorSpace )
 		</h3>
 		<p>
 			[page:Float h] — hue value between 0.0 and 1.0 <br />
@@ -337,7 +337,7 @@ const color7 = new THREE.Color( 1, 0, 0 );
 
 		<h3>
 			[method:this setRGB]( [param:Float r], [param:Float g], [param:Float b],
-			[param:string colorSpace] = LinearSRGBColorSpace )
+			[param:ColorSpace colorSpace] = LinearSRGBColorSpace )
 		</h3>
 		<p>
 			[page:Float r] — Red channel value between 0.0 and 1.0.<br />
@@ -355,7 +355,7 @@ const color7 = new THREE.Color( 1, 0, 0 );
 		</p>
 
 		<h3>
-			[method:this setStyle]( [param:String style], [param:string colorSpace] =
+			[method:this setStyle]( [param:String style], [param:ColorSpace colorSpace] =
 			SRGBColorSpace )
 		</h3>
 		<p>
@@ -375,7 +375,7 @@ const color7 = new THREE.Color( 1, 0, 0 );
 		</p>
 
 		<h3>
-			[method:this setColorName]( [param:String style], [param:string colorSpace] = SRGBColorSpace )
+			[method:this setColorName]( [param:String style], [param:ColorSpace colorSpace] = SRGBColorSpace )
 		</h3>
 		<p>
 			[page:String style] — color name ( from

--- a/docs/api/en/renderers/WebGLRenderer.html
+++ b/docs/api/en/renderers/WebGLRenderer.html
@@ -199,7 +199,7 @@ document.body.appendChild( renderer.domElement );
 			<li>`WEBGL_compressed_texture_etc1`</li>
 		</ul>
 
-		<h3>[property:string outputColorSpace]</h3>
+		<h3>[property:ColorSpace outputColorSpace]</h3>
 		<p>
 			Defines the output color space of the renderer. Default is [page:Textures THREE.SRGBColorSpace].
 		</p>

--- a/docs/api/en/textures/Texture.html
+++ b/docs/api/en/textures/Texture.html
@@ -253,7 +253,7 @@
 			[link:http://www.khronos.org/opengles/sdk/docs/man/xhtml/glPixelStorei.xml glPixelStorei] for more information.
 		</p>
 
-		<h3>[property:string colorSpace]</h3>
+		<h3>[property:ColorSpace colorSpace]</h3>
 		<p>
 			[page:Textures THREE.NoColorSpace] is the default. Textures containing color data should be
 			annotated with [page:Textures THREE.SRGBColorSpace] or

--- a/docs/api/it/math/Color.html
+++ b/docs/api/it/math/Color.html
@@ -162,13 +162,13 @@ const color7 = new THREE.Color( 1, 0, 0 );
 		Imposta i componenti del colore dall'[page:BufferAttribute attributo].
 		</p>
 
-		<h3>[method:Integer getHex]( [param:string colorSpace] = SRGBColorSpace )</h3>
+		<h3>[method:Integer getHex]( [param:ColorSpace colorSpace] = SRGBColorSpace )</h3>
 		<p>Restituisce il valore esadecimale di questo colore.</p>
 
-		<h3>[method:String getHexString]( [param:string colorSpace] = SRGBColorSpace )</h3>
+		<h3>[method:String getHexString]( [param:ColorSpace colorSpace] = SRGBColorSpace )</h3>
 		<p>Restituisce il valore esadecimale di questo colore come una stringa (per esempio, 'FFFFFF').</p>
 
-		<h3>[method:Object getHSL]( [param:Object target], [param:string colorSpace] = LinearSRGBColorSpace )</h3>
+		<h3>[method:Object getHSL]( [param:Object target], [param:ColorSpace colorSpace] = LinearSRGBColorSpace )</h3>
 		<p>
 			[page:Object target] - questo risultato sarà copiato in questo Oggetto. Aggiunge le chiavi h, s e l all'oggetto (se non è già presente).<br /><br />
 
@@ -181,14 +181,14 @@ const color7 = new THREE.Color( 1, 0, 0 );
 
 		</p>
 
-		<h3>[method:Color getRGB]( [param:Color target], [param:string colorSpace] = SRGBColorSpace )</h3>
+		<h3>[method:Color getRGB]( [param:Color target], [param:ColorSpace colorSpace] = SRGBColorSpace )</h3>
 		<p>
 			[page:Color target] - questo risultato sarà copiato in questo oggetto.<br /><br />
 
 			Returns the RGB values of this color as an instance of [page:Color].
 		</p>
 
-		<h3>[method:String getStyle]( [param:string colorSpace] = SRGBColorSpace )</h3>
+		<h3>[method:String getStyle]( [param:ColorSpace colorSpace] = SRGBColorSpace )</h3>
 		<p>Restituisce il valore di questo colore come una stringa CSS style. Esempio: `rgb(255,0,0)`.</p>
 
 		<h3>[method:this lerp]( [param:Color color], [param:Float alpha] ) </h3>
@@ -245,14 +245,14 @@ const color7 = new THREE.Color( 1, 0, 0 );
 		Delega a [page:.copy], [page:.setStyle], o [page:.setHex] a seconda del tipo di input.
 		</p>
 
-		<h3>[method:this setHex]( [param:Integer hex], [param:string colorSpace] = SRGBColorSpace ) </h3>
+		<h3>[method:this setHex]( [param:Integer hex], [param:ColorSpace colorSpace] = SRGBColorSpace ) </h3>
 		<p>
 		[page:Integer hex] - formato [link:https://en.wikipedia.org/wiki/Web_colors#Hex_triplet tripletta esadecimale].<br /><br />
 
 		Imposta questo colore da un valore esadecimale.
 		</p>
 
-		<h3>[method:this setHSL]( [param:Float h], [param:Float s], [param:Float l], [param:string colorSpace] = LinearSRGBColorSpace ) </h3>
+		<h3>[method:this setHSL]( [param:Float h], [param:Float s], [param:Float l], [param:ColorSpace colorSpace] = LinearSRGBColorSpace ) </h3>
 		<p>
 		[page:Float h] - Valore di tonalità compreso tra 0.0 e 1.0 <br />
 		[page:Float s] - Valore di saturazione compreso tra 0.0 e 1.0 <br />
@@ -261,7 +261,7 @@ const color7 = new THREE.Color( 1, 0, 0 );
 		Imposta il colore dai valori HSL.
 		</p>
 
-		<h3>[method:this setRGB]( [param:Float r], [param:Float g], [param:Float b], [param:string colorSpace] = LinearSRGBColorSpace ) </h3>
+		<h3>[method:this setRGB]( [param:Float r], [param:Float g], [param:Float b], [param:ColorSpace colorSpace] = LinearSRGBColorSpace ) </h3>
 		<p>
 		[page:Float r] - Valore del canale rosso tra 0.0 e 1.0.<br />
 		[page:Float g] - Valore del canale verde tra 0.0 e 1.0.<br />
@@ -277,7 +277,7 @@ const color7 = new THREE.Color( 1, 0, 0 );
 		Imposta tutti e tre i componenti del colore al valore [page:Float scalare].
 		</p>
 
-		<h3>[method:this setStyle]( [param:String style], [param:string colorSpace] = SRGBColorSpace ) </h3>
+		<h3>[method:this setStyle]( [param:String style], [param:ColorSpace colorSpace] = SRGBColorSpace ) </h3>
 		<p>
 		[page:String style] - colore come una stringa CSS-style.<br /><br />
 
@@ -296,7 +296,7 @@ const color7 = new THREE.Color( 1, 0, 0 );
 		Si noti che per i nomi dei colori X11, più parole come Dark Orange diventano la stringa 'darkorange'.
 		</p>
 
-		<h3>[method:this setColorName]( [param:String style], [param:string colorSpace] = SRGBColorSpace ) </h3>
+		<h3>[method:this setColorName]( [param:String style], [param:ColorSpace colorSpace] = SRGBColorSpace ) </h3>
 		<p>
 		[page:String style] - nome del colore ( dai [link:https://en.wikipedia.org/wiki/X11_color_names#Color_name_chart nomi dei colori X11] ).<br /><br />
 

--- a/docs/api/it/renderers/WebGLRenderer.html
+++ b/docs/api/it/renderers/WebGLRenderer.html
@@ -175,7 +175,7 @@
 		</ul>
 		</p>
 
-		<h3>[property:string outputColorSpace]</h3>
+		<h3>[property:ColorSpace outputColorSpace]</h3>
 		<p>Definisce la codifica di output del renderer. Il valore predefinito è [page:Textures THREE.SRGBColorSpace].</p>
 		<p>Se il target render è stato impostato utilizzando [page:WebGLRenderer.setRenderTarget .setRenderTarget],
 			verrà invece utilizzato renderTarget.texture.colorSpace.</p>

--- a/docs/api/it/textures/Texture.html
+++ b/docs/api/it/textures/Texture.html
@@ -225,7 +225,7 @@
 			Vedi [link:http://www.khronos.org/opengles/sdk/docs/man/xhtml/glPixelStorei.xml glPixelStorei] per maggiori informazioni.
 		</p>
 
-		<h3>[property:string colorSpace]</h3>
+		<h3>[property:ColorSpace colorSpace]</h3>
 		<p>
 		[page:Textures THREE.NoColorSpace] è l'impostazione predefinita.
 		Vedi la pagina [page:Textures texture constants] per i dettagli su altri formati.

--- a/docs/api/zh/math/Color.html
+++ b/docs/api/zh/math/Color.html
@@ -164,13 +164,13 @@
 		根据参数 [page:BufferAttribute attribute] 设置该颜色。
 		</p>
 
-		<h3>[method:Integer getHex]( [param:string colorSpace] = SRGBColorSpace )</h3>
+		<h3>[method:Integer getHex]( [param:ColorSpace colorSpace] = SRGBColorSpace )</h3>
 		<p>返回此颜色的十六进制值。</p>
 
-		<h3>[method:String getHexString]( [param:string colorSpace] = SRGBColorSpace )</h3>
+		<h3>[method:String getHexString]( [param:ColorSpace colorSpace] = SRGBColorSpace )</h3>
 		<p>将此颜色的十六进制值作为字符串返回 (例如, 'FFFFFF')。</p>
 
-		<h3>[method:Object getHSL]( [param:Object target], [param:string colorSpace] = LinearSRGBColorSpace )</h3>
+		<h3>[method:Object getHSL]( [param:Object target], [param:ColorSpace colorSpace] = LinearSRGBColorSpace )</h3>
 		<p>
 			[page:Object target] — 结果将复制到这个对象中。向对象添加h、s和l键(如果不存在)。<br /><br />
 
@@ -182,14 +182,14 @@
 
 		</p>
 
-		<h3>[method:Color getRGB]( [param:Color target], [param:string colorSpace] = SRGBColorSpace )</h3>
+		<h3>[method:Color getRGB]( [param:Color target], [param:ColorSpace colorSpace] = SRGBColorSpace )</h3>
 		<p>
 			[page:Color target] - 结果将复制到这个对象中.<br /><br />
 
 			Returns the RGB values of this color as an instance of [page:Color].
 		</p>
 
-		<h3>[method:String getStyle]( [param:string colorSpace] = SRGBColorSpace )</h3>
+		<h3>[method:String getStyle]( [param:ColorSpace colorSpace] = SRGBColorSpace )</h3>
 		<p>以CSS样式字符串的形式返回该颜色的值。例如:“rgb(255,0,0)”。</p>
 
 		<h3>[method:this lerp]( [param:Color color], [param:Float alpha] ) </h3>
@@ -241,7 +241,7 @@
 		根据输入类型，将会委托给 [page:.copy], [page:.setStyle], 或者 [page:.setHex] 函数处理。
 		</p>
 
-		<h3>[method:this setHex]( [param:Integer hex], [param:string colorSpace] = SRGBColorSpace ) </h3>
+		<h3>[method:this setHex]( [param:Integer hex], [param:ColorSpace colorSpace] = SRGBColorSpace ) </h3>
 		<p>
 		[page:Integer hex] — [link:https://en.wikipedia.org/wiki/Web_colors#Hex_triplet hexadecimal triplet] 格式。<br /><br />
 
@@ -249,7 +249,7 @@
 
 		</p>
 
-		<h3>[method:this setHSL]( [param:Float h], [param:Float s], [param:Float l], [param:string colorSpace] = LinearSRGBColorSpace ) </h3>
+		<h3>[method:this setHSL]( [param:Float h], [param:Float s], [param:Float l], [param:ColorSpace colorSpace] = LinearSRGBColorSpace ) </h3>
 		<p>
 		[page:Float h] — 色相值处于0到1之间。hue value between 0.0 and 1.0 <br />
 		[page:Float s] — 饱和度值处于0到1之间。<br />
@@ -258,7 +258,7 @@
 		采用HLS值设置此颜色。
 		</p>
 
-		<h3>[method:this setRGB]( [param:Float r], [param:Float g], [param:Float b], [param:string colorSpace] = LinearSRGBColorSpace ) </h3>
+		<h3>[method:this setRGB]( [param:Float r], [param:Float g], [param:Float b], [param:ColorSpace colorSpace] = LinearSRGBColorSpace ) </h3>
 		<p>
 		[page:Float r] — 红色通道的值在0到1之间。<br />
 		[page:Float g] — 绿色通道的值在0到1之间。<br />
@@ -274,7 +274,7 @@
 		将颜色的RGB值都设为该 [page:Float scalar] 的值。
 		</p>
 
-		<h3>[method:this setStyle]( [param:String style], [param:string colorSpace] = SRGBColorSpace ) </h3>
+		<h3>[method:this setStyle]( [param:String style], [param:ColorSpace colorSpace] = SRGBColorSpace ) </h3>
 		<p>
 		[page:String style] — 颜色css样式的字符串<br /><br />
 
@@ -293,7 +293,7 @@
 		注意，对于X11颜色名称，多个单词(如暗橙色)变成字符串“darkorange”。
 		</p>
 
-		<h3>[method:this setColorName]( [param:String style], [param:string colorSpace] = SRGBColorSpace ) </h3>
+		<h3>[method:this setColorName]( [param:String style], [param:ColorSpace colorSpace] = SRGBColorSpace ) </h3>
 		<p>
 		[page:String style] — 颜色名字的英文单词 ( 具体请查阅 [link:https://en.wikipedia.org/wiki/X11_color_names#Color_name_chart X11 color names] )<br /><br />
 

--- a/docs/api/zh/renderers/WebGLRenderer.html
+++ b/docs/api/zh/renderers/WebGLRenderer.html
@@ -151,7 +151,7 @@
 		</ul>
 		</p>
 
-		<h3>[property:string outputColorSpace]</h3>
+		<h3>[property:ColorSpace outputColorSpace]</h3>
 		<p>定义渲染器的输出编码。默认为[page:Textures THREE.SRGBColorSpace]</p>
 		<p>如果渲染目标已经使用 [page:WebGLRenderer.setRenderTarget .setRenderTarget]、之后将直接使用renderTarget.texture.colorSpace</p>
 		<p>查看[page:Textures texture constants]页面以获取其他格式细节</p>

--- a/docs/api/zh/textures/Texture.html
+++ b/docs/api/zh/textures/Texture.html
@@ -209,7 +209,7 @@
 			请参阅[link:http://www.khronos.org/opengles/sdk/docs/man/xhtml/glPixelStorei.xml glPixelStorei]来了解详细信息。
 		</p>
 
-		<h3>[property:string colorSpace]</h3>
+		<h3>[property:ColorSpace colorSpace]</h3>
 		<p>
 		默认值为[page:Textures THREE.NoColorSpace]。
 		请参阅[page:Textures texture constants]来了解其他格式的详细信息。

--- a/docs/page.js
+++ b/docs/page.js
@@ -191,7 +191,7 @@ function onDocumentLoad() {
 
 	function getFragment( id ) {
 
-		switch (id) {
+		switch ( id ) {
 
 			case 'ColorSpace':
 

--- a/docs/page.js
+++ b/docs/page.js
@@ -66,8 +66,8 @@ function onDocumentLoad() {
 	// text = text.replace( /\[member:.([\w]+) ([\w\.\s]+)\]/gi, "<a onclick=\"window.parent.setUrlFragment('" + name + ".$1')\" title=\"$1\">$2</a>" );
 
 	text = text.replace( /\[(member|property|method|param):([\w]+)\]/gi, '[$1:$2 $2]' ); // [member:name] to [member:name title]
-	text = text.replace( /\[(?:member|property|method):([\w]+) ([\w\.\s]+)\]\s*(\(.*\))?/gi, `<a class='permalink links' data-fragment='${name}.$2' target='_parent' title='${name}.$2'>#</a> .<a class='links' data-fragment='${name}.$2' id='$2'>$2</a> $3 : <a class='param links' data-fragment='$1'>$1</a>` );
-	text = text.replace( /\[param:([\w\.]+) ([\w\.\s]+)\]/gi, '$2 : <a class=\'param links\' data-fragment=\'$1\'>$1</a>' ); // [param:name title]
+	text = text.replace( /\[(?:member|property|method):([\w]+) ([\w\.\s]+)\]\s*(\(.*\))?/gim, replaceMember ); // [member:name title] ( ...params )
+	text = text.replace( /\[param:([\w\.]+) ([\w\.\s]+)\]/gi, replaceParam ); // [param:name title]
 
 	text = text.replace( /\[link:([\w\:\/\.\-\_\(\)\?\#\=\!\~]+)\]/gi, '<a href="$1" target="_blank">$1</a>' ); // [link:url]
 	text = text.replace( /\[link:([\w:/.\-_()?#=!~]+) ([\w\p{L}:/.\-_'\s]+)\]/giu, '<a href="$1" target="_blank">$2</a>' ); // [link:url title]
@@ -170,6 +170,40 @@ function onDocumentLoad() {
 	};
 
 	document.head.appendChild( prettify );
+
+	// Links
+
+	function replaceMember( _, name, title, params ) {
+
+		const fragment = getFragment( name );
+
+		return `<a class='permalink links' data-fragment='${fragment}.${title}' target='_parent' title='${name}.${title}'>#</a> .<a class='links' data-fragment='${fragment}.${title}' id='${title}'>${title}</a> ${params || ''} : <a class='param links' data-fragment='${fragment}'>${name}</a>`;
+
+	}
+
+	function replaceParam( _, name, type ) {
+
+		const fragment = getFragment( name );
+
+		return `${type} : <a class=\'param links\' data-fragment=\'${fragment}\'>${name}</a>`;
+
+	}
+
+	function getFragment( id ) {
+
+		switch (id) {
+
+			case 'ColorSpace':
+
+				return 'Core';
+
+			default:
+
+				return id;
+
+		}
+
+	}
 
 }
 


### PR DESCRIPTION
Thought it might be nice to be able to link to enum types in method signatures. In the screenshot below, `ColorSpace` is clickable and goes to [Core Constants](https://threejs.org/docs/#api/en/constants/Core).

Before:
![Screenshot 2023-04-24 at 11 57 35 PM](https://user-images.githubusercontent.com/1848368/234171136-df4c4228-1ee4-4c10-877d-06a845e266d5.png)


After:
![Screenshot 2023-04-24 at 11 57 16 PM](https://user-images.githubusercontent.com/1848368/234171146-1b1591e2-b951-4671-891e-4e0a12a5acbe.png)

If this complicates `page.js` more than we'd like, I'm also fine with skipping this. Certainly no rush to include it in this week's release.
  