### PR TITLE
Editor: Fixed gizmo not update when switching local/global space

### DIFF
--- a/editor/js/Viewport.js
+++ b/editor/js/Viewport.js
@@ -292,6 +292,8 @@ function Viewport( editor ) {
 
 		transformControls.setSpace( space );
 
+		render();
+
 	} );
 
 	signals.rendererUpdated.add( function () {


### PR DESCRIPTION
The issu: Currently when users toggle local space in viewport's toolbar, the gizmo doesn't re-render until users' pointer hovered it once.

This PR fixed that by re-rendering the scene on `spaceChanged`:

https://github.com/mrdoob/three.js/assets/1063018/1ea69cf2-a8f7-42b4-8dfe-0aab2d8f82a7

Preview: https://raw.githack.com/ycw/three.js/editor-update-gizmo-immediately/editor/index.html
 


