### PR TITLE
Examples: Fixed ESLint error.

### DIFF
--- a/examples/webgpu_compute_texture_pingpong.html
+++ b/examples/webgpu_compute_texture_pingpong.html
@@ -35,7 +35,7 @@
 			let pingTexture, pongTexture;
 			let material;
 			let phase = true;
-			let seed = uniform( new THREE.Vector2() );
+			const seed = uniform( new THREE.Vector2() );
 
 			init();
 			render();


### PR DESCRIPTION
Related issue: #XXXX

**Description**

ESLint: 'seed' is never reassigned. Use 'const' instead.