### PR TITLE
Fix support for texture transform for anisotropy map

### DIFF
--- a/src/renderers/shaders/ShaderChunk/uv_pars_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/uv_pars_vertex.glsl.js
@@ -66,6 +66,7 @@ export default /* glsl */`
 #endif
 #ifdef USE_ANISOTROPYMAP
 
+	uniform mat3 anisotropyMapTransform;
 	varying vec2 vAnisotropyMapUv;
 
 #endif

--- a/src/renderers/shaders/ShaderChunk/uv_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/uv_vertex.glsl.js
@@ -56,7 +56,7 @@ export default /* glsl */`
 #endif
 #ifdef USE_ANISOTROPYMAP
 
-	vAnisotropyMapUv = ( vec3( ANISOTROPYMAP_UV, 1 ) ).xy;
+	vAnisotropyMapUv = ( anisotropyMapTransform * vec3( ANISOTROPYMAP_UV, 1 ) ).xy;
 
 #endif
 #ifdef USE_CLEARCOATMAP

--- a/src/renderers/shaders/ShaderLib.js
+++ b/src/renderers/shaders/ShaderLib.js
@@ -346,6 +346,7 @@ ShaderLib.physical = {
 			specularIntensityMapTransform: { value: /*@__PURE__*/ new Matrix3() },
 			anisotropyVector: { value: /*@__PURE__*/ new Vector2() },
 			anisotropyMap: { value: null },
+			anisotropyMapTransform: { value: /*@__PURE__*/ new Matrix3() },
 		}
 	] ),
 

--- a/src/renderers/webgl/WebGLMaterials.js
+++ b/src/renderers/webgl/WebGLMaterials.js
@@ -506,6 +506,8 @@ function WebGLMaterials( renderer, properties ) {
 
 				uniforms.anisotropyMap.value = material.anisotropyMap;
 
+				refreshTransformUniform( material.anisotropyMap, uniforms.anisotropyMapTransform );
+
 			}
 
 		}


### PR DESCRIPTION
This is necessary to make glTF files that use KHR_materials_anisotropy together with KHR_texture_transform work properly.

Tested using gltfpack and updated model from glTF-Sample-Models that specifies the texture properly + some local fixes to the model:

![image](https://github.com/mrdoob/three.js/assets/1106629/8f58606e-1784-43d0-8a30-00851ed51fe5)
