### PR TITLE
Examples: Enhance env maps demo.

### DIFF
--- a/examples/webgl_materials_envmaps.html
+++ b/examples/webgl_materials_envmaps.html
@@ -31,7 +31,7 @@
 
 			let controls, camera, scene, renderer;
 			let textureEquirec, textureCube;
-			let sphereMesh, sphereMaterial;
+			let sphereMesh, sphereMaterial, params;
 
 			init();
 			animate();
@@ -84,7 +84,7 @@
 
 				//
 
-				const params = {
+				params = {
 					Cube: function () {
 
 						scene.background = textureCube;
@@ -101,10 +101,14 @@
 						sphereMaterial.needsUpdate = true;
 
 					},
-					Refraction: false
+					Refraction: false,
+					backgroundRotationX: false,
+					backgroundRotationY: false,
+					backgroundRotationZ: false,
+					syncMaterial: false
 				};
 
-				const gui = new GUI();
+				const gui = new GUI( { width: 300 } );
 				gui.add( params, 'Cube' );
 				gui.add( params, 'Equirectangular' );
 				gui.add( params, 'Refraction' ).onChange( function ( value ) {
@@ -124,6 +128,10 @@
 					sphereMaterial.needsUpdate = true;
 
 				} );
+				gui.add( params, 'backgroundRotationX' );
+				gui.add( params, 'backgroundRotationY' );
+				gui.add( params, 'backgroundRotationZ' );
+				gui.add( params, 'syncMaterial' );
 				gui.open();
 
 				window.addEventListener( 'resize', onWindowResize );
@@ -150,6 +158,30 @@
 			}
 
 			function render() {
+
+				if ( params.backgroundRotationX ) {
+
+					scene.backgroundRotation.x += 0.001;
+
+				}
+
+				if ( params.backgroundRotationY ) {
+
+					scene.backgroundRotation.y += 0.001;
+
+				}
+
+				if ( params.backgroundRotationZ ) {
+
+					scene.backgroundRotation.z += 0.001;
+
+				}
+
+				if ( params.syncMaterial ) {
+
+					sphereMesh.material.envMapRotation.copy( scene.backgroundRotation );
+
+				}
 
 				camera.lookAt( scene.position );
 				renderer.render( scene, camera );


### PR DESCRIPTION
Related issue: #27758

**Description**

This PR enhances the `webgl_materials_envmaps` demo to demonstrate the new background and env map rotation. We can test now the rotation for `CubeTexture` and cube render targets.

When enabling one of the new rotation checkboxes, it's important that the direction of the rotation does not change when switching between "cube" and "equirectangular".