### PR TITLE
Cleanup onWindowResize for procedural postprocessing example

### DIFF
--- a/examples/webgl_postprocessing_procedural.html
+++ b/examples/webgl_postprocessing_procedural.html
@@ -130,13 +130,7 @@
 
 			function onWindowResize() {
 
-				const width = window.innerWidth;
-				const height = window.innerHeight;
-
-				postCamera.aspect = width / height;
-				postCamera.updateProjectionMatrix();
-
-				renderer.setSize( width, height );
+				renderer.setSize( window.innerWidth, window.innerHeight );
 
 			}
 


### PR DESCRIPTION
Related issue: N/A

**Description**

`OrthographicCamera` has no `aspect` property. This PR cleans up the ineffectual code.