### PR TITLE
TrackballControls: Fix logical error and allow buttons modification

### DIFF
--- a/examples/jsm/controls/TrackballControls.js
+++ b/examples/jsm/controls/TrackballControls.js
@@ -1,7 +1,6 @@
 import {
 	EventDispatcher,
 	MathUtils,
-	MOUSE,
 	Quaternion,
 	Vector2,
 	Vector3

--- a/examples/jsm/controls/TrackballControls.js
+++ b/examples/jsm/controls/TrackballControls.js
@@ -49,7 +49,7 @@ class TrackballControls extends EventDispatcher {
 
 		this.keys = [ 'KeyA' /*A*/, 'KeyS' /*S*/, 'KeyD' /*D*/ ];
 
-		this.mouseButtons = { LEFT: MOUSE.ROTATE, MIDDLE: MOUSE.DOLLY, RIGHT: MOUSE.PAN };
+		this.mouseButtons = { LEFT: STATE.ROTATE, MIDDLE: STATE.DOLLY, RIGHT: STATE.PAN };
 
 		// internals
 
@@ -538,22 +538,7 @@ class TrackballControls extends EventDispatcher {
 
 			if ( _state === STATE.NONE ) {
 
-				switch ( event.button ) {
-
-					case scope.mouseButtons.LEFT:
-						_state = STATE.ROTATE;
-						break;
-
-					case scope.mouseButtons.MIDDLE:
-						_state = STATE.ZOOM;
-						break;
-
-					case scope.mouseButtons.RIGHT:
-						_state = STATE.PAN;
-						break;
-
-				}
-
+				_state = scope.mouseButtons[ event.button ] || STATE.NONE;
 			}
 
 			const state = ( _keyState !== STATE.NONE ) ? _keyState : _state;

--- a/examples/jsm/controls/TrackballControls.js
+++ b/examples/jsm/controls/TrackballControls.js
@@ -1,6 +1,7 @@
 import {
 	EventDispatcher,
 	MathUtils,
+	MOUSE,
 	Quaternion,
 	Vector2,
 	Vector3
@@ -48,7 +49,11 @@ class TrackballControls extends EventDispatcher {
 
 		this.keys = [ 'KeyA' /*A*/, 'KeyS' /*S*/, 'KeyD' /*D*/ ];
 
-		this.mouseButtons = { LEFT: STATE.ROTATE, MIDDLE: STATE.DOLLY, RIGHT: STATE.PAN };
+		this.mouseButtons = {
+			[ MOUSE.LEFT ]: STATE.ROTATE,
+			[ MOUSE.MIDDLE ]: STATE.DOLLY,
+			[ MOUSE.RIGHT ]: STATE.PAN
+		};
 
 		// internals
 


### PR DESCRIPTION
Fixes https://github.com/mrdoob/three.js/issues/26366

**Description**

Fix the logical error occuring from comparing `event.button` (being a button) and `mouseButtons.SOMEBUTTON` (being a `ROTATE/DOLLY/PAN`).
It may be also needed to do the similar change in other controls.

(By the way, what is the purpose of `STATE.NONE`, why isn't `null` just used? It would make code a bit simpler)
(Also, quite a larger suggestion -- could we move all those `STATE`s in various controls to global constant STATE, making it contain something like `ROTATE, DOLLY, PAN, TOUCH_ROTATE, TOUCH_DOLLY, TOUCH_PAN, TOUCH_DOLLY_PAN, TOUCH_DOLLY_ROTATE, TOUCH_PAN_ROTATE`? And we could then remove the first three from the `MOUSE`, where I feel they don't really should belong to in the first place)