### PR TITLE
BatchedMesh: Add fallback for when the multi draw extension is not supported

### DIFF
--- a/src/renderers/webgl/WebGLBufferRenderer.js
+++ b/src/renderers/webgl/WebGLBufferRenderer.js
@@ -56,21 +56,26 @@ function WebGLBufferRenderer( gl, extensions, info, capabilities ) {
 		const extension = extensions.get( 'WEBGL_multi_draw' );
 		if ( extension === null ) {
 
-			console.error( 'THREE.WebGLBufferRenderer: using THREE.BatchedMesh but hardware does not support extension WEBGL_multi_draw.' );
-			return;
+			for ( let i = 0; i < drawCount; i ++ ) {
+
+				this.render( starts[ i ], counts[ i ] );
+
+			}
+
+		} else {
+
+			extension.multiDrawArraysWEBGL( mode, starts, 0, counts, 0, drawCount );
+
+			let elementCount = 0;
+			for ( let i = 0; i < drawCount; i ++ ) {
+
+				elementCount += counts[ i ];
+
+			}
+
+			info.update( elementCount, mode, 1 );
 
 		}
-
-		extension.multiDrawArraysWEBGL( mode, starts, 0, counts, 0, drawCount );
-
-		let elementCount = 0;
-		for ( let i = 0; i < drawCount; i ++ ) {
-
-			elementCount += counts[ i ];
-
-		}
-
-		info.update( elementCount, mode, 1 );
 
 	}
 

--- a/src/renderers/webgl/WebGLIndexedBufferRenderer.js
+++ b/src/renderers/webgl/WebGLIndexedBufferRenderer.js
@@ -65,21 +65,26 @@ function WebGLIndexedBufferRenderer( gl, extensions, info, capabilities ) {
 		const extension = extensions.get( 'WEBGL_multi_draw' );
 		if ( extension === null ) {
 
-			console.error( 'THREE.WebGLBufferRenderer: using THREE.BatchedMesh but hardware does not support extension WEBGL_multi_draw.' );
-			return;
+			for ( let i = 0; i < drawCount; i ++ ) {
+
+				this.render( starts[ i ] / bytesPerElement, counts[ i ] );
+
+			}
+
+		} else {
+
+			extension.multiDrawElementsWEBGL( mode, counts, 0, type, starts, 0, drawCount );
+
+			let elementCount = 0;
+			for ( let i = 0; i < drawCount; i ++ ) {
+
+				elementCount += counts[ i ];
+
+			}
+
+			info.update( elementCount, mode, 1 );
 
 		}
-
-		extension.multiDrawElementsWEBGL( mode, counts, 0, type, starts, 0, drawCount );
-
-		let elementCount = 0;
-		for ( let i = 0; i < drawCount; i ++ ) {
-
-			elementCount += counts[ i ];
-
-		}
-
-		info.update( elementCount, mode, 1 );
 
 	}
 


### PR DESCRIPTION
Related issue: #22376, #27111, #27170 

**Description**

Adds fallback for rendering BatchedMesh when multi draw is not supported by calling "drawArrays" multiple times in a tight loop. From testing even when the multi_draw extension is not used we still get some performance benefits since we don't have to change material uniforms for individual objects.

cc @RenaudRohlinger 