### PR TITLE
Editor: Added dedicated `.eslintrc.json`

### DIFF
--- a/editor/.eslintrc.json
+++ b/editor/.eslintrc.json
@@ -1,0 +1,9 @@
+{
+    "extends": [
+        "../.eslintrc.json"
+    ],
+    "parserOptions": {
+        "sourceType": "module",
+        "ecmaVersion": 2020
+    }
+}


### PR DESCRIPTION
three.js sticks to ES2018 ... but the editor codebase uses ES2019 and ES2020 features ... so a dedicated eslintrc is needed. 


Dynamic import (ES2020):
https://github.com/mrdoob/three.js/blob/a980f81e61191f98267c7bbac28b0d4b9500a6c3/editor/js/Loader.js#L90
https://github.com/mrdoob/three.js/blob/a980f81e61191f98267c7bbac28b0d4b9500a6c3/editor/js/Menubar.File.js#L89
https://github.com/mrdoob/three.js/blob/a980f81e61191f98267c7bbac28b0d4b9500a6c3/editor/js/Sidebar.Geometry.js#L233

Optional catch binding (ES2019):
https://github.com/mrdoob/three.js/blob/a980f81e61191f98267c7bbac28b0d4b9500a6c3/editor/sw.js#L240


 