### PR TITLE
WebGPU Fat Lines Example: Enable Damping

### DIFF
--- a/examples/webgpu_lines_fat.html
+++ b/examples/webgpu_lines_fat.html
@@ -79,6 +79,7 @@
 				camera2.position.copy( camera.position );
 
 				controls = new OrbitControls( camera, renderer.domElement );
+				controls.enableDamping = true;
 				controls.minDistance = 10;
 				controls.maxDistance = 500;
 
@@ -181,6 +182,8 @@
 				renderer.setClearColor( 0x000000, 0 );
 
 				renderer.setViewport( 0, 0, window.innerWidth, window.innerHeight );
+
+				controls.update();
 
 				renderer.autoClear = true;
 


### PR DESCRIPTION
.... why not, since there is an animation loop anyway.

The other option is to remove the animation loop from the example.