### PR TITLE
ShaderNode: Fix .isArrayInput

### DIFF
--- a/examples/jsm/nodes/shadernode/ShaderNode.js
+++ b/examples/jsm/nodes/shadernode/ShaderNode.js
@@ -341,7 +341,7 @@ class ShaderNodeInternal extends Node {
 
 	get isArrayInput() {
 
-		return /^\(\s+?\[/.test( this.jsFunc.toString() );
+		return /^\((\s+)?\[/.test( this.jsFunc.toString() );
 
 	}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/27426

**Description**

Fix `.isArrayInput`. It is used to check whether the `tslFn` input function was designated to receive parameters as `Array` or `Object`.
