### PR TITLE
WebXR: optional `onLoad` callback when loading hands or controllers

### DIFF
--- a/examples/jsm/webxr/XRControllerModelFactory.js
+++ b/examples/jsm/webxr/XRControllerModelFactory.js
@@ -206,11 +206,12 @@ function addAssetSceneToControllerModel( controllerModel, scene ) {
 
 class XRControllerModelFactory {
 
-	constructor( gltfLoader = null ) {
+	constructor( gltfLoader = null, onLoad = null ) {
 
 		this.gltfLoader = gltfLoader;
 		this.path = DEFAULT_PROFILES_PATH;
 		this._assetCache = {};
+		this.onLoad = onLoad;
 
 		// If a GLTFLoader wasn't supplied to the constructor create a new one.
 		if ( ! this.gltfLoader ) {
@@ -247,6 +248,8 @@ class XRControllerModelFactory {
 
 					addAssetSceneToControllerModel( controllerModel, scene );
 
+					if ( this.onLoad ) this.onLoad( scene );
+
 				} else {
 
 					if ( ! this.gltfLoader ) {
@@ -263,6 +266,8 @@ class XRControllerModelFactory {
 						scene = asset.scene.clone();
 
 						addAssetSceneToControllerModel( controllerModel, scene );
+
+						if ( this.onLoad ) this.onLoad( scene );
 
 					},
 					null,

--- a/examples/jsm/webxr/XRHandMeshModel.js
+++ b/examples/jsm/webxr/XRHandMeshModel.js
@@ -4,7 +4,7 @@ const DEFAULT_HAND_PROFILE_PATH = 'https://cdn.jsdelivr.net/npm/@webxr-input-pro
 
 class XRHandMeshModel {
 
-	constructor( handModel, controller, path, handedness, loader = null ) {
+	constructor( handModel, controller, path, handedness, loader = null, onLoad = null ) {
 
 		this.controller = controller;
 		this.handModel = handModel;
@@ -73,6 +73,8 @@ class XRHandMeshModel {
 				this.bones.push( bone );
 
 			} );
+
+			if ( onLoad ) onLoad( object );
 
 		} );
 


### PR DESCRIPTION
Closes
- https://github.com/mrdoob/three.js/pull/23279

**Description**

Alternative approach to be able to react to hand and controller models actually being loaded. The callback allows setting layers, adjusting materials, ... on the loaded meshes/objects once the internal loading routines are actually done.

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Needle](https://needle.tools)*
