### PR TITLE
Examples: bump @monogrid/gainmap-js to v3.0.0 in webgl_loader_texture_hdrjpg.html

### DIFF
--- a/examples/webgl_loader_texture_hdrjpg.html
+++ b/examples/webgl_loader_texture_hdrjpg.html
@@ -39,7 +39,7 @@
 				"imports": {
 					"three": "../build/three.module.js",
 					"three/addons/": "./jsm/",
-					"@monogrid/gainmap-js": "https://unpkg.com/@monogrid/gainmap-js@2.0.6/dist/decode.js"
+					"@monogrid/gainmap-js": "https://unpkg.com/@monogrid/gainmap-js@3.0.0/dist/decode.js"
 				}
 			}
 		</script>
@@ -138,11 +138,9 @@
 						hdrJpgPMREMRenderTarget = pmremGenerator.fromEquirectangular( hdrJpgEquirectangularMap );
 			
 						hdrJpgEquirectangularMap.mapping = THREE.EquirectangularReflectionMapping;
-						hdrJpgEquirectangularMap.minFilter = THREE.LinearFilter;
-						hdrJpgEquirectangularMap.magFilter = THREE.LinearFilter;
-						hdrJpgEquirectangularMap.generateMipmaps = false;
-
 						hdrJpgEquirectangularMap.needsUpdate = true;
+
+						hdrJpg.dispose();
 
 					}, function ( progress ) {
 
@@ -163,11 +161,9 @@
 						gainMapPMREMRenderTarget = pmremGenerator.fromEquirectangular( gainMapBackground );
 
 						gainMapBackground.mapping = THREE.EquirectangularReflectionMapping;
-						gainMapBackground.minFilter = THREE.LinearFilter;
-						gainMapBackground.magFilter = THREE.LinearFilter;
-						gainMapBackground.generateMipmaps = false;
-
 						gainMapBackground.needsUpdate = true;
+
+						gainMap.dispose();
 			
 					}, function ( progress ) {
 


### PR DESCRIPTION
Related issue: [Issue in gainmap-js repository](https://github.com/MONOGRID/gainmap-js/issues/15)

**Description**

This fixes a problem **in this specific example** (the root cause of the problem in the three.js library remains unknown) where WebGLCubeMap generation using an Equirectangular renderTarget (allowed by #27230) with `generateMipmaps = true` caused visual artifacts (see below).

Our library now doesn't create renderTargets with `generateMipmaps = true` by default anymore, this solves this specific problem in this example.

### before
![before](https://github.com/mrdoob/three.js/assets/19731017/b7ad78d9-a208-456f-82bb-77d02ca90f8f)
### after
![after](https://github.com/mrdoob/three.js/assets/19731017/3d7c1b62-43dc-4542-af5e-444bb26526f6)


The example is now updated and working as intended (plus I added `dispose()` methods, which free up GPU memory)