### PR TITLE
BatchedMesh: cleanup, add maxGeometryCount member

### DIFF
--- a/docs/api/en/objects/BatchedMesh.html
+++ b/docs/api/en/objects/BatchedMesh.html
@@ -21,8 +21,28 @@
 			<br/>
 			<br/>
 
-			Requires platform support for the [link:https://developer.mozilla.org/en-US/docs/Web/API/WEBGL_multi_draw WEBGL_multi_draw extension].
+			If the [link:https://developer.mozilla.org/en-US/docs/Web/API/WEBGL_multi_draw WEBGL_multi_draw extension] is
+			not supported then a less performant callback is used.
 		</p>
+
+		<h2>Code Example</h2>
+
+		<code>
+		const box = new THREE.BoxGeometry( 1, 1, 1 );
+		const sphere = new THREE.BoxGeometry( 1, 1, 1 );
+		const material = new THREE.MeshBasicMaterial( { color: 0x00ff00 } );
+
+		// initialize and add geometries into the batched mesh
+		const batchedMesh = new BatchedMesh( 10, 5000, 10000, material );
+		const boxId = batchedMesh.addGeometry( box );
+		const sphereId = batchedMesh.addGeometry( sphere );
+
+		// position the geometries
+		batchedMesh.setMatrixAt( boxId, boxMatrix );
+		batchedMesh.setMatrixAt( sphereId, sphereMatrix );
+
+		scene.add( batchedMesh );
+		</code>
 
 		<h2>Examples</h2>
 		<p>
@@ -69,6 +89,11 @@
 			If true then the individual objects within the [name] are sorted to improve overdraw-related artifacts.
 			If the material is marked as "transparent" objects are rendered back to front and if not then they are
 			rendered front to back. Default is `true`.
+		</p>
+
+		<h3>[property:Integer maxGeometryCount]</h3>
+		<p>
+			The maximum number of individual geometries that can be stored in the [name]. Read only.
 		</p>
 
 		<h3>[property:Boolean isBatchedMesh]</h3>

--- a/examples/webgl_mesh_batch.html
+++ b/examples/webgl_mesh_batch.html
@@ -287,17 +287,17 @@
 			// initialize options
 			this._options = this._options || {
 				get: el => el.z,
-				aux: new Array( this._maxGeometryCount )
+				aux: new Array( this.maxGeometryCount )
 			};
 
 			const options = this._options;
 			options.reversed = this.material.transparent;
 
 			// convert depth to unsigned 32 bit range
-			const factor = ( 2**32 - 1 ) / camera.far; // UINT32_MAX / max_depth
+			const factor = ( 2 ** 32 - 1 ) / camera.far; // UINT32_MAX / max_depth
 			for ( let i = 0, l = list.length; i < l; i ++ ) {
 
-				list[i].z *= factor;
+				list[ i ].z *= factor;
 
 			}
 

--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -120,6 +120,12 @@ function copyAttributeData( src, target, targetOffset = 0 ) {
 
 class BatchedMesh extends Mesh {
 
+	get maxGeometryCount() {
+
+		return this._maxGeometryCount;
+
+	}
+
 	constructor( maxGeometryCount, maxVertexCount, maxIndexCount = maxVertexCount * 2, material ) {
 
 		super( new BufferGeometry(), material );
@@ -257,45 +263,6 @@ class BatchedMesh extends Mesh {
 				throw new Error( 'BatchedMesh: All attributes must have a consistent itemSize and normalized value.' );
 
 			}
-
-		}
-
-	}
-
-	getGeometryCount() {
-
-		return this._geometryCount;
-
-	}
-
-	getVertexCount() {
-
-		const reservedRanges = this._reservedRanges;
-		if ( reservedRanges.length === 0 ) {
-
-			return 0;
-
-		} else {
-
-			const finalRange = reservedRanges[ reservedRanges.length - 1 ];
-			return finalRange.vertexStart + finalRange.vertexCount;
-
-		}
-
-	}
-
-	getIndexCount() {
-
-		const reservedRanges = this._reservedRanges;
-		const geometry = this.geometry;
-		if ( geometry.getIndex() === null || reservedRanges.length === 0 ) {
-
-			return 0;
-
-		} else {
-
-			const finalRange = reservedRanges[ reservedRanges.length - 1 ];
-			return finalRange.indexStart + finalRange.indexCount;
 
 		}
 


### PR DESCRIPTION
Related issue: #22376, #27228

**Description**

- Add `maxGeometryCount` as a public, readonly member
- Remove unused getter functions (can be readded when we find a use)
- Update documentation
- Linting in batched mesh example