### PR TITLE
WebGLObjects: Optimize `InstancedMesh` updates.

### DIFF
--- a/src/objects/Skeleton.js
+++ b/src/objects/Skeleton.js
@@ -23,8 +23,6 @@ class Skeleton {
 		this.boneTexture = null;
 		this.boneTextureSize = 0;
 
-		this.frame = - 1;
-
 		this.init();
 
 	}

--- a/src/renderers/webgl/WebGLObjects.js
+++ b/src/renderers/webgl/WebGLObjects.js
@@ -27,11 +27,17 @@ function WebGLObjects( gl, geometries, attributes, info ) {
 
 			}
 
-			attributes.update( object.instanceMatrix, gl.ARRAY_BUFFER );
+			if ( updateMap.get( object ) !== frame ) {
 
-			if ( object.instanceColor !== null ) {
+				attributes.update( object.instanceMatrix, gl.ARRAY_BUFFER );
 
-				attributes.update( object.instanceColor, gl.ARRAY_BUFFER );
+				if ( object.instanceColor !== null ) {
+
+					attributes.update( object.instanceColor, gl.ARRAY_BUFFER );
+
+				}
+
+				updateMap.set( object, frame );
 
 			}
 
@@ -39,10 +45,13 @@ function WebGLObjects( gl, geometries, attributes, info ) {
 
 		if ( object.isSkinnedMesh ) {
 
-			if ( object.skeleton.frame !== info.render.frame ) {
+			const skeleton = object.skeleton;
 
-				object.skeleton.update();
-				object.skeleton.frame = info.render.frame;
+			if ( updateMap.get( skeleton ) !== frame ) {
+
+				skeleton.update();
+
+				updateMap.set( skeleton, frame );
 
 			}
 


### PR DESCRIPTION
Related issue: #26293

**Description**

I've noticed updating `InstancedMesh` can be improved by checking the `frame` value similar to how geometries are updated.

The PR also refactors the skeleton update by removing `Skeleton.frame`. The frame is now stored in the internal update map of `WebGLObjects`. 
