### PR TITLE
Examples: Remove usages of `FirstPersonControls.noFly`.

### DIFF
--- a/examples/webaudio_sandbox.html
+++ b/examples/webaudio_sandbox.html
@@ -227,7 +227,6 @@
 
 				controls.movementSpeed = 70;
 				controls.lookSpeed = 0.05;
-				controls.noFly = true;
 				controls.lookVertical = false;
 
 				//

--- a/examples/webgl_shadowmap.html
+++ b/examples/webgl_shadowmap.html
@@ -127,7 +127,6 @@
 
 				controls.lookSpeed = 0.0125;
 				controls.movementSpeed = 500;
-				controls.noFly = false;
 				controls.lookVertical = true;
 
 				controls.lookAt( scene.position );

--- a/examples/webgl_shadowmap_performance.html
+++ b/examples/webgl_shadowmap_performance.html
@@ -121,7 +121,6 @@
 
 				controls.lookSpeed = 0.0125;
 				controls.movementSpeed = 500;
-				controls.noFly = false;
 				controls.lookVertical = true;
 
 				controls.lookAt( scene.position );


### PR DESCRIPTION
Related issue: N/A

**Description**

As far as I can tell `noFly` is not a property of `FirstPersonControls`.