### PR TITLE
Editor: Fixed viewport camera selector out of sync

### DIFF
--- a/editor/js/Viewport.Controls.js
+++ b/editor/js/Viewport.Controls.js
@@ -46,6 +46,15 @@ function ViewportControls( editor ) {
 
 	signals.cameraAdded.add( update );
 	signals.cameraRemoved.add( update );
+	signals.objectChanged.add( function ( object ) {
+
+		if ( object.isCamera ) {
+
+			update();
+
+		}
+
+	} );
 
 	// shading
 


### PR DESCRIPTION
The issue: camera selector in viewport doesn't reflect camera changes (renaming/deletion):

https://github.com/mrdoob/three.js/assets/1063018/01574c30-2a91-4aff-8a9d-20884211edef

This PR fixed that by re-rendering the camera selector on `objectChanged`:

https://github.com/mrdoob/three.js/assets/1063018/c69644e1-396e-4860-8247-0e8bbf2fb438

Preview: https://raw.githack.com/ycw/three.js/editor-viewport-controls-cameras-insync/editor/index.html
