### PR TITLE
Examples: update bvh, csg versions

### DIFF
--- a/examples/webgl_geometry_csg.html
+++ b/examples/webgl_geometry_csg.html
@@ -33,8 +33,8 @@
 				"imports": {
 					"three": "../build/three.module.js",
 					"three/addons/": "./jsm/",
-					"three-mesh-bvh": "https://unpkg.com/three-mesh-bvh@^0.5.22/build/index.module.js",
-					"three-bvh-csg": "https://unpkg.com/three-bvh-csg@^0.0.4/build/index.module.js"
+					"three-mesh-bvh": "https://unpkg.com/three-mesh-bvh@0.6.0/build/index.module.js",
+					"three-bvh-csg": "https://unpkg.com/three-bvh-csg@0.0.6/build/index.module.js"
 				}
 			}
 		</script>

--- a/examples/webgl_raycaster_bvh.html
+++ b/examples/webgl_raycaster_bvh.html
@@ -33,7 +33,7 @@
 				"imports": {
 					"three": "../build/three.module.js",
 					"three/addons/": "./jsm/",
-					"three-mesh-bvh": "https://unpkg.com/three-mesh-bvh@^0.5.21/build/index.module.js"
+					"three-mesh-bvh": "https://unpkg.com/three-mesh-bvh@0.6.0/build/index.module.js"
 				}
 			}
 		</script>

--- a/examples/webgl_renderer_pathtracer.html
+++ b/examples/webgl_renderer_pathtracer.html
@@ -49,7 +49,7 @@
 					"three/addons/": "./jsm/",
 					"three/examples/": "./",
 					"three-gpu-pathtracer": "https://unpkg.com/three-gpu-pathtracer@0.0.14/build/index.module.js",
-					"three-mesh-bvh": "https://unpkg.com/three-mesh-bvh@^0.5.21/build/index.module.js"
+					"three-mesh-bvh": "https://unpkg.com/three-mesh-bvh@0.6.0/build/index.module.js"
 				}
 			}
 		</script>


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/26175#issuecomment-1570519458

**Description**

Bump bvh and csg to the latest versions.