### PR TITLE
TextureNode: Introduce `referenceNode`

### DIFF
--- a/examples/jsm/nodes/accessors/TextureNode.js
+++ b/examples/jsm/nodes/accessors/TextureNode.js
@@ -25,7 +25,31 @@ class TextureNode extends UniformNode {
 		this.updateMatrix = false;
 		this.updateType = NodeUpdateType.NONE;
 
+		this.referenceNode = null;
+
+		this._value = value;
+
 		this.setUpdateMatrix( uvNode === null );
+
+	}
+
+	set value( value ) {
+
+		if ( this.referenceNode ) {
+
+			this.referenceNode.value = value;
+
+		} else {
+
+			this._value = value;
+
+		}
+
+	}
+
+	get value() {
+
+		return this.referenceNode ? this.referenceNode.value : this._value;
 
 	}
 
@@ -258,6 +282,7 @@ class TextureNode extends UniformNode {
 
 		const textureNode = this.clone();
 		textureNode.uvNode = uvNode;
+		textureNode.referenceNode = this;
 
 		return nodeObject( textureNode );
 
@@ -267,6 +292,7 @@ class TextureNode extends UniformNode {
 
 		const textureNode = this.clone();
 		textureNode.levelNode = levelNode.mul( maxMipLevel( textureNode ) );
+		textureNode.referenceNode = this;
 
 		return nodeObject( textureNode );
 
@@ -276,6 +302,7 @@ class TextureNode extends UniformNode {
 
 		const textureNode = this.clone();
 		textureNode.levelNode = levelNode;
+		textureNode.referenceNode = this;
 
 		return textureNode;
 
@@ -291,6 +318,7 @@ class TextureNode extends UniformNode {
 
 		const textureNode = this.clone();
 		textureNode.compareNode = nodeObject( compareNode );
+		textureNode.referenceNode = this;
 
 		return nodeObject( textureNode );
 
@@ -300,6 +328,7 @@ class TextureNode extends UniformNode {
 
 		const textureNode = this.clone();
 		textureNode.depthNode = nodeObject( depthNode );
+		textureNode.referenceNode = this;
 
 		return nodeObject( textureNode );
 


### PR DESCRIPTION
**Description**

It's allow that `texture()` sampler can be modified inside a function as parameter and preserve the root uniform as dynamic value. e.g:

```js
const samplerNode = texture( map, uv() );

const otherUV = tslFn( ( [ tex ] ) => {

	const newSampler = tex.uv( viewportTopLeft ); // new sampler from TextureNode using as reference

	return newSampler;

} );

material.colorNode = otherUV( samplerNode );

// in loop

// this will update all instances (newSampler) created from samplerNode
samplerNode.value = otherMap;
```