### PR TITLE
Docs: Improve `Object3D` page.

### DIFF
--- a/docs/api/ar/core/Object3D.html
+++ b/docs/api/ar/core/Object3D.html
@@ -143,12 +143,42 @@
 			أو [page:Bone] ليست قابلة للتقديم وبالتالي لا يتم تنفيذ هذا الرد الاتصال
 			لمثل هذه الكائنات.
 		</p>
+
+		<h3>[property:Function onAfterShadow]</h3>
+		<p>
+			An optional callback that is executed immediately after a 3D object is
+			rendered to a shadow map. This function is called with the following parameters: renderer,
+			scene, camera, shadowCamera, geometry, depthMaterial, group.
+		</p>
+		<p>
+			يرجى ملاحظة أن هذا الرد الاتصال يتم تنفيذه فقط لـ `renderable` 3D
+			كائنات. معنى كائنات ثلاثية الأبعاد التي تحدد مظهرها المرئي مع
+			الهندسة والمواد مثل نسخ [page:Mesh]، [page:Line]،
+			[page:Points] أو [page:Sprite]. نسخ من [page:Object3D]، [page:Group]
+			أو [page:Bone] ليست قابلة للتقديم وبالتالي لا يتم تنفيذ هذا الرد الاتصال
+			لمثل هذه الكائنات.
+		</p>
 			 
 		<h3>[property:Function onBeforeRender]</h3>
 		<p>
 			رد اتصال اختياري يتم تنفيذه مباشرة قبل تقديم كائن ثلاثي الأبعاد
 			. يتم استدعاء هذه الوظيفة بالمعلمات التالية: renderer,
 			scene, camera, geometry, material, group.
+		</p>
+		<p>
+			يرجى ملاحظة أن هذا الرد الاتصال يتم تنفيذه فقط لـ `renderable` 3D
+			كائنات. معنى كائنات ثلاثية الأبعاد التي تحدد مظهرها المرئي مع
+			الهندسة والمواد مثل نسخ [page:Mesh]، [page:Line]،
+			[page:Points] أو [page:Sprite]. نسخ من [page:Object3D]، [page:Group]
+			أو [page:Bone] ليست قابلة للتقديم وبالتالي لا يتم تنفيذ هذا الرد الاتصال
+			لمثل هذه الكائنات.
+		</p>
+
+		<h3>[property:Function onBeforeShadow]</h3>
+		<p>
+			An optional callback that is executed immediately before a 3D object is
+			rendered to a shadow map. This function is called with the following parameters: renderer,
+			scene, camera, shadowCamera, geometry, depthMaterial, group.
 		</p>
 		<p>
 			يرجى ملاحظة أن هذا الرد الاتصال يتم تنفيذه فقط لـ `renderable` 3D

--- a/docs/api/en/core/Object3D.html
+++ b/docs/api/en/core/Object3D.html
@@ -144,11 +144,41 @@
 			for such objects.
 		</p>
 
+		<h3>[property:Function onAfterShadow]</h3>
+		<p>
+			An optional callback that is executed immediately after a 3D object is
+			rendered to a shadow map. This function is called with the following parameters: renderer,
+			scene, camera, shadowCamera, geometry, depthMaterial, group.
+		</p>
+		<p>
+			Please notice that this callback is only executed for `renderable` 3D
+			objects. Meaning 3D objects which define their visual appearance with
+			geometries and materials like instances of [page:Mesh], [page:Line],
+			[page:Points] or [page:Sprite]. Instances of [page:Object3D], [page:Group]
+			or [page:Bone] are not renderable and thus this callback is not executed
+			for such objects.
+		</p>
+
 		<h3>[property:Function onBeforeRender]</h3>
 		<p>
 			An optional callback that is executed immediately before a 3D object is
 			rendered. This function is called with the following parameters: renderer,
 			scene, camera, geometry, material, group.
