### PR TITLE
Timer: Added FixedTimer

### DIFF
--- a/docs/examples/en/misc/Timer.html
+++ b/docs/examples/en/misc/Timer.html
@@ -64,11 +64,6 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:this dispose]()</h3>
-		<p>
-			Can be used to free all internal resources. Usually called when the timer instance isn't required anymore.
-		</p>
-
 		<h3>[method:Number getDelta]()</h3>
 		<p>
 			Returns the time delta in seconds.
@@ -79,14 +74,19 @@
 			Returns the elapsed time in seconds.
 		</p>
 
+		<h3>[method:this setTimescale]( [param:Number timescale] )</h3>
+		<p>
+			Sets a time scale that scales the time delta in [page:.update]().
+		</p>
+
 		<h3>[method:this reset]()</h3>
 		<p>
 			Resets the time computation for the current simulation step.
 		</p>
 
-		<h3>[method:this setTimescale]( [param:Number timescale] )</h3>
+		<h3>[method:this dispose]()</h3>
 		<p>
-			Sets a time scale that scales the time delta in [page:.update]().
+			Can be used to free all internal resources. Usually called when the timer instance isn't required anymore.
 		</p>
 
 		<h3>[method:this update]( [param:Number timestamp] )</h3>

--- a/docs/examples/en/misc/Timer.html
+++ b/docs/examples/en/misc/Timer.html
@@ -17,7 +17,6 @@
 			<ul>
 				<li>[name] has an [page:.update]() method that updates its internal state. That makes it possible to call [page:.getDelta]() and [page:.getElapsed]() multiple times per simulation step without getting different values.</li>
 				<li>The class uses the Page Visibility API to avoid large time delta values when the app is inactive (e.g. tab switched or browser hidden).</li>
-				<li>It's possible to configure a fixed time delta and a time scale value (similar to Unity's Time interface).</li>
 			</ul>
 		</p>
 
@@ -65,19 +64,9 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:this disableFixedDelta]()</h3>
-		<p>
-			Disables the usage of a fixed delta time.
-		</p>
-
 		<h3>[method:this dispose]()</h3>
 		<p>
 			Can be used to free all internal resources. Usually called when the timer instance isn't required anymore.
-		</p>
-
-		<h3>[method:this enableFixedDelta]()</h3>
-		<p>
-			Enables the usage of a fixed delta time.
 		</p>
 
 		<h3>[method:Number getDelta]()</h3>
@@ -90,19 +79,9 @@
 			Returns the elapsed time in seconds.
 		</p>
 
-		<h3>[method:Number getFixedDelta]()</h3>
-		<p>
-			Returns the fixed time delta that has been previously configured via [page:.setFixedDelta]().
-		</p>
-
 		<h3>[method:this reset]()</h3>
 		<p>
 			Resets the time computation for the current simulation step.
-		</p>
-
-		<h3>[method:this setFixedDelta]( [param:Number delta] )</h3>
-		<p>
-			Defines a fixed time delta value which is used to update the timer per simulation step.
 		</p>
 
 		<h3>[method:this setTimescale]( [param:Number timescale] )</h3>
@@ -115,8 +94,7 @@
 			timestamp -- (optional) The current time in milliseconds. Can be obtained from the
 			[link:https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame requestAnimationFrame]
 			callback argument. If not provided, the current time will be determined with
-			[link:https://developer.mozilla.org/en-US/docs/Web/API/Performance/now performance.now]. Please note that this
-			parameter has no effect when using a fixed time delta.<br /><br />
+			[link:https://developer.mozilla.org/en-US/docs/Web/API/Performance/now performance.now].<br /><br />
 
 			Updates the internal state of the timer. This method should be called once per simulation step
 			and before you perform queries against the timer (e.g. via [page:.getDelta]()).

--- a/examples/jsm/misc/Timer.js
+++ b/examples/jsm/misc/Timer.js
@@ -11,9 +11,6 @@ class Timer {
 
 		this._timescale = 1;
 
-		this._useFixedDelta = false;
-		this._fixedDelta = 16.67; // ms, corresponds to approx. 60 FPS
-
 		// use Page Visibility API to avoid large time delta values
 
 		this._usePageVisibilityAPI = ( typeof document !== 'undefined' && document.hidden !== undefined );
@@ -28,9 +25,35 @@ class Timer {
 
 	}
 
-	disableFixedDelta() {
+	getDelta() {
 
-		this._useFixedDelta = false;
+		return this._delta / 1000;
+
+	}
+
+	getElapsed() {
+
+		return this._elapsed / 1000;
+
+	}
+
+	getTimescale() {
+
+		return this._timescale;
+
+	}
+
+	setTimescale( timescale ) {
+
+		this._timescale = timescale;
+
+		return this;
+
+	}
+
+	reset() {
+
+		this._currentTime = now() - this._startTime;
 
 		return this;
 
@@ -48,80 +71,32 @@ class Timer {
 
 	}
 
-	enableFixedDelta() {
+	update() {
 
-		this._useFixedDelta = true;
-
-		return this;
-
-	}
-
-	getDelta() {
-
-		return this._delta / 1000;
-
-	}
-
-	getElapsed() {
-
-		return this._elapsed / 1000;
-
-	}
-
-	getFixedDelta() {
-
-		return this._fixedDelta / 1000;
-
-	}
-
-	getTimescale() {
-
-		return this._timescale;
-
-	}
-
-	reset() {
-
+		this._previousTime = this._currentTime;
 		this._currentTime = now() - this._startTime;
 
-		return this;
-
-	}
-
-	setFixedDelta( fixedDelta ) {
-
-		this._fixedDelta = fixedDelta * 1000;
+		this._delta = ( this._currentTime - this._previousTime ) * this._timescale;
+		this._elapsed += this._delta; // _elapsed is the accumulation of all previous deltas
 
 		return this;
 
 	}
 
-	setTimescale( timescale ) {
+}
 
-		this._timescale = timescale;
+class FixedTimer extends Timer {
 
-		return this;
+	constructor( fps = 60 ) {
+
+		super();
+		this._delta = ( 1 / fps ) * 1000;
 
 	}
 
 	update() {
 
-		if ( this._useFixedDelta === true ) {
-
-			this._delta = this._fixedDelta;
-
-		} else {
-
-			this._previousTime = this._currentTime;
-			this._currentTime = now() - this._startTime;
-
-			this._delta = this._currentTime - this._previousTime;
-
-		}
-
-		this._delta *= this._timescale;
-
-		this._elapsed += this._delta; // _elapsed is the accumulation of all previous deltas
+		this._elapsed += ( this._delta * this._timescale ); // _elapsed is the accumulation of all previous deltas
 
 		return this;
 
@@ -141,4 +116,4 @@ function handleVisibilityChange() {
 
 }
 
-export { Timer };
+export { Timer, FixedTimer };


### PR DESCRIPTION
Related issue: #17912

**Description**

Moved the `_fixedDelta` and `_useFixedDelta` functionality into its own `FixedTimer` class and removed the `enableFixedDelta()` and `disableFixedDelta()` methods.

I think this approach is cleaner... but I'm not sure how `FixedTimer` is supposed to be used.

@Mugen87 I guess it's supposed to be used for debugging? https://github.com/mrdoob/three.js/pull/17912#issuecomment-553411218