### PR TITLE
support updating only dirty `CompressedArrayTexture` layers

### DIFF
--- a/docs/api/en/textures/CompressedArrayTexture.html
+++ b/docs/api/en/textures/CompressedArrayTexture.html
@@ -61,6 +61,20 @@
 		<h3>[property:Object image]</h3>
 		<p>Overridden with a object containing width, height, and depth.</p>
 
+		<h3>[property:Boolean layerNeedsUpdate]</h3>
+		<p>
+			Specifies that a specific layer of the texture needs to be updated. Unlike
+			[page:Texture.needsUpdate needsUpdate] which sends the entire compressed
+			texture array to the GPU, marking specific layers will only transmit
+			subsets of all mipmaps associated with a specific depth in the array.
+		</p>
+
+		<h3>[property:Array dirtyLayers]</h3>
+		<p>
+			A list of all dirty layers in the texture. See
+			[Page:CompressedTextureArray.layerNeedsUpdate layerNeedsUpdate].
+		</p>
+
 		<h3>[property:Boolean isCompressedArrayTexture]</h3>
 		<p>Read-only flag to check if a given object is of type [name].</p>
 

--- a/docs/api/en/textures/CompressedArrayTexture.html
+++ b/docs/api/en/textures/CompressedArrayTexture.html
@@ -61,18 +61,10 @@
 		<h3>[property:Object image]</h3>
 		<p>Overridden with a object containing width, height, and depth.</p>
 
-		<h3>[property:Boolean layerNeedsUpdate]</h3>
+		<h3>[property:Set dirtyLayers]</h3>
 		<p>
-			Specifies that a specific layer of the texture needs to be updated. Unlike
-			[page:Texture.needsUpdate needsUpdate] which sends the entire compressed
-			texture array to the GPU, marking specific layers will only transmit
-			subsets of all mipmaps associated with a specific depth in the array.
-		</p>
-
-		<h3>[property:Array dirtyLayers]</h3>
-		<p>
-			A list of all dirty layers in the texture. See
-			[Page:CompressedTextureArray.layerNeedsUpdate layerNeedsUpdate].
+			A set of all dirty layers in the texture. See
+			[Page:CompressedTextureArray.addDirtyLayer addDirtyLayer].
 		</p>
 
 		<h3>[property:Boolean isCompressedArrayTexture]</h3>
@@ -80,9 +72,19 @@
 
 		<h2>Methods</h2>
 
+		<h3>[method:addDirtyLayer addDirtyLayer]( layerIndex )</h3>
 		<p>
-			See the base [page:CompressedTexture CompressedTexture] class for common
-			methods.
+			Describes that a specific layer of the texture needs to be updated.
+			Normally when [page:Texture.needsUpdate needsUpdate] is set to true, the
+			entire compressed texture array is sent to the GPU. Marking specific
+			layers will only transmit subsets of all mipmaps associated with a
+			specific depth in the array which is often much more performant. 
+		</p>
+
+		<h3>[method:clearDirtyLayers clearDirtyLayers]()</h3>
+		<p>
+			Resets the dirty layers registry. See
+			[Page:CompressedTextureArray.addDirtyLayer addDirtyLayer].
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/en/textures/CompressedArrayTexture.html
+++ b/docs/api/en/textures/CompressedArrayTexture.html
@@ -61,10 +61,10 @@
 		<h3>[property:Object image]</h3>
 		<p>Overridden with a object containing width, height, and depth.</p>
 
-		<h3>[property:Set dirtyLayers]</h3>
+		<h3>[property:Set layerUpdates]</h3>
 		<p>
-			A set of all dirty layers in the texture. See
-			[Page:CompressedTextureArray.addDirtyLayer addDirtyLayer].
+			A set of all layers which need to be updated in the texture. See
+			[Page:CompressedTextureArray.addLayerUpdate addLayerUpdate].
 		</p>
 
 		<h3>[property:Boolean isCompressedArrayTexture]</h3>
@@ -72,7 +72,7 @@
 
 		<h2>Methods</h2>
 
-		<h3>[method:addDirtyLayer addDirtyLayer]( layerIndex )</h3>
+		<h3>[method:addLayerUpdate addLayerUpdate]( layerIndex )</h3>
 		<p>
 			Describes that a specific layer of the texture needs to be updated.
 			Normally when [page:Texture.needsUpdate needsUpdate] is set to true, the
