### PR TITLE
[Docs] Add warning on Object3D.applyMatrix4 based on Matrix4.decompose

### DIFF
--- a/docs/api/en/core/Object3D.html
+++ b/docs/api/en/core/Object3D.html
@@ -300,11 +300,6 @@
 			Applies the matrix transform to the object and updates the object's
 			position, rotation and scale.
 		</p>
-		<p>
-			Note: This method relies on [page:Matrix4.decompose], and not all matrices are decomposable in this way. 
-			For example, if an object has a non-uniformly scaled parent, then the object's world matrix may not be decomposable, 
-			and this method may not be appropriate.
-		</p>
 
 		<h3>[method:this applyQuaternion]( [param:Quaternion quaternion] )</h3>
 		<p>Applies the rotation represented by the quaternion to the object.</p>

--- a/docs/api/en/core/Object3D.html
+++ b/docs/api/en/core/Object3D.html
@@ -300,6 +300,11 @@
 			Applies the matrix transform to the object and updates the object's
 			position, rotation and scale.
 		</p>
+		<p>
+			Note: This method relies on [page:Matrix4.decompose], and not all matrices are decomposable in this way. 
+			For example, if an object has a non-uniformly scaled parent, then the object's world matrix may not be decomposable, 
+			and this method may not be appropriate.
+		</p>
 
 		<h3>[method:this applyQuaternion]( [param:Quaternion quaternion] )</h3>
 		<p>Applies the rotation represented by the quaternion to the object.</p>

--- a/docs/manual/en/introduction/Matrix-transformations.html
+++ b/docs/manual/en/introduction/Matrix-transformations.html
@@ -56,7 +56,6 @@ object.matrixAutoUpdate = false;
 		</p>
 		<p>
 		An object can be transformed via [page:Object3D.applyMatrix4]. Note: Under-the-hood, this method relies on [page:Matrix4.decompose], and not all matrices are decomposable in this way. For example, if an object has a non-uniformly scaled parent, then the object's world matrix may not be decomposable, and this method may not be appropriate.
-		In this case, it might be safer to use the second method `object.matrix.premultiply(transform);`
 		</p>
 
 		<h2>Rotation and Quaternion</h2>

--- a/docs/manual/en/introduction/Matrix-transformations.html
+++ b/docs/manual/en/introduction/Matrix-transformations.html
@@ -54,6 +54,10 @@ object.matrixAutoUpdate = false;
 		<p>
 		When either the parent or the child object's transformation changes, you can request that the child object's [page:Object3D.matrixWorld matrixWorld] be updated by calling [page:Object3D.updateMatrixWorld updateMatrixWorld]().
 		</p>
+		<p>
+		An object can be transformed via [page:Object3D.applyMatrix4]. Note: Under-the-hood, this method relies on [page:Matrix4.decompose], and not all matrices are decomposable in this way. For example, if an object has a non-uniformly scaled parent, then the object's world matrix may not be decomposable, and this method may not be appropriate.
+		In this case, it might be safer to use the second method `object.matrix.premultiply(transform);`
+		</p>
 
 		<h2>Rotation and Quaternion</h2>
 		<p>


### PR DESCRIPTION
[Docs] Add warning on Object3D.applyMatrix4 based on Matrix4.decompose for potentially non-decomposable matrices

Fixed #27713.

**Description**

Object3D.applyMatrix4 can have issues when used with objects which have parents with non uniform scale. A note is already present on Matrix4.decompose, and could be added to Object3D.applyMatrix4
