### PR TITLE
WebGPURenderer: update sampler bindings on texture change

### DIFF
--- a/examples/jsm/renderers/common/Bindings.js
+++ b/examples/jsm/renderers/common/Bindings.js
@@ -122,6 +122,10 @@ class Bindings extends DataMap {
 
 				}
 
+			} else if ( binding.isSampler ) {
+
+				binding.update();
+
 			} else if ( binding.isSampledTexture ) {
 
 				const texture = binding.texture;

--- a/examples/jsm/renderers/common/nodes/NodeSampler.js
+++ b/examples/jsm/renderers/common/nodes/NodeSampler.js
@@ -12,11 +12,7 @@ class NodeSampler extends Sampler {
 
 	update() {
 
-		if ( this.texture !== this.textureNode.value ) {
-
-			this.texture = this.textureNode.value;
-
-		}
+		this.texture = this.textureNode.value;
 
 	}
 

--- a/examples/jsm/renderers/common/nodes/NodeSampler.js
+++ b/examples/jsm/renderers/common/nodes/NodeSampler.js
@@ -10,6 +10,16 @@ class NodeSampler extends Sampler {
 
 	}
 
+	update() {
+
+		if ( this.texture !== this.textureNode.value ) {
+
+			this.texture = this.textureNode.value;
+
+		}
+
+	}
+
 }
 
 export default NodeSampler;


### PR DESCRIPTION
Replacing the matcap texture by dragging a new matcap png in recent MeshMatcapNode Material exposes a bug where when a texture is changed, the related sampler binding is not, resulting in a failure in createBindGroup(). 

Update the sampler texture in these cases, we don't need to flag the update because the related sampledTexture binding will flag the update as required. The WebGL backend does not have this problem.
