### PR TITLE
Editor: Fixed unreadable text in viewport

### DIFF
--- a/editor/css/main.css
+++ b/editor/css/main.css
@@ -308,7 +308,7 @@ select {
 	bottom: 0;
 }
 
-	#viewport #info {
+	#viewport .Text {
 		text-shadow: 1px 1px 0 rgba(0,0,0,0.25);
 		pointer-events: none;
 	}


### PR DESCRIPTION
This PR makes _all text_ in viewport more readable by dropping text shadow

Before: 'Grid' and 'Helpers' are not readable at all
![unreadable](https://github.com/mrdoob/three.js/assets/1063018/577ed82c-1e94-4bb1-93ad-70fa0fdcb99d)

After: 
![readable](https://github.com/mrdoob/three.js/assets/1063018/95985091-8e10-4fb2-a4ba-612b26258e3f)

