### PR TITLE
Added check for non-array and empty array inputs for GeometryUtils.mergeGeometries()

### DIFF
--- a/examples/jsm/utils/BufferGeometryUtils.js
+++ b/examples/jsm/utils/BufferGeometryUtils.js
@@ -106,6 +106,11 @@ function computeMikkTSpaceTangents( geometry, MikkTSpace, negateSign = true ) {
  */
 function mergeGeometries( geometries, useGroups = false ) {
 
+	// Ensure that we have a non-empty array. If not, make the developer aware with an informative error message
+	if (!Array.isArray(geometries) || geometries.length === 0) {
+        throw new Error('mergeGeometries() was provided an empty array or a non-array type object. The expected input is an array of Geometries.');
+    }
+
 	const isIndexed = geometries[ 0 ].index !== null;
 
 	const attributesUsed = new Set( Object.keys( geometries[ 0 ].attributes ) );


### PR DESCRIPTION
Related issue: #27509

**Description**

Earlier, the `GeometryUtils.mergeGeometries()` function would return a confusing 

> Cannot read properties of undefined (reading 'index')
TypeError: Cannot read properties of undefined (reading 'index')

message if given an empty array. This was not a bug per say, but the error could be more informative.

This PR adds a check for non-array object type input as well as if the array is empty. If either of these conditions are true, we throw an error with an informative message:

> mergeGeometries() was provided an empty array or a non-array type object. The expected input is an array of Geometries.

Suggestions in terms of wording or further checks are greatly appreciated if anyone sees potential improvements to be made. Thanks