### PR TITLE
WebGPURenderer: Add Offscreen Support

### DIFF
--- a/examples/jsm/capabilities/WebGPU.js
+++ b/examples/jsm/capabilities/WebGPU.js
@@ -4,36 +4,28 @@ if ( self.GPUShaderStage === undefined ) {
 
 }
 
+// statics
+
+let isAvailable = navigator.gpu !== undefined;
+
+
+if ( typeof window !== 'undefined' && isAvailable ) {
+
+	isAvailable = await navigator.gpu.requestAdapter();
+
+}
+
 class WebGPU {
 
 	static isAvailable() {
 
-		return navigator.gpu !== undefined;
-
-	}
-
-
-	static async requestStaticAdapter() {
-
-		if ( navigator.gpu ) {
-
-			return await navigator.gpu.requestAdapter();
-
-		}
-
-		return false;
+		return isAvailable;
 
 	}
 
 	static async getStaticAdapter() {
 
-		if ( this._adapterPromise === undefined ) {
-
-			this._adapterPromise = WebGPU.requestStaticAdapter();
-
-		}
-
-		return await this._adapterPromise;
+		return await isAvailable;
 
 	}
 
@@ -61,8 +53,5 @@ class WebGPU {
 
 }
 
-// Initialize static properties.
-
-WebGPU.getStaticAdapter();
 
 export default WebGPU;

--- a/examples/jsm/capabilities/WebGPU.js
+++ b/examples/jsm/capabilities/WebGPU.js
@@ -4,29 +4,55 @@ if ( self.GPUShaderStage === undefined ) {
 
 }
 
-let isAvailable = false;
+class WebGPU {
 
-( async () => {
+	static async checkAvailability() {
 
-	if ( navigator.gpu !== undefined ) {
+		if ( navigator.gpu ) {
 
-		const adapter = await navigator.gpu.requestAdapter();
-
-		if ( adapter !== null ) {
-
-			isAvailable = true;
+			const adapter = await navigator.gpu.requestAdapter();
+			return adapter !== null;
 
 		}
 
+		return false;
+
 	}
 
-} )();
+	static async isAvailable() {
 
-class WebGPU {
+		if ( this._isAvailablePromise === undefined ) {
 
-	static isAvailable() {
+			this._isAvailablePromise = WebGPU.checkAvailability();
 
-		return isAvailable;
+		}
+
+		return await this._isAvailablePromise;
+
+	}
+
+
+	static async requestStaticAdapter() {
+
+		if ( navigator.gpu ) {
+
+			return await navigator.gpu.requestAdapter();
+
+		}
+
+		return false;
+
+	}
+
+	static async getStaticAdapter() {
+
+		if ( this._adapterPromise === undefined ) {
+
+			this._adapterPromise = WebGPU.requestStaticAdapter();
+
+		}
+
+		return await this._adapterPromise;
 
 	}
 
@@ -53,5 +79,10 @@ class WebGPU {
 	}
 
 }
+
+// Initialize static properties.
+
+WebGPU.isAvailable();
+WebGPU.getStaticAdapter();
 
 export default WebGPU;

--- a/examples/jsm/capabilities/WebGPU.js
+++ b/examples/jsm/capabilities/WebGPU.js
@@ -19,13 +19,13 @@ class WebGPU {
 
 	static isAvailable() {
 
-		return isAvailable;
+		return Boolean( isAvailable );
 
 	}
 
-	static async getStaticAdapter() {
+	static getStaticAdapter() {
 
-		return await isAvailable;
+		return isAvailable;
 
 	}
 

--- a/examples/jsm/capabilities/WebGPU.js
+++ b/examples/jsm/capabilities/WebGPU.js
@@ -1,22 +1,26 @@
-if ( window.GPUShaderStage === undefined ) {
+if ( self.GPUShaderStage === undefined ) {
 
-	window.GPUShaderStage = { VERTEX: 1, FRAGMENT: 2, COMPUTE: 4 };
+	self.GPUShaderStage = { VERTEX: 1, FRAGMENT: 2, COMPUTE: 4 };
 
 }
 
 let isAvailable = false;
 
-if ( navigator.gpu !== undefined ) {
+( async () => {
 
-	const adapter = await navigator.gpu.requestAdapter();
+	if ( navigator.gpu !== undefined ) {
 
-	if ( adapter !== null ) {
+		const adapter = await navigator.gpu.requestAdapter();
 
-		isAvailable = true;
+		if ( adapter !== null ) {
+
+			isAvailable = true;
+
+		}
 
 	}
 
-}
+} )();
 
 class WebGPU {
 

--- a/examples/jsm/capabilities/WebGPU.js
+++ b/examples/jsm/capabilities/WebGPU.js
@@ -6,28 +6,9 @@ if ( self.GPUShaderStage === undefined ) {
 
 class WebGPU {
 
-	static async checkAvailability() {
+	static isAvailable() {
 
-		if ( navigator.gpu ) {
-
-			const adapter = await navigator.gpu.requestAdapter();
-			return adapter !== null;
-
-		}
-
-		return false;
-
-	}
-
-	static async isAvailable() {
-
-		if ( this._isAvailablePromise === undefined ) {
-
-			this._isAvailablePromise = WebGPU.checkAvailability();
-
-		}
-
-		return await this._isAvailablePromise;
+		return navigator.gpu !== undefined;
 
 	}
 
@@ -82,7 +63,6 @@ class WebGPU {
 
 // Initialize static properties.
 
-WebGPU.isAvailable();
 WebGPU.getStaticAdapter();
 
 export default WebGPU;

--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -120,18 +120,26 @@ class KTX2Loader extends Loader {
 
 	}
 
-	async detectSupport( renderer ) {
+	async detectSupportAsync( renderer ) {
+
+		this.workerConfig = {
+			astcSupported: await renderer.hasFeature( 'texture-compression-astc' ),
+			etc1Supported: await renderer.hasFeature( 'texture-compression-etc1' ),
+			etc2Supported: await renderer.hasFeature( 'texture-compression-etc2' ),
+			dxtSupported: await renderer.hasFeature( 'texture-compression-bc' ),
+			bptcSupported: await renderer.hasFeature( 'texture-compression-bptc' ),
+			pvrtcSupported: await renderer.hasFeature( 'texture-compression-pvrtc' )
+		};
+
+		return this;
+
+	}
+
+	detectSupport( renderer ) {
 
 		if ( renderer.isWebGPURenderer === true ) {
 
-			this.workerConfig = {
-				astcSupported: await renderer.hasFeature( 'texture-compression-astc' ),
-				etc1Supported: await renderer.hasFeature( 'texture-compression-etc1' ),
-				etc2Supported: await renderer.hasFeature( 'texture-compression-etc2' ),
-				dxtSupported: await renderer.hasFeature( 'texture-compression-bc' ),
-				bptcSupported: await renderer.hasFeature( 'texture-compression-bptc' ),
-				pvrtcSupported: await renderer.hasFeature( 'texture-compression-pvrtc' )
-			};
+			this.detectSupportAsync( renderer );
 
 		} else {
 

--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -123,12 +123,12 @@ class KTX2Loader extends Loader {
 	async detectSupportAsync( renderer ) {
 
 		this.workerConfig = {
-			astcSupported: await renderer.hasFeature( 'texture-compression-astc' ),
-			etc1Supported: await renderer.hasFeature( 'texture-compression-etc1' ),
-			etc2Supported: await renderer.hasFeature( 'texture-compression-etc2' ),
-			dxtSupported: await renderer.hasFeature( 'texture-compression-bc' ),
-			bptcSupported: await renderer.hasFeature( 'texture-compression-bptc' ),
-			pvrtcSupported: await renderer.hasFeature( 'texture-compression-pvrtc' )
+			astcSupported: await renderer.hasFeatureAsync( 'texture-compression-astc' ),
+			etc1Supported: await renderer.hasFeatureAsync( 'texture-compression-etc1' ),
+			etc2Supported: await renderer.hasFeatureAsync( 'texture-compression-etc2' ),
+			dxtSupported: await renderer.hasFeatureAsync( 'texture-compression-bc' ),
+			bptcSupported: await renderer.hasFeatureAsync( 'texture-compression-bptc' ),
+			pvrtcSupported: await renderer.hasFeatureAsync( 'texture-compression-pvrtc' )
 		};
 
 		return this;
@@ -139,7 +139,17 @@ class KTX2Loader extends Loader {
 
 		if ( renderer.isWebGPURenderer === true ) {
 
-			return this.detectSupportAsync( renderer );
+			console.warn( 'THREE.KTX2Loader.detectSupport: For the WebGPURenderer use detectSupportAsync instead.' );
+
+			this.workerConfig = {
+				astcSupported: renderer.hasFeature( 'texture-compression-astc' ),
+				etc1Supported: renderer.hasFeature( 'texture-compression-etc1' ),
+				etc2Supported: renderer.hasFeature( 'texture-compression-etc2' ),
+				dxtSupported: renderer.hasFeature( 'texture-compression-bc' ),
+				bptcSupported: renderer.hasFeature( 'texture-compression-bptc' ),
+				pvrtcSupported: renderer.hasFeature( 'texture-compression-pvrtc' )
+			};
+
 
 		} else {
 

--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -139,8 +139,6 @@ class KTX2Loader extends Loader {
 
 		if ( renderer.isWebGPURenderer === true ) {
 
-			console.warn( 'THREE.KTX2Loader.detectSupport: For the WebGPURenderer use detectSupportAsync instead.' );
-
 			this.workerConfig = {
 				astcSupported: renderer.hasFeature( 'texture-compression-astc' ),
 				etc1Supported: renderer.hasFeature( 'texture-compression-etc1' ),
@@ -149,7 +147,6 @@ class KTX2Loader extends Loader {
 				bptcSupported: renderer.hasFeature( 'texture-compression-bptc' ),
 				pvrtcSupported: renderer.hasFeature( 'texture-compression-pvrtc' )
 			};
-
 
 		} else {
 

--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -120,17 +120,17 @@ class KTX2Loader extends Loader {
 
 	}
 
-	detectSupport( renderer ) {
+	async detectSupport( renderer ) {
 
 		if ( renderer.isWebGPURenderer === true ) {
 
 			this.workerConfig = {
-				astcSupported: renderer.hasFeature( 'texture-compression-astc' ),
-				etc1Supported: renderer.hasFeature( 'texture-compression-etc1' ),
-				etc2Supported: renderer.hasFeature( 'texture-compression-etc2' ),
-				dxtSupported: renderer.hasFeature( 'texture-compression-bc' ),
-				bptcSupported: renderer.hasFeature( 'texture-compression-bptc' ),
-				pvrtcSupported: renderer.hasFeature( 'texture-compression-pvrtc' )
+				astcSupported: await renderer.hasFeature( 'texture-compression-astc' ),
+				etc1Supported: await renderer.hasFeature( 'texture-compression-etc1' ),
+				etc2Supported: await renderer.hasFeature( 'texture-compression-etc2' ),
+				dxtSupported: await renderer.hasFeature( 'texture-compression-bc' ),
+				bptcSupported: await renderer.hasFeature( 'texture-compression-bptc' ),
+				pvrtcSupported: await renderer.hasFeature( 'texture-compression-pvrtc' )
 			};
 
 		} else {

--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -139,7 +139,7 @@ class KTX2Loader extends Loader {
 
 		if ( renderer.isWebGPURenderer === true ) {
 
-			this.detectSupportAsync( renderer );
+			return this.detectSupportAsync( renderer );
 
 		} else {
 

--- a/examples/jsm/renderers/common/Backend.js
+++ b/examples/jsm/renderers/common/Backend.js
@@ -90,6 +90,8 @@ class Backend {
 
 	// utils
 
+	hasFeatureAsync( name ) { } // return Boolean
+
 	hasFeature( name ) { } // return Boolean
 
 	getInstanceCount( renderObject ) {

--- a/examples/jsm/renderers/common/Renderer.js
+++ b/examples/jsm/renderers/common/Renderer.js
@@ -770,6 +770,12 @@ class Renderer {
 
 	}
 
+	hasFeatureAsync( name ) {
+
+		return this.backend.hasFeatureAsync( name );
+
+	}
+
 	hasFeature( name ) {
 
 		return this.backend.hasFeature( name );

--- a/examples/jsm/renderers/webgl/WebGLBackend.js
+++ b/examples/jsm/renderers/webgl/WebGLBackend.js
@@ -837,6 +837,12 @@ class WebGLBackend extends Backend {
 
 	}
 
+	async hasFeatureAsync( name ) {
+
+		return this.hasFeature( name );
+
+	}
+
 	hasFeature( name ) {
 
 		const keysMatching = Object.keys( GLFeatureName ).filter( key => GLFeatureName[ key ] === name );

--- a/examples/jsm/renderers/webgpu/WebGPUBackend.js
+++ b/examples/jsm/renderers/webgpu/WebGPUBackend.js
@@ -19,11 +19,15 @@ import WebGPUTextureUtils from './utils/WebGPUTextureUtils.js';
 
 let _staticAdapter = null;
 
-if ( navigator.gpu !== undefined ) {
+( async () => {
 
-	_staticAdapter = await navigator.gpu.requestAdapter();
+	if ( navigator.gpu !== undefined ) {
 
-}
+		_staticAdapter = await navigator.gpu.requestAdapter();
+
+	}
+
+} )();
 
 //
 

--- a/examples/jsm/renderers/webgpu/WebGPUBackend.js
+++ b/examples/jsm/renderers/webgpu/WebGPUBackend.js
@@ -1061,14 +1061,28 @@ class WebGPUBackend extends Backend {
 		return 16;
 
 	}
-
-	async hasFeature( name ) {
+		
+	async hasFeatureAsync( name ) {
 
 		const adapter = this.adapter || await WebGPU.getStaticAdapter();
 
 		//
 
 		return adapter.features.has( name );
+
+	}
+
+	hasFeature( name ) {
+
+		if ( !this.adapter ) {
+
+			console.warn( 'WebGPUBackend: WebGPU adapter has not been initialized yet. Please use detectSupportAsync instead' );
+
+			return true;
+
+		}
+
+		return this.adapter.features.has( name );
 
 	}
 

--- a/examples/jsm/renderers/webgpu/WebGPUBackend.js
+++ b/examples/jsm/renderers/webgpu/WebGPUBackend.js
@@ -1078,7 +1078,7 @@ class WebGPUBackend extends Backend {
 
 			console.warn( 'WebGPUBackend: WebGPU adapter has not been initialized yet. Please use detectSupportAsync instead' );
 
-			return true;
+			return false;
 
 		}
 

--- a/examples/jsm/renderers/webgpu/WebGPUBackend.js
+++ b/examples/jsm/renderers/webgpu/WebGPUBackend.js
@@ -14,20 +14,7 @@ import WebGPUAttributeUtils from './utils/WebGPUAttributeUtils.js';
 import WebGPUBindingUtils from './utils/WebGPUBindingUtils.js';
 import WebGPUPipelineUtils from './utils/WebGPUPipelineUtils.js';
 import WebGPUTextureUtils from './utils/WebGPUTextureUtils.js';
-
-// statics
-
-let _staticAdapter = null;
-
-( async () => {
-
-	if ( navigator.gpu !== undefined ) {
-
-		_staticAdapter = await navigator.gpu.requestAdapter();
-
-	}
-
-} )();
+import WebGPU from '../../capabilities/WebGPU.js';
 
 //
 
@@ -1075,9 +1062,9 @@ class WebGPUBackend extends Backend {
 
 	}
 
-	hasFeature( name ) {
+	async hasFeature( name ) {
 
-		const adapter = this.adapter || _staticAdapter;
+		const adapter = this.adapter || await WebGPU.getStaticAdapter();
 
 		//
 

--- a/examples/jsm/renderers/webgpu/WebGPURenderer.js
+++ b/examples/jsm/renderers/webgpu/WebGPURenderer.js
@@ -23,7 +23,7 @@ class WebGPURenderer extends Renderer {
 
 		let BackendClass;
 
-		if ( WebGPU.isAvailable() ) {
+		if ( navigator.gpu ) {
 
 			BackendClass = WebGPUBackend;
 

--- a/examples/jsm/renderers/webgpu/WebGPURenderer.js
+++ b/examples/jsm/renderers/webgpu/WebGPURenderer.js
@@ -23,7 +23,7 @@ class WebGPURenderer extends Renderer {
 
 		let BackendClass;
 
-		if ( navigator.gpu ) {
+		if ( WebGPU.isAvailable() ) {
 
 			BackendClass = WebGPUBackend;
 

--- a/examples/jsm/renderers/webgpu/WebGPURenderer.js
+++ b/examples/jsm/renderers/webgpu/WebGPURenderer.js
@@ -1,7 +1,8 @@
+import WebGPU from '../../capabilities/WebGPU.js';
+
 import Renderer from '../common/Renderer.js';
 import WebGLBackend from '../webgl/WebGLBackend.js';
 import WebGPUBackend from './WebGPUBackend.js';
-import WebGPU from '../../capabilities/WebGPU.js';
 /*
 const debugHandler = {
 

--- a/examples/jsm/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/examples/jsm/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -16,7 +16,7 @@ import { getFormat } from '../utils/WebGPUTextureUtils.js';
 import WGSLNodeParser from './WGSLNodeParser.js';
 
 // GPUShaderStage is not defined in browsers not supporting WebGPU
-const GPUShaderStage = window.GPUShaderStage;
+const GPUShaderStage = self.GPUShaderStage;
 
 const gpuShaderStageLib = {
 	'vertex': GPUShaderStage ? GPUShaderStage.VERTEX : 1,

--- a/examples/webgpu_instance_mesh.html
+++ b/examples/webgpu_instance_mesh.html
@@ -44,7 +44,7 @@
 
 			init();
 
-			function init() {
+			async function init() {
 
 				if ( WebGPU.isAvailable() === false && WebGL.isWebGL2Available() === false ) {
 
@@ -87,7 +87,7 @@
 
 				//
 
-				renderer = new WebGPURenderer( { antialias: true } );
+				renderer = await new WebGPURenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setAnimationLoop( animate );

--- a/examples/webgpu_instance_mesh.html
+++ b/examples/webgpu_instance_mesh.html
@@ -87,7 +87,7 @@
 
 				//
 
-				renderer = await new WebGPURenderer( { antialias: true } );
+				renderer = new WebGPURenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setAnimationLoop( animate );

--- a/examples/webgpu_loader_gltf_compressed.html
+++ b/examples/webgpu_loader_gltf_compressed.html
@@ -69,7 +69,7 @@
 
 				const ktx2Loader = await new KTX2Loader()
 					.setTranscoderPath( 'jsm/libs/basis/' )
-					.detectSupport( renderer );
+					.detectSupportAsync( renderer );
 
 				const loader = new GLTFLoader();
 				loader.setKTX2Loader( ktx2Loader );

--- a/examples/webgpu_loader_gltf_compressed.html
+++ b/examples/webgpu_loader_gltf_compressed.html
@@ -67,7 +67,7 @@
 				controls.maxDistance = 6;
 				controls.update();
 
-				const ktx2Loader = new KTX2Loader()
+				const ktx2Loader = await new KTX2Loader()
 					.setTranscoderPath( 'jsm/libs/basis/' )
 					.detectSupport( renderer );
 

--- a/examples/webgpu_morphtargets_face.html
+++ b/examples/webgpu_morphtargets_face.html
@@ -81,7 +81,7 @@
 
 				const ktx2Loader = await new KTX2Loader()
 					.setTranscoderPath( 'jsm/libs/basis/' )
-					.detectSupport( renderer );
+					.detectSupportAsync( renderer );
 
 				new GLTFLoader()
 					.setKTX2Loader( ktx2Loader )

--- a/examples/webgpu_morphtargets_face.html
+++ b/examples/webgpu_morphtargets_face.html
@@ -48,7 +48,7 @@
 
 			init();
 
-			function init() {
+			async function init() {
 
 				if ( WebGPU.isAvailable() === false && WebGL.isWebGL2Available() === false ) {
 
@@ -79,7 +79,7 @@
 
 				container.appendChild( renderer.domElement );
 
-				const ktx2Loader = new KTX2Loader()
+				const ktx2Loader = await new KTX2Loader()
 					.setTranscoderPath( 'jsm/libs/basis/' )
 					.detectSupport( renderer );
 

--- a/examples/webgpu_sandbox.html
+++ b/examples/webgpu_sandbox.html
@@ -76,7 +76,7 @@
 
 				const ktxLoader = await new KTX2Loader()
 					.setTranscoderPath( 'jsm/libs/basis/' )
-					.detectSupport( renderer );
+					.detectSupportAsync( renderer );
 
 				const ktxTexture = await ktxLoader.loadAsync( './textures/compressed/sample_uastc_zstd.ktx2' );
 

--- a/examples/webgpu_sandbox.html
+++ b/examples/webgpu_sandbox.html
@@ -74,7 +74,7 @@
 				textureDisplace.wrapS = THREE.RepeatWrapping;
 				textureDisplace.wrapT = THREE.RepeatWrapping;
 
-				const ktxLoader = new KTX2Loader()
+				const ktxLoader = await new KTX2Loader()
 					.setTranscoderPath( 'jsm/libs/basis/' )
 					.detectSupport( renderer );
 


### PR DESCRIPTION
This PR fix the use of the `WebGPURenderer` in a worker context.


A small issue is that the WebGPURenderer is intricately tied to direct imports from 'three' making it complex to create an example without changing the configuration of the project.
Web browsers do not currently support the importmap feature in worker contexts. Alternatives would be to update the rollup configuration or use relatives paths. (`Uncaught (in promise) TypeError: Failed to resolve module specifier "three". Relative references must start with either "/", "./", or "../".`)

I tested on my local with another project on both backends and it works fine.

_This contribution is funded by [Utsubo](https://utsubo.com/)_