### PR TITLE
Editor: Fixed outliner's low contrast issue in dark theme

### DIFF
--- a/editor/css/main.css
+++ b/editor/css/main.css
@@ -664,9 +664,9 @@ select {
 		background: #222;
 	}
 
-        .Outliner .option {
-            color: #999;
-        }
+		.Outliner .option {
+			color: #999;
+		}
 
 		.Outliner .option:hover {
 			background-color: rgba(21,60,94,0.5);

--- a/editor/css/main.css
+++ b/editor/css/main.css
@@ -661,9 +661,12 @@ select {
 		}
 
 	.Outliner {
-		color: #888;
 		background: #222;
 	}
+
+        .Outliner .option {
+            color: #999;
+        }
 
 		.Outliner .option:hover {
 			background-color: rgba(21,60,94,0.5);


### PR DESCRIPTION
This PR increases specificity of `.outliner .option {color:..}` in dark theme in order to win [the one defined in light theme](https://github.com/mrdoob/three.js/blob/b8198a746bc8ddaf8999a962c766951186d98310/editor/css/main.css#L487-L491), also increases the fg/bg contrast.

Before: (I wrapped the text node by a `span` for showing the accessibility(contrast) issue, this PR doesn't include this html modification)
![lo con](https://github.com/mrdoob/three.js/assets/1063018/1abebc71-669b-45ff-93e4-12f1041f0b6c)

After: ([preview on githack](https://raw.githack.com/ycw/three.js/editor-outliner-fg/editor/index.html))
![hi con](https://github.com/mrdoob/three.js/assets/1063018/5b2548e4-c046-42a4-8fa4-d79dd7d51063)




