### PR TITLE
Docs: Proper `lang` attr in Creating-a-scene.html

### DIFF
--- a/docs/manual/en/introduction/Creating-a-scene.html
+++ b/docs/manual/en/introduction/Creating-a-scene.html
@@ -105,8 +105,8 @@
 
 		<code>
 		&lt;!DOCTYPE html&gt;
-		&lt;html&gt;
-			&lt;head lang="en"&gt;
+		&lt;html lang="en"&gt;
+			&lt;head&gt;
 				&lt;meta charset="utf-8"&gt;
 				&lt;title&gt;My first three.js app&lt;/title&gt;
 				&lt;style&gt;


### PR DESCRIPTION
In the example code, `lang` attr is incorrectly added to `<head>`, this PR fixed that by adding it to `<html>` instead.