### PR TITLE
Add recast-navigation-js to libraries and plugins docs

### DIFF
--- a/docs/manual/en/introduction/Libraries-and-Plugins.html
+++ b/docs/manual/en/introduction/Libraries-and-Plugins.html
@@ -96,6 +96,7 @@
 		<ul>
 			<li>[link:https://mugen87.github.io/yuka/ yuka]</li>
 			<li>[link:https://github.com/donmccurdy/three-pathfinding three-pathfinding]</li>
+			<li>[link:https://github.com/isaac-mason/recast-navigation-js recast-navigation-js]</li>
 		</ul>
 
 		<h3>Wrappers and Frameworks</h3>

--- a/docs/manual/fr/introduction/Libraries-and-Plugins.html
+++ b/docs/manual/fr/introduction/Libraries-and-Plugins.html
@@ -95,6 +95,7 @@
 		<ul>
 			<li>[link:https://mugen87.github.io/yuka/ yuka]</li>
 			<li>[link:https://github.com/donmccurdy/three-pathfinding three-pathfinding]</li>
+			<li>[link:https://github.com/isaac-mason/recast-navigation-js recast-navigation-js]</li>
 		</ul>
 
 		<h3>Wrappers et Frameworks</h3>

--- a/docs/manual/it/introduction/Libraries-and-Plugins.html
+++ b/docs/manual/it/introduction/Libraries-and-Plugins.html
@@ -95,6 +95,7 @@
 		<ul>
 			<li>[link:https://mugen87.github.io/yuka/ yuka]</li>
 			<li>[link:https://github.com/donmccurdy/three-pathfinding three-pathfinding]</li>
+			<li>[link:https://github.com/isaac-mason/recast-navigation-js recast-navigation-js]</li>
 		</ul>
 
 		<h3>Wrappers e Frameworks</h3>

--- a/docs/manual/ja/introduction/Libraries-and-Plugins.html
+++ b/docs/manual/ja/introduction/Libraries-and-Plugins.html
@@ -88,6 +88,7 @@
     <ul>
         <li>[link:https://mugen87.github.io/yuka/ yuka]</li>
         <li>[link:https://github.com/donmccurdy/three-pathfinding three-pathfinding]</li>
+        <li>[link:https://github.com/isaac-mason/recast-navigation-js recast-navigation-js]</li>
     </ul>
 
     <h3>Wrappers and Frameworks</h3>

--- a/docs/manual/pt-br/introduction/Libraries-and-Plugins.html
+++ b/docs/manual/pt-br/introduction/Libraries-and-Plugins.html
@@ -95,6 +95,7 @@
 		<ul>
 			<li>[link:https://mugen87.github.io/yuka/ yuka]</li>
 			<li>[link:https://github.com/donmccurdy/three-pathfinding three-pathfinding]</li>
+			<li>[link:https://github.com/isaac-mason/recast-navigation-js recast-navigation-js]</li>
 		</ul>
 
 		<h3>Wrappers e Frameworks</h3>

--- a/docs/manual/ru/introduction/Libraries-and-Plugins.html
+++ b/docs/manual/ru/introduction/Libraries-and-Plugins.html
@@ -95,6 +95,7 @@
 		<ul>
 			<li>[link:https://mugen87.github.io/yuka/ yuka]</li>
 			<li>[link:https://github.com/donmccurdy/three-pathfinding three-pathfinding]</li>
+			<li>[link:https://github.com/isaac-mason/recast-navigation-js recast-navigation-js]</li>
 		</ul>
 
 		<h3>Обертки и фреймворки</h3>


### PR DESCRIPTION
**Description**

This PR adds [recast-navigation-js](https://github.com/isaac-mason/recast-navigation-js) to the Libraries and Plugins docs under the "Game AI" section
