### PR TITLE
Shaders: Remove struct GeometricContext to improve Adreno GPU support.

### DIFF
--- a/examples/jsm/csm/CSMShader.js
+++ b/examples/jsm/csm/CSMShader.js
@@ -2,20 +2,20 @@ import { ShaderChunk } from 'three';
 
 const CSMShader = {
 	lights_fragment_begin: /* glsl */`
-GeometricContext geometry;
+vec3 geometryPosition = - vViewPosition;
+vec3 geometryNormal = normal;
+vec3 geometryViewDir = ( isOrthographic ) ? vec3( 0, 0, 1 ) : normalize( vViewPosition );
 
-geometry.position = - vViewPosition;
-geometry.normal = normal;
-geometry.viewDir = ( isOrthographic ) ? vec3( 0, 0, 1 ) : normalize( vViewPosition );
+vec3 geometryClearcoatNormal;
 
 #ifdef USE_CLEARCOAT
 
-	geometry.clearcoatNormal = clearcoatNormal;
+	geometryClearcoatNormal = clearcoatNormal;
 
 #endif
 
 #ifdef USE_IRIDESCENCE
-	float dotNVi = saturate( dot( normal, geometry.viewDir ) );
+	float dotNVi = saturate( dot( normal, geometryViewDir ) );
 	if ( material.iridescenceThickness == 0.0 ) {
 		material.iridescence = 0.0;
 	} else {
@@ -42,14 +42,14 @@ IncidentLight directLight;
 
 		pointLight = pointLights[ i ];
 
-		getPointLightInfo( pointLight, geometry, directLight );
+		getPointLightInfo( pointLight, geometryPosition, directLight );
 
 		#if defined( USE_SHADOWMAP ) && ( UNROLLED_LOOP_INDEX < NUM_POINT_LIGHT_SHADOWS )
 		pointLightShadow = pointLightShadows[ i ];
 		directLight.color *= ( directLight.visible && receiveShadow ) ? getPointShadow( pointShadowMap[ i ], pointLightShadow.shadowMapSize, pointLightShadow.shadowBias, pointLightShadow.shadowRadius, vPointShadowCoord[ i ], pointLightShadow.shadowCameraNear, pointLightShadow.shadowCameraFar ) : 1.0;
 		#endif
 
-		RE_Direct( directLight, geometry, material, reflectedLight );
+		RE_Direct( directLight, geometryPosition, geometryNormal, geometryViewDir, geometryClearcoatNormal, material, reflectedLight );
 
 	}
 	#pragma unroll_loop_end
@@ -72,7 +72,7 @@ IncidentLight directLight;
 
 		spotLight = spotLights[ i ];
 
-		getSpotLightInfo( spotLight, geometry, directLight );
+		getSpotLightInfo( spotLight, geometryPosition, directLight );
 
   		// spot lights are ordered [shadows with maps, shadows without maps, maps without shadows, none]
 		#if ( UNROLLED_LOOP_INDEX < NUM_SPOT_LIGHT_SHADOWS_WITH_MAPS )
@@ -96,7 +96,7 @@ IncidentLight directLight;
 
 		#endif
 
-		RE_Direct( directLight, geometry, material, reflectedLight );
+		RE_Direct( directLight, geometryPosition, geometryNormal, geometryViewDir, geometryClearcoatNormal, material, reflectedLight );
 
 	}
 	#pragma unroll_loop_end
@@ -123,7 +123,7 @@ IncidentLight directLight;
 	for ( int i = 0; i < NUM_DIR_LIGHTS; i ++ ) {
 
 		directionalLight = directionalLights[ i ];
-		getDirectionalLightInfo( directionalLight, geometry, directLight );
+		getDirectionalLightInfo( directionalLight, directLight );
 
 	  	#if defined( USE_SHADOWMAP ) && ( UNROLLED_LOOP_INDEX < NUM_DIR_LIGHT_SHADOWS )
 			// NOTE: Depth gets larger away from the camera.
@@ -147,7 +147,7 @@ IncidentLight directLight;
 				directLight.color = mix( prevColor, directLight.color, shouldFadeLastCascade ? ratio : 1.0 );
 
 				ReflectedLight prevLight = reflectedLight;
-				RE_Direct( directLight, geometry, material, reflectedLight );
+				RE_Direct( directLight, geometryPosition, geometryNormal, geometryViewDir, geometryClearcoatNormal, material, reflectedLight );
 
 				bool shouldBlend = UNROLLED_LOOP_INDEX != CSM_CASCADES - 1 || UNROLLED_LOOP_INDEX == CSM_CASCADES - 1 && linearDepth < cascadeCenter;
 				float blendRatio = shouldBlend ? ratio : 1.0;
@@ -168,14 +168,14 @@ IncidentLight directLight;
 		for ( int i = 0; i < NUM_DIR_LIGHTS; i ++ ) {
 
 			directionalLight = directionalLights[ i ];
-			getDirectionalLightInfo( directionalLight, geometry, directLight );
+			getDirectionalLightInfo( directionalLight, directLight );
 
 			#if defined( USE_SHADOWMAP ) && ( UNROLLED_LOOP_INDEX < NUM_DIR_LIGHT_SHADOWS )
 
 			directionalLightShadow = directionalLightShadows[ i ];
 			if(linearDepth >= CSM_cascades[UNROLLED_LOOP_INDEX].x && linearDepth < CSM_cascades[UNROLLED_LOOP_INDEX].y) directLight.color *= ( directLight.visible && receiveShadow ) ? getShadow( directionalShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowBias, directionalLightShadow.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;
 
-			if(linearDepth >= CSM_cascades[UNROLLED_LOOP_INDEX].x && (linearDepth < CSM_cascades[UNROLLED_LOOP_INDEX].y || UNROLLED_LOOP_INDEX == CSM_CASCADES - 1)) RE_Direct( directLight, geometry, material, reflectedLight );
+			if(linearDepth >= CSM_cascades[UNROLLED_LOOP_INDEX].x && (linearDepth < CSM_cascades[UNROLLED_LOOP_INDEX].y || UNROLLED_LOOP_INDEX == CSM_CASCADES - 1)) RE_Direct( directLight, geometryPosition, geometryNormal, geometryViewDir, geometryClearcoatNormal, material, reflectedLight );
 
 			#endif
 
@@ -192,9 +192,9 @@ IncidentLight directLight;
 
 			directionalLight = directionalLights[ i ];
 
-			getDirectionalLightInfo( directionalLight, geometry, directLight );
+			getDirectionalLightInfo( directionalLight, directLight );
 
-			RE_Direct( directLight, geometry, material, reflectedLight );
+			RE_Direct( directLight, geometryPosition, geometryNormal, geometryViewDir, geometryClearcoatNormal, material, reflectedLight );
 
 		}
 		#pragma unroll_loop_end
@@ -216,14 +216,14 @@ IncidentLight directLight;
 
 		directionalLight = directionalLights[ i ];
 
-		getDirectionalLightInfo( directionalLight, geometry, directLight );
+		getDirectionalLightInfo( directionalLight, directLight );
 
 		#if defined( USE_SHADOWMAP ) && ( UNROLLED_LOOP_INDEX < NUM_DIR_LIGHT_SHADOWS )
 		directionalLightShadow = directionalLightShadows[ i ];
 		directLight.color *= ( directLight.visible && receiveShadow ) ? getShadow( directionalShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowBias, directionalLightShadow.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;
 		#endif
 
-		RE_Direct( directLight, geometry, material, reflectedLight );
+		RE_Direct( directLight, geometryPosition, geometryNormal, geometryViewDir, geometryClearcoatNormal, material, reflectedLight );
 
 	}
 	#pragma unroll_loop_end
@@ -238,7 +238,7 @@ IncidentLight directLight;
 	for ( int i = 0; i < NUM_RECT_AREA_LIGHTS; i ++ ) {
 
 		rectAreaLight = rectAreaLights[ i ];
-		RE_Direct_RectArea( rectAreaLight, geometry, material, reflectedLight );
+		RE_Direct_RectArea( rectAreaLight, geometryPosition, geometryNormal, geometryViewDir, geometryClearcoatNormal, material, reflectedLight );
 
 	}
 	#pragma unroll_loop_end
@@ -253,7 +253,7 @@ IncidentLight directLight;
 
 	#if defined( USE_LIGHT_PROBES )
 
-		irradiance += getLightProbeIrradiance( lightProbe, geometry.normal );
+		irradiance += getLightProbeIrradiance( lightProbe, geometryNormal );
 
 	#endif
 
@@ -262,7 +262,7 @@ IncidentLight directLight;
 		#pragma unroll_loop_start
 		for ( int i = 0; i < NUM_HEMI_LIGHTS; i ++ ) {
 
-			irradiance += getHemisphereLightIrradiance( hemisphereLights[ i ], geometry.normal );
+			irradiance += getHemisphereLightIrradiance( hemisphereLights[ i ], geometryNormal );
 
 		}
 		#pragma unroll_loop_end

--- a/examples/jsm/materials/MeshGouraudMaterial.js
+++ b/examples/jsm/materials/MeshGouraudMaterial.js
@@ -74,15 +74,11 @@ const GouraudShader = {
 
 			vec3 diffuse = vec3( 1.0 );
 
-			GeometricContext geometry;
-			geometry.position = mvPosition.xyz;
-			geometry.normal = normalize( transformedNormal );
-			geometry.viewDir = ( isOrthographic ) ? vec3( 0, 0, 1 ) : normalize( -mvPosition.xyz );
+			vec3 geometryPosition = mvPosition.xyz;
+			vec3 geometryNormal = normalize( transformedNormal );
+			vec3 geometryViewDir = ( isOrthographic ) ? vec3( 0, 0, 1 ) : normalize( -mvPosition.xyz );
 
-			GeometricContext backGeometry;
-			backGeometry.position = geometry.position;
-			backGeometry.normal = -geometry.normal;
-			backGeometry.viewDir = geometry.viewDir;
+			vec3 backGeometryNormal = - geometryNormal;
 
 			vLightFront = vec3( 0.0 );
 			vIndirectFront = vec3( 0.0 );
@@ -99,7 +95,7 @@ const GouraudShader = {
 
 			#if defined( USE_LIGHT_PROBES )
 
-				vIndirectFront += getLightProbeIrradiance( lightProbe, geometry.normal );
+				vIndirectFront += getLightProbeIrradiance( lightProbe, geometryNormal );
 
 			#endif
 
@@ -109,7 +105,7 @@ const GouraudShader = {
 
 				#if defined( USE_LIGHT_PROBES )
 
-					vIndirectBack += getLightProbeIrradiance( lightProbe, backGeometry.normal );
+					vIndirectBack += getLightProbeIrradiance( lightProbe, backGeometryNormal );
 
 				#endif
 
@@ -120,9 +116,9 @@ const GouraudShader = {
 				#pragma unroll_loop_start
 				for ( int i = 0; i < NUM_POINT_LIGHTS; i ++ ) {
 
-					getPointLightInfo( pointLights[ i ], geometry, directLight );
+					getPointLightInfo( pointLights[ i ], geometryPosition, directLight );
 
-					dotNL = dot( geometry.normal, directLight.direction );
+					dotNL = dot( geometryNormal, directLight.direction );
 					directLightColor_Diffuse = directLight.color;
 
 					vLightFront += saturate( dotNL ) * directLightColor_Diffuse;
@@ -143,9 +139,9 @@ const GouraudShader = {
 				#pragma unroll_loop_start
 				for ( int i = 0; i < NUM_SPOT_LIGHTS; i ++ ) {
 
-					getSpotLightInfo( spotLights[ i ], geometry, directLight );
+					getSpotLightInfo( spotLights[ i ], geometryPosition, directLight );
 
-					dotNL = dot( geometry.normal, directLight.direction );
+					dotNL = dot( geometryNormal, directLight.direction );
 					directLightColor_Diffuse = directLight.color;
 
 					vLightFront += saturate( dotNL ) * directLightColor_Diffuse;
@@ -165,9 +161,9 @@ const GouraudShader = {
 				#pragma unroll_loop_start
 				for ( int i = 0; i < NUM_DIR_LIGHTS; i ++ ) {
 
-					getDirectionalLightInfo( directionalLights[ i ], geometry, directLight );
+					getDirectionalLightInfo( directionalLights[ i ], directLight );
 
-					dotNL = dot( geometry.normal, directLight.direction );
+					dotNL = dot( geometryNormal, directLight.direction );
 					directLightColor_Diffuse = directLight.color;
 
 					vLightFront += saturate( dotNL ) * directLightColor_Diffuse;
@@ -188,11 +184,11 @@ const GouraudShader = {
 				#pragma unroll_loop_start
 				for ( int i = 0; i < NUM_HEMI_LIGHTS; i ++ ) {
 
-					vIndirectFront += getHemisphereLightIrradiance( hemisphereLights[ i ], geometry.normal );
+					vIndirectFront += getHemisphereLightIrradiance( hemisphereLights[ i ], geometryNormal );
 
 					#ifdef DOUBLE_SIDED
 
-						vIndirectBack += getHemisphereLightIrradiance( hemisphereLights[ i ], backGeometry.normal );
+						vIndirectBack += getHemisphereLightIrradiance( hemisphereLights[ i ], backGeometryNormal );
 
 					#endif
 

--- a/examples/jsm/renderers/webgl-legacy/nodes/WebGLNodeBuilder.js
+++ b/examples/jsm/renderers/webgl-legacy/nodes/WebGLNodeBuilder.js
@@ -220,7 +220,7 @@ class WebGLNodeBuilder extends NodeBuilder {
 						this.addSlot( 'fragment', new SlotNode( {
 							node: material.clearcoatNormalNode,
 							nodeType: 'vec3',
-							source: 'vec3 clearcoatNormal = geometryNormal;',
+							source: 'vec3 clearcoatNormal = nonPerturbedNormal;',
 							target: 'vec3 clearcoatNormal = %RESULT%;'
 						} ) );
 

--- a/examples/jsm/shaders/MMDToonShader.js
+++ b/examples/jsm/shaders/MMDToonShader.js
@@ -27,17 +27,17 @@ struct BlinnPhongMaterial {
 
 };
 
-void RE_Direct_BlinnPhong( const in IncidentLight directLight, const in GeometricContext geometry, const in BlinnPhongMaterial material, inout ReflectedLight reflectedLight ) {
+void RE_Direct_BlinnPhong( const in IncidentLight directLight, const in vec3 geometryPosition, const in vec3 geometryNormal, const in vec3 geometryViewDir, const in vec3 geometryClearcoatNormal, const in BlinnPhongMaterial material, inout ReflectedLight reflectedLight ) {
 
-	vec3 irradiance = getGradientIrradiance( geometry.normal, directLight.direction ) * directLight.color;
+	vec3 irradiance = getGradientIrradiance( geometryNormal, directLight.direction ) * directLight.color;
 
 	reflectedLight.directDiffuse += irradiance * BRDF_Lambert( material.diffuseColor );
 
-	reflectedLight.directSpecular += irradiance * BRDF_BlinnPhong( directLight.direction, geometry.viewDir, geometry.normal, material.specularColor, material.specularShininess ) * material.specularStrength;
+	reflectedLight.directSpecular += irradiance * BRDF_BlinnPhong( directLight.direction, geometryViewDir, geometryNormal, material.specularColor, material.specularShininess ) * material.specularStrength;
 
 }
 
-void RE_IndirectDiffuse_BlinnPhong( const in vec3 irradiance, const in GeometricContext geometry, const in BlinnPhongMaterial material, inout ReflectedLight reflectedLight ) {
+void RE_IndirectDiffuse_BlinnPhong( const in vec3 irradiance, const in vec3 geometryPosition, const in vec3 geometryNormal, const in vec3 geometryViewDir, const in vec3 geometryClearcoatNormal, const in BlinnPhongMaterial material, inout ReflectedLight reflectedLight ) {
 
 	reflectedLight.indirectDiffuse += irradiance * BRDF_Lambert( material.diffuseColor );
 

--- a/examples/jsm/shaders/SubsurfaceScatteringShader.js
+++ b/examples/jsm/shaders/SubsurfaceScatteringShader.js
@@ -57,10 +57,10 @@ const SubsurfaceScatteringShader = {
 		'uniform float thicknessAttenuation;',
 		'uniform vec3 thicknessColor;',
 
-		'void RE_Direct_Scattering(const in IncidentLight directLight, const in vec2 uv, const in GeometricContext geometry, inout ReflectedLight reflectedLight) {',
+		'void RE_Direct_Scattering(const in IncidentLight directLight, const in vec2 uv, const in vec3 geometryPosition, const in vec3 geometryNormal, const in vec3 geometryViewDir, const in vec3 geometryClearcoatNormal, inout ReflectedLight reflectedLight) {',
 		'	vec3 thickness = thicknessColor * texture2D(thicknessMap, uv).r;',
-		'	vec3 scatteringHalf = normalize(directLight.direction + (geometry.normal * thicknessDistortion));',
-		'	float scatteringDot = pow(saturate(dot(geometry.viewDir, -scatteringHalf)), thicknessPower) * thicknessScale;',
+		'	vec3 scatteringHalf = normalize(directLight.direction + (geometryNormal * thicknessDistortion));',
+		'	float scatteringDot = pow(saturate(dot(geometryViewDir, -scatteringHalf)), thicknessPower) * thicknessScale;',
 		'	vec3 scatteringIllu = (scatteringDot + thicknessAmbient) * thickness;',
 		'	reflectedLight.directDiffuse += scatteringIllu * thicknessAttenuation * directLight.color;',
 		'}',
@@ -69,12 +69,12 @@ const SubsurfaceScatteringShader = {
 
 			replaceAll(
 				ShaderChunk[ 'lights_fragment_begin' ],
-				'RE_Direct( directLight, geometry, material, reflectedLight );',
+				'RE_Direct( directLight, geometryPosition, geometryNormal, geometryViewDir, geometryClearcoatNormal, material, reflectedLight );',
 				[
-					'RE_Direct( directLight, geometry, material, reflectedLight );',
+					'RE_Direct( directLight, geometryPosition, geometryNormal, geometryViewDir, geometryClearcoatNormal, material, reflectedLight );',
 
 					'#if defined( SUBSURFACE ) && defined( USE_UV )',
-					' RE_Direct_Scattering(directLight, vUv, geometry, reflectedLight);',
+					' RE_Direct_Scattering(directLight, vUv, geometryPosition, geometryNormal, geometryViewDir, geometryClearcoatNormal, reflectedLight);',
 					'#endif',
 				].join( '\n' )
 			),

--- a/src/renderers/shaders/ShaderChunk/aomap_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/aomap_fragment.glsl.js
@@ -8,7 +8,7 @@ export default /* glsl */`
 
 	#if defined( USE_ENVMAP ) && defined( STANDARD )
 
-		float dotNV = saturate( dot( geometry.normal, geometry.viewDir ) );
+		float dotNV = saturate( dot( geometryNormal, geometryViewDir ) );
 
 		reflectedLight.indirectSpecular *= computeSpecularOcclusion( dotNV, ambientOcclusion, material.roughness );
 

--- a/src/renderers/shaders/ShaderChunk/clearcoat_normal_fragment_begin.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/clearcoat_normal_fragment_begin.glsl.js
@@ -1,7 +1,7 @@
 export default /* glsl */`
 #ifdef USE_CLEARCOAT
 
-	vec3 clearcoatNormal = geometryNormal;
+	vec3 clearcoatNormal = nonPerturbedNormal;
 
 #endif
 `;

--- a/src/renderers/shaders/ShaderChunk/common.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/common.glsl.js
@@ -52,15 +52,6 @@ struct ReflectedLight {
 	vec3 indirectSpecular;
 };
 
-struct GeometricContext {
-	vec3 position;
-	vec3 normal;
-	vec3 viewDir;
-#ifdef USE_CLEARCOAT
-	vec3 clearcoatNormal;
-#endif
-};
-
 #ifdef USE_ALPHAHASH
 
 	varying vec3 vPosition;

--- a/src/renderers/shaders/ShaderChunk/lights_fragment_begin.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_fragment_begin.glsl.js
@@ -13,21 +13,21 @@ export default /* glsl */`
  * - Add diffuse light probe (irradiance cubemap) support.
  */
 
-GeometricContext geometry;
+vec3 geometryPosition = - vViewPosition;
+vec3 geometryNormal = normal;
+vec3 geometryViewDir = ( isOrthographic ) ? vec3( 0, 0, 1 ) : normalize( vViewPosition );
 
-geometry.position = - vViewPosition;
-geometry.normal = normal;
-geometry.viewDir = ( isOrthographic ) ? vec3( 0, 0, 1 ) : normalize( vViewPosition );
+vec3 geometryClearcoatNormal;
 
 #ifdef USE_CLEARCOAT
 
-	geometry.clearcoatNormal = clearcoatNormal;
+	geometryClearcoatNormal = clearcoatNormal;
 
 #endif
 
 #ifdef USE_IRIDESCENCE
 
-	float dotNVi = saturate( dot( normal, geometry.viewDir ) );
+	float dotNVi = saturate( dot( normal, geometryViewDir ) );
 
 	if ( material.iridescenceThickness == 0.0 ) {
 
@@ -64,14 +64,14 @@ IncidentLight directLight;
 
 		pointLight = pointLights[ i ];
 
-		getPointLightInfo( pointLight, geometry, directLight );
+		getPointLightInfo( pointLight, geometryPosition, directLight );
 
 		#if defined( USE_SHADOWMAP ) && ( UNROLLED_LOOP_INDEX < NUM_POINT_LIGHT_SHADOWS )
 		pointLightShadow = pointLightShadows[ i ];
 		directLight.color *= ( directLight.visible && receiveShadow ) ? getPointShadow( pointShadowMap[ i ], pointLightShadow.shadowMapSize, pointLightShadow.shadowBias, pointLightShadow.shadowRadius, vPointShadowCoord[ i ], pointLightShadow.shadowCameraNear, pointLightShadow.shadowCameraFar ) : 1.0;
 		#endif
 
-		RE_Direct( directLight, geometry, material, reflectedLight );
+		RE_Direct( directLight, geometryPosition, geometryNormal, geometryViewDir, geometryClearcoatNormal, material, reflectedLight );
 
 	}
 	#pragma unroll_loop_end
@@ -94,7 +94,7 @@ IncidentLight directLight;
 
 		spotLight = spotLights[ i ];
 
-		getSpotLightInfo( spotLight, geometry, directLight );
+		getSpotLightInfo( spotLight, geometryPosition, directLight );
 
 		// spot lights are ordered [shadows with maps, shadows without maps, maps without shadows, none]
 		#if ( UNROLLED_LOOP_INDEX < NUM_SPOT_LIGHT_SHADOWS_WITH_MAPS )
@@ -119,7 +119,7 @@ IncidentLight directLight;
 		directLight.color *= ( directLight.visible && receiveShadow ) ? getShadow( spotShadowMap[ i ], spotLightShadow.shadowMapSize, spotLightShadow.shadowBias, spotLightShadow.shadowRadius, vSpotLightCoord[ i ] ) : 1.0;
 		#endif
 
-		RE_Direct( directLight, geometry, material, reflectedLight );
+		RE_Direct( directLight, geometryPosition, geometryNormal, geometryViewDir, geometryClearcoatNormal, material, reflectedLight );
 
 	}
 	#pragma unroll_loop_end
@@ -138,14 +138,14 @@ IncidentLight directLight;
 
 		directionalLight = directionalLights[ i ];
 
-		getDirectionalLightInfo( directionalLight, geometry, directLight );
+		getDirectionalLightInfo( directionalLight, directLight );
 
 		#if defined( USE_SHADOWMAP ) && ( UNROLLED_LOOP_INDEX < NUM_DIR_LIGHT_SHADOWS )
 		directionalLightShadow = directionalLightShadows[ i ];
 		directLight.color *= ( directLight.visible && receiveShadow ) ? getShadow( directionalShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowBias, directionalLightShadow.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;
 		#endif
 
-		RE_Direct( directLight, geometry, material, reflectedLight );
+		RE_Direct( directLight, geometryPosition, geometryNormal, geometryViewDir, geometryClearcoatNormal, material, reflectedLight );
 
 	}
 	#pragma unroll_loop_end
@@ -160,7 +160,7 @@ IncidentLight directLight;
 	for ( int i = 0; i < NUM_RECT_AREA_LIGHTS; i ++ ) {
 
 		rectAreaLight = rectAreaLights[ i ];
-		RE_Direct_RectArea( rectAreaLight, geometry, material, reflectedLight );
+		RE_Direct_RectArea( rectAreaLight, geometryPosition, geometryNormal, geometryViewDir, geometryClearcoatNormal, material, reflectedLight );
 
 	}
 	#pragma unroll_loop_end
@@ -175,7 +175,7 @@ IncidentLight directLight;
 
 	#if defined( USE_LIGHT_PROBES )
 
-		irradiance += getLightProbeIrradiance( lightProbe, geometry.normal );
+		irradiance += getLightProbeIrradiance( lightProbe, geometryNormal );
 
 	#endif
 
@@ -184,7 +184,7 @@ IncidentLight directLight;
 		#pragma unroll_loop_start
 		for ( int i = 0; i < NUM_HEMI_LIGHTS; i ++ ) {
 
-			irradiance += getHemisphereLightIrradiance( hemisphereLights[ i ], geometry.normal );
+			irradiance += getHemisphereLightIrradiance( hemisphereLights[ i ], geometryNormal );
 
 		}
 		#pragma unroll_loop_end

--- a/src/renderers/shaders/ShaderChunk/lights_fragment_end.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_fragment_end.glsl.js
@@ -1,13 +1,13 @@
 export default /* glsl */`
 #if defined( RE_IndirectDiffuse )
 
-	RE_IndirectDiffuse( irradiance, geometry, material, reflectedLight );
+	RE_IndirectDiffuse( irradiance, geometryPosition, geometryNormal, geometryViewDir, geometryClearcoatNormal, material, reflectedLight );
 
 #endif
 
 #if defined( RE_IndirectSpecular )
 
-	RE_IndirectSpecular( radiance, iblIrradiance, clearcoatRadiance, geometry, material, reflectedLight );
+	RE_IndirectSpecular( radiance, iblIrradiance, clearcoatRadiance, geometryPosition, geometryNormal, geometryViewDir, geometryClearcoatNormal, material, reflectedLight );
 
 #endif
 `;

--- a/src/renderers/shaders/ShaderChunk/lights_fragment_maps.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_fragment_maps.glsl.js
@@ -12,7 +12,7 @@ export default /* glsl */`
 
 	#if defined( USE_ENVMAP ) && defined( STANDARD ) && defined( ENVMAP_TYPE_CUBE_UV )
 
-		iblIrradiance += getIBLIrradiance( geometry.normal );
+		iblIrradiance += getIBLIrradiance( geometryNormal );
 
 	#endif
 
@@ -22,17 +22,17 @@ export default /* glsl */`
 
 	#ifdef USE_ANISOTROPY
 
-		radiance += getIBLAnisotropyRadiance( geometry.viewDir, geometry.normal, material.roughness, material.anisotropyB, material.anisotropy );
+		radiance += getIBLAnisotropyRadiance( geometryViewDir, geometryNormal, material.roughness, material.anisotropyB, material.anisotropy );
 
 	#else
 
-		radiance += getIBLRadiance( geometry.viewDir, geometry.normal, material.roughness );
+		radiance += getIBLRadiance( geometryViewDir, geometryNormal, material.roughness );
 
 	#endif
 
 	#ifdef USE_CLEARCOAT
 
-		clearcoatRadiance += getIBLRadiance( geometry.viewDir, geometry.clearcoatNormal, material.clearcoatRoughness );
+		clearcoatRadiance += getIBLRadiance( geometryViewDir, geometryClearcoatNormal, material.clearcoatRoughness );
 
 	#endif
 

--- a/src/renderers/shaders/ShaderChunk/lights_lambert_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_lambert_pars_fragment.glsl.js
@@ -8,16 +8,16 @@ struct LambertMaterial {
 
 };
 
-void RE_Direct_Lambert( const in IncidentLight directLight, const in GeometricContext geometry, const in LambertMaterial material, inout ReflectedLight reflectedLight ) {
+void RE_Direct_Lambert( const in IncidentLight directLight, const in vec3 geometryPosition, const in vec3 geometryNormal, const in vec3 geometryViewDir, const in vec3 geometryClearcoatNormal, const in LambertMaterial material, inout ReflectedLight reflectedLight ) {
 
-	float dotNL = saturate( dot( geometry.normal, directLight.direction ) );
+	float dotNL = saturate( dot( geometryNormal, directLight.direction ) );
 	vec3 irradiance = dotNL * directLight.color;
 
 	reflectedLight.directDiffuse += irradiance * BRDF_Lambert( material.diffuseColor );
 
 }
 
-void RE_IndirectDiffuse_Lambert( const in vec3 irradiance, const in GeometricContext geometry, const in LambertMaterial material, inout ReflectedLight reflectedLight ) {
+void RE_IndirectDiffuse_Lambert( const in vec3 irradiance, const in vec3 geometryPosition, const in vec3 geometryNormal, const in vec3 geometryViewDir, const in vec3 geometryClearcoatNormal, const in LambertMaterial material, inout ReflectedLight reflectedLight ) {
 
 	reflectedLight.indirectDiffuse += irradiance * BRDF_Lambert( material.diffuseColor );
 

--- a/src/renderers/shaders/ShaderChunk/lights_pars_begin.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_pars_begin.glsl.js
@@ -99,7 +99,7 @@ float getSpotAttenuation( const in float coneCosine, const in float penumbraCosi
 
 	uniform DirectionalLight directionalLights[ NUM_DIR_LIGHTS ];
 
-	void getDirectionalLightInfo( const in DirectionalLight directionalLight, const in GeometricContext geometry, out IncidentLight light ) {
+	void getDirectionalLightInfo( const in DirectionalLight directionalLight, out IncidentLight light ) {
 
 		light.color = directionalLight.color;
 		light.direction = directionalLight.direction;
@@ -122,9 +122,9 @@ float getSpotAttenuation( const in float coneCosine, const in float penumbraCosi
 	uniform PointLight pointLights[ NUM_POINT_LIGHTS ];
 
 	// light is an out parameter as having it as a return value caused compiler errors on some devices
-	void getPointLightInfo( const in PointLight pointLight, const in GeometricContext geometry, out IncidentLight light ) {
+	void getPointLightInfo( const in PointLight pointLight, const in vec3 geometryPosition, out IncidentLight light ) {
 
-		vec3 lVector = pointLight.position - geometry.position;
+		vec3 lVector = pointLight.position - geometryPosition;
 
 		light.direction = normalize( lVector );
 
@@ -154,9 +154,9 @@ float getSpotAttenuation( const in float coneCosine, const in float penumbraCosi
 	uniform SpotLight spotLights[ NUM_SPOT_LIGHTS ];
 
 	// light is an out parameter as having it as a return value caused compiler errors on some devices
-	void getSpotLightInfo( const in SpotLight spotLight, const in GeometricContext geometry, out IncidentLight light ) {
+	void getSpotLightInfo( const in SpotLight spotLight, const in vec3 geometryPosition, out IncidentLight light ) {
 
-		vec3 lVector = spotLight.position - geometry.position;
+		vec3 lVector = spotLight.position - geometryPosition;
 
 		light.direction = normalize( lVector );
 

--- a/src/renderers/shaders/ShaderChunk/lights_phong_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_phong_pars_fragment.glsl.js
@@ -10,18 +10,18 @@ struct BlinnPhongMaterial {
 
 };
 
-void RE_Direct_BlinnPhong( const in IncidentLight directLight, const in GeometricContext geometry, const in BlinnPhongMaterial material, inout ReflectedLight reflectedLight ) {
+void RE_Direct_BlinnPhong( const in IncidentLight directLight, const in vec3 geometryPosition, const in vec3 geometryNormal, const in vec3 geometryViewDir, const in vec3 geometryClearcoatNormal, const in BlinnPhongMaterial material, inout ReflectedLight reflectedLight ) {
 
-	float dotNL = saturate( dot( geometry.normal, directLight.direction ) );
+	float dotNL = saturate( dot( geometryNormal, directLight.direction ) );
 	vec3 irradiance = dotNL * directLight.color;
 
 	reflectedLight.directDiffuse += irradiance * BRDF_Lambert( material.diffuseColor );
 
-	reflectedLight.directSpecular += irradiance * BRDF_BlinnPhong( directLight.direction, geometry.viewDir, geometry.normal, material.specularColor, material.specularShininess ) * material.specularStrength;
+	reflectedLight.directSpecular += irradiance * BRDF_BlinnPhong( directLight.direction, geometryViewDir, geometryNormal, material.specularColor, material.specularShininess ) * material.specularStrength;
 
 }
 
-void RE_IndirectDiffuse_BlinnPhong( const in vec3 irradiance, const in GeometricContext geometry, const in BlinnPhongMaterial material, inout ReflectedLight reflectedLight ) {
+void RE_IndirectDiffuse_BlinnPhong( const in vec3 irradiance, const in vec3 geometryPosition, const in vec3 geometryNormal, const in vec3 geometryViewDir, const in vec3 geometryClearcoatNormal, const in BlinnPhongMaterial material, inout ReflectedLight reflectedLight ) {
 
 	reflectedLight.indirectDiffuse += irradiance * BRDF_Lambert( material.diffuseColor );
 

--- a/src/renderers/shaders/ShaderChunk/lights_physical_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_physical_fragment.glsl.js
@@ -2,7 +2,7 @@ export default /* glsl */`
 PhysicalMaterial material;
 material.diffuseColor = diffuseColor.rgb * ( 1.0 - metalnessFactor );
 
-vec3 dxy = max( abs( dFdx( geometryNormal ) ), abs( dFdy( geometryNormal ) ) );
+vec3 dxy = max( abs( dFdx( nonPerturbedNormal ) ), abs( dFdy( nonPerturbedNormal ) ) );
 float geometryRoughness = max( max( dxy.x, dxy.y ), dxy.z );
 
 material.roughness = max( roughnessFactor, 0.0525 );// 0.0525 corresponds to the base mip of a 256 cubemap.

--- a/src/renderers/shaders/ShaderChunk/lights_toon_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_toon_pars_fragment.glsl.js
@@ -7,15 +7,15 @@ struct ToonMaterial {
 
 };
 
-void RE_Direct_Toon( const in IncidentLight directLight, const in GeometricContext geometry, const in ToonMaterial material, inout ReflectedLight reflectedLight ) {
+void RE_Direct_Toon( const in IncidentLight directLight, const in vec3 geometryPosition, const in vec3 geometryNormal, const in vec3 geometryViewDir, const in vec3 geometryClearcoatNormal, const in ToonMaterial material, inout ReflectedLight reflectedLight ) {
 
-	vec3 irradiance = getGradientIrradiance( geometry.normal, directLight.direction ) * directLight.color;
+	vec3 irradiance = getGradientIrradiance( geometryNormal, directLight.direction ) * directLight.color;
 
 	reflectedLight.directDiffuse += irradiance * BRDF_Lambert( material.diffuseColor );
 
 }
 
-void RE_IndirectDiffuse_Toon( const in vec3 irradiance, const in GeometricContext geometry, const in ToonMaterial material, inout ReflectedLight reflectedLight ) {
+void RE_IndirectDiffuse_Toon( const in vec3 irradiance, const in vec3 geometryPosition, const in vec3 geometryNormal, const in vec3 geometryViewDir, const in vec3 geometryClearcoatNormal, const in ToonMaterial material, inout ReflectedLight reflectedLight ) {
 
 	reflectedLight.indirectDiffuse += irradiance * BRDF_Lambert( material.diffuseColor );
 

--- a/src/renderers/shaders/ShaderChunk/normal_fragment_begin.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/normal_fragment_begin.glsl.js
@@ -71,6 +71,6 @@ float faceDirection = gl_FrontFacing ? 1.0 : - 1.0;
 
 // non perturbed normal for clearcoat among others
 
-vec3 geometryNormal = normal;
+vec3 nonPerturbedNormal = normal;
 
 `;

--- a/src/renderers/shaders/ShaderLib/meshphysical.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshphysical.glsl.js
@@ -203,7 +203,7 @@ void main() {
 
 	#ifdef USE_CLEARCOAT
 
-		float dotNVcc = saturate( dot( geometry.clearcoatNormal, geometry.viewDir ) );
+		float dotNVcc = saturate( dot( geometryClearcoatNormal, geometryViewDir ) );
 
 		vec3 Fcc = F_Schlick( material.clearcoatF0, material.clearcoatF90, dotNVcc );
 


### PR DESCRIPTION
Fixed #26687.

**Description**

This PR removes the struct `GeometricContext` from the GLSL code base to better support Adreno mobile GPUs. Even the latest 600 series of GPUs has a driver bug that limits the precision of structs in GLSL. The issue is explained in detail in https://github.com/KhronosGroup/WebGL/issues/3351.

Since browsers won't apply a workaround and since it's unlikely to expect a fast driver updates of Qualcomm, I vote to apply a fix in the engine. Simply because Adreno GPUs are one of the most used chips in the mobile space so this PR should hopefully fix rendering glitches on many devices.
