### PR TITLE
Editor: `signals.transformModeChanged` call `render` function.

### DIFF
--- a/editor/js/Viewport.js
+++ b/editor/js/Viewport.js
@@ -299,6 +299,8 @@ function Viewport( editor ) {
 
 		transformControls.setMode( mode );
 
+		render();
+
 	} );
 
 	signals.snapChanged.add( function ( dist ) {


### PR DESCRIPTION
Related issue: #XXXX

**Description**

I think `signals.transformModeChanged` has been changed, Editor can be render immediately, the user experience should be better.

If this PR has any problem, please tell me.