### PR TITLE
Cleanup webgl_raymarching_reflect

### DIFF
--- a/examples/webgl_raymarching_reflect.html
+++ b/examples/webgl_raymarching_reflect.html
@@ -281,7 +281,7 @@
 
 				renderer = new THREE.WebGLRenderer( { canvas: canvas } );
 				renderer.setPixelRatio( window.devicePixelRatio );
-				renderer.setSize( config.resolution, config.resolution );
+				renderer.setSize( parseInt( config.resolution ), parseInt( config.resolution ) );
 
 				window.addEventListener( 'resize', onWindowResize );
 
@@ -333,7 +333,7 @@
 
 				} else {
 
-					renderer.setSize( config.resolution, config.resolution );
+					renderer.setSize( parseInt( config.resolution ), parseInt( config.resolution ) );
 
 				}
 


### PR DESCRIPTION
Related issue: N/A

**Description**

[`WebGLRenderer.setSize` takes ints](https://threejs.org/docs/index.html?q=webglre#api/en/renderers/WebGLRenderer.setSize). Cleans up `webgl_raymarching_reflect` to pass integers instead of strings.