### PR TITLE
KTX2Loader: Fix regression in mipmap chain upload

### DIFF
--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -541,7 +541,8 @@ KTX2Loader.BasisWorker = function () {
 					} else {
 
 						// Handles non-multiple-of-four dimensions in textures without mipmaps. Textures with
-						// mipmaps must use multiple-of-four dimensions. See mrdoob/three.js#25908.
+						// mipmaps must use multiple-of-four dimensions, for some texture formats and APIs.
+						// See mrdoob/three.js#25908.
 						mipWidth = levelInfo.width;
 						mipHeight = levelInfo.height;
 

--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -526,8 +526,27 @@ KTX2Loader.BasisWorker = function () {
 				for ( let layer = 0; layer < layerCount; layer ++ ) {
 
 					const levelInfo = ktx2File.getImageLevelInfo( mip, layer, face );
-					mipWidth = levelInfo.origWidth < 4 ? levelInfo.origWidth : levelInfo.width;
-					mipHeight = levelInfo.origHeight < 4 ? levelInfo.origHeight : levelInfo.height;
+
+					if ( face === 0 && mip === 0 && layer === 0 && ( levelInfo.origWidth % 4 !== 0 || levelInfo.origHeight % 4 !== 0 ) ) {
+
+						console.warn( 'THREE.KTX2Loader: ETC1S and UASTC textures should use multiple-of-four dimensions.' );
+
+					}
+
+					if ( levelCount > 1 ) {
+
+						mipWidth = levelInfo.origWidth;
+						mipHeight = levelInfo.origHeight;
+
+					} else {
+
+						// Handles non-multiple-of-four dimensions in textures without mipmaps. Textures with
+						// mipmaps must use multiple-of-four dimensions. See mrdoob/three.js#25908.
+						mipWidth = levelInfo.width;
+						mipHeight = levelInfo.height;
+
+					}
+
 					const dst = new Uint8Array( ktx2File.getImageTranscodedSizeInBytes( mip, layer, 0, transcoderFormat ) );
 					const status = ktx2File.transcodeImage( dst, mip, layer, face, transcoderFormat, 0, - 1, - 1 );
 


### PR DESCRIPTION
- Fixes #25908
- Related #25339
- Related #25375

Changes in #25375 allowed textures with non-multiple-of-four dimensions to display if the texture had no mipmaps, but caused a regression in mipmapped textures with non-power-of-two dimensions. As proposed in #25908, this PR aims to do both, but we cannot support non-multiple-of-four mipmapped textures in some texture formats and WebGL backends.

A warning will now be logged when loading a non-multiple-of-four texture with ETC1S or UASTC compression. Multiple-of-four dimensions are mandatory for KTX2 files used in glTF models, but the KTX2 format has no such restriction.