### PR TITLE
Example: Update GPU picking to use integer Ids, target

### DIFF
--- a/examples/webgl_interactive_cubes_gpu.html
+++ b/examples/webgl_interactive_cubes_gpu.html
@@ -257,11 +257,7 @@
 				// clear the background to - 1 meaning no item was hit
 				clearColor.setRGB( - 1, - 1, - 1 );
 				renderer.setClearColor( clearColor );
-				renderer.clear();
-
-				renderer.autoClear = false;
 				renderer.render( pickingScene, camera );
-				renderer.autoClear = true;
 
 				// clear the view offset so rendering returns to normal
 				camera.clearViewOffset();

--- a/examples/webgl_interactive_cubes_gpu.html
+++ b/examples/webgl_interactive_cubes_gpu.html
@@ -69,6 +69,20 @@
 				scene = new THREE.Scene();
 				scene.background = new THREE.Color( 0xffffff );
 
+				scene.add( new THREE.AmbientLight( 0x555555 ) );
+
+				const light = new THREE.SpotLight( 0xffffff, 1.5 );
+				light.position.set( 0, 500, 2000 );
+				scene.add( light );
+
+				const defaultMaterial = new THREE.MeshPhongMaterial( {
+					color: 0xffffff,
+					flatShading: true,
+					vertexColors: true,
+					shininess: 0
+				} );
+
+				// set up the picking texture to use a 32 bit integer so we can write and read integer ids from it
 				pickingScene = new THREE.Scene();
 				pickingTexture = new THREE.WebGLRenderTarget( 1, 1, {
 
@@ -77,14 +91,6 @@
 					internalFormat: 'R32I',
 
 				} );
-
-				scene.add( new THREE.AmbientLight( 0x555555 ) );
-
-				const light = new THREE.SpotLight( 0xffffff, 1.5 );
-				light.position.set( 0, 500, 2000 );
-				scene.add( light );
-
-				const defaultMaterial = new THREE.MeshPhongMaterial( { color: 0xffffff, flatShading: true, vertexColors: true, shininess: 0	} );
 				const pickingMaterial = new THREE.ShaderMaterial( {
 
 					glslVersion: THREE.GLSL3,
@@ -101,16 +107,14 @@
 					`,
 
 					fragmentShader: /* glsl */`
-
 						layout(location = 0) out int out_id;
 						flat varying int vid;
 
 						void main() {
 
-							out_id = int( vid );
+							out_id = vid;
 
 						}
-
 					`,
 
 				} );
@@ -170,8 +174,8 @@
 
 					geometry.applyMatrix4( matrix );
 
-					// give the geometry's vertices a random color, to be displayed
-
+					// give the geometry's vertices a random color to be displayed and an integer
+					// identifier as a vertex attribute so boxes can be identified after being merged.
 					applyVertexColors( geometry, color.setHex( Math.random() * 0xffffff ) );
 					applyId( geometry, i );
 
@@ -238,41 +242,40 @@
 
 			function pick() {
 
-				//render the picking scene off-screen
-
+				// render the picking scene off-screen
 				// set the view offset to represent just a single pixel under the mouse
-
-				camera.setViewOffset( renderer.domElement.width, renderer.domElement.height, pointer.x * window.devicePixelRatio | 0, pointer.y * window.devicePixelRatio | 0, 1, 1 );
+				const dpr = window.devicePixelRatio;
+				camera.setViewOffset(
+					renderer.domElement.width, renderer.domElement.height,
+					Math.floor( pointer.x * dpr ), Math.floor( pointer.y * dpr ),
+					1, 1
+				);
 
 				// render the scene
-				clearColor.setRGB( - 1, - 1, - 1 );
-				renderer.autoClear = false;
 				renderer.setRenderTarget( pickingTexture );
+
+				// clear the background to - 1 meaning no item was hit
+				clearColor.setRGB( - 1, - 1, - 1 );
 				renderer.setClearColor( clearColor );
 				renderer.clear();
-				renderer.render( pickingScene, camera );
 
+				renderer.autoClear = false;
+				renderer.render( pickingScene, camera );
 				renderer.autoClear = true;
 
 				// clear the view offset so rendering returns to normal
-
 				camera.clearViewOffset();
 
-				//create buffer for reading single pixel
-
+				// create buffer for reading single pixel
 				const pixelBuffer = new Int32Array( 1 );
 
-				//read the pixel
-
+				// read the pixel
 				renderer.readRenderTargetPixels( pickingTexture, 0, 0, 1, 1, pixelBuffer );
 
-				//interpret the pixel as an ID
 				const id = pixelBuffer[ 0 ];
-
 				if ( id !== - 1 ) {
 
-					//move our highlightBox so that it surrounds the picked object
-
+					// move our highlightBox so that it surrounds the picked object
 					const data = pickingData[ id ];
 					highlightBox.position.copy( data.position );
 					highlightBox.rotation.copy( data.rotation );

--- a/examples/webgl_interactive_cubes_gpu.html
+++ b/examples/webgl_interactive_cubes_gpu.html
@@ -84,6 +84,7 @@
 				light.position.set( 0, 500, 2000 );
 				scene.add( light );
 
+				const defaultMaterial = new THREE.MeshPhongMaterial( { color: 0xffffff, flatShading: true, vertexColors: true, shininess: 0	} );
 				const pickingMaterial = new THREE.ShaderMaterial( {
 
 					glslVersion: THREE.GLSL3,
@@ -113,10 +114,6 @@
 					`,
 
 				} );
