### PR TITLE
CurvePath: Return `this` in `closePath()`.

### DIFF
--- a/docs/api/ar/extras/core/CurvePath.html
+++ b/docs/api/ar/extras/core/CurvePath.html
@@ -36,7 +36,7 @@
 		<h3>[method:undefined add]( [param:Curve curve] )</h3>
 		<p>إضافة منحى إلى مصفوفة [page:.curves].</p>
 	 
-		<h3>[method:undefined closePath]()</h3>
+		<h3>[method:this closePath]()</h3>
 		<p>يضيف [page:LineCurve lineCurve] لإغلاق المسار.</p>
 	 
 		<h3>[method:Array getCurveLengths]()</h3>

--- a/docs/api/en/extras/core/CurvePath.html
+++ b/docs/api/en/extras/core/CurvePath.html
@@ -36,7 +36,7 @@
 		<h3>[method:undefined add]( [param:Curve curve] )</h3>
 		<p>Add a curve to the [page:.curves] array.</p>
 
-		<h3>[method:undefined closePath]()</h3>
+		<h3>[method:this closePath]()</h3>
 		<p>Adds a [page:LineCurve lineCurve] to close the path.</p>
 
 		<h3>[method:Array getCurveLengths]()</h3>

--- a/docs/api/it/extras/core/CurvePath.html
+++ b/docs/api/it/extras/core/CurvePath.html
@@ -38,7 +38,7 @@
 		<h3>[method:undefined add]( [param:Curve curve] )</h3>
 		<p>Aggiunge una curva all'array [page:.curves].</p>
 
-		<h3>[method:undefined closePath]()</h3>
+		<h3>[method:this closePath]()</h3>
 		<p>Aggiunge una [page:LineCurve lineCurve] per chiudere il percorso.</p>
 
 		<h3>[method:Array getCurveLengths]()</h3>

--- a/docs/api/ko/extras/core/CurvePath.html
+++ b/docs/api/ko/extras/core/CurvePath.html
@@ -37,7 +37,7 @@
 		<h3>[method:undefined add]( [param:Curve curve] )</h3>
 		<p>[page:.curves] 배열에 곡선을 추가합니다.</p>
 
-		<h3>[method:undefined closePath]()</h3>
+		<h3>[method:this closePath]()</h3>
 		<p>path를 닫기위해 [page:LineCurve lineCurve]를 추가합니다.</p>
 
 		<h3>[method:Array getCurveLengths]()</h3>

--- a/docs/api/zh/extras/core/CurvePath.html
+++ b/docs/api/zh/extras/core/CurvePath.html
@@ -45,7 +45,7 @@
 		<h3>[method:undefined add]( [param:Curve curve] )</h3>
 		<p>添加一条曲线到[page:.curves]数组中。</p>
 
-		<h3>[method:undefined closePath]()</h3>
+		<h3>[method:this closePath]()</h3>
 		<p>添加一条[page:LineCurve lineCurve]用于闭合路径。</p>
 
 		<h3>[method:Array getCurveLengths]()</h3>

--- a/src/extras/core/CurvePath.js
+++ b/src/extras/core/CurvePath.js
@@ -37,6 +37,8 @@ class CurvePath extends Curve {
 
 		}
 
+		return this;
+
 	}
 
 	// To get accurate point with reference to


### PR DESCRIPTION
Fixed #26696.

**Description**

The PR makes sure `CurvePath.closePath()` returns `this` so it's possible to use the method in a chaining fashion.
