### PR TITLE
Examples: Remove obsolete renderer settings.

### DIFF
--- a/examples/jsm/misc/GPUComputationRenderer.js
+++ b/examples/jsm/misc/GPUComputationRenderer.js
@@ -3,10 +3,8 @@ import {
 	ClampToEdgeWrapping,
 	DataTexture,
 	FloatType,
-	LinearSRGBColorSpace,
 	Mesh,
 	NearestFilter,
-	NoToneMapping,
 	PlaneGeometry,
 	RGBAFormat,
 	Scene,
@@ -400,14 +398,9 @@ class GPUComputationRenderer {
 
 			const currentXrEnabled = renderer.xr.enabled;
 			const currentShadowAutoUpdate = renderer.shadowMap.autoUpdate;
-			const currentOutputColorSpace = renderer.outputColorSpace;
-			const currentToneMapping = renderer.toneMapping;
 
 			renderer.xr.enabled = false; // Avoid camera modification
 			renderer.shadowMap.autoUpdate = false; // Avoid re-computing shadows
-			renderer.outputColorSpace = LinearSRGBColorSpace;
-			renderer.toneMapping = NoToneMapping;
-
 			mesh.material = material;
 			renderer.setRenderTarget( output );
 			renderer.render( scene, camera );
@@ -415,8 +408,6 @@ class GPUComputationRenderer {
 
 			renderer.xr.enabled = currentXrEnabled;
 			renderer.shadowMap.autoUpdate = currentShadowAutoUpdate;
-			renderer.outputColorSpace = currentOutputColorSpace;
-			renderer.toneMapping = currentToneMapping;
 
 			renderer.setRenderTarget( currentRenderTarget );
 

--- a/examples/jsm/objects/Reflector.js
+++ b/examples/jsm/objects/Reflector.js
@@ -9,9 +9,7 @@ import {
 	Vector3,
 	Vector4,
 	WebGLRenderTarget,
-	HalfFloatType,
-	NoToneMapping,
-	LinearSRGBColorSpace
+	HalfFloatType
 } from 'three';
 
 class Reflector extends Mesh {
@@ -147,13 +145,9 @@ class Reflector extends Mesh {
 
 			const currentXrEnabled = renderer.xr.enabled;
 			const currentShadowAutoUpdate = renderer.shadowMap.autoUpdate;
-			const currentOutputColorSpace = renderer.outputColorSpace;
-			const currentToneMapping = renderer.toneMapping;
 
 			renderer.xr.enabled = false; // Avoid camera modification
 			renderer.shadowMap.autoUpdate = false; // Avoid re-computing shadows
-			renderer.outputColorSpace = LinearSRGBColorSpace;
-			renderer.toneMapping = NoToneMapping;
 
 			renderer.setRenderTarget( renderTarget );
 
@@ -164,8 +158,6 @@ class Reflector extends Mesh {
 
 			renderer.xr.enabled = currentXrEnabled;
 			renderer.shadowMap.autoUpdate = currentShadowAutoUpdate;
-			renderer.outputColorSpace = currentOutputColorSpace;
-			renderer.toneMapping = currentToneMapping;
 
 			renderer.setRenderTarget( currentRenderTarget );
 

--- a/examples/jsm/objects/Refractor.js
+++ b/examples/jsm/objects/Refractor.js
@@ -10,8 +10,6 @@ import {
 	Vector3,
 	Vector4,
 	WebGLRenderTarget,
-	LinearSRGBColorSpace,
-	NoToneMapping,
 	HalfFloatType
 } from 'three';
 
@@ -194,13 +192,9 @@ class Refractor extends Mesh {
 			const currentRenderTarget = renderer.getRenderTarget();
 			const currentXrEnabled = renderer.xr.enabled;
 			const currentShadowAutoUpdate = renderer.shadowMap.autoUpdate;
-			const currentOutputColorSpace = renderer.outputColorSpace;
-			const currentToneMapping = renderer.toneMapping;
 
 			renderer.xr.enabled = false; // avoid camera modification
 			renderer.shadowMap.autoUpdate = false; // avoid re-computing shadows
-			renderer.outputColorSpace = LinearSRGBColorSpace;
-			renderer.toneMapping = NoToneMapping;
 
 			renderer.setRenderTarget( renderTarget );
 			if ( renderer.autoClear === false ) renderer.clear();
@@ -208,8 +202,6 @@ class Refractor extends Mesh {
 
 			renderer.xr.enabled = currentXrEnabled;
 			renderer.shadowMap.autoUpdate = currentShadowAutoUpdate;
-			renderer.outputColorSpace = currentOutputColorSpace;
-			renderer.toneMapping = currentToneMapping;
 			renderer.setRenderTarget( currentRenderTarget );
 
 			// restore viewport


### PR DESCRIPTION
Related issue: #26371

**Description**

This PR removes unnecessary state settings from `GPUComputationRenderer`, `Reflector` and `Refractor` that were applied to `WebGLRenderer`.
