### PR TITLE
Examples: Fix `webgpu_morphtargets_face`

### DIFF
--- a/examples/webgpu_morphtargets_face.html
+++ b/examples/webgpu_morphtargets_face.html
@@ -75,6 +75,7 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
+				renderer.setAnimationLoop( animate );
 
 				container.appendChild( renderer.domElement );
 
@@ -132,7 +133,9 @@
 				const stats = new Stats();
 				container.appendChild( stats.dom );
 
-				renderer.setAnimationLoop( () => {
+
+
+				function animate() {
 
 					const delta = clock.getDelta();
 
@@ -148,7 +151,7 @@
 
 					stats.update();
 
-				} );
+				}
 
 				window.addEventListener( 'resize', () => {
 


### PR DESCRIPTION
The demo is broken since the support of KTX2Loader as it was hardcoded before. This PR fix the issue. The error was muted since it's in the exceptionList of puppeteer.

With the support for KTX2Loader, it's necessary to invoke the setAnimationLoop method prior to loading any compressed textures. This step is required for initializing the renderer, which in turn provides the WebGL context to the KTX2Loader.