### PR TITLE
WebGPURenderer: Fix attribute data getting reset when using `vec3` in WebGPU

### DIFF
--- a/examples/jsm/renderers/webgpu/utils/WebGPUAttributeUtils.js
+++ b/examples/jsm/renderers/webgpu/utils/WebGPUAttributeUtils.js
@@ -49,6 +49,12 @@ class WebGPUAttributeUtils {
 				bufferAttribute.itemSize = 4;
 				array = new array.constructor( bufferAttribute.count * 4 );
 
+				for ( let i = 0; i < bufferAttribute.count; i ++ ) {
+
+					array.set( bufferAttribute.array.subarray( i * 3, i * 3 + 3 ), i * 4 );
+
+				}
+
 			}
 
 			const size = array.byteLength + ( ( 4 - ( array.byteLength % 4 ) ) % 4 ); // ensure 4 byte alignment, see #20441


### PR DESCRIPTION
**Description**
This PR fixes an issue where the array content of the attribute is getting reset when using `vec3` attributes.

*This contribution is funded by [Utsubo](https://utsubo.com)*
