### PR TITLE
Texture: Add Texture.DEFAULT_COLOR_SPACE

### DIFF
--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -19,7 +19,7 @@ let _textureId = 0;
 
 class Texture extends EventDispatcher {
 
-	constructor( image = Texture.DEFAULT_IMAGE, mapping = Texture.DEFAULT_MAPPING, wrapS = ClampToEdgeWrapping, wrapT = ClampToEdgeWrapping, magFilter = LinearFilter, minFilter = LinearMipmapLinearFilter, format = RGBAFormat, type = UnsignedByteType, anisotropy = Texture.DEFAULT_ANISOTROPY, colorSpace = NoColorSpace ) {
+	constructor( image = Texture.DEFAULT_IMAGE, mapping = Texture.DEFAULT_MAPPING, wrapS = ClampToEdgeWrapping, wrapT = ClampToEdgeWrapping, magFilter = LinearFilter, minFilter = LinearMipmapLinearFilter, format = RGBAFormat, type = UnsignedByteType, anisotropy = Texture.DEFAULT_ANISOTROPY, colorSpace = Texture.DEFAULT_COLORSPACE ) {
 
 		super();
 
@@ -316,5 +316,6 @@ class Texture extends EventDispatcher {
 Texture.DEFAULT_IMAGE = null;
 Texture.DEFAULT_MAPPING = UVMapping;
 Texture.DEFAULT_ANISOTROPY = 1;
+Texture.DEFAULT_COLORSPACE = NoColorSpace;
 
 export { Texture };

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -19,7 +19,7 @@ let _textureId = 0;
 
 class Texture extends EventDispatcher {
 
-	constructor( image = Texture.DEFAULT_IMAGE, mapping = Texture.DEFAULT_MAPPING, wrapS = ClampToEdgeWrapping, wrapT = ClampToEdgeWrapping, magFilter = LinearFilter, minFilter = LinearMipmapLinearFilter, format = RGBAFormat, type = UnsignedByteType, anisotropy = Texture.DEFAULT_ANISOTROPY, colorSpace = Texture.DEFAULT_COLORSPACE ) {
+	constructor( image = Texture.DEFAULT_IMAGE, mapping = Texture.DEFAULT_MAPPING, wrapS = ClampToEdgeWrapping, wrapT = ClampToEdgeWrapping, magFilter = LinearFilter, minFilter = LinearMipmapLinearFilter, format = RGBAFormat, type = UnsignedByteType, anisotropy = Texture.DEFAULT_ANISOTROPY, colorSpace = Texture.DEFAULT_COLOR_SPACE ) {
 
 		super();
 
@@ -316,6 +316,6 @@ class Texture extends EventDispatcher {
 Texture.DEFAULT_IMAGE = null;
 Texture.DEFAULT_MAPPING = UVMapping;
 Texture.DEFAULT_ANISOTROPY = 1;
-Texture.DEFAULT_COLORSPACE = NoColorSpace;
+Texture.DEFAULT_COLOR_SPACE = NoColorSpace;
 
 export { Texture };


### PR DESCRIPTION
Related issue: #XXXX

**Description**

Add `Texture.DEFAULT_COLORSPACE` variable.
In some cases, reduce the amount of duplicate code.