### PR TITLE
Renderer: Auto-Instancing [WIP]

### DIFF
--- a/examples/jsm/nodes/accessors/AutoInstanceNode.js
+++ b/examples/jsm/nodes/accessors/AutoInstanceNode.js
@@ -1,0 +1,153 @@
+import Node, { addNodeClass } from '../core/Node.js';
+import { nodeProxy, mat3, mat4 } from '../shadernode/ShaderNode.js';
+import { cameraProjectionMatrix } from './CameraNode.js';
+import { modelViewMatrix, transformedViewMatrix, transformedNormalMatrix, modelNormalMatrix } from './ModelNode.js';
+import { positionLocal } from './PositionNode.js';
+import { normalLocal } from './NormalNode.js';
+import InstanceNode from './InstanceNode.js';
+import { NodeUpdateType } from '../core/constants.js';
+import { instancedBufferAttribute, instancedDynamicBufferAttribute } from './BufferAttributeNode.js';
+import { DynamicDrawUsage, InstancedBufferAttribute, InstancedInterleavedBuffer } from 'three';
+import { instanceIndex } from '../core/IndexNode.js';
+
+class AutoInstanceNode extends Node {
+
+	constructor( instances ) {
+
+		super( 'void' );
+
+		this.instances = instances;
+
+		this._modelViewMatrix = null;
+		this._modelViewMatrixNode = null;
+
+		this._normalMatrix = null;
+		this._normalMatrixNode = null;
+
+		//this.updateType = NodeUpdateType.OBJECT;
+		this.updateBeforeType = NodeUpdateType.OBJECT;
+
+	}
+
+	constructorModelViewMatrix() {
+
+		let instanceModelViewMatrixNode = this._modelViewMatrixNode;
+
+		if ( instanceModelViewMatrixNode === null ) {
+
+			const instances = this.instances;
+
+			const instanceCount = instances.length;
+			const instanceAttribute = new InstancedBufferAttribute( new Float32Array( instanceCount * 16 ), 16 );
+			instanceAttribute.usage = DynamicDrawUsage;
+
+			const buffer = new InstancedInterleavedBuffer( instanceAttribute.array, 16, 1 );
+
+			const bufferFn = instanceAttribute.usage === DynamicDrawUsage ? instancedDynamicBufferAttribute : instancedBufferAttribute;
+
+			const instanceBuffers = [
+				// F.Signature -> bufferAttribute( array, type, stride, offset )
+				bufferFn( buffer, 'vec4', 16, 0 ),
+				bufferFn( buffer, 'vec4', 16, 4 ),
+				bufferFn( buffer, 'vec4', 16, 8 ),
+				bufferFn( buffer, 'vec4', 16, 12 )
+			];
+
+			instanceModelViewMatrixNode = mat4( ...instanceBuffers );
+
+			this._modelViewMatrix = instanceAttribute;
+			this._modelViewMatrixNode = instanceModelViewMatrixNode;
+
+		}
+
+		return instanceModelViewMatrixNode;
+
+	}
+
+	constructorNormalMatrix() {
+
+		let normalMatrixNode = this._normalMatrixNode;
+
+		if ( normalMatrixNode === null ) {
+
+			const instances = this.instances;
+
+			const instanceCount = instances.length;
+			const instanceAttribute = new InstancedBufferAttribute( new Float32Array( instanceCount * 9 ), 9 );
+			instanceAttribute.usage = DynamicDrawUsage;
+
+			const buffer = new InstancedInterleavedBuffer( instanceAttribute.array, 9, 1 );
+
+			const bufferFn = instanceAttribute.usage === DynamicDrawUsage ? instancedDynamicBufferAttribute : instancedBufferAttribute;
+
+			const instanceBuffers = [
+				bufferFn( buffer, 'vec3', 9, 0 ),
+				bufferFn( buffer, 'vec3', 9, 3 ),
+				bufferFn( buffer, 'vec3', 9, 6 )
+			];
+
+			normalMatrixNode = mat3( ...instanceBuffers );
+
+			this._normalMatrix = instanceAttribute;
+			this._normalMatrixNode = normalMatrixNode;
+
+		}
+
+		return normalMatrixNode;
+
+	}
+
+	construct( builder ) {
+
+		const instanceMatrixNode = this.constructorModelViewMatrix();
+		const normalMatrixNode = this.constructorNormalMatrix();
+
+		builder.stack.assign( transformedViewMatrix, instanceMatrixNode );
+		builder.stack.assign( transformedNormalMatrix, normalMatrixNode );
+
+
+		//builder.stack.assign( transformedViewMatrix, modelViewMatrix );
+		//builder.stack.assign( transformedNormalMatrix, modelNormalMatrix );
+
+		//return cameraProjectionMatrix.mul( instanceMatrixNode ).mul( positionLocal );
+
+	}
+
+	updateBefore( frame ) {
+
+		const { object, camera } = frame;
+		const { instances, _modelViewMatrix, _normalMatrix } = this;
+
+		// Set instance definitions ( injection! )
+
+		const count = instances.length;
+
+		object.isInstancedMesh = true;
+		object.count = count;
+
+		// --
+
+		for ( let i = 0; i < count; i ++ ) {
+
+			const instance = instances[ i ];
+
+			instance.modelViewMatrix.multiplyMatrices( camera.matrixWorldInverse, instance.matrixWorld );
+			instance.normalMatrix.getNormalMatrix( instance.modelViewMatrix );
+
+			//instance.updateWorldMatrix();
+			//instance.matrixWorld.toArray( instanceMatrix.array, i * 16 );
+
+			instance.modelViewMatrix.toArray( _modelViewMatrix.array, i * 16 );
+			instance.normalMatrix.toArray( _normalMatrix.array, i * 9 );
+
+		}
+
+	}
+
+}
+
+export default AutoInstanceNode;
+
+export const autoInstance = nodeProxy( AutoInstanceNode );
+
+addNodeClass( AutoInstanceNode );

