### PR TITLE
PMREMGenerator: Clarify image size limitations

### DIFF
--- a/src/extras/PMREMGenerator.js
+++ b/src/extras/PMREMGenerator.js
@@ -132,6 +132,7 @@ class PMREMGenerator {
 	 * Generates a PMREM from an equirectangular texture, which can be either LDR
 	 * or HDR. The ideal input image size is 1k (1024 x 512),
 	 * as this matches best with the 256 x 256 cubemap output.
+	 * The smallest supported equirectangular image size is 64 x 32.
 	 */
 	fromEquirectangular( equirectangular, renderTarget = null ) {
 
@@ -143,6 +144,7 @@ class PMREMGenerator {
 	 * Generates a PMREM from an cubemap texture, which can be either LDR
 	 * or HDR. The ideal input cube size is 256 x 256,
 	 * as this matches best with the 256 x 256 cubemap output.
+	 * The smallest supported cube size is 16 x 16.
 	 */
 	fromCubemap( cubemap, renderTarget = null ) {
 


### PR DESCRIPTION
As suggested in https://github.com/mrdoob/three.js/issues/27716#issuecomment-1948068813.