### PR TITLE
OculusHandPointerModel: Make `_onDisconnected()` more robust.

### DIFF
--- a/examples/jsm/webxr/OculusHandPointerModel.js
+++ b/examples/jsm/webxr/OculusHandPointerModel.js
@@ -70,8 +70,8 @@ class OculusHandPointerModel extends THREE.Object3D {
 		this.visible = false;
 		this.xrInputSource = null;
 
-		this.pointerGeometry.dispose();
-		this.pointerMesh.material.dispose();
+		if (this.pointerGeometry) this.pointerGeometry.dispose();
+		if (this.pointerMesh && this.pointerMesh.material) this.pointerMesh.material.dispose();
 
 		this.clear();
 


### PR DESCRIPTION
Related issue: 
- https://github.com/needle-tools/three.js/issues/26262

**Description**

In applications supporting both hands and controllers, and dynamic switching between them, it's quite common to create a hand pointer model early on even if no hand is connected at that point.
Using controllers will then cause the connected event to fire, no hand model being created (because the connected thing is not a hand) but then on session exit the current code tries to dispose the non-existant hand and pointer model.

This PR just checks if they exist before disposing them. cc @CodyJasonBennett 

*This contribution is funded by [Needle](https://needle.tools)*
