### PR TITLE
Implement the ownKeys trap for ShaderNode proxy

### DIFF
--- a/examples/jsm/nodes/shadernode/ShaderNode.js
+++ b/examples/jsm/nodes/shadernode/ShaderNode.js
@@ -27,6 +27,15 @@ const shaderNodeHandler = {
 
 	},
 
+	ownKeys(node) {
+		const nodeElements = [...NodeElements.keys()];
+		return Object.getOwnPropertyNames(node)
+			.concat(nodeElements)
+			.concat(nodeElements.map(element => element + "Assign"))
+			.concat(["w", "z", "y", "x"].reduce((acc, el) => (acc.forEach(v => acc.push(el + v)), acc.push(el), acc), []))
+			.concat(["width", "height"]);
+	},
+
 	get: function ( node, prop, nodeObj ) {
 
 		if ( typeof prop === 'string' && node[ prop ] === undefined ) {

--- a/examples/jsm/nodes/shadernode/ShaderNode.js
+++ b/examples/jsm/nodes/shadernode/ShaderNode.js
@@ -27,13 +27,16 @@ const shaderNodeHandler = {
 
 	},
 
-	ownKeys(node) {
-		const nodeElements = [...NodeElements.keys()];
-		return Object.getOwnPropertyNames(node)
-			.concat(nodeElements)
-			.concat(nodeElements.map(element => element + "Assign"))
-			.concat(["w", "z", "y", "x"].reduce((acc, el) => (acc.forEach(v => acc.push(el + v)), acc.push(el), acc), []))
-			.concat(["width", "height"]);
+	ownKeys( node ) {
+
+		const nodeElements = [ ...NodeElements.keys() ];
+
+		return Object.getOwnPropertyNames( node )
+			.concat( nodeElements )
+			.concat( nodeElements.map( element => element + "Assign" ) )
+			.concat( [ "w", "z", "y", "x" ].reduce( ( acc, el ) => ( acc.forEach( v => acc.push( el + v ) ), acc.push( el ), acc ), [] ) )
+			.concat( [ "width", "height" ] );
+
 	},
 
 	get: function ( node, prop, nodeObj ) {

--- a/examples/jsm/nodes/shadernode/ShaderNode.js
+++ b/examples/jsm/nodes/shadernode/ShaderNode.js
@@ -33,9 +33,9 @@ const shaderNodeHandler = {
 
 		return Object.getOwnPropertyNames( node )
 			.concat( nodeElements )
-			.concat( nodeElements.map( element => element + "Assign" ) )
-			.concat( [ "w", "z", "y", "x" ].reduce( ( acc, el ) => ( acc.forEach( v => acc.push( el + v ) ), acc.push( el ), acc ), [] ) )
-			.concat( [ "width", "height" ] );
+			.concat( nodeElements.map( element => element + 'Assign' ) )
+			.concat( [ 'w', 'z', 'y', 'x' ].reduce( ( acc, el ) => ( acc.forEach( v => acc.push( el + v ) ), acc.push( el ), acc ), [] ) )
+			.concat( [ 'width', 'height' ] );
 
 	},
 

--- a/examples/jsm/nodes/shadernode/ShaderNode.js
+++ b/examples/jsm/nodes/shadernode/ShaderNode.js
@@ -18,7 +18,6 @@ export function addNodeElement( name, nodeElement ) {
 }
 
 const shaderNodeHandler = {
-
 	construct( NodeClosure, params ) {
 
 		const inputs = params.shift();
@@ -31,12 +30,11 @@ const shaderNodeHandler = {
 
 		const nodeElements = [ ...NodeElements.keys() ];
 
-		return Object.getOwnPropertyNames( node )
+		return [...new Set(Object.getOwnPropertyNames( node )
 			.concat( nodeElements )
 			.concat( nodeElements.map( element => element + 'Assign' ) )
 			.concat( [ 'w', 'z', 'y', 'x' ].reduce( ( acc, el ) => ( acc.forEach( v => acc.push( el + v ) ), acc.push( el ), acc ), [] ) )
-			.concat( [ 'width', 'height' ] );
-
+			.concat( [ 'width', 'height' ] ))];
 	},
 
 	get: function ( node, prop, nodeObj ) {


### PR DESCRIPTION
Related issue: N/A

**Description**

Adds the ownKeys trap to the ShaderNode proxy. Implementing ownkeys allows for autocompletion on ShaderNode chain functions.