### PR TITLE
WebGLRenderer: Disable transmission pass if override material is enabled.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1329,6 +1329,14 @@ class WebGLRenderer {
 
 		function renderTransmissionPass( opaqueObjects, transmissiveObjects, scene, camera ) {
 
+			const overrideMaterial = scene.isScene === true ? scene.overrideMaterial : null;
+
+			if ( overrideMaterial !== null ) {
+
+				return;
+
+			}
+
 			const isWebGL2 = capabilities.isWebGL2;
 
 			if ( _transmissionRenderTarget === null ) {


### PR DESCRIPTION
Original object materials are ignored in rendering in case an override material is used, so rendering the transmission pass is not necessary in this case.

*This contribution is funded by [Higharc](https://higharc.com/)*
