### PR TITLE
RenderTarget: Add `resolveDepthBuffer`.

### DIFF
--- a/docs/api/ar/renderers/WebGLRenderTarget.html
+++ b/docs/api/ar/renderers/WebGLRenderTarget.html
@@ -49,6 +49,7 @@
 		[page:String internalFormat] - الافتراضي هو `null`.<br />
 		[page:Boolean depthBuffer] - الافتراضي هو `true`. <br />
 		[page:Boolean stencilBuffer] - الافتراضي هو `false`. <br />
+		[page:Boolean resolveDepthBuffer] - الافتراضي هو `true`. <br />
 		[page:Boolean resolveStencilBuffer] - الافتراضي هو `true`. <br />
 		[page:Number samples] - الافتراضي هو 0. <br /><br />
 		 
@@ -89,9 +90,16 @@
 		<h3>[property:Boolean stencilBuffer]</h3>
 		<p>يعرض على مخزن القالب. الافتراضي هو false.</p>
 
+		<h3>[property:Boolean resolveDepthBuffer]</h3>
+		<p>
+			Defines whether the depth buffer should be resolved when rendering into a multisampled render target. 
+			Default is `true`.
+		</p>
+
 		<h3>[property:Boolean resolveStencilBuffer]</h3>
 		<p>
 			Defines whether the stencil buffer should be resolved when rendering into a multisampled render target. 
+			This property has no effect when [page:.resolveDepthBuffer] is set to `false`. 
 			Default is `true`.
 		</p>
 	 

--- a/docs/api/en/renderers/WebGLRenderTarget.html
+++ b/docs/api/en/renderers/WebGLRenderTarget.html
@@ -50,6 +50,7 @@
 			[page:String internalFormat] - default is `null`.<br />
 			[page:Boolean depthBuffer] - default is `true`. <br />
 			[page:Boolean stencilBuffer] - default is `false`.<br />
+			[page:Boolean resolveDepthBuffer] - default is `true`.<br />
 			[page:Boolean resolveStencilBuffer] - default is `true`.<br />
 			[page:Number samples] - default is `0`.<br />
 			[page:Number count] - default is `1`.<br /><br />
@@ -98,9 +99,16 @@
 		<h3>[property:Boolean stencilBuffer]</h3>
 		<p>Renders to the stencil buffer. Default is false.</p>
 
+		<h3>[property:Boolean resolveDepthBuffer]</h3>
+		<p>
+			Defines whether the depth buffer should be resolved when rendering into a multisampled render target. 
+			Default is `true`.
+		</p>
+
 		<h3>[property:Boolean resolveStencilBuffer]</h3>
 		<p>
 			Defines whether the stencil buffer should be resolved when rendering into a multisampled render target. 
+			This property has no effect when [page:.resolveDepthBuffer] is set to `false`. 
 			Default is `true`.
 		</p>
 

--- a/docs/api/it/renderers/WebGLRenderTarget.html
+++ b/docs/api/it/renderers/WebGLRenderTarget.html
@@ -43,6 +43,7 @@
 		[page:String internalFormat] - il valore predefinito è `null`.<br />
 		[page:Boolean depthBuffer] - il valore predefinito è `true`. <br />
 		[page:Boolean stencilBuffer] - il valore predefinito è `false`.<br />
+		[page:Boolean resolveDepthBuffer] - il valore predefinito è `true`.<br />
 		[page:Boolean resolveStencilBuffer] - il valore predefinito è `true`.<br />
 		[page:Number samples] - il valore predefinito è 0.<br />
 		[page:Number count] - default is `1`.<br /><br />
@@ -103,9 +104,16 @@
 			Effettua il rendering al buffer stencil. Il valore predefinito è `false`.
 		</p>
 
+		<h3>[property:Boolean resolveDepthBuffer]</h3>
+		<p>
+			Defines whether the depth buffer should be resolved when rendering into a multisampled render target. 
+			Il valore predefinito è `true`.
+		</p>
+
 		<h3>[property:Boolean resolveStencilBuffer]</h3>
 		<p>
 			Defines whether the stencil buffer should be resolved when rendering into a multisampled render target. 
+			This property has no effect when [page:.resolveDepthBuffer] is set to `false`. 
 			Il valore predefinito è `true`.
 		</p>
 

--- a/docs/api/zh/renderers/WebGLRenderTarget.html
+++ b/docs/api/zh/renderers/WebGLRenderTarget.html
@@ -39,6 +39,7 @@
 		[page:String internalFormat] -  默认是 `null`.<br />
 		[page:Boolean depthBuffer] - 默认是`true`.<br />
 		[page:Boolean stencilBuffer] - 默认是`false`.<br />
