### PR TITLE
Lensflare: Better RTT support.

### DIFF
--- a/examples/jsm/objects/Lensflare.js
+++ b/examples/jsm/objects/Lensflare.js
@@ -9,6 +9,7 @@ import {
 	Mesh,
 	MeshBasicMaterial,
 	RawShaderMaterial,
+	UnsignedByteType,
 	Vector2,
 	Vector3,
 	Vector4
@@ -35,6 +36,8 @@ class Lensflare extends Mesh {
 
 		const tempMap = new FramebufferTexture( 16, 16 );
 		const occlusionMap = new FramebufferTexture( 16, 16 );
+
+		let currentType = UnsignedByteType;
 
 		// material
 
@@ -161,6 +164,20 @@ class Lensflare extends Mesh {
 		this.onBeforeRender = function ( renderer, scene, camera ) {
 
 			renderer.getCurrentViewport( viewport );
+
+			const renderTarget = renderer.getRenderTarget();
+			const type = ( renderTarget !== null ) ? renderTarget.texture.type : UnsignedByteType;
+
+			if ( currentType !== type ) {
+
+				tempMap.dispose();
+				occlusionMap.dispose();
+
+				tempMap.type = occlusionMap.type = type;
+
+				currentType = type;
+
+			}
 
 			const invAspect = viewport.w / viewport.z;
 			const halfViewportWidth = viewport.z / 2.0;


### PR DESCRIPTION
Fixed #26330.

**Description**

`Lensflare` uses `FramebufferTexture` to copy data from the current bound framebuffer to internal textures. The type of these textures must match the render target's texture type which is now half float when using `EffectComposer`. Meaning the default `UnsignedByteType` does not work in these scenarios.

The PR ensures `Lensflare` automatically detects the correct texture type. `Lensflare` even works if you toggle RTT.
