### PR TITLE
Editor: Fixed object changes out-of-sync with outliner options

### DIFF
--- a/editor/js/Sidebar.Scene.js
+++ b/editor/js/Sidebar.Scene.js
@@ -119,13 +119,11 @@ function SidebarScene( editor ) {
 
 	function getScript( uuid ) {
 
-		if ( editor.scripts[ uuid ] !== undefined ) {
+		if ( editor.scripts[ uuid ] === undefined ) return '';
 
-			return ' <span class="type Script"></span>';
+		if ( editor.scripts[ uuid ].length === 0 ) return '';
 
-		}
-
-		return '';
+		return ' <span class="type Script"></span>';
 
 	}
 
@@ -494,18 +492,22 @@ function SidebarScene( editor ) {
 
 	signals.refreshSidebarEnvironment.add( refreshUI );
 
-	/*
 	signals.objectChanged.add( function ( object ) {
 
-		let options = outliner.options;
+		const options = outliner.options;
 
 		for ( let i = 0; i < options.length; i ++ ) {
 
-			let option = options[ i ];
+			const option = options[ i ];
 
 			if ( option.value === object.id ) {
 
-				option.innerHTML = buildHTML( object );
+				const openerElement = option.querySelector( ':scope > .opener' );
+
+				const openerHTML = openerElement ? openerElement.outerHTML : '';
+
+				option.innerHTML = openerHTML + buildHTML( object );
+
 				return;
 
 			}
@@ -513,7 +515,19 @@ function SidebarScene( editor ) {
 		}
 
 	} );
-	*/
+
+	signals.scriptAdded.add( function () {
+
+		signals.objectChanged.dispatch( editor.selected );
+
+	} );
+
+	signals.scriptRemoved.add( function () {
+
+		signals.objectChanged.dispatch( editor.selected );
+
+	} );
+
 
 	signals.objectSelected.add( function ( object ) {
 


### PR DESCRIPTION
fix: #28290

The issue: Outliner doesn't keep in sync with OBJECT (`name`) and SCRIPT (add/remove):

https://github.com/mrdoob/three.js/assets/1063018/c0d740f0-328c-4e39-b1ce-399dcfbdc907

With this PR, Outliner does keep in sync with those changes ... via re-render the outliner on `objectChanged`, `scriptAdded` and `scriptRemoved` ... Besides that, I also fixed an issue of `getScript`, it now correctly handles empty array as "no scripts binding to object", s.t. it will not generate `◎` in the outliner for no-scripts objects:

https://github.com/mrdoob/three.js/assets/1063018/6068f4db-32d1-4400-9083-5c72fe8a7644

Preview: https://raw.githack.com/ycw/three.js/tmp-rename/editor/index.html