### PR TITLE
Fix some of the lint-addons warnings and errors

### DIFF
--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -1270,7 +1270,7 @@ class FBXTreeParser {
 
 		} else {
 
-			material = new MeshPhongMaterial( { 
+			material = new MeshPhongMaterial( {
 				name: Loader.DEFAULT_MATERIAL_NAME,
 				color: 0xcccccc
 			} );

--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -315,12 +315,14 @@ class KTX2Loader extends Loader {
 
 			const texture = mipmaps[ 0 ];
 			texture.mipmaps = mipmaps.map( dt => {
+
 				return {
 					data: dt.source.data,
 					width: dt.source.data.width,
 					height: dt.source.data.height,
 					depth: dt.source.data.depth
 				};
+
 			} );
 			return texture;
 

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -767,7 +767,7 @@ class LDrawParsedCache {
 				const text = await fileLoader.loadAsync( subobjectURL );
 				return text;
 
-			} catch {
+			} catch ( _ ) {
 
 				continue;
 

--- a/examples/jsm/loaders/NRRDLoader.js
+++ b/examples/jsm/loaders/NRRDLoader.js
@@ -473,10 +473,10 @@ class NRRDLoader extends Loader {
 
 		volume.inverseMatrix = new Matrix4();
 		volume.inverseMatrix.copy( volume.matrix ).invert();
-		
+
 		volume.RASDimensions = [
-			Math.floor( volume.xLength * spacingX ), 
-			Math.floor( volume.yLength * spacingY ), 
+			Math.floor( volume.xLength * spacingX ),
+			Math.floor( volume.yLength * spacingY ),
 			Math.floor( volume.zLength * spacingZ )
 		];
 

--- a/examples/jsm/loaders/PLYLoader.js
+++ b/examples/jsm/loaders/PLYLoader.js
@@ -706,7 +706,7 @@ class PLYLoader extends Loader {
 			// ascii section using \r\n as line endings
 			if ( hasCRNL === true ) i ++;
 
-			return { headerText: lines.join( '\r' ) + '\r',  headerLength: i };
+			return { headerText: lines.join( '\r' ) + '\r', headerLength: i };
 
 		}
 

--- a/examples/jsm/loaders/VRMLLoader.js
+++ b/examples/jsm/loaders/VRMLLoader.js
@@ -960,7 +960,7 @@ class VRMLLoader extends Loader {
 
 			// if the appearance field is NULL or unspecified, lighting is off and the unlit object color is (0, 0, 0)
 
-			let material = new MeshBasicMaterial( { 
+			let material = new MeshBasicMaterial( {
 				name: Loader.DEFAULT_MATERIAL_NAME,
 				color: 0x000000
 			} );

--- a/examples/jsm/misc/Volume.js
+++ b/examples/jsm/misc/Volume.js
@@ -340,20 +340,18 @@ class Volume {
 
 		}
 
-
-		let iLength, jLength;
-
-		if( ! this.segmentation ) {
+		if ( ! this.segmentation ) {
 
 			firstDirection.applyMatrix4( volume.inverseMatrix ).normalize();
 			secondDirection.applyMatrix4( volume.inverseMatrix ).normalize();
 			axisInIJK.applyMatrix4( volume.inverseMatrix ).normalize();
 
 		}
+
 		firstDirection.arglet = 'i';
 		secondDirection.arglet = 'j';
-		iLength = Math.floor( Math.abs( firstDirection.dot( dimensions ) ) );
-		jLength = Math.floor( Math.abs( secondDirection.dot( dimensions ) ) );
+		const iLength = Math.floor( Math.abs( firstDirection.dot( dimensions ) ) );
+		const jLength = Math.floor( Math.abs( secondDirection.dot( dimensions ) ) );
 		const planeWidth = Math.abs( iLength * firstSpacing );
 		const planeHeight = Math.abs( jLength * secondSpacing );
 

--- a/examples/jsm/nodes/geometry/RangeNode.js
+++ b/examples/jsm/nodes/geometry/RangeNode.js
@@ -44,8 +44,8 @@ class RangeNode extends Node {
 
 		if ( object.isInstancedMesh === true ) {
 
-			let minValue = this.minNode.value;
-			let maxValue = this.maxNode.value;
+			const minValue = this.minNode.value;
+			const maxValue = this.maxNode.value;
 
 			const minLength = builder.getTypeLength( getValueType( minValue ) );
 			const maxLength = builder.getTypeLength( getValueType( maxValue ) );

--- a/examples/jsm/nodes/shadernode/ShaderNode.js
+++ b/examples/jsm/nodes/shadernode/ShaderNode.js
@@ -261,7 +261,7 @@ const safeGetNodeType = ( node ) => {
 
 		return node.getNodeType();
 
-	} catch {
+	} catch ( _ ) {
 
 		return undefined;
 

--- a/examples/jsm/renderers/webgpu/utils/WebGPUAttributeUtils.js
+++ b/examples/jsm/renderers/webgpu/utils/WebGPUAttributeUtils.js
@@ -57,6 +57,7 @@ class WebGPUAttributeUtils {
 			buffer.unmap();
 
 			bufferData.buffer = buffer;
+
 		}
 
 	}


### PR DESCRIPTION
**Description**

Running `npm run lint-addons` unveils quite a number of small formatting issues;
the ones that were clear to me are fixed with this PR (so that using linting is more useful again).

Before:
```
✖ 68 problems (39 errors, 29 warnings)
```

After:
```
✖ 32 problems (3 errors, 29 warnings)
```

The remaining warnings are almost all from `jsm/renderers/common/Backend.js` and a few async import warnings that the linter probably is not configured to understand:

```
/Users/herbst/git/three/examples/jsm/capabilities/WebGPU.js
  11:18  error  Parsing error: Cannot use keyword 'await' outside an async function

/Users/herbst/git/three/examples/jsm/physics/RapierPhysics.js
  41:18  error  Parsing error: Unexpected token import

/Users/herbst/git/three/examples/jsm/renderers/common/Backend.js
  25:9   warning  'renderContext' is defined but never used  no-unused-vars
  27:10  warning  'renderContext' is defined but never used  no-unused-vars
  31:8   warning  'renderObject' is defined but never used   no-unused-vars
  31:22  warning  'info' is defined but never used           no-unused-vars
  35:17  warning  'program' is defined but never used        no-unused-vars
  37:18  warning  'program' is defined but never used        no-unused-vars
  41:18  warning  'renderObject' is defined but never used   no-unused-vars
  43:18  warning  'renderObject' is defined but never used   no-unused-vars
  47:24  warning  'renderObject' is defined but never used   no-unused-vars
  49:25  warning  'computeNode' is defined but never used    no-unused-vars
  49:38  warning  'pipeline' is defined but never used       no-unused-vars
  51:19  warning  'pipeline' is defined but never used       no-unused-vars
  55:15  warning  'renderObject' is defined but never used   no-unused-vars
  57:15  warning  'renderObject' is defined but never used   no-unused-vars
  61:21  warning  'renderObject' is defined but never used   no-unused-vars
  65:17  warning  'texture' is defined but never used        no-unused-vars
  67:24  warning  'texture' is defined but never used        no-unused-vars
  69:17  warning  'texture' is defined but never used        no-unused-vars
  71:23  warning  'texture' is defined but never used        no-unused-vars
  71:32  warning  'x' is defined but never used              no-unused-vars
  71:35  warning  'y' is defined but never used              no-unused-vars
  71:38  warning  'width' is defined but never used          no-unused-vars
  71:45  warning  'height' is defined but never used         no-unused-vars
  75:19  warning  'attribute' is defined but never used      no-unused-vars
  77:24  warning  'attribute' is defined but never used      no-unused-vars
  79:19  warning  'attribute' is defined but never used      no-unused-vars
  81:20  warning  'attribute' is defined but never used      no-unused-vars
  89:14  warning  'name' is defined but never used           no-unused-vars

/Users/herbst/git/three/examples/jsm/renderers/webgpu/WebGPUBackend.js
  24:19  error  Parsing error: Cannot use keyword 'await' outside an async function

/Users/herbst/git/three/examples/jsm/renderers/webgpu/utils/WebGPUTextureUtils.js
  136:27  warning  'VideoFrame' is not defined  no-undef
```

*This contribution is funded by [Needle](https://needle.tools)*
