### PR TITLE
OrbitControls: handle duplicated pointerId

### DIFF
--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -1013,6 +1013,10 @@ class OrbitControls extends EventDispatcher {
 
 			//
 
+			if ( isTrackingPointer( event ) ) return;
+
+			//
+
 			addPointer( event );
 
 			if ( event.pointerType === 'touch' ) {
@@ -1457,6 +1461,18 @@ class OrbitControls extends EventDispatcher {
 				}
 
 			}
+
+		}
+
+		function isTrackingPointer( event ) {
+
+			for ( let i = 0; i < pointers.length; i ++ ) {
+
+				if ( pointers[ i ] == event.pointerId ) return true;
+
+			}
+
+			return false;
 
 		}
 


### PR DESCRIPTION
Fixes #27746

Reported issue occurs when clicking both left/right mouse buttons and dragging mouse outside DOM area. This underlying issue is that both actions use the same `pointerId`, which in turn, duplicates their reference internally leading to incorrect handling of later actions.

Issue is resolved by only keeping track of new clicks, if their `pointerId` is unique and currently not tracked.

[PR Example](https://rawcdn.githack.com/sciecode/three.js/4169c506b7c7b46b32df084c66bb8b524943f943/examples/misc_controls_orbit.html)

The problem reported in #24566, still occurs. However, it does appear like it is a browser-side issue. As it stems from events not firing under specific situations and not something we can easily manage internally, without simply removing any currently tracked events when pointer goes outside DOM.

