### PR TITLE
TransformControls: fix some edge case transforms

### DIFF
--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -215,7 +215,13 @@ class TransformControls extends Object3D {
 
 		}
 
-		super.updateMatrixWorld( this );
+		// the TransformControl should ignore any parent matrix
+		this.matrixAutoUpdate = false;
+		this.updateMatrix();
+		this.matrixWorldNeedsUpdate = false;
+		this.matrixWorld.copy( this.matrix );
+
+		super.updateMatrixWorld();
 
 	}
 

--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -359,35 +359,28 @@ class TransformControls extends Object3D {
 
 				if ( space === 'world' ) {
 
-					if ( object.parent ) {
-
-						object.position.add( _tempVector.setFromMatrixPosition( object.parent.matrixWorld ) );
-
-					}
+					this.worldPosition;
+					object.getWorldPosition( this.worldPosition );
 
 					if ( axis.search( 'X' ) !== - 1 ) {
 
-						object.position.x = Math.round( object.position.x / this.translationSnap ) * this.translationSnap;
+						this.worldPosition.x = Math.round( this.worldPosition.x / this.translationSnap ) * this.translationSnap;
 
 					}
 
 					if ( axis.search( 'Y' ) !== - 1 ) {
 
-						object.position.y = Math.round( object.position.y / this.translationSnap ) * this.translationSnap;
+						this.worldPosition.y = Math.round( this.worldPosition.y / this.translationSnap ) * this.translationSnap;
 
 					}
 
 					if ( axis.search( 'Z' ) !== - 1 ) {
 
-						object.position.z = Math.round( object.position.z / this.translationSnap ) * this.translationSnap;
+						this.worldPosition.z = Math.round( this.worldPosition.z / this.translationSnap ) * this.translationSnap;
 
 					}
 
-					if ( object.parent ) {
-
-						object.position.sub( _tempVector.setFromMatrixPosition( object.parent.matrixWorld ) );
-
-					}
+					object.position.copy( object.parent.worldToLocal( this.worldPosition ) );
 
 				}
 

--- a/examples/misc_controls_transform.html
+++ b/examples/misc_controls_transform.html
@@ -10,7 +10,7 @@
 
 		<div id="info">
 			"W" translate | "E" rotate | "R" scale | "+/-" adjust size<br />
-			"Q" toggle world/local space |  "Shift" snap to grid<br />
+			"Q" toggle world/local space |  "Shift" hold to snap to grid<br />
 			"X" toggle X | "Y" toggle Y | "Z" toggle Z | "Spacebar" toggle enabled<br />
 			"Esc" reset current transform<br />
 			"C" toggle camera | "V" random zoom
@@ -100,7 +100,7 @@
 							break;
 
 						case 16: // Shift
-							control.setTranslationSnap( 100 );
+							control.setTranslationSnap( 1 );
 							control.setRotationSnap( THREE.MathUtils.degToRad( 15 ) );
 							control.setScaleSnap( 0.25 );
 							break;


### PR DESCRIPTION
Related issue: #21840

**Description**

Unexpected transform happens when using TransformControls under theese three specific conditions:

-  When the object has a rotated parent
- The coordinate space is set to 'world'
- TranslationSnap is a numeric value

Addiotionnaly if the scene had a rotation, it would also mess up the TransformControls expected behaviour.

Both have been fixed in this PR.

*note, changed a snap value in the demo that was wayy to high to be usable with translate

https://github.com/mrdoob/three.js/assets/7174039/44ba9f08-f25a-4b81-b78d-f90a83573b5e



*This contribution is funded by [Alaric Baraou 🦦](https://alaricbaraou.com/)*
