### PR TITLE
Docs: fixed malformed `.clone` sigature in shadermaterial.html

### DIFF
--- a/docs/api/en/materials/ShaderMaterial.html
+++ b/docs/api/en/materials/ShaderMaterial.html
@@ -462,7 +462,7 @@ this.extensions = {
 		<h2>Methods</h2>
 		<p>See the base [page:Material] class for common methods.</p>
 
-		<h3>[method:ShaderMaterial clone]() [param:ShaderMaterial this]</h3>
+		<h3>[method:ShaderMaterial clone]()</h3>
 		<p>
 			Generates a shallow copy of this material. Note that the vertexShader and
 			fragmentShader are copied `by reference`, as are the definitions of the

--- a/docs/api/fr/materials/ShaderMaterial.html
+++ b/docs/api/fr/materials/ShaderMaterial.html
@@ -423,7 +423,7 @@ et la page [page:BufferAttribute] pour un aperçu détaillé de l'API `BufferAtt
 		<h2>Méthodes</h2>
 		<p>Voir la classe [page:Material] pour les méthodes communes.</p>
 
-		<h3>[method:ShaderMaterial clone]() [param:ShaderMaterial this]</h3>
+		<h3>[method:ShaderMaterial clone]()</h3>
 		<p>
 			Génère une copie superficielle de ce matériau. Notez que le vertexShader et le fragmentShader
 			sont copiés "par référence", de même que les définitions des "attributs" ; cela signifie

--- a/docs/api/it/materials/ShaderMaterial.html
+++ b/docs/api/it/materials/ShaderMaterial.html
@@ -428,7 +428,7 @@ this.extensions = {
 		<h2>Metodi</h2>
 		<p>Vedi la classe base [page:Material] per i metodi comuni.</p>
 
-		<h3>[method:ShaderMaterial clone]() [param:ShaderMaterial this]</h3>
+		<h3>[method:ShaderMaterial clone]()</h3>
 		<p>
 			Genera una copia superficiale di questo materiale. Si noti che il vertexShader e il fragmentShader
 			sono copiati `per riferimento`, così come le definizioni degli `attributi`; questo significa

--- a/docs/api/zh/materials/ShaderMaterial.html
+++ b/docs/api/zh/materials/ShaderMaterial.html
@@ -374,7 +374,7 @@ this.extensions = {
 		<h2>方法(Methods)</h2>
 		<p>共有方法请参见其基类[page:Material]。</p>
 
-		<h3>[method:ShaderMaterial clone]() [param:ShaderMaterial this]</h3>
+		<h3>[method:ShaderMaterial clone]()</h3>
 		<p> 创建该材质的一个浅拷贝。需要注意的是，vertexShader和fragmentShader使用<em>引用拷贝</em>；
 			*attributes*的定义也是如此;
 			这意味着，克隆的材质将共享相同的编译[page:WebGLProgram]；


### PR DESCRIPTION
This PR fixs the malformed sig of `.clone`
