### PR TITLE
DepthTexture: Support texture depth comparison.

### DIFF
--- a/docs/api/en/constants/Textures.html
+++ b/docs/api/en/constants/Textures.html
@@ -316,6 +316,18 @@
 			[link:https://www.khronos.org/registry/webgl/extensions/EXT_texture_compression_bptc/ EXT_texture_compression_bptc] extension. <br /><br />
 		</p>
 
+		<h2>Texture Comparison functions</h2>
+		<code>
+		THREE.NeverCompare
+		THREE.LessCompare
+		THREE.EqualCompare
+		THREE.LessEqualCompare
+		THREE.GreaterCompare
+		THREE.NotEqualCompare
+		THREE.GreaterEqualCompare
+		THREE.AlwaysCompare
+		</code>
+
 		<h2>Internal Formats</h2>
 		<code>
 		'ALPHA'

--- a/docs/api/en/textures/DepthTexture.html
+++ b/docs/api/en/textures/DepthTexture.html
@@ -119,6 +119,13 @@
 		<h3>[property:Boolean isDepthTexture]</h3>
 		<p>Read-only flag to check if a given object is of type [name].</p>
 
+		<h3>[property:String compareFunction]</h3>
+		<p>
+		This is used to define the comparison function used when comparing texels in the depth texture to the value in the depth buffer.<br /><br/>
+
+		See the [page:Textures texture constants] page for details of other functions.
+		</p>
+
 		<h2>Methods</h2>
 
 		<p>See the base [page:Texture Texture] class for common methods.</p>

--- a/docs/api/en/textures/Texture.html
+++ b/docs/api/en/textures/Texture.html
@@ -147,6 +147,13 @@
 			formats.
 		</p>
 
+		<h3>[property:String compareFunc]</h3>
+		<p>
+		This is used to define the comparison function used when comparing texels in the depth texture to the value in the depth buffer.<br /><br/>
+
+		See the [page:Textures texture constants] page for details of other functions.
+		</p>
+
 		<h3>[property:String internalFormat]</h3>
 		<p>
 			The default value is obtained using a combination of [page:Texture.format .format] and [page:Texture.type .type].<br />

--- a/docs/api/en/textures/Texture.html
+++ b/docs/api/en/textures/Texture.html
@@ -147,13 +147,6 @@
 			formats.
 		</p>
 
-		<h3>[property:String compareFunc]</h3>
-		<p>
-		This is used to define the comparison function used when comparing texels in the depth texture to the value in the depth buffer.<br /><br/>
-
-		See the [page:Textures texture constants] page for details of other functions.
-		</p>
-
 		<h3>[property:String internalFormat]</h3>
 		<p>
 			The default value is obtained using a combination of [page:Texture.format .format] and [page:Texture.type .type].<br />

--- a/src/constants.js
+++ b/src/constants.js
@@ -173,6 +173,15 @@ export const NotEqualStencilFunc = 517;
 export const GreaterEqualStencilFunc = 518;
 export const AlwaysStencilFunc = 519;
 
+export const NeverCompare = 512;
+export const LessCompare = 513;
+export const EqualCompare = 514;
+export const LessEqualCompare = 515;
+export const GreaterCompare = 516;
+export const NotEqualCompare = 517;
+export const GreaterEqualCompare = 518;
+export const AlwaysCompare = 519;
+
 export const StaticDrawUsage = 35044;
 export const DynamicDrawUsage = 35048;
 export const StreamDrawUsage = 35040;

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -667,6 +667,7 @@ class ObjectLoader extends Loader {
 				if ( data.generateMipmaps !== undefined ) texture.generateMipmaps = data.generateMipmaps;
 				if ( data.premultiplyAlpha !== undefined ) texture.premultiplyAlpha = data.premultiplyAlpha;
 				if ( data.unpackAlignment !== undefined ) texture.unpackAlignment = data.unpackAlignment;
+				if ( data.compareFunction !== undefined ) texture.compareFunction = data.compareFunction;
 
 				if ( data.userData !== undefined ) texture.userData = data.userData;
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -1,4 +1,4 @@
-import { LinearFilter, LinearMipmapLinearFilter, LinearMipmapNearestFilter, NearestFilter, NearestMipmapLinearFilter, NearestMipmapNearestFilter, RGBAFormat, DepthFormat, DepthStencilFormat, UnsignedShortType, UnsignedIntType, UnsignedInt248Type, FloatType, HalfFloatType, MirroredRepeatWrapping, ClampToEdgeWrapping, RepeatWrapping, UnsignedByteType, _SRGBAFormat, NoColorSpace, LinearSRGBColorSpace, SRGBColorSpace } from '../../constants.js';
+import { LinearFilter, LinearMipmapLinearFilter, LinearMipmapNearestFilter, NearestFilter, NearestMipmapLinearFilter, NearestMipmapNearestFilter, RGBAFormat, DepthFormat, DepthStencilFormat, UnsignedShortType, UnsignedIntType, UnsignedInt248Type, FloatType, HalfFloatType, MirroredRepeatWrapping, ClampToEdgeWrapping, RepeatWrapping, UnsignedByteType, _SRGBAFormat, NoColorSpace, LinearSRGBColorSpace, SRGBColorSpace, NeverCompare, AlwaysCompare, LessCompare, LessEqualCompare, EqualCompare, GreaterEqualCompare, GreaterCompare, NotEqualCompare } from '../../constants.js';
 import * as MathUtils from '../../math/MathUtils.js';
 import { ImageUtils } from '../../extras/ImageUtils.js';
 import { createElementNS } from '../../utils.js';
@@ -526,6 +526,17 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 		[ LinearMipmapLinearFilter ]: _gl.LINEAR_MIPMAP_LINEAR
 	};
 
+	const compareToGL = {
+		[ NeverCompare ]: _gl.NEVER,
+		[ AlwaysCompare ]: _gl.ALWAYS,
+		[ LessCompare ]: _gl.LESS,
+		[ LessEqualCompare ]: _gl.LEQUAL,
+		[ EqualCompare ]: _gl.EQUAL,
+		[ GreaterEqualCompare ]: _gl.GEQUAL,
+		[ GreaterCompare ]: _gl.GREATER,
+		[ NotEqualCompare ]: _gl.NOTEQUAL
+	};
+
 	function setTextureParameters( textureType, texture, supportsMips ) {
 
 		if ( supportsMips ) {
@@ -567,6 +578,13 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 				console.warn( 'THREE.WebGLRenderer: Texture is not power of two. Texture.minFilter should be set to THREE.NearestFilter or THREE.LinearFilter.' );
 
 			}
+
+		}
+
+		if ( texture.compareFunc ) {
+
+			_gl.texParameteri( textureType, _gl.TEXTURE_COMPARE_MODE, _gl.COMPARE_REF_TO_TEXTURE );
+			_gl.texParameteri( textureType, _gl.TEXTURE_COMPARE_FUNC, compareToGL[ texture.compareFunc ] );
 
 		}
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -581,10 +581,10 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		}
 
