### PR TITLE
fix: WebGLAttributes Add Float64Array

### DIFF
--- a/src/renderers/webgl/WebGLAttributes.js
+++ b/src/renderers/webgl/WebGLAttributes.js
@@ -23,7 +23,11 @@ function WebGLAttributes( gl, capabilities ) {
 
 			type = gl.FLOAT;
 
-		} else if ( array instanceof Uint16Array ) {
+		} else if ( array instanceof Float64Array ) {
+
+			type = gl.FLOAT;
+
+		}  else if ( array instanceof Uint16Array ) {
 
 			if ( attribute.isFloat16BufferAttribute ) {
 


### PR DESCRIPTION
WebGLAttributes Add Float64Array

I saw in BufferAttribute Types that Float64Array is supported, but there is a lack of judgment in WebGLAttributes.