### PR TITLE
WebGLMultipleRenderTargets: return void in setSize

### DIFF
--- a/src/renderers/WebGLMultipleRenderTargets.js
+++ b/src/renderers/WebGLMultipleRenderTargets.js
@@ -44,8 +44,6 @@ class WebGLMultipleRenderTargets extends WebGLRenderTarget {
 		this.viewport.set( 0, 0, width, height );
 		this.scissor.set( 0, 0, width, height );
 
-		return this;
-
 	}
 
 	copy( source ) {


### PR DESCRIPTION
Related issue: #21930

**Description**

Aligns `WebGLMultipleRenderTargets` with the other render target classes. I saw https://github.com/three-types/three-ts-types/pull/519 which removed a lot of divergent signatures and thought to fix it properly here.