### PR TITLE
Docs: update from the old way of importing

### DIFF
--- a/docs/examples/en/animations/CCDIKSolver.html
+++ b/docs/examples/en/animations/CCDIKSolver.html
@@ -24,7 +24,7 @@
 		</p>
 
 		<code>
-			import { CCDIKSolver } from 'three/addons/animation/CCDIKSolver.js';
+			import { CCDIKSolver } from 'three/examples/jsm/animation/CCDIKSolver.js';
 		</code>
 
 		<h2>Code Example</h2>

--- a/docs/examples/en/animations/MMDAnimationHelper.html
+++ b/docs/examples/en/animations/MMDAnimationHelper.html
@@ -22,7 +22,7 @@
 		</p>
 
 		<code>
-			import { MMDAnimationHelper } from 'three/addons/animation/MMDAnimationHelper.js';
+			import { MMDAnimationHelper } from 'three/examples/jsm/animation/MMDAnimationHelper.js';
 		</code>
 
 		<h2>Code Example</h2>

--- a/docs/examples/en/animations/MMDPhysics.html
+++ b/docs/examples/en/animations/MMDPhysics.html
@@ -21,7 +21,7 @@
 		</p>
 
 		<code>
-			import { MMDPhysics } from 'three/addons/animation/MMDPhysics.js';
+			import { MMDPhysics } from 'three/examples/jsm/animation/MMDPhysics.js';
 		</code>
 
 		<h2>Code Example</h2>

--- a/docs/examples/en/controls/ArcballControls.html
+++ b/docs/examples/en/controls/ArcballControls.html
@@ -41,7 +41,7 @@
 		</p>
 
 		<code>
-			import { ArcballControls } from 'three/addons/controls/ArcballControls.js';
+			import { ArcballControls } from 'three/examples/jsm/controls/ArcballControls.js';
 		</code>
 
 		<h2>Code Example</h2>

--- a/docs/examples/en/controls/DragControls.html
+++ b/docs/examples/en/controls/DragControls.html
@@ -23,7 +23,7 @@
 		</p>
 
 		<code>
-			import { DragControls } from 'three/addons/controls/DragControls.js';
+			import { DragControls } from 'three/examples/jsm/controls/DragControls.js';
 		</code>
 
 		<h2>Code Example</h2>

--- a/docs/examples/en/controls/FirstPersonControls.html
+++ b/docs/examples/en/controls/FirstPersonControls.html
@@ -22,7 +22,7 @@
 		</p>
 
 		<code>
-			import { FirstPersonControls } from 'three/addons/controls/FirstPersonControls.js';
+			import { FirstPersonControls } from 'three/examples/jsm/controls/FirstPersonControls.js';
 		</code>
 
 		<h2>Examples</h2>

--- a/docs/examples/en/controls/FlyControls.html
+++ b/docs/examples/en/controls/FlyControls.html
@@ -23,7 +23,7 @@
 		</p>
 
 		<code>
-			import { FlyControls } from 'three/addons/controls/FlyControls.js';
+			import { FlyControls } from 'three/examples/jsm/controls/FlyControls.js';
 		</code>
 
 		<h2>Examples</h2>

--- a/docs/examples/en/controls/MapControls.html
+++ b/docs/examples/en/controls/MapControls.html
@@ -24,7 +24,7 @@
 		</p>
 
 		<code>
-			import { MapControls } from 'three/addons/controls/MapControls.js';
+			import { MapControls } from 'three/examples/jsm/controls/MapControls.js';
 		</code>
 
 		<h2>Code Example</h2>

--- a/docs/examples/en/controls/OrbitControls.html
+++ b/docs/examples/en/controls/OrbitControls.html
@@ -24,7 +24,7 @@
 		</p>
 
 		<code>
-			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 		</code>
 
 		<h2>Code Example</h2>

--- a/docs/examples/en/controls/PointerLockControls.html
+++ b/docs/examples/en/controls/PointerLockControls.html
@@ -24,7 +24,7 @@
 		</p>
 
 		<code>
-			import { PointerLockControls } from 'three/addons/controls/PointerLockControls.js';
+			import { PointerLockControls } from 'three/examples/jsm/controls/PointerLockControls.js';
 		</code>
 
 		<h2>Code Example</h2>

--- a/docs/examples/en/controls/TrackballControls.html
+++ b/docs/examples/en/controls/TrackballControls.html
@@ -26,7 +26,7 @@
 		</p>
 
 		<code>
-			import { TrackballControls } from 'three/addons/controls/TrackballControls.js';
+			import { TrackballControls } from 'three/examples/jsm/controls/TrackballControls.js';
 		</code>
 
 		<h2>Examples</h2>

--- a/docs/examples/en/controls/TransformControls.html
+++ b/docs/examples/en/controls/TransformControls.html
@@ -26,7 +26,7 @@
 		</p>
 
 		<code>
-			import { TransformControls } from 'three/addons/controls/TransformControls.js';
+			import { TransformControls } from 'three/examples/jsm/controls/TransformControls.js';
 		</code>
 
 		<h2>Examples</h2>

--- a/docs/examples/en/exporters/DRACOExporter.html
+++ b/docs/examples/en/exporters/DRACOExporter.html
@@ -32,7 +32,7 @@
 		</p>
 
 		<code>
-			import { DRACOExporter } from 'three/addons/exporters/DRACOExporter.js';
+			import { DRACOExporter } from 'three/examples/jsm/exporters/DRACOExporter.js';
 		</code>
 
 		<h2>Code Example</h2>

--- a/docs/examples/en/exporters/EXRExporter.html
+++ b/docs/examples/en/exporters/EXRExporter.html
@@ -29,7 +29,7 @@
 		</p>
 
 		<code>
-			import { EXRExporter } from 'three/addons/exporters/EXRExporter.js';
+			import { EXRExporter } from 'three/examples/jsm/exporters/EXRExporter.js';
 		</code>
 
 		<h2>Code Example</h2>

--- a/docs/examples/en/exporters/GLTFExporter.html
+++ b/docs/examples/en/exporters/GLTFExporter.html
@@ -28,7 +28,7 @@
 		</p>
 
 		<code>
-			import { GLTFExporter } from 'three/addons/exporters/GLTFExporter.js';
+			import { GLTFExporter } from 'three/examples/jsm/exporters/GLTFExporter.js';
 		</code>
 
 		<h2>Extensions</h2>

--- a/docs/examples/en/exporters/OBJExporter.html
+++ b/docs/examples/en/exporters/OBJExporter.html
@@ -23,7 +23,7 @@
 		</p>
 
 		<code>
-			import { OBJExporter } from 'three/addons/exporters/OBJExporter.js';
+			import { OBJExporter } from 'three/examples/jsm/exporters/OBJExporter.js';
 		</code>
 
 		<h2>Code Example</h2>

--- a/docs/examples/en/exporters/PLYExporter.html
+++ b/docs/examples/en/exporters/PLYExporter.html
@@ -26,7 +26,7 @@
 		</p>
 
 		<code>
-			import { PLYExporter } from 'three/addons/exporters/PLYExporter.js';
+			import { PLYExporter } from 'three/examples/jsm/exporters/PLYExporter.js';
 		</code>
 
 		<h2>Code Example</h2>

--- a/docs/examples/en/exporters/STLExporter.html
+++ b/docs/examples/en/exporters/STLExporter.html
@@ -25,7 +25,7 @@
 		</p>
 
 		<code>
-			import { STLExporter } from 'three/addons/exporters/STLExporter.js';
+			import { STLExporter } from 'three/examples/jsm/exporters/STLExporter.js';
 		</code>
 
 		<h2>Code Example</h2>

--- a/docs/examples/en/geometries/ConvexGeometry.html
+++ b/docs/examples/en/geometries/ConvexGeometry.html
@@ -24,7 +24,7 @@
 		</p>
 
 		<code>
-			import { ConvexGeometry } from 'three/addons/geometries/ConvexGeometry.js';
+			import { ConvexGeometry } from 'three/examples/jsm/geometries/ConvexGeometry.js';
 		</code>
 
 		<h2>Code Example</h2>

--- a/docs/examples/en/geometries/DecalGeometry.html
+++ b/docs/examples/en/geometries/DecalGeometry.html
@@ -24,7 +24,7 @@
 		</p>
 
 		<code>
