### PR TITLE
Material: add flat colors attribute to disable color interpolation

### DIFF
--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -362,6 +362,7 @@ class Material extends EventDispatcher {
 		if ( this.wireframeLinecap !== 'round' ) data.wireframeLinecap = this.wireframeLinecap;
 		if ( this.wireframeLinejoin !== 'round' ) data.wireframeLinejoin = this.wireframeLinejoin;
 
+		if ( this.flatColors === true ) data.flatColors = this.flatColors;
 		if ( this.flatShading === true ) data.flatShading = this.flatShading;
 
 		if ( this.visible === false ) data.visible = false;

--- a/src/materials/MeshBasicMaterial.js
+++ b/src/materials/MeshBasicMaterial.js
@@ -13,6 +13,7 @@ class MeshBasicMaterial extends Material {
 		this.type = 'MeshBasicMaterial';
 
 		this.color = new Color( 0xffffff ); // emissive
+		this.flatColors = false;
 
 		this.map = null;
 
@@ -47,6 +48,7 @@ class MeshBasicMaterial extends Material {
 		super.copy( source );
 
 		this.color.copy( source.color );
+		this.flatColors = source.flatColors;
 
 		this.map = source.map;
 

--- a/src/renderers/shaders/ShaderChunk/color_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/color_pars_fragment.glsl.js
@@ -1,11 +1,19 @@
 export default /* glsl */`
 #if defined( USE_COLOR_ALPHA )
 
-	varying vec4 vColor;
+	#if defined( FLAT_COLORS )
+		flat varying vec4 vColor;
+	#else
+		varying vec4 vColor;
+	#endif
 
 #elif defined( USE_COLOR )
 
-	varying vec3 vColor;
+	#if defined( FLAT_COLORS )
+		flat varying vec3 vColor;
+	#else
+		varying vec3 vColor;
+	#endif
 
 #endif
 `;

--- a/src/renderers/shaders/ShaderChunk/color_pars_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/color_pars_vertex.glsl.js
@@ -1,11 +1,19 @@
 export default /* glsl */`
 #if defined( USE_COLOR_ALPHA )
 
-	varying vec4 vColor;
+	#if defined( FLAT_COLORS )
+		flat varying vec4 vColor;
+	#else
+		varying vec4 vColor;
+	#endif
 
 #elif defined( USE_COLOR ) || defined( USE_INSTANCING_COLOR )
 
-	varying vec3 vColor;
+	#if defined( FLAT_COLORS )
+		flat varying vec3 vColor;
+	#else
+		varying vec3 vColor;
+	#endif
 
 #endif
 `;

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -545,6 +545,7 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 
 			parameters.pointsUvs ? '#define USE_POINTS_UV' : '',
 
+			parameters.flatColors ? '#define FLAT_COLORS' : '',
 			parameters.flatShading ? '#define FLAT_SHADED' : '',
 
 			parameters.skinning ? '#define USE_SKINNING' : '',
@@ -735,6 +736,7 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 			parameters.gradientMap ? '#define USE_GRADIENTMAP' : '',
 
 			parameters.flatShading ? '#define FLAT_SHADED' : '',
+			parameters.flatColors ? '#define FLAT_COLORS' : '',
 
 			parameters.doubleSided ? '#define DOUBLE_SIDED' : '',
 			parameters.flipSided ? '#define FLIP_SIDED' : '',

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -284,6 +284,7 @@ function WebGLPrograms( renderer, cubemaps, cubeuvmaps, extensions, capabilities
 			useFog: material.fog === true,
 			fogExp2: ( fog && fog.isFogExp2 ),
 
+			flatColors: material.flatColors === true,
 			flatShading: material.flatShading === true,
 
 			sizeAttenuation: material.sizeAttenuation === true,


### PR DESCRIPTION
Related issue: #26173

**Description**

While normal interpolation can be disabled with `flatShading: false`, colors are always interpolated since `vColor` is defined as `varying` in the `color_pars` shader chunk. 

This PR introduces a `flatColors` attribute to materials for disabling color interpolation in the shaders.

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [me, myself & i](https://deermichel.me)*
