### PR TITLE
chore: replace the cdn, unpkg -> jsdelivr

### DIFF
--- a/docs/examples/en/loaders/3DMLoader.html
+++ b/docs/examples/en/loaders/3DMLoader.html
@@ -166,7 +166,7 @@
 			// Specify path to a folder containing WASM/JS libraries or a CDN.
 			// For example, /jsm/libs/rhino3dm/ is the location of the library inside the three.js repository
 			// loader.setLibraryPath( '/path_to_library/rhino3dm/' );
-			loader.setLibraryPath( 'https://unpkg.com/rhino3dm@8.4.0/' );
+			loader.setLibraryPath( 'https://cdn.jsdelivr.net/npm/rhino3dm@8.4.0/' );
 	
 			// Load a 3DM file
 			loader.load(
@@ -205,13 +205,13 @@
 		</p>
 
 		<code>
-		import rhino3dm from 'https://unpkg.com/rhino3dm@8.4.0'
+		import rhino3dm from 'https://cdn.jsdelivr.net/npm/rhino3dm@8.4.0'
 
 		// Instantiate a loader
 		const loader = new Rhino3dmLoader();
 
 		// Specify path to a folder containing WASM/JS libraries or a CDN.
-		loader.setLibraryPath( 'https://unpkg.com/rhino3dm@8.4.0' );
+		loader.setLibraryPath( 'https://cdn.jsdelivr.net/npm/rhino3dm@8.4.0' );
 
 		const rhino = await rhino3dm();
 		console.log('Loaded rhino3dm.');
@@ -244,7 +244,7 @@
 		// Specify path to a folder containing the WASM/JS library:
 		loader.setLibraryPath( '/path_to_library/rhino3dm/' );
 		// or from a CDN:
-		loader.setLibraryPath( 'https://unpkg.com/rhino3dm@8.4.0' );
+		loader.setLibraryPath( 'https://cdn.jsdelivr.net/npm/rhino3dm@8.4.0' );
 		</code>
 
 		<h3>[method:this setWorkerLimit]( [param:Number workerLimit] )</h3>

--- a/docs/examples/zh/loaders/3DMLoader.html
+++ b/docs/examples/zh/loaders/3DMLoader.html
@@ -171,7 +171,7 @@
 			// Specify path to a folder containing WASM/JS libraries or a CDN.
 			// For example, /jsm/libs/rhino3dm/ is the location of the library inside the three.js repository
 			// loader.setLibraryPath( '/path_to_library/rhino3dm/' );
-			loader.setLibraryPath( 'https://unpkg.com/rhino3dm@8.0.1/' );
+			loader.setLibraryPath( 'https://cdn.jsdelivr.net/npm/rhino3dm@8.0.1/' );
 	
 			// Load a 3DM file
 			loader.load(
@@ -212,13 +212,13 @@
 	</p>
 
 	<code>
-		import rhino3dm from 'https://unpkg.com/rhino3dm@8.0.1'
+		import rhino3dm from 'https://cdn.jsdelivr.net/npm/rhino3dm@8.0.1'
 
 		// Instantiate a loader
 		const loader = new Rhino3dmLoader();
 
 		// Specify path to a folder containing WASM/JS libraries or a CDN.
-		loader.setLibraryPath( 'https://unpkg.com/rhino3dm@8.0.1' );
+		loader.setLibraryPath( 'https://cdn.jsdelivr.net/npm/rhino3dm@8.0.1' );
 
 		const rhino = await rhino3dm();
 		console.log('Loaded rhino3dm.');
@@ -251,7 +251,7 @@
 		// Specify path to a folder containing the WASM/JS library:
 		loader.setLibraryPath( '/path_to_library/rhino3dm/' );
 		// or from a CDN:
-		loader.setLibraryPath( 'https://unpkg.com/rhino3dm@8.0.1' );
+		loader.setLibraryPath( 'https://cdn.jsdelivr.net/npm/rhino3dm@8.0.1' );
 		</code>
 
 	<h3>[method:this setWorkerLimit]( [param:Number workerLimit] )</h3>

--- a/docs/manual/ar/introduction/Installation.html
+++ b/docs/manual/ar/introduction/Installation.html
@@ -88,7 +88,7 @@
 		&lt;script type="importmap">
 			{
 			"imports": {
-				"three": "https://unpkg.com/three@&lt;version&gt;/build/three.module.js"
+				"three": "https://cdn.jsdelivr.net/npm/three@&lt;version&gt;/build/three.module.js"
 			}
 			}
 		&lt;/script>
@@ -127,8 +127,8 @@
 		&lt;script type="importmap">
 			{
 			"imports": {
-				"three": "https://unpkg.com/three@&lt;version&gt;/build/three.module.js",
-				"three/addons/": "https://unpkg.com/three@&lt;version&gt;/examples/jsm/"
+				"three": "https://cdn.jsdelivr.net/npm/three@&lt;version&gt;/build/three.module.js",
+				"three/addons/": "https://cdn.jsdelivr.net/npm/three@&lt;version&gt;/examples/jsm/"
 			}
 			}
 		&lt;/script>

--- a/docs/manual/en/introduction/Installation.html
+++ b/docs/manual/en/introduction/Installation.html
@@ -152,8 +152,8 @@ npm install --save-dev vite
 &lt;script type="importmap">
   {
     "imports": {
-      "three": "https://unpkg.com/three@&lt;version&gt;/build/three.module.js",
-      "three/addons/": "https://unpkg.com/three@&lt;version&gt;/examples/jsm/"
+      "three": "https://cdn.jsdelivr.net/npm/three@&lt;version&gt;/build/three.module.js",
+      "three/addons/": "https://cdn.jsdelivr.net/npm/three@&lt;version&gt;/examples/jsm/"
     }
   }
 &lt;/script>

--- a/docs/manual/fr/introduction/Creating-a-scene.html
+++ b/docs/manual/fr/introduction/Creating-a-scene.html
@@ -27,7 +27,7 @@
 			&lt;/head&gt;
 			&lt;body&gt;
 				&lt;script type="module"&gt;
-					import * as THREE from 'https://unpkg.com/three/build/three.module.js';
+					import * as THREE from 'https://cdn.jsdelivr.net/npm/three/build/three.module.js';
 
 					// Our Javascript will go here.
 				&lt;/script&gt;
@@ -129,7 +129,7 @@
 			&lt;/head&gt;
 			&lt;body&gt;
 				&lt;script type="module"&gt;
-					import * as THREE from 'https://unpkg.com/three/build/three.module.js';
+					import * as THREE from 'https://cdn.jsdelivr.net/npm/three/build/three.module.js';
 
 					const scene = new THREE.Scene();
 					const camera = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 0.1, 1000 );

--- a/docs/manual/fr/introduction/Installation.html
+++ b/docs/manual/fr/introduction/Installation.html
@@ -71,7 +71,7 @@
 		&lt;script type="importmap">
 		  {
 		    "imports": {
-		      "three": "https://unpkg.com/three@&lt;version&gt;/build/three.module.js"
+		      "three": "https://cdn.jsdelivr.net/npm/three@&lt;version&gt;/build/three.module.js"
 		    }
 		  }
 		&lt;/script>
@@ -110,8 +110,8 @@
 		&lt;script type="importmap">
 			{
 			"imports": {
-				"three": "https://unpkg.com/three@&lt;version&gt;/build/three.module.js",
-				"three/addons/": "https://unpkg.com/three@&lt;version&gt;/examples/jsm/"
+				"three": "https://cdn.jsdelivr.net/npm/three@&lt;version&gt;/build/three.module.js",
+				"three/addons/": "https://cdn.jsdelivr.net/npm/three@&lt;version&gt;/examples/jsm/"
 			}
 			}
 		&lt;/script>

--- a/docs/manual/it/introduction/Creating-a-scene.html
+++ b/docs/manual/it/introduction/Creating-a-scene.html
@@ -30,7 +30,7 @@
 			&lt;/head&gt;
 			&lt;body&gt;
 				&lt;script type="module"&gt;
-					import * as THREE from 'https://unpkg.com/three/build/three.module.js';
+					import * as THREE from 'https://cdn.jsdelivr.net/npm/three/build/three.module.js';
 
 					// Il nostro Javascript andrà qui
 				&lt;/script&gt;
@@ -147,7 +147,7 @@
 			&lt;/head&gt;
 			&lt;body&gt;
 				&lt;script type="module"&gt;
-					import * as THREE from 'https://unpkg.com/three/build/three.module.js';
+					import * as THREE from 'https://cdn.jsdelivr.net/npm/three/build/three.module.js';
 
 					const scene = new THREE.Scene();
 					const camera = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 0.1, 1000 );

