### PR TITLE
WebGPURenderer: createImageBitmap options update

### DIFF
--- a/examples/jsm/renderers/webgpu/utils/WebGPUTextureUtils.js
+++ b/examples/jsm/renderers/webgpu/utils/WebGPUTextureUtils.js
@@ -439,7 +439,7 @@ class WebGPUTextureUtils {
 
 		const options = {};
 
-		options.imageOrientation = ( texture.flipY === true ) ? 'flipY' : 'none';
+		options.imageOrientation = ( texture.flipY === true ) ? 'flipY' : 'default';
 		options.premultiplyAlpha = ( texture.premultiplyAlpha === true ) ? 'premultiply' : 'default';
 
 		return createImageBitmap( image, 0, 0, width, height, options );


### PR DESCRIPTION
Recently the meaning of the createImageBitmap 'imageOrientation' option of 'none' was changed to match similar CSS properties for images.  Originally imageBitmaps created with an orientation of 'none' had any rotations/flips specified in an images EXIF data or equivalent applied.  'default' now provides that behaviour, while 'none' will ignore any EXIF data.

The new behavior of none is implemented in Chrome, and although not implemented by Firefox yet, it does accept 'default'.