### PR TITLE
NodeBuilder: Fix `construct()` node data

### DIFF
--- a/examples/jsm/nodes/core/NodeBuilder.js
+++ b/examples/jsm/nodes/core/NodeBuilder.js
@@ -576,7 +576,6 @@ class NodeBuilder {
 	}
 
 	getNodeProperties( node, shaderStage = 'any' ) {
-ode, shaderStage = 'any' ) {
 
 		const nodeData = this.getDataFromNode( node, shaderStage );
 

--- a/examples/jsm/nodes/core/NodeBuilder.js
+++ b/examples/jsm/nodes/core/NodeBuilder.js
@@ -563,17 +563,20 @@ class NodeBuilder {
 
 		if ( nodeData === undefined ) {
 
-			nodeData = { vertex: {}, fragment: {}, compute: {} };
+			nodeData = {};
 
 			cache.setNodeData( node, nodeData );
 
 		}
 
+		if ( nodeData[ shaderStage ] === undefined ) nodeData[ shaderStage ] = {};
+
 		return shaderStage !== null ? nodeData[ shaderStage ] : nodeData;
 
 	}
 
-	getNodeProperties( node, shaderStage = this.shaderStage ) {
+	getNodeProperties( node, shaderStage = 'any' ) {
+ode, shaderStage = 'any' ) {
 
 		const nodeData = this.getDataFromNode( node, shaderStage );
 

--- a/examples/jsm/nodes/core/NodeBuilder.js
+++ b/examples/jsm/nodes/core/NodeBuilder.js
@@ -571,7 +571,7 @@ class NodeBuilder {
 
 		if ( nodeData[ shaderStage ] === undefined ) nodeData[ shaderStage ] = {};
 
-		return shaderStage !== null ? nodeData[ shaderStage ] : nodeData;
+		return nodeData[ shaderStage ];
 
 	}
 
@@ -652,7 +652,7 @@ class NodeBuilder {
 
 	getVaryingFromNode( node, type ) {
 
-		const nodeData = this.getDataFromNode( node, null );
+		const nodeData = this.getDataFromNode( node, 'any' );
 
 		let nodeVarying = nodeData.varying;
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/26528

**Description**

`Node.construct()` was missing the return Node when it was constructed and reused in different `shader stages`.
