### PR TITLE
Nodes: Line2NodeMaterial - simplify extension

### DIFF
--- a/examples/jsm/nodes/materials/Line2NodeMaterial.js
+++ b/examples/jsm/nodes/materials/Line2NodeMaterial.js
@@ -43,9 +43,15 @@ class Line2NodeMaterial extends NodeMaterial {
 		this.dashSizeNode = null;
 		this.gapSizeNode = null;
 
+		this.setValues( params );
+
+	}
+
+	setup( builder ) {
+
 		this.setupShaders();
 
-		this.setValues( params );
+		super.setup( builder );
 
 	}
 

--- a/examples/jsm/nodes/materials/Line2NodeMaterial.js
+++ b/examples/jsm/nodes/materials/Line2NodeMaterial.js
@@ -377,8 +377,6 @@ class Line2NodeMaterial extends NodeMaterial {
 
 		} )();
 
-		this.needsUpdate = true;
-
 	}
 
 
@@ -393,7 +391,7 @@ class Line2NodeMaterial extends NodeMaterial {
 		if ( this.useWorldUnits !== value ) {
 
 			this.useWorldUnits = value;
-			this.setupShaders();
+			this.needsUpdate = true;
 
 		}
 
@@ -411,7 +409,7 @@ class Line2NodeMaterial extends NodeMaterial {
 		if ( this.useDash !== value ) {
 
 			this.useDash = value;
-			this.setupShaders();
+			this.needsUpdate = true;
 
 		}
 
@@ -429,7 +427,7 @@ class Line2NodeMaterial extends NodeMaterial {
 		if ( this.useAlphaToCoverage !== value ) {
 
 			this.useAlphaToCoverage = value;
-			this.setupShaders();
+			this.needsUpdate = true;
 
 		}
 


### PR DESCRIPTION
Delay the call to setupShaders() to setup() phase, to allow easier and more efficient subclassing (removes requirement for subclass making a redundant call to setupShaders()).
