### PR TITLE
Object3D: Reuse the child added and child removed events

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -25,6 +25,9 @@ const _zAxis = /*@__PURE__*/ new Vector3( 0, 0, 1 );
 const _addedEvent = { type: 'added' };
 const _removedEvent = { type: 'removed' };
 
+const _childaddedEvent = { type: 'childadded', child: null };
+const _childremovedEvent = { type: 'childremoved', child: null };
+
 class Object3D extends EventDispatcher {
 
 	constructor() {
@@ -340,7 +343,10 @@ class Object3D extends EventDispatcher {
 			this.children.push( object );
 
 			object.dispatchEvent( _addedEvent );
-			this.dispatchEvent( { type: 'childadded', child: object } );
+
+			_childaddedEvent.child = object;
+			this.dispatchEvent( _childaddedEvent );
+			_childaddedEvent.child = null;
 
 		} else {
 
@@ -374,7 +380,10 @@ class Object3D extends EventDispatcher {
 			this.children.splice( index, 1 );
 
 			object.dispatchEvent( _removedEvent );
-			this.dispatchEvent( { type: 'childremoved', child: object } );
+
+			_childremovedEvent.child = object;
+			this.dispatchEvent( _childremovedEvent );
+			_childremovedEvent.child = null;
 
 		}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/16934#discussion_r1492334260

**Description**

Re use the child added and child removed event objects.