### PR TITLE
PropertyBinding: Change error to warning and reword.

### DIFF
--- a/src/animation/PropertyBinding.js
+++ b/src/animation/PropertyBinding.js
@@ -436,7 +436,7 @@ class PropertyBinding {
 		// ensure there is a value node
 		if ( ! targetObject ) {
 
-			console.error( 'THREE.PropertyBinding: Trying to update node for track: ' + this.path + ' but it wasn\'t found.' );
+			console.warn( 'THREE.PropertyBinding: No target node found for track: ' + this.path + '.' );
 			return;
 
 		}


### PR DESCRIPTION
Related issue:
- https://github.com/mrdoob/three.js/issues/26328

**Description**

Changes the PropertyBinding error when a path isn't found in the target hierarchy to a warning.
This can, for example, happen when an animation is retargeted to a hierarchy that isn't identical, so some tracks can't be applied to the new hierarchy.

*This contribution is funded by [Needle](https://needle.tools)*
