### PR TITLE
WebGPURenderer: Uniform Group

### DIFF
--- a/examples/jsm/nodes/Nodes.js
+++ b/examples/jsm/nodes/Nodes.js
@@ -30,6 +30,7 @@ export { default as ParameterNode, parameter } from './core/ParameterNode.js';
 export { default as PropertyNode, property, output, diffuseColor, roughness, metalness, clearcoat, clearcoatRoughness, sheen, sheenRoughness, iridescence, iridescenceIOR, iridescenceThickness, specularColor, shininess, dashSize, gapSize, pointWidth } from './core/PropertyNode.js';
 export { default as StackNode, stack } from './core/StackNode.js';
 export { default as TempNode } from './core/TempNode.js';
+export { default as UniformGroupNode, uniformGroup, objectGroup, renderGroup, frameGroup } from './core/UniformGroupNode.js';
 export { default as UniformNode, uniform } from './core/UniformNode.js';
 export { default as VaryingNode, varying } from './core/VaryingNode.js';
 export { default as OutputStructNode, outputStruct } from './core/OutputStructNode.js';

--- a/examples/jsm/nodes/accessors/CameraNode.js
+++ b/examples/jsm/nodes/accessors/CameraNode.js
@@ -1,13 +1,21 @@
 import Object3DNode from './Object3DNode.js';
 import { addNodeClass } from '../core/Node.js';
 import { label } from '../core/ContextNode.js';
+import { NodeUpdateType } from '../core/constants.js';
+//import { sharedUniformGroup } from '../core/UniformGroupNode.js';
 import { nodeImmutable } from '../shadernode/ShaderNode.js';
