### PR TITLE
Box3: Better support for animated objects in `expandByObject()` in precise mode.

### DIFF
--- a/editor/js/Viewport.js
+++ b/editor/js/Viewport.js
@@ -713,6 +713,13 @@ function Viewport( editor ) {
 			mixer.update( delta );
 			needsUpdate = true;
 
+			if ( editor.selected !== null ) {
+
+				editor.selected.updateWorldMatrix( false, true ); // avoid frame late effect for certain skinned meshes (e.g. Michelle.glb)
+				selectionBox.box.setFromObject( editor.selected, true ); // selection box should reflect current animation state
+
+			}
+
 		}
 
 		// View Helper


### PR DESCRIPTION
Fixed #18245.

**Description**

This PR makes sure the precise mode of `Box3.expandByObject()` supports the animated state of morphed and skinned meshes which leads to more correct bounding boxes (especially when using `setFromObject()`).

With this change, the editor only requires a small addition in its animation loop so the selection box reflects the current animation state.
