### PR TITLE
WebGPURenderer: Remove HTMLImage to OffscreenCanvas conversion

### DIFF
--- a/examples/jsm/renderers/common/Textures.js
+++ b/examples/jsm/renderers/common/Textures.js
@@ -191,7 +191,7 @@ class Textures extends DataMap {
 
 						for ( const image of texture.images ) {
 
-							images.push( this._getUploadImage( image ) );
+							images.push( image );
 
 						}
 
@@ -199,7 +199,7 @@ class Textures extends DataMap {
 
 					} else {
 
-						options.image = this._getUploadImage( image );
+						options.image = image;
 
 					}
 
@@ -314,38 +314,6 @@ class Textures extends DataMap {
 		const mapping = texture.mapping;
 
 		return ( mapping === EquirectangularReflectionMapping || mapping === EquirectangularRefractionMapping ) || ( mapping === CubeReflectionMapping || mapping === CubeRefractionMapping );
-
-	}
-
-	_getUploadImage( image ) {
-
-		if ( this._isHTMLImage( image ) ) {
-
-			return this._imageToCanvas( image );
-
-		}
-
-		return image;
-
-	}
-
-	_imageToCanvas( image ) {
-
-		const { width, height } = image;
-
-		// eslint-disable-next-line compat/compat
-		const canvas = new OffscreenCanvas( width, height );
-
-		const context = canvas.getContext( '2d' );
-		context.drawImage( image, 0, 0, width, height );
-
-		return canvas;
-
-	}
-
-	_isHTMLImage( image ) {
-
-		return ( typeof HTMLImageElement !== 'undefined' && image instanceof HTMLImageElement ) || ( typeof HTMLCanvasElement !== 'undefined' && image instanceof HTMLCanvasElement );
 
 	}
 

--- a/examples/jsm/renderers/webgl/WebGLBackend.js
+++ b/examples/jsm/renderers/webgl/WebGLBackend.js
@@ -496,7 +496,7 @@ class WebGLBackend extends Backend {
 
 				return source.image.data;
 
-			} else if ( source instanceof ImageBitmap || source instanceof OffscreenCanvas ) {
+			} else if ( source instanceof ImageBitmap || source instanceof OffscreenCanvas || source instanceof HTMLImageElement || source instanceof HTMLCanvasElement ) {
 
 				return source;
 


### PR DESCRIPTION
The WebGPU standard and Chrome 118 now accept HTMLImage and HTMLCanvas objects as image sources in GPUImageCopyExternalImage(). Remove the conversions and also correctly handle these image types in the WebGLBackend