### PR TITLE
Fix ball impulse for FPS game example

### DIFF
--- a/examples/games_fps.html
+++ b/examples/games_fps.html
@@ -138,7 +138,7 @@
 
 			} );
 
-			container.addEventListener( 'mousedown', () => {
+			document.addEventListener( 'mousedown', () => {
 
 				document.body.requestPointerLock();
 


### PR DESCRIPTION
Currently the `mousedown` event is only triggered once because the call to `requestPointerLock` blocks any following click made from the mouse to trigger `mousedown` again. This results in `mouseTime` never being reevaluated and, as the ball impulse force is using this value, the ball uses max force each time we click (instead of being based on the click duration).