### PR TITLE
WebGLRenderer: Add 'AgXPunchyToneMapping'

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -57,6 +57,7 @@ export const CineonToneMapping = 3;
 export const ACESFilmicToneMapping = 4;
 export const CustomToneMapping = 5;
 export const AgXToneMapping = 6;
+export const AgXPunchyToneMapping = 7;
 export const AttachedBindMode = 'attached';
 export const DetachedBindMode = 'detached';
 

--- a/src/renderers/shaders/ShaderChunk/tonemapping_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/tonemapping_pars_fragment.glsl.js
@@ -115,6 +115,16 @@ vec3 agxDefaultContrastApprox( vec3 x ) {
 
 vec3 agxLook( vec3 color, uint look ) {
 
+    if ( look == AGX_LOOK_BASE ) {
+
+        return color;
+
+    }
+
+    const vec3 lw = vec3( 0.2126, 0.7152, 0.0722 );
+
+    float luma = dot( color, lw );
+
     vec3 offset = vec3( 0.0 );
     vec3 slope = vec3( 1.0 );
     vec3 power = vec3( 1.0 );
@@ -129,7 +139,9 @@ vec3 agxLook( vec3 color, uint look ) {
     }
 
     // ASC CDL
-    return pow( color * slope + offset, power );
+    color = pow( color * slope + offset, power );
+
+    return luma + sat * ( color - luma );
 
 }
 

--- a/src/renderers/shaders/ShaderChunk/tonemapping_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/tonemapping_pars_fragment.glsl.js
@@ -93,8 +93,8 @@ const mat3 LINEAR_SRGB_TO_LINEAR_REC2020 = mat3(
 // https://github.com/google/filament/pull/7236
 // Inputs and outputs are encoded as Linear-sRGB.
 
-#define AGX_LOOK_BASE 0u
-#define AGX_LOOK_PUNCHY 1u
+#define AGX_LOOK_BASE 0
+#define AGX_LOOK_PUNCHY 1
 
 // https://iolite-engine.com/blog_posts/minimal_agx_implementation
 // Mean error^2: 3.6705141e-06
@@ -113,7 +113,7 @@ vec3 agxDefaultContrastApprox( vec3 x ) {
 
 }
 
-vec3 agxLook( vec3 color, uint look ) {
+vec3 agxLook( vec3 color, int look ) {
 
     if ( look == AGX_LOOK_BASE ) {
 
@@ -145,7 +145,7 @@ vec3 agxLook( vec3 color, uint look ) {
 
 }
 
-vec3 AgXToneMapping( vec3 color, uint look ) {
+vec3 AgXToneMapping( vec3 color, int look ) {
 
 	// AgX constants
 	const mat3 AgXInsetMatrix = mat3(

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -1,7 +1,7 @@
 import { WebGLUniforms } from './WebGLUniforms.js';
 import { WebGLShader } from './WebGLShader.js';
 import { ShaderChunk } from '../shaders/ShaderChunk.js';
-import { NoToneMapping, AddOperation, MixOperation, MultiplyOperation, CubeRefractionMapping, CubeUVReflectionMapping, CubeReflectionMapping, PCFSoftShadowMap, PCFShadowMap, VSMShadowMap, AgXToneMapping, ACESFilmicToneMapping, CineonToneMapping, CustomToneMapping, ReinhardToneMapping, LinearToneMapping, GLSL3, LinearSRGBColorSpace, SRGBColorSpace, LinearDisplayP3ColorSpace, DisplayP3ColorSpace, P3Primaries, Rec709Primaries } from '../../constants.js';
+import { NoToneMapping, AddOperation, MixOperation, MultiplyOperation, CubeRefractionMapping, CubeUVReflectionMapping, CubeReflectionMapping, PCFSoftShadowMap, PCFShadowMap, VSMShadowMap, AgXToneMapping, AgXPunchyToneMapping, ACESFilmicToneMapping, CineonToneMapping, CustomToneMapping, ReinhardToneMapping, LinearToneMapping, GLSL3, LinearSRGBColorSpace, SRGBColorSpace, LinearDisplayP3ColorSpace, DisplayP3ColorSpace, P3Primaries, Rec709Primaries } from '../../constants.js';
 import { ColorManagement } from '../../math/ColorManagement.js';
 
 // From https://www.khronos.org/registry/webgl/extensions/KHR_parallel_shader_compile/
@@ -122,6 +122,10 @@ function getToneMappingFunction( functionName, toneMapping ) {
 
 		case AgXToneMapping:
 			toneMappingName = 'AgX';
+			break;
+
+		case AgXPunchyToneMapping:
+			toneMappingName = 'AgXPunchy';
 			break;
 
 		case CustomToneMapping:


### PR DESCRIPTION
Related issue: 

- #27362 

**Description**

Adds THREE.AgXPunchyToneMapping, as found in Blender and Filament. A more contrasty and saturated look, intended for sRGB displays. Intended to provide easier workflows to/from Blender, while retaining a more similar look to what users are currently getting from ACES Filmic.

## Comparisons

_From left to right: linear • agx • agx-punchy • aces-filmic._

> [!CAUTION]
> In the screenshots below, the third column ("agx-punchy") is out of date based on comments in https://github.com/mrdoob/three.js/pull/27618#discussion_r1465757969. I'll update the screenshots soon, and would expect a boost in saturation for the entire column.

![game_fps](https://github.com/mrdoob/three.js/assets/1848368/8f31c7b5-fa95-4c80-b7fa-0b68cea21cbd)
![keyframes](https://github.com/mrdoob/three.js/assets/1848368/1cafad69-fc3c-423a-90f7-a037df204499)
![anisotropy](https://github.com/mrdoob/three.js/assets/1848368/af325c64-4ee6-4b70-b3c5-bf425aaad0b4)
![compressed](https://github.com/mrdoob/three.js/assets/1848368/eee9a132-bd68-4810-921f-e898d49fe08e)
![lights](https://github.com/mrdoob/three.js/assets/1848368/0eb176af-aeb2-4272-a1c1-f5a4b3b9807f)
![sheen](https://github.com/mrdoob/three.js/assets/1848368/30952cef-c8b9-4d36-95fc-21c6149dcc0e)
![ldraw](https://github.com/mrdoob/three.js/assets/1848368/74a87bb9-50c5-446c-9a33-c477155c9674)
![ground_envmap](https://github.com/mrdoob/three.js/assets/1848368/39de3da7-13f4-4c4c-8dcd-626a10722abf)

