### PR TITLE
TGALoader: Bubble parsing errors.

### DIFF
--- a/examples/jsm/loaders/TGALoader.js
+++ b/examples/jsm/loaders/TGALoader.js
@@ -25,7 +25,7 @@ class TGALoader extends DataTextureLoader {
 				case TGA_TYPE_RLE_INDEXED:
 					if ( header.colormap_length > 256 || header.colormap_size !== 24 || header.colormap_type !== 1 ) {
 
-						console.error( 'THREE.TGALoader: Invalid type colormap data for indexed type.' );
+						throw new Error( 'THREE.TGALoader: Invalid type colormap data for indexed type.' );
 
 					}
 
@@ -39,7 +39,7 @@ class TGALoader extends DataTextureLoader {
 				case TGA_TYPE_RLE_GREY:
 					if ( header.colormap_type ) {
 
-						console.error( 'THREE.TGALoader: Invalid type colormap data for colormap type.' );
+						throw new Error( 'THREE.TGALoader: Invalid type colormap data for colormap type.' );
 
 					}
 
@@ -48,12 +48,12 @@ class TGALoader extends DataTextureLoader {
 					// What the need of a file without data ?
 
 				case TGA_TYPE_NO_DATA:
-					console.error( 'THREE.TGALoader: No data.' );
+					throw new Error.error( 'THREE.TGALoader: No data.' );
 
 					// Invalid type ?
 
 				default:
-					console.error( 'THREE.TGALoader: Invalid type "%s".', header.image_type );
+					throw new Error( 'THREE.TGALoader: Invalid type ' + header.image_type );
 
 			}
 
@@ -61,7 +61,7 @@ class TGALoader extends DataTextureLoader {
 
 			if ( header.width <= 0 || header.height <= 0 ) {
 
-				console.error( 'THREE.TGALoader: Invalid image size.' );
+				throw new Error( 'THREE.TGALoader: Invalid image size.' );
 
 			}
 
@@ -70,7 +70,7 @@ class TGALoader extends DataTextureLoader {
 			if ( header.pixel_size !== 8 && header.pixel_size !== 16 &&
 				header.pixel_size !== 24 && header.pixel_size !== 32 ) {
 
-				console.error( 'THREE.TGALoader: Invalid pixel size "%s".', header.pixel_size );
+				throw new Error( 'THREE.TGALoader: Invalid pixel size ' + header.pixel_size );
 
 			}
 
@@ -365,7 +365,7 @@ class TGALoader extends DataTextureLoader {
 						break;
 
 					default:
-						console.error( 'THREE.TGALoader: Format not supported.' );
+						throw new Error( 'THREE.TGALoader: Format not supported.' );
 						break;
 
 				}
@@ -391,7 +391,7 @@ class TGALoader extends DataTextureLoader {
 						break;
 
 					default:
-						console.error( 'THREE.TGALoader: Format not supported.' );
+						throw new Error( 'THREE.TGALoader: Format not supported.' );
 						break;
 
 				}
@@ -422,7 +422,7 @@ class TGALoader extends DataTextureLoader {
 			TGA_ORIGIN_UL = 0x02,
 			TGA_ORIGIN_UR = 0x03;
 
-		if ( buffer.length < 19 ) console.error( 'THREE.TGALoader: Not enough data to contain header.' );
+		if ( buffer.length < 19 ) throw new Error( 'THREE.TGALoader: Not enough data to contain header.' );
 
 		let offset = 0;
 
@@ -450,7 +450,7 @@ class TGALoader extends DataTextureLoader {
 
 		if ( header.id_length + offset > buffer.length ) {
 
-			console.error( 'THREE.TGALoader: No data.' );
+			throw new Error( 'THREE.TGALoader: No data.' );
 
 		}
 

--- a/examples/jsm/loaders/TGALoader.js
+++ b/examples/jsm/loaders/TGALoader.js
@@ -48,7 +48,7 @@ class TGALoader extends DataTextureLoader {
 					// What the need of a file without data ?
 
 				case TGA_TYPE_NO_DATA:
-					throw new Error.error( 'THREE.TGALoader: No data.' );
+					throw new Error( 'THREE.TGALoader: No data.' );
 
 					// Invalid type ?
 

--- a/src/loaders/DataTextureLoader.js
+++ b/src/loaders/DataTextureLoader.js
@@ -30,9 +30,28 @@ class DataTextureLoader extends Loader {
 		loader.setWithCredentials( scope.withCredentials );
 		loader.load( url, function ( buffer ) {
 
-			const texData = scope.parse( buffer ); // TODO: Use try/catch here and throw errors in derived loaders, see #26412
+			let texData;
 
-			if ( ! texData ) return onError();
+			try {
+
+				texData = scope.parse( buffer );
+
+			} catch ( error ) {
+
+				if ( onError !== undefined ) {
+
+					onError( error );
+
+				} else {
+
+					console.error( error );
+					return;
+
+				}
+
+			}
+
+			if ( ! texData ) return onError(); // TODO: Remove this when all loaders properly throw errors
 
 			if ( texData.image !== undefined ) {
 


### PR DESCRIPTION
Related issue: #26457

**Description**

This PR ensures `TGALoader` does not log errors but _throws_ them instead. `DataTextureLoader` then catches the error and executes `onError()` if available. Otherwise the error is logged as before.

When this PR is approved, its approach can be used in all other loaders deriving from `DataTextureLoader`.
