### PR TITLE
MeshPhysicalMaterial: Fix shader error for clear coat/anisotropy when normal map is missing.

### DIFF
--- a/src/renderers/shaders/ShaderChunk/normal_fragment_begin.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/normal_fragment_begin.glsl.js
@@ -27,7 +27,15 @@ float faceDirection = gl_FrontFacing ? 1.0 : - 1.0;
 
 	#else
 
-		mat3 tbn = getTangentFrame( - vViewPosition, normal, vNormalMapUv );
+		mat3 tbn = getTangentFrame( - vViewPosition, normal,
+		#if defined( USE_NORMALMAP )
+			vNormalMapUv
+		#elif defined( USE_CLEARCOAT_NORMALMAP )
+			vClearcoatNormalMapUv
+		#else
+			vUv
+		#endif
+		);
 
 	#endif
 

--- a/src/renderers/shaders/ShaderChunk/uv_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/uv_pars_fragment.glsl.js
@@ -1,5 +1,5 @@
 export default /* glsl */`
-#ifdef USE_UV
+#if defined( USE_UV ) || defined( USE_ANISOTROPY )
 
 	varying vec2 vUv;
 

--- a/src/renderers/shaders/ShaderChunk/uv_pars_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/uv_pars_vertex.glsl.js
@@ -1,5 +1,5 @@
 export default /* glsl */`
-#ifdef USE_UV
+#if defined( USE_UV ) || defined( USE_ANISOTROPY )
 
 	varying vec2 vUv;
 

--- a/src/renderers/shaders/ShaderChunk/uv_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/uv_vertex.glsl.js
@@ -1,5 +1,5 @@
 export default /* glsl */`
-#ifdef USE_UV
+#if defined( USE_UV ) || defined( USE_ANISOTROPY )
 
 	vUv = vec3( uv, 1 ).xy;
 


### PR DESCRIPTION
Related PR discussion: https://github.com/mrdoob/three.js/pull/25580#discussion_r1241101709

**Description**

Add support for using vUv or vClearcoatMapUv for anisotropy when normal map is not present.
This is the smallest fix. It's also possible to set USE_UV in javascript instead of checking for USE_ANISTROPY while defining the variable.

Fixes loading of model from: https://discourse.threejs.org/t/shader-error-0-validate-status-false/53195/2
Model: https://sketchfab.com/3d-models/free-1975-porsche-911-930-turbo-8568d9d14a994b9cae59499f0dbed21e#download

