### PR TITLE
HemisphereLightNode: Fix construct() call

### DIFF
--- a/examples/jsm/nodes/lighting/HemisphereLightNode.js
+++ b/examples/jsm/nodes/lighting/HemisphereLightNode.js
@@ -33,7 +33,7 @@ class HemisphereLightNode extends AnalyticLightNode {
 
 	}
 
-	generate( builder ) {
+	construct( builder ) {
 
 		const { colorNode, groundColorNode, lightDirectionNode } = this;
 


### PR DESCRIPTION
**Description**

`HemisphereLight` was not working on WebGPU because of wrong sequence of call which was not updated.