### PR TITLE
Optimise GLTFParser.createUniqueName

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -3429,17 +3429,19 @@ class GLTFParser {
 
 		const sanitizedName = PropertyBinding.sanitizeNodeName( originalName || '' );
 
-		let name = sanitizedName;
+		if (sanitizedName in this.nodeNamesUsed) {
 
-		for ( let i = 1; this.nodeNamesUsed[ name ]; ++ i ) {
+			const num = ++this.nodeNamesUsed[ sanitizedName ];
 
-			name = sanitizedName + '_' + i;
+			return sanitizedName + "_" + num;
+
+		} else {
+
+			this.nodeNamesUsed[ sanitizedName ] = 0;
+
+			return sanitizedName;
 
 		}
-
-		this.nodeNamesUsed[ name ] = true;
-
-		return name;
 
 	}
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -3429,11 +3429,9 @@ class GLTFParser {
 
 		const sanitizedName = PropertyBinding.sanitizeNodeName( originalName || '' );
 
-		if (sanitizedName in this.nodeNamesUsed) {
+		if ( sanitizedName in this.nodeNamesUsed ) {
 
-			const num = ++this.nodeNamesUsed[ sanitizedName ];
-
-			return sanitizedName + "_" + num;
+			return sanitizedName + '_' + ( ++ this.nodeNamesUsed[ sanitizedName ] );
 
 		} else {
 


### PR DESCRIPTION
When I'm loading a big scene with lots of repeated names in it, it's about 3x faster if I get rid of the loop in `GLTFParser.createUniqueName`.

(I messed this PR up yesterday, hopefully not this time 🙃)