### PR TITLE
Changed "clear()" position in Object3D Docs

### DIFF
--- a/docs/api/en/core/Object3D.html
+++ b/docs/api/en/core/Object3D.html
@@ -280,6 +280,9 @@
 			Note: This method does not support scene graphs having
 			non-uniformly-scaled nodes(s).
 		</p>
+		
+		<h3>[method:this clear]()</h3>
+		<p>Removes all child objects.</p>
 
 		<h3>[method:Object3D clone]( [param:Boolean recursive] )</h3>
 		<p>
@@ -411,9 +414,6 @@
 
 		<h3>[method:this removeFromParent]()</h3>
 		<p>Removes this object from its current parent.</p>
-
-		<h3>[method:this clear]()</h3>
-		<p>Removes all child objects.</p>
 
 		<h3>[method:this rotateOnAxis]( [param:Vector3 axis], [param:Float angle] )</h3>
 		<p>


### PR DESCRIPTION
On the [Object3D Documentation](https://threejs.org/docs/#api/en/core/Object3D) the "clear" method appears out of alphabetical order. This was fixed in this proposed change