### PR TITLE
NRRDLoader: Make sure `scan()` always returns a typed array.

### DIFF
--- a/examples/jsm/loaders/NRRDLoader.js
+++ b/examples/jsm/loaders/NRRDLoader.js
@@ -76,12 +76,6 @@ class NRRDLoader extends Loader {
 
 		function scan( type, chunks ) {
 
-			if ( chunks === undefined || chunks === null ) {
-
-				chunks = 1;
-
-			}
-
 			let _chunkSize = 1;
 			let _array_type = Uint8Array;
 
@@ -135,13 +129,6 @@ class NRRDLoader extends Loader {
 
 				// we need to flip here since the format doesn't match the native endianness
 				_bytes = flipEndianness( _bytes, _chunkSize );
-
-			}
-
-			if ( chunks == 1 ) {
-
-				// if only one chunk was requested, just return one value
-				return _bytes[ 0 ];
 
 			}
 


### PR DESCRIPTION
Fixed #22018.

**Description**

This PR ensures the internal `scan()` function of `NRRDLoader` always returns a typed array. Previously, a number could be returned in a special case. However, this edge case isn't supported since it would produce a runtime error in subsequent code anyway. The details for this are explained in #22018.
