### PR TITLE
WebGPUBackend: Request static adapter in init async.

### DIFF
--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -110,15 +110,16 @@ class KTX2Loader extends Loader {
 
 	}
 
-	detectSupport( renderer ) {
+	async detectSupport( renderer ) {
 
 		if ( renderer.isWebGPURenderer === true ) {
-
+			// wait for WebGPU adapter to get features 
+			//https://github.com/mrdoob/three.js/pull/26242
 			this.workerConfig = {
-				astcSupported: renderer.hasFeature( 'texture-compression-astc' ),
+				astcSupported: await renderer.hasFeature( 'texture-compression-astc' ),
 				etc1Supported: false,
-				etc2Supported: renderer.hasFeature( 'texture-compression-etc2' ),
-				dxtSupported: renderer.hasFeature( 'texture-compression-bc' ),
+				etc2Supported: await renderer.hasFeature( 'texture-compression-etc2' ),
+				dxtSupported: await renderer.hasFeature( 'texture-compression-bc' ),
 				bptcSupported: false,
 				pvrtcSupported: false
 			};

--- a/examples/jsm/renderers/webgpu/WebGPUBackend.js
+++ b/examples/jsm/renderers/webgpu/WebGPUBackend.js
@@ -17,8 +17,15 @@ import WebGPUTextureUtils from './utils/WebGPUTextureUtils.js';
 
 // statics
 
-let _staticAdapter = null;
+/*let _staticAdapter = null;
 
+if ( navigator.gpu !== undefined ) {
+
+	_staticAdapter = await navigator.gpu.requestAdapter();
+
+}*/
+
+let _deferFeatures = [];
 //
 
 class WebGPUBackend extends Backend {
@@ -60,16 +67,10 @@ class WebGPUBackend extends Backend {
 
 	async init( renderer ) {
 
+		//console.log("INIT1", _staticAdapter);
+
 		await super.init( renderer );
 
-		//request static adapter in init async
-		if ( navigator.gpu !== undefined && !_staticAdapter ) {
-
-			_staticAdapter = await navigator.gpu.requestAdapter();
-		
-		}
-
-		//
 
 		const parameters = this.parameters;
 
@@ -84,6 +85,8 @@ class WebGPUBackend extends Backend {
 			throw new Error( 'WebGPUBackend: Unable to create WebGPU adapter.' );
 
 		}
+
+	
 
 		// feature support
 
@@ -113,6 +116,14 @@ class WebGPUBackend extends Backend {
 		this.adapter = adapter;
 		this.device = device;
 		this.context = context;
+
+		
+		//resolve deferred adapter features
+		//https://github.com/mrdoob/three.js/pull/26242
+		if (_deferFeatures.length) {	
+			_deferFeatures.forEach(resolve => resolve());
+			_deferFeatures = [];
+		}
 
 		this.updateSize();
 
@@ -678,23 +689,25 @@ class WebGPUBackend extends Backend {
 	// utils public
 
 	hasFeature( name ) {
+		return new Promise((resolve, reject) => {
+			
+			if (this.adapter) {
+				//const adapter = this.adapter || _staticAdapter;
+				//const features = Object.values( GPUFeatureName );
 
-		const adapter = this.adapter || _staticAdapter;
+				//if ( features.includes( name ) === false ) {
 
-		//
+				//	resolve(false);
 
-		const features = Object.values( GPUFeatureName );
+					//reject( 'THREE.WebGPURenderer: Unknown WebGPU GPU feature: ' + name );
+					//throw new Error( 'THREE.WebGPURenderer: Unknown WebGPU GPU feature: ' + name );
 
-		if ( features.includes( name ) === false ) {
-
-			throw new Error( 'THREE.WebGPURenderer: Unknown WebGPU GPU feature: ' + name );
-
-		}
-
-		//
-
-		return adapter.features.has( name );
-
+				//}
+				resolve(this.adapter.features.has( name ));
+			} else {
+				_deferFeatures.push(() => resolve(this.hasFeature(name)));
+			}
+		});
 	}
 
 	copyFramebufferToTexture( texture, renderContext ) {

--- a/examples/jsm/renderers/webgpu/WebGPUBackend.js
+++ b/examples/jsm/renderers/webgpu/WebGPUBackend.js
@@ -19,12 +19,6 @@ import WebGPUTextureUtils from './utils/WebGPUTextureUtils.js';
 
 let _staticAdapter = null;
 
-if ( navigator.gpu !== undefined ) {
-
-	_staticAdapter = await navigator.gpu.requestAdapter();
-
-}
-
 //
 
 class WebGPUBackend extends Backend {
@@ -67,6 +61,13 @@ class WebGPUBackend extends Backend {
 	async init( renderer ) {
 
 		await super.init( renderer );
+
+		//request static adapter in init async
+		if ( navigator.gpu !== undefined && !_staticAdapter ) {
+
+			_staticAdapter = await navigator.gpu.requestAdapter();
+		
+		}
 
 		//
 


### PR DESCRIPTION
When bundling the WebGPURenderer the external await breaks bundling when not an es6 module bundle. When bundling umd/iife. Therefore create the static adapter in the async init method works. 

The error produced is

```
[!] Error: Module format iife does not support top-level await. Use the "es" or "system" output formats rather.
```

Modules will end up as these bundles. 

