### PR TITLE
Editor: Fixed ghost background and environment issue in a `New`-ed app

### DIFF
--- a/editor/js/Sidebar.Scene.js
+++ b/editor/js/Sidebar.Scene.js
@@ -419,6 +419,8 @@ function SidebarScene( editor ) {
 		} else {
 
 			backgroundType.setValue( 'None' );
+			backgroundTexture.setValue( null );
+			backgroundEquirectangularTexture.setValue( null );
 
 		}
 
@@ -438,6 +440,7 @@ function SidebarScene( editor ) {
 		} else {
 
 			environmentType.setValue( 'None' );
+			environmentEquirectangularTexture.setValue( null );
 
 		}
 


### PR DESCRIPTION
The issue: ghost background and environment remains in a `New`-ed app's UI:

https://github.com/mrdoob/three.js/assets/1063018/4bfb07ba-97a0-4d5e-8131-afa52ec1848c

This PR fixed this UI issue by explicitly assigning null to scene background's UITexture and scene environment's UITexture, in turn [viewport.js will assign null to scene.background on sceneBackgroundChanged](https://github.com/mrdoob/three.js/blob/6d905135f5f915277c11f1c41a362be896201994/editor/js/Viewport.js#L472-L522) (same for scene.environment), in this way no ghost textures will be shown in UITexture and Viewport, in a `New`-ed app:

https://github.com/mrdoob/three.js/assets/1063018/6cc8355c-5a65-4ff9-a668-06bd6fa9a830   

Preview: https://raw.githack.com/ycw/three.js/editor-cleared/editor/index.html