### PR TITLE
WebGLProgram: Show which shader caused compilation error

### DIFF
--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -966,6 +966,7 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 					console.error(
 						'THREE.WebGLProgram: Shader Error ' + gl.getError() + ' - ' +
 						'VALIDATE_STATUS ' + gl.getProgramParameter( program, gl.VALIDATE_STATUS ) + '\n\n' +
+						'Shader Info: ' + self.name + '(' + self.type + ')' + '\n' +
 						'Program Info Log: ' + programLog + '\n' +
 						vertexErrors + '\n' +
 						fragmentErrors


### PR DESCRIPTION
When I'm running into shader issues, it's often quite cumbersome to understand which shader/material has actually caused the issue. This PR just adds shader name and type to the error log.