### PR TITLE
WebGLAttributes: Strict buffer size check when updating data.

### DIFF
--- a/src/renderers/webgl/WebGLAttributes.js
+++ b/src/renderers/webgl/WebGLAttributes.js
@@ -8,6 +8,7 @@ function WebGLAttributes( gl, capabilities ) {
 
 		const array = attribute.array;
 		const usage = attribute.usage;
+		const size = array.byteLength;
 
 		const buffer = gl.createBuffer();
 
@@ -76,7 +77,8 @@ function WebGLAttributes( gl, capabilities ) {
 			buffer: buffer,
 			type: type,
 			bytesPerElement: array.BYTES_PER_ELEMENT,
-			version: attribute.version
+			version: attribute.version,
+			size: size
 		};
 
 	}
@@ -198,6 +200,10 @@ function WebGLAttributes( gl, capabilities ) {
 			buffers.set( attribute, createBuffer( attribute, bufferType ) );
 
 		} else if ( data.version < attribute.version ) {
+
+			if ( data.size < attribute.array.byteLength ) {
+				throw new Error( 'Too many data for update current attribute, dynamic sized attributes not supported.' );
+			}
 
 			updateBuffer( data.buffer, attribute, bufferType );
 

--- a/src/renderers/webgl/WebGLAttributes.js
+++ b/src/renderers/webgl/WebGLAttributes.js
@@ -203,7 +203,7 @@ function WebGLAttributes( gl, capabilities ) {
 
 			if ( data.size !== attribute.array.byteLength ) {
 
-				throw new Error( 'THREE.WebGLAttributes: The size of the buffer attribute\'s array buffer does not match the original size. Dynamic sized attributes not supported.' );
+				throw new Error( 'THREE.WebGLAttributes: The size of the buffer attribute\'s array buffer does not match the original size. Resizing buffer attributes is supported.' );
 
 			}
 

--- a/src/renderers/webgl/WebGLAttributes.js
+++ b/src/renderers/webgl/WebGLAttributes.js
@@ -201,9 +201,9 @@ function WebGLAttributes( gl, capabilities ) {
 
 		} else if ( data.version < attribute.version ) {
 
-			if ( data.size < attribute.array.byteLength ) {
+			if ( data.size !== attribute.array.byteLength ) {
 
-				throw new Error( 'Too many data for update current attribute, dynamic sized attributes not supported.' );
+				throw new Error( 'THREE.WebGLAttributes: The size of the buffer attribute\'s array buffer does not match the original size. Dynamic sized attributes not supported.' );
 
 			}
 

--- a/src/renderers/webgl/WebGLAttributes.js
+++ b/src/renderers/webgl/WebGLAttributes.js
@@ -202,7 +202,9 @@ function WebGLAttributes( gl, capabilities ) {
 		} else if ( data.version < attribute.version ) {
 
 			if ( data.size < attribute.array.byteLength ) {
+
 				throw new Error( 'Too many data for update current attribute, dynamic sized attributes not supported.' );
+
 			}
 
 			updateBuffer( data.buffer, attribute, bufferType );

--- a/src/renderers/webgl/WebGLAttributes.js
+++ b/src/renderers/webgl/WebGLAttributes.js
@@ -203,7 +203,7 @@ function WebGLAttributes( gl, capabilities ) {
 
 			if ( data.size !== attribute.array.byteLength ) {
 
-				throw new Error( 'THREE.WebGLAttributes: The size of the buffer attribute\'s array buffer does not match the original size. Resizing buffer attributes is supported.' );
+				throw new Error( 'THREE.WebGLAttributes: The size of the buffer attribute\'s array buffer does not match the original size. Resizing buffer attributes is not supported.' );
 
 			}
 


### PR DESCRIPTION
Strict check for buffer size while upload..

Related issue: #27180 
