### PR TITLE
BatchedMesh: Clean up.

### DIFF
--- a/examples/jsm/objects/BatchedMesh.js
+++ b/examples/jsm/objects/BatchedMesh.js
@@ -92,7 +92,6 @@ class BatchedMesh extends Mesh {
 		this._matrices = [];
 		this._matricesArray = null;
 		this._matricesTexture = null;
-		this._matricesTextureSize = null;
 
 		// @TODO: Calculate the entire binding box and make frustumCulled true
 		this.frustumCulled = false;
@@ -125,10 +124,9 @@ class BatchedMesh extends Mesh {
 
 		this._matricesArray = matricesArray;
 		this._matricesTexture = matricesTexture;
-		this._matricesTextureSize = size;
 
 		this._customUniforms.batchingTexture.value = this._matricesTexture;
-		this._customUniforms.batchingTextureSize.value = this._matricesTextureSize;
+		this._customUniforms.batchingTextureSize.value = size;
 
 	}
 

--- a/examples/jsm/objects/BatchedMesh.js
+++ b/examples/jsm/objects/BatchedMesh.js
@@ -74,8 +74,8 @@ class BatchedMesh extends Mesh {
 		this._indexStarts = [];
 		this._indexCounts = [];
 
-		this._visibles = [];
-		this._alives = [];
+		this._visible = [];
+		this._active = [];
 
 		this._maxGeometryCount = maxGeometryCount;
 		this._maxVertexCount = maxVertexCount;
@@ -253,8 +253,8 @@ class BatchedMesh extends Mesh {
 		}
 
 		const batchGeometry = this.geometry;
-		const visibles = this._visibles;
-		const alives = this._alives;
+		const visible = this._visible;
+		const active = this._active;
 		const matricesTexture = this._matricesTexture;
 		const matrices = this._matrices;
 		const matricesArray = this._matricesTexture.image.data;
@@ -324,8 +324,8 @@ class BatchedMesh extends Mesh {
 		this._vertexCount += srcPositionAttribute.count;
 
 		// push new visibility states
-		visibles.push( true );
-		alives.push( true );
+		visible.push( true );
+		active.push( true );
 
 		// initialize matrix information
 		matrices.push( new Matrix4() );
@@ -340,16 +340,16 @@ class BatchedMesh extends Mesh {
 
 		// Note: User needs to call optimize() afterward to pack the data.
 
-		const alives = this._alives;
+		const active = this._active;
 		const matricesArray = this._matricesTexture.image.data;
 		const matricesTexture = this._matricesTexture;
-		if ( geometryId >= alives.length || alives[ geometryId ] === false ) {
+		if ( geometryId >= active.length || active[ geometryId ] === false ) {
 
 			return this;
 
 		}
 
-		alives[ geometryId ] = false;
+		active[ geometryId ] = false;
 		_zeroScaleMatrix.toArray( matricesArray, geometryId * 16 );
 		matricesTexture.needsUpdate = true;
 
@@ -370,18 +370,18 @@ class BatchedMesh extends Mesh {
 		// @TODO: Map geometryId to index of the arrays because
 		//        optimize() can make geometryId mismatch the index
 
-		const visibles = this._visibles;
-		const alives = this._alives;
+		const visible = this._visible;
+		const active = this._active;
 		const matricesTexture = this._matricesTexture;
 		const matrices = this._matrices;
 		const matricesArray = this._matricesTexture.image.data;
-		if ( geometryId >= matrices.length || alives[ geometryId ] === false ) {
+		if ( geometryId >= matrices.length || active[ geometryId ] === false ) {
 
 			return this;
 
 		}
 
-		if ( visibles[ geometryId ] === true ) {
+		if ( visible[ geometryId ] === true ) {
 
 			matrix.toArray( matricesArray, geometryId * 16 );
 			matricesTexture.needsUpdate = true;
@@ -397,8 +397,8 @@ class BatchedMesh extends Mesh {
 	getMatrixAt( geometryId, matrix ) {
 
 		const matrices = this._matrices;
-		const alives = this._alives;
-		if ( geometryId >= matrices.length || alives[ geometryId ] === false ) {
+		const active = this._active;
+		if ( geometryId >= matrices.length || active[ geometryId ] === false ) {
 
 			return matrix;
 
@@ -408,10 +408,10 @@ class BatchedMesh extends Mesh {
 
 	}
 
-	setVisibleAt( geometryId, visible ) {
+	setVisibleAt( geometryId, value ) {
 
-		const visibles = this._visibles;
-		const alives = this._alives;
+		const visible = this._visible;
+		const active = this._active;
 		const matricesTexture = this._matricesTexture;
 		const matrices = this._matrices;
 		const matricesArray = this._matricesTexture.image.data;
@@ -419,9 +419,9 @@ class BatchedMesh extends Mesh {
 		// if the geometry is out of range, not active, or visibility state
 		// does not change then return early
 		if (
-			geometryId >= visibles.length ||
-			alives[ geometryId ] === false ||
-			visibles[ geometryId ] === visible
+			geometryId >= visible.length ||
+			active[ geometryId ] === false ||
+			visible[ geometryId ] === value
 		) {
 
 			return this;
@@ -429,7 +429,7 @@ class BatchedMesh extends Mesh {
 		}
 
 		// scale the matrix to zero if it's hidden
-		if ( visible === true ) {
+		if ( value === true ) {
 
 			matrices[ geometryId ].toArray( matricesArray, geometryId * 16 );
 
@@ -440,24 +440,24 @@ class BatchedMesh extends Mesh {
 		}
 
 		matricesTexture.needsUpdate = true;
-		visibles[ geometryId ] = visible;
+		visible[ geometryId ] = value;
 		return this;
 
 	}
 
 	getVisibleAt( geometryId ) {
 
-		const visibles = this._visibles;
-		const alives = this._alives;
+		const visible = this._visible;
+		const active = this._active;
 
 		// return early if the geometry is out of range or not active
-		if ( geometryId >= visibles.length || alives[ geometryId ] === false ) {
+		if ( geometryId >= visible.length || active[ geometryId ] === false ) {
 
 			return false;
 
 		}
 
-		return visibles[ geometryId ];
+		return visible[ geometryId ];
 
 	}
 

--- a/examples/jsm/objects/BatchedMesh.js
+++ b/examples/jsm/objects/BatchedMesh.js
@@ -257,7 +257,7 @@ class BatchedMesh extends Mesh {
 		const alives = this._alives;
 		const matricesTexture = this._matricesTexture;
 		const matrices = this._matrices;
-		const matricesArray = this._matricesArray;
+		const matricesArray = this._matricesTexture.image.data;
 		const vertexCount = this._vertexCount;
 		const indexCount = this._indexCount;
 
@@ -341,7 +341,7 @@ class BatchedMesh extends Mesh {
 		// Note: User needs to call optimize() afterward to pack the data.
 
 		const alives = this._alives;
-		const matricesArray = this._matricesArray;
+		const matricesArray = this._matricesTexture.image.data;
 		const matricesTexture = this._matricesTexture;
 		if ( geometryId >= alives.length || alives[ geometryId ] === false ) {
 
@@ -374,7 +374,7 @@ class BatchedMesh extends Mesh {
 		const alives = this._alives;
 		const matricesTexture = this._matricesTexture;
 		const matrices = this._matrices;
-		const matricesArray = this._matricesArray;
+		const matricesArray = this._matricesTexture.image.data;
 		if ( geometryId >= matrices.length || alives[ geometryId ] === false ) {
 
 			return this;
@@ -414,7 +414,7 @@ class BatchedMesh extends Mesh {
 		const alives = this._alives;
 		const matricesTexture = this._matricesTexture;
 		const matrices = this._matrices;
-		const matricesArray = this._matricesArray;
+		const matricesArray = this._matricesTexture.image.data;
 
 		// if the geometry is out of range, not active, or visibility state
 		// does not change then return early

--- a/examples/jsm/objects/BatchedMesh.js
+++ b/examples/jsm/objects/BatchedMesh.js
@@ -9,6 +9,7 @@ import {
 	RGBAFormat
 } from 'three';
 
+const ID_ATTR_NAME = '_batch_id_';
 const _identityMatrix = new Matrix4();
 const _zeroScaleMatrix = new Matrix4().set(
 	0, 0, 0, 0,
@@ -20,7 +21,7 @@ const _zeroScaleMatrix = new Matrix4().set(
 // Custom shaders
 const batchingParsVertex = `
 #ifdef BATCHING
-	attribute float id;
+	attribute float ${ ID_ATTR_NAME };
 	uniform highp sampler2D batchingTexture;
 	uniform int batchingTextureSize;
 	mat4 getBatchingMatrix( const in float i ) {
@@ -41,7 +42,7 @@ const batchingParsVertex = `
 
 const batchingbaseVertex = `
 #ifdef BATCHING
-	mat4 batchingMatrix = getBatchingMatrix( id );
+	mat4 batchingMatrix = getBatchingMatrix( ${ ID_ATTR_NAME } );
 #endif
 `;
 
@@ -210,8 +211,7 @@ class BatchedMesh extends Mesh {
 			const idArray = maxGeometryCount > 65536
 				? new Uint32Array( maxVertexCount )
 				: new Uint16Array( maxVertexCount );
-			// @TODO: What if attribute name 'id' is already used?
-			geometry.setAttribute( 'id', new BufferAttribute( idArray, 1 ) );
+			geometry.setAttribute( ID_ATTR_NAME, new BufferAttribute( idArray, 1 ) );
 
 			this._geometryInitialized = true;
 
@@ -311,7 +311,7 @@ class BatchedMesh extends Mesh {
 		const geometryId = this._geometryCount;
 		this._geometryCount ++;
 
-		const idAttribute = batchGeometry.getAttribute( 'id' );
+		const idAttribute = batchGeometry.getAttribute( ID_ATTR_NAME );
 		for ( let i = 0; i < srcPositionAttribute.count; i ++ ) {
 
 			idAttribute.setX( this._vertexCount + i, geometryId );


### PR DESCRIPTION
Related issue: #25059, #22376

**Description**

- Adjust grammar of some of the member names: "alives" to "active", "visibles" to "visible"
- Remove unnecessary redundant storage of matrix texture information
- Change attribute id name to something more unique - `id` -> `_batch_id_`
  - For reference the 3d tiles' (now legacy) b3dm format uses the `_batchid` identifier

cc @takahirox 