### PR TITLE
Nodes: consume labels() when used, to prevent duplicate uniform names.

### DIFF
--- a/examples/jsm/nodes/core/UniformNode.js
+++ b/examples/jsm/nodes/core/UniformNode.js
@@ -39,6 +39,8 @@ class UniformNode extends InputNode {
 		const nodeUniform = builder.getUniformFromNode( sharedNode, sharedNodeType, builder.shaderStage, builder.context.label );
 		const propertyName = builder.getPropertyName( nodeUniform );
 
+		if ( builder.context.label !== undefined ) delete builder.context.label;
+
 		return builder.format( propertyName, type, output );
 
 	}


### PR DESCRIPTION
The GLSL code produced by the default shader in the example webgpu_tsl_editor has a texture and a uniform with the same name, specified by the texture().label() feature.

As far as I can tell this is the result of the creation of the timer input uniform being nested within the AST of the texture and this inherits the builder.context.label set by the context of the texture.

I have avoided this problem by removing the label when it is encountered by a `UniformNode`

The faulty source produced is:

```
// uniforms

layout( std140 ) uniform fragmentNodeUniforms {
	float myTexture;
	vec3 myColor;
};
uniform sampler2D myTexture;

// varyings
in vec2 nodeVarying0;
```

