### PR TITLE
SkeletonHelper: add optional AxesHelpers for each bone

### DIFF
--- a/docs/api/en/helpers/SkeletonHelper.html
+++ b/docs/api/en/helpers/SkeletonHelper.html
@@ -33,10 +33,20 @@
 
 		<h2>Constructor</h2>
 
-		<h3>[name]( [param:Object3D object] )</h3>
+		<h3>[name]( [param:Object3D object], [param:Object options] )</h3>
 		<p>
 			object -- Usually an instance of [page:SkinnedMesh]. However, any instance
 			of [page:Object3D] can be used if it represents a hierarchy of [page:Bone Bone]s (via [page:Object3D.children]).
+		</p>
+
+		<p>
+			options -- Optional, an object with the following properties:<br />
+
+			<ul>
+				<li>
+					axesHelperSize - number - If greater than 0, an [page:AxesHelper] with the given size will be shown for each bone to aid in visual debugging. Defaults to 0.<br />
+				</li>
+			</ul>
 		</p>
 
 		<h2>Properties</h2>

--- a/docs/scenes/bones-browser.html
+++ b/docs/scenes/bones-browser.html
@@ -184,7 +184,7 @@
 
 				mesh.bind( skeleton );
 
-				skeletonHelper = new SkeletonHelper( mesh );
+				skeletonHelper = new SkeletonHelper( mesh, { axesHelperSize: 1.5 } );
 				skeletonHelper.material.linewidth = 2;
 				scene.add( skeletonHelper );
 

--- a/docs/scenes/ccdiksolver-browser.html
+++ b/docs/scenes/ccdiksolver-browser.html
@@ -197,7 +197,7 @@
 
 				mesh.bind( skeleton );
 
-				skeletonHelper = new SkeletonHelper( mesh );
+				skeletonHelper = new SkeletonHelper( mesh, { axesHelperSize: 2 } );
 				skeletonHelper.material.linewidth = 2;
 				scene.add( skeletonHelper );
 

--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -433,11 +433,13 @@ Editor.prototype = {
 
 				} else if ( object.isSkinnedMesh ) {
 
-					helper = new THREE.SkeletonHelper( object.skeleton.bones[ 0 ] );
+					// Note, axes helper size is not known, depends on object size. TODO: Calculate it automatically.
+					helper = new THREE.SkeletonHelper( object.skeleton.bones[ 0 ], { axesHelperSize: 0 } );
 
 				} else if ( object.isBone === true && object.parent && object.parent.isBone !== true ) {
 
-					helper = new THREE.SkeletonHelper( object );
+					// Note, axes helper size is not known, depends on object size. TODO: Calculate it automatically.
+					helper = new THREE.SkeletonHelper( object, { axesHelperSize: 0 } );
 
 				} else {
 

--- a/examples/webgl_animation_skinning_additive_blending.html
+++ b/examples/webgl_animation_skinning_additive_blending.html
@@ -104,7 +104,7 @@
 
 					} );
 
-					skeleton = new THREE.SkeletonHelper( model );
+					skeleton = new THREE.SkeletonHelper( model, { axesHelperSize: 5 } );
 					skeleton.visible = false;
 					scene.add( skeleton );
 

--- a/examples/webgl_animation_skinning_blending.html
+++ b/examples/webgl_animation_skinning_blending.html
@@ -103,7 +103,7 @@
 
 					//
 
-					skeleton = new THREE.SkeletonHelper( model );
+					skeleton = new THREE.SkeletonHelper( model, { axesHelperSize: 5 } );
 					skeleton.visible = false;
 					scene.add( skeleton );
 

