### PR TITLE
Update WebGPU.js -- fix error: await is only valid in async functions and the top level bodies of modules

### DIFF
--- a/examples/jsm/capabilities/WebGPU.js
+++ b/examples/jsm/capabilities/WebGPU.js
@@ -9,11 +9,17 @@ if ( self.GPUShaderStage === undefined ) {
 let isAvailable = navigator.gpu !== undefined;
 
 
-if ( typeof window !== 'undefined' && isAvailable ) {
+async function checkGPUAvailability() {
 
-	isAvailable = await navigator.gpu.requestAdapter();
+  if ( typeof window !== 'undefined' && isAvailable ) {
+
+    isAvailable = await navigator.gpu.requestAdapter();
+
+  }
 
 }
+
+checkGPUAvailability();
 
 class WebGPU {
 


### PR DESCRIPTION
Related issue: 
fix error: await is only valid in async functions and the top level bodies of modules

**Description**

when I run on chrome，find error: Uncaught SyntaxError: await is only valid in async functions and the top level bodies of modules (at main.1f19ae8e.js:62752:18)

<img width="444" alt="image" src="https://github.com/mrdoob/three.js/assets/2100549/87e431ad-3abb-401d-8a87-3504386dca9e">

A clear and concise description of what the problem was and how this pull request solves it.

await must be in async function


