### PR TITLE
PointLight/SpotLight: `distance` does not influence shadows anymore.

### DIFF
--- a/docs/api/ar/lights/shadows/PointLightShadow.html
+++ b/docs/api/ar/lights/shadows/PointLightShadow.html
@@ -25,7 +25,7 @@
 		renderer.shadowMap.type = THREE.PCFSoftShadowMap; // default THREE.PCFShadowMap
 
 		//Create a PointLight and turn on shadows for the light
-		const light = new THREE.PointLight( 0xffffff, 1, 100 );
+		const light = new THREE.PointLight();
 		light.position.set( 0, 10, 4 );
 		light.castShadow = true; // default false
 		scene.add( light );

--- a/docs/api/ar/lights/shadows/SpotLightShadow.html
+++ b/docs/api/ar/lights/shadows/SpotLightShadow.html
@@ -24,7 +24,7 @@
 		renderer.shadowMap.type = THREE.PCFSoftShadowMap; // default THREE.PCFShadowMap
 
 		//Create a SpotLight and turn on shadows for the light
-		const light = new THREE.SpotLight( 0xffffff );
+		const light = new THREE.SpotLight();
 		light.castShadow = true; // default false
 		scene.add( light );
 
@@ -79,9 +79,7 @@
 		خاصية [page:SpotLight SpotLight] المملوكة عبر
 		[page:SpotLightShadow.update update] طريقة. بالمثل ،
 		[page:PerspectiveCamera.aspect aspect] خاصية ستتبع نسبة
-		[page:LightShadow.mapSize mapSize]. إذا تم تعيين [page:SpotLight.distance distance]
-		خاصية الضوء ، فستتبع [page:PerspectiveCamera.far far]
-		كليبينغ بلان ذلك ، وإلا فإنه يفترض `500`.
+		[page:LightShadow.mapSize mapSize].
 		</p>
 		
 		<h3>[property:Number focus]</h3>

--- a/docs/api/en/lights/shadows/PointLightShadow.html
+++ b/docs/api/en/lights/shadows/PointLightShadow.html
@@ -24,7 +24,7 @@
 		renderer.shadowMap.type = THREE.PCFSoftShadowMap; // default THREE.PCFShadowMap
 
 		//Create a PointLight and turn on shadows for the light
-		const light = new THREE.PointLight( 0xffffff, 1, 100 );
+		const light = new THREE.PointLight();
 		light.position.set( 0, 10, 4 );
 		light.castShadow = true; // default false
 		scene.add( light );

--- a/docs/api/en/lights/shadows/SpotLightShadow.html
+++ b/docs/api/en/lights/shadows/SpotLightShadow.html
@@ -24,7 +24,7 @@
 		renderer.shadowMap.type = THREE.PCFSoftShadowMap; // default THREE.PCFShadowMap
 
 		//Create a SpotLight and turn on shadows for the light
-		const light = new THREE.SpotLight( 0xffffff );
+		const light = new THREE.SpotLight();
 		light.castShadow = true; // default false
 		scene.add( light );
 
@@ -79,9 +79,7 @@
 			property of the owning [page:SpotLight SpotLight] via the
 			[page:SpotLightShadow.update update] method. Similarly, the
 			[page:PerspectiveCamera.aspect aspect] property will track the aspect of
-			the [page:LightShadow.mapSize mapSize]. If the [page:SpotLight.distance distance] 
-			property of the light is set, the [page:PerspectiveCamera.far far] 
-			clipping plane will track that, otherwise it defaults to `500`.
+			the [page:LightShadow.mapSize mapSize].
 		</p>
 
 		<h3>[property:Number focus]</h3>

--- a/docs/api/it/lights/shadows/PointLightShadow.html
+++ b/docs/api/it/lights/shadows/PointLightShadow.html
@@ -24,7 +24,7 @@
 		renderer.shadowMap.type = THREE.PCFSoftShadowMap; // default THREE.PCFShadowMap
 
 		// Crea una PointLight e attiva le ombre per la luce
-		const light = new THREE.PointLight( 0xffffff, 1, 100 );
+		const light = new THREE.PointLight();
 		light.position.set( 0, 10, 4 );
 		light.castShadow = true; // default false
 		scene.add( light );

--- a/docs/api/it/lights/shadows/SpotLightShadow.html
+++ b/docs/api/it/lights/shadows/SpotLightShadow.html
@@ -23,7 +23,7 @@
 		renderer.shadowMap.type = THREE.PCFSoftShadowMap; // default THREE.PCFShadowMap
 
 		// Crea una SpotLight e attiva le ombre per la luce
-		const light = new THREE.SpotLight( 0xffffff );
+		const light = new THREE.SpotLight();
 		light.castShadow = true; // default false
 		scene.add( light );
 
