### PR TITLE
MaterialXLoader: improve `onError` handling

### DIFF
--- a/examples/jsm/loaders/MaterialXLoader.js
+++ b/examples/jsm/loaders/MaterialXLoader.js
@@ -141,6 +141,20 @@ class MaterialXLoader extends Loader {
 
 	load( url, onLoad, onProgress, onError ) {
 
+		const _onError = function ( e ) {
+
+			if ( onError ) {
+
+				onError( e );
+
+			} else {
+
+				console.error( e );
+
+			}
+
+		};
+
 		new FileLoader( this.manager )
 			.setPath( this.path )
 			.load( url, async ( text ) => {
@@ -151,11 +165,11 @@ class MaterialXLoader extends Loader {
 
 				} catch ( e ) {
 
-					onError( e );
+					_onError( e );
 
 				}
 
-			}, onProgress, onError );
+			}, onProgress, _onError );
 
 		return this;
 


### PR DESCRIPTION
**Description**

Error handling now matches what GLTFLoader does and properly works when there is no error handler passed into `load()`.
<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Needle](https://needle.tools)*
