### PR TITLE
Bump metadata.version from toJSON functions to 4.6.

### DIFF
--- a/examples/jsm/nodes/core/Node.js
+++ b/examples/jsm/nodes/core/Node.js
@@ -374,7 +374,7 @@ class Node {
 				type,
 				meta,
 				metadata: {
-					version: 4.5,
+					version: 4.6,
 					type: 'Node',
 					generator: 'Node.toJSON'
 				}

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -855,7 +855,7 @@ class BufferGeometry extends EventDispatcher {
 
 		const data = {
 			metadata: {
-				version: 4.5,
+				version: 4.6,
 				type: 'BufferGeometry',
 				generator: 'BufferGeometry.toJSON'
 			}

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -693,7 +693,7 @@ class Object3D extends EventDispatcher {
 			};
 
 			output.metadata = {
-				version: 4.5,
+				version: 4.6,
 				type: 'Object',
 				generator: 'Object3D.toJSON'
 			};

--- a/src/extras/core/Curve.js
+++ b/src/extras/core/Curve.js
@@ -389,7 +389,7 @@ class Curve {
 
 		const data = {
 			metadata: {
-				version: 4.5,
+				version: 4.6,
 				type: 'Curve',
 				generator: 'Curve.toJSON'
 			}

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -165,7 +165,7 @@ class Material extends EventDispatcher {
 
 		const data = {
 			metadata: {
-				version: 4.5,
+				version: 4.6,
 				type: 'Material',
 				generator: 'Material.toJSON'
 			}

--- a/src/objects/Skeleton.js
+++ b/src/objects/Skeleton.js
@@ -249,7 +249,7 @@ class Skeleton {
 
 		const data = {
 			metadata: {
-				version: 4.5,
+				version: 4.6,
 				type: 'Skeleton',
 				generator: 'Skeleton.toJSON'
 			},

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -169,7 +169,7 @@ class Texture extends EventDispatcher {
 		const output = {
 
 			metadata: {
-				version: 4.5,
+				version: 4.6,
 				type: 'Texture',
 				generator: 'Texture.toJSON'
 			},

--- a/test/unit/src/core/BufferGeometry.tests.js
+++ b/test/unit/src/core/BufferGeometry.tests.js
@@ -646,7 +646,7 @@ export default QUnit.module( 'Core', () => {
 			let j = a.toJSON();
 			const gold = {
 				'metadata': {
-					'version': 4.5,
+					'version': 4.6,
 					'type': 'BufferGeometry',
 					'generator': 'BufferGeometry.toJSON'
 				},

--- a/test/unit/src/core/Object3D.tests.js
+++ b/test/unit/src/core/Object3D.tests.js
@@ -1270,7 +1270,7 @@ export default QUnit.module( 'Core', () => {
 
 			const gold = {
 				'metadata': {
-					'version': 4.5,
+					'version': 4.6,
 					'type': 'Object',
 					'generator': 'Object3D.toJSON'
 				},

--- a/test/unit/utils/qunit-utils.js
+++ b/test/unit/utils/qunit-utils.js
@@ -121,7 +121,7 @@ function getDifferingProp( geometryA, geometryB ) {
 // Compare json file with its source geometry.
 function checkGeometryJsonWriting( geom, json ) {
 
-	QUnit.assert.equal( json.metadata.version, '4.5', 'check metadata version' );
+	QUnit.assert.equal( json.metadata.version, '4.6', 'check metadata version' );
 	QUnit.assert.equalKey( geom, json, 'type' );
 	QUnit.assert.equalKey( geom, json, 'uuid' );
 	QUnit.assert.equal( json.id, undefined, 'should not persist id' );
@@ -270,7 +270,7 @@ function checkLightCopyClone( assert, light ) {
 // Compare json file with its source Light.
 function checkLightJsonWriting( assert, light, json ) {
 
-	assert.equal( json.metadata.version, '4.5', 'check metadata version' );
+	assert.equal( json.metadata.version, '4.6', 'check metadata version' );
 
 	const object = json.object;
 	assert.equalKey( light, object, 'type' );


### PR DESCRIPTION
Fixed: #25989

**Description**

Update the version number in toJSON functions to 4.6, to make it possible to determine old and new files, after changes in Color Management and how colors are serialized.
