### PR TITLE
update Neutral tone mapper

### DIFF
--- a/src/renderers/shaders/ShaderChunk/tonemapping_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/tonemapping_pars_fragment.glsl.js
@@ -185,7 +185,7 @@ vec3 NeutralToneMapping( vec3 color ) {
 	color *= newPeak / peak;
 
 	float g = 1. - 1. / (desaturation * (peak - newPeak) + 1.);
-	return mix(color, vec3(1, 1, 1), g);
+	return mix(color, newPeak * vec3(1, 1, 1), g);
 }
 
 vec3 CustomToneMapping( vec3 color ) { return color; }


### PR DESCRIPTION
This one-liner makes a pretty much imperceptible change (<1% difference at maximum), but allows the Khronos PBR Neutral tone mapper to be analytically invertible, which turns out to be important for a bunch of industry use-cases. See details here: https://github.com/google/model-viewer/pull/4716

Khronos now has an official repo for this spec, such as it is, which has just been updated accordingly: https://github.com/KhronosGroup/ToneMapping. It also includes the inverse function.

FYI @mrdoob @WestLangley 