### PR TITLE
BatchedMesh Example: fix floating point error in rotation

### DIFF
--- a/examples/webgl_mesh_batch.html
+++ b/examples/webgl_mesh_batch.html
@@ -41,7 +41,6 @@
 		let camera, controls, scene, renderer;
 		let geometries, mesh;
 		const ids = [];
-		const rotationMatrix = new THREE.Matrix4();
 		const matrix = new THREE.Matrix4();
 
 		//
@@ -173,6 +172,7 @@
 			const vertexCount = api.count * 512;
 			const indexCount = api.count * 1024;
 
+			const euler = new THREE.Euler();
 			const matrix = new THREE.Matrix4();
 			mesh = new BatchedMesh( geometryCount, vertexCount, indexCount, createMaterial() );
 			mesh.userData.rotationSpeeds = [];
@@ -182,7 +182,11 @@
 
 				const id = mesh.applyGeometry( geometries[ i % geometries.length ] );
 				mesh.setMatrixAt( id, randomizeMatrix( matrix ) );
-				mesh.userData.rotationSpeeds.push( randomizeRotationSpeed( new THREE.Euler() ) );
+
+				const rotationMatrix = new THREE.Matrix4();
+				rotationMatrix.makeRotationFromEuler( randomizeRotationSpeed( euler ) );
+				mesh.userData.rotationSpeeds.push( rotationMatrix );
+
 				ids.push( id );
 
 			}
@@ -275,11 +279,10 @@
 
 				for ( let i = 0; i < loopNum; i ++ ) {
 
-					const rotationSpeed = mesh.userData.rotationSpeeds[ i ];
+					const rotationMatrix = mesh.userData.rotationSpeeds[ i ];
 					const id = ids[ i ];
 
 					mesh.getMatrixAt( id, matrix );
-					rotationMatrix.makeRotationFromEuler( rotationSpeed );
 					matrix.multiply( rotationMatrix );
 					mesh.setMatrixAt( id, matrix );
 

--- a/examples/webgl_mesh_batch.html
+++ b/examples/webgl_mesh_batch.html
@@ -41,7 +41,8 @@
 		let camera, controls, scene, renderer;
 		let geometries, mesh;
 		const ids = [];
-		const dummy = new THREE.Object3D();
+		const rotationMatrix = new THREE.Matrix4();
+		const matrix = new THREE.Matrix4();
 
 		//
 
@@ -277,15 +278,10 @@
 					const rotationSpeed = mesh.userData.rotationSpeeds[ i ];
 					const id = ids[ i ];
 
-					mesh.getMatrixAt( id, dummy.matrix );
-					dummy.matrix.decompose( dummy.position, dummy.quaternion, dummy.scale );
-					dummy.rotation.set(
-						dummy.rotation.x + rotationSpeed.x,
-						dummy.rotation.y + rotationSpeed.y,
-						dummy.rotation.z + rotationSpeed.z
-					);
-					dummy.updateMatrix();
-					mesh.setMatrixAt( id, dummy.matrix );
+					mesh.getMatrixAt( id, matrix );
+					rotationMatrix.makeRotationFromEuler( rotationSpeed );
+					matrix.multiply( rotationMatrix );
+					mesh.setMatrixAt( id, matrix );
 
 				}
 


### PR DESCRIPTION
Related issue: #25059 

**Description**

It seems that the previous approach of decomposing the rotation from a matrix was resulting in lost rotation information due to floating point error or something - either way all the geometry was starting to rotate in the same direction. This PR avoids decomposition to address this.

**Before**

_Cubes used everywhere to make the issue more clear_

https://github.com/mrdoob/three.js/assets/734200/d82c3df4-f8de-42bb-bdd0-6cd27fcb478a

**After**

_Notice the shapes rotating in different directions_

https://github.com/mrdoob/three.js/assets/734200/fa30ece0-d474-4b12-b0f8-108401ae1652

cc @takahirox 