### PR TITLE
Example `webgl_loader_gltf_anisotropy`: Adjustments to avoid clipping.

### DIFF
--- a/examples/webgl_loader_gltf_anisotropy.html
+++ b/examples/webgl_loader_gltf_anisotropy.html
@@ -53,12 +53,13 @@
 
 				scene = new THREE.Scene();
 
-				camera = new THREE.PerspectiveCamera( 50, window.innerWidth / window.innerHeight, 0.25, 20 );
+				camera = new THREE.PerspectiveCamera( 50, window.innerWidth / window.innerHeight, 0.02, 2 );
 				camera.position.set( 0.35, 0.05, 0.35 );
 
 				controls = new OrbitControls( camera, renderer.domElement );
 				controls.addEventListener( 'change', render );
 				controls.target.set( 0, -0.05, 0.1 );
+				controls.maxDistance = 1.5;
 				controls.update();
 
 				const rgbeLoader = new RGBELoader()

--- a/examples/webgl_loader_gltf_anisotropy.html
+++ b/examples/webgl_loader_gltf_anisotropy.html
@@ -59,6 +59,8 @@
 				controls = new OrbitControls( camera, renderer.domElement );
 				controls.addEventListener( 'change', render );
 				controls.target.set( 0, -0.05, 0.1 );
+				controls.enableZoom = false;
+				controls.enablePan = false;
 				controls.update();
 
 				const rgbeLoader = new RGBELoader()

--- a/examples/webgl_loader_gltf_anisotropy.html
+++ b/examples/webgl_loader_gltf_anisotropy.html
@@ -53,13 +53,12 @@
 
 				scene = new THREE.Scene();
 
-				camera = new THREE.PerspectiveCamera( 50, window.innerWidth / window.innerHeight, 0.02, 2 );
+				camera = new THREE.PerspectiveCamera( 50, window.innerWidth / window.innerHeight, 0.25, 20 );
 				camera.position.set( 0.35, 0.05, 0.35 );
 
 				controls = new OrbitControls( camera, renderer.domElement );
 				controls.addEventListener( 'change', render );
 				controls.target.set( 0, -0.05, 0.1 );
-				controls.maxDistance = 1.5;
 				controls.update();
 
 				const rgbeLoader = new RGBELoader()


### PR DESCRIPTION
**Description**

Adjustments to avoid clipping.

![image](https://github.com/mrdoob/three.js/assets/502810/d2895fa6-8861-48cf-b734-934f0ce28651)
