### PR TITLE
Editor: Fixed camera name is always 'Camera' when recovering from indexedDB

### DIFF
--- a/editor/js/Viewport.Controls.js
+++ b/editor/js/Viewport.Controls.js
@@ -77,6 +77,12 @@ function ViewportControls( editor ) {
 
 	} );
 
+	signals.cameraResetted.add( function () {
+
+		update();
+
+	} );
+
 	update();
 
 	//

--- a/editor/js/Viewport.Controls.js
+++ b/editor/js/Viewport.Controls.js
@@ -77,11 +77,7 @@ function ViewportControls( editor ) {
 
 	} );
 
-	signals.cameraResetted.add( function () {
-
-		update();
-
-	} );
+	signals.cameraResetted.add( update );
 
 	update();
 


### PR DESCRIPTION
The issue: Camera name in **viewport camera selector** is always 'Camera' (default camera's default name) when recovering from indexedDB, this is a problem when users renamed the default camera; It happens only in a special case that when the scene is empty, since there's no objects in the scene, editor won't dispatch objectChanged nor cameraAdded, while these signals are listened by Viewport.Controls for re-rendering its UI.

The solution: Let Viewport.Controls listens one more signal, `cameraResetted`, [dispatched from `editor.fromJSON()`](https://github.com/mrdoob/three.js/blob/0e01940a39fab5d8d1fac0e8b10f0397fd665082/editor/js/Editor.js#L657-L663), then re-render UI on `cameraResetted`

To reproduce the issue:

1. Go to https://raw.githack.com/mrdoob/three.js/dev/editor/index.html
2. Press File>New
3. Renames the default camera to 'Camera123'
4. Refresh the page
5. You should see 'Camera123' in outliner and 'Camera' in viewport camera selector 
