### PR TITLE
WebGPURenderer: add getInstanceIndex() for GLSLNodeBuilder

### DIFF
--- a/examples/jsm/renderers/webgl/nodes/GLSLNodeBuilder.js
+++ b/examples/jsm/renderers/webgl/nodes/GLSLNodeBuilder.js
@@ -309,7 +309,7 @@ ${ flowData.code }
 
 	getInstanceIndex() {
 
-		return 'gl_InstanceID';
+		return 'uint( gl_InstanceID )';
 
 	}
 

--- a/examples/jsm/renderers/webgl/nodes/GLSLNodeBuilder.js
+++ b/examples/jsm/renderers/webgl/nodes/GLSLNodeBuilder.js
@@ -307,6 +307,12 @@ ${ flowData.code }
 
 	}
 
+	getInstanceIndex() {
+
+		return 'gl_InstanceID';
+
+	}
+
 	getFrontFacing() {
 
 		return 'gl_FrontFacing';


### PR DESCRIPTION

This adds the basic translation of the variable name, but gl_InstanceID is an int not uint, so a mechanism to change the type is needed and I am not sure what the best way is to do that. @sunag 