### PR TITLE
fix: WebGLAttributes Add Float64Array

### DIFF
--- a/src/renderers/webgl/WebGLAttributes.js
+++ b/src/renderers/webgl/WebGLAttributes.js
@@ -19,7 +19,7 @@ function WebGLAttributes( gl, capabilities ) {
 
 		let type;
 
-		if ( array instanceof Float32Array ) {
+		if ( array instanceof Float32Array || array instanceof Float64Array ) {
 
 			type = gl.FLOAT;
 


### PR DESCRIPTION
I saw in BufferAttribute Types that Float64Array is supported, but there is a lack of judgment in WebGLAttributes.