### PR TITLE
Create RenderTarget.js

### DIFF
--- a/examples/jsm/renderers/common/RenderTarget.js
+++ b/examples/jsm/renderers/common/RenderTarget.js
@@ -1,0 +1,147 @@
+import { EventDispatcher, Texture, LinearFilter, Vector4, Source } from 'three';
+
+
+class RenderTarget extends EventDispatcher {
+
+    constructor( width = 1, height = 1, options = {} ) {
+
+        super();
+
+        this.isRenderTarget = true;
+
+        this.width = width;
+        this.height = height;
+        this.depth = 1;
+
+        this.scissor = new Vector4( 0, 0, width, height );
+        this.scissorTest = false;
+
+        this.viewport = new Vector4( 0, 0, width, height );
+
+        const image = { width: width, height: height, depth: 1 };
+
+        options = Object.assign( {
+            generateMipmaps: false,
+            internalFormat: null,
+            minFilter: LinearFilter,
+            depthBuffer: true,
+            stencilBuffer: false,
+            depthTexture: null,
+            samples: 0,
+            count: 1
+        }, options );
+
+        const texture = new Texture( image, options.mapping, options.wrapS, options.wrapT, options.magFilter, options.minFilter, options.format, options.type, options.anisotropy, options.colorSpace );
+
+        texture.flipY = false;
+        texture.generateMipmaps = options.generateMipmaps;
+        texture.internalFormat = options.internalFormat;
+
+        this.textures = [];
+
+        const count = options.count;
+        for ( let i = 0; i < count; i ++ ) {
+
+            this.textures[ i ] = texture.clone();
+            this.textures[ i ].isRenderTargetTexture = true;
+
+        }
+
+        this.depthBuffer = options.depthBuffer;
+        this.stencilBuffer = options.stencilBuffer;
+
+        this.depthTexture = options.depthTexture;
+
+        this.samples = options.samples;
+
+    }
+
+    get texture() {
+
+        return this.textures[ 0 ];
+
+    }
+
+    set texture( value ) {
+
+        this.textures[ 0 ] = value;
+
+    }
+
+    setSize( width, height, depth = 1 ) {
+
+        if ( this.width !== width || this.height !== height || this.depth !== depth ) {
+
+            this.width = width;
+            this.height = height;
+            this.depth = depth;
+
+            for ( let i = 0, il = this.textures.length; i < il; i ++ ) {
+
+                this.textures[ i ].image.width = width;
+                this.textures[ i ].image.height = height;
+                this.textures[ i ].image.depth = depth;
+
+            }
+
+            this.dispose();
+
+        }
+
+        this.viewport.set( 0, 0, width, height );
+        this.scissor.set( 0, 0, width, height );
+
+    }
+
+    clone() {
+
+        return new this.constructor().copy( this );
+
+    }
+
+    copy( source ) {
+
+        this.width = source.width;
+        this.height = source.height;
+        this.depth = source.depth;
+
+        this.scissor.copy( source.scissor );
+        this.scissorTest = source.scissorTest;
+
+        this.viewport.copy( source.viewport );
+
+        this.textures.length = 0;
+
+        for ( let i = 0, il = source.textures.length; i < il; i ++ ) {
+
+            this.textures[ i ] = source.textures[ i ].clone();
+            this.textures[ i ].isRenderTargetTexture = true;
+
+        }
+
+        // ensure image object is not shared, see #20328
+
+        const image = Object.assign( {}, source.texture.image );
+        this.texture.source = new Source( image );
+
+        this.depthBuffer = source.depthBuffer;
+        this.stencilBuffer = source.stencilBuffer;
+
+        if ( source.depthTexture !== null ) this.depthTexture = source.depthTexture.clone();
+
+        this.samples = source.samples;
+
+        return this;
+
+    }
+
+    dispose() {
+
+        this.dispatchEvent( { type: 'dispose' } );
+
+    }
+
+}
+
+
+export default RenderTarget;


### PR DESCRIPTION
Related issue: #27502

This is a copy of the renderTarget from the three.module.js file with the necessary imports from three.module.js. WGSL requires a strict separation between texture read and texture write accessors. For the compute shader, texture node is used for read and textureStore node for write to separate the bindings for the same resource. Since the StorageTexture class is located here, I also copied the RenderTarget here. At the moment the renderTarget does nothing other than the same as the renderTarget in three.module.js. This renderTarget can now be specifically expanded to separate the bindings and avoid the error messages caused by the access of WGSL shaders (read access) and the renderTarget (write access) to the same resource.




