### PR TITLE
Shaders: Initialize `geometryClearcoatNormal` to suppress OpenGL warning.

### DIFF
--- a/src/renderers/shaders/ShaderChunk/lights_fragment_begin.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_fragment_begin.glsl.js
@@ -17,7 +17,7 @@ vec3 geometryPosition = - vViewPosition;
 vec3 geometryNormal = normal;
 vec3 geometryViewDir = ( isOrthographic ) ? vec3( 0, 0, 1 ) : normalize( vViewPosition );
 
-vec3 geometryClearcoatNormal;
+vec3 geometryClearcoatNormal = vec3( 0.0 );
 
 #ifdef USE_CLEARCOAT
 


### PR DESCRIPTION
Fix of 0(1578) : 'warning C7050: "geometryClearcoatNormal" might be used before being initialized' 

Fixed #26994

**Description**

This warning appears while running ThreeJS on top of WebGL implementation that uses system OpenGL directly. 
In particular in [Sciter Engine](https://sciter.com) on Windows with OpenGL 4.6 / NVIDIA drivers.

This warning manifests on any attempt to use "physical" materials like: 
```
const material = new THREE.MeshStandardMaterial( { color: 0xFFFFFF } );
```
Note, no such warning in non-physical materials like MeshNormalMaterial
