### PR TITLE
WebGPURenderer: Fix `BachedMesh` coordinate system in case of `WebGLBackend`

### DIFF
--- a/examples/jsm/renderers/webgpu/WebGPUBackend.js
+++ b/examples/jsm/renderers/webgpu/WebGPUBackend.js
@@ -2,6 +2,8 @@
 import 'https://greggman.github.io/webgpu-avoid-redundant-state-setting/webgpu-check-redundant-state-setting.js';
 //*/
 
+import { WebGPUCoordinateSystem } from 'three';
+
 import { GPUFeatureName, GPUTextureFormat, GPULoadOp, GPUStoreOp, GPUIndexFormat, GPUTextureViewDimension } from './utils/WebGPUConstants.js';
 
 import WGSLNodeBuilder from './nodes/WGSLNodeBuilder.js';

--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -8,8 +8,6 @@ import { RGBAFormat } from '../constants.js';
 import { Box3 } from '../math/Box3.js';
 import { Sphere } from '../math/Sphere.js';
 import { Frustum } from '../math/Frustum.js';
-import { WebGLCoordinateSystem } from '../constants.js';
-import { WebGPUCoordinateSystem } from '../constants.js';
 import { Vector3 } from '../math/Vector3.js';
 
 function sortOpaque( a, b ) {
@@ -909,7 +907,7 @@ class BatchedMesh extends Mesh {
 				.multiply( this.matrixWorld );
 			_frustum.setFromProjectionMatrix(
 				_projScreenMatrix,
-				renderer.isWebGPURenderer ? WebGPUCoordinateSystem : WebGLCoordinateSystem
+				renderer.coordinateSystem
 			);
 
 		}


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/27120#discussion_r1450522562

**Description**

Fix `BachedMesh` coordinate system in case of `WebGLBackend`.