### PR TITLE
Docs: Add WebGLRenderer.initRenderTarget docs

### DIFF
--- a/docs/api/en/renderers/WebGLRenderer.html
+++ b/docs/api/en/renderers/WebGLRenderer.html
@@ -493,6 +493,13 @@ document.body.appendChild( renderer.domElement );
 			and GPU upload overhead).
 		</p>
 
+		<h3>[method:undefined initRenderTarget]( [param:WebGLRenderTarget target] )</h3>
+		<p>
+			Initializes the given WebGLRenderTarget memory. Useful for initializing a render
+			target so data can be copied into it using [page:WebGLRenderer.copyTextureToTexture .copyTextureToTexture]
+			before it has been rendered to.
+		</p>
+
 		<h3>[method:undefined resetGLState]( )</h3>
 		<p>
 			Reset the GL state to default. Called internally if the WebGL context is


### PR DESCRIPTION
Related issue: #28285

**Description**

Add docs for the newly added `initRenderTarget` function.

_This contribution is funded by the [Cesium GIS Ecosystem Grant](https://cesium.com/cesium-ecosystem-grants/grant-directory/)_