### PR TITLE
Fix source maps in minified build files.

### DIFF
--- a/utils/build/rollup.config.js
+++ b/utils/build/rollup.config.js
@@ -124,8 +124,8 @@ const builds = [
 		plugins: [
 			addons(),
 			glsl(),
-			terser(),
-			header()
+			header(),
+			terser()
 		],
 		output: [
 			{
@@ -173,9 +173,9 @@ const builds = [
 		plugins: [
 			addons(),
 			glsl(),
-			terser(),
 			header(),
-			deprecationWarning()
+			deprecationWarning(),
+			terser()
 		],
 		output: [
 			{


### PR DESCRIPTION
fix: #26779
 
The cause: if magicstring generates map without `hires`, many mappings in the map generated from terser plugin will be lost. 

A solution is that, enables `hires` for those plugins came after `terser()`

```json5
// rollup.config.json

function header() {
  return { 
    renderChunk(code, id) {
      code = new MagicString(..
      return { map: code.generateMap({ hires: true }) .. // <<<

// builds
const builds = [ {
  input: 'src/Three.js',
  plugins: [
    ..,
    terser(),
    header(),
    ..
  ]
```

A workaround (this PR) simply re-orders the plugins: let terser plugin be the last one; ([no `hires`, quicker](https://github.com/Rich-Harris/magic-string#sgeneratemap-options-))

```json5
// rollup.config.json

const builds = [ {
  input: 'src/Three.js',
  plugins: [
    ..,
    header(),
    ..,
    terser()  // <<< 
  ]
```

without PR:

<img width="191" alt="sourcemap_fail2" src="https://github.com/mrdoob/three.js/assets/1063018/ed741dd8-a337-4faa-87d8-7a900717c109">

with PR:

<img width="217" alt="sourcemap_ok" src="https://github.com/mrdoob/three.js/assets/1063018/a4e418ff-7238-44df-9875-fb0a2c3f7bf6">


