### PR TITLE
EllipseCurve: Use ES6 default parameters in `getPoint()`.

### DIFF
--- a/src/extras/curves/EllipseCurve.js
+++ b/src/extras/curves/EllipseCurve.js
@@ -26,9 +26,9 @@ class EllipseCurve extends Curve {
 
 	}
 
-	getPoint( t, optionalTarget ) {
+	getPoint( t, optionalTarget = new Vector2() ) {
 
-		const point = optionalTarget || new Vector2();
+		const point = optionalTarget;
 
 		const twoPi = Math.PI * 2;
 		let deltaAngle = this.aEndAngle - this.aStartAngle;


### PR DESCRIPTION
Related issue: #XXXX

**Description**

Use ES6 default parameters for `EllipseCurve.getPoint`
