### PR TITLE
RenderTarget: Add `resolveStencilBuffer`.

### DIFF
--- a/docs/api/ar/renderers/WebGLRenderTarget.html
+++ b/docs/api/ar/renderers/WebGLRenderTarget.html
@@ -48,6 +48,7 @@
 		<br />
 		[page:Boolean depthBuffer] - الافتراضي هو `true`. <br />
 		[page:Boolean stencilBuffer] - الافتراضي هو `false`. <br />
+		[page:Boolean resolveStencilBuffer] - الافتراضي هو `true`. <br />
 		[page:Number samples] - الافتراضي هو 0. <br /><br />
 		 
 		ينشئ جديدًا [name]
@@ -86,6 +87,12 @@
 	 
 		<h3>[property:Boolean stencilBuffer]</h3>
 		<p>يعرض على مخزن القالب. الافتراضي هو false.</p>
+
+		<h3>[property:Boolean resolveStencilBuffer]</h3>
+		<p>
+			Defines whether the stencil buffer should be resolved when rendering into a multisampled render target or not. 
+			Default is `true`.
+		</p>
 	 
 		<h3>[property:DepthTexture depthTexture]</h3>
 		<p>

--- a/docs/api/ar/renderers/WebGLRenderTarget.html
+++ b/docs/api/ar/renderers/WebGLRenderTarget.html
@@ -90,7 +90,7 @@
 
 		<h3>[property:Boolean resolveStencilBuffer]</h3>
 		<p>
-			Defines whether the stencil buffer should be resolved when rendering into a multisampled render target or not. 
+			Defines whether the stencil buffer should be resolved when rendering into a multisampled render target. 
 			Default is `true`.
 		</p>
 	 

--- a/docs/api/en/renderers/WebGLRenderTarget.html
+++ b/docs/api/en/renderers/WebGLRenderTarget.html
@@ -99,7 +99,7 @@
 
 		<h3>[property:Boolean resolveStencilBuffer]</h3>
 		<p>
-			Defines whether the stencil buffer should be resolved when rendering into a multisampled render target or not. 
+			Defines whether the stencil buffer should be resolved when rendering into a multisampled render target. 
 			Default is `true`.
 		</p>
 

--- a/docs/api/en/renderers/WebGLRenderTarget.html
+++ b/docs/api/en/renderers/WebGLRenderTarget.html
@@ -49,6 +49,7 @@
 			<br />
 			[page:Boolean depthBuffer] - default is `true`. <br />
 			[page:Boolean stencilBuffer] - default is `false`.<br />
+			[page:Boolean resolveStencilBuffer] - default is `true`.<br />
 			[page:Number samples] - default is `0`.<br />
 			[page:Number count] - default is `1`.<br /><br />
 
@@ -95,6 +96,12 @@
 
 		<h3>[property:Boolean stencilBuffer]</h3>
 		<p>Renders to the stencil buffer. Default is false.</p>
+
+		<h3>[property:Boolean resolveStencilBuffer]</h3>
+		<p>
+			Defines whether the stencil buffer should be resolved when rendering into a multisampled render target or not. 
+			Default is `true`.
+		</p>
 
 		<h3>[property:DepthTexture depthTexture]</h3>
 		<p>

--- a/docs/api/it/renderers/WebGLRenderTarget.html
+++ b/docs/api/it/renderers/WebGLRenderTarget.html
@@ -104,7 +104,7 @@
 
 		<h3>[property:Boolean resolveStencilBuffer]</h3>
 		<p>
-			Defines whether the stencil buffer should be resolved when rendering into a multisampled render target or not. 
+			Defines whether the stencil buffer should be resolved when rendering into a multisampled render target. 
 			Il valore predefinito è `true`.
 		</p>
 

--- a/docs/api/it/renderers/WebGLRenderTarget.html
+++ b/docs/api/it/renderers/WebGLRenderTarget.html
@@ -42,6 +42,7 @@
 		[page:Constant colorSpace] - il valore predefinito è [page:Textures NoColorSpace]. <br />
 		[page:Boolean depthBuffer] - il valore predefinito è `true`. <br />
 		[page:Boolean stencilBuffer] - il valore predefinito è `false`.<br />
+		[page:Boolean resolveStencilBuffer] - il valore predefinito è `true`.<br />
 		[page:Number samples] - il valore predefinito è 0.<br />
 		[page:Number count] - default is `1`.<br /><br />
 
@@ -99,6 +100,12 @@
 		<h3>[property:Boolean stencilBuffer]</h3>
 		<p>
 			Effettua il rendering al buffer stencil. Il valore predefinito è `false`.
