### PR TITLE
WebGPURenderer: Fix Renderer `dispose()`

### DIFF
--- a/examples/jsm/renderers/common/DataMap.js
+++ b/examples/jsm/renderers/common/DataMap.js
@@ -45,7 +45,7 @@ class DataMap {
 
 	dispose() {
 
-		this.data.clear();
+		this.data = new WeakMap();
 
 	}
 

--- a/examples/jsm/renderers/common/Renderer.js
+++ b/examples/jsm/renderers/common/Renderer.js
@@ -70,7 +70,6 @@ class Renderer {
 		this._scissor = new Vector4( 0, 0, this._width, this._height );
 		this._scissorTest = false;
 
-		this._properties = null;
 		this._attributes = null;
 		this._geometries = null;
 		this._nodes = null;
@@ -660,7 +659,6 @@ class Renderer {
 
 		this._animation.dispose();
 		this._objects.dispose();
-		// this._properties.dispose();
 		this._pipelines.dispose();
 		this._nodes.dispose();
 		this._bindings.dispose();

--- a/examples/jsm/renderers/common/Renderer.js
+++ b/examples/jsm/renderers/common/Renderer.js
@@ -660,7 +660,7 @@ class Renderer {
 
 		this._animation.dispose();
 		this._objects.dispose();
-		this._properties.dispose();
+		// this._properties.dispose();
 		this._pipelines.dispose();
 		this._nodes.dispose();
 		this._bindings.dispose();


### PR DESCRIPTION
`WeakMap.clear()` is deprecated and doesn't exist anymore in most web browsers.
`this._properties` is currently always `null`.

_This contribution is funded by [Utsubo](https://utsubo.com/)_