### PR TITLE
RGBELoader: Correct error display message.

### DIFF
--- a/examples/jsm/loaders/RGBELoader.js
+++ b/examples/jsm/loaders/RGBELoader.js
@@ -395,7 +395,7 @@ class RGBELoader extends DataTextureLoader {
 
 			default:
 
-				throw new Error( 'THREE.RGBELoader: unsupported type: ', this.type );
+				throw new Error(`RGBELoader: unsupported type: ${this.type}`);
 				break;
 
 		}

--- a/examples/jsm/loaders/RGBELoader.js
+++ b/examples/jsm/loaders/RGBELoader.js
@@ -395,7 +395,7 @@ class RGBELoader extends DataTextureLoader {
 
 			default:
 
-				throw new Error(`RGBELoader: unsupported type: ${this.type}`);
+				throw new Error( 'THREE.RGBELoader: Unsupported type: ' + this.type );
 				break;
 
 		}


### PR DESCRIPTION
this.type is not an ErrorOptions compatible value so errors do not display value.
