### PR TITLE
TextureNode: Use `context.tempWrite=false` for conditionals

### DIFF
--- a/examples/jsm/nodes/accessors/CubeTextureNode.js
+++ b/examples/jsm/nodes/accessors/CubeTextureNode.js
@@ -2,6 +2,8 @@ import TextureNode from './TextureNode.js';
 import UniformNode from '../core/UniformNode.js';
 import { reflectVector } from './ReflectVectorNode.js';
 import { addNodeClass } from '../core/Node.js';
+import { colorSpaceToLinear } from '../display/ColorSpaceNode.js';
+import { expression } from '../code/ExpressionNode.js';
 import { addNodeElement, nodeProxy, vec3 } from '../shadernode/ShaderNode.js';
 
 class CubeTextureNode extends TextureNode {
@@ -52,6 +54,7 @@ class CubeTextureNode extends TextureNode {
 
 		} else {
 
+			const nodeType = this.getNodeType( builder );
 			const nodeData = builder.getDataFromNode( this );
 
 			let propertyName = nodeData.propertyName;
@@ -81,12 +84,24 @@ class CubeTextureNode extends TextureNode {
 
 				builder.addLineFlowCode( `${propertyName} = ${snippet}` );
 
-				nodeData.snippet = snippet;
-				nodeData.propertyName = propertyName;
+				if ( builder.context.tempWrite !== false ) {
+
+					nodeData.snippet = snippet;
+					nodeData.propertyName = propertyName;
+
+				}
 
 			}
 
-			return builder.format( propertyName, 'vec4', output );
+			let snippet = propertyName;
+
+			if ( builder.needsColorSpaceToLinear( this.value ) ) {
+
+				snippet = colorSpaceToLinear( expression( snippet, nodeType ), this.value.colorSpace ).construct( builder ).build( builder, nodeType );
+
+			}
+
+			return builder.format( snippet, 'vec4', output );
 
 		}
 

--- a/examples/jsm/nodes/accessors/TextureNode.js
+++ b/examples/jsm/nodes/accessors/TextureNode.js
@@ -168,8 +168,12 @@ class TextureNode extends UniformNode {
 
 				builder.addLineFlowCode( `${propertyName} = ${snippet}` );
 
-				nodeData.snippet = snippet;
-				nodeData.propertyName = propertyName;
+				if ( builder.context.tempWrite !== false ) {
+
+					nodeData.snippet = snippet;
+					nodeData.propertyName = propertyName;
+
+				}
 
 			}
 


### PR DESCRIPTION
Related issue: Fixes https://github.com/mrdoob/three.js/issues/26572

**Description**

Use `context.tempWrite=false` for conditionals, most used in `TempNode` ( Temporary Node ).
This does not cache the snippet in the global scope variable.
