### PR TITLE
BatchedMesh: Add comments, use local variables in functions

### DIFF
--- a/examples/jsm/objects/BatchedMesh.js
+++ b/examples/jsm/objects/BatchedMesh.js
@@ -165,9 +165,6 @@ class BatchedMesh extends Mesh {
 
 			}
 
-			// for debug
-			// console.log( parameters.vertexShader, parameters.uniforms );
-
 			currentOnBeforeCompile.call( this, parameters, renderer );
 
 		};
@@ -316,17 +313,20 @@ class BatchedMesh extends Mesh {
 
 	deleteGeometry( geometryId ) {
 
-		if ( geometryId >= this._alives.length || this._alives[ geometryId ] === false ) {
+		// Note: User needs to call optimize() afterward to pack the data.
+
+		const alives = this._alives;
+		const matricesArray = this._matricesArray;
+		const matricesTexture = this._matricesTexture;
+		if ( geometryId >= alives.length || alives[ geometryId ] === false ) {
 
 			return this;
 
 		}
 
-		this._alives[ geometryId ] = false;
-		_zeroScaleMatrix.toArray( this._matricesArray, geometryId * 16 );
-		this._matricesTexture.needsUpdate = true;
-
-		// User needs to call optimize() to pack the data.
+		alives[ geometryId ] = false;
+		_zeroScaleMatrix.toArray( matricesArray, geometryId * 16 );
+		matricesTexture.needsUpdate = true;
 
 		return this;
 

--- a/examples/jsm/objects/BatchedMesh.js
+++ b/examples/jsm/objects/BatchedMesh.js
@@ -275,19 +275,12 @@ class BatchedMesh extends Mesh {
 		// Assuming geometry has position attribute
 		const srcPositionAttribute = geometry.getAttribute( 'position' );
 
+		// push new geometry data range
 		vertexStarts.push( vertexCount );
 		vertexCounts.push( srcPositionAttribute.count );
 
-		if ( hasIndex ) {
-
-			indexStarts.push( indexCount );
-			indexCounts.push( srcIndex.count );
-
-		}
-
-		visibles.push( true );
-		alives.push( true );
-
+		// copy attribute data over
+		// @TODO: Handle case where geometry does not have common attributes
 		for ( const attributeName in geometry.attributes ) {
 
 			const srcAttribute = geometry.getAttribute( attributeName );
@@ -300,6 +293,11 @@ class BatchedMesh extends Mesh {
 
 		if ( hasIndex ) {
 
+			// push new index range
+			indexStarts.push( indexCount );
+			indexCounts.push( srcIndex.count );
+
+			// copy index data over
 			for ( let i = 0; i < srcIndex.count; i ++ ) {
 
 				dstIndex.setX( indexCount + i, vertexCount + srcIndex.getX( i ) );
@@ -311,11 +309,11 @@ class BatchedMesh extends Mesh {
 
 		}
 
+		// fill in the geometry ids
 		const geometryId = this._geometryCount;
 		this._geometryCount ++;
 
 		const idAttribute = batchGeometry.getAttribute( 'id' );
-
 		for ( let i = 0; i < srcPositionAttribute.count; i ++ ) {
 
 			idAttribute.setX( this._vertexCount + i, geometryId );
@@ -324,8 +322,14 @@ class BatchedMesh extends Mesh {
 
 		idAttribute.needsUpdate = true;
 
+		// extend new range
 		this._vertexCount += srcPositionAttribute.count;
 
+		// push new visibility states
+		visibles.push( true );
+		alives.push( true );
+
+		// initialize matrix information
 		matrices.push( new Matrix4() );
 		_identityMatrix.toArray( matricesArray, geometryId * 16 );
 		matricesTexture.needsUpdate = true;

--- a/examples/jsm/objects/BatchedMesh.js
+++ b/examples/jsm/objects/BatchedMesh.js
@@ -243,34 +243,48 @@ class BatchedMesh extends Mesh {
 
 		}
 
-		const hasIndex = this.geometry.getIndex() !== null;
-		const dstIndex = this.geometry.getIndex();
+		const batchGeometry = this.geometry;
+		const visibles = this._visibles;
+		const alives = this._alives;
+		const matricesTexture = this._matricesTexture;
+		const matrices = this._matrices;
+		const matricesArray = this._matricesArray;
+		const vertexCount = this._vertexCount;
+		const indexCount = this._indexCount;
+
+		const indexCounts = this._indexCounts;
+		const indexStarts = this._indexStarts;
+		const vertexCounts = this._vertexCounts;
+		const vertexStarts = this._vertexStarts;
+
+		const hasIndex = batchGeometry.getIndex() !== null;
+		const dstIndex = batchGeometry.getIndex();
 		const srcIndex = geometry.getIndex();
 
 		// Assuming geometry has position attribute
 		const srcPositionAttribute = geometry.getAttribute( 'position' );
 
-		this._vertexStarts.push( this._vertexCount );
-		this._vertexCounts.push( srcPositionAttribute.count );
+		vertexStarts.push( vertexCount );
+		vertexCounts.push( srcPositionAttribute.count );
 
 		if ( hasIndex ) {
 
-			this._indexStarts.push( this._indexCount );
-			this._indexCounts.push( srcIndex.count );
+			indexStarts.push( indexCount );
+			indexCounts.push( srcIndex.count );
 
 		}
 
-		this._visibles.push( true );
-		this._alives.push( true );
+		visibles.push( true );
+		alives.push( true );
 
 		// @TODO: Error handling if exceeding maxVertexCount or maxIndexCount
 
 		for ( const attributeName in geometry.attributes ) {
 
 			const srcAttribute = geometry.getAttribute( attributeName );
-			const dstAttribute = this.geometry.getAttribute( attributeName );
+			const dstAttribute = batchGeometry.getAttribute( attributeName );
 
-			dstAttribute.array.set( srcAttribute.array, this._vertexCount * dstAttribute.itemSize );
+			dstAttribute.array.set( srcAttribute.array, vertexCount * dstAttribute.itemSize );
 			dstAttribute.needsUpdate = true;
 
 		}
@@ -279,7 +293,7 @@ class BatchedMesh extends Mesh {
 
 			for ( let i = 0; i < srcIndex.count; i ++ ) {
 
-				dstIndex.setX( this._indexCount + i, this._vertexCount + srcIndex.getX( i ) );
+				dstIndex.setX( indexCount + i, vertexCount + srcIndex.getX( i ) );
 
 			}
 
@@ -291,7 +305,7 @@ class BatchedMesh extends Mesh {
 		const geometryId = this._geometryCount;
 		this._geometryCount ++;
 
-		const idAttribute = this.geometry.getAttribute( 'id' );
+		const idAttribute = batchGeometry.getAttribute( 'id' );
 
 		for ( let i = 0; i < srcPositionAttribute.count; i ++ ) {
 
@@ -303,9 +317,9 @@ class BatchedMesh extends Mesh {
 
 		this._vertexCount += srcPositionAttribute.count;
 
-		this._matrices.push( new Matrix4() );
-		_identityMatrix.toArray( this._matricesArray, geometryId * 16 );
-		this._matricesTexture.needsUpdate = true;
+		matrices.push( new Matrix4() );
+		_identityMatrix.toArray( matricesArray, geometryId * 16 );
+		matricesTexture.needsUpdate = true;
 
 		return geometryId;
 

--- a/examples/jsm/objects/BatchedMesh.js
+++ b/examples/jsm/objects/BatchedMesh.js
@@ -174,6 +174,57 @@ class BatchedMesh extends Mesh {
 
 	}
 
+	_initializeGeometry( reference ) {
+
+		// @TODO: geometry.groups support?
+		// @TODO: geometry.drawRange support?
+		// @TODO: geometry.morphAttributes support?
+
+		const geometry = this.geometry;
+		const maxVertexCount = this._maxVertexCount;
+		const maxGeometryCount = this._maxGeometryCount;
+		const maxIndexCount = this._maxIndexCount;
+		if ( this._geometryInitialized === false ) {
+
+			for ( const attributeName in reference.attributes ) {
+
+				const srcAttribute = reference.getAttribute( attributeName );
+				const { array, itemSize, normalized } = srcAttribute;
+
+				const dstArray = new array.constructor( maxVertexCount * itemSize );
+				const dstAttribute = new srcAttribute.constructor( dstArray, itemSize, normalized );
+				dstAttribute.setUsage( srcAttribute.usage );
+
+				geometry.setAttribute( attributeName, dstAttribute );
+
+			}
+
+			if ( reference.getIndex() !== null ) {
+
+				const indexArray = maxVertexCount > 65536
+					? new Uint32Array( maxIndexCount )
+					: new Uint16Array( maxIndexCount );
+
+				geometry.setIndex( new BufferAttribute( indexArray, 1 ) );
+
+			}
+
+			const idArray = maxGeometryCount > 65536
+				? new Uint32Array( maxVertexCount )
+				: new Uint16Array( maxVertexCount );
+			// @TODO: What if attribute name 'id' is already used?
+			geometry.setAttribute( 'id', new BufferAttribute( idArray, 1 ) );
+
+			this._geometryInitialized = true;
+
+		} else {
+
+			// @TODO: Check if geometry has the same attributes set
+
+		}
+
+	}
+
 	getGeometryCount() {
 
 		return this._geometryCount;
@@ -194,52 +245,12 @@ class BatchedMesh extends Mesh {
 
 	applyGeometry( geometry ) {
 
-		// @TODO: geometry.groups support?
-		// @TODO: geometry.drawRange support?
-		// @TODO: geometry.morphAttributes support?
+		this._initializeGeometry( geometry );
 
+		// @TODO: Error handling if exceeding maxVertexCount or maxIndexCount
 		if ( this._geometryCount >= this._maxGeometryCount ) {
 
 			// @TODO: Error handling
-
-		}
-
-		if ( this._geometryInitialized === false ) {
-
-			for ( const attributeName in geometry.attributes ) {
-
-				const srcAttribute = geometry.getAttribute( attributeName );
-				const { array, itemSize, normalized } = srcAttribute;
-
-				const dstArray = new array.constructor( this._maxVertexCount * itemSize );
-				const dstAttribute = new srcAttribute.constructor( dstArray, itemSize, normalized );
-				dstAttribute.setUsage( srcAttribute.usage );
-
-				this.geometry.setAttribute( attributeName, dstAttribute );
-
-			}
-
-			if ( geometry.getIndex() !== null ) {
-
-				const indexArray = this._maxVertexCount > 65536
-					? new Uint32Array( this._maxIndexCount )
-					: new Uint16Array( this._maxIndexCount );
-
-				this.geometry.setIndex( new BufferAttribute( indexArray, 1 ) );
-
-			}
-
-			const idArray = this._maxGeometryCount > 65536
-				? new Uint32Array( this._maxVertexCount )
-				: new Uint16Array( this._maxVertexCount );
-			// @TODO: What if attribute name 'id' is already used?
-			this.geometry.setAttribute( 'id', new BufferAttribute( idArray, 1 ) );
-
-			this._geometryInitialized = true;
-
-		} else {
-
-			// @TODO: Check if geometry has the same attributes set
 
 		}
 
@@ -276,8 +287,6 @@ class BatchedMesh extends Mesh {
 
 		visibles.push( true );
 		alives.push( true );
-
-		// @TODO: Error handling if exceeding maxVertexCount or maxIndexCount
 
 		for ( const attributeName in geometry.attributes ) {
 


### PR DESCRIPTION
Related issue: #25059, #22376

**Description**

Use local variables, add comments, and rearrange `deleteGeometry`, `applyGeometry`. The big thing that makes the PR a bit difficult to diff is that the initialization logic when adding a first geometry has been moved to a separate `_initializeGeometry` function. If needed I can remove that and add it in another PR.

cc @takahirox 