--- a/docs/manual/it/introduction/Installation.html
+++ b/docs/manual/it/introduction/Installation.html
@@ -72,7 +72,7 @@
 		&lt;script type="importmap">
 		  {
 		    "imports": {
-		      "three": "https://unpkg.com/three@&lt;version&gt;/build/three.module.js"
+		      "three": "https://cdn.jsdelivr.net/npm/three@&lt;version&gt;/build/three.module.js"
 		    }
 		  }
 		&lt;/script>
@@ -110,8 +110,8 @@
 		&lt;script type="importmap">
 			{
 			"imports": {
-				"three": "https://unpkg.com/three@&lt;version&gt;/build/three.module.js",
-				"three/addons/": "https://unpkg.com/three@&lt;version&gt;/examples/jsm/"
+				"three": "https://cdn.jsdelivr.net/npm/three@&lt;version&gt;/build/three.module.js",
+				"three/addons/": "https://cdn.jsdelivr.net/npm/three@&lt;version&gt;/examples/jsm/"
 			}
 			}
 		&lt;/script>

--- a/docs/manual/ja/introduction/Creating-a-scene.html
+++ b/docs/manual/ja/introduction/Creating-a-scene.html
@@ -27,7 +27,7 @@
 			&lt;/head&gt;
 			&lt;body&gt;
 				&lt;script type="module"&gt;
