### PR TITLE
AudioLoader: Fix uncaught `DOMException` in promise.

### DIFF
--- a/src/loaders/AudioLoader.js
+++ b/src/loaders/AudioLoader.js
@@ -32,7 +32,7 @@ class AudioLoader extends Loader {
 
 					onLoad( audioBuffer );
 
-				}, handleError );
+				} ).catch( handleError );
 
 			} catch ( e ) {
 


### PR DESCRIPTION
Fixed #21754.

**Description**

Although the `onError()` callback is called when using `AudioLoader.load()`, there is still an uncaught DOMException of the returned promise. This can be reproduced with https://jsfiddle.net/DRL9/epnz47dj/1/.

The PR fixes the issue by implementing the error handling with the promise syntax.