### PR TITLE
StorageTexture: Mipmaps

### DIFF
--- a/examples/jsm/renderers/common/Bindings.js
+++ b/examples/jsm/renderers/common/Bindings.js
@@ -144,7 +144,7 @@ class Bindings extends DataMap {
 
 						textureData.needsMipmap = true;
 
-					} else if ( textureData.needsMipmap === true ) {
+					} else if ( this.textures.needsMipmaps( texture ) && textureData.needsMipmap === true ) {
 
 						this.backend.generateMipmaps( texture );
 

--- a/examples/jsm/renderers/common/Bindings.js
+++ b/examples/jsm/renderers/common/Bindings.js
@@ -124,6 +124,8 @@ class Bindings extends DataMap {
 
 			} else if ( binding.isSampledTexture ) {
 
+				const texture = binding.texture;
+
 				if ( binding.needsBindingsUpdate ) needsBindingsUpdate = true;
 
 				const updated = binding.update();
@@ -131,6 +133,24 @@ class Bindings extends DataMap {
 				if ( updated ) {
 
 					this.textures.updateTexture( binding.texture );
+
+				}
+
+				if ( texture.isStorageTexture === true ) {
+
+					const textureData = this.get( texture );
+
+					if ( binding.store === true ) {
+
+						textureData.needsMipmap = true;
+
+					} else if ( textureData.needsMipmap === true ) {
+
+						this.backend.generateMipmaps( texture );
+
+						textureData.needsMipmap = false;
+
+					}
 
 				}
 

--- a/examples/jsm/renderers/common/Bindings.js
+++ b/examples/jsm/renderers/common/Bindings.js
@@ -144,7 +144,7 @@ class Bindings extends DataMap {
 
 						textureData.needsMipmap = true;
 
-					} else if ( this.textures.needsMipmaps( texture ) && textureData.needsMipmap === true ) {
+					} else if ( texture.generateMipmaps === true && this.textures.needsMipmaps( texture ) && textureData.needsMipmap === true ) {
 
 						this.backend.generateMipmaps( texture );
 

--- a/examples/jsm/renderers/common/Renderer.js
+++ b/examples/jsm/renderers/common/Renderer.js
@@ -352,6 +352,12 @@ class Renderer {
 
 	}
 
+	getMaxAnisotropy() {
+
+		return this.backend.getMaxAnisotropy();
+
+	}
+
 	getActiveCubeFace() {
 
 		return this._activeCubeFace;

--- a/examples/jsm/renderers/common/StorageTexture.js
+++ b/examples/jsm/renderers/common/StorageTexture.js
@@ -14,6 +14,7 @@ class StorageTexture extends Texture {
 		this.isStorageTexture = true;
 
 	}
+
 }
 
 export default StorageTexture;

--- a/examples/jsm/renderers/webgl/WebGLBackend.js
+++ b/examples/jsm/renderers/webgl/WebGLBackend.js
@@ -8,6 +8,7 @@ import WebGLState from './utils/WebGLState.js';
 import WebGLUtils from './utils/WebGLUtils.js';
 import WebGLTextureUtils from './utils/WebGLTextureUtils.js';
 import WebGLExtensions from './utils/WebGLExtensions.js';
+import WebGLCapabilities from './utils/WebGLCapabilities.js';
 
 //
 
@@ -34,6 +35,7 @@ class WebGLBackend extends Backend {
 		this.gl = glContext;
 
 		this.extensions = new WebGLExtensions( this );
+		this.capabilities = new WebGLCapabilities( this );
 		this.attributeUtils = new WebGLAttributeUtils( this );
 		this.textureUtils = new WebGLTextureUtils( this );
 		this.state = new WebGLState( this );
@@ -877,9 +879,15 @@ class WebGLBackend extends Backend {
 
 	}
 
-	hasFeature( name ) {
+	hasFeature( /*name*/ ) {
 
 		return true;
+
+	}
+
+	getMaxAnisotropy() {
+
+		return this.capabilities.getMaxAnisotropy();
 
 	}
 

--- a/examples/jsm/renderers/webgl/utils/WebGLCapabilities.js
+++ b/examples/jsm/renderers/webgl/utils/WebGLCapabilities.js
@@ -1,0 +1,36 @@
+class WebGLCapabilities {
+
+	constructor( backend ) {
+
+		this.backend = backend;
+
+		this.maxAnisotropy = null;
+
+	}
+
+	getMaxAnisotropy() {
+
+		if ( this.maxAnisotropy !== null ) return this.maxAnisotropy;
+
+		const gl = this.backend.gl;
+		const extensions = this.backend.extensions;
+
+		if ( extensions.has( 'EXT_texture_filter_anisotropic' ) === true ) {
+
+			const extension = extensions.get( 'EXT_texture_filter_anisotropic' );
+
+			this.maxAnisotropy = gl.getParameter( extension.MAX_TEXTURE_MAX_ANISOTROPY_EXT );
+
+		} else {
+
+			this.maxAnisotropy = 0;
+
+		}
+
+		return this.maxAnisotropy;
+
+	}
+
+}
+
+export default WebGLCapabilities;

--- a/examples/jsm/renderers/webgl/utils/WebGLExtensions.js
+++ b/examples/jsm/renderers/webgl/utils/WebGLExtensions.js
@@ -7,11 +7,21 @@ class WebGLExtensions {
 		this.gl = this.backend.gl;
 		this.availableExtensions = this.gl.getSupportedExtensions();
 
+		this.extensions = {};
+
 	}
 
 	get( name ) {
 
-		return this.gl.getExtension( name );
+		let extension = this.extensions[ name ];
+
+		if ( extension === undefined ) {
+
+			extension = this.gl.getExtension( name );
+
+		}
+
+		return extension;
 
 	}
 

--- a/examples/jsm/renderers/webgpu/WebGPUBackend.js
+++ b/examples/jsm/renderers/webgpu/WebGPUBackend.js
@@ -1056,6 +1056,12 @@ class WebGPUBackend extends Backend {
 
 	// utils public
 
+	getMaxAnisotropy() {
+
+		return 16;
+
+	}
+
 	hasFeature( name ) {
 
 		const adapter = this.adapter || _staticAdapter;

--- a/examples/jsm/renderers/webgpu/utils/WebGPUBindingUtils.js
+++ b/examples/jsm/renderers/webgpu/utils/WebGPUBindingUtils.js
@@ -220,7 +220,7 @@ class WebGPUBindingUtils {
 
 					const aspectGPU = GPUTextureAspect.All;
 
-					resourceGPU = textureData.texture.createView( { aspect: aspectGPU, dimension: dimensionViewGPU } );
+					resourceGPU = textureData.texture.createView( { aspect: aspectGPU, dimension: dimensionViewGPU, mipLevelCount: binding.store ? 1 : textureData.mipLevelCount } );
 
 				}
 

--- a/examples/webgpu_compute_texture.html
+++ b/examples/webgpu_compute_texture.html
@@ -56,6 +56,8 @@
 				const width = 512, height = 512;
 
 				const storageTexture = new StorageTexture( width, height );
+				//storageTexture.minFilter = THREE.LinearMipMapLinearFilter;
+				//storageTexture.generateMipmaps = true;
 
 				// create function
 

--- a/examples/webgpu_compute_texture.html
+++ b/examples/webgpu_compute_texture.html
@@ -57,7 +57,6 @@
 
 				const storageTexture = new StorageTexture( width, height );
 				//storageTexture.minFilter = THREE.LinearMipMapLinearFilter;
-				//storageTexture.generateMipmaps = true;
 
 				// create function
 


### PR DESCRIPTION
Related issue: Closes https://github.com/mrdoob/three.js/issues/27274

**Description**

Whenever `StorageTexture` is computed and `storageTexture.generateMipmaps=true` and `storageTexture.minFilter=Mipmaps..` the `Backend.generateMipmaps()` will be called.

--
- [x] WebGPURenderer.getMaxAnisotropy()