### PR TITLE
BatchedMesh: Cleanup

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -728,7 +728,7 @@ class Object3D extends EventDispatcher {
 			object.drawRanges = this._drawRanges;
 			object.reservedRanges = this._reservedRanges;
 
-			object.visible = this._visible;
+			object.visibility = this._visibility;
 			object.active = this._active;
 			object.bounds = this._bounds.map( bound => ( {
 				boxInitialized: bound.boxInitialized,

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -913,7 +913,7 @@ class ObjectLoader extends Loader {
 				object._drawRanges = data.drawRanges;
 				object._reservedRanges = data.reservedRanges;
 
-				object._visible = data.visible;
+				object._visibility = data.visibility;
 				object._active = data.active;
 				object._bounds = data.bounds.map( bound => {
 

--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -85,7 +85,6 @@ const _mesh = new Mesh();
 const _batchIntersects = [];
 
 // @TODO: SkinnedMesh support?
-// @TODO: Future work if needed. Move into the core. Can be optimized more with WEBGL_multi_draw.
 // @TODO: geometry.groups support?
 // @TODO: geometry.drawRange support?
 // @TODO: geometry.morphAttributes support?

--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -137,7 +137,7 @@ class BatchedMesh extends Mesh {
 		this._drawRanges = [];
 		this._reservedRanges = [];
 
-		this._visible = [];
+		this._visibility = [];
 		this._active = [];
 		this._bounds = [];
 
@@ -440,13 +440,13 @@ class BatchedMesh extends Mesh {
 
 		}
 
-		const visible = this._visible;
+		const visibility = this._visibility;
 		const active = this._active;
 		const matricesTexture = this._matricesTexture;
 		const matricesArray = this._matricesTexture.image.data;
 
 		// push new visibility states
-		visible.push( true );
+		visibility.push( true );
 		active.push( true );
 
 		// update id
@@ -751,7 +751,7 @@ class BatchedMesh extends Mesh {
 
 	setVisibleAt( geometryId, value ) {
 
-		const visible = this._visible;
+		const visibility = this._visibility;
 		const active = this._active;
 		const geometryCount = this._geometryCount;
 
@@ -760,21 +760,21 @@ class BatchedMesh extends Mesh {
 		if (
 			geometryId >= geometryCount ||
 			active[ geometryId ] === false ||
-			visible[ geometryId ] === value
+			visibility[ geometryId ] === value
 		) {
 
 			return this;
 
 		}
 
-		visible[ geometryId ] = value;
+		visibility[ geometryId ] = value;
 		return this;
 
 	}
 
 	getVisibleAt( geometryId ) {
 
-		const visible = this._visible;
+		const visibility = this._visibility;
 		const active = this._active;
 		const geometryCount = this._geometryCount;
 
@@ -785,13 +785,13 @@ class BatchedMesh extends Mesh {
 
 		}
 
-		return visible[ geometryId ];
+		return visibility[ geometryId ];
 
 	}
 
 	raycast( raycaster, intersects ) {
 
-		const visible = this._visible;
+		const visibility = this._visibility;
 		const active = this._active;
 		const drawRanges = this._drawRanges;
 		const geometryCount = this._geometryCount;
@@ -816,7 +816,7 @@ class BatchedMesh extends Mesh {
 
 		for ( let i = 0; i < geometryCount; i ++ ) {
 
-			if ( ! visible[ i ] || ! active[ i ] ) {
+			if ( ! visibility[ i ] || ! active[ i ] ) {
 
 				continue;
 
@@ -865,7 +865,7 @@ class BatchedMesh extends Mesh {
 		this._drawRanges = source._drawRanges.map( range => ( { ...range } ) );
 		this._reservedRanges = source._reservedRanges.map( range => ( { ...range } ) );
 
-		this._visible = source._visible.slice();
+		this._visibility = source._visibility.slice();
 		this._active = source._active.slice();
 		this._bounds = source._bounds.map( bound => ( {
 			boxInitialized: bound.boxInitialized,
@@ -909,7 +909,7 @@ class BatchedMesh extends Mesh {
 		const index = geometry.getIndex();
 		const bytesPerElement = index === null ? 1 : index.array.BYTES_PER_ELEMENT;
 
-		const visible = this._visible;
+		const visibility = this._visibility;
 		const multiDrawStarts = this._multiDrawStarts;
 		const multiDrawCounts = this._multiDrawCounts;
 		const drawRanges = this._drawRanges;
@@ -935,9 +935,9 @@ class BatchedMesh extends Mesh {
 			// get the camera position
 			_vector.setFromMatrixPosition( camera.matrixWorld );
 
-			for ( let i = 0, l = visible.length; i < l; i ++ ) {
+			for ( let i = 0, l = visibility.length; i < l; i ++ ) {
 
-				if ( visible[ i ] ) {
+				if ( visibility[ i ] ) {
 
 					this.getMatrixAt( i, _matrix );
 					this.getBoundingSphereAt( i, _sphere ).applyMatrix4( _matrix );
@@ -984,9 +984,9 @@ class BatchedMesh extends Mesh {
 
 		} else {
 
-			for ( let i = 0, l = visible.length; i < l; i ++ ) {
+			for ( let i = 0, l = visibility.length; i < l; i ++ ) {
 
-				if ( visible[ i ] ) {
+				if ( visibility[ i ] ) {
 
 					// determine whether the batched geometry is within the frustum
 					let culled = false;


### PR DESCRIPTION
Related issue: #22376 

**Description**

Changes the `BatchedMesh._visible` member to `BatchedMesh._visibility` and `visible` member in toJSON to `visibility` to avoid name collision with Object3D's `visible` member. Also remove comment.

With this I think it's ready!