### PR TITLE
Triangle: Return `null` in `getInterpolation()` if triangle is degenerate.

### DIFF
--- a/docs/api/en/math/Triangle.html
+++ b/docs/api/en/math/Triangle.html
@@ -137,7 +137,7 @@
 			[page:Vector target] — Result will be copied into this Vector.<br /><br />
 
 			Returns the value barycentrically interpolated for the given point on the
-			triangle.
+			triangle. Returns null if the triangle is degenerate
 		</p>
 
 		<h3>[method:Boolean intersectsBox]( [param:Box3 box] )</h3>

--- a/docs/api/en/math/Triangle.html
+++ b/docs/api/en/math/Triangle.html
@@ -97,7 +97,7 @@
 			[page:Vector3 target] — the result will be copied into this Vector3.<br /><br />
 
 			Return a [link:https://en.wikipedia.org/wiki/Barycentric_coordinate_system barycentric coordinate] 
-			from the given vector. Returns null if the triangle is degenerate.<br /><br />
+			from the given vector. Returns `null` if the triangle is degenerate.<br /><br />
 
 			[link:http://commons.wikimedia.org/wiki/File:Barycentric_coordinates_1.png Picture of barycentric coordinates]
 		</p>
@@ -137,7 +137,7 @@
 			[page:Vector target] — Result will be copied into this Vector.<br /><br />
 
 			Returns the value barycentrically interpolated for the given point on the
-			triangle. Returns null if the triangle is degenerate
+			triangle. Returns `null` if the triangle is degenerate.
 		</p>
 
 		<h3>[method:Boolean intersectsBox]( [param:Box3 box] )</h3>

--- a/src/math/Triangle.js
+++ b/src/math/Triangle.js
@@ -103,7 +103,12 @@ class Triangle {
 
 	static getInterpolation( point, p1, p2, p3, v1, v2, v3, target ) {
 
-		this.getBarycoord( point, p1, p2, p3, _v3 );
+		if ( this.getBarycoord( point, p1, p2, p3, _v3 ) === null ) {
+
+			target.set( 0, 0, 0 );
+			return null;
+
+		}
 
 		target.setScalar( 0 );
 		target.addScaledVector( v1, _v3.x );

--- a/src/math/Triangle.js
+++ b/src/math/Triangle.js
@@ -105,7 +105,10 @@ class Triangle {
 
 		if ( this.getBarycoord( point, p1, p2, p3, _v3 ) === null ) {
 
-			target.set( 0, 0, 0 );
+			target.x = 0;
+			target.y = 0;
+			if ( 'z' in target ) target.z = 0;
+			if ( 'w' in target ) target.w = 0;
 			return null;
 
 		}


### PR DESCRIPTION
Related issue: #27311

**Description**

I had intended to make this one last change in the other PR - but this changes `getInterpolation` to behave similarly to `getBarycoord` in that it now returns null if the triangle is degenerate.