### PR TITLE
Examples: Change how after image effect is toggled.

### DIFF
--- a/examples/webgl_postprocessing_afterimage.html
+++ b/examples/webgl_postprocessing_afterimage.html
@@ -116,15 +116,10 @@
 				mesh.rotation.x += 0.005;
 				mesh.rotation.y += 0.01;
 
-				if ( params.enable ) {
+				afterimagePass.enabled = params.enable;
 
-					composer.render();
+				composer.render();
 
-				} else {
-
-					renderer.render( scene, camera );
-
-				}
 
 			}
 


### PR DESCRIPTION
Fixed #26320.

**Description**

The `enable` GUI option in `webgl_postprocessing_afterimage` now toggles the after image effect and not the entire usage of `EffectComposer`.