### PR TITLE
Quaternion: Add missing call of `_onChangeCallback()` to `fromBufferAttribute()`.

### DIFF
--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -650,6 +650,8 @@ class Quaternion {
 		this._z = attribute.getZ( index );
 		this._w = attribute.getW( index );
 
+		this._onChangeCallback();
+
 		return this;
 
 	}


### PR DESCRIPTION
Related issue: -

**Description**

Similar to `fromArray()`, `fromBufferAttribute()` has to call `_onChangeCallback()`.
