### PR TITLE
Editor: Fix glTF assets with external KTX2 textures.

### DIFF
--- a/editor/js/Loader.js
+++ b/editor/js/Loader.js
@@ -974,7 +974,7 @@ function Loader( editor ) {
 		const dracoLoader = new DRACOLoader();
 		dracoLoader.setDecoderPath( '../examples/jsm/libs/draco/gltf/' );
 
-		const ktx2Loader = new KTX2Loader();
+		const ktx2Loader = new KTX2Loader( manager );
 		ktx2Loader.setTranscoderPath( '../examples/jsm/libs/basis/' );
 
 		editor.signals.rendererDetectKTX2Support.dispatch( ktx2Loader );


### PR DESCRIPTION
Fixed #28202.

**Description**

This PR makes sure `KTX2Loader` receives the loading manager instance so the correct `setURLModifier()` callback is exectued.
