### PR TITLE
InstancedMesh/SkinnedMesh: Honor bounding volumes in `copy()`.

### DIFF
--- a/src/objects/InstancedMesh.js
+++ b/src/objects/InstancedMesh.js
@@ -110,6 +110,9 @@ class InstancedMesh extends Mesh {
 
 		this.count = source.count;
 
+		if ( source.boundingBox !== null ) this.boundingBox = source.boundingBox.clone();
+		if ( source.boundingSphere !== null ) this.boundingSphere = source.boundingSphere.clone();
+
 		return this;
 
 	}

--- a/src/objects/SkinnedMesh.js
+++ b/src/objects/SkinnedMesh.js
@@ -96,6 +96,9 @@ class SkinnedMesh extends Mesh {
 
 		this.skeleton = source.skeleton;
 
+		if ( source.boundingBox !== null ) this.boundingBox = source.boundingBox.clone();
+		if ( source.boundingSphere !== null ) this.boundingSphere = source.boundingSphere.clone();
+
 		return this;
 
 	}


### PR DESCRIPTION
Related issue: #25960

**Description**

Honor bounding volumes in `InstancedMesh.copy()` and `SkinnedMesh.copy()`.
