### PR TITLE
Added Per Object: Transparency / Visibility / Opacity

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -105,6 +105,8 @@ class Object3D extends EventDispatcher {
 		this.layers = new Layers();
 		this.visible = true;
 
+		this.visibility = 1.0;
+
 		this.castShadow = false;
 		this.receiveShadow = false;
 
@@ -696,6 +698,7 @@ class Object3D extends EventDispatcher {
 		if ( this.castShadow === true ) object.castShadow = true;
 		if ( this.receiveShadow === true ) object.receiveShadow = true;
 		if ( this.visible === false ) object.visible = false;
+		if ( this.visibility !== 1.0 ) object.visibility = this.visibility;
 		if ( this.frustumCulled === false ) object.frustumCulled = false;
 		if ( this.renderOrder !== 0 ) object.renderOrder = this.renderOrder;
 		if ( Object.keys( this.userData ).length > 0 ) object.userData = this.userData;
@@ -726,7 +729,8 @@ class Object3D extends EventDispatcher {
 			object.drawRanges = this._drawRanges;
 			object.reservedRanges = this._reservedRanges;
 
-			object.visibility = this._visibility;
+			object.visibilityState = this._visibilityState;
+
 			object.active = this._active;
 			object.bounds = this._bounds.map( bound => ( {
 				boxInitialized: bound.boxInitialized,
@@ -973,6 +977,8 @@ class Object3D extends EventDispatcher {
 
 		this.layers.mask = source.layers.mask;
 		this.visible = source.visible;
+
+		this.visibility = source.visibility;
 
 		this.castShadow = source.castShadow;
 		this.receiveShadow = source.receiveShadow;

--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -141,7 +141,7 @@ class BatchedMesh extends Mesh {
 		this._drawRanges = [];
 		this._reservedRanges = [];
 
-		this._visibility = [];
+		this._visibilityState = [];
 		this._active = [];
 		this._bounds = [];
 
@@ -413,7 +413,7 @@ class BatchedMesh extends Mesh {
 
 		}
 
-		const visibility = this._visibility;
+		const visibility = this._visibilityState;
 		const active = this._active;
 		const matricesTexture = this._matricesTexture;
 		const matricesArray = this._matricesTexture.image.data;
@@ -726,7 +726,7 @@ class BatchedMesh extends Mesh {
 
 	setVisibleAt( geometryId, value ) {
 
-		const visibility = this._visibility;
+		const visibility = this._visibilityState;
 		const active = this._active;
 		const geometryCount = this._geometryCount;
 
@@ -751,7 +751,7 @@ class BatchedMesh extends Mesh {
 
 	getVisibleAt( geometryId ) {
 
-		const visibility = this._visibility;
+		const visibility = this._visibilityState;
 		const active = this._active;
 		const geometryCount = this._geometryCount;
 
@@ -768,7 +768,7 @@ class BatchedMesh extends Mesh {
 
 	raycast( raycaster, intersects ) {
 
-		const visibility = this._visibility;
+		const visibility = this._visibilityState;
 		const active = this._active;
 		const drawRanges = this._drawRanges;
 		const geometryCount = this._geometryCount;
@@ -895,7 +895,7 @@ class BatchedMesh extends Mesh {
 		const bytesPerElement = index === null ? 1 : index.array.BYTES_PER_ELEMENT;
 
 		const active = this._active;
-		const visibility = this._visibility;
+		const visibility = this._visibilityState;
 		const multiDrawStarts = this._multiDrawStarts;
 		const multiDrawCounts = this._multiDrawCounts;
 		const drawRanges = this._drawRanges;
@@ -954,7 +954,7 @@ class BatchedMesh extends Mesh {
 			const customSort = this.customSort;
 			if ( customSort === null ) {
 
-				list.sort( material.transparent ? sortTransparent : sortOpaque );
+				list.sort( material.transparent || this.visibility < 1.0 ? sortTransparent : sortOpaque );
 
 			} else {
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2013,11 +2013,7 @@ class WebGLRenderer {
 
 			// Refresh opacity uniforms per frame and upload if necessary
 
-			if ( m_uniforms.opacity ) {
-
-				m_uniforms.opacity.value = opacity;
-
-			}
+			materials.refreshMaterialOpacity( m_uniforms, material, opacity );
 
 			if ( ! refreshMaterial && m_uniforms.opacity !== opacity ) {
 

--- a/src/renderers/webgl/WebGLMaterials.js
+++ b/src/renderers/webgl/WebGLMaterials.js
@@ -603,6 +603,10 @@ function WebGLMaterials( renderer, properties ) {
 
 			uniforms.opacity.value = opacity;
 
+		} else if ( material.isShadowMaterial ) {
+
+			uniforms.opacity.value = opacity;
+
 		}
 
 	}

--- a/src/renderers/webgl/WebGLMaterials.js
+++ b/src/renderers/webgl/WebGLMaterials.js
@@ -102,7 +102,6 @@ function WebGLMaterials( renderer, properties ) {
 		} else if ( material.isShadowMaterial ) {
 
 			uniforms.color.value.copy( material.color );
-			uniforms.opacity.value = material.opacity;
 
 		} else if ( material.isShaderMaterial ) {
 
@@ -113,8 +112,6 @@ function WebGLMaterials( renderer, properties ) {
 	}
 
 	function refreshUniformsCommon( uniforms, material ) {
-
-		uniforms.opacity.value = material.opacity;
 
 		if ( material.color ) {
 
@@ -250,7 +247,6 @@ function WebGLMaterials( renderer, properties ) {
 	function refreshUniformsLine( uniforms, material ) {
 
 		uniforms.diffuse.value.copy( material.color );
-		uniforms.opacity.value = material.opacity;
 
 		if ( material.map ) {
 
@@ -273,7 +269,6 @@ function WebGLMaterials( renderer, properties ) {
 	function refreshUniformsPoints( uniforms, material, pixelRatio, height ) {
 
 		uniforms.diffuse.value.copy( material.color );
-		uniforms.opacity.value = material.opacity;
 		uniforms.size.value = material.size * pixelRatio;
 		uniforms.scale.value = height * 0.5;
 
@@ -304,7 +299,6 @@ function WebGLMaterials( renderer, properties ) {
 	function refreshUniformsSprites( uniforms, material ) {
 
 		uniforms.diffuse.value.copy( material.color );
-		uniforms.opacity.value = material.opacity;
 		uniforms.rotation.value = material.rotation;
 
 		if ( material.map ) {

--- a/src/renderers/webgl/WebGLMaterials.js
+++ b/src/renderers/webgl/WebGLMaterials.js
@@ -551,9 +551,66 @@ function WebGLMaterials( renderer, properties ) {
 
 	}
 
+	// Same as refreshMaterialUniforms, but for opacity only
+
+	function refreshMaterialOpacity( uniforms, material, opacity ) {
+
+		if ( material.isMeshBasicMaterial ) {
+
+			uniforms.opacity.value = opacity;
+
+		} else if ( material.isMeshLambertMaterial ) {
+
+			uniforms.opacity.value = opacity;
+
+		} else if ( material.isMeshToonMaterial ) {
+
+			uniforms.opacity.value = opacity;
+
+		} else if ( material.isMeshPhongMaterial ) {
+
+			uniforms.opacity.value = opacity;
+
+		} else if ( material.isMeshStandardMaterial ) {
+
+			uniforms.opacity.value = opacity;
+
+		} else if ( material.isMeshMatcapMaterial ) {
+
+			uniforms.opacity.value = opacity;
+
+		} else if ( material.isMeshDepthMaterial ) {
+
+			uniforms.opacity.value = opacity;
+
+		} else if ( material.isMeshDistanceMaterial ) {
+
+			uniforms.opacity.value = opacity;
+
+		} else if ( material.isMeshNormalMaterial ) {
+
+			uniforms.opacity.value = opacity;
+
+		} else if ( material.isLineBasicMaterial ) {
+
+			uniforms.opacity.value = opacity;
+
+		} else if ( material.isPointsMaterial ) {
+
+			uniforms.opacity.value = opacity;
+
+		} else if ( material.isSpriteMaterial ) {
+
+			uniforms.opacity.value = opacity;
+
+		}
+
+	}
+
 	return {
 		refreshFogUniforms: refreshFogUniforms,
-		refreshMaterialUniforms: refreshMaterialUniforms
+		refreshMaterialUniforms: refreshMaterialUniforms,
+		refreshMaterialOpacity: refreshMaterialOpacity
 	};
 
 }

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -245,7 +245,7 @@ function WebGLPrograms( renderer, cubemaps, cubeuvmaps, extensions, capabilities
 
 			gradientMap: HAS_GRADIENTMAP,
 
-			opaque: material.transparent === false && material.blending === NormalBlending,
+			opaque: material.transparent === false && material.blending === NormalBlending && object.visibility >= 1.0,
 
 			alphaMap: HAS_ALPHAMAP,
 			alphaTest: HAS_ALPHATEST,

--- a/src/renderers/webgl/WebGLRenderLists.js
+++ b/src/renderers/webgl/WebGLRenderLists.js
@@ -112,7 +112,7 @@ function WebGLRenderList() {
 
 			transmissive.push( renderItem );
 
-		} else if ( material.transparent === true ) {
+		} else if ( material.transparent === true || object.visibility < 1.0 ) {
 
 			transparent.push( renderItem );
 
@@ -132,7 +132,7 @@ function WebGLRenderList() {
 
 			transmissive.unshift( renderItem );
 
-		} else if ( material.transparent === true ) {
+		} else if ( material.transparent === true || object.visibility < 1.0 ) {
 
 			transparent.unshift( renderItem );
 

--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -755,7 +755,7 @@ function WebGLState( gl, extensions, capabilities ) {
 
 	}
 
-	function setMaterial( material, frontFaceCW ) {
+	function setMaterial( material, object, frontFaceCW ) {
 
 		material.side === DoubleSide
 			? disable( gl.CULL_FACE )
@@ -766,7 +766,7 @@ function WebGLState( gl, extensions, capabilities ) {
 
 		setFlipSided( flipSided );
 
-		( material.blending === NormalBlending && material.transparent === false )
+		( material.blending === NormalBlending && material.transparent === false && object.visibility >= 1.0 )
 			? setBlending( NoBlending )
 			: setBlending( material.blending, material.blendEquation, material.blendSrc, material.blendDst, material.blendEquationAlpha, material.blendSrcAlpha, material.blendDstAlpha, material.blendColor, material.blendAlpha, material.premultipliedAlpha );
 


### PR DESCRIPTION
**Description**

It is hard to fade objects with many materials. A `float` parameter handles the transparency per object.

![Animation3](https://github.com/mrdoob/three.js/assets/16117001/1433d6bf-527e-4f71-9326-77a3b71f03fe)

```javascript
const mesh = new Mesh(geom, materials);
mesh.visibility = 0.5;
``` 
or
```javascript
const scene = glb.scene;
scene.taverse((obj) => obj.visibility = 0.5);
``` 


Decisions that could be discussed:
- **Name (visibility, opacity, transparency, fade)**: `visibility` like in (https://doc.babylonjs.com/typedoc/classes/BABYLON.AbstractMesh#visibility) or 3ds Max 
![image](https://github.com/mrdoob/three.js/assets/16117001/98aa419e-d3b2-41ec-b5bb-6d18265c2492)
- **`Object3D`**: I defined the parameter in `Object3d`. This offers flexibility for traversing. It might be better suited for `Mesh`s (renderable objects).
- **Like opacity**: It behaves exactly like changing the properties `transparent` and `opacity` on the `Material`.
- **No hierarchical inheritance**:  It will only affect the current object. If you want hierarchical fading, you have to handle this in the application. This offers flexibility how to refresh or inherit the visibility value.
- **Behaves not like `visible`**: Setting `visible = false` will prevent the object and hierachy from rendering. However setting the `**visibility** = 0.0`  won't prevent the object from rendering. (This is the same behavior as setting `material.opacity = 0.0`).
- **No custom blending**: Blending will be used like defined in the material.
- ** Don't affect lights, etc... **: Lights could be faded too...