### PR TITLE
fix: toCreasedNormals(): call toNonIndexed() only on non-indexed geometries

### DIFF
--- a/docs/examples/en/utils/BufferGeometryUtils.html
+++ b/docs/examples/en/utils/BufferGeometryUtils.html
@@ -137,10 +137,6 @@
 		that meet at an angle greater than the crease angle.
 		</p>
 
-		<p>
-		Backwards compatible with code that uses this method to operate on the original geometry.
-		</p>
-
 		<h3>[method:BufferGeometry toTrianglesDrawMode]( [param:BufferGeometry geometry], [param:TrianglesDrawMode drawMode] )</h3>
 		<p>
 		geometry -- Instance of [page:BufferGeometry BufferGeometry].<br />

--- a/docs/examples/en/utils/BufferGeometryUtils.html
+++ b/docs/examples/en/utils/BufferGeometryUtils.html
@@ -126,7 +126,17 @@
 		geometry -- The input geometry. <br />
 		creaseAngle -- The crease angle. <br /><br />
 
-		Creates a new, non-indexed geometry with smooth normals everywhere except faces that meet at an angle greater than the crease angle.
+		Modifies the supplied geometry if it is non-indexed, otherwise creates a new,
+		non-indexed geometry.<br /><br />
+
+		Returns the geometry with smooth normals everywhere except faces
+		that meet at an angle greater than the crease angle.<br /><br />
+
+		Backwards compatible with code that uses this method to operate on the original geometry.<br /><br />
+
+		[page:BufferGeometry.toNonIndexed]() warns if the geometry is non-indexed and
+		returns <code>this</code>, i.e. the same geometry on which it was called:<br /><br />
+		<code>BufferGeometry is already non-indexed.</code>
 		</p>
 
 		<h3>[method:BufferGeometry toTrianglesDrawMode]( [param:BufferGeometry geometry], [param:TrianglesDrawMode drawMode] )</h3>

--- a/docs/examples/en/utils/BufferGeometryUtils.html
+++ b/docs/examples/en/utils/BufferGeometryUtils.html
@@ -122,21 +122,23 @@
 		</p>
 
 		<h3>[method:BufferGeometry toCreasedNormals]( [param:BufferGeometry geometry], [param:Number creaseAngle] )</h3>
+		<ul>
+			<li>geometry -- The input geometry.</li>
+			<li>creaseAngle -- The crease angle.</li>
+		</ul>
+
 		<p>
-		geometry -- The input geometry. <br />
-		creaseAngle -- The crease angle. <br /><br />
-
 		Modifies the supplied geometry if it is non-indexed, otherwise creates a new,
-		non-indexed geometry.<br /><br />
+		non-indexed geometry.
+		</p>
 
+		<p>
 		Returns the geometry with smooth normals everywhere except faces
-		that meet at an angle greater than the crease angle.<br /><br />
+		that meet at an angle greater than the crease angle.
+		</p>
 
-		Backwards compatible with code that uses this method to operate on the original geometry.<br /><br />
-
-		[page:BufferGeometry.toNonIndexed]() warns if the geometry is non-indexed and
-		returns <code>this</code>, i.e. the same geometry on which it was called:<br /><br />
-		<code>BufferGeometry is already non-indexed.</code>
+		<p>
+		Backwards compatible with code that uses this method to operate on the original geometry.
 		</p>
 
 		<h3>[method:BufferGeometry toTrianglesDrawMode]( [param:BufferGeometry geometry], [param:TrianglesDrawMode drawMode] )</h3>

--- a/docs/examples/zh/utils/BufferGeometryUtils.html
+++ b/docs/examples/zh/utils/BufferGeometryUtils.html
@@ -125,7 +125,17 @@
 			creaseAngle -- The crease angle.
 		</p>
 		<p>
-		Creates a new, non-indexed geometry with smooth normals everywhere except faces that meet at an angle greater than the crease angle.
+			Modifies the supplied geometry if it is non-indexed, otherwise creates a new,
+			non-indexed geometry.<br /><br />
+
+			Returns the geometry with smooth normals everywhere except faces
+			that meet at an angle greater than the crease angle.<br /><br />
+
+			Backwards compatible with code that uses this method to operate on the original geometry.<br /><br />
+
+			[page:BufferGeometry.toNonIndexed]() warns if the geometry is non-indexed and
+			returns <code>this</code>, i.e. the same geometry on which it was called:<br /><br />
+			<code>BufferGeometry is already non-indexed.</code>
 		</p>
 
 		<h3>[method:BufferGeometry toTrianglesDrawMode]( [param:BufferGeometry geometry], [param:TrianglesDrawMode drawMode] )</h3>

--- a/docs/examples/zh/utils/BufferGeometryUtils.html
+++ b/docs/examples/zh/utils/BufferGeometryUtils.html
@@ -135,10 +135,6 @@
 			that meet at an angle greater than the crease angle.
 		</p>
 
-		<p>
-			Backwards compatible with code that uses this method to operate on the original geometry.
-		</p>
-
 		<h3>[method:BufferGeometry toTrianglesDrawMode]( [param:BufferGeometry geometry], [param:TrianglesDrawMode drawMode] )</h3>
 		<p>
 		geometry -- Instance of [page:BufferGeometry BufferGeometry].<br />

--- a/docs/examples/zh/utils/BufferGeometryUtils.html
+++ b/docs/examples/zh/utils/BufferGeometryUtils.html
@@ -120,22 +120,23 @@
 		</p>
 
 		<h3>[method:BufferGeometry toCreasedNormals]( [param:BufferGeometry geometry], [param:Number creaseAngle] )</h3>
