### PR TITLE
Fix FlyControls DragToLook sometimes stuck on dragging

### DIFF
--- a/examples/jsm/controls/FlyControls.js
+++ b/examples/jsm/controls/FlyControls.js
@@ -123,7 +123,7 @@ class FlyControls extends EventDispatcher {
 
 			if ( this.dragToLook ) {
 
-				this.status ++;
+				this.status = 1;
 
 			} else {
 
@@ -144,7 +144,7 @@ class FlyControls extends EventDispatcher {
 
 			if ( this.enabled === false ) return;
 
-			if ( ! this.dragToLook || this.status > 0 ) {
+			if ( ! this.dragToLook || this.status == 1 ) {
 
 				const container = this.getContainerDimensions();
 				const halfWidth = container.size[ 0 ] / 2;
@@ -165,7 +165,7 @@ class FlyControls extends EventDispatcher {
 
 			if ( this.dragToLook ) {
 
-				this.status --;
+				this.status = 0;
 
 				this.moveState.yawLeft = this.moveState.pitchDown = 0;
 


### PR DESCRIPTION
Related issue: None

When using FlyControls, after a couple of clicks and drags the Look Around gets stuck and keeps on rotating the camera even when the mouse button is released.

I suspected this to be the case because status gets incremented twice and never switches back to 0 again.

So i fixed it :) And it works reliable now.