### PR TITLE
Raycaster.setFromCamera: Position the ray origin such that it is on the camera near plane

### DIFF
--- a/src/core/Raycaster.js
+++ b/src/core/Raycaster.js
@@ -38,13 +38,13 @@ class Raycaster {
 
 		if ( camera.isPerspectiveCamera ) {
 
-			this.ray.origin.setFromMatrixPosition( camera.matrixWorld );
+			this.ray.origin.set( coords.x, coords.y, - 1 ).unproject( camera );
 			this.ray.direction.set( coords.x, coords.y, 0.5 ).unproject( camera ).sub( this.ray.origin ).normalize();
 			this.camera = camera;
 
 		} else if ( camera.isOrthographicCamera ) {
 
-			this.ray.origin.set( coords.x, coords.y, ( camera.near + camera.far ) / ( camera.near - camera.far ) ).unproject( camera ); // set origin in plane of camera
+			this.ray.origin.set( coords.x, coords.y, - 1 ).unproject( camera );
 			this.ray.direction.set( 0, 0, - 1 ).transformDirection( camera.matrixWorld );
 			this.camera = camera;
 

--- a/test/unit/src/core/Raycaster.tests.js
+++ b/test/unit/src/core/Raycaster.tests.js
@@ -12,8 +12,12 @@ import { OrthographicCamera } from '../../../../src/cameras/OrthographicCamera.j
 
 function checkRayDirectionAgainstReferenceVector( rayDirection, refVector, assert ) {
 
-	assert.ok( refVector.x - rayDirection.x <= Number.EPSILON && refVector.y - rayDirection.y <= Number.EPSILON && refVector.z - rayDirection.z <= Number.EPSILON, 'camera is pointing to' +
-		' the same direction as expected' );
+	assert.ok(
+		refVector.x - rayDirection.x <= Number.EPSILON &&
+		refVector.y - rayDirection.y <= Number.EPSILON &&
+		refVector.z - rayDirection.z <= Number.EPSILON,
+		'camera is pointing to the same direction as expected'
+	);
 
 }
 
@@ -141,7 +145,7 @@ export default QUnit.module( 'Core', () => {
 
 			const raycaster = new Raycaster();
 			const rayDirection = raycaster.ray.direction;
-			const camera = new PerspectiveCamera( 90, 1, 1, 1000 );
+			const camera = new PerspectiveCamera( 90, 1, 0.1, 1000 );
 
 			raycaster.setFromCamera( {
 				x: 0,


### PR DESCRIPTION
Fix #28026

**Description**

Adjust `Raycaster.setFromCamera` so the origin is placed on the camera near plane.