### PR TITLE
Return `this` from `BatchedMesh#copy`

### DIFF
--- a/examples/jsm/objects/BatchedMesh.js
+++ b/examples/jsm/objects/BatchedMesh.js
@@ -785,6 +785,8 @@ class BatchedMesh extends Mesh {
 		this._matricesTexture = source._matricesTexture.clone();
 		this._matricesTexture.image.data = this._matricesTexture.image.slice();
 
+		return this;
+
 	}
 
 	dispose() {


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/27131#discussion_r1388014852

**Description**

Adds a `return this` in `BatchedMesh#copy` to keep it consistent with `Mesh#copy` and `Object3D#copy`. Necessary for the TS types and generally seems like a good idea.