### PR TITLE
TAARenderPass: Fix runtime error in `dispose()`.

### DIFF
--- a/examples/jsm/postprocessing/TAARenderPass.js
+++ b/examples/jsm/postprocessing/TAARenderPass.js
@@ -147,7 +147,6 @@ class TAARenderPass extends SSAARenderPass {
 
 		super.dispose();
 
-		if ( this.sampleRenderTarget ) this.sampleRenderTarget.dispose();
 		if ( this.holdRenderTarget ) this.holdRenderTarget.dispose();
 
 	}

--- a/examples/jsm/postprocessing/TAARenderPass.js
+++ b/examples/jsm/postprocessing/TAARenderPass.js
@@ -147,8 +147,8 @@ class TAARenderPass extends SSAARenderPass {
 
 		super.dispose();
 
-		if ( this.sampleRenderTarget !== undefined ) this.sampleRenderTarget.dispose();
-		if ( this.holdRenderTarget !== undefined ) this.holdRenderTarget.dispose();
+		if ( this.sampleRenderTarget ) this.sampleRenderTarget.dispose();
+		if ( this.holdRenderTarget ) this.holdRenderTarget.dispose();
 
 	}
 


### PR DESCRIPTION
**Description**
TAARenderPass throws an error when trying to dispose.

sampleRenderTarget is being deleted and set to null by super.dispose();
the check for undefined was incorrect causing an attempt to call dispose on a null object.