@@ -81,10 +81,10 @@
 			specific depth in the array which is often much more performant.
 		</p>
 
-		<h3>[method:clearDirtyLayers clearDirtyLayers]()</h3>
+		<h3>[method:clearLayerUpdates clearLayerUpdates]()</h3>
 		<p>
-			Resets the dirty layers registry. See
-			[Page:CompressedTextureArray.addDirtyLayer addDirtyLayer].
+			Resets the layer updates registry. See
+			[Page:CompressedTextureArray.addLayerUpdate addLayerUpdate].
 		</p>
 
 		<p>

--- a/docs/api/en/textures/CompressedArrayTexture.html
+++ b/docs/api/en/textures/CompressedArrayTexture.html
@@ -78,13 +78,18 @@
 			Normally when [page:Texture.needsUpdate needsUpdate] is set to true, the
 			entire compressed texture array is sent to the GPU. Marking specific
 			layers will only transmit subsets of all mipmaps associated with a
-			specific depth in the array which is often much more performant. 
+			specific depth in the array which is often much more performant.
 		</p>
 
 		<h3>[method:clearDirtyLayers clearDirtyLayers]()</h3>
 		<p>
 			Resets the dirty layers registry. See
 			[Page:CompressedTextureArray.addDirtyLayer addDirtyLayer].
+		</p>
+
+		<p>
+			See the base [page:CompressedTexture CompressedTexture] class for common
+			methods.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/en/textures/DataArrayTexture.html
+++ b/docs/api/en/textures/DataArrayTexture.html
@@ -143,7 +143,29 @@
 			page for details.
 		</p>
 
+		<h3>[property:Set dirtyLayers]</h3>
+		<p>
+			A set of all dirty layers in the texture. See
+			[Page:DataArrayTexture.addDirtyLayer addDirtyLayer].
+		</p>
+
 		<h2>Methods</h2>
+
+		<h3>[method:addDirtyLayer addDirtyLayer]( layerIndex )</h3>
+		<p>
+			Describes that a specific layer of the texture needs to be updated.
+			Normally when [page:Texture.needsUpdate needsUpdate] is set to true, the
+			entire compressed texture array is sent to the GPU. Marking specific
+			layers will only transmit subsets of all mipmaps associated with a
+			specific depth in the array which is often much more performant.
+		</p>
+
+		<h3>[method:clearDirtyLayers clearDirtyLayers]()</h3>
+		<p>
+			Resets the dirty layers registry. See
+			[Page:DataArrayTexture.addDirtyLayer addDirtyLayer].
+		</p>
+
 
 		<p>See the base [page:Texture Texture] class for common methods.</p>
 

--- a/docs/api/en/textures/DataArrayTexture.html
+++ b/docs/api/en/textures/DataArrayTexture.html
@@ -143,15 +143,15 @@
 			page for details.
 		</p>
 
-		<h3>[property:Set dirtyLayers]</h3>
+		<h3>[property:Set layerUpdates]</h3>
 		<p>
-			A set of all dirty layers in the texture. See
-			[Page:DataArrayTexture.addDirtyLayer addDirtyLayer].
+			A set of all layers which need to be updated in the texture. See
+			[Page:DataArrayTexture.addLayerUpdate addLayerUpdate].
 		</p>
 
 		<h2>Methods</h2>
 
-		<h3>[method:addDirtyLayer addDirtyLayer]( layerIndex )</h3>
+		<h3>[method:addLayerUpdate addLayerUpdate]( layerIndex )</h3>
 		<p>
 			Describes that a specific layer of the texture needs to be updated.
 			Normally when [page:Texture.needsUpdate needsUpdate] is set to true, the
@@ -160,10 +160,10 @@
 			specific depth in the array which is often much more performant.
 		</p>
 
-		<h3>[method:clearDirtyLayers clearDirtyLayers]()</h3>
+		<h3>[method:clearLayerUpdates clearLayerUpdates]()</h3>
 		<p>
