### PR TITLE
WebGPURenderer: clear() - use cached descriptor properties and views were possible 

### DIFF
--- a/examples/jsm/renderers/webgpu/WebGPUBackend.js
+++ b/examples/jsm/renderers/webgpu/WebGPUBackend.js
@@ -7,8 +7,6 @@ import { GPUFeatureName, GPUTextureFormat, GPULoadOp, GPUStoreOp, GPUIndexFormat
 import WGSLNodeBuilder from './nodes/WGSLNodeBuilder.js';
 import Backend from '../common/Backend.js';
 
-import { DepthFormat, WebGPUCoordinateSystem } from 'three';
-
 import WebGPUUtils from './utils/WebGPUUtils.js';
 import WebGPUAttributeUtils from './utils/WebGPUAttributeUtils.js';
 import WebGPUBindingUtils from './utils/WebGPUBindingUtils.js';

--- a/examples/jsm/renderers/webgpu/WebGPUBackend.js
+++ b/examples/jsm/renderers/webgpu/WebGPUBackend.js
@@ -259,12 +259,6 @@ class WebGPUBackend extends Backend {
 				view: depthTextureData.texture.createView(),
 			};
 
-			if ( renderContext.stencil && renderContext.depthTexture.format === DepthFormat ) {
-
-				renderContext.stencil = false;
-
-			}
-
 			descriptor = {
 				colorAttachments,
 				depthStencilAttachment

--- a/examples/jsm/renderers/webgpu/WebGPUBackend.js
+++ b/examples/jsm/renderers/webgpu/WebGPUBackend.js
@@ -138,7 +138,7 @@ class WebGPUBackend extends Backend {
 
 	}
 
-	_getDefaultRenderPassDescriptor( renderContext ) {
+	_getDefaultRenderPassDescriptor() {
 
 		let descriptor = this.defaultRenderPassdescriptor;
 
@@ -146,12 +146,14 @@ class WebGPUBackend extends Backend {
 
 		if ( descriptor === null ) {
 
+			const renderer = this.renderer;
+
 			descriptor = {
 				colorAttachments: [ {
 					view: null
 				} ],
 				depthStencilAttachment: {
-					view: this.textureUtils.getDepthBuffer( renderContext.depth, renderContext.stencil ).createView()
+					view: this.textureUtils.getDepthBuffer( renderer.depth, renderer.stencil ).createView()
 				}
 			};
 
@@ -311,13 +313,13 @@ class WebGPUBackend extends Backend {
 
 		let descriptor;
 
-		if ( renderContext.textures !== null ) {
+		if ( renderContext.textures === null ) {
 
-			descriptor = this._getRenderPassDescriptor( renderContext );
+			descriptor = this._getDefaultRenderPassDescriptor();
 
 		} else {
 
-			descriptor = this._getDefaultRenderPassDescriptor( renderContext );
+			descriptor = this._getRenderPassDescriptor( renderContext );
 
 		}
 
@@ -572,7 +574,7 @@ class WebGPUBackend extends Backend {
 		const device = this.device;
 		const renderer = this.renderer;
 
-		const colorAttachments = [];
+		let colorAttachments = [];
 
 		let depthStencilAttachment;
 		let clearValue;
@@ -596,36 +598,23 @@ class WebGPUBackend extends Backend {
 			depth = depth && supportsDepth;
 			stencil = stencil && supportsStencil;
 
+			const descriptor = this._getDefaultRenderPassDescriptor();
+
 			if ( color ) {
 
-				const antialias = this.parameters.antialias;
+				colorAttachments = descriptor.colorAttachments;
 
-				const colorAttachment = {};
-
-				if ( antialias === true ) {
-
-					colorAttachment.view = this.colorBuffer.createView();
-					colorAttachment.resolveTarget = this.context.getCurrentTexture().createView();
-
-				} else {
-
-					colorAttachment.view = this.context.getCurrentTexture().createView();
-
-				}
+				const colorAttachment = colorAttachments[ 0 ];
 
 				colorAttachment.clearValue = clearValue;
 				colorAttachment.loadOp = GPULoadOp.Clear;
 				colorAttachment.storeOp = GPUStoreOp.Store;
 
-				colorAttachments.push( colorAttachment );
-
 			}
 
 			if ( depth || stencil ) {
 
-				depthStencilAttachment = {
-					view: this.textureUtils.getDepthBuffer( renderer.depth, renderer.stencil ).createView()
-				};
+				depthStencilAttachment = descriptor.depthStencilAttachment;
 
 			}
 


### PR DESCRIPTION
Use components of  cached renderPassDescriptor for default (null) render target in clear() operations.

Also remove some now obsolete code now renderContext,stencil is set correctly,
