### PR TITLE
RenderObject: Ignore private properties in `getMaterialCacheKey()`

### DIFF
--- a/examples/jsm/renderers/common/RenderObject.js
+++ b/examples/jsm/renderers/common/RenderObject.js
@@ -155,7 +155,7 @@ export default class RenderObject {
 
 		for ( const property in material ) {
 
-			if ( /^(is[A-Z])|^(visible|version|uuid|name|opacity|userData)$/.test( property ) ) continue;
+			if ( /^(is[A-Z]|_)|^(visible|version|uuid|name|opacity|userData)$/.test( property ) ) continue;
 
 			let value = material[ property ];
 


### PR DESCRIPTION
**Description**

Ignore private properties in `RenderObject.getMaterialCacheKey()`.

