### PR TITLE
WebGLProgram: Restore `gl_FragDepth` fallback.

### DIFF
--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -879,6 +879,7 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 			'#define varying in',
 			( parameters.glslVersion === GLSL3 ) ? '' : 'layout(location = 0) out highp vec4 pc_fragColor;',
 			( parameters.glslVersion === GLSL3 ) ? '' : '#define gl_FragColor pc_fragColor',
+			'#define gl_FragDepthEXT gl_FragDepth',
 			'#define texture2D texture',
 			'#define textureCube texture',
 			'#define texture2DProj textureProj',


### PR DESCRIPTION
Related issue: #27853

**Description**

I think it does not hurt to keep the `gl_FragDepthEXT` define as a fallback for custom shader materials.
