### PR TITLE
Renderer: Set `stencil` to `false` by default.

### DIFF
--- a/docs/api/ar/renderers/WebGLRenderer.html
+++ b/docs/api/ar/renderers/WebGLRenderer.html
@@ -50,7 +50,7 @@
 		 
 		[page:Boolean stencil] - ما إذا كانت ذاكرة التخزين المؤقت للرسم لديها
 		[link:https://en.wikipedia.org/wiki/Stencil_buffer stencil buffer] من على
-		الأقل 8 بت. الافتراضي هو `true`. <br />
+		الأقل 8 بت. الافتراضي هو `false`. <br />
 		 
 		[page:Boolean preserveDrawingBuffer] - ما إذا كان سيتم الحفاظ على المخابئ
 		حتى يتم مسحها يدويًا أو استبدالها. الافتراضي هو `false`. <br />

--- a/docs/api/en/renderers/WebGLRenderer.html
+++ b/docs/api/en/renderers/WebGLRenderer.html
@@ -49,7 +49,7 @@
 
 			[page:Boolean stencil] - whether the drawing buffer has a
 			[link:https://en.wikipedia.org/wiki/Stencil_buffer stencil buffer] of at
-			least 8 bits. Default is `true`.<br />
+			least 8 bits. Default is `false`.<br />
 
 			[page:Boolean preserveDrawingBuffer] - whether to preserve the buffers
 			until manually cleared or overwritten. Default is `false`.<br />

--- a/docs/api/it/renderers/WebGLRenderer.html
+++ b/docs/api/it/renderers/WebGLRenderer.html
@@ -45,7 +45,7 @@
 
 		[page:Boolean stencil] - Indica se il buffer di disegno ha un
 		[link:https://en.wikipedia.org/wiki/Stencil_buffer buffer stencil] di almeno 8 bit.
-		Il valore predefinito è `true`.<br />
+		Il valore predefinito è `false`.<br />
 
 		[page:Boolean preserveDrawingBuffer] - Indica se conservare i buffer finché non verranno cancellati
 		o sovrascritti manualmente. Il valore predefinito è `false`.<br />

--- a/docs/api/zh/renderers/WebGLRenderer.html
+++ b/docs/api/zh/renderers/WebGLRenderer.html
@@ -38,7 +38,7 @@
 
 		[page:Boolean antialias] - 是否执行抗锯齿。默认为*false*.<br />
 
-		[page:Boolean stencil] - 绘图缓存是否有一个至少8位的模板缓存([link:https://en.wikipedia.org/wiki/Stencil_buffer stencil buffer])。默认为*true*<br />
+		[page:Boolean stencil] - 绘图缓存是否有一个至少8位的模板缓存([link:https://en.wikipedia.org/wiki/Stencil_buffer stencil buffer])。默认为*false*<br />
 
 		[page:Boolean preserveDrawingBuffer] -是否保留缓直到手动清除或被覆盖。 默认*false*.<br />
 

--- a/examples/jsm/renderers/common/Renderer.js
+++ b/examples/jsm/renderers/common/Renderer.js
@@ -57,7 +57,7 @@ class Renderer {
 		this.sortObjects = true;
 
 		this.depth = true;
-		this.stencil = true;
+		this.stencil = false;
 
 		this.clippingPlanes = [];
 

--- a/examples/webgl_clipping_stencil.html
+++ b/examples/webgl_clipping_stencil.html
@@ -216,7 +216,7 @@
 				document.body.appendChild( stats.dom );
 
 				// Renderer
-				renderer = new THREE.WebGLRenderer( { antialias: true } );
+				renderer = new THREE.WebGLRenderer( { antialias: true, stencil: true } );
 				renderer.shadowMap.enabled = true;
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );

--- a/examples/webgl_shadowmesh.html
+++ b/examples/webgl_shadowmesh.html
@@ -35,7 +35,7 @@
 			const scene = new THREE.Scene();
 			const camera = new THREE.PerspectiveCamera( 55, SCREEN_WIDTH / SCREEN_HEIGHT, 1, 3000 );
 			const clock = new THREE.Clock();
-			const renderer = new THREE.WebGLRenderer();
+			const renderer = new THREE.WebGLRenderer( { stencil: true } );
 
 			const sunLight = new THREE.DirectionalLight( 'rgb(255,255,255)', 3 );
 			let useDirectionalLight = true;

--- a/examples/webgpu_backdrop_area.html
+++ b/examples/webgpu_backdrop_area.html
@@ -124,7 +124,6 @@
 				// renderer
 
 				renderer = new WebGPURenderer( /*{ antialias: true }*/ );
-				renderer.stencil = false;
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setAnimationLoop( animate );

--- a/examples/webgpu_backdrop_water.html
+++ b/examples/webgpu_backdrop_water.html
@@ -201,7 +201,6 @@
 				// renderer
 
 				renderer = new WebGPURenderer( /*{ antialias: true }*/ );
-				renderer.stencil = false;
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setAnimationLoop( animate );

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -68,7 +68,7 @@ class WebGLRenderer {
 			canvas = createCanvasElement(),
 			context = null,
 			depth = true,
-			stencil = true,
+			stencil = false,
 			alpha = false,
 			antialias = false,
 			premultipliedAlpha = true,


### PR DESCRIPTION
Related issue: #27799

**Description**

As suggested in https://github.com/mrdoob/three.js/pull/27799#issuecomment-1987017656, the `stencil` parameter of `WebGLRenderer` and the new `Renderer.stencil` property are now `false` by default. That means applications have to set the value to `true` now if they rely on stencil related logic.

The motivation behind this change is to only request resources if they are required. Since `stencil` is only used in special circumstances, the new default value seems more appropriate.

Note: Not enabling stencil for the default drawing buffer does not exclude depth textures or render targets of having stencil types/formats or attachments.

@cabanier I've seen `WebXRManager` also evaluates the `stencil` property for its layer related logic. Do you see any issues with this change?