### PR TITLE
BufferAttribute: Allow 2D `position` data.

### DIFF
--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -258,6 +258,8 @@ class BufferAttribute {
 
 	getZ( index ) {
 
+		if ( this.itemSize < 3 ) return 0; // 2D vertex data support
+
 		let z = this.array[ index * this.itemSize + 2 ];
 
 		if ( this.normalized ) z = denormalize( z, this.array );
@@ -268,9 +270,13 @@ class BufferAttribute {
 
 	setZ( index, z ) {
 
-		if ( this.normalized ) z = normalize( z, this.array );
+		if ( this.itemSize > 2 ) { // 2D vertex data support
 
-		this.array[ index * this.itemSize + 2 ] = z;
+			if ( this.normalized ) z = normalize( z, this.array );
+
+			this.array[ index * this.itemSize + 2 ] = z;
+
+		}
 
 		return this;
 
@@ -328,7 +334,12 @@ class BufferAttribute {
 
 		this.array[ index + 0 ] = x;
 		this.array[ index + 1 ] = y;
-		this.array[ index + 2 ] = z;
+
+		if ( this.itemSize > 2 ) { // 2D vertex data support
+
+			this.array[ index + 2 ] = z;
+
+		}
 
 		return this;
 
@@ -512,6 +523,8 @@ class Float16BufferAttribute extends BufferAttribute {
 
 	getZ( index ) {
 
+		if ( this.itemSize < 3 ) return 0; // 2D vertex data support
+
 		let z = fromHalfFloat( this.array[ index * this.itemSize + 2 ] );
 
 		if ( this.normalized ) z = denormalize( z, this.array );
@@ -522,9 +535,13 @@ class Float16BufferAttribute extends BufferAttribute {
 
 	setZ( index, z ) {
 
-		if ( this.normalized ) z = normalize( z, this.array );
+		if ( this.itemSize > 2 ) { // 2D vertex data support
 
-		this.array[ index * this.itemSize + 2 ] = toHalfFloat( z );
+			if ( this.normalized ) z = normalize( z, this.array );
+
+			this.array[ index * this.itemSize + 2 ] = toHalfFloat( z );
+
+		}
 
 		return this;
 
@@ -582,7 +599,12 @@ class Float16BufferAttribute extends BufferAttribute {
 
 		this.array[ index + 0 ] = toHalfFloat( x );
 		this.array[ index + 1 ] = toHalfFloat( y );
-		this.array[ index + 2 ] = toHalfFloat( z );
+
+		if ( this.itemSize > 2 ) { // 2D vertex data support
+
+			this.array[ index + 2 ] = toHalfFloat( z );
+
+		}
 
 		return this;
 

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -132,9 +132,17 @@ class BufferGeometry extends EventDispatcher {
 
 		if ( position !== undefined ) {
 
-			position.applyMatrix4( matrix );
+			if ( position.itemSize === 3 ) {
 
-			position.needsUpdate = true;
+				position.applyMatrix4( matrix );
+
+				position.needsUpdate = true;
+
+			} else {
+
+				console.warn( 'THREE.BufferGeometry: .applyMatrix4() requires a position attribute item size of 3.' );
+
+			}
 
 		}
 

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -128,21 +128,36 @@ class BufferGeometry extends EventDispatcher {
 
 	applyMatrix4( matrix ) {
 
-		const position = this.attributes.position;
+		let position = this.attributes.position;
 
 		if ( position !== undefined ) {
 
-			if ( position.itemSize === 3 ) {
+			if ( position.itemSize === 2 ) {
 
-				position.applyMatrix4( matrix );
+				// expand data to item size 3
 
-				position.needsUpdate = true;
+				const data = [];
 
-			} else {
+				for ( let i = 0; i < position.count; i ++ ) {
 
-				console.warn( 'THREE.BufferGeometry: .applyMatrix4() requires a position attribute item size of 3.' );
+					const x = position.getX( i );
+					const y = position.getY( i );
+					const z = 0;
+
+					data.push( x, y, z );
+
+				}
+
+				position = new position.constructor( data, 3 );
+				this.attributes.position = position;
+
+				console.warn( 'THREE.BufferGeometry: The position buffer attribute has been resized to item size 3 since .applyMatrix4() requires 3D data.' );
 
 			}
+
+			position.applyMatrix4( matrix );
+
+			position.needsUpdate = true;
 
 		}
 

--- a/src/core/InterleavedBufferAttribute.js
+++ b/src/core/InterleavedBufferAttribute.js
@@ -128,9 +128,13 @@ class InterleavedBufferAttribute {
 
 	setZ( index, z ) {
 
-		if ( this.normalized ) z = normalize( z, this.array );
+		if ( this.itemSize > 2 ) { // 2D vertex data support
 
-		this.data.array[ index * this.data.stride + this.offset + 2 ] = z;
+			if ( this.normalized ) z = normalize( z, this.array );
+
+			this.data.array[ index * this.data.stride + this.offset + 2 ] = z;
+
+		}
 
 		return this;
 
@@ -167,6 +171,8 @@ class InterleavedBufferAttribute {
 	}
 
 	getZ( index ) {
+
+		if ( this.itemSize < 3 ) return 0; // 2D vertex data support
 
 		let z = this.data.array[ index * this.data.stride + this.offset + 2 ];
 
@@ -218,7 +224,12 @@ class InterleavedBufferAttribute {
 
 		this.data.array[ index + 0 ] = x;
 		this.data.array[ index + 1 ] = y;
-		this.data.array[ index + 2 ] = z;
+
+		if ( this.itemSize > 2 ) { // 2D vertex data support
+
+			this.data.array[ index + 2 ] = z;
+
+		}
 
 		return this;
 

--- a/test/unit/src/core/BufferGeometry.tests.js
+++ b/test/unit/src/core/BufferGeometry.tests.js
@@ -15,6 +15,7 @@ import { Sphere } from '../../../../src/math/Sphere.js';
 import { x, y, z } from '../../utils/math-constants.js';
 import { EventDispatcher } from '../../../../src/core/EventDispatcher.js';
 import { toHalfFloat } from '../../../../src/extras/DataUtils.js';
+import { Vector2 } from '../../../../src/math/Vector2.js';
 
 const DegToRad = Math.PI / 180;
 
@@ -43,22 +44,26 @@ function bufferAttributeEquals( a, b, tolerance ) {
 
 }
 
-function getBBForVertices( vertices ) {
+function getBBForVertices( vertices, itemSize ) {
+
+	itemSize = itemSize || 3;
 
 	const geometry = new BufferGeometry();
 
-	geometry.setAttribute( 'position', new BufferAttribute( new Float32Array( vertices ), 3 ) );
+	geometry.setAttribute( 'position', new BufferAttribute( new Float32Array( vertices ), itemSize ) );
 	geometry.computeBoundingBox();
 
 	return geometry.boundingBox;
 
 }
 
-function getBSForVertices( vertices ) {
+function getBSForVertices( vertices, itemSize ) {
+
+	itemSize = itemSize || 3;
 
 	const geometry = new BufferGeometry();
 
-	geometry.setAttribute( 'position', new BufferAttribute( new Float32Array( vertices ), 3 ) );
+	geometry.setAttribute( 'position', new BufferAttribute( new Float32Array( vertices ), itemSize ) );
 	geometry.computeBoundingSphere();
 
 	return geometry.boundingSphere;
@@ -447,30 +452,55 @@ export default QUnit.module( 'Core', () => {
 
 		} );
 
+		QUnit.test( 'computeBoundingBox - 2D', ( assert ) => {
+
+			const bb = getBBForVertices( [ - 1, - 3, 7, 13 ], 2 );
+
+			assert.ok( bb.min.x === - 1 && bb.min.y === - 3 && bb.min.z === 0, 'min values are set correctly' );
+			assert.ok( bb.max.x === 7 && bb.max.y === 13 && bb.max.z === 0, 'max values are set correctly' );
+
+		} );
+
 		QUnit.test( 'computeBoundingSphere', ( assert ) => {
 
 			let bs = getBSForVertices( [ - 10, 0, 0, 10, 0, 0 ] );
 
 			assert.ok( bs.radius === 10, 'radius is equal to deltaMinMax / 2' );
-			assert.ok( bs.center.x === 0 && bs.center.y === 0 && bs.center.y === 0, 'bounding sphere is at ( 0, 0, 0 )' );
+			assert.ok( bs.center.x === 0 && bs.center.y === 0 && bs.center.z === 0, 'bounding sphere is at ( 0, 0, 0 )' );
 
 			bs = getBSForVertices( [ - 5, 11, - 3, 5, - 11, 3 ] );
 			const radius = new Vector3( 5, 11, 3 ).length();
 
 			assert.ok( bs.radius === radius, 'radius is equal to directionLength' );
-			assert.ok( bs.center.x === 0 && bs.center.y === 0 && bs.center.y === 0, 'bounding sphere is at ( 0, 0, 0 )' );
+			assert.ok( bs.center.x === 0 && bs.center.y === 0 && bs.center.z === 0, 'bounding sphere is at ( 0, 0, 0 )' );
+
+		} );
+
+		QUnit.test( 'computeBoundingSphere - 2D', ( assert ) => {
+
+			const bs = getBSForVertices( [ - 1, - 3, 1, 3 ], 2 );
+			const radius = new Vector2( 1, 3 ).length();
+
+			assert.ok( bs.radius === radius, 'radius is equal to directionLength' );
+			assert.ok( bs.center.x === 0 && bs.center.y === 0 && bs.center.z === 0, 'bounding sphere is at ( 0, 0, 0 )' );
 
 		} );
 
 		const toHalfFloatArray = ( f32Array ) => {
+
 			const f16Array = new Uint16Array( f32Array.length );
-			for ( let i = 0, n = f32Array.length; i < n; ++i ) {
+			for ( let i = 0, n = f32Array.length; i < n; ++ i ) {
+
 				f16Array[ i ] = toHalfFloat( f32Array[ i ] );
+
 			}
+
 			return f16Array;
+
 		};
 
 		QUnit.test( 'computeBoundingBox - Float16', ( assert ) => {
+
 			const vertices = [ - 1, - 2, - 3, 13, - 2, - 3.5, - 1, - 20, 0, - 4, 5, 6 ];
 			const geometry = new BufferGeometry();
 
@@ -490,6 +520,7 @@ export default QUnit.module( 'Core', () => {
 		} );
 
 		QUnit.test( 'computeBoundingSphere - Float16', ( assert ) => {
+
 			const vertices = [ - 10, 0, 0, 10, 0, 0 ];
 			const geometry = new BufferGeometry();
 


### PR DESCRIPTION
Related issue: #27401, #6288, #8798, #12221, #15009, #19735, #25748

**Description**

Over the past years, different developers wanted to use the library with a 2D `position` attribute. We did not support this so far since we were unsure about the implications of this change.

It turns out that logic that relies on the setter/getter API of `BufferAttribute` (which is true for `BufferGeometry`) can support a 2D `position` attribute with just a few changes. The idea is to apply the same policy as the WebGL and WebGPU implementations. Meaning the `z` component is considered as `0` if not explicitly set.

That means `getZ()` now returns `0` for `vec2` data. And `setZ()` and `setXYZ()` ignore the given z values. This is done for `BufferAttribute` as well as `InterleavedBufferAttribute`. Things like bounding volume, normal or tangent computation via `BufferGeometry` should work with this change as expected.

Edit: `BufferGeometry.applyMatrix4()` and the related transformation methods are an exception since the matrix-vector multiplication requires 3D vectors.

I think it's okay to give this PR a try under the label of an "experimental feature". If we encounter serious issues with 2D `position` data in production, we can reconsider and revert if necessary.

