### PR TITLE
Fix GUI title parameter in webgl_postprocessing_afterimage

### DIFF
--- a/examples/webgl_postprocessing_afterimage.html
+++ b/examples/webgl_postprocessing_afterimage.html
@@ -94,7 +94,7 @@
 
 			function createGUI() {
 
-				const gui = new GUI( { name: 'Damp setting' } );
+				const gui = new GUI( { title: 'Damp setting' } );
 				gui.add( afterimagePass.uniforms[ 'damp' ], 'value', 0, 1 ).step( 0.001 );
 				gui.add( params, 'enable' );
 


### PR DESCRIPTION
Related issue: N/A

**Description**

Replaces the `name` parameter with `title`, since `name` [is not a valid parameter for `GUI`](https://lil-gui.georgealways.com/#GUI). Presumably this was missed when switching from dat.gui to lil-gui.
