### PR TITLE
Nodes: Introduce NodeBuilder.formatOperation

### DIFF
--- a/examples/jsm/nodes/Nodes.js
+++ b/examples/jsm/nodes/Nodes.js
@@ -38,7 +38,7 @@ import * as NodeUtils from './core/NodeUtils.js';
 export { NodeUtils };
 
 // math
-export { default as MathNode, PI, PI2, EPSILON, INFINITY, radians, degrees, exp, exp2, log, log2, sqrt, inverseSqrt, floor, ceil, normalize, fract, sin, cos, tan, asin, acos, atan, abs, sign, length, lengthSq, negate, oneMinus, dFdx, dFdy, round, reciprocal, trunc, fwidth, bitcast, atan2, min, max, mod, step, reflect, distance, difference, dot, cross, pow, pow2, pow3, pow4, transformDirection, mix, clamp, saturate, refract, smoothstep, faceForward, cbrt, all, any, equals } from './math/MathNode.js';
+export { default as MathNode, PI, PI2, EPSILON, INFINITY, radians, degrees, exp, exp2, log, log2, sqrt, inverseSqrt, floor, ceil, normalize, fract, sin, cos, tan, asin, acos, atan, abs, sign, length, lengthSq, negate, oneMinus, dFdx, dFdy, round, reciprocal, trunc, fwidth, bitcast, atan2, min, max, mod, step, reflect, distance, difference, dot, cross, pow, pow2, pow3, pow4, transformDirection, mix, clamp, saturate, refract, smoothstep, faceForward, cbrt, all, any } from './math/MathNode.js';
 
 export { default as OperatorNode, add, sub, mul, div, remainder, equal, lessThan, greaterThan, lessThanEqual, greaterThanEqual, and, or, not, xor, bitAnd, bitNot, bitOr, bitXor, shiftLeft, shiftRight } from './math/OperatorNode.js';
 export { default as CondNode, cond } from './math/CondNode.js';

--- a/examples/jsm/nodes/accessors/TextureSizeNode.js
+++ b/examples/jsm/nodes/accessors/TextureSizeNode.js
@@ -20,7 +20,7 @@ class TextureSizeNode extends Node {
 		const textureProperty = this.textureNode.build( builder, 'property' );
 		const levelNode = this.levelNode.build( builder, 'int' );
 
-		return builder.format( `${builder.getMethod( 'textureDimensions' )}( ${textureProperty}, ${levelNode} )`, this.getNodeType( builder ), output );
+		return builder.format( builder.formatOperation( '()', 'textureDimensions', [ textureProperty, levelNode ] ), this.getNodeType( builder ), output );
 
 	}
 

--- a/examples/jsm/nodes/code/FunctionCallNode.js
+++ b/examples/jsm/nodes/code/FunctionCallNode.js
@@ -74,8 +74,7 @@ class FunctionCallNode extends TempNode {
 		}
 
 		const functionName = functionNode.build( builder, 'property' );
-
-		return `${functionName}( ${params.join( ', ' )} )`;
+		return builder.formatOperation( '()', functionName, params );
 
 	}
 

