### PR TITLE
TSL: Add output and material.outputNode

### DIFF
--- a/examples/jsm/nodes/Nodes.js
+++ b/examples/jsm/nodes/Nodes.js
@@ -24,7 +24,7 @@ export { default as NodeKeywords } from './core/NodeKeywords.js';
 export { default as NodeUniform } from './core/NodeUniform.js';
 export { default as NodeVar } from './core/NodeVar.js';
 export { default as NodeVarying } from './core/NodeVarying.js';
-export { default as PropertyNode, property, diffuseColor, roughness, metalness, specularColor, shininess } from './core/PropertyNode.js';
+export { default as PropertyNode, property, output, diffuseColor, roughness, metalness, specularColor, shininess } from './core/PropertyNode.js';
 export { default as StackNode, stack } from './core/StackNode.js';
 export { default as TempNode } from './core/TempNode.js';
 export { default as UniformNode, uniform } from './core/UniformNode.js';

--- a/examples/jsm/nodes/core/PropertyNode.js
+++ b/examples/jsm/nodes/core/PropertyNode.js
@@ -53,5 +53,6 @@ export const sheen = nodeImmutable( PropertyNode, 'vec3', 'Sheen' );
 export const sheenRoughness = nodeImmutable( PropertyNode, 'float', 'SheenRoughness' );
 export const specularColor = nodeImmutable( PropertyNode, 'color', 'SpecularColor' );
 export const shininess = nodeImmutable( PropertyNode, 'float', 'Shininess' );
+export const output = nodeImmutable( PropertyNode, 'vec4', 'Output' );
 
 addNodeClass( PropertyNode );

--- a/examples/jsm/nodes/materials/NodeMaterial.js
+++ b/examples/jsm/nodes/materials/NodeMaterial.js
@@ -1,7 +1,7 @@
 import { Material, ShaderMaterial, NoColorSpace } from 'three';
 import { getNodeChildren, getCacheKey } from '../core/NodeUtils.js';
 import { attribute } from '../core/AttributeNode.js';
-import { diffuseColor } from '../core/PropertyNode.js';
+import { output, diffuseColor } from '../core/PropertyNode.js';
 import { materialNormal } from '../accessors/ExtendedMaterialNode.js';
 import { materialAlphaTest, materialColor, materialOpacity, materialEmissive } from '../accessors/MaterialNode.js';
 import { modelViewProjection } from '../accessors/ModelViewProjectionNode.js';
@@ -85,11 +85,27 @@ class NodeMaterial extends ShaderMaterial {
 
 			const outgoingLightNode = this.constructLighting( builder );
 
-			builder.stack.outputNode = this.constructOutput( builder, vec4( outgoingLightNode, diffuseColor.a ) );
+			const outputNode = this.constructOutput( builder, vec4( outgoingLightNode, diffuseColor.a ) );
+
+			builder.stack.assign( output, outputNode );
+
+			if ( this.outputNode !== null ) {
+
+				builder.stack.outputNode = vec4( this.outputNode );
+
+			} else {
+
+				builder.stack.outputNode = output;
+
+			}
 
 		} else {
 
-			builder.stack.outputNode = this.constructOutput( builder, this.outputNode || vec4( 0, 0, 0, 1 ) );
+			const outputNode = this.constructOutput( builder, this.outputNode || vec4( 0, 0, 0, 1 ) );
+
+			builder.stack.assign( output, outputNode );
+
+			builder.stack.outputNode = output;
 
 		}
 