-		<p>
-			geometry -- The input geometry. <br />
-			creaseAngle -- The crease angle.
-		</p>
+		<ul>
+			<li>geometry -- The input geometry.</li>
+			<li>creaseAngle -- The crease angle.</li>
+		</ul>
+
 		<p>
 			Modifies the supplied geometry if it is non-indexed, otherwise creates a new,
-			non-indexed geometry.<br /><br />
+			non-indexed geometry.
+		</p>
 
+		<p>
 			Returns the geometry with smooth normals everywhere except faces
-			that meet at an angle greater than the crease angle.<br /><br />
+			that meet at an angle greater than the crease angle.
+		</p>
 
-			Backwards compatible with code that uses this method to operate on the original geometry.<br /><br />
-
-			[page:BufferGeometry.toNonIndexed]() warns if the geometry is non-indexed and
-			returns <code>this</code>, i.e. the same geometry on which it was called:<br /><br />
-			<code>BufferGeometry is already non-indexed.</code>
+		<p>
+			Backwards compatible with code that uses this method to operate on the original geometry.
 		</p>
 
 		<h3>[method:BufferGeometry toTrianglesDrawMode]( [param:BufferGeometry geometry], [param:TrianglesDrawMode drawMode] )</h3>

--- a/examples/jsm/utils/BufferGeometryUtils.js
+++ b/examples/jsm/utils/BufferGeometryUtils.js
@@ -1243,7 +1243,7 @@ function toCreasedNormals( geometry, creaseAngle = Math.PI / 3 /* 60 degrees */ 
 	const creaseDot = Math.cos( creaseAngle );
 	const hashMultiplier = ( 1 + 1e-10 ) * 1e2;
 
-	// reusable vertors
+	// reusable vectors
 	const verts = [ new Vector3(), new Vector3(), new Vector3() ];
 	const tempVec1 = new Vector3();
 	const tempVec2 = new Vector3();

--- a/examples/jsm/utils/BufferGeometryUtils.js
+++ b/examples/jsm/utils/BufferGeometryUtils.js
@@ -1229,8 +1229,22 @@ function mergeGroups( geometry ) {
 }
 
 
-// Creates a new, non-indexed geometry with smooth normals everywhere except faces that meet at
-// an angle greater than the crease angle.
+/**
+ * Modifies the supplied geometry if it is non-indexed, otherwise creates a new,
+ * non-indexed geometry. Returns the geometry with smooth normals everywhere except
+ * faces that meet at an angle greater than the crease angle.
+ *
+ * Backwards compatible with code such as @react-three/drei's `<RoundedBox>`
+ * which uses this method to operate on the original geometry.
+ *
+ * As of this writing, BufferGeometry.toNonIndexed() warns if the geometry is
+ * non-indexed and returns `this`, i.e. the same geometry on which it was called:
+ * `BufferGeometry is already non-indexed.`
+ *
+ * @param {BufferGeometry} geometry
+ * @param {number} [creaseAngle]
+ * @return {BufferGeometry}
+ */
 function toCreasedNormals( geometry, creaseAngle = Math.PI / 3 /* 60 degrees */ ) {
 
 	const creaseDot = Math.cos( creaseAngle );
@@ -1253,7 +1267,7 @@ function toCreasedNormals( geometry, creaseAngle = Math.PI / 3 /* 60 degrees */ 
 
 	}
 
-	const resultGeometry = geometry.toNonIndexed();
+	const resultGeometry = geometry.index ? geometry.toNonIndexed() : geometry;
 	const posAttr = resultGeometry.attributes.position;
 	const vertexMap = {};
 

--- a/examples/jsm/utils/BufferGeometryUtils.js
+++ b/examples/jsm/utils/BufferGeometryUtils.js
@@ -1234,13 +1234,6 @@ function mergeGroups( geometry ) {
  * non-indexed geometry. Returns the geometry with smooth normals everywhere except
  * faces that meet at an angle greater than the crease angle.
  *
- * Backwards compatible with code such as @react-three/drei's `<RoundedBox>`
- * which uses this method to operate on the original geometry.
- *
- * As of this writing, BufferGeometry.toNonIndexed() warns if the geometry is
- * non-indexed and returns `this`, i.e. the same geometry on which it was called:
- * `BufferGeometry is already non-indexed.`
- *
  * @param {BufferGeometry} geometry
  * @param {number} [creaseAngle]
  * @return {BufferGeometry}
@@ -1267,6 +1260,8 @@ function toCreasedNormals( geometry, creaseAngle = Math.PI / 3 /* 60 degrees */ 
 
 	}
 
+	// BufferGeometry.toNonIndexed() warns if the geometry is non-indexed
+	// and returns the original geometry
 	const resultGeometry = geometry.index ? geometry.toNonIndexed() : geometry;
 	const posAttr = resultGeometry.attributes.position;
 	const vertexMap = {};


### PR DESCRIPTION
Related issue: #26378

**Description**

`BufferGeometryUtils.toCreasedNormals()` produces a warning by `BufferGeometry.toNonIndexed()` if the provided geometry is already non-indexed:

```
THREE.BufferGeometry.toNonIndexed(): BufferGeometry is already non-indexed.
```

It should not produce the warning.

This PR changes `BufferGeometryUtils.toCreasedNormals()` to call `BufferGeometry.toNonIndexed()` only if the provided geometry is indexed.
Otherwise, it will just use the original geometry, as has been the case before:
`BufferGeometry.toNonIndexed()` returns `this` if the geometry is non-indexed.
