### PR TITLE
Examples: Clean up.

### DIFF
--- a/examples/webgl2_buffergeometry_attributes_integer.html
+++ b/examples/webgl2_buffergeometry_attributes_integer.html
@@ -57,14 +57,6 @@
 
 			import * as THREE from 'three';
 
-			import WebGL from 'three/addons/capabilities/WebGL.js';
-
-			if ( WebGL.isWebGL2Available() === false ) {
-
-				document.body.appendChild( WebGL.getWebGL2ErrorMessage() );
-
-			}
-
 			let camera, scene, renderer, mesh;
 
 			init();

--- a/examples/webgl2_buffergeometry_attributes_none.html
+++ b/examples/webgl2_buffergeometry_attributes_none.html
@@ -93,14 +93,6 @@
 
 			import * as THREE from 'three';
 
-			import WebGL from 'three/addons/capabilities/WebGL.js';
-
-			if ( WebGL.isWebGL2Available() === false ) {
-
-				document.body.appendChild( WebGL.getWebGL2ErrorMessage() );
-
-			}
-
 			let camera, scene, renderer, mesh;
 
 			init();

--- a/examples/webgl2_materials_texture2darray.html
+++ b/examples/webgl2_materials_texture2darray.html
@@ -67,14 +67,6 @@
 			import Stats from 'three/addons/libs/stats.module.js';
 			import { unzipSync } from 'three/addons/libs/fflate.module.js';
 
-			import WebGL from 'three/addons/capabilities/WebGL.js';
-
-			if ( WebGL.isWebGL2Available() === false ) {
-
-				document.body.appendChild( WebGL.getWebGL2ErrorMessage() );
-
-			}
-
 			let camera, scene, mesh, renderer, stats;
 
 			const planeWidth = 50;

--- a/examples/webgl2_materials_texture3d.html
+++ b/examples/webgl2_materials_texture3d.html
@@ -29,13 +29,6 @@
 		import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 		import { NRRDLoader } from 'three/addons/loaders/NRRDLoader.js';
 		import { VolumeRenderShader1 } from 'three/addons/shaders/VolumeShader.js';
-		import WebGL from 'three/addons/capabilities/WebGL.js';
-
-		if ( WebGL.isWebGL2Available() === false ) {
-
-			document.body.appendChild( WebGL.getWebGL2ErrorMessage() );
-
-		}
 
 		let renderer,
 			scene,

--- a/examples/webgl2_materials_texture3d_partialupdate.html
+++ b/examples/webgl2_materials_texture3d_partialupdate.html
@@ -27,13 +27,6 @@
 			import { ImprovedNoise } from 'three/addons/math/ImprovedNoise.js';
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
-			import WebGL from 'three/addons/capabilities/WebGL.js';
-
-			if ( WebGL.isWebGL2Available() === false ) {
-
-				document.body.appendChild( WebGL.getWebGL2ErrorMessage() );
-
-			}
 
 			const INITIAL_CLOUD_SIZE = 128;
 

--- a/examples/webgl2_multiple_rendertargets.html
+++ b/examples/webgl2_multiple_rendertargets.html
@@ -121,7 +121,6 @@
 
 			import * as THREE from 'three';
 
-			import WebGL from 'three/addons/capabilities/WebGL.js';
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 
@@ -142,13 +141,6 @@
 			init();
 
 			function init() {
-
-				if ( WebGL.isWebGL2Available() === false ) {
-
-					document.body.appendChild( WebGL.getWebGL2ErrorMessage() );
-					return;
-
-				}
 
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );

--- a/examples/webgl2_multisampled_renderbuffers.html
+++ b/examples/webgl2_multisampled_renderbuffers.html
@@ -49,7 +49,6 @@
 			import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
 			import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
 			import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
-			import WebGL from 'three/addons/capabilities/WebGL.js';
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 
 			let camera, renderer, group, container;
