### PR TITLE
WebGPURenderer: Added sync render()/clear()

### DIFF
--- a/examples/jsm/renderers/common/Renderer.js
+++ b/examples/jsm/renderers/common/Renderer.js
@@ -312,6 +312,27 @@ class Renderer {
 
 		if ( this._initialized === false ) await this.init();
 
+		const renderContext = this._renderContext( scene, camera );
+
+		await this.backend.resolveTimestampAsync( renderContext, 'render' );
+
+	}
+
+	render( scene, camera ) {
+
+		if ( this._initialized === false ) {
+
+			console.error( 'THREE.Renderer: .render() called before the backend is initialized. Try using .renderAsync() instead.' );
+			return;
+
+		}
+
+		this._renderContext( scene, camera );
+
+	}
+
+	_renderContext( scene, camera ) {
+
 		// preserve render tree
 
 		const nodeFrame = this._nodes.nodeFrame;
@@ -486,8 +507,9 @@ class Renderer {
 
 		sceneRef.onAfterRender( this, scene, camera, renderTarget );
 
+		//
 
-		await this.backend.resolveTimestampAsync( renderContext, 'render' );
+		return renderContext;
 
 	}
 
@@ -737,9 +759,7 @@ class Renderer {
 
 	}
 
-	async clearAsync( color = true, depth = true, stencil = true ) {
-
-		if ( this._initialized === false ) await this.init();
+	clear( color = true, depth = true, stencil = true ) {
 
 		let renderTargetData = null;
 		const renderTarget = this._renderTarget;
@@ -753,6 +773,32 @@ class Renderer {
 		}
 
 		this.backend.clear( color, depth, stencil, renderTargetData );
+
+	}
+
+	clearColor() {
+
+		return this.clear( true, false, false );
+
+	}
+
+	clearDepth() {
+
+		return this.clear( false, true, false );
+
+	}
+
+	clearStencil() {
+
+		return this.clear( false, false, true );
+
+	}
+
+	async clearAsync( color = true, depth = true, stencil = true ) {
+
+		if ( this._initialized === false ) await this.init();
+
+		this.clear( color, depth, stencil );
 
 	}
 
@@ -1250,36 +1296,6 @@ class Renderer {
 	get compile() {
 
 		return this.compileAsync;
-
-	}
-
-	get render() {
-
-		return this.renderAsync;
-
-	}
-
-	get clear() {
-
-		return this.clearAsync;
-
-	}
-
-	get clearColor() {
-
-		return this.clearColorAsync;
-
-	}
-
-	get clearDepth() {
-
-		return this.clearDepthAsync;
-
-	}
-
-	get clearStencil() {
-
-		return this.clearStencilAsync;
 
 	}
 

--- a/examples/webgpu_compute_texture.html
+++ b/examples/webgpu_compute_texture.html
@@ -126,7 +126,7 @@
 
 			function render() {
 
-				renderer.render( scene, camera );
+				renderer.renderAsync( scene, camera );
 
 			}
 

--- a/examples/webgpu_loader_gltf.html
+++ b/examples/webgpu_loader_gltf.html
@@ -120,7 +120,7 @@
 
 			function render() {
 
-				renderer.render( scene, camera );
+				renderer.renderAsync( scene, camera );
 
 			}
 

--- a/examples/webgpu_mirror.html
+++ b/examples/webgpu_mirror.html
@@ -38,7 +38,6 @@
 			let sphereGroup, smallSphere;
 
 			init();
-			animate();
 
 			function init() {
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/27597#issuecomment-1902253058, https://github.com/mrdoob/three.js/pull/26964

**Description**

On some Nodes including PMREMGenetaror(WebGPU) that is being developed, we will need to do render call synchronized in the same render pass, so as not to confuse the stack and don't have `race condition` problem. The best alternative I found so far was to alert the user with an error if they calls `render()` before initialization and directing them to use `renderAsync()`

`THREE.Renderer: .render() called before the backend is initialized. Try using .renderAsync() instead.`