### PR TITLE
AnimationClip: default constructor parameters

### DIFF
--- a/src/animation/AnimationClip.js
+++ b/src/animation/AnimationClip.js
@@ -11,7 +11,7 @@ import { NormalAnimationBlendMode } from '../constants.js';
 
 class AnimationClip {
 
-	constructor( name, duration = - 1, tracks, blendMode = NormalAnimationBlendMode ) {
+	constructor( name = '', duration = - 1, tracks = [], blendMode = NormalAnimationBlendMode ) {
 
 		this.name = name;
 		this.tracks = tracks;


### PR DESCRIPTION
Related issue: N/A

**Description**

This makes AnimationClip easier to use without providing initial arguments, f.e.

```js
const clip = new AnimationClip();

// ...any time later...
clip.tracks.push(...keyframeTracks)
clip.resetDuration()
```

The above code will currently throw because it tries to calculate duration based on nothing (tracks array is undefined).

Currently we have to do this,

```js
const clip = new AnimationClip('', -1, []);
```
or this,
```js
const clip = new AnimationClip('', 0);
clip.tracks = []
```
to successfully be able to do this:
```js
// ...any time later...
clip.tracks.push(...keyframeTracks)
clip.resetDuration()
```

Sidenote, this new signature happens to match with the type definition in `@types/three`.

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Lume (3D HTML)](https://lume.io)*
