### PR TITLE
Add GitHub workflow for automated releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [released]  # only triggers for actual releases, not drafts or pre-releases
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    environment: release
+
+    permissions:
+      id-token: write  # for workflow identification in provenance
+
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
+      - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3
+        with:
+          node-version: "18"
+          registry-url: "https://registry.npmjs.org"
+          cache: npm
+
+      - name: Verify version
+        run: |
+          # Ensure versions in package.json and GitHub Release's name match
+          pkg_json_version=$(jq '.version' package.json -r | sed 's/[0.]//g')
+          release_version=$(echo "${{ github.event.release.name }}" | sed 's/r//')
+
+          [ $pkg_json_version = $release_version ] || exit 1
+
+      - name: Update npm, install dependencies
+        run: |
+          npm install -g npm@latest
+          npm ci
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}


### PR DESCRIPTION
Fixes #26568 

**Description**

This PR adds a workflow for automated release to npm. 

As written, the workflow is triggered automatically whenever a GitHub Release is created. (see below for alternatives)

The workflow makes a basic sanity check by ensuring the version given in `package.json` matches the GitHub Release's name (`0.155.0 == r155`).

Releases published with this workflow will have [provenance](https://docs.npmjs.com/generating-provenance-statements) information that guarantees the release was created by this specific workflow, on a specific commit. See the [next.js package on npm](https://www.npmjs.com/package/next/v/13.4.10#provenance) for an example:

![Screenshot 2023-08-22 at 13 55 20](https://github.com/mrdoob/three.js/assets/15221358/1926fb97-c9a4-40cf-95c4-8cbf6d005a82)

**Discussion**

The workflow is automatically triggered by the creation of a GitHub Release. It requires that an NPM publishing token (named `NPM_PUBLISH_TOKEN`) be stored as a repository secret. If you'd rather keep the token off the repository, I can change the workflow so that it's triggered manually and simply takes the token as an input.

To guarantee that a human has approved this release, the workflow currently requires approvals from `environment: release`. [GitHub Environments](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment) allow you to create rules before workflows can run. I'd suggest creating a `release` Environment that requires explicit approval from a maintainer (the group can be restricted to a subset of maintainers is preferred). See [this "release" from my fork](https://github.com/pnacht/three.js/actions/runs/5942160411) (doomed to fail since I don't have an npm token) as an example. However, this is entirely optional; I can remove this constraint if you prefer.



*This contribution is funded by [Google](https://google.com)*
