### PR TITLE
LineSegments2: Support variable width per point

### DIFF
--- a/examples/jsm/lines/LineGeometry.js
+++ b/examples/jsm/lines/LineGeometry.js
@@ -62,6 +62,27 @@ class LineGeometry extends LineSegmentsGeometry {
 
 	}
 
+	setWidths( array ) {
+
+		// converts [ w1, w2 ] to pairs format
+
+		const length = array.length - 1;
+		const widths = new Float32Array( 2 * length );
+
+		for ( let i = 0; i < length; i ++ ) {
+
+			widths[ 2 * i ] = array[ i ];
+
+			widths[ 2 * i + 1 ] = array[ i + 1 ];
+
+		}
+
+		super.setWidths( widths );
+
+		return this;
+
+	}
+
 	fromLine( line ) {
 
 		const geometry = line.geometry;

--- a/examples/jsm/lines/LineMaterial.js
+++ b/examples/jsm/lines/LineMaterial.js
@@ -172,7 +172,7 @@ ShaderLib[ 'line' ] = {
 			dir = normalize( dir );
 
 			// width
-			#ifdef USE_WIDTH
+			#ifdef USE_VERTEX_WIDTH
 
 				float widthStart = instanceWidthStart;
 				float widthEnd = instanceWidthEnd;
@@ -543,7 +543,7 @@ class LineMaterial extends ShaderMaterial {
 
 				get: function () {
 
-					return 'USE_WIDTH' in this.defines;
+					return 'USE_VERTEX_WIDTH' in this.defines;
 
 				},
 
@@ -551,11 +551,11 @@ class LineMaterial extends ShaderMaterial {
 
 					if ( value === true ) {
 
-						this.defines.USE_WIDTH = '';
+						this.defines.USE_VERTEX_WIDTH = '';
 
 					} else {
 
-						delete this.defines.USE_WIDTH;
+						delete this.defines.USE_VERTEX_WIDTH;
 
 					}
 

--- a/examples/jsm/lines/LineSegmentsGeometry.js
+++ b/examples/jsm/lines/LineSegmentsGeometry.js
@@ -114,6 +114,29 @@ class LineSegmentsGeometry extends InstancedBufferGeometry {
 
 	}
 
+	setWidths( array ) {
+
+		let widths;
+
+		if ( array instanceof Float32Array ) {
+
+			widths = array;
+
+		} else if ( Array.isArray( array ) ) {
+
+			widths = new Float32Array( array );
+
+		}
+
+		const instanceWidthBuffer = new InstancedInterleavedBuffer( widths, 2, 1 );
+
+		this.setAttribute( 'instanceWidthStart', new InterleavedBufferAttribute( instanceWidthBuffer, 1, 0 ) );
+		this.setAttribute( 'instanceWidthEnd', new InterleavedBufferAttribute( instanceWidthBuffer, 1, 1 ) );
+
+		return this;
+
+	}
+
 	fromWireframeGeometry( geometry ) {
 
 		this.setPositions( geometry.attributes.position.array );

--- a/examples/webgl_lines_fat_raycasting.html
+++ b/examples/webgl_lines_fat_raycasting.html
@@ -60,9 +60,9 @@
 			const matLine = new LineMaterial( {
 
 				color: 0xffffff,
-				linewidth: 1, // in world units with size attenuation, pixels otherwise
 				worldUnits: true,
 				vertexColors: true,
+				vertexWidths: true,
 
 				//resolution:  // to be set by renderer, eventually
 				alphaToCoverage: true,
@@ -72,9 +72,9 @@
 			const matThresholdLine = new LineMaterial( {
 
 				color: 0xffffff,
-				linewidth: matLine.linewidth, // in world units with size attenuation, pixels otherwise
 				worldUnits: true,
 				// vertexColors: true,
+				vertexWidths: true,
 				transparent: true,
 				opacity: 0.2,
 				depthTest: false,
@@ -88,7 +88,8 @@
 				'line type': 0,
 				'world units': matLine.worldUnits,
 				'visualize threshold': matThresholdLine.visible,
-				'width': matLine.linewidth,
+				'startWidth': matLine.linewidth,
+				'endWidth': matLine.linewidth,
 				'alphaToCoverage': matLine.alphaToCoverage,
 				'threshold': raycaster.params.Line2.threshold,
 				'translation': raycaster.params.Line2.threshold,
@@ -160,10 +161,6 @@
 
 				}
 
-				const lineGeometry = new LineGeometry();
-				lineGeometry.setPositions( positions );
-				lineGeometry.setColors( colors );
-
 				const segmentsGeometry = new LineSegmentsGeometry();
 				segmentsGeometry.setPositions( positions );
 				segmentsGeometry.setColors( colors );
@@ -174,27 +171,35 @@
 				scene.add( segments );
 				segments.visible = false;
 
-				thresholdSegments = new LineSegments2( segmentsGeometry, matThresholdLine );
+				const thresholdSegmentsGeometry = new LineSegmentsGeometry();
+				thresholdSegmentsGeometry.setPositions( positions );
+				thresholdSegmentsGeometry.setColors( colors );
+
+				thresholdSegments = new LineSegments2( thresholdSegmentsGeometry, matThresholdLine );
 				thresholdSegments.computeLineDistances();
 				thresholdSegments.scale.set( 1, 1, 1 );
 				scene.add( thresholdSegments );
 				thresholdSegments.visible = false;
+
+				const lineGeometry = new LineGeometry();
+				lineGeometry.setPositions( positions );
+				lineGeometry.setColors( colors );
 
 				line = new Line2( lineGeometry, matLine );
 				line.computeLineDistances();
 				line.scale.set( 1, 1, 1 );
 				scene.add( line );
 
-				thresholdLine = new Line2( lineGeometry, matThresholdLine );
+				const thresholdLineGeometry = new LineGeometry();
+				thresholdLineGeometry.setPositions( positions );
+				thresholdLineGeometry.setColors( colors );
+
+				thresholdLine = new Line2( thresholdLineGeometry, matThresholdLine );
 				thresholdLine.computeLineDistances();
 				thresholdLine.scale.set( 1, 1, 1 );
 				scene.add( thresholdLine );
 
-				const geo = new THREE.BufferGeometry();
-				geo.setAttribute( 'position', new THREE.Float32BufferAttribute( positions, 3 ) );
-				geo.setAttribute( 'color', new THREE.Float32BufferAttribute( colors, 3 ) );
-
-				//
+				updateWidths();
 
 				document.addEventListener( 'pointermove', onPointerMove );
 				window.addEventListener( 'resize', onWindowResize );
@@ -316,6 +321,27 @@
 
 			}
 
+			function updateWidths() {
+
+				const widths = [];
+				const thresholdWidths = [];
+				const points = segments.geometry.getAttribute( 'instanceStart' ).array;
+				const numPoints = points.length / 3;
+				for ( let i = 0; i < numPoints; i ++ ) {
+
+					const width = i / ( numPoints - 1 ) * ( params.endWidth - params.startWidth ) + params.startWidth;
+					widths.push( width );
+					thresholdWidths.push( width + raycaster.params.Line2.threshold );
+
+				}
+
+				segments.geometry.setWidths( widths );
+				thresholdSegments.geometry.setWidths( thresholdWidths );
+				line.geometry.setWidths( widths );
+				thresholdLine.geometry.setWidths( thresholdWidths );
+
+			}
+
 			function initGui() {
 
 				gui = new GUI();
@@ -342,10 +368,15 @@
 
 				} );
 
-				gui.add( params, 'width', 1, 10 ).onChange( function ( val ) {
+				gui.add( params, 'startWidth', 1, 50 ).onChange( function () {
 
-					matLine.linewidth = val;
-					matThresholdLine.linewidth = matLine.linewidth + raycaster.params.Line2.threshold;
+					updateWidths();
+
+				} );
+
+				gui.add( params, 'endWidth', 1, 50 ).onChange( function () {
+
+					updateWidths();
 
 				} );
 
@@ -355,10 +386,10 @@
 
 				} );
 
-				gui.add( params, 'threshold', 0, 10 ).onChange( function ( val ) {
+				gui.add( params, 'threshold', 0, 50 ).onChange( function ( val ) {
 
 					raycaster.params.Line2.threshold = val;
-					matThresholdLine.linewidth = matLine.linewidth + raycaster.params.Line2.threshold;
+					updateWidths();
 
 				} );
 

--- a/examples/webgl_lines_fat_raycasting.html
+++ b/examples/webgl_lines_fat_raycasting.html
@@ -88,8 +88,8 @@
 				'line type': 0,
 				'world units': matLine.worldUnits,
 				'visualize threshold': matThresholdLine.visible,
-				'startWidth': matLine.linewidth,
-				'endWidth': matLine.linewidth,
+				'width': matLine.linewidth,
+				'variable widths': false,
 				'alphaToCoverage': matLine.alphaToCoverage,
 				'threshold': raycaster.params.Line2.threshold,
 				'translation': raycaster.params.Line2.threshold,
@@ -329,7 +329,14 @@
 				const numPoints = points.length / 3;
 				for ( let i = 0; i < numPoints; i ++ ) {
 
-					const width = i / ( numPoints - 1 ) * ( params.endWidth - params.startWidth ) + params.startWidth;
+					let width = params.width;
+					if ( params[ 'variable widths' ] ) {
+
+						const segment = i;
+						width += params.width * ( Math.sin( segment / 4 ) + 1 );
+
+					}
+
 					widths.push( width );
 					thresholdWidths.push( width + raycaster.params.Line2.threshold );
 
@@ -368,14 +375,15 @@
 
 				} );
 
-				gui.add( params, 'startWidth', 1, 50 ).onChange( function () {
+				gui.add( params, 'width', 1, 10 ).onChange( function () {
 
 					updateWidths();
 
 				} );
 
-				gui.add( params, 'endWidth', 1, 50 ).onChange( function () {
+				gui.add( params, 'variable widths' ).onChange( function ( val ) {
 
+					params[ 'variable widths' ] = val;
 					updateWidths();
 
 				} );
@@ -386,7 +394,7 @@
 
 				} );
 
-				gui.add( params, 'threshold', 0, 50 ).onChange( function ( val ) {
+				gui.add( params, 'threshold', 0, 10 ).onChange( function ( val ) {
 
 					raycaster.params.Line2.threshold = val;
 					updateWidths();


### PR DESCRIPTION
**Description**

There is currently no way to have a variable width line with `Line2` and `LineSegments2`; a constant width must be used. This PR adds supports for per-point line widths. To use per-point line widths, the `LineMaterial` must have the `vertexWidths` property set, and the `LineGeometry` or `LineSegmentsGeometry` must be supplied with widths via the `setWidths` method.

I have tested:
* World Units / Pixel Units
* Dashed lines
* Line2 and LineSegments2
* Raycasting

I have updated the fat lines raycasting example with the ability to set a line start and end width to demonstrate this feature.

<img width="1391" alt="image" src="https://github.com/mrdoob/three.js/assets/120892/72ab3ed6-e7bc-4f73-973d-8034a4d1135d">

There are a few visual imperfections with this implementation:
1. The end caps are not tangential to the body of each segment. So if there is a significant different in width between the start and end of a segment, relative to the distance between the points, there can be some peculiar rendering in both screen space and world space units.
2. In world space units, connected segments with variable widths have a little discontinuity in the widths at the joint, instead of connecting smoothly.

*This contribution is funded by [Zoox](https://zoox.com/)*
