### PR TITLE
Material: Fix `emissiveIntensity` not persisting.

### DIFF
--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -190,7 +190,7 @@ class Material extends EventDispatcher {
 		if ( this.sheenColor && this.sheenColor.isColor ) data.sheenColor = this.sheenColor.getHex();
 		if ( this.sheenRoughness !== undefined ) data.sheenRoughness = this.sheenRoughness;
 		if ( this.emissive && this.emissive.isColor ) data.emissive = this.emissive.getHex();
-		if ( this.emissiveIntensity && this.emissiveIntensity !== 1 ) data.emissiveIntensity = this.emissiveIntensity;
+		if ( this.emissiveIntensity !== undefined && this.emissiveIntensity !== 1 ) data.emissiveIntensity = this.emissiveIntensity;
 
 		if ( this.specular && this.specular.isColor ) data.specular = this.specular.getHex();
 		if ( this.specularIntensity !== undefined ) data.specularIntensity = this.specularIntensity;


### PR DESCRIPTION

Related issue: N/A

**Description**

If a Material with an `emissiveIntensity` of 0 is serialized, the previous truthy check does not persist this field.  It will get reset to the default of 1 when loaded by the `ObjectLoader`.
Solution: Be explicit and add `!== undefined` (same as specularIntensity).