### PR TITLE
USDZExporter: add defaultPrim to make usdchecker happy

### DIFF
--- a/examples/jsm/exporters/USDZExporter.js
+++ b/examples/jsm/exporters/USDZExporter.js
@@ -165,6 +165,7 @@ function buildHeader() {
 	customLayerData = {
 		string creator = "Three.js USDZExporter"
 	}
+	defaultPrim = "Root"
 	metersPerUnit = 1
 	upAxis = "Y"
 )


### PR DESCRIPTION
**Description**

`usdchecker` is the official tool to verify USD/USDZ files from Pixar.
Current exported files don't pass it and don't log anything useful because it already fails on a missing `defaultPrim`, so this PR adds that. Currently the root name is hardcoded so it's always "Root".

Before:
```
herbst@ % usdchecker "scene.usdz" 
Stage has missing or invalid defaultPrim. (fails 'StageMetadataChecker')
Failed!
```

After:
```
herbst@ % usdchecker scene.usdz                                
Success!
```

*This contribution is funded by [Needle](https://needle.tools)*
