### PR TITLE
DracoLoader: Normalise color attributes by default

### DIFF
--- a/examples/jsm/loaders/DRACOLoader.js
+++ b/examples/jsm/loaders/DRACOLoader.js
@@ -209,6 +209,8 @@ class DRACOLoader extends Loader {
 
 				this._assignVertexColorSpace( attribute, result.vertexColorSpace );
 
+				attribute.normalized = true;
+
 			}
 
 			geometry.setAttribute( name, attribute );

--- a/examples/jsm/loaders/DRACOLoader.js
+++ b/examples/jsm/loaders/DRACOLoader.js
@@ -209,7 +209,7 @@ class DRACOLoader extends Loader {
 
 				this._assignVertexColorSpace( attribute, result.vertexColorSpace );
 
-				attribute.normalized = true;
+				attribute.normalized = ( array instanceof Float32Array ) === false;
 
 			}
 


### PR DESCRIPTION
Fixes: #26035

**Description**

I would expect color attributes from the loader to default to normalised.
Set the normalized to true in the dracoLoader for color attributes.