### PR TITLE
BatchedMesh: Fix MeshBasicMaterial not working

### DIFF
--- a/src/renderers/shaders/ShaderChunk.js
+++ b/src/renderers/shaders/ShaderChunk.js
@@ -7,6 +7,7 @@ import alphatest_pars_fragment from './ShaderChunk/alphatest_pars_fragment.glsl.
 import aomap_fragment from './ShaderChunk/aomap_fragment.glsl.js';
 import aomap_pars_fragment from './ShaderChunk/aomap_pars_fragment.glsl.js';
 import batching_pars_vertex from './ShaderChunk/batching_pars_vertex.glsl.js';
+import batching_vertex from './ShaderChunk/batching_vertex.glsl.js';
 import begin_vertex from './ShaderChunk/begin_vertex.glsl.js';
 import beginnormal_vertex from './ShaderChunk/beginnormal_vertex.glsl.js';
 import bsdfs from './ShaderChunk/bsdfs.glsl.js';
@@ -133,6 +134,7 @@ export const ShaderChunk = {
 	aomap_fragment: aomap_fragment,
 	aomap_pars_fragment: aomap_pars_fragment,
 	batching_pars_vertex: batching_pars_vertex,
+	batching_vertex: batching_vertex,
 	begin_vertex: begin_vertex,
 	beginnormal_vertex: beginnormal_vertex,
 	bsdfs: bsdfs,

--- a/src/renderers/shaders/ShaderChunk/batching_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/batching_vertex.glsl.js
@@ -1,0 +1,5 @@
+export default /* glsl */`
+#ifdef USE_BATCHING
+	mat4 batchingMatrix = getBatchingMatrix( batchId );
+#endif
+`;

--- a/src/renderers/shaders/ShaderChunk/defaultnormal_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/defaultnormal_vertex.glsl.js
@@ -12,7 +12,6 @@ vec3 transformedNormal = objectNormal;
 	// this is in lieu of a per-instance normal-matrix
 	// shear transforms in the instance matrix are not supported
 
-	mat4 batchingMatrix = getBatchingMatrix( batchId );
 	mat3 bm = mat3( batchingMatrix );
 	transformedNormal /= vec3( dot( bm[ 0 ], bm[ 0 ] ), dot( bm[ 1 ], bm[ 1 ] ), dot( bm[ 2 ], bm[ 2 ] ) );
 	transformedNormal = bm * transformedNormal;

--- a/src/renderers/shaders/ShaderLib/depth.glsl.js
+++ b/src/renderers/shaders/ShaderLib/depth.glsl.js
@@ -17,6 +17,7 @@ void main() {
 
 	#include <uv_vertex>
 
+	#include <batching_vertex>
 	#include <skinbase_vertex>
 
 	#ifdef USE_DISPLACEMENTMAP

--- a/src/renderers/shaders/ShaderLib/distanceRGBA.glsl.js
+++ b/src/renderers/shaders/ShaderLib/distanceRGBA.glsl.js
@@ -15,6 +15,7 @@ void main() {
 
 	#include <uv_vertex>
 
+	#include <batching_vertex>
 	#include <skinbase_vertex>
 
 	#ifdef USE_DISPLACEMENTMAP

--- a/src/renderers/shaders/ShaderLib/meshbasic.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshbasic.glsl.js
@@ -15,6 +15,7 @@ void main() {
 	#include <uv_vertex>
 	#include <color_vertex>
 	#include <morphcolor_vertex>
+	#include <batching_vertex>
 
 	#if defined ( USE_ENVMAP ) || defined ( USE_SKINNING )
 

--- a/src/renderers/shaders/ShaderLib/meshlambert.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshlambert.glsl.js
@@ -22,6 +22,7 @@ void main() {
 	#include <uv_vertex>
 	#include <color_vertex>
 	#include <morphcolor_vertex>
+	#include <batching_vertex>
 
 	#include <beginnormal_vertex>
 	#include <morphnormal_vertex>

--- a/src/renderers/shaders/ShaderLib/meshmatcap.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshmatcap.glsl.js
@@ -21,6 +21,8 @@ void main() {
 	#include <uv_vertex>
 	#include <color_vertex>
 	#include <morphcolor_vertex>
+	#include <batching_vertex>
+
 	#include <beginnormal_vertex>
 	#include <morphnormal_vertex>
 	#include <skinbase_vertex>

--- a/src/renderers/shaders/ShaderLib/meshnormal.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshnormal.glsl.js
@@ -20,6 +20,7 @@ export const vertex = /* glsl */`
 void main() {
 
 	#include <uv_vertex>
+	#include <batching_vertex>
 
 	#include <beginnormal_vertex>
 	#include <morphnormal_vertex>

--- a/src/renderers/shaders/ShaderLib/meshphong.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshphong.glsl.js
@@ -22,6 +22,7 @@ void main() {
 	#include <uv_vertex>
 	#include <color_vertex>
 	#include <morphcolor_vertex>
+	#include <batching_vertex>
 
 	#include <beginnormal_vertex>
 	#include <morphnormal_vertex>

--- a/src/renderers/shaders/ShaderLib/meshphysical.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshphysical.glsl.js
@@ -27,6 +27,7 @@ void main() {
 	#include <uv_vertex>
 	#include <color_vertex>
 	#include <morphcolor_vertex>
+	#include <batching_vertex>
 
 	#include <beginnormal_vertex>
 	#include <morphnormal_vertex>

--- a/src/renderers/shaders/ShaderLib/meshtoon.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshtoon.glsl.js
@@ -21,6 +21,7 @@ void main() {
 	#include <uv_vertex>
 	#include <color_vertex>
 	#include <morphcolor_vertex>
+	#include <batching_vertex>
 
 	#include <beginnormal_vertex>
 	#include <morphnormal_vertex>

--- a/src/renderers/shaders/ShaderLib/shadow.glsl.js
+++ b/src/renderers/shaders/ShaderLib/shadow.glsl.js
@@ -9,6 +9,8 @@ export const vertex = /* glsl */`
 
 void main() {
 
+	#include <batching_vertex>
+
 	#include <beginnormal_vertex>
 	#include <morphnormal_vertex>
 	#include <skinbase_vertex>


### PR DESCRIPTION
Related issue: #22376

**Description**

Previously `MeshBasicMaterial` wasn't working with BatchedMesh since the batchMatrix was retrieved in the normal_vertex chunk which basic material did not use. The batch matrix is now retrieved at the beginning of all visual mesh shaders.