### PR TITLE
OrbitControls: fix Orthographic 'change' event

### DIFF
--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -376,7 +376,7 @@ class OrbitControls extends EventDispatcher {
 
 					scope.object.zoom = Math.max( scope.minZoom, Math.min( scope.maxZoom, scope.object.zoom / scale ) );
 					scope.object.updateProjectionMatrix();
-					zoomChanged = true;
+					zoomChanged = scale != 1;
 
 				}
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -374,7 +374,7 @@ class OrbitControls extends EventDispatcher {
 
 				} else if ( scope.object.isOrthographicCamera ) {
 					
-					zoomChanged = scale != 1;
+					zoomChanged = scale !== 1;
 
 					if ( zoomChanged ) {
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -373,10 +373,15 @@ class OrbitControls extends EventDispatcher {
 					}
 
 				} else if ( scope.object.isOrthographicCamera ) {
-
-					scope.object.zoom = Math.max( scope.minZoom, Math.min( scope.maxZoom, scope.object.zoom / scale ) );
-					scope.object.updateProjectionMatrix();
+					
 					zoomChanged = scale != 1;
+
+					if ( zoomChanged ) {
+
+						scope.object.zoom = Math.max( scope.minZoom, Math.min( scope.maxZoom, scope.object.zoom / scale ) );
+						scope.object.updateProjectionMatrix();
+						
+					}
 
 				}
 


### PR DESCRIPTION
Fixes #27280

Prevents `OrthographicCamera` from triggering `change` event every frame.