### PR TITLE
Pass `onLoad` callback to `XRHandModelFactory` and `OculusHandModel`

### DIFF
--- a/examples/jsm/webxr/OculusHandModel.js
+++ b/examples/jsm/webxr/OculusHandModel.js
@@ -6,7 +6,7 @@ const POINTING_JOINT = 'index-finger-tip';
 
 class OculusHandModel extends Object3D {
 
-	constructor( controller, loader = null ) {
+	constructor( controller, loader = null, onLoad = null ) {
 
 		super();
 
@@ -14,6 +14,7 @@ class OculusHandModel extends Object3D {
 		this.motionController = null;
 		this.envMap = null;
 		this.loader = loader;
+		this.onLoad = onLoad;
 
 		this.mesh = null;
 
@@ -25,7 +26,7 @@ class OculusHandModel extends Object3D {
 
 				this.xrInputSource = xrInputSource;
 
-				this.motionController = new XRHandMeshModel( this, controller, this.path, xrInputSource.handedness, this.loader );
+				this.motionController = new XRHandMeshModel( this, controller, this.path, xrInputSource.handedness, this.loader, this.onLoad );
 
 			}
 

--- a/examples/jsm/webxr/XRHandModelFactory.js
+++ b/examples/jsm/webxr/XRHandModelFactory.js
@@ -40,7 +40,7 @@ class XRHandModel extends Object3D {
 
 class XRHandModelFactory {
 
-	constructor(gltfLoader = null, onLoad = null) {
+	constructor( gltfLoader = null, onLoad = null ) {
 
 		this.gltfLoader = gltfLoader;
 		this.path = null;

--- a/examples/jsm/webxr/XRHandModelFactory.js
+++ b/examples/jsm/webxr/XRHandModelFactory.js
@@ -40,9 +40,11 @@ class XRHandModel extends Object3D {
 
 class XRHandModelFactory {
 
-	constructor() {
+	constructor(gltfLoader = null, onLoad = null) {
 
+		this.gltfLoader = gltfLoader;
 		this.path = null;
+		this.onLoad = onLoad;
 
 	}
 
@@ -77,7 +79,7 @@ class XRHandModelFactory {
 
 				} else if ( profile === 'mesh' ) {
 
-					handModel.motionController = new XRHandMeshModel( handModel, controller, this.path, xrInputSource.handedness );
+					handModel.motionController = new XRHandMeshModel( handModel, controller, this.path, xrInputSource.handedness, this.gltfLoader, this.onLoad );
 
 				}
 


### PR DESCRIPTION
Allows passing an onLoad callback to `XRHandModelFactory` and `OculusHandModel`, the same way it is implemented in `XRControllerModelFactory`. 

For XR applications, this can be particularly useful to override the default MeshStandardMaterial of the hand models for cheaper materials that could help in getting higher FPS.
