### PR TITLE
fix: Fix leak of morph targets

### DIFF
--- a/src/renderers/webgl/WebGLGeometries.js
+++ b/src/renderers/webgl/WebGLGeometries.js
@@ -22,6 +22,18 @@ function WebGLGeometries( gl, attributes, info, bindingStates ) {
 
 		}
 
+		for ( const name in geometry.morphAttributes ) {
+
+			const array = geometry.morphAttributes[ name ];
+
+			for ( let i = 0, l = array.length; i < l; i ++ ) {
+
+				attributes.remove( array[ i ] );
+
+			}
+
+		}
+
 		geometry.removeEventListener( 'dispose', onGeometryDispose );
 
 		delete geometries[ geometry.id ];


### PR DESCRIPTION
Should resolve #26028

**Description**

Buffers of morph targets leaked even if I call `geometry.dispose()`; This PR will fix this.

Fixed by WebGLGeometries.js side, I believe this is the most appropriate way to fix this.

See: https://github.com/mrdoob/three.js/issues/26028#issuecomment-1543044296
