### PR TITLE
WebGLRenderer: Rename `KhronosNeutralToneMapping` to `NeutralToneMapping`.

### DIFF
--- a/docs/api/ar/constants/Renderer.html
+++ b/docs/api/ar/constants/Renderer.html
@@ -51,13 +51,17 @@
 		THREE.CineonToneMapping 
 		THREE.ACESFilmicToneMapping
 		THREE.AgXToneMapping
+		THREE.NeutralToneMapping
 		THREE.CustomToneMapping
 		</code>
 		<p>
 			هذه الخيارات تحدد خاصية [page:WebGLRenderer.toneMapping toneMapping] في WebGLRenderer. يتم استخدام هذا لتقريب مظهر نطاق الإضاءة العالي (HDR) على الوسط الذي يحتوي على نطاق إضاءة منخفض على شاشة الكمبيوتر القياسية أو شاشة الجوال.
 		</p>
 		<p>
-			THREE.LinearToneMapping، THREE.ReinhardToneMapping، THREE.CineonToneMapping، THREE.ACESFilmicToneMapping و THREE.AgXToneMapping هي تنفيذات مدمجة لتقريب مظهر نطاق الإضاءة العالي (HDR). يتوقع THREE.CustomToneMapping تنفيذًا مخصصًا عن طريق تعديل شفرة GLSL لبرنامج تظليل مقطع المواد. راجع [example:webgl_tonemapping WebGL / tonemapping] مثالًا. 
+			THREE.LinearToneMapping، THREE.ReinhardToneMapping، THREE.CineonToneMapping، THREE.ACESFilmicToneMapping، THREE.AgXToneMapping و THREE.NeutralToneMapping هي تنفيذات مدمجة لتقريب مظهر نطاق الإضاءة العالي (HDR). يتوقع THREE.CustomToneMapping تنفيذًا مخصصًا عن طريق تعديل شفرة GLSL لبرنامج تظليل مقطع المواد. راجع [example:webgl_tonemapping WebGL / tonemapping] مثالًا. 
+		</p>
+		<p>
+			THREE.NeutralToneMapping is an implementation based on the Khronos 3D Commerce Group standard tone mapping.
 		</p>
 
 		<h2>المصدر (Source)</h2>

--- a/docs/api/en/constants/Renderer.html
+++ b/docs/api/en/constants/Renderer.html
@@ -53,6 +53,7 @@
 		THREE.CineonToneMapping 
 		THREE.ACESFilmicToneMapping
 		THREE.AgXToneMapping
+		THREE.NeutralToneMapping
 		THREE.CustomToneMapping
 		</code>
 		<p>
@@ -61,11 +62,13 @@
 			monitor or mobile device's screen.
 		</p>
 		<p>
-			THREE.LinearToneMapping, THREE.ReinhardToneMapping,
-			THREE.CineonToneMapping, THREE.ACESFilmicToneMapping, and THREE.AgXToneMapping are built-in
-			implementations of tone mapping. THREE.CustomToneMapping expects a custom
-			implementation by modyfing GLSL code of the material's fragment shader.
+			THREE.LinearToneMapping, THREE.ReinhardToneMapping, THREE.CineonToneMapping, THREE.ACESFilmicToneMapping, 
+			THREE.AgXToneMapping and THREE.NeutralToneMapping are built-inimplementations of tone mapping. 
+			THREE.CustomToneMapping expects a custom implementation by modyfing GLSL code of the material's fragment shader.
 			See the [example:webgl_tonemapping WebGL / tonemapping] example.
+		</p>
+		<p>
+			THREE.NeutralToneMapping is an implementation based on the Khronos 3D Commerce Group standard tone mapping.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/fr/constants/Renderer.html
+++ b/docs/api/fr/constants/Renderer.html
@@ -47,6 +47,7 @@
 		THREE.CineonToneMapping
 		THREE.ACESFilmicToneMapping
 		THREE.AgXToneMapping
+		THREE.NeutralToneMapping
 		THREE.CustomToneMapping
 		</code>
 		<p>
@@ -55,11 +56,13 @@
 		milieu de plage dynamique faible d'un écran d'ordinateur standard ou d'un écran d'appareil mobile.
 		</p>
 		<p>
