### PR TITLE
WebGPURenderer: CCW FrontFace as default

### DIFF
--- a/examples/jsm/renderers/webgpu/utils/WebGPUPipelineUtils.js
+++ b/examples/jsm/renderers/webgpu/utils/WebGPUPipelineUtils.js
@@ -466,17 +466,17 @@ class WebGPUPipelineUtils {
 		switch ( material.side ) {
 
 			case FrontSide:
-				descriptor.frontFace = GPUFrontFace.CW;
-				descriptor.cullMode = GPUCullMode.Front;
-				break;
-
-			case BackSide:
-				descriptor.frontFace = GPUFrontFace.CW;
+				descriptor.frontFace = GPUFrontFace.CCW;
 				descriptor.cullMode = GPUCullMode.Back;
 				break;
 
+			case BackSide:
+				descriptor.frontFace = GPUFrontFace.CCW;
+				descriptor.cullMode = GPUCullMode.Front;
+				break;
+
 			case DoubleSide:
-				descriptor.frontFace = GPUFrontFace.CW;
+				descriptor.frontFace = GPUFrontFace.CCW;
 				descriptor.cullMode = GPUCullMode.None;
 				break;
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/23965#issuecomment-1201903682, https://github.com/mrdoob/three.js/pull/26776

**Description**

https://github.com/mrdoob/three.js/pull/26776 introduced inverted NormalMap, but this will be resolved now leaving FrontFace CCW as the default without affecting the code targeting both backends.

/cc @WestLangley 