### PR TITLE
ensure that indirect sheen is shadowed by specular ambient occlusion.

### DIFF
--- a/src/renderers/shaders/ShaderChunk/aomap_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/aomap_fragment.glsl.js
@@ -6,11 +6,18 @@ export default /* glsl */`
 
 	reflectedLight.indirectDiffuse *= ambientOcclusion;
 
+
 	#if defined( USE_ENVMAP ) && defined( STANDARD )
 
 		float dotNV = saturate( dot( geometryNormal, geometryViewDir ) );
 
-		reflectedLight.indirectSpecular *= computeSpecularOcclusion( dotNV, ambientOcclusion, material.roughness );
+		float specularOcclusion = computeSpecularOcclusion( dotNV, ambientOcclusion, material.roughness );
+
+		reflectedLight.indirectSpecular *= specularOcclusion;
+
+		#if defined( USE_SHEEN ) 
+			sheenSpecularIndirect *= specularOcclusion;
+		#endif
 
 	#endif
 

--- a/src/renderers/shaders/ShaderChunk/aomap_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/aomap_fragment.glsl.js
@@ -6,18 +6,15 @@ export default /* glsl */`
 
 	reflectedLight.indirectDiffuse *= ambientOcclusion;
 
+	#if defined( USE_SHEEN ) 
+		sheenSpecularIndirect *= ambientOcclusion;
+	#endif
 
 	#if defined( USE_ENVMAP ) && defined( STANDARD )
 
 		float dotNV = saturate( dot( geometryNormal, geometryViewDir ) );
 
-		float specularOcclusion = computeSpecularOcclusion( dotNV, ambientOcclusion, material.roughness );
-
-		reflectedLight.indirectSpecular *= specularOcclusion;
-
-		#if defined( USE_SHEEN ) 
-			sheenSpecularIndirect *= specularOcclusion;
-		#endif
+		reflectedLight.indirectSpecular *= computeSpecularOcclusion( dotNV, ambientOcclusion, material.roughness );
 
 	#endif
 

--- a/src/renderers/shaders/ShaderChunk/lights_physical_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_physical_pars_fragment.glsl.js
@@ -50,7 +50,9 @@ struct PhysicalMaterial {
 
 // temporary
 vec3 clearcoatSpecular = vec3( 0.0 );
-vec3 sheenSpecular = vec3( 0.0 );
+
+vec3 sheenSpecularDirect = vec3( 0.0 );
+vec3 sheenSpecularIndirect = vec3(0.0 );
 
 vec3 Schlick_to_F0( const in vec3 f, const in float f90, const in float dotVH ) {
     float x = clamp( 1.0 - dotVH, 0.0, 1.0 );
@@ -491,7 +493,7 @@ void RE_Direct_Physical( const in IncidentLight directLight, const in vec3 geome
 
 	#ifdef USE_SHEEN
 
-		sheenSpecular += irradiance * BRDF_Sheen( directLight.direction, geometryViewDir, geometryNormal, material.sheenColor, material.sheenRoughness );
+		sheenSpecularDirect += irradiance * BRDF_Sheen( directLight.direction, geometryViewDir, geometryNormal, material.sheenColor, material.sheenRoughness );
 
 	#endif
 
@@ -516,7 +518,7 @@ void RE_IndirectSpecular_Physical( const in vec3 radiance, const in vec3 irradia
 
 	#ifdef USE_SHEEN
 
-		sheenSpecular += irradiance * material.sheenColor * IBLSheenBRDF( geometryNormal, geometryViewDir, material.sheenRoughness );
+		sheenSpecularIndirect += irradiance * material.sheenColor * IBLSheenBRDF( geometryNormal, geometryViewDir, material.sheenRoughness );
 
 	#endif
 

--- a/src/renderers/shaders/ShaderLib/meshphysical.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshphysical.glsl.js
@@ -197,7 +197,7 @@ void main() {
 		// https://drive.google.com/file/d/1T0D1VSyR4AllqIJTQAraEIzjlb5h4FKH/view?usp=sharing
 		float sheenEnergyComp = 1.0 - 0.157 * max3( material.sheenColor );
 
-		outgoingLight = outgoingLight * sheenEnergyComp + sheenSpecular;
+		outgoingLight = outgoingLight * sheenEnergyComp + sheenSpecularDirect + sheenSpecularIndirect;
 
 	#endif
 


### PR DESCRIPTION
Fixed #26939

**Description**

This fixes sheen so that that when it is lit by indirect light (IBL) it will be shadowed by ambient occlusion.

Before:
![Screenshot 2023-10-10 at 5 01 25 PM](https://github.com/mrdoob/three.js/assets/588541/667edc9f-8c55-4287-bf52-bd8f8fdef0cc)

After:
![Screenshot 2023-10-10 at 8 26 38 PM](https://github.com/mrdoob/three.js/assets/588541/03e88b2e-9315-42cd-ac38-fe69d02399be)
 
Caveat: My reuse of the specularOcclusion function is an approximation.  I am not sure if it is appropriate for indirect specular, rather I think it was designed for direct specular.  It is close anyhow and better than not occluding indirect sheen.

Fun fact: I think that clear coat has the same bug.  I will make a [PR for occluding indirect clearcoat separately](https://github.com/mrdoob/three.js/pull/26941).

*This contribution is funded by [Threekit](https://threekit.com)*
