### PR TITLE
KTX2Loader.js: Prefer traditional for loop

### DIFF
--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -450,17 +450,7 @@ class FBXTreeParser {
 
 		} else {
 
-			let loader = this.manager.getHandler( fileName );
-
-			if ( loader === null ) {
-
-				loader = this.textureLoader;
-
-			}
-
-			loader.setPath( currentPath );
-			loader.setCrossOrigin( this.crossOrigin );
-			texture = loader.load( fileName );
+			texture = this.textureLoader.load( fileName );
 
 		}
 

--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -632,8 +632,8 @@ KTX2Loader.BasisWorker = function () {
 
 		let totalByteLength = 0;
 
-		for ( const array of arrays ) {
-
+		for ( let i = 0; i < arrays.length; i ++ ) {
+			const array = arrays[ i ];
 			totalByteLength += array.byteLength;
 
 		}
@@ -642,8 +642,8 @@ KTX2Loader.BasisWorker = function () {
 
 		let byteOffset = 0;
 
-		for ( const array of arrays ) {
-
+		for ( let i = 0; i < arrays.length; i ++ ) {
+			const array = arrays[ i ];
 			result.set( array, byteOffset );
 
 			byteOffset += array.byteLength;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "three",
-  "version": "0.151.2",
+  "version": "0.151.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "three",
-  "version": "0.151.2",
+  "version": "0.151.3",
   "description": "JavaScript 3D library",
   "type": "module",
   "main": "./build/three.js",


### PR DESCRIPTION
This PR addresses a syntax issue that was causing problems with Babel's conversion of the original for...of loop. To ensure compatibility and avoid issues during transpilation, the loop has been refactored to use a traditional for loop with an index variable.

This change ensures broader compatibility and smoother integration with Babel if a developer wants to embed the source of KTX2Loader.js in its own project.