### PR TITLE
Point-light shadows example github link is broken

### DIFF
--- a/examples/webgl_shadowmap_pointlight.html
+++ b/examples/webgl_shadowmap_pointlight.html
@@ -8,7 +8,7 @@
 	</head>
 	<body>
 		<div id="info">
-			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - THREE.PointLight ShadowMap by <a href="https://github.com/mkkellogg">mkkellogg</a>
+			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - THREE.PointLight ShadowMap by <a href="https://github.com/mkkellogg" target="_blank" rel="noopener">mkkellogg</a>
 		</div>
 
 		<script type="importmap">


### PR DESCRIPTION
A very non-urgent fix :)

Currently the point-light shadow example page (https://threejs.org/examples/?q=shadow#webgl_shadowmap_pointlight) has a github link that when followed gives the following error in the console:

```
Refused to frame 'https://github.com/' because an ancestor violates the following Content Security Policy directive: "frame-ancestors 'none'".
```

Adding the `target="_blank"` and `rel="noopener"` attributes to the link fixes it.