### PR TITLE
Material: document disabling depth test disables depth write caveat.

### DIFF
--- a/docs/api/en/materials/Material.html
+++ b/docs/api/en/materials/Material.html
@@ -161,7 +161,8 @@
 		<h3>[property:Boolean depthTest]</h3>
 		<p>
 			Whether to have depth test enabled when rendering this material. Default
-			is `true`.
+			is `true`. When the depth test is disabled, the depth write will also be
+			implicitly disabled.
 		</p>
 
 		<h3>[property:Boolean depthWrite]</h3>


### PR DESCRIPTION
When setting the `depthTest` flag of a material to false, this will also implicitly disable the depth write, because `glDisable(GL_DEPTH_TEST)` is called internally. 

See: https://www.khronos.org/opengl/wiki/Depth_Test
> When depth testing is disabled, writes to the depth buffer are also disabled. 

While the behavior makes sense I think (after all `depthFunc` can be used to achieve the desired behavior), it caught me off guard, so I thought it would make sense to document it.
