### PR TITLE
MeshSurfaceSampler: add sampleFaceIndex function

### DIFF
--- a/examples/jsm/math/MeshSurfaceSampler.js
+++ b/examples/jsm/math/MeshSurfaceSampler.js
@@ -108,11 +108,15 @@ class MeshSurfaceSampler {
 
 	sample( targetPosition, targetNormal, targetColor ) {
 
-		const cumulativeTotal = this.distribution[ this.distribution.length - 1 ];
-
-		const faceIndex = this.binarySearch( this.randomFunction() * cumulativeTotal );
-
+		const faceIndex = this.sampleFaceIndex();
 		return this.sampleFace( faceIndex, targetPosition, targetNormal, targetColor );
+
+	}
+
+	sampleFaceIndex() {
+
+		const cumulativeTotal = this.distribution[ this.distribution.length - 1 ];
+		return this.binarySearch( this.randomFunction() * cumulativeTotal );
 
 	}
 


### PR DESCRIPTION
Related issue: --

**Description**

Adds `MeshSurfaceSampler.sampleFaceIndex` to allow for sampling a random face from the mesh which can then be used in conjunction with "sampleFace" to get a random value on that face. I needed a function like this for [this work](https://gkjohnson.github.io/three-sketches/surface-flow/galacticSurface.html) since I needed to know which face the random point was placed from.