### PR TITLE
WebGPURenderer: Fix use of same Material with different Skeleton

### DIFF
--- a/examples/jsm/renderers/common/RenderObject.js
+++ b/examples/jsm/renderers/common/RenderObject.js
@@ -129,6 +129,12 @@ export default class RenderObject {
 
 		}
 
+		if ( object.skeleton ) {
+
+			cacheKey += object.skeleton.uuid + ',';
+
+		}
+
 		if ( object.morphTargetInfluences ) {
 
 			cacheKey += object.morphTargetInfluences.length + ',';


### PR DESCRIPTION
Related issue: Fixes https://github.com/mrdoob/three.js/issues/27221

**Description**

Fix the use of same Material with different Skeleton.
