### PR TITLE
Object3D: Fix `clear()` emitting `removed` events too early.

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -392,20 +392,7 @@ class Object3D extends EventDispatcher {
 
 	clear() {
 
-		for ( let i = 0; i < this.children.length; i ++ ) {
-
-			const object = this.children[ i ];
-
-			object.parent = null;
-
-			object.dispatchEvent( _removedEvent );
-
-		}
-
-		this.children.length = 0;
-
-		return this;
-
+		return this.remove( ... this.children );
 
 	}
 


### PR DESCRIPTION
The issue: [demo: state not yet updated in `removed` handler](https://jsfiddle.net/e1Lxgt0a/1/)

The cause: `clear()` emits `removed` event before removing children from parent

A solution: `clear()` emits `removed` event immediately after a child gets removed from parent

i.e. remove children one by one (instead of `children.length=0`) should do the trick