### PR TITLE
WebXRManager: Remove redundant `updateMatrixWorld` calls

### DIFF
--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -595,14 +595,6 @@ class WebXRManager extends EventDispatcher {
 			camera.matrix.decompose( camera.position, camera.quaternion, camera.scale );
 			camera.updateMatrixWorld( true );
 
-			const children = camera.children;
-
-			for ( let i = 0, l = children.length; i < l; i ++ ) {
-
-				children[ i ].updateMatrixWorld( true );
-
-			}
-
 			camera.projectionMatrix.copy( cameraXR.projectionMatrix );
 			camera.projectionMatrixInverse.copy( cameraXR.projectionMatrixInverse );
 


### PR DESCRIPTION
**Description**

The matrix world of the camera is updated with a call to `.updateMatrixWorld( true )`. This method already recurses into its children, so the subsequent code that did the same for each child is redundant. This PR simply removes the redundant code.

*This contribution is funded by [Fern Solutions](https://fern.solutions)*
