### PR TITLE
XREstimatedLight: Check `session.enabledFeatures` (if available) before attempting `session.requestLightProbe`

### DIFF
--- a/examples/jsm/webxr/XREstimatedLight.js
+++ b/examples/jsm/webxr/XREstimatedLight.js
@@ -156,8 +156,9 @@ export class XREstimatedLight extends Group {
 		renderer.xr.addEventListener( 'sessionstart', () => {
 
 			const session = renderer.xr.getSession();
-
-			if ( 'requestLightProbe' in session ) {
+			const featureIsNotEnabled = session.enabledFeatures && !session.enabledFeatures.includes( 'light-estimation' );
+			
+			if ( !featureIsNotEnabled && 'requestLightProbe' in session ) {
 
 				session.requestLightProbe( {
 


### PR DESCRIPTION
## Description:

The double-negative here is unfortunate, but `session.enabledFeatures` is currently only available in Chromium-based browsers, so we can't always 'positively' know that the feature is supported.

Another approach would be to wrap `session.requestLightProbe` in try/catch, or add `.catch` after the `.then`, but for whatever reason, those don't seem to actually catch the `DOMException` error for me.

Related: https://github.com/immersive-web/webxr/pull/1296

## Motivation:

The thrown error doesn't cause any serious problem - it just errors and fails. But it is annoying when using the "Pause on uncaught exceptions" feature of Chrome DevTools.