### PR TITLE
OrbitControls: update state on pointer up

### DIFF
--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -1053,6 +1053,16 @@ class OrbitControls extends EventDispatcher {
 
 			state = STATE.NONE;
 
+			if ( pointers.length == 1 ) {
+
+				const pointerId = pointers[ 0 ];
+				const position = pointerPositions[ pointerId ];
+
+				// minimal placeholder event - allows state correction on pointer-up
+				onTouchStart( { pointerId: pointerId, pageX: position.x, pageY: position.y } );
+
+			}
+
 		}
 
 		function onMouseDown( event ) {


### PR DESCRIPTION
Currently, whenever a 2-touch event is in progress and only one 1 pointer is removed, the controls won't properly re-initiate the configured 1-touch event; which leads to unresponsiveness.

This PR addresses this issue, by properly re-initiating states when necessary. At first I thought this could be related to #27333. Although, I'm not too sure anymore.

If anyone with compatible devices could test, I would appreciate it. I would like to investigate that issue, but I can only speculate as to the causes without access to a device that can replicate it.

[Live Example - PR](https://rawcdn.githack.com/sciecode/three.js/ec4b8f713bf4cc5238e5c66e5b5d8c66191fe5f7/examples/misc_controls_map.html)

https://rawcdn.githack.com/sciecode/three.js/ec4b8f713bf4cc5238e5c66e5b5d8c66191fe5f7/examples/misc_controls_orbit.html