### PR TITLE
Capsule: Move and rename lineToLineClosestPoints function to Octree util

### DIFF
--- a/examples/jsm/math/Capsule.js
+++ b/examples/jsm/math/Capsule.js
@@ -2,12 +2,6 @@ import {
 	Vector3
 } from 'three';
 
-const _v1 = new Vector3();
-const _v2 = new Vector3();
-const _v3 = new Vector3();
-
-const EPS = 1e-10;
-
 class Capsule {
 
 	constructor( start = new Vector3( 0, 0, 0 ), end = new Vector3( 0, 1, 0 ), radius = 1 ) {
@@ -80,55 +74,6 @@ class Capsule {
 				box.min.y, box.max.y, box.min.z, box.max.z,
 				this.radius )
 		);
-
-	}
-
-	lineLineMinimumPoints( line1, line2 ) {
-
-		const r = _v1.copy( line1.end ).sub( line1.start );
-		const s = _v2.copy( line2.end ).sub( line2.start );
-		const w = _v3.copy( line2.start ).sub( line1.start );
-
-		const a = r.dot( s ),
-			b = r.dot( r ),
-			c = s.dot( s ),
-			d = s.dot( w ),
-			e = r.dot( w );
-
-		let t1, t2;
-		const divisor = b * c - a * a;
-
-		if ( Math.abs( divisor ) < EPS ) {
-
-			const d1 = - d / c;
-			const d2 = ( a - d ) / c;
-
-			if ( Math.abs( d1 - 0.5 ) < Math.abs( d2 - 0.5 ) ) {
-
-				t1 = 0;
-				t2 = d1;
-
-			} else {
-
-				t1 = 1;
-				t2 = d2;
-
-			}
-
-		} else {
-
-			t1 = ( d * a + e * c ) / divisor;
-			t2 = ( t1 * a - d ) / c;
-
-		}
-
-		t2 = Math.max( 0, Math.min( 1, t2 ) );
-		t1 = Math.max( 0, Math.min( 1, t1 ) );
-
-		const point1 = r.multiplyScalar( t1 ).add( line1.start );
-		const point2 = s.multiplyScalar( t2 ).add( line2.start );
-
-		return [ point1, point2 ];
 
 	}
 


### PR DESCRIPTION
Fix #26923 

**Description**

Found some time to move the function. Moves the function from capsule class (where it confusingly didn't refer to the current capsule) to octree class file as util.