### PR TITLE
BufferGeometryUtils.mergeVertices: Shift the hash bin to avoid missing neighbors

### DIFF
--- a/examples/jsm/utils/BufferGeometryUtils.js
+++ b/examples/jsm/utils/BufferGeometryUtils.js
@@ -631,8 +631,10 @@ function mergeVertices( geometry, tolerance = 1e-4 ) {
 	}
 
 	// convert the error tolerance to an amount of decimal places to truncate to
-	const decimalShift = Math.log10( 1 / tolerance );
-	const shiftMultiplier = Math.pow( 10, decimalShift );
+	const halfTolerance = tolerance * 0.5;
+	const exponent = Math.log10( 1 / tolerance );
+	const hashMultiplier = Math.pow( 10, exponent );
+	const hashAdditive = halfTolerance * hashMultiplier;
 	for ( let i = 0; i < vertexCount; i ++ ) {
 
 		const index = indices ? indices.getX( i ) : i;
@@ -648,7 +650,7 @@ function mergeVertices( geometry, tolerance = 1e-4 ) {
 			for ( let k = 0; k < itemSize; k ++ ) {
 
 				// double tilde truncates the decimal value
-				hash += `${ ~ ~ ( attribute[ getters[ k ] ]( index ) * shiftMultiplier ) },`;
+				hash += `${ ~ ~ ( attribute[ getters[ k ] ]( index ) * hashMultiplier + hashAdditive ) },`;
 
 			}
 


### PR DESCRIPTION
Fixed #24621

**Description**

Adjusts the hashing approach for mergeVertice to shift the hash bin boundary away from round numbers where vertices will more commonly be. This is not a perfect fix - I think that would require a significantly slower solution - but should improve the ability to merge in more common cases.

Here's version of the codesandbox from #24621 using the new function showing that it fixes the missed vertex in this case.

https://jsfiddle.net/zejt0Lrb/

**Before / After**

<img height="400" alt="image" src="https://github.com/mrdoob/three.js/assets/734200/03f46a2d-5160-4801-bb94-e36942978026"> <img height="400" alt="image" src="https://github.com/mrdoob/three.js/assets/734200/f51f057b-7812-469d-8bc5-3a2f40f1f434"> 

cc @erasta @donmccurdy 