-					import * as THREE from 'https://unpkg.com/three/build/three.module.js';
+					import * as THREE from 'https://cdn.jsdelivr.net/npm/three/build/three.module.js';
 
 					// Our Javascript will go here.
 				&lt;/script&gt;
@@ -130,7 +130,7 @@
 			&lt;/head&gt;
 			&lt;body&gt;
 				&lt;script type="module"&gt;
-					import * as THREE from 'https://unpkg.com/three/build/three.module.js';
+					import * as THREE from 'https://cdn.jsdelivr.net/npm/three/build/three.module.js';
 
 					const scene = new THREE.Scene();
 					const camera = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 0.1, 1000 );

--- a/docs/manual/ja/introduction/Installation.html
+++ b/docs/manual/ja/introduction/Installation.html
@@ -72,7 +72,7 @@
 &lt;script type="importmap">
     {
     "imports": {
-        "three": "https://unpkg.com/three@&lt;version&gt;/build/three.module.js"
+        "three": "https://cdn.jsdelivr.net/npm/three@&lt;version&gt;/build/three.module.js"
     }
     }
 &lt;/script>
@@ -111,8 +111,8 @@
 &lt;script type="importmap">
     {
     "imports": {
-        "three": "https://unpkg.com/three@&lt;version&gt;/build/three.module.js",
-        "three/addons/": "https://unpkg.com/three@&lt;version&gt;/examples/jsm/"
+        "three": "https://cdn.jsdelivr.net/npm/three@&lt;version&gt;/build/three.module.js",
+        "three/addons/": "https://cdn.jsdelivr.net/npm/three@&lt;version&gt;/examples/jsm/"
     }
     }
 &lt;/script>

--- a/docs/manual/ko/introduction/Creating-a-scene.html
+++ b/docs/manual/ko/introduction/Creating-a-scene.html
@@ -28,7 +28,7 @@
 			&lt;/head&gt;
 			&lt;body&gt;
 				&lt;script type="module"&gt;
-					import * as THREE from 'https://unpkg.com/three/build/three.module.js';
+					import * as THREE from 'https://cdn.jsdelivr.net/npm/three/build/three.module.js';
 ´
 					// Our Javascript will go here.
 				&lt;/script&gt;
@@ -133,7 +133,7 @@
 			&lt;/head&gt;
 			&lt;body&gt;
 				&lt;script type="module"&gt;
-					import * as THREE from 'https://unpkg.com/three/build/three.module.js';
+					import * as THREE from 'https://cdn.jsdelivr.net/npm/three/build/three.module.js';
 
 					const scene = new THREE.Scene();
 					const camera = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 0.1, 1000 );

--- a/docs/manual/ko/introduction/Installation.html
+++ b/docs/manual/ko/introduction/Installation.html
@@ -80,7 +80,7 @@
 &lt;script type="importmap">
     {
     "imports": {
-        "three": "https://unpkg.com/three@&lt;version&gt;/build/three.module.js"
+        "three": "https://cdn.jsdelivr.net/npm/three@&lt;version&gt;/build/three.module.js"
     }
     }
 &lt;/script>
