### PR TITLE
DracoLoader: Fix not calling `onError()`.

### DIFF
--- a/examples/jsm/loaders/DRACOLoader.js
+++ b/examples/jsm/loaders/DRACOLoader.js
@@ -82,13 +82,18 @@ class DRACOLoader extends Loader {
 
 	}
 
+
 	parse( buffer, onLoad, onError ) {
 
-		this.decodeDracoFile( buffer, onLoad, null, null, SRGBColorSpace ).catch( onError );
+		this.decodeDracoFile( buffer, onLoad, null, null, SRGBColorSpace ).catch( ( error ) => {
+
+			onError && onError( error );
+
+		} );
 
 	}
 
-	decodeDracoFile( buffer, callback, attributeIDs, attributeTypes, vertexColorSpace = LinearSRGBColorSpace ) {
+	decodeDracoFile( buffer, callback, attributeIDs, attributeTypes, vertexColorSpace = LinearSRGBColorSpace, onError = undefined ) {
 
 		const taskConfig = {
 			attributeIDs: attributeIDs || this.defaultAttributeIDs,
@@ -97,7 +102,11 @@ class DRACOLoader extends Loader {
 			vertexColorSpace: vertexColorSpace,
 		};
 
-		return this.decodeGeometry( buffer, taskConfig ).then( callback );
+		return this.decodeGeometry( buffer, taskConfig ).then( callback ).catch( ( error ) => {
+
+			onError && onError( error );
+
+		} );
 
 	}
 
@@ -156,7 +165,12 @@ class DRACOLoader extends Loader {
 				} );
 
 			} )
-			.then( ( message ) => this._createGeometry( message.geometry ) );
+			.then( ( message ) => this._createGeometry( message.geometry ) )
+			.catch( ( error ) => {
+
+				throw new Error( error );
+
+			} );
 
 		// Remove task from the task list.
 		// Note: replaced '.finally()' with '.catch().then()' block - iOS 11 support (#19416)

--- a/examples/jsm/loaders/DRACOLoader.js
+++ b/examples/jsm/loaders/DRACOLoader.js
@@ -83,17 +83,13 @@ class DRACOLoader extends Loader {
 	}
 
 
-	parse( buffer, onLoad, onError ) {
+	parse( buffer, onLoad, onError = ()=>{} ) {
 
-		this.decodeDracoFile( buffer, onLoad, null, null, SRGBColorSpace ).catch( ( error ) => {
-
-			onError && onError( error );
-
-		} );
+		this.decodeDracoFile( buffer, onLoad, null, null, SRGBColorSpace ).catch( onError );
 
 	}
 
-	decodeDracoFile( buffer, callback, attributeIDs, attributeTypes, vertexColorSpace = LinearSRGBColorSpace, onError = undefined ) {
+	decodeDracoFile( buffer, callback, attributeIDs, attributeTypes, vertexColorSpace = LinearSRGBColorSpace, onError = () => {} ) {
 
 		const taskConfig = {
 			attributeIDs: attributeIDs || this.defaultAttributeIDs,
@@ -102,11 +98,7 @@ class DRACOLoader extends Loader {
 			vertexColorSpace: vertexColorSpace,
 		};
 
-		return this.decodeGeometry( buffer, taskConfig ).then( callback ).catch( ( error ) => {
-
-			onError && onError( error );
-
-		} );
+		return this.decodeGeometry( buffer, taskConfig ).then( callback ).catch( onError );
 
 	}
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -1938,7 +1938,7 @@ class GLTFDracoMeshCompressionExtension {
 
 					resolve( geometry );
 
-				}, threeAttributeMap, attributeTypeMap, undefined, reject );
+				}, threeAttributeMap, attributeTypeMap, LinearSRGBColorSpace, reject );
 
 			} );
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -1923,7 +1923,7 @@ class GLTFDracoMeshCompressionExtension {
 
 		return parser.getDependency( 'bufferView', bufferViewIndex ).then( function ( bufferView ) {
 
-			return new Promise( function ( resolve ) {
+			return new Promise( function ( resolve, reject ) {
 
 				dracoLoader.decodeDracoFile( bufferView, function ( geometry ) {
 
@@ -1938,7 +1938,7 @@ class GLTFDracoMeshCompressionExtension {
 
 					resolve( geometry );
 
-				}, threeAttributeMap, attributeTypeMap );
+				}, threeAttributeMap, attributeTypeMap, reject );
 
 			} );
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -1938,7 +1938,7 @@ class GLTFDracoMeshCompressionExtension {
 
 					resolve( geometry );
 
-				}, threeAttributeMap, attributeTypeMap, reject );
+				}, threeAttributeMap, attributeTypeMap, undefined, reject );
 
 			} );
 


### PR DESCRIPTION
Fixed #20883

**Description**

I'm aware the dracoLoader might be getting a refactor sometime in the future, however in the meantime, this needed to be addressed;
The problem is that the onError is never called on failed DracoLoader load;

This PR fixes this issue by passing the promise reject to the onError argument

Please feel free to edit this PR if needed.