### PR TITLE
ShaderChunk: link issue and fix typo in inline video decode.

### DIFF
--- a/src/renderers/shaders/ShaderChunk/map_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/map_fragment.glsl.js
@@ -5,7 +5,7 @@ export default /* glsl */`
 
 	#ifdef DECODE_VIDEO_TEXTURE
 
-		// use inline sRGB decode until browsers properly support SRGB8_APLHA8 with video textures
+		// use inline sRGB decode until browsers properly support SRGB8_ALPHA8 with video textures (#26516)
 
 		sampledDiffuseColor = vec4( mix( pow( sampledDiffuseColor.rgb * 0.9478672986 + vec3( 0.0521327014 ), vec3( 2.4 ) ), sampledDiffuseColor.rgb * 0.0773993808, vec3( lessThanEqual( sampledDiffuseColor.rgb, vec3( 0.04045 ) ) ) ), sampledDiffuseColor.w );
 	


### PR DESCRIPTION
Related issue: #26516

**Description**

Was linking this shader chunk and PR for reference of another platform bug and found a typo and no ticket in code.
