### PR TITLE
Docs: Add some missing options to `MeshPhysicalMaterial` demo.

### DIFF
--- a/docs/api/ar/materials/MeshPhysicalMaterial.html
+++ b/docs/api/ar/materials/MeshPhysicalMaterial.html
@@ -186,7 +186,7 @@
 		</p>
 		
 		<h3>[property:Color sheenColor]</h3>
-		<p>لون اللمعان. الافتراضي هو `0xffffff`، أبيض.</p>
+		<p>لون اللمعان. الافتراضي هو `0x000000`، أسود.</p>
 		
 		<h3>[property:Texture sheenColorMap]</h3>
 		<p>

--- a/docs/api/en/materials/MeshPhysicalMaterial.html
+++ b/docs/api/en/materials/MeshPhysicalMaterial.html
@@ -227,7 +227,7 @@
 		</p>
 
 		<h3>[property:Color sheenColor]</h3>
-		<p>The sheen tint. Default is `0xffffff`, white.</p>
+		<p>The sheen tint. Default is `0x000000`, black.</p>
 
 		<h3>[property:Texture sheenColorMap]</h3>
 		<p>

--- a/docs/api/fr/materials/MeshPhysicalMaterial.html
+++ b/docs/api/fr/materials/MeshPhysicalMaterial.html
@@ -161,7 +161,7 @@
 
 		<h3>[property:Color sheenColor]</h3>
 		<p>
-			La teinte brillante. La valeur par défaut est `0xffffff`, white.
+			La teinte brillante. La valeur par défaut est `0x000000`, noire.
 		</p>
 
 		<h3>[property:Texture sheenColorMap]</h3>

--- a/docs/api/it/materials/MeshPhysicalMaterial.html
+++ b/docs/api/it/materials/MeshPhysicalMaterial.html
@@ -166,7 +166,7 @@
 
 		<h3>[property:Color sheenColor]</h3>
 		<p>
-			La tinta brillante. Il valore predefinito è `0xffffff`, bianco.
+			La tinta brillante. Il valore predefinito è `0x000000`, nera.
 		</p>
 
 		<h3>[property:Texture sheenColorMap]</h3>

--- a/docs/api/zh/materials/MeshPhysicalMaterial.html
+++ b/docs/api/zh/materials/MeshPhysicalMaterial.html
@@ -149,7 +149,7 @@
 
 		<h3>[property:Color sheenColor]</h3>
 		<p>
-			光泽颜色，默认为*0xffffff*白色。
+			光泽颜色，默认为*0x000000*黑色。
 		</p>
 
 		<h3>[property:Texture sheenColorMap]</h3>

--- a/docs/scenes/material-browser.html
+++ b/docs/scenes/material-browser.html
@@ -690,6 +690,8 @@
 						guiMaterial( gui, mesh, material, geometry );
 						guiMeshPhysicalMaterial( gui, mesh, material, geometry );
 
+						// only use scene environment
+
 						light1.visible = false;
 						light2.visible = false;
 						light3.visible = false;

--- a/docs/scenes/material-browser.html
+++ b/docs/scenes/material-browser.html
@@ -690,6 +690,8 @@
 						guiMaterial( gui, mesh, material, geometry );
 						guiMeshPhysicalMaterial( gui, mesh, material, geometry );
 
+						light1.visible = false;
+						light2.visible = false;
 						light3.visible = false;
 
 						return material;

--- a/docs/scenes/material-browser.html
+++ b/docs/scenes/material-browser.html
@@ -530,7 +530,8 @@
 					envMaps: envMapKeysPBR[ 0 ],
 					map: diffuseMapKeys[ 0 ],
 					roughnessMap: roughnessMapKeys[ 0 ],
-					alphaMap: alphaMapKeys[ 0 ]
+					alphaMap: alphaMapKeys[ 0 ],
+					metalnessMap: alphaMapKeys[ 0 ]
 				};
 
 				const folder = gui.addFolder( 'THREE.MeshStandardMaterial' );
@@ -548,8 +549,7 @@
 				folder.add( data, 'map', diffuseMapKeys ).onChange( updateTexture( material, 'map', diffuseMaps ) );
 				folder.add( data, 'roughnessMap', roughnessMapKeys ).onChange( updateTexture( material, 'roughnessMap', roughnessMaps ) );
 				folder.add( data, 'alphaMap', alphaMapKeys ).onChange( updateTexture( material, 'alphaMap', alphaMaps ) );
