### PR TITLE
WebGLExtensions: Use warnOnce to report unsupported extensions

### DIFF
--- a/src/renderers/webgl/WebGLExtensions.js
+++ b/src/renderers/webgl/WebGLExtensions.js
@@ -1,3 +1,5 @@
+import { warnOnce } from '../../utils.js';
+
 function WebGLExtensions( gl ) {
 
 	const extensions = {};
@@ -66,7 +68,7 @@ function WebGLExtensions( gl ) {
 
 			if ( extension === null ) {
 
-				console.warn( 'THREE.WebGLRenderer: ' + name + ' extension not supported.' );
+				warnOnce( 'THREE.WebGLRenderer: ' + name + ' extension not supported.' );
 
 			}
 


### PR DESCRIPTION
**Description**

`WebGLExtensions` currently uses `console.warn` to report missing support for requested extensions which causes console spam in some situations. For example, the [batched mesh example](https://threejs.org/examples/?q=batch#webgl_mesh_batch) logs the following message each frame in Firefox:

```js
THREE.WebGLRenderer: WEBGL_multi_draw extension not supported.
```

This PR changes the logging to use `warnOnce` instead.