### PR TITLE
WebXR: Don't request `hand-tracking` feature by default.

### DIFF
--- a/examples/jsm/webxr/VRButton.js
+++ b/examples/jsm/webxr/VRButton.js
@@ -1,6 +1,6 @@
 class VRButton {
 
-	static createButton( renderer ) {
+	static createButton( renderer, sessionInit = {} ) {
 
 		const button = document.createElement( 'button' );
 
@@ -46,7 +46,16 @@ class VRButton {
 			// ('local' is always available for immersive sessions and doesn't need to
 			// be requested separately.)
 
-			const sessionInit = { optionalFeatures: [ 'local-floor', 'bounded-floor', 'hand-tracking', 'layers' ] };
+			const sessionOptions = {
+				...sessionInit,
+				optionalFeatures: [
+					'local-floor',
+					'bounded-floor',
+					'hand-tracking',
+					'layers',
+					...( sessionInit.optionalFeatures || [] )
+				],
+			};
 
 			button.onmouseenter = function () {
 
@@ -64,7 +73,7 @@ class VRButton {
 
 				if ( currentSession === null ) {
 
-					navigator.xr.requestSession( 'immersive-vr', sessionInit ).then( onSessionStarted );
+					navigator.xr.requestSession( 'immersive-vr', sessionOptions ).then( onSessionStarted );
 
 				} else {
 
@@ -72,7 +81,7 @@ class VRButton {
 
 					if ( navigator.xr.offerSession !== undefined ) {
 
-						navigator.xr.offerSession( 'immersive-vr', sessionInit )
+						navigator.xr.offerSession( 'immersive-vr', sessionOptions )
 							.then( onSessionStarted )
 							.catch( ( err ) => {
 
@@ -88,7 +97,7 @@ class VRButton {
 
 			if ( navigator.xr.offerSession !== undefined ) {
 
-				navigator.xr.offerSession( 'immersive-vr', sessionInit )
+				navigator.xr.offerSession( 'immersive-vr', sessionOptions )
 					.then( onSessionStarted )
 					.catch( ( err ) => {
 

--- a/examples/jsm/webxr/VRButton.js
+++ b/examples/jsm/webxr/VRButton.js
@@ -51,7 +51,6 @@ class VRButton {
 				optionalFeatures: [
 					'local-floor',
 					'bounded-floor',
-					'hand-tracking',
 					'layers',
 					...( sessionInit.optionalFeatures || [] )
 				],

--- a/examples/jsm/webxr/XRButton.js
+++ b/examples/jsm/webxr/XRButton.js
@@ -45,7 +45,6 @@ class XRButton {
 				optionalFeatures: [
 					'local-floor',
 					'bounded-floor',
-					'hand-tracking',
 					'layers',
 					...( sessionInit.optionalFeatures || [] )
 				],

--- a/examples/webxr_vr_handinput.html
+++ b/examples/webxr_vr_handinput.html
@@ -85,7 +85,11 @@
 
 				container.appendChild( renderer.domElement );
 
-				document.body.appendChild( VRButton.createButton( renderer ) );
+				const sessionInit = {
+					optionalFeatures: [ 'hand-tracking' ]
+				};
+
+				document.body.appendChild( VRButton.createButton( renderer, sessionInit ) );
 
 				// controllers
 

--- a/examples/webxr_vr_handinput_cubes.html
+++ b/examples/webxr_vr_handinput_cubes.html
@@ -98,7 +98,11 @@
 
 				container.appendChild( renderer.domElement );
 
-				document.body.appendChild( VRButton.createButton( renderer ) );
+				const sessionInit = {
+					optionalFeatures: [ 'hand-tracking' ]
+				};
+
+				document.body.appendChild( VRButton.createButton( renderer, sessionInit ) );
 
 				// controllers
 

--- a/examples/webxr_vr_handinput_pointerclick.html
+++ b/examples/webxr_vr_handinput_pointerclick.html
@@ -320,7 +320,11 @@
 
 			container.appendChild( renderer.domElement );
 
-			document.body.appendChild( VRButton.createButton( renderer ) );
+			const sessionInit = {
+				optionalFeatures: [ 'hand-tracking' ]
+			};
+
+			document.body.appendChild( VRButton.createButton( renderer, sessionInit ) );
 
 			// controllers
 			const controller1 = renderer.xr.getController( 0 );

--- a/examples/webxr_vr_handinput_pointerdrag.html
+++ b/examples/webxr_vr_handinput_pointerdrag.html
@@ -423,7 +423,11 @@
 
 			container.appendChild( renderer.domElement );
 
-			document.body.appendChild( VRButton.createButton( renderer ) );
+			const sessionInit = {
+				optionalFeatures: [ 'hand-tracking' ]
+			};
+
+			document.body.appendChild( VRButton.createButton( renderer, sessionInit ) );
 
 			// controllers
 			const controller1 = renderer.xr.getController( 0 );

--- a/examples/webxr_vr_handinput_pressbutton.html
+++ b/examples/webxr_vr_handinput_pressbutton.html
@@ -380,7 +380,11 @@
 
 			container.appendChild( renderer.domElement );
 
-			document.body.appendChild( VRButton.createButton( renderer ) );
+			const sessionInit = {
+				optionalFeatures: [ 'hand-tracking' ]
+			};
+
+			document.body.appendChild( VRButton.createButton( renderer, sessionInit ) );
 
 			// controllers
 			const controller1 = renderer.xr.getController( 0 );

--- a/examples/webxr_vr_handinput_profiles.html
+++ b/examples/webxr_vr_handinput_profiles.html
@@ -92,7 +92,11 @@
 
 				container.appendChild( renderer.domElement );
 
-				document.body.appendChild( VRButton.createButton( renderer ) );
+				const sessionInit = {
+					optionalFeatures: [ 'hand-tracking' ]
+				};
+
+				document.body.appendChild( VRButton.createButton( renderer, sessionInit ) );
 
 				// controllers
 


### PR DESCRIPTION
Fixed #27698.

**Description**

This PR ensures `VRButtons.createButton()` gets the `sessionInit` parameter like `XRButton` and `ARButton`.

Besides, the optional feature `hand-tracking` is not requested by default anymore to avoid unnecessary permission prompts in visionOS.

/cc @cabanier 
