### PR TITLE
WebGPURenderer: Add Timestamp Queries WebGL fallback support

### DIFF
--- a/examples/jsm/renderers/common/Renderer.js
+++ b/examples/jsm/renderers/common/Renderer.js
@@ -889,6 +889,7 @@ class Renderer {
 		const previousRenderId = nodeFrame.renderId;
 
 		//
+		if ( this.info.autoReset === true ) this.info.resetCompute();
 
 		this.info.calls ++;
 		this.info.compute.calls ++;
@@ -897,7 +898,6 @@ class Renderer {
 		nodeFrame.renderId = this.info.calls;
 
 		//
-		if ( this.info.autoReset === true ) this.info.resetCompute();
 
 		const backend = this.backend;
 		const pipelines = this._pipelines;

--- a/examples/jsm/renderers/webgl/WebGLBackend.js
+++ b/examples/jsm/renderers/webgl/WebGLBackend.js
@@ -131,6 +131,8 @@ class WebGLBackend extends Backend {
 				this.gl.deleteQuery( queryInfo.query );
 				renderContextData.gpuQueries.splice( i, 1 ); // Remove the processed query
 
+				i --;
+
 				this.renderer.info.updateTimestamp( type, duration );
 
 			}

--- a/examples/jsm/renderers/webgl/utils/WebGLConstants.js
+++ b/examples/jsm/renderers/webgl/utils/WebGLConstants.js
@@ -7,5 +7,6 @@ export const GLFeatureName = {
 	'WEBKIT_WEBGL_compressed_texture_pvrtc': 'texture-compression-pvrtc',
 	'WEBGL_compressed_texture_s3tc': 'texture-compression-bc',
 	'EXT_texture_compression_bptc': 'texture-compression-bptc',
+	'EXT_disjoint_timer_query_webgl2': 'timestamp-query',
 
 };

--- a/examples/webgpu_compute_particles.html
+++ b/examples/webgpu_compute_particles.html
@@ -294,8 +294,8 @@
 
 						timestamps.innerHTML = `
 
-							Compute ${renderer.info.compute.computeCalls} pass in ${renderer.info.timestamp.compute}ms<br>
-							Draw ${renderer.info.render.drawCalls} pass in ${renderer.info.timestamp.render}ms`;
+							Compute ${renderer.info.compute.computeCalls} pass in ${renderer.info.timestamp.compute.toFixed( 6 )}ms<br>
+							Draw ${renderer.info.render.drawCalls} pass in ${renderer.info.timestamp.render.toFixed( 6 )}ms`;
 
 					}
 

--- a/examples/webgpu_storage_buffer.html
+++ b/examples/webgpu_storage_buffer.html
@@ -11,6 +11,32 @@
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a>
 			<br />This example demonstrate the fetch of external element from a StorageBuffer.
 			<br /> Left canvas is using WebGPU Backend, right canvas is WebGL Backend.
+			<div id="timestamps" style="
+				position: absolute;
+				top: 60px;
+				left: 0;
+				padding: 10px;
+				background: rgba( 0, 0, 0, 0.5 );
+				color: #fff;
+				font-family: monospace;
+				font-size: 12px;
+				line-height: 1.5;
+				pointer-events: none;
+				text-align: left;
+			"></div>
+			<div id="timestamps_webgl" style="
+			position: absolute;
+			top: 60px;
+			right: 0;
+			padding: 10px;
+			background: rgba( 0, 0, 0, 0.5 );
+			color: #fff;
+			font-family: monospace;
+			font-size: 12px;
+			line-height: 1.5;
+			pointer-events: none;
+			text-align: left;
+		"></div>
 		</div>
 
 		<script type="importmap">
@@ -30,6 +56,11 @@
 
 			import WebGPURenderer from 'three/addons/renderers/webgpu/WebGPURenderer.js';
 			import StorageInstancedBufferAttribute from 'three/addons/renderers/common/StorageInstancedBufferAttribute.js';
+
+			const timestamps = {
+				webgpu: document.getElementById( 'timestamps' ),
+				webgl: document.getElementById( 'timestamps_webgl' )
+			};
 
 			// WebGPU Backend
 			init();
@@ -153,7 +184,7 @@
 				const plane = new THREE.Mesh( new THREE.PlaneGeometry( 1, 1 ), material );
 				scene.add( plane );
 
-				const renderer = new WebGPURenderer( { antialias: false, forceWebGL: forceWebGL } );
+				const renderer = new WebGPURenderer( { antialias: false, forceWebGL: forceWebGL, trackTimestamp: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth / 2, window.innerHeight );
 
@@ -183,6 +214,11 @@
 
 					await renderer.computeAsync( compute );
 					await renderer.renderAsync( scene, camera );
+
+					timestamps[ forceWebGL ? 'webgl' : 'webgpu' ].innerHTML = `
+
+							Compute ${renderer.info.compute.computeCalls} pass in ${renderer.info.timestamp.compute.toFixed( 6 )}ms<br>
+							Draw ${renderer.info.render.drawCalls} pass in ${renderer.info.timestamp.render.toFixed( 6 )}ms`;
 
 					setTimeout( stepAnimation, 1000 );
 			


### PR DESCRIPTION
This pull request introduces functionality to measure the execution time of programs on the GPU within the WebGL Backend by using the `EXT_disjoint_timer_query_webgl2` extension.
This feature is useful for benchmarking performance disparities between the WebGPU and WebGL Backends.

As an example I updated `webgpu_storage_buffer` to use the `trackTimestamp` parameter, WebGPU is on the left and WebGL and the right:
[https://raw.githack.com/renaudrohlinger/three.js/feat/utsubo/timestamp-webgl/examples/webgpu_storage_buffer.html](https://raw.githack.com/renaudrohlinger/three.js/feat/utsubo/timestamp-webgl/examples/webgpu_storage_buffer.html)
<img width="1723" alt="image" src="https://github.com/mrdoob/three.js/assets/15867665/d0c8c435-a4c9-44ff-bf75-162fcffaa958">

PS:
Please note that the WebGL performances appears to consistently take approximately 5 to 10 times longer than its WebGPU counterpart. Despite thorough verification to ensure accuracy in the implementation, this discrepancy persists. My hypothesis would be that the additional time consumed by WebGL may be attributed to the security validations performed with each WebGL instruction.

Related:
https://github.com/mrdoob/three.js/pull/27597

_This contribution is funded by [Utsubo](https://utsubo.com/)_