### PR TITLE
Material: Add documentation for .alphaHash

### DIFF
--- a/docs/api/ar/materials/Material.html
+++ b/docs/api/ar/materials/Material.html
@@ -26,6 +26,14 @@
 		<p>هذا ينشئ مادة عامة.</p>
 			
 		<h2>الخصائص (Properties)</h2>
+
+		<h3>[property:Boolean alphaHash]</h3>
+		<p>
+			Enables alpha hashed transparency, an alternative to [page:.transparent] or [page:.alphaTest].
+			The material will not be rendered if opacity is lower than a random threshold.
+			Randomization introduces some grain or noise, but approximates alpha blending without
+			the associated problems of sorting. Using TAARenderPass can reduce the resulting noise.
+		</p>
 			
 		<h3>[property:Float alphaTest]</h3>
 		<p>

--- a/docs/api/en/materials/Material.html
+++ b/docs/api/en/materials/Material.html
@@ -27,6 +27,14 @@
 
 		<h2>Properties</h2>
 
+		<h3>[property:Boolean alphaHash]</h3>
+		<p>
+			Enables alpha hashed transparency, an alternative to [page:.transparent] or [page:.alphaTest].
+			The material will not be rendered if opacity is lower than a random threshold.
+			Randomization introduces some grain or noise, but approximates alpha blending without
+			the associated problems of sorting. Using TAARenderPass can reduce the resulting noise.
+		</p>
+
 		<h3>[property:Float alphaTest]</h3>
 		<p>
 			Sets the alpha value to be used when running an alpha test. The material

--- a/docs/api/fr/materials/Material.html
+++ b/docs/api/fr/materials/Material.html
@@ -29,6 +29,14 @@
 
 		<h2>Propriétés</h2>
 
+		<h3>[property:Boolean alphaHash]</h3>
+		<p>
+			Enables alpha hashed transparency, an alternative to [page:.transparent] or [page:.alphaTest].
+			The material will not be rendered if opacity is lower than a random threshold.
+			Randomization introduces some grain or noise, but approximates alpha blending without
+			the associated problems of sorting. Using TAARenderPass can reduce the resulting noise.
+		</p>
+
 		<h3>[property:Float alphaTest]</h3>
 		<p>
 		Définit la valeur alpha à utiliser lors de l'exécution d'un test alpha.

--- a/docs/api/it/materials/Material.html
+++ b/docs/api/it/materials/Material.html
@@ -29,6 +29,14 @@
 
 		<h2>Proprietà</h2>
 
+		<h3>[property:Boolean alphaHash]</h3>
+		<p>
+			Enables alpha hashed transparency, an alternative to [page:.transparent] or [page:.alphaTest].
+			The material will not be rendered if opacity is lower than a random threshold.
+			Randomization introduces some grain or noise, but approximates alpha blending without
+			the associated problems of sorting. Using TAARenderPass can reduce the resulting noise.
+		</p>
+
 		<h3>[property:Float alphaTest]</h3>
 		<p>
 			Imposta il valore alfa per essere usato quando vengono eseguiti i test alfa.

--- a/docs/api/zh/materials/Material.html
+++ b/docs/api/zh/materials/Material.html
@@ -24,6 +24,14 @@
 
 <h2>属性(Properties)</h2>
 
+<h3>[property:Boolean alphaHash]</h3>
+<p>
+	Enables alpha hashed transparency, an alternative to [page:.transparent] or [page:.alphaTest].
+	The material will not be rendered if opacity is lower than a random threshold.
+	Randomization introduces some grain or noise, but approximates alpha blending without
+	the associated problems of sorting. Using TAARenderPass can reduce the resulting noise.
+</p>
+
 <h3>[property:Float alphaTest]</h3>
 <p>设置运行alphaTest时要使用的alpha值。如果不透明度低于此值，则不会渲染材质。默认值为*0*。
 </p>


### PR DESCRIPTION
Adds documentation for `.alphaHash`, introduced in https://github.com/mrdoob/three.js/pull/24271. I've updated only `docs/api/en/materials/Material.html` so far, but will update the remaining pages if there are no objections to the wording here in the next few days.