### PR TITLE
Nodes: Fix `viewportCoordinate` build

### DIFF
--- a/examples/jsm/nodes/display/ViewportNode.js
+++ b/examples/jsm/nodes/display/ViewportNode.js
@@ -59,8 +59,6 @@ class ViewportNode extends Node {
 
 		const scope = this.scope;
 
-		if ( scope === ViewportNode.COORDINATE ) return;
-
 		let output = null;
 
 		if ( scope === ViewportNode.RESOLUTION ) {


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/27559

**Description**

Fix `viewportCoordinate` build.