### PR TITLE
GLTFExporter: Restore multi material support for non-indexed geometries.

### DIFF
--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -1835,6 +1835,24 @@ class GLTFWriter {
 
 		if ( isMultiMaterial && geometry.groups.length === 0 ) return null;
 
+		let didForceIndices = false;
+
+		if ( isMultiMaterial && geometry.index === null ) {
+
+			const indices = [];
+
+			for ( let i = 0, il = geometry.attributes.position.count; i < il; i ++ ) {
+
+				indices[ i ] = i;
+
+			}
+
+			geometry.setIndex( indices );
+
+			didForceIndices = true;
+
+		}
+
 		const materials = isMultiMaterial ? mesh.material : [ mesh.material ];
 		const groups = isMultiMaterial ? geometry.groups : [ { materialIndex: 0, start: undefined, count: undefined } ];
 
@@ -1879,6 +1897,12 @@ class GLTFWriter {
 			if ( material !== null ) primitive.material = material;
 
 			primitives.push( primitive );
+
+		}
+
+		if ( didForceIndices === true ) {
+
+			geometry.setIndex( null );
 
 		}
 


### PR DESCRIPTION
Fixed #21538.

**Description**

When the `forceIndices` flag was removed via #19113, a code section was deleted that ensured group data were honored of non-indexed geometries. This PR restores the original code from #13536 which means a temporary index is created so the primitive generation works as expected.

@danielealbano With this PR in place, I was able to correctly export the problematic zombie FBX asset from #27259 to glTF. This is how it looks like in Don's viewer:

<img width="1747" alt="image" src="https://github.com/mrdoob/three.js/assets/12612165/1fa1a5e7-41a2-4ffb-8b28-7b8e692df946">