-			import { DecalGeometry } from 'three/addons/geometries/DecalGeometry.js';
+			import { DecalGeometry } from 'three/examples/jsm/geometries/DecalGeometry.js';
 		</code>
 
 		<h2>Code Example</h2>

--- a/docs/examples/en/geometries/ParametricGeometry.html
+++ b/docs/examples/en/geometries/ParametricGeometry.html
@@ -23,7 +23,7 @@
 		</p>
 
 		<code>
-			import { ParametricGeometry } from 'three/addons/geometries/ParametricGeometry.js';
+			import { ParametricGeometry } from 'three/examples/jsm/geometries/ParametricGeometry.js';
 		</code>
 
 		<h2>Code Example</h2>

--- a/docs/examples/en/geometries/TextGeometry.html
+++ b/docs/examples/en/geometries/TextGeometry.html
@@ -25,7 +25,7 @@
 		</p>
 
 		<code>
-			import { TextGeometry } from 'three/addons/geometries/TextGeometry.js';
+			import { TextGeometry } from 'three/examples/jsm/geometries/TextGeometry.js';
 		</code>
 
 		<h2>Code Example</h2>

--- a/docs/examples/en/helpers/LightProbeHelper.html
+++ b/docs/examples/en/helpers/LightProbeHelper.html
@@ -23,7 +23,7 @@
 		</p>
 
 		<code>
-			import { LightProbeHelper } from 'three/addons/helpers/LightProbeHelper.js';
+			import { LightProbeHelper } from 'three/examples/jsm/helpers/LightProbeHelper.js';
 		</code>
 
 		<h2>Code Example</h2>

--- a/docs/examples/en/helpers/PositionalAudioHelper.html
+++ b/docs/examples/en/helpers/PositionalAudioHelper.html
@@ -21,7 +21,7 @@
 		</p>
 
 		<code>
-			import { PositionalAudioHelper } from 'three/addons/helpers/PositionalAudioHelper.js';
+			import { PositionalAudioHelper } from 'three/examples/jsm/helpers/PositionalAudioHelper.js';
 		</code>
 
 		<h2>Code Example</h2>

--- a/docs/examples/en/helpers/RectAreaLightHelper.html
+++ b/docs/examples/en/helpers/RectAreaLightHelper.html
@@ -23,7 +23,7 @@
 		</p>
 
 		<code>
-			import { RectAreaLightHelper } from 'three/addons/helpers/RectAreaLightHelper.js';
+			import { RectAreaLightHelper } from 'three/examples/jsm/helpers/RectAreaLightHelper.js';
 		</code>
 
 		<h2>Code Example</h2>

--- a/docs/examples/en/helpers/VertexNormalsHelper.html
+++ b/docs/examples/en/helpers/VertexNormalsHelper.html
@@ -25,7 +25,7 @@
 		</p>
 
 		<code>
-			import { VertexNormalsHelper } from 'three/addons/helpers/VertexNormalsHelper.js';
+			import { VertexNormalsHelper } from 'three/examples/jsm/helpers/VertexNormalsHelper.js';
 		</code>
 
 		<h2>Code Example</h2>

--- a/docs/examples/en/helpers/VertexTangentsHelper.html
+++ b/docs/examples/en/helpers/VertexTangentsHelper.html
@@ -25,7 +25,7 @@
 		</p>
 
 		<code>
-			import { VertexTangentsHelper } from 'three/addons/helpers/VertexTangentsHelper.js';
+			import { VertexTangentsHelper } from 'three/examples/jsm/helpers/VertexTangentsHelper.js';
 		</code>
 
 		<h2>Code Example</h2>

--- a/docs/examples/en/lights/LightProbeGenerator.html
+++ b/docs/examples/en/lights/LightProbeGenerator.html
@@ -22,7 +22,7 @@
 		</p>
 
 		<code>
-			import { LightProbeGenerator } from 'three/addons/lights/LightProbeGenerator.js';
+			import { LightProbeGenerator } from 'three/examples/jsm/lights/LightProbeGenerator.js';
 		</code>
 
 		<h2>Examples</h2>

--- a/docs/examples/en/loaders/3DMLoader.html
+++ b/docs/examples/en/loaders/3DMLoader.html
@@ -25,7 +25,7 @@
 		</p>
 
 		<code>
-			import { Rhino3dmLoader } from 'three/addons/loaders/3DMLoader.js';
+			import { Rhino3dmLoader } from 'three/examples/jsm/loaders/3DMLoader.js';
 		</code>
 
 		<h2>Supported Conversions</h2>

--- a/docs/examples/en/loaders/DRACOLoader.html
+++ b/docs/examples/en/loaders/DRACOLoader.html
@@ -39,7 +39,7 @@
 		</p>
 
 		<code>
-			import { DRACOLoader } from 'three/addons/loaders/DRACOLoader.js';
+			import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader.js';
 		</code>
 
 		<h2>Code Example</h2>

--- a/docs/examples/en/loaders/FontLoader.html
+++ b/docs/examples/en/loaders/FontLoader.html
@@ -27,7 +27,7 @@
 		</p>
 
 		<code>
-			import { FontLoader } from 'three/addons/loaders/FontLoader.js';
+			import { FontLoader } from 'three/examples/jsm/loaders/FontLoader.js';
 		</code>
 
 		<h2>Code Example</h2>

--- a/docs/examples/en/loaders/GLTFLoader.html
+++ b/docs/examples/en/loaders/GLTFLoader.html
@@ -33,7 +33,7 @@
 		</p>
 
 		<code>
-			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+			import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 		</code>
 
 		<h2>Extensions</h2>

--- a/docs/examples/en/loaders/KTX2Loader.html
+++ b/docs/examples/en/loaders/KTX2Loader.html
@@ -35,7 +35,7 @@
 		</p>
 
 		<code>
-			import { KTX2Loader } from 'three/addons/loaders/KTX2Loader.js';
+			import { KTX2Loader } from 'three/examples/jsm/loaders/KTX2Loader.js';
 		</code>
 
 		<h2>Code Example</h2>

--- a/docs/examples/en/loaders/LDrawLoader.html
+++ b/docs/examples/en/loaders/LDrawLoader.html
@@ -37,7 +37,7 @@
 		</p>
 
 		<code>
-			import { LDrawLoader } from 'three/addons/loaders/LDrawLoader.js';
+			import { LDrawLoader } from 'three/examples/jsm/loaders/LDrawLoader.js';
 		</code>
 
 		<h2>Extensions</h2>

--- a/docs/examples/en/loaders/MMDLoader.html
+++ b/docs/examples/en/loaders/MMDLoader.html
@@ -25,7 +25,7 @@
 		</p>
 
 		<code>
-			import { MMDLoader } from 'three/addons/loaders/MMDLoader.js';
+			import { MMDLoader } from 'three/examples/jsm/loaders/MMDLoader.js';
 		</code>
 
 		<h2>Code Example</h2>

--- a/docs/examples/en/loaders/MTLLoader.html
+++ b/docs/examples/en/loaders/MTLLoader.html
@@ -24,7 +24,7 @@
 		</p>
 
 		<code>
-			import { MTLLoader } from 'three/addons/loaders/MTLLoader.js';
+			import { MTLLoader } from 'three/examples/jsm/loaders/MTLLoader.js';
 		</code>
 
 		<h2>Constructor</h2>

--- a/docs/examples/en/loaders/OBJLoader.html
+++ b/docs/examples/en/loaders/OBJLoader.html
@@ -26,7 +26,7 @@
 		</p>
 
 		<code>
-			import { OBJLoader } from 'three/addons/loaders/OBJLoader.js';
+			import { OBJLoader } from 'three/examples/jsm/loaders/OBJLoader.js';
 		</code>
 
 		<h2>Code Example</h2>

--- a/docs/examples/en/loaders/PCDLoader.html
+++ b/docs/examples/en/loaders/PCDLoader.html
@@ -30,7 +30,7 @@
 		</p>
 
 		<code>
-			import { PCDLoader } from 'three/addons/loaders/PCDLoader.js';
+			import { PCDLoader } from 'three/examples/jsm/loaders/PCDLoader.js';
 		</code>
 
 		<h2>Code Example</h2>

--- a/docs/examples/en/loaders/PDBLoader.html
+++ b/docs/examples/en/loaders/PDBLoader.html
@@ -23,7 +23,7 @@
 		</p>
 
 		<code>
