### PR TITLE
KTX2Loader: Add parse function

### DIFF
--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -242,33 +242,33 @@ class KTX2Loader extends Loader {
 	load( url, onLoad, onProgress, onError ) {
 
 		if ( this.workerConfig === null ) {
-
-			throw new Error( 'THREE.KTX2Loader: Missing initialization with `.detectSupport( renderer )`.' );
-
+		  throw new Error( 'THREE.KTX2Loader: Missing initialization with `.detectSupport( renderer )`.' );
 		}
-
+	  
 		const loader = new FileLoader( this.manager );
-
+	  
 		loader.setResponseType( 'arraybuffer' );
 		loader.setWithCredentials( this.withCredentials );
-
+	  
 		loader.load( url, ( buffer ) => {
-
-			// Check for an existing task using this buffer. A transferred buffer cannot be transferred
-			// again from this thread.
-			if ( _taskCache.has( buffer ) ) {
-
-				const cachedTask = _taskCache.get( buffer );
-
-				return cachedTask.promise.then( onLoad ).catch( onError );
-
-			}
-
-			this._createTexture( buffer )
-				.then( ( texture ) => onLoad ? onLoad( texture ) : null )
-				.catch( onError );
-
+		  this.parse( buffer, onLoad, onError );
 		}, onProgress, onError );
+
+	}
+
+	parse( arrayBuffer, onLoad, onError ) {
+		
+		if ( this.workerConfig === null ) {
+		  throw new Error( 'THREE.KTX2Loader: Missing initialization with `.detectSupport( renderer )`.' );
+		}
+	  
+		this._createTexture( arrayBuffer )
+			.then( texture => {
+				if ( onLoad ) onLoad( texture );
+			} )
+			.catch( err => {
+				if ( onError ) onError( err );
+			} );
 
 	}
 


### PR DESCRIPTION
### Description
**Problem:**
The KTX2Loader in the three.js library currently lacks a parse function that allows parsing KTX2 data directly from an ArrayBuffer, similar to the parse function available in the GLTFLoader. This limits the flexibility of the KTX2Loader and requires users to always load KTX2 files via a URL, even if they already have the data in memory.

**Solution:**
This pull request adds a new parse function to the KTX2Loader class, enabling users to parse KTX2 data directly from an ArrayBuffer. The parse function follows a similar structure to the parse function in the GLTFLoader, taking an ArrayBuffer as input along with onLoad and onError callbacks.

The parse function performs the following steps:

Checks if the workerConfig is initialized, throwing an error if it's not set.
Calls the internal _createTexture method with the provided ArrayBuffer.
Upon successful texture creation, invokes the onLoad callback with the created texture.
If an error occurs during parsing or texture creation, invokes the onError callback with the error.
Additionally, the existing load function has been modified to use the new parse function internally. It now loads the KTX2 file as an ArrayBuffer using the FileLoader and then calls the parse function with the loaded data.

Benefits:

Provides a consistent API for parsing KTX2 data, similar to the GLTFLoader.
Allows users to parse KTX2 data directly from an ArrayBuffer, enabling scenarios where the data is already loaded or obtained from other sources.
Improves flexibility and usability of the KTX2Loader by providing an alternative way to create textures from KTX2 data.
This pull request enhances the KTX2Loader and brings it closer in functionality to other loaders in the three.js library, such as the GLTFLoader.