### PR TITLE
Editor: Added submenu navigation

### DIFF
--- a/editor/css/main.css
+++ b/editor/css/main.css
@@ -367,13 +367,14 @@ select {
 			display: none;
 			padding: 5px 0;
 			background: #eee;
-			width: 150px;
-			max-height: calc(100% - 80px);
+			min-width: 150px;
+			max-height: calc(100vh - 80px);
 			overflow: auto;
 		}
 
 		#menubar .menu:hover .options {
 			display: block;
+			box-shadow: 0 5px 10px -5px #000;
 		}
 
 			#menubar .menu .options hr {
@@ -395,6 +396,11 @@ select {
 				#menubar .menu .options .option:active {
 					color: #666;
 					background: transparent;
+				}
+
+				#menubar .submenu-title::after {
+					content: '>';
+					float: right;
 				}
 
 		#menubar .menu .options .inactive {
@@ -533,7 +539,7 @@ select {
 	}
 
 	#menubar .menu .options {
-		max-height: calc(100% - 372px);
+		max-height: calc(100% - 80px);
 	}
 
 	#menubar .menu.right {

--- a/editor/js/Menubar.Add.js
+++ b/editor/js/Menubar.Add.js
@@ -42,26 +42,26 @@ function MenubarAdd( editor ) {
 
 	//
 
-	const addGeometryRow = new UIRow().setTextContent( strings.getKey( 'menubar/add/mesh' ) ).addClass( 'option' ).addClass( 'submenu-title' );
-	addGeometryRow.onMouseOver( function () {
+	const meshSubmenuTitleRow = new UIRow().setTextContent( strings.getKey( 'menubar/add/mesh' ) ).addClass( 'option' ).addClass( 'submenu-title' );
+	meshSubmenuTitleRow.onMouseOver( function () {
 
-		const { top, right } = addGeometryRow.dom.getBoundingClientRect();
+		const { top, right } = meshSubmenuTitleRow.dom.getBoundingClientRect();
 		const { paddingTop } = getComputedStyle( this.dom );
-		addGeometryPanel.setLeft( right + 'px' );
-		addGeometryPanel.setTop( top - parseFloat( paddingTop ) + 'px' );
-		addGeometryPanel.setStyle( 'max-height', [ `calc( 100vh - ${top}px )` ] );
-		addGeometryPanel.setDisplay( 'block' );
+		meshSubmenuPanel.setLeft( right + 'px' );
+		meshSubmenuPanel.setTop( top - parseFloat( paddingTop ) + 'px' );
+		meshSubmenuPanel.setStyle( 'max-height', [ `calc( 100vh - ${top}px )` ] );
+		meshSubmenuPanel.setDisplay( 'block' );
 
 	} );
-	addGeometryRow.onMouseOut( function () {
+	meshSubmenuTitleRow.onMouseOut( function () {
 
-		addGeometryPanel.setDisplay( 'none' );
+		meshSubmenuPanel.setDisplay( 'none' );
 
 	} );
-	options.add( addGeometryRow );
+	options.add( meshSubmenuTitleRow );
 
-	const addGeometryPanel = new UIPanel().setPosition( 'fixed' ).addClass( 'options' ).setDisplay( 'none' );
-	addGeometryRow.add( addGeometryPanel );
+	const meshSubmenuPanel = new UIPanel().setPosition( 'fixed' ).addClass( 'options' ).setDisplay( 'none' );
+	meshSubmenuTitleRow.add( meshSubmenuPanel );
 
 	// Box
 
@@ -77,7 +77,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
-	addGeometryPanel.add( option );
+	meshSubmenuPanel.add( option );
 
 	// Capsule
 
@@ -94,7 +94,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
-	addGeometryPanel.add( option );
+	meshSubmenuPanel.add( option );
 
 	// Circle
 
@@ -110,7 +110,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
-	addGeometryPanel.add( option );
+	meshSubmenuPanel.add( option );
 
 	// Cylinder
 
@@ -126,7 +126,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
-	addGeometryPanel.add( option );
+	meshSubmenuPanel.add( option );
 
 	// Dodecahedron
 
@@ -142,7 +142,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
-	addGeometryPanel.add( option );
+	meshSubmenuPanel.add( option );
 
 	// Icosahedron
 
@@ -158,7 +158,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
-	addGeometryPanel.add( option );
+	meshSubmenuPanel.add( option );
 
 	// Lathe
 
@@ -174,7 +174,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
-	addGeometryPanel.add( option );
+	meshSubmenuPanel.add( option );
 
 	// Octahedron
 
@@ -190,7 +190,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
-	addGeometryPanel.add( option );
+	meshSubmenuPanel.add( option );
 
 	// Plane
 
@@ -207,7 +207,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
-	addGeometryPanel.add( option );
+	meshSubmenuPanel.add( option );
 
 	// Ring
 
@@ -223,7 +223,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
-	addGeometryPanel.add( option );
+	meshSubmenuPanel.add( option );
 
 	// Sphere
 
@@ -239,7 +239,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
-	addGeometryPanel.add( option );
+	meshSubmenuPanel.add( option );
 
 	// Sprite
 
@@ -254,7 +254,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, sprite ) );
 
 	} );
-	addGeometryPanel.add( option );
+	meshSubmenuPanel.add( option );
 
 	// Tetrahedron
 
@@ -270,7 +270,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
-	addGeometryPanel.add( option );
+	meshSubmenuPanel.add( option );
 
 	// Torus
 
@@ -286,7 +286,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
-	addGeometryPanel.add( option );
+	meshSubmenuPanel.add( option );
 
 	// TorusKnot
 
@@ -302,7 +302,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
-	addGeometryPanel.add( option );
+	meshSubmenuPanel.add( option );
 
 	// Tube
 
@@ -325,7 +325,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
-	addGeometryPanel.add( option );
+	meshSubmenuPanel.add( option );
 
 	//
 

--- a/editor/js/Menubar.Add.js
+++ b/editor/js/Menubar.Add.js
@@ -40,28 +40,28 @@ function MenubarAdd( editor ) {
 	options.add( new UIHorizontalRule() );
 
 
-	//
+	// Mesh (submenu)
 
-	const meshSubmenuTitleRow = new UIRow().setTextContent( strings.getKey( 'menubar/add/mesh' ) ).addClass( 'option' ).addClass( 'submenu-title' );
-	meshSubmenuTitleRow.onMouseOver( function () {
+	const meshSubmenuTitle = new UIRow().setTextContent( strings.getKey( 'menubar/add/mesh' ) ).addClass( 'option' ).addClass( 'submenu-title' );
+	meshSubmenuTitle.onMouseOver( function () {
 
-		const { top, right } = meshSubmenuTitleRow.dom.getBoundingClientRect();
+		const { top, right } = meshSubmenuTitle.dom.getBoundingClientRect();
 		const { paddingTop } = getComputedStyle( this.dom );
-		meshSubmenuPanel.setLeft( right + 'px' );
-		meshSubmenuPanel.setTop( top - parseFloat( paddingTop ) + 'px' );
-		meshSubmenuPanel.setStyle( 'max-height', [ `calc( 100vh - ${top}px )` ] );
-		meshSubmenuPanel.setDisplay( 'block' );
+		meshSubmenu.setLeft( right + 'px' );
+		meshSubmenu.setTop( top - parseFloat( paddingTop ) + 'px' );
+		meshSubmenu.setStyle( 'max-height', [ `calc( 100vh - ${top}px )` ] );
+		meshSubmenu.setDisplay( 'block' );
 
 	} );
-	meshSubmenuTitleRow.onMouseOut( function () {
+	meshSubmenuTitle.onMouseOut( function () {
 
-		meshSubmenuPanel.setDisplay( 'none' );
+		meshSubmenu.setDisplay( 'none' );
 
 	} );
-	options.add( meshSubmenuTitleRow );
+	options.add( meshSubmenuTitle );
 
-	const meshSubmenuPanel = new UIPanel().setPosition( 'fixed' ).addClass( 'options' ).setDisplay( 'none' );
-	meshSubmenuTitleRow.add( meshSubmenuPanel );
+	const meshSubmenu = new UIPanel().setPosition( 'fixed' ).addClass( 'options' ).setDisplay( 'none' );
+	meshSubmenuTitle.add( meshSubmenu );
 
 	// Box
 
@@ -77,7 +77,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
-	meshSubmenuPanel.add( option );
+	meshSubmenu.add( option );
 
 	// Capsule
 
@@ -94,7 +94,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
-	meshSubmenuPanel.add( option );
+	meshSubmenu.add( option );
 
 	// Circle
 
@@ -110,7 +110,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
-	meshSubmenuPanel.add( option );
+	meshSubmenu.add( option );
 
 	// Cylinder
 
@@ -126,7 +126,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
-	meshSubmenuPanel.add( option );
+	meshSubmenu.add( option );
 
 	// Dodecahedron
 
@@ -142,7 +142,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
-	meshSubmenuPanel.add( option );
+	meshSubmenu.add( option );
 
 	// Icosahedron
 
@@ -158,7 +158,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
-	meshSubmenuPanel.add( option );
+	meshSubmenu.add( option );
 
 	// Lathe
 
@@ -174,7 +174,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
-	meshSubmenuPanel.add( option );
+	meshSubmenu.add( option );
 
 	// Octahedron
 
@@ -190,7 +190,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
-	meshSubmenuPanel.add( option );
+	meshSubmenu.add( option );
 
 	// Plane
 
@@ -207,7 +207,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
-	meshSubmenuPanel.add( option );
+	meshSubmenu.add( option );
 
 	// Ring
 
@@ -223,7 +223,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
-	meshSubmenuPanel.add( option );
+	meshSubmenu.add( option );
 
 	// Sphere
 
@@ -239,7 +239,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
-	meshSubmenuPanel.add( option );
+	meshSubmenu.add( option );
 
 	// Sprite
 
@@ -254,7 +254,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, sprite ) );
 
 	} );
-	meshSubmenuPanel.add( option );
+	meshSubmenu.add( option );
 
 	// Tetrahedron
 
@@ -270,7 +270,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
-	meshSubmenuPanel.add( option );
+	meshSubmenu.add( option );
 
 	// Torus
 
@@ -286,7 +286,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
-	meshSubmenuPanel.add( option );
+	meshSubmenu.add( option );
 
 	// TorusKnot
 
@@ -302,7 +302,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
-	meshSubmenuPanel.add( option );
+	meshSubmenu.add( option );
 
 	// Tube
 
@@ -325,7 +325,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
-	meshSubmenuPanel.add( option );
+	meshSubmenu.add( option );
 
 	//
 

--- a/editor/js/Menubar.Add.js
+++ b/editor/js/Menubar.Add.js
@@ -39,6 +39,30 @@ function MenubarAdd( editor ) {
 
 	options.add( new UIHorizontalRule() );
 
+
+	//
+
+	const addGeometryRow = new UIRow().setTextContent( strings.getKey( 'menubar/add/mesh' ) ).addClass( 'option' ).addClass( 'submenu-title' );
+	addGeometryRow.onMouseOver( function () {
+
+		const { top, right } = addGeometryRow.dom.getBoundingClientRect();
+		const { paddingTop } = getComputedStyle( this.dom );
+		addGeometryPanel.setLeft( right + 'px' );
+		addGeometryPanel.setTop( top - parseFloat( paddingTop ) + 'px' );
+		addGeometryPanel.setStyle( 'max-height', [ `calc( 100vh - ${top}px )` ] );
+		addGeometryPanel.setDisplay( 'block' );
+
+	} );
+	addGeometryRow.onMouseOut( function () {
+
+		addGeometryPanel.setDisplay( 'none' );
+
+	} );
+	options.add( addGeometryRow );
+
+	const addGeometryPanel = new UIPanel().setPosition( 'fixed' ).addClass( 'options' ).setDisplay( 'none' );
+	addGeometryRow.add( addGeometryPanel );
+
 	// Box
 
 	option = new UIRow();
@@ -53,7 +77,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
-	options.add( option );
+	addGeometryPanel.add( option );
 
 	// Capsule
 
@@ -70,7 +94,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
-	options.add( option );
+	addGeometryPanel.add( option );
 
 	// Circle
 
@@ -86,7 +110,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
-	options.add( option );
+	addGeometryPanel.add( option );
 
 	// Cylinder
 
@@ -102,7 +126,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
-	options.add( option );
+	addGeometryPanel.add( option );
 
 	// Dodecahedron
 
@@ -118,7 +142,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
-	options.add( option );
+	addGeometryPanel.add( option );
 
 	// Icosahedron
 
@@ -134,7 +158,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
-	options.add( option );
+	addGeometryPanel.add( option );
 
 	// Lathe
 
@@ -150,7 +174,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
-	options.add( option );
+	addGeometryPanel.add( option );
 
 	// Octahedron
 
@@ -166,7 +190,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
-	options.add( option );
+	addGeometryPanel.add( option );
 
 	// Plane
 
@@ -183,7 +207,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
-	options.add( option );
+	addGeometryPanel.add( option );
 
 	// Ring
 
@@ -199,7 +223,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
-	options.add( option );
+	addGeometryPanel.add( option );
 
 	// Sphere
 
@@ -215,7 +239,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
-	options.add( option );
+	addGeometryPanel.add( option );
 
 	// Sprite
 
@@ -230,7 +254,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, sprite ) );
 
 	} );
