### PR TITLE
ensure bump map scale is texture UV scale invariant. adjust examples.

### DIFF
--- a/examples/webgl_lights_physical.html
+++ b/examples/webgl_lights_physical.html
@@ -111,7 +111,7 @@
 					roughness: 0.8,
 					color: 0xffffff,
 					metalness: 0.2,
-					bumpScale: 0.0005
+					bumpScale: 1
 				} );
 				const textureLoader = new THREE.TextureLoader();
 				textureLoader.load( 'textures/hardwood2_diffuse.jpg', function ( map ) {
@@ -149,7 +149,7 @@
 				cubeMat = new THREE.MeshStandardMaterial( {
 					roughness: 0.7,
 					color: 0xffffff,
-					bumpScale: 0.002,
+					bumpScale: 1,
 					metalness: 0.2
 				} );
 				textureLoader.load( 'textures/brick_diffuse.jpg', function ( map ) {

--- a/examples/webgl_materials_bumpmap.html
+++ b/examples/webgl_materials_bumpmap.html
@@ -92,7 +92,7 @@
 					specular: 0x666666,
 					shininess: 25,
 					bumpMap: mapHeight,
-					bumpScale: 0.1
+					bumpScale: 10
 				} );
 
 				loader = new GLTFLoader();

--- a/src/renderers/shaders/ShaderChunk/bumpmap_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/bumpmap_pars_fragment.glsl.js
@@ -24,8 +24,9 @@ export default /* glsl */`
 
 	vec3 perturbNormalArb( vec3 surf_pos, vec3 surf_norm, vec2 dHdxy, float faceDirection ) {
 
-		vec3 vSigmaX = dFdx( surf_pos.xyz );
-		vec3 vSigmaY = dFdy( surf_pos.xyz );
+		// normalize is done to ensure that the bump map looks the same regardless of the texture's scale
+		vec3 vSigmaX = normalize( dFdx( surf_pos.xyz ) );
+		vec3 vSigmaY = normalize( dFdy( surf_pos.xyz ) );
 		vec3 vN = surf_norm; // normalized
 
 		vec3 R1 = cross( vSigmaY, vN );


### PR DESCRIPTION
**Description**

Right now our bump scale is dependent upon the texture UV scale in world space.  This is incorrect, rather a bump map should look the same regardless of the texture UV scale in world space.  Our normal factors are invariant to texture UV scale, it is just the bump scale that isn't.

By fixing this, this allows us to use more sensible scale factors that are close to 1.0 by default.  Otherwise we had to use weird 0.01 scale factors or similar if the texture UV scale in world space wasn't close to unity.

You can see here how we made the normal factors texture UV scale invariant, it is the normalization right here using the determinant scale:

https://github.com/mrdoob/three.js/blob/dev/src/renderers/shaders/ShaderChunk/normalmap_pars_fragment.glsl.js#L36C2-L36C2

Also in Babylon.js, they are normalizing the texture UV space in this code, which they label "construct a scale-invariant frame":

https://github.com/BabylonJS/Babylon.js/blob/master/packages/dev/core/src/Shaders/ShadersInclude/bumpFragmentMainFunctions.fx#L105

This is a breaking change to anyone who is using bump map scale factors.  But I believe it should increase our compatibility with other systems who do this correctly.

*This contribution is funded by [Threekit](https://threekit.com)*
