### PR TITLE
docs: add Tresjs library to docs

### DIFF
--- a/docs/manual/ar/introduction/Libraries-and-Plugins.html
+++ b/docs/manual/ar/introduction/Libraries-and-Plugins.html
@@ -104,6 +104,7 @@
 			<li>[link:https://github.com/ecsyjs/ecsy-three ECSY]</li>
 			<li>[link:https://threlte.xyz/ Threlte] - Svelte components for 3D graphics built on Three.</li>
 			<li>[link:https://needle.tools/ Needle Engine]</li>
+			<li>[link:https://tresjs.org/ tresjs] - Vue components for 3D graphics built on Three.</li>
 		</ul>
 
 	</body>

--- a/docs/manual/en/introduction/Libraries-and-Plugins.html
+++ b/docs/manual/en/introduction/Libraries-and-Plugins.html
@@ -108,6 +108,7 @@
 			<li>[link:https://github.com/ecsyjs/ecsy-three ECSY]</li>
 			<li>[link:https://threlte.xyz/ Threlte] - Svelte components for 3D graphics built on Three.</li>
 			<li>[link:https://needle.tools/ Needle Engine]</li>
+			<li>[link:https://tresjs.org/ tresjs] - Vue components for 3D graphics built on Three.</li>
 		</ul>
 
 	</body>

--- a/docs/manual/fr/introduction/Libraries-and-Plugins.html
+++ b/docs/manual/fr/introduction/Libraries-and-Plugins.html
@@ -107,6 +107,7 @@
 			<li>[link:https://github.com/ecsyjs/ecsy-three ECSY]</li>
 			<li>[link:https://threlte.xyz/ Threlte] - Svelte components for 3D graphics built on Three.</li>
 			<li>[link:https://needle.tools/ Needle Engine]</li>
+			<li>[link:https://tresjs.org/ tresjs] - Vue components for 3D graphics built on Three.</li>
 		</ul>
 
 	</body>

--- a/docs/manual/it/introduction/Libraries-and-Plugins.html
+++ b/docs/manual/it/introduction/Libraries-and-Plugins.html
@@ -107,6 +107,7 @@
 			<li>[link:https://github.com/ecsyjs/ecsy-three ECSY]</li>
 			<li>[link:https://threlte.xyz/ Threlte] - Svelte components for 3D graphics built on Three.</li>
 			<li>[link:https://needle.tools/ Needle Engine]</li>
+			<li>[link:https://tresjs.org/ tresjs] - Vue components for 3D graphics built on Three.</li>
 		</ul>
 
 	</body>

--- a/docs/manual/ja/introduction/Libraries-and-Plugins.html
+++ b/docs/manual/ja/introduction/Libraries-and-Plugins.html
@@ -100,6 +100,7 @@
         <li>[link:https://github.com/ecsyjs/ecsy-three ECSY]</li>
         <li>[link:https://threlte.xyz/ Threlte] - Svelte components for 3D graphics built on Three.</li>
         <li>[link:https://needle.tools/ Needle Engine]</li>
+        <li>[link:https://tresjs.org/ tresjs] - Vue components for 3D graphics built on Three.</li>
     </ul>
 
 </body>

--- a/docs/manual/pt-br/introduction/Libraries-and-Plugins.html
+++ b/docs/manual/pt-br/introduction/Libraries-and-Plugins.html
@@ -107,6 +107,7 @@
 			<li>[link:https://github.com/ecsyjs/ecsy-three ECSY]</li>
 			<li>[link:https://threlte.xyz/ Threlte] - Svelte components for 3D graphics built on Three.</li>
 			<li>[link:https://needle.tools/ Needle Engine]</li>
+			<li>[link:https://tresjs.org/ tresjs] - Vue components for 3D graphics built on Three.</li>
 		</ul>
 
 	</body>

--- a/docs/manual/ru/introduction/Libraries-and-Plugins.html
+++ b/docs/manual/ru/introduction/Libraries-and-Plugins.html
@@ -107,6 +107,7 @@
 			<li>[link:https://github.com/ecsyjs/ecsy-three ECSY]</li>
 			<li>[link:https://threlte.xyz/ Threlte] - Svelte components for 3D graphics built on Three.</li>
 			<li>[link:https://needle.tools/ Needle Engine]</li>
+			<li>[link:https://tresjs.org/ tresjs] - Vue components for 3D graphics built on Three.</li>
 		</ul>
 
 	</body>

--- a/docs/manual/zh/introduction/Libraries-and-Plugins.html
+++ b/docs/manual/zh/introduction/Libraries-and-Plugins.html
@@ -104,6 +104,7 @@
 			<li>[link:https://github.com/ecsyjs/ecsy-three ECSY]</li>
 			<li>[link:https://threlte.xyz/ Threlte] - Svelte components for 3D graphics built on Three.</li>
 			<li>[link:https://needle.tools/ Needle Engine]</li>
+			<li>[link:https://tresjs.org/ tresjs] - Vue components for 3D graphics built on Three.</li>
 		</ul>
 
 	</body>


### PR DESCRIPTION
**Description**

A simple changes into the docs, just for add Tresjs a R3F like library for VueJs developers
