### PR TITLE
WebGLRenderer: Let transmissionRenderTarget size match relevant viewport size

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -26,7 +26,6 @@ import {
 import { Color } from '../math/Color.js';
 import { Frustum } from '../math/Frustum.js';
 import { Matrix4 } from '../math/Matrix4.js';
-import { Vector2 } from '../math/Vector2.js';
 import { Vector3 } from '../math/Vector3.js';
 import { Vector4 } from '../math/Vector4.js';
 import { WebGLAnimation } from './webgl/WebGLAnimation.js';
@@ -205,7 +204,6 @@ class WebGLRenderer {
 
 		const _projScreenMatrix = new Matrix4();
 
-		const _vector2 = new Vector2();
 		const _vector3 = new Vector3();
 
 		const _emptyScene = { background: null, fog: null, environment: null, overrideMaterial: null, isScene: true };
@@ -1428,8 +1426,8 @@ class WebGLRenderer {
 
 			const transmissionRenderTarget = currentRenderState.state.transmissionRenderTarget;
 
-			_this.getDrawingBufferSize( _vector2 );
-			transmissionRenderTarget.setSize( _vector2.x, _vector2.y );
+			const activeViewport = camera.viewport || _currentViewport;
+			transmissionRenderTarget.setSize( activeViewport.z, activeViewport.w );
 
 			//
 
@@ -1446,6 +1444,11 @@ class WebGLRenderer {
 			// Otherwise they are applied twice in opaque objects pass and transmission objects pass.
 			const currentToneMapping = _this.toneMapping;
 			_this.toneMapping = NoToneMapping;
+
+			// Remove viewport from camera to avoid nested render calls resetting viewport to it (e.g Reflector).
+			// Transmission render pass requires viewport to match the transmissionRenderTarget.
+			const currentCameraViewport = camera.viewport;
+			if ( camera.viewport !== undefined ) camera.viewport = undefined;
 
 			renderObjects( opaqueObjects, scene, camera );
 
@@ -1491,6 +1494,8 @@ class WebGLRenderer {
 			_this.setRenderTarget( currentRenderTarget );
 
 			_this.setClearColor( _currentClearColor, _currentClearAlpha );
+
+			if ( currentCameraViewport !== undefined ) camera.viewport = currentCameraViewport;
 
 			_this.toneMapping = currentToneMapping;
 


### PR DESCRIPTION
Related issue: #28073 (split off from #28078)

**Description**

This PR ensures that the `transmissionRenderTarget` dimensions match the current viewport size (or would-be viewport in case of WebXR). As a result the render target size matches that of each eye, instead of the full WebXR framebuffer size. Similarly when rendering to a render target, it will match its size instead of the full drawing buffer size.

There is one additional fix for WebXR with nested render calls (e.g. when using a `Reflector`). The `Reflector` tries to "restore" the viewport when in a WebXR session ([Reflector.js#L164-L172](https://github.com/mrdoob/three.js/blob/dev/examples/jsm/objects/Reflector.js#L164-L172)), but when rendering the transmission pass, the viewport should be left unchanged (matching the transmission render target)

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Fern Solutions](https://fern.solutions)*
