### PR TITLE
package.json: Don't export `examples/fonts` directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
       "import": "./build/three.module.js",
       "require": "./build/three.cjs"
     },
-    "./examples/fonts/*": "./examples/fonts/*",
     "./examples/jsm/*": "./examples/jsm/*",
     "./addons/*": "./examples/jsm/*",
     "./src/*": "./src/*",
@@ -24,7 +23,6 @@
   "files": [
     "build",
     "examples/jsm",
-    "examples/fonts",
     "LICENSE",
     "package.json",
     "README.md",


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/20019#issuecomment-1546593357

**Description**

I don't really understand why we need it...