### PR TITLE
WebXR: Add `setPath()` to `XRControllerModelFactory`.

### DIFF
--- a/examples/jsm/webxr/XRControllerModelFactory.js
+++ b/examples/jsm/webxr/XRControllerModelFactory.js
@@ -222,6 +222,14 @@ class XRControllerModelFactory {
 
 	}
 
+	setPath( path ) {
+
+		this.path = path;
+
+		return this;
+
+	}
+
 	createControllerModel( controller ) {
 
 		const controllerModel = new XRControllerModel();


### PR DESCRIPTION
To set a custom URL to load the VR controllers meshes. It works the same way as XRHandModelFactory().setPath()