-	options.add( option );
+	addGeometryPanel.add( option );
 
 	// Tetrahedron
 
@@ -246,7 +270,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
-	options.add( option );
+	addGeometryPanel.add( option );
 
 	// Torus
 
@@ -262,7 +286,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
-	options.add( option );
+	addGeometryPanel.add( option );
 
 	// TorusKnot
 
@@ -278,7 +302,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
-	options.add( option );
+	addGeometryPanel.add( option );
 
 	// Tube
 
@@ -301,7 +325,7 @@ function MenubarAdd( editor ) {
 		editor.execute( new AddObjectCommand( editor, mesh ) );
 
 	} );
-	options.add( option );
+	addGeometryPanel.add( option );
 
 	//
 

--- a/editor/js/Menubar.File.js
+++ b/editor/js/Menubar.File.js
@@ -70,6 +70,29 @@ function MenubarFile( editor ) {
 
 	options.add( new UIHorizontalRule() );
 
+
+	//
+
+	const fileExportRow = new UIRow().setTextContent( strings.getKey( 'menubar/file/export' ) ).addClass( 'option' ).addClass( 'submenu-title' );
+	fileExportRow.onMouseOver( function () {
+
+		const { top, right } = this.dom.getBoundingClientRect();
+		const { paddingTop } = getComputedStyle( this.dom );
+		fileExportPanel.setLeft( right + 'px' );
+		fileExportPanel.setTop( top - parseFloat( paddingTop ) + 'px' );
+		fileExportPanel.setDisplay( 'block' );
+
+	} );
+	fileExportRow.onMouseOut( function () {
+
+		fileExportPanel.setDisplay( 'none' );
+
+	} );
+	options.add( fileExportRow );
+
+	const fileExportPanel = new UIPanel().setPosition( 'fixed' ).addClass( 'options' ).setDisplay( 'none' );
+	fileExportRow.add( fileExportPanel );
+
 	// Export DRC
 
 	option = new UIRow();
@@ -105,7 +128,7 @@ function MenubarFile( editor ) {
 		saveArrayBuffer( result, 'model.drc' );
 
 	} );
