### PR TITLE
GLTFLoader: Assign extras to texture.

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -3317,6 +3317,8 @@ class GLTFParser {
 
 			}
 
+			assignExtrasToUserData(texture, sourceDef);
+
 			texture.userData.mimeType = sourceDef.mimeType || getImageURIMimeType( sourceDef.uri );
 
 			return texture;

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -3317,7 +3317,7 @@ class GLTFParser {
 
 			}
 
-			assignExtrasToUserData(texture, sourceDef);
+			assignExtrasToUserData( texture, sourceDef );
 
 			texture.userData.mimeType = sourceDef.mimeType || getImageURIMimeType( sourceDef.uri );
 


### PR DESCRIPTION
Modified the GLTFLoader to assign extras to texture user data. I noticed the extras defined in my GLTF textures were not being assigned during loading.