### PR TITLE
STLLoader: Add group names.

### DIFF
--- a/examples/jsm/loaders/STLLoader.js
+++ b/examples/jsm/loaders/STLLoader.js
@@ -274,6 +274,7 @@ class STLLoader extends Loader {
 			const geometry = new BufferGeometry();
 			const patternSolid = /solid([\s\S]*?)endsolid/g;
 			const patternFace = /facet([\s\S]*?)endfacet/g;
+			const patternName = /solid\s(.+)/;
 			let faceCounter = 0;
 
 			const patternFloat = /[\s]+([+-]?(?:\d*)(?:\.\d*)?(?:[eE][+-]?\d+)?)/.source;
@@ -282,6 +283,7 @@ class STLLoader extends Loader {
 
 			const vertices = [];
 			const normals = [];
+			const groupNames = [];
 
 			const normal = new Vector3();
 
@@ -296,6 +298,9 @@ class STLLoader extends Loader {
 				startVertex = endVertex;
 
 				const solid = result[ 0 ];
+
+				const name = ( result = patternName.exec( solid ) ) !== null ? result[ 1 ] : '';
+				groupNames.push( name );
 
 				while ( ( result = patternFace.exec( solid ) ) !== null ) {
 
@@ -344,6 +349,8 @@ class STLLoader extends Loader {
 
 				const start = startVertex;
 				const count = endVertex - startVertex;
+
+				geometry.userData.groupNames = groupNames;
 
 				geometry.addGroup( start, count, groupCount );
 				groupCount ++;


### PR DESCRIPTION
Fixed #26537.

**Description**

Added to the `geometry.userData` the names of the groups. **Only for an ASCII STL file**
In this way, it is possible to save the names of the solid of the STL file.