-				pickingMaterial.outputType = 'ivec4';
-
-				// const pickingMaterial = new THREE.MeshBasicMaterial( { vertexColors: true } );
-				const defaultMaterial = new THREE.MeshPhongMaterial( { color: 0xffffff, flatShading: true, vertexColors: true, shininess: 0	} );
 
 				function applyId( geometry, id ) {
 
@@ -144,16 +141,14 @@
 
 				}
 
-				const geometriesDrawn = [];
-				const geometriesPicking = [];
-
+				const geometries = [];
 				const matrix = new THREE.Matrix4();
 				const quaternion = new THREE.Quaternion();
 				const color = new THREE.Color();
 
 				for ( let i = 0; i < 5000; i ++ ) {
 
-					let geometry = new THREE.BoxGeometry();
+					const geometry = new THREE.BoxGeometry();
 
 					const position = new THREE.Vector3();
 					position.x = Math.random() * 10000 - 5000;
@@ -178,17 +173,9 @@
 					// give the geometry's vertices a random color, to be displayed
 
 					applyVertexColors( geometry, color.setHex( Math.random() * 0xffffff ) );
-
-					geometriesDrawn.push( geometry );
-
-					geometry = geometry.clone();
-
-					// give the geometry's vertices a color corresponding to the "id"
-
-					applyVertexColors( geometry, color.setHex( i, THREE.NoColorSpace ) );
 					applyId( geometry, i );
 
-					geometriesPicking.push( geometry );
+					geometries.push( geometry );
 
 					pickingData[ i ] = {
 
@@ -200,15 +187,14 @@
 
 				}
 
-				const objects = new THREE.Mesh( BufferGeometryUtils.mergeGeometries( geometriesDrawn ), defaultMaterial );
-				scene.add( objects );
-
-				pickingScene.add( new THREE.Mesh( BufferGeometryUtils.mergeGeometries( geometriesPicking ), pickingMaterial ) );
+				const mergedGeometry = BufferGeometryUtils.mergeGeometries( geometries );
+				scene.add( new THREE.Mesh( mergedGeometry, defaultMaterial ) );
+				pickingScene.add( new THREE.Mesh( mergedGeometry, pickingMaterial ) );
 
 				highlightBox = new THREE.Mesh(
 					new THREE.BoxGeometry(),
-					new THREE.MeshLambertMaterial( { color: 0xffff00 }
-					) );
+					new THREE.MeshLambertMaterial( { color: 0xffff00 } )
+				);
 				scene.add( highlightBox );
 
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
@@ -281,23 +267,17 @@
 				renderer.readRenderTargetPixels( pickingTexture, 0, 0, 1, 1, pixelBuffer );
 
 				//interpret the pixel as an ID
-				console.log(pixelBuffer[0]);
+				const id = pixelBuffer[ 0 ];
 
