### PR TITLE
LightProbeGenerator: Add support for half float render targets.

### DIFF
--- a/examples/jsm/lights/LightProbeGenerator.js
+++ b/examples/jsm/lights/LightProbeGenerator.js
@@ -5,7 +5,9 @@ import {
 	SphericalHarmonics3,
 	Vector3,
 	SRGBColorSpace,
-	NoColorSpace
+	NoColorSpace,
+	HalfFloatType,
+	DataUtils
 } from 'three';
 
 class LightProbeGenerator {
@@ -140,18 +142,50 @@ class LightProbeGenerator {
 		const sh = new SphericalHarmonics3();
 		const shCoefficients = sh.coefficients;
 
+		const dataType = cubeRenderTarget.texture.type;
+
 		for ( let faceIndex = 0; faceIndex < 6; faceIndex ++ ) {
 
 			const imageWidth = cubeRenderTarget.width; // assumed to be square
-			const data = new Uint8Array( imageWidth * imageWidth * 4 );
+
+			let data;
+
+			if ( dataType === HalfFloatType ) {
+
+				data = new Uint16Array( imageWidth * imageWidth * 4 );
+
+			} else {
+
+				// assuming UnsignedByteType
+
+				data = new Uint8Array( imageWidth * imageWidth * 4 );
+
+			}
+
 			renderer.readRenderTargetPixels( cubeRenderTarget, 0, 0, imageWidth, imageWidth, data, faceIndex );
 
 			const pixelSize = 2 / imageWidth;
 
 			for ( let i = 0, il = data.length; i < il; i += 4 ) { // RGBA assumed
 
+				let r, g, b;
+
+				if ( dataType === HalfFloatType ) {
+
+					r = DataUtils.fromHalfFloat( data[ i ] );
+					g = DataUtils.fromHalfFloat( data[ i + 1 ] );
+					b = DataUtils.fromHalfFloat( data[ i + 2 ] );
+
+				} else {
+
+					r = data[ i ] / 255;
+					g = data[ i + 1 ] / 255;
+					b = data[ i + 2 ] / 255;
+
+				}
+
 				// pixel color
-				color.setRGB( data[ i ] / 255, data[ i + 1 ] / 255, data[ i + 2 ] / 255 );
+				color.setRGB( r, g, b );
 
 				// convert to linear color space
 				convertColorToLinear( color, cubeRenderTarget.texture.colorSpace );


### PR DESCRIPTION
Fixed #26765.

**Description**

`LightProbeGenerator.fromCubeRenderTarget()` can now process half float render targets.
