### PR TITLE
Fix: CSM lights when shadow maps are disabled

### DIFF
--- a/examples/jsm/csm/CSMShader.js
+++ b/examples/jsm/csm/CSMShader.js
@@ -162,7 +162,7 @@ IncidentLight directLight;
 
 		}
 		#pragma unroll_loop_end
-	#else
+	#elif defined (USE_SHADOWMAP)
 
 		#pragma unroll_loop_start
 		for ( int i = 0; i < NUM_DIR_LIGHTS; i ++ ) {
@@ -170,7 +170,7 @@ IncidentLight directLight;
 			directionalLight = directionalLights[ i ];
 			getDirectionalLightInfo( directionalLight, directLight );
 
-			#if defined( USE_SHADOWMAP ) && ( UNROLLED_LOOP_INDEX < NUM_DIR_LIGHT_SHADOWS )
+			#if ( UNROLLED_LOOP_INDEX < NUM_DIR_LIGHT_SHADOWS )
 
 				directionalLightShadow = directionalLightShadows[ i ];
 				if(linearDepth >= CSM_cascades[UNROLLED_LOOP_INDEX].x && linearDepth < CSM_cascades[UNROLLED_LOOP_INDEX].y) directLight.color *= ( directLight.visible && receiveShadow ) ? getShadow( directionalShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowBias, directionalLightShadow.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;
@@ -181,6 +181,11 @@ IncidentLight directLight;
 
 		}
 		#pragma unroll_loop_end
+
+	#elif ( NUM_DIR_LIGHT_SHADOWS > 0 )
+		// note: no loop here - all CSM lights are in fact one light only
+		getDirectionalLightInfo( directionalLights[0], directLight );
+		RE_Direct( directLight, geometryPosition, geometryNormal, geometryViewDir, geometryClearcoatNormal, material, reflectedLight );
 
 	#endif
 

--- a/examples/jsm/csm/CSMShader.js
+++ b/examples/jsm/csm/CSMShader.js
@@ -62,7 +62,7 @@ IncidentLight directLight;
  	vec4 spotColor;
 	vec3 spotLightCoord;
 	bool inSpotLightMap;
- 
+
 	#if defined( USE_SHADOWMAP ) && NUM_SPOT_LIGHT_SHADOWS > 0
 	SpotLightShadow spotLightShadow;
 	#endif
@@ -112,56 +112,56 @@ IncidentLight directLight;
 	#endif
 
 	#if defined( USE_SHADOWMAP ) && defined( CSM_FADE )
-	vec2 cascade;
-	float cascadeCenter;
-	float closestEdge;
-	float margin;
-	float csmx;
-	float csmy;
+		vec2 cascade;
+		float cascadeCenter;
+		float closestEdge;
+		float margin;
+		float csmx;
+		float csmy;
 
-	#pragma unroll_loop_start
-	for ( int i = 0; i < NUM_DIR_LIGHTS; i ++ ) {
+		#pragma unroll_loop_start
+		for ( int i = 0; i < NUM_DIR_LIGHTS; i ++ ) {
 
-		directionalLight = directionalLights[ i ];
-		getDirectionalLightInfo( directionalLight, directLight );
+			directionalLight = directionalLights[ i ];
+			getDirectionalLightInfo( directionalLight, directLight );
 
-	  	#if defined( USE_SHADOWMAP ) && ( UNROLLED_LOOP_INDEX < NUM_DIR_LIGHT_SHADOWS )
-			// NOTE: Depth gets larger away from the camera.
-			// cascade.x is closer, cascade.y is further
-			cascade = CSM_cascades[ i ];
-			cascadeCenter = ( cascade.x + cascade.y ) / 2.0;
-			closestEdge = linearDepth < cascadeCenter ? cascade.x : cascade.y;
-			margin = 0.25 * pow( closestEdge, 2.0 );
-			csmx = cascade.x - margin / 2.0;
-			csmy = cascade.y + margin / 2.0;
-			if( linearDepth >= csmx && ( linearDepth < csmy || UNROLLED_LOOP_INDEX == CSM_CASCADES - 1 ) ) {
+			#if ( UNROLLED_LOOP_INDEX < NUM_DIR_LIGHT_SHADOWS )
+				// NOTE: Depth gets larger away from the camera.
+				// cascade.x is closer, cascade.y is further
+				cascade = CSM_cascades[ i ];
+				cascadeCenter = ( cascade.x + cascade.y ) / 2.0;
+				closestEdge = linearDepth < cascadeCenter ? cascade.x : cascade.y;
+				margin = 0.25 * pow( closestEdge, 2.0 );
+				csmx = cascade.x - margin / 2.0;
+				csmy = cascade.y + margin / 2.0;
+				if( linearDepth >= csmx && ( linearDepth < csmy || UNROLLED_LOOP_INDEX == CSM_CASCADES - 1 ) ) {
 
-				float dist = min( linearDepth - csmx, csmy - linearDepth );
-				float ratio = clamp( dist / margin, 0.0, 1.0 );
+					float dist = min( linearDepth - csmx, csmy - linearDepth );
+					float ratio = clamp( dist / margin, 0.0, 1.0 );
 
-				vec3 prevColor = directLight.color;
-				directionalLightShadow = directionalLightShadows[ i ];
-				directLight.color *= ( directLight.visible && receiveShadow ) ? getShadow( directionalShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowBias, directionalLightShadow.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;
+					vec3 prevColor = directLight.color;
+					directionalLightShadow = directionalLightShadows[ i ];
+					directLight.color *= ( directLight.visible && receiveShadow ) ? getShadow( directionalShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowBias, directionalLightShadow.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;
 
-				bool shouldFadeLastCascade = UNROLLED_LOOP_INDEX == CSM_CASCADES - 1 && linearDepth > cascadeCenter;
-				directLight.color = mix( prevColor, directLight.color, shouldFadeLastCascade ? ratio : 1.0 );
+					bool shouldFadeLastCascade = UNROLLED_LOOP_INDEX == CSM_CASCADES - 1 && linearDepth > cascadeCenter;
+					directLight.color = mix( prevColor, directLight.color, shouldFadeLastCascade ? ratio : 1.0 );
 
-				ReflectedLight prevLight = reflectedLight;
-				RE_Direct( directLight, geometryPosition, geometryNormal, geometryViewDir, geometryClearcoatNormal, material, reflectedLight );
+					ReflectedLight prevLight = reflectedLight;
+					RE_Direct( directLight, geometryPosition, geometryNormal, geometryViewDir, geometryClearcoatNormal, material, reflectedLight );
 
-				bool shouldBlend = UNROLLED_LOOP_INDEX != CSM_CASCADES - 1 || UNROLLED_LOOP_INDEX == CSM_CASCADES - 1 && linearDepth < cascadeCenter;
-				float blendRatio = shouldBlend ? ratio : 1.0;
+					bool shouldBlend = UNROLLED_LOOP_INDEX != CSM_CASCADES - 1 || UNROLLED_LOOP_INDEX == CSM_CASCADES - 1 && linearDepth < cascadeCenter;
+					float blendRatio = shouldBlend ? ratio : 1.0;
 
-				reflectedLight.directDiffuse = mix( prevLight.directDiffuse, reflectedLight.directDiffuse, blendRatio );
-				reflectedLight.directSpecular = mix( prevLight.directSpecular, reflectedLight.directSpecular, blendRatio );
-				reflectedLight.indirectDiffuse = mix( prevLight.indirectDiffuse, reflectedLight.indirectDiffuse, blendRatio );
-				reflectedLight.indirectSpecular = mix( prevLight.indirectSpecular, reflectedLight.indirectSpecular, blendRatio );
+					reflectedLight.directDiffuse = mix( prevLight.directDiffuse, reflectedLight.directDiffuse, blendRatio );
+					reflectedLight.directSpecular = mix( prevLight.directSpecular, reflectedLight.directSpecular, blendRatio );
+					reflectedLight.indirectDiffuse = mix( prevLight.indirectDiffuse, reflectedLight.indirectDiffuse, blendRatio );
+					reflectedLight.indirectSpecular = mix( prevLight.indirectSpecular, reflectedLight.indirectSpecular, blendRatio );
 
-			}
-	  	#endif
+				}
+			#endif
 
-	}
-	#pragma unroll_loop_end
+		}
+		#pragma unroll_loop_end
 	#else
 
 		#pragma unroll_loop_start
@@ -172,10 +172,10 @@ IncidentLight directLight;
 
 			#if defined( USE_SHADOWMAP ) && ( UNROLLED_LOOP_INDEX < NUM_DIR_LIGHT_SHADOWS )
 
-			directionalLightShadow = directionalLightShadows[ i ];
-			if(linearDepth >= CSM_cascades[UNROLLED_LOOP_INDEX].x && linearDepth < CSM_cascades[UNROLLED_LOOP_INDEX].y) directLight.color *= ( directLight.visible && receiveShadow ) ? getShadow( directionalShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowBias, directionalLightShadow.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;
+				directionalLightShadow = directionalLightShadows[ i ];
+				if(linearDepth >= CSM_cascades[UNROLLED_LOOP_INDEX].x && linearDepth < CSM_cascades[UNROLLED_LOOP_INDEX].y) directLight.color *= ( directLight.visible && receiveShadow ) ? getShadow( directionalShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowBias, directionalLightShadow.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;
 
-			if(linearDepth >= CSM_cascades[UNROLLED_LOOP_INDEX].x && (linearDepth < CSM_cascades[UNROLLED_LOOP_INDEX].y || UNROLLED_LOOP_INDEX == CSM_CASCADES - 1)) RE_Direct( directLight, geometryPosition, geometryNormal, geometryViewDir, geometryClearcoatNormal, material, reflectedLight );
+				if(linearDepth >= CSM_cascades[UNROLLED_LOOP_INDEX].x && (linearDepth < CSM_cascades[UNROLLED_LOOP_INDEX].y || UNROLLED_LOOP_INDEX == CSM_CASCADES - 1)) RE_Direct( directLight, geometryPosition, geometryNormal, geometryViewDir, geometryClearcoatNormal, material, reflectedLight );
 
 			#endif
 

--- a/examples/webgl_shadowmap_csm.html
+++ b/examples/webgl_shadowmap_csm.html
@@ -37,6 +37,7 @@
 			const params = {
 				orthographic: false,
 				fade: false,
+				shadows: true,
 				far: 1000,
 				mode: 'practical',
 				lightX: - 1,
@@ -82,7 +83,7 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				document.body.appendChild( renderer.domElement );
-				renderer.shadowMap.enabled = true;
+				renderer.shadowMap.enabled = params.shadows;
 				renderer.shadowMap.type = THREE.PCFSoftShadowMap;
 
 				controls = new OrbitControls( camera, renderer.domElement );
@@ -160,6 +161,22 @@
 
 					csm.fade = value;
 					csm.updateFrustums();
+
+				} );
+
+				gui.add( params, 'shadows' ).onChange( function ( value ) {
+
+					renderer.shadowMap.enabled = value;
+
+					scene.traverse( function ( child ) {
+
+						if ( child.material ) {
+
+							child.material.needsUpdate = true;
+
+						}
+
+					} );
 
 				} );
 


### PR DESCRIPTION
Fixed #27338

**Description**

Even when the shadows are not computed, the light contribution needs to be added.

Fixed example: https://raw.githack.com/ondrejspanel/three.js/fix-csm-shadows-disabled/examples/webgl_shadowmap_csm.html

Note: as shown in the linked issue, I have also included an option to toggle shadows on / off. I think it does no harm, it is something users can play with in the sample and it makes verification of the fix much easier.
