### PR TITLE
KeyframeTrack: Improve docs and subtype ctors.

### DIFF
--- a/docs/api/en/animation/tracks/BooleanKeyframeTrack.html
+++ b/docs/api/en/animation/tracks/BooleanKeyframeTrack.html
@@ -23,6 +23,10 @@
 			[page:Array times] - (required) array of keyframe times.<br />
 			[page:Array values] - values for the keyframes at the times specified.<br />
 		</p>
+		<p>
+			This keyframe track type has no interpolation parameter because the
+			interpolation is always [page:Animation InterpolateDiscrete].
+		</p>
 
 		<h2>Properties</h2>
 
@@ -30,7 +34,7 @@
 
 		<h3>[property:Constant DefaultInterpolation]</h3>
 		<p>
-			The default interpolation type to use, [page:Animation InterpolateDiscrete].
+			The default interpolation type to use. Only [page:Animation InterpolateDiscrete] makes sense for this track type.
 		</p>
 
 		<h3>[property:Array ValueBufferType]</h3>

--- a/docs/api/en/animation/tracks/BooleanKeyframeTrack.html
+++ b/docs/api/en/animation/tracks/BooleanKeyframeTrack.html
@@ -34,7 +34,7 @@
 
 		<h3>[property:Constant DefaultInterpolation]</h3>
 		<p>
-			The default interpolation type to use. Only [page:Animation InterpolateDiscrete] makes sense for this track type.
+			The default interpolation type to use. Only [page:Animation InterpolateDiscrete] is valid for this track type.
 		</p>
 
 		<h3>[property:Array ValueBufferType]</h3>

--- a/docs/api/en/animation/tracks/ColorKeyframeTrack.html
+++ b/docs/api/en/animation/tracks/ColorKeyframeTrack.html
@@ -20,7 +20,7 @@
 		<h2>Constructor</h2>
 
 		<h3>
-			[name]( [param:String name], [param:Array times], [param:Array values] )
+			[name]( [param:String name], [param:Array times], [param:Array values], [param:Constant interpolation] )
 		</h3>
 		<p>
 			[page:String name] - (required) identifier for the KeyframeTrack.<br />

--- a/docs/api/en/animation/tracks/NumberKeyframeTrack.html
+++ b/docs/api/en/animation/tracks/NumberKeyframeTrack.html
@@ -16,7 +16,7 @@
 		<h2>Constructor</h2>
 
 		<h3>
-			[name]( [param:String name], [param:Array times], [param:Array values] )
+			[name]( [param:String name], [param:Array times], [param:Array values], [param:Constant interpolation] )
 		</h3>
 		<p>
 			[page:String name] - (required) identifier for the KeyframeTrack.<br />

--- a/docs/api/en/animation/tracks/QuaternionKeyframeTrack.html
+++ b/docs/api/en/animation/tracks/QuaternionKeyframeTrack.html
@@ -16,14 +16,14 @@
 		<h2>Constructor</h2>
 
 		<h3>
-			[name]( [param:String name], [param:Array times], [param:Array values] )
+			[name]( [param:String name], [param:Array times], [param:Array values], [param:Constant interpolation] )
 		</h3>
 		<p>
-			[page:String name] (required) identifier for the KeyframeTrack.<br />
-			[page:Array times] (required) array of keyframe times.<br />
-			[page:Array values] values for the keyframes at the times specified, a
+			[page:String name] - (required) identifier for the KeyframeTrack.<br />
+			[page:Array times] - (required) array of keyframe times.<br />
+			[page:Array values] - values for the keyframes at the times specified, a
 			flat array of quaternion components.<br />
-			[page:Constant interpolation] the type of interpolation to use. See
+			[page:Constant interpolation] - the type of interpolation to use. See
 			[page:Animation Animation Constants] for possible values. Default is
 			[page:Animation InterpolateLinear].
 		</p>

