### PR TITLE
Octree: Add `clear()`.

### DIFF
--- a/examples/jsm/math/Octree.js
+++ b/examples/jsm/math/Octree.js
@@ -82,18 +82,17 @@ function lineToLineClosestPoints( line1, line2, target1 = null, target2 = null )
 
 class Octree {
 
-
 	constructor( box ) {
 
-		this.triangles = [];
 		this.box = box;
+		this.bounds = new Box3();
+
 		this.subTrees = [];
+		this.triangles = [];
 
 	}
 
 	addTriangle( triangle ) {
-
-		if ( ! this.bounds ) this.bounds = new Box3();
 
 		this.bounds.min.x = Math.min( this.bounds.min.x, triangle.a.x, triangle.b.x, triangle.c.x );
 		this.bounds.min.y = Math.min( this.bounds.min.y, triangle.a.y, triangle.b.y, triangle.c.y );
@@ -526,12 +525,14 @@ class Octree {
 
 	clear() {
 
-		this.subTrees = [];
-		this.triangles = [];
-		this.bounds = null;
 		this.box = null;
+		this.bounds.makeEmpty();
+
+		this.subTrees.length = 0;
+		this.triangles.length = 0;
 
 		return this;
+
 	}
 
 }

--- a/examples/jsm/math/Octree.js
+++ b/examples/jsm/math/Octree.js
@@ -524,6 +524,16 @@ class Octree {
 
 	}
 
+	clear() {
+
+		this.subTrees = [];
+		this.triangles = [];
+		this.bounds = null;
+		this.box = null;
+
+		return this;
+	}
+
 }
 
 export { Octree };


### PR DESCRIPTION
When I use octree, I need to reset octree in some scenarios, so I add the clear method