### PR TITLE
Octree: Add `layers` property for filtering objects.

### DIFF
--- a/examples/jsm/math/Octree.js
+++ b/examples/jsm/math/Octree.js
@@ -4,7 +4,8 @@ import {
 	Plane,
 	Sphere,
 	Triangle,
-	Vector3
+	Vector3,
+	Layers
 } from 'three';
 import { Capsule } from '../math/Capsule.js';
 
@@ -89,6 +90,7 @@ class Octree {
 
 		this.subTrees = [];
 		this.triangles = [];
+		this.layers = new Layers();
 
 	}
 
@@ -470,7 +472,7 @@ class Octree {
 
 	}
 
-	fromGraphNode( group, skip ) {
+	fromGraphNode( group ) {
 
 		group.updateWorldMatrix( true, true );
 
@@ -478,11 +480,7 @@ class Octree {
 
 			if ( obj.isMesh === true ) {
 
-			    if ( skip && skip.includes(obj.material.name) ) {
-
-				// ignore these meshes
-
-			    } else {
+			    if ( this.layers.test( obj.layers ) ) {
 
 				let geometry, isTemp = false;
 

--- a/examples/jsm/math/Octree.js
+++ b/examples/jsm/math/Octree.js
@@ -470,13 +470,19 @@ class Octree {
 
 	}
 
-	fromGraphNode( group ) {
+	fromGraphNode( group, skip ) {
 
 		group.updateWorldMatrix( true, true );
 
 		group.traverse( ( obj ) => {
 
 			if ( obj.isMesh === true ) {
+
+			    if ( skip && skip.includes(obj.material.name) ) {
+
+				// ignore these meshes
+
+			    } else {
 
 				let geometry, isTemp = false;
 
@@ -512,6 +518,8 @@ class Octree {
 					geometry.dispose();
 
 				}
+
+			    }
 
 			}
 


### PR DESCRIPTION
This is a very useful feature (especially in games), it's 100% backwards compatible with the exisiting users logic and I thought to share it.
Long story short: many times you need to ignore a list of models/meshes when performing collisions or raycasting.
Think about the vegetation in a 3D world for example.
And here is this feature in action: https://necromanthus.com/Test/html5/SMC_Octree.html 