### PR TITLE
HTMLMesh: create canvas in its original position instead of (0,0)

### DIFF
--- a/examples/jsm/interactive/HTMLMesh.js
+++ b/examples/jsm/interactive/HTMLMesh.js
@@ -267,10 +267,15 @@ function html2canvas( element ) {
 			// Canvas element
 			if ( element.style.display === 'none' ) return;
 
-			context.save();
+			const rect = element.getBoundingClientRect();
+
+			x = rect.left - offset.left - 0.5;
+			y = rect.top - offset.top - 0.5;
+
+		        context.save();
 			const dpr = window.devicePixelRatio;
 			context.scale( 1 / dpr, 1 / dpr );
-			context.drawImage( element, 0, 0 );
+			context.drawImage( element, x, y );
 			context.restore();
 
 		} else if ( element instanceof HTMLImageElement ) {


### PR DESCRIPTION
Related issue: [AdaRoseCannon/aframe-htmlmesh/pull/19](https://github.com/AdaRoseCannon/aframe-htmlmesh/pull/19) and https://github.com/mrdoob/three.js/pull/25916

Similar to what has been done for images, this change introduces that canvas elements are also rendered in position rather than 0,0

All the best

