### PR TITLE
CubeTextureLoader: Return sRGB textures by default.

### DIFF
--- a/examples/webaudio_orientation.html
+++ b/examples/webaudio_orientation.html
@@ -63,8 +63,6 @@
 				.setPath( 'textures/cube/SwedishRoyalCastle/' )
 				.load( [ 'px.jpg', 'nx.jpg', 'py.jpg', 'ny.jpg', 'pz.jpg', 'nz.jpg' ] );
 
-			reflectionCube.colorSpace = THREE.SRGBColorSpace;
-
 			scene = new THREE.Scene();
 			scene.background = new THREE.Color( 0xa0a0a0 );
 			scene.fog = new THREE.Fog( 0xa0a0a0, 2, 20 );

--- a/examples/webgl_effects_anaglyph.html
+++ b/examples/webgl_effects_anaglyph.html
@@ -64,7 +64,6 @@
 				];
 
 				const textureCube = new THREE.CubeTextureLoader().load( urls );
-				textureCube.colorSpace = THREE.SRGBColorSpace;
 
 				scene = new THREE.Scene();
 				scene.background = textureCube;

--- a/examples/webgl_effects_parallaxbarrier.html
+++ b/examples/webgl_effects_parallaxbarrier.html
@@ -65,7 +65,6 @@
 				];
 
 				const textureCube = new THREE.CubeTextureLoader().load( urls );
-				textureCube.colorSpace = THREE.SRGBColorSpace;
 
 				scene = new THREE.Scene();
 				scene.background = textureCube;

--- a/examples/webgl_effects_stereo.html
+++ b/examples/webgl_effects_stereo.html
@@ -57,7 +57,6 @@
 				scene.background = new THREE.CubeTextureLoader()
 					.setPath( 'textures/cube/Park3Med/' )
 					.load( [ 'px.jpg', 'nx.jpg', 'py.jpg', 'ny.jpg', 'pz.jpg', 'nz.jpg' ] );
-				scene.background.colorSpace = THREE.SRGBColorSpace;
 
 				const geometry = new THREE.SphereGeometry( 100, 32, 16 );
 
@@ -65,7 +64,6 @@
 					.setPath( 'textures/cube/Park3Med/' )
 					.load( [ 'px.jpg', 'nx.jpg', 'py.jpg', 'ny.jpg', 'pz.jpg', 'nz.jpg' ] );
 				textureCube.mapping = THREE.CubeRefractionMapping;
-				textureCube.colorSpace = THREE.SRGBColorSpace;
 
 				const material = new THREE.MeshBasicMaterial( { color: 0xffffff, envMap: textureCube, refractionRatio: 0.95 } );
 

--- a/examples/webgl_geometry_teapot.html
+++ b/examples/webgl_geometry_teapot.html
@@ -96,7 +96,6 @@
 				const urls = [ 'px.png', 'nx.png', 'py.png', 'ny.png', 'pz.png', 'nz.png' ];
 
 				textureCube = new THREE.CubeTextureLoader().setPath( path ).load( urls );
-				textureCube.colorSpace = THREE.SRGBColorSpace;
 
 				materials[ 'wireframe' ] = new THREE.MeshBasicMaterial( { wireframe: true } );
 				materials[ 'flat' ] = new THREE.MeshPhongMaterial( { specular: 0x000000, flatShading: true, side: THREE.DoubleSide } );

