### PR TITLE
XR buttons: Add support for `offerSession()`.

### DIFF
--- a/examples/jsm/webxr/ARButton.js
+++ b/examples/jsm/webxr/ARButton.js
@@ -108,6 +108,13 @@ class ARButton {
 
 			};
 
+			if ( navigator.xr.offerSession !== undefined ) {
+
+				navigator.xr.offerSession( 'immersive-ar', sessionInit )
+					.then( onSessionStarted );
+
+			}
+
 		}
 
 		function disableButton() {

--- a/examples/jsm/webxr/VRButton.js
+++ b/examples/jsm/webxr/VRButton.js
@@ -39,6 +39,15 @@ class VRButton {
 
 			button.textContent = 'ENTER VR';
 
+			// WebXR's requestReferenceSpace only works if the corresponding feature
+			// was requested at session creation time. For simplicity, just ask for
+			// the interesting ones as optional features, but be aware that the
+			// requestReferenceSpace call will fail if it turns out to be unavailable.
+			// ('local' is always available for immersive sessions and doesn't need to
+			// be requested separately.)
+
+			const sessionInit = { optionalFeatures: [ 'local-floor', 'bounded-floor', 'hand-tracking', 'layers' ] };
+
 			button.onmouseenter = function () {
 
 				button.style.opacity = '1.0';
@@ -55,14 +64,6 @@ class VRButton {
 
 				if ( currentSession === null ) {
 
-					// WebXR's requestReferenceSpace only works if the corresponding feature
-					// was requested at session creation time. For simplicity, just ask for
-					// the interesting ones as optional features, but be aware that the
-					// requestReferenceSpace call will fail if it turns out to be unavailable.
-					// ('local' is always available for immersive sessions and doesn't need to
-					// be requested separately.)
-
-					const sessionInit = { optionalFeatures: [ 'local-floor', 'bounded-floor', 'hand-tracking', 'layers' ] };
 					navigator.xr.requestSession( 'immersive-vr', sessionInit ).then( onSessionStarted );
 
 				} else {
@@ -72,6 +73,13 @@ class VRButton {
 				}
 
 			};
+
+			if ( navigator.xr.offerSession !== undefined ) {
+
+				navigator.xr.offerSession( 'immersive-vr', sessionInit )
+					.then( onSessionStarted );
+
+			}
 
 		}
 

--- a/examples/jsm/webxr/XRButton.js
+++ b/examples/jsm/webxr/XRButton.js
@@ -40,6 +40,17 @@ class XRButton {
 
 			button.textContent = 'START XR';
 
+			const sessionOptions = {
+				...sessionInit,
+				optionalFeatures: [
+					'local-floor',
+					'bounded-floor',
+					'hand-tracking',
+					'layers',
+					...( sessionInit.optionalFeatures || [] )
+				],
+			};
+
 			button.onmouseenter = function () {
 
 				button.style.opacity = '1.0';
@@ -56,17 +67,6 @@ class XRButton {
 
 				if ( currentSession === null ) {
 
-					const sessionOptions = {
-						...sessionInit,
-						optionalFeatures: [
-							'local-floor',
-							'bounded-floor',
-							'hand-tracking',
-							'layers',
-							...( sessionInit.optionalFeatures || [] )
-						],
-					};
-
 					navigator.xr.requestSession( mode, sessionOptions )
 						.then( onSessionStarted );
 
@@ -77,6 +77,13 @@ class XRButton {
 				}
 
 			};
+
+			if ( navigator.xr.offerSession !== undefined ) {
+
+				navigator.xr.offerSession( mode, sessionOptions )
+					.then( onSessionStarted );
+
+			}
 
 		}
 


### PR DESCRIPTION
`offerSession` is a recent addition to WebXR that makes it more obvious that a page can enter WebXR.
Quest browser got feedback that the "Enter VR/AR/XR" buttons on a lot of sites is hard to find. Often the button is small or scrolled of the bottom of the page. To remedy this, we worked with the W3C Immersive group on a new API that adds a button to the URL bar. This button will launch a pending immersive session.

This change adds support for this new API. Authors are free to use it or comment it out if they prefer to only allow their own UI.

cc @mrdoob 

*This contribution is funded by [Meta](https://meta.com)*
