### PR TITLE
Fix `addNodeClass` and `addNodeMaterial` in case of renaming classes

### DIFF
--- a/examples/jsm/nodes/accessors/BitangentNode.js
+++ b/examples/jsm/nodes/accessors/BitangentNode.js
@@ -86,4 +86,4 @@ export const bitangentWorld = nodeImmutable( BitangentNode, BitangentNode.WORLD 
 export const transformedBitangentView = normalize( transformedNormalView.cross( transformedTangentView ).mul( tangentGeometry.w ) );
 export const transformedBitangentWorld = normalize( transformedBitangentView.transformDirection( cameraViewMatrix ) );
 
-addNodeClass( BitangentNode );
+addNodeClass( 'BitangentNode', BitangentNode );

--- a/examples/jsm/nodes/accessors/BufferAttributeNode.js
+++ b/examples/jsm/nodes/accessors/BufferAttributeNode.js
@@ -122,4 +122,4 @@ export const instancedDynamicBufferAttribute = ( array, type, stride, offset ) =
 
 addNodeElement( 'toAttribute', ( bufferNode ) => bufferAttribute( bufferNode.value ) );
 
-addNodeClass( BufferAttributeNode );
+addNodeClass( 'BufferAttributeNode', BufferAttributeNode );

--- a/examples/jsm/nodes/accessors/BufferNode.js
+++ b/examples/jsm/nodes/accessors/BufferNode.js
@@ -27,4 +27,4 @@ export default BufferNode;
 
 export const buffer = ( value, type, count ) => nodeObject( new BufferNode( value, type, count ) );
 
-addNodeClass( BufferNode );
+addNodeClass( 'BufferNode', BufferNode );

--- a/examples/jsm/nodes/accessors/CameraNode.js
+++ b/examples/jsm/nodes/accessors/CameraNode.js
@@ -95,4 +95,4 @@ export const cameraNormalMatrix = nodeImmutable( CameraNode, CameraNode.NORMAL_M
 export const cameraWorldMatrix = nodeImmutable( CameraNode, CameraNode.WORLD_MATRIX );
 export const cameraPosition = nodeImmutable( CameraNode, CameraNode.POSITION );
 
-addNodeClass( CameraNode );
+addNodeClass( 'CameraNode', CameraNode );

--- a/examples/jsm/nodes/accessors/CubeTextureNode.js
+++ b/examples/jsm/nodes/accessors/CubeTextureNode.js
@@ -115,4 +115,4 @@ export const cubeTexture = nodeProxy( CubeTextureNode );
 
 addNodeElement( 'cubeTexture', cubeTexture );
 
-addNodeClass( CubeTextureNode );
+addNodeClass( 'CubeTextureNode', CubeTextureNode );

--- a/examples/jsm/nodes/accessors/ExtendedMaterialNode.js
+++ b/examples/jsm/nodes/accessors/ExtendedMaterialNode.js
@@ -73,4 +73,4 @@ export default ExtendedMaterialNode;
 export const materialNormal = nodeImmutable( ExtendedMaterialNode, ExtendedMaterialNode.NORMAL );
 export const materialClearcoatNormal = nodeImmutable( ExtendedMaterialNode, ExtendedMaterialNode.CLEARCOAT_NORMAL );
 
-addNodeClass( ExtendedMaterialNode );
+addNodeClass( 'ExtendedMaterialNode', ExtendedMaterialNode );

--- a/examples/jsm/nodes/accessors/InstanceNode.js
+++ b/examples/jsm/nodes/accessors/InstanceNode.js
@@ -68,4 +68,4 @@ export default InstanceNode;
 
 export const instance = nodeProxy( InstanceNode );
 
-addNodeClass( InstanceNode );
+addNodeClass( 'InstanceNode', InstanceNode );

--- a/examples/jsm/nodes/accessors/LineMaterialNode.js
+++ b/examples/jsm/nodes/accessors/LineMaterialNode.js
@@ -26,4 +26,4 @@ export const materialLineDashSize = nodeImmutable( LineMaterialNode, LineMateria
 export const materialLineGapSize = nodeImmutable( LineMaterialNode, LineMaterialNode.GAP_SIZE );
 export const materialLineWidth = nodeImmutable( LineMaterialNode, LineMaterialNode.LINEWIDTH );
 
-addNodeClass( LineMaterialNode );
+addNodeClass( 'LineMaterialNode', LineMaterialNode );

--- a/examples/jsm/nodes/accessors/MaterialNode.js
+++ b/examples/jsm/nodes/accessors/MaterialNode.js
@@ -274,4 +274,4 @@ export const materialIridescence = nodeImmutable( MaterialNode, MaterialNode.IRI
 export const materialIridescenceIOR = nodeImmutable( MaterialNode, MaterialNode.IRIDESCENCE_IOR );
 export const materialIridescenceThickness = nodeImmutable( MaterialNode, MaterialNode.IRIDESCENCE_THICKNESS );
 
-addNodeClass( MaterialNode );
+addNodeClass( 'MaterialNode', MaterialNode );

--- a/examples/jsm/nodes/accessors/MaterialReferenceNode.js
+++ b/examples/jsm/nodes/accessors/MaterialReferenceNode.js
@@ -39,4 +39,4 @@ export default MaterialReferenceNode;
 
 export const materialReference = ( name, type, material ) => nodeObject( new MaterialReferenceNode( name, type, material ) );
 
-addNodeClass( MaterialReferenceNode );
+addNodeClass( 'MaterialReferenceNode', MaterialReferenceNode );

--- a/examples/jsm/nodes/accessors/ModelNode.js
+++ b/examples/jsm/nodes/accessors/ModelNode.js
@@ -31,4 +31,4 @@ export const modelPosition = nodeImmutable( ModelNode, ModelNode.POSITION );
 export const modelScale = nodeImmutable( ModelNode, ModelNode.SCALE );
 export const modelViewPosition = nodeImmutable( ModelNode, ModelNode.VIEW_POSITION );
 
-addNodeClass( ModelNode );
+addNodeClass( 'ModelNode', ModelNode );

--- a/examples/jsm/nodes/accessors/ModelViewProjectionNode.js
+++ b/examples/jsm/nodes/accessors/ModelViewProjectionNode.js
@@ -27,4 +27,4 @@ export default ModelViewProjectionNode;
 
 export const modelViewProjection = nodeProxy( ModelViewProjectionNode );
 
-addNodeClass( ModelViewProjectionNode );
+addNodeClass( 'ModelViewProjectionNode', ModelViewProjectionNode );

--- a/examples/jsm/nodes/accessors/MorphNode.js
+++ b/examples/jsm/nodes/accessors/MorphNode.js
@@ -67,4 +67,4 @@ export default MorphNode;
 
 export const morph = nodeProxy( MorphNode );
 
-addNodeClass( MorphNode );
+addNodeClass( 'MorphNode', MorphNode );

--- a/examples/jsm/nodes/accessors/NormalNode.js
+++ b/examples/jsm/nodes/accessors/NormalNode.js
@@ -93,4 +93,4 @@ export const transformedNormalView = property( 'vec3', 'TransformedNormalView' )
 export const transformedNormalWorld = transformedNormalView.transformDirection( cameraViewMatrix ).normalize();
 export const transformedClearcoatNormalView = property( 'vec3', 'TransformedClearcoatNormalView' );
 
-addNodeClass( NormalNode );
+addNodeClass( 'NormalNode', NormalNode );

--- a/examples/jsm/nodes/accessors/Object3DNode.js
+++ b/examples/jsm/nodes/accessors/Object3DNode.js
@@ -147,4 +147,4 @@ export const objectPosition = nodeProxy( Object3DNode, Object3DNode.POSITION );
 export const objectScale = nodeProxy( Object3DNode, Object3DNode.SCALE );
 export const objectViewPosition = nodeProxy( Object3DNode, Object3DNode.VIEW_POSITION );
 
-addNodeClass( Object3DNode );
+addNodeClass( 'Object3DNode', Object3DNode );

--- a/examples/jsm/nodes/accessors/PointUVNode.js
+++ b/examples/jsm/nodes/accessors/PointUVNode.js
@@ -23,4 +23,4 @@ export default PointUVNode;
 
 export const pointUV = nodeImmutable( PointUVNode );
 
-addNodeClass( PointUVNode );
+addNodeClass( 'PointUVNode', PointUVNode );

--- a/examples/jsm/nodes/accessors/PositionNode.js
+++ b/examples/jsm/nodes/accessors/PositionNode.js
@@ -101,4 +101,4 @@ export const positionWorldDirection = nodeImmutable( PositionNode, PositionNode.
 export const positionView = nodeImmutable( PositionNode, PositionNode.VIEW );
 export const positionViewDirection = nodeImmutable( PositionNode, PositionNode.VIEW_DIRECTION );
 
-addNodeClass( PositionNode );
+addNodeClass( 'PositionNode', PositionNode );

--- a/examples/jsm/nodes/accessors/ReferenceNode.js
+++ b/examples/jsm/nodes/accessors/ReferenceNode.js
@@ -75,4 +75,4 @@ export default ReferenceNode;
 
 export const reference = ( name, type, object ) => nodeObject( new ReferenceNode( name, type, object ) );
 
-addNodeClass( ReferenceNode );
+addNodeClass( 'ReferenceNode', ReferenceNode );

--- a/examples/jsm/nodes/accessors/ReflectVectorNode.js
+++ b/examples/jsm/nodes/accessors/ReflectVectorNode.js
@@ -32,4 +32,4 @@ export default ReflectVectorNode;
 
 export const reflectVector = nodeImmutable( ReflectVectorNode );
 
-addNodeClass( ReflectVectorNode );
+addNodeClass( 'ReflectVectorNode', ReflectVectorNode );

--- a/examples/jsm/nodes/accessors/SceneNode.js
+++ b/examples/jsm/nodes/accessors/SceneNode.js
@@ -49,4 +49,4 @@ export default SceneNode;
 export const backgroundBlurriness = nodeImmutable( SceneNode, SceneNode.BACKGROUND_BLURRINESS );
 export const backgroundIntensity = nodeImmutable( SceneNode, SceneNode.BACKGROUND_INTENSITY );
 
-addNodeClass( SceneNode );
+addNodeClass( 'SceneNode', SceneNode );

--- a/examples/jsm/nodes/accessors/SkinningNode.js
+++ b/examples/jsm/nodes/accessors/SkinningNode.js
@@ -90,4 +90,4 @@ export default SkinningNode;
 
 export const skinning = nodeProxy( SkinningNode );
 
-addNodeClass( SkinningNode );
+addNodeClass( 'SkinningNode', SkinningNode );

--- a/examples/jsm/nodes/accessors/StorageBufferNode.js
+++ b/examples/jsm/nodes/accessors/StorageBufferNode.js
@@ -24,4 +24,4 @@ export default StorageBufferNode;
 
 export const storage = ( value, type, count ) => nodeObject( new StorageBufferNode( value, type, count ) );
 
-addNodeClass( StorageBufferNode );
+addNodeClass( 'StorageBufferNode', StorageBufferNode );

--- a/examples/jsm/nodes/accessors/TangentNode.js
+++ b/examples/jsm/nodes/accessors/TangentNode.js
@@ -100,4 +100,4 @@ export const tangentWorld = nodeImmutable( TangentNode, TangentNode.WORLD );
 export const transformedTangentView = temp( tangentView, 'TransformedTangentView' );
 export const transformedTangentWorld = normalize( transformedTangentView.transformDirection( cameraViewMatrix ) );
 
-addNodeClass( TangentNode );
+addNodeClass( 'TangentNode', TangentNode );

--- a/examples/jsm/nodes/accessors/TextureBicubicNode.js
+++ b/examples/jsm/nodes/accessors/TextureBicubicNode.js
@@ -91,4 +91,4 @@ export const textureBicubic = nodeProxy( TextureBicubicNode );
 
 addNodeElement( 'bicubic', textureBicubic );
 
-addNodeClass( TextureBicubicNode );
+addNodeClass( 'TextureBicubicNode', TextureBicubicNode );

--- a/examples/jsm/nodes/accessors/TextureNode.js
+++ b/examples/jsm/nodes/accessors/TextureNode.js
@@ -278,4 +278,4 @@ export const sampler = ( aTexture ) => ( aTexture.isNode === true ? aTexture : t
 addNodeElement( 'texture', texture );
 //addNodeElement( 'textureLevel', textureLevel );
 
-addNodeClass( TextureNode );
+addNodeClass( 'TextureNode', TextureNode );

--- a/examples/jsm/nodes/accessors/TextureSizeNode.js
+++ b/examples/jsm/nodes/accessors/TextureSizeNode.js
@@ -32,4 +32,4 @@ export const textureSize = nodeProxy( TextureSizeNode );
 
 addNodeElement( 'textureSize', textureSize );
 
-addNodeClass( TextureSizeNode );
+addNodeClass( 'TextureSizeNode', TextureSizeNode );

--- a/examples/jsm/nodes/accessors/TextureStoreNode.js
+++ b/examples/jsm/nodes/accessors/TextureStoreNode.js
@@ -26,4 +26,4 @@ export default TextureStoreNode;
 
 export const textureStore = nodeProxy( TextureStoreNode );
 
-addNodeClass( TextureStoreNode );
+addNodeClass( 'TextureStoreNode', TextureStoreNode );

--- a/examples/jsm/nodes/accessors/UVNode.js
+++ b/examples/jsm/nodes/accessors/UVNode.js
@@ -44,4 +44,4 @@ export default UVNode;
 
 export const uv = ( ...params ) => nodeObject( new UVNode( ...params ) );
 
-addNodeClass( UVNode );
+addNodeClass( 'UVNode', UVNode );

--- a/examples/jsm/nodes/accessors/UserDataNode.js
+++ b/examples/jsm/nodes/accessors/UserDataNode.js
@@ -26,4 +26,4 @@ export default UserDataNode;
 
 export const userData = ( name, inputType, userData ) => nodeObject( new UserDataNode( name, inputType, userData ) );
 
-addNodeClass( UserDataNode );
+addNodeClass( 'UserDataNode', UserDataNode );

--- a/examples/jsm/nodes/code/CodeNode.js
+++ b/examples/jsm/nodes/code/CodeNode.js
@@ -75,4 +75,4 @@ export const js = ( src, includes ) => code( src, includes, 'js' );
 export const wgsl = ( src, includes ) => code( src, includes, 'wgsl' );
 export const glsl = ( src, includes ) => code( src, includes, 'glsl' );
 
-addNodeClass( CodeNode );
+addNodeClass( 'CodeNode', CodeNode );

--- a/examples/jsm/nodes/code/ExpressionNode.js
+++ b/examples/jsm/nodes/code/ExpressionNode.js
@@ -34,4 +34,4 @@ export default ExpressionNode;
 
 export const expression = nodeProxy( ExpressionNode );
 
-addNodeClass( ExpressionNode );
+addNodeClass( 'ExpressionNode', ExpressionNode );

--- a/examples/jsm/nodes/code/FunctionCallNode.js
+++ b/examples/jsm/nodes/code/FunctionCallNode.js
@@ -93,4 +93,4 @@ export const call = ( func, ...params ) => {
 
 addNodeElement( 'call', call );
 
-addNodeClass( FunctionCallNode );
+addNodeClass( 'FunctionCallNode', FunctionCallNode );

--- a/examples/jsm/nodes/code/FunctionNode.js
+++ b/examples/jsm/nodes/code/FunctionNode.js
@@ -124,4 +124,4 @@ export const func = ( code, includes ) => { // @deprecated, r154
 
 };
 
-addNodeClass( FunctionNode );
+addNodeClass( 'FunctionNode', FunctionNode );

--- a/examples/jsm/nodes/code/ScriptableNode.js
+++ b/examples/jsm/nodes/code/ScriptableNode.js
@@ -485,4 +485,4 @@ export const scriptable = nodeProxy( ScriptableNode );
 
 addNodeElement( 'scriptable', scriptable );
 
-addNodeClass( ScriptableNode );
+addNodeClass( 'ScriptableNode', ScriptableNode );

--- a/examples/jsm/nodes/code/ScriptableValueNode.js
+++ b/examples/jsm/nodes/code/ScriptableValueNode.js
@@ -164,4 +164,4 @@ export const scriptableValue = nodeProxy( ScriptableValueNode );
 
 addNodeElement( 'scriptableValue', scriptableValue );
 
-addNodeClass( ScriptableValueNode );
+addNodeClass( 'ScriptableValueNode', ScriptableValueNode );

--- a/examples/jsm/nodes/core/ArrayUniformNode.js
+++ b/examples/jsm/nodes/core/ArrayUniformNode.js
@@ -23,4 +23,4 @@ class ArrayUniformNode extends UniformNode {
 
 export default ArrayUniformNode;
 
-addNodeClass( ArrayUniformNode );
+addNodeClass( 'ArrayUniformNode', ArrayUniformNode );

--- a/examples/jsm/nodes/core/AttributeNode.js
+++ b/examples/jsm/nodes/core/AttributeNode.js
@@ -99,4 +99,4 @@ export default AttributeNode;
 
 export const attribute = ( name, nodeType ) => nodeObject( new AttributeNode( name, nodeType ) );
 
-addNodeClass( AttributeNode );
+addNodeClass( 'AttributeNode', AttributeNode );

--- a/examples/jsm/nodes/core/BypassNode.js
+++ b/examples/jsm/nodes/core/BypassNode.js
@@ -42,4 +42,4 @@ export const bypass = nodeProxy( BypassNode );
 
 addNodeElement( 'bypass', bypass );
 
-addNodeClass( BypassNode );
+addNodeClass( 'BypassNode', BypassNode );

--- a/examples/jsm/nodes/core/CacheNode.js
+++ b/examples/jsm/nodes/core/CacheNode.js
@@ -43,4 +43,4 @@ export const cache = nodeProxy( CacheNode );
 
 addNodeElement( 'cache', cache );
 
-addNodeClass( CacheNode );
+addNodeClass( 'CacheNode', CacheNode );

--- a/examples/jsm/nodes/core/ConstNode.js
+++ b/examples/jsm/nodes/core/ConstNode.js
@@ -29,4 +29,4 @@ class ConstNode extends InputNode {
 
 export default ConstNode;
 
-addNodeClass( ConstNode );
+addNodeClass( 'ConstNode', ConstNode );

--- a/examples/jsm/nodes/core/ContextNode.js
+++ b/examples/jsm/nodes/core/ContextNode.js
@@ -58,4 +58,4 @@ export const label = ( node, name ) => context( node, { label: name } );
 addNodeElement( 'context', context );
 addNodeElement( 'label', label );
 
-addNodeClass( ContextNode );
+addNodeClass( 'ContextNode', ContextNode );

--- a/examples/jsm/nodes/core/IndexNode.js
+++ b/examples/jsm/nodes/core/IndexNode.js
@@ -63,4 +63,4 @@ export default IndexNode;
 export const vertexIndex = nodeImmutable( IndexNode, IndexNode.VERTEX );
 export const instanceIndex = nodeImmutable( IndexNode, IndexNode.INSTANCE );
 
-addNodeClass( IndexNode );
+addNodeClass( 'IndexNode', IndexNode );

--- a/examples/jsm/nodes/core/InputNode.js
+++ b/examples/jsm/nodes/core/InputNode.js
@@ -80,4 +80,4 @@ class InputNode extends Node {
 
 export default InputNode;
 
-addNodeClass( InputNode );
+addNodeClass( 'InputNode', InputNode );

--- a/examples/jsm/nodes/core/Node.js
+++ b/examples/jsm/nodes/core/Node.js
@@ -28,7 +28,7 @@ class Node extends EventDispatcher {
 
 	get type() {
 
-		return this.constructor.name;
+		return this.constructor.type;
 
 	}
 
@@ -462,12 +462,13 @@ class Node extends EventDispatcher {
 
 export default Node;
 
-export function addNodeClass( nodeClass ) {
+export function addNodeClass( type, nodeClass ) {
 
-	if ( typeof nodeClass !== 'function' || ! nodeClass.name ) throw new Error( `Node class ${ nodeClass.name } is not a class` );
-	if ( NodeClasses.has( nodeClass.name ) ) throw new Error( `Redefinition of node class ${ nodeClass.name }` );
+	if ( typeof nodeClass !== 'function' || ! type ) throw new Error( `Node class ${ type } is not a class` );
+	if ( NodeClasses.has( type ) ) throw new Error( `Redefinition of node class ${ type }` );
 
-	NodeClasses.set( nodeClass.name, nodeClass );
+	NodeClasses.set( type, nodeClass );
+	nodeClass.type = type;
 
 }
 

--- a/examples/jsm/nodes/core/OutputStructNode.js
+++ b/examples/jsm/nodes/core/OutputStructNode.js
@@ -59,4 +59,4 @@ export default OutputStructNode;
 
 export const outputStruct = nodeProxy( OutputStructNode );
 
-addNodeClass( OutputStructNode );
+addNodeClass( 'OutputStructNode', OutputStructNode );

--- a/examples/jsm/nodes/core/PropertyNode.js
+++ b/examples/jsm/nodes/core/PropertyNode.js
@@ -60,4 +60,4 @@ export const output = nodeImmutable( PropertyNode, 'vec4', 'Output' );
 export const dashSize = nodeImmutable( PropertyNode, 'float', 'dashSize' );
 export const gapSize = nodeImmutable( PropertyNode, 'float', 'gapSize' );
 
-addNodeClass( PropertyNode );
+addNodeClass( 'PropertyNode', PropertyNode );

--- a/examples/jsm/nodes/core/StackNode.js
+++ b/examples/jsm/nodes/core/StackNode.js
@@ -96,4 +96,4 @@ export default StackNode;
 
 export const stack = nodeProxy( StackNode );
 
-addNodeClass( StackNode );
+addNodeClass( 'StackNode', StackNode );

--- a/examples/jsm/nodes/core/StructTypeNode.js
+++ b/examples/jsm/nodes/core/StructTypeNode.js
@@ -21,4 +21,4 @@ class StructTypeNode extends Node {
 
 export default StructTypeNode;
 
-addNodeClass( StructTypeNode );
+addNodeClass( 'StructTypeNode', StructTypeNode );

--- a/examples/jsm/nodes/core/TempNode.js
+++ b/examples/jsm/nodes/core/TempNode.js
@@ -55,4 +55,4 @@ class TempNode extends Node {
 
 export default TempNode;
 
-addNodeClass( TempNode );
+addNodeClass( 'TempNode', TempNode );

--- a/examples/jsm/nodes/core/UniformNode.js
+++ b/examples/jsm/nodes/core/UniformNode.js
@@ -60,4 +60,4 @@ export const uniform = ( arg1, arg2 ) => {
 
 };
 
-addNodeClass( UniformNode );
+addNodeClass( 'UniformNode', UniformNode );

--- a/examples/jsm/nodes/core/VarNode.js
+++ b/examples/jsm/nodes/core/VarNode.js
@@ -84,4 +84,4 @@ export const temp = nodeProxy( VarNode );
 
 addNodeElement( 'temp', temp );
 
-addNodeClass( VarNode );
+addNodeClass( 'VarNode', VarNode );

--- a/examples/jsm/nodes/core/VaryingNode.js
+++ b/examples/jsm/nodes/core/VaryingNode.js
@@ -66,4 +66,4 @@ export const varying = nodeProxy( VaryingNode );
 
 addNodeElement( 'varying', varying );
 
-addNodeClass( VaryingNode );
+addNodeClass( 'VaryingNode', VaryingNode );

--- a/examples/jsm/nodes/display/BlendModeNode.js
+++ b/examples/jsm/nodes/display/BlendModeNode.js
@@ -96,4 +96,4 @@ addNodeElement( 'dodge', dodge );
 addNodeElement( 'overlay', overlay );
 addNodeElement( 'screen', screen );
 
-addNodeClass( BlendModeNode );
+addNodeClass( 'BlendModeNode', BlendModeNode );

--- a/examples/jsm/nodes/display/BumpMapNode.js
+++ b/examples/jsm/nodes/display/BumpMapNode.js
@@ -74,4 +74,4 @@ export default BumpMapNode;
 
 export const bumpMap = nodeProxy( BumpMapNode );
 
-addNodeClass( BumpMapNode );
+addNodeClass( 'BumpMapNode', BumpMapNode );

--- a/examples/jsm/nodes/display/ColorAdjustmentNode.js
+++ b/examples/jsm/nodes/display/ColorAdjustmentNode.js
@@ -97,4 +97,4 @@ addNodeElement( 'saturation', saturation );
 addNodeElement( 'vibrance', vibrance );
 addNodeElement( 'hue', hue );
 
-addNodeClass( ColorAdjustmentNode );
+addNodeClass( 'ColorAdjustmentNode', ColorAdjustmentNode );

--- a/examples/jsm/nodes/display/ColorSpaceNode.js
+++ b/examples/jsm/nodes/display/ColorSpaceNode.js
@@ -105,4 +105,4 @@ addNodeElement( 'sRGBToLinear', sRGBToLinear );
 addNodeElement( 'linearToColorSpace', linearToColorSpace );
 addNodeElement( 'colorSpaceToLinear', colorSpaceToLinear );
 
-addNodeClass( ColorSpaceNode );
+addNodeClass( 'ColorSpaceNode', ColorSpaceNode );

--- a/examples/jsm/nodes/display/FrontFacingNode.js
+++ b/examples/jsm/nodes/display/FrontFacingNode.js
@@ -24,4 +24,4 @@ export default FrontFacingNode;
 export const frontFacing = nodeImmutable( FrontFacingNode );
 export const faceDirection = float( frontFacing ).mul( 2.0 ).sub( 1.0 );
 
-addNodeClass( FrontFacingNode );
+addNodeClass( 'FrontFacingNode', FrontFacingNode );

--- a/examples/jsm/nodes/display/NormalMapNode.js
+++ b/examples/jsm/nodes/display/NormalMapNode.js
@@ -103,4 +103,4 @@ export const normalMap = nodeProxy( NormalMapNode );
 
 export const TBNViewMatrix = mat3( tangentView, bitangentView, normalView );
 
-addNodeClass( NormalMapNode );
+addNodeClass( 'NormalMapNode', NormalMapNode );

--- a/examples/jsm/nodes/display/PosterizeNode.js
+++ b/examples/jsm/nodes/display/PosterizeNode.js
@@ -29,4 +29,4 @@ export const posterize = nodeProxy( PosterizeNode );
 
 addNodeElement( 'posterize', posterize );
 
-addNodeClass( PosterizeNode );
+addNodeClass( 'PosterizeNode', PosterizeNode );

--- a/examples/jsm/nodes/display/ToneMappingNode.js
+++ b/examples/jsm/nodes/display/ToneMappingNode.js
@@ -138,4 +138,4 @@ export default ToneMappingNode;
 
 export const toneMapping = ( mapping, exposure, color ) => nodeObject( new ToneMappingNode( mapping, nodeObject( exposure ), nodeObject( color ) ) );
 
-addNodeClass( ToneMappingNode );
+addNodeClass( 'ToneMappingNode', ToneMappingNode );

--- a/examples/jsm/nodes/display/ViewportDepthNode.js
+++ b/examples/jsm/nodes/display/ViewportDepthNode.js
@@ -66,4 +66,4 @@ export default ViewportDepthNode;
 export const depth = nodeImmutable( ViewportDepthNode, ViewportDepthNode.DEPTH );
 export const depthTexture = nodeProxy( ViewportDepthNode, ViewportDepthNode.DEPTH_TEXTURE );
 
-addNodeClass( ViewportDepthNode );
+addNodeClass( 'ViewportDepthNode', ViewportDepthNode );

--- a/examples/jsm/nodes/display/ViewportDepthTextureNode.js
+++ b/examples/jsm/nodes/display/ViewportDepthTextureNode.js
@@ -31,4 +31,4 @@ export const viewportDepthTexture = nodeProxy( ViewportDepthTextureNode );
 
 addNodeElement( 'viewportDepthTexture', viewportDepthTexture );
 
-addNodeClass( ViewportDepthTextureNode );
+addNodeClass( 'ViewportDepthTextureNode', ViewportDepthTextureNode );

--- a/examples/jsm/nodes/display/ViewportNode.js
+++ b/examples/jsm/nodes/display/ViewportNode.js
@@ -126,4 +126,4 @@ export const viewportBottomLeft = nodeImmutable( ViewportNode, ViewportNode.BOTT
 export const viewportTopRight = nodeImmutable( ViewportNode, ViewportNode.TOP_RIGHT );
 export const viewportBottomRight = nodeImmutable( ViewportNode, ViewportNode.BOTTOM_RIGHT );
 
-addNodeClass( ViewportNode );
+addNodeClass( 'ViewportNode', ViewportNode );

--- a/examples/jsm/nodes/display/ViewportSharedTextureNode.js
+++ b/examples/jsm/nodes/display/ViewportSharedTextureNode.js
@@ -28,4 +28,4 @@ export const viewportSharedTexture = nodeProxy( ViewportSharedTextureNode );
 
 addNodeElement( 'viewportSharedTexture', viewportSharedTexture );
 
-addNodeClass( ViewportSharedTextureNode );
+addNodeClass( 'ViewportSharedTextureNode', ViewportSharedTextureNode );

--- a/examples/jsm/nodes/display/ViewportTextureNode.js
+++ b/examples/jsm/nodes/display/ViewportTextureNode.js
@@ -72,4 +72,4 @@ export const viewportMipTexture = nodeProxy( ViewportTextureNode, null, null, { 
 addNodeElement( 'viewportTexture', viewportTexture );
 addNodeElement( 'viewportMipTexture', viewportMipTexture );
 
-addNodeClass( ViewportTextureNode );
+addNodeClass( 'ViewportTextureNode', ViewportTextureNode );

--- a/examples/jsm/nodes/fog/FogExp2Node.js
+++ b/examples/jsm/nodes/fog/FogExp2Node.js
@@ -32,4 +32,4 @@ export const densityFog = nodeProxy( FogExp2Node );
 
 addNodeElement( 'densityFog', densityFog );
 
-addNodeClass( FogExp2Node );
+addNodeClass( 'FogExp2Node', FogExp2Node );

--- a/examples/jsm/nodes/fog/FogNode.js
+++ b/examples/jsm/nodes/fog/FogNode.js
@@ -34,4 +34,4 @@ export const fog = nodeProxy( FogNode );
 
 addNodeElement( 'fog', fog );
 
-addNodeClass( FogNode );
+addNodeClass( 'FogNode', FogNode );

--- a/examples/jsm/nodes/fog/FogRangeNode.js
+++ b/examples/jsm/nodes/fog/FogRangeNode.js
@@ -31,4 +31,4 @@ export const rangeFog = nodeProxy( FogRangeNode );
 
 addNodeElement( 'rangeFog', rangeFog );
 
-addNodeClass( FogRangeNode );
+addNodeClass( 'FogRangeNode', FogRangeNode );

--- a/examples/jsm/nodes/geometry/RangeNode.js
+++ b/examples/jsm/nodes/geometry/RangeNode.js
@@ -101,4 +101,4 @@ export default RangeNode;
 
 export const range = nodeProxy( RangeNode );
 
-addNodeClass( RangeNode );
+addNodeClass( 'RangeNode', RangeNode );

--- a/examples/jsm/nodes/gpgpu/ComputeNode.js
+++ b/examples/jsm/nodes/gpgpu/ComputeNode.js
@@ -82,4 +82,4 @@ export const compute = ( node, count, workgroupSize ) => nodeObject( new Compute
 
 addNodeElement( 'compute', compute );
 
-addNodeClass( ComputeNode );
+addNodeClass( 'ComputeNode', ComputeNode );

--- a/examples/jsm/nodes/lighting/AONode.js
+++ b/examples/jsm/nodes/lighting/AONode.js
@@ -24,4 +24,4 @@ class AONode extends LightingNode {
 
 export default AONode;
 
-addNodeClass( AONode );
+addNodeClass( 'AONode', AONode );

--- a/examples/jsm/nodes/lighting/AmbientLightNode.js
+++ b/examples/jsm/nodes/lighting/AmbientLightNode.js
@@ -24,4 +24,4 @@ export default AmbientLightNode;
 
 addLightNode( AmbientLight, AmbientLightNode );
 
-addNodeClass( AmbientLightNode );
+addNodeClass( 'AmbientLightNode', AmbientLightNode );

--- a/examples/jsm/nodes/lighting/AnalyticLightNode.js
+++ b/examples/jsm/nodes/lighting/AnalyticLightNode.js
@@ -181,4 +181,4 @@ class AnalyticLightNode extends LightingNode {
 
 export default AnalyticLightNode;
 
-addNodeClass( AnalyticLightNode );
+addNodeClass( 'AnalyticLightNode', AnalyticLightNode );

--- a/examples/jsm/nodes/lighting/DirectionalLightNode.js
+++ b/examples/jsm/nodes/lighting/DirectionalLightNode.js
@@ -37,4 +37,4 @@ export default DirectionalLightNode;
 
 addLightNode( DirectionalLight, DirectionalLightNode );
 
-addNodeClass( DirectionalLightNode );
+addNodeClass( 'DirectionalLightNode', DirectionalLightNode );

--- a/examples/jsm/nodes/lighting/EnvironmentNode.js
+++ b/examples/jsm/nodes/lighting/EnvironmentNode.js
@@ -188,4 +188,4 @@ const createIrradianceContext = ( normalWorldNode ) => {
 
 export default EnvironmentNode;
 
-addNodeClass( EnvironmentNode );
+addNodeClass( 'EnvironmentNode', EnvironmentNode );

--- a/examples/jsm/nodes/lighting/HemisphereLightNode.js
+++ b/examples/jsm/nodes/lighting/HemisphereLightNode.js
@@ -52,4 +52,4 @@ export default HemisphereLightNode;
 
 addLightNode( HemisphereLight, HemisphereLightNode );
 
-addNodeClass( HemisphereLightNode );
+addNodeClass( 'HemisphereLightNode', HemisphereLightNode );

--- a/examples/jsm/nodes/lighting/IESSpotLightNode.js
+++ b/examples/jsm/nodes/lighting/IESSpotLightNode.js
@@ -36,4 +36,4 @@ export default IESSpotLightNode;
 
 addLightNode( IESSpotLight, IESSpotLightNode );
 
-addNodeClass( IESSpotLightNode );
+addNodeClass( 'IESSpotLightNode', IESSpotLightNode );

--- a/examples/jsm/nodes/lighting/LightNode.js
+++ b/examples/jsm/nodes/lighting/LightNode.js
@@ -54,4 +54,4 @@ export default LightNode;
 
 export const lightTargetDirection = nodeProxy( LightNode, LightNode.TARGET_DIRECTION );
 
-addNodeClass( LightNode );
+addNodeClass( 'LightNode', LightNode );

--- a/examples/jsm/nodes/lighting/LightingContextNode.js
+++ b/examples/jsm/nodes/lighting/LightingContextNode.js
@@ -99,4 +99,4 @@ export const lightingContext = nodeProxy( LightingContextNode );
 
 addNodeElement( 'lightingContext', lightingContext );
 
-addNodeClass( LightingContextNode );
+addNodeClass( 'LightingContextNode', LightingContextNode );

--- a/examples/jsm/nodes/lighting/LightingNode.js
+++ b/examples/jsm/nodes/lighting/LightingNode.js
@@ -18,4 +18,4 @@ class LightingNode extends Node {
 
 export default LightingNode;
 
-addNodeClass( LightingNode );
+addNodeClass( 'LightingNode', LightingNode );

--- a/examples/jsm/nodes/lighting/PointLightNode.js
+++ b/examples/jsm/nodes/lighting/PointLightNode.js
@@ -65,4 +65,4 @@ export default PointLightNode;
 
 addLightNode( PointLight, PointLightNode );
 
-addNodeClass( PointLightNode );
+addNodeClass( 'PointLightNode', PointLightNode );

--- a/examples/jsm/nodes/lighting/SpotLightNode.js
+++ b/examples/jsm/nodes/lighting/SpotLightNode.js
@@ -86,4 +86,4 @@ export default SpotLightNode;
 
 addLightNode( SpotLight, SpotLightNode );
 
-addNodeClass( SpotLightNode );
+addNodeClass( 'SpotLightNode', SpotLightNode );

--- a/examples/jsm/nodes/materials/Line2NodeMaterial.js
+++ b/examples/jsm/nodes/materials/Line2NodeMaterial.js
@@ -446,4 +446,4 @@ class Line2NodeMaterial extends NodeMaterial {
 
 export default Line2NodeMaterial;
 
-addNodeMaterial( Line2NodeMaterial );
+addNodeMaterial( 'Line2NodeMaterial', Line2NodeMaterial );

--- a/examples/jsm/nodes/materials/LineBasicNodeMaterial.js
+++ b/examples/jsm/nodes/materials/LineBasicNodeMaterial.js
@@ -25,4 +25,4 @@ class LineBasicNodeMaterial extends NodeMaterial {
 
 export default LineBasicNodeMaterial;
 
-addNodeMaterial( LineBasicNodeMaterial );
+addNodeMaterial( 'LineBasicNodeMaterial', LineBasicNodeMaterial );

--- a/examples/jsm/nodes/materials/LineDashedNodeMaterial.js
+++ b/examples/jsm/nodes/materials/LineDashedNodeMaterial.js
@@ -51,4 +51,4 @@ class LineDashedNodeMaterial extends NodeMaterial {
 
 export default LineDashedNodeMaterial;
 
-addNodeMaterial( LineDashedNodeMaterial );
+addNodeMaterial( 'LineDashedNodeMaterial', LineDashedNodeMaterial );

--- a/examples/jsm/nodes/materials/MeshBasicNodeMaterial.js
+++ b/examples/jsm/nodes/materials/MeshBasicNodeMaterial.js
@@ -24,4 +24,4 @@ class MeshBasicNodeMaterial extends NodeMaterial {
 
 export default MeshBasicNodeMaterial;
 
-addNodeMaterial( MeshBasicNodeMaterial );
+addNodeMaterial( 'MeshBasicNodeMaterial', MeshBasicNodeMaterial );

--- a/examples/jsm/nodes/materials/MeshLambertNodeMaterial.js
+++ b/examples/jsm/nodes/materials/MeshLambertNodeMaterial.js
@@ -31,4 +31,4 @@ class MeshLambertNodeMaterial extends NodeMaterial {
 
 export default MeshLambertNodeMaterial;
 
-addNodeMaterial( MeshLambertNodeMaterial );
+addNodeMaterial( 'MeshLambertNodeMaterial', MeshLambertNodeMaterial );

--- a/examples/jsm/nodes/materials/MeshNormalNodeMaterial.js
+++ b/examples/jsm/nodes/materials/MeshNormalNodeMaterial.js
@@ -37,4 +37,4 @@ class MeshNormalNodeMaterial extends NodeMaterial {
 
 export default MeshNormalNodeMaterial;
 
-addNodeMaterial( MeshNormalNodeMaterial );
+addNodeMaterial( 'MeshNormalNodeMaterial', MeshNormalNodeMaterial );

--- a/examples/jsm/nodes/materials/MeshPhongNodeMaterial.js
+++ b/examples/jsm/nodes/materials/MeshPhongNodeMaterial.js
@@ -62,4 +62,4 @@ class MeshPhongNodeMaterial extends NodeMaterial {
 
 export default MeshPhongNodeMaterial;
 
-addNodeMaterial( MeshPhongNodeMaterial );
+addNodeMaterial( 'MeshPhongNodeMaterial', MeshPhongNodeMaterial );

--- a/examples/jsm/nodes/materials/MeshPhysicalNodeMaterial.js
+++ b/examples/jsm/nodes/materials/MeshPhysicalNodeMaterial.js
@@ -125,4 +125,4 @@ class MeshPhysicalNodeMaterial extends MeshStandardNodeMaterial {
 
 export default MeshPhysicalNodeMaterial;
 
-addNodeMaterial( MeshPhysicalNodeMaterial );
+addNodeMaterial( 'MeshPhysicalNodeMaterial', MeshPhysicalNodeMaterial );

--- a/examples/jsm/nodes/materials/MeshStandardNodeMaterial.js
+++ b/examples/jsm/nodes/materials/MeshStandardNodeMaterial.js
@@ -77,4 +77,4 @@ class MeshStandardNodeMaterial extends NodeMaterial {
 
 export default MeshStandardNodeMaterial;
 
-addNodeMaterial( MeshStandardNodeMaterial );
+addNodeMaterial( 'MeshStandardNodeMaterial', MeshStandardNodeMaterial );

--- a/examples/jsm/nodes/materials/NodeMaterial.js
+++ b/examples/jsm/nodes/materials/NodeMaterial.js
@@ -29,7 +29,7 @@ class NodeMaterial extends ShaderMaterial {
 
 		this.isNodeMaterial = true;
 
-		this.type = this.constructor.name;
+		this.type = this.constructor.type;
 
 		this.forceSinglePass = false;
 
@@ -521,12 +521,13 @@ class NodeMaterial extends ShaderMaterial {
 
 export default NodeMaterial;
 
-export function addNodeMaterial( nodeMaterial ) {
+export function addNodeMaterial( type, nodeMaterial ) {
 
-	if ( typeof nodeMaterial !== 'function' || ! nodeMaterial.name ) throw new Error( `Node material ${ nodeMaterial.name } is not a class` );
-	if ( NodeMaterials.has( nodeMaterial.name ) ) throw new Error( `Redefinition of node material ${ nodeMaterial.name }` );
+	if ( typeof nodeMaterial !== 'function' || ! type ) throw new Error( `Node material ${ type } is not a class` );
+	if ( NodeMaterials.has( type ) ) throw new Error( `Redefinition of node material ${ type }` );
 
-	NodeMaterials.set( nodeMaterial.name, nodeMaterial );
+	NodeMaterials.set( type, nodeMaterial );
+	nodeMaterial.type = type;
 
 }
 
@@ -542,4 +543,4 @@ export function createNodeMaterialFromType( type ) {
 
 }
 
-addNodeMaterial( NodeMaterial );
+addNodeMaterial( 'NodeMaterial', NodeMaterial );

--- a/examples/jsm/nodes/materials/PointsNodeMaterial.js
+++ b/examples/jsm/nodes/materials/PointsNodeMaterial.js
@@ -46,4 +46,4 @@ class PointsNodeMaterial extends NodeMaterial {
 
 export default PointsNodeMaterial;
 
-addNodeMaterial( PointsNodeMaterial );
+addNodeMaterial( 'PointsNodeMaterial', PointsNodeMaterial );

--- a/examples/jsm/nodes/materials/SpriteNodeMaterial.js
+++ b/examples/jsm/nodes/materials/SpriteNodeMaterial.js
@@ -100,4 +100,4 @@ class SpriteNodeMaterial extends NodeMaterial {
 
 export default SpriteNodeMaterial;
 
-addNodeMaterial( SpriteNodeMaterial );
+addNodeMaterial( 'SpriteNodeMaterial', SpriteNodeMaterial );

--- a/examples/jsm/nodes/math/CondNode.js
+++ b/examples/jsm/nodes/math/CondNode.js
@@ -83,4 +83,4 @@ export const cond = nodeProxy( CondNode );
 
 addNodeElement( 'cond', cond );
 
-addNodeClass( CondNode );
+addNodeClass( 'CondNode', CondNode );

--- a/examples/jsm/nodes/math/HashNode.js
+++ b/examples/jsm/nodes/math/HashNode.js
@@ -31,4 +31,4 @@ export const hash = nodeProxy( HashNode );
 
 addNodeElement( 'hash', hash );
 
-addNodeClass( HashNode );
+addNodeClass( 'HashNode', HashNode );

--- a/examples/jsm/nodes/math/MathNode.js
+++ b/examples/jsm/nodes/math/MathNode.js
@@ -356,4 +356,4 @@ addNodeElement( 'faceForward', faceForward );
 addNodeElement( 'difference', difference );
 addNodeElement( 'saturate', saturate );
 
-addNodeClass( MathNode );
+addNodeClass( 'MathNode', MathNode );

--- a/examples/jsm/nodes/math/OperatorNode.js
+++ b/examples/jsm/nodes/math/OperatorNode.js
@@ -266,4 +266,4 @@ addNodeElement( 'bitXor', bitXor );
 addNodeElement( 'shiftLeft', shiftLeft );
 addNodeElement( 'shiftRight', shiftRight );
 
-addNodeClass( OperatorNode );
+addNodeClass( 'OperatorNode', OperatorNode );

--- a/examples/jsm/nodes/procedural/CheckerNode.js
+++ b/examples/jsm/nodes/procedural/CheckerNode.js
@@ -39,4 +39,4 @@ export const checker = nodeProxy( CheckerNode );
 
 addNodeElement( 'checker', checker );
 
-addNodeClass( CheckerNode );
+addNodeClass( 'CheckerNode', CheckerNode );

--- a/examples/jsm/nodes/shadernode/ShaderNode.js
+++ b/examples/jsm/nodes/shadernode/ShaderNode.js
@@ -399,7 +399,7 @@ export const tslFn = ( jsFunc ) => {
 
 };
 
-addNodeClass( ShaderNode );
+addNodeClass( 'ShaderNode', ShaderNode );
 
 // types
 // @TODO: Maybe export from ConstNode.js?

--- a/examples/jsm/nodes/utils/ArrayElementNode.js
+++ b/examples/jsm/nodes/utils/ArrayElementNode.js
@@ -30,4 +30,4 @@ class ArrayElementNode extends Node { // @TODO: If extending from TempNode it br
 
 export default ArrayElementNode;
 
-addNodeClass( ArrayElementNode );
+addNodeClass( 'ArrayElementNode', ArrayElementNode );

--- a/examples/jsm/nodes/utils/ConvertNode.js
+++ b/examples/jsm/nodes/utils/ConvertNode.js
@@ -62,4 +62,4 @@ class ConvertNode extends Node {
 
 export default ConvertNode;
 
-addNodeClass( ConvertNode );
+addNodeClass( 'ConvertNode', ConvertNode );

--- a/examples/jsm/nodes/utils/DiscardNode.js
+++ b/examples/jsm/nodes/utils/DiscardNode.js
@@ -23,4 +23,4 @@ export const discard = nodeProxy( DiscardNode );
 
 addNodeElement( 'discard', discard );
 
-addNodeClass( DiscardNode );
+addNodeClass( 'DiscardNode', DiscardNode );

--- a/examples/jsm/nodes/utils/EquirectUVNode.js
+++ b/examples/jsm/nodes/utils/EquirectUVNode.js
@@ -30,4 +30,4 @@ export default EquirectUVNode;
 
 export const equirectUV = nodeProxy( EquirectUVNode );
 
-addNodeClass( EquirectUVNode );
+addNodeClass( 'EquirectUVNode', EquirectUVNode );

--- a/examples/jsm/nodes/utils/JoinNode.js
+++ b/examples/jsm/nodes/utils/JoinNode.js
@@ -48,4 +48,4 @@ class JoinNode extends TempNode {
 
 export default JoinNode;
 
-addNodeClass( JoinNode );
+addNodeClass( 'JoinNode', JoinNode );

--- a/examples/jsm/nodes/utils/LoopNode.js
+++ b/examples/jsm/nodes/utils/LoopNode.js
@@ -183,4 +183,4 @@ export const loop = ( ...params ) => nodeObject( new LoopNode( nodeArray( params
 
 addNodeElement( 'loop', ( returns, ...params ) => bypass( returns, loop( ...params ) ) );
 
-addNodeClass( LoopNode );
+addNodeClass( 'LoopNode', LoopNode );

--- a/examples/jsm/nodes/utils/MatcapUVNode.js
+++ b/examples/jsm/nodes/utils/MatcapUVNode.js
@@ -27,4 +27,4 @@ export default MatcapUVNode;
 
 export const matcapUV = nodeImmutable( MatcapUVNode );
 
-addNodeClass( MatcapUVNode );
+addNodeClass( 'MatcapUVNode', MatcapUVNode );

--- a/examples/jsm/nodes/utils/MaxMipLevelNode.js
+++ b/examples/jsm/nodes/utils/MaxMipLevelNode.js
@@ -43,4 +43,4 @@ export default MaxMipLevelNode;
 
 export const maxMipLevel = nodeProxy( MaxMipLevelNode );
 
-addNodeClass( MaxMipLevelNode );
+addNodeClass( 'MaxMipLevelNode', MaxMipLevelNode );

--- a/examples/jsm/nodes/utils/OscNode.js
+++ b/examples/jsm/nodes/utils/OscNode.js
@@ -78,4 +78,4 @@ export const oscSquare = nodeProxy( OscNode, OscNode.SQUARE );
 export const oscTriangle = nodeProxy( OscNode, OscNode.TRIANGLE );
 export const oscSawtooth = nodeProxy( OscNode, OscNode.SAWTOOTH );
 
-addNodeClass( OscNode );
+addNodeClass( 'OscNode', OscNode );

--- a/examples/jsm/nodes/utils/PackingNode.js
+++ b/examples/jsm/nodes/utils/PackingNode.js
@@ -52,4 +52,4 @@ export const colorToDirection = nodeProxy( PackingNode, PackingNode.COLOR_TO_DIR
 addNodeElement( 'directionToColor', directionToColor );
 addNodeElement( 'colorToDirection', colorToDirection );
 
-addNodeClass( PackingNode );
+addNodeClass( 'PackingNode', PackingNode );

--- a/examples/jsm/nodes/utils/RemapNode.js
+++ b/examples/jsm/nodes/utils/RemapNode.js
@@ -39,4 +39,4 @@ export const remapClamp = nodeProxy( RemapNode );
 addNodeElement( 'remap', remap );
 addNodeElement( 'remapClamp', remapClamp );
 
-addNodeClass( RemapNode );
+addNodeClass( 'RemapNode', RemapNode );

--- a/examples/jsm/nodes/utils/RotateUVNode.js
+++ b/examples/jsm/nodes/utils/RotateUVNode.js
@@ -40,4 +40,4 @@ export const rotateUV = nodeProxy( RotateUVNode );
 
 addNodeElement( 'rotateUV', rotateUV );
 
-addNodeClass( RotateUVNode );
+addNodeClass( 'RotateUVNode', RotateUVNode );

--- a/examples/jsm/nodes/utils/SetNode.js
+++ b/examples/jsm/nodes/utils/SetNode.js
@@ -59,4 +59,4 @@ class SetNode extends TempNode {
 
 export default SetNode;
 
-addNodeClass( SetNode );
+addNodeClass( 'SetNode', SetNode );

--- a/examples/jsm/nodes/utils/SpecularMIPLevelNode.js
+++ b/examples/jsm/nodes/utils/SpecularMIPLevelNode.js
@@ -34,4 +34,4 @@ export default SpecularMIPLevelNode;
 
 export const specularMIPLevel = nodeProxy( SpecularMIPLevelNode );
 
-addNodeClass( SpecularMIPLevelNode );
+addNodeClass( 'SpecularMIPLevelNode', SpecularMIPLevelNode );

--- a/examples/jsm/nodes/utils/SplitNode.js
+++ b/examples/jsm/nodes/utils/SplitNode.js
@@ -101,4 +101,4 @@ class SplitNode extends Node {
 
 export default SplitNode;
 
-addNodeClass( SplitNode );
+addNodeClass( 'SplitNode', SplitNode );

--- a/examples/jsm/nodes/utils/SpriteSheetUVNode.js
+++ b/examples/jsm/nodes/utils/SpriteSheetUVNode.js
@@ -38,4 +38,4 @@ export default SpriteSheetUVNode;
 
 export const spritesheetUV = nodeProxy( SpriteSheetUVNode );
 
-addNodeClass( SpriteSheetUVNode );
+addNodeClass( 'SpriteSheetUVNode', SpriteSheetUVNode );

--- a/examples/jsm/nodes/utils/TimerNode.js
+++ b/examples/jsm/nodes/utils/TimerNode.js
@@ -91,4 +91,4 @@ export const timerGlobal = ( timeScale, value = 0 ) => nodeObject( new TimerNode
 export const timerDelta = ( timeScale, value = 0 ) => nodeObject( new TimerNode( TimerNode.DELTA, timeScale, value ) );
 export const frameId = nodeImmutable( TimerNode, TimerNode.FRAME );
 
-addNodeClass( TimerNode );
+addNodeClass( 'TimerNode', TimerNode );

--- a/examples/jsm/nodes/utils/TriplanarTexturesNode.js
+++ b/examples/jsm/nodes/utils/TriplanarTexturesNode.js
@@ -59,4 +59,4 @@ export const triplanarTexture = ( ...params ) => triplanarTextures( ...params );
 
 addNodeElement( 'triplanarTexture', triplanarTexture );
 
-addNodeClass( TriplanarTexturesNode );
+addNodeClass( 'TriplanarTexturesNode', TriplanarTexturesNode );


### PR DESCRIPTION
Fixes https://github.com/mrdoob/three.js/issues/26518

**Description**

Fix `addNodeClass` and `addNodeMaterial` in case of renaming classes (e.g. when performing minification).
