### PR TITLE
Examples: Disable color management with `SVGRenderer`.

### DIFF
--- a/examples/svg_sandbox.html
+++ b/examples/svg_sandbox.html
@@ -34,7 +34,7 @@
 
 			import { SVGRenderer, SVGObject } from 'three/addons/renderers/SVGRenderer.js';
 
-			THREE.ColorManagement.enabled = false; // TODO: Consider enabling color management.
+			THREE.ColorManagement.enabled = false;
 
 			let camera, scene, renderer, stats;
 


### PR DESCRIPTION
Related issue: -

**Description**

This is just a tiny PR but I've wanted to file it separately for better transparency.

`SVGRenderer` uses no shaders so it does not require a distinction between input, working and output color space since everything is sRGB. Hence, disabling color management is okay for all examples using `SVGRenderer` (it is in fact just one). So this PR just removes the TODO comment.
