### PR TITLE
BufferAttribute: add gpuType

### DIFF
--- a/docs/api/en/core/BufferAttribute.html
+++ b/docs/api/en/core/BufferAttribute.html
@@ -63,6 +63,9 @@
 			or color), then this will count the number of such vectors stored.
 		</p>
 
+		<h3>[property:Number gpuType]</h3>
+		<p>Configures the internal bound GPU type. Either [page:BufferAttribute THREE.FloatType] or [page:BufferAttribute THREE.IntType], default is [page:BufferAttribute THREE.FloatType].</p>
+
 		<h3>[property:Boolean isBufferAttribute]</h3>
 		<p>Read-only flag to check if a given object is of type [name].</p>
 

--- a/docs/api/en/core/BufferAttribute.html
+++ b/docs/api/en/core/BufferAttribute.html
@@ -64,7 +64,11 @@
 		</p>
 
 		<h3>[property:Number gpuType]</h3>
-		<p>Configures the internal bound GPU type. Either [page:BufferAttribute THREE.FloatType] or [page:BufferAttribute THREE.IntType], default is [page:BufferAttribute THREE.FloatType].</p>
+		<p>
+			Configures the bound GPU type for use in shaders. Either [page:BufferAttribute THREE.FloatType] or [page:BufferAttribute THREE.IntType], default is [page:BufferAttribute THREE.FloatType].
+
+			Note: this only has an effect for integer arrays and is not configurable for float arrays. For lower precision float types, see [page:BufferAttributeTypes THREE.Float16BufferAttribute].
+		</p>
 
 		<h3>[property:Boolean isBufferAttribute]</h3>
 		<p>Read-only flag to check if a given object is of type [name].</p>

--- a/docs/api/fr/core/BufferAttribute.html
+++ b/docs/api/fr/core/BufferAttribute.html
@@ -55,6 +55,9 @@
 		cela comptera alors le nombre de ces vecteurs stockés.
 		</p>
 
+		<h3>[property:Number gpuType]</h3>
+		<p>Configures the internal bound GPU type. Either [page:BufferAttribute THREE.FloatType] or [page:BufferAttribute THREE.IntType], default is [page:BufferAttribute THREE.FloatType].</p>
+
 		<h3>[property:Boolean isBufferAttribute]</h3>
 		<p>
 		Booléen en lecture seule pour vérifier si un objet donné est de type[name].

--- a/docs/api/fr/core/BufferAttribute.html
+++ b/docs/api/fr/core/BufferAttribute.html
@@ -56,7 +56,11 @@
 		</p>
 
 		<h3>[property:Number gpuType]</h3>
-		<p>Configures the internal bound GPU type. Either [page:BufferAttribute THREE.FloatType] or [page:BufferAttribute THREE.IntType], default is [page:BufferAttribute THREE.FloatType].</p>
+		<p>
+			Configures the bound GPU type for use in shaders. Either [page:BufferAttribute THREE.FloatType] or [page:BufferAttribute THREE.IntType], default is [page:BufferAttribute THREE.FloatType].
+
+			Note: this only has an effect for integer arrays and is not configurable for float arrays. For lower precision float types, see [page:BufferAttributeTypes THREE.Float16BufferAttribute].
+		</p>
 
 		<h3>[property:Boolean isBufferAttribute]</h3>
 		<p>

--- a/docs/api/it/core/BufferAttribute.html
+++ b/docs/api/it/core/BufferAttribute.html
@@ -54,7 +54,11 @@
 		</p>
 
 		<h3>[property:Number gpuType]</h3>
