### PR TITLE
WebGLRenderer: Introduce `asyncShaderCompilation` flag.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -125,6 +125,10 @@ class WebGLRenderer {
 			onShaderError: null
 		};
 
+		// shader compilation
+
+		this.asyncShaderCompilation = false;
+
 		// clearing
 
 		this.autoClear = true;
@@ -784,6 +788,8 @@ class WebGLRenderer {
 			const frontFaceCW = ( object.isMesh && object.matrixWorld.determinant() < 0 );
 
 			const program = setProgram( camera, scene, geometry, material, object );
+
+			if ( program === null ) return;
 
 			state.setMaterial( material, frontFaceCW );
 
@@ -1899,6 +1905,14 @@ class WebGLRenderer {
 			if ( needsProgramChange === true ) {
 
 				program = getProgram( material, scene, object );
+
+			}
+
+			if ( _this.asyncShaderCompilation === true ) {
+
+				// check if the shader program can be already used for rendering.
+
+				if ( program.isReady() === false ) return null;
 
 			}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/19752#issuecomment-1762925622

**Description**

Thanks to @toji's preparation in #19745, this change was actually easy to implement. `WebGLRenderer` now has a new flag called `asyncShaderCompilation`. When set to `true`, the renderer automatically makes use of `KHR_parallel_shader_compile` for all shader programs. 

Using the new async mode potentially breaks apps if they rely on certain patterns like on-demand rendering though. Sync renderings like the code below do not work anymore (it just produces a black screen since the shader program isn't ready in the first frame):
```js
let camera, scene, renderer;

init();
render();

function init() {

	camera = new THREE.PerspectiveCamera( 70, window.innerWidth / window.innerHeight, 0.1, 100 );
	camera.position.z = 2;

	scene = new THREE.Scene();

	const geometry = new THREE.BoxGeometry();
	const material = new THREE.MeshBasicMaterial();

	const mesh = new THREE.Mesh( geometry, material );
	scene.add( mesh );

	renderer = new THREE.WebGLRenderer( { antialias: true } );
	renderer.setPixelRatio( window.devicePixelRatio );
	renderer.setSize( window.innerWidth, window.innerHeight );
	renderer.asyncShaderCompilation = true;
	document.body.appendChild( renderer.domElement );

}

function render() {

	renderer.render( scene, camera );

}
```
Unfortunately, a global async mode also breaks modules like `PMREMGenerator` which rely on a sync pattern as well.