### PR TITLE
WebGPURenderer: Relocate VAO handling in WebGLBackend

### DIFF
--- a/examples/jsm/renderers/webgl/WebGLBackend.js
+++ b/examples/jsm/renderers/webgl/WebGLBackend.js
@@ -287,7 +287,6 @@ class WebGLBackend extends Backend {
 		state.setMaterial( material );
 
 		gl.useProgram( programGPU );
-		gl.bindVertexArray( vaoGPU );
 		
 		//
 
@@ -654,66 +653,10 @@ class WebGLBackend extends Backend {
 
 		}
 
-		// VAO
-
-		const vaoGPU = gl.createVertexArray();
-
-		const index = renderObject.getIndex();
-		const attributes = renderObject.getAttributes();
-
-		gl.bindVertexArray( vaoGPU );
-
-		if ( index !== null ) {
-
-			const indexData = this.get( index );
-
-			gl.bindBuffer( gl.ELEMENT_ARRAY_BUFFER, indexData.bufferGPU );
-
-		}
-
-		for ( let i = 0; i < attributes.length; i ++ ) {
-
-			const attribute = attributes[ i ];
-			const attributeData = this.get( attribute );
-
-			gl.bindBuffer( gl.ARRAY_BUFFER, attributeData.bufferGPU );
-			gl.enableVertexAttribArray( i );
-
-			let stride, offset;
-
-			if ( attribute.isInterleavedBufferAttribute === true ) {
-
-				stride = attribute.data.stride * attributeData.bytesPerElement;
-				offset = attribute.offset * attributeData.bytesPerElement;
-
-			} else {
-
-				stride = 0;
-				offset = 0;
-
-			}
-
-			gl.vertexAttribPointer( i, attribute.itemSize, attributeData.type, false, stride, offset );
-
-			if ( attribute.isInstancedBufferAttribute && ! attribute.isInterleavedBufferAttribute ) {
-
-				gl.vertexAttribDivisor( i, attribute.meshPerAttribute );
-
-			} else if ( attribute.isInterleavedBufferAttribute && attribute.data.isInstancedInterleavedBuffer ) {
-
-				gl.vertexAttribDivisor( i, attribute.data.meshPerAttribute );
-
-			}
-
-		}
-
-		gl.bindVertexArray( null );
-
 		//
 
 		this.set( pipeline, {
-			programGPU,
-			vaoGPU
+			programGPU
 		} );
 
 	}

