### PR TITLE
Docs: Improve `CubeTextureLoader` page.

### DIFF
--- a/docs/api/en/loaders/CubeTextureLoader.html
+++ b/docs/api/en/loaders/CubeTextureLoader.html
@@ -12,8 +12,13 @@
 		<h1>[name]</h1>
 
 		<p class="desc">
-			Class for loading a [page:CubeTexture CubeTexture]. This uses the
-			[page:ImageLoader] internally for loading files.
+			[name] can be used to load cube maps. The loader returns an instance of [page:CubeTexture] and expects the cube map to
+			be defined as six separate images representing the sides of a cube. Other cube map definitions like vertical and horizontal cross, 
+			column and row layouts are not supported.
+		</p>
+		<p>
+			The loaded [page:CubeTexture] is in sRGB color space. Meaning the [page:Texture.colorSpace colorSpace] 
+			property is set to `THREE.SRGBColorSpace` by default.
 		</p>
 
 		<h2>Code Example</h2>

--- a/docs/api/it/loaders/CubeTextureLoader.html
+++ b/docs/api/it/loaders/CubeTextureLoader.html
@@ -16,6 +16,11 @@
       Utilizza internamente l'[page:ImageLoader] per caricare i file.
 		</p>
 
+		<p>
+			The loaded [page:CubeTexture] is in sRGB color space. Meaning the [page:Texture.colorSpace colorSpace] 
+			property is set to `THREE.SRGBColorSpace` by default.
+		</p>
+
 		<h2>Codice di Esempio</h2>
 
 		<code>

--- a/docs/api/zh/loaders/CubeTextureLoader.html
+++ b/docs/api/zh/loaders/CubeTextureLoader.html
@@ -16,6 +16,11 @@
 			内部使用[page:ImageLoader]来加载文件。
 		</p>
 
+		<p>
+			The loaded [page:CubeTexture] is in sRGB color space. Meaning the [page:Texture.colorSpace colorSpace] 
+			property is set to `THREE.SRGBColorSpace` by default.
+		</p>
+
 		<h2>代码示例</h2>
 
 		<code>


### PR DESCRIPTION
Related issue: #26162

**Description**

This PR updates the description of `CubeTextureLoader` to honor the latest sRGB related change. The change also clarifies which type of cube map definitions are supported and which are not.