### PR TITLE
Update CSMShader.js

### DIFF
--- a/examples/jsm/csm/CSMShader.js
+++ b/examples/jsm/csm/CSMShader.js
@@ -8,10 +8,24 @@ geometry.position = - vViewPosition;
 geometry.normal = normal;
 geometry.viewDir = ( isOrthographic ) ? vec3( 0, 0, 1 ) : normalize( vViewPosition );
 
-#ifdef CLEARCOAT
+#ifdef USE_CLEARCOAT
 
 	geometry.clearcoatNormal = clearcoatNormal;
 
+#endif
+
+#ifdef USE_IRIDESCENCE
+	float dotNVi = saturate( dot( normal, geometry.viewDir ) );
+	if ( material.iridescenceThickness == 0.0 ) {
+		material.iridescence = 0.0;
+	} else {
+		material.iridescence = saturate( material.iridescence );
+	}
+	if ( material.iridescence > 0.0 ) {
+		material.iridescenceFresnel = evalIridescence( 1.0, material.iridescenceIOR, dotNVi, material.iridescenceThickness, material.specularColor );
+		// Iridescence F0 approximation
+		material.iridescenceF0 = Schlick_to_F0( material.iridescenceFresnel, 1.0, dotNVi );
+	}
 #endif
 
 IncidentLight directLight;
@@ -45,6 +59,10 @@ IncidentLight directLight;
 #if ( NUM_SPOT_LIGHTS > 0 ) && defined( RE_Direct )
 
 	SpotLight spotLight;
+ 	vec4 spotColor;
+	vec3 spotLightCoord;
+	bool inSpotLightMap;
+ 
 	#if defined( USE_SHADOWMAP ) && NUM_SPOT_LIGHT_SHADOWS > 0
 	SpotLightShadow spotLightShadow;
 	#endif
@@ -55,6 +73,22 @@ IncidentLight directLight;
 		spotLight = spotLights[ i ];
 
 		getSpotLightInfo( spotLight, geometry, directLight );
+
+  		// spot lights are ordered [shadows with maps, shadows without maps, maps without shadows, none]
+		#if ( UNROLLED_LOOP_INDEX < NUM_SPOT_LIGHT_SHADOWS_WITH_MAPS )
+		#define SPOT_LIGHT_MAP_INDEX UNROLLED_LOOP_INDEX
+		#elif ( UNROLLED_LOOP_INDEX < NUM_SPOT_LIGHT_SHADOWS )
+		#define SPOT_LIGHT_MAP_INDEX NUM_SPOT_LIGHT_MAPS
+		#else
+		#define SPOT_LIGHT_MAP_INDEX ( UNROLLED_LOOP_INDEX - NUM_SPOT_LIGHT_SHADOWS + NUM_SPOT_LIGHT_SHADOWS_WITH_MAPS )
+		#endif
+		#if ( SPOT_LIGHT_MAP_INDEX < NUM_SPOT_LIGHT_MAPS )
+			spotLightCoord = vSpotLightCoord[ i ].xyz / vSpotLightCoord[ i ].w;
+			inSpotLightMap = all( lessThan( abs( spotLightCoord * 2. - 1. ), vec3( 1.0 ) ) );
+			spotColor = texture2D( spotLightMap[ SPOT_LIGHT_MAP_INDEX ], spotLightCoord.xy );
+			directLight.color = inSpotLightMap ? directLight.color * spotColor.rgb : directLight.color;
+		#endif
+		#undef SPOT_LIGHT_MAP_INDEX
 
 		#if defined( USE_SHADOWMAP ) && ( UNROLLED_LOOP_INDEX < NUM_SPOT_LIGHT_SHADOWS )
 		spotLightShadow = spotLightShadows[ i ];


### PR DESCRIPTION
CSM injects its own lights_fragment_begin instead of the original [lights_fragment_begin](https://github.com/mrdoob/three.js/blob/master/src/renderers/shaders/ShaderChunk/lights_fragment_begin.glsl.js) to enable CSM shadows.
Problem: The CSM one is not up to date with the original lights_fragment_begin.
I decided to update it.
