### PR TITLE
SkinnedMesh: Introduce constants for `bindMode`.

### DIFF
--- a/docs/api/ar/objects/SkinnedMesh.html
+++ b/docs/api/ar/objects/SkinnedMesh.html
@@ -99,10 +99,10 @@
 		
 		<h3>[property:String bindMode]</h3>
 		<p>
-		إما "مرفق" أو "منفصل". "مرفق" يستخدم
-		خاصية [page:SkinnedMesh.matrixWorld] لمصفوفة التحويل الأساسية لـ
-		العظام. "منفصل" يستخدم [page:SkinnedMesh.bindMatrix]. الافتراضي هو
-		"مرفق".
+			Either `AttachedBindMode` or `DetachedBindMode`. `AttachedBindMode` means the skinned mesh
+			shares the same world space as the skeleton. This is not true when using `DetachedBindMode`
+			which is useful when sharing a skeleton across multiple skinned meshes.
+			Default is `AttachedBindMode`.
 		</p>
 		
 		<h3>[property:Matrix4 bindMatrix]</h3>

--- a/docs/api/en/objects/SkinnedMesh.html
+++ b/docs/api/en/objects/SkinnedMesh.html
@@ -99,10 +99,10 @@
 
 		<h3>[property:String bindMode]</h3>
 		<p>
-			Either "attached" or "detached". "attached" uses the
-			[page:SkinnedMesh.matrixWorld] property for the base transform matrix of
-			the bones. "detached" uses the [page:SkinnedMesh.bindMatrix]. Default is
-			"attached".
+			Either `AttachedBindMode` or `DetachedBindMode`. `AttachedBindMode` means the skinned mesh
+			shares the same world space as the skeleton. This is not true when using `DetachedBindMode`
+			which is useful when sharing a skeleton across multiple skinned meshes.
+			 Default is `AttachedBindMode`.
 		</p>
 
 		<h3>[property:Matrix4 bindMatrix]</h3>

--- a/docs/api/en/objects/SkinnedMesh.html
+++ b/docs/api/en/objects/SkinnedMesh.html
@@ -102,7 +102,7 @@
 			Either `AttachedBindMode` or `DetachedBindMode`. `AttachedBindMode` means the skinned mesh
 			shares the same world space as the skeleton. This is not true when using `DetachedBindMode`
 			which is useful when sharing a skeleton across multiple skinned meshes.
-			 Default is `AttachedBindMode`.
+			Default is `AttachedBindMode`.
 		</p>
 
 		<h3>[property:Matrix4 bindMatrix]</h3>

--- a/docs/api/it/objects/SkinnedMesh.html
+++ b/docs/api/it/objects/SkinnedMesh.html
@@ -101,10 +101,11 @@
 		<h2>Proprietà</h2>
 		<p>Vedi la classe base [page:Mesh] per le proprietà comuni.</p>
 
-		<h3>[property:String bindMode]</h3>
 		<p>
-			O "attached" o "detached". "attached" utilizza la proprietà [page:SkinnedMesh.matrixWorld]
-			per la matrice di trasformazione delle ossa. "detached" utilizza [page:SkinnedMesh.bindMatrix]. Il valore predefinito è "attached".
+			Either `AttachedBindMode` or `DetachedBindMode`. `AttachedBindMode` means the skinned mesh
+			shares the same world space as the skeleton. This is not true when using `DetachedBindMode`
+			which is useful when sharing a skeleton across multiple skinned meshes.
+			Default is `AttachedBindMode`.
 		</p>
 
 		<h3>[property:Matrix4 bindMatrix]</h3>

--- a/docs/api/zh/objects/SkinnedMesh.html
+++ b/docs/api/zh/objects/SkinnedMesh.html
@@ -100,9 +100,10 @@
 
 		<h3>[property:String bindMode]</h3>
 		<p>
-			“attached”（附加）或者“detached”（分离）。“attached”使用[page:SkinnedMesh.matrixWorld]
-			属性作为对骨骼的基本变换矩阵，“detached”则使用[page:SkinnedMesh.bindMatrix]。
-			默认值是“attached”。
+			Either `AttachedBindMode` or `DetachedBindMode`. `AttachedBindMode` means the skinned mesh
+			shares the same world space as the skeleton. This is not true when using `DetachedBindMode`
+			which is useful when sharing a skeleton across multiple skinned meshes.
+			Default is `AttachedBindMode`.
 		</p>
 
 		<h3>[property:Matrix4 bindMatrix]</h3>

