### PR TITLE
TextureNode: Rename `.getTextureMatrix()` -> `.getTransformedUV()`

### DIFF
--- a/examples/jsm/nodes/accessors/TextureNode.js
+++ b/examples/jsm/nodes/accessors/TextureNode.js
@@ -59,7 +59,7 @@ class TextureNode extends UniformNode {
 
 	}
 
-	getTextureMatrix( uvNode ) {
+	getTransformedUV( uvNode ) {
 
 		const texture = this.value;
 
@@ -94,7 +94,7 @@ class TextureNode extends UniformNode {
 
 		if ( this.updateMatrix === true ) {
 
-			uvNode = this.getTextureMatrix( uvNode );
+			uvNode = this.getTransformedUV( uvNode );
 
 		}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/26461#discussion_r1312099436

**Description**

Rename `.getTextureMatrix()` → `.getTransformedUV()`