### PR TITLE
TSL: Introduce ShaderCallNode & `tslFn` improvements

### DIFF
--- a/examples/jsm/nodes/procedural/CheckerNode.js
+++ b/examples/jsm/nodes/procedural/CheckerNode.js
@@ -25,9 +25,9 @@ class CheckerNode extends TempNode {
 
 	}
 
-	generate( builder ) {
+	construct() {
 
-		return checkerShaderNode( { uv: this.uvNode } ).build( builder );
+		return checkerShaderNode( { uv: this.uvNode } );
 
 	}
 

--- a/examples/jsm/nodes/utils/LoopNode.js
+++ b/examples/jsm/nodes/utils/LoopNode.js
@@ -1,7 +1,7 @@
 import Node, { addNodeClass } from '../core/Node.js';
 import { expression } from '../code/ExpressionNode.js';
 import { bypass } from '../core/BypassNode.js';
-import { context as contextNode } from '../core/ContextNode.js';
+import { context } from '../core/ContextNode.js';
 import { addNodeElement, nodeObject, nodeArray } from '../shadernode/ShaderNode.js';
 
 class LoopNode extends Node {
@@ -65,12 +65,10 @@ class LoopNode extends Node {
 
 		const properties = this.getProperties( builder );
 
-		const context = { tempWrite: false };
+		const contextData = { tempWrite: false };
 
 		const params = this.params;
 		const stackNode = properties.stackNode;
-
-		const returnsSnippet = properties.returnsNode ? properties.returnsNode.build( builder ) : '';
 
 		for ( let i = 0, l = params.length - 1; i < l; i ++ ) {
 
@@ -82,7 +80,7 @@ class LoopNode extends Node {
 			if ( param.isNode ) {
 
 				start = '0';
-				end = param.generate( builder, 'int' );
+				end = param.build( builder, 'int' );
 				direction = 'forward';
 
 			} else {
@@ -92,10 +90,10 @@ class LoopNode extends Node {
 				direction = param.direction;
 
 				if ( typeof start === 'number' ) start = start.toString();
-				else if ( start && start.isNode ) start = start.generate( builder, 'int' );
+				else if ( start && start.isNode ) start = start.build( builder, 'int' );
 
 				if ( typeof end === 'number' ) end = end.toString();
-				else if ( end && end.isNode ) end = end.generate( builder, 'int' );
+				else if ( end && end.isNode ) end = end.build( builder, 'int' );
 
 				if ( start !== undefined && end === undefined ) {
 
@@ -159,7 +157,9 @@ class LoopNode extends Node {
 
 		}
 
-		const stackSnippet = contextNode( stackNode, context ).build( builder, 'void' );
+		const stackSnippet = context( stackNode, contextData ).build( builder, 'void' );
+
+		const returnsSnippet = properties.returnsNode ? properties.returnsNode.build( builder ) : '';
 
 		builder.removeFlowTab().addFlowCode( '\n' + builder.tab + stackSnippet );
 

--- a/examples/webgpu_audio_processing.html
+++ b/examples/webgpu_audio_processing.html
@@ -31,7 +31,7 @@
 		<script type="module">
 
 			import * as THREE from 'three';
-			import { ShaderNode, uniform, storage, instanceIndex, float, texture, viewportTopLeft, color } from 'three/nodes';
+			import { tslFn, uniform, storage, instanceIndex, float, texture, viewportTopLeft, color } from 'three/nodes';
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 
@@ -136,10 +136,9 @@
 
 				// compute (shader-node)
 
-				const computeShaderNode = new ShaderNode( ( stack ) => {
+				const computeShaderFn = tslFn( ( stack ) => {
 
 					const index = float( instanceIndex );
-
 
 					// pitch
 
@@ -171,7 +170,7 @@
 
 				// compute
 
-				computeNode = computeShaderNode.compute( waveBuffer.length );
+				computeNode = computeShaderFn().compute( waveBuffer.length );
 
 
 				// gui

--- a/examples/webgpu_compute.html
+++ b/examples/webgpu_compute.html
@@ -26,7 +26,7 @@
 		<script type="module">
 
 			import * as THREE from 'three';
-			import { ShaderNode, uniform, storage, attribute, float, vec2, vec3, color, instanceIndex, PointsNodeMaterial } from 'three/nodes';
+			import { tslFn, uniform, storage, attribute, float, vec2, vec3, color, instanceIndex, PointsNodeMaterial } from 'three/nodes';
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 
@@ -74,7 +74,7 @@
 
 				// create function
 
-				const computeShaderNode = new ShaderNode( ( stack ) => {
+				const computeShaderFn = tslFn( ( stack ) => {
 
 					const particle = particleBufferNode.element( instanceIndex );
 					const velocity = velocityBufferNode.element( instanceIndex );
@@ -98,10 +98,10 @@
 
 				// compute
 
-				computeNode = computeShaderNode.compute( particleNum );
+				computeNode = computeShaderFn().compute( particleNum );
 				computeNode.onInit = ( { renderer } ) => {
 
-					const precomputeShaderNode = new ShaderNode( ( stack ) => {
+					const precomputeShaderNode = tslFn( ( stack ) => {
 
 						const particleIndex = float( instanceIndex );
 
@@ -117,7 +117,7 @@
 
 					} );
 
-					renderer.compute( precomputeShaderNode.compute( particleNum ) );
+					renderer.compute( precomputeShaderNode().compute( particleNum ) );
 
 				};
 

--- a/examples/webgpu_compute_particles.html
+++ b/examples/webgpu_compute_particles.html
@@ -26,7 +26,7 @@
 		<script type="module">
 
 			import * as THREE from 'three';
-			import { ShaderNode, uniform, texture, instanceIndex, float, vec3, storage, SpriteNodeMaterial } from 'three/nodes';
+			import { tslFn, uniform, texture, instanceIndex, float, vec3, storage, SpriteNodeMaterial } from 'three/nodes';
 
 			import WebGPU from 'three/addons/capabilities/WebGPU.js';
 			import WebGPURenderer from 'three/addons/renderers/webgpu/WebGPURenderer.js';
@@ -83,7 +83,7 @@
 
 				// compute
 
-				const computeInit = new ShaderNode( ( stack ) => {
+				const computeInit = tslFn( ( stack ) => {
 
 					const position = positionBuffer.element( instanceIndex );
 					const color = colorBuffer.element( instanceIndex );
@@ -98,11 +98,11 @@
 
 					stack.assign( color, vec3( randX, randY, randZ ) );
 
-				} ).compute( particleCount );
+				} )().compute( particleCount );
 
 				//
 
-				const computeUpdate = new ShaderNode( ( stack ) => {
+				const computeUpdate = tslFn( ( stack ) => {
 
 					const position = positionBuffer.element( instanceIndex );
 					const velocity = velocityBuffer.element( instanceIndex );
@@ -128,7 +128,7 @@
 
 				} );
 
-				computeParticles = computeUpdate.compute( particleCount );
+				computeParticles = computeUpdate().compute( particleCount );
 
 				// create nodes
 
@@ -179,7 +179,7 @@
 
 				// click event
 
-				const computeHit = new ShaderNode( ( stack ) => {
+				const computeHit = tslFn( ( stack ) => {
 
 					const position = positionBuffer.element( instanceIndex );
 					const velocity = velocityBuffer.element( instanceIndex );
@@ -193,7 +193,7 @@
 
 					stack.assign( velocity, velocity.add( direction.mul( relativePower ) ) );
 
-				} ).compute( particleCount );
+				} )().compute( particleCount );
 
 				//
 

--- a/examples/webgpu_materials.html
+++ b/examples/webgpu_materials.html
@@ -29,7 +29,7 @@
 			import * as THREE from 'three';
 			import * as Nodes from 'three/nodes';
 
-			import { tslFn, wgslFn, attribute, positionLocal, positionWorld, normalLocal, normalWorld, normalView, color, texture, uv, float, vec2, vec3, vec4, oscSine, triplanarTexture, viewportBottomLeft, js, string, global, loop, MeshBasicNodeMaterial, NodeObjectLoader } from 'three/nodes';
+			import { tslFn, wgslFn, positionLocal, positionWorld, normalLocal, normalWorld, normalView, color, texture, uv, float, vec2, vec3, vec4, oscSine, triplanarTexture, viewportBottomLeft, js, string, global, loop, MeshBasicNodeMaterial, NodeObjectLoader } from 'three/nodes';
 
 			import WebGPU from 'three/addons/capabilities/WebGPU.js';
 			import WebGPURenderer from 'three/addons/renderers/webgpu/WebGPURenderer.js';


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/26821

**Description**

`ShaderCallNode` separates the function call from the function itself allowing the function to be constructed in the `construct()` process, this also paves the way for `function cache` creation.
