### PR TITLE
WebGPURenderer: Render Pass ID and Double Pass

### DIFF
--- a/examples/jsm/renderers/common/RenderObjects.js
+++ b/examples/jsm/renderers/common/RenderObjects.js
@@ -13,26 +13,26 @@ class RenderObjects {
 		this.info = info;
 
 		this.chainMaps = {};
-		this.dataMaps = {};
+		this.dataMap = new DataMap();
 
 	}
 
-	get( object, material, scene, camera, lightsNode, namespace ) {
+	get( object, material, scene, camera, lightsNode, passId ) {
 
-		const chainMap = this.getChainMap( namespace );
+		const chainMap = this.getChainMap( passId );
 		const chainArray = [ object, material, scene, camera, lightsNode ];
 
 		let renderObject = chainMap.get( chainArray );
 
 		if ( renderObject === undefined ) {
 
-			renderObject = this.createRenderObject( this.nodes, this.geometries, this.renderer, object, material, scene, camera, lightsNode, namespace );
+			renderObject = this.createRenderObject( this.nodes, this.geometries, this.renderer, object, material, scene, camera, lightsNode, passId );
 
 			chainMap.set( chainArray, renderObject );
 
 		} else {
 
-			const data = this.getDataMap( namespace ).get( renderObject );
+			const data = this.dataMap.get( renderObject );
 			const cacheKey = renderObject.getCacheKey();
 
 			if ( data.cacheKey !== cacheKey ) {
@@ -49,29 +49,23 @@ class RenderObjects {
 
 	}
 
-	getChainMap( namespace = 'default' ) {
+	getChainMap( passId = 'default' ) {
 
-		return this.chainMaps[ namespace ] || ( this.chainMaps[ namespace ] = new ChainMap() );
-
-	}
-
-	getDataMap( namespace = 'default' ) {
-
-		return this.dataMaps[ namespace ] || ( this.dataMaps[ namespace ] = new DataMap() );
+		return this.chainMaps[ passId ] || ( this.chainMaps[ passId ] = new ChainMap() );
 
 	}
 
 	dispose() {
 
 		this.chainMaps = {};
-		this.dataMaps = {};
+		this.dataMap = new DataMap();
 
 	}
 
-	createRenderObject( nodes, geometries, renderer, object, material, scene, camera, lightsNode, namespace ) {
+	createRenderObject( nodes, geometries, renderer, object, material, scene, camera, lightsNode, passId ) {
 
-		const chainMap = this.getChainMap( namespace );
-		const dataMap = this.getDataMap( namespace );
+		const chainMap = this.getChainMap( passId );
+		const dataMap = this.dataMap;
 		const renderObject = new RenderObject( nodes, geometries, renderer, object, material, scene, camera, lightsNode );
 
 		const data = dataMap.get( renderObject );

--- a/examples/jsm/renderers/common/Renderer.js
+++ b/examples/jsm/renderers/common/Renderer.js
@@ -10,7 +10,7 @@ import RenderContexts from './RenderContexts.js';
 import Textures from './Textures.js';
 import Background from './Background.js';
 import Nodes from './nodes/Nodes.js';
-import { Frustum, Matrix4, Vector2, Vector3, Vector4, Color, SRGBColorSpace, NoToneMapping } from 'three';
+import { Frustum, Matrix4, Vector2, Vector3, Vector4, Color, DoubleSide, BackSide, FrontSide, SRGBColorSpace, NoToneMapping } from 'three';
 
 const _drawingBufferSize = new Vector2();
 const _screen = new Vector4();
@@ -805,17 +805,47 @@ class Renderer {
 
 		//
 
-		const renderObject = this._objects.get( object, material, scene, camera, lightsNode );
+		object.modelViewMatrix.multiplyMatrices( camera.matrixWorldInverse, object.matrixWorld );
+		object.normalMatrix.getNormalMatrix( object.modelViewMatrix );
+
+		//
+
+		material.onBeforeRender( this, scene, camera, geometry, material, group );
+
+		//
+
+		if ( material.transparent === true && material.side === DoubleSide && material.forceSinglePass === false ) {
+
+			material.side = BackSide;
+			this._renderObjectDirect( object, scene, camera, geometry, material, group, lightsNode, 'backSide' );
+
+			material.side = FrontSide;
+			this._renderObjectDirect( object, scene, camera, geometry, material, group, lightsNode );
+
+			material.side = DoubleSide;
+
+		} else {
+
+			this._renderObjectDirect( object, scene, camera, geometry, material, group, lightsNode );
+
+		}
+
+		//
+
+		object.onAfterRender( this, scene, camera, geometry, material, group );
+
+	}
+
+	_renderObjectDirect( object, scene, camera, geometry, material, group, lightsNode, namespace ) {
+
+		//
+
+		const renderObject = this._objects.get( object, material, scene, camera, lightsNode, namespace );
 		renderObject.context = this._currentRenderContext;
 
 		//
 
 		this._nodes.updateBefore( renderObject );
-
-		//
-
-		object.modelViewMatrix.multiplyMatrices( camera.matrixWorldInverse, object.matrixWorld );
-		object.normalMatrix.getNormalMatrix( object.modelViewMatrix );
 
 		//
 

--- a/examples/jsm/renderers/common/Renderer.js
+++ b/examples/jsm/renderers/common/Renderer.js
@@ -817,10 +817,10 @@ class Renderer {
 		if ( material.transparent === true && material.side === DoubleSide && material.forceSinglePass === false ) {
 
 			material.side = BackSide;
-			this._renderObjectDirect( object, scene, camera, geometry, material, group, lightsNode, 'backSide' );
+			this._renderObjectDirect( object, scene, camera, geometry, material, group, lightsNode, 'backSide' ); // create backSide pass id
 
 			material.side = FrontSide;
-			this._renderObjectDirect( object, scene, camera, geometry, material, group, lightsNode );
+			this._renderObjectDirect( object, scene, camera, geometry, material, group, lightsNode ); // use default pass id
 
 			material.side = DoubleSide;
 

--- a/examples/jsm/renderers/common/Renderer.js
+++ b/examples/jsm/renderers/common/Renderer.js
@@ -836,11 +836,11 @@ class Renderer {
 
 	}
 
-	_renderObjectDirect( object, scene, camera, geometry, material, group, lightsNode, namespace ) {
+	_renderObjectDirect( object, scene, camera, geometry, material, group, lightsNode, passId ) {
 
 		//
 
-		const renderObject = this._objects.get( object, material, scene, camera, lightsNode, namespace );
+		const renderObject = this._objects.get( object, material, scene, camera, lightsNode, passId );
 		renderObject.context = this._currentRenderContext;
 
 		//

--- a/examples/webgpu_backdrop_area.html
+++ b/examples/webgpu_backdrop_area.html
@@ -86,16 +86,19 @@
 				volumeMaterial.backdropNode = viewportSharedTexture();
 				volumeMaterial.backdropAlphaNode = depthAlphaNode;
 				volumeMaterial.transparent = true;
+				volumeMaterial.side = THREE.DoubleSide;
 
 				const depthMaterial = new MeshBasicNodeMaterial();
 				depthMaterial.backdropNode = depthAlphaNode;
 				depthMaterial.transparent = true;
+				depthMaterial.side = THREE.DoubleSide;
 
 				const bicubicMaterial = new MeshBasicNodeMaterial();
 				bicubicMaterial.backdropNode = viewportMipTexture().bicubic( 5 ); // @TODO: Move to alpha value [ 0, 1 ]
 				bicubicMaterial.backdropAlphaNode = checker( uv().mul( 3 ).mul( modelScale.xy ) );
 				bicubicMaterial.opacityNode = bicubicMaterial.backdropAlphaNode;
 				bicubicMaterial.transparent = true;
+				bicubicMaterial.side = THREE.DoubleSide;
 
 				const pixelMaterial = new MeshBasicNodeMaterial();
 				pixelMaterial.backdropNode = viewportSharedTexture( viewportTopLeft.mul( 100 ).floor().div( 100 ) );
@@ -105,14 +108,7 @@
 
 				const box = new THREE.Mesh( new THREE.BoxGeometry( 2, 2, 2 ), volumeMaterial );
 				box.position.set( 0, 1, 0 );
-				//box.material.side = THREE.DoubleSide; // @TODO: Needed add support to material.forceSinglePass = false;
 				scene.add( box );
-
-				const boxBack = new THREE.Mesh( new THREE.BoxGeometry( 2, 2, 2 ).scale( - 1, - 1, - 1 ), volumeMaterial );
-				boxBack.position.set( 0, 1, 0 );
-				boxBack.renderOrder = - 1;
-				boxBack.visible = false;
-				scene.add( boxBack );
 
 				const floor = new THREE.Mesh( new THREE.BoxGeometry( 1.99, .01, 1.99 ), new MeshBasicNodeMaterial( { color: 0x333333 } ) );
 				floor.position.set( 0, 0, 0 );
@@ -146,12 +142,11 @@
 				const gui = new GUI();
 				const options = { material: 'volume' };
 
-				gui.add( box.scale, 'x', 0.1, 2, 0.01 ).onChange( () => boxBack.scale.copy( box.scale ) );
-				gui.add( box.scale, 'z', 0.1, 2, 0.01 ).onChange( () => boxBack.scale.copy( box.scale ) );
+				gui.add( box.scale, 'x', 0.1, 2, 0.01 );
+				gui.add( box.scale, 'z', 0.1, 2, 0.01 );
 				gui.add( options, 'material', Object.keys( materials ) ).onChange( name => {
 
-					box.material = boxBack.material = materials[ name ];
-					boxBack.visible = ( name === 'bicubic' );
+					box.material = materials[ name ];
 
 				} );
 


### PR DESCRIPTION
**Description**

`RenderObjects` `pass id` is useful to renderer the same object with internal modifications without needs to use `material.needsUpdate` and preserving the chain map.

Added support for `forceSinglePass = false`

https://raw.githack.com/sunag/three.js/dev-ns/examples/webgpu_backdrop_area.html

![image](https://github.com/mrdoob/three.js/assets/502810/ab3beb4b-3362-4e93-9f8f-5358abe23c70)
