### PR TITLE
Instanced mesh docs update frustum culled

### DIFF
--- a/docs/api/en/objects/InstancedMesh.html
+++ b/docs/api/en/objects/InstancedMesh.html
@@ -45,7 +45,10 @@
 		<h3>[property:Box3 boundingBox]</h3>
 		<p>
 			This bounding box encloses all instances of the [name]. Can be calculated
-			with [page:.computeBoundingBox](). Default is `null`.
+			with [page:.computeBoundingBox](). Default is `null`. By default, this
+			bounding box is used for the purposes of frustum culling. You have to
+			manually update the bounding box if you transform any instances outside of
+			the current bounds.
 		</p>
 
 		<h3>[property:Sphere boundingSphere]</h3>
@@ -179,7 +182,10 @@
 		<p>
 			Sets the given local transformation matrix to the defined instance. Make
 			sure you set [page:.instanceMatrix][page:BufferAttribute.needsUpdate .needsUpdate] 
-			to true after updating all the matrices.
+			to true after updating all the matrices. Additionally, if the instance's new
+			transform is outside the current [page:.boundingBox] while
+			[page:Object3D.frustumCulled .frustumCulled] is enabled (the default), you have to
+			manually call [page:.computeBoundingBox]() to update it.
 		</p>
 
 		<h3>

--- a/docs/api/en/objects/InstancedMesh.html
+++ b/docs/api/en/objects/InstancedMesh.html
@@ -44,17 +44,16 @@
 
 		<h3>[property:Box3 boundingBox]</h3>
 		<p>
-			This bounding box encloses all instances of the [name]. Can be calculated
-			with [page:.computeBoundingBox](). By default, this bounding box is used for
-			the purposes of frustum culling. You have to manually update the bounding box
-			if you transform any instances outside of the current bounds. Default is
-			`null`.
+			This bounding box encloses all instances of the [name]. If you transform any
+			instances, you are responsible for updating the bounding box as needed. Can be
+			calculated with [page:.computeBoundingBox](). Default is `null`.
 		</p>
 
 		<h3>[property:Sphere boundingSphere]</h3>
 		<p>
-			This bounding sphere encloses all instances of the [name]. Can be
-			calculated with [page:.computeBoundingSphere](). Default is `null`.
+			This bounding sphere encloses all instances of the [name]. If you transform any
+			instances, you are responsible for updating the bounding sphere as needed. Can
+			be calculated with [page:.computeBoundingSphere](). Default is `null`.
 		</p>
 
 		<h3>[property:Integer count]</h3>
@@ -182,10 +181,10 @@
 		<p>
 			Sets the given local transformation matrix to the defined instance. Make
 			sure you set [page:.instanceMatrix][page:BufferAttribute.needsUpdate .needsUpdate] 
-			to true after updating all the matrices. Additionally, if the instance's new
-			transform is outside the current [page:.boundingBox] while
-			[page:Object3D.frustumCulled .frustumCulled] is enabled (the default), you have to
-			manually call [page:.computeBoundingBox]() to update it.
+			to true after updating all the matrices. The bounding volumes should be updated
+			whenever instances are transformed. Depending on how you transform instances, the
+			bounds can be larger or smaller than before and the bounding volumes should
+			reflect that.
 		</p>
 
 		<h3>

--- a/docs/api/en/objects/InstancedMesh.html
+++ b/docs/api/en/objects/InstancedMesh.html
@@ -45,10 +45,10 @@
 		<h3>[property:Box3 boundingBox]</h3>
 		<p>
 			This bounding box encloses all instances of the [name]. Can be calculated
-			with [page:.computeBoundingBox](). Default is `null`. By default, this
-			bounding box is used for the purposes of frustum culling. You have to
-			manually update the bounding box if you transform any instances outside of
-			the current bounds.
+			with [page:.computeBoundingBox](). By default, this bounding box is used for
+			the purposes of frustum culling. You have to manually update the bounding box
+			if you transform any instances outside of the current bounds. Default is
+			`null`.
 		</p>
 
 		<h3>[property:Sphere boundingSphere]</h3>


### PR DESCRIPTION
Related issue: #27733

**Description**

The current docs for InstancedMesh can be clearer about the bounding box being used for automatic camera frustum culling, and how the developer is responsible for updating it after any transformations that may move instances outside the bounding box. These changes hopefully add more clarity.
