### PR TITLE
Examples: tonemapping  add backgroundIntensity gui

### DIFF
--- a/examples/webgl_tonemapping.html
+++ b/examples/webgl_tonemapping.html
@@ -43,7 +43,8 @@
 			const params = {
 				exposure: 1.0,
 				toneMapping: 'ACESFilmic',
-				blurriness: 0.3
+				blurriness: 0.3,
+				intensity: 1.0,
 			};
 
 			const toneMappingOptions = {
@@ -142,6 +143,15 @@
 					.onChange( function ( value ) {
 
 						scene.backgroundBlurriness = value;
+						render();
+
+					} );
+
+				gui.add( params, 'intensity', 0, 1 )
+
+					.onChange( function ( value ) {
+
+						scene.backgroundIntensity = value;
 						render();
 
 					} );

--- a/examples/webgl_tonemapping.html
+++ b/examples/webgl_tonemapping.html
@@ -126,19 +126,21 @@
 				window.addEventListener( 'resize', onWindowResize );
 
 				gui = new GUI();
-
-				gui.add( params, 'toneMapping', Object.keys( toneMappingOptions ) )
+				const toneMappingFolder = gui.addFolder( 'tone mapping' );
+			
+				toneMappingFolder.add( params, 'toneMapping', Object.keys( toneMappingOptions ) )
 
 					.onChange( function () {
 
-						updateGUI();
+						updateGUI( toneMappingFolder );
 
 						renderer.toneMapping = toneMappingOptions[ params.toneMapping ];
 						render();
 
 					} );
+				const backgroundFolder = gui.addFolder( 'background' );
 
-				gui.add( params, 'blurriness', 0, 1 )
+				backgroundFolder.add( params, 'blurriness', 0, 1 )
 
 					.onChange( function ( value ) {
 
@@ -147,7 +149,7 @@
 
 					} );
 
-				gui.add( params, 'intensity', 0, 1 )
+				backgroundFolder.add( params, 'intensity', 0, 1 )
 
 					.onChange( function ( value ) {
 
@@ -156,13 +158,13 @@
 
 					} );
 
-				updateGUI();
+				updateGUI( toneMappingFolder );
 
 				gui.open();
 
 			}
 
-			function updateGUI() {
+			function updateGUI( folder ) {
 
 				if ( guiExposure !== null ) {
 
@@ -173,7 +175,7 @@
 
 				if ( params.toneMapping !== 'None' ) {
 
-					guiExposure = gui.add( params, 'exposure', 0, 2 )
+					guiExposure = folder.add( params, 'exposure', 0, 2 )
 
 						.onChange( function () {
 


### PR DESCRIPTION
**Description**

 Since [tonemapping ](https://threejs.org/examples/?q=tone#webgl_tonemapping)example already has `scene.backgroundBlurriness` , adding `scene.backgroundIntensity` slider also
<!-- Remove the line below if is not relevant -->

