### PR TITLE
GLTFLoader: Fix `loadAnimation()` refactor.

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -4302,9 +4302,24 @@ class GLTFParser {
 
 			case PATH_PROPERTIES.position:
 			case PATH_PROPERTIES.scale:
-			default:
 
 				TypedKeyframeTrack = VectorKeyframeTrack;
+				break;
+
+			default:
+
+				switch ( outputAccessor.itemSize ) {
+
+					case 1:
+						TypedKeyframeTrack = NumberKeyframeTrack;
+						break;
+					case 2:
+					case 3:
+					default:
+						TypedKeyframeTrack = VectorKeyframeTrack;
+						break;
+
+				}
 				break;
 
 		}

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -4320,6 +4320,7 @@ class GLTFParser {
 						break;
 
 				}
+
 				break;
 
 		}
@@ -4394,6 +4395,7 @@ class GLTFParser {
 		track.createInterpolant.isInterpolantFactoryMethodGLTFCubicSpline = true;
 
 	}
+
 }
 
 /**

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -4264,6 +4264,28 @@ class GLTFParser {
 	_createAnimationTracks( node, inputAccessor, outputAccessor, sampler, target ) {
 
 		const tracks = [];
+
+		const targetName = node.name ? node.name : node.uuid;
+		const targetNames = [];
+
+		if ( PATH_PROPERTIES[ target.path ] === PATH_PROPERTIES.weights ) {
+
+			node.traverse( function ( object ) {
+
+				if ( object.morphTargetInfluences ) {
+
+					targetNames.push( object.name ? object.name : object.uuid );
+
+				}
+
+			} );
+
+		} else {
+
+			targetNames.push( targetName );
+
+		}
+
 		let TypedKeyframeTrack;
 
 		switch ( PATH_PROPERTIES[ target.path ] ) {
@@ -4287,29 +4309,8 @@ class GLTFParser {
 
 		}
 
-		const targetName = node.name ? node.name : node.uuid;
-
 		const interpolation = sampler.interpolation !== undefined ? INTERPOLATION[ sampler.interpolation ] : InterpolateLinear;
 
-		const targetNames = [];
-
-		if ( PATH_PROPERTIES[ target.path ] === PATH_PROPERTIES.weights ) {
-
-			node.traverse( function ( object ) {
-
-				if ( object.morphTargetInfluences ) {
-
-					targetNames.push( object.name ? object.name : object.uuid );
-
-				}
-
-			} );
-
-		} else {
-
-			targetNames.push( targetName );
-
-		}
 
 		const outputArray = this._getArrayFromAccessor( outputAccessor );
 


### PR DESCRIPTION
Fixes
- https://github.com/mrdoob/three.js/issues/26470
bug introduced in
- https://github.com/mrdoob/three.js/pull/26126 

that caused cubic interpolators in glTF to break.

**Description**

One mistake during the earlier refactor, my bad.
![image](https://github.com/mrdoob/three.js/assets/2693840/ca9440d6-75b7-48c4-9119-1a9d9394a11d)

cc @Mugen87 