### PR TITLE
DataTextureLoader: fix promise never rejected on error

### DIFF
--- a/src/loaders/DataTextureLoader.js
+++ b/src/loaders/DataTextureLoader.js
@@ -32,7 +32,7 @@ class DataTextureLoader extends Loader {
 
 			const texData = scope.parse( buffer );
 
-			if ( ! texData ) return;
+			if ( ! texData ) return onError();
 
 			if ( texData.image !== undefined ) {
 


### PR DESCRIPTION
Related issue: None

**Description**

When using something that extends `DataTextureLoader` (eg `RGBELoader`) if it fails to parse the file then the `.load()` error callback is never called, and the `.loadAsync()` promise is never rejected.

This is especially important when preloading assets for games etc, if the promise never succeeds or fails it gets stuck loading forever.