### PR TITLE
Manual: Refactor canvas width and height computation.

### DIFF
--- a/manual/en/responsive.html
+++ b/manual/en/responsive.html
@@ -228,8 +228,8 @@ you passed in. <strong>This is strongly NOT RECOMMENDED</strong>. See below</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">    function resizeRendererToDisplaySize(renderer) {
       const canvas = renderer.domElement;
       const pixelRatio = window.devicePixelRatio;
-      const width  = canvas.clientWidth  * pixelRatio | 0;
-      const height = canvas.clientHeight * pixelRatio | 0;
+      const width  = canvas.clientWidth  * pixelRatio | 1;
+      const height = canvas.clientHeight * pixelRatio | 1;
       const needResize = canvas.width !== width || canvas.height !== height;
       if (needResize) {
         renderer.setSize(width, height, false);

--- a/manual/en/responsive.html
+++ b/manual/en/responsive.html
@@ -228,8 +228,8 @@ you passed in. <strong>This is strongly NOT RECOMMENDED</strong>. See below</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">    function resizeRendererToDisplaySize(renderer) {
       const canvas = renderer.domElement;
       const pixelRatio = window.devicePixelRatio;
-      const width  = canvas.clientWidth  * pixelRatio | 1;
-      const height = canvas.clientHeight * pixelRatio | 1;
+      const width  = Math.floor(canvas.clientWidth  * pixelRatio);
+      const height = Math.floor(canvas.clientHeight * pixelRatio);
       const needResize = canvas.width !== width || canvas.height !== height;
       if (needResize) {
         renderer.setSize(width, height, false);

--- a/manual/examples/responsive-hd-dpi.html
+++ b/manual/examples/responsive-hd-dpi.html
@@ -83,8 +83,8 @@ function main() {
 
 		const canvas = renderer.domElement;
 		const pixelRatio = window.devicePixelRatio;
-		const width = canvas.clientWidth * pixelRatio | 1;
-		const height = canvas.clientHeight * pixelRatio | 1;
+		const width = Math.floor(canvas.clientWidth * pixelRatio);
+		const height = Math.floor(canvas.clientHeight * pixelRatio);
 		const needResize = canvas.width !== width || canvas.height !== height;
 		if ( needResize ) {
 

--- a/manual/examples/responsive-hd-dpi.html
+++ b/manual/examples/responsive-hd-dpi.html
@@ -83,8 +83,8 @@ function main() {
 
 		const canvas = renderer.domElement;
 		const pixelRatio = window.devicePixelRatio;
-		const width = canvas.clientWidth * pixelRatio | 0;
-		const height = canvas.clientHeight * pixelRatio | 0;
+		const width = canvas.clientWidth * pixelRatio | 1;
+		const height = canvas.clientHeight * pixelRatio | 1;
 		const needResize = canvas.width !== width || canvas.height !== height;
 		if ( needResize ) {
 

--- a/manual/fr/responsive.html
+++ b/manual/fr/responsive.html
@@ -235,8 +235,8 @@ ratio que vous avez demandé.
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">    function resizeRendererToDisplaySize(renderer) {
       const canvas = renderer.domElement;
       const pixelRatio = window.devicePixelRatio;
-      const width  = canvas.clientWidth  * pixelRatio | 0;
-      const height = canvas.clientHeight * pixelRatio | 0;
+      const width  = canvas.clientWidth  * pixelRatio | 1;
+      const height = canvas.clientHeight * pixelRatio | 1;
       const needResize = canvas.width !== width || canvas.height !== height;
       if (needResize) {
         renderer.setSize(width, height, false);

--- a/manual/fr/responsive.html
+++ b/manual/fr/responsive.html
@@ -235,8 +235,8 @@ ratio que vous avez demandé.
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">    function resizeRendererToDisplaySize(renderer) {
       const canvas = renderer.domElement;
       const pixelRatio = window.devicePixelRatio;
-      const width  = canvas.clientWidth  * pixelRatio | 1;
-      const height = canvas.clientHeight * pixelRatio | 1;
+      const width  = Math.floor(canvas.clientWidth  * pixelRatio);
+      const height = Math.floor(canvas.clientHeight * pixelRatio);
       const needResize = canvas.width !== width || canvas.height !== height;
       if (needResize) {
         renderer.setSize(width, height, false);

--- a/manual/ja/responsive.html
+++ b/manual/ja/responsive.html
@@ -166,8 +166,8 @@ CSSピクセルからデバイスピクセルへの乗数をブラウザに伝�
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">    function resizeRendererToDisplaySize(renderer) {
       const canvas = renderer.domElement;
       const pixelRatio = window.devicePixelRatio;
-      const width  = canvas.clientWidth  * pixelRatio | 0;
-      const height = canvas.clientHeight * pixelRatio | 0;
+      const width  = canvas.clientWidth  * pixelRatio | 1;
+      const height = canvas.clientHeight * pixelRatio | 1;
       const needResize = canvas.width !== width || canvas.height !== height;
       if (needResize) {
         renderer.setSize(width, height, false);

--- a/manual/ja/responsive.html
+++ b/manual/ja/responsive.html
@@ -166,8 +166,8 @@ CSSピクセルからデバイスピクセルへの乗数をブラウザに伝�
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">    function resizeRendererToDisplaySize(renderer) {
       const canvas = renderer.domElement;
       const pixelRatio = window.devicePixelRatio;
-      const width  = canvas.clientWidth  * pixelRatio | 1;
-      const height = canvas.clientHeight * pixelRatio | 1;
+      const width  = Math.floor(canvas.clientWidth  * pixelRatio);
+      const height = Math.floor(canvas.clientHeight * pixelRatio);
       const needResize = canvas.width !== width || canvas.height !== height;
       if (needResize) {
         renderer.setSize(width, height, false);

--- a/manual/ko/responsive.html
+++ b/manual/ko/responsive.html
@@ -217,8 +217,8 @@ Three.js에게 넘겨주는 것이죠.</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">    function resizeRendererToDisplaySize(renderer) {
       const canvas = renderer.domElement;
       const pixelRatio = window.devicePixelRatio;
-      const width  = canvas.clientWidth  * pixelRatio | 0;
-      const height = canvas.clientHeight * pixelRatio | 0;
+      const width  = canvas.clientWidth  * pixelRatio | 1;
+      const height = canvas.clientHeight * pixelRatio | 1;
       const needResize = canvas.width !== width || canvas.height !== height;
       if (needResize) {
         renderer.setSize(width, height, false);

--- a/manual/ko/responsive.html
+++ b/manual/ko/responsive.html
@@ -217,8 +217,8 @@ Three.js에게 넘겨주는 것이죠.</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">    function resizeRendererToDisplaySize(renderer) {
       const canvas = renderer.domElement;
       const pixelRatio = window.devicePixelRatio;
-      const width  = canvas.clientWidth  * pixelRatio | 1;
-      const height = canvas.clientHeight * pixelRatio | 1;
+      const width  = Math.floor(canvas.clientWidth  * pixelRatio);
+      const height = Math.floor(canvas.clientHeight * pixelRatio);
       const needResize = canvas.width !== width || canvas.height !== height;
       if (needResize) {
         renderer.setSize(width, height, false);

--- a/manual/ru/responsive.html
+++ b/manual/ru/responsive.html
@@ -222,8 +222,8 @@ html, body {
 <pre class="prettyprint showlinemods notranslate notranslate" translate="no">    function resizeRendererToDisplaySize(renderer) {
       const canvas = renderer.domElement;
       const pixelRatio = window.devicePixelRatio;
-      const width = canvas.clientWidth * pixelRatio | 0;
-      const height = canvas.clientHeight * pixelRatio | 0;
+      const width = canvas.clientWidth * pixelRatio | 1;
+      const height = canvas.clientHeight * pixelRatio | 1;
       const needResize = canvas.width !== width || canvas.height !== height;
       if (needResize) {
         renderer.setSize(width, height, false);

--- a/manual/ru/responsive.html
+++ b/manual/ru/responsive.html
@@ -222,8 +222,8 @@ html, body {
 <pre class="prettyprint showlinemods notranslate notranslate" translate="no">    function resizeRendererToDisplaySize(renderer) {
       const canvas = renderer.domElement;
       const pixelRatio = window.devicePixelRatio;
-      const width = canvas.clientWidth * pixelRatio | 1;
-      const height = canvas.clientHeight * pixelRatio | 1;
+      const width = Math.floor(canvas.clientWidth * pixelRatio);
+      const height = Math.floor(canvas.clientHeight * pixelRatio);
       const needResize = canvas.width !== width || canvas.height !== height;
       if (needResize) {
         renderer.setSize(width, height, false);

--- a/manual/zh/responsive.html
+++ b/manual/zh/responsive.html
@@ -215,8 +215,8 @@ html, body {
         <pre class="prettyprint showlinemods notranslate lang-js" translate="no">    function resizeRendererToDisplaySize(renderer) {
       const canvas = renderer.domElement;
       const pixelRatio = window.devicePixelRatio;
-      const width = canvas.clientWidth * pixelRatio | 1;
-      const height = canvas.clientHeight * pixelRatio | 1;
+      const width = Math.floor(canvas.clientWidth * pixelRatio);
+      const height = Math.floor(canvas.clientHeight * pixelRatio);
       const needResize = canvas.width !== width || canvas.height !== height;
       if (needResize) {
         renderer.setSize(width, height, false);

--- a/manual/zh/responsive.html
+++ b/manual/zh/responsive.html
@@ -215,8 +215,8 @@ html, body {
         <pre class="prettyprint showlinemods notranslate lang-js" translate="no">    function resizeRendererToDisplaySize(renderer) {
       const canvas = renderer.domElement;
       const pixelRatio = window.devicePixelRatio;
-      const width = canvas.clientWidth * pixelRatio | 0;
-      const height = canvas.clientHeight * pixelRatio | 0;
+      const width = canvas.clientWidth * pixelRatio | 1;
+      const height = canvas.clientHeight * pixelRatio | 1;
       const needResize = canvas.width !== width || canvas.height !== height;
       if (needResize) {
         renderer.setSize(width, height, false);


### PR DESCRIPTION
**Description**

I think the examples should say device pixel ratio OR 1, instead of OR 0, then it would get a zero size
