### PR TITLE
WebGPUBackend: Fix Depth Buffer

### DIFF
--- a/examples/jsm/renderers/common/RenderContexts.js
+++ b/examples/jsm/renderers/common/RenderContexts.js
@@ -38,7 +38,7 @@ class RenderContexts {
 
 	dispose() {
 
-		this.renderStates = new ChainMap();
+		this.chainMaps = {};
 
 	}
 


### PR DESCRIPTION
Related issue: Fixes https://github.com/mrdoob/three.js/issues/26381

**Description**

Fix the use of the same Depth Buffer used in different `RenderContext`.
