### PR TITLE
Nodes: Some refactoring and clean up

### DIFF
--- a/examples/jsm/nodes/Nodes.js
+++ b/examples/jsm/nodes/Nodes.js
@@ -5,6 +5,9 @@
 export * from './core/constants.js';
 
 // core
+export { default as Node, addNodeClass, createNodeFromType } from './core/Node.js';
+export * from './shadernode/ShaderNode.js';
+
 export { default as ArrayUniformNode /* @TODO: arrayUniform */ } from './core/ArrayUniformNode.js';
 export { default as AssignNode, assign } from './core/AssignNode.js';
 export { default as AttributeNode, attribute } from './core/AttributeNode.js';
@@ -13,20 +16,8 @@ export { default as CacheNode, cache } from './core/CacheNode.js';
 export { default as ConstNode } from './core/ConstNode.js';
 export { default as ContextNode, context, label } from './core/ContextNode.js';
 export { default as IndexNode, vertexIndex, instanceIndex } from './core/IndexNode.js';
-export { default as LightingModel } from './core/LightingModel.js';
-export { default as Node, addNodeClass, createNodeFromType } from './core/Node.js';
 export { default as VarNode, temp } from './core/VarNode.js';
-export { default as NodeAttribute } from './core/NodeAttribute.js';
-export { default as NodeBuilder } from './core/NodeBuilder.js';
-export { default as NodeCache } from './core/NodeCache.js';
-export { default as NodeCode } from './core/NodeCode.js';
-export { default as NodeFrame } from './core/NodeFrame.js';
-export { default as NodeFunctionInput } from './core/NodeFunctionInput.js';
-export { default as NodeKeywords } from './core/NodeKeywords.js';
-export { default as NodeUniform } from './core/NodeUniform.js';
-export { default as NodeVar } from './core/NodeVar.js';
-export { default as NodeVarying } from './core/NodeVarying.js';
-export { default as PropertyNode, property, output, diffuseColor, roughness, metalness, specularColor, shininess } from './core/PropertyNode.js';
+export { default as PropertyNode, property, vertexPosition, output, position, normal, tangent, diffuseColor, roughness, metalness, specularColor, shininess } from './core/PropertyNode.js';
 export { default as StackNode, stack } from './core/StackNode.js';
 export { default as TempNode } from './core/TempNode.js';
 export { default as UniformNode, uniform } from './core/UniformNode.js';
@@ -37,10 +28,18 @@ import * as NodeUtils from './core/NodeUtils.js';
 export { NodeUtils };
 
 // math
-export { default as MathNode, EPSILON, INFINITY, radians, degrees, exp, exp2, log, log2, sqrt, inverseSqrt, floor, ceil, normalize, fract, sin, cos, tan, asin, acos, atan, abs, sign, length, negate, oneMinus, dFdx, dFdy, round, reciprocal, trunc, fwidth, atan2, min, max, mod, step, reflect, distance, difference, dot, cross, pow, pow2, pow3, pow4, transformDirection, mix, clamp, saturate, refract, smoothstep, faceForward } from './math/MathNode.js';
+export { default as MathNode, EPSILON, INFINITY, radians, degrees, exp, exp2, log, log2, sqrt, inverseSqrt, floor, ceil, normalize, fract, sin, cos, tan, asin, acos, atan, abs, sign, length, negate, oneMinus, dFdx, dFdy, round, reciprocal, trunc, fwidth, atan2, min, max, mod, step, reflect, distance, difference, dot, cross, pow, pow2, pow3, pow4, transformDirection, mix, clamp, saturate, refract, smoothstep, faceForward, mixElement, smoothstepElement } from './math/MathNode.js';
 export { default as OperatorNode, add, sub, mul, div, remainder, equal, lessThan, greaterThan, lessThanEqual, greaterThanEqual, and, or, xor, bitAnd, bitOr, bitXor, shiftLeft, shiftRight } from './math/OperatorNode.js';
 export { default as CondNode, cond } from './math/CondNode.js';
 export { default as HashNode, hash } from './math/HashNode.js';
+
+// code
+export { default as ExpressionNode, expression } from './code/ExpressionNode.js';
+export { default as CodeNode, code, js, wgsl, glsl } from './code/CodeNode.js';
+export { default as FunctionCallNode, call } from './code/FunctionCallNode.js';
+export { default as FunctionNode, nativeFn, wgslFn, glslFn } from './code/FunctionNode.js';
+export { default as ScriptableNode, scriptable, global } from './code/ScriptableNode.js';
+export { default as ScriptableValueNode, scriptableValue } from './code/ScriptableValueNode.js';
 
 // utils
 export { default as ArrayElementNode } from './utils/ArrayElementNode.js';
@@ -53,17 +52,14 @@ export { default as MatcapUVNode, matcapUV } from './utils/MatcapUVNode.js';
 export { default as MaxMipLevelNode, maxMipLevel } from './utils/MaxMipLevelNode.js';
 export { default as OscNode, oscSine, oscSquare, oscTriangle, oscSawtooth } from './utils/OscNode.js';
 export { default as PackingNode, directionToColor, colorToDirection } from './utils/PackingNode.js';
-export { default as RemapNode, remap, remapClamp } from './utils/RemapNode.js';
+export { default as RemapNode, remap, remapClamp, remapIn, remapInClamp } from './utils/RemapNode.js';
 export { default as RotateUVNode, rotateUV } from './utils/RotateUVNode.js';
 export { default as SetNode } from './utils/SetNode.js';
-export { default as SpecularMIPLevelNode, specularMIPLevel } from './utils/SpecularMIPLevelNode.js';
+export { default as SpecularMipLevelNode, specularMipLevel } from './utils/SpecularMipLevelNode.js';
 export { default as SplitNode } from './utils/SplitNode.js';
 export { default as SpriteSheetUVNode, spritesheetUV } from './utils/SpriteSheetUVNode.js';
 export { default as TimerNode, timerLocal, timerGlobal, timerDelta, frameId } from './utils/TimerNode.js';
 export { default as TriplanarTexturesNode, triplanarTextures, triplanarTexture } from './utils/TriplanarTexturesNode.js';
-
-// shadernode
-export * from './shadernode/ShaderNode.js';
 
 // accessors
 export { default as BitangentNode, bitangentGeometry, bitangentLocal, bitangentView, bitangentWorld, transformedBitangentView, transformedBitangentWorld } from './accessors/BitangentNode.js';
@@ -92,6 +88,7 @@ export { default as SceneNode, backgroundBlurriness, backgroundIntensity } from 
 export { default as StorageBufferNode, storage } from './accessors/StorageBufferNode.js';
 export { default as TangentNode, tangentGeometry, tangentLocal, tangentView, tangentWorld, transformedTangentView, transformedTangentWorld } from './accessors/TangentNode.js';
 export { default as TextureNode, texture, /*textureLevel,*/ sampler } from './accessors/TextureNode.js';
+export { default as TextureSizeNode, textureSize } from './accessors/TextureSizeNode.js';
 export { default as TextureStoreNode, textureStore } from './accessors/TextureStoreNode.js';
 export { default as UVNode, uv } from './accessors/UVNode.js';
 export { default as UserDataNode, userData } from './accessors/UserDataNode.js';
@@ -111,14 +108,6 @@ export { default as ViewportSharedTextureNode, viewportSharedTexture } from './d
 export { default as ViewportDepthTextureNode, viewportDepthTexture } from './display/ViewportDepthTextureNode.js';
 export { default as ViewportDepthNode, viewZToOrthographicDepth, orthographicDepthToViewZ, viewZToPerspectiveDepth, perspectiveDepthToViewZ, depth, depthTexture } from './display/ViewportDepthNode.js';
 
-// code
-export { default as ExpressionNode, expression } from './code/ExpressionNode.js';
-export { default as CodeNode, code, js, wgsl, glsl } from './code/CodeNode.js';
-export { default as FunctionCallNode, call } from './code/FunctionCallNode.js';
-export { default as FunctionNode, wgslFn, glslFn } from './code/FunctionNode.js';
-export { default as ScriptableNode, scriptable, global } from './code/ScriptableNode.js';
-export { default as ScriptableValueNode, scriptableValue } from './code/ScriptableValueNode.js';
-
 // fog
 export { default as FogNode, fog } from './fog/FogNode.js';
 export { default as FogRangeNode, rangeFog } from './fog/FogRangeNode.js';
@@ -131,15 +120,16 @@ export { default as RangeNode, range } from './geometry/RangeNode.js';
 export { default as ComputeNode, compute } from './gpgpu/ComputeNode.js';
 
 // lighting
+export { default as LightingModel } from './core/LightingModel.js';
 export { default as LightNode, lightTargetDirection } from './lighting/LightNode.js';
+export { default as LightsNode, lights, lightsWithoutWrap, addLightNode } from './lighting/LightsNode.js';
+export { default as LightingNode /* @TODO: lighting (abstract), light */ } from './lighting/LightingNode.js';
+export { default as LightingContextNode, lightingContext } from './lighting/LightingContextNode.js';
 export { default as PointLightNode } from './lighting/PointLightNode.js';
 export { default as DirectionalLightNode } from './lighting/DirectionalLightNode.js';
 export { default as SpotLightNode } from './lighting/SpotLightNode.js';
 export { default as IESSpotLightNode } from './lighting/IESSpotLightNode.js';
 export { default as AmbientLightNode } from './lighting/AmbientLightNode.js';
-export { default as LightsNode, lights, lightsWithoutWrap, addLightNode } from './lighting/LightsNode.js';
-export { default as LightingNode /* @TODO: lighting (abstract), light */ } from './lighting/LightingNode.js';
-export { default as LightingContextNode, lightingContext } from './lighting/LightingContextNode.js';
 export { default as HemisphereLightNode } from './lighting/HemisphereLightNode.js';
 export { default as EnvironmentNode } from './lighting/EnvironmentNode.js';
 export { default as AONode } from './lighting/AONode.js';
@@ -152,9 +142,6 @@ export { default as CheckerNode, checker } from './procedural/CheckerNode.js';
 export { default as NodeLoader } from './loaders/NodeLoader.js';
 export { default as NodeObjectLoader } from './loaders/NodeObjectLoader.js';
 export { default as NodeMaterialLoader } from './loaders/NodeMaterialLoader.js';
-
-// parsers
-export { default as GLSLNodeParser } from './parsers/GLSLNodeParser.js'; // @TODO: Move to jsm/renderers/webgl.
 
 // materials
 export * from './materials/Materials.js';
@@ -178,3 +165,18 @@ export { default as getRoughness } from './functions/material/getRoughness.js';
 
 export { default as PhongLightingModel } from './functions/PhongLightingModel.js';
 export { default as PhysicalLightingModel } from './functions/PhysicalLightingModel.js';
+
+// node builder
+export { default as NodeBuilder } from './core/NodeBuilder.js';
+export { default as NodeAttribute } from './core/NodeAttribute.js';
+export { default as NodeCache } from './core/NodeCache.js';
+export { default as NodeCode } from './core/NodeCode.js';
+export { default as NodeFrame } from './core/NodeFrame.js';
+export { default as NodeFunction } from './core/NodeFunction.js';
+export { default as NodeFunctionInput } from './core/NodeFunctionInput.js';
+export { default as NodeKeywords } from './core/NodeKeywords.js';
+export { default as NodeParser } from './core/NodeParser.js';
+export { default as NodeUniform } from './core/NodeUniform.js';
+export { default as NodeVar } from './core/NodeVar.js';
+export { default as NodeVarying } from './core/NodeVarying.js';
+export { default as GLSLNodeParser } from './parsers/GLSLNodeParser.js'; // @TODO: Move to jsm/renderers/webgl.

--- a/examples/jsm/nodes/accessors/BitangentNode.js
+++ b/examples/jsm/nodes/accessors/BitangentNode.js
@@ -1,12 +1,10 @@
-import Node, { addNodeClass } from '../core/Node.js';
-import { varying } from '../core/VaryingNode.js';
-import { normalize } from '../math/MathNode.js';
-import { cameraViewMatrix } from './CameraNode.js';
-import { normalGeometry, normalLocal, normalView, normalWorld, transformedNormalView } from './NormalNode.js';
-import { tangentGeometry, tangentLocal, tangentView, tangentWorld, transformedTangentView } from './TangentNode.js';
+import TempNode from '../core/TempNode.js';
+import { addNodeClass } from '../core/Node.js';
+import { normalGeometry, normalLocal, normalView, normalWorld, transformedNormalView, transformedNormalWorld } from './NormalNode.js';
+import { tangentGeometry, tangentLocal, tangentView, tangentWorld, transformedTangentView, transformedTangentWorld } from './TangentNode.js';
 import { nodeImmutable } from '../shadernode/ShaderNode.js';
 
