### PR TITLE
FileLoader: Evaluate `X-File-Size` header before `Content-Length`.

### DIFF
--- a/src/loaders/FileLoader.js
+++ b/src/loaders/FileLoader.js
@@ -112,7 +112,7 @@ class FileLoader extends Loader {
 
 					// Nginx needs X-File-Size check
 					// https://serverfault.com/questions/482875/why-does-nginx-remove-content-length-header-for-chunked-content
-					const contentLength = response.headers.get( 'Content-Length' ) || response.headers.get( 'X-File-Size' );
+					const contentLength = response.headers.get( 'X-File-Size' ) || response.headers.get( 'Content-Length' );
 					const total = contentLength ? parseInt( contentLength ) : 0;
 					const lengthComputable = total !== 0;
 					let loaded = 0;


### PR DESCRIPTION
Closes #23896.

**Description**

This makes sure devs can use `X-File-Size` to report the uncompressed content length of compressed assets. If `X-File-Size` isn't set, `Content-Length` will be used as before.

Using this approach makes #23896 obsolete so there is no need to expose the response object in a custom progress event.