### PR TITLE
Fix import target in OrbitControls.html

### DIFF
--- a/docs/examples/en/controls/OrbitControls.html
+++ b/docs/examples/en/controls/OrbitControls.html
@@ -24,7 +24,7 @@
 		</p>
 
 		<code>
-			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls';
 		</code>
 
 		<h2>Code Example</h2>


### PR DESCRIPTION
It seems that the import target in this example isn't quite right? I've replaced the path with one that works on my system with THREE 0.159.0. Do other example need a fix like this?