### PR TITLE
BatchedMesh: use texelFetch, textureSize

### DIFF
--- a/examples/jsm/objects/BatchedMesh.js
+++ b/examples/jsm/objects/BatchedMesh.js
@@ -23,19 +23,18 @@ const batchingParsVertex = /* glsl */`
 #ifdef BATCHING
 	attribute float ${ ID_ATTR_NAME };
 	uniform highp sampler2D batchingTexture;
-	uniform int batchingTextureSize;
 	mat4 getBatchingMatrix( const in float i ) {
-		float j = i * 4.0;
-		float x = mod( j, float( batchingTextureSize ) );
-		float y = floor( j / float( batchingTextureSize ) );
-		float dx = 1.0 / float( batchingTextureSize );
-		float dy = 1.0 / float( batchingTextureSize );
-		y = dy * ( y + 0.5 );
-		vec4 v1 = texture2D( batchingTexture, vec2( dx * ( x + 0.5 ), y ) );
-		vec4 v2 = texture2D( batchingTexture, vec2( dx * ( x + 1.5 ), y ) );
-		vec4 v3 = texture2D( batchingTexture, vec2( dx * ( x + 2.5 ), y ) );
-		vec4 v4 = texture2D( batchingTexture, vec2( dx * ( x + 3.5 ), y ) );
+
+		int size = textureSize( batchingTexture, 0 ).x;
+		int j = int( i ) * 4;
+		int x = j % size;
+		int y = j / size;
+		vec4 v1 = texelFetch( batchingTexture, ivec2( x, y ), 0 );
+		vec4 v2 = texelFetch( batchingTexture, ivec2( x + 1, y ), 0 );
+		vec4 v3 = texelFetch( batchingTexture, ivec2( x + 2, y ), 0 );
+		vec4 v4 = texelFetch( batchingTexture, ivec2( x + 3, y ), 0 );
 		return mat4( v1, v2, v3, v4 );
+
 	}
 #endif
 `;
@@ -127,8 +126,7 @@ class BatchedMesh extends Mesh {
 		this.frustumCulled = false;
 
 		this._customUniforms = {
-			batchingTexture: { value: null },
-			batchingTextureSize: { value: 0 }
+			batchingTexture: { value: null }
 		};
 
 		this._initMatricesTexture();
@@ -154,7 +152,6 @@ class BatchedMesh extends Mesh {
 
 		this._matricesTexture = matricesTexture;
 		this._customUniforms.batchingTexture.value = this._matricesTexture;
-		this._customUniforms.batchingTextureSize.value = size;
 
 	}
 


### PR DESCRIPTION
Related issue: #25059, #22376 

**Description**

Use the texelFetch, textureSize functions in BatchedMes which remove the need for a uniform, casting, and half-texel insets. Note that these functions can only be used in WebGL2.