--- a/src/constants.js
+++ b/src/constants.js
@@ -57,6 +57,8 @@ export const ReinhardToneMapping = 2;
 export const CineonToneMapping = 3;
 export const ACESFilmicToneMapping = 4;
 export const CustomToneMapping = 5;
+export const AttachedBindMode = 'attached';
+export const DetachedBindMode = 'detached';
 
 export const UVMapping = 300;
 export const CubeReflectionMapping = 301;

--- a/src/objects/SkinnedMesh.js
+++ b/src/objects/SkinnedMesh.js
@@ -5,6 +5,7 @@ import { Sphere } from '../math/Sphere.js';
 import { Vector3 } from '../math/Vector3.js';
 import { Vector4 } from '../math/Vector4.js';
 import { Ray } from '../math/Ray.js';
+import { AttachedBindMode, DetachedBindMode } from '../constants.js';
 
 const _basePosition = /*@__PURE__*/ new Vector3();
 
@@ -29,7 +30,7 @@ class SkinnedMesh extends Mesh {
 
 		this.type = 'SkinnedMesh';
 
-		this.bindMode = 'attached';
+		this.bindMode = AttachedBindMode;
 		this.bindMatrix = new Matrix4();
 		this.bindMatrixInverse = new Matrix4();
 
@@ -203,11 +204,11 @@ class SkinnedMesh extends Mesh {
 
 		super.updateMatrixWorld( force );
 
-		if ( this.bindMode === 'attached' ) {
+		if ( this.bindMode === AttachedBindMode ) {
 
 			this.bindMatrixInverse.copy( this.matrixWorld ).invert();
 
-		} else if ( this.bindMode === 'detached' ) {
+		} else if ( this.bindMode === DetachedBindMode ) {
 
 			this.bindMatrixInverse.copy( this.bindMatrix ).invert();
 

--- a/test/unit/src/constants.tests.js
+++ b/test/unit/src/constants.tests.js
@@ -72,6 +72,9 @@ export default QUnit.module( 'Constants', () => {
 		assert.equal( Constants.ACESFilmicToneMapping, 4, 'ACESFilmicToneMapping is equal to 4' );
 		assert.equal( Constants.CustomToneMapping, 5, 'CustomToneMapping is equal to 5' );
 
+		assert.equal( Constants.AttachedBindMode, 'attached', 'AttachedBindMode is equal to attached' );
+		assert.equal( Constants.DetachedBindMode, 'detached', 'DetachedBindMode is equal to detached' );
+
 		assert.equal( Constants.UVMapping, 300, 'UVMapping is equal to 300' );
 		assert.equal( Constants.CubeReflectionMapping, 301, 'CubeReflectionMapping is equal to 301' );
 		assert.equal( Constants.CubeRefractionMapping, 302, 'CubeRefractionMapping is equal to 302' );

--- a/test/unit/src/objects/SkinnedMesh.tests.js
+++ b/test/unit/src/objects/SkinnedMesh.tests.js
@@ -3,6 +3,7 @@
 import { Object3D } from '../../../../src/core/Object3D.js';
 import { Mesh } from '../../../../src/objects/Mesh.js';
 import { SkinnedMesh } from '../../../../src/objects/SkinnedMesh.js';
+import { AttachedBindMode } from '../../../../src/constants.js';
 
 export default QUnit.module( 'Objects', () => {
 
@@ -41,8 +42,8 @@ export default QUnit.module( 'Objects', () => {
 
 			const object = new SkinnedMesh();
 			assert.ok(
-				object.bindMode === 'attached',
-				'SkinnedMesh.bindMode should be attached'
+				object.bindMode === AttachedBindMode,
+				'SkinnedMesh.bindMode should be AttachedBindMode'
 			);
 
 		} );


### PR DESCRIPTION
Related issue:-

**Description**

Compared to other classes, `SkinnedMesh.bindMode` uses plain strings instead of constants which is inconsistent. The PR adds `THREE.AttachedBindMode` and `THREE.DetachedBindMode` and also clarifies the documentation what both bind modes actually do.

The PR does not break code since the values of the constants are equal to the existing strings.
