### PR TITLE
HTMLMesh: do not render the script tag

### DIFF
--- a/examples/jsm/interactive/HTMLMesh.js
+++ b/examples/jsm/interactive/HTMLMesh.js
@@ -241,9 +241,11 @@ function html2canvas( element ) {
 
 	function drawElement( element, style ) {
 
-	        // Do not render invisible elements, comments and scripts.
-		if (element.nodeType === Node.COMMENT_NODE || element.nodeName === 'SCRIPT' || (element.style && element.style.display === 'none')) {
+		// Do not render invisible elements, comments and scripts.
+		if ( element.nodeType === Node.COMMENT_NODE || element.nodeName === 'SCRIPT' || ( element.style && element.style.display === 'none' ) ) {
+
 			return;
+
 		}
 
 		let x = 0, y = 0, width = 0, height = 0;

--- a/examples/jsm/interactive/HTMLMesh.js
+++ b/examples/jsm/interactive/HTMLMesh.js
@@ -241,6 +241,11 @@ function html2canvas( element ) {
 
 	function drawElement( element, style ) {
 
+	        // Do not render invisible elements, comments and scripts.
+		if (element.nodeType === Node.COMMENT_NODE || element.nodeName === 'SCRIPT' || (element.style && element.style.display === 'none')) {
+			return;
+		}
+
 		let x = 0, y = 0, width = 0, height = 0;
 
 		if ( element.nodeType === Node.TEXT_NODE ) {
@@ -258,14 +263,9 @@ function html2canvas( element ) {
 
 			drawText( style, x, y, element.nodeValue.trim() );
 
-		} else if ( element.nodeType === Node.COMMENT_NODE ) {
-
-			return;
-
 		} else if ( element instanceof HTMLCanvasElement ) {
 
 			// Canvas element
-			if ( element.style.display === 'none' ) return;
 
 			const rect = element.getBoundingClientRect();
 
@@ -280,8 +280,6 @@ function html2canvas( element ) {
 
 		} else if ( element instanceof HTMLImageElement ) {
 
-			if ( element.style.display === 'none' ) return;
-
 			const rect = element.getBoundingClientRect();
 
 			x = rect.left - offset.left - 0.5;
@@ -292,8 +290,6 @@ function html2canvas( element ) {
 			context.drawImage( element, x, y, width, height );
 
 		} else {
-
-			if ( element.style.display === 'none' ) return;
 
 			const rect = element.getBoundingClientRect();
 


### PR DESCRIPTION
**Description**

Dear maintainers,

in the following proposed change I add the "script" tag to those that are not rendered on the HTML mesh.

In my use case, I have some dynamic HTML which may end up containing some javascript code. So far, this code would be rendered as text together with the mesh, which is not the expected behavior IMO.

I have also taken the chance to cleanup some duplication and move all of the "skipping" logics in the function to the very beginning.

Thanks for any feedback on this

All the best

Antonio