-			import { PDBLoader } from 'three/addons/loaders/PDBLoader.js';
+			import { PDBLoader } from 'three/examples/jsm/loaders/PDBLoader.js';
 		</code>
 
 		<h2>Code Example</h2>

--- a/docs/examples/en/loaders/SVGLoader.html
+++ b/docs/examples/en/loaders/SVGLoader.html
@@ -23,7 +23,7 @@
 		</p>
 
 		<code>
-			import { SVGLoader } from 'three/addons/loaders/SVGLoader.js';
+			import { SVGLoader } from 'three/examples/jsm/loaders/SVGLoader.js';
 		</code>
 
 		<h2>Code Example</h2>

--- a/docs/examples/en/loaders/TGALoader.html
+++ b/docs/examples/en/loaders/TGALoader.html
@@ -23,7 +23,7 @@
 		</p>
 
 		<code>
-			import { TGALoader } from 'three/addons/loaders/TGALoader.js';
+			import { TGALoader } from 'three/examples/jsm/loaders/TGALoader.js';
 		</code>
 
 		<h2>Code Example</h2>

--- a/docs/examples/en/math/Lut.html
+++ b/docs/examples/en/math/Lut.html
@@ -21,7 +21,7 @@
 		</p>
 
 		<code>
-			import { Lut } from 'three/addons/math/Lut.js';
+			import { Lut } from 'three/examples/jsm/math/Lut.js';
 		</code>
 
 		<h2>Code Example</h2>

--- a/docs/examples/en/math/MeshSurfaceSampler.html
+++ b/docs/examples/en/math/MeshSurfaceSampler.html
@@ -21,7 +21,7 @@
 		</p>
 
 		<code>
-			import { MeshSurfaceSampler } from 'three/addons/math/MeshSurfaceSampler.js';
+			import { MeshSurfaceSampler } from 'three/examples/jsm/math/MeshSurfaceSampler.js';
 		</code>
 
 		<h2>Code Example</h2>

--- a/docs/examples/en/math/OBB.html
+++ b/docs/examples/en/math/OBB.html
@@ -21,7 +21,7 @@
 		</p>
 
 		<code>
-			import { OBB } from 'three/addons/math/OBB.js';
+			import { OBB } from 'three/examples/jsm/math/OBB.js';
 		</code>
 
 		<h2>Examples</h2>

--- a/docs/examples/en/math/convexhull/ConvexHull.html
+++ b/docs/examples/en/math/convexhull/ConvexHull.html
@@ -21,7 +21,7 @@
 		</p>
 
 		<code>
-			import { ConvexHull } from 'three/addons/math/ConvexHull.js';
+			import { ConvexHull } from 'three/examples/jsm/math/ConvexHull.js';
 		</code>
 
 

--- a/docs/examples/en/math/convexhull/Face.html
+++ b/docs/examples/en/math/convexhull/Face.html
@@ -22,7 +22,7 @@
 		</p>
 
 		<code>
-			import { Face } from 'three/addons/math/ConvexHull.js';
+			import { Face } from 'three/examples/jsm/math/ConvexHull.js';
 		</code>
 
 

--- a/docs/examples/en/math/convexhull/HalfEdge.html
+++ b/docs/examples/en/math/convexhull/HalfEdge.html
@@ -21,7 +21,7 @@
 		</p>
 
 		<code>
-			import { HalfEdge } from 'three/addons/math/ConvexHull.js';
+			import { HalfEdge } from 'three/examples/jsm/math/ConvexHull.js';
 		</code>
 
 

--- a/docs/examples/en/math/convexhull/VertexList.html
+++ b/docs/examples/en/math/convexhull/VertexList.html
@@ -21,7 +21,7 @@
 		</p>
 
 		<code>
-			import { VertexList } from 'three/addons/math/ConvexHull.js';
+			import { VertexList } from 'three/examples/jsm/math/ConvexHull.js';
 		</code>
 
 

--- a/docs/examples/en/math/convexhull/VertexNode.html
+++ b/docs/examples/en/math/convexhull/VertexNode.html
@@ -21,7 +21,7 @@
 		</p>
 
 		<code>
-			import { VertexNode } from 'three/addons/math/ConvexHull.js';
+			import { VertexNode } from 'three/examples/jsm/math/ConvexHull.js';
 		</code>
 
 

--- a/docs/examples/en/objects/Lensflare.html
+++ b/docs/examples/en/objects/Lensflare.html
@@ -23,7 +23,7 @@
 		</p>
 
 		<code>
-			import { Lensflare } from 'three/addons/objects/Lensflare.js';
+			import { Lensflare } from 'three/examples/jsm/objects/Lensflare.js';
 		</code>
 
 		<h2>Code Example</h2>

--- a/docs/examples/en/postprocessing/EffectComposer.html
+++ b/docs/examples/en/postprocessing/EffectComposer.html
@@ -24,7 +24,7 @@
 		</p>
 
 		<code>
-			import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
+			import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js';
 		</code>
 
 		<h2>Examples</h2>

--- a/docs/examples/en/renderers/CSS2DRenderer.html
+++ b/docs/examples/en/renderers/CSS2DRenderer.html
@@ -22,7 +22,7 @@
 		</p>
 
 		<code>
-			import { CSS2DRenderer } from 'three/addons/renderers/CSS2DRenderer.js';
+			import { CSS2DRenderer } from 'three/examples/jsm/renderers/CSS2DRenderer.js';
 		</code>
 
 		<h2>Examples</h2>

--- a/docs/examples/en/renderers/CSS3DRenderer.html
+++ b/docs/examples/en/renderers/CSS3DRenderer.html
@@ -31,7 +31,7 @@
 		</p>
 
 		<code>
-			import { CSS3DRenderer } from 'three/addons/renderers/CSS3DRenderer.js';
+			import { CSS3DRenderer } from 'three/examples/jsm/renderers/CSS3DRenderer.js';
 		</code>
 
 		<h2>Examples</h2>

--- a/docs/examples/en/renderers/SVGRenderer.html
+++ b/docs/examples/en/renderers/SVGRenderer.html
@@ -41,7 +41,7 @@
 		</p>
 
 		<code>
-			import { SVGRenderer } from 'three/addons/renderers/SVGRenderer.js';
+			import { SVGRenderer } from 'three/examples/jsm/renderers/SVGRenderer.js';
 		</code>
 
 		<h2>Examples</h2>

--- a/docs/examples/en/utils/BufferGeometryUtils.html
+++ b/docs/examples/en/utils/BufferGeometryUtils.html
@@ -21,7 +21,7 @@
 		</p>
 
 		<code>
-			import * as BufferGeometryUtils from 'three/addons/utils/BufferGeometryUtils.js';
+			import * as BufferGeometryUtils from 'three/examples/jsm/utils/BufferGeometryUtils.js';
 		</code>
 
 		<h2>Methods</h2>

--- a/docs/examples/en/utils/CameraUtils.html
+++ b/docs/examples/en/utils/CameraUtils.html
@@ -21,7 +21,7 @@
 		</p>
 
 		<code>
-			import * as CameraUtils from 'three/addons/utils/CameraUtils.js';
+			import * as CameraUtils from 'three/examples/jsm/utils/CameraUtils.js';
 		</code>
 
 		<h2>Methods</h2>

--- a/docs/examples/en/utils/SceneUtils.html
+++ b/docs/examples/en/utils/SceneUtils.html
@@ -21,7 +21,7 @@
 		</p>
 
 		<code>
-			import { SceneUtils } from 'three/addons/utils/SceneUtils.js';
+			import { SceneUtils } from 'three/examples/jsm/utils/SceneUtils.js';
 		</code>
 
 		<h2>Methods</h2>

--- a/docs/examples/en/utils/SkeletonUtils.html
+++ b/docs/examples/en/utils/SkeletonUtils.html
@@ -21,7 +21,7 @@
 		</p>
 
 		<code>
-			import * as SkeletonUtils from 'three/addons/utils/SkeletonUtils.js';
+			import * as SkeletonUtils from 'three/examples/jsm/utils/SkeletonUtils.js';
 		</code>
 
 		<h2>Methods</h2>

--- a/docs/examples/ko/controls/DragControls.html
+++ b/docs/examples/ko/controls/DragControls.html
@@ -23,7 +23,7 @@
 		</p>
 
 		<code>
