### PR TITLE
BumpMapNode: Subflows of TextureNode and UVNode

### DIFF
--- a/examples/jsm/nodes/accessors/ExtendedMaterialNode.js
+++ b/examples/jsm/nodes/accessors/ExtendedMaterialNode.js
@@ -44,8 +44,7 @@ class ExtendedMaterialNode extends MaterialNode {
 
 			} else if ( material.bumpMap ) {
 
-				// @TODO: Replace material.bumpMap to this.getTexture( 'bumpMap' )
-				node = bumpMap( material.bumpMap, materialReference( 'bumpScale', 'float' ) );
+				node = bumpMap( this.getTexture( 'bumpMap' ).r, materialReference( 'bumpScale', 'float' ) );
 
 			} else {
 

--- a/examples/jsm/nodes/display/BumpMapNode.js
+++ b/examples/jsm/nodes/display/BumpMapNode.js
@@ -1,5 +1,4 @@
 import TempNode from '../core/TempNode.js';
-import { texture } from '../accessors/TextureNode.js';
 import { addNodeClass } from '../core/Node.js';
 import { uv } from '../accessors/UVNode.js';
 import { normalView } from '../accessors/NormalNode.js';
@@ -28,7 +27,7 @@ const dHdxy_fwd = tslFn( ( { textureNode, bumpScale } ) => {
 
 	if ( texNode.isTextureNode !== true ) {
 
-		throw new Error( 'THREE.TSL: dHdxy_fwd() textureNode is not a TextureNode.' );
+		throw new Error( 'THREE.TSL: dHdxy_fwd() requires a TextureNode.' );
 
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/mrdoob/three.js/issues/26848, https://github.com/mrdoob/three.js/issues/26847

**Description**

This approach allows the creation of subflows of samplers without having to create new `TextureNodes`, thus preserving the instance, an important feature when used in a `MaterialNode` or to define algorithms or channels before calling `BumpMapNode`, such as `bumpMap( node.r )`.

The inverted bump correction was also made.