### PR TITLE
Puppeteer E2E test: Fix WebGL on Mac ARM

### DIFF
--- a/test/e2e/puppeteer.js
+++ b/test/e2e/puppeteer.js
@@ -229,8 +229,8 @@ async function main() {
 
 	/* Launch browser */
 
-	const flags = [ '--hide-scrollbars', '--enable-unsafe-webgpu' ];
-	flags.push( '--enable-features=Vulkan', '--use-gl=swiftshader', '--use-angle=swiftshader', '--use-vulkan=swiftshader', '--use-webgpu-adapter=swiftshader' );
+	const flags = [ '--hide-scrollbars', '--enable-gpu' ];
+	// flags.push( '--enable-unsafe-webgpu', '--enable-features=Vulkan', '--use-gl=swiftshader', '--use-angle=swiftshader', '--use-vulkan=swiftshader', '--use-webgpu-adapter=swiftshader' );
 	// if ( process.platform === 'linux' ) flags.push( '--enable-features=Vulkan,UseSkiaRenderer', '--use-vulkan=native', '--disable-vulkan-surface', '--disable-features=VaapiVideoDecoder', '--ignore-gpu-blocklist', '--use-angle=vulkan' );
 
 	const viewport = { width: width * viewScale, height: height * viewScale };


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/25504#issuecomment-1429458541 https://github.com/mrdoob/three.js/pull/25504#issuecomment-1429505564 https://github.com/mrdoob/three.js/pull/26341#issue-1778040105

**Description**

This should probably fix WebGL on Mac ARM by using `--enable-gpu` flag.

@donmccurdy Does it solve your issue?