### PR TITLE
Editor: Fix `LDrawLoader` usage.

### DIFF
--- a/editor/js/Loader.js
+++ b/editor/js/Loader.js
@@ -444,7 +444,7 @@ function Loader( editor ) {
 
 					const loader = new LDrawLoader();
 					loader.setPath( '../../examples/models/ldraw/officialLibrary/' );
-					loader.parse( event.target.result, undefined, function ( group ) {
+					loader.parse( event.target.result, function ( group ) {
 
 						group.name = filename;
 						// Convert from LDraw coordinates: rotate 180 degrees around OX


### PR DESCRIPTION
Related issue: #26279

**Description**

This PR ensures the editor uses `LDrawLoader.parse()` correctly.