### PR TITLE
Examples: Fix resizing of webgl2_multisampled_renderbuffers demo.

### DIFF
--- a/examples/webgl2_multisampled_renderbuffers.html
+++ b/examples/webgl2_multisampled_renderbuffers.html
@@ -138,12 +138,14 @@
 				//
 
 				composer1 = new EffectComposer( renderer );
+				composer1.setPixelRatio( window.devicePixelRatio );
 				composer1.addPass( renderPass );
 				composer1.addPass( copyPass );
 
 				//
 
 				composer2 = new EffectComposer( renderer, renderTarget );
+				composer2.setPixelRatio( window.devicePixelRatio );
 				composer2.addPass( renderPass );
 				composer2.addPass( copyPass );
 


### PR DESCRIPTION
Fixed #25940.

**Description**

Setting the pixel ratio explicitly is one way to ensure correct resizing of multisampled effect composers. Another way would be to set the effective dimensions (width * pixel ratio, height * pixel ratio) in the resize function.