### PR TITLE
Fix: Incorrect usage of 'await' in WebGPU.js

### DIFF
--- a/examples/jsm/capabilities/WebGPU.js
+++ b/examples/jsm/capabilities/WebGPU.js
@@ -4,28 +4,31 @@ if ( self.GPUShaderStage === undefined ) {
 
 }
 
-// statics
-
 let isAvailable = navigator.gpu !== undefined;
-
-
-if ( typeof window !== 'undefined' && isAvailable ) {
-
-	isAvailable = await navigator.gpu.requestAdapter();
-
-}
 
 class WebGPU {
 
 	static isAvailable() {
 
-		return Boolean( isAvailable );
+		return isAvailable;
 
 	}
 
-	static getStaticAdapter() {
+	static async getStaticAdapter () {
 
-		return isAvailable;
+		if ( navigator.gpu ) {
+
+			const adapter = await navigator.gpu.requestAdapter();
+
+			if ( !adapter ) {
+
+				isAvailable = false;
+
+			}
+
+			return adapter;
+
+		}
 
 	}
 


### PR DESCRIPTION
The previous code was very poorly readable.

`isAvailable` seems to be a Boolean value, but why does it suddenly become a GPUAdapter later?



<br>

The most critical error is: **await can only run in async function** !



<br>

If you use [vite](https://github.com/vitejs/vite) , when you write this line of code:

```
const renderer = new WebGPURenderer()
```

You will receive an error like this:

```
Top-level await is not available in the configured target environment ("chrome87", "edge88", "es2020", "firefox78", "safari14" + 2 overrides)
```

<br>
----------------

By the way, I don't understand the meaning of `getStaticAdapter()` at all. It feels completely unnecessary.
