### PR TITLE
PLYLoader: Add vertex colors back.

### DIFF
--- a/examples/jsm/loaders/PLYLoader.js
+++ b/examples/jsm/loaders/PLYLoader.js
@@ -408,6 +408,12 @@ class PLYLoader extends Loader {
 
 			}
 
+			if ( buffer.colors.length > 0 ) {
+
+				geometry.setAttribute( 'color', new Float32BufferAttribute( buffer.colors, 3 ) );
+
+			}
+
 			if ( buffer.faceVertexUvs.length > 0 || buffer.faceVertexColors.length > 0 ) {
 
 				geometry = geometry.toNonIndexed();


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/26014/files#r1220433050

**Description**

This PR restores the deleted `if` clause handling vertex colors in `PLYLoader`.
