### PR TITLE
docs: remove `THREE.` prefix from several addon uses

### DIFF
--- a/docs/api/ar/loaders/managers/LoadingManager.html
+++ b/docs/api/ar/loaders/managers/LoadingManager.html
@@ -74,7 +74,7 @@
 		} );
 	
 		// Load as usual, then revoke the blob URLs.
-		const loader = new THREE.GLTFLoader( manager );
+		const loader = new GLTFLoader( manager );
 		loader.load( 'fish.gltf', (gltf) => {
 	
 			scene.add( gltf.scene );

--- a/docs/api/ar/loaders/managers/LoadingManager.html
+++ b/docs/api/ar/loaders/managers/LoadingManager.html
@@ -44,7 +44,7 @@
 			console.log( 'There was an error loading ' + url );
 		};
 	
-		const loader = new THREE.OBJLoader( manager );
+		const loader = new OBJLoader( manager );
 		loader.load( 'file.obj', function ( object ) {
 			//
 		} );

--- a/docs/api/en/loaders/managers/LoadingManager.html
+++ b/docs/api/en/loaders/managers/LoadingManager.html
@@ -74,7 +74,7 @@
 		} );
 
 		// Load as usual, then revoke the blob URLs.
-		const loader = new THREE.GLTFLoader( manager );
+		const loader = new GLTFLoader( manager );
 		loader.load( 'fish.gltf', (gltf) => {
 
 			scene.add( gltf.scene );

--- a/docs/api/en/loaders/managers/LoadingManager.html
+++ b/docs/api/en/loaders/managers/LoadingManager.html
@@ -44,7 +44,7 @@
 			console.log( 'There was an error loading ' + url );
 		};
 
-		const loader = new THREE.OBJLoader( manager );
+		const loader = new OBJLoader( manager );
 		loader.load( 'file.obj', function ( object ) {
 			//
 		} );

--- a/docs/api/it/loaders/managers/LoadingManager.html
+++ b/docs/api/it/loaders/managers/LoadingManager.html
@@ -51,7 +51,7 @@
 
 		};
 
-		const loader = new THREE.OBJLoader( manager );
+		const loader = new OBJLoader( manager );
 		loader.load( 'file.obj', function ( object ) {
 
 			//

--- a/docs/api/it/loaders/managers/LoadingManager.html
+++ b/docs/api/it/loaders/managers/LoadingManager.html
@@ -86,7 +86,7 @@
 		} );
 
 		// Carica come di solito, quindi revoca gli URL dei Blob 
