### PR TITLE
MMDLoader: Catch parser exceptions.

### DIFF
--- a/examples/jsm/loaders/MMDLoader.js
+++ b/examples/jsm/loaders/MMDLoader.js
@@ -226,7 +226,15 @@ class MMDLoader extends Loader {
 			.setWithCredentials( this.withCredentials )
 			.load( url, function ( buffer ) {
 
-				onLoad( parser.parsePmd( buffer, true ) );
+				try {
+
+					onLoad( parser.parsePmd( buffer, true ) );
+
+				} catch ( e ) {
+
+					if ( onError ) onError( e );
+
+				}
 
 			}, onProgress, onError );
 
@@ -252,7 +260,15 @@ class MMDLoader extends Loader {
 			.setWithCredentials( this.withCredentials )
 			.load( url, function ( buffer ) {
 
-				onLoad( parser.parsePmx( buffer, true ) );
+				try {
+
+					onLoad( parser.parsePmx( buffer, true ) );
+
+				} catch ( e ) {
+
+					if ( onError ) onError( e );
+
+				}
 
 			}, onProgress, onError );
 
@@ -287,9 +303,17 @@ class MMDLoader extends Loader {
 
 			this.loader.load( urls[ i ], function ( buffer ) {
 
-				vmds.push( parser.parseVmd( buffer, true ) );
+				try {
 
-				if ( vmds.length === vmdNum ) onLoad( parser.mergeVmds( vmds ) );
+					vmds.push( parser.parseVmd( buffer, true ) );
+
+					if ( vmds.length === vmdNum ) onLoad( parser.mergeVmds( vmds ) );
+
+				} catch ( e ) {
+
+					if ( onError ) onError( e );
+
+				}
 
 			}, onProgress, onError );
 
@@ -318,7 +342,15 @@ class MMDLoader extends Loader {
 			.setWithCredentials( this.withCredentials )
 			.load( url, function ( text ) {
 
-				onLoad( parser.parseVpd( text, true ) );
+				try {
+
+					onLoad( parser.parseVpd( text, true ) );
+
+				} catch ( e ) {
+
+					if ( onError ) onError( e );
+
+				}
 
 			}, onProgress, onError );
 


### PR DESCRIPTION
**Description**

In MMDLoader, the exceptions from [mmd-parser](https://github.com/takahirox/mmd-parser/blob/master/src/Parser.js) are not sent onError function, for example, this is one exception from mmd-parser: https://github.com/takahirox/mmd-parser/blob/master/src/Parser.js#L523 . This PR resends all the errors to onError function