### PR TITLE
Remove passing second parameter to requestAnimationFrame

### DIFF
--- a/examples/webgl_postprocessing_godrays.html
+++ b/examples/webgl_postprocessing_godrays.html
@@ -231,7 +231,7 @@
 
 			function animate() {
 
-				requestAnimationFrame( animate, renderer.domElement );
+				requestAnimationFrame( animate );
 
 				stats.begin();
 				render();


### PR DESCRIPTION
Related issue: N/A

**Description**

`requestAnimationFrame` only has [one documented parameter](https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame#parameters). I could be missing something, but the second parameter seems ineffectual.