### PR TITLE
Bundler support for DRACOLoader and KTX2Loader (#26403)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,7 @@
     "es2018": true
   },
   "parserOptions": {
-    "ecmaVersion": 2018,
+    "ecmaVersion": 2020,
     "sourceType": "module"
   },
   "extends": [

--- a/examples/jsm/loaders/DRACOLoader.js
+++ b/examples/jsm/loaders/DRACOLoader.js
@@ -11,10 +11,10 @@ import {
 const _taskCache = new WeakMap();
 
 const _dependencies = {
-	"draco_decoder.js": new URL("../libs/draco/draco_decoder.js", import.meta.url).toString(),
-	"draco_decoder.wasm": new URL("../libs/draco/draco_decoder.wasm", import.meta.url).toString(),
-	"draco_encoder.js": new URL("../libs/draco/draco_encoder.js", import.meta.url).toString(),
-	"draco_wasm_wrapper.js": new URL("../libs/draco/draco_wasm_wrapper.js", import.meta.url).toString(),
+	'draco_decoder.js': new URL( '../libs/draco/draco_decoder.js', import.meta.url ).toString(),
+	'draco_decoder.wasm': new URL( '../libs/draco/draco_decoder.wasm', import.meta.url ).toString(),
+	'draco_encoder.js': new URL( '../libs/draco/draco_encoder.js', import.meta.url ).toString(),
+	'draco_wasm_wrapper.js': new URL( '../libs/draco/draco_wasm_wrapper.js', import.meta.url ).toString(),
 };
 
 class DRACOLoader extends Loader {
@@ -250,8 +250,10 @@ class DRACOLoader extends Loader {
 
 	_loadLibrary( url, responseType ) {
 
-		if (!this.decoderPath && _dependencies[url]) {
-			url = _dependencies[url];	
+		if ( ! this.decoderPath && _dependencies[ url ] ) {
+
+			url = _dependencies[ url ];
+
 		}
 
 		const loader = new FileLoader( this.manager );

--- a/examples/jsm/loaders/DRACOLoader.js
+++ b/examples/jsm/loaders/DRACOLoader.js
@@ -10,6 +10,13 @@ import {
 
 const _taskCache = new WeakMap();
 
+const _dependencies = {
+	"draco_decoder.js": new URL("../libs/draco/draco_decoder.js", import.meta.url).toString(),
+	"draco_decoder.wasm": new URL("../libs/draco/draco_decoder.wasm", import.meta.url).toString(),
+	"draco_encoder.js": new URL("../libs/draco/draco_encoder.js", import.meta.url).toString(),
+	"draco_wasm_wrapper.js": new URL("../libs/draco/draco_wasm_wrapper.js", import.meta.url).toString(),
+};
+
 class DRACOLoader extends Loader {
 
 	constructor( manager ) {
@@ -242,6 +249,10 @@ class DRACOLoader extends Loader {
 	}
 
 	_loadLibrary( url, responseType ) {
+
+		if (!this.decoderPath && _dependencies[url]) {
+			url = _dependencies[url];	
+		}
 
 		const loader = new FileLoader( this.manager );
 		loader.setPath( this.decoderPath );

--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -68,6 +68,11 @@ let _activeLoaders = 0;
 
 let _zstd;
 
+const _dependencies = {
+	"basis_transcoder.js": new URL("../libs/basis/basis_transcoder.js", import.meta.url).toString(),
+	"basis_transcoder.wasm": new URL("../libs/basis/basis_transcoder.wasm", import.meta.url).toString(),
+};
+
 class KTX2Loader extends Loader {
 
 	constructor( manager ) {
@@ -157,14 +162,14 @@ class KTX2Loader extends Loader {
 			const jsLoader = new FileLoader( this.manager );
 			jsLoader.setPath( this.transcoderPath );
 			jsLoader.setWithCredentials( this.withCredentials );
-			const jsContent = jsLoader.loadAsync( 'basis_transcoder.js' );
+			const jsContent = jsLoader.loadAsync( this.transcoderPath ? 'basis_transcoder.js' : _dependencies['basis_transcoder.js'] );
 
 			// Load transcoder WASM binary.
 			const binaryLoader = new FileLoader( this.manager );
 			binaryLoader.setPath( this.transcoderPath );
 			binaryLoader.setResponseType( 'arraybuffer' );
 			binaryLoader.setWithCredentials( this.withCredentials );
-			const binaryContent = binaryLoader.loadAsync( 'basis_transcoder.wasm' );
+			const binaryContent = binaryLoader.loadAsync( this.transcoderPath ? 'basis_transcoder.wasm' : _dependencies['basis_transcoder.wasm']);
 
 			this.transcoderPending = Promise.all( [ jsContent, binaryContent ] )
 				.then( ( [ jsContent, binaryContent ] ) => {

--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -69,8 +69,8 @@ let _activeLoaders = 0;
 let _zstd;
 
 const _dependencies = {
-	"basis_transcoder.js": new URL("../libs/basis/basis_transcoder.js", import.meta.url).toString(),
-	"basis_transcoder.wasm": new URL("../libs/basis/basis_transcoder.wasm", import.meta.url).toString(),
+	'basis_transcoder.js': new URL( '../libs/basis/basis_transcoder.js', import.meta.url ).toString(),
+	'basis_transcoder.wasm': new URL( '../libs/basis/basis_transcoder.wasm', import.meta.url ).toString(),
 };
 
 class KTX2Loader extends Loader {
@@ -162,14 +162,14 @@ class KTX2Loader extends Loader {
 			const jsLoader = new FileLoader( this.manager );
 			jsLoader.setPath( this.transcoderPath );
 			jsLoader.setWithCredentials( this.withCredentials );
-			const jsContent = jsLoader.loadAsync( this.transcoderPath ? 'basis_transcoder.js' : _dependencies['basis_transcoder.js'] );
+			const jsContent = jsLoader.loadAsync( this.transcoderPath ? 'basis_transcoder.js' : _dependencies[ 'basis_transcoder.js' ] );
 
 			// Load transcoder WASM binary.
 			const binaryLoader = new FileLoader( this.manager );
 			binaryLoader.setPath( this.transcoderPath );
 			binaryLoader.setResponseType( 'arraybuffer' );
 			binaryLoader.setWithCredentials( this.withCredentials );
-			const binaryContent = binaryLoader.loadAsync( this.transcoderPath ? 'basis_transcoder.wasm' : _dependencies['basis_transcoder.wasm']);
+			const binaryContent = binaryLoader.loadAsync( this.transcoderPath ? 'basis_transcoder.wasm' : _dependencies[ 'basis_transcoder.wasm' ] );
 
 			this.transcoderPending = Promise.all( [ jsContent, binaryContent ] )
 				.then( ( [ jsContent, binaryContent ] ) => {

--- a/examples/webgl_loader_draco.html
+++ b/examples/webgl_loader_draco.html
@@ -38,8 +38,6 @@
 
 		// Configure and create Draco decoder.
 		const dracoLoader = new DRACOLoader();
-		dracoLoader.setDecoderPath( 'jsm/libs/draco/' );
-		dracoLoader.setDecoderConfig( { type: 'js' } );
 
 		init();
 		animate();

--- a/examples/webgl_loader_texture_ktx2.html
+++ b/examples/webgl_loader_texture_ktx2.html
@@ -85,7 +85,6 @@
 
 				// Samples: sample_etc1s.ktx2, sample_uastc.ktx2, sample_uastc_zstd.ktx2
 				const loader = new KTX2Loader()
-					.setTranscoderPath( 'jsm/libs/basis/' )
 					.detectSupport( renderer );
 
 


### PR DESCRIPTION
Use the `new URL(..., import.meta.url);` structure, supported by browsers and several bundlers (including Webpack and Parcel), to allow for 'config-less' use of DRACOLoader and KTX2Loader

Related issue: #26403
