### PR TITLE
ObjectLoader: Refector (de)serialization of Fog and FogExp2

### DIFF
--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -785,6 +785,12 @@ class ObjectLoader extends Loader {
 
 					}
 
+					if ( data.fog.name !== '' ) {
+
+						object.fog.name = data.fog.name;
+
+					}
+
 				}
 
 				if ( data.backgroundBlurriness !== undefined ) object.backgroundBlurriness = data.backgroundBlurriness;

--- a/src/scenes/Fog.js
+++ b/src/scenes/Fog.js
@@ -23,12 +23,16 @@ class Fog {
 
 	toJSON( /* meta */ ) {
 
-		return {
-			type: 'Fog',
-			color: this.color.getHex(),
-			near: this.near,
-			far: this.far
-		};
+		const data = {};
+
+		data.type = 'Fog';
+		data.color = this.color.getHex();
+
+		if ( this.name !== '' ) data.name = this.name;
+		if ( this.near !== 1 ) data.near = this.near;
+		if ( this.far !== 1000 ) data.far = this.far;
+
+		return data;
 
 	}
 

--- a/src/scenes/Fog.js
+++ b/src/scenes/Fog.js
@@ -23,16 +23,13 @@ class Fog {
 
 	toJSON( /* meta */ ) {
 
-		const data = {};
-
-		data.type = 'Fog';
-		data.color = this.color.getHex();
-
-		if ( this.name !== '' ) data.name = this.name;
-		if ( this.near !== 1 ) data.near = this.near;
-		if ( this.far !== 1000 ) data.far = this.far;
-
-		return data;
+		return {
+			type: 'Fog',
+			name: this.name,
+			color: this.color.getHex(),
+			near: this.near,
+			far: this.far
+		};
 
 	}
 

--- a/src/scenes/FogExp2.js
+++ b/src/scenes/FogExp2.js
@@ -21,15 +21,12 @@ class FogExp2 {
 
 	toJSON( /* meta */ ) {
 
-		const data = {};
-
-		data.type = 'FogExp2';
-		data.color = this.color.getHex();
-
-		if ( this.name !== '' ) data.name = this.name;
-		if ( this.density !== 0.00025 ) data.desnity = this.density;
-
-		return data;
+		return {
+			type: 'FogExp2',
+			name: this.name,
+			color: this.color.getHex(),
+			density: this.density
+		};
 
 	}
 

--- a/src/scenes/FogExp2.js
+++ b/src/scenes/FogExp2.js
@@ -21,11 +21,15 @@ class FogExp2 {
 
 	toJSON( /* meta */ ) {
 
-		return {
-			type: 'FogExp2',
-			color: this.color.getHex(),
-			density: this.density
-		};
+		const data = {};
+
+		data.type = 'FogExp2';
+		data.color = this.color.getHex();
+
+		if ( this.name !== '' ) data.name = this.name;
+		if ( this.density !== 0.00025 ) data.desnity = this.density;
+
+		return data;
 
 	}
 


### PR DESCRIPTION
This PR refactors the (de)serialization of Fog and FogExp2 for ObjectLoader:

- honor `.name` prop, [just like other objects, eg. lights](https://jsfiddle.net/kcrwqjup/)
- ~~(when serialize) exclude props that have default value~~ [reason](https://github.com/mrdoob/three.js/pull/26793#discussion_r1328466409)


