### PR TITLE
Editor: Fix sidebar refresh.

### DIFF
--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -83,6 +83,7 @@ function Editor() {
 		showGridChanged: new Signal(),
 		showHelpersChanged: new Signal(),
 		refreshSidebarObject3D: new Signal(),
+		refreshSidebarEnvironment: new Signal(),
 		historyChanged: new Signal(),
 
 		viewportCameraChanged: new Signal(),
@@ -662,6 +663,7 @@ Editor.prototype = {
 		if ( json.environment === 'ModelViewer' ) {
 
 			this.signals.sceneEnvironmentChanged.dispatch( json.environment );
+			this.signals.refreshSidebarEnvironment.dispatch();
 
 		}
 

--- a/editor/js/Sidebar.Scene.js
+++ b/editor/js/Sidebar.Scene.js
@@ -484,7 +484,7 @@ function SidebarScene( editor ) {
 
 	signals.sceneGraphChanged.add( refreshUI );
 
-	signals.sceneEnvironmentChanged.add( refreshUI );
+	signals.refreshSidebarEnvironment.add( refreshUI );
 
 	/*
 	signals.objectChanged.add( function ( object ) {


### PR DESCRIPTION
Related issue: #26718

**Description**

This PR fixes a small regression when #26718 was implemented. The change ensures the sidebar is correctly refreshed when the environment type is changed.