### PR TITLE
WebGPURenderer: Apply setupDepth even if fragmentNode isn't null

### DIFF
--- a/examples/jsm/nodes/materials/NodeMaterial.js
+++ b/examples/jsm/nodes/materials/NodeMaterial.js
@@ -96,9 +96,9 @@ class NodeMaterial extends ShaderMaterial {
 
 		const clippingNode = this.setupClipping( builder );
 
-		if ( this.fragmentNode === null ) {
+		if ( this.depthWrite === true ) this.setupDepth( builder );
 
-			if ( this.depthWrite === true ) this.setupDepth( builder );
+		if ( this.fragmentNode === null ) {
 
 			if ( this.normals === true ) this.setupNormal( builder );
 


### PR DESCRIPTION
**Description**

Building on issue #28042, similar to `clippingNode`, this pull request ensures that the shared custom `depthNode` is applied even when the `fragmentNode` is not null. This adjustment is crucial because `setupShadow` generates an `overrideMaterial` that, by default, includes a `fragmentNode`.

/cc @sunag 

*This contribution is funded by [Utsubo](https://utsubo.com)*
