### PR TITLE
Add Needle Engine to libraries / frameworks docs

### DIFF
--- a/docs/manual/en/introduction/Libraries-and-Plugins.html
+++ b/docs/manual/en/introduction/Libraries-and-Plugins.html
@@ -103,6 +103,7 @@
 			<li>[link:https://github.com/pmndrs/react-three-fiber react-three-fiber]</li>
 			<li>[link:https://github.com/ecsyjs/ecsy-three ECSY]</li>
 			<li>[link:https://threlte.xyz/ Threlte]</li>
+			<li>[link:https://needle.tools/ Needle Engine]</li>
 		</ul>
 
 	</body>

--- a/docs/manual/fr/introduction/Libraries-and-Plugins.html
+++ b/docs/manual/fr/introduction/Libraries-and-Plugins.html
@@ -103,6 +103,7 @@
 			<li>[link:https://github.com/pmndrs/react-three-fiber react-three-fiber]</li>
 			<li>[link:https://github.com/ecsyjs/ecsy-three ECSY]</li>
 			<li>[link:https://threlte.xyz/ Threlte]</li>
+			<li>[link:https://needle.tools/ Needle Engine]</li>
 		</ul>
 
 	</body>

--- a/docs/manual/it/introduction/Libraries-and-Plugins.html
+++ b/docs/manual/it/introduction/Libraries-and-Plugins.html
@@ -103,6 +103,7 @@
 			<li>[link:https://github.com/pmndrs/react-three-fiber react-three-fiber]</li>
 			<li>[link:https://github.com/ecsyjs/ecsy-three ECSY]</li>
 			<li>[link:https://threlte.xyz/ Threlte]</li>
+			<li>[link:https://needle.tools/ Needle Engine]</li>
 		</ul>
 
 	</body>

--- a/docs/manual/ja/introduction/Libraries-and-Plugins.html
+++ b/docs/manual/ja/introduction/Libraries-and-Plugins.html
@@ -96,6 +96,7 @@
         <li>[link:https://github.com/pmndrs/react-three-fiber react-three-fiber]</li>
         <li>[link:https://github.com/ecsyjs/ecsy-three ECSY]</li>
         <li>[link:https://threlte.xyz/ Threlte]</li>
+        <li>[link:https://needle.tools/ Needle Engine]</li>
     </ul>
 
 </body>

--- a/docs/manual/pt-br/introduction/Libraries-and-Plugins.html
+++ b/docs/manual/pt-br/introduction/Libraries-and-Plugins.html
@@ -103,6 +103,7 @@
 			<li>[link:https://github.com/pmndrs/react-three-fiber react-three-fiber]</li>
 			<li>[link:https://github.com/ecsyjs/ecsy-three ECSY]</li>
 			<li>[link:https://threlte.xyz/ Threlte]</li>
+			<li>[link:https://needle.tools/ Needle Engine]</li>
 		</ul>
 
 	</body>

--- a/docs/manual/ru/introduction/Libraries-and-Plugins.html
+++ b/docs/manual/ru/introduction/Libraries-and-Plugins.html
@@ -103,6 +103,7 @@
 			<li>[link:https://github.com/pmndrs/react-three-fiber react-three-fiber]</li>
 			<li>[link:https://github.com/ecsyjs/ecsy-three ECSY]</li>
 			<li>[link:https://threlte.xyz/ Threlte]</li>
+			<li>[link:https://needle.tools/ Needle Engine]</li>
 		</ul>
 
 	</body>


### PR DESCRIPTION
**Description**

This PR adds Needle Engine to the Libraries and Plugins docs under the Wrappers and Frameworks section
