### PR TITLE
WebGLTextures: Improve `RED_INTEGER` texture support.

### DIFF
--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -157,6 +157,17 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		}
 
+		if ( glFormat === _gl.RED_INTEGER ) {
+
+			if ( glType === _gl.UNSIGNED_BYTE ) internalFormat = _gl.R8UI;
+			if ( glType === _gl.UNSIGNED_SHORT ) internalFormat = _gl.R16UI;
+			if ( glType === _gl.UNSIGNED_INT ) internalFormat = _gl.R32UI;
+			if ( glType === _gl.BYTE ) internalFormat = _gl.R8I;
+			if ( glType === _gl.SHORT ) internalFormat = _gl.R16I;
+			if ( glType === _gl.INT ) internalFormat = _gl.R32I;
+
+		}
+
 		if ( glFormat === _gl.RG ) {
 
 			if ( glType === _gl.FLOAT ) internalFormat = _gl.RG32F;


### PR DESCRIPTION
This pull request enhances the THREE.WebGLTextures class in three.js to support the use of integer textures in WebGL2. Specifically, it adds conditional handling for the `glFormat` value of `RED_INTEGER`, assigning the appropriate `internalFormat` based on the given `glType`.

With this enhancement, WebGLTextures now correctly assigns the internalFormat for `BYTE, SHORT`, `INT`, `UNSIGNED_BYTE`, `UNSIGNED_SHORT`, and `UNSIGNED_INT` texture types when using the `RED_INTEGER` format.