### PR TITLE
WebGL Fat Lines Example: Enable Damping

### DIFF
--- a/examples/webgl_lines_fat.html
+++ b/examples/webgl_lines_fat.html
@@ -66,6 +66,7 @@
 				camera2.position.copy( camera.position );
 
 				controls = new OrbitControls( camera, renderer.domElement );
+				controls.enableDamping = true;
 				controls.minDistance = 10;
 				controls.maxDistance = 500;
 
@@ -175,6 +176,8 @@
 				renderer.setClearColor( 0x000000, 0 );
 
 				renderer.setViewport( 0, 0, window.innerWidth, window.innerHeight );
+
+				controls.update();
 
 				// renderer will set this eventually
 				matLine.resolution.set( window.innerWidth, window.innerHeight ); // resolution of the viewport


### PR DESCRIPTION
as was done in #26969