-			import { DragControls } from 'three/addons/controls/DragControls.js';
+			import { DragControls } from 'three/examples/jsm/controls/DragControls.js';
 		</code>
 
 		<h2>코드 예시</h2>

--- a/docs/examples/ko/controls/FirstPersonControls.html
+++ b/docs/examples/ko/controls/FirstPersonControls.html
@@ -22,7 +22,7 @@
 		</p>
 
 		<code>
-			import { FirstPersonControls } from 'three/addons/controls/FirstPersonControls.js';
+			import { FirstPersonControls } from 'three/examples/jsm/controls/FirstPersonControls.js';
 		</code>
 
 		<h2>예시</h2>

--- a/docs/examples/ko/controls/FlyControls.html
+++ b/docs/examples/ko/controls/FlyControls.html
@@ -23,7 +23,7 @@
 		</p>
 
 		<code>
-			import { FlyControls } from 'three/addons/controls/FlyControls.js';
+			import { FlyControls } from 'three/examples/jsm/controls/FlyControls.js';
 		</code>
 
 		<h2>예시</h2>

--- a/docs/examples/ko/controls/OrbitControls.html
+++ b/docs/examples/ko/controls/OrbitControls.html
@@ -24,7 +24,7 @@
 		</p>
 
 		<code>
-			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 		</code>
 
 		<h2>코드 예시</h2>

--- a/docs/examples/ko/controls/PointerLockControls.html
+++ b/docs/examples/ko/controls/PointerLockControls.html
@@ -23,7 +23,7 @@
 		</p>
 
 		<code>
-			import { PointerLockControls } from 'three/addons/controls/PointerLockControls.js';
+			import { PointerLockControls } from 'three/examples/jsm/controls/PointerLockControls.js';
 		</code>
 
 		<h2>Code Example</h2>

--- a/docs/examples/ko/controls/TrackballControls.html
+++ b/docs/examples/ko/controls/TrackballControls.html
@@ -26,7 +26,7 @@
 		</p>
 
 		<code>
-			import { TrackballControls } from 'three/addons/controls/TrackballControls.js';
+			import { TrackballControls } from 'three/examples/jsm/controls/TrackballControls.js';
 		</code>
 
 		<h2>예시</h2>

--- a/docs/examples/ko/controls/TransformControls.html
+++ b/docs/examples/ko/controls/TransformControls.html
@@ -27,7 +27,7 @@
 		</p>
 
 		<code>
-			import { TransformControls } from 'three/addons/controls/TransformControls.js';
+			import { TransformControls } from 'three/examples/jsm/controls/TransformControls.js';
 		</code>
 
 		<h2>예시</h2>

--- a/docs/examples/zh/controls/DragControls.html
+++ b/docs/examples/zh/controls/DragControls.html
@@ -23,7 +23,7 @@
 		</p>
 
 		<code>
-			import { DragControls } from 'three/addons/controls/DragControls.js';
+			import { DragControls } from 'three/examples/jsm/controls/DragControls.js';
 		</code>
 
 		<h2>代码示例</h2>

--- a/docs/examples/zh/controls/FirstPersonControls.html
+++ b/docs/examples/zh/controls/FirstPersonControls.html
@@ -22,7 +22,7 @@
 		</p>
 
 		<code>
-			import { FirstPersonControls } from 'three/addons/controls/FirstPersonControls.js';
+			import { FirstPersonControls } from 'three/examples/jsm/controls/FirstPersonControls.js';
 		</code>
 
 		<h2>例子</h2>

--- a/docs/examples/zh/controls/FlyControls.html
+++ b/docs/examples/zh/controls/FlyControls.html
@@ -23,7 +23,7 @@
 		</p>
 
 		<code>
-			import { FlyControls } from 'three/addons/controls/FlyControls.js';
+			import { FlyControls } from 'three/examples/jsm/controls/FlyControls.js';
 		</code>
 
 		<h2>例子</h2>

--- a/docs/examples/zh/controls/OrbitControls.html
+++ b/docs/examples/zh/controls/OrbitControls.html
@@ -25,7 +25,7 @@
 		</p>
 
 		<code>
-			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 		</code>
 
 		<h2>代码示例</h2>

--- a/docs/examples/zh/controls/PointerLockControls.html
+++ b/docs/examples/zh/controls/PointerLockControls.html
@@ -24,7 +24,7 @@
 		</p>
 
 		<code>
-			import { PointerLockControls } from 'three/addons/controls/PointerLockControls.js';
+			import { PointerLockControls } from 'three/examples/jsm/controls/PointerLockControls.js';
 		</code>
 
 		<h2>代码示例</h2>

--- a/docs/examples/zh/controls/TrackballControls.html
+++ b/docs/examples/zh/controls/TrackballControls.html
@@ -26,7 +26,7 @@
 		</p>
 
 		<code>
-			import { TrackballControls } from 'three/addons/controls/TrackballControls.js';
+			import { TrackballControls } from 'three/examples/jsm/controls/TrackballControls.js';
 		</code>
 
 		<h2>例子</h2>

--- a/docs/examples/zh/controls/TransformControls.html
+++ b/docs/examples/zh/controls/TransformControls.html
@@ -26,7 +26,7 @@
 		</p>
 
 		<code>
-			import { TransformControls } from 'three/addons/controls/TransformControls.js';
+			import { TransformControls } from 'three/examples/jsm/controls/TransformControls.js';
 		</code>
 
 		<h2>例子</h2>

--- a/docs/examples/zh/geometries/ConvexGeometry.html
+++ b/docs/examples/zh/geometries/ConvexGeometry.html
@@ -22,7 +22,7 @@
 		</p>
 
 		<code>
-			import { ConvexGeometry } from 'three/addons/geometries/ConvexGeometry.js';
+			import { ConvexGeometry } from 'three/examples/jsm/geometries/ConvexGeometry.js';
 		</code>
 
 		<h2>代码示例</h2>

--- a/docs/examples/zh/geometries/DecalGeometry.html
+++ b/docs/examples/zh/geometries/DecalGeometry.html
@@ -21,7 +21,7 @@
 		</p>
 
 		<code>
-			import { DecalGeometry } from 'three/addons/geometries/DecalGeometry.js';
+			import { DecalGeometry } from 'three/examples/jsm/geometries/DecalGeometry.js';
 		</code>
 
 		<h2>代码示例</h2>

--- a/docs/examples/zh/geometries/ParametricGeometry.html
+++ b/docs/examples/zh/geometries/ParametricGeometry.html
@@ -21,7 +21,7 @@
 		</p>
 
 		<code>
-			import { ParametricGeometry } from 'three/addons/geometries/ParametricGeometry.js';
+			import { ParametricGeometry } from 'three/examples/jsm/geometries/ParametricGeometry.js';
 		</code>
 
 		<h2>代码示例</h2>

--- a/docs/examples/zh/geometries/TextGeometry.html
+++ b/docs/examples/zh/geometries/TextGeometry.html
@@ -25,7 +25,7 @@
 		</p>
 
 		<code>
-			import { TextGeometry } from 'three/addons/geometries/TextGeometry.js';
+			import { TextGeometry } from 'three/examples/jsm/geometries/TextGeometry.js';
 		</code>
 
 		<h2>代码示例</h2>

--- a/docs/examples/zh/helpers/LightProbeHelper.html
+++ b/docs/examples/zh/helpers/LightProbeHelper.html
@@ -23,7 +23,7 @@
 		</p>
 
 		<code>
-			import { LightProbeHelper } from 'three/addons/helpers/LightProbeHelper.js';
+			import { LightProbeHelper } from 'three/examples/jsm/helpers/LightProbeHelper.js';
 		</code>
 
 		<h2>代码示例</h2>

--- a/docs/examples/zh/helpers/PositionalAudioHelper.html
+++ b/docs/examples/zh/helpers/PositionalAudioHelper.html
@@ -21,7 +21,7 @@
 		</p>
 
 		<code>
-			import { PositionalAudioHelper } from 'three/addons/helpers/PositionalAudioHelper.js';
+			import { PositionalAudioHelper } from 'three/examples/jsm/helpers/PositionalAudioHelper.js';
 		</code>
 
 		<h2>代码示例</h2>

