### PR TITLE
MorphNode: Fix loop performance

### DIFF
--- a/examples/jsm/nodes/accessors/MorphNode.js
+++ b/examples/jsm/nodes/accessors/MorphNode.js
@@ -9,6 +9,7 @@ import { textureLoad } from './TextureNode.js';
 import { vertexIndex } from '../core/IndexNode.js';
 import { ivec2, int } from '../shadernode/ShaderNode.js';
 import { DataArrayTexture, Vector2, Vector4, FloatType } from 'three';
+import { loop } from '../utils/LoopNode.js';
 
 const morphTextures = new WeakMap();
 const morphVec4 = new Vector4();
@@ -185,10 +186,9 @@ class MorphNode extends Node {
 
 		const width = int( size.width );
 
-		for ( let i = 0; i < morphTargetsCount; i ++ ) {
+		loop( morphTargetsCount, ( { i } ) => {
 
 			const influence = referenceIndex( 'morphTargetInfluences', i, 'float' );
-			const depth = int( i );
 
 			if ( hasMorphPosition === true ) {
 
@@ -197,7 +197,7 @@ class MorphNode extends Node {
 					influence,
 					stride,
 					width,
-					depth,
+					depth: i,
 					offset: int( 0 )
 				} ) );
 
@@ -210,13 +210,13 @@ class MorphNode extends Node {
 					influence,
 					stride,
 					width,
-					depth,
+					depth: i,
 					offset: int( 1 )
 				} ) );
 
 			}
 
-		}
+		} );
 
 	}
 

--- a/examples/jsm/nodes/accessors/ReferenceNode.js
+++ b/examples/jsm/nodes/accessors/ReferenceNode.js
@@ -3,15 +3,16 @@ import { NodeUpdateType } from '../core/constants.js';
 import { uniform } from '../core/UniformNode.js';
 import { texture } from './TextureNode.js';
 import { nodeObject } from '../shadernode/ShaderNode.js';
+import { uniforms } from './UniformsNode.js';
 
 class ReferenceNode extends Node {
 
-	constructor( property, uniformType, object = null ) {
+	constructor( property, uniformType, object = null, indexNode = null ) {
 
 		super();
 
 		this.property = property;
-		this.index = null;
+		this.indexNode = indexNode;
 
 		this.uniformType = uniformType;
 
@@ -34,20 +35,6 @@ class ReferenceNode extends Node {
 
 	}
 
-	setIndex( index ) {
-
-		this.index = index;
-
-		return this;
-
-	}
-
-	getIndex() {
-
-		return this.index;
-
-	}
-
 	setNodeType( uniformType ) {
 
 		let node = null;
@@ -55,6 +42,10 @@ class ReferenceNode extends Node {
 		if ( uniformType === 'texture' ) {
 
 			node = texture( null );
+
+		} else if ( this.indexNode !== null ) {
+
+			node = uniforms( null, uniformType ).element( this.indexNode );
 
 		} else {
 
@@ -74,19 +65,28 @@ class ReferenceNode extends Node {
 
 	update( /*frame*/ ) {
 
-		let value = this.reference[ this.property ];
+		const value = this.reference[ this.property ];
 
-		if ( this.index !== null ) {
+		if ( this.indexNode !== null ) {
 
-			value = value[ this.index ];
+			this.node.node.array = value;
+
+		} else {
+
+			this.node.value = value;
 
 		}
 
-		this.node.value = value;
 
 	}
 
-	setup( /*builder*/ ) {
+	setup( builder ) {
+
+		if ( this.indexNode !== null ) {
+
+			this.node.node.array = ( this.object !== null ? this.object : builder.object )[ this.property ];
+
+		}
 
 		return this.node;
 
@@ -97,6 +97,6 @@ class ReferenceNode extends Node {
 export default ReferenceNode;
 
 export const reference = ( name, type, object ) => nodeObject( new ReferenceNode( name, type, object ) );
-export const referenceIndex = ( name, index, type, object ) => nodeObject( new ReferenceNode( name, type, object ).setIndex( index ) );
+export const referenceIndex = ( name, index, type, object ) => nodeObject( new ReferenceNode( name, type, object, index ) );
 
 addNodeClass( 'ReferenceNode', ReferenceNode );

--- a/examples/jsm/nodes/accessors/UniformsNode.js
+++ b/examples/jsm/nodes/accessors/UniformsNode.js
@@ -44,7 +44,7 @@ class UniformsNode extends BufferNode {
 		this._elementType = null;
 		this._elementLength = 0;
 
-		this.updateBeforeType = NodeUpdateType.RENDER;
+		this.updateType = NodeUpdateType.RENDER;
 
 		this.isArrayBufferNode = true;
 
@@ -62,7 +62,7 @@ class UniformsNode extends BufferNode {
 
 	}
 
-	updateBefore( /*frame*/ ) {
+	update( /*frame*/ ) {
 
 		const { array, value } = this;
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/27706, https://discourse.threejs.org/t/webgpurenderer-shader-compilation-time-is-long-with-models-with-a-lot-of-morphs/60446/2

**Description**

Fix loop performance.

/cc @0b5vr @mrdoob 