### PR TITLE
Playground: Revision mat*/bool color and json matrix* types

### DIFF
--- a/playground/DataTypeLib.js
+++ b/playground/DataTypeLib.js
@@ -36,7 +36,7 @@ export function getLengthFromType( type ) {
 
 export function getLengthFromNode( value ) {
 
-	let type = getTypeFromNode( value );
+	const type = getTypeFromNode( value );
 
 	return getLengthFromType( type );
 
@@ -46,10 +46,10 @@ export const typeToColorLib = {
 	// gpu
 	string: '#ff0000',
 	float: '#eeeeee',
-	bool: '#00dd00',
-	mat2: '#70d030',
-	mat3: '#70d030',
-	mat4: '#70d030',
+	bool: '#0060ff',
+	mat2: '#d0dc8b',
+	mat3: '#d0dc8b',
+	mat4: '#d0dc8b',
 	// cpu
 	String: '#ff0000',
 	Number: '#eeeeee',
@@ -69,7 +69,7 @@ export function getColorFromType( type ) {
 
 export function getColorFromNode( value ) {
 
-	let type = getTypeFromNode( value );
+	const type = getTypeFromNode( value );
 
 	return getColorFromType( type );
 
@@ -82,6 +82,7 @@ function getTypeFromNode( value ) {
 		if ( value.isMaterial ) return 'Material';
 
 		return value.nodeType === 'ArrayBuffer' ? 'URL' : ( value.nodeType || getTypeFromValue( value.value ) );
+
 	}
 
 }

--- a/playground/Nodes.json
+++ b/playground/Nodes.json
@@ -57,7 +57,7 @@
 						{
 							"name": "Camera Normal Matrix",
 							"icon": "video",
-							"nodeType": "mat4",
+							"nodeType": "mat3",
 							"shaderNode": "cameraNormalMatrix"
 						},
 						{
@@ -232,7 +232,7 @@
 						{
 							"name": "Model Normal Matrix",
 							"icon": "box",
-							"nodeType": "vec3",
+							"nodeType": "mat3",
 							"shaderNode": "modelNormalMatrix"
 						},
 						{
@@ -244,7 +244,7 @@
 						{
 							"name": "Model View Matrix",
 							"icon": "box",
-							"nodeType": "vec3",
+							"nodeType": "mat4",
 							"shaderNode": "modelViewMatrix"
 						},
 						{
@@ -256,7 +256,7 @@
 						{
 							"name": "Model World Matrix",
 							"icon": "box",
-							"nodeType": "vec3",
+							"nodeType": "mat4",
 							"shaderNode": "modelWorldMatrix"
 						}
 					]
@@ -280,6 +280,7 @@
 							"name": "Object Normal Matrix",
 							"icon": "3d-cube-sphere",
 							"shaderNode": "objectNormalMatrix",
+							"nodeType": "mat3",
 							"properties": [
 								{
 									"name": "object3d",
@@ -302,6 +303,7 @@
 							"name": "Object View Matrix",
 							"icon": "3d-cube-sphere",
 							"shaderNode": "objectViewMatrix",
+							"nodeType": "mat4",
 							"properties": [
 								{
 									"name": "object3d",


### PR DESCRIPTION
Related issue: #XXXX

**Description**

Differentiates the color of a Boolean from the material, although it is close to `Objecto3D` it is closer to how we know the Boolean in code editors.

Fix mat3/4 in nodes list of json.

