### PR TITLE
NodeMaterial: Fix default forceSinglePass & .alphaMap

### DIFF
--- a/examples/jsm/nodes/materials/NodeMaterial.js
+++ b/examples/jsm/nodes/materials/NodeMaterial.js
@@ -29,6 +29,8 @@ class NodeMaterial extends ShaderMaterial {
 
 		this.type = this.constructor.name;
 
+		this.forceSinglePass = false;
+
 		this.lights = true;
 		this.normals = true;
 

--- a/examples/jsm/renderers/webgl/nodes/WebGLNodeBuilder.js
+++ b/examples/jsm/renderers/webgl/nodes/WebGLNodeBuilder.js
@@ -141,10 +141,6 @@ class WebGLNodeBuilder extends NodeBuilder {
 				inclusionType: 'append'
 			} ) );
 
-		} else {
-
-			this.addCode( 'fragment', getIncludeSnippet( 'alphatest_fragment' ), 'diffuseColor.a = opacity;', this.shader );
-
 		}
 
 		if ( material.normalNode && material.normalNode.isNode ) {


### PR DESCRIPTION
Related issue: https://discourse.threejs.org/t/node-materials-incompatibility-with-regular-materials/52589

**Description**

Fix `forceSinglePass = false` as default.
Fix `alphaMap` if `opacityNode` is not used.

