### PR TITLE
Removing shader preamble from isRawShaderMaterial

### DIFF
--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -459,9 +459,6 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 
 		prefixVertex = [
 
-			'#define SHADER_TYPE ' + parameters.shaderType,
-			'#define SHADER_NAME ' + parameters.shaderName,
-
 			customDefines
 
 		].filter( filterEmptyLine ).join( '\n' );
@@ -475,10 +472,6 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 		prefixFragment = [
 
 			customExtensions,
-
-			'#define SHADER_TYPE ' + parameters.shaderType,
-			'#define SHADER_NAME ' + parameters.shaderName,
-
 			customDefines
 
 		].filter( filterEmptyLine ).join( '\n' );


### PR DESCRIPTION
**Description**

Three.js around version 150(?) introduced a shader preamble to all shaders in https://github.com/mrdoob/three.js/pull/26101. All shader GLSL source code now starts with the line `#define SHADER_NAME myname`

This is a problem for those of us using THREE.RawShaderMaterial and GLSL 3.00. Specifically, if I do:

```javascript
new THREE.RawShaderMaterial({
    fragment: `#version 300 es
in float time;
`
})
```

This makes the final compiled GLSL:

```glsl
#define SHADER_TYPE RawShaderMaterial
#define SHADER_NAME MyShaderName
#version 300 es
in float time;
```

And this causes the shader to fail to compile:

```
ERROR: 0:3: 'version' : #version directive must occur before anything else, except for comments and white space

  1: #define SHADER_TYPE RawShaderMaterial
  2: #define SHADER_NAME MyShaderName
> 3: #version 300 es
```

Since the string concatenation happens in the guts of three.js, it doesn't seem possible to intercept this.

This prevents end users from using GLSL ES 3.00 in custom shaders in Three.

This PR removes the preamble from RawShaderMaterial. This makes sense, because a _Raw_ ShaderMaterial should let the user control the source code entirely.
