### PR TITLE
Docs: Use `useLegacyLights=false` in browsers.

### DIFF
--- a/docs/scenes/bones-browser.html
+++ b/docs/scenes/bones-browser.html
@@ -43,11 +43,11 @@
 				Bone,
 				Color,
 				CylinderGeometry,
+				DirectionalLight,
 				DoubleSide,
 				Float32BufferAttribute,
 				MeshPhongMaterial,
 				PerspectiveCamera,
-				PointLight,
 				Scene,
 				SkinnedMesh,
 				Skeleton,
@@ -80,15 +80,16 @@
 				renderer = new WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
+				renderer.useLegacyLights = false;
 				document.body.appendChild( renderer.domElement );
 
 				orbit = new OrbitControls( camera, renderer.domElement );
 				orbit.enableZoom = false;
 
 				lights = [];
-				lights[ 0 ] = new PointLight( 0xffffff, 1, 0 );
-				lights[ 1 ] = new PointLight( 0xffffff, 1, 0 );
-				lights[ 2 ] = new PointLight( 0xffffff, 1, 0 );
+				lights[ 0 ] = new DirectionalLight( 0xffffff, 3 );
+				lights[ 1 ] = new DirectionalLight( 0xffffff, 3 );
+				lights[ 2 ] = new DirectionalLight( 0xffffff, 3 );
 
 				lights[ 0 ].position.set( 0, 200, 0 );
 				lights[ 1 ].position.set( 100, 200, 100 );

--- a/docs/scenes/ccdiksolver-browser.html
+++ b/docs/scenes/ccdiksolver-browser.html
@@ -84,6 +84,7 @@
 				renderer = new WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
+				renderer.useLegacyLights = false;
 				document.body.appendChild( renderer.domElement );
 
 				orbit = new OrbitControls( camera, renderer.domElement );

--- a/docs/scenes/geometry-browser.html
+++ b/docs/scenes/geometry-browser.html
@@ -48,6 +48,7 @@
 				ConeGeometry,
 				Curve,
 				CylinderGeometry,
+				DirectionalLight,
 				DodecahedronGeometry,
 				DoubleSide,
 				ExtrudeGeometry,
@@ -62,7 +63,6 @@
 				OctahedronGeometry,
 				PerspectiveCamera,
 				PlaneGeometry,
-				PointLight,
 				RingGeometry,
 				Scene,
 				Shape,
@@ -749,16 +749,17 @@
 			const renderer = new WebGLRenderer( { antialias: true } );
 			renderer.setPixelRatio( window.devicePixelRatio );
 			renderer.setSize( window.innerWidth, window.innerHeight );
+			renderer.useLegacyLights = false;
 			document.body.appendChild( renderer.domElement );
 
 			const orbit = new OrbitControls( camera, renderer.domElement );
 			orbit.enableZoom = false;
 
 			const lights = [];
-			lights[ 0 ] = new PointLight( 0xffffff, 1, 0 );
-			lights[ 1 ] = new PointLight( 0xffffff, 1, 0 );
-			lights[ 2 ] = new PointLight( 0xffffff, 1, 0 );
-
+			lights[ 0 ] = new DirectionalLight( 0xffffff, 3 );
+			lights[ 1 ] = new DirectionalLight( 0xffffff, 3 );
+			lights[ 2 ] = new DirectionalLight( 0xffffff, 3 );
+			
 			lights[ 0 ].position.set( 0, 200, 0 );
 			lights[ 1 ].position.set( 100, 200, 100 );
 			lights[ 2 ].position.set( - 100, - 200, - 100 );

--- a/docs/scenes/material-browser.html
+++ b/docs/scenes/material-browser.html
@@ -737,6 +737,7 @@
 			const renderer = new THREE.WebGLRenderer( { antialias: true } );
 			renderer.setPixelRatio( window.devicePixelRatio );
 			renderer.setSize( window.innerWidth, window.innerHeight );
+			renderer.useLegacyLights = false;
 			document.body.appendChild( renderer.domElement );
 
 			const pmremGenerator = new THREE.PMREMGenerator( renderer );
@@ -751,15 +752,15 @@
 			const ambientLight = new THREE.AmbientLight( 0x000000 );
 			scene.add( ambientLight );
 
-			const light1 = new THREE.PointLight( 0xffffff, 1, 0 );
+			const light1 = new THREE.DirectionalLight( 0xffffff, 3 );
 			light1.position.set( 0, 200, 0 );
 			scene.add( light1 );
 
-			const light2 = new THREE.PointLight( 0xffffff, 1, 0 );
+			const light2 = new THREE.DirectionalLight( 0xffffff, 3 );
 			light2.position.set( 100, 200, 100 );
 			scene.add( light2 );
 
-			const light3 = new THREE.PointLight( 0xffffff, 1, 0 );
+			const light3 = new THREE.DirectionalLight( 0xffffff, 3 );
 			light3.position.set( - 100, - 200, - 100 );
 			scene.add( light3 );
 


### PR DESCRIPTION
Related issue: -

**Description**

This PR ensures the documentation's live examples use `useLegacyLights=false`.
