### PR TITLE
Audio: Make `setDetune()` more robust.

### DIFF
--- a/src/audio/Audio.js
+++ b/src/audio/Audio.js
@@ -270,9 +270,7 @@ class Audio extends Object3D {
 
 		this.detune = value;
 
-		if ( this.source.detune === undefined ) return; // only set detune when available
-
-		if ( this.isPlaying === true ) {
+		if ( this.isPlaying === true && this.source.detune !== undefined ) {
 
 			this.source.detune.setTargetAtTime( this.detune, this.context.currentTime, 0.01 );
 


### PR DESCRIPTION
Fixed #27477.

**Description**

Now the code only checks for `source.detune` when the audio is playing. That ensures an audio source is defined.