-		<p>Configures the internal bound GPU type. Either [page:BufferAttribute THREE.FloatType] or [page:BufferAttribute THREE.IntType], default is [page:BufferAttribute THREE.FloatType].</p>
+		<p>
+			Configures the bound GPU type for use in shaders. Either [page:BufferAttribute THREE.FloatType] or [page:BufferAttribute THREE.IntType], default is [page:BufferAttribute THREE.FloatType].
+
+			Note: this only has an effect for integer arrays and is not configurable for float arrays. For lower precision float types, see [page:BufferAttributeTypes THREE.Float16BufferAttribute].
+		</p>
 
 		<h3>[property:Boolean isBufferAttribute]</h3>
 		<p>

--- a/docs/api/it/core/BufferAttribute.html
+++ b/docs/api/it/core/BufferAttribute.html
@@ -53,6 +53,9 @@
       questo conterà il numero dei vettori memorizzati.
 		</p>
 
+		<h3>[property:Number gpuType]</h3>
+		<p>Configures the internal bound GPU type. Either [page:BufferAttribute THREE.FloatType] or [page:BufferAttribute THREE.IntType], default is [page:BufferAttribute THREE.FloatType].</p>
+
 		<h3>[property:Boolean isBufferAttribute]</h3>
 		<p>
       Flag di sola lettura per verificare se un dato oggetto è di tipo [name].

--- a/docs/api/ko/core/BufferAttribute.html
+++ b/docs/api/ko/core/BufferAttribute.html
@@ -59,6 +59,9 @@
 		저장된 벡터들의 수를 계산합니다.
 		</p>
 
+		<h3>[property:Number gpuType]</h3>
+		<p>Configures the internal bound GPU type. Either [page:BufferAttribute THREE.FloatType] or [page:BufferAttribute THREE.IntType], default is [page:BufferAttribute THREE.FloatType].</p>
+
 		<h3>[property:Boolean isBufferAttribute]</h3>
 		<p>
 			Read-only flag to check if a given object is of type [name].

--- a/docs/api/ko/core/BufferAttribute.html
+++ b/docs/api/ko/core/BufferAttribute.html
@@ -60,7 +60,11 @@
 		</p>
 
 		<h3>[property:Number gpuType]</h3>
-		<p>Configures the internal bound GPU type. Either [page:BufferAttribute THREE.FloatType] or [page:BufferAttribute THREE.IntType], default is [page:BufferAttribute THREE.FloatType].</p>
+		<p>
+			Configures the bound GPU type for use in shaders. Either [page:BufferAttribute THREE.FloatType] or [page:BufferAttribute THREE.IntType], default is [page:BufferAttribute THREE.FloatType].
+
+			Note: this only has an effect for integer arrays and is not configurable for float arrays. For lower precision float types, see [page:BufferAttributeTypes THREE.Float16BufferAttribute].
+		</p>
 
 		<h3>[property:Boolean isBufferAttribute]</h3>
 		<p>

--- a/docs/api/zh/core/BufferAttribute.html
+++ b/docs/api/zh/core/BufferAttribute.html
@@ -56,6 +56,9 @@
 			若缓存存储三元组（例如顶点位置、法向量、颜色值），则该值应等于队列中三元组的个数。
 		</p>
 
+		<h3>[property:Number gpuType]</h3>
+		<p>Configures the internal bound GPU type. Either [page:BufferAttribute THREE.FloatType] or [page:BufferAttribute THREE.IntType], default is [page:BufferAttribute THREE.FloatType].</p>
+
 		<h3>[property:Boolean isBufferAttribute]</h3>
 		<p>
 			用于判断对象是否为[name]类型的只读标记.

--- a/docs/api/zh/core/BufferAttribute.html
+++ b/docs/api/zh/core/BufferAttribute.html
@@ -57,7 +57,11 @@
 		</p>
 
 		<h3>[property:Number gpuType]</h3>
