### PR TITLE
BufferGeometryUtils.mergeAttributes: Add support for interleaved buffers

### DIFF
--- a/examples/jsm/utils/BufferGeometryUtils.js
+++ b/examples/jsm/utils/BufferGeometryUtils.js
@@ -361,7 +361,7 @@ function mergeAttributes( attributes ) {
 
 				for ( let c = 0; c < itemSize; c ++ ) {
 
-					const value = attribute.getComponent( j + tupleOffset, c );
+					const value = attribute.getComponent( j, c );
 					result.setComponent( j + tupleOffset, c, value );
 
 				}

--- a/examples/jsm/utils/BufferGeometryUtils.js
+++ b/examples/jsm/utils/BufferGeometryUtils.js
@@ -311,13 +311,6 @@ function mergeAttributes( attributes ) {
 
 		const attribute = attributes[ i ];
 
-		if ( attribute.isInterleavedBufferAttribute ) {
-
-			console.error( 'THREE.BufferGeometryUtils: .mergeAttributes() failed. InterleavedBufferAttributes are not supported.' );
-			return null;
-
-		}
-
 		if ( TypedArray === undefined ) TypedArray = attribute.array.constructor;
 		if ( TypedArray !== attribute.array.constructor ) {
 
@@ -350,22 +343,41 @@ function mergeAttributes( attributes ) {
 
 		}
 
-		arrayLength += attribute.array.length;
+		arrayLength += attribute.count * itemSize;
 
 	}
 
 	const array = new TypedArray( arrayLength );
+	const result = new BufferAttribute( array, itemSize, normalized );
 	let offset = 0;
 
 	for ( let i = 0; i < attributes.length; ++ i ) {
 
-		array.set( attributes[ i ].array, offset );
+		const attribute = attributes[ i ];
+		if ( attribute.isInterleavedBufferAttribute ) {
 
-		offset += attributes[ i ].array.length;
+			const tupleOffset = offset / itemSize;
+			for ( let j = 0, l = attribute.count; j < l; j ++ ) {
+
+				for ( let c = 0; c < itemSize; c ++ ) {
+
+					const value = attribute.getComponent( j + tupleOffset, c );
+					result.setComponent( j + tupleOffset, c, value );
+
+				}
+
+			}
+
+		} else {
+
+			array.set( attribute.array, offset );
+
+		}
+
+		offset += attribute.count * itemSize;
 
 	}
 
-	const result = new BufferAttribute( array, itemSize, normalized );
 	if ( gpuType !== undefined ) {
 
 		result.gpuType = gpuType;


### PR DESCRIPTION
Related issue: --

**Description**

Adjusts the `mergeAttributes` to fall back to individual element item copying when interleaved attribute buffers are used. Relies on `getComponent` from #27590.