### PR TITLE
WebGLRenderer: Add Support for Khronos Neutral Tone Mapping

### DIFF
--- a/examples/jsm/postprocessing/OutputPass.js
+++ b/examples/jsm/postprocessing/OutputPass.js
@@ -62,7 +62,7 @@ class OutputPass extends Pass {
 			else if ( this._toneMapping === CineonToneMapping ) this.material.defines.CINEON_TONE_MAPPING = '';
 			else if ( this._toneMapping === ACESFilmicToneMapping ) this.material.defines.ACES_FILMIC_TONE_MAPPING = '';
 			else if ( this._toneMapping === AgXToneMapping ) this.material.defines.AGX_TONE_MAPPING = '';
-			else if ( this._toneMapping === KhronosNeutralToneMapping ) this.material.defines.COMMERECE_TONE_MAPPING = '';
+			else if ( this._toneMapping === KhronosNeutralToneMapping ) this.material.defines.KHRONOS_NEUTRAL_TONE_MAPPING = '';
 
 			this.material.needsUpdate = true;
 

--- a/examples/jsm/postprocessing/OutputPass.js
+++ b/examples/jsm/postprocessing/OutputPass.js
@@ -7,7 +7,7 @@ import {
 	CineonToneMapping,
 	AgXToneMapping,
 	ACESFilmicToneMapping,
-	CommerceToneMapping,
+	KhronosNeutralToneMapping,
 	SRGBTransfer
 } from 'three';
 import { Pass, FullScreenQuad } from './Pass.js';
@@ -62,7 +62,7 @@ class OutputPass extends Pass {
 			else if ( this._toneMapping === CineonToneMapping ) this.material.defines.CINEON_TONE_MAPPING = '';
 			else if ( this._toneMapping === ACESFilmicToneMapping ) this.material.defines.ACES_FILMIC_TONE_MAPPING = '';
 			else if ( this._toneMapping === AgXToneMapping ) this.material.defines.AGX_TONE_MAPPING = '';
-			else if ( this._toneMapping === CommerceToneMapping ) this.material.defines.COMMERECE_TONE_MAPPING = '';
+			else if ( this._toneMapping === KhronosNeutralToneMapping ) this.material.defines.COMMERECE_TONE_MAPPING = '';
 
 			this.material.needsUpdate = true;
 

--- a/examples/jsm/postprocessing/OutputPass.js
+++ b/examples/jsm/postprocessing/OutputPass.js
@@ -7,6 +7,7 @@ import {
 	CineonToneMapping,
 	AgXToneMapping,
 	ACESFilmicToneMapping,
+	CommerceToneMapping,
 	SRGBTransfer
 } from 'three';
 import { Pass, FullScreenQuad } from './Pass.js';
@@ -61,6 +62,7 @@ class OutputPass extends Pass {
 			else if ( this._toneMapping === CineonToneMapping ) this.material.defines.CINEON_TONE_MAPPING = '';
 			else if ( this._toneMapping === ACESFilmicToneMapping ) this.material.defines.ACES_FILMIC_TONE_MAPPING = '';
 			else if ( this._toneMapping === AgXToneMapping ) this.material.defines.AGX_TONE_MAPPING = '';
+			else if ( this._toneMapping === CommerceToneMapping ) this.material.defines.COMMERECE_TONE_MAPPING = '';
 
 			this.material.needsUpdate = true;
 

--- a/examples/jsm/shaders/OutputShader.js
+++ b/examples/jsm/shaders/OutputShader.js
@@ -66,7 +66,7 @@ const OutputShader = {
 
 			#elif defined( COMMERECE_TONE_MAPPING )
 
-				gl_FragColor.rgb = CommerceToneMapping( gl_FragColor.rgb );
+				gl_FragColor.rgb = KhronosNeutralToneMapping( gl_FragColor.rgb );
 
 			#endif
 

--- a/examples/jsm/shaders/OutputShader.js
+++ b/examples/jsm/shaders/OutputShader.js
@@ -64,6 +64,10 @@ const OutputShader = {
 
 				gl_FragColor.rgb = AgXToneMapping( gl_FragColor.rgb );
 
+			#elif defined( COMMERECE_TONE_MAPPING )
+
+				gl_FragColor.rgb = CommerceToneMapping( gl_FragColor.rgb );
+
 			#endif
 
 			// color space

--- a/examples/jsm/shaders/OutputShader.js
+++ b/examples/jsm/shaders/OutputShader.js
@@ -64,7 +64,7 @@ const OutputShader = {
 
 				gl_FragColor.rgb = AgXToneMapping( gl_FragColor.rgb );
 
-			#elif defined( COMMERECE_TONE_MAPPING )
+			#elif defined( KHRONOS_NEUTRAL_TONE_MAPPING )
 
 				gl_FragColor.rgb = KhronosNeutralToneMapping( gl_FragColor.rgb );
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -57,7 +57,7 @@ export const CineonToneMapping = 3;
 export const ACESFilmicToneMapping = 4;
 export const CustomToneMapping = 5;
 export const AgXToneMapping = 6;
-export const CommerceToneMapping = 7;
+export const KhronosNeutralToneMapping = 7;
 export const AttachedBindMode = 'attached';
 export const DetachedBindMode = 'detached';
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -57,6 +57,7 @@ export const CineonToneMapping = 3;
 export const ACESFilmicToneMapping = 4;
 export const CustomToneMapping = 5;
 export const AgXToneMapping = 6;
+export const CommerceToneMapping = 7;
 export const AttachedBindMode = 'attached';
 export const DetachedBindMode = 'detached';
 

--- a/src/renderers/shaders/ShaderChunk/tonemapping_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/tonemapping_pars_fragment.glsl.js
@@ -165,5 +165,26 @@ vec3 AgXToneMapping( vec3 color ) {
 
 }
 
+vec3 CommerceToneMapping( vec3 color ) {
+	float startCompression = 0.8 - 0.04;
+	float desaturation = 0.15;
+
+	color *= toneMappingExposure;
+
+	float x = min(color.r, min(color.g, color.b));
+	float offset = x < 0.08 ? x - 6.25 * x * x : 0.04;
+	color -= offset;
+
+	float peak = max(color.r, max(color.g, color.b));
+	if (peak < startCompression) return color;
+
+	float d = 1. - startCompression;
+	float newPeak = 1. - d * d / (peak + d - startCompression);
+	color *= newPeak / peak;
+
+	float g = 1. - 1. / (desaturation * (peak - newPeak) + 1.);
+	return mix(color, vec3(1, 1, 1), g);
+}
+
 vec3 CustomToneMapping( vec3 color ) { return color; }
 `;

--- a/src/renderers/shaders/ShaderChunk/tonemapping_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/tonemapping_pars_fragment.glsl.js
@@ -165,6 +165,8 @@ vec3 AgXToneMapping( vec3 color ) {
 
 }
 
+// https://modelviewer.dev/examples/tone-mapping
+
 vec3 CommerceToneMapping( vec3 color ) {
 	float startCompression = 0.8 - 0.04;
 	float desaturation = 0.15;

--- a/src/renderers/shaders/ShaderChunk/tonemapping_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/tonemapping_pars_fragment.glsl.js
@@ -167,7 +167,7 @@ vec3 AgXToneMapping( vec3 color ) {
 
 // https://modelviewer.dev/examples/tone-mapping
 
-vec3 CommerceToneMapping( vec3 color ) {
+vec3 KhronosNeutralToneMapping( vec3 color ) {
 	float startCompression = 0.8 - 0.04;
 	float desaturation = 0.15;
 

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -1,7 +1,7 @@
 import { WebGLUniforms } from './WebGLUniforms.js';
 import { WebGLShader } from './WebGLShader.js';
 import { ShaderChunk } from '../shaders/ShaderChunk.js';
-import { NoToneMapping, AddOperation, MixOperation, MultiplyOperation, CubeRefractionMapping, CubeUVReflectionMapping, CubeReflectionMapping, PCFSoftShadowMap, PCFShadowMap, VSMShadowMap, AgXToneMapping, ACESFilmicToneMapping, CommerceToneMapping, CineonToneMapping, CustomToneMapping, ReinhardToneMapping, LinearToneMapping, GLSL3, LinearSRGBColorSpace, SRGBColorSpace, LinearDisplayP3ColorSpace, DisplayP3ColorSpace, P3Primaries, Rec709Primaries } from '../../constants.js';
+import { NoToneMapping, AddOperation, MixOperation, MultiplyOperation, CubeRefractionMapping, CubeUVReflectionMapping, CubeReflectionMapping, PCFSoftShadowMap, PCFShadowMap, VSMShadowMap, AgXToneMapping, ACESFilmicToneMapping, KhronosNeutralToneMapping, CineonToneMapping, CustomToneMapping, ReinhardToneMapping, LinearToneMapping, GLSL3, LinearSRGBColorSpace, SRGBColorSpace, LinearDisplayP3ColorSpace, DisplayP3ColorSpace, P3Primaries, Rec709Primaries } from '../../constants.js';
 import { ColorManagement } from '../../math/ColorManagement.js';
 
 // From https://www.khronos.org/registry/webgl/extensions/KHR_parallel_shader_compile/
@@ -124,8 +124,8 @@ function getToneMappingFunction( functionName, toneMapping ) {
 			toneMappingName = 'AgX';
 			break;
 
-		case CommerceToneMapping:
-			toneMappingName = 'Commerce';
+		case KhronosNeutralToneMapping:
+			toneMappingName = 'KhronosNeutral';
 			break;
 
 		case CustomToneMapping:

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -1,7 +1,7 @@
 import { WebGLUniforms } from './WebGLUniforms.js';
 import { WebGLShader } from './WebGLShader.js';
 import { ShaderChunk } from '../shaders/ShaderChunk.js';
-import { NoToneMapping, AddOperation, MixOperation, MultiplyOperation, CubeRefractionMapping, CubeUVReflectionMapping, CubeReflectionMapping, PCFSoftShadowMap, PCFShadowMap, VSMShadowMap, AgXToneMapping, ACESFilmicToneMapping, CineonToneMapping, CustomToneMapping, ReinhardToneMapping, LinearToneMapping, GLSL3, LinearSRGBColorSpace, SRGBColorSpace, LinearDisplayP3ColorSpace, DisplayP3ColorSpace, P3Primaries, Rec709Primaries } from '../../constants.js';
+import { NoToneMapping, AddOperation, MixOperation, MultiplyOperation, CubeRefractionMapping, CubeUVReflectionMapping, CubeReflectionMapping, PCFSoftShadowMap, PCFShadowMap, VSMShadowMap, AgXToneMapping, ACESFilmicToneMapping, CommerceToneMapping, CineonToneMapping, CustomToneMapping, ReinhardToneMapping, LinearToneMapping, GLSL3, LinearSRGBColorSpace, SRGBColorSpace, LinearDisplayP3ColorSpace, DisplayP3ColorSpace, P3Primaries, Rec709Primaries } from '../../constants.js';
 import { ColorManagement } from '../../math/ColorManagement.js';
 
 // From https://www.khronos.org/registry/webgl/extensions/KHR_parallel_shader_compile/
@@ -122,6 +122,10 @@ function getToneMappingFunction( functionName, toneMapping ) {
 
 		case AgXToneMapping:
 			toneMappingName = 'AgX';
+			break;
+
+		case CommerceToneMapping:
+			toneMappingName = 'Commerce';
 			break;
 
 		case CustomToneMapping:

--- a/test/unit/src/constants.tests.js
+++ b/test/unit/src/constants.tests.js
@@ -72,7 +72,7 @@ export default QUnit.module( 'Constants', () => {
 		assert.equal( Constants.ACESFilmicToneMapping, 4, 'ACESFilmicToneMapping is equal to 4' );
 		assert.equal( Constants.CustomToneMapping, 5, 'CustomToneMapping is equal to 5' );
 		assert.equal( Constants.AgXToneMapping, 6, 'AgXToneMapping is equal to 6' );
-		assert.equal( Constants.CommerceToneMapping, 6, 'CommerceToneMapping is equal to 7' );
+		assert.equal( Constants.CommerceToneMapping, 7, 'CommerceToneMapping is equal to 7' );
 
 		assert.equal( Constants.AttachedBindMode, 'attached', 'AttachedBindMode is equal to attached' );
 		assert.equal( Constants.DetachedBindMode, 'detached', 'DetachedBindMode is equal to detached' );

--- a/test/unit/src/constants.tests.js
+++ b/test/unit/src/constants.tests.js
@@ -72,7 +72,7 @@ export default QUnit.module( 'Constants', () => {
 		assert.equal( Constants.ACESFilmicToneMapping, 4, 'ACESFilmicToneMapping is equal to 4' );
 		assert.equal( Constants.CustomToneMapping, 5, 'CustomToneMapping is equal to 5' );
 		assert.equal( Constants.AgXToneMapping, 6, 'AgXToneMapping is equal to 6' );
-		assert.equal( Constants.CommerceToneMapping, 7, 'CommerceToneMapping is equal to 7' );
+		assert.equal( Constants.KhronosNeutralToneMapping, 7, 'KhronosNeutralToneMapping is equal to 7' );
 
 		assert.equal( Constants.AttachedBindMode, 'attached', 'AttachedBindMode is equal to attached' );
 		assert.equal( Constants.DetachedBindMode, 'detached', 'DetachedBindMode is equal to detached' );

--- a/test/unit/src/constants.tests.js
+++ b/test/unit/src/constants.tests.js
@@ -72,6 +72,7 @@ export default QUnit.module( 'Constants', () => {
 		assert.equal( Constants.ACESFilmicToneMapping, 4, 'ACESFilmicToneMapping is equal to 4' );
 		assert.equal( Constants.CustomToneMapping, 5, 'CustomToneMapping is equal to 5' );
 		assert.equal( Constants.AgXToneMapping, 6, 'AgXToneMapping is equal to 6' );
+		assert.equal( Constants.CommerceToneMapping, 6, 'CommerceToneMapping is equal to 7' );
 
 		assert.equal( Constants.AttachedBindMode, 'attached', 'AttachedBindMode is equal to attached' );
 		assert.equal( Constants.DetachedBindMode, 'detached', 'DetachedBindMode is equal to detached' );


### PR DESCRIPTION
This is the tone mapper I designed for color-accuracy and that we are working to make a standard through the Khronos 3D Commerce group. In-depth writeup [here](https://modelviewer.dev/examples/tone-mapping). The summary is this is an improved alternative to No/Linear/Clamped tone mapping. It preserves the baseColor sRGB values as faithfully as possible through to the final render under uncolored lighting. 

Improvements over No tone mapping:
- Avoids clamping artifacts in highlights
- Has a uniform path to white
- Avoids hue skews
- Avoids saturation loss especially on darker dielectric materials

Improvements over ACES/AgX:
- Maintains color saturation
- Has a larger reachable set of sRGB
- Avoids hue skews

Situations where AgX is a better choice:
- Out-of-gamut colors: if your textures or lights contain colors outside of the Rec.709 (sRGB) gamut.
- If you have important visual detail across a wide dynamic range (e.g. landscape photography). The HDR is aggressively compressed in this tone mapper, which is most appropriate for highlights.
- If your output will not be directly compared to images, so absolute sRGB values are less important than scene-relative perception. 

I've already [shipped](https://modelviewer.dev/examples/lightingandenv/#toneMapping) this in `<model-viewer>` and I intend to make it our default in v4.0. You can test it yourself by drag-and-dropping any GLB and HDR into this [Glitch](https://tone-mapping.glitch.me/). 

FYI @mrdoob @WestLangley @donmccurdy @bhouston @hybridherbst 