### PR TITLE
WebGPURenderer: QuadMesh extended from Mesh

### DIFF
--- a/examples/jsm/objects/QuadMesh.js
+++ b/examples/jsm/objects/QuadMesh.js
@@ -23,41 +23,25 @@ class QuadGeometry extends BufferGeometry {
 
 const _geometry = new QuadGeometry();
 
-class QuadMesh {
+class QuadMesh extends Mesh {
 
 	constructor( material = null ) {
 
-		this._mesh = new Mesh( _geometry, material );
+		super( _geometry, material );
+
+		this.camera = _camera;
 
 	}
 
-	dispose() {
+	renderAsync( renderer ) {
 
-		this._mesh.geometry.dispose();
-
-	}
-
-	async renderAsync( renderer ) {
-
-		await renderer.renderAsync( this._mesh, _camera );
+		return renderer.renderAsync( this, _camera );
 
 	}
 
-	get material() {
+	render( renderer ) {
 
-		return this._mesh.material;
-
-	}
-
-	set material( value ) {
-
-		this._mesh.material = value;
-
-	}
-
-	get render() {
-
-		return this.renderAsync;
+		renderer.render( this, _camera );
 
 	}
 

--- a/examples/jsm/renderers/common/PostProcessing.js
+++ b/examples/jsm/renderers/common/PostProcessing.js
@@ -1,7 +1,7 @@
-import { vec4, MeshBasicNodeMaterial } from '../../nodes/Nodes.js';
+import { vec4, NodeMaterial } from '../../nodes/Nodes.js';
 import QuadMesh from '../../objects/QuadMesh.js';
 
-const quadMesh = new QuadMesh( new MeshBasicNodeMaterial() );
+const quadMesh = new QuadMesh( new NodeMaterial() );
 
 class PostProcessing {
 
@@ -12,11 +12,19 @@ class PostProcessing {
 
 	}
 
-	async render() {
+	render() {
 
 		quadMesh.material.fragmentNode = this.outputNode;
 
-		await quadMesh.render( this.renderer );
+		quadMesh.render( this.renderer );
+
+	}
+
+	renderAsync() {
+
+		quadMesh.material.fragmentNode = this.outputNode;
+
+		return quadMesh.renderAsync( this.renderer );
 
 	}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/27369

**Description**

- [x] [QuadMesh extended from Mesh](https://github.com/mrdoob/three.js/commit/8574b4391ab85826d661257a68aac85bf95e9bd6)
- [x] [PostProcessing: Added renderAsync()](https://github.com/mrdoob/three.js/commit/b455ce8e8d12e85d7a30462268f6af695781cdaf)