### PR TITLE
Mesh: Add deprecation comment in `checkGeometryIntersection`

### DIFF
--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -388,7 +388,7 @@ function checkGeometryIntersection( object, material, raycaster, ray, uv, uv1, n
 			_uvC.fromBufferAttribute( uv1, c );
 
 			intersection.uv1 = Triangle.getInterpolation( _intersectionPoint, _vA, _vB, _vC, _uvA, _uvB, _uvC, new Vector2() );
-			intersection.uv2 = intersection.uv1; // Backwards compatibility
+			intersection.uv2 = intersection.uv1; // @deprecated, r152
 
 		}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/25943#discussion_r1181692893