### PR TITLE
Examples: More clean up.

### DIFF
--- a/examples/webaudio_orientation.html
+++ b/examples/webaudio_orientation.html
@@ -42,8 +42,6 @@
 		import { PositionalAudioHelper } from 'three/addons/helpers/PositionalAudioHelper.js';
 		import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 
-		THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
-
 		let scene, camera, renderer;
 
 		const startButton = document.getElementById( 'startButton' );
@@ -65,13 +63,15 @@
 				.setPath( 'textures/cube/SwedishRoyalCastle/' )
 				.load( [ 'px.jpg', 'nx.jpg', 'py.jpg', 'ny.jpg', 'pz.jpg', 'nz.jpg' ] );
 
+			reflectionCube.colorSpace = THREE.SRGBColorSpace;
+
 			scene = new THREE.Scene();
 			scene.background = new THREE.Color( 0xa0a0a0 );
 			scene.fog = new THREE.Fog( 0xa0a0a0, 2, 20 );
 
 			//
 
-			const hemiLight = new THREE.HemisphereLight( 0xffffff, 0x444444 );
+			const hemiLight = new THREE.HemisphereLight( 0xffffff, 0x8d8d8d );
 			hemiLight.position.set( 0, 20, 0 );
 			scene.add( hemiLight );
 
@@ -90,12 +90,12 @@
 
 			//
 
-			const mesh = new THREE.Mesh( new THREE.PlaneGeometry( 50, 50 ), new THREE.MeshPhongMaterial( { color: 0x999999, depthWrite: false } ) );
+			const mesh = new THREE.Mesh( new THREE.PlaneGeometry( 50, 50 ), new THREE.MeshPhongMaterial( { color: 0xcbcbcb, depthWrite: false } ) );
 			mesh.rotation.x = - Math.PI / 2;
 			mesh.receiveShadow = true;
 			scene.add( mesh );
 
-			const grid = new THREE.GridHelper( 50, 50, 0x888888, 0x888888 );
+			const grid = new THREE.GridHelper( 50, 50, 0xc1c1c1, 0xc1c1c1 );
 			scene.add( grid );
 
 			//

--- a/examples/webgl_animation_multiple.html
+++ b/examples/webgl_animation_multiple.html
@@ -32,8 +32,6 @@
 			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 			import * as SkeletonUtils from 'three/addons/utils/SkeletonUtils.js';
 
-			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
-
 			let camera, scene, renderer;
 			let clock;
 
@@ -54,7 +52,7 @@
 				scene.background = new THREE.Color( 0xa0a0a0 );
 				scene.fog = new THREE.Fog( 0xa0a0a0, 10, 50 );
 
-				const hemiLight = new THREE.HemisphereLight( 0xffffff, 0x444444 );
+				const hemiLight = new THREE.HemisphereLight( 0xffffff, 0x8d8d8d );
 				hemiLight.position.set( 0, 20, 0 );
 				scene.add( hemiLight );
 
@@ -73,7 +71,7 @@
 
 				// ground
 
-				const mesh = new THREE.Mesh( new THREE.PlaneGeometry( 200, 200 ), new THREE.MeshPhongMaterial( { color: 0x999999, depthWrite: false } ) );
+				const mesh = new THREE.Mesh( new THREE.PlaneGeometry( 200, 200 ), new THREE.MeshPhongMaterial( { color: 0xcbcbcb, depthWrite: false } ) );
 				mesh.rotation.x = - Math.PI / 2;
 				mesh.receiveShadow = true;
 				scene.add( mesh );

--- a/examples/webgl_animation_skinning_additive_blending.html
+++ b/examples/webgl_animation_skinning_additive_blending.html
@@ -43,8 +43,6 @@
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 
-			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
-
 			let scene, renderer, camera, stats;
 			let model, skeleton, mixer, clock;
 
@@ -76,7 +74,7 @@
 				scene.background = new THREE.Color( 0xa0a0a0 );
 				scene.fog = new THREE.Fog( 0xa0a0a0, 10, 50 );
 
-				const hemiLight = new THREE.HemisphereLight( 0xffffff, 0x444444 );
+				const hemiLight = new THREE.HemisphereLight( 0xffffff, 0x8d8d8d );
 				hemiLight.position.set( 0, 20, 0 );
 				scene.add( hemiLight );
 
@@ -93,7 +91,7 @@
 
 				// ground
 
-				const mesh = new THREE.Mesh( new THREE.PlaneGeometry( 100, 100 ), new THREE.MeshPhongMaterial( { color: 0x999999, depthWrite: false } ) );
+				const mesh = new THREE.Mesh( new THREE.PlaneGeometry( 100, 100 ), new THREE.MeshPhongMaterial( { color: 0xcbcbcb, depthWrite: false } ) );
 				mesh.rotation.x = - Math.PI / 2;
 				mesh.receiveShadow = true;
 				scene.add( mesh );

--- a/examples/webgl_animation_skinning_morph.html
+++ b/examples/webgl_animation_skinning_morph.html
@@ -56,8 +56,6 @@
 
 			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 
-			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
-
 			let container, stats, clock, gui, mixer, actions, activeAction, previousAction;
 			let camera, scene, renderer, model, face;
 
@@ -83,7 +81,7 @@
 
 				// lights
 
-				const hemiLight = new THREE.HemisphereLight( 0xffffff, 0x444444 );
+				const hemiLight = new THREE.HemisphereLight( 0xffffff, 0x8d8d8d );
 				hemiLight.position.set( 0, 20, 0 );
 				scene.add( hemiLight );
 
@@ -93,7 +91,7 @@
 
 				// ground
 
-				const mesh = new THREE.Mesh( new THREE.PlaneGeometry( 2000, 2000 ), new THREE.MeshPhongMaterial( { color: 0x999999, depthWrite: false } ) );
+				const mesh = new THREE.Mesh( new THREE.PlaneGeometry( 2000, 2000 ), new THREE.MeshPhongMaterial( { color: 0xcbcbcb, depthWrite: false } ) );
 				mesh.rotation.x = - Math.PI / 2;
 				scene.add( mesh );
 


### PR DESCRIPTION
Related issue: -

**Description**

When `webaudio_orientation.html` was created, I've forgot to define the color space of the environment map. The PR fixes that and also enables color management for a few more examples (same changes as in #25986).
