### PR TITLE
WebGPUBackend: Allows the device to be created externally

### DIFF
--- a/examples/jsm/renderers/webgpu/WebGPUBackend.js
+++ b/examples/jsm/renderers/webgpu/WebGPUBackend.js
@@ -101,7 +101,7 @@ class WebGPUBackend extends Backend {
 			requiredLimits: parameters.requiredLimits
 		};
 
-		const device = await adapter.requestDevice( deviceDescriptor );
+		const device = ( parameters.device !== undefined ) ? parameters.device : await adapter.requestDevice( deviceDescriptor );
 
 		const context = ( parameters.context !== undefined ) ? parameters.context : renderer.domElement.getContext( 'webgpu' );
 


### PR DESCRIPTION
**Description**

For now the WebGPU Backend always create the device by itself. This PR makes it able to use the device object from the `parameters` argument, so three.js can run on [deno](https://deno.land).