### PR TITLE
NodeMaterial: Use type 'vec3' when getting color attribute, fixing crash in WebGPU.

### DIFF
--- a/examples/jsm/nodes/materials/NodeMaterial.js
+++ b/examples/jsm/nodes/materials/NodeMaterial.js
@@ -160,7 +160,7 @@ class NodeMaterial extends ShaderMaterial {
 
 		if ( this.vertexColors === true && geometry.hasAttribute( 'color' ) ) {
 
-			colorNode = vec4( colorNode.xyz.mul( attribute( 'color' ) ), colorNode.a );
+			colorNode = vec4( colorNode.xyz.mul( attribute( 'color', 'vec3' ) ), colorNode.a );
 
 		}
 


### PR DESCRIPTION
NodeMaterial: Use type 'vec3' when getting color attribute, fixing crash in WebGPU:
> Error: no matching constructor for vec4.

Related issue: Fixes #27208
Related issue: https://github.com/danrossi/three-webgpu-renderer/issues/7

Solution found by @LeviPesin


*This contribution is funded by me. :) 


![image](https://github.com/mrdoob/three.js/assets/41650711/7857172f-bf42-4fa9-86cd-a31fb65d441d)

This is part of updating https://Fciv.net ( https://github.com/fciv-net/fciv-net ) to the new WebGPU renderer using https://github.com/danrossi/three-webgpu-renderer/ 

