### PR TITLE
Add THREE.CompressedCubeTexture

### DIFF
--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -14,6 +14,7 @@
 import {
 	CompressedTexture,
 	CompressedArrayTexture,
+	CompressedCubeTexture,
 	Data3DTexture,
 	DataTexture,
 	FileLoader,
@@ -261,10 +262,7 @@ class KTX2Loader extends Loader {
 
 		if ( container.faceCount === 6 ) {
 
-			texture = new CompressedTexture();
-			texture.image = faces;
-			texture.format = format;
-			texture.type = UnsignedByteType;
+			texture = new CompressedCubeTexture( faces, format, UnsignedByteType );
 
 		} else {
 

--- a/src/Three.js
+++ b/src/Three.js
@@ -34,6 +34,7 @@ export { DataArrayTexture } from './textures/DataArrayTexture.js';
 export { Data3DTexture } from './textures/Data3DTexture.js';
 export { CompressedTexture } from './textures/CompressedTexture.js';
 export { CompressedArrayTexture } from './textures/CompressedArrayTexture.js';
+export { CompressedCubeTexture } from './textures/CompressedCubeTexture.js';
 export { CubeTexture } from './textures/CubeTexture.js';
 export { CanvasTexture } from './textures/CanvasTexture.js';
 export { DepthTexture } from './textures/DepthTexture.js';

--- a/src/textures/CompressedCubeTexture.js
+++ b/src/textures/CompressedCubeTexture.js
@@ -1,0 +1,19 @@
+import { CubeReflectionMapping } from '../constants.js';
+import { CompressedTexture } from './CompressedTexture.js';
+
+class CompressedCubeTexture extends CompressedTexture {
+
+	constructor( images, format, type ) {
+
+		super( undefined, images[ 0 ].width, images[ 0 ].height, format, type, CubeReflectionMapping );
+
+		this.isCompressedCubeTexture = true;
+		this.isCubeTexture = true;
+
+		this.image = images;
+
+	}
+
+}
+
+export { CompressedCubeTexture };


### PR DESCRIPTION
Related:

- #24065
- #25871
- #25909

Adds a *THREE.CompressedCubeTexture* class, and updates THREE.KTX2Loader to use it where appropriate. This resolves issues discussed in #25909, where the renderer failed to recognize 'synthetic' compressed cube textures in some cases.


I've kept the constructor signature simple, at least for the time being:

```
constructor( images, format, type ) { ... }
```

Tested against the texture below:

[pisa.ktx2.zip](https://github.com/mrdoob/three.js/files/11944123/pisa.ktx2.zip)

The texture was generated from our Pisa PNG cubemap, with the KTX-Software v4.3 alpha release. I ran into an issue with the alpha release, tracked in https://github.com/KhronosGroup/KTX-Software/issues/728, but in future stable releases the command below should work as-is:

```
ktx create --cubemap --format R8G8B8_SRGB --encode uastc --assign-oetf srgb \
  px.png nx.png py.png ny.png pz.png nz.png pisa.ktx2
```