### PR TITLE
WebGPURenderer: Ensure bump map scale is texture UV scale invariant.

### DIFF
--- a/examples/jsm/nodes/display/BumpMapNode.js
+++ b/examples/jsm/nodes/display/BumpMapNode.js
@@ -48,8 +48,9 @@ const perturbNormalArb = tslFn( ( inputs ) => {
 
 	const { surf_pos, surf_norm, dHdxy } = inputs;
 
-	const vSigmaX = surf_pos.dFdx();
-	const vSigmaY = surf_pos.dFdy();
+	// normalize is done to ensure that the bump map looks the same regardless of the texture's scale
+	const vSigmaX = surf_pos.dFdx().normalize();
+	const vSigmaY = surf_pos.dFdy().normalize();
 	const vN = surf_norm; // normalized
 
 	const R1 = vSigmaY.cross( vN );


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/26899

**Description**

Synchronizes WebGPURenderer with revisions made to WebGLRenderer.