### PR TITLE
OrbitControls: Add zoom to cursor

### DIFF
--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -7,7 +7,8 @@ import {
 	Vector2,
 	Vector3,
 	Plane,
-	Ray
+	Ray,
+	MathUtils
 } from 'three';
 
 // OrbitControls performs orbiting, dollying (zooming), and panning.
@@ -22,6 +23,7 @@ const _startEvent = { type: 'start' };
 const _endEvent = { type: 'end' };
 const _ray = new Ray();
 const _plane = new Plane();
+const TILT_LIMIT = Math.cos( 70 * MathUtils.DEG2RAD );
 
 class OrbitControls extends EventDispatcher {
 
@@ -342,9 +344,9 @@ class OrbitControls extends EventDispatcher {
 							_ray.origin.copy( scope.object.position );
 							_ray.direction.set( 0, 0, - 1 ).transformDirection( scope.object.matrix );
 
-							// if the camera is ~30 degrees above the horizon then don't adjust the focus target to avoid
+							// if the camera is ~20 degrees above the horizon then don't adjust the focus target to avoid
 							// extremely large values
-							if ( Math.abs( scope.object.up.dot( _ray.direction ) ) < 0.3 ) {
+							if ( Math.abs( scope.object.up.dot( _ray.direction ) ) < TILT_LIMIT ) {
 
 								object.lookAt( scope.target );
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -249,7 +249,7 @@ class OrbitControls extends EventDispatcher {
 
 				// adjust the camera position based on zoom only if we're not zooming to the cursor or if it's an ortho camera
 				// we adjust zoom later in these cases
-				if ( scope.zoomToCursor || scope.object.isOrthographicCamera ) {
+				if ( scope.zoomToCursor && performCursorZoom || scope.object.isOrthographicCamera ) {
 
 					spherical.radius = clampDistance( spherical.radius );
 
@@ -286,7 +286,7 @@ class OrbitControls extends EventDispatcher {
 
 				// adjust camera position
 				let zoomChanged = false;
-				if ( scope.zoomToCursor ) {
+				if ( scope.zoomToCursor && performCursorZoom ) {
 
 					let newRadius = null;
 					if ( scope.object.isPerspectiveCamera ) {
@@ -359,6 +359,7 @@ class OrbitControls extends EventDispatcher {
 				}
 
 				scale = 1;
+				performCursorZoom = false;
 
 				// update condition is:
 				// min(camera displacement, camera rotation in radians)^2 > EPS
@@ -452,6 +453,7 @@ class OrbitControls extends EventDispatcher {
 
 		const dollyDirection = new Vector3();
 		const mouse = new Vector2();
+		let performCursorZoom = false;
 
 		const pointers = [];
 		const pointerPositions = {};
@@ -592,6 +594,14 @@ class OrbitControls extends EventDispatcher {
 		}
 
 		function updateMouseParameters( event ) {
+
+			if ( ! scope.zoomToCursor ) {
+
+				return;
+
+			}
+
+			performCursorZoom = true;
 
 			const x = event.clientX - scope.domElement.clientLeft;
 			const y = event.clientY - scope.domElement.clientTop;

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -251,11 +251,11 @@ class OrbitControls extends EventDispatcher {
 				// we adjust zoom later in these cases
 				if ( scope.zoomToCursor || scope.object.isOrthographicCamera ) {
 
-					spherical.radius = Math.max( scope.minDistance, Math.min( scope.maxDistance, spherical.radius ) );
+					spherical.radius = clampDistance( spherical.radius );
 
 				} else {
 
-					spherical.radius = Math.max( scope.minDistance, Math.min( scope.maxDistance, spherical.radius * scale ) );
+					spherical.radius = clampDistance( spherical.radius * scale );
 
 				}
 
@@ -294,8 +294,7 @@ class OrbitControls extends EventDispatcher {
 						// move the camera down the pointer ray
 						// this method avoids floating point error
 						const prevRadius = offset.length();
-						newRadius = prevRadius * scale;
-						newRadius = Math.max( scope.minDistance, Math.min( scope.maxDistance, newRadius ) );
+						newRadius = clampDistance( prevRadius * scale );
 
 						const radiusDelta = prevRadius - newRadius;
 						scope.object.position.addScaledVector( dollyDirection, radiusDelta );
@@ -603,6 +602,12 @@ class OrbitControls extends EventDispatcher {
 			mouse.y = - ( y / h ) * 2 + 1;
 
 			dollyDirection.set( mouse.x, mouse.y, 1 ).unproject( object ).sub( object.position ).normalize();
+
+		}
+
+		function clampDistance( dist ) {
+
+			return Math.max( scope.minDistance, Math.min( scope.maxDistance, dist ) );
 
 		}
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -558,6 +558,14 @@ class OrbitControls extends EventDispatcher {
 
 		}
 
+		function updateMouseParameters( event ) {
+
+			mouse.x = ( event.clientX / window.innerWidth ) * 2 - 1;
+			mouse.y = - ( event.clientY / window.innerHeight ) * 2 + 1;
+			dollyDirection.set( mouse.x, mouse.y, 1 ).unproject( object ).sub( object.position ).normalize();
+
+		}
+
 		//
 		// event callbacks - update the object state
 		//
@@ -570,6 +578,7 @@ class OrbitControls extends EventDispatcher {
 
 		function handleMouseDownDolly( event ) {
 
+			updateMouseParameters( event );
 			dollyStart.set( event.clientX, event.clientY );
 
 		}
@@ -636,9 +645,7 @@ class OrbitControls extends EventDispatcher {
 
 		function handleMouseWheel( event ) {
 
-			mouse.x = ( event.clientX / window.innerWidth ) * 2 - 1;
-			mouse.y = - ( event.clientY / window.innerHeight ) * 2 + 1;
-			dollyDirection.set( mouse.x, mouse.y, 1 ).unproject( object ).sub( object.position ).normalize();
+			updateMouseParameters( event );
 
 			if ( event.deltaY < 0 ) {
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -20,6 +20,8 @@ import {
 const _changeEvent = { type: 'change' };
 const _startEvent = { type: 'start' };
 const _endEvent = { type: 'end' };
+const _ray = new Ray();
+const _plane = new Plane();
 
 class OrbitControls extends EventDispatcher {
 
@@ -325,14 +327,12 @@ class OrbitControls extends EventDispatcher {
 						} else {
 
 							// get the ray and translation plane to compute target
-							const ray = new Ray();
-							ray.origin.copy( scope.object.position );
-							ray.direction.set( 0, 0, - 1 ).transformDirection( scope.object.matrix );
+							_ray.origin.copy( scope.object.position );
+							_ray.direction.set( 0, 0, - 1 ).transformDirection( scope.object.matrix );
 
-							const plane = new Plane();
-							plane.setFromNormalAndCoplanarPoint( scope.object.up, scope.target );
+							_plane.setFromNormalAndCoplanarPoint( scope.object.up, scope.target );
 
-							ray.intersectPlane( plane, scope.target );
+							_ray.intersectPlane( _plane, scope.target );
 
 						}
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -303,6 +303,9 @@ class OrbitControls extends EventDispatcher {
 
 					} else {
 
+						console.warn( 'WARNING: OrbitControls.js encountered an unknown camera type - zoom to cursor disabled.' );
+						scope.zoomToCursor = false;
+
 						newRadius = offset.length();
 
 					}

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -342,9 +342,18 @@ class OrbitControls extends EventDispatcher {
 							_ray.origin.copy( scope.object.position );
 							_ray.direction.set( 0, 0, - 1 ).transformDirection( scope.object.matrix );
 
-							_plane.setFromNormalAndCoplanarPoint( scope.object.up, scope.target );
+							// if the camera is ~30 degrees above the horizon then don't adjust the focus target to avoid
+							// extremely large values
+							if ( Math.abs( scope.object.up.dot( _ray.direction ) ) < 0.3 ) {
 
-							_ray.intersectPlane( _plane, scope.target );
+								object.lookAt( scope.target );
+
+							} else {
+
+								_plane.setFromNormalAndCoplanarPoint( scope.object.up, scope.target );
+								_ray.intersectPlane( _plane, scope.target );
+
+							}
 
 						}
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -5,7 +5,9 @@ import {
 	Spherical,
 	TOUCH,
 	Vector2,
-	Vector3
+	Vector3,
+	Plane,
+	Ray
 } from 'three';
 
 // OrbitControls performs orbiting, dollying (zooming), and panning.
@@ -72,7 +74,7 @@ class OrbitControls extends EventDispatcher {
 		this.panSpeed = 1.0;
 		this.screenSpacePanning = true; // if false, pan orthogonal to world-space direction camera.up
 		this.keyPanSpeed = 7.0;	// pixels moved per arrow key push
-		this.zoomToCursor = true;
+		this.zoomToCursor = false;
 
 		// Set to true to automatically rotate around the target
 		// If auto-rotate is enabled, you must call controls.update() in your animation loop
@@ -306,7 +308,28 @@ class OrbitControls extends EventDispatcher {
 					}
 
 					scope.object.updateMatrixWorld();
-					scope.target.set( 0, 0, - 1 ).transformDirection( scope.object.matrixWorld ).multiplyScalar( newRadius ).add( scope.object.position );
+
+					if ( this.screenSpacePanning ) {
+
+						// position the orbit target in front of the new camera position
+						scope.target.set( 0, 0, - 1 )
+							.transformDirection( scope.object.matrix )
+							.multiplyScalar( newRadius )
+							.add( scope.object.position );
+
+					} else {
+
+						// get the ray and translation plane to compute target
+						const ray = new Ray();
+						ray.origin.copy( scope.object.position );
+						ray.direction.set( 0, 0, - 1 ).transformDirection( scope.object.matrix );
+
+						const plane = new Plane();
+						plane.setFromNormalAndCoplanarPoint( scope.object.up, scope.target );
+
+						ray.intersectPlane( plane, scope.target );
+
+					}
 
 				} else {
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -563,7 +563,7 @@ class OrbitControls extends EventDispatcher {
 
 		function dollyOut( dollyScale ) {
 
-			if ( scope.object.isPerspectiveCamera || scope.object.isPerspectiveCamera ) {
+			if ( scope.object.isPerspectiveCamera || scope.object.isOrthographicCamera ) {
 
 				scale /= dollyScale;
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -583,8 +583,14 @@ class OrbitControls extends EventDispatcher {
 
 		function updateMouseParameters( event ) {
 
-			mouse.x = ( event.clientX / window.innerWidth ) * 2 - 1;
-			mouse.y = - ( event.clientY / window.innerHeight ) * 2 + 1;
+			const x = event.clientX - scope.domElement.clientLeft;
+			const y = event.clientY - scope.domElement.clientTop;
+			const w = scope.domElement.clientWidth;
+			const h = scope.domElement.clientHeight;
+
+			mouse.x = ( x / w ) * 2 - 1;
+			mouse.y = - ( y / h ) * 2 + 1;
+
 			dollyDirection.set( mouse.x, mouse.y, 1 ).unproject( object ).sub( object.position ).normalize();
 
 		}

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -614,10 +614,11 @@ class OrbitControls extends EventDispatcher {
 
 			performCursorZoom = true;
 
-			const x = event.clientX - scope.domElement.clientLeft;
-			const y = event.clientY - scope.domElement.clientTop;
-			const w = scope.domElement.clientWidth;
-			const h = scope.domElement.clientHeight;
+			const rect = scope.domElement.getBoundingClientRect();
+			const x = event.clientX - rect.left;
+			const y = event.clientY - rect.top;
+			const w = rect.width;
+			const h = rect.height;
 
 			mouse.x = ( x / w ) * 2 - 1;
 			mouse.y = - ( y / h ) * 2 + 1;

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -344,7 +344,7 @@ class OrbitControls extends EventDispatcher {
 							_ray.origin.copy( scope.object.position );
 							_ray.direction.set( 0, 0, - 1 ).transformDirection( scope.object.matrix );
 
-							// if the camera is ~20 degrees above the horizon then don't adjust the focus target to avoid
+							// if the camera is 20 degrees above the horizon then don't adjust the focus target to avoid
 							// extremely large values
 							if ( Math.abs( scope.object.up.dot( _ray.direction ) ) < TILT_LIMIT ) {
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -247,6 +247,19 @@ class OrbitControls extends EventDispatcher {
 
 				}
 
+				// adjust the camera position based on zoom only if we're not zooming to the cursor or if it's an ortho camera
+				// we adjust zoom later in these cases
+				if ( scope.zoomToCursor || scope.object.isOrthographicCamera ) {
+
+					spherical.radius = Math.max( scope.minDistance, Math.min( scope.maxDistance, spherical.radius ) );
+
+				} else {
+
+					spherical.radius = Math.max( scope.minDistance, Math.min( scope.maxDistance, spherical.radius * scale ) );
+
+				}
+
+
 				offset.setFromSpherical( spherical );
 
 				// rotate offset back to "camera-up-vector-is-up" space
@@ -338,22 +351,11 @@ class OrbitControls extends EventDispatcher {
 
 					}
 
-				} else {
+				} else if ( scope.object.isOrthographicCamera ) {
 
-					if ( scope.object.isOrthographicCamera ) {
-
-						scope.object.zoom = Math.max( scope.minZoom, Math.min( scope.maxZoom, scope.object.zoom / scale ) );
-						scope.object.updateProjectionMatrix();
-						zoomChanged = true;
-
-					} else {
-
-						let radius = offset.length() * scale;
-						radius = Math.max( scope.minDistance, Math.min( scope.maxDistance, radius ) );
-
-						position.copy( scope.target ).addScaledVector( offset, radius / offset.length() );
-
-					}
+					scope.object.zoom = Math.max( scope.minZoom, Math.min( scope.maxZoom, scope.object.zoom / scale ) );
+					scope.object.updateProjectionMatrix();
+					zoomChanged = true;
 
 				}
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -333,10 +333,20 @@ class OrbitControls extends EventDispatcher {
 
 				} else {
 
-					let radius = offset.length() * scale;
-					radius = Math.max( scope.minDistance, Math.min( scope.maxDistance, radius ) );
+					if ( scope.object.isOrthographicCamera ) {
 
-					position.copy( scope.target ).addScaledVector( offset, radius / offset.length() );
+						scope.object.zoom = Math.max( scope.minZoom, Math.min( scope.maxZoom, scope.object.zoom / scale ) );
+						scope.object.updateProjectionMatrix();
+						zoomChanged = true;
+
+					} else {
+
+						let radius = offset.length() * scale;
+						radius = Math.max( scope.minDistance, Math.min( scope.maxDistance, radius ) );
+
+						position.copy( scope.target ).addScaledVector( offset, radius / offset.length() );
+
+					}
 
 				}
 

--- a/examples/misc_controls_map.html
+++ b/examples/misc_controls_map.html
@@ -119,6 +119,7 @@
 
 
 				const gui = new GUI();
+				gui.add( controls, 'zoomToCursor' );
 				gui.add( controls, 'screenSpacePanning' );
 
 			}


### PR DESCRIPTION
Fixed #22522.

Related PRs: #24983, #17145, #23254

**Description**

Another effort to get map-like zoom to cursor working with OrbitControls. Some of the other efforts were not sufficient from what I could tell. I tried a few different approaches and seemed to be suffering from numeric precision issues before I landed on this one.

- Damping is not required.
- Mouse scroll and mouse cursor position dolly works correctly.
- Touch-zoom to cursor does not work. I would like to consider this future work.

A question:
- If panning is disabled should zoom to cursor be implicitly disabled? I'm fine with leaving this as is and letting the user set the desired behavior.

In Progress:
- "Jump" when reaching the max distance
- ~Handle initially unset or 0 distance to target~
- ~Simplify zoom cases with non camera objects~
- ~Fix non-cursor zooming with ortho cameras~

cc @WestLangley @Mugen87 
