### PR TITLE
Editor: Fix loading zip files with `.glTF`.

### DIFF
--- a/editor/js/Loader.js
+++ b/editor/js/Loader.js
@@ -963,7 +963,7 @@ function Loader( editor ) {
 
 				{
 
-					const loader = await createGLTFLoader();
+					const loader = await createGLTFLoader( manager );
 					
 					loader.parse( strFromU8( file ), '', function ( result ) {
 


### PR DESCRIPTION
Related issue: https://discourse.threejs.org/t/r159-parse-gltf-from-zip-is-not-working-in-threejs-editor/58983

**Description**

A developer in the forum noticed we need the fix of #27336 at another place, too. Only then zipped glTF asset containing `.glTF` files (not glb) can be correctly imported into the editor.