### PR TITLE
BatchedMesh: Fix exception when using Geometry with InterleavedBuffers

### DIFF
--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -195,8 +195,7 @@ class BatchedMesh extends Mesh {
 				const { array, itemSize, normalized } = srcAttribute;
 
 				const dstArray = new array.constructor( maxVertexCount * itemSize );
-				const dstAttribute = new srcAttribute.constructor( dstArray, itemSize, normalized );
-				dstAttribute.setUsage( srcAttribute.usage );
+				const dstAttribute = new BufferAttribute( dstArray, itemSize, normalized );
 
 				geometry.setAttribute( attributeName, dstAttribute );
 


### PR DESCRIPTION
Fixed https://github.com/mrdoob/three.js/issues/27973

**Description**

Adding geometry that has interleaved buffers currently throws because `setUsage` is not defined on the InterleavedBufferAttribute.
The PR enforces dstAttribute to `new BufferAttribute` and removes the call to `setUsage` as suggested by @gkjohnson 

*This contribution is funded by [🌵 Needle](https://needle.tools)*
