### PR TITLE
OrbitControls: Add missing epsilon to change check

### DIFF
--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -395,7 +395,7 @@ class OrbitControls extends EventDispatcher {
 				if ( zoomChanged ||
 					lastPosition.distanceToSquared( scope.object.position ) > EPS ||
 					8 * ( 1 - lastQuaternion.dot( scope.object.quaternion ) ) > EPS ||
-					lastTargetPosition.distanceToSquared( scope.target ) > 0 ) {
+					lastTargetPosition.distanceToSquared( scope.target ) > EPS ) {
 
 					scope.dispatchEvent( _changeEvent );
 


### PR DESCRIPTION
**Description**

OrbitControls returns a boolean value denoting if the camera has been changed or not. To determine a change, it checks if the camera position, target, and rotation have been modified. These values have to be checked against epsilon as to not see floating point precision errors.

Thehe camera target change check is missing this epsilon limit and therefore change events are fired significantly longer than they should and after camera change has stopped.

@N8python @mrdoob  I noticed this error when adding support for N8AO accumulation, since this causes accumulation to wait several (~10 seconds) after a pan event has occurred and the camera stop moving.

*This contribution is funded by [Protex](https://oneprotex.com).*