### PR TITLE
Quaternion: Add default parameter to `setFromEuler()`.

### DIFF
--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -198,7 +198,7 @@ class Quaternion {
 
 	}
 
-	setFromEuler( euler, update ) {
+	setFromEuler( euler, update = true ) {
 
 		const x = euler._x, y = euler._y, z = euler._z, order = euler._order;
 
@@ -266,7 +266,7 @@ class Quaternion {
 
 		}
 
-		if ( update !== false ) this._onChangeCallback();
+		if ( update === true ) this._onChangeCallback();
 
 		return this;
 


### PR DESCRIPTION
Related issue: -

**Description**

Similar to [Euler.setFromRotationMatrix()](https://github.com/mrdoob/three.js/blob/64148ccd1a280066090f0dcdfd955b8b28a58983/src/math/Euler.js#L105) it's more readable to provide a default parameter for `update`. 
