### PR TITLE
ci.yml: only build module in e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Build
-        run: npm run build
+        run: npm run build-module
 
       - name: === E2E testing ===
         run: npm run test-e2e


### PR DESCRIPTION
Related issue: #XXXX

**Description**

I don't think we need to create all the builds when doing e2e.

This saves ~15s per run.
