### PR TITLE
USDZLoader: Fix index array type.

### DIFF
--- a/examples/jsm/loaders/USDZLoader.js
+++ b/examples/jsm/loaders/USDZLoader.js
@@ -368,7 +368,7 @@ class USDZLoader extends Loader {
 			if ( 'int[] faceVertexIndices' in data ) {
 
 				const indices = JSON.parse( data[ 'int[] faceVertexIndices' ] );
-				geometry.setIndex( new BufferAttribute( new Uint16Array( indices ), 1 ) );
+				geometry.setIndex( new BufferAttribute( new Uint32Array( indices ), 1 ) );
 
 			}
 

--- a/examples/jsm/loaders/USDZLoader.js
+++ b/examples/jsm/loaders/USDZLoader.js
@@ -368,7 +368,7 @@ class USDZLoader extends Loader {
 			if ( 'int[] faceVertexIndices' in data ) {
 
 				const indices = JSON.parse( data[ 'int[] faceVertexIndices' ] );
-				geometry.setIndex( new BufferAttribute( new Uint32Array( indices ), 1 ) );
+				geometry.setIndex( indices );
 
 			}
 


### PR DESCRIPTION
Related issue: No reported issue that I could find

**Description**

- Current `Uint16Array` type might cause spaghetti-like effect when opening some USDZ models
- Changed to `Uint32Array` type
- This can be tested with the [coffeemat.glb](https://github.com/mrdoob/three.js/blob/dev/examples/models/gltf/coffeemat.glb) example by opening it in the current `r157dev` editor, exporting it as a USDZ file and then opening the exported file in the same editor.

The following pictures show before and after effects.


![USDZ - Uint16Array Index](https://github.com/mrdoob/three.js/assets/69928501/91123465-d8e7-4794-a9a2-f4f42f497044)
![USDZ - Uint32Array Index](https://github.com/mrdoob/three.js/assets/69928501/84474c61-9810-49b6-b6da-45dfed953f01)
