### PR TITLE
OculusHandPointerModel: cleanup on disconnect, implement dispose

### DIFF
--- a/examples/jsm/webxr/OculusHandPointerModel.js
+++ b/examples/jsm/webxr/OculusHandPointerModel.js
@@ -13,8 +13,8 @@ const POINTER_LENGTH = 0.035;
 const POINTER_SEGMENTS = 16;
 const POINTER_RINGS = 12;
 const POINTER_HEMISPHERE_ANGLE = 110;
-const YAXIS = new THREE.Vector3( 0, 1, 0 );
-const ZAXIS = new THREE.Vector3( 0, 0, 1 );
+const YAXIS = /* @__PURE__ */ new THREE.Vector3( 0, 1, 0 );
+const ZAXIS = /* @__PURE__ */ new THREE.Vector3( 0, 0, 1 );
 
 const CURSOR_RADIUS = 0.02;
 const CURSOR_MAX_DISTANCE = 1.5;
@@ -27,9 +27,10 @@ class OculusHandPointerModel extends THREE.Object3D {
 
 		this.hand = hand;
 		this.controller = controller;
+
+		// Unused
 		this.motionController = null;
 		this.envMap = null;
-
 		this.mesh = null;
 
 		this.pointerGeometry = null;
@@ -43,24 +44,36 @@ class OculusHandPointerModel extends THREE.Object3D {
 
 		this.raycaster = null;
 
-		hand.addEventListener( 'connected', ( event ) => {
+		this._onConnected = this._onConnected.bind( this );
+		this._onDisconnected = this._onDisconnected.bind( this );
+		this.hand.addEventListener( 'connected', this._onConnected );
+		this.hand.addEventListener( 'disconnected', this._onDisconnected );
 
-			const xrInputSource = event.data;
+	}
 
-			if ( xrInputSource.hand ) {
+	_onConnected( event ) {
 
-				this.visible = true;
-				this.xrInputSource = xrInputSource;
+		const xrInputSource = event.data;
+		if ( xrInputSource.hand ) {
 
-				if ( this.pointerObject === null ) {
+			this.visible = true;
+			this.xrInputSource = xrInputSource;
 
-					this.createPointer();
+			this.createPointer();
 
-				}
+		}
 
-			}
+	}
 
-		} );
+	_onDisconnected() {
+
+		this.visible = false;
+		this.xrInputSource = null;
+
+		this.pointerGeometry.dispose();
+		this.pointerMesh.material.dispose();
+
+		this.clear();
 
 	}
 
@@ -384,6 +397,14 @@ class OculusHandPointerModel extends THREE.Object3D {
 			this.cursorObject.position.copy( direction.multiplyScalar( distance ) );
 
 		}
+
+	}
+
+	dispose() {
+
+		this._onDisconnected();
+		this.hand.removeEventListener( 'connected', this._onConnected );
+		this.hand.removeEventListener( 'disconnected', this._onDisconnected );
 
 	}
 


### PR DESCRIPTION
Related issue: #XXXX (mirrors https://github.com/pmndrs/three-stdlib/pull/266)

**Description**

Fixes an issue in `OculusHandPointerModel` where it would repeatedly create cursors on input change and create a memory leak. Additionally, I've implemented `dispose` to cleanup its listeners and to match the other WebXR classes.