--- a/examples/webgl_lightprobe.html
+++ b/examples/webgl_lightprobe.html
@@ -100,8 +100,6 @@
 
 				new THREE.CubeTextureLoader().load( urls, function ( cubeTexture ) {
 
-					cubeTexture.colorSpace = THREE.SRGBColorSpace;
-
 					scene.background = cubeTexture;
 
 					lightProbe.copy( LightProbeGenerator.fromCubeTexture( cubeTexture ) );

--- a/examples/webgl_lightprobe_cubecamera.html
+++ b/examples/webgl_lightprobe_cubecamera.html
@@ -84,8 +84,6 @@
 
 				new THREE.CubeTextureLoader().load( urls, function ( cubeTexture ) {
 
-					cubeTexture.colorSpace = THREE.SRGBColorSpace;
-
 					scene.background = cubeTexture;
 
 					cubeCamera.update( renderer, scene );

--- a/examples/webgl_marchingcubes.html
+++ b/examples/webgl_marchingcubes.html
@@ -160,9 +160,6 @@
 			const refractionCube = cubeTextureLoader.load( urls );
 			refractionCube.mapping = THREE.CubeRefractionMapping;
 
-			reflectionCube.colorSpace = THREE.SRGBColorSpace;
-			refractionCube.colorSpace = THREE.SRGBColorSpace;
-
 			// toons
 
 			const toonMaterial1 = createShaderMaterial( ToonShader1, light, ambientLight );

--- a/examples/webgl_materials_cubemap.html
+++ b/examples/webgl_materials_cubemap.html
@@ -63,9 +63,7 @@
 				];
 
 				const reflectionCube = new THREE.CubeTextureLoader().load( urls );
-				reflectionCube.colorSpace = THREE.SRGBColorSpace;
 				const refractionCube = new THREE.CubeTextureLoader().load( urls );
-				refractionCube.colorSpace = THREE.SRGBColorSpace;
 				refractionCube.mapping = THREE.CubeRefractionMapping;
 
 				scene = new THREE.Scene();

--- a/examples/webgl_materials_cubemap_refraction.html
+++ b/examples/webgl_materials_cubemap_refraction.html
@@ -68,7 +68,6 @@
 				];
 
 				const textureCube = new THREE.CubeTextureLoader().load( urls );
-				textureCube.colorSpace = THREE.SRGBColorSpace;
 				textureCube.mapping = THREE.CubeRefractionMapping;
 
 				scene = new THREE.Scene();

--- a/examples/webgl_materials_displacementmap.html
+++ b/examples/webgl_materials_displacementmap.html
@@ -162,7 +162,6 @@
 				];
 
 				const reflectionCube = new THREE.CubeTextureLoader().load( urls );
-				reflectionCube.colorSpace = THREE.SRGBColorSpace;
 
 				// textures
 

--- a/examples/webgl_materials_envmaps.html
+++ b/examples/webgl_materials_envmaps.html
@@ -57,7 +57,6 @@
 				loader.setPath( 'textures/cube/Bridge2/' );
 
 				textureCube = loader.load( [ 'posx.jpg', 'negx.jpg', 'posy.jpg', 'negy.jpg', 'posz.jpg', 'negz.jpg' ] );
-				textureCube.colorSpace = THREE.SRGBColorSpace;
 
 				const textureLoader = new THREE.TextureLoader();
 

--- a/examples/webgl_materials_envmaps_hdr.html
+++ b/examples/webgl_materials_envmaps_hdr.html
@@ -116,8 +116,6 @@
 					.setPath( './textures/cube/pisa/' )
 					.load( ldrUrls, function () {
 
-						ldrCubeMap.colorSpace = THREE.SRGBColorSpace;
-
 						ldrCubeRenderTarget = pmremGenerator.fromCubemap( ldrCubeMap );
 
 					} );

--- a/examples/webgl_nodes_materials_instance_uniform.html
+++ b/examples/webgl_nodes_materials_instance_uniform.html
@@ -100,7 +100,6 @@
 				];
 
 				const cubeMap = new THREE.CubeTextureLoader().load( urls );
-				cubeMap.colorSpace = THREE.SRGBColorSpace;
 
 				// Material
 

