### PR TITLE
Editor: No pollute Number's prototype

### DIFF
--- a/editor/index.html
+++ b/editor/index.html
@@ -74,12 +74,6 @@
 			window.URL = window.URL || window.webkitURL;
 			window.BlobBuilder = window.BlobBuilder || window.WebKitBlobBuilder || window.MozBlobBuilder;
 
-			Number.prototype.format = function () {
-
-				return this.toString().replace( /(\d)(?=(\d{3})+(?!\d))/g, '$1,' );
-
-			};
-
 			//
 
 			const editor = new Editor();

--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -754,7 +754,8 @@ Editor.prototype = {
 
 		save: save,
 		saveArrayBuffer: saveArrayBuffer,
-		saveString: saveString
+		saveString: saveString,
+		formatNumber: formatNumber
 
 	}
 
@@ -785,6 +786,12 @@ function saveArrayBuffer( buffer, filename ) {
 function saveString( text, filename ) {
 
 	save( new Blob( [ text ], { type: 'text/plain' } ), filename );
+
+}
+
+function formatNumber( number ) {
+
+	return new Intl.NumberFormat( 'en-us', { useGrouping: true } ).format( number );
 
 }
 

--- a/editor/js/Loader.js
+++ b/editor/js/Loader.js
@@ -70,7 +70,7 @@ function Loader( editor ) {
 		const reader = new FileReader();
 		reader.addEventListener( 'progress', function ( event ) {
 
-			const size = '(' + Math.floor( event.total / 1000 ).format() + ' KB)';
+			const size = '(' + editor.utils.formatNumber( Math.floor( event.total / 1000 ) ) + ' KB)';
 			const progress = Math.floor( ( event.loaded / event.total ) * 100 ) + '%';
 
 			console.log( 'Loading', filename, size, progress );

--- a/editor/js/Sidebar.Geometry.BufferGeometry.js
+++ b/editor/js/Sidebar.Geometry.BufferGeometry.js
@@ -35,7 +35,7 @@ function SidebarGeometryBufferGeometry( editor ) {
 			if ( index !== null ) {
 
 				containerAttributes.add( new UIText( strings.getKey( 'sidebar/geometry/buffer_geometry/index' ) ).setWidth( '80px' ) );
-				containerAttributes.add( new UIText( ( index.count ).format() ).setFontSize( '12px' ) );
+				containerAttributes.add( new UIText( editor.utils.formatNumber( index.count ) ).setFontSize( '12px' ) );
 				containerAttributes.add( new UIBreak() );
 
 			}
@@ -47,7 +47,7 @@ function SidebarGeometryBufferGeometry( editor ) {
 				const attribute = attributes[ name ];
 
 				containerAttributes.add( new UIText( name ).setWidth( '80px' ) );
-				containerAttributes.add( new UIText( ( attribute.count ).format() + ' (' + attribute.itemSize + ')' ).setFontSize( '12px' ) );
+				containerAttributes.add( new UIText( editor.utils.formatNumber( attribute.count ) + ' (' + attribute.itemSize + ')' ).setFontSize( '12px' ) );
 				containerAttributes.add( new UIBreak() );
 
 			}
@@ -76,7 +76,7 @@ function SidebarGeometryBufferGeometry( editor ) {
 					const morphTargets = morphAttributes[ name ];
 
 					containerMorphAttributes.add( new UIText( name ).setWidth( '80px' ) );
-					containerMorphAttributes.add( new UIText( ( morphTargets.length ).format() ).setFontSize( '12px' ) );
+					containerMorphAttributes.add( new UIText( editor.utils.formatNumber( morphTargets.length ) ).setFontSize( '12px' ) );
 					containerMorphAttributes.add( new UIBreak() );
 
 				}

--- a/editor/js/Viewport.Info.js
+++ b/editor/js/Viewport.Info.js
@@ -75,9 +75,9 @@ function ViewportInfo( editor ) {
 
 		}
 
-		objectsText.setValue( objects.format() );
-		verticesText.setValue( vertices.format() );
-		trianglesText.setValue( triangles.format() );
+		objectsText.setValue( editor.utils.formatNumber( objects ) );
+		verticesText.setValue( editor.utils.formatNumber( vertices ) );
+		trianglesText.setValue( editor.utils.formatNumber( triangles ) );
 
 		const pluralRules = new Intl.PluralRules( editor.config.getKey( 'language' ) );
 


### PR DESCRIPTION
With this PR, number formatting is now easier to reason about:

1/ The fn is now from `editor.utils` instead of Number's prototype
2/ For grouping, uses `Intl` module instead of regex
