### PR TITLE
PMREMGenerator: Make blur order consistent.

### DIFF
--- a/src/extras/PMREMGenerator.js
+++ b/src/extras/PMREMGenerator.js
@@ -58,7 +58,7 @@ const _axisDirections = [
 	/*@__PURE__*/ new Vector3( - 1, 1, - 1 ),
 	/*@__PURE__*/ new Vector3( 1, 1, - 1 ),
 	/*@__PURE__*/ new Vector3( - 1, 1, 1 ),
-	/*@__PURE__*/ new Vector3( 1, 1, 1 )];
+	/*@__PURE__*/ new Vector3( 1, 1, 1 ) ];
 
 /**
  * This class generates a Prefiltered, Mipmapped Radiance Environment Map

--- a/src/extras/PMREMGenerator.js
+++ b/src/extras/PMREMGenerator.js
@@ -49,16 +49,16 @@ const INV_PHI = 1 / PHI;
 // Vertices of a dodecahedron (except the opposites, which represent the
 // same axis), used as axis directions evenly spread on a sphere.
 const _axisDirections = [
-	/*@__PURE__*/ new Vector3( 1, 1, 1 ),
-	/*@__PURE__*/ new Vector3( - 1, 1, 1 ),
-	/*@__PURE__*/ new Vector3( 1, 1, - 1 ),
-	/*@__PURE__*/ new Vector3( - 1, 1, - 1 ),
-	/*@__PURE__*/ new Vector3( 0, PHI, INV_PHI ),
-	/*@__PURE__*/ new Vector3( 0, PHI, - INV_PHI ),
-	/*@__PURE__*/ new Vector3( INV_PHI, 0, PHI ),
-	/*@__PURE__*/ new Vector3( - INV_PHI, 0, PHI ),
+	/*@__PURE__*/ new Vector3( - PHI, INV_PHI, 0 ),
 	/*@__PURE__*/ new Vector3( PHI, INV_PHI, 0 ),
-	/*@__PURE__*/ new Vector3( - PHI, INV_PHI, 0 ) ];
+	/*@__PURE__*/ new Vector3( - INV_PHI, 0, PHI ),
+	/*@__PURE__*/ new Vector3( INV_PHI, 0, PHI ),
+	/*@__PURE__*/ new Vector3( 0, PHI, - INV_PHI ),
+	/*@__PURE__*/ new Vector3( 0, PHI, INV_PHI ),
+	/*@__PURE__*/ new Vector3( - 1, 1, - 1 ),
+	/*@__PURE__*/ new Vector3( 1, 1, - 1 ),
+	/*@__PURE__*/ new Vector3( - 1, 1, 1 ),
+	/*@__PURE__*/ new Vector3( 1, 1, 1 )];
 
 /**
  * This class generates a Prefiltered, Mipmapped Radiance Environment Map
@@ -444,12 +444,13 @@ class PMREMGenerator {
 		const renderer = this._renderer;
 		const autoClear = renderer.autoClear;
 		renderer.autoClear = false;
+		const n = this._lodPlanes.length;
 
-		for ( let i = 1; i < this._lodPlanes.length; i ++ ) {
+		for ( let i = 1; i < n; i ++ ) {
 
 			const sigma = Math.sqrt( this._sigmas[ i ] * this._sigmas[ i ] - this._sigmas[ i - 1 ] * this._sigmas[ i - 1 ] );
 
-			const poleAxis = _axisDirections[ ( i - 1 ) % _axisDirections.length ];
+			const poleAxis = _axisDirections[ ( n - i - 1 ) % _axisDirections.length ];
 
 			this._blur( cubeUVRenderTarget, i - 1, i, sigma, poleAxis );
 


### PR DESCRIPTION
Related #28071

**Description**

Here I've tweaked the ordering of the blur directions so they are anchored by the bottom of the stack instead of the top - this way when using two differently-sized environments, once the larger has been blurred down to the smaller, they follow exactly the same operations for the rest of the mip levels. Before, the axis direction of the blur was cycled from the top, so it used a different sequence for the lower mips based on how many there were total. 

This does make the result look more consistent, but sadly it does nothing regarding the overall increased brightness of the PMREM for lower-res versions of the same HDR. That is very strange - I think the fundamental issue is that the HDR in question is dominated by the sun, which is just a few pixels of extremely high intensity, which dominate the blur results. My lat/long blur is certainly unusual - I'm curious if it ends up biasing the result, perhaps more as bright pixels are farther from the equator? @WestLangley if you'd like to take a look at my blur math, I'd appreciate it. I haven't found anything glaring yet, and I'm out next week.

FYI @mrdoob 