### PR TITLE
Nodes: Log warnings instead of throwing on redefinitions of Node types

### DIFF
--- a/examples/jsm/nodes/core/Node.js
+++ b/examples/jsm/nodes/core/Node.js
@@ -458,7 +458,12 @@ export default Node;
 export function addNodeClass( type, nodeClass ) {
 
 	if ( typeof nodeClass !== 'function' || ! type ) throw new Error( `Node class ${ type } is not a class` );
-	if ( NodeClasses.has( type ) ) throw new Error( `Redefinition of node class ${ type }` );
+	if ( NodeClasses.has( type ) ) {
+
+		console.warn( `Redefinition of node class ${ type }` );
+		return;
+
+	}
 
 	NodeClasses.set( type, nodeClass );
 	nodeClass.type = type;

--- a/examples/jsm/nodes/lighting/LightsNode.js
+++ b/examples/jsm/nodes/lighting/LightsNode.js
@@ -173,7 +173,13 @@ export const lightNodes = nodeProxy( LightsNode );
 
 export function addLightNode( lightClass, lightNodeClass ) {
 
-	if ( LightNodes.has( lightClass ) ) throw new Error( `Redefinition of light node ${ lightNodeClass.type }` );
+	if ( LightNodes.has( lightClass ) ) {
+
+		console.warn( `Redefinition of light node ${ lightNodeClass.type }` );
+		return;
+
+	}
+
 	if ( typeof lightClass !== 'function' ) throw new Error( `Light ${ lightClass.name } is not a class` );
 	if ( typeof lightNodeClass !== 'function' || ! lightNodeClass.type ) throw new Error( `Light node ${ lightNodeClass.type } is not a class` );
 

--- a/examples/jsm/nodes/materials/NodeMaterial.js
+++ b/examples/jsm/nodes/materials/NodeMaterial.js
@@ -541,7 +541,12 @@ export default NodeMaterial;
 export function addNodeMaterial( type, nodeMaterial ) {
 
 	if ( typeof nodeMaterial !== 'function' || ! type ) throw new Error( `Node material ${ type } is not a class` );
-	if ( NodeMaterials.has( type ) ) throw new Error( `Redefinition of node material ${ type }` );
+	if ( NodeMaterials.has( type ) ) {
+
+		console.warn( `Redefinition of node material ${ type }` );
+		return;
+
+	}
 
 	NodeMaterials.set( type, nodeMaterial );
 	nodeMaterial.type = type;

--- a/examples/jsm/nodes/shadernode/ShaderNode.js
+++ b/examples/jsm/nodes/shadernode/ShaderNode.js
@@ -15,7 +15,13 @@ const NodeElements = new Map(); // @TODO: Currently only a few nodes are added, 
 
 export function addNodeElement( name, nodeElement ) {
 
-	if ( NodeElements.has( name ) ) throw new Error( `Redefinition of node element ${ name }` );
+	if ( NodeElements.has( name ) ) {
+
+		console.warn( `Redefinition of node element ${ name }` );
+		return;
+
+	}
+
 	if ( typeof nodeElement !== 'function' ) throw new Error( `Node element ${ name } is not a function` );
 
 	NodeElements.set( name, nodeElement );


### PR DESCRIPTION
**Description**

Currently, when multiple versions of three are used (which is almost always accidental, yet can happen for example when using browser extensions that bring their own version of three.js), using Nodes leads to exceptions.

This PR downgrades those to warnings.
This is the same behaviour as three.js itself has when it's imported multiple times:
- https://github.com/mrdoob/three.js/blob/ca7261b12e3caebce06958bc08e8cc386dc333d4/src/Three.js#L176

*This contribution is funded by [Needle](https://needle.tools)*
