### PR TITLE
WebGPURenderer: invert viewport/scissor y coords

### DIFF
--- a/examples/jsm/renderers/common/RenderContext.js
+++ b/examples/jsm/renderers/common/RenderContext.js
@@ -31,6 +31,9 @@ class RenderContext {
 		this.activeCubeFace = 0;
 		this.sampleCount = 1;
 
+		this.width = 0;
+		this.height = 0;
+
 	}
 
 }

--- a/examples/jsm/renderers/common/Renderer.js
+++ b/examples/jsm/renderers/common/Renderer.js
@@ -280,11 +280,15 @@ class Renderer {
 
 			renderContext.textures = renderTargetData.textures;
 			renderContext.depthTexture = renderTargetData.depthTexture;
+			renderContext.width = renderTargetData.width;
+			renderContext.height = renderTargetData.height;
 
 		} else {
 
 			renderContext.textures = null;
 			renderContext.depthTexture = null;
+			renderContext.width = this.domElement.width;
+			renderContext.height = this.domElement.height;
 
 		}
 

--- a/examples/jsm/renderers/webgpu/WebGPUBackend.js
+++ b/examples/jsm/renderers/webgpu/WebGPUBackend.js
@@ -138,6 +138,7 @@ class WebGPUBackend extends Backend {
 		const device = this.device;
 		const occlusionQueryCount = renderContext.occlusionQueryCount;
 
+		let bufferHeight;
 		let occlusionQuerySet;
 
 		if ( occlusionQueryCount > 0 ) {
@@ -231,6 +232,8 @@ class WebGPUBackend extends Backend {
 
 			}
 
+			bufferHeight = Math.floor( textures[ 0 ].source.data.height );
+
 		} else {
 
 			if ( antialias === true ) {
@@ -246,6 +249,8 @@ class WebGPUBackend extends Backend {
 			}
 
 			depthStencilAttachment.view = this._getDepthBufferGPU( renderContext ).createView();
+
+			bufferHeight = this.colorBuffer.height;
 
 		}
 
@@ -342,7 +347,7 @@ class WebGPUBackend extends Backend {
 
 		if ( renderContext.viewport ) {
 
-			this.updateViewport( renderContext );
+			this.updateViewport( renderContext, bufferHeight );
 
 		}
 
@@ -350,7 +355,7 @@ class WebGPUBackend extends Backend {
 
 			const { x, y, width, height } = renderContext.scissorValue;
 
-			currentPass.setScissorRect( x, y, width, height );
+			currentPass.setScissorRect( x, bufferHeight - height - y, width, height );
 
 		}
 
@@ -481,12 +486,12 @@ class WebGPUBackend extends Backend {
 
 	}
 
-	updateViewport( renderContext ) {
+	updateViewport( renderContext, bufferHeight ) {
 
 		const { currentPass } = this.get( renderContext );
-		const { x, y, width, height, minDepth, maxDepth } = renderContext.viewportValue;
+		let { x, y, width, height, minDepth, maxDepth } = renderContext.viewportValue;
 
-		currentPass.setViewport( x, y, width, height, minDepth, maxDepth );
+		currentPass.setViewport( x, bufferHeight - height - y, width, height, minDepth, maxDepth );
 
 	}
 

--- a/examples/jsm/renderers/webgpu/WebGPUBackend.js
+++ b/examples/jsm/renderers/webgpu/WebGPUBackend.js
@@ -232,7 +232,8 @@ class WebGPUBackend extends Backend {
 
 			}
 
-			bufferHeight = Math.floor( textures[ 0 ].source.data.height );
+			renderContext.height = Math.floor( textures[ 0 ].source.data.height );
+			renderContext.width = Math.floor( textures[ 0 ].source.data.width );
 
 		} else {
 
@@ -250,7 +251,8 @@ class WebGPUBackend extends Backend {
 
 			depthStencilAttachment.view = this._getDepthBufferGPU( renderContext ).createView();
 
-			bufferHeight = this.colorBuffer.height;
+			renderContext.height = this.colorBuffer.height;
+			renderContext.width = this.colorBuffer.width;
 
 		}
 
@@ -347,7 +349,7 @@ class WebGPUBackend extends Backend {
 
 		if ( renderContext.viewport ) {
 
-			this.updateViewport( renderContext, bufferHeight );
+			this.updateViewport( renderContext );
 
 		}
 
@@ -355,7 +357,7 @@ class WebGPUBackend extends Backend {
 
 			const { x, y, width, height } = renderContext.scissorValue;
 
-			currentPass.setScissorRect( x, bufferHeight - height - y, width, height );
+			currentPass.setScissorRect( x, renderContext.height - height - y, width, height );
 
 		}
 
@@ -486,12 +488,12 @@ class WebGPUBackend extends Backend {
 
 	}
 
-	updateViewport( renderContext, bufferHeight ) {
+	updateViewport( renderContext ) {
 
 		const { currentPass } = this.get( renderContext );
 		let { x, y, width, height, minDepth, maxDepth } = renderContext.viewportValue;
 
-		currentPass.setViewport( x, bufferHeight - height - y, width, height, minDepth, maxDepth );
+		currentPass.setViewport( x, renderContext.height - height - y, width, height, minDepth, maxDepth );
 
 	}
 

--- a/examples/jsm/renderers/webgpu/WebGPUBackend.js
+++ b/examples/jsm/renderers/webgpu/WebGPUBackend.js
@@ -232,9 +232,6 @@ class WebGPUBackend extends Backend {
 
 			}
 
-			renderContext.height = Math.floor( textures[ 0 ].source.data.height );
-			renderContext.width = Math.floor( textures[ 0 ].source.data.width );
-
 		} else {
 
 			if ( antialias === true ) {
@@ -250,9 +247,6 @@ class WebGPUBackend extends Backend {
 			}
 
 			depthStencilAttachment.view = this._getDepthBufferGPU( renderContext ).createView();
-
-			renderContext.height = this.colorBuffer.height;
-			renderContext.width = this.colorBuffer.width;
 
 		}
 

--- a/examples/jsm/renderers/webgpu/WebGPUBackend.js
+++ b/examples/jsm/renderers/webgpu/WebGPUBackend.js
@@ -138,7 +138,6 @@ class WebGPUBackend extends Backend {
 		const device = this.device;
 		const occlusionQueryCount = renderContext.occlusionQueryCount;
 
-		let bufferHeight;
 		let occlusionQuerySet;
 
 		if ( occlusionQueryCount > 0 ) {

--- a/examples/webgpu_lines_fat.html
+++ b/examples/webgpu_lines_fat.html
@@ -195,9 +195,9 @@
 
 				renderer.setScissorTest( true );
 
-				renderer.setScissor( 20, window.innerHeight - insetHeight - 20, insetWidth, insetHeight );
+				renderer.setScissor( 20, 20, insetWidth, insetHeight );
 
-				renderer.setViewport( 20, window.innerHeight - insetHeight - 20, insetWidth, insetHeight );
+				renderer.setViewport( 20, 20, insetWidth, insetHeight );
 
 				camera2.position.copy( camera.position );
 				camera2.quaternion.copy( camera.quaternion );


### PR DESCRIPTION
WebGPU uses the top left corner of the framebuffer origin for viewport and scissor operations while WebGL uses the bottom left corner. Preserve the existing API by inverting y coordinate and adjust line2 example.