### PR TITLE
Object3D: Fix events in `attach()`.

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -333,12 +333,7 @@ class Object3D extends EventDispatcher {
 
 		if ( object && object.isObject3D ) {
 
-			if ( object.parent !== null ) {
-
-				object.parent.remove( object );
-
-			}
-
+			object.removeFromParent();
 			object.parent = this;
 			this.children.push( object );
 
@@ -431,9 +426,17 @@ class Object3D extends EventDispatcher {
 
 		object.applyMatrix4( _m1 );
 
-		this.add( object );
+		object.removeFromParent();
+		object.parent = this;
+		this.children.push( object );
 
 		object.updateWorldMatrix( false, true );
+
+		object.dispatchEvent( _addedEvent );
+
+		_childaddedEvent.child = object;
+		this.dispatchEvent( _childaddedEvent );
+		_childaddedEvent.child = null;
 
 		return this;
 


### PR DESCRIPTION
Fixed #26739.

**Description**

This PR fixes #26739 by inlining the relevant code of `add()` and is a simplified version of #26750.