### PR TITLE
BatchedMesh: Change visibility to use a zero-scale matrix

### DIFF
--- a/examples/jsm/objects/BatchedMesh.js
+++ b/examples/jsm/objects/BatchedMesh.js
@@ -10,11 +10,11 @@ import {
 } from 'three';
 
 const _identityMatrix = new Matrix4();
-const _zeroMatrix = new Matrix4().set(
+const _zeroScaleMatrix = new Matrix4().set(
 	0, 0, 0, 0,
 	0, 0, 0, 0,
 	0, 0, 0, 0,
-	0, 0, 0, 0
+	0, 0, 0, 1,
 );
 
 // Custom shaders
@@ -323,7 +323,7 @@ class BatchedMesh extends Mesh {
 		}
 
 		this._alives[ geometryId ] = false;
-		_zeroMatrix.toArray( this._matricesArray, geometryId * 16 );
+		_zeroScaleMatrix.toArray( this._matricesArray, geometryId * 16 );
 		this._matricesTexture.needsUpdate = true;
 
 		// User needs to call optimize() to pack the data.
@@ -396,7 +396,7 @@ class BatchedMesh extends Mesh {
 
 		} else {
 
-			_zeroMatrix.toArray( this._matricesArray, geometryId * 16 );
+			_zeroScaleMatrix.toArray( this._matricesArray, geometryId * 16 );
 
 		}
 


### PR DESCRIPTION
Related issue: #25059, #22376

**Description**

BatchedMesh was using a matrix full of zeros to "hide" a geometry - but when multiplying a homogenous vector 4 position by this matrix you get a 0 in the w component which isn't correct for a position coordinate. This PR changes the hidden-visibility matrix to use a 1 in the final field to ensure the w remains untouched.

cc @takahirox 