### PR TITLE
MathUtils: Add support for Uint32 and Int32 to normalize / denormalize functions

### DIFF
--- a/src/math/MathUtils.js
+++ b/src/math/MathUtils.js
@@ -235,6 +235,10 @@ function denormalize( value, array ) {
 
 			return value;
 
+		case Uint32Array:
+
+			return value / 4294967295.0;
+
 		case Uint16Array:
 
 			return value / 65535.0;
@@ -242,6 +246,10 @@ function denormalize( value, array ) {
 		case Uint8Array:
 
 			return value / 255.0;
+
+		case Int32Array:
+
+			return Math.max( value / 2147483647.0, - 1.0 );
 
 		case Int16Array:
 
@@ -267,6 +275,10 @@ function normalize( value, array ) {
 
 			return value;
 
+		case Uint32Array:
+
+			return Math.round( value * 4294967295.0 );
+
 		case Uint16Array:
 
 			return Math.round( value * 65535.0 );
@@ -274,6 +286,10 @@ function normalize( value, array ) {
 		case Uint8Array:
 
 			return Math.round( value * 255.0 );
+
+		case Int32Array:
+
+			return Math.round( value * 2147483647.0 );
 
 		case Int16Array:
 


### PR DESCRIPTION
Related issue: #21606

**Description**

Adds support for normalizing and denormalizing 32 bit int and uint values. After #21606 it will be possible to load int32 and uint32 buffers as "normalized" which will currently cause errors when generating bounding boxes or spheres if used with position attributes.

```js
2**31 - 1 === 2147483647.0
2**32 - 1 === 4294967295.0
```