### PR TITLE
Examples: Fix flickering in decals demo.

### DIFF
--- a/examples/webgl_decals.html
+++ b/examples/webgl_decals.html
@@ -267,6 +267,7 @@
 				material.color.setHex( Math.random() * 0xffffff );
 
 				const m = new THREE.Mesh( new DecalGeometry( mesh, position, orientation, size ), material );
+				m.renderOrder = decals.length; // give decals a fixed render order
 
 				decals.push( m );
 				scene.add( m );


### PR DESCRIPTION
Related issue: https://discourse.threejs.org/t/three-js-edit-planegeometry-look-realistic/55009/4

**Description**

It was noticed in the forum that the decal demo shows flickering with overlapping decals when the camera is moved around the asset. After investigating the issue I can confirm that #25913 changed the behavior of the example.

In order to provide a stable render order, the demo defines now a value for `Object3D.renderOrder` for all decals. I'm open for other suggestions that fix the issue equally good.
