### PR TITLE
Docs: fix incorrect chinese translation in SpriteMaterial.html

### DIFF
--- a/docs/api/zh/materials/SpriteMaterial.html
+++ b/docs/api/zh/materials/SpriteMaterial.html
@@ -36,7 +36,7 @@
 		<h3>[name]( [param:Object parameters] )</h3>
 		<p>
 			[page:Object parameters] - (可选)用于定义材质外观的对象，具有一个或多个属性。
-			材质的任何属性都可以从此处传入(包括从[page:Material] 和 [page:ShaderMaterial]继承的任何属性)。<br /><br />
+			材质的任何属性都可以从此处传入(包括从[page:Material]继承的任何属性)。<br /><br />
 
 			属性[page:Hexadecimal color]例外，其可以作为十六进制字符串传递，默认情况下为 *0xffffff*（白色），
 			内部调用[page:Color.set](color)。


### PR DESCRIPTION
Related issue: -

**Description**

Fixed incorrect chinese translation.

The original incorrect chinese translation means
`
Any property of the
			material (including any property inherited from Material and  ShaderMaterial can be
			passed in here.
`


