### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
 		<div id="panel">
 
 			<div id="header">
-				<h1><div>three.js</div><a id="version" href="http://github.com/mrdoob/three.js/releases">r152</a></h1>
+				<h1><span translate="no">three.js</span> <a id="version" href="http://github.com/mrdoob/three.js/releases">r152</a></h1>
 
 				<div id="sections">
 					<a href="docs/index.html#manual/introduction/Creating-a-scene">docs</a>


### PR DESCRIPTION
hints translators keep the term 'three.js' as-is, otherwise, `スリー.js` in chrome, `3つ.js` in edge :D

h1>div is illegal by the way, use h1>span instead



