### PR TITLE
WebGLRenderer: Fix shadow update when object is culled.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1093,6 +1093,9 @@ class WebGLRenderer {
 
 			const shadowsArray = currentRenderState.state.shadowsArray;
 
+			// muse be done before shadowMap.render, so that the number is the the same for shadows and real objects
+			this.info.render.frame ++;
+
 			shadowMap.render( shadowsArray, scene, camera );
 
 			if ( _clippingEnabled === true ) clipping.endShadows();
@@ -1101,7 +1104,6 @@ class WebGLRenderer {
 
 			if ( this.info.autoReset === true ) this.info.reset();
 
-			this.info.render.frame ++;
 
 			//
 
@@ -1230,19 +1232,6 @@ class WebGLRenderer {
 				} else if ( object.isMesh || object.isLine || object.isPoints ) {
 
 					if ( ! object.frustumCulled || _frustum.intersectsObject( object ) ) {
-
-						if ( object.isSkinnedMesh ) {
-
-							// update skeleton only once in a frame
-
-							if ( object.skeleton.frame !== info.render.frame ) {
-
-								object.skeleton.update();
-								object.skeleton.frame = info.render.frame;
-
-							}
-
-						}
 
 						const geometry = objects.update( object );
 						const material = object.material;

--- a/src/renderers/webgl/WebGLObjects.js
+++ b/src/renderers/webgl/WebGLObjects.js
@@ -37,6 +37,20 @@ function WebGLObjects( gl, geometries, attributes, info ) {
 
 		}
 
+		if ( object.isSkinnedMesh ) {
+
+			// update skeleton only once in a frame
+
+			if ( object.skeleton.frame !== info.render.frame ) {
+
+				object.skeleton.update();
+				object.skeleton.frame = info.render.frame;
+
+			}
+
+		}
+
+
 		return buffergeometry;
 
 	}


### PR DESCRIPTION
Related issue: #26292 

**Description**

Update of the skeleton needs to be called whenever the object or its shadow are rendered.  The update is optimized to be done only once per frame already, one just needs to be careful to have the rendered frame index updated at the right moment.

I have an updated bones-browser.html demonstrating the issue, however I am not sure if (and how) I should include it in this PR.