### PR TITLE
Constants: Remove deprecated code.

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -13,7 +13,6 @@ export const VSMShadowMap = 3;
 export const FrontSide = 0;
 export const BackSide = 1;
 export const DoubleSide = 2;
-export const TwoPassDoubleSide = 2; // r149
 export const NoBlending = 0;
 export const NormalBlending = 1;
 export const AdditiveBlending = 2;


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/25239/files#r1062773019

**Description**

Removes `TwoPassDoubleSide` which was deprecated since r147 in favor of `Material.forceSinglePass` with #25239.