### PR TITLE
display offersession promise failure instead of showing console errors

### DIFF
--- a/examples/jsm/webxr/ARButton.js
+++ b/examples/jsm/webxr/ARButton.js
@@ -110,7 +110,7 @@ class ARButton {
 							.then( onSessionStarted )
 							.catch( ( err ) => {
 
-								console.log( err );
+								console.warn( err );
 
 							} );
 
@@ -126,7 +126,7 @@ class ARButton {
 					.then( onSessionStarted )
 					.catch( ( err ) => {
 
-						console.log( err );
+						console.warn( err );
 
 					} );
 

--- a/examples/jsm/webxr/ARButton.js
+++ b/examples/jsm/webxr/ARButton.js
@@ -107,7 +107,12 @@ class ARButton {
 					if ( navigator.xr.offerSession !== undefined ) {
 
 						navigator.xr.offerSession( 'immersive-ar', sessionInit )
-							.then( onSessionStarted );
+							.then( onSessionStarted )
+							.catch( ( err ) => {
+
+								console.log( err );
+
+							} );
 
 					}
 
@@ -118,7 +123,12 @@ class ARButton {
 			if ( navigator.xr.offerSession !== undefined ) {
 
 				navigator.xr.offerSession( 'immersive-ar', sessionInit )
-					.then( onSessionStarted );
+					.then( onSessionStarted )
+					.catch( ( err ) => {
+
+						console.log( err );
+
+					} );
 
 			}
 

--- a/examples/jsm/webxr/VRButton.js
+++ b/examples/jsm/webxr/VRButton.js
@@ -73,7 +73,12 @@ class VRButton {
 					if ( navigator.xr.offerSession !== undefined ) {
 
 						navigator.xr.offerSession( 'immersive-vr', sessionInit )
-							.then( onSessionStarted );
+							.then( onSessionStarted )
+							.catch( ( err ) => {
+
+								console.log( err );
+
+							} );
 
 					}
 
@@ -84,7 +89,12 @@ class VRButton {
 			if ( navigator.xr.offerSession !== undefined ) {
 
 				navigator.xr.offerSession( 'immersive-vr', sessionInit )
-					.then( onSessionStarted );
+					.then( onSessionStarted )
+					.catch( ( err ) => {
+
+						console.log( err );
+
+					} );
 
 			}
 

--- a/examples/jsm/webxr/VRButton.js
+++ b/examples/jsm/webxr/VRButton.js
@@ -76,7 +76,7 @@ class VRButton {
 							.then( onSessionStarted )
 							.catch( ( err ) => {
 
-								console.log( err );
+								console.warn( err );
 
 							} );
 
@@ -92,7 +92,7 @@ class VRButton {
 					.then( onSessionStarted )
 					.catch( ( err ) => {
 
-						console.log( err );
+						console.warn( err );
 
 					} );
 

--- a/examples/jsm/webxr/XRButton.js
+++ b/examples/jsm/webxr/XRButton.js
@@ -77,7 +77,12 @@ class XRButton {
 					if ( navigator.xr.offerSession !== undefined ) {
 
 						navigator.xr.offerSession( mode, sessionOptions )
-							.then( onSessionStarted );
+							.then( onSessionStarted )
+							.catch( ( err ) => {
+
+								console.log( err );
+
+							} );
 
 					}
 
@@ -88,7 +93,12 @@ class XRButton {
 			if ( navigator.xr.offerSession !== undefined ) {
 
 				navigator.xr.offerSession( mode, sessionOptions )
-					.then( onSessionStarted );
+					.then( onSessionStarted )
+					.catch( ( err ) => {
+
+						console.log( err );
+
+					} );
 
 			}
 

--- a/examples/jsm/webxr/XRButton.js
+++ b/examples/jsm/webxr/XRButton.js
@@ -80,7 +80,7 @@ class XRButton {
 							.then( onSessionStarted )
 							.catch( ( err ) => {
 
-								console.log( err );
+								console.warn( err );
 
 							} );
 
@@ -96,7 +96,7 @@ class XRButton {
 					.then( onSessionStarted )
 					.catch( ( err ) => {
 
-						console.log( err );
+						console.warn( err );
 
 					} );
 


### PR DESCRIPTION
A developer complained that when they put multiple buttons on the page, they get errors in the js console.
These errors are harmless failed promises from `offerSession` but they claim that people don't like to see errors in the console.
This PR will catch the failed promises and show them as console warnings

*This contribution is funded by [Meta](https://meta.com)*