--- a/docs/api/en/animation/tracks/StringKeyframeTrack.html
+++ b/docs/api/en/animation/tracks/StringKeyframeTrack.html
@@ -24,9 +24,10 @@
 			[page:String name] - (required) identifier for the KeyframeTrack.<br />
 			[page:Array times] - (required) array of keyframe times.<br />
 			[page:Array values] - values for the keyframes at the times specified.<br />
-			[page:Constant interpolation] - the type of interpolation to use. See
-			[page:Animation Animation Constants] for possible values. Default is
-			[page:Animation InterpolateDiscrete].
+		</p>
+		<p>
+			This keyframe track type has no interpolation parameter because the
+			interpolation is always [page:Animation InterpolateDiscrete].
 		</p>
 
 		<h2>Properties</h2>
@@ -35,7 +36,7 @@
 
 		<h3>[property:Constant DefaultInterpolation]</h3>
 		<p>
-			The default interpolation type to use, [page:Animation InterpolateDiscrete].
+			The default interpolation type to use. Only [page:Animation InterpolateDiscrete] makes sense for this track type.
 		</p>
 
 		<h3>[property:Array ValueBufferType]</h3>

--- a/docs/api/en/animation/tracks/StringKeyframeTrack.html
+++ b/docs/api/en/animation/tracks/StringKeyframeTrack.html
@@ -36,7 +36,7 @@
 
 		<h3>[property:Constant DefaultInterpolation]</h3>
 		<p>
-			The default interpolation type to use. Only [page:Animation InterpolateDiscrete] makes sense for this track type.
+			The default interpolation type to use. Only [page:Animation InterpolateDiscrete] is valid for this track type.
 		</p>
 
 		<h3>[property:Array ValueBufferType]</h3>

--- a/docs/api/en/animation/tracks/VectorKeyframeTrack.html
+++ b/docs/api/en/animation/tracks/VectorKeyframeTrack.html
@@ -17,7 +17,7 @@
 		<h2>Constructor</h2>
 
 		<h3>
-			[name]( [param:String name], [param:Array times], [param:Array values] )
+			[name]( [param:String name], [param:Array times], [param:Array values], [param:Constant interpolation] )
 		</h3>
 		<p>
 			[page:String name] - (required) identifier for the KeyframeTrack.<br />

--- a/src/animation/tracks/BooleanKeyframeTrack.js
+++ b/src/animation/tracks/BooleanKeyframeTrack.js
@@ -4,7 +4,16 @@ import { KeyframeTrack } from '../KeyframeTrack.js';
 /**
  * A Track of Boolean keyframe values.
  */
-class BooleanKeyframeTrack extends KeyframeTrack {}
+class BooleanKeyframeTrack extends KeyframeTrack {
+
+	// No interpolation parameter because only InterpolateDiscrete makes sense.
+	constructor( name, times, values ) {
+
+		super( name, times, values );
+
+	}
+
+}
 
 BooleanKeyframeTrack.prototype.ValueTypeName = 'bool';
 BooleanKeyframeTrack.prototype.ValueBufferType = Array;