--- a/examples/jsm/nodes/accessors/InstanceNode.js
+++ b/examples/jsm/nodes/accessors/InstanceNode.js
@@ -7,24 +7,23 @@ import { DynamicDrawUsage, InstancedInterleavedBuffer } from 'three';
 
 class InstanceNode extends Node {
 
-	constructor( instanceMesh ) {
+	constructor( instanceAttribute = null ) {
 
 		super( 'void' );
 
-		this.instanceMesh = instanceMesh;
+		this.instanceAttribute = instanceAttribute;
 
-		this.instanceMatrixNode = null;
+		this._instanceMatrixNode = null;
 
 	}
 
-	construct( builder ) {
+	constructorInstanceMatrix() {
 
-		let instanceMatrixNode = this.instanceMatrixNode;
+		let instanceMatrixNode = this._instanceMatrixNode;
 
 		if ( instanceMatrixNode === null ) {
 
-			const instanceMesh = this.instanceMesh;
-			const instanceAttribute = instanceMesh.instanceMatrix;
+			const instanceAttribute = this.instanceAttribute;
 			const buffer = new InstancedInterleavedBuffer( instanceAttribute.array, 16, 1 );
 
 			const bufferFn = instanceAttribute.usage === DynamicDrawUsage ? instancedDynamicBufferAttribute : instancedBufferAttribute;
@@ -39,9 +38,17 @@ class InstanceNode extends Node {
 
 			instanceMatrixNode = mat4( ...instanceBuffers );
 
-			this.instanceMatrixNode = instanceMatrixNode;
+			this._instanceMatrixNode = instanceMatrixNode;
 
 		}
+
+		this._instanceMatrixNode = instanceMatrixNode;
+
+	}
+
+	construct( builder ) {
+
+		const instanceMatrixNode = this.constructorInstanceMatrix();
 
 		// POSITION
 

--- a/examples/jsm/nodes/accessors/ModelNode.js
+++ b/examples/jsm/nodes/accessors/ModelNode.js
@@ -1,6 +1,7 @@
 import Object3DNode from './Object3DNode.js';
 import { addNodeClass } from '../core/Node.js';
 import { label } from '../core/ContextNode.js';
+import { property } from '../core/PropertyNode.js';
 import { nodeImmutable } from '../shadernode/ShaderNode.js';
 
 class ModelNode extends Object3DNode {
@@ -30,5 +31,8 @@ export const modelWorldMatrix = nodeImmutable( ModelNode, ModelNode.WORLD_MATRIX
 export const modelPosition = nodeImmutable( ModelNode, ModelNode.POSITION );
 export const modelScale = nodeImmutable( ModelNode, ModelNode.SCALE );
 export const modelViewPosition = nodeImmutable( ModelNode, ModelNode.VIEW_POSITION );
+
+export const transformedViewMatrix = property( 'mat4', 'transformedViewMatrix' );
+export const transformedNormalMatrix = property( 'mat3', 'transformedNormalMatrix' );
 
 addNodeClass( ModelNode );

--- a/examples/jsm/nodes/accessors/ModelViewProjectionNode.js
+++ b/examples/jsm/nodes/accessors/ModelViewProjectionNode.js
@@ -1,6 +1,6 @@
 import Node, { addNodeClass } from '../core/Node.js';
 import { cameraProjectionMatrix } from './CameraNode.js';
-import { modelViewMatrix } from './ModelNode.js';
+import { modelViewMatrix, transformedViewMatrix } from './ModelNode.js';
 import { positionLocal } from './PositionNode.js';
 import { nodeProxy } from '../shadernode/ShaderNode.js';
 
@@ -16,7 +16,8 @@ class ModelViewProjectionNode extends Node {
 
 	construct() {
 
-		return cameraProjectionMatrix.mul( modelViewMatrix ).mul( this.positionNode );
+		//return cameraProjectionMatrix.mul( modelViewMatrix ).mul( this.positionNode );
+		return cameraProjectionMatrix.mul( transformedViewMatrix ).mul( this.positionNode );
 
 	}
 

--- a/examples/jsm/nodes/accessors/NormalNode.js
+++ b/examples/jsm/nodes/accessors/NormalNode.js
@@ -4,7 +4,7 @@ import { varying } from '../core/VaryingNode.js';
 import { property } from '../core/PropertyNode.js';
 import { normalize } from '../math/MathNode.js';
 import { cameraViewMatrix } from './CameraNode.js';
-import { modelNormalMatrix } from './ModelNode.js';
+import { modelNormalMatrix, transformedNormalMatrix } from './ModelNode.js';
 import { nodeImmutable } from '../shadernode/ShaderNode.js';
 
 class NormalNode extends Node {
@@ -45,7 +45,8 @@ class NormalNode extends Node {
 
 		} else if ( scope === NormalNode.VIEW ) {
 
-			const vertexNode = modelNormalMatrix.mul( normalLocal );
+			//const vertexNode = modelNormalMatrix.mul( normalLocal );
+			const vertexNode = transformedNormalMatrix.mul( normalLocal );
 			outputNode = normalize( varying( vertexNode ) );
 
 		} else if ( scope === NormalNode.WORLD ) {

--- a/examples/jsm/nodes/core/NodeBuilder.js
+++ b/examples/jsm/nodes/core/NodeBuilder.js
@@ -51,6 +51,7 @@ class NodeBuilder {
 		this.renderer = renderer;
 		this.parser = parser;
 		this.scene = scene;
+		this.instances = null;
 
 		this.nodes = [];
 		this.updateNodes = [];

--- a/examples/jsm/nodes/materials/NodeMaterial.js
+++ b/examples/jsm/nodes/materials/NodeMaterial.js
@@ -7,6 +7,7 @@ import { materialAlphaTest, materialColor, materialOpacity, materialEmissive } f
 import { modelViewProjection } from '../accessors/ModelViewProjectionNode.js';
 import { transformedNormalView } from '../accessors/NormalNode.js';
 import { instance } from '../accessors/InstanceNode.js';
+import { autoInstance } from '../accessors/AutoInstanceNode.js';
 import { positionLocal, positionView } from '../accessors/PositionNode.js';
 import { skinning } from '../accessors/SkinningNode.js';
 import { morph } from '../accessors/MorphNode.js';
@@ -137,7 +138,14 @@ class NodeMaterial extends ShaderMaterial {
 
 		if ( ( object.instanceMatrix && object.instanceMatrix.isInstancedBufferAttribute === true ) && builder.isAvailable( 'instance' ) === true ) {
 
-			builder.stack.add( instance( object ) );
+			builder.stack.add( instance( object.instanceMatrix ) );
+
+		} else if ( builder.instances ) {
+
+			//builder.stack.add( dynamicInstance( builder.instances ) );
+			builder.stack.add( autoInstance( builder.instances ) );
+
+			//this.vertexNode = autoInstance( builder.instances );
 
 		}
 

--- a/examples/jsm/renderers/common/RenderObject.js
+++ b/examples/jsm/renderers/common/RenderObject.js
@@ -16,6 +16,7 @@ export default class RenderObject {
 		this.camera = camera;
 		this.lightsNode = lightsNode;
 		this.context = renderContext;
+		this.instances = null;
 
 		this.geometry = object.geometry;
 

--- a/examples/jsm/renderers/common/RenderObjects.js
+++ b/examples/jsm/renderers/common/RenderObjects.js
@@ -18,6 +18,38 @@ class RenderObjects {
 
 	}
 
+	_getInstanceChainKey( object, material, lightsNode, renderContext ) {
+
+		const geometry = object.geometry;
+
+		return [ geometry, material, renderContext, lightsNode ];
+
+	}
+
+	getInstance( renderObject, passId ) {
+
+		const { object, material, lightsNode, context } = renderObject;
+
+		const chainArray = this._getInstanceChainKey( object, material, lightsNode, context );
+
+		const chainMap = this.getChainMap( passId );
+
+		//
+
+		let renderObjectInstance = chainMap.get( chainArray );
+
+		if ( renderObjectInstance === undefined ) {
+
+			renderObjectInstance = renderObject;
+
+			chainMap.set( chainArray, renderObjectInstance );
+
+		}
+
+		return renderObjectInstance;
+
+	}
+
 	get( object, material, scene, camera, lightsNode, renderContext, passId ) {
 
 		const chainMap = this.getChainMap( passId );
@@ -28,6 +60,7 @@ class RenderObjects {
 		if ( renderObject === undefined ) {
 
 			renderObject = this.createRenderObject( this.nodes, this.geometries, this.renderer, object, material, scene, camera, lightsNode, renderContext, passId );
+			renderObject.instance = this.getInstance( renderObject, passId );
 
 			chainMap.set( chainArray, renderObject );
 
@@ -81,6 +114,7 @@ class RenderObjects {
 			this.bindings.delete( renderObject );
 			this.nodes.delete( renderObject );
 
+			chainMap.delete( this._getInstanceChainKey( object, material, lightsNode, renderContext ) );
 			chainMap.delete( renderObject.getChainArray() );
 
 		};

--- a/examples/jsm/renderers/common/nodes/Nodes.js
+++ b/examples/jsm/renderers/common/nodes/Nodes.js
@@ -42,6 +42,7 @@ class Nodes extends DataMap {
 
 				nodeBuilder = this.backend.createNodeBuilder( renderObject.object, this.renderer, renderObject.scene );
 				nodeBuilder.material = renderObject.material;
+				nodeBuilder.instances = renderObject.instances;
 				nodeBuilder.lightsNode = renderObject.lightsNode;
 				nodeBuilder.environmentNode = this.getEnvironmentNode( renderObject.scene );
 				nodeBuilder.fogNode = this.getFogNode( renderObject.scene );

--- a/examples/jsm/renderers/webgpu/WebGPUBackend.js
+++ b/examples/jsm/renderers/webgpu/WebGPUBackend.js
@@ -493,6 +493,7 @@ class WebGPUBackend extends Backend {
 
 		const instanceCount = this.getInstanceCount( renderObject );
 
+		console.log(instanceCount);
 		if ( hasIndex === true ) {
 
 			const indexCount = ( drawRange.count !== Infinity ) ? drawRange.count : index.count;

--- a/examples/webgpu_auto_instance_mesh.html
+++ b/examples/webgpu_auto_instance_mesh.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>three.js - WebGPU - Auto Instance Mesh</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<link type="text/css" rel="stylesheet" href="main.css">
+	</head>
+	<body>
+
+		<div id="info">
+			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - WebGPU - Auto Instance Mesh
+		</div>
+
+		<script async src="https://unpkg.com/es-module-shims@1.6.3/dist/es-module-shims.js"></script>
+
+		<script type="importmap">
+			{
+				"imports": {
+					"three": "../build/three.module.js",
+					"three/addons/": "./jsm/",
+					"three/nodes": "./jsm/nodes/Nodes.js"
+				}
+			}
+		</script>
+
+		<script type="module">
+
+			import * as THREE from 'three';
+			import { mix, range, normalWorld, oscSine, timerLocal } from 'three/nodes';
+
+			import Stats from 'three/addons/libs/stats.module.js';
+			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
+
+			import WebGPU from 'three/addons/capabilities/WebGPU.js';
+			import WebGPURenderer from 'three/addons/renderers/webgpu/WebGPURenderer.js';
+
+			let camera, scene, renderer, stats;
+
+			let group;
+			const amount = parseInt( window.location.search.slice( 1 ) ) || 10;
+			const count = Math.pow( amount, 3 );
+			const dummy = new THREE.Object3D();
+
+			init();
+
+			function init() {
+
+				if ( WebGPU.isAvailable() === false ) {
+
+					document.body.appendChild( WebGPU.getErrorMessage() );
+
+					throw new Error( 'No WebGPU support' );
+
+				}
+
+				camera = new THREE.PerspectiveCamera( 60, window.innerWidth / window.innerHeight, 0.1, 100 );
+				camera.position.set( amount * 0.9, amount * 0.9, amount * 0.9 );
+				camera.lookAt( 0, 0, 0 );
+
+				scene = new THREE.Scene();
+
+				const material = new THREE.MeshBasicMaterial();
+
+				// random colors between instances from 0x000000 to 0xFFFFFF
+				const randomColors = range( new THREE.Color( 0x000000 ), new THREE.Color( 0xFFFFFF ) );
+
+				material.colorNode = normalWorld;//mix( normalWorld, randomColors, oscSine( timerLocal( .1 ) ) );
+
+				const loader = new THREE.BufferGeometryLoader();
+				loader.load( 'models/json/suzanne_buffergeometry.json', function ( geometry ) {
+
+					geometry.computeVertexNormals();
+					geometry.scale( 0.5, 0.5, 0.5 );
+
+					group = new THREE.Group();
+					scene.add( group );
+
+					const material2 = new THREE.MeshBasicMaterial( { color: 0xffffff } );
+					material2.colorNode = normalWorld.y;
+
+					for ( let i = 0; i < count; i ++ ) {
+
+					 	const mesh = new THREE.Mesh( geometry, i < 300 ? material : material2 );
+						//mesh.instanceMatrix.setUsage( THREE.DynamicDrawUsage );
+
+						group.add( mesh );
+
+					}
+
+					//
+
+					//const gui = new GUI();
+					//gui.add( mesh, 'count', 0, count );
+
+				} );
+
+				//
+
+				renderer = new WebGPURenderer();
+				renderer.setPixelRatio( window.devicePixelRatio );
+				renderer.setSize( window.innerWidth, window.innerHeight );
+				renderer.setAnimationLoop( animate );
+				document.body.appendChild( renderer.domElement );
+
+				//
+
+				stats = new Stats();
+				document.body.appendChild( stats.dom );
+
+				//
+
+				window.addEventListener( 'resize', onWindowResize );
+
+			}
+
+			function onWindowResize() {
+
+				camera.aspect = window.innerWidth / window.innerHeight;
+				camera.updateProjectionMatrix();
+
+				renderer.setSize( window.innerWidth, window.innerHeight );
+
+			}
+
+			//
+
+			function animate() {
+
+				render();
+
+				stats.update();
+
+			}
+
+			async function render() {
+
+				if ( group ) {
+
+					const time = Date.now() * 0.001;
+
+					group.rotation.x = Math.sin( time / 4 );
+					group.rotation.y = Math.sin( time / 2 );
+
+					let i = 0;
+					const offset = ( amount - 1 ) / 2;
+
+					for ( let x = 0; x < amount; x ++ ) {
+
+						for ( let y = 0; y < amount; y ++ ) {
+
+							for ( let z = 0; z < amount; z ++ ) {
+
+								const relativeTime = time + ( i * .1 );
+
+								group.children[ i ].position.set( offset - x, offset - y, offset - z );
+								group.children[ i ].rotation.y = ( Math.sin( x / 4 + relativeTime ) + Math.sin( y / 4 + relativeTime ) + Math.sin( z / 4 + relativeTime ) );
+								group.children[ i ].rotation.z = dummy.rotation.y * 2 + relativeTime;
+
+								++ i;
+
+							}
+
+						}
+
+					}
+
+				}
+
+				await renderer.render( scene, camera );
+
+			}
+
+		</script>
+
+	</body>
+</html>


### PR DESCRIPTION
**Description**

`renderer.autoInstancing = true` will automatically instantiates a `Mesh` that contains the same similarities to another `Mesh` except for position/rotation/scale. Before release, it is important to decide on what policy to adopt for expanding/unexpand buffers, how to adopt hysteresis or not for example, among some extra checks and tests that I need to made.

The example below is rendered in just two draw calls, and this process is done automatically without additional code.


https://raw.githack.com/sunag/three.js/dev-auto-instance/examples/webgpu_auto_instance_mesh.html

![image](https://github.com/mrdoob/three.js/assets/502810/f833510c-1751-4848-9c9b-0a8cbbd59586)
