### PR TITLE
Editor: Fixed viewport penetrates tabbed panel issue

### DIFF
--- a/editor/js/Resizer.js
+++ b/editor/js/Resizer.js
@@ -36,7 +36,7 @@ function Resizer( editor ) {
 
 		const cX = clientX < 0 ? 0 : clientX > offsetWidth ? offsetWidth : clientX;
 
-		const x = Math.max( 260, offsetWidth - cX ); // .TabbedPanel min-width: 260px
+		const x = Math.max( 335, offsetWidth - cX ); // .TabbedPanel min-width: 335px
 
 		dom.style.right = x + 'px';
 


### PR DESCRIPTION
The issue:

https://github.com/mrdoob/three.js/assets/1063018/56bc6070-e36d-4669-8160-e98c61a98056

This PR set proper lower bound for the resizer, the value [should be 335px](https://github.com/mrdoob/three.js/blob/61444937d1f0f4da72ca630749bc6b02fc22d4a1/editor/css/main.css#L59-L70)



