### PR TITLE
NodeMaterial: Rename .colorSpace -> .colorSpaced property

### DIFF
--- a/examples/jsm/nodes/materials/MeshNormalNodeMaterial.js
+++ b/examples/jsm/nodes/materials/MeshNormalNodeMaterial.js
@@ -17,7 +17,7 @@ class MeshNormalNodeMaterial extends NodeMaterial {
 
 		this.isMeshNormalNodeMaterial = true;
 
-		this.colorSpace = false;
+		this.colorSpaced = false;
 
 		this.setDefaultValues( defaultValues );
 

--- a/examples/jsm/nodes/materials/NodeMaterial.js
+++ b/examples/jsm/nodes/materials/NodeMaterial.js
@@ -37,7 +37,8 @@ class NodeMaterial extends ShaderMaterial {
 		this.fog = true;
 		this.lights = true;
 		this.normals = true;
-		this.colorSpace = true;
+
+		this.colorSpaced = true;
 
 		this.lightsNode = null;
 		this.envNode = null;
@@ -334,7 +335,7 @@ class NodeMaterial extends ShaderMaterial {
 
 		// ENCODING
 
-		if ( this.colorSpace === true ) {
+		if ( this.colorSpaced === true ) {
 
 			const renderTarget = renderer.getRenderTarget();
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/26440#discussion_r1328277315

**Description**

Folowing the same logic of `Material.toneMapped`.