### PR TITLE
Editor: Visualize the resizer

### DIFF
--- a/editor/css/main.css
+++ b/editor/css/main.css
@@ -293,12 +293,23 @@ select {
 #resizer {
 	position: absolute;
 	top: 32px;
-	right: 345px;
+	right: 350px;
 	width: 5px;
 	bottom: 0px;
-	/* background-color: rgba(255,0,0,0.5); */
+	transform: translatex(2.5px);
 	cursor: col-resize;
 }
+
+	#resizer:hover {
+		background-color: #08f8;
+		transition-property: background-color;
+		transition-delay: 0.1s;
+		transition-duration: 0.2s;
+	}
+
+	#resizer:active {
+		background-color: #08f;
+	}
 
 #viewport {
 	position: absolute;


### PR DESCRIPTION
With this PR: resizer will be visualized on hover/dragging; debounced by 0.1s to avoid flicking when user pointer  moves too fast from one side to another.

https://github.com/mrdoob/three.js/assets/1063018/c660cebe-df6c-427e-ab24-28cc7dded7d7

Preview: https://raw.githack.com/ycw/three.js/editor-toggle-resizer-vis/editor/index.html