--- a/docs/examples/zh/helpers/RectAreaLightHelper.html
+++ b/docs/examples/zh/helpers/RectAreaLightHelper.html
@@ -23,7 +23,7 @@
 		</p>
 
 		<code>
-			import { RectAreaLightHelper } from 'three/addons/helpers/RectAreaLightHelper.js';
+			import { RectAreaLightHelper } from 'three/examples/jsm/helpers/RectAreaLightHelper.js';
 		</code>
 
 		<h2>代码示例</h2>

--- a/docs/examples/zh/helpers/VertexNormalsHelper.html
+++ b/docs/examples/zh/helpers/VertexNormalsHelper.html
@@ -25,7 +25,7 @@
 		</p>
 
 		<code>
-			import { VertexNormalsHelper } from 'three/addons/helpers/VertexNormalsHelper.js';
+			import { VertexNormalsHelper } from 'three/examples/jsm/helpers/VertexNormalsHelper.js';
 		</code>
 
 		<h2>代码示例</h2>

--- a/docs/examples/zh/lights/LightProbeGenerator.html
+++ b/docs/examples/zh/lights/LightProbeGenerator.html
@@ -22,7 +22,7 @@
 		</p>
 
 		<code>
-			import { LightProbeGenerator } from 'three/addons/lights/LightProbeGenerator.js';
+			import { LightProbeGenerator } from 'three/examples/jsm/lights/LightProbeGenerator.js';
 		</code>
 
 		<h2>例子</h2>

--- a/docs/examples/zh/loaders/DRACOLoader.html
+++ b/docs/examples/zh/loaders/DRACOLoader.html
@@ -35,7 +35,7 @@
 		</p>
 
 		<code>
-			import { DRACOLoader } from 'three/addons/loaders/DRACOLoader.js';
+			import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader.js';
 		</code>
 
 		<h2>代码示例</h2>

--- a/docs/examples/zh/loaders/FontLoader.html
+++ b/docs/examples/zh/loaders/FontLoader.html
@@ -26,7 +26,7 @@
 		</p>
 
 		<code>
-			import { FontLoader } from 'three/addons/loaders/FontLoader.js';
+			import { FontLoader } from 'three/examples/jsm/loaders/FontLoader.js';
 		</code>
 
 		<h2>代码示例</h2>

--- a/docs/examples/zh/loaders/GLTFLoader.html
+++ b/docs/examples/zh/loaders/GLTFLoader.html
@@ -32,7 +32,7 @@
 		</p>
 
 		<code>
-			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+			import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 		</code>
 
 

--- a/docs/examples/zh/loaders/MMDLoader.html
+++ b/docs/examples/zh/loaders/MMDLoader.html
@@ -25,7 +25,7 @@
 		</p>
 
 		<code>
-			import { MMDLoader } from 'three/addons/loaders/MMDLoader.js';
+			import { MMDLoader } from 'three/examples/jsm/loaders/MMDLoader.js';
 		</code>
 
 		<h2>代码示例</h2>

--- a/docs/examples/zh/loaders/MTLLoader.html
+++ b/docs/examples/zh/loaders/MTLLoader.html
@@ -24,7 +24,7 @@
 		</p>
 
 		<code>
-			import { MTLLoader } from 'three/addons/loaders/MTLLoader.js';
+			import { MTLLoader } from 'three/examples/jsm/loaders/MTLLoader.js';
 		</code>
 
 		<h2>构造函数</h2>

--- a/docs/examples/zh/loaders/OBJLoader.html
+++ b/docs/examples/zh/loaders/OBJLoader.html
@@ -25,7 +25,7 @@
 		</p>
 
 		<code>
-			import { OBJLoader } from 'three/addons/loaders/OBJLoader.js';
+			import { OBJLoader } from 'three/examples/jsm/loaders/OBJLoader.js';
 		</code>
 
 		<h2>代码示例</h2>

--- a/docs/examples/zh/loaders/PCDLoader.html
+++ b/docs/examples/zh/loaders/PCDLoader.html
@@ -30,7 +30,7 @@
 		</p>
 
 		<code>
-			import { PCDLoader } from 'three/addons/loaders/PCDLoader.js';
+			import { PCDLoader } from 'three/examples/jsm/loaders/PCDLoader.js';
 		</code>
 
 		<h2>代码示例</h2>

--- a/docs/examples/zh/loaders/SVGLoader.html
+++ b/docs/examples/zh/loaders/SVGLoader.html
@@ -23,7 +23,7 @@
 		</p>
 
 		<code>
-			import { SVGLoader } from 'three/addons/loaders/SVGLoader.js';
+			import { SVGLoader } from 'three/examples/jsm/loaders/SVGLoader.js';
 		</code>
 
 		<h2>代码示例</h2>

--- a/docs/examples/zh/loaders/TGALoader.html
+++ b/docs/examples/zh/loaders/TGALoader.html
@@ -22,7 +22,7 @@
 		</p>
 
 		<code>
-			import { TGALoader } from 'three/addons/loaders/TGALoader.js';
+			import { TGALoader } from 'three/examples/jsm/loaders/TGALoader.js';
 		</code>
 
 		<h2>代码示例</h2>

--- a/docs/examples/zh/objects/Lensflare.html
+++ b/docs/examples/zh/objects/Lensflare.html
@@ -21,7 +21,7 @@
 		</p>
 
 		<code>
-			import { Lensflare } from 'three/addons/objects/Lensflare.js';
+			import { Lensflare } from 'three/examples/jsm/objects/Lensflare.js';
 		</code>
 
 		<h2>代码示例</h2>

--- a/docs/examples/zh/postprocessing/EffectComposer.html
+++ b/docs/examples/zh/postprocessing/EffectComposer.html
@@ -23,7 +23,7 @@
 		</p>
 
 		<code>
-			import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
+			import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js';
 		</code>
 
 		<h2>例子</h2>

--- a/docs/examples/zh/renderers/CSS2DRenderer.html
+++ b/docs/examples/zh/renderers/CSS2DRenderer.html
@@ -22,7 +22,7 @@
 		</p>
 
 		<code>
-			import { CSS2DRenderer } from 'three/addons/renderers/CSS2DRenderer.js';
+			import { CSS2DRenderer } from 'three/examples/jsm/renderers/CSS2DRenderer.js';
 		</code>
 
 		<h2>例子</h2>

--- a/docs/examples/zh/renderers/CSS3DRenderer.html
+++ b/docs/examples/zh/renderers/CSS3DRenderer.html
@@ -32,7 +32,7 @@
 		</p>
 
 		<code>
-			import { CSS3DRenderer } from 'three/addons/renderers/CSS3DRenderer.js';
+			import { CSS3DRenderer } from 'three/examples/jsm/renderers/CSS3DRenderer.js';
 		</code>
 
 		<h2>例子</h2>

--- a/docs/examples/zh/renderers/SVGRenderer.html
+++ b/docs/examples/zh/renderers/SVGRenderer.html
@@ -41,7 +41,7 @@
 		</p>
 
 		<code>
-			import { SVGRenderer } from 'three/addons/renderers/SVGRenderer.js';
+			import { SVGRenderer } from 'three/examples/jsm/renderers/SVGRenderer.js';
 		</code>
 
 		<h2>例子</h2>

--- a/docs/examples/zh/utils/BufferGeometryUtils.html
+++ b/docs/examples/zh/utils/BufferGeometryUtils.html
@@ -21,7 +21,7 @@
 		</p>
 
 		<code>
-			import * as BufferGeometryUtils from 'three/addons/utils/BufferGeometryUtils.js';
+			import * as BufferGeometryUtils from 'three/examples/jsm/utils/BufferGeometryUtils.js';
 		</code>
 
 		<h2>方法</h2>

--- a/docs/examples/zh/utils/SceneUtils.html
+++ b/docs/examples/zh/utils/SceneUtils.html
@@ -19,7 +19,7 @@
 		</p>
 
 		<code>
-			import { SceneUtils } from 'three/addons/utils/SceneUtils.js';
+			import { SceneUtils } from 'three/examples/jsm/utils/SceneUtils.js';
 		</code>
 
 		<h2>方法</h2>

--- a/docs/examples/zh/utils/SkeletonUtils.html
+++ b/docs/examples/zh/utils/SkeletonUtils.html
@@ -19,7 +19,7 @@
 		</p>
 
 		<code>
