### PR TITLE
WebGLPrograms: Fix `fogExp2` parameter.

### DIFF
--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -300,7 +300,7 @@ function WebGLPrograms( renderer, cubemaps, cubeuvmaps, extensions, capabilities
 
 			fog: !! fog,
 			useFog: material.fog === true,
-			fogExp2: ( fog && fog.isFogExp2 ),
+			fogExp2: ( !! fog && fog.isFogExp2 ),
 
 			flatShading: material.flatShading === true,
 


### PR DESCRIPTION
**Description**

The `fogExp2` parameter returned by `WebGLPrograms.getParameters` can currently be `null` if `fog` is `null` which seems to be a mistake. This PR fixes this by converting `fog` to a boolean.
