### PR TITLE
Editor: Remove IFC support

### DIFF
--- a/editor/js/Loader.js
+++ b/editor/js/Loader.js
@@ -376,29 +376,6 @@ function Loader( editor ) {
 
 			}
 
-			case 'ifc':
-
-			{
-
-				reader.addEventListener( 'load', async function ( event ) {
-
-					const { IFCLoader } = await import( 'three/addons/loaders/IFCLoader.js' );
-
-					var loader = new IFCLoader();
-					loader.ifcManager.setWasmPath( 'three/addons/loaders/ifc/' );
-
-					const model = await loader.parse( event.target.result );
-					model.mesh.name = filename;
-
-					editor.execute( new AddObjectCommand( editor, model.mesh ) );
-
-				}, false );
-				reader.readAsArrayBuffer( file );
-
-				break;
-
-			}
-
 			case 'kmz':
 
 			{


### PR DESCRIPTION
Related issue: #28098 

**Description**

`IFCLoader.js` was removed from addons in #25440. Due to issues replicating the import map updates made to the `webgl_loader_ifc` example (also in #25440), this PR removes support for IFC models in the editor until `webgl_loader_ifc` can be migrated to [`Open BIM Components`](https://github.com/ThatOpen/engine_components) as discussed in #27467 (and #28098).

