### PR TITLE
Docs: Improve `LineDashedMaterial` page.

### DIFF
--- a/docs/api/ar/materials/LineDashedMaterial.html
+++ b/docs/api/ar/materials/LineDashedMaterial.html
@@ -12,7 +12,8 @@
 		<h1>[name]</h1>
 
 		<p class="desc">
-			مادة لرسم الهندسة على طريقة الإطار السلكي بخطوط متقطعة.
+			مادة لرسم الهندسة على طريقة الإطار السلكي بخطوط متقطعة.<br />
+			Note: Make sure to call [page:Line.computeLineDistances]() when using [name].
 		</p>
 		 
 		<h2>مثال الكود</h2>

--- a/docs/api/en/materials/LineDashedMaterial.html
+++ b/docs/api/en/materials/LineDashedMaterial.html
@@ -12,7 +12,8 @@
 		<h1>[name]</h1>
 
 		<p class="desc">
-			A material for drawing wireframe-style geometries with dashed lines.
+			A material for drawing wireframe-style geometries with dashed lines.<br />
+			Note: Make sure to call [page:Line.computeLineDistances]() when using [name].
 		</p>
 
 		<h2>Code Example</h2>

--- a/docs/api/fr/materials/LineDashedMaterial.html
+++ b/docs/api/fr/materials/LineDashedMaterial.html
@@ -11,7 +11,10 @@
 
 		<h1>[name]</h1>
 
-		<p class="desc">Un matériau pour dessiner des géométries de style filaire, avec des pointillés.</p>
+		<p class="desc">
+			Un matériau pour dessiner des géométries de style filaire, avec des pointillés.<br />
+			Note: Make sure to call [page:Line.computeLineDistances]() when using [name].
+		</p>
 
 		<h2>Exemple de Code</h2>
 

--- a/docs/api/it/materials/LineDashedMaterial.html
+++ b/docs/api/it/materials/LineDashedMaterial.html
@@ -11,7 +11,10 @@
 
 		<h1>[name]</h1>
 
-		<p class="desc">Un materiale per disegnare geometrie in stile wireframe con linee tratteggiate.</p>
+		<p class="desc">
+			Un materiale per disegnare geometrie in stile wireframe con linee tratteggiate.<br />
+			Note: Make sure to call [page:Line.computeLineDistances]() when using [name].
+		</p>
 
 		<h2>Codice di Esempio</h2>
 

--- a/docs/api/zh/materials/LineDashedMaterial.html
+++ b/docs/api/zh/materials/LineDashedMaterial.html
@@ -11,7 +11,10 @@
 
 		<h1>虚线材质([name])</h1>
 
-		<p class="desc">一种用于绘制虚线样式几何体的材质。</p>
+		<p class="desc">
+			一种用于绘制虚线样式几何体的材质。<br />
+			Note: Make sure to call [page:Line.computeLineDistances]() when using [name].
+		</p>
 
 		<h2>代码示例</h2>
 


### PR DESCRIPTION
Related issue: #27255

**Description**

Adds a note to the `LineDashedMaterial` page that `Line.computeLineDistances()` has to be used with this material type.