### PR TITLE
WebGLRenderer: Explicitly specify precision for all sampler types

### DIFF
--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -313,7 +313,30 @@ function loopReplacer( match, start, end, snippet ) {
 
 function generatePrecision( parameters ) {
 
-	let precisionstring = 'precision ' + parameters.precision + ' float;\nprecision ' + parameters.precision + ' int;';
+	let precisionstring = `precision ${parameters.precision} float;
+	precision ${parameters.precision} int;
+	precision ${parameters.precision} sampler2D;
+	precision ${parameters.precision} samplerCube;
+	`;
+
+	if ( parameters.isWebGL2 ) {
+
+		precisionstring += `precision ${parameters.precision} sampler3D;
+		precision ${parameters.precision} sampler2DArray;
+		precision ${parameters.precision} sampler2DShadow;
+		precision ${parameters.precision} samplerCubeShadow;
+		precision ${parameters.precision} sampler2DArrayShadow;
+		precision ${parameters.precision} isampler2D;
+		precision ${parameters.precision} isampler3D;
+		precision ${parameters.precision} isamplerCube;
+		precision ${parameters.precision} isampler2DArray;
+		precision ${parameters.precision} usampler2D;
+		precision ${parameters.precision} usampler3D;
+		precision ${parameters.precision} usamplerCube;
+		precision ${parameters.precision} usampler2DArray;
+		`;
+
+	}
 
 	if ( parameters.precision === 'highp' ) {
 


### PR DESCRIPTION
**Description**

Most of the code written using Three.js (and Three.js itself in the case of shadow mapping) doesn't use depth textures to store depth values — RGBA8 textures are used instead by storing depth in an encoded format. However, there are cases when you want to render scene depth into a depth texture directly and subsequently sample depth values from this texture.

It seems like on some Android devices if you sample a depth texture without specifing a precision qualifier in the shader code then the precision ends up to be very low. It leads to noticable artifacts which can be described as banding.

This PR adds precision qualifiers for all possible sampler types to make sure that the precision value specified when creating a `WebGLRenderer` gets applied to all samplers.

WebGL1 sampler types are listed here: https://www.khronos.org/files/webgl/webgl-reference-card-1_0.pdf
And WebGL2 sampler types are listed in this card: https://www.khronos.org/files/webgl20-reference-guide.pdf

See screenshots below from `webgl_depth_texture` example taken on Google Pixel 7a. Note much smoother depth rendering on the second screenshot.

| Before (no `precision highp sampler2D;`) | After (with `precision highp sampler2D;`) |
|---------|------------|
|![Screenshot_20240101-011539](https://github.com/mrdoob/three.js/assets/48140945/8bc7fa4e-b316-49db-9983-15a7eedd9d02)|![Screenshot_20240101-011506](https://github.com/mrdoob/three.js/assets/48140945/c4a6f296-eec9-4ad5-8e44-b895d913c33f)|