+		</p>
+
+		<h3>[property:Boolean resolveStencilBuffer]</h3>
+		<p>
+			Defines whether the stencil buffer should be resolved when rendering into a multisampled render target or not. 
+			Il valore predefinito è `true`.
 		</p>
 
 		<h3>[property:DepthTexture depthTexture]</h3>

--- a/docs/api/zh/renderers/WebGLRenderTarget.html
+++ b/docs/api/zh/renderers/WebGLRenderTarget.html
@@ -38,6 +38,7 @@
 		[page:Constant colorSpace] - 默认是[page:Textures NoColorSpace]. <br />
 		[page:Boolean depthBuffer] - 默认是`true`.<br />
 		[page:Boolean stencilBuffer] - 默认是`false`.<br />
+		[page:Boolean resolveStencilBuffer] - 默认是`true`.<br />
 		[page:Number samples] - 默认是`0`.<br />
 		[page:Number count] - default is `1`.<br /><br />
 
@@ -94,7 +95,13 @@
 
 		<h3>[property:Boolean stencilBuffer]</h3>
 		<p>
-		渲染到模板缓冲区。默认为false
+		渲染到模板缓冲区。默认为false.
+		</p>
+
+		<h3>[property:Boolean resolveStencilBuffer]</h3>
+		<p>
+			Defines whether the stencil buffer should be resolved when rendering into a multisampled render target or not. 
+			默认为`true`.
 		</p>
 
 		<h3>[property:DepthTexture depthTexture]</h3>

--- a/docs/api/zh/renderers/WebGLRenderTarget.html
+++ b/docs/api/zh/renderers/WebGLRenderTarget.html
@@ -100,7 +100,7 @@
 
 		<h3>[property:Boolean resolveStencilBuffer]</h3>
 		<p>
-			Defines whether the stencil buffer should be resolved when rendering into a multisampled render target or not. 
+			Defines whether the stencil buffer should be resolved when rendering into a multisampled render target. 
 			默认为`true`.
 		</p>
 

--- a/src/core/RenderTarget.js
+++ b/src/core/RenderTarget.js
@@ -34,6 +34,7 @@ class RenderTarget extends EventDispatcher {
 			minFilter: LinearFilter,
 			depthBuffer: true,
 			stencilBuffer: false,
+			resolveStencilBuffer: true,
 			depthTexture: null,
 			samples: 0,
 			count: 1
@@ -57,6 +58,8 @@ class RenderTarget extends EventDispatcher {
 
 		this.depthBuffer = options.depthBuffer;
 		this.stencilBuffer = options.stencilBuffer;
+
+		this.resolveStencilBuffer = options.resolveStencilBuffer;
 
 		this.depthTexture = options.depthTexture;
 
@@ -134,6 +137,8 @@ class RenderTarget extends EventDispatcher {
 
 		this.depthBuffer = source.depthBuffer;
 		this.stencilBuffer = source.stencilBuffer;
+
+		this.resolveStencilBuffer = source.resolveStencilBuffer;
 
 		if ( source.depthTexture !== null ) this.depthTexture = source.depthTexture.clone();
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1404,11 +1404,9 @@ class WebGLRenderer {
 					type: ( extensions.has( 'EXT_color_buffer_half_float' ) || extensions.has( 'EXT_color_buffer_float' ) ) ? HalfFloatType : UnsignedByteType,
 					minFilter: LinearMipmapLinearFilter,
 					samples: 4,
-					stencilBuffer: stencil
+					stencilBuffer: stencil,
+					resolveStencilBuffer: false
 				} );
-
-				const renderTargetProperties = properties.get( currentRenderState.state.transmissionRenderTarget );
-				renderTargetProperties.__isTransmissionRenderTarget = true;
 
 				// debug
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -1880,7 +1880,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 					// resolving stencil is slow with a D3D backend. disable it for all transmission render targets (see #27799)
 
-					if ( renderTarget.stencilBuffer && renderTargetProperties.__isTransmissionRenderTarget !== true ) mask |= _gl.STENCIL_BUFFER_BIT;
+					if ( renderTarget.stencilBuffer && renderTarget.resolveStencilBuffer ) mask |= _gl.STENCIL_BUFFER_BIT;
 
 				}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/27799#issuecomment-2042745278

**Description**

This PR introduces a new flag `RenderTarget.resolveStencilBuffer`. It can be used to control whether the stencil buffer should be resolved or not when rendering to a multisampled render target.
