### PR TITLE
VRButton: Test navigator for SSR.

### DIFF
--- a/examples/jsm/webxr/VRButton.js
+++ b/examples/jsm/webxr/VRButton.js
@@ -176,7 +176,7 @@ class VRButton {
 
 	static registerSessionGrantedListener() {
 
-		if ( 'xr' in navigator ) {
+		if ( typeof navigator !== 'undefined' && 'xr' in navigator ) {
 
 			// WebXRViewer (based on Firefox) has a bug where addEventListener
 			// throws a silent exception and aborts execution entirely.


### PR DESCRIPTION
Related issue: #XXXX

**Description**

Noticed that only `VRButton` breaks Node/Edge compatibility for SSR with the unconditional use of `navigator`.

With #26910, I tested with `node examples/jsm/Addons.js` which should run without error.
