### PR TITLE
WebGPURenderer: Fix updateAttribute in WebGL Backend.

### DIFF
--- a/examples/jsm/renderers/webgl/utils/WebGLAttributeUtils.js
+++ b/examples/jsm/renderers/webgl/utils/WebGLAttributeUtils.js
@@ -8,6 +8,7 @@ class DualAttributeData {
 
 		this.buffers = [ attributeData.bufferGPU, dualBuffer ];
 		this.type = attributeData.type;
+		this.bufferType = attributeData.bufferType;
 		this.pbo = attributeData.pbo;
 		this.byteLength = attributeData.byteLength;
 		this.bytesPerElement = attributeData.BYTES_PER_ELEMENT;
@@ -128,6 +129,7 @@ class WebGLAttributeUtils {
 
 		let attributeData = {
 			bufferGPU,
+			bufferType,
 			type,
 			byteLength: array.byteLength,
 			bytesPerElement: array.BYTES_PER_ELEMENT,


### PR DESCRIPTION
`updateAttribute` was broken in the `WebGLBackend` because `bufferType` was `undefined` since it was not forwarded to `attributeData`.

_This contribution is funded by [Utsubo](https://utsubo.com/)_