### PR TITLE
PositionalAudio: Implement missing `connect()` method.

### DIFF
--- a/src/audio/PositionalAudio.js
+++ b/src/audio/PositionalAudio.js
@@ -19,7 +19,6 @@ class PositionalAudio extends Audio {
 
 	}
 	
-	
 	connect() {
 
 		super.connect();

--- a/src/audio/PositionalAudio.js
+++ b/src/audio/PositionalAudio.js
@@ -18,6 +18,15 @@ class PositionalAudio extends Audio {
 		this.panner.connect( this.gain );
 
 	}
+	
+	
+	connect() {
+
+		super.connect();
+
+		this.panner.connect( this.gain );
+
+	}
 
 	disconnect() {
 

--- a/src/audio/PositionalAudio.js
+++ b/src/audio/PositionalAudio.js
@@ -18,7 +18,7 @@ class PositionalAudio extends Audio {
 		this.panner.connect( this.gain );
 
 	}
-	
+
 	connect() {
 
 		super.connect();


### PR DESCRIPTION
**Description**

If you look at the constructor method of `PositionalAudio`, panner is connected to `this.gain`:

```javascript

	constructor( listener ) {

		super( listener );

		this.panner = this.context.createPanner();
		this.panner.panningModel = 'HRTF';
		this.panner.connect( this.gain ); // <--------- HERE

	}
```

If you call `.disconnect()` it would disconnect panner from `this.gain`.

```javascript
	disconnect() {

		super.disconnect();

		this.panner.disconnect( this.gain ); // <------------- HERE

	}
```

But as `PositionalAudio` doesn't extend `connect()` method as well, **then when you try to connect it back, panner would not connect back to `this.gain`.**

```javascript
//...
class PositionalAudio extends Audio {

	constructor( listener ) {

		super( listener );

		this.panner = this.context.createPanner();
		this.panner.panningModel = 'HRTF';
		this.panner.connect( this.gain ); 

	}

	disconnect() {

		super.disconnect();

		this.panner.disconnect( this.gain );

	}
	
	// <------------- NO connect method() HERE!

	getOutput() {

		return this.panner;

	}

	getRefDistance() {

		return this.panner.refDistance;

	}
	//...
```
