### PR TITLE
Timer: Add optional `timestamp` parameter.

### DIFF
--- a/docs/examples/en/misc/Timer.html
+++ b/docs/examples/en/misc/Timer.html
@@ -11,7 +11,7 @@
 		<h1>[name]</h1>
 
 		<p class="desc">
-			This class is an alternative to [page:Clock] with a different API design and behavior
+			This class is an alternative to [page:Clock] with a different API design and behavior.
 			The goal is to avoid the conceptual flaws that became apparent in [page:Clock] over time.
 
 			<ul>
@@ -37,11 +37,12 @@
 		<code>
 		const timer = new Timer();
 
-		function animate() {
+		function animate( timestamp ) {
 
 			requestAnimationFrame( animate );
-			
-			timer.update();
+
+			// timestamp is optional
+			timer.update( timestamp );
 
 			const delta = timer.getDelta();
 
@@ -109,8 +110,14 @@
 			Sets a time scale that scales the time delta in [page:.update]().
 		</p>
 
-		<h3>[method:this update]()</h3>
+		<h3>[method:this update]( [param:Number timestamp] )</h3>
 		<p>
+			timestamp -- (optional) The current time in milliseconds. Can be obtained from the
+			[link:https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame requestAnimationFrame]
+			callback argument. If not provided, the current time will be determined with
+			[link:https://developer.mozilla.org/en-US/docs/Web/API/Performance/now performance.now]. Please note that this
+			parameter has no effect when using a fixed time delta.<br /><br />
+
 			Updates the internal state of the timer. This method should be called once per simulation step
 			and before you perform queries against the timer (e.g. via [page:.getDelta]()).
 		</p>

--- a/examples/jsm/misc/Timer.js
+++ b/examples/jsm/misc/Timer.js
@@ -104,7 +104,7 @@ class Timer {
 
 	}
 
-	update() {
+	update( timestamp ) {
 
 		if ( this._useFixedDelta === true ) {
 
@@ -113,7 +113,7 @@ class Timer {
 		} else {
 
 			this._previousTime = this._currentTime;
-			this._currentTime = now() - this._startTime;
+			this._currentTime = ( timestamp !== undefined ? timestamp : now() ) - this._startTime;
 
 			this._delta = this._currentTime - this._previousTime;
 


### PR DESCRIPTION
Related PR: #17912

**Description**

This PR continues the discussion from https://github.com/mrdoob/three.js/pull/17912#issuecomment-1858922072.

I've added an optional `timestamp` parameter to `Timer.update()` that allows the user to pass the same timestamp to multiple timers. This also avoids unnecessary calls to `performance.now()` when using [requestAnimationFrame](https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame) because the callback already receives a timestamp argument.

@Mugen87 previously raised some concerns regarding this parameter:
> I was unsure about this feature since the parameter has no effect when a fixed time delta is used. Besides, I couldn't decide how the parameter should play together with `_startTime` (which was added to support multiple timers).

We can clarify in the docs that using a `fixedDelta` overrides dynamic time deltas. I'm not sure if the `timestamp` parameter would somehow interfere with `_startTime`. Shouldn't this just work as if `performance.now()` was used?