### PR TITLE
USDZExporter: Add support for vertex colors.

### DIFF
--- a/examples/jsm/exporters/USDZExporter.js
+++ b/examples/jsm/exporters/USDZExporter.js
@@ -409,19 +409,20 @@ function buildPrimvars( attributes ) {
 
 	}
 
-	  // Handle vertex colors
-	  const colorAttribute = attributes.color;
-	
-	  if (colorAttribute !== undefined) {
-	
-	    const count = colorAttribute.count;
-	
-	    string += `
-	      color3f[] primvars:displayColor = [${buildVector3Array(colorAttribute, count)}] (
+	// vertex colors
+
+	const colorAttribute = attributes.color;
+
+	if ( colorAttribute !== undefined ) {
+
+		const count = colorAttribute.count;
+
+		string += `
+	color3f[] primvars:displayColor = [${buildVector3Array( colorAttribute, count )}] (
 		interpolation = "vertex"
-	      )`;
-	
-	  }
+		)`;
+
+	}
 
 	return string;
 

--- a/examples/jsm/exporters/USDZExporter.js
+++ b/examples/jsm/exporters/USDZExporter.js
@@ -409,6 +409,20 @@ function buildPrimvars( attributes ) {
 
 	}
 
+	  // Handle vertex colors
+	  const colorAttribute = attributes.color;
+	
+	  if (colorAttribute !== undefined) {
+	
+	    const count = colorAttribute.count;
+	
+	    string += `
+	      color3f[] primvars:displayColor = [${buildVector3Array(colorAttribute, count)}] (
+		interpolation = "vertex"
+	      )`;
+	
+	  }
+
 	return string;
 
 }


### PR DESCRIPTION
**Description :**
This pull request addresses the issue of the USDZ exporter not supporting the export of vertex colors from Three.js geometries.

Fixed #27942

**Changes  :** 

- Modified the `buildPrimvars` function in the USDZ exporter to handle the `color` attribute from Three.js geometries.
```
  const colorAttribute = attributes.color;
  if (colorAttribute !== undefined) {
    const count = colorAttribute.count;
    string += `
      color3f[] primvars:displayColor = [${buildVector3Array(colorAttribute, count)}] (
        interpolation = "vertex"
      )`;
  }
```
- Tested the changes to verify that vertex colors are accurately exported to the USDZ file and rendered correctly in USDZ-compatible viewers.


**Before :**
The USDZ exporter did not support exporting vertex colors from Three.js geometries, resulting in meshes with vertex colors appearing incorrectly or without the expected coloring when viewed in USDZ-compatible viewers.

**After :**
The USDZ exporter now correctly exports vertex colors from Three.js geometries, ensuring that meshes with vertex colors are rendered accurately in USDZ-compatible viewers.
