### PR TITLE
WebGLRenderer: Simplify env map rotation.

### DIFF
--- a/src/renderers/webgl/WebGLBackground.js
+++ b/src/renderers/webgl/WebGLBackground.js
@@ -111,10 +111,7 @@ function WebGLBackground( renderer, cubemaps, cubeuvmaps, state, objects, alpha,
 
 			_e1.copy( scene.backgroundRotation );
 
-			// accommodate left-handed frame
-			_e1.x *= - 1; _e1.y *= - 1; _e1.z *= - 1;
-
-			if ( background.isCubeTexture && background.isRenderTargetTexture === false ) {
+			if ( ( background.isCubeTexture && background.isRenderTargetTexture === true ) || background.mapping === CubeUVReflectionMapping ) {
 
 				// environment maps which are not cube render targets or PMREMs follow a different convention
 				_e1.y *= - 1;

--- a/src/renderers/webgl/WebGLMaterials.js
+++ b/src/renderers/webgl/WebGLMaterials.js
@@ -1,4 +1,4 @@
-import { BackSide } from '../../constants.js';
+import { BackSide, CubeUVReflectionMapping } from '../../constants.js';
 import { getUnlitUniformColorSpace } from '../shaders/UniformsUtils.js';
 import { Euler } from '../../math/Euler.js';
 import { Matrix4 } from '../../math/Matrix4.js';
@@ -225,10 +225,7 @@ function WebGLMaterials( renderer, properties ) {
 
 			_e1.copy( envMapRotation );
 
-			// accommodate left-handed frame
-			_e1.x *= - 1; _e1.y *= - 1; _e1.z *= - 1;
-
-			if ( envMap.isCubeTexture && envMap.isRenderTargetTexture === false ) {
+			if ( ( envMap.isCubeTexture && envMap.isRenderTargetTexture === true ) || envMap.mapping === CubeUVReflectionMapping ) {
 
 				// environment maps which are not cube render targets or PMREMs follow a different convention
 				_e1.y *= - 1;


### PR DESCRIPTION
Related issue: -

**Description**

This restores my original computation of the env map rotation for testing. It should be functionally equal to #27785 but require less computations. The change can be tested with the updated `webgl_materials_envmaps` demo (see #27787).