### PR TITLE
Improve transmission when background is transparent

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -22,6 +22,7 @@ import {
 	UnsignedShort4444Type,
 	UnsignedShort5551Type
 } from '../constants.js';
+import { Color } from '../math/Color.js';
 import { Frustum } from '../math/Frustum.js';
 import { Matrix4 } from '../math/Matrix4.js';
 import { Vector3 } from '../math/Vector3.js';
@@ -173,6 +174,9 @@ class WebGLRenderer {
 		const _currentViewport = new Vector4();
 		const _currentScissor = new Vector4();
 		let _currentScissorTest = null;
+
+		const _currentClearColor = new Color( 0x000000 );
+		let _currentClearAlpha = 0;
 
 		//
 
@@ -1359,6 +1363,11 @@ class WebGLRenderer {
 
 			const currentRenderTarget = _this.getRenderTarget();
 			_this.setRenderTarget( _transmissionRenderTarget );
+
+			_this.getClearColor( _currentClearColor );
+			_currentClearAlpha = _this.getClearAlpha();
+			if ( _currentClearAlpha < 1 ) _this.setClearColor( 0x7f7f7f, 0.8 );
+
 			_this.clear();
 
 			// Turn off the features which can affect the frag color for opaque objects pass.
@@ -1408,6 +1417,8 @@ class WebGLRenderer {
 			}
 
 			_this.setRenderTarget( currentRenderTarget );
+
+			_this.setClearColor( _currentClearColor, _currentClearAlpha );
 
 			_this.toneMapping = currentToneMapping;
 

--- a/src/renderers/shaders/ShaderChunk/output_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/output_fragment.glsl.js
@@ -5,7 +5,7 @@ diffuseColor.a = 1.0;
 
 // https://github.com/mrdoob/three.js/pull/22425
 #ifdef USE_TRANSMISSION
-diffuseColor.a *= material.transmissionAlpha + 0.1;
+	diffuseColor.a *= material.transmissionAlpha;
 #endif
 
 gl_FragColor = vec4( outgoingLight, diffuseColor.a );


### PR DESCRIPTION
Follow-on to #25881.

Transmission, as implemented in three.js, requires either opaque scene objects, a skybox, or an opaque scene background to serve as a source of light.

Light is transmitted and attenuated from behind the model towards the camera. If there is no light, there is no color.

Consequently, the rendering will be incorrect if the background is transparent. It will also be incorrect even if there is a CSS background, since the CSS background is not accessible to the renderer.

This workaround ensures a background is present during the transmission calculation to serve as a source of light.
