### PR TITLE
Editor: Fixed uncaught exception when environment/background combination is illegal

### DIFF
--- a/editor/js/Sidebar.Scene.js
+++ b/editor/js/Sidebar.Scene.js
@@ -424,7 +424,11 @@ function SidebarScene( editor ) {
 
 		if ( scene.environment ) {
 
-			if ( scene.environment.mapping === THREE.EquirectangularReflectionMapping ) {
+			if ( scene.background && scene.background.isTexture && scene.background.uuid === scene.environment.uuid ) {
+
+				environmentType.setValue( 'Background' );
+
+			} else if ( scene.environment.mapping === THREE.EquirectangularReflectionMapping ) {
 
 				environmentType.setValue( 'Equirectangular' );
 				environmentEquirectangularTexture.setValue( scene.environment );
@@ -558,6 +562,17 @@ function SidebarScene( editor ) {
 		} else {
 
 			outliner.setValue( null );
+
+		}
+
+	} );
+
+	signals.sceneBackgroundChanged.add( function () {
+
+		if ( environmentType.getValue() === 'Background' ) {
+
+			onEnvironmentChanged();
+			refreshEnvironmentUI();
 
 		}
 

--- a/editor/js/Viewport.js
+++ b/editor/js/Viewport.js
@@ -538,9 +538,13 @@ function Viewport( editor ) {
 
 				useBackgroundAsEnvironment = true;
 
-				scene.environment = scene.background;
-				scene.environment.mapping = THREE.EquirectangularReflectionMapping;
-				scene.environmentRotation.y = scene.backgroundRotation.y;
+				if ( scene.background !== null && scene.background.isTexture ) {
+
+					scene.environment = scene.background;
+					scene.environment.mapping = THREE.EquirectangularReflectionMapping;
+					scene.environmentRotation.y = scene.backgroundRotation.y;
+
+				}
 
 				break;
 


### PR DESCRIPTION
The issues: 

1. Currently it causes error when environment is BACKGROUND and background is not TEXTURE|EQUIRECT; If it happens, users have no clue about the failure because the error is only shown in console: ![image](https://github.com/mrdoob/three.js/assets/1063018/8f492f86-dd5a-4598-8af7-2b94bef42e0c)

2. Environment will be unlinked from background when recovering from IndexedDB, i.e. environment can never be 'BACKGROUND' after recovering.

~This PR fixed 1 by checking If environment/background combination is illegal, then highlight the environment selector in UI~ 

~https://github.com/mrdoob/three.js/assets/1063018/4aa0f62a-8166-400d-a767-25859eef1e18~

This PR fixed 1 by handling exception of illegal combinations.

This PR fixed 2 by checking if environment.uuid is equal to background.uuid, then set environment value to `BACKGROUND` 

Preview: https://raw.githack.com/ycw/three.js/editor-handle-scene-env-exception/editor/index.html



