### PR TITLE
Docs: Use `<math>` for matrices in Matrix3.html

### DIFF
--- a/docs/api/ar/math/Matrix3.html
+++ b/docs/api/ar/math/Matrix3.html
@@ -86,19 +86,76 @@ m.elements = [ 11, 21, 31,
 		<p>
 		يستخرج [link:https://en.wikipedia.org/wiki/Basis_(linear_algebra) الأساس]
 		لهذه المصفوفة في ثلاثة متجهات محورية مقدمة. إذا كانت هذه المصفوفة
-		هي:
-		<code>
-	 a, b, c, 
-	 d, e, f, 
-	 g, h, i 
-		</code>
+		هي:<br /><br />
+
+		<math>
+			<mrow>
+				<mo>[</mo>
+				<mtable>
+					<mtr>
+						<mtd><mi>a</mi></mtd>
+						<mtd><mi>b</mi></mtd>
+						<mtd><mi>c</mi></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mi>d</mi></mtd>
+						<mtd><mi>e</mi></mtd>
+						<mtd><mi>f</mi></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mi>g</mi></mtd>
+						<mtd><mi>h</mi></mtd>
+						<mtd><mi>i</mi></mtd>
+					</mtr>
+				</mtable>
+				<mo>]</mo>
+			</mrow>
+		</math><br /><br />
+
 		ثم سيتم تعيين [page:Vector3 xAxis] ، [page:Vector3 yAxis] ، [page:Vector3 zAxis]
-		إلى:
-		<code>
-	 xAxis = (a, d, g) 
-	 yAxis = (b, e, h) 
-	 zAxis = (c, f, i) 
-		</code>
+		إلى:<br /><br />
+
+		<math>
+			<mrow>
+				<mi>xAxis</mi>
+				<mo>=</mo>
+				<mo>[</mo>
+				<mtable>
+					<mtr><mtd style="height: 1rem"><mi>a</mi></mtd></mtr>
+					<mtr><mtd style="height: 1rem"><mi>d</mi></mtd></mtr>
+					<mtr><mtd style="height: 1rem"><mi>g</mi></mtd></mtr>
+				</mtable>
+				<mo>]</mo>
+			</mrow>
+		</math>,
+
+		<math>
+			<mrow>
+				<mi>yAxis</mi>
+				<mo>=</mo>
+				<mo>[</mo>
+				<mtable>
+					<mtr><mtd style="height: 1rem"><mi>b</mi></mtd></mtr>
+					<mtr><mtd style="height: 1rem"><mi>e</mi></mtd></mtr>
+					<mtr><mtd style="height: 1rem"><mi>h</mi></mtd></mtr>
+				</mtable>
+				<mo>]</mo>
+			</mrow>
+		</math>, and
+
+		<math>
+			<mrow>
+				<mi>zAxis</mi>
+				<mo>=</mo>
+				<mo>[</mo>
+				<mtable>
+					<mtr><mtd style="height: 1rem"><mi>c</mi></mtd></mtr>
+					<mtr><mtd style="height: 1rem"><mi>f</mi></mtd></mtr>
+					<mtr><mtd style="height: 1rem"><mi>i</mi></mtd></mtr>
+				</mtable>
+				<mo>]</mo>
+			</mrow>
+		</math>
 		</p>
 	 
 		<h3>
@@ -135,12 +192,31 @@ m.elements = [ 11, 21, 31,
 	 
 		<h3>[method:this identity]()</h3>
 		<p>
-		يعيد هذه المصفوفة إلى مصفوفة الهوية 3x3:
-		<code> 
-	 1, 0, 0 
-	 0, 1, 0 
-	 0, 0, 1 
-		</code>
+		يعيد هذه المصفوفة إلى مصفوفة الهوية 3x3:<br /><br />
+
+		<math>
+			<mrow>
+				<mo>[</mo>
+				<mtable>
+					<mtr>
+						<mtd><mn>1</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>1</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>1</mn></mtd>
+					</mtr>
+				</mtable>
+				<mo>]</mo>
+			</mrow>
+		</math>
 		</p>
 	 
 		<h3>[method:this makeRotation]( [param:Float theta] )</h3>
@@ -149,12 +225,47 @@ m.elements = [ 11, 21, 31,
 		عكس عقارب الساعة.<br /><br />
 	 
 		يضع هذه المصفوفة كتحول دوران ثنائي الأبعاد بـ [page:Float theta]
-		راديان. المصفوفة الناتجة ستكون:
-		<code>
-	 cos(θ) -sin(θ) 0 
-	 sin(θ) cos(θ) 0 
-	 0 0 1
-		</code>
+		راديان. المصفوفة الناتجة ستكون:<br /><br />
+
+		<math>
+			<mrow>
+				<mo>[</mo>
+				<mtable>
+					<mtr>
+						<mtd>
+							<mi>cos</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mi>-sin</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+					</mtr>
+					<mtr>
+						<mtd>
+							<mi>sin</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mi>cos</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+					</mtr>
+					<mtr>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>1</mn></mtd>
+					</mtr>
+				</mtable>
+				<mo>]</mo>
+			</mrow>
+		</math>
 		</p>
 	 
 		<h3>[method:this makeScale]( [param:Float x], [param:Float y] )</h3>
@@ -162,12 +273,31 @@ m.elements = [ 11, 21, 31,
 		[page:Float x] - المبلغ الذي يتم قياسه في المحور X.<br />
 		[page:Float y] - المبلغ الذي يتم قياسه في المحور Y.<br />
 	 
-		يضع هذه المصفوفة كتحول قياس ثنائي الأبعاد:
-		<code> 
-	 x, 0, 0, 
-	 0, y, 0, 
-	 0, 0, 1 
-		</code>
+		يضع هذه المصفوفة كتحول قياس ثنائي الأبعاد:<br /><br />
+
+		<math>
+			<mrow>
+				<mo>[</mo>
+				<mtable>
+					<mtr>
+						<mtd><mi>x</mi></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mi>y</mi></mtd>
+						<mtd><mn>0</mn></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>1</mn></mtd>
+					</mtr>
+				</mtable>
+				<mo>]</mo>
+			</mrow>
+		</math>
 		</p>
 	 
 		<h3>[method:this makeTranslation]( [param:Vector2 v] )</h3>
@@ -178,12 +308,31 @@ m.elements = [ 11, 21, 31,
 		[page:Float x] - المبلغ الذي يتم ترجمته في المحور X.<br />
 		[page:Float y] - المبلغ الذي يتم ترجمته في المحور Y.<br />
 	 
-		يضع هذه المصفوفة كتحويل ترجمة ثنائي الأبعاد:
-		<code>
-	 1, 0, x, 
-	 0, 1, y, 
-	 0, 0, 1 
-		</code>
+		يضع هذه المصفوفة كتحويل ترجمة ثنائي الأبعاد:<br /><br />
+
+		<math>
+			<mrow>
+				<mo>[</mo>
+				<mtable>
+					<mtr>
+						<mtd><mn>1</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mi>x</mi></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>1</mn></mtd>
+						<mtd><mi>y</mi></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>1</mn></mtd>
+					</mtr>
+				</mtable>
+				<mo>]</mo>
+			</mrow>
+		</math>
 		</p>
 	 
 		<h3>[method:this multiply]( [param:Matrix3 m] )</h3>
@@ -207,15 +356,32 @@ m.elements = [ 11, 21, 31,
 		[method:this set]( [param:Float n11], [param:Float n12], [param:Float n13], [param:Float n21], [param:Float n22], [param:Float n23], [param:Float n31], [param:Float n32], [param:Float n33] )
 		</h3>
 		<p>
-		[page:Float n11] - القيمة التي يتم وضعها في الصف 1 ، العمود 1.<br />
-		[page:Float n12] - القيمة التي يتم وضعها في الصف 1 ، العمود 2.<br />
-		...<br />
-		...<br />
-		[page:Float n32] - القيمة التي يتم وضعها في الصف 3 ، العمود 2.<br />
-		[page:Float n33] - القيمة التي يتم وضعها في الصف 3 ، العمود 3.<br /><br />
-	 
 		يضع قيم المصفوفة 3x3 على
-		[link:https://en.wikipedia.org/wiki/Row-_and_column-major_order تسلسل قيم رئيسية للصف].
+		[link:https://en.wikipedia.org/wiki/Row-_and_column-major_order تسلسل قيم رئيسية للصف]:<br /><br />
+
+		<math>
+			<mrow>
+				<mo>[</mo>
+				<mtable>
+					<mtr>
+						<mtd><mi>n11</mi></mtd>
+						<mtd><mi>n12</mi></mtd>
+						<mtd><mi>n13</mi></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mi>n21</mi></mtd>
+						<mtd><mi>n22</mi></mtd>
+						<mtd><mi>n23</mi></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mi>n31</mi></mtd>
+						<mtd><mi>n32</mi></mtd>
+						<mtd><mi>n33</mi></mtd>
+					</mtr>
+				</mtable>
+				<mo>]</mo>
+			</mrow>
+		</math>
 		</p>
 	 
 		<h3>[method:this premultiply]( [param:Matrix3 m] )</h3>

--- a/docs/api/en/math/Matrix3.html
+++ b/docs/api/en/math/Matrix3.html
@@ -86,19 +86,76 @@ m.elements = [ 11, 21, 31,
 		<p>
 			Extracts the [link:https://en.wikipedia.org/wiki/Basis_(linear_algebra) basis] 
 			of this matrix into the three axis vectors provided. If this matrix
-			is:
-			<code>
-a, b, c, 
-d, e, f, 
-g, h, i 
-			</code>
+			is:<br /><br />
+
+			<math>
+				<mrow>
+					<mo>[</mo>
+					<mtable>
+						<mtr>
+							<mtd><mi>a</mi></mtd>
+							<mtd><mi>b</mi></mtd>
+							<mtd><mi>c</mi></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mi>d</mi></mtd>
+							<mtd><mi>e</mi></mtd>
+							<mtd><mi>f</mi></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mi>g</mi></mtd>
+							<mtd><mi>h</mi></mtd>
+							<mtd><mi>i</mi></mtd>
+						</mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math><br /><br />
+
 			then the [page:Vector3 xAxis], [page:Vector3 yAxis], [page:Vector3 zAxis]
-			will be set to:
-			<code>
-xAxis = (a, d, g) 
-yAxis = (b, e, h) 
-zAxis = (c, f, i) 
-			</code>
+			will be set to:<br /><br />
+
+			<math>
+				<mrow>
+					<mi>xAxis</mi>
+					<mo>=</mo>
+					<mo>[</mo>
+					<mtable>
+						<mtr><mtd style="height: 1rem"><mi>a</mi></mtd></mtr>
+						<mtr><mtd style="height: 1rem"><mi>d</mi></mtd></mtr>
+						<mtr><mtd style="height: 1rem"><mi>g</mi></mtd></mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math>,
+
+			<math>
+				<mrow>
+					<mi>yAxis</mi>
+					<mo>=</mo>
+					<mo>[</mo>
+					<mtable>
+						<mtr><mtd style="height: 1rem"><mi>b</mi></mtd></mtr>
+						<mtr><mtd style="height: 1rem"><mi>e</mi></mtd></mtr>
+						<mtr><mtd style="height: 1rem"><mi>h</mi></mtd></mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math>, and
+
+			<math>
+				<mrow>
+					<mi>zAxis</mi>
+					<mo>=</mo>
+					<mo>[</mo>
+					<mtable>
+						<mtr><mtd style="height: 1rem"><mi>c</mi></mtd></mtr>
+						<mtr><mtd style="height: 1rem"><mi>f</mi></mtd></mtr>
+						<mtr><mtd style="height: 1rem"><mi>i</mi></mtd></mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math>
 		</p>
 
 		<h3>
@@ -136,11 +193,31 @@ zAxis = (c, f, i)
 
 		<h3>[method:this identity]()</h3>
 		<p>
-			Resets this matrix to the 3x3 identity matrix:
-			<code> 
-1, 0, 0 
-0, 1, 0 
-0, 0, 1 	</code>
+			Resets this matrix to the 3x3 identity matrix:<br /><br />
+
+			<math>
+				<mrow>
+					<mo>[</mo>
+					<mtable>
+						<mtr>
+							<mtd><mn>1</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>1</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>1</mn></mtd>
+						</mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math>
 		</p>
 
 		<h3>[method:this makeRotation]( [param:Float theta] )</h3>
@@ -149,12 +226,47 @@ zAxis = (c, f, i)
 			counterclockwise.<br /><br />
 
 			Sets this matrix as a 2D rotational transformation by [page:Float theta]
-			radians. The resulting matrix will be:
-			<code>
-cos(&theta;) -sin(&theta;) 0 
-sin(&theta;) cos(&theta;) 0 
-0 0 1
-			</code>
+			radians. The resulting matrix will be:<br /><br />
+
+			<math>
+				<mrow>
+					<mo>[</mo>
+					<mtable>
+						<mtr>
+							<mtd>
+								<mi>cos</mi>
+								<mi>&theta;</mi>
+							</mtd>
+							<mtd>
+								<mi>-sin</mi>
+								<mi>&theta;</mi>
+							</mtd>
+							<mtd>
+								<mn>0</mn>
+							</mtd>
+						</mtr>
+						<mtr>
+							<mtd>
+								<mi>sin</mi>
+								<mi>&theta;</mi>
+							</mtd>
+							<mtd>
+								<mi>cos</mi>
+								<mi>&theta;</mi>
+							</mtd>
+							<mtd>
+								<mn>0</mn>
+							</mtd>
+						</mtr>
+						<mtr>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>1</mn></mtd>
+						</mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math>
 		</p>
 
 		<h3>[method:this makeScale]( [param:Float x], [param:Float y] )</h3>
@@ -162,11 +274,31 @@ sin(&theta;) cos(&theta;) 0
 			[page:Float x] - the amount to scale in the X axis.<br />
 			[page:Float y] - the amount to scale in the Y axis.<br />
 
-			Sets this matrix as a 2D scale transform:
-			<code> 
-x, 0, 0, 
-0, y, 0, 
-0, 0, 1 	</code>
+			Sets this matrix as a 2D scale transform:<br /><br />
+
+			<math>
+				<mrow>
+					<mo>[</mo>
+					<mtable>
+						<mtr>
+							<mtd><mi>x</mi></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mi>y</mi></mtd>
+							<mtd><mn>0</mn></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>1</mn></mtd>
+						</mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math>
 		</p>
 
 		<h3>[method:this makeTranslation]( [param:Vector2 v] )</h3>
@@ -177,11 +309,31 @@ x, 0, 0,
 			[page:Float x] - the amount to translate in the X axis.<br />
 			[page:Float y] - the amount to translate in the Y axis.<br />
 
-			Sets this matrix as a 2D translation transform:
-			<code>
-1, 0, x, 
-0, 1, y, 
-0, 0, 1 	</code>
+			Sets this matrix as a 2D translation transform:<br /><br />
+
+			<math>
+				<mrow>
+					<mo>[</mo>
+					<mtable>
+						<mtr>
+							<mtd><mn>1</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mi>x</mi></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>1</mn></mtd>
+							<mtd><mi>y</mi></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>1</mn></mtd>
+						</mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math>
 		</p>
 
 		<h3>[method:this multiply]( [param:Matrix3 m] )</h3>
@@ -205,16 +357,33 @@ x, 0, 0,
 			[method:this set]( [param:Float n11], [param:Float n12], [param:Float n13], [param:Float n21], [param:Float n22], [param:Float n23], [param:Float n31], [param:Float n32], [param:Float n33] )
 		</h3>
 		<p>
-			[page:Float n11] - value to put in row 1, col 1.<br />
-			[page:Float n12] - value to put in row 1, col 2.<br />
-			...<br />
-			...<br />
-			[page:Float n32] - value to put in row 3, col 2.<br />
-			[page:Float n33] - value to put in row 3, col 3.<br /><br />
-
 			Sets the 3x3 matrix values to the given
 			[link:https://en.wikipedia.org/wiki/Row-_and_column-major_order row-major]
-			sequence of values.
+			sequence of values:<br /><br />
+
+			<math>
+				<mrow>
+					<mo>[</mo>
+					<mtable>
+						<mtr>
+							<mtd><mi>n11</mi></mtd>
+							<mtd><mi>n12</mi></mtd>
+							<mtd><mi>n13</mi></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mi>n21</mi></mtd>
+							<mtd><mi>n22</mi></mtd>
+							<mtd><mi>n23</mi></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mi>n31</mi></mtd>
+							<mtd><mi>n32</mi></mtd>
+							<mtd><mi>n33</mi></mtd>
+						</mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math>
 		</p>
 
 		<h3>[method:this premultiply]( [param:Matrix3 m] )</h3>

--- a/docs/api/it/math/Matrix3.html
+++ b/docs/api/it/math/Matrix3.html
@@ -81,18 +81,75 @@ m.elements = [ 11, 21, 31,
 		<h3>[method:this extractBasis]( [param:Vector3 xAxis], [param:Vector3 yAxis], [param:Vector3 zAxis] )</h3>
 		<p>
 			Estrae la [link:https://en.wikipedia.org/wiki/Basis_(linear_algebra) base] di questa matrice
-			nei tre vettori asse forniti. Se questa matrice è:
-		<code>
-a, b, c,
-d, e, f,
-g, h, i
-		</code>
-		allora [page:Vector3 xAxis], [page:Vector3 yAxis], [page:Vector3 zAxis] saranno impostate a:
-		<code>
-xAxis = (a, d, g)
-yAxis = (b, e, h)
-zAxis = (c, f, i)
-		</code>
+			nei tre vettori asse forniti. Se questa matrice è:<br /><br />
+
+			<math>
+				<mrow>
+					<mo>[</mo>
+					<mtable>
+						<mtr>
+							<mtd><mi>a</mi></mtd>
+							<mtd><mi>b</mi></mtd>
+							<mtd><mi>c</mi></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mi>d</mi></mtd>
+							<mtd><mi>e</mi></mtd>
+							<mtd><mi>f</mi></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mi>g</mi></mtd>
+							<mtd><mi>h</mi></mtd>
+							<mtd><mi>i</mi></mtd>
+						</mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math><br /><br />
+
+			allora [page:Vector3 xAxis], [page:Vector3 yAxis], [page:Vector3 zAxis] saranno impostate a:<br /><br />
+
+			<math>
+				<mrow>
+					<mi>xAxis</mi>
+					<mo>=</mo>
+					<mo>[</mo>
+					<mtable>
+						<mtr><mtd style="height: 1rem"><mi>a</mi></mtd></mtr>
+						<mtr><mtd style="height: 1rem"><mi>d</mi></mtd></mtr>
+						<mtr><mtd style="height: 1rem"><mi>g</mi></mtd></mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math>,
+
+			<math>
+				<mrow>
+					<mi>yAxis</mi>
+					<mo>=</mo>
+					<mo>[</mo>
+					<mtable>
+						<mtr><mtd style="height: 1rem"><mi>b</mi></mtd></mtr>
+						<mtr><mtd style="height: 1rem"><mi>e</mi></mtd></mtr>
+						<mtr><mtd style="height: 1rem"><mi>h</mi></mtd></mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math>, and
+
+			<math>
+				<mrow>
+					<mi>zAxis</mi>
+					<mo>=</mo>
+					<mo>[</mo>
+					<mtable>
+						<mtr><mtd style="height: 1rem"><mi>c</mi></mtd></mtr>
+						<mtr><mtd style="height: 1rem"><mi>f</mi></mtd></mtr>
+						<mtr><mtd style="height: 1rem"><mi>i</mi></mtd></mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math>
 		</p>
 
 		<h3>[method:this fromArray]( [param:Array array], [param:Integer offset] )</h3>
@@ -122,13 +179,31 @@ zAxis = (c, f, i)
 
 		<h3>[method:this identity]()</h3>
 		<p>
-			Reimposta questa matrice alla matrice identità 3x3:
-		<code>
-1, 0, 0
-0, 1, 0
-0, 0, 1
-		</code>
+			Reimposta questa matrice alla matrice identità 3x3:<br /><br />
 
+			<math>
+				<mrow>
+					<mo>[</mo>
+					<mtable>
+						<mtr>
+							<mtd><mn>1</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>1</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>1</mn></mtd>
+						</mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math>
 		</p>
 
 		<h3>[method:this makeRotation]( [param:Float theta] )</h3>
@@ -136,12 +211,47 @@ zAxis = (c, f, i)
 		[page:Float theta] — Angolo di rotazione in radianti. I valori positivi ruotano in senso antiorario.<br /><br />
 
 		Imposta questa matrice come una trasformazione rotazionale 2D di [page:Float teta] radianti.
-		La matrice risultante sarà:
-		<code>
-cos(&theta;) -sin(&theta;) 0
-sin(&theta;) cos(&theta;)  0
-0      0       1
-		</code>
+		La matrice risultante sarà:<br /><br />
+
+		<math>
+			<mrow>
+				<mo>[</mo>
+				<mtable>
+					<mtr>
+						<mtd>
+							<mi>cos</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mi>-sin</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+					</mtr>
+					<mtr>
+						<mtd>
+							<mi>sin</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mi>cos</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+					</mtr>
+					<mtr>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>1</mn></mtd>
+					</mtr>
+				</mtable>
+				<mo>]</mo>
+			</mrow>
+		</math>
 		</p>
 
 		<h3>[method:this makeScale]( [param:Float x], [param:Float y] )</h3>
@@ -149,12 +259,31 @@ sin(&theta;) cos(&theta;)  0
 		[page:Float x] - la quantità da scalare sull'asse X.<br />
 		[page:Float y] - la quantità da scalare sull'asse Y.<br />
 
-		Imposta questa matrice come una trasformazione di scala 2D:
-		<code>
-x, 0, 0,
-0, y, 0,
-0, 0, 1
-		</code>
+		Imposta questa matrice come una trasformazione di scala 2D:<br /><br />
+
+		<math>
+			<mrow>
+				<mo>[</mo>
+				<mtable>
+					<mtr>
+						<mtd><mi>x</mi></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mi>y</mi></mtd>
+						<mtd><mn>0</mn></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>1</mn></mtd>
+					</mtr>
+				</mtable>
+				<mo>]</mo>
+			</mrow>
+		</math>
 		</p>
 
 		<h3>[method:this makeTranslation]( [param:Vector2 v] )</h3>
@@ -165,12 +294,31 @@ x, 0, 0,
 		[page:Float x] - la quantità da translare sull'asse X.<br />
 		[page:Float y] - la quantità da translare sull'asse Y.<br />
 
-		Imposta questa matrice come una trasformazione di traslazione 2D:
-		<code>
-1, 0, x,
-0, 1, y,
-0, 0, 1
-		</code>
+		Imposta questa matrice come una trasformazione di traslazione 2D:<br /><br />
+
+		<math>
+			<mrow>
+				<mo>[</mo>
+				<mtable>
+					<mtr>
+						<mtd><mn>1</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mi>x</mi></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>1</mn></mtd>
+						<mtd><mi>y</mi></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>1</mn></mtd>
+					</mtr>
+				</mtable>
+				<mo>]</mo>
+			</mrow>
+		</math>
 		</p>
 
 		<h3>[method:this multiply]( [param:Matrix3 m] )</h3>
@@ -190,15 +338,32 @@ x, 0, 0,
 
 		<h3>[method:this set]( [param:Float n11], [param:Float n12], [param:Float n13], [param:Float n21], [param:Float n22], [param:Float n23], [param:Float n31], [param:Float n32], [param:Float n33] )</h3>
 		<p>
-		[page:Float n11] - valore da inserire nella riga 1, colonna 1.<br />
-		[page:Float n12] - valore da inserire nella riga 1, colonna 2.<br />
-		...<br />
-		...<br />
-		[page:Float n32] - valore da inserire nella riga 3, colonna 2.<br />
-		[page:Float n33] - valore da inserire nella riga 3, colonna 3.<br /><br />
-
 		Imposta i valori della matrice 3x3 sulla sequenza di valori della
-		[link:https://en.wikipedia.org/wiki/Row-_and_column-major_order row-major] specificata.
+		[link:https://en.wikipedia.org/wiki/Row-_and_column-major_order row-major] specificata.<br /><br />
+
+		<math>
+			<mrow>
+				<mo>[</mo>
+				<mtable>
+					<mtr>
+						<mtd><mi>n11</mi></mtd>
+						<mtd><mi>n12</mi></mtd>
+						<mtd><mi>n13</mi></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mi>n21</mi></mtd>
+						<mtd><mi>n22</mi></mtd>
+						<mtd><mi>n23</mi></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mi>n31</mi></mtd>
+						<mtd><mi>n32</mi></mtd>
+						<mtd><mi>n33</mi></mtd>
+					</mtr>
+				</mtable>
+				<mo>]</mo>
+			</mrow>
+		</math>
 		</p>
 
 		<h3>[method:this premultiply]( [param:Matrix3 m] )</h3>

--- a/docs/api/zh/math/Matrix3.html
+++ b/docs/api/zh/math/Matrix3.html
@@ -79,18 +79,75 @@ m.elements = [ 11, 21, 31,
 
 		<h3>[method:this extractBasis]( [param:Vector3 xAxis], [param:Vector3 yAxis], [param:Vector3 zAxis] )</h3>
 		<p>
-		将该矩阵的基向量 [link:https://en.wikipedia.org/wiki/Basis_(linear_algebra) basis] 提取到提供的三个轴向中。如果该矩阵如下：
-		<code>
-a, b, c,
-d, e, f,
-g, h, i
-		</code>
-		那么 [page:Vector3 xAxis], [page:Vector3 yAxis], [page:Vector3 zAxis] 将会被设置为：
-		<code>
-xAxis = (a, d, g)
-yAxis = (b, e, h)
-zAxis = (c, f, i)
-		</code>
+		将该矩阵的基向量 [link:https://en.wikipedia.org/wiki/Basis_(linear_algebra) basis] 提取到提供的三个轴向中。如果该矩阵如下：<br /><br />
+
+		<math>
+			<mrow>
+				<mo>[</mo>
+				<mtable>
+					<mtr>
+						<mtd><mi>a</mi></mtd>
+						<mtd><mi>b</mi></mtd>
+						<mtd><mi>c</mi></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mi>d</mi></mtd>
+						<mtd><mi>e</mi></mtd>
+						<mtd><mi>f</mi></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mi>g</mi></mtd>
+						<mtd><mi>h</mi></mtd>
+						<mtd><mi>i</mi></mtd>
+					</mtr>
+				</mtable>
+				<mo>]</mo>
+			</mrow>
+		</math><br /><br />
+
+		那么 [page:Vector3 xAxis], [page:Vector3 yAxis], [page:Vector3 zAxis] 将会被设置为：<br /><br />
+
+		<math>
+			<mrow>
+				<mi>xAxis</mi>
+				<mo>=</mo>
+				<mo>[</mo>
+				<mtable>
+					<mtr><mtd style="height: 1rem"><mi>a</mi></mtd></mtr>
+					<mtr><mtd style="height: 1rem"><mi>d</mi></mtd></mtr>
+					<mtr><mtd style="height: 1rem"><mi>g</mi></mtd></mtr>
+				</mtable>
+				<mo>]</mo>
+			</mrow>
+		</math>,
+
+		<math>
+			<mrow>
+				<mi>yAxis</mi>
+				<mo>=</mo>
+				<mo>[</mo>
+				<mtable>
+					<mtr><mtd style="height: 1rem"><mi>b</mi></mtd></mtr>
+					<mtr><mtd style="height: 1rem"><mi>e</mi></mtd></mtr>
+					<mtr><mtd style="height: 1rem"><mi>h</mi></mtd></mtr>
+				</mtable>
+				<mo>]</mo>
+			</mrow>
+		</math>, and
+
+		<math>
+			<mrow>
+				<mi>zAxis</mi>
+				<mo>=</mo>
+				<mo>[</mo>
+				<mtable>
+					<mtr><mtd style="height: 1rem"><mi>c</mi></mtd></mtr>
+					<mtr><mtd style="height: 1rem"><mi>f</mi></mtd></mtr>
+					<mtr><mtd style="height: 1rem"><mi>i</mi></mtd></mtr>
+				</mtable>
+				<mo>]</mo>
+			</mrow>
+		</math>
 		</p>
 
 		<h3>[method:this fromArray]( [param:Array array], [param:Integer offset] )</h3>
@@ -116,13 +173,31 @@ zAxis = (c, f, i)
 
 		<h3>[method:this identity]()</h3>
 		<p>
-			将此矩阵重置为3x3单位矩阵:
-				<code>
-1, 0, 0
-0, 1, 0
-0, 0, 1
-		</code>
+			将此矩阵重置为3x3单位矩阵:<br /><br />
 
+			<math>
+				<mrow>
+					<mo>[</mo>
+					<mtable>
+						<mtr>
+							<mtd><mn>1</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>1</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+						</mtr>
+						<mtr>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>0</mn></mtd>
+							<mtd><mn>1</mn></mtd>
+						</mtr>
+					</mtable>
+					<mo>]</mo>
+				</mrow>
+			</math>
 		</p>
 
 		<h3>[method:this makeRotation]( [param:Float theta] )</h3>
@@ -130,12 +205,47 @@ zAxis = (c, f, i)
 		[page:Float theta] — Rotation angle in radians. Positive values rotate counterclockwise.<br /><br />
 
 		Sets this matrix as a 2D rotational transformation by [page:Float theta] radians.
-		The resulting matrix will be:
-		<code>
-cos(&theta;) -sin(&theta;) 0
-sin(&theta;) cos(&theta;)  0
-0      0       1
-		</code>
+		The resulting matrix will be:<br /><br />
+
+		<math>
+			<mrow>
+				<mo>[</mo>
+				<mtable>
+					<mtr>
+						<mtd>
+							<mi>cos</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mi>-sin</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+					</mtr>
+					<mtr>
+						<mtd>
+							<mi>sin</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mi>cos</mi>
+							<mi>&theta;</mi>
+						</mtd>
+						<mtd>
+							<mn>0</mn>
+						</mtd>
+					</mtr>
+					<mtr>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>1</mn></mtd>
+					</mtr>
+				</mtable>
+				<mo>]</mo>
+			</mrow>
+		</math>
 		</p>
 
 		<h3>[method:this makeScale]( [param:Float x], [param:Float y] )</h3>
@@ -143,12 +253,31 @@ sin(&theta;) cos(&theta;)  0
 		[page:Float x] - the amount to scale in the X axis.<br />
 		[page:Float y] - the amount to scale in the Y axis.<br />
 
-		Sets this matrix as a 2D scale transform:
-		<code>
-x, 0, 0,
-0, y, 0,
-0, 0, 1
-		</code>
+		Sets this matrix as a 2D scale transform:<br /><br />
+
+		<math>
+			<mrow>
+				<mo>[</mo>
+				<mtable>
+					<mtr>
+						<mtd><mi>x</mi></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mi>y</mi></mtd>
+						<mtd><mn>0</mn></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>1</mn></mtd>
+					</mtr>
+				</mtable>
+				<mo>]</mo>
+			</mrow>
+		</math>
 		</p>
 
 		<h3>[method:this makeTranslation]( [param:Vector2 v] )</h3>
@@ -159,12 +288,31 @@ x, 0, 0,
 		[page:Float x] - the amount to translate in the X axis.<br />
 		[page:Float y] - the amount to translate in the Y axis.<br />
 
-		Sets this matrix as a 2D translation transform:
-		<code>
-1, 0, x,
-0, 1, y,
-0, 0, 1
-		</code>
+		Sets this matrix as a 2D translation transform:<br /><br />
+
+		<math>
+			<mrow>
+				<mo>[</mo>
+				<mtable>
+					<mtr>
+						<mtd><mn>1</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mi>x</mi></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>1</mn></mtd>
+						<mtd><mi>y</mi></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>0</mn></mtd>
+						<mtd><mn>1</mn></mtd>
+					</mtr>
+				</mtable>
+				<mo>]</mo>
+			</mrow>
+		</math>
 		</p>
 
 		<h3>[method:this multiply]( [param:Matrix3 m] )</h3>
@@ -178,14 +326,31 @@ x, 0, 0,
 
 		<h3>[method:this set]( [param:Float n11], [param:Float n12], [param:Float n13], [param:Float n21], [param:Float n22], [param:Float n23], [param:Float n31], [param:Float n32], [param:Float n33] )</h3>
 		<p>
-		[page:Float n11] - 设置第一行第一列的值。<br />
-		[page:Float n12] - 设置第一行第二列的值。<br />
-		...<br />
-		...<br />
-		[page:Float n32] - 设置第三行第二列的值。<br />
-		[page:Float n33] - 设置第三行第三列的值。<br /><br />
+		使用行优先 [link:https://en.wikipedia.org/wiki/Row-_and_column-major_order row-major] 的格式来设置该矩阵:<br /><br />
 
-		使用行优先 [link:https://en.wikipedia.org/wiki/Row-_and_column-major_order row-major] 的格式来设置该矩阵。
+		<math>
+			<mrow>
+				<mo>[</mo>
+				<mtable>
+					<mtr>
+						<mtd><mi>n11</mi></mtd>
+						<mtd><mi>n12</mi></mtd>
+						<mtd><mi>n13</mi></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mi>n21</mi></mtd>
+						<mtd><mi>n22</mi></mtd>
+						<mtd><mi>n23</mi></mtd>
+					</mtr>
+					<mtr>
+						<mtd><mi>n31</mi></mtd>
+						<mtd><mi>n32</mi></mtd>
+						<mtd><mi>n33</mi></mtd>
+					</mtr>
+				</mtable>
+				<mo>]</mo>
+			</mrow>
+		</math>
 		</p>
 
 		<h3>[method:this premultiply]( [param:Matrix3 m] )</h3>


### PR DESCRIPTION
Related issue: #26812

This PR replaces `<code>` with `<math>` for matrices in docs

preview: https://raw.githack.com/ycw/three.js/mat3_html_mathml/docs/index.html#api/en/math/Matrix3.extractBasis

Also, updates `.set()` from using textual desc to mathml:

https://raw.githack.com/ycw/three.js/mat3_html_mathml/docs/index.html#api/en/math/Matrix3.set