### PR TITLE
Object3D: Clone material arrays

### DIFF
--- a/examples/jsm/nodes/core/PropertyNode.js
+++ b/examples/jsm/nodes/core/PropertyNode.js
@@ -58,6 +58,6 @@ export const specularColor = nodeImmutable( PropertyNode, 'color', 'SpecularColo
 export const shininess = nodeImmutable( PropertyNode, 'float', 'Shininess' );
 export const output = nodeImmutable( PropertyNode, 'vec4', 'Output' );
 export const dashSize = nodeImmutable( PropertyNode, 'float', 'dashScale' );
-export const gapSize= nodeImmutable( PropertyNode, 'float', 'gapSize' );
+export const gapSize = nodeImmutable( PropertyNode, 'float', 'gapSize' );
 
 addNodeClass( PropertyNode );

--- a/examples/jsm/nodes/core/PropertyNode.js
+++ b/examples/jsm/nodes/core/PropertyNode.js
@@ -58,6 +58,6 @@ export const specularColor = nodeImmutable( PropertyNode, 'color', 'SpecularColo
 export const shininess = nodeImmutable( PropertyNode, 'float', 'Shininess' );
 export const output = nodeImmutable( PropertyNode, 'vec4', 'Output' );
 export const dashSize = nodeImmutable( PropertyNode, 'float', 'dashScale' );
-export const gapSize = nodeImmutable( PropertyNode, 'float', 'gapSize' );
+export const gapSize= nodeImmutable( PropertyNode, 'float', 'gapSize' );
 
 addNodeClass( PropertyNode );

--- a/src/objects/Line.js
+++ b/src/objects/Line.js
@@ -34,16 +34,7 @@ class Line extends Object3D {
 
 		super.copy( source, recursive );
 
-		if ( Array.isArray( source.material ) ) {
-
-			this.material = source.material.slice();
-
-		} else {
-
-			this.material = source.material;
-
-		}
-
+		this.material = Array.isArray( source.material ) ? source.material.slice() : source.material;
 		this.geometry = source.geometry;
 
 		return this;

--- a/src/objects/Line.js
+++ b/src/objects/Line.js
@@ -34,7 +34,16 @@ class Line extends Object3D {
 
 		super.copy( source, recursive );
 
-		this.material = source.material;
+		if ( Array.isArray( source.material ) ) {
+
+			this.material = source.material.slice();
+
+		} else {
+
+			this.material = source.material;
+
+		}
+
 		this.geometry = source.geometry;
 
 		return this;

--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -65,16 +65,7 @@ class Mesh extends Object3D {
 
 		}
 
-		if ( Array.isArray( source.material ) ) {
-
-			this.material = source.material.slice();
-
-		} else {
-
-			this.material = source.material;
-
-		}
-
+		this.material = Array.isArray( source.material ) ? source.material.slice() : source.material;
 		this.geometry = source.geometry;
 
 		return this;

--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -65,7 +65,16 @@ class Mesh extends Object3D {
 
 		}
 
-		this.material = source.material;
+		if ( Array.isArray( source.material ) ) {
+
+			this.material = source.material.slice();
+
+		} else {
+
+			this.material = source.material;
+
+		}
+
 		this.geometry = source.geometry;
 
 		return this;

--- a/src/objects/Points.js
+++ b/src/objects/Points.js
@@ -32,16 +32,7 @@ class Points extends Object3D {
 
 		super.copy( source, recursive );
 
-		if ( Array.isArray( source.material ) ) {
-
-			this.material = source.material.slice();
-
-		} else {
-
-			this.material = source.material;
-
-		}
-
+		this.material = Array.isArray( source.material ) ? source.material.slice() : source.material;
 		this.geometry = source.geometry;
 
 		return this;

--- a/src/objects/Points.js
+++ b/src/objects/Points.js
@@ -32,7 +32,16 @@ class Points extends Object3D {
 
 		super.copy( source, recursive );
 
-		this.material = source.material;
+		if ( Array.isArray( source.material ) ) {
+
+			this.material = source.material.slice();
+
+		} else {
+
+			this.material = source.material;
+
+		}
+
 		this.geometry = source.geometry;
 
 		return this;

--- a/test/unit/src/objects/Line.tests.js
+++ b/test/unit/src/objects/Line.tests.js
@@ -3,6 +3,7 @@
 import { Line } from '../../../../src/objects/Line.js';
 
 import { Object3D } from '../../../../src/core/Object3D.js';
+import { Material } from '../../../../src/materials/Material.js';
 
 export default QUnit.module( 'Objects', () => {
 
@@ -64,6 +65,23 @@ export default QUnit.module( 'Objects', () => {
 		QUnit.todo( 'copy', ( assert ) => {
 
 			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.test( 'copy/material', ( assert ) => {
+
+			// Material arrays are cloned
+			const mesh1 = new Line();
+			mesh1.material = [ new Material() ];
+
+			const copy1 = mesh1.clone();
+			assert.notStrictEqual( mesh1.material, copy1.material );
+
+			// Non arrays are not cloned
+			const mesh2 = new Line();
+			mesh1.material = new Material();
+			const copy2 = mesh2.clone();
+			assert.strictEqual( mesh2.material, copy2.material );
 
 		} );
 

--- a/test/unit/src/objects/Mesh.tests.js
+++ b/test/unit/src/objects/Mesh.tests.js
@@ -9,6 +9,7 @@ import { MeshBasicMaterial } from '../../../../src/materials/MeshBasicMaterial.j
 import { Vector2 } from '../../../../src/math/Vector2.js';
 import { Vector3 } from '../../../../src/math/Vector3.js';
 import { DoubleSide } from '../../../../src/constants.js';
+import { Material } from '../../../../src/materials/Material.js';
 
 export default QUnit.module( 'Objects', () => {
 
@@ -70,6 +71,23 @@ export default QUnit.module( 'Objects', () => {
 		QUnit.todo( 'copy', ( assert ) => {
 
 			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.test( 'copy/material', ( assert ) => {
+
+			// Material arrays are cloned
+			const mesh1 = new Mesh();
+			mesh1.material = [ new Material() ];
+
+			const copy1 = mesh1.clone();
+			assert.notStrictEqual( mesh1.material, copy1.material );
+
+			// Non arrays are not cloned
+			const mesh2 = new Mesh();
+			mesh1.material = new Material();
+			const copy2 = mesh2.clone();
+			assert.strictEqual( mesh2.material, copy2.material );
 
 		} );
 

--- a/test/unit/src/objects/Points.tests.js
+++ b/test/unit/src/objects/Points.tests.js
@@ -1,6 +1,7 @@
 /* global QUnit */
 
 import { Object3D } from '../../../../src/core/Object3D.js';
+import { Material } from '../../../../src/materials/Material.js';
 import { Points } from '../../../../src/objects/Points.js';
 
 export default QUnit.module( 'Objects', () => {
@@ -63,6 +64,23 @@ export default QUnit.module( 'Objects', () => {
 		QUnit.todo( 'copy', ( assert ) => {
 
 			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.test( 'copy/material', ( assert ) => {
+
+			// Material arrays are cloned
+			const mesh1 = new Points();
+			mesh1.material = [ new Material() ];
+
+			const copy1 = mesh1.clone();
+			assert.notStrictEqual( mesh1.material, copy1.material );
+
+			// Non arrays are not cloned
+			const mesh2 = new Points();
+			mesh1.material = new Material();
+			const copy2 = mesh2.clone();
+			assert.strictEqual( mesh2.material, copy2.material );
 
 		} );
 


### PR DESCRIPTION
Fixed #26588

**Description**

Previously, calling `Object3D.clone()` would not clone material arrays. Causing the new object to share a reference to the array of the old object. This change fixes that, preventing unexpected modifications to the wrong object.
