### PR TITLE
USDZExporter: add MaterialBindingAPI schema, fix primvars:st data type, add colorspace for normal map

### DIFF
--- a/examples/jsm/exporters/USDZExporter.js
+++ b/examples/jsm/exporters/USDZExporter.js
@@ -255,6 +255,7 @@ function buildXform( object, geometry, material ) {
 
 	return `def Xform "${ name }" (
     prepend references = @./geometries/Geometry_${ geometry.id }.usda@</Geometry>
+    prepend apiSchemas = ["MaterialBindingAPI"]
 )
 {
     matrix4d xformOp:transform = ${ transform }
@@ -415,7 +416,7 @@ function buildPrimvars( attributes, count ) {
 		if ( attribute !== undefined ) {
 
 			string += `
-		float2[] primvars:st${ id } = [${ buildVector2Array( attribute, count )}] (
+		texCoord2f[] primvars:st${ id } = [${ buildVector2Array( attribute, count )}] (
 			interpolation = "vertex"
 		)`;
 
@@ -467,6 +468,10 @@ function buildMaterial( material, textures ) {
 
 		const uv = texture.channel > 0 ? 'st' + texture.channel : 'st';
 
+		const rawTextureExtra = `(
+			colorSpace = "Raw"
+		)`;
+
 		return `
 		def Shader "PrimvarReader_${ mapType }"
 		{
@@ -488,7 +493,7 @@ function buildMaterial( material, textures ) {
         def Shader "Texture_${ texture.id }_${ mapType }"
         {
             uniform token info:id = "UsdUVTexture"
-            asset inputs:file = @textures/Texture_${ id }.${ isRGBA ? 'png' : 'jpg' }@
+            asset inputs:file = @textures/Texture_${ id }.${ isRGBA ? 'png' : 'jpg' }@ ${mapType === 'normal' ? rawTextureExtra : ''}
 			float2 inputs:st.connect = </Materials/Material_${ material.id }/Transform2d_${ mapType }.outputs:result>
             token inputs:wrapS = "repeat"
             token inputs:wrapT = "repeat"


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/25996

**Description**

This PR fixes UV2 for AR QuickLook (needs to be texCoord2f[] instead of float2[]), and future proofs the exporter with the MaterialBindingAPI schema, which will be required starting with USD 23.08.
To quote,
> 23.08 will be the drop-dead for MaterialBindingAPI.  non-compliant scenes will no longer render properly in 23.08

It also adds `colorSpace = "Raw"` for the normal map. QuickLook doesn't care but other viewers do.

There's more fixes needed - follow-up PR :)

*This contribution is funded by [Needle](https://needle.tools)*
