### PR TITLE
Material: Fix .needsUpdate + .alphaHash

### DIFF
--- a/docs/scenes/material-browser.html
+++ b/docs/scenes/material-browser.html
@@ -352,6 +352,7 @@
 				// folder.add( material, 'polygonOffsetFactor' );
 				// folder.add( material, 'polygonOffsetUnits' );
 				folder.add( material, 'alphaTest', 0, 1 ).step( 0.01 ).onChange( needsUpdate( material, geometry ) );
+				folder.add( material, 'alphaHash' ).onChange( needsUpdate( material, geometry ) );
 				folder.add( material, 'visible' );
 				folder.add( material, 'side', constants.side ).onChange( needsUpdate( material, geometry ) );
 

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -500,6 +500,8 @@ function WebGLPrograms( renderer, cubemaps, cubeuvmaps, extensions, capabilities
 			_programLayers.enable( 16 );
 		if ( parameters.anisotropy )
 			_programLayers.enable( 17 );
+		if ( parameters.alphaHash )
+			_programLayers.enable( 18 );
 
 		array.push( _programLayers.mask );
 		_programLayers.disableAll();


### PR DESCRIPTION
Currently `.alphaHash` is not included in the program cache key.

Related:

- #24271 