### PR TITLE
Nodes: TSL Support `return`, `continue` and `break`

### DIFF
--- a/examples/jsm/nodes/Nodes.js
+++ b/examples/jsm/nodes/Nodes.js
@@ -54,6 +54,8 @@ export { default as EquirectUVNode, equirectUV } from './utils/EquirectUVNode.js
 export { default as FunctionOverloadingNode, overloadingFn } from './utils/FunctionOverloadingNode.js';
 export { default as JoinNode } from './utils/JoinNode.js';
 export { default as LoopNode, loop } from './utils/LoopNode.js';
+export { default as LoopBreakNode, loopBreak } from './utils/LoopBreakNode.js';
+export { default as LoopContinueNode, loopContinue } from './utils/LoopContinueNode.js';
 export { default as MatcapUVNode, matcapUV } from './utils/MatcapUVNode.js';
 export { default as MaxMipLevelNode, maxMipLevel } from './utils/MaxMipLevelNode.js';
 export { default as OscNode, oscSine, oscSquare, oscTriangle, oscSawtooth } from './utils/OscNode.js';

--- a/examples/jsm/nodes/Nodes.js
+++ b/examples/jsm/nodes/Nodes.js
@@ -54,8 +54,9 @@ export { default as EquirectUVNode, equirectUV } from './utils/EquirectUVNode.js
 export { default as FunctionOverloadingNode, overloadingFn } from './utils/FunctionOverloadingNode.js';
 export { default as JoinNode } from './utils/JoinNode.js';
 export { default as LoopNode, loop } from './utils/LoopNode.js';
-export { default as LoopBreakNode, loopBreak } from './utils/LoopBreakNode.js';
-export { default as LoopContinueNode, loopContinue } from './utils/LoopContinueNode.js';
+export { default as ReturnNode, Return } from './utils/ReturnNode.js';
+export { default as LoopBreakNode, Break } from './utils/LoopBreakNode.js';
+export { default as LoopContinueNode, Continue } from './utils/LoopContinueNode.js';
 export { default as MatcapUVNode, matcapUV } from './utils/MatcapUVNode.js';
 export { default as MaxMipLevelNode, maxMipLevel } from './utils/MaxMipLevelNode.js';
 export { default as OscNode, oscSine, oscSquare, oscTriangle, oscSawtooth } from './utils/OscNode.js';

