### PR TITLE
Extend EdgesGeometry to inherit custom attributes from the original geometry

### DIFF
--- a/src/geometries/EdgesGeometry.js
+++ b/src/geometries/EdgesGeometry.js
@@ -1,152 +1,185 @@
-import { BufferGeometry } from '../core/BufferGeometry.js';
-import { Float32BufferAttribute } from '../core/BufferAttribute.js';
-import * as MathUtils from '../math/MathUtils.js';
-import { Triangle } from '../math/Triangle.js';
-import { Vector3 } from '../math/Vector3.js';
+import { BufferGeometry } from "../core/BufferGeometry.js";
+import { Float32BufferAttribute } from "../core/BufferAttribute.js";
+import * as MathUtils from "../math/MathUtils.js";
+import { Triangle } from "../math/Triangle.js";
+import { Vector3 } from "../math/Vector3.js";
 
+//Retrieve data at the current position.
+const getDataByIndex = (array, size, index) => {
+	const newArray = [];
+	for (let s = 0; s < size; s++) {
+		newArray.push(array[index * size + s]);
+	}
+	return newArray;
+};
 const _v0 = /*@__PURE__*/ new Vector3();
 const _v1 = /*@__PURE__*/ new Vector3();
 const _normal = /*@__PURE__*/ new Vector3();
 const _triangle = /*@__PURE__*/ new Triangle();
 
 class EdgesGeometry extends BufferGeometry {
-
-	constructor( geometry = null, thresholdAngle = 1 ) {
-
+	constructor(geometry = null, thresholdAngle = 1) {
 		super();
 
-		this.type = 'EdgesGeometry';
+		this.type = "EdgesGeometry";
 
 		this.parameters = {
 			geometry: geometry,
-			thresholdAngle: thresholdAngle
+			thresholdAngle: thresholdAngle,
 		};
 
-		if ( geometry !== null ) {
-
+		if (geometry !== null) {
 			const precisionPoints = 4;
-			const precision = Math.pow( 10, precisionPoints );
-			const thresholdDot = Math.cos( MathUtils.DEG2RAD * thresholdAngle );
+			const precision = Math.pow(10, precisionPoints);
+			const thresholdDot = Math.cos(MathUtils.DEG2RAD * thresholdAngle);
 
 			const indexAttr = geometry.getIndex();
-			const positionAttr = geometry.getAttribute( 'position' );
+			const positionAttr = geometry.getAttribute("position");
 			const indexCount = indexAttr ? indexAttr.count : positionAttr.count;
 
-			const indexArr = [ 0, 0, 0 ];
-			const vertKeys = [ 'a', 'b', 'c' ];
-			const hashes = new Array( 3 );
+			const indexArr = [0, 0, 0];
+			const vertKeys = ["a", "b", "c"];
+			const hashes = new Array(3);
 
 			const edgeData = {};
 			const vertices = [];
-			for ( let i = 0; i < indexCount; i += 3 ) {
-
-				if ( indexAttr ) {
-
-					indexArr[ 0 ] = indexAttr.getX( i );
-					indexArr[ 1 ] = indexAttr.getX( i + 1 );
-					indexArr[ 2 ] = indexAttr.getX( i + 2 );
-
+			const dotSequential = [];
+			for (let i = 0; i < indexCount; i += 3) {
+				if (indexAttr) {
+					indexArr[0] = indexAttr.getX(i);
+					indexArr[1] = indexAttr.getX(i + 1);
+					indexArr[2] = indexAttr.getX(i + 2);
 				} else {
-
-					indexArr[ 0 ] = i;
-					indexArr[ 1 ] = i + 1;
-					indexArr[ 2 ] = i + 2;
-
+					indexArr[0] = i;
+					indexArr[1] = i + 1;
+					indexArr[2] = i + 2;
 				}
 
 				const { a, b, c } = _triangle;
-				a.fromBufferAttribute( positionAttr, indexArr[ 0 ] );
-				b.fromBufferAttribute( positionAttr, indexArr[ 1 ] );
-				c.fromBufferAttribute( positionAttr, indexArr[ 2 ] );
-				_triangle.getNormal( _normal );
+				a.fromBufferAttribute(positionAttr, indexArr[0]);
+				b.fromBufferAttribute(positionAttr, indexArr[1]);
+				c.fromBufferAttribute(positionAttr, indexArr[2]);
+				_triangle.getNormal(_normal);
 
 				// create hashes for the edge from the vertices
-				hashes[ 0 ] = `${ Math.round( a.x * precision ) },${ Math.round( a.y * precision ) },${ Math.round( a.z * precision ) }`;
-				hashes[ 1 ] = `${ Math.round( b.x * precision ) },${ Math.round( b.y * precision ) },${ Math.round( b.z * precision ) }`;
-				hashes[ 2 ] = `${ Math.round( c.x * precision ) },${ Math.round( c.y * precision ) },${ Math.round( c.z * precision ) }`;
+				hashes[0] = `${Math.round(a.x * precision)},${Math.round(
+					a.y * precision
+				)},${Math.round(a.z * precision)}`;
+				hashes[1] = `${Math.round(b.x * precision)},${Math.round(
+					b.y * precision
+				)},${Math.round(b.z * precision)}`;
+				hashes[2] = `${Math.round(c.x * precision)},${Math.round(
+					c.y * precision
+				)},${Math.round(c.z * precision)}`;
 
 				// skip degenerate triangles
-				if ( hashes[ 0 ] === hashes[ 1 ] || hashes[ 1 ] === hashes[ 2 ] || hashes[ 2 ] === hashes[ 0 ] ) {
-
+				if (
+					hashes[0] === hashes[1] ||
+					hashes[1] === hashes[2] ||
+					hashes[2] === hashes[0]
+				) {
 					continue;
-
 				}
 
 				// iterate over every edge
-				for ( let j = 0; j < 3; j ++ ) {
-
+				for (let j = 0; j < 3; j++) {
 					// get the first and next vertex making up the edge
-					const jNext = ( j + 1 ) % 3;
-					const vecHash0 = hashes[ j ];
-					const vecHash1 = hashes[ jNext ];
-					const v0 = _triangle[ vertKeys[ j ] ];
-					const v1 = _triangle[ vertKeys[ jNext ] ];
+					const jNext = (j + 1) % 3;
+					const vecHash0 = hashes[j];
+					const vecHash1 = hashes[jNext];
+					const v0 = _triangle[vertKeys[j]];
+					const v1 = _triangle[vertKeys[jNext]];
 
-					const hash = `${ vecHash0 }_${ vecHash1 }`;
-					const reverseHash = `${ vecHash1 }_${ vecHash0 }`;
+					const hash = `${vecHash0}_${vecHash1}`;
+					const reverseHash = `${vecHash1}_${vecHash0}`;
 
-					if ( reverseHash in edgeData && edgeData[ reverseHash ] ) {
-
+					if (reverseHash in edgeData && edgeData[reverseHash]) {
 						// if we found a sibling edge add it into the vertex array if
 						// it meets the angle threshold and delete the edge from the map.
-						if ( _normal.dot( edgeData[ reverseHash ].normal ) <= thresholdDot ) {
+						if (_normal.dot(edgeData[reverseHash].normal) <= thresholdDot) {
+							vertices.push(v0.x, v0.y, v0.z);
+							vertices.push(v1.x, v1.y, v1.z);
 
-							vertices.push( v0.x, v0.y, v0.z );
-							vertices.push( v1.x, v1.y, v1.z );
-
+							//Record the coordinates of the ‘position’
+							if (vertKeys[j] == "a") {
+								dotSequential.push(indexArr[0]);
+							} else if (vertKeys[j] == "b") {
+								dotSequential.push(indexArr[1]);
+							} else if (vertKeys[j] == "c") {
+								dotSequential.push(indexArr[2]);
+							}
+							if (vertKeys[jNext] == "a") {
+								dotSequential.push(indexArr[0]);
+							} else if (vertKeys[jNext] == "b") {
+								dotSequential.push(indexArr[1]);
+							} else if (vertKeys[jNext] == "c") {
+								dotSequential.push(indexArr[2]);
+							}
 						}
 
-						edgeData[ reverseHash ] = null;
-
-					} else if ( ! ( hash in edgeData ) ) {
-
+						edgeData[reverseHash] = null;
+					} else if (!(hash in edgeData)) {
 						// if we've already got an edge here then skip adding a new one
-						edgeData[ hash ] = {
-
-							index0: indexArr[ j ],
-							index1: indexArr[ jNext ],
+						edgeData[hash] = {
+							index0: indexArr[j],
+							index1: indexArr[jNext],
 							normal: _normal.clone(),
-
 						};
-
 					}
-
 				}
-
 			}
 
 			// iterate over all remaining, unmatched edges and add them to the vertex array
-			for ( const key in edgeData ) {
+			for (const key in edgeData) {
+				if (edgeData[key]) {
+					const { index0, index1 } = edgeData[key];
+					_v0.fromBufferAttribute(positionAttr, index0);
+					_v1.fromBufferAttribute(positionAttr, index1);
 
-				if ( edgeData[ key ] ) {
+					vertices.push(_v0.x, _v0.y, _v0.z);
+					vertices.push(_v1.x, _v1.y, _v1.z);
 
-					const { index0, index1 } = edgeData[ key ];
-					_v0.fromBufferAttribute( positionAttr, index0 );
-					_v1.fromBufferAttribute( positionAttr, index1 );
-
-					vertices.push( _v0.x, _v0.y, _v0.z );
-					vertices.push( _v1.x, _v1.y, _v1.z );
-
+					//Record the coordinates of the ‘position’
+					dotSequential.push(index0);
+					dotSequential.push(index1);
 				}
-
 			}
 
-			this.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
+			this.setAttribute("position", new Float32BufferAttribute(vertices, 3));
 
+			//Based on the recorded position, locate data from other attributes and reorganize.
+			for (const key in geometry.attributes) {
+				if (key != "normal" && key != "uv" && key != "position") {
+					let attributeArray = [];
+					for (let s = 0, t = dotSequential.length; s < t; s++) {
+						const newDataArray = getDataByIndex(
+							geometry.attributes[key].array,
+							geometry.attributes[key].itemSize,
+							dotSequential[s]
+						);
+						for (let a = 0, b = newDataArray.length; a < b; a++) {
+							attributeArray.push(newDataArray[a]);
+						}
+					}
+					this.setAttribute(
+						key,
+						new Float32BufferAttribute(
+							attributeArray,
+							geometry.attributes[key].itemSize
+						)
+					);
+				}
+			}
 		}
-
 	}
 
-	copy( source ) {
+	copy(source) {
+		super.copy(source);
 
-		super.copy( source );
-
-		this.parameters = Object.assign( {}, source.parameters );
+		this.parameters = Object.assign({}, source.parameters);
 
 		return this;
-
 	}
-
 }
 
 export { EdgesGeometry };

--- a/src/geometries/EdgesGeometry.js
+++ b/src/geometries/EdgesGeometry.js
@@ -1,8 +1,8 @@
-import { BufferGeometry } from "../core/BufferGeometry.js";
-import { Float32BufferAttribute } from "../core/BufferAttribute.js";
-import * as MathUtils from "../math/MathUtils.js";
-import { Triangle } from "../math/Triangle.js";
-import { Vector3 } from "../math/Vector3.js";
+import { BufferGeometry } from '../core/BufferGeometry.js';
+import { Float32BufferAttribute } from '../core/BufferAttribute.js';
+import * as MathUtils from '../math/MathUtils.js';
+import { Triangle } from '../math/Triangle.js';
+import { Vector3 } from '../math/Vector3.js';
 
 //Retrieve data at the current position.
 const getDataByIndex = (array, size, index) => {
@@ -18,138 +18,151 @@ const _normal = /*@__PURE__*/ new Vector3();
 const _triangle = /*@__PURE__*/ new Triangle();
 
 class EdgesGeometry extends BufferGeometry {
-	constructor(geometry = null, thresholdAngle = 1) {
+
+	constructor( geometry = null, thresholdAngle = 1 ) {
+
 		super();
 
-		this.type = "EdgesGeometry";
+		this.type = 'EdgesGeometry';
 
 		this.parameters = {
 			geometry: geometry,
-			thresholdAngle: thresholdAngle,
+			thresholdAngle: thresholdAngle
 		};
 
-		if (geometry !== null) {
+		if ( geometry !== null ) {
+
 			const precisionPoints = 4;
-			const precision = Math.pow(10, precisionPoints);
-			const thresholdDot = Math.cos(MathUtils.DEG2RAD * thresholdAngle);
+			const precision = Math.pow( 10, precisionPoints );
+			const thresholdDot = Math.cos( MathUtils.DEG2RAD * thresholdAngle );
 
 			const indexAttr = geometry.getIndex();
-			const positionAttr = geometry.getAttribute("position");
+			const positionAttr = geometry.getAttribute( 'position' );
 			const indexCount = indexAttr ? indexAttr.count : positionAttr.count;
 
-			const indexArr = [0, 0, 0];
-			const vertKeys = ["a", "b", "c"];
-			const hashes = new Array(3);
+			const indexArr = [ 0, 0, 0 ];
+			const vertKeys = [ 'a', 'b', 'c' ];
+			const hashes = new Array( 3 );
 
 			const edgeData = {};
 			const vertices = [];
 			const dotSequential = [];
-			for (let i = 0; i < indexCount; i += 3) {
-				if (indexAttr) {
-					indexArr[0] = indexAttr.getX(i);
-					indexArr[1] = indexAttr.getX(i + 1);
-					indexArr[2] = indexAttr.getX(i + 2);
+			for ( let i = 0; i < indexCount; i += 3 ) {
+
+				if ( indexAttr ) {
+
+					indexArr[ 0 ] = indexAttr.getX( i );
+					indexArr[ 1 ] = indexAttr.getX( i + 1 );
+					indexArr[ 2 ] = indexAttr.getX( i + 2 );
+
 				} else {
-					indexArr[0] = i;
-					indexArr[1] = i + 1;
-					indexArr[2] = i + 2;
+
+					indexArr[ 0 ] = i;
+					indexArr[ 1 ] = i + 1;
+					indexArr[ 2 ] = i + 2;
+
 				}
 
 				const { a, b, c } = _triangle;
-				a.fromBufferAttribute(positionAttr, indexArr[0]);
-				b.fromBufferAttribute(positionAttr, indexArr[1]);
-				c.fromBufferAttribute(positionAttr, indexArr[2]);
-				_triangle.getNormal(_normal);
+				a.fromBufferAttribute( positionAttr, indexArr[ 0 ] );
+				b.fromBufferAttribute( positionAttr, indexArr[ 1 ] );
+				c.fromBufferAttribute( positionAttr, indexArr[ 2 ] );
+				_triangle.getNormal( _normal );
 
 				// create hashes for the edge from the vertices
-				hashes[0] = `${Math.round(a.x * precision)},${Math.round(
-					a.y * precision
-				)},${Math.round(a.z * precision)}`;
-				hashes[1] = `${Math.round(b.x * precision)},${Math.round(
-					b.y * precision
-				)},${Math.round(b.z * precision)}`;
-				hashes[2] = `${Math.round(c.x * precision)},${Math.round(
-					c.y * precision
-				)},${Math.round(c.z * precision)}`;
+				hashes[ 0 ] = `${ Math.round( a.x * precision ) },${ Math.round( a.y * precision ) },${ Math.round( a.z * precision ) }`;
+				hashes[ 1 ] = `${ Math.round( b.x * precision ) },${ Math.round( b.y * precision ) },${ Math.round( b.z * precision ) }`;
+				hashes[ 2 ] = `${ Math.round( c.x * precision ) },${ Math.round( c.y * precision ) },${ Math.round( c.z * precision ) }`;
 
 				// skip degenerate triangles
-				if (
-					hashes[0] === hashes[1] ||
-					hashes[1] === hashes[2] ||
-					hashes[2] === hashes[0]
-				) {
+				if ( hashes[ 0 ] === hashes[ 1 ] || hashes[ 1 ] === hashes[ 2 ] || hashes[ 2 ] === hashes[ 0 ] ) {
+
 					continue;
+
 				}
 
 				// iterate over every edge
-				for (let j = 0; j < 3; j++) {
+				for ( let j = 0; j < 3; j ++ ) {
+
 					// get the first and next vertex making up the edge
-					const jNext = (j + 1) % 3;
-					const vecHash0 = hashes[j];
-					const vecHash1 = hashes[jNext];
-					const v0 = _triangle[vertKeys[j]];
-					const v1 = _triangle[vertKeys[jNext]];
+					const jNext = ( j + 1 ) % 3;
+					const vecHash0 = hashes[ j ];
+					const vecHash1 = hashes[ jNext ];
+					const v0 = _triangle[ vertKeys[ j ] ];
+					const v1 = _triangle[ vertKeys[ jNext ] ];
 
-					const hash = `${vecHash0}_${vecHash1}`;
-					const reverseHash = `${vecHash1}_${vecHash0}`;
+					const hash = `${ vecHash0 }_${ vecHash1 }`;
+					const reverseHash = `${ vecHash1 }_${ vecHash0 }`;
 
-					if (reverseHash in edgeData && edgeData[reverseHash]) {
+					if ( reverseHash in edgeData && edgeData[ reverseHash ] ) {
+
 						// if we found a sibling edge add it into the vertex array if
 						// it meets the angle threshold and delete the edge from the map.
-						if (_normal.dot(edgeData[reverseHash].normal) <= thresholdDot) {
-							vertices.push(v0.x, v0.y, v0.z);
-							vertices.push(v1.x, v1.y, v1.z);
+						if ( _normal.dot( edgeData[ reverseHash ].normal ) <= thresholdDot ) {
+
+							vertices.push( v0.x, v0.y, v0.z );
+							vertices.push( v1.x, v1.y, v1.z );
 
 							//Record the coordinates of the ‘position’
-							if (vertKeys[j] == "a") {
+							if (vertKeys[j] == 'a') {
 								dotSequential.push(indexArr[0]);
-							} else if (vertKeys[j] == "b") {
+							} else if (vertKeys[j] == 'b') {
 								dotSequential.push(indexArr[1]);
-							} else if (vertKeys[j] == "c") {
+							} else if (vertKeys[j] == 'c') {
 								dotSequential.push(indexArr[2]);
 							}
-							if (vertKeys[jNext] == "a") {
+							if (vertKeys[jNext] == 'a') {
 								dotSequential.push(indexArr[0]);
-							} else if (vertKeys[jNext] == "b") {
+							} else if (vertKeys[jNext] == 'b') {
 								dotSequential.push(indexArr[1]);
-							} else if (vertKeys[jNext] == "c") {
+							} else if (vertKeys[jNext] == 'c') {
 								dotSequential.push(indexArr[2]);
 							}
 						}
 
-						edgeData[reverseHash] = null;
-					} else if (!(hash in edgeData)) {
+						edgeData[ reverseHash ] = null;
+
+					} else if ( ! ( hash in edgeData ) ) {
+
 						// if we've already got an edge here then skip adding a new one
-						edgeData[hash] = {
-							index0: indexArr[j],
-							index1: indexArr[jNext],
+						edgeData[ hash ] = {
+
+							index0: indexArr[ j ],
+							index1: indexArr[ jNext ],
 							normal: _normal.clone(),
+
 						};
+
 					}
+
 				}
+
 			}
 
 			// iterate over all remaining, unmatched edges and add them to the vertex array
-			for (const key in edgeData) {
-				if (edgeData[key]) {
-					const { index0, index1 } = edgeData[key];
-					_v0.fromBufferAttribute(positionAttr, index0);
-					_v1.fromBufferAttribute(positionAttr, index1);
+			for ( const key in edgeData ) {
 
-					vertices.push(_v0.x, _v0.y, _v0.z);
-					vertices.push(_v1.x, _v1.y, _v1.z);
+				if ( edgeData[ key ] ) {
+
+					const { index0, index1 } = edgeData[ key ];
+					_v0.fromBufferAttribute( positionAttr, index0 );
+					_v1.fromBufferAttribute( positionAttr, index1 );
+
+					vertices.push( _v0.x, _v0.y, _v0.z );
+					vertices.push( _v1.x, _v1.y, _v1.z );
 
 					//Record the coordinates of the ‘position’
 					dotSequential.push(index0);
 					dotSequential.push(index1);
 				}
+
 			}
 
-			this.setAttribute("position", new Float32BufferAttribute(vertices, 3));
+			this.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
 
 			//Based on the recorded position, locate data from other attributes and reorganize.
 			for (const key in geometry.attributes) {
-				if (key != "normal" && key != "uv" && key != "position") {
+				if (key != 'normal' && key != 'uv' && key != 'position') {
 					let attributeArray = [];
 					for (let s = 0, t = dotSequential.length; s < t; s++) {
 						const newDataArray = getDataByIndex(
@@ -159,7 +172,7 @@ class EdgesGeometry extends BufferGeometry {
 						);
 						for (let a = 0, b = newDataArray.length; a < b; a++) {
 							attributeArray.push(newDataArray[a]);
-						}
+		}
 					}
 					this.setAttribute(
 						key,
@@ -173,13 +186,16 @@ class EdgesGeometry extends BufferGeometry {
 		}
 	}
 
-	copy(source) {
-		super.copy(source);
+	copy( source ) {
 
-		this.parameters = Object.assign({}, source.parameters);
+		super.copy( source );
+
+		this.parameters = Object.assign( {}, source.parameters );
 
 		return this;
+
 	}
+
 }
 
 export { EdgesGeometry };


### PR DESCRIPTION


Related issue: #When I was creating a 'Geometry', I passed in my custom "attribute" to the 'Geometry'. However, after converting it into an "EdgesGeometry", I noticed that some of the custom "attribute" data from my original 'Geometry' was missing in the new "EdgesGeometry". As a result, I am unable to retrieve this data in my "shaderMaterial".

**Description**

I recorded the order while recalculating the "position" data of the "attributes" in the original "Geometry" after reordering "EdgesGeometry". Then, I rearranged the other custom attributes in the original "geometry.attributes," excluding the three attributes "normal, position, uv," in the order that was recorded. Finally, I placed them into the new "EdgesGeometry."

