### PR TITLE
WebGPURenderer: Allow specifying texture index for MRT in `readRenderTargetPixelsAsync()`.  

### DIFF
--- a/examples/jsm/renderers/common/Renderer.js
+++ b/examples/jsm/renderers/common/Renderer.js
@@ -1088,7 +1088,7 @@ class Renderer {
 
 	readRenderTargetPixelsAsync( renderTarget, x, y, width, height, index = 0 ) {
 
-		return this.backend.copyTextureToBuffer( renderTarget.textures[index], x, y, width, height );
+		return this.backend.copyTextureToBuffer( renderTarget.textures[ index ], x, y, width, height );
 
 	}
 

--- a/examples/jsm/renderers/common/Renderer.js
+++ b/examples/jsm/renderers/common/Renderer.js
@@ -1086,9 +1086,9 @@ class Renderer {
 	}
 
 
-	readRenderTargetPixelsAsync( renderTarget, x, y, width, height ) {
+	readRenderTargetPixelsAsync( renderTarget, x, y, width, height, index = 0 ) {
 
-		return this.backend.copyTextureToBuffer( renderTarget.texture, x, y, width, height );
+		return this.backend.copyTextureToBuffer( renderTarget.textures[index], x, y, width, height );
 
 	}
 


### PR DESCRIPTION
Related: #22403

The readRenderTargetAsync function accepts a renderTarget, but so far has no option to choose between the different textures of a renderTarget if it has more than just one texture. That's why I added an index = 0 so that everyone who has used the function so far has no disadvantages because the first texture is always selected by default.
