### PR TITLE
WebGLRenderer: Add pixelRatio to transmissionRenderTarget

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1338,7 +1338,7 @@ class WebGLRenderer {
 
 				const isWebGL2 = capabilities.isWebGL2;
 
-				_transmissionRenderTarget = new WebGLRenderTarget( 1024, 1024, {
+				_transmissionRenderTarget = new WebGLRenderTarget( 1024 * _pixelRatio, 1024 * _pixelRatio, {
 					generateMipmaps: true,
 					type: extensions.has( 'EXT_color_buffer_half_float' ) ? HalfFloatType : UnsignedByteType,
 					minFilter: LinearMipmapLinearFilter,


### PR DESCRIPTION
Related issue: #25494

**Description**

I'm okay with having the size being POT but I think we should at least take the pixelRatio into account.
Otherwise it's too ugly.

| Before | After |
| --- | --- |
| <img width="939" alt="Screenshot 2023-05-25 at 10 11 24" src="https://github.com/mrdoob/three.js/assets/97088/9964b1f2-5a4e-4a74-84b5-9b9bd6c4b5db"> | <img width="939" alt="Screenshot 2023-05-25 at 10 11 08" src="https://github.com/mrdoob/three.js/assets/97088/536a76d0-2524-46d2-ac4a-f765458f28a6"> |
| <img width="939" alt="Screenshot 2023-05-25 at 10 11 54" src="https://github.com/mrdoob/three.js/assets/97088/857aa451-b6d4-4edc-9035-3818fbe3efd4"> | <img width="939" alt="Screenshot 2023-05-25 at 10 12 04" src="https://github.com/mrdoob/three.js/assets/97088/7c810798-bb73-4d15-94b0-039d53407a3e"> |
