### PR TITLE
Examples: Remove lensflares from VR sandbox demo.

### DIFF
--- a/examples/webxr_vr_sandbox.html
+++ b/examples/webxr_vr_sandbox.html
@@ -21,7 +21,6 @@
 			import * as THREE from 'three';
 
 			import { RGBELoader } from 'three/addons/loaders/RGBELoader.js';
-			import { Lensflare, LensflareElement } from 'three/addons/objects/Lensflare.js';
 			import { Reflector } from 'three/addons/objects/Reflector.js';
 			import { VRButton } from 'three/addons/webxr/VRButton.js';
 
@@ -84,20 +83,6 @@
 				const cylinder = new THREE.Mesh( cylinderGeometry, cylinderMaterial );
 				cylinder.position.z = - 2;
 				scene.add( cylinder );
-
-				// lensflare
-				const loader = new THREE.TextureLoader();
-				const texture0 = loader.load( 'textures/lensflare/lensflare0.png' );
-				const texture3 = loader.load( 'textures/lensflare/lensflare3.png' );
-
-				const lensflare = new Lensflare();
-				lensflare.position.set( 0, 5, - 5 );
-				lensflare.addElement( new LensflareElement( texture0, 700, 0 ) );
-				lensflare.addElement( new LensflareElement( texture3, 60, 0.6 ) );
-				lensflare.addElement( new LensflareElement( texture3, 70, 0.7 ) );
-				lensflare.addElement( new LensflareElement( texture3, 120, 0.9 ) );
-				lensflare.addElement( new LensflareElement( texture3, 70, 1 ) );
-				scene.add( lensflare );
 
 				//
 


### PR DESCRIPTION
Related issue: -

**Description**

The lensflares in `webxr_vr_sandbox.html` are broken. I couldn't find the root cause yet but it seems even the non-XR combination of transmission and lensflares does not work as expected (the flares sometimes suddenly flash depending on the camera transformation). 

For now, I think it's better to remove them from the scene.