+
+//const cameraGroup = sharedUniformGroup( 'camera' );
 
 class CameraNode extends Object3DNode {
 
 	constructor( scope = CameraNode.POSITION ) {
 
 		super( scope );
+
+		this.updateType = NodeUpdateType.RENDER;
+
+		//this._uniformNode.groupNode = cameraGroup;
 
 	}
 
@@ -34,6 +42,8 @@ class CameraNode extends Object3DNode {
 		const camera = frame.camera;
 		const uniformNode = this._uniformNode;
 		const scope = this.scope;
+
+		//cameraGroup.needsUpdate = true;
 
 		if ( scope === CameraNode.VIEW_MATRIX ) {
 

--- a/examples/jsm/nodes/accessors/MaterialReferenceNode.js
+++ b/examples/jsm/nodes/accessors/MaterialReferenceNode.js
@@ -1,5 +1,6 @@
 import ReferenceNode from './ReferenceNode.js';
-import { NodeUpdateType } from '../core/constants.js';
+//import { renderGroup } from '../core/UniformGroupNode.js';
+//import { NodeUpdateType } from '../core/constants.js';
 import { addNodeClass } from '../core/Node.js';
 import { nodeObject } from '../shadernode/ShaderNode.js';
 
@@ -11,9 +12,17 @@ class MaterialReferenceNode extends ReferenceNode {
 
 		this.material = material;
 
-		this.updateType = NodeUpdateType.RENDER;
+		//this.updateType = NodeUpdateType.RENDER;
 
 	}
+
+	/*setNodeType( node ) {
+
+		super.setNodeType( node );
+
+		this.node.groupNode = renderGroup;
+
+	}*/
 
 	updateReference( frame ) {
 

--- a/examples/jsm/nodes/accessors/ModelNode.js
+++ b/examples/jsm/nodes/accessors/ModelNode.js
@@ -23,7 +23,7 @@ class ModelNode extends Object3DNode {
 export default ModelNode;
 
 export const modelDirection = nodeImmutable( ModelNode, ModelNode.DIRECTION );
-export const modelViewMatrix = nodeImmutable( ModelNode, ModelNode.VIEW_MATRIX ).temp( 'ModelViewMatrix' );
+export const modelViewMatrix = nodeImmutable( ModelNode, ModelNode.VIEW_MATRIX ).label( 'modelViewMatrix' ).temp( 'ModelViewMatrix' );
 export const modelNormalMatrix = nodeImmutable( ModelNode, ModelNode.NORMAL_MATRIX );
 export const modelWorldMatrix = nodeImmutable( ModelNode, ModelNode.WORLD_MATRIX );
 export const modelPosition = nodeImmutable( ModelNode, ModelNode.POSITION );

--- a/examples/jsm/nodes/core/NodeFrame.js
+++ b/examples/jsm/nodes/core/NodeFrame.js
@@ -47,9 +47,9 @@ class NodeFrame {
 		const updateType = node.getUpdateBeforeType();
 		const reference = node.updateReference( this );
 
-		const { frameMap, renderMap } = this._getMaps( this.updateBeforeMap, reference );
-
 		if ( updateType === NodeUpdateType.FRAME ) {
+
+			const { frameMap } = this._getMaps( this.updateBeforeMap, reference );
 
 			if ( frameMap.get( node ) !== this.frameId ) {
 
@@ -61,10 +61,11 @@ class NodeFrame {
 
 		} else if ( updateType === NodeUpdateType.RENDER ) {
 
-			if ( renderMap.get( node ) !== this.renderId || frameMap.get( node ) !== this.frameId ) {
+			const { renderMap } = this._getMaps( this.updateBeforeMap, reference );
+
+			if ( renderMap.get( node ) !== this.renderId ) {
 
 				renderMap.set( node, this.renderId );
-				frameMap.set( node, this.frameId );
 
 				node.updateBefore( this );
 
@@ -83,9 +84,9 @@ class NodeFrame {
 		const updateType = node.getUpdateType();
 		const reference = node.updateReference( this );
 
-		const { frameMap, renderMap } = this._getMaps( this.updateMap, reference );
-
 		if ( updateType === NodeUpdateType.FRAME ) {
+
+			const { frameMap } = this._getMaps( this.updateMap, reference );
 
 			if ( frameMap.get( node ) !== this.frameId ) {
 
@@ -97,10 +98,11 @@ class NodeFrame {
 
 		} else if ( updateType === NodeUpdateType.RENDER ) {
 
-			if ( renderMap.get( node ) !== this.renderId || frameMap.get( node ) !== this.frameId ) {
+			const { renderMap } = this._getMaps( this.updateMap, reference );
+
+			if ( renderMap.get( node ) !== this.renderId ) {
 
 				renderMap.set( node, this.renderId );
-				frameMap.set( node, this.frameId );
 
 				node.update( this );
 

--- a/examples/jsm/nodes/core/NodeUniform.js
+++ b/examples/jsm/nodes/core/NodeUniform.js
@@ -23,6 +23,18 @@ class NodeUniform {
 
 	}
 
+	get id() {
+
+		return this.node.id;
+
+	}
+
+	get groupNode() {
+
+		return this.node.groupNode;
+
+	}
+
 }
 
 export default NodeUniform;

--- a/examples/jsm/nodes/core/UniformGroup.js
+++ b/examples/jsm/nodes/core/UniformGroup.js
@@ -1,0 +1,13 @@
+class UniformGroup {
+
+	constructor( name ) {
+
+		this.name = name;
+
+		this.isUniformGroup = true;
+
+	}
+
+}
+
+export default UniformGroup;

--- a/examples/jsm/nodes/core/UniformGroupNode.js
+++ b/examples/jsm/nodes/core/UniformGroupNode.js
@@ -1,0 +1,36 @@
+import Node from './Node.js';
+import { addNodeClass } from './Node.js';
+
+class UniformGroupNode extends Node {
+
+	constructor( name, shared = false ) {
+
+		super( 'string' );
+
+		this.name = name;
+		this.version = 0;
+
+		this.shared = shared;
+
+		this.isUniformGroup = true;
+
+	}
+
+	set needsUpdate( value ) {
+
+		if ( value === true ) this.version ++;
+
+	}
+
+}
+
+export const uniformGroup = ( name ) => new UniformGroupNode( name );
+export const sharedUniformGroup = ( name ) => new UniformGroupNode( name, true );
+
+export const frameGroup = sharedUniformGroup( 'frame' );
+export const renderGroup = sharedUniformGroup( 'render' );
+export const objectGroup = uniformGroup( 'object' );
+
+export default UniformGroupNode;
+
+addNodeClass( 'UniformGroupNode', UniformGroupNode );

--- a/examples/jsm/nodes/core/UniformNode.js
+++ b/examples/jsm/nodes/core/UniformNode.js
@@ -1,4 +1,5 @@
 import InputNode from './InputNode.js';
+import { objectGroup } from './UniformGroupNode.js';
 import { addNodeClass } from './Node.js';
 import { nodeObject, getConstNodeType } from '../shadernode/ShaderNode.js';
 
@@ -9,6 +10,22 @@ class UniformNode extends InputNode {
 		super( value, nodeType );
 
 		this.isUniformNode = true;
+
+		this.groupNode = objectGroup;
+
+	}
+
+	setGroup( group ) {
+
+		this.groupNode = group;
+
+		return this;
+
+	}
+
+	getGroup() {
+
+		return this.groupNode;
 
 	}
 

--- a/examples/jsm/nodes/materials/MeshBasicNodeMaterial.js
+++ b/examples/jsm/nodes/materials/MeshBasicNodeMaterial.js
@@ -13,6 +13,7 @@ class MeshBasicNodeMaterial extends NodeMaterial {
 		this.isMeshBasicNodeMaterial = true;
 
 		this.lights = false;
+		//this.normals = false; @TODO: normals usage by context
 
 		this.setDefaultValues( defaultValues );
 

--- a/examples/jsm/renderers/common/Bindings.js
+++ b/examples/jsm/renderers/common/Bindings.js
@@ -16,8 +16,6 @@ class Bindings extends DataMap {
 
 		this.pipelines.bindings = this; // assign bindings to pipelines
 
-		this.updateMap = new WeakMap();
-
 	}
 
 	getForRender( renderObject ) {
@@ -100,24 +98,25 @@ class Bindings extends DataMap {
 
 		const { backend } = this;
 
-		const updateMap = this.updateMap;
-		const callId = this.info.calls;
-
 		let needsBindingsUpdate = false;
 
 		// iterate over all bindings and check if buffer updates or a new binding group is required
 
 		for ( const binding of bindings ) {
 
-			const isUpdated = updateMap.get( binding ) === callId;
+			if ( binding.isNodeUniformsGroup ) {
 
-			if ( isUpdated ) continue;
+				const updated = this.nodes.updateGroup( binding );
+
+				if ( ! updated ) continue;
+
+			}
 
 			if ( binding.isUniformBuffer ) {
 
-				const needsUpdate = binding.update();
+				const updated = binding.update();
 
-				if ( needsUpdate ) {
+				if ( updated ) {
 
 					backend.updateBinding( binding );
 
@@ -127,17 +126,15 @@ class Bindings extends DataMap {
 
 				if ( binding.needsBindingsUpdate ) needsBindingsUpdate = true;
 
-				const needsUpdate = binding.update();
+				const updated = binding.update();
 
-				if ( needsUpdate ) {
+				if ( updated ) {
 
 					this.textures.updateTexture( binding.texture );
 
 				}
 
 			}
-
-			updateMap.set( binding, callId );
 
 		}
 
@@ -148,14 +145,6 @@ class Bindings extends DataMap {
 			this.backend.updateBindings( bindings, pipeline );
 
 		}
-
-	}
-
-	dispose() {
-
-		super.dispose();
-
-		this.updateMap = new WeakMap();
 
 	}
 

--- a/examples/jsm/renderers/common/ChainMap.js
+++ b/examples/jsm/renderers/common/ChainMap.js
@@ -12,7 +12,7 @@ export default class ChainMap {
 
 			let map = this.weakMap;
 
-			for ( let i = 0; i < keys.length - 1; i ++ ) {
+			for ( let i = 0; i < keys.length; i ++ ) {
 
 				map = map.get( keys[ i ] );
 
@@ -36,7 +36,7 @@ export default class ChainMap {
 
 			let map = this.weakMap;
 
-			for ( let i = 0; i < keys.length - 1; i ++ ) {
+			for ( let i = 0; i < keys.length; i ++ ) {
 
 				const key = keys[ i ];
 
@@ -62,7 +62,7 @@ export default class ChainMap {
 
 			let map = this.weakMap;
 
-			for ( let i = 0; i < keys.length - 1; i ++ ) {
+			for ( let i = 0; i < keys.length; i ++ ) {
 
 				map = map.get( keys[ i ] );
 

--- a/examples/jsm/renderers/common/Renderer.js
+++ b/examples/jsm/renderers/common/Renderer.js
@@ -9,7 +9,6 @@ import RenderLists from './RenderLists.js';
 import RenderContexts from './RenderContexts.js';
 import Textures from './Textures.js';
 import Background from './Background.js';
-import UniformGroupNode from '../../nodes/core/UniformGroupNode.js';
 import Nodes from './nodes/Nodes.js';
 import { Scene, Frustum, Matrix4, Vector2, Vector3, Vector4, Color, DoubleSide, BackSide, FrontSide, SRGBColorSpace, NoToneMapping } from 'three';
 

--- a/examples/jsm/renderers/common/Renderer.js
+++ b/examples/jsm/renderers/common/Renderer.js
@@ -9,6 +9,7 @@ import RenderLists from './RenderLists.js';
 import RenderContexts from './RenderContexts.js';
 import Textures from './Textures.js';
 import Background from './Background.js';
+import UniformGroupNode from '../../nodes/core/UniformGroupNode.js';
 import Nodes from './nodes/Nodes.js';
 import { Scene, Frustum, Matrix4, Vector2, Vector3, Vector4, Color, DoubleSide, BackSide, FrontSide, SRGBColorSpace, NoToneMapping } from 'three';
 
@@ -196,10 +197,10 @@ class Renderer {
 
 		//
 
-		nodeFrame.renderId ++;
-
 		this.info.calls ++;
 		this.info.render.calls ++;
+
+		nodeFrame.renderId = this.info.calls;
 
 		//
 
@@ -660,10 +661,16 @@ class Renderer {
 
 		if ( this._initialized === false ) await this.init();
 
+		const nodeFrame = this._nodes.nodeFrame;
+
+		const previousRenderId = nodeFrame.renderId;
+
 		//
 
 		this.info.calls ++;
 		this.info.compute.calls ++;
+
+		nodeFrame.renderId = this.info.calls;
 
 		//
 
@@ -716,6 +723,10 @@ class Renderer {
 		}
 
 		backend.finishCompute( computeNodes );
+
+		//
+
+		nodeFrame.renderId = previousRenderId;
 
 	}
 

--- a/examples/jsm/renderers/common/nodes/NodeBuilderState.js
+++ b/examples/jsm/renderers/common/nodes/NodeBuilderState.js
@@ -20,9 +20,17 @@ class NodeBuilderState {
 
 		const bindingsArray = [];
 
-		for ( const binding of this.bindings ) {
+		for ( const instanceBinding of this.bindings ) {
 
-			bindingsArray.push( binding.clone() );
+			let binding = instanceBinding;
+
+			if ( instanceBinding.shared !== true ) {
+
+				binding = instanceBinding.clone();
+
+			}
+
+			bindingsArray.push( binding );
 
 		}
 

--- a/examples/jsm/renderers/common/nodes/NodeUniformsGroup.js
+++ b/examples/jsm/renderers/common/nodes/NodeUniformsGroup.js
@@ -1,0 +1,44 @@
+import UniformsGroup from '../UniformsGroup.js';
+
+let id = 0;
+
+class NodeUniformsGroup extends UniformsGroup {
+
+	constructor( name, groupNode ) {
+
+		super( name );
+
+		this.id = id ++;
+		this.groupNode = groupNode;
+
+		this.isNodeUniformsGroup = true;
+
+	}
+
+	get shared() {
+
+		return this.groupNode.shared;
+
+	}
+
+	getNodes() {
+
+		const nodes = [];
+
+		for ( const uniform of this.uniforms ) {
+
+			const node = uniform.nodeUniform.node;
+
+			if ( ! node ) throw new Error( 'NodeUniformsGroup: Uniform has no node.' );
+
+			nodes.push( node );
+
+		}
+
+		return nodes;
+
+	}
+
+}
+
+export default NodeUniformsGroup;

--- a/examples/jsm/renderers/webgpu/utils/WebGPUBindingUtils.js
+++ b/examples/jsm/renderers/webgpu/utils/WebGPUBindingUtils.js
@@ -91,7 +91,7 @@ class WebGPUBindingUtils {
 
 			} else {
 
-				console.error( 'WebGPUBindingUtils: Unsupported binding "${ binding }".' );
+				console.error( `WebGPUBindingUtils: Unsupported binding "${ binding }".` );
 
 			}
 
@@ -152,7 +152,7 @@ class WebGPUBindingUtils {
 					const usage = GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST;
 
 					const bufferGPU = device.createBuffer( {
-						label: 'bindingBuffer',
+						label: 'bindingBuffer_' + binding.name,
 						size: byteLength,
 						usage: usage
 					} );


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/27101, https://github.com/mrdoob/three.js/issues/26673

### GOAL

This PR implements shared and unique Uniform Groups in `WebGPURenderer`. 

### NODE UPDATE

Node System has 3 root update systems, `FRAME`, `RENDER`, `OBJECT`.

- `FRAME`: The Node is updated once per frame.
- `RENDER`: The Node is updated whenever `.render()` or `.compute()` is called.
- `OBJECT`: The Node is updated in each `Mesh` or derivative (`RenderObject`).

Normally, Nodes belonging to `projectionMatrix` (Camera) and `materialColor` (Material) are classified as updating type `RENDER`, and the buffer can be shared with others.

While `modelViewMatrix` (Mesh), for example, is classified as `OBJECT`, and is updated every time the object is rendered, its buffer is not shared.

Global nodes like `timerGlobal()` are classified as `FRAME`, and are updated once for each `requestAnimationFrame()`, unlike `RENDER` it is not updated if there are other `RTT` in the same frame, the buffer of a `FRAME` is shared.

### UNIFORM GROUP

To implement a uniform group, you just need to tell the uniform which group it will be linked to. Groups will be automatically created in the code, if the group is shared it will look for other equivalent blocks in the active shaders already created to share the buffer. Defining the children of a group should not be a concern for the end user.

```js
import { frameGroup, renderGroup, objectGroup, uniform } from 'three/nodes';

const myUniform = uniform( new THRE.Color( 0x0066FF ) );

// frameGroup, renderGroup, objectGroup are the system groups
myUniform.setGroup( renderGroup );

...
material.colorNode = myUniform;
```

### CUSTOM UNIFORM GROUP

```js
import { uniformGroup, sharedUniformGroup, uniform } from 'three/nodes';

const myUniform = uniform( new THRE.Color( 0x0066FF ) );
const myGroup = sharedUniformGroup( 'myGroup' );

myUniform.setGroup( myGroup );

...
material.colorNode = myUniform;

// For update your group...
// The uniform updates will be sent to the GPU if the version is different from the CPU, 
// in this case use `.needsUpdate=true` to update the version.

myGroup.needsUpdate = true;
```

### NEXT STEP

This PR offers the necessary support for optimization that must be done in separate PRs, so that each Node is in its equivalent group as proposed in the design.

### WGSL TEST RESULT

```wgsl
...
// uniforms

struct cameraStruct {
	projectionMatrix : mat4x4<f32>
};
@binding( 0 ) @group( 0 )
var<uniform> camera : cameraStruct;

struct objectStruct {
	modelViewMatrix : mat4x4<f32>
};
@binding( 1 ) @group( 0 )
var<uniform> object : objectStruct;

...
// You need to remove comments left on `CameraNode` to view this example.
```