### PR TITLE
Node: Add `increaseUsage()`

### DIFF
--- a/examples/jsm/nodes/core/Node.js
+++ b/examples/jsm/nodes/core/Node.js
@@ -150,12 +150,20 @@ class Node extends EventDispatcher {
 
 	}
 
-	analyze( builder ) {
+	increaseUsage( builder ) {
 
 		const nodeData = builder.getDataFromNode( this );
-		nodeData.dependenciesCount = nodeData.dependenciesCount === undefined ? 1 : nodeData.dependenciesCount + 1;
+		nodeData.usageCount = nodeData.usageCount === undefined ? 1 : nodeData.usageCount + 1;
 
-		if ( nodeData.dependenciesCount === 1 ) {
+		return nodeData.usageCount;
+
+	}
+
+	analyze( builder ) {
+
+		const usageCount = this.increaseUsage( builder );
+
+		if ( usageCount === 1 ) {
 
 			// node flow children
 

--- a/examples/jsm/nodes/core/TempNode.js
+++ b/examples/jsm/nodes/core/TempNode.js
@@ -12,7 +12,7 @@ class TempNode extends Node {
 
 	hasDependencies( builder ) {
 
-		return builder.getDataFromNode( this ).dependenciesCount > 1;
+		return builder.getDataFromNode( this ).usageCount > 1;
 
 	}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/27661

**Description**

Allow increasing the usage count of a Node without needs to recall `build()`. Useful to force `generate()` snippet into cache.