### PR TITLE
RenderNodes: Fix `context.material` reference.

### DIFF
--- a/examples/jsm/renderers/common/nodes/Nodes.js
+++ b/examples/jsm/renderers/common/nodes/Nodes.js
@@ -40,6 +40,7 @@ class Nodes extends DataMap {
 
 				const nodeBuilder = this.backend.createNodeBuilder( renderObject.object, this.renderer, renderObject.scene );
 				nodeBuilder.material = renderObject.material;
+				nodeBuilder.context.material = renderObject.material;
 				nodeBuilder.lightsNode = renderObject.lightsNode;
 				nodeBuilder.environmentNode = this.getEnvironmentNode( renderObject.scene );
 				nodeBuilder.fogNode = this.getFogNode( renderObject.scene );


### PR DESCRIPTION
Related issue: Fixes https://github.com/mrdoob/three.js/issues/26830

**Description**

Fix material reference when used in `NodeBuilder.context.material`
