### PR TITLE
3MFLoader: Throw error on missing rels.

### DIFF
--- a/examples/jsm/loaders/3MFLoader.js
+++ b/examples/jsm/loaders/3MFLoader.js
@@ -144,6 +144,8 @@ class ThreeMFLoader extends Loader {
 
 			}
 
+			if ( relsName === undefined ) throw new Error( 'THREE.ThreeMFLoader: Cannot find relationship file `rels` in 3MF archive.' );
+
 			//
 
 			const relsView = zip[ relsName ];
@@ -1435,9 +1437,6 @@ class ThreeMFLoader extends Loader {
 			const group = new Group();
 
 			const relationship = fetch3DModelPart( data3mf[ 'rels' ] );
-
-			if ( relationship === undefined ) throw new Error( 'THREE.ThreeMFLoader: Cannot find relationship file `rels` in 3MF archive.' );
-
 			const buildData = data3mf.model[ relationship[ 'target' ].substring( 1 ) ][ 'build' ];
 
 			for ( let i = 0; i < buildData.length; i ++ ) {

--- a/examples/jsm/loaders/3MFLoader.js
+++ b/examples/jsm/loaders/3MFLoader.js
@@ -1435,6 +1435,9 @@ class ThreeMFLoader extends Loader {
 			const group = new Group();
 
 			const relationship = fetch3DModelPart( data3mf[ 'rels' ] );
+
+			if ( relationship === undefined ) throw new Error( 'THREE.ThreeMFLoader: Cannot find relationship file `rels` in 3MF archive.' );
+
 			const buildData = data3mf.model[ relationship[ 'target' ].substring( 1 ) ][ 'build' ];
 
 			for ( let i = 0; i < buildData.length; i ++ ) {


### PR DESCRIPTION

Related issue: #27947 

**Description**

This throws an error in case the 3MF file is malformed and is missing the `rels` object. Otherwise, the error is a bit cryptic.
