### PR TITLE
Matrix3/4: Constructor has now parameters.

### DIFF
--- a/docs/api/en/math/Matrix3.html
+++ b/docs/api/en/math/Matrix3.html
@@ -21,7 +21,7 @@ const m = new Matrix3();
 
 		<h2>A Note on Row-Major and Column-Major Ordering</h2>
 		<p>
-			The [page:set]() method takes arguments in
+			The constructor and [page:set]() method take arguments in
 			[link:https://en.wikipedia.org/wiki/Row-_and_column-major_order#Column-major_order row-major] 
 			order, while internally they are stored in the [page:.elements elements] 
 			array in column-major order.<br /><br />
@@ -49,10 +49,12 @@ m.elements = [ 11, 21, 31,
 
 		<h2>Constructor</h2>
 
-		<h3>[name]()</h3>
+		<h3>[name]( [param:Number n11], [param:Number n12], [param:Number n13],
+			[param:Number n21], [param:Number n22], [param:Number n22],
+			[param:Number n31], [param:Number n32], [param:Number n33] )</h3>
 		<p>
-			Creates and initializes the [name] to the 3x3
-			[link:https://en.wikipedia.org/wiki/Identity_matrix identity matrix].
+			Creates a 3x3 matrix with the given arguments in row-major order. If no arguments are provided, the constructor initializes
+			the [name] to the 3x3 [link:https://en.wikipedia.org/wiki/Identity_matrix identity matrix].
 		</p>
 
 		<h2>Properties</h2>

--- a/docs/api/en/math/Matrix4.html
+++ b/docs/api/en/math/Matrix4.html
@@ -62,7 +62,7 @@
 
 		<h2>A Note on Row-Major and Column-Major Ordering</h2>
 		<p>
-			The [page:set]() method takes arguments in
+			The constructor and [page:set]() method take arguments in
 			[link:https://en.wikipedia.org/wiki/Row-_and_column-major_order#Column-major_order row-major] 
 			order, while internally they are stored in the [page:.elements elements] array in column-major order.<br /><br />
 
@@ -117,11 +117,14 @@ m.elements = [ 11, 21, 31, 41,
 
 		<h2>Constructor</h2>
 
-		<h3>[name]()</h3>
+		<h3>[name]( [param:Number n11], [param:Number n12], [param:Number n13], [param:Number n14],
+			[param:Number n21], [param:Number n22], [param:Number n23], [param:Number n24],
+			[param:Number n31], [param:Number n32], [param:Number n33], [param:Number n34],
+			[param:Number n41], [param:Number n42], [param:Number n43], [param:Number n44] )</h3>
 
 		<p>
-			Creates and initializes the [name] to the 4x4
-			[link:https://en.wikipedia.org/wiki/Identity_matrix identity matrix].
+			Creates a 4x4 matrix with the given arguments in row-major order. If no arguments are provided, the constructor initializes 
+			the [name] to the 4x4 [link:https://en.wikipedia.org/wiki/Identity_matrix identity matrix].
 		</p>
 
 		<h2>Properties</h2>

--- a/docs/api/it/math/Matrix3.html
+++ b/docs/api/it/math/Matrix3.html
@@ -46,10 +46,12 @@ m.elements = [ 11, 21, 31,
 		<h2>Costruttore</h2>
 
 
-		<h3>[name]()</h3>
+		<h3>[name]( [param:Number n11], [param:Number n12], [param:Number n13],
+			[param:Number n21], [param:Number n22], [param:Number n22],
+			[param:Number n31], [param:Number n32], [param:Number n33] )</h3>
 		<p>
-			Crea e inizializza [name] nella 
-			[link:https://en.wikipedia.org/wiki/Identity_matrix matrice] identità 3x3.
+			Creates a 3x3 matrix with the given arguments in row-major. If no arguments are provided, the constructor initializes
+			the [name] to the 3x3 [link:https://en.wikipedia.org/wiki/Identity_matrix identity matrix].
 		</p>
 
 		<h2>Proprietà</h2>

--- a/docs/api/it/math/Matrix4.html
+++ b/docs/api/it/math/Matrix4.html
@@ -105,11 +105,15 @@ m.elements = [ 11, 21, 31, 41,
 		<h2>Costruttore</h2>
 
 
-		<h3>[name]()</h3>
+		<h3>[name]( [param:Number n11], [param:Number n12], [param:Number n13], [param:Number n14],
+			[param:Number n21], [param:Number n22], [param:Number n23], [param:Number n24],
+			[param:Number n31], [param:Number n32], [param:Number n33], [param:Number n34],
+			[param:Number n41], [param:Number n42], [param:Number n43], [param:Number n44] )</h3>
 
 		<p>
-			Crea e inizializza [name] nella [link:https://en.wikipedia.org/wiki/Identity_matrix matrice] identità 4x4.
-	</p>
+			Creates a 4x4 matrix with the given arguments in row-major order. If no arguments are provided, the constructor initializes 
+			the [name] to the 4x4 [link:https://en.wikipedia.org/wiki/Identity_matrix identity matrix].
+		</p>
 
 		<h2>Proprietà</h2>
 

--- a/docs/api/zh/math/Matrix3.html
+++ b/docs/api/zh/math/Matrix3.html
@@ -43,11 +43,13 @@ m.elements = [ 11, 21, 31,
 		<h2>Constructor</h2>
 
 
-		<h3>[name]()</h3>
+		<h3>[name]( [param:Number n11], [param:Number n12], [param:Number n13],
+			[param:Number n21], [param:Number n22], [param:Number n22],
+			[param:Number n31], [param:Number n32], [param:Number n33] )</h3>
 		<p>
-		创建并初始化一个3X3的单位矩阵[link:https://en.wikipedia.org/wiki/Identity_matrix identity matrix].
+			Creates a 3x3 matrix with the given arguments in row-major order. If no arguments are provided, the constructor initializes
+			the [name] to the 3x3 [link:https://en.wikipedia.org/wiki/Identity_matrix identity matrix].
 		</p>
-
 
 
 		<h2>属性（Properties）</h2>

--- a/docs/api/zh/math/Matrix4.html
+++ b/docs/api/zh/math/Matrix4.html
@@ -95,11 +95,15 @@ m.elements = [ 11, 21, 31, 41,
 		<h2>构造器（Constructor）</h2>
 
 
-		<h3>[name]()</h3>
+		<h3>[name]( [param:Number n11], [param:Number n12], [param:Number n13], [param:Number n14],
+			[param:Number n21], [param:Number n22], [param:Number n23], [param:Number n24],
+			[param:Number n31], [param:Number n32], [param:Number n33], [param:Number n34],
+			[param:Number n41], [param:Number n42], [param:Number n43], [param:Number n44] )</h3>
 
 		<p>
-			创建并初始化一个4X4的单位矩阵[link:https://en.wikipedia.org/wiki/Identity_matrix identity matrix].
-	</p>
+			Creates a 4x4 matrix with the given arguments in row-major order. If no arguments are provided, the constructor initializes 
+			the [name] to the 4x4 [link:https://en.wikipedia.org/wiki/Identity_matrix identity matrix].
+		</p>
 
 		<h2>属性（Properties）</h2>
 

--- a/src/math/Matrix3.js
+++ b/src/math/Matrix3.js
@@ -1,6 +1,6 @@
 class Matrix3 {
 
-	constructor() {
+	constructor( n11, n12, n13, n21, n22, n23, n31, n32, n33 ) {
 
 		Matrix3.prototype.isMatrix3 = true;
 
@@ -11,6 +11,12 @@ class Matrix3 {
 			0, 0, 1
 
 		];
+
+		if ( n11 !== undefined ) {
+
+			this.set( n11, n12, n13, n21, n22, n23, n31, n32, n33 );
+
+		}
 
 	}
 

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -2,7 +2,7 @@ import { Vector3 } from './Vector3.js';
 
 class Matrix4 {
 
-	constructor() {
+	constructor( n11, n12, n13, n14, n21, n22, n23, n24, n31, n32, n33, n34, n41, n42, n43, n44 ) {
 
 		Matrix4.prototype.isMatrix4 = true;
 
@@ -14,6 +14,12 @@ class Matrix4 {
 			0, 0, 0, 1
 
 		];
+
+		if ( n11 !== undefined ) {
+
+			this.set( n11, n12, n13, n14, n21, n22, n23, n24, n31, n32, n33, n34, n41, n42, n43, n44 );
+
+		}
 
 	}
 

--- a/test/unit/src/math/Matrix3.tests.js
+++ b/test/unit/src/math/Matrix3.tests.js
@@ -69,6 +69,19 @@ export default QUnit.module( 'Maths', () => {
 
 			assert.ok( ! matrixEquals3( a, b ), 'Passed!' );
 
+			const c = new Matrix3( 0, 1, 2, 3, 4, 5, 6, 7, 8 );
+			assert.ok( c.elements[ 0 ] == 0 );
+			assert.ok( c.elements[ 1 ] == 3 );
+			assert.ok( c.elements[ 2 ] == 6 );
+			assert.ok( c.elements[ 3 ] == 1 );
+			assert.ok( c.elements[ 4 ] == 4 );
+			assert.ok( c.elements[ 5 ] == 7 );
+			assert.ok( c.elements[ 6 ] == 2 );
+			assert.ok( c.elements[ 7 ] == 5 );
+			assert.ok( c.elements[ 8 ] == 8 );
+
+			assert.ok( ! matrixEquals3( a, c ), 'Passed!' );
+
 		} );
 
 		// PUBLIC STUFF

--- a/test/unit/src/math/Matrix4.tests.js
+++ b/test/unit/src/math/Matrix4.tests.js
@@ -72,6 +72,26 @@ export default QUnit.module( 'Maths', () => {
 
 			assert.ok( ! matrixEquals4( a, b ), 'Passed!' );
 
+			const c = new Matrix4( 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 );
+			assert.ok( c.elements[ 0 ] == 0 );
+			assert.ok( c.elements[ 1 ] == 4 );
+			assert.ok( c.elements[ 2 ] == 8 );
+			assert.ok( c.elements[ 3 ] == 12 );
+			assert.ok( c.elements[ 4 ] == 1 );
+			assert.ok( c.elements[ 5 ] == 5 );
+			assert.ok( c.elements[ 6 ] == 9 );
+			assert.ok( c.elements[ 7 ] == 13 );
+			assert.ok( c.elements[ 8 ] == 2 );
+			assert.ok( c.elements[ 9 ] == 6 );
+			assert.ok( c.elements[ 10 ] == 10 );
+			assert.ok( c.elements[ 11 ] == 14 );
+			assert.ok( c.elements[ 12 ] == 3 );
+			assert.ok( c.elements[ 13 ] == 7 );
+			assert.ok( c.elements[ 14 ] == 11 );
+			assert.ok( c.elements[ 15 ] == 15 );
+
+			assert.ok( ! matrixEquals4( a, c ), 'Passed!' );
+
 		} );
 
 		// PUBLIC STUFF


### PR DESCRIPTION
Fixed: #23634

**Description**

The constructors of `Matrix3` and `Matrix4` now have parameters representing the matrix elements in row-major order. This allows to define matrices similar to the `set()` method. 

The motivation behind this change is to make the matrix constructors more consistent to other math classes, see https://github.com/mrdoob/three.js/issues/23634#issuecomment-1537964042.
