### PR TITLE
GLTFExporter: Include three.js version in generator string

### DIFF
--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -26,6 +26,7 @@ import {
 	Quaternion,
 } from 'three';
 import { decompress } from './../utils/TextureUtils.js';
+import { REVISION } from '../../../src/constants.js';
 
 
 /**
@@ -502,7 +503,7 @@ class GLTFWriter {
 		this.json = {
 			asset: {
 				version: '2.0',
-				generator: 'THREE.GLTFExporter'
+				generator: 'THREE.GLTFExporter r' + REVISION
 			}
 		};
 


### PR DESCRIPTION
It's helpful for debugging if GLTFExporter includes the three.js version in the generator string, and consistent with many other glTF authoring tools.