### PR TITLE
Docs: Add missing intersectsPlane() method to OBB documentation

### DIFF
--- a/docs/examples/en/math/OBB.html
+++ b/docs/examples/en/math/OBB.html
@@ -148,6 +148,14 @@
 			Whether the given [name] intersects this [name] or not.
 		</p>
 
+		<h3>[method:Boolean intersectsPlane]( [param:Plane plane] )</h3>
+		<p>
+			[page:Plane plane] — The plane to test.
+		</p>
+		<p>
+			Whether the given plane intersects this [name] or not.
+		</p>
+
 		<h3>[method:Boolean intersectsRay]( [param:Ray ray] )</h3>
 		<p>
 			[page:Ray ray] — The ray to test.


### PR DESCRIPTION
**Description**

Adds missing documentation of the `intersectsPlane(plane: Plane): boolean` method on the OBB example/add-on class.