### PR TITLE
bug fix : crash when objectload parse edgegeometry

### DIFF
--- a/src/geometries/EdgesGeometry.js
+++ b/src/geometries/EdgesGeometry.js
@@ -149,7 +149,7 @@ class EdgesGeometry extends BufferGeometry {
 
 	static fromJSON( data ) {
 
-		return new EdgesGeometry( data.geometry, data.thresholdAngle);
+		return new EdgesGeometry( data.geometry, data.thresholdAngle );
 
 	}
 

--- a/src/geometries/EdgesGeometry.js
+++ b/src/geometries/EdgesGeometry.js
@@ -147,6 +147,12 @@ class EdgesGeometry extends BufferGeometry {
 
 	}
 
+	static fromJSON( data ) {
+
+		return new EdgesGeometry( data.geometry, data.thresholdAngle);
+
+	}
+
 }
 
 export { EdgesGeometry };


### PR DESCRIPTION
Related issue: #26425

**Description**

crash when ObjectLoader parse EdgeGeometry,

root cause:

1. in line 301 of  EdgeGeometry.js
    geometry = Geometries[ data.type ].fromJSON( data, shapes );


2. there is no fromJson function in EdgeGeometry.

