### PR TITLE
WebGPURenderer: Ignore `webgpu_backdrop_water` from E2E tests

### DIFF
--- a/test/e2e/puppeteer.js
+++ b/test/e2e/puppeteer.js
@@ -129,6 +129,7 @@ const exceptionList = [
 	'webgpu_video_panorama',
 
 	// WebGPURenderer: Unknown problem
+	'webgpu_backdrop_water',
 	'webgpu_camera_logarithmicdepthbuffer',
 	'webgpu_loader_materialx',
 	'webgpu_materials_video',


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/27447#issuecomment-1870146663
