### PR TITLE
BatchedMesh: update example, fix depth conversion & auxiliary buffer

### DIFF
--- a/examples/jsm/utils/SortUtils.js
+++ b/examples/jsm/utils/SortUtils.js
@@ -5,20 +5,16 @@ const POWER = 3;
 const BIT_MAX = 32;
 const BIN_BITS = 1 << POWER;
 const BIN_SIZE = 1 << BIN_BITS;
+const BIN_MAX = BIN_SIZE - 1;
 const ITERATIONS = BIT_MAX / BIN_BITS;
 
 const bins = new Array( ITERATIONS );
-const caches = new Array( ITERATIONS );
-const bins_buffer = new ArrayBuffer( 2 * ITERATIONS * BIN_SIZE * 4 );
+const bins_buffer = new ArrayBuffer( ( ITERATIONS + 1 ) * BIN_SIZE * 4 );
 
 let c = 0;
-for ( let i = 0; i < ITERATIONS; i ++ ) {
-
+for ( let i = 0; i < ( ITERATIONS + 1 ); i ++ ) {
 	bins[ i ] = new Uint32Array( bins_buffer, c, BIN_SIZE );
 	c += BIN_SIZE * 4;
-	caches[ i ] = new Uint32Array( bins_buffer, c, BIN_SIZE );
-	c += BIN_SIZE * 4;
-
 }
 
 const defaultGet = ( el ) => el;
@@ -48,7 +44,7 @@ export const radixSort = ( arr, opt ) => {
 		recurse = ( cache, depth, start ) => {
 
 			let prev = 0;
-			for ( let j = BIN_SIZE - 1; j >= 0; j -- ) {
+			for ( let j = BIN_MAX; j >= 0; j -- ) {
 
 				const cur = cache[ j ], diff = cur - prev;
 				if ( diff != 0 ) {
@@ -135,21 +131,21 @@ export const radixSort = ( arr, opt ) => {
 
 		const shift = ( 3 - depth ) << POWER;
 		const end = start + len;
-
-		const bin = bins[ depth ];
-		const cache = caches[ depth ];
+		
+		const cache = bins[ depth ];
+		const bin = bins[ depth + 1 ];
 
 		bin.fill( 0 );
 
 		for ( let j = start; j < end; j ++ )
-			bin[ ( get( a[ j ] ) >> shift ) & ( BIN_SIZE - 1 ) ] ++;
+			bin[ ( get( a[ j ] ) >> shift ) & BIN_MAX ] ++;
 
 		accumulate( bin );
 
 		cache.set( bin );
 
 		for ( let j = end - 1; j >= start; j -- )
-			b[ start + -- bin[ ( get( a[ j ] ) >> shift ) & ( BIN_SIZE - 1 ) ] ] = a[ j ];
+			b[ start + -- bin[ ( get( a[ j ] ) >> shift ) & BIN_MAX ] ] = a[ j ];
 
 		if ( depth == ITERATIONS - 1 ) return;
 

--- a/examples/jsm/utils/SortUtils.js
+++ b/examples/jsm/utils/SortUtils.js
@@ -131,7 +131,7 @@ export const radixSort = ( arr, opt ) => {
 
 		const shift = ( 3 - depth ) << POWER;
 		const end = start + len;
-		
+
 		const cache = bins[ depth ];
 		const bin = bins[ depth + 1 ];
 

--- a/examples/webgl_mesh_batch.html
+++ b/examples/webgl_mesh_batch.html
@@ -40,6 +40,7 @@
 		let stats, gui, guiStatsEl;
 		let camera, controls, scene, renderer;
 		let geometries, mesh, material;
+		let aux = [];
 		const ids = [];
 		const matrix = new THREE.Matrix4();
 
@@ -49,6 +50,12 @@
 		const rotation = new THREE.Euler();
 		const quaternion = new THREE.Quaternion();
 		const scale = new THREE.Vector3();
+
+		//
+
+		const buffer = new ArrayBuffer( 4 );
+		const f32 = new Float32Array( buffer );
+		const u32 = new Uint32Array( buffer );
 
 		//
 
@@ -188,6 +195,8 @@
 			mesh = new THREE.BatchedMesh( geometryCount, vertexCount, indexCount, createMaterial() );
 			mesh.userData.rotationSpeeds = [];
 
+			aux = new Array( geometryCount );
+
 			// disable full-object frustum culling since all of the objects can be dynamic.
 			mesh.frustumCulled = false;
 
@@ -285,20 +294,18 @@
 		function sortFunction( list, camera ) {
 
 			// initialize options
-			this._options = this._options || {
+			const options = {
 				get: el => el.z,
-				aux: new Array( list.length ),
+				aux: aux,
 			};
 
-			const options = this._options;
 			options.reversed = this.material.transparent;
 
-			// convert depth to unsigned 32 bit range
-			const den = camera.far;
+			// bit-cast depth to unsigned 32-bit
 			for ( let i = 0, l = list.length; i < l; i ++ ) {
 
-				const el = list[ i ];
-				el.z = ( 1 << 30 ) * ( el.z / den );
+				f32[ 0 ] = list[ i ].z;
+				list[ i ].z = u32[ 0 ];
 
 			}
 

--- a/examples/webgl_mesh_batch.html
+++ b/examples/webgl_mesh_batch.html
@@ -53,12 +53,6 @@
 
 		//
 
-		const buffer = new ArrayBuffer( 4 );
-		const f32 = new Float32Array( buffer );
-		const u32 = new Uint32Array( buffer );
-
-		//
-
 		const MAX_GEOMETRY_COUNT = 20000;
 
 		const Method = {
@@ -294,18 +288,21 @@
 		function sortFunction( list, camera ) {
 
 			// initialize options
-			const options = {
+			this._options = this._options || { 
 				get: el => el.z,
-				aux: aux,
+				aux: new Array( this._maxGeometryCount )
 			};
 
+			const options = this._options;
 			options.reversed = this.material.transparent;
 
-			// bit-cast depth to unsigned 32-bit
+			// normalization factor = ( UINT32_MAX / far distance )
+			const factor = ( 2**32 - 1 ) / camera.far;
+
+			// convert depth to unsigned 32 bit range
 			for ( let i = 0, l = list.length; i < l; i ++ ) {
 
-				f32[ 0 ] = list[ i ].z;
-				list[ i ].z = u32[ 0 ];
+				list[i].z *= factor;
 
 			}
 

--- a/examples/webgl_mesh_batch.html
+++ b/examples/webgl_mesh_batch.html
@@ -40,7 +40,6 @@
 		let stats, gui, guiStatsEl;
 		let camera, controls, scene, renderer;
 		let geometries, mesh, material;
-		let aux = [];
 		const ids = [];
 		const matrix = new THREE.Matrix4();
 
@@ -188,8 +187,6 @@
 			const matrix = new THREE.Matrix4();
 			mesh = new THREE.BatchedMesh( geometryCount, vertexCount, indexCount, createMaterial() );
 			mesh.userData.rotationSpeeds = [];
-
-			aux = new Array( geometryCount );
 
 			// disable full-object frustum culling since all of the objects can be dynamic.
 			mesh.frustumCulled = false;

--- a/examples/webgl_mesh_batch.html
+++ b/examples/webgl_mesh_batch.html
@@ -285,7 +285,7 @@
 		function sortFunction( list, camera ) {
 
 			// initialize options
-			this._options = this._options || { 
+			this._options = this._options || {
 				get: el => el.z,
 				aux: new Array( this._maxGeometryCount )
 			};
@@ -293,10 +293,8 @@
 			const options = this._options;
 			options.reversed = this.material.transparent;
 
-			// normalization factor = ( UINT32_MAX / far distance )
-			const factor = ( 2**32 - 1 ) / camera.far;
-
 			// convert depth to unsigned 32 bit range
+			const factor = ( 2**32 - 1 ) / camera.far; // UINT32_MAX / max_depth
 			for ( let i = 0, l = list.length; i < l; i ++ ) {
 
 				list[i].z *= factor;


### PR DESCRIPTION
Related issue: #27202, #27213

`SortUtils`: minor changes - smaller memory footprint.
`webgl_mesh_batch`: converts depth to uint32 by bit-cast instead of normalization.
`webgl_mesh_batch`: correctly maintains auxiliary buffer between calls, based on geometry count.

Simply normalizing the float depth is not enough to correctly sort, as the fractional part gets truncated - producing incorrect ties. If float values are strictly positive, a simple bit-cast is sufficient to solve this. If negative values are possible you can use the following conversion:

```
const f32 = new Float32Array( 1 );
const u32 = new Uint32Array( f32.buffer );
const convert = (val) => {
   f32[0] = val;
   return u32[0] ^ ( - ( val >>> 31 ) | 0x80000000 );
}
```