### PR TITLE
WebGPURenderer: `transmission` and `clearcoat` shouldn't be ignored in `getMaterialCacheKey`

### DIFF
--- a/examples/jsm/renderers/common/RenderObject.js
+++ b/examples/jsm/renderers/common/RenderObject.js
@@ -2,6 +2,40 @@ import ClippingContext from './ClippingContext.js';
 
 let id = 0;
 
+function getKeys( obj ) {
+
+	const keys = Object.keys( obj );
+
+	let proto = Object.getPrototypeOf( obj );
+
+	while ( proto ) {
+
+		const descriptors = Object.getOwnPropertyDescriptors( proto );
+
+		for ( const key in descriptors ) {
+
+			if ( descriptors[ key ] !== undefined ) {
+
+				const descriptor = descriptors[ key ];
+
+				if ( descriptor && typeof descriptor.get === 'function' ) {
+
+					keys.push( key );
+
+				}
+
+			}
+
+		}
+
+		proto = Object.getPrototypeOf( proto );
+
+	}
+
+	return keys;
+
+}
+
 export default class RenderObject {
 
 	constructor( nodes, geometries, renderer, object, material, scene, camera, lightsNode, renderContext ) {
@@ -153,9 +187,9 @@ export default class RenderObject {
 
 		let cacheKey = material.customProgramCacheKey();
 
-		for ( const property in material ) {
+		for ( const property of getKeys( material ) ) {
 
-			if ( /^(is[A-Z]|_(?!(transmission|clearcoat)))|^(visible|version|uuid|name|opacity|userData)$/.test( property ) ) continue;
+			if ( /^(is[A-Z]|_)|^(visible|version|uuid|name|opacity|userData)$/.test( property ) ) continue;
 
 			let value = material[ property ];
 

--- a/examples/jsm/renderers/common/RenderObject.js
+++ b/examples/jsm/renderers/common/RenderObject.js
@@ -155,7 +155,7 @@ export default class RenderObject {
 
 		for ( const property in material ) {
 
-			if ( /^(is[A-Z]|_)|^(visible|version|uuid|name|opacity|userData)$/.test( property ) ) continue;
+			if ( /^(is[A-Z]|_(?!(transmission|clearcoat)))|^(visible|version|uuid|name|opacity|userData)$/.test( property ) ) continue;
 
 			let value = material[ property ];
 


### PR DESCRIPTION


Related issue: #27995



|             | before | after |
|-------------|--------|-------|
| transmission |<video src="https://github.com/mrdoob/three.js/assets/20318608/7fec67d1-c11b-4154-9e08-8fa470810a2f"></video>|<video src="https://github.com/mrdoob/three.js/assets/20318608/29d886b1-6d8e-4b95-ba49-7f0ce4111100"></video>|
| clearcoat     |<video src="https://github.com/mrdoob/three.js/assets/20318608/12e27b1b-3136-4f67-b39a-ea650536da40"></video>|<video src="https://github.com/mrdoob/three.js/assets/20318608/d7490ae4-7e6c-4e2b-86c0-051f00249d63"></video>|
