### PR TITLE
Editor: Fixed selected object unselected when recovering

### DIFF
--- a/editor/index.html
+++ b/editor/index.html
@@ -106,13 +106,13 @@
 
 			editor.storage.init( function () {
 
-				editor.storage.get( function ( state ) {
+				editor.storage.get( async function ( state ) {
 
 					if ( isLoadingFromHash ) return;
 
 					if ( state !== undefined ) {
 
-						editor.fromJSON( state );
+						await editor.fromJSON( state );
 
 					}
 


### PR DESCRIPTION
The issue: The selected **scene object** in outliner becomes unselected when recovering

To reproduce:

1. Select a **scene object** in outliner
2. Refresh the page
3. You should see nothing is being selected in outliner

This cause: "Restoring selected object" `editor.selectByUuid()` should follow "Restoring the editor" `editor.fromJSON()`,  however, `editor.fromJSON()` returns a promise which ... isn't be awaited ... , so the order is reversed and failed as expected.

This PR fixed that by simply awaiting the `editor.fromJSON()` .
