### PR TITLE
Editor: Fixed ghost viewport camera

### DIFF
--- a/editor/js/Viewport.Controls.js
+++ b/editor/js/Viewport.Controls.js
@@ -89,7 +89,7 @@ function ViewportControls( editor ) {
 
 		const selectedCamera = ( editor.viewportCamera.uuid in options )
 			? editor.viewportCamera
-			: Object.values( editor.cameras )[ 0 ];
+			: editor.camera;
 
 		cameraSelect.setValue( selectedCamera.uuid );
 		editor.setViewportCamera( selectedCamera.uuid );

--- a/editor/js/Viewport.Controls.js
+++ b/editor/js/Viewport.Controls.js
@@ -61,6 +61,8 @@ function ViewportControls( editor ) {
 
 	signals.editorCleared.add( function () {
 
+		editor.setViewportCamera( Object.keys( editor.cameras )[ 0 ] );
+
 		shadingSelect.setValue( 'solid' );
 		editor.setViewportShading( shadingSelect.getValue() );
 
@@ -84,7 +86,13 @@ function ViewportControls( editor ) {
 		}
 
 		cameraSelect.setOptions( options );
-		cameraSelect.setValue( editor.viewportCamera.uuid );
+
+		const selectedCamera = ( editor.viewportCamera.uuid in options )
+			? editor.viewportCamera
+			: Object.values( editor.cameras )[ 0 ];
+
+		cameraSelect.setValue( selectedCamera.uuid );
+		editor.setViewportCamera( selectedCamera.uuid );
 
 	}
 

--- a/editor/js/Viewport.Controls.js
+++ b/editor/js/Viewport.Controls.js
@@ -61,7 +61,7 @@ function ViewportControls( editor ) {
 
 	signals.editorCleared.add( function () {
 
-		editor.setViewportCamera( Object.keys( editor.cameras )[ 0 ] );
+		editor.setViewportCamera( editor.camera.uuid );
 
 		shadingSelect.setValue( 'solid' );
 		editor.setViewportShading( shadingSelect.getValue() );


### PR DESCRIPTION
The issue: When a non-default active `viewportCamera` is removed, the viewport doesn't update its view:

https://github.com/mrdoob/three.js/assets/1063018/cab2161f-0cf2-4878-b27f-c7a8938d4f89

File>New has the same issue, viewport will select ghost camera if previous file's active `viewportCamera` isn't default camera:

https://github.com/mrdoob/three.js/assets/1063018/67ce53d8-b648-441e-9dcb-510c70cea2a1

This PR fixed them all by checking if old `viewportCamera` is gone, then set default camera as `viewportCamera`. 

Preview: https://raw.githack.com/ycw/three.js/editor-viewport-controls-cameras/editor/index.html