### PR TITLE
Object3D: Add onBeforeShadow and onAfterShadow callbacks

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -117,6 +117,10 @@ class Object3D extends EventDispatcher {
 
 	}
 
+	onBeforeShadow( /* renderer, object, camera, shadowCamera, geometry, depthMaterial, group */ ) {}
+
+	onAfterShadow( /* renderer, object, camera, shadowCamera, geometry, depthMaterial, group */ ) {}
+
 	onBeforeRender( /* renderer, scene, camera, geometry, material, group */ ) {}
 
 	onAfterRender( /* renderer, scene, camera, geometry, material, group */ ) {}

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -355,7 +355,11 @@ function WebGLShadowMap( _renderer, _objects, _capabilities ) {
 
 							const depthMaterial = getDepthMaterial( object, groupMaterial, light, type );
 
+							object.onBeforeShadow( _renderer, object, camera, shadowCamera, geometry, depthMaterial, group );
+
 							_renderer.renderBufferDirect( shadowCamera, null, geometry, depthMaterial, object, group );
+
+							object.onAfterShadow( _renderer, object, camera, shadowCamera, geometry, depthMaterial, group );
 
 						}
 
@@ -365,7 +369,11 @@ function WebGLShadowMap( _renderer, _objects, _capabilities ) {
 
 					const depthMaterial = getDepthMaterial( object, material, light, type );
 
+					object.onBeforeShadow( _renderer, object, camera, shadowCamera, geometry, depthMaterial, null );
+
 					_renderer.renderBufferDirect( shadowCamera, null, geometry, depthMaterial, object, null );
+
+					object.onAfterShadow( _renderer, object, camera, shadowCamera, geometry, depthMaterial, null );
 
 				}
 


### PR DESCRIPTION
Fixed #14921.

Reopening #25933.

This PR introduces two new optional callbacks to the Object3D class in three.js. The onBeforeShadow and onAfterShadow callbacks allow developers to execute custom code immediately before and after the shadow of a 3D object is rendered, respectively. These callbacks provide the following parameters: renderer, scene, camera, shadowCamera, geometry, depthMaterial, and group.

Example usage:
```js
cube.onBeforeShadow = function ( renderer, scene, camera, shadowCamera, geometry, depthMaterial, group ) {

	anothercube.visible = true;
	anothercube.modelViewMatrix.multiplyMatrices( shadowCamera.matrixWorldInverse, anothercube.matrixWorld );
	renderer.renderBufferDirect( shadowCamera, null, anothercube.geometry, depthMaterial, anothercube, group );

};

cube.onAfterShadow = function ( ) {

	anothercube.visible = false;

};
```

Seems that we would really need it for the newly introduced `BatchedMesh` /cc @gkjohnson.

 https://github.com/mrdoob/three.js/issues/14921#issuecomment-1826777214