### PR TITLE
Improve Texture documentation

### DIFF
--- a/docs/api/en/textures/Texture.html
+++ b/docs/api/en/textures/Texture.html
@@ -191,7 +191,7 @@
 
 		<h3>[property:Vector2 center]</h3>
 		<p>
-			The point around which rotation occurs. A value of (0.5, 0.5) corresponds
+			The origin point around which the texture will be rotated or scaled. A value of (0.5, 0.5) corresponds
 			to the center of the texture. Default is (0, 0), the lower left.
 		</p>
 


### PR DESCRIPTION
Improves the Texture documentation by mentioning that **Texture.center** affects the texture's rotation and scale, as current docs only mention rotation.