### PR TITLE
Shaders: Add support for transforming instanced mesh tangents

### DIFF
--- a/src/renderers/shaders/ShaderChunk/defaultnormal_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/defaultnormal_vertex.glsl.js
@@ -19,7 +19,6 @@ vec3 transformedNormal = objectNormal;
 
 	#ifdef USE_TANGENT
 
-		transformedTangent /= vec3( dot( bm[ 0 ], bm[ 0 ] ), dot( bm[ 1 ], bm[ 1 ] ), dot( bm[ 2 ], bm[ 2 ] ) );
 		transformedTangent = bm * transformedTangent;
 
 	#endif
@@ -37,7 +36,6 @@ vec3 transformedNormal = objectNormal;
 
 	#ifdef USE_TANGENT
 
-		transformedTangent /= vec3( dot( im[ 0 ], im[ 0 ] ), dot( im[ 1 ], im[ 1 ] ), dot( im[ 2 ], im[ 2 ] ) );
 		transformedTangent = im * transformedTangent;
 
 	#endif

--- a/src/renderers/shaders/ShaderChunk/defaultnormal_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/defaultnormal_vertex.glsl.js
@@ -1,5 +1,12 @@
 export default /* glsl */`
 
+vec3 transformedNormal = objectNormal;
+#ifdef USE_TANGENT
+
+	vec3 transformedTangent = objectTangent;
+
+#endif
+
 #ifdef USE_BATCHING
 
 	// this is in lieu of a per-instance normal-matrix
@@ -7,30 +14,33 @@ export default /* glsl */`
 
 	mat4 batchingMatrix = getBatchingMatrix( batchId );
 	mat3 bm = mat3( batchingMatrix );
-	objectNormal /= vec3( dot( bm[ 0 ], bm[ 0 ] ), dot( bm[ 1 ], bm[ 1 ] ), dot( bm[ 2 ], bm[ 2 ] ) );
-	objectNormal = bm * objectNormal;
+	transformedNormal /= vec3( dot( bm[ 0 ], bm[ 0 ] ), dot( bm[ 1 ], bm[ 1 ] ), dot( bm[ 2 ], bm[ 2 ] ) );
+	transformedNormal = bm * transformedNormal;
 
 	#ifdef USE_TANGENT
 
-		objectTangent /= vec3( dot( bm[ 0 ], bm[ 0 ] ), dot( bm[ 1 ], bm[ 1 ] ), dot( bm[ 2 ], bm[ 2 ] ) );
-		objectTangent = bm * objectTangent;
+		transformedTangent /= vec3( dot( bm[ 0 ], bm[ 0 ] ), dot( bm[ 1 ], bm[ 1 ] ), dot( bm[ 2 ], bm[ 2 ] ) );
+		transformedTangent = bm * transformedTangent;
 
 	#endif
 
 #endif
-
-vec3 transformedNormal = objectNormal;
 
 #ifdef USE_INSTANCING
 
 	// this is in lieu of a per-instance normal-matrix
 	// shear transforms in the instance matrix are not supported
 
-	mat3 m = mat3( instanceMatrix );
+	mat3 im = mat3( instanceMatrix );
+	transformedNormal /= vec3( dot( im[ 0 ], im[ 0 ] ), dot( im[ 1 ], im[ 1 ] ), dot( im[ 2 ], im[ 2 ] ) );
+	transformedNormal = im * transformedNormal;
 
-	transformedNormal /= vec3( dot( m[ 0 ], m[ 0 ] ), dot( m[ 1 ], m[ 1 ] ), dot( m[ 2 ], m[ 2 ] ) );
+	#ifdef USE_TANGENT
 
-	transformedNormal = m * transformedNormal;
+		transformedTangent /= vec3( dot( im[ 0 ], im[ 0 ] ), dot( im[ 1 ], im[ 1 ] ), dot( im[ 2 ], im[ 2 ] ) );
+		transformedTangent = im * transformedTangent;
+
+	#endif
 
 #endif
 
@@ -44,7 +54,7 @@ transformedNormal = normalMatrix * transformedNormal;
 
 #ifdef USE_TANGENT
 
-	vec3 transformedTangent = ( modelViewMatrix * vec4( objectTangent, 0.0 ) ).xyz;
+	transformedTangent = ( modelViewMatrix * vec4( transformedTangent, 0.0 ) ).xyz;
 
 	#ifdef FLIP_SIDED
 


### PR DESCRIPTION
Fix #27116

**Description**

- Pulls the "transformedTangent" variable to the beginning of the shader block.
- Ensure the batched geometry block modifies "transformedNormal" and "transformedTangent" rather than the "objectNormal" and "objectTangent" variants.
- Ensure instanced geometry correct transform tangents.