### PR TITLE
Backend: Add this.isWeb*Backend

### DIFF
--- a/examples/jsm/renderers/webgl/WebGLBackend.js
+++ b/examples/jsm/renderers/webgl/WebGLBackend.js
@@ -17,6 +17,8 @@ class WebGLBackend extends Backend {
 
 		super( parameters );
 
+		this.isWebGLBackend = true;
+
 	}
 
 	async init( renderer ) {

--- a/examples/jsm/renderers/webgpu/WebGPUBackend.js
+++ b/examples/jsm/renderers/webgpu/WebGPUBackend.js
@@ -33,6 +33,8 @@ class WebGPUBackend extends Backend {
 
 		super( parameters );
 
+		this.isWebGPUBackend = true;
+
 		// some parameters require default values other than "undefined"
 
 		this.parameters.antialias = ( parameters.antialias === true );


### PR DESCRIPTION
I want to know which Backend is running. Maybe there is a better way...

```js
console.log( 'renderer.backend: ', renderer.backend.isWebGLBackend ? 'WebGLBackend' : 'WebGPUBackend' );
```