### PR TITLE
Playground: Fix `PreviewEditor`

### DIFF
--- a/playground/editors/PreviewEditor.js
+++ b/playground/editors/PreviewEditor.js
@@ -2,8 +2,9 @@ import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import { ViewHelper } from 'three/addons/helpers/ViewHelper.js';
 import { Element, LabelElement, SelectInput } from 'flow';
 import { BaseNodeEditor } from '../BaseNodeEditor.js';
-import { MeshBasicNodeMaterial, float } from 'three/nodes';
-import { WebGLRenderer, PerspectiveCamera, Scene, Mesh, DoubleSide, SphereGeometry, BoxGeometry, PlaneGeometry, TorusKnotGeometry } from 'three';
+import { MeshBasicNodeMaterial, vec4 } from 'three/nodes';
+import { PerspectiveCamera, Scene, Mesh, DoubleSide, SphereGeometry, BoxGeometry, PlaneGeometry, TorusKnotGeometry } from 'three';
+import WebGPURenderer from 'three/addons/renderers/webgpu/WebGPURenderer.js';
 import { setInputAestheticsFromType } from '../DataTypeLib.js';
 
 const sceneDict = {};
@@ -57,7 +58,7 @@ export class PreviewEditor extends BaseNodeEditor {
 		super( 'Preview', null, width );
 
 		const material = new MeshBasicNodeMaterial();
-		material.colorNode = float();
+		material.colorNode = vec4( 0, 0, 0, 1 );
 		material.side = DoubleSide;
 		material.transparent = true;
 
@@ -77,7 +78,7 @@ export class PreviewEditor extends BaseNodeEditor {
 
 		const inputElement = setInputAestheticsFromType( new LabelElement( 'Input' ), 'Color' ).onConnect( () => {
 
-			material.colorNode = inputElement.getLinkedObject() || float();
+			material.colorNode = inputElement.getLinkedObject() || vec4( 0, 0, 0, 1 );
 			material.dispose();
 
 		}, true );
@@ -89,7 +90,7 @@ export class PreviewEditor extends BaseNodeEditor {
 
 		previewElement.dom.addEventListener( 'wheel', e => e.stopPropagation() );
 
-		const renderer = new WebGLRenderer( {
+		const renderer = new WebGPURenderer( {
 			canvas,
 			alpha: true
 		} );
@@ -140,7 +141,7 @@ export class PreviewEditor extends BaseNodeEditor {
 
 	}
 
-	update() {
+	async update() {
 
 		const { viewHelper, material, renderer, camera, sceneInput } = this;
 
@@ -159,8 +160,8 @@ export class PreviewEditor extends BaseNodeEditor {
 
 		}
 
-		renderer.clear();
-		renderer.render( scene, camera );
+		await renderer.clearAsync();
+		await renderer.renderAsync( scene, camera );
 
 		viewHelper.render( renderer );
 

--- a/playground/editors/PreviewEditor.js
+++ b/playground/editors/PreviewEditor.js
@@ -92,7 +92,8 @@ export class PreviewEditor extends BaseNodeEditor {
 
 		const renderer = new WebGPURenderer( {
 			canvas,
-			alpha: true
+			alpha: true,
+			antialias: true
 		} );
 
 		renderer.autoClear = false;


### PR DESCRIPTION
**Description**

Fix PreviewEditor. 
Updated renderer for `WebGPURenderer`, previous `WebGLRenderer`.

![image](https://github.com/mrdoob/three.js/assets/502810/f3eb0601-379d-4347-8286-7e9a785f0e23)
