### PR TITLE
BatchedMesh: Improve frustum culling performance

### DIFF
--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -948,6 +948,7 @@ class BatchedMesh extends Mesh {
 
 				if ( visibility[ i ] ) {
 
+					// get the bounds in world space
 					this.getMatrixAt( i, _matrix );
 					this.getBoundingSphereAt( i, _sphere ).applyMatrix4( _matrix );
 
@@ -955,12 +956,7 @@ class BatchedMesh extends Mesh {
 					let culled = false;
 					if ( perObjectFrustumCulled ) {
 
-						// get the bounds in camera space
-						this.getMatrixAt( i, _matrix );
-
-						// get the bounds
-						this.getBoundingBoxAt( i, _box ).applyMatrix4( _matrix );
-						culled = ! _frustum.intersectsBox( _box ) || ! _frustum.intersectsSphere( _sphere );
+						culled = ! _frustum.intersectsSphere( _sphere );
 
 					}
 
@@ -1001,13 +997,10 @@ class BatchedMesh extends Mesh {
 					let culled = false;
 					if ( perObjectFrustumCulled ) {
 
-						// get the bounds in camera space
+						// get the bounds in world space
 						this.getMatrixAt( i, _matrix );
-
-						// get the bounds
-						this.getBoundingBoxAt( i, _box ).applyMatrix4( _matrix );
 						this.getBoundingSphereAt( i, _sphere ).applyMatrix4( _matrix );
-						culled = ! _frustum.intersectsBox( _box ) || ! _frustum.intersectsSphere( _sphere );
+						culled = ! _frustum.intersectsSphere( _sphere );
 
 					}
 


### PR DESCRIPTION
Related issue: #22376 

**Description**

Adjusts the BatchedMesh frustum culling logic to use only the bounding sphere as [Frustum.intersectsObject does](https://github.com/mrdoob/three.js/blob/245750c17eb2b58d5cb172ec9d7da6f207eef4ce/src/math/Frustum.js#L79-L99) (I missed this previously). This improves the time to perform frustum culling performance only by over 3x (sorting disabled). Between this and #27213 - the execution time of onBeforeRender can come down significantly from what was reported in #27202.

**Before**

~6.1ms

**After**

~1.9ms