### PR TITLE
AnimationUtils: Remove `arraySlice()`.

### DIFF
--- a/docs/api/ar/animation/AnimationUtils.html
+++ b/docs/api/ar/animation/AnimationUtils.html
@@ -17,11 +17,6 @@
 		<h2>الوظائف (Methods)</h2>
 
 
-		<h3>[method:Array arraySlice]( array, from, to )</h3>
-		<p>
-		نفسه عمل Array.prototype.slice ، ولكنه يعمل أيضًا على المصفوفات المكتوبة.
-		</p>
-
 		<h3>[method:Array convertArray]( array, type, forceClone )</h3>
 		<p>
 		يحول مصفوفة إلى نوع معين.

--- a/docs/api/en/animation/AnimationUtils.html
+++ b/docs/api/en/animation/AnimationUtils.html
@@ -16,11 +16,6 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:Array arraySlice]( array, from, to )</h3>
-		<p>
-			This is the same as Array.prototype.slice, but also works on typed arrays.
-		</p>
-
 		<h3>[method:Array convertArray]( array, type, forceClone )</h3>
 		<p>Converts an array to a specific type.</p>
 

--- a/docs/api/fr/animation/AnimationUtils.html
+++ b/docs/api/fr/animation/AnimationUtils.html
@@ -17,11 +17,6 @@
 		<h2>Méthodes</h2>
 
 
-		<h3>[method:Array arraySlice]( array, from, to )</h3>
-		<p>
-		Cette méthode est la même que Array.prototype.slice, mais fonctionne également sur les tableaux typés.
-		</p>
-
 		<h3>[method:Array convertArray]( array, type, forceClone )</h3>
 		<p>
 		Convertis un tableau en un type spécifique.

--- a/docs/api/it/animation/AnimationUtils.html
+++ b/docs/api/it/animation/AnimationUtils.html
@@ -17,11 +17,6 @@
 		<h2>Metodi</h2>
 
 
-		<h3>[method:Array arraySlice]( array, from, to )</h3>
-		<p>
-      È lo stesso di Array.prototype.slice, ma funziona anche su array tipizzati.
-		</p>
-
 		<h3>[method:Array convertArray]( array, type, forceClone )</h3>
 		<p>
       Converte un array in un tipo specifico.

--- a/docs/api/ko/animation/AnimationUtils.html
+++ b/docs/api/ko/animation/AnimationUtils.html
@@ -17,11 +17,6 @@
 		<h2>메서드</h2>
 
 
-		<h3>[method:Array arraySlice]( array, from, to )</h3>
-		<p>
-		Array.prototype.slice와 동일하지만, 타입 배열에서도 작동합니다.
-		</p>
-
 		<h3>[method:Array convertArray]( array, type, forceClone )</h3>
 		<p>
 		배열을 특정 타입으로 변환합니다.

--- a/docs/api/pt-br/animation/AnimationUtils.html
+++ b/docs/api/pt-br/animation/AnimationUtils.html
@@ -17,11 +17,6 @@
 		<h2>Métodos</h2>
 
 
-		<h3>[method:Array arraySlice]( array, from, to )</h3>
-		<p>
-			É o mesmo que Array.prototype.slice, mas também funciona em arrays tipados.
-		</p>
-
 		<h3>[method:Array convertArray]( array, type, forceClone )</h3>
 		<p>
 			Converte um array em um tipo específico.

--- a/docs/api/zh/animation/AnimationUtils.html
+++ b/docs/api/zh/animation/AnimationUtils.html
@@ -17,11 +17,6 @@
 		<h2>方法</h2>
 
 
-		<h3>[method:Array arraySlice]( array, from, to )</h3>
-		<p>
-		和Array.prototype.slice作用一样, 但也适用于类型化数组.
-		</p>
-
 		<h3>[method:Array convertArray]( array, type, forceClone )</h3>
 		<p>
 		将数组转换为某种特定类型。

--- a/src/animation/AnimationUtils.js
+++ b/src/animation/AnimationUtils.js
@@ -2,7 +2,7 @@ import { Quaternion } from '../math/Quaternion.js';
 import { AdditiveAnimationBlendMode } from '../constants.js';
 
 // same as Array.prototype.slice, but also works on typed arrays
