### PR TITLE
BufferAttribute: `warnOnce` for deprecated methods

### DIFF
--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -3,6 +3,7 @@ import { Vector2 } from '../math/Vector2.js';
 import { denormalize, normalize } from '../math/MathUtils.js';
 import { StaticDrawUsage, FloatType } from '../constants.js';
 import { fromHalfFloat, toHalfFloat } from '../extras/DataUtils.js';
+import { warnOnce } from '../utils.js';
 
 const _vector = /*@__PURE__*/ new Vector3();
 const _vector2 = /*@__PURE__*/ new Vector2();
@@ -45,7 +46,7 @@ class BufferAttribute {
 
 	get updateRange() {
 
-		console.warn( 'THREE.BufferAttribute: updateRange() is deprecated and will be removed in r169. Use addUpdateRange() instead.' ); // @deprecated, r159
+		warnOnce( 'THREE.BufferAttribute: updateRange() is deprecated and will be removed in r169. Use addUpdateRange() instead.' ); // @deprecated, r159
 		return this._updateRange;
 
 	}

--- a/src/core/InterleavedBuffer.js
+++ b/src/core/InterleavedBuffer.js
@@ -1,5 +1,6 @@
 import * as MathUtils from '../math/MathUtils.js';
 import { StaticDrawUsage } from '../constants.js';
+import { warnOnce } from '../utils.js';
 
 class InterleavedBuffer {
 
@@ -31,7 +32,7 @@ class InterleavedBuffer {
 
 	get updateRange() {
 
-		console.warn( 'THREE.InterleavedBuffer: updateRange() is deprecated and will be removed in r169. Use addUpdateRange() instead.' ); // @deprecated, r159
+		warnOnce( 'THREE.InterleavedBuffer: updateRange() is deprecated and will be removed in r169. Use addUpdateRange() instead.' ); // @deprecated, r159
 		return this._updateRange;
 
 	}


### PR DESCRIPTION
**Description**

Some libraries and utlilities update meshes _a lot_, for example particle systems like three.quarks.
This PR changes the warning on using deprecated buffer updateRange methods to warnOnce to prevent tens of thousands of logs per second.

<img width="689" alt="image" src="https://github.com/mrdoob/three.js/assets/2693840/4b94b1c5-8c22-44f9-bb96-0c1ca8e3291a">

*This contribution is funded by [Needle](https://needle.tools)*
