### PR TITLE
update function about points intersect with ray

### DIFF
--- a/src/objects/Points.js
+++ b/src/objects/Points.js
@@ -144,13 +144,14 @@ function testPoint( point, index, localThresholdSq, matrixWorld, raycaster, inte
 		_ray.closestPointToPoint( point, intersectPoint );
 		intersectPoint.applyMatrix4( matrixWorld );
 
-		const distance = raycaster.ray.origin.distanceTo( intersectPoint );
+		const intersectPoint2Ray = raycaster.ray.origin.distanceTo( intersectPoint );
+		
+		if ( intersectPoint2Ray < raycaster.near || intersectPoint2Ray > raycaster.far ) return;
 
-		if ( distance < raycaster.near || distance > raycaster.far ) return;
-
+		const distance2Ray = raycaster.ray.distanceToPoint(point);
+		
 		intersects.push( {
-
-			distance: distance,
+			distance: distance2Ray,
 			distanceToRay: Math.sqrt( rayPointDistanceSq ),
 			point: intersectPoint,
 			index: index,

--- a/src/objects/Points.js
+++ b/src/objects/Points.js
@@ -148,7 +148,7 @@ function testPoint( point, index, localThresholdSq, matrixWorld, raycaster, inte
 
 		if ( intersectPoint2Ray < raycaster.near || intersectPoint2Ray > raycaster.far ) return;
 
-		const distance2Ray = raycaster.ray.distanceToPoint(point);
+		const distance2Ray = raycaster.ray.distanceToPoint( point );
 
 		intersects.push( {
 			distance: distance2Ray,

--- a/src/objects/Points.js
+++ b/src/objects/Points.js
@@ -145,11 +145,11 @@ function testPoint( point, index, localThresholdSq, matrixWorld, raycaster, inte
 		intersectPoint.applyMatrix4( matrixWorld );
 
 		const intersectPoint2Ray = raycaster.ray.origin.distanceTo( intersectPoint );
-		
+
 		if ( intersectPoint2Ray < raycaster.near || intersectPoint2Ray > raycaster.far ) return;
 
 		const distance2Ray = raycaster.ray.distanceToPoint(point);
-		
+
 		intersects.push( {
 			distance: distance2Ray,
 			distanceToRay: Math.sqrt( rayPointDistanceSq ),


### PR DESCRIPTION
During development, I used the default intersect function of points and found that the sorting method was not very good at returning the point closest to the mouse, so I adjusted the distance value of sort to the distance from the point to the ray, and the effect will be better.

*This contribution is funded by pubgoso*
