### PR TITLE
Examples: Clean up.

### DIFF
--- a/examples/webgl_loader_gltf.html
+++ b/examples/webgl_loader_gltf.html
@@ -35,7 +35,6 @@
 			let camera, scene, renderer;
 
 			init();
-			render();
 
 			function init() {
 
@@ -63,12 +62,12 @@
 						const loader = new GLTFLoader().setPath( 'models/gltf/DamagedHelmet/glTF/' );
 						loader.load( 'DamagedHelmet.gltf', async function ( gltf ) {
 
-							await renderer.compileAsync( gltf.scene, camera );
-
 							scene.add( gltf.scene );
 
-							render();
+							await renderer.compileAsync( scene, camera );
 
+							render();
+			
 						} );
 
 					} );

--- a/examples/webgl_loader_gltf_transmission.html
+++ b/examples/webgl_loader_gltf_transmission.html
@@ -65,12 +65,10 @@
 						new GLTFLoader()
 							.setPath( 'models/gltf/' )
 							.setDRACOLoader( new DRACOLoader().setDecoderPath( 'jsm/libs/draco/gltf/' ) )
-							.load( 'IridescentDishWithOlives.glb', async function ( gltf ) {
+							.load( 'IridescentDishWithOlives.glb', function ( gltf ) {
 
 								mixer = new THREE.AnimationMixer( gltf.scene );
 								mixer.clipAction( gltf.animations[ 0 ] ).play();
-
-								await renderer.compileAsync( gltf.scene, camera );
 
 								scene.add( gltf.scene );
 


### PR DESCRIPTION
Related issue: #19752

**Description**

Using `compileAsync()` in just `webgl_loader_gltf` for now. Reorder the calls a bit.
