### PR TITLE
HTMLMesh: Remove the +0.5 offset for image

### DIFF
--- a/examples/jsm/interactive/HTMLMesh.js
+++ b/examples/jsm/interactive/HTMLMesh.js
@@ -281,8 +281,8 @@ function html2canvas( element ) {
 
 			x = rect.left - offset.left - 0.5;
 			y = rect.top - offset.top - 0.5;
-			width = rect.width + 0.5;
-			height = rect.height + 0.5;
+			width = rect.width;
+			height = rect.height;
 
 			context.drawImage( element, x, y, width, height );
 


### PR DESCRIPTION
Related issue: #25655 and PR #25916 that was merged with follow-up discussion in #25925

**Description**

Remove the +0.5 offset for image. That was ok with a button wrapping the image, button having a border of 2px, but not ok for a border of 1px, the image wasn't centered.
We need to keep the -0.5 offset so the image is centered in the button container that does a render with the -0.5 offset.
Note in #25925 it was mentioned a lesser quality of the image with -0.5 offset although I don't see it in VR.