### PR TITLE
Added documentation for target

### DIFF
--- a/docs/examples/en/controls/TrackballControls.html
+++ b/docs/examples/en/controls/TrackballControls.html
@@ -171,6 +171,11 @@
 			Whether or not damping is disabled. Default is `false`.
 		</p>
 
+		<h3>[property:Vector3 target]</h3>
+		<p>
+			The point in world space the controls are centered around.
+		</p>
+
 		<h3>[property:Number zoomSpeed]</h3>
 		<p>
 			The zoom speed. Default is `1.2`.

--- a/docs/examples/en/controls/TrackballControls.html
+++ b/docs/examples/en/controls/TrackballControls.html
@@ -173,7 +173,7 @@
 
 		<h3>[property:Vector3 target]</h3>
 		<p>
-			The point in world space the controls are centered around.
+			The focus point of the controls.
 		</p>
 
 		<h3>[property:Number zoomSpeed]</h3>


### PR DESCRIPTION
**Improved Documentation**

Documentation was missing for the 'target' property on the TrackballControls doc page. I added a short description, feel free to improve it if necessary.