### PR TITLE
Examples: Fix `monaco-editor`

### DIFF
--- a/examples/jsm/nodes/materials/NodeMaterial.js
+++ b/examples/jsm/nodes/materials/NodeMaterial.js
@@ -146,6 +146,8 @@ class NodeMaterial extends ShaderMaterial {
 
 	setupClipping( builder ) {
 
+		if ( builder.clippingContext === null ) return null;
+
 		const { globalClippingCount, localClippingCount } = builder.clippingContext;
 
 		let result = null;

--- a/examples/webgpu_tsl_editor.html
+++ b/examples/webgpu_tsl_editor.html
@@ -59,7 +59,6 @@
 			import WebGPURenderer from 'three/addons/renderers/webgpu/WebGPURenderer.js';
 			import WGSLNodeBuilder from 'three/addons/renderers/webgpu/nodes/WGSLNodeBuilder.js';
 			import GLSLNodeBuilder from 'three/addons/renderers/webgl/nodes/GLSLNodeBuilder.js';
-			import GLSL1NodeBuilder from 'three/addons/renderers/webgl-legacy/nodes/GLSL1NodeBuilder.js';
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 
@@ -109,7 +108,7 @@
 
 				// editor
 
-				window.require.config( { paths: { 'vs': 'https://cdn.jsdelivr.net/npm/monaco-editor@latest/min/vs' } } );
+				window.require.config( { paths: { 'vs': 'https://cdn.jsdelivr.net/npm/monaco-editor@0.48.0/min/vs' } } );
 
 				require( [ 'vs/editor/editor.main' ], () => {
 
@@ -196,10 +195,6 @@ output = vec4( finalColor, opacity );
 
 								NodeBuilder = GLSLNodeBuilder;
 
-							} else {
-
-								NodeBuilder = GLSL1NodeBuilder;
-
 							}
 
 							nodeBuilder = new NodeBuilder( mesh, renderer );
@@ -238,7 +233,7 @@ output = vec4( finalColor, opacity );
 
 					const gui = new GUI();
 
-					gui.add( options, 'output', [ 'WGSL', 'GLSL ES 3.0', 'GLSL' ] ).onChange( build );
+					gui.add( options, 'output', [ 'WGSL', 'GLSL ES 3.0' ] ).onChange( build );
 					gui.add( options, 'shader', [ 'vertex', 'fragment' ] ).onChange( showCode );
 
 					gui.add( options, 'outputColorSpace', [ THREE.LinearSRGBColorSpace, THREE.SRGBColorSpace ] ).onChange( ( value ) => {

--- a/examples/webgpu_tsl_transpiler.html
+++ b/examples/webgpu_tsl_transpiler.html
@@ -50,7 +50,7 @@
 
 				// editor
 
-				window.require.config( { paths: { 'vs': 'https://cdn.jsdelivr.net/npm/monaco-editor@latest/min/vs' } } );
+				window.require.config( { paths: { 'vs': 'https://cdn.jsdelivr.net/npm/monaco-editor@0.48.0/min/vs' } } );
 
 				require( [ 'vs/editor/editor.main' ], () => {
 

--- a/playground/elements/CodeEditorElement.js
+++ b/playground/elements/CodeEditorElement.js
@@ -22,7 +22,7 @@ export class CodeEditorElement extends Element {
 
 		this.editor = null; // async
 
-		window.require.config( { paths: { 'vs': 'https://cdn.jsdelivr.net/npm/monaco-editor@latest/min/vs' } } );
+		window.require.config( { paths: { 'vs': 'https://cdn.jsdelivr.net/npm/monaco-editor@0.48.0/min/vs' } } );
 
 		require( [ 'vs/editor/editor.main' ], () => {
 

--- a/playground/index.html
+++ b/playground/index.html
@@ -92,7 +92,7 @@
 	</head>
 	<body>
 
-		<script src="https://cdn.jsdelivr.net/npm/monaco-editor@latest/min/vs/loader.min.js"></script>
+		<script src="https://cdn.jsdelivr.net/npm/monaco-editor@0.48.0/min/vs/loader.min.js"></script>
 
 		<script type="importmap">
 			{


### PR DESCRIPTION
**Description**

- [x] Fixed `monaco-editor` version.
- [x] Fix `clippingContext = null` if used `NodeBuilder` externally.