-		<p>Configures the internal bound GPU type. Either [page:BufferAttribute THREE.FloatType] or [page:BufferAttribute THREE.IntType], default is [page:BufferAttribute THREE.FloatType].</p>
+		<p>
+			Configures the bound GPU type for use in shaders. Either [page:BufferAttribute THREE.FloatType] or [page:BufferAttribute THREE.IntType], default is [page:BufferAttribute THREE.FloatType].
+
+			Note: this only has an effect for integer arrays and is not configurable for float arrays. For lower precision float types, see [page:BufferAttributeTypes THREE.Float16BufferAttribute].
+		</p>
 
 		<h3>[property:Boolean isBufferAttribute]</h3>
 		<p>

--- a/examples/webgl2_buffergeometry_attributes_integer.html
+++ b/examples/webgl2_buffergeometry_attributes_integer.html
@@ -135,7 +135,8 @@
 
 				geometry.setAttribute( 'position', new THREE.Float32BufferAttribute( positions, 3 ) );
 				geometry.setAttribute( 'uv', new THREE.Float32BufferAttribute( uvs, 2 ) );
-				geometry.setAttribute( 'textureIndex', new THREE.Int32BufferAttribute( textureIndices, 1 ) );
+				geometry.setAttribute( 'textureIndex', new THREE.Int16BufferAttribute( textureIndices, 1 ) );
+				geometry.attributes.textureIndex.gpuType = THREE.IntType;
 
 				geometry.computeBoundingSphere();
 

--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -28,6 +28,7 @@ class BufferAttribute {
 
 		this.usage = StaticDrawUsage;
 		this.updateRange = { offset: 0, count: - 1 };
+		this.gpuType = FloatType;
 
 		this.version = 0;
 
@@ -58,6 +59,7 @@ class BufferAttribute {
 		this.normalized = source.normalized;
 
 		this.usage = source.usage;
+		this.gpuType = source.gpuType;
 
 		return this;
 
@@ -378,18 +380,6 @@ class Int8BufferAttribute extends BufferAttribute {
 
 		super( new Int8Array( array ), itemSize, normalized );
 
-		this.gpuType = FloatType;
-
-	}
-
-	copy( source ) {
-
-		super.copy( source );
-
-		this.gpuType = source.gpuType;
-
-		return this;
-
 	}
 
 }
@@ -399,18 +389,6 @@ class Uint8BufferAttribute extends BufferAttribute {
 	constructor( array, itemSize, normalized ) {
 
 		super( new Uint8Array( array ), itemSize, normalized );
-
-		this.gpuType = FloatType;
-
-	}
-
-	copy( source ) {
-
-		super.copy( source );
-
-		this.gpuType = source.gpuType;
-
-		return this;
 
 	}
 
@@ -432,18 +410,6 @@ class Int16BufferAttribute extends BufferAttribute {
 
 		super( new Int16Array( array ), itemSize, normalized );
 
-		this.gpuType = FloatType;
-
-	}
-
-	copy( source ) {
-
-		super.copy( source );
-
-		this.gpuType = source.gpuType;
-
-		return this;
-
 	}
 
 }
@@ -453,18 +419,6 @@ class Uint16BufferAttribute extends BufferAttribute {
 	constructor( array, itemSize, normalized ) {
 
 		super( new Uint16Array( array ), itemSize, normalized );
-
-		this.gpuType = FloatType;
-
-	}
-
-	copy( source ) {
-
-		super.copy( source );
-
-		this.gpuType = source.gpuType;
-
-		return this;
 
 	}
 


### PR DESCRIPTION
Related issue: #21595, follow-up to #21606.

**Description**

Adds `gpuType` to `BufferAttribute` which allows three.js to defer to an appropriate GPU type based on the precision of incoming data. Previously, this was only accidentally configurable (see https://github.com/mrdoob/three.js/pull/26084#issuecomment-1555936880).

```js
// Available as uint in GLSL or u32 in WGSL
// see https://threejs.org/examples/#webgl2_buffergeometry_attributes_integer
const attribute = new THREE.BufferAttribute( new Uint16Array( [ ... ] ), 1 );
attribute.gpuType = THREE.IntType;
```