### PR TITLE
WebGPURenderer: `getTextureLevel` of `background` should multiply `maxMipLevel`

### DIFF
--- a/examples/jsm/renderers/common/Background.js
+++ b/examples/jsm/renderers/common/Background.js
@@ -1,8 +1,7 @@
 import DataMap from './DataMap.js';
 import Color4 from './Color4.js';
 import { Mesh, SphereGeometry, BackSide } from 'three';
-import { vec4, context, normalWorld, backgroundBlurriness, backgroundIntensity, NodeMaterial, modelViewProjection } from '../../nodes/Nodes.js';
-import { maxMipLevel } from '../../nodes/utils/MaxMipLevelNode.js';
+import { vec4, context, normalWorld, backgroundBlurriness, backgroundIntensity, NodeMaterial, modelViewProjection, maxMipLevel } from '../../nodes/Nodes.js';
 
 const _clearColor = new Color4();
 

--- a/examples/jsm/renderers/common/Background.js
+++ b/examples/jsm/renderers/common/Background.js
@@ -2,6 +2,7 @@ import DataMap from './DataMap.js';
 import Color4 from './Color4.js';
 import { Mesh, SphereGeometry, BackSide } from 'three';
 import { vec4, context, normalWorld, backgroundBlurriness, backgroundIntensity, NodeMaterial, modelViewProjection } from '../../nodes/Nodes.js';
+import { maxMipLevel } from '../../nodes/utils/MaxMipLevelNode.js';
 
 const _clearColor = new Color4();
 
@@ -53,7 +54,7 @@ class Background extends DataMap {
 				const backgroundMeshNode = context( vec4( backgroundNode ), {
 					// @TODO: Add Texture2D support using node context
 					getUV: () => normalWorld,
-					getTextureLevel: () => backgroundBlurriness
+					getTextureLevel: ( textureNode ) => backgroundBlurriness.mul( maxMipLevel( textureNode ) )
 				} ).mul( backgroundIntensity );
 
 				let viewProj = modelViewProjection();


### PR DESCRIPTION
| Before  | After |
| ------------- | ------------- |
|<video src="https://github.com/mrdoob/three.js/assets/20318608/22bb504f-dca4-40ab-aa8f-edeab59d6036">   | <video src="https://github.com/mrdoob/three.js/assets/20318608/2034ebbb-133a-428c-ac8b-60e016eb6ed5">  |

```js
const equirectTexture = new THREE.TextureLoader().load( 'textures/2294472375_24a3b8ef46_o.jpg' );
equirectTexture.flipY = false;
equirectTexture.mapping = THREE.EquirectangularReflectionMapping;
equirectTexture.colorSpace = THREE.SRGBColorSpace;

scene = new THREE.Scene();
scene.background = equirectTexture;


scene.backgroundBlurriness = .5;
```




