### PR TITLE
WebGLRenderer: Deprecate WebGL 1 support.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -270,6 +270,12 @@ class WebGLRenderer {
 
 			}
 
+			if ( _gl instanceof WebGLRenderingContext ) { // @deprecated, r153
+
+				console.warn( 'THREE.WebGLRenderer: WebGL 1 support is deprecated with r153+, and will be removed with r163.' );
+
+			}
+
 			// Some experimental-webgl implementations do not have getShaderPrecisionFormat
 
 			if ( _gl.getShaderPrecisionFormat === undefined ) {

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -272,7 +272,7 @@ class WebGLRenderer {
 
 			if ( _gl instanceof WebGLRenderingContext ) { // @deprecated, r153
 
-				console.warn( 'THREE.WebGLRenderer: WebGL 1 support is deprecated with r153+, and will be removed with r163.' );
+				console.warn( 'THREE.WebGLRenderer: WebGL 1 support was deprecated in r153 and will be removed in r163.' );
 
 			}
 


### PR DESCRIPTION
Related issue: -

**Description**

This PR deprecates WebGL 1 supports in `three.js`. That means the renderer logs now a warning when a WebGL 1 rendering context is detected. That could happen when `WebGL1Renderer` is used, a custom WebGL 1 rendering context is passed to the renderer's constructor or `WebGLRenderer` is unable to create a WebGL 2 rendering context and falls back to WebGL 1.

The warning states that in ten releases (`r163`) WebGL 1 support will be removed. `three.js` will then require WebGL 2.

[Hardware support for WebGL 2 is already very decent](https://web3dsurvey.com/webgl2). However, I think we should announce the WebGL 1 removal and give users enough time to prepare/react since certain projects still rely on WebGL 1.

Removing WebGL 1 support will allow us to completely delete certain code paths in the renderer which will simplify the code and make it easier to support more WebGL 2 specific features.