### PR TITLE
WebGLRenderer: Remove `gl_FragDepthEXT`.

### DIFF
--- a/src/renderers/shaders/ShaderChunk/logdepthbuf_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/logdepthbuf_fragment.glsl.js
@@ -3,7 +3,7 @@ export default /* glsl */`
 
 	// Doing a strict comparison with == 1.0 can cause noise artifacts
 	// on some platforms. See issue #17623.
-	gl_FragDepthEXT = vIsPerspective == 0.0 ? gl_FragCoord.z : log2( vFragDepth ) * logDepthBufFC * 0.5;
+	gl_FragDepth = vIsPerspective == 0.0 ? gl_FragCoord.z : log2( vFragDepth ) * logDepthBufFC * 0.5;
 
 #endif
 `;

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -881,7 +881,6 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 			'#define varying in',
 			( parameters.glslVersion === GLSL3 ) ? '' : 'layout(location = 0) out highp vec4 pc_fragColor;',
 			( parameters.glslVersion === GLSL3 ) ? '' : '#define gl_FragColor pc_fragColor',
-			'#define gl_FragDepthEXT gl_FragDepth',
 			'#define texture2D texture',
 			'#define textureCube texture',
 			'#define texture2DProj textureProj',

--- a/src/renderers/webxr/WebXRDepthSensing.js
+++ b/src/renderers/webxr/WebXRDepthSensing.js
@@ -21,11 +21,11 @@ void main() {
 
 	if ( coord.x >= 1.0 ) {
 
-		gl_FragDepthEXT = texture( depthColor, vec3( coord.x - 1.0, coord.y, 1 ) ).r;
+		gl_FragDepth = texture( depthColor, vec3( coord.x - 1.0, coord.y, 1 ) ).r;
 
 	} else {
 
-		gl_FragDepthEXT = texture( depthColor, vec3( coord.x, coord.y, 0 ) ).r;
+		gl_FragDepth = texture( depthColor, vec3( coord.x, coord.y, 0 ) ).r;
 
 	}
 
@@ -73,7 +73,6 @@ class WebXRDepthSensing {
 
 				const viewport = cameraXR.cameras[ 0 ].viewport;
 				const material = new ShaderMaterial( {
-					extensions: { fragDepth: true },
 					vertexShader: _occlusion_vertex,
 					fragmentShader: _occlusion_fragment,
 					uniforms: {


### PR DESCRIPTION
Related issue: #27836

**Description**

This PR removes an oversight in #27836. `gl_FragDepthEXT` is related to the WebGL 1 `EXT_frag_depth` extension. When using WebGL 2, `gl_FragDepth` can be used.
