### PR TITLE
Editor: Remove `Fix Color Maps` script.

### DIFF
--- a/editor/js/Menubar.Edit.js
+++ b/editor/js/Menubar.Edit.js
@@ -153,67 +153,6 @@ function MenubarEdit( editor ) {
 
 	options.add( new UIHorizontalRule() );
 
-	// Set textures to sRGB. See #15903
-
-	option = new UIRow();
-	option.setClass( 'option' );
-	option.setTextContent( strings.getKey( 'menubar/edit/fixcolormaps' ) );
-	option.onClick( function () {
-
-		editor.scene.traverse( fixColorMap );
-
-	} );
-	options.add( option );
-
-	const colorMaps = [ 'map', 'envMap', 'emissiveMap' ];
-
-	function fixColorMap( obj ) {
-
-		const material = obj.material;
-
-		if ( material !== undefined ) {
-
-			if ( Array.isArray( material ) === true ) {
-
-				for ( let i = 0; i < material.length; i ++ ) {
-
-					fixMaterial( material[ i ] );
-
-				}
-
-			} else {
-
-				fixMaterial( material );
-
-			}
-
-			editor.signals.sceneGraphChanged.dispatch();
-
-		}
-
-	}
-
-	function fixMaterial( material ) {
-
-		let needsUpdate = material.needsUpdate;
-
-		for ( let i = 0; i < colorMaps.length; i ++ ) {
-
-			const map = material[ colorMaps[ i ] ];
-
-			if ( map ) {
-
-				map.colorSpace = THREE.SRGBColorSpace;
-				needsUpdate = true;
-
-			}
-
-		}
-
-		material.needsUpdate = needsUpdate;
-
-	}
-
 	return container;
 
 }

--- a/editor/js/Menubar.Edit.js
+++ b/editor/js/Menubar.Edit.js
@@ -149,10 +149,6 @@ function MenubarEdit( editor ) {
 	} );
 	options.add( option );
 
-	//
-
-	options.add( new UIHorizontalRule() );
-
 	return container;
 
 }

--- a/editor/js/Strings.js
+++ b/editor/js/Strings.js
@@ -30,7 +30,6 @@ function Strings( config ) {
 			'menubar/edit/center': 'Center',
 			'menubar/edit/clone': 'Clone',
 			'menubar/edit/delete': 'Delete (Del)',
-			'menubar/edit/fixcolormaps': 'Fix Color Maps',
 
 			'menubar/add': 'Add',
 			'menubar/add/group': 'Group',
@@ -382,7 +381,6 @@ function Strings( config ) {
 			'menubar/edit/center': 'Center',
 			'menubar/edit/clone': 'Cloner',
 			'menubar/edit/delete': 'Supprimer (Supp)',
-			'menubar/edit/fixcolormaps': 'Correction des couleurs',
 
 			'menubar/add': 'Ajouter',
 			'menubar/add/group': 'Groupe',
@@ -732,7 +730,6 @@ function Strings( config ) {
 			'menubar/edit/center': '居中',
 			'menubar/edit/clone': '拷贝',
 			'menubar/edit/delete': '删除 (Del)',
-			'menubar/edit/fixcolormaps': '修复颜色贴图',
 
 			'menubar/add': '添加',
 			'menubar/add/group': '组',


### PR DESCRIPTION
Related issue: #15903, #16148

**Description**

The `Fix Color Maps` menu item in the editor triggers a script that set the `colorSpace` property of all color textures in the scene to `SRGBColorSpace`. The script was intended to ensure "old" scenes use a more correct color space configuration.

Now that all loaders properly set color spaces and the editors UI also set the `colorSpace` property when a map is added, I think it's safe to remove the script from the editor. If someone relies on it, devs can use https://rawcdn.githack.com/mrdoob/three.js/r157/editor/index.html.