### PR TITLE
NodeBuilder: Fix item size if there is no padding

### DIFF
--- a/examples/jsm/nodes/core/NodeBuilder.js
+++ b/examples/jsm/nodes/core/NodeBuilder.js
@@ -30,6 +30,8 @@ const typeFromArray = new Map( [
 	[ Float32Array, 'float' ]
 ] );
 
+const isNonPaddingElementArray = new Set( [ Int32Array, Uint32Array, Float32Array ] );
+
 const toFloat = ( value ) => {
 
 	value = Number( value );
@@ -444,7 +446,7 @@ class NodeBuilder {
 		if ( attribute.isInterleavedBufferAttribute ) dataAttribute = attribute.data;
 
 		const array = dataAttribute.array;
-		const itemSize = dataAttribute.stride || attribute.itemSize;
+		const itemSize = isNonPaddingElementArray.has( array.constructor ) ? attribute.itemSize : dataAttribute.stride || attribute.itemSize;
 		const normalized = attribute.normalized;
 
 		let arrayType;

--- a/examples/jsm/renderers/webgpu/WebGPUBackground.js
+++ b/examples/jsm/renderers/webgpu/WebGPUBackground.js
@@ -69,10 +69,10 @@ class WebGPUBackground {
 				nodeMaterial.side = BackSide;
 				nodeMaterial.depthTest = false;
 				nodeMaterial.depthWrite = false;
-				nodeMaterial.frustumCulled = false;
 				nodeMaterial.fog = false;
 
 				this.boxMesh = boxMesh = new Mesh( new BoxGeometry( 1, 1, 1 ), nodeMaterial );
+				boxMesh.frustumCulled = false;
 
 				boxMesh.onBeforeRender = function ( renderer, scene, camera ) {
 
@@ -86,13 +86,13 @@ class WebGPUBackground {
 
 			const backgroundCacheKey = backgroundNode.getCacheKey();
 
-			if ( sceneProperties.backgroundMeshCacheKey !== backgroundCacheKey ) {
+			if ( sceneProperties.backgroundCacheKey !== backgroundCacheKey ) {
 
 				this.boxMeshNode.node = backgroundNode;
 
 				boxMesh.material.needsUpdate = true;
 
-				sceneProperties.backgroundMeshCacheKey = backgroundCacheKey;
+				sceneProperties.backgroundCacheKey = backgroundCacheKey;
 
 			}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/25924

**Description**

It fix `webgpu_sprite` example, I will improve it soon.