### PR TITLE
MeshSurfaceSampler: Add `uv` support.

### DIFF
--- a/docs/examples/en/math/MeshSurfaceSampler.html
+++ b/docs/examples/en/math/MeshSurfaceSampler.html
@@ -80,9 +80,9 @@
 		Processes the input geometry and prepares to return samples. Any configuration of the geometry or sampler must occur before this method is called. Time complexity is <i>O(n)</i> for a surface with <i>n</i> faces.
 		</p>
 
-		<h3>[method:this sample]( [param:Vector3 targetPosition], [param:Vector3 targetNormal], [param:Color targetColor] )</h3>
+		<h3>[method:this sample]( [param:Vector3 targetPosition], [param:Vector3 targetNormal], [param:Color targetColor], [param:Vector2 targetUV] )</h3>
 		<p>
-		Selects a random point on the surface of the input geometry, returning the position and optionally the normal vector and color at that point. Time complexity is <i>O(log n)</i> for a surface with <i>n</i> faces.</i></p>
+		Selects a random point on the surface of the input geometry, returning the position and optionally the normal vector, color and UV Coordinate at that point. Time complexity is <i>O(log n)</i> for a surface with <i>n</i> faces.</i></p>
 
 		<h2>Source</h2>
 

--- a/examples/jsm/math/MeshSurfaceSampler.js
+++ b/examples/jsm/math/MeshSurfaceSampler.js
@@ -1,5 +1,6 @@
 import {
 	Triangle,
+	Vector2,
 	Vector3
 } from 'three';
 
@@ -16,6 +17,7 @@ import {
 
 const _face = new Triangle();
 const _color = new Vector3();
+const _uva = new Vector2(), _uvb = new Vector2(), _uvc = new Vector2();
 
 class MeshSurfaceSampler {
 
@@ -36,6 +38,7 @@ class MeshSurfaceSampler {
 
 		this.positionAttribute = this.geometry.getAttribute( 'position' );
 		this.colorAttribute = this.geometry.getAttribute( 'color' );
+		this.uvAttribute = this.geometry.getAttribute( 'uv' );
 		this.weightAttribute = null;
 
 		this.distribution = null;
@@ -106,10 +109,10 @@ class MeshSurfaceSampler {
 
 	}
 
-	sample( targetPosition, targetNormal, targetColor ) {
+	sample( targetPosition, targetNormal, targetColor, targetUV ) {
 
 		const faceIndex = this.sampleFaceIndex();
-		return this.sampleFace( faceIndex, targetPosition, targetNormal, targetColor );
+		return this.sampleFace( faceIndex, targetPosition, targetNormal, targetColor, targetUV );
 
 	}
 
@@ -154,7 +157,7 @@ class MeshSurfaceSampler {
 
 	}
 
-	sampleFace( faceIndex, targetPosition, targetNormal, targetColor ) {
+	sampleFace( faceIndex, targetPosition, targetNormal, targetColor, targetUV ) {
 
 		let u = this.randomFunction();
 		let v = this.randomFunction();
@@ -197,6 +200,15 @@ class MeshSurfaceSampler {
 			targetColor.r = _color.x;
 			targetColor.g = _color.y;
 			targetColor.b = _color.z;
+
+		}
+
+		if ( targetUV !== undefined && this.uvAttribute !== undefined ) {
+
+			_uva.fromBufferAttribute( this.uvAttribute, faceIndex * 3 );
+			_uvb.fromBufferAttribute( this.uvAttribute, faceIndex * 3 + 1 );
+			_uvc.fromBufferAttribute( this.uvAttribute, faceIndex * 3 + 2 );
+			targetUV.set( 0, 0 ).addScaledVector( _uva, u ).addScaledVector( _uvb, v ).addScaledVector( _uvc, 1 - ( u + v ) );
 
 		}
 


### PR DESCRIPTION
this is one of two changes I had to do to MeshSurfaceSampler in order to use it for the [grass effect](https://cdn.discordapp.com/attachments/1102540843660886087/1115870644622598184/1181.png) - let's see if it makes sense to you, and then I will maybe come back with the other one