### PR TITLE
examples: GTAOPass - fix setting of PERSPECTIVE_CAMERA

### DIFF
--- a/examples/jsm/postprocessing/GTAOPass.js
+++ b/examples/jsm/postprocessing/GTAOPass.js
@@ -61,7 +61,7 @@ class GTAOPass extends Pass {
 			depthTest: false,
 			depthWrite: false,
 		} );
-		this.gtaoMaterial.definesPERSPECTIVE_CAMERA = this.camera.isPerspectiveCamera ? 1 : 0;
+		this.gtaoMaterial.defines.PERSPECTIVE_CAMERA = this.camera.isPerspectiveCamera ? 1 : 0;
 		this.gtaoMaterial.uniforms.tNoise.value = this.gtaoNoiseTexture;
 		this.gtaoMaterial.uniforms.resolution.value.set( this.width, this.height );
 		this.gtaoMaterial.uniforms.cameraNear.value = this.camera.near;


### PR DESCRIPTION
Related issue: #27317

this one-liner is actually self-explanatory

Fortunately, the common case, `PERSPECTIVE_CAMERA: 1` is the default setting. However, it was not possible to use an orthographic camera correctly.