### PR TITLE
WebGLArrayRenderTarget: Missing options in constructor

### DIFF
--- a/src/renderers/WebGL3DRenderTarget.js
+++ b/src/renderers/WebGL3DRenderTarget.js
@@ -2,17 +2,21 @@ import { WebGLRenderTarget } from './WebGLRenderTarget.js';
 import { Data3DTexture } from '../textures/Data3DTexture.js';
 
 class WebGL3DRenderTarget extends WebGLRenderTarget {
-  constructor(width = 1, height = 1, depth = 1) {
-    super(width, height);
 
-    this.isWebGL3DRenderTarget = true;
+	constructor( width = 1, height = 1, depth = 1, options = {} ) {
 
-    this.depth = depth;
+		super( width, height, options );
 
-    this.texture = new Data3DTexture(null, width, height, depth);
+		this.isWebGL3DRenderTarget = true;
 
-    this.texture.isRenderTargetTexture = true;
-  }
+		this.depth = depth;
+
+		this.texture = new Data3DTexture( null, width, height, depth );
+
+		this.texture.isRenderTargetTexture = true;
+
+	}
+
 }
 
 export { WebGL3DRenderTarget };

--- a/src/renderers/WebGL3DRenderTarget.js
+++ b/src/renderers/WebGL3DRenderTarget.js
@@ -2,21 +2,17 @@ import { WebGLRenderTarget } from './WebGLRenderTarget.js';
 import { Data3DTexture } from '../textures/Data3DTexture.js';
 
 class WebGL3DRenderTarget extends WebGLRenderTarget {
+  constructor(width = 1, height = 1, depth = 1) {
+    super(width, height);
 
-	constructor( width = 1, height = 1, depth = 1 ) {
+    this.isWebGL3DRenderTarget = true;
 
-		super( width, height );
+    this.depth = depth;
 
-		this.isWebGL3DRenderTarget = true;
+    this.texture = new Data3DTexture(null, width, height, depth);
 
-		this.depth = depth;
-
-		this.texture = new Data3DTexture( null, width, height, depth );
-
-		this.texture.isRenderTargetTexture = true;
-
-	}
-
+    this.texture.isRenderTargetTexture = true;
+  }
 }
 
 export { WebGL3DRenderTarget };

--- a/src/renderers/WebGLArrayRenderTarget.js
+++ b/src/renderers/WebGLArrayRenderTarget.js
@@ -2,21 +2,17 @@ import { WebGLRenderTarget } from './WebGLRenderTarget.js';
 import { DataArrayTexture } from '../textures/DataArrayTexture.js';
 
 class WebGLArrayRenderTarget extends WebGLRenderTarget {
+  constructor(width = 1, height = 1, depth = 1, options = {}) {
+    super(width, height, options);
 
-	constructor( width = 1, height = 1, depth = 1 ) {
+    this.isWebGLArrayRenderTarget = true;
 
-		super( width, height );
+    this.depth = depth;
 
-		this.isWebGLArrayRenderTarget = true;
+    this.texture = new DataArrayTexture(null, width, height, depth);
 
-		this.depth = depth;
-
-		this.texture = new DataArrayTexture( null, width, height, depth );
-
-		this.texture.isRenderTargetTexture = true;
-
-	}
-
+    this.texture.isRenderTargetTexture = true;
+  }
 }
 
 export { WebGLArrayRenderTarget };

--- a/src/renderers/WebGLArrayRenderTarget.js
+++ b/src/renderers/WebGLArrayRenderTarget.js
@@ -2,17 +2,21 @@ import { WebGLRenderTarget } from './WebGLRenderTarget.js';
 import { DataArrayTexture } from '../textures/DataArrayTexture.js';
 
 class WebGLArrayRenderTarget extends WebGLRenderTarget {
-  constructor(width = 1, height = 1, depth = 1, options = {}) {
-    super(width, height, options);
 
-    this.isWebGLArrayRenderTarget = true;
+	constructor( width = 1, height = 1, depth = 1, options = {} ) {
 
-    this.depth = depth;
+		super( width, height, options );
 
-    this.texture = new DataArrayTexture(null, width, height, depth);
+		this.isWebGLArrayRenderTarget = true;
 
-    this.texture.isRenderTargetTexture = true;
-  }
+		this.depth = depth;
+
+		this.texture = new DataArrayTexture( null, width, height, depth );
+
+		this.texture.isRenderTargetTexture = true;
+
+	}
+
 }
 
 export { WebGLArrayRenderTarget };


### PR DESCRIPTION
Added `options` parameter to `WebGLArrayRenderTarget` and `WebGL3DRenderTarget`