### PR TITLE
AudioLoader: simplify `.load()`

### DIFF
--- a/src/loaders/AudioLoader.js
+++ b/src/loaders/AudioLoader.js
@@ -12,8 +12,6 @@ class AudioLoader extends Loader {
 
 	load( url, onLoad, onProgress, onError ) {
 
-		const scope = this;
-
 		const loader = new FileLoader( this.manager );
 		loader.setResponseType( 'arraybuffer' );
 		loader.setPath( this.path );
@@ -21,42 +19,11 @@ class AudioLoader extends Loader {
 		loader.setWithCredentials( this.withCredentials );
 		loader.load( url, function ( buffer ) {
 
-			try {
-
-				// Create a copy of the buffer. The `decodeAudioData` method
-				// detaches the buffer when complete, preventing reuse.
-				const bufferCopy = buffer.slice( 0 );
-
-				const context = AudioContext.getContext();
-				context.decodeAudioData( bufferCopy, function ( audioBuffer ) {
-
-					onLoad( audioBuffer );
-
-				}, handleError );
-
-			} catch ( e ) {
-
-				handleError( e );
-
-			}
+			// Create a copy of the buffer. The `decodeAudioData` method
+			// detaches the buffer when complete, preventing reuse.
+			AudioContext.getContext().decodeAudioData( buffer.slice() ).then( onLoad, onError );
 
 		}, onProgress, onError );
-
-		function handleError( e ) {
-
-			if ( onError ) {
-
-				onError( e );
-
-			} else {
-
-				console.error( e );
-
-			}
-
-			scope.manager.itemError( url );
-
-		}
 
 	}
 


### PR DESCRIPTION
This PR simplifies the `.load()` method

1. FileLoader's onLoad callback is not in async context, the try-catch cannot catch err raised from `.decodeAudioData()` which returns a promise... so deleted.

3. AudioLoader's `manager` had been shared with the FileLoader, i.e. no need of enqueuing err item manually... so deleted.