### PR TITLE
NodeMaterial: Introduce `outputFinalNode`

### DIFF
--- a/examples/jsm/nodes/materials/NodeMaterial.js
+++ b/examples/jsm/nodes/materials/NodeMaterial.js
@@ -112,7 +112,6 @@ class NodeMaterial extends ShaderMaterial {
 			//
 
 			if ( this.outputNode !== null ) resultNode = this.outputNode;
-			console.log( resultNode );
 
 		} else {
 

--- a/examples/jsm/nodes/materials/NodeMaterial.js
+++ b/examples/jsm/nodes/materials/NodeMaterial.js
@@ -56,6 +56,9 @@ class NodeMaterial extends ShaderMaterial {
 
 		this.outputNode = null;
 
+		this.outputFinalNode = null;
+		this.outputFinalFactor = 0;
+
 		this.fragmentNode = null;
 		this.vertexNode = null;
 
@@ -109,6 +112,7 @@ class NodeMaterial extends ShaderMaterial {
 			//
 
 			if ( this.outputNode !== null ) resultNode = this.outputNode;
+			console.log( resultNode );
 
 		} else {
 
@@ -379,6 +383,12 @@ class NodeMaterial extends ShaderMaterial {
 				outputNode = outputNode.linearToColorSpace( outputColorSpace );
 
 			}
+
+		}
+
+		if ( this.outputFinalNode !== null ) {
+
+			outputNode = mix( outputNode, this.outputFinalNode, this.outputFinalFactor );
 
 		}
 


### PR DESCRIPTION
Introduce an enhancement to the material node system by adding a new node `outputFinalNode` that operates at the very end of the pipeline, post tone mapping, fog, and color space adjustments.
This addition unlocks the capability to apply custom effects on a per-material basis, providing a level of control and customization not achievable with a uniform post-processing setup.

Currently the only operation possible is `mix`, if possible it would be better to be able to apply any operator using tslFn, for example:
```js
material.outputFinalNode = tslFn( ( { color } ) => {
    return color.rgb.addAssign(vec3(0.1));
} )