### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+If you have discovered a security vulnerability in this project, please report it
+privately. **Do not disclose it as a public issue.** This gives us time to work with you
+to fix the issue before public exposure, reducing the chance that the exploit will be
+used before a patch is released.
+
+You may submit the report in the following ways:
+
+- send an email to hello@mrdoob.com; and/or
+- send us a [private vulnerability report](https://github.com/mrdoob/three.js/security/advisories/new)
+
+Please provide the following information in your report:
+
+- A description of the vulnerability and its impact
+- How to reproduce the issue
+
+This project is maintained by volunteers on a reasonable-effort basis. As such,
+we ask that you give us 90 days to work on a fix before public exposure.


### PR DESCRIPTION
Fixes: #26205

**Description**

Anyone who's found a vulnerability in three.js (i.e. denial-of-service) has no clear way of privately reporting it. This PR adds a security policy that tells users how to report vulnerabilities responsibly.

The current version of the policy suggests users either send an email (to an address found in the Code of Conduct) or use GitHub's private reporting tool. If you'd rather choose just one, change the email (if you'd rather use another with a smaller or different subset of maintainers) or anything else, let me know and I'll patch the PR!

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Google](https://google.com).*
