### PR TITLE
Preserve unknown gltf mesh extensions in GLTFLoader

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -3620,6 +3620,8 @@ class GLTFParser {
 
 				if ( primitive.extensions ) addUnknownExtensionsToUserData( extensions, mesh, primitive );
 
+				if ( meshDef.extensions ) addUnknownExtensionsToUserData( extensions, mesh, meshDef );
+
 				parser.assignFinalMaterial( mesh );
 
 				meshes.push( mesh );

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -3620,8 +3620,6 @@ class GLTFParser {
 
 				if ( primitive.extensions ) addUnknownExtensionsToUserData( extensions, mesh, primitive );
 
-				if ( meshDef.extensions ) addUnknownExtensionsToUserData( extensions, mesh, meshDef );
-
 				parser.assignFinalMaterial( mesh );
 
 				meshes.push( mesh );
@@ -3639,11 +3637,15 @@ class GLTFParser {
 
 			if ( meshes.length === 1 ) {
 
+				if ( meshDef.extensions ) addUnknownExtensionsToUserData( extensions, meshes[ 0 ], meshDef );
+
 				return meshes[ 0 ];
 
 			}
 
 			const group = new Group();
+
+			if ( meshDef.extensions ) addUnknownExtensionsToUserData( extensions, group, meshDef );
 
 			parser.associations.set( group, { meshes: meshIndex } );
 


### PR DESCRIPTION
**Description**

This is needed for custom glTF extensions which handle extension data under each `mesh` entry in the glTF json.

Previously, only unknown extensions in the glTF json's `meshes[].primitives[].extensions` field were added to the populated mesh's `userData.gltfExtensions` field. It is also valid to add data under glTF json `meshes[].extensions` so those should be added to the resulting mesh, too.



