### PR TITLE
WebGPURenderer: Fix strip index format

### DIFF
--- a/examples/jsm/renderers/webgpu/utils/WebGPUPipelineUtils.js
+++ b/examples/jsm/renderers/webgpu/utils/WebGPUPipelineUtils.js
@@ -456,10 +456,9 @@ class WebGPUPipelineUtils {
 
 		descriptor.topology = utils.getPrimitiveTopology( object, material );
 
-		if ( object.isLine === true && object.isLineSegments !== true ) {
+		if ( geometry.index !== null && object.isLine === true && object.isLineSegments !== true ) {
 
-			const count = ( geometry.index ) ? geometry.index.count : geometry.attributes.position.count;
-			descriptor.stripIndexFormat = ( count > 65535 ) ? GPUIndexFormat.Uint32 : GPUIndexFormat.Uint16; // define data type for primitive restart value
+			descriptor.stripIndexFormat = ( geometry.index.array instanceof Uint16Array ) ? GPUIndexFormat.Uint16 : GPUIndexFormat.Uint32;
 
 		}
 


### PR DESCRIPTION
**Description**

Fix ```Strip index format (IndexFormat::Uint32) of [RenderPipeline] does not match index buffer format (IndexFormat::Uint16).```