### PR TITLE
Plane: Make second set parameter optional.

### DIFF
--- a/src/math/Plane.js
+++ b/src/math/Plane.js
@@ -18,7 +18,7 @@ class Plane {
 
 	}
 
-	set( normal, constant ) {
+	set( normal, constant = 0 ) {
 
 		this.normal.copy( normal );
 		this.constant = constant;


### PR DESCRIPTION
Calling Plane.set() without passing a value for ``constant`` results in a plane with a constant of ``undefined``.
The docs already say that this parameter should default to 0.

This makes it actually do that.