### PR TITLE
WebGPURenderer: Rename getArrayBuffer() to getArrayBufferAsync()

### DIFF
--- a/examples/jsm/renderers/common/Renderer.js
+++ b/examples/jsm/renderers/common/Renderer.js
@@ -329,9 +329,17 @@ class Renderer {
 
 	}
 
-	async getArrayBuffer( attribute ) {
+	getArrayBuffer( attribute ) { // @deprecated, r155
 
-		return await this.backend.getArrayBuffer( attribute );
+		console.warn( 'THREE.Renderer: getArrayBuffer() is deprecated. Use getArrayBufferAsync() instead.' );
+
+		return this.getArrayBufferAsync( attribute );
+
+	}
+
+	async getArrayBufferAsync( attribute ) {
+
+		return await this.backend.getArrayBufferAsync( attribute );
 
 	}
 

--- a/examples/jsm/renderers/webgpu/WebGPUBackend.js
+++ b/examples/jsm/renderers/webgpu/WebGPUBackend.js
@@ -123,9 +123,9 @@ class WebGPUBackend extends Backend {
 
 	}
 
-	async getArrayBuffer( attribute ) {
+	async getArrayBufferAsync( attribute ) {
 
-		return await this.attributeUtils.getArrayBuffer( attribute );
+		return await this.attributeUtils.getArrayBufferAsync( attribute );
 
 	}
 

--- a/examples/jsm/renderers/webgpu/utils/WebGPUAttributeUtils.js
+++ b/examples/jsm/renderers/webgpu/utils/WebGPUAttributeUtils.js
@@ -165,7 +165,7 @@ class WebGPUAttributeUtils {
 
 	}
 
-	async getArrayBuffer( attribute ) {
+	async getArrayBufferAsync( attribute ) {
 
 		const backend = this.backend;
 		const device = backend.device;


### PR DESCRIPTION
**Description**

In order to standardize async functions name that need to return values must have the Async suffix.