### PR TITLE
Update webgl_loader_svg.html

### DIFF
--- a/examples/webgl_loader_svg.html
+++ b/examples/webgl_loader_svg.html
@@ -173,6 +173,7 @@
 					for ( const path of data.paths ) {
 
 						const fillColor = path.userData.style.fill;
+
 						if ( guiData.drawFillShapes && fillColor !== undefined && fillColor !== 'none' ) {
 
 							const material = new THREE.MeshBasicMaterial( {
@@ -184,7 +185,9 @@
 								wireframe: guiData.fillShapesWireframe
 							} );
 
-							for ( const shape of SVGLoader.createShapes( path )) {
+							const shapes = SVGLoader.createShapes( path );
+
+							for ( const shape of shapes ) {
 
 								const geometry = new THREE.ShapeGeometry( shape );
 								const mesh = new THREE.Mesh( geometry, material );

--- a/examples/webgl_loader_svg.html
+++ b/examples/webgl_loader_svg.html
@@ -162,17 +162,15 @@
 
 				loader.load( url, function ( data ) {
 
-					const paths = data.paths;
-
 					const group = new THREE.Group();
 					group.scale.multiplyScalar( 0.25 );
 					group.position.x = - 70;
 					group.position.y = 70;
 					group.scale.y *= - 1;
+					
+					let renderOrder = 0;
 
-					for ( let i = 0; i < paths.length; i ++ ) {
-
-						const path = paths[ i ];
+					for ( const path of data.paths ) {
 
 						const fillColor = path.userData.style.fill;
 						if ( guiData.drawFillShapes && fillColor !== undefined && fillColor !== 'none' ) {
@@ -186,14 +184,11 @@
 								wireframe: guiData.fillShapesWireframe
 							} );
 
-							const shapes = SVGLoader.createShapes( path );
-
-							for ( let j = 0; j < shapes.length; j ++ ) {
-
-								const shape = shapes[ j ];
+							for ( const shape of SVGLoader.createShapes( path )) {
 
 								const geometry = new THREE.ShapeGeometry( shape );
 								const mesh = new THREE.Mesh( geometry, material );
+								mesh.renderOrder = renderOrder ++;
 
 								group.add( mesh );
 
@@ -214,15 +209,14 @@
 								wireframe: guiData.strokesWireframe
 							} );
 
-							for ( let j = 0, jl = path.subPaths.length; j < jl; j ++ ) {
-
-								const subPath = path.subPaths[ j ];
+							for ( const subPath of path.subPaths ) {
 
 								const geometry = SVGLoader.pointsToStroke( subPath.getPoints(), path.userData.style );
 
 								if ( geometry ) {
 
 									const mesh = new THREE.Mesh( geometry, material );
+									mesh.renderOrder = renderOrder ++;
 
 									group.add( mesh );
 
@@ -248,6 +242,7 @@
 				camera.updateProjectionMatrix();
 
 				renderer.setSize( window.innerWidth, window.innerHeight );
+				render();
 
 			}
 


### PR DESCRIPTION
fix #26110

- assigns `renderOrder` for each mesh based on `data.paths[]` seq
- re render onresize

test https://raw.githack.com/ycw/three.js/patch-2/examples/webgl_loader_svg.html
