### PR TITLE
OrbitControls: Use scroll event delta to modulate zoom speed

### DIFF
--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -492,9 +492,10 @@ class OrbitControls extends EventDispatcher {
 
 		}
 
-		function getZoomScale() {
+		function getZoomScale( delta ) {
 
-			return Math.pow( 0.95, scope.zoomSpeed );
+			const normalized_delta = Math.abs( delta ) / ( 100 * ( window.devicePixelRatio | 0 ) );
+			return Math.pow( 0.95, scope.zoomSpeed * normalized_delta );
 
 		}
 
@@ -699,11 +700,11 @@ class OrbitControls extends EventDispatcher {
 
 			if ( dollyDelta.y > 0 ) {
 
-				dollyOut( getZoomScale() );
+				dollyOut( getZoomScale( dollyDelta.y ) );
 
 			} else if ( dollyDelta.y < 0 ) {
 
-				dollyIn( getZoomScale() );
+				dollyIn( getZoomScale( dollyDelta.y ) );
 
 			}
 
@@ -733,11 +734,11 @@ class OrbitControls extends EventDispatcher {
 
 			if ( event.deltaY < 0 ) {
 
-				dollyIn( getZoomScale() );
+				dollyIn( getZoomScale( event.deltaY ) );
 
 			} else if ( event.deltaY > 0 ) {
 
-				dollyOut( getZoomScale() );
+				dollyOut( getZoomScale( event.deltaY ) );
 
 			}
 


### PR DESCRIPTION
This PR is an attempt to normalize zoom-speed across devices & operating systems.

I've noticed that `OrbitControls` zoom implementation leads to different zoom behaviors depending on the device / method of interacting with the module. This occurs because we attempt to normalize the amount that is zoomed on every tick / scroll event ( `getZoomScale` ).

While this was probably done in an attempt to circumvent potential differences in the way devices handle scrolling, this ends up having the exact opposite effect. This is quite easy to detect if you ever try zooming on a trackpad, as most operating systems implement a built-in damping system for it. In fact, I'm quite surprised I couldn't find any issues or complaints about this behaviour, as it has been present for many years now.

Every scroll event (or equivalent) provides a `deltaY` to inform the underlying page of the amount that should be scrolled, this allows the page to respond correctly to the event. By ignoring this amount, we are in practice ignoring potential changes in scroll behavior the user might've set in the operating system, as well as making built-in damping systems work incorrectly.

When the operating system has a built-in damping system, it does so by triggering extra events with increasingly smaller `deltaY`, but since this amount is ignored, we treat each of these events as a full scroll, which leads to extremelly fast zoom. In fact, this also affects the regular middle-mouse button scroll, if you try it, you'll notice it is extremely fast and hard to control. (Touch events are handled correctly)

I believe our current behaviour for middle mouse button scroll can also be improved, but I'll leave this discussion for a follow-up Issue/PR.

[Live Example](https://rawcdn.githack.com/sciecode/three.js/fcfefba6badea9fa73fb4b5cee80f55cc089a63d/examples/misc_controls_map.html)

@Mugen87 @WestLangley @gkjohnson

