### PR TITLE
Editor: Fix `CapsuleGeometry` parameter.

### DIFF
--- a/editor/js/Sidebar.Geometry.CapsuleGeometry.js
+++ b/editor/js/Sidebar.Geometry.CapsuleGeometry.js
@@ -26,7 +26,7 @@ function GeometryParametersPanel( editor, object ) {
 	// length
 
 	const lengthRow = new UIRow();
-	const length = new UINumber( parameters.height ).onChange( update );
+	const length = new UINumber( parameters.length ).onChange( update );
 
 	lengthRow.add( new UIText( strings.getKey( 'sidebar/geometry/capsule_geometry/length' ) ).setWidth( '90px' ) );
 	lengthRow.add( length );


### PR DESCRIPTION
Fixed #26786.

**Description**

The editor still used `height` instead of `length` in context of `CapsuleGeometry` at one place.
