### PR TITLE
WebGPURenderer: bug fixes for WebGLBackend

### DIFF
--- a/examples/jsm/renderers/common/Renderer.js
+++ b/examples/jsm/renderers/common/Renderer.js
@@ -298,6 +298,7 @@ class Renderer {
 			renderContext.depthTexture = renderTargetData.depthTexture;
 			renderContext.width = renderTargetData.width;
 			renderContext.height = renderTargetData.height;
+			renderContext.renderTarget = renderTarget;
 
 		} else {
 

--- a/examples/jsm/renderers/webgl/WebGLBackend.js
+++ b/examples/jsm/renderers/webgl/WebGLBackend.js
@@ -943,7 +943,7 @@ class WebGLBackend extends Backend {
 
 		if ( renderContext.textures !== null ) {
 
-			const renderContextData = this.get( renderContext );
+			const renderContextData = this.get( renderContext.renderTarget );
 
 			let fb = renderContextData.framebuffer;
 

--- a/examples/jsm/renderers/webgl/utils/WebGLTextureUtils.js
+++ b/examples/jsm/renderers/webgl/utils/WebGLTextureUtils.js
@@ -243,6 +243,8 @@ class WebGLTextureUtils {
 		gl.getBufferSubData( gl.PIXEL_PACK_BUFFER, 0, dstBuffer );
 		gl.bindBuffer(  gl.PIXEL_PACK_BUFFER, null );
 
+		gl.deleteFramebuffer( fb );
+
 		return dstBuffer;
 
 	}


### PR DESCRIPTION
Related issue: #27400 

Multiple RenderTargets may map to a single RenderContext so we can't cache framebuffers by RenderContext. Pass RenderTarget to use as cache key for framebuffers.  Exposed by the compute_snow example which otherwise works with #27367.

Also add missing temporary framebuffer deletion.
