### PR TITLE
TSL: Rename `storageObject` -> `storageBuffer`

### DIFF
--- a/examples/jsm/nodes/Nodes.js
+++ b/examples/jsm/nodes/Nodes.js
@@ -98,7 +98,7 @@ export { default as ReferenceNode, reference, referenceIndex } from './accessors
 export { default as ReflectVectorNode, reflectVector } from './accessors/ReflectVectorNode.js';
 export { default as SkinningNode, skinning } from './accessors/SkinningNode.js';
 export { default as SceneNode, backgroundBlurriness, backgroundIntensity } from './accessors/SceneNode.js';
-export { default as StorageBufferNode, storage, storageObject } from './accessors/StorageBufferNode.js';
+export { default as StorageBufferNode, storage, storageBuffer } from './accessors/StorageBufferNode.js';
 export { default as TangentNode, tangentGeometry, tangentLocal, tangentView, tangentWorld, transformedTangentView, transformedTangentWorld } from './accessors/TangentNode.js';
 export { default as TextureNode, texture, textureLoad, /*textureLevel,*/ sampler } from './accessors/TextureNode.js';
 export { default as TextureStoreNode, textureStore } from './accessors/TextureStoreNode.js';

--- a/examples/jsm/nodes/accessors/StorageBufferNode.js
+++ b/examples/jsm/nodes/accessors/StorageBufferNode.js
@@ -13,7 +13,7 @@ class StorageBufferNode extends BufferNode {
 
 		this.isStorageBufferNode = true;
 
-		this.bufferObject = false;
+		this.accessMode = false;
 
 		this._attribute = null;
 		this._varying = null;
@@ -32,9 +32,9 @@ class StorageBufferNode extends BufferNode {
 
 	}
 
-	setBufferObject( value ) {
+	setAccessMode( value ) {
 
-		this.bufferObject = value;
+		this.accessMode = value;
 
 		return this;
 
@@ -67,6 +67,6 @@ class StorageBufferNode extends BufferNode {
 export default StorageBufferNode;
 
 export const storage = ( value, type, count ) => nodeObject( new StorageBufferNode( value, type, count ) );
-export const storageObject = ( value, type, count ) => nodeObject( new StorageBufferNode( value, type, count ).setBufferObject( true ) );
+export const storageBuffer = ( value, type, count ) => nodeObject( new StorageBufferNode( value, type, count ).setAccessMode( true ) );
 
 addNodeClass( 'StorageBufferNode', StorageBufferNode );

--- a/examples/jsm/nodes/utils/StorageArrayElementNode.js
+++ b/examples/jsm/nodes/utils/StorageArrayElementNode.js
@@ -28,7 +28,7 @@ class StorageArrayElementNode extends ArrayElementNode {
 
 		if ( builder.isAvailable( 'storageBuffer' ) === false ) {
 
-			if ( ! this.node.instanceIndex && this.node.bufferObject === true ) {
+			if ( ! this.node.instanceIndex && this.node.accessMode === true ) {
 
 				builder.setupPBO( this.node );
 
@@ -52,7 +52,7 @@ class StorageArrayElementNode extends ArrayElementNode {
 
 			const { node } = this;
 
-			if ( ! node.instanceIndex && this.node.bufferObject === true && isAssignContext !== true ) {
+			if ( ! node.instanceIndex && this.node.accessMode === true && isAssignContext !== true ) {
 
 				snippet = builder.generatePBO( this );
 

--- a/examples/webgpu_compute_audio.html
+++ b/examples/webgpu_compute_audio.html
@@ -29,7 +29,7 @@
 		<script type="module">
 
 			import * as THREE from 'three';
-			import { tslFn, uniform, storage, storageObject, instanceIndex, float, texture, viewportTopLeft, color } from 'three/nodes';
+			import { tslFn, uniform, storage, storageBuffer, instanceIndex, float, texture, viewportTopLeft, color } from 'three/nodes';
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 
@@ -115,7 +115,7 @@
 
 				// read-only buffer
 
-				const waveNode = storageObject( new StorageBufferAttribute( waveBuffer, 1 ), 'float', waveBuffer.length );
+				const waveNode = storageBuffer( new StorageBufferAttribute( waveBuffer, 1 ), 'float', waveBuffer.length );
 
 
 				// params

--- a/examples/webgpu_storage_buffer.html
+++ b/examples/webgpu_storage_buffer.html
@@ -26,7 +26,7 @@
 		<script type="module">
 
 			import * as THREE from 'three';
-			import { storageObject, vec3, uv, uint, float, tslFn, instanceIndex, MeshBasicNodeMaterial } from 'three/nodes';
+			import { storageBuffer, vec3, uv, uint, float, tslFn, instanceIndex, MeshBasicNodeMaterial } from 'three/nodes';
 
 			import WebGPURenderer from 'three/addons/renderers/webgpu/WebGPURenderer.js';
 			import StorageBufferAttribute from 'three/addons/renderers/common/StorageBufferAttribute.js';
@@ -56,7 +56,7 @@
 
 				const arrayBuffer = new StorageBufferAttribute( new Float32Array( array ), typeSize );
 
-				const arrayBufferNode = storageObject( arrayBuffer, type, size );
+				const arrayBufferNode = storageBuffer( arrayBuffer, type, size );
 
 
 				const computeInitOrder = tslFn( () => {


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/27661#issuecomment-1928972925

**Description**

I think it's even more similar to the "storage - buffer" name example. :)

/cc @LeviPesin @RenaudRohlinger 