+		[page:Boolean resolveDepthBuffer] - 默认是`true`.<br />
 		[page:Boolean resolveStencilBuffer] - 默认是`true`.<br />
 		[page:Number samples] - 默认是`0`.<br />
 		[page:Number count] - default is `1`.<br /><br />
@@ -99,9 +100,16 @@
 		渲染到模板缓冲区。默认为false.
 		</p>
 
+		<h3>[property:Boolean resolveDepthBuffer]</h3>
+		<p>
+			Defines whether the depth buffer should be resolved when rendering into a multisampled render target. 
+			默认为`true`.
+		</p>
+
 		<h3>[property:Boolean resolveStencilBuffer]</h3>
 		<p>
 			Defines whether the stencil buffer should be resolved when rendering into a multisampled render target. 
+			This property has no effect when [page:.resolveDepthBuffer] is set to `false`. 
 			默认为`true`.
 		</p>
 

--- a/src/core/RenderTarget.js
+++ b/src/core/RenderTarget.js
@@ -34,7 +34,7 @@ class RenderTarget extends EventDispatcher {
 			minFilter: LinearFilter,
 			depthBuffer: true,
 			stencilBuffer: false,
-			ignoreDepthValues: false,
+			resolveDepthBuffer: true,
 			resolveStencilBuffer: true,
 			depthTexture: null,
 			samples: 0,
@@ -60,7 +60,7 @@ class RenderTarget extends EventDispatcher {
 		this.depthBuffer = options.depthBuffer;
 		this.stencilBuffer = options.stencilBuffer;
 
-		this.ignoreDepthValues = options.ignoreDepthValues;
+		this.resolveDepthBuffer = options.resolveDepthBuffer;
 		this.resolveStencilBuffer = options.resolveStencilBuffer;
 
 		this.depthTexture = options.depthTexture;
@@ -140,7 +140,7 @@ class RenderTarget extends EventDispatcher {
 		this.depthBuffer = source.depthBuffer;
 		this.stencilBuffer = source.stencilBuffer;
 
-		this.ignoreDepthValues = source.ignoreDepthValues;
+		this.resolveDepthBuffer = source.resolveDepthBuffer;
 		this.resolveStencilBuffer = source.resolveStencilBuffer;
 
 		if ( source.depthTexture !== null ) this.depthTexture = source.depthTexture.clone();

--- a/src/core/RenderTarget.js
+++ b/src/core/RenderTarget.js
@@ -34,6 +34,7 @@ class RenderTarget extends EventDispatcher {
 			minFilter: LinearFilter,
 			depthBuffer: true,
 			stencilBuffer: false,
+			ignoreDepthValues: false,
 			resolveStencilBuffer: true,
 			depthTexture: null,
 			samples: 0,
@@ -59,6 +60,7 @@ class RenderTarget extends EventDispatcher {
 		this.depthBuffer = options.depthBuffer;
 		this.stencilBuffer = options.stencilBuffer;
 
+		this.ignoreDepthValues = options.ignoreDepthValues;
 		this.resolveStencilBuffer = options.resolveStencilBuffer;
 
 		this.depthTexture = options.depthTexture;
@@ -138,6 +140,7 @@ class RenderTarget extends EventDispatcher {
 		this.depthBuffer = source.depthBuffer;
 		this.stencilBuffer = source.stencilBuffer;
 
+		this.ignoreDepthValues = source.ignoreDepthValues;
 		this.resolveStencilBuffer = source.resolveStencilBuffer;
 
 		if ( source.depthTexture !== null ) this.depthTexture = source.depthTexture.clone();

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1432,7 +1432,7 @@ class WebGLRenderer {
 					minFilter: LinearMipmapLinearFilter,
 					samples: 4,
 					stencilBuffer: stencil,
-					ignoreDepthValues: true,
+					resolveDepthBuffer: false,
 					resolveStencilBuffer: false
 				} );
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1432,11 +1432,9 @@ class WebGLRenderer {
 					minFilter: LinearMipmapLinearFilter,
 					samples: 4,
 					stencilBuffer: stencil,
+					ignoreDepthValues: true,
 					resolveStencilBuffer: false
 				} );
-
-				const renderTargetProperties = properties.get( currentRenderState.state.transmissionRenderTarget[ camera.id ] );
-				renderTargetProperties.__ignoreDepthValues = true;
 
 				// debug
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -1868,7 +1868,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 				for ( let i = 0; i < textures.length; i ++ ) {
 
-					if ( renderTarget.ignoreDepthValues === false ) {
+					if ( renderTarget.resolveDepthBuffer ) {
 
 						if ( renderTarget.depthBuffer ) mask |= _gl.DEPTH_BUFFER_BIT;
 
@@ -1896,7 +1896,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 						invalidationArrayRead.push( _gl.COLOR_ATTACHMENT0 + i );
 
-						if ( renderTarget.depthBuffer && renderTarget.ignoreDepthValues === true ) {
+						if ( renderTarget.depthBuffer && renderTarget.resolveDepthBuffer === false ) {
 
 							invalidationArrayRead.push( depthStyle );
 							invalidationArrayDraw.push( depthStyle );
@@ -1935,7 +1935,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 			} else {
 
-				if ( renderTarget.depthBuffer && renderTarget.ignoreDepthValues && supportsInvalidateFramebuffer ) {
+				if ( renderTarget.depthBuffer && renderTarget.resolveDepthBuffer === false && supportsInvalidateFramebuffer ) {
 
 					const depthStyle = renderTarget.stencilBuffer ? _gl.DEPTH_STENCIL_ATTACHMENT : _gl.DEPTH_ATTACHMENT;
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -1868,9 +1868,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 				for ( let i = 0; i < textures.length; i ++ ) {
 
-					const ignoreDepthValues = ( renderTargetProperties.__ignoreDepthValues !== undefined ) ? renderTargetProperties.__ignoreDepthValues : false;
-
-					if ( ignoreDepthValues === false ) {
+					if ( renderTarget.ignoreDepthValues === false ) {
 
 						if ( renderTarget.depthBuffer ) mask |= _gl.DEPTH_BUFFER_BIT;
 
@@ -1898,7 +1896,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 						invalidationArrayRead.push( _gl.COLOR_ATTACHMENT0 + i );
 
-						if ( renderTarget.depthBuffer && ignoreDepthValues === true ) {
+						if ( renderTarget.depthBuffer && renderTarget.ignoreDepthValues === true ) {
 
 							invalidationArrayRead.push( depthStyle );
 							invalidationArrayDraw.push( depthStyle );
@@ -1937,10 +1935,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 			} else {
 
-				const renderTargetProperties = properties.get( renderTarget );
-				const ignoreDepthValues = ( renderTargetProperties.__ignoreDepthValues !== undefined ) ? renderTargetProperties.__ignoreDepthValues : false;
-
-				if ( renderTarget.depthBuffer && ignoreDepthValues && supportsInvalidateFramebuffer ) {
+				if ( renderTarget.depthBuffer && renderTarget.ignoreDepthValues && supportsInvalidateFramebuffer ) {
 
 					const depthStyle = renderTarget.stencilBuffer ? _gl.DEPTH_STENCIL_ATTACHMENT : _gl.DEPTH_ATTACHMENT;
 

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -346,7 +346,7 @@ class WebXRManager extends EventDispatcher {
 							stencilBuffer: attributes.stencil,
 							colorSpace: renderer.outputColorSpace,
 							samples: attributes.antialias ? 4 : 0,
-							ignoreDepthValues: glProjLayer.ignoreDepthValues
+							resolveDepthBuffer: ( glProjLayer.ignoreDepthValues === false )
 						} );
 
 				}

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -345,11 +345,9 @@ class WebXRManager extends EventDispatcher {
 							depthTexture: new DepthTexture( glProjLayer.textureWidth, glProjLayer.textureHeight, depthType, undefined, undefined, undefined, undefined, undefined, undefined, depthFormat ),
 							stencilBuffer: attributes.stencil,
 							colorSpace: renderer.outputColorSpace,
-							samples: attributes.antialias ? 4 : 0
+							samples: attributes.antialias ? 4 : 0,
+							ignoreDepthValues: glProjLayer.ignoreDepthValues
 						} );
-
-					const renderTargetProperties = renderer.properties.get( newRenderTarget );
-					renderTargetProperties.__ignoreDepthValues = glProjLayer.ignoreDepthValues;
 
 				}
 


### PR DESCRIPTION
Related issue: #28132

**Description**

This PR fixes a bug in the transmission implementation. `ignoreDepthValues` was a stored in the render target properties so far. When a render target gets resized though, the properties are deleted because `dispose()` is internally called so the flag is lost. This actually happens in `renderTransmissionPass()` when the transmission render target gets resized. 

Since `ignoreDepthValues` is also used in the WebXR space, it seems reasonable to add it as `resolveDepthBuffer` to the `RenderTarget` class.

/cc @mrxz 
