### PR TITLE
WebGPURenderer: Fix DataTexture - FloatType

### DIFF
--- a/examples/jsm/renderers/webgpu/utils/WebGPUBindingUtils.js
+++ b/examples/jsm/renderers/webgpu/utils/WebGPUBindingUtils.js
@@ -1,6 +1,7 @@
 import {
-	GPUTextureAspect, GPUTextureViewDimension, GPUBufferBindingType
+	GPUTextureAspect, GPUTextureViewDimension, GPUBufferBindingType, GPUTextureSampleType
 } from './WebGPUConstants.js';
+import { FloatType } from 'three';
 
 class WebGPUBindingUtils {
 
@@ -64,7 +65,13 @@ class WebGPUBindingUtils {
 
 				if ( binding.texture.isDepthTexture ) {
 
-					texture.sampleType = 'depth';
+					texture.sampleType = GPUTextureSampleType.Depth;
+
+				} else if ( binding.texture.isDataTexture && binding.texture.type === FloatType ) {
+
+					// @TODO: Add support for this soon: backend.hasFeature( 'float32-filterable' )
+
+					texture.sampleType = GPUTextureSampleType.UnfilterableFloat;
 
 				}
 


### PR DESCRIPTION
Related issue: Fixes https://github.com/mrdoob/three.js/issues/26576

**Description**

`WebGPU` does not support texture filtering/sampling in 32bit format except for the `"float32-filterable"` extension which seems to be unavailable at the moment. This PR disables sampling for `DataTexture` that uses `FloatType`.

