### PR TITLE
WebGPURenderer: Reuse `MatcapUVNode` in `MeshMatcapNodeMaterial`

### DIFF
--- a/examples/jsm/nodes/materials/MeshMatcapNodeMaterial.js
+++ b/examples/jsm/nodes/materials/MeshMatcapNodeMaterial.js
@@ -1,11 +1,10 @@
 import NodeMaterial, { addNodeMaterial } from './NodeMaterial.js';
 import { materialReference } from '../accessors/MaterialReferenceNode.js';
 import { diffuseColor } from '../core/PropertyNode.js';
-import { vec2, vec3 } from '../shadernode/ShaderNode.js';
-import { positionViewDirection } from '../accessors/PositionNode.js';
+import { vec3 } from '../shadernode/ShaderNode.js';
 import { MeshMatcapMaterial } from 'three';
-import { transformedNormalView } from '../accessors/NormalNode.js';
 import { mix } from '../math/MathNode.js';
+import { matcapUV } from '../utils/MatcapUVNode.js';
 
 const defaultValues = new MeshMatcapMaterial();
 
@@ -27,10 +26,7 @@ class MeshMatcapNodeMaterial extends NodeMaterial {
 
 	setupVariants( builder ) {
 
-		const x = vec3( positionViewDirection.z, 0.0, positionViewDirection.x.negate() ).normalize();
-		const y = positionViewDirection.cross( x );
-
-		const uv = vec2( x.dot( transformedNormalView ), y.dot( transformedNormalView ) ).mul( 0.495 ).add( 0.5 ) ; // 0.495 to remove artifacts caused by undersized matcap disks
+		const uv = matcapUV;
 
 		let matcapColor;
 

--- a/examples/jsm/nodes/utils/MatcapUVNode.js
+++ b/examples/jsm/nodes/utils/MatcapUVNode.js
@@ -17,7 +17,7 @@ class MatcapUVNode extends TempNode {
 		const x = vec3( positionViewDirection.z, 0, positionViewDirection.x.negate() ).normalize();
 		const y = positionViewDirection.cross( x );
 
-		return vec2( x.dot( transformedNormalView ), y.dot( transformedNormalView ) ).mul( 0.495 ).add( 0.5 );
+		return vec2( x.dot( transformedNormalView ), y.dot( transformedNormalView ) ).mul( 0.495 ).add( 0.5 ); // 0.495 to remove artifacts caused by undersized matcap disks
 
 	}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/28259, https://github.com/mrdoob/three.js/pull/23705

**Description**

Use the existing `matcapUV`.
