### PR TITLE
Add `dev-ssl` npm script since HTTPS is required for WebXR and other secure web APIs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "build": "rollup -c utils/build/rollup.config.js",
     "build-module": "rollup -c utils/build/rollup.config.js --configOnlyModule",
     "dev": "concurrently --names \"ROLLUP,HTTP\" -c \"bgBlue.bold,bgGreen.bold\" \"rollup -c utils/build/rollup.config.js -w -m inline\" \"servez -p 8080\"",
+    "dev-host": "concurrently --names \"ROLLUP,HTTP\" -c \"bgBlue.bold,bgGreen.bold\" \"rollup -c utils/build/rollup.config.js -w -m inline\" \"servez -p 8080 --ssl\"",
     "lint-core": "eslint src",
     "lint-addons": "eslint examples/jsm --ext .js --ignore-pattern libs --ignore-pattern ifc",
     "lint-examples": "eslint examples --ext .html",


### PR DESCRIPTION
Related issue: #27164

**Description**

Restores the removal of the --ssl option. Without that option, files are served over http instead of https, which breaks, among other things, WebXR completely (requires HTTPS).

*This contribution is funded by [Needle](https://needle.tools)*

cc @elalish 