### PR TITLE
WebGLRenderer: Simplify `getContext()`.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -222,10 +222,7 @@ class WebGLRenderer {
 
 		function getContext( contextName, contextAttributes ) {
 
-			const context = canvas.getContext( contextName, contextAttributes );
-			if ( context !== null ) return context;
-
-			return null;
+			return canvas.getContext( contextName, contextAttributes );
 
 		}
 


### PR DESCRIPTION
Related issue: N/A

**Description**

The null check seems to have been redundant.

This code should behave the same as the previous code and return `null` when `context === null` or return `context` otherwise.

Maybe there is a good reason it was like it was (ability to put a debugger on line 227?) in which case feel free to decline this PR - I just came across the code when I was searching for something else and thought I'd clean it up in case it was unnecessarily there based on a historical change...

Sidenote: I tried running `npm run lint-fix` as mentioned in `CONTRIBUTING.md` but that changed some unrelated files
so I didn't commit them.