@@ -123,8 +123,8 @@
 &lt;script type="importmap">
     {
     "imports": {
-        "three": "https://unpkg.com/three@&lt;version&gt;/build/three.module.js",
-        "three/addons/": "https://unpkg.com/three@&lt;version&gt;/examples/jsm/"
+        "three": "https://cdn.jsdelivr.net/npm/three@&lt;version&gt;/build/three.module.js",
+        "three/addons/": "https://cdn.jsdelivr.net/npm/three@&lt;version&gt;/examples/jsm/"
     }
     }
 &lt;/script>

--- a/docs/manual/pt-br/introduction/Creating-a-scene.html
+++ b/docs/manual/pt-br/introduction/Creating-a-scene.html
@@ -27,7 +27,7 @@
 			&lt;/head&gt;
 			&lt;body&gt;
 				&lt;script type="module"&gt;
-					import * as THREE from 'https://unpkg.com/three/build/three.module.js';
+					import * as THREE from 'https://cdn.jsdelivr.net/npm/three/build/three.module.js';
 
 					// Our Javascript will go here.
 				&lt;/script&gt;
@@ -131,7 +131,7 @@
 			&lt;/head&gt;
 			&lt;body&gt;
 				&lt;script type="module"&gt;
-					import * as THREE from 'https://unpkg.com/three/build/three.module.js';
+					import * as THREE from 'https://cdn.jsdelivr.net/npm/three/build/three.module.js';
 
 					const scene = new THREE.Scene();
 					const camera = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 0.1, 1000 );

--- a/docs/manual/pt-br/introduction/Installation.html
+++ b/docs/manual/pt-br/introduction/Installation.html
@@ -56,7 +56,7 @@
 		&lt;script type="importmap">
 		  {
 		    "imports": {
-		      "three": "https://unpkg.com/three@&lt;version&gt;/build/three.module.js"
+		      "three": "https://cdn.jsdelivr.net/npm/three@&lt;version&gt;/build/three.module.js"
 		    }
 		  }
 		&lt;/script>
@@ -96,8 +96,8 @@
 		&lt;script type="importmap">
 			{
 			"imports": {
-				"three": "https://unpkg.com/three@&lt;version&gt;/build/three.module.js",
-				"three/addons/": "https://unpkg.com/three@&lt;version&gt;/examples/jsm/"
+				"three": "https://cdn.jsdelivr.net/npm/three@&lt;version&gt;/build/three.module.js",
+				"three/addons/": "https://cdn.jsdelivr.net/npm/three@&lt;version&gt;/examples/jsm/"
 			}
 			}
 		&lt;/script>

--- a/docs/manual/ru/introduction/Creating-a-scene.html
+++ b/docs/manual/ru/introduction/Creating-a-scene.html
@@ -29,7 +29,7 @@
 			&lt;/head&gt;
 			&lt;body&gt;
 				&lt;script type="module"&gt;
-					import * as THREE from 'https://unpkg.com/three/build/three.module.js';
+					import * as THREE from 'https://cdn.jsdelivr.net/npm/three/build/three.module.js';
 
 					// Наш Javascript будет здесь..
 				&lt;/script&gt;
@@ -130,7 +130,7 @@
 			&lt;/head&gt;
 			&lt;body&gt;
 				&lt;script type="module"&gt;
-					import * as THREE from 'https://unpkg.com/three/build/three.module.js';
+					import * as THREE from 'https://cdn.jsdelivr.net/npm/three/build/three.module.js';
 
 					const scene = new THREE.Scene();
 					const camera = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 0.1, 1000 );

--- a/docs/manual/ru/introduction/Installation.html
+++ b/docs/manual/ru/introduction/Installation.html
@@ -95,7 +95,7 @@
 		&lt;script type="importmap">
 		{
 			"imports": {
-				"three": "https://unpkg.com/three@&lt;version&gt;/build/three.module.js"
+				"three": "https://cdn.jsdelivr.net/npm/three@&lt;version&gt;/build/three.module.js"
 			}
 		}
 		&lt;/script>
