### PR TITLE
Docs: Improve `Lensflare` page.

### DIFF
--- a/docs/examples/en/objects/Lensflare.html
+++ b/docs/examples/en/objects/Lensflare.html
@@ -23,7 +23,7 @@
 		</p>
 
 		<code>
-			import { Lensflare } from 'three/addons/objects/Lensflare.js';
+			import { Lensflare, LensflareElement } from 'three/addons/objects/Lensflare.js';
 		</code>
 
 		<h2>Code Example</h2>


### PR DESCRIPTION
Added import syntax for [LensFlareElement](https://threejs.org/docs/#examples/en/objects/Lensflare). So that users can know where this element is coming from.