### PR TITLE
Node: Fix .getNodeType() if .construct() return some Node

### DIFF
--- a/examples/jsm/nodes/core/AttributeNode.js
+++ b/examples/jsm/nodes/core/AttributeNode.js
@@ -20,11 +20,11 @@ class AttributeNode extends Node {
 
 	getNodeType( builder ) {
 
-		const attributeName = this.getAttributeName( builder );
-
 		let nodeType = super.getNodeType( builder );
 
 		if ( nodeType === null ) {
+
+			const attributeName = this.getAttributeName( builder );
 
 			if ( builder.hasGeometryAttribute( attributeName ) ) {
 

--- a/examples/jsm/nodes/core/Node.js
+++ b/examples/jsm/nodes/core/Node.js
@@ -105,7 +105,15 @@ class Node extends EventDispatcher {
 
 	}
 
-	getNodeType( /*builder*/ ) {
+	getNodeType( builder ) {
+
+		const nodeProperties = builder.getNodeProperties( this );
+
+		if ( nodeProperties.outputNode ) {
+
+			return nodeProperties.outputNode.getNodeType( builder );
+
+		}
 
 		return this.nodeType;
 

--- a/examples/jsm/nodes/materials/NodeMaterial.js
+++ b/examples/jsm/nodes/materials/NodeMaterial.js
@@ -303,7 +303,7 @@ class NodeMaterial extends ShaderMaterial {
 
 		if ( ( emissiveNode && emissiveNode.isNode === true ) || ( material.emissive && material.emissive.isColor === true ) ) {
 
-			outgoingLightNode = outgoingLightNode.add( emissiveNode ? vec3( emissiveNode ) : materialEmissive );
+			outgoingLightNode = outgoingLightNode.add( vec3( emissiveNode ? emissiveNode : materialEmissive ) );
 
 		}
 

--- a/examples/jsm/nodes/utils/SplitNode.js
+++ b/examples/jsm/nodes/utils/SplitNode.js
@@ -59,7 +59,7 @@ class SplitNode extends Node {
 
 			if ( this.components.length === nodeTypeLength && this.components === stringVectorComponents.slice( 0, this.components.length ) ) {
 
-				// unecessary swizzle
+				// unnecessary swizzle
 
 				snippet = builder.format( nodeSnippet, type, output );
 


### PR DESCRIPTION
Related issue: Fixes https://github.com/mrdoob/three.js/issues/26630

**Description**

`.getNodeType()` must be the same of `Node` returned from `.construct()` if any, so that the type references are correct.