### PR TITLE
PhysicalLightingModel: Modular usage

### DIFF
--- a/examples/jsm/nodes/functions/PhysicalLightingModel.js
+++ b/examples/jsm/nodes/functions/PhysicalLightingModel.js
@@ -161,7 +161,7 @@ const clearcoatF90 = vec3( 1 );
 
 class PhysicalLightingModel extends LightingModel {
 
-	constructor( clearcoat = true, sheen = true, iridescence = true ) {
+	constructor( clearcoat = false, sheen = false, iridescence = false ) {
 
 		super();
 

--- a/examples/jsm/nodes/materials/MeshPhysicalNodeMaterial.js
+++ b/examples/jsm/nodes/materials/MeshPhysicalNodeMaterial.js
@@ -44,9 +44,27 @@ class MeshPhysicalNodeMaterial extends MeshStandardNodeMaterial {
 
 	}
 
+	get useClearcoat() {
+
+		return this.clearcoat > 0 || this.clearcoatNode !== null;
+
+	}
+
+	get useIridescence() {
+
+		return this.iridescence > 0 || this.iridescenceNode !== null;
+
+	}
+
+	get useSheen() {
+
+		return this.sheen > 0 || this.sheenNode !== null;
+
+	}
+
 	setupLightingModel( /*builder*/ ) {
 
-		return new PhysicalLightingModel(); // @TODO: Optimize shader using parameters.
+		return new PhysicalLightingModel( this.useClearcoat, this.useSheen, this.useIridescence );
 
 	}
 
@@ -58,29 +76,41 @@ class MeshPhysicalNodeMaterial extends MeshStandardNodeMaterial {
 
 		// CLEARCOAT
 
-		const clearcoatNode = this.clearcoatNode ? float( this.clearcoatNode ) : materialClearcoat;
-		const clearcoatRoughnessNode = this.clearcoatRoughnessNode ? float( this.clearcoatRoughnessNode ) : materialClearcoatRoughness;
+		if ( this.useClearcoat ) {
 
-		stack.assign( clearcoat, clearcoatNode );
-		stack.assign( clearcoatRoughness, clearcoatRoughnessNode );
+			const clearcoatNode = this.clearcoatNode ? float( this.clearcoatNode ) : materialClearcoat;
+			const clearcoatRoughnessNode = this.clearcoatRoughnessNode ? float( this.clearcoatRoughnessNode ) : materialClearcoatRoughness;
+
+			stack.assign( clearcoat, clearcoatNode );
+			stack.assign( clearcoatRoughness, clearcoatRoughnessNode );
+
+		}
 
 		// SHEEN
 
-		const sheenNode = this.sheenNode ? vec3( this.sheenNode ) : materialSheen;
-		const sheenRoughnessNode = this.sheenRoughnessNode ? float( this.sheenRoughnessNode ) : materialSheenRoughness;
+		if ( this.useSheen ) {
 
-		stack.assign( sheen, sheenNode );
-		stack.assign( sheenRoughness, sheenRoughnessNode );
+			const sheenNode = this.sheenNode ? vec3( this.sheenNode ) : materialSheen;
+			const sheenRoughnessNode = this.sheenRoughnessNode ? float( this.sheenRoughnessNode ) : materialSheenRoughness;
+
+			stack.assign( sheen, sheenNode );
+			stack.assign( sheenRoughness, sheenRoughnessNode );
+
+		}
 
 		// IRIDESCENCE
 
-		const iridescenceNode = this.iridescenceNode ? float( this.iridescenceNode ) : materialIridescence;
-		const iridescenceIORNode = this.iridescenceIORNode ? float( this.iridescenceIORNode ) : materialIridescenceIOR;
-		const iridescenceThicknessNode = this.iridescenceThicknessNode ? float( this.iridescenceThicknessNode ) : materialIridescenceThickness;
+		if ( this.useIridescence ) {
 
-		stack.assign( iridescence, iridescenceNode );
-		stack.assign( iridescenceIOR, iridescenceIORNode );
-		stack.assign( iridescenceThickness, iridescenceThicknessNode );
+			const iridescenceNode = this.iridescenceNode ? float( this.iridescenceNode ) : materialIridescence;
+			const iridescenceIORNode = this.iridescenceIORNode ? float( this.iridescenceIORNode ) : materialIridescenceIOR;
+			const iridescenceThicknessNode = this.iridescenceThicknessNode ? float( this.iridescenceThicknessNode ) : materialIridescenceThickness;
+
+			stack.assign( iridescence, iridescenceNode );
+			stack.assign( iridescenceIOR, iridescenceIORNode );
+			stack.assign( iridescenceThickness, iridescenceThicknessNode );
+
+		}
 
 	}
 

--- a/examples/jsm/nodes/materials/MeshStandardNodeMaterial.js
+++ b/examples/jsm/nodes/materials/MeshStandardNodeMaterial.js
@@ -31,7 +31,7 @@ class MeshStandardNodeMaterial extends NodeMaterial {
 
 	setupLightingModel( /*builder*/ ) {
 
-		return new PhysicalLightingModel( false, false, false ); // ( clearcoat, sheen, iridescence ) -> standard
+		return new PhysicalLightingModel();
 
 	}
 

--- a/examples/jsm/nodes/materials/MeshStandardNodeMaterial.js
+++ b/examples/jsm/nodes/materials/MeshStandardNodeMaterial.js
@@ -31,7 +31,7 @@ class MeshStandardNodeMaterial extends NodeMaterial {
 
 	setupLightingModel( /*builder*/ ) {
 
-		return new PhysicalLightingModel( false, false ); // ( clearcoat, sheen ) -> standard
+		return new PhysicalLightingModel( false, false, false ); // ( clearcoat, sheen, iridescence ) -> standard
 
 	}
 


### PR DESCRIPTION
Related issue: Fixes https://github.com/mrdoob/three.js/issues/26820

**Description**

All `MeshStandard*Material` materials were computing `iridescence`' causing unnecessary extra computation. 
I added too `MeshPhysical*Material` properties flags to modulate the shader in favor of optimization.

```js
new PhysicalLightingModel( false, false, false ); // ( clearcoat, sheen, iridescence )
```