### PR TITLE
BatchedMesh: Fix failure with MeshBasicMaterial

### DIFF
--- a/examples/jsm/objects/BatchedMesh.js
+++ b/examples/jsm/objects/BatchedMesh.js
@@ -174,9 +174,13 @@ class BatchedMesh extends Mesh {
 						+ batchingParsVertex
 				)
 				.replace(
+					'#include <uv_vertex>',
+					'#include <uv_vertex>\n'
+                        + batchingbaseVertex
+				)
+				.replace(
 					'#include <skinnormal_vertex>',
 					'#include <skinnormal_vertex>\n'
-						+ batchingbaseVertex
 						+ batchingnormalVertex
 				)
 				.replace(

--- a/examples/jsm/objects/BatchedMesh.js
+++ b/examples/jsm/objects/BatchedMesh.js
@@ -176,7 +176,7 @@ class BatchedMesh extends Mesh {
 				.replace(
 					'#include <uv_vertex>',
 					'#include <uv_vertex>\n'
-                        + batchingbaseVertex
+						+ batchingbaseVertex
 				)
 				.replace(
 					'#include <skinnormal_vertex>',


### PR DESCRIPTION
Related issue: #25059, #22376

**Description**

Fix BatchedMesh failing when using MeshBasicMaterial.