### PR TITLE
Examples: OffscreenCanvas fix safari without WebGL context support

### DIFF
--- a/examples/webgl_worker_offscreencanvas.html
+++ b/examples/webgl_worker_offscreencanvas.html
@@ -53,7 +53,7 @@
 	<body>
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener noreferrer">three.js</a> - offscreen canvas (<a href="https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas" target="_blank" rel="noopener noreferrer">about</a>)<br/>
-			<p id="message">Your browser does not support OffscreenCanvas. Check the browser support <a href="https://caniuse.com/#feat=offscreencanvas" target="_blank" rel="noopener noreferrer">here</a></p>
+			<p id="message">Your browser does not support OffscreenCanvas with a WebGL Context. Check the browser support <a href="https://caniuse.com/#feat=offscreencanvas" target="_blank" rel="noopener noreferrer">here</a></p>
 		</div>
 
 		<div id="container">
@@ -77,7 +77,7 @@
 
 			import initJank from 'three/addons/offscreen/jank.js';
 			import init from 'three/addons/offscreen/scene.js';
-
+			
 			// onscreen
 
 			const canvas1 = document.getElementById( 'canvas1' );
@@ -92,7 +92,20 @@
 
 			// offscreen
 
-			if ( 'transferControlToOffscreen' in canvas2 ) {
+			const isSafari = /^((?!chrome|android).)*safari/i.test( navigator.userAgent );
+			let supportOffScreenWebGL = 'transferControlToOffscreen' in canvas2;
+
+			// If it's Safari, then check the version because Safari < 17 doesn't support OffscreenCanvas with a WebGL context.
+			if ( isSafari ) {
+
+				var versionMatch = navigator.userAgent.match( /version\/(\d+)/i );
+				var safariVersion = versionMatch ? parseInt( versionMatch[ 1 ] ) : 0;
+
+				supportOffScreenWebGL = safariVersion >= 17;
+
+			}
+
+			if ( supportOffScreenWebGL ) {
 
 				const offscreen = canvas2.transferControlToOffscreen();
 				const worker = new Worker( 'jsm/offscreen/offscreen.js', { type: 'module' } );


### PR DESCRIPTION
Safari < 17 [doesn't support WebGL context](https://caniuse.com/offscreencanvas).
Improved the condition in the webgl_worker_offscreencanvas example to cover this.

