### PR TITLE
FBXLoader error when loaded 1 frame animation

### DIFF
--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -2978,6 +2978,13 @@ class AnimationParser {
 
 		const times = [];
 		const values = [];
+
+		// Add first frame
+		times.push( curvex.times[ 0 ] );
+		values.push( MathUtils.degToRad( curvex.values[ 0 ] ) );
+		values.push( MathUtils.degToRad( curvey.values[ 0 ] ) );
+		values.push( MathUtils.degToRad( curvez.values[ 0 ] ) );
+
 		for ( let i = 1; i < curvex.values.length; i ++ ) {
 
 			const initialValue = [


### PR DESCRIPTION
Related issue: #27142

**Description**

In FBX Loader and geenrateRotationTrack: First animation frame wasn't added to the values and times in [this previous PR](https://github.com/mrdoob/three.js/pull/27057) hence the animation with one frame were empty hence the error.
