### PR TITLE
CCDIKSolver: Allow specifying sphere size in `createHelper()`.

### DIFF
--- a/examples/jsm/animation/CCDIKSolver.js
+++ b/examples/jsm/animation/CCDIKSolver.js
@@ -216,7 +216,7 @@ class CCDIKSolver {
 	 * @param {number} sphereSize
 	 * @return {CCDIKHelper}
 	 */
-	createHelper(sphereSize) {
+	createHelper( sphereSize ) {
 
 		return new CCDIKHelper( this.mesh, this.iks, sphereSize );
 

--- a/examples/jsm/animation/CCDIKSolver.js
+++ b/examples/jsm/animation/CCDIKSolver.js
@@ -212,7 +212,7 @@ class CCDIKSolver {
 
 	/**
 	 * Creates Helper
-	 *  
+	 *
 	 * @param {number} sphereSize
 	 * @return {CCDIKHelper}
 	 */

--- a/examples/jsm/animation/CCDIKSolver.js
+++ b/examples/jsm/animation/CCDIKSolver.js
@@ -212,12 +212,13 @@ class CCDIKSolver {
 
 	/**
 	 * Creates Helper
-	 *
+	 *  
+	 * @param {number} sphereSize
 	 * @return {CCDIKHelper}
 	 */
-	createHelper() {
+	createHelper(sphereSize) {
 
-		return new CCDIKHelper( this.mesh, this.iks );
+		return new CCDIKHelper( this.mesh, this.iks, sphereSize );
 
 	}
 
@@ -280,6 +281,7 @@ function setPositionOfBoneToAttributeArray( array, index, bone, matrixWorldInv )
  *
  * @param {SkinnedMesh} mesh
  * @param {Array<Object>} iks
+ * @param {number} sphereSize
  */
 class CCDIKHelper extends Object3D {
 


### PR DESCRIPTION
**Description**

Currently, if you want to create a CCDIKHelper with spheres of a certain size, you can't use the CCDIKSolver.createHelper() function to do so, since it doesn't expose that parameter.
I've added it and it just gets passed straight through.