### PR TITLE
Remove outdated setting of focal length in examples

### DIFF
--- a/examples/webgl_effects_anaglyph.html
+++ b/examples/webgl_effects_anaglyph.html
@@ -53,7 +53,6 @@
 
 				camera = new THREE.PerspectiveCamera( 60, window.innerWidth / window.innerHeight, 0.01, 100 );
 				camera.position.z = 3;
-				camera.setFocalLength( 3 );
 
 				const path = 'textures/cube/pisa/';
 				const format = '.png';

--- a/examples/webgl_effects_anaglyph.html
+++ b/examples/webgl_effects_anaglyph.html
@@ -53,7 +53,7 @@
 
 				camera = new THREE.PerspectiveCamera( 60, window.innerWidth / window.innerHeight, 0.01, 100 );
 				camera.position.z = 3;
-				camera.focalLength = 3;
+				camera.setFocalLength( 3 );
 
 				const path = 'textures/cube/pisa/';
 				const format = '.png';

--- a/examples/webgl_effects_parallaxbarrier.html
+++ b/examples/webgl_effects_parallaxbarrier.html
@@ -54,7 +54,6 @@
 
 				camera = new THREE.PerspectiveCamera( 60, window.innerWidth / window.innerHeight, 0.01, 100 );
 				camera.position.z = 3;
-				camera.setFocalLength( 3 );
 
 				const path = 'textures/cube/pisa/';
 				const format = '.png';

--- a/examples/webgl_effects_parallaxbarrier.html
+++ b/examples/webgl_effects_parallaxbarrier.html
@@ -54,7 +54,7 @@
 
 				camera = new THREE.PerspectiveCamera( 60, window.innerWidth / window.innerHeight, 0.01, 100 );
 				camera.position.z = 3;
-				camera.focalLength = 3;
+				camera.setFocalLength( 3 );
 
 				const path = 'textures/cube/pisa/';
 				const format = '.png';


### PR DESCRIPTION
Related issue: N/A

**Description**

`PerspectiveCamera` no longer has a `focalLength` property and requires calling `setFocalLength` as of https://github.com/mrdoob/three.js/pull/8495. Setting the focal length changes the screenshot, so I just removed the call.