### PR TITLE
Skeleton: Compute a smaller texture dimension

### DIFF
--- a/src/objects/Skeleton.js
+++ b/src/objects/Skeleton.js
@@ -168,7 +168,7 @@ class Skeleton {
 		//       64x64 pixel texture max 1024 bones * 4 pixels = (64 * 64)
 
 		let size = Math.sqrt( this.bones.length * 4 ); // 4 pixels needed for 1 matrix
-		size = MathUtils.ceilPowerOfTwo( size );
+		size = Math.ceil( size / 4 ) * 4;
 		size = Math.max( size, 4 );
 
 		const boneMatrices = new Float32Array( size * size * 4 ); // 4 floats per RGBA pixel


### PR DESCRIPTION
Related issue: #27202

**Description**

Computes a smaller, non-power of two texture dimension for storing the bone matrices. It's a small memory savings in more common cases but why not. There shouldn't be any reason to require a PoT texture here since mipmaps aren't used:

| bone count | old size | new size |
|---|---|---|
| 17 | 16 | 12 |
| 65 | 32 | 20 |
| 257 | 64 | 36 |
| 1025 | 128 | 68 |