### PR TITLE
Audio: Prevent `null` source error in `disconnect()`.

### DIFF
--- a/src/audio/Audio.js
+++ b/src/audio/Audio.js
@@ -210,6 +210,12 @@ class Audio extends Object3D {
 
 	disconnect() {
 
+		if ( this._connected === false ) {
+
+			return;
+
+		}
+
 		if ( this.filters.length > 0 ) {
 
 			this.source.disconnect( this.filters[ 0 ] );


### PR DESCRIPTION
**Problem**

`Audio.disconnect()` expects `Audio.source` is non-null and calls [`Audio.source.disconnect()`](https://github.com/mrdoob/three.js/blob/r155/src/audio/Audio.js#L213-L233). But `Audio.source` is initialized as `null` in the constructor and later it is set in `.play()` or `.set*()` methods.

So if `Audio.disconnect()` is called before starting to play or setting source, it can cause an error when attemping to call `Audio.source.disconnect()`

**Solution**

In `Audio.disconnect()` add a guard that checks audio is already connected.

**Alternative solutions**

1. If we think it should be managed on user end whether `.disconnect()` can be called it would be good to add an API to know whether it's connected. Currently users can check with `Audio.source !== null` but it may not be intuitive. We may add a getter for `._connected`.

```
// in Audio
get connected() {
  return this._connected;
}

// User code
if (audio.connected) {
  audio.disconnect();
}
```

2. Add a description in the documents that calling `Audio.disconnect()` before starting to play or setting source can cause an error.