### PR TITLE
WebGPURenderer: dFdy vs dpdy 

### DIFF
--- a/examples/jsm/nodes/materials/NodeMaterial.js
+++ b/examples/jsm/nodes/materials/NodeMaterial.js
@@ -199,7 +199,7 @@ class NodeMaterial extends ShaderMaterial {
 		if ( this.flatShading === true ) {
 
 			const fdx = dFdx( positionView );
-			const fdy = dFdy( positionView.negate() ); // use -positionView ?
+			const fdy = dFdy( positionView );
 			const normalNode = fdx.cross( fdy ).normalize();
 
 			stack.assign( transformedNormalView, normalNode );

--- a/examples/jsm/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/examples/jsm/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -58,7 +58,7 @@ const wgslTypeLib = {
 
 const wgslMethods = {
 	dFdx: 'dpdx',
-	dFdy: 'dpdy',
+	dFdy: '- dpdy',
 	mod: 'threejs_mod',
 	lessThanEqual: 'threejs_lessThanEqual',
 	inversesqrt: 'inverseSqrt'


### PR DESCRIPTION
Flat shading broken in WebGL backend

WGSL dpdy() is equivalent to  - dFdy() because of the reversed window y axis.

Handle this so the expectations of dFdy are preserved in all cases and remove the negation from NodeMaterial.  This fixes flat shading with the WebGL backend.

