### PR TITLE
SkeletonUtils: Fix `retargetClip()` duration and last frame handling.

### DIFF
--- a/examples/jsm/utils/SkeletonUtils.js
+++ b/examples/jsm/utils/SkeletonUtils.js
@@ -200,7 +200,8 @@ function retarget( target, source, options = {} ) {
 function retargetClip( target, source, clip, options = {} ) {
 
 	options.useFirstFramePosition = options.useFirstFramePosition !== undefined ? options.useFirstFramePosition : false;
-	options.fps = options.fps !== undefined ? options.fps : ( clip.tracks[ 0 ].times.length / clip.duration );
+	// Calculate the fps from the source clip based on the track with the most frames, unless fps is already provided.
+	options.fps = options.fps !== undefined ? options.fps : ( Math.max( ...clip.tracks.map( track => track.times.length ) ) / clip.duration );
 	options.names = options.names || [];
 
 	if ( ! source.isObject3D ) {

--- a/examples/jsm/utils/SkeletonUtils.js
+++ b/examples/jsm/utils/SkeletonUtils.js
@@ -210,7 +210,7 @@ function retargetClip( target, source, clip, options = {} ) {
 	}
 
 	const numFrames = Math.round( clip.duration * ( options.fps / 1000 ) * 1000 ),
-		delta = 1 / options.fps,
+		delta = clip.duration / ( numFrames - 1 ),
 		convertedTracks = [],
 		mixer = new AnimationMixer( source ),
 		bones = getBones( target.skeleton ),
@@ -287,7 +287,17 @@ function retargetClip( target, source, clip, options = {} ) {
 
 		}
 
-		mixer.update( delta );
+		if ( i === numFrames - 2 ) {
+
+			// last mixer update before final loop iteration
+			// make sure we do not go over or equal to clip duration
+			mixer.update( delta - 0.0000001 );
+
+		} else {
+
+			mixer.update( delta );
+
+		}
 
 		source.updateMatrixWorld();
 

--- a/examples/jsm/utils/SkeletonUtils.js
+++ b/examples/jsm/utils/SkeletonUtils.js
@@ -200,7 +200,7 @@ function retarget( target, source, options = {} ) {
 function retargetClip( target, source, clip, options = {} ) {
 
 	options.useFirstFramePosition = options.useFirstFramePosition !== undefined ? options.useFirstFramePosition : false;
-	options.fps = options.fps !== undefined ? options.fps : 30;
+	options.fps = options.fps !== undefined ? options.fps : ( clip.tracks[ 0 ].times.length / clip.duration );
 	options.names = options.names || [];
 
 	if ( ! source.isObject3D ) {


### PR DESCRIPTION
Fixed #25288

**Description**

## Description

This PR addresses two main issues in the animation retargeting process:

### Issue 1: Incorrect Delta Calculation

**Problem**: The calculation of the relation between `numFrames` and `delta` was incorrect. 

**Expected Behavior**: For an animation lasting 2 seconds with 3 frames spaced evenly, the expected delta should be 1s.

- **Frame 0:** 0s
- **Frame 1:** 1s
- **Frame 2:** 2s

For a given 1.5 FPS ( 3 frames / 2 seconds ) = 1.5
amount of frames = Duration ( 2s ) * 1.5 FPS = 3 frames
**New Formula**: The revised formula correctly calculates the delta:
duration (2s) / (amount of frames (3) - 1) => 1s
**Old Formula**: Previously, the formula incorrectly calculated the delta:
1 second / FPS (1.5) => 0.666666s
**Impact**: This incorrect delta calculation resulted in the animation retrieving the wrong part, leading to a shortened and trimmed appearance.

### Issue 2: Incorrect Last Frame in Loop

**Problem**: In the final loop iteration, the last frame was identical to the first frame, instead of representing the state of the last frame of the original animation.

To illustrate, here is how a 3 frame animation loop back to its start position without that fix.
Before adding if ( i === numFrames - 2 )  
https://github.com/mrdoob/three.js/assets/7174039/c2bb49ef-3810-4b53-b6d4-a0e413a8140f
After 
https://github.com/mrdoob/three.js/assets/7174039/226ed358-bc8d-4d38-bdde-5354b25c5953



