### PR TITLE
CurvePath: Use correct line type in `closePath()`.

### DIFF
--- a/src/extras/core/CurvePath.js
+++ b/src/extras/core/CurvePath.js
@@ -33,7 +33,7 @@ class CurvePath extends Curve {
 
 		if ( ! startPoint.equals( endPoint ) ) {
 
-			const lineType = startPoint.isVector3 ? 'LineCurve3' : 'LineCurve';
+			const lineType = ( startPoint.isVector2 === true ) ? 'LineCurve' : 'LineCurve3';
 			this.curves.push( new Curves[ lineType ]( endPoint, startPoint ) );
 
 		}

--- a/src/extras/core/CurvePath.js
+++ b/src/extras/core/CurvePath.js
@@ -33,7 +33,8 @@ class CurvePath extends Curve {
 
 		if ( ! startPoint.equals( endPoint ) ) {
 
-			this.curves.push( new Curves[ 'LineCurve' ]( endPoint, startPoint ) );
+			const lineType = startPoint.isVector3 ? 'LineCurve3' : 'LineCurve';
+			this.curves.push( new Curves[ lineType ]( endPoint, startPoint ) );
 
 		}
 


### PR DESCRIPTION
Fixed #26849

**Description**

For curvePath, a Vector3 curve, when the 'curvePath.closePath()' method is called, the points returned by 'curvePath.getPoints()' contain points of type Vector2

** solution**
I added the point type judgment to the 'curvePath.closePath()' method, and then decided whether to use 'LineCurve3' or 'LineCurve' to close the curve depending on the point type
