### PR TITLE
TSL: Introduce `.onReference()`

### DIFF
--- a/examples/jsm/nodes/core/Node.js
+++ b/examples/jsm/nodes/core/Node.js
@@ -74,6 +74,14 @@ class Node extends EventDispatcher {
 
 	}
 
+	onReference( callback ) {
+
+		this.updateReference = callback.bind( this.getSelf() );
+
+		return this;
+
+	}
+
 	getSelf() {
 
 		// Returns non-node object.


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/27964

**Description**

Same logic as `.onUpdate()` but allows you to customize the reference. In the example below, the uniform will be updated once in the rendering in each different material, if the reference is not defined, it would be updated only once, regardless of how many different materials are used in rendering.

```js
const materialRotation = uniform( 0 )
	.onReference( ( frame ) => frame.material )
	.onRenderUpdate( () => {

		return material.rotation;

	} );
```
