### PR TITLE
webgl_camera example: Remove unnecessary clear()

### DIFF
--- a/examples/webgl_camera.html
+++ b/examples/webgl_camera.html
@@ -133,7 +133,6 @@
 				renderer.setSize( SCREEN_WIDTH, SCREEN_HEIGHT );
 				container.appendChild( renderer.domElement );
 
-				renderer.autoClear = false;
 				renderer.setScissorTest( true );
 
 				//
@@ -250,8 +249,6 @@
 
 				renderer.setClearColor( 0x000000, 1 );
 				renderer.setScissor( 0, 0, SCREEN_WIDTH / 2, SCREEN_HEIGHT );
-				renderer.clear();
-
 				renderer.setViewport( 0, 0, SCREEN_WIDTH / 2, SCREEN_HEIGHT );
 				renderer.render( scene, activeCamera );
 
@@ -261,8 +258,6 @@
 
 				renderer.setClearColor( 0x111111, 1 );
 				renderer.setScissor( SCREEN_WIDTH / 2, 0, SCREEN_WIDTH / 2, SCREEN_HEIGHT );
-				renderer.clear();
-
 				renderer.setViewport( SCREEN_WIDTH / 2, 0, SCREEN_WIDTH / 2, SCREEN_HEIGHT );
 				renderer.render( scene, camera );
 


### PR DESCRIPTION
Follow-on to #27644

There is no need to manually clear since the scissor region is properly set.