### PR TITLE
Editor: Fix clone of skinned meshes.

### DIFF
--- a/editor/js/Menubar.Edit.js
+++ b/editor/js/Menubar.Edit.js
@@ -5,6 +5,7 @@ import { UIPanel, UIRow, UIHorizontalRule } from './libs/ui.js';
 import { AddObjectCommand } from './commands/AddObjectCommand.js';
 import { RemoveObjectCommand } from './commands/RemoveObjectCommand.js';
 import { SetPositionCommand } from './commands/SetPositionCommand.js';
+import { clone } from '../../examples/jsm/utils/SkeletonUtils.js';
 
 function MenubarEdit( editor ) {
 
@@ -123,7 +124,7 @@ function MenubarEdit( editor ) {
 
 		if ( object === null || object.parent === null ) return; // avoid cloning the camera or scene
 
-		object = object.clone();
+		object = clone( object );
 
 		editor.execute( new AddObjectCommand( editor, object ) );
 


### PR DESCRIPTION
Fixed #25944.

**Description**

The editor has to use `SkeletonUtils.clone()` so skinned meshes are correctly cloned, too.