--- a/examples/jsm/nodes/utils/LoopBreakNode.js
+++ b/examples/jsm/nodes/utils/LoopBreakNode.js
@@ -20,8 +20,8 @@ class LoopBreakNode extends CondNode {
 export default LoopBreakNode;
 
 export const inlineBreak = nodeProxy( LoopBreakNode );
-export const loopBreak = ( condNode ) => inlineBreak( condNode ).append();
+export const Break = ( condNode ) => inlineBreak( condNode ).append();
 
-addNodeElement( 'break', loopBreak ); // @TODO: Check... this cause a little confusing using in chaining
+addNodeElement( 'break', Break ); // @TODO: Check... this cause a little confusing using in chaining
 
 addNodeClass( 'LoopBreakNode', LoopBreakNode );

--- a/examples/jsm/nodes/utils/LoopBreakNode.js
+++ b/examples/jsm/nodes/utils/LoopBreakNode.js
@@ -1,0 +1,27 @@
+import CondNode from '../math/CondNode.js';
+import { expression } from '../code/ExpressionNode.js';
+import { addNodeClass } from '../core/Node.js';
+import { addNodeElement, nodeProxy } from '../shadernode/ShaderNode.js';
+
+let breakExpression;
+
+class LoopBreakNode extends CondNode {
+
+	constructor( condNode ) {
+
+		breakExpression = breakExpression || expression( 'break' );
+
+		super( condNode, breakExpression );
+
+	}
+
+}
+
+export default LoopBreakNode;
+
+export const inlineBreak = nodeProxy( LoopBreakNode );
+export const loopBreak = ( condNode ) => inlineBreak( condNode ).append();
+
+addNodeElement( 'break', loopBreak ); // @TODO: Check... this cause a little confusing using in chaining
+
+addNodeClass( 'LoopBreakNode', LoopBreakNode );

--- a/examples/jsm/nodes/utils/LoopContinueNode.js
+++ b/examples/jsm/nodes/utils/LoopContinueNode.js
@@ -20,8 +20,8 @@ class LoopContinueNode extends CondNode {
 export default LoopContinueNode;
 
 export const inlineContinue = nodeProxy( LoopContinueNode );
-export const loopContinue = ( condNode ) => inlineContinue( condNode ).append();
+export const Continue = ( condNode ) => inlineContinue( condNode ).append();
 
-addNodeElement( 'continue', loopContinue ); // @TODO: Check... this cause a little confusing using in chaining
+addNodeElement( 'continue', Continue ); // @TODO: Check... this cause a little confusing using in chaining
 
 addNodeClass( 'LoopContinueNode', LoopContinueNode );

--- a/examples/jsm/nodes/utils/LoopContinueNode.js
+++ b/examples/jsm/nodes/utils/LoopContinueNode.js
@@ -1,0 +1,27 @@
+import CondNode from '../math/CondNode.js';
+import { expression } from '../code/ExpressionNode.js';
+import { addNodeClass } from '../core/Node.js';
+import { addNodeElement, nodeProxy } from '../shadernode/ShaderNode.js';
+
+let continueExpression;
+
+class LoopContinueNode extends CondNode {
+
+	constructor( condNode ) {
+
+		continueExpression = continueExpression || expression( 'continue' );
+
+		super( condNode, continueExpression );
+
+	}
+
+}
+
+export default LoopContinueNode;
+
+export const inlineContinue = nodeProxy( LoopContinueNode );
+export const loopContinue = ( condNode ) => inlineContinue( condNode ).append();
+
+addNodeElement( 'continue', loopContinue ); // @TODO: Check... this cause a little confusing using in chaining
+
+addNodeClass( 'LoopContinueNode', LoopContinueNode );

--- a/examples/jsm/nodes/utils/ReturnNode.js
+++ b/examples/jsm/nodes/utils/ReturnNode.js
@@ -1,0 +1,27 @@
+import CondNode from '../math/CondNode.js';
+import { expression } from '../code/ExpressionNode.js';
+import { addNodeClass } from '../core/Node.js';
+import { addNodeElement, nodeProxy } from '../shadernode/ShaderNode.js';
+
+let breakExpression;
+
+class ReturnNode extends CondNode {
+
+	constructor( condNode ) {
+
+		breakExpression = breakExpression || expression( 'return' );
+
+		super( condNode, breakExpression );
+
+	}
+
+}
+
+export default ReturnNode;
+
+export const inlineBreak = nodeProxy( ReturnNode );
+export const Return = ( condNode ) => inlineBreak( condNode ).append();
+
+addNodeElement( 'return', Return ); // @TODO: Check... this cause a little confusing using in chaining
+
+addNodeClass( 'ReturnNode', ReturnNode );


### PR DESCRIPTION
There is currently no ways to interrupt a loop in TSL.

This PR adds `cond.continue()` and `cond.break()` and `cond.return()` methods.

Example usage:
```js
loop( 10, ( { i } ) => {

	i.greaterThan( 5 ).continue();

	position.addAssign( velocity );

} );
```

I wanted to also add standalones `Continue()`, `Break()` and `Return()` but it currently doesn't seem to work, not sure how to do this /cc @sunag 
```js
loop( 10, ( { i } ) => {

	If (i.greaterThan( 5 ), () => {
	
		Continue()
		position.addAssign( velocity );

	} )

} );
```

_This contribution is funded by [Utsubo](https://utsubo.com/)_