--- a/examples/jsm/nodes/core/AssignNode.js
+++ b/examples/jsm/nodes/core/AssignNode.js
@@ -75,7 +75,7 @@ class AssignNode extends TempNode {
 			const sourceVar = builder.getVarFromNode( this, null, targetType );
 			const sourceProperty = builder.getPropertyName( sourceVar );
 
-			builder.addLineFlowCode( `${ sourceProperty } = ${ source }` );
+			builder.addLineFlowCode( builder.formatOperation( '=', sourceProperty, source ) );
 
 			const targetRoot = targetNode.node.context( { assign: true } ).build( builder );
 
@@ -83,7 +83,7 @@ class AssignNode extends TempNode {
 
 				const component = targetNode.components[ i ];
 
-				builder.addLineFlowCode( `${ targetRoot }.${ component } = ${ sourceProperty }[ ${ i } ]` );
+				builder.addLineFlowCode( builder.formatOperation( '=', `${ targetRoot }.${ component }`, `${ sourceProperty }[ ${ i } ]` ) );
 
 			}
 
@@ -95,7 +95,7 @@ class AssignNode extends TempNode {
 
 		} else {
 
-			snippet = `${ target } = ${ source }`;
+			snippet = builder.formatOperation( '=', target, source );
 
 			if ( output === 'void' || sourceType === 'void' ) {
 

--- a/examples/jsm/nodes/core/NodeBuilder.js
+++ b/examples/jsm/nodes/core/NodeBuilder.js
@@ -957,12 +957,6 @@ class NodeBuilder {
 
 	}
 
-	getFunctionOperator() {
-
-		return null;
-
-	}
-
 	flowChildNode( node, output = null ) {
 
 		const previousFlow = this.flow;

--- a/examples/jsm/nodes/core/NodeBuilder.js
+++ b/examples/jsm/nodes/core/NodeBuilder.js
@@ -7,6 +7,7 @@ import NodeKeywords from './NodeKeywords.js';
 import NodeCache from './NodeCache.js';
 import ParameterNode from './ParameterNode.js';
 import FunctionNode from '../code/FunctionNode.js';
+import CodeNode from '../code/CodeNode.js';
 import { createNodeMaterialFromType, default as NodeMaterial } from '../materials/NodeMaterial.js';
 import { NodeUpdateType, defaultBuildStages, shaderStages } from './constants.js';
 
@@ -265,12 +266,6 @@ class NodeBuilder {
 
 	}
 
-	getMethod( method ) {
-
-		return method;
-
-	}
-
 	getNodeFromHash( hash ) {
 
 		return this.hashNodes[ hash ];
@@ -374,7 +369,6 @@ class NodeBuilder {
 		if ( type === 'int' ) return `${ Math.round( value ) }`;
 		if ( type === 'uint' ) return value >= 0 ? `${ Math.round( value ) }u` : '0u';
 		if ( type === 'bool' ) return value ? 'true' : 'false';
-		if ( type === 'color' ) return `${ this.getType( 'vec3' ) }( ${ toFloat( value.r ) }, ${ toFloat( value.g ) }, ${ toFloat( value.b ) } )`;
 
 		const typeLength = this.getTypeLength( type );
 
@@ -382,25 +376,17 @@ class NodeBuilder {
 
 		const generateConst = value => this.generateConst( componentType, value );
 
-		if ( typeLength === 2 ) {
+		if ( typeLength >= 2 && typeLength <= 4 ) {
 
-			return `${ this.getType( type ) }( ${ generateConst( value.x ) }, ${ generateConst( value.y ) } )`;
-
-		} else if ( typeLength === 3 ) {
-
-			return `${ this.getType( type ) }( ${ generateConst( value.x ) }, ${ generateConst( value.y ) }, ${ generateConst( value.z ) } )`;
-
-		} else if ( typeLength === 4 ) {
-
-			return `${ this.getType( type ) }( ${ generateConst( value.x ) }, ${ generateConst( value.y ) }, ${ generateConst( value.z ) }, ${ generateConst( value.w ) } )`;
+			return this.formatOperation( '()', this.getType( type ), [ ...value ].map( generateConst ) );
 
 		} else if ( typeLength > 4 && value && ( value.isMatrix3 || value.isMatrix4 ) ) {
 
-			return `${ this.getType( type ) }( ${ value.elements.map( generateConst ).join( ', ' ) } )`;
+			return this.formatOperation( '()', this.getType( type ), value.elements.map( generateConst ) );
 
 		} else if ( typeLength > 4 ) {
 
-			return `${ this.getType( type ) }()`;
+			return this.formatOperation( '()', this.getType( type ) );
 
 		}
 
@@ -599,6 +585,42 @@ class NodeBuilder {
 		if ( componentType === 'int' || componentType === 'uint' ) return type;
 
 		return this.changeComponentType( type, 'int' );
+
+	}
+
+	_getPolyfills() {
+
+		return {};
+
+	}
+
+	_resolvePolyfill( name, type = null ) {
+
+		return this._getPolyfills()[ name + '_' + type ] ? `threejs_${ name }_${ type }` : `threejs_${ name }`;
+
+	}
+
+	_include( name, type = null ) {
+
+		const polyfills = this._getPolyfills();
+
+		if ( typeof polyfills[ name ] === 'function' && type !== null && ! polyfills[ name + '_' + type ] ) { // auto-generate polyfill for the required type
+
+			polyfills[ name + '_' + type ] = new CodeNode( polyfills[ name ]( `threejs_${ name }_${ type }`, this.getType( type ) ) );
+
+		}
+
+		const codeNode = polyfills[ name + '_' + type ] || polyfills[ name ];
+
+		codeNode.build( this );
+
+		if ( this.currentFunctionNode !== null ) {
+
+			this.currentFunctionNode.includes.push( codeNode );
+
+		}
+
+		return codeNode;
 
 	}
 
@@ -1209,25 +1231,25 @@ class NodeBuilder {
 
 		if ( fromTypeLength === toTypeLength ) {
 
-			return `${ this.getType( toType ) }( ${ snippet } )`;
+			return this.formatOperation( '()', this.getType( toType ), snippet );
 
 		}
 
 		if ( fromTypeLength > toTypeLength ) {
 
-			return this.format( `${ snippet }.${ 'xyz'.slice( 0, toTypeLength ) }`, this.getTypeFromLength( toTypeLength, this.getComponentType( fromType ) ), toType );
+			return this.format( this.formatOperation( '.', snippet, 'xyz'.slice( 0, toTypeLength ) ), this.getTypeFromLength( toTypeLength, this.getComponentType( fromType ) ), toType );
 
 		}
 
 		if ( toTypeLength === 4 && fromTypeLength > 1 ) { // toType is vec4-like
 
-			return `${ this.getType( toType ) }( ${ this.format( snippet, fromType, 'vec3' ) }, 1.0 )`;
+			return this.formatOperation( '()', this.getType( toType ), [ this.format( snippet, fromType, 'vec3' ), '1.0' ] );
 
 		}
 
 		if ( fromTypeLength === 2 ) { // fromType is vec2-like and toType is vec3-like
 
-			return `${ this.getType( toType ) }( ${ this.format( snippet, fromType, 'vec2' ) }, 0.0 )`;
+			return this.formatOperation( '()', this.getType( toType ), [ this.format( snippet, fromType, 'vec2' ), '0.0' ] );
 
 		}
 
@@ -1236,11 +1258,259 @@ class NodeBuilder {
 			// convert a number value to vector type, e.g:
 			// vec3( 1u ) -> vec3( float( 1u ) )
 
-			snippet = `${ this.getType( this.getComponentType( toType ) ) }( ${ snippet } )`;
+			snippet = this.formatOperation( '()', this.getType( this.getComponentType( toType ) ), snippet );
 
 		}
 
-		return `${ this.getType( toType ) }( ${ snippet } )`; // fromType is float-like
+		return this.formatOperation( '()', this.getType( toType ), snippet ); // fromType is float-like
+
+	}
+
+	_parseTopLevel( str ) {
+
+		const operators = [ ',', '.', '~', '!', '++', '--', '+', '-', '*', '/', '%', '<<', '>>', '<', '>', '<=', '>=', '==', '!=', '&', '^', '|', '&&', '^^', '||' ];
+
+		const list = [];
+		let level = 0;
+
+		for ( let i = 0; i < str.length; i ++ ) {
+
+			let opData = null;
+
+			if ( str[ i ] === '(' || str[ i ] === '[' ) {
+
+				level ++;
+
+			} else if ( str[ i ] === ')' || str[ i ] === ']' ) {
+
+				level --;
+
+			} else if ( level === 0 && operators.includes( str[ i ] + str[ i + 1 ] ) ) {
+
+				opData = { start: i, end: i + 2, op: str[ i ] + str[ i + 1 ] };
+				i ++;
+
+			} else if ( level === 0 && operators.includes( str[ i ] ) ) {
+
+				opData = { start: i, end: i + 1, op: str[ i ] };
+
+			}
+
+			if ( opData === null ) continue;
+
+			// not an operator, a part of type
+			// @TODO: move this to WGSLNodeBuilder?
+			if ( opData.op === '<' && [ 'f32', 'i32', 'u32', 'bool' ].includes( str.slice( opData.start + 1, str.indexOf( '>', opData.start ) ) ) ) continue;
+			if ( opData.op === '>' && [ 'f32', 'i32', 'u32', 'bool' ].includes( str.slice( str.lastIndexOf( '<', opData.start ) + 1, opData.start ) ) ) continue;
+
+			const lastEnd = list.length > 0 ? list[ list.length - 1 ].end : 0;
+			const arg = str.slice( lastEnd, opData.start );
+			const argNonEmpty = [ ...arg ].some( x => x !== ' ' );
+
+			if ( argNonEmpty === true ) {
+
+				list.push( { start: lastEnd, end: opData.start, arg } );
+
+			} else {
+
+				// if we have two operators in row (or one directly in the start) and the previous one is not unary, mark this one as unary
+				if ( list.length === 0 || ! list[ list.length - 1 ].unary ) opData.unary = true;
+
+			}
+
+			if ( opData.op === '++' || opData.op === '--' ) {
+
+				opData.unary = true;
+
+				if ( argNonEmpty ) opData.postfix = true;
+				else opData.prefix = true;
+
+			}
+
+			list.push( opData );
+
+		}
+
+		const lastEnd = list.length > 0 ? list[ list.length - 1 ].end : 0;
+		const arg = str.slice( lastEnd );
+		if ( [ ...arg ].some( x => x !== ' ' ) ) list.push( { start: lastEnd, end: str.length, arg } );
+
+		return list;
+
+	}
+
+	_getOperators() {
+
+		console.warn( 'Abstract function.' );
+
+	}
+
+	formatOperation( op, arg1, arg2, output = null ) {
+
+		const languageOperators = this._getOperators(); // @TODO: make this just a static property
+
+		if ( op === '()' && languageOperators.replace[ arg1 + '()' ] !== undefined ) { // change function
+
+			if ( ! languageOperators.replace[ arg1 + '()' ].endsWith( '()' ) ) { // function -> op
+
+				op = languageOperators.replace[ arg1 + '()' ];
+				arg1 = arg2;
+
+				const argParsed = this._parseTopLevel( arg1 );
+				const comma = argParsed.find( arg => arg.op === ',' );
+
+				if ( comma !== undefined ) {
+
+					arg2 = arg1.slice( comma.end ).trimLeft();
+					arg1 = arg1.slice( 0, comma.start ).trimRight();
+
+				}
+
+			} else { // function -> function
+
+				arg1 = languageOperators.replace[ arg1 + '()' ].slice( 0, - 2 );
+
+			}
+
+		}
+
+		if ( languageOperators.replace[ op ] !== undefined ) { // change operator
+
+			if ( languageOperators.replace[ op ].endsWith( '()' ) ) { // op -> function
+
+				if ( output !== null && this.getTypeLength( output ) > 1 ) {
+
+					arg2 = [ arg1, arg2 ];
+					arg1 = languageOperators.replace[ op ].slice( 0, - 2 );
+					op = '()';
+
+				}
+
+			} else { // op -> op
+
+				op = languageOperators.replace[ op ];
+
+			}
+
+		}
+
+		if ( op === '()' && arg1.startsWith( 'threejs_' ) ) { // include function polyfill
+
+			this._include( arg1.slice( 'threejs_'.length ), output );
+			arg1 = this._resolvePolyfill( arg1.slice( 'threejs_'.length ), output );
+
+		}
+
+		if ( arg2 === undefined && ! op.startsWith( 'pre' ) && ! op.startsWith( 'post' ) ) op = 'un' + op;
+
+		const inversePrecedence = languageOperators.ops;
+
+		const precedence = {};
+		for ( let i = 0; i < inversePrecedence.length; i ++ ) {
+
+			for ( const op of inversePrecedence[ i ].ops ) {
+
+				precedence[ op ] = { prec: i, maxAllowed: inversePrecedence[ i ].maxPrec, allowEqual: inversePrecedence[ i ].allowSelf };
+
+			}
+
+		}
+
+		const operators = inversePrecedence.map( x => x.ops ).flat();
+
+		if ( ! operators.includes( op ) || op === ',' ) {
+
+			console.warn( `${ this.constructor.name }: Operator ${ op } is not supported.` );
+
+		}
+
+		if ( Array.isArray( arg2 ) ) arg2 = arg2.join( ', ' );
+
+		if ( op === '()' || op === '[]' ) {
+
+			if ( arg2 === undefined ) arg2 = '';
+			if ( arg2 !== '' ) arg2 = ` ${ arg2 } `;
+			return `${ arg1 }${ op[ 0 ] }${ arg2 }${ op[ 1 ] }`;
+
+		}
+
+		const arg1Parsed = this._parseTopLevel( arg1 );
+		const arg2Parsed = arg2 !== undefined ? this._parseTopLevel( arg2 ) : [];
+
+		if ( op === '=' && arg2.startsWith( arg1 ) ) {
+
+			const rhsOp = arg2Parsed.find( arg => !! arg.op && arg.start >= arg1.length );
+
+			if ( rhsOp === undefined ) { // dummy assignment
+
+				return '';
+
+			}
+
+			if ( rhsOp.op !== '<' && rhsOp.op !== '>' && operators.includes( rhsOp.op + '=' ) ) { // use assignment statement
+
+				op = rhsOp.op + '=';
+				arg2 = arg2.slice( rhsOp.end ).trimLeft();
+
+				if ( arg2.startsWith( '(' ) && arg2.endsWith( ')' ) ) { // RHS' second argument could be wrapped in brackets
+
+					let i, diff = 0;
+
+					for ( i = 0; i < arg2.length; i ++ ) {
+
+						if ( arg2[ i ] === '(' ) diff ++;
+						if ( arg2[ i ] === ')' ) diff --;
+
+						if ( diff === 0 ) break;
+
+					}
+
+					if ( i === arg2.length - 1 ) arg2 = arg2.slice( 1, - 1 ).trim(); // the brackets are indeed outmost, remove them
+
+				}
+
+			}
+
+		}
+
+		const cannotAssociate = left => data => {
+
+			if ( ! data.op ) return false;
+
+			return precedence[ data.op ].prec > precedence[ op ].prec ||
+			       ( precedence[ data.op ].prec > precedence[ op ].maxAllowed && precedence[ data.op ].prec !== precedence[ op ].prec ) ||
+				   ( precedence[ data.op ].prec === precedence[ op ].prec && precedence[ op ].allowEqual === false ) ||
+				   ( precedence[ data.op ].prec === precedence[ op ].prec && left === false && // assuming left-to-right associativity for all binary operators
+				       ! ( ( ( data.op === op ) && [ '&&', '||', '^^', '&', '|', '^' ].includes( op ) ) || [ '+', '[]', '()' ].includes( op ) ) // operators that do allow RTL associativity with same-precedence operators
+										// TODO: if we could somehow determine whether * is used in context of mat * mat/vec or component-wise multiplication, we could use it in the second list (only in the second context)
+				   );
+
+		};
+
+		if ( arg1Parsed.some( cannotAssociate( true ) ) ) arg1 = `( ${ arg1 } )`;
+		if ( arg2Parsed.some( cannotAssociate( false ) ) ) arg2 = `( ${ arg2 } )`;
+
+		if ( op === '.' ) {
+
+			return `${ arg1 }.${ arg2 }`;
+
+		} else if ( op.startsWith( 'un' ) ) {
+
+			return `${ op.slice( 2 ) } ${ arg1 }`;
+
+		} else if ( op.startsWith( 'pre' ) ) {
+
+			return `${ op.slice( 3 ) } ${ arg1 }`;
+
+		} else if ( op.startsWith( 'post' ) ) {
+
+			return `${ arg1 } ${ op.slice( 4 ) }`;
+
+		} else {
+
+			return `${ arg1 } ${ op } ${ arg2 }`;
+
+		}
 
 	}
 

--- a/examples/jsm/nodes/core/NodeBuilder.js
+++ b/examples/jsm/nodes/core/NodeBuilder.js
@@ -1444,24 +1444,16 @@ class NodeBuilder {
 			if ( rhsOp.op !== '<' && rhsOp.op !== '>' && operators.includes( rhsOp.op + '=' ) ) { // use assignment statement
 
 				op = rhsOp.op + '=';
-				arg2 = arg2.slice( rhsOp.end ).trimLeft();
+				let newArg2 = arg2.slice( rhsOp.end ).trimLeft();
 
-				if ( arg2.startsWith( '(' ) && arg2.endsWith( ')' ) ) { // RHS' second argument could be wrapped in brackets
+				if ( newArg2.startsWith( '(' ) && newArg2.endsWith( ')' ) // RHS' second argument could be wrapped in brackets
+					 && arg2Parsed.find( arg => arg.start >= rhsOp.end ).end === arg2.length ) { // the brackets are indeed outmost, remove them
 
-					let i, diff = 0;
-
-					for ( i = 0; i < arg2.length; i ++ ) {
-
-						if ( arg2[ i ] === '(' ) diff ++;
-						if ( arg2[ i ] === ')' ) diff --;
-
-						if ( diff === 0 ) break;
-
-					}
-
-					if ( i === arg2.length - 1 ) arg2 = arg2.slice( 1, - 1 ).trim(); // the brackets are indeed outmost, remove them
+					newArg2 = newArg2.slice( 1, - 1 ).trim(); 
 
 				}
+
+				arg2 = newArg2;
 
 			}
 

--- a/examples/jsm/nodes/core/VarNode.js
+++ b/examples/jsm/nodes/core/VarNode.js
@@ -42,7 +42,7 @@ class VarNode extends Node {
 
 		const snippet = node.build( builder, nodeVar.type );
 
-		builder.addLineFlowCode( `${propertyName} = ${snippet}` );
+		builder.addLineFlowCode( builder.formatOperation( '=', propertyName, snippet ) );
 
 		return propertyName;
 

--- a/examples/jsm/nodes/math/MathNode.js
+++ b/examples/jsm/nodes/math/MathNode.js
@@ -57,13 +57,9 @@ class MathNode extends TempNode {
 
 			return 'vec3';
 
-		} else if ( method === MathNode.ALL ) {
+		} else if ( method === MathNode.ALL || method === MathNode.ANY ) {
 
 			return 'bool';
-
-		} else if ( method === MathNode.EQUALS ) {
-
-			return builder.changeComponentType( this.aNode.getNodeType( builder ), 'bool' );
 
 		} else if ( method === MathNode.MOD ) {
 

--- a/examples/jsm/nodes/math/MathNode.js
+++ b/examples/jsm/nodes/math/MathNode.js
@@ -114,7 +114,7 @@ class MathNode extends TempNode {
 
 		} else if ( method === MathNode.NEGATE ) {
 
-			return builder.format( '( - ' + a.build( builder, inputType ) + ' )', type, output );
+			return builder.format( builder.formatOperation( '-', a.build( builder, inputType ) ), type, output );
 
 		} else if ( method === MathNode.ONE_MINUS ) {
 
@@ -177,7 +177,7 @@ class MathNode extends TempNode {
 
 			}
 
-			return builder.format( `${ builder.getMethod( method, type ) }( ${params.join( ', ' )} )`, type, output );
+			return builder.format( builder.formatOperation( '()', method, params, type ), type, output );
 
 		}
 
@@ -205,7 +205,6 @@ class MathNode extends TempNode {
 
 MathNode.ALL = 'all';
 MathNode.ANY = 'any';
-MathNode.EQUALS = 'equals';
 
 MathNode.RADIANS = 'radians';
 MathNode.DEGREES = 'degrees';
@@ -270,7 +269,6 @@ export const PI2 = float( Math.PI * 2 );
 
 export const all = nodeProxy( MathNode, MathNode.ALL );
 export const any = nodeProxy( MathNode, MathNode.ANY );
-export const equals = nodeProxy( MathNode, MathNode.EQUALS );
 
 export const radians = nodeProxy( MathNode, MathNode.RADIANS );
 export const degrees = nodeProxy( MathNode, MathNode.DEGREES );
@@ -333,7 +331,6 @@ export const smoothstepElement = ( x, low, high ) => smoothstep( low, high, x );
 
 addNodeElement( 'all', all );
 addNodeElement( 'any', any );
-addNodeElement( 'equals', equals );
 
 addNodeElement( 'radians', radians );
 addNodeElement( 'degrees', degrees );

--- a/examples/jsm/nodes/math/OperatorNode.js
+++ b/examples/jsm/nodes/math/OperatorNode.js
@@ -51,11 +51,11 @@ class OperatorNode extends TempNode {
 
 			return builder.getIntegerType( typeA );
 
-		} else if ( op === '!' || op === '==' || op === '&&' || op === '||' || op === '^^' ) {
+		} else if ( op === '!' || op === '&&' || op === '||' || op === '^^' ) {
 
 			return 'bool';
 
-		} else if ( op === '<' || op === '>' || op === '<=' || op === '>=' ) {
+		} else if ( op === '<' || op === '>' || op === '<=' || op === '>=' || op === '==' || op === '!=' ) {
 
 			const typeLength = output ? builder.getTypeLength( output ) : Math.max( builder.getTypeLength( typeA ), builder.getTypeLength( typeB ) );
 
@@ -110,7 +110,7 @@ class OperatorNode extends TempNode {
 			typeA = aNode.getNodeType( builder );
 			typeB = typeof bNode !== 'undefined' ? bNode.getNodeType( builder ) : null;
 
-			if ( op === '<' || op === '>' || op === '<=' || op === '>=' || op === '==' ) {
+			if ( op === '<' || op === '>' || op === '<=' || op === '>=' || op === '==' || op === '!=' ) {
 
 				if ( builder.isVector( typeA ) ) {
 

--- a/examples/jsm/nodes/math/OperatorNode.js
+++ b/examples/jsm/nodes/math/OperatorNode.js
@@ -156,54 +156,8 @@ class OperatorNode extends TempNode {
 		const a = aNode.build( builder, typeA );
 		const b = typeof bNode !== 'undefined' ? bNode.build( builder, typeB ) : null;
 
-		const outputLength = builder.getTypeLength( output );
-		const fnOpSnippet = builder.getFunctionOperator( op );
-
-		if ( output !== 'void' ) {
-
-			if ( op === '<' && outputLength > 1 ) {
-
-				return builder.format( `${ builder.getMethod( 'lessThan' ) }( ${ a }, ${ b } )`, type, output );
-
-			} else if ( op === '<=' && outputLength > 1 ) {
-
-				return builder.format( `${ builder.getMethod( 'lessThanEqual' ) }( ${ a }, ${ b } )`, type, output );
-
-			} else if ( op === '>' && outputLength > 1 ) {
-
-				return builder.format( `${ builder.getMethod( 'greaterThan' ) }( ${ a }, ${ b } )`, type, output );
-
-			} else if ( op === '>=' && outputLength > 1 ) {
-
-				return builder.format( `${ builder.getMethod( 'greaterThanEqual' ) }( ${ a }, ${ b } )`, type, output );
-
-			} else if ( op === '!' || op === '~' ) {
-
-				return builder.format( `(${op}${a})`, typeA, output );
-
-			} else if ( fnOpSnippet ) {
-
-				return builder.format( `${ fnOpSnippet }( ${ a }, ${ b } )`, type, output );
-
-			} else {
-
-				return builder.format( `( ${ a } ${ op } ${ b } )`, type, output );
-
-			}
-
-		} else if ( typeA !== 'void' ) {
-
-			if ( fnOpSnippet ) {
-
-				return builder.format( `${ fnOpSnippet }( ${ a }, ${ b } )`, type, output );
-
-			} else {
-
-				return builder.format( `${ a } ${ op } ${ b }`, type, output );
-
-			}
-
-		}
+		const snippet = builder.formatOperation( op, a, b, type );
+		return builder.format( snippet, type, output );
 
 	}
 

--- a/examples/jsm/nodes/pmrem/PMREMUtils.js
+++ b/examples/jsm/nodes/pmrem/PMREMUtils.js
@@ -258,7 +258,7 @@ export const blur = tslFn( ( { n, latitudinal, poleAxis, outputDirection, weight
 
 	const axis = vec3( cond( latitudinal, poleAxis, cross( poleAxis, outputDirection ) ) ).toVar();
 
-	If( all( axis.equals( vec3( 0.0 ) ) ), () => {
+	If( all( axis.equal( vec3( 0.0 ) ) ), () => {
 
 		axis.assign( vec3( outputDirection.z, 0.0, outputDirection.x.negate() ) );
 

--- a/examples/jsm/nodes/utils/ArrayElementNode.js
+++ b/examples/jsm/nodes/utils/ArrayElementNode.js
@@ -24,7 +24,7 @@ class ArrayElementNode extends Node { // @TODO: If extending from TempNode it br
 		const nodeSnippet = this.node.build( builder );
 		const indexSnippet = this.indexNode.build( builder, 'uint' );
 
-		return `${nodeSnippet}[ ${indexSnippet} ]`;
+		return builder.formatOperation( '[]', nodeSnippet, indexSnippet );
 
 	}
 

--- a/examples/jsm/nodes/utils/JoinNode.js
+++ b/examples/jsm/nodes/utils/JoinNode.js
@@ -48,8 +48,7 @@ class JoinNode extends TempNode {
 
 		}
 
-		const snippet = `${ builder.getType( type ) }( ${ snippetValues.join( ', ' ) } )`;
-
+		const snippet = builder.formatOperation( '()', builder.getType( type ), snippetValues );
 		return builder.format( snippet, type, output );
 
 	}

--- a/examples/jsm/nodes/utils/SetNode.js
+++ b/examples/jsm/nodes/utils/SetNode.js
@@ -45,13 +45,13 @@ class SetNode extends TempNode {
 
 			} else {
 
-				snippetValues.push( sourceSnippet + '.' + component );
+				snippetValues.push( builder.formatOperation( '.', sourceSnippet, component ) );
 
 			}
 
 		}
 
-		return `${ builder.getType( sourceType ) }( ${ snippetValues.join( ', ' ) } )`;
+		return builder.formatOperation( '()', builder.getType( sourceType ), snippetValues.join( ', ' ) );
 
 	}
 

--- a/examples/jsm/nodes/utils/SplitNode.js
+++ b/examples/jsm/nodes/utils/SplitNode.js
@@ -73,7 +73,7 @@ class SplitNode extends Node {
 
 			} else {
 
-				snippet = builder.format( `${nodeSnippet}.${this.components}`, this.getNodeType( builder ), output );
+				snippet = builder.format( builder.formatOperation( '.', nodeSnippet, this.components ), this.getNodeType( builder ), output );
 
 			}
 

--- a/examples/jsm/renderers/webgl-legacy/nodes/GLSL1NodeBuilder.js
+++ b/examples/jsm/renderers/webgl-legacy/nodes/GLSL1NodeBuilder.js
@@ -1,9 +1,5 @@
 import { MathNode, GLSLNodeParser, NodeBuilder } from '../../../nodes/Nodes.js';
 
-const glslMethods = {
-	[ MathNode.ATAN2 ]: 'atan'
-};
-
 const precisionLib = {
 	low: 'lowp',
 	medium: 'mediump',
@@ -15,12 +11,6 @@ class GLSL1NodeBuilder extends NodeBuilder {
 	constructor( object, renderer, scene = null ) {
 
 		super( object, renderer, new GLSLNodeParser(), scene );
-
-	}
-
-	getMethod( method ) {
-
-		return glslMethods[ method ] || method;
 
 	}
 
@@ -310,6 +300,37 @@ void main() {
 			//this.computeShader = this._getGLSLComputeCode( shadersData.compute );
 
 		}
+
+	}
+
+	_getOperators() {
+
+		return { // https://www.khronos.org/files/opengles_shading_language.pdf, section 5.1
+			ops: [
+				{ ops: [ '[]', '()', '.', 'post++', 'post--' ], maxPrec: Infinity, allowSelf: true },
+				{ ops: [ 'pre++', 'pre--', 'un+', 'un-', 'un!' ], maxPrec: Infinity, allowSelf: true },
+				{ ops: [ '*', '/' ], maxPrec: Infinity, allowSelf: true },
+				{ ops: [ '+', '-' ], maxPrec: Infinity, allowSelf: true },
+				{ ops: [ '<', '>', '<=', '>=' ], maxPrec: Infinity, allowSelf: true },
+				{ ops: [ '==', '!=' ], maxPrec: Infinity, allowSelf: true },
+				{ ops: [ '&&' ], maxPrec: Infinity, allowSelf: true },
+				{ ops: [ '^^' ], maxPrec: Infinity, allowSelf: true },
+				{ ops: [ '||' ], maxPrec: Infinity, allowSelf: true },
+				{ ops: [ '=', '+=', '-=', '*=', '/=' ], maxPrec: Infinity, allowSelf: true },
+				{ ops: [ ',' ], maxPrec: Infinity, allowSelf: true }
+			],
+			replace: {
+				// section 5.9
+				'<': 'lessThan()',
+				'<=': 'lessThanEqual()',
+				'>': 'greaterThan()',
+				'>=': 'greaterThanEqual()',
+				'==': 'equal()',
+				'!=': 'notEqual()',
+
+				'atan2()': 'atan()'
+			}
+		};
 
 	}
 

--- a/examples/jsm/renderers/webgl-legacy/nodes/GLSL1NodeBuilder.js
+++ b/examples/jsm/renderers/webgl-legacy/nodes/GLSL1NodeBuilder.js
@@ -1,4 +1,4 @@
-import { MathNode, GLSLNodeParser, NodeBuilder } from '../../../nodes/Nodes.js';
+import { GLSLNodeParser, NodeBuilder } from '../../../nodes/Nodes.js';
 
 const precisionLib = {
 	low: 'lowp',

--- a/examples/jsm/renderers/webgl-legacy/nodes/WebGLNodeBuilder.js
+++ b/examples/jsm/renderers/webgl-legacy/nodes/WebGLNodeBuilder.js
@@ -1,4 +1,4 @@
-import { defaultShaderStages, NodeFrame, MathNode, GLSLNodeParser, NodeBuilder, normalView } from '../../../nodes/Nodes.js';
+import { defaultShaderStages, NodeFrame, GLSLNodeParser, NodeBuilder, normalView } from '../../../nodes/Nodes.js';
 import SlotNode from './SlotNode.js';
 import { PerspectiveCamera, ShaderChunk, ShaderLib, UniformsUtils, UniformsLib } from 'three';
 

--- a/examples/jsm/renderers/webgl-legacy/nodes/WebGLNodeBuilder.js
+++ b/examples/jsm/renderers/webgl-legacy/nodes/WebGLNodeBuilder.js
@@ -14,10 +14,6 @@ const nodeShaderLib = {
 	MeshPhongNodeMaterial: ShaderLib.phong
 };
 
-const glslMethods = {
-	[ MathNode.ATAN2 ]: 'atan'
-};
-
 const precisionLib = {
 	low: 'lowp',
 	medium: 'mediump',
@@ -50,12 +46,6 @@ class WebGLNodeBuilder extends NodeBuilder {
 		this._parseObject();
 
 		this._sortSlotsToFlow();
-
-	}
-
-	getMethod( method ) {
-
-		return glslMethods[ method ] || method;
 
 	}
 
@@ -784,6 +774,43 @@ ${this.shader[ getShaderStageProperty( shaderStage ) ]}
 			nodeFrame.updateNode( node );
 
 		}
+
+	}
+
+	_getOperators() {
+
+		return { // https://registry.khronos.org/OpenGL/specs/es/3.0/GLSL_ES_Specification_3.00.pdf, section 5.1
+			ops: [
+				{ ops: [ '[]', '()', '.', 'post++', 'post--' ], maxPrec: Infinity, allowSelf: true },
+				{ ops: [ 'pre++', 'pre--', 'un+', 'un-', 'un~', 'un!' ], maxPrec: Infinity, allowSelf: true },
+				{ ops: [ '*', '/', '%' ], maxPrec: Infinity, allowSelf: true },
+				{ ops: [ '+', '-' ], maxPrec: Infinity, allowSelf: true },
+				{ ops: [ '<<', '>>' ], maxPrec: Infinity, allowSelf: true },
+				{ ops: [ '<', '>', '<=', '>=' ], maxPrec: Infinity, allowSelf: true },
+				{ ops: [ '==', '!=' ], maxPrec: Infinity, allowSelf: true },
+				{ ops: [ '&' ], maxPrec: Infinity, allowSelf: true },
+				{ ops: [ '^' ], maxPrec: Infinity, allowSelf: true },
+				{ ops: [ '|' ], maxPrec: Infinity, allowSelf: true },
+				{ ops: [ '&&' ], maxPrec: Infinity, allowSelf: true },
+				{ ops: [ '^^' ], maxPrec: Infinity, allowSelf: true },
+				{ ops: [ '||' ], maxPrec: Infinity, allowSelf: true },
+				{ ops: [ '=', '+=', '-=', '*=', '/=', '%=', '<<=', '>>=', '&=', '^=', '|=' ], maxPrec: Infinity, allowSelf: true },
+				{ ops: [ ',' ], maxPrec: Infinity, allowSelf: true }
+			],
+			replace: {
+				// section 5.9
+				'<': 'lessThan()',
+				'<=': 'lessThanEqual()',
+				'>': 'greaterThan()',
+				'>=': 'greaterThanEqual()',
+				'==': 'equal()',
+				'!=': 'notEqual()',
+
+				// functions under different names
+				'atan2()': 'atan()',
+				'textureDimensions()': 'textureSize()'
+			}
+		};
 
 	}
 

--- a/examples/jsm/renderers/webgl/nodes/GLSLNodeBuilder.js
+++ b/examples/jsm/renderers/webgl/nodes/GLSLNodeBuilder.js
@@ -7,12 +7,6 @@ import { NodeSampledTexture, NodeSampledCubeTexture } from '../../common/nodes/N
 
 import { RedFormat, RGFormat, IntType, DataTexture, RGBAFormat, FloatType } from 'three';
 
-const glslMethods = {
-	[ MathNode.ATAN2 ]: 'atan',
-	textureDimensions: 'textureSize',
-	equals: 'equal'
-};
-
 const precisionLib = {
 	low: 'lowp',
 	medium: 'mediump',
@@ -39,12 +33,6 @@ class GLSLNodeBuilder extends NodeBuilder {
 
 		this.uniformGroups = {};
 		this.transforms = [];
-
-	}
-
-	getMethod( method ) {
-
-		return glslMethods[ method ] || method;
 
 	}
 
@@ -796,6 +784,43 @@ void main() {
 		}
 
 		return uniformNode;
+
+	}
+
+	_getOperators() {
+
+		return { // https://registry.khronos.org/OpenGL/specs/es/3.0/GLSL_ES_Specification_3.00.pdf, section 5.1
+			ops: [
+				{ ops: [ '[]', '()', '.', 'post++', 'post--' ], maxPrec: Infinity, allowSelf: true },
+				{ ops: [ 'pre++', 'pre--', 'un+', 'un-', 'un~', 'un!' ], maxPrec: Infinity, allowSelf: true },
+				{ ops: [ '*', '/', '%' ], maxPrec: Infinity, allowSelf: true },
+				{ ops: [ '+', '-' ], maxPrec: Infinity, allowSelf: true },
+				{ ops: [ '<<', '>>' ], maxPrec: Infinity, allowSelf: true },
+				{ ops: [ '<', '>', '<=', '>=' ], maxPrec: Infinity, allowSelf: true },
+				{ ops: [ '==', '!=' ], maxPrec: Infinity, allowSelf: true },
+				{ ops: [ '&' ], maxPrec: Infinity, allowSelf: true },
+				{ ops: [ '^' ], maxPrec: Infinity, allowSelf: true },
+				{ ops: [ '|' ], maxPrec: Infinity, allowSelf: true },
+				{ ops: [ '&&' ], maxPrec: Infinity, allowSelf: true },
+				{ ops: [ '^^' ], maxPrec: Infinity, allowSelf: true },
+				{ ops: [ '||' ], maxPrec: Infinity, allowSelf: true },
+				{ ops: [ '=', '+=', '-=', '*=', '/=', '%=', '<<=', '>>=', '&=', '^=', '|=' ], maxPrec: Infinity, allowSelf: true },
+				{ ops: [ ',' ], maxPrec: Infinity, allowSelf: true }
+			],
+			replace: {
+				// section 5.9
+				'<': 'lessThan()',
+				'<=': 'lessThanEqual()',
+				'>': 'greaterThan()',
+				'>=': 'greaterThanEqual()',
+				'==': 'equal()',
+				'!=': 'notEqual()',
+
+				// functions under different names
+				'atan2()': 'atan()',
+				'textureDimensions()': 'textureSize()'
+			}
+		};
 
 	}
 

--- a/examples/jsm/renderers/webgl/nodes/GLSLNodeBuilder.js
+++ b/examples/jsm/renderers/webgl/nodes/GLSLNodeBuilder.js
@@ -1,4 +1,4 @@
-import { MathNode, GLSLNodeParser, NodeBuilder, UniformNode, vectorComponents } from '../../../nodes/Nodes.js';
+import { GLSLNodeParser, NodeBuilder, UniformNode, vectorComponents } from '../../../nodes/Nodes.js';
 
 import NodeUniformBuffer from '../../common/nodes/NodeUniformBuffer.js';
 import NodeUniformsGroup from '../../common/nodes/NodeUniformsGroup.js';


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/27512

**Description**

This is (finally) the first PR of https://github.com/mrdoob/three.js/pull/27512 -- I started with this one because I think this is the most useful and simple feature of all included (I hope I will file other PRs soon).

This PR introduces a new NodeBuilder method for formatting operations and functions. This allows to not worry about enclosing operations in brackets anymore (as it was done in OperatorNode previously and caused many unneeded ones), allows to simplify polyfilling of missing in GLSL/WGSL operators and functions (now it can be done in basically one line; .getMethod() and .getFunctionOperator() are also not needed now), and as a bonus also allows auto-building something like `node.addAssign( node2 )` to `node += node2` (on the shader code generation step instead of node graph building, but I think in this case this is enough). I also removed `equals` element because it seems to be just a duplicate of already existing `equal`.
