### PR TITLE
Docs: Improve color space constant documentation

### DIFF
--- a/docs/api/en/constants/Core.html
+++ b/docs/api/en/constants/Core.html
@@ -21,11 +21,15 @@ THREE.REVISION
 
 		<h2>Color Spaces</h2>
 		<code>
-THREE.NoColorSpace 
-THREE.SRGBColorSpace 
-THREE.LinearSRGBColorSpace
+THREE.NoColorSpace = ""
+THREE.SRGBColorSpace = "srgb"
+THREE.LinearSRGBColorSpace = "srgb-linear"
 		</code>
-		<p>[page:NoColorSpace] defines no specific color space.</p>
+		<p>
+			[page:NoColorSpace] defines no specific color space. It is commonly used
+			for textures including normal maps, roughness maps, metalness maps,
+			ambient occlusion maps, and other non-color data.
+		</p>
 		<p>
 			[page:SRGBColorSpace] (“srgb”) refers to the color space defined by the
 			Rec. 709 primaries, D65 white point, and nonlinear sRGB transfer

--- a/docs/api/en/constants/Textures.html
+++ b/docs/api/en/constants/Textures.html
@@ -601,10 +601,9 @@
 
 		<h2>Color Space</h2>
 		<code>
-		THREE.NoColorSpace 
-		THREE.SRGBColorSpace 
-		THREE.LinearSRGBColorSpace
-		THREE.DisplayP3ColorSpace
+		THREE.NoColorSpace = ""
+		THREE.SRGBColorSpace = "srgb"
+		THREE.LinearSRGBColorSpace = "srgb-linear"
 		</code>
 		<p>
 			Used to define the color space of textures (and the output color space of

--- a/docs/api/fr/constants/Core.html
+++ b/docs/api/fr/constants/Core.html
@@ -21,9 +21,9 @@ THREE.REVISION
 
 		<h2>Espaces colorimétriques</h2>
 		<code>
-THREE.NoColorSpace			
-THREE.SRGBColorSpace
-THREE.LinearSRGBColorSpace
+THREE.NoColorSpace = ""
+THREE.SRGBColorSpace = "srgb"
+THREE.LinearSRGBColorSpace = "srgb-linear"
 		</code>
 		<p>
 			[page:NoColorSpace] ne définit aucun espace colorimétrique spécifique. 

--- a/docs/api/fr/constants/Textures.html
+++ b/docs/api/fr/constants/Textures.html
@@ -545,10 +545,9 @@
 
 		<h2>Color Space</h2>
 		<code>
-		THREE.NoColorSpace
-		THREE.SRGBColorSpace
-		THREE.LinearSRGBColorSpace
-		THREE.DisplayP3ColorSpace
+		THREE.NoColorSpace = ""
+		THREE.SRGBColorSpace = "srgb"
+		THREE.LinearSRGBColorSpace = "srgb-linear"
 		</code>
 		<p>
 		Used to define the color space of textures (and the output color space of the renderer).<br /><br />

--- a/docs/api/it/constants/Core.html
+++ b/docs/api/it/constants/Core.html
@@ -21,9 +21,9 @@ THREE.REVISION
 
 		<h2>Spazi Colore</h2>
 		<code>
-THREE.NoColorSpace			
-THREE.SRGBColorSpace
-THREE.LinearSRGBColorSpace
+THREE.NoColorSpace = ""
+THREE.SRGBColorSpace = "srgb"
+THREE.LinearSRGBColorSpace = "srgb-linear"
 		</code>
 		<p>
 			[page:NoColorSpace] non definisce uno spazio colore specifico. 

--- a/docs/api/it/constants/Textures.html
+++ b/docs/api/it/constants/Textures.html
@@ -545,10 +545,9 @@
 
 		<h2>Color Space</h2>
 		<code>
-		THREE.NoColorSpace
-		THREE.SRGBColorSpace
-		THREE.LinearSRGBColorSpace
-		THREE.DisplayP3ColorSpace
+		THREE.NoColorSpace = ""
+		THREE.SRGBColorSpace = "srgb"
+		THREE.LinearSRGBColorSpace = "srgb-linear"
 		</code>
 		<p>
 		Used to define the color space of textures (and the output color space of the renderer).<br /><br />

--- a/docs/api/ko/constants/Textures.html
+++ b/docs/api/ko/constants/Textures.html
@@ -533,10 +533,9 @@
 
 		<h2>Color Space</h2>
 		<code>
-		THREE.NoColorSpace
-		THREE.SRGBColorSpace
-		THREE.LinearSRGBColorSpace
-		THREE.DisplayP3ColorSpace
+		THREE.NoColorSpace = ""
+		THREE.SRGBColorSpace = "srgb"
+		THREE.LinearSRGBColorSpace = "srgb-linear"
 		</code>
 		<p>
 		Used to define the color space of textures (and the output color space of the renderer).<br /><br />

--- a/docs/api/pt-br/constants/Core.html
+++ b/docs/api/pt-br/constants/Core.html
@@ -21,9 +21,9 @@ THREE.REVISION
 
 		<h2>Espaço de Cores</h2>
 		<code>
-THREE.NoColorSpace			
-THREE.SRGBColorSpace
-THREE.LinearSRGBColorSpace
+THREE.NoColorSpace = ""
+THREE.SRGBColorSpace = "srgb"
+THREE.LinearSRGBColorSpace = "srgb-linear"
 		</code>
 		<p>
 			[page:NoColorSpace] não define nenhum espaço de cor específico.

--- a/docs/api/pt-br/constants/Textures.html
+++ b/docs/api/pt-br/constants/Textures.html
@@ -545,10 +545,9 @@
 
 		<h2>Color Space</h2>
 		<code>
-		THREE.NoColorSpace
-		THREE.SRGBColorSpace
-		THREE.LinearSRGBColorSpace
-		THREE.DisplayP3ColorSpace
+		THREE.NoColorSpace = ""
+		THREE.SRGBColorSpace = "srgb"
+		THREE.LinearSRGBColorSpace = "srgb-linear"
 		</code>
 		<p>
 		Used to define the color space of textures (and the output color space of the renderer).<br /><br />

--- a/docs/api/zh/constants/Textures.html
+++ b/docs/api/zh/constants/Textures.html
@@ -528,10 +528,9 @@
 
 	<h2>Color Space</h2>
 	<code>
-	THREE.NoColorSpace
-	THREE.SRGBColorSpace
-	THREE.LinearSRGBColorSpace
-	THREE.DisplayP3ColorSpace
+	THREE.NoColorSpace = ""
+	THREE.SRGBColorSpace = "srgb"
+	THREE.LinearSRGBColorSpace = "srgb-linear"
 	</code>
 	<p>
 	Used to define the color space of textures (and the output color space of the renderer).<br /><br />


### PR DESCRIPTION
Clarifies relationship between our color space constants and the CSS Color Module Level 4 string values. Excludes DisplayP3ColorSpace for now, as it isn't ready for use.

Related:

- #23614 