### PR TITLE
InstancedMesh: Add support for async color definitions.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1486,8 +1486,6 @@ class WebGLRenderer {
 
 			const materialProperties = properties.get( material );
 
-			materialProperties.instancingColor = object.isInstancedMesh === true && object.instanceColor !== null;
-
 			const lights = currentRenderState.state.lights;
 			const shadowsArray = currentRenderState.state.shadowsArray;
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1486,6 +1486,8 @@ class WebGLRenderer {
 
 			const materialProperties = properties.get( material );
 
+			materialProperties.instancingColor = object.isInstancedMesh === true && object.instanceColor !== null;
+
 			const lights = currentRenderState.state.lights;
 			const shadowsArray = currentRenderState.state.shadowsArray;
 
@@ -1601,6 +1603,7 @@ class WebGLRenderer {
 
 			materialProperties.outputColorSpace = parameters.outputColorSpace;
 			materialProperties.instancing = parameters.instancing;
+			materialProperties.instancingColor = parameters.instancingColor;
 			materialProperties.skinning = parameters.skinning;
 			materialProperties.morphTargets = parameters.morphTargets;
 			materialProperties.morphNormals = parameters.morphNormals;
@@ -1692,6 +1695,14 @@ class WebGLRenderer {
 					needsProgramChange = true;
 
 				} else if ( ! object.isSkinnedMesh && materialProperties.skinning === true ) {
+
+					needsProgramChange = true;
+
+				} else if ( object.isInstancedMesh && materialProperties.instancingColor === true && object.instanceColor === null ) {
+
+					needsProgramChange = true;
+
+				} else if ( object.isInstancedMesh && materialProperties.instancingColor === false && object.instanceColor !== null ) {
 
 					needsProgramChange = true;
 


### PR DESCRIPTION
Fixed #21786

**Description**

Flags the current instanced material for update on render whenever `instanceColor` is (un)set. This tracks async effects without explicitly managing them in `InstancedMesh`.

<details>

<summary>Show Example:</summary>

<br />

The following renders a red cube whenever `instanceColor` is properly in sync with the mesh (~1s).

```js
import * as THREE from 'three';

let renderer, scene, camera;

init();
animate();

function init() {

    renderer = new THREE.WebGLRenderer();
    renderer.setSize( window.innerWidth, window.innerHeight );
    renderer.setPixelRatio( window.devicePixelRatio );
    document.body.appendChild( renderer.domElement );

    scene = new THREE.Scene();
    
    camera = new THREE.PerspectiveCamera( 40, window.innerWidth / window.innerHeight );
    camera.position.z = 5;

    const geometry = new THREE.BoxGeometry();

    const material = new THREE.ShaderMaterial({
      vertexShader: /* glsl */ `

        varying vec3 vColor;

        void main() {

          #ifdef USE_INSTANCING_COLOR

            vColor = instanceColor;

          #endif

          gl_Position = projectionMatrix * modelViewMatrix * instanceMatrix * vec4( position, 1.0 );

        }

      `,
      fragmentShader: /* glsl */ `

        varying vec3 vColor;

        void main() {

          gl_FragColor = vec4( vColor, 1.0 );

        }

      `,
    });

    const mesh = new THREE.InstancedMesh( geometry, material, 1 );
    scene.add( mesh );

    setTimeout(() => {

      mesh.setColorAt( 0, new THREE.Color( 'red' ) );
      mesh.instanceColor.needsUpdate = true;

    }, 1000 );

}

function animate() {

  requestAnimationFrame( animate );
  renderer.render( scene, camera );

}
```

</details>