### PR TITLE
Introduce `Scene.environmentIntensity`

### DIFF
--- a/docs/api/en/scenes/Scene.html
+++ b/docs/api/en/scenes/Scene.html
@@ -62,6 +62,12 @@
 			[page:MeshStandardMaterial.envMap]. Default is `null`.
 		</p>
 
+		<h3>[property:Float environmentIntensity]</h3>
+		<p>
+			Attenuates the color of the environment. Only influences environment maps
+			assigned to [page:Scene.environment]. Default is `1`.
+		</p>
+
 		<h3>[property:Euler environmentRotation]</h3>
 		<p>
 			The rotation of the environment map in radians. Only influences physical materials 

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -798,6 +798,8 @@ class ObjectLoader extends Loader {
 				if ( data.backgroundBlurriness !== undefined ) object.backgroundBlurriness = data.backgroundBlurriness;
 				if ( data.backgroundIntensity !== undefined ) object.backgroundIntensity = data.backgroundIntensity;
 				if ( data.backgroundRotation !== undefined ) object.backgroundRotation.fromArray( data.backgroundRotation );
+
+				if ( data.environmentIntensity !== undefined ) object.environmentIntensity = data.environmentIntensity;
 				if ( data.environmentRotation !== undefined ) object.environmentRotation.fromArray( data.environmentRotation );
 
 				break;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1986,6 +1986,12 @@ class WebGLRenderer {
 
 			}
 
+			if ( material.isMeshStandardMaterial && material.envMap === null && scene.environment !== null ) {
+
+				m_uniforms.envMapIntensity.value = scene.environmentIntensity;
+
+			}
+
 			if ( refreshMaterial ) {
 
 				p_uniforms.setValue( _gl, 'toneMappingExposure', _this.toneMappingExposure );

--- a/src/renderers/webgl/WebGLMaterials.js
+++ b/src/renderers/webgl/WebGLMaterials.js
@@ -393,11 +393,10 @@ function WebGLMaterials( renderer, properties ) {
 
 		}
 
-		const envMap = properties.get( material ).envMap;
-
-		if ( envMap ) {
+		if ( material.envMap ) {
 
 			//uniforms.envMap.value = material.envMap; // part of uniforms common
+
 			uniforms.envMapIntensity.value = material.envMapIntensity;
 
 		}

--- a/src/scenes/Scene.js
+++ b/src/scenes/Scene.js
@@ -18,6 +18,8 @@ class Scene extends Object3D {
 		this.backgroundBlurriness = 0;
 		this.backgroundIntensity = 1;
 		this.backgroundRotation = new Euler();
+
+		this.environmentIntensity = 1;
 		this.environmentRotation = new Euler();
 
 		this.overrideMaterial = null;
@@ -41,6 +43,8 @@ class Scene extends Object3D {
 		this.backgroundBlurriness = source.backgroundBlurriness;
 		this.backgroundIntensity = source.backgroundIntensity;
 		this.backgroundRotation.copy( source.backgroundRotation );
+
+		this.environmentIntensity = source.environmentIntensity;
 		this.environmentRotation.copy( source.environmentRotation );
 
 		if ( source.overrideMaterial !== null ) this.overrideMaterial = source.overrideMaterial.clone();
@@ -56,10 +60,12 @@ class Scene extends Object3D {
 		const data = super.toJSON( meta );
 
 		if ( this.fog !== null ) data.object.fog = this.fog.toJSON();
+
 		if ( this.backgroundBlurriness > 0 ) data.object.backgroundBlurriness = this.backgroundBlurriness;
 		if ( this.backgroundIntensity !== 1 ) data.object.backgroundIntensity = this.backgroundIntensity;
-
 		data.object.backgroundRotation = this.backgroundRotation.toArray();
+
+		if ( this.environmentIntensity !== 1 ) data.object.environmentIntensity = this.environmentIntensity;
 		data.object.environmentRotation = this.environmentRotation.toArray();
 
 		return data;


### PR DESCRIPTION
As suggested in https://github.com/mrdoob/three.js/issues/24665#issuecomment-1467130545.

Currently, `material.envMapIntensity` attenuates both `scene.environment` and `material.envMap`.

With this change, `material.envMapIntensity` attenuates only `material.envMap`.

A new property `scene.environmentIntensity` is introduced that attenuates only `scene.environment`.

