### PR TITLE
WebGPURenderer: Add `preferWebGL` parameter.

### DIFF
--- a/examples/jsm/renderers/webgpu/WebGPURenderer.js
+++ b/examples/jsm/renderers/webgpu/WebGPURenderer.js
@@ -23,7 +23,11 @@ class WebGPURenderer extends Renderer {
 
 		let BackendClass;
 
-		if ( WebGPU.isAvailable() ) {
+		if ( parameters.preferWebGL ) {
+
+			BackendClass = WebGLBackend;
+
+		} else if ( WebGPU.isAvailable() ) {
 
 			BackendClass = WebGPUBackend;
 


### PR DESCRIPTION
Add a new parameter to the `WebGPURenderer` to force the `WebGL` backend even if `WebGPU` is available.

Example usage:
```js
const renderer = new WebGPURenderer( { preferWebGL: true } );
```

_This contribution is funded by [Utsubo](https://utsubo.com/)_