### PR TITLE
OrbitControls: Fix offscreen and cleanup

### DIFF
--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -1228,7 +1228,7 @@ class OrbitControls extends EventDispatcher {
 				clientX: event.clientX,
 				clientY: event.clientY,
 				deltaY: event.deltaY,
-			}
+			};
 
 			switch ( mode ) {
 
@@ -1243,7 +1243,7 @@ class OrbitControls extends EventDispatcher {
 			}
 
 			// detect if event was triggered by pinching
-			if ( event.ctrlKey && !controlActive ) {
+			if ( event.ctrlKey && ! controlActive ) {
 
 				newEvent.deltaY *= 10;
 
@@ -1255,11 +1255,11 @@ class OrbitControls extends EventDispatcher {
 
 		function interceptControlDown( event ) {
 
-			if ( event.key === "Control" ) {
+			if ( event.key === 'Control' ) {
 
 				controlActive = true;
-				
-				document.addEventListener('keyup', interceptControlUp, { passive: true, capture: true });
+
+				scope.domElement.addEventListener( 'keyup', interceptControlUp, { passive: true, capture: true } );
 
 			}
 
@@ -1267,11 +1267,11 @@ class OrbitControls extends EventDispatcher {
 
 		function interceptControlUp( event ) {
 
-			if ( event.key === "Control" ) {
+			if ( event.key === 'Control' ) {
 
 				controlActive = false;
-				
-				document.removeEventListener('keyup', interceptControlUp, { passive: true, capture: true });
+
+				scope.domElement.removeEventListener( 'keyup', interceptControlUp, { passive: true, capture: true } );
 
 			}
 
@@ -1485,7 +1485,7 @@ class OrbitControls extends EventDispatcher {
 		scope.domElement.addEventListener( 'pointercancel', onPointerUp );
 		scope.domElement.addEventListener( 'wheel', onMouseWheel, { passive: false } );
 
-		document.addEventListener( 'keydown', interceptControlDown, { passive: true, capture: true } );
+		scope.domElement.addEventListener( 'keydown', interceptControlDown, { passive: true, capture: true } );
 
 		// force an update at start
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -1259,13 +1259,10 @@ class OrbitControls extends EventDispatcher {
 
 				controlActive = true;
 
-				if ( typeof scope.domElement.getRootNode === 'function' ) {
 
-					const document = scope.domElement.getRootNode();
+				const document = scope.domElement.getRootNode(); // offscreen canvas compatibility
 
-					document.addEventListener( 'keyup', interceptControlUp, { passive: true, capture: true } );
-
-				}
+				document.addEventListener( 'keyup', interceptControlUp, { passive: true, capture: true } );
 
 			}
 
@@ -1277,13 +1274,10 @@ class OrbitControls extends EventDispatcher {
 
 				controlActive = false;
 
-				if ( typeof scope.domElement.getRootNode === 'function' ) {
 
-					const document = scope.domElement.getRootNode();
+				const document = scope.domElement.getRootNode(); // offscreen canvas compatibility
 
-					document.removeEventListener( 'keyup', interceptControlUp, { passive: true, capture: true } );
-
-				}
+				document.removeEventListener( 'keyup', interceptControlUp, { passive: true, capture: true } );
 
 			}
 
@@ -1497,14 +1491,9 @@ class OrbitControls extends EventDispatcher {
 		scope.domElement.addEventListener( 'pointercancel', onPointerUp );
 		scope.domElement.addEventListener( 'wheel', onMouseWheel, { passive: false } );
 
+		const document = scope.domElement.getRootNode(); // offscreen canvas compatibility
 
-		if ( typeof scope.domElement.getRootNode === 'function' ) {
-
-			const document = scope.domElement.getRootNode();
-
-			document.addEventListener( 'keydown', interceptControlDown, { passive: true, capture: true } );
-
-		}
+		document.addEventListener( 'keydown', interceptControlDown, { passive: true, capture: true } );
 
 		// force an update at start
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -1259,7 +1259,13 @@ class OrbitControls extends EventDispatcher {
 
 				controlActive = true;
 
-				scope.domElement.addEventListener( 'keyup', interceptControlUp, { passive: true, capture: true } );
+				if ( typeof scope.domElement.getRootNode === 'function' ) {
+
+					const document = scope.domElement.getRootNode();
+
+					document.addEventListener( 'keyup', interceptControlUp, { passive: true, capture: true } );
+
+				}
 
 			}
 
@@ -1271,7 +1277,13 @@ class OrbitControls extends EventDispatcher {
 
 				controlActive = false;
 
-				scope.domElement.removeEventListener( 'keyup', interceptControlUp, { passive: true, capture: true } );
+				if ( typeof scope.domElement.getRootNode === 'function' ) {
+
+					const document = scope.domElement.getRootNode();
+
+					document.removeEventListener( 'keyup', interceptControlUp, { passive: true, capture: true } );
+
+				}
 
 			}
 
@@ -1485,7 +1497,14 @@ class OrbitControls extends EventDispatcher {
 		scope.domElement.addEventListener( 'pointercancel', onPointerUp );
 		scope.domElement.addEventListener( 'wheel', onMouseWheel, { passive: false } );
 
-		scope.domElement.addEventListener( 'keydown', interceptControlDown, { passive: true, capture: true } );
+
+		if ( typeof scope.domElement.getRootNode === 'function' ) {
+
+			const document = scope.domElement.getRootNode();
+
+			document.addEventListener( 'keydown', interceptControlDown, { passive: true, capture: true } );
+
+		}
 
 		// force an update at start
 


### PR DESCRIPTION
#27446 broke the offscreen canvas support (yes it is possible to use controls such as OrbitControls in workers by using virtual dom elements).

Also code syntax wasn't correct so I cleaned up the file to align with the lint rules.

_This contribution is funded by [Utsubo](https://utsubo.com/)_