### PR TITLE
Editor: Assign `SRGBColorSpace` only to color maps.

### DIFF
--- a/editor/js/Sidebar.Material.MapProperty.js
+++ b/editor/js/Sidebar.Material.MapProperty.js
@@ -22,6 +22,8 @@ function SidebarMaterialMapProperty( editor, property, name ) {
 
 	const mapType = property.replace( 'Map', '' );
 
+	const colorMaps = [ 'map', 'emissiveMap', 'sheenColorMap', 'specularColorMap', 'envMap' ];
+
 	let intensity;
 
 	if ( property === 'aoMap' ) {
@@ -111,7 +113,7 @@ function SidebarMaterialMapProperty( editor, property, name ) {
 
 		if ( texture !== null ) {
 
-			if ( texture.isDataTexture !== true && texture.colorSpace !== THREE.SRGBColorSpace ) {
+			if ( colorMaps[ property ] !== undefined && texture.isDataTexture !== true && texture.colorSpace !== THREE.SRGBColorSpace ) {
 
 				texture.colorSpace = THREE.SRGBColorSpace;
 				material.needsUpdate = true;


### PR DESCRIPTION
Related issue: #16148

**Description**

Since #16148 the editor assigns `SRGBColorSpace` to _all_ textures configured via the UI. This isn't right since only color maps should have `SRGBColorSpace` assigned to their `colorSpace` property.
