### PR TITLE
WebGPURenderer: fix renderContext tracking in WebGLBackend

### DIFF
--- a/examples/jsm/renderers/webgl/WebGLBackend.js
+++ b/examples/jsm/renderers/webgl/WebGLBackend.js
@@ -172,9 +172,6 @@ class WebGLBackend extends Backend {
 
 		}
 
-
-		this._currentContext = renderContext;
-
 		const occlusionQueryCount = renderContext.occlusionQueryCount;
 
 		if ( occlusionQueryCount > 0 ) {
@@ -355,7 +352,7 @@ class WebGLBackend extends Backend {
 
 	draw( renderObject, info ) {
 
-		const { pipeline, material, context, isRenderObject } = renderObject;
+		const { pipeline, material, context } = renderObject;
 		const { programGPU, vaoGPU } = this.get( pipeline );
 
 		const { gl, state } = this;
@@ -363,13 +360,6 @@ class WebGLBackend extends Backend {
 		const contextData = this.get( context );
 
 		//
-
-		if ( isRenderObject ) {
-
-			// we need to bind the framebuffer per object in multi pass pipeline
-			this._setFramebuffer( context );
-
-		}
 
 		const bindings = renderObject.getBindings();
 


### PR DESCRIPTION
MSAA implementation accidentally mis set the backend._currentContext value which resulted in incorrect linked lists of renderContexts  within nested passes.  This broke the shadow example using WebGLBackend which has two nested shadow map creation passes.

This removes the need to set the framebuffer in draw(), since finishRender now restores the correct settings as expected. New examples appear to be working as expected still.

@RenaudRohlinger