### PR TITLE
Cleanup webgl_materials_modified

### DIFF
--- a/examples/webgl_materials_modified.html
+++ b/examples/webgl_materials_modified.html
@@ -112,7 +112,7 @@
 
 				material.customProgramCacheKey = function () {
 
-					return amount.toFixed(1);
+					return amount.toFixed( 1 );
 
 				};
 

--- a/examples/webgl_materials_modified.html
+++ b/examples/webgl_materials_modified.html
@@ -112,7 +112,7 @@
 
 				material.customProgramCacheKey = function () {
 
-					return amount;
+					return amount.toFixed(1);
 
 				};
 


### PR DESCRIPTION
Related issue: N/A

**Description**

`Material.customProgramCacheKey` is [documented as returning a `string`](https://threejs.org/docs/index.html?q=material#api/en/materials/Material.customProgramCacheKey). This keeps things clean by returning a string and uses `.toFixed(1)` since that's what's used in the vertex shader.