### PR TITLE
Addons: Don't expose LWO parsers.

### DIFF
--- a/examples/jsm/Addons.js
+++ b/examples/jsm/Addons.js
@@ -128,9 +128,6 @@ export * from './loaders/VOXLoader.js';
 export * from './loaders/VRMLLoader.js';
 export * from './loaders/VTKLoader.js';
 export * from './loaders/XYZLoader.js';
-export * from './loaders/lwo/IFFParser.js';
-export * from './loaders/lwo/LWO2Parser.js';
-export * from './loaders/lwo/LWO3Parser.js';
 
 export * from './materials/MeshGouraudMaterial.js';
 


### PR DESCRIPTION
Follow-up to #26910.

**Description**

I had previously exported `examples/jsm/loaders/lwo`, but this isn't user-facing code and dependencies of other loaders.

I'm keeping them as an implementation detail as I do `examples/jsm/libs`.