### PR TITLE
PLYLoader: Add support for files with face color definitions.

### DIFF
--- a/examples/jsm/loaders/PLYLoader.js
+++ b/examples/jsm/loaders/PLYLoader.js
@@ -408,8 +408,40 @@ class PLYLoader extends Loader {
 			}
 
 			if ( buffer.colors.length > 0 ) {
+				if ( buffer.colors.length == buffer.vertices.length  ){
+					geometry.setAttribute( 'color', new Float32BufferAttribute( buffer.colors, 3 ) );
+				}else{
+					const numVertices =  buffer.vertices.length;
+					const vertexColors = new Float32BufferAttribute(new Float32Array(numVertices * 3), 3);
+					vertexColors.needsUpdate = true;
 
-				geometry.setAttribute( 'color', new Float32BufferAttribute( buffer.colors, 3 ) );
+
+
+					// aversing the triangle surface, 
+					// copying each vertex color to the corresponding index position, 
+					// and copying each vertex color to the corresponding index position
+					for (let i = 0, il = geometry.index.count; i < il; i += 3) {
+						const a = geometry.index.array[i];
+						const b = geometry.index.array[i + 1];
+						const c = geometry.index.array[i + 2];
+
+
+						const faceColor = new Color();
+						faceColor.fromArray(buffer.colors, i);
+
+
+
+						vertexColors.setXYZ(a, faceColor.r, faceColor.g, faceColor.b);
+						vertexColors.setXYZ(b, faceColor.r, faceColor.g, faceColor.b);
+						vertexColors.setXYZ(c, faceColor.r, faceColor.g, faceColor.b);
+
+
+					}
+					geometry.setAttribute('color', vertexColors);
+					geometry.setAttribute('FaceColor',  new Float32BufferAttribute( buffer.colors, 3 ) );
+				}
+
+
 
 			}
 
