### PR TITLE
OrbitControls: Ensure `interceptControlDown()` listener is removed in `dispose()`.

### DIFF
--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -426,8 +426,7 @@ class OrbitControls extends EventDispatcher {
 
 			const document = scope.domElement.getRootNode(); // offscreen canvas compatibility
 
-		  document.removeEventListener( 'keydown', interceptControlDown, { capture: true } );
-
+			document.removeEventListener( 'keydown', interceptControlDown, { capture: true } );
 
 			if ( scope._domElementKeyEvents !== null ) {
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -424,6 +424,10 @@ class OrbitControls extends EventDispatcher {
 			scope.domElement.removeEventListener( 'pointermove', onPointerMove );
 			scope.domElement.removeEventListener( 'pointerup', onPointerUp );
 
+			const document = scope.domElement.getRootNode(); // offscreen canvas compatibility
+
+		  document.removeEventListener( 'keydown', interceptControlDown, { capture: true } );
+
 
 			if ( scope._domElementKeyEvents !== null ) {
 


### PR DESCRIPTION
**Description**

#27446 never seems to remove the `interceptControlDown()` from the `keydown` event of the `document`. I found that this caused the memory leak during my memory leak troubleshooting, so I added `removeEventListener` to `dispose()`.

<img width="1158" alt="image" src="https://github.com/mrdoob/three.js/assets/30215105/e030919a-00d1-4f4c-a195-e850bad3e70a">

Please feel free to correct me if my understanding is wrong, thanks.