### PR TITLE
Skeleton: Clean up.

### DIFF
--- a/docs/api/ar/objects/Skeleton.html
+++ b/docs/api/ar/objects/Skeleton.html
@@ -76,10 +76,7 @@
 		<p>
 		[page:DataTexture] التي تحمل بيانات العظام عند استخدام نسيج الرأس.
 		</p>
-		
-		<h3>[property:Integer boneTextureSize]</h3>
-		<p>حجم [page:.boneTexture].</p>
-		
+
 		<h2>الطرق (Methods)</h2>
 		
 		<h3>[method:Skeleton clone]()</h3>

--- a/docs/api/en/objects/Skeleton.html
+++ b/docs/api/en/objects/Skeleton.html
@@ -77,9 +77,6 @@
 			The [page:DataTexture] holding the bone data when using a vertex texture.
 		</p>
 
-		<h3>[property:Integer boneTextureSize]</h3>
-		<p>The size of the [page:.boneTexture].</p>
-
 		<h2>Methods</h2>
 
 		<h3>[method:Skeleton clone]()</h3>

--- a/docs/api/it/objects/Skeleton.html
+++ b/docs/api/it/objects/Skeleton.html
@@ -79,11 +79,6 @@
 			Il [page:DataTexture] che contiene i dati dell'osso quando si utilizza una texture di vertice.
 		</p>
 
-		<h3>[property:Integer boneTextureSize]</h3>
-		<p>
-			La dimensione del [page:.boneTexture].
-		</p>
-
 		<h2>Metodi</h2>
 
 		<h3>[method:Skeleton clone]()</h3>

--- a/docs/api/zh/objects/Skeleton.html
+++ b/docs/api/zh/objects/Skeleton.html
@@ -76,11 +76,6 @@
 		当使用顶点纹理时，[page:DataTexture]保存着骨骼数据。
 		</p>
 
-		<h3>[property:Integer boneTextureSize]</h3>
-		<p>
-		The size of the [page:.boneTexture].
-		</p>
-
 		<h2>方法</h2>
 
 		<h3>[method:Skeleton clone]()</h3>

--- a/test/unit/src/objects/Skeleton.tests.js
+++ b/test/unit/src/objects/Skeleton.tests.js
@@ -45,12 +45,6 @@ export default QUnit.module( 'Objects', () => {
 
 		} );
 
-		QUnit.todo( 'boneTextureSize', ( assert ) => {
-
-			assert.ok( false, 'everything\'s gonna be alright' );
-
-		} );
-
 		QUnit.todo( 'frame', ( assert ) => {
 
 			assert.ok( false, 'everything\'s gonna be alright' );


### PR DESCRIPTION
Related issue: #27117

**Description**

Removes the remaining references to `boneTextureSize`.
