### PR TITLE
GLTFLoader: Compute world matrices before calling `onLoad()`.

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2627,7 +2627,11 @@ class GLTFParser {
 
 			} ) ).then( function () {
 
-				result.scene.updateMatrixWorld();
+				for ( const scene of result.scenes ) {
+
+					scene.updateMatrixWorld();
+
+				}
 
 				onLoad( result );
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2627,6 +2627,8 @@ class GLTFParser {
 
 			} ) ).then( function () {
 
+				result.scene.updateMatrixWorld();
+
 				onLoad( result );
 
 			} );


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/14499#issuecomment-1979757155

**Description**

`GLTFLoader` now computes the world matrices for `gltf.scene` and its descendant nodes before calling `onLoad()`. That should hopefully fix issues like https://github.com/mrdoob/three.js/issues/14499#issuecomment-1975637963 where devs report wrong bounding volumes when computing them in the `onLoad()` callback.

Some background: This change would not be required if bounding volumes (and other logic) could request up-to-date world matrices in their routines (e.g. with a special getter). With the current world matrix computations in `three.js`, there is no performant way to ensure that, see #21411.

Of course the issue can also be avoided if devs remember to update their world matrices correctly but this task or responsibility is easy to overlook.
