### PR TITLE
BatchedMesh: setGeometry sets active to true again

### DIFF
--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -571,6 +571,8 @@ class BatchedMesh extends Mesh {
 		drawRange.count = hasIndex ? srcIndex.count : posAttr.count;
 		this._visibilityChanged = true;
 
+		this._active[ id ] = true;
+
 		return id;
 
 	}


### PR DESCRIPTION
Fixed https://github.com/mrdoob/three.js/issues/27985

**Description**

Calling `deleteGeometry` just marks the instance as inactive with no way to re-use the reserved space.

With this PR the `active` state of a instance is enabled again when the geometry is added or updated (via `addGeometry` or `setGeometryAt`) 
because calling these methods is an indicator that the instance is actively used (and it can still be invisible by `visible=false` state)

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [🌵 Needle](https://needle.tools)*


## Before

https://github.com/mrdoob/three.js/assets/5083203/3d1beeb7-368d-4dab-b501-d2d2e445832e


## After

https://github.com/mrdoob/three.js/assets/5083203/d13440f1-441c-4984-b141-d41540609e04


