### PR TITLE
GLTFExporter: Add support for 4 UV channels.

### DIFF
--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -1646,6 +1646,8 @@ class GLTFWriter {
 		const nameConversion = {
 			uv: 'TEXCOORD_0',
 			uv1: 'TEXCOORD_1',
+			uv2: 'TEXCOORD_2',
+			uv3: 'TEXCOORD_3',
 			color: 'COLOR_0',
 			skinWeight: 'WEIGHTS_0',
 			skinIndex: 'JOINTS_0'


### PR DESCRIPTION
**Description**

Three.js now supports multiple UV channels per mesh, up to 4:

https://github.com/mrdoob/three.js/blob/76e1fb171af400afebbfb851ef7d7297625c5f0a/src/renderers/webgl/WebGLPrograms.js#L160-L162

https://github.com/mrdoob/three.js/blob/76e1fb171af400afebbfb851ef7d7297625c5f0a/src/renderers/webgl/WebGLProgram.js#L585-L587

The GLTFImporter supports 4 channels per mesh of UVs:

https://github.com/mrdoob/three.js/blob/dev/examples/jsm/loaders/GLTFLoader.js#L2116-L2118

But the GLTFExporter only support 2 channels per mesh:

https://github.com/mrdoob/three.js/blob/76e1fb171af400afebbfb851ef7d7297625c5f0a/examples/jsm/exporters/GLTFExporter.js#L1647-L1650

This PR fixes that discrepancy.

*This contribution is funded by [Threekit](https://threekit.com)*
