### PR TITLE
fix: WebGLAttributes Add Float64Array

### DIFF
--- a/src/renderers/webgl/WebGLAttributes.js
+++ b/src/renderers/webgl/WebGLAttributes.js
@@ -23,7 +23,11 @@ function WebGLAttributes( gl, capabilities ) {
 
 			type = gl.FLOAT;
 
-		} else if ( array instanceof Uint16Array ) {
+		} else if ( array instanceof Float64Array ) {
+
+			type = gl.FLOAT;
+
+		}  else if ( array instanceof Uint16Array ) {
 
 			if ( attribute.isFloat16BufferAttribute ) {
 

--- a/src/renderers/webgl/WebGLAttributes.js
+++ b/src/renderers/webgl/WebGLAttributes.js
@@ -19,15 +19,11 @@ function WebGLAttributes( gl, capabilities ) {
 
 		let type;
 
-		if ( array instanceof Float32Array ) {
+		if ( array instanceof Float32Array && array instanceof Float64Array ) {
 
 			type = gl.FLOAT;
 
-		} else if ( array instanceof Float64Array ) {
-
-			type = gl.FLOAT;
-
-		}  else if ( array instanceof Uint16Array ) {
+		} else if ( array instanceof Uint16Array ) {
 
 			if ( attribute.isFloat16BufferAttribute ) {
 


### PR DESCRIPTION
I saw in BufferAttribute Types that Float64Array is supported, but there is a lack of judgment in WebGLAttributes.