### PR TITLE
USDZExporter: Remove obsolete code in `buildVector2Array()`.

### DIFF
--- a/examples/jsm/exporters/USDZExporter.js
+++ b/examples/jsm/exporters/USDZExporter.js
@@ -287,7 +287,7 @@ function buildMesh( geometry ) {
 			interpolation = "vertex"
 		)
 		point3f[] points = [${ buildVector3Array( attributes.position, count )}]
-${ buildPrimvars( attributes, count ) }
+${ buildPrimvars( attributes ) }
 		uniform token subdivisionScheme = "none"
 	}
 `;
@@ -356,14 +356,7 @@ function buildVector3Array( attribute, count ) {
 
 }
 
-function buildVector2Array( attribute, count ) {
-
-	if ( attribute === undefined ) {
-
-		console.warn( 'USDZExporter: UVs missing.' );
-		return Array( count ).fill( '(0, 0)' ).join( ', ' );
-
-	}
+function buildVector2Array( attribute ) {
 
 	const array = [];
 
@@ -380,7 +373,7 @@ function buildVector2Array( attribute, count ) {
 
 }
 
-function buildPrimvars( attributes, count ) {
+function buildPrimvars( attributes ) {
 
 	let string = '';
 
@@ -392,7 +385,7 @@ function buildPrimvars( attributes, count ) {
 		if ( attribute !== undefined ) {
 
 			string += `
-		texCoord2f[] primvars:st${ id } = [${ buildVector2Array( attribute, count )}] (
+		texCoord2f[] primvars:st${ id } = [${ buildVector2Array( attribute )}] (
 			interpolation = "vertex"
 		)`;
 


### PR DESCRIPTION
Related issue: -

**Description**

The PR removes a `if` clause from `buildVector2Array()` that is never executed. That happens since #25996 because `buildPrimvars()` now always calls `buildVector2Array()` with a defined attribute.

@mrdoob The code that adds default uvs was present since the first commit of the exporter. I'm not sure defining default uvs is required but the respective code has no effect right now.