### PR TITLE
FilmShader: Fix deterioration.

### DIFF
--- a/examples/jsm/shaders/FilmShader.js
+++ b/examples/jsm/shaders/FilmShader.js
@@ -38,7 +38,7 @@ const FilmShader = {
 
 			vec4 base = texture2D( tDiffuse, vUv );
 
-			float noise = rand( vUv + mod(time,1.0) );
+			float noise = rand( fract(vUv + time) );
 
 			vec3 color = base.rgb + base.rgb * clamp( 0.1 + noise, 0.0, 1.0 );
 

--- a/examples/jsm/shaders/FilmShader.js
+++ b/examples/jsm/shaders/FilmShader.js
@@ -38,7 +38,7 @@ const FilmShader = {
 
 			vec4 base = texture2D( tDiffuse, vUv );
 
-			float noise = rand( vUv + time );
+			float noise = rand( vUv + mod(time,1.0) );
 
 			vec3 color = base.rgb + base.rgb * clamp( 0.1 + noise, 0.0, 1.0 );
 

--- a/examples/jsm/shaders/FilmShader.js
+++ b/examples/jsm/shaders/FilmShader.js
@@ -38,7 +38,7 @@ const FilmShader = {
 
 			vec4 base = texture2D( tDiffuse, vUv );
 
-			float noise = rand( fract(vUv + time) );
+			float noise = rand( fract( vUv + time ) );
 
 			vec3 color = base.rgb + base.rgb * clamp( 0.1 + noise, 0.0, 1.0 );
 


### PR DESCRIPTION
No Related Issue

**Description**
Incorrect usage of the ``rand`` function causes the film effect to deteriorate with large time values. This is fixed by applying a modulus to the time value, restraining it to the expected [0,1]x[0,1] range of the ``rand`` function

https://github.com/mrdoob/three.js/blob/76e1fb171af400afebbfb851ef7d7297625c5f0a/src/renderers/shaders/ShaderChunk/common.glsl.js#L24