@@ -65,13 +64,6 @@
 			init();
 
 			function init() {
-
-				if ( WebGL.isWebGL2Available() === false ) {
-
-					document.body.appendChild( WebGL.getWebGL2ErrorMessage() );
-					return;
-
-				}
 
 				container = document.getElementById( 'container' );
 

--- a/examples/webgl2_rendertarget_texture2darray.html
+++ b/examples/webgl2_rendertarget_texture2darray.html
@@ -112,14 +112,6 @@
 			import { unzipSync } from 'three/addons/libs/fflate.module.js';
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 
-			import WebGL from 'three/addons/capabilities/WebGL.js';
-
-			if ( WebGL.isWebGL2Available() === false ) {
-
-				document.body.appendChild( WebGL.getWebGL2ErrorMessage() );
-
-			}
-
 			const DIMENSIONS = {
 				width: 256,
 				height: 256,

--- a/examples/webgl2_texture2darray_compressed.html
+++ b/examples/webgl2_texture2darray_compressed.html
@@ -65,14 +65,6 @@
 			import Stats from 'three/addons/libs/stats.module.js';
 			import { KTX2Loader } from 'three/addons/loaders/KTX2Loader.js';
 
-			import WebGL from 'three/addons/capabilities/WebGL.js';
-
-			if ( WebGL.isWebGL2Available() === false ) {
-
-				document.body.appendChild( WebGL.getWebGL2ErrorMessage() );
-
-			}
-
 			let camera, scene, mesh, renderer, stats, clock;
 
 			const planeWidth = 50;

--- a/examples/webgl2_ubo.html
+++ b/examples/webgl2_ubo.html
@@ -188,21 +188,12 @@
 
 			import * as THREE from 'three';
 
-			import WebGL from 'three/addons/capabilities/WebGL.js';
-
 			let camera, scene, renderer, clock;
 
 			init();
 			animate();
 
 			function init() {
-
-				if ( WebGL.isWebGL2Available() === false ) {
-
-					document.body.appendChild( WebGL.getWebGL2ErrorMessage() );
-					return;
-
-				}
 
 				const container = document.getElementById( 'container' );
 

--- a/examples/webgl2_ubo_arrays.html
+++ b/examples/webgl2_ubo_arrays.html
@@ -115,7 +115,6 @@
 
 			import * as THREE from 'three';
 
-			import WebGL from 'three/addons/capabilities/WebGL.js';
 			import Stats from 'three/addons/libs/stats.module.js';
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
@@ -136,13 +135,6 @@
 			animate();
 
 			function init() {
-
-				if ( WebGL.isWebGL2Available() === false ) {
-
-					document.body.appendChild( WebGL.getWebGL2ErrorMessage() );
-					return;
-
-				}
 
 				camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 0.1, 100 );
 				camera.position.set( 0, 50, 50 );

--- a/examples/webgl2_volume_cloud.html
+++ b/examples/webgl2_volume_cloud.html
@@ -27,13 +27,6 @@
 			import { ImprovedNoise } from 'three/addons/math/ImprovedNoise.js';
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
-			import WebGL from 'three/addons/capabilities/WebGL.js';
-
-			if ( WebGL.isWebGL2Available() === false ) {
-
-				document.body.appendChild( WebGL.getWebGL2ErrorMessage() );
-
-			}
 
 			let renderer, scene, camera;
 			let mesh;

--- a/examples/webgl2_volume_instancing.html
+++ b/examples/webgl2_volume_instancing.html
@@ -26,14 +26,6 @@
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { VOXLoader, VOXData3DTexture } from 'three/addons/loaders/VOXLoader.js';
 
-			import WebGL from 'three/addons/capabilities/WebGL.js';
-
-			if ( WebGL.isWebGL2Available() === false ) {
-
-				document.body.appendChild( WebGL.getWebGL2ErrorMessage() );
-
-			}
-
 			let renderer, scene, camera, controls, clock;
 
 			init();

--- a/examples/webgl2_volume_perlin.html
+++ b/examples/webgl2_volume_perlin.html
@@ -27,13 +27,6 @@
 			import { ImprovedNoise } from 'three/addons/math/ImprovedNoise.js';
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
-			import WebGL from 'three/addons/capabilities/WebGL.js';
-
-			if ( WebGL.isWebGL2Available() === false ) {
-
-				document.body.appendChild( WebGL.getWebGL2ErrorMessage() );
-
-			}
 
 			let renderer, scene, camera;
 			let mesh;


### PR DESCRIPTION
Related issue: #27836

**Description**

Explicit checks for WebGL 2 support in the examples are not necessary anymore.