### PR TITLE
USDZLoader: Load metallic, roughness, emissive, occlusion textures and fix color spaces

### DIFF
--- a/examples/jsm/loaders/USDZLoader.js
+++ b/examples/jsm/loaders/USDZLoader.js
@@ -4,6 +4,7 @@ import {
 	ClampToEdgeWrapping,
 	FileLoader,
 	Group,
+	LinearSRGBColorSpace,
 	Loader,
 	Mesh,
 	MeshStandardMaterial,
@@ -466,24 +467,69 @@ class USDZLoader extends Loader {
 
 					}
 
+					if ( 'color3f inputs:emissiveColor.connect' in surface ) {
+
+						const path = surface[ 'color3f inputs:emissiveColor.connect' ];
+						const sampler = findTexture( root, /(\w+).output/.exec( path )[ 1 ] );
+
+						material.emissiveMap = buildTexture( sampler );
+						material.emissiveMap.colorSpace = SRGBColorSpace;
+						material.emissive.set( 0xffffff );
+
+					} else if ( 'color3f inputs:emissiveColor' in surface ) {
+
+						const color = surface[ 'color3f inputs:emissiveColor' ].replace( /[()]*/g, '' );
+						material.emissive.fromArray( JSON.parse( '[' + color + ']' ) );
+
+					}
+
 					if ( 'normal3f inputs:normal.connect' in surface ) {
 
 						const path = surface[ 'normal3f inputs:normal.connect' ];
 						const sampler = findTexture( root, /(\w+).output/.exec( path )[ 1 ] );
 
 						material.normalMap = buildTexture( sampler );
+						material.normalMap.colorSpace = LinearSRGBColorSpace;
 
 					}
 
-					if ( 'float inputs:roughness' in surface ) {
+					if ( 'float inputs:roughness.connect' in surface ) {
+
+						const path = surface[ 'float inputs:roughness.connect' ];
+						const sampler = findTexture( root, /(\w+).output/.exec( path )[ 1 ] );
+
+						material.roughness = 1.0;
+						material.roughnessMap = buildTexture( sampler );
+						material.roughnessMap.colorSpace = LinearSRGBColorSpace;
+
+					} else if ( 'float inputs:roughness' in surface ) {
 
 						material.roughness = parseFloat( surface[ 'float inputs:roughness' ] );
 
 					}
 
-					if ( 'float inputs:metallic' in surface ) {
+					if ( 'float inputs:metallic.connect' in surface ) {
+
+						const path = surface[ 'float inputs:metallic.connect' ];
+						const sampler = findTexture( root, /(\w+).output/.exec( path )[ 1 ] );
+
+						material.metalness = 1.0;
+						material.metalnessMap = buildTexture( sampler );
+						material.metalnessMap.colorSpace = LinearSRGBColorSpace;
+
+					} else if ( 'float inputs:metallic' in surface ) {
 
 						material.metalness = parseFloat( surface[ 'float inputs:metallic' ] );
+
+					}
+
+					if ( 'float inputs:occlusion.connect' in surface ) {
+
+						const path = surface[ 'float inputs:occlusion.connect' ];
+						const sampler = findTexture( root, /(\w+).output/.exec( path )[ 1 ] );
+
+						material.aoMap = buildTexture( sampler );
+						material.aoMap.colorSpace = LinearSRGBColorSpace;
 
 					}
 
@@ -503,6 +549,7 @@ class USDZLoader extends Loader {
 					const sampler = data[ 'def Shader "normal_texture"' ];
 
 					material.normalMap = buildTexture( sampler );
+					material.normalMap.colorSpace = LinearSRGBColorSpace;
 
 				}
 

--- a/examples/jsm/loaders/USDZLoader.js
+++ b/examples/jsm/loaders/USDZLoader.js
@@ -4,7 +4,7 @@ import {
 	ClampToEdgeWrapping,
 	FileLoader,
 	Group,
-	LinearSRGBColorSpace,
+	NoColorSpace,
 	Loader,
 	Mesh,
 	MeshStandardMaterial,
@@ -489,7 +489,7 @@ class USDZLoader extends Loader {
 						const sampler = findTexture( root, /(\w+).output/.exec( path )[ 1 ] );
 
 						material.normalMap = buildTexture( sampler );
-						material.normalMap.colorSpace = LinearSRGBColorSpace;
+						material.normalMap.colorSpace = NoColorSpace;
 
 					}
 
@@ -500,7 +500,7 @@ class USDZLoader extends Loader {
 
 						material.roughness = 1.0;
 						material.roughnessMap = buildTexture( sampler );
-						material.roughnessMap.colorSpace = LinearSRGBColorSpace;
+						material.roughnessMap.colorSpace = NoColorSpace;
 
 					} else if ( 'float inputs:roughness' in surface ) {
 
@@ -515,7 +515,7 @@ class USDZLoader extends Loader {
 
 						material.metalness = 1.0;
 						material.metalnessMap = buildTexture( sampler );
-						material.metalnessMap.colorSpace = LinearSRGBColorSpace;
+						material.metalnessMap.colorSpace = NoColorSpace;
 
 					} else if ( 'float inputs:metallic' in surface ) {
 
@@ -529,7 +529,7 @@ class USDZLoader extends Loader {
 						const sampler = findTexture( root, /(\w+).output/.exec( path )[ 1 ] );
 
 						material.aoMap = buildTexture( sampler );
-						material.aoMap.colorSpace = LinearSRGBColorSpace;
+						material.aoMap.colorSpace = NoColorSpace;
 
 					}
 
@@ -549,7 +549,7 @@ class USDZLoader extends Loader {
 					const sampler = data[ 'def Shader "normal_texture"' ];
 
 					material.normalMap = buildTexture( sampler );
-					material.normalMap.colorSpace = LinearSRGBColorSpace;
+					material.normalMap.colorSpace = NoColorSpace;
 
 				}
 


### PR DESCRIPTION
Related issues:
- #26616
- #26709

**Description**

This PR adds USDZLoader support for metallic, roughness, emissive and occlusion textures in the respective correct color spaces. This is especially useful for files exported with USDZExporter.

With the PR, DamagedHelmet does roundtrip pretty nicely:

| .glb | .usdz<br/>exported with USDZExporter<br/>and loaded with USDZLoader) |
| - | - |
| <img width="787" alt="image" src="https://github.com/mrdoob/three.js/assets/2693840/ff7878a5-558c-4c01-8505-53209f506f36"> | <img width="786" alt="image" src="https://github.com/mrdoob/three.js/assets/2693840/893839f7-3e1f-4672-8c75-af4c01fb443e"> |



Thanks to @GitHubDragonFly for starting with #26623. This PR improves on it especially in terms of color spaces.

This PR does _not_ fix a number of other issues with material roundtrip, notably
- texture scale and bias (which are the USD equivalent of specifying both "metalness" and "metalnessMap" and so on)
  - also affects normalStrength, occlusionScale and so on
- texture transforms
- clearcoat / clearcoatRoughness / ior (can be a future PR)

*This contribution is funded by [Needle](https://needle.tools)*