### PR TITLE
Utils: export `createCanvasElement` to public and use it for `WebGPURenderer` module

### DIFF
--- a/examples/jsm/renderers/common/Backend.js
+++ b/examples/jsm/renderers/common/Backend.js
@@ -1,7 +1,7 @@
 let vector2 = null;
 let vector4 = null;
 
-import { Vector2, Vector4, REVISION } from 'three';
+import { Vector2, Vector4, REVISION, createCanvasElement } from 'three';
 
 class Backend {
 
@@ -118,7 +118,7 @@ class Backend {
 
 		if ( domElement === null ) {
 
-			domElement = ( this.parameters.canvas !== undefined ) ? this.parameters.canvas : this.createCanvasElement();
+			domElement = ( this.parameters.canvas !== undefined ) ? this.parameters.canvas : createCanvasElement();
 
 			// OffscreenCanvas does not have setAttribute, see #22811
 			if ( 'setAttribute' in domElement ) domElement.setAttribute( 'data-engine', `three.js r${REVISION}` );
@@ -128,14 +128,6 @@ class Backend {
 		}
 
 		return domElement;
-
-	}
-
-	createCanvasElement() {
-
-		const canvas = document.createElementNS( 'http://www.w3.org/1999/xhtml', 'canvas' );
-		canvas.style.display = 'block';
-		return canvas;
 
 	}
 

--- a/src/Three.js
+++ b/src/Three.js
@@ -158,6 +158,7 @@ export { ImageUtils } from './extras/ImageUtils.js';
 export { ShapeUtils } from './extras/ShapeUtils.js';
 export { PMREMGenerator } from './extras/PMREMGenerator.js';
 export { WebGLUtils } from './renderers/webgl/WebGLUtils.js';
+export { createCanvasElement } from './utils.js';
 export * from './constants.js';
 export * from './Three.Legacy.js';
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -58,15 +58,7 @@ import { WebGLUtils } from './webgl/WebGLUtils.js';
 import { WebXRManager } from './webxr/WebXRManager.js';
 import { WebGLMaterials } from './webgl/WebGLMaterials.js';
 import { WebGLUniformsGroups } from './webgl/WebGLUniformsGroups.js';
-import { createElementNS } from '../utils.js';
-
-function createCanvasElement() {
-
-	const canvas = createElementNS( 'canvas' );
-	canvas.style.display = 'block';
-	return canvas;
-
-}
+import { createCanvasElement } from '../utils.js';
 
 class WebGLRenderer {
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -68,6 +68,14 @@ function createElementNS( name ) {
 
 }
 
+function createCanvasElement() {
+
+	const canvas = createElementNS( 'canvas' );
+	canvas.style.display = 'block';
+	return canvas;
+
+}
+
 const _cache = {};
 
 function warnOnce( message ) {
@@ -80,4 +88,4 @@ function warnOnce( message ) {
 
 }
 
-export { arrayMin, arrayMax, arrayNeedsUint32, getTypedArray, createElementNS, warnOnce };
+export { arrayMin, arrayMax, arrayNeedsUint32, getTypedArray, createElementNS, createCanvasElement, warnOnce };


### PR DESCRIPTION
Related issue: #XXXX

**Description**

Motivation: Export  `createCanvasElement` function method, and use it for `WebGPURenderer` module. like:

https://github.com/mrdoob/three.js/blob/b37b76b2a34db377963a67ef0d1022d73bccee93/examples/jsm/renderers/common/Backend.js#L134-L140

TODO:

- [x] Export `createCanvasElement` to public
- [x] Use `createCanvasElement` function for `WebGPURenderer` module from `three`.

