### PR TITLE
WebGPURenderer Compute: Fix uniform update

### DIFF
--- a/examples/jsm/nodes/gpgpu/ComputeNode.js
+++ b/examples/jsm/nodes/gpgpu/ComputeNode.js
@@ -17,7 +17,7 @@ class ComputeNode extends Node {
 		this.dispatchCount = 0;
 
 		this.version = 1;
-		this.updateType = NodeUpdateType.OBJECT;
+		this.updateBeforeType = NodeUpdateType.OBJECT;
 
 		this.updateDispatchCount();
 
@@ -50,7 +50,7 @@ class ComputeNode extends Node {
 
 	onInit() { }
 
-	update( { renderer } ) {
+	updateBefore( { renderer } ) {
 
 		renderer.compute( this );
 

--- a/examples/jsm/renderers/common/Bindings.js
+++ b/examples/jsm/renderers/common/Bindings.js
@@ -50,7 +50,7 @@ class Bindings extends DataMap {
 
 			const nodeBuilderState = this.nodes.getForCompute( computeNode );
 
-			const bindings = nodeBuilderState.bindings;
+			const bindings = nodeBuilderState.bindings.compute;
 
 			data.bindings = bindings;
 

--- a/examples/jsm/renderers/common/nodes/Nodes.js
+++ b/examples/jsm/renderers/common/nodes/Nodes.js
@@ -336,22 +336,28 @@ class Nodes extends DataMap {
 
 	}
 
-	getNodeFrame( renderObject ) {
+	getNodeFrame( renderer = this.renderer, scene = null, object = null, camera = null, material = null ) {
 
 		const nodeFrame = this.nodeFrame;
-		nodeFrame.scene = renderObject.scene;
-		nodeFrame.object = renderObject.object;
-		nodeFrame.camera = renderObject.camera;
-		nodeFrame.renderer = renderObject.renderer;
-		nodeFrame.material = renderObject.material;
+		nodeFrame.renderer = renderer;
+		nodeFrame.scene = scene;
+		nodeFrame.object = object;
+		nodeFrame.camera = camera;
+		nodeFrame.material = material;
 
 		return nodeFrame;
 
 	}
 
+	getNodeFrameForRender( renderObject ) {
+
+		return this.getNodeFrame( renderObject.renderer, renderObject.scene, renderObject.object, renderObject.camera, renderObject.material );
+
+	}
+
 	updateBefore( renderObject ) {
 
-		const nodeFrame = this.getNodeFrame( renderObject );
+		const nodeFrame = this.getNodeFrameForRender( renderObject );
 		const nodeBuilder = renderObject.getNodeBuilderState();
 
 		for ( const node of nodeBuilder.updateBeforeNodes ) {
@@ -362,11 +368,22 @@ class Nodes extends DataMap {
 
 	}
 
-	updateForCompute( /*computeNode*/ ) { }
+	updateForCompute( computeNode ) {
+
+		const nodeFrame = this.getNodeFrame();
+		const nodeBuilder = this.getForCompute( computeNode );
+
+		for ( const node of nodeBuilder.updateNodes ) {
+
+			nodeFrame.updateNode( node );
+
+		}
+
+	}
 
 	updateForRender( renderObject ) {
 
-		const nodeFrame = this.getNodeFrame( renderObject );
+		const nodeFrame = this.getNodeFrameForRender( renderObject );
 		const nodeBuilder = renderObject.getNodeBuilderState();
 
 		for ( const node of nodeBuilder.updateNodes ) {


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/26769#issuecomment-1748078444

**Description**

The uniform updates were not occurring correctly for `renderer.compute()`, this PR fixed that.
