### PR TITLE
Editor: Fixed non-localized prompt messages

### DIFF
--- a/editor/index.html
+++ b/editor/index.html
@@ -226,7 +226,7 @@
 
 				const file = hash.slice( 6 );
 
-				if ( confirm( 'Any unsaved data will be lost. Are you sure?' ) ) {
+				if ( confirm( editor.strings.getKey( '[prompt]/file/open' ) ) ) {
 
 					const loader = new THREE.FileLoader();
 					loader.crossOrigin = '';

--- a/editor/index.html
+++ b/editor/index.html
@@ -226,7 +226,7 @@
 
 				const file = hash.slice( 6 );
 
-				if ( confirm( editor.strings.getKey( '[prompt]/file/open' ) ) ) {
+				if ( confirm( editor.strings.getKey( 'prompt/file/open' ) ) ) {
 
 					const loader = new THREE.FileLoader();
 					loader.crossOrigin = '';

--- a/editor/js/History.js
+++ b/editor/js/History.js
@@ -88,7 +88,7 @@ class History {
 
 		if ( this.historyDisabled ) {
 
-			alert( this.editor.strings.getKey( '[prompt]/history/forbid' ) );
+			alert( this.editor.strings.getKey( 'prompt/history/forbid' ) );
 			return;
 
 		}
@@ -123,7 +123,7 @@ class History {
 
 		if ( this.historyDisabled ) {
 
-			alert( this.editor.strings.getKey( '[prompt]/history/forbid' ) );
+			alert( this.editor.strings.getKey( 'prompt/history/forbid' ) );
 			return;
 
 		}
@@ -241,7 +241,7 @@ class History {
 
 		if ( this.historyDisabled ) {
 
-			alert( this.editor.strings.getKey( '[prompt]/history/forbid' ) );
+			alert( this.editor.strings.getKey( 'prompt/history/forbid' ) );
 			return;
 
 		}

--- a/editor/js/History.js
+++ b/editor/js/History.js
@@ -88,7 +88,7 @@ class History {
 
 		if ( this.historyDisabled ) {
 
-			alert( 'Undo/Redo disabled while scene is playing.' );
+			alert( this.editor.strings.getKey( '[prompt]/history/forbid' ) );
 			return;
 
 		}
@@ -123,7 +123,7 @@ class History {
 
 		if ( this.historyDisabled ) {
 
-			alert( 'Undo/Redo disabled while scene is playing.' );
+			alert( this.editor.strings.getKey( '[prompt]/history/forbid' ) );
 			return;
 
 		}
@@ -241,7 +241,7 @@ class History {
 
 		if ( this.historyDisabled ) {
 
-			alert( 'Undo/Redo disabled while scene is playing.' );
+			alert( this.editor.strings.getKey( '[prompt]/history/forbid' ) );
 			return;
 
 		}

--- a/editor/js/Menubar.Examples.js
+++ b/editor/js/Menubar.Examples.js
@@ -41,7 +41,7 @@ function MenubarExamples( editor ) {
 			option.setTextContent( strings.getKey( item.title ) );
 			option.onClick( function () {
 
-				if ( confirm( 'Any unsaved data will be lost. Are you sure?' ) ) {
+				if ( confirm( strings.getKey( '[prompt]/file/open' ) ) ) {
 
 					loader.load( 'examples/' + item.file, function ( text ) {
 

--- a/editor/js/Menubar.Examples.js
+++ b/editor/js/Menubar.Examples.js
@@ -41,7 +41,7 @@ function MenubarExamples( editor ) {
 			option.setTextContent( strings.getKey( item.title ) );
 			option.onClick( function () {
 
-				if ( confirm( strings.getKey( '[prompt]/file/open' ) ) ) {
+				if ( confirm( strings.getKey( 'prompt/file/open' ) ) ) {
 
 					loader.load( 'examples/' + item.file, function ( text ) {
 

--- a/editor/js/Menubar.File.js
+++ b/editor/js/Menubar.File.js
@@ -26,7 +26,7 @@ function MenubarFile( editor ) {
 	option.setTextContent( strings.getKey( 'menubar/file/new' ) );
 	option.onClick( function () {
 
-		if ( confirm( 'Any unsaved data will be lost. Are you sure?' ) ) {
+		if ( confirm( strings.getKey( '[prompt]/file/open' ) ) ) {
 
 			editor.clear();
 
@@ -81,7 +81,7 @@ function MenubarFile( editor ) {
 
 		if ( object === null || object.isMesh === undefined ) {
 
-			alert( 'No mesh selected' );
+			alert( strings.getKey( '[prompt]/file/export/noMeshSelected' ) );
 			return;
 
 		}
@@ -181,7 +181,7 @@ function MenubarFile( editor ) {
 
 		if ( object === null ) {
 
-			alert( 'No object selected.' );
+			alert( strings.getKey( '[prompt]/file/export/noObjectSelected' ) );
 			return;
 
 		}

--- a/editor/js/Menubar.File.js
+++ b/editor/js/Menubar.File.js
@@ -26,7 +26,7 @@ function MenubarFile( editor ) {
 	option.setTextContent( strings.getKey( 'menubar/file/new' ) );
 	option.onClick( function () {
 
-		if ( confirm( strings.getKey( '[prompt]/file/open' ) ) ) {
+		if ( confirm( strings.getKey( 'prompt/file/open' ) ) ) {
 
 			editor.clear();
 
@@ -81,7 +81,7 @@ function MenubarFile( editor ) {
 
 		if ( object === null || object.isMesh === undefined ) {
 
-			alert( strings.getKey( '[prompt]/file/export/noMeshSelected' ) );
+			alert( strings.getKey( 'prompt/file/export/noMeshSelected' ) );
 			return;
 
 		}
@@ -181,7 +181,7 @@ function MenubarFile( editor ) {
 
 		if ( object === null ) {
 
-			alert( strings.getKey( '[prompt]/file/export/noObjectSelected' ) );
+			alert( strings.getKey( 'prompt/file/export/noObjectSelected' ) );
 			return;
 
 		}

--- a/editor/js/Sidebar.Script.js
+++ b/editor/js/Sidebar.Script.js
@@ -81,7 +81,7 @@ function SidebarScript( editor ) {
 					remove.setMarginLeft( '4px' );
 					remove.onClick( function () {
 
-						if ( confirm( strings.getKey( '[prompt]/script/remove' ) ) ) {
+						if ( confirm( strings.getKey( 'prompt/script/remove' ) ) ) {
 
 							editor.execute( new RemoveScriptCommand( editor, editor.selected, script ) );
 

--- a/editor/js/Sidebar.Script.js
+++ b/editor/js/Sidebar.Script.js
@@ -81,7 +81,7 @@ function SidebarScript( editor ) {
 					remove.setMarginLeft( '4px' );
 					remove.onClick( function () {
 
-						if ( confirm( 'Are you sure?' ) ) {
+						if ( confirm( strings.getKey( '[prompt]/script/remove' ) ) ) {
 
 							editor.execute( new RemoveScriptCommand( editor, editor.selected, script ) );
 

--- a/editor/js/Sidebar.Settings.History.js
+++ b/editor/js/Sidebar.Settings.History.js
@@ -25,7 +25,7 @@ function SidebarSettingsHistory( editor ) {
 
 		if ( value ) {
 
-			alert( strings.getKey( '[prompt]/history/preserve' ) );
+			alert( strings.getKey( 'prompt/history/preserve' ) );
 
 			const lastUndoCmd = history.undos[ history.undos.length - 1 ];
 			const lastUndoId = ( lastUndoCmd !== undefined ) ? lastUndoCmd.id : 0;
@@ -63,7 +63,7 @@ function SidebarSettingsHistory( editor ) {
 	const option = new UIButton( strings.getKey( 'sidebar/history/clear' ) );
 	option.onClick( function () {
 
-		if ( confirm( strings.getKey( '[prompt]/history/clear' ) ) ) {
+		if ( confirm( strings.getKey( 'prompt/history/clear' ) ) ) {
 
 			editor.history.clear();
 

--- a/editor/js/Sidebar.Settings.History.js
+++ b/editor/js/Sidebar.Settings.History.js
@@ -25,7 +25,7 @@ function SidebarSettingsHistory( editor ) {
 
 		if ( value ) {
 
-			alert( 'The history will be preserved across sessions.\nThis can have an impact on performance when working with textures.' );
+			alert( strings.getKey( '[prompt]/history/preserve' ) );
 
 			const lastUndoCmd = history.undos[ history.undos.length - 1 ];
 			const lastUndoId = ( lastUndoCmd !== undefined ) ? lastUndoCmd.id : 0;
@@ -63,7 +63,7 @@ function SidebarSettingsHistory( editor ) {
 	const option = new UIButton( strings.getKey( 'sidebar/history/clear' ) );
 	option.onClick( function () {
 
-		if ( confirm( 'The Undo/Redo History will be cleared. Are you sure?' ) ) {
+		if ( confirm( strings.getKey( '[prompt]/history/clear' ) ) ) {
 
 			editor.history.clear();
 

--- a/editor/js/Strings.js
+++ b/editor/js/Strings.js
@@ -6,13 +6,13 @@ function Strings( config ) {
 
 		en: {
 
-			'[prompt]/file/open': 'Any unsaved data will be lost. Are you sure?',
-			'[prompt]/file/export/noMeshSelected': 'No Mesh selected!',
-			'[prompt]/file/export/noObjectSelected': 'No Object selected!',
-			'[prompt]/script/remove': 'Are you sure?',
-			'[prompt]/history/clear': 'The Undo/Redo History will be cleared. Are you sure?',
-			'[prompt]/history/preserve': 'The history will be preserved across sessions.\nThis can have an impact on performance when working with textures.',
-			'[prompt]/history/forbid': 'Undo/Redo disabled while scene is playing.',
+			'prompt/file/open': 'Any unsaved data will be lost. Are you sure?',
+			'prompt/file/export/noMeshSelected': 'No Mesh selected!',
+			'prompt/file/export/noObjectSelected': 'No Object selected!',
+			'prompt/script/remove': 'Are you sure?',
+			'prompt/history/clear': 'The Undo/Redo History will be cleared. Are you sure?',
+			'prompt/history/preserve': 'The history will be preserved across sessions.\nThis can have an impact on performance when working with textures.',
+			'prompt/history/forbid': 'Undo/Redo disabled while scene is playing.',
 
 			'menubar/file': 'File',
 			'menubar/file/new': 'New',
@@ -370,13 +370,13 @@ function Strings( config ) {
 
 		fr: {
 
-			'[prompt]/file/open': 'Toutes les données non enregistrées seront perdues Êtes-vous sûr ?',
-			'[prompt]/file/export/noMeshSelected': 'Aucun maillage sélectionné !',
-			'[prompt]/file/export/noObjectSelected': 'Aucun objet sélectionné !',
-			'[prompt]/script/remove': 'Es-tu sûr?',
-			'[prompt]/history/clear': 'L\'historique d\'annulation/rétablissement sera effacé Êtes-vous sûr ?',
-			'[prompt]/history/preserve': 'L\'histoire sera conservée entre les sessions.\nCela peut avoir un impact sur les performances lors de la manipulation des textures.',
-			'[prompt]/history/forbid': 'Les fonctions Annuler/Rétablir sont désactivées pendant la lecture de la scène.',
+			'prompt/file/open': 'Toutes les données non enregistrées seront perdues Êtes-vous sûr ?',
+			'prompt/file/export/noMeshSelected': 'Aucun maillage sélectionné !',
+			'prompt/file/export/noObjectSelected': 'Aucun objet sélectionné !',
+			'prompt/script/remove': 'Es-tu sûr?',
+			'prompt/history/clear': 'L\'historique d\'annulation/rétablissement sera effacé Êtes-vous sûr ?',
+			'prompt/history/preserve': 'L\'histoire sera conservée entre les sessions.\nCela peut avoir un impact sur les performances lors de la manipulation des textures.',
+			'prompt/history/forbid': 'Les fonctions Annuler/Rétablir sont désactivées pendant la lecture de la scène.',
 
 			'menubar/file': 'Fichier',
 			'menubar/file/new': 'Nouveau',
@@ -734,13 +734,13 @@ function Strings( config ) {
 
 		zh: {
 
-			'[prompt]/file/open': '您确定吗？未保存的数据将会丢失。',
-			'[prompt]/file/export/noMeshSelected': '未选择网格！',
-			'[prompt]/file/export/noObjectSelected': '未选择对象！',
-			'[prompt]/script/remove': '你确定吗？',
-			'[prompt]/history/clear': '撤销/重做历史记录将被清除。您确定吗？',
-			'[prompt]/history/preserve': '历史将在会话之间保留。\n这可能会影响在处理纹理时的性能。',
-			'[prompt]/history/forbid': '在播放场景时，撤消/重做被禁用。',
+			'prompt/file/open': '您确定吗？未保存的数据将会丢失。',
+			'prompt/file/export/noMeshSelected': '未选择网格！',
+			'prompt/file/export/noObjectSelected': '未选择对象！',
+			'prompt/script/remove': '你确定吗？',
+			'prompt/history/clear': '撤销/重做历史记录将被清除。您确定吗？',
+			'prompt/history/preserve': '历史将在会话之间保留。\n这可能会影响在处理纹理时的性能。',
+			'prompt/history/forbid': '在播放场景时，撤消/重做被禁用。',
 
 			'menubar/file': '文件',
 			'menubar/file/new': '新建',
@@ -1098,13 +1098,13 @@ function Strings( config ) {
 
 		ja: {
 
-			'[prompt]/file/open': '保存されていないデータは失われます。 本気ですか？',
-			'[prompt]/file/export/noMeshSelected': 'メッシュが選択されていません!',
-			'[prompt]/file/export/noObjectSelected': 'オブジェクトが選択されていません!',
-			'[prompt]/script/remove': '本気ですか？',
-			'[prompt]/history/clear': '元に戻す/やり直しの履歴が消去されます。 本気ですか？',
-			'[prompt]/history/preserve': '履歴はセッションをまたいで保存されます。\nこれは、テクスチャを操作する際のパフォーマンスに影響を与える可能性があります。',
-			'[prompt]/history/forbid': 'シーンの再生中は元に戻す/やり直しは無効になります。',
+			'prompt/file/open': '保存されていないデータは失われます。 本気ですか？',
+			'prompt/file/export/noMeshSelected': 'メッシュが選択されていません!',
+			'prompt/file/export/noObjectSelected': 'オブジェクトが選択されていません!',
+			'prompt/script/remove': '本気ですか？',
+			'prompt/history/clear': '元に戻す/やり直しの履歴が消去されます。 本気ですか？',
+			'prompt/history/preserve': '履歴はセッションをまたいで保存されます。\nこれは、テクスチャを操作する際のパフォーマンスに影響を与える可能性があります。',
+			'prompt/history/forbid': 'シーンの再生中は元に戻す/やり直しは無効になります。',
 
 			'menubar/file': 'ファイル',
 			'menubar/file/new': '新規',

--- a/editor/js/Strings.js
+++ b/editor/js/Strings.js
@@ -6,6 +6,14 @@ function Strings( config ) {
 
 		en: {
 
+			'[prompt]/file/open': 'Any unsaved data will be lost. Are you sure?',
+			'[prompt]/file/export/noMeshSelected': 'No Mesh selected!',
+			'[prompt]/file/export/noObjectSelected': 'No Object selected!',
+			'[prompt]/script/remove': 'Are you sure?',
+			'[prompt]/history/clear': 'The Undo/Redo History will be cleared. Are you sure?',
+			'[prompt]/history/preserve': 'The history will be preserved across sessions.\nThis can have an impact on performance when working with textures.',
+			'[prompt]/history/forbid': 'Undo/Redo disabled while scene is playing.',
+
 			'menubar/file': 'File',
 			'menubar/file/new': 'New',
 			'menubar/file/import': 'Import',
@@ -361,6 +369,14 @@ function Strings( config ) {
 		},
 
 		fr: {
+
+			'[prompt]/file/open': 'Toutes les données non enregistrées seront perdues Êtes-vous sûr ?',
+			'[prompt]/file/export/noMeshSelected': 'Aucun maillage sélectionné !',
+			'[prompt]/file/export/noObjectSelected': 'Aucun objet sélectionné !',
+			'[prompt]/script/remove': 'Es-tu sûr?',
+			'[prompt]/history/clear': 'L\'historique d\'annulation/rétablissement sera effacé Êtes-vous sûr ?',
+			'[prompt]/history/preserve': 'L\'histoire sera conservée entre les sessions.\nCela peut avoir un impact sur les performances lors de la manipulation des textures.',
+			'[prompt]/history/forbid': 'Les fonctions Annuler/Rétablir sont désactivées pendant la lecture de la scène.',
 
 			'menubar/file': 'Fichier',
 			'menubar/file/new': 'Nouveau',
@@ -718,6 +734,14 @@ function Strings( config ) {
 
 		zh: {
 
+			'[prompt]/file/open': '您确定吗？未保存的数据将会丢失。',
+			'[prompt]/file/export/noMeshSelected': '未选择网格！',
+			'[prompt]/file/export/noObjectSelected': '未选择对象！',
+			'[prompt]/script/remove': '你确定吗？',
+			'[prompt]/history/clear': '撤销/重做历史记录将被清除。您确定吗？',
+			'[prompt]/history/preserve': '历史将在会话之间保留。\n这可能会影响在处理纹理时的性能。',
+			'[prompt]/history/forbid': '在播放场景时，撤消/重做被禁用。',
+
 			'menubar/file': '文件',
 			'menubar/file/new': '新建',
 			'menubar/file/import': '导入',
@@ -1073,6 +1097,14 @@ function Strings( config ) {
 		},
 
 		ja: {
+
+			'[prompt]/file/open': '保存されていないデータは失われます。 本気ですか？',
+			'[prompt]/file/export/noMeshSelected': 'メッシュが選択されていません!',
+			'[prompt]/file/export/noObjectSelected': 'オブジェクトが選択されていません!',
+			'[prompt]/script/remove': '本気ですか？',
+			'[prompt]/history/clear': '元に戻す/やり直しの履歴が消去されます。 本気ですか？',
+			'[prompt]/history/preserve': '履歴はセッションをまたいで保存されます。\nこれは、テクスチャを操作する際のパフォーマンスに影響を与える可能性があります。',
+			'[prompt]/history/forbid': 'シーンの再生中は元に戻す/やり直しは無効になります。',
 
 			'menubar/file': 'ファイル',
 			'menubar/file/new': '新規',


### PR DESCRIPTION
This PR extracted and translated all the prompt messages, e.g.:

https://github.com/mrdoob/three.js/assets/1063018/beaa6609-c114-4801-8570-12a6f7b2bca8

About the pathname, takes ~`[prompt]/file/open`~ `prompt/file/open` for example:

- ~`[prompt]` ... the square brackets aims to emphasize that this entry doesn't belong to any real component;~
- `/file/open` ... the cause that triggers the prompt, in this case 'when opens file';
- How the prompt gets triggered doesn't matter, e.g. by `File>New`, `Examples>Arkanoid` etc

Preview: https://raw.githack.com/ycw/three.js/editor-confirm-msg/editor/index.html