### PR TITLE
Docs: Improve `MeshSurfaceSampler` page.

### DIFF
--- a/docs/examples/en/math/MeshSurfaceSampler.html
+++ b/docs/examples/en/math/MeshSurfaceSampler.html
@@ -32,24 +32,22 @@
 			.setWeightAttribute( 'color' )
 			.build();
 
-		const sampleMesh = new THREE.InstancedMesh( sampleGeometry, sampleMaterial, 100 );
+		const mesh = new THREE.InstancedMesh( sampleGeometry, sampleMaterial, 100 );
 
-		const _position = new THREE.Vector3();
-		const _matrix = new THREE.Matrix4();
+		const position = new THREE.Vector3();
+		const matrix = new THREE.Matrix4();
 
 		// Sample randomly from the surface, creating an instance of the sample
 		// geometry at each sample point.
 		for ( let i = 0; i < 100; i ++ ) {
 
-			sampler.sample( _position );
+			sampler.sample( position );
 
-			_matrix.makeTranslation( _position.x, _position.y, _position.z );
+			matrix.makeTranslation( position.x, position.y, position.z );
 
-			mesh.setMatrixAt( i, _matrix );
+			mesh.setMatrixAt( i, matrix );
 
 		}
-
-		mesh.instanceMatrix.needsUpdate = true;
 
 		scene.add( mesh );
 		</code>


### PR DESCRIPTION
ok, so 1st `sampleMesh` is referred to as just `mesh` through the code, 2nd those underscores serve no other purpose than to make things less readable, and finally `needsUpdate = true` is not needed since it's brand new mesh.