### PR TITLE
Audio: Fix uncaught exception in Audio.pause when the buffer isn't set

### DIFF
--- a/src/audio/Audio.js
+++ b/src/audio/Audio.js
@@ -143,7 +143,7 @@ class Audio extends Object3D {
 
 				// ensure _progress does not exceed duration with looped audios
 
-				this._progress = this._progress % ( this.duration || this.buffer.duration );
+				this._progress = this._progress % ( this.duration || ( this.buffer ? this.buffer.duration : Number.MAX_VALUE ) );
 
 			}
 


### PR DESCRIPTION
**Description**

I ran into this issue when updating an application from three r154 to r159. I'm not entirely sure why it happens now (doesn't look like there have been audio code changes in quite a while), but I think it can't hurt to catch the exception here.

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Needle](https://needle.tools)*