-	options.add( option );
+	fileExportPanel.add( option );
 
 	// Export GLB
 
@@ -136,7 +159,7 @@ function MenubarFile( editor ) {
 		}, undefined, { binary: true, animations: optimizedAnimations } );
 
 	} );
-	options.add( option );
+	fileExportPanel.add( option );
 
 	// Export GLTF
 
@@ -168,7 +191,7 @@ function MenubarFile( editor ) {
 
 
 	} );
-	options.add( option );
+	fileExportPanel.add( option );
 
 	// Export OBJ
 
@@ -193,7 +216,7 @@ function MenubarFile( editor ) {
 		saveString( exporter.parse( object ), 'model.obj' );
 
 	} );
-	options.add( option );
+	fileExportPanel.add( option );
 
 	// Export PLY (ASCII)
 
@@ -213,7 +236,7 @@ function MenubarFile( editor ) {
 		} );
 
 	} );
-	options.add( option );
+	fileExportPanel.add( option );
 
 	// Export PLY (Binary)
 
@@ -233,7 +256,7 @@ function MenubarFile( editor ) {
 		}, { binary: true } );
 
 	} );
-	options.add( option );
+	fileExportPanel.add( option );
 
 	// Export STL (ASCII)
 
@@ -249,7 +272,7 @@ function MenubarFile( editor ) {
 		saveString( exporter.parse( editor.scene ), 'model.stl' );
 
 	} );
