### PR TITLE
Nodes: Simplify `builder.createNodeMaterial()` usage

### DIFF
--- a/examples/jsm/nodes/core/NodeBuilder.js
+++ b/examples/jsm/nodes/core/NodeBuilder.js
@@ -1171,7 +1171,7 @@ class NodeBuilder {
 
 	}
 
-	createNodeMaterial( type ) {
+	createNodeMaterial( type = 'NodeMaterial' ) {
 
 		return createNodeMaterialFromType( type );
 

--- a/examples/jsm/nodes/display/AfterImageNode.js
+++ b/examples/jsm/nodes/display/AfterImageNode.js
@@ -108,8 +108,7 @@ class AfterImageNode extends TempNode {
 
 		//
 
-		const materialComposed = this._materialComposed || ( this._materialComposed = builder.createNodeMaterial( 'MeshBasicNodeMaterial' ) );
-		materialComposed.toneMapped = false;
+		const materialComposed = this._materialComposed || ( this._materialComposed = builder.createNodeMaterial() );
 		materialComposed.fragmentNode = afterImg();
 
 		quadMeshComp.material = materialComposed;

--- a/examples/jsm/nodes/display/GaussianBlurNode.js
+++ b/examples/jsm/nodes/display/GaussianBlurNode.js
@@ -139,8 +139,7 @@ class GaussianBlurNode extends TempNode {
 
 		//
 
-		const material = this._material || ( this._material = builder.createNodeMaterial( 'MeshBasicNodeMaterial' ) );
-		material.toneMapped = false;
+		const material = this._material || ( this._material = builder.createNodeMaterial() );
 		material.fragmentNode = blur();
 
 		//

--- a/examples/jsm/nodes/lighting/AnalyticLightNode.js
+++ b/examples/jsm/nodes/lighting/AnalyticLightNode.js
@@ -2,7 +2,7 @@ import LightingNode from './LightingNode.js';
 import { NodeUpdateType } from '../core/constants.js';
 import { uniform } from '../core/UniformNode.js';
 import { addNodeClass } from '../core/Node.js';
-import { /*vec2,*/ vec3 } from '../shadernode/ShaderNode.js';
+import { /*vec2,*/ vec3, vec4 } from '../shadernode/ShaderNode.js';
 import { reference } from '../accessors/ReferenceNode.js';
 import { texture } from '../accessors/TextureNode.js';
 import { positionWorld } from '../accessors/PositionNode.js';
@@ -12,7 +12,7 @@ import { WebGPUCoordinateSystem } from 'three';
 
 import { Color, DepthTexture, NearestFilter, LessCompare } from 'three';
 
-let depthMaterial = null;
+let overrideMaterial = null;
 
 class AnalyticLightNode extends LightingNode {
 
@@ -54,7 +54,12 @@ class AnalyticLightNode extends LightingNode {
 
 		if ( shadowNode === null ) {
 
-			if ( depthMaterial === null ) depthMaterial = builder.createNodeMaterial( 'MeshBasicNodeMaterial' );
+			if ( overrideMaterial === null ) {
+
+				overrideMaterial = builder.createNodeMaterial();
+				overrideMaterial.fragmentNode = vec4( 1 );
+
+			}
 
 			const shadow = this.light.shadow;
 			const rtt = builder.getRenderTarget( shadow.mapSize.width, shadow.mapSize.height );
@@ -169,7 +174,7 @@ class AnalyticLightNode extends LightingNode {
 
 		const currentOverrideMaterial = scene.overrideMaterial;
 
-		scene.overrideMaterial = depthMaterial;
+		scene.overrideMaterial = overrideMaterial;
 
 		rtt.setSize( light.shadow.mapSize.width, light.shadow.mapSize.height );
 


### PR DESCRIPTION
**Description**

Simplify `builder.createNodeMaterial()` usage, in this case we don't needs to use `MeshBasicNodeMaterial` and `toneMapped` and `colorSpaced`. `fragmentNode` will replace all these.
