### PR TITLE
Examples: SVGLoader - fix triangle segment uv coordinates

### DIFF
--- a/examples/jsm/loaders/SVGLoader.js
+++ b/examples/jsm/loaders/SVGLoader.js
@@ -2924,8 +2924,8 @@ class SVGLoader extends Loader {
 			addVertex( currentPointL, u1, 0 );
 
 			addVertex( lastPointR, u0, 1 );
-			addVertex( currentPointL, u1, 1 );
-			addVertex( currentPointR, u1, 0 );
+			addVertex( currentPointL, u1, 0 );
+			addVertex( currentPointR, u1, 1 );
 
 		}
 


### PR DESCRIPTION
Fixed #27464.

The V-component of the texture coordinates is swapped in comparison to the other texture coordinates for `currentPointL` and `currentPointR` in the `makeSegmentTriangles` function.  
The V-component on the left side should always be 0 and on the right side it should always be 1.
