### PR TITLE
WebGLBindingStates: support (u)int 8-16 buffer attributes

### DIFF
--- a/examples/webgl2_buffergeometry_attributes_integer.html
+++ b/examples/webgl2_buffergeometry_attributes_integer.html
@@ -12,9 +12,9 @@
 		<div id="info"><a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> WebGL 2 - buffergeometry - integer attributes</div>
 
 		<script id="vertexShader" type="x-shader/x-vertex">
-			in int textureIndex;
+			in uint textureIndex;
 
-			flat out int vIndex; // "flat" indicates that the value will not be interpolated (required for integer attributes)
+			flat out uint vIndex; // "flat" indicates that the value will not be interpolated (required for integer attributes)
 			out vec2 vUv;
 
 			void main()	{
@@ -28,7 +28,7 @@
 		</script>
 
 		<script id="fragmentShader" type="x-shader/x-fragment">
-			flat in int vIndex;
+			flat in uint vIndex;
 			in vec2 vUv;
 
 			uniform sampler2D uTextures[ 3 ];
@@ -37,9 +37,9 @@
 
 			void main()	{
 
-				if ( vIndex == 0 ) outColor = texture( uTextures[ 0 ], vUv );
-				else if ( vIndex == 1 ) outColor = texture( uTextures[ 1 ], vUv );
-				else if ( vIndex == 2 ) outColor = texture( uTextures[ 2 ], vUv );
+				if ( vIndex == 0u ) outColor = texture( uTextures[ 0 ], vUv );
+				else if ( vIndex == 1u ) outColor = texture( uTextures[ 1 ], vUv );
+				else if ( vIndex == 2u ) outColor = texture( uTextures[ 2 ], vUv );
 
 			}
 		</script>

--- a/examples/webgl2_buffergeometry_attributes_integer.html
+++ b/examples/webgl2_buffergeometry_attributes_integer.html
@@ -135,7 +135,7 @@
 
 				geometry.setAttribute( 'position', new THREE.Float32BufferAttribute( positions, 3 ) );
 				geometry.setAttribute( 'uv', new THREE.Float32BufferAttribute( uvs, 2 ) );
-				geometry.setAttribute( 'textureIndex', new THREE.Int32BufferAttribute( textureIndices, 1 ) );
+				geometry.setAttribute( 'textureIndex', new THREE.Uint16BufferAttribute( textureIndices, 1 ) );
 
 				geometry.computeBoundingSphere();
 

--- a/examples/webgl2_buffergeometry_attributes_integer.html
+++ b/examples/webgl2_buffergeometry_attributes_integer.html
@@ -136,6 +136,7 @@
 				geometry.setAttribute( 'position', new THREE.Float32BufferAttribute( positions, 3 ) );
 				geometry.setAttribute( 'uv', new THREE.Float32BufferAttribute( uvs, 2 ) );
 				geometry.setAttribute( 'textureIndex', new THREE.Uint16BufferAttribute( textureIndices, 1 ) );
+				geometry.attributes.textureIndex.gpuType = THREE.UnsignedShortType;
 
 				geometry.computeBoundingSphere();
 

--- a/src/renderers/webgl/WebGLBindingStates.js
+++ b/src/renderers/webgl/WebGLBindingStates.js
@@ -384,7 +384,7 @@ function WebGLBindingStates( gl, extensions, attributes, capabilities ) {
 
 					// check for integer attributes (WebGL 2 only)
 
-					const integer = ( capabilities.isWebGL2 === true && ( type === gl.BYTE || type === gl.SHORT || type === gl.INT || type === gl.UNSIGNED_BYTE || type === gl.UNSIGNED_SHORT || type === gl.UNSIGNED_INT || geometryAttribute.gpuType === ByteType || geometryAttribute.gpuType === ShortType || geometryAttribute.gpuType === IntType || geometryAttribute.gpuType === UnsignedByteType || geometryAttribute.gpuType === UnsignedShortType || geometryAttribute.gpuType === UnsignedIntType ) );
+					const integer = ( capabilities.isWebGL2 === true && ( geometryAttribute.gpuType === ByteType || geometryAttribute.gpuType === ShortType || geometryAttribute.gpuType === IntType || geometryAttribute.gpuType === UnsignedByteType || geometryAttribute.gpuType === UnsignedShortType || geometryAttribute.gpuType === UnsignedIntType ) );
 
 					if ( geometryAttribute.isInterleavedBufferAttribute ) {
 

--- a/src/renderers/webgl/WebGLBindingStates.js
+++ b/src/renderers/webgl/WebGLBindingStates.js
@@ -321,6 +321,11 @@ function WebGLBindingStates( gl, extensions, attributes, capabilities ) {
 
 		if ( integer === true ) {
 
+			// Bind unsigned integers as signed
+			if ( type === gl.UNSIGNED_BYTE ) type = gl.BYTE;
+			else if ( type === gl.UNSIGNED_SHORT ) type = gl.SHORT;
+			else if ( type === gl.UNSIGNED_INT ) type = gl.INT;
+
 			gl.vertexAttribIPointer( index, size, type, stride, offset );
 
 		} else {

--- a/src/renderers/webgl/WebGLBindingStates.js
+++ b/src/renderers/webgl/WebGLBindingStates.js
@@ -321,11 +321,6 @@ function WebGLBindingStates( gl, extensions, attributes, capabilities ) {
 
 		if ( integer === true ) {
 
-			// Bind unsigned integers as signed
-			if ( type === gl.UNSIGNED_BYTE ) type = gl.BYTE;
-			else if ( type === gl.UNSIGNED_SHORT ) type = gl.SHORT;
-			else if ( type === gl.UNSIGNED_INT ) type = gl.INT;
-
 			gl.vertexAttribIPointer( index, size, type, stride, offset );
 
 		} else {

--- a/src/renderers/webgl/WebGLBindingStates.js
+++ b/src/renderers/webgl/WebGLBindingStates.js
@@ -1,4 +1,4 @@
-﻿import { IntType } from '../../constants.js';
+﻿import { ByteType, ShortType, IntType, UnsignedByteType, UnsignedShortType, UnsignedIntType } from '../../constants.js';
 
 function WebGLBindingStates( gl, extensions, attributes, capabilities ) {
 
@@ -379,7 +379,7 @@ function WebGLBindingStates( gl, extensions, attributes, capabilities ) {
 
 					// check for integer attributes (WebGL 2 only)
 
-					const integer = ( capabilities.isWebGL2 === true && ( type === gl.INT || type === gl.UNSIGNED_INT || geometryAttribute.gpuType === IntType ) );
+					const integer = ( capabilities.isWebGL2 === true && ( type === gl.BYTE || type === gl.SHORT || type === gl.INT || type === gl.UNSIGNED_BYTE || type === gl.UNSIGNED_SHORT || type === gl.UNSIGNED_INT || geometryAttribute.gpuType === ByteType || geometryAttribute.gpuType === ShortType || geometryAttribute.gpuType === IntType || geometryAttribute.gpuType === UnsignedByteType || geometryAttribute.gpuType === UnsignedShortType || geometryAttribute.gpuType === UnsignedIntType ) );
 
 					if ( geometryAttribute.isInterleavedBufferAttribute ) {
 


### PR DESCRIPTION
Related issue: #21595, follow-up to #21606.

**Description**

This PR expands support for `Uint32BufferAttribute`, `Uint16BufferAttribute`, `Int16BufferAttribute`, `Uint8ClampedBufferAttribute`, `Uint8BufferAttribute`, and `Int8BufferAttribute`.

I've tested all of the integer attribute types of https://threejs.org/docs/#api/en/core/bufferAttributeTypes/BufferAttributeTypes in the `webgl2_buffergeometry_attributes_integer` example.

For reference, the following matches integer attributes and their appropriate `BufferAttribute.gpuType` (should this be documented? #26084):

| Attribute                  | three.js Type     | GLSL type | Range                           |
|----------------------------|-------------------|------|--------------------------------------|
| Uint32BufferAttribute      | UnsignedIntType   | uint | 0 to 4,294,967,295                   |
| Uint16BufferAttribute      | UnsignedShortType | uint | 0 to 65,535                          |
| Uint8BufferAttribute       | UnsignedByteType  | uint | 0 to 255                             |
| Uint8ClampedBufferAttribute| UnsignedByteType  | uint | 0 to 255                             |
| Int32BufferAttribute       | IntType           | int  | -2,147,483,648 to 2,147,483,647      |
| Int16BufferAttribute       | ShortType         | int  | -32,768 to 32,767                    |
| Int8BufferAttribute        | ByteType          | int  | -128 to 127                          |
