### PR TITLE
CSS3DRenderer: Modify perspective transform to avoid issues in Chrome and Firefox

### DIFF
--- a/examples/jsm/renderers/CSS3DRenderer.js
+++ b/examples/jsm/renderers/CSS3DRenderer.js
@@ -95,7 +95,7 @@ class CSS3DRenderer {
 		let _widthHalf, _heightHalf;
 
 		const cache = {
-			camera: { fov: 0, style: '' },
+			camera: { style: '' },
 			objects: new WeakMap()
 		};
 
@@ -129,13 +129,6 @@ class CSS3DRenderer {
 
 			const fov = camera.projectionMatrix.elements[ 5 ] * _heightHalf;
 
-			if ( cache.camera.fov !== fov ) {
-
-				viewElement.style.perspective = camera.isPerspectiveCamera ? fov + 'px' : '';
-				cache.camera.fov = fov;
-
-			}
-
 			if ( camera.view && camera.view.enabled ) {
 
 				// view offset
@@ -166,8 +159,9 @@ class CSS3DRenderer {
 			const cameraCSSMatrix = camera.isOrthographicCamera ?
 				`scale( ${ scaleByViewOffset } )` + 'scale(' + fov + ')' + 'translate(' + epsilon( tx ) + 'px,' + epsilon( ty ) + 'px)' + getCameraCSSMatrix( camera.matrixWorldInverse ) :
 				`scale( ${ scaleByViewOffset } )` + 'translateZ(' + fov + 'px)' + getCameraCSSMatrix( camera.matrixWorldInverse );
+			const perspective = camera.isPerspectiveCamera ? 'perspective(' + fov + 'px) ' : '';
 
-			const style = cameraCSSMatrix +
+			const style = perspective + cameraCSSMatrix +
 				'translate(' + _widthHalf + 'px,' + _heightHalf + 'px)';
 
 			if ( cache.camera.style !== style ) {


### PR DESCRIPTION
Related:

- https://github.com/mrdoob/three.js/issues/26950
- https://github.com/mrdoob/three.js/issues/26583

**Description**

As described in https://github.com/mrdoob/three.js/issues/26950, Chrome, Safari, and Firefox all have slightly different issues rendering HTML elements positioned with CSS 3D transforms. I've reported bugs to Chrome and Safari, but some similar issues have been open for a while. My approach with this fix was to try slightly different CSS syntax that seemed like it *should* do the same thing, and see if any alternatives would side-step the browser issues.

This solution avoids the issues in Chrome and Firefox, leaving only the original issue in Safari. When the container has even-numbered pixel width and height, Safari renders correctly as well.

References on `perspective: XXpx` vs. `transform: perspective(XXpx)`:

- https://jsfiddle.net/donmccurdy/2fq87d0c/
- https://css-tricks.com/almanac/properties/p/perspective/

*This contribution is funded by [The New York Times](https://rd.nytimes.com/)*.