### PR TITLE
Nodes: Introduce `Node.needsUpdate=true`

### DIFF
--- a/examples/jsm/nodes/core/Node.js
+++ b/examples/jsm/nodes/core/Node.js
@@ -20,9 +20,24 @@ class Node extends EventDispatcher {
 
 		this.uuid = MathUtils.generateUUID();
 
+		this.version = 0;
+
+		this._cacheKey = null;
+		this._version = 0;
+
 		this.isNode = true;
 
 		Object.defineProperty( this, 'id', { value: _nodeId ++ } );
+
+	}
+
+	set needsUpdate( value ) {
+
+		if ( value === true ) {
+
+			this.version ++;
+
+		}
 
 	}
 
@@ -80,9 +95,18 @@ class Node extends EventDispatcher {
 
 	}
 
-	getCacheKey() {
+	getCacheKey( force = false ) {
 
-		return getCacheKey( this );
+		force = force || this.version !== this._version;
+
+		if ( force === true || this._cacheKey === null ) {
+
+			this._cacheKey = getCacheKey( this, force );
+			this._version = this.version;
+
+		}
+
+		return this._cacheKey;
 
 	}
 

--- a/examples/jsm/nodes/core/Node.js
+++ b/examples/jsm/nodes/core/Node.js
@@ -23,7 +23,7 @@ class Node extends EventDispatcher {
 		this.version = 0;
 
 		this._cacheKey = null;
-		this._version = 0;
+		this._cacheKeyVersion = 0;
 
 		this.isNode = true;
 
@@ -97,12 +97,12 @@ class Node extends EventDispatcher {
 
 	getCacheKey( force = false ) {
 
-		force = force || this.version !== this._version;
+		force = force || this.version !== this._cacheKeyVersion;
 
 		if ( force === true || this._cacheKey === null ) {
 
 			this._cacheKey = getCacheKey( this, force );
-			this._version = this.version;
+			this._cacheKeyVersion = this.version;
 
 		}
 

--- a/examples/jsm/nodes/core/NodeUtils.js
+++ b/examples/jsm/nodes/core/NodeUtils.js
@@ -1,6 +1,6 @@
 import { Color, Matrix3, Matrix4, Vector2, Vector3, Vector4 } from 'three';
 
-export function getCacheKey( object ) {
+export function getCacheKey( object, force = false ) {
 
 	let cacheKey = '{';
 
@@ -12,7 +12,7 @@ export function getCacheKey( object ) {
 
 	for ( const { property, childNode } of getNodeChildren( object ) ) {
 
-		cacheKey += ',' + property.slice( 0, - 4 ) + ':' + childNode.getCacheKey();
+		cacheKey += ',' + property.slice( 0, - 4 ) + ':' + childNode.getCacheKey( force );
 
 	}
 

--- a/examples/jsm/renderers/common/Background.js
+++ b/examples/jsm/renderers/common/Background.js
@@ -50,11 +50,11 @@ class Background extends DataMap {
 
 			if ( backgroundMesh === undefined ) {
 
-				const backgroundMeshNode = context( vec4( backgroundNode ), {
+				const backgroundMeshNode = context( vec4( backgroundNode ).mul( backgroundIntensity ), {
 					// @TODO: Add Texture2D support using node context
 					getUV: () => normalWorld,
 					getTextureLevel: () => backgroundBlurriness
-				} ).mul( backgroundIntensity );
+				} );
 
 				let viewProj = modelViewProjection();
 				viewProj = viewProj.setZ( viewProj.w );

--- a/examples/jsm/renderers/common/RenderObject.js
+++ b/examples/jsm/renderers/common/RenderObject.js
@@ -1,4 +1,4 @@
-import ClippingContext from "./ClippingContext.js";
+import ClippingContext from './ClippingContext.js';
 
 let id = 0;
 
@@ -75,7 +75,7 @@ export default class RenderObject {
 
 	}
 
-	clippingNeedsUpdate () {
+	get clippingNeedsUpdate() {
 
 		if ( this.clippingContext.version === this.clippingContextVersion ) return false;
 
@@ -192,7 +192,7 @@ export default class RenderObject {
 
 	get needsUpdate() {
 
-		return this.initialNodesCacheKey !== this.getNodesCacheKey();
+		return this.initialNodesCacheKey !== this.getNodesCacheKey() || this.clippingNeedsUpdate;
 
 	}
 

--- a/examples/jsm/renderers/common/RenderObjects.js
+++ b/examples/jsm/renderers/common/RenderObjects.js
@@ -33,7 +33,7 @@ class RenderObjects {
 
 			renderObject.updateClipping( renderContext.clippingContext );
 
-			if ( renderObject.version !== material.version || renderObject.needsUpdate || renderObject.clippingNeedsUpdate() ) {
+			if ( renderObject.version !== material.version || renderObject.needsUpdate ) {
 
 				if ( renderObject.initialCacheKey !== renderObject.getCacheKey() ) {
 


### PR DESCRIPTION
Related issue: Closes https://github.com/mrdoob/three.js/issues/27895

### Description

In the vast majority of cases, `cacheKeys` are being generated without any real need, which would be to change the TSL code, causing overloading. This PR introduces `node.needsUpdate=true` so that the system can identify when it is really necessary to recreate the Node's `cacheKey`.

### Comparation

Comparison below of `webgpu_backdrop_water` in the range of 1 to 4 seconds.
| Before | Now |
| ------------- | ------------- |
| ![image](https://github.com/mrdoob/three.js/assets/502810/36f67cbe-eb62-44a6-b4b9-168bb70d99a9) | ![image](https://github.com/mrdoob/three.js/assets/502810/f55982f2-3ed6-4d9f-b3b1-c6e1f9522bcb) |

### When should I use it?

Every time you need to update a specific `Node` chain, for exemple:

```js
// mix( a, b, c ) = mix( aNode, bNode, cNode )
material.colorNode = mix( color( 0x0487e2 ), color( 0x0066ff ), normalWorld.y );

// ... in the software cycle

material.colorNode.aNode = color( 0xffffff );
material.colorNode.needsUpdate = true;
```