### PR TITLE
Nodes: add ViewportNode.VIEWPORT

### DIFF
--- a/examples/jsm/nodes/display/ViewportNode.js
+++ b/examples/jsm/nodes/display/ViewportNode.js
@@ -5,7 +5,7 @@ import { nodeImmutable, vec2 } from '../shadernode/ShaderNode.js';
 
 import { Vector2, Vector4 } from 'three';
 
-let resolution, viewport;
+let resolution, viewportResult;
 
 class ViewportNode extends Node {
 
@@ -45,7 +45,7 @@ class ViewportNode extends Node {
 
 		if ( this.scope === ViewportNode.VIEWPORT ) {
 
-			renderer.getViewport( viewport );
+			renderer.getViewport( viewportResult );
 
 		} else {
 
@@ -69,7 +69,7 @@ class ViewportNode extends Node {
 
 		} else if ( scope === ViewportNode.VIEWPORT ) {
 
-			output = uniform( viewport || ( viewport = new Vector4() ) );
+			output = uniform( viewportResult || ( viewportResult = new Vector4() ) );
 
 		} else {
 
@@ -120,7 +120,7 @@ export default ViewportNode;
 
 export const viewportCoordinate = nodeImmutable( ViewportNode, ViewportNode.COORDINATE );
 export const viewportResolution = nodeImmutable( ViewportNode, ViewportNode.RESOLUTION );
-export const viewportViewport = nodeImmutable( ViewportNode, ViewportNode.VIEWPORT );
+export const viewport = nodeImmutable( ViewportNode, ViewportNode.VIEWPORT );
 export const viewportTopLeft = nodeImmutable( ViewportNode, ViewportNode.TOP_LEFT );
 export const viewportBottomLeft = nodeImmutable( ViewportNode, ViewportNode.BOTTOM_LEFT );
 export const viewportTopRight = nodeImmutable( ViewportNode, ViewportNode.TOP_RIGHT );

--- a/examples/jsm/nodes/display/ViewportNode.js
+++ b/examples/jsm/nodes/display/ViewportNode.js
@@ -3,9 +3,9 @@ import { NodeUpdateType } from '../core/constants.js';
 import { uniform } from '../core/UniformNode.js';
 import { nodeImmutable, vec2 } from '../shadernode/ShaderNode.js';
 
-import { Vector2 } from 'three';
+import { Vector2, Vector4 } from 'three';
 
-let resolution;
+let resolution, viewport;
 
 class ViewportNode extends Node {
 
@@ -21,7 +21,7 @@ class ViewportNode extends Node {
 
 	getNodeType() {
 
-		return this.scope === ViewportNode.COORDINATE ? 'vec4' : 'vec2';
+		return this.scope === ViewportNode.COORDINATE || this.scope === ViewportNode.VIEWPORT ? 'vec4' : 'vec2';
 
 	}
 
@@ -29,7 +29,7 @@ class ViewportNode extends Node {
 
 		let updateType = NodeUpdateType.NONE;
 
-		if ( this.scope === ViewportNode.RESOLUTION ) {
+		if ( this.scope === ViewportNode.RESOLUTION || this.scope === ViewportNode.VIEWPORT ) {
 
 			updateType = NodeUpdateType.FRAME;
 
@@ -43,7 +43,15 @@ class ViewportNode extends Node {
 
 	update( { renderer } ) {
 
-		renderer.getDrawingBufferSize( resolution );
+		if ( this.scope === ViewportNode.VIEWPORT ) {
+
+			renderer.getViewport( viewport );
+
+		} else {
+
+			renderer.getDrawingBufferSize( resolution );
+
+		}
 
 	}
 
@@ -58,6 +66,10 @@ class ViewportNode extends Node {
 		if ( scope === ViewportNode.RESOLUTION ) {
 
 			output = uniform( resolution || ( resolution = new Vector2() ) );
+
+		} else if ( scope === ViewportNode.VIEWPORT ) {
+
+			output = uniform( viewport || ( viewport = new Vector4() ) );
 
 		} else {
 
@@ -98,6 +110,7 @@ class ViewportNode extends Node {
 
 ViewportNode.COORDINATE = 'coordinate';
 ViewportNode.RESOLUTION = 'resolution';
+ViewportNode.VIEWPORT = 'viewport';
 ViewportNode.TOP_LEFT = 'topLeft';
 ViewportNode.BOTTOM_LEFT = 'bottomLeft';
 ViewportNode.TOP_RIGHT = 'topRight';
@@ -107,6 +120,7 @@ export default ViewportNode;
 
 export const viewportCoordinate = nodeImmutable( ViewportNode, ViewportNode.COORDINATE );
 export const viewportResolution = nodeImmutable( ViewportNode, ViewportNode.RESOLUTION );
+export const viewportViewport = nodeImmutable( ViewportNode, ViewportNode.VIEWPORT );
 export const viewportTopLeft = nodeImmutable( ViewportNode, ViewportNode.TOP_LEFT );
 export const viewportBottomLeft = nodeImmutable( ViewportNode, ViewportNode.BOTTOM_LEFT );
 export const viewportTopRight = nodeImmutable( ViewportNode, ViewportNode.TOP_RIGHT );


### PR DESCRIPTION

For some use cases access to the current renderer viewport rather than the drawing buffer dimensions is required.