--- a/src/animation/tracks/BooleanKeyframeTrack.js
+++ b/src/animation/tracks/BooleanKeyframeTrack.js
@@ -6,7 +6,7 @@ import { KeyframeTrack } from '../KeyframeTrack.js';
  */
 class BooleanKeyframeTrack extends KeyframeTrack {
 
-	// No interpolation parameter because only InterpolateDiscrete makes sense.
+	// No interpolation parameter because only InterpolateDiscrete is valid.
 	constructor( name, times, values ) {
 
 		super( name, times, values );

--- a/src/animation/tracks/QuaternionKeyframeTrack.js
+++ b/src/animation/tracks/QuaternionKeyframeTrack.js
@@ -1,4 +1,3 @@
-import { InterpolateLinear } from '../../constants.js';
 import { KeyframeTrack } from '../KeyframeTrack.js';
 import { QuaternionLinearInterpolant } from '../../math/interpolants/QuaternionLinearInterpolant.js';
 
@@ -17,7 +16,7 @@ class QuaternionKeyframeTrack extends KeyframeTrack {
 
 QuaternionKeyframeTrack.prototype.ValueTypeName = 'quaternion';
 // ValueBufferType is inherited
-QuaternionKeyframeTrack.prototype.DefaultInterpolation = InterpolateLinear;
+// DefaultInterpolation is inherited;
 QuaternionKeyframeTrack.prototype.InterpolantFactoryMethodSmooth = undefined;
 
 export { QuaternionKeyframeTrack };

--- a/src/animation/tracks/StringKeyframeTrack.js
+++ b/src/animation/tracks/StringKeyframeTrack.js
@@ -6,7 +6,7 @@ import { KeyframeTrack } from '../KeyframeTrack.js';
  */
 class StringKeyframeTrack extends KeyframeTrack {
 
-	// No interpolation parameter because only InterpolateDiscrete makes sense.
+	// No interpolation parameter because only InterpolateDiscrete is valid.
 	constructor( name, times, values ) {
 
 		super( name, times, values );

--- a/src/animation/tracks/StringKeyframeTrack.js
+++ b/src/animation/tracks/StringKeyframeTrack.js
@@ -4,7 +4,16 @@ import { KeyframeTrack } from '../KeyframeTrack.js';
 /**
  * A Track that interpolates Strings
  */
-class StringKeyframeTrack extends KeyframeTrack {}
+class StringKeyframeTrack extends KeyframeTrack {
+
+	// No interpolation parameter because only InterpolateDiscrete makes sense.
+	constructor( name, times, values ) {
+
+		super( name, times, values );
+
+	}
+
+}
 
 StringKeyframeTrack.prototype.ValueTypeName = 'string';
 StringKeyframeTrack.prototype.ValueBufferType = Array;

--- a/test/unit/src/animation/tracks/BooleanKeyframeTrack.tests.js
+++ b/test/unit/src/animation/tracks/BooleanKeyframeTrack.tests.js
@@ -14,7 +14,6 @@ export default QUnit.module( 'Animation', () => {
 				name: '.visible',
 				times: [ 0, 1 ],
 				values: [ true, false ],
-				interpolation: BooleanKeyframeTrack.DefaultInterpolation
 			};
 
 			// INHERITANCE
@@ -34,10 +33,6 @@ export default QUnit.module( 'Animation', () => {
 				// name, times, values
 				const object = new BooleanKeyframeTrack( parameters.name, parameters.times, parameters.values );
 				assert.ok( object, 'Can instantiate a BooleanKeyframeTrack.' );
-
-				// name, times, values, interpolation
-				const object_all = new BooleanKeyframeTrack( parameters.name, parameters.times, parameters.values, parameters.interpolation );
-				assert.ok( object_all, 'Can instantiate a BooleanKeyframeTrack with name, times, values, interpolation.' );
 
 			} );
 

--- a/test/unit/src/animation/tracks/StringKeyframeTrack.tests.js
+++ b/test/unit/src/animation/tracks/StringKeyframeTrack.tests.js
@@ -14,7 +14,6 @@ export default QUnit.module( 'Animation', () => {
 				name: '.name',
 				times: [ 0, 1 ],
 				values: [ 'foo', 'bar' ],
-				interpolation: StringKeyframeTrack.DefaultInterpolation
 			};
 
 			// INHERITANCE
@@ -34,10 +33,6 @@ export default QUnit.module( 'Animation', () => {
 				// name, times, values
 				const object = new StringKeyframeTrack( parameters.name, parameters.times, parameters.values );
 				assert.ok( object, 'Can instantiate a StringKeyframeTrack.' );
-
-				// name, times, values, interpolation
-				const object_all = new StringKeyframeTrack( parameters.name, parameters.times, parameters.values, parameters.interpolation );
-				assert.ok( object_all, 'Can instantiate a StringKeyframeTrack with name, times, values, interpolation.' );
 
 			} );
 


### PR DESCRIPTION
**Description**

Adds a few small details to docs for KeyframeTrack and its subtypes. Also expresses the lack of `interpolation` parameters for Boolean and String keyframe tracks in their class `constructor`. 

*This contribution is funded by [Lume - 3D HTML elements](https://lume.io)*
