### PR TITLE
WebGLRenderer: Add uploadGeometry function

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -939,6 +939,21 @@ class WebGLRenderer {
 
 		}
 
+		// uploads any new geometry or changed buffer attribute changes immediately
+		this.uploadGeometry = function ( scene ) {
+
+			scene.traverse( function ( object ) {
+
+				if ( object.geometry !== null ) {
+
+					objects.update( object );
+
+				}
+
+			} );
+
+		};
+
 		this.compile = function ( scene, camera, targetScene = null ) {
 
 			if ( targetScene === null ) targetScene = scene;


### PR DESCRIPTION
Related issue: #27078

**Description**

Adds `WebGLRenderer.uploadGeometry` which is for geometry as `compile` is for materials and `initTexture` is for textures. It uploads any necessary buffer attributes, respecting any "updateRange" values if needed.

I've run into this issue a number of times but it's particularly noticeable with frequent BatchedMesh geometry updates (see demo in #27078, also mentioned [here](https://twitter.com/garrettkjohnson/status/1642890723531055104)) since any change in loaded geometry means reuploading the _entire_ large attribute buffer which can be unnecessarily slow and ultimately undermine any benefits from the batched mesh in the first place. Instead if you only update 4 out of 800 geometries in a BatchedMesh you should only upload the changed ones immediately, which this enables:

```js
const attr = mesh.geometry.attributes.position;
attr.updateRange.start = 100;
attr.updateRange.count = 100;
renderer.updateGeometry( mesh );
```

In the tiles renderer demo I'm doing this to force an update of the geometry on change since you can't specify multiple update ranges:

```js
// Force an upload of the given range
const visible = mesh.visible;
mesh.visible = true;
mesh.geometry.setDrawRange( 0, 3 );
renderer.render( mesh, _camera );
mesh.geometry.setDrawRange( 0, Infinity );
mesh.visible = visible;
```

I can add documentation if this is merged.