-	options.add( option );
+	fileExportPanel.add( option );
 
 	// Export STL (Binary)
 
@@ -265,7 +288,7 @@ function MenubarFile( editor ) {
 		saveArrayBuffer( exporter.parse( editor.scene, { binary: true } ), 'model-binary.stl' );
 
 	} );
-	options.add( option );
+	fileExportPanel.add( option );
 
 	// Export USDZ
 
@@ -281,7 +304,7 @@ function MenubarFile( editor ) {
 		saveArrayBuffer( await exporter.parseAsync( editor.scene ), 'model.usdz' );
 
 	} );
-	options.add( option );
+	fileExportPanel.add( option );
 
 	//
 

--- a/editor/js/Menubar.File.js
+++ b/editor/js/Menubar.File.js
@@ -73,25 +73,25 @@ function MenubarFile( editor ) {
 
 	//
 
-	const fileExportRow = new UIRow().setTextContent( strings.getKey( 'menubar/file/export' ) ).addClass( 'option' ).addClass( 'submenu-title' );
-	fileExportRow.onMouseOver( function () {
+	const fileExportSubmenuTitleRow = new UIRow().setTextContent( strings.getKey( 'menubar/file/export' ) ).addClass( 'option' ).addClass( 'submenu-title' );
+	fileExportSubmenuTitleRow.onMouseOver( function () {
 
 		const { top, right } = this.dom.getBoundingClientRect();
 		const { paddingTop } = getComputedStyle( this.dom );
-		fileExportPanel.setLeft( right + 'px' );
-		fileExportPanel.setTop( top - parseFloat( paddingTop ) + 'px' );
-		fileExportPanel.setDisplay( 'block' );
+		fileExportSubmenuPanel.setLeft( right + 'px' );
+		fileExportSubmenuPanel.setTop( top - parseFloat( paddingTop ) + 'px' );
+		fileExportSubmenuPanel.setDisplay( 'block' );
 
 	} );
-	fileExportRow.onMouseOut( function () {
+	fileExportSubmenuTitleRow.onMouseOut( function () {
 
-		fileExportPanel.setDisplay( 'none' );
+		fileExportSubmenuPanel.setDisplay( 'none' );
 
 	} );
-	options.add( fileExportRow );
+	options.add( fileExportSubmenuTitleRow );
 
-	const fileExportPanel = new UIPanel().setPosition( 'fixed' ).addClass( 'options' ).setDisplay( 'none' );
-	fileExportRow.add( fileExportPanel );
+	const fileExportSubmenuPanel = new UIPanel().setPosition( 'fixed' ).addClass( 'options' ).setDisplay( 'none' );
+	fileExportSubmenuTitleRow.add( fileExportSubmenuPanel );
 
 	// Export DRC
 
@@ -128,7 +128,7 @@ function MenubarFile( editor ) {
 		saveArrayBuffer( result, 'model.drc' );
 
 	} );
-	fileExportPanel.add( option );
+	fileExportSubmenuPanel.add( option );
 
 	// Export GLB
 
@@ -159,7 +159,7 @@ function MenubarFile( editor ) {
 		}, undefined, { binary: true, animations: optimizedAnimations } );
 
 	} );
-	fileExportPanel.add( option );
+	fileExportSubmenuPanel.add( option );
 
 	// Export GLTF
 
@@ -191,7 +191,7 @@ function MenubarFile( editor ) {
 
 
 	} );
