### PR TITLE
WebGPURenderer: ViewportNode, fix viewportCoordinate in WebGL Backend

### DIFF
--- a/examples/jsm/nodes/display/ViewportNode.js
+++ b/examples/jsm/nodes/display/ViewportNode.js
@@ -95,7 +95,7 @@ class ViewportNode extends Node {
 
 			let coord = builder.getFragCoord();
 
-			if ( builder.isFlipY() ) {
+			if ( builder.isFlipY() && ! builder.renderer.backend.isWebGLBackend ) {
 
 				// follow webgpu standards
 


### PR DESCRIPTION
The `viewportCoordinate` node was broken in WebGL. This PR fixes the issue.

_This contribution is funded by [Utsubo](https://utsubo.com/)_