### PR TITLE
Docs: Improve `Plane` page.

### DIFF
--- a/docs/api/ar/math/Plane.html
+++ b/docs/api/ar/math/Plane.html
@@ -145,8 +145,7 @@
 		<p>
 		[page:Vector3 normal] - وحدة طول [page:Vector3] تحدد الطبيعي
 		من الطائرة. <br />
-		[page:Float constant] - المسافة الموقعة من المنشأ إلى الطائرة.
-		الافتراضي هو `0`. <br /><br />
+		[page:Float constant] - المسافة الموقعة من المنشأ إلى الطائرة. <br /><br />
 	 
 		يضع خصائص [page:.normal normal] و[page:.constant constant]
 		لهذه الطائرة عن طريق نسخ القيم من الطبيعي المعطى.

--- a/docs/api/en/math/Plane.html
+++ b/docs/api/en/math/Plane.html
@@ -146,7 +146,7 @@ const optionalNormalMatrix = new THREE.Matrix3().getNormalMatrix( matrix );
 			[page:Vector3 normal] - a unit length [page:Vector3] defining the normal
 			of the plane.<br />
 			[page:Float constant] - the signed distance from the origin to the plane.
-			Default is `0`.<br /><br />
+			<br /><br />
 
 			Sets this plane's [page:.normal normal] and [page:.constant constant]
 			properties by copying the values from the given normal.

--- a/docs/api/it/math/Plane.html
+++ b/docs/api/it/math/Plane.html
@@ -131,7 +131,7 @@
 		<h3>[method:this set]( [param:Vector3 normal], [param:Float constant] )</h3>
 		<p>
 			[page:Vector3 normal] - un [page:Vector3] di lunghezza unitaria che definisce la normale del piano.<br />
-			[page:Float constant] - la distanza con segno dall'origine al piano. Il valore predefinito è `0`.<br /><br />
+			[page:Float constant] - la distanza con segno dall'origine al piano.<br /><br />
 
 			Imposta le proprietà [page:.normal normal] e [page:.constant constant] del piano copiando i valori dalla normale data.
 		</p>

--- a/docs/api/zh/math/Plane.html
+++ b/docs/api/zh/math/Plane.html
@@ -125,7 +125,7 @@
 		<h3>[method:this set]( [param:Vector3 normal], [param:Float constant] )</h3>
 		<p>
 			[page:Vector3 normal] - 单位长度的向量表示平面的法向量。<br />
-			[page:Float constant] - 原点到平面有符号距离。默认值为 *0*。<br /><br />
+			[page:Float constant] - 原点到平面有符号距离。<br /><br />
 
 			设置平面 [page:.normal normal] 的法线和常量 [page:.constant constant] 属性值。
 		</p>


### PR DESCRIPTION
Closes #28150.

**Description**

Removes a wrong default value definition from `Plane.set()`.
