### PR TITLE
SAOPass: Remove `depthMaterial` reference from `dispose()`.

### DIFF
--- a/examples/jsm/postprocessing/SAOPass.js
+++ b/examples/jsm/postprocessing/SAOPass.js
@@ -314,7 +314,6 @@ class SAOPass extends Pass {
 		this.blurIntermediateRenderTarget.dispose();
 		this.normalRenderTarget.dispose();
 
-		this.depthMaterial.dispose();
 		this.normalMaterial.dispose();
 		this.saoMaterial.dispose();
 		this.vBlurMaterial.dispose();


### PR DESCRIPTION
Fixes `Uncaught TypeError: Cannot read properties of undefined (reading 'dispose')` when disposing a `SAOPass`.


**Description**

This commit https://github.com/mrdoob/three.js/pull/26599/commits/8c047d605aeab3e296168acbbf6a3136eac6ff26 removes `depthMaterial` from SAOPass but does not remove the dispose call of it.

This PR removes it.
