### PR TITLE
Remove `SRGB_ALPHA_BPTC_Format`.

### DIFF
--- a/examples/webgl_loader_texture_dds.html
+++ b/examples/webgl_loader_texture_dds.html
@@ -84,20 +84,20 @@
 				map6.colorSpace = THREE.SRGBColorSpace;
 
 				const map7 = loader.load( 'textures/compressed/disturb_dx10_bc6h_signed_nomip.dds' );
-				map6.anisotropy = 4;
-				map6.colorSpace = THREE.SRGBColorSpace;
+				map7.anisotropy = 4;
+				map7.colorSpace = THREE.SRGBColorSpace;
 
 				const map8 = loader.load( 'textures/compressed/disturb_dx10_bc6h_signed_mip.dds' );
-				map6.anisotropy = 4;
-				map6.colorSpace = THREE.SRGBColorSpace;
+				map8.anisotropy = 4;
+				map8.colorSpace = THREE.SRGBColorSpace;
 
 				const map9 = loader.load( 'textures/compressed/disturb_dx10_bc6h_unsigned_nomip.dds' );
-				map6.anisotropy = 4;
-				map6.colorSpace = THREE.SRGBColorSpace;
+				map9.anisotropy = 4;
+				map9.colorSpace = THREE.SRGBColorSpace;
 
 				const map10 = loader.load( 'textures/compressed/disturb_dx10_bc6h_unsigned_mip.dds' );
