### PR TITLE
Cleanup wegl_gpgpu_water

### DIFF
--- a/examples/webgl_gpgpu_water.html
+++ b/examples/webgl_gpgpu_water.html
@@ -414,14 +414,10 @@
 				material.lights = true;
 
 				// Material attributes from THREE.MeshPhongMaterial
-				material.color = new THREE.Color( materialColor );
-				material.specular = new THREE.Color( 0x111111 );
-				material.shininess = 50;
-
 				// Sets the uniforms with the material values
-				material.uniforms[ 'diffuse' ].value = material.color;
-				material.uniforms[ 'specular' ].value = material.specular;
-				material.uniforms[ 'shininess' ].value = Math.max( material.shininess, 1e-4 );
+				material.uniforms[ 'diffuse' ].value = new THREE.Color( materialColor );
+				material.uniforms[ 'specular' ].value = new THREE.Color( 0x111111 );
+				material.uniforms[ 'shininess' ].value = Math.max( 50, 1e-4 );
 				material.uniforms[ 'opacity' ].value = material.opacity;
 
 				// Defines


### PR DESCRIPTION
Related issue:  N/A

**Description**

The `wegl_gpgpu_water` assigns properties to `ShaderMaterial` that aren't actual properties of a `ShaderMaterial`. The more straightforward approach seems to assign those values directly to the uniforms.