### PR TITLE
Add envMapIntensityNode for node materials in WebGLRenderer

### DIFF
--- a/examples/jsm/nodes/materials/NodeMaterial.js
+++ b/examples/jsm/nodes/materials/NodeMaterial.js
@@ -42,6 +42,9 @@ class NodeMaterial extends ShaderMaterial {
 
 		this.lightsNode = null;
 		this.envNode = null;
+
+		// Only used by WebGLRenderer for scaling the environment illumination
+		// For WebGPURenderer, scaling of the environment intensity can be achieved as envNode.mul(...)
 		this.envMapIntensityNode = null;
 
 		this.colorNode = null;
@@ -230,12 +233,6 @@ class NodeMaterial extends ShaderMaterial {
 		} else if ( builder.environmentNode ) {
 
 			node = builder.environmentNode;
-
-		}
-
-		if( this.envMapIntensityNode && node ) {
-
-			node = node.mul( this.envMapIntensityNode );
 
 		}
 
@@ -479,6 +476,7 @@ class NodeMaterial extends ShaderMaterial {
 
 		this.lightsNode = source.lightsNode;
 		this.envNode = source.envNode;
+
 		this.envMapIntensityNode = source.envMapIntensityNode;
 
 		this.colorNode = source.colorNode;

--- a/examples/jsm/nodes/materials/NodeMaterial.js
+++ b/examples/jsm/nodes/materials/NodeMaterial.js
@@ -42,6 +42,7 @@ class NodeMaterial extends ShaderMaterial {
 
 		this.lightsNode = null;
 		this.envNode = null;
+		this.envMapIntensityNode = null;
 
 		this.colorNode = null;
 		this.normalNode = null;
@@ -229,6 +230,12 @@ class NodeMaterial extends ShaderMaterial {
 		} else if ( builder.environmentNode ) {
 
 			node = builder.environmentNode;
+
+		}
+
+		if( this.envMapIntensityNode && node ) {
+
+			node = node.mul( this.envMapIntensityNode );
 
 		}
 
@@ -472,6 +479,7 @@ class NodeMaterial extends ShaderMaterial {
 
 		this.lightsNode = source.lightsNode;
 		this.envNode = source.envNode;
+		this.envMapIntensityNode = source.envMapIntensityNode;
 
 		this.colorNode = source.colorNode;
 		this.normalNode = source.normalNode;

--- a/examples/jsm/renderers/webgl-legacy/nodes/WebGLNodeBuilder.js
+++ b/examples/jsm/renderers/webgl-legacy/nodes/WebGLNodeBuilder.js
@@ -172,7 +172,7 @@ class WebGLNodeBuilder extends NodeBuilder {
 			this.addSlot( 'fragment', new SlotNode( {
 				node: material.envMapIntensityNode,
 				nodeType: 'float',
-				source: 'float envMapIntensityFactor = envMapIntensity;',
+				source: 'float envMapIntensityFactor = 1.0;',
 				target: 'float envMapIntensityFactor = %RESULT%;'
 			} ) );
 

--- a/examples/jsm/renderers/webgl-legacy/nodes/WebGLNodeBuilder.js
+++ b/examples/jsm/renderers/webgl-legacy/nodes/WebGLNodeBuilder.js
@@ -46,7 +46,7 @@ class WebGLNodeBuilder extends NodeBuilder {
 		this.slots = { vertex: [], fragment: [] };
 
 		this._parseShaderLib();
-		this._parseInclude( 'fragment', 'lights_physical_fragment', 'clearcoat_normal_fragment_begin', 'transmission_fragment' );
+		this._parseInclude( 'fragment', 'lights_physical_fragment', 'clearcoat_normal_fragment_begin', 'transmission_fragment', 'lights_fragment_maps' );
 		this._parseObject();
 
 		this._sortSlotsToFlow();
@@ -163,6 +163,17 @@ class WebGLNodeBuilder extends NodeBuilder {
 				source: getIncludeSnippet( 'emissivemap_fragment' ),
 				target: 'totalEmissiveRadiance = %RESULT%;',
 				inclusionType: 'append'
+			} ) );
+
+		}
+
+		if ( material.envMapIntensityNode && material.envMapIntensityNode.isNode ) {
+
+			this.addSlot( 'fragment', new SlotNode( {
+				node: material.envMapIntensityNode,
+				nodeType: 'float',
+				source: 'float envMapIntensityFactor = envMapIntensity;',
+				target: 'float envMapIntensityFactor = %RESULT%;'
 			} ) );
 
 		}

--- a/src/renderers/shaders/ShaderChunk/envmap_physical_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/envmap_physical_pars_fragment.glsl.js
@@ -9,7 +9,7 @@ export default /* glsl */`
 
 			vec4 envMapColor = textureCubeUV( envMap, worldNormal, 1.0 );
 
-			return PI * envMapColor.rgb * envMapIntensity;
+			return PI * envMapColor.rgb;
 
 		#else
 
@@ -32,7 +32,7 @@ export default /* glsl */`
 
 			vec4 envMapColor = textureCubeUV( envMap, reflectVec, roughness );
 
-			return envMapColor.rgb * envMapIntensity;
+			return envMapColor.rgb;
 
 		#else
 

--- a/src/renderers/shaders/ShaderChunk/envmap_physical_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/envmap_physical_pars_fragment.glsl.js
@@ -9,7 +9,7 @@ export default /* glsl */`
 
 			vec4 envMapColor = textureCubeUV( envMap, worldNormal, 1.0 );
 
-			return PI * envMapColor.rgb;
+			return PI * envMapColor.rgb * envMapIntensity;
 
 		#else
 
@@ -32,7 +32,7 @@ export default /* glsl */`
 
 			vec4 envMapColor = textureCubeUV( envMap, reflectVec, roughness );
 
-			return envMapColor.rgb;
+			return envMapColor.rgb * envMapIntensity;
 
 		#else
 

--- a/src/renderers/shaders/ShaderChunk/lights_fragment_maps.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_fragment_maps.glsl.js
@@ -1,7 +1,7 @@
 export default /* glsl */`
 #ifdef USE_ENVMAP
 
-	float envMapIntensityFactor = envMapIntensity;
+	float envMapIntensityFactor = 1.0;
 
 #endif
 

--- a/src/renderers/shaders/ShaderChunk/lights_fragment_maps.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_fragment_maps.glsl.js
@@ -1,4 +1,10 @@
 export default /* glsl */`
+#ifdef USE_ENVMAP
+
+	float envMapIntensityFactor = envMapIntensity;
+
+#endif
+
 #if defined( RE_IndirectDiffuse )
 
 	#ifdef USE_LIGHTMAP
@@ -12,7 +18,7 @@ export default /* glsl */`
 
 	#if defined( USE_ENVMAP ) && defined( STANDARD ) && defined( ENVMAP_TYPE_CUBE_UV )
 
-		iblIrradiance += getIBLIrradiance( geometryNormal );
+		iblIrradiance += getIBLIrradiance( geometryNormal ) * envMapIntensityFactor;
 
 	#endif
 
@@ -22,17 +28,17 @@ export default /* glsl */`
 
 	#ifdef USE_ANISOTROPY
 
-		radiance += getIBLAnisotropyRadiance( geometryViewDir, geometryNormal, material.roughness, material.anisotropyB, material.anisotropy );
+		radiance += getIBLAnisotropyRadiance( geometryViewDir, geometryNormal, material.roughness, material.anisotropyB, material.anisotropy ) * envMapIntensityFactor;
 
 	#else
 
-		radiance += getIBLRadiance( geometryViewDir, geometryNormal, material.roughness );
+		radiance += getIBLRadiance( geometryViewDir, geometryNormal, material.roughness ) * envMapIntensityFactor;
 
 	#endif
 
 	#ifdef USE_CLEARCOAT
 
-		clearcoatRadiance += getIBLRadiance( geometryViewDir, geometryClearcoatNormal, material.clearcoatRoughness );
+		clearcoatRadiance += getIBLRadiance( geometryViewDir, geometryClearcoatNormal, material.clearcoatRoughness ) * envMapIntensityFactor;
 
 	#endif
 


### PR DESCRIPTION
Related issue: #27141

**Description**

ThreeJS already supports scaling the effect of the environment map by the `envMapIntensity` property of a material.
For the node materials, it would be very handy to also have a `envMapIntensityNode` property available to setup more complex intensity values rather than just a single float value.

While a similar effect can already be achieved by `material.envNode = cubeTexture( myCubeTexture ).mul( intensity );` for the `WebGPURenderer`, the `WebGLRenderer` currently only supports setting the environment via `scene.environment = texture;`, i.e. all materials share one common environment map.

For some use-cases it is desirable to scale the intensity of the environment map for each material individually.
It is already possible to do this via `material.envMapIntensity = 0.5;`. However, this allows to only set static values. For the node materials, it would be really good to have a `envMapIntensityNode` parameter which allows more sophisticated node based settings. For example `material.envMapIntensityNode = THREENodes.pow(material.roughnessNode, THREENodes.float(4.0));` to let the environment map only contribute to the really mirroring parts of a surface.