### PR TITLE
RapierPhysics: Rapier physics example Improvement

### DIFF
--- a/examples/jsm/physics/RapierPhysics.js
+++ b/examples/jsm/physics/RapierPhysics.js
@@ -1,220 +1,399 @@
-import { Clock, Vector3, Quaternion, Matrix4 } from 'three';
+import {
+	Box3,
+	BufferGeometry,
+	IcosahedronGeometry,
+	InstancedMesh,
+	Matrix4,
+	Mesh,
+	Object3D,
+	Quaternion,
+	SphereGeometry,
+	Vector3,
+} from "three";
 
-const RAPIER_PATH = 'https://cdn.skypack.dev/@dimforge/rapier3d-compat@0.12.0';
+/**
+ * @typedef {{} & import('@dimforge/rapier3d')} Rapier
+ */
 
-const frameRate = 60;
+/**
+ * @typedef {{
+ *   rigidBodyDesc: Rapier.RigidBodyDesc;
+ *   rigidBody: Rapier.RigidBody;
+ *   colliderDesc: Rapier.ColliderDesc;
+ *   collider: Rapier.Collider;
+ * }} PhysicProperties
+ */
 
-const _scale = new Vector3( 1, 1, 1 );
-const ZERO = new Vector3();
+/**
+ * @typedef {{
+ *   geometry?: BufferGeometry;
+ * } & Object3D } Object3DWithGeometry
+ */
 
+/**
+ * @initial_author mrdoob | info@mrdoob.com
+ *
+ * @description Physic helper based on `Rapier`
+ *
+ * @docs https://rapier.rs/docs/api/javascript/JavaScript3D/
+ */
+
+const RAPIER_PATH = "https://cdn.skypack.dev/@dimforge/rapier3d-compat@0.12.0";
+/** @type {Rapier | null | undefined} */
 let RAPIER = null;
 
