### PR TITLE
BatchedMesh: Add "toJSON" and "copy" support

### DIFF
--- a/examples/jsm/objects/BatchedMesh.js
+++ b/examples/jsm/objects/BatchedMesh.js
@@ -589,12 +589,6 @@ class BatchedMesh extends Mesh {
 
 	}
 
-	toJSON() {
-
-		throw new Error( 'BatchedMesh: toJSON function not implemented.' );
-
-	}
-
 	dispose() {
 
 		// Assuming the geometry is not shared with other meshes

--- a/examples/jsm/objects/BatchedMesh.js
+++ b/examples/jsm/objects/BatchedMesh.js
@@ -582,7 +582,7 @@ class BatchedMesh extends Mesh {
 		this._geometryInitialized = source._geometryInitialized;
 		this._geometryCount = source._geometryCount;
 		this._multiDrawCounts = source._multiDrawCounts.slice();
-		this._multiDrawStarts = source._multiDrawCounts.slice();
+		this._multiDrawStarts = source._multiDrawStarts.slice();
 
 		this._matricesTexture = source._matricesTexture.clone();
 		this._matricesTexture.image.data = this._matricesTexture.image.slice();

--- a/examples/jsm/objects/BatchedMesh.js
+++ b/examples/jsm/objects/BatchedMesh.js
@@ -563,11 +563,29 @@ class BatchedMesh extends Mesh {
 
 	}
 
-	copy() {
+	copy( source ) {
 
-		// super.copy( source );
+		super.copy( source );
 
-		throw new Error( 'BatchedMesh: Copy function not implemented.' );
+		this.geometry = source.geometry.clone();
+
+		this._drawRanges = source._drawRanges.map( range => ( { ...range } ) );
+		this._reservedRanges = source._reservedRanges.map( range => ( { ...range } ) );
+
+		this._visible = source._visible.slice();
+		this._active = source._active.slice();
+
+		this._maxGeometryCount = source._maxGeometryCount;
+		this._maxVertexCount = source._maxVertexCount;
+		this._maxIndexCount = source._maxIndexCount;
+
+		this._geometryInitialized = source._geometryInitialized;
+		this._geometryCount = source._geometryCount;
+		this._multiDrawCounts = source._multiDrawCounts.slice();
+		this._multiDrawStarts = source._multiDrawCounts.slice();
+
+		this._matricesTexture = source._matricesTexture.clone();
+		this._matricesTexture.image.data = this._matricesTexture.image.slice();
 
 	}
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -719,6 +719,26 @@ class Object3D extends EventDispatcher {
 
 		}
 
+		if ( this.isBatchedMesh ) {
+
+			object.type = 'BatchedMesh';
+			object._drawRanges = this._drawRanges;
+			object._reservedRanges = this._reservedRanges;
+
+			object._visible = this._visible;
+			object._active = this._active;
+
+			object._maxGeometryCount = this._maxGeometryCount;
+			object._maxVertexCount = this._maxVertexCount;
+			object._maxIndexCount = this._maxIndexCount;
+
+			object._geometryInitialized = this._geometryInitialized;
+			object._geometryCount = this._geometryCount;
+
+			object._matricesTexture = this._matricesTexture.toJSON();
+
+		}
+
 		//
 
 		function serialize( library, element ) {

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -722,20 +722,20 @@ class Object3D extends EventDispatcher {
 		if ( this.isBatchedMesh ) {
 
 			object.type = 'BatchedMesh';
-			object._drawRanges = this._drawRanges;
-			object._reservedRanges = this._reservedRanges;
+			object.drawRanges = this._drawRanges;
+			object.reservedRanges = this._reservedRanges;
 
-			object._visible = this._visible;
-			object._active = this._active;
+			object.visible = this._visible;
+			object.active = this._active;
 
-			object._maxGeometryCount = this._maxGeometryCount;
-			object._maxVertexCount = this._maxVertexCount;
-			object._maxIndexCount = this._maxIndexCount;
+			object.maxGeometryCount = this._maxGeometryCount;
+			object.maxVertexCount = this._maxVertexCount;
+			object.maxIndexCount = this._maxIndexCount;
 
-			object._geometryInitialized = this._geometryInitialized;
-			object._geometryCount = this._geometryCount;
+			object.geometryInitialized = this._geometryInitialized;
+			object.geometryCount = this._geometryCount;
 
-			object._matricesTexture = this._matricesTexture.toJSON();
+			object.matricesTexture = this._matricesTexture.toJSON();
 
 		}
 


### PR DESCRIPTION
Related issue: #22376, #27111 

**Description**

Add support for "toJSON" and "copy" to "BatchedMesh".

**Upcoming PRs**
- Raycasting, sorting support
- Object-level bounds
- Add support to ObjectLoader
- Move to core
- Documentation