### PR TITLE
LUTPass: Remove WebGL 1 fallback.

### DIFF
--- a/examples/jsm/loaders/LUT3dlLoader.js
+++ b/examples/jsm/loaders/LUT3dlLoader.js
@@ -3,7 +3,6 @@
 
 import {
 	ClampToEdgeWrapping,
-	DataTexture,
 	Data3DTexture,
 	FileLoader,
 	FloatType,
@@ -144,19 +143,6 @@ export class LUT3dlLoader extends Loader {
 
 		}
 
-		const texture = new DataTexture();
-		texture.image.data = data;
-		texture.image.width = size;
-		texture.image.height = size * size;
-		texture.format = RGBAFormat;
-		texture.type = this.type;
-		texture.magFilter = LinearFilter;
-		texture.minFilter = LinearFilter;
-		texture.wrapS = ClampToEdgeWrapping;
-		texture.wrapT = ClampToEdgeWrapping;
-		texture.generateMipmaps = false;
-		texture.needsUpdate = true;
-
 		const texture3D = new Data3DTexture();
 		texture3D.image.data = data;
 		texture3D.image.width = size;
@@ -174,7 +160,6 @@ export class LUT3dlLoader extends Loader {
 
 		return {
 			size,
-			texture,
 			texture3D,
 		};
 

--- a/examples/jsm/loaders/LUTCubeLoader.js
+++ b/examples/jsm/loaders/LUTCubeLoader.js
@@ -2,7 +2,6 @@
 
 import {
 	ClampToEdgeWrapping,
-	DataTexture,
 	Data3DTexture,
 	FileLoader,
 	FloatType,
@@ -127,18 +126,6 @@ export class LUTCubeLoader extends Loader {
 
 		}
 
-		const texture = new DataTexture();
-		texture.image.data = data;
-		texture.image.width = size;
-		texture.image.height = size * size;
-		texture.type = this.type;
-		texture.magFilter = LinearFilter;
-		texture.minFilter = LinearFilter;
-		texture.wrapS = ClampToEdgeWrapping;
-		texture.wrapT = ClampToEdgeWrapping;
-		texture.generateMipmaps = false;
-		texture.needsUpdate = true;
-
 		const texture3D = new Data3DTexture();
 		texture3D.image.data = data;
 		texture3D.image.width = size;
@@ -158,7 +145,6 @@ export class LUTCubeLoader extends Loader {
 			size,
 			domainMin,
 			domainMax,
-			texture,
 			texture3D,
 		};
 

--- a/examples/jsm/loaders/LUTImageLoader.js
+++ b/examples/jsm/loaders/LUTImageLoader.js
@@ -1,7 +1,6 @@
 import {
 	Loader,
 	TextureLoader,
-	DataTexture,
 	Data3DTexture,
 	RGBAFormat,
 	UnsignedByteType,
@@ -124,18 +123,6 @@ export class LUTImageLoader extends Loader {
 	parse( dataArray, size ) {
 
 		const data = new Uint8Array( dataArray );
-		const texture = new DataTexture();
-		texture.image.data = data;
-		texture.image.width = size;
-		texture.image.height = size * size;
-		texture.format = RGBAFormat;
-		texture.type = UnsignedByteType;
-		texture.magFilter = LinearFilter;
-		texture.minFilter = LinearFilter;
-		texture.wrapS = ClampToEdgeWrapping;
-		texture.wrapT = ClampToEdgeWrapping;
-		texture.generateMipmaps = false;
-		texture.needsUpdate = true;
 
 		const texture3D = new Data3DTexture();
 		texture3D.image.data = data;
@@ -154,7 +141,6 @@ export class LUTImageLoader extends Loader {
 
 		return {
 			size,
-			texture,
 			texture3D,
 		};
 

--- a/examples/jsm/postprocessing/LUTPass.js
+++ b/examples/jsm/postprocessing/LUTPass.js
@@ -4,12 +4,7 @@ const LUTShader = {
 
 	name: 'LUTShader',
 
-	defines: {
-		USE_3DTEXTURE: 1,
-	},
-
 	uniforms: {
-		lut3d: { value: null },
 
 		lut: { value: null },
 		lutSize: { value: 0 },
@@ -34,45 +29,9 @@ const LUTShader = {
 	fragmentShader: /* glsl */`
 
 		uniform float lutSize;
-		#if USE_3DTEXTURE
+
 		precision highp sampler3D;
-		uniform sampler3D lut3d;
-		#else
-		uniform sampler2D lut;
-
-		vec3 lutLookup( sampler2D tex, float size, vec3 rgb ) {
-
-			float sliceHeight = 1.0 / size;
-			float yPixelHeight = 1.0 / ( size * size );
-
-			// Get the slices on either side of the sample
-			float slice = rgb.b * size;
-			float interp = fract( slice );
-			float slice0 = slice - interp;
-			float centeredInterp = interp - 0.5;
-
-			float slice1 = slice0 + sign( centeredInterp );
-
-			// Pull y sample in by half a pixel in each direction to avoid color
-			// bleeding from adjacent slices.
-			float greenOffset = clamp( rgb.g * sliceHeight, yPixelHeight * 0.5, sliceHeight - yPixelHeight * 0.5 );
-
-			vec2 uv0 = vec2(
-				rgb.r,
-				slice0 * sliceHeight + greenOffset
-			);
-			vec2 uv1 = vec2(
-				rgb.r,
-				slice1 * sliceHeight + greenOffset
-			);
-
-			vec3 sample0 = texture2D( tex, uv0 ).rgb;
-			vec3 sample1 = texture2D( tex, uv1 ).rgb;
-
-			return mix( sample0, sample1, abs( centeredInterp ) );
-
-		}
-		#endif
+		uniform sampler3D lut;
 
 		varying vec2 vUv;
 		uniform float intensity;
@@ -88,15 +47,8 @@ const LUTShader = {
 			float halfPixelWidth = 0.5 / lutSize;
 			vec3 uvw = vec3( halfPixelWidth ) + val.rgb * ( 1.0 - pixelWidth );
 
-			#if USE_3DTEXTURE
 
-			lutVal = vec4( texture( lut3d, uvw ).rgb, val.a );
-
-			#else
-
-			lutVal = vec4( lutLookup( lut, lutSize, uvw ), val.a );
-
-			#endif
+			lutVal = vec4( texture( lut, uvw ).rgb, val.a );
 
 			gl_FragColor = vec4( mix( val, lutVal, intensity ) );
 
@@ -111,31 +63,15 @@ class LUTPass extends ShaderPass {
 	set lut( v ) {
 
 		const material = this.material;
+
 		if ( v !== this.lut ) {
 
-			material.uniforms.lut3d.value = null;
 			material.uniforms.lut.value = null;
 
 			if ( v ) {
 
-				const is3dTextureDefine = v.isData3DTexture ? 1 : 0;
-				if ( is3dTextureDefine !== material.defines.USE_3DTEXTURE ) {
-
-					material.defines.USE_3DTEXTURE = is3dTextureDefine;
-					material.needsUpdate = true;
-
-				}
-
 				material.uniforms.lutSize.value = v.image.width;
-				if ( v.isData3DTexture ) {
-
-					material.uniforms.lut3d.value = v;
-
-				} else {
-
-					material.uniforms.lut.value = v;
-
-				}
+				material.uniforms.lut.value = v;
 
 			}
 
@@ -145,7 +81,7 @@ class LUTPass extends ShaderPass {
 
 	get lut() {
 
-		return this.material.uniforms.lut.value || this.material.uniforms.lut3d.value;
+		return this.material.uniforms.lut.value;
 
 	}
 

--- a/examples/webgl_postprocessing_3dlut.html
+++ b/examples/webgl_postprocessing_3dlut.html
@@ -43,8 +43,7 @@
 			const params = {
 				enabled: true,
 				lut: 'Bourbon 64.CUBE',
-				intensity: 1,
-				use2DLut: false,
+				intensity: 1
 			};
 
 			const lutMap = {
@@ -184,7 +183,7 @@
 				if ( lutMap[ params.lut ] ) {
 
 					const lut = lutMap[ params.lut ];
-					lutPass.lut = params.use2DLut ? lut.texture : lut.texture3D;
+					lutPass.lut = lut.texture3D;
 
 				}
 


### PR DESCRIPTION
Related issue: #27836

**Description**

`LUTPass` can now always rely on 3D textures which greatly simplifies the implementation.