@@ -140,8 +140,8 @@
 		&lt;script type="importmap">
 		{
 			"imports": {
-				"three": "https://unpkg.com/three@&lt;version&gt;/build/three.module.js",
-				"three/addons/": "https://unpkg.com/three@&lt;version&gt;/examples/jsm/"
+				"three": "https://cdn.jsdelivr.net/npm/three@&lt;version&gt;/build/three.module.js",
+				"three/addons/": "https://cdn.jsdelivr.net/npm/three@&lt;version&gt;/examples/jsm/"
 			}
 		}
 		&lt;/script>

--- a/docs/manual/zh/introduction/Installation.html
+++ b/docs/manual/zh/introduction/Installation.html
@@ -151,8 +151,8 @@ npm install --save-dev vite
 &lt;script type="importmap">
   {
     "imports": {
-      "three": "https://unpkg.com/three@&lt;version&gt;/build/three.module.js",
-      "three/addons/": "https://unpkg.com/three@&lt;version&gt;/examples/jsm/"
+      "three": "https://cdn.jsdelivr.net/npm/three@&lt;version&gt;/build/three.module.js",
+      "three/addons/": "https://cdn.jsdelivr.net/npm/three@&lt;version&gt;/examples/jsm/"
     }
   }
 &lt;/script>

--- a/editor/index.html
+++ b/editor/index.html
@@ -52,8 +52,8 @@
 					"three/addons/": "../examples/jsm/",
 
 					"three/examples/": "../examples/",
-					"three-gpu-pathtracer": "https://unpkg.com/three-gpu-pathtracer@0.0.19/build/index.module.js",
-					"three-mesh-bvh": "https://unpkg.com/three-mesh-bvh@0.7.3/build/index.module.js"
+					"three-gpu-pathtracer": "https://cdn.jsdelivr.net/npm/three-gpu-pathtracer@0.0.19/build/index.module.js",
+					"three-mesh-bvh": "https://cdn.jsdelivr.net/npm/three-mesh-bvh@0.7.3/build/index.module.js"
 				}
 			}
 		</script>

--- a/examples/webgl2_ubo_arrays.html
+++ b/examples/webgl2_ubo_arrays.html
@@ -98,10 +98,6 @@
 
 		</script>
 
-		<!-- Import maps polyfill -->
-		<!-- Remove this when import maps will be widely supported -->
-		<script async src="https://cdn.jsdelivr.net/npm/es-module-shims@1.6.3/dist/es-module-shims.js"></script>
-
 		<script type="importmap">
 			{
 				"imports": {

--- a/examples/webgl2_ubo_arrays.html
+++ b/examples/webgl2_ubo_arrays.html
@@ -100,7 +100,7 @@
 
 		<!-- Import maps polyfill -->
 		<!-- Remove this when import maps will be widely supported -->
-		<script async src="https://unpkg.com/es-module-shims@1.6.3/dist/es-module-shims.js"></script>
+		<script async src="https://cdn.jsdelivr.net/npm/es-module-shims@1.6.3/dist/es-module-shims.js"></script>
 
 		<script type="importmap">
 			{

--- a/examples/webgl_geometry_csg.html
+++ b/examples/webgl_geometry_csg.html
@@ -29,8 +29,8 @@
 				"imports": {
 					"three": "../build/three.module.js",
 					"three/addons/": "./jsm/",
-					"three-mesh-bvh": "https://unpkg.com/three-mesh-bvh@0.7.3/build/index.module.js",
-					"three-bvh-csg": "https://unpkg.com/three-bvh-csg@0.0.16/build/index.module.js"
+					"three-mesh-bvh": "https://cdn.jsdelivr.net/npm/three-mesh-bvh@0.7.3/build/index.module.js",
+					"three-bvh-csg": "https://cdn.jsdelivr.net/npm/three-bvh-csg@0.0.16/build/index.module.js"
 				}
 			}
 		</script>

--- a/examples/webgl_loader_ifc.html
+++ b/examples/webgl_loader_ifc.html
@@ -23,9 +23,9 @@
 					"three": "../build/three.module.js",
 					"three/addons/": "./jsm/",
 					"three/examples/jsm/utils/BufferGeometryUtils": "./jsm/utils/BufferGeometryUtils.js",
-					"three-mesh-bvh": "https://unpkg.com/three-mesh-bvh@0.5.23/build/index.module.js",
-					"web-ifc": "https://unpkg.com/web-ifc@0.0.36/web-ifc-api.js",
-					"web-ifc-three": "https://unpkg.com/web-ifc-three@0.0.126/IFCLoader.js"
+					"three-mesh-bvh": "https://cdn.jsdelivr.net/npm/three-mesh-bvh@0.5.23/build/index.module.js",
+					"web-ifc": "https://cdn.jsdelivr.net/npm/web-ifc@0.0.36/web-ifc-api.js",
+					"web-ifc-three": "https://cdn.jsdelivr.net/npm/web-ifc-three@0.0.126/IFCLoader.js"
 				}
 			}
 		</script>
