### PR TITLE
WebGLTextures: Fix `gl.invalidateFramebuffer()` call.

### DIFF
--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -1892,7 +1892,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 					}
 
-					if ( ignoreDepthValues === true ) {
+					if ( ignoreDepthValues === true && supportsInvalidateFramebuffer ) {
 
 						_gl.invalidateFramebuffer( _gl.READ_FRAMEBUFFER, [ depthStyle ] );
 						_gl.invalidateFramebuffer( _gl.DRAW_FRAMEBUFFER, [ depthStyle ] );


### PR DESCRIPTION
Related issue: see https://github.com/mrdoob/three.js/pull/28132#issuecomment-2056229668

**Description**

This PR makes sure `gl.invalidateFramebuffer()` is only called when `supportsInvalidateFramebuffer` is set to `true`.
