### PR TITLE
CSSRenderer: add DEFAULT_MATRIX_WORLD_AUTO_UPDATE flag support

### DIFF
--- a/examples/jsm/renderers/CSS2DRenderer.js
+++ b/examples/jsm/renderers/CSS2DRenderer.js
@@ -90,8 +90,8 @@ class CSS2DRenderer {
 
 		this.render = function ( scene, camera ) {
 
-			if ( scene.matrixWorldAutoUpdate === true ) scene.updateMatrixWorld();
-			if ( camera.parent === null && camera.matrixWorldAutoUpdate === true ) camera.updateMatrixWorld();
+			if ( scene.matrixWorldAutoUpdate === true && CSS2DRenderer.DEFAULT_MATRIX_WORLD_AUTO_UPDATE ) scene.updateMatrixWorld();
+			if ( camera.parent === null && camera.matrixWorldAutoUpdate === true && CSS2DRenderer.DEFAULT_MATRIX_WORLD_AUTO_UPDATE ) camera.updateMatrixWorld();
 
 			_viewMatrix.copy( camera.matrixWorldInverse );
 			_viewProjectionMatrix.multiplyMatrices( camera.projectionMatrix, _viewMatrix );
@@ -211,5 +211,7 @@ class CSS2DRenderer {
 	}
 
 }
+
+CSS2DRenderer.DEFAULT_MATRIX_WORLD_AUTO_UPDATE = true;
 
 export { CSS2DObject, CSS2DRenderer };

--- a/examples/jsm/renderers/CSS3DRenderer.js
+++ b/examples/jsm/renderers/CSS3DRenderer.js
@@ -143,8 +143,8 @@ class CSS3DRenderer {
 
 			}
 
-			if ( scene.matrixWorldAutoUpdate === true ) scene.updateMatrixWorld();
-			if ( camera.parent === null && camera.matrixWorldAutoUpdate === true ) camera.updateMatrixWorld();
+			if ( scene.matrixWorldAutoUpdate === true && CSS3DRenderer.DEFAULT_MATRIX_WORLD_AUTO_UPDATE ) scene.updateMatrixWorld();
+			if ( camera.parent === null && camera.matrixWorldAutoUpdate === true && CSS3DRenderer.DEFAULT_MATRIX_WORLD_AUTO_UPDATE ) camera.updateMatrixWorld();
 
 			let tx, ty;
 
@@ -325,5 +325,7 @@ class CSS3DRenderer {
 	}
 
 }
+
+CSS3DRenderer.DEFAULT_MATRIX_WORLD_AUTO_UPDATE = true;
 
 export { CSS3DObject, CSS3DSprite, CSS3DRenderer };


### PR DESCRIPTION
**Description**

It's not a bug fix, just a small optimization.

The background context in my scene is I use WebGLRenderer, CSS3DRenderer and CSS2DRenderer together. I found my scene render slowly, so I make a performance profiling.

In my case, when the data became too large, updateMatrixWorld method will cost 10-20ms, maybe from optimization opinion, the first thing I should do is try to reduce draw calls, but after reading the source code, I found three renderer do the same thing in scene and camera object, It's right to ensure each renderer can work indenpently, but if I use them together, I need one way to turn off this behavior after the first renderer.

The performance profiling result:
![image](https://github.com/mrdoob/three.js/assets/20576218/f5ad7f2b-a3db-4b74-b779-871f19f4808b)

So I introduce a static property named DEFAULT_MATRIX_WORLD_AUTO_UPDATE in CSSRenderer(align to Object3D class).

If this pr will be approved, the next step I will do.
* add description about doc.
* add typescript declaration in @types/three pkg.

I don't know whether is right or worth, be happy to receive some advice.