### PR TITLE
USDZLoader: Avoid recursive calls of `parseNextLine()`.

### DIFF
--- a/examples/jsm/loaders/USDZLoader.js
+++ b/examples/jsm/loaders/USDZLoader.js
@@ -25,9 +25,7 @@ class USDAParser {
 		const data = {};
 
 		const lines = text.split( '\n' );
-		const length = lines.length;
 
-		let current = 0;
 		let string = null;
 		let target = data;
 
@@ -35,9 +33,7 @@ class USDAParser {
 
 		// debugger;
 
-		function parseNextLine() {
-
-			const line = lines[ current ];
+		for ( const line of lines ) {
 
 			// console.log( line );
 
@@ -74,7 +70,7 @@ class USDAParser {
 
 				stack.pop();
 
-				if ( stack.length === 0 ) return;
+				if ( stack.length === 0 ) continue;
 
 				target = stack[ stack.length - 1 ];
 
@@ -100,17 +96,7 @@ class USDAParser {
 
 			}
 
-			current ++;
-
-			if ( current < length ) {
-
-				parseNextLine();
-
-			}
-
 		}
-
-		parseNextLine();
 
 		return data;
 
@@ -640,7 +626,7 @@ class USDZLoader extends Loader {
 
 						}
 
-					} else  if ( 'float inputs:clearcoat' in surface ) {
+					} else if ( 'float inputs:clearcoat' in surface ) {
 
 						material.clearcoat = parseFloat( surface[ 'float inputs:clearcoat' ] );
 


### PR DESCRIPTION
Related issue: #27158

**Description**

When testing with the asset from #27158, I have noticed the exported UDSZ could not be loaded with `USDZLoader`. But only in Chrome. The following error was thrown in `parseNextLine()`:

> RangeError: Maximum call stack size exceeded

The error does not appear with smaller assets and not in Firefox. I suppose when a certain number of nested calls are exceeded, Chrome does not allow further processing. The PR introduces a simple `for` loop which makes the error go away.