### PR TITLE
Camera: Simplify `getWorldDirection()`.

### DIFF
--- a/src/cameras/Camera.js
+++ b/src/cameras/Camera.js
@@ -38,11 +38,7 @@ class Camera extends Object3D {
 
 	getWorldDirection( target ) {
 
-		this.updateWorldMatrix( true, false );
-
-		const e = this.matrixWorld.elements;
-
-		return target.set( - e[ 8 ], - e[ 9 ], - e[ 10 ] ).normalize();
+		return super.getWorldDirection( target ).negate();
 
 	}
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -511,9 +511,7 @@ class Object3D extends EventDispatcher {
 
 		this.updateWorldMatrix( true, false );
 
-		const e = this.matrixWorld.elements;
-
-		return target.set( e[ 8 ], e[ 9 ], e[ 10 ] ).normalize();
+		return target.fromArray( this.matrixWorld.elements, 8 ).normalize();
 
 	}
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -511,7 +511,9 @@ class Object3D extends EventDispatcher {
 
 		this.updateWorldMatrix( true, false );
 
-		return target.fromArray( this.matrixWorld.elements, 8 ).normalize();
+		const e = this.matrixWorld.elements;
+
+		return target.set( e[ 8 ], e[ 9 ], e[ 10 ] ).normalize();
 
 	}
 


### PR DESCRIPTION
This PR reduces noise at ...

- ~~`Object3D.getWorldDirection`: elim. an intermediate var~~ [reason](https://github.com/mrdoob/three.js/pull/26743#discussion_r1323499602)

- `Camera3D.getWorldDirection`: more usage of base meth