### PR TITLE
Docs: Improve `CapsuleGeometry` page.

### DIFF
--- a/docs/api/ar/geometries/CapsuleGeometry.html
+++ b/docs/api/ar/geometries/CapsuleGeometry.html
@@ -47,7 +47,7 @@
 		<h2>المنشئ (Constructor)</h2>
 
  		<h3>
- 		[name]([param:Float radius], [param:Float length], [param:Integer capSubdivisions], [param:Integer radialSegments])
+ 		[name]([param:Float radius], [param:Float length], [param:Integer capSegments], [param:Integer radialSegments])
  		</h3>
  		<p>
  		radius — نصف قطر الكبسولة. اختياري؛ الافتراضي هو 1.<br />

--- a/docs/api/en/geometries/CapsuleGeometry.html
+++ b/docs/api/en/geometries/CapsuleGeometry.html
@@ -48,7 +48,7 @@ const capsule = new THREE.Mesh( geometry, material ); scene.add( capsule );
 		<h2>Constructor</h2>
 
 		<h3>
-			[name]([param:Float radius], [param:Float length], [param:Integer capSubdivisions], [param:Integer radialSegments])
+			[name]([param:Float radius], [param:Float length], [param:Integer capSegments], [param:Integer radialSegments])
 		</h3>
 		<p>
 			radius — Radius of the capsule. Optional; defaults to `1`.<br />

--- a/docs/api/fr/geometries/CapsuleGeometry.html
+++ b/docs/api/fr/geometries/CapsuleGeometry.html
@@ -44,7 +44,7 @@
 
 		<h2>Constructeur</h2>
 
-		<h3>[name]([param:Float radius], [param:Float length], [param:Integer capSubdivisions], [param:Integer radialSegments])</h3>
+		<h3>[name]([param:Float radius], [param:Float length], [param:Integer capSegments], [param:Integer radialSegments])</h3>
 		<p>
 
 		radius — Rayon de la capsule. Optionnel; par défaut à 1.<br />

--- a/docs/api/it/geometries/CapsuleGeometry.html
+++ b/docs/api/it/geometries/CapsuleGeometry.html
@@ -44,7 +44,7 @@
 
 		<h2>Costruttore</h2>
 
-		<h3>[name]([param:Float radius], [param:Float length], [param:Integer capSubdivisions], [param:Integer radialSegments])</h3>
+		<h3>[name]([param:Float radius], [param:Float length], [param:Integer capSegments], [param:Integer radialSegments])</h3>
 		<p>
 
 		radius — Raggio della capsula. Opzionale; il valore predefinito è 1.<br />

--- a/docs/api/ko/geometries/CapsuleGeometry.html
+++ b/docs/api/ko/geometries/CapsuleGeometry.html
@@ -45,7 +45,7 @@
 
 		<h2>생성자</h2>
 
-		<h3>[name]([param:Float radius], [param:Float length], [param:Integer capSubdivisions], [param:Integer radialSegments])</h3>
+		<h3>[name]([param:Float radius], [param:Float length], [param:Integer capSegments], [param:Integer radialSegments])</h3>
 		<p>
 
 		radius — 캡슐의 반경입니다. Optional; 기본값은 1 입니다.<br />

--- a/docs/api/zh/geometries/CapsuleGeometry.html
+++ b/docs/api/zh/geometries/CapsuleGeometry.html
@@ -47,7 +47,7 @@ const capsule = new THREE.Mesh( geometry, material ); scene.add( capsule );
 		<h2>构造函数</h2>
 
 		<h3>
-			[name]([param:Float radius], [param:Float length], [param:Integer capSubdivisions], [param:Integer radialSegments])
+			[name]([param:Float radius], [param:Float length], [param:Integer capSegments], [param:Integer radialSegments])
 		</h3>
 		<p>
 			radius — 胶囊半径。可选的; 默认值为1。<br />


### PR DESCRIPTION
Fixed #27004.

**Description**

Renamed `capSubdivisions` to `capSegments`.
