### PR TITLE
GLTFLoader: Fix collision in unique object names

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -3524,17 +3524,17 @@ class GLTFParser {
 
 		const sanitizedName = PropertyBinding.sanitizeNodeName( originalName || '' );
 
+		let uniqueName = sanitizedName;
+
 		if ( sanitizedName in this.nodeNamesUsed ) {
 
-			return sanitizedName + '_' + ( ++ this.nodeNamesUsed[ sanitizedName ] );
-
-		} else {
-
-			this.nodeNamesUsed[ sanitizedName ] = 0;
-
-			return sanitizedName;
+			uniqueName = sanitizedName + '_' + ( ++ this.nodeNamesUsed[ sanitizedName ] );
 
 		}
+
+		this.nodeNamesUsed[ uniqueName ] = 0;
+
+		return uniqueName;
 
 	}
 
@@ -4278,7 +4278,7 @@ class GLTFParser {
 
 		const tracks = [];
 
-		const targetName = node.uuid;
+		const targetName = node.name ? node.name : node.uuid;
 		const targetNames = [];
 
 		if ( PATH_PROPERTIES[ target.path ] === PATH_PROPERTIES.weights ) {

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2549,6 +2549,8 @@ class GLTFParser {
 				userData: {}
 			};
 
+			console.log(result);
+
 			addUnknownExtensionsToUserData( extensions, result, json );
 
 			assignExtrasToUserData( result, json );
@@ -4278,7 +4280,7 @@ class GLTFParser {
 
 		const tracks = [];
 
-		const targetName = node.name ? node.name : node.uuid;
+		const targetName = node.uuid;
 		const targetNames = [];
 
 		if ( PATH_PROPERTIES[ target.path ] === PATH_PROPERTIES.weights ) {

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2549,8 +2549,6 @@ class GLTFParser {
 				userData: {}
 			};
 
-			console.log(result);
-
 			addUnknownExtensionsToUserData( extensions, result, json );
 
 			assignExtrasToUserData( result, json );


### PR DESCRIPTION
Related issue: #27051

**Description**

~Use uuid instead of name to avoid name conflict. Due to name conflict, animation could run on the wrong mesh.~

_Edit:_
Instead of using uuid, I re-arrange the unique name generation to handle conflicted names.

