### PR TITLE
USDZLoader: Distinguish between text (supported) and binary (not supported) usd files and fix UV parsing

### DIFF
--- a/examples/jsm/loaders/USDZLoader.js
+++ b/examples/jsm/loaders/USDZLoader.js
@@ -178,7 +178,14 @@ class USDZLoader extends Loader {
 
 				}
 
-				if ( filename.endsWith( 'usd' ) ) {
+				if ( filename.endsWith( 'usd' ) || filename.endsWith( 'usda' ) ) {
+
+					if ( isCrateFile( zip[ filename ] ) ) {
+
+						console.warn( 'THREE.USDZLoader: Crate files (.usdc or binary .usd) are not supported.' );
+						continue;
+
+					}
 
 					const text = fflate.strFromU8( zip[ filename ] );
 					data[ filename ] = parser.parse( text );

--- a/examples/jsm/loaders/USDZLoader.js
+++ b/examples/jsm/loaders/USDZLoader.js
@@ -237,6 +237,7 @@ class USDZLoader extends Loader {
 					isCrate = true;
 
 				}
+
 			}
 
 			if ( isCrate ) {
@@ -296,9 +297,11 @@ class USDZLoader extends Loader {
 
 		function findGeometry( data, id ) {
 
+			if ( ! data ) return undefined;
+
 			if ( id !== undefined ) {
 
-				const def = `def "${id}"`;
+				const def = `def Mesh "${id}"`;
 
 				if ( def in data ) {
 
@@ -324,9 +327,9 @@ class USDZLoader extends Loader {
 
 					// Move st to Mesh
 
-					if ( 'float2[] primvars:st' in data ) {
+					if ( 'texCoord2f[] primvars:st' in data ) {
 
-						object[ 'float2[] primvars:st' ] = data[ 'float2[] primvars:st' ];
+						object[ 'texCoord2f[] primvars:st' ] = data[ 'texCoord2f[] primvars:st' ];
 
 					}
 


### PR DESCRIPTION
Related issue:
- #26616

**Description**

The previous USDZLoader implementation looked for the first .usda file in the USDZ archive and attempted to load that, and looked for .usd files for geometry references.

This PR improves this by
- using the first file in the archive as root file (according to the USD spec)
- treating .usd and .usda both as valid files
- checking if a root .usd is a crate file (binary, not supported, log warning) or a text file (continue loading it)
- warning when any .usd file is a crate file (binary, not supported)

It also fixes incorrect UV parsing and incorrect mesh parsing that were written against an old version of the USDZExporter (and were not actually USD spec compliant).

The PR doesn't entirely close the aforementioned issue, as there are still discrepancies between exporter and loader (the exporter supports more USD features at the moment).

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Needle](https://needle.tools)*
