### PR TITLE
Examples: Clean up.

### DIFF
--- a/examples/webgl_postprocessing_fxaa.html
+++ b/examples/webgl_postprocessing_fxaa.html
@@ -122,7 +122,6 @@
 				//
 
 				const renderPass = new RenderPass( scene, camera );
-				renderPass.clearColor = new THREE.Color( 0, 0, 0 );
 				renderPass.clearAlpha = 0;
 
 				//


### PR DESCRIPTION
Related issue: #26638

**Description**

With #26638, `webgl_postprocessing_fxaa` can be simplified since the clear color is not required anymore to make the clear alpha value work.

@WojtekPachowiak I think this was exactly the issue reported in #26614.