--- a/examples/jsm/renderers/webgl/WebGLBackend.js
+++ b/examples/jsm/renderers/webgl/WebGLBackend.js
@@ -54,8 +54,6 @@ class WebGLBackend extends Backend {
 
 		//
 
-		this._setFramebuffer( renderContext );
-
 		let clear = 0;
 
 		if ( renderContext.clearColor ) clear |= gl.COLOR_BUFFER_BIT;
@@ -64,26 +62,8 @@ class WebGLBackend extends Backend {
 
 		const clearColor = renderContext.clearColorValue;
 
-		if ( clear !== 0 ) {
-
-			if ( renderContext.textures === null ) {
-
-				gl.clearColor( clearColor.r, clearColor.g, clearColor.b, clearColor.a );
-				gl.clear( clear );
-
-			} else {
-
-				for ( let i = 0; i < renderContext.textures.length; i ++ ) {
-
-					gl.clearBufferfv( gl.COLOR, i, [ clearColor.r, clearColor.g, clearColor.b, clearColor.a ] );
-
-				}
-
-				gl.clearBufferfi( gl.DEPTH_STENCIL, 0, 1, 1 );
-
-			}
-
-		}
+		gl.clearColor( clearColor.x, clearColor.y, clearColor.z, clearColor.a );
+		gl.clear( clear );
 
 		//
 
@@ -97,111 +77,11 @@ class WebGLBackend extends Backend {
 
 		}
 
-		const occlusionQueryCount = renderContext.occlusionQueryCount;
-
-		if ( occlusionQueryCount > 0 ) {
-
-			const renderContextData = this.get( renderContext );
-
-			// Get a reference to the array of objects with queries. The renderContextData property
-			// can be changed by another render pass before the async reading of all previous queries complete
-			renderContextData.currentOcclusionQueries = renderContextData.occlusionQueries;
-			renderContextData.currentOcclusionQueryObjects = renderContextData.occlusionQueryObjects;
-
-			renderContextData.lastOcclusionObject = null;
-			renderContextData.occlusionQueries = new Array( occlusionQueryCount );
-			renderContextData.occlusionQueryObjects = new Array( occlusionQueryCount );
-			renderContextData.occlusionQueryIndex = 0;
-
-		}
-
 	}
 
-	finishRender( renderContext ) {
+	finishRender( /*renderContext*/ ) {
 
-		const occlusionQueryCount = renderContext.occlusionQueryCount;
-
-		if ( occlusionQueryCount > 0 ) {
-
-			const renderContextData = this.get( renderContext );
-
-			if ( occlusionQueryCount > renderContextData.occlusionQueryIndex ) {
-
-				const { gl } = this;
-
-				gl.endQuery( gl.ANY_SAMPLES_PASSED );
-
-			}
-
-			this.resolveOccludedAsync( renderContext );
-
-		}
-
-	}
-
-	resolveOccludedAsync( renderContext ) {
-
-		const renderContextData = this.get( renderContext );
-
-		// handle occlusion query results
-
-		const { currentOcclusionQueries, currentOcclusionQueryObjects } = renderContextData;
-
-		if ( currentOcclusionQueries && currentOcclusionQueryObjects ) {
-
-			const occluded = new WeakSet();
-			const { gl } = this;
-
-			renderContextData.currentOcclusionQueryObjects = null;
-			renderContextData.currentOcclusionQueries = null;
-
-			const check = () => {
-
-				let completed = 0;
-
-				// check all queries and requeue as appropriate
-				for ( let i = 0; i < currentOcclusionQueries.length; i ++ ) {
-
-					const query = currentOcclusionQueries[ i ];
-
-					if ( query === null ) continue;
-
-					if ( gl.getQueryParameter( query, gl.QUERY_RESULT_AVAILABLE ) ) {
-
-						if ( gl.getQueryParameter( query, gl.QUERY_RESULT ) > 0 ) occluded.add( currentOcclusionQueryObjects[ i ] );
-
-						currentOcclusionQueries[ i ] = null;
-						gl.deleteQuery( query );
-
-						completed ++;
-
-					}
-
-				}
-
-				if ( completed < currentOcclusionQueries.length ) {
-
-					requestAnimationFrame( check );
-
-				} else {
-
-					renderContextData.occluded = occluded;
-
-				}
-
-			}
-
-			check();
-
-		}
-
-	}
-
-	isOccluded( renderContext, object ) {
-
-		const renderContextData = this.get( renderContext );
-
-		return renderContextData.occluded && renderContextData.occluded.has( object );
+		//console.warn( 'Abstract class.' );
 
 	}
 
@@ -214,24 +94,9 @@ class WebGLBackend extends Backend {
 
 	}
 
-	clear( renderContext, color, depth, stencil ) {
+	clear( /*renderContext, color, depth, stencil*/ ) {
 
-		const { gl } = this;
-
-		//
-
-		let clear = 0;
-
-		if ( color ) clear |= gl.COLOR_BUFFER_BIT;
-		if ( depth ) clear |= gl.DEPTH_BUFFER_BIT;
-		if ( stencil ) clear |= gl.STENCIL_BUFFER_BIT;
-
-		const clearColor = renderContext.clearColorValue;
-
-		if ( clear === 0 ) return;
-
-		gl.clearColor( clearColor.x, clearColor.y, clearColor.z, clearColor.a );
-		gl.clear( clear );
+		console.warn( 'Abstract class.' );
 
 	}
 
@@ -255,12 +120,10 @@ class WebGLBackend extends Backend {
 
 	draw( renderObject, info ) {
 
-		const { pipeline, material, context } = renderObject;
-		const { programGPU, vaoGPU } = this.get( pipeline );
+		const { pipeline, material } = renderObject;
+		const { programGPU } = this.get( pipeline );
 
 		const { gl, state } = this;
-
-		const contextData = this.get( context );
 
 		//
 
@@ -287,7 +150,22 @@ class WebGLBackend extends Backend {
 		state.setMaterial( material );
 
 		gl.useProgram( programGPU );
+
+		//
+
+		let { vaoGPU } = this.get( renderObject );
+
+		if ( vaoGPU === undefined ) {
+
+			vaoGPU = this._createVAO( renderObject );
+
+			this.get( renderObject ).vaoGPU = vaoGPU;
+
+		}
+
+
 		gl.bindVertexArray( vaoGPU );
+
 
 		//
 
@@ -300,61 +178,23 @@ class WebGLBackend extends Backend {
 
 		//
 
-		const lastObject = contextData.lastOcclusionObject;
-
-		if ( lastObject !== object && lastObject !== undefined ) {
-
-			if ( lastObject !== null && lastObject.occlusionTest === true ) {
-
-				gl.endQuery( gl.ANY_SAMPLES_PASSED );
-
-				contextData.occlusionQueryIndex ++;
-
-			}
-
-			if ( object.occlusionTest === true ) {
-
-				const query = gl.createQuery();
-
-				gl.beginQuery( gl.ANY_SAMPLES_PASSED, query );
-
-				contextData.occlusionQueries[ contextData.occlusionQueryIndex ] = query;
-				contextData.occlusionQueryObjects[ contextData.occlusionQueryIndex ] = object;
-
-			}
-
-			contextData.lastOcclusionObject = object;
-
-		}
-
-		//
-
 		let mode;
 		if ( object.isPoints ) mode = gl.POINTS;
-		else if ( object.isLine ) mode = gl.LINE_STRIP;
+		else if ( object.isLine ) mode = gl.LINES;
 		else if ( object.isLineLoop ) mode = gl.LINE_LOOP;
 		else if ( object.isLineSegments ) mode = gl.LINES;
 		else mode = gl.TRIANGLES;
 
 		//
 
-		const instanceCount = this.getInstanceCount( renderObject );
 
 		if ( index !== null ) {
 
 			const indexData = this.get( index );
+
 			const indexCount = ( drawRange.count !== Infinity ) ? drawRange.count : index.count;
 
-			if ( instanceCount > 1 ) {
-
-				gl.drawElementsInstanced( mode, index.count, indexData.type, firstVertex, instanceCount );
-
-			} else {
-
-				gl.drawElements( mode, index.count, indexData.type, firstVertex );
-
-			}
-
+			gl.drawElements( mode, index.count, indexData.type, firstVertex );
 
 			info.update( object, indexCount, 1 );
 
@@ -363,16 +203,8 @@ class WebGLBackend extends Backend {
 			const positionAttribute = geometry.attributes.position;
 			const vertexCount = ( drawRange.count !== Infinity ) ? drawRange.count : positionAttribute.count;
 
-			if ( instanceCount > 1 ) {
 
-				gl.drawArraysInstanced( mode, 0, vertexCount, instanceCount );
-
-			} else {
-
-				gl.drawArrays( mode, 0, vertexCount );
-
-			}
-
+			gl.drawArrays( mode, 0, vertexCount );
 			//gl.drawArrays( mode, vertexCount, gl.UNSIGNED_SHORT, firstVertex );
 
 			info.update( object, vertexCount, 1 );
@@ -395,7 +227,7 @@ class WebGLBackend extends Backend {
 
 	getCacheKey( renderObject ) {
 
-		return renderObject.geometry.id;
+		return '';
 
 	}
 
@@ -465,12 +297,7 @@ class WebGLBackend extends Backend {
 		textureUtils.setTextureParameters( glTextureType, texture );
 
 		gl.bindTexture( glTextureType, textureGPU );
-
-		if ( ! texture.isVideoTexture ) {
-
-			gl.texStorage2D( glTextureType, levels, glInternalFormat, width, height );
-
-		}
+		gl.texStorage2D( glTextureType, levels, glInternalFormat, width, height );
 
 		this.set( texture, {
 			textureGPU,
@@ -486,7 +313,7 @@ class WebGLBackend extends Backend {
 
 		const { gl } = this;
 		const { width, height } = options;
-		const { textureGPU, glTextureType, glFormat, glType, glInternalFormat } = this.get( texture );
+		const { textureGPU, glTextureType, glFormat, glType } = this.get( texture );
 
 		const getImage = ( source ) => {
 
@@ -494,13 +321,9 @@ class WebGLBackend extends Backend {
 
 				return source.image.data;
 
-			} else if ( source instanceof ImageBitmap || source instanceof OffscreenCanvas ) {
-
-				return source;
-
 			}
 
-			return source.data;
+			return source;
 
 		};
 
@@ -517,13 +340,6 @@ class WebGLBackend extends Backend {
 				gl.texSubImage2D( gl.TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, 0, 0, width, height, glFormat, glType, image );
 
 			}
-
-		} else if ( texture.isVideoTexture ) {
-
-			texture.update();
-
-			gl.texImage2D( glTextureType, 0, glInternalFormat, glFormat, glType, options.image );
-
 
 		} else {
 
@@ -640,66 +456,10 @@ class WebGLBackend extends Backend {
 
 		}
 
-		// VAO
-
-		const vaoGPU = gl.createVertexArray();
-
-		const index = renderObject.getIndex();
-		const attributes = renderObject.getAttributes();
-
-		gl.bindVertexArray( vaoGPU );
-
-		if ( index !== null ) {
-
-			const indexData = this.get( index );
-
-			gl.bindBuffer( gl.ELEMENT_ARRAY_BUFFER, indexData.bufferGPU );
-
-		}
-
-		for ( let i = 0; i < attributes.length; i ++ ) {
-
-			const attribute = attributes[ i ];
-			const attributeData = this.get( attribute );
-
-			gl.bindBuffer( gl.ARRAY_BUFFER, attributeData.bufferGPU );
-			gl.enableVertexAttribArray( i );
-
-			let stride, offset;
-
-			if ( attribute.isInterleavedBufferAttribute === true ) {
-
-				stride = attribute.data.stride * attributeData.bytesPerElement;
-				offset = attribute.offset * attributeData.bytesPerElement;
-
-			} else {
-
-				stride = 0;
-				offset = 0;
-
-			}
-
-			gl.vertexAttribPointer( i, attribute.itemSize, attributeData.type, false, stride, offset );
-
-			if ( attribute.isInstancedBufferAttribute && ! attribute.isInterleavedBufferAttribute ) {
-
-				gl.vertexAttribDivisor( i, attribute.meshPerAttribute );
-
-			} else if ( attribute.isInterleavedBufferAttribute && attribute.data.isInstancedInterleavedBuffer ) {
-
-				gl.vertexAttribDivisor( i, attribute.data.meshPerAttribute );
-
-			}
-
-		}
-
-		gl.bindVertexArray( null );
-
 		//
 
 		this.set( pipeline, {
-			programGPU,
-			vaoGPU
+			programGPU
 		} );
 
 	}
@@ -796,9 +556,9 @@ class WebGLBackend extends Backend {
 
 	}
 
-	updateAttribute( attribute ) {
+	updateAttribute( /*attribute*/ ) {
 
-		this.attributeUtils.updateAttribute( attribute );
+		console.warn( 'Abstract class.' );
 
 	}
 
@@ -826,62 +586,64 @@ class WebGLBackend extends Backend {
 
 	}
 
-	_setFramebuffer( renderContext ) {
+	_createVAO( renderObject ) {
 
 		const { gl } = this;
 
-		if ( renderContext.textures !== null ) {
+		const vaoGPU = gl.createVertexArray();
 
-			const renderContextData = this.get( renderContext );
+		const index = renderObject.getIndex();
+		const attributes = renderObject.getAttributes();
 
-			let fb = renderContextData.framebuffer;
+		gl.bindVertexArray( vaoGPU );
 
-			if ( fb === undefined ) {
+		if ( index !== null ) {
 
-				fb = gl.createFramebuffer();
+			const indexData = this.get( index );
 
-				gl.bindFramebuffer( gl.FRAMEBUFFER, fb );
+			gl.bindBuffer( gl.ELEMENT_ARRAY_BUFFER, indexData.bufferGPU );
 
-				const textures = renderContext.textures;
+		}
 
-				const drawBuffers = [];
+		for ( let i = 0; i < attributes.length; i ++ ) {
 
-				for ( let i = 0; i < textures.length; i++ ) {
+			const attribute = attributes[ i ];
+			const attributeData = this.get( attribute );
 
-					const texture = textures[ i ];
-					const { textureGPU } = this.get( texture );
+			gl.bindBuffer( gl.ARRAY_BUFFER, attributeData.bufferGPU );
+			gl.enableVertexAttribArray( i );
 
-					const attachment = gl.COLOR_ATTACHMENT0 + i;
+			let stride, offset;
 
-					gl.framebufferTexture2D( gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0 + i, gl.TEXTURE_2D, textureGPU, 0 );
+			if ( attribute.isInterleavedBufferAttribute === true ) {
 
-					drawBuffers.push( attachment );
-
-				}
-
-				gl.drawBuffers( drawBuffers );
-
-				if ( renderContext.depthTexture !== null ) {
-
-					const { textureGPU } = this.get( renderContext.depthTexture );
-
-					gl.framebufferTexture2D( gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.TEXTURE_2D, textureGPU, 0 );
-
-				}
-
-				renderContextData.framebuffer = fb;
+				stride = attribute.data.stride * attributeData.bytesPerElement;
+				offset = attribute.offset * attributeData.bytesPerElement;
 
 			} else {
 
-				gl.bindFramebuffer( gl.FRAMEBUFFER, fb );
+				stride = 0;
+				offset = 0;
 
 			}
 
-		} else {
+			gl.vertexAttribPointer( i, attribute.itemSize, attributeData.type, false, stride, offset );
 
-			gl.bindFramebuffer( gl.FRAMEBUFFER, null );
+			if ( attribute.isInstancedBufferAttribute && ! attribute.isInterleavedBufferAttribute ) {
+
+				gl.vertexAttribDivisor( i, attribute.meshPerAttribute );
+
+			} else if ( attribute.isInterleavedBufferAttribute && attribute.data.isInstancedInterleavedBuffer ) {
+
+				gl.vertexAttribDivisor( i, attribute.data.meshPerAttribute );
+
+			}
 
 		}
+
+		gl.bindVertexArray( null );
+
+		return vaoGPU;
 
 	}
 


### PR DESCRIPTION
Associating the VAO with the WebGL pipeline causes the wrong attributes to be used in a draw call when materials are shared. 

A previous PR added geometry id as an element to the pipeline cache but that has the side effect of excessive shader program compilations etc.

Move the VAO creation into a separate method and cache against the renderObject. This aligns more with the WebGPU backend.

With the previous PR enabling video textures this enables the example 'material / video' to work correctly with the WebGL backend 
