### PR TITLE
GLTFExporter: handle count=Infinity in processAccessor

### DIFF
--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -1165,7 +1165,7 @@ class GLTFWriter {
 		}
 
 		if ( start === undefined ) start = 0;
-		if ( count === undefined ) count = attribute.count;
+		if ( count === undefined || count === Infinity ) count = attribute.count;
 
 		// Skip creating an accessor if the attribute doesn't have data to export
 		if ( count === 0 ) return null;


### PR DESCRIPTION
Part of #26666 

Adding a group with child.geometry.addGroup(0, Infinity, 0); breaks the export as count = Infinity is passed to processAccessor
So we handle the case