### PR TITLE
fix SSL serving error

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "test": "npm run lint && npm run test-unit",
     "build": "rollup -c utils/build/rollup.config.js",
     "build-module": "rollup -c utils/build/rollup.config.js --configOnlyModule",
-    "dev": "concurrently --names \"ROLLUP,HTTP\" -c \"bgBlue.bold,bgGreen.bold\" \"rollup -c utils/build/rollup.config.js -w -m inline\" \"servez -p 8080 --ssl\"",
+    "dev": "concurrently --names \"ROLLUP,HTTP\" -c \"bgBlue.bold,bgGreen.bold\" \"rollup -c utils/build/rollup.config.js -w -m inline\" \"servez -p 8080\"",
     "lint-core": "eslint src",
     "lint-addons": "eslint examples/jsm --ext .js --ignore-pattern libs --ignore-pattern ifc",
     "lint-examples": "eslint examples --ext .html",


### PR DESCRIPTION
When doing local development using `npm run dev`, it was trying to serve localhost on HTTPS, which Chrome was then complaining loudly about (lots of "are you sure? this is unsafe!" warnings). Simple one-liner fixed it. @mrdoob