### PR TITLE
OrbitControls: Remove useless assignment.

### DIFF
--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -398,8 +398,6 @@ class OrbitControls extends EventDispatcher {
 					lastQuaternion.copy( scope.object.quaternion );
 					lastTargetPosition.copy( scope.target );
 
-					zoomChanged = false;
-
 					return true;
 
 				}


### PR DESCRIPTION
Related issue: -

**Description**

An assignment to the local variable `zoomChanged` in `update()` has no effect since it is later never read again.
