### PR TITLE
ProgressiveLightMap: Fix uv regression.

### DIFF
--- a/examples/jsm/misc/ProgressiveLightMap.js
+++ b/examples/jsm/misc/ProgressiveLightMap.js
@@ -45,6 +45,7 @@ class ProgressiveLightMap {
 
 			// Vertex Shader: Set Vertex Positions to the Unwrapped UV Positions
 			shader.vertexShader =
+				'attribute vec2 uv1;\n' +
 				'#define USE_LIGHTMAP\n' +
 				'#define LIGHTMAP_UV uv1\n' +
 				shader.vertexShader.slice( 0, - 1 ) +


### PR DESCRIPTION
Related issue: #27608

**Description**

`ProgressiveLightMap` enhance a built-in material via `onBeforeCompile()` and injects uv related defines which conflicts with the solution in #27608. To make `ProgressiveLightMap` work again, it must define the `uv1` attribute by itself.