--- a/examples/webgl_loader_bvh.html
+++ b/examples/webgl_loader_bvh.html
@@ -47,7 +47,7 @@
 			const loader = new BVHLoader();
 			loader.load( 'models/bvh/pirouette.bvh', function ( result ) {
 
-				const skeletonHelper = new THREE.SkeletonHelper( result.skeleton.bones[ 0 ] );
+				const skeletonHelper = new THREE.SkeletonHelper( result.skeleton.bones[ 0 ], { axesHelperSize: 5 } );
 
 				scene.add( result.skeleton.bones[ 0 ] );
 				scene.add( skeletonHelper );
@@ -76,8 +76,10 @@
 				document.body.appendChild( renderer.domElement );
 
 				controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 300;
+				controls.target = new THREE.Vector3( 0, 50, 0 );
+				controls.minDistance = 100;
 				controls.maxDistance = 700;
+				controls.update();
 
 				window.addEventListener( 'resize', onWindowResize );
 

--- a/src/helpers/SkeletonHelper.js
+++ b/src/helpers/SkeletonHelper.js
@@ -5,6 +5,7 @@ import { Color } from '../math/Color.js';
 import { Vector3 } from '../math/Vector3.js';
 import { BufferGeometry } from '../core/BufferGeometry.js';
 import { Float32BufferAttribute } from '../core/BufferAttribute.js';
+import { AxesHelper } from './AxesHelper.js';
 
 const _vector = /*@__PURE__*/ new Vector3();
 const _boneMatrix = /*@__PURE__*/ new Matrix4();
@@ -13,7 +14,7 @@ const _matrixWorldInv = /*@__PURE__*/ new Matrix4();
 
 class SkeletonHelper extends LineSegments {
 
-	constructor( object ) {
+	constructor( object, options = { axesHelperSize: 0 } ) {
 
 		const bones = getBoneList( object );
 
@@ -21,6 +22,7 @@ class SkeletonHelper extends LineSegments {
 
 		const vertices = [];
 		const colors = [];
+		const axesHelpers = [];
 
 		const color1 = new Color( 0, 0, 1 );
 		const color2 = new Color( 0, 1, 0 );
@@ -35,6 +37,16 @@ class SkeletonHelper extends LineSegments {
 				vertices.push( 0, 0, 0 );
 				colors.push( color1.r, color1.g, color1.b );
 				colors.push( color2.r, color2.g, color2.b );
+
+			}
+
+			if ( options.axesHelperSize > 0 ) {
+
+				const helper = new AxesHelper( options.axesHelperSize );
+				helper.material = new LineBasicMaterial( { vertexColors: true, depthTest: false, depthWrite: false, toneMapped: false, transparent: true } );
+				helper.updateMatrixWorld = () => {}; // disable it, we do it here in this class.
+
+				axesHelpers.push( helper );
 
 			}
 
@@ -53,6 +65,9 @@ class SkeletonHelper extends LineSegments {
 
 		this.root = object;
 		this.bones = bones;
+
+		for ( const helper of axesHelpers ) this.add( helper );
+		this.axesHelpers = axesHelpers;
 
 		this.matrix = object.matrixWorld;
 		this.matrixAutoUpdate = false;
@@ -86,6 +101,15 @@ class SkeletonHelper extends LineSegments {
 
 			}
 
+			const hasAxesHelpers = !! this.axesHelpers.length;
+
+			if ( hasAxesHelpers ) {
+
+				const helper = this.axesHelpers[ i ];
+				helper.matrixWorld.copy( bone.matrixWorld );
+
+			}
+
 		}
 
 		geometry.getAttribute( 'position' ).needsUpdate = true;
@@ -98,6 +122,7 @@ class SkeletonHelper extends LineSegments {
 
 		this.geometry.dispose();
 		this.material.dispose();
+		for ( const helper of this.axesHelpers ) helper.dispose();
 
 	}
 

--- a/test/unit/src/helpers/SkeletonHelper.tests.js
+++ b/test/unit/src/helpers/SkeletonHelper.tests.js
@@ -25,8 +25,12 @@ export default QUnit.module( 'Helpers', () => {
 		QUnit.test( 'Instancing', ( assert ) => {
 
 			const bone = new Bone();
-			const object = new SkeletonHelper( bone );
+			bone.add( new Bone() );
+			let object = new SkeletonHelper( bone );
 			assert.ok( object, 'Can instantiate a SkeletonHelper.' );
+			assert.ok( object.axesHelpers.length === 0, 'No axes helpers unless a non-zero size is specified.' );
+			object = new SkeletonHelper( bone, { axesHelperSize: 1 } );
+			assert.ok( object.axesHelpers.length === 2, 'Axes helpers are created per bone when a non-zero size is specified.' );
 
 		} );
 


### PR DESCRIPTION
Related issue: 

- #25751 (axes helpers will help debugging animation/retargeting issues with bone transforms)

**Description**

Adds an options paramters to `SkeletonHelper` with a property `axesHelperSize` that when greater than zero will show AxesHelpers of the given size for each bone.

**Screenshots**

<img width="493" alt="Screenshot 2024-05-08 at 1 18 03 AM" src="https://github.com/mrdoob/three.js/assets/297678/fe486b8a-73e4-4f72-9ace-985145ea626f">
<img width="539" alt="Screenshot 2024-05-08 at 1 18 43 AM" src="https://github.com/mrdoob/three.js/assets/297678/7defb140-0ae1-4d3d-870a-2a5ae747525a">
<img width="431" alt="Screenshot 2024-05-08 at 1 19 48 AM" src="https://github.com/mrdoob/three.js/assets/297678/f069a205-c3f0-4176-bdca-5c474d81e6f6">


<img width="814" alt="Screenshot 2024-05-08 at 1 43 14 AM" src="https://github.com/mrdoob/three.js/assets/297678/458d7c7f-37b7-415b-bb60-e2c1e2f00779">

Do you prefer a single `axesHelperSize` number parameter instead of an options object parameter? And do you prefer a different name than `axesHelperSize`?

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Lume, 3D HTML](https://lume.io)*
