### PR TITLE
Object3D: Remove Object.defineProperties() for `position`, `scale`, `rotation` and `quaternion`.

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -66,17 +66,10 @@ class Object3D extends EventDispatcher {
 		rotation._onChange( onRotationChange );
 		quaternion._onChange( onQuaternionChange );
 
+		this.rotation = rotation;
+		this.quaternion = quaternion;
+
 		Object.defineProperties( this, {
-			rotation: {
-				configurable: true,
-				enumerable: true,
-				value: rotation
-			},
-			quaternion: {
-				configurable: true,
-				enumerable: true,
-				value: quaternion
-			},
 			modelViewMatrix: {
 				value: new Matrix4()
 			},

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -45,10 +45,11 @@ class Object3D extends EventDispatcher {
 
 		this.up = Object3D.DEFAULT_UP.clone();
 
-		const position = new Vector3();
+		this.position = new Vector3();
+		this.scale = new Vector3( 1, 1, 1 );
+
 		const rotation = new Euler();
 		const quaternion = new Quaternion();
-		const scale = new Vector3( 1, 1, 1 );
 
 		function onRotationChange() {
 
@@ -66,11 +67,6 @@ class Object3D extends EventDispatcher {
 		quaternion._onChange( onQuaternionChange );
 
 		Object.defineProperties( this, {
-			position: {
-				configurable: true,
-				enumerable: true,
-				value: position
-			},
 			rotation: {
 				configurable: true,
 				enumerable: true,
@@ -80,11 +76,6 @@ class Object3D extends EventDispatcher {
 				configurable: true,
 				enumerable: true,
 				value: quaternion
-			},
-			scale: {
-				configurable: true,
-				enumerable: true,
-				value: scale
 			},
 			modelViewMatrix: {
 				value: new Matrix4()


### PR DESCRIPTION
Related issue: #XXXX

**Description**

Follow up #26720

Object3D: Remove Object.defineProperties() for `position`, `scale`, `rotation` and `quaternion`.

This PR passed the `npm run test-unit`, maybe I miss something...

If this PR has any problem, please tell me.
