### PR TITLE
WebGLRenderer: Add `targetScene` parameter to `compile()` methods.

### DIFF
--- a/examples/webgl_loader_gltf.html
+++ b/examples/webgl_loader_gltf.html
@@ -62,9 +62,13 @@
 						const loader = new GLTFLoader().setPath( 'models/gltf/DamagedHelmet/glTF/' );
 						loader.load( 'DamagedHelmet.gltf', async function ( gltf ) {
 
-							scene.add( gltf.scene );
+							const model = gltf.scene;
 
-							await renderer.compileAsync( scene, camera );
+							// wait until the model can be added to the scene without blocking due to shader compilation
+
+							await renderer.compileAsync( model, camera, scene );
+
+							scene.add( model );
 
 							render();
 			


### PR DESCRIPTION
Related issue: #19752

**Description**

This PR implements the feedback from https://github.com/mrdoob/three.js/pull/19752#issuecomment-1763060543 and introduces the `targetScene` parameter, which was part of the original version of #19752.

@toji I've managed to refactor the code such that  `compileAsync()` reuses the implementation from `compile()` which makes the code more manageable. Do you think your use case will work with this version of `compileAsync()`?

BTW: Existing usage of `compile()` should not be affected by this change. `targetScene` is optional.