### PR TITLE
WebGLUniformsGroups: Fix and improve UBOs array caching system

### DIFF
--- a/src/renderers/webgl/WebGLUniformsGroups.js
+++ b/src/renderers/webgl/WebGLUniformsGroups.js
@@ -102,7 +102,7 @@ function WebGLUniformsGroups( gl, info, capabilities, state ) {
 
 				const uniform = uniformArray[ j ];
 
-				if ( hasUniformChanged( uniform, i, cache ) === true ) {
+				if ( hasUniformChanged( uniform, i, j, cache ) === true ) {
 
 					const offset = uniform.__offset;
 
@@ -110,9 +110,9 @@ function WebGLUniformsGroups( gl, info, capabilities, state ) {
 
 					let arrayOffset = 0;
 
-					for ( let i = 0; i < values.length; i ++ ) {
+					for ( let k = 0; k < values.length; k ++ ) {
 
-						const value = values[ i ];
+						const value = values[ k ];
 
 						const info = getUniformSize( value );
 
@@ -161,31 +161,22 @@ function WebGLUniformsGroups( gl, info, capabilities, state ) {
 
 	}
 
-	function hasUniformChanged( uniform, index, cache ) {
+	function hasUniformChanged( uniform, index, indexArray, cache ) {
 
 		const value = uniform.value;
+		const indexString = index + '_' + indexArray;
 
-		if ( cache[ index ] === undefined ) {
+		if ( cache[ indexString ] === undefined ) {
 
 			// cache entry does not exist so far
 
 			if ( typeof value === 'number' || typeof value === 'boolean' ) {
 
-				cache[ index ] = value;
+				cache[ indexString ] = value;
 
 			} else {
 
-				const values = Array.isArray( value ) ? value : [ value ];
-
-				const tempValues = [];
-
-				for ( let i = 0; i < values.length; i ++ ) {
-
-					tempValues.push( values[ i ].clone() );
-
-				}
-
-				cache[ index ] = tempValues;
+				cache[ indexString ] = value.clone();
 
 			}
 
@@ -197,37 +188,30 @@ function WebGLUniformsGroups( gl, info, capabilities, state ) {
 
 			if ( typeof value === 'number' || typeof value === 'boolean' ) {
 
-				if ( cache[ index ] !== value ) {
+				if ( cache[ indexString ] !== value ) {
 
-					cache[ index ] = value;
+					cache[ indexString ] = value;
 					return true;
 
 				}
 
 			} else {
 
-				const cachedObjects = Array.isArray( cache[ index ] ) ? cache[ index ] : [ cache[ index ] ];
-				const values = Array.isArray( value ) ? value : [ value ];
+				const cachedObject = cache[ indexString ];
 
-				for ( let i = 0; i < cachedObjects.length; i ++ ) {
+				if ( typeof cachedObject === 'number' || typeof cachedObject === 'boolean' ) {
 
-					const cachedObject = cachedObjects[ i ];
+					if ( cachedObject !== value ) {
 
-					if ( typeof cachedObject === 'number' || typeof cachedObject === 'boolean' ) {
-
-						if ( cachedObject !== values[ i ] ) {
-
-							cachedObjects[ i ] = values[ i ];
-							return true;
-
-						}
-
-					} else if ( cachedObject.equals( values[ i ] ) === false ) {
-
-						cachedObject.copy( values[ i ] );
+						cache[ indexString ] = value;
 						return true;
 
 					}
+
+				} else if ( cachedObject.equals( value ) === false ) {
+
+					cachedObject.copy( value );
+					return true;
 
 				}
 

--- a/src/renderers/webgl/WebGLUniformsGroups.js
+++ b/src/renderers/webgl/WebGLUniformsGroups.js
@@ -184,11 +184,13 @@ function WebGLUniformsGroups( gl, info, capabilities, state ) {
 
 		} else {
 
+			const cachedObject = cache[ indexString ];
+
 			// compare current value with cached entry
 
 			if ( typeof value === 'number' || typeof value === 'boolean' ) {
 
-				if ( cache[ indexString ] !== value ) {
+				if ( cachedObject !== value ) {
 
 					cache[ indexString ] = value;
 					return true;
@@ -197,18 +199,7 @@ function WebGLUniformsGroups( gl, info, capabilities, state ) {
 
 			} else {
 
-				const cachedObject = cache[ indexString ];
-
-				if ( typeof cachedObject === 'number' || typeof cachedObject === 'boolean' ) {
-
-					if ( cachedObject !== value ) {
-
-						cache[ indexString ] = value;
-						return true;
-
-					}
-
-				} else if ( cachedObject.equals( value ) === false ) {
+				if ( cachedObject.equals( value ) === false ) {
 
 					cachedObject.copy( value );
 					return true;


### PR DESCRIPTION
While testing array of UBOs I realized that the caching system was only taking in consideration the first entry of an array of uniform.

I refactored the caching system with using a `uniformIndex_uniformIndexInArray` key system to fix this.

Also the caching system was handling basic arrays which is something that `WebGLUniformsGroups` doesn't support yet. Not sure if Uniforms in threejs supports basic arrays OOTB (for example `Uniform( [0,1,2] )` instead of `Uniform( new THREE.Vector3(0,1,2) )` )?
Currently it adds unnecessary complexity to the caching system and anyway support is not there so I removed it.