### PR TITLE
OrbitControls: fix zoom-changed detection

### DIFF
--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -261,6 +261,7 @@ class OrbitControls extends EventDispatcher {
 				scope.target.clampLength( scope.minTargetRadius, scope.maxTargetRadius );
 				scope.target.add( scope.cursor );
 
+				let zoomChanged = false;
 				// adjust the camera position based on zoom only if we're not zooming to the cursor or if it's an ortho camera
 				// we adjust zoom later in these cases
 				if ( scope.zoomToCursor && performCursorZoom || scope.object.isOrthographicCamera ) {
@@ -269,7 +270,9 @@ class OrbitControls extends EventDispatcher {
 
 				} else {
 
+					const prevRadius = spherical.radius;
 					spherical.radius = clampDistance( spherical.radius * scale );
+					zoomChanged = prevRadius != spherical.radius;
 
 				}
 
@@ -298,7 +301,6 @@ class OrbitControls extends EventDispatcher {
 				}
 
 				// adjust camera position
-				let zoomChanged = false;
 				if ( scope.zoomToCursor && performCursorZoom ) {
 
 					let newRadius = null;
@@ -313,15 +315,19 @@ class OrbitControls extends EventDispatcher {
 						scope.object.position.addScaledVector( dollyDirection, radiusDelta );
 						scope.object.updateMatrixWorld();
 
+						zoomChanged = !!radiusDelta;
+
 					} else if ( scope.object.isOrthographicCamera ) {
 
 						// adjust the ortho camera position based on zoom changes
 						const mouseBefore = new Vector3( mouse.x, mouse.y, 0 );
 						mouseBefore.unproject( scope.object );
 
+						const prevZoom = scope.object.zoom;
 						scope.object.zoom = Math.max( scope.minZoom, Math.min( scope.maxZoom, scope.object.zoom / scale ) );
 						scope.object.updateProjectionMatrix();
-						zoomChanged = true;
+
+						zoomChanged = prevZoom != scope.object.zoom;
 
 						const mouseAfter = new Vector3( mouse.x, mouse.y, 0 );
 						mouseAfter.unproject( scope.object );
@@ -374,12 +380,13 @@ class OrbitControls extends EventDispatcher {
 
 				} else if ( scope.object.isOrthographicCamera ) {
 
-					zoomChanged = scale !== 1;
+					const prevZoom = scope.object.zoom;
+					scope.object.zoom = Math.max( scope.minZoom, Math.min( scope.maxZoom, scope.object.zoom / scale ) );
 
-					if ( zoomChanged ) {
+					if ( prevZoom != scope.object.zoom ) {
 
-						scope.object.zoom = Math.max( scope.minZoom, Math.min( scope.maxZoom, scope.object.zoom / scale ) );
 						scope.object.updateProjectionMatrix();
+						zoomChanged = true;
 
 					}
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -315,7 +315,7 @@ class OrbitControls extends EventDispatcher {
 						scope.object.position.addScaledVector( dollyDirection, radiusDelta );
 						scope.object.updateMatrixWorld();
 
-						zoomChanged = !!radiusDelta;
+						zoomChanged = !! radiusDelta;
 
 					} else if ( scope.object.isOrthographicCamera ) {
 
@@ -327,7 +327,7 @@ class OrbitControls extends EventDispatcher {
 						scope.object.zoom = Math.max( scope.minZoom, Math.min( scope.maxZoom, scope.object.zoom / scale ) );
 						scope.object.updateProjectionMatrix();
 
-						zoomChanged = prevZoom != scope.object.zoom;
+						zoomChanged = prevZoom !== scope.object.zoom;
 
 						const mouseAfter = new Vector3( mouse.x, mouse.y, 0 );
 						mouseAfter.unproject( scope.object );
@@ -383,7 +383,7 @@ class OrbitControls extends EventDispatcher {
 					const prevZoom = scope.object.zoom;
 					scope.object.zoom = Math.max( scope.minZoom, Math.min( scope.maxZoom, scope.object.zoom / scale ) );
 
-					if ( prevZoom != scope.object.zoom ) {
+					if ( prevZoom !== scope.object.zoom ) {
 
 						scope.object.updateProjectionMatrix();
 						zoomChanged = true;


### PR DESCRIPTION
Fixes #27831

At some point our logic for detecting `zoomChanged` was modified and it is currently not functioning properly. Currently, the changes are being detected by the condition that validates camera movement and not actual zoom, however this is unreliable as seen in the linked issue. 

I made sure to properly detect changes for every variation of zoom logic (ortho/persp for zoomToCursor and regular zoom).

Also took the opportunity to only set this variable if zoom was actually modified, and not every time it is attempted. This way, if the zoom event is triggered but camera is already clamped to min/max distance, an event won't be triggered falsely.
