### PR TITLE
Examples: Clean up.

### DIFF
--- a/examples/webgl_lights_spotlight.html
+++ b/examples/webgl_lights_spotlight.html
@@ -170,7 +170,7 @@
 				} );
 
 
-				gui.add( params, 'distance', 50, 200 ).onChange( function ( val ) {
+				gui.add( params, 'distance', 0, 20 ).onChange( function ( val ) {
 
 					spotLight.distance = val;
 


### PR DESCRIPTION
Related issue: -

**Description**

The current `distance` range in `webgl_lights_spotlight` does not make sense. Switching to `[0, 20]` shows much better how the parameter works.