### PR TITLE
WebGPURenderer: Static adapter for `hasFeature()`

### DIFF
--- a/examples/jsm/renderers/webgpu/WebGPURenderer.js
+++ b/examples/jsm/renderers/webgpu/WebGPURenderer.js
@@ -16,6 +16,14 @@ import WebGPUNodes from './nodes/WebGPUNodes.js';
 import WebGPUUtils from './WebGPUUtils.js';
 import { Frustum, Matrix4, Vector3, Color, SRGBColorSpace, NoToneMapping, DepthFormat } from 'three';
 
+let staticAdapter = null;
+
+if ( navigator.gpu !== undefined ) {
+
+	staticAdapter = await navigator.gpu.requestAdapter();
+
+}
+
 console.info( 'THREE.WebGPURenderer: Modified Matrix4.makePerspective() and Matrix4.makeOrtographic() to work with WebGPU, see https://github.com/mrdoob/three.js/issues/20276.' );
 
 Matrix4.prototype.makePerspective = function ( left, right, top, bottom, near, far ) {
@@ -762,11 +770,7 @@ class WebGPURenderer {
 
 	hasFeature( name ) {
 
-		if ( this._initialized === false ) {
-
-			throw new Error( 'THREE.WebGPURenderer: Renderer must be initialized before testing features.' );
-
-		}
+		const adapter = this._adapter || staticAdapter;
 
 		//
 
@@ -780,7 +784,7 @@ class WebGPURenderer {
 
 		//
 
-		return this._adapter.features.has( name );
+		return adapter.features.has( name );
 
 	}
 

--- a/examples/webgpu_loader_gltf_compressed.html
+++ b/examples/webgpu_loader_gltf_compressed.html
@@ -78,8 +78,6 @@
 				controls.maxDistance = 6;
 				controls.update();
 
-				await renderer.init();
-
 				const ktx2Loader = new KTX2Loader()
 					.setTranscoderPath( 'jsm/libs/basis/' )
 					.detectSupport( renderer );


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/25878, https://github.com/mrdoob/three.js/pull/25964#issuecomment-1529429434

**Description**

I think it would be the simplest solution, moving `hasFeature()` to `async` needs to make modifications to the already existing examples for WebGL too. Using a static adapter, we can remove the `init()` external call and keep the examples the same in both renderers.

/cc @mrdoob @Mugen87 