### PR TITLE
Remove setting Group.material in godrays example

### DIFF
--- a/examples/webgl_postprocessing_godrays.html
+++ b/examples/webgl_postprocessing_godrays.html
@@ -80,7 +80,6 @@
 				const loader = new OBJLoader();
 				loader.load( 'models/obj/tree.obj', function ( object ) {
 
-					object.material = materialScene;
 					object.position.set( 0, - 150, - 150 );
 					object.scale.multiplyScalar( 400 );
 					scene.add( object );

--- a/examples/webgl_postprocessing_godrays.html
+++ b/examples/webgl_postprocessing_godrays.html
@@ -73,8 +73,6 @@
 
 				materialDepth = new THREE.MeshDepthMaterial();
 
-				const materialScene = new THREE.MeshBasicMaterial( { color: 0x000000 } );
-
 				// tree
 
 				const loader = new OBJLoader();
@@ -89,7 +87,7 @@
 				// sphere
 
 				const geo = new THREE.SphereGeometry( 1, 20, 10 );
-				sphereMesh = new THREE.Mesh( geo, materialScene );
+				sphereMesh = new THREE.Mesh( geo, new THREE.MeshBasicMaterial( { color: 0x000000 } ) );
 				sphereMesh.scale.multiplyScalar( 20 );
 				scene.add( sphereMesh );
 


### PR DESCRIPTION
Related issue: N/A

**Description**

The `object` that is loaded is a `Group` which does not typically have a `material` property set. I could be missing something, but it seems like setting the `material` property is ineffectual.