### PR TITLE
DragControls: Add `rotate` mode.

### DIFF
--- a/docs/examples/en/controls/DragControls.html
+++ b/docs/examples/en/controls/DragControls.html
@@ -116,7 +116,7 @@
 			The current transformation mode. Possible values are `translate`, and `rotate`. Default is `translate`.
 		</p>
 
-		<h3>[property:String rotateSpeed]</h3>
+		<h3>[property:Float rotateSpeed]</h3>
 		<p>
 			The speed at which the object will rotate when dragged in `rotate` mode. The higher the number the faster the rotation. Default is `1`.
 		</p>

--- a/docs/examples/en/controls/DragControls.html
+++ b/docs/examples/en/controls/DragControls.html
@@ -116,6 +116,11 @@
 			The current transformation mode. Possible values are "translate", and "rotate". Default is `translate`.
 		</p>
 
+		<h3>[property:String rotateSpeed]</h3>
+		<p>
+			The speed at which the object will rotate when dragged in "rotate" mode. The higher the number the faster the rotation. Default is 1.
+		</p>
+
 		<h2>Methods</h2>
 
 		<p>See the base [page:EventDispatcher] class for common methods.</p>

--- a/docs/examples/en/controls/DragControls.html
+++ b/docs/examples/en/controls/DragControls.html
@@ -111,6 +111,11 @@
 			If set to `true`, [name] does not transform individual objects but the entire group. Default is `false`.
 		</p>
 
+		<h3>[property:String mode]</h3>
+		<p>
+			The current transformation mode. Possible values are "translate", and "rotate". Default is `translate`.
+		</p>
+
 		<h2>Methods</h2>
 
 		<p>See the base [page:EventDispatcher] class for common methods.</p>

--- a/docs/examples/en/controls/DragControls.html
+++ b/docs/examples/en/controls/DragControls.html
@@ -113,12 +113,12 @@
 
 		<h3>[property:String mode]</h3>
 		<p>
-			The current transformation mode. Possible values are "translate", and "rotate". Default is `translate`.
+			The current transformation mode. Possible values are `translate`, and `rotate`. Default is `translate`.
 		</p>
 
 		<h3>[property:String rotateSpeed]</h3>
 		<p>
-			The speed at which the object will rotate when dragged in "rotate" mode. The higher the number the faster the rotation. Default is 1.
+			The speed at which the object will rotate when dragged in `rotate` mode. The higher the number the faster the rotation. Default is `1`.
 		</p>
 
 		<h2>Methods</h2>

--- a/examples/jsm/controls/DragControls.js
+++ b/examples/jsm/controls/DragControls.js
@@ -13,8 +13,7 @@ const _raycaster = new Raycaster();
 const _pointer = new Vector2();
 const _offset = new Vector3();
 const _diff = new Vector2();
-const _start = new Vector2();
-const _end = new Vector2();
+const _previousPointer = new Vector2();
 const _intersection = new Vector3();
 const _worldPosition = new Vector3();
 const _inverseMatrix = new Matrix4();
