### PR TITLE
Quaternion: Remove redundant `_onChangeCallback()` in `slerp()`.

### DIFF
--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -561,8 +561,7 @@ class Quaternion {
 			this._y = s * y + t * this._y;
 			this._z = s * z + t * this._z;
 
-			this.normalize();
-			this._onChangeCallback();
+			this.normalize(); // normalize calls _onChangeCallback()
 
 			return this;
 


### PR DESCRIPTION
Related issue: -

**Description**

There is one occasion where `Quaternion.slerp()` redundantly calls `_onChangeCallback`.
