### PR TITLE
Examples: Clean up.

### DIFF
--- a/examples/webgl_loader_texture_hdrjpg.html
+++ b/examples/webgl_loader_texture_hdrjpg.html
@@ -155,7 +155,7 @@
 
 						resolutions[ 'Webp Gain map (separate)' ] = gainMap.width + 'x' + gainMap.height;
 			
-						gainMapBackground = hdrJpg.renderTarget.texture;
+						gainMapBackground = gainMap.renderTarget.texture;
 						gainMapPMREMRenderTarget = pmremGenerator.fromEquirectangular( gainMapBackground );
 
 						gainMapBackground.mapping = THREE.EquirectangularReflectionMapping;


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/27230

**Description**

@elalish It seems there is a copy/paste error in `webgl_loader_texture_hdrjpg`. When using `GainMapLoader`, the code should access `gainMap.renderTarget.texture` and not the `hdrJpg` reference.
