### PR TITLE
Minor examples cleanup

### DIFF
--- a/examples/webgl_buffergeometry_drawrange.html
+++ b/examples/webgl_buffergeometry_drawrange.html
@@ -82,7 +82,7 @@
 				gui.add( effectController, 'maxConnections', 0, 30, 1 );
 				gui.add( effectController, 'particleCount', 0, maxParticleCount, 1 ).onChange( function ( value ) {
 
-					particleCount = parseInt( value );
+					particleCount = value;
 					particles.setDrawRange( 0, particleCount );
 
 				} );

--- a/examples/webgl_gpgpu_water.html
+++ b/examples/webgl_gpgpu_water.html
@@ -372,7 +372,7 @@
 
 				gui.add( effectController, 'mouseSize', 1.0, 100.0, 1.0 ).onChange( valuesChanger );
 				gui.add( effectController, 'viscosity', 0.9, 0.999, 0.001 ).onChange( valuesChanger );
-				gui.add( effectController, 'spheresEnabled', 0, 1, 1 ).onChange( valuesChanger );
+				gui.add( effectController, 'spheresEnabled' ).onChange( valuesChanger );
 				const buttonSmooth = {
 					smoothWater: function () {
 

--- a/examples/webgl_postprocessing_sao.html
+++ b/examples/webgl_postprocessing_sao.html
@@ -132,7 +132,7 @@
 					'Normal': SAOPass.OUTPUT.Normal
 				} ).onChange( function ( value ) {
 
-					saoPass.params.output = parseInt( value );
+					saoPass.params.output = value;
 
 				} );
 				gui.add( saoPass.params, 'saoBias', - 1, 1 );

--- a/examples/webgl_postprocessing_ssao.html
+++ b/examples/webgl_postprocessing_ssao.html
@@ -117,7 +117,7 @@
 					'Normal': SSAOPass.OUTPUT.Normal
 				} ).onChange( function ( value ) {
 
-					ssaoPass.output = parseInt( value );
+					ssaoPass.output = value;
 
 				} );
 				gui.add( ssaoPass, 'kernelRadius' ).min( 0 ).max( 32 );

--- a/examples/webgl_postprocessing_ssr.html
+++ b/examples/webgl_postprocessing_ssr.html
@@ -262,7 +262,7 @@
 				'Metalness': SSRPass.OUTPUT.Metalness,
 			} ).onChange( function ( value ) {
 
-				ssrPass.output = parseInt( value );
+				ssrPass.output = value;
 
 			} );
 			ssrPass.opacity = 1;


### PR DESCRIPTION
Related issue: N/A

**Description**

For the removals of `parseInt`, the value is already an integer. For the removal of the number parameters in webgl_gpgpu_water, the value is a boolean so the number parameters are ineffectual.