### PR TITLE
WebGLUniforms: Add `sampler2DShadow` support.

### DIFF
--- a/src/renderers/webgl/WebGLUniforms.js
+++ b/src/renderers/webgl/WebGLUniforms.js
@@ -571,8 +571,7 @@ function setValueT1( gl, v, textures ) {
 
 	let emptyTexture2D = emptyTexture;
 
-	// if type is a sampler2DShadow, use the empty shadow texture.
-	if ( ! v && this.type === 0x8b62 ) {
+	if ( ! v && this.type === gl.SAMPLER_2D_SHADOW ) {
 
 		emptyTexture2D = emptyShadowTexture;
 

--- a/src/renderers/webgl/WebGLUniforms.js
+++ b/src/renderers/webgl/WebGLUniforms.js
@@ -45,8 +45,13 @@ import { CubeTexture } from '../../textures/CubeTexture.js';
 import { Texture } from '../../textures/Texture.js';
 import { DataArrayTexture } from '../../textures/DataArrayTexture.js';
 import { Data3DTexture } from '../../textures/Data3DTexture.js';
+import { DepthTexture } from '../../textures/DepthTexture.js';
+import { LessEqualCompare } from '../../constants.js';
 
 const emptyTexture = /*@__PURE__*/ new Texture();
+
+const emptyShadowTexture = /*@__PURE__*/ new DepthTexture( 1, 1, null, null, null, null, null, null, null, null, LessEqualCompare );
+
 const emptyArrayTexture = /*@__PURE__*/ new DataArrayTexture();
 const empty3dTexture = /*@__PURE__*/ new Data3DTexture();
 const emptyCubeTexture = /*@__PURE__*/ new CubeTexture();
@@ -563,7 +568,16 @@ function setValueT1( gl, v, textures ) {
 
 	}
 
-	textures.setTexture2D( v || emptyTexture, unit );
+	let emptyTexture2D = emptyTexture;
+
+	// if type is a sampler2DShadow, use the empty shadow texture.
+	if ( ! v && this.type === 0x8b62 ) {
+
+		emptyTexture2D = emptyShadowTexture;
+
+	}
+
+	textures.setTexture2D( v || emptyTexture2D, unit );
 
 }
 
@@ -947,6 +961,7 @@ class SingleUniform {
 		this.id = id;
 		this.addr = addr;
 		this.cache = [];
+		this.type = activeInfo.type;
 		this.setValue = getSingularSetter( activeInfo.type );
 
 		// this.path = activeInfo.name; // DEBUG
@@ -962,6 +977,7 @@ class PureArrayUniform {
 		this.id = id;
 		this.addr = addr;
 		this.cache = [];
+		this.type = activeInfo.type;
 		this.size = activeInfo.size;
 		this.setValue = getPureArraySetter( activeInfo.type );
 

--- a/src/renderers/webgl/WebGLUniforms.js
+++ b/src/renderers/webgl/WebGLUniforms.js
@@ -50,7 +50,8 @@ import { LessEqualCompare } from '../../constants.js';
 
 const emptyTexture = /*@__PURE__*/ new Texture();
 
-const emptyShadowTexture = /*@__PURE__*/ new DepthTexture( 1, 1, null, null, null, null, null, null, null, null, LessEqualCompare );
+const emptyShadowTexture = /*@__PURE__*/ new DepthTexture( 1, 1 );
+emptyShadowTexture.compareFunction = LessEqualCompare;
 
 const emptyArrayTexture = /*@__PURE__*/ new DataArrayTexture();
 const empty3dTexture = /*@__PURE__*/ new Data3DTexture();

--- a/src/renderers/webgl/WebGLUniforms.js
+++ b/src/renderers/webgl/WebGLUniforms.js
@@ -569,13 +569,7 @@ function setValueT1( gl, v, textures ) {
 
 	}
 
-	let emptyTexture2D = emptyTexture;
-
-	if ( ! v && this.type === gl.SAMPLER_2D_SHADOW ) {
-
-		emptyTexture2D = emptyShadowTexture;
-
-	}
+	const emptyTexture2D = ( this.type === gl.SAMPLER_2D_SHADOW ) ? emptyShadowTexture : emptyTexture;
 
 	textures.setTexture2D( v || emptyTexture2D, unit );
 


### PR DESCRIPTION
Init `sampler2DShadow` if the texture is not set yet by the user to `WebGLUniforms`. 

Basically if in your shader you're using a `sampler2DShadow` and you didn't bind the correct texture format yet, WebGL will not be happy and crash as it will fallback to a basic texture.

~~Requires `compareFunc` parameter in `DepthTexture` constructor #27251 (otherwise we need `needsUpdate=true` which is probably something we don't want to add in `WebGLUniforms`.~~

All these elements are necessary for  a better implementation of shadows that I want to introduce in the future that use `sampler2DShadow` instead of `sampler2D`.