### PR TITLE
Example webgpu_instance_uniform: generate -> construct

### DIFF
--- a/examples/webgpu_instance_uniform.html
+++ b/examples/webgpu_instance_uniform.html
@@ -60,9 +60,9 @@
 
 				}
 
-				generate( builder, output ) {
+				construct( /*builder*/ ) {
 
-					return this.uniformNode.build( builder, output );
+					return this.uniformNode;
 
 				}
 


### PR DESCRIPTION
**Description**

In case of a `Node` returns other nodes it is better to use `construct()` instead of `generate()`, it usually makes better use of cache.
