### PR TITLE
WebGLRenderer: Revert stencil support for transmission.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1418,8 +1418,7 @@ class WebGLRenderer {
 					generateMipmaps: true,
 					type: ( extensions.has( 'EXT_color_buffer_half_float' ) || extensions.has( 'EXT_color_buffer_float' ) ) ? HalfFloatType : UnsignedByteType,
 					minFilter: LinearMipmapLinearFilter,
-					samples: 4,
-					stencilBuffer: stencil
+					samples: 4
 				} );
 
 				// debug


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/27799#issuecomment-1985538145

**Description**

Reverting until https://github.com/mrdoob/three.js/pull/27799#issuecomment-1985538145 is clear.
