### PR TITLE
Spherical: Clean up.

### DIFF
--- a/src/math/Spherical.js
+++ b/src/math/Spherical.js
@@ -1,4 +1,3 @@
-
 import * as MathUtils from './MathUtils.js';
 
 /**

--- a/src/math/Spherical.js
+++ b/src/math/Spherical.js
@@ -1,11 +1,12 @@
-/**
- * Ref: https://en.wikipedia.org/wiki/Spherical_coordinate_system
- *
- * The polar angle (phi) is measured from the positive y-axis. The positive y-axis is up.
- * The azimuthal angle (theta) is measured from the positive z-axis.
- */
 
 import * as MathUtils from './MathUtils.js';
+
+/**
+ * Ref: https://en.wikipedia.org/wiki/Spherical_coordinate_system (mathematics convention)
+ *
+ * phi (the polar angle) is measured from the positive y-axis. The positive y-axis is up.
+ * theta (the azimuthal angle) is measured from the positive z-axis.
+ */
 
 class Spherical {
 

--- a/src/math/Spherical.js
+++ b/src/math/Spherical.js
@@ -2,12 +2,11 @@
 import * as MathUtils from './MathUtils.js';
 
 /**
- * Ref: https://en.wikipedia.org/wiki/Spherical_coordinate_system (mathematics convention)
+ * Ref: https://en.wikipedia.org/wiki/Spherical_coordinate_system
  *
  * phi (the polar angle) is measured from the positive y-axis. The positive y-axis is up.
  * theta (the azimuthal angle) is measured from the positive z-axis.
  */
-
 class Spherical {
 
 	constructor( radius = 1, phi = 0, theta = 0 ) {


### PR DESCRIPTION
**Description**

- Put JSDoc on the line before the class definition so that IDEs can pick it up correctly. 
- specify the used spherical convention

EG: this allows getting JSDoc while hovering over the `Spherical` class symbol.
