### PR TITLE
Playground: Fix animation loop reference

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -125,7 +125,7 @@
 
 				//
 
-				renderer.setAnimationLoop( render );
+				renderer.setAnimationLoop( animate );
 				renderer.toneMapping = THREE.LinearToneMapping;
 				renderer.toneMappingExposure = 1;
 				document.body.appendChild( renderer.domElement );
@@ -178,8 +178,6 @@
 			//
 
 			function animate() {
-
-				requestAnimationFrame( animate );
 
 				if ( renderer.isWebGLRenderer ) nodeFrame.update();
 


### PR DESCRIPTION
Related issue: Closes https://github.com/mrdoob/three.js/issues/27999

**Description**

`WebGLRenderer` node system require `nodeFrame.update()` call before render. This PR fix this.