### PR TITLE
WebGPURenderer: fix `D_BlinnPhong`

### DIFF
--- a/examples/jsm/nodes/functions/PhongLightingModel.js
+++ b/examples/jsm/nodes/functions/PhongLightingModel.js
@@ -12,7 +12,7 @@ const G_BlinnPhong_Implicit = () => float( 0.25 );
 
 const D_BlinnPhong = tslFn( ( { dotNH } ) => {
 
-	return shininess.mul( float( 0.5 / Math.PI ).add( 1.0 ) ).mul( dotNH.pow( shininess ) );
+	return shininess.mul( float( 0.5 ) ).add( 1.0 ).mul( float( 1 / Math.PI ) ).mul( dotNH.pow( shininess ) );
 
 } );
 

--- a/examples/jsm/nodes/functions/PhongLightingModel.js
+++ b/examples/jsm/nodes/functions/PhongLightingModel.js
@@ -12,7 +12,7 @@ const G_BlinnPhong_Implicit = () => float( 0.25 );
 
 const D_BlinnPhong = tslFn( ( { dotNH } ) => {
 
-	return shininess.mul( 0.5 / Math.PI ).add( 1.0 ).mul( dotNH.pow( shininess ) );
+	return shininess.mul( float( 0.5 / Math.PI ).add( 1.0 ) ).mul( dotNH.pow( shininess ) );
 
 } );
 


### PR DESCRIPTION
```JS
shininess.mul( 0.5 / Math.PI ).add( 1.0 ).mul( dotNH.pow( shininess ) );
```
translate to glsl is 
```glsl
(shininess * ( 1 / ( 2 * PI ) ) + 1.0 ) * pow( dotNH, shininess )

```
result is not same with 
```glsl
( 1 / PI ) * ( shininess * 0.5 + 1.0 ) * pow( dotNH, shininess );
```