-	fileExportPanel.add( option );
+	fileExportSubmenuPanel.add( option );
 
 	// Export OBJ
 
@@ -216,7 +216,7 @@ function MenubarFile( editor ) {
 		saveString( exporter.parse( object ), 'model.obj' );
 
 	} );
-	fileExportPanel.add( option );
+	fileExportSubmenuPanel.add( option );
 
 	// Export PLY (ASCII)
 
@@ -236,7 +236,7 @@ function MenubarFile( editor ) {
 		} );
 
 	} );
-	fileExportPanel.add( option );
+	fileExportSubmenuPanel.add( option );
 
 	// Export PLY (Binary)
 
@@ -256,7 +256,7 @@ function MenubarFile( editor ) {
 		}, { binary: true } );
 
 	} );
-	fileExportPanel.add( option );
+	fileExportSubmenuPanel.add( option );
 
 	// Export STL (ASCII)
 
@@ -272,7 +272,7 @@ function MenubarFile( editor ) {
 		saveString( exporter.parse( editor.scene ), 'model.stl' );
 
 	} );
-	fileExportPanel.add( option );
+	fileExportSubmenuPanel.add( option );
 
 	// Export STL (Binary)
 
@@ -288,7 +288,7 @@ function MenubarFile( editor ) {
 		saveArrayBuffer( exporter.parse( editor.scene, { binary: true } ), 'model-binary.stl' );
 
 	} );