-			Resets the dirty layers registry. See
-			[Page:DataArrayTexture.addDirtyLayer addDirtyLayer].
+			Resets the layer updates registry. See
+			[Page:DataArrayTexture.addLayerUpdate addLayerUpdate].
 		</p>
 
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -820,16 +820,16 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 									if ( dataReady ) {
 
-										if ( texture.dirtyLayers.size > 0 ) {
+										if ( texture.layerUpdates.size > 0 ) {
 
-											for ( const layerIndex of texture.dirtyLayers ) {
+											for ( const layerIndex of texture.layerUpdates ) {
 
 												const layerSize = mipmap.width * mipmap.height;
 												state.compressedTexSubImage3D( _gl.TEXTURE_2D_ARRAY, i, 0, 0, layerIndex, mipmap.width, mipmap.height, 1, glFormat, mipmap.data.slice( layerSize * layerIndex, layerSize * ( layerIndex + 1 ) ), 0, 0 );
 
 											}
 
-											texture.clearDirtyLayers();
+											texture.clearLayerUpdates();
 
 										} else {
 
@@ -941,7 +941,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 					if ( dataReady ) {
 
-						if ( texture.dirtyLayers.size > 0 ) {
+						if ( texture.layerUpdates.size > 0 ) {
 
 							// When type is GL_UNSIGNED_BYTE, each of these bytes is
 							// interpreted as one color component, depending on format. When
@@ -994,13 +994,13 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 							const layerSize = image.width * image.height * texelSize;
 
-							for ( const layerIndex of texture.dirtyLayers ) {
+							for ( const layerIndex of texture.layerUpdates ) {
 
 								state.texSubImage3D( _gl.TEXTURE_2D_ARRAY, 0, 0, 0, layerIndex, image.width, image.height, 1, glFormat, glType, image.data.slice( layerSize * layerIndex, layerSize * ( layerIndex + 1 ) ) );
 
 							}
 
-							texture.clearDirtyLayers();
+							texture.clearLayerUpdates();
 
 						} else {
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -948,8 +948,8 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 							// type is one of GL_UNSIGNED_SHORT_5_6_5,
 							// GL_UNSIGNED_SHORT_4_4_4_4, GL_UNSIGNED_SHORT_5_5_5_1, each
 							// unsigned value is interpreted as containing all the components
-              // for a single pixel, with the color components arranged
-              // according to format.
+							// for a single pixel, with the color components arranged
+							// according to format.
 							//
 							// See https://registry.khronos.org/OpenGL-Refpages/es1.1/xhtml/glTexImage2D.xml
 							let texelSize;

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -943,50 +943,51 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 						if ( texture.dirtyLayers.size > 0 ) {
 
+							// When type is GL_UNSIGNED_BYTE, each of these bytes is
+							// interpreted as one color component, depending on format. When
+							// type is one of GL_UNSIGNED_SHORT_5_6_5,
+							// GL_UNSIGNED_SHORT_4_4_4_4, GL_UNSIGNED_SHORT_5_5_5_1, each
+							// unsigned value is interpreted as containing all the components
+              // for a single pixel, with the color components arranged
+              // according to format.
+							//
+							// See https://registry.khronos.org/OpenGL-Refpages/es1.1/xhtml/glTexImage2D.xml
+							let texelSize;
+							switch ( glType ) {
+
+								case _gl.UNSIGNED_BYTE:
+									switch ( glFormat ) {
+
+										case _gl.ALPHA:
+											texelSize = 1;
+										case _gl.LUMINANCE:
+											texelSize = 1;
+										case _gl.LUMINANCE_ALPHA:
+											texelSize = 2;
+										case _gl.RGB:
+											texelSize = 3;
+										case _gl.RGBA:
+											texelSize = 4;
+
+										default:
+											throw new Error( `Unknown texel size for format ${glFormat}.` );
+
+									}
+
+								case _gl.UNSIGNED_SHORT_4_4_4_4:
+								case _gl.UNSIGNED_SHORT_5_5_5_1:
+								case _gl.UNSIGNED_SHORT_5_6_5:
+									texelSize = 1;
+
+								default:
+									throw new Error( `Unknown texel size for type ${glType}.` );
+
+							}
+
+							const layerSize = image.width * image.height * texelSize;
+
 							for ( const layerIndex of texture.dirtyLayers ) {
 
-								// When type is GL_UNSIGNED_BYTE, each of these bytes is
-								// interpreted as one color component, depending on format. When
-								// type is one of GL_UNSIGNED_SHORT_5_6_5,
-								// GL_UNSIGNED_SHORT_4_4_4_4, GL_UNSIGNED_SHORT_5_5_5_1, each
-								// unsigned value is interpreted as containing all the
-								// components for a single pixel, with the color components
-								// arranged according to format.
-								//
-								// See https://registry.khronos.org/OpenGL-Refpages/es1.1/xhtml/glTexImage2D.xml
-								let texelSize;
-								switch ( glType ) {
-
-									case _gl.UNSIGNED_BYTE:
-										switch ( glFormat ) {
-
-											case _gl.ALPHA:
-												texelSize = 1;
-											case _gl.LUMINANCE:
-												texelSize = 1;
-											case _gl.LUMINANCE_ALPHA:
-												texelSize = 2;
-											case _gl.RGB:
-												texelSize = 3;
-											case _gl.RGBA:
-												texelSize = 4;
-
-											default:
-												throw new Error( `Unknown texel size for format ${glFormat}.` );
-
-										}
-
-									case _gl.UNSIGNED_SHORT_4_4_4_4:
-									case _gl.UNSIGNED_SHORT_5_5_5_1:
-									case _gl.UNSIGNED_SHORT_5_6_5:
-										texelSize = 1;
-
-									default:
-										throw new Error( `Unknown texel size for type ${glType}.` );
-
-								}
-
-								const layerSize = image.width * image.height * texelSize;
 								state.texSubImage3D( _gl.TEXTURE_2D_ARRAY, 0, 0, 0, layerIndex, image.width, image.height, 1, glFormat, glType, image.data.slice( layerSize * layerIndex, layerSize * ( layerIndex + 1 ) ) );
 
 							}

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -829,7 +829,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 											}
 
-											texture.dirtyLayers = [];
+											texture.clearDirtyLayers();
 
 										} else {
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -820,7 +820,22 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 									if ( dataReady ) {
 
-										state.compressedTexSubImage3D( _gl.TEXTURE_2D_ARRAY, i, 0, 0, 0, mipmap.width, mipmap.height, image.depth, glFormat, mipmap.data, 0, 0 );
+										if ( texture.dirtyLayers.length > 0 ) {
+
+											for ( const layerIndex of texture.dirtyLayers ) {
+
+												const layerSize = mipmap.width * mipmap.height;
+												state.compressedTexSubImage3D( _gl.TEXTURE_2D_ARRAY, i, 0, 0, layerIndex, mipmap.width, mipmap.height, 1, glFormat, mipmap.data.slice( layerSize * layerIndex, layerSize * ( layerIndex + 1 ) ), 0, 0 );
+
+											}
+
+											texture.dirtyLayers = [];
+
+										} else {
+
+											state.compressedTexSubImage3D( _gl.TEXTURE_2D_ARRAY, i, 0, 0, 0, mipmap.width, mipmap.height, image.depth, glFormat, mipmap.data, 0, 0 );
+
+										}
 
 									}
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -960,24 +960,32 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 										case _gl.ALPHA:
 											texelSize = 1;
+											break;
 										case _gl.LUMINANCE:
 											texelSize = 1;
+											break;
 										case _gl.LUMINANCE_ALPHA:
 											texelSize = 2;
+											break;
 										case _gl.RGB:
 											texelSize = 3;
+											break;
 										case _gl.RGBA:
 											texelSize = 4;
+											break;
 
 										default:
 											throw new Error( `Unknown texel size for format ${glFormat}.` );
 
 									}
 
+									break;
+
 								case _gl.UNSIGNED_SHORT_4_4_4_4:
 								case _gl.UNSIGNED_SHORT_5_5_5_1:
 								case _gl.UNSIGNED_SHORT_5_6_5:
 									texelSize = 1;
+									break;
 
 								default:
 									throw new Error( `Unknown texel size for type ${glType}.` );

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -820,7 +820,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 									if ( dataReady ) {
 
-										if ( texture.dirtyLayers.length > 0 ) {
+										if ( texture.dirtyLayers.size > 0 ) {
 
 											for ( const layerIndex of texture.dirtyLayers ) {
 

--- a/src/textures/CompressedArrayTexture.js
+++ b/src/textures/CompressedArrayTexture.js
@@ -10,6 +10,14 @@ class CompressedArrayTexture extends CompressedTexture {
 		this.isCompressedArrayTexture = true;
 		this.image.depth = depth;
 		this.wrapR = ClampToEdgeWrapping;
+		this.dirtyLayers = [];
+
+	}
+
+	set layerNeedsUpdate( layerIndex ) {
+
+		this.needsUpdate = true;
+		this.dirtyLayers.push( layerIndex );
 
 	}
 

--- a/src/textures/CompressedArrayTexture.js
+++ b/src/textures/CompressedArrayTexture.js
@@ -11,19 +11,19 @@ class CompressedArrayTexture extends CompressedTexture {
 		this.image.depth = depth;
 		this.wrapR = ClampToEdgeWrapping;
 
-		this.dirtyLayers = new Set();
+		this.layerUpdates = new Set();
 
 	}
 
-	addDirtyLayer( layerIndex ) {
+	addLayerUpdates( layerIndex ) {
 
-		this.dirtyLayers.add( layerIndex );
+		this.layerUpdates.add( layerIndex );
 
 	}
 
-	clearDirtyLayers() {
+	clearLayerUpdates() {
 
-		this.dirtyLayers.clear();
+		this.layerUpdates.clear();
 
 	}
 

--- a/src/textures/CompressedArrayTexture.js
+++ b/src/textures/CompressedArrayTexture.js
@@ -10,14 +10,20 @@ class CompressedArrayTexture extends CompressedTexture {
 		this.isCompressedArrayTexture = true;
 		this.image.depth = depth;
 		this.wrapR = ClampToEdgeWrapping;
-		this.dirtyLayers = [];
+
+		this.dirtyLayers = new Set();
 
 	}
 
-	set layerNeedsUpdate( layerIndex ) {
+	addDirtyLayer( layerIndex ) {
 
-		this.needsUpdate = true;
-		this.dirtyLayers.push( layerIndex );
+		this.dirtyLayers.add( layerIndex );
+
+	}
+
+	clearDirtyLayers() {
+
+		this.dirtyLayers.clear();
 
 	}
 

--- a/src/textures/DataArrayTexture.js
+++ b/src/textures/DataArrayTexture.js
@@ -20,19 +20,19 @@ class DataArrayTexture extends Texture {
 		this.flipY = false;
 		this.unpackAlignment = 1;
 
-		this.dirtyLayers = new Set();
+		this.layerUpdates = new Set();
 
 	}
 
-	addDirtyLayer( layerIndex ) {
+	addLayerUpdate( layerIndex ) {
 
-		this.dirtyLayers.add( layerIndex );
+		this.layerUpdates.add( layerIndex );
 
 	}
 
-	clearDirtyLayers() {
+	clearLayerUpdates() {
 
-		this.dirtyLayers.clear();
+		this.layerUpdates.clear();
 
 	}
 

--- a/src/textures/DataArrayTexture.js
+++ b/src/textures/DataArrayTexture.js
@@ -20,6 +20,20 @@ class DataArrayTexture extends Texture {
 		this.flipY = false;
 		this.unpackAlignment = 1;
 
+		this.dirtyLayers = new Set();
+
+	}
+
+	addDirtyLayer( layerIndex ) {
+
+		this.dirtyLayers.add( layerIndex );
+
+	}
+
+	clearDirtyLayers() {
+
+		this.dirtyLayers.clear();
+
 	}
 
 }


### PR DESCRIPTION
Related issue: n/a

**Description**

ThreeJS's `CompressedArrayTexture` is useful to pack multiple compressed textures into a single sampler (making more efficient use of GPU resources). However, it's critical for performance that when making changes to the texture array, that the CPU only update subsets of the bound GPU texture. It turns out that ThreeJS does not currently support modifying individual texture array layers, instead it always flushes the entire texture array to the GPU on every change. This PR changes ThreeJS by adding new functionality to update specific layers individually resulting in much less data transmission during render and therefore better performance.

**Case Study**

My company [SOOT], uses `CompressedArrayTexture` regularly with large numbers of 256x256 layers. We observed that if we needed to update `N` layers in a frame this would result in a command buffer issued to the GPU with `N * byteSize(textureArray)` when we expected `N * byteSize(layer)`. This resulted in 16777216 bytes transmitted from CPU to GPU multiple times per frame instead of 65536. By authoring this change we observed a 99.6% reduction in command buffer size between the CPU and GPU and a 423% increase in framerate.

**Implementation Strategy**

I designed this change to be minimally invasive and not impact existing ThreeJS projects. The feature is gated by the new field `layerUpdates` which was not previously used by the codebase. As a result, if ThreeJS users don't call `texture.addLayerUpdate(...)` then this change has no impact.

*This contribution is funded by [SOOT]*

[SOOT]: https://soot.com
