### PR TITLE
MaterialXLoader: Respect handlers attached to manager when loading textures

### DIFF
--- a/examples/jsm/loaders/MaterialXLoader.js
+++ b/examples/jsm/loaders/MaterialXLoader.js
@@ -312,7 +312,17 @@ class MaterialXNode {
 
 		const filePrefix = this.getRecursiveAttribute( 'fileprefix' ) || '';
 
-		const texture = this.materialX.textureLoader.load( filePrefix + this.value );
+		let loader = this.materialX.textureLoader;
+		const uri = filePrefix + this.value;
+
+		if ( uri ) {
+
+			const handler = this.materialX.manager.getHandler( uri );
+			if ( handler !== null ) loader = handler;
+
+		}
+
+		const texture = loader.load( uri );
 		texture.wrapS = texture.wrapT = RepeatWrapping;
 		texture.flipY = false;
 


### PR DESCRIPTION
**Description**

Texture loading now matches how GLTFloader does this, which allows to add custom handlers to the LoadingManager (for example for loading textures from embedded glTF resources).

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Needle](https://needle.tools)*