@@ -72,7 +72,7 @@
 
 				//Setup IFC Loader
 				const ifcLoader = new IFCLoader();
-				await ifcLoader.ifcManager.setWasmPath( 'https://unpkg.com/web-ifc@0.0.36/', true );
+				await ifcLoader.ifcManager.setWasmPath( 'https://cdn.jsdelivr.net/npm/web-ifc@0.0.36/', true );
 
 				await ifcLoader.ifcManager.parser.setupOptionalCategories( {
 					[ IFCSPACE ]: false,

--- a/examples/webgl_loader_texture_hdrjpg.html
+++ b/examples/webgl_loader_texture_hdrjpg.html
@@ -39,7 +39,7 @@
 				"imports": {
 					"three": "../build/three.module.js",
 					"three/addons/": "./jsm/",
-					"@monogrid/gainmap-js": "https://unpkg.com/@monogrid/gainmap-js@3.0.0/dist/decode.js"
+					"@monogrid/gainmap-js": "https://cdn.jsdelivr.net/npm/@monogrid/gainmap-js@3.0.0/dist/decode.js"
 				}
 			}
 		</script>

--- a/examples/webgl_modifier_subdivision.html
+++ b/examples/webgl_modifier_subdivision.html
@@ -18,7 +18,7 @@
 				"imports": {
 					"three": "../build/three.module.js",
 					"three/addons/": "./jsm/",
-					"three-subdivide": "https://unpkg.com/three-subdivide@1.1.2/build/index.module.js"
+					"three-subdivide": "https://cdn.jsdelivr.net/npm/three-subdivide@1.1.2/build/index.module.js"
 				}
 			}
 		</script>

--- a/examples/webgl_raycaster_bvh.html
+++ b/examples/webgl_raycaster_bvh.html
@@ -29,7 +29,7 @@
 				"imports": {
 					"three": "../build/three.module.js",
 					"three/addons/": "./jsm/",
-					"three-mesh-bvh": "https://unpkg.com/three-mesh-bvh@0.7.3/build/index.module.js"
+					"three-mesh-bvh": "https://cdn.jsdelivr.net/npm/three-mesh-bvh@0.7.3/build/index.module.js"
 				}
 			}
 		</script>

--- a/examples/webgl_renderer_pathtracer.html
+++ b/examples/webgl_renderer_pathtracer.html
@@ -44,8 +44,8 @@
 					"three": "../build/three.module.js",
 					"three/addons/": "./jsm/",
 					"three/examples/": "./",
-					"three-gpu-pathtracer": "https://unpkg.com/three-gpu-pathtracer@0.0.20/build/index.module.js",
-					"three-mesh-bvh": "https://unpkg.com/three-mesh-bvh@0.7.3/build/index.module.js"
+					"three-gpu-pathtracer": "https://cdn.jsdelivr.net/npm/three-gpu-pathtracer@0.0.20/build/index.module.js",
+					"three-mesh-bvh": "https://cdn.jsdelivr.net/npm/three-mesh-bvh@0.7.3/build/index.module.js"
 				}
 			}
 		</script>

--- a/examples/webgpu_compute_particles_snow.html
+++ b/examples/webgpu_compute_particles_snow.html
@@ -17,7 +17,7 @@
 					"three": "../build/three.module.js",
 					"three/addons/": "./jsm/",
 					"three/nodes": "./jsm/nodes/Nodes.js",
-					"stats-gl": "https://www.unpkg.com/stats-gl@2.2.6/dist/main.js"
+					"stats-gl": "https://cdn.jsdelivr.net/npm/stats-gl@2.2.6/dist/main.js"
 				}
 			}
 		</script>

--- a/examples/webgpu_mesh_batch.html
+++ b/examples/webgpu_mesh_batch.html
@@ -29,7 +29,7 @@
 				"three": "../build/three.module.js",
 				"three/addons/": "./jsm/",
 				"three/nodes": "./jsm/nodes/Nodes.js",
