### PR TITLE
Manual: Fix GPU picking demo.

### DIFF
--- a/manual/en/picking.html
+++ b/manual/en/picking.html
@@ -279,7 +279,7 @@ for (let i = 0; i &lt; numObjects; ++i) {
   cube.scale.set(rand(3, 6), rand(3, 6), rand(3, 6));
 
 +  const pickingMaterial = new THREE.MeshPhongMaterial({
-+    emissive: new THREE.Color(id),
++    emissive: new THREE.Color().setHex(id, THREE.NoColorSpace),
 +    color: new THREE.Color(0, 0, 0),
 +    specular: new THREE.Color(0, 0, 0),
 +    map: texture,

--- a/manual/examples/picking-gpu.html
+++ b/manual/examples/picking-gpu.html
@@ -151,7 +151,7 @@ function main() {
 		constructor() {
 
 			// create a 1x1 pixel render target
-			this.pickingTexture = new THREE.WebGLRenderTarget( 1, 1, { colorSpace: THREE.LinearSRGBColorSpace } );
+			this.pickingTexture = new THREE.WebGLRenderTarget( 1, 1 );
 			this.pixelBuffer = new Uint8Array( 4 );
 			this.pickedObject = null;
 			this.pickedObjectSavedColor = 0;

--- a/manual/examples/picking-gpu.html
+++ b/manual/examples/picking-gpu.html
@@ -113,7 +113,7 @@ function main() {
 		cube.scale.set( rand( 3, 6 ), rand( 3, 6 ), rand( 3, 6 ) );
 
 		const pickingMaterial = new THREE.MeshPhongMaterial( {
-			emissive: new THREE.Color( id ),
+			emissive: new THREE.Color().setHex( id, THREE.NoColorSpace ),
 			color: new THREE.Color( 0, 0, 0 ),
 			specular: new THREE.Color( 0, 0, 0 ),
 			map: texture,
@@ -151,7 +151,7 @@ function main() {
 		constructor() {
 
 			// create a 1x1 pixel render target
-			this.pickingTexture = new THREE.WebGLRenderTarget( 1, 1 );
+			this.pickingTexture = new THREE.WebGLRenderTarget( 1, 1, { colorSpace: THREE.LinearSRGBColorSpace } );
 			this.pixelBuffer = new Uint8Array( 4 );
 			this.pickedObject = null;
 			this.pickedObjectSavedColor = 0;

--- a/manual/ja/picking.html
+++ b/manual/ja/picking.html
@@ -296,7 +296,7 @@ for (let i = 0; i &lt; numObjects; ++i) {
   cube.scale.set(rand(3, 6), rand(3, 6), rand(3, 6));
 
 +  const pickingMaterial = new THREE.MeshPhongMaterial({
-+    emissive: new THREE.Color(id),
++    emissive: new THREE.Color().setHex(id, THREE.NoColorSpace),
 +    color: new THREE.Color(0, 0, 0),
 +    specular: new THREE.Color(0, 0, 0),
 +    map: texture,

--- a/manual/ko/picking.html
+++ b/manual/ko/picking.html
@@ -268,7 +268,7 @@ for (let i = 0; i &lt; numObjects; ++i) {
   cube.scale.set(rand(3, 6), rand(3, 6), rand(3, 6));
 
 +  const pickingMaterial = new THREE.MeshPhongMaterial({
-+    emissive: new THREE.Color(id),
++    emissive: new THREE.Color().setHex(id, THREE.NoColorSpace),
 +    color: new THREE.Color(0, 0, 0),
 +    specular: new THREE.Color(0, 0, 0),
 +    map: texture,

--- a/manual/zh/picking.html
+++ b/manual/zh/picking.html
@@ -262,7 +262,7 @@ for (let i = 0; i &lt; numObjects; ++i) {
   cube.scale.set(rand(3, 6), rand(3, 6), rand(3, 6));
 
 +  const pickingMaterial = new THREE.MeshPhongMaterial({
-+    emissive: new THREE.Color(id),
++    emissive: new THREE.Color().setHex(id, THREE.NoColorSpace),
 +    color: new THREE.Color(0, 0, 0),
 +    specular: new THREE.Color(0, 0, 0),
 +    map: texture,


### PR DESCRIPTION
Fixed #27862.

**Description**

This PR fixes the GPU picking demo in the manual. Since color management is enabled, storing the `id` in emissive fields requires the definition of a `linear-srgb` color space.
