### PR TITLE
Fix 'car' WebGL example not working in playground

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -91,7 +91,7 @@
 
 				//
 
-				camera = new THREE.PerspectiveCamera( 40, window.innerWidth / window.innerHeight, 0.5, 60 );
+				camera = new THREE.PerspectiveCamera( 40, window.innerWidth / window.innerHeight, 0.5, 200 );
 				camera.position.set( 0.0, 3, 4 * 3 );
 
 				scene = new THREE.Scene();

--- a/playground/index.html
+++ b/playground/index.html
@@ -117,7 +117,6 @@
 				} else {
 
 					renderer = new THREE.WebGLRenderer( { antialias: true } );
-					renderer.useLegacyLights = false;
 
 					composer = new EffectComposer( renderer );
 					composer.addPass( new RenderPass( scene, camera ) );


### PR DESCRIPTION
**Description**

Fixes a regression in the three.js playground 'car' example. https://github.com/mrdoob/three.js/pull/27448 renamed `GroundProjectedSkybox` to `GroundedSkybox`, but this change was never applied to the playground example.
