### PR TITLE
Examples: Fix color space in `webgl_materials_video_webcam`.

### DIFF
--- a/examples/webgl_materials_video_webcam.html
+++ b/examples/webgl_materials_video_webcam.html
@@ -48,6 +48,7 @@
 				video = document.getElementById( 'video' );
 
 				const texture = new THREE.VideoTexture( video );
+				texture.colorSpace = THREE.SRGBColorSpace;
 
 				const geometry = new THREE.PlaneGeometry( 16, 9 );
 				geometry.scale( 0.5, 0.5, 0.5 );


### PR DESCRIPTION
Related issue: https://discourse.threejs.org/t/webcam-texture-is-washed-out/53412

**Description**

It was noticed in the forum that the sRGB color space definition for the video texture in `webgl_materials_video_webcam` is missing.
