### PR TITLE
Added getScale(v) function to Matrix4

### DIFF
--- a/docs/api/en/math/Matrix4.html
+++ b/docs/api/en/math/Matrix4.html
@@ -231,6 +231,9 @@ zAxis = (c, g, k) </code>
 			attempt this, the method produces a zero matrix instead.
 		</p>
 
+		<h3>[method:this getScale]( [param:Vector3 v] )</h3>
+		<p>Gets the scale component from this matrix.</p>
+
 		<h3>[method:Float getMaxScaleOnAxis]()</h3>
 		<p>Gets the maximum scale value of the 3 axes.</p>
 

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -547,6 +547,18 @@ class Matrix4 {
 
 	}
 
+	getScale( v ) {
+
+		const te = this.elements;
+
+		v.x = _v1.set( te[ 0 ], te[ 1 ], te[ 2 ] ).length();
+		v.y = _v1.set( te[ 4 ], te[ 5 ], te[ 6 ] ).length();
+		v.z = _v1.set( te[ 8 ], te[ 9 ], te[ 10 ] ).length();
+
+		return this;
+
+	}
+
 	getMaxScaleOnAxis() {
 
 		const te = this.elements;

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -549,11 +549,9 @@ class Matrix4 {
 
 	getScale( v ) {
 
-		const te = this.elements;
-
-		v.x = _v1.set( te[ 0 ], te[ 1 ], te[ 2 ] ).length();
-		v.y = _v1.set( te[ 4 ], te[ 5 ], te[ 6 ] ).length();
-		v.z = _v1.set( te[ 8 ], te[ 9 ], te[ 10 ] ).length();
+		v.x = _v1.setFromMatrixColumn( this, 0 ).length();
+		v.y = _v1.setFromMatrixColumn( this, 1 ).length();
+		v.z = _v1.setFromMatrixColumn( this, 2 ).length();
 
 		return this;
 

--- a/test/unit/src/math/Matrix4.tests.js
+++ b/test/unit/src/math/Matrix4.tests.js
@@ -570,6 +570,23 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
+		QUnit.test( 'getScale', ( assert ) => {
+
+			const m = new Matrix4().set( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 );
+			const expected = new Vector3(
+				Math.sqrt( 1 * 1 + 5 * 5 + 9 * 9 ),
+				Math.sqrt( 2 * 2 + 6 * 6 + 10 * 10 ),
+				Math.sqrt( 3 * 3 + 7 * 7 + 11 * 11 ) );
+
+			const scale = new Vector3();
+			m.getScale( scale );
+
+			assert.ok( Math.abs( scale.x - expected.x ) <= eps, 'Passed!' );
+			assert.ok( Math.abs( scale.y - expected.y ) <= eps, 'Passed!' );
+			assert.ok( Math.abs( scale.z - expected.z ) <= eps, 'Passed!' );
+
+		} );
+
 		QUnit.test( 'getMaxScaleOnAxis', ( assert ) => {
 
 			const a = new Matrix4().set( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 );


### PR DESCRIPTION
This operation is often used when working with transformation matrices. We have to use Matrix4.decompose() to get scaling, which is much slower than the proposed getScale().