### PR TITLE
editor: geometry export json in utf-8

### DIFF
--- a/editor/js/Sidebar.Geometry.js
+++ b/editor/js/Sidebar.Geometry.js
@@ -195,7 +195,7 @@ function SidebarGeometry( editor ) {
 		const left = ( screen.width - 500 ) / 2;
 		const top = ( screen.height - 500 ) / 2;
 
-		const url = URL.createObjectURL( new Blob( [ output ], { type: 'text/plain' } ) );
+		const url = URL.createObjectURL( new Blob( [ output ], { type: 'text/plain;charset=utf-8' } ) );
 		window.open( url, '_blank', `location=no,left=${left},top=${top},width=500,height=500` );
 
 	} );


### PR DESCRIPTION
preserves utf-8 of geometry `name`, and oncoming https://github.com/mrdoob/three.js/pull/27931 `text`  in exported json



<img width="688" alt="image" src="https://github.com/mrdoob/three.js/assets/1063018/0878bdd9-9aaf-4d2e-b679-93b71433d9f0">