-class BitangentNode extends Node {
+class BitangentNode extends TempNode {
 
 	constructor( scope = BitangentNode.LOCAL ) {
 
@@ -22,7 +20,7 @@ class BitangentNode extends Node {
 
 	}
 
-	generate( builder ) {
+	setup( /*builder*/ ) {
 
 		const scope = this.scope;
 
@@ -44,13 +42,19 @@ class BitangentNode extends Node {
 
 			crossNormalTangent = normalWorld.cross( tangentWorld );
 
+		} else if ( scope === BitangentNode.TRANSFORMED_VIEW ) {
+
+			crossNormalTangent = transformedNormalView.cross( transformedTangentView );
+
+		} else if ( scope === BitangentNode.TRANSFORMED_WORLD ) {
+
+			crossNormalTangent = transformedNormalWorld.cross( transformedTangentWorld );
+
 		}
 
 		const vertexNode = crossNormalTangent.mul( tangentGeometry.w ).xyz;
 
-		const outputNode = normalize( varying( vertexNode ) );
-
-		return outputNode.build( builder, this.getNodeType( builder ) );
+		return vertexNode.varying().normalize();
 
 	}
 
@@ -76,6 +80,8 @@ BitangentNode.GEOMETRY = 'geometry';
 BitangentNode.LOCAL = 'local';
 BitangentNode.VIEW = 'view';
 BitangentNode.WORLD = 'world';
+BitangentNode.TRANSFORMED_VIEW = 'transformedView';
+BitangentNode.TRANSFORMED_WORLD = 'transformedWorld';
 
 export default BitangentNode;
 
@@ -83,7 +89,7 @@ export const bitangentGeometry = nodeImmutable( BitangentNode, BitangentNode.GEO
 export const bitangentLocal = nodeImmutable( BitangentNode, BitangentNode.LOCAL );
 export const bitangentView = nodeImmutable( BitangentNode, BitangentNode.VIEW );
 export const bitangentWorld = nodeImmutable( BitangentNode, BitangentNode.WORLD );
-export const transformedBitangentView = normalize( transformedNormalView.cross( transformedTangentView ).mul( tangentGeometry.w ) );
-export const transformedBitangentWorld = normalize( transformedBitangentView.transformDirection( cameraViewMatrix ) );
+export const transformedBitangentView = nodeImmutable( BitangentNode, BitangentNode.TRANSFORMED_VIEW );
+export const transformedBitangentWorld = nodeImmutable( BitangentNode, BitangentNode.TRANSFORMED_WORLD );
 
 addNodeClass( 'BitangentNode', BitangentNode );

--- a/examples/jsm/nodes/accessors/BufferAttributeNode.js
+++ b/examples/jsm/nodes/accessors/BufferAttributeNode.js
@@ -1,6 +1,5 @@
 import InputNode from '../core/InputNode.js';
 import { addNodeClass } from '../core/Node.js';
-import { varying } from '../core/VaryingNode.js';
 import { nodeObject, addNodeElement } from '../shadernode/ShaderNode.js';
 import { InterleavedBufferAttribute, InterleavedBuffer, StaticDrawUsage, DynamicDrawUsage } from 'three';
 
@@ -61,30 +60,18 @@ class BufferAttributeNode extends InputNode {
 		this.attribute = bufferAttribute;
 		this.attribute.isInstancedBufferAttribute = this.instanced; // @TODO: Add a possible: InstancedInterleavedBufferAttribute
 
+		if ( builder.getShaderStage() !== 'vertex' ) return this.varying();
+
 	}
 
 	generate( builder ) {
 
-		const nodeType = this.getNodeType( builder );
+		if ( builder.getShaderStage() !== 'vertex' ) return super.generate( builder );
 
-		const nodeUniform = builder.getBufferAttributeFromNode( this, nodeType );
+		const nodeUniform = builder.getBufferAttributeFromNode( this );
 		const propertyName = builder.getPropertyName( nodeUniform );
 
-		let output = null;
-
-		if ( builder.shaderStage === 'vertex' ) {
-
-			output = propertyName;
-
-		} else {
-
-			const nodeVarying = varying( this );
-
-			output = nodeVarying.build( builder, nodeType );
-
-		}
-
-		return output;
+		return propertyName;
 
 	}
 

--- a/examples/jsm/nodes/accessors/BufferNode.js
+++ b/examples/jsm/nodes/accessors/BufferNode.js
@@ -21,6 +21,12 @@ class BufferNode extends UniformNode {
 
 	}
 
+	getNodeType() {
+
+		return `${ this.bufferType }[ ${ this.bufferCount } ]`;
+
+	}
+
 }
 
 export default BufferNode;

--- a/examples/jsm/nodes/accessors/CameraNode.js
+++ b/examples/jsm/nodes/accessors/CameraNode.js
@@ -1,6 +1,5 @@
 import Object3DNode from './Object3DNode.js';
 import { addNodeClass } from '../core/Node.js';
-import { label } from '../core/ContextNode.js';
 import { nodeImmutable } from '../shadernode/ShaderNode.js';
 
 class CameraNode extends Object3DNode {
@@ -61,7 +60,7 @@ class CameraNode extends Object3DNode {
 
 	}
 
-	generate( builder ) {
+	setup() {
 
 		const scope = this.scope;
 
@@ -75,7 +74,7 @@ class CameraNode extends Object3DNode {
 
 		}
 
-		return super.generate( builder );
+		return super.setup();
 
 	}
 
@@ -87,7 +86,7 @@ CameraNode.FAR = 'far';
 
 export default CameraNode;
 
-export const cameraProjectionMatrix = label( nodeImmutable( CameraNode, CameraNode.PROJECTION_MATRIX ), 'projectionMatrix' );
+export const cameraProjectionMatrix = nodeImmutable( CameraNode, CameraNode.PROJECTION_MATRIX ).label( 'projectionMatrix' );
 export const cameraNear = nodeImmutable( CameraNode, CameraNode.NEAR );
 export const cameraFar = nodeImmutable( CameraNode, CameraNode.FAR );
 export const cameraViewMatrix = nodeImmutable( CameraNode, CameraNode.VIEW_MATRIX );

--- a/examples/jsm/nodes/accessors/CubeTextureNode.js
+++ b/examples/jsm/nodes/accessors/CubeTextureNode.js
@@ -1,9 +1,6 @@
 import TextureNode from './TextureNode.js';
-import UniformNode from '../core/UniformNode.js';
 import { reflectVector } from './ReflectVectorNode.js';
 import { addNodeClass } from '../core/Node.js';
-import { colorSpaceToLinear } from '../display/ColorSpaceNode.js';
-import { expression } from '../code/ExpressionNode.js';
 import { addNodeElement, nodeProxy, vec3 } from '../shadernode/ShaderNode.js';
 
 class CubeTextureNode extends TextureNode {
@@ -16,12 +13,6 @@ class CubeTextureNode extends TextureNode {
 
 	}
 
-	getInputType( /*builder*/ ) {
-
-		return 'cubeTexture';
-
-	}
-
 	getDefaultUV() {
 
 		return reflectVector;
@@ -30,80 +21,24 @@ class CubeTextureNode extends TextureNode {
 
 	setUpdateMatrix( /*updateMatrix*/ ) { } // Ignore .updateMatrix for CubeTextureNode
 
+	setup( builder ) {
+
+		super.setup( builder );
+
+		const properties = builder.getNodeProperties( this );
+		properties.uvNode = vec3( properties.uvNode.x.negate(), properties.uvNode.yz );
+
+	}
+
 	generate( builder, output ) {
 
-		const { uvNode, levelNode } = builder.getNodeProperties( this );
-
-		const texture = this.value;
-
-		if ( ! texture || texture.isCubeTexture !== true ) {
+		if ( ! this.texture.value || this.texture.value.isCubeTexture !== true ) {
 
 			throw new Error( 'CubeTextureNode: Need a three.js cube texture.' );
 
 		}
 
-		const textureProperty = UniformNode.prototype.generate.call( this, builder, 'cubeTexture' );
-
-		if ( output === 'sampler' ) {
-
-			return textureProperty + '_sampler';
-
-		} else if ( builder.isReference( output ) ) {
-
-			return textureProperty;
-
-		} else {
-
-			const nodeData = builder.getDataFromNode( this );
-
-			let propertyName = nodeData.propertyName;
-
-			if ( propertyName === undefined ) {
-
-				const cubeUV = vec3( uvNode.x.negate(), uvNode.yz );
-				const uvSnippet = cubeUV.build( builder, 'vec3' );
-
-				const nodeVar = builder.getVarFromNode( this );
-
-				propertyName = builder.getPropertyName( nodeVar );
-
-				let snippet = null;
-
-				if ( levelNode && levelNode.isNode === true ) {
-
-					const levelSnippet = levelNode.build( builder, 'float' );
-
-					snippet = builder.getTextureLevel( this, textureProperty, uvSnippet, levelSnippet );
-
-				} else {
-
-					snippet = builder.getTexture( this, textureProperty, uvSnippet );
-
-				}
-
-				builder.addLineFlowCode( `${propertyName} = ${snippet}` );
-
-				if ( builder.context.tempWrite !== false ) {
-
-					nodeData.snippet = snippet;
-					nodeData.propertyName = propertyName;
-
-				}
-
-			}
-
-			let snippet = propertyName;
-			const nodeType = this.getNodeType( builder );
-
-			if ( builder.needsColorSpaceToLinear( this.value ) ) {
-
-				snippet = colorSpaceToLinear( expression( snippet, nodeType ), this.value.colorSpace ).setup( builder ).build( builder, nodeType );
-
-			}
-
-			return builder.format( snippet, nodeType, output );
-
-		}
+		return super.generate( builder, output );
 
 	}
 

--- a/examples/jsm/nodes/accessors/MaterialNode.js
+++ b/examples/jsm/nodes/accessors/MaterialNode.js
@@ -1,11 +1,12 @@
-import Node, { addNodeClass } from '../core/Node.js';
+import TempNode from '../core/TempNode.js';
+import { addNodeClass } from '../core/Node.js';
 import { reference } from './ReferenceNode.js';
 import { materialReference } from './MaterialReferenceNode.js';
 import { nodeImmutable, float } from '../shadernode/ShaderNode.js';
 
 const _propertyCache = new Map();
 
-class MaterialNode extends Node {
+class MaterialNode extends TempNode {
 
 	constructor( scope ) {
 

--- a/examples/jsm/nodes/accessors/MaterialReferenceNode.js
+++ b/examples/jsm/nodes/accessors/MaterialReferenceNode.js
@@ -27,7 +27,7 @@ class MaterialReferenceNode extends ReferenceNode {
 
 		const material = this.material !== null ? this.material : builder.material;
 
-		this.node.value = material[ this.property ];
+		if ( material[ this.property ] !== undefined && material[ this.property ] !== null ) this.node.value = material[ this.property ];
 
 		return super.setup( builder );
 

--- a/examples/jsm/nodes/accessors/ModelNode.js
+++ b/examples/jsm/nodes/accessors/ModelNode.js
@@ -23,7 +23,7 @@ class ModelNode extends Object3DNode {
 export default ModelNode;
 
 export const modelDirection = nodeImmutable( ModelNode, ModelNode.DIRECTION );
-export const modelViewMatrix = nodeImmutable( ModelNode, ModelNode.VIEW_MATRIX ).temp( 'ModelViewMatrix' );
+export const modelViewMatrix = nodeImmutable( ModelNode, ModelNode.VIEW_MATRIX ).label( 'ModelViewMatrix' );
 export const modelNormalMatrix = nodeImmutable( ModelNode, ModelNode.NORMAL_MATRIX );
 export const modelWorldMatrix = nodeImmutable( ModelNode, ModelNode.WORLD_MATRIX );
 export const modelPosition = nodeImmutable( ModelNode, ModelNode.POSITION );

--- a/examples/jsm/nodes/accessors/ModelViewProjectionNode.js
+++ b/examples/jsm/nodes/accessors/ModelViewProjectionNode.js
@@ -1,13 +1,14 @@
-import { addNodeClass } from '../core/Node.js';
 import TempNode from '../core/TempNode.js';
+import { addNodeClass } from '../core/Node.js';
 import { cameraProjectionMatrix } from './CameraNode.js';
 import { modelViewMatrix } from './ModelNode.js';
-import { positionLocal } from './PositionNode.js';
+import { position } from '../core/PropertyNode.js';
+import { positionView } from './PositionNode.js';
 import { nodeProxy } from '../shadernode/ShaderNode.js';
 
 class ModelViewProjectionNode extends TempNode {
 
-	constructor( positionNode = positionLocal ) {
+	constructor( positionNode = position ) {
 
 		super( 'vec4' );
 
@@ -17,7 +18,11 @@ class ModelViewProjectionNode extends TempNode {
 
 	setup() {
 
-		return cameraProjectionMatrix.mul( modelViewMatrix ).mul( this.positionNode );
+		let view = modelViewMatrix.mul( this.positionNode );
+
+		if ( this.positionNode === position ) view = positionView; // caching
+
+		return cameraProjectionMatrix.mul( view );
 
 	}
 

--- a/examples/jsm/nodes/accessors/MorphNode.js
+++ b/examples/jsm/nodes/accessors/MorphNode.js
@@ -4,7 +4,7 @@ import { nodeProxy } from '../shadernode/ShaderNode.js';
 import { uniform } from '../core/UniformNode.js';
 import { reference } from './ReferenceNode.js';
 import { bufferAttribute } from './BufferAttributeNode.js';
-import { positionLocal } from './PositionNode.js';
+import { position } from '../core/PropertyNode.js';
 
 class MorphNode extends Node {
 
@@ -19,7 +19,7 @@ class MorphNode extends Node {
 
 	}
 
-	setupAttribute( name, assignNode = positionLocal ) {
+	setupAttribute( name, assignNode = position ) {
 
 		const mesh = this.mesh;
 		const attributes = mesh.geometry.morphAttributes[ name ];

--- a/examples/jsm/nodes/accessors/Object3DNode.js
+++ b/examples/jsm/nodes/accessors/Object3DNode.js
@@ -1,11 +1,12 @@
-import Node, { addNodeClass } from '../core/Node.js';
+import TempNode from '../core/TempNode.js';
+import { addNodeClass } from '../core/Node.js';
 import { NodeUpdateType } from '../core/constants.js';
 import UniformNode from '../core/UniformNode.js';
 import { nodeProxy } from '../shadernode/ShaderNode.js';
 
 import { Vector3 } from 'three';
 
-class Object3DNode extends Node {
+class Object3DNode extends TempNode {
 
 	constructor( scope = Object3DNode.VIEW_MATRIX, object3d = null ) {
 
@@ -89,7 +90,7 @@ class Object3DNode extends Node {
 
 	}
 
-	generate( builder ) {
+	setup() {
 
 		const scope = this.scope;
 
@@ -107,7 +108,7 @@ class Object3DNode extends Node {
 
 		}
 
-		return this._uniformNode.build( builder );
+		return this._uniformNode;
 
 	}
 

--- a/examples/jsm/nodes/accessors/PointUVNode.js
+++ b/examples/jsm/nodes/accessors/PointUVNode.js
@@ -1,7 +1,8 @@
-import Node, { addNodeClass } from '../core/Node.js';
+import TempNode from '../core/TempNode.js';
+import { addNodeClass } from '../core/Node.js';
 import { nodeImmutable } from '../shadernode/ShaderNode.js';
 
-class PointUVNode extends Node {
+class PointUVNode extends TempNode {
 
 	constructor() {
 
@@ -11,7 +12,9 @@ class PointUVNode extends Node {
 
 	}
 
-	generate( /*builder*/ ) {
+	generate( builder ) {
+
+		if ( builder.isGLSLNodeBuilder !== true ) throw new Error( 'PointUVNode can only be used in WebGL' );
 
 		return 'vec2( gl_PointCoord.x, 1.0 - gl_PointCoord.y )';
 

--- a/examples/jsm/nodes/accessors/ReferenceNode.js
+++ b/examples/jsm/nodes/accessors/ReferenceNode.js
@@ -1,10 +1,11 @@
-import Node, { addNodeClass } from '../core/Node.js';
+import TempNode from '../core/TempNode.js';
+import { addNodeClass } from '../core/Node.js';
 import { NodeUpdateType } from '../core/constants.js';
 import { uniform } from '../core/UniformNode.js';
 import { texture } from './TextureNode.js';
 import { nodeObject } from '../shadernode/ShaderNode.js';
 
-class ReferenceNode extends Node {
+class ReferenceNode extends TempNode {
 
 	constructor( property, uniformType, object = null ) {
 
@@ -59,7 +60,7 @@ class ReferenceNode extends Node {
 
 	update( /*frame*/ ) {
 
-		this.node.value = this.reference[ this.property ];
+		if ( this.reference[ this.property ] !== undefined && this.reference[ this.property ] !== null ) this.node.value = this.reference[ this.property ];
 
 	}
 

--- a/examples/jsm/nodes/accessors/ReflectVectorNode.js
+++ b/examples/jsm/nodes/accessors/ReflectVectorNode.js
@@ -1,10 +1,11 @@
-import Node, { addNodeClass } from '../core/Node.js';
+import TempNode from '../core/TempNode.js';
+import { addNodeClass } from '../core/Node.js';
 import { cameraViewMatrix } from './CameraNode.js';
 import { transformedNormalView } from './NormalNode.js';
 import { positionViewDirection } from './PositionNode.js';
 import { nodeImmutable } from '../shadernode/ShaderNode.js';
 
-class ReflectVectorNode extends Node {
+class ReflectVectorNode extends TempNode {
 
 	constructor() {
 

--- a/examples/jsm/nodes/accessors/SceneNode.js
+++ b/examples/jsm/nodes/accessors/SceneNode.js
@@ -1,5 +1,4 @@
-import Node from '../core/Node.js';
-import { addNodeClass } from '../core/Node.js';
+import Node, { addNodeClass } from '../core/Node.js';
 import { nodeImmutable } from '../shadernode/ShaderNode.js';
 import { reference } from './ReferenceNode.js';
 

--- a/examples/jsm/nodes/accessors/TextureSizeNode.js
+++ b/examples/jsm/nodes/accessors/TextureSizeNode.js
@@ -1,8 +1,8 @@
-import Node from '../core/Node.js';
+import TempNode from '../core/TempNode.js';
 import { addNodeClass } from '../core/Node.js';
 import { addNodeElement, nodeProxy } from '../shadernode/ShaderNode.js';
 
-class TextureSizeNode extends Node {
+class TextureSizeNode extends TempNode {
 
 	constructor( textureNode, levelNode = null ) {
 
@@ -17,10 +17,10 @@ class TextureSizeNode extends Node {
 
 	generate( builder, output ) {
 
-		const textureProperty = this.textureNode.build( builder, 'property' );
+		const textureProperty = this.textureNode.texture.build( builder );
 		const levelNode = this.levelNode.build( builder, 'int' );
 
-		return builder.format( `${builder.getMethod( 'textureDimensions' )}( ${textureProperty}, ${levelNode} )`, this.getNodeType( builder ), output );
+		return builder.format( builder.formatOperation( '()', builder.getMethod( 'textureDimensions' ), [ textureProperty, levelNode ] ), this.getNodeType( builder ), output );
 
 	}
 

--- a/examples/jsm/nodes/accessors/TextureStoreNode.js
+++ b/examples/jsm/nodes/accessors/TextureStoreNode.js
@@ -4,13 +4,13 @@ import { nodeProxy } from '../shadernode/ShaderNode.js';
 
 class TextureStoreNode extends TextureNode {
 
-	constructor( value, uvNode, storeNode = null ) {
+	constructor( value, uvNode/*, storeNode = null*/ ) {
 
 		super( value, uvNode );
 
-		this.storeNode = storeNode;
+		//this.storeNode = storeNode;
 
-		this.isStoreTextureNode = true;
+		this.texture.isStoreTextureNode = true;
 
 	}
 

--- a/examples/jsm/nodes/code/CodeNode.js
+++ b/examples/jsm/nodes/code/CodeNode.js
@@ -40,7 +40,7 @@ class CodeNode extends Node {
 
 		}
 
-		const nodeCode = builder.getCodeFromNode( this, this.getNodeType( builder ) );
+		const nodeCode = builder.getCodeFromNode( this );
 		nodeCode.code = this.code;
 
 		return nodeCode.code;

--- a/examples/jsm/nodes/code/ExpressionNode.js
+++ b/examples/jsm/nodes/code/ExpressionNode.js
@@ -22,7 +22,7 @@ class ExpressionNode extends Node {
 
 		} else {
 
-			return builder.format( `( ${ snippet } )`, type, output );
+			return builder.format( snippet, type, output );
 
 		}
 

--- a/examples/jsm/nodes/code/FunctionCallNode.js
+++ b/examples/jsm/nodes/code/FunctionCallNode.js
@@ -75,7 +75,7 @@ class FunctionCallNode extends TempNode {
 
 		const functionName = functionNode.build( builder, 'property' );
 
-		return `${functionName}( ${params.join( ', ' )} )`;
+		return builder.formatOperation( '()', functionName, params.join( ', ' ) );
 
 	}
 

--- a/examples/jsm/nodes/code/FunctionNode.js
+++ b/examples/jsm/nodes/code/FunctionNode.js
@@ -10,6 +10,14 @@ class FunctionNode extends CodeNode {
 
 		this.keywords = {};
 
+		this._shaderNode = null;
+
+	}
+
+	isGlobal() {
+
+		return true;
+
 	}
 
 	getNodeType( builder ) {
@@ -26,7 +34,7 @@ class FunctionNode extends CodeNode {
 
 	getNodeFunction( builder ) {
 
-		const nodeData = builder.getDataFromNode( this );
+		const nodeData = builder.getNodeData( this );
 
 		let nodeFunction = nodeData.nodeFunction;
 
@@ -39,6 +47,22 @@ class FunctionNode extends CodeNode {
 		}
 
 		return nodeFunction;
+
+	}
+
+	setup( builder ) {
+
+		super.setup( builder );
+
+		if ( this._shaderNode !== null ) this._shaderNode.build( builder );
+
+	}
+
+	analyze( builder ) {
+
+		super.analyze( builder );
+
+		if ( this._shaderNode !== null ) this._shaderNode.build( builder );
 
 	}
 
@@ -63,7 +87,7 @@ class FunctionNode extends CodeNode {
 
 		const propertyName = builder.getPropertyName( nodeCode );
 
-		let code = this.getNodeFunction( builder ).getCode( propertyName );
+		let code = nodeFunction.getCode( propertyName );
 
 		const keywords = this.keywords;
 		const keywordsProperties = Object.keys( keywords );
@@ -99,7 +123,7 @@ class FunctionNode extends CodeNode {
 
 export default FunctionNode;
 
-const nativeFn = ( code, includes = [], language = '' ) => {
+export const nativeFn = ( code, includes = [], language = '' ) => {
 
 	for ( let i = 0; i < includes.length; i ++ ) {
 

--- a/examples/jsm/nodes/code/ScriptableNode.js
+++ b/examples/jsm/nodes/code/ScriptableNode.js
@@ -431,7 +431,9 @@ class ScriptableNode extends Node {
 
 	}
 
-	setup() {
+	setup( builder ) {
+
+		super.setup( builder );
 
 		return this.getDefaultOutputNode();
 

--- a/examples/jsm/nodes/code/ScriptableValueNode.js
+++ b/examples/jsm/nodes/code/ScriptableValueNode.js
@@ -1,9 +1,10 @@
-import Node, { addNodeClass } from '../core/Node.js';
+import TempNode from '../core/TempNode.js';
+import { addNodeClass } from '../core/Node.js';
 import { arrayBufferToBase64, base64ToArrayBuffer } from '../core/NodeUtils.js';
 import { addNodeElement, nodeProxy, float } from '../shadernode/ShaderNode.js';
 import { EventDispatcher } from 'three';
 
-class ScriptableValueNode extends Node {
+class ScriptableValueNode extends TempNode {
 
 	constructor( value = null ) {
 
@@ -13,7 +14,7 @@ class ScriptableValueNode extends Node {
 		this._cache = null;
 
 		this.inputType = null;
-		this.outpuType = null;
+		this.outputType = null;
 
 		this.events = new EventDispatcher();
 

--- a/examples/jsm/nodes/core/AttributeNode.js
+++ b/examples/jsm/nodes/core/AttributeNode.js
@@ -1,14 +1,20 @@
-import Node, { addNodeClass } from './Node.js';
-import { varying } from './VaryingNode.js';
+import TempNode from './TempNode.js';
+import { addNodeClass } from './Node.js';
 import { nodeObject } from '../shadernode/ShaderNode.js';
 
-class AttributeNode extends Node {
+class AttributeNode extends TempNode {
 
 	constructor( attributeName, nodeType = null ) {
 
 		super( nodeType );
 
 		this._attributeName = attributeName;
+
+	}
+
+	isGlobal() {
+
+		return true;
 
 	}
 
@@ -20,7 +26,7 @@ class AttributeNode extends Node {
 
 	getNodeType( builder ) {
 
-		let nodeType = super.getNodeType( builder );
+		let nodeType = this.nodeType;
 
 		if ( nodeType === null ) {
 
@@ -58,6 +64,16 @@ class AttributeNode extends Node {
 
 	}
 
+	setup( builder ) {
+
+		if ( builder.hasGeometryAttribute( this.getAttributeName( builder ) ) && builder.getShaderStage() !== 'vertex' ) {
+
+			return this.varying();
+
+		}
+
+	}
+
 	generate( builder ) {
 
 		const attributeName = this.getAttributeName( builder );
@@ -71,15 +87,13 @@ class AttributeNode extends Node {
 
 			const nodeAttribute = builder.getAttribute( attributeName, attributeType );
 
-			if ( builder.shaderStage === 'vertex' ) {
+			if ( builder.getShaderStage() === 'vertex' ) {
 
 				return builder.format( nodeAttribute.name, attributeType, nodeType );
 
 			} else {
 
-				const nodeVarying = varying( this );
-
-				return nodeVarying.build( builder, nodeType );
+				return super.generate( builder );
 
 			}
 

--- a/examples/jsm/nodes/core/CacheNode.js
+++ b/examples/jsm/nodes/core/CacheNode.js
@@ -11,7 +11,9 @@ class CacheNode extends Node {
 		this.isCacheNode = true;
 
 		this.node = node;
+
 		this.cache = cache;
+		this.caches = new Map();
 
 	}
 
@@ -21,13 +23,27 @@ class CacheNode extends Node {
 
 	}
 
+	// @TODO: solve two major caching problems of interaction of CacheNode (or specifically CondNode) with .analyze():
+	// 1) don't increase dependency count of child nodes if they are placed in a cache (so that nodes wouldn't auto-temp when not required)
+	// 2) do increase dependency count of child nodes if they present in both CondNode's branches and allow generating them *outside* of it
+
+	_build( builder, ...params ) { // @TODO: similar structures occur in multiple nodes, maybe such a function could be moved to Node class?
+
+		if ( builder.getBuildStage() === 'setup' ) super.build( builder, ...params );
+		if ( builder.getBuildStage() === 'analyze' ) return super.build( builder, ...params );
+
+		return this.node.build( builder, ...params );
+
+	}
+
 	build( builder, ...params ) {
 
 		const previousCache = builder.getCache();
 
-		builder.setCache( this.cache );
+		if ( ! this.caches.has( previousCache ) ) this.caches.set( previousCache, this.cache.merge( previousCache ) );
+		builder.setCache( this.caches.get( previousCache ) );
 
-		const data = this.node.build( builder, ...params );
+		const data = this._build( builder, ...params );
 
 		builder.setCache( previousCache );
 
@@ -39,7 +55,7 @@ class CacheNode extends Node {
 
 export default CacheNode;
 
-export const cache = nodeProxy( CacheNode );
+export const cache = nodeProxy( CacheNode ); // @TODO: rename this to `isolate`?
 
 addNodeElement( 'cache', cache );
 

--- a/examples/jsm/nodes/core/ContextNode.js
+++ b/examples/jsm/nodes/core/ContextNode.js
@@ -1,16 +1,17 @@
-import Node, { addNodeClass } from './Node.js';
+import TempNode from './TempNode.js';
+import { addNodeClass } from './Node.js';
 import { addNodeElement, nodeProxy } from '../shadernode/ShaderNode.js';
 
-class ContextNode extends Node {
+class ContextNode extends TempNode {
 
-	constructor( node, context = {} ) {
+	constructor( node, context = {}, isolate = true ) {
 
 		super();
 
 		this.isContextNode = true;
 
-		this.node = node;
-		this.context = context;
+		this.node = isolate === true ? node.cache() : node;
+		this._context = context;
 
 	}
 
@@ -24,7 +25,9 @@ class ContextNode extends Node {
 
 		const previousContext = builder.getContext();
 
-		builder.setContext( { ...builder.context, ...this.context } );
+		builder.setContext( { ...builder.context, ...this._context } );
+
+		super.setup( builder );
 
 		const node = this.node.build( builder );
 
@@ -38,7 +41,7 @@ class ContextNode extends Node {
 
 		const previousContext = builder.getContext();
 
-		builder.setContext( { ...builder.context, ...this.context } );
+		builder.setContext( { ...builder.context, ...this._context } );
 
 		const snippet = this.node.build( builder, output );
 
@@ -53,7 +56,7 @@ class ContextNode extends Node {
 export default ContextNode;
 
 export const context = nodeProxy( ContextNode );
-export const label = ( node, name ) => context( node, { label: name } );
+export const label = ( node, name ) => context( node, { label: name }, false );
 
 addNodeElement( 'context', context );
 addNodeElement( 'label', label );

--- a/examples/jsm/nodes/core/IndexNode.js
+++ b/examples/jsm/nodes/core/IndexNode.js
@@ -1,8 +1,8 @@
-import Node, { addNodeClass } from './Node.js';
-import { varying } from './VaryingNode.js';
+import TempNode from '../core/TempNode.js';
+import { addNodeClass } from '../core/Node.js';
 import { nodeImmutable } from '../shadernode/ShaderNode.js';
 
-class IndexNode extends Node {
+class IndexNode extends TempNode {
 
 	constructor( scope ) {
 
@@ -14,9 +14,16 @@ class IndexNode extends Node {
 
 	}
 
+	setup( builder ) {
+
+		if ( builder.getShaderStage() !== 'vertex' && builder.getShaderStage() !== 'compute' ) return this.varying();
+
+	}
+
 	generate( builder ) {
 
-		const nodeType = this.getNodeType( builder );
+		if ( builder.getShaderStage() !== 'vertex' && builder.getShaderStage() !== 'compute' ) return super.generate( builder );
+
 		const scope = this.scope;
 
 		let propertyName;
@@ -35,21 +42,7 @@ class IndexNode extends Node {
 
 		}
 
-		let output;
-
-		if ( builder.shaderStage === 'vertex' || builder.shaderStage === 'compute' ) {
-
-			output = propertyName;
-
-		} else {
-
-			const nodeVarying = varying( this );
-
-			output = nodeVarying.build( builder, nodeType );
-
-		}
-
-		return output;
+		return propertyName;
 
 	}
 

--- a/examples/jsm/nodes/core/NodeCache.js
+++ b/examples/jsm/nodes/core/NodeCache.js
@@ -2,22 +2,59 @@ let id = 0;
 
 class NodeCache {
 
-	constructor() {
+	constructor( builder ) {
 
 		this.id = id ++;
-		this.nodesData = new WeakMap();
+		this.nodesData = new Map();
+		this.builder = builder;
 
 	}
 
 	getNodeData( node ) {
 
-		return this.nodesData.get( node );
+		let data = this.nodesData.get( node.getHash( this.builder ) );
+
+		if ( data === undefined ) {
+
+			data = {};
+			this.nodesData.set( node.getHash( this.builder ), data );
+
+		}
+
+		return data;
 
 	}
 
 	setNodeData( node, data ) {
 
-		this.nodesData.set( node, data );
+		this.nodesData.set( node.getHash( this.builder ), data );
+
+	}
+
+	merge( cache ) { // @TODO: a simpler way for this would be to just have two caches (global and local; look-ups first happen in first and then in second), the second one of which could be changed while the first one couldn't. but this would prevent creating nested caches
+
+		const newCache = new NodeCache();
+
+		newCache.builder = this.builder || cache.builder;
+
+		newCache.nodesData = new Map( [ ...this.nodesData, ...cache.nodesData ] );
+
+		for ( let [ key, value ] of newCache.nodesData ) {
+
+			value = { ...value };
+
+			for ( const shaderStage of Object.keys( value ) ) {
+
+				value[ shaderStage ] = { ...value[ shaderStage ] };
+				if ( value[ shaderStage ].properties ) value[ shaderStage ].properties = { ...value[ shaderStage ].properties };
+
+			}
+
+			newCache.nodesData.set( key, value );
+
+		}
+
+		return newCache;
 
 	}
 

--- a/examples/jsm/nodes/core/NodeFunction.js
+++ b/examples/jsm/nodes/core/NodeFunction.js
@@ -1,11 +1,11 @@
 class NodeFunction {
 
-	constructor( type, inputs, name = '', presicion = '' ) {
+	constructor( type, inputs, name = '', precision = '' ) {
 
 		this.type = type;
 		this.inputs = inputs;
 		this.name = name;
-		this.presicion = presicion;
+		this.precision = precision;
 
 	}
 

--- a/examples/jsm/nodes/core/NodeUtils.js
+++ b/examples/jsm/nodes/core/NodeUtils.js
@@ -6,7 +6,7 @@ export function getCacheKey( object ) {
 
 	if ( object.isNode === true ) {
 
-		cacheKey += `uuid:"${ object.uuid }"`;
+		cacheKey += `hash:"${ object.getHash() }"`;
 
 	}
 

--- a/examples/jsm/nodes/core/OutputStructNode.js
+++ b/examples/jsm/nodes/core/OutputStructNode.js
@@ -1,8 +1,11 @@
-import Node, { addNodeClass } from './Node.js';
+import TempNode from './TempNode.js';
+import { addNodeClass } from './Node.js';
 import StructTypeNode from './StructTypeNode.js';
 import { nodeProxy } from '../shadernode/ShaderNode.js';
 
-class OutputStructNode extends Node {
+// @TODO: clean up structs-related code (rename StructTypeNode to NodeStruct, OutputStructNode to StructNode possibly, NodeBuilder.getStructTypeFromNode to NodeBuilder.getStructFromNode, remove NodeBuilder._getWGSLStruct and NodeBuilder._getWGSLStructBinding)
+
+class OutputStructNode extends TempNode {
 
 	constructor( ...members ) {
 

--- a/examples/jsm/nodes/core/PropertyNode.js
+++ b/examples/jsm/nodes/core/PropertyNode.js
@@ -40,6 +40,13 @@ export default PropertyNode;
 
 export const property = ( type, name ) => nodeObject( new PropertyNode( type, name ) );
 
+export const vertexPosition = nodeImmutable( PropertyNode, 'vec4', 'Vertex' );
+export const output = nodeImmutable( PropertyNode, 'vec4', 'Output' );
+
+export const position = nodeImmutable( PropertyNode, 'vec3', 'Position' );
+export const normal = nodeImmutable( PropertyNode, 'vec3', 'Normal' );
+export const tangent = nodeImmutable( PropertyNode, 'vec3', 'Tangent' );
+
 export const diffuseColor = nodeImmutable( PropertyNode, 'vec4', 'DiffuseColor' );
 export const roughness = nodeImmutable( PropertyNode, 'float', 'Roughness' );
 export const metalness = nodeImmutable( PropertyNode, 'float', 'Metalness' );
@@ -52,7 +59,6 @@ export const iridescenceIOR = nodeImmutable( PropertyNode, 'float', 'Iridescence
 export const iridescenceThickness = nodeImmutable( PropertyNode, 'float', 'IridescenceThickness' );
 export const specularColor = nodeImmutable( PropertyNode, 'color', 'SpecularColor' );
 export const shininess = nodeImmutable( PropertyNode, 'float', 'Shininess' );
-export const output = nodeImmutable( PropertyNode, 'vec4', 'Output' );
 export const dashSize = nodeImmutable( PropertyNode, 'float', 'dashSize' );
 export const gapSize = nodeImmutable( PropertyNode, 'float', 'gapSize' );
 export const pointWidth = nodeImmutable( PropertyNode, 'float', 'pointWidth' );

--- a/examples/jsm/nodes/core/TempNode.js
+++ b/examples/jsm/nodes/core/TempNode.js
@@ -12,9 +12,16 @@ class TempNode extends Node {
 
 	hasDependencies( builder ) {
 
-		return builder.getDataFromNode( this ).dependenciesCount > 1;
+		const { dependenciesCount } = builder.getNodeData( this );
+
+		if ( dependenciesCount === undefined ) console.warn( 'Nodes System: It looks like the following node didn\'t have .analyze() method ran on it, which is a bug:', this );
+
+		return dependenciesCount > 1;
 
 	}
+
+	// @TODO: introduce properties like .allowsAssign=false (true in VarNode, PropertyNode, SplitNode and ArrayElementNode) and .reuseGenerated=true (false in e.g. AssignNode, ExpressionNode, BypassNode, StackNode (because of side effects) and in e.g. UniformNode, ArrayElementNode, SplitNode, MaterialNode (because of not doing any work suggesting reuse)). these properties mend the corresponding clauses of the `output === 'void' || this.hasDependencies( builder )` condition below (`++ nodeData.dependenciesCount === 1` condition in Node.analyze() also should be mended to account for .reuseGenerated = false). this will allow to merge Node and TempNode together
+	// @TODO: auto-temp nodes that require usage inside of a uniform control flow if they are placed outside of it (e.g. in CondNode)
 
 	build( builder, output ) {
 
@@ -23,13 +30,13 @@ class TempNode extends Node {
 		if ( buildStage === 'generate' ) {
 
 			const type = builder.getVectorType( this.getNodeType( builder, output ) );
-			const nodeData = builder.getDataFromNode( this );
+			const nodeData = builder.getNodeData( this );
 
-			if ( builder.context.tempRead !== false && nodeData.propertyName !== undefined ) {
+			if ( nodeData.propertyName !== undefined ) {
 
 				return builder.format( nodeData.propertyName, type, output );
 
-			} else if ( builder.context.tempWrite !== false && type !== 'void' && output !== 'void' && this.hasDependencies( builder ) ) {
+			} else if ( type !== 'void' && ( output === 'void' || this.hasDependencies( builder ) ) ) { // we auto-temp the node if something is assigned to it or it is used multiple times
 
 				const snippet = super.build( builder, type );
 

--- a/examples/jsm/nodes/core/UniformNode.js
+++ b/examples/jsm/nodes/core/UniformNode.js
@@ -1,4 +1,5 @@
 import InputNode from './InputNode.js';
+//import TempNode from './TempNode.js';
 import { addNodeClass } from './Node.js';
 import { nodeObject, getConstNodeType } from '../shadernode/ShaderNode.js';
 
@@ -9,41 +10,40 @@ class UniformNode extends InputNode {
 		super( value, nodeType );
 
 		this.isUniformNode = true;
+		//this.isTempNode = true;
 
 	}
 
-	getUniformHash( builder ) {
+	isGlobal() {
 
-		return this.getHash( builder );
+		return true;
 
 	}
 
-	generate( builder, output ) {
+	/*hasDependencies( builder ) {
 
-		const type = this.getNodeType( builder );
+		return TempNode.prototype.hasDependencies.call( this, builder );
 
-		const hash = this.getUniformHash( builder );
+	}*/
 
-		let sharedNode = builder.getNodeFromHash( hash );
+	generate( builder ) {
 
-		if ( sharedNode === undefined ) {
+		const sharedNode = this.getShared( builder );
 
-			builder.setHashNode( this, hash );
-
-			sharedNode = this;
-
-		}
-
-		const sharedNodeType = sharedNode.getInputType( builder );
-
-		const nodeUniform = builder.getUniformFromNode( sharedNode, sharedNodeType, builder.shaderStage, builder.context.label );
+		const nodeUniform = builder.getUniformFromNode( sharedNode, builder.context.label, sharedNode.getInputType( builder ) );
 		const propertyName = builder.getPropertyName( nodeUniform );
 
 		if ( builder.context.label !== undefined ) delete builder.context.label;
 
-		return builder.format( propertyName, type, output );
+		return propertyName;
 
 	}
+
+	/*build( builder, output ) {
+
+		return TempNode.prototype.build.call( this, builder, output );
+
+	}*/
 
 }
 

--- a/examples/jsm/nodes/core/VarNode.js
+++ b/examples/jsm/nodes/core/VarNode.js
@@ -12,12 +12,6 @@ class VarNode extends Node {
 
 	}
 
-	isGlobal() {
-
-		return true;
-
-	}
-
 	getHash( builder ) {
 
 		return this.name || super.getHash( builder );
@@ -40,7 +34,7 @@ class VarNode extends Node {
 
 		const snippet = node.build( builder, nodeVar.type );
 
-		builder.addLineFlowCode( `${propertyName} = ${snippet}` );
+		builder.addLineFlowCode( builder.formatOperation( '=', propertyName, snippet ) );
 
 		return propertyName;
 

--- a/examples/jsm/nodes/core/constants.js
+++ b/examples/jsm/nodes/core/constants.js
@@ -1,24 +1,8 @@
-export const NodeShaderStage = {
-	VERTEX: 'vertex',
-	FRAGMENT: 'fragment'
-};
-
 export const NodeUpdateType = {
 	NONE: 'none',
 	FRAME: 'frame',
 	RENDER: 'render',
 	OBJECT: 'object'
-};
-
-export const NodeType = {
-	BOOLEAN: 'bool',
-	INTEGER: 'int',
-	FLOAT: 'float',
-	VECTOR2: 'vec2',
-	VECTOR3: 'vec3',
-	VECTOR4: 'vec4',
-	MATRIX3: 'mat3',
-	MATRIX4: 'mat4'
 };
 
 export const defaultShaderStages = [ 'fragment', 'vertex' ];

--- a/examples/jsm/nodes/display/BumpMapNode.js
+++ b/examples/jsm/nodes/display/BumpMapNode.js
@@ -4,7 +4,7 @@ import { uv } from '../accessors/UVNode.js';
 import { normalView } from '../accessors/NormalNode.js';
 import { positionView } from '../accessors/PositionNode.js';
 import { faceDirection } from './FrontFacingNode.js';
-import { tslFn, nodeProxy, float, vec2 } from '../shadernode/ShaderNode.js';
+import { tslFn, nodeProxy, vec2 } from '../shadernode/ShaderNode.js';
 
 // Bump Mapping Unparametrized Surfaces on the GPU by Morten S. Mikkelsen
 // https://mmikk.github.io/papers3d/mm_sfgrad_bump.pdf
@@ -31,16 +31,13 @@ const dHdxy_fwd = tslFn( ( { textureNode, bumpScale } ) => {
 
 	}
 
-	const Hll = float( textureNode );
+	const Hll = textureNode.float();
 	const uvNode = texNode.uvNode || uv();
 
 	// It's used to preserve the same TextureNode instance
-	const sampleTexture = ( uv ) => textureNode.cache().context( { getUVNode: () => uv } );
+	const sampleTexture = ( uv ) => textureNode.cache().context( { getUVNode: () => uv } ).float();
 
-	return vec2(
-		float( sampleTexture( uvNode.add( uvNode.dFdx() ) ) ).sub( Hll ),
-		float( sampleTexture( uvNode.add( uvNode.dFdy() ) ) ).sub( Hll )
-	).mul( bumpScale );
+	return vec2( sampleTexture( uvNode.add( uvNode.dFdx() ) ), sampleTexture( uvNode.add( uvNode.dFdy() ) ) ).sub( H11 ).mul( bumpScale );
 
 } );
 
@@ -81,7 +78,7 @@ class BumpMapNode extends TempNode {
 		const dHdxy = dHdxy_fwd( { textureNode: this.textureNode, bumpScale } );
 
 		return perturbNormalArb( {
-			surf_pos: positionView,
+			surf_pos: positionView.xyz,
 			surf_norm: normalView,
 			dHdxy
 		} );

--- a/examples/jsm/nodes/display/ColorAdjustmentNode.js
+++ b/examples/jsm/nodes/display/ColorAdjustmentNode.js
@@ -1,27 +1,32 @@
 import TempNode from '../core/TempNode.js';
-import { dot, mix } from '../math/MathNode.js';
-import { add } from '../math/OperatorNode.js';
 import { addNodeClass } from '../core/Node.js';
 import { addNodeElement, tslFn, nodeProxy, float, vec3, mat3 } from '../shadernode/ShaderNode.js';
 
 const saturationNode = tslFn( ( { color, adjustment } ) => {
 
-	return adjustment.mix( luminance( color ), color );
+	color = color.temp();
+	color.rgb = adjustment.mix( color.rgb.luminance(), color.rgb );
+	return color;
 
 } );
 
 const vibranceNode = tslFn( ( { color, adjustment } ) => {
 
-	const average = add( color.r, color.g, color.b ).div( 3.0 );
+	color = color.temp();
 
-	const mx = color.r.max( color.g.max( color.b ) );
-	const amt = mx.sub( average ).mul( adjustment ).mul( - 3.0 );
+	const average = color.r.add( color.g, color.b ).div( 3.0 );
 
-	return mix( color, mx, amt );
+	const mx = color.r.max( color.g, color.b );
+	const amt = mx.sub( average ).mul( adjustment, - 3.0 );
+
+	color.rgb = amt.mix( color.rgb, mx );
+	return color;
 
 } );
 
 const hueNode = tslFn( ( { color, adjustment } ) => {
+
+	color = color.temp();
 
 	const RGBtoYIQ = mat3( 0.299, 0.587, 0.114, 0.595716, - 0.274453, - 0.321263, 0.211456, - 0.522591, 0.311135 );
 	const YIQtoRGB = mat3( 1.0, 0.9563, 0.6210, 1.0, - 0.2721, - 0.6474, 1.0, - 1.107, 1.7046 );
@@ -31,7 +36,8 @@ const hueNode = tslFn( ( { color, adjustment } ) => {
 	const hue = yiq.z.atan2( yiq.y ).add( adjustment );
 	const chroma = yiq.yz.length();
 
-	return YIQtoRGB.mul( vec3( yiq.x, chroma.mul( hue.cos() ), chroma.mul( hue.sin() ) ) );
+	color.rgb = YIQtoRGB.mul( vec3( yiq.x, chroma.mul( hue.cos() ), chroma.mul( hue.sin() ) ) );
+	return color;
 
 } );
 
@@ -91,10 +97,11 @@ export const vibrance = nodeProxy( ColorAdjustmentNode, ColorAdjustmentNode.VIBR
 export const hue = nodeProxy( ColorAdjustmentNode, ColorAdjustmentNode.HUE );
 
 export const lumaCoeffs = vec3( 0.2125, 0.7154, 0.0721 );
-export const luminance = ( color, luma = lumaCoeffs ) => dot( color, luma );
+export const luminance = ( color, luma = lumaCoeffs ) => luma.dot( color.rgb );
 
 addNodeElement( 'saturation', saturation );
 addNodeElement( 'vibrance', vibrance );
 addNodeElement( 'hue', hue );
+addNodeElement( 'luminance', luminance );
 
 addNodeClass( 'ColorAdjustmentNode', ColorAdjustmentNode );

--- a/examples/jsm/nodes/display/ColorSpaceNode.js
+++ b/examples/jsm/nodes/display/ColorSpaceNode.js
@@ -1,37 +1,34 @@
 import TempNode from '../core/TempNode.js';
-import { mix } from '../math/MathNode.js';
 import { addNodeClass } from '../core/Node.js';
 import { addNodeElement, tslFn, nodeObject, nodeProxy, vec4 } from '../shadernode/ShaderNode.js';
 
 import { LinearSRGBColorSpace, SRGBColorSpace } from 'three';
 
-const sRGBToLinearShader = tslFn( ( inputs ) => {
+const sRGBToLinearShader = tslFn( ( { value } ) => {
 
-	const { value } = inputs;
 	const { rgb } = value;
 
 	const a = rgb.mul( 0.9478672986 ).add( 0.0521327014 ).pow( 2.4 );
 	const b = rgb.mul( 0.0773993808 );
 	const factor = rgb.lessThanEqual( 0.04045 );
 
-	const rgbResult = mix( a, b, factor );
+	value.rgb = factor.mix( a, b );
 
-	return vec4( rgbResult, value.a );
+	return value;
 
 } );
 
-const LinearTosRGBShader = tslFn( ( inputs ) => {
+const LinearTosRGBShader = tslFn( ( { value } ) => {
 
-	const { value } = inputs;
 	const { rgb } = value;
 
 	const a = rgb.pow( 0.41666 ).mul( 1.055 ).sub( 0.055 );
 	const b = rgb.mul( 12.92 );
 	const factor = rgb.lessThanEqual( 0.0031308 );
 
-	const rgbResult = mix( a, b, factor );
+	value.rgb = factor.mix( a, b );
 
-	return vec4( rgbResult, value.a );
+	return value;
 
 } );
 
@@ -74,8 +71,7 @@ class ColorSpaceNode extends TempNode {
 
 		const { method, node } = this;
 
-		if ( method === ColorSpaceNode.LINEAR_TO_LINEAR )
-			return node;
+		if ( method === ColorSpaceNode.LINEAR_TO_LINEAR ) return node;
 
 		return Methods[ method ]( { value: node } );
 

--- a/examples/jsm/nodes/display/FrontFacingNode.js
+++ b/examples/jsm/nodes/display/FrontFacingNode.js
@@ -1,5 +1,5 @@
 import Node, { addNodeClass } from '../core/Node.js';
-import { nodeImmutable, float } from '../shadernode/ShaderNode.js';
+import { nodeImmutable } from '../shadernode/ShaderNode.js';
 
 class FrontFacingNode extends Node {
 
@@ -22,6 +22,6 @@ class FrontFacingNode extends Node {
 export default FrontFacingNode;
 
 export const frontFacing = nodeImmutable( FrontFacingNode );
-export const faceDirection = float( frontFacing ).mul( 2.0 ).sub( 1.0 );
+export const faceDirection = frontFacing.float().mul( 2.0 ).sub( 1.0 );
 
 addNodeClass( 'FrontFacingNode', FrontFacingNode );

--- a/examples/jsm/nodes/display/NormalMapNode.js
+++ b/examples/jsm/nodes/display/NormalMapNode.js
@@ -1,5 +1,4 @@
 import TempNode from '../core/TempNode.js';
-import { add } from '../math/OperatorNode.js';
 import { bitangentView } from '../accessors/BitangentNode.js';
 import { modelNormalMatrix } from '../accessors/ModelNode.js';
 import { normalView } from '../accessors/NormalNode.js';
@@ -35,7 +34,7 @@ const perturbNormal2Arb = tslFn( ( inputs ) => {
 	const det = T.dot( T ).max( B.dot( B ) );
 	const scale = faceDirection.mul( det.inverseSqrt() );
 
-	return add( T.mul( mapN.x, scale ), B.mul( mapN.y, scale ), N.mul( mapN.z ) ).normalize();
+	return T.mul( mapN.x ).add( B.mul( mapN.y ) ).mul( scale ).add( N.mul( mapN.z ) ).normalize();
 
 } );
 
@@ -81,7 +80,7 @@ class NormalMapNode extends TempNode {
 			} else {
 
 				outputNode = perturbNormal2Arb( {
-					eye_pos: positionView,
+					eye_pos: positionView.xyz,
 					surf_norm: normalView,
 					mapN: normalMap,
 					uv: uv()

--- a/examples/jsm/nodes/display/ToneMappingNode.js
+++ b/examples/jsm/nodes/display/ToneMappingNode.js
@@ -61,7 +61,7 @@ const ACESFilmicToneMappingNode = tslFn( ( { color, exposure } ) => {
 		- 0.00327, - 0.07276, 1.07602
 	);
 
-	color = color.mul( exposure ).div( 0.6 );
+	color = color.mul( exposure, 1 / 0.6 );
 
 	color = ACESInputMat.mul( color );
 
@@ -97,10 +97,7 @@ class ToneMappingNode extends TempNode {
 
 	getCacheKey() {
 
-		let cacheKey = super.getCacheKey();
-		cacheKey = '{toneMapping:' + this.toneMapping + ',nodes:' + cacheKey + '}';
-
-		return cacheKey;
+		return '{toneMapping:' + this.toneMapping + ',nodes:' + super.getCacheKey() + '}';
 
 	}
 

--- a/examples/jsm/nodes/display/ViewportDepthNode.js
+++ b/examples/jsm/nodes/display/ViewportDepthNode.js
@@ -1,10 +1,11 @@
-import Node, { addNodeClass } from '../core/Node.js';
+import TempNode from '../core/TempNode.js';
+import { addNodeClass } from '../core/Node.js';
 import { nodeImmutable, nodeProxy } from '../shadernode/ShaderNode.js';
 import { cameraNear, cameraFar } from '../accessors/CameraNode.js';
 import { positionView } from '../accessors/PositionNode.js';
 import { viewportDepthTexture } from './ViewportDepthTextureNode.js';
 
-class ViewportDepthNode extends Node {
+class ViewportDepthNode extends TempNode {
 
 	constructor( scope, textureNode = null ) {
 
@@ -45,18 +46,18 @@ class ViewportDepthNode extends Node {
 // NOTE: viewZ, the z-coordinate in camera space, is negative for points in front of the camera
 
 // -near maps to 0; -far maps to 1
-export const viewZToOrthographicDepth = ( viewZ, near, far ) => viewZ.add( near ).div( near.sub( far ) );
+export const viewZToOrthographicDepth = ( viewZ, near, far ) => viewZ.remapIn( near.negate(), far.negate() );
 
 // maps orthographic depth in [ 0, 1 ] to viewZ
-export const orthographicDepthToViewZ = ( depth, near, far ) => near.sub( far ).mul( depth ).sub( near );
+export const orthographicDepthToViewZ = ( depth, near, far ) => depth.mix( near, far ).negate();
 
 // NOTE: https://twitter.com/gonnavis/status/1377183786949959682
 
-// -near maps to 0; -far maps to 1
-export const viewZToPerspectiveDepth = ( viewZ, near, far ) => near.add( viewZ ).mul( far ).div( near.sub( far ).mul( viewZ ) );
+// -near maps to 0; -far maps to -1
+export const viewZToPerspectiveDepth = ( viewZ, near, far ) => viewZ.remapIn( near.negate(), far.negate() ).mul( far ).div( viewZ );
 
 // maps perspective depth in [ 0, 1 ] to viewZ
-export const perspectiveDepthToViewZ = ( depth, near, far ) => near.mul( far ).div( far.sub( near ).mul( depth ).sub( far ) );
+export const perspectiveDepthToViewZ = ( depth, near, far ) => near.mul( far ).div( depth.mix( far, near ) ).negate();
 
 ViewportDepthNode.DEPTH = 'depth';
 ViewportDepthNode.DEPTH_TEXTURE = 'depthTexture';

--- a/examples/jsm/nodes/display/ViewportNode.js
+++ b/examples/jsm/nodes/display/ViewportNode.js
@@ -1,4 +1,5 @@
-import Node, { addNodeClass } from '../core/Node.js';
+import TempNode from '../core/TempNode.js';
+import { addNodeClass } from '../core/Node.js';
 import { NodeUpdateType } from '../core/constants.js';
 import { uniform } from '../core/UniformNode.js';
 import { nodeImmutable, vec2 } from '../shadernode/ShaderNode.js';
@@ -7,7 +8,7 @@ import { Vector2, Vector4 } from 'three';
 
 let resolution, viewportResult;
 
-class ViewportNode extends Node {
+class ViewportNode extends TempNode {
 
 	constructor( scope ) {
 
@@ -73,20 +74,10 @@ class ViewportNode extends Node {
 
 		} else {
 
-			const coordinateNode = vec2( new ViewportNode( ViewportNode.COORDINATE ) );
-			const resolutionNode = new ViewportNode( ViewportNode.RESOLUTION );
+			output = vec2( viewportCoordinate ).div( viewportResolution );
 
-			output = coordinateNode.div( resolutionNode );
-
-			let outX = output.x;
-			let outY = output.y;
-
-			if ( /top/i.test( scope ) && builder.isFlipY() ) outY = outY.oneMinus();
-			else if ( /bottom/i.test( scope ) && builder.isFlipY() === false ) outY = outY.oneMinus();
-
-			if ( /right/i.test( scope ) ) outX = outX.oneMinus();
-
-			output = vec2( outX, outY );
+			if ( /right/i.test( scope ) === true ) output.x = output.x.oneMinus();
+			if ( /top/i.test( scope ) === builder.isFlipY() ) output.y = output.y.oneMinus();
 
 		}
 

--- a/examples/jsm/nodes/display/ViewportTextureNode.js
+++ b/examples/jsm/nodes/display/ViewportTextureNode.js
@@ -1,7 +1,7 @@
 import TextureNode from '../accessors/TextureNode.js';
 import { NodeUpdateType } from '../core/constants.js';
 import { addNodeClass } from '../core/Node.js';
-import { addNodeElement, nodeProxy } from '../shadernode/ShaderNode.js';
+import { addNodeElement, nodeProxy, nodeObject } from '../shadernode/ShaderNode.js';
 import { viewportTopLeft } from './ViewportNode.js';
 import { Vector2, FramebufferTexture, LinearMipmapLinearFilter } from 'three';
 
@@ -58,7 +58,7 @@ class ViewportTextureNode extends TextureNode {
 
 	clone() {
 
-		return new this.constructor( this.uvNode, this.levelNode, this.value );
+		return nodeObject( new this.constructor( this.uvNode, this.levelNode, this.value ) );
 
 	}
 

--- a/examples/jsm/nodes/fog/FogNode.js
+++ b/examples/jsm/nodes/fog/FogNode.js
@@ -1,7 +1,9 @@
-import Node, { addNodeClass } from '../core/Node.js';
+import TempNode from '../core/TempNode.js';
+import { addNodeClass } from '../core/Node.js';
+import { mix } from '../math/MathNode.js';
 import { addNodeElement, nodeProxy } from '../shadernode/ShaderNode.js';
 
-class FogNode extends Node {
+class FogNode extends TempNode {
 
 	constructor( colorNode, factorNode ) {
 
@@ -14,14 +16,15 @@ class FogNode extends Node {
 
 	}
 
-	mixAssign( outputNode ) {
+	mix( outputNode ) {
 
-		return this.mix( outputNode, this.colorNode );
+		return mix( outputNode, this.colorNode, this );
 
 	}
 
-	setup() {
+	setup( builder ) {
 
+		super.setup( builder );
 		return this.factorNode;
 
 	}

--- a/examples/jsm/nodes/fog/FogRangeNode.js
+++ b/examples/jsm/nodes/fog/FogRangeNode.js
@@ -1,5 +1,4 @@
 import FogNode from './FogNode.js';
-import { smoothstep } from '../math/MathNode.js';
 import { positionView } from '../accessors/PositionNode.js';
 import { addNodeClass } from '../core/Node.js';
 import { addNodeElement, nodeProxy } from '../shadernode/ShaderNode.js';
@@ -19,7 +18,7 @@ class FogRangeNode extends FogNode {
 
 	setup() {
 
-		return smoothstep( this.nearNode, this.farNode, positionView.z.negate() );
+		return positionView.z.negate().smoothstep( this.nearNode, this.farNode );
 
 	}
 

--- a/examples/jsm/nodes/functions/BSDF/BRDF_GGX.js
+++ b/examples/jsm/nodes/functions/BSDF/BRDF_GGX.js
@@ -18,7 +18,7 @@ const BRDF_GGX = tslFn( ( inputs ) => {
 	const halfDir = lightDirection.add( positionViewDirection ).normalize();
 
 	const dotNL = normalView.dot( lightDirection ).clamp();
-	const dotNV = normalView.dot( positionViewDirection ).clamp(); // @ TODO: Move to core dotNV
+	const dotNV = normalView.dot( positionViewDirection ).clamp(); // @TODO: Move to core dotNV (maybe along with other dotSomethings?)
 	const dotNH = normalView.dot( halfDir ).clamp();
 	const dotVH = positionViewDirection.dot( halfDir ).clamp();
 
@@ -33,7 +33,7 @@ const BRDF_GGX = tslFn( ( inputs ) => {
 	const V = V_GGX_SmithCorrelated( { alpha, dotNL, dotNV } );
 	const D = D_GGX( { alpha, dotNH } );
 
-	return F.mul( V ).mul( D );
+	return F.mul( V, D );
 
 } ); // validated
 

--- a/examples/jsm/nodes/functions/BSDF/BRDF_Sheen.js
+++ b/examples/jsm/nodes/functions/BSDF/BRDF_Sheen.js
@@ -1,7 +1,7 @@
 import { transformedNormalView } from '../../accessors/NormalNode.js';
 import { positionViewDirection } from '../../accessors/PositionNode.js';
 import { sheen, sheenRoughness } from '../../core/PropertyNode.js';
-import { tslFn, float } from '../../shadernode/ShaderNode.js';
+import { tslFn } from '../../shadernode/ShaderNode.js';
 
 // https://github.com/google/filament/blob/master/shaders/src/brdf.fs
 const D_Charlie = tslFn( ( { roughness, dotNH } ) => {
@@ -9,11 +9,11 @@ const D_Charlie = tslFn( ( { roughness, dotNH } ) => {
 	const alpha = roughness.pow2();
 
 	// Estevez and Kulla 2017, "Production Friendly Microfacet Sheen BRDF"
-	const invAlpha = float( 1.0 ).div( alpha );
+	const invAlpha = alpha.reciprocal();
 	const cos2h = dotNH.pow2();
-	const sin2h = cos2h.oneMinus().max( 0.0078125 ); // 2^(-14/2), so sin2h^2 > 0 in fp16
+	const sin2h = cos2h.oneMinus().max( 1 / 2 ** 7 ); // 2^(-14/2), so sin2h^2 > 0 in fp16
 
-	return float( 2.0 ).add( invAlpha ).mul( sin2h.pow( invAlpha.mul( 0.5 ) ) ).div( 2.0 * Math.PI );
+	return invAlpha.add( 2.0 ).mul( sin2h.pow( invAlpha.mul( 0.5 ) ) ).mul( 0.5 / Math.PI );
 
 } ).setLayout( {
 	name: 'D_Charlie',
@@ -28,7 +28,7 @@ const D_Charlie = tslFn( ( { roughness, dotNH } ) => {
 const V_Neubelt = tslFn( ( { dotNV, dotNL } ) => {
 
 	// Neubelt and Pettineo 2013, "Crafting a Next-gen Material Pipeline for The Order: 1886"
-	return float( 1.0 ).div( float( 4.0 ).mul( dotNL.add( dotNV ).sub( dotNL.mul( dotNV ) ) ) );
+	return dotNL.add( dotNV ).sub( dotNL.mul( dotNV ) ).mul( 4.0 ).reciprocal();
 
 } ).setLayout( {
 	name: 'V_Neubelt',
@@ -50,7 +50,7 @@ const BRDF_Sheen = tslFn( ( { lightDirection } ) => {
 	const D = D_Charlie( { roughness: sheenRoughness, dotNH } );
 	const V = V_Neubelt( { dotNV, dotNL } );
 
-	return sheen.mul( D ).mul( V );
+	return sheen.mul( D, V );
 
 } );
 

--- a/examples/jsm/nodes/functions/BSDF/DFGApprox.js
+++ b/examples/jsm/nodes/functions/BSDF/DFGApprox.js
@@ -12,7 +12,7 @@ const DFGApprox = tslFn( ( { roughness, dotNV } ) => {
 
 	const r = roughness.mul( c0 ).add( c1 );
 
-	const a004 = r.x.mul( r.x ).min( dotNV.mul( - 9.28 ).exp2() ).mul( r.x ).add( r.y );
+	const a004 = r.x.mul( r.x ).min( dotNV.xy.mul( - 9.28 ).exp2() ).mul( r.x ).add( r.y );
 
 	const fab = vec2( - 1.04, 1.04 ).mul( a004 ).add( r.zw );
 

--- a/examples/jsm/nodes/functions/BSDF/F_Schlick.js
+++ b/examples/jsm/nodes/functions/BSDF/F_Schlick.js
@@ -9,7 +9,7 @@ const F_Schlick = tslFn( ( { f0, f90, dotVH } ) => {
 	// https://cdn2.unrealengine.com/Resources/files/2013SiggraphPresentationsNotes-26915738.pdf
 	const fresnel = dotVH.mul( - 5.55473 ).sub( 6.98316 ).mul( dotVH ).exp2();
 
-	return f0.mul( fresnel.oneMinus() ).add( f90.mul( fresnel ) );
+	return fresnel.mix( f0, f90 );
 
 } ); // validated
 

--- a/examples/jsm/nodes/functions/PhongLightingModel.js
+++ b/examples/jsm/nodes/functions/PhongLightingModel.js
@@ -6,9 +6,9 @@ import { transformedNormalView } from '../accessors/NormalNode.js';
 import { materialSpecularStrength } from '../accessors/MaterialNode.js';
 import { shininess, specularColor } from '../core/PropertyNode.js';
 import { positionViewDirection } from '../accessors/PositionNode.js';
-import { tslFn, float } from '../shadernode/ShaderNode.js';
+import { tslFn } from '../shadernode/ShaderNode.js';
 
-const G_BlinnPhong_Implicit = () => float( 0.25 );
+const G_BlinnPhong_Implicit = () => 0.25;
 
 const D_BlinnPhong = tslFn( ( { dotNH } ) => {
 
@@ -27,7 +27,7 @@ const BRDF_BlinnPhong = tslFn( ( { lightDirection } ) => {
 	const G = G_BlinnPhong_Implicit();
 	const D = D_BlinnPhong( { dotNH } );
 
-	return F.mul( G ).mul( D );
+	return F.mul( G, D );
 
 } );
 
@@ -50,7 +50,7 @@ class PhongLightingModel extends LightingModel {
 
 		if ( this.specular === true ) {
 
-			reflectedLight.directSpecular.addAssign( irradiance.mul( BRDF_BlinnPhong( { lightDirection } ) ).mul( materialSpecularStrength ) );
+			reflectedLight.directSpecular.addAssign( irradiance.mul( BRDF_BlinnPhong( { lightDirection } ), materialSpecularStrength ) );
 
 		}
 

--- a/examples/jsm/nodes/functions/material/getGeometryRoughness.js
+++ b/examples/jsm/nodes/functions/material/getGeometryRoughness.js
@@ -1,10 +1,10 @@
-import { normalGeometry } from '../../accessors/NormalNode.js';
+import { normalLocal } from '../../accessors/NormalNode.js';
 import { tslFn } from '../../shadernode/ShaderNode.js';
 
 const getGeometryRoughness = tslFn( () => {
 
-	const dxy = normalGeometry.dFdx().abs().max( normalGeometry.dFdy().abs() );
-	const geometryRoughness = dxy.x.max( dxy.y ).max( dxy.z );
+	const dxy = normalLocal.dFdx().abs().max( normalLocal.dFdy().abs() );
+	const geometryRoughness = dxy.x.max( dxy.y, dxy.z );
 
 	return geometryRoughness;
 

--- a/examples/jsm/nodes/functions/material/getRoughness.js
+++ b/examples/jsm/nodes/functions/material/getRoughness.js
@@ -7,11 +7,7 @@ const getRoughness = tslFn( ( inputs ) => {
 
 	const geometryRoughness = getGeometryRoughness();
 
-	let roughnessFactor = roughness.max( 0.0525 ); // 0.0525 corresponds to the base mip of a 256 cubemap.
-	roughnessFactor = roughnessFactor.add( geometryRoughness );
-	roughnessFactor = roughnessFactor.min( 1.0 );
-
-	return roughnessFactor;
+	return roughness.max( 0.0525 ).add( geometryRoughness ).clamp(); // 0.0525 corresponds to the base mip of a 256 cubemap.
 
 } );
 

--- a/examples/jsm/nodes/geometry/RangeNode.js
+++ b/examples/jsm/nodes/geometry/RangeNode.js
@@ -1,4 +1,5 @@
-import Node, { addNodeClass } from '../core/Node.js';
+import TempNode from '../core/TempNode.js';
+import { addNodeClass } from '../core/Node.js';
 import { getValueType } from '../core/NodeUtils.js';
 import { buffer } from '../accessors/BufferNode.js';
 //import { bufferAttribute } from '../accessors/BufferAttributeNode.js';
@@ -10,7 +11,7 @@ import { Vector4, MathUtils } from 'three';
 let min = null;
 let max = null;
 
-class RangeNode extends Node {
+class RangeNode extends TempNode {
 
 	constructor( minNode = float(), maxNode = float() ) {
 
@@ -37,6 +38,8 @@ class RangeNode extends Node {
 	}
 
 	setup( builder ) {
+
+		super.setup( builder );
 
 		const object = builder.object;
 

--- a/examples/jsm/nodes/gpgpu/ComputeNode.js
+++ b/examples/jsm/nodes/gpgpu/ComputeNode.js
@@ -58,9 +58,7 @@ class ComputeNode extends Node {
 
 	generate( builder ) {
 
-		const { shaderStage } = builder;
-
-		if ( shaderStage === 'compute' ) {
+		if ( builder.getShaderStage() === 'compute' ) {
 
 			const snippet = this.computeNode.build( builder, 'void' );
 

--- a/examples/jsm/nodes/lighting/AONode.js
+++ b/examples/jsm/nodes/lighting/AONode.js
@@ -13,6 +13,8 @@ class AONode extends LightingNode {
 
 	setup( builder ) {
 
+		super.setup( builder );
+
 		const aoIntensity = 1;
 		const aoNode = this.aoNode.x.sub( 1.0 ).mul( aoIntensity ).add( 1.0 );
 

--- a/examples/jsm/nodes/lighting/AmbientLightNode.js
+++ b/examples/jsm/nodes/lighting/AmbientLightNode.js
@@ -12,9 +12,11 @@ class AmbientLightNode extends AnalyticLightNode {
 
 	}
 
-	setup( { context } ) {
+	setup( builder ) {
 
-		context.irradiance.addAssign(this.colorNode );
+		super.setup( builder );
+
+		builder.context.irradiance.addAssign( this.colorNode );
 
 	}
 

--- a/examples/jsm/nodes/lighting/HemisphereLightNode.js
+++ b/examples/jsm/nodes/lighting/HemisphereLightNode.js
@@ -1,7 +1,6 @@
 import AnalyticLightNode from './AnalyticLightNode.js';
 import { addLightNode } from './LightsNode.js';
 import { uniform } from '../core/UniformNode.js';
-import { mix } from '../math/MathNode.js';
 import { normalView } from '../accessors/NormalNode.js';
 import { objectPosition } from '../accessors/Object3DNode.js';
 import { addNodeClass } from '../core/Node.js';
@@ -35,12 +34,14 @@ class HemisphereLightNode extends AnalyticLightNode {
 
 	setup( builder ) {
 
+		super.setup( builder );
+
 		const { colorNode, groundColorNode, lightDirectionNode } = this;
 
 		const dotNL = normalView.dot( lightDirectionNode );
 		const hemiDiffuseWeight = dotNL.mul( 0.5 ).add( 0.5 );
 
-		const irradiance = mix( groundColorNode, colorNode, hemiDiffuseWeight );
+		const irradiance = hemiDiffuseWeight.mix( groundColorNode, colorNode );
 
 		builder.context.irradiance.addAssign( irradiance );
 

--- a/examples/jsm/nodes/lighting/LightNode.js
+++ b/examples/jsm/nodes/lighting/LightNode.js
@@ -1,9 +1,10 @@
-import Node, { addNodeClass } from '../core/Node.js';
+import TempNode from '../core/TempNode.js';
+import { addNodeClass } from '../core/Node.js';
 import { nodeProxy } from '../shadernode/ShaderNode.js';
 import { objectPosition } from '../accessors/Object3DNode.js';
 import { cameraViewMatrix } from '../accessors/CameraNode.js';
 
-class LightNode extends Node {
+class LightNode extends TempNode {
 
 	constructor( scope = LightNode.TARGET_DIRECTION, light = null ) {
 

--- a/examples/jsm/nodes/lighting/LightingContextNode.js
+++ b/examples/jsm/nodes/lighting/LightingContextNode.js
@@ -39,7 +39,7 @@ class LightingContextNode extends ContextNode {
 			ambientOcclusion: float( 1 ).temp( 'ambientOcclusion' ),
 			reflectedLight,
 			backdrop: backdropNode,
-			backdropAlpha : backdropAlphaNode
+			backdropAlpha: backdropAlphaNode
 		};
 
 		return context;

--- a/examples/jsm/nodes/lighting/LightsNode.js
+++ b/examples/jsm/nodes/lighting/LightsNode.js
@@ -1,4 +1,4 @@
-import Node from '../core/Node.js';
+import Node, { addNodeClass } from '../core/Node.js';
 import AnalyticLightNode from './AnalyticLightNode.js';
 import { nodeObject, nodeProxy, vec3 } from '../shadernode/ShaderNode.js';
 
@@ -46,7 +46,7 @@ class LightsNode extends Node {
 
 			context.outgoingLight = outgoingLightNode;
 
-			const stack = builder.addStack();
+			const stack = builder.stack;
 
 			//
 
@@ -56,7 +56,8 @@ class LightsNode extends Node {
 
 			for ( const lightNode of lightNodes ) {
 
-				lightNode.build( builder );
+				const result = lightNode.build( builder );
+				if ( result !== null ) stack.add( result );
 	
 			}
 
@@ -90,7 +91,7 @@ class LightsNode extends Node {
 
 			//
 
-			outgoingLightNode = outgoingLightNode.bypass( builder.removeStack() );
+			outgoingLightNode = outgoingLightNode.bypass( stack );
 
 		}
 
@@ -102,7 +103,7 @@ class LightsNode extends Node {
 
 		if ( this._hash === null ) {
 
-			let hash = '';
+			let hash = 'lights: ';
 
 			const lightNodes = this.lightNodes;
 
@@ -112,7 +113,7 @@ class LightsNode extends Node {
 
 			}
 
-			this._hash = hash;
+			this._hash = hash.slice( 0, - 1 );
 
 		}
 
@@ -184,3 +185,5 @@ export function addLightNode( lightClass, lightNodeClass ) {
 	LightNodes.set( lightClass, lightNodeClass );
 
 }
+
+addNodeClass( 'LightsNode', LightsNode );

--- a/examples/jsm/nodes/materials/LineDashedNodeMaterial.js
+++ b/examples/jsm/nodes/materials/LineDashedNodeMaterial.js
@@ -1,9 +1,7 @@
 import NodeMaterial, { addNodeMaterial } from './NodeMaterial.js';
 import { attribute } from '../core/AttributeNode.js';
-import { varying } from '../core/VaryingNode.js';
 import { materialLineDashSize, materialLineGapSize, materialLineScale } from '../accessors/LineMaterialNode.js';
 import { dashSize, gapSize } from '../core/PropertyNode.js';
-import { float } from '../shadernode/ShaderNode.js';
 import { LineDashedMaterial } from 'three';
 
 const defaultValues = new LineDashedMaterial();
@@ -33,14 +31,14 @@ class LineDashedNodeMaterial extends NodeMaterial {
 	setupVariants() {
 
 		const offsetNode = this.offsetNode;
-		const dashScaleNode = this.dashScaleNode ? float( this.dashScaleNode ) : materialLineScale;
-		const dashSizeNode = this.dashSizeNode ? float( this.dashSizeNode ) : materialLineDashSize;
-		const gapSizeNode = this.dashSizeNode ? float( this.dashGapNode ) : materialLineGapSize;
+		const dashScaleNode = this.dashScaleNode || materialLineScale;
+		const dashSizeNode = this.dashSizeNode || materialLineDashSize;
+		const gapSizeNode = this.dashSizeNode || materialLineGapSize;
 
 		dashSize.assign( dashSizeNode );
 		gapSize.assign( gapSizeNode );
 
-		const vLineDistance = varying( attribute( 'lineDistance' ).mul( dashScaleNode ) );
+		const vLineDistance = attribute( 'lineDistance' ).mul( dashScaleNode ).varying();
 		const vLineDistanceOffset = offsetNode ? vLineDistance.add( offsetNode ) : vLineDistance;
 
 		vLineDistanceOffset.mod( dashSize.add( gapSize ) ).greaterThan( dashSize ).discard();

--- a/examples/jsm/nodes/materials/MeshNormalNodeMaterial.js
+++ b/examples/jsm/nodes/materials/MeshNormalNodeMaterial.js
@@ -1,9 +1,7 @@
 import NodeMaterial, { addNodeMaterial } from './NodeMaterial.js';
 import { diffuseColor } from '../core/PropertyNode.js';
-import { directionToColor } from '../utils/PackingNode.js';
 import { materialOpacity } from '../accessors/MaterialNode.js';
 import { transformedNormalView } from '../accessors/NormalNode.js';
-import { float, vec4 } from '../shadernode/ShaderNode.js';
 
 import { MeshNormalMaterial } from 'three';
 
@@ -27,9 +25,8 @@ class MeshNormalNodeMaterial extends NodeMaterial {
 
 	setupDiffuseColor() {
 
-		const opacityNode = this.opacityNode ? float( this.opacityNode ) : materialOpacity;
-
-		diffuseColor.assign( vec4( directionToColor( transformedNormalView ), opacityNode ) );
+		diffuseColor.rgb = transformedNormalView.directionToColor();
+		diffuseColor.a = this.opacityNode || materialOpacity;
 
 	}
 

--- a/examples/jsm/nodes/materials/MeshPhongNodeMaterial.js
+++ b/examples/jsm/nodes/materials/MeshPhongNodeMaterial.js
@@ -1,7 +1,6 @@
 import NodeMaterial, { addNodeMaterial } from './NodeMaterial.js';
 import { shininess, specularColor } from '../core/PropertyNode.js';
 import { materialShininess, materialSpecularColor } from '../accessors/MaterialNode.js';
-import { float } from '../shadernode/ShaderNode.js';
 import PhongLightingModel from '../functions/PhongLightingModel.js';
 
 import { MeshPhongMaterial } from 'three';
@@ -35,17 +34,9 @@ class MeshPhongNodeMaterial extends NodeMaterial {
 
 	setupVariants() {
 
-		// SHININESS
+		shininess.assign( ( this.shininessNode || materialShininess ).max( 1e-4 ) ); // to prevent pow( 0.0, 0.0 )
 
-		const shininessNode = ( this.shininessNode ? float( this.shininessNode ) : materialShininess ).max( 1e-4 ); // to prevent pow( 0.0, 0.0 )
-
-		shininess.assign( shininessNode );
-
-		// SPECULAR COLOR
-
-		const specularNode = this.specularNode || materialSpecularColor;
-
-		specularColor.assign( specularNode );
+		specularColor.assign( this.specularNode || materialSpecularColor );
 
 	}
 

--- a/examples/jsm/nodes/materials/MeshPhysicalNodeMaterial.js
+++ b/examples/jsm/nodes/materials/MeshPhysicalNodeMaterial.js
@@ -3,7 +3,6 @@ import { transformedClearcoatNormalView } from '../accessors/NormalNode.js';
 import { clearcoat, clearcoatRoughness, sheen, sheenRoughness, iridescence, iridescenceIOR, iridescenceThickness } from '../core/PropertyNode.js';
 import { materialClearcoatNormal } from '../accessors/ExtendedMaterialNode.js';
 import { materialClearcoat, materialClearcoatRoughness, materialSheen, materialSheenRoughness, materialIridescence, materialIridescenceIOR, materialIridescenceThickness } from '../accessors/MaterialNode.js';
-import { float, vec3 } from '../shadernode/ShaderNode.js';
 import PhysicalLightingModel from '../functions/PhysicalLightingModel.js';
 import MeshStandardNodeMaterial from './MeshStandardNodeMaterial.js';
 
@@ -72,41 +71,25 @@ class MeshPhysicalNodeMaterial extends MeshStandardNodeMaterial {
 
 		super.setupVariants( builder );
 
-		// CLEARCOAT
-
 		if ( this.useClearcoat ) {
 
-			const clearcoatNode = this.clearcoatNode ? float( this.clearcoatNode ) : materialClearcoat;
-			const clearcoatRoughnessNode = this.clearcoatRoughnessNode ? float( this.clearcoatRoughnessNode ) : materialClearcoatRoughness;
-
-			clearcoat.assign( clearcoatNode );
-			clearcoatRoughness.assign( clearcoatRoughnessNode );
+			clearcoat.assign( this.clearcoatNode || materialClearcoat );
+			clearcoatRoughness.assign( this.clearcoatRoughnessNode || materialClearcoatRoughness );
 
 		}
-
-		// SHEEN
 
 		if ( this.useSheen ) {
 
-			const sheenNode = this.sheenNode ? vec3( this.sheenNode ) : materialSheen;
-			const sheenRoughnessNode = this.sheenRoughnessNode ? float( this.sheenRoughnessNode ) : materialSheenRoughness;
-
-			sheen.assign( sheenNode );
-			sheenRoughness.assign( sheenRoughnessNode );
+			sheen.assign( this.sheenNode || materialSheen );
+			sheenRoughness.assign( this.sheenRoughnessNode || materialSheenRoughness );
 
 		}
 
-		// IRIDESCENCE
-
 		if ( this.useIridescence ) {
 
-			const iridescenceNode = this.iridescenceNode ? float( this.iridescenceNode ) : materialIridescence;
-			const iridescenceIORNode = this.iridescenceIORNode ? float( this.iridescenceIORNode ) : materialIridescenceIOR;
-			const iridescenceThicknessNode = this.iridescenceThicknessNode ? float( this.iridescenceThicknessNode ) : materialIridescenceThickness;
-
-			iridescence.assign( iridescenceNode );
-			iridescenceIOR.assign( iridescenceIORNode );
-			iridescenceThickness.assign( iridescenceThicknessNode );
+			iridescence.assign( this.iridescenceNode || materialIridescence );
+			iridescenceIOR.assign( this.iridescenceIORNode || materialIridescenceIOR );
+			iridescenceThickness.assign( this.iridescenceThicknessNode || materialIridescenceThickness );
 
 		}
 
@@ -116,11 +99,7 @@ class MeshPhysicalNodeMaterial extends MeshStandardNodeMaterial {
 
 		super.setupNormal( builder );
 
-		// CLEARCOAT NORMAL
-
-		const clearcoatNormalNode = this.clearcoatNormalNode ? vec3( this.clearcoatNormalNode ) : materialClearcoatNormal;
-
-		transformedClearcoatNormalView.assign( clearcoatNormalNode );
+		transformedClearcoatNormalView.assign( this.clearcoatNormalNode || materialClearcoatNormal );
 
 	}
 

--- a/examples/jsm/nodes/materials/MeshStandardNodeMaterial.js
+++ b/examples/jsm/nodes/materials/MeshStandardNodeMaterial.js
@@ -4,7 +4,6 @@ import { mix } from '../math/MathNode.js';
 import { materialRoughness, materialMetalness } from '../accessors/MaterialNode.js';
 import getRoughness from '../functions/material/getRoughness.js';
 import PhysicalLightingModel from '../functions/PhysicalLightingModel.js';
-import { float, vec3, vec4 } from '../shadernode/ShaderNode.js';
 
 import { MeshStandardMaterial } from 'three';
 
@@ -39,26 +38,20 @@ class MeshStandardNodeMaterial extends NodeMaterial {
 
 		// METALNESS
 
-		const metalnessNode = this.metalnessNode ? float( this.metalnessNode ) : materialMetalness;
-
+		const metalnessNode = this.metalnessNode || materialMetalness;
 		metalness.assign( metalnessNode );
 
 		// ROUGHNESS
 
-		let roughnessNode = this.roughnessNode ? float( this.roughnessNode ) : materialRoughness;
-		roughnessNode = getRoughness( { roughness: roughnessNode } );
-
-		roughness.assign( roughnessNode );
+		roughness.assign( getRoughness( { roughness: this.roughnessNode || materialRoughness } ) );
 
 		// SPECULAR COLOR
 
-		const specularColorNode = mix( vec3( 0.04 ), diffuseColor.rgb, metalnessNode );
-
-		specularColor.assign( specularColorNode );
+		specularColor.assign( metalnessNode.mix( 0.04, diffuseColor.rgb ) );
 
 		// DIFFUSE COLOR
 
-		diffuseColor.assign( vec4( diffuseColor.rgb.mul( metalnessNode.oneMinus() ), diffuseColor.a ) );
+		diffuseColor.rgb.mulAssign( metalnessNode.oneMinus() );
 
 	}
 

--- a/examples/jsm/nodes/materials/SpriteNodeMaterial.js
+++ b/examples/jsm/nodes/materials/SpriteNodeMaterial.js
@@ -3,8 +3,9 @@ import { uniform } from '../core/UniformNode.js';
 import { cameraProjectionMatrix } from '../accessors/CameraNode.js';
 import { materialRotation } from '../accessors/MaterialNode.js';
 import { modelViewMatrix, modelWorldMatrix } from '../accessors/ModelNode.js';
-import { positionLocal } from '../accessors/PositionNode.js';
-import { float, vec2, vec3, vec4 } from '../shadernode/ShaderNode.js';
+import { positionGeometry } from '../accessors/PositionNode.js';
+import { vertexPosition } from '../core/PropertyNode.js';
+import { float, vec2, vec3 } from '../shadernode/ShaderNode.js';
 
 import { SpriteMaterial } from 'three';
 
@@ -44,19 +45,17 @@ class SpriteNodeMaterial extends NodeMaterial {
 
 		const { positionNode, rotationNode, scaleNode } = this;
 
-		const vertex = positionLocal;
-
 		let mvPosition = modelViewMatrix.mul( vec3( positionNode || 0 ) );
 
 		let scale = vec2( modelWorldMatrix[ 0 ].xyz.length(), modelWorldMatrix[ 1 ].xyz.length() );
 
-		if ( scaleNode !== null ) {
+		if ( scaleNode ) {
 
 			scale = scale.mul( scaleNode );
 
 		}
 
-		let alignedPosition = vertex.xy;
+		let alignedPosition = positionGeometry.xy;
 
 		if ( object.center && object.center.isVector2 === true ) {
 
@@ -76,13 +75,9 @@ class SpriteNodeMaterial extends NodeMaterial {
 			vec2( sinAngle, cosAngle ).dot( alignedPosition )
 		);
 
-		mvPosition = vec4( mvPosition.xy.add( rotatedPosition ), mvPosition.zw );
+		mvPosition.xy.addAssign( rotatedPosition );
 
-		const modelViewProjection = cameraProjectionMatrix.mul( mvPosition );
-
-		context.vertex = vertex;
-
-		return modelViewProjection;
+		vertexPosition.assign( cameraProjectionMatrix.mul( mvPosition ) );
 
 	}
 

--- a/examples/jsm/nodes/math/HashNode.js
+++ b/examples/jsm/nodes/math/HashNode.js
@@ -1,7 +1,8 @@
-import Node, { addNodeClass } from '../core/Node.js';
+import TempNode from '../core/TempNode.js';
+import { addNodeClass } from '../core/Node.js';
 import { addNodeElement, nodeProxy } from '../shadernode/ShaderNode.js';
 
-class HashNode extends Node {
+class HashNode extends TempNode {
 
 	constructor( seedNode ) {
 

--- a/examples/jsm/nodes/math/OperatorNode.js
+++ b/examples/jsm/nodes/math/OperatorNode.js
@@ -27,6 +27,8 @@ class OperatorNode extends TempNode {
 		this.aNode = aNode;
 		this.bNode = bNode;
 
+		this.isOperatorNode = true;
+
 	}
 
 	getNodeType( builder, output ) {
@@ -156,37 +158,9 @@ class OperatorNode extends TempNode {
 		const a = aNode.build( builder, typeA );
 		const b = bNode.build( builder, typeB );
 
-		const outputLength = builder.getTypeLength( output );
+		const snippet = builder.formatOperation( op, a, b, type );
 
-		if ( output !== 'void' ) {
-
-			if ( op === '<' && outputLength > 1 ) {
-
-				return builder.format( `${ builder.getMethod( 'lessThan' ) }( ${a}, ${b} )`, type, output );
-
-			} else if ( op === '<=' && outputLength > 1 ) {
-
-				return builder.format( `${ builder.getMethod( 'lessThanEqual' ) }( ${a}, ${b} )`, type, output );
-
-			} else if ( op === '>' && outputLength > 1 ) {
-
-				return builder.format( `${ builder.getMethod( 'greaterThan' ) }( ${a}, ${b} )`, type, output );
-
-			} else if ( op === '>=' && outputLength > 1 ) {
-
-				return builder.format( `${ builder.getMethod( 'greaterThanEqual' ) }( ${a}, ${b} )`, type, output );
-
-			} else {
-
-				return builder.format( `( ${a} ${this.op} ${b} )`, type, output );
-
-			}
-
-		} else if ( typeA !== 'void' ) {
-
-			return builder.format( `${a} ${this.op} ${b}`, type, output );
-
-		}
+		return builder.format( snippet, type, output );
 
 	}
 

--- a/examples/jsm/nodes/parsers/GLSLNodeFunction.js
+++ b/examples/jsm/nodes/parsers/GLSLNodeFunction.js
@@ -79,7 +79,7 @@ const parse = ( source ) => {
 		const name = declaration[ 3 ] !== undefined ? declaration[ 3 ] : '';
 		const type = declaration[ 2 ];
 
-		const presicion = declaration[ 1 ] !== undefined ? declaration[ 1 ] : '';
+		const precision = declaration[ 1 ] !== undefined ? declaration[ 1 ] : '';
 
 		const headerCode = pragmaMainIndex !== - 1 ? source.slice( 0, pragmaMainIndex ) : '';
 
@@ -87,7 +87,7 @@ const parse = ( source ) => {
 			type,
 			inputs,
 			name,
-			presicion,
+			precision,
 			inputsCode,
 			blockCode,
 			headerCode
@@ -105,9 +105,9 @@ class GLSLNodeFunction extends NodeFunction {
 
 	constructor( source ) {
 
-		const { type, inputs, name, presicion, inputsCode, blockCode, headerCode } = parse( source );
+		const { type, inputs, name, precision, inputsCode, blockCode, headerCode } = parse( source );
 
-		super( type, inputs, name, presicion );
+		super( type, inputs, name, precision );
 
 		this.inputsCode = inputsCode;
 		this.blockCode = blockCode;
@@ -123,13 +123,13 @@ class GLSLNodeFunction extends NodeFunction {
 
 		if ( blockCode !== '' ) {
 
-			const { type, inputsCode, headerCode, presicion } = this;
+			const { type, inputsCode, headerCode, precision } = this;
 
-			let declarationCode = `${ type } ${ name } ( ${ inputsCode.trim() } )`;
+			let declarationCode = `${ type } ${ name }( ${ inputsCode.trim() } )`;
 
-			if ( presicion !== '' ) {
+			if ( precision !== '' ) {
 
-				declarationCode = `${ presicion } ${ declarationCode }`;
+				declarationCode = `${ precision } ${ declarationCode }`;
 
 			}
 

--- a/examples/jsm/nodes/utils/ArrayElementNode.js
+++ b/examples/jsm/nodes/utils/ArrayElementNode.js
@@ -1,6 +1,6 @@
 import Node, { addNodeClass } from '../core/Node.js';
 
-class ArrayElementNode extends Node { // @TODO: If extending from TempNode it breaks webgpu_compute
+class ArrayElementNode extends Node {
 
 	constructor( node, indexNode ) {
 
@@ -15,7 +15,17 @@ class ArrayElementNode extends Node { // @TODO: If extending from TempNode it br
 
 	getNodeType( builder ) {
 
-		return this.node.getNodeType( builder );
+		const type = this.node.getNodeType( builder );
+
+		const arrayType = /(.+)\[\s*(\d+?)\s*\]/.exec( type );
+		if ( arrayType !== null ) return arrayType[ 1 ];
+
+		const componentType = builder.getComponentType( type );
+
+		if ( builder.getTypeLength( type ) > 4 ) return builder.getTypeFromLength( Math.sqrt( builder.getTypeLength( type ) ), componentType );
+		else if ( builder.getTypeLength( type ) > 1 ) return componentType;
+
+		return type;
 
 	}
 
@@ -24,7 +34,7 @@ class ArrayElementNode extends Node { // @TODO: If extending from TempNode it br
 		const nodeSnippet = this.node.build( builder );
 		const indexSnippet = this.indexNode.build( builder, 'uint' );
 
-		return `${nodeSnippet}[ ${indexSnippet} ]`;
+		return builder.formatOperation( '[]', nodeSnippet, indexSnippet );
 
 	}
 

--- a/examples/jsm/nodes/utils/ConvertNode.js
+++ b/examples/jsm/nodes/utils/ConvertNode.js
@@ -1,6 +1,7 @@
-import Node, { addNodeClass } from '../core/Node.js';
+import TempNode from '../core/TempNode.js';
+import { addNodeClass } from '../core/Node.js';
 
-class ConvertNode extends Node {
+class ConvertNode extends TempNode {
 
 	constructor( node, convertTo ) {
 
@@ -31,6 +32,17 @@ class ConvertNode extends Node {
 
 	}
 
+	generate( builder, output ) {
+
+		const node = this.node;
+		const type = this.getNodeType( builder );
+
+		const snippet = node.build( builder, type );
+
+		return builder.format( snippet, type, output );
+
+	}
+
 	serialize( data ) {
 
 		super.serialize( data );
@@ -44,17 +56,6 @@ class ConvertNode extends Node {
 		super.deserialize( data );
 
 		this.convertTo = data.convertTo;
-
-	}
-
-	generate( builder, output ) {
-
-		const node = this.node;
-		const type = this.getNodeType( builder );
-
-		const snippet = node.build( builder, type );
-
-		return builder.format( snippet, type, output );
 
 	}
 

--- a/examples/jsm/nodes/utils/EquirectUVNode.js
+++ b/examples/jsm/nodes/utils/EquirectUVNode.js
@@ -1,6 +1,6 @@
 import TempNode from '../core/TempNode.js';
 import { positionWorldDirection } from '../accessors/PositionNode.js';
-import { nodeProxy, vec2 } from '../shadernode/ShaderNode.js';
+import { addNodeElement, nodeProxy, vec2 } from '../shadernode/ShaderNode.js';
 import { addNodeClass } from '../core/Node.js';
 
 class EquirectUVNode extends TempNode {
@@ -29,5 +29,7 @@ class EquirectUVNode extends TempNode {
 export default EquirectUVNode;
 
 export const equirectUV = nodeProxy( EquirectUVNode );
+
+addNodeElement( 'equirectUV', equirectUV );
 
 addNodeClass( 'EquirectUVNode', EquirectUVNode );

--- a/examples/jsm/nodes/utils/JoinNode.js
+++ b/examples/jsm/nodes/utils/JoinNode.js
@@ -19,7 +19,9 @@ class JoinNode extends TempNode {
 
 		}
 
-		return builder.getTypeFromLength( this.nodes.reduce( ( count, cur ) => count + builder.getTypeLength( cur.getNodeType( builder ) ), 0 ) );
+		const typeLength = this.nodes.reduce( ( count, cur ) => count + builder.getTypeLength( cur.getNodeType( builder ) ), 0 );
+
+		return builder.getTypeFromLength( typeLength, builder.getComponentType( this.nodes[ 0 ].getNodeType( builder ) ) );
 
 	}
 

--- a/examples/jsm/nodes/utils/MaxMipLevelNode.js
+++ b/examples/jsm/nodes/utils/MaxMipLevelNode.js
@@ -1,6 +1,6 @@
 import UniformNode from '../core/UniformNode.js';
 import { NodeUpdateType } from '../core/constants.js';
-import { nodeProxy } from '../shadernode/ShaderNode.js';
+import { addNodeElement, nodeProxy } from '../shadernode/ShaderNode.js';
 import { addNodeClass } from '../core/Node.js';
 
 class MaxMipLevelNode extends UniformNode {
@@ -9,7 +9,7 @@ class MaxMipLevelNode extends UniformNode {
 
 		super( 0 );
 
-		this.textureNode = textureNode;
+		this._textureNode = textureNode;
 
 		this.updateType = NodeUpdateType.FRAME;
 
@@ -17,7 +17,7 @@ class MaxMipLevelNode extends UniformNode {
 
 	get texture() {
 
-		return this.textureNode.value;
+		return this._textureNode.value;
 
 	}
 
@@ -42,5 +42,7 @@ class MaxMipLevelNode extends UniformNode {
 export default MaxMipLevelNode;
 
 export const maxMipLevel = nodeProxy( MaxMipLevelNode );
+
+addNodeElement( 'maxMipLevel', maxMipLevel );
 
 addNodeClass( 'MaxMipLevelNode', MaxMipLevelNode );

--- a/examples/jsm/nodes/utils/OscNode.js
+++ b/examples/jsm/nodes/utils/OscNode.js
@@ -1,8 +1,9 @@
-import Node, { addNodeClass } from '../core/Node.js';
+import TempNode from '../core/TempNode.js';
+import { addNodeClass } from '../core/Node.js';
 import { timerLocal } from './TimerNode.js';
 import { nodeObject, nodeProxy } from '../shadernode/ShaderNode.js';
 
-class OscNode extends Node {
+class OscNode extends TempNode {
 
 	constructor( method = OscNode.SINE, timeNode = timerLocal() ) {
 

--- a/examples/jsm/nodes/utils/RemapNode.js
+++ b/examples/jsm/nodes/utils/RemapNode.js
@@ -1,7 +1,8 @@
-import Node, { addNodeClass } from '../core/Node.js';
+import TempNode from '../core/TempNode.js';
+import { addNodeClass } from '../core/Node.js';
 import { addNodeElement, nodeProxy } from '../shadernode/ShaderNode.js';
 
-class RemapNode extends Node {
+class RemapNode extends TempNode {
 
 	constructor( node, inLowNode, inHighNode, outLowNode, outHighNode ) {
 
@@ -14,18 +15,20 @@ class RemapNode extends Node {
 		this.outHighNode = outHighNode;
 
 		this.doClamp = true;
+		this.doOut = true;
 
 	}
 
 	setup() {
 
-		const { node, inLowNode, inHighNode, outLowNode, outHighNode, doClamp } = this;
+		const { node, inLowNode, inHighNode, outLowNode, outHighNode, doClamp, doOut } = this;
 
 		let t = node.sub( inLowNode ).div( inHighNode.sub( inLowNode ) );
 
 		if ( doClamp === true ) t = t.clamp();
+		if ( doOut === true ) t = t.mix( outLowNode, outHighNode );
 
-		return t.mul( outHighNode.sub( outLowNode ) ).add( outLowNode );
+		return t;
 
 	}
 
@@ -35,8 +38,12 @@ export default RemapNode;
 
 export const remap = nodeProxy( RemapNode, null, null, { doClamp: false } );
 export const remapClamp = nodeProxy( RemapNode );
+export const remapIn = nodeProxy( RemapNode, null, null, { doClamp: false, doOut: false } );
+export const remapInClamp = nodeProxy( RemapNode, null, null, { doOut: false } );
 
 addNodeElement( 'remap', remap );
 addNodeElement( 'remapClamp', remapClamp );
+addNodeElement( 'remapIn', remapIn );
+addNodeElement( 'remapInClamp', remapInClamp );
 
 addNodeClass( 'RemapNode', RemapNode );

--- a/examples/jsm/nodes/utils/SpecularMIPLevelNode.js
+++ b/examples/jsm/nodes/utils/SpecularMIPLevelNode.js
@@ -1,8 +1,9 @@
-import Node, { addNodeClass } from '../core/Node.js';
+import TempNode from '../core/TempNode.js';
+import { addNodeClass } from '../core/Node.js';
 import { maxMipLevel } from './MaxMipLevelNode.js';
-import { nodeProxy } from '../shadernode/ShaderNode.js';
+import { addNodeElement, nodeProxy } from '../shadernode/ShaderNode.js';
 
-class SpecularMIPLevelNode extends Node {
+class SpecularMipLevelNode extends TempNode {
 
 	constructor( textureNode, roughnessNode = null ) {
 
@@ -19,19 +20,21 @@ class SpecularMIPLevelNode extends Node {
 
 		// taken from here: http://casual-effects.blogspot.ca/2011/08/plausible-environment-lighting-in-two.html
 
-		const maxMIPLevelScalar = maxMipLevel( textureNode );
+		const maxMipLevelScalar = maxMipLevel( textureNode );
 
 		const sigma = roughnessNode.mul( roughnessNode ).mul( Math.PI ).div( roughnessNode.add( 1.0 ) );
-		const desiredMIPLevel = maxMIPLevelScalar.add( sigma.log2() );
+		const desiredMipLevel = maxMipLevelScalar.add( sigma.log2() );
 
-		return desiredMIPLevel.clamp( 0.0, maxMIPLevelScalar );
+		return desiredMipLevel.clamp( 0.0, maxMipLevelScalar );
 
 	}
 
 }
 
-export default SpecularMIPLevelNode;
+export default SpecularMipLevelNode;
 
-export const specularMIPLevel = nodeProxy( SpecularMIPLevelNode );
+export const specularMipLevel = nodeProxy( SpecularMipLevelNode );
 
-addNodeClass( 'SpecularMIPLevelNode', SpecularMIPLevelNode );
+addNodeElement( 'specularMipLevel', specularMipLevel );
+
+addNodeClass( 'SpecularMipLevelNode', SpecularMipLevelNode );

--- a/examples/jsm/nodes/utils/SplitNode.js
+++ b/examples/jsm/nodes/utils/SplitNode.js
@@ -9,6 +9,13 @@ class SplitNode extends Node {
 
 		super();
 
+		/*if ( node.isSplitNode === true ) {
+
+			components = components.split( '' ).map( c => node.components[ vectorComponents.indexOf( c ) ] ).join( '' );
+			node = node.node;
+
+		}*/
+
 		this.node = node;
 		this.components = components;
 
@@ -32,14 +39,15 @@ class SplitNode extends Node {
 
 	getNodeType( builder ) {
 
-		return builder.getTypeFromLength( this.components.length );
+		return builder.getTypeFromLength( this.components.length, builder.getComponentType( this.node.getNodeType( builder ) ) );
 
 	}
 
 	generate( builder, output ) {
 
 		const node = this.node;
-		const nodeTypeLength = builder.getTypeLength( node.getNodeType( builder ) );
+		const nodeType = node.getNodeType( builder );
+		const nodeTypeLength = builder.getTypeLength( nodeType );
 
 		let snippet = null;
 
@@ -49,13 +57,13 @@ class SplitNode extends Node {
 
 			const componentsLength = this.getVectorLength();
 
-			if ( componentsLength >= nodeTypeLength ) {
+			if ( componentsLength > nodeTypeLength ) { // need to expand the input node
 
-				// needed expand the input node
-
-				type = builder.getTypeFromLength( this.getVectorLength() );
+				type = builder.getTypeFromLength( this.getVectorLength(), builder.getComponentType( nodeType ) );
 
 			}
+
+			if ( output === 'void' ) type = 'void';
 
 			const nodeSnippet = node.build( builder, type );
 
@@ -67,7 +75,7 @@ class SplitNode extends Node {
 
 			} else {
 
-				snippet = builder.format( `${nodeSnippet}.${this.components}`, this.getNodeType( builder ), output );
+				snippet = builder.format( builder.formatOperation( '.', nodeSnippet, this.components ), this.getNodeType( builder ), output );
 
 			}
 

--- a/examples/jsm/nodes/utils/SpriteSheetUVNode.js
+++ b/examples/jsm/nodes/utils/SpriteSheetUVNode.js
@@ -1,8 +1,9 @@
-import Node, { addNodeClass } from '../core/Node.js';
+import TempNode from '../core/TempNode.js';
+import { addNodeClass } from '../core/Node.js';
 import { uv } from '../accessors/UVNode.js';
 import { nodeProxy, float, vec2 } from '../shadernode/ShaderNode.js';
 
-class SpriteSheetUVNode extends Node {
+class SpriteSheetUVNode extends TempNode {
 
 	constructor( countNode, uvNode = uv(), frameNode = float( 0 ) ) {
 
@@ -28,7 +29,7 @@ class SpriteSheetUVNode extends Node {
 		const scale = countNode.reciprocal();
 		const uvFrameOffset = vec2( column, row );
 
-		return uvNode.add( uvFrameOffset ).mul( scale );
+		return uvNode.add( uvFrameOffset ).div( countNode );
 
 	}
 

--- a/examples/jsm/nodes/utils/TimerNode.js
+++ b/examples/jsm/nodes/utils/TimerNode.js
@@ -15,8 +15,7 @@ class TimerNode extends UniformNode {
 		this.updateType = NodeUpdateType.FRAME;
 
 	}
-	/*
-	@TODO:
+
 	getNodeType( builder ) {
 
 		const scope = this.scope;
@@ -30,7 +29,7 @@ class TimerNode extends UniformNode {
 		return 'float';
 
 	}
-*/
+
 	update( frame ) {
 
 		const scope = this.scope;
@@ -48,9 +47,7 @@ class TimerNode extends UniformNode {
 
 			this.value = frame.frameId;
 
-		} else {
-
-			// global
+		} else if ( scope === TimerNode.GLOBAL ) {
 
 			this.value = frame.time * scale;
 
@@ -89,6 +86,6 @@ export default TimerNode;
 export const timerLocal = ( timeScale, value = 0 ) => nodeObject( new TimerNode( TimerNode.LOCAL, timeScale, value ) );
 export const timerGlobal = ( timeScale, value = 0 ) => nodeObject( new TimerNode( TimerNode.GLOBAL, timeScale, value ) );
 export const timerDelta = ( timeScale, value = 0 ) => nodeObject( new TimerNode( TimerNode.DELTA, timeScale, value ) );
-export const frameId = nodeImmutable( TimerNode, TimerNode.FRAME ).uint();
+export const frameId = nodeImmutable( TimerNode, TimerNode.FRAME );
 
 addNodeClass( 'TimerNode', TimerNode );

--- a/examples/jsm/nodes/utils/TriplanarTexturesNode.js
+++ b/examples/jsm/nodes/utils/TriplanarTexturesNode.js
@@ -1,11 +1,11 @@
-import Node, { addNodeClass } from '../core/Node.js';
-import { add } from '../math/OperatorNode.js';
+import TempNode from '../core/TempNode.js';
+import { addNodeClass } from '../core/Node.js';
 import { normalWorld } from '../accessors/NormalNode.js';
 import { positionWorld } from '../accessors/PositionNode.js';
 import { texture } from '../accessors/TextureNode.js';
-import { addNodeElement, nodeProxy, float, vec3 } from '../shadernode/ShaderNode.js';
+import { addNodeElement, nodeProxy, float } from '../shadernode/ShaderNode.js';
 
-class TriplanarTexturesNode extends Node {
+class TriplanarTexturesNode extends TempNode {
 
 	constructor( textureXNode, textureYNode = null, textureZNode = null, scaleNode = float( 1 ), positionNode = positionWorld, normalNode = normalWorld ) {
 
@@ -30,7 +30,7 @@ class TriplanarTexturesNode extends Node {
 
 		// Blending factor of triplanar mapping
 		let bf = normalNode.abs().normalize();
-		bf = bf.div( bf.dot( vec3( 1.0 ) ) );
+		bf = bf.div( bf.x.add( bf.y, bf.z ) );
 
 		// Triplanar mapping
 		const tx = positionNode.yz.mul( scaleNode );
@@ -46,7 +46,7 @@ class TriplanarTexturesNode extends Node {
 		const cy = texture( textureY, ty ).mul( bf.y );
 		const cz = texture( textureZ, tz ).mul( bf.z );
 
-		return add( cx, cy, cz );
+		return cx.add( cy, cz );
 
 	}
 

--- a/examples/jsm/renderers/common/Background.js
+++ b/examples/jsm/renderers/common/Background.js
@@ -1,6 +1,6 @@
 import DataMap from './DataMap.js';
 import { Color, Mesh, SphereGeometry, BackSide } from 'three';
-import { context, normalWorld, backgroundBlurriness, backgroundIntensity, NodeMaterial, modelViewProjection } from '../../nodes/Nodes.js';
+import { context, normalWorld, backgroundBlurriness, backgroundIntensity, NodeMaterial, modelViewProjection } from 'three/nodes';
 
 let _clearAlpha;
 const _clearColor = new Color();
@@ -15,7 +15,6 @@ class Background extends DataMap {
 		this.nodes = nodes;
 
 		this.backgroundMesh = null;
-		this.backgroundMeshNode = null;
 
 	}
 
@@ -44,7 +43,6 @@ class Background extends DataMap {
 		} else if ( background.isNode === true ) {
 
 			const sceneData = this.get( scene );
-			const backgroundNode = background;
 
 			_clearColor.copy( renderer._clearColor );
 			_clearAlpha = renderer._clearAlpha;
@@ -53,17 +51,10 @@ class Background extends DataMap {
 
 			if ( backgroundMesh === null ) {
 
-				this.backgroundMeshNode = context( backgroundNode, {
-					// @TODO: Add Texture2D support using node context
-					getUVNode: () => normalWorld,
-					getSamplerLevelNode: () => backgroundBlurriness
-				} ).mul( backgroundIntensity );
-
 				let viewProj = modelViewProjection();
 				viewProj = viewProj.setZ( viewProj.w );
 
 				const nodeMaterial = new NodeMaterial();
-				nodeMaterial.outputNode = this.backgroundMeshNode;
 				nodeMaterial.side = BackSide;
 				nodeMaterial.depthTest = false;
 				nodeMaterial.depthWrite = false;
@@ -81,11 +72,15 @@ class Background extends DataMap {
 
 			}
 
-			const backgroundCacheKey = backgroundNode.getCacheKey();
+			const backgroundCacheKey = background.getCacheKey();
 
 			if ( sceneData.backgroundCacheKey !== backgroundCacheKey ) {
 
-				this.backgroundMeshNode.node = backgroundNode;
+				backgroundMesh.material.colorNode = background.context( {
+					// @TODO: Add Texture2D support using node context
+					getUVNode: () => normalWorld,
+					getSamplerLevelNode: () => backgroundBlurriness
+				} ).mul( backgroundIntensity );
 
 				backgroundMesh.material.needsUpdate = true;
 

--- a/examples/jsm/renderers/common/CubeRenderTarget.js
+++ b/examples/jsm/renderers/common/CubeRenderTarget.js
@@ -1,8 +1,9 @@
 import { WebGLCubeRenderTarget, Scene, CubeCamera, BoxGeometry, Mesh, BackSide, NoBlending, LinearFilter, LinearMipmapLinearFilter } from 'three';
-import { equirectUV } from '../../nodes/utils/EquirectUVNode.js';
+
+// @TODO: fix the circular dependency in some more elegant way
 import { texture as TSL_Texture } from '../../nodes/accessors/TextureNode.js';
 import { positionWorldDirection } from '../../nodes/accessors/PositionNode.js';
-import { createNodeMaterialFromType } from '../../nodes/materials/NodeMaterial.js';
+import MeshBasicNodeMaterial from '../../nodes/materials/MeshBasicNodeMaterial.js';
 
 // @TODO: Consider rename WebGLCubeRenderTarget to just CubeRenderTarget
 
@@ -32,9 +33,9 @@ class CubeRenderTarget extends WebGLCubeRenderTarget {
 
 		const geometry = new BoxGeometry( 5, 5, 5 );
 
-		const uvNode = equirectUV( positionWorldDirection );
+		const uvNode = positionWorldDirection.equirectUV();
 
-		const material = createNodeMaterialFromType( 'MeshBasicNodeMaterial' );
+		const material = new MeshBasicNodeMaterial();
 		material.colorNode = TSL_Texture( texture, uvNode, 0 );
 		material.side = BackSide;
 		material.blending = NoBlending;

--- a/examples/jsm/renderers/common/RenderList.js
+++ b/examples/jsm/renderers/common/RenderList.js
@@ -1,4 +1,4 @@
-import { LightsNode } from '../../nodes/Nodes.js';
+import { lights } from 'three/nodes';
 
 function painterSortStable( a, b ) {
 
@@ -58,7 +58,7 @@ class RenderList {
 		this.opaque = [];
 		this.transparent = [];
 
-		this.lightsNode = new LightsNode( [] );
+		this.lightsNode = lights();
 		this.lightsArray = [];
 
 		this.occlusionQueryCount = 0;

--- a/examples/jsm/renderers/common/UniformsGroup.js
+++ b/examples/jsm/renderers/common/UniformsGroup.js
@@ -218,7 +218,7 @@ class UniformsGroup extends UniformBuffer {
 		const a = this.buffer;
 		const c = uniform.getValue();
 		const offset = uniform.offset;
-
+if(c===undefined)console.log(uniform)
 		if ( a[ offset + 0 ] !== c.r || a[ offset + 1 ] !== c.g || a[ offset + 2 ] !== c.b ) {
 
 			a[ offset + 0 ] = c.r;

--- a/examples/jsm/renderers/common/nodes/Nodes.js
+++ b/examples/jsm/renderers/common/nodes/Nodes.js
@@ -2,7 +2,7 @@ import DataMap from '../DataMap.js';
 import ChainMap from '../ChainMap.js';
 import NodeBuilderState from './NodeBuilderState.js';
 import { NoToneMapping, EquirectangularReflectionMapping, EquirectangularRefractionMapping } from 'three';
-import { NodeFrame, cubeTexture, texture, rangeFog, densityFog, reference, toneMapping, equirectUV, viewportBottomLeft, normalWorld } from '../../../nodes/Nodes.js';
+import { NodeFrame, cubeTexture, texture, rangeFog, densityFog, reference, toneMapping, equirectUV, viewportBottomLeft, normalWorld } from 'three/nodes';
 
 class Nodes extends DataMap {
 
@@ -70,9 +70,8 @@ class Nodes extends DataMap {
 		if ( object.isRenderObject ) {
 
 			const nodeBuilderState = this.get( object ).nodeBuilderState;
-			nodeBuilderState.usedTimes --;
 
-			if ( nodeBuilderState.usedTimes === 0 ) {
+			if ( nodeBuilderState !== undefined && -- nodeBuilderState.usedTimes === 0 ) {
 
 				this.nodeBuilderCache.delete( this.getForRenderCacheKey( object ) );
 

--- a/examples/jsm/renderers/webgpu/nodes/WGSLNodeFunction.js
+++ b/examples/jsm/renderers/webgpu/nodes/WGSLNodeFunction.js
@@ -1,5 +1,4 @@
-import NodeFunction from '../../../nodes/core/NodeFunction.js';
-import NodeFunctionInput from '../../../nodes/core/NodeFunctionInput.js';
+import { NodeFunction, NodeFunctionInput } from 'three/nodes';
 
 const declarationRegexp = /^[fn]*\s*([a-z_0-9]+)?\s*\(([\s\S]*?)\)\s*[\-\>]*\s*([a-z_0-9]+)?/i;
 const propertiesRegexp = /[a-z_0-9]+|<(.*?)>+/ig;
@@ -95,7 +94,7 @@ class WGSLNodeFunction extends NodeFunction {
 
 		const type = this.type !== 'void' ? '-> ' + this.type : '';
 
-		return `fn ${ name } ( ${ this.inputsCode.trim() } ) ${ type }` + this.blockCode;
+		return `fn ${ name }( ${ this.inputsCode.trim() } ) ${ type }` + this.blockCode;
 
 	}
 

--- a/examples/jsm/renderers/webgpu/nodes/WGSLNodeParser.js
+++ b/examples/jsm/renderers/webgpu/nodes/WGSLNodeParser.js
@@ -1,4 +1,4 @@
-import NodeParser from '../../../nodes/core/NodeParser.js';
+import { NodeParser } from 'three/nodes';
 import WGSLNodeFunction from './WGSLNodeFunction.js';
 
 class WGSLNodeParser extends NodeParser {

--- a/examples/jsm/renderers/webgpu/utils/WebGPUBindingUtils.js
+++ b/examples/jsm/renderers/webgpu/utils/WebGPUBindingUtils.js
@@ -127,6 +127,8 @@ class WebGPUBindingUtils {
 		const buffer = binding.buffer;
 		const bufferGPU = backend.get( binding ).buffer;
 
+		if ( bufferGPU === undefined ) return; // @TODO: why this happens?
+
 		device.queue.writeBuffer( bufferGPU, 0, buffer, 0 );
 
 	}

--- a/examples/jsm/renderers/webgpu/utils/WebGPUTextureUtils.js
+++ b/examples/jsm/renderers/webgpu/utils/WebGPUTextureUtils.js
@@ -100,7 +100,7 @@ class WebGPUTextureUtils {
 		}
 
 		if ( options.needsMipmaps === undefined ) options.needsMipmaps = false;
-		if ( options.levels === undefined ) options.levels = 1;
+		if ( options.levels === undefined || options.levels === - Infinity ) options.levels = 1; // @TODO: why -Infinity levels happen?
 		if ( options.depth === undefined ) options.depth = 1;
 
 		const { width, height, depth, levels } = options;
@@ -386,6 +386,8 @@ class WebGPUTextureUtils {
 	}
 
 	_copyImageToTexture( image, textureGPU, textureDescriptorGPU, originDepth, flipY ) {
+
+		if ( image.width === 0 || image.height === 0 ) return; // @TODO: why this happens?
 
 		const device = this.backend.device;
 

--- a/examples/webgpu_backdrop.html
+++ b/examples/webgpu_backdrop.html
@@ -75,7 +75,6 @@
 					const material = object.children[ 0 ].children[ 0 ].material;
 
 					// output material effect ( better using hsv )
-					// ignore output.sRGBToLinear().linearTosRGB() for now
 
 					material.outputNode = oscSine( timerLocal( .1 ) ).mix( output, output.add( .1 ).posterize( 4 ).mul( 2 ) );
 
@@ -121,7 +120,7 @@
 				addBackdropSphere( viewportSharedTexture().rgb.oneMinus() );
 				addBackdropSphere( viewportSharedTexture().rgb.saturation( 0 ) );
 				addBackdropSphere( viewportSharedTexture().rgb.saturation( 10 ), oscSine() );
-				addBackdropSphere( viewportSharedTexture().rgb.overlay( checker( uv().mul( 10 ) ) ) );
+				addBackdropSphere( viewportSharedTexture().rgb.temp().overlay( checker( uv().mul( 10 ) ) ) ); // @TODO: remove this .temp() after making TempNodes work with non-uniform control flows
 				addBackdropSphere( viewportSharedTexture( viewportTopLeft.mul( 40 ).floor().div( 40 ) ) );
 				addBackdropSphere( viewportSharedTexture( viewportTopLeft.mul( 80 ).floor().div( 80 ) ).add( color( 0x0033ff ) ) );
 				addBackdropSphere( vec3( 0, 0, viewportSharedTexture().b ) );

--- a/examples/webgpu_clearcoat.html
+++ b/examples/webgpu_clearcoat.html
@@ -15,7 +15,8 @@
 			{
 				"imports": {
 					"three": "../build/three.module.js",
-					"three/addons/": "./jsm/"
+					"three/addons/": "./jsm/",
+					"three/nodes": "./jsm/nodes/Nodes.js"
 				}
 			}
 		</script>

--- a/examples/webgpu_compute_particles.html
+++ b/examples/webgpu_compute_particles.html
@@ -90,9 +90,9 @@
 					const randY = instanceIndex.add( 2 ).hash();
 					const randZ = instanceIndex.add( 3 ).hash();
 
-					position.x = randX.mul( 60 ).add( - 30 );
+					position.x = randX.mul( 60 ).sub( 30 );
 					position.y = randY.mul( 10 );
-					position.z = randZ.mul( 60 ).add( - 30 );
+					position.z = randZ.mul( 60 ).sub( 30 );
 
 					color.assign( vec3( randX, randY, randZ ) );
 
@@ -105,7 +105,7 @@
 					const position = positionBuffer.element( instanceIndex );
 					const velocity = velocityBuffer.element( instanceIndex );
 
-					velocity.addAssign( vec3( 0.00, gravity, 0.00 ) );
+					velocity.y.addAssign( gravity );
 					position.addAssign( velocity );
 
 					velocity.mulAssign( friction );
@@ -115,12 +115,12 @@
 					If( position.y.lessThan( 0 ), () => {
 
 						position.y = 0;
-						velocity.y = velocity.y.negate().mul( bounce );
+						velocity.y.mulAssign( bounce.negate() );
 
 						// floor friction
 
-						velocity.x = velocity.x.mul( .9 );
-						velocity.z = velocity.z.mul( .9 );
+						velocity.x.mulAssign( .9 );
+						velocity.z.mulAssign( .9 );
 
 					} );
 

--- a/examples/webgpu_compute_points.html
+++ b/examples/webgpu_compute_points.html
@@ -24,7 +24,7 @@
 		<script type="module">
 
 			import * as THREE from 'three';
-			import { tslFn, uniform, storage, attribute, float, vec2, vec3, color, instanceIndex, PointsNodeMaterial } from 'three/nodes';
+			import { tslFn, If, uniform, storage, attribute, float, vec2, color, instanceIndex, PointsNodeMaterial } from 'three/nodes';
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 
@@ -80,17 +80,17 @@
 					const pointer = uniform( pointerVector );
 					const limit = uniform( scaleVector );
 
-					const position = particle.add( velocity ).temp();
+					const position = particle.add( velocity );
 
-					velocity.x = position.x.abs().greaterThanEqual( limit.x ).cond( velocity.x.negate(), velocity.x );
-					velocity.y = position.y.abs().greaterThanEqual( limit.y ).cond( velocity.y.negate(), velocity.y );
+					If( position.x.abs().greaterThanEqual( limit.x ), () => velocity.x.negateAssign() );
+					If( position.y.abs().greaterThanEqual( limit.y ), () => velocity.y.negateAssign() );
 
-					position.assign( position.min( limit ).max( limit.negate() ) );
+					position.clampAssign( limit.negate(), limit );
 
 					const pointerSize = 0.1;
 					const distanceFromPointer = pointer.sub( position ).length();
 
-					particle.assign( distanceFromPointer.lessThanEqual( pointerSize ).cond( vec3(), position ) );
+					If( distanceFromPointer.lessThanEqual( pointerSize ), () => particle.assign( 0 ), () => particle.assign( position ) );
 
 				} );
 
@@ -104,14 +104,11 @@
 						const particleIndex = float( instanceIndex );
 
 						const randomAngle = particleIndex.mul( .005 ).mul( Math.PI * 2 );
-						const randomSpeed = particleIndex.mul( 0.00000001 ).add( 0.0000001 );
-
-						const velX = randomAngle.sin().mul( randomSpeed );
-						const velY = randomAngle.cos().mul( randomSpeed );
+						const randomSpeed = particleIndex.add( 10 ).mul( 0.00000001 );
 
 						const velocity = velocityBufferNode.element( instanceIndex );
 
-						velocity.xy = vec2( velX, velY );
+						velocity.assign( vec2( randomAngle.sin(), randomAngle.cos() ).mul( randomSpeed ) );
 
 					} );
 

--- a/examples/webgpu_lights_custom.html
+++ b/examples/webgpu_lights_custom.html
@@ -35,7 +35,7 @@
 
 			class CustomLightingModel extends LightingModel {
 
-				direct( { lightColor, reflectedLight }, stack ) {
+				direct( { lightColor, reflectedLight } ) {
 
 					reflectedLight.directDiffuse.addAssign( lightColor );
 

--- a/examples/webgpu_lights_phong.html
+++ b/examples/webgpu_lights_phong.html
@@ -10,7 +10,7 @@
 
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - WebGPU - Phong Model Lighting<br />
-			<b style="color:red">Left: Red lights</b> - <b>Center: All lights</b> - <b style="color:blue">Right: blue light</b>
+			<b style="color:blue">Left: Blue light</b> - <b style="color:green">Center: All lights</b> - <b>Right: White light</b>
 		</div>
 
 		<script type="importmap">

--- a/examples/webgpu_lights_selective.html
+++ b/examples/webgpu_lights_selective.html
@@ -10,7 +10,7 @@
 
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - WebGPU - Selective Lights<br />
-			<b style="color:red">Left: Red lights</b> - <b>Center: All lights</b> - <b style="color:blue">Right: blue light</b>
+			<b style="color:red">Left: Red light</b> - <b>Center: All lights</b> - <b style="color:blue">Right: Blue light</b>
 		</div>
 
 		<script type="importmap">

--- a/examples/webgpu_loader_gltf.html
+++ b/examples/webgpu_loader_gltf.html
@@ -19,7 +19,8 @@
 			{
 				"imports": {
 					"three": "../build/three.module.js",
-					"three/addons/": "./jsm/"
+					"three/addons/": "./jsm/",
+					"three/nodes": "./jsm/nodes/Nodes.js"
 				}
 			}
 		</script>

--- a/examples/webgpu_loader_gltf_compressed.html
+++ b/examples/webgpu_loader_gltf_compressed.html
@@ -16,7 +16,8 @@
 			{
 				"imports": {
 					"three": "../build/three.module.js",
-					"three/addons/": "./jsm/"
+					"three/addons/": "./jsm/",
+					"three/nodes": "./jsm/nodes/Nodes.js"
 				}
 			}
 		</script>

--- a/examples/webgpu_loader_gltf_iridescence.html
+++ b/examples/webgpu_loader_gltf_iridescence.html
@@ -18,7 +18,8 @@
 			{
 				"imports": {
 					"three": "../build/three.module.js",
-					"three/addons/": "./jsm/"
+					"three/addons/": "./jsm/",
+					"three/nodes": "./jsm/nodes/Nodes.js"
 				}
 			}
 		</script>

--- a/examples/webgpu_loader_gltf_sheen.html
+++ b/examples/webgpu_loader_gltf_sheen.html
@@ -22,7 +22,8 @@
 			{
 				"imports": {
 					"three": "../build/three.module.js",
-					"three/addons/": "./jsm/"
+					"three/addons/": "./jsm/",
+					"three/nodes": "./jsm/nodes/Nodes.js"
 				}
 			}
 		</script>

--- a/examples/webgpu_video_panorama.html
+++ b/examples/webgpu_video_panorama.html
@@ -27,7 +27,8 @@
 			{
 				"imports": {
 					"three": "../build/three.module.js",
-					"three/addons/": "./jsm/"
+					"three/addons/": "./jsm/",
+					"three/nodes": "./jsm/nodes/Nodes.js"
 				}
 			}
 		</script>


### PR DESCRIPTION
## Description
Refactoring including removing some no longer needed NodeBuilder methods, some nodes and node builders clean up (e.g. using node chaining more, simplifying some code paths, fixing some methods signatures to be more consistent, cleaning up the flows algorithm), and fixes of a few potential and current bugs (including cases when a TempNode, which was used more than once was generated more than once, or when it was possible to generate something like `mix( abc, def, ghi ).xyz = somethingElse` -- both these issues could happen in a quite a number of cases -- it's still not *perfect* now, but hopefully should become so with another PR unifying Node and TempNode). Also this cleans up the resulting shader code in quite a lot of cases (mostly by adding `NodeBuilder.formatOperation()` method; the refactoring of TextureNode also helps).

This PR mostly only cleans the nodes/ directory, not touching renderers or node examples (they can be cleaned up in a separate PR).

Unfortunately there seems to be a VERY strange bug with normal maps, of which I have no idea what it is caused by. You can see it as a "blockiness" on the fibers ball in the webgpu_clearcoat example.
If you replace the code for the fibers ball with the following it becomes easier to see:
```
const normalMap5 = textureLoader.load( 'textures/uv_grid_opengl.jpg' );
normalMap5.wrapS = THREE.RepeatWrapping;
normalMap5.wrapT = THREE.RepeatWrapping;
normalMap5.repeat.x = 10;
normalMap5.repeat.y = 10;

material = new THREE.MeshStandardMaterial( {
	normalMap: normalMap
} );
mesh = new THREE.Mesh( geometry, material );
mesh.position.x = 1;
mesh.position.y = 1;
group.add( mesh );

material = new THREE.MeshStandardMaterial( {
	map: normalMap5
} );
mesh = new THREE.Mesh( geometry, material );
mesh.position.x = 1;
mesh.position.y = 3;
group.add( mesh );

material = new THREE.MeshStandardMaterial( {
	map: normalMap
} );
mesh = new THREE.Mesh( geometry, material );
mesh.position.x = 3;
mesh.position.y = 1;
group.add( mesh );

material = new THREE.MeshStandardMaterial( {
	normalMap: normalMap5
} );
mesh = new THREE.Mesh( geometry, material );
mesh.position.x = 3;
mesh.position.y = 3;
group.add( mesh );
```
You can see that the first ball has a blocky-like map (instead of the correct "meridians"-like) and the last ball has just a flat map, whilst it should be visible as having large cavities.
The most interesting part is that (at least on my machine) if you try to move the camera (by move+rotate or zooming in) so that only one of these two balls is visible, then somewhere along that path both balls magically autofixes (this happens in 100% of time). Even more interestingly, if two other new balls are removed -- this no longer happens, the bug still occurs and no longer fixes.
I have no idea why this happens -- but I'm very sure this is not a bug in this PR but rather maybe some WebGPU bug -- I checked the original and the new vertex and fragment shaders and they are 100% the same in terms of functionality.

The PR is tested on all WGSL examples that were at the moment of its creation and all GLSL examples that worked at the moment of its creation.

(I've spent about 2.5 months working on this PR... Sorry that it has so much changes combined together, I will try to split it into smaller PRs if requested -- or will just rebase it on the latest dev if it's OK to merge as this is)