--- a/examples/webgl_postprocessing_backgrounds.html
+++ b/examples/webgl_postprocessing_backgrounds.html
@@ -178,7 +178,6 @@
 				const ldrUrls = genCubeUrls( 'textures/cube/pisa/', '.png' );
 				new THREE.CubeTextureLoader().load( ldrUrls, function ( ldrCubeMap ) {
 
-					ldrCubeMap.colorSpace = THREE.SRGBColorSpace;
 					cubeTexturePassP = new CubeTexturePass( cameraP, ldrCubeMap );
 					composer.insertPass( cubeTexturePassP, 2 );
 

--- a/examples/webgl_postprocessing_dof.html
+++ b/examples/webgl_postprocessing_dof.html
@@ -82,7 +82,6 @@
 				];
 
 				const textureCube = new THREE.CubeTextureLoader().load( urls );
-				textureCube.colorSpace = THREE.SRGBColorSpace;
 
 				parameters = { color: 0xff4900, envMap: textureCube };
 				cubeMaterial = new THREE.MeshBasicMaterial( parameters );

--- a/examples/webgl_postprocessing_dof2.html
+++ b/examples/webgl_postprocessing_dof2.html
@@ -97,7 +97,6 @@
 							 r + 'posz.jpg', r + 'negz.jpg' ];
 
 				const textureCube = new THREE.CubeTextureLoader().load( urls );
-				textureCube.colorSpace = THREE.SRGBColorSpace;
 
 				scene.background = textureCube;
 

--- a/examples/webgl_water.html
+++ b/examples/webgl_water.html
@@ -121,7 +121,6 @@
 					'posy.jpg', 'negy.jpg',
 					'posz.jpg', 'negz.jpg'
 				] );
-				cubeTexture.colorSpace = THREE.SRGBColorSpace;
 
 				scene.background = cubeTexture;
 

--- a/examples/webgpu_cubemap_adjustments.html
+++ b/examples/webgpu_cubemap_adjustments.html
@@ -85,7 +85,6 @@
 
 				cube2Texture.generateMipmaps = true;
 				cube2Texture.minFilter = THREE.LinearMipmapLinearFilter;
-				cube2Texture.colorSpace = THREE.SRGBColorSpace;
 
 				// nodes and environment
 

--- a/examples/webgpu_cubemap_mix.html
+++ b/examples/webgpu_cubemap_mix.html
@@ -79,7 +79,6 @@
 
 				cube2Texture.generateMipmaps = true;
 				cube2Texture.minFilter = THREE.LinearMipmapLinearFilter;
-				cube2Texture.colorSpace = THREE.SRGBColorSpace;
 
 				scene.environmentNode = mix( cubeTexture( cube2Texture ), cubeTexture( cube1Texture ), oscSine( timerLocal( .1 ) ) );
 

--- a/examples/webgpu_instance_uniform.html
+++ b/examples/webgpu_instance_uniform.html
@@ -113,7 +113,6 @@
 				];
 
 				const cTexture = new THREE.CubeTextureLoader().load( urls );
-				cTexture.colorSpace = THREE.SRGBColorSpace;
 
 				// Materials
 

--- a/examples/webxr_xr_sculpt.html
+++ b/examples/webxr_xr_sculpt.html
@@ -134,7 +134,6 @@
 				];
 
 				let reflectionCube = new THREE.CubeTextureLoader().load( urls );
-				reflectionCube.colorSpace = THREE.SRGBColorSpace;
 				*/
 
 				const material = new THREE.MeshStandardMaterial( {

--- a/src/loaders/CubeTextureLoader.js
+++ b/src/loaders/CubeTextureLoader.js
@@ -1,6 +1,7 @@
 import { ImageLoader } from './ImageLoader.js';
 import { CubeTexture } from '../textures/CubeTexture.js';
 import { Loader } from './Loader.js';
+import { SRGBColorSpace } from '../constants.js';
 
 class CubeTextureLoader extends Loader {
 
@@ -13,6 +14,7 @@ class CubeTextureLoader extends Loader {
 	load( urls, onLoad, onProgress, onError ) {
 
 		const texture = new CubeTexture();
+		texture.colorSpace = SRGBColorSpace;
 
 		const loader = new ImageLoader( this.manager );
 		loader.setCrossOrigin( this.crossOrigin );


### PR DESCRIPTION
Related issue: #23614

**Description**

When working at the sRGB migration, I've noticed that the examples use `CubeTextureLoader` to load always sRGB textures. Compared to `TextureLoader`, you usually do not use `CubeTextureLoader` to load non-color data like normal, roughness or ao maps. Even for HDR textures `three.js` offers specific loaders. 

Because of this and because sRGB output is the default since `r152`, I think it's safe to change the color space of the loaded cube texture to `SRGBColorSpace`. 
