### PR TITLE
Matrix4: Make `makeTranslation()` accept `Vector3`.

### DIFF
--- a/docs/api/en/math/Matrix4.html
+++ b/docs/api/en/math/Matrix4.html
@@ -396,15 +396,12 @@ xz, yz, 1, 0,
 0, 0, 0, 1 </code>
 		</p>
 
+		<h3>[method:this makeTranslation]( [param:Vector3 v] )</h3>
 		<h3>
-			[method:this makeTranslation]( [param:Float x], [param:Float y], [param:Float z] )
+			[method:this makeTranslation]( [param:Float x], [param:Float y], [param:Float z] ) // optional API
 		</h3>
 		<p>
-			[page:Float x] - the amount to translate in the X axis.<br />
-			[page:Float y] - the amount to translate in the Y axis.<br />
-			[page:Float z] - the amount to translate in the Z axis.<br /><br />
-
-			Sets this matrix as a translation transform:
+			Sets this matrix as a translation transform from vector [page:Vector3 v], or numbers [page:Float x], [page:Float y] and [page:Float z]:
 			<code> 
 1, 0, 0, x, 
 0, 1, 0, y, 

--- a/docs/api/it/math/Matrix4.html
+++ b/docs/api/it/math/Matrix4.html
@@ -342,13 +342,12 @@ xz,  yz,   1,  0,
 </code>
 		</p>
 
-		<h3>[method:this makeTranslation]( [param:Float x], [param:Float y], [param:Float z] )</h3>
+		<h3>[method:this makeTranslation]( [param:Vector3 v] )</h3>
+		<h3>
+			[method:this makeTranslation]( [param:Float x], [param:Float y], [param:Float z] ) // optional API
+		</h3>
 		<p>
-			[page:Float x] - la quantità da translare sull'asse X.<br />
-			[page:Float y] - la quantità da translare sull'asse Y.<br />
-			[page:Float z] - la quantità da translare sull'asse Z.<br /><br />
-
-			Imposta questa matrice come una trasformata di traslazione:
+			Imposta questa matrice come una trasformata di traslazione dal vettore [page:Vector3 v]:
 		<code>
 1, 0, 0, x,
 0, 1, 0, y,

--- a/docs/api/zh/math/Matrix4.html
+++ b/docs/api/zh/math/Matrix4.html
@@ -320,13 +320,12 @@ x, y, 1, 0,
 </code>
 		</p>
 
-		<h3>[method:this makeTranslation]( [param:Float x], [param:Float y], [param:Float z] )</h3>
+		<h3>[method:this makeTranslation]( [param:Vector3 v] )</h3>
+		<h3>
+			[method:this makeTranslation]( [param:Float x], [param:Float y], [param:Float z] ) // optional API
+		</h3>
 		<p>
-			[page:Float x] - 在X轴上的平移量。<br />
-			[page:Float y] - 在Y轴上的平移量。<br />
-			[page:Float z] - 在Z轴上的平移量。<br /><br />
-
-		设置该矩阵为平移变换：
+		取传入参数[param:Vector3 v]中值设设置该矩阵为平移变换：
 		<code>
 1, 0, 0, x,
 0, 1, 0, y,

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -560,14 +560,29 @@ class Matrix4 {
 
 	makeTranslation( x, y, z ) {
 
-		this.set(
+		if ( x.isVector3 ) {
 
-			1, 0, 0, x,
-			0, 1, 0, y,
-			0, 0, 1, z,
-			0, 0, 0, 1
+			this.set(
 
-		);
+				1, 0, 0, x.x,
+				0, 1, 0, x.y,
+				0, 0, 1, x.z,
+				0, 0, 0, 1
+
+			);
+
+		} else {
+
+			this.set(
+
+				1, 0, 0, x,
+				0, 1, 0, y,
+				0, 0, 1, z,
+				0, 0, 0, 1
+
+			);
+
+		}
 
 		return this;
 

--- a/test/unit/src/math/Matrix4.tests.js
+++ b/test/unit/src/math/Matrix4.tests.js
@@ -588,6 +588,9 @@ export default QUnit.module( 'Maths', () => {
 			a.makeTranslation( b.x, b.y, b.z );
 			assert.ok( matrixEquals4( a, c ), 'Passed!' );
 
+			a.makeTranslation( b );
+			assert.ok( matrixEquals4( a, c ), 'Passed!' );
+
 		} );
 
 		QUnit.test( 'makeRotationX', ( assert ) => {


### PR DESCRIPTION
Fixed #26038.

As discussed with @Mugen87 

Docs might need human proof-reading (I only checked with googel translate)