### PR TITLE
WebGLRenderer: Fix feedback loop in transmission pass for WebGL 2.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1346,7 +1346,7 @@ class WebGLRenderer {
 					generateMipmaps: true,
 					type: extensions.has( 'EXT_color_buffer_half_float' ) ? HalfFloatType : UnsignedByteType,
 					minFilter: LinearMipmapLinearFilter,
-					samples: ( isWebGL2 && antialias === true ) ? 4 : 0
+					samples: ( isWebGL2 ) ? 4 : 0
 				} );
 
 				// debug


### PR DESCRIPTION
Fixed #25990.

**Description**

#25502 introduced a feedback loop during the [back-side transmission pass](https://github.com/mrdoob/three.js/blob/90858b213dcab40509d6b98f776c5e9a4b29dd83/src/renderers/WebGLRenderer.js#L1392-L1406) since the active render target is equal to the texture which is assigned to `transmissionSamplerMap`. The feedback loop produces a WebGL warning but also the result of the back-side pass is missing in the render target (so the transmissive surface looks like before #25502 was added). The warning looks like so:

> GL_INVALID_OPERATION: Feedback loop formed between Framebuffer and active Texture.

This issue does not pop-up when `antialias` is set to `true` which is why the issue was overlooked initially. This happens because setting `antialias` to `true` means the transmissive render target is multisampled. Multisampled render targets do have more than one framebuffer so using it as the active render target and as a texture does not produce a feedback loop.

Solving this issue without multisampling is difficult because you need a separate code path that copies the contents of the transmissive render target via `copyTexSubImage2D()` into a texture and then uses it as the value for `transmissionSamplerMap`. When trying to get this to work, I have realized this will noticeably increase the code complexity with unclear performance implications (since you have to call `copyTexSubImage2D()` two times inside `renderTransmissionPass()`).

For simplicity reasons, I suggest to always use a multisampled render target for the transmission pass when using WebGL 2 which fixes the issue.