-
-				// TODO metalnessMap
+				folder.add( data, 'metalnessMap', alphaMapKeys ).onChange( updateTexture( material, 'metalnessMap', alphaMaps ) );
 
 			}
 
@@ -561,7 +561,11 @@
 					envMaps: envMapKeys[ 0 ],
 					map: diffuseMapKeys[ 0 ],
 					roughnessMap: roughnessMapKeys[ 0 ],
-					alphaMap: alphaMapKeys[ 0 ]
+					alphaMap: alphaMapKeys[ 0 ],
+					metalnessMap: alphaMapKeys[ 0 ],
+					sheenColor: 0xffffff,
+					specularColor: material.specularColor.getHex(),
+					iridescenceMap: alphaMapKeys[ 0 ]
 				};
 
 				const folder = gui.addFolder( 'THREE.MeshPhysicalMaterial' );
@@ -571,9 +575,17 @@
 
 				folder.add( material, 'roughness', 0, 1 );
 				folder.add( material, 'metalness', 0, 1 );
+				folder.add( material, 'ior', 1, 2.333 );
 				folder.add( material, 'reflectivity', 0, 1 );
+				folder.add( material, 'iridescence', 0, 1 );
+				folder.add( material, 'iridescenceIOR', 1, 2.333 );
+				folder.add( material, 'sheen', 0, 1 );
+				folder.add( material, 'sheenRoughness', 0, 1 );
+				folder.addColor( data, 'sheenColor' ).onChange( handleColorChange( material.sheenColor ) );
 				folder.add( material, 'clearcoat', 0, 1 ).step( 0.01 );
 				folder.add( material, 'clearcoatRoughness', 0, 1 ).step( 0.01 );
+				folder.add( material, 'specularIntensity', 0, 1);
+				folder.addColor( data, 'specularColor' ).onChange( handleColorChange( material.specularColor ) );
 				folder.add( material, 'flatShading' ).onChange( needsUpdate( material, geometry ) );
 				folder.add( material, 'wireframe' );
 				folder.add( material, 'vertexColors' ).onChange( needsUpdate( material, geometry ) );
@@ -582,8 +594,8 @@
 				folder.add( data, 'map', diffuseMapKeys ).onChange( updateTexture( material, 'map', diffuseMaps ) );
 				folder.add( data, 'roughnessMap', roughnessMapKeys ).onChange( updateTexture( material, 'roughnessMap', roughnessMaps ) );
 				folder.add( data, 'alphaMap', alphaMapKeys ).onChange( updateTexture( material, 'alphaMap', alphaMaps ) );
-
-				// TODO metalnessMap
+				folder.add( data, 'metalnessMap', alphaMapKeys ).onChange( updateTexture( material, 'metalnessMap', alphaMaps ) );
+				folder.add( data, 'iridescenceMap', alphaMapKeys ).onChange( updateTexture( material, 'iridescenceMap', alphaMaps ) );
 
 			}
 
@@ -678,10 +690,6 @@
 						guiMaterial( gui, mesh, material, geometry );
 						guiMeshPhysicalMaterial( gui, mesh, material, geometry );
 
-						// only use scene environment
-
-						light1.visible = false;
-						light2.visible = false;
 						light3.visible = false;
 
 						return material;

--- a/docs/scenes/material-browser.html
+++ b/docs/scenes/material-browser.html
@@ -563,7 +563,7 @@
 					roughnessMap: roughnessMapKeys[ 0 ],
 					alphaMap: alphaMapKeys[ 0 ],
 					metalnessMap: alphaMapKeys[ 0 ],
-					sheenColor: 0xffffff,
+					sheenColor: material.sheenColor.getHex(),
 					specularColor: material.specularColor.getHex(),
 					iridescenceMap: alphaMapKeys[ 0 ]
 				};


### PR DESCRIPTION
## Motivation

I've often referred to the official Three.JS docs for materials while learning, and I find the inline demos for the materials with the torus knot extremely helpful for getting a feel for what various parameters do.

However, I noticed that several of the more recently added parameters for `MeshPhysicalMaterial` like iridescence and sheen were missing from the controls.  These are really neat layers that add a lot of power to the shaders, and I think it would be really beneficial to have knobs for people to play with them directly on the docs page to get a feel for what effects they have.

## Changes

 * Add GUI options for some missing properties including sheen, ior, iridescence, and others to the material browser embedded on the docs pages for materials

![](https://i.ameo.link/bgz.png)