### PR TITLE
Allow flexibility on DragControls for multi-part GLTF models & other hierarchical objects

### DIFF
--- a/docs/examples/en/controls/DragControls.html
+++ b/docs/examples/en/controls/DragControls.html
@@ -106,6 +106,16 @@
 			If set to `true`, [name] does not transform individual objects but the entire group. Default is `false`.
 		</p>
 
+		<h3>[property:Boolean transformDescendants]</h3>
+		<p>
+			This option can be set to prevent DragControls from operating on descendant objects that are not specified
+			in the array of draggable 3D objects.
+			When this option is set, such descendant objects can be dragged individually.
+			When this option is not set, rather than descendant objects being dragged individually, the object that is dragged will be
+			the closest of its ancestors that appears in the array of draggable 3D objects.
+			Default is `true`.
+		</p>
+
 		<h2>Methods</h2>
 
 		<p>See the base [page:EventDispatcher] class for common methods.</p>

--- a/examples/jsm/controls/DragControls.js
+++ b/examples/jsm/controls/DragControls.js
@@ -142,26 +142,31 @@ class DragControls extends EventDispatcher {
 
 		}
 
-		function objectFromIntersection(intersection) {
+		function objectFromIntersection( intersection ) {
 
-			if (scope.transformGroup === true) return _objects[0]
+			if ( scope.transformGroup === true ) return _objects[ 0 ];
 
-			if (scope.transformDescendants === true) return intersection.object
+			if ( scope.transformDescendants === true ) return intersection.object;
 
-			function findAncestorInObjectsList(object) {
+			function findAncestorInObjectsList( object ) {
 
-				if (_objects.includes(object)) {
-					return object
+				if ( _objects.includes( object ) ) {
+
+					return object;
+
+				} else if ( object.parent ) {
+
+					return findAncestorInObjectsList( object.parent );
+
+				} else {
+
+					return null;
+
 				}
-				else if (object.parent) {
-					return findAncestorInObjectsList(object.parent)
-				}
-				else {
-					return null
-				}
+
 			}
 
-			return findAncestorInObjectsList(intersection.object)
+			return findAncestorInObjectsList( intersection.object );
 
 		}
 
@@ -178,7 +183,7 @@ class DragControls extends EventDispatcher {
 
 			if ( _intersections.length > 0 ) {
 
-				_selected = objectFromIntersection(_intersections[ 0 ]);
+				_selected = objectFromIntersection( _intersections[ 0 ] );
 
 				_plane.setFromNormalAndCoplanarPoint( _camera.getWorldDirection( _plane.normal ), _worldPosition.setFromMatrixPosition( _selected.matrixWorld ) );
 
@@ -229,7 +234,7 @@ class DragControls extends EventDispatcher {
 
 		this.enabled = true;
 		this.transformGroup = false;
-    this.transformDescendants = true;
+		this.transformDescendants = true;
 
 		this.activate = activate;
 		this.deactivate = deactivate;

--- a/examples/jsm/controls/DragControls.js
+++ b/examples/jsm/controls/DragControls.js
@@ -142,28 +142,28 @@ class DragControls extends EventDispatcher {
 
 		}
 
-    function objectFromIntersection(intersection) {
+		function objectFromIntersection(intersection) {
 
-      if ( scope.transformGroup === true ) return _objects[0]
-  
-      if ( scope.transformDescendants === true ) return intersection.object
-  
-      function findAncestorInObjectsList(object) {
-  
-        if (_objects.includes(object)) {
-          return object
-        }
-        else if (object.parent) {
-          return findAncestorInObjectsList(object.parent)
-        }
-        else {
-          return null
-        }
-      }
-  
-      return findAncestorInObjectsList(intersection.object)
-  
-    }
+			if (scope.transformGroup === true) return _objects[0]
+
+			if (scope.transformDescendants === true) return intersection.object
+
+			function findAncestorInObjectsList(object) {
+
+				if (_objects.includes(object)) {
+					return object
+				}
+				else if (object.parent) {
+					return findAncestorInObjectsList(object.parent)
+				}
+				else {
+					return null
+				}
+			}
+
+			return findAncestorInObjectsList(intersection.object)
+
+		}
 
 		function onPointerDown( event ) {
 

--- a/examples/jsm/controls/DragControls.js
+++ b/examples/jsm/controls/DragControls.js
@@ -142,6 +142,29 @@ class DragControls extends EventDispatcher {
 
 		}
 
+    function objectFromIntersection(intersection) {
+
+      if ( scope.transformGroup === true ) return _objects[0]
+  
+      if ( scope.transformDescendants === true ) return intersection.object
+  
+      function findAncestorInObjectsList(object) {
+  
+        if (_objects.includes(object)) {
+          return object
+        }
+        else if (object.parent) {
+          return findAncestorInObjectsList(object.parent)
+        }
+        else {
+          return null
+        }
+      }
+  
+      return findAncestorInObjectsList(intersection.object)
+  
+    }
+
 		function onPointerDown( event ) {
 
 			if ( scope.enabled === false ) return;
@@ -155,7 +178,7 @@ class DragControls extends EventDispatcher {
 
 			if ( _intersections.length > 0 ) {
 
-				_selected = ( scope.transformGroup === true ) ? _objects[ 0 ] : _intersections[ 0 ].object;
+				_selected = objectFromIntersection(_intersections[ 0 ]);
 
 				_plane.setFromNormalAndCoplanarPoint( _camera.getWorldDirection( _plane.normal ), _worldPosition.setFromMatrixPosition( _selected.matrixWorld ) );
 
@@ -206,6 +229,7 @@ class DragControls extends EventDispatcher {
 
 		this.enabled = true;
 		this.transformGroup = false;
+    this.transformDescendants = true;
 
 		this.activate = activate;
 		this.deactivate = deactivate;


### PR DESCRIPTION
I haven't raised a related issue - I can do so if required

**Description**

DragControls doesn't offer the flexibility needed to use DragControls with multi-part GLTF models (or other smilar hierarchical objects).

DragControls can be configured on an array of object3Ds.  The drag behaviour then operates on all these objects, and all their descendants.

When dragging happens, it is applied to the object3D that the raycaster hit.  If this is a descendant of an object specified in the array, then the descendant will be dragged independently of the ancestor object.

So if I have a multi-part GLTF, which gets mapped into a hierarchy of object3Ds, I can't use DragControls to move the GLTF as a whole.   If I click and drag on it, I'll end up dragging the part of the model I clicked on, rather than the whole model.

DragControls does have a config option `transformGroup` which results in the entire group of objects being transformed (ignoring where the raycaster hit completely).  However this can only be used when DragControls is being used on a single object.  It can't be used when I want a single instance of DragControls to allow dragging of multiple objects.

Proposed fix is another flag, "transformDescendants".  This is set to "true" by defult, preserving current behaviour.

When this is set to "false" (and transformGroup is also "false"), then the logic for which object to move is as follows:
- if the object hit by the raycaster is in the specified aray of objects, allow it to be dragged
- else look for the closest ancestor that is in the specified array of objects, and apply the drag to that object instead.

So far this fix has been tested in various A-Frame contexts: https://github.com/SeregPie/aframe-drag-controls/pull/2

However the same issue exists for vanilla Three.js when using multi-part GLTF models.  Happy to create a pure Three.js example to illustrate the problem if that would be helpful.