### PR TITLE
fix sky shader at non-zero origins

### DIFF
--- a/examples/jsm/objects/Sky.js
+++ b/examples/jsm/objects/Sky.js
@@ -62,7 +62,7 @@ Sky.SkyShader = {
 		uniform float mieCoefficient;
 		uniform vec3 up;
 
-		varying vec3 vWorldPosition;
+		varying vec3 vPosition;
 		varying vec3 vSunDirection;
 		varying float vSunfade;
 		varying vec3 vBetaR;
@@ -104,8 +104,7 @@ Sky.SkyShader = {
 
 		void main() {
 
-			vec4 worldPosition = modelMatrix * vec4( position, 1.0 );
-			vWorldPosition = worldPosition.xyz;
+			vPosition = position;
 
 			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 			gl_Position.z = gl_Position.w; // set z to camera.far
@@ -128,7 +127,7 @@ Sky.SkyShader = {
 		}`,
 
 	fragmentShader: /* glsl */`
-		varying vec3 vWorldPosition;
+		varying vec3 vPosition;
 		varying vec3 vSunDirection;
 		varying float vSunfade;
 		varying vec3 vBetaR;
@@ -137,8 +136,6 @@ Sky.SkyShader = {
 
 		uniform float mieDirectionalG;
 		uniform vec3 up;
-
-		const vec3 cameraPos = vec3( 0.0, 0.0, 0.0 );
 
 		// constants for atmospheric scattering
 		const float pi = 3.141592653589793238462643383279502884197169;
@@ -169,7 +166,7 @@ Sky.SkyShader = {
 
 		void main() {
 
-			vec3 direction = normalize( vWorldPosition - cameraPos );
+			vec3 direction = normalize( vPosition );
 
 			// optical length
 			// cutoff angle at 90 to avoid singularity in next formula.


### PR DESCRIPTION
ok, so the sky "as is" only works when placed at 0,0,0

when you move it with the camera somewhere far, far away - you get this:

<img width="531" alt="Снимок экрана (1122)" src="https://github.com/mrdoob/three.js/assets/242577/e10105ef-c801-487a-826a-0bdb2efa5e05">

this change fixes it to what it looks like at 0,0,0 again:

<img width="530" alt="Снимок экрана (1123)" src="https://github.com/mrdoob/three.js/assets/242577/cc7d58ec-e107-4639-b656-9e938d0ee79c">

~~personally, I would also replace BoxGeometry with SphereGeometry because the box edges are too visible, but that is separate issue (and you could maybe also address that in the shader instead).~~