### PR TITLE
GLTFLoader: Fix to handle reject on afterRoot

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2544,7 +2544,7 @@ class GLTFParser {
 
 			assignExtrasToUserData( result, json );
 
-			Promise.all( parser._invokeAll( function ( ext ) {
+			return Promise.all( parser._invokeAll( function ( ext ) {
 
 				return ext.afterRoot && ext.afterRoot( result );
 


### PR DESCRIPTION
**Description**

Enable to handle rejects generated within the GLTFLoader's afterRoot process.

**Problem**

onError(load function's parameter) is not called when an error occurs in afterRoot.

Here is the reproduced code
```js
  const loader = new GLTFLoader();
  loader.register(() => {
    return {
      afterRoot: async () => {
        throw 'something wrong';
      },
    };
  });
  try {
    const gltf = await loader.loadAsync(url);
  } catch {
    // Not passing through
  }
  // Uncaught (in promise) something wrong
```