### PR TITLE
WebXRManager: re-enable getCamera()

### DIFF
--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -68,7 +68,11 @@ class WebXRManager extends EventDispatcher {
 
 		this.isPresenting = false;
 
-		this.getCamera = function () {}; // @deprecated, r153
+		this.getCamera = function () {
+
+			return cameraXR;
+
+		};
 
 		this.setUserCamera = function ( value ) {
 


### PR DESCRIPTION
Related Issue: #26041

**Description**

`WebXRManager.getCamera()` was removed in favor of `WebXRManager.setUserCamera()` but as others and myself have expressed, this doesn't allow finer control over layers etc.