### PR TITLE
Nodes: use relative references inside examples/jsm

### DIFF
--- a/examples/jsm/loaders/MaterialXLoader.js
+++ b/examples/jsm/loaders/MaterialXLoader.js
@@ -19,7 +19,7 @@ import {
 	mx_safepower, mx_contrast,
 	mx_srgb_texture_to_lin_rec709,
 	saturation
-} from 'three/nodes';
+} from '../nodes/Nodes.js';
 
 const colorSpaceLib = {
 	mx_srgb_texture_to_lin_rec709

--- a/examples/jsm/renderers/webgl-legacy/nodes/SlotNode.js
+++ b/examples/jsm/renderers/webgl-legacy/nodes/SlotNode.js
@@ -1,4 +1,4 @@
-import { Node } from 'three/nodes';
+import { Node } from '../../../nodes/Nodes.js';
 
 class SlotNode extends Node {
 

--- a/examples/jsm/renderers/webgl-legacy/nodes/WebGLNodeBuilder.js
+++ b/examples/jsm/renderers/webgl-legacy/nodes/WebGLNodeBuilder.js
@@ -1,4 +1,4 @@
-import { defaultShaderStages, NodeFrame, MathNode, GLSLNodeParser, NodeBuilder, normalView } from 'three/nodes';
+import { defaultShaderStages, NodeFrame, MathNode, GLSLNodeParser, NodeBuilder, normalView } from '../../../nodes/Nodes.js';
 import SlotNode from './SlotNode.js';
 import { PerspectiveCamera, ShaderChunk, ShaderLib, UniformsUtils, UniformsLib } from 'three';
 

--- a/examples/jsm/renderers/webgl-legacy/nodes/WebGLNodes.js
+++ b/examples/jsm/renderers/webgl-legacy/nodes/WebGLNodes.js
@@ -1,5 +1,5 @@
 import { WebGLNodeBuilder } from './WebGLNodeBuilder.js';
-import { NodeFrame } from 'three/nodes';
+import { NodeFrame } from '../../../nodes/Nodes.js';
 
 import { Material } from 'three';
 


### PR DESCRIPTION
Fixes (at least partically)
- https://github.com/mrdoob/three.js/issues/27354

**Description**

These are the only places where importmaps are currently required when accessing code from `examples/jsm`.
All other places that import from `three/nodes` are either inside example HTML files (that have importmaps) or inside the playground folder.

CC @sunag; is there a specific reason for why `three/nodes` is used? I understand that the location of this code may change again but I think then the paths should be adjusted instead of in the meantime requiring users to go through hoops with various bundlers to get these references to work.