-				map6.anisotropy = 4;
-				map6.colorSpace = THREE.SRGBColorSpace;
+				map10.anisotropy = 4;
+				map10.colorSpace = THREE.SRGBColorSpace;
 
 
 				const cubemap1 = loader.load( 'textures/compressed/Mountains.dds', function ( texture ) {
@@ -168,13 +168,13 @@
 				meshes.push( mesh );
 
 				mesh = new THREE.Mesh( geometry, material5 );
-				mesh.position.x = -2;
+				mesh.position.x = - 2;
 				mesh.position.y = 2;
 				scene.add( mesh );
 				meshes.push( mesh );
 
 				mesh = new THREE.Mesh( geometry, material6 );
-				mesh.position.x = -2;
+				mesh.position.x = - 2;
 				mesh.position.y = - 2;
 				scene.add( mesh );
 				meshes.push( mesh );

--- a/examples/webgl_loader_texture_dds.html
+++ b/examples/webgl_loader_texture_dds.html
@@ -85,19 +85,15 @@
 
 				const map7 = loader.load( 'textures/compressed/disturb_dx10_bc6h_signed_nomip.dds' );
 				map7.anisotropy = 4;
-				map7.colorSpace = THREE.SRGBColorSpace;
 
 				const map8 = loader.load( 'textures/compressed/disturb_dx10_bc6h_signed_mip.dds' );
 				map8.anisotropy = 4;
-				map8.colorSpace = THREE.SRGBColorSpace;
 
 				const map9 = loader.load( 'textures/compressed/disturb_dx10_bc6h_unsigned_nomip.dds' );
 				map9.anisotropy = 4;
-				map9.colorSpace = THREE.SRGBColorSpace;
 
 				const map10 = loader.load( 'textures/compressed/disturb_dx10_bc6h_unsigned_mip.dds' );
 				map10.anisotropy = 4;
-				map10.colorSpace = THREE.SRGBColorSpace;
 
 
 				const cubemap1 = loader.load( 'textures/compressed/Mountains.dds', function ( texture ) {

--- a/src/constants.js
+++ b/src/constants.js
@@ -122,7 +122,6 @@ export const RGBA_ASTC_10x10_Format = 37819;
 export const RGBA_ASTC_12x10_Format = 37820;
 export const RGBA_ASTC_12x12_Format = 37821;
 export const RGBA_BPTC_Format = 36492;
-export const SRGB_ALPHA_BPTC_Format = 36493;
 export const RGB_BPTC_SIGNED_Format = 36494;
 export const RGB_BPTC_UNSIGNED_Format = 36495;
 export const RED_RGTC1_Format = 36283;

--- a/src/renderers/webgl/WebGLUtils.js
+++ b/src/renderers/webgl/WebGLUtils.js
@@ -1,4 +1,4 @@
-import { RGBA_ASTC_4x4_Format, RGBA_ASTC_5x4_Format, RGBA_ASTC_5x5_Format, RGBA_ASTC_6x5_Format, RGBA_ASTC_6x6_Format, RGBA_ASTC_8x5_Format, RGBA_ASTC_8x6_Format, RGBA_ASTC_8x8_Format, RGBA_ASTC_10x5_Format, RGBA_ASTC_10x6_Format, RGBA_ASTC_10x8_Format, RGBA_ASTC_10x10_Format, RGBA_ASTC_12x10_Format, RGBA_ASTC_12x12_Format, RGB_ETC1_Format, RGB_ETC2_Format, RGBA_ETC2_EAC_Format, RGBA_PVRTC_2BPPV1_Format, RGBA_PVRTC_4BPPV1_Format, RGB_PVRTC_2BPPV1_Format, RGB_PVRTC_4BPPV1_Format, RGBA_S3TC_DXT5_Format, RGBA_S3TC_DXT3_Format, RGBA_S3TC_DXT1_Format, RGB_S3TC_DXT1_Format, DepthFormat, DepthStencilFormat, LuminanceAlphaFormat, LuminanceFormat, RedFormat, RGBAFormat, AlphaFormat, RedIntegerFormat, RGFormat, RGIntegerFormat, RGBAIntegerFormat, HalfFloatType, FloatType, UnsignedIntType, IntType, UnsignedShortType, ShortType, ByteType, UnsignedInt248Type, UnsignedShort5551Type, UnsignedShort4444Type, UnsignedByteType, RGBA_BPTC_Format, SRGB_ALPHA_BPTC_Format, RGB_BPTC_SIGNED_Format, RGB_BPTC_UNSIGNED_Format, _SRGBAFormat, RED_RGTC1_Format, SIGNED_RED_RGTC1_Format, RED_GREEN_RGTC2_Format, SIGNED_RED_GREEN_RGTC2_Format, SRGBColorSpace, NoColorSpace } from '../../constants.js';
+import { RGBA_ASTC_4x4_Format, RGBA_ASTC_5x4_Format, RGBA_ASTC_5x5_Format, RGBA_ASTC_6x5_Format, RGBA_ASTC_6x6_Format, RGBA_ASTC_8x5_Format, RGBA_ASTC_8x6_Format, RGBA_ASTC_8x8_Format, RGBA_ASTC_10x5_Format, RGBA_ASTC_10x6_Format, RGBA_ASTC_10x8_Format, RGBA_ASTC_10x10_Format, RGBA_ASTC_12x10_Format, RGBA_ASTC_12x12_Format, RGB_ETC1_Format, RGB_ETC2_Format, RGBA_ETC2_EAC_Format, RGBA_PVRTC_2BPPV1_Format, RGBA_PVRTC_4BPPV1_Format, RGB_PVRTC_2BPPV1_Format, RGB_PVRTC_4BPPV1_Format, RGBA_S3TC_DXT5_Format, RGBA_S3TC_DXT3_Format, RGBA_S3TC_DXT1_Format, RGB_S3TC_DXT1_Format, DepthFormat, DepthStencilFormat, LuminanceAlphaFormat, LuminanceFormat, RedFormat, RGBAFormat, AlphaFormat, RedIntegerFormat, RGFormat, RGIntegerFormat, RGBAIntegerFormat, HalfFloatType, FloatType, UnsignedIntType, IntType, UnsignedShortType, ShortType, ByteType, UnsignedInt248Type, UnsignedShort5551Type, UnsignedShort4444Type, UnsignedByteType, RGBA_BPTC_Format, RGB_BPTC_SIGNED_Format, RGB_BPTC_UNSIGNED_Format, _SRGBAFormat, RED_RGTC1_Format, SIGNED_RED_RGTC1_Format, RED_GREEN_RGTC2_Format, SIGNED_RED_GREEN_RGTC2_Format, SRGBColorSpace, NoColorSpace } from '../../constants.js';
 
 function WebGLUtils( gl, extensions, capabilities ) {
 
@@ -207,13 +207,13 @@ function WebGLUtils( gl, extensions, capabilities ) {
 
 		// BPTC
 
-		if ( p === RGBA_BPTC_Format || p === SRGB_ALPHA_BPTC_Format || p === RGB_BPTC_SIGNED_Format || p === RGB_BPTC_UNSIGNED_Format ) {
+		if ( p === RGBA_BPTC_Format || p === RGB_BPTC_SIGNED_Format || p === RGB_BPTC_UNSIGNED_Format ) {
 
 			extension = extensions.get( 'EXT_texture_compression_bptc' );
 
 			if ( extension !== null ) {
 
-				if ( p === RGBA_BPTC_Format || p === SRGB_ALPHA_BPTC_Format ) return ( colorSpace === SRGBColorSpace ) ? extension.COMPRESSED_SRGB_ALPHA_BPTC_UNORM_EXT : extension.COMPRESSED_RGBA_BPTC_UNORM_EXT;
+				if ( p === RGBA_BPTC_Format ) return ( colorSpace === SRGBColorSpace ) ? extension.COMPRESSED_SRGB_ALPHA_BPTC_UNORM_EXT : extension.COMPRESSED_RGBA_BPTC_UNORM_EXT;
 				if ( p === RGB_BPTC_SIGNED_Format ) return extension.COMPRESSED_RGB_BPTC_SIGNED_FLOAT_EXT;
 				if ( p === RGB_BPTC_UNSIGNED_Format ) return extension.COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT_EXT;
 

--- a/test/unit/src/constants.tests.js
+++ b/test/unit/src/constants.tests.js
@@ -135,7 +135,6 @@ export default QUnit.module( 'Constants', () => {
 		assert.equal( Constants.RGBA_ASTC_12x10_Format, 37820, 'Constants.RGBA_ASTC_12x10_Format is equal to 37820' );
 		assert.equal( Constants.RGBA_ASTC_12x12_Format, 37821, 'Constants.RGBA_ASTC_12x12_Format is equal to 37821' );
 		assert.equal( Constants.RGBA_BPTC_Format, 36492, 'Constants.RGBA_BPTC_Format is equal to 36492' );
-		assert.equal( Constants.SRGB_ALPHA_BPTC_Format, 36493, 'Constants.SRGB_ALPHA_BPTC_Format is equal to 36493' );
 		assert.equal( Constants.RGB_BPTC_SIGNED_Format, 36494, 'Constants.RGB_BPTC_SIGNED_Format is equal to 36494' );
 		assert.equal( Constants.RGB_BPTC_UNSIGNED_Format, 36495, 'Constants.RGB_BPTC_UNSIGNED_Format is equal to 36495' );
 		assert.equal( Constants.RED_RGTC1_Format, 36283, 'Constants.RED_RGTC1_Format is equal to 36283' );


### PR DESCRIPTION
Related issue: #26608

**Description**

Removes the `SRGB_ALPHA_BPTC_Format` constant as suggested in https://github.com/mrdoob/three.js/pull/26608#discussion_r1300088834.
