### PR TITLE
AudioListener: prevent invalid data being passed to `linearRampToValueAtTime`

### DIFF
--- a/src/audio/AudioListener.js
+++ b/src/audio/AudioListener.js
@@ -105,6 +105,9 @@ class AudioListener extends Object3D {
 
 		this.matrixWorld.decompose( _position, _quaternion, _scale );
 
+		if ( ! Number.isFinite( _position.x ) || ! Number.isFinite( _position.y ) || !Number.isFinite( _position.z ))
+			return;
+
 		_orientation.set( 0, 0, - 1 ).applyQuaternion( _quaternion );
 
 		if ( listener.positionX ) {


### PR DESCRIPTION
**Description**

This issue has been bugging us for a while – under certain circumstances, entering an XR session can result in the cameras being non-decomposable for a frame or two (for reasons not entirely clear to me, randomly happens with three.js XR examples as well), and then the render loop breaks when an AudioListener is used, since passing non-finite numbers to the audio filters throws an exception. This PR fixes that and prevents invalid data being passed into AudioListener.

I understand this does not "feel clean", but it fixes a super hard to debug issue that has been bugging us for a while.

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Needle](https://needle.tools)*
