### PR TITLE
SimplifyModifier: Add uv/normal/tangent/color support.

### DIFF
--- a/examples/jsm/modifiers/SimplifyModifier.js
+++ b/examples/jsm/modifiers/SimplifyModifier.js
@@ -32,7 +32,7 @@ class SimplifyModifier {
 
 		for ( const name in attributes ) {
 
-			if ( name !== 'position' && name !== 'uv' && name !== 'tangent' && name !== 'normal' ) geometry.deleteAttribute( name );
+			if ( name !== 'position' && name !== 'uv' && name !== 'normal' && name !== 'tangent' && name !== 'color' ) geometry.deleteAttribute( name );
 
 		}
 
@@ -51,10 +51,12 @@ class SimplifyModifier {
 		const uvAttribute = geometry.getAttribute( 'uv' );
 		const normalAttribute = geometry.getAttribute( 'normal' );
 		const tangentAttribute = geometry.getAttribute( 'tangent' );
+		const colorAttribute = geometry.getAttribute( 'color' );
 
 		let t = null;
 		let v2 = null;
 		let nor = null;
+		let col = null;
 
 		for ( let i = 0; i < positionAttribute.count; i ++ ) {
 
@@ -77,7 +79,13 @@ class SimplifyModifier {
 
 			}
 
-			const vertex = new Vertex( v, v2, nor, t );
+			if ( colorAttribute ) {
+
+				col = new THREE.Color().fromBufferAttribute( colorAttribute, i );
+
+			}
+
+			const vertex = new Vertex( v, v2, nor, t, col );
 			vertices.push( vertex );
 
 		}
@@ -148,6 +156,7 @@ class SimplifyModifier {
 		const uv = [];
 		const normal = [];
 		const tangent = [];
+		const color = [];
 
 		index = [];
 
@@ -175,6 +184,13 @@ class SimplifyModifier {
 
 			}
 
+			if ( vertex.color ) {
+
+				color.push( vertex.color.r, vertex.color.g, vertex.color.b );
+
+			}
+
+
 			// cache final index to GREATLY speed up faces reconstruction
 			vertex.id = i;
 
@@ -193,6 +209,8 @@ class SimplifyModifier {
 		if ( uv.length > 0 ) simplifiedGeometry.setAttribute( 'uv', new Float32BufferAttribute( uv, 2 ) );
 		if ( normal.length > 0 ) simplifiedGeometry.setAttribute( 'normal', new Float32BufferAttribute( normal, 3 ) );
 		if ( tangent.length > 0 ) simplifiedGeometry.setAttribute( 'tangent', new Float32BufferAttribute( tangent, 4 ) );
+		if ( color.length > 0 ) simplifiedGeometry.setAttribute( 'color', new Float32BufferAttribute( color, 3 ) );
+
 		simplifiedGeometry.setIndex( index );
 
 		return simplifiedGeometry;
@@ -550,12 +568,13 @@ class Triangle {
 
 class Vertex {
 
-	constructor( v, uv, normal, tangent ) {
+	constructor( v, uv, normal, tangent, color ) {
 
 		this.position = v;
 		this.uv = uv;
 		this.normal = normal;
 		this.tangent = tangent;
+		this.color = color;
 
 		this.id = - 1; // external use position in vertices list (for e.g. face generation)
 

--- a/examples/jsm/modifiers/SimplifyModifier.js
+++ b/examples/jsm/modifiers/SimplifyModifier.js
@@ -1,7 +1,9 @@
 import {
 	BufferGeometry,
 	Float32BufferAttribute,
-	Vector3
+	Vector2,
+	Vector3,
+	Vector4
 } from 'three';
 import * as BufferGeometryUtils from '../utils/BufferGeometryUtils.js';
 
@@ -20,13 +22,17 @@ class SimplifyModifier {
 	modify( geometry, count ) {
 
 		geometry = geometry.clone();
+
+		// currently morphAttributes are not supported
+		delete geometry.morphAttributes.position;
+		delete geometry.morphAttributes.normal;
 		const attributes = geometry.attributes;
 
-		// this modifier can only process indexed and non-indexed geomtries with a position attribute
+		// this modifier can only process indexed and non-indexed geomtries with at least a position attribute
 
 		for ( const name in attributes ) {
 
-			if ( name !== 'position' ) geometry.deleteAttribute( name );
+			if ( name !== 'position' && name !== 'uv' && name !== 'tangent' && name !== 'normal' ) geometry.deleteAttribute( name );
 
 		}
 
@@ -42,12 +48,36 @@ class SimplifyModifier {
 		// add vertices
 
 		const positionAttribute = geometry.getAttribute( 'position' );
+		const uvAttribute = geometry.getAttribute( 'uv' );
+		const normalAttribute = geometry.getAttribute( 'normal' );
+		const tangentAttribute = geometry.getAttribute( 'tangent' );
+
+		let t = null;
+		let v2 = null;
+		let nor = null;
 
 		for ( let i = 0; i < positionAttribute.count; i ++ ) {
 
 			const v = new Vector3().fromBufferAttribute( positionAttribute, i );
+			if ( uvAttribute ) {
 
-			const vertex = new Vertex( v );
+				v2 = new Vector2().fromBufferAttribute( uvAttribute, i );
+
+			}
+
+			if ( normalAttribute ) {
+
+				nor = new Vector3().fromBufferAttribute( normalAttribute, i );
+
+			}
+
+			if ( tangentAttribute ) {
+
+				t = new Vector4().fromBufferAttribute( tangentAttribute, i );
+
+			}
+
+			const vertex = new Vertex( v, v2, nor, t );
 			vertices.push( vertex );
 
 		}
@@ -115,6 +145,9 @@ class SimplifyModifier {
 
 		const simplifiedGeometry = new BufferGeometry();
 		const position = [];
+		const uv = [];
+		const normal = [];
+		const tangent = [];
 
 		index = [];
 
@@ -122,10 +155,28 @@ class SimplifyModifier {
 
 		for ( let i = 0; i < vertices.length; i ++ ) {
 
-			const vertex = vertices[ i ].position;
-			position.push( vertex.x, vertex.y, vertex.z );
+			const vertex = vertices[ i ];
+			position.push( vertex.position.x, vertex.position.y, vertex.position.z );
+			if ( vertex.uv ) {
+
+				uv.push( vertex.uv.x, vertex.uv.y );
+
+			}
+
+			if ( vertex.normal ) {
+
+				normal.push( vertex.normal.x, vertex.normal.y, vertex.normal.z );
+
+			}
+
+			if ( vertex.tangent ) {
+
+				tangent.push( vertex.tangent.x, vertex.tangent.y, vertex.tangent.z, vertex.tangent.w );
+
+			}
+
 			// cache final index to GREATLY speed up faces reconstruction
-			vertices[ i ].id = i;
+			vertex.id = i;
 
 		}
 
@@ -138,9 +189,10 @@ class SimplifyModifier {
 
 		}
 
-		//
-
 		simplifiedGeometry.setAttribute( 'position', new Float32BufferAttribute( position, 3 ) );
+		if ( uv.length > 0 ) simplifiedGeometry.setAttribute( 'uv', new Float32BufferAttribute( uv, 2 ) );
+		if ( normal.length > 0 ) simplifiedGeometry.setAttribute( 'normal', new Float32BufferAttribute( normal, 3 ) );
+		if ( tangent.length > 0 ) simplifiedGeometry.setAttribute( 'tangent', new Float32BufferAttribute( tangent, 4 ) );
 		simplifiedGeometry.setIndex( index );
 
 		return simplifiedGeometry;
@@ -318,7 +370,7 @@ function removeFace( f, faces ) {
 
 }
 
-function collapse( vertices, faces, u, v ) { // u and v are pointers to vertices of an edge
+function collapse( vertices, faces, u, v ) {
 
 	// Collapse the edge uv by moving vertex u onto v
 
@@ -327,6 +379,24 @@ function collapse( vertices, faces, u, v ) { // u and v are pointers to vertices
 		// u is a vertex all by itself so just delete it..
 		removeVertex( u, vertices );
 		return;
+
+	}
+
+	if ( v.uv ) {
+
+		u.uv.copy( v.uv );
+
+	}
+
+	if ( v.normal ) {
+
+		v.normal.add( u.normal ).normalize();
+
+	}
+
+	if ( v.tangent ) {
+
+		v.tangent.add( u.tangent ).normalize();
 
 	}
 
@@ -480,9 +550,12 @@ class Triangle {
 
 class Vertex {
 
-	constructor( v ) {
+	constructor( v, uv, normal, tangent ) {
 
 		this.position = v;
+		this.uv = uv;
+		this.normal = normal;
+		this.tangent = tangent;
 
 		this.id = - 1; // external use position in vertices list (for e.g. face generation)
 


### PR DESCRIPTION
Related issue: #14058

**Description**

The SimplifyModifier now conserve the original uv / texture / tangent of a geometry if they exists. It leads to texture conservation and better result.

Here some test : 

Original 
![image](https://github.com/mrdoob/three.js/assets/213351/e55cbc71-fa78-4f94-b1e4-9f596dc3aaef)
simplify 45%
![image](https://github.com/mrdoob/three.js/assets/213351/95836ecf-7be9-41c5-9122-0d11315f1a37)
simplify 20%
![image](https://github.com/mrdoob/three.js/assets/213351/86fcfedf-8b9b-4e6e-9fff-d6d07e0b7689)

Original : 
![image](https://github.com/mrdoob/three.js/assets/213351/70f58f06-0736-43ca-bfd5-56b05ae42f2e)
Simplify 65%
![image](https://github.com/mrdoob/three.js/assets/213351/c405a0c8-07d9-4a8a-8b79-b1e56a151693)

Original:
![image](https://github.com/mrdoob/three.js/assets/213351/d19d0e5d-9d9a-40cf-9218-d61cc67e5d75)
Simplify 80%
![image](https://github.com/mrdoob/three.js/assets/213351/57c83abb-6451-4fce-82a4-b8e72c69acdc)

