### PR TITLE
SkinnedMesh: Revert own raycast() method.

### DIFF
--- a/src/objects/SkinnedMesh.js
+++ b/src/objects/SkinnedMesh.js
@@ -14,7 +14,7 @@ const _vector3 = /*@__PURE__*/ new Vector3();
 const _matrix4 = /*@__PURE__*/ new Matrix4();
 const _vertex = /*@__PURE__*/ new Vector3();
 
-const _sphere = /*@__PURE__*/ new Sphere();
+//const _sphere = /*@__PURE__*/ new Sphere();
 
 class SkinnedMesh extends Mesh {
 
@@ -97,18 +97,18 @@ class SkinnedMesh extends Mesh {
 
 	}
 
-	raycast( raycaster, intersects ) {
+	// raycast( raycaster, intersects ) {
 
-		if ( this.boundingSphere === null ) this.computeBoundingSphere();
+	// 	if ( this.boundingSphere === null ) this.computeBoundingSphere();
 
-		_sphere.copy( this.boundingSphere );
-		_sphere.applyMatrix4( this.matrixWorld );
+	// 	_sphere.copy( this.boundingSphere );
+	// 	_sphere.applyMatrix4( this.matrixWorld );
 
-		if ( raycaster.ray.intersectsSphere( _sphere ) === false ) return;
+	// 	if ( raycaster.ray.intersectsSphere( _sphere ) === false ) return;
 
-		this._computeIntersections( raycaster, intersects );
+	// 	this._computeIntersections( raycaster, intersects );
 
-	}
+	// }
 
 	getVertexPosition( index, target ) {
 


### PR DESCRIPTION
Fixed #25953

Mainly reverts #25791.

**Description**

`SkinnedMesh.raycast()` does not yet work reliably since with some skeletons the ray casting completely fails. I'm not yet sure why certain skeletons break the logic. 

For now I think it's best to revert the change until the issue can be fully understand.
