### PR TITLE
Examples: Improve AO shaders.

### DIFF
--- a/examples/jsm/postprocessing/GTAOPass.js
+++ b/examples/jsm/postprocessing/GTAOPass.js
@@ -4,6 +4,7 @@ import {
 	CustomBlending,
 	DataTexture,
 	DepthTexture,
+	DepthStencilFormat,
 	DstAlphaFactor,
 	DstColorFactor,
 	HalfFloatType,
@@ -15,6 +16,7 @@ import {
 	ShaderMaterial,
 	UniformsUtils,
 	UnsignedByteType,
+	UnsignedInt248Type,
 	WebGLRenderTarget,
 	ZeroFactor
 } from 'three';
@@ -171,6 +173,8 @@ class GTAOPass extends Pass {
 		} else {
 
 			this.depthTexture = new DepthTexture();
+			this.depthTexture.format = DepthStencilFormat;
+			this.depthTexture.type = UnsignedInt248Type;
 			this.normalRenderTarget = new WebGLRenderTarget( this.width, this.height, {
 				minFilter: NearestFilter,
 				magFilter: NearestFilter,

--- a/examples/jsm/shaders/GTAOShader.js
+++ b/examples/jsm/shaders/GTAOShader.js
@@ -79,10 +79,9 @@ const GTAOShader = {
 		}`,
 
 	fragmentShader: /* glsl */`
-		precision highp sampler2D;
 		varying vec2 vUv;
 		uniform sampler2D tNormal;
-		uniform sampler2D tDepth;
+		uniform highp sampler2D tDepth;
 		uniform sampler2D tNoise;
 		uniform vec2 resolution;
 		uniform float cameraNear;

--- a/examples/jsm/shaders/GTAOShader.js
+++ b/examples/jsm/shaders/GTAOShader.js
@@ -79,7 +79,7 @@ const GTAOShader = {
 		}`,
 
 	fragmentShader: /* glsl */`
-
+		precision highp sampler2D;
 		varying vec2 vUv;
 		uniform sampler2D tNormal;
 		uniform sampler2D tDepth;

--- a/examples/jsm/shaders/SAOShader.js
+++ b/examples/jsm/shaders/SAOShader.js
@@ -49,8 +49,6 @@ const SAOShader = {
 		}`,
 
 	fragmentShader: /* glsl */`
-		precision highp sampler2D;
-
 		#include <common>
 
 		varying vec2 vUv;
@@ -59,7 +57,7 @@ const SAOShader = {
 		uniform sampler2D tDiffuse;
 		#endif
 
-		uniform sampler2D tDepth;
+		uniform highp sampler2D tDepth;
 		uniform sampler2D tNormal;
 
 		uniform float cameraNear;

--- a/examples/jsm/shaders/SAOShader.js
+++ b/examples/jsm/shaders/SAOShader.js
@@ -49,6 +49,7 @@ const SAOShader = {
 		}`,
 
 	fragmentShader: /* glsl */`
+		precision highp sampler2D;
 
 		#include <common>
 

--- a/examples/jsm/shaders/SSAOShader.js
+++ b/examples/jsm/shaders/SSAOShader.js
@@ -49,10 +49,8 @@ const SSAOShader = {
 		}`,
 
 	fragmentShader: /* glsl */`
-		precision highp sampler2D;
-
 		uniform sampler2D tNormal;
-		uniform sampler2D tDepth;
+		uniform highp sampler2D tDepth;
 		uniform sampler2D tNoise;
 
 		uniform vec3 kernel[ KERNEL_SIZE ];

--- a/examples/jsm/shaders/SSAOShader.js
+++ b/examples/jsm/shaders/SSAOShader.js
@@ -49,6 +49,7 @@ const SSAOShader = {
 		}`,
 
 	fragmentShader: /* glsl */`
+		precision highp sampler2D;
 
 		uniform sampler2D tNormal;
 		uniform sampler2D tDepth;


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/27319#issuecomment-1841103414

**Description**

This PR makes sure `GTAOPass` uses the same depth texture setup like `SSAOPass` and `SAOPass`.

It also defines the depth samplers as `highp` which solves an artifact issue with `GTAOPass` on mobile devices. This change is also done for the other AO shaders to make sure something like this does not happen there, too.
