### PR TITLE
Nodes: Mark as effectful for Webpack.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "type": "git",
     "url": "https://github.com/mrdoob/three.js"
   },
-  "sideEffects": false,
+  "sideEffects": ["./examples/jsm/nodes/Nodes.js"],
   "files": [
     "build",
     "examples/jsm",


### PR DESCRIPTION
Fixes: #27076

**Description**

Configures [`sideEffects`](https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free) to exclude `three/nodes` from coarse module skipping prior to tree-shaking. Since #26881, Nodes are effectful and cannot be individually tree-shaken.