### PR TITLE
Docs: Fix wrong bbcode in Matrix4.html

### DIFF
--- a/docs/api/ar/math/Matrix4.html
+++ b/docs/api/ar/math/Matrix4.html
@@ -63,7 +63,7 @@
 
 		<h2>ملاحظة حول ترتيب الصف الرئيسي والعمود الرئيسي</h2>
 		<p>
-		يأخذ الباني وطريقة [page:set]() المعاملات في
+		يأخذ الباني وطريقة [page:.set set]() المعاملات في
 		[link:https://en.wikipedia.org/wiki/Row-_and_column-major_order#Column-major_order row-major] 
 		ترتيب ، في حين يتم تخزينها داخليًا في مصفوفة [page:.elements elements] بترتيب العمود الرئيسي. <br /><br />
 	 

--- a/docs/api/en/math/Matrix4.html
+++ b/docs/api/en/math/Matrix4.html
@@ -62,7 +62,7 @@
 
 		<h2>A Note on Row-Major and Column-Major Ordering</h2>
 		<p>
-			The constructor and [page:set]() method take arguments in
+			The constructor and [page:.set set]() method take arguments in
 			[link:https://en.wikipedia.org/wiki/Row-_and_column-major_order#Column-major_order row-major] 
 			order, while internally they are stored in the [page:.elements elements] array in column-major order.<br /><br />
 

--- a/docs/api/it/math/Matrix4.html
+++ b/docs/api/it/math/Matrix4.html
@@ -54,7 +54,7 @@
 
 		<h2>Una nota sull'ordine delle Row-Major (righe principali) e delle Column-Major (colonne principali)</h2>
 		<p>
-			Il metodo [page:set]() accetta gli argomenti in ordine 
+			Il metodo [page:.set set]() accetta gli argomenti in ordine 
 			[link:https://en.wikipedia.org/wiki/Row-_and_column-major_order#Column-major_order row-major], mentre internamente 
 			vengono memorizzati nell'array [page:.elements elements] nell'ordine column-major.<br /><br />
 

--- a/docs/api/zh/math/Matrix4.html
+++ b/docs/api/zh/math/Matrix4.html
@@ -48,7 +48,7 @@
 
 		<h2>注意行优先列优先的顺序。</h2>
 		<p>
-				设置[page:set]()方法参数采用行优先[link:https://en.wikipedia.org/wiki/Row-_and_column-major_order#Column-major_order row-major]，
+				设置[page:.set set]()方法参数采用行优先[link:https://en.wikipedia.org/wiki/Row-_and_column-major_order#Column-major_order row-major]，
 				而它们在内部是用列优先[link:https://en.wikipedia.org/wiki/Row-_and_column-major_order column-major]顺序存储在数组当中。<br /><br />
 
 				这意味着


### PR DESCRIPTION
This PR uses proper bbcode to reference self `.set()` in docs.
