### PR TITLE
WebGLRenderer: Track camera per render state.

### DIFF
--- a/examples/jsm/objects/Reflector.js
+++ b/examples/jsm/objects/Reflector.js
@@ -161,16 +161,6 @@ class Reflector extends Mesh {
 
 			renderer.setRenderTarget( currentRenderTarget );
 
-			// Restore viewport
-
-			const viewport = camera.viewport;
-
-			if ( viewport !== undefined ) {
-
-				renderer.state.viewport( viewport );
-
-			}
-
 			scope.visible = true;
 
 		};

--- a/examples/jsm/objects/ReflectorForSSRPass.js
+++ b/examples/jsm/objects/ReflectorForSSRPass.js
@@ -226,16 +226,6 @@ class ReflectorForSSRPass extends Mesh {
 
 			renderer.setRenderTarget( currentRenderTarget );
 
-			// Restore viewport
-
-			const viewport = camera.viewport;
-
-			if ( viewport !== undefined ) {
-
-				renderer.state.viewport( viewport );
-
-			}
-
 			// scope.visible = true;
 
 		};

--- a/examples/jsm/objects/Refractor.js
+++ b/examples/jsm/objects/Refractor.js
@@ -186,7 +186,7 @@ class Refractor extends Mesh {
 
 		//
 
-		function render( renderer, scene, camera ) {
+		function render( renderer, scene ) {
 
 			scope.visible = false;
 
@@ -204,16 +204,6 @@ class Refractor extends Mesh {
 			renderer.xr.enabled = currentXrEnabled;
 			renderer.shadowMap.autoUpdate = currentShadowAutoUpdate;
 			renderer.setRenderTarget( currentRenderTarget );
-
-			// restore viewport
-
-			const viewport = camera.viewport;
-
-			if ( viewport !== undefined ) {
-
-				renderer.state.viewport( viewport );
-
-			}
 
 			scope.visible = true;
 
@@ -239,7 +229,7 @@ class Refractor extends Mesh {
 
 			updateVirtualCamera( camera );
 
-			render( renderer, scene, camera );
+			render( renderer, scene );
 
 		};
 

--- a/examples/jsm/objects/Water.js
+++ b/examples/jsm/objects/Water.js
@@ -314,16 +314,6 @@ class Water extends Mesh {
 
 			renderer.setRenderTarget( currentRenderTarget );
 
-			// Restore viewport
-
-			const viewport = camera.viewport;
-
-			if ( viewport !== undefined ) {
-
-				renderer.state.viewport( viewport );
-
-			}
-
 		};
 
 	}

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -949,6 +949,7 @@ class WebGLRenderer {
 			}
 
 			currentRenderState.setupLights( _this._useLegacyLights );
+			currentRenderState.setupLightsView( camera );
 
 			// Only initialize materials in the new scene, not the targetScene.
 
@@ -1241,6 +1242,20 @@ class WebGLRenderer {
 			if ( renderStateStack.length > 0 ) {
 
 				currentRenderState = renderStateStack[ renderStateStack.length - 1 ];
+
+				// restore clipping uniforms and viewport
+
+				const renderStateCamera = currentRenderState.state.camera;
+
+				if ( _clippingEnabled === true ) clipping.setGlobalState( _this.clippingPlanes, renderStateCamera );
+
+				const viewport = renderStateCamera.viewport;
+
+				if ( viewport !== undefined ) {
+
+					state.viewport( viewport );
+
+				}
 
 			} else {
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1247,13 +1247,17 @@ class WebGLRenderer {
 
 				const renderStateCamera = currentRenderState.state.camera;
 
-				if ( _clippingEnabled === true ) clipping.setGlobalState( _this.clippingPlanes, renderStateCamera );
+				if ( renderStateCamera !== null ) {
 
-				const viewport = renderStateCamera.viewport;
+					if ( _clippingEnabled === true ) clipping.setGlobalState( _this.clippingPlanes, renderStateCamera );
 
-				if ( viewport !== undefined ) {
+					const viewport = renderStateCamera.viewport;
 
-					state.viewport( viewport );
+					if ( viewport !== undefined ) {
+
+						state.viewport( viewport );
+
+					}
 
 				}
 

--- a/src/renderers/webgl/WebGLRenderStates.js
+++ b/src/renderers/webgl/WebGLRenderStates.js
@@ -34,6 +34,8 @@ function WebGLRenderState( extensions ) {
 
 	function setupLightsView( camera ) {
 
+		state.camera = camera;
+
 		lights.setupView( lightsArray, camera );
 
 	}
@@ -43,6 +45,7 @@ function WebGLRenderState( extensions ) {
 		shadowsArray: shadowsArray,
 
 		lights: lights,
+		camera: null,
 
 		transmissionRenderTarget: {}
 	};


### PR DESCRIPTION
Fixed #28111.

**Description**

This PR makes sure the camera is tracked in the render state so it's possible to perform camera related restore operation after a nested render call.

Clipping uniforms are now correctly restores and also the viewport configuration can be restored in the renderer now. This was previously done in the component which triggers the nested render call.