### PR TITLE
Addons: export GroundedSkybox.

### DIFF
--- a/examples/jsm/Addons.js
+++ b/examples/jsm/Addons.js
@@ -160,7 +160,7 @@ export * from './modifiers/EdgeSplitModifier.js';
 export * from './modifiers/SimplifyModifier.js';
 export * from './modifiers/TessellateModifier.js';
 
-export * from './objects/GroundProjectedSkybox.js';
+export * from './objects/GroundedSkybox.js';
 export * from './objects/Lensflare.js';
 export * from './objects/MarchingCubes.js';
 export * from './objects/Reflector.js';


### PR DESCRIPTION
Related issue: #27448

**Description**

Changes the export from `GroundProjectedSkybox`. Can test with `node examples/jsm/Addons.js`.

Perhaps we need a lint rule or test for this.