### PR TITLE
Docs: Improve `LineBasicMaterial` page.

### DIFF
--- a/docs/api/ar/materials/LineBasicMaterial.html
+++ b/docs/api/ar/materials/LineBasicMaterial.html
@@ -36,7 +36,6 @@
 		[example:webgl_interactive_voxelpainter WebGL / interactive / voxelpainter]<br />
 		[example:webgl_lines_colors WebGL / lines / colors]<br />
 		[example:webgl_lines_dashed WebGL / lines / dashed]<br />
-		[example:webgl_materials WebGL / materials]<br />
 		[example:physics_ammo_rope physics / ammo / rope]
 		</p>
 	 

--- a/docs/api/en/materials/LineBasicMaterial.html
+++ b/docs/api/en/materials/LineBasicMaterial.html
@@ -36,7 +36,6 @@
 			[example:webgl_interactive_voxelpainter WebGL / interactive / voxelpainter]<br />
 			[example:webgl_lines_colors WebGL / lines / colors]<br />
 			[example:webgl_lines_dashed WebGL / lines / dashed]<br />
-			[example:webgl_materials WebGL / materials]<br />
 			[example:physics_ammo_rope physics / ammo / rope]
 		</p>
 

--- a/docs/api/fr/materials/LineBasicMaterial.html
+++ b/docs/api/fr/materials/LineBasicMaterial.html
@@ -38,7 +38,6 @@
 			[example:webgl_interactive_voxelpainter WebGL / interactive / voxelpainter]<br />
 			[example:webgl_lines_colors WebGL / lines / colors]<br />
 			[example:webgl_lines_dashed WebGL / lines / dashed]<br />
-			[example:webgl_materials WebGL / materials]<br />
 			[example:physics_ammo_rope physics / ammo / rope]
 		</p>
 

--- a/docs/api/it/materials/LineBasicMaterial.html
+++ b/docs/api/it/materials/LineBasicMaterial.html
@@ -38,7 +38,6 @@
 			[example:webgl_interactive_voxelpainter WebGL / interactive / voxelpainter]<br />
 			[example:webgl_lines_colors WebGL / lines / colors]<br />
 			[example:webgl_lines_dashed WebGL / lines / dashed]<br />
-			[example:webgl_materials WebGL / materials]<br />
 			[example:physics_ammo_rope physics / ammo / rope]
 		</p>
 

--- a/docs/api/zh/materials/LineBasicMaterial.html
+++ b/docs/api/zh/materials/LineBasicMaterial.html
@@ -38,7 +38,6 @@
 			[example:webgl_interactive_voxelpainter WebGL / interactive / voxelpainter]<br />
 			[example:webgl_lines_colors WebGL / lines / colors]<br />
 			[example:webgl_lines_dashed WebGL / lines / dashed]<br />
-			[example:webgl_materials WebGL / materials]<br />
 			[example:physics_ammo_rope physics / ammo / rope]
 		</p>
 


### PR DESCRIPTION
Related issue: https://discourse.threejs.org/t/example-webgl-materials-in-linematerials-does-not-work/52632

**Description**

This PR removes dead links to the deleted example `webgl_materials`.