### PR TITLE
Examples: remove unused render pass for webgpu mrt readback

### DIFF
--- a/examples/webgpu_multiple_rendertargets_readback.html
+++ b/examples/webgpu_multiple_rendertargets_readback.html
@@ -192,16 +192,18 @@
 
 			async function render( time ) {
 
+				const selection = options.selection;
+
 				torus.rotation.y = ( time / 1000 ) * .4;
 
 				// render scene into target
-				renderer.setRenderTarget( renderTarget );
+				renderer.setRenderTarget( selection === 'mrt' ? renderTarget : readbackTarget );
 				renderer.render( scene, camera );
 
 				// render post FX
 				renderer.setRenderTarget( null );
 
-				if ( options.selection === 'mrt' ) {
+				if ( selection === 'mrt' ) {
 
 					quadMesh.material = material;
 
@@ -218,10 +220,6 @@
 			}
 
 			async function readback() {
-
-				renderer.setRenderTarget( readbackTarget );
-				renderer.render( scene, camera );
-				renderer.setRenderTarget( null );
 
 				const width = readbackTarget.width;
 				const height = readbackTarget.height;


### PR DESCRIPTION
As title, composite render results are unused when demonstrating readRenderTargetPixelAsync()
