### PR TITLE
USDZExporter: Added texture.channel support

### DIFF
--- a/examples/jsm/exporters/USDZExporter.js
+++ b/examples/jsm/exporters/USDZExporter.js
@@ -406,10 +406,10 @@ function buildVector2Array( attribute, count ) {
 function buildPrimvars( attributes, count ) {
 
 	let string = '';
-	const ids = [ '', '1' ];
 
-	for ( const id of ids ) {
+	for ( let i = 0; i < 4; i ++ ) {
 
+		const id = ( i > 0 ? i : '' );
 		const attribute = attributes[ 'uv' + id ];
 
 		if ( attribute !== undefined ) {


### PR DESCRIPTION
Related issue: #25721

**Description**

This is how the `SheenChair` model renders in https://www.usdz-viewer.net/

| Before | After |
| --- | --- |
| <img width="893" alt="Screenshot 2023-05-06 at 06 37 30" src="https://user-images.githubusercontent.com/97088/236573026-abc978f9-ef80-475a-9838-f1bbbd686a23.png"> | <img width="893" alt="Screenshot 2023-05-06 at 06 37 40" src="https://user-images.githubusercontent.com/97088/236573053-c117d9e3-7538-4d8a-8330-cce6949774b0.png"> |

Edit: I've [no idea](https://twitter.com/mrdoob/status/1654494500230778887) what viewer to use as reference in MacOS though...