### PR TITLE
WebGPURenderer: Forward context to Renderer

### DIFF
--- a/examples/jsm/renderers/common/Backend.js
+++ b/examples/jsm/renderers/common/Backend.js
@@ -84,6 +84,8 @@ class Backend {
 
 	// canvas
 
+	getContext() { }
+
 	updateSize() { }
 
 	// utils

--- a/examples/jsm/renderers/common/Renderer.js
+++ b/examples/jsm/renderers/common/Renderer.js
@@ -401,7 +401,7 @@ class Renderer {
 
 	getContext() {
 
-		return this._context;
+		return this.backend.getContext();
 
 	}
 

--- a/examples/jsm/renderers/webgl/WebGLBackend.js
+++ b/examples/jsm/renderers/webgl/WebGLBackend.js
@@ -33,6 +33,7 @@ class WebGLBackend extends Backend {
 		const glContext = ( parameters.context !== undefined ) ? parameters.context : renderer.domElement.getContext( 'webgl2' );
 
 		this.gl = glContext;
+		this.renderer._context = glContext;
 
 		this.extensions = new WebGLExtensions( this );
 		this.capabilities = new WebGLCapabilities( this );

--- a/examples/jsm/renderers/webgl/WebGLBackend.js
+++ b/examples/jsm/renderers/webgl/WebGLBackend.js
@@ -33,7 +33,6 @@ class WebGLBackend extends Backend {
 		const glContext = ( parameters.context !== undefined ) ? parameters.context : renderer.domElement.getContext( 'webgl2' );
 
 		this.gl = glContext;
-		this.renderer._context = glContext;
 
 		this.extensions = new WebGLExtensions( this );
 		this.capabilities = new WebGLCapabilities( this );
@@ -57,6 +56,12 @@ class WebGLBackend extends Backend {
 	async getArrayBufferAsync( attribute ) {
 
 		return await this.attributeUtils.getArrayBufferAsync( attribute );
+
+	}
+
+	getContext() {
+
+		return this.gl;
 
 	}
 

--- a/examples/jsm/renderers/webgpu/WebGPUBackend.js
+++ b/examples/jsm/renderers/webgpu/WebGPUBackend.js
@@ -114,7 +114,6 @@ class WebGPUBackend extends Backend {
 		this.adapter = adapter;
 		this.device = device;
 		this.context = context;
-		this.renderer._context = context;
 
 		const alphaMode = parameters.alpha ? 'premultiplied' : 'opaque';
 
@@ -138,6 +137,12 @@ class WebGPUBackend extends Backend {
 	async getArrayBufferAsync( attribute ) {
 
 		return await this.attributeUtils.getArrayBufferAsync( attribute );
+
+	}
+
+	getContext() {
+
+		return this.context;
 
 	}
 

--- a/examples/jsm/renderers/webgpu/WebGPUBackend.js
+++ b/examples/jsm/renderers/webgpu/WebGPUBackend.js
@@ -114,6 +114,7 @@ class WebGPUBackend extends Backend {
 		this.adapter = adapter;
 		this.device = device;
 		this.context = context;
+		this.renderer._context = context;
 
 		const alphaMode = parameters.alpha ? 'premultiplied' : 'opaque';
 


### PR DESCRIPTION
Currently the `getContext()` method of the Renderer always return `undefined` because the context is never forwarded.

This PR fix the issue.

_This contribution is funded by [Utsubo](https://utsubo.com/)_