-		const loader = new THREE.GLTFLoader( manager );
+		const loader = new GLTFLoader( manager );
 		loader.load( 'fish.gltf', (gltf) => {
 
 			scene.add( gltf.scene );

--- a/docs/api/zh/loaders/managers/LoadingManager.html
+++ b/docs/api/zh/loaders/managers/LoadingManager.html
@@ -50,7 +50,7 @@
 
 		};
 
-		const loader = new THREE.OBJLoader( manager );
+		const loader = new OBJLoader( manager );
 		loader.load( 'file.obj', function ( object ) {
 
 			//

--- a/docs/api/zh/loaders/managers/LoadingManager.html
+++ b/docs/api/zh/loaders/managers/LoadingManager.html
@@ -83,7 +83,7 @@
 		} );
 
 		// 像通常一样加载，然后撤消blob URL
-		const loader = new THREE.GLTFLoader( manager );
+		const loader = new GLTFLoader( manager );
 		loader.load( 'fish.gltf', (gltf) => {
 
 			scene.add( gltf.scene );

--- a/docs/examples/en/loaders/GLTFLoader.html
+++ b/docs/examples/en/loaders/GLTFLoader.html
@@ -199,7 +199,7 @@
 
 		<h3>[method:this setKTX2Loader]( [param:KTX2Loader ktx2Loader] )</h3>
 		<p>
-		[page:KTX2Loader ktx2Loader] — Instance of THREE.KTX2Loader, to be used for loading KTX2 compressed textures.
+		[page:KTX2Loader ktx2Loader] — Instance of KTX2Loader, to be used for loading KTX2 compressed textures.
 		</p>
 
 		<h3>[method:undefined parse]( [param:ArrayBuffer data], [param:String path], [param:Function onLoad], [param:Function onError] )</h3>

--- a/docs/examples/en/loaders/GLTFLoader.html
+++ b/docs/examples/en/loaders/GLTFLoader.html
@@ -191,7 +191,7 @@
 
 		<h3>[method:this setDRACOLoader]( [param:DRACOLoader dracoLoader] )</h3>
 		<p>
-		[page:DRACOLoader dracoLoader] — Instance of THREE.DRACOLoader, to be used for decoding assets compressed with the KHR_draco_mesh_compression extension.
+		[page:DRACOLoader dracoLoader] — Instance of DRACOLoader, to be used for decoding assets compressed with the KHR_draco_mesh_compression extension.
 		</p>
 		<p>
 		Refer to this [link:https://github.com/mrdoob/three.js/tree/dev/examples/jsm/libs/draco#readme readme] for the details of Draco and its decoder.

--- a/docs/examples/en/loaders/KTX2Loader.html
+++ b/docs/examples/en/loaders/KTX2Loader.html
@@ -41,7 +41,7 @@
 		<h2>Code Example</h2>
 
 		<code>
-		var ktx2Loader = new THREE.KTX2Loader();
+		var ktx2Loader = new KTX2Loader();
 		ktx2Loader.setTranscoderPath( 'examples/jsm/libs/basis/' );
 		ktx2Loader.detectSupport( renderer );
 		ktx2Loader.load( 'diffuse.ktx2', function ( texture ) {

--- a/docs/examples/zh/loaders/GLTFLoader.html
+++ b/docs/examples/zh/loaders/GLTFLoader.html
@@ -197,7 +197,7 @@
 
 		<h3>[method:this setDRACOLoader]( [param:DRACOLoader dracoLoader] )</h3>
 		<p>
-		[page:DRACOLoader dracoLoader] — THREE.DRACOLoader的实例，用于解码使用KHR_draco_mesh_compression扩展压缩过的文件。
+		[page:DRACOLoader dracoLoader] — DRACOLoader的实例，用于解码使用KHR_draco_mesh_compression扩展压缩过的文件。
 		</p>
 		<p>
 		请参阅[link:https://github.com/mrdoob/three.js/tree/dev/examples/jsm/libs/draco#readme readme]来了解Draco及其解码器的详细信息。

--- a/docs/examples/zh/loaders/KTX2Loader.html
+++ b/docs/examples/zh/loaders/KTX2Loader.html
@@ -38,7 +38,7 @@
 	<h2>代码示例</h2>
 
 	<code>
-		var ktx2Loader = new THREE.KTX2Loader();
+		var ktx2Loader = new KTX2Loader();
 		ktx2Loader.setTranscoderPath( 'examples/jsm/libs/basis/' );
 		ktx2Loader.detectSupport( renderer );
 		ktx2Loader.load( 'diffuse.ktx2', function ( texture ) {

--- a/examples/jsm/libs/draco/README.md
+++ b/examples/jsm/libs/draco/README.md
@@ -17,10 +17,10 @@ Each file is provided in two variations:
 * **Default:** Latest stable builds, tracking the project's [master branch](https://github.com/google/draco).
 * **glTF:** Builds targeted by the [glTF mesh compression extension](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_draco_mesh_compression), tracking the [corresponding Draco branch](https://github.com/google/draco/tree/gltf_2.0_draco_extension).
 
-Either variation may be used with `THREE.DRACOLoader`:
+Either variation may be used with `DRACOLoader`:
 
 ```js
-var dracoLoader = new THREE.DRACOLoader();
+var dracoLoader = new DRACOLoader();
 dracoLoader.setDecoderPath('path/to/decoders/');
 dracoLoader.setDecoderConfig({type: 'js'}); // (Optional) Override detection of WASM support.
 ```


### PR DESCRIPTION
**Description**

I think we no longer use the `THREE.` prefix for addons, so I removed the `THREE.` from docs. It especially shouldn't exist in example codes.

I checked addon loaders (`/examples/jsm/addons`) this time. We might still have some in other places.
