### PR TITLE
Examples: Some revision of webgpu examples

### DIFF
--- a/examples/webgpu_compute_texture_pingpong.html
+++ b/examples/webgpu_compute_texture_pingpong.html
@@ -40,7 +40,6 @@
 			const seed = uniform( new THREE.Vector2() );
 
 			init();
-			render();
 
 			function init() {
 
@@ -163,7 +162,7 @@
 
 				// compute init
 
-				renderer.compute( computeInitNode );
+				renderer.computeAsync( computeInitNode );
 
 			}
 
@@ -179,8 +178,6 @@
 				camera.right = frustumHeight * aspect / 2;
 
 				camera.updateProjectionMatrix();
-
-				render();
 
 			}
 

--- a/examples/webgpu_postprocessing_anamorphic.html
+++ b/examples/webgpu_postprocessing_anamorphic.html
@@ -48,7 +48,7 @@
 
 			init();
 
-			function init() {
+			async function init() {
 
 				if ( WebGPU.isAvailable() === false && WebGL.isWebGL2Available() === false ) {
 
@@ -67,10 +67,10 @@
 				scene = new THREE.Scene();
 
 				const rgbmUrls = [ 'px.png', 'nx.png', 'py.png', 'ny.png', 'pz.png', 'nz.png' ];
-				const cube1Texture = new RGBMLoader()
+				const cube1Texture = await new RGBMLoader()
 					.setMaxRange( 16 )
 					.setPath( './textures/cube/pisaRGBM16/' )
-					.loadCubemap( rgbmUrls );
+					.loadCubemapAsync( rgbmUrls );
 
 				scene.environment = cube1Texture;
 				scene.backgroundNode = cubeTexture( cube1Texture ).mul( viewportTopLeft.distance( .5 ).oneMinus().remapClamp( .1, 4 ) ).saturation( 0 );

--- a/examples/webgpu_shadowmap.html
+++ b/examples/webgpu_shadowmap.html
@@ -31,7 +31,7 @@
 			import WebGPURenderer from 'three/addons/renderers/webgpu/WebGPURenderer.js';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
-			import { vec4, tslFn, vertexIndex, MeshPhongNodeMaterial } from 'three/nodes';
+			import { vec4, tslFn, color, vertexIndex, MeshPhongNodeMaterial } from 'three/nodes';
 			let camera, scene, renderer, clock;
 			let dirLight, spotLight;
 			let torusKnot, dirGroup;
@@ -52,7 +52,7 @@
 				camera.position.set( 0, 10, 20 );
 
 				scene = new THREE.Scene();
-				scene.background = new THREE.Color( 0x222244 );
+				scene.backgroundNode = color( 0x222244 );
 				scene.fog = new THREE.Fog( 0x222244, 50, 100 );
 
 				// lights


### PR DESCRIPTION
**Description**

- [webgpu_compute_texture_pingpong: use .computeAsync()](https://github.com/mrdoob/three.js/commit/8ecf8ecd674ed4b479b50d13c5a2a8f5067cd971)
Fix warn to use `renderer.computeAsync()`

- [webgpu_postprocessing_anamorphic: use .loadCubemapAsync()](https://github.com/mrdoob/three.js/commit/a6c9fa66b1fe34036f17fc57e6aa74bc338236a9)
Fix non-loaded texture used in `pmremTexture()` 

- [webgpu_shadowmap: use scene.backgroundNode](https://github.com/mrdoob/three.js/commit/5f7ecdad0ec80d5162c27a769ca6e8eeb1bc9ae4)
Apply tone mapping in background color.
