### PR TITLE
EditorControls: Add duplicate pointer ID fix.

### DIFF
--- a/editor/js/EditorControls.js
+++ b/editor/js/EditorControls.js
@@ -136,6 +136,10 @@ class EditorControls extends THREE.EventDispatcher {
 
 			//
 
+			if ( isTrackingPointer( event ) ) return;
+
+			//
+
 			addPointer( event );
 
 			if ( event.pointerType === 'touch' ) {
@@ -389,6 +393,18 @@ class EditorControls extends THREE.EventDispatcher {
 				}
 
 			}
+
+		}
+
+		function isTrackingPointer( event ) {
+
+			for ( var i = 0; i < pointers.length; i ++ ) {
+
+				if ( pointers[ i ] == event.pointerId ) return true;
+
+			}
+
+			return false;
 
 		}
 


### PR DESCRIPTION
Related issue: #27748

**Description**

Applying the same pointer ID fix from `OrbitControls` to `EditorControls`.

@sciecode Given how similar controls handle multi pointer events, I wonder if we could centralize some logic into an upper class `Controls` (or `PointerControls`) and then extend from it 🤔 .