### PR TITLE
Optimise GLTFLoader.createUniqueName

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -3428,18 +3428,20 @@ class GLTFParser {
 	createUniqueName( originalName ) {
 
 		const sanitizedName = PropertyBinding.sanitizeNodeName( originalName || '' );
-
-		let name = sanitizedName;
-
-		for ( let i = 1; this.nodeNamesUsed[ name ]; ++ i ) {
-
-			name = sanitizedName + '_' + i;
-
+		
+		if (sanitizedName in this.nodeNamesUsed) {
+			
+			const num = ++this.nodeNamesUsed[ sanitizedName ];
+			
+			return sanitizedName + "_" + num;
+			
+		} else {
+			
+			nodeNamesUsed[ sanitizedName ] = 0;
+			
+			return sanitizedName;
+			
 		}
-
-		this.nodeNamesUsed[ name ] = true;
-
-		return name;
 
 	}
 


### PR DESCRIPTION
When I'm loading a big scene with lots of repeated names in it, it's about 3x faster if I get rid of the loop in `GLTFLoader.createUniqueName`.