### PR TITLE
WebGLState: Check `WEBGL_draw_buffers` extension before calling `drawBuffersWEBGL()`.

### DIFF
--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -541,9 +541,13 @@ function WebGLState( gl, extensions, capabilities ) {
 
 				gl.drawBuffers( drawBuffers );
 
-			} else {
+			} else if ( extensions.has( 'WEBGL_draw_buffers' ) === true ) {
 
 				extensions.get( 'WEBGL_draw_buffers' ).drawBuffersWEBGL( drawBuffers );
+
+			} else {
+
+				throw new Error( 'THREE.WebGLState: Usage of gl.drawBuffers() require WebGL2 or WEBGL_draw_buffers extension' );
 
 			}
 


### PR DESCRIPTION
**Description**

There are two places have called `state.drawBuffers`, but only the one in `WebGLRenderer` has check `drawBuffers`, other one hasn't.
