### PR TITLE
FBXLoader: Support loading DDS textures.

### DIFF
--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -445,6 +445,22 @@ class FBXTreeParser {
 
 			}
 
+		} else if ( extension === 'dds' ) {
+
+			const loader = this.manager.getHandler( '.dds' );
+
+			if ( loader === null ) {
+
+				console.warn( 'FBXLoader: DDS loader not found, creating placeholder texture for', textureNode.RelativeFilename );
+				texture = new Texture();
+
+			} else {
+
+				loader.setPath( this.textureLoader.path );
+				texture = loader.load( fileName );
+
+			}
+
 		} else if ( extension === 'psd' ) {
 
 			console.warn( 'FBXLoader: PSD textures are not supported, creating placeholder texture for', textureNode.RelativeFilename );


### PR DESCRIPTION
Fixed #13203.

**Description**

`FBXLoader` can load DDS textures now similar to TGAs. 

I've tested with the DDS textures from https://github.com/mrdoob/three.js/issues/13203#issuecomment-362540802 by creating a simple cube in Blender, applied one of the textures, exported to FBX and then imported with `FBXLoader`. All textures were tested and all did work meaning the runtime error mentioned in https://github.com/mrdoob/three.js/issues/13203#issuecomment-362521803 did not occur with this PR.