### PR TITLE
TSL Editor Example: Disable Minimap

### DIFF
--- a/examples/webgpu_tsl_editor.html
+++ b/examples/webgpu_tsl_editor.html
@@ -156,7 +156,8 @@ output = vec4( finalColor, opacity );
 						value: tslCode,
 						language: 'javascript',
 						theme: 'vs-dark',
-						automaticLayout: true
+						automaticLayout: true,
+						minimap: { enabled: false }
 					} );
 
 					const result = window.monaco.editor.create( resultDOM, {
@@ -164,7 +165,8 @@ output = vec4( finalColor, opacity );
 						language: 'wgsl',
 						theme: 'vs-dark',
 						automaticLayout: true,
-						readOnly: true
+						readOnly: true,
+						minimap: { enabled: false }
 					} );
 
 					const showCode = () => {


### PR DESCRIPTION
The Minimap gets in the way of Lil-gui, and is likely not needed in this example.