### PR TITLE
Docs: add consistency in code values (en).

### DIFF
--- a/docs/api/en/lights/SpotLight.html
+++ b/docs/api/en/lights/SpotLight.html
@@ -143,7 +143,7 @@
 		<h3>[property:Object3D target]</h3>
 		<p>
 			The Spotlight points from its [page:.position position] to
-			target.position. The default position of the target is *(0, 0, 0)*.<br />
+			target.position. The default position of the target is `(0, 0, 0)`.<br />
 			*Note*: For the target's position to be changed to anything other than the
 			default, it must be added to the [page:Scene scene] using
 			<code> scene.add( light.target ); </code>

--- a/docs/api/en/lights/shadows/LightShadow.html
+++ b/docs/api/en/lights/shadows/LightShadow.html
@@ -68,7 +68,7 @@
 			Values must be powers of 2, up to the
 			[page:WebGLRenderer.capabilities].maxTextureSize for a given device,
 			although the width and height don't have to be the same (so, for example,
-			(512, 1024) is valid). The default is *( 512, 512 )*.
+			(512, 1024) is valid). The default is `( 512, 512 )`.
 		</p>
 
 		<h3>[property:Matrix4 matrix]</h3>

--- a/docs/api/en/math/Plane.html
+++ b/docs/api/en/math/Plane.html
@@ -20,7 +20,7 @@
 		<h3>[name]( [param:Vector3 normal], [param:Float constant] )</h3>
 		<p>
 			[page:Vector3 normal] - (optional) a unit length [page:Vector3] defining
-			the normal of the plane. Default is *(1, 0, 0)*.<br />
+			the normal of the plane. Default is `(1, 0, 0)`.<br />
 			[page:Float constant] - (optional) the signed distance from the origin to
 			the plane. Default is `0`.
 		</p>

--- a/docs/api/en/scenes/Scene.html
+++ b/docs/api/en/scenes/Scene.html
@@ -39,14 +39,14 @@
 		<h3>[property:Float backgroundBlurriness]</h3>
 		<p>
 			Sets the blurriness of the background. Only influences environment maps
-			assigned to [page:Scene.background]. Valid input is a float between *0*
-			and *1*. Default is *0*.
+			assigned to [page:Scene.background]. Valid input is a float between `0`
+			and `1`. Default is `0`.
 		</p>
 
 		<h3>[property:Float backgroundIntensity]</h3>
 		<p>
 			Attenuates the color of the background. Only applies to background
-			textures. Default is *1*.
+			textures. Default is `1`.
 		</p>
 
 		<h3>[property:Texture environment]</h3>

--- a/docs/api/en/textures/DepthTexture.html
+++ b/docs/api/en/textures/DepthTexture.html
@@ -122,7 +122,7 @@
 		<h3>[property:number compareFunction]</h3>
 		<p>
 		This is used to define the comparison function used when comparing texels in the depth texture to the value in the depth buffer. 
-		Default is *null* which means comparison is disabled.<br /><br/>
+		Default is `null` which means comparison is disabled.<br /><br/>
 
 		See the [page:Textures texture constants] page for details of other functions.
 		</p>


### PR DESCRIPTION
**Description**

add consistency in code values instead of **bold** make them appear as `code` values.
