### PR TITLE
Raycaster: add ability to stop raycast traversal

### DIFF
--- a/src/core/Raycaster.js
+++ b/src/core/Raycaster.js
@@ -1,6 +1,8 @@
 import { Ray } from '../math/Ray.js';
 import { Layers } from './Layers.js';
 
+class TraversalStopException {}
+
 class Raycaster {
 
 	constructor( origin, direction, near = 0, far = Infinity ) {
@@ -55,7 +57,19 @@ class Raycaster {
 
 	intersectObject( object, recursive = true, intersects = [] ) {
 
-		intersectObject( object, this, intersects, recursive );
+		try {
+
+			intersectObject( object, this, intersects, recursive );
+
+		} catch ( e ) {
+
+			if ( ! e instanceof TraversalStopException ) {
+
+				throw e;
+
+			}
+
+		}
 
 		intersects.sort( ascSort );
 
@@ -65,15 +79,33 @@ class Raycaster {
 
 	intersectObjects( objects, recursive = true, intersects = [] ) {
 
-		for ( let i = 0, l = objects.length; i < l; i ++ ) {
+		try {
 
-			intersectObject( objects[ i ], this, intersects, recursive );
+			for ( let i = 0, l = objects.length; i < l; i ++ ) {
+
+				intersectObject( objects[ i ], this, intersects, recursive );
+
+			}
+
+		} catch ( e ) {
+
+			if ( ! e instanceof TraversalStopException ) {
+
+				throw e;
+
+			}
 
 		}
 
 		intersects.sort( ascSort );
 
 		return intersects;
+
+	}
+
+	stopTraversal() {
+
+		throw new TraversalStopException();
 
 	}
 

--- a/src/core/Raycaster.js
+++ b/src/core/Raycaster.js
@@ -1,8 +1,6 @@
 import { Ray } from '../math/Ray.js';
 import { Layers } from './Layers.js';
 
-class TraversalStopException {}
-
 class Raycaster {
 
 	constructor( origin, direction, near = 0, far = Infinity ) {
@@ -79,12 +77,6 @@ class Raycaster {
 
 	}
 
-	stopTraversal() {
-
-		throw new TraversalStopException();
-
-	}
-
 }
 
 function ascSort( a, b ) {
@@ -95,31 +87,21 @@ function ascSort( a, b ) {
 
 function intersectObject( object, raycaster, intersects, recursive ) {
 
-	try {
+	let stopTraversal = false;
 
-		if ( object.layers.test( raycaster.layers ) ) {
+	if ( object.layers.test( raycaster.layers ) ) {
 
-			object.raycast( raycaster, intersects );
+		stopTraversal = object.raycast( raycaster, intersects );
 
-		}
+	}
 
-		if ( recursive === true ) {
+	if ( recursive === true && ! stopTraversal ) {
 
-			const children = object.children;
+		const children = object.children;
 
-			for ( let i = 0, l = children.length; i < l; i ++ ) {
+		for ( let i = 0, l = children.length; i < l; i ++ ) {
 
-				intersectObject( children[ i ], raycaster, intersects, true );
-
-			}
-
-		}
-
-	} catch ( e ) {
-
-		if ( e instanceof TraversalStopException === false ) {
-
-			throw e;
+			intersectObject( children[ i ], raycaster, intersects, true );
 
 		}
 

--- a/src/core/Raycaster.js
+++ b/src/core/Raycaster.js
@@ -57,19 +57,7 @@ class Raycaster {
 
 	intersectObject( object, recursive = true, intersects = [] ) {
 
-		try {
-
-			intersectObject( object, this, intersects, recursive );
-
-		} catch ( e ) {
-
-			if ( e instanceof TraversalStopException === false ) {
-
-				throw e;
-
-			}
-
-		}
+		intersectObject( object, this, intersects, recursive );
 
 		intersects.sort( ascSort );
 
@@ -79,21 +67,9 @@ class Raycaster {
 
 	intersectObjects( objects, recursive = true, intersects = [] ) {
 
-		try {
+		for ( let i = 0, l = objects.length; i < l; i ++ ) {
 
-			for ( let i = 0, l = objects.length; i < l; i ++ ) {
-
-				intersectObject( objects[ i ], this, intersects, recursive );
-
-			}
-
-		} catch ( e ) {
-
-			if ( e instanceof TraversalStopException === false ) {
-
-				throw e;
-
-			}
+			intersectObject( objects[ i ], this, intersects, recursive );
 
 		}
 
@@ -119,19 +95,31 @@ function ascSort( a, b ) {
 
 function intersectObject( object, raycaster, intersects, recursive ) {
 
-	if ( object.layers.test( raycaster.layers ) ) {
+	try {
 
-		object.raycast( raycaster, intersects );
+		if ( object.layers.test( raycaster.layers ) ) {
 
-	}
+			object.raycast( raycaster, intersects );
 
-	if ( recursive === true ) {
+		}
 
-		const children = object.children;
+		if ( recursive === true ) {
 
-		for ( let i = 0, l = children.length; i < l; i ++ ) {
+			const children = object.children;
 
-			intersectObject( children[ i ], raycaster, intersects, true );
+			for ( let i = 0, l = children.length; i < l; i ++ ) {
+
+				intersectObject( children[ i ], raycaster, intersects, true );
+
+			}
+
+		}
+
+	} catch ( e ) {
+
+		if ( e instanceof TraversalStopException === false ) {
+
+			throw e;
 
 		}
 

--- a/src/core/Raycaster.js
+++ b/src/core/Raycaster.js
@@ -95,7 +95,7 @@ function intersectObject( object, raycaster, intersects, recursive ) {
 
 	}
 
-	if ( recursive === true && stopTraversal === false ) {
+	if ( recursive === true && stopTraversal !== true ) {
 
 		const children = object.children;
 

--- a/src/core/Raycaster.js
+++ b/src/core/Raycaster.js
@@ -63,7 +63,7 @@ class Raycaster {
 
 		} catch ( e ) {
 
-			if ( ! e instanceof TraversalStopException ) {
+			if ( e instanceof TraversalStopException === false ) {
 
 				throw e;
 
@@ -89,7 +89,7 @@ class Raycaster {
 
 		} catch ( e ) {
 
-			if ( ! e instanceof TraversalStopException ) {
+			if ( e instanceof TraversalStopException === false ) {
 
 				throw e;
 

--- a/src/core/Raycaster.js
+++ b/src/core/Raycaster.js
@@ -95,7 +95,7 @@ function intersectObject( object, raycaster, intersects, recursive ) {
 
 	}
 
-	if ( recursive === true && ! stopTraversal ) {
+	if ( recursive === true && stopTraversal === false ) {
 
 		const children = object.children;
 


### PR DESCRIPTION
Fixed #27702

**Description**

When using set of data amounting to thousands of objects and hundreds or thousands of meshes. Without any custom implementation even a single raycast can take an extremely long time.
The use case for this is well described in the issue.

This solution add a method to the Raycaster that allows for the ability to stop raycast traversal. 
By calling `Raycaster.stopTraversal()` from inside one of the raycast, it'll terminate the Raycast traversal.

According to this [perf test](https://perf.link/#eyJpZCI6IjNyd2FpMXZhY2xjIiwidGl0bGUiOiJGaW5kaW5nIG51bWJlcnMgaW4gYW4gYXJyYXkgb2YgMTAwMCIsImJlZm9yZSI6ImNvbnN0IGRhdGEgPSBbLi4uQXJyYXkoMTAwMDApLmtleXMoKV1cbmxldCBqID0gMFxubGV0IHN0b3AgPSBmYWxzZVxuLy8gRGVmaW5lIGEgY3VzdG9tIGV4Y2VwdGlvblxuY2xhc3Mgc3RvcFRyYXZlcnNhbEV4Y2VwdGlvbiB7fVxuIiwidGVzdHMiOlt7Im5hbWUiOiJ1c3VhbCBSYXljYXN0IGxvb3AiLCJjb2RlIjoiZm9yIChsZXQgaSA9IDA7IGkgPCBkYXRhLmxlbmd0aDsgaSsrKSB7XG4gICAgaisrOyAvLyBzaW11bGF0ZSBzb21lIG9wZXJhdGlvblxufSIsInJ1bnMiOlsxMjUwMCw3MDAwLDc1MDAsNjAwMCw2MDAwLDE3MDAwLDcwMDAsNjUwMCw0NTAwLDYwMDAsMzUwMCw3MDAwLDQ1MDAsMzUwMCw2MDAwLDEwMDAwLDY1MDAsMjk1MDAsODUwMCw2MDAwLDQwMDAsNzAwMCw1NTAwLDE1MDAwLDY1MDAsNDAwMCw3NTAwLDI2NTAwLDk1MDAsNjUwMCwzNTAwLDM1MDAsMTI1MDAsMjUwMCw3MDAwLDU1MDAsODUwMCw1NTAwLDQwMDAsMjgwMDAsNjUwMCwxODUwMCw0MDAwLDYwMDAsNjAwMCw3MDAwLDQwMDAsNTAwMCw0MDAwLDcwMDAsNzAwMCwxNDUwMCw1MDAwLDQwMDAsNjUwMCw2NTAwLDIzNTAwLDc1MDAsNDAwMCw1MDAwLDE2MDAwLDUwMDAsNTAwMCwzNTAwLDY1MDAsMjUwMCwzMDAwLDExMDAwLDQ1MDAsMjI1MDAsODAwMCw4MDAwLDcwMDAsNjAwMCw1NTAwLDM1MDAsNjAwMCw3MDAwLDI1MDAsNTUwMCw5MDAwLDc1MDAsMTUwMDAsNzUwMCwyNTAwLDEyNTAwLDU1MDAsNDUwMCwxMzUwMCw2MDAwLDUwMDAsNTUwMCw2MDAwLDg1MDAsNTUwMCw0NTAwLDQ1MDAsNTUwMCw2MDAwLDQ1MDBdLCJvcHMiOjc2NjV9LHsibmFtZSI6InVzdWFsIFJheWNhc3QgbG9vcCB0aGF0IGNoZWNrIGlmIGEgZmxhZyBpcyBzZXQgdG8gc3RvcCIsImNvZGUiOiJmb3IgKGxldCBpID0gMDsgaSA8IGRhdGEubGVuZ3RoOyBpKyspIHtcbiAgICBpZiAoc3RvcCkge1xuICAgICAgICBicmVhazsgLy8gU2ltdWxhdGUgc3RvcHBpbmcgdGhlIGxvb3AgYmFzZWQgb24gYSBjb25kaXRpb25cbiAgICB9XG4gICAgaisrOyAvLyBzaW11bGF0ZSBzb21lIG9wZXJhdGlvblxufSIsInJ1bnMiOls1NTAwLDk1MDAsMTk1MDAsNDUwMCw0NTAwLDY1MDAsNDUwMCwzNTAwLDk1MDAsNTUwMCw1MDAwLDY1MDAsNDAwMCw1NTAwLDU1MDAsMTUwMDAsNjAwMCw1MDAwLDcwMDAsNjUwMCw0MDAwLDYwMDAsNDAwMCwxNTUwMCwxNjAwMCw0MDAwLDY1MDAsOTUwMCw1NTAwLDU1MDAsNTAwMCw0MDAwLDY1MDAsMzAwMCwxNTAwMCw3NTAwLDc1MDAsNzAwMCw4MDAwLDgwMDAsNDUwMCwxMDUwMCwzNTAwLDUwMDAsMTQwMDAsNDAwMCw0MDAwLDU1MDAsNTAwMCw2NTAwLDM1MDAsNDAwMCw0NTAwLDYwMDAsNTUwMCw2MDAwLDE2MDAwLDU1MDAsMzAwMCw0MDAwLDQwMDAsMTA1MDAsNDUwMCw0NTAwLDUwMDAsNDAwMCw1MDAwLDE1MDAwLDQ1MDAsMTQwMDAsMTIwMDAsNDAwMCw0NTAwLDQ1MDAsNzUwMCw4NTAwLDY1MDAsNjAwMCwyMDAwLDQ1MDAsODAwMCw1MDAwLDE0MDAwLDYwMDAsMjUwMCw3NTAwLDUwMDAsNDAwMCw3MDAwLDYwMDAsMzUwMCw2NTAwLDQ1MDAsNDAwMCw2NTAwLDQwMDAsMzUwMCw1MDAwLDU1MDAsNDAwMF0sIm9wcyI6NjUwNX0seyJuYW1lIjoidXN1YWwgUmF5Y2FzdCBsb29wIHRoYXQgaGFuZGxlIHRoZSBzdG9wVHJhdmVyc2FsRXhjZXB0aW9uIGZvciBlYWNoIHJheWNhc3QiLCJjb2RlIjoiZm9yIChsZXQgaSA9IDA7IGkgPCBkYXRhLmxlbmd0aDsgaSsrKSB7XG4gICAgICB0cnkge1xuICAgICAgICAgIGorKzsgLy8gc2ltdWxhdGUgc29tZSBvcGVyYXRpb25cbiAgICAgIH0gY2F0Y2ggKGUpIHtcbiAgICAgICAgICBpZiAoIShlIGluc3RhbmNlb2Ygc3RvcFRyYXZlcnNhbEV4Y2VwdGlvbikpIHtcbiAgICAgICAgICAgICAgdGhyb3cgZTsgLy8gUmUtdGhyb3cgaWYgaXQncyBub3Qgb3VyIGN1c3RvbSBleGNlcHRpb25cbiAgICAgICAgICB9XG4gICAgfVxufVxuIiwicnVucyI6WzYwMDAsNjUwMCwxMzAwMCwyMzAwMCw2NTAwLDQ1MDAsNTAwMCw3MDAwLDE1MDAwLDYwMDAsMzUwMCwyNDUwMCw0NTAwLDYwMDAsMjAwMDAsMTkwMDAsNjUwMCw2NTAwLDQ1MDAsNDAwMCwxMTAwMCw3MDAwLDUwMDAsMjEwMDAsNzAwMCw1NTAwLDEwMDAwLDc1MDAsNTUwMCw0MDAwLDYwMDAsNDUwMCw2NTAwLDQ1MDAsNDAwMCw4MDAwLDcwMDAsNzAwMCwzNTAwLDg1MDAsODUwMCwxNzUwMCw4MDAwLDE4NTAwLDc1MDAsNjUwMCw1MDAwLDY1MDAsNjAwMCw0NTAwLDQwMDAsMjQ1MDAsMTU1MDAsNjUwMCw1MDAwLDEyNTAwLDQ1MDAsNTAwMCwyNTUwMCw1MDAwLDcwMDAsMTUwMDAsNTAwMCw1NTAwLDU1MDAsMTMwMDAsMTA1MDAsMjIwMDAsMTE1MDAsMTc1MDAsNTAwMCwxMzUwMCwxODUwMCw0NTAwLDE1NTAwLDYwMDAsMjAwMDAsNDAwMCw0NTAwLDU1MDAsNjUwMCw5MDAwLDUwMDAsNjAwMCw0NTAwLDIyNTAwLDUwMDAsNDUwMCw2NTAwLDcwMDAsNTUwMCw3NTAwLDE1NTAwLDcwMDAsODAwMCwzNTAwLDU1MDAsNjUwMCw2MDAwLDQ1MDBdLCJvcHMiOjg4NjV9LHsibmFtZSI6InVzdWFsIFJheWNhc3QgbG9vcCB0aGF0IGhhbmRsZSB0aGUgc3RvcFRyYXZlcnNhbEV4Y2VwdGlvbiBhcm91bmQgZXZlcnl0aGluZyIsImNvZGUiOiJ0cnkge1xuICAgIGZvciAobGV0IGkgPSAwOyBpIDwgZGF0YS5sZW5ndGg7IGkrKykge1xuICAgICAgIGorKzsgLy8gc2ltdWxhdGUgc29tZSBvcGVyYXRpb25cbiAgICB9XG59IGNhdGNoIChlKSB7XG4gICAgaWYgKCEoZSBpbnN0YW5jZW9mIHN0b3BUcmF2ZXJzYWxFeGNlcHRpb24pKSB7XG4gICAgICAgIHRocm93IGU7IC8vIFJlLXRocm93IGlmIGl0J3Mgbm90IG91ciBjdXN0b20gZXhjZXB0aW9uXG4gICAgfVxufVxuICAgXG4iLCJydW5zIjpbOTUwMCw1NTAwLDcwMDAsNjAwMCw1NTAwLDQ1MDAsNjAwMCw0MDAwLDcwMDAsNjAwMCw1NTAwLDExNTAwLDUwMDAsNjUwMCw2NTAwLDkwMDAsMzAwMCw3NTAwLDg1MDAsNzUwMCw3NTAwLDcwMDAsODUwMCw3MDAwLDU1MDAsNTAwMCw3NTAwLDgwMDAsOTAwMCw2MDAwLDQ1MDAsNTAwMCw4MDAwLDcwMDAsNTUwMCwzNTAwLDMwMDAsNTUwMCw4MDAwLDc1MDAsNzUwMCw4MDAwLDcwMDAsNjUwMCwzMDAwLDY1MDAsODUwMCwzMDAwLDEwMDAwLDcwMDAsOTAwMCw3MDAwLDU1MDAsOTAwMCw1MDAwLDY1MDAsNjUwMCw1MDAwLDcwMDAsNzUwMCw2MDAwLDYwMDAsMjY1MDAsNTUwMCwyODAwMCw3MDAwLDEwMDAsNzUwMCwyMTAwMCw3MDAwLDYwMDAsMTgwMDAsNzAwMCwzMDAwLDQ1MDAsNjAwMCw3NTAwLDY1MDAsNTUwMCw3NTAwLDQ1MDAsODUwMCw5NTAwLDE4NTAwLDcwMDAsNjUwMCw1MDAwLDY1MDAsNjAwMCw2NTAwLDM1MDAsODAwMCw3NTAwLDY1MDAsNjUwMCwzNTAwLDM1MDAsMTc1MDAsNDUwMCw0NTAwXSwib3BzIjo3MjYwfV0sInVwZGF0ZWQiOiIyMDI0LTAyLTA4VDA2OjI5OjI5LjI1NVoifQ%3D%3D) ( that isn't consistent, might need a better test ) there is no downside for the regular usage and performance of the current Raycast.

*This contribution is funded by [Alaric Baraou ✌](https://www.linkedin.com/in/alaric-baraou/)*
