### PR TITLE
Docs: Use `<math>` for matrices in Matrix4.html

### DIFF
--- a/docs/api/ar/math/Matrix4.html
+++ b/docs/api/ar/math/Matrix4.html
@@ -194,20 +194,85 @@
 		<p>
 		يستخرج[link:https://en.wikipedia.org/wiki/Basis_(linear_algebra) basis] 
 		من هذه المصفوفة في المتجهات الثلاثة المحورية المقدمة. إذا كانت هذه المصفوفة
-		:
-		<code>
-	 a، b، c، d، 
-	 e، f، g، h، 
-	 i، j، k، l، 
-	 m، n، o، p 
-		</code>
+		:<br /><br />
+
+		<math>
+			<mrow>
+				<mo>[</mo>
+				<mtable>
+					<mtr>
+						<mtd><mi>a</mi></mtd>
+						<mtd><mi>b</mi></mtd>
+						<mtd><mi>c</mi></mtd>
+						<mtd><mi>d</mi></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mi>e</mi></mtd>
+						<mtd><mi>f</mi></mtd>
+						<mtd><mi>g</mi></mtd>
+						<mtd><mi>h</mi></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mi>i</mi></mtd>
+						<mtd><mi>j</mi></mtd>
+						<mtd><mi>k</mi></mtd>
+						<mtd><mi>l</mi></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mi>m</mi></mtd>
+						<mtd><mi>n</mi></mtd>
+						<mtd><mi>o</mi></mtd>
+						<mtd><mi>p</mi></mtd>
+					</mtr>
+				</mtable>
+				<mo>]</mo>
+			</mrow>
+		</math><br /><br />
+
 		ثم سيتم تعيين[page:Vector3 xAxis] ،[page:Vector3 yAxis] ،[page:Vector3 zAxis]
-		إلى:
-		<code>
-	 xAxis = (a, e, i) 
-	 yAxis = (b, f, j) 
-	 zAxis = (c, g, k) 
-		</code>
+		إلى:<br /><br />
+
+		<math>
+			<mrow>
+				<mi>xAxis</mi>
+				<mo>=</mo>
+				<mo>[</mo>
+				<mtable>
+					<mtr><mtd style="height: 1rem"><mi>a</mi></mtd></mtr>
+					<mtr><mtd style="height: 1rem"><mi>e</mi></mtd></mtr>
+					<mtr><mtd style="height: 1rem"><mi>i</mi></mtd></mtr>
+				</mtable>
+				<mo>]</mo>
+			</mrow>
+		</math>,
+
+		<math>
+			<mrow>
+				<mi>yAxis</mi>
+				<mo>=</mo>
+				<mo>[</mo>
+				<mtable>
+					<mtr><mtd style="height: 1rem"><mi>b</mi></mtd></mtr>
+					<mtr><mtd style="height: 1rem"><mi>f</mi></mtd></mtr>
+					<mtr><mtd style="height: 1rem"><mi>j</mi></mtd></mtr>
+				</mtable>
+				<mo>]</mo>
+			</mrow>
+		</math>, and
+
+		<math>
+			<mrow>
+				<mi>zAxis</mi>
+				<mo>=</mo>
+				<mo>[</mo>
+				<mtable>
+					<mtr><mtd style="height: 1rem"><mi>c</mi></mtd></mtr>
+					<mtr><mtd style="height: 1rem"><mi>g</mi></mtd></mtr>
+					<mtr><mtd style="height: 1rem"><mi>k</mi></mtd></mtr>
+				</mtable>
+				<mo>]</mo>
+			</mrow>
+		</math>
 		</p>
 
 		<h3>[method:this extractRotation]( [param:Matrix4 m] )</h3>
@@ -272,13 +337,40 @@
 		</h3>
 		<p>
 		قم بتعيين هذا إلى [link:https://en.wikipedia.org/wiki/Basis_(linear_algebra) basis] 
-		مصفوفة تتكون من المتجهات الأساسية الثلاثة المقدمة:
-		<code>
-		xAxis.x، yAxis.x، zAxis.x، 0، 
-		xAxis.y، yAxis.y، zAxis.y، 0، 
-		xAxis.z، yAxis.z، zAxis.z، 0، 
-		0, 		0, 		0, 	   1
-		</code>
+		مصفوفة تتكون من المتجهات الأساسية الثلاثة المقدمة:<br /><br />
+
+		<math>
+			<mrow>
+				<mo>[</mo>
+				<mtable>
+					<mtr>
+						<mtd><mi>xAxis.x</mi></mtd>
+						<mtd><mi>yAxis.x</mi></mtd>
+						<mtd><mi>zAxis.x</mi></mtd>
+						<mtd><mn>0</mn></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mi>xAxis.y</mi></mtd>
+						<mtd><mi>yAxis.y</mi></mtd>
+						<mtd><mi>zAxis.y</mi></mtd>
+						<mtd><mn>0</mn></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mi>xAxis.z</mi></mtd>
+						<mtd><mi>yAxis.z</mi></mtd>
+						<mtd><mi>zAxis.z</mi></mtd>
+						<mtd><mn>0</mn></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>1</mn></mtd>
+					</mtr>
+				</mtable>
+				<mo>]</mo>
+			</mrow>
+		</math>
 		</p>
 		 
 		<h3>
@@ -314,13 +406,136 @@
 		[page:Quaternion q] ، كما هو مبين
 		[link:https://en.wikipedia.org/wiki/Rotation_matrix#Quaternion هنا]. ال
 		باقي من المصفوفة يتم تعيينه إلى المعرف. لذلك ، بالنظر إلى[page:Quaternion q] =
-		w + xi + yj + zk ، فإن المصفوفة الناتجة ستكون:
-		<code>
-1-2y²-2z² 	2xy-2zw 	2xz+2yw 	0 
-2xy+2zw   	1-2x²-2z² 	2yz-2xw 	0 
-2xz-2yw   	2yz+2xw   	1-2x²-2y²   0
-	0 			0	 		0 		1
-			</code>
+		w + xi + yj + zk ، فإن المصفوفة الناتجة ستكون:<br /><br />
+
+		<math>
+			<mrow>
+				<mo>[</mo>
+				<mtable>
+					<mtr>
+						<mtd>
+							<mn>1</mn>
+							<mo>-</mo>
+							<mn>2</mn>
+							<msup>
+								<mi>y</mi>
+								<mn>2</mn>
+							</msup>
+							<mo>-</mo>
+							<mn>2</mn>
+							<msup>
+								<mi>z</mi>
+								<mn>2</mn>
+							</msup>
+						</mtd>
+						<mtd>
+							<mn>2</mn>
+							<mi>x</mi>
+							<mi>y</mi>
+							<mo>-</mo>
+							<mn>2</mn>
+							<mi>z</mi>
+							<mi>w</mi>
+						</mtd>
+						<mtd>
+							<mn>2</mn>
+							<mi>x</mi>
+							<mi>z</mi>
+							<mo>+</mo>
+							<mn>2</mn>
+							<mi>y</mi>
+							<mi>w</mi>
+						</mtd>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+					</mtr>
+					<mtr>
+						<mtd>
+							<mn>2</mn>
+							<mi>x</mi>
+							<mi>y</mi>
+							<mo>+</mo>
+							<mn>2</mn>
+							<mi>z</mi>
+							<mi>w</mi>
+						</mtd>
+						<mtd>
+							<mn>1</mn>
+							<mo>-</mo>
+							<mn>2</mn>
+							<msup>
+								<mi>x</mi>
+								<mn>2</mn>
+							</msup>
+							<mo>-</mo>
+							<mn>2</mn>
+							<msup>
+								<mi>z</mi>
+								<mn>2</mn>
+							</msup>
+						</mtd>
+						<mtd>
+							<mn>2</mn>
+							<mi>y</mi>
+							<mi>z</mi>
+							<mo>-</mo>
+							<mn>2</mn>
+							<mi>x</mi>
+							<mi>w</mi>
+						</mtd>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+					</mtr>
+					<mtr>
+						<mtd>
+							<mn>2</mn>
+							<mi>x</mi>
+							<mi>z</mi>
+							<mo>-</mo>
+							<mn>2</mn>
+							<mi>y</mi>
+							<mi>w</mi>
+						</mtd>
+						<mtd>
+							<mn>2</mn>
+							<mi>y</mi>
+							<mi>z</mi>
+							<mo>+</mo>
+							<mn>2</mn>
+							<mi>x</mi>
+							<mi>w</mi>
+						</mtd>
+						<mtd>
+							<mn>1</mn>
+							<mo>-</mo>
+							<mn>2</mn>
+							<msup>
+								<mi>x</mi>
+								<mn>2</mn>
+							</msup>
+							<mo>-</mo>
+							<mn>2</mn>
+							<msup>
+								<mi>y</mi>
+								<mn>2</mn>
+							</msup>
+						</mtd>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+					</mtr>
+					<mtr>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>1</mn></mtd>
+					</mtr>
+				</mtable>
+				<mo>]</mo>
+			</mrow>
+		</math>
 		</p>
 
 		<h3>[method:this makeRotationX]( [param:Float theta] )</h3>
@@ -328,13 +543,61 @@
 		[page:Float theta] - زاوية الدوران بالراديان. <br /><br />
 	 
 		يضع هذه المصفوفة كتحويل دوران حول محور X بواسطة
-		[page:Float theta] (&theta;) راديان. المصفوفة الناتجة ستكون:
-		<code>
-1 		0	 		0 			0 
-0 	cos(&theta;) -sin(&theta;) 	0 
-0 	sin(&theta;) cos(&theta;) 	0 
-0 		0			0 			1
-		</code>
+		[page:Float theta] (&theta;) راديان. المصفوفة الناتجة ستكون:<br /><br />
+
+		<math>
+			<mrow>
+				<mo>[</mo>
+				<mtable>
+					<mtr>
+						<mtd><mn>1</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+					</mtr>
+					<mtr>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+						<mtd>
+							<mi>cos</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mo>-</mo>
+							<mi>sin</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+					</mtr>
+					<mtr>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+						<mtd>
+							<mi>sin</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mi>cos</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+					</mtr>
+					<mtr>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>1</mn></mtd>
+					</mtr>
+				</mtable>
+				<mo>]</mo>
+			</mrow>
+		</math>
 		</p>
 	 
 		<h3>[method:this makeRotationY]( [param:Float theta] )</h3>
@@ -342,11 +605,61 @@
 		[page:Float theta] - زاوية الدوران بالراديان. <br /><br />
 	 
 		يضع هذه المصفوفة كتحويل دوران حول محور Y بواسطة
-		[page:Float theta] (&theta;) راديان. المصفوفة الناتجة ستكون:
-		<code>
-		cos(&theta;) 0 sin(&theta;) 0 0 1 0 0 -sin(&theta;) 0 cos(&theta;) 0 0 0
-		0 1
-		</code>
+		[page:Float theta] (&theta;) راديان. المصفوفة الناتجة ستكون:<br /><br />
+
+		<math>
+			<mrow>
+				<mo>[</mo>
+				<mtable>
+					<mtr>
+						<mtd>
+							<mi>cos</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+						<mtd>
+							<mi>sin</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+					</mtr>
+					<mtr>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>1</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+					</mtr>
+					<mtr>
+						<mtd>
+							<mo>-</mo>
+							<mi>sin</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+						<mtd>
+							<mi>cos</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+					</mtr>
+					<mtr>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>1</mn></mtd>
+					</mtr>
+				</mtable>
+				<mo>]</mo>
+			</mrow>
+		</math>
 		</p>
 	 
 		<h3>[method:this makeRotationZ]( [param:Float theta] )</h3>
@@ -354,13 +667,61 @@
 		[page:Float theta] - زاوية الدوران بالراديان. <br /><br />
 	 
 		يضع هذه المصفوفة كتحويل دوران حول محور Z بواسطة
-		[page:Float theta] (&theta;) راديان. المصفوفة الناتجة ستكون:
-		<code>
-cos(&theta;) -sin(&theta;) 0 0 
-sin(&theta;) cos(&theta;)  0 0 
-0 		0 	1   0 
-0 		0	0   1
-				</code>
+		[page:Float theta] (&theta;) راديان. المصفوفة الناتجة ستكون:<br /><br />
+			
+		<math>
+			<mrow>
+				<mo>[</mo>
+				<mtable>
+					<mtr>
+						<mtd>
+							<mi>cos</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mo>-</mo>
+							<mi>sin</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+					</mtr>
+					<mtr>
+						<mtd>
+							<mi>sin</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mi>cos</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+					</mtr>
+					<mtr>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>1</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>1</mn></mtd>
+					</mtr>
+				</mtable>
+				<mo>]</mo>
+			</mrow>
+		</math>
 		</p>
 	 
 		<h3>
@@ -371,13 +732,40 @@ sin(&theta;) cos(&theta;)  0 0
 		[page:Float y] - المقدار الذي يجب تغييره في محور Y. <br />
 		[page:Float z] - المقدار الذي يجب تغييره في محور Z. <br /><br />
 	 
-		يضع هذه المصفوفة كتحويل قياس:
-		<code>
-	 x، 0، 0، 0، 
-	 0، y، 0، 0، 
-	 0، 0، z، 0، 
-	 0، 0، 0، 1 
-		</code>
+		يضع هذه المصفوفة كتحويل قياس:<br /><br />
+
+		<math>
+			<mrow>
+				<mo>[</mo>
+				<mtable>
+					<mtr>
+						<mtd><mi>x</mi></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mi>y</mi></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mi>z</mi></mtd>
+						<mtd><mn>0</mn></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>1</mn></mtd>
+					</mtr>
+				</mtable>
+				<mo>]</mo>
+			</mrow>
+		</math>
 		</p>
 	 
 		<h3>
@@ -392,12 +780,40 @@ sin(&theta;) cos(&theta;)  0 0
 		[page:Float zx] - المقدار الذي يجب قصه Z بواسطة X. <br />
 		[page:Float zy] - المقدار الذي يجب قصه Z بواسطة Y. <br /><br />
 		 
-		يضع هذه المصفوفة كتحويل قص:
-		<code> 
-		1، yx، zx، 0، 
-		xy، 1، zy، 0، 
-		xz، yz، 1، 0، 
-		0، 0، 0، 1 </code>
+		يضع هذه المصفوفة كتحويل قص:<br /><br />
+
+		<math>
+			<mrow>
+				<mo>[</mo>
+				<mtable>
+					<mtr>
+						<mtd><mn>1</mn></mtd>
+						<mtd><mi>y</mi><mi>x</mi></mtd>
+						<mtd><mi>z</mi><mi>x</mi></mtd>
+						<mtd><mn>0</mn></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mi>x</mi><mi>y</mi></mtd>
+						<mtd><mn>1</mn></mtd>
+						<mtd><mi>z</mi><mi>y</mi></mtd>
+						<mtd><mn>0</mn></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mi>x</mi><mi>z</mi></mtd>
+						<mtd><mi>y</mi><mi>z</mi></mtd>
+						<mtd><mn>1</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>1</mn></mtd>
+					</mtr>
+				</mtable>
+				<mo>]</mo>
+			</mrow>
+		</math>
 		</p>
 		 
 		<h3>[method:this makeTranslation]( [param:Vector3 v] )</h3>
@@ -405,12 +821,40 @@ sin(&theta;) cos(&theta;)  0 0
 		[method:this makeTranslation]( [param:Float x], [param:Float y], [param:Float z] ) // واجهة برمجة التطبيقات الاختيارية
 		</h3>
 		<p>
-		يضع هذه المصفوفة كتحويل ترجمة من متجه [page:Vector3 v] ، أو أرقام [page:Float x] ، [page:Float y] و [page:Float z]:
-		<code> 
-		1، 0، 0، x، 
-		0، 1، 0، y، 
-		0، 0، 1، z، 
-		0، 0، 0، 1 </code>
+		يضع هذه المصفوفة كتحويل ترجمة من متجه [page:Vector3 v] ، أو أرقام [page:Float x] ، [page:Float y] و [page:Float z]:<br /><br />
+
+		<math>
+			<mrow>
+				<mo>[</mo>
+				<mtable>
+					<mtr>
+						<mtd><mn>1</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mi>x</mi></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>1</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mi>y</mi></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>1</mn></mtd>
+						<mtd><mi>z</mi></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>1</mn></mtd>
+					</mtr>
+				</mtable>
+				<mo>]</mo>
+			</mrow>
+		</math>
 		</p>
 		 
 		<h3>[method:this multiply]( [param:Matrix4 m] )</h3>
@@ -453,18 +897,75 @@ sin(&theta;) cos(&theta;)  0 0
 		<p>
 		يضع مكون الموضع لهذه المصفوفة من المتجه [page:Vector3 v] ،
 		دون التأثير على بقية المصفوفة - أي إذا كانت المصفوفة هي
-		حاليا:
-		<code>
-		a, b, c, d, 
-		e, f, g, h, 
-		i, j, k, l, 
-		m, n, o, p </code>
-		هذا يصبح:
-		<code>
-		a, b, c, v.x, 
-		e, f, g, v.y, 
-		i, j, k, v.z, 
-		m, n, o, p </code>
+		حاليا:<br /><br />
+
+		<math>
+			<mrow>
+				<mo>[</mo>
+				<mtable>
+					<mtr>
+						<mtd><mi>a</mi></mtd>
+						<mtd><mi>b</mi></mtd>
+						<mtd><mi>c</mi></mtd>
+						<mtd><mi>d</mi></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mi>e</mi></mtd>
+						<mtd><mi>f</mi></mtd>
+						<mtd><mi>g</mi></mtd>
+						<mtd><mi>h</mi></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mi>i</mi></mtd>
+						<mtd><mi>j</mi></mtd>
+						<mtd><mi>k</mi></mtd>
+						<mtd><mi>l</mi></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mi>m</mi></mtd>
+						<mtd><mi>n</mi></mtd>
+						<mtd><mi>o</mi></mtd>
+						<mtd><mi>p</mi></mtd>
+					</mtr>
+				</mtable>
+				<mo>]</mo>
+			</mrow>
+		</math><br /><br />
+
+		هذا يصبح:<br /><br />
+
+		<math>
+			<mrow>
+				<mo>[</mo>
+				<mtable>
+					<mtr>
+						<mtd><mi>a</mi></mtd>
+						<mtd><mi>b</mi></mtd>
+						<mtd><mi>c</mi></mtd>
+						<mtd><mi>v.x</mi></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mi>e</mi></mtd>
+						<mtd><mi>f</mi></mtd>
+						<mtd><mi>g</mi></mtd>
+						<mtd><mi>v.y</mi></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mi>i</mi></mtd>
+						<mtd><mi>j</mi></mtd>
+						<mtd><mi>k</mi></mtd>
+						<mtd><mi>v.z</mi></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mi>m</mi></mtd>
+						<mtd><mi>n</mi></mtd>
+						<mtd><mi>o</mi></mtd>
+						<mtd><mi>p</mi></mtd>
+					</mtr>
+				</mtable>
+				<mo>]</mo>
+			</mrow>
+		</math>
 		</p>
 		 
 		<h3>

--- a/docs/api/en/math/Matrix4.html
+++ b/docs/api/en/math/Matrix4.html
@@ -191,18 +191,85 @@ m.elements = [ 11, 21, 31, 41,
 		<p>
 			Extracts the [link:https://en.wikipedia.org/wiki/Basis_(linear_algebra) basis] 
 			of this matrix into the three axis vectors provided. If this matrix
-			is:
-		<code>
-a, b, c, d, 
-e, f, g, h, 
-i, j, k, l, 
-m, n, o, p </code>
+			is:<br /><br />
+
+			<math>
+				<mrow>
+					<mo>[</mo>
+					<mtable>
+						<mtr>
+							<mtd><mi>a</mi></mtd>
+							<mtd><mi>b</mi></mtd>
+							<mtd><mi>c</mi></mtd>
+							<mtd><mi>d</mi></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mi>e</mi></mtd>
+							<mtd><mi>f</mi></mtd>
+							<mtd><mi>g</mi></mtd>
+							<mtd><mi>h</mi></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mi>i</mi></mtd>
+							<mtd><mi>j</mi></mtd>
+							<mtd><mi>k</mi></mtd>
+							<mtd><mi>l</mi></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mi>m</mi></mtd>
+							<mtd><mi>n</mi></mtd>
+							<mtd><mi>o</mi></mtd>
+							<mtd><mi>p</mi></mtd>
+						</mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math><br /><br />
+
 			then the [page:Vector3 xAxis], [page:Vector3 yAxis], [page:Vector3 zAxis]
-			will be set to:
-			<code>
-xAxis = (a, e, i) 
-yAxis = (b, f, j) 
-zAxis = (c, g, k) </code>
+			will be set to:<br /><br />
+
+			<math>
+				<mrow>
+					<mi>xAxis</mi>
+					<mo>=</mo>
+					<mo>[</mo>
+					<mtable>
+						<mtr><mtd style="height: 1rem"><mi>a</mi></mtd></mtr>
+						<mtr><mtd style="height: 1rem"><mi>e</mi></mtd></mtr>
+						<mtr><mtd style="height: 1rem"><mi>i</mi></mtd></mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math>,
+
+			<math>
+				<mrow>
+					<mi>yAxis</mi>
+					<mo>=</mo>
+					<mo>[</mo>
+					<mtable>
+						<mtr><mtd style="height: 1rem"><mi>b</mi></mtd></mtr>
+						<mtr><mtd style="height: 1rem"><mi>f</mi></mtd></mtr>
+						<mtr><mtd style="height: 1rem"><mi>j</mi></mtd></mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math>, and
+
+			<math>
+				<mrow>
+					<mi>zAxis</mi>
+					<mo>=</mo>
+					<mo>[</mo>
+					<mtable>
+						<mtr><mtd style="height: 1rem"><mi>c</mi></mtd></mtr>
+						<mtr><mtd style="height: 1rem"><mi>g</mi></mtd></mtr>
+						<mtr><mtd style="height: 1rem"><mi>k</mi></mtd></mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math>
 		</p>
 
 		<h3>[method:this extractRotation]( [param:Matrix4 m] )</h3>
@@ -268,13 +335,40 @@ zAxis = (c, g, k) </code>
 		</h3>
 		<p>
 			Set this to the [link:https://en.wikipedia.org/wiki/Basis_(linear_algebra) basis] 
-			matrix consisting of the three provided basis vectors:
-			<code>
-xAxis.x, yAxis.x, zAxis.x, 0, 
-xAxis.y, yAxis.y, zAxis.y, 0, 
-xAxis.z, yAxis.z, zAxis.z, 0, 
-	0, 		0, 		0, 	   1
-			</code>
+			matrix consisting of the three provided basis vectors:<br /><br />
+
+			<math>
+				<mrow>
+					<mo>[</mo>
+					<mtable>
+						<mtr>
+							<mtd><mi>xAxis.x</mi></mtd>
+							<mtd><mi>yAxis.x</mi></mtd>
+							<mtd><mi>zAxis.x</mi></mtd>
+							<mtd><mn>0</mn></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mi>xAxis.y</mi></mtd>
+							<mtd><mi>yAxis.y</mi></mtd>
+							<mtd><mi>zAxis.y</mi></mtd>
+							<mtd><mn>0</mn></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mi>xAxis.z</mi></mtd>
+							<mtd><mi>yAxis.z</mi></mtd>
+							<mtd><mi>zAxis.z</mi></mtd>
+							<mtd><mn>0</mn></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>1</mn></mtd>
+						</mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math>
 		</p>
 
 		<h3>
@@ -311,13 +405,136 @@ xAxis.z, yAxis.z, zAxis.z, 0,
 			[page:Quaternion q], as outlined
 			[link:https://en.wikipedia.org/wiki/Rotation_matrix#Quaternion here]. The
 			rest of the matrix is set to the identity. So, given [page:Quaternion q] =
-			w + xi + yj + zk, the resulting matrix will be:
-			<code>
-1-2y²-2z² 	2xy-2zw 	2xz+2yw 	0 
-2xy+2zw   	1-2x²-2z² 	2yz-2xw 	0 
-2xz-2yw   	2yz+2xw   	1-2x²-2y²   0
-	0 			0	 		0 		1
-			</code>
+			w + xi + yj + zk, the resulting matrix will be:<br /><br />
+
+			<math>
+				<mrow>
+					<mo>[</mo>
+					<mtable>
+						<mtr>
+							<mtd>
+								<mn>1</mn>
+								<mo>-</mo>
+								<mn>2</mn>
+								<msup>
+									<mi>y</mi>
+									<mn>2</mn>
+								</msup>
+								<mo>-</mo>
+								<mn>2</mn>
+								<msup>
+									<mi>z</mi>
+									<mn>2</mn>
+								</msup>
+							</mtd>
+							<mtd>
+								<mn>2</mn>
+								<mi>x</mi>
+								<mi>y</mi>
+								<mo>-</mo>
+								<mn>2</mn>
+								<mi>z</mi>
+								<mi>w</mi>
+							</mtd>
+							<mtd>
+								<mn>2</mn>
+								<mi>x</mi>
+								<mi>z</mi>
+								<mo>+</mo>
+								<mn>2</mn>
+								<mi>y</mi>
+								<mi>w</mi>
+							</mtd>
+							<mtd>
+								<mn>0</mn>
+							</mtd>
+						</mtr>
+						<mtr>
+							<mtd>
+								<mn>2</mn>
+								<mi>x</mi>
+								<mi>y</mi>
+								<mo>+</mo>
+								<mn>2</mn>
+								<mi>z</mi>
+								<mi>w</mi>
+							</mtd>
+							<mtd>
+								<mn>1</mn>
+								<mo>-</mo>
+								<mn>2</mn>
+								<msup>
+									<mi>x</mi>
+									<mn>2</mn>
+								</msup>
+								<mo>-</mo>
+								<mn>2</mn>
+								<msup>
+									<mi>z</mi>
+									<mn>2</mn>
+								</msup>
+							</mtd>
+							<mtd>
+								<mn>2</mn>
+								<mi>y</mi>
+								<mi>z</mi>
+								<mo>-</mo>
+								<mn>2</mn>
+								<mi>x</mi>
+								<mi>w</mi>
+							</mtd>
+							<mtd>
+								<mn>0</mn>
+							</mtd>
+						</mtr>
+						<mtr>
+							<mtd>
+								<mn>2</mn>
+								<mi>x</mi>
+								<mi>z</mi>
+								<mo>-</mo>
+								<mn>2</mn>
+								<mi>y</mi>
+								<mi>w</mi>
+							</mtd>
+							<mtd>
+								<mn>2</mn>
+								<mi>y</mi>
+								<mi>z</mi>
+								<mo>+</mo>
+								<mn>2</mn>
+								<mi>x</mi>
+								<mi>w</mi>
+							</mtd>
+							<mtd>
+								<mn>1</mn>
+								<mo>-</mo>
+								<mn>2</mn>
+								<msup>
+									<mi>x</mi>
+									<mn>2</mn>
+								</msup>
+								<mo>-</mo>
+								<mn>2</mn>
+								<msup>
+									<mi>y</mi>
+									<mn>2</mn>
+								</msup>
+							</mtd>
+							<mtd>
+								<mn>0</mn>
+							</mtd>
+						</mtr>
+						<mtr>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>1</mn></mtd>
+						</mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math>
 		</p>
 
 		<h3>[method:this makeRotationX]( [param:Float theta] )</h3>
@@ -325,13 +542,61 @@ xAxis.z, yAxis.z, zAxis.z, 0,
 			[page:Float theta] — Rotation angle in radians.<br /><br />
 
 			Sets this matrix as a rotational transformation around the X axis by
-			[page:Float theta] (&theta;) radians. The resulting matrix will be:
-			<code>
-	1 		0	 		0 			0 
-	0 	cos(&theta;) -sin(&theta;) 	0 
-	0 	sin(&theta;) cos(&theta;) 	0 
-	0 		0			0 			1
-			</code>
+			[page:Float theta] (&theta;) radians. The resulting matrix will be:<br /><br />
+
+			<math>
+				<mrow>
+					<mo>[</mo>
+					<mtable>
+						<mtr>
+							<mtd><mn>1</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+						</mtr>
+						<mtr>
+							<mtd>
+								<mn>0</mn>
+							</mtd>
+							<mtd>
+								<mi>cos</mi>
+								<mi>&theta;</mi>
+							</mtd>
+							<mtd>
+								<mo>-</mo>
+								<mi>sin</mi>
+								<mi>&theta;</mi>
+							</mtd>
+							<mtd>
+								<mn>0</mn>
+							</mtd>
+						</mtr>
+						<mtr>
+							<mtd>
+								<mn>0</mn>
+							</mtd>
+							<mtd>
+								<mi>sin</mi>
+								<mi>&theta;</mi>
+							</mtd>
+							<mtd>
+								<mi>cos</mi>
+								<mi>&theta;</mi>
+							</mtd>
+							<mtd>
+								<mn>0</mn>
+							</mtd>
+						</mtr>
+						<mtr>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>1</mn></mtd>
+						</mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math>
 		</p>
 
 		<h3>[method:this makeRotationY]( [param:Float theta] )</h3>
@@ -339,11 +604,61 @@ xAxis.z, yAxis.z, zAxis.z, 0,
 			[page:Float theta] — Rotation angle in radians.<br /><br />
 
 			Sets this matrix as a rotational transformation around the Y axis by
-			[page:Float theta] (&theta;) radians. The resulting matrix will be:
-			<code>
-				cos(&theta;) 0 sin(&theta;) 0 0 1 0 0 -sin(&theta;) 0 cos(&theta;) 0 0 0
-				0 1
-			</code>
+			[page:Float theta] (&theta;) radians. The resulting matrix will be:<br /><br />
+
+			<math>
+				<mrow>
+					<mo>[</mo>
+					<mtable>
+						<mtr>
+							<mtd>
+								<mi>cos</mi>
+								<mi>&theta;</mi>
+							</mtd>
+							<mtd>
+								<mn>0</mn>
+							</mtd>
+							<mtd>
+								<mi>sin</mi>
+								<mi>&theta;</mi>
+							</mtd>
+							<mtd>
+								<mn>0</mn>
+							</mtd>
+						</mtr>
+						<mtr>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>1</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+						</mtr>
+						<mtr>
+							<mtd>
+								<mo>-</mo>
+								<mi>sin</mi>
+								<mi>&theta;</mi>
+							</mtd>
+							<mtd>
+								<mn>0</mn>
+							</mtd>
+							<mtd>
+								<mi>cos</mi>
+								<mi>&theta;</mi>
+							</mtd>
+							<mtd>
+								<mn>0</mn>
+							</mtd>
+						</mtr>
+						<mtr>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>1</mn></mtd>
+						</mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math>
 		</p>
 
 		<h3>[method:this makeRotationZ]( [param:Float theta] )</h3>
@@ -351,13 +666,61 @@ xAxis.z, yAxis.z, zAxis.z, 0,
 			[page:Float theta] — Rotation angle in radians.<br /><br />
 
 			Sets this matrix as a rotational transformation around the Z axis by
-			[page:Float theta] (&theta;) radians. The resulting matrix will be:
-			<code>
-cos(&theta;) -sin(&theta;) 0 0 
-sin(&theta;) cos(&theta;)  0 0 
-	0 			0 		   1 0 
-	0 			0		   0 1
-			</code>
+			[page:Float theta] (&theta;) radians. The resulting matrix will be:<br /><br />
+			
+			<math>
+				<mrow>
+					<mo>[</mo>
+					<mtable>
+						<mtr>
+							<mtd>
+								<mi>cos</mi>
+								<mi>&theta;</mi>
+							</mtd>
+							<mtd>
+								<mo>-</mo>
+								<mi>sin</mi>
+								<mi>&theta;</mi>
+							</mtd>
+							<mtd>
+								<mn>0</mn>
+							</mtd>
+							<mtd>
+								<mn>0</mn>
+							</mtd>
+						</mtr>
+						<mtr>
+							<mtd>
+								<mi>sin</mi>
+								<mi>&theta;</mi>
+							</mtd>
+							<mtd>
+								<mi>cos</mi>
+								<mi>&theta;</mi>
+							</mtd>
+							<mtd>
+								<mn>0</mn>
+							</mtd>
+							<mtd>
+								<mn>0</mn>
+							</mtd>
+						</mtr>
+						<mtr>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>1</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>1</mn></mtd>
+						</mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math>
 		</p>
 
 		<h3>
@@ -368,12 +731,40 @@ sin(&theta;) cos(&theta;)  0 0
 			[page:Float y] - the amount to scale in the Y axis.<br />
 			[page:Float z] - the amount to scale in the Z axis.<br /><br />
 
-			Sets this matrix as scale transform:
-			<code>
-x, 0, 0, 0, 
-0, y, 0, 0, 
-0, 0, z, 0, 
-0, 0, 0, 1 </code>
+			Sets this matrix as scale transform:<br /><br />
+
+			<math>
+				<mrow>
+					<mo>[</mo>
+					<mtable>
+						<mtr>
+							<mtd><mi>x</mi></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mi>y</mi></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mi>z</mi></mtd>
+							<mtd><mn>0</mn></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>1</mn></mtd>
+						</mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math>
 		</p>
 
 		<h3>
@@ -388,12 +779,40 @@ x, 0, 0, 0,
 			[page:Float zx] - the amount to shear Z by X.<br />
 			[page:Float zy] - the amount to shear Z by Y.<br /><br />
 
-			Sets this matrix as a shear transform:
-			<code> 
-1, yx, zx, 0, 
-xy, 1, zy, 0, 
-xz, yz, 1, 0, 
-0, 0, 0, 1 </code>
+			Sets this matrix as a shear transform:<br /><br />
+
+			<math>
+				<mrow>
+					<mo>[</mo>
+					<mtable>
+						<mtr>
+							<mtd><mn>1</mn></mtd>
+							<mtd><mi>y</mi><mi>x</mi></mtd>
+							<mtd><mi>z</mi><mi>x</mi></mtd>
+							<mtd><mn>0</mn></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mi>x</mi><mi>y</mi></mtd>
+							<mtd><mn>1</mn></mtd>
+							<mtd><mi>z</mi><mi>y</mi></mtd>
+							<mtd><mn>0</mn></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mi>x</mi><mi>z</mi></mtd>
+							<mtd><mi>y</mi><mi>z</mi></mtd>
+							<mtd><mn>1</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>1</mn></mtd>
+						</mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math>
 		</p>
 
 		<h3>[method:this makeTranslation]( [param:Vector3 v] )</h3>
@@ -401,12 +820,40 @@ xz, yz, 1, 0,
 			[method:this makeTranslation]( [param:Float x], [param:Float y], [param:Float z] ) // optional API
 		</h3>
 		<p>
-			Sets this matrix as a translation transform from vector [page:Vector3 v], or numbers [page:Float x], [page:Float y] and [page:Float z]:
-			<code> 
-1, 0, 0, x, 
-0, 1, 0, y, 
-0, 0, 1, z, 
-0, 0, 0, 1 </code>
+			Sets this matrix as a translation transform from vector [page:Vector3 v], or numbers [page:Float x], [page:Float y] and [page:Float z]:<br /><br />
+
+			<math>
+				<mrow>
+					<mo>[</mo>
+					<mtable>
+						<mtr>
+							<mtd><mn>1</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mi>x</mi></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>1</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mi>y</mi></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>1</mn></mtd>
+							<mtd><mi>z</mi></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>1</mn></mtd>
+						</mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math>
 		</p>
 
 		<h3>[method:this multiply]( [param:Matrix4 m] )</h3>
@@ -449,18 +896,75 @@ xz, yz, 1, 0,
 		<p>
 			Sets the position component for this matrix from vector [page:Vector3 v],
 			without affecting the rest of the matrix - i.e. if the matrix is
-			currently:
-			<code>
-a, b, c, d, 
-e, f, g, h, 
-i, j, k, l, 
-m, n, o, p </code>
-			This becomes:
-			<code>
-a, b, c, v.x, 
-e, f, g, v.y, 
-i, j, k, v.z, 
-m, n, o, p </code>
+			currently:<br /><br />
+
+			<math>
+				<mrow>
+					<mo>[</mo>
+					<mtable>
+						<mtr>
+							<mtd><mi>a</mi></mtd>
+							<mtd><mi>b</mi></mtd>
+							<mtd><mi>c</mi></mtd>
+							<mtd><mi>d</mi></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mi>e</mi></mtd>
+							<mtd><mi>f</mi></mtd>
+							<mtd><mi>g</mi></mtd>
+							<mtd><mi>h</mi></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mi>i</mi></mtd>
+							<mtd><mi>j</mi></mtd>
+							<mtd><mi>k</mi></mtd>
+							<mtd><mi>l</mi></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mi>m</mi></mtd>
+							<mtd><mi>n</mi></mtd>
+							<mtd><mi>o</mi></mtd>
+							<mtd><mi>p</mi></mtd>
+						</mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math><br /><br />
+
+			This becomes:<br /><br />
+
+			<math>
+				<mrow>
+					<mo>[</mo>
+					<mtable>
+						<mtr>
+							<mtd><mi>a</mi></mtd>
+							<mtd><mi>b</mi></mtd>
+							<mtd><mi>c</mi></mtd>
+							<mtd><mi>v.x</mi></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mi>e</mi></mtd>
+							<mtd><mi>f</mi></mtd>
+							<mtd><mi>g</mi></mtd>
+							<mtd><mi>v.y</mi></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mi>i</mi></mtd>
+							<mtd><mi>j</mi></mtd>
+							<mtd><mi>k</mi></mtd>
+							<mtd><mi>v.z</mi></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mi>m</mi></mtd>
+							<mtd><mi>n</mi></mtd>
+							<mtd><mi>o</mi></mtd>
+							<mtd><mi>p</mi></mtd>
+						</mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math>
 		</p>
 
 		<h3>

--- a/docs/api/it/math/Matrix4.html
+++ b/docs/api/it/math/Matrix4.html
@@ -164,19 +164,85 @@ m.elements = [ 11, 21, 31, 41,
 		<h3>[method:this extractBasis]( [param:Vector3 xAxis], [param:Vector3 yAxis], [param:Vector3 zAxis] )</h3>
 		<p>
 			Estrae la [link:https://en.wikipedia.org/wiki/Basis_(linear_algebra) base] di questa matrice
-			nei tre vettori asse forniti. Se questa matrice è:
-		<code>
-a, b, c, d,
-e, f, g, h,
-i, j, k, l,
-m, n, o, p
-		</code>
-		allora [page:Vector3 xAxis], [page:Vector3 yAxis], [page:Vector3 zAxis] saranno impostate a:
-		<code>
-xAxis = (a, e, i)
-yAxis = (b, f, j)
-zAxis = (c, g, k)
-		</code>
+			nei tre vettori asse forniti. Se questa matrice è:<br /><br />
+
+			<math>
+				<mrow>
+					<mo>[</mo>
+					<mtable>
+						<mtr>
+							<mtd><mi>a</mi></mtd>
+							<mtd><mi>b</mi></mtd>
+							<mtd><mi>c</mi></mtd>
+							<mtd><mi>d</mi></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mi>e</mi></mtd>
+							<mtd><mi>f</mi></mtd>
+							<mtd><mi>g</mi></mtd>
+							<mtd><mi>h</mi></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mi>i</mi></mtd>
+							<mtd><mi>j</mi></mtd>
+							<mtd><mi>k</mi></mtd>
+							<mtd><mi>l</mi></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mi>m</mi></mtd>
+							<mtd><mi>n</mi></mtd>
+							<mtd><mi>o</mi></mtd>
+							<mtd><mi>p</mi></mtd>
+						</mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math><br /><br />
+
+			then the [page:Vector3 xAxis], [page:Vector3 yAxis], [page:Vector3 zAxis]
+			will be set to:<br /><br />
+
+			<math>
+				<mrow>
+					<mi>xAxis</mi>
+					<mo>=</mo>
+					<mo>[</mo>
+					<mtable>
+						<mtr><mtd style="height: 1rem"><mi>a</mi></mtd></mtr>
+						<mtr><mtd style="height: 1rem"><mi>e</mi></mtd></mtr>
+						<mtr><mtd style="height: 1rem"><mi>i</mi></mtd></mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math>,
+
+			<math>
+				<mrow>
+					<mi>yAxis</mi>
+					<mo>=</mo>
+					<mo>[</mo>
+					<mtable>
+						<mtr><mtd style="height: 1rem"><mi>b</mi></mtd></mtr>
+						<mtr><mtd style="height: 1rem"><mi>f</mi></mtd></mtr>
+						<mtr><mtd style="height: 1rem"><mi>j</mi></mtd></mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math>, and
+
+			<math>
+				<mrow>
+					<mi>zAxis</mi>
+					<mo>=</mo>
+					<mo>[</mo>
+					<mtable>
+						<mtr><mtd style="height: 1rem"><mi>c</mi></mtd></mtr>
+						<mtr><mtd style="height: 1rem"><mi>g</mi></mtd></mtr>
+						<mtr><mtd style="height: 1rem"><mi>k</mi></mtd></mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math>
 		</p>
 
 		<h3>[method:this extractRotation]( [param:Matrix4 m] )</h3>
@@ -226,13 +292,40 @@ zAxis = (c, g, k)
 		<h3>[method:this makeBasis]( [param:Vector3 xAxis], [param:Vector3 yAxis], [param:Vector3 zAxis] )</h3>
 		<p>
 			Imposta questo sulla matrice di [link:https://en.wikipedia.org/wiki/Basis_(linear_algebra) base] composta dai tre
-			vettori di base forniti:
-		<code>
-xAxis.x, yAxis.x, zAxis.x, 0,
-xAxis.y, yAxis.y, zAxis.y, 0,
-xAxis.z, yAxis.z, zAxis.z, 0,
-0,       0,       0,       1
-		</code>
+			vettori di base forniti:<br /><br />
+
+			<math>
+				<mrow>
+					<mo>[</mo>
+					<mtable>
+						<mtr>
+							<mtd><mi>xAxis.x</mi></mtd>
+							<mtd><mi>yAxis.x</mi></mtd>
+							<mtd><mi>zAxis.x</mi></mtd>
+							<mtd><mn>0</mn></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mi>xAxis.y</mi></mtd>
+							<mtd><mi>yAxis.y</mi></mtd>
+							<mtd><mi>zAxis.y</mi></mtd>
+							<mtd><mn>0</mn></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mi>xAxis.z</mi></mtd>
+							<mtd><mi>yAxis.z</mi></mtd>
+							<mtd><mi>zAxis.z</mi></mtd>
+							<mtd><mn>0</mn></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>1</mn></mtd>
+						</mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math>
 		</p>
 
 		<h3>[method:this makePerspective]( [param:Float left], [param:Float right], [param:Float top], [param:Float bottom], [param:Float near], [param:Float far] )</h3>
@@ -258,13 +351,136 @@ xAxis.z, yAxis.z, zAxis.z, 0,
 		<p>
 			Imposta il componente rotazinoe di questa matrice alla rotazione specificata da [page:Quaternion q], come 
 			descritto [link:https://en.wikipedia.org/wiki/Rotation_matrix#Quaternion qui].
-			Il resto della matrice è impostato all'identità. Quindi, dato [page:Quaternion q] = w + xi + yj + zk, la matrice risultante sarà:
-		<code>
-1-2y²-2z²    2xy-2zw    2xz+2yw    0
-2xy+2zw      1-2x²-2z²  2yz-2xw    0
-2xz-2yw      2yz+2xw    1-2x²-2y²  0
-0            0          0          1
-		</code>
+			Il resto della matrice è impostato all'identità. Quindi, dato [page:Quaternion q] = w + xi + yj + zk, la matrice risultante sarà:<br /><br />
+
+			<math>
+				<mrow>
+					<mo>[</mo>
+					<mtable>
+						<mtr>
+							<mtd>
+								<mn>1</mn>
+								<mo>-</mo>
+								<mn>2</mn>
+								<msup>
+									<mi>y</mi>
+									<mn>2</mn>
+								</msup>
+								<mo>-</mo>
+								<mn>2</mn>
+								<msup>
+									<mi>z</mi>
+									<mn>2</mn>
+								</msup>
+							</mtd>
+							<mtd>
+								<mn>2</mn>
+								<mi>x</mi>
+								<mi>y</mi>
+								<mo>-</mo>
+								<mn>2</mn>
+								<mi>z</mi>
+								<mi>w</mi>
+							</mtd>
+							<mtd>
+								<mn>2</mn>
+								<mi>x</mi>
+								<mi>z</mi>
+								<mo>+</mo>
+								<mn>2</mn>
+								<mi>y</mi>
+								<mi>w</mi>
+							</mtd>
+							<mtd>
+								<mn>0</mn>
+							</mtd>
+						</mtr>
+						<mtr>
+							<mtd>
+								<mn>2</mn>
+								<mi>x</mi>
+								<mi>y</mi>
+								<mo>+</mo>
+								<mn>2</mn>
+								<mi>z</mi>
+								<mi>w</mi>
+							</mtd>
+							<mtd>
+								<mn>1</mn>
+								<mo>-</mo>
+								<mn>2</mn>
+								<msup>
+									<mi>x</mi>
+									<mn>2</mn>
+								</msup>
+								<mo>-</mo>
+								<mn>2</mn>
+								<msup>
+									<mi>z</mi>
+									<mn>2</mn>
+								</msup>
+							</mtd>
+							<mtd>
+								<mn>2</mn>
+								<mi>y</mi>
+								<mi>z</mi>
+								<mo>-</mo>
+								<mn>2</mn>
+								<mi>x</mi>
+								<mi>w</mi>
+							</mtd>
+							<mtd>
+								<mn>0</mn>
+							</mtd>
+						</mtr>
+						<mtr>
+							<mtd>
+								<mn>2</mn>
+								<mi>x</mi>
+								<mi>z</mi>
+								<mo>-</mo>
+								<mn>2</mn>
+								<mi>y</mi>
+								<mi>w</mi>
+							</mtd>
+							<mtd>
+								<mn>2</mn>
+								<mi>y</mi>
+								<mi>z</mi>
+								<mo>+</mo>
+								<mn>2</mn>
+								<mi>x</mi>
+								<mi>w</mi>
+							</mtd>
+							<mtd>
+								<mn>1</mn>
+								<mo>-</mo>
+								<mn>2</mn>
+								<msup>
+									<mi>x</mi>
+									<mn>2</mn>
+								</msup>
+								<mo>-</mo>
+								<mn>2</mn>
+								<msup>
+									<mi>y</mi>
+									<mn>2</mn>
+								</msup>
+							</mtd>
+							<mtd>
+								<mn>0</mn>
+							</mtd>
+						</mtr>
+						<mtr>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>1</mn></mtd>
+						</mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math>
 		</p>
 
 		<h3>[method:this makeRotationX]( [param:Float theta] )</h3>
@@ -272,13 +488,61 @@ xAxis.z, yAxis.z, zAxis.z, 0,
 		[page:Float theta] — Angolo rotazione in radianti.<br /><br />
 
 		Imposta questa matrice come una trasformazione rotazionale attorno all'asse X in radianti theta [page:Float theta] (&theta;).
-		La matrice risultante sarà:
-		<code>
-1 0      0        0
-0 cos(&theta;) -sin(&theta;)  0
-0 sin(&theta;) cos(&theta;)   0
-0 0      0        1
-		</code>
+		La matrice risultante sarà:<br /><br />
+
+		<math>
+			<mrow>
+				<mo>[</mo>
+				<mtable>
+					<mtr>
+						<mtd><mn>1</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+					</mtr>
+					<mtr>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+						<mtd>
+							<mi>cos</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mo>-</mo>
+							<mi>sin</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+					</mtr>
+					<mtr>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+						<mtd>
+							<mi>sin</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mi>cos</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+					</mtr>
+					<mtr>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>1</mn></mtd>
+					</mtr>
+				</mtable>
+				<mo>]</mo>
+			</mrow>
+		</math>
 		</p>
 
 		<h3>[method:this makeRotationY]( [param:Float theta] )</h3>
@@ -286,13 +550,61 @@ xAxis.z, yAxis.z, zAxis.z, 0,
 		[page:Float theta] — Angolo rotazione in radianti.<br /><br />
 
 		Imposta questa matrice come una trasformazione rotazionale attorno all'asse Y in radianti theta [page:Float theta] (&theta;).
-		La matrice risultante sarà:
-		<code>
-cos(&theta;)  0 sin(&theta;) 0
-0       1 0      0
--sin(&theta;) 0 cos(&theta;) 0
-0       0 0      1
-		</code>
+		La matrice risultante sarà:<br /><br />
+
+		<math>
+			<mrow>
+				<mo>[</mo>
+				<mtable>
+					<mtr>
+						<mtd>
+							<mi>cos</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+						<mtd>
+							<mi>sin</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+					</mtr>
+					<mtr>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>1</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+					</mtr>
+					<mtr>
+						<mtd>
+							<mo>-</mo>
+							<mi>sin</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+						<mtd>
+							<mi>cos</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+					</mtr>
+					<mtr>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>1</mn></mtd>
+					</mtr>
+				</mtable>
+				<mo>]</mo>
+			</mrow>
+		</math>
 		</p>
 
 		<h3>[method:this makeRotationZ]( [param:Float theta] )</h3>
@@ -300,13 +612,61 @@ cos(&theta;)  0 sin(&theta;) 0
 		[page:Float theta] — Angolo rotazione in radianti.<br /><br />
 
 		Imposta questa matrice come una trasformazione rotazionale attorno all'asse Z in radianti theta [page:Float theta] (&theta;).
-		La matrice risultante sarà:
-		<code>
-cos(&theta;) -sin(&theta;) 0 0
-sin(&theta;) cos(&theta;)  0 0
-0      0       1 0
-0      0       0 1
-		</code>
+		La matrice risultante sarà:<br /><br />
+			
+		<math>
+			<mrow>
+				<mo>[</mo>
+				<mtable>
+					<mtr>
+						<mtd>
+							<mi>cos</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mo>-</mo>
+							<mi>sin</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+					</mtr>
+					<mtr>
+						<mtd>
+							<mi>sin</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mi>cos</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+					</mtr>
+					<mtr>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>1</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>1</mn></mtd>
+					</mtr>
+				</mtable>
+				<mo>]</mo>
+			</mrow>
+		</math>
 		</p>
 
 		<h3>[method:this makeScale]( [param:Float x], [param:Float y], [param:Float z] )</h3>
@@ -315,13 +675,40 @@ sin(&theta;) cos(&theta;)  0 0
 			[page:Float y] - la quantità da scalare sull'asse Y.<br />
 			[page:Float z] - la quantità da scalare sull'asse Z.<br /><br />
 
-			Imposta questa matrice come trasformazione di scala:
-			<code>
-x, 0, 0, 0,
-0, y, 0, 0,
-0, 0, z, 0,
-0, 0, 0, 1
-			</code>
+			Imposta questa matrice come trasformazione di scala:<br /><br />
+
+			<math>
+				<mrow>
+					<mo>[</mo>
+					<mtable>
+						<mtr>
+							<mtd><mi>x</mi></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mi>y</mi></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mi>z</mi></mtd>
+							<mtd><mn>0</mn></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>1</mn></mtd>
+						</mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math>
 		</p>
 
 		<h3>[method:this makeShear]( [param:Float xy], [param:Float xz], [param:Float yx], [param:Float yz], [param:Float zx], [param:Float zy] )</h3>
@@ -333,13 +720,40 @@ x, 0, 0, 0,
 			[page:Float zx] - la quantità di taglio di Z per X.<br />
 			[page:Float zy] - la quantità di taglio di Z per Y.<br /><br />
 
-			Imposta questa matrice come trasformata di taglio:
-<code>
-1,   yx,  zx,  0,
-xy,   1,  zy,  0,
-xz,  yz,   1,  0,
-0,    0,   0,  1
-</code>
+			Imposta questa matrice come trasformata di taglio:<br /><br />
+
+			<math>
+				<mrow>
+					<mo>[</mo>
+					<mtable>
+						<mtr>
+							<mtd><mn>1</mn></mtd>
+							<mtd><mi>y</mi><mi>x</mi></mtd>
+							<mtd><mi>z</mi><mi>x</mi></mtd>
+							<mtd><mn>0</mn></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mi>x</mi><mi>y</mi></mtd>
+							<mtd><mn>1</mn></mtd>
+							<mtd><mi>z</mi><mi>y</mi></mtd>
+							<mtd><mn>0</mn></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mi>x</mi><mi>z</mi></mtd>
+							<mtd><mi>y</mi><mi>z</mi></mtd>
+							<mtd><mn>1</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>1</mn></mtd>
+						</mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math>
 		</p>
 
 		<h3>[method:this makeTranslation]( [param:Vector3 v] )</h3>
@@ -347,13 +761,40 @@ xz,  yz,   1,  0,
 			[method:this makeTranslation]( [param:Float x], [param:Float y], [param:Float z] ) // optional API
 		</h3>
 		<p>
-			Imposta questa matrice come una trasformata di traslazione dal vettore [page:Vector3 v]:
-		<code>
-1, 0, 0, x,
-0, 1, 0, y,
-0, 0, 1, z,
-0, 0, 0, 1
-		</code>
+			Imposta questa matrice come una trasformata di traslazione dal vettore [page:Vector3 v]:<br /><br />
+
+			<math>
+				<mrow>
+					<mo>[</mo>
+					<mtable>
+						<mtr>
+							<mtd><mn>1</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mi>x</mi></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>1</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mi>y</mi></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>1</mn></mtd>
+							<mtd><mi>z</mi></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>1</mn></mtd>
+						</mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math>
 		</p>
 
 		<h3>[method:this multiply]( [param:Matrix4 m] )</h3>
@@ -384,20 +825,75 @@ xz,  yz,   1,  0,
 		<h3>[method:this setPosition]( [param:Float x], [param:Float y], [param:Float z] ) // optional API</h3>
 		<p>
 			Imposta la componente posizione per questa matrice dal vettore [page:Vector3 v], senza influenzare 
-			il resto della matrice - ovvero se la matrice è attulmente:
-<code>
-a, b, c, d,
-e, f, g, h,
-i, j, k, l,
-m, n, o, p
-</code>
-Questa diventa:
-<code>
-a, b, c, v.x,
-e, f, g, v.y,
-i, j, k, v.z,
-m, n, o, p
-</code>
+			il resto della matrice - ovvero se la matrice è attulmente:<br /><br />
+
+			<math>
+				<mrow>
+					<mo>[</mo>
+					<mtable>
+						<mtr>
+							<mtd><mi>a</mi></mtd>
+							<mtd><mi>b</mi></mtd>
+							<mtd><mi>c</mi></mtd>
+							<mtd><mi>d</mi></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mi>e</mi></mtd>
+							<mtd><mi>f</mi></mtd>
+							<mtd><mi>g</mi></mtd>
+							<mtd><mi>h</mi></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mi>i</mi></mtd>
+							<mtd><mi>j</mi></mtd>
+							<mtd><mi>k</mi></mtd>
+							<mtd><mi>l</mi></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mi>m</mi></mtd>
+							<mtd><mi>n</mi></mtd>
+							<mtd><mi>o</mi></mtd>
+							<mtd><mi>p</mi></mtd>
+						</mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math><br /><br />
+
+			Questa diventa:<br /><br />
+
+			<math>
+				<mrow>
+					<mo>[</mo>
+					<mtable>
+						<mtr>
+							<mtd><mi>a</mi></mtd>
+							<mtd><mi>b</mi></mtd>
+							<mtd><mi>c</mi></mtd>
+							<mtd><mi>v.x</mi></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mi>e</mi></mtd>
+							<mtd><mi>f</mi></mtd>
+							<mtd><mi>g</mi></mtd>
+							<mtd><mi>v.y</mi></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mi>i</mi></mtd>
+							<mtd><mi>j</mi></mtd>
+							<mtd><mi>k</mi></mtd>
+							<mtd><mi>v.z</mi></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mi>m</mi></mtd>
+							<mtd><mi>n</mi></mtd>
+							<mtd><mi>o</mi></mtd>
+							<mtd><mi>p</mi></mtd>
+						</mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math>
 		</p>
 
 		<h3>[method:Array toArray]( [param:Array array], [param:Integer offset] )</h3>

--- a/docs/api/zh/math/Matrix4.html
+++ b/docs/api/zh/math/Matrix4.html
@@ -152,19 +152,84 @@ m.elements = [ 11, 21, 31, 41,
 		<h3>[method:this extractBasis]( [param:Vector3 xAxis], [param:Vector3 yAxis], [param:Vector3 zAxis] )</h3>
 		<p>
 			将矩阵的基向量[link:https://en.wikipedia.org/wiki/Basis_(linear_algebra) basis]提取到指定的3个轴向量中。
-			如果矩阵如下：
-		<code>
-a, b, c, d,
-e, f, g, h,
-i, j, k, l,
-m, n, o, p
-		</code>
-		然后x轴y轴z轴被设为：
-		<code>
-xAxis = (a, e, i)
-yAxis = (b, f, j)
-zAxis = (c, g, k)
-		</code>
+			如果矩阵如下：<br /><br />
+
+			<math>
+				<mrow>
+					<mo>[</mo>
+					<mtable>
+						<mtr>
+							<mtd><mi>a</mi></mtd>
+							<mtd><mi>b</mi></mtd>
+							<mtd><mi>c</mi></mtd>
+							<mtd><mi>d</mi></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mi>e</mi></mtd>
+							<mtd><mi>f</mi></mtd>
+							<mtd><mi>g</mi></mtd>
+							<mtd><mi>h</mi></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mi>i</mi></mtd>
+							<mtd><mi>j</mi></mtd>
+							<mtd><mi>k</mi></mtd>
+							<mtd><mi>l</mi></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mi>m</mi></mtd>
+							<mtd><mi>n</mi></mtd>
+							<mtd><mi>o</mi></mtd>
+							<mtd><mi>p</mi></mtd>
+						</mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math><br /><br />
+
+			然后x轴y轴z轴被设为：<br /><br />
+
+			<math>
+				<mrow>
+					<mi>xAxis</mi>
+					<mo>=</mo>
+					<mo>[</mo>
+					<mtable>
+						<mtr><mtd style="height: 1rem"><mi>a</mi></mtd></mtr>
+						<mtr><mtd style="height: 1rem"><mi>e</mi></mtd></mtr>
+						<mtr><mtd style="height: 1rem"><mi>i</mi></mtd></mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math>,
+
+			<math>
+				<mrow>
+					<mi>yAxis</mi>
+					<mo>=</mo>
+					<mo>[</mo>
+					<mtable>
+						<mtr><mtd style="height: 1rem"><mi>b</mi></mtd></mtr>
+						<mtr><mtd style="height: 1rem"><mi>f</mi></mtd></mtr>
+						<mtr><mtd style="height: 1rem"><mi>j</mi></mtd></mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math>, and
+
+			<math>
+				<mrow>
+					<mi>zAxis</mi>
+					<mo>=</mo>
+					<mo>[</mo>
+					<mtable>
+						<mtr><mtd style="height: 1rem"><mi>c</mi></mtd></mtr>
+						<mtr><mtd style="height: 1rem"><mi>g</mi></mtd></mtr>
+						<mtr><mtd style="height: 1rem"><mi>k</mi></mtd></mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math>
 		</p>
 
 		<h3>[method:this extractRotation]( [param:Matrix4 m] )</h3>
@@ -208,13 +273,40 @@ zAxis = (c, g, k)
 
 		<h3>[method:this makeBasis]( [param:Vector3 xAxis], [param:Vector3 yAxis], [param:Vector3 zAxis] )</h3>
 		<p>
-			通过给定的三个向量设置该矩阵为基矩阵[link:https://en.wikipedia.org/wiki/Basis_(linear_algebra) basis]：
-		<code>
-xAxis.x, yAxis.x, zAxis.x, 0,
-xAxis.y, yAxis.y, zAxis.y, 0,
-xAxis.z, yAxis.z, zAxis.z, 0,
-0,       0,       0,       1
-		</code>
+			通过给定的三个向量设置该矩阵为基矩阵[link:https://en.wikipedia.org/wiki/Basis_(linear_algebra) basis]：<br /><br />
+
+			<math>
+				<mrow>
+					<mo>[</mo>
+					<mtable>
+						<mtr>
+							<mtd><mi>xAxis.x</mi></mtd>
+							<mtd><mi>yAxis.x</mi></mtd>
+							<mtd><mi>zAxis.x</mi></mtd>
+							<mtd><mn>0</mn></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mi>xAxis.y</mi></mtd>
+							<mtd><mi>yAxis.y</mi></mtd>
+							<mtd><mi>zAxis.y</mi></mtd>
+							<mtd><mn>0</mn></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mi>xAxis.z</mi></mtd>
+							<mtd><mi>yAxis.z</mi></mtd>
+							<mtd><mi>zAxis.z</mi></mtd>
+							<mtd><mn>0</mn></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>1</mn></mtd>
+						</mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math>
 		</p>
 
 		<h3>[method:this makePerspective]( [param:Float left], [param:Float right], [param:Float top], [param:Float bottom], [param:Float near], [param:Float far] )</h3>
@@ -239,13 +331,136 @@ xAxis.z, yAxis.z, zAxis.z, 0,
 		<h3>[method:this makeRotationFromQuaternion]( [param:Quaternion q] )</h3>
 		<p>
 		将这个矩阵的旋转分量设置为四元数[page:Quaternion q]指定的旋转，如下链接所诉[link:https://en.wikipedia.org/wiki/Rotation_matrix#Quaternion here]。
-		矩阵的其余部分被设为单位矩阵。因此，给定四元数[page:Quaternion q] = w + xi + yj + zk，得到的矩阵为:
-		<code>
-1-2y²-2z²    2xy-2zw    2xz+2yw    0
-2xy+2zw      1-2x²-2z²  2yz-2xw    0
-2xz-2yw      2yz+2xw    1-2x²-2y²  0
-0            0          0          1
-		</code>
+		矩阵的其余部分被设为单位矩阵。因此，给定四元数[page:Quaternion q] = w + xi + yj + zk，得到的矩阵为:<br /><br />
+
+		<math>
+			<mrow>
+				<mo>[</mo>
+				<mtable>
+					<mtr>
+						<mtd>
+							<mn>1</mn>
+							<mo>-</mo>
+							<mn>2</mn>
+							<msup>
+								<mi>y</mi>
+								<mn>2</mn>
+							</msup>
+							<mo>-</mo>
+							<mn>2</mn>
+							<msup>
+								<mi>z</mi>
+								<mn>2</mn>
+							</msup>
+						</mtd>
+						<mtd>
+							<mn>2</mn>
+							<mi>x</mi>
+							<mi>y</mi>
+							<mo>-</mo>
+							<mn>2</mn>
+							<mi>z</mi>
+							<mi>w</mi>
+						</mtd>
+						<mtd>
+							<mn>2</mn>
+							<mi>x</mi>
+							<mi>z</mi>
+							<mo>+</mo>
+							<mn>2</mn>
+							<mi>y</mi>
+							<mi>w</mi>
+						</mtd>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+					</mtr>
+					<mtr>
+						<mtd>
+							<mn>2</mn>
+							<mi>x</mi>
+							<mi>y</mi>
+							<mo>+</mo>
+							<mn>2</mn>
+							<mi>z</mi>
+							<mi>w</mi>
+						</mtd>
+						<mtd>
+							<mn>1</mn>
+							<mo>-</mo>
+							<mn>2</mn>
+							<msup>
+								<mi>x</mi>
+								<mn>2</mn>
+							</msup>
+							<mo>-</mo>
+							<mn>2</mn>
+							<msup>
+								<mi>z</mi>
+								<mn>2</mn>
+							</msup>
+						</mtd>
+						<mtd>
+							<mn>2</mn>
+							<mi>y</mi>
+							<mi>z</mi>
+							<mo>-</mo>
+							<mn>2</mn>
+							<mi>x</mi>
+							<mi>w</mi>
+						</mtd>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+					</mtr>
+					<mtr>
+						<mtd>
+							<mn>2</mn>
+							<mi>x</mi>
+							<mi>z</mi>
+							<mo>-</mo>
+							<mn>2</mn>
+							<mi>y</mi>
+							<mi>w</mi>
+						</mtd>
+						<mtd>
+							<mn>2</mn>
+							<mi>y</mi>
+							<mi>z</mi>
+							<mo>+</mo>
+							<mn>2</mn>
+							<mi>x</mi>
+							<mi>w</mi>
+						</mtd>
+						<mtd>
+							<mn>1</mn>
+							<mo>-</mo>
+							<mn>2</mn>
+							<msup>
+								<mi>x</mi>
+								<mn>2</mn>
+							</msup>
+							<mo>-</mo>
+							<mn>2</mn>
+							<msup>
+								<mi>y</mi>
+								<mn>2</mn>
+							</msup>
+						</mtd>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+					</mtr>
+					<mtr>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>1</mn></mtd>
+					</mtr>
+				</mtable>
+				<mo>]</mo>
+			</mrow>
+		</math>
 		</p>
 
 		<h3>[method:this makeRotationX]( [param:Float theta] )</h3>
@@ -253,13 +468,61 @@ xAxis.z, yAxis.z, zAxis.z, 0,
 		[page:Float theta] — Rotation angle in radians.<br /><br />
 
 		把该矩阵设置为绕x轴旋转弧度[page:Float theta] (&theta;)大小的矩阵。
-		结果如下：
-		<code>
-1 0      0        0
-0 cos(&theta;) -sin(&theta;)  0
-0 sin(&theta;) cos(&theta;)   0
-0 0      0        1
-		</code>
+		结果如下：<br /><br />
+
+		<math>
+			<mrow>
+				<mo>[</mo>
+				<mtable>
+					<mtr>
+						<mtd><mn>1</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+					</mtr>
+					<mtr>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+						<mtd>
+							<mi>cos</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mo>-</mo>
+							<mi>sin</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+					</mtr>
+					<mtr>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+						<mtd>
+							<mi>sin</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mi>cos</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+					</mtr>
+					<mtr>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>1</mn></mtd>
+					</mtr>
+				</mtable>
+				<mo>]</mo>
+			</mrow>
+		</math>
 		</p>
 
 		<h3>[method:this makeRotationY]( [param:Float theta] )</h3>
@@ -267,13 +530,61 @@ xAxis.z, yAxis.z, zAxis.z, 0,
 		[page:Float theta] — Rotation angle in radians.<br /><br />
 
 		把该矩阵设置为绕Y轴旋转弧度[page:Float theta] (&theta;)大小的矩阵。
-		结果如下：
-		<code>
-cos(&theta;)  0 sin(&theta;) 0
-0       1 0      0
--sin(&theta;) 0 cos(&theta;) 0
-0       0 0      1
-		</code>
+		结果如下：<br /><br />
+
+		<math>
+			<mrow>
+				<mo>[</mo>
+				<mtable>
+					<mtr>
+						<mtd>
+							<mi>cos</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+						<mtd>
+							<mi>sin</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+					</mtr>
+					<mtr>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>1</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+					</mtr>
+					<mtr>
+						<mtd>
+							<mo>-</mo>
+							<mi>sin</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+						<mtd>
+							<mi>cos</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+					</mtr>
+					<mtr>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>1</mn></mtd>
+					</mtr>
+				</mtable>
+				<mo>]</mo>
+			</mrow>
+		</math>
 		</p>
 
 		<h3>[method:this makeRotationZ]( [param:Float theta] )</h3>
@@ -281,13 +592,61 @@ cos(&theta;)  0 sin(&theta;) 0
 		[page:Float theta] — Rotation angle in radians.<br /><br />
 
 		把该矩阵设置为绕z轴旋转弧度[page:Float theta] (&theta;)大小的矩阵。
-		结果如下：
-		<code>
-cos(&theta;) -sin(&theta;) 0 0
-sin(&theta;) cos(&theta;)  0 0
-0      0       1 0
-0      0       0 1
-		</code>
+		结果如下：<br /><br />
+			
+		<math>
+			<mrow>
+				<mo>[</mo>
+				<mtable>
+					<mtr>
+						<mtd>
+							<mi>cos</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mo>-</mo>
+							<mi>sin</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+					</mtr>
+					<mtr>
+						<mtd>
+							<mi>sin</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mi>cos</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+					</mtr>
+					<mtr>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>1</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>1</mn></mtd>
+					</mtr>
+				</mtable>
+				<mo>]</mo>
+			</mrow>
+		</math>
 		</p>
 
 		<h3>[method:this makeScale]( [param:Float x], [param:Float y], [param:Float z] )</h3>
@@ -296,13 +655,40 @@ sin(&theta;) cos(&theta;)  0 0
 			[page:Float y] - 在Y轴方向的缩放比。<br />
 			[page:Float z] - 在Z轴方向的缩放比。<br /><br />
 
-			将这个矩阵设置为缩放变换:
-			<code>
-x, 0, 0, 0,
-0, y, 0, 0,
-0, 0, z, 0,
-0, 0, 0, 1
-			</code>
+			将这个矩阵设置为缩放变换:<br /><br />
+
+			<math>
+				<mrow>
+					<mo>[</mo>
+					<mtable>
+						<mtr>
+							<mtd><mi>x</mi></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mi>y</mi></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mi>z</mi></mtd>
+							<mtd><mn>0</mn></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>1</mn></mtd>
+						</mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math>
 		</p>
 
 		<h3>[method:this makeShear]( [param:Float x], [param:Float y], [param:Float z] )</h3>
@@ -311,13 +697,40 @@ x, 0, 0, 0,
 		[page:Float y] - 在Y轴上剪切的量。<br />
 		[page:Float z] - 在Z轴上剪切的量。<br /><br />
 
-		将此矩阵设置为剪切变换:
-<code>
-1, y, z, 0,
-x, 1, z, 0,
-x, y, 1, 0,
-0, 0, 0, 1
-</code>
+		将此矩阵设置为剪切变换:<br /><br />
+
+		<math>
+			<mrow>
+				<mo>[</mo>
+				<mtable>
+					<mtr>
+						<mtd><mn>1</mn></mtd>
+						<mtd><mi>y</mi><mi>x</mi></mtd>
+						<mtd><mi>z</mi><mi>x</mi></mtd>
+						<mtd><mn>0</mn></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mi>x</mi><mi>y</mi></mtd>
+						<mtd><mn>1</mn></mtd>
+						<mtd><mi>z</mi><mi>y</mi></mtd>
+						<mtd><mn>0</mn></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mi>x</mi><mi>z</mi></mtd>
+						<mtd><mi>y</mi><mi>z</mi></mtd>
+						<mtd><mn>1</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>1</mn></mtd>
+					</mtr>
+				</mtable>
+				<mo>]</mo>
+			</mrow>
+		</math>
 		</p>
 
 		<h3>[method:this makeTranslation]( [param:Vector3 v] )</h3>
@@ -325,13 +738,40 @@ x, y, 1, 0,
 			[method:this makeTranslation]( [param:Float x], [param:Float y], [param:Float z] ) // optional API
 		</h3>
 		<p>
-		取传入参数[param:Vector3 v]中值设设置该矩阵为平移变换：
-		<code>
-1, 0, 0, x,
-0, 1, 0, y,
-0, 0, 1, z,
-0, 0, 0, 1
-		</code>
+		取传入参数[param:Vector3 v]中值设设置该矩阵为平移变换：<br /><br />
+
+		<math>
+			<mrow>
+				<mo>[</mo>
+				<mtable>
+					<mtr>
+						<mtd><mn>1</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mi>x</mi></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>1</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mi>y</mi></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>1</mn></mtd>
+						<mtd><mi>z</mi></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>1</mn></mtd>
+					</mtr>
+				</mtable>
+				<mo>]</mo>
+			</mrow>
+		</math>
 		</p>
 
 		<h3>[method:this multiply]( [param:Matrix4 m] )</h3>
@@ -360,20 +800,75 @@ x, y, 1, 0,
 		<h3>[method:this setPosition]( [param:Vector3 v] )</h3>
 		<h3>[method:this setPosition]( [param:Float x], [param:Float y], [param:Float z] ) // optional API</h3>
 		<p>
-			取传入参数[param:Vector3 v]中值设置该矩阵的位置分量，不影响该矩阵的其余部分——即，如果该矩阵当前为:
-<code>
-a, b, c, d,
-e, f, g, h,
-i, j, k, l,
-m, n, o, p
-</code>
-变成:
-<code>
-a, b, c, v.x,
-e, f, g, v.y,
-i, j, k, v.z,
-m, n, o, p
-</code>
+			取传入参数[param:Vector3 v]中值设置该矩阵的位置分量，不影响该矩阵的其余部分——即，如果该矩阵当前为:<br /><br />
+
+			<math>
+				<mrow>
+					<mo>[</mo>
+					<mtable>
+						<mtr>
+							<mtd><mi>a</mi></mtd>
+							<mtd><mi>b</mi></mtd>
+							<mtd><mi>c</mi></mtd>
+							<mtd><mi>d</mi></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mi>e</mi></mtd>
+							<mtd><mi>f</mi></mtd>
+							<mtd><mi>g</mi></mtd>
+							<mtd><mi>h</mi></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mi>i</mi></mtd>
+							<mtd><mi>j</mi></mtd>
+							<mtd><mi>k</mi></mtd>
+							<mtd><mi>l</mi></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mi>m</mi></mtd>
+							<mtd><mi>n</mi></mtd>
+							<mtd><mi>o</mi></mtd>
+							<mtd><mi>p</mi></mtd>
+						</mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math><br /><br />
+
+			变成:<br /><br />
+
+			<math>
+				<mrow>
+					<mo>[</mo>
+					<mtable>
+						<mtr>
+							<mtd><mi>a</mi></mtd>
+							<mtd><mi>b</mi></mtd>
+							<mtd><mi>c</mi></mtd>
+							<mtd><mi>v.x</mi></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mi>e</mi></mtd>
+							<mtd><mi>f</mi></mtd>
+							<mtd><mi>g</mi></mtd>
+							<mtd><mi>v.y</mi></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mi>i</mi></mtd>
+							<mtd><mi>j</mi></mtd>
+							<mtd><mi>k</mi></mtd>
+							<mtd><mi>v.z</mi></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mi>m</mi></mtd>
+							<mtd><mi>n</mi></mtd>
+							<mtd><mi>o</mi></mtd>
+							<mtd><mi>p</mi></mtd>
+						</mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math>
 		</p>
 
 		<h3>[method:Array toArray]( [param:Array array], [param:Integer offset] )</h3>


### PR DESCRIPTION
fix #26812

This PR replaces `<code>` with `<math>` for matrices in docs.

Preview: https://raw.githack.com/ycw/three.js/mat-html-mathml/docs/index.html?q=matrix#api/en/math/Matrix4.extractBasis

