### PR TITLE
feature: export the class GLTFParser

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -4568,4 +4568,4 @@ function addPrimitiveAttributes( geometry, primitiveDef, parser ) {
 
 }
 
-export { GLTFLoader };
+export { GLTFLoader, GLTFParser };


### PR DESCRIPTION

**Description**

Sometime, Our databuffer is encrypted, so we need decrypt it before parse data buffer
