### PR TITLE
SSAARenderPass: Remove `unbiased` property.

### DIFF
--- a/examples/jsm/postprocessing/SSAARenderPass.js
+++ b/examples/jsm/postprocessing/SSAARenderPass.js
@@ -32,7 +32,6 @@ class SSAARenderPass extends Pass {
 		this.camera = camera;
 
 		this.sampleLevel = 4; // specified as n, where the number of samples is 2^n, so sampleLevel = 4, is 2^4 samples, 16.
-		this.unbiased = true;
 
 		// as we need to clear the buffer in this pass, clearColor must be set to something, defaults to black.
 		this.clearColor = ( clearColor !== undefined ) ? clearColor : 0x000000;
@@ -101,8 +100,6 @@ class SSAARenderPass extends Pass {
 		renderer.getClearColor( this._oldClearColor );
 		const oldClearAlpha = renderer.getClearAlpha();
 
-		const baseSampleWeight = 1.0 / jitterOffsets.length;
-		const roundingRange = 1 / 32;
 		this.copyUniforms[ 'tDiffuse' ].value = this.sampleRenderTarget.texture;
 
 		const viewOffset = {
@@ -139,20 +136,7 @@ class SSAARenderPass extends Pass {
 
 			}
 
-			let sampleWeight = baseSampleWeight;
-
-			if ( this.unbiased ) {
-
-				// the theory is that equal weights for each sample lead to an accumulation of rounding errors.
-				// The following equation varies the sampleWeight per sample so that it is uniformly distributed
-				// across a range of values whose rounding errors cancel each other out.
-
-				const uniformCenteredDistribution = ( - 0.5 + ( i + 0.5 ) / jitterOffsets.length );
-				sampleWeight += roundingRange * uniformCenteredDistribution;
-
-			}
-
-			this.copyUniforms[ 'opacity' ].value = sampleWeight;
+			this.copyUniforms[ 'opacity' ].value = 1.0 / jitterOffsets.length;
 			renderer.setClearColor( this.clearColor, this.clearAlpha );
 			renderer.setRenderTarget( this.sampleRenderTarget );
 			renderer.clear();

--- a/examples/webgl_postprocessing_ssaa.html
+++ b/examples/webgl_postprocessing_ssaa.html
@@ -8,9 +8,7 @@
 	</head>
 	<body>
 		<div id="info">
-			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - Unbiased Manual Supersamling Anti-Aliasing (SSAA) pass by <a href="https://clara.io" target="_blank" rel="noopener">Ben Houston</a><br/><br/>
-			This example shows how to unbias the rounding errors accumulated using high number of SSAA samples on a 8-bit per channel buffer.<br/><br/>
-			Turn off the "unbiased" feature to see the banding that results from accumulated rounding errors.
+			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - Manual Supersamling Anti-Aliasing (SSAA) pass by <a href="https://clara.io" target="_blank" rel="noopener">Ben Houston</a>
 		</div>
 
 		<div id="container"></div>
@@ -47,7 +45,6 @@
 
 			const params = {
 				sampleLevel: 4,
-				unbiased: true,
 				camera: 'perspective',
 				clearColor: 'black',
 				clearAlpha: 1.0,
@@ -67,7 +64,6 @@
 
 				gui = new GUI();
 
-				gui.add( params, 'unbiased' );
 				gui.add( params, 'sampleLevel', {
 					'Level 0: 1 Sample': 0,
 					'Level 1: 2 Samples': 1,
@@ -235,7 +231,6 @@
 				ssaaRenderPassP.clearAlpha = ssaaRenderPassO.clearAlpha = params.clearAlpha;
 
 				ssaaRenderPassP.sampleLevel = ssaaRenderPassO.sampleLevel = params.sampleLevel;
-				ssaaRenderPassP.unbiased = ssaaRenderPassO.unbiased = params.unbiased;
 
 				ssaaRenderPassP.enabled = ( params.camera === 'perspective' );
 				ssaaRenderPassO.enabled = ( params.camera === 'orthographic' );


### PR DESCRIPTION
Related issue: -

**Description**

Now with half-float render targets `SSAARenderPass` does not need to handle rounding errors anymore. This was necessary in the past since the implementation assumed to operate on `UnsignedByteType` data.

You can verify that the logic isn't required any more by opening [webgl_postprocessing_ssaa](https://threejs.org/examples/webgl_postprocessing_ssaa), uncheck the `unbiased` option and see no banding. This banding did occur with [previous versions](https://rawcdn.githack.com/mrdoob/three.js/r151/examples/webgl_postprocessing_ssaa.html) of the example.
