### PR TITLE
Vector3: correct the randomDirection() method

### DIFF
--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -694,15 +694,15 @@ class Vector3 {
 
 	randomDirection() {
 
-		// Derived from https://mathworld.wolfram.com/SpherePointPicking.html
+		// https://mathworld.wolfram.com/SpherePointPicking.html
 
-		const u = ( Math.random() - 0.5 ) * 2;
-		const t = Math.random() * Math.PI * 2;
-		const f = Math.sqrt( 1 - u ** 2 );
+		const theta = Math.random() * Math.PI * 2;
+		const u = Math.random() * 2 - 1;
+		const c = Math.sqrt( 1 - u * u );
 
-		this.x = f * Math.cos( t );
-		this.y = f * Math.sin( t );
-		this.z = u;
+		this.x = c * Math.cos( theta );
+		this.y = u;
+		this.z = c * Math.sin( theta );
 
 		return this;
 


### PR DESCRIPTION
Follow-on to #22494

three.js uses a 'y-up' convention. The current implementation was copied from a source using a 'z-up' convention. This PR fixes that oversight.

Note: the prior code did generate uniform samples, in spite of the oversight.


