### PR TITLE
TransformControls: Use in-plane rotation when eye and selected gizmo axis are parallel

### DIFF
--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -465,17 +465,9 @@ class TransformControls extends Object3D {
 
 			const ROTATION_SPEED = 20 / this.worldPosition.distanceTo( _tempVector.setFromMatrixPosition( this.camera.matrixWorld ) );
 
-			if ( axis === 'E' ) {
+			let _inPlaneRotation = false;
 
-				this.rotationAxis.copy( this.eye );
-				this.rotationAngle = this.pointEnd.angleTo( this.pointStart );
-
-				this._startNorm.copy( this.pointStart ).normalize();
-				this._endNorm.copy( this.pointEnd ).normalize();
-
-				this.rotationAngle *= ( this._endNorm.cross( this._startNorm ).dot( this.eye ) < 0 ? 1 : - 1 );
-
-			} else if ( axis === 'XYZE' ) {
+			if ( axis === 'XYZE' ) {
 
 				this.rotationAxis.copy( this._offset ).cross( this.eye ).normalize();
 				this.rotationAngle = this._offset.dot( _tempVector.copy( this.rotationAxis ).cross( this.eye ) ) * ROTATION_SPEED;
@@ -492,7 +484,31 @@ class TransformControls extends Object3D {
 
 				}
 
-				this.rotationAngle = this._offset.dot( _tempVector.cross( this.eye ).normalize() ) * ROTATION_SPEED;
+				_tempVector.cross( this.eye );
+
+				// When _tempVector is 0 after cross with this.eye the vectors are parallel and should use in-plane rotation logic.
+				if ( _tempVector.length() === 0 ) {
+
+					_inPlaneRotation = true;
+
+				} else {
+
+					this.rotationAngle = this._offset.dot( _tempVector.normalize() ) * ROTATION_SPEED;
+
+				}
+
+
+			}
+
+			if ( axis === 'E' || _inPlaneRotation ) {
+
+				this.rotationAxis.copy( this.eye );
+				this.rotationAngle = this.pointEnd.angleTo( this.pointStart );
+
+				this._startNorm.copy( this.pointStart ).normalize();
+				this._endNorm.copy( this.pointEnd ).normalize();
+
+				this.rotationAngle *= ( this._endNorm.cross( this._startNorm ).dot( this.eye ) < 0 ? 1 : - 1 );
 
 			}
 


### PR DESCRIPTION
**Description**

I found this bug when using the rotate TransformControls in a web-app that allows users to set a camera to be perfectly parallel to a cardinal axis. When the TransformControls eye and the selected axis for rotation are parallel, the resulting rotation is zero as the cross product of two parallel vectors is the zero vector and the dot product with the zero vector is zero. This was fixed by performing the cross product and checking if the resulting vector has a length of zero, indicating that the vectors are parallel. If the vectors are parallel, the rotation logic for the `E` handle is used.

This bug does not occur very often as setting the value of `this.eye` from the camera position usually small rounding errors causing the vector to not be perfectly parallel with a cardinal axis. For the app I am working on, the camera can be set perfectly inline with a cardinal axis when the rotation control is displayed causing the bug to occur frequently.

Other notes/questions:

- I am not sure if `_inPlaneRotation` is the best name for the variable. I tend to refer to the `E` handle as the in-plane handle but I am open to other suggestions.
- I did not check if `_tempVector` is equal to `_zeroVector` as the resulting vector could include `-0` and may not be strictly equal to `_zeroVector` even when `_tempVector` and `this.eye` are parallel

Before (using a modified version of the transform controls example where I have hardcoded the camera position to be parallel to the x-axis):

https://github.com/mrdoob/three.js/assets/37275661/e252212c-f9e8-448f-b59b-b9045f62b34d

After:

https://github.com/mrdoob/three.js/assets/37275661/e60b8b45-5385-4af3-8362-254b329741c2
