### PR TITLE
PhysicalMaterial: remove `USE_SPECULAR`

### DIFF
--- a/src/renderers/shaders/ShaderChunk/lights_physical_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_physical_fragment.glsl.js
@@ -13,32 +13,22 @@ material.roughness = min( material.roughness, 1.0 );
 
 	material.ior = ior;
 
-	#ifdef USE_SPECULAR
+	float specularIntensityFactor = specularIntensity;
+	vec3 specularColorFactor = specularColor;
 
-		float specularIntensityFactor = specularIntensity;
-		vec3 specularColorFactor = specularColor;
+	#ifdef USE_SPECULAR_COLORMAP
 
-		#ifdef USE_SPECULAR_COLORMAP
-
-			specularColorFactor *= texture2D( specularColorMap, vSpecularColorMapUv ).rgb;
-
-		#endif
-
-		#ifdef USE_SPECULAR_INTENSITYMAP
-
-			specularIntensityFactor *= texture2D( specularIntensityMap, vSpecularIntensityMapUv ).a;
-
-		#endif
-
-		material.specularF90 = mix( specularIntensityFactor, 1.0, metalnessFactor );
-
-	#else
-
-		float specularIntensityFactor = 1.0;
-		vec3 specularColorFactor = vec3( 1.0 );
-		material.specularF90 = 1.0;
+		specularColorFactor *= texture2D( specularColorMap, vSpecularColorMapUv ).rgb;
 
 	#endif
+
+	#ifdef USE_SPECULAR_INTENSITYMAP
+
+		specularIntensityFactor *= texture2D( specularIntensityMap, vSpecularIntensityMapUv ).a;
+
+	#endif
+
+	material.specularF90 = mix( specularIntensityFactor, 1.0, metalnessFactor );
 
 	material.specularColor = mix( min( pow2( ( material.ior - 1.0 ) / ( material.ior + 1.0 ) ) * specularColorFactor, vec3( 1.0 ) ) * specularIntensityFactor, diffuseColor.rgb, metalnessFactor );
 

--- a/src/renderers/shaders/ShaderLib/meshphysical.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshphysical.glsl.js
@@ -64,7 +64,6 @@ export const fragment = /* glsl */`
 
 #ifdef PHYSICAL
 	#define IOR
-	#define USE_SPECULAR
 #endif
 
 uniform vec3 diffuse;
@@ -75,16 +74,13 @@ uniform float opacity;
 
 #ifdef IOR
 	uniform float ior;
-#endif
-
-#ifdef USE_SPECULAR
 	uniform float specularIntensity;
 	uniform vec3 specularColor;
-
+	
 	#ifdef USE_SPECULAR_COLORMAP
 		uniform sampler2D specularColorMap;
 	#endif
-
+	
 	#ifdef USE_SPECULAR_INTENSITYMAP
 		uniform sampler2D specularIntensityMap;
 	#endif


### PR DESCRIPTION
For physical material, `USE_SPECULAR` looks redundent, 