-		THREE.LinearToneMapping, THREE.ReinhardToneMapping, THREE.CineonToneMapping, THREE.ACESFilmicToneMapping et THREE.AgXToneMapping sont des implémentations intégrées à la cartographie des tons.
+		THREE.LinearToneMapping, THREE.ReinhardToneMapping, THREE.CineonToneMapping, THREE.ACESFilmicToneMapping, THREE.AgXToneMapping et THREE.NeutralToneMapping sont des implémentations intégrées à la cartographie des tons.
 		THREE.CustomToneMapping attend une implémentation personnalisée en modifiant le code GLSL du fragment shader du matériau.
 		Voir l'exemple [example:webgl_tonemapping WebGL / tonemapping].
 		</p>
-
+		<p>
+			THREE.NeutralToneMapping is an implementation based on the Khronos 3D Commerce Group standard tone mapping.
+		</p>
 
 		<h2>Source</h2>
 

--- a/docs/api/it/constants/Renderer.html
+++ b/docs/api/it/constants/Renderer.html
@@ -49,6 +49,7 @@
 		THREE.CineonToneMapping
 		THREE.ACESFilmicToneMapping
 		THREE.AgXToneMapping
+		THREE.NeutralToneMapping
 		THREE.CustomToneMapping
 		</code>
 		<p>
@@ -57,10 +58,13 @@
       gamma dinamica bassa del monitor di un computer o dello schermo di un dispositivo mobile.
 		</p>
 		<p>
-      THREE.LinearToneMapping, THREE.ReinhardToneMapping, THREE.CineonToneMapping, THREE.ACESFilmicToneMapping e THREE.AgXToneMapping sono implementazioni 
+      THREE.LinearToneMapping, THREE.ReinhardToneMapping, THREE.CineonToneMapping, THREE.ACESFilmicToneMapping THREE.AgXToneMapping e THREE.NeutralToneMapping sono implementazioni 
       integrate della mappatura dei toni.
       THREE.CustomToneMapping prevede un'implementazione personalizzata modificando il codice GLSL dello shader di frammenti del materiale.
       Vedi l'esempio [example:webgl_tonemapping WebGL / tonemapping].
+		</p>
+		<p>
+			THREE.NeutralToneMapping is an implementation based on the Khronos 3D Commerce Group standard tone mapping.
 		</p>
 
 

--- a/docs/api/ko/constants/Renderer.html
+++ b/docs/api/ko/constants/Renderer.html
@@ -47,6 +47,7 @@
 		THREE.CineonToneMapping
 		THREE.ACESFilmicToneMapping
 		THREE.AgXToneMapping
+		THREE.NeutralToneMapping
 		THREE.CustomToneMapping
 		</code>
 		<p>
@@ -56,7 +57,9 @@
 		[example:webgl_tonemapping WebGL / tonemapping] 예제를 참고하세요.
 
 		</p>
-
+		<p>
+			THREE.NeutralToneMapping is an implementation based on the Khronos 3D Commerce Group standard tone mapping.
+		</p>
 
 		<h2>소스 코드</h2>
 

--- a/docs/api/pt-br/constants/Renderer.html
+++ b/docs/api/pt-br/constants/Renderer.html
@@ -47,6 +47,7 @@
 		THREE.CineonToneMapping
 		THREE.ACESFilmicToneMapping
 		THREE.AgXToneMapping
+		THREE.NeutralToneMapping
 		THREE.CustomToneMapping
 		</code>
 		<p>
@@ -55,9 +56,12 @@
 		médio da faixa dinâmica baixa de um monitor de computador padrão ou tela de dispositivo móvel.
 		</p>
 		<p>
-		THREE.LinearToneMapping, THREE.ReinhardToneMapping, THREE.CineonToneMapping, THREE.ACESFilmicToneMapping e THREE.AgXToneMapping são implementações internas de mapeamento de tom.
+		THREE.LinearToneMapping, THREE.ReinhardToneMapping, THREE.CineonToneMapping, THREE.ACESFilmicToneMapping, THREE.AgXToneMapping e THREE.NeutralToneMapping são implementações internas de mapeamento de tom.
 		THREE.CustomToneMapping espera uma implementação personalizada modificando o código GLSL do sombreador de fragmento do material.  
 		Vejo o exemplo [example:webgl_tonemapping WebGL / tonemapping].
