### PR TITLE
src: Default parameters for ES6

### DIFF
--- a/src/extras/curves/ArcCurve.js
+++ b/src/extras/curves/ArcCurve.js
@@ -2,7 +2,7 @@ import { EllipseCurve } from './EllipseCurve.js';
 
 class ArcCurve extends EllipseCurve {
 
-	constructor( aX, aY, aRadius, aStartAngle, aEndAngle, aClockwise ) {
+	constructor( aX = 0, aY = 0, aRadius = 1, aStartAngle = 0, aEndAngle = Math.PI * 2, aClockwise = false ) {
 
 		super( aX, aY, aRadius, aRadius, aStartAngle, aEndAngle, aClockwise );
 


### PR DESCRIPTION
Related issue: #XXXX

**Description**

Added default parameters for `ArcCurve`.