### PR TITLE
Playground: Fix NodePrototypes being available across load/save-cycles

### DIFF
--- a/playground/editors/NodePrototypeEditor.js
+++ b/playground/editors/NodePrototypeEditor.js
@@ -87,6 +87,12 @@ export class NodePrototypeEditor extends JavaScriptEditor {
 
 	setEditor( editor ) {
 
+		if ( editor === null && this.editor ) {
+
+			this.editor.removeClass( this._prototype );
+
+		}
+
 		super.setEditor( editor );
 
 		if ( editor === null ) {


### PR DESCRIPTION
**Description**

When using Node Prototypes and loading a new scene in the playground, the classes generated by the Node Prototypes don't get removed from the search menu, such that classes that existed in the last scene could be used in the new one.
Example: Open the Playground, you'll see the teapot scene:
![image](https://github.com/mrdoob/three.js/assets/21260178/37c32d22-85e0-4f91-a1d3-641f553eddf5)
Now, create a new scene and search for the "Teapot Scene":
![image](https://github.com/mrdoob/three.js/assets/21260178/25d38580-966b-49cc-9d5c-1455ba78901a)

This PR fixes that by removing the class properly when removing the Node Prototype.
