### PR TITLE
SelectionHelper: Add `enabled` property.

### DIFF
--- a/examples/jsm/interactive/SelectionHelper.js
+++ b/examples/jsm/interactive/SelectionHelper.js
@@ -40,9 +40,7 @@ class SelectionHelper {
 
 		}.bind( this );
 
-		this.renderer.domElement.addEventListener( 'pointerdown', this.onPointerDown );
-		this.renderer.domElement.addEventListener( 'pointermove', this.onPointerMove );
-		this.renderer.domElement.addEventListener( 'pointerup', this.onPointerUp );
+		this.reactive();
 
 	}
 
@@ -51,6 +49,14 @@ class SelectionHelper {
 		this.renderer.domElement.removeEventListener( 'pointerdown', this.onPointerDown );
 		this.renderer.domElement.removeEventListener( 'pointermove', this.onPointerMove );
 		this.renderer.domElement.removeEventListener( 'pointerup', this.onPointerUp );
+
+	}
+
+	reactive() {
+
+		this.renderer.domElement.addEventListener( 'pointerdown', this.onPointerDown );
+		this.renderer.domElement.addEventListener( 'pointermove', this.onPointerMove );
+		this.renderer.domElement.addEventListener( 'pointerup', this.onPointerUp );
 
 	}
 

--- a/examples/jsm/interactive/SelectionHelper.js
+++ b/examples/jsm/interactive/SelectionHelper.js
@@ -15,8 +15,11 @@ class SelectionHelper {
 		this.pointBottomRight = new Vector2();
 
 		this.isDown = false;
+		this.enabled = true;
 
 		this.onPointerDown = function ( event ) {
+
+			if (this.enabled === false) return;
 
 			this.isDown = true;
 			this.onSelectStart( event );
@@ -24,6 +27,8 @@ class SelectionHelper {
 		}.bind( this );
 
 		this.onPointerMove = function ( event ) {
+
+			if (this.enabled === false) return;
 
 			if ( this.isDown ) {
 
@@ -35,12 +40,16 @@ class SelectionHelper {
 
 		this.onPointerUp = function ( ) {
 
+			if (this.enabled === false) return;
+
 			this.isDown = false;
 			this.onSelectOver();
 
 		}.bind( this );
 
-		this.reactive();
+		this.renderer.domElement.addEventListener( 'pointerdown', this.onPointerDown );
+		this.renderer.domElement.addEventListener( 'pointermove', this.onPointerMove );
+		this.renderer.domElement.addEventListener( 'pointerup', this.onPointerUp );
 
 	}
 
@@ -49,14 +58,6 @@ class SelectionHelper {
 		this.renderer.domElement.removeEventListener( 'pointerdown', this.onPointerDown );
 		this.renderer.domElement.removeEventListener( 'pointermove', this.onPointerMove );
 		this.renderer.domElement.removeEventListener( 'pointerup', this.onPointerUp );
-
-	}
-
-	reactive() {
-
-		this.renderer.domElement.addEventListener( 'pointerdown', this.onPointerDown );
-		this.renderer.domElement.addEventListener( 'pointermove', this.onPointerMove );
-		this.renderer.domElement.addEventListener( 'pointerup', this.onPointerUp );
 
 	}
 

--- a/examples/jsm/interactive/SelectionHelper.js
+++ b/examples/jsm/interactive/SelectionHelper.js
@@ -19,7 +19,7 @@ class SelectionHelper {
 
 		this.onPointerDown = function ( event ) {
 
-			if (this.enabled === false) return;
+			if ( this.enabled === false ) return;
 
 			this.isDown = true;
 			this.onSelectStart( event );
@@ -28,7 +28,7 @@ class SelectionHelper {
 
 		this.onPointerMove = function ( event ) {
 
-			if (this.enabled === false) return;
+			if ( this.enabled === false ) return;
 
 			if ( this.isDown ) {
 
@@ -40,7 +40,7 @@ class SelectionHelper {
 
 		this.onPointerUp = function ( ) {
 
-			if (this.enabled === false) return;
+			if ( this.enabled === false ) return;
 
 			this.isDown = false;
 			this.onSelectOver();


### PR DESCRIPTION
At some point I need to disable or enable SelectionHelper, but SelectionHelper currently only has .dispose() , and if I want to reactivate, I have to renew SelectionHelper() , so I added `.enabled`.