### PR TITLE
Node: Rename `.setReference()` -> `.updateReference()` and use reference in `renderMap`/`frameMap`

### DIFF
--- a/examples/jsm/nodes/accessors/MaterialReferenceNode.js
+++ b/examples/jsm/nodes/accessors/MaterialReferenceNode.js
@@ -24,7 +24,7 @@ class MaterialReferenceNode extends ReferenceNode {
 
 	}*/
 
-	setReference( state ) {
+	updateReference( state ) {
 
 		this.reference = this.material !== null ? this.material : state.material;
 

--- a/examples/jsm/nodes/accessors/ReferenceNode.js
+++ b/examples/jsm/nodes/accessors/ReferenceNode.js
@@ -110,7 +110,7 @@ class ReferenceNode extends Node {
 
 	}
 
-	setReference( state ) {
+	updateReference( state ) {
 
 		this.reference = this.object !== null ? this.object : state.object;
 

--- a/examples/jsm/nodes/accessors/RendererReferenceNode.js
+++ b/examples/jsm/nodes/accessors/RendererReferenceNode.js
@@ -12,7 +12,7 @@ class RendererReferenceNode extends ReferenceNode {
 
 	}
 
-	setReference( state ) {
+	updateReference( state ) {
 
 		this.reference = this.renderer !== null ? this.renderer : state.renderer;
 

--- a/examples/jsm/nodes/accessors/TextureNode.js
+++ b/examples/jsm/nodes/accessors/TextureNode.js
@@ -79,7 +79,7 @@ class TextureNode extends UniformNode {
 
 	}
 
-	setReference( /*state*/ ) {
+	updateReference( /*state*/ ) {
 
 		return this.value;
 

--- a/examples/jsm/nodes/core/Node.js
+++ b/examples/jsm/nodes/core/Node.js
@@ -82,7 +82,7 @@ class Node extends EventDispatcher {
 
 	}
 
-	setReference( /*state*/ ) {
+	updateReference( /*state*/ ) {
 
 		return this;
 
@@ -282,7 +282,7 @@ class Node extends EventDispatcher {
 
 		if ( buildStage === 'setup' ) {
 
-			this.setReference( builder );
+			this.updateReference( builder );
 
 			const properties = builder.getNodeProperties( this );
 

--- a/examples/jsm/nodes/core/NodeFrame.js
+++ b/examples/jsm/nodes/core/NodeFrame.js
@@ -51,11 +51,11 @@ class NodeFrame {
 
 			const { frameMap } = this._getMaps( this.updateBeforeMap, reference );
 
-			if ( frameMap.get( node ) !== this.frameId ) {
+			if ( frameMap.get( reference ) !== this.frameId ) {
 
 				if ( node.updateBefore( this ) !== false ) {
 
-					frameMap.set( node, this.frameId );
+					frameMap.set( reference, this.frameId );
 
 				}
 
@@ -65,11 +65,11 @@ class NodeFrame {
 
 			const { renderMap } = this._getMaps( this.updateBeforeMap, reference );
 
-			if ( renderMap.get( node ) !== this.renderId ) {
+			if ( renderMap.get( reference ) !== this.renderId ) {
 
 				if ( node.updateBefore( this ) !== false ) {
 
-					renderMap.set( node, this.renderId );
+					renderMap.set( reference, this.renderId );
 
 				}
 
@@ -92,11 +92,11 @@ class NodeFrame {
 
 			const { frameMap } = this._getMaps( this.updateMap, reference );
 
-			if ( frameMap.get( node ) !== this.frameId ) {
+			if ( frameMap.get( reference ) !== this.frameId ) {
 
 				if ( node.update( this ) !== false ) {
 
-					frameMap.set( node, this.frameId );
+					frameMap.set( reference, this.frameId );
 
 				}
 
@@ -106,11 +106,11 @@ class NodeFrame {
 
 			const { renderMap } = this._getMaps( this.updateMap, reference );
 
-			if ( renderMap.get( node ) !== this.renderId ) {
+			if ( renderMap.get( reference ) !== this.renderId ) {
 
 				if ( node.update( this ) !== false ) {
 
-					renderMap.set( node, this.renderId );
+					renderMap.set( reference, this.renderId );
 
 				}
 

--- a/examples/jsm/nodes/core/NodeFrame.js
+++ b/examples/jsm/nodes/core/NodeFrame.js
@@ -45,7 +45,7 @@ class NodeFrame {
 	updateBeforeNode( node ) {
 
 		const updateType = node.getUpdateBeforeType();
-		const reference = node.setReference( this );
+		const reference = node.updateReference( this );
 
 		if ( updateType === NodeUpdateType.FRAME ) {
 
@@ -86,7 +86,7 @@ class NodeFrame {
 	updateNode( node ) {
 
 		const updateType = node.getUpdateType();
-		const reference = node.setReference( this );
+		const reference = node.updateReference( this );
 
 		if ( updateType === NodeUpdateType.FRAME ) {
 

--- a/examples/jsm/nodes/display/ViewportSharedTextureNode.js
+++ b/examples/jsm/nodes/display/ViewportSharedTextureNode.js
@@ -20,6 +20,12 @@ class ViewportSharedTextureNode extends ViewportTextureNode {
 
 	}
 
+	updateReference() {
+
+		return this;
+
+	}
+
 }
 
 export default ViewportSharedTextureNode;


### PR DESCRIPTION
**Description**

I believe the name better represents the purpose, this also corrects duplicate event calls when used in the same references.
