### PR TITLE
USDZExporter: Improve UsdTransform2d

### DIFF
--- a/examples/jsm/exporters/USDZExporter.js
+++ b/examples/jsm/exporters/USDZExporter.js
@@ -9,7 +9,8 @@ class USDZExporter {
 			ar: {
 				anchoring: { type: 'plane' },
 				planeAnchoring: { alignment: 'horizontal' }
-			}
+			},
+			quickLookCompatible: false,
 		}, options );
 
 		const files = {};
@@ -68,7 +69,7 @@ class USDZExporter {
 
 		output += buildSceneEnd();
 
-		output += buildMaterials( materials, textures );
+		output += buildMaterials( materials, textures, options.quickLookCompatible );
 
 		files[ modelFileName ] = fflate.strToU8( output );
 		output = null;
@@ -404,7 +405,7 @@ function buildPrimvars( attributes, count ) {
 
 // Materials
 
-function buildMaterials( materials, textures ) {
+function buildMaterials( materials, textures, quickLookCompatible = false ) {
 
 	const array = [];
 
@@ -412,7 +413,7 @@ function buildMaterials( materials, textures ) {
 
 		const material = materials[ uuid ];
 
-		array.push( buildMaterial( material, textures ) );
+		array.push( buildMaterial( material, textures, quickLookCompatible ) );
 
 	}
 
@@ -425,7 +426,7 @@ ${ array.join( '' ) }
 
 }
 
-function buildMaterial( material, textures ) {
+function buildMaterial( material, textures, quickLookCompatible = false ) {
 
 	// https://graphics.pixar.com/usd/docs/UsdPreviewSurface-Proposal.html
 
@@ -458,10 +459,9 @@ function buildMaterial( material, textures ) {
 		// texture coordinates start in the opposite corner, need to correct
 		offset.y = 1 - offset.y - repeat.y;
 
-		// turns out QuickLook is buggy and interprets texture repeat inverted.
+		// turns out QuickLook is buggy and interprets texture repeat inverted/applies operations in a different order.
 		// Apple Feedback: 	FB10036297 and FB11442287
-		const exportForQuickLook = false;
-		if ( exportForQuickLook ) {
+		if ( quickLookCompatible ) {
 
 			// This is NOT correct yet in QuickLook, but comes close for a range of models.
 			// It becomes more incorrect the bigger the offset is


### PR DESCRIPTION
This PR fixes UsdTransform2d rotation for usdview and other USD-spec-compliant viewers that support the UsdTransform2d schema.
Notably, QuickLook does things differently. There is currently a const in the code to switch between QuickLook behaviour (which is not 100% correct yet, but comes close) and proper behaviour. Unfortunately there doesn't seem to be a way to make both happy until Apple fixes their bugs.

I believe we want to default to the QuickLook behaviour (and hopefully get that fixed) since e.g. model-viewer's main target is conversion to that. 

Here is a better test file - the glTF sample model is not sufficiently accurate to show the QuickLook errors:
[BetterTextureTransformTests.zip](https://github.com/mrdoob/three.js/files/11429036/BetterTextureTransformTests.zip)

| Viewer | exportForQuickLook=true | exportForQuickLook=false |
| - | - | - |
| three.js (ground truth) | ![20230509-104237_chrome](https://user-images.githubusercontent.com/2693840/237044891-33511c64-cdfc-4966-9932-7834869e2aab.png) | ![20230509-104237_chrome](https://user-images.githubusercontent.com/2693840/237044891-33511c64-cdfc-4966-9932-7834869e2aab.png) |
| usdview | ![20230509-104357_python](https://user-images.githubusercontent.com/2693840/237045056-09b9c751-0a8f-4171-bd03-fa2a871de790.png) | ![20230509-104438_python](https://user-images.githubusercontent.com/2693840/237045088-6b790792-3af8-4f9e-9245-915dcfb1c09d.png) |
| QuickLook | ![20230509-104844_chrome](https://user-images.githubusercontent.com/2693840/237045179-9a7e9cf5-7f01-476d-bcc0-1d2f62018dfd.png) | ![20230509-104859_chrome](https://user-images.githubusercontent.com/2693840/237045238-dae26d2a-3704-4af6-a79c-11ff8bc38e23.png) |

*This contribution is funded by [Needle](https://needle.tools)*
