### PR TITLE
Introduce ExposureShader

### DIFF
--- a/examples/jsm/shaders/ExposureShader.js
+++ b/examples/jsm/shaders/ExposureShader.js
@@ -1,0 +1,44 @@
+/**
+ * Exposure shader
+ */
+
+const ExposureShader = {
+
+	name: 'ExposureShader',
+
+	uniforms: {
+
+		'tDiffuse': { value: null },
+		'exposure': { value: 1.0 }
+
+	},
+
+	vertexShader: /* glsl */`
+
+		varying vec2 vUv;
+
+		void main() {
+
+			vUv = uv;
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+
+		}`,
+
+	fragmentShader: /* glsl */`
+
+		uniform float exposure;
+
+		uniform sampler2D tDiffuse;
+
+		varying vec2 vUv;
+
+		void main() {
+
+			gl_FragColor = texture2D( tDiffuse, vUv );
+			gl_FragColor.rgb *= exposure;
+
+		}`
+
+};
+
+export { ExposureShader };


### PR DESCRIPTION
> This is an exposure-only pass. Useful for rendering HDR output to an archive EXR in working color space, for example.

As suggested in https://github.com/mrdoob/three.js/pull/26130#issuecomment-1562138017.