### PR TITLE
Docs: Improve `GridHelper` page.

### DIFF
--- a/docs/api/en/helpers/GridHelper.html
+++ b/docs/api/en/helpers/GridHelper.html
@@ -7,7 +7,7 @@
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>
 	<body>
-		[page:Object3D] &rarr; [page:Line] &rarr;
+		[page:Object3D] &rarr; [page:Line] &rarr; [page:LineSegments] &rarr;
 
 		<h1>[name]</h1>
 


### PR DESCRIPTION

**Description**

`LineSegments` was missing from `GirdHelper`'s hierarchy.

- [ ] apply to other langs too

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Lume](https://lume.io)*