-			import * as SkeletonUtils from 'three/addons/utils/SkeletonUtils.js';
+			import * as SkeletonUtils from 'three/examples/jsm/utils/SkeletonUtils.js';
 		</code>
 
 		<h2>方法</h2>

--- a/docs/manual/ar/introduction/How-to-create-VR-content.html
+++ b/docs/manual/ar/introduction/How-to-create-VR-content.html
@@ -22,7 +22,7 @@
 		</p>
 
 		<code>
-import { VRButton } from 'three/addons/webxr/VRButton.js';
+import { VRButton } from 'three/examples/jsm/webxr/VRButton.js';
 		</code>
 
 		<p>

--- a/docs/manual/ar/introduction/How-to-use-post-processing.html
+++ b/docs/manual/ar/introduction/How-to-use-post-processing.html
@@ -24,9 +24,9 @@
 		</p>
 
 		<code>
-		import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
-		import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
-		import { GlitchPass } from 'three/addons/postprocessing/GlitchPass.js';
+		import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js';
+		import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js';
+		import { GlitchPass } from 'three/examples/jsm/postprocessing/GlitchPass.js';
 		</code>
 
 		<p>
@@ -80,8 +80,8 @@
 		</p>
 
 		<code>
-		import { ShaderPass } from 'three/addons/postprocessing/ShaderPass.js';
-		import { LuminosityShader } from 'three/addons/shaders/LuminosityShader.js';
+		import { ShaderPass } from 'three/examples/jsm/postprocessing/ShaderPass.js';
+		import { LuminosityShader } from 'three/examples/jsm/shaders/LuminosityShader.js';
 
 		// later in your init routine
 

--- a/docs/manual/ar/introduction/Installation.html
+++ b/docs/manual/ar/introduction/Installation.html
@@ -114,7 +114,7 @@
 		</p>
 
 		<code>
-		import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+		import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 
 		const controls = new OrbitControls( camera, renderer.domElement );
 		</code>
@@ -136,7 +136,7 @@
 		&lt;script type="module">
 
 			import * as THREE from 'three';
-			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 
 			const controls = new OrbitControls( camera, renderer.domElement );
 

--- a/docs/manual/ar/introduction/Loading-3D-models.html
+++ b/docs/manual/ar/introduction/Loading-3D-models.html
@@ -69,7 +69,7 @@
 	</p>
 
 	<code>
-		import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+		import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 	</code>
 
 	<p>

--- a/docs/manual/ar/introduction/WebGL-compatibility-check.html
+++ b/docs/manual/ar/introduction/WebGL-compatibility-check.html
@@ -15,7 +15,7 @@
 		</p>
 
 		<code>
