### PR TITLE
Examples: Fix broken GPU picking demo.

### DIFF
--- a/examples/webgl_interactive_cubes_gpu.html
+++ b/examples/webgl_interactive_cubes_gpu.html
@@ -69,7 +69,7 @@
 				scene.background = new THREE.Color( 0xffffff );
 
 				pickingScene = new THREE.Scene();
-				pickingTexture = new THREE.WebGLRenderTarget( 1, 1, { colorSpace: THREE.SRGBColorSpace } );
+				pickingTexture = new THREE.WebGLRenderTarget( 1, 1 );
 
 				scene.add( new THREE.AmbientLight( 0x555555 ) );
 
@@ -136,7 +136,7 @@
 
 					// give the geometry's vertices a color corresponding to the "id"
 
-					applyVertexColors( geometry, color.setHex( i ) );
+					applyVertexColors( geometry, color.setHex( i, THREE.NoColorSpace ) );
 
 					geometriesPicking.push( geometry );
 

--- a/examples/webgl_interactive_cubes_gpu.html
+++ b/examples/webgl_interactive_cubes_gpu.html
@@ -69,7 +69,7 @@
 				scene.background = new THREE.Color( 0xffffff );
 
 				pickingScene = new THREE.Scene();
-				pickingTexture = new THREE.WebGLRenderTarget( 1, 1 );
+				pickingTexture = new THREE.WebGLRenderTarget( 1, 1, { colorSpace: THREE.SRGBColorSpace } );
 
 				scene.add( new THREE.AmbientLight( 0x555555 ) );
 


### PR DESCRIPTION
Related issue: https://discourse.threejs.org/t/how-can-i-render-400000-polygons-mesh/50957/12

**Description**

[webgl_interactive_cubes_gpu](https://threejs.org/examples/webgl_interactive_cubes_gpu) is broken because the picking does not work anymore. The reason for this is the enabled color management and the fact that the render target holds sRGB values without specifying the right color space.
