### PR TITLE
Examples: Use cameraPosition uniform instead of world origin in sky shader

### DIFF
--- a/examples/jsm/objects/Sky.js
+++ b/examples/jsm/objects/Sky.js
@@ -138,8 +138,6 @@ Sky.SkyShader = {
 		uniform float mieDirectionalG;
 		uniform vec3 up;
 
-		const vec3 cameraPos = vec3( 0.0, 0.0, 0.0 );
-
 		// constants for atmospheric scattering
 		const float pi = 3.141592653589793238462643383279502884197169;
 
@@ -169,7 +167,7 @@ Sky.SkyShader = {
 
 		void main() {
 
-			vec3 direction = normalize( vWorldPosition - cameraPos );
+			vec3 direction = normalize( vWorldPosition - cameraPosition );
 
 			// optical length
 			// cutoff angle at 90 to avoid singularity in next formula.


### PR DESCRIPTION
**Description**

The sky shader example requires camera position in world space in order to calculate view direction. Previously, the fragment shader for some reason used `vec3(0,0,0)` instead of the actual camera position. This worked fine as long as the skybox scale is large enough and both the skybox and the camera are close the world origin. On very large scenes with dynamic camera in order for the sky and the sun to be rendered correctly you had to scale up the skybox by a huge number to avoid distortion.

This PR replaces hardcoded `vec3(0,0,0)` with `cameraPosition` uniform (camera position in world space, updated automatically), which is already present in the shader. This allows to render skybox without any distortion as long as the camera is inside the skybox. The camera isn't required to be directly in the center of the skybox anymore and the sky always looks like it's infinitely far away.

**Results**

For this demonstration I took `webgl_shaders_sky` example and moved the camera far away from the origin using `camera.position.set( 100000, 100000, 250000 )`.

Before:
<img width="1427" alt="Screenshot 2023-09-15 at 13 48 06" src="https://github.com/mrdoob/three.js/assets/48140945/c7c040d7-7ec8-45b3-9e88-5c6cccec6b15">

After:
<img width="1427" alt="Screenshot 2023-09-15 at 13 47 50" src="https://github.com/mrdoob/three.js/assets/48140945/7b177d80-7057-4d79-a334-395be11df1f7">