### PR TITLE
WebGLBackground: Split adding to render list and clearing of buffers

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1149,6 +1149,13 @@ class WebGLRenderer {
 
 			}
 
+			const renderBackground = xr.enabled === false || xr.isPresenting === false || xr.hasDepthSensing() === false;
+			if ( renderBackground ) {
+
+				background.addToRenderList( currentRenderList, scene );
+
+			}
+
 			//
 
 			this.info.render.frame ++;
@@ -1164,15 +1171,6 @@ class WebGLRenderer {
 			//
 
 			if ( this.info.autoReset === true ) this.info.reset();
-
-
-			//
-
-			if ( xr.enabled === false || xr.isPresenting === false || xr.hasDepthSensing() === false ) {
-
-				background.render( currentRenderList, scene );
-
-			}
 
 			// render scene
 
@@ -1197,6 +1195,8 @@ class WebGLRenderer {
 
 				}
 
+				if ( renderBackground ) background.render( scene );
+
 				for ( let i = 0, l = cameras.length; i < l; i ++ ) {
 
 					const camera2 = cameras[ i ];
@@ -1208,6 +1208,8 @@ class WebGLRenderer {
 			} else {
 
 				if ( transmissiveObjects.length > 0 ) renderTransmissionPass( opaqueObjects, transmissiveObjects, scene, camera );
+
+				if ( renderBackground ) background.render( scene );
 
 				renderScene( currentRenderList, scene, camera );
 

--- a/src/renderers/webgl/WebGLBackground.js
+++ b/src/renderers/webgl/WebGLBackground.js
@@ -26,9 +26,8 @@ function WebGLBackground( renderer, cubemaps, cubeuvmaps, state, objects, alpha,
 	let currentBackgroundVersion = 0;
 	let currentTonemapping = null;
 
-	function render( renderList, scene ) {
+	function getBackground( scene ) {
 
-		let forceClear = false;
 		let background = scene.isScene === true ? scene.background : null;
 
 		if ( background && background.isTexture ) {
@@ -37,6 +36,15 @@ function WebGLBackground( renderer, cubemaps, cubeuvmaps, state, objects, alpha,
 			background = ( usePMREM ? cubeuvmaps : cubemaps ).get( background );
 
 		}
+
+		return background;
+
+	}
+
+	function render( scene ) {
+
+		let forceClear = false;
+		const background = getBackground( scene );
 
 		if ( background === null ) {
 
@@ -66,6 +74,12 @@ function WebGLBackground( renderer, cubemaps, cubeuvmaps, state, objects, alpha,
 			renderer.clear( renderer.autoClearColor, renderer.autoClearDepth, renderer.autoClearStencil );
 
 		}
+
+	}
+
+	function addToRenderList( renderList, scene ) {
+
+		const background = getBackground( scene );
 
 		if ( background && ( background.isCubeTexture || background.mapping === CubeUVReflectionMapping ) ) {
 
@@ -247,7 +261,8 @@ function WebGLBackground( renderer, cubemaps, cubeuvmaps, state, objects, alpha,
 			setClear( clearColor, clearAlpha );
 
 		},
-		render: render
+		render: render,
+		addToRenderList: addToRenderList
 
 	};
 


### PR DESCRIPTION
Related issue: #28078 

**Description**
At the start of the frame the WebXR framebuffer is bound. When rendering transmission pass(es) or shadow maps, a switch happens to a different render target. This is basically free, _unless_ something has been written to the WebXR framebuffer already. Meaning the contents need to be stored and later loaded again.

The `WebGLBackground` handles various kinds of backgrounds. Some of which induce a clear, others insert themselves into the render list. To avoid the above mentioned overhead, any clear operation should happen _after_ the transmission pass, at the same time the transmission pass expects backgrounds to be in the render list. This PR splits these two background paths so the render list is complete before the transmission pass and any applicable clears happens after it.

Compare the following outputs of `ovrgpuprofiler` before and after:
```
Surface 0    | 3360x1760 | color 32bit, depth 24bit, stencil 0 bit, MSAA 4, Mode: 2 (SwBinning) | 72  288x320 bins ( 57  rendered) |  2.69 ms | 171 stages : Render : 0.27ms StoreColor : 0.415ms Blit : 0.005ms Preempt : 0.823ms StoreDepthStencil : 0.532ms
Surface 1    | 1680x1760 | color 64bit, depth 24bit, stencil 0 bit, MSAA 4, Mode: 1 (HwBinning) | 48  288x224 bins ( 48  rendered) |  3.38 ms | 148 stages : Binning : 0.063ms Render : 1.212ms StoreColor : 0.624ms Blit : 0.372ms Preempt : 0.387ms StoreDepthStencil : 0.099ms
Surface 2    | 1680x1760 | color 64bit, depth 24bit, stencil 0 bit, MSAA 4, Mode: 1 (HwBinning) | 48  288x224 bins ( 48  rendered) |  2.92 ms | 147 stages : Binning : 0.06ms Render : 1.218ms StoreColor : 0.623ms Blit : 0.337ms StoreDepthStencil : 0.104ms
Surface 3    | 3360x1760 | color 32bit, depth 24bit, stencil 0 bit, MSAA 4, Mode: 1 (HwBinning) | 72  288x320 bins ( 72  rendered) |  5.70 ms | 292 stages : Binning : 0.125ms LoadColor : 0.157ms Render : 3.061ms StoreColor : 0.155ms Preempt : 1.216ms LoadDepthStencil : 0.163ms
```
Notice the `StoreColor`, `StoreDepthStencil` on surface 0 and `LoadColor` and `LoadDepthStencil` on surface 3. Which are gone when looking at the output with this PR in place:
```
Surface 0    | 3360x1760 | color 32bit, depth 24bit, stencil 0 bit, MSAA 4, Mode: 0 (Direct)    | 1   3360x1760 bins ( 1   rendered) |  0.00 ms | 1   stages : Render : 0.002ms
Surface 1    | 1680x1760 | color 64bit, depth 24bit, stencil 0 bit, MSAA 4, Mode: 1 (HwBinning) | 48  288x224 bins ( 48  rendered) |  3.54 ms | 148 stages : Binning : 0.063ms Render : 1.224ms StoreColor : 0.63ms Blit : 0.372ms Preempt : 0.494ms StoreDepthStencil : 0.102ms
Surface 2    | 1680x1760 | color 64bit, depth 24bit, stencil 0 bit, MSAA 4, Mode: 1 (HwBinning) | 48  288x224 bins ( 48  rendered) |  5.03 ms | 150 stages : Binning : 0.062ms Render : 1.228ms StoreColor : 0.639ms Blit : 0.502ms Preempt : 1.677ms StoreDepthStencil : 0.103ms
Surface 3    | 3360x1760 | color 32bit, depth 24bit, stencil 0 bit, MSAA 4, Mode: 1 (HwBinning) | 72  288x320 bins ( 46  rendered) |  2.65 ms | 94  stages : Binning : 0.127ms Render : 1.945ms StoreColor : 0.336ms Blit : 0.004ms
```

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Fern Solutions](https://fern.solutions)*
