### PR TITLE
Editor: Fixed missing unit in background rotation control

### DIFF
--- a/editor/js/libs/ui.js
+++ b/editor/js/libs/ui.js
@@ -782,6 +782,8 @@ class UINumber extends UIElement {
 
 		this.unit = unit;
 
+		this.setValue( this.value );
+
 		return this;
 
 	}


### PR DESCRIPTION
The issue: `backgroundRotation` control doesn't initialize its value with the supplied unit '°':
![not show background rotation unit](https://github.com/mrdoob/three.js/assets/1063018/0bfd8aa6-d796-455f-85d2-2a5b95383e3d)

This PR fixed that by ~dispatching an artificial `change` event right after initializing~ updating value in `setUnit()`:
![show background rotation unit](https://github.com/mrdoob/three.js/assets/1063018/07adfd25-eff7-4ef9-996a-902dcdaf731d)
