### PR TITLE
Editor: Update realistic viewport packages

### DIFF
--- a/editor/index.html
+++ b/editor/index.html
@@ -52,8 +52,8 @@
 					"three/addons/": "../examples/jsm/",
 
 					"three/examples/": "../examples/",
-					"three-gpu-pathtracer": "https://unpkg.com/three-gpu-pathtracer@0.0.18/build/index.module.js",
-					"three-mesh-bvh": "https://unpkg.com/three-mesh-bvh@0.7.2/build/index.module.js"
+					"three-gpu-pathtracer": "https://unpkg.com/three-gpu-pathtracer@0.0.19/build/index.module.js",
+					"three-mesh-bvh": "https://unpkg.com/three-mesh-bvh@0.7.3/build/index.module.js"
 				}
 			}
 		</script>

--- a/editor/index.html
+++ b/editor/index.html
@@ -52,8 +52,8 @@
 					"three/addons/": "../examples/jsm/",
 
 					"three/examples/": "../examples/",
-					"three-gpu-pathtracer": "https://unpkg.com/three-gpu-pathtracer@0.0.17/build/index.module.js",
-					"three-mesh-bvh": "https://unpkg.com/three-mesh-bvh@0.7.0/build/index.module.js"
+					"three-gpu-pathtracer": "https://unpkg.com/three-gpu-pathtracer@0.0.18/build/index.module.js",
+					"three-mesh-bvh": "https://unpkg.com/three-mesh-bvh@0.7.2/build/index.module.js"
 				}
 			}
 		</script>

--- a/editor/js/Viewport.Pathtracer.js
+++ b/editor/js/Viewport.Pathtracer.js
@@ -3,14 +3,20 @@ import { FullScreenQuad } from 'three/examples/jsm/postprocessing/Pass.js';
 import {
 	PathTracingSceneGenerator,
 	PathTracingRenderer,
-	PhysicalPathTracingMaterial
+	PhysicalPathTracingMaterial,
+	ProceduralEquirectTexture,
 } from 'three-gpu-pathtracer';
 
 function buildColorTexture( color ) {
 
-	const data = new Uint8Array( [ color.r * 255, color.g * 255, color.b * 255, 255 ] );
-	const texture = new THREE.DataTexture( data, 1, 1, THREE.RGBAFormat );
-	texture.needsUpdate = true;
+	const texture = new ProceduralEquirectTexture( 4, 4 );
+	texture.generationCallback = ( polar, uv, coord, target ) => {
+
+		target.copy( color );
+
+	};
+
+	texture.update();
 
 	return texture;
 

--- a/editor/js/Viewport.Pathtracer.js
+++ b/editor/js/Viewport.Pathtracer.js
@@ -137,9 +137,13 @@ function ViewportPathtracer( renderer ) {
 
 		pathtracer.update();
 
-		renderer.autoClear = false;
-		quad.render( renderer );
-		renderer.autoClear = true;
+		if ( pathtracer.samples >= 1 ) {
+
+			renderer.autoClear = false;
+			quad.render( renderer );
+			renderer.autoClear = true;
+
+		}
 
 	}
 

--- a/editor/js/Viewport.Pathtracer.js
+++ b/editor/js/Viewport.Pathtracer.js
@@ -76,6 +76,7 @@ function ViewportPathtracer( renderer ) {
 		ptMaterial.textures.setTextures( renderer, 2048, 2048, textures );
 		ptMaterial.materials.updateFrom( materials, textures );
 		ptMaterial.lights.updateFrom( lights );
+		ptMaterial.filterGlossyFactor = 0.5;
 
 		//
 
@@ -95,7 +96,7 @@ function ViewportPathtracer( renderer ) {
 
 		} else {
 
-			ptMaterial.backgroundMap = buildColorTexture( new THREE.Color( 0x000000 ) );
+			ptMaterial.backgroundMap = buildColorTexture( new THREE.Color( 0 ) );
 
 		}
 
@@ -103,7 +104,7 @@ function ViewportPathtracer( renderer ) {
 
 		const environment = scene.environment;
 
-		if ( environment && environment.isTexture === true ) {
+		if ( environment && environment.isDataTexture === true ) {
 
 			// Avoid calling envMapInfo() with the same hdr
 
@@ -116,7 +117,7 @@ function ViewportPathtracer( renderer ) {
 
 		} else {
 
-			ptMaterial.envMapInfo.updateFrom( buildColorTexture( new THREE.Color( 0xffffff ) ) );
+			ptMaterial.envMapInfo.updateFrom( buildColorTexture( new THREE.Color( 0 ) ) );
 
 		}
 

--- a/editor/js/Viewport.Pathtracer.js
+++ b/editor/js/Viewport.Pathtracer.js
@@ -52,14 +52,6 @@ function ViewportPathtracer( renderer ) {
 		pathtracer.material.backgroundBlur = scene.backgroundBlurriness;
 		pathtracer.reset();
 
-		// TOFIX: If the scene is empty the generator crashes so we render a tiny cube (:
-
-		if ( scene.children.length === 0 ) {
-
-			scene = new THREE.Mesh( new THREE.BoxGeometry( 0.0001, 0.0001, 0.0001 ) );
-
-		}
-
 		const { bvh, textures, materials, lights } = generator.generate( scene );
 
 		const ptGeometry = bvh.geometry;


### PR DESCRIPTION
Related issue: -

**Description**

- Bump three-mesh-bvh to v0.7.3
  - Fixes for inverted geometry
  - Fixes for handling scenes with no geometry
- Bump three-gpu-pathtracer to v0.0.19
  - More resiliently handle non-float data textures for environment map
  - Handle black environment maps
  - Better sampling patterns
  - more
- Editor changes
  - Use a black environment map if one isn't provided like the main view
  - Don't render the path traced view until 1 sample is complete
  - Remove dummy data if no geometry is present
  - Use a 4x4 texture for the env map since there seems to be a small issue in the sampling logic with a 1x1

Spot lights working:

<img width="898" alt="image" src="https://github.com/mrdoob/three.js/assets/734200/b6eb820a-1713-4a48-9ebc-d3cd01af515e">

cc @mrdoob it looks like `init` gets called every time the scene is modified. Is this correct? If so that means a lot of textures and materials are getting recreated with out ever being disposed.