### PR TITLE
Editor: Alerts if File>Import failed

### DIFF
--- a/editor/js/Loader.js
+++ b/editor/js/Loader.js
@@ -77,437 +77,115 @@ function Loader( editor ) {
 
 		} );
 
-		switch ( extension ) {
+		const fileHandlers = {};
 
-			case '3dm':
+		fileHandlers[ '3dm' ] = function () {
 
-			{
+			reader.addEventListener( 'load', async function ( event ) {
 
-				reader.addEventListener( 'load', async function ( event ) {
+				const contents = event.target.result;
 
-					const contents = event.target.result;
+				const { Rhino3dmLoader } = await import( 'three/addons/loaders/3DMLoader.js' );
 
-					const { Rhino3dmLoader } = await import( 'three/addons/loaders/3DMLoader.js' );
+				const loader = new Rhino3dmLoader();
+				loader.setLibraryPath( '../examples/jsm/libs/rhino3dm/' );
+				loader.parse( contents, function ( object ) {
 
-					const loader = new Rhino3dmLoader();
-					loader.setLibraryPath( '../examples/jsm/libs/rhino3dm/' );
-					loader.parse( contents, function ( object ) {
-
-						object.name = filename;
-
-						editor.execute( new AddObjectCommand( editor, object ) );
-
-					}, function ( error ) {
-
-						console.error( error );
-
-					} );
-
-				}, false );
-				reader.readAsArrayBuffer( file );
-
-				break;
-
-			}
-
-			case '3ds':
-
-			{
-
-				reader.addEventListener( 'load', async function ( event ) {
-
-					const { TDSLoader } = await import( 'three/addons/loaders/TDSLoader.js' );
-
-					const loader = new TDSLoader();
-					const object = loader.parse( event.target.result );
-
-					editor.execute( new AddObjectCommand( editor, object ) );
-
-				}, false );
-				reader.readAsArrayBuffer( file );
-
-				break;
-
-			}
-
-			case '3mf':
-
-			{
-
-				reader.addEventListener( 'load', async function ( event ) {
-
-					const { ThreeMFLoader } = await import( 'three/addons/loaders/3MFLoader.js' );
-
-					const loader = new ThreeMFLoader();
-					const object = loader.parse( event.target.result );
-
-					editor.execute( new AddObjectCommand( editor, object ) );
-
-				}, false );
-				reader.readAsArrayBuffer( file );
-
-				break;
-
-			}
-
-			case 'amf':
-
-			{
-
-				reader.addEventListener( 'load', async function ( event ) {
-
-					const { AMFLoader } = await import( 'three/addons/loaders/AMFLoader.js' );
-
-					const loader = new AMFLoader();
-					const amfobject = loader.parse( event.target.result );
-
-					editor.execute( new AddObjectCommand( editor, amfobject ) );
-
-				}, false );
-				reader.readAsArrayBuffer( file );
-
-				break;
-
-			}
-
-			case 'dae':
-
-			{
-
-				reader.addEventListener( 'load', async function ( event ) {
-
-					const contents = event.target.result;
-
-					const { ColladaLoader } = await import( 'three/addons/loaders/ColladaLoader.js' );
-
-					const loader = new ColladaLoader( manager );
-					const collada = loader.parse( contents );
-
-					collada.scene.name = filename;
-
-					editor.execute( new AddObjectCommand( editor, collada.scene ) );
-
-				}, false );
-				reader.readAsText( file );
-
-				break;
-
-			}
-
-			case 'drc':
-
-			{
-
-				reader.addEventListener( 'load', async function ( event ) {
-
-					const contents = event.target.result;
-
-					const { DRACOLoader } = await import( 'three/addons/loaders/DRACOLoader.js' );
-
-					const loader = new DRACOLoader();
-					loader.setDecoderPath( '../examples/jsm/libs/draco/' );
-					loader.parse( contents, function ( geometry ) {
-
-						let object;
-
-						if ( geometry.index !== null ) {
-
-							const material = new THREE.MeshStandardMaterial();
-
-							object = new THREE.Mesh( geometry, material );
-							object.name = filename;
-
-						} else {
-
-							const material = new THREE.PointsMaterial( { size: 0.01 } );
-							material.vertexColors = geometry.hasAttribute( 'color' );
-
-							object = new THREE.Points( geometry, material );
-							object.name = filename;
-
-						}
-
-						loader.dispose();
-						editor.execute( new AddObjectCommand( editor, object ) );
-
-					} );
-
-				}, false );
-				reader.readAsArrayBuffer( file );
-
-				break;
-
-			}
-
-			case 'fbx':
-
-			{
-
-				reader.addEventListener( 'load', async function ( event ) {
-
-					const contents = event.target.result;
-
-					const { FBXLoader } = await import( 'three/addons/loaders/FBXLoader.js' );
-
-					const loader = new FBXLoader( manager );
-					const object = loader.parse( contents );
-
-					editor.execute( new AddObjectCommand( editor, object ) );
-
-				}, false );
-				reader.readAsArrayBuffer( file );
-
-				break;
-
-			}
-
-			case 'glb':
-
-			{
-
-				reader.addEventListener( 'load', async function ( event ) {
-
-					const contents = event.target.result;
-
-					const loader = await createGLTFLoader();
-
-					loader.parse( contents, '', function ( result ) {
-
-						const scene = result.scene;
-						scene.name = filename;
-
-						scene.animations.push( ...result.animations );
-						editor.execute( new AddObjectCommand( editor, scene ) );
-
-						loader.dracoLoader.dispose();
-						loader.ktx2Loader.dispose();
-
-					} );
-
-				}, false );
-				reader.readAsArrayBuffer( file );
-
-				break;
-
-			}
-
-			case 'gltf':
-
-			{
-
-				reader.addEventListener( 'load', async function ( event ) {
-
-					const contents = event.target.result;
-
-					const loader = await createGLTFLoader( manager );
-
-					loader.parse( contents, '', function ( result ) {
-
-						const scene = result.scene;
-						scene.name = filename;
-
-						scene.animations.push( ...result.animations );
-						editor.execute( new AddObjectCommand( editor, scene ) );
-
-						loader.dracoLoader.dispose();
-						loader.ktx2Loader.dispose();
-
-					} );
-
-				}, false );
-				reader.readAsArrayBuffer( file );
-
-				break;
-
-			}
-
-			case 'js':
-			case 'json':
-
-			{
-
-				reader.addEventListener( 'load', function ( event ) {
-
-					const contents = event.target.result;
-
-					// 2.0
-
-					if ( contents.indexOf( 'postMessage' ) !== - 1 ) {
-
-						const blob = new Blob( [ contents ], { type: 'text/javascript' } );
-						const url = URL.createObjectURL( blob );
-
-						const worker = new Worker( url );
-
-						worker.onmessage = function ( event ) {
-
-							event.data.metadata = { version: 2 };
-							handleJSON( event.data );
-
-						};
-
-						worker.postMessage( Date.now() );
-
-						return;
-
-					}
-
-					// >= 3.0
-
-					let data;
-
-					try {
-
-						data = JSON.parse( contents );
-
-					} catch ( error ) {
-
-						alert( error );
-						return;
-
-					}
-
-					handleJSON( data );
-
-				}, false );
-				reader.readAsText( file );
-
-				break;
-
-			}
-
-			case 'kmz':
-
-			{
-
-				reader.addEventListener( 'load', async function ( event ) {
-
-					const { KMZLoader } = await import( 'three/addons/loaders/KMZLoader.js' );
-
-					const loader = new KMZLoader();
-					const collada = loader.parse( event.target.result );
-
-					collada.scene.name = filename;
-
-					editor.execute( new AddObjectCommand( editor, collada.scene ) );
-
-				}, false );
-				reader.readAsArrayBuffer( file );
-
-				break;
-
-			}
-
-			case 'ldr':
-			case 'mpd':
-
-			{
-
-				reader.addEventListener( 'load', async function ( event ) {
-
-					const { LDrawLoader } = await import( 'three/addons/loaders/LDrawLoader.js' );
-
-					const loader = new LDrawLoader();
-					loader.setPath( '../../examples/models/ldraw/officialLibrary/' );
-					loader.parse( event.target.result, function ( group ) {
-
-						group.name = filename;
-						// Convert from LDraw coordinates: rotate 180 degrees around OX
-						group.rotation.x = Math.PI;
-
-						editor.execute( new AddObjectCommand( editor, group ) );
-
-					} );
-
-				}, false );
-				reader.readAsText( file );
-
-				break;
-
-			}
-
-			case 'md2':
-
-			{
-
-				reader.addEventListener( 'load', async function ( event ) {
-
-					const contents = event.target.result;
-
-					const { MD2Loader } = await import( 'three/addons/loaders/MD2Loader.js' );
-
-					const geometry = new MD2Loader().parse( contents );
-					const material = new THREE.MeshStandardMaterial();
-
-					const mesh = new THREE.Mesh( geometry, material );
-					mesh.mixer = new THREE.AnimationMixer( mesh );
-					mesh.name = filename;
-
-					mesh.animations.push( ...geometry.animations );
-					editor.execute( new AddObjectCommand( editor, mesh ) );
-
-				}, false );
-				reader.readAsArrayBuffer( file );
-
-				break;
-
-			}
-
-			case 'obj':
-
-			{
-
-				reader.addEventListener( 'load', async function ( event ) {
-
-					const contents = event.target.result;
-
-					const { OBJLoader } = await import( 'three/addons/loaders/OBJLoader.js' );
-
-					const object = new OBJLoader().parse( contents );
 					object.name = filename;
 
 					editor.execute( new AddObjectCommand( editor, object ) );
 
-				}, false );
-				reader.readAsText( file );
+				}, function ( error ) {
 
-				break;
+					console.error( error );
 
-			}
+				} );
 
-			case 'pcd':
+			}, false );
+			reader.readAsArrayBuffer( file );
 
-			{
+		};
 
-				reader.addEventListener( 'load', async function ( event ) {
+		fileHandlers[ '3ds' ] = function () {
 
-					const contents = event.target.result;
+			reader.addEventListener( 'load', async function ( event ) {
 
-					const { PCDLoader } = await import( 'three/addons/loaders/PCDLoader.js' );
+				const { TDSLoader } = await import( 'three/addons/loaders/TDSLoader.js' );
 
-					const points = new PCDLoader().parse( contents );
-					points.name = filename;
+				const loader = new TDSLoader();
+				const object = loader.parse( event.target.result );
 
-					editor.execute( new AddObjectCommand( editor, points ) );
+				editor.execute( new AddObjectCommand( editor, object ) );
 
-				}, false );
-				reader.readAsArrayBuffer( file );
+			}, false );
+			reader.readAsArrayBuffer( file );
 
-				break;
+		};
 
-			}
+		fileHandlers[ '3mf' ] = function () {
 
-			case 'ply':
+			reader.addEventListener( 'load', async function ( event ) {
 
-			{
+				const { ThreeMFLoader } = await import( 'three/addons/loaders/3MFLoader.js' );
 
-				reader.addEventListener( 'load', async function ( event ) {
+				const loader = new ThreeMFLoader();
+				const object = loader.parse( event.target.result );
 
-					const contents = event.target.result;
+				editor.execute( new AddObjectCommand( editor, object ) );
 
-					const { PLYLoader } = await import( 'three/addons/loaders/PLYLoader.js' );
+			}, false );
+			reader.readAsArrayBuffer( file );
 
-					const geometry = new PLYLoader().parse( contents );
+		};
+
+		fileHandlers[ 'amf' ] = function () {
+
+			reader.addEventListener( 'load', async function ( event ) {
+
+				const { AMFLoader } = await import( 'three/addons/loaders/AMFLoader.js' );
+
+				const loader = new AMFLoader();
+				const amfobject = loader.parse( event.target.result );
+
+				editor.execute( new AddObjectCommand( editor, amfobject ) );
+
+			}, false );
+			reader.readAsArrayBuffer( file );
+
+		};
+
+		fileHandlers[ 'dae' ] = function () {
+
+			reader.addEventListener( 'load', async function ( event ) {
+
+				const contents = event.target.result;
+
+				const { ColladaLoader } = await import( 'three/addons/loaders/ColladaLoader.js' );
+
+				const loader = new ColladaLoader( manager );
+				const collada = loader.parse( contents );
+
+				collada.scene.name = filename;
+
+				editor.execute( new AddObjectCommand( editor, collada.scene ) );
+
+			}, false );
+			reader.readAsText( file );
+
+		};
+
+		fileHandlers[ 'drc' ] = function () {
+
+			reader.addEventListener( 'load', async function ( event ) {
+
+				const contents = event.target.result;
+
+				const { DRACOLoader } = await import( 'three/addons/loaders/DRACOLoader.js' );
+
+				const loader = new DRACOLoader();
+				loader.setDecoderPath( '../examples/jsm/libs/draco/' );
+				loader.parse( contents, function ( geometry ) {
+
 					let object;
 
 					if ( geometry.index !== null ) {
@@ -527,258 +205,485 @@ function Loader( editor ) {
 
 					}
 
+					loader.dispose();
 					editor.execute( new AddObjectCommand( editor, object ) );
 
-				}, false );
-				reader.readAsArrayBuffer( file );
+				} );
 
-				break;
+			}, false );
+			reader.readAsArrayBuffer( file );
 
-			}
+		};
 
-			case 'stl':
+		fileHandlers[ 'fbx' ] = function () {
 
-			{
+			reader.addEventListener( 'load', async function ( event ) {
 
-				reader.addEventListener( 'load', async function ( event ) {
+				const contents = event.target.result;
 
-					const contents = event.target.result;
+				const { FBXLoader } = await import( 'three/addons/loaders/FBXLoader.js' );
 
-					const { STLLoader } = await import( 'three/addons/loaders/STLLoader.js' );
+				const loader = new FBXLoader( manager );
+				const object = loader.parse( contents );
 
-					const geometry = new STLLoader().parse( contents );
-					const material = new THREE.MeshStandardMaterial();
+				editor.execute( new AddObjectCommand( editor, object ) );
 
-					const mesh = new THREE.Mesh( geometry, material );
-					mesh.name = filename;
+			}, false );
+			reader.readAsArrayBuffer( file );
 
-					editor.execute( new AddObjectCommand( editor, mesh ) );
+		};
 
-				}, false );
+		fileHandlers[ 'glb' ] = function () {
 
-				if ( reader.readAsBinaryString !== undefined ) {
+			reader.addEventListener( 'load', async function ( event ) {
 
-					reader.readAsBinaryString( file );
+				const contents = event.target.result;
 
-				} else {
+				const loader = await createGLTFLoader();
 
-					reader.readAsArrayBuffer( file );
+				loader.parse( contents, '', function ( result ) {
+
+					const scene = result.scene;
+					scene.name = filename;
+
+					scene.animations.push( ...result.animations );
+					editor.execute( new AddObjectCommand( editor, scene ) );
+
+					loader.dracoLoader.dispose();
+					loader.ktx2Loader.dispose();
+
+				} );
+
+			}, false );
+			reader.readAsArrayBuffer( file );
+
+		};
+
+		fileHandlers[ 'gltf' ] = function () {
+
+			reader.addEventListener( 'load', async function ( event ) {
+
+				const contents = event.target.result;
+
+				const loader = await createGLTFLoader( manager );
+
+				loader.parse( contents, '', function ( result ) {
+
+					const scene = result.scene;
+					scene.name = filename;
+
+					scene.animations.push( ...result.animations );
+					editor.execute( new AddObjectCommand( editor, scene ) );
+
+					loader.dracoLoader.dispose();
+					loader.ktx2Loader.dispose();
+
+				} );
+
+			}, false );
+			reader.readAsArrayBuffer( file );
+
+		};
+
+		fileHandlers[ 'js' ] = fileHandlers[ 'json' ] = function () {
+
+			reader.addEventListener( 'load', function ( event ) {
+
+				const contents = event.target.result;
+
+				// 2.0
+
+				if ( contents.indexOf( 'postMessage' ) !== - 1 ) {
+
+					const blob = new Blob( [ contents ], { type: 'text/javascript' } );
+					const url = URL.createObjectURL( blob );
+
+					const worker = new Worker( url );
+
+					worker.onmessage = function ( event ) {
+
+						event.data.metadata = { version: 2 };
+						handleJSON( event.data );
+
+					};
+
+					worker.postMessage( Date.now() );
+
+					return;
 
 				}
 
-				break;
+				// >= 3.0
 
-			}
+				let data;
 
-			case 'svg':
+				try {
 
-			{
+					data = JSON.parse( contents );
 
-				reader.addEventListener( 'load', async function ( event ) {
+				} catch ( error ) {
 
-					const contents = event.target.result;
+					alert( error );
+					return;
 
-					const { SVGLoader } = await import( 'three/addons/loaders/SVGLoader.js' );
+				}
 
-					const loader = new SVGLoader();
-					const paths = loader.parse( contents ).paths;
+				handleJSON( data );
 
-					//
+			}, false );
+			reader.readAsText( file );
 
-					const group = new THREE.Group();
-					group.scale.multiplyScalar( 0.1 );
-					group.scale.y *= - 1;
+		};
 
-					for ( let i = 0; i < paths.length; i ++ ) {
+		fileHandlers[ 'kmz' ] = function () {
 
-						const path = paths[ i ];
+			reader.addEventListener( 'load', async function ( event ) {
 
-						const material = new THREE.MeshBasicMaterial( {
-							color: path.color,
-							depthWrite: false
-						} );
+				const { KMZLoader } = await import( 'three/addons/loaders/KMZLoader.js' );
 
-						const shapes = SVGLoader.createShapes( path );
+				const loader = new KMZLoader();
+				const collada = loader.parse( event.target.result );
 
-						for ( let j = 0; j < shapes.length; j ++ ) {
+				collada.scene.name = filename;
 
-							const shape = shapes[ j ];
+				editor.execute( new AddObjectCommand( editor, collada.scene ) );
 
-							const geometry = new THREE.ShapeGeometry( shape );
-							const mesh = new THREE.Mesh( geometry, material );
+			}, false );
+			reader.readAsArrayBuffer( file );
 
-							group.add( mesh );
+		};
 
-						}
+		fileHandlers[ 'ldr' ] = fileHandlers[ 'mpd' ] = function () {
 
-					}
+			reader.addEventListener( 'load', async function ( event ) {
 
-					editor.execute( new AddObjectCommand( editor, group ) );
+				const { LDrawLoader } = await import( 'three/addons/loaders/LDrawLoader.js' );
 
-				}, false );
-				reader.readAsText( file );
+				const loader = new LDrawLoader();
+				loader.setPath( '../../examples/models/ldraw/officialLibrary/' );
+				loader.parse( event.target.result, function ( group ) {
 
-				break;
-
-			}
-
-			case 'usdz':
-
-			{
-
-				reader.addEventListener( 'load', async function ( event ) {
-
-					const contents = event.target.result;
-
-					const { USDZLoader } = await import( 'three/addons/loaders/USDZLoader.js' );
-
-					const group = new USDZLoader().parse( contents );
 					group.name = filename;
+					// Convert from LDraw coordinates: rotate 180 degrees around OX
+					group.rotation.x = Math.PI;
 
 					editor.execute( new AddObjectCommand( editor, group ) );
 
-				}, false );
+				} );
+
+			}, false );
+			reader.readAsText( file );
+
+		};
+
+		fileHandlers[ 'md2' ] = function () {
+
+			reader.addEventListener( 'load', async function ( event ) {
+
+				const contents = event.target.result;
+
+				const { MD2Loader } = await import( 'three/addons/loaders/MD2Loader.js' );
+
+				const geometry = new MD2Loader().parse( contents );
+				const material = new THREE.MeshStandardMaterial();
+
+				const mesh = new THREE.Mesh( geometry, material );
+				mesh.mixer = new THREE.AnimationMixer( mesh );
+				mesh.name = filename;
+
+				mesh.animations.push( ...geometry.animations );
+				editor.execute( new AddObjectCommand( editor, mesh ) );
+
+			}, false );
+			reader.readAsArrayBuffer( file );
+
+		};
+
+		fileHandlers[ 'obj' ] = function () {
+
+			reader.addEventListener( 'load', async function ( event ) {
+
+				const contents = event.target.result;
+
+				const { OBJLoader } = await import( 'three/addons/loaders/OBJLoader.js' );
+
+				const object = new OBJLoader().parse( contents );
+				object.name = filename;
+
+				editor.execute( new AddObjectCommand( editor, object ) );
+
+			}, false );
+			reader.readAsText( file );
+
+		};
+
+		fileHandlers[ 'pcd' ] = function () {
+
+			reader.addEventListener( 'load', async function ( event ) {
+
+				const contents = event.target.result;
+
+				const { PCDLoader } = await import( 'three/addons/loaders/PCDLoader.js' );
+
+				const points = new PCDLoader().parse( contents );
+				points.name = filename;
+
+				editor.execute( new AddObjectCommand( editor, points ) );
+
+			}, false );
+			reader.readAsArrayBuffer( file );
+
+		};
+
+		fileHandlers[ 'ply' ] = function () {
+
+			reader.addEventListener( 'load', async function ( event ) {
+
+				const contents = event.target.result;
+
+				const { PLYLoader } = await import( 'three/addons/loaders/PLYLoader.js' );
+
+				const geometry = new PLYLoader().parse( contents );
+				let object;
+
+				if ( geometry.index !== null ) {
+
+					const material = new THREE.MeshStandardMaterial();
+
+					object = new THREE.Mesh( geometry, material );
+					object.name = filename;
+
+				} else {
+
+					const material = new THREE.PointsMaterial( { size: 0.01 } );
+					material.vertexColors = geometry.hasAttribute( 'color' );
+
+					object = new THREE.Points( geometry, material );
+					object.name = filename;
+
+				}
+
+				editor.execute( new AddObjectCommand( editor, object ) );
+
+			}, false );
+			reader.readAsArrayBuffer( file );
+
+		};
+
+		fileHandlers[ 'stl' ] = function () {
+
+			reader.addEventListener( 'load', async function ( event ) {
+
+				const contents = event.target.result;
+
+				const { STLLoader } = await import( 'three/addons/loaders/STLLoader.js' );
+
+				const geometry = new STLLoader().parse( contents );
+				const material = new THREE.MeshStandardMaterial();
+
+				const mesh = new THREE.Mesh( geometry, material );
+				mesh.name = filename;
+
+				editor.execute( new AddObjectCommand( editor, mesh ) );
+
+			}, false );
+
+			if ( reader.readAsBinaryString !== undefined ) {
+
+				reader.readAsBinaryString( file );
+
+			} else {
+
 				reader.readAsArrayBuffer( file );
 
-				break;
-
 			}
 
-			case 'vox':
+		};
 
-			{
+		fileHandlers[ 'svg' ] = function () {
 
-				reader.addEventListener( 'load', async function ( event ) {
+			reader.addEventListener( 'load', async function ( event ) {
 
-					const contents = event.target.result;
+				const contents = event.target.result;
 
-					const { VOXLoader, VOXMesh } = await import( 'three/addons/loaders/VOXLoader.js' );
+				const { SVGLoader } = await import( 'three/addons/loaders/SVGLoader.js' );
 
-					const chunks = new VOXLoader().parse( contents );
+				const loader = new SVGLoader();
+				const paths = loader.parse( contents ).paths;
 
-					const group = new THREE.Group();
-					group.name = filename;
+				//
 
-					for ( let i = 0; i < chunks.length; i ++ ) {
+				const group = new THREE.Group();
+				group.scale.multiplyScalar( 0.1 );
+				group.scale.y *= - 1;
 
-						const chunk = chunks[ i ];
+				for ( let i = 0; i < paths.length; i ++ ) {
 
-						const mesh = new VOXMesh( chunk );
+					const path = paths[ i ];
+
+					const material = new THREE.MeshBasicMaterial( {
+						color: path.color,
+						depthWrite: false
+					} );
+
+					const shapes = SVGLoader.createShapes( path );
+
+					for ( let j = 0; j < shapes.length; j ++ ) {
+
+						const shape = shapes[ j ];
+
+						const geometry = new THREE.ShapeGeometry( shape );
+						const mesh = new THREE.Mesh( geometry, material );
+
 						group.add( mesh );
 
 					}
 
-					editor.execute( new AddObjectCommand( editor, group ) );
+				}
 
-				}, false );
-				reader.readAsArrayBuffer( file );
+				editor.execute( new AddObjectCommand( editor, group ) );
 
-				break;
+			}, false );
+			reader.readAsText( file );
 
-			}
+		};
 
-			case 'vtk':
-			case 'vtp':
+		fileHandlers[ 'usdz' ] = function () {
 
-			{
+			reader.addEventListener( 'load', async function ( event ) {
 
-				reader.addEventListener( 'load', async function ( event ) {
+				const contents = event.target.result;
 
-					const contents = event.target.result;
+				const { USDZLoader } = await import( 'three/addons/loaders/USDZLoader.js' );
 
-					const { VTKLoader } = await import( 'three/addons/loaders/VTKLoader.js' );
+				const group = new USDZLoader().parse( contents );
+				group.name = filename;
 
-					const geometry = new VTKLoader().parse( contents );
-					const material = new THREE.MeshStandardMaterial();
+				editor.execute( new AddObjectCommand( editor, group ) );
 
-					const mesh = new THREE.Mesh( geometry, material );
-					mesh.name = filename;
+			}, false );
+			reader.readAsArrayBuffer( file );
 
-					editor.execute( new AddObjectCommand( editor, mesh ) );
+		};
 
-				}, false );
-				reader.readAsArrayBuffer( file );
+		fileHandlers[ 'vox' ] = function () {
 
-				break;
+			reader.addEventListener( 'load', async function ( event ) {
 
-			}
+				const contents = event.target.result;
 
-			case 'wrl':
+				const { VOXLoader, VOXMesh } = await import( 'three/addons/loaders/VOXLoader.js' );
 
-			{
+				const chunks = new VOXLoader().parse( contents );
 
-				reader.addEventListener( 'load', async function ( event ) {
+				const group = new THREE.Group();
+				group.name = filename;
 
-					const contents = event.target.result;
+				for ( let i = 0; i < chunks.length; i ++ ) {
 
-					const { VRMLLoader } = await import( 'three/addons/loaders/VRMLLoader.js' );
+					const chunk = chunks[ i ];
 
-					const result = new VRMLLoader().parse( contents );
+					const mesh = new VOXMesh( chunk );
+					group.add( mesh );
 
-					editor.execute( new SetSceneCommand( editor, result ) );
+				}
 
-				}, false );
-				reader.readAsText( file );
+				editor.execute( new AddObjectCommand( editor, group ) );
 
-				break;
+			}, false );
+			reader.readAsArrayBuffer( file );
 
-			}
+		};
 
-			case 'xyz':
+		fileHandlers[ 'vtk' ] = fileHandlers[ 'vtp' ] = function () {
 
-			{
+			reader.addEventListener( 'load', async function ( event ) {
 
-				reader.addEventListener( 'load', async function ( event ) {
+				const contents = event.target.result;
 
-					const contents = event.target.result;
+				const { VTKLoader } = await import( 'three/addons/loaders/VTKLoader.js' );
 
-					const { XYZLoader } = await import( 'three/addons/loaders/XYZLoader.js' );
+				const geometry = new VTKLoader().parse( contents );
+				const material = new THREE.MeshStandardMaterial();
 
-					const geometry = new XYZLoader().parse( contents );
+				const mesh = new THREE.Mesh( geometry, material );
+				mesh.name = filename;
 
-					const material = new THREE.PointsMaterial();
-					material.vertexColors = geometry.hasAttribute( 'color' );
+				editor.execute( new AddObjectCommand( editor, mesh ) );
 
-					const points = new THREE.Points( geometry, material );
-					points.name = filename;
+			}, false );
+			reader.readAsArrayBuffer( file );
 
-					editor.execute( new AddObjectCommand( editor, points ) );
+		};
 
-				}, false );
-				reader.readAsText( file );
+		fileHandlers[ 'wrl' ] = function () {
 
-				break;
+			reader.addEventListener( 'load', async function ( event ) {
 
-			}
+				const contents = event.target.result;
 
-			case 'zip':
+				const { VRMLLoader } = await import( 'three/addons/loaders/VRMLLoader.js' );
 
-			{
+				const result = new VRMLLoader().parse( contents );
 
-				reader.addEventListener( 'load', function ( event ) {
+				editor.execute( new SetSceneCommand( editor, result ) );
 
-					handleZIP( event.target.result );
+			}, false );
+			reader.readAsText( file );
 
-				}, false );
-				reader.readAsArrayBuffer( file );
+		};
 
-				break;
+		fileHandlers[ 'xyz' ] = function () {
 
-			}
+			reader.addEventListener( 'load', async function ( event ) {
 
-			default:
+				const contents = event.target.result;
 
-				alert( [
+				const { XYZLoader } = await import( 'three/addons/loaders/XYZLoader.js' );
 
-					editor.strings.getKey( 'prompt/file/import/fail' ) + ': ' +
-					editor.strings.getKey( 'prompt/file/import/unsupportedFileFormat' ) + ' (' + extension + ')',
-					'',
-					editor.strings.getKey( 'prompt/file/import/supportedFileFormat' ) + ': ',
-					'3dm, 3ds, 3mf, amf, dae, drc, fbx, glb, gltf, js, json, kmz, ldr, mpd, md2, obj, pcd, ply, stl, svg, usdz, vtk, vtp, wrl, xyz, zip(fbx), zip(glb), zip(gltf), zip(obj)'
+				const geometry = new XYZLoader().parse( contents );
 
-				].join( '\n' ) );
+				const material = new THREE.PointsMaterial();
+				material.vertexColors = geometry.hasAttribute( 'color' );
 
-				break;
+				const points = new THREE.Points( geometry, material );
+				points.name = filename;
+
+				editor.execute( new AddObjectCommand( editor, points ) );
+
+			}, false );
+			reader.readAsText( file );
+
+		};
+
+		fileHandlers[ 'zip' ] = function () {
+
+			reader.addEventListener( 'load', function ( event ) {
+
+				handleZIP( event.target.result );
+
+			}, false );
+			reader.readAsArrayBuffer( file );
+
+		};
+
+		if ( extension in fileHandlers ) {
+
+			fileHandlers[ extension ]();
+
+		} else {
+
+			const supportedFormats = Object.keys( fileHandlers ).sort();
+
+			alert( [
+
+				editor.strings.getKey( 'prompt/file/import/fail' ) + ': ' +
+				editor.strings.getKey( 'prompt/file/import/unsupportedFileFormat' ) + ' (' + extension + ')',
+				'',
+				editor.strings.getKey( 'prompt/file/import/supportedFileFormat' ) + ': ',
+				supportedFormats.join( ', ' )
+
+			].join( '\n' ) );
 
 		}
 

--- a/editor/js/Loader.js
+++ b/editor/js/Loader.js
@@ -768,7 +768,15 @@ function Loader( editor ) {
 
 			default:
 
-				console.error( 'Unsupported file format (' + extension + ').' );
+				alert( [
+
+					editor.strings.getKey( 'prompt/file/import/fail' ) + ': ' +
+					editor.strings.getKey( 'prompt/file/import/unsupportedFileFormat' ) + ' (' + extension + ')',
+					'',
+					editor.strings.getKey( 'prompt/file/import/supportedFileFormat' ) + ': ',
+					'3dm, 3ds, 3mf, amf, dae, drc, fbx, glb, gltf, js, json, kmz, ldr, mpd, md2, obj, pcd, ply, stl, svg, usdz, vtk, vtp, wrl, xyz, zip(fbx), zip(glb), zip(gltf), zip(obj)'
+
+				].join( '\n' ) );
 
 				break;
 

--- a/editor/js/Strings.js
+++ b/editor/js/Strings.js
@@ -7,6 +7,9 @@ function Strings( config ) {
 		en: {
 
 			'prompt/file/open': 'Any unsaved data will be lost. Are you sure?',
+			'prompt/file/import/fail': 'Failed to import file',
+			'prompt/file/import/supportedFileFormat': 'Supported file formats',
+			'prompt/file/import/unsupportedFileFormat': 'Unsupported file format',
 			'prompt/file/export/noMeshSelected': 'No Mesh selected!',
 			'prompt/file/export/noObjectSelected': 'No Object selected!',
 			'prompt/script/remove': 'Are you sure?',
@@ -394,6 +397,9 @@ function Strings( config ) {
 		fr: {
 
 			'prompt/file/open': 'Toutes les données non enregistrées seront perdues Êtes-vous sûr ?',
+			'prompt/file/import/fail': 'Echec de l’importation du fichier',
+			'prompt/file/import/supportedFileFormat': 'Formats de fichiers pris en charge',
+			'prompt/file/import/unsupportedFileFormat': 'Format de fichier non pris en charge',
 			'prompt/file/export/noMeshSelected': 'Aucun maillage sélectionné !',
 			'prompt/file/export/noObjectSelected': 'Aucun objet sélectionné !',
 			'prompt/script/remove': 'Es-tu sûr?',
@@ -781,6 +787,9 @@ function Strings( config ) {
 		zh: {
 
 			'prompt/file/open': '您确定吗？未保存的数据将会丢失。',
+			'prompt/file/import/fail': '导入文件失败',
+			'prompt/file/import/supportedFileFormat': '支持的文件格式',
+			'prompt/file/import/unsupportedFileFormat': '不支持的文件格式',
 			'prompt/file/export/noMeshSelected': '未选择网格！',
 			'prompt/file/export/noObjectSelected': '未选择对象！',
 			'prompt/script/remove': '你确定吗？',
@@ -1168,6 +1177,9 @@ function Strings( config ) {
 		ja: {
 
 			'prompt/file/open': '保存されていないデータは失われます。 本気ですか？',
+			'prompt/file/import/fail': 'ファイルのインポートに失敗しました',
+			'prompt/file/import/supportedFileFormat': 'サポートされているファイル形式',
+			'prompt/file/import/unsupportedFileFormat': 'サポートされていないファイル形式です',
 			'prompt/file/export/noMeshSelected': 'メッシュが選択されていません!',
 			'prompt/file/export/noObjectSelected': 'オブジェクトが選択されていません!',
 			'prompt/script/remove': '本気ですか？',


### PR DESCRIPTION
This PR `alert` users that if `File>Import` failed, it'll prompt the reason and hint, for example IFC support is currently removed from loader, so editor will alert like this:

![import failed](https://github.com/mrdoob/three.js/assets/1063018/5e6165f3-3393-4840-adef-3c22c78cee72)

Preview: https://raw.githack.com/ycw/three.js/editor-prompt-failed-to-import/editor/index.html