### PR TITLE
WebGPURenderer: Add (u)int16 Support

### DIFF
--- a/examples/jsm/nodes/accessors/BatchNode.js
+++ b/examples/jsm/nodes/accessors/BatchNode.js
@@ -4,8 +4,7 @@ import { positionLocal } from './PositionNode.js';
 import { nodeProxy, vec3, mat3, mat4, int, ivec2, float } from '../shadernode/ShaderNode.js';
 import { textureLoad } from './TextureNode.js';
 import { textureSize } from './TextureSizeNode.js';
-import { Float32BufferAttribute } from 'three';
-import { bufferAttribute } from './BufferAttributeNode.js';
+import { attribute } from '../core/AttributeNode.js';
 import { tangentLocal } from './TangentNode.js';
 
 class BatchNode extends Node {
@@ -29,12 +28,7 @@ class BatchNode extends Node {
 
 		if ( this.batchingIdNode === null ) {
 
-			const batchingAttribute = this.batchMesh.geometry.getAttribute( 'batchId' );
-			const array = new Float32Array( batchingAttribute.array );
-
-			const buffer = new Float32BufferAttribute( array, 1 );
-
-			this.batchingIdNode = bufferAttribute( buffer, 'float' ).toVar();
+			this.batchingIdNode = attribute( 'batchId' );
 
 		}
 

--- a/examples/jsm/renderers/webgl/nodes/GLSLNodeBuilder.js
+++ b/examples/jsm/renderers/webgl/nodes/GLSLNodeBuilder.js
@@ -390,7 +390,7 @@ ${ flowData.code }
 
 			const array = dataAttribute.array;
 
-			if ( ( array instanceof Uint32Array || array instanceof Int32Array || array instanceof Uint16Array || array instanceof Int16Array ) === false ) {
+			if ( ( array instanceof Uint32Array || array instanceof Int32Array ) ) {
 
 				nodeType = nodeType.slice( 1 );
 

--- a/examples/jsm/renderers/webgl/nodes/GLSLNodeBuilder.js
+++ b/examples/jsm/renderers/webgl/nodes/GLSLNodeBuilder.js
@@ -390,7 +390,7 @@ ${ flowData.code }
 
 			const array = dataAttribute.array;
 
-			if ( ( array instanceof Uint32Array || array instanceof Int32Array ) ) {
+			if ( ( array instanceof Uint32Array || array instanceof Int32Array || array instanceof Uint16Array || array instanceof Int16Array ) === false ) {
 
 				nodeType = nodeType.slice( 1 );
 

--- a/examples/jsm/renderers/webgl/nodes/GLSLNodeBuilder.js
+++ b/examples/jsm/renderers/webgl/nodes/GLSLNodeBuilder.js
@@ -390,7 +390,7 @@ ${ flowData.code }
 
 			const array = dataAttribute.array;
 
-			if ( ( array instanceof Uint32Array || array instanceof Int32Array ) === false ) {
+			if ( ( array instanceof Uint32Array || array instanceof Int32Array || array instanceof Uint16Array || array instanceof Int16Array ) === false ) {
 
 				nodeType = nodeType.slice( 1 );
 

--- a/examples/jsm/renderers/webgl/utils/WebGLAttributeUtils.js
+++ b/examples/jsm/renderers/webgl/utils/WebGLAttributeUtils.js
@@ -1,3 +1,5 @@
+import { IntType } from 'three';
+
 let _id = 0;
 
 class DualAttributeData {
@@ -78,19 +80,16 @@ class WebGLAttributeUtils {
 		//attribute.onUploadCallback();
 
 		let type;
-		let isInteger = true;
 
 		if ( array instanceof Float32Array ) {
 
 			type = gl.FLOAT;
-			isInteger = false;
 
 		} else if ( array instanceof Uint16Array ) {
 
 			if ( attribute.isFloat16BufferAttribute ) {
 
 				type = gl.HALF_FLOAT;
-				isInteger = false;
 
 			} else {
 
@@ -136,7 +135,7 @@ class WebGLAttributeUtils {
 			bytesPerElement: array.BYTES_PER_ELEMENT,
 			version: attribute.version,
 			pbo: attribute.pbo,
-			isInteger,
+			isInteger: type === gl.INT || type === gl.UNSIGNED_INT || type === gl.UNSIGNED_SHORT || attribute.gpuType === IntType,
 			id: _id ++
 		};
 

--- a/examples/jsm/renderers/webgl/utils/WebGLAttributeUtils.js
+++ b/examples/jsm/renderers/webgl/utils/WebGLAttributeUtils.js
@@ -1,5 +1,3 @@
-import { IntType } from 'three';
-
 let _id = 0;
 
 class DualAttributeData {
@@ -80,16 +78,19 @@ class WebGLAttributeUtils {
 		//attribute.onUploadCallback();
 
 		let type;
+		let isInteger = true;
 
 		if ( array instanceof Float32Array ) {
 
 			type = gl.FLOAT;
+			isInteger = false;
 
 		} else if ( array instanceof Uint16Array ) {
 
 			if ( attribute.isFloat16BufferAttribute ) {
 
 				type = gl.HALF_FLOAT;
+				isInteger = false;
 
 			} else {
 
@@ -135,7 +136,7 @@ class WebGLAttributeUtils {
 			bytesPerElement: array.BYTES_PER_ELEMENT,
 			version: attribute.version,
 			pbo: attribute.pbo,
-			isInteger: type === gl.INT || type === gl.UNSIGNED_INT || attribute.gpuType === IntType,
+			isInteger,
 			id: _id ++
 		};
 

--- a/examples/jsm/renderers/webgpu/utils/WebGPUAttributeUtils.js
+++ b/examples/jsm/renderers/webgpu/utils/WebGPUAttributeUtils.js
@@ -17,7 +17,9 @@ const typedAttributeToVertexFormatPrefix = new Map( [
 
 const typeArraysToVertexFormatPrefixForItemSize1 = new Map( [
 	[ Int32Array, 'sint32' ],
+	[ Int16Array, 'sint32' ], // patch for INT16
 	[ Uint32Array, 'uint32' ],
+	[ Uint16Array, 'uint32' ], // patch for UINT16
 	[ Float32Array, 'float32' ]
 ] );
 
@@ -43,6 +45,22 @@ class WebGPUAttributeUtils {
 			const device = backend.device;
 
 			let array = bufferAttribute.array;
+
+			// patch for INT16 and UINT16
+			if ( array.constructor === Int16Array || array.constructor === Uint16Array ) {
+
+				const tempArray = new Uint32Array( array.length );
+				for ( let i = 0; i < array.length; i ++ ) {
+
+					tempArray[ i ] = array[ i ];
+
+				}
+
+				array = tempArray;
+
+			}
+
+			bufferAttribute.array = array;
 
 			if ( ( bufferAttribute.isStorageBufferAttribute || bufferAttribute.isStorageInstancedBufferAttribute ) && bufferAttribute.itemSize === 3 ) {
 
@@ -146,6 +164,13 @@ class WebGPUAttributeUtils {
 
 					arrayStride = geometryAttribute.itemSize * bytesPerElement;
 					stepMode = geometryAttribute.isInstancedBufferAttribute ? GPUInputStepMode.Instance : GPUInputStepMode.Vertex;
+
+				}
+
+				// patch for INT16 and UINT16
+				if ( geometryAttribute.array.constructor === Int16Array || geometryAttribute.array.constructor === Uint16Array ) {
+
+					arrayStride = 4;
 
 				}
 


### PR DESCRIPTION
**Description**

This PR adds the support to int16 and uint16 to the WebGL Backend and also handle automatically the conversion to int32 and uint32 typed arrays in WebGPU since 16 format is not available by default.

*This contribution is funded by [Utsubo](https://utsubo.com)*
