### PR TITLE
WebGLNodes: Ensure `onBuild()` uses the correct material reference.

### DIFF
--- a/examples/jsm/renderers/webgl-legacy/nodes/WebGLNodes.js
+++ b/examples/jsm/renderers/webgl-legacy/nodes/WebGLNodes.js
@@ -24,7 +24,7 @@ Material.prototype.onBuild = function ( object, parameters, renderer ) {
 
 	} else if ( material.isNodeMaterial === true ) {
 
-		builders.set( material, new WebGLNodeBuilder( object, renderer, parameters ).build() );
+		builders.set( material, new WebGLNodeBuilder( object, renderer, parameters, material ).build() );
 
 	}
 

--- a/examples/jsm/renderers/webgl-legacy/nodes/WebGLNodes.js
+++ b/examples/jsm/renderers/webgl-legacy/nodes/WebGLNodes.js
@@ -8,21 +8,23 @@ export const nodeFrame = new NodeFrame();
 
 Material.prototype.onBuild = function ( object, parameters, renderer ) {
 
-	if ( Array.isArray( object.material ) ) {
+	const material = this;
 
-		for ( const material of object.material ) {
+	if ( Array.isArray( material ) ) {
 
-			if ( material.isNodeMaterial === true ) {
+		for ( const m of material ) {
 
-				builders.set( material, new WebGLNodeBuilder( object, renderer, parameters, material ).build() );
+			if ( m.isNodeMaterial === true ) {
+
+				builders.set( m, new WebGLNodeBuilder( object, renderer, parameters, m ).build() );
 
 			}
 
 		}
 
-	} else if ( object.material.isNodeMaterial === true ) {
+	} else if ( material.isNodeMaterial === true ) {
 
-		builders.set( object.material, new WebGLNodeBuilder( object, renderer, parameters ).build() );
+		builders.set( material, new WebGLNodeBuilder( object, renderer, parameters ).build() );
 
 	}
 

--- a/examples/jsm/renderers/webgl-legacy/nodes/WebGLNodes.js
+++ b/examples/jsm/renderers/webgl-legacy/nodes/WebGLNodes.js
@@ -10,19 +10,7 @@ Material.prototype.onBuild = function ( object, parameters, renderer ) {
 
 	const material = this;
 
-	if ( Array.isArray( material ) ) {
-
-		for ( const m of material ) {
-
-			if ( m.isNodeMaterial === true ) {
-
-				builders.set( m, new WebGLNodeBuilder( object, renderer, parameters, m ).build() );
-
-			}
-
-		}
-
-	} else if ( material.isNodeMaterial === true ) {
+	if ( material.isNodeMaterial === true ) {
 
 		builders.set( material, new WebGLNodeBuilder( object, renderer, parameters, material ).build() );
 


### PR DESCRIPTION
Fixed #27095.

**Description**

This PR ensures `WebGLNodes` can process renderings with an active `overrideMaterial`.

The fix is actually simple. `Material.onBuild()` does not extract the material from the 3D object anymore but uses `this` instead.