+		</p>
+		<p>
+			THREE.NeutralToneMapping is an implementation based on the Khronos 3D Commerce Group standard tone mapping.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/zh/constants/Renderer.html
+++ b/docs/api/zh/constants/Renderer.html
@@ -47,6 +47,7 @@
 		THREE.CineonToneMapping
 		THREE.ACESFilmicToneMapping
 		THREE.AgXToneMapping
+		THREE.NeutralToneMapping
 		THREE.CustomToneMapping
 		</code>
 		<p>
@@ -57,7 +58,9 @@
 		请查看示例：[example:webgl_tonemapping WebGL / tonemapping]。
 
 		</p>
-
+		<p>
+			THREE.NeutralToneMapping is an implementation based on the Khronos 3D Commerce Group standard tone mapping.
+		</p>
 
 		<h2>源代码</h2>
 

--- a/editor/js/Sidebar.Project.Renderer.js
+++ b/editor/js/Sidebar.Project.Renderer.js
@@ -68,7 +68,8 @@ function SidebarProjectRenderer( editor ) {
 		2: 'Reinhard',
 		3: 'Cineon',
 		4: 'ACESFilmic',
-		6: 'AgX'
+		6: 'AgX',
+		7: 'Neutral'
 	} ).setWidth( '120px' ).onChange( updateToneMapping );
 	toneMappingSelect.setValue( config.getKey( 'project/renderer/toneMapping' ) );
 	toneMappingRow.add( toneMappingSelect );

--- a/examples/jsm/postprocessing/OutputPass.js
+++ b/examples/jsm/postprocessing/OutputPass.js
@@ -7,7 +7,7 @@ import {
 	CineonToneMapping,
 	AgXToneMapping,
 	ACESFilmicToneMapping,
-	KhronosNeutralToneMapping,
+	NeutralToneMapping,
 	SRGBTransfer
 } from 'three';
 import { Pass, FullScreenQuad } from './Pass.js';
