### PR TITLE
GLTFLoader: Log error when loader extension doesn't have a name.

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -361,6 +361,9 @@ class GLTFLoader extends Loader {
 		for ( let i = 0; i < this.pluginCallbacks.length; i ++ ) {
 
 			const plugin = this.pluginCallbacks[ i ]( parser );
+
+			if ( ! plugin.name ) console.error( 'THREE.GLTFLoader: Invalid plugin found: missing name', plugin );
+
 			plugins[ plugin.name ] = plugin;
 
 			// Workaround to avoid determining as unknown extension

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -362,7 +362,7 @@ class GLTFLoader extends Loader {
 
 			const plugin = this.pluginCallbacks[ i ]( parser );
 
-			if ( ! plugin.name ) console.error( 'THREE.GLTFLoader: Invalid plugin found: missing name', plugin );
+			if ( ! plugin.name ) console.error( 'THREE.GLTFLoader: Invalid plugin found: missing name' );
 
 			plugins[ plugin.name ] = plugin;
 


### PR DESCRIPTION
**Description**

This logs an error when a new GltfLoader plugin is registered that does not have a name

*This contribution is funded by 🌵 [Needle](https://needle.tools)*
