### PR TITLE
Revert "SSAARenderPass: Remove `unbiased` property. (#26178)"

### DIFF
--- a/examples/jsm/postprocessing/SSAARenderPass.js
+++ b/examples/jsm/postprocessing/SSAARenderPass.js
@@ -29,6 +29,7 @@ class SSAARenderPass extends Pass {
 		this.camera = camera;
 
 		this.sampleLevel = 4; // specified as n, where the number of samples is 2^n, so sampleLevel = 4, is 2^4 samples, 16.
+		this.unbiased = true;
 
 		// as we need to clear the buffer in this pass, clearColor must be set to something, defaults to black.
 		this.clearColor = ( clearColor !== undefined ) ? clearColor : 0x000000;
@@ -91,6 +92,8 @@ class SSAARenderPass extends Pass {
 		renderer.getClearColor( this._oldClearColor );
 		const oldClearAlpha = renderer.getClearAlpha();
 
+		const baseSampleWeight = 1.0 / jitterOffsets.length;
+		const roundingRange = 1 / 32;
 		this.copyUniforms[ 'tDiffuse' ].value = this.sampleRenderTarget.texture;
 
 		const viewOffset = {
@@ -127,7 +130,20 @@ class SSAARenderPass extends Pass {
 
 			}
 
-			this.copyUniforms[ 'opacity' ].value = 1.0 / jitterOffsets.length;
+			let sampleWeight = baseSampleWeight;
+
+			if ( this.unbiased ) {
+
+				// the theory is that equal weights for each sample lead to an accumulation of rounding errors.
+				// The following equation varies the sampleWeight per sample so that it is uniformly distributed
+				// across a range of values whose rounding errors cancel each other out.
+
+				const uniformCenteredDistribution = ( - 0.5 + ( i + 0.5 ) / jitterOffsets.length );
+				sampleWeight += roundingRange * uniformCenteredDistribution;
+
+			}
+
+			this.copyUniforms[ 'opacity' ].value = sampleWeight;
 			renderer.setClearColor( this.clearColor, this.clearAlpha );
 			renderer.setRenderTarget( this.sampleRenderTarget );
 			renderer.clear();

--- a/examples/webgl_postprocessing_ssaa.html
+++ b/examples/webgl_postprocessing_ssaa.html
@@ -8,7 +8,9 @@
 	</head>
 	<body>
 		<div id="info">
-			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - Manual Supersamling Anti-Aliasing (SSAA) pass by <a href="https://clara.io" target="_blank" rel="noopener">Ben Houston</a>
+			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - Unbiased Manual Supersamling Anti-Aliasing (SSAA) pass by <a href="https://clara.io" target="_blank" rel="noopener">Ben Houston</a><br/><br/>
+			This example shows how to unbias the rounding errors accumulated using high number of SSAA samples on a 8-bit per channel buffer.<br/><br/>
+			Turn off the "unbiased" feature to see the banding that results from accumulated rounding errors.
 		</div>
 
 		<div id="container"></div>
@@ -45,6 +47,7 @@
 
 			const params = {
 				sampleLevel: 4,
+				unbiased: true,
 				camera: 'perspective',
 				clearColor: 'black',
 				clearAlpha: 1.0,
@@ -64,6 +67,7 @@
 
 				gui = new GUI();
 
+				gui.add( params, 'unbiased' );
 				gui.add( params, 'sampleLevel', {
 					'Level 0: 1 Sample': 0,
 					'Level 1: 2 Samples': 1,
@@ -231,6 +235,7 @@
 				ssaaRenderPassP.clearAlpha = ssaaRenderPassO.clearAlpha = params.clearAlpha;
 
 				ssaaRenderPassP.sampleLevel = ssaaRenderPassO.sampleLevel = params.sampleLevel;
+				ssaaRenderPassP.unbiased = ssaaRenderPassO.unbiased = params.unbiased;
 
 				ssaaRenderPassP.enabled = ( params.camera === 'perspective' );
 				ssaaRenderPassO.enabled = ( params.camera === 'orthographic' );


### PR DESCRIPTION
This reverts commit 33d074702a5648444e182645919c3e7040f60c9a.

**Description**

Reverting for now since I see different behavior when rendering directly to screen with `SSAARenderPass`. When no sRGB color space conversion happens, banding is still there when `unbiased` isn't used. 