### PR TITLE
TSL: Support for split assignment

### DIFF
--- a/examples/jsm/nodes/core/AssignNode.js
+++ b/examples/jsm/nodes/core/AssignNode.js
@@ -1,6 +1,7 @@
 import { addNodeClass } from '../core/Node.js';
 import TempNode from '../core/TempNode.js';
 import { addNodeElement, nodeProxy } from '../shadernode/ShaderNode.js';
+import { vectorComponents } from '../core/constants.js';
 
 class AssignNode extends TempNode {
 
@@ -25,38 +26,81 @@ class AssignNode extends TempNode {
 
 	}
 
+	needsSplitAssign( builder ) {
+
+		const { targetNode } = this;
+
+		if ( builder.isAvailable( 'swizzleAssign' ) === false && targetNode.isSplitNode && targetNode.components.length > 1 ) {
+
+			const targetLength = builder.getTypeLength( targetNode.getNodeType( builder ) );
+			const assignDiferentVector = vectorComponents.join( '' ).slice( 0, targetLength ) !== targetNode.components;
+
+			return assignDiferentVector;
+
+		}
+
+		return false;
+
+	}
+
 	generate( builder, output ) {
 
 		const { targetNode, sourceNode } = this;
+
+		const needsSplitAssign = this.needsSplitAssign( builder );
+
+		if ( needsSplitAssign ) sourceNode.increaseUsage( builder ); // flag to cache system
 
 		const targetType = targetNode.getNodeType( builder );
 
 		const target = targetNode.context( { assign: true } ).build( builder );
 		const source = sourceNode.build( builder, targetType );
 
-		const snippet = `${ target } = ${ source }`;
+		const sourceType = sourceNode.getNodeType( builder );
 
-		if ( output === 'void' ) {
+		//
 
-			builder.addLineFlowCode( snippet );
+		let snippet;
 
-			return;
+		if ( needsSplitAssign ) {
 
-		} else {
+			const targetRoot = targetNode.node.context( { assign: true } ).build( builder );
 
-			const sourceType = sourceNode.getNodeType( builder );
+			for ( let i = 0; i < targetNode.components.length; i ++ ) {
 
-			if ( sourceType === 'void' ) {
+				const component = targetNode.components[ i ];
+
+				snippet = `${ targetRoot }.${ component } = ${ source }[ ${ i } ]`;
 
 				builder.addLineFlowCode( snippet );
 
-				return target;
+			}
+
+			if ( output !== 'void' ) {
+
+				snippet = target;
 
 			}
 
-			return builder.format( snippet, targetType, output );
+		} else {
+
+			snippet = `${ target } = ${ source }`;
+
+			if ( output === 'void' || sourceType === 'void' ) {
+
+				builder.addLineFlowCode( snippet );
+
+				if ( output !== 'void' ) {
+
+					snippet = target;
+
+				}
+
+			}
 
 		}
+
+		return builder.format( snippet, targetType, output );
 
 	}
 

--- a/examples/jsm/renderers/webgl/nodes/GLSLNodeBuilder.js
+++ b/examples/jsm/renderers/webgl/nodes/GLSLNodeBuilder.js
@@ -19,7 +19,8 @@ const precisionLib = {
 };
 
 const supports = {
-	instance: true
+	instance: true,
+	swizzleAssign: true
 };
 
 const defaultPrecisions = `
@@ -539,7 +540,6 @@ ${ flowData.code }
 		return supports[ name ] === true;
 
 	}
-
 
 	isFlipY() {
 

--- a/examples/webgpu_compute_particles_rain.html
+++ b/examples/webgpu_compute_particles_rain.html
@@ -167,9 +167,8 @@
 
 						position.y = 25;
 
-						ripplePosition.x = position.x;
+						ripplePosition.xz = position.xz;
 						ripplePosition.y = floorPosition;
-						ripplePosition.z = position.z;
 
 						// reset hit time: x = time
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/26982

**Description**

Adding support for split assignment in TSL, GLSL allows defining multiple components of a vector like `v.xy = a.xy` while WGSL does not offer this support. The PR adds this compatibility to WGSL by splitting the assign into multiple lines of `v.x = a.x; v.y = a.y;`. This improves support for codes transpiled from GLSL to TSL.
