### PR TITLE
Core: Remove deprecated code.

### DIFF
--- a/src/math/ColorManagement.js
+++ b/src/math/ColorManagement.js
@@ -64,22 +64,6 @@ export const ColorManagement = {
 
 	_workingColorSpace: LinearSRGBColorSpace,
 
-	get legacyMode() {
-
-		console.warn( 'THREE.ColorManagement: .legacyMode=false renamed to .enabled=true in r150.' );
-
-		return ! this.enabled;
-
-	},
-
-	set legacyMode( legacyMode ) {
-
-		console.warn( 'THREE.ColorManagement: .legacyMode=false renamed to .enabled=true in r150.' );
-
-		this.enabled = ! legacyMode;
-
-	},
-
 	get workingColorSpace() {
 
 		return this._workingColorSpace;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2572,20 +2572,6 @@ class WebGLRenderer {
 
 	}
 
-	get physicallyCorrectLights() { // @deprecated, r150
-
-		console.warn( 'THREE.WebGLRenderer: The property .physicallyCorrectLights has been removed. Set renderer.useLegacyLights instead.' );
-		return ! this.useLegacyLights;
-
-	}
-
-	set physicallyCorrectLights( value ) { // @deprecated, r150
-
-		console.warn( 'THREE.WebGLRenderer: The property .physicallyCorrectLights has been removed. Set renderer.useLegacyLights instead.' );
-		this.useLegacyLights = ! value;
-
-	}
-
 	get outputEncoding() { // @deprecated, r152
 
 		console.warn( 'THREE.WebGLRenderer: Property .outputEncoding has been removed. Use .outputColorSpace instead.' );

--- a/test/unit/src/math/ColorManagement.tests.js
+++ b/test/unit/src/math/ColorManagement.tests.js
@@ -2,8 +2,6 @@
 
 import { ColorManagement } from '../../../../src/math/ColorManagement.js';
 
-import { CONSOLE_LEVEL } from '../../utils/console-wrapper.js';
-
 export default QUnit.module( 'Maths', () => {
 
 	QUnit.module( 'ColorManagement', () => {
@@ -14,22 +12,6 @@ export default QUnit.module( 'Maths', () => {
 			assert.strictEqual(
 				ColorManagement.enabled, true,
 				'ColorManagement.enabled is true by default.'
-			);
-
-		} );
-
-		QUnit.test( 'legacyMode', ( assert ) => {
-
-			// surpress the following console message during testing
-			// THREE.ColorManagement: .legacyMode=false renamed to .enabled=true in r150.
-
-			console.level = CONSOLE_LEVEL.OFF;
-			const expected = ColorManagement.legacyMode === false;
-			console.level = CONSOLE_LEVEL.DEFAULT;
-
-			assert.ok(
-				expected,
-				'ColorManagement.legacyMode is false by default.'
 			);
 
 		} );


### PR DESCRIPTION
Related issue: -

**Description**

The deprecated properties `ColorManagement.legacyMode` and `WebGLRenderer.physicallyCorrectLights` can be removed with `r160`.