### PR TITLE
Editor: fix `Resizer.js` error.

### DIFF
--- a/editor/css/main.css
+++ b/editor/css/main.css
@@ -67,7 +67,7 @@ textarea, input { outline: none; } /* osx */
 	position: relative;
 	display: block;
 	width: 100%;
-	min-width: 260px;
+	min-width: 260px; /* It has side effects on Resizer.js */
 }
 
 .TabbedPanel .Tabs {

--- a/editor/css/main.css
+++ b/editor/css/main.css
@@ -67,7 +67,7 @@ textarea, input { outline: none; } /* osx */
 	position: relative;
 	display: block;
 	width: 100%;
-	min-width: 260px; /* It has side effects on Resizer.js */
+	min-width: 260px;
 }
 
 .TabbedPanel .Tabs {

--- a/editor/js/Resizer.js
+++ b/editor/js/Resizer.js
@@ -36,7 +36,7 @@ function Resizer( editor ) {
 
 		const cX = clientX < 0 ? 0 : clientX > offsetWidth ? offsetWidth : clientX;
 
-		const x = offsetWidth - cX;
+		const x = Math.max( 260, offsetWidth - cX ); // .TabbedPanel min-width: 260px
 
 		dom.style.right = x + 'px';
 


### PR DESCRIPTION
Related commit: https://github.com/mrdoob/three.js/commit/fe31bbc5b35132d38239f70ec6454cef205b8690

**Description**

The `viewport` width is error when the `resizer` move right over to the `sidebar`.

Screenshot:

![图片](https://github.com/mrdoob/three.js/assets/23699926/48f816ae-466d-431d-8089-723857265f81)

PS:
I used Chinglish, the remarks maybe need to be modified.
The problem is solved, but there maybe have a better way.
