### PR TITLE
KTX2Loader: Fix regression with 3D textures.

### DIFF
--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -864,17 +864,19 @@ async function createRawTexture( container ) {
 
 	if ( UNCOMPRESSED_FORMATS.has( FORMAT_MAP[ vkFormat ] ) ) {
 
+		const textureData = mipmaps.length > 0 ? mipmaps[ 0 ].data : null;
+
 		texture = container.pixelDepth === 0
-		? new DataTexture( mipmaps, container.pixelWidth, container.pixelHeight )
-		: new Data3DTexture( mipmaps, container.pixelWidth, container.pixelHeight, container.pixelDepth );
+		? new DataTexture( textureData, container.pixelWidth, container.pixelHeight )
+		: new Data3DTexture( textureData, container.pixelWidth, container.pixelHeight, container.pixelDepth );
+
+		texture.mipmaps = mipmaps;
 
 	} else {
 
 		if ( container.pixelDepth > 0 ) throw new Error( 'THREE.KTX2Loader: Unsupported pixelDepth.' );
 
 		texture = new CompressedTexture( mipmaps, container.pixelWidth, container.pixelHeight );
-
-
 
 	}
 

--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -870,8 +870,6 @@ async function createRawTexture( container ) {
 		? new DataTexture( textureData, container.pixelWidth, container.pixelHeight )
 		: new Data3DTexture( textureData, container.pixelWidth, container.pixelHeight, container.pixelDepth );
 
-		texture.mipmaps = mipmaps;
-
 	} else {
 
 		if ( container.pixelDepth > 0 ) throw new Error( 'THREE.KTX2Loader: Unsupported pixelDepth.' );

--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -864,11 +864,9 @@ async function createRawTexture( container ) {
 
 	if ( UNCOMPRESSED_FORMATS.has( FORMAT_MAP[ vkFormat ] ) ) {
 
-		const textureData = mipmaps.length > 0 ? mipmaps[ 0 ].data : null;
-
 		texture = container.pixelDepth === 0
-		? new DataTexture( textureData, container.pixelWidth, container.pixelHeight )
-		: new Data3DTexture( textureData, container.pixelWidth, container.pixelHeight, container.pixelDepth );
+		? new DataTexture( mipmaps[ 0 ].data, container.pixelWidth, container.pixelHeight )
+		: new Data3DTexture( mipmaps[ 0 ].data, container.pixelWidth, container.pixelHeight, container.pixelDepth );
 
 	} else {
 


### PR DESCRIPTION
After the latest changes in KTX2Loader of `r156`, data 3D textures stopped working. This PR fixes them.