### PR TITLE
Fix copyright year range in license info

### DIFF
--- a/utils/build/rollup.config.js
+++ b/utils/build/rollup.config.js
@@ -45,7 +45,7 @@ function header() {
 
 			code.prepend( `/**
  * @license
- * Copyright 2010-2023 Three.js Authors
+ * Copyright 2010-2024 Three.js Authors
  * SPDX-License-Identifier: MIT
  */\n` );
 


### PR DESCRIPTION
should always be the same of the LICENSE https://github.com/mrdoob/three.js/blob/01ee1a73c0677c741d0e8e8eae9dd28c3c05c028/LICENSE#L1-L3