### PR TITLE
TextureNode: `.forceUVContext`

### DIFF
--- a/examples/jsm/nodes/accessors/TextureNode.js
+++ b/examples/jsm/nodes/accessors/TextureNode.js
@@ -84,7 +84,7 @@ class TextureNode extends UniformNode {
 
 		let uvNode = this.uvNode;
 
-		if ( uvNode === null && builder.context.getUVNode ) {
+		if ( ( uvNode === null || builder.context.forceUVContext === true ) && builder.context.getUVNode ) {
 
 			uvNode = builder.context.getUVNode( this );
 

--- a/examples/jsm/nodes/display/BumpMapNode.js
+++ b/examples/jsm/nodes/display/BumpMapNode.js
@@ -35,7 +35,7 @@ const dHdxy_fwd = tslFn( ( { textureNode, bumpScale } ) => {
 	const uvNode = texNode.uvNode || uv();
 
 	// It's used to preserve the same TextureNode instance
-	const sampleTexture = ( uv ) => textureNode.cache().context( { getUVNode: () => uv } );
+	const sampleTexture = ( uv ) => textureNode.cache().context( { getUVNode: () => uv, forceUVContext: true } );
 
 	return vec2(
 		float( sampleTexture( uvNode.add( uvNode.dFdx() ) ) ).sub( Hll ),


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/26848#issuecomment-1774193885

**Description**

Force replacement of `UVNode` if the context includes `forceUVContext=true`.