-	fileExportPanel.add( option );
+	fileExportSubmenuPanel.add( option );
 
 	// Export USDZ
 
@@ -304,7 +304,7 @@ function MenubarFile( editor ) {
 		saveArrayBuffer( await exporter.parseAsync( editor.scene ), 'model.usdz' );
 
 	} );
-	fileExportPanel.add( option );
+	fileExportSubmenuPanel.add( option );
 
 	//
 

--- a/editor/js/Menubar.File.js
+++ b/editor/js/Menubar.File.js
@@ -71,27 +71,27 @@ function MenubarFile( editor ) {
 	options.add( new UIHorizontalRule() );
 
 
-	//
+	// Export (submenu)
 
-	const fileExportSubmenuTitleRow = new UIRow().setTextContent( strings.getKey( 'menubar/file/export' ) ).addClass( 'option' ).addClass( 'submenu-title' );
-	fileExportSubmenuTitleRow.onMouseOver( function () {
+	const fileExportSubmenuTitle = new UIRow().setTextContent( strings.getKey( 'menubar/file/export' ) ).addClass( 'option' ).addClass( 'submenu-title' );
+	fileExportSubmenuTitle.onMouseOver( function () {
 
 		const { top, right } = this.dom.getBoundingClientRect();
 		const { paddingTop } = getComputedStyle( this.dom );
-		fileExportSubmenuPanel.setLeft( right + 'px' );
-		fileExportSubmenuPanel.setTop( top - parseFloat( paddingTop ) + 'px' );
-		fileExportSubmenuPanel.setDisplay( 'block' );
+		fileExportSubmenu.setLeft( right + 'px' );
+		fileExportSubmenu.setTop( top - parseFloat( paddingTop ) + 'px' );
+		fileExportSubmenu.setDisplay( 'block' );
 
 	} );
-	fileExportSubmenuTitleRow.onMouseOut( function () {
+	fileExportSubmenuTitle.onMouseOut( function () {
 
-		fileExportSubmenuPanel.setDisplay( 'none' );
+		fileExportSubmenu.setDisplay( 'none' );
 
 	} );
-	options.add( fileExportSubmenuTitleRow );
+	options.add( fileExportSubmenuTitle );
 
-	const fileExportSubmenuPanel = new UIPanel().setPosition( 'fixed' ).addClass( 'options' ).setDisplay( 'none' );
-	fileExportSubmenuTitleRow.add( fileExportSubmenuPanel );
+	const fileExportSubmenu = new UIPanel().setPosition( 'fixed' ).addClass( 'options' ).setDisplay( 'none' );
+	fileExportSubmenuTitle.add( fileExportSubmenu );
 
 	// Export DRC
 
@@ -128,7 +128,7 @@ function MenubarFile( editor ) {
 		saveArrayBuffer( result, 'model.drc' );
 
 	} );
-	fileExportSubmenuPanel.add( option );
+	fileExportSubmenu.add( option );
 
 	// Export GLB
 
@@ -159,7 +159,7 @@ function MenubarFile( editor ) {
 		}, undefined, { binary: true, animations: optimizedAnimations } );
 
 	} );
-	fileExportSubmenuPanel.add( option );
+	fileExportSubmenu.add( option );
 
 	// Export GLTF
 
@@ -191,7 +191,7 @@ function MenubarFile( editor ) {
 
 
 	} );
-	fileExportSubmenuPanel.add( option );
+	fileExportSubmenu.add( option );
 
 	// Export OBJ
 
@@ -216,7 +216,7 @@ function MenubarFile( editor ) {
 		saveString( exporter.parse( object ), 'model.obj' );
 
 	} );
-	fileExportSubmenuPanel.add( option );
+	fileExportSubmenu.add( option );
 
 	// Export PLY (ASCII)
 
@@ -236,7 +236,7 @@ function MenubarFile( editor ) {
 		} );
 
 	} );
-	fileExportSubmenuPanel.add( option );
+	fileExportSubmenu.add( option );
 
 	// Export PLY (Binary)
 
@@ -256,7 +256,7 @@ function MenubarFile( editor ) {
 		}, { binary: true } );
 
 	} );
-	fileExportSubmenuPanel.add( option );
+	fileExportSubmenu.add( option );
 
 	// Export STL (ASCII)
 
@@ -272,7 +272,7 @@ function MenubarFile( editor ) {
 		saveString( exporter.parse( editor.scene ), 'model.stl' );
 
 	} );
