### PR TITLE
WebGPURenderer: Revert and fix updateBefore() - (2)

### DIFF
--- a/examples/jsm/renderers/common/Renderer.js
+++ b/examples/jsm/renderers/common/Renderer.js
@@ -837,16 +837,16 @@ class Renderer {
 		if ( material.transparent === true && material.side === DoubleSide && material.forceSinglePass === false ) {
 
 			material.side = BackSide;
-			this._renderObjectDirect( object, scene, camera, geometry, material, group, lightsNode, 'backSide' ); // create backSide pass id
+			this._renderObjectDirect( object, material, scene, camera, lightsNode, 'backSide' ); // create backSide pass id
 
 			material.side = FrontSide;
-			this._renderObjectDirect( object, scene, camera, geometry, material, group, lightsNode ); // use default pass id
+			this._renderObjectDirect( object, material, scene, camera, lightsNode ); // use default pass id
 
 			material.side = DoubleSide;
 
 		} else {
 
-			this._renderObjectDirect( object, scene, camera, geometry, material, group, lightsNode );
+			this._renderObjectDirect( object, material, scene, camera, lightsNode );
 
 		}
 
@@ -856,7 +856,7 @@ class Renderer {
 
 	}
 
-	_renderObjectDirect( object, scene, camera, geometry, material, group, lightsNode, passId ) {
+	_renderObjectDirect( object, material, scene, camera, lightsNode, passId ) {
 
 		const renderObject = this._objects.get( object, material, scene, camera, lightsNode, this._currentRenderContext, passId );
 

--- a/examples/jsm/renderers/common/Renderer.js
+++ b/examples/jsm/renderers/common/Renderer.js
@@ -822,12 +822,6 @@ class Renderer {
 
 	}
 
-	_getRenderObject( object, material, scene, camera, lightsNode, passId ) {
-
-		return this._objects.get( object, material, scene, camera, lightsNode, this._currentRenderContext, passId );
-
-	}
-
 	_renderObject( object, scene, camera, geometry, material, group, lightsNode ) {
 
 		material = scene.overrideMaterial !== null ? scene.overrideMaterial : material;
@@ -836,19 +830,6 @@ class Renderer {
 
 		object.onBeforeRender( this, scene, camera, geometry, material, group );
 
-		//
-
-		const renderObject = this._getRenderObject( object, material, scene, camera, lightsNode );
-
-		this._nodes.updateBefore( renderObject );
-
-		//
-
-		object.modelViewMatrix.multiplyMatrices( camera.matrixWorldInverse, object.matrixWorld );
-		object.normalMatrix.getNormalMatrix( object.modelViewMatrix );
-
-		//
-
 		material.onBeforeRender( this, scene, camera, geometry, material, group );
 
 		//
@@ -856,16 +837,16 @@ class Renderer {
 		if ( material.transparent === true && material.side === DoubleSide && material.forceSinglePass === false ) {
 
 			material.side = BackSide;
-			this._renderObjectDirect( this._getRenderObject( object, material, scene, camera, lightsNode, 'backSide' ) ); // create backSide pass id
+			this._renderObjectDirect( object, scene, camera, geometry, material, group, lightsNode, 'backSide' ); // create backSide pass id
 
 			material.side = FrontSide;
-			this._renderObjectDirect( renderObject ); // use default pass id
+			this._renderObjectDirect( object, scene, camera, geometry, material, group, lightsNode ); // use default pass id
 
 			material.side = DoubleSide;
 
 		} else {
 
-			this._renderObjectDirect( renderObject );
+			this._renderObjectDirect( object, scene, camera, geometry, material, group, lightsNode );
 
 		}
 
@@ -875,7 +856,20 @@ class Renderer {
 
 	}
 
-	_renderObjectDirect( renderObject ) {
+	_renderObjectDirect( object, scene, camera, geometry, material, group, lightsNode, passId ) {
+
+		const renderObject = this._objects.get( object, material, scene, camera, lightsNode, this._currentRenderContext, passId );
+
+		//
+
+		this._nodes.updateBefore( renderObject );
+
+		//
+
+		object.modelViewMatrix.multiplyMatrices( camera.matrixWorldInverse, object.matrixWorld );
+		object.normalMatrix.getNormalMatrix( object.modelViewMatrix );
+
+		//
 
 		this._nodes.updateForRender( renderObject );
 		this._geometries.updateForRender( renderObject );

--- a/examples/jsm/renderers/common/Renderer.js
+++ b/examples/jsm/renderers/common/Renderer.js
@@ -250,6 +250,10 @@ class Renderer {
 
 		//
 
+		sceneRef.onBeforeRender( this, scene, camera, renderTarget );
+
+		//
+
 		_projScreenMatrix.multiplyMatrices( camera.projectionMatrix, camera.matrixWorldInverse );
 		_frustum.setFromProjectionMatrix( _projScreenMatrix, coordinateSystem );
 
@@ -317,6 +321,10 @@ class Renderer {
 		this._currentRenderContext = previousRenderState;
 
 		this._lastRenderContext = renderContext;
+
+		//
+
+		sceneRef.onAfterRender( this, scene, camera, renderTarget );
 
 	}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/26417, https://github.com/mrdoob/three.js/pull/26391

**Description**

I think it's the last fix for `updateBefore()` in that sense, seems the best approach.
The latest updates although fix some problems brought others in `viewportTexture()`, this PR looks like a general fix.