### PR TITLE
WebGPURenderer: Apply batching matrice before instancing and Expand multiDraw Support

### DIFF
--- a/examples/jsm/nodes/materials/NodeMaterial.js
+++ b/examples/jsm/nodes/materials/NodeMaterial.js
@@ -205,15 +205,15 @@ class NodeMaterial extends ShaderMaterial {
 
 		}
 
-		if ( ( object.instanceMatrix && object.instanceMatrix.isInstancedBufferAttribute === true ) && builder.isAvailable( 'instance' ) === true ) {
-
-			instance( object ).append();
-
-		}
-
 		if ( object.isBatchedMesh ) {
 
 			batch( object ).append();
+
+		}
+
+		if ( ( object.instanceMatrix && object.instanceMatrix.isInstancedBufferAttribute === true ) && builder.isAvailable( 'instance' ) === true ) {
+
+			instance( object ).append();
 
 		}
 

--- a/examples/jsm/renderers/webgl/WebGLBackend.js
+++ b/examples/jsm/renderers/webgl/WebGLBackend.js
@@ -699,7 +699,24 @@ class WebGLBackend extends Backend {
 
 		if ( object.isBatchedMesh ) {
 
-			renderer.renderMultiDraw( object._multiDrawStarts, object._multiDrawCounts, object._multiDrawCount );
+			if ( instanceCount > 1 ) {
+
+				// TODO: Better support with InstancedBatchedMesh
+				if ( object._multiDrawInstances === undefined ) {
+
+					object._multiDrawInstances = new Int32Array( object._maxGeometryCount );
+
+				}
+
+				object._multiDrawInstances.fill( instanceCount );
+
+				renderer.renderMultiDrawInstances( object._multiDrawStarts, object._multiDrawCounts, object._multiDrawCount, object._multiDrawInstances );
+
+			} else {
+
+				renderer.renderMultiDraw( object._multiDrawStarts, object._multiDrawCounts, object._multiDrawCount );
+
+			}
 
 		} else if ( instanceCount > 1 ) {
 

--- a/examples/jsm/renderers/webgl/WebGLBufferRenderer.js
+++ b/examples/jsm/renderers/webgl/WebGLBufferRenderer.js
@@ -91,6 +91,48 @@ class WebGLBufferRenderer {
 
 	}
 
+	renderMultiDrawInstances( starts, counts, drawCount, primcount ) {
+
+		const { extensions, mode, object, info } = this;
+
+		if ( drawCount === 0 ) return;
+
+		const extension = extensions.get( 'WEBGL_multi_draw' );
+
+		if ( extension === null ) {
+
+			for ( let i = 0; i < drawCount; i ++ ) {
+
+				this.renderInstances( starts[ i ], counts[ i ], primcount[ i ] );
+
+			}
+
+		} else {
+
+			if ( this.index !== 0 ) {
+
+				extension.multiDrawElementsInstancedWEBGL( mode, counts, 0, this.type, starts, 0, primcount, 0, drawCount );
+
+			} else {
+
+				extension.multiDrawArraysInstancedWEBGL( mode, starts, 0, counts, 0, primcount, 0, drawCount );
+
+			}
+
+			let elementCount = 0;
+
+			for ( let i = 0; i < drawCount; i ++ ) {
+
+				elementCount += counts[ i ];
+
+			}
+
+			info.update( object, elementCount, mode, primcount );
+
+		}
+
+	}
+
 	//
 
 }


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/27937

**Description**

This fix addresses an issue where the batching matrices should be applied before the instancing matrices. It also introduces support for `multiDrawElementsInstancedWEBGL` and `multiDrawArraysInstancedWEBGL`, which offer comparable functionality to the basic multiDraw methods and have the same browser support (95%+).

The `WebGPURenderer` and `Nodes` makes this combination pretty straightforward to achieve and works on both backends, for example this scene is rendered in a single draw call:
<img width="1716" alt="image" src="https://github.com/mrdoob/three.js/assets/15867665/71da43a5-fc43-4989-96d9-6a0671a2a878">


This enhancement also aims to provide guidance for the `WebGLRenderer`, for example with `renderMultiDrawInstances`.
In the future, we might witness the introduction of an `InstancedBatchMesh` or some improvements to the `BatchMesh`. The current implementation of `BatchMesh` inefficiently allocates excessive memory by redundantly replicating geometries instead of utilizing a Map for referencing and instancing them.
That said, these changes extend to a much wider scope which I do not plan to explore any time soon, unless a bounty or a similar incentive is provided, allowing me the time to do so.


*This contribution is funded by [Utsubo](https://utsubo.com)*