### PR TITLE
TSL: Fix texture_depth_2d in wgslFn

### DIFF
--- a/examples/jsm/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/examples/jsm/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -422,7 +422,7 @@ class WGSLNodeBuilder extends NodeBuilder {
 
 	isReference( type ) {
 
-		return super.isReference( type ) || type === 'texture_2d' || type === 'texture_cube' || type === 'texture_storage_2d';
+		return super.isReference( type ) || type === 'texture_2d' || type === 'texture_cube' || type === 'texture_depth_2d' || type === 'texture_storage_2d';
 
 	}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/27274#issuecomment-1837234469

**Description**

Fix `texture_depth_2d` node reference if used as parameter in `wgslFn`.