### PR TITLE
WebGPURenderer: Fix SampledTexture not correctly bound

### DIFF
--- a/examples/jsm/renderers/common/Bindings.js
+++ b/examples/jsm/renderers/common/Bindings.js
@@ -124,13 +124,7 @@ class Bindings extends DataMap {
 
 			} else if ( binding.isSampler ) {
 
-				const updated = binding.update();
-
-				if ( updated ) {
-
-					backend.updateBinding( binding );
-
-				}
+				binding.update();
 
 			} else if ( binding.isSampledTexture ) {
 

--- a/examples/jsm/renderers/common/Bindings.js
+++ b/examples/jsm/renderers/common/Bindings.js
@@ -124,7 +124,13 @@ class Bindings extends DataMap {
 
 			} else if ( binding.isSampler ) {
 
-				binding.update();
+				const updated = binding.update();
+
+				if ( updated ) {
+
+					this.textures.updateTexture( binding.texture );
+
+				}
 
 			} else if ( binding.isSampledTexture ) {
 

--- a/examples/jsm/renderers/common/Bindings.js
+++ b/examples/jsm/renderers/common/Bindings.js
@@ -128,8 +128,6 @@ class Bindings extends DataMap {
 
 			} else if ( binding.isSampledTexture ) {
 
-				const texture = binding.texture;
-
 				const updated = binding.update();
 
 				if ( updated ) {
@@ -139,6 +137,8 @@ class Bindings extends DataMap {
 					needsBindingsUpdate = true;
 
 				}
+
+				const texture = binding.texture;
 
 				if ( texture.isStorageTexture === true ) {
 

--- a/examples/jsm/renderers/common/Bindings.js
+++ b/examples/jsm/renderers/common/Bindings.js
@@ -128,7 +128,7 @@ class Bindings extends DataMap {
 
 				if ( updated ) {
 
-					this.textures.updateTexture( binding.texture );
+					backend.updateBinding( binding );
 
 				}
 
@@ -136,13 +136,13 @@ class Bindings extends DataMap {
 
 				const texture = binding.texture;
 
-				if ( binding.needsBindingsUpdate ) needsBindingsUpdate = true;
-
 				const updated = binding.update();
 
 				if ( updated ) {
 
 					this.textures.updateTexture( binding.texture );
+
+					needsBindingsUpdate = true;
 
 				}
 

--- a/examples/jsm/renderers/common/SampledTexture.js
+++ b/examples/jsm/renderers/common/SampledTexture.js
@@ -18,14 +18,6 @@ class SampledTexture extends Binding {
 
 	}
 
-	get needsBindingsUpdate() {
-
-		const { texture, version } = this;
-
-		return texture.isVideoTexture ? true : version !== texture.version; // @TODO: version === 0 && texture.version > 0 ( add it just to External Textures like PNG,JPG )
-
-	}
-
 	update() {
 
 		const { texture, version } = this;

--- a/examples/jsm/renderers/common/nodes/NodeSampledTexture.js
+++ b/examples/jsm/renderers/common/nodes/NodeSampledTexture.js
@@ -10,12 +10,6 @@ class NodeSampledTexture extends SampledTexture {
 
 	}
 
-	get needsBindingsUpdate() {
-
-		return this.textureNode.value !== this.texture || super.needsBindingsUpdate;
-
-	}
-
 	update() {
 
 		const { textureNode } = this;


### PR DESCRIPTION
Related issue: #28268

**Description**

When resizing a `RenderTarget`, for example using a PostProcess pipeline with a `PassNode`, the resize will trigger `this.renderTarget.setSize()` which will dispatch `dispose` destroying the associated textures in the backend and then lose the proper binding on the GPU side:
```js
_destroyTexture( texture ) {

		this.backend.destroySampler( texture );
		this.backend.destroyTexture( texture );

		this.delete( texture );

}
```
This PR fix `SampledTexture` binding update. Related comment https://github.com/mrdoob/three.js/pull/28268#issuecomment-2095075418
With this fix, the error seems to no longer appears.


<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Utsubo](https://utsubo.com)*
