### PR TITLE
Triangle: Add `getAreaSquared()`.

### DIFF
--- a/docs/api/en/math/Triangle.html
+++ b/docs/api/en/math/Triangle.html
@@ -89,6 +89,9 @@
 		<h3>[method:Float getArea]()</h3>
 		<p>Return the area of the triangle.</p>
 
+		<h3>[method:Float getAreaSquared]()</h3>
+		<p>Return the squared area of the triangle.</p>
+
 		<h3>
 			[method:Vector3 getBarycoord]( [param:Vector3 point], [param:Vector3 target] )
 		</h3>

--- a/src/math/Triangle.js
+++ b/src/math/Triangle.js
@@ -179,6 +179,15 @@ class Triangle {
 
 	}
 
+	getAreaSquared() {
+
+		_v0.subVectors( this.c, this.b );
+		_v1.subVectors( this.a, this.b );
+
+		return _v0.cross( _v1 ).lengthSq() * 0.25;
+
+	}
+
 	getMidpoint( target ) {
 
 		return target.addVectors( this.a, this.b ).add( this.c ).multiplyScalar( 1 / 3 );

--- a/test/unit/src/math/Triangle.tests.js
+++ b/test/unit/src/math/Triangle.tests.js
@@ -141,6 +141,24 @@ export default QUnit.module( 'Maths', () => {
 			a = new Triangle( new Vector3( 2, 0, 0 ), new Vector3( 0, 0, 0 ), new Vector3( 3, 0, 0 ) );
 			assert.ok( a.getArea() == 0, 'Passed!' );
 
+		});
+
+		QUnit.test( 'getAreaSquared', ( assert ) => {
+
+			let a = new Triangle();
+
+			assert.ok( a.getAreaSquared() == 0, 'Passed!' );
+
+			a = new Triangle( new Vector3( 0, 0, 0 ), new Vector3( 1, 0, 0 ), new Vector3( 0, 1, 0 ) );
+			assert.ok( a.getAreaSquared() == 0.25, 'Passed!' );
+
+			a = new Triangle( new Vector3( 2, 0, 0 ), new Vector3( 0, 0, 0 ), new Vector3( 0, 0, 2 ) );
+			assert.ok( a.getAreaSquared() == 4, 'Passed!' );
+
+			// colinear triangle.
+			a = new Triangle( new Vector3( 2, 0, 0 ), new Vector3( 0, 0, 0 ), new Vector3( 3, 0, 0 ) );
+			assert.ok( a.getAreaSquared() == 0, 'Passed!' );
+
 		} );
 
 		QUnit.test( 'getMidpoint', ( assert ) => {


### PR DESCRIPTION
**Description**

Adding a method to compute the squared area of a Triangle. I'm implementing the algorithm: "Adaptive Sampling of Parametric Curves" from Graphics Gems V and one way to do it is to compute the area of a triangle and compare to some threshold. Of course, the squared area can be compared as well. Hence this PR.

Note, because the area of a triangle is the length of the cross product divided by two, the squared area is therefore the lengthSq divided by 4.