### PR TITLE
Editor: Fix import of TGA textures.

### DIFF
--- a/editor/js/libs/ui.three.js
+++ b/editor/js/libs/ui.three.js
@@ -76,18 +76,22 @@ class UITexture extends UISpan {
 
 				reader.addEventListener( 'load', function ( event ) {
 
-					const canvas = new TGALoader().parse( event.target.result );
+					const loader = new TGALoader();
+					loader.load( event.target.result, function ( texture ) {
 
-					const texture = new THREE.CanvasTexture( canvas, mapping );
-					texture.sourceFile = file.name;
+						texture.colorSpace = THREE.SRGBColorSpace;
+						texture.sourceFile = file.name;
 
-					scope.setValue( texture );
+						scope.setValue( texture );
 
-					if ( scope.onChangeCallback ) scope.onChangeCallback( texture );
+						if ( scope.onChangeCallback ) scope.onChangeCallback( texture );
+
+
+					} );
 
 				}, false );
 
-				reader.readAsArrayBuffer( file );
+				reader.readAsDataURL( file );
 
 			} else if ( file.type.match( 'image.*' ) ) {
 


### PR DESCRIPTION
Fixed #26312.

**Description**

This PR fixes the usage of TGA textures when importing them over the UI. It uses a the same approach like when loading HDR textures via `RGBELoader`.
