### PR TITLE
USDZExporter: Rename parse to parseAsync

### DIFF
--- a/editor/js/Menubar.File.js
+++ b/editor/js/Menubar.File.js
@@ -278,7 +278,7 @@ function MenubarFile( editor ) {
 
 		const exporter = new USDZExporter();
 
-		saveArrayBuffer( await exporter.parse( editor.scene ), 'model.usdz' );
+		saveArrayBuffer( await exporter.parseAsync( editor.scene ), 'model.usdz' );
 
 	} );
 	options.add( option );

--- a/examples/jsm/exporters/USDZExporter.js
+++ b/examples/jsm/exporters/USDZExporter.js
@@ -12,7 +12,13 @@ import { decompress } from './../utils/TextureUtils.js';
 
 class USDZExporter {
 
-	async parse( scene, options = {} ) {
+	parse( scene, onDone, onError, options ) {
+
+		this.parseAsync( scene, options ).then( onDone ).catch( onError );
+
+	}
+
+	async parseAsync( scene, options = {} ) {
 
 		options = Object.assign( {
 			ar: {

--- a/examples/misc_exporter_usdz.html
+++ b/examples/misc_exporter_usdz.html
@@ -97,7 +97,7 @@
 					// USDZ
 
 					const exporter = new USDZExporter();
-					const arraybuffer = await exporter.parse( gltf.scene );
+					const arraybuffer = await exporter.parseAsync( gltf.scene );
 					const blob = new Blob( [ arraybuffer ], { type: 'application/octet-stream' } );
 
 					const link = document.getElementById( 'link' );


### PR DESCRIPTION
Related issue: [#28050](https://github.com/mrdoob/three.js/issues/28050)

**Description**

Adjust naming consistency for USDZExporter
