### PR TITLE
Call offerSession at session end time

### DIFF
--- a/examples/jsm/webxr/ARButton.js
+++ b/examples/jsm/webxr/ARButton.js
@@ -104,6 +104,13 @@ class ARButton {
 
 					currentSession.end();
 
+					if ( navigator.xr.offerSession !== undefined ) {
+
+						navigator.xr.offerSession( 'immersive-ar', sessionInit )
+							.then( onSessionStarted );
+
+					}
+
 				}
 
 			};

--- a/examples/jsm/webxr/VRButton.js
+++ b/examples/jsm/webxr/VRButton.js
@@ -70,6 +70,13 @@ class VRButton {
 
 					currentSession.end();
 
+					if ( navigator.xr.offerSession !== undefined ) {
+
+						navigator.xr.offerSession( 'immersive-vr', sessionInit )
+							.then( onSessionStarted );
+
+					}
+
 				}
 
 			};

--- a/examples/jsm/webxr/XRButton.js
+++ b/examples/jsm/webxr/XRButton.js
@@ -74,6 +74,13 @@ class XRButton {
 
 					currentSession.end();
 
+					if ( navigator.xr.offerSession !== undefined ) {
+
+						navigator.xr.offerSession( mode, sessionOptions )
+							.then( onSessionStarted );
+
+					}
+
 				}
 
 			};


### PR DESCRIPTION
In a previous [PR](https://github.com/mrdoob/three.js/pull/27359), basic support for `offerSession` was added.
Because `offerSession`'s promise is fulfilled when the browser button is clicked, we need to call it again so the button can be displayed again. 

cc: @Mugen87 

*This contribution is funded by [Meta](https://meta.com)*