@@ -73,8 +73,6 @@
       Il [page:PerspectiveCamera.fov fov] traccerà la proprietà dell'[page:SpotLight.angle angolo] del proprietario 
       [page:SpotLight SpotLight] tramite il metodo [page:SpotLightShadow.update update]. Allo stesso modo, la proprietà
       [page:PerspectiveCamera.aspect aspect] terrà traccia dell'aspetto della [page:LightShadow.mapSize mapSize].
-      Se la proprietà [page:SpotLight.distance distance] della luce è impostata, il piano [page:PerspectiveCamera.far far]
-      la seguirà, altrimenti il valore predefinito è `500`.
 		</p>
 
 		<h3>[property:Number focus]</h3>

--- a/docs/api/zh/lights/shadows/PointLightShadow.html
+++ b/docs/api/zh/lights/shadows/PointLightShadow.html
@@ -25,7 +25,7 @@
 		renderer.shadowMap.type = THREE.PCFSoftShadowMap; // default THREE.PCFShadowMap
 
 		//Create a PointLight and turn on shadows for the light
-		const light = new THREE.PointLight( 0xffffff, 1, 100 );
+		const light = new THREE.PointLight();
 		light.position.set( 0, 10, 4 );
 		light.castShadow = true; // default false
 		scene.add( light );

--- a/docs/api/zh/lights/shadows/SpotLightShadow.html
+++ b/docs/api/zh/lights/shadows/SpotLightShadow.html
@@ -24,7 +24,7 @@
 		renderer.shadowMap.type = THREE.PCFSoftShadowMap; // default THREE.PCFShadowMap
 
 		//Create a SpotLight and turn on shadows for the light
-		const light = new THREE.SpotLight( 0xffffff );
+		const light = new THREE.SpotLight();
 		light.castShadow = true;            // default false
 		scene.add( light );
 
@@ -65,7 +65,7 @@
 		<p>
 			在光的世界里。这用于生成场景的深度图;从光的角度来看，其他物体背后的物体将处于阴影中。<br /><br />
 
-			默认值为PerspectiveCamera，近剪裁平面为0.5。 fov将通过更新方法跟踪拥有SpotLight的角度属性。同样，aspect属性将跟踪mapSize的方面。如果设置了灯光的距离属性，则远剪裁平面将跟踪该值，否则默认为500。
+			默认值为PerspectiveCamera，近剪裁平面为0.5。 fov将通过更新方法跟踪拥有SpotLight的角度属性。同样，aspect属性将跟踪mapSize的方面。
 		</p>
 
 		<h3>[property:Number focus]</h3>

--- a/src/lights/PointLightShadow.js
+++ b/src/lights/PointLightShadow.js
@@ -66,15 +66,6 @@ class PointLightShadow extends LightShadow {
 		const camera = this.camera;
 		const shadowMatrix = this.matrix;
 
-		const far = light.distance || camera.far;
-
-		if ( far !== camera.far ) {
-
-			camera.far = far;
-			camera.updateProjectionMatrix();
-
-		}
-
 		_lightPositionWorld.setFromMatrixPosition( light.matrixWorld );
 		camera.position.copy( _lightPositionWorld );
 

--- a/src/lights/SpotLightShadow.js
+++ b/src/lights/SpotLightShadow.js
@@ -20,13 +20,11 @@ class SpotLightShadow extends LightShadow {
 
 		const fov = MathUtils.RAD2DEG * 2 * light.angle * this.focus;
 		const aspect = this.mapSize.width / this.mapSize.height;
-		const far = light.distance || camera.far;
 
-		if ( fov !== camera.fov || aspect !== camera.aspect || far !== camera.far ) {
+		if ( fov !== camera.fov || aspect !== camera.aspect ) {
 
 			camera.fov = fov;
 			camera.aspect = aspect;
-			camera.far = far;
 			camera.updateProjectionMatrix();
 
 		}


### PR DESCRIPTION
Fixes #27290.
Closes #27345.

**Description**

The `distance` property is currently coupled to the `far` value of shadow cameras in context of spot and point lights. That's because the engine provides an automatism that configures a proper `far` values based on the light's distance. However, the current implementation is inconsistent and produces a buggy behavior like reported in #27290 or #27523.

Since there is no clean way to fix this I suggest to completely remove the coupling. That means `distance` does not affect shadows anymore.

Devs who rely on a physically correct workflow won't notice this change since they do not change the default distance value `0`. Devs with a custom distance value might have to update their `light.shadow.camera.far` to an appropriate value after this change. So this change needs to be noted in the migration guide.

With this PR devs always have to configure the shadow camera's frustum like with directional lights or when `distance` is zero which should produce a more predictable engine behavior.
