### PR TITLE
package.json: Don't export `src` directory in package files

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "./examples/fonts/*": "./examples/fonts/*",
     "./examples/jsm/*": "./examples/jsm/*",
     "./addons/*": "./examples/jsm/*",
-    "./src/*": "./src/*",
     "./nodes": "./examples/jsm/nodes/Nodes.js"
   },
   "repository": {
@@ -27,8 +26,7 @@
     "examples/fonts",
     "LICENSE",
     "package.json",
-    "README.md",
-    "src"
+    "README.md"
   ],
   "directories": {
     "doc": "docs",


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/20019#issuecomment-1546593357

#26048 proposes to remove fonts from the distribution files.
This is the same for the `src` directory.
