### PR TITLE
WebGPURenderer: Fix Node.updateBefore() sequence call 

### DIFF
--- a/examples/jsm/renderers/common/Geometries.js
+++ b/examples/jsm/renderers/common/Geometries.js
@@ -88,7 +88,7 @@ class Geometries extends DataMap {
 
 	}
 
-	update( renderObject ) {
+	updateForRender( renderObject ) {
 
 		if ( this.has( renderObject ) === false ) this.initGeometry( renderObject );
 

--- a/examples/jsm/renderers/common/RenderObject.js
+++ b/examples/jsm/renderers/common/RenderObject.js
@@ -15,11 +15,11 @@ export default class RenderObject {
 		this.scene = scene;
 		this.camera = camera;
 		this.lightsNode = lightsNode;
+		this.context = renderContext;
 
 		this.geometry = object.geometry;
 
 		this.attributes = null;
-		this.context = renderContext;
 		this.pipeline = null;
 		this.vertexBuffers = null;
 

--- a/examples/jsm/renderers/common/RenderObjects.js
+++ b/examples/jsm/renderers/common/RenderObjects.js
@@ -39,7 +39,7 @@ class RenderObjects {
 
 				renderObject.dispose();
 
-				renderObject = this.get( object, material, scene, camera, lightsNode, renderContext );
+				renderObject = this.get( object, material, scene, camera, lightsNode, renderContext, passId );
 
 			}
 
@@ -66,6 +66,7 @@ class RenderObjects {
 
 		const chainMap = this.getChainMap( passId );
 		const dataMap = this.dataMap;
+
 		const renderObject = new RenderObject( nodes, geometries, renderer, object, material, scene, camera, lightsNode, renderContext );
 
 		const data = dataMap.get( renderObject );

--- a/examples/jsm/renderers/common/Renderer.js
+++ b/examples/jsm/renderers/common/Renderer.js
@@ -805,6 +805,12 @@ class Renderer {
 
 		//
 
+		const renderObject = this._objects.get( object, material, scene, camera, lightsNode, this._currentRenderContext );
+
+		this._nodes.updateBefore( renderObject );
+
+		//
+
 		object.modelViewMatrix.multiplyMatrices( camera.matrixWorldInverse, object.matrixWorld );
 		object.normalMatrix.getNormalMatrix( object.modelViewMatrix );
 
@@ -844,12 +850,8 @@ class Renderer {
 
 		//
 
-		this._nodes.updateBefore( renderObject );
-
-		//
-
 		this._nodes.updateForRender( renderObject );
-		this._geometries.update( renderObject );
+		this._geometries.updateForRender( renderObject );
 		this._bindings.updateForRender( renderObject );
 
 		//


### PR DESCRIPTION
**Description**

`Node.updateBefore()` must be called before update `modelViewMatrix` and `normalMatrix`.