### PR TITLE
Shaders: Add name property

### DIFF
--- a/examples/jsm/misc/GPUComputationRenderer.js
+++ b/examples/jsm/misc/GPUComputationRenderer.js
@@ -332,6 +332,7 @@ class GPUComputationRenderer {
 			uniforms = uniforms || {};
 
 			const material = new ShaderMaterial( {
+				name: 'GPUComputationShader',
 				uniforms: uniforms,
 				vertexShader: getPassThroughVertexShader(),
 				fragmentShader: computeFragmentShader

--- a/examples/jsm/objects/Reflector.js
+++ b/examples/jsm/objects/Reflector.js
@@ -54,7 +54,7 @@ class Reflector extends Mesh {
 		const renderTarget = new WebGLRenderTarget( textureWidth, textureHeight, { samples: multisample, type: HalfFloatType } );
 
 		const material = new ShaderMaterial( {
-			name: ( shader.name !== undefined ) ? shader.name : shader.type,
+			name: shader.name,
 			uniforms: UniformsUtils.clone( shader.uniforms ),
 			fragmentShader: shader.fragmentShader,
 			vertexShader: shader.vertexShader

--- a/examples/jsm/objects/Reflector.js
+++ b/examples/jsm/objects/Reflector.js
@@ -54,7 +54,7 @@ class Reflector extends Mesh {
 		const renderTarget = new WebGLRenderTarget( textureWidth, textureHeight, { samples: multisample, type: HalfFloatType } );
 
 		const material = new ShaderMaterial( {
-			name: shader.name,
+			name: ( shader.name !== undefined ) ? shader.name : 'unspecified',
 			uniforms: UniformsUtils.clone( shader.uniforms ),
 			fragmentShader: shader.fragmentShader,
 			vertexShader: shader.vertexShader

--- a/examples/jsm/objects/Reflector.js
+++ b/examples/jsm/objects/Reflector.js
@@ -54,6 +54,7 @@ class Reflector extends Mesh {
 		const renderTarget = new WebGLRenderTarget( textureWidth, textureHeight, { samples: multisample, type: HalfFloatType } );
 
 		const material = new ShaderMaterial( {
+			name: ( shader.name !== undefined ) ? shader.name : shader.type,
 			uniforms: UniformsUtils.clone( shader.uniforms ),
 			fragmentShader: shader.fragmentShader,
 			vertexShader: shader.vertexShader
@@ -200,6 +201,8 @@ class Reflector extends Mesh {
 }
 
 Reflector.ReflectorShader = {
+
+	name: 'ReflectorShader',
 
 	uniforms: {
 

--- a/examples/jsm/postprocessing/BloomPass.js
+++ b/examples/jsm/postprocessing/BloomPass.js
@@ -29,6 +29,7 @@ class BloomPass extends Pass {
 
 		this.materialCombine = new ShaderMaterial( {
 
+			name: CombineShader.name,
 			uniforms: this.combineUniforms,
 			vertexShader: CombineShader.vertexShader,
 			fragmentShader: CombineShader.fragmentShader,
@@ -48,6 +49,7 @@ class BloomPass extends Pass {
 
 		this.materialConvolution = new ShaderMaterial( {
 
+			name: convolutionShader.name,
 			uniforms: this.convolutionUniforms,
 			vertexShader: convolutionShader.vertexShader,
 			fragmentShader: convolutionShader.fragmentShader,
@@ -125,6 +127,8 @@ class BloomPass extends Pass {
 }
 
 const CombineShader = {
+
+	name: 'CombineShader',
 
 	uniforms: {
 

--- a/examples/jsm/postprocessing/DotScreenPass.js
+++ b/examples/jsm/postprocessing/DotScreenPass.js
@@ -21,6 +21,7 @@ class DotScreenPass extends Pass {
 
 		this.material = new ShaderMaterial( {
 
+			name: shader.name,
 			uniforms: this.uniforms,
 			vertexShader: shader.vertexShader,
 			fragmentShader: shader.fragmentShader

--- a/examples/jsm/postprocessing/FilmPass.js
+++ b/examples/jsm/postprocessing/FilmPass.js
@@ -17,6 +17,7 @@ class FilmPass extends Pass {
 
 		this.material = new ShaderMaterial( {
 
+			name: shader.name,
 			uniforms: this.uniforms,
 			vertexShader: shader.vertexShader,
 			fragmentShader: shader.fragmentShader

--- a/examples/jsm/postprocessing/ShaderPass.js
+++ b/examples/jsm/postprocessing/ShaderPass.js
@@ -24,7 +24,7 @@ class ShaderPass extends Pass {
 
 			this.material = new ShaderMaterial( {
 
-				name: ( shader.name !== undefined ) ? shader.name : shader.type,
+				name: shader.name,
 				defines: Object.assign( {}, shader.defines ),
 				uniforms: this.uniforms,
 				vertexShader: shader.vertexShader,

--- a/examples/jsm/postprocessing/ShaderPass.js
+++ b/examples/jsm/postprocessing/ShaderPass.js
@@ -24,6 +24,7 @@ class ShaderPass extends Pass {
 
 			this.material = new ShaderMaterial( {
 
+				name: ( shader.name !== undefined ) ? shader.name : shader.type,
 				defines: Object.assign( {}, shader.defines ),
 				uniforms: this.uniforms,
 				vertexShader: shader.vertexShader,

--- a/examples/jsm/postprocessing/ShaderPass.js
+++ b/examples/jsm/postprocessing/ShaderPass.js
@@ -24,7 +24,7 @@ class ShaderPass extends Pass {
 
 			this.material = new ShaderMaterial( {
 
-				name: shader.name,
+				name: ( shader.name !== undefined ) ? shader.name : 'unspecified',
 				defines: Object.assign( {}, shader.defines ),
 				uniforms: this.uniforms,
 				vertexShader: shader.vertexShader,

--- a/examples/jsm/shaders/BleachBypassShader.js
+++ b/examples/jsm/shaders/BleachBypassShader.js
@@ -6,6 +6,8 @@
 
 const BleachBypassShader = {
 
+	name: 'BleachBypassShader',
+
 	uniforms: {
 
 		'tDiffuse': { value: null },

--- a/examples/jsm/shaders/ColorifyShader.js
+++ b/examples/jsm/shaders/ColorifyShader.js
@@ -8,6 +8,8 @@ import {
 
 const ColorifyShader = {
 
+	name: 'ColorifyShader',
+
 	uniforms: {
 
 		'tDiffuse': { value: null },

--- a/examples/jsm/shaders/ConvolutionShader.js
+++ b/examples/jsm/shaders/ConvolutionShader.js
@@ -9,6 +9,8 @@ import {
 
 const ConvolutionShader = {
 
+	name: 'ConvolutionShader',
+
 	defines: {
 
 		'KERNEL_SIZE_FLOAT': '25.0',

--- a/examples/jsm/shaders/CopyShader.js
+++ b/examples/jsm/shaders/CopyShader.js
@@ -4,6 +4,8 @@
 
 const CopyShader = {
 
+	name: 'CopyShader',
+
 	uniforms: {
 
 		'tDiffuse': { value: null },

--- a/examples/jsm/shaders/DotScreenShader.js
+++ b/examples/jsm/shaders/DotScreenShader.js
@@ -10,6 +10,8 @@ import {
 
 const DotScreenShader = {
 
+	name: 'DotScreenShader',
+
 	uniforms: {
 
 		'tDiffuse': { value: null },

--- a/examples/jsm/shaders/FilmShader.js
+++ b/examples/jsm/shaders/FilmShader.js
@@ -20,6 +20,8 @@
 
 const FilmShader = {
 
+	name: 'FilmShader',
+
 	uniforms: {
 
 		'tDiffuse': { value: null },

--- a/examples/jsm/shaders/GammaCorrectionShader.js
+++ b/examples/jsm/shaders/GammaCorrectionShader.js
@@ -5,6 +5,8 @@
 
 const GammaCorrectionShader = {
 
+	name: 'GammaCorrectionShader',
+
 	uniforms: {
 
 		'tDiffuse': { value: null }

--- a/examples/jsm/shaders/HorizontalBlurShader.js
+++ b/examples/jsm/shaders/HorizontalBlurShader.js
@@ -9,6 +9,8 @@
 
 const HorizontalBlurShader = {
 
+	name: 'HorizontalBlurShader',
+
 	uniforms: {
 
 		'tDiffuse': { value: null },

--- a/examples/jsm/shaders/RGBShiftShader.js
+++ b/examples/jsm/shaders/RGBShiftShader.js
@@ -10,6 +10,8 @@
 
 const RGBShiftShader = {
 
+	name: 'RGBShiftShader',
+
 	uniforms: {
 
 		'tDiffuse': { value: null },

--- a/examples/jsm/shaders/SepiaShader.js
+++ b/examples/jsm/shaders/SepiaShader.js
@@ -6,6 +6,8 @@
 
 const SepiaShader = {
 
+	name: 'SepiaShader',
+
 	uniforms: {
 
 		'tDiffuse': { value: null },

--- a/examples/jsm/shaders/VerticalBlurShader.js
+++ b/examples/jsm/shaders/VerticalBlurShader.js
@@ -9,6 +9,8 @@
 
 const VerticalBlurShader = {
 
+	name: 'VerticalBlurShader',
+
 	uniforms: {
 
 		'tDiffuse': { value: null },

--- a/examples/jsm/shaders/VignetteShader.js
+++ b/examples/jsm/shaders/VignetteShader.js
@@ -6,6 +6,8 @@
 
 const VignetteShader = {
 
+	name: 'VignetteShader',
+
 	uniforms: {
 
 		'tDiffuse': { value: null },

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -418,6 +418,8 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 
 		prefixVertex = [
 
+			'#define SHADER_NAME ' + parameters.shaderName,
+
 			customDefines
 
 		].filter( filterEmptyLine ).join( '\n' );
@@ -431,6 +433,9 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 		prefixFragment = [
 
 			customExtensions,
+
+			'#define SHADER_NAME ' + parameters.shaderName,
+
 			customDefines
 
 		].filter( filterEmptyLine ).join( '\n' );

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -418,6 +418,7 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 
 		prefixVertex = [
 
+			'#define SHADER_TYPE ' + parameters.shaderType,
 			'#define SHADER_NAME ' + parameters.shaderName,
 
 			customDefines
@@ -434,6 +435,7 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 
 			customExtensions,
 
+			'#define SHADER_TYPE ' + parameters.shaderType,
 			'#define SHADER_NAME ' + parameters.shaderName,
 
 			customDefines
@@ -452,6 +454,7 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 
 			generatePrecision( parameters ),
 
+			'#define SHADER_TYPE ' + parameters.shaderType,
 			'#define SHADER_NAME ' + parameters.shaderName,
 
 			customDefines,
@@ -665,6 +668,7 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 
 			generatePrecision( parameters ),
 
+			'#define SHADER_TYPE ' + parameters.shaderType,
 			'#define SHADER_NAME ' + parameters.shaderName,
 
 			customDefines,
@@ -963,6 +967,7 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 
 	//
 
+	this.type = parameters.shaderType;
 	this.name = parameters.shaderName;
 	this.id = programIdCount ++;
 	this.cacheKey = cacheKey;

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -163,7 +163,7 @@ function WebGLPrograms( renderer, cubemaps, cubeuvmaps, extensions, capabilities
 			isWebGL2: IS_WEBGL2,
 
 			shaderID: shaderID,
-			shaderName: material.type,
+			shaderName: ( ( material.isShaderMaterial || material.isRawShaderMaterial ) && material.name !== '' ) ? material.name : material.type,
 
 			vertexShader: vertexShader,
 			fragmentShader: fragmentShader,

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -163,7 +163,8 @@ function WebGLPrograms( renderer, cubemaps, cubeuvmaps, extensions, capabilities
 			isWebGL2: IS_WEBGL2,
 
 			shaderID: shaderID,
-			shaderName: ( ( material.isShaderMaterial || material.isRawShaderMaterial ) && material.name !== '' ) ? material.name : material.type,
+			shaderType: material.type,
+			shaderName: material.name,
 
 			vertexShader: vertexShader,
 			fragmentShader: fragmentShader,


### PR DESCRIPTION
This is a suggested change. Perhaps there is an easier way to implement this?

Before

<img width="672" alt="Screenshot 2023-05-20 at 11 36 08 PM" src="https://github.com/mrdoob/three.js/assets/1000017/cdbbd624-ca56-4bac-8549-d13f3620a128">

After

<img width="682" alt="Screenshot 2023-05-20 at 11 37 42 PM" src="https://github.com/mrdoob/three.js/assets/1000017/78b964a4-2d6b-41e5-8deb-ff4ebe3ebce4">


