### PR TITLE
Remove `Float64BufferAttribute`.

### DIFF
--- a/docs/api/ar/core/bufferAttributeTypes/BufferAttributeTypes.html
+++ b/docs/api/ar/core/bufferAttributeTypes/BufferAttributeTypes.html
@@ -17,7 +17,6 @@
 		</p>
 
 		<code>
-		THREE.Float64BufferAttribute 
 		THREE.Float32BufferAttribute
 		THREE.Float16BufferAttribute 
 		THREE.Uint32BufferAttribute

--- a/docs/api/en/core/bufferAttributeTypes/BufferAttributeTypes.html
+++ b/docs/api/en/core/bufferAttributeTypes/BufferAttributeTypes.html
@@ -18,7 +18,6 @@
 		</p>
 
 		<code>
-		THREE.Float64BufferAttribute 
 		THREE.Float32BufferAttribute
 		THREE.Float16BufferAttribute 
 		THREE.Uint32BufferAttribute

--- a/docs/api/it/core/bufferAttributeTypes/BufferAttributeTypes.html
+++ b/docs/api/it/core/bufferAttributeTypes/BufferAttributeTypes.html
@@ -17,7 +17,6 @@
 		</p>
 
 		<code>
-		THREE.Float64BufferAttribute
 		THREE.Float32BufferAttribute
 		THREE.Float16BufferAttribute
 		THREE.Uint32BufferAttribute

--- a/docs/api/ko/core/bufferAttributeTypes/BufferAttributeTypes.html
+++ b/docs/api/ko/core/bufferAttributeTypes/BufferAttributeTypes.html
@@ -17,7 +17,6 @@
 		</p>
 
 		<code>
-		THREE.Float64BufferAttribute
 		THREE.Float32BufferAttribute
 		THREE.Float16BufferAttribute
 		THREE.Uint32BufferAttribute

--- a/docs/api/zh/core/bufferAttributeTypes/BufferAttributeTypes.html
+++ b/docs/api/zh/core/bufferAttributeTypes/BufferAttributeTypes.html
@@ -17,7 +17,6 @@
 		</p>
 
 		<code>
-		THREE.Float64BufferAttribute
 		THREE.Float32BufferAttribute
 		THREE.Float16BufferAttribute
 		THREE.Uint32BufferAttribute

--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -623,20 +623,9 @@ class Float32BufferAttribute extends BufferAttribute {
 
 }
 
-class Float64BufferAttribute extends BufferAttribute {
-
-	constructor( array, itemSize, normalized ) {
-
-		super( new Float64Array( array ), itemSize, normalized );
-
-	}
-
-}
-
 //
 
 export {
-	Float64BufferAttribute,
 	Float32BufferAttribute,
 	Float16BufferAttribute,
 	Uint32BufferAttribute,

--- a/test/unit/src/core/BufferAttribute.tests.js
+++ b/test/unit/src/core/BufferAttribute.tests.js
@@ -11,8 +11,7 @@ import {
 	Int32BufferAttribute,
 	Uint32BufferAttribute,
 	Float16BufferAttribute,
-	Float32BufferAttribute,
-	Float64BufferAttribute
+	Float32BufferAttribute
 } from '../../../../src/core/BufferAttribute.js';
 
 import { DynamicDrawUsage } from '../../../../src/constants.js';
@@ -505,7 +504,7 @@ export default QUnit.module( 'Core', () => {
 		const toHalfFloatArray = ( f32Array ) => {
 
 			const f16Array = new Uint16Array( f32Array.length );
-			for ( let i = 0, n = f32Array.length; i < n; ++i ) {
+			for ( let i = 0, n = f32Array.length; i < n; ++ i ) {
 
 				f16Array[ i ] = toHalfFloat( f32Array[ i ] );
 
@@ -518,7 +517,7 @@ export default QUnit.module( 'Core', () => {
 		const fromHalfFloatArray = ( f16Array ) => {
 
 			const f32Array = new Float32Array( f16Array.length );
-			for ( let i = 0, n = f16Array.length; i < n; ++i ) {
+			for ( let i = 0, n = f16Array.length; i < n; ++ i ) {
 
 				f32Array[ i ] = fromHalfFloat( f16Array[ i ] );
 
@@ -599,29 +598,6 @@ export default QUnit.module( 'Core', () => {
 
 			const object = new Float32BufferAttribute();
 			assert.ok( object, 'Can instantiate a Float32BufferAttribute.' );
-
-		} );
-
-	} );
-
-	QUnit.module( 'Float64BufferAttribute', () => {
-
-		// INHERITANCE
-		QUnit.test( 'Extending', ( assert ) => {
-
-			const object = new Float64BufferAttribute();
-			assert.strictEqual(
-				object instanceof BufferAttribute, true,
-				'Float64BufferAttribute extends from BufferAttribute'
-			);
-
-		} );
-
-		// INSTANCING
-		QUnit.test( 'Instancing', ( assert ) => {
-
-			const object = new Float64BufferAttribute();
-			assert.ok( object, 'Can instantiate a Float64BufferAttribute.' );
 
 		} );
 


### PR DESCRIPTION
Related issue: #27805, #23006

**Description**

WebGL does not support processing double precision floating point buffer data. The renderer is also unable to process  `Float64BufferAttribute` so I think it's best to remove the class. Otherwise it just causes further confusion.
