### PR TITLE
Improved performance of Unreal Bloom example.

### DIFF
--- a/examples/jsm/postprocessing/UnrealBloomPass.js
+++ b/examples/jsm/postprocessing/UnrealBloomPass.js
@@ -300,19 +300,16 @@ class UnrealBloomPass extends Pass {
 
 		const coefficients = [];
 
-		const sigma = kernelRadius;
-
 		for ( let i = 0; i < kernelRadius; i ++ ) {
 
-			coefficients.push( 0.39894 * Math.exp( - 0.5 * i * i / ( sigma * sigma ) ) / sigma );
+			coefficients.push( 0.39894 * Math.exp( - 0.5 * i * i / ( kernelRadius * kernelRadius ) ) / kernelRadius );
 
 		}
 
 		return new ShaderMaterial( {
 
 			defines: {
-				'KERNEL_RADIUS': kernelRadius,
-				'SIGMA': kernelRadius
+				'KERNEL_RADIUS': kernelRadius
 			},
 
 			uniforms: {


### PR DESCRIPTION
Implemented pre-calculated Gaussian coefficients in shader for Unreal Bloom example.

Related issue: None.

**Description**

I've noticed that fragment shader for blur calculates Gaussian coefficients which uses quite expensive math.
I moved these coefficients to a pre-computed uniform array which eliminated most of math in shader.
Additionally, simplified math for texture fetch - passing reciprocal of texture size instead of calculating it per fragment.

Visually there is no difference between the old and new shaders - math is kept intact, only offloaded from GPU to CPU.