### PR TITLE
WebGPURenderer: Fix approach to clear()

### DIFF
--- a/examples/jsm/renderers/webgpu/WebGPUBackground.js
+++ b/examples/jsm/renderers/webgpu/WebGPUBackground.js
@@ -15,14 +15,6 @@ class WebGPUBackground {
 		this.boxMesh = null;
 		this.boxMeshNode = null;
 
-		this.forceClear = false;
-
-	}
-
-	clear() {
-
-		this.forceClear = true;
-
 	}
 
 	update( scene, renderList, renderState ) {
@@ -30,7 +22,7 @@ class WebGPUBackground {
 		const renderer = this.renderer;
 		const background = ( scene.isScene === true ) ? scene.backgroundNode || this.properties.get( scene ).backgroundNode || scene.background : null;
 
-		let forceClear = this.forceClear;
+		let forceClear = false;
 
 		if ( background === null ) {
 


### PR DESCRIPTION
**Description**

The clear must be executed immediately after call `WebGPURenderer.clear()`, which was not the case with the previous approach. Were also added: `.clearColor()`, `clearDepth()`, `clearStencil()`.

<- webgl left | webgpu right ->

![image](https://github.com/mrdoob/three.js/assets/502810/ed6882b7-5ace-43b0-9193-34051608616d)
