### PR TITLE
Object3D: Shallow copy the animations array in copy()

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -945,7 +945,7 @@ class Object3D extends EventDispatcher {
 		this.frustumCulled = source.frustumCulled;
 		this.renderOrder = source.renderOrder;
 
-		this.animations = source.animations;
+		this.animations = source.animations.slice();
 
 		this.userData = JSON.parse( JSON.stringify( source.userData ) );
 


### PR DESCRIPTION
Currently, when an `Object3D` is copied or cloned, the copy's `animations` array will be the same array object as the original. This is problematic because modifying the array in one object will also modify the other object. This PR makes a shallow copy of the `animations` array to allow safely modifying it.