### PR TITLE
Renderer: `.setRenderObjectFunction()`

### DIFF
--- a/examples/jsm/nodes/lighting/AnalyticLightNode.js
+++ b/examples/jsm/nodes/lighting/AnalyticLightNode.js
@@ -168,9 +168,9 @@ class AnalyticLightNode extends LightingNode {
 		light.shadow.updateMatrices( light );
 
 		const currentRenderTarget = renderer.getRenderTarget();
-		const currentRenderObject = renderer.getRenderObject();
+		const currentRenderObjectFunction = renderer.getRenderObjectFunction();
 
-		renderer.setRenderObject( ( object, ...params ) => {
+		renderer.setRenderObjectFunction( ( object, ...params ) => {
 
 			if ( object.castShadow === true ) {
 
@@ -185,7 +185,7 @@ class AnalyticLightNode extends LightingNode {
 		renderer.render( scene, light.shadow.camera );
 
 		renderer.setRenderTarget( currentRenderTarget );
-		renderer.setRenderObject( currentRenderObject );
+		renderer.setRenderObjectFunction( currentRenderObjectFunction );
 
 		scene.overrideMaterial = null;
 

--- a/examples/jsm/nodes/lighting/AnalyticLightNode.js
+++ b/examples/jsm/nodes/lighting/AnalyticLightNode.js
@@ -167,9 +167,25 @@ class AnalyticLightNode extends LightingNode {
 
 		light.shadow.updateMatrices( light );
 
+		const currentRenderTarget = renderer.getRenderTarget();
+		const currentRenderObject = renderer.getRenderObject();
+
+		renderer.setRenderObject( ( object, ...params ) => {
+
+			if ( object.castShadow === true ) {
+
+				renderer.renderObject( object, ...params );
+
+			}
+
+		} );
+
 		renderer.setRenderTarget( rtt );
+
 		renderer.render( scene, light.shadow.camera );
-		renderer.setRenderTarget( null );
+
+		renderer.setRenderTarget( currentRenderTarget );
+		renderer.setRenderObject( currentRenderObject );
 
 		scene.overrideMaterial = null;
 

--- a/examples/jsm/renderers/common/Renderer.js
+++ b/examples/jsm/renderers/common/Renderer.js
@@ -649,9 +649,9 @@ class Renderer {
 
 	}
 
-	setRenderObjectFunction( renderObject ) {
+	setRenderObjectFunction( renderObjectFunction ) {
 
-		this._renderObjectFunction = renderObject;
+		this._renderObjectFunction = renderObjectFunction;
 
 	}
 

--- a/examples/jsm/renderers/common/Renderer.js
+++ b/examples/jsm/renderers/common/Renderer.js
@@ -87,6 +87,9 @@ class Renderer {
 		this._activeCubeFace = 0;
 		this._activeMipmapLevel = 0;
 
+		this._renderObject = null;
+		this._currentRenderObject = null;
+
 		this._initialized = false;
 		this._initPromise = null;
 
@@ -180,6 +183,7 @@ class Renderer {
 
 		const previousRenderId = nodeFrame.renderId;
 		const previousRenderState = this._currentRenderContext;
+		const previousRenderObject = this._currentRenderObject;
 
 		//
 
@@ -191,6 +195,7 @@ class Renderer {
 		const activeMipmapLevel = this._activeMipmapLevel;
 
 		this._currentRenderContext = renderContext;
+		this._currentRenderObject = this._renderObject || this.renderObject;
 
 		nodeFrame.renderId ++;
 
@@ -332,7 +337,9 @@ class Renderer {
 		// restore render tree
 
 		nodeFrame.renderId = previousRenderId;
+
 		this._currentRenderContext = previousRenderState;
+		this._currentRenderObject = previousRenderObject;
 
 		this._lastRenderContext = renderContext;
 
@@ -642,6 +649,18 @@ class Renderer {
 
 	}
 
+	setRenderObject( renderObject ) {
+
+		this._renderObject = renderObject;
+
+	}
+
+	getRenderObject() {
+
+		return this._renderTarget;
+
+	}
+
 	async compute( computeNodes ) {
 
 		if ( this._initialized === false ) await this.init();
@@ -825,7 +844,7 @@ class Renderer {
 			const renderItem = renderList[ i ];
 
 			// @TODO: Add support for multiple materials per object. This will require to extract
-			// the material from the renderItem object and pass it with its group data to _renderObject().
+			// the material from the renderItem object and pass it with its group data to renderObject().
 
 			const { object, geometry, material, group } = renderItem;
 
@@ -850,7 +869,7 @@ class Renderer {
 
 						this.backend.updateViewport( this._currentRenderContext );
 
-						this._renderObject( object, scene, camera2, geometry, material, group, lightsNode );
+						this._currentRenderObject( object, scene, camera2, geometry, material, group, lightsNode );
 
 					}
 
@@ -858,7 +877,7 @@ class Renderer {
 
 			} else {
 
-				this._renderObject( object, scene, camera, geometry, material, group, lightsNode );
+				this._currentRenderObject( object, scene, camera, geometry, material, group, lightsNode );
 
 			}
 
@@ -866,7 +885,7 @@ class Renderer {
 
 	}
 
-	_renderObject( object, scene, camera, geometry, material, group, lightsNode ) {
+	renderObject( object, scene, camera, geometry, material, group, lightsNode ) {
 
 		material = scene.overrideMaterial !== null ? scene.overrideMaterial : material;
 

--- a/examples/jsm/renderers/common/Renderer.js
+++ b/examples/jsm/renderers/common/Renderer.js
@@ -87,8 +87,8 @@ class Renderer {
 		this._activeCubeFace = 0;
 		this._activeMipmapLevel = 0;
 
-		this._renderObject = null;
-		this._currentRenderObject = null;
+		this._renderObjectFunction = null;
+		this._currentRenderObjectFunction = null;
 
 		this._initialized = false;
 		this._initPromise = null;
@@ -182,8 +182,8 @@ class Renderer {
 		const nodeFrame = this._nodes.nodeFrame;
 
 		const previousRenderId = nodeFrame.renderId;
-		const previousRenderState = this._currentRenderContext;
-		const previousRenderObject = this._currentRenderObject;
+		const previousRenderContext = this._currentRenderContext;
+		const previousRenderObjectFunction = this._currentRenderObjectFunction;
 
 		//
 
@@ -195,7 +195,7 @@ class Renderer {
 		const activeMipmapLevel = this._activeMipmapLevel;
 
 		this._currentRenderContext = renderContext;
-		this._currentRenderObject = this._renderObject || this.renderObject;
+		this._currentRenderObjectFunction = this._renderObjectFunction || this.renderObject;
 
 		nodeFrame.renderId ++;
 
@@ -338,8 +338,8 @@ class Renderer {
 
 		nodeFrame.renderId = previousRenderId;
 
-		this._currentRenderContext = previousRenderState;
-		this._currentRenderObject = previousRenderObject;
+		this._currentRenderContext = previousRenderContext;
+		this._currentRenderObjectFunction = previousRenderObjectFunction;
 
 		this._lastRenderContext = renderContext;
 
@@ -649,15 +649,15 @@ class Renderer {
 
 	}
 
-	setRenderObject( renderObject ) {
+	setRenderObjectFunction( renderObject ) {
 
-		this._renderObject = renderObject;
+		this._renderObjectFunction = renderObject;
 
 	}
 
-	getRenderObject() {
+	getRenderObjectFunction() {
 
-		return this._renderTarget;
+		return this._renderObjectFunction;
 
 	}
 
@@ -869,7 +869,7 @@ class Renderer {
 
 						this.backend.updateViewport( this._currentRenderContext );
 
-						this._currentRenderObject( object, scene, camera2, geometry, material, group, lightsNode );
+						this._currentRenderObjectFunction( object, scene, camera2, geometry, material, group, lightsNode );
 
 					}
 
@@ -877,7 +877,7 @@ class Renderer {
 
 			} else {
 
-				this._currentRenderObject( object, scene, camera, geometry, material, group, lightsNode );
+				this._currentRenderObjectFunction( object, scene, camera, geometry, material, group, lightsNode );
 
 			}
 

--- a/examples/webgpu_compute_particles_rain.html
+++ b/examples/webgpu_compute_particles_rain.html
@@ -62,7 +62,6 @@
 				const { innerWidth, innerHeight } = window;
 
 				camera = new THREE.PerspectiveCamera( 60, innerWidth / innerHeight, .1, 110 );
-				camera.layers.enable( 2 ); // @TODO: Fix .castShadow and remove it
 				camera.position.set( 40, 8, 0 );
 				camera.lookAt( 0, 0, 0 );
 
@@ -234,8 +233,6 @@
 				const rainParticles = new THREE.Mesh( new THREE.PlaneGeometry( .1, 2 ), rainMaterial );
 				rainParticles.isInstancedMesh = true;
 				rainParticles.count = instanceCount;
-				rainParticles.layers.disableAll();
-				rainParticles.layers.enable( 2 );
 				scene.add( rainParticles );
 
 				// ripple
@@ -276,8 +273,6 @@
 				const rippleParticles = new THREE.Mesh( rippleGeometry, rippleMaterial );
 				rippleParticles.isInstancedMesh = true;
 				rippleParticles.count = instanceCount;
-				rippleParticles.layers.disableAll();
-				rippleParticles.layers.enable( 2 );
 				scene.add( rippleParticles );
 
 				// floor geometry


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/25822, https://github.com/mrdoob/three.js/pull/27053, https://github.com/mrdoob/three.js/pull/25933

**Description**

`renderer.renderObjectFunction()` offers the ability to filter or change the object in the rendering state, this fixes the current optimization problem in shadow rendering in `WebGPURenderer` and can also be used in cases like this https://github.com/mrdoob/three.js/pull/25933 and others where users use `scene.traverse()` to make the filter of objects could use this method which already pass through the `frustumCulled` filter.

Usage
```js
function renderObjectFunction( object, ...params ) {

	if ( object.castShadow === true ) {

		renderer.renderObject( object, ...params );

	}

}


renderer.setRenderTarget( rtt );
renderer.setRenderObjectFunction( renderObject );

renderer.render( scene, camera );

```