### PR TITLE
Docs: Fix incorrect advice on opacity setting for transmission

### DIFF
--- a/docs/api/en/materials/MeshPhysicalMaterial.html
+++ b/docs/api/en/materials/MeshPhysicalMaterial.html
@@ -286,7 +286,7 @@
 			property can be used to model these materials.<br />
 
 			When transmission is non-zero, [page:Material.opacity opacity] should be
-			set to `0`.
+			set to `1`.
 		</p>
 
 		<h3>[property:Texture transmissionMap]</h3>


### PR DESCRIPTION
Related issue: --

**Description**

Previously the docs stated opacity should be set to "0" when using transmission - but 0 opacity means the object is faded out which isn't what we want. See the demo here that lets you change the fields:

https://jsfiddle.net/kdpqtau0/1/