### PR TITLE
CSM: Remove default value of `data` ctor parameter.

### DIFF
--- a/examples/jsm/csm/CSM.js
+++ b/examples/jsm/csm/CSM.js
@@ -24,8 +24,6 @@ export class CSM {
 
 	constructor( data ) {
 
-		data = data || {};
-
 		this.camera = data.camera;
 		this.parent = data.parent;
 		this.cascades = data.cascades || 3;


### PR DESCRIPTION
Fixed #25956.

**Description**

Removes the default value of the `data` constructor parameter. This means `data` is now considered to be mandatory.
