### PR TITLE
WebXR: Unify buttons

### DIFF
--- a/examples/jsm/webxr/ARButton.js
+++ b/examples/jsm/webxr/ARButton.js
@@ -1,205 +1,94 @@
-class ARButton {
+import { WebXRButton } from './WebXRButton.js';
+
+class ARButton extends WebXRButton {
+
+	constructor( renderer, sessionInit ) {
+
+		super( renderer, sessionInit );
+		this.id = 'ARbutton';
+		this.stopLabel = 'STOP AR';
+		this.startLabel = 'START AR';
+		this.notSupportedLabel = 'AR NOT SUPPORTED';
+		this.notAllowedLabel = 'AR NOT ALLOWED';
+
+	}
 
 	static createButton( renderer, sessionInit = {} ) {
 
-		const button = document.createElement( 'button' );
+		const arButtonInstance = new ARButton( renderer, sessionInit );
+		return arButtonInstance.createButtonElement();
 
-		function showStartAR( /*device*/ ) {
+	}
 
-			if ( sessionInit.domOverlay === undefined ) {
+	setupDOMOverlay() {
 
-				const overlay = document.createElement( 'div' );
-				overlay.style.display = 'none';
-				document.body.appendChild( overlay );
+		if ( this.sessionOptions.domOverlay === undefined ) {
 
-				const svg = document.createElementNS( 'http://www.w3.org/2000/svg', 'svg' );
-				svg.setAttribute( 'width', 38 );
-				svg.setAttribute( 'height', 38 );
-				svg.style.position = 'absolute';
-				svg.style.right = '20px';
-				svg.style.top = '20px';
-				svg.addEventListener( 'click', function () {
+			const overlay = document.createElement( 'div' );
+			overlay.style.display = 'none';
+			document.body.appendChild( overlay );
 
-					currentSession.end();
+			const svg = document.createElementNS( 'http://www.w3.org/2000/svg', 'svg' );
+			svg.setAttribute( 'width', 38 );
+			svg.setAttribute( 'height', 38 );
+			svg.style.position = 'absolute';
+			svg.style.right = '20px';
+			svg.style.top = '20px';
+			svg.addEventListener( 'click', function () {
 
-				} );
-				overlay.appendChild( svg );
+				currentSession.end();
 
-				const path = document.createElementNS( 'http://www.w3.org/2000/svg', 'path' );
-				path.setAttribute( 'd', 'M 12,12 L 28,28 M 28,12 12,28' );
-				path.setAttribute( 'stroke', '#fff' );
-				path.setAttribute( 'stroke-width', 2 );
-				svg.appendChild( path );
+			} );
+			overlay.appendChild( svg );
 
-				if ( sessionInit.optionalFeatures === undefined ) {
+			const path = document.createElementNS(
+				'http://www.w3.org/2000/svg',
+				'path'
+			);
+			path.setAttribute( 'd', 'M 12,12 L 28,28 M 28,12 12,28' );
+			path.setAttribute( 'stroke', '#fff' );
+			path.setAttribute( 'stroke-width', 2 );
+			svg.appendChild( path );
 
-					sessionInit.optionalFeatures = [];
+			if ( this.sessionOptions.optionalFeatures === undefined ) {
 
-				}
-
-				sessionInit.optionalFeatures.push( 'dom-overlay' );
-				sessionInit.domOverlay = { root: overlay };
-
-			}
-
-			//
-
-			let currentSession = null;
-
-			async function onSessionStarted( session ) {
-
-				session.addEventListener( 'end', onSessionEnded );
-
-				renderer.xr.setReferenceSpaceType( 'local' );
-
-				await renderer.xr.setSession( session );
-
-				button.textContent = 'STOP AR';
-				sessionInit.domOverlay.root.style.display = '';
-
-				currentSession = session;
+				this.sessionOptions.optionalFeatures = [];
 
 			}
 
-			function onSessionEnded( /*event*/ ) {
-
-				currentSession.removeEventListener( 'end', onSessionEnded );
-
-				button.textContent = 'START AR';
-				sessionInit.domOverlay.root.style.display = 'none';
-
-				currentSession = null;
-
-			}
-
-			//
-
-			button.style.display = '';
-
-			button.style.cursor = 'pointer';
-			button.style.left = 'calc(50% - 50px)';
-			button.style.width = '100px';
-
-			button.textContent = 'START AR';
-
-			button.onmouseenter = function () {
-
-				button.style.opacity = '1.0';
-
-			};
-
-			button.onmouseleave = function () {
-
-				button.style.opacity = '0.5';
-
-			};
-
-			button.onclick = function () {
-
-				if ( currentSession === null ) {
-
-					navigator.xr.requestSession( 'immersive-ar', sessionInit ).then( onSessionStarted );
-
-				} else {
-
-					currentSession.end();
-
-				}
-
-			};
+			this.sessionOptions.optionalFeatures.push( 'dom-overlay' );
+			this.sessionOptions.domOverlay = { root: overlay };
 
 		}
 
-		function disableButton() {
+	}
 
-			button.style.display = '';
+	async onSessionStarted( session ) {
 
-			button.style.cursor = 'auto';
-			button.style.left = 'calc(50% - 75px)';
-			button.style.width = '150px';
+		this.renderer.xr.setReferenceSpaceType( 'local' );
+		await super.onSessionStarted( session );
+		this.sessionOptions.domOverlay.root.style.display = '';
 
-			button.onmouseenter = null;
-			button.onmouseleave = null;
+	}
 
-			button.onclick = null;
+	async getSessionMode( xr ) {
 
-		}
+		const isSupported = await xr.isSessionSupported( 'immersive-ar' );
+		return isSupported ? 'immersive-ar' : null;
 
-		function showARNotSupported() {
+	}
 
-			disableButton();
+	onSessionEnded() {
 
-			button.textContent = 'AR NOT SUPPORTED';
+		super.onSessionEnded();
+		this.sessionOptions.domOverlay.root.style.display = 'none';
 
-		}
+	}
 
-		function showARNotAllowed( exception ) {
+	showStart() {
 
-			disableButton();
-
-			console.warn( 'Exception when trying to call xr.isSessionSupported', exception );
-
-			button.textContent = 'AR NOT ALLOWED';
-
-		}
-
-		function stylizeElement( element ) {
-
-			element.style.position = 'absolute';
-			element.style.bottom = '20px';
-			element.style.padding = '12px 6px';
-			element.style.border = '1px solid #fff';
-			element.style.borderRadius = '4px';
-			element.style.background = 'rgba(0,0,0,0.1)';
-			element.style.color = '#fff';
-			element.style.font = 'normal 13px sans-serif';
-			element.style.textAlign = 'center';
-			element.style.opacity = '0.5';
-			element.style.outline = 'none';
-			element.style.zIndex = '999';
-
-		}
-
-		if ( 'xr' in navigator ) {
-
-			button.id = 'ARButton';
-			button.style.display = 'none';
-
-			stylizeElement( button );
-
-			navigator.xr.isSessionSupported( 'immersive-ar' ).then( function ( supported ) {
-
-				supported ? showStartAR() : showARNotSupported();
-
-			} ).catch( showARNotAllowed );
-
-			return button;
-
-		} else {
-
-			const message = document.createElement( 'a' );
-
-			if ( window.isSecureContext === false ) {
-
-				message.href = document.location.href.replace( /^http:/, 'https:' );
-				message.innerHTML = 'WEBXR NEEDS HTTPS'; // TODO Improve message
-
-			} else {
-
-				message.href = 'https://immersiveweb.dev/';
-				message.innerHTML = 'WEBXR NOT AVAILABLE';
-
-			}
-
-			message.style.left = 'calc(50% - 90px)';
-			message.style.width = '180px';
-			message.style.textDecoration = 'none';
-
-			stylizeElement( message );
-
-			return message;
-
-		}
+		this.setupDOMOverlay();
+		super.showStart();
 
 	}
 

--- a/examples/jsm/webxr/ARButton.js
+++ b/examples/jsm/webxr/ARButton.js
@@ -5,7 +5,7 @@ class ARButton extends WebXRButton {
 	constructor( renderer, sessionInit ) {
 
 		super( renderer, sessionInit );
-		this.id = 'ARbutton';
+		this.id = 'ARButton';
 		this.stopLabel = 'STOP AR';
 		this.startLabel = 'START AR';
 		this.notSupportedLabel = 'AR NOT SUPPORTED';

--- a/examples/jsm/webxr/VRButton.js
+++ b/examples/jsm/webxr/VRButton.js
@@ -5,7 +5,7 @@ class VRButton extends WebXRButton {
 	constructor( renderer, sessionInit ) {
 
 		super( renderer, sessionInit );
-		this.id = 'VRbutton';
+		this.id = 'VRButton';
 		this.stopLabel = 'EXIT VR';
 		this.startLabel = 'ENTER VR';
 		this.notSupportedLabel = 'VR NOT SUPPORTED';

--- a/examples/jsm/webxr/VRButton.js
+++ b/examples/jsm/webxr/VRButton.js
@@ -1,200 +1,55 @@
-class VRButton {
+import { WebXRButton } from './WebXRButton.js';
 
-	static createButton( renderer ) {
+class VRButton extends WebXRButton {
 
-		const button = document.createElement( 'button' );
+	constructor( renderer, sessionInit ) {
 
-		function showEnterVR( /*device*/ ) {
-
-			let currentSession = null;
-
-			async function onSessionStarted( session ) {
-
-				session.addEventListener( 'end', onSessionEnded );
-
-				await renderer.xr.setSession( session );
-				button.textContent = 'EXIT VR';
-
-				currentSession = session;
-
-			}
-
-			function onSessionEnded( /*event*/ ) {
-
-				currentSession.removeEventListener( 'end', onSessionEnded );
-
-				button.textContent = 'ENTER VR';
-
-				currentSession = null;
-
-			}
-
-			//
-
-			button.style.display = '';
-
-			button.style.cursor = 'pointer';
-			button.style.left = 'calc(50% - 50px)';
-			button.style.width = '100px';
-
-			button.textContent = 'ENTER VR';
-
-			button.onmouseenter = function () {
-
-				button.style.opacity = '1.0';
-
-			};
-
-			button.onmouseleave = function () {
-
-				button.style.opacity = '0.5';
-
-			};
-
-			button.onclick = function () {
-
-				if ( currentSession === null ) {
-
-					// WebXR's requestReferenceSpace only works if the corresponding feature
-					// was requested at session creation time. For simplicity, just ask for
-					// the interesting ones as optional features, but be aware that the
-					// requestReferenceSpace call will fail if it turns out to be unavailable.
-					// ('local' is always available for immersive sessions and doesn't need to
-					// be requested separately.)
-
-					const sessionInit = { optionalFeatures: [ 'local-floor', 'bounded-floor', 'hand-tracking', 'layers' ] };
-					navigator.xr.requestSession( 'immersive-vr', sessionInit ).then( onSessionStarted );
-
-				} else {
-
-					currentSession.end();
-
-				}
-
-			};
-
-		}
-
-		function disableButton() {
-
-			button.style.display = '';
-
-			button.style.cursor = 'auto';
-			button.style.left = 'calc(50% - 75px)';
-			button.style.width = '150px';
-
-			button.onmouseenter = null;
-			button.onmouseleave = null;
-
-			button.onclick = null;
-
-		}
-
-		function showWebXRNotFound() {
-
-			disableButton();
-
-			button.textContent = 'VR NOT SUPPORTED';
-
-		}
-
-		function showVRNotAllowed( exception ) {
-
-			disableButton();
-
-			console.warn( 'Exception when trying to call xr.isSessionSupported', exception );
-
-			button.textContent = 'VR NOT ALLOWED';
-
-		}
-
-		function stylizeElement( element ) {
-
-			element.style.position = 'absolute';
-			element.style.bottom = '20px';
-			element.style.padding = '12px 6px';
-			element.style.border = '1px solid #fff';
-			element.style.borderRadius = '4px';
-			element.style.background = 'rgba(0,0,0,0.1)';
-			element.style.color = '#fff';
-			element.style.font = 'normal 13px sans-serif';
-			element.style.textAlign = 'center';
-			element.style.opacity = '0.5';
-			element.style.outline = 'none';
-			element.style.zIndex = '999';
-
-		}
-
-		if ( 'xr' in navigator ) {
-
-			button.id = 'VRButton';
-			button.style.display = 'none';
-
-			stylizeElement( button );
-
-			navigator.xr.isSessionSupported( 'immersive-vr' ).then( function ( supported ) {
-
-				supported ? showEnterVR() : showWebXRNotFound();
-
-				if ( supported && VRButton.xrSessionIsGranted ) {
-
-					button.click();
-
-				}
-
-			} ).catch( showVRNotAllowed );
-
-			return button;
-
-		} else {
-
-			const message = document.createElement( 'a' );
-
-			if ( window.isSecureContext === false ) {
-
-				message.href = document.location.href.replace( /^http:/, 'https:' );
-				message.innerHTML = 'WEBXR NEEDS HTTPS'; // TODO Improve message
-
-			} else {
-
-				message.href = 'https://immersiveweb.dev/';
-				message.innerHTML = 'WEBXR NOT AVAILABLE';
-
-			}
-
-			message.style.left = 'calc(50% - 90px)';
-			message.style.width = '180px';
-			message.style.textDecoration = 'none';
-
-			stylizeElement( message );
-
-			return message;
-
-		}
+		super( renderer, sessionInit );
+		this.id = 'VRbutton';
+		this.stopLabel = 'EXIT VR';
+		this.startLabel = 'ENTER VR';
+		this.notSupportedLabel = 'VR NOT SUPPORTED';
+		this.notAllowedLabel = 'VR NOT ALLOWED';
 
 	}
 
-	static registerSessionGrantedListener() {
-
-		if ( typeof navigator !== 'undefined' && 'xr' in navigator ) {
-
-			// WebXRViewer (based on Firefox) has a bug where addEventListener
-			// throws a silent exception and aborts execution entirely.
-			if ( /WebXRViewer\//i.test( navigator.userAgent ) ) return;
-
-			navigator.xr.addEventListener( 'sessiongranted', () => {
-
-				VRButton.xrSessionIsGranted = true;
-
-			} );
-
+	static createButton(
+		renderer,
+		sessionInit = {
+			// These have been kept for historical reasons: the previous
+			// implementation of VRButton set these optional features. This
+			// way, developers relying on the previous implementation can
+			// still use the same code.
+			//
+			// Original implementation's comment:
+			//
+			// WebXR's requestReferenceSpace only works if the corresponding feature
+			// was requested at session creation time. For simplicity, just ask for
+			// the interesting ones as optional features, but be aware that the
+			// requestReferenceSpace call will fail if it turns out to be unavailable.
+			// ('local' is always available for immersive sessions and doesn't need to
+			// be requested separately.)
+			optionalFeatures: [
+				'local-floor',
+				'bounded-floor',
+				'hand-tracking',
+				'layers',
+			],
 		}
+	) {
+
+		const vrButtonInstance = new VRButton( renderer, sessionInit );
+		return vrButtonInstance.createButtonElement();
+
+	}
+
+	async getSessionMode( xr ) {
+
+		const isSupported = await xr.isSessionSupported( 'immersive-vr' );
+		return isSupported ? 'immersive-vr' : null;
 
 	}
 
 }
-
-VRButton.xrSessionIsGranted = false;
-VRButton.registerSessionGrantedListener();
 
 export { VRButton };

--- a/examples/jsm/webxr/WebXRButton.js
+++ b/examples/jsm/webxr/WebXRButton.js
@@ -1,0 +1,194 @@
+class WebXRButton {
+
+	constructor( renderer, sessionOptions ) {
+
+		this.renderer = renderer;
+		this.sessionOptions = sessionOptions;
+		this.currentSession = null;
+		this.button = null;
+		this.id = 'WebXRButton';
+		this.stopLabel = 'STOP WEBXR';
+		this.startLabel = 'START WEBXR';
+		this.notSupportedLabel = 'WEBXR NOT SUPPORTED';
+		this.notAllowedLabel = 'WEBXR NOT ALLOWED';
+
+	}
+
+	createButtonElement() {
+
+		const button = document.createElement( 'button' );
+		this.button = button;
+
+		if ( 'xr' in navigator ) {
+
+			button.id = this.id;
+			button.style.display = 'none';
+			this.stylizeElement( button );
+
+			this.getSessionMode( navigator.xr )
+				.then( ( mode ) => {
+
+					mode ? this.showStart( mode ) : this.showNotSupported();
+
+				} )
+				.catch( this.showNotAllowed );
+
+			return button;
+
+		} else {
+
+			return this.createErrorMessage();
+
+		}
+
+	}
+
+	async getSessionMode( xr ) {
+
+		const isSupported = await xr.isSessionSupported( 'inline' );
+		return isSupported ? 'inline' : null;
+
+	}
+
+	async onSessionStarted( session ) {
+
+		session.addEventListener( 'end', this.onSessionEnded );
+		await this.renderer.xr.setSession( session );
+
+		this.button.textContent = this.stopLabel;
+		this.currentSession = session;
+
+	}
+
+	onSessionEnded() {
+
+		this.currentSession.removeEventListener( 'end', this.onSessionEnded );
+		this.button.textContent = this.startLabel;
+		this.currentSession = null;
+
+	}
+
+	showStart( mode ) {
+
+		this.currentSession = null;
+
+		this.button.style.display = '';
+
+		this.button.style.cursor = 'pointer';
+		this.button.style.left = 'calc(50% - 50px)';
+		this.button.style.width = '100px';
+
+		this.button.textContent = this.startLabel;
+
+		this.button.onmouseenter = () => {
+
+			this.button.style.opacity = '1.0';
+
+		};
+
+		this.button.onmouseleave = () => {
+
+			this.button.style.opacity = '0.5';
+
+		};
+
+		this.button.onclick = () => {
+
+			if ( this.currentSession === null ) {
+
+				navigator.xr
+					.requestSession( mode, this.sessionOptions )
+					.then( this.onSessionStarted.bind( this ) );
+
+			} else {
+
+				this.currentSession.end();
+
+			}
+
+		};
+
+	}
+
+	disableButton() {
+
+		this.button.style.display = '';
+
+		this.button.style.cursor = 'auto';
+		this.button.style.left = 'calc(50% - 75px)';
+		this.button.style.width = '150px';
+
+		this.button.onmouseenter = null;
+		this.button.onmouseleave = null;
+
+		this.button.onclick = null;
+
+	}
+
+	showNotSupported() {
+
+		this.disableButton();
+
+		this.button.textContent = this.notSupportedLabel;
+
+	}
+
+	showNotAllowed( exception ) {
+
+		this.disableButton();
+
+		console.warn(
+			'Exception when trying to call xr.isSessionSupported',
+			exception
+		);
+
+		this.button.textContent = this.notAllowedLabel;
+
+	}
+
+	stylizeElement( element ) {
+
+		element.style.position = 'absolute';
+		element.style.bottom = '20px';
+		element.style.padding = '12px 6px';
+		element.style.border = '1px solid #fff';
+		element.style.borderRadius = '4px';
+		element.style.background = 'rgba(0,0,0,0.1)';
+		element.style.color = '#fff';
+		element.style.font = 'normal 13px sans-serif';
+		element.style.textAlign = 'center';
+		element.style.opacity = '0.5';
+		element.style.outline = 'none';
+		element.style.zIndex = '999';
+
+	}
+
+	createErrorMessage() {
+
+		const message = document.createElement( 'a' );
+
+		if ( window.isSecureContext === false ) {
+
+			message.href = document.location.href.replace( /^http:/, 'https:' );
+			message.innerHTML = 'WEBXR NEEDS HTTPS'; // TODO Improve message
+
+		} else {
+
+			message.href = 'https://immersiveweb.dev/';
+			message.innerHTML = 'WEBXR NOT AVAILABLE';
+
+		}
+
+		message.style.left = 'calc(50% - 90px)';
+		message.style.width = '180px';
+		message.style.textDecoration = 'none';
+
+		this.stylizeElement( message );
+
+		return message;
+
+	}
+
+}
+
+export { WebXRButton };

--- a/examples/jsm/webxr/XRButton.js
+++ b/examples/jsm/webxr/XRButton.js
@@ -5,7 +5,7 @@ class XRButton extends WebXRButton {
 	constructor( renderer, sessionOptions ) {
 
 		super( renderer, sessionOptions );
-		this.id = 'XRbutton';
+		this.id = 'XRButton';
 		this.stopLabel = 'STOP XR';
 		this.startLabel = 'START XR';
 		this.notSupportedLabel = 'XR NOT SUPPORTED';
@@ -26,8 +26,8 @@ class XRButton extends WebXRButton {
 			],
 		};
 
-		const arButtonInstance = new XRButton( renderer, sessionOptions );
-		return arButtonInstance.createButtonElement();
+		const xrButtonInstance = new XRButton( renderer, sessionOptions );
+		return xrButtonInstance.createButtonElement();
 
 	}
 

--- a/examples/jsm/webxr/XRButton.js
+++ b/examples/jsm/webxr/XRButton.js
@@ -1,197 +1,45 @@
-class XRButton {
+import { WebXRButton } from './WebXRButton.js';
+
+class XRButton extends WebXRButton {
+
+	constructor( renderer, sessionOptions ) {
+
+		super( renderer, sessionOptions );
+		this.id = 'XRbutton';
+		this.stopLabel = 'STOP XR';
+		this.startLabel = 'START XR';
+		this.notSupportedLabel = 'XR NOT SUPPORTED';
+		this.notAllowedLabel = 'XR NOT ALLOWED';
+
+	}
 
 	static createButton( renderer, sessionInit = {} ) {
 
-		const button = document.createElement( 'button' );
-
-		function showStartXR( mode ) {
-
-			let currentSession = null;
-
-			async function onSessionStarted( session ) {
-
-				session.addEventListener( 'end', onSessionEnded );
-
-				await renderer.xr.setSession( session );
-
-				button.textContent = 'STOP XR';
-
-				currentSession = session;
-
-			}
-
-			function onSessionEnded( /*event*/ ) {
-
-				currentSession.removeEventListener( 'end', onSessionEnded );
-
-				button.textContent = 'START XR';
-
-				currentSession = null;
-
-			}
-
-			//
-
-			button.style.display = '';
-
-			button.style.cursor = 'pointer';
-			button.style.left = 'calc(50% - 50px)';
-			button.style.width = '100px';
-
-			button.textContent = 'START XR';
-
-			button.onmouseenter = function () {
-
-				button.style.opacity = '1.0';
-
-			};
-
-			button.onmouseleave = function () {
-
-				button.style.opacity = '0.5';
-
-			};
-
-			button.onclick = function () {
-
-				if ( currentSession === null ) {
-
-					const sessionOptions = {
-						...sessionInit,
-						optionalFeatures: [
-							'local-floor',
-							'bounded-floor',
-							'hand-tracking',
-							'layers',
-							...( sessionInit.optionalFeatures || [] )
-						],
-					};
-
-					navigator.xr.requestSession( mode, sessionOptions )
-						.then( onSessionStarted );
-
-				} else {
-
-					currentSession.end();
-
-				}
-
-			};
-
-		}
-
-		function disableButton() {
-
-			button.style.display = '';
-
-			button.style.cursor = 'auto';
-			button.style.left = 'calc(50% - 75px)';
-			button.style.width = '150px';
-
-			button.onmouseenter = null;
-			button.onmouseleave = null;
-
-			button.onclick = null;
-
-		}
-
-		function showXRNotSupported() {
-
-			disableButton();
-
-			button.textContent = 'XR NOT SUPPORTED';
-
-		}
-
-		function showXRNotAllowed( exception ) {
-
-			disableButton();
-
-			console.warn( 'Exception when trying to call xr.isSessionSupported', exception );
-
-			button.textContent = 'XR NOT ALLOWED';
-
-		}
-
-		function stylizeElement( element ) {
-
-			element.style.position = 'absolute';
-			element.style.bottom = '20px';
-			element.style.padding = '12px 6px';
-			element.style.border = '1px solid #fff';
-			element.style.borderRadius = '4px';
-			element.style.background = 'rgba(0,0,0,0.1)';
-			element.style.color = '#fff';
-			element.style.font = 'normal 13px sans-serif';
-			element.style.textAlign = 'center';
-			element.style.opacity = '0.5';
-			element.style.outline = 'none';
-			element.style.zIndex = '999';
-
-		}
-
-		if ( 'xr' in navigator ) {
-
-			button.id = 'XRButton';
-			button.style.display = 'none';
-
-			stylizeElement( button );
-
-			navigator.xr.isSessionSupported( 'immersive-ar' )
-				.then( function ( supported ) {
-
-					if ( supported ) {
-
-						showStartXR( 'immersive-ar' );
-
-					} else {
-
-						navigator.xr.isSessionSupported( 'immersive-vr' )
-							.then( function ( supported ) {
-
-								if ( supported ) {
-
-									showStartXR( 'immersive-vr' );
-
-								} else {
-
-									showXRNotSupported();
-
-								}
-
-							} ).catch( showXRNotAllowed );
-
-					}
-
-				} ).catch( showXRNotAllowed );
-
-			return button;
-
-		} else {
-
-			const message = document.createElement( 'a' );
-
-			if ( window.isSecureContext === false ) {
-
-				message.href = document.location.href.replace( /^http:/, 'https:' );
-				message.innerHTML = 'WEBXR NEEDS HTTPS'; // TODO Improve message
-
-			} else {
-
-				message.href = 'https://immersiveweb.dev/';
-				message.innerHTML = 'WEBXR NOT AVAILABLE';
-
-			}
-
-			message.style.left = 'calc(50% - 90px)';
-			message.style.width = '180px';
-			message.style.textDecoration = 'none';
-
-			stylizeElement( message );
-
-			return message;
-
-		}
+		const sessionOptions = {
+			...sessionInit,
+			optionalFeatures: [
+				'local-floor',
+				'bounded-floor',
+				'hand-tracking',
+				'layers',
+				...( sessionInit.optionalFeatures || [] ),
+			],
+		};
+
+		const arButtonInstance = new XRButton( renderer, sessionOptions );
+		return arButtonInstance.createButtonElement();
+
+	}
+
+	async getSessionMode( xr ) {
+
+		const isARSupported = await xr.isSessionSupported( 'immersive-ar' );
+		if ( isARSupported ) return 'immersive-ar';
+
+		const isVRSupported = await xr.isSessionSupported( 'immersive-vr' );
+		if ( isVRSupported ) return 'immersive-vr';
+
+		return null;
 
 	}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/27030

**Description**

Unify the various WebXR buttons (`ARButton`, `VRButton` and `XRButton`) so that they share code that previously was repeated between them.

This is so that if, say, a styling change is made in the base class, it gets reflected on all of them.

Keep the user-facing API as it was before so that previous users of the buttons aren't disrupted.
