### PR TITLE
WebGPURenderer: cache renderPassDesciptors and associated views.

### DIFF
--- a/examples/jsm/renderers/common/Renderer.js
+++ b/examples/jsm/renderers/common/Renderer.js
@@ -266,9 +266,6 @@ class Renderer {
 		renderContext.scissorValue.width >>= activeMipmapLevel;
 		renderContext.scissorValue.height >>= activeMipmapLevel;
 
-		renderContext.depth = this.depth;
-		renderContext.stencil = this.stencil;
-
 		//
 
 		sceneRef.onBeforeRender( this, scene, camera, renderTarget );
@@ -304,6 +301,8 @@ class Renderer {
 			renderContext.width = renderTargetData.width;
 			renderContext.height = renderTargetData.height;
 			renderContext.renderTarget = renderTarget;
+			renderContext.depth = renderTarget.depthBuffer;
+			renderContext.stencil = renderTarget.stencilBuffer;
 
 		} else {
 
@@ -311,6 +310,8 @@ class Renderer {
 			renderContext.depthTexture = null;
 			renderContext.width = this.domElement.width;
 			renderContext.height = this.domElement.height;
+			renderContext.depth = this.depth;
+			renderContext.stencil = this.stencil;
 
 		}
 

--- a/examples/jsm/renderers/common/Textures.js
+++ b/examples/jsm/renderers/common/Textures.js
@@ -1,6 +1,6 @@
 import DataMap from './DataMap.js';
 
-import { Vector3, DepthTexture, DepthStencilFormat, UnsignedInt248Type, LinearFilter, NearestFilter, EquirectangularReflectionMapping, EquirectangularRefractionMapping, CubeReflectionMapping, CubeRefractionMapping } from 'three';
+import { Vector3, DepthTexture, DepthStencilFormat, DepthFormat, UnsignedIntType, UnsignedInt248Type, LinearFilter, NearestFilter, EquirectangularReflectionMapping, EquirectangularRefractionMapping, CubeReflectionMapping, CubeRefractionMapping } from 'three';
 
 const _size = new Vector3();
 
@@ -47,8 +47,8 @@ class Textures extends DataMap {
 		if ( depthTexture === undefined ) {
 
 			depthTexture = new DepthTexture();
-			depthTexture.format = DepthStencilFormat;
-			depthTexture.type = UnsignedInt248Type;
+			depthTexture.format = renderTarget.stencilBuffer ? DepthStencilFormat : DepthFormat;
+			depthTexture.type = renderTarget.stencilBuffer ? UnsignedInt248Type : UnsignedIntType;
 			depthTexture.image.width = mipWidth;
 			depthTexture.image.height = mipHeight;
 

--- a/examples/jsm/renderers/webgpu/WebGPUBackend.js
+++ b/examples/jsm/renderers/webgpu/WebGPUBackend.js
@@ -266,7 +266,7 @@ class WebGPUBackend extends Backend {
 
 			const depthStencilAttachment = {
 				view: depthTextureData.texture.createView(),
-			}
+			};
 
 			if ( renderContext.stencil && renderContext.depthTexture.format === DepthFormat ) {
 

--- a/examples/jsm/renderers/webgpu/WebGPUBackend.js
+++ b/examples/jsm/renderers/webgpu/WebGPUBackend.js
@@ -211,7 +211,11 @@ class WebGPUBackend extends Backend {
 
 		}
 
-		if ( renderTargetData.width !== renderTarget.width || renderTargetData.height !== renderTarget.height || renderTargetData.activeMipmapLevel !== renderTarget.activeMipmapLevel ) {
+		if ( renderTargetData.width !== renderTarget.width ||
+			renderTargetData.height !== renderTarget.height ||
+			renderTargetData.activeMipmapLevel !== renderTarget.activeMipmapLevel ||
+			renderTargetData.samples !== renderTarget.samples
+		) {
 
 			descriptors.length = 0;
 
@@ -279,6 +283,7 @@ class WebGPUBackend extends Backend {
 
 			renderTargetData.width = renderTarget.width;
 			renderTargetData.height = renderTarget.height;
+			renderTargetData.samples = renderTarget.samples;
 			renderTargetData.activeMipmapLevel = renderTarget.activeMipmapLevel;
 
 		}


### PR DESCRIPTION
For the default null renderTarget cache descriptor, depth texture view and msaa texture view where appropriate.
For non null targets, use the renderTarget as a key for caching renderPassDescriptors to reduce per pass object creation .

The default descriptor members could be reused in the clear() method.