-	fileExportSubmenuPanel.add( option );
+	fileExportSubmenu.add( option );
 
 	// Export STL (Binary)
 
@@ -288,7 +288,7 @@ function MenubarFile( editor ) {
 		saveArrayBuffer( exporter.parse( editor.scene, { binary: true } ), 'model-binary.stl' );
 
 	} );
-	fileExportSubmenuPanel.add( option );
+	fileExportSubmenu.add( option );
 
 	// Export USDZ
 
@@ -304,7 +304,7 @@ function MenubarFile( editor ) {
 		saveArrayBuffer( await exporter.parseAsync( editor.scene ), 'model.usdz' );
 
 	} );
-	fileExportSubmenuPanel.add( option );
+	fileExportSubmenu.add( option );
 
 	//
 

--- a/editor/js/Strings.js
+++ b/editor/js/Strings.js
@@ -40,6 +40,7 @@ function Strings( config ) {
 			'menubar/file': 'File',
 			'menubar/file/new': 'New',
 			'menubar/file/import': 'Import',
+			'menubar/file/export': 'Export',
 			'menubar/file/export/drc': 'Export DRC',
 			'menubar/file/export/glb': 'Export GLB',
 			'menubar/file/export/gltf': 'Export GLTF',
@@ -59,6 +60,7 @@ function Strings( config ) {
 
 			'menubar/add': 'Add',
 			'menubar/add/group': 'Group',
+			'menubar/add/mesh': 'Mesh',
 			'menubar/add/plane': 'Plane',
 			'menubar/add/box': 'Box',
 			'menubar/add/capsule': 'Capsule',
@@ -427,6 +429,7 @@ function Strings( config ) {
 			'menubar/file': 'Fichier',
 			'menubar/file/new': 'Nouveau',
 			'menubar/file/import': 'Importer',
+			'menubar/file/export': 'Exporter',
 			'menubar/file/export/drc': 'Exporter DRC',
 			'menubar/file/export/glb': 'Exporter GLB',
 			'menubar/file/export/gltf': 'Exporter GLTF',
@@ -446,6 +449,7 @@ function Strings( config ) {
 
 			'menubar/add': 'Ajouter',
 			'menubar/add/group': 'Groupe',
+			'menubar/add/mesh': 'Maille',
 			'menubar/add/plane': 'Plan',
 			'menubar/add/box': 'Cube',
 			'menubar/add/capsule': 'Capsule',
@@ -814,6 +818,7 @@ function Strings( config ) {
 			'menubar/file': '文件',
 			'menubar/file/new': '新建',
 			'menubar/file/import': '导入',
+			'menubar/file/export': '导出',
 			'menubar/file/export/drc': '导出DRC',
 			'menubar/file/export/glb': '导出GLB',
 			'menubar/file/export/gltf': '导出GLTF',
@@ -833,6 +838,7 @@ function Strings( config ) {
 
 			'menubar/add': '添加',
 			'menubar/add/group': '组',
+			'menubar/add/mesh': '网格',
 			'menubar/add/plane': '平面',
 			'menubar/add/box': '正方体',
 			'menubar/add/capsule': '胶囊',
@@ -1201,6 +1207,7 @@ function Strings( config ) {
 			'menubar/file': 'ファイル',
 			'menubar/file/new': '新規',
 			'menubar/file/import': 'インポート',
+			'menubar/file/export': 'エクスポート',
 			'menubar/file/export/drc': 'エクスポート DRC',
 			'menubar/file/export/glb': 'エクスポート GLB',
 			'menubar/file/export/gltf': 'エクスポート GLTF',
@@ -1220,6 +1227,7 @@ function Strings( config ) {
 
 			'menubar/add': '追加',
 			'menubar/add/group': 'グループ',
+			'menubar/add/mesh': 'メッシュ',
 			'menubar/add/plane': '平面',
 			'menubar/add/box': '直方体',
 			'menubar/add/capsule': 'カプセル',


### PR DESCRIPTION
Related: #28284

This PR added submenu navigation

- Added box-shadow to menu and submenu for more popover-ish
- Localized the submenu titles 
- Can close #28284

https://github.com/mrdoob/three.js/assets/1063018/6f6a5cb5-1d37-4864-9a24-379244245562



Preview: https://raw.githack.com/ycw/three.js/editor-submenu/editor/index.html
