### PR TITLE
NodeMaterial: Prioritize .depthNode

### DIFF
--- a/examples/jsm/nodes/materials/NodeMaterial.js
+++ b/examples/jsm/nodes/materials/NodeMaterial.js
@@ -130,7 +130,7 @@ class NodeMaterial extends ShaderMaterial {
 
 		let depthNode = this.depthNode;
 
-		if ( renderer.logarithmicDepthBuffer === true ) {
+		if ( depthNode === null && renderer.logarithmicDepthBuffer === true ) {
 
 			const fragDepth = modelViewProjection().w.add( 1 );
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/27243

**Description**

Prioritize `material.depthNode` value.
