### PR TITLE
Nodes: Mark directory as effectful for Webpack/Vite.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "type": "git",
     "url": "https://github.com/mrdoob/three.js"
   },
-  "sideEffects": ["./examples/jsm/nodes/Nodes.js"],
+  "sideEffects": ["./examples/jsm/nodes/**/*"],
   "files": [
     "build",
     "examples/jsm",


### PR DESCRIPTION
Fixes: #27360

**Description**

#27189 marked only the entrypoint for `three/nodes` as effectful which sufficed for Webpack, but wasn't correct as per the below comment.

> https://github.com/vitejs/vite/issues/15319#issuecomment-1855784471
> Yeah. According to my understanding, all modules in `./examples/jsm/nodes` have `side effects`, so the value of the `sideEffects` field in `https://github.com/mrdoob/three.js/blob/dev/package.json` should be `./examples/jsm/nodes/**/*` instead of `./examples/jsm/nodes/Nodes.js`.

