### PR TITLE
Docs: Improve `GLTFLoader` page.

### DIFF
--- a/docs/examples/en/loaders/GLTFLoader.html
+++ b/docs/examples/en/loaders/GLTFLoader.html
@@ -53,7 +53,7 @@
 			<li>KHR_materials_unlit</li>
 			<li>KHR_materials_volume</li>
 			<li>KHR_mesh_quantization</li>
-			<li>KHR_lights_punctual<sup>1</sup></li>
+			<li>KHR_lights_punctual</li>
 			<li>KHR_texture_basisu</li>
 			<li>KHR_texture_transform</li>
 			<li>EXT_texture_webp</li>
@@ -66,12 +66,12 @@
 		</p>
 
 		<ul>
-			<li>[link:https://github.com/takahirox/three-gltf-extensions KHR_materials_variants]<sup>2</sup></li>
+			<li>[link:https://github.com/takahirox/three-gltf-extensions KHR_materials_variants]<sup>1</sup></li>
 			<li>[link:https://github.com/takahirox/three-gltf-extensions MSFT_texture_dds]</li>
 		</ul>
 
 		<p><i>
-			<sup>2</sup>You can also manually process the extension after loading in your application. See [link:https://threejs.org/examples/#webgl_loader_gltf_variants Three.js glTF materials variants example].
+			<sup>1</sup>You can also manually process the extension after loading in your application. See [link:https://threejs.org/examples/#webgl_loader_gltf_variants Three.js glTF materials variants example].
 		</i></p>
 
 		<h2>Code Example</h2>


### PR DESCRIPTION
**Description**

It looks like the previous footnote for the KHR_lights_punctual extension was to mention that useLegacyLights needed to be disabled. The footnote itself was removed in a previous commit (cce80b8f87d110b75aa770678db7c8465d3ff3db), but the reference to it remained despite there being no "footnote 1" any longer.

Removed the footnote marker, and renumbered footnote 2 to footnote 1.