### PR TITLE
WebGLRenderer: Remove unnecessary `__hasExternalTextures` check.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2162,25 +2162,20 @@ class WebGLRenderer {
 			const renderTargetProperties = properties.get( renderTarget );
 			renderTargetProperties.__hasExternalTextures = true;
 
-			if ( renderTargetProperties.__hasExternalTextures ) {
-
-				renderTargetProperties.__autoAllocateDepthBuffer = depthTexture === undefined;
-
-				if ( ! renderTargetProperties.__autoAllocateDepthBuffer ) {
-
-					// The multisample_render_to_texture extension doesn't work properly if there
-					// are midframe flushes and an external depth buffer. Disable use of the extension.
-					if ( extensions.has( 'WEBGL_multisampled_render_to_texture' ) === true ) {
-
-						console.warn( 'THREE.WebGLRenderer: Render-to-texture extension was disabled because an external texture was provided' );
-						renderTargetProperties.__useRenderToTexture = false;
-
-					}
-
+			renderTargetProperties.__autoAllocateDepthBuffer = depthTexture === undefined;
+	
+			if ( ! renderTargetProperties.__autoAllocateDepthBuffer ) {
+	
+				// The multisample_render_to_texture extension doesn't work properly if there
+				// are midframe flushes and an external depth buffer. Disable use of the extension.
+				if ( extensions.has( 'WEBGL_multisampled_render_to_texture' ) === true ) {
+	
+					console.warn( 'THREE.WebGLRenderer: Render-to-texture extension was disabled because an external texture was provided' );
+					renderTargetProperties.__useRenderToTexture = false;
+	
 				}
-
+	
 			}
-
 		};
 
 		this.setRenderTargetFramebuffer = function ( renderTarget, defaultFramebuffer ) {

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2163,18 +2163,18 @@ class WebGLRenderer {
 			renderTargetProperties.__hasExternalTextures = true;
 
 			renderTargetProperties.__autoAllocateDepthBuffer = depthTexture === undefined;
-	
+
 			if ( ! renderTargetProperties.__autoAllocateDepthBuffer ) {
-	
+
 				// The multisample_render_to_texture extension doesn't work properly if there
 				// are midframe flushes and an external depth buffer. Disable use of the extension.
 				if ( extensions.has( 'WEBGL_multisampled_render_to_texture' ) === true ) {
-	
+
 					console.warn( 'THREE.WebGLRenderer: Render-to-texture extension was disabled because an external texture was provided' );
 					renderTargetProperties.__useRenderToTexture = false;
-	
+
 				}
-	
+
 			}
 		};
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2176,6 +2176,7 @@ class WebGLRenderer {
 				}
 
 			}
+
 		};
 
 		this.setRenderTargetFramebuffer = function ( renderTarget, defaultFramebuffer ) {

--- a/src/renderers/webgl/WebGLBindingStates.js
+++ b/src/renderers/webgl/WebGLBindingStates.js
@@ -5,6 +5,7 @@ function WebGLBindingStates( gl, extensions, attributes, capabilities ) {
 	const maxVertexAttributes = gl.getParameter( gl.MAX_VERTEX_ATTRIBS );
 
 	const extension = capabilities.isWebGL2 ? null : extensions.get( 'OES_vertex_array_object' );
+	const vaoAvailable = capabilities.isWebGL2 || extension !== null;
 
 	const bindingStates = {};
 
@@ -15,7 +16,6 @@ function WebGLBindingStates( gl, extensions, attributes, capabilities ) {
 	function setup( object, material, program, geometry, index ) {
 
 		let updateBuffers = false;
-		const vaoAvailable = capabilities.isWebGL2 || extension !== null;
 
 		if ( vaoAvailable ) {
 

--- a/src/renderers/webgl/WebGLBindingStates.js
+++ b/src/renderers/webgl/WebGLBindingStates.js
@@ -5,7 +5,6 @@ function WebGLBindingStates( gl, extensions, attributes, capabilities ) {
 	const maxVertexAttributes = gl.getParameter( gl.MAX_VERTEX_ATTRIBS );
 
 	const extension = capabilities.isWebGL2 ? null : extensions.get( 'OES_vertex_array_object' );
-	const vaoAvailable = capabilities.isWebGL2 || extension !== null;
 
 	const bindingStates = {};
 
@@ -16,6 +15,7 @@ function WebGLBindingStates( gl, extensions, attributes, capabilities ) {
 	function setup( object, material, program, geometry, index ) {
 
 		let updateBuffers = false;
+		const vaoAvailable = capabilities.isWebGL2 || extension !== null;
 
 		if ( vaoAvailable ) {
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -626,15 +626,13 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		if ( extensions.has( 'EXT_texture_filter_anisotropic' ) === true ) {
 
-			const extension = extensions.get( 'EXT_texture_filter_anisotropic' );
-
 			if ( texture.magFilter === NearestFilter ) return;
 			if ( texture.minFilter !== NearestMipmapLinearFilter && texture.minFilter !== LinearMipmapLinearFilter ) return;
 			if ( texture.type === FloatType && extensions.has( 'OES_texture_float_linear' ) === false ) return; // verify extension for WebGL 1 and WebGL 2
 			if ( isWebGL2 === false && ( texture.type === HalfFloatType && extensions.has( 'OES_texture_half_float_linear' ) === false ) ) return; // verify extension for WebGL 1 only
 
 			if ( texture.anisotropy > 1 || properties.get( texture ).__currentAnisotropy ) {
-
+				const extension = extensions.get( 'EXT_texture_filter_anisotropic' );
 				_gl.texParameterf( textureType, extension.TEXTURE_MAX_ANISOTROPY_EXT, Math.min( texture.anisotropy, capabilities.getMaxAnisotropy() ) );
 				properties.get( texture ).__currentAnisotropy = texture.anisotropy;
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -633,6 +633,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 			if ( texture.anisotropy > 1 || properties.get( texture ).__currentAnisotropy ) {
 				const extension = extensions.get( 'EXT_texture_filter_anisotropic' );
+
 				_gl.texParameterf( textureType, extension.TEXTURE_MAX_ANISOTROPY_EXT, Math.min( texture.anisotropy, capabilities.getMaxAnisotropy() ) );
 				properties.get( texture ).__currentAnisotropy = texture.anisotropy;
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -632,8 +632,8 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 			if ( isWebGL2 === false && ( texture.type === HalfFloatType && extensions.has( 'OES_texture_half_float_linear' ) === false ) ) return; // verify extension for WebGL 1 only
 
 			if ( texture.anisotropy > 1 || properties.get( texture ).__currentAnisotropy ) {
-				const extension = extensions.get( 'EXT_texture_filter_anisotropic' );
 
+				const extension = extensions.get( 'EXT_texture_filter_anisotropic' );
 				_gl.texParameterf( textureType, extension.TEXTURE_MAX_ANISOTROPY_EXT, Math.min( texture.anisotropy, capabilities.getMaxAnisotropy() ) );
 				properties.get( texture ).__currentAnisotropy = texture.anisotropy;
 


### PR DESCRIPTION
**Description**

`renderTargetProperties.__hasExternalTextures` is set be `true` just one line above if statement, so I think if can be removed.

Also move some variables to proper place.

