### PR TITLE
WebGPURenderer: PostProcessing fix tone mapping on display nodes

### DIFF
--- a/examples/jsm/nodes/display/AfterImageNode.js
+++ b/examples/jsm/nodes/display/AfterImageNode.js
@@ -109,7 +109,7 @@ class AfterImageNode extends TempNode {
 		//
 
 		const materialComposed = this._materialComposed || ( this._materialComposed = builder.createNodeMaterial( 'MeshBasicNodeMaterial' ) );
-		materialComposed.toneMapping = false;
+		materialComposed.toneMapped = false;
 		materialComposed.fragmentNode = afterImg();
 
 		quadMeshComp.material = materialComposed;

--- a/examples/jsm/nodes/display/AfterImageNode.js
+++ b/examples/jsm/nodes/display/AfterImageNode.js
@@ -109,6 +109,7 @@ class AfterImageNode extends TempNode {
 		//
 
 		const materialComposed = this._materialComposed || ( this._materialComposed = builder.createNodeMaterial( 'MeshBasicNodeMaterial' ) );
+		materialComposed.toneMapping = false;
 		materialComposed.fragmentNode = afterImg();
 
 		quadMeshComp.material = materialComposed;

--- a/examples/jsm/nodes/display/GaussianBlurNode.js
+++ b/examples/jsm/nodes/display/GaussianBlurNode.js
@@ -140,6 +140,7 @@ class GaussianBlurNode extends TempNode {
 		//
 
 		const material = this._material || ( this._material = builder.createNodeMaterial( 'MeshBasicNodeMaterial' ) );
+		material.toneMapped = false;
 		material.fragmentNode = blur();
 
 		//


### PR DESCRIPTION
Postprocessing nodes shouldn't have tone mapping.

_This contribution is funded by [Utsubo](https://utsubo.com/)_