--- a/examples/jsm/nodes/materials/NodeMaterial.js
+++ b/examples/jsm/nodes/materials/NodeMaterial.js
@@ -76,6 +76,8 @@ class NodeMaterial extends ShaderMaterial {
 
 		builder.addStack();
 
+		let outputNode;
+
 		if ( this.isUnlit === false ) {
 
 			if ( this.normals === true ) this.constructNormal( builder );
@@ -85,29 +87,17 @@ class NodeMaterial extends ShaderMaterial {
 
 			const outgoingLightNode = this.constructLighting( builder );
 
-			const outputNode = this.constructOutput( builder, vec4( outgoingLightNode, diffuseColor.a ) );
+			outputNode = this.constructOutput( builder, vec4( outgoingLightNode, diffuseColor.a ) );
 
-			builder.stack.assign( output, outputNode );
-
-			if ( this.outputNode !== null ) {
-
-				builder.stack.outputNode = vec4( this.outputNode );
-
-			} else {
-
-				builder.stack.outputNode = output;
-
-			}
+			if ( this.outputNode !== null ) outputNode = this.outputNode;
 
 		} else {
 
-			const outputNode = this.constructOutput( builder, this.outputNode || vec4( 0, 0, 0, 1 ) );
-
-			builder.stack.assign( output, outputNode );
-
-			builder.stack.outputNode = output;
+			outputNode = this.constructOutput( builder, this.outputNode || vec4( 0, 0, 0, 1 ) );
 
 		}
+
+		builder.stack.outputNode = outputNode;
 
 		builder.addFlow( 'fragment', builder.removeStack() );
 
@@ -345,6 +335,10 @@ class NodeMaterial extends ShaderMaterial {
 		const fogNode = builder.fogNode;
 
 		if ( fogNode ) outputNode = vec4( fogNode.mixAssign( outputNode.rgb ), outputNode.a );
+
+		// OUTPUT NODE
+
+		builder.stack.assign( output, outputNode );
 
 		return outputNode;
 

--- a/examples/webgpu_backdrop.html
+++ b/examples/webgpu_backdrop.html
@@ -27,7 +27,7 @@
 		<script type="module">
 
 			import * as THREE from 'three';
-			import { float, vec3, color, toneMapping, viewportSharedTexture, viewportTopLeft, checker, uv, oscSine, MeshStandardNodeMaterial } from 'three/nodes';
+			import { float, vec3, color, toneMapping, viewportSharedTexture, viewportTopLeft, checker, uv, oscSine, output, MeshStandardNodeMaterial } from 'three/nodes';
 
 			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 
@@ -73,6 +73,10 @@
 
 					const object = gltf.scene;
 					mixer = new THREE.AnimationMixer( object );
+
+					const material = object.children[ 0 ].children[ 0 ].material;
+					// output material effect ( better using hsv )
+					material.outputNode = oscSine().mix( output, output.posterize( 4 ).rgb.saturation( 0 ).add( .3 ) );
 
 					const action = mixer.clipAction( gltf.animations[ 0 ] );
 					action.play();

--- a/examples/webgpu_backdrop.html
+++ b/examples/webgpu_backdrop.html
@@ -27,7 +27,7 @@
 		<script type="module">
 
 			import * as THREE from 'three';
-			import { float, vec3, color, toneMapping, viewportSharedTexture, viewportTopLeft, checker, uv, oscSine, output, MeshStandardNodeMaterial } from 'three/nodes';
+			import { float, vec3, color, toneMapping, viewportSharedTexture, viewportTopLeft, checker, uv, timerLocal, oscSine, output, MeshStandardNodeMaterial } from 'three/nodes';
 
 			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 
@@ -75,8 +75,11 @@
 					mixer = new THREE.AnimationMixer( object );
 
 					const material = object.children[ 0 ].children[ 0 ].material;
+
 					// output material effect ( better using hsv )
-					material.outputNode = oscSine().mix( output, output.posterize( 4 ).rgb.saturation( 0 ).add( .3 ) );
+					// ignore output.sRGBToLinear().linearTosRGB() for now
+
+					material.outputNode = oscSine( timerLocal( .1 ) ).mix( output, output.add( .1 ).posterize( 4 ).mul( 2 ) );
 
 					const action = mixer.clipAction( gltf.animations[ 0 ] );
 					action.play();


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/26409#issuecomment-1632809692

**Description**

I create a simple posterize effect using `outputNode`, it can be used to create effects like cel shader, overlay and  others.

```js
// output -- shader result

material.outputNode = vec4( output.rgb.saturation( 0 ), output.a );
```

![image](https://github.com/mrdoob/three.js/assets/502810/2b55e1b0-191e-48d6-a290-d78f592a1ebc)
