### PR TITLE
LUTPass: Remove redundant precision qualifier.

### DIFF
--- a/examples/jsm/postprocessing/LUTPass.js
+++ b/examples/jsm/postprocessing/LUTPass.js
@@ -29,8 +29,6 @@ const LUTShader = {
 	fragmentShader: /* glsl */`
 
 		uniform float lutSize;
-
-		precision highp sampler3D;
 		uniform sampler3D lut;
 
 		varying vec2 vUv;


### PR DESCRIPTION
Related issue: -

**Description**

With #27482 in place `LUTPass` does not have to specify the precision for `sampler3D`.
