### PR TITLE
BatchedMesh: Add support for per-object opaque and transparent sorting

### DIFF
--- a/examples/jsm/objects/BatchedMesh.js
+++ b/examples/jsm/objects/BatchedMesh.js
@@ -27,7 +27,7 @@ function sortTransparent( a, b ) {
 
 }
 
-class RenderInfoPool {
+class MultiDrawRenderList {
 
 	constructor() {
 
@@ -37,7 +37,7 @@ class RenderInfoPool {
 
 	}
 
-	getNextItem( drawRange, z ) {
+	push( drawRange, z ) {
 
 		const pool = this.pool;
 		const list = this.list;
@@ -60,7 +60,6 @@ class RenderInfoPool {
 		item.start = drawRange.start;
 		item.count = drawRange.count;
 		item.z = z;
-		return item;
 
 	}
 
@@ -87,7 +86,7 @@ const _frustum = new Frustum();
 const _box = new Box3();
 const _sphere = new Sphere();
 const _vector = new Vector3();
-const _renderItems = new RenderInfoPool();
+const _renderList = new MultiDrawRenderList();
 
 // @TODO: SkinnedMesh support?
 // @TODO: Future work if needed. Move into the core. Can be optimized more with WEBGL_multi_draw.
@@ -916,7 +915,7 @@ class BatchedMesh extends Mesh {
 
 					if ( ! culled || true ) {
 
-						_renderItems.getNextItem( drawRanges[ i ], z );
+						_renderList.push( drawRanges[ i ], z );
 
 					}
 
@@ -924,7 +923,7 @@ class BatchedMesh extends Mesh {
 
 			}
 
-			const list = _renderItems.list;
+			const list = _renderList.list;
 			list.sort( material.transparent ? sortTransparent : sortOpaque );
 
 			for ( let i = 0, l = list.length; i < l; i ++ ) {
@@ -936,7 +935,7 @@ class BatchedMesh extends Mesh {
 
 			}
 
-			_renderItems.reset();
+			_renderList.reset();
 
 		} else {
 

--- a/examples/jsm/objects/BatchedMesh.js
+++ b/examples/jsm/objects/BatchedMesh.js
@@ -875,6 +875,7 @@ class BatchedMesh extends Mesh {
 
 		this.geometry = source.geometry.clone();
 		this.perObjectFrustumCulled = source.perObjectFrustumCulled;
+		this.sortObjects = source.sortObjects;
 		this.boundingBox = source.boundingBox !== null ? source.boundingBox.clone() : null;
 		this.boundingSphere = source.boundingSphere !== null ? source.boundingSphere.clone() : null;
 

--- a/examples/jsm/objects/BatchedMesh.js
+++ b/examples/jsm/objects/BatchedMesh.js
@@ -948,16 +948,15 @@ class BatchedMesh extends Mesh {
 
 		if ( this.sortObjects ) {
 
+			// get the camera position
 			_vector.setFromMatrixPosition( camera.matrixWorld );
 
-			let added = 0;
 			for ( let i = 0, l = visible.length; i < l; i ++ ) {
 
 				if ( visible[ i ] ) {
 
 					this.getMatrixAt( i, _matrix );
 					this.getBoundingSphereAt( i, _sphere ).applyMatrix4( _matrix );
-					const z = _vector.distanceToSquared( _sphere.center );
 
 					// determine whether the batched geometry is within the frustum
 					let culled = false;
@@ -972,8 +971,10 @@ class BatchedMesh extends Mesh {
 
 					}
 
-					if ( ! culled || true ) {
+					if ( ! culled ) {
 
+						// get the distance from camera used for sorting
+						const z = _vector.distanceToSquared( _sphere.center );
 						_renderList.push( drawRanges[ i ], z );
 
 					}
@@ -982,6 +983,7 @@ class BatchedMesh extends Mesh {
 
 			}
 
+			// Sort the draw ranges and prep for rendering
 			const list = _renderList.list;
 			list.sort( material.transparent ? sortTransparent : sortOpaque );
 

--- a/examples/webgl_mesh_batch.html
+++ b/examples/webgl_mesh_batch.html
@@ -39,7 +39,7 @@
 
 		let stats, gui, guiStatsEl;
 		let camera, controls, scene, renderer;
-		let geometries, mesh;
+		let geometries, mesh, material;
 		const ids = [];
 		const matrix = new THREE.Matrix4();
 
@@ -62,7 +62,10 @@
 		const api = {
 			method: Method.BATCHED,
 			count: 256,
-			dynamic: 16
+			dynamic: 16,
+
+			sortObjects: true,
+			opacity: 1,
 		};
 
 		init();
@@ -111,7 +114,14 @@
 
 		function createMaterial() {
 
-			return new THREE.MeshNormalMaterial();
+			if ( ! material ) {
+
+				material = new THREE.MeshNormalMaterial();
+				material.opacity = 0.1;
+
+			}
+
+			return material;
 
 		}
 
@@ -238,6 +248,25 @@
 			gui.add( api, 'count', 1, MAX_GEOMETRY_COUNT ).step( 1 ).onChange( initMesh );
 			gui.add( api, 'dynamic', 0, MAX_GEOMETRY_COUNT ).step( 1 );
 			gui.add( api, 'method', Method ).onChange( initMesh );
+			gui.add( api, 'opacity', 0, 1 ).onChange( v => {
+
+				if ( v < 1 ) {
+
+					material.transparent = true;
+					material.depthWrite = false;
+
+				} else {
+
+					material.transparent = false;
+					material.depthWrite = true;
+
+				}
+
+				material.opacity = v;
+				material.needsUpdate = true;
+
+			} );
+			gui.add( api, 'sortObjects' );
 
 			guiStatsEl = document.createElement( 'li' );
 			guiStatsEl.classList.add( 'gui-stats' );
@@ -312,6 +341,12 @@
 		}
 
 		function render() {
+
+			if ( mesh.isBatchedMesh ) {
+
+				mesh.sortObjects = api.sortObjects;
+
+			}
 
 			renderer.render( scene, camera );
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -723,6 +723,7 @@ class Object3D extends EventDispatcher {
 
 			object.type = 'BatchedMesh';
 			object.perObjectFrustumCulled = this.perObjectFrustumCulled;
+			object.sortObjects = this.sortObjects;
 
 			object.drawRanges = this._drawRanges;
 			object.reservedRanges = this._reservedRanges;


### PR DESCRIPTION
Related issue: #22376, #27111 

**Description**

Adds `BatchedMesh.sortObjects` which enables sorting every individual batched object from front to back or back to front depending on whether the material is transparent. This helps address GPU overdraw performance issues, as well - similar to WebGLRenderer's sort. Updated demo with new flags [here](https://raw.githack.com/mrdoob/three.js/9d767faa52fff5b805271a5726b59dbf06e6fa9b/examples/webgl_mesh_batch.html).

Here's a before and after enabling sorting for a 0.9 opacity material:

| sortObjects = false | sortObjects = true |
|---|---|
| <img width="564" alt="image" src="https://github.com/mrdoob/three.js/assets/734200/057c1821-7575-4e0f-b70d-1a41245b9e1a"> | <img width="604" alt="image" src="https://github.com/mrdoob/three.js/assets/734200/9f316601-b3c8-44f0-a9b7-f936a28970dd"> |

**Upcoming PRs**

- Move to core
- Add support to ObjectLoader
- Documentation
