### PR TITLE
EffectComposer: Always honor pixel ratio when creating the composer.

### DIFF
--- a/examples/jsm/postprocessing/EffectComposer.js
+++ b/examples/jsm/postprocessing/EffectComposer.js
@@ -14,10 +14,11 @@ class EffectComposer {
 
 		this.renderer = renderer;
 
+		this._pixelRatio = renderer.getPixelRatio();
+
 		if ( renderTarget === undefined ) {
 
 			const size = renderer.getSize( new Vector2() );
-			this._pixelRatio = renderer.getPixelRatio();
 			this._width = size.width;
 			this._height = size.height;
 
@@ -26,7 +27,6 @@ class EffectComposer {
 
 		} else {
 
-			this._pixelRatio = 1;
 			this._width = renderTarget.width;
 			this._height = renderTarget.height;
 

--- a/examples/webgl2_multisampled_renderbuffers.html
+++ b/examples/webgl2_multisampled_renderbuffers.html
@@ -138,14 +138,12 @@
 				//
 
 				composer1 = new EffectComposer( renderer );
-				composer1.setPixelRatio( window.devicePixelRatio );
 				composer1.addPass( renderPass );
 				composer1.addPass( copyPass );
 
 				//
 
 				composer2 = new EffectComposer( renderer, renderTarget );
-				composer2.setPixelRatio( window.devicePixelRatio );
 				composer2.addPass( renderPass );
 				composer2.addPass( copyPass );
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/25941#issuecomment-1523926268

**Description**

Second attempt for fixing the resizing issue.

When passing a custom render target to the composer, it needs to honor the actual pixel ratio of the renderer.
