### PR TITLE
Examples: Add GUI to USDZ exporter demo.

### DIFF
--- a/examples/misc_exporter_usdz.html
+++ b/examples/misc_exporter_usdz.html
@@ -57,8 +57,13 @@
 
 			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 			import { USDZExporter } from 'three/addons/exporters/USDZExporter.js';
+			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 
 			let camera, scene, renderer;
+
+			const params = {
+				exportUSDZ: exportUSDZ
+			};
 
 			init();
 			render();
@@ -113,6 +118,17 @@
 
 				window.addEventListener( 'resize', onWindowResize );
 
+				const isIOS = /iPad|iPhone|iPod/.test( navigator.userAgent );
+
+				if ( isIOS === false ) {
+
+					const gui = new GUI();
+
+					gui.add( params, 'exportUSDZ' ).name( 'Export USDZ' );
+					gui.open();
+
+				}
+
 			}
 
 			function createSpotShadowMesh() {
@@ -151,6 +167,13 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 
 				render();
+
+			}
+
+			function exportUSDZ() {
+
+				const link = document.getElementById( 'link' );
+				link.click();
 
 			}
 


### PR DESCRIPTION
Fixed  #26551

**Description**

This PR adds a download button via lil-gui to `misc_exporter_usdz` if the user is not on iOS. Otherwise it is not obvious how to trigger the download. 
