### PR TITLE
WebGPURenderer: GPU FlipY

### DIFF
--- a/examples/jsm/renderers/webgpu/utils/WebGPUTextureMipmapUtils.js
+++ b/examples/jsm/renderers/webgpu/utils/WebGPUTextureMipmapUtils.js
@@ -184,7 +184,7 @@ fn main( @location( 0 ) vTex : vec2<f32> ) -> @location( 0 ) vec4<f32> {
 
 		const commandEncoder = this.device.createCommandEncoder( {} );
 
-		const pass = ( pipeline, sourceView, destinyView ) => {
+		const pass = ( pipeline, sourceView, destinationView ) => {
 
 			const bindGroupLayout = pipeline.getBindGroupLayout( 0 ); // @TODO: Consider making this static.
 
@@ -201,7 +201,7 @@ fn main( @location( 0 ) vTex : vec2<f32> ) -> @location( 0 ) vec4<f32> {
 
 			const passEncoder = commandEncoder.beginRenderPass( {
 				colorAttachments: [ {
-					view: destinyView,
+					view: destinationView,
 					loadOp: GPULoadOp.Clear,
 					storeOp: GPUStoreOp.Store,
 					clearValue: [ 0, 0, 0, 0 ]

--- a/examples/jsm/renderers/webgpu/utils/WebGPUTexturePassUtils.js
+++ b/examples/jsm/renderers/webgpu/utils/WebGPUTexturePassUtils.js
@@ -1,6 +1,6 @@
 import { GPUTextureViewDimension, GPUIndexFormat, GPUFilterMode, GPUPrimitiveTopology, GPULoadOp, GPUStoreOp } from './WebGPUConstants.js';
 
-class WebGPUTextureMipmapUtils {
+class WebGPUTexturePassUtils {
 
 	constructor( device ) {
 
@@ -282,4 +282,4 @@ fn main( @location( 0 ) vTex : vec2<f32> ) -> @location( 0 ) vec4<f32> {
 
 }
 
-export default WebGPUTextureMipmapUtils;
+export default WebGPUTexturePassUtils;

--- a/examples/jsm/renderers/webgpu/utils/WebGPUTextureUtils.js
+++ b/examples/jsm/renderers/webgpu/utils/WebGPUTextureUtils.js
@@ -15,7 +15,7 @@ import {
 
 import { CubeReflectionMapping, CubeRefractionMapping, EquirectangularReflectionMapping, EquirectangularRefractionMapping } from 'three';
 
-import WebGPUTextureMipmapUtils from './WebGPUTextureMipmapUtils.js';
+import WebGPUTexturePassUtils from './WebGPUTexturePassUtils.js';
 
 const _compareToWebGPU = {
 	[ NeverCompare ]: 'never',
@@ -36,7 +36,7 @@ class WebGPUTextureUtils {
 
 		this.backend = backend;
 
-		this.mipmapUtils = null;
+		this._passUtils = null;
 
 		this.defaultTexture = null;
 		this.defaultCubeTexture = null;
@@ -411,29 +411,29 @@ class WebGPUTextureUtils {
 
 	}
 
-	_initMipmapUtils() {
+	_getPassUtils() {
 
-		if ( this.mipmapUtils === null ) {
+		let passUtils = this._passUtils;
 
-			this.mipmapUtils = new WebGPUTextureMipmapUtils( this.backend.device );
+		if ( passUtils === null ) {
+
+			this._passUtils = passUtils = new WebGPUTexturePassUtils( this.backend.device );
 
 		}
+
+		return passUtils;
 
 	}
 
 	_generateMipmaps( textureGPU, textureDescriptorGPU, baseArrayLayer = 0 ) {
 
-		this._initMipmapUtils();
-
-		this.mipmapUtils.generateMipmaps( textureGPU, textureDescriptorGPU, baseArrayLayer );
+		this._getPassUtils().generateMipmaps( textureGPU, textureDescriptorGPU, baseArrayLayer );
 
 	}
 
 	_flipY( textureGPU, textureDescriptorGPU, originDepth = 0 ) {
 
-		this._initMipmapUtils();
-
-		this.mipmapUtils.flipY( textureGPU, textureDescriptorGPU, originDepth );
+		this._getPassUtils().flipY( textureGPU, textureDescriptorGPU, originDepth );
 
 	}
 


### PR DESCRIPTION
Related issue: Fixes https://github.com/mrdoob/three.js/issues/26813

**Description**

This PR `.flipY` texture approach using GPU-Pass. 

I also fixed CubeMap's flipY but for WebGPU.

Examples applied flipY in CubeMaps
| WebGPURenderer - `webgpu_cubemap_adjustments` | WebGLRenderer - `webgl_materials_envmaps_hdr` |
| ------------- | ------------- |
| ![image](https://github.com/mrdoob/three.js/assets/502810/987d73a6-a70f-456e-a05a-babb4f2c95ae) | ![image](https://github.com/mrdoob/three.js/assets/502810/13b176a7-323e-4cba-9916-a9fdbcc2728f) |
