### PR TITLE
Docs: Improve `Material` page.

### DIFF
--- a/docs/api/en/materials/Material.html
+++ b/docs/api/en/materials/Material.html
@@ -340,7 +340,7 @@
 		<h3>[property:Boolean toneMapped]</h3>
 		<p>
 			Defines whether this material is tone mapped according to the renderer's			
-			[page:WebGLRenderer.toneMapping toneMapping] setting. It is ignored when rendering to a render target.
+			[page:WebGLRenderer.toneMapping toneMapping] setting. It is ignored when rendering to a render target or using post processing.
 			Default is `true`.
 		</p>
 


### PR DESCRIPTION
Clarification on the Tonemapped Property

**Description**

After observing some confusion, including my own experiences, regarding the behavior of tonemapping following the r154 update, particularly among users accustomed to utilizing effect composers for post-processing, I have taken steps to enhance the clarity of the documentation pertaining to the `tonemapped` property.

This update includes additional insights aimed at providing further assistance to readers encountering similar challenges.
