### PR TITLE
OutputShader: Use `#include` instead of `ShaderChunk`.

### DIFF
--- a/examples/jsm/shaders/OutputShader.js
+++ b/examples/jsm/shaders/OutputShader.js
@@ -35,7 +35,8 @@ const OutputShader = {
 
 		uniform sampler2D tDiffuse;
 
-		` + ShaderChunk[ 'tonemapping_pars_fragment' ] + ShaderChunk[ 'colorspace_pars_fragment' ] + `
+		#include <tonemapping_pars_fragment>
+		#include <colorspace_pars_fragment>
 
 		varying vec2 vUv;
 

--- a/examples/jsm/shaders/OutputShader.js
+++ b/examples/jsm/shaders/OutputShader.js
@@ -1,7 +1,3 @@
-import {
-	ShaderChunk
-} from 'three';
-
 const OutputShader = {
 
 	uniforms: {


### PR DESCRIPTION
Related issue: #XXXX

**Description**

Minor changes from #26912 which were previously needed for tree-shaking better align with surrounding shader chunk consumption.
