### PR TITLE
devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+{
+  "image": "mcr.microsoft.com/vscode/devcontainers/javascript-node:18",
+  "hostRequirements": {
+    "memory": "8gb"
+  },
+  "waitFor": "onCreateCommand",
+  "updateContentCommand": "npm ci",
+  "postCreateCommand": "",
+  "postAttachCommand": "npm start",
+  "customizations": {
+    "codespaces": {
+      "openFiles": [".github/CONTRIBUTING.md"]
+    },
+    "vscode": {
+      "settings": {},
+      "extensions": ["dbaeumer.vscode-eslint"]
+    }
+  },
+  "portsAttributes": {
+    "8080": {
+      "label": "Dev server",
+      "onAutoForward": "openPreview"
+    }
+  },
+  "forwardPorts": [8080]
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
   "waitFor": "onCreateCommand",
   "updateContentCommand": "npm ci",
   "postCreateCommand": "",
-  "postAttachCommand": "npm start",
+  "postAttachCommand": "npm start -- -- -- --ssl=false",
   "customizations": {
     "codespaces": {
       "openFiles": [".github/CONTRIBUTING.md"]

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![NPM Downloads][npm-downloads]][npmtrends-url]
 [![DeepScan][deepscan]][deepscan-url]
 [![Discord][discord]][discord-url]
+[![Open in GitHub Codespaces](https://img.shields.io/static/v1?label=GitHub&message=Open%20in%20%20Codespaces&color=24292f)](https://codespaces.new/mrdoob/three.js)
 
 #### JavaScript 3D library
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "test": "npm run lint && npm run test-unit",
     "build": "rollup -c utils/build/rollup.config.js",
     "build-module": "rollup -c utils/build/rollup.config.js --configOnlyModule",
-    "dev": "concurrently --names \"ROLLUP,HTTP\" -c \"bgBlue.bold,bgGreen.bold\" \"rollup -c utils/build/rollup.config.js -w -m inline\" \"servez -p 8080 --ssl\"",
+    "dev": "concurrently -P --names \"ROLLUP,HTTP\" -c \"bgBlue.bold,bgGreen.bold\" \"rollup -c utils/build/rollup.config.js -w -m inline\" \"servez -p 8080 --ssl {@}\"",
     "lint-core": "eslint src",
     "lint-addons": "eslint examples/jsm --ext .js --ignore-pattern libs --ignore-pattern ifc",
     "lint-examples": "eslint examples --ext .html",


### PR DESCRIPTION
**Description**

This PR aims at enhancing the developer experience, by allowing anyone to have the project up-and-running in a Codespace in one click, right from his browser: https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/setting-up-your-repository/facilitating-quick-creation-and-resumption-of-codespaces

<img width="1871" alt="image" src="https://github.com/mrdoob/three.js/assets/76580/bfe6c19e-0cb6-49a3-a746-69ea987857e9">


This PR adds a `.devcontainer` to the repository, that:

- runs a linux machine (with enough memory)
- with node 18
- automatically being pre-`npm ci`
- launches `npm start`
- opens a http://localhost:8080 preview
- pre-installs eslint extension

NB: It also works locally with [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)

---

- [x] Ready for review
- [ ] let the reviewer runs this devcontainer based on this `abernier:devcontainer` branch: [![Open in GitHub Codespaces](https://img.shields.io/static/v1?label=GitHub&message=Open%20in%20%20Codespaces&color=24292f)](https://github.com/codespaces/new?template_repository=abernier%2Fthree.js&ref=devcontainer)