-				"stats-gl": "https://www.unpkg.com/stats-gl@2.2.7/dist/main.js"
+				"stats-gl": "https://cdn.jsdelivr.net/npm/stats-gl@2.2.7/dist/main.js"
 			}
 		}
 	</script>

--- a/manual/en/fundamentals.html
+++ b/manual/en/fundamentals.html
@@ -404,8 +404,8 @@ You can also use a CDN
 <pre class="prettyprint showlinemods notranslate lang-html" translate="no">&lt;script type="importmap"&gt;
 {
   "imports": {
-    "three": "https://unpkg.com/three@&lt;version&gt;/build/three.module.js",
-    "three/addons/": "https://unpkg.com/three@&lt;version&gt;/examples/jsm/"
+    "three": "https://cdn.jsdelivr.net/npm/three@&lt;version&gt;/build/three.module.js",
+    "three/addons/": "https://cdn.jsdelivr.net/npm/three@&lt;version&gt;/examples/jsm/"
   }
 }
 &lt;/script&gt;

--- a/manual/examples/resources/editor-settings.js
+++ b/manual/examples/resources/editor-settings.js
@@ -169,8 +169,8 @@
 
 		const moduleRE = /(import.*?)('|")(.*?)('|")/g;
 
-		// convert https://threejs.org/build/three.module.js -> https://unpkg.com/three@<version>
-		// convert https://threejs.org/examples/jsm/.?? -> https://unpkg.com/three@<version>/examples/jsm/.??
+		// convert https://threejs.org/build/three.module.js -> https://cdn.jsdelivr.net/npm/three@<version>
+		// convert https://threejs.org/examples/jsm/.?? -> https://cdn.jsdelivr.net/npm/three@<version>/examples/jsm/.??
 
 		if ( ! version ) {
 
@@ -194,12 +194,12 @@
 
 				if ( href.includes( '/build/three.module.js' ) ) {
 
-					return `https://unpkg.com/three@${version}`;
+					return `https://cdn.jsdelivr.net/npm/three@${version}`;
 
 				} else if ( href.includes( '/examples/jsm/' ) ) {
 
 					const url = new URL( href );
-					return `https://unpkg.com/three@${version}${url.pathname}${url.search}${url.hash}`;
+					return `https://cdn.jsdelivr.net/npm/three@${version}${url.pathname}${url.search}${url.hash}`;
 
 				}
 

--- a/manual/examples/resources/editor.html
+++ b/manual/examples/resources/editor.html
@@ -277,7 +277,7 @@ button:focus {
   </div>
 </div>
 </body>
-<script src="https://unpkg.com/monaco-editor@0.40.0/min/vs/loader.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/monaco-editor@0.40.0/min/vs/loader.js"></script>
 <script src="editor-settings.js"></script>
 <script src="editor.js"></script>
 

--- a/manual/examples/resources/editor.js
+++ b/manual/examples/resources/editor.js
@@ -1961,7 +1961,7 @@ async function openInStackBlitz() {
 		} else {
 
 			applySubstitutions();
-			require.config( { paths: { 'vs': 'https://unpkg.com/monaco-editor@0.34.1/min/vs' } } );
+			require.config( { paths: { 'vs': 'https://cdn.jsdelivr.net/npm/monaco-editor@0.34.1/min/vs' } } );
 			require( [ 'vs/editor/editor.main' ], main );
 
 		}

--- a/manual/fr/fundamentals.html
+++ b/manual/fr/fundamentals.html
@@ -418,8 +418,8 @@ import {OrbitControls} from './someFolder/addons/controls/OrbitControls.js';
 </pre>
 <p>Cela est valable aussi lors de l'utilisation d'un CDN. Assurez vous que vos chemins versThis includes when using a CDN. Be  <code class="notranslate" translate="no">three.modules.js</code> terminent par
 <code class="notranslate" translate="no">/build/three.modules.js</code>. Par exemple :</p>
-<pre class="prettyprint">import * as THREE from 'https://unpkg.com/three@&lt;version&gt;/<b>build/three.module.js</b>';
-import {OrbitControls} from 'https://unpkg.com/three@&lt;version&gt;/addons/controls/OrbitControls.js';
+<pre class="prettyprint">import * as THREE from 'https://cdn.jsdelivr.net/npm/three@&lt;version&gt;/<b>build/three.module.js</b>';
+import {OrbitControls} from 'https://cdn.jsdelivr.net/npm/three@&lt;version&gt;/addons/controls/OrbitControls.js';
 </pre>
 </div>
 

--- a/manual/ja/fundamentals.html
+++ b/manual/ja/fundamentals.html
@@ -301,8 +301,8 @@ three.jsの場合、すべてのexamplesを正しいフォルダ階層に入れ�
 import {OrbitControls} from './someFolder/addons/controls/OrbitControls.js';
 </pre>
 <p>これにはCDNを使用する場合も含まれます。 <code class="notranslate" translate="no">three.modules.js</code> のパスが <code class="notranslate" translate="no">/build/three.modules.js</code> のようになってる事を確認して下さい。例えば</p>
-<pre class="prettyprint">import * as THREE from 'https://unpkg.com/three@&lt;version&gt;/<b>build/three.module.js</b>';
-import {OrbitControls} from 'https://unpkg.com/three@&lt;version&gt;/addons/controls/OrbitControls.js';
+<pre class="prettyprint">import * as THREE from 'https://cdn.jsdelivr.net/npm/three@&lt;version&gt;/<b>build/three.module.js</b>';
+import {OrbitControls} from 'https://cdn.jsdelivr.net/npm/three@&lt;version&gt;/addons/controls/OrbitControls.js';
 </pre>
 </div>
 

--- a/manual/ko/fundamentals.html
+++ b/manual/ko/fundamentals.html
@@ -389,8 +389,8 @@ import {OrbitControls} from './someFolder/addons/controls/OrbitControls.js';
 </pre>
 <p>아래는 CDN을 사용하는 예시입니다. <code class="notranslate" translate="no">three.modules.js</code>의 경로가 <code class="notranslate" translate="no">/build/three.modules.js</code>
 로 끝나야 한다는 것을 명심하세요.</p>
-<pre class="prettyprint">import * as THREE from 'https://unpkg.com/three@&lt;version&gt;/<b>build/three.module.js</b>';
-import {OrbitControls} from 'https://unpkg.com/three@&lt;version&gt;/addons/controls/OrbitControls.js';
+<pre class="prettyprint">import * as THREE from 'https://cdn.jsdelivr.net/npm/three@&lt;version&gt;/<b>build/three.module.js</b>';
+import {OrbitControls} from 'https://cdn.jsdelivr.net/npm/three@&lt;version&gt;/addons/controls/OrbitControls.js';
 </pre>
 </div>
         </div>

--- a/manual/zh/fundamentals.html
+++ b/manual/zh/fundamentals.html
@@ -302,8 +302,8 @@ import {OrbitControls} from './someFolder/addons/controls/OrbitControls.js';
 </pre>
 <p>在使用CDN时，是同样的道理。确保<code class="notranslate" translate="no">three.modules.js</code>的路径以
 <code class="notranslate" translate="no">/build/three.modules.js</code>结尾，比如</p>
-<pre class="prettyprint">import * as THREE from 'https://unpkg.com/three@&lt;version&gt;/<b>build/three.module.js</b>';
-import {OrbitControls} from 'https://unpkg.com/three@&lt;version&gt;/addons/controls/OrbitControls.js';
+<pre class="prettyprint">import * as THREE from 'https://cdn.jsdelivr.net/npm/three@&lt;version&gt;/<b>build/three.module.js</b>';
+import {OrbitControls} from 'https://cdn.jsdelivr.net/npm/three@&lt;version&gt;/addons/controls/OrbitControls.js';
 </pre>
 </div>
         </div>


### PR DESCRIPTION
Will resolve #28002 

### Description

I changed the CDN from unpkg to jsDelivr.

`unpkg.com/` -> `cdn.jsdelivr.net/npm/`

I checked all changed examples, editor, manuals are working properly.

### Context

unpkg is not reliable, especially when we are using NodeMaterials since there are a lot of modules to load.

See: https://github.com/mrdoob/three.js/issues/28002#issuecomment-2019553689

### Notes

- Note that I also replaced in `editor-settings.js`
- I excluded `editor/js/libs/ffmpeg.min.js` and `examples/jsm/libs/chevrotain.module.min.js`
- `webgl2_ubo_arrays.html` still imports es-module-shims, is this required?
