### PR TITLE
TransformControls: Fix `updateMatrixWorld()` override.

### DIFF
--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -178,8 +178,8 @@ class TransformControls extends Object3D {
 
 	}
 
-	// updateMatrixWorld  updates key transformation variables
-	updateMatrixWorld() {
+	// updateMatrixWorld updates key transformation variables
+	updateMatrixWorld( force ) {
 
 		if ( this.object !== undefined ) {
 
@@ -215,7 +215,7 @@ class TransformControls extends Object3D {
 
 		}
 
-		super.updateMatrixWorld( this );
+		super.updateMatrixWorld( force );
 
 	}
 


### PR DESCRIPTION
Related issue: -

**Description**

The implementation of `updateMatrixWorld()` in `TransformControls` has a wrong signature and calls the parent method with a invalid argument.
