### PR TITLE
Docs: Cleanup How-to-use-post-processing.html

### DIFF
--- a/docs/manual/en/introduction/How-to-use-post-processing.html
+++ b/docs/manual/en/introduction/How-to-use-post-processing.html
@@ -77,7 +77,7 @@
 
 		<p>
 			`RenderPass` is normally placed at the beginning of the chain in order to provide the rendered scene as an input for the next post-processing step. In our case,
-			`GlitchPass` is going to use these image data to apply a wild glitch effect. `OutputPass` is usually the last pass in the chain which performs sRGB color space conversion and optional tone mapping.
+			`GlitchPass` is going to use these image data to apply a wild glitch effect. `OutputPass` is usually the last pass in the chain which performs sRGB color space conversion and tone mapping.
 			Check out this [link:https://threejs.org/examples/webgl_postprocessing_glitch live example] to see it in action.
 		</p>
 


### PR DESCRIPTION
**Description**
Improved Output Pass related statement in the doc.

Since the tone mapping is being extracted from the renderer state, the term `optional` seems to be a bit misleading or outdated ( as per the changes mentioned in [here](https://github.com/mrdoob/three.js/wiki/Migration-Guide#154--155)  )
