### PR TITLE
WebGPURenderer: Fix `viewportCoordinate`

### DIFF
--- a/examples/jsm/nodes/display/ViewportNode.js
+++ b/examples/jsm/nodes/display/ViewportNode.js
@@ -93,7 +93,7 @@ class ViewportNode extends Node {
 
 			let coord = builder.getFragCoord();
 
-			if ( builder.isFlipY() ) {
+			if ( ! builder.isFlipY() ) {
 
 				// follow webgpu standards
 

--- a/examples/jsm/nodes/display/ViewportNode.js
+++ b/examples/jsm/nodes/display/ViewportNode.js
@@ -93,7 +93,7 @@ class ViewportNode extends Node {
 
 			let coord = builder.getFragCoord();
 
-			if ( ! builder.isFlipY() ) {
+			if ( builder.isFlipY() === false ) {
 
 				// follow webgpu standards
 


### PR DESCRIPTION
The issue was actually that `isFlipY` was inverted. It is false with the `WGSLNodeBuilder` and true with `GLSL`. 😄  @sunag

Related:
https://github.com/mrdoob/three.js/pull/27559
https://github.com/mrdoob/three.js/pull/27566