### PR TITLE
WebGLRenderer: Don't automatically rebind in WebXR.

### DIFF
--- a/examples/jsm/postprocessing/OutputPass.js
+++ b/examples/jsm/postprocessing/OutputPass.js
@@ -67,7 +67,7 @@ class OutputPass extends Pass {
 
 		if ( this.renderToScreen === true ) {
 
-			renderer.setRenderTarget( null );
+			renderer.setRenderTarget( renderer.xr.enabled ? renderer.xr.getRenderTarget() : null );
 			this.fsQuad.render( renderer );
 
 		} else {

--- a/examples/jsm/postprocessing/OutputPass.js
+++ b/examples/jsm/postprocessing/OutputPass.js
@@ -67,7 +67,7 @@ class OutputPass extends Pass {
 
 		if ( this.renderToScreen === true ) {
 
-			renderer.setRenderTarget( renderer.xr.enabled ? renderer.xr.getRenderTarget() : null );
+			renderer.setRenderTarget( renderer.xr.isPresenting ? renderer.xr.getRenderTarget() : null );
 			this.fsQuad.render( renderer );
 
 		} else {

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2060,13 +2060,6 @@ class WebGLRenderer {
 
 		this.setRenderTarget = function ( renderTarget, activeCubeFace = 0, activeMipmapLevel = 0 ) {
 
-			// Render to base layer instead of canvas in WebXR
-			if ( renderTarget === null && this.xr.isPresenting ) {
-
-				renderTarget = this.xr._getRenderTarget();
-
-			}
-
 			_currentRenderTarget = renderTarget;
 			_currentActiveCubeFace = activeCubeFace;
 			_currentActiveMipmapLevel = activeMipmapLevel;

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -235,7 +235,7 @@ class WebXRManager extends EventDispatcher {
 
 		};
 
-		this._getRenderTarget = function () {
+		this.getRenderTarget = function () {
 
 			return newRenderTarget;
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/26160#issuecomment-1751012842

**Description**

Manually binds to the layer render target at the end of the chain to work around misc. performance issues.
