### PR TITLE
WebGPURenderer: Added BufferAttributeNode (cleanup)

### DIFF
--- a/examples/webgpu_cubemap_adjustments.html
+++ b/examples/webgpu_cubemap_adjustments.html
@@ -134,14 +134,6 @@
 
 					scene.add( gltf.scene );
 
-
-					setTimeout( () => {
-
-						gltf.scene.children[0].material.dispose();
-						gltf.scene.children[0].geometry.dispose();
-
-					}, 2000 )
-
 				} );
 
 				const sphereGeometry = new THREE.SphereGeometry( .5, 64, 32 );


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/26016

**Description**

I forgot to remove the test in the example.
