### PR TITLE
WebGLRenderer: Reset mask before clearing stencil.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -629,7 +629,12 @@ class WebGLRenderer {
 			}
 
 			if ( depth ) bits |= _gl.DEPTH_BUFFER_BIT;
-			if ( stencil ) bits |= _gl.STENCIL_BUFFER_BIT;
+			if ( stencil ) {
+
+				bits |= _gl.STENCIL_BUFFER_BIT;
+				this.state.buffers.stencil.setMask( 0xffffffff );
+
+			}
 
 			_gl.clear( bits );
 


### PR DESCRIPTION
**Description**

When the last object rendered before the `clear` uses `stencilWriteMask`, which may happen when doing multiple passes with such materials, or when using some render targets, the `clear` will not clear bits disabled by the mask.

See https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/clear

> The scissor box, dithering, and buffer writemasks can affect the clear() method

This PR resets mask before doing the clear