@@ -85,9 +84,6 @@ class DragControls extends EventDispatcher {
 			if ( scope.enabled === false ) return;
 
 			updatePointer( event );
-			_end.copy( _pointer );
-			_diff.subVectors( _end, _start );
-			_start.copy( _end );
 
 			_raycaster.setFromCamera( _pointer, _camera );
 
@@ -103,7 +99,7 @@ class DragControls extends EventDispatcher {
 
 				} else if ( scope.mode === 'rotate' ) {
 
-					_diff.multiplyScalar( scope.rotateSpeed );
+					_diff.subVectors( _pointer, _previousPointer ).multiplyScalar( scope.rotateSpeed );
 					_selected.rotateOnWorldAxis( _up, _diff.x );
 					_selected.rotateOnWorldAxis( _right.normalize(), - _diff.y );
 
@@ -111,57 +107,61 @@ class DragControls extends EventDispatcher {
 
 				scope.dispatchEvent( { type: 'drag', object: _selected } );
 
-				return;
+				_previousPointer.copy( _pointer );
 
-			}
+			} else {
 
-			// hover support
+				// hover support
 
-			if ( event.pointerType === 'mouse' || event.pointerType === 'pen' ) {
+				if ( event.pointerType === 'mouse' || event.pointerType === 'pen' ) {
 
-				_intersections.length = 0;
+					_intersections.length = 0;
 
-				_raycaster.setFromCamera( _pointer, _camera );
-				_raycaster.intersectObjects( _objects, scope.recursive, _intersections );
+					_raycaster.setFromCamera( _pointer, _camera );
+					_raycaster.intersectObjects( _objects, scope.recursive, _intersections );
 
-				if ( _intersections.length > 0 ) {
+					if ( _intersections.length > 0 ) {
 
-					const object = _intersections[ 0 ].object;
+						const object = _intersections[ 0 ].object;
 
-					_plane.setFromNormalAndCoplanarPoint( _camera.getWorldDirection( _plane.normal ), _worldPosition.setFromMatrixPosition( object.matrixWorld ) );
+						_plane.setFromNormalAndCoplanarPoint( _camera.getWorldDirection( _plane.normal ), _worldPosition.setFromMatrixPosition( object.matrixWorld ) );
 
-					if ( _hovered !== object && _hovered !== null ) {
+						if ( _hovered !== object && _hovered !== null ) {
 
-						scope.dispatchEvent( { type: 'hoveroff', object: _hovered } );
+							scope.dispatchEvent( { type: 'hoveroff', object: _hovered } );
 
-						_domElement.style.cursor = 'auto';
-						_hovered = null;
+							_domElement.style.cursor = 'auto';
+							_hovered = null;
 
-					}
+						}
 
-					if ( _hovered !== object ) {
+						if ( _hovered !== object ) {
 
-						scope.dispatchEvent( { type: 'hoveron', object: object } );
+							scope.dispatchEvent( { type: 'hoveron', object: object } );
 
-						_domElement.style.cursor = 'pointer';
-						_hovered = object;
+							_domElement.style.cursor = 'pointer';
+							_hovered = object;
 
-					}
+						}
 
-				} else {
+					} else {
 
-					if ( _hovered !== null ) {
+						if ( _hovered !== null ) {
 
-						scope.dispatchEvent( { type: 'hoveroff', object: _hovered } );
+							scope.dispatchEvent( { type: 'hoveroff', object: _hovered } );
 
-						_domElement.style.cursor = 'auto';
-						_hovered = null;
+							_domElement.style.cursor = 'auto';
+							_hovered = null;
+
+						}
 
 					}
 
 				}
 
 			}
+
+			_previousPointer.copy( _pointer );
 
 		}
 
@@ -205,6 +205,7 @@ class DragControls extends EventDispatcher {
 
 			}
 
+			_previousPointer.copy( _pointer );
 
 		}
 

--- a/examples/jsm/controls/DragControls.js
+++ b/examples/jsm/controls/DragControls.js
@@ -191,7 +191,7 @@ class DragControls extends EventDispatcher {
 
 					} else if ( scope.mode === 'rotate' ) {
 
-						// the controls only support the Y+ coordinate system
+						// the controls only support Y+ up
 						_up.set( 0, 1, 0 ).applyQuaternion( _camera.quaternion ).normalize();
 						_right.set( 1, 0, 0 ).applyQuaternion( _camera.quaternion ).normalize();
 

--- a/examples/jsm/controls/DragControls.js
+++ b/examples/jsm/controls/DragControls.js
@@ -34,7 +34,7 @@ class DragControls extends EventDispatcher {
 
 		const _intersections = [];
 
-		this.mode = "translate";
+		this.mode = 'translate';
 
 		this.rotateSpeed = 1;
 
@@ -85,30 +85,29 @@ class DragControls extends EventDispatcher {
 			if ( scope.enabled === false ) return;
 
 			updatePointer( event );
-			_end.copy(_pointer);
-			_diff.subVectors(_end, _start);
-			_start.copy(_end);
-			
+			_end.copy( _pointer );
+			_diff.subVectors( _end, _start );
+			_start.copy( _end );
+
 			_raycaster.setFromCamera( _pointer, _camera );
-			
+
 			if ( _selected ) {
-				
-				if (scope.mode === "translate") {
-				
+
+				if ( scope.mode === 'translate' ) {
+
 					if ( _raycaster.ray.intersectPlane( _plane, _intersection ) ) {
-						
+
 						_selected.position.copy( _intersection.sub( _offset ).applyMatrix4( _inverseMatrix ) );
-						
+
 					}
-				
-				} else if (scope.mode === "rotate") {
 
-					_diff.multiplyScalar(this.rotateSpeed);
-					_selected.rotateOnWorldAxis(_up, _diff.x);
-					_selected.rotateOnWorldAxis(_right.normalize(), -_diff.y);
-				
+				} else if ( scope.mode === 'rotate' ) {
+
+					_diff.multiplyScalar( scope.rotateSpeed );
+					_selected.rotateOnWorldAxis( _up, _diff.x );
+					_selected.rotateOnWorldAxis( _right.normalize(), - _diff.y );
+
 				}
-
 
 				scope.dispatchEvent( { type: 'drag', object: _selected } );
 
@@ -185,19 +184,19 @@ class DragControls extends EventDispatcher {
 
 				if ( _raycaster.ray.intersectPlane( _plane, _intersection ) ) {
 
-					if (scope.mode === "translate") {
-					
+					if ( scope.mode === 'translate' ) {
+
 						_inverseMatrix.copy( _selected.parent.matrixWorld ).invert();
 						_offset.copy( _intersection ).sub( _worldPosition.setFromMatrixPosition( _selected.matrixWorld ) );
-					
-					} else if (scope.mode === "rotate") {
-					
+
+					} else if ( scope.mode === 'rotate' ) {
+
 						//Note: the controls only support the Y+ rotation
-						_up.set(0,1,0).applyQuaternion(_camera.quaternion).normalize();
-						_right.set(1,0,0).applyQuaternion(_camera.quaternion).normalize();
-					
+						_up.set( 0, 1, 0 ).applyQuaternion( _camera.quaternion ).normalize();
+						_right.set( 1, 0, 0 ).applyQuaternion( _camera.quaternion ).normalize();
+
 					}
-					
+
 				}
 
 				_domElement.style.cursor = 'move';

--- a/examples/jsm/controls/DragControls.js
+++ b/examples/jsm/controls/DragControls.js
@@ -191,7 +191,7 @@ class DragControls extends EventDispatcher {
 
 					} else if ( scope.mode === 'rotate' ) {
 
-						//Note: the controls only support the Y+ rotation
+						// the controls only support the Y+ coordinate system
 						_up.set( 0, 1, 0 ).applyQuaternion( _camera.quaternion ).normalize();
 						_right.set( 1, 0, 0 ).applyQuaternion( _camera.quaternion ).normalize();
 

--- a/examples/jsm/controls/DragControls.js
+++ b/examples/jsm/controls/DragControls.js
@@ -20,8 +20,7 @@ const _worldPosition = new Vector3();
 const _inverseMatrix = new Matrix4();
 
 const _up = new Vector3();
-const _horizen = new Vector3();
-const _lookAt = new Vector3();
+const _right = new Vector3();
 
 class DragControls extends EventDispatcher {
 
@@ -36,6 +35,8 @@ class DragControls extends EventDispatcher {
 		const _intersections = [];
 
 		this.mode = "translate";
+
+		this.rotateSpeed = 1;
 
 		//
 
@@ -102,9 +103,9 @@ class DragControls extends EventDispatcher {
 				
 				} else if (scope.mode === "rotate") {
 
-					_diff.multiplyScalar(2); //Just a random scalling factor since it rotated too slow
+					_diff.multiplyScalar(this.rotateSpeed);
 					_selected.rotateOnWorldAxis(_up, _diff.x);
-					_selected.rotateOnWorldAxis(_horizen.normalize(), -_diff.y);
+					_selected.rotateOnWorldAxis(_right.normalize(), -_diff.y);
 				
 				}
 
@@ -191,9 +192,9 @@ class DragControls extends EventDispatcher {
 					
 					} else if (scope.mode === "rotate") {
 					
+						//Note: the controls only support the Y+ rotation
 						_up.set(0,1,0).applyQuaternion(_camera.quaternion).normalize();
-						_horizen.set(1,0,0).applyQuaternion(_camera.quaternion).normalize();
-						_lookAt.set(0,0,-1).applyQuaternion(_camera.quaternion).normalize();
+						_right.set(1,0,0).applyQuaternion(_camera.quaternion).normalize();
 					
 					}
 					

--- a/examples/misc_controls_drag.html
+++ b/examples/misc_controls_drag.html
@@ -20,7 +20,7 @@
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> webgl - drag controls<br />
 			Use "Shift+Click" to add/remove objects to/from a group.<br />
-			Use "M" to toggle between rotate and translate modes.<br />
+			Use "M" to toggle between rotate and translate mode.<br />
 			Grouped objects can be transformed as a union.
 		</div>
 
@@ -143,8 +143,10 @@
 
 				enableSelection = ( event.keyCode === 16 ) ? true : false;
 				
-				if (event.keyCode === 77) {
-					controls.mode = (controls.mode === "translate") ? "rotate" : "translate";
+				if ( event.keyCode === 77 ) {
+
+					controls.mode = ( controls.mode === 'translate' ) ? 'rotate' : 'translate';
+			
 				}
 
 			}

--- a/examples/misc_controls_drag.html
+++ b/examples/misc_controls_drag.html
@@ -20,6 +20,7 @@
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> webgl - drag controls<br />
 			Use "Shift+Click" to add/remove objects to/from a group.<br />
+			Use "M" to toggle between rotate and translate modes.<br />
 			Grouped objects can be transformed as a union.
 		</div>
 
@@ -141,6 +142,10 @@
 			function onKeyDown( event ) {
 
 				enableSelection = ( event.keyCode === 16 ) ? true : false;
+				
+				if (event.keyCode === 77) {
+					controls.mode = (controls.mode === "translate") ? "rotate" : "translate";
+				}
 
 			}
 

--- a/examples/misc_controls_drag.html
+++ b/examples/misc_controls_drag.html
@@ -114,6 +114,7 @@
 				container.appendChild( renderer.domElement );
 
 				controls = new DragControls( [ ... objects ], camera, renderer.domElement );
+				controls.rotateSpeed = 2;
 				controls.addEventListener( 'drag', render );
 
 				//


### PR DESCRIPTION
**Description**

I often use three extensions that do not work well with the TranslateControls. I as a result have been using DragControls but when I need to rotate I have been using my own variation RotateControls. I am pushing this so that perhaps others don't need to rewrite the same code.

It intentionally has extremely similar API to DragControls as well so most of this was copy pasted from that code.

The way that it works, is that when the user clicks on an object, a up vector and horizon are created. When the user moves their mouse, the object is rotated around those vectors.