### PR TITLE
WebGPURenderer: Align depth range of WebGPU and WebGL backends

### DIFF
--- a/examples/jsm/nodes/display/ViewportDepthNode.js
+++ b/examples/jsm/nodes/display/ViewportDepthNode.js
@@ -3,7 +3,7 @@ import { nodeImmutable, nodeProxy } from '../shadernode/ShaderNode.js';
 import { cameraNear, cameraFar } from '../accessors/CameraNode.js';
 import { positionView } from '../accessors/PositionNode.js';
 import { viewportDepthTexture } from './ViewportDepthTextureNode.js';
-
+import { WebGLCoordinateSystem } from 'three';
 class ViewportDepthNode extends Node {
 
 	constructor( scope, valueNode = null ) {
@@ -31,7 +31,7 @@ class ViewportDepthNode extends Node {
 
 	}
 
-	setup( /*builder*/ ) {
+	setup( builder ) {
 
 		const { scope } = this;
 
@@ -52,7 +52,16 @@ class ViewportDepthNode extends Node {
 
 			if ( this.valueNode !== null ) {
 
- 				node = depthPixelBase().assign( this.valueNode );
+				let depth = this.valueNode;
+
+				// WebGL: Conversion [ -1, 0 ] to [ 0, 1 ], without EXT_depth_clamp extension WebGL internally clamps these values to the range [0, 1] during the rasterization process
+				if ( builder.renderer.coordinateSystem === WebGLCoordinateSystem ) {
+
+					depth = depth.add( 1 ).div( 2 );
+
+				}
+
+ 				node = depthPixelBase().assign( depth );
 
 			}
 


### PR DESCRIPTION
**Description**
When overriding the `depthPixelBase`, both backends display different behaviors related to their distinct depth ranges, with WebGPU being `[0, 1]` and WebGL being `[-1, 1]`.

It seems that without extensions such as `EXT_depth_clamp`, WebGL internally clamps these values to the range [0, 1] during the rasterization process. So, I believe that it wouldn't be wrong to handle it internally, ensuring that if a user overrides the depth of a material, both backends will show the same result.


Edit: Or should we do the opposite and handle WebGL depth range first? I'm not sure, it seems that the case is very variable on if we want to handle it manually. For example the issue I was solving there was that using `0.5 * modelViewMatrix.z / modelViewMatrix.w + 0.5` breaks in WebGPU as it should be `modelViewMatrix.z / modelViewMatrix.w`.

*This contribution is funded by [Utsubo](https://utsubo.com)*
