### PR TITLE
WebGPURenderer: Fix skinning bone multiplication order

### DIFF
--- a/examples/jsm/nodes/accessors/ModelViewProjectionNode.js
+++ b/examples/jsm/nodes/accessors/ModelViewProjectionNode.js
@@ -6,22 +6,17 @@ import { nodeProxy } from '../shadernode/ShaderNode.js';
 
 class ModelViewProjectionNode extends Node {
 
-	constructor( position = positionLocal ) {
+	constructor( positionNode = positionLocal ) {
 
 		super( 'vec4' );
 
-		this.position = position;
+		this.positionNode = positionNode;
 
 	}
 
-	generate( builder ) {
+	construct() {
 
-		const position = this.position;
-
-		const mvpMatrix = cameraProjectionMatrix.mul( modelViewMatrix );
-		const mvpNode = mvpMatrix.mul( position );
-
-		return mvpNode.build( builder );
+		return cameraProjectionMatrix.mul( modelViewMatrix ).mul( this.positionNode );
 
 	}
 

--- a/examples/jsm/nodes/accessors/SkinningNode.js
+++ b/examples/jsm/nodes/accessors/SkinningNode.js
@@ -23,10 +23,10 @@ const Skinning = new ShaderNode( ( inputs, {}, builder ) => {
 	const skinVertex = bindMatrix.mul( positionLocal );
 
 	const skinned = add(
-		boneMatX.mul( skinVertex ).mul( weight.x ),
-		boneMatY.mul( skinVertex ).mul( weight.y ),
-		boneMatZ.mul( skinVertex ).mul( weight.z ),
-		boneMatW.mul( skinVertex ).mul( weight.w )
+		boneMatX.mul( weight.x ).mul( skinVertex ),
+		boneMatY.mul( weight.y ).mul( skinVertex ),
+		boneMatZ.mul( weight.z ).mul( skinVertex ),
+		boneMatW.mul( weight.w ).mul( skinVertex )
 	);
 
 	const skinPosition = bindMatrixInverse.mul( skinned ).xyz;


### PR DESCRIPTION
Related issue: Closes https://github.com/mrdoob/three.js/issues/25985

**Description**

This caused a skinning bad position.