### PR TITLE
FileLoader: Make sure all network errors are catched in `load()`.

### DIFF
--- a/src/loaders/FileLoader.js
+++ b/src/loaders/FileLoader.js
@@ -148,6 +148,10 @@ class FileLoader extends Loader {
 
 									}
 
+								}, ( e ) => {
+
+									controller.error( e );
+
 								} );
 
 							}


### PR DESCRIPTION
Related: #24450

Problem: 
FileLoader ignores edge cases like ... server down when response body still in progress ... in turns uncaught rejection

Solution: 
This PR voids the readable stream for those edge cases s.t. it will enter `catch()` eventually.

