### PR TITLE
BatchedMesh: addUpdateRanges

### DIFF
--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -514,6 +514,7 @@ class BatchedMesh extends Mesh {
 			}
 
 			dstAttribute.needsUpdate = true;
+			dstAttribute.addUpdateRange( vertexStart * itemSize, vertexCount * itemSize );
 
 		}
 
@@ -537,6 +538,7 @@ class BatchedMesh extends Mesh {
 			}
 
 			dstIndex.needsUpdate = true;
+			dstIndex.addUpdateRange( indexStart, reservedRange.indexCount );
 
 		}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/27980

**Description**

Currently when a BatchedMesh geometry changes the whole buffer is updated via bufferSubData which causes lags when just a part of the buffer has actually changed. 

This PR registers the changed range in the BatchedMesh attributes so only the necessary areas are updated

*This contribution is funded by [🌵 Needle](https://needle.tools)*

### Before the change

https://github.com/mrdoob/three.js/assets/5083203/f393616e-90d2-4bf4-8306-742adc2f4821

### After the change

https://github.com/mrdoob/three.js/assets/5083203/f32c60b7-9adc-4062-8b66-ff31b6ac01bb



