### PR TITLE
Lights: Add shadowLimit property to PointLightShadow and SpotLightShadow

### DIFF
--- a/src/lights/PointLightShadow.js
+++ b/src/lights/PointLightShadow.js
@@ -17,6 +17,8 @@ class PointLightShadow extends LightShadow {
 
 		this.isPointLightShadow = true;
 
+		this.shadowLimit = 500;
+
 		this._frameExtents = new Vector2( 4, 2 );
 
 		this._viewportCount = 6;
@@ -66,7 +68,7 @@ class PointLightShadow extends LightShadow {
 		const camera = this.camera;
 		const shadowMatrix = this.matrix;
 
-		const far = light.distance || camera.far;
+		const far = light.distance || this.shadowLimit;
 
 		if ( far !== camera.far ) {
 

--- a/src/lights/SpotLightShadow.js
+++ b/src/lights/SpotLightShadow.js
@@ -12,6 +12,8 @@ class SpotLightShadow extends LightShadow {
 
 		this.focus = 1;
 
+		this.shadowLimit = 500;
+
 	}
 
 	updateMatrices( light ) {
@@ -20,7 +22,7 @@ class SpotLightShadow extends LightShadow {
 
 		const fov = MathUtils.RAD2DEG * 2 * light.angle * this.focus;
 		const aspect = this.mapSize.width / this.mapSize.height;
-		const far = light.distance || camera.far;
+		const far = light.distance || this.shadowLimit;
 
 		if ( fov !== camera.fov || aspect !== camera.aspect || far !== camera.far ) {
 


### PR DESCRIPTION
Fixed #27290 

**Description**

Setting the distance of `PointLight`/`SpotLight` affect the `PointLightShadow`/`SpotLightShadow`'s `camera.far` when the distance is set to 0. If I set the distance to 5 and then later to 0, the `camera.far` of the Shadow is still set to 5. This change introduces a `shadowLimit` property to the Shadow class that will be used to set the value of `camera.far` when the corresponding light object is 0
