### PR TITLE
Editor: Initialize UIs in user preferred language on the first run

### DIFF
--- a/editor/js/Config.js
+++ b/editor/js/Config.js
@@ -2,8 +2,12 @@ function Config() {
 
 	const name = 'threejs-editor';
 
+	const userLanguage = navigator.language.split( '-' )[ 0 ];
+
+	const suggestedLanguage = [ 'fr', 'ja', 'zh' ].includes( userLanguage ) ? userLanguage : 'en';
+
 	const storage = {
-		'language': 'en',
+		'language': suggestedLanguage,
 
 		'autosave': true,
 


### PR DESCRIPTION
This PR inits UIs in user-preferred lang on the first run (i.e. when localStorage is empty); fallback to `en` if lang isn't `fr | ja | zh`.

To test: 

1. Go to browser settings, set preferred language to Japanese, then 
2. Open https://raw.githack.com/ycw/three.js/autodetect-ui-lang/editor/index.html in incognito mode (mimic first run), then
3. UIs should be shown in Japanese