### PR TITLE
WebGPURenderer: Add batch texture to cacheKey

### DIFF
--- a/examples/jsm/renderers/common/RenderObject.js
+++ b/examples/jsm/renderers/common/RenderObject.js
@@ -186,6 +186,12 @@ export default class RenderObject {
 
 		}
 
+		if ( object.isBatchedMesh ) {
+
+			cacheKey += object._matricesTexture.uuid + ',';
+
+		}
+
 		return cacheKey;
 
 	}


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/27937#issuecomment-2026674350

**Description**

The update of the BatchedMesh texture wasn't properly translated in the Node System. This PR fix the issue by adding the batch texture ID to the cacheKey.

New working example:
https://raw.githack.com/renaudrohlinger/three.js/utsubo/fix/batch-dynamic/examples/webgpu_mesh_batch.html

/cc @mrdoob @sunag 

*This contribution is funded by [Utsubo](https://utsubo.com)*