-		import WebGL from 'three/addons/capabilities/WebGL.js';
+		import WebGL from 'three/examples/jsm/capabilities/WebGL.js';
 
 		if ( WebGL.isWebGLAvailable() ) {
 

--- a/docs/manual/en/introduction/How-to-create-VR-content.html
+++ b/docs/manual/en/introduction/How-to-create-VR-content.html
@@ -24,7 +24,7 @@
 	</p>
 
 	<code>
-import { VRButton } from 'three/addons/webxr/VRButton.js';
+import { VRButton } from 'three/examples/jsm/webxr/VRButton.js';
 	</code>
 
 	<p>

--- a/docs/manual/en/introduction/How-to-use-post-processing.html
+++ b/docs/manual/en/introduction/How-to-use-post-processing.html
@@ -28,10 +28,10 @@
 		</p>
 
 		<code>
-		import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
-		import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
-		import { GlitchPass } from 'three/addons/postprocessing/GlitchPass.js';
-		import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
+		import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js';
+		import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js';
+		import { GlitchPass } from 'three/examples/jsm/postprocessing/GlitchPass.js';
+		import { OutputPass } from 'three/examples/jsm/postprocessing/OutputPass.js';
 		</code>
 
 		<p>
@@ -96,8 +96,8 @@
 		</p>
 
 		<code>
-		import { ShaderPass } from 'three/addons/postprocessing/ShaderPass.js';
-		import { LuminosityShader } from 'three/addons/shaders/LuminosityShader.js';
+		import { ShaderPass } from 'three/examples/jsm/postprocessing/ShaderPass.js';
+		import { LuminosityShader } from 'three/examples/jsm/shaders/LuminosityShader.js';
 
 		// later in your init routine
 

--- a/docs/manual/en/introduction/Installation.html
+++ b/docs/manual/en/introduction/Installation.html
@@ -245,8 +245,8 @@ npm install --save-dev vite
 
 		<code>
 import * as THREE from 'three';
-import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
-import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 
 const controls = new OrbitControls( camera, renderer.domElement );
 const loader = new GLTFLoader();

--- a/docs/manual/en/introduction/Loading-3D-models.html
+++ b/docs/manual/en/introduction/Loading-3D-models.html
@@ -84,7 +84,7 @@
 	</p>
 
 	<code>
-		import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+		import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 	</code>
 
 	<p>

--- a/docs/manual/en/introduction/WebGL-compatibility-check.html
+++ b/docs/manual/en/introduction/WebGL-compatibility-check.html
@@ -15,7 +15,7 @@
 		</p>
 
 		<code>
-		import WebGL from 'three/addons/capabilities/WebGL.js';
+		import WebGL from 'three/examples/jsm/capabilities/WebGL.js';
 
 		if ( WebGL.isWebGLAvailable() ) {
 

--- a/docs/manual/fr/introduction/How-to-create-VR-content.html
+++ b/docs/manual/fr/introduction/How-to-create-VR-content.html
@@ -24,7 +24,7 @@
 	</p>
 
 	<code>
-import { VRButton } from 'three/addons/webxr/VRButton.js';
+import { VRButton } from 'three/examples/jsm/webxr/VRButton.js';
 	</code>
 
 	<p>

--- a/docs/manual/fr/introduction/How-to-use-post-processing.html
+++ b/docs/manual/fr/introduction/How-to-use-post-processing.html
@@ -28,10 +28,10 @@
 		</p>
 
 		<code>
-		import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
-		import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
-		import { GlitchPass } from 'three/addons/postprocessing/GlitchPass.js';
-		import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
+		import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js';
+		import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js';
+		import { GlitchPass } from 'three/examples/jsm/postprocessing/GlitchPass.js';
+		import { OutputPass } from 'three/examples/jsm/postprocessing/OutputPass.js';
 		</code>
 
 		<p>
@@ -96,8 +96,8 @@
 		</p>
 
 		<code>
-		import { ShaderPass } from 'three/addons/postprocessing/ShaderPass.js';
-		import { LuminosityShader } from 'three/addons/shaders/LuminosityShader.js';
+		import { ShaderPass } from 'three/examples/jsm/postprocessing/ShaderPass.js';
+		import { LuminosityShader } from 'three/examples/jsm/shaders/LuminosityShader.js';
 
 		// later in your init routine
 

--- a/docs/manual/fr/introduction/Installation.html
+++ b/docs/manual/fr/introduction/Installation.html
@@ -97,7 +97,7 @@
 
 
 		<code>
-		import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+		import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 
 		const controls = new OrbitControls( camera, renderer.domElement );
 		</code>
@@ -119,7 +119,7 @@
 		&lt;script type="module">
 
 			import * as THREE from 'three';
-			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 
 			const controls = new OrbitControls( camera, renderer.domElement );
 

--- a/docs/manual/fr/introduction/Loading-3D-models.html
+++ b/docs/manual/fr/introduction/Loading-3D-models.html
@@ -84,7 +84,7 @@
 	</p>
 
 	<code>
-		import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+		import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 	</code>
 
 	<p>

--- a/docs/manual/fr/introduction/WebGL-compatibility-check.html
+++ b/docs/manual/fr/introduction/WebGL-compatibility-check.html
@@ -15,7 +15,7 @@
 		</p>
 
 		<code>
-		import WebGL from 'three/addons/capabilities/WebGL.js';
+		import WebGL from 'three/examples/jsm/capabilities/WebGL.js';
 
 		if ( WebGL.isWebGLAvailable() ) {
 

--- a/docs/manual/it/introduction/How-to-create-VR-content.html
+++ b/docs/manual/it/introduction/How-to-create-VR-content.html
@@ -22,7 +22,7 @@
 	</p>
 
 	<code>
-import { VRButton } from 'three/addons/webxr/VRButton.js';
+import { VRButton } from 'three/examples/jsm/webxr/VRButton.js';
 	</code>
 
 	<p>

--- a/docs/manual/it/introduction/How-to-use-post-processing.html
+++ b/docs/manual/it/introduction/How-to-use-post-processing.html
@@ -29,10 +29,10 @@
 		</p>
 
 		<code>
-		import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
-		import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
-		import { GlitchPass } from 'three/addons/postprocessing/GlitchPass.js';
-		import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
+		import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js';
+		import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js';
+		import { GlitchPass } from 'three/examples/jsm/postprocessing/GlitchPass.js';
+		import { OutputPass } from 'three/examples/jsm/postprocessing/OutputPass.js';
 		</code>
 
 		<p>
@@ -98,8 +98,8 @@
 		</p>
 
 		<code>
-		import { ShaderPass } from 'three/addons/postprocessing/ShaderPass.js';
-		import { LuminosityShader } from 'three/addons/shaders/LuminosityShader.js';
+		import { ShaderPass } from 'three/examples/jsm/postprocessing/ShaderPass.js';
+		import { LuminosityShader } from 'three/examples/jsm/shaders/LuminosityShader.js';
 
 		// later in your init routine
 

--- a/docs/manual/it/introduction/Installation.html
+++ b/docs/manual/it/introduction/Installation.html
@@ -97,7 +97,7 @@
 		</p>
 
 		<code>
-		import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+		import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 
 		const controls = new OrbitControls( camera, renderer.domElement );
 		</code>
@@ -119,7 +119,7 @@
 		&lt;script type="module">
 
 			import * as THREE from 'three';
-			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 
 			const controls = new OrbitControls( camera, renderer.domElement );
 

--- a/docs/manual/it/introduction/Loading-3D-models.html
+++ b/docs/manual/it/introduction/Loading-3D-models.html
@@ -76,7 +76,7 @@
 	</p>
 
 	<code>
-		import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+		import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 	</code>
 
 	<p>

--- a/docs/manual/it/introduction/WebGL-compatibility-check.html
+++ b/docs/manual/it/introduction/WebGL-compatibility-check.html
@@ -16,7 +16,7 @@
 
 
 		<code>
-		import WebGL from 'three/addons/capabilities/WebGL.js';
+		import WebGL from 'three/examples/jsm/capabilities/WebGL.js';
 
 		if ( WebGL.isWebGLAvailable() ) {
 

--- a/docs/manual/ja/introduction/How-to-create-VR-content.html
+++ b/docs/manual/ja/introduction/How-to-create-VR-content.html
@@ -22,7 +22,7 @@
 	</p>
 
 	<code>
-import { VRButton } from 'three/addons/webxr/VRButton.js';
+import { VRButton } from 'three/examples/jsm/webxr/VRButton.js';
 	</code>
 
 	<p>

--- a/docs/manual/ja/introduction/How-to-use-post-processing.html
+++ b/docs/manual/ja/introduction/How-to-use-post-processing.html
@@ -30,10 +30,10 @@
 	</p>
 
 	<code>
-		import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
-		import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
-		import { GlitchPass } from 'three/addons/postprocessing/GlitchPass.js';
-		import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
+		import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js';
+		import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js';
+		import { GlitchPass } from 'three/examples/jsm/postprocessing/GlitchPass.js';
+		import { OutputPass } from 'three/examples/jsm/postprocessing/OutputPass.js';
 		</code>
 
 	<p>
@@ -101,8 +101,8 @@
 	</p>
 
 	<code>
-		import { ShaderPass } from 'three/addons/postprocessing/ShaderPass.js';
-		import { LuminosityShader } from 'three/addons/shaders/LuminosityShader.js';
+		import { ShaderPass } from 'three/examples/jsm/postprocessing/ShaderPass.js';
+		import { LuminosityShader } from 'three/examples/jsm/shaders/LuminosityShader.js';
 
 		// later in your init routine
 

--- a/docs/manual/ja/introduction/Installation.html
+++ b/docs/manual/ja/introduction/Installation.html
@@ -98,7 +98,7 @@
 
 
     <code>
-		import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+		import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 
 		const controls = new OrbitControls( camera, renderer.domElement );
 		</code>
@@ -120,7 +120,7 @@
 &lt;script type="module">
 
     import * as THREE from 'three';
-    import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+    import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 
     const controls = new OrbitControls( camera, renderer.domElement );
 

--- a/docs/manual/ja/introduction/Loading-3D-models.html
+++ b/docs/manual/ja/introduction/Loading-3D-models.html
@@ -84,7 +84,7 @@
 	</p>
 
 	<code>
-		import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+		import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 	</code>
 
 	<p>

--- a/docs/manual/ja/introduction/WebGL-compatibility-check.html
+++ b/docs/manual/ja/introduction/WebGL-compatibility-check.html
@@ -14,7 +14,7 @@
 		</p>
 
 		<code>
-		import WebGL from 'three/addons/capabilities/WebGL.js';
+		import WebGL from 'three/examples/jsm/capabilities/WebGL.js';
 
 		if ( WebGL.isWebGLAvailable() ) {
 

--- a/docs/manual/ko/introduction/How-to-create-VR-content.html
+++ b/docs/manual/ko/introduction/How-to-create-VR-content.html
@@ -23,7 +23,7 @@
 	</p>
 
 	<code>
-import { VRButton } from 'three/addons/webxr/VRButton.js';
+import { VRButton } from 'three/examples/jsm/webxr/VRButton.js';
 	</code>
 
 	<p>

--- a/docs/manual/ko/introduction/How-to-use-post-processing.html
+++ b/docs/manual/ko/introduction/How-to-use-post-processing.html
@@ -28,10 +28,10 @@
 		</p>
 
 		<code>
-		import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
-		import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
-		import { GlitchPass } from 'three/addons/postprocessing/GlitchPass.js';
-		import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
+		import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js';
+		import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js';
+		import { GlitchPass } from 'three/examples/jsm/postprocessing/GlitchPass.js';
+		import { OutputPass } from 'three/examples/jsm/postprocessing/OutputPass.js';
 		</code>
 
 		<p>
@@ -97,8 +97,8 @@
 		</p>
 
 		<code>
-		import { ShaderPass } from 'three/addons/postprocessing/ShaderPass.js';
-		import { LuminosityShader } from 'three/addons/shaders/LuminosityShader.js';
+		import { ShaderPass } from 'three/examples/jsm/postprocessing/ShaderPass.js';
+		import { LuminosityShader } from 'three/examples/jsm/shaders/LuminosityShader.js';
 
 		// later in your init routine
 

--- a/docs/manual/ko/introduction/Installation.html
+++ b/docs/manual/ko/introduction/Installation.html
@@ -110,7 +110,7 @@
 
 
     <code>
-		import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+		import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 
 		const controls = new OrbitControls( camera, renderer.domElement );
 		</code>
@@ -132,7 +132,7 @@
 &lt;script type="module">
 
     import * as THREE from 'three';
-    import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+    import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 
     const controls = new OrbitControls( camera, renderer.domElement );
 

--- a/docs/manual/ko/introduction/Loading-3D-models.html
+++ b/docs/manual/ko/introduction/Loading-3D-models.html
@@ -76,7 +76,7 @@
 	</p>
 
 	<code>
-		import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+		import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 	</code>
 
 	<p>

--- a/docs/manual/ko/introduction/WebGL-compatibility-check.html
+++ b/docs/manual/ko/introduction/WebGL-compatibility-check.html
@@ -15,7 +15,7 @@
 		</p>
 
 		<code>
-		import WebGL from 'three/addons/capabilities/WebGL.js';
+		import WebGL from 'three/examples/jsm/capabilities/WebGL.js';
 
 		if ( WebGL.isWebGLAvailable() ) {
 

--- a/docs/manual/pt-br/introduction/How-to-create-VR-content.html
+++ b/docs/manual/pt-br/introduction/How-to-create-VR-content.html
@@ -24,7 +24,7 @@
 	</p>
 
 	<code>
-import { VRButton } from 'three/addons/webxr/VRButton.js';
+import { VRButton } from 'three/examples/jsm/webxr/VRButton.js';
 	</code>
 
 	<p>

--- a/docs/manual/pt-br/introduction/How-to-use-post-processing.html
+++ b/docs/manual/pt-br/introduction/How-to-use-post-processing.html
@@ -28,10 +28,10 @@
 		</p>
 
 		<code>
-		import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
-		import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
-		import { GlitchPass } from 'three/addons/postprocessing/GlitchPass.js';
-		import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
+		import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js';
+		import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js';
+		import { GlitchPass } from 'three/examples/jsm/postprocessing/GlitchPass.js';
+		import { OutputPass } from 'three/examples/jsm/postprocessing/OutputPass.js';
 		</code>
 
 		<p>
@@ -97,8 +97,8 @@
 		</p>
 
 		<code>
-		import { ShaderPass } from 'three/addons/postprocessing/ShaderPass.js';
-		import { LuminosityShader } from 'three/addons/shaders/LuminosityShader.js';
+		import { ShaderPass } from 'three/examples/jsm/postprocessing/ShaderPass.js';
+		import { LuminosityShader } from 'three/examples/jsm/shaders/LuminosityShader.js';
 
 		// later in your init routine
 

--- a/docs/manual/pt-br/introduction/Installation.html
+++ b/docs/manual/pt-br/introduction/Installation.html
@@ -85,7 +85,7 @@
 		</p>
 
 		<code>
-		import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+		import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 
 		const controls = new OrbitControls( camera, renderer.domElement );
 		</code>
@@ -105,7 +105,7 @@
 		&lt;script type="module">
 
 			import * as THREE from 'three';
-			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 
 			const controls = new OrbitControls( camera, renderer.domElement );
 

--- a/docs/manual/pt-br/introduction/Loading-3D-models.html
+++ b/docs/manual/pt-br/introduction/Loading-3D-models.html
@@ -81,7 +81,7 @@
 	</p>
 
 	<code>
-		import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+		import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 	</code>
 
 	<p>

--- a/docs/manual/pt-br/introduction/WebGL-compatibility-check.html
+++ b/docs/manual/pt-br/introduction/WebGL-compatibility-check.html
@@ -16,7 +16,7 @@
 		</p>
 
 		<code>
-		import WebGL from 'three/addons/capabilities/WebGL.js';
+		import WebGL from 'three/examples/jsm/capabilities/WebGL.js';
 
 		if ( WebGL.isWebGLAvailable() ) {
 

--- a/docs/manual/ru/introduction/Installation.html
+++ b/docs/manual/ru/introduction/Installation.html
@@ -127,7 +127,7 @@
 
 
 	<code>
-		import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+		import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 
 		const controls = new OrbitControls( camera, renderer.domElement );
 	</code>
@@ -148,7 +148,7 @@
 		&lt;script type="module">
 
 			import * as THREE from 'three';
-			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 
 			const controls = new OrbitControls( camera, renderer.domElement );
 

--- a/docs/manual/ru/introduction/Loading-3D-models.html
+++ b/docs/manual/ru/introduction/Loading-3D-models.html
@@ -82,7 +82,7 @@
 	</p>
 
 	<code>
-		import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+		import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 	</code>
 
 	<p>

--- a/docs/manual/ru/introduction/WebGL-compatibility-check.html
+++ b/docs/manual/ru/introduction/WebGL-compatibility-check.html
@@ -15,7 +15,7 @@
 		</p>
 
 		<code>
-		import WebGL from 'three/addons/capabilities/WebGL.js';
+		import WebGL from 'three/examples/jsm/capabilities/WebGL.js';
 
 		if ( WebGL.isWebGLAvailable() ) {
 

--- a/docs/manual/zh/introduction/How-to-create-VR-content.html
+++ b/docs/manual/zh/introduction/How-to-create-VR-content.html
@@ -23,7 +23,7 @@
 	</p>
 
 	<code>
-import { VRButton } from 'three/addons/webxr/VRButton.js';
+import { VRButton } from 'three/examples/jsm/webxr/VRButton.js';
 	</code>
 
 	<p>*VRButton.createButton()*做了两件重要的事情：首先，它创建了一个按钮，指示了VR的兼容性；

--- a/docs/manual/zh/introduction/How-to-use-post-processing.html
+++ b/docs/manual/zh/introduction/How-to-use-post-processing.html
@@ -28,10 +28,10 @@
 		</p>
 
 		<code>
-		import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
-		import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
-		import { GlitchPass } from 'three/addons/postprocessing/GlitchPass.js';
-		import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
+		import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js';
+		import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js';
+		import { GlitchPass } from 'three/examples/jsm/postprocessing/GlitchPass.js';
+		import { OutputPass } from 'three/examples/jsm/postprocessing/OutputPass.js';
 		</code>
 
 		<p>
@@ -97,8 +97,8 @@
 		</p>
 
 		<code>
-		import { ShaderPass } from 'three/addons/postprocessing/ShaderPass.js';
-		import { LuminosityShader } from 'three/addons/shaders/LuminosityShader.js';
+		import { ShaderPass } from 'three/examples/jsm/postprocessing/ShaderPass.js';
+		import { LuminosityShader } from 'three/examples/jsm/shaders/LuminosityShader.js';
 
 		// later in your init routine
 

--- a/docs/manual/zh/introduction/Installation.html
+++ b/docs/manual/zh/introduction/Installation.html
@@ -96,7 +96,7 @@
 
 
 		<code>
-		import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+		import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 
 		const controls = new OrbitControls( camera, renderer.domElement );
 		</code>
@@ -118,7 +118,7 @@
 		&lt;script type="module">
 
 			import * as THREE from 'three';
-			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 
 			const controls = new OrbitControls( camera, renderer.domElement );
 

--- a/docs/manual/zh/introduction/Loading-3D-models.html
+++ b/docs/manual/zh/introduction/Loading-3D-models.html
@@ -73,7 +73,7 @@
 	</p>
 
 	<code>
-		import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+		import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 	</code>
 
 	<p>

--- a/docs/scenes/bones-browser.html
+++ b/docs/scenes/bones-browser.html
@@ -52,8 +52,8 @@
 				WebGLRenderer
 			} from 'three';
 
-			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
-			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import { GUI } from 'three/examples/jsm/libs/lil-gui.module.min.js';
+			import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 
 			let gui, scene, camera, renderer, orbit, lights, mesh, bones, skeletonHelper;
 

--- a/docs/scenes/ccdiksolver-browser.html
+++ b/docs/scenes/ccdiksolver-browser.html
@@ -54,10 +54,10 @@
 				Uint16BufferAttribute,
 				WebGLRenderer
 			} from 'three';
-			import { CCDIKSolver, CCDIKHelper } from 'three/addons/animation/CCDIKSolver.js';
+			import { CCDIKSolver, CCDIKHelper } from 'three/examples/jsm/animation/CCDIKSolver.js';
 
-			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
-			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import { GUI } from 'three/examples/jsm/libs/lil-gui.module.min.js';
+			import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 
 			let gui, scene, camera, renderer, orbit, mesh, bones, skeletonHelper, ikSolver;
 

--- a/docs/scenes/geometry-browser.html
+++ b/docs/scenes/geometry-browser.html
@@ -73,8 +73,8 @@
 				WebGLRenderer
 			} from 'three';
 
-			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
-			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import { GUI } from 'three/examples/jsm/libs/lil-gui.module.min.js';
+			import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 
 			const twoPi = Math.PI * 2;
 

--- a/docs/scenes/material-browser.html
+++ b/docs/scenes/material-browser.html
@@ -36,8 +36,8 @@
 		<script type="module">
 
 			import * as THREE from 'three';
-			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
-			import { RoomEnvironment } from 'three/addons/environments/RoomEnvironment.js';
+			import { GUI } from 'three/examples/jsm/libs/lil-gui.module.min.js';
+			import { RoomEnvironment } from 'three/examples/jsm/environments/RoomEnvironment.js';
 
 			const constants = {
 


### PR DESCRIPTION
When I was following the docs it told me to do this:
`import { OBJLoader } from 'three/addons/loaders/OBJLoader.js';`

But I found out it has changed from this link
[https://discourse.threejs.org/t/the-examples-js-directory-will-be-removed-with-r148/45349](https://discourse.threejs.org/t/the-examples-js-directory-will-be-removed-with-r148/45349)

So I fixed the docs to say this:
`import { OBJLoader } from 'three/examples/jsm/loaders/OBJLoader.js';`

I changed it for everywhere else it says that in the docs directory.