+		</p>
+		<p>
+			Please notice that this callback is only executed for `renderable` 3D
+			objects. Meaning 3D objects which define their visual appearance with
+			geometries and materials like instances of [page:Mesh], [page:Line],
+			[page:Points] or [page:Sprite]. Instances of [page:Object3D], [page:Group]
+			or [page:Bone] are not renderable and thus this callback is not executed
+			for such objects.
+		</p>
+
+		<h3>[property:Function onBeforeShadow]</h3>
+		<p>
+			An optional callback that is executed immediately before a 3D object is
+			rendered to a shadow map. This function is called with the following parameters: renderer,
+			scene, camera, shadowCamera, geometry, depthMaterial, group.
 		</p>
 		<p>
 			Please notice that this callback is only executed for `renderable` 3D

--- a/docs/api/it/core/Object3D.html
+++ b/docs/api/it/core/Object3D.html
@@ -128,6 +128,17 @@
       Invece, le istanze di [page:Object3D], [page:Group] o [page:Bone] non sono renderizzabili e quindi questa callback non viene eseguita su questi oggetti.
 		</p>
 
+		<h3>[property:Function onAfterShadow]</h3>
+		<p>
+			An optional callback that is executed immediately after a 3D object is rendered to a shadow map. 
+			Questa funzione è chiamata con i seguenti parametri: renderer, scene, camera, shadowCamera, geometry, depthMaterial, group.
+		</p>
+		<p>
+			Si noti che questa funzione di callback viene eseguita per oggi 3D `renderizzabili` (renderable). Ovvero oggetti 3D che definiscono
+			il loro aspetto visivo con geometrie e materiali come istanze di [page:Mesh], [page:Line], [page:Points] o [page:Sprite].
+			Invece, le istanze di [page:Object3D], [page:Group] o [page:Bone] non sono renderizzabili e quindi questa callback non viene eseguita su questi oggetti.
+		</p>
+
 		<h3>[property:Function onBeforeRender]</h3>
 		<p>
       Una callback opzionale che viene eseguita immediatamente prima che un oggetto 3D è stato renderizzato.
@@ -137,6 +148,17 @@
       Si noti che questa funzione di callback viene eseguita per oggi 3D `renderizzabili` (renderable). Ovvero oggetti 3D che definiscono
       il loro aspetto visivo con geometrie e materiali come istanze di [page:Mesh], [page:Line], [page:Points] o [page:Sprite].
       Invece, le istanze di [page:Object3D], [page:Group] o [page:Bone] non sono renderizzabili e quindi questa callback non viene eseguita su questi oggetti.
+		</p>
+
+		<h3>[property:Function onBeforeShadow]</h3>
+		<p>
+			An optional callback that is executed immediately before a 3D object is rendered to a shadow map. 
+			Questa funzione è chiamata con i seguenti parametri: renderer, scene, camera, shadowCamera, geometry, depthMaterial, group.
+		</p>
+		<p>
+			Si noti che questa funzione di callback viene eseguita per oggi 3D `renderizzabili` (renderable). Ovvero oggetti 3D che definiscono
+			il loro aspetto visivo con geometrie e materiali come istanze di [page:Mesh], [page:Line], [page:Points] o [page:Sprite].
+			Invece, le istanze di [page:Object3D], [page:Group] o [page:Bone] non sono renderizzabili e quindi questa callback non viene eseguita su questi oggetti.
 		</p>
 
 		<h3>[property:Object3D parent]</h3>

--- a/docs/api/ko/core/Object3D.html
+++ b/docs/api/ko/core/Object3D.html
@@ -122,10 +122,32 @@
 		[page:Object3D], [page:Group] 혹은 [page:Bone] 인스턴스는 렌더링할 수 없으므로 이러한 객체에 대해서는 콜백이 실행되지 않습니다.
 		</p>
 
+		<h3>[property:Function onAfterShadow]</h3>
+		<p>
+			An optional callback that is executed immediately after a 3D object is
+			rendered to a shadow map. This function is called with the following parameters: renderer,
+			scene, camera, shadowCamera, geometry, depthMaterial, group.
+		</p>
+		<p>
+			이 콜백은 *렌더링 가능한* 3D 객체에만 실행됩니다. [page:Mesh], [page:Line], [page:Points] 혹은 [page:Sprite]같은 기하학 및 재질로 시각적 표현을 정의하는 3D 객체들에 한정됩니다.
+			[page:Object3D], [page:Group] 혹은 [page:Bone] 인스턴스는 렌더링할 수 없으므로 이러한 객체에 대해서는 콜백이 실행되지 않습니다.
+		</p>
+
 		<h3>[property:Function onBeforeRender]</h3>
 		<p>
 			3D 객체가 렌더링되기 바로 전에 실행되는 선택적 콜백입니다.
 			이 함수는 렌더러, 장면, 카메라, 기하학, 재질, 그룹 등의 매개 변수를 사용하여 호출됩니다.
