### PR TITLE
Editor: Fix camera transform when using select in Firefox.

### DIFF
--- a/editor/js/libs/ui.js
+++ b/editor/js/libs/ui.js
@@ -357,6 +357,12 @@ class UISelect extends UIElement {
 
 		this.dom.setAttribute( 'autocomplete', 'off' );
 
+		this.dom.addEventListener( 'pointerdown', function ( event ) {
+
+			event.stopPropagation();
+
+		} );
+
 	}
 
 	setMultiple( boolean ) {


### PR DESCRIPTION
Fixed #26705.

**Description**

This PR makes sure that the camera is not transformed by `EditorControls` when the camera and rendering mode `select` UI elements are used. This only happens in Firefox though.
