### PR TITLE
WebGLShadowMap: Dispose of unique depth/distance materials.

### DIFF
--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -398,7 +398,7 @@ function WebGLShadowMap( _renderer, _objects, _capabilities ) {
 
 		material.removeEventListener( 'dispose', onMaterialDispose );
 
-		// make sure to remove the unique distance or depth material used for shadow map rendering
+		// make sure to remove the unique distance/depth materials used for shadow map rendering
 
 		for ( const id in _materialCache ) {
 

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -279,6 +279,7 @@ function WebGLShadowMap( _renderer, _objects, _capabilities ) {
 
 					cachedMaterial = result.clone();
 					materialsForVariant[ keyB ] = cachedMaterial;
+					material.addEventListener( 'dispose', onMaterialDispose );
 
 				}
 
@@ -386,6 +387,32 @@ function WebGLShadowMap( _renderer, _objects, _capabilities ) {
 		for ( let i = 0, l = children.length; i < l; i ++ ) {
 
 			renderObject( children[ i ], camera, shadowCamera, light, type );
+
+		}
+
+	}
+
+	function onMaterialDispose( event ) {
+
+		const material = event.target;
+
+		material.removeEventListener( 'dispose', onMaterialDispose );
+
+		// make sure to remove the unique distance or depth used for shadow map rendering
+
+		for ( const id in _materialCache ) {
+
+			const cache = _materialCache[ id ];
+
+			const uuid = event.target.uuid;
+
+			if ( uuid in cache ) {
+
+				const shadowMaterial = cache[ uuid ];
+				shadowMaterial.dispose();
+				delete cache[ uuid ];
+
+			}
 
 		}
 

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -398,7 +398,7 @@ function WebGLShadowMap( _renderer, _objects, _capabilities ) {
 
 		material.removeEventListener( 'dispose', onMaterialDispose );
 
-		// make sure to remove the unique distance or depth used for shadow map rendering
+		// make sure to remove the unique distance or depth material used for shadow map rendering
 
 		for ( const id in _materialCache ) {
 


### PR DESCRIPTION
Related issue: -

**Description**

`WebGLShadowMap` creates unique depth/distance materials for shadow map rendering when certain conditions are met. This PR ensures these internal materials are removed when the respective `dispose()` is called on the actual material. Otherwise a memory leak can occur.
