### PR TITLE
WebGLAttributes: allow half floats for uint16 with float gpuType

### DIFF
--- a/src/renderers/webgl/WebGLAttributes.js
+++ b/src/renderers/webgl/WebGLAttributes.js
@@ -1,3 +1,5 @@
+import { FloatType } from '../../constants.js';
+
 function WebGLAttributes( gl, capabilities ) {
 
 	const isWebGL2 = capabilities.isWebGL2;
@@ -24,7 +26,7 @@ function WebGLAttributes( gl, capabilities ) {
 
 		} else if ( array instanceof Uint16Array ) {
 
-			if ( attribute.isFloat16BufferAttribute ) {
+			if ( attribute.isFloat16BufferAttribute || attribute.gpuType === FloatType ) {
 
 				if ( isWebGL2 ) {
 

--- a/src/renderers/webgl/WebGLAttributes.js
+++ b/src/renderers/webgl/WebGLAttributes.js
@@ -26,7 +26,7 @@ function WebGLAttributes( gl, capabilities ) {
 
 		} else if ( array instanceof Uint16Array ) {
 
-			if ( attribute.isFloat16BufferAttribute || attribute.gpuType === FloatType ) {
+			if ( attribute.isFloat16BufferAttribute || ( bufferType !== gl.ELEMENT_ARRAY_BUFFER && attribute.gpuType === FloatType ) ) {
 
 				if ( isWebGL2 ) {
 


### PR DESCRIPTION
Related issue: #15480, depends on #26084.

**Description**

Allows `Float16BufferAttribute` to be emulated in user-land with `BufferAttribute`, `Uint16Array`, and `BufferAttribute.gpuType = FloatType` (default in #26084).

This tries to remove the need for specialized attribute classes, although I see `instanceof` and constructor lookups in WebGPU and Nodes code. Not sure if this is a good idea with https://github.com/mrdoob/three.js/pull/25519#issuecomment-1434415612, so I've split it from changes in #26084.