### PR TITLE
Add USE_ANISOTROPY to prefixVertex in WebGLProgram

### DIFF
--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -494,6 +494,7 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 			parameters.displacementMap ? '#define USE_DISPLACEMENTMAP' : '',
 			parameters.emissiveMap ? '#define USE_EMISSIVEMAP' : '',
 
+			parameters.anisotropy ? '#define USE_ANISOTROPY' : '',
 			parameters.anisotropyMap ? '#define USE_ANISOTROPYMAP' : '',
 
 			parameters.clearcoatMap ? '#define USE_CLEARCOATMAP' : '',


### PR DESCRIPTION
Found during the investigation of https://github.com/pmndrs/drei/issues/1628.
Error at MeshPhysicalMaterial when use anisotropy and no clearcoat normalmap and no tangent.