### PR TITLE
Docs: Add AgX tone mapping constant

### DIFF
--- a/docs/api/en/constants/Renderer.html
+++ b/docs/api/en/constants/Renderer.html
@@ -52,6 +52,7 @@
 		THREE.ReinhardToneMapping
 		THREE.CineonToneMapping 
 		THREE.ACESFilmicToneMapping
+		THREE.AgXToneMapping
 		THREE.CustomToneMapping
 		</code>
 		<p>
@@ -61,7 +62,7 @@
 		</p>
 		<p>
 			THREE.LinearToneMapping, THREE.ReinhardToneMapping,
-			THREE.CineonToneMapping and THREE.ACESFilmicToneMapping are built-in
+			THREE.CineonToneMapping, THREE.ACESFilmicToneMapping, and THREE.AgXToneMapping are built-in
 			implementations of tone mapping. THREE.CustomToneMapping expects a custom
 			implementation by modyfing GLSL code of the material's fragment shader.
 			See the [example:webgl_tonemapping WebGL / tonemapping] example.


### PR DESCRIPTION
Related issue: #27362 

**Description**

Adds the AgX Tone Mapping constant to the docs.