### PR TITLE
try to sort docs page content alphabetically

### DIFF
--- a/docs/page.js
+++ b/docs/page.js
@@ -76,6 +76,8 @@ function onDocumentLoad() {
 
 	document.body.innerHTML = text;
 
+	order( document.body );
+
 	if ( window.parent.getPageURL ) {
 
 		const links = document.querySelectorAll( '.links' );
@@ -166,4 +168,44 @@ function onDocumentLoad() {
 
 	document.head.appendChild( prettify );
 
+}
+
+function order(body) {
+    let sections = [],
+        currentSection = [],
+        currentSubSection = [];
+    while(body.childNodes.length) {
+        const child = body.firstChild;
+        child.remove();
+        if(child.nodeName === 'H3') {
+            if(currentSubSection.length) currentSection.push(currentSubSection);
+            currentSubSection = [];
+        }
+        if(child.nodeName === 'H2') {
+            if(currentSubSection.length) currentSection.push(currentSubSection);
+            currentSubSection = [];
+            if(currentSection.length) sections.push(currentSection);
+            currentSection = [];
+        }
+        currentSubSection.push(child);
+    }
+    currentSection.push(currentSubSection);
+    sections.push(currentSection);
+
+    sections.forEach(function(section) {
+        section.sort(function(a, b) {
+            a = a[0]; b = b[0];
+            if(a.nodeName !== 'H3') return -1;
+            a = a.textContent; b = b.textContent;
+            if(a > b) return 1;
+            if(a < b) return -1;
+            return 0;
+        });
+
+        section.forEach(function(subSection) {
+            subSection.forEach(function(element) {
+                body.appendChild(element);
+            });
+        });
+    });
 }


### PR DESCRIPTION
Ok, so I was browsing the docs the other day and noticed that some pages are not in alphabetic order, which means people can miss the property or method when they are lower in the page, right? But, even you find all the pages with said issue, reorder them and commit, there is still a chance that new commits will break the order again. So I thought, what if we order this in javascript? For example, here is [Texture page](https://threejs.org/docs/#api/en/textures/Texture) before - [click for long image](https://github.com/mrdoob/three.js/assets/242577/7b22a1b4-46e2-489f-9164-f4a4fcf86750) - and after - [long image again](https://github.com/mrdoob/three.js/assets/242577/462e9382-f6c1-4452-b9b4-1d884b7e7cf3). You can also sort of test it [live at githack](https://raw.githack.com/makc/three.js.fork/sorted-docs/docs/index.html#api/en/textures/Texture) but beware that githack cant load prettify script so it looks buggy where it isn't. I did not check all the docs yet, and no idea if I will - so this PR is going to be "draft", I guess? Let me know if you are interested and how do you suppose we can verify it.
