### PR TITLE
Playground: Fix split node not working

### DIFF
--- a/playground/editors/JoinEditor.js
+++ b/playground/editors/JoinEditor.js
@@ -40,6 +40,8 @@ export class JoinEditor extends BaseNodeEditor {
 
 			this.invalidate();
 
+			this.title.setOutput( length );
+
 		};
 
 		const xElement = setInputAestheticsFromType( new LabelElement( 'x | r' ), 'Number' ).onConnect( update );

--- a/playground/editors/SplitEditor.js
+++ b/playground/editors/SplitEditor.js
@@ -1,7 +1,7 @@
 import { LabelElement } from 'flow';
 import { BaseNodeEditor } from '../BaseNodeEditor.js';
 import { nodeObject, float } from 'three/nodes';
-import { setInputAestheticsFromType } from '../DataTypeLib.js';
+import { setInputAestheticsFromType, setOutputAestheticsFromType } from '../DataTypeLib.js';
 
 export class SplitEditor extends BaseNodeEditor {
 
@@ -33,12 +33,10 @@ export class SplitEditor extends BaseNodeEditor {
 
 		} );
 
-		this.add( inputElement );
-
-		const xElement = setInputAestheticsFromType( new LabelElement( 'x | r' ), 'Number' ).setObject( float() );
-		const yElement = setInputAestheticsFromType( new LabelElement( 'y | g' ), 'Number' ).setObject( float() );
-		const zElement = setInputAestheticsFromType( new LabelElement( 'z | b' ), 'Number' ).setObject( float() );
-		const wElement = setInputAestheticsFromType( new LabelElement( 'w | a' ), 'Number' ).setObject( float() );
+		const xElement = setOutputAestheticsFromType( new LabelElement( 'x | r' ), 'Number' ).setObject( float() );
+		const yElement = setOutputAestheticsFromType( new LabelElement( 'y | g' ), 'Number' ).setObject( float() );
+		const zElement = setOutputAestheticsFromType( new LabelElement( 'z | b' ), 'Number' ).setObject( float() );
+		const wElement = setOutputAestheticsFromType( new LabelElement( 'w | a' ), 'Number' ).setObject( float() );
 
 		this.add( inputElement )
 			.add( xElement )


### PR DESCRIPTION
**Description**

Fixes a regression made by #27891, which accidentally converted all outputs into inputs:
![image](https://github.com/mrdoob/three.js/assets/21260178/b471bd35-313d-4277-9e2a-f4c2ec575434)

Also adds that the JoinEditor dynamically corrects the length of the output.