### PR TITLE
WebGLNodeBuilder: Support more than 4 UV layers

### DIFF
--- a/examples/jsm/renderers/webgl/nodes/WebGLNodeBuilder.js
+++ b/examples/jsm/renderers/webgl/nodes/WebGLNodeBuilder.js
@@ -499,7 +499,7 @@ class WebGLNodeBuilder extends NodeBuilder {
 			for ( const attribute of attributes ) {
 
 				// ignore common attributes to prevent redefinitions
-				if ( /^(position|normal|uv\d?)$/.test( attribute.name ) )
+				if ( /^(position|normal|uv[1-3]?)$/.test( attribute.name ) )
 					continue;
 
 				snippet += `attribute ${attribute.type} ${attribute.name}; `;


### PR DESCRIPTION
Related issue: Fixes https://github.com/mrdoob/three.js/issues/26570

**Description**

Support more than 4 UV layers. `WebGPURenderer` already follow this principle.
