### PR TITLE
WebGPURenderer: Fix ambiguous field in WebGL Backend

### DIFF
--- a/examples/jsm/nodes/accessors/CameraNode.js
+++ b/examples/jsm/nodes/accessors/CameraNode.js
@@ -1,6 +1,6 @@
 import Object3DNode from './Object3DNode.js';
 import { addNodeClass } from '../core/Node.js';
-import { label } from '../core/ContextNode.js';
+// import { label } from '../core/ContextNode.js';
 import { NodeUpdateType } from '../core/constants.js';
 //import { sharedUniformGroup } from '../core/UniformGroupNode.js';
 import { nodeImmutable } from '../shadernode/ShaderNode.js';

--- a/examples/jsm/nodes/accessors/CameraNode.js
+++ b/examples/jsm/nodes/accessors/CameraNode.js
@@ -107,8 +107,8 @@ CameraNode.LOG_DEPTH = 'logDepth';
 
 export default CameraNode;
 
-export const cameraProjectionMatrix = label( nodeImmutable( CameraNode, CameraNode.PROJECTION_MATRIX ), 'projectionMatrix' );
-export const cameraProjectionMatrixInverse = label( nodeImmutable( CameraNode, CameraNode.PROJECTION_MATRIX_INVERSE ), 'projectionMatrixInverse' );
+export const cameraProjectionMatrix = nodeImmutable( CameraNode, CameraNode.PROJECTION_MATRIX );
+export const cameraProjectionMatrixInverse = nodeImmutable( CameraNode, CameraNode.PROJECTION_MATRIX_INVERSE );
 export const cameraNear = nodeImmutable( CameraNode, CameraNode.NEAR );
 export const cameraFar = nodeImmutable( CameraNode, CameraNode.FAR );
 export const cameraLogDepth = nodeImmutable( CameraNode, CameraNode.LOG_DEPTH );

--- a/examples/jsm/nodes/accessors/CameraNode.js
+++ b/examples/jsm/nodes/accessors/CameraNode.js
@@ -1,6 +1,5 @@
 import Object3DNode from './Object3DNode.js';
 import { addNodeClass } from '../core/Node.js';
-// import { label } from '../core/ContextNode.js';
 import { NodeUpdateType } from '../core/constants.js';
 //import { sharedUniformGroup } from '../core/UniformGroupNode.js';
 import { nodeImmutable } from '../shadernode/ShaderNode.js';


### PR DESCRIPTION
Not sure what is the purpose of labeling in that context but using `cameraProjectionMatrix` in a `tslFn` that then gets translated to a fragment shader seems to break in the WebGL Backend in Google Chrome (not Firefox).

Removing the labels seems to fix the issue.

<img width="651" alt="image" src="https://github.com/mrdoob/three.js/assets/15867665/6dee15d4-0b96-4b86-bd98-fd0f74b448fe">

_This contribution is funded by [Utsubo](https://utsubo.com/)_
