### PR TITLE
WebGPURenderer: WebGLTextureUtils - missing call to state helper

### DIFF
--- a/examples/jsm/renderers/webgl/utils/WebGLTextureUtils.js
+++ b/examples/jsm/renderers/webgl/utils/WebGLTextureUtils.js
@@ -398,7 +398,7 @@ class WebGLTextureUtils {
 		const { gl, backend } = this;
 		const { textureGPU, glTextureType } = backend.get( texture );
 
-		gl.bindTexture( glTextureType, textureGPU );
+		backend.state.bindTexture( glTextureType, textureGPU );
 		gl.generateMipmap( glTextureType );
 
 	}


### PR DESCRIPTION
As title. keep stateUtils view in sync with actual texture bindings.
