### PR TITLE
KTX2Loader: Prefer traditional `for` loop.

### DIFF
--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -647,8 +647,9 @@ KTX2Loader.BasisWorker = function () {
 
 		let totalByteLength = 0;
 
-		for ( const array of arrays ) {
+		for ( let i = 0; i < arrays.length; i ++ ) {
 
+			const array = arrays[ i ];
 			totalByteLength += array.byteLength;
 
 		}
@@ -657,8 +658,9 @@ KTX2Loader.BasisWorker = function () {
 
 		let byteOffset = 0;
 
-		for ( const array of arrays ) {
+		for ( let i = 0; i < arrays.length; i ++ ) {
 
+			const array = arrays[ i ];
 			result.set( array, byteOffset );
 
 			byteOffset += array.byteLength;


### PR DESCRIPTION
This PR addresses a syntax issue that was causing problems with Babel's conversion of the original for...of loop. To ensure compatibility and avoid issues during transpilation, the loop has been refactored to use a traditional for loop with an index variable.

This change ensures broader compatibility and smoother integration with Babel if a developer wants to embed the source of KTX2Loader.js in its own project.