### PR TITLE
WebGLLights: support scaled cameras

### DIFF
--- a/examples/webgl_lights_pointlights.html
+++ b/examples/webgl_lights_pointlights.html
@@ -47,6 +47,10 @@
 
 				camera = new THREE.PerspectiveCamera( 50, window.innerWidth / window.innerHeight, 1, 1000 );
 				camera.position.z = 100;
+				setInterval(()=>{
+					const scale = Math.random() * 10 + .5;
+					camera.scale.set(scale, scale, scale)
+				}, 500)
 
 				scene = new THREE.Scene();
 

--- a/examples/webgl_lights_spotlight.html
+++ b/examples/webgl_lights_spotlight.html
@@ -58,8 +58,12 @@
 
 				scene = new THREE.Scene();
 
-				camera = new THREE.PerspectiveCamera( 40, window.innerWidth / window.innerHeight, 0.1, 100 );
+				camera = new THREE.PerspectiveCamera( 40, window.innerWidth / window.innerHeight, 0.1, 1000 );
 				camera.position.set( 7, 4, 1 );
+				setInterval(()=>{
+					const scale = Math.random() * 3 + .5;
+					camera.scale.set(scale, scale, scale)
+				}, 500)
 
 				const controls = new OrbitControls( camera, renderer.domElement );
 				controls.minDistance = 2;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1558,6 +1558,7 @@ class WebGLRenderer {
 
 				uniforms.ambientLightColor.value = lights.state.ambient;
 				uniforms.lightProbe.value = lights.state.probe;
+				uniforms.cameraScale.value = lights.state.cameraScale;
 				uniforms.directionalLights.value = lights.state.directional;
 				uniforms.directionalLightShadows.value = lights.state.directionalShadow;
 				uniforms.spotLights.value = lights.state.spot;
@@ -1975,6 +1976,7 @@ class WebGLRenderer {
 
 			uniforms.ambientLightColor.needsUpdate = value;
 			uniforms.lightProbe.needsUpdate = value;
+			uniforms.cameraScale.needsUpdate = value;
 
 			uniforms.directionalLights.needsUpdate = value;
 			uniforms.directionalLightShadows.needsUpdate = value;

--- a/src/renderers/shaders/ShaderChunk/lights_pars_begin.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_pars_begin.glsl.js
@@ -2,6 +2,7 @@ export default /* glsl */`
 uniform bool receiveShadow;
 uniform vec3 ambientLightColor;
 uniform vec3 lightProbe[ 9 ];
+uniform float cameraScale;
 
 // get the irradiance (radiance convolved with cosine lobe) at the point 'normal' on the unit sphere
 // source: https://graphics.stanford.edu/papers/envmap/envmap.pdf
@@ -123,7 +124,7 @@ float getSpotAttenuation( const in float coneCosine, const in float penumbraCosi
 
 		light.direction = normalize( lVector );
 
-		float lightDistance = length( lVector );
+		float lightDistance = length( lVector ) * cameraScale;
 
 		light.color = pointLight.color;
 		light.color *= getDistanceAttenuation( lightDistance, pointLight.distance, pointLight.decay );
@@ -161,7 +162,7 @@ float getSpotAttenuation( const in float coneCosine, const in float penumbraCosi
 
 		if ( spotAttenuation > 0.0 ) {
 
-			float lightDistance = length( lVector );
+			float lightDistance = length( lVector ) * cameraScale;
 
 			light.color = spotLight.color * spotAttenuation;
 			light.color *= getDistanceAttenuation( lightDistance, spotLight.distance, spotLight.decay );

--- a/src/renderers/shaders/UniformsLib.js
+++ b/src/renderers/shaders/UniformsLib.js
@@ -123,6 +123,8 @@ const UniformsLib = {
 
 		lightProbe: { value: [] },
 
+		cameraScale: { value: 1 },
+
 		directionalLights: { value: [], properties: {
 			direction: {},
 			color: {}

--- a/src/renderers/webgl/WebGLLights.js
+++ b/src/renderers/webgl/WebGLLights.js
@@ -235,6 +235,7 @@ function WebGLLights( extensions, capabilities ) {
 			const distance = light.distance;
 
 			const shadowMap = ( light.shadow && light.shadow.map ) ? light.shadow.map.texture : null;
+			state.cameraScale = 0.0;
 
 			if ( light.isAmbientLight ) {
 
@@ -472,6 +473,9 @@ function WebGLLights( extensions, capabilities ) {
 
 		}
 
+		// TODO how can we properly set the version here?
+		state.version = nextVersion ++;
+
 	}
 
 	function setupView( lights, camera ) {
@@ -481,6 +485,9 @@ function WebGLLights( extensions, capabilities ) {
 		let spotLength = 0;
 		let rectAreaLength = 0;
 		let hemiLength = 0;
+
+		camera.getWorldScale(vector3);
+		state.cameraScale = vector3.x;
 
 		const viewMatrix = camera.matrixWorldInverse;
 


### PR DESCRIPTION
Related issue: #26659 

**Description**

Currently, lights in three.js change intensity when the world scale of the camera changes. In many cases that can be worked around by "counter scaling" the camera to ensure a world scale of 1 no matter the hierarchy, however, in XR scenarios where a scaled camera is actually required to get proper eye distance (e.g. scaling a player up or down) this workaround can't be used.

This PR (draft) passes a cameraScale float uniform through to the lighting calculations to ensure lighting doesn't change intensity when a camera is scaled.

The PR is currently a DRAFT because I'm probably missing one piece for where and how to update the actual uniforms. Currently, the state version is bumped every frame just to demonstrate that the scaled camera doesn't affect lighting anymore.

To test, you can visit [examples/?q=light#webgl_lights_spotlight](https://localhost:8080/examples/?q=light#webgl_lights_spotlight) which has been modified for this draft to scale the camera every few moments.

*This contribution is funded by [Needle](https://needle.tools)*
