### PR TITLE
Examples: Clean up.

### DIFF
--- a/examples/webgl_animation_skinning_blending.html
+++ b/examples/webgl_animation_skinning_blending.html
@@ -69,7 +69,7 @@
 				scene.background = new THREE.Color( 0xa0a0a0 );
 				scene.fog = new THREE.Fog( 0xa0a0a0, 10, 50 );
 
-				const hemiLight = new THREE.HemisphereLight( 0xffffff, 0x444444 );
+				const hemiLight = new THREE.HemisphereLight( 0xffffff, 0x8d8d8d );
 				hemiLight.position.set( 0, 20, 0 );
 				scene.add( hemiLight );
 
@@ -88,7 +88,7 @@
 
 				// ground
 
-				const mesh = new THREE.Mesh( new THREE.PlaneGeometry( 100, 100 ), new THREE.MeshPhongMaterial( { color: 0x999999, depthWrite: false } ) );
+				const mesh = new THREE.Mesh( new THREE.PlaneGeometry( 100, 100 ), new THREE.MeshPhongMaterial( { color: 0xcbcbcb, depthWrite: false } ) );
 				mesh.rotation.x = - Math.PI / 2;
 				mesh.receiveShadow = true;
 				scene.add( mesh );


### PR DESCRIPTION
Related issue: -

**Description**

The skinning example looks still top dark on my system:

<img width="2554" alt="image" src="https://user-images.githubusercontent.com/12612165/236156942-2087a1e0-4429-46c3-b160-29dabba407fe.png">

Since color management is enabled, certain light and material color values have to be updated so the result looks like before. Both new color values are the sRGB pendant compared to the previous linear values. After these changes the example renders like so:

<img width="2553" alt="image" src="https://user-images.githubusercontent.com/12612165/236157133-90fa5068-933e-4621-bae3-2ba0dbd57080.png">

BTW: I wonder how the E2E screenshot can look correctly without using the corrected color values...