### PR TITLE
GPUStatsPanel: Clean up, add ability to customize precision to stats

### DIFF
--- a/examples/jsm/libs/stats.module.js
+++ b/examples/jsm/libs/stats.module.js
@@ -139,7 +139,11 @@ Stats.Panel = function ( name, fg, bg ) {
 
 		dom: canvas,
 
+		getDisplayValue: round,
+
 		update: function ( value, maxValue ) {
+
+			const getDisplayValue = this.getDisplayValue;
 
 			min = Math.min( min, value );
 			max = Math.max( max, value );
@@ -148,7 +152,7 @@ Stats.Panel = function ( name, fg, bg ) {
 			context.globalAlpha = 1;
 			context.fillRect( 0, 0, WIDTH, GRAPH_Y );
 			context.fillStyle = fg;
-			context.fillText( round( value ) + ' ' + name + ' (' + round( min ) + '-' + round( max ) + ')', TEXT_X, TEXT_Y );
+			context.fillText( getDisplayValue( value ) + ' ' + name + ' (' + getDisplayValue( min ) + '-' + getDisplayValue( max ) + ')', TEXT_X, TEXT_Y );
 
 			context.drawImage( canvas, GRAPH_X + PR, GRAPH_Y, GRAPH_WIDTH - PR, GRAPH_HEIGHT, GRAPH_X, GRAPH_Y, GRAPH_WIDTH - PR, GRAPH_HEIGHT );
 

--- a/examples/jsm/utils/GPUStatsPanel.js
+++ b/examples/jsm/utils/GPUStatsPanel.js
@@ -83,6 +83,17 @@ export class GPUStatsPanel extends Stats.Panel {
 
 					}
 
+					// release the query
+					if ( isWebGL2 ) {
+
+						gl.deleteQuery( query );
+
+					} else {
+
+						ext.deleteQueryEXT( query );
+
+					}
+
 					this.activeQueries --;
 
 

--- a/examples/jsm/utils/GPUStatsPanel.js
+++ b/examples/jsm/utils/GPUStatsPanel.js
@@ -4,7 +4,7 @@ import Stats from '../libs/stats.module.js';
 // https://www.khronos.org/registry/webgl/extensions/EXT_disjoint_timer_query_webgl2/
 export class GPUStatsPanel extends Stats.Panel {
 
-	constructor( context, name = 'GPU MS' ) {
+	constructor( context, name = 'GPU' ) {
 
 		super( name, '#f90', '#210' );
 
@@ -27,6 +27,8 @@ export class GPUStatsPanel extends Stats.Panel {
 		this.extension = extension;
 		this.maxTime = 30;
 		this.activeQueries = 0;
+
+		this.getDisplayValue = value => value.toFixed( 2 );
 
 		this.startQuery = function () {
 
@@ -95,7 +97,6 @@ export class GPUStatsPanel extends Stats.Panel {
 					}
 
 					this.activeQueries --;
-
 
 				} else if ( gl.isContextLost() === false ) {
 


### PR DESCRIPTION
Related issue: #27347 

**Description**

- Make sure the GPUStatsPanel queries are cleaned up.
- Adjust the stats library to enable displaying the values to a custom precision.

As suggested in #27347 it might make sense to adjust stats.js to display more values of precision by default and make it display average value over time. And maybe expand the width of the stats panel to ~90-100 px so the min / max values can all be displayed.

cc @RenaudRohlinger 