### PR TITLE
Vector2/3/4: Update constructors slightly

### DIFF
--- a/examples/jsm/nodes/core/NodeUtils.js
+++ b/examples/jsm/nodes/core/NodeUtils.js
@@ -137,12 +137,6 @@ export function getValueFromType( type, ...params ) {
 
 	const last4 = type ? type.slice( - 4 ) : undefined;
 
-	if ( ( last4 === 'vec2' || last4 === 'vec3' || last4 === 'vec4' ) && params.length === 1 ) { // ensure same behaviour as in NodeBuilder.format()
-
-		params = last4 === 'vec2' ? [ params[ 0 ], params[ 0 ] ] : [ params[ 0 ], params[ 0 ], params[ 0 ] ];
-
-	}
-
 	if ( type === 'color' ) {
 
 		return new Color( ...params );

--- a/src/math/Vector2.js
+++ b/src/math/Vector2.js
@@ -2,7 +2,7 @@ import * as MathUtils from './MathUtils.js';
 
 class Vector2 {
 
-	constructor( x = 0, y = 0 ) {
+	constructor( x = 0, y = x ) {
 
 		Vector2.prototype.isVector2 = true;
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -3,9 +3,16 @@ import { Quaternion } from './Quaternion.js';
 
 class Vector3 {
 
-	constructor( x = 0, y = 0, z = 0 ) {
+	constructor( x = 0, y, z ) {
 
 		Vector3.prototype.isVector3 = true;
+
+		if ( z === undefined ) {
+
+			if ( y === undefined ) z = y = x;
+			else z = 0;
+
+		}
 
 		this.x = x;
 		this.y = y;

--- a/src/math/Vector4.js
+++ b/src/math/Vector4.js
@@ -1,8 +1,15 @@
 class Vector4 {
 
-	constructor( x = 0, y = 0, z = 0, w = 1 ) {
+	constructor( x = 0, y, z, w = 1 ) {
 
 		Vector4.prototype.isVector4 = true;
+
+		if ( z === undefined ) {
+
+			if ( y === undefined ) z = y = x;
+			else z = 0;
+
+		}
 
 		this.x = x;
 		this.y = y;

--- a/test/unit/src/math/Vector2.tests.js
+++ b/test/unit/src/math/Vector2.tests.js
@@ -20,6 +20,10 @@ export default QUnit.module( 'Maths', () => {
 			assert.ok( a.x == 0, 'Passed!' );
 			assert.ok( a.y == 0, 'Passed!' );
 
+			a = new Vector2( x );
+			assert.ok( a.x == x, 'Passed!' );
+			assert.ok( a.y == x, 'Passed!' );
+
 			a = new Vector2( x, y );
 			assert.ok( a.x === x, 'Passed!' );
 			assert.ok( a.y === y, 'Passed!' );

--- a/test/unit/src/math/Vector3.tests.js
+++ b/test/unit/src/math/Vector3.tests.js
@@ -30,6 +30,16 @@ export default QUnit.module( 'Maths', () => {
 			assert.ok( a.y == 0, 'Passed!' );
 			assert.ok( a.z == 0, 'Passed!' );
 
+			a = new Vector3( x );
+			assert.ok( a.x == x, 'Passed!' );
+			assert.ok( a.y == x, 'Passed!' );
+			assert.ok( a.z == x, 'Passed!' );
+
+			a = new Vector3( x, y );
+			assert.ok( a.x == x, 'Passed!' );
+			assert.ok( a.y == y, 'Passed!' );
+			assert.ok( a.z == 0, 'Passed!' );
+
 			a = new Vector3( x, y, z );
 			assert.ok( a.x === x, 'Passed!' );
 			assert.ok( a.y === y, 'Passed!' );

--- a/test/unit/src/math/Vector4.tests.js
+++ b/test/unit/src/math/Vector4.tests.js
@@ -24,6 +24,24 @@ export default QUnit.module( 'Maths', () => {
 			assert.ok( a.z == 0, 'Passed!' );
 			assert.ok( a.w == 1, 'Passed!' );
 
+			a = new Vector4( x );
+			assert.ok( a.x === x, 'Passed!' );
+			assert.ok( a.y === x, 'Passed!' );
+			assert.ok( a.z === x, 'Passed!' );
+			assert.ok( a.w === 1, 'Passed!' );
+
+			a = new Vector4( x, y );
+			assert.ok( a.x === x, 'Passed!' );
+			assert.ok( a.y === y, 'Passed!' );
+			assert.ok( a.z === 0, 'Passed!' );
+			assert.ok( a.w === 1, 'Passed!' );
+
+			a = new Vector4( x, y, z );
+			assert.ok( a.x === x, 'Passed!' );
+			assert.ok( a.y === y, 'Passed!' );
+			assert.ok( a.z === z, 'Passed!' );
+			assert.ok( a.w === 1, 'Passed!' );
+
 			a = new Vector4( x, y, z, w );
 			assert.ok( a.x === x, 'Passed!' );
 			assert.ok( a.y === y, 'Passed!' );


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/26025#discussion_r1189910302

**Description**

This updates the constructors of Vector classes (tests included, docs not yet updated) allowing use-cases like `new Vector2( 1 )` -- meaning `(1, 1)` contrary to the `(1, 0)` before. This mimics the vectors behavior from the Nodes system.

This is _a bit_ of a breaking change:
* `new Vector2()` -- was (0, 0), remains (0, 0), nothing changes,
* `new Vector2( x )` -- was (x, 0), becomes (x, x), **changes**,
* `new Vector2( x, y )` -- was (x, y), remains (x, y), nothing changes,
* `new Vector3()` -- was (0, 0, 0), remains (0, 0, 0), nothing changes,
* `new Vector3( x )` -- was (x, 0, 0), becomes (x, x, x), **changes**,
* `new Vector3( x, y )` -- was (x, y, 0), remains (x, y, 0), nothing changes,
* `new Vector3( x, y, z )` -- was (x, y, z), remains (x, y, z), nothing changes,
* `new Vector4()` -- was (0, 0, 0, 1), remains (0, 0, 0, 1), nothing changes,
* `new Vector4( x )` -- was (x, 0, 0, 1), becomes (x, x, x, 1), **changes**,
* `new Vector4( x, y )` -- was (x, y, 0, 1), remains (x, y, 0, 1), nothing changes,
* `new Vector4( x, y, z )` -- was (x, y, z, 1), remains (x, y, z, 1), nothing changes,
* `new Vector4( x, y, z, w )` -- was (x, y, z, w), remains (x, y, z, w), nothing changes.

I'm not sure how used were these breaking cases before, but I don't think that much.

@mrdoob @Mugen87 @sunag What is your opinion about this? Should we do this, effectively upstreaming the convention from the Nodes system to the core?