### PR TITLE
CubeCamera: Add comment to clarify mipmap generation.

### DIFF
--- a/src/cameras/CubeCamera.js
+++ b/src/cameras/CubeCamera.js
@@ -149,6 +149,9 @@ class CubeCamera extends Object3D {
 		renderer.setRenderTarget( renderTarget, 4 );
 		renderer.render( scene, cameraPZ );
 
+		// mipmaps are generated during the last call of render()
+		// at this point, all sides of the cube render target are defined
+
 		renderTarget.texture.generateMipmaps = generateMipmaps;
 
 		renderer.setRenderTarget( renderTarget, 5 );


### PR DESCRIPTION
Fixed #26736.

**Description**

This PR adds a comment that clarifies the mipmap generation in `CubeCamera.update()`.