### PR TITLE
Examples: Disable damping in alpha hash demo.

### DIFF
--- a/examples/webgl_materials_alphahash.html
+++ b/examples/webgl_materials_alphahash.html
@@ -132,10 +132,8 @@
 				//
 
 				controls = new OrbitControls( camera, renderer.domElement );
-				controls.enableDamping = true;
 				controls.enableZoom = false;
 				controls.enablePan = false;
-				controls.dampingFactor = 0.2;
 
 				controls.addEventListener( 'change', () => ( needsUpdate = true ) );
 
@@ -197,8 +195,6 @@
 			function animate() {
 
 				requestAnimationFrame( animate );
-
-				controls.update();
 
 				render();
 


### PR DESCRIPTION
Related issue: -

**Description**

I've noticed a minor issue in `webgl_materials_alphahash`. When using `OrbitControls` with damping, the TAA accumulation sometimes starts during the damping phase because `needsUpdate` is not correctly set to `true` (since the `change` event listener is not executed in certain frames). This causes flashing which can easily be reproduced in production. Not using damping fixes the issue. 
