### PR TITLE
Object3D.traverse added parameter - breakout of callback loop

### DIFF
--- a/docs/api/en/core/Object3D.html
+++ b/docs/api/en/core/Object3D.html
@@ -548,10 +548,10 @@
 		<h3>[method:this translateZ]( [param:Float distance] )</h3>
 		<p>Translates object along z axis in object space by `distance` units.</p>
 
-		<h3>[method:undefined traverse]( [param:Function callback] )</h3>
+		<h3>[method:undefined traverse]( [param:Function callback], [param:Boolean cancellable] )</h3>
 		<p>
 			callback - A function with as first argument an object3D object.<br /><br />
-
+			cancellable - if true, traverse can be ended early by placing 'return true' within callback function.
 			Executes the callback on this object and all descendants.<br />
 			Note: Modifying the scene graph inside the callback is discouraged.
 		</p>

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -519,14 +519,14 @@ class Object3D extends EventDispatcher {
 
 	traverse( callback, cancellable ) {
 
-		if(callback( this ) && cancellable)
+		if ( callback( this ) && cancellable )
 			return;
 
 		const children = this.children;
 
 		for ( let i = 0, l = children.length; i < l; i ++ ) {
 
-			if(children[ i ].traverse( callback ) && cancellable)
+			if ( children[ i ].traverse( callback ) && cancellable )
 				return;
 
 		}

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -517,15 +517,17 @@ class Object3D extends EventDispatcher {
 
 	raycast( /* raycaster, intersects */ ) {}
 
-	traverse( callback ) {
+	traverse( callback, cancellable ) {
 
-		callback( this );
+		if(callback( this ) && cancellable)
+			return;
 
 		const children = this.children;
 
 		for ( let i = 0, l = children.length; i < l; i ++ ) {
 
-			children[ i ].traverse( callback );
+			if(children[ i ].traverse( callback ) && cancellable)
+				return;
 
 		}
 


### PR DESCRIPTION
Object3D.traverse added parameter - breakout of callback loop

Related issue: #XXXX

**Description**
Adds a parameter to Object3D.traverse where one can 'return true' from inside the callback to end traverse early.  Helpful for objects with large hierarchies or when the callback is time-consuming.