### PR TITLE
FramebufferTexture: Remove `format` parameter.

### DIFF
--- a/docs/api/en/textures/FramebufferTexture.html
+++ b/docs/api/en/textures/FramebufferTexture.html
@@ -17,23 +17,23 @@
 		</p>
 
 		<code>
-			const pixelRatio = window.devicePixelRatio;
-			const textureSize = 128 * pixelRatio;
+const pixelRatio = window.devicePixelRatio;
+const textureSize = 128 * pixelRatio;
 
-			// instantiate a framebuffer texture
-			const frameTexture = new FramebufferTexture( textureSize, textureSize, RGBAFormat );
-	
-			// calculate start position for copying part of the frame data
-			const vector = new Vector2();
-			vector.x = ( window.innerWidth * pixelRatio / 2 ) - ( textureSize / 2 );
-			vector.y = ( window.innerHeight * pixelRatio / 2 ) - ( textureSize / 2 );
+// instantiate a framebuffer texture
+const frameTexture = new FramebufferTexture( textureSize, textureSize );
 
-			// render the scene
-			renderer.clear();
-			renderer.render( scene, camera );
+// calculate start position for copying part of the frame data
+const vector = new Vector2();
+vector.x = ( window.innerWidth * pixelRatio / 2 ) - ( textureSize / 2 );
+vector.y = ( window.innerHeight * pixelRatio / 2 ) - ( textureSize / 2 );
 
-			// copy part of the rendered frame into the framebuffer texture
-			renderer.copyFramebufferToTexture( vector, frameTexture );
+// render the scene
+renderer.clear();
+renderer.render( scene, camera );
+
+// copy part of the rendered frame into the framebuffer texture
+renderer.copyFramebufferToTexture( vector, frameTexture );
 		</code>
 
 		<h2>Examples</h2>
@@ -43,15 +43,12 @@
 		<h2>Constructor</h2>
 
 		<h3>
-			[name]( [param:Number width], [param:Number height], [param:Constant format] )
+			[name]( [param:Number width], [param:Number height] )
 		</h3>
 		<p>
 			[page:Number width] -- The width of the texture.<br />
 
-			[page:Number height] -- The height of the texture.<br />
-
-			[page:Constant format] -- The format used in the texture. See
-			[page:Textures format constants] for other choices.<br />
+			[page:Number height] -- The height of the texture.
 		</p>
 
 		<h2>Properties</h2>

--- a/docs/api/it/textures/FramebufferTexture.html
+++ b/docs/api/it/textures/FramebufferTexture.html
@@ -16,16 +16,12 @@
 		</p>
 
 		<h2>Costruttore</h2>
-		<h3>[name]( [param:Number width], [param:Number height], [param:Constant format] )</h3>
+		<h3>[name]( [param:Number width], [param:Number height] )</h3>
 		<p>
 		[page:Number width] -- La larghezza della texture.<br />
 
-		[page:Number height] -- L'altezza della texture.<br />
-
-		[page:Constant format] -- Il formato utilizzato nella texture.
-		Vedi [page:Textures format constants] per altre scelte.<br />
+		[page:Number height] -- L'altezza della texture.
 		</p>
-
 
 		<h2>Proprietà</h2>
 

--- a/docs/api/zh/textures/FramebufferTexture.html
+++ b/docs/api/zh/textures/FramebufferTexture.html
@@ -16,14 +16,11 @@
 		</p>
 
 		<h2>Constructor</h2>
-		<h3>[name]( [param:Number width], [param:Number height], [param:Constant format] )</h3>
+		<h3>[name]( [param:Number width], [param:Number height] )</h3>
 		<p>
 		[page:Number width] -- The width of the texture.<br />
 
-		[page:Number height] -- The height of the texture.<br />
-
-		[page:Constant format] -- The format used in the texture.
-		See [page:Textures format constants] for other choices.<br />
+		[page:Number height] -- The height of the texture.
 		</p>
 
 

--- a/examples/jsm/objects/Lensflare.js
+++ b/examples/jsm/objects/Lensflare.js
@@ -11,8 +11,7 @@ import {
 	RawShaderMaterial,
 	Vector2,
 	Vector3,
-	Vector4,
-	RGBAFormat
+	Vector4
 } from 'three';
 
 class Lensflare extends Mesh {
@@ -34,8 +33,8 @@ class Lensflare extends Mesh {
 
 		// textures
 
-		const tempMap = new FramebufferTexture( 16, 16, RGBAFormat );
-		const occlusionMap = new FramebufferTexture( 16, 16, RGBAFormat );
+		const tempMap = new FramebufferTexture( 16, 16 );
+		const occlusionMap = new FramebufferTexture( 16, 16 );
 
 		// material
 

--- a/examples/webgl_framebuffer_texture.html
+++ b/examples/webgl_framebuffer_texture.html
@@ -108,9 +108,7 @@
 
 				//
 
-				texture = new THREE.FramebufferTexture( textureSize, textureSize, THREE.RGBAFormat );
-				texture.minFilter = THREE.NearestFilter;
-				texture.magFilter = THREE.NearestFilter;
+				texture = new THREE.FramebufferTexture( textureSize, textureSize );
 
 				//
 

--- a/src/textures/FramebufferTexture.js
+++ b/src/textures/FramebufferTexture.js
@@ -3,13 +3,11 @@ import { NearestFilter } from '../constants.js';
 
 class FramebufferTexture extends Texture {
 
-	constructor( width, height, format ) {
+	constructor( width, height ) {
 
 		super( { width, height } );
 
 		this.isFramebufferTexture = true;
-
-		this.format = format;
 
 		this.magFilter = NearestFilter;
 		this.minFilter = NearestFilter;


### PR DESCRIPTION
Related issue: -

**Description**

Now that the drawing buffer is always RGBA, `FramebufferTexture` does not need a `format` parameter anymore. The class can always use `RGBAFormat` which simplifies the code at a few places.
