### PR TITLE
WebGLInfo: Decouple info.render.frame from info.autoReset

### DIFF
--- a/examples/jsm/renderers/webgpu/WebGPUInfo.js
+++ b/examples/jsm/renderers/webgpu/WebGPUInfo.js
@@ -49,7 +49,6 @@ class WebGPUInfo {
 
 	reset() {
 
-		this.render.frame ++;
 		this.render.drawCalls = 0;
 		this.render.triangles = 0;
 		this.render.points = 0;

--- a/examples/jsm/renderers/webgpu/WebGPURenderer.js
+++ b/examples/jsm/renderers/webgpu/WebGPURenderer.js
@@ -301,6 +301,8 @@ class WebGPURenderer {
 
 		if ( this._info.autoReset === true ) this._info.reset();
 
+		this._info.render.frame ++;
+
 		_projScreenMatrix.multiplyMatrices( camera.projectionMatrix, camera.matrixWorldInverse );
 		_frustum.setFromProjectionMatrix( _projScreenMatrix );
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1022,8 +1022,9 @@ class WebGLRenderer {
 
 			if ( this.info.autoReset === true ) this.info.reset();
 
-			//
 			this.info.render.frame ++;
+
+			//
 
 			background.render( currentRenderList, scene );
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1023,6 +1023,7 @@ class WebGLRenderer {
 			if ( this.info.autoReset === true ) this.info.reset();
 
 			//
+			this.info.render.frame ++;
 
 			background.render( currentRenderList, scene );
 

--- a/src/renderers/webgl/WebGLInfo.js
+++ b/src/renderers/webgl/WebGLInfo.js
@@ -49,7 +49,6 @@ function WebGLInfo( gl ) {
 
 	function reset() {
 
-		render.frame ++;
 		render.calls = 0;
 		render.triangles = 0;
 		render.points = 0;


### PR DESCRIPTION
This pull request addresses an issue with the `info.autoReset` property, which currently impacts the behavior of Uniform Buffer Objects (UBOs) binding, geometry updates, and skeleton updates, as these processes rely on the `info.render.frame` state.

The proposed changes ensure that developers who intend to manually control the gl/gpu pipeline information by setting `info.autoReset` to false do not encounter unexpected behavior. 