### PR TITLE
PerspectiveCamera: getViewBounds(), getViewSize()

### DIFF
--- a/docs/api/en/cameras/PerspectiveCamera.html
+++ b/docs/api/en/cameras/PerspectiveCamera.html
@@ -118,19 +118,6 @@
 		<h3>[method:undefined clearViewOffset]()</h3>
 		<p>Removes any offset set by the [page:PerspectiveCamera.setViewOffset .setViewOffset] method.</p>
 
-		<h3>[method:Vector2 getFrustumSize]( [param:Float distance], [param:Vector2 target] )</h3>
-		<p>
-			Computes the height/width of the camera's viewable rectangle at a given distance along the viewing direction.
-			Copies the result into provided target [page:Vector2] where x is width and y is height.
-		</p>
-
-		<h3>[method:undefined getFrustumBounds]( [param:Float distance], [param:Vector2 minTarget], [param:Vector2 maxTarget] )
-		</h3>
-		<p>
-			Calculates the min/max 2D bounds of the camera's viewable rectangle at a given distance along the viewing direction.
-			Results are copied into minTarget and maxTarget input vars. 
-		</p>
-
 		<h3>[method:Float getEffectiveFOV]()</h3>
 		<p>Returns the current vertical field of view angle in degrees considering .zoom.</p>
 
@@ -156,6 +143,19 @@
 			Sets the FOV by focal length in respect to the current
 			[page:PerspectiveCamera.filmGauge .filmGauge].<br /><br />
 			By default, the focal length is specified for a 35mm (full frame) camera.
+		</p>
+
+		<h3>[method:undefined getViewBounds]( [param:Float distance], [param:Vector2 minTarget], [param:Vector2 maxTarget] )
+		</h3>
+		<p>
+			Computes the 2D bounds of the camera's viewable rectangle at a given distance along the viewing direction.
+			Sets minTarget and maxTarget to the coordinates of the lower-left and upper-right corners of the view rectangle.
+		</p>
+
+		<h3>[method:Vector2 getViewSize]( [param:Float distance], [param:Vector2 target] )</h3>
+		<p>
+			Computes the width and height of the camera's viewable rectangle at a given distance along the viewing direction.
+			Copies the result into the target Vector2, where x is width and y is height.
 		</p>
 
 		<h3>[method:undefined setViewOffset]( [param:Float fullWidth], [param:Float fullHeight], [param:Float x], [param:Float y], [param:Float width], [param:Float height] )</h3>

--- a/src/cameras/PerspectiveCamera.js
+++ b/src/cameras/PerspectiveCamera.js
@@ -106,28 +106,29 @@ class PerspectiveCamera extends Camera {
 
 	}
 
-	/*
-	 * Computes 2D bounds of the camera's frustum at a given distance along the viewing direction.
-	 * Copies max/min height and width of the frustum's rectangle into minTarget and maxTarget.
-	 * Results are in the camera's local coordinate space, independent of its global position/rotation/scale.
+	/**
+	 * Computes the 2D bounds of the camera's viewable rectangle at a given distance along the viewing direction.
+	 * Sets minTarget and maxTarget to the coordinates of the lower-left and upper-right corners of the view rectangle.
 	 */
-	getFrustumBounds( distance, minTarget, maxTarget ) {
+	getViewBounds( distance, minTarget, maxTarget ) {
 
 		_v3.set( - 1, - 1, 0.5 ).applyMatrix4( this.projectionMatrixInverse );
-		minTarget.copy( _v3 ).multiplyScalar( - distance / _v3.z );
+
+		minTarget.set( _v3.x, _v3.y ).multiplyScalar( - distance / _v3.z );
 
 		_v3.set( 1, 1, 0.5 ).applyMatrix4( this.projectionMatrixInverse );
-		maxTarget.copy( _v3 ).multiplyScalar( - distance / _v3.z );
+
+		maxTarget.set( _v3.x, _v3.y ).multiplyScalar( - distance / _v3.z );
 
 	}
 
-	/*
-	 * Computes the height/width of the camera's frustum at a given distance along the viewing direction.
-	 * Copies the result into provided target Vector2 where x is width and y is height.
- 	 */
-	getFrustumSize( distance, target ) {
+	/**
+	 * Computes the width and height of the camera's viewable rectangle at a given distance along the viewing direction.
+	 * Copies the result into the target Vector2, where x is width and y is height.
+	 */
+	getViewSize( distance, target ) {
 
-		this.getFrustumBounds( distance, _minTarget, _maxTarget );
+		this.getViewBounds( distance, _minTarget, _maxTarget );
 
 		return target.subVectors( _maxTarget, _minTarget );
 


### PR DESCRIPTION
Follow-on to #27574.

This PR renames two methods to be consistent with the nomenclature [suggested](https://github.com/mrdoob/three.js/issues/27556#issuecomment-1890952649) by @gkjohnson.

It also parallels the existing nomenclature: `setViewOffset()`, `clearViewOffset()`.

`getViewBounds()` and `getViewSize()` work correctly when a view offset is specified.