@@ -62,7 +62,7 @@ class OutputPass extends Pass {
 			else if ( this._toneMapping === CineonToneMapping ) this.material.defines.CINEON_TONE_MAPPING = '';
 			else if ( this._toneMapping === ACESFilmicToneMapping ) this.material.defines.ACES_FILMIC_TONE_MAPPING = '';
 			else if ( this._toneMapping === AgXToneMapping ) this.material.defines.AGX_TONE_MAPPING = '';
-			else if ( this._toneMapping === KhronosNeutralToneMapping ) this.material.defines.KHRONOS_NEUTRAL_TONE_MAPPING = '';
+			else if ( this._toneMapping === NeutralToneMapping ) this.material.defines.NEUTRAL_TONE_MAPPING = '';
 
 			this.material.needsUpdate = true;
 

--- a/examples/jsm/shaders/OutputShader.js
+++ b/examples/jsm/shaders/OutputShader.js
@@ -64,9 +64,9 @@ const OutputShader = {
 
 				gl_FragColor.rgb = AgXToneMapping( gl_FragColor.rgb );
 
-			#elif defined( KHRONOS_NEUTRAL_TONE_MAPPING )
+			#elif defined( NEUTRAL_TONE_MAPPING )
 
-				gl_FragColor.rgb = KhronosNeutralToneMapping( gl_FragColor.rgb );
+				gl_FragColor.rgb = NeutralToneMapping( gl_FragColor.rgb );
 
 			#endif
 

--- a/examples/webgl_tonemapping.html
+++ b/examples/webgl_tonemapping.html
@@ -50,6 +50,7 @@
 				Cineon: THREE.CineonToneMapping,
 				ACESFilmic: THREE.ACESFilmicToneMapping,
 				AgX: THREE.AgXToneMapping,
+				Neutral: THREE.NeutralToneMapping,
 				Custom: THREE.CustomToneMapping
 			};
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -57,7 +57,7 @@ export const CineonToneMapping = 3;
 export const ACESFilmicToneMapping = 4;
 export const CustomToneMapping = 5;
 export const AgXToneMapping = 6;
-export const KhronosNeutralToneMapping = 7;
+export const NeutralToneMapping = 7;
 export const AttachedBindMode = 'attached';
 export const DetachedBindMode = 'detached';
 

--- a/src/renderers/shaders/ShaderChunk/tonemapping_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/tonemapping_pars_fragment.glsl.js
@@ -167,7 +167,7 @@ vec3 AgXToneMapping( vec3 color ) {
 
 // https://modelviewer.dev/examples/tone-mapping
 
-vec3 KhronosNeutralToneMapping( vec3 color ) {
+vec3 NeutralToneMapping( vec3 color ) {
 	float startCompression = 0.8 - 0.04;
 	float desaturation = 0.15;
 

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -1,7 +1,7 @@
 import { WebGLUniforms } from './WebGLUniforms.js';
 import { WebGLShader } from './WebGLShader.js';
 import { ShaderChunk } from '../shaders/ShaderChunk.js';
-import { NoToneMapping, AddOperation, MixOperation, MultiplyOperation, CubeRefractionMapping, CubeUVReflectionMapping, CubeReflectionMapping, PCFSoftShadowMap, PCFShadowMap, VSMShadowMap, AgXToneMapping, ACESFilmicToneMapping, KhronosNeutralToneMapping, CineonToneMapping, CustomToneMapping, ReinhardToneMapping, LinearToneMapping, GLSL3, LinearSRGBColorSpace, SRGBColorSpace, LinearDisplayP3ColorSpace, DisplayP3ColorSpace, P3Primaries, Rec709Primaries } from '../../constants.js';
+import { NoToneMapping, AddOperation, MixOperation, MultiplyOperation, CubeRefractionMapping, CubeUVReflectionMapping, CubeReflectionMapping, PCFSoftShadowMap, PCFShadowMap, VSMShadowMap, AgXToneMapping, ACESFilmicToneMapping, NeutralToneMapping, CineonToneMapping, CustomToneMapping, ReinhardToneMapping, LinearToneMapping, GLSL3, LinearSRGBColorSpace, SRGBColorSpace, LinearDisplayP3ColorSpace, DisplayP3ColorSpace, P3Primaries, Rec709Primaries } from '../../constants.js';
 import { ColorManagement } from '../../math/ColorManagement.js';
 
 // From https://www.khronos.org/registry/webgl/extensions/KHR_parallel_shader_compile/
@@ -124,8 +124,8 @@ function getToneMappingFunction( functionName, toneMapping ) {
 			toneMappingName = 'AgX';
 			break;
 
-		case KhronosNeutralToneMapping:
-			toneMappingName = 'KhronosNeutral';
+		case NeutralToneMapping:
+			toneMappingName = 'Neutral';
 			break;
 
 		case CustomToneMapping:

--- a/test/unit/src/constants.tests.js
+++ b/test/unit/src/constants.tests.js
@@ -72,7 +72,7 @@ export default QUnit.module( 'Constants', () => {
 		assert.equal( Constants.ACESFilmicToneMapping, 4, 'ACESFilmicToneMapping is equal to 4' );
 		assert.equal( Constants.CustomToneMapping, 5, 'CustomToneMapping is equal to 5' );
 		assert.equal( Constants.AgXToneMapping, 6, 'AgXToneMapping is equal to 6' );
-		assert.equal( Constants.KhronosNeutralToneMapping, 7, 'KhronosNeutralToneMapping is equal to 7' );
+		assert.equal( Constants.NeutralToneMapping, 7, 'NeutralToneMapping is equal to 7' );
 
 		assert.equal( Constants.AttachedBindMode, 'attached', 'AttachedBindMode is equal to attached' );
 		assert.equal( Constants.DetachedBindMode, 'detached', 'DetachedBindMode is equal to detached' );


### PR DESCRIPTION
Related issue: #27668

**Description**

This PR renames `KhronosNeutralToneMapping` to `NeutralToneMapping`.

The new tone mapping is also integrated in the docs, the example `webgl_tonemapping` and in the editor.