-		if ( texture.compareFunc ) {
+		if ( texture.compareFunction ) {
 
 			_gl.texParameteri( textureType, _gl.TEXTURE_COMPARE_MODE, _gl.COMPARE_REF_TO_TEXTURE );
-			_gl.texParameteri( textureType, _gl.TEXTURE_COMPARE_FUNC, compareToGL[ texture.compareFunc ] );
+			_gl.texParameteri( textureType, _gl.TEXTURE_COMPARE_FUNC, compareToGL[ texture.compareFunction ] );
 
 		}
 

--- a/src/textures/DepthTexture.js
+++ b/src/textures/DepthTexture.js
@@ -35,9 +35,9 @@ class DepthTexture extends Texture {
 
 	copy( source ) {
 
-		this.compareFunction = source.compareFunction;
-
 		super.copy( source );
+
+		this.compareFunction = source.compareFunction;
 
 		return this;
 

--- a/src/textures/DepthTexture.js
+++ b/src/textures/DepthTexture.js
@@ -28,8 +28,30 @@ class DepthTexture extends Texture {
 		this.flipY = false;
 		this.generateMipmaps = false;
 
+		this.compareFunction = null;
+
 	}
 
+
+	copy( source ) {
+
+		this.compareFunction = source.compareFunction;
+
+		super.copy( source );
+
+		return this;
+
+	}
+
+	toJSON( meta ) {
+
+		const data = super.toJSON( meta );
+
+		if ( this.compareFunction !== null ) data.compareFunction = this.compareFunction;
+
+		return data;
+
+	}
 
 }
 


### PR DESCRIPTION
This PR introduces a `compareFunction` property to the `DepthTexture` class, enabling depth texture comparison.

This is the first step in order to improve the shadows in a WebGL2 context. This will allow implementing hardware anti-aliasing of shadow maps through depth comparison.
