### PR TITLE
InstancedMesh: Add clone and dispose method for `morphTexture`

### DIFF
--- a/examples/jsm/nodes/accessors/MorphNode.js
+++ b/examples/jsm/nodes/accessors/MorphNode.js
@@ -190,7 +190,7 @@ class MorphNode extends Node {
 
 			const influence = float( 0 ).toVar();
 
-			if ( this.mesh.isInstancedMesh === true && this.mesh.morphTexture !== null ) {
+			if ( this.mesh.isInstancedMesh === true && ( this.mesh.morphTexture !== null && this.mesh.morphTexture !== undefined ) ) {
 
 				influence.assign( textureLoad( this.mesh.morphTexture, ivec2( int( i ).add( 1 ), int( instanceIndex ) ) ).r );
 

--- a/examples/webgpu_parallax_uv.html
+++ b/examples/webgpu_parallax_uv.html
@@ -109,7 +109,7 @@
 
 				// renderer
 
-				renderer = new WebGPURenderer( { antialias: true, forceWebGL: false } );
+				renderer = new WebGPURenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setAnimationLoop( animate );

--- a/src/objects/InstancedMesh.js
+++ b/src/objects/InstancedMesh.js
@@ -259,6 +259,8 @@ class InstancedMesh extends Mesh {
 
 	dispose() {
 
+		this.dispatchEvent( { type: 'dispose' } );
+
 		if ( this.morphTexture !== null ) {
 
 			this.morphTexture.dispose();

--- a/src/objects/InstancedMesh.js
+++ b/src/objects/InstancedMesh.js
@@ -109,6 +109,7 @@ class InstancedMesh extends Mesh {
 
 		this.instanceMatrix.copy( source.instanceMatrix );
 
+		if ( source.morphTexture !== null ) this.morphTexture = source.morphTexture.clone();
 		if ( source.instanceColor !== null ) this.instanceColor = source.instanceColor.clone();
 
 		this.count = source.count;

--- a/src/objects/InstancedMesh.js
+++ b/src/objects/InstancedMesh.js
@@ -259,7 +259,14 @@ class InstancedMesh extends Mesh {
 
 	dispose() {
 
-		this.dispatchEvent( { type: 'dispose' } );
+		if ( this.morphTexture !== null ) {
+
+			this.morphTexture.dispose();
+			this.morphTexture = null;
+
+		}
+
+		return this;
 
 	}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/27928 https://github.com/mrdoob/three.js/pull/27669 https://github.com/mrdoob/three.js/pull/27768

**Description**
WebGLRenderer: The copy method wasn't cloning the new `morphTexture` DataTexture and the texture was never cleaned when the `InstancedMesh` disposed.

WebGPURenderer: When using nodes, it is possible to create instanced skinning meshes with morph targets. In such cases, `morphTexture` is `undefined`. This update also includes a cleanup of missing code in an example.

*This contribution is funded by [Utsubo](https://utsubo.com)*
