### PR TITLE
OrbitControls: Add 3D cursor and limit to orbit camera target.

### DIFF
--- a/docs/examples/en/controls/OrbitControls.html
+++ b/docs/examples/en/controls/OrbitControls.html
@@ -264,7 +264,7 @@ controls.mouseButtons = {
 
 		<h3>[property:Vector3 cursor]</h3>
 		<p>
-			The focus point of the [page:.target] [page:.minTargetRadius] and [page:.maxTargetRadius]. It can be updated manually at any point to change the center of interest for the [page:.target] limits.
+			The focus point of the [page:.minTargetRadius] and [page:.maxTargetRadius] limits. It can be updated manually at any point to change the center of interest for the [page:.target].
 		</p>
 
 		<h3>[property:Object touches]</h3>

--- a/docs/examples/en/controls/OrbitControls.html
+++ b/docs/examples/en/controls/OrbitControls.html
@@ -181,6 +181,16 @@ controls.keys = {
 			How far you can zoom out ( [page:OrthographicCamera] only ). Default is Infinity.
 		</p>
 
+		<h3>[property:Float minTargetRadius]</h3>
+		<p>
+			How close you can get the target to the 3D [page:.cursor]. Default is 0.
+		</p>
+
+		<h3>[property:Float maxTargetRadius]</h3>
+		<p>
+			How far you can move the target from the 3D [page:.cursor]. Default is Infinity.
+		</p>
+
 		<h3>[property:Float minAzimuthAngle]</h3>
 		<p>
 			How far you can orbit horizontally, lower limit. If set, the interval [ min, max ] must be a sub-interval of [ - 2 PI, 2 PI ], with ( max - min < 2 PI ). Default is Infinity.
@@ -250,6 +260,11 @@ controls.mouseButtons = {
 		<p>
 			The focus point of the controls, the [page:.object] orbits around this. It can be updated manually at any point to change
 			the focus of the controls.
+		</p>
+
+		<h3>[property:Vector3 cursor]</h3>
+		<p>
+			The focus point of the [page:.target] [page:.minTargetRadius] and [page:.maxTargetRadius]. It can be updated manually at any point to change the center of interest for the [page:.target] limits.
 		</p>
 
 		<h3>[property:Object touches]</h3>

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -41,7 +41,7 @@ class OrbitControls extends EventDispatcher {
 		// "target" sets the location of focus, where the object orbits around
 		this.target = new Vector3();
 
-		// Sets the 3D cursor (similar to Blender), from which the maxPanRadius takes effect
+		// Sets the 3D cursor (similar to Blender), from which the maxTargetRadius takes effect
 		this.cursor = new Vector3();
 
 		// How far you can dolly in and out ( PerspectiveCamera only )
@@ -52,9 +52,9 @@ class OrbitControls extends EventDispatcher {
 		this.minZoom = 0;
 		this.maxZoom = Infinity;
 
-		// Limit camera pan within a sphere
-		this.minPanRadius = 0;
-	    this.maxPanRadius = Infinity;
+		// Limit camera target within a spherical area around the cursor
+		this.minTargetRadius = 0;
+	    this.maxTargetRadius = Infinity;
 
 		// How far you can orbit vertically, upper and lower limits.
 		// Range is 0 to Math.PI radians.
@@ -270,7 +270,7 @@ class OrbitControls extends EventDispatcher {
 
 				// Limit the target distance from the cursor to create a sphere around the center of interest
 				scope.target.sub( scope.cursor );
-        		scope.target.clampLength( scope.minPanRadius, scope.maxPanRadius );
+        		scope.target.clampLength( scope.minTargetRadius, scope.maxTargetRadius );
         		scope.target.add( scope.cursor );
 				offset.setFromSpherical( spherical );
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -41,6 +41,9 @@ class OrbitControls extends EventDispatcher {
 		// "target" sets the location of focus, where the object orbits around
 		this.target = new Vector3();
 
+		// Sets the 3D cursor (similar to Blender), from which the maxPanRadius takes effect
+		this.cursor = new Vector3();
+
 		// How far you can dolly in and out ( PerspectiveCamera only )
 		this.minDistance = 0;
 		this.maxDistance = Infinity;
@@ -48,6 +51,10 @@ class OrbitControls extends EventDispatcher {
 		// How far you can zoom in and out ( OrthographicCamera only )
 		this.minZoom = 0;
 		this.maxZoom = Infinity;
+
+		// Limit camera pan within a sphere
+		this.minPanRadius = 0;
+	    this.maxPanRadius = Infinity;
 
 		// How far you can orbit vertically, upper and lower limits.
 		// Range is 0 to Math.PI radians.
@@ -261,7 +268,10 @@ class OrbitControls extends EventDispatcher {
 
 				}
 
-
+				// Limit the target distance from the cursor to create a sphere around the center of interest
+				scope.target.sub( scope.cursor );
+        		scope.target.clampLength( scope.minPanRadius, scope.maxPanRadius );
+        		scope.target.add( scope.cursor );
 				offset.setFromSpherical( spherical );
 
 				// rotate offset back to "camera-up-vector-is-up" space

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -256,6 +256,11 @@ class OrbitControls extends EventDispatcher {
 
 				}
 
+				// Limit the target distance from the cursor to create a sphere around the center of interest
+				scope.target.sub( scope.cursor );
+				scope.target.clampLength( scope.minTargetRadius, scope.maxTargetRadius );
+				scope.target.add( scope.cursor );
+
 				// adjust the camera position based on zoom only if we're not zooming to the cursor or if it's an ortho camera
 				// we adjust zoom later in these cases
 				if ( scope.zoomToCursor && performCursorZoom || scope.object.isOrthographicCamera ) {
@@ -268,10 +273,6 @@ class OrbitControls extends EventDispatcher {
 
 				}
 
-				// Limit the target distance from the cursor to create a sphere around the center of interest
-				scope.target.sub( scope.cursor );
-				scope.target.clampLength( scope.minTargetRadius, scope.maxTargetRadius );
-				scope.target.add( scope.cursor );
 				offset.setFromSpherical( spherical );
 
 				// rotate offset back to "camera-up-vector-is-up" space

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -54,7 +54,7 @@ class OrbitControls extends EventDispatcher {
 
 		// Limit camera target within a spherical area around the cursor
 		this.minTargetRadius = 0;
-	    this.maxTargetRadius = Infinity;
+		this.maxTargetRadius = Infinity;
 
 		// How far you can orbit vertically, upper and lower limits.
 		// Range is 0 to Math.PI radians.

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -270,8 +270,8 @@ class OrbitControls extends EventDispatcher {
 
 				// Limit the target distance from the cursor to create a sphere around the center of interest
 				scope.target.sub( scope.cursor );
-        		scope.target.clampLength( scope.minTargetRadius, scope.maxTargetRadius );
-        		scope.target.add( scope.cursor );
+				scope.target.clampLength( scope.minTargetRadius, scope.maxTargetRadius );
+				scope.target.add( scope.cursor );
 				offset.setFromSpherical( spherical );
 
 				// rotate offset back to "camera-up-vector-is-up" space


### PR DESCRIPTION
Allows the user to limit the orbit controls target distance from a 3D cursor. 

My use case is having models load far from the origin. I want to move the camera to the object, then limit it's distance from that object. This change allows me to limit the scale of the scene (and camera frustum) to achieve the highest quality rendering.

*This contribution is funded by [Axial3D](https://axial3d.com)*
