### PR TITLE
UniformsUtils: Check for XRRenderTarget in getUnlitUniformColorSpace

### DIFF
--- a/src/renderers/shaders/UniformsUtils.js
+++ b/src/renderers/shaders/UniformsUtils.js
@@ -95,6 +95,7 @@ export function getUnlitUniformColorSpace( renderer ) {
 
 	}
 
+	// https://github.com/mrdoob/three.js/issues/27868
 	if ( currentRenderTarget.isXRRenderTarget === true ) {
 
 		return currentRenderTarget.texture.colorSpace;

--- a/src/renderers/shaders/UniformsUtils.js
+++ b/src/renderers/shaders/UniformsUtils.js
@@ -86,10 +86,18 @@ export function cloneUniformsGroups( src ) {
 
 export function getUnlitUniformColorSpace( renderer ) {
 
-	if ( renderer.getRenderTarget() === null ) {
+	const currentRenderTarget = renderer.getRenderTarget();
+
+	if ( currentRenderTarget === null ) {
 
 		// https://github.com/mrdoob/three.js/pull/23937#issuecomment-1111067398
 		return renderer.outputColorSpace;
+
+	}
+
+	if ( currentRenderTarget.isXRRenderTarget === true ) {
+
+		return currentRenderTarget.texture.colorSpace;
 
 	}
 


### PR DESCRIPTION
Fixed #27868

**Description**

Adds a check to `getUnlitUniformColorSpace` to return the render target's texture colour space in case of the WebXR render target. With this change both fog colour and background colour remain consistent inside and outside VR sessions. This is similar to the logic in [`WebGLProgams.js`](https://github.com/mrdoob/three.js/blob/7e74e4cc6458005ea9a4c3176f933c33bde17e72/src/renderers/webgl/WebGLPrograms.js#L199) and [`WebGLRenderer.js`](https://github.com/mrdoob/three.js/blob/7e74e4cc6458005ea9a4c3176f933c33bde17e72/src/renderers/WebGLRenderer.js#L1715C1-L1715C200).

*This contribution is funded by [Fern Solutions](https://fern.solutions)*
