### PR TITLE
OrbitControls: respect scope.enabled in onTouchStart

### DIFF
--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -1179,6 +1179,8 @@ class OrbitControls extends EventDispatcher {
 
 		function onTouchStart( event ) {
 
+			if ( scope.enabled === false ) return;
+
 			trackPointer( event );
 
 			switch ( pointers.length ) {


### PR DESCRIPTION
Check for scope.enabled was missing from onTouchStart, it's already in all other start events.

**Description**

OrbitControls still worked when disabled on touch devices.

*This contribution is funded by [Needle](https://needle.tools)*