-				const id = pixelBuffer[ 0 ]; //( pixelBuffer[ 0 ] << 16 ) | ( pixelBuffer[ 1 ] << 8 ) | ( pixelBuffer[ 2 ] );
-				const data = pickingData[ id ];
-
-				if ( data ) {
+				if ( id !== - 1 ) {
 
 					//move our highlightBox so that it surrounds the picked object
 
-					if ( data.position && data.rotation && data.scale ) {
-
-						highlightBox.position.copy( data.position );
-						highlightBox.rotation.copy( data.rotation );
-						highlightBox.scale.copy( data.scale ).add( offset );
-						highlightBox.visible = true;
-
-					}
+					const data = pickingData[ id ];
+					highlightBox.position.copy( data.position );
+					highlightBox.rotation.copy( data.rotation );
+					highlightBox.scale.copy( data.scale ).add( offset );
+					highlightBox.visible = true;
 
 				} else {
 

--- a/examples/webgl_interactive_cubes_gpu.html
+++ b/examples/webgl_interactive_cubes_gpu.html
@@ -54,6 +54,7 @@
 
 			const pointer = new THREE.Vector2();
 			const offset = new THREE.Vector3( 10, 10, 10 );
+			const clearColor = new THREE.Color();
 
 			init();
 			animate();
@@ -69,7 +70,13 @@
 				scene.background = new THREE.Color( 0xffffff );
 
 				pickingScene = new THREE.Scene();
-				pickingTexture = new THREE.WebGLRenderTarget( 1, 1 );
+				pickingTexture = new THREE.WebGLRenderTarget( 1, 1, {
+
+					type: THREE.IntType,
+					format: THREE.RedIntegerFormat,
+					internalFormat: 'R32I',
+
+				} );
 
 				scene.add( new THREE.AmbientLight( 0x555555 ) );
 
@@ -77,8 +84,50 @@
 				light.position.set( 0, 500, 2000 );
 				scene.add( light );
 
-				const pickingMaterial = new THREE.MeshBasicMaterial( { vertexColors: true } );
+				const pickingMaterial = new THREE.ShaderMaterial( {
+
+					glslVersion: THREE.GLSL3,
+
+					vertexShader: /* glsl */`
+						attribute int id;
+						flat varying int vid;
+						void main() {
+
+							vid = int( id );
+							gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+
+						}
+					`,
+
+					fragmentShader: /* glsl */`
+
+						layout(location = 0) out int out_id;
+						flat varying int vid;
+
+						void main() {
+
+							out_id = int( vid );
+
+						}
+
+					`,
+
+				} );
+				pickingMaterial.outputType = 'ivec4';
+
+				// const pickingMaterial = new THREE.MeshBasicMaterial( { vertexColors: true } );
 				const defaultMaterial = new THREE.MeshPhongMaterial( { color: 0xffffff, flatShading: true, vertexColors: true, shininess: 0	} );
+
+				function applyId( geometry, id ) {
+
+					const position = geometry.attributes.position;
+					const array = new Int32Array( position.count );
+					array.fill( id );
+
+					const bufferAttribute = new THREE.BufferAttribute( array, 1, false );
+					geometry.setAttribute( 'id', bufferAttribute );
+
+				}
 
 				function applyVertexColors( geometry, color ) {
 
@@ -137,6 +186,7 @@
 					// give the geometry's vertices a color corresponding to the "id"
 
 					applyVertexColors( geometry, color.setHex( i, THREE.NoColorSpace ) );
+					applyId( geometry, i );
 
 					geometriesPicking.push( geometry );
 
@@ -209,9 +259,14 @@
 				camera.setViewOffset( renderer.domElement.width, renderer.domElement.height, pointer.x * window.devicePixelRatio | 0, pointer.y * window.devicePixelRatio | 0, 1, 1 );
 
 				// render the scene
-
+				clearColor.setRGB( - 1, - 1, - 1 );
+				renderer.autoClear = false;
 				renderer.setRenderTarget( pickingTexture );
+				renderer.setClearColor( clearColor );
+				renderer.clear();
 				renderer.render( pickingScene, camera );
+
+				renderer.autoClear = true;
 
 				// clear the view offset so rendering returns to normal
 
@@ -219,15 +274,16 @@
 
 				//create buffer for reading single pixel
 
-				const pixelBuffer = new Uint8Array( 4 );
+				const pixelBuffer = new Int32Array( 1 );
 
 				//read the pixel
 
 				renderer.readRenderTargetPixels( pickingTexture, 0, 0, 1, 1, pixelBuffer );
 
 				//interpret the pixel as an ID
+				console.log(pixelBuffer[0]);
 
-				const id = ( pixelBuffer[ 0 ] << 16 ) | ( pixelBuffer[ 1 ] << 8 ) | ( pixelBuffer[ 2 ] );
+				const id = pixelBuffer[ 0 ]; //( pixelBuffer[ 0 ] << 16 ) | ( pixelBuffer[ 1 ] << 8 ) | ( pixelBuffer[ 2 ] );
 				const data = pickingData[ id ];
 
 				if ( data ) {

--- a/examples/webgl_interactive_cubes_gpu.html
+++ b/examples/webgl_interactive_cubes_gpu.html
@@ -100,7 +100,7 @@
 						flat varying int vid;
 						void main() {
 
-							vid = int( id );
+							vid = id;
 							gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
 						}


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/25952#issuecomment-1528805375

**Description**

Updates the GPU picking example to use an integer vertex attribute, 32 bit integer target for rendering rather than the color-based approach that required using bit shifts on color values to reconstitute the id.

Note - I realized that no changes were needed to ShaderMaterial in order to enable rendering to an integer target since using GLSL3 enables control over the output type.

_edit: also addresses and issue that was causing the 0th box to be selected when hovering over the background_