### PR TITLE
CapsuleGeometry: Use correct `length` property name in `parameters`.

### DIFF
--- a/src/geometries/CapsuleGeometry.js
+++ b/src/geometries/CapsuleGeometry.js
@@ -15,7 +15,7 @@ class CapsuleGeometry extends LatheGeometry {
 
 		this.parameters = {
 			radius: radius,
-			height: length,
+			length: length,
 			capSegments: capSegments,
 			radialSegments: radialSegments,
 		};


### PR DESCRIPTION
modify this.parameters.height to 'length' cuz it uses data.length in fromJSON(). 

**Description**
this problem happens when you try passing a CapsuleGeometry.parameters object to create another capsule using fromJSON(), inside fromJSON(), the 2nd param - length will always be 'undefined' cuz there's no this key - 'length' in CapsuleGeometry.parameters

