### PR TITLE
WebGPURenderer: PMREMGenerator use `textureGrad`

### DIFF
--- a/examples/jsm/nodes/pmrem/PMREMUtils.js
+++ b/examples/jsm/nodes/pmrem/PMREMUtils.js
@@ -237,7 +237,7 @@ const bilinearCubeUV = tslFn( ( [ envMap, direction_immutable, mipInt_immutable,
 	uv.x.mulAssign( CUBEUV_TEXEL_WIDTH );
 	uv.y.mulAssign( CUBEUV_TEXEL_HEIGHT );
 
-	return envMap.uv( uv );
+	return envMap.uv( uv ).grad( vec2(), vec2() );
 
 } );
 

--- a/examples/jsm/nodes/pmrem/PMREMUtils.js
+++ b/examples/jsm/nodes/pmrem/PMREMUtils.js
@@ -237,7 +237,7 @@ const bilinearCubeUV = tslFn( ( [ envMap, direction_immutable, mipInt_immutable,
 	uv.x.mulAssign( CUBEUV_TEXEL_WIDTH );
 	uv.y.mulAssign( CUBEUV_TEXEL_HEIGHT );
 
-	return envMap.uv( uv ).grad( vec2(), vec2() );
+	return envMap.uv( uv ).grad( vec2(), vec2() ); // disable anisotropic filtering
 
 } );
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/27829, https://github.com/mrdoob/three.js/pull/28048

**Description**

Reference:

https://github.com/mrdoob/three.js/blob/4d2add2aaf049672f57826f99f24ebdecd2ce4ae/src/renderers/shaders/ShaderChunk/cube_uv_reflection_fragment.glsl.js#L107-L111