### PR TITLE
Scene: Add support for overriding children in the WebGLRenderer render function

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -998,7 +998,20 @@ class WebGLRenderer {
 
 			renderListStack.push( currentRenderList );
 
-			projectObject( scene, camera, 0, _this.sortObjects );
+			if ( scene.overrideChildrens !== undefined ) {
+
+				const objects = Array.isArray( scene.overrideChildrens ) ? scene.overrideChildrens : [ scene.overrideChildrens ];
+				for ( let i = 0, l = objects.length; i < l; i ++ ) {
+
+					projectObject( objects[ i ], camera, 0, _this.sortObjects );
+
+				}
+
+			} else {
+
+				projectObject( scene, camera, 0, _this.sortObjects );
+
+			}
 
 			currentRenderList.finish();
 


### PR DESCRIPTION
Description:

This PR introduces a new feature that allows users to selectively override the children of a scene when rendering the scene. 

This update is useful for cases when users need to project only specific objects in the scene, rather than the entire scene. Users can now provide an array of objects or a single object to the overrideChildrens property in the scene, and the projection process will be limited to those objects.

For example:

```js

renderer.setRenderTarget(fboWithCoolEffect)
scene.overrideChildren = scene.getObjectByName( 'a_specific_mesh' ); // could be an array of mesh
renderer.render( scene, camera );
scene.overrideChildren = null
```

For performance optimization I would let the user take care of disabling `scene.matrixWorldAutoUpdate` in this type of setup, if not, we could just add:
```js
if ( scene.matrixWorldAutoUpdate === true && overrideChildren === undefined ) scene.updateMatrixWorld();
```

Please let me know what you think about the idea, I will add documentation if you think this hook could be useful.
