### PR TITLE
NodeMaterial: Force unsigned float in basic output

### DIFF
--- a/examples/jsm/nodes/materials/NodeMaterial.js
+++ b/examples/jsm/nodes/materials/NodeMaterial.js
@@ -107,7 +107,11 @@ class NodeMaterial extends ShaderMaterial {
 
 			if ( clippingNode !== null ) builder.stack.add( clippingNode );
 
-			resultNode = this.setupOutput( builder, vec4( outgoingLightNode, diffuseColor.a ) );
+			// force unsigned floats - useful for RenderTargets
+
+			const basicOutput = vec4( outgoingLightNode, diffuseColor.a ).max( 0 );
+
+			resultNode = this.setupOutput( builder, basicOutput );
 
 			// OUTPUT NODE
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/27880

**Description**

It fix some case of uses when `RenderTarget` is used with negative values, mainly `alpha` related.