### PR TITLE
TransformControls: Make events more coherent.

### DIFF
--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -32,7 +32,7 @@ const _unit = {
 };
 
 const _changeEvent = { type: 'change' };
-const _mouseDownEvent = { type: 'mouseDown' };
+const _mouseDownEvent = { type: 'mouseDown', mode: null };
 const _mouseUpEvent = { type: 'mouseUp', mode: null };
 const _objectChangeEvent = { type: 'objectChange' };
 


### PR DESCRIPTION
`_mouseDownEvent` and `_mouseUpEvent` events are used in the exact same way but `mode` is currently only set to null on `_mouseUpEvent` by default.