### PR TITLE
WebGPURenderer: Fix .flipY example

### DIFF
--- a/examples/jsm/renderers/webgpu/utils/WebGPUTextureUtils.js
+++ b/examples/jsm/renderers/webgpu/utils/WebGPUTextureUtils.js
@@ -239,7 +239,7 @@ class WebGPUTextureUtils {
 
 		if ( texture.isDataTexture || texture.isDataArrayTexture || texture.isData3DTexture ) {
 
-			this._copyBufferToTexture( options.image, textureData.texture, textureDescriptorGPU, 0, texture.flipY );
+			this._copyBufferToTexture( options.image, textureData.texture, textureDescriptorGPU, 0, false );
 
 		} else if ( texture.isCompressedTexture ) {
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/26818

**Description**

I believe that WebGPU is already doing this on some textures by default, I will check how to normalize this soon.