### PR TITLE
Playground: Add more hotkeys to the playground

### DIFF
--- a/playground/NodeEditor.js
+++ b/playground/NodeEditor.js
@@ -411,8 +411,15 @@ export class NodeEditor extends THREE.EventDispatcher {
 
 					this.preview = ! this.preview;
 
-				}
+				} else if ( key === 'Delete' ) {
 
+					if ( this.canvas.selected ) this.canvas.selected.dispose();
+					
+				} else if ( key === 'Escape' ) {
+
+					this.canvas.select( null );
+
+				}
 			}
 
 		} );


### PR DESCRIPTION
**Description**
As demanded in #27759, now as a separate PR. This single commit adds two more hotkeys to the playground:
- 'Escape' for deselection of nodes
- 'Delete' for deletion of a selected node