### PR TITLE
FlyControls: Introduce `enabled` property.

### DIFF
--- a/examples/jsm/controls/FlyControls.js
+++ b/examples/jsm/controls/FlyControls.js
@@ -85,7 +85,7 @@ class FlyControls extends EventDispatcher {
 
 		this.keyup = function ( event ) {
 
-			if ( scope.enabled === false ) return;
+			if ( this.enabled === false ) return;
 
 			switch ( event.code ) {
 
@@ -119,7 +119,7 @@ class FlyControls extends EventDispatcher {
 
 		this.pointerdown = function ( event ) {
 
-			if ( scope.enabled === false ) return;
+			if ( this.enabled === false ) return;
 
 			if ( this.dragToLook ) {
 
@@ -142,7 +142,7 @@ class FlyControls extends EventDispatcher {
 
 		this.pointermove = function ( event ) {
 
-			if ( scope.enabled === false ) return;
+			if ( this.enabled === false ) return;
 
 			if ( ! this.dragToLook || this.status > 0 ) {
 
@@ -161,7 +161,7 @@ class FlyControls extends EventDispatcher {
 
 		this.pointerup = function ( event ) {
 
-			if ( scope.enabled === false ) return;
+			if ( this.enabled === false ) return;
 
 			if ( this.dragToLook ) {
 
@@ -188,7 +188,7 @@ class FlyControls extends EventDispatcher {
 
 		this.contextMenu = function ( event ) {
 
-			if ( scope.enabled === false ) return;
+			if ( this.enabled === false ) return;
 
 			event.preventDefault();
 
@@ -196,7 +196,7 @@ class FlyControls extends EventDispatcher {
 
 		this.update = function ( delta ) {
 
-			if ( scope.enabled === false ) return;
+			if ( this.enabled === false ) return;
 
 			const moveMult = delta * scope.movementSpeed;
 			const rotMult = delta * scope.rollSpeed;

--- a/examples/jsm/controls/FlyControls.js
+++ b/examples/jsm/controls/FlyControls.js
@@ -17,6 +17,9 @@ class FlyControls extends EventDispatcher {
 
 		// API
 
+		// Set to false to disable this control
+		this.enabled = true;
+
 		this.movementSpeed = 1.0;
 		this.rollSpeed = 0.005;
 
@@ -44,7 +47,7 @@ class FlyControls extends EventDispatcher {
 
 		this.keydown = function ( event ) {
 
-			if ( event.altKey ) {
+			if ( event.altKey || this.enabled === false ) {
 
 				return;
 
@@ -82,6 +85,8 @@ class FlyControls extends EventDispatcher {
 
 		this.keyup = function ( event ) {
 
+			if ( scope.enabled === false ) return;
+
 			switch ( event.code ) {
 
 				case 'ShiftLeft':
@@ -114,6 +119,8 @@ class FlyControls extends EventDispatcher {
 
 		this.pointerdown = function ( event ) {
 
+			if ( scope.enabled === false ) return;
+
 			if ( this.dragToLook ) {
 
 				this.status ++;
@@ -135,6 +142,8 @@ class FlyControls extends EventDispatcher {
 
 		this.pointermove = function ( event ) {
 
+			if ( scope.enabled === false ) return;
+
 			if ( ! this.dragToLook || this.status > 0 ) {
 
 				const container = this.getContainerDimensions();
@@ -151,6 +160,8 @@ class FlyControls extends EventDispatcher {
 		};
 
 		this.pointerup = function ( event ) {
+
+			if ( scope.enabled === false ) return;
 
 			if ( this.dragToLook ) {
 
@@ -175,7 +186,17 @@ class FlyControls extends EventDispatcher {
 
 		};
 
+		this.contextMenu = function ( event ) {
+
+			if ( scope.enabled === false ) return;
+
+			event.preventDefault();
+
+		};
+
 		this.update = function ( delta ) {
+
+			if ( scope.enabled === false ) return;
 
 			const moveMult = delta * scope.movementSpeed;
 			const rotMult = delta * scope.rollSpeed;
@@ -244,7 +265,7 @@ class FlyControls extends EventDispatcher {
 
 		this.dispose = function () {
 
-			this.domElement.removeEventListener( 'contextmenu', contextmenu );
+			this.domElement.removeEventListener( 'contextmenu', _contextmenu );
 			this.domElement.removeEventListener( 'pointerdown', _pointerdown );
 			this.domElement.removeEventListener( 'pointermove', _pointermove );
 			this.domElement.removeEventListener( 'pointerup', _pointerup );
@@ -254,13 +275,14 @@ class FlyControls extends EventDispatcher {
 
 		};
 
+		const _contextmenu = this.contextMenu.bind( this );
 		const _pointermove = this.pointermove.bind( this );
 		const _pointerdown = this.pointerdown.bind( this );
 		const _pointerup = this.pointerup.bind( this );
 		const _keydown = this.keydown.bind( this );
 		const _keyup = this.keyup.bind( this );
 
-		this.domElement.addEventListener( 'contextmenu', contextmenu );
+		this.domElement.addEventListener( 'contextmenu', _contextmenu );
 		this.domElement.addEventListener( 'pointerdown', _pointerdown );
 		this.domElement.addEventListener( 'pointermove', _pointermove );
 		this.domElement.addEventListener( 'pointerup', _pointerup );
@@ -272,12 +294,6 @@ class FlyControls extends EventDispatcher {
 		this.updateRotationVector();
 
 	}
-
-}
-
-function contextmenu( event ) {
-
-	event.preventDefault();
 
 }
 


### PR DESCRIPTION
**Description**

Recently, I came across a bug in FlyControls class. This class has a variable named "status" which controls whether the user is dragging the mouse/pointer. This variable is a counter, which is incremented on pointerDown event, and decremented on pointerUp event. On pointerMove event, the camera only rotates if this "status" variable is greater than 0 (when dragToLook is set to True).

In my application, I have an input form of file type. When the file dialog opens up, if it is above the threejs canvas, and the user selects any file by double-clicking, this dispatch only one pointerUp event to the FlyControls. As a consequence, the FlyControls remains in an invalid state, because the "status" variable is negative, and the user can never rotate the camera again.  

I've seen similar issues with this missing pointer/mouse up event: [example](https://stackoverflow.com/questions/25893328/avoid-mouseup-event-when-selecting-a-file-from-dialog-when-double-clicking). This issue occurs in all majors browsers. So, to avoid this problem, I change this control variable to a boolean that only indicates whether the user is dragging the pointer or not. I can't see any reason for this variable to be a counter. 

A JSFiddle [example](https://jsfiddle.net/vqwub1e8/) to reproduce the bug: just remind to reposition the file dialog over the canvas, in such a way the double click to the file is also over the canvas. After this, you are not allowed to rotate the camera.