### PR TITLE
ArcballControls: Add `rotateSpeed`.

### DIFF
--- a/docs/examples/en/controls/ArcballControls.html
+++ b/docs/examples/en/controls/ArcballControls.html
@@ -186,6 +186,16 @@
 			How far you can zoom in ( [page:OrthographicCamera] only ). Default is 0.
 		</p>
 
+		<h3>[property:Float radiusFactor]</h3>
+		<p>
+			The size of the gizmo relative to the screen width and height. Default is 0.67.
+		</p>
+
+		<h3>[property:Float rotateSpeed]</h3>
+		<p>
+			Speed of rotation. Default is 1.
+		</p>
+
 		<h3>[property:Float scaleFactor]</h3>
 		<p>
 			The scaling factor used when performing zoom operation.
@@ -199,11 +209,6 @@
 		<h3>[property:Float wMax]</h3>
 		<p>
 			Maximum angular velocity allowed on rotation animation start.
-		</p>
-
-		<h3>[property:Float radiusFactor]</h3>
-		<p>
-			The size of the gizmo relative to the screen width and height. Default is 0.67.
 		</p>
 
 

--- a/examples/jsm/controls/ArcballControls.js
+++ b/examples/jsm/controls/ArcballControls.js
@@ -199,6 +199,7 @@ class ArcballControls extends EventDispatcher {
 		this.cursorZoom = false;	//if wheel zoom should be cursor centered
 		this.minFov = 5;
 		this.maxFov = 90;
+		this.rotateSpeed = 1;
 
 		this.enabled = true;
 		this.enablePan = true;
@@ -445,7 +446,7 @@ class ArcballControls extends EventDispatcher {
 
 							const distance = this._startCursorPosition.distanceTo( this._currentCursorPosition );
 							const angle = this._startCursorPosition.angleTo( this._currentCursorPosition );
-							const amount = Math.max( distance / this._tbRadius, angle ); //effective rotation angle
+							const amount = Math.max( distance / this._tbRadius, angle ) * this.rotateSpeed; //effective rotation angle
 
 							this.applyTransformMatrix( this.rotate( this.calculateRotationAxis( this._startCursorPosition, this._currentCursorPosition ), amount ) );
 


### PR DESCRIPTION
**Description**

The user wants to set the rotational speed for the arcball controls. Currently it is fix and cannot be set. Similar to the orbit controls, I added a "rotateSpeed" option that lets you define a speed factor.
