### PR TITLE
WebGPUBackend: Remove unnecessary use of GPUAdapter (2)

### DIFF
--- a/examples/jsm/renderers/webgpu/WebGPUBackend.js
+++ b/examples/jsm/renderers/webgpu/WebGPUBackend.js
@@ -14,6 +14,7 @@ import WebGPUAttributeUtils from './utils/WebGPUAttributeUtils.js';
 import WebGPUBindingUtils from './utils/WebGPUBindingUtils.js';
 import WebGPUPipelineUtils from './utils/WebGPUPipelineUtils.js';
 import WebGPUTextureUtils from './utils/WebGPUTextureUtils.js';
+import WebGPU from '../../capabilities/WebGPU.js';
 
 //
 
@@ -1231,7 +1232,11 @@ class WebGPUBackend extends Backend {
 
 	async hasFeatureAsync( name ) {
 
-		return this.hasFeature( name );
+		const device = this.device || await WebGPU.getStaticAdapter();
+
+		//
+
+		return device.features.has( name );
 
 	}
 
@@ -1239,7 +1244,7 @@ class WebGPUBackend extends Backend {
 
 		if ( ! this.device ) {
 
-			console.warn( 'WebGPUBackend: WebGPU device has not been initialized yet.' );
+			console.warn( 'WebGPUBackend: WebGPU device has not been initialized yet. Please use hasFeatureAsync() instead.' );
 
 			return false;
 

--- a/examples/jsm/renderers/webgpu/WebGPUBackend.js
+++ b/examples/jsm/renderers/webgpu/WebGPUBackend.js
@@ -1242,7 +1242,9 @@ class WebGPUBackend extends Backend {
 
 	hasFeature( name ) {
 
-		if ( ! this.device ) {
+		const device = this.device;
+
+		if ( ! device ) {
 
 			console.warn( 'WebGPUBackend: WebGPU device has not been initialized yet. Please use hasFeatureAsync() instead.' );
 
@@ -1250,7 +1252,7 @@ class WebGPUBackend extends Backend {
 
 		}
 
-		return this.device.features.has( name );
+		return device.features.has( name );
 
 	}
 

--- a/examples/jsm/renderers/webgpu/WebGPUBackend.js
+++ b/examples/jsm/renderers/webgpu/WebGPUBackend.js
@@ -14,7 +14,6 @@ import WebGPUAttributeUtils from './utils/WebGPUAttributeUtils.js';
 import WebGPUBindingUtils from './utils/WebGPUBindingUtils.js';
 import WebGPUPipelineUtils from './utils/WebGPUPipelineUtils.js';
 import WebGPUTextureUtils from './utils/WebGPUTextureUtils.js';
-import WebGPU from '../../capabilities/WebGPU.js';
 
 //
 
@@ -45,7 +44,6 @@ class WebGPUBackend extends Backend {
 
 		this.trackTimestamp = ( parameters.trackTimestamp === true );
 
-		this.adapter = null;
 		this.device = null;
 		this.context = null;
 		this.colorBuffer = null;
@@ -68,44 +66,55 @@ class WebGPUBackend extends Backend {
 
 		const parameters = this.parameters;
 
-		const adapterOptions = {
-			powerPreference: parameters.powerPreference
-		};
+		// create the device if it is not passed with parameters
 
-		const adapter = await navigator.gpu.requestAdapter( adapterOptions );
+		let device;
 
-		if ( adapter === null ) {
+		if ( parameters.device === undefined ) {
 
-			throw new Error( 'WebGPUBackend: Unable to create WebGPU adapter.' );
+			const adapterOptions = {
+				powerPreference: parameters.powerPreference
+			};
 
-		}
+			const adapter = await navigator.gpu.requestAdapter( adapterOptions );
 
-		// feature support
+			if ( adapter === null ) {
 
-		const features = Object.values( GPUFeatureName );
-
-		const supportedFeatures = [];
-
-		for ( const name of features ) {
-
-			if ( adapter.features.has( name ) ) {
-
-				supportedFeatures.push( name );
+				throw new Error( 'WebGPUBackend: Unable to create WebGPU adapter.' );
 
 			}
 
+			// feature support
+
+			const features = Object.values( GPUFeatureName );
+
+			const supportedFeatures = [];
+
+			for ( const name of features ) {
+
+				if ( adapter.features.has( name ) ) {
+
+					supportedFeatures.push( name );
+
+				}
+
+			}
+
+			const deviceDescriptor = {
+				requiredFeatures: supportedFeatures,
+				requiredLimits: parameters.requiredLimits
+			};
+
+			device = await adapter.requestDevice( deviceDescriptor );
+
+		} else {
+
+			device = parameters.device;
+
 		}
-
-		const deviceDescriptor = {
-			requiredFeatures: supportedFeatures,
-			requiredLimits: parameters.requiredLimits
-		};
-
-		const device = ( parameters.device !== undefined ) ? parameters.device : await adapter.requestDevice( deviceDescriptor );
 
 		const context = ( parameters.context !== undefined ) ? parameters.context : renderer.domElement.getContext( 'webgpu' );
 
-		this.adapter = adapter;
 		this.device = device;
 		this.context = context;
 
@@ -1222,25 +1231,21 @@ class WebGPUBackend extends Backend {
 
 	async hasFeatureAsync( name ) {
 
-		const adapter = this.adapter || await WebGPU.getStaticAdapter();
-
-		//
-
-		return adapter.features.has( name );
+		return this.hasFeature( name );
 
 	}
 
 	hasFeature( name ) {
 
-		if ( ! this.adapter ) {
+		if ( ! this.device ) {
 
-			console.warn( 'WebGPUBackend: WebGPU adapter has not been initialized yet. Please use hasFeatureAsync instead' );
+			console.warn( 'WebGPUBackend: WebGPU device has not been initialized yet.' );
 
 			return false;
 
 		}
 
-		return this.adapter.features.has( name );
+		return this.device.features.has( name );
 
 	}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/28208

**Description**

Fix `hasFeatureAsync()` of https://github.com/mrdoob/three.js/pull/28208 PR. 

`GPUSupportedFeatures` can be found in `device` and `adapter`, this PR fix the example of `webgpu_loader_gltf_compressed` and maintains the original idea of ​​the previous PR https://github.com/mrdoob/three.js/pull/28208.