### PR TITLE
WebGPURenderer: Fix `copyFramebufferToTexture` wrong framebuffer binding in WebGLBackend

### DIFF
--- a/examples/jsm/renderers/webgl/utils/WebGLTextureUtils.js
+++ b/examples/jsm/renderers/webgl/utils/WebGLTextureUtils.js
@@ -486,8 +486,6 @@ class WebGLTextureUtils {
 		const width = texture.image.width;
 		const height = texture.image.height;
 
-		state.bindFramebuffer( gl.READ_FRAMEBUFFER, null );
-
 		if ( texture.isDepthTexture ) {
 
 			let mask = gl.DEPTH_BUFFER_BIT;

--- a/examples/jsm/renderers/webgl/utils/WebGLTextureUtils.js
+++ b/examples/jsm/renderers/webgl/utils/WebGLTextureUtils.js
@@ -490,13 +490,20 @@ class WebGLTextureUtils {
 
 		if ( texture.isDepthTexture ) {
 
-			const fb = gl.createFramebuffer();
+			let mask = gl.DEPTH_BUFFER_BIT;
 
-			gl.bindFramebuffer( gl.DRAW_FRAMEBUFFER, fb );
+			if ( renderContext.stencil ) {
+
+				mask |= gl.STENCIL_BUFFER_BIT;
+
+			}
+
+			const fb = gl.createFramebuffer();
+			state.bindFramebuffer( gl.DRAW_FRAMEBUFFER, fb );
 
 			gl.framebufferTexture2D( gl.DRAW_FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.TEXTURE_2D, textureGPU, 0 );
 
-			gl.blitFramebuffer( 0, 0, width, height, 0, 0, width, height, gl.DEPTH_BUFFER_BIT, gl.NEAREST );
+			gl.blitFramebuffer( 0, 0, width, height, 0, 0, width, height, mask, gl.NEAREST );
 
 			gl.deleteFramebuffer( fb );
 

--- a/examples/jsm/renderers/webgl/utils/WebGLTextureUtils.js
+++ b/examples/jsm/renderers/webgl/utils/WebGLTextureUtils.js
@@ -500,7 +500,6 @@ class WebGLTextureUtils {
 
 			gl.deleteFramebuffer( fb );
 
-
 		} else {
 
 			state.bindTexture( gl.TEXTURE_2D, textureGPU );


### PR DESCRIPTION
In the WebGLBackend the `copyFramebufferToTexture` was not binding the correct framebuffer.

Also, the `null` binding of the `READ_FRAMEBUFFER` was throwing a WebGL warning, I removed it as anyway WebGL `DRAW_FRAMEBUFFER` operation will fallback to read the window-system-provided framebuffer and work just fine. This does another error warning throw on firefox and chrome.  /cc @aardgoose 

This fix the new `webgpu_backdrop_water` example (error caused by `copyFramebufferToTexture` called in `ViewportTextureNode`).

Before:
<img width="1712" alt="image" src="https://github.com/mrdoob/three.js/assets/15867665/a5707b9b-d158-4b73-88fb-7dc9f5ff10ab">
After:
<img width="1712" alt="image" src="https://github.com/mrdoob/three.js/assets/15867665/0dada2f4-e300-434d-8152-668b3147533c">

_This contribution is funded by [Utsubo](https://utsubo.com/)_