### PR TITLE
Fix GLTFLoader.createUniqueName to cover some cases

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -3592,17 +3592,17 @@ class GLTFParser {
 
 		const sanitizedName = PropertyBinding.sanitizeNodeName( originalName || '' );
 
-		if ( sanitizedName in this.nodeNamesUsed ) {
+		let newName = sanitizedName;
 
-			return sanitizedName + '_' + ( ++ this.nodeNamesUsed[ sanitizedName ] );
+		while (newName in this.nodeNamesUsed) {
 
-		} else {
-
-			this.nodeNamesUsed[ sanitizedName ] = 0;
-
-			return sanitizedName;
+			newName = sanitizedName + '_' + ( ++ this.nodeNamesUsed[ sanitizedName ] );
 
 		}
+
+		this.nodeNamesUsed[ newName ] = 0;
+
+		return newName;
 
 	}
 


### PR DESCRIPTION
The original algorithm creates duplicate names in the following test cases

input:
```
createUniqueName("123");
createUniqueName("123");
createUniqueName("123");
createUniqueName("123_1");
createUniqueName("123_3");
createUniqueName("123");
```

output:
```
"123"
"123_1"
"123_2"
"123_1"
"123_3"
"123_3"
```