### PR TITLE
PLYLoader: Fix handling binary files with \n\r line endings in header.

### DIFF
--- a/examples/jsm/loaders/PLYLoader.js
+++ b/examples/jsm/loaders/PLYLoader.js
@@ -704,7 +704,7 @@ class PLYLoader extends Loader {
 			} while ( cont && i < bytes.length );
 
 			// ascii section using \r\n as line endings
-			if ( hasCRNL ) i++;
+			if ( hasCRNL === true ) i ++;
 
 			return { headerText: lines.join( '\r' ) + '\r',  headerLength: i };
 

--- a/examples/jsm/loaders/PLYLoader.js
+++ b/examples/jsm/loaders/PLYLoader.js
@@ -678,10 +678,8 @@ class PLYLoader extends Loader {
 			let line = '';
 			const lines = [];
 
-			const startBytes = new TextDecoder().decode( bytes.subarray( 0, 5 ) );
-			const startLine = startBytes.match( /^ply[\n\r]+/ )[ 0 ]
-
-			const hasCRNL = startLine.length === 5;
+			const startLine = new TextDecoder().decode( bytes.subarray( 0, 5 ) );
+			const hasCRNL = /^ply\r\n/.test( startLine );
 
 			do {
 

--- a/examples/jsm/loaders/PLYLoader.js
+++ b/examples/jsm/loaders/PLYLoader.js
@@ -113,8 +113,10 @@ class PLYLoader extends Loader {
 
 			if ( result !== null ) {
 
+				const newlineCount = result[ 0 ].match( /\r/g ).length;
+
 				headerText = result[ 1 ];
-				headerLength = new Blob( [ result[ 0 ] ] ).size;
+				headerLength = new Blob( [ result[ 0 ] ] ).size + newlineCount;
 
 			}
 

--- a/examples/jsm/renderers/webgl/nodes/WebGLNodeBuilder.js
+++ b/examples/jsm/renderers/webgl/nodes/WebGLNodeBuilder.js
@@ -10,7 +10,8 @@ const nodeShaderLib = {
 	MeshBasicNodeMaterial: ShaderLib.basic,
 	PointsNodeMaterial: ShaderLib.points,
 	MeshStandardNodeMaterial: ShaderLib.standard,
-	MeshPhysicalNodeMaterial: ShaderLib.physical
+	MeshPhysicalNodeMaterial: ShaderLib.physical,
+	MeshPhongNodeMaterial: ShaderLib.phong
 };
 
 const glslMethods = {
@@ -74,6 +75,7 @@ class WebGLNodeBuilder extends NodeBuilder {
 
 		if ( material.isMeshPhysicalNodeMaterial ) type = 'MeshPhysicalNodeMaterial';
 		else if ( material.isMeshStandardNodeMaterial ) type = 'MeshStandardNodeMaterial';
+		else if ( material.isMeshPhongNodeMaterial ) type = 'MeshPhongNodeMaterial';
 		else if ( material.isMeshBasicNodeMaterial ) type = 'MeshBasicNodeMaterial';
 		else if ( material.isPointsNodeMaterial ) type = 'PointsNodeMaterial';
 		else if ( material.isLineBasicNodeMaterial ) type = 'LineBasicNodeMaterial';


### PR DESCRIPTION
Fixed #26229

Header length calculations were carried out after \n characters were removed from the header text hence the file offset for reading binary data was incorrect.

Detect type of line ending for first line, and get header length in extractHeaderText() function instead of in parseHeader().
The header length is only required in binary format files. 


