### PR TITLE
WebGPURenderer: Tight morph target packing

### DIFF
--- a/examples/jsm/nodes/accessors/MorphNode.js
+++ b/examples/jsm/nodes/accessors/MorphNode.js
@@ -33,10 +33,10 @@ const getMorph = tslFn( ( { bufferMap, influence, stride, width, depth, offset }
 	morphUV.x.addAssign( 1 );
 	bufferAttrib.z = textureLoad( bufferMap, morphUV ).depth( depth ).r;
 
-	If( all( stride.equal( 10 ) ), () => {
+	If( stride.equal( 10 ), () => {
 
 		morphUV.x.addAssign( 1 );
-		bufferAttrib.a = offset.equal( 2 ).all().cond( textureLoad( bufferMap, morphUV ).depth( depth ).r, 0. );
+		bufferAttrib.a = offset.equal( 2 ).cond( textureLoad( bufferMap, morphUV ).depth( depth ).r, 0. );
 
 	} );
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/27768

**Description**
Adapted the tight morph target packing PR to the WebGPURenderer fo testing purpose.

Benchmark on `webgpu_instancing_morph` using `stats-gl` on Mac Book Pro M1 Max:
```js
stats = new Stats( {
	logsPerSecond: 0.25,
	samplesLog: 1000,
	precision: 3
} );
```

WebGL:
Before: 4.2ms GPU average
After: 4.4ms GPU average

WebGPU:
Before: 4.1ms GPU average
After: 4.5ms GPU average

Tight pack through Red Channel seems inefficient and GPUs seems to always prefer using RGBA?

*This contribution is funded by [Utsubo](https://utsubo.com)*
