### PR TITLE
WebGLRenderer: Improve efficiency of transmission pass for WebXR

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1150,6 +1150,13 @@ class WebGLRenderer {
 
 			}
 
+			const renderBackground = xr.enabled === false || xr.isPresenting === false || xr.hasDepthSensing() === false;
+			if ( renderBackground ) {
+
+				background.addToRenderList( currentRenderList, scene );
+
+			}
+
 			//
 
 			this.info.render.frame ++;
@@ -1165,15 +1172,6 @@ class WebGLRenderer {
 			//
 
 			if ( this.info.autoReset === true ) this.info.reset();
-
-
-			//
-
-			if ( xr.enabled === false || xr.isPresenting === false || xr.hasDepthSensing() === false ) {
-
-				background.render( currentRenderList, scene );
-
-			}
 
 			// render scene
 
@@ -1198,6 +1196,8 @@ class WebGLRenderer {
 
 				}
 
+				if ( renderBackground ) background.render( scene );
+
 				for ( let i = 0, l = cameras.length; i < l; i ++ ) {
 
 					const camera2 = cameras[ i ];
@@ -1209,6 +1209,8 @@ class WebGLRenderer {
 			} else {
 
 				if ( transmissiveObjects.length > 0 ) renderTransmissionPass( opaqueObjects, transmissiveObjects, scene, camera );
+
+				if ( renderBackground ) background.render( scene );
 
 				renderScene( currentRenderList, scene, camera );
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1427,7 +1427,7 @@ class WebGLRenderer {
 				} );
 
 				const renderTargetProperties = properties.get( currentRenderState.state.transmissionRenderTarget[ camera.id ] );
-				renderTargetProperties.__isTransmissionRenderTarget = true;
+				renderTargetProperties.__ignoreDepthValues = true;
 
 				// debug
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -26,7 +26,6 @@ import {
 import { Color } from '../math/Color.js';
 import { Frustum } from '../math/Frustum.js';
 import { Matrix4 } from '../math/Matrix4.js';
-import { Vector2 } from '../math/Vector2.js';
 import { Vector3 } from '../math/Vector3.js';
 import { Vector4 } from '../math/Vector4.js';
 import { WebGLAnimation } from './webgl/WebGLAnimation.js';
@@ -205,7 +204,6 @@ class WebGLRenderer {
 
 		const _projScreenMatrix = new Matrix4();
 
-		const _vector2 = new Vector2();
 		const _vector3 = new Vector3();
 
 		const _emptyScene = { background: null, fog: null, environment: null, overrideMaterial: null, isScene: true };
@@ -1428,8 +1426,8 @@ class WebGLRenderer {
 
 			const transmissionRenderTarget = currentRenderState.state.transmissionRenderTarget;
 
-			_this.getDrawingBufferSize( _vector2 );
-			transmissionRenderTarget.setSize( _vector2.x, _vector2.y );
+			const activeViewport = camera.viewport || _currentViewport;
+			transmissionRenderTarget.setSize( activeViewport.z, activeViewport.w );
 
 			//
 
@@ -1446,6 +1444,15 @@ class WebGLRenderer {
 			// Otherwise they are applied twice in opaque objects pass and transmission objects pass.
 			const currentToneMapping = _this.toneMapping;
 			_this.toneMapping = NoToneMapping;
+
+			// Remove viewport from camera to avoid nested render calls resetting viewport to it (e.g Reflector).
+			// Transmission render pass requires viewport to match the transmissionRenderTarget.
+			const currentCameraViewport = camera.viewport;
+			if ( camera.viewport !== undefined ) {
+
+				camera.viewport = undefined;
+
+			}
 
 			renderObjects( opaqueObjects, scene, camera );
 
@@ -1491,6 +1498,8 @@ class WebGLRenderer {
 			_this.setRenderTarget( currentRenderTarget );
 
 			_this.setClearColor( _currentClearColor, _currentClearAlpha );
+
+			camera.viewport = currentCameraViewport;
 
 			_this.toneMapping = currentToneMapping;
 

--- a/src/renderers/webgl/WebGLBackground.js
+++ b/src/renderers/webgl/WebGLBackground.js
@@ -26,9 +26,8 @@ function WebGLBackground( renderer, cubemaps, cubeuvmaps, state, objects, alpha,
 	let currentBackgroundVersion = 0;
 	let currentTonemapping = null;
 
-	function render( renderList, scene ) {
+	function getBackground( scene ) {
 
-		let forceClear = false;
 		let background = scene.isScene === true ? scene.background : null;
 
 		if ( background && background.isTexture ) {
@@ -37,6 +36,15 @@ function WebGLBackground( renderer, cubemaps, cubeuvmaps, state, objects, alpha,
 			background = ( usePMREM ? cubeuvmaps : cubemaps ).get( background );
 
 		}
+
+		return background;
+
+	}
+
+	function render( scene ) {
+
+		let forceClear = false;
+		const background = getBackground( scene );
 
 		if ( background === null ) {
 
@@ -66,6 +74,12 @@ function WebGLBackground( renderer, cubemaps, cubeuvmaps, state, objects, alpha,
 			renderer.clear( renderer.autoClearColor, renderer.autoClearDepth, renderer.autoClearStencil );
 
 		}
+
+	}
+
+	function addToRenderList( renderList, scene ) {
+
+		const background = getBackground( scene );
 
 		if ( background && ( background.isCubeTexture || background.mapping === CubeUVReflectionMapping ) ) {
 
@@ -247,7 +261,8 @@ function WebGLBackground( renderer, cubemaps, cubeuvmaps, state, objects, alpha,
 			setClear( clearColor, clearAlpha );
 
 		},
-		render: render
+		render: render,
+		addToRenderList: addToRenderList
 
 	};
 

--- a/src/renderers/webgl/WebGLRenderStates.js
+++ b/src/renderers/webgl/WebGLRenderStates.js
@@ -44,7 +44,7 @@ function WebGLRenderState( extensions ) {
 
 		lights: lights,
 
-		transmissionRenderTarget: null
+		transmissionRenderTarget: {}
 	};
 
 	return {

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -1878,9 +1878,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 					if ( renderTarget.depthBuffer ) mask |= _gl.DEPTH_BUFFER_BIT;
 
-					// resolving stencil is slow with a D3D backend. disable it for all transmission render targets (see #27799)
-
-					if ( renderTarget.stencilBuffer && renderTargetProperties.__isTransmissionRenderTarget !== true ) mask |= _gl.STENCIL_BUFFER_BIT;
+					if ( renderTarget.stencilBuffer ) mask |= _gl.STENCIL_BUFFER_BIT;
 
 				}
 


### PR DESCRIPTION
Related issue: #28073 and #22594

**Description**
This PR attempts to improve the efficiency of the transmission pass (for WebXR). The render targets used were incorrectly sized and rendering was interleaved with the main scene rendering (#22594). See the following before and after logs made using `ovrgpuprofiler` on a Quest 3.

**Before:** 
```
Surface 0    | 3360x1760 | color 32bit, depth 24bit, stencil 0 bit, MSAA 4, Mode: 2 (SwBinning) | 72  288x320 bins ( 57  rendered) |  2.93 ms | 171 stages : Render : 0.244ms StoreColor : 0.392ms Blit : 0.004ms Preempt : 1.296ms StoreDepthStencil : 0.509ms
Surface 1    | 3360x1760 | color 64bit, depth 24bit, stencil 0 bit, MSAA 4, Mode: 1 (HwBinning) | 96  288x224 bins ( 96  rendered) |  5.29 ms | 291 stages : Binning : 0.069ms Render : 2.149ms StoreColor : 1.14ms Blit : 0.689ms StoreDepthStencil : 0.19ms
Surface 2    | 3360x1760 | color 32bit, depth 24bit, stencil 0 bit, MSAA 4, Mode: 1 (HwBinning) | 72  288x320 bins ( 72  rendered) |  5.80 ms | 222 stages : Binning : 0.274ms LoadColor : 0.075ms Render : 1.788ms StoreColor : 0.073ms Preempt : 2.62ms LoadDepthStencil : 0.255ms StoreDepthStencil : 0.072ms
Surface 3    | 3360x1760 | color 64bit, depth 24bit, stencil 0 bit, MSAA 4, Mode: 1 (HwBinning) | 96  288x224 bins ( 96  rendered) |  5.26 ms | 291 stages : Binning : 0.067ms Render : 2.143ms StoreColor : 1.141ms Blit : 0.659ms StoreDepthStencil : 0.184ms
Surface 4    | 3360x1760 | color 32bit, depth 24bit, stencil 0 bit, MSAA 4, Mode: 1 (HwBinning) | 72  288x320 bins ( 72  rendered) |  5.49 ms | 204 stages : Binning : 0.264ms LoadColor : 0.084ms Render : 1.773ms StoreColor : 0.082ms Preempt : 2.594ms LoadDepthStencil : 0.087ms
```
Background clear WebXR buffer -> left eye transmission -> left eye WebXR buffer -> right eye transmission -> right eye WebXR buffer

**After:**
```
Surface 0    | 3360x1760 | color 32bit, depth 24bit, stencil 0 bit, MSAA 4, Mode: 0 (Direct)    | 1   3360x1760 bins ( 1   rendered) |  0.00 ms | 1   stages : Render : 0.002ms
Surface 1    | 1680x1760 | color 64bit, depth 24bit, stencil 0 bit, MSAA 4, Mode: 1 (HwBinning) | 48  288x224 bins ( 48  rendered) |  3.22 ms | 147 stages : Binning : 0.07ms Render : 1.343ms StoreColor : 0.689ms Blit : 0.386ms StoreDepthStencil : 0.114ms
Surface 2    | 1680x1760 | color 64bit, depth 24bit, stencil 0 bit, MSAA 4, Mode: 1 (HwBinning) | 48  288x224 bins ( 48  rendered) |  5.27 ms | 150 stages : Binning : 0.067ms Render : 1.37ms StoreColor : 0.7ms Blit : 0.395ms Preempt : 1.84ms StoreDepthStencil : 0.115ms
Surface 3    | 3360x1760 | color 32bit, depth 24bit, stencil 0 bit, MSAA 4, Mode: 1 (HwBinning) | 72  288x320 bins ( 46  rendered) |  2.94 ms | 94  stages : Binning : 0.143ms Render : 2.157ms StoreColor : 0.37ms Blit : 0.005ms
```
WebXR buffer (no-op) -> left eye transmission -> right eye transmission -> WebXR buffer (background clear, left and right eye)

The individual changes are kept as individual commits for easier review. It might also make sense to split this up into individual PRs, as while they all serve the same goal, they do stand on their own. In order:

- [f6a71b2745ba2941a5006916cd92b3da9bdffb7c] Size the `transmissionRenderTarget` based on the current viewport (or would-be viewport for WebXR). 
  - Note the dimensions in the after logs are now half the width of the full framebuffer
  - This fix also applies to nested render calls from e.g. Reflector, which now match the dimensions of their render target.
- [66a769f88b0622232d1b95a6eabb6b5853ae8ec1] Move rendering of the transmission pass outside and before the `renderScene` method, allowing transmission passes for both eyes to be rendered in advance.
- [4e9490b8c13fa8f6a0cc31a7e2e505a7d95edd70] Split `WebGLBackground` to treat backgrounds that insert themselves into the render list differently from ones causing a clear.
  - Depending on the scene setup and clear flags, the `WebGLBackground` could perform a clear, but it can also inserts entries in the render list. A clear causes a "StoreColor" and "StoreDepthStencil" when switching to the transmission render target, despite the framebuffer being effectively empty. At the same time the background items are needed in the render list before rendering the transmission pass, so this commit splits the two behaviours.
- [94bd72055f02872bbceeacdae4fa175d87ce05c4] Replace specific `__transmissionRenderTarget` flag with `__ignoreDepthValues` as neither depth nor stencil are needed after rendering
  - I had hoped to save on the `StoreDepthStencil` from the transmission passes, as the depth isn't needed any more. However it seems that when the multisample RTT extension is used this code path isn't used (i.e. `__ignoreDepthValues` has no effect on Quest). A follow-up PR should address this, though I'm not sure what the best place for this logic would be.

*This contribution is funded by [Fern Solutions](https://fern.solutions)*
