### PR TITLE
WebGLRenderer: Remove material condition for unconditional uniforms.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1812,47 +1812,16 @@ class WebGLRenderer {
 
 				}
 
-				// load material specific uniforms
-				// (shader material also gets them for the sake of genericity)
+				// load material common uniforms
 
-				if ( material.isShaderMaterial ||
-					material.isMeshPhongMaterial ||
-					material.isMeshToonMaterial ||
-					material.isMeshStandardMaterial ||
-					material.envMap ) {
+				p_uniforms.setValue( _gl, 'viewMatrix', camera.matrixWorldInverse );
+				p_uniforms.setValue( _gl, 'isOrthographic', camera.isOrthographicCamera === true );
 
-					const uCamPos = p_uniforms.map.cameraPosition;
+				const uCamPos = p_uniforms.map.cameraPosition;
 
-					if ( uCamPos !== undefined ) {
+				if ( uCamPos !== undefined ) {
 
-						uCamPos.setValue( _gl,
-							_vector3.setFromMatrixPosition( camera.matrixWorld ) );
-
-					}
-
-				}
-
-				if ( material.isMeshPhongMaterial ||
-					material.isMeshToonMaterial ||
-					material.isMeshLambertMaterial ||
-					material.isMeshBasicMaterial ||
-					material.isMeshStandardMaterial ||
-					material.isShaderMaterial ) {
-
-					p_uniforms.setValue( _gl, 'isOrthographic', camera.isOrthographicCamera === true );
-
-				}
-
-				if ( material.isMeshPhongMaterial ||
-					material.isMeshToonMaterial ||
-					material.isMeshLambertMaterial ||
-					material.isMeshBasicMaterial ||
-					material.isMeshStandardMaterial ||
-					material.isShaderMaterial ||
-					material.isShadowMaterial ||
-					object.isSkinnedMesh ) {
-
-					p_uniforms.setValue( _gl, 'viewMatrix', camera.matrixWorldInverse );
+					uCamPos.setValue( _gl, _vector3.setFromMatrixPosition( camera.matrixWorld ) );
 
 				}
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1823,7 +1823,7 @@ class WebGLRenderer {
 					refreshLights = true;		// remains set until update done
 
 				}
-				
+
 			}
 
 			// skinning and morph target uniforms must be set even if material didn't change

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1790,7 +1790,19 @@ class WebGLRenderer {
 
 			if ( refreshProgram || _currentCamera !== camera ) {
 
+				// common camera uniforms
+
 				p_uniforms.setValue( _gl, 'projectionMatrix', camera.projectionMatrix );
+				p_uniforms.setValue( _gl, 'viewMatrix', camera.matrixWorldInverse );
+				p_uniforms.setValue( _gl, 'isOrthographic', camera.isOrthographicCamera === true );
+
+				const uCamPos = p_uniforms.map.cameraPosition;
+
+				if ( uCamPos !== undefined ) {
+
+					uCamPos.setValue( _gl, _vector3.setFromMatrixPosition( camera.matrixWorld ) );
+
+				}
 
 				if ( capabilities.logarithmicDepthBuffer ) {
 
@@ -1811,20 +1823,7 @@ class WebGLRenderer {
 					refreshLights = true;		// remains set until update done
 
 				}
-
-				// load material common uniforms
-
-				p_uniforms.setValue( _gl, 'viewMatrix', camera.matrixWorldInverse );
-				p_uniforms.setValue( _gl, 'isOrthographic', camera.isOrthographicCamera === true );
-
-				const uCamPos = p_uniforms.map.cameraPosition;
-
-				if ( uCamPos !== undefined ) {
-
-					uCamPos.setValue( _gl, _vector3.setFromMatrixPosition( camera.matrixWorld ) );
-
-				}
-
+				
 			}
 
 			// skinning and morph target uniforms must be set even if material didn't change

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1810,8 +1810,7 @@ class WebGLRenderer {
 
 				}
 
-				// isOrthographic is defined in the scaffold for all shaders, but may not be used in all.
-				// https://github.com/mrdoob/three.js/pull/26467#issuecomment-1645185067
+				// consider moving isOrthographic to UniformLib and WebGLMaterials, see https://github.com/mrdoob/three.js/pull/26467#issuecomment-1645185067
 
 				if ( material.isMeshPhongMaterial ||
 					material.isMeshToonMaterial ||

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1794,7 +1794,6 @@ class WebGLRenderer {
 
 				p_uniforms.setValue( _gl, 'projectionMatrix', camera.projectionMatrix );
 				p_uniforms.setValue( _gl, 'viewMatrix', camera.matrixWorldInverse );
-				p_uniforms.setValue( _gl, 'isOrthographic', camera.isOrthographicCamera === true );
 
 				const uCamPos = p_uniforms.map.cameraPosition;
 
@@ -1808,6 +1807,20 @@ class WebGLRenderer {
 
 					p_uniforms.setValue( _gl, 'logDepthBufFC',
 						2.0 / ( Math.log( camera.far + 1.0 ) / Math.LN2 ) );
+
+				}
+
+				// isOrthographic is defined in the scaffold for all shaders, but may not be used in all.
+				// https://github.com/mrdoob/three.js/pull/26467#issuecomment-1645185067
+
+				if ( material.isMeshPhongMaterial ||
+					material.isMeshToonMaterial ||
+					material.isMeshLambertMaterial ||
+					material.isMeshBasicMaterial ||
+					material.isMeshStandardMaterial ||
+					material.isShaderMaterial ) {
+
+					p_uniforms.setValue( _gl, 'isOrthographic', camera.isOrthographicCamera === true );
 
 				}
 


### PR DESCRIPTION
**Description**

WebGLRenderer load [default (unconditional) uniforms](https://threejs.org/docs/#api/en/renderers/webgl/WebGLProgram) for not all built-in materials. This uniforms declare in `common` shader chunk and include for all built-in materials. Also material has [onBeforeCompile](https://threejs.org/docs/api/en/materials/index.html#api/en/materials/Material.onBeforeCompile) callback witch
> Useful for the modification of built-in materials.

If I completely legally modify built-in materials, I want to get access to default unconditional uniforms. 

In WebGLRenderer before load some uniforms set conditional that check material type, and for some material not provide some uniforms. I am remove this conditionals. 

This doesn't affect performance much, but will make the behavior more predictable.