-function arraySlice( array, from, to = - 1 ) {
+function arraySlice( array, from, to = array.length ) {
 
 	if ( isTypedArray( array ) ) {
 

--- a/src/animation/AnimationUtils.js
+++ b/src/animation/AnimationUtils.js
@@ -2,13 +2,13 @@ import { Quaternion } from '../math/Quaternion.js';
 import { AdditiveAnimationBlendMode } from '../constants.js';
 
 // same as Array.prototype.slice, but also works on typed arrays
-function arraySlice( array, from, to ) {
+function arraySlice( array, from, to = - 1 ) {
 
 	if ( isTypedArray( array ) ) {
 
 		// in ios9 array.subarray(from, undefined) will return empty array
 		// but array.subarray(from) or array.subarray(from, len) is correct
-		return new array.constructor( array.subarray( from, to !== undefined ? to : array.length ) );
+		return new array.constructor( array.subarray( from, to ) );
 
 	}
 

--- a/src/animation/AnimationUtils.js
+++ b/src/animation/AnimationUtils.js
@@ -1,21 +1,6 @@
 import { Quaternion } from '../math/Quaternion.js';
 import { AdditiveAnimationBlendMode } from '../constants.js';
 
-// same as Array.prototype.slice, but also works on typed arrays
-function arraySlice( array, from, to = array.length ) {
-
-	if ( isTypedArray( array ) ) {
-
-		// in ios9 array.subarray(from, undefined) will return empty array
-		// but array.subarray(from) or array.subarray(from, len) is correct
-		return new array.constructor( array.subarray( from, to ) );
-
-	}
-
-	return array.slice( from, to );
-
-}
-
 // converts an array to a specific type
 function convertArray( array, type, forceClone ) {
 
@@ -279,14 +264,14 @@ function makeClipAdditive( targetClip, referenceFrame = 0, referenceClip = targe
 			// Reference frame is earlier than the first keyframe, so just use the first keyframe
 			const startIndex = referenceOffset;
 			const endIndex = referenceValueSize - referenceOffset;
-			referenceValue = arraySlice( referenceTrack.values, startIndex, endIndex );
+			referenceValue = referenceTrack.values.slice( startIndex, endIndex );
 
 		} else if ( referenceTime >= referenceTrack.times[ lastIndex ] ) {
 
 			// Reference frame is after the last keyframe, so just use the last keyframe
 			const startIndex = lastIndex * referenceValueSize + referenceOffset;
 			const endIndex = startIndex + referenceValueSize - referenceOffset;
-			referenceValue = arraySlice( referenceTrack.values, startIndex, endIndex );
+			referenceValue = referenceTrack.values.slice( startIndex, endIndex );
 
 		} else {
 
@@ -295,7 +280,7 @@ function makeClipAdditive( targetClip, referenceFrame = 0, referenceClip = targe
 			const startIndex = referenceOffset;
 			const endIndex = referenceValueSize - referenceOffset;
 			interpolant.evaluate( referenceTime );
-			referenceValue = arraySlice( interpolant.resultBuffer, startIndex, endIndex );
+			referenceValue = interpolant.resultBuffer.slice( startIndex, endIndex );
 
 		}
 
@@ -350,7 +335,6 @@ function makeClipAdditive( targetClip, referenceFrame = 0, referenceClip = targe
 }
 
 const AnimationUtils = {
-	arraySlice: arraySlice,
 	convertArray: convertArray,
 	isTypedArray: isTypedArray,
 	getKeyframeOrder: getKeyframeOrder,
@@ -361,7 +345,6 @@ const AnimationUtils = {
 };
 
 export {
-	arraySlice,
 	convertArray,
 	isTypedArray,
 	getKeyframeOrder,

--- a/src/animation/KeyframeTrack.js
+++ b/src/animation/KeyframeTrack.js
@@ -239,8 +239,8 @@ class KeyframeTrack {
 			}
 
 			const stride = this.getValueSize();
-			this.times = AnimationUtils.arraySlice( times, from, to );
-			this.values = AnimationUtils.arraySlice( this.values, from * stride, to * stride );
+			this.times = times.slice( from, to );
+			this.values = this.values.slice( from * stride, to * stride );
 
 		}
 
@@ -330,8 +330,8 @@ class KeyframeTrack {
 	optimize() {
 
 		// times or values may be shared with other tracks, so overwriting is unsafe
-		const times = AnimationUtils.arraySlice( this.times ),
-			values = AnimationUtils.arraySlice( this.values ),
+		const times = this.times.slice(),
+			values = this.values.slice(),
 			stride = this.getValueSize(),
 
 			smoothInterpolation = this.getInterpolation() === InterpolateSmooth,
@@ -424,8 +424,8 @@ class KeyframeTrack {
 
 		if ( writeIndex !== times.length ) {
 
-			this.times = AnimationUtils.arraySlice( times, 0, writeIndex );
-			this.values = AnimationUtils.arraySlice( values, 0, writeIndex * stride );
+			this.times = times.slice( 0, writeIndex );
+			this.values = values.slice( 0, writeIndex * stride );
 
 		} else {
 
@@ -440,8 +440,8 @@ class KeyframeTrack {
 
 	clone() {
 
-		const times = AnimationUtils.arraySlice( this.times, 0 );
-		const values = AnimationUtils.arraySlice( this.values, 0 );
+		const times = this.times.slice();
+		const values = this.values.slice();
 
 		const TypedKeyframeTrack = this.constructor;
 		const track = new TypedKeyframeTrack( this.name, times, values );

--- a/test/unit/src/animation/AnimationUtils.tests.js
+++ b/test/unit/src/animation/AnimationUtils.tests.js
@@ -7,11 +7,6 @@ export default QUnit.module( 'Animation', () => {
 	QUnit.module( 'AnimationUtils', () => {
 
 		// PUBLIC
-		QUnit.todo( 'arraySlice', ( assert ) => {
-
-			assert.ok( false, 'everything\'s gonna be alright' );
-
-		} );
 
 		QUnit.todo( 'convertArray', ( assert ) => {
 


### PR DESCRIPTION
this PR simpilies the polyfill of typedarray.prototype.slice a bit ... in case [its still relevant(?)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/slice#browser_compatibility)