### PR TITLE
Fog.html: Fix malformed code blocks

### DIFF
--- a/docs/api/ar/scenes/Fog.html
+++ b/docs/api/ar/scenes/Fog.html
@@ -17,8 +17,8 @@
 		<h2>مثال للكود</h2>
 		 
 		<code>
-		const scene = new THREE.Scene();
-		scene.fog = new THREE.Fog( 0xcccccc, 10, 15 );
+			const scene = new THREE.Scene();
+			scene.fog = new THREE.Fog( 0xcccccc, 10, 15 );
 		</code>
 		 
 		<h2>المنشئ (Constructor)</h2>

--- a/docs/api/ar/scenes/FogExp2.html
+++ b/docs/api/ar/scenes/FogExp2.html
@@ -18,8 +18,8 @@
 		<h2>مثال للكود</h2>
 		 
 		<code>
-		const scene = new THREE.Scene();
-		scene.fog = new THREE.FogExp2( 0xcccccc, 0.002 );
+			const scene = new THREE.Scene();
+			scene.fog = new THREE.FogExp2( 0xcccccc, 0.002 );
 		</code>
 		 
 		<h2>المنشئ (Constructor)</h2>

--- a/docs/api/en/scenes/Fog.html
+++ b/docs/api/en/scenes/Fog.html
@@ -16,8 +16,9 @@
 
 		<h2>Code Example</h2>
 
-		<code>const scene = new THREE.Scene();
-		scene.fog = new THREE.Fog( 0xcccccc, 10, 15 );
+		<code>
+			const scene = new THREE.Scene();
+			scene.fog = new THREE.Fog( 0xcccccc, 10, 15 );
 		</code>
 
 		<h2>Constructor</h2>

--- a/docs/api/en/scenes/FogExp2.html
+++ b/docs/api/en/scenes/FogExp2.html
@@ -18,8 +18,8 @@
 		<h2>Code Example</h2>
 
 		<code>
-const scene = new THREE.Scene();
-scene.fog = new THREE.FogExp2( 0xcccccc, 0.002 );
+			const scene = new THREE.Scene();
+			scene.fog = new THREE.FogExp2( 0xcccccc, 0.002 );
 		</code>
 
 		<h2>Constructor</h2>

--- a/docs/api/it/scenes/Fog.html
+++ b/docs/api/it/scenes/Fog.html
@@ -13,8 +13,9 @@
 
 		<h2>Codice di Esempio</h2>
 
-		<code>const scene = new THREE.Scene();
-		scene.fog = new THREE.Fog( 0xcccccc, 10, 15 );
+		<code>
+			const scene = new THREE.Scene();
+			scene.fog = new THREE.Fog( 0xcccccc, 10, 15 );
 		</code>
 
 		<h2>Costruttore</h2>

--- a/docs/api/it/scenes/FogExp2.html
+++ b/docs/api/it/scenes/FogExp2.html
@@ -17,8 +17,9 @@
 
 		<h2>Codice di Esempio</h2>
 
-		<code>const scene = new THREE.Scene();
-		scene.fog = new THREE.FogExp2( 0xcccccc, 0.002 );
+		<code>
+			const scene = new THREE.Scene();
+			scene.fog = new THREE.FogExp2( 0xcccccc, 0.002 );
 		</code>
 
 		<h2>Costruttore</h2>

--- a/docs/api/zh/scenes/Fog.html
+++ b/docs/api/zh/scenes/Fog.html
@@ -13,8 +13,9 @@
 
 		<h2>代码示例</h2>
 
-		<code>const scene = new THREE.Scene();
-		scene.fog = new THREE.Fog( 0xcccccc, 10, 15 );
+		<code>
+			const scene = new THREE.Scene();
+			scene.fog = new THREE.Fog( 0xcccccc, 10, 15 );
 		</code>
 
 		<h2>构造器</h2>

--- a/docs/api/zh/scenes/FogExp2.html
+++ b/docs/api/zh/scenes/FogExp2.html
@@ -13,8 +13,9 @@
 
 		<h2>代码示例</h2>
 
-		<code>const scene = new THREE.Scene();
-		scene.fog = new THREE.FogExp2( 0xcccccc, 0.002 );
+		<code>
+			const scene = new THREE.Scene();
+			scene.fog = new THREE.FogExp2( 0xcccccc, 0.002 );
 		</code>
 
 		<h2>构造器</h2>


### PR DESCRIPTION
This PR corrects the indents

from this
<img width="420" alt="fog_html_indent_fail" src="https://github.com/mrdoob/three.js/assets/1063018/8ebb07c6-5d73-4682-9311-d23025a0ad64">

to this:
<img width="413" alt="fog_html_indent_ok" src="https://github.com/mrdoob/three.js/assets/1063018/dbcc023c-c0b8-4941-85ba-a27f2df59db8">
