### PR TITLE
Skinning Shaders: Remove need skinning texture size uniform by using textureSize function

### DIFF
--- a/src/objects/Skeleton.js
+++ b/src/objects/Skeleton.js
@@ -21,7 +21,6 @@ class Skeleton {
 		this.boneMatrices = null;
 
 		this.boneTexture = null;
-		this.boneTextureSize = 0;
 
 		this.init();
 
@@ -180,7 +179,6 @@ class Skeleton {
 
 		this.boneMatrices = boneMatrices;
 		this.boneTexture = boneTexture;
-		this.boneTextureSize = size;
 
 		return this;
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1975,7 +1975,6 @@ class WebGLRenderer {
 						if ( skeleton.boneTexture === null ) skeleton.computeBoneTexture();
 
 						p_uniforms.setValue( _gl, 'boneTexture', skeleton.boneTexture, textures );
-						p_uniforms.setValue( _gl, 'boneTextureSize', skeleton.boneTextureSize );
 
 					} else {
 

--- a/src/renderers/shaders/ShaderChunk/skinning_pars_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/skinning_pars_vertex.glsl.js
@@ -8,25 +8,16 @@ export default /* glsl */`
 
 	mat4 getBoneMatrix( const in float i ) {
 
-		float boneTextureSize = textureSize( boneTexture, 0 ).x;
+		int size = textureSize( boneTexture, 0 ).x;
+		int j = int( i ) * 4;
+		int x = j % size;
+		int y = j / size;
+		vec4 v1 = texelFetch( boneTexture, ivec2( x, y ), 0 );
+		vec4 v2 = texelFetch( boneTexture, ivec2( x + 1, y ), 0 );
+		vec4 v3 = texelFetch( boneTexture, ivec2( x + 2, y ), 0 );
+		vec4 v4 = texelFetch( boneTexture, ivec2( x + 3, y ), 0 );
 
-		float j = i * 4.0;
-		float x = mod( j, boneTextureSize );
-		float y = floor( j / boneTextureSize );
-
-		float dx = 1.0 / boneTextureSize;
-		float dy = 1.0 / boneTextureSize;
-
-		y = dy * ( y + 0.5 );
-
-		vec4 v1 = texture2D( boneTexture, vec2( dx * ( x + 0.5 ), y ) );
-		vec4 v2 = texture2D( boneTexture, vec2( dx * ( x + 1.5 ), y ) );
-		vec4 v3 = texture2D( boneTexture, vec2( dx * ( x + 2.5 ), y ) );
-		vec4 v4 = texture2D( boneTexture, vec2( dx * ( x + 3.5 ), y ) );
-
-		mat4 bone = mat4( v1, v2, v3, v4 );
-
-		return bone;
+		return mat4( v1, v2, v3, v4 );
 
 	}
 

--- a/src/renderers/shaders/ShaderChunk/skinning_pars_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/skinning_pars_vertex.glsl.js
@@ -5,16 +5,17 @@ export default /* glsl */`
 	uniform mat4 bindMatrixInverse;
 
 	uniform highp sampler2D boneTexture;
-	uniform int boneTextureSize;
 
 	mat4 getBoneMatrix( const in float i ) {
 
-		float j = i * 4.0;
-		float x = mod( j, float( boneTextureSize ) );
-		float y = floor( j / float( boneTextureSize ) );
+		float boneTextureSize = textureSize( boneTexture, 0 ).x;
 
-		float dx = 1.0 / float( boneTextureSize );
-		float dy = 1.0 / float( boneTextureSize );
+		float j = i * 4.0;
+		float x = mod( j, boneTextureSize );
+		float y = floor( j / boneTextureSize );
+
+		float dx = 1.0 / boneTextureSize;
+		float dy = 1.0 / boneTextureSize;
 
 		y = dy * ( y + 0.5 );
 


### PR DESCRIPTION
Related issue: --

**Description**

Similar to what's used in batching - use the `textureSize` function to get the texture size, instead. WebGL2 only but Skinning already requires webgl 2.