+		</p>
+		<p>
+			이 콜백은 *렌더링 가능한* 3D 객체에만 실행됩니다. [page:Mesh], [page:Line], [page:Points] 혹은 [page:Sprite]같은 기하학 및 재질로 시각적 표현을 정의하는 3D 객체들에 한정됩니다.
+			[page:Object3D], [page:Group] 혹은 [page:Bone] 인스턴스는 렌더링할 수 없으므로 이러한 객체에 대해서는 콜백이 실행되지 않습니다.
+		</p>
+
+		<h3>[property:Function onBeforeShadow]</h3>
+		<p>
+			An optional callback that is executed immediately before a 3D object is
+			rendered to a shadow map. This function is called with the following parameters: renderer,
+			scene, camera, shadowCamera, geometry, depthMaterial, group.
 		</p>
 		<p>
 			이 콜백은 *렌더링 가능한* 3D 객체에만 실행됩니다. [page:Mesh], [page:Line], [page:Points] 혹은 [page:Sprite]같은 기하학 및 재질로 시각적 표현을 정의하는 3D 객체들에 한정됩니다.

--- a/docs/api/zh/core/Object3D.html
+++ b/docs/api/zh/core/Object3D.html
@@ -116,6 +116,17 @@
 	[page:Object3D]、 [page:Group] 或者 [page:Bone] 这些是不可渲染的物体，因此此回调函数不会在这样的物体上执行。
 	</p>
 
+	<h3>[property:Function onAfterShadow]</h3>
+	<p>
+		An optional callback that is executed immediately after a 3D object is
+		rendered to a shadow map. This function is called with the following parameters: renderer,
+		scene, camera, shadowCamera, geometry, depthMaterial, group.
+	</p>
+	<p>
+		注意此回调函数只会在*可渲染*的3D物体上执行。可渲染的3D物体指的是那种拥有视觉表现的、定义了几何体与材质的物体，例如像是[page:Mesh]、[page:Line]、[page:Points] 或者[page:Sprite]。
+		[page:Object3D]、 [page:Group] 或者 [page:Bone] 这些是不可渲染的物体，因此此回调函数不会在这样的物体上执行。
+	</p>
+
 	<h3>[property:Function onBeforeRender]</h3>
 	<p>
 		一个可选的回调函数，在Object3D渲染之前直接执行。
@@ -124,6 +135,17 @@
 	<p>
 	注意此回调函数只会在*可渲染*的3D物体上执行。可渲染的3D物体指的是那种拥有视觉表现的、定义了几何体与材质的物体，例如像是[page:Mesh]、[page:Line]、[page:Points] 或者[page:Sprite]。
 	[page:Object3D]、 [page:Group] 或者 [page:Bone] 这些是不可渲染的物体，因此此回调函数不会在这样的物体上执行。
+	</p>
+
+	<h3>[property:Function onBeforeShadow]</h3>
+	<p>
+		An optional callback that is executed immediately before a 3D object is
+		rendered to a shadow map. This function is called with the following parameters: renderer,
+		scene, camera, shadowCamera, geometry, depthMaterial, group.
+	</p>
+	<p>
+		注意此回调函数只会在*可渲染*的3D物体上执行。可渲染的3D物体指的是那种拥有视觉表现的、定义了几何体与材质的物体，例如像是[page:Mesh]、[page:Line]、[page:Points] 或者[page:Sprite]。
+		[page:Object3D]、 [page:Group] 或者 [page:Bone] 这些是不可渲染的物体，因此此回调函数不会在这样的物体上执行。
 	</p>
 
 	<h3>[property:Object3D parent]</h3>


### PR DESCRIPTION
Related issue: #27250

**Description**

Adds the new `onAfterShadow()` and `onBeforeShadow()` callbacks to the `Object3D` doc pages.