### PR TITLE
Object3D: Honor `animations` in `copy()`.

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -945,6 +945,8 @@ class Object3D extends EventDispatcher {
 		this.frustumCulled = source.frustumCulled;
 		this.renderOrder = source.renderOrder;
 
+		this.animations = source.animations;
+
 		this.userData = JSON.parse( JSON.stringify( source.userData ) );
 
 		if ( recursive === true ) {


### PR DESCRIPTION
Fixed #25920.

**Description**

Animation clips are now honored in `Object3D.copy().