@@ -488,6 +520,18 @@ class PLYLoader extends Loader {
 
 				const vertex_indices = element.vertex_indices || element.vertex_index; // issue #9338
 				const texcoord = element.texcoord;
+				
+				//  save face color attributes
+				if ( cacheEntry.attrR !== null && cacheEntry.attrG !== null && cacheEntry.attrB !== null ) {
+
+					_color.setRGB(
+						element[ cacheEntry.attrR ] / 255.0,
+						element[ cacheEntry.attrG ] / 255.0,
+						element[ cacheEntry.attrB ] / 255.0
+					).convertSRGBToLinear();
+					buffer.colors.push( _color.r, _color.g, _color.b );
+
+				}
 
 				if ( vertex_indices.length === 3 ) {
 

--- a/examples/jsm/loaders/PLYLoader.js
+++ b/examples/jsm/loaders/PLYLoader.js
@@ -287,7 +287,7 @@ class PLYLoader extends Loader {
 			  uvs: [],
 			  faceVertexUvs: [],
 			  colors: [],
-			  faceVertexColors: [],// save face color data in a new data structure
+			  faceVertexColors: []
 			};
 
 			for ( const customProperty of Object.keys( scope.customPropertyMapping ) ) {
@@ -416,6 +416,7 @@ class PLYLoader extends Loader {
 				if ( buffer.faceVertexColors.length > 0 ) geometry.setAttribute( 'color', new Float32BufferAttribute( buffer.faceVertexColors, 3 ) );
 
 			}
+
 			// custom buffer data
 
 			for ( const customProperty of Object.keys( scope.customPropertyMapping ) ) {
@@ -484,20 +485,6 @@ class PLYLoader extends Loader {
 
 				const vertex_indices = element.vertex_indices || element.vertex_index; // issue #9338
 				const texcoord = element.texcoord;
-				
-				//  save face color attributes
-				if ( cacheEntry.attrR !== null && cacheEntry.attrG !== null && cacheEntry.attrB !== null ) {
-
-					_color.setRGB(
-						element[ cacheEntry.attrR ] / 255.0,
-						element[ cacheEntry.attrG ] / 255.0,
-						element[ cacheEntry.attrB ] / 255.0
-					).convertSRGBToLinear();
-					buffer.faceVertexColors.push( _color.r, _color.g, _color.b );
-					buffer.faceVertexColors.push( _color.r, _color.g, _color.b );
-					buffer.faceVertexColors.push( _color.r, _color.g, _color.b );
-
-				}
 
 				if ( vertex_indices.length === 3 ) {
 
@@ -515,6 +502,21 @@ class PLYLoader extends Loader {
 
 					buffer.indices.push( vertex_indices[ 0 ], vertex_indices[ 1 ], vertex_indices[ 3 ] );
 					buffer.indices.push( vertex_indices[ 1 ], vertex_indices[ 2 ], vertex_indices[ 3 ] );
+
+				}
+
+				// face colors
+
+				if ( cacheEntry.attrR !== null && cacheEntry.attrG !== null && cacheEntry.attrB !== null ) {
+
+					_color.setRGB(
+						element[ cacheEntry.attrR ] / 255.0,
+						element[ cacheEntry.attrG ] / 255.0,
+						element[ cacheEntry.attrB ] / 255.0
+					).convertSRGBToLinear();
+					buffer.faceVertexColors.push( _color.r, _color.g, _color.b );
+					buffer.faceVertexColors.push( _color.r, _color.g, _color.b );
+					buffer.faceVertexColors.push( _color.r, _color.g, _color.b );
 
 				}
 

--- a/examples/jsm/loaders/PLYLoader.js
+++ b/examples/jsm/loaders/PLYLoader.js
@@ -287,6 +287,7 @@ class PLYLoader extends Loader {
 			  uvs: [],
 			  faceVertexUvs: [],
 			  colors: [],
+			  faceVertexColors: [],// save face color data in a new data structure
 			};
 
 			for ( const customProperty of Object.keys( scope.customPropertyMapping ) ) {
@@ -407,51 +408,14 @@ class PLYLoader extends Loader {
 
 			}
 
-			if ( buffer.colors.length > 0 ) {
-				if ( buffer.colors.length == buffer.vertices.length  ){
-					geometry.setAttribute( 'color', new Float32BufferAttribute( buffer.colors, 3 ) );
-				}else{
-					const numVertices =  buffer.vertices.length;
-					const vertexColors = new Float32BufferAttribute(new Float32Array(numVertices * 3), 3);
-					vertexColors.needsUpdate = true;
-
-
-
-					// aversing the triangle surface, 
-					// copying each vertex color to the corresponding index position, 
-					// and copying each vertex color to the corresponding index position
-					for (let i = 0, il = geometry.index.count; i < il; i += 3) {
-						const a = geometry.index.array[i];
-						const b = geometry.index.array[i + 1];
-						const c = geometry.index.array[i + 2];
-
-
-						const faceColor = new Color();
-						faceColor.fromArray(buffer.colors, i);
-
-
-
-						vertexColors.setXYZ(a, faceColor.r, faceColor.g, faceColor.b);
-						vertexColors.setXYZ(b, faceColor.r, faceColor.g, faceColor.b);
-						vertexColors.setXYZ(c, faceColor.r, faceColor.g, faceColor.b);
-
-
-					}
-					geometry.setAttribute('color', vertexColors);
-					geometry.setAttribute('FaceColor',  new Float32BufferAttribute( buffer.colors, 3 ) );
-				}
-
-
-
-			}
-
-			if ( buffer.faceVertexUvs.length > 0 ) {
+			if ( buffer.faceVertexUvs.length > 0 || buffer.faceVertexColors.length > 0 ) {
 
 				geometry = geometry.toNonIndexed();
-				geometry.setAttribute( 'uv', new Float32BufferAttribute( buffer.faceVertexUvs, 2 ) );
+
+				if ( buffer.faceVertexUvs.length > 0 ) geometry.setAttribute( 'uv', new Float32BufferAttribute( buffer.faceVertexUvs, 2 ) );
+				if ( buffer.faceVertexColors.length > 0 ) geometry.setAttribute( 'color', new Float32BufferAttribute( buffer.faceVertexColors, 3 ) );
 
 			}
-
 			// custom buffer data
 
 			for ( const customProperty of Object.keys( scope.customPropertyMapping ) ) {
@@ -529,7 +493,9 @@ class PLYLoader extends Loader {
 						element[ cacheEntry.attrG ] / 255.0,
 						element[ cacheEntry.attrB ] / 255.0
 					).convertSRGBToLinear();
-					buffer.colors.push( _color.r, _color.g, _color.b );
+					buffer.faceVertexColors.push( _color.r, _color.g, _color.b );
+					buffer.faceVertexColors.push( _color.r, _color.g, _color.b );
+					buffer.faceVertexColors.push( _color.r, _color.g, _color.b );
 
 				}
 


### PR DESCRIPTION
Related issue: Cannot render mesh with face color

**Description**

automatically convert face color to vertex color

**Call code**
```
const loader = new PLYLoader();
loader.load( './data/color.ply', function ( geometry ) {
     const material = new THREE.MeshStandardMaterial( {flatShading: true,vertexColors:true} );
     const mesh = new THREE.Mesh( geometry, material );
     ........
     ]
```

**show**
![image](https://user-images.githubusercontent.com/31204461/236735681-ca4522ae-c4e9-4b2e-a8ef-651b459709d8.png)