-function getShape( geometry ) {
+export class Physic {
+	/** @access private */
+	_vector = new Vector3();
+	/** @access private */
+	_quaternion = new Quaternion();
+	/** @access private */
+	_matrix = new Matrix4();
+	/** @access private */
+	_scale = new Vector3(1, 1, 1);
 
-	const parameters = geometry.parameters;
+	/**
+	 * @description `Rapier3D.js`.
+	 *
+	 * @type {Rapier}
+	 */
+	rapier;
+	/**
+	 * @description {@link Rapier.World} instance.
+	 *
+	 * @type {Rapier.World}
+	 */
+	world;
+	/**
+	 * @description List of {@link Object3D} with physic applied.
+	 *
+	 * @type {Object3DWithGeometry[]}
+	 */
+	dynamicObjects = [];
+	/**
+	 * @description {@link WeakMap} of dynamic objects {@link Rapier.RigidBody}
+	 *
+	 * @type {WeakMap<WeakKey, Rapier.RigidBody | Rapier.RigidBody[]>}
+	 */
+	dynamicObjectMap = new WeakMap();
 
-	// TODO change type to is*
+	constructor(rapier) {
+		this.rapier = rapier;
 
-	if ( geometry.type === 'BoxGeometry' ) {
-
-		const sx = parameters.width !== undefined ? parameters.width / 2 : 0.5;
-		const sy = parameters.height !== undefined ? parameters.height / 2 : 0.5;
-		const sz = parameters.depth !== undefined ? parameters.depth / 2 : 0.5;
-
-		return RAPIER.ColliderDesc.cuboid( sx, sy, sz );
-
-	} else if ( geometry.type === 'SphereGeometry' || geometry.type === 'IcosahedronGeometry' ) {
-
-		const radius = parameters.radius !== undefined ? parameters.radius : 1;
-		return RAPIER.ColliderDesc.ball( radius );
-
+		const gravity = new this.rapier.Vector3(0.0, -9.81, 0.0);
+		this.world = new this.rapier.World(gravity);
 	}
 
-	return null;
+	/**
+	 * @description Add the specified `object` to the physic `dynamicObjects` map.
+	 *
+	 * @param {Object3DWithGeometry} object `Object3D` based.
+	 * @param {number} mass Physic object mass.
+	 * @param {number} restitution Physic Object restitution.
+	 *
+	 * @access private
+	 */
+	_addObject(object, mass = 0, restitution = 0) {
+		const { colliderDesc } = this.getShape(object);
+		if (!colliderDesc) return;
 
-}
+		colliderDesc.setMass(mass);
+		colliderDesc.setRestitution(restitution);
 
-async function RapierPhysics() {
+		const physicProperties =
+			object instanceof InstancedMesh
+				? this.createInstancedPhysicProperties(object, colliderDesc, mass)
+				: this.createPhysicProperties(
+						colliderDesc,
+						object.position,
+						object.quaternion,
+						mass
+				  );
 
-	if ( RAPIER === null ) {
-
-		RAPIER = await import( RAPIER_PATH );
-		await RAPIER.init();
-
-	}
-
-	// Docs: https://rapier.rs/docs/api/javascript/JavaScript3D/
-
-	const gravity = new Vector3( 0.0, - 9.81, 0.0 );
-	const world = new RAPIER.World( gravity );
-
-	const meshes = [];
-	const meshMap = new WeakMap();
-
-	const _vector = new Vector3();
-	const _quaternion = new Quaternion();
-	const _matrix = new Matrix4();
-
-	function addScene( scene ) {
-
-		scene.traverse( function ( child ) {
-
-			if ( child.isMesh ) {
-
-				const physics = child.userData.physics;
-
-				if ( physics ) {
-
-					addMesh( child, physics.mass, physics.restitution );
-
-				}
-
-			}
-
-		} );
-
-	}
-
-	function addMesh( mesh, mass = 0, restitution = 0 ) {
-
-		const shape = getShape( mesh.geometry );
-
-		if ( shape === null ) return;
-
-		shape.setMass( mass );
-		shape.setRestitution( restitution );
-
-		const body = mesh.isInstancedMesh
-							? createInstancedBody( mesh, mass, shape )
-							: createBody( mesh.position, mesh.quaternion, mass, shape );
-
-		if ( mass > 0 ) {
-
-			meshes.push( mesh );
-			meshMap.set( mesh, body );
-
+		if (mass > 0) {
+			this.dynamicObjects.push(object);
+			this.dynamicObjectMap.set(object, physicProperties);
 		}
 
+		return physicProperties;
 	}
 
-	function createInstancedBody( mesh, mass, shape ) {
+	/**
+	 * Add objects children from the specified {@link Object3D} to the physic world using the userData.
+	 *
+	 * @param {Object3DWithGeometry} object Object3D based.
+	 *
+	 * @example ```ts
+	 *  const floor = new Mesh(
+	 *    new BoxGeometry(500, 5, 500),
+	 *    new MeshBasicMaterial({})
+	 *  );
+	 *  floor.position.setY(-10);
+	 *  floor.userData.physics = { mass: 0, restitution: restitution };
+	 *
+	 *  rapierPhysicsHelper?.addToWorld(floor, 0);
+	 * ```
+	 */
+	addSceneToWorld(object) {
+		object.traverse((child) => {
+			if (!(child instanceof Object3D) || !child.userData.physics) return;
 
+			const physics = child.userData.physics;
+
+			if (!physics) return;
+
+			this._addObject(child, physics.mass, physics.restitution);
+		});
+	}
+
+	/**
+	 * @description Apply physic to the specified object. Add the object to the physic `world`.
+	 *
+	 * @param {Object3D} object Object3D based.
+	 * @param {number} mass Physic mass.
+	 * @param {number} restitution Physic restitution.
+	 */
+	addToWorld(object, mass = 0, restitution = 0) {
+		if (object instanceof Object3D)
+			return this._addObject(object, Number(mass), Number(restitution));
+		return undefined;
+	}
+
+	/**
+	 * @description Retrieve the shape of the passed `object`.
+	 *
+	 * @param {Object3DWithGeometry} object `Object3D` based.
+	 */
+	getShape(object) {
+		const positions = object?.geometry?.attributes?.position?.array;
+		let width = 0;
+		let height = 0;
+		let depth = 0;
+		let halfWidth = 0;
+		let halfHeight = 0;
+		let halfDepth = 0;
+		let radius = 0;
+		/** @type {Rapier.ColliderDesc} */
+		let colliderDesc;
+
+		if (
+			object instanceof Mesh &&
+			(object.geometry instanceof SphereGeometry ||
+				object.geometry instanceof IcosahedronGeometry)
+		) {
+			const parameters = object.geometry.parameters;
+
+			radius = parameters.radius ?? 1;
+			colliderDesc = this.rapier.ColliderDesc.ball(radius);
+		} else if (positions) {
+			let minX = 0,
+				minY = 0,
+				minZ = 0,
+				maxX = 0,
+				maxY = 0,
+				maxZ = 0;
+
+			for (let i = 0; i < positions.length; i += 3) {
+				const _vector = new this.rapier.Vector3(
+					positions[i],
+					positions[i + 1],
+					positions[i + 2]
+				);
+
+				minX = Math.min(minX, _vector.x);
+				minY = Math.min(minY, _vector.y);
+				minZ = Math.min(minZ, _vector.z);
+				maxX = Math.max(maxX, _vector.x);
+				maxY = Math.max(maxY, _vector.y);
+				maxZ = Math.max(maxZ, _vector.z);
+			}
+
+			width = maxX - minX;
+			height = maxY - minY;
+			depth = maxZ - minZ;
+
+			halfWidth = width / 2;
+			halfHeight = height / 2;
+			halfDepth = depth / 2;
+
+			colliderDesc = this.rapier.ColliderDesc.cuboid(
+				halfWidth,
+				halfHeight,
+				halfDepth
+			);
+		} else {
+			const boundingBox = new Box3().setFromObject(object);
+
+			width = boundingBox.max.x - boundingBox.min.x;
+			height = boundingBox.max.y - boundingBox.min.y;
+			depth = boundingBox.max.z - boundingBox.min.z;
+
+			halfWidth = width / 2;
+			halfHeight = height / 2;
+			halfDepth = depth / 2;
+
+			colliderDesc = this.rapier.ColliderDesc.cuboid(
+				halfWidth,
+				halfHeight,
+				halfDepth
+			);
+		}
+
+		return {
+			width,
+			height,
+			depth,
+			halfWidth,
+			halfHeight,
+			halfDepth,
+			colliderDesc,
+		};
+	}
+
+	/**
+	 * @description Create {@link Rapier.RigidBody} for each instance of the {@link InstancedMesh} specified mesh
+	 *
+	 * @param {InstancedMesh} mesh {@link InstancedMesh}
+	 * @param {Rapier.ColliderDesc} colliderDesc {@link Rapier.ColliderDesc}
+	 * @param {number | undefined} mass
+	 */
+	createInstancedPhysicProperties(mesh, colliderDesc, mass) {
 		const array = mesh.instanceMatrix.array;
-
 		const bodies = [];
 
-		for ( let i = 0; i < mesh.count; i ++ ) {
-
-			const position = _vector.fromArray( array, i * 16 + 12 );
-			bodies.push( createBody( position, null, mass, shape ) );
-
+		for (let i = 0; i < mesh.count; i++) {
+			const position = this._vector.fromArray(array, i * 16 + 12);
+			bodies.push(
+				this.createPhysicProperties(colliderDesc, position, null, mass)
+			);
 		}
 
 		return bodies;
-
 	}
 
-	function createBody( position, quaternion, mass, shape ) {
+	/**
+	 * @description Create {@link Rapier.RigidBody} for the specified {@link Rapier.Collider}
+	 *
+	 * @param {Rapier.ColliderDesc} colliderDesc {@link Rapier.ColliderDesc}
+	 * @param {Rapier.Vector3} position {@link Rapier.Vector3}
+	 * @param {Rapier.Rotation} rotation {@link Rapier.Rotation}
+	 * @param {number | null | undefined} mass
+	 */
+	createPhysicProperties(colliderDesc, position, rotation, mass = 0) {
+		const rigidBodyDesc =
+			mass > 0
+				? this.rapier.RigidBodyDesc.dynamic()
+				: this.rapier.RigidBodyDesc.fixed();
+		rigidBodyDesc.setTranslation(position.x, position.y, position.z);
+		if (rotation) rigidBodyDesc.setRotation(rotation);
 
-		const desc = mass > 0 ? RAPIER.RigidBodyDesc.dynamic() : RAPIER.RigidBodyDesc.fixed();
-		desc.setTranslation( ...position );
-		if ( quaternion !== null ) desc.setRotation( quaternion );
+		const rigidBody = this.world.createRigidBody(rigidBodyDesc);
+		const collider = this.world.createCollider(colliderDesc, rigidBody);
 
-		const body = world.createRigidBody( desc );
-		world.createCollider( shape, body );
+		return { rigidBodyDesc, rigidBody, colliderDesc, collider };
+	}
+
+	/**
+	 *
+	 * @param {Object3DWithGeometry} object
+	 * @param {number | number} index
+	 */
+	getPhysicPropertiesFromObject(object, index = 0) {
+		const _physicProperties = this.dynamicObjectMap.get(object);
+		/** @type {PhysicProperties} */
+		let body;
+
+		if (!_physicProperties) return undefined;
+		if (
+			object instanceof InstancedMesh &&
+			typeof _physicProperties === "object"
+		)
+			body = _physicProperties[index];
+		else body = _physicProperties;
 
 		return body;
-
 	}
 
-	function setMeshPosition( mesh, position, index = 0 ) {
+	/**
+	 *
+	 * @param {Object3DWithGeometry} object
+	 * @param {Rapier.Vector3} position
+	 * @param {number | undefined} index
+	 * @returns
+	 */
+	setObjectPosition(object, position, index = 0) {
+		const physicProperties = this.getPhysicPropertiesFromObject(object, index);
+		if (!physicProperties) return;
 
-		let body = meshMap.get( mesh );
+		const _vectorZero = new this.rapier.Vector3(0, 0, 0);
+		physicProperties.rigidBody.setAngvel(_vectorZero, true);
+		physicProperties.rigidBody.setLinvel(_vectorZero, true);
+		physicProperties.rigidBody.setTranslation(position, true);
 
-		if ( mesh.isInstancedMesh ) {
-
-			body = body[ index ];
-
-		}
-
-		body.setAngvel( ZERO );
-		body.setLinvel( ZERO );
-		body.setTranslation( position );
-
+		return physicProperties;
 	}
 
-	function setMeshVelocity( mesh, velocity, index = 0 ) {
+	/**
+	 *
+	 * @param {Object3DWithGeometry} object
+	 * @param {Rapier.Vector3} velocity
+	 * @param {number | undefined} index
+	 */
+	setObjectVelocity(object, velocity, index = 0) {
+		const physicProperties = this.getPhysicPropertiesFromObject(object, index);
+		if (!physicProperties) return;
 
-		let body = meshMap.get( mesh );
+		physicProperties.rigidBody.setLinvel(velocity, true);
 
-		if ( mesh.isInstancedMesh ) {
-
-			body = body[ index ];
-
-		}
-
-		body.setLinvel( velocity );
-
+		return physicProperties;
 	}
 
-	//
+	/**
+	 * @description Update the physic world.
+	 *
+	 * @param {number | undefined} delta
+	 */
+	step(delta = undefined) {
+		this.world.step(delta);
 
-	const clock = new Clock();
+		for (let i = 0, l = this.dynamicObjects.length; i < l; i++) {
+			const mesh = this.dynamicObjects[i];
 
-	function step() {
-
-		world.timestep = clock.getDelta();
-		world.step();
-
-		//
-
-		for ( let i = 0, l = meshes.length; i < l; i ++ ) {
-
-			const mesh = meshes[ i ];
-
-			if ( mesh.isInstancedMesh ) {
-
+			if (mesh instanceof InstancedMesh) {
 				const array = mesh.instanceMatrix.array;
-				const bodies = meshMap.get( mesh );
+				/** @type {PhysicProperties[]} */
+				const bodies = this.dynamicObjectMap.get(mesh);
 
-				for ( let j = 0; j < bodies.length; j ++ ) {
+				for (let j = 0; j < bodies.length; j++) {
+					const physicProperties = bodies[j];
 
-					const body = bodies[ j ];
+					const position = new Vector3().copy(
+						physicProperties.rigidBody.translation()
+					);
+					this._quaternion.copy(physicProperties.rigidBody.rotation());
 
-					const position = body.translation();
-					_quaternion.copy( body.rotation() );
-
-					_matrix.compose( position, _quaternion, _scale ).toArray( array, j * 16 );
-
+					this._matrix
+						.compose(position, this._quaternion, this._scale)
+						.toArray(array, j * 16);
 				}
 
 				mesh.instanceMatrix.needsUpdate = true;
 				mesh.computeBoundingSphere();
-
 			} else {
+				/** @type {PhysicProperties} */
+				const physicProperties = this.dynamicObjectMap.get(mesh);
 
-				const body = meshMap.get( mesh );
-
-				mesh.position.copy( body.translation() );
-				mesh.quaternion.copy( body.rotation() );
-
+				mesh.position.copy(physicProperties.rigidBody.translation());
+				mesh.quaternion.copy(physicProperties.rigidBody.rotation());
 			}
-
 		}
-
 	}
-
-	// animate
-
-	setInterval( step, 1000 / frameRate );
-
-	return {
-		addScene: addScene,
-		addMesh: addMesh,
-		setMeshPosition: setMeshPosition,
-		setMeshVelocity: setMeshVelocity
-	};
-
 }
 
-export { RapierPhysics };
+export async function RapierPhysics() {
+	if (RAPIER === null) await (RAPIER = await import(RAPIER_PATH)).init();
+
+	const _rapierPhysics = new Physic(RAPIER);
+
+	return _rapierPhysics;
+}

--- a/examples/jsm/physics/RapierPhysics.js
+++ b/examples/jsm/physics/RapierPhysics.js
@@ -355,12 +355,12 @@ export class Physic {
 		this.world.step(delta);
 
 		for (let i = 0, l = this.dynamicObjects.length; i < l; i++) {
-			const mesh = this.dynamicObjects[i];
+			const object = this.dynamicObjects[i];
 
-			if (mesh instanceof InstancedMesh) {
-				const array = mesh.instanceMatrix.array;
+			if (object instanceof InstancedMesh) {
+				const array = object.instanceMatrix.array;
 				/** @type {PhysicProperties[]} */
-				const bodies = this.dynamicObjectMap.get(mesh);
+				const bodies = this.dynamicObjectMap.get(object);
 
 				for (let j = 0; j < bodies.length; j++) {
 					const physicProperties = bodies[j];
@@ -375,16 +375,40 @@ export class Physic {
 						.toArray(array, j * 16);
 				}
 
-				mesh.instanceMatrix.needsUpdate = true;
-				mesh.computeBoundingSphere();
+				object.instanceMatrix.needsUpdate = true;
+				object.computeBoundingSphere();
 			} else {
 				/** @type {PhysicProperties} */
-				const physicProperties = this.dynamicObjectMap.get(mesh);
+				const physicProperties = this.dynamicObjectMap.get(object);
 
-				mesh.position.copy(physicProperties.rigidBody.translation());
-				mesh.quaternion.copy(physicProperties.rigidBody.rotation());
+				object.position.copy(physicProperties.rigidBody.translation());
+				object.quaternion.copy(physicProperties.rigidBody.rotation());
 			}
 		}
+	}
+
+	/**
+	 * @description Remove the specified object to the physic `world`.
+	 *
+	 * @param {Object3D} object Object3D based.
+	 */
+	removeFromWorld(object) {
+		for (let i = 0; i < this.dynamicObjects.length; i++) {
+			const dynamicObject = this.dynamicObjects[i];
+			if (dynamicObject.id === object.id) {
+				this.dynamicObjectMap.delete(dynamicObject);
+				this.dynamicObjects.splice(i, 1);
+				return;
+			}
+		}
+	}
+
+	/**
+	 * @description remove all the stored physical objects.
+	 */
+	dispose() {
+		this.dynamicObjects = [];
+		this.dynamicObjectMap = new WeakMap();
 	}
 }
 

--- a/examples/jsm/physics/RapierPhysics.js
+++ b/examples/jsm/physics/RapierPhysics.js
@@ -349,10 +349,11 @@ export class Physic {
 	/**
 	 * @description Update the physic world.
 	 *
-	 * @param {number | undefined} delta
+	 * @param {number | undefined} timestep The timestep length, in seconds.
 	 */
-	step(delta = undefined) {
-		this.world.step(delta);
+	step(timestep = undefined) {
+		if (typeof timestep === "number") this.world.timestep = timestep;
+		this.world.step();
 
 		for (let i = 0, l = this.dynamicObjects.length; i < l; i++) {
 			const object = this.dynamicObjects[i];

--- a/examples/jsm/physics/RapierPhysics.js
+++ b/examples/jsm/physics/RapierPhysics.js
@@ -21,7 +21,7 @@ import {
  *   rigidBody: Rapier.RigidBody;
  *   colliderDesc: Rapier.ColliderDesc;
  *   collider: Rapier.Collider;
- * }} PhysicProperties
+ * }} PhysicsProperties
  */
 
 /**
@@ -30,6 +30,11 @@ import {
  * } & Object3D } Object3DWithGeometry
  */
 
+const RAPIER_PATH = "https://cdn.skypack.dev/@dimforge/rapier3d-compat@0.12.0";
+
+/** @type {Rapier | null | undefined} */
+let RAPIER = null;
+
 /**
  * @initial_author mrdoob | info@mrdoob.com
  *
@@ -37,12 +42,7 @@ import {
  *
  * @docs https://rapier.rs/docs/api/javascript/JavaScript3D/
  */
-
-const RAPIER_PATH = "https://cdn.skypack.dev/@dimforge/rapier3d-compat@0.12.0";
-/** @type {Rapier | null | undefined} */
-let RAPIER = null;
-
-export class Physic {
+export class Physics {
 	/** @access private */
 	_vector = new Vector3();
 	/** @access private */
@@ -65,7 +65,7 @@ export class Physic {
 	 */
 	world;
 	/**
-	 * @description List of {@link Object3D} with physic applied.
+	 * @description List of {@link Object3D} with applied physics.
 	 *
 	 * @type {Object3DWithGeometry[]}
 	 */
@@ -85,11 +85,11 @@ export class Physic {
 	}
 
 	/**
-	 * @description Add the specified `object` to the physic `dynamicObjects` map.
+	 * @description Add the specified `object` to the physics `dynamicObjects` map.
 	 *
 	 * @param {Object3DWithGeometry} object `Object3D` based.
-	 * @param {number} mass Physic object mass.
-	 * @param {number} restitution Physic Object restitution.
+	 * @param {number} mass Physics object mass.
+	 * @param {number} restitution Physics Object restitution.
 	 *
 	 * @access private
 	 */
@@ -100,7 +100,7 @@ export class Physic {
 		colliderDesc.setMass(mass);
 		colliderDesc.setRestitution(restitution);
 
-		const physicProperties =
+		const physicsProperties =
 			object instanceof InstancedMesh
 				? this.createInstancedPhysicProperties(object, colliderDesc, mass)
 				: this.createPhysicProperties(
@@ -112,14 +112,14 @@ export class Physic {
 
 		if (mass > 0) {
 			this.dynamicObjects.push(object);
-			this.dynamicObjectMap.set(object, physicProperties);
+			this.dynamicObjectMap.set(object, physicsProperties);
 		}
 
-		return physicProperties;
+		return physicsProperties;
 	}
 
 	/**
-	 * Add objects children from the specified {@link Object3D} to the physic world using the userData.
+	 * Add objects children from the specified {@link Object3D} to the physics world using `userData`.
 	 *
 	 * @param {Object3DWithGeometry} object Object3D based.
 	 *
@@ -145,11 +145,11 @@ export class Physic {
 	}
 
 	/**
-	 * @description Apply physic to the specified object. Add the object to the physic `world`.
+	 * @description Apply physics to the specified object. Add the object to the physical `world`.
 	 *
 	 * @param {Object3D} object Object3D based.
-	 * @param {number} mass Physic mass.
-	 * @param {number} restitution Physic restitution.
+	 * @param {number} mass Physics mass.
+	 * @param {number} restitution Physics restitution.
 	 */
 	addToWorld(object, mass = 0, restitution = 0) {
 		if (object instanceof Object3D)
@@ -249,7 +249,7 @@ export class Physic {
 	}
 
 	/**
-	 * @description Create {@link Rapier.RigidBody} for each instance of the {@link InstancedMesh} specified mesh
+	 * @description Create a {@link Rapier.RigidBody} for each instance of the specified {@link InstancedMesh}
 	 *
 	 * @param {InstancedMesh} mesh {@link InstancedMesh}
 	 * @param {Rapier.ColliderDesc} colliderDesc {@link Rapier.ColliderDesc}
@@ -270,7 +270,7 @@ export class Physic {
 	}
 
 	/**
-	 * @description Create {@link Rapier.RigidBody} for the specified {@link Rapier.Collider}
+	 * @description Create a {@link Rapier.RigidBody} for the specified {@link Rapier.Collider}
 	 *
 	 * @param {Rapier.ColliderDesc} colliderDesc {@link Rapier.ColliderDesc}
 	 * @param {Rapier.Vector3} position {@link Rapier.Vector3}
@@ -292,22 +292,21 @@ export class Physic {
 	}
 
 	/**
-	 *
 	 * @param {Object3DWithGeometry} object
 	 * @param {number | number} index
 	 */
 	getPhysicPropertiesFromObject(object, index = 0) {
-		const _physicProperties = this.dynamicObjectMap.get(object);
-		/** @type {PhysicProperties} */
+		const _physicsProperties = this.dynamicObjectMap.get(object);
+		/** @type {PhysicsProperties} */
 		let body;
 
-		if (!_physicProperties) return undefined;
+		if (!_physicsProperties) return undefined;
 		if (
 			object instanceof InstancedMesh &&
-			typeof _physicProperties === "object"
+			typeof _physicsProperties === "object"
 		)
-			body = _physicProperties[index];
-		else body = _physicProperties;
+			body = _physicsProperties[index];
+		else body = _physicsProperties;
 
 		return body;
 	}
@@ -320,15 +319,15 @@ export class Physic {
 	 * @returns
 	 */
 	setObjectPosition(object, position, index = 0) {
-		const physicProperties = this.getPhysicPropertiesFromObject(object, index);
-		if (!physicProperties) return;
+		const physicsProperties = this.getPhysicPropertiesFromObject(object, index);
+		if (!physicsProperties) return;
 
 		const _vectorZero = new this.rapier.Vector3(0, 0, 0);
-		physicProperties.rigidBody.setAngvel(_vectorZero, true);
-		physicProperties.rigidBody.setLinvel(_vectorZero, true);
-		physicProperties.rigidBody.setTranslation(position, true);
+		physicsProperties.rigidBody.setAngvel(_vectorZero, true);
+		physicsProperties.rigidBody.setLinvel(_vectorZero, true);
+		physicsProperties.rigidBody.setTranslation(position, true);
 
-		return physicProperties;
+		return physicsProperties;
 	}
 
 	/**
@@ -338,16 +337,16 @@ export class Physic {
 	 * @param {number | undefined} index
 	 */
 	setObjectVelocity(object, velocity, index = 0) {
-		const physicProperties = this.getPhysicPropertiesFromObject(object, index);
-		if (!physicProperties) return;
+		const physicsProperties = this.getPhysicPropertiesFromObject(object, index);
+		if (!physicsProperties) return;
 
-		physicProperties.rigidBody.setLinvel(velocity, true);
+		physicsProperties.rigidBody.setLinvel(velocity, true);
 
-		return physicProperties;
+		return physicsProperties;
 	}
 
 	/**
-	 * @description Update the physic world.
+	 * @description Update the physics world.
 	 *
 	 * @param {number | undefined} timestep The timestep length, in seconds.
 	 */
@@ -360,16 +359,16 @@ export class Physic {
 
 			if (object instanceof InstancedMesh) {
 				const array = object.instanceMatrix.array;
-				/** @type {PhysicProperties[]} */
+				/** @type {PhysicsProperties[]} */
 				const bodies = this.dynamicObjectMap.get(object);
 
 				for (let j = 0; j < bodies.length; j++) {
-					const physicProperties = bodies[j];
+					const physicsProperties = bodies[j];
 
 					const position = new Vector3().copy(
-						physicProperties.rigidBody.translation()
+						physicsProperties.rigidBody.translation()
 					);
-					this._quaternion.copy(physicProperties.rigidBody.rotation());
+					this._quaternion.copy(physicsProperties.rigidBody.rotation());
 
 					this._matrix
 						.compose(position, this._quaternion, this._scale)
@@ -379,11 +378,11 @@ export class Physic {
 				object.instanceMatrix.needsUpdate = true;
 				object.computeBoundingSphere();
 			} else {
-				/** @type {PhysicProperties} */
-				const physicProperties = this.dynamicObjectMap.get(object);
+				/** @type {PhysicsProperties} */
+				const physicsProperties = this.dynamicObjectMap.get(object);
 
-				object.position.copy(physicProperties.rigidBody.translation());
-				object.quaternion.copy(physicProperties.rigidBody.rotation());
+				object.position.copy(physicsProperties.rigidBody.translation());
+				object.quaternion.copy(physicsProperties.rigidBody.rotation());
 			}
 		}
 	}
@@ -396,7 +395,7 @@ export class Physic {
 	removeFromWorld(object) {
 		for (let i = 0; i < this.dynamicObjects.length; i++) {
 			const dynamicObject = this.dynamicObjects[i];
-			/** @type PhysicProperties */
+			/** @type PhysicsProperties */
 			const dynamicObjectProps = this.dynamicObjectMap.get(dynamicObject);
 
 			if (dynamicObject.id === object.id && dynamicObjectProps) {
@@ -429,7 +428,7 @@ export class Physic {
 export async function RapierPhysics() {
 	if (RAPIER === null) await (RAPIER = await import(RAPIER_PATH)).init();
 
-	const _rapierPhysics = new Physic(RAPIER);
+	const _rapierPhysics = new Physics(RAPIER);
 
 	return _rapierPhysics;
 }

--- a/examples/jsm/physics/RapierPhysics.js
+++ b/examples/jsm/physics/RapierPhysics.js
@@ -384,7 +384,7 @@ export class Physics {
 					quaternion = this._quaternion.copy(
 						physicProperties.rigidBody.rotation()
 					);
-					scale = this._scale.copy(scale ?? object.scale);
+					scale = this._scale.copy(scale);
 
 					this._matrix
 						.compose(position, quaternion, scale)

--- a/examples/jsm/physics/RapierPhysics.js
+++ b/examples/jsm/physics/RapierPhysics.js
@@ -46,11 +46,13 @@ export class Physics {
 	/** @access private */
 	_vector = new Vector3();
 	/** @access private */
+	_position = new Vector3();
+	/** @access private */
 	_quaternion = new Quaternion();
 	/** @access private */
-	_matrix = new Matrix4();
-	/** @access private */
 	_scale = new Vector3(1, 1, 1);
+	/** @access private */
+	_matrix = new Matrix4();
 
 	/**
 	 * @description `Rapier3D.js`.
@@ -319,6 +321,7 @@ export class Physics {
 	 * @returns
 	 */
 	setObjectPosition(object, position, index = 0) {
+		/** @description Object physics properties (rigid body, collider, ...). */
 		const physicsProperties = this.getPhysicPropertiesFromObject(object, index);
 		if (!physicsProperties) return;
 
@@ -363,15 +366,28 @@ export class Physics {
 				const bodies = this.dynamicObjectMap.get(object);
 
 				for (let j = 0; j < bodies.length; j++) {
-					const physicsProperties = bodies[j];
+					const physicProperties = bodies[j];
 
-					const position = new Vector3().copy(
-						physicsProperties.rigidBody.translation()
+					/** @type {Vector3} */
+					let position = this._position;
+					/** @type {Quaternion} */
+					let quaternion = this._quaternion;
+					/** @type {Vector3} */
+					let scale = this._scale;
+
+					object.getMatrixAt(j, this._matrix);
+					this._matrix.decompose(position, quaternion, scale);
+
+					position = this._position.copy(
+						physicProperties.rigidBody.translation()
 					);
-					this._quaternion.copy(physicsProperties.rigidBody.rotation());
+					quaternion = this._quaternion.copy(
+						physicProperties.rigidBody.rotation()
+					);
+					scale = this._scale.copy(scale ?? object.scale);
 
 					this._matrix
-						.compose(position, this._quaternion, this._scale)
+						.compose(position, quaternion, scale)
 						.toArray(array, j * 16);
 				}
 

--- a/examples/jsm/physics/RapierPhysics.js
+++ b/examples/jsm/physics/RapierPhysics.js
@@ -140,8 +140,6 @@ export class Physic {
 
 			const physics = child.userData.physics;
 
-			if (!physics) return;
-
 			this._addObject(child, physics.mass, physics.restitution);
 		});
 	}

--- a/examples/jsm/physics/RapierPhysics.js
+++ b/examples/jsm/physics/RapierPhysics.js
@@ -396,7 +396,20 @@ export class Physic {
 	removeFromWorld(object) {
 		for (let i = 0; i < this.dynamicObjects.length; i++) {
 			const dynamicObject = this.dynamicObjects[i];
-			if (dynamicObject.id === object.id) {
+			/** @type PhysicProperties */
+			const dynamicObjectProps = this.dynamicObjectMap.get(dynamicObject);
+
+			if (dynamicObject.id === object.id && dynamicObjectProps) {
+				if (object instanceof InstancedMesh)
+					dynamicObjectProps.map((props) => {
+						this.world.removeRigidBody(props.rigidBody);
+						this.world.removeCollider(props.collider, true);
+					});
+				else {
+					this.world.removeRigidBody(dynamicObjectProps.rigidBody);
+					this.world.removeCollider(dynamicObjectProps.collider, true);
+				}
+
 				this.dynamicObjectMap.delete(dynamicObject);
 				this.dynamicObjects.splice(i, 1);
 				return;

--- a/examples/jsm/physics/RapierPhysics.js
+++ b/examples/jsm/physics/RapierPhysics.js
@@ -38,7 +38,7 @@ let RAPIER = null;
 /**
  * @initial_author mrdoob | info@mrdoob.com
  *
- * @description Physic helper based on `Rapier`
+ * @description Physics helper based on `Rapier`
  *
  * @docs https://rapier.rs/docs/api/javascript/JavaScript3D/
  */
@@ -104,8 +104,8 @@ export class Physics {
 
 		const physicsProperties =
 			object instanceof InstancedMesh
-				? this.createInstancedPhysicProperties(object, colliderDesc, mass)
-				: this.createPhysicProperties(
+				? this.createInstancedPhysicsProperties(object, colliderDesc, mass)
+				: this.createPhysicsProperties(
 						colliderDesc,
 						object.position,
 						object.quaternion,
@@ -257,14 +257,14 @@ export class Physics {
 	 * @param {Rapier.ColliderDesc} colliderDesc {@link Rapier.ColliderDesc}
 	 * @param {number | undefined} mass
 	 */
-	createInstancedPhysicProperties(mesh, colliderDesc, mass) {
+	createInstancedPhysicsProperties(mesh, colliderDesc, mass) {
 		const array = mesh.instanceMatrix.array;
 		const bodies = [];
 
 		for (let i = 0; i < mesh.count; i++) {
 			const position = this._vector.fromArray(array, i * 16 + 12);
 			bodies.push(
-				this.createPhysicProperties(colliderDesc, position, null, mass)
+				this.createPhysicsProperties(colliderDesc, position, null, mass)
 			);
 		}
 
@@ -279,7 +279,7 @@ export class Physics {
 	 * @param {Rapier.Rotation} rotation {@link Rapier.Rotation}
 	 * @param {number | null | undefined} mass
 	 */
-	createPhysicProperties(colliderDesc, position, rotation, mass = 0) {
+	createPhysicsProperties(colliderDesc, position, rotation, mass = 0) {
 		const rigidBodyDesc =
 			mass > 0
 				? this.rapier.RigidBodyDesc.dynamic()
@@ -297,7 +297,7 @@ export class Physics {
 	 * @param {Object3DWithGeometry} object
 	 * @param {number | number} index
 	 */
-	getPhysicPropertiesFromObject(object, index = 0) {
+	getPhysicsPropertiesFromObject(object, index = 0) {
 		const _physicsProperties = this.dynamicObjectMap.get(object);
 		/** @type {PhysicsProperties} */
 		let body;
@@ -322,7 +322,7 @@ export class Physics {
 	 */
 	setObjectPosition(object, position, index = 0) {
 		/** @description Object physics properties (rigid body, collider, ...). */
-		const physicsProperties = this.getPhysicPropertiesFromObject(object, index);
+		const physicsProperties = this.getPhysicsPropertiesFromObject(object, index);
 		if (!physicsProperties) return;
 
 		const _vectorZero = new this.rapier.Vector3(0, 0, 0);
@@ -340,7 +340,7 @@ export class Physics {
 	 * @param {number | undefined} index
 	 */
 	setObjectVelocity(object, velocity, index = 0) {
-		const physicsProperties = this.getPhysicPropertiesFromObject(object, index);
+		const physicsProperties = this.getPhysicsPropertiesFromObject(object, index);
 		if (!physicsProperties) return;
 
 		physicsProperties.rigidBody.setLinvel(velocity, true);
@@ -366,7 +366,7 @@ export class Physics {
 				const bodies = this.dynamicObjectMap.get(object);
 
 				for (let j = 0; j < bodies.length; j++) {
-					const physicProperties = bodies[j];
+					const physicsProperties = bodies[j];
 
 					/** @type {Vector3} */
 					let position = this._position;
@@ -379,10 +379,10 @@ export class Physics {
 					this._matrix.decompose(position, quaternion, scale);
 
 					position = this._position.copy(
-						physicProperties.rigidBody.translation()
+						physicsProperties.rigidBody.translation()
 					);
 					quaternion = this._quaternion.copy(
-						physicProperties.rigidBody.rotation()
+						physicsProperties.rigidBody.rotation()
 					);
 					scale = this._scale.copy(scale);
 
@@ -404,7 +404,7 @@ export class Physics {
 	}
 
 	/**
-	 * @description Remove the specified object to the physic `world`.
+	 * @description Remove the specified object to the physics `world`.
 	 *
 	 * @param {Object3D} object Object3D based.
 	 */

--- a/examples/jsm/physics/RapierPhysics.js
+++ b/examples/jsm/physics/RapierPhysics.js
@@ -121,9 +121,9 @@ export class Physics {
 	}
 
 	/**
-	 * Add objects children from the specified {@link Object3D} to the physics world using `userData`.
+	 * Add {@link Object3D} children to the physics world using `userData`.
 	 *
-	 * @param {Object3DWithGeometry} object Object3D based.
+	 * @param {Object3DWithGeometry} object {@link Object3D} based.
 	 *
 	 * @example ```ts
 	 *  const floor = new Mesh(

--- a/examples/physics_rapier_instancing.html
+++ b/examples/physics_rapier_instancing.html
@@ -9,7 +9,8 @@
 	<body>
 
 		<div id="info">
-			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> physics - <a href="https://github.com/dimforge/rapier.js" target="_blank">rapier</a> instancing
+			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> physics - <a href="https://github.com/dimforge/rapier.js" target="_blank">rapier</a> instancing<br />
+			Press any <strong>key</strong> to shake.
 		</div>
 
 		<script type="importmap">
@@ -28,10 +29,11 @@
 			import { RapierPhysics } from 'three/addons/physics/RapierPhysics.js';
 			import Stats from 'three/addons/libs/stats.module.js';
 
-			let camera, scene, renderer, stats;
+			let camera, controls, scene, renderer, stats;
 			let physics, position;
 
 			let boxes, spheres;
+			let physicBoxes = [], physicSpheres = [];
 
 			init();
 
@@ -110,7 +112,9 @@
 
 				}
 
-				physics.addSceneToWorld( scene );
+				physics.addToWorld( floor, 0 );
+				physicBoxes = physics.addToWorld( boxes, 1 );
+				physicSpheres = physics.addToWorld( spheres, 1 );
 
 				//
 
@@ -125,8 +129,28 @@
 
 				//
 
-				const controls = new OrbitControls( camera, renderer.domElement );
+				window.onkeydown = () =>{
+
+					[ ...physicBoxes, ...physicSpheres ].map( ( item ) => {
+
+						item.rigidBody.applyImpulse(
+							{
+								x: ( Math.random() - 0.5 ) * 5,
+								y: Math.random() * 5,
+								z: ( Math.random() - 0.5 ) * 5
+							},
+							true
+						);
+
+					} );
+
+				};
+
+				//
+
+				controls = new OrbitControls( camera, renderer.domElement );
 				controls.target.y = 0.5;
+				controls.autoRotate = true;
 				controls.update();
 
 				animate();
@@ -152,6 +176,8 @@
 			function animate() {
 
 				physics.step();
+
+				controls.update();
 
 				requestAnimationFrame( animate );
 

--- a/examples/physics_rapier_instancing.html
+++ b/examples/physics_rapier_instancing.html
@@ -10,7 +10,7 @@
 
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> physics - <a href="https://github.com/dimforge/rapier.js" target="_blank">rapier</a> instancing<br />
-			Press any <strong>key</strong> to shake.
+			<button id="shake" style="margin-top: 25px;">Press to shake</button>
 		</div>
 
 		<script type="importmap">
@@ -129,7 +129,7 @@
 
 				//
 
-				window.onkeydown = () =>{
+				document.querySelector( 'button#shake' ).addEventListener( 'click', () => {
 
 					[ ...physicBoxes, ...physicSpheres ].map( ( item ) => {
 
@@ -144,7 +144,7 @@
 
 					} );
 
-				};
+				} );
 
 				//
 

--- a/examples/physics_rapier_instancing.html
+++ b/examples/physics_rapier_instancing.html
@@ -110,7 +110,7 @@
 
 				}
 
-				physics.addScene( scene );
+				physics.addSceneToWorld( scene );
 
 				//
 
@@ -136,20 +136,22 @@
 					let index = Math.floor( Math.random() * boxes.count );
 
 					position.set( 0, Math.random() + 1, 0 );
-					physics.setMeshPosition( boxes, position, index );
+					physics.setObjectPosition( boxes, position, index );
 
 					//
 
 					index = Math.floor( Math.random() * spheres.count );
 
 					position.set( 0, Math.random() + 1, 0 );
-					physics.setMeshPosition( spheres, position, index );
+					physics.setObjectPosition( spheres, position, index );
 
 				}, 1000 / 60 );
 
 			}
 
 			function animate() {
+
+				physics.step();
 
 				requestAnimationFrame( animate );
 

--- a/examples/physics_rapier_instancing.html
+++ b/examples/physics_rapier_instancing.html
@@ -173,9 +173,11 @@
 
 			}
 
-			function animate() {
+			const clock = new THREE.Clock();
 
-				physics.step();
+ 			function animate() {
+
+				physics.step( clock.getDelta() );
 
 				controls.update();
 

--- a/examples/physics_rapier_instancing.html
+++ b/examples/physics_rapier_instancing.html
@@ -33,7 +33,7 @@
 			let physics, position;
 
 			let boxes, spheres;
-			let physicBoxes = [], physicSpheres = [];
+			let physicsBoxes = [], physicsSpheres = [];
 
 			init();
 
@@ -113,8 +113,8 @@
 				}
 
 				physics.addToWorld( floor, 0 );
-				physicBoxes = physics.addToWorld( boxes, 1 );
-				physicSpheres = physics.addToWorld( spheres, 1 );
+				physicsBoxes = physics.addToWorld( boxes, 1 );
+				physicsSpheres = physics.addToWorld( spheres, 1 );
 
 				//
 
@@ -131,7 +131,7 @@
 
 				document.querySelector( 'button#shake' ).addEventListener( 'click', () => {
 
-					[ ...physicBoxes, ...physicSpheres ].map( ( item ) => {
+					[ ...physicsBoxes, ...physicsSpheres ].map( ( item ) => {
 
 						item.rigidBody.applyImpulse(
 							{

--- a/examples/webxr_xr_ballshooter.html
+++ b/examples/webxr_xr_ballshooter.html
@@ -252,7 +252,7 @@
 
 				}
 
-				physics.addScene( scene );
+				physics.addSceneToWorld( scene );
 
 			}
 
@@ -262,14 +262,14 @@
 
 				if ( controller.userData.isSelecting ) {
 
-					physics.setMeshPosition( spheres, controller.position, count );
+					physics.setObjectPosition( spheres, controller.position, count );
 
 					velocity.x = ( Math.random() - 0.5 ) * 2;
 					velocity.y = ( Math.random() - 0.5 ) * 2;
 					velocity.z = ( Math.random() - 9 );
 					velocity.applyQuaternion( controller.quaternion );
 
-					physics.setMeshVelocity( spheres, velocity, count );
+					physics.setObjectVelocity( spheres, velocity, count );
 
 					if ( ++ count === spheres.count ) count = 0;
 
@@ -278,6 +278,8 @@
 			}
 
 			function render() {
+
+				physics?.step();
 
 				handleController( controller1 );
 				handleController( controller2 );


### PR DESCRIPTION
> ℹ️ No issue associated with this PR

### Description

I was working on one of my projects based on the `Rapier3D.js`, and I noticed that @mrdoob recently added an example using `Rapier` and `InstancedMesh` which were exactly what I was working on.

Unfortunately, the existing [Rapier addon](https://github.com/mrdoob/three.js/blob/master/examples/jsm/physics/RapierPhysics.js) was a bit restrictive to me at some point (and in the [example page](https://github.com/mrdoob/three.js/blob/master/examples/physics_rapier_instancing.html)  as well).

- We don't have access to the `collider`, `colliderDesc`, ...;
- It comes with its timer, what if I want to branch it to my timer?
- The getter returns only the `rigidBody`, and we're necessarily retrained to use it to get a `mesh`
- The current implementation is mainly designed for `meshes`
- etc...

Because I updated it on my side and where using it, I decided to share my version based and following the original version of the  [RapierPhysics](https://github.com/mrdoob/three.js/blob/master/examples/jsm/physics/RapierPhysics.js).

### What are the changes

- Use the new `addToWorld` instead of `addSceneToWorld` | Example preview.
- Set `OrbitControl` to auto-rotate |  Example preview.
- Add a Window `keyboard` event to apply impulse to objects (to shake) | Example preview.
- Add the`addToWorld()` method to add only one object (and return a bunch of Rapier properties).
- Remove the integrated timer inside `RapierPhysics` but expose the `RapierPhysics.step()` method; 
- Migrate the `RapierPhysics` function implementation to the **class** version.
- **Exposed** more Rapier properties (such `rigidBody`, `collider`, ...). accessible from the `WeakMap` store
- Commented methods (with types support) using `JsDoc`.

#### Here's the updated version coming with this PR

[Screenshot](https://github.com/mrdoob/three.js/assets/44310540/a777b5ec-39bc-4342-9666-b23511d39163)

> 🔖 This is my first contribution here, I've read the **code of conduct** and the **Contribution guidelines** before pushing my changes.
> I may forget something some details, if it's the case, please let me know.
>
> And this is a small change not related to the core of `threejs` but just a small example improvement.
> Hoping that will help someone in the future
