### PR TITLE
Timer: only update delta and elapsed time when document is visible

### DIFF
--- a/examples/jsm/misc/Timer.js
+++ b/examples/jsm/misc/Timer.js
@@ -74,7 +74,7 @@ class Timer {
 	update( timestamp ) {
 
 
-		if ( this._usePageVisibilityAPI === true && document.hidden ) {
+		if ( this._usePageVisibilityAPI === true && document.hidden === true ) {
 
 			this._delta = 0;
 

--- a/examples/jsm/misc/Timer.js
+++ b/examples/jsm/misc/Timer.js
@@ -73,11 +73,20 @@ class Timer {
 
 	update( timestamp ) {
 
-		this._previousTime = this._currentTime;
-		this._currentTime = ( timestamp !== undefined ? timestamp : now() ) - this._startTime;
 
-		this._delta = ( this._currentTime - this._previousTime ) * this._timescale;
-		this._elapsed += this._delta; // _elapsed is the accumulation of all previous deltas
+		if ( this._usePageVisibilityAPI === true && document.hidden ) {
+
+			this._delta = 0;
+
+		} else {
+
+			this._previousTime = this._currentTime;
+			this._currentTime = ( timestamp !== undefined ? timestamp : now() ) - this._startTime;
+
+			this._delta = ( this._currentTime - this._previousTime ) * this._timescale;
+			this._elapsed += this._delta; // _elapsed is the accumulation of all previous deltas
+
+		}
 
 		return this;
 


### PR DESCRIPTION
Fixed #27626 

**Description**

As [suggested](https://github.com/mrdoob/three.js/issues/27626#issuecomment-1912814524) in the linked issue, a check on `document.hidden` in `Timer.update` to ensure that any rAF happening while the page is hidden does not result in elapsed time. The `_delta` is explicitly set to `0`, otherwise `getDelta` would continue to return the last computed delta.

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Fern Solutions](https://fern.solutions)*
