### PR TITLE
Docs: Fix mistake in Color#getRGB signature

### DIFF
--- a/docs/api/en/math/Color.html
+++ b/docs/api/en/math/Color.html
@@ -217,7 +217,7 @@ const color7 = new THREE.Color( 1, 0, 0 );
 		</p>
 
 		<h3>
-			[method:Color getRGB]( [param:Color target], [param:string colorSpace] = SRGBColorSpace )
+			[method:Color getRGB]( [param:Color target], [param:string colorSpace] = LinearSRGBColorSpace )
 		</h3>
 		<p>
 			[page:Color target] — the result will be copied into this object.<br /><br />

--- a/docs/api/it/math/Color.html
+++ b/docs/api/it/math/Color.html
@@ -181,7 +181,7 @@ const color7 = new THREE.Color( 1, 0, 0 );
 
 		</p>
 
-		<h3>[method:Color getRGB]( [param:Color target], [param:string colorSpace] = SRGBColorSpace )</h3>
+		<h3>[method:Color getRGB]( [param:Color target], [param:string colorSpace] = LinearSRGBColorSpace )</h3>
 		<p>
 			[page:Color target] - questo risultato sarà copiato in questo oggetto.<br /><br />
 

--- a/docs/api/zh/math/Color.html
+++ b/docs/api/zh/math/Color.html
@@ -182,7 +182,7 @@
 
 		</p>
 
-		<h3>[method:Color getRGB]( [param:Color target], [param:string colorSpace] = SRGBColorSpace )</h3>
+		<h3>[method:Color getRGB]( [param:Color target], [param:string colorSpace] = LinearSRGBColorSpace )</h3>
 		<p>
 			[page:Color target] - 结果将复制到这个对象中.<br /><br />
 


### PR DESCRIPTION
The getRGB method returns colors in the working color space by default (Linear-sRGB), not sRGB.

https://github.com/mrdoob/three.js/blob/14ba68981194a8d1e0a16d9e0af00fa3dabd5146/src/math/Color.js#L412-L422