### PR TITLE
Nodes:  Add LineDashedNodeMaterial

### DIFF
--- a/examples/jsm/nodes/accessors/LineMaterialNode.js
+++ b/examples/jsm/nodes/accessors/LineMaterialNode.js
@@ -1,0 +1,33 @@
+import MaterialNode from './MaterialNode.js';
+import { addNodeClass } from '../core/Node.js';
+import { nodeImmutable } from '../shadernode/ShaderNode.js';
+
+class LineMaterialNode extends MaterialNode {
+
+	constructor( scope ) {
+
+		super();
+
+		this.scope = scope;
+
+	}
+
+	construct( /* builder */ ) {
+
+		return this.getFloat( this.scope );
+
+	}
+
+}
+
+LineMaterialNode.SCALE = 'scale';
+LineMaterialNode.DASH_SIZE = 'dashSize';
+LineMaterialNode.GAP_SIZE = 'gapSize';
+
+export default LineMaterialNode;
+
+export const materialLineScale = nodeImmutable( LineMaterialNode, LineMaterialNode.SCALE );
+export const materialLineDashSize = nodeImmutable( LineMaterialNode, LineMaterialNode.DASH_SIZE );
+export const materialLineGapSize = nodeImmutable( LineMaterialNode, LineMaterialNode.GAP_SIZE );
+
+addNodeClass( LineMaterialNode );

--- a/examples/jsm/nodes/accessors/LineMaterialNode.js
+++ b/examples/jsm/nodes/accessors/LineMaterialNode.js
@@ -6,9 +6,7 @@ class LineMaterialNode extends MaterialNode {
 
 	constructor( scope ) {
 
-		super();
-
-		this.scope = scope;
+		super( scope );
 
 	}
 

--- a/examples/jsm/nodes/core/PropertyNode.js
+++ b/examples/jsm/nodes/core/PropertyNode.js
@@ -57,5 +57,8 @@ export const iridescenceThickness = nodeImmutable( PropertyNode, 'float', 'Iride
 export const specularColor = nodeImmutable( PropertyNode, 'color', 'SpecularColor' );
 export const shininess = nodeImmutable( PropertyNode, 'float', 'Shininess' );
 export const output = nodeImmutable( PropertyNode, 'vec4', 'Output' );
+export const dashScale = nodeImmutable( PropertyNode, 'float', 'dashSize' );
+export const dashSize = nodeImmutable( PropertyNode, 'float', 'dashScale' );
+export const gapSize= nodeImmutable( PropertyNode, 'float', 'gapSize' );
 
 addNodeClass( PropertyNode );

--- a/examples/jsm/nodes/core/PropertyNode.js
+++ b/examples/jsm/nodes/core/PropertyNode.js
@@ -57,7 +57,6 @@ export const iridescenceThickness = nodeImmutable( PropertyNode, 'float', 'Iride
 export const specularColor = nodeImmutable( PropertyNode, 'color', 'SpecularColor' );
 export const shininess = nodeImmutable( PropertyNode, 'float', 'Shininess' );
 export const output = nodeImmutable( PropertyNode, 'vec4', 'Output' );
-export const dashScale = nodeImmutable( PropertyNode, 'float', 'dashSize' );
 export const dashSize = nodeImmutable( PropertyNode, 'float', 'dashScale' );
 export const gapSize= nodeImmutable( PropertyNode, 'float', 'gapSize' );
 

--- a/examples/jsm/nodes/materials/LineDashedNodeMaterial.js
+++ b/examples/jsm/nodes/materials/LineDashedNodeMaterial.js
@@ -1,0 +1,39 @@
+import NodeMaterial, { addNodeMaterial } from './NodeMaterial.js';
+import { attribute } from '../core/AttributeNode.js';
+import { varying } from '../core/VaryingNode.js';
+import { materialLineDashSize, materialLineGapSize, materialLineScale } from '../accessors/LineMaterialNode.js';
+
+import { LineDashedMaterial } from 'three';
+
+const defaultValues = new LineDashedMaterial();
+
+class LineDashedNodeMaterial extends NodeMaterial {
+
+	constructor( parameters ) {
+
+		super();
+
+		this.isLineDashedNodeMaterial = true;
+
+		this.lights = false;
+		this.normals = false;
+
+		this.setDefaultValues( defaultValues );
+
+		this.setValues( parameters );
+
+	}
+
+	constructVariants( { stack } ) {
+
+		const vLineDistance = varying( attribute( 'lineDistance' ).mul( materialLineScale ) );
+
+		stack.add( vLineDistance.mod( materialLineDashSize.add( materialLineGapSize ) ).greaterThan( materialLineDashSize ).discard() );
+
+	}
+
+}
+
+export default LineDashedNodeMaterial;
+
+addNodeMaterial( LineDashedNodeMaterial );

--- a/examples/jsm/nodes/materials/LineDashedNodeMaterial.js
+++ b/examples/jsm/nodes/materials/LineDashedNodeMaterial.js
@@ -2,7 +2,7 @@ import NodeMaterial, { addNodeMaterial } from './NodeMaterial.js';
 import { attribute } from '../core/AttributeNode.js';
 import { varying } from '../core/VaryingNode.js';
 import { materialLineDashSize, materialLineGapSize, materialLineScale } from '../accessors/LineMaterialNode.js';
-
+import { dashScale, dashSize, gapSize } from '../core/PropertyNode.js';
 import { LineDashedMaterial } from 'three';
 
 const defaultValues = new LineDashedMaterial();
@@ -20,15 +20,27 @@ class LineDashedNodeMaterial extends NodeMaterial {
 
 		this.setDefaultValues( defaultValues );
 
+		this.dashScaleNode = null;
+		this.dashSizeNode = null;
+		this.gapSizeNode = null;
+
 		this.setValues( parameters );
 
 	}
 
 	constructVariants( { stack } ) {
 
-		const vLineDistance = varying( attribute( 'lineDistance' ).mul( materialLineScale ) );
+		const dashScaleNode = this.dashScaleNode ? float( this.dashScaleNode ) : materialLineScale;
+		const dashSizeNode = this.dashSizeNode ? float( this.dashSizeNode ) : materialLineDashSize;
+		const gapSizeNode = this.dashSizeNode ? float( this.dashGapNode ) : materialLineGapSize;
 
-		stack.add( vLineDistance.mod( materialLineDashSize.add( materialLineGapSize ) ).greaterThan( materialLineDashSize ).discard() );
+		stack.assign( dashScale, dashScaleNode );
+		stack.assign( dashSize, dashSizeNode );
+		stack.assign( gapSize, gapSizeNode );
+
+		const vLineDistance = varying( attribute( 'lineDistance' ).mul( dashScale ) );
+
+		stack.add( vLineDistance.mod( dashSize.add( gapSize ) ).greaterThan( dashSize ).discard() );
 
 	}
 

--- a/examples/jsm/nodes/materials/LineDashedNodeMaterial.js
+++ b/examples/jsm/nodes/materials/LineDashedNodeMaterial.js
@@ -2,7 +2,8 @@ import NodeMaterial, { addNodeMaterial } from './NodeMaterial.js';
 import { attribute } from '../core/AttributeNode.js';
 import { varying } from '../core/VaryingNode.js';
 import { materialLineDashSize, materialLineGapSize, materialLineScale } from '../accessors/LineMaterialNode.js';
-import { dashScale, dashSize, gapSize } from '../core/PropertyNode.js';
+import { dashSize, gapSize } from '../core/PropertyNode.js';
+import { float } from '../shadernode/ShaderNode.js';
 import { LineDashedMaterial } from 'three';
 
 const defaultValues = new LineDashedMaterial();
@@ -34,11 +35,10 @@ class LineDashedNodeMaterial extends NodeMaterial {
 		const dashSizeNode = this.dashSizeNode ? float( this.dashSizeNode ) : materialLineDashSize;
 		const gapSizeNode = this.dashSizeNode ? float( this.dashGapNode ) : materialLineGapSize;
 
-		stack.assign( dashScale, dashScaleNode );
 		stack.assign( dashSize, dashSizeNode );
 		stack.assign( gapSize, gapSizeNode );
 
-		const vLineDistance = varying( attribute( 'lineDistance' ).mul( dashScale ) );
+		const vLineDistance = varying( attribute( 'lineDistance' ).mul( dashScaleNode ) );
 
 		stack.add( vLineDistance.mod( dashSize.add( gapSize ) ).greaterThan( dashSize ).discard() );
 

--- a/examples/jsm/nodes/materials/Materials.js
+++ b/examples/jsm/nodes/materials/Materials.js
@@ -2,6 +2,7 @@
 
 export { default as NodeMaterial, addNodeMaterial, createNodeMaterialFromType } from './NodeMaterial.js';
 export { default as LineBasicNodeMaterial } from './LineBasicNodeMaterial.js';
+export { default as LineDashedNodeMaterial } from './LineDashedNodeMaterial.js';
 export { default as MeshNormalNodeMaterial } from './MeshNormalNodeMaterial.js';
 export { default as MeshBasicNodeMaterial } from './MeshBasicNodeMaterial.js';
 export { default as MeshLambertNodeMaterial } from './MeshLambertNodeMaterial.js';


### PR DESCRIPTION
Add  support for dashed lines.

@sunag 
materialReferences() fail when accessed across code flows. The generate() methods added resolve the problem but there is probably a better fix. The required outputNodes for the lineScale reference are cached against the fragment shader but required in the vertex shader. Without the changes the required uniform name is missing from the generated code.

ie (pseudo code).

uniform lineScale;

varying = ( * lineLength );

instead of:

varying = ( lineScale * lineLength );

