### PR TITLE
DragControls: Add `recursive` property. 

### DIFF
--- a/docs/examples/en/controls/DragControls.html
+++ b/docs/examples/en/controls/DragControls.html
@@ -100,6 +100,11 @@
 			Whether or not the controls are enabled.
 		</p>
 
+		<h3>[property:Boolean recursive]</h3>
+		<p>
+			Whether children of draggable objects can be dragged independently from their parent. Default is `true`.
+		</p>
+
 		<h3>[property:Boolean transformGroup]</h3>
 		<p>
 			This option only works if the [page:DragControls.objects] array contains a single draggable group object.

--- a/examples/jsm/controls/DragControls.js
+++ b/examples/jsm/controls/DragControls.js
@@ -18,7 +18,7 @@ const _inverseMatrix = new Matrix4();
 
 class DragControls extends EventDispatcher {
 
-	constructor( _objects, _camera, _domElement) {
+	constructor( _objects, _camera, _domElement ) {
 
 		super();
 

--- a/examples/jsm/controls/DragControls.js
+++ b/examples/jsm/controls/DragControls.js
@@ -18,7 +18,7 @@ const _inverseMatrix = new Matrix4();
 
 class DragControls extends EventDispatcher {
 
-	constructor( _objects, _camera, _domElement ) {
+	constructor( _objects, _camera, _domElement) {
 
 		super();
 
@@ -99,7 +99,7 @@ class DragControls extends EventDispatcher {
 				_intersections.length = 0;
 
 				_raycaster.setFromCamera( _pointer, _camera );
-				_raycaster.intersectObjects( _objects, true, _intersections );
+				_raycaster.intersectObjects( _objects, scope.recursive, _intersections );
 
 				if ( _intersections.length > 0 ) {
 
@@ -151,7 +151,7 @@ class DragControls extends EventDispatcher {
 			_intersections.length = 0;
 
 			_raycaster.setFromCamera( _pointer, _camera );
-			_raycaster.intersectObjects( _objects, true, _intersections );
+			_raycaster.intersectObjects( _objects, scope.recursive, _intersections );
 
 			if ( _intersections.length > 0 ) {
 
@@ -205,6 +205,7 @@ class DragControls extends EventDispatcher {
 		// API
 
 		this.enabled = true;
+		this.recursive = true;
 		this.transformGroup = false;
 
 		this.activate = activate;


### PR DESCRIPTION
Related forum post: https://discourse.threejs.org/t/making-draggable-objects-without-independent-children/54560

**Description**
This PR adds the recursive property to DragControls, allowing you to choose whether children of draggable objects can be dragged independently from their parents. The original code did not allow for this behavior to be disabled. This was also probably the reason that the `transformGroup` property was created in the first place. The new property is more generally applicable and covers more use cases, such as the one in the linked forum post.