### PR TITLE
Nodes: Fix circular dependency

### DIFF
--- a/examples/jsm/nodes/core/NodeBuilder.js
+++ b/examples/jsm/nodes/core/NodeBuilder.js
@@ -5,6 +5,7 @@ import NodeVar from './NodeVar.js';
 import NodeCode from './NodeCode.js';
 import NodeKeywords from './NodeKeywords.js';
 import NodeCache from './NodeCache.js';
+import { createNodeMaterialFromType } from '../materials/NodeMaterial.js';
 import { NodeUpdateType, defaultBuildStages, shaderStages } from './constants.js';
 
 import { REVISION, NoColorSpace, LinearEncoding, sRGBEncoding, SRGBColorSpace, Color, Vector2, Vector3, Vector4, Float16BufferAttribute } from 'three';
@@ -918,6 +919,12 @@ class NodeBuilder {
 		this.buildCode();
 
 		return this;
+
+	}
+
+	createNodeMaterial( type ) {
+
+		return createNodeMaterialFromType( type );
 
 	}
 

--- a/examples/jsm/nodes/lighting/AnalyticLightNode.js
+++ b/examples/jsm/nodes/lighting/AnalyticLightNode.js
@@ -8,7 +8,6 @@ import { texture } from '../accessors/TextureNode.js';
 import { positionWorld } from '../accessors/PositionNode.js';
 //import { step } from '../math/MathNode.js';
 import { cond } from '../math/CondNode.js';
-import MeshBasicNodeMaterial from '../materials/MeshBasicNodeMaterial.js';
 
 import { Color, DepthTexture, NearestFilter } from 'three';
 
@@ -44,7 +43,7 @@ class AnalyticLightNode extends LightingNode {
 
 		if ( shadowNode === null ) {
 
-			if ( depthMaterial === null ) depthMaterial = new MeshBasicNodeMaterial();
+			if ( depthMaterial === null ) depthMaterial = builder.createNodeMaterial( 'MeshBasicNodeMaterial' );
 
 			const shadow = this.light.shadow;
 			const rtt = builder.getRenderTarget( shadow.mapSize.width, shadow.mapSize.height );


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/26161, https://github.com/mrdoob/three.js/issues/25947#issuecomment-1559650018

**Description**

Fix circular dependency and add `NodeBuilder.createNodeMaterial( type )`
