### PR TITLE
Examples: Fix translation snap unit.

### DIFF
--- a/examples/misc_controls_transform.html
+++ b/examples/misc_controls_transform.html
@@ -100,7 +100,7 @@
 							break;
 
 						case 16: // Shift
-							control.setTranslationSnap( 100 );
+							control.setTranslationSnap( 1 );
 							control.setRotationSnap( THREE.MathUtils.degToRad( 15 ) );
 							control.setScaleSnap( 0.25 );
 							break;


### PR DESCRIPTION
Related issue: #26280

**Description**

When the units in #26280 where updated to a real-world scale in `misc_controls_transform`, I have missed to update the translation snap value for `TransformControls`.
