### PR TITLE
WebGPURenderer: Fix group draw range

### DIFF
--- a/examples/jsm/renderers/common/RenderObject.js
+++ b/examples/jsm/renderers/common/RenderObject.js
@@ -56,6 +56,8 @@ export default class RenderObject {
 		this.geometry = object.geometry;
 		this.version = material.version;
 
+		this.drawRange = null;
+
 		this.attributes = null;
 		this.pipeline = null;
 		this.vertexBuffers = null;

--- a/examples/jsm/renderers/common/Renderer.js
+++ b/examples/jsm/renderers/common/Renderer.js
@@ -1325,16 +1325,16 @@ class Renderer {
 		if ( material.transparent === true && material.side === DoubleSide && material.forceSinglePass === false ) {
 
 			material.side = BackSide;
-			this._handleObjectFunction( object, material, scene, camera, lightsNode, 'backSide' ); // create backSide pass id
+			this._handleObjectFunction( object, material, scene, camera, lightsNode, group, 'backSide' ); // create backSide pass id
 
 			material.side = FrontSide;
-			this._handleObjectFunction( object, material, scene, camera, lightsNode ); // use default pass id
+			this._handleObjectFunction( object, material, scene, camera, lightsNode, group ); // use default pass id
 
 			material.side = DoubleSide;
 
 		} else {
 
-			this._handleObjectFunction( object, material, scene, camera, lightsNode );
+			this._handleObjectFunction( object, material, scene, camera, lightsNode, group );
 
 		}
 
@@ -1364,9 +1364,10 @@ class Renderer {
 
 	}
 
-	_renderObjectDirect( object, material, scene, camera, lightsNode, passId ) {
+	_renderObjectDirect( object, material, scene, camera, lightsNode, group, passId ) {
 
 		const renderObject = this._objects.get( object, material, scene, camera, lightsNode, this._currentRenderContext, passId );
+		renderObject.drawRange = group || object.geometry.drawRange;
 
 		//
 

--- a/examples/jsm/renderers/webgl/WebGLBackend.js
+++ b/examples/jsm/renderers/webgl/WebGLBackend.js
@@ -615,7 +615,7 @@ class WebGLBackend extends Backend {
 		const index = renderObject.getIndex();
 
 		const geometry = renderObject.geometry;
-		const drawRange = geometry.drawRange;
+		const drawRange = renderObject.drawRange;
 		const firstVertex = drawRange.start;
 
 		//

--- a/examples/jsm/renderers/webgpu/WebGPUBackend.js
+++ b/examples/jsm/renderers/webgpu/WebGPUBackend.js
@@ -871,7 +871,7 @@ class WebGPUBackend extends Backend {
 
 		// draw
 
-		const drawRange = geometry.drawRange;
+		const drawRange = renderObject.drawRange;
 		const firstVertex = drawRange.start;
 
 		const instanceCount = this.getInstanceCount( renderObject );


### PR DESCRIPTION
**Description**

Fix `geometry.groups` if the Mesh has Material Array.

| Before | After  |
| ------------- | ------------- |
| ![image](https://github.com/mrdoob/three.js/assets/502810/1a281879-bf75-453f-ad2c-cd056efec937) | ![image](https://github.com/mrdoob/three.js/assets/502810/a4059c06-0e88-400c-9c31-2c42947d2d80) |