### PR TITLE
Docs: Clean up.

### DIFF
--- a/docs/manual/ar/introduction/Libraries-and-Plugins.html
+++ b/docs/manual/ar/introduction/Libraries-and-Plugins.html
@@ -102,6 +102,7 @@
 			<li>[link:https://aframe.io/ A-Frame]</li>
 			<li>[link:https://lume.io/ Lume] - HTML elements for 3D graphics built on Three.</li>
 			<li>[link:https://github.com/pmndrs/react-three-fiber react-three-fiber] - React components for 3D graphics built on Three.</li>
+			<li>[link:https://threepipe.org/ threepipe] - A versatile 3D viewer framework using three.js for rendering.</li>
 			<li>[link:https://github.com/ecsyjs/ecsy-three ECSY]</li>
 			<li>[link:https://threlte.xyz/ Threlte] - Svelte components for 3D graphics built on Three.</li>
 			<li>[link:https://needle.tools/ Needle Engine]</li>

--- a/docs/manual/fr/introduction/Libraries-and-Plugins.html
+++ b/docs/manual/fr/introduction/Libraries-and-Plugins.html
@@ -105,6 +105,7 @@
 			<li>[link:https://aframe.io/ A-Frame]</li>
 			<li>[link:https://lume.io/ Lume] - HTML elements for 3D graphics built on Three.</li>
 			<li>[link:https://github.com/pmndrs/react-three-fiber react-three-fiber] - React components for 3D graphics built on Three.</li>
+			<li>[link:https://threepipe.org/ threepipe] - A versatile 3D viewer framework using three.js for rendering.</li>
 			<li>[link:https://github.com/ecsyjs/ecsy-three ECSY]</li>
 			<li>[link:https://threlte.xyz/ Threlte] - Svelte components for 3D graphics built on Three.</li>
 			<li>[link:https://needle.tools/ Needle Engine]</li>

--- a/docs/manual/it/introduction/Libraries-and-Plugins.html
+++ b/docs/manual/it/introduction/Libraries-and-Plugins.html
@@ -105,6 +105,7 @@
 			<li>[link:https://aframe.io/ A-Frame]</li>
 			<li>[link:https://lume.io/ Lume] - HTML elements for 3D graphics built on Three.</li>
 			<li>[link:https://github.com/pmndrs/react-three-fiber react-three-fiber] - React components for 3D graphics built on Three.</li>
+			<li>[link:https://threepipe.org/ threepipe] - A versatile 3D viewer framework using three.js for rendering.</li>
 			<li>[link:https://github.com/ecsyjs/ecsy-three ECSY]</li>
 			<li>[link:https://threlte.xyz/ Threlte] - Svelte components for 3D graphics built on Three.</li>
 			<li>[link:https://needle.tools/ Needle Engine]</li>

--- a/docs/manual/ja/introduction/Libraries-and-Plugins.html
+++ b/docs/manual/ja/introduction/Libraries-and-Plugins.html
@@ -98,6 +98,7 @@
         <li>[link:https://aframe.io/ A-Frame]</li>
         <li>[link:https://lume.io/ Lume] - HTML elements for 3D graphics built on Three.</li>
         <li>[link:https://github.com/pmndrs/react-three-fiber react-three-fiber] - React components for 3D graphics built on Three.</li>
+        <li>[link:https://threepipe.org/ threepipe] - A versatile 3D viewer framework using three.js for rendering.</li>
         <li>[link:https://github.com/ecsyjs/ecsy-three ECSY]</li>
         <li>[link:https://threlte.xyz/ Threlte] - Svelte components for 3D graphics built on Three.</li>
         <li>[link:https://needle.tools/ Needle Engine]</li>

--- a/docs/manual/pt-br/introduction/Libraries-and-Plugins.html
+++ b/docs/manual/pt-br/introduction/Libraries-and-Plugins.html
@@ -105,6 +105,7 @@
 			<li>[link:https://aframe.io/ A-Frame]</li>
 			<li>[link:https://lume.io/ Lume] - HTML elements for 3D graphics built on Three.</li>
 			<li>[link:https://github.com/pmndrs/react-three-fiber react-three-fiber] - React components for 3D graphics built on Three.</li>
+			<li>[link:https://threepipe.org/ threepipe] - A versatile 3D viewer framework using three.js for rendering.</li>
 			<li>[link:https://github.com/ecsyjs/ecsy-three ECSY]</li>
 			<li>[link:https://threlte.xyz/ Threlte] - Svelte components for 3D graphics built on Three.</li>
 			<li>[link:https://needle.tools/ Needle Engine]</li>

--- a/docs/manual/zh/introduction/Libraries-and-Plugins.html
+++ b/docs/manual/zh/introduction/Libraries-and-Plugins.html
@@ -101,6 +101,7 @@
 			<li>[link:https://aframe.io/ A-Frame]</li>
 			<li>[link:https://lume.io/ Lume] - HTML elements for 3D graphics built on Three.</li>
 			<li>[link:https://github.com/pmndrs/react-three-fiber react-three-fiber] - React components for 3D graphics built on Three.</li>
+			<li>[link:https://threepipe.org/ threepipe] - A versatile 3D viewer framework using three.js for rendering.</li>
 			<li>[link:https://github.com/ecsyjs/ecsy-three ECSY]</li>
 			<li>[link:https://threlte.xyz/ Threlte] - Svelte components for 3D graphics built on Three.</li>
 			<li>[link:https://needle.tools/ Needle Engine]</li>


### PR DESCRIPTION
Related issue: #28077

**Description**

This PR adds the new `threepipe` framework link to translated pages as well.