### PR TITLE
Editor: Set cursor to `not-allowed` for inactive menubar options

### DIFF
--- a/editor/css/main.css
+++ b/editor/css/main.css
@@ -402,6 +402,7 @@ select {
 			background-color: transparent;
 			padding: 5px 10px;
 			margin: 0 !important;
+			cursor: not-allowed;
 		}
 
 #sidebar {


### PR DESCRIPTION
Hovering on inactive options in menubar should show `not-allowed` cursor instead of `pointer` cursor

Preview: https://raw.githack.com/ycw/three.js/editor-menubar-cursor-not-allowed/editor/index.html
