### PR TITLE
USDZLoader: Switch to MeshPhysicalMaterial and add initial clearcoat/clearcoatRoughness/ior support

### DIFF
--- a/examples/jsm/loaders/USDZLoader.js
+++ b/examples/jsm/loaders/USDZLoader.js
@@ -7,7 +7,7 @@ import {
 	NoColorSpace,
 	Loader,
 	Mesh,
-	MeshStandardMaterial,
+	MeshPhysicalMaterial,
 	MirroredRepeatWrapping,
 	RepeatWrapping,
 	SRGBColorSpace,
@@ -491,7 +491,7 @@ class USDZLoader extends Loader {
 
 		function buildMaterial( data ) {
 
-			const material = new MeshStandardMaterial();
+			const material = new MeshPhysicalMaterial();
 
 			if ( data !== undefined ) {
 
@@ -567,6 +567,42 @@ class USDZLoader extends Loader {
 					} else if ( 'float inputs:metallic' in surface ) {
 
 						material.metalness = parseFloat( surface[ 'float inputs:metallic' ] );
+
+					}
+
+					if ( 'float inputs:clearcoat.connect' in surface ) {
+
+						const path = surface[ 'float inputs:clearcoat.connect' ];
+						const sampler = findTexture( root, /(\w+).output/.exec( path )[ 1 ] );
+
+						material.clearcoat = 1.0;
+						material.clearcoatMap = buildTexture( sampler );
+						material.clearcoatMap.colorSpace = NoColorSpace;
+
+					} else  if ( 'float inputs:clearcoat' in surface ) {
+
+						material.clearcoat = parseFloat( surface[ 'float inputs:clearcoat' ] );
+
+					}
+
+					if ( 'float inputs:clearcoatRoughness.connect' in surface ) {
+
+						const path = surface[ 'float inputs:clearcoatRoughness.connect' ];
+						const sampler = findTexture( root, /(\w+).output/.exec( path )[ 1 ] );
+
+						material.clearcoatRoughness = 1.0;
+						material.clearcoatRoughnessMap = buildTexture( sampler );
+						material.clearcoatRoughnessMap.colorSpace = NoColorSpace;
+
+					} else if ( 'float inputs:clearcoatRoughness' in surface ) {
+
+						material.clearcoatRoughness = parseFloat( surface[ 'float inputs:clearcoatRoughness' ] );
+
+					}
+
+					if ( 'float inputs:ior' in surface ) {
+
+						material.ior = parseFloat( surface[ 'float inputs:ior' ] );
 
 					}
 


### PR DESCRIPTION
Related issue:
- #26616

This PR should be merged after
- https://github.com/mrdoob/three.js/pull/26710.

**Description**

Switches USDZLoader to MeshPhysicalMaterial and adds loading support for clearcoat/clearcoatRoughness.
These parameters are already exported by USDZExporter.

Some details seem to be wrong, but I currently suspect GLTFLoader not loading the clearcoat test file correctly in the first place (will report a separate issue).

_USDZ loaded into Mac QuickLook_
<img width="386" alt="image" src="https://github.com/mrdoob/three.js/assets/2693840/7345d005-6cd5-4921-b975-0dd87d385c69">

_USDZ loaded into three.js_
<img width="482" alt="image" src="https://github.com/mrdoob/three.js/assets/2693840/3c2e1753-f724-4652-9463-757f3d31f5dd">

Test file: [ClearCoatTest.zip](https://github.com/mrdoob/three.js/files/12543168/ClearCoatTest.zip)

*This contribution is funded by [Needle](https://needle.tools)*
