### PR TITLE
WebGLRenderer: Only update skeletons in frustum

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1148,20 +1148,20 @@ class WebGLRenderer {
 
 				} else if ( object.isMesh || object.isLine || object.isPoints ) {
 
-					if ( object.isSkinnedMesh ) {
+					if ( ! object.frustumCulled || _frustum.intersectsObject( object ) ) {
 
-						// update skeleton only once in a frame
+						if ( object.isSkinnedMesh ) {
 
-						if ( object.skeleton.frame !== info.render.frame ) {
+							// update skeleton only once in a frame
 
-							object.skeleton.update();
-							object.skeleton.frame = info.render.frame;
+							if ( object.skeleton.frame !== info.render.frame ) {
+
+								object.skeleton.update();
+								object.skeleton.frame = info.render.frame;
+
+							}
 
 						}
-
-					}
-
-					if ( ! object.frustumCulled || _frustum.intersectsObject( object ) ) {
 
 						const geometry = objects.update( object );
 						const material = object.material;


### PR DESCRIPTION
This changes `WebGLRenderer.projectObject` so that instead of updating all skeletons every frame, it only updates skeletons if they are in the frustum.

This offers a large performance improvement for scenes that contain a lot of SkinnedMesh's.

Fixed #25914
