### PR TITLE
BokehPass: Correctly set `aspect` in `setSize()`.

### DIFF
--- a/examples/jsm/postprocessing/BokehPass.js
+++ b/examples/jsm/postprocessing/BokehPass.js
@@ -26,7 +26,6 @@ class BokehPass extends Pass {
 		this.camera = camera;
 
 		const focus = ( params.focus !== undefined ) ? params.focus : 1.0;
-		const aspect = ( params.aspect !== undefined ) ? params.aspect : camera.aspect;
 		const aperture = ( params.aperture !== undefined ) ? params.aperture : 0.025;
 		const maxblur = ( params.maxblur !== undefined ) ? params.maxblur : 1.0;
 
@@ -54,7 +53,7 @@ class BokehPass extends Pass {
 		bokehUniforms[ 'tDepth' ].value = this.renderTargetDepth.texture;
 
 		bokehUniforms[ 'focus' ].value = focus;
-		bokehUniforms[ 'aspect' ].value = aspect;
+		bokehUniforms[ 'aspect' ].value = camera.aspect;
 		bokehUniforms[ 'aperture' ].value = aperture;
 		bokehUniforms[ 'maxblur' ].value = maxblur;
 		bokehUniforms[ 'nearClip' ].value = camera.near;
@@ -119,6 +118,8 @@ class BokehPass extends Pass {
 	}
 
 	setSize( width, height ) {
+
+		this.materialBokeh.uniforms[ 'aspect' ].value = width / height;
 
 		this.renderTargetDepth.setSize( width, height );
 


### PR DESCRIPTION
Related issue: https://discourse.threejs.org/t/bokehpass-resize-issue/57435/2

**Description**

`BokehPass.setSize()` did not update the `aspect` so far. The PR fixes that.