### PR TITLE
Loaders: Bubble parsing errors in remaining data texture loaders.

### DIFF
--- a/examples/jsm/loaders/EXRLoader.js
+++ b/examples/jsm/loaders/EXRLoader.js
@@ -1996,7 +1996,7 @@ class EXRLoader extends DataTextureLoader {
 
 			if ( dataView.getUint32( 0, true ) != 20000630 ) { // magic
 
-				throw new Error( 'THREE.EXRLoader: provided file doesn\'t appear to be in OpenEXR format.' );
+				throw new Error( 'THREE.EXRLoader: Provided file doesn\'t appear to be in OpenEXR format.' );
 
 			}
 
@@ -2033,7 +2033,7 @@ class EXRLoader extends DataTextureLoader {
 
 					if ( attributeValue === undefined ) {
 
-						console.warn( `EXRLoader.parse: skipped unknown header attribute type \'${attributeType}\'.` );
+						console.warn( `THREE.EXRLoader: Skipped unknown header attribute type \'${attributeType}\'.` );
 
 					} else {
 
@@ -2047,8 +2047,8 @@ class EXRLoader extends DataTextureLoader {
 
 			if ( ( spec & ~ 0x04 ) != 0 ) { // unsupported tiled, deep-image, multi-part
 
-				console.error( 'EXRHeader:', EXRHeader );
-				throw new Error( 'THREE.EXRLoader: provided file is currently unsupported.' );
+				console.error( 'THREE.EXRHeader:', EXRHeader );
+				throw new Error( 'THREE.EXRLoader: Provided file is currently unsupported.' );
 
 			}
 

--- a/examples/jsm/loaders/LogLuvLoader.js
+++ b/examples/jsm/loaders/LogLuvLoader.js
@@ -393,7 +393,7 @@ UTIF.toRGBA = function ( out, type ) {
 			break;
 
 		default:
-			console.error( 'THREE.LogLuvLoader: Unsupported texture data type:', type );
+			throw new Error( 'THREE.LogLuvLoader: Unsupported texture data type: ' + type );
 
 	}
 
@@ -451,7 +451,7 @@ UTIF.toRGBA = function ( out, type ) {
 
 	} else {
 
-		console.log( 'Unsupported Photometric interpretation: ' + intp );
+		throw new Error( 'THREE.LogLuvLoader: Unsupported Photometric interpretation: ' + intp );
 
 	}
 

--- a/examples/jsm/loaders/RGBELoader.js
+++ b/examples/jsm/loaders/RGBELoader.js
@@ -25,10 +25,6 @@ class RGBELoader extends DataTextureLoader {
 	parse( buffer ) {
 
 		const
-			/* return codes for rgbe routines */
-			//RGBE_RETURN_SUCCESS = 0,
-			RGBE_RETURN_FAILURE = - 1,
-
 			/* default error routine.  change this to change error handling */
 			rgbe_read_error = 1,
 			rgbe_write_error = 2,
@@ -38,18 +34,13 @@ class RGBELoader extends DataTextureLoader {
 
 				switch ( rgbe_error_code ) {
 
-					case rgbe_read_error: console.error( 'THREE.RGBELoader Read Error: ' + ( msg || '' ) );
-						break;
-					case rgbe_write_error: console.error( 'THREE.RGBELoader Write Error: ' + ( msg || '' ) );
-						break;
-					case rgbe_format_error: console.error( 'THREE.RGBELoader Bad File Format: ' + ( msg || '' ) );
-						break;
+					case rgbe_read_error: throw new Error( 'THREE.RGBELoader: Read Error: ' + ( msg || '' ) );
+					case rgbe_write_error: throw new Error( 'THREE.RGBELoader: Write Error: ' + ( msg || '' ) );
+					case rgbe_format_error: throw new Error( 'THREE.RGBELoader: Bad File Format: ' + ( msg || '' ) );
 					default:
-					case rgbe_memory_error: console.error( 'THREE.RGBELoader: Error: ' + ( msg || '' ) );
+					case rgbe_memory_error: throw new Error( 'THREE.RGBELoader: Memory Error: ' + ( msg || '' ) );
 
 				}
-
-				return RGBE_RETURN_FAILURE;
 
 			},
 
@@ -138,14 +129,14 @@ class RGBELoader extends DataTextureLoader {
 
 				if ( buffer.pos >= buffer.byteLength || ! ( line = fgets( buffer ) ) ) {
 
-					return rgbe_error( rgbe_read_error, 'no header found' );
+					rgbe_error( rgbe_read_error, 'no header found' );
 
 				}
 
 				/* if you want to require the magic token then uncomment the next line */
 				if ( ! ( match = line.match( magic_token_re ) ) ) {
 
-					return rgbe_error( rgbe_format_error, 'bad initial token' );
+					rgbe_error( rgbe_format_error, 'bad initial token' );
 
 				}
 
@@ -199,13 +190,13 @@ class RGBELoader extends DataTextureLoader {
 
 				if ( ! ( header.valid & RGBE_VALID_FORMAT ) ) {
 
-					return rgbe_error( rgbe_format_error, 'missing format specifier' );
+					rgbe_error( rgbe_format_error, 'missing format specifier' );
 
 				}
 
 				if ( ! ( header.valid & RGBE_VALID_DIMENSIONS ) ) {
 
-					return rgbe_error( rgbe_format_error, 'missing image size specifier' );
+					rgbe_error( rgbe_format_error, 'missing image size specifier' );
 
 				}
 
@@ -231,7 +222,7 @@ class RGBELoader extends DataTextureLoader {
 
 				if ( scanline_width !== ( ( buffer[ 2 ] << 8 ) | buffer[ 3 ] ) ) {
 
-					return rgbe_error( rgbe_format_error, 'wrong scanline width' );
+					rgbe_error( rgbe_format_error, 'wrong scanline width' );
 
 				}
 
@@ -239,7 +230,7 @@ class RGBELoader extends DataTextureLoader {
 
 				if ( ! data_rgba.length ) {
 
-					return rgbe_error( rgbe_memory_error, 'unable to allocate buffer space' );
+					rgbe_error( rgbe_memory_error, 'unable to allocate buffer space' );
 
 				}
 
@@ -255,7 +246,7 @@ class RGBELoader extends DataTextureLoader {
 
 					if ( pos + 4 > buffer.byteLength ) {
 
-						return rgbe_error( rgbe_read_error );
+						rgbe_error( rgbe_read_error );
 
 					}
 
@@ -266,7 +257,7 @@ class RGBELoader extends DataTextureLoader {
 
 					if ( ( 2 != rgbeStart[ 0 ] ) || ( 2 != rgbeStart[ 1 ] ) || ( ( ( rgbeStart[ 2 ] << 8 ) | rgbeStart[ 3 ] ) != scanline_width ) ) {
 
-						return rgbe_error( rgbe_format_error, 'bad rgbe scanline format' );
+						rgbe_error( rgbe_format_error, 'bad rgbe scanline format' );
 
 					}
 
@@ -282,7 +273,7 @@ class RGBELoader extends DataTextureLoader {
 
 						if ( ( 0 === count ) || ( ptr + count > ptr_end ) ) {
 
-							return rgbe_error( rgbe_format_error, 'bad scanline data' );
+							rgbe_error( rgbe_format_error, 'bad scanline data' );
 
 						}
 
@@ -362,70 +353,61 @@ class RGBELoader extends DataTextureLoader {
 		byteArray.pos = 0;
 		const rgbe_header_info = RGBE_ReadHeader( byteArray );
 
-		if ( RGBE_RETURN_FAILURE !== rgbe_header_info ) {
+		const w = rgbe_header_info.width,
+			h = rgbe_header_info.height,
+			image_rgba_data = RGBE_ReadPixels_RLE( byteArray.subarray( byteArray.pos ), w, h );
 
-			const w = rgbe_header_info.width,
-				h = rgbe_header_info.height,
-				image_rgba_data = RGBE_ReadPixels_RLE( byteArray.subarray( byteArray.pos ), w, h );
 
-			if ( RGBE_RETURN_FAILURE !== image_rgba_data ) {
+		let data, type;
+		let numElements;
 
-				let data, type;
-				let numElements;
+		switch ( this.type ) {
 
-				switch ( this.type ) {
+			case FloatType:
 
-					case FloatType:
+				numElements = image_rgba_data.length / 4;
+				const floatArray = new Float32Array( numElements * 4 );
 
-						numElements = image_rgba_data.length / 4;
-						const floatArray = new Float32Array( numElements * 4 );
+				for ( let j = 0; j < numElements; j ++ ) {
 
-						for ( let j = 0; j < numElements; j ++ ) {
-
-							RGBEByteToRGBFloat( image_rgba_data, j * 4, floatArray, j * 4 );
-
-						}
-
-						data = floatArray;
-						type = FloatType;
-						break;
-
-					case HalfFloatType:
-
-						numElements = image_rgba_data.length / 4;
-						const halfArray = new Uint16Array( numElements * 4 );
-
-						for ( let j = 0; j < numElements; j ++ ) {
-
-							RGBEByteToRGBHalf( image_rgba_data, j * 4, halfArray, j * 4 );
-
-						}
-
-						data = halfArray;
-						type = HalfFloatType;
-						break;
-
-					default:
-
-						console.error( 'THREE.RGBELoader: unsupported type: ', this.type );
-						break;
+					RGBEByteToRGBFloat( image_rgba_data, j * 4, floatArray, j * 4 );
 
 				}
 
-				return {
-					width: w, height: h,
-					data: data,
-					header: rgbe_header_info.string,
-					gamma: rgbe_header_info.gamma,
-					exposure: rgbe_header_info.exposure,
-					type: type
-				};
+				data = floatArray;
+				type = FloatType;
+				break;
 
-			}
+			case HalfFloatType:
+
+				numElements = image_rgba_data.length / 4;
+				const halfArray = new Uint16Array( numElements * 4 );
+
+				for ( let j = 0; j < numElements; j ++ ) {
+
+					RGBEByteToRGBHalf( image_rgba_data, j * 4, halfArray, j * 4 );
+
+				}
+
+				data = halfArray;
+				type = HalfFloatType;
+				break;
+
+			default:
+
+				throw new Error( 'THREE.RGBELoader: unsupported type: ', this.type );
+				break;
 
 		}
 
-		return null;
+		return {
+			width: w, height: h,
+			data: data,
+			header: rgbe_header_info.string,
+			gamma: rgbe_header_info.gamma,
+			exposure: rgbe_header_info.exposure,
+			type: type
+		};
 
 	}
 

--- a/src/loaders/DataTextureLoader.js
+++ b/src/loaders/DataTextureLoader.js
@@ -51,8 +51,6 @@ class DataTextureLoader extends Loader {
 
 			}
 
-			if ( ! texData ) return onError(); // TODO: Remove this when all loaders properly throw errors
-
 			if ( texData.image !== undefined ) {
 
 				texture.image = texData.image;


### PR DESCRIPTION
Fixed #26457.

**Description**

This PR updates the remaining data texture loaders so they properly throw parsing errors. 

`EXRLoader` already throws errors so there are just some formatting updates. `LogLuvLoader` and `RGBELoader` required some updates. 

`TIFFLoader` and `RGBMLoader` use external modules for parsing which I did not want to monkey patch. 
