### PR TITLE
HTMLMesh: Clear the canvas before starting to draw

### DIFF
--- a/examples/jsm/interactive/HTMLMesh.js
+++ b/examples/jsm/interactive/HTMLMesh.js
@@ -501,6 +501,8 @@ function html2canvas( element ) {
 
 	// console.time( 'drawElement' );
 
+	context.clearRect(0, 0, canvas.width, canvas.height);
+
 	drawElement( element );
 
 	// console.timeEnd( 'drawElement' );


### PR DESCRIPTION
Related issue: [AdaRoseCannon/aframe-htmlmesh/pull/20](https://github.com/AdaRoseCannon/aframe-htmlmesh/pull/20)

In related issue, @vincentfretin suggests that a better fix would be to clear the whole canvas every time at the beginning. I think this makes sense, as the mesh is meant to be completely redrawn on update.

The proposed change implements the suggestions and clears the whole canvas first thing before starting to draw.

All the best