### PR TITLE
Examples: Fix displacement map usage of velocity shader.

### DIFF
--- a/examples/webgl_materials_channels.html
+++ b/examples/webgl_materials_channels.html
@@ -200,6 +200,7 @@
 					fragmentShader: VelocityShader.fragmentShader,
 					side: THREE.DoubleSide
 				} );
+				materialVelocity.displacementMap = displacementMap; // required for defines
 				materialVelocity.uniforms.displacementMap.value = displacementMap;
 				materialVelocity.uniforms.displacementScale.value = SCALE;
 				materialVelocity.uniforms.displacementBias.value = BIAS;


### PR DESCRIPTION
Related issue: -

**Description**

The displacement map for the velocity shader in `webgl_materials_channels` is broken since the displacement defines are not properly generated. This can easily be fixed by adding a member `displacementMap` to the custom material. 
