### PR TITLE
RenderPass - Introduce default value for clearColor

### DIFF
--- a/examples/jsm/postprocessing/RenderPass.js
+++ b/examples/jsm/postprocessing/RenderPass.js
@@ -14,7 +14,7 @@ class RenderPass extends Pass {
 
 		this.overrideMaterial = overrideMaterial;
 
-		this.clearColor = clearColor;
+		this.clearColor = ( clearColor !== undefined ) ? clearColor : new THREE.Color(0x000000);
 		this.clearAlpha = ( clearAlpha !== undefined ) ? clearAlpha : 0;
 
 		this.clear = true;


### PR DESCRIPTION
# My problem
I was trying to mix two shader passes, but was struggling with blending their output textures based on alpha, because alpha was always 1.0 for every pixel. 

# Solution
When creating a `RenderPass` ([link](https://github.com/mrdoob/three.js/blob/f9e2a0c56791d685fc441296f4e70e67c24755e0/examples/jsm/postprocessing/RenderPass.js)), it turns out that I need to assign `clearColor` first before any changes to `clearAlpha` do something - very unintuitive! Especially when seeing that `clearAlpha` is 0.0 by default in the source code. 

This is the code I needed to use:
```
const renderScene = new RenderPass(scene, camera);
renderScene.clearColor = new THREE.Color(0x000000);
renderScene.clearAlpha = 0.;
```


# What should be changed

I propose to simply give `clearColor` a default value of `0x000000`. Which also makes the default `clearAlpha` of 0.0 work properly. Then the above 3 lines of code could be shortened to:
```
const renderScene = new RenderPass(scene, camera);
```

