### PR TITLE
WebGPURenderer: Add timestamp queries support in WebGPU

### DIFF
--- a/examples/jsm/objects/QuadMesh.js
+++ b/examples/jsm/objects/QuadMesh.js
@@ -37,9 +37,9 @@ class QuadMesh {
 
 	}
 
-	render( renderer ) {
+	async render( renderer ) {
 
-		renderer.render( this._mesh, _camera );
+		await renderer.render( this._mesh, _camera );
 
 	}
 

--- a/examples/jsm/objects/QuadMesh.js
+++ b/examples/jsm/objects/QuadMesh.js
@@ -37,9 +37,9 @@ class QuadMesh {
 
 	}
 
-	async render( renderer ) {
+	async renderAsync( renderer ) {
 
-		await renderer.render( this._mesh, _camera );
+		await renderer.renderAsync( this._mesh, _camera );
 
 	}
 
@@ -52,6 +52,12 @@ class QuadMesh {
 	set material( value ) {
 
 		this._mesh.material = value;
+
+	}
+
+	get render() {
+
+		return this.renderAsync;
 
 	}
 

--- a/examples/jsm/renderers/common/Backend.js
+++ b/examples/jsm/renderers/common/Backend.js
@@ -90,6 +90,8 @@ class Backend {
 
 	// utils
 
+	resolveTimeStampAsync( renderContext, type ) { }
+
 	hasFeatureAsync( name ) { } // return Boolean
 
 	hasFeature( name ) { } // return Boolean

--- a/examples/jsm/renderers/common/Info.js
+++ b/examples/jsm/renderers/common/Info.js
@@ -66,6 +66,14 @@ class Info {
 
 	}
 
+	resetCompute() {
+
+		this.compute.computeCalls = 0;
+
+		this.timestamp.compute = 0;
+
+	}
+
 	reset() {
 
 		this.render.drawCalls = 0;
@@ -73,9 +81,6 @@ class Info {
 		this.render.points = 0;
 		this.render.lines = 0;
 
-		this.compute.computeCalls = 0;
-
-		this.timestamp.compute = 0;
 		this.timestamp.render = 0;
 
 	}

--- a/examples/jsm/renderers/common/Info.js
+++ b/examples/jsm/renderers/common/Info.js
@@ -16,12 +16,18 @@ class Info {
 		};
 
 		this.compute = {
-			calls: 0
+			calls: 0,
+			computeCalls: 0
 		};
 
 		this.memory = {
 			geometries: 0,
 			textures: 0
+		};
+
+		this.timestamp = {
+			compute: 0,
+			render: 0
 		};
 
 	}
@@ -54,12 +60,23 @@ class Info {
 
 	}
 
+	updateTimestamp( type, time ) {
+
+		this.timestamp[ type ] += time;
+
+	}
+
 	reset() {
 
 		this.render.drawCalls = 0;
 		this.render.triangles = 0;
 		this.render.points = 0;
 		this.render.lines = 0;
+
+		this.compute.computeCalls = 0;
+
+		this.timestamp.compute = 0;
+		this.timestamp.render = 0;
 
 	}
 
@@ -72,6 +89,8 @@ class Info {
 		this.render.calls = 0;
 		this.compute.calls = 0;
 
+		this.timestamp.compute = 0;
+		this.timestamp.render = 0;
 		this.memory.geometries = 0;
 		this.memory.textures = 0;
 

--- a/examples/jsm/renderers/common/PostProcessing.js
+++ b/examples/jsm/renderers/common/PostProcessing.js
@@ -12,11 +12,11 @@ class PostProcessing {
 
 	}
 
-	render() {
+	async render() {
 
 		quadMesh.material.fragmentNode = this.outputNode;
 
-		quadMesh.render( this.renderer );
+		await quadMesh.render( this.renderer );
 
 	}
 

--- a/examples/jsm/renderers/common/Renderer.js
+++ b/examples/jsm/renderers/common/Renderer.js
@@ -357,6 +357,9 @@ class Renderer {
 
 		sceneRef.onAfterRender( this, scene, camera, renderTarget );
 
+
+		await this.backend.resolveTimeStampAsync( renderContext, 'render' );
+
 	}
 
 	getMaxAnisotropy() {
@@ -715,6 +718,7 @@ class Renderer {
 		nodeFrame.renderId = this.info.calls;
 
 		//
+		if ( this.info.autoReset === true ) this.info.resetCompute();
 
 		const backend = this.backend;
 		const pipelines = this._pipelines;
@@ -765,6 +769,8 @@ class Renderer {
 		}
 
 		backend.finishCompute( computeNodes );
+
+		await this.backend.resolveTimeStampAsync( computeNodes, 'compute' );
 
 		//
 

--- a/examples/jsm/renderers/common/Renderer.js
+++ b/examples/jsm/renderers/common/Renderer.js
@@ -710,6 +710,7 @@ class Renderer {
 
 		this.info.calls ++;
 		this.info.compute.calls ++;
+		this.info.compute.computeCalls ++;
 
 		nodeFrame.renderId = this.info.calls;
 

--- a/examples/jsm/renderers/common/Renderer.js
+++ b/examples/jsm/renderers/common/Renderer.js
@@ -182,7 +182,7 @@ class Renderer {
 
 	}
 
-	async render( scene, camera ) {
+	async renderAsync( scene, camera ) {
 
 		if ( this._initialized === false ) await this.init();
 
@@ -701,7 +701,7 @@ class Renderer {
 
 	}
 
-	async compute( computeNodes ) {
+	async computeAsync( computeNodes ) {
 
 		if ( this._initialized === false ) await this.init();
 
@@ -1041,6 +1041,19 @@ class Renderer {
 		//
 
 		this.backend.draw( renderObject, this.info );
+
+	}
+
+
+	get compute() {
+
+		return this.computeAsync;
+
+	}
+
+	get render() {
+
+		return this.renderAsync;
 
 	}
 

--- a/examples/jsm/renderers/webgpu/WebGPUBackend.js
+++ b/examples/jsm/renderers/webgpu/WebGPUBackend.js
@@ -498,7 +498,6 @@ class WebGPUBackend extends Backend {
 
 		this.device.queue.submit( [ renderContextData.encoder.finish() ] );
 
-		this.resolveTimeStampAsync( renderContext, 'render' );
 
 		//
 
@@ -771,8 +770,6 @@ class WebGPUBackend extends Backend {
 		this.prepareTimeStampBuffer( computeGroup, groupData.cmdEncoderGPU );
 
 		this.device.queue.submit( [ groupData.cmdEncoderGPU.finish() ] );
-
-		this.resolveTimeStampAsync( computeGroup, 'compute' );
 
 	}
 

--- a/examples/jsm/renderers/webgpu/WebGPUBackend.js
+++ b/examples/jsm/renderers/webgpu/WebGPUBackend.js
@@ -43,7 +43,7 @@ class WebGPUBackend extends Backend {
 
 		this.parameters.requiredLimits = ( parameters.requiredLimits === undefined ) ? {} : parameters.requiredLimits;
 
-		this.trackTimestampQueries = ( parameters.trackTimestampQueries === true );
+		this.trackTimestamp = ( parameters.trackTimestamp === true );
 
 		this.adapter = null;
 		this.device = null;
@@ -1033,7 +1033,7 @@ class WebGPUBackend extends Backend {
 
 	initTimeStampQuery( renderContext, descriptor ) {
 
-		if ( ! this.hasFeature( GPUFeatureName.TimestampQuery ) || ! this.trackTimestampQueries ) return;
+		if ( ! this.hasFeature( GPUFeatureName.TimestampQuery ) || ! this.trackTimestamp ) return;
 
 		const renderContextData = this.get( renderContext );
 
@@ -1061,7 +1061,7 @@ class WebGPUBackend extends Backend {
 
 	prepareTimeStampBuffer( renderContext, encoder ) {
 
-		if ( ! this.hasFeature( GPUFeatureName.TimestampQuery ) || ! this.trackTimestampQueries ) return;
+		if ( ! this.hasFeature( GPUFeatureName.TimestampQuery ) || ! this.trackTimestamp ) return;
 
 		const renderContextData = this.get( renderContext );
 
@@ -1085,7 +1085,7 @@ class WebGPUBackend extends Backend {
 
 	async resolveTimeStampAsync( renderContext, type = 'render' ) {
 
-		if ( ! this.hasFeature( GPUFeatureName.TimestampQuery ) || ! this.trackTimestampQueries ) return;
+		if ( ! this.hasFeature( GPUFeatureName.TimestampQuery ) || ! this.trackTimestamp ) return;
 
 		const renderContextData = this.get( renderContext );
 

--- a/examples/webgpu_compute_particles.html
+++ b/examples/webgpu_compute_particles.html
@@ -283,16 +283,23 @@ const timestamps = document.getElementById( 'timestamps' );
 
 				renderer.compute( computeParticles );
 
-	// console.log( `Compute ${renderer.info.compute.computeCalls} pass in ${renderer.info.timestamp.compute}ms` );
-	// console.log( `Draw ${renderer.info.render.drawCalls} pass in ${renderer.info.timestamp.render}ms` );
 
 	// throttle the logging
 
-	if ( renderer.info.render.calls % 10 === 0 ) {
+	if ( renderer.hasFeature( 'timestamp-query' ) ) {
 
-		timestamps.innerHTML = `
-Compute ${renderer.info.compute.computeCalls} pass in ${renderer.info.timestamp.compute}ms<br>
-Draw ${renderer.info.render.drawCalls} pass in ${renderer.info.timestamp.render}ms`;
+		if ( renderer.info.render.calls % 10 === 0 ) {
+
+			timestamps.innerHTML = `
+
+            Compute ${renderer.info.compute.computeCalls} pass in ${renderer.info.timestamp.compute}ms<br>
+            Draw ${renderer.info.render.drawCalls} pass in ${renderer.info.timestamp.render}ms`;
+
+		}
+
+	} else {
+
+		timestamps.innerHTML = 'Timestamp queries not supported';
 
 	}
 

--- a/examples/webgpu_compute_particles.html
+++ b/examples/webgpu_compute_particles.html
@@ -9,19 +9,19 @@
 
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> WebGPU - Compute - 1M Particles
-            <div id="timestamps" style="
-                position: absolute;
-                top: 60px;
-                left: 0;
-                padding: 10px;
-                background: rgba( 0, 0, 0, 0.5 );
-                color: #fff;
-                font-family: monospace;
-                font-size: 12px;
-                line-height: 1.5;
-                pointer-events: none;
-                text-align: left;
-            "></div>
+			<div id="timestamps" style="
+				position: absolute;
+				top: 60px;
+				left: 0;
+				padding: 10px;
+				background: rgba( 0, 0, 0, 0.5 );
+				color: #fff;
+				font-family: monospace;
+				font-size: 12px;
+				line-height: 1.5;
+				pointer-events: none;
+				text-align: left;
+			"></div>
 		</div>
 
 		<script type="importmap">
@@ -191,7 +191,8 @@
 				document.body.appendChild( stats.dom );
 
 				//
-	            renderer.info.autoReset = false;
+
+				renderer.info.autoReset = false;
 
 				renderer.compute( computeInit );
 

--- a/examples/webgpu_compute_particles.html
+++ b/examples/webgpu_compute_particles.html
@@ -62,7 +62,8 @@
 			let controls, stats;
 			let computeParticles;
 
-const timestamps = document.getElementById( 'timestamps' );
+			const timestamps = document.getElementById( 'timestamps' );
+
 			init();
 
 			function init() {
@@ -180,7 +181,7 @@ const timestamps = document.getElementById( 'timestamps' );
 
 				//
 
-				renderer = new WebGPURenderer( { antialias: true, trackTimestampQueries: true } );
+				renderer = new WebGPURenderer( { antialias: true, trackTimestamp: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setAnimationLoop( animate );
@@ -190,6 +191,7 @@ const timestamps = document.getElementById( 'timestamps' );
 				document.body.appendChild( stats.dom );
 
 				//
+	            renderer.info.autoReset = false;
 
 				renderer.compute( computeInit );
 
@@ -241,7 +243,6 @@ const timestamps = document.getElementById( 'timestamps' );
 				// events
 
 				renderer.domElement.addEventListener( 'pointermove', onMove );
-
 				//
 
 				controls = new OrbitControls( camera, renderer.domElement );
@@ -276,35 +277,35 @@ const timestamps = document.getElementById( 'timestamps' );
 
 			}
 
-			function animate() {
+			async function animate() {
 
 				stats.update();
 
+				await renderer.compute( computeParticles );
 
-				renderer.compute( computeParticles );
+				await renderer.render( scene, camera );
 
+				// throttle the logging
 
-	// throttle the logging
+				if ( renderer.hasFeature( 'timestamp-query' ) ) {
 
-	if ( renderer.hasFeature( 'timestamp-query' ) ) {
+					if ( renderer.info.render.calls % 5 === 0 ) {
 
-		if ( renderer.info.render.calls % 10 === 0 ) {
+						timestamps.innerHTML = `
 
-			timestamps.innerHTML = `
+										Compute ${renderer.info.compute.computeCalls} pass in ${renderer.info.timestamp.compute}ms<br>
+										Draw ${renderer.info.render.drawCalls} pass in ${renderer.info.timestamp.render}ms`;
 
-            Compute ${renderer.info.compute.computeCalls} pass in ${renderer.info.timestamp.compute}ms<br>
-            Draw ${renderer.info.render.drawCalls} pass in ${renderer.info.timestamp.render}ms`;
+					}
 
-		}
+				} else {
 
-	} else {
+					timestamps.innerHTML = 'Timestamp queries not supported';
 
-		timestamps.innerHTML = 'Timestamp queries not supported';
+				}
 
-	}
-
-				renderer.render( scene, camera );
-
+	            renderer.info.resetCompute();
+				renderer.info.reset();
 
 			}
 

--- a/examples/webgpu_compute_particles.html
+++ b/examples/webgpu_compute_particles.html
@@ -281,9 +281,9 @@
 
 				stats.update();
 
-				await renderer.compute( computeParticles );
+				await renderer.computeAsync( computeParticles );
 
-				await renderer.render( scene, camera );
+				await renderer.renderAsync( scene, camera );
 
 				// throttle the logging
 
@@ -304,7 +304,7 @@
 
 				}
 
-	            renderer.info.resetCompute();
+				renderer.info.resetCompute();
 				renderer.info.reset();
 
 			}

--- a/examples/webgpu_compute_particles.html
+++ b/examples/webgpu_compute_particles.html
@@ -9,6 +9,19 @@
 
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> WebGPU - Compute - 1M Particles
+            <div id="timestamps" style="
+                position: absolute;
+                top: 60px;
+                left: 0;
+                padding: 10px;
+                background: rgba( 0, 0, 0, 0.5 );
+                color: #fff;
+                font-family: monospace;
+                font-size: 12px;
+                line-height: 1.5;
+                pointer-events: none;
+                text-align: left;
+            "></div>
 		</div>
 
 		<script type="importmap">
@@ -49,6 +62,7 @@
 			let controls, stats;
 			let computeParticles;
 
+const timestamps = document.getElementById( 'timestamps' );
 			init();
 
 			function init() {
@@ -166,7 +180,7 @@
 
 				//
 
-				renderer = new WebGPURenderer( { antialias: true } );
+				renderer = new WebGPURenderer( { antialias: true, trackTimestampQueries: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setAnimationLoop( animate );
@@ -265,8 +279,25 @@
 			function animate() {
 
 				stats.update();
+
+
 				renderer.compute( computeParticles );
+
+	// console.log( `Compute ${renderer.info.compute.computeCalls} pass in ${renderer.info.timestamp.compute}ms` );
+	// console.log( `Draw ${renderer.info.render.drawCalls} pass in ${renderer.info.timestamp.render}ms` );
+
+	// throttle the logging
+
+	if ( renderer.info.render.calls % 10 === 0 ) {
+
+		timestamps.innerHTML = `
+Compute ${renderer.info.compute.computeCalls} pass in ${renderer.info.timestamp.compute}ms<br>
+Draw ${renderer.info.render.drawCalls} pass in ${renderer.info.timestamp.render}ms`;
+
+	}
+
 				renderer.render( scene, camera );
+
 
 			}
 


### PR DESCRIPTION
This PR add support for timestamp queries to monitor WebGPU performances. (Requires Chrome 121)

In my opinion this feature should be included OOTB in the Renderer, it will be really useful to compare WebGPU vs WebGL performances and is optional (disabled by default). I will add WebGL fallback via `EXT_disjoint_timer_query_webgl2` in a second time.

The monitoring of performances can be enable with:
`new WebGPURenderer( { trackTimestamp: true } );`

Also improved the info system and honored all render calls to be async as they should (`render()` is async).
[honor async render and move to renderer await functions](https://github.com/mrdoob/three.js/pull/27597/commits/1d62772cf640892d8bccb7f29a33c6fc9ae1d1e3)

Live demo:
[https://raw.githack.com/renaudrohlinger/three.js/timestamp-queries/examples/webgpu_compute_particles.html](https://raw.githack.com/renaudrohlinger/three.js/timestamp-queries/examples/webgpu_compute_particles.html
)
![Screenshot 2024-01-20 at 18 57 30](https://github.com/mrdoob/three.js/assets/15867665/adf97dc8-57a2-4133-9352-0918a069e567)

_This contribution is funded by [Utsubo](https://utsubo.com/)_