### PR TITLE
Examples: Revert usage of `setAnimationLoop()`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,22 +89,12 @@ jobs:
       - name: === E2E testing ===
         run: npm run test-e2e
       - name: Upload output screenshots
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4
+        uses: actions/upload-artifact@v3
         if: always()
         with:
           name: Output screenshots-${{ matrix.os }}-${{ matrix.CI }}
           path: test/e2e/output-screenshots
           if-no-files-found: ignore
-
-  merge:
-    runs-on: ${{ matrix.os }}
-    needs: [ e2e ]
-    steps:
-      - name: Merge Artifacts
-        uses: actions/upload-artifact/merge@v4
-        with:
-          name: artifacts
-          pattern:  Output screenshots-*
 
   e2e-cov:
     name: Examples ready for release

--- a/examples/games_fps.html
+++ b/examples/games_fps.html
@@ -71,7 +71,6 @@
 			const renderer = new THREE.WebGLRenderer( { antialias: true } );
 			renderer.setPixelRatio( window.devicePixelRatio );
 			renderer.setSize( window.innerWidth, window.innerHeight );
-			renderer.setAnimationLoop( animate );
 			renderer.shadowMap.enabled = true;
 			renderer.shadowMap.type = THREE.VSMShadowMap;
 			renderer.toneMapping = THREE.ACESFilmicToneMapping;
@@ -443,7 +442,9 @@
 						helper.visible = value;
 
 					} );
-			
+
+				animate();
+
 			} );
 
 			function teleportPlayerIfOob() {
@@ -483,6 +484,8 @@
 				renderer.render( scene, camera );
 
 				stats.update();
+
+				requestAnimationFrame( animate );
 
 			}
 

--- a/examples/misc_animation_groups.html
+++ b/examples/misc_animation_groups.html
@@ -31,6 +31,7 @@
 			let scene, camera, renderer, mixer;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -96,7 +97,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				//
@@ -124,6 +124,14 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
+
+				render();
+
+			}
+
+			function render() {
 
 				const delta = clock.getDelta();
 

--- a/examples/misc_animation_keys.html
+++ b/examples/misc_animation_keys.html
@@ -31,6 +31,7 @@
 			let scene, camera, renderer, mixer;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -96,7 +97,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				//
@@ -124,6 +124,14 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
+
+				render();
+
+			}
+
+			function render() {
 
 				const delta = clock.getDelta();
 

--- a/examples/misc_boxselection.html
+++ b/examples/misc_boxselection.html
@@ -51,6 +51,7 @@
 			let camera, scene, renderer;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -105,7 +106,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.shadowMap.enabled = true;
 				renderer.shadowMap.type = THREE.PCFShadowMap;
 
@@ -131,9 +131,16 @@
 
 			function animate() {
 
-				renderer.render( scene, camera );
+				requestAnimationFrame( animate );
 
+				render();
 				stats.update();
+
+			}
+
+			function render() {
+
+				renderer.render( scene, camera );
 
 			}
 

--- a/examples/misc_controls_fly.html
+++ b/examples/misc_controls_fly.html
@@ -73,6 +73,7 @@
 			const clock = new THREE.Clock();
 
 			init();
+			animate();
 
 			function init() {
 
@@ -200,7 +201,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( SCREEN_WIDTH, SCREEN_HEIGHT );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				//
@@ -248,6 +248,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/misc_controls_map.html
+++ b/examples/misc_controls_map.html
@@ -42,7 +42,8 @@
 			let camera, controls, scene, renderer;
 
 			init();
-			//render(); // remove when using animation loop
+			//render(); // remove when using next line for animation loop (requestAnimationFrame)
+			animate();
 
 			function init() {
 
@@ -53,7 +54,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				camera = new THREE.PerspectiveCamera( 60, window.innerWidth / window.innerHeight, 1, 1000 );
@@ -130,6 +130,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				controls.update(); // only required if controls.enableDamping = true, or if controls.autoRotate = true
 

--- a/examples/misc_controls_orbit.html
+++ b/examples/misc_controls_orbit.html
@@ -40,7 +40,8 @@
 			let camera, controls, scene, renderer;
 
 			init();
-			//render(); // remove when using animation loop
+			//render(); // remove when using next line for animation loop (requestAnimationFrame)
+			animate();
 
 			function init() {
 
@@ -51,7 +52,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				camera = new THREE.PerspectiveCamera( 60, window.innerWidth / window.innerHeight, 1, 1000 );
@@ -120,6 +120,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				controls.update(); // only required if controls.enableDamping = true, or if controls.autoRotate = true
 

--- a/examples/misc_controls_pointerlock.html
+++ b/examples/misc_controls_pointerlock.html
@@ -76,6 +76,7 @@
 			const color = new THREE.Color();
 
 			init();
+			animate();
 
 			function init() {
 
@@ -259,7 +260,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				//
@@ -278,6 +278,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				const time = performance.now();
 

--- a/examples/misc_controls_trackball.html
+++ b/examples/misc_controls_trackball.html
@@ -49,6 +49,7 @@
 			const frustumSize = 400;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -99,7 +100,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				stats = new Stats();
@@ -157,11 +157,13 @@
 
 			function animate() {
 
+				requestAnimationFrame( animate );
+
 				controls.update();
 
-				render();
-
 				stats.update();
+
+				render();
 
 			}
 

--- a/examples/misc_exporter_draco.html
+++ b/examples/misc_exporter_draco.html
@@ -37,6 +37,7 @@
 			};
 
 			init();
+			animate();
 
 			function init() {
 
@@ -90,7 +91,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.shadowMap.enabled = true;
 				document.body.appendChild( renderer.domElement );
 
@@ -123,6 +123,7 @@
 
 			function animate() {
 
+				requestAnimationFrame( animate );
 				renderer.render( scene, camera );
 
 			}

--- a/examples/misc_exporter_exr.html
+++ b/examples/misc_exporter_exr.html
@@ -39,13 +39,13 @@
 			};
 
 			init();
+			animate();
 
 			function init() {
 
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				//
@@ -109,6 +109,7 @@
 
 			function animate() {
 
+				requestAnimationFrame( animate );
 				controls.update();
 				renderer.render( scene, camera );
 

--- a/examples/misc_exporter_gltf.html
+++ b/examples/misc_exporter_gltf.html
@@ -114,6 +114,7 @@
 			};
 
 			init();
+			animate();
 
 			function init() {
 
@@ -463,7 +464,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				renderer.toneMappingExposure = 1;
 
@@ -572,6 +572,14 @@
 
 			function animate() {
 
+				requestAnimationFrame( animate );
+
+				render();
+
+			}
+
+			function render() {
+
 				const timer = Date.now() * 0.0001;
 
 				camera.position.x = Math.cos( timer ) * 800;
@@ -581,8 +589,6 @@
 				renderer.render( scene1, camera );
 
 			}
-
-
 
 		</script>
 

--- a/examples/misc_exporter_obj.html
+++ b/examples/misc_exporter_obj.html
@@ -41,13 +41,13 @@
 			};
 
 			init();
+			animate();
 
 			function init() {
 
-				renderer = new THREE.WebGLRenderer( { antialias: true } );
+				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				camera = new THREE.PerspectiveCamera( 70, window.innerWidth / window.innerHeight, 1, 1000 );
@@ -239,6 +239,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				renderer.render( scene, camera );
 

--- a/examples/misc_exporter_ply.html
+++ b/examples/misc_exporter_ply.html
@@ -37,6 +37,7 @@
 			};
 
 			init();
+			animate();
 
 			function init() {
 
@@ -102,7 +103,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.shadowMap.enabled = true;
 				document.body.appendChild( renderer.domElement );
 
@@ -136,6 +136,7 @@
 
 			function animate() {
 
+				requestAnimationFrame( animate );
 				renderer.render( scene, camera );
 
 			}

--- a/examples/misc_exporter_stl.html
+++ b/examples/misc_exporter_stl.html
@@ -36,6 +36,7 @@
 			};
 
 			init();
+			animate();
 
 			function init() {
 
@@ -90,7 +91,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.shadowMap.enabled = true;
 				document.body.appendChild( renderer.domElement );
 
@@ -123,6 +123,7 @@
 
 			function animate() {
 
+				requestAnimationFrame( animate );
 				renderer.render( scene, camera );
 
 			}

--- a/examples/misc_lookat.html
+++ b/examples/misc_lookat.html
@@ -46,6 +46,8 @@
 			document.addEventListener( 'mousemove', onDocumentMouseMove );
 
 			init();
+			animate();
+
 
 			function init() {
 
@@ -77,7 +79,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				stats = new Stats();
@@ -111,6 +112,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/physics_ammo_break.html
+++ b/examples/physics_ammo_break.html
@@ -86,6 +86,7 @@
 			Ammo = AmmoLib;
 
 			init();
+			animate();
 
 		} );
 
@@ -118,7 +119,6 @@
 			renderer = new THREE.WebGLRenderer( { antialias: true } );
 			renderer.setPixelRatio( window.devicePixelRatio );
 			renderer.setSize( window.innerWidth, window.innerHeight );
-			renderer.setAnimationLoop( animate );
 			renderer.shadowMap.enabled = true;
 			container.appendChild( renderer.domElement );
 
@@ -430,6 +430,8 @@
 		}
 
 		function animate() {
+
+			requestAnimationFrame( animate );
 
 			render();
 			stats.update();

--- a/examples/physics_ammo_cloth.html
+++ b/examples/physics_ammo_cloth.html
@@ -55,6 +55,7 @@
 				Ammo = AmmoLib;
 
 				init();
+				animate();
 
 			} );
 
@@ -85,7 +86,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.shadowMap.enabled = true;
 				container.appendChild( renderer.domElement );
 
@@ -395,6 +395,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/physics_ammo_instancing.html
+++ b/examples/physics_ammo_instancing.html
@@ -119,7 +119,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.shadowMap.enabled = true;
 				document.body.appendChild( renderer.domElement );
 
@@ -131,6 +130,8 @@
 				const controls = new OrbitControls( camera, renderer.domElement );
 				controls.target.y = 0.5;
 				controls.update();
+
+				animate();
 
 				setInterval( () => {
 
@@ -151,6 +152,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				renderer.render( scene, camera );
 

--- a/examples/physics_ammo_rope.html
+++ b/examples/physics_ammo_rope.html
@@ -59,6 +59,7 @@
 			Ammo = AmmoLib;
 
 			init();
+			animate();
 
 		} );
 
@@ -88,7 +89,6 @@
 			renderer = new THREE.WebGLRenderer( { antialias: true } );
 			renderer.setPixelRatio( window.devicePixelRatio );
 			renderer.setSize( window.innerWidth, window.innerHeight );
-			renderer.setAnimationLoop( animate );
 			renderer.shadowMap.enabled = true;
 			container.appendChild( renderer.domElement );
 
@@ -418,6 +418,8 @@
 		}
 
 		function animate() {
+
+			requestAnimationFrame( animate );
 
 			render();
 			stats.update();

--- a/examples/physics_ammo_terrain.html
+++ b/examples/physics_ammo_terrain.html
@@ -72,6 +72,7 @@
 				Ammo = AmmoLib;
 
 				init();
+				animate();
 
 			} );
 
@@ -92,7 +93,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.shadowMap.enabled = true;
 				container.appendChild( renderer.domElement );
 
@@ -390,6 +390,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/physics_ammo_volume.html
+++ b/examples/physics_ammo_volume.html
@@ -63,6 +63,7 @@
 				Ammo = AmmoLib;
 
 				init();
+				animate();
 
 			} );
 
@@ -92,7 +93,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.shadowMap.enabled = true;
 				container.appendChild( renderer.domElement );
 
@@ -413,6 +413,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/physics_jolt_instancing.html
+++ b/examples/physics_jolt_instancing.html
@@ -117,7 +117,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.shadowMap.enabled = true;
 				document.body.appendChild( renderer.domElement );
 
@@ -129,6 +128,8 @@
 				const controls = new OrbitControls( camera, renderer.domElement );
 				controls.target.y = 0.5;
 				controls.update();
+
+				animate();
 
 				setInterval( () => {
 
@@ -149,6 +150,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				renderer.render( scene, camera );
 

--- a/examples/physics_rapier_instancing.html
+++ b/examples/physics_rapier_instancing.html
@@ -117,7 +117,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.shadowMap.enabled = true;
 				document.body.appendChild( renderer.domElement );
 
@@ -129,6 +128,8 @@
 				const controls = new OrbitControls( camera, renderer.domElement );
 				controls.target.y = 0.5;
 				controls.update();
+
+				animate();
 
 				setInterval( () => {
 
@@ -149,6 +150,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				renderer.render( scene, camera );
 

--- a/examples/tags.json
+++ b/examples/tags.json
@@ -6,7 +6,6 @@
 	"misc_controls_trackball": [ "rotation" ],
 	"misc_controls_transform": [ "scale", "rotate", "translate" ],
 	"physics_ammo_cloth": [ "integration" ],
-	"physics_jolt_instancing": [ "external" ],
 	"physics_rapier_instancing": [ "external" ],
 	"webgl_clipping": [ "solid" ],
 	"webgl_clipping_advanced": [ "solid" ],

--- a/examples/webaudio_orientation.html
+++ b/examples/webaudio_orientation.html
@@ -131,8 +131,7 @@
 
 				boomBox.add( positionalAudio );
 				scene.add( boomBox );
-		
-				renderer.setAnimationLoop( animate );
+				animate();
 
 			} );
 
@@ -180,6 +179,7 @@
 
 		function animate() {
 
+			requestAnimationFrame( animate );
 			renderer.render( scene, camera );
 
 		}

--- a/examples/webaudio_sandbox.html
+++ b/examples/webaudio_sandbox.html
@@ -214,7 +214,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				//
@@ -228,6 +227,8 @@
 				//
 
 				window.addEventListener( 'resize', onWindowResize );
+
+				animate();
 
 			}
 
@@ -243,6 +244,14 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
+				render();
+
+			}
+
+
+			function render() {
 
 				const delta = clock.getDelta();
 

--- a/examples/webaudio_timing.html
+++ b/examples/webaudio_timing.html
@@ -130,7 +130,7 @@
 
 				}
 
-				renderer.setAnimationLoop( animate );
+				animate();
 
 			} );
 
@@ -164,6 +164,14 @@
 		}
 
 		function animate() {
+
+			requestAnimationFrame( animate );
+
+			render();
+
+		}
+
+		function render() {
 
 			const time = clock.getElapsedTime();
 

--- a/examples/webaudio_visualizer.html
+++ b/examples/webaudio_visualizer.html
@@ -82,6 +82,11 @@
 
 				const container = document.getElementById( 'container' );
 
+				renderer = new THREE.WebGLRenderer( { antialias: true } );
+				renderer.setPixelRatio( window.devicePixelRatio );
+				renderer.setSize( window.innerWidth, window.innerHeight );
+				container.appendChild( renderer.domElement );
+
 				scene = new THREE.Scene();
 
 				camera = new THREE.Camera();
@@ -137,15 +142,9 @@
 
 				//
 
-				renderer = new THREE.WebGLRenderer( { antialias: true } );
-				renderer.setPixelRatio( window.devicePixelRatio );
-				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
-				container.appendChild( renderer.domElement );
-
-				//
-
 				window.addEventListener( 'resize', onWindowResize );
+
+				animate();
 
 			}
 
@@ -156,6 +155,14 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
+
+				render();
+
+			}
+
+			function render() {
 
 				analyser.getFrequencyData();
 

--- a/examples/webgl2_buffergeometry_attributes_integer.html
+++ b/examples/webgl2_buffergeometry_attributes_integer.html
@@ -60,6 +60,7 @@
 			let camera, scene, renderer, mesh;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -157,12 +158,13 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				const time = Date.now() * 0.001;
 

--- a/examples/webgl2_buffergeometry_attributes_none.html
+++ b/examples/webgl2_buffergeometry_attributes_none.html
@@ -96,6 +96,7 @@
 			let camera, scene, renderer, mesh;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -138,12 +139,13 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 			}
 
 			function animate( time ) {
+
+				requestAnimationFrame( animate );
 
 				mesh.rotation.x = time / 1000.0 * 0.25;
 				mesh.rotation.y = time / 1000.0 * 0.50;

--- a/examples/webgl2_clipculldistance.html
+++ b/examples/webgl2_clipculldistance.html
@@ -67,6 +67,7 @@
 			let material;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -82,7 +83,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				if ( renderer.extensions.has( 'WEBGL_clip_cull_distance' ) === false ) {
@@ -173,6 +173,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				controls.update();
 				stats.update();

--- a/examples/webgl2_materials_texture2darray.html
+++ b/examples/webgl2_materials_texture2darray.html
@@ -75,6 +75,7 @@
 			let depthStep = 0.4;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -123,7 +124,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				stats = new Stats();
@@ -143,6 +143,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				if ( mesh ) {
 

--- a/examples/webgl2_materials_texture3d_partialupdate.html
+++ b/examples/webgl2_materials_texture3d_partialupdate.html
@@ -36,6 +36,7 @@
 			let cloudTexture = null;
 
 			init();
+			animate();
 
 			function generateCloudTexture( size, scaleFactor = 1.0 ) {
 
@@ -73,7 +74,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				scene = new THREE.Scene();
@@ -328,6 +328,8 @@
 			const perElementSize = Math.floor( ( INITIAL_CLOUD_SIZE - 1 ) / countPerRow );
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				const time = performance.now();
 				if ( time - prevTime > 1500.0 && curr < totalCount ) {

--- a/examples/webgl2_multiple_rendertargets.html
+++ b/examples/webgl2_multiple_rendertargets.html
@@ -216,6 +216,7 @@
 
 				controls = new OrbitControls( camera, renderer.domElement );
 				controls.addEventListener( 'change', render );
+				//controls.enableZoom = false;
 
 				window.addEventListener( 'resize', onWindowResize );
 

--- a/examples/webgl2_multisampled_renderbuffers.html
+++ b/examples/webgl2_multisampled_renderbuffers.html
@@ -120,7 +120,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( container.offsetWidth, container.offsetHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.autoClear = false;
 				container.appendChild( renderer.domElement );
 
@@ -153,6 +152,7 @@
 
 				window.addEventListener( 'resize', onWindowResize );
 
+				animate();
 
 			}
 
@@ -168,6 +168,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				const halfWidth = container.offsetWidth / 2;
 

--- a/examples/webgl2_rendertarget_texture2darray.html
+++ b/examples/webgl2_rendertarget_texture2darray.html
@@ -213,7 +213,7 @@
 
 						postProcessMaterial.uniforms.uTexture.value = texture;
 
-						renderer.setAnimationLoop( animate );
+						animate();
 
 					} );
 
@@ -229,6 +229,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				let value = mesh.material.uniforms[ 'depth' ].value;
 
@@ -246,8 +248,6 @@
 				mesh.material.uniforms[ 'depth' ].value = value;
 
 				render();
-
-				stats.update();
 
 			}
 

--- a/examples/webgl2_texture2darray_compressed.html
+++ b/examples/webgl2_texture2darray_compressed.html
@@ -73,6 +73,7 @@
 			let depthStep = 1;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -90,7 +91,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				//
@@ -138,6 +138,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				if ( mesh ) {
 

--- a/examples/webgl2_ubo.html
+++ b/examples/webgl2_ubo.html
@@ -191,6 +191,7 @@
 			let camera, scene, renderer, clock;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -303,7 +304,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				window.addEventListener( 'resize', onWindowResize, false );
@@ -322,6 +322,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				const delta = clock.getDelta();
 

--- a/examples/webgl2_ubo_arrays.html
+++ b/examples/webgl2_ubo_arrays.html
@@ -128,6 +128,7 @@
 			};
 
 			init();
+			animate();
 
 			function init() {
 
@@ -229,7 +230,6 @@
 
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				window.addEventListener( 'resize', onWindowResize, false );
@@ -267,6 +267,10 @@
 
 			function animate() {
 
+				requestAnimationFrame( animate );
+
+				stats.update();
+
 				const elapsedTime = clock.getElapsedTime();
 
 				const lights = lightingUniformsGroup.uniforms[ 0 ];
@@ -292,8 +296,6 @@
 				}
 
 				renderer.render( scene, camera );
-
-				stats.update();
 
 			}
 

--- a/examples/webgl2_volume_cloud.html
+++ b/examples/webgl2_volume_cloud.html
@@ -32,13 +32,13 @@
 			let mesh;
 
 			init();
+			animate();
 
 			function init() {
 
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				scene = new THREE.Scene();
@@ -300,6 +300,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				mesh.material.uniforms.cameraPos.value.copy( camera.position );
 				mesh.rotation.y = - performance.now() / 7500;

--- a/examples/webgl2_volume_instancing.html
+++ b/examples/webgl2_volume_instancing.html
@@ -29,13 +29,13 @@
 			let renderer, scene, camera, controls, clock;
 
 			init();
+			animate();
 
 			function init() {
 
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				scene = new THREE.Scene();
@@ -221,6 +221,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				const delta = clock.getDelta();
 				controls.update( delta );

--- a/examples/webgl2_volume_perlin.html
+++ b/examples/webgl2_volume_perlin.html
@@ -32,13 +32,13 @@
 			let mesh;
 
 			init();
+			animate();
 
 			function init() {
 
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				scene = new THREE.Scene();
@@ -238,6 +238,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				mesh.material.uniforms.cameraPos.value.copy( camera.position );
 

--- a/examples/webgl_animation_keyframes.html
+++ b/examples/webgl_animation_keyframes.html
@@ -91,7 +91,7 @@
 				mixer = new THREE.AnimationMixer( model );
 				mixer.clipAction( gltf.animations[ 0 ] ).play();
 
-				renderer.setAnimationLoop( animate );
+				animate();
 
 			}, undefined, function ( e ) {
 
@@ -111,6 +111,8 @@
 
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				const delta = clock.getDelta();
 

--- a/examples/webgl_animation_multiple.html
+++ b/examples/webgl_animation_multiple.html
@@ -39,6 +39,7 @@
 			};
 
 			init();
+			animate();
 
 			function init() {
 
@@ -95,7 +96,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.shadowMap.enabled = true;
 				document.body.appendChild( renderer.domElement );
 
@@ -236,6 +236,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				const delta = clock.getDelta();
 

--- a/examples/webgl_animation_skinning_additive_blending.html
+++ b/examples/webgl_animation_skinning_additive_blending.html
@@ -148,7 +148,7 @@
 
 					createPanel();
 
-					renderer.setAnimationLoop( animate );
+					animate();
 
 				} );
 
@@ -394,6 +394,8 @@
 
 				// Render loop
 
+				requestAnimationFrame( animate );
+
 				for ( let i = 0; i !== numAnimations; ++ i ) {
 
 					const action = allActions[ i ];
@@ -411,9 +413,9 @@
 
 				mixer.update( mixerUpdateDelta );
 
-				renderer.render( scene, camera );
-
 				stats.update();
+
+				renderer.render( scene, camera );
 
 			}
 

--- a/examples/webgl_animation_skinning_blending.html
+++ b/examples/webgl_animation_skinning_blending.html
@@ -126,7 +126,7 @@
 
 					activateAllActions();
 
-					renderer.setAnimationLoop( animate );
+					animate();
 
 				} );
 
@@ -466,6 +466,10 @@
 
 			function animate() {
 
+				// Render loop
+
+				requestAnimationFrame( animate );
+
 				idleWeight = idleAction.getEffectiveWeight();
 				walkWeight = walkAction.getEffectiveWeight();
 				runWeight = runAction.getEffectiveWeight();
@@ -495,9 +499,9 @@
 
 				mixer.update( mixerUpdateDelta );
 
-				renderer.render( scene, camera );
-
 				stats.update();
+
+				renderer.render( scene, camera );
 
 			}
 

--- a/examples/webgl_animation_skinning_ik.html
+++ b/examples/webgl_animation_skinning_ik.html
@@ -48,7 +48,7 @@
 		let stats, gui, conf;
 		const v0 = new THREE.Vector3();
 
-		init();
+		init().then( animate );
 
 		async function init() {
 
@@ -70,6 +70,19 @@
 			const ambientLight = new THREE.AmbientLight( 0xffffff, 8 ); // soft white light
 			scene.add( ambientLight );
 
+			renderer = new THREE.WebGLRenderer( { antialias: true, logarithmicDepthBuffer: true } );
+			renderer.setPixelRatio( window.devicePixelRatio );
+			renderer.setSize( window.innerWidth, window.innerHeight );
+			document.body.appendChild( renderer.domElement );
+
+			stats = new Stats();
+			document.body.appendChild( stats.dom );
+
+			orbitControls = new OrbitControls( camera, renderer.domElement );
+			orbitControls.minDistance = 0.2;
+			orbitControls.maxDistance = 1.5;
+			orbitControls.enableDamping = true;
+
 			const dracoLoader = new DRACOLoader();
 			dracoLoader.setDecoderPath( 'jsm/libs/draco/' );
 			const gltfLoader = new GLTFLoader();
@@ -90,7 +103,7 @@
 			} );
 			scene.add( gltf.scene );
 
-			const targetPosition = OOI.sphere.position.clone(); // for orbit controls
+			orbitControls.target.copy( OOI.sphere.position ); // orbit controls lookAt the sphere
 			OOI.hand_l.attach( OOI.sphere );
 
 			// mirror sphere cube-camera
@@ -99,6 +112,17 @@
 			scene.add( mirrorSphereCamera );
 			const mirrorSphereMaterial = new THREE.MeshBasicMaterial( { envMap: cubeRenderTarget.texture } );
 			OOI.sphere.material = mirrorSphereMaterial;
+
+			transformControls = new TransformControls( camera, renderer.domElement );
+			transformControls.size = 0.75;
+			transformControls.showX = false;
+			transformControls.space = 'world';
+			transformControls.attach( OOI.target_hand_l );
+			scene.add( transformControls );
+
+			// disable orbitControls while using transformControls
+			transformControls.addEventListener( 'mouseDown', () => orbitControls.enabled = false );
+			transformControls.addEventListener( 'mouseUp', () => orbitControls.enabled = true );
 
 			OOI.kira.add( OOI.kira.skeleton.bones[ 0 ] );
 			const iks = [
@@ -129,38 +153,6 @@
 			gui.add( conf, 'ik_solver' ).name( 'IK auto update' );
 			gui.add( conf, 'update' ).name( 'IK manual update()' );
 			gui.open();
-
-			//
-
-			renderer = new THREE.WebGLRenderer( { antialias: true } );
-			renderer.setPixelRatio( window.devicePixelRatio );
-			renderer.setSize( window.innerWidth, window.innerHeight );
-			renderer.setAnimationLoop( animate );
-			document.body.appendChild( renderer.domElement );
-
-			//
-
-			orbitControls = new OrbitControls( camera, renderer.domElement );
-			orbitControls.minDistance = 0.2;
-			orbitControls.maxDistance = 1.5;
-			orbitControls.enableDamping = true;
-			orbitControls.target.copy( targetPosition );
-
-			transformControls = new TransformControls( camera, renderer.domElement );
-			transformControls.size = 0.75;
-			transformControls.showX = false;
-			transformControls.space = 'world';
-			transformControls.attach( OOI.target_hand_l );
-			scene.add( transformControls );
-
-			// disable orbitControls while using transformControls
-			transformControls.addEventListener( 'mouseDown', () => orbitControls.enabled = false );
-			transformControls.addEventListener( 'mouseUp', () => orbitControls.enabled = true );
-
-			//
-
-			stats = new Stats();
-			document.body.appendChild( stats.dom );
 
 			window.addEventListener( 'resize', onWindowResize, false );
 
@@ -204,6 +196,8 @@
 			renderer.render( scene, camera );
 
 			stats.update(); // fps stats
+
+			requestAnimationFrame( animate );
 
 		}
 

--- a/examples/webgl_animation_skinning_morph.html
+++ b/examples/webgl_animation_skinning_morph.html
@@ -58,6 +58,7 @@
 			const api = { state: 'Walking' };
 
 			init();
+			animate();
 
 			function init() {
 
@@ -114,7 +115,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				window.addEventListener( 'resize', onWindowResize );
@@ -255,6 +255,8 @@
 				const dt = clock.getDelta();
 
 				if ( mixer ) mixer.update( dt );
+
+				requestAnimationFrame( animate );
 
 				renderer.render( scene, camera );
 

--- a/examples/webgl_buffergeometry.html
+++ b/examples/webgl_buffergeometry.html
@@ -167,7 +167,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				//
@@ -194,14 +193,21 @@
 
 			function animate() {
 
+				requestAnimationFrame( animate );
+
+				render();
+				stats.update();
+
+			}
+
+			function render() {
+
 				const time = Date.now() * 0.001;
 
 				mesh.rotation.x = time * 0.25;
 				mesh.rotation.y = time * 0.5;
 
 				renderer.render( scene, camera );
-
-				stats.update();
 
 			}
 

--- a/examples/webgl_buffergeometry_compression.html
+++ b/examples/webgl_buffergeometry_compression.html
@@ -32,6 +32,8 @@
 			import { TeapotGeometry } from 'three/addons/geometries/TeapotGeometry.js';
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 
+			const statsEnabled = true;
+
 			let container, stats, gui;
 
 			let camera, scene, renderer, controls;
@@ -68,6 +70,8 @@
 
 			//
 			init();
+			animate();
+
 
 			function init() {
 
@@ -76,12 +80,21 @@
 				container = document.createElement( 'div' );
 				document.body.appendChild( container );
 
+				renderer = new THREE.WebGLRenderer( { antialias: true } );
+				renderer.setPixelRatio( window.devicePixelRatio );
+				renderer.setSize( window.innerWidth, window.innerHeight );
+				container.appendChild( renderer.domElement );
+
 				//
 
 				scene = new THREE.Scene();
 
 				camera = new THREE.PerspectiveCamera( 50, window.innerWidth / window.innerHeight, 1, 1000 );
 				camera.position.setScalar( 2 * radius );
+
+				controls = new OrbitControls( camera, renderer.domElement );
+				controls.enablePan = false;
+				controls.enableZoom = false;
 
 				//
 
@@ -177,22 +190,12 @@
 
 				//
 
-				renderer = new THREE.WebGLRenderer( { antialias: true } );
-				renderer.setPixelRatio( window.devicePixelRatio );
-				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
-				container.appendChild( renderer.domElement );
+				if ( statsEnabled ) {
 
-				//
+					stats = new Stats();
+					container.appendChild( stats.dom );
 
-				controls = new OrbitControls( camera, renderer.domElement );
-				controls.enablePan = false;
-				controls.enableZoom = false;
-
-				//
-
-				stats = new Stats();
-				container.appendChild( stats.dom );
+				}
 
 				window.addEventListener( 'resize', onWindowResize );
 
@@ -214,9 +217,11 @@
 
 			function animate() {
 
+				requestAnimationFrame( animate );
+
 				renderer.render( scene, camera );
 
-				stats.update();
+				if ( statsEnabled ) stats.update();
 
 			}
 

--- a/examples/webgl_buffergeometry_custom_attributes_particles.html
+++ b/examples/webgl_buffergeometry_custom_attributes_particles.html
@@ -68,6 +68,7 @@
 			const particles = 100000;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -131,7 +132,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 
 				const container = document.getElementById( 'container' );
 				container.appendChild( renderer.domElement );
@@ -156,6 +156,15 @@
 
 			function animate() {
 
+				requestAnimationFrame( animate );
+
+				render();
+				stats.update();
+
+			}
+
+			function render() {
+
 				const time = Date.now() * 0.005;
 
 				particleSystem.rotation.z = 0.01 * time;
@@ -171,8 +180,6 @@
 				geometry.attributes.size.needsUpdate = true;
 
 				renderer.render( scene, camera );
-
-				stats.update();
 
 			}
 

--- a/examples/webgl_buffergeometry_drawrange.html
+++ b/examples/webgl_buffergeometry_drawrange.html
@@ -57,6 +57,7 @@
 			};
 
 			init();
+			animate();
 
 			function initGUI() {
 
@@ -173,7 +174,7 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
+
 				container.appendChild( renderer.domElement );
 
 				//
@@ -274,9 +275,10 @@
 
 				pointCloud.geometry.attributes.position.needsUpdate = true;
 
-				render();
+				requestAnimationFrame( animate );
 
 				stats.update();
+				render();
 
 			}
 

--- a/examples/webgl_buffergeometry_glbufferattribute.html
+++ b/examples/webgl_buffergeometry_glbufferattribute.html
@@ -44,10 +44,9 @@
 
 				//
 
-				renderer = new THREE.WebGLRenderer();
+				renderer = new THREE.WebGLRenderer( { antialias: false } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 
 				container.appendChild( renderer.domElement );
 
@@ -129,7 +128,9 @@
 
 				points = new THREE.Points( geometry, material );
 
-				geometry.boundingSphere = new THREE.Sphere().set( new THREE.Vector3(), 500 );
+				// Choose one:
+				// geometry.boundingSphere = ( new THREE.Sphere() ).set( new THREE.Vector3(), Infinity );
+				points.frustumCulled = false;
 
 				scene.add( points );
 
@@ -157,6 +158,15 @@
 
 			function animate() {
 
+				requestAnimationFrame( animate );
+
+				render();
+				stats.update();
+
+			}
+
+			function render() {
+
 				drawCount = ( Math.max( 5000, drawCount ) + Math.floor( 500 * Math.random() ) ) % particles;
 				points.geometry.setDrawRange( 0, drawCount );
 
@@ -166,8 +176,6 @@
 				points.rotation.y = time * 0.2;
 
 				renderer.render( scene, camera );
-
-				stats.update();
 
 			}
 

--- a/examples/webgl_buffergeometry_indexed.html
+++ b/examples/webgl_buffergeometry_indexed.html
@@ -32,6 +32,7 @@
 			let mesh;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -131,7 +132,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				//
@@ -163,14 +163,21 @@
 
 			function animate() {
 
+				requestAnimationFrame( animate );
+
+				render();
+				stats.update();
+
+			}
+
+			function render() {
+
 				const time = Date.now() * 0.001;
 
 				mesh.rotation.x = time * 0.25;
 				mesh.rotation.y = time * 0.5;
 
 				renderer.render( scene, camera );
-
-				stats.update();
 
 			}
 

--- a/examples/webgl_buffergeometry_instancing.html
+++ b/examples/webgl_buffergeometry_instancing.html
@@ -86,6 +86,7 @@
 		let camera, scene, renderer;
 
 		init();
+		animate();
 
 		function init() {
 
@@ -176,7 +177,6 @@
 			renderer = new THREE.WebGLRenderer();
 			renderer.setPixelRatio( window.devicePixelRatio );
 			renderer.setSize( window.innerWidth, window.innerHeight );
-			renderer.setAnimationLoop( animate );
 			container.appendChild( renderer.domElement );
 
 			//
@@ -208,6 +208,15 @@
 
 		function animate() {
 
+			requestAnimationFrame( animate );
+
+			render();
+			stats.update();
+
+		}
+
+		function render() {
+
 			const time = performance.now();
 
 			const object = scene.children[ 0 ];
@@ -217,8 +226,6 @@
 			object.material.uniforms[ 'sineTime' ].value = Math.sin( object.material.uniforms[ 'time' ].value * 0.05 );
 
 			renderer.render( scene, camera );
-
-			stats.update();
 
 		}
 

--- a/examples/webgl_buffergeometry_instancing_billboards.html
+++ b/examples/webgl_buffergeometry_instancing_billboards.html
@@ -89,8 +89,6 @@
 		let camera, scene, renderer;
 		let geometry, material, mesh;
 
-		init();
-
 		function init() {
 
 			container = document.createElement( 'div' );
@@ -139,7 +137,6 @@
 			renderer = new THREE.WebGLRenderer();
 			renderer.setPixelRatio( window.devicePixelRatio );
 			renderer.setSize( window.innerWidth, window.innerHeight );
-			renderer.setAnimationLoop( animate );
 			container.appendChild( renderer.domElement );
 
 			stats = new Stats();
@@ -162,6 +159,15 @@
 
 		function animate() {
 
+			requestAnimationFrame( animate );
+
+			render();
+			stats.update();
+
+		}
+
+		function render() {
+
 			const time = performance.now() * 0.0005;
 
 			material.uniforms[ 'time' ].value = time;
@@ -171,10 +177,13 @@
 
 			renderer.render( scene, camera );
 
-			stats.update();
-
 		}
 
+		if ( init() ) {
+
+			animate();
+
+		}
 	</script>
 
 </body>

--- a/examples/webgl_buffergeometry_instancing_interleaved.html
+++ b/examples/webgl_buffergeometry_instancing_interleaved.html
@@ -40,6 +40,7 @@
 		const currentM = new THREE.Matrix4();
 
 		init();
+		animate();
 
 		function init() {
 
@@ -162,7 +163,6 @@
 			renderer = new THREE.WebGLRenderer();
 			renderer.setPixelRatio( window.devicePixelRatio );
 			renderer.setSize( window.innerWidth, window.innerHeight );
-			renderer.setAnimationLoop( animate );
 			container.appendChild( renderer.domElement );
 
 			stats = new Stats();
@@ -184,6 +184,15 @@
 		//
 
 		function animate() {
+
+			requestAnimationFrame( animate );
+
+			render();
+			stats.update();
+
+		}
+
+		function render() {
 
 			const time = performance.now();
 
@@ -207,8 +216,6 @@
 			lastTime = time;
 
 			renderer.render( scene, camera );
-
-			stats.update();
 
 		}
 

--- a/examples/webgl_buffergeometry_lines.html
+++ b/examples/webgl_buffergeometry_lines.html
@@ -37,6 +37,7 @@
 			let t = 0;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -89,7 +90,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 
 				container.appendChild( renderer.domElement );
 
@@ -117,6 +117,15 @@
 
 			function animate() {
 
+				requestAnimationFrame( animate );
+
+				render();
+				stats.update();
+
+			}
+
+			function render() {
+
 				const delta = clock.getDelta();
 				const time = clock.getElapsedTime();
 
@@ -127,8 +136,6 @@
 				line.morphTargetInfluences[ 0 ] = Math.abs( Math.sin( t ) );
 
 				renderer.render( scene, camera );
-
-				stats.update();
 
 			}
 

--- a/examples/webgl_buffergeometry_lines_indexed.html
+++ b/examples/webgl_buffergeometry_lines_indexed.html
@@ -34,6 +34,7 @@
 			let parent_node;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -192,7 +193,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 
 				container.appendChild( renderer.domElement );
 
@@ -220,13 +220,20 @@
 
 			function animate() {
 
+				requestAnimationFrame( animate );
+
+				render();
+				stats.update();
+
+			}
+
+			function render() {
+
 				const time = Date.now() * 0.001;
 
 				parent_node.rotation.z = time * 0.5;
 
 				renderer.render( scene, camera );
-
-				stats.update();
 
 			}
 

--- a/examples/webgl_buffergeometry_points.html
+++ b/examples/webgl_buffergeometry_points.html
@@ -100,7 +100,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 
 				container.appendChild( renderer.domElement );
 
@@ -128,14 +127,21 @@
 
 			function animate() {
 
+				requestAnimationFrame( animate );
+
+				render();
+				stats.update();
+
+			}
+
+			function render() {
+
 				const time = Date.now() * 0.001;
 
 				points.rotation.x = time * 0.25;
 				points.rotation.y = time * 0.5;
 
 				renderer.render( scene, camera );
-
-				stats.update();
 
 			}
 

--- a/examples/webgl_buffergeometry_points_interleaved.html
+++ b/examples/webgl_buffergeometry_points_interleaved.html
@@ -33,6 +33,7 @@
 			let points;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -113,7 +114,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 
 				container.appendChild( renderer.domElement );
 
@@ -141,14 +141,21 @@
 
 			function animate() {
 
+				requestAnimationFrame( animate );
+
+				render();
+				stats.update();
+
+			}
+
+			function render() {
+
 				const time = Date.now() * 0.001;
 
 				points.rotation.x = time * 0.25;
 				points.rotation.y = time * 0.5;
 
 				renderer.render( scene, camera );
-
-				stats.update();
 
 			}
 

--- a/examples/webgl_buffergeometry_rawshader.html
+++ b/examples/webgl_buffergeometry_rawshader.html
@@ -77,6 +77,7 @@
 			let camera, scene, renderer;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -140,7 +141,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				stats = new Stats();
@@ -163,6 +163,15 @@
 
 			function animate() {
 
+				requestAnimationFrame( animate );
+
+				render();
+				stats.update();
+
+			}
+
+			function render() {
+
 				const time = performance.now();
 
 				const object = scene.children[ 0 ];
@@ -171,8 +180,6 @@
 				object.material.uniforms.time.value = time * 0.005;
 
 				renderer.render( scene, camera );
-
-				stats.update();
 
 			}
 

--- a/examples/webgl_buffergeometry_selective_draw.html
+++ b/examples/webgl_buffergeometry_selective_draw.html
@@ -68,9 +68,14 @@
 			let numLinesCulled = 0;
 
 			init();
+			animate();
 
 			function init() {
 
+				renderer = new THREE.WebGLRenderer( { antialias: true } );
+				renderer.setPixelRatio( window.devicePixelRatio );
+				renderer.setSize( window.innerWidth, window.innerHeight );
+				document.body.appendChild( renderer.domElement );
 
 				scene = new THREE.Scene();
 
@@ -89,12 +94,6 @@
 
 				const showAllLinesButton = document.getElementById( 'showAllLines' );
 				showAllLinesButton.addEventListener( 'click', showAllLines );
-
-				renderer = new THREE.WebGLRenderer( { antialias: true } );
-				renderer.setPixelRatio( window.devicePixelRatio );
-				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
-				document.body.appendChild( renderer.domElement );
 
 			}
 
@@ -220,14 +219,15 @@
 
 			function animate() {
 
+				requestAnimationFrame( animate );
+
 				const time = Date.now() * 0.001;
 
 				mesh.rotation.x = time * 0.25;
 				mesh.rotation.y = time * 0.5;
 
-				renderer.render( scene, camera );
-
 				stats.update();
+				renderer.render( scene, camera );
 
 			}
 

--- a/examples/webgl_buffergeometry_uint.html
+++ b/examples/webgl_buffergeometry_uint.html
@@ -33,6 +33,7 @@
 			let mesh;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -165,7 +166,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				//
@@ -192,14 +192,21 @@
 
 			function animate() {
 
+				requestAnimationFrame( animate );
+
+				render();
+				stats.update();
+
+			}
+
+			function render() {
+
 				const time = Date.now() * 0.001;
 
 				mesh.rotation.x = time * 0.25;
 				mesh.rotation.y = time * 0.5;
 
 				renderer.render( scene, camera );
-
-				stats.update();
 
 			}
 

--- a/examples/webgl_camera.html
+++ b/examples/webgl_camera.html
@@ -43,6 +43,7 @@
 			const frustumSize = 600;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -130,7 +131,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( SCREEN_WIDTH, SCREEN_HEIGHT );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				renderer.setScissorTest( true );
@@ -198,6 +198,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/webgl_camera_array.html
+++ b/examples/webgl_camera_array.html
@@ -25,6 +25,7 @@
 			const AMOUNT = 6;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -85,7 +86,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.shadowMap.enabled = true;
 				document.body.appendChild( renderer.domElement );
 
@@ -133,6 +133,8 @@
 				mesh.rotation.z += 0.01;
 
 				renderer.render( scene, camera );
+
+				requestAnimationFrame( animate );
 
 			}
 

--- a/examples/webgl_camera_cinematic.html
+++ b/examples/webgl_camera_cinematic.html
@@ -47,6 +47,7 @@
 			let theta = 0;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -82,7 +83,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				stats = new Stats();
@@ -171,6 +171,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate, renderer.domElement );
 
 				render();
 				stats.update();

--- a/examples/webgl_clipping.html
+++ b/examples/webgl_clipping.html
@@ -28,6 +28,7 @@
 			let camera, scene, renderer, startTime, object, stats;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -102,27 +103,25 @@
 				ground.receiveShadow = true;
 				scene.add( ground );
 
+				// Stats
+
+				stats = new Stats();
+				document.body.appendChild( stats.dom );
+
 				// Renderer
 
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
+				renderer.shadowMap.enabled = true;
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
-				renderer.shadowMap.enabled = true;
-				document.body.appendChild( renderer.domElement );
-
 				window.addEventListener( 'resize', onWindowResize );
+				document.body.appendChild( renderer.domElement );
 
 				// ***** Clipping setup (renderer): *****
 				const globalPlanes = [ globalPlane ],
 					Empty = Object.freeze( [] );
 				renderer.clippingPlanes = Empty; // GUI sets it to globalPlanes
 				renderer.localClippingEnabled = true;
-
-				// Stats
-
-				stats = new Stats();
-				document.body.appendChild( stats.dom );
 
 				// Controls
 
@@ -235,6 +234,8 @@
 
 				const currentTime = Date.now();
 				const time = ( currentTime - startTime ) / 1000;
+
+				requestAnimationFrame( animate );
 
 				object.position.y = 0.8;
 				object.rotation.x = time * 0.5;

--- a/examples/webgl_clipping_advanced.html
+++ b/examples/webgl_clipping_advanced.html
@@ -279,17 +279,15 @@
 				const container = document.body;
 
 				renderer = new THREE.WebGLRenderer();
+				renderer.shadowMap.enabled = true;
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
-				renderer.shadowMap.enabled = true;
+				window.addEventListener( 'resize', onWindowResize );
 				container.appendChild( renderer.domElement );
 				// Clipping setup:
 				globalClippingPlanes = createPlanes( GlobalClippingPlanes.length );
 				renderer.clippingPlanes = Empty;
 				renderer.localClippingEnabled = true;
-
-				window.addEventListener( 'resize', onWindowResize );
 
 				// Stats
 
@@ -399,6 +397,8 @@
 				const currentTime = Date.now(),
 					time = ( currentTime - startTime ) / 1000;
 
+				requestAnimationFrame( animate );
+
 				object.position.y = 1;
 				object.rotation.x = time * 0.5;
 				object.rotation.y = time * 0.2;
@@ -433,6 +433,7 @@
 			}
 
 			init();
+			animate();
 
 		</script>
 

--- a/examples/webgl_clipping_stencil.html
+++ b/examples/webgl_clipping_stencil.html
@@ -58,6 +58,7 @@
 			};
 
 			init();
+			animate();
 
 			function createPlaneStencilGroup( geometry, plane, renderOrder ) {
 
@@ -210,23 +211,20 @@
 				ground.receiveShadow = true;
 				scene.add( ground );
 
-				// Renderer
-				renderer = new THREE.WebGLRenderer( { antialias: true, stencil: true } );
-				renderer.setPixelRatio( window.devicePixelRatio );
-				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setClearColor( 0x263238 );
-				renderer.setAnimationLoop( animate );
-				renderer.shadowMap.enabled = true;
-				renderer.localClippingEnabled = true;
-				document.body.appendChild( renderer.domElement );
-
 				// Stats
 				stats = new Stats();
 				document.body.appendChild( stats.dom );
 
-				//
-
+				// Renderer
+				renderer = new THREE.WebGLRenderer( { antialias: true, stencil: true } );
+				renderer.shadowMap.enabled = true;
+				renderer.setPixelRatio( window.devicePixelRatio );
+				renderer.setSize( window.innerWidth, window.innerHeight );
+				renderer.setClearColor( 0x263238 );
 				window.addEventListener( 'resize', onWindowResize );
+				document.body.appendChild( renderer.domElement );
+
+				renderer.localClippingEnabled = true;
 
 				// Controls
 				const controls = new OrbitControls( camera, renderer.domElement );
@@ -285,6 +283,8 @@
 			function animate() {
 
 				const delta = clock.getDelta();
+
+				requestAnimationFrame( animate );
 
 				if ( params.animate ) {
 

--- a/examples/webgl_custom_attributes.html
+++ b/examples/webgl_custom_attributes.html
@@ -78,6 +78,7 @@
 			let displacement, noise;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -127,7 +128,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 
 				const container = document.getElementById( 'container' );
 				container.appendChild( renderer.domElement );
@@ -151,6 +151,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/webgl_custom_attributes_lines.html
+++ b/examples/webgl_custom_attributes_lines.html
@@ -73,6 +73,7 @@
 			loader.load( 'fonts/helvetiker_bold.typeface.json', function ( font ) {
 
 				init( font );
+				animate();
 
 			} );
 
@@ -145,7 +146,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 
 				const container = document.getElementById( 'container' );
 				container.appendChild( renderer.domElement );
@@ -169,6 +169,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/webgl_custom_attributes_points.html
+++ b/examples/webgl_custom_attributes_points.html
@@ -71,6 +71,7 @@
 			const HEIGHT = window.innerHeight;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -144,7 +145,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( WIDTH, HEIGHT );
-				renderer.setAnimationLoop( animate );
 
 				const container = document.getElementById( 'container' );
 				container.appendChild( renderer.domElement );
@@ -168,6 +168,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/webgl_custom_attributes_points2.html
+++ b/examples/webgl_custom_attributes_points2.html
@@ -73,6 +73,7 @@
 			const HEIGHT = window.innerHeight;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -161,7 +162,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( WIDTH, HEIGHT );
-				renderer.setAnimationLoop( animate );
 
 				const container = document.getElementById( 'container' );
 				container.appendChild( renderer.domElement );
@@ -250,6 +250,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/webgl_custom_attributes_points3.html
+++ b/examples/webgl_custom_attributes_points3.html
@@ -84,6 +84,7 @@
 			const HEIGHT = window.innerHeight;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -236,7 +237,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( WIDTH, HEIGHT );
-				renderer.setAnimationLoop( animate );
 
 				const container = document.getElementById( 'container' );
 				container.appendChild( renderer.domElement );
@@ -260,6 +260,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/webgl_decals.html
+++ b/examples/webgl_decals.html
@@ -86,13 +86,13 @@
 			};
 
 			init();
+			animate();
 
 			function init() {
 
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				stats = new Stats();
@@ -292,6 +292,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				renderer.render( scene, camera );
 

--- a/examples/webgl_depth_texture.html
+++ b/examples/webgl_depth_texture.html
@@ -83,6 +83,7 @@
 			let camera, scene, renderer, controls, stats;
 			let target;
 			let postScene, postCamera, postMaterial;
+			const supportsExtension = true;
 
 			const params = {
 				format: THREE.DepthFormat,
@@ -93,13 +94,13 @@
 			const types = { UnsignedShortType: THREE.UnsignedShortType, UnsignedIntType: THREE.UnsignedIntType, UnsignedInt248Type: THREE.UnsignedInt248Type };
 
 			init();
+			animate();
 
 			function init() {
 
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				//
@@ -214,6 +215,10 @@
 			}
 
 			function animate() {
+
+				if ( ! supportsExtension ) return;
+
+				requestAnimationFrame( animate );
 
 				// render scene into target
 				renderer.setRenderTarget( target );

--- a/examples/webgl_effects_anaglyph.html
+++ b/examples/webgl_effects_anaglyph.html
@@ -40,6 +40,7 @@
 			document.addEventListener( 'mousemove', onDocumentMouseMove );
 
 			init();
+			animate();
 
 			function init() {
 
@@ -85,7 +86,6 @@
 
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				const width = window.innerWidth || 2;
@@ -122,6 +122,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 

--- a/examples/webgl_effects_ascii.html
+++ b/examples/webgl_effects_ascii.html
@@ -33,6 +33,7 @@
 			const start = Date.now();
 
 			init();
+			animate();
 
 			function init() {
 
@@ -63,7 +64,6 @@
 
 				renderer = new THREE.WebGLRenderer();
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 
 				effect = new AsciiEffect( renderer, ' .:-+*=%@#', { invert: true } );
 				effect.setSize( window.innerWidth, window.innerHeight );
@@ -96,6 +96,14 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
+
+				render();
+
+			}
+
+			function render() {
 
 				const timer = Date.now() - start;
 

--- a/examples/webgl_effects_parallaxbarrier.html
+++ b/examples/webgl_effects_parallaxbarrier.html
@@ -41,6 +41,7 @@
 			document.addEventListener( 'mousemove', onDocumentMouseMove );
 
 			init();
+			animate();
 
 			function init() {
 
@@ -86,7 +87,6 @@
 
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				const width = window.innerWidth || 2;
@@ -123,6 +123,14 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
+
+				render();
+
+			}
+
+			function render() {
 
 				const timer = 0.0001 * Date.now();
 

--- a/examples/webgl_effects_peppersghost.html
+++ b/examples/webgl_effects_peppersghost.html
@@ -34,6 +34,7 @@
 			let group;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -92,7 +93,6 @@
 
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				effect = new PeppersGhostEffect( renderer );
@@ -113,6 +113,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				group.rotation.y += 0.01;
 

--- a/examples/webgl_effects_stereo.html
+++ b/examples/webgl_effects_stereo.html
@@ -39,6 +39,7 @@
 			document.addEventListener( 'mousemove', onDocumentMouseMove );
 
 			init();
+			animate();
 
 			function init() {
 
@@ -79,7 +80,6 @@
 
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				effect = new StereoEffect( renderer );
@@ -113,6 +113,14 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
+
+				render();
+
+			}
+
+			function render() {
 
 				const timer = 0.0001 * Date.now();
 

--- a/examples/webgl_framebuffer_texture.html
+++ b/examples/webgl_framebuffer_texture.html
@@ -65,6 +65,7 @@
 			const color = new THREE.Color();
 
 			init();
+			animate();
 
 			function init() {
 
@@ -119,7 +120,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.autoClear = false;
 				document.body.appendChild( renderer.domElement );
 
@@ -168,6 +168,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				const colorAttribute = line.geometry.getAttribute( 'color' );
 				updateColors( colorAttribute );

--- a/examples/webgl_geometries.html
+++ b/examples/webgl_geometries.html
@@ -28,6 +28,7 @@
 			let camera, scene, renderer, stats;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -119,7 +120,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				stats = new Stats();
@@ -143,6 +143,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/webgl_geometries_parametric.html
+++ b/examples/webgl_geometries_parametric.html
@@ -33,6 +33,7 @@
 			let camera, scene, renderer, stats;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -109,7 +110,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				stats = new Stats();
@@ -129,6 +129,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/webgl_geometry_colors.html
+++ b/examples/webgl_geometry_colors.html
@@ -45,6 +45,7 @@
 			let windowHalfY = window.innerHeight / 2;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -159,7 +160,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				stats = new Stats();
@@ -195,6 +195,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/webgl_geometry_convex.html
+++ b/examples/webgl_geometry_convex.html
@@ -30,6 +30,7 @@
 			let group, camera, scene, renderer;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -38,7 +39,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				// camera
@@ -141,7 +141,15 @@
 
 			function animate() {
 
+				requestAnimationFrame( animate );
+
 				group.rotation.y += 0.005;
+
+				render();
+
+			}
+
+			function render() {
 
 				renderer.render( scene, camera );
 

--- a/examples/webgl_geometry_csg.html
+++ b/examples/webgl_geometry_csg.html
@@ -58,6 +58,7 @@
 			};
 
 			init();
+			animate();
 
 			function init() {
 
@@ -84,7 +85,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.shadowMap.enabled = true;
 				renderer.shadowMap.type = THREE.PCFSoftShadowMap;
 				document.body.appendChild( renderer.domElement );
@@ -195,6 +195,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				// update the transforms
 				const t = window.performance.now() + 9000;

--- a/examples/webgl_geometry_cube.html
+++ b/examples/webgl_geometry_cube.html
@@ -24,6 +24,7 @@
 			let mesh;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -44,7 +45,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				//
@@ -63,6 +63,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				mesh.rotation.x += 0.005;
 				mesh.rotation.y += 0.01;

--- a/examples/webgl_geometry_dynamic.html
+++ b/examples/webgl_geometry_dynamic.html
@@ -42,6 +42,7 @@
 			const worldWidth = 128, worldDepth = 128;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -80,7 +81,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				controls = new FirstPersonControls( camera, renderer.domElement );
@@ -111,6 +111,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/webgl_geometry_extrude_shapes.html
+++ b/examples/webgl_geometry_extrude_shapes.html
@@ -34,6 +34,7 @@
 			let camera, scene, renderer, controls;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -50,7 +51,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				scene = new THREE.Scene();
@@ -181,6 +181,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				controls.update();
 				renderer.render( scene, camera );

--- a/examples/webgl_geometry_extrude_splines.html
+++ b/examples/webgl_geometry_extrude_splines.html
@@ -162,6 +162,7 @@
 			}
 
 			init();
+			animate();
 
 			function init() {
 
@@ -211,7 +212,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				// stats
@@ -289,6 +289,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/webgl_geometry_minecraft.html
+++ b/examples/webgl_geometry_minecraft.html
@@ -51,6 +51,7 @@
 			const clock = new THREE.Clock();
 
 			init();
+			animate();
 
 			function init() {
 
@@ -166,7 +167,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				controls = new FirstPersonControls( camera, renderer.domElement );
@@ -231,6 +231,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/webgl_geometry_nurbs.html
+++ b/examples/webgl_geometry_nurbs.html
@@ -54,6 +54,7 @@
 			let windowHalfX = window.innerWidth / 2;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -321,7 +322,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				stats = new Stats();
@@ -383,6 +383,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/webgl_geometry_sdf.html
+++ b/examples/webgl_geometry_sdf.html
@@ -79,6 +79,7 @@
 			`;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -95,7 +96,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				stats = new Stats();
@@ -191,6 +191,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				controls.update();
 

--- a/examples/webgl_geometry_shapes.html
+++ b/examples/webgl_geometry_shapes.html
@@ -46,6 +46,7 @@
 			let windowHalfX = window.innerWidth / 2;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -356,7 +357,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				stats = new Stats();
@@ -418,6 +418,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/webgl_geometry_terrain.html
+++ b/examples/webgl_geometry_terrain.html
@@ -46,6 +46,7 @@
 			const clock = new THREE.Clock();
 
 			init();
+			animate();
 
 			function init() {
 
@@ -84,7 +85,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				controls = new FirstPersonControls( camera, renderer.domElement );
@@ -213,6 +213,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/webgl_geometry_terrain_raycast.html
+++ b/examples/webgl_geometry_terrain_raycast.html
@@ -53,6 +53,7 @@
 			const pointer = new THREE.Vector2();
 
 			init();
+			animate();
 
 			function init() {
 
@@ -62,7 +63,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				scene = new THREE.Scene();
@@ -226,6 +226,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/webgl_geometry_text.html
+++ b/examples/webgl_geometry_text.html
@@ -95,6 +95,7 @@
 			let fontIndex = 1;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -150,7 +151,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				// EVENTS
@@ -384,6 +384,14 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
+
+				render();
+
+			}
+
+			function render() {
 
 				group.rotation.y += ( targetRotation - group.rotation.y ) * 0.05;
 

--- a/examples/webgl_gpgpu_birds.html
+++ b/examples/webgl_gpgpu_birds.html
@@ -434,6 +434,7 @@
 			let birdUniforms;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -450,7 +451,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				initComputeRenderer();
@@ -633,6 +633,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/webgl_gpgpu_birds_gltf.html
+++ b/examples/webgl_gpgpu_birds_gltf.html
@@ -340,6 +340,7 @@
 				BirdGeometry.setIndex( indices );
 
 				init();
+				animate();
 
 			} );
 
@@ -389,7 +390,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				initComputeRenderer();
@@ -630,6 +630,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/webgl_gpgpu_protoplanet.html
+++ b/examples/webgl_gpgpu_protoplanet.html
@@ -263,6 +263,7 @@
 			let effectController;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -278,7 +279,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				const controls = new OrbitControls( camera, renderer.domElement );
@@ -532,6 +532,8 @@
 
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/webgl_gpgpu_water.html
+++ b/examples/webgl_gpgpu_water.html
@@ -294,6 +294,7 @@
 			const simplex = new SimplexNoise();
 
 			init();
+			animate();
 
 			function init() {
 
@@ -317,7 +318,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				stats = new Stats();
@@ -666,6 +666,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/webgl_helpers.html
+++ b/examples/webgl_helpers.html
@@ -35,13 +35,13 @@
 			let vth;
 
 			init();
+			animate();
 
 			function init() {
 
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				//
@@ -131,6 +131,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				const time = - performance.now() * 0.0003;
 

--- a/examples/webgl_instancing_dynamic.html
+++ b/examples/webgl_instancing_dynamic.html
@@ -31,6 +31,7 @@
 			const dummy = new THREE.Object3D();
 
 			init();
+			animate();
 
 			function init() {
 
@@ -66,7 +67,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				//
@@ -92,6 +92,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 

--- a/examples/webgl_instancing_morph.html
+++ b/examples/webgl_instancing_morph.html
@@ -39,6 +39,7 @@
 			const clock = new THREE.Clock( true );
 
 			init();
+			animate();
 
 			function init() {
 
@@ -127,7 +128,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 				renderer.shadowMap.enabled = true;
 				renderer.shadowMap.type = THREE.VSMShadowMap;
@@ -154,6 +154,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 

--- a/examples/webgl_instancing_performance.html
+++ b/examples/webgl_instancing_performance.html
@@ -64,6 +64,7 @@
 
 		init();
 		initMesh();
+		animate();
 
 		//
 
@@ -249,7 +250,6 @@
 			renderer = new THREE.WebGLRenderer( { antialias: true } );
 			renderer.setPixelRatio( window.devicePixelRatio );
 			renderer.setSize( width, height );
-			renderer.setAnimationLoop( animate );
 			container = document.getElementById( 'container' );
 			container.appendChild( renderer.domElement );
 
@@ -306,11 +306,18 @@
 
 		function animate() {
 
+			requestAnimationFrame( animate );
+
 			controls.update();
+			stats.update();
+
+			render();
+
+		}
+
+		function render() {
 
 			renderer.render( scene, camera );
-
-			stats.update();
 
 		}
 

--- a/examples/webgl_instancing_raycast.html
+++ b/examples/webgl_instancing_raycast.html
@@ -37,6 +37,7 @@
 			const white = new THREE.Color().setHex( 0xffffff );
 
 			init();
+			animate();
 
 			function init() {
 
@@ -89,7 +90,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				controls = new OrbitControls( camera, renderer.domElement );
@@ -125,6 +125,8 @@
 
 			function animate() {
 
+				requestAnimationFrame( animate );
+
 				controls.update();
 
 				raycaster.setFromCamera( mouse, camera );
@@ -147,9 +149,15 @@
 
 				}
 
-				renderer.render( scene, camera );
+				render();
 
 				stats.update();
+
+			}
+
+			function render() {
+
+				renderer.render( scene, camera );
 
 			}
 

--- a/examples/webgl_instancing_scatter.html
+++ b/examples/webgl_instancing_scatter.html
@@ -112,6 +112,7 @@
 				resample();
 
 				init();
+				animate();
 
 			} );
 
@@ -169,7 +170,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				//
@@ -278,6 +278,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 

--- a/examples/webgl_interactive_buffergeometry.html
+++ b/examples/webgl_interactive_buffergeometry.html
@@ -35,6 +35,7 @@
 			let mesh, line;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -198,7 +199,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				//
@@ -232,6 +232,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/webgl_interactive_cubes.html
+++ b/examples/webgl_interactive_cubes.html
@@ -46,6 +46,7 @@
 			const radius = 5;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -85,7 +86,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				stats = new Stats();
@@ -118,6 +118,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/webgl_interactive_cubes_gpu.html
+++ b/examples/webgl_interactive_cubes_gpu.html
@@ -53,6 +53,7 @@
 			const clearColor = new THREE.Color();
 
 			init();
+			animate();
 
 			function init() {
 
@@ -200,7 +201,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				controls = new TrackballControls( camera, renderer.domElement );
@@ -229,6 +229,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/webgl_interactive_cubes_ortho.html
+++ b/examples/webgl_interactive_cubes_ortho.html
@@ -47,6 +47,7 @@
 			const frustumSize = 50;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -87,7 +88,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				stats = new Stats();
@@ -126,6 +126,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/webgl_interactive_lines.html
+++ b/examples/webgl_interactive_lines.html
@@ -39,6 +39,7 @@
 			let theta = 0;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -138,7 +139,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				stats = new Stats();
@@ -171,6 +171,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/webgl_interactive_points.html
+++ b/examples/webgl_interactive_points.html
@@ -79,6 +79,7 @@
 			let pointer, INTERSECTED;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -147,7 +148,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				//
@@ -184,6 +184,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/webgl_interactive_raycasting_points.html
+++ b/examples/webgl_interactive_raycasting_points.html
@@ -44,6 +44,7 @@
 			const rotateY = new THREE.Matrix4().makeRotationY( 0.005 );
 
 			init();
+			animate();
 
 			function generatePointCloudGeometry( color, width, length ) {
 
@@ -202,7 +203,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				//
@@ -239,6 +239,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/webgl_layers.html
+++ b/examples/webgl_layers.html
@@ -44,6 +44,7 @@
 			const radius = 5;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -96,7 +97,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				stats = new Stats();
@@ -161,6 +161,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/webgl_lensflares.html
+++ b/examples/webgl_lensflares.html
@@ -40,6 +40,7 @@
 			const clock = new THREE.Clock();
 
 			init();
+			animate();
 
 			function init() {
 
@@ -123,7 +124,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				//
@@ -161,6 +161,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/webgl_lights_hemisphere.html
+++ b/examples/webgl_lights_hemisphere.html
@@ -80,6 +80,7 @@
 			const clock = new THREE.Clock();
 
 			init();
+			animate();
 
 			function init() {
 
@@ -195,7 +196,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 				renderer.shadowMap.enabled = true;
 
@@ -245,6 +245,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/webgl_lights_physical.html
+++ b/examples/webgl_lights_physical.html
@@ -74,6 +74,7 @@
 			};
 
 			init();
+			animate();
 
 			function init() {
 
@@ -226,11 +227,10 @@
 
 
 				renderer = new THREE.WebGLRenderer();
-				renderer.setPixelRatio( window.devicePixelRatio );
-				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.shadowMap.enabled = true;
 				renderer.toneMapping = THREE.ReinhardToneMapping;
+				renderer.setPixelRatio( window.devicePixelRatio );
+				renderer.setSize( window.innerWidth, window.innerHeight );
 				container.appendChild( renderer.domElement );
 
 
@@ -263,6 +263,14 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
+
+				render();
+
+			}
+
+			function render() {
 
 				renderer.toneMappingExposure = Math.pow( params.exposure, 5.0 ); // to allow for very bright scenes.
 				renderer.shadowMap.enabled = params.shadows;

--- a/examples/webgl_lights_pointlights.html
+++ b/examples/webgl_lights_pointlights.html
@@ -37,6 +37,7 @@
 			const clock = new THREE.Clock();
 
 			init();
+			animate();
 
 			function init() {
 
@@ -82,7 +83,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				//stats
@@ -104,6 +104,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/webgl_lights_spotlight.html
+++ b/examples/webgl_lights_spotlight.html
@@ -41,14 +41,16 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				renderer.shadowMap.enabled = true;
 				renderer.shadowMap.type = THREE.PCFSoftShadowMap;
 
+
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				renderer.toneMappingExposure = 1;
+
+				renderer.setAnimationLoop( render );
 
 				scene = new THREE.Scene();
 
@@ -228,7 +230,7 @@
 
 			}
 
-			function animate() {
+			function render() {
 
 				const time = performance.now() / 3000;
 

--- a/examples/webgl_lights_spotlights.html
+++ b/examples/webgl_lights_spotlights.html
@@ -30,7 +30,6 @@
 			const renderer = new THREE.WebGLRenderer( { antialias: true } );
 			renderer.setPixelRatio( window.devicePixelRatio );
 			renderer.setSize( window.innerWidth, window.innerHeight );
-			renderer.setAnimationLoop( animate );
 
 			const camera = new THREE.PerspectiveCamera( 35, window.innerWidth / window.innerHeight, 0.1, 100 );
 
@@ -134,17 +133,17 @@
 
 			}
 
-			function updateTweens() {
+			function animate() {
 
 				tween( spotLight1 );
 				tween( spotLight2 );
 				tween( spotLight3 );
 
-				setTimeout( updateTweens, 5000 );
+				setTimeout( animate, 5000 );
 
 			}
 
-			function animate() {
+			function render() {
 
 				TWEEN.update();
 
@@ -154,10 +153,13 @@
 
 				renderer.render( scene, camera );
 
+				requestAnimationFrame( render );
+
 			}
 
 			init();
-			updateTweens();
+			render();
+			animate();
 
 		</script>
 	</body>

--- a/examples/webgl_lines_colors.html
+++ b/examples/webgl_lines_colors.html
@@ -36,6 +36,7 @@
 			let camera, scene, renderer;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -47,7 +48,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				//
@@ -198,6 +198,13 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
+				render();
+
+			}
+
+			function render() {
 
 				camera.position.x += ( mouseX - camera.position.x ) * 0.05;
 				camera.position.y += ( - mouseY + 200 - camera.position.y ) * 0.05;

--- a/examples/webgl_lines_dashed.html
+++ b/examples/webgl_lines_dashed.html
@@ -33,6 +33,7 @@
 			const WIDTH = window.innerWidth, HEIGHT = window.innerHeight;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -69,7 +70,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( WIDTH, HEIGHT );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				stats = new Stats();
@@ -144,6 +144,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/webgl_lines_fat.html
+++ b/examples/webgl_lines_fat.html
@@ -47,14 +47,14 @@
 			let insetHeight;
 
 			init();
+			animate();
 
 			function init() {
 
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
-				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setClearColor( 0x000000, 0.0 );
-				renderer.setAnimationLoop( animate );
+				renderer.setSize( window.innerWidth, window.innerHeight );
 				document.body.appendChild( renderer.domElement );
 
 				scene = new THREE.Scene();
@@ -167,6 +167,10 @@
 
 			function animate() {
 
+				requestAnimationFrame( animate );
+
+				stats.update();
+
 				// main scene
 
 				renderer.setClearColor( 0x000000, 0 );
@@ -203,8 +207,6 @@
 				renderer.render( scene, camera2 );
 
 				renderer.setScissorTest( false );
-
-				stats.update();
 
 			}
 

--- a/examples/webgl_lines_fat_raycasting.html
+++ b/examples/webgl_lines_fat_raycasting.html
@@ -93,6 +93,7 @@
 			};
 
 			init();
+			animate();
 
 			function init() {
 
@@ -100,9 +101,8 @@
 
 				renderer = new THREE.WebGLRenderer( { antialias: true, alpha: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
-				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setClearColor( 0x000000, 0.0 );
-				renderer.setAnimationLoop( animate );
+				renderer.setSize( window.innerWidth, window.innerHeight );
 				document.body.appendChild( renderer.domElement );
 
 				scene = new THREE.Scene();
@@ -228,6 +228,10 @@
 
 			function animate() {
 
+				requestAnimationFrame( animate );
+
+				stats.update();
+
 				const delta = clock.getDelta();
 
 				const obj = line.visible ? line : segments;
@@ -277,8 +281,6 @@
 				gpuPanel.startQuery();
 				renderer.render( scene, camera );
 				gpuPanel.endQuery();
-
-				stats.update();
 
 			}
 

--- a/examples/webgl_lines_fat_wireframe.html
+++ b/examples/webgl_lines_fat_wireframe.html
@@ -45,14 +45,14 @@
 			let insetHeight;
 
 			init();
+			animate();
 
 			function init() {
 
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
-				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setClearColor( 0x000000, 0.0 );
-				renderer.setAnimationLoop( animate );
+				renderer.setSize( window.innerWidth, window.innerHeight );
 				document.body.appendChild( renderer.domElement );
 
 				scene = new THREE.Scene();
@@ -130,6 +130,10 @@
 
 			function animate() {
 
+				requestAnimationFrame( animate );
+
+				stats.update();
+
 				// main scene
 
 				renderer.setClearColor( 0x000000, 0 );
@@ -162,8 +166,6 @@
 				renderer.render( scene, camera2 );
 
 				renderer.setScissorTest( false );
-
-				stats.update();
 
 			}
 

--- a/examples/webgl_loader_3dm.html
+++ b/examples/webgl_loader_3dm.html
@@ -54,6 +54,7 @@
 			let controls, gui;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -62,7 +63,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				camera = new THREE.PerspectiveCamera( 60, window.innerWidth / window.innerHeight, 1, 1000 );
@@ -87,11 +87,11 @@
 
 				}, function ( progress ) {
 
-					console.log( ( progress.loaded / progress.total * 100 ) + '%' );
+					console.log ( ( progress.loaded / progress.total * 100 ) + '%' );
 
 				}, function ( error ) {
 
-					console.log( error );
+					console.log ( error );
 
 				} );
 
@@ -117,6 +117,8 @@
 
 				controls.update();
 				renderer.render( scene, camera );
+
+				requestAnimationFrame( animate );
 
 			}
 

--- a/examples/webgl_loader_3ds.html
+++ b/examples/webgl_loader_3ds.html
@@ -32,6 +32,7 @@
 			let camera, scene, renderer;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -73,7 +74,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				controls = new TrackballControls( camera, renderer.domElement );
@@ -95,6 +95,8 @@
 
 				controls.update();
 				renderer.render( scene, camera );
+
+				requestAnimationFrame( animate );
 
 			}
 		</script>

--- a/examples/webgl_loader_bvh.html
+++ b/examples/webgl_loader_bvh.html
@@ -43,6 +43,7 @@
 			let mixer;
 
 			init();
+			animate();
 
 			const loader = new BVHLoader();
 			loader.load( 'models/bvh/pirouette.bvh', function ( result ) {
@@ -72,7 +73,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				controls = new OrbitControls( camera, renderer.domElement );
@@ -93,6 +93,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				const delta = clock.getDelta();
 

--- a/examples/webgl_loader_collada.html
+++ b/examples/webgl_loader_collada.html
@@ -35,6 +35,7 @@
 			let camera, scene, renderer, elf;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -79,7 +80,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				//
@@ -103,6 +103,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/webgl_loader_collada_kinematics.html
+++ b/examples/webgl_loader_collada_kinematics.html
@@ -61,6 +61,7 @@
 				kinematics = collada.kinematics;
 
 				init();
+				animate();
 
 			} );
 
@@ -91,7 +92,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				stats = new Stats();
@@ -172,9 +172,11 @@
 
 			function animate() {
 
-				TWEEN.update();
+				requestAnimationFrame( animate );
+
 				render();
 				stats.update();
+				TWEEN.update();
 
 			}
 

--- a/examples/webgl_loader_collada_skinning.html
+++ b/examples/webgl_loader_collada_skinning.html
@@ -36,6 +36,7 @@
 			let camera, scene, renderer, mixer;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -82,7 +83,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				//
@@ -115,6 +115,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/webgl_loader_draco.html
+++ b/examples/webgl_loader_draco.html
@@ -38,6 +38,7 @@
 		dracoLoader.setDecoderConfig( { type: 'js' } );
 
 		init();
+		animate();
 
 		function init() {
 
@@ -89,7 +90,6 @@
 			renderer = new THREE.WebGLRenderer( { antialias: true } );
 			renderer.setPixelRatio( window.devicePixelRatio );
 			renderer.setSize( window.innerWidth, window.innerHeight );
-			renderer.setAnimationLoop( animate );
 			renderer.shadowMap.enabled = true;
 			container.appendChild( renderer.domElement );
 
@@ -107,6 +107,13 @@
 		}
 
 		function animate() {
+
+			render();
+			requestAnimationFrame( animate );
+
+		}
+
+		function render() {
 
 			const timer = Date.now() * 0.0003;
 

--- a/examples/webgl_loader_fbx.html
+++ b/examples/webgl_loader_fbx.html
@@ -38,6 +38,7 @@
 			let mixer;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -104,7 +105,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.shadowMap.enabled = true;
 				container.appendChild( renderer.domElement );
 
@@ -132,6 +132,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				const delta = clock.getDelta();
 

--- a/examples/webgl_loader_fbx_nurbs.html
+++ b/examples/webgl_loader_fbx_nurbs.html
@@ -33,6 +33,7 @@
 			let camera, scene, renderer, stats;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -63,7 +64,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				const controls = new OrbitControls( camera, renderer.domElement );
@@ -86,6 +86,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				renderer.render( scene, camera );
 

--- a/examples/webgl_loader_gltf_iridescence.html
+++ b/examples/webgl_loader_gltf_iridescence.html
@@ -42,7 +42,7 @@
 			async function init() {
 
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
-				renderer.setAnimationLoop( animate );
+				renderer.setAnimationLoop( render );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
@@ -80,6 +80,8 @@
 
 				scene.add( gltf.scene );
 
+				render();
+
 				window.addEventListener( 'resize', onWindowResize );
 
 			}
@@ -92,9 +94,11 @@
 
 				renderer.setSize( window.innerWidth, window.innerHeight );
 
+				render();
+
 			}
 
-			function animate() {
+			function render() {
 
 				controls.update();
 				renderer.render( scene, camera );

--- a/examples/webgl_loader_gltf_sheen.html
+++ b/examples/webgl_loader_gltf_sheen.html
@@ -40,6 +40,7 @@
 			let camera, scene, renderer, controls;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -71,7 +72,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				renderer.toneMappingExposure = 1;
 				container.appendChild( renderer.domElement );
@@ -106,7 +106,15 @@
 
 			function animate() {
 
+				requestAnimationFrame( animate );
+
 				controls.update(); // required if damping enabled
+
+				render();
+
+			}
+
+			function render() {
 
 				renderer.render( scene, camera );
 

--- a/examples/webgl_loader_gltf_transmission.html
+++ b/examples/webgl_loader_gltf_transmission.html
@@ -77,9 +77,9 @@
 					} );
 
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
+				renderer.setAnimationLoop( render );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				renderer.toneMappingExposure = 1;
 				container.appendChild( renderer.domElement );
@@ -108,7 +108,7 @@
 
 			//
 
-			function animate() {
+			function render() {
 
 				if ( mixer ) mixer.update( clock.getDelta() );
 

--- a/examples/webgl_loader_imagebitmap.html
+++ b/examples/webgl_loader_imagebitmap.html
@@ -28,6 +28,7 @@
 			let group, cubes;
 
 			init();
+			animate();
 
 			function addImageBitmap() {
 
@@ -113,7 +114,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				// TESTS
@@ -145,6 +145,8 @@
 				group.rotation.y = performance.now() / 3000;
 
 				renderer.render( scene, camera );
+
+				requestAnimationFrame( animate );
 
 			}
 

--- a/examples/webgl_loader_ldraw.html
+++ b/examples/webgl_loader_ldraw.html
@@ -69,6 +69,8 @@
 			};
 
 			init();
+			animate();
+
 
 			function init() {
 
@@ -83,7 +85,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				container.appendChild( renderer.domElement );
 
@@ -320,6 +321,7 @@
 
 			function animate() {
 
+				requestAnimationFrame( animate );
 				controls.update();
 				render();
 

--- a/examples/webgl_loader_lwo.html
+++ b/examples/webgl_loader_lwo.html
@@ -77,7 +77,7 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
+				renderer.setAnimationLoop( animation );
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				container.appendChild( renderer.domElement );
 
@@ -98,7 +98,7 @@
 
 			}
 
-			function animate() {
+			function animation() {
 
 				renderer.render( scene, camera );
 

--- a/examples/webgl_loader_md2.html
+++ b/examples/webgl_loader_md2.html
@@ -55,6 +55,7 @@
 			let stats;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -120,7 +121,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( SCREEN_WIDTH, SCREEN_HEIGHT );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				//
@@ -324,6 +324,7 @@
 
 			function animate() {
 
+				requestAnimationFrame( animate );
 				render();
 
 				stats.update();

--- a/examples/webgl_loader_md2_control.html
+++ b/examples/webgl_loader_md2_control.html
@@ -64,6 +64,7 @@
 			const clock = new THREE.Clock();
 
 			init();
+			animate();
 
 			function init() {
 
@@ -129,7 +130,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( SCREEN_WIDTH, SCREEN_HEIGHT );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				//
@@ -306,6 +306,7 @@
 
 			function animate() {
 
+				requestAnimationFrame( animate );
 				render();
 
 				stats.update();

--- a/examples/webgl_loader_mdd.html
+++ b/examples/webgl_loader_mdd.html
@@ -61,6 +61,8 @@
 					mixer = new THREE.AnimationMixer( mesh );
 					mixer.clipAction( clip ).play(); // use clip
 
+					animate();
+
 				} );
 
 				//
@@ -68,7 +70,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				window.addEventListener( 'resize', onWindowResize );
@@ -85,6 +86,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				const delta = clock.getDelta();
 

--- a/examples/webgl_loader_mmd.html
+++ b/examples/webgl_loader_mmd.html
@@ -60,6 +60,7 @@
 				Ammo = AmmoLib;
 
 				init();
+				animate();
 
 			} );
 
@@ -93,7 +94,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				effect = new OutlineEffect( renderer );
@@ -220,6 +220,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				stats.begin();
 				render();

--- a/examples/webgl_loader_mmd_audio.html
+++ b/examples/webgl_loader_mmd_audio.html
@@ -62,6 +62,7 @@
 				Ammo().then( function () {
 
 					init();
+					animate();
 
 				} );
 
@@ -100,7 +101,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				effect = new OutlineEffect( renderer );
@@ -176,6 +176,13 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
+				render();
+
+			}
+
+			function render() {
 
 				if ( ready ) {
 

--- a/examples/webgl_loader_mmd_pose.html
+++ b/examples/webgl_loader_mmd_pose.html
@@ -56,6 +56,7 @@
 				Ammo = AmmoLib;
 
 				init();
+				animate();
 
 			} );
 
@@ -84,7 +85,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				effect = new OutlineEffect( renderer );
@@ -287,6 +287,13 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
+				render();
+
+			}
+
+			function render() {
 
 				effect.render( scene, camera );
 

--- a/examples/webgl_loader_nrrd.html
+++ b/examples/webgl_loader_nrrd.html
@@ -41,6 +41,7 @@
 				renderer;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -149,7 +150,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				controls = new TrackballControls( camera, renderer.domElement );
@@ -180,6 +180,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				controls.update();
 

--- a/examples/webgl_loader_obj.html
+++ b/examples/webgl_loader_obj.html
@@ -34,6 +34,7 @@
 
 			init();
 
+
 			function init() {
 
 				camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 0.1, 20 );

--- a/examples/webgl_loader_obj_mtl.html
+++ b/examples/webgl_loader_obj_mtl.html
@@ -32,6 +32,8 @@
 			let camera, scene, renderer;
 
 			init();
+			animate();
+
 
 			function init() {
 
@@ -86,7 +88,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				//
@@ -114,6 +115,7 @@
 
 			function animate() {
 
+				requestAnimationFrame( animate );
 				renderer.render( scene, camera );
 
 			}

--- a/examples/webgl_loader_pdb.html
+++ b/examples/webgl_loader_pdb.html
@@ -68,6 +68,7 @@
 			const offset = new THREE.Vector3();
 
 			init();
+			animate();
 
 			function init() {
 
@@ -94,7 +95,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.getElementById( 'container' ).appendChild( renderer.domElement );
 
 				labelRenderer = new CSS2DRenderer();
@@ -219,6 +219,8 @@
 
 					}
 
+					render();
+
 				} );
 
 			}
@@ -233,10 +235,13 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				labelRenderer.setSize( window.innerWidth, window.innerHeight );
 
+				render();
+
 			}
 
 			function animate() {
 
+				requestAnimationFrame( animate );
 				controls.update();
 
 				const time = Date.now() * 0.0004;

--- a/examples/webgl_loader_ply.html
+++ b/examples/webgl_loader_ply.html
@@ -35,6 +35,7 @@
 			let camera, cameraTarget, scene, renderer;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -117,7 +118,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 
 				renderer.shadowMap.enabled = true;
 
@@ -168,6 +168,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/webgl_loader_stl.html
+++ b/examples/webgl_loader_stl.html
@@ -35,6 +35,7 @@
 			let camera, cameraTarget, scene, renderer;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -153,7 +154,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 
 				renderer.shadowMap.enabled = true;
 
@@ -201,6 +201,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/webgl_loader_texture_dds.html
+++ b/examples/webgl_loader_texture_dds.html
@@ -32,6 +32,7 @@
 			const meshes = [];
 
 			init();
+			animate();
 
 			function init() {
 
@@ -209,7 +210,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				window.addEventListener( 'resize', onWindowResize );
@@ -226,6 +226,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				const time = Date.now() * 0.001;
 

--- a/examples/webgl_loader_texture_hdrjpg.html
+++ b/examples/webgl_loader_texture_hdrjpg.html
@@ -75,6 +75,7 @@
 			const resolutions = {};
 
 			init();
+			animate();
 
 			function init() {
 
@@ -165,7 +166,6 @@
 
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				stats = new Stats();
@@ -236,7 +236,9 @@
 			}
 
 			function animate() {
-			
+
+				requestAnimationFrame( animate );
+
 				stats.begin();
 				render();
 				stats.end();

--- a/examples/webgl_loader_texture_ktx.html
+++ b/examples/webgl_loader_texture_ktx.html
@@ -46,13 +46,13 @@
 	const meshes = [];
 
 	init();
+	animate();
 
 	function init() {
 
 		renderer = new THREE.WebGLRenderer( { antialias: true } );
 		renderer.setPixelRatio( window.devicePixelRatio );
 		renderer.setSize( window.innerWidth, window.innerHeight );
-		renderer.setAnimationLoop( animate );
 		document.body.appendChild( renderer.domElement );
 
 		const formats = {
@@ -164,6 +164,8 @@
 	}
 
 	function animate() {
+
+		requestAnimationFrame( animate );
 
 		const time = Date.now() * 0.001;
 

--- a/examples/webgl_loader_texture_ktx2.html
+++ b/examples/webgl_loader_texture_ktx2.html
@@ -72,7 +72,7 @@
 				sample: Object.values( SAMPLES )[ 0 ],
 			};
 
-			init();
+			init().then( animate );
 
 			async function init() {
 
@@ -116,11 +116,12 @@
 
 				await loadTexture( params.sample );
 
-				renderer.setAnimationLoop( animate );
 
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				controls.update();
 

--- a/examples/webgl_loader_texture_lottie.html
+++ b/examples/webgl_loader_texture_lottie.html
@@ -33,6 +33,7 @@
 			let mesh;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -61,7 +62,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				const environment = new RoomEnvironment( renderer );
@@ -124,6 +124,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				if ( mesh ) {
 

--- a/examples/webgl_loader_texture_pvrtc.html
+++ b/examples/webgl_loader_texture_pvrtc.html
@@ -31,6 +31,7 @@
 			const meshes = [];
 
 			init();
+			animate();
 
 			function init() {
 
@@ -161,7 +162,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				window.addEventListener( 'resize', onWindowResize );
@@ -178,6 +178,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				const time = Date.now() * 0.001;
 

--- a/examples/webgl_loader_texture_tga.html
+++ b/examples/webgl_loader_texture_tga.html
@@ -32,6 +32,7 @@
 			let camera, scene, renderer, stats;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -84,7 +85,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				//
@@ -115,8 +115,16 @@
 
 			function animate() {
 
-				renderer.render( scene, camera );
+				requestAnimationFrame( animate );
+
+				render();
 				stats.update();
+
+			}
+
+			function render() {
+
+				renderer.render( scene, camera );
 
 			}
 

--- a/examples/webgl_loader_ttf.html
+++ b/examples/webgl_loader_ttf.html
@@ -54,6 +54,7 @@
 			let windowHalfX = window.innerWidth / 2;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -113,7 +114,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				// EVENTS
@@ -280,6 +280,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				group.rotation.y += ( targetRotation - group.rotation.y ) * 0.05;
 

--- a/examples/webgl_loader_usdz.html
+++ b/examples/webgl_loader_usdz.html
@@ -40,6 +40,7 @@
 			let camera, scene, renderer;
 
 			init();
+			animate();
 
 			async function init() {
 
@@ -47,6 +48,19 @@
 				camera.position.set( 0, 0.75, - 1.5 );
 
 				scene = new THREE.Scene();
+
+				renderer = new THREE.WebGLRenderer( { antialias: true } );
+				renderer.setPixelRatio( window.devicePixelRatio );
+				renderer.setSize( window.innerWidth, window.innerHeight );
+				renderer.toneMapping = THREE.ACESFilmicToneMapping;
+				renderer.toneMappingExposure = 2.0;
+				document.body.appendChild( renderer.domElement );
+
+				const controls = new OrbitControls( camera, renderer.domElement );
+				controls.minDistance = 1;
+				controls.maxDistance = 8;
+				// controls.target.y = 15;
+				// controls.update();
 
 				const rgbeLoader = new RGBELoader()
 					.setPath( 'textures/equirectangular/' );
@@ -73,22 +87,6 @@
 				model.position.z = - 0.25;
 				scene.add( model );
 
-				// renderer
-
-				renderer = new THREE.WebGLRenderer( { antialias: true } );
-				renderer.setPixelRatio( window.devicePixelRatio );
-				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
-				renderer.toneMapping = THREE.ACESFilmicToneMapping;
-				renderer.toneMappingExposure = 2.0;
-				document.body.appendChild( renderer.domElement );
-
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.minDistance = 1;
-				controls.maxDistance = 8;
-				// controls.target.y = 15;
-				// controls.update();
-
 				window.addEventListener( 'resize', onWindowResize );
 
 			}
@@ -103,6 +101,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				renderer.render( scene, camera );
 

--- a/examples/webgl_loader_vox.html
+++ b/examples/webgl_loader_vox.html
@@ -31,6 +31,7 @@
 			let camera, controls, scene, renderer;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -75,7 +76,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				// controls
@@ -131,6 +131,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				controls.update();
 

--- a/examples/webgl_loader_vrml.html
+++ b/examples/webgl_loader_vrml.html
@@ -57,6 +57,7 @@
 			let vrmlScene;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -83,7 +84,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				// controls
@@ -149,6 +149,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				controls.update(); // to support damping
 

--- a/examples/webgl_loader_vtk.html
+++ b/examples/webgl_loader_vtk.html
@@ -37,6 +37,7 @@
 			let camera, controls, scene, renderer;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -126,7 +127,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				// controls
@@ -157,6 +157,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				controls.update();
 

--- a/examples/webgl_loader_xyz.html
+++ b/examples/webgl_loader_xyz.html
@@ -33,6 +33,7 @@
 			let points;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -64,7 +65,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				//
@@ -83,6 +83,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				const delta = clock.getDelta();
 

--- a/examples/webgl_lod.html
+++ b/examples/webgl_lod.html
@@ -34,6 +34,7 @@
 			const clock = new THREE.Clock();
 
 			init();
+			animate();
 
 			function init() {
 
@@ -93,7 +94,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				//
@@ -118,6 +118,13 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
+				render();
+
+			}
+
+			function render() {
 
 				controls.update( clock.getDelta() );
 

--- a/examples/webgl_marchingcubes.html
+++ b/examples/webgl_marchingcubes.html
@@ -52,6 +52,7 @@
 		const clock = new THREE.Clock();
 
 		init();
+		animate();
 
 		function init() {
 
@@ -103,7 +104,6 @@
 			renderer = new THREE.WebGLRenderer();
 			renderer.setPixelRatio( window.devicePixelRatio );
 			renderer.setSize( window.innerWidth, window.innerHeight );
-			renderer.setAnimationLoop( animate );
 			container.appendChild( renderer.domElement );
 
 			// CONTROLS
@@ -320,6 +320,8 @@
 		//
 
 		function animate() {
+
+			requestAnimationFrame( animate );
 
 			render();
 			stats.update();

--- a/examples/webgl_materials_alphahash.html
+++ b/examples/webgl_materials_alphahash.html
@@ -49,6 +49,7 @@
 			};
 
 			init();
+			animate();
 
 			function init() {
 
@@ -99,7 +100,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				//
@@ -189,6 +189,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 

--- a/examples/webgl_materials_blending.html
+++ b/examples/webgl_materials_blending.html
@@ -26,6 +26,7 @@
 			const textureLoader = new THREE.TextureLoader();
 
 			init();
+			animate();
 
 			function init() {
 
@@ -122,7 +123,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				// EVENTS
@@ -170,6 +170,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				const time = Date.now() * 0.00025;
 				const ox = ( time * - 0.01 * mapBg.repeat.x ) % 1;

--- a/examples/webgl_materials_blending_custom.html
+++ b/examples/webgl_materials_blending_custom.html
@@ -34,6 +34,7 @@
 			const equations = { Add: THREE.AddEquation, Subtract: THREE.SubtractEquation, ReverseSubtract: THREE.ReverseSubtractEquation, Min: THREE.MinEquation, Max: THREE.MaxEquation };
 
 			init();
+			animate();
 
 			function init() {
 
@@ -173,7 +174,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				// EVENTS
@@ -236,6 +236,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				const time = Date.now() * 0.00025;
 				const ox = ( time * - 0.01 * mapBg.repeat.x ) % 1;

--- a/examples/webgl_materials_bumpmap.html
+++ b/examples/webgl_materials_bumpmap.html
@@ -48,6 +48,7 @@
 			const windowHalfY = window.innerHeight / 2;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -104,7 +105,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				renderer.shadowMap.enabled = true;
@@ -156,6 +156,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 

--- a/examples/webgl_materials_car.html
+++ b/examples/webgl_materials_car.html
@@ -68,7 +68,7 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
+				renderer.setAnimationLoop( render );
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				renderer.toneMappingExposure = 0.85;
 				container.appendChild( renderer.domElement );
@@ -193,7 +193,7 @@
 
 			}
 
-			function animate() {
+			function render() {
 
 				controls.update();
 

--- a/examples/webgl_materials_channels.html
+++ b/examples/webgl_materials_channels.html
@@ -59,6 +59,18 @@
 			const BIAS = - 0.428408; // from original model
 
 			init();
+			animate();
+			initGui();
+
+			// Init gui
+			function initGui() {
+
+				const gui = new GUI();
+				gui.add( params, 'material', [ 'standard', 'normal', 'velocity', 'depthBasic', 'depthRGBA' ] );
+				gui.add( params, 'camera', [ 'perspective', 'ortho' ] );
+				gui.add( params, 'side', [ 'front', 'back', 'double' ] );
+
+			}
 
 			function init() {
 
@@ -68,7 +80,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				//
@@ -212,13 +223,6 @@
 
 				//
 
-				const gui = new GUI();
-				gui.add( params, 'material', [ 'standard', 'normal', 'velocity', 'depthBasic', 'depthRGBA' ] );
-				gui.add( params, 'camera', [ 'perspective', 'ortho' ] );
-				gui.add( params, 'side', [ 'front', 'back', 'double' ] );
-
-				//
-
 				window.addEventListener( 'resize', onWindowResize );
 
 			}
@@ -245,6 +249,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				stats.begin();
 				render();

--- a/examples/webgl_materials_cubemap.html
+++ b/examples/webgl_materials_cubemap.html
@@ -39,6 +39,7 @@
 			let pointLight;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -103,7 +104,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				//controls
@@ -131,6 +131,13 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
+				render();
+
+			}
+
+			function render() {
 
 				renderer.render( scene, camera );
 				stats.update();

--- a/examples/webgl_materials_cubemap_dynamic.html
+++ b/examples/webgl_materials_cubemap_dynamic.html
@@ -48,7 +48,7 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
+				renderer.setAnimationLoop( animation );
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				document.body.appendChild( renderer.domElement );
 
@@ -124,7 +124,7 @@
 
 			}
 
-			function animate( msTime ) {
+			function animation( msTime ) {
 
 				const time = msTime / 1000;
 

--- a/examples/webgl_materials_cubemap_mipmaps.html
+++ b/examples/webgl_materials_cubemap_mipmaps.html
@@ -35,6 +35,7 @@
 			let camera, scene, renderer;
 
 			init();
+			animate();
 
 			//load customized cube texture
 			async function loadCubeTextureWithMipmaps() {
@@ -141,7 +142,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				//controls
@@ -164,6 +164,7 @@
 
 			function animate() {
 
+				requestAnimationFrame( animate );
 				renderer.render( scene, camera );
 
 			}

--- a/examples/webgl_materials_cubemap_refraction.html
+++ b/examples/webgl_materials_cubemap_refraction.html
@@ -41,6 +41,7 @@
 			let windowHalfY = window.innerHeight / 2;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -82,7 +83,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				stats = new Stats();
@@ -147,6 +147,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/webgl_materials_cubemap_render_to_mipmaps.html
+++ b/examples/webgl_materials_cubemap_render_to_mipmaps.html
@@ -84,6 +84,8 @@
 
 
 			init();
+			animate();
+
 
 			async function loadCubeTexture( urls ) {
 
@@ -167,7 +169,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				scene = new THREE.Scene();
@@ -228,6 +229,7 @@
 
 			function animate() {
 
+				requestAnimationFrame( animate );
 				renderer.render( scene, camera );
 
 			}

--- a/examples/webgl_materials_curvature.html
+++ b/examples/webgl_materials_curvature.html
@@ -64,6 +64,7 @@
 			let ninjaMeshRaw, curvatureAttribute, bufferGeo;
 
 			init();
+			animate();
 
 			//returns average of elements in a dictionary
 			function average( dict ) {
@@ -136,7 +137,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.autoClear = false;
 				document.body.appendChild( renderer.domElement );
 
@@ -354,6 +354,14 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
+
+				render();
+
+			}
+
+			function render() {
 
 				renderer.render( scene, camera );
 

--- a/examples/webgl_materials_displacementmap.html
+++ b/examples/webgl_materials_displacementmap.html
@@ -55,6 +55,7 @@
 			let r = 0.0;
 
 			init();
+			animate();
 			initGui();
 
 			// Init gui
@@ -114,7 +115,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				//
@@ -234,6 +234,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				controls.update();
 

--- a/examples/webgl_materials_envmaps.html
+++ b/examples/webgl_materials_envmaps.html
@@ -34,6 +34,7 @@
 			let sphereMesh, sphereMaterial, params;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -73,7 +74,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				//
@@ -150,6 +150,14 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
+
+				render();
+
+			}
+
+			function render() {
 
 				if ( params.backgroundRotationX ) {
 

--- a/examples/webgl_materials_envmaps_exr.html
+++ b/examples/webgl_materials_envmaps_exr.html
@@ -45,6 +45,7 @@
 			let pngBackground, exrBackground;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -59,7 +60,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 
 				container.appendChild( renderer.domElement );
 
@@ -146,6 +146,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				stats.begin();
 				render();

--- a/examples/webgl_materials_envmaps_groundprojected.html
+++ b/examples/webgl_materials_envmaps_groundprojected.html
@@ -147,14 +147,15 @@
 
 				const gui = new GUI();
 
-				gui.add( params, 'enabled' ).name( 'Grounded' ).onChange( function ( value ) {
+				gui.add( params, 'enabled' ).name( "Grounded" ).onChange( function ( value ) {
 
 					if ( value ) {
 
 						scene.add( skybox );
 						scene.background = null;
 
-					} else {
+					}
+					else {
 
 						scene.remove( skybox );
 						scene.background = scene.environment;
@@ -164,9 +165,7 @@
 					render();
 
 				} );
-
 				gui.open();
-			
 			}
 
 			function onWindowResize() {

--- a/examples/webgl_materials_envmaps_hdr.html
+++ b/examples/webgl_materials_envmaps_hdr.html
@@ -50,6 +50,7 @@
 			let ldrCubeMap, hdrCubeMap, rgbmCubeMap;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -132,7 +133,6 @@
 
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				//renderer.toneMapping = ReinhardToneMapping;
@@ -170,6 +170,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				stats.begin();
 				render();

--- a/examples/webgl_materials_modified.html
+++ b/examples/webgl_materials_modified.html
@@ -34,6 +34,7 @@
 			let camera, scene, renderer, stats;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -62,7 +63,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				const controls = new OrbitControls( camera, renderer.domElement );
@@ -133,6 +133,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 

--- a/examples/webgl_materials_normalmap.html
+++ b/examples/webgl_materials_normalmap.html
@@ -57,6 +57,7 @@
 			let composer, effectFXAA;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -119,7 +120,6 @@
 
 				renderer = new THREE.WebGLRenderer();
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				//
@@ -190,6 +190,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 

--- a/examples/webgl_materials_physical_clearcoat.html
+++ b/examples/webgl_materials_physical_clearcoat.html
@@ -39,6 +39,7 @@
 			let group;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -176,7 +177,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				//
@@ -219,7 +219,9 @@
 			//
 
 			function animate() {
-			
+
+				requestAnimationFrame( animate );
+
 				render();
 
 				stats.update();

--- a/examples/webgl_materials_subsurface_scattering.html
+++ b/examples/webgl_materials_subsurface_scattering.html
@@ -38,6 +38,7 @@
 		let model;
 
 		init();
+		animate();
 
 		function init() {
 
@@ -74,7 +75,6 @@
 			renderer = new THREE.WebGLRenderer( { antialias: true } );
 			renderer.setPixelRatio( window.devicePixelRatio );
 			renderer.setSize( window.innerWidth, window.innerHeight );
-			renderer.setAnimationLoop( animate );
 			container.appendChild( renderer.domElement );
 
 			//
@@ -202,6 +202,8 @@
 		//
 
 		function animate() {
+
+			requestAnimationFrame( animate );
 
 			render();
 

--- a/examples/webgl_materials_texture_anisotropy.html
+++ b/examples/webgl_materials_texture_anisotropy.html
@@ -81,6 +81,8 @@
 			const windowHalfY = window.innerHeight / 2;
 
 			init();
+			animate();
+
 
 			function init() {
 
@@ -166,7 +168,6 @@
 
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( SCREEN_WIDTH, SCREEN_HEIGHT );
-				renderer.setAnimationLoop( animate );
 				renderer.autoClear = false;
 
 				renderer.domElement.style.position = 'relative';
@@ -191,6 +192,8 @@
 
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/webgl_materials_texture_canvas.html
+++ b/examples/webgl_materials_texture_canvas.html
@@ -43,6 +43,7 @@
 
 			init();
 			setupCanvasDrawing();
+			animate();
 
 			function init() {
 
@@ -59,7 +60,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				window.addEventListener( 'resize', onWindowResize );
@@ -139,6 +139,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				mesh.rotation.x += 0.01;
 				mesh.rotation.y += 0.01;

--- a/examples/webgl_materials_texture_filters.html
+++ b/examples/webgl_materials_texture_filters.html
@@ -69,6 +69,8 @@
 			const windowHalfY = window.innerHeight / 2;
 
 			init();
+			animate();
+
 
 			function init() {
 
@@ -188,7 +190,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( SCREEN_WIDTH, SCREEN_HEIGHT );
-				renderer.setAnimationLoop( animate );
 				renderer.autoClear = false;
 
 				renderer.domElement.style.position = 'relative';
@@ -208,6 +209,14 @@
 
 
 			function animate() {
+
+				requestAnimationFrame( animate );
+
+				render();
+
+			}
+
+			function render() {
 
 				camera.position.x += ( mouseX - camera.position.x ) * .05;
 				camera.position.y += ( - ( mouseY - 200 ) - camera.position.y ) * .05;

--- a/examples/webgl_materials_texture_manualmipmap.html
+++ b/examples/webgl_materials_texture_manualmipmap.html
@@ -69,6 +69,8 @@
 			const windowHalfY = window.innerHeight / 2;
 
 			init();
+			animate();
+
 
 			function init() {
 
@@ -200,7 +202,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( SCREEN_WIDTH, SCREEN_HEIGHT );
-				renderer.setAnimationLoop( animate );
 				renderer.autoClear = false;
 
 				renderer.domElement.style.position = 'relative';
@@ -220,6 +221,14 @@
 
 
 			function animate() {
+
+				requestAnimationFrame( animate );
+
+				render();
+
+			}
+
+			function render() {
 
 				camera.position.x += ( mouseX - camera.position.x ) * .05;
 				camera.position.y += ( - ( mouseY - 200 ) - camera.position.y ) * .05;

--- a/examples/webgl_materials_texture_partialupdate.html
+++ b/examples/webgl_materials_texture_partialupdate.html
@@ -34,7 +34,7 @@
 
 			init();
 
-			async function init() {
+			function init() {
 
 				camera = new THREE.PerspectiveCamera( 70, window.innerWidth / window.innerHeight, 0.01, 10 );
 				camera.position.z = 2;
@@ -44,7 +44,7 @@
 				clock = new THREE.Clock();
 
 				const loader = new THREE.TextureLoader();
-				diffuseMap = await loader.loadAsync( 'textures/floors/FloorsCheckerboard_S_Diffuse.jpg' );
+				diffuseMap = loader.load( 'textures/floors/FloorsCheckerboard_S_Diffuse.jpg', animate );
 				diffuseMap.colorSpace = THREE.SRGBColorSpace;
 				diffuseMap.minFilter = THREE.LinearFilter;
 				diffuseMap.generateMipmaps = false;
@@ -68,7 +68,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				//
@@ -87,6 +86,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				const elapsedTime = clock.getElapsedTime();
 

--- a/examples/webgl_materials_toon.html
+++ b/examples/webgl_materials_toon.html
@@ -40,6 +40,7 @@
 			loader.load( 'fonts/gentilis_regular.typeface.json', function ( font ) {
 
 				init( font );
+				animate();
 
 			} );
 
@@ -61,7 +62,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				// Materials
@@ -179,6 +179,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				stats.begin();
 				render();

--- a/examples/webgl_materials_video.html
+++ b/examples/webgl_materials_video.html
@@ -67,6 +67,7 @@
 			startButton.addEventListener( 'click', function () {
 
 				init();
+				animate();
 
 			} );
 
@@ -90,7 +91,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				video = document.getElementById( 'video' );
@@ -217,9 +217,17 @@
 
 			//
 
+			function animate() {
+
+				requestAnimationFrame( animate );
+
+				render();
+
+			}
+
 			let h, counter = 1;
 
-			function animate() {
+			function render() {
 
 				const time = Date.now() * 0.00005;
 

--- a/examples/webgl_materials_video_webcam.html
+++ b/examples/webgl_materials_video_webcam.html
@@ -32,6 +32,7 @@
 			let camera, scene, renderer, video;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -67,7 +68,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				const controls = new OrbitControls( camera, renderer.domElement );
@@ -114,6 +114,7 @@
 
 			function animate() {
 
+				requestAnimationFrame( animate );
 				renderer.render( scene, camera );
 
 			}

--- a/examples/webgl_math_obb.html
+++ b/examples/webgl_math_obb.html
@@ -44,6 +44,7 @@
 			const objects = [], mouse = new THREE.Vector2();
 
 			init();
+			animate();
 
 			function init() {
 
@@ -105,7 +106,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				//
@@ -191,6 +191,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				controls.update();
 

--- a/examples/webgl_math_orientation_transform.html
+++ b/examples/webgl_math_orientation_transform.html
@@ -35,6 +35,7 @@
 			const speed = 2;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -69,7 +70,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				//
@@ -92,6 +92,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				const delta = clock.getDelta();
 

--- a/examples/webgl_mesh_batch.html
+++ b/examples/webgl_mesh_batch.html
@@ -73,6 +73,7 @@
 		init();
 		initGeometries();
 		initMesh();
+		animate();
 
 		//
 
@@ -224,7 +225,6 @@
 			renderer = new THREE.WebGLRenderer( { antialias: true } );
 			renderer.setPixelRatio( window.devicePixelRatio );
 			renderer.setSize( width, height );
-			renderer.setAnimationLoop( animate );
 			document.body.appendChild( renderer.domElement );
 
 			// scene
@@ -319,6 +319,8 @@
 		}
 
 		function animate() {
+
+			requestAnimationFrame( animate );
 
 			animateMeshes();
 

--- a/examples/webgl_mirror.html
+++ b/examples/webgl_mirror.html
@@ -45,6 +45,7 @@
 			let groundMirror, verticalMirror;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -54,7 +55,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				// scene
@@ -192,6 +192,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				const timer = Date.now() * 0.01;
 

--- a/examples/webgl_modifier_curve.html
+++ b/examples/webgl_modifier_curve.html
@@ -45,6 +45,7 @@
 				action = ACTION_NONE;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -137,7 +138,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				renderer.domElement.addEventListener( 'pointerdown', onPointerDown );
@@ -181,6 +181,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				if ( action === ACTION_SELECT ) {
 

--- a/examples/webgl_modifier_curve_instanced.html
+++ b/examples/webgl_modifier_curve_instanced.html
@@ -45,6 +45,7 @@
 				action = ACTION_NONE;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -163,7 +164,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				renderer.domElement.addEventListener( 'pointerdown', onPointerDown );
@@ -211,6 +211,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				if ( action === ACTION_SELECT ) {
 

--- a/examples/webgl_modifier_tessellation.html
+++ b/examples/webgl_modifier_tessellation.html
@@ -86,6 +86,7 @@
 			loader.load( 'fonts/helvetiker_bold.typeface.json', function ( font ) {
 
 				init( font );
+				animate();
 
 			} );
 
@@ -182,7 +183,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( WIDTH, HEIGHT );
-				renderer.setAnimationLoop( animate );
 
 				const container = document.getElementById( 'container' );
 				container.appendChild( renderer.domElement );
@@ -208,6 +208,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 

--- a/examples/webgl_morphtargets_face.html
+++ b/examples/webgl_morphtargets_face.html
@@ -43,26 +43,25 @@
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 
-			let camera, scene, renderer, stats, mixer, clock, controls;
-
 			init();
 
 			function init() {
 
-				clock = new THREE.Clock();
+				let mixer;
+
+				const clock = new THREE.Clock();
 
 				const container = document.createElement( 'div' );
 				document.body.appendChild( container );
 
-				camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 1, 20 );
+				const camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 1, 20 );
 				camera.position.set( - 1.8, 0.8, 3 );
 
-				scene = new THREE.Scene();
+				const scene = new THREE.Scene();
 
-				renderer = new THREE.WebGLRenderer( { antialias: true } );
+				const renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 
 				container.appendChild( renderer.domElement );
@@ -108,7 +107,7 @@
 				scene.background = new THREE.Color( 0x666666 );
 				scene.environment = pmremGenerator.fromScene( environment ).texture;
 
-				controls = new OrbitControls( camera, renderer.domElement );
+				const controls = new OrbitControls( camera, renderer.domElement );
 				controls.enableDamping = true;
 				controls.minDistance = 2.5;
 				controls.maxDistance = 5;
@@ -117,40 +116,37 @@
 				controls.maxPolarAngle = Math.PI / 1.8;
 				controls.target.set( 0, 0.15, - 0.2 );
 
-				stats = new Stats();
+				const stats = new Stats();
 				container.appendChild( stats.dom );
 
-				window.addEventListener( 'resize', onWindowResize );
+				renderer.setAnimationLoop( () => {
+
+					const delta = clock.getDelta();
+
+					if ( mixer ) {
+
+						mixer.update( delta );
+
+					}
+
+					renderer.render( scene, camera );
+
+					controls.update();
+
+					stats.update();
+
+				} );
+
+				window.addEventListener( 'resize', () => {
+
+					camera.aspect = window.innerWidth / window.innerHeight;
+					camera.updateProjectionMatrix();
+
+					renderer.setSize( window.innerWidth, window.innerHeight );
+
+				} );
 
 			}
-
-			function onWindowResize() {
-
-				camera.aspect = window.innerWidth / window.innerHeight;
-				camera.updateProjectionMatrix();
-
-				renderer.setSize( window.innerWidth, window.innerHeight );
-
-			}
-
-			function animate() {
-
-				const delta = clock.getDelta();
-
-				if ( mixer ) {
-
-					mixer.update( delta );
-
-				}
-
-				renderer.render( scene, camera );
-
-				controls.update();
-
-				stats.update();
-
-			}
-
 		</script>
 	</body>
 </html>

--- a/examples/webgl_morphtargets_horse.html
+++ b/examples/webgl_morphtargets_horse.html
@@ -48,6 +48,7 @@
 			let prevTime = Date.now();
 
 			init();
+			animate();
 
 			function init() {
 
@@ -90,7 +91,7 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
+
 
 				container.appendChild( renderer.domElement );
 
@@ -117,6 +118,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/webgl_morphtargets_sphere.html
+++ b/examples/webgl_morphtargets_sphere.html
@@ -38,6 +38,7 @@
 			const speed = 0.5;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -88,7 +89,7 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
+
 
 				container.appendChild( renderer.domElement );
 
@@ -115,6 +116,7 @@
 
 			function animate() {
 
+				requestAnimationFrame( animate );
 				timer.update();
 				render();
 

--- a/examples/webgl_morphtargets_webcam.html
+++ b/examples/webgl_morphtargets_webcam.html
@@ -163,7 +163,7 @@
 
 					}
 
-					renderer.setAnimationLoop( animate );
+					renderer.setAnimationLoop( animation );
 
 				} );
 
@@ -215,7 +215,7 @@
 
 			const transform = new THREE.Object3D();
 
-			function animate() {
+			function animation() {
 
 				if ( video.readyState >= HTMLMediaElement.HAVE_METADATA ) {
 
@@ -298,10 +298,10 @@
 
 						}
 
-						eyeL.rotation.z = eyeScore.leftHorizontal * eyeRotationLimit;
-						eyeR.rotation.z = eyeScore.rightHorizontal * eyeRotationLimit;
-						eyeL.rotation.x = eyeScore.leftVertical * eyeRotationLimit;
-						eyeR.rotation.x = eyeScore.rightVertical * eyeRotationLimit;
+					eyeL.rotation.z = eyeScore.leftHorizontal * eyeRotationLimit;
+      					eyeR.rotation.z = eyeScore.rightHorizontal * eyeRotationLimit;
+      					eyeL.rotation.x = eyeScore.leftVertical * eyeRotationLimit;
+      					eyeR.rotation.x = eyeScore.rightVertical * eyeRotationLimit;
 			
 					}
 

--- a/examples/webgl_multiple_elements.html
+++ b/examples/webgl_multiple_elements.html
@@ -83,6 +83,7 @@
 			const scenes = [];
 
 			init();
+			animate();
 
 			function init() {
 
@@ -155,7 +156,6 @@
 				renderer = new THREE.WebGLRenderer( { canvas: canvas, antialias: true } );
 				renderer.setClearColor( 0xffffff, 1 );
 				renderer.setPixelRatio( window.devicePixelRatio );
-				renderer.setAnimationLoop( animate );
 
 			}
 
@@ -173,6 +173,13 @@
 			}
 
 			function animate() {
+
+				render();
+				requestAnimationFrame( animate );
+
+			}
+
+			function render() {
 
 				updateSize();
 

--- a/examples/webgl_multiple_elements_text.html
+++ b/examples/webgl_multiple_elements_text.html
@@ -87,7 +87,6 @@
 
 				renderer = new THREE.WebGLRenderer( { canvas: canvas, antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
-				renderer.setAnimationLoop( animate );
 
 				views = document.querySelectorAll( '.view' );
 
@@ -184,6 +183,13 @@
 			}
 
 			function animate() {
+
+				render();
+				requestAnimationFrame( animate );
+
+			}
+
+			function render() {
 
 				updateSize();
 

--- a/examples/webgl_multiple_scenes_comparison.html
+++ b/examples/webgl_multiple_scenes_comparison.html
@@ -87,7 +87,7 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setScissorTest( true );
-				renderer.setAnimationLoop( animate );
+				renderer.setAnimationLoop( render );
 				container.appendChild( renderer.domElement );
 
 				window.addEventListener( 'resize', onWindowResize );
@@ -154,7 +154,7 @@
 
 			}
 
-			function animate() {
+			function render() {
 
 				renderer.setScissor( 0, 0, sliderPos, window.innerHeight );
 				renderer.render( sceneL, camera );

--- a/examples/webgl_multiple_views.html
+++ b/examples/webgl_multiple_views.html
@@ -89,6 +89,7 @@
 			];
 
 			init();
+			animate();
 
 			function init() {
 
@@ -209,7 +210,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				stats = new Stats();
@@ -243,6 +243,8 @@
 
 				render();
 				stats.update();
+
+				requestAnimationFrame( animate );
 
 			}
 

--- a/examples/webgl_panorama_cube.html
+++ b/examples/webgl_panorama_cube.html
@@ -32,6 +32,7 @@
 			let scene;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -40,7 +41,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				scene = new THREE.Scene();
@@ -117,6 +117,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				controls.update(); // required when damping is enabled
 

--- a/examples/webgl_panorama_equirectangular.html
+++ b/examples/webgl_panorama_equirectangular.html
@@ -36,6 +36,7 @@
 				phi = 0, theta = 0;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -60,7 +61,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				container.style.touchAction = 'none';
@@ -169,6 +169,13 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
+				update();
+
+			}
+
+			function update() {
 
 				if ( isUserInteracting === false ) {
 

--- a/examples/webgl_points_billboards.html
+++ b/examples/webgl_points_billboards.html
@@ -36,6 +36,7 @@
 			let windowHalfY = window.innerHeight / 2;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -74,7 +75,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				//
@@ -129,6 +129,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/webgl_points_dynamic.html
+++ b/examples/webgl_points_dynamic.html
@@ -52,6 +52,7 @@
 			let stats;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -95,7 +96,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.autoClear = false;
 				container.appendChild( renderer.domElement );
 
@@ -237,6 +237,7 @@
 
 			function animate() {
 
+				requestAnimationFrame( animate );
 				render();
 				stats.update();
 

--- a/examples/webgl_points_sprites.html
+++ b/examples/webgl_points_sprites.html
@@ -39,6 +39,7 @@
 			const materials = [];
 
 			init();
+			animate();
 
 			function init() {
 
@@ -109,7 +110,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				//
@@ -171,6 +171,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/webgl_points_waves.html
+++ b/examples/webgl_points_waves.html
@@ -70,6 +70,7 @@
 			let windowHalfY = window.innerHeight / 2;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -131,7 +132,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				stats = new Stats();
@@ -172,6 +172,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/webgl_portal.html
+++ b/examples/webgl_portal.html
@@ -46,6 +46,7 @@
 				rightPortalTexture, bottomLeftCorner, bottomRightCorner, topLeftCorner;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -53,12 +54,11 @@
 
 				// renderer
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
+				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
-				renderer.localClippingEnabled = true;
-				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				container.appendChild( renderer.domElement );
+				renderer.localClippingEnabled = true;
 
 				// scene
 				scene = new THREE.Scene();
@@ -204,6 +204,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				// move the bouncing sphere(s)
 				const timerOne = Date.now() * 0.01;

--- a/examples/webgl_postprocessing.html
+++ b/examples/webgl_postprocessing.html
@@ -32,13 +32,13 @@
 			let object;
 
 			init();
+			animate();
 
 			function init() {
 
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				//
@@ -105,6 +105,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				object.rotation.x += 0.005;
 				object.rotation.y += 0.01;

--- a/examples/webgl_postprocessing_3dlut.html
+++ b/examples/webgl_postprocessing_3dlut.html
@@ -63,6 +63,7 @@
 			let composer, lutPass;
 
 			init();
+			render();
 
 			function init() {
 
@@ -130,7 +131,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				container.appendChild( renderer.domElement );
 
@@ -154,6 +154,7 @@
 				gui.add( params, 'enabled' );
 				gui.add( params, 'lut', Object.keys( lutMap ) );
 				gui.add( params, 'intensity' ).min( 0 ).max( 1 );
+				gui.add( params, 'use2DLut' );
 
 				window.addEventListener( 'resize', onWindowResize );
 
@@ -167,11 +168,15 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				composer.setSize( window.innerWidth, window.innerHeight );
 
+				render();
+
 			}
 
 			//
 
-			function animate() {
+			function render() {
+
+				requestAnimationFrame( render );
 
 				lutPass.enabled = params.enabled && Boolean( lutMap[ params.lut ] );
 				lutPass.intensity = params.intensity;

--- a/examples/webgl_postprocessing_advanced.html
+++ b/examples/webgl_postprocessing_advanced.html
@@ -66,6 +66,7 @@
 			const delta = 0.01;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -126,7 +127,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( width, height );
-				renderer.setAnimationLoop( animate );
 				renderer.autoClear = false;
 
 				//
@@ -315,6 +315,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				stats.begin();
 				render();

--- a/examples/webgl_postprocessing_afterimage.html
+++ b/examples/webgl_postprocessing_afterimage.html
@@ -39,13 +39,14 @@
 			};
 
 			init();
+			createGUI();
+			animate();
 
 			function init() {
 
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				camera = new THREE.PerspectiveCamera( 70, window.innerWidth / window.innerHeight, 1, 1000 );
@@ -72,6 +73,22 @@
 
 				window.addEventListener( 'resize', onWindowResize );
 
+				if ( typeof TESTING !== 'undefined' ) {
+
+					for ( let i = 0; i < 45; i ++ ) {
+
+						render();
+
+					}
+
+
+
+				}
+
+			}
+
+			function createGUI() {
+
 				const gui = new GUI( { title: 'Damp setting' } );
 				gui.add( afterimagePass.uniforms[ 'damp' ], 'value', 0, 1 ).step( 0.001 );
 				gui.add( params, 'enable' );
@@ -88,7 +105,7 @@
 
 			}
 
-			function animate() {
+			function render() {
 
 				mesh.rotation.x += 0.005;
 				mesh.rotation.y += 0.01;
@@ -97,6 +114,13 @@
 
 				composer.render();
 
+
+			}
+
+			function animate() {
+
+				requestAnimationFrame( animate );
+				render();
 
 			}
 

--- a/examples/webgl_postprocessing_backgrounds.html
+++ b/examples/webgl_postprocessing_backgrounds.html
@@ -59,6 +59,7 @@
 			};
 
 			init();
+			animate();
 
 			clearGui();
 
@@ -96,7 +97,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( devicePixelRatio );
 				renderer.setSize( width, height );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				stats = new Stats();
@@ -207,6 +207,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				stats.begin();
 

--- a/examples/webgl_postprocessing_dof.html
+++ b/examples/webgl_postprocessing_dof.html
@@ -51,6 +51,7 @@
 			const postprocessing = {};
 
 			init();
+			animate();
 
 			function init() {
 
@@ -65,7 +66,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( width, height );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				const path = 'textures/cube/SwedishRoyalCastle/';
@@ -221,6 +221,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate, renderer.domElement );
 
 				stats.begin();
 				render();

--- a/examples/webgl_postprocessing_dof2.html
+++ b/examples/webgl_postprocessing_dof2.html
@@ -53,6 +53,7 @@
 			const leaves = 100;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -70,7 +71,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.autoClear = false;
 				container.appendChild( renderer.domElement );
 
@@ -366,6 +366,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate, renderer.domElement );
 
 				render();
 				stats.update();

--- a/examples/webgl_postprocessing_fxaa.html
+++ b/examples/webgl_postprocessing_fxaa.html
@@ -57,6 +57,7 @@
 			let composer1, composer2, fxaaPass;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -111,7 +112,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( container.offsetWidth, container.offsetHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.autoClear = false;
 				container.appendChild( renderer.domElement );
 
@@ -168,6 +168,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				const halfWidth = container.offsetWidth / 2;
 

--- a/examples/webgl_postprocessing_glitch.html
+++ b/examples/webgl_postprocessing_glitch.html
@@ -50,6 +50,7 @@
 				overlay.remove();
 
 				init();
+				animate();
 
 			} );
 
@@ -65,7 +66,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				//
@@ -135,6 +135,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				object.rotation.x += 0.005;
 				object.rotation.y += 0.01;

--- a/examples/webgl_postprocessing_godrays.html
+++ b/examples/webgl_postprocessing_godrays.html
@@ -51,6 +51,7 @@
 			const godrayRenderTargetResolutionMultiplier = 1.0 / 4.0;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -92,7 +93,6 @@
 				renderer.setClearColor( 0xffffff );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				renderer.autoClear = false;
@@ -223,6 +223,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				stats.begin();
 				render();

--- a/examples/webgl_postprocessing_gtao.html
+++ b/examples/webgl_postprocessing_gtao.html
@@ -46,6 +46,7 @@
 			let camera, scene, renderer, composer, controls, clock, stats, mixer;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -65,7 +66,6 @@
 
 				renderer = new THREE.WebGLRenderer();
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				const pmremGenerator = new THREE.PMREMGenerator( renderer );
@@ -185,6 +185,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				const delta = clock.getDelta();
 

--- a/examples/webgl_postprocessing_masking.html
+++ b/examples/webgl_postprocessing_masking.html
@@ -33,6 +33,7 @@
 			let box, torus;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -52,7 +53,6 @@
 				renderer.setClearColor( 0xe0e0e0 );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.autoClear = false;
 				document.body.appendChild( renderer.domElement );
 
@@ -110,6 +110,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				const time = performance.now() * 0.001 + 6000;
 

--- a/examples/webgl_postprocessing_material_ao.html
+++ b/examples/webgl_postprocessing_material_ao.html
@@ -62,6 +62,7 @@
 			};
 
 			init();
+			animate();
 
 			function init() {
 
@@ -73,7 +74,6 @@
 
 				renderer = new THREE.WebGLRenderer();
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 				renderer.shadowMap.enabled = sceneParameters.shadow;
 
@@ -263,6 +263,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				controls.update();
 				stats.begin();

--- a/examples/webgl_postprocessing_outline.html
+++ b/examples/webgl_postprocessing_outline.html
@@ -115,6 +115,7 @@
 			} );
 
 			init();
+			animate();
 
 			function init() {
 
@@ -128,7 +129,6 @@
 				renderer.shadowMap.enabled = true;
 				// todo - support pixelRatio in this demo
 				renderer.setSize( width, height );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				scene = new THREE.Scene();
@@ -326,6 +326,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				stats.begin();
 

--- a/examples/webgl_postprocessing_pixel.html
+++ b/examples/webgl_postprocessing_pixel.html
@@ -39,6 +39,7 @@
 		let gui, params;
 
 		init();
+		animate();
 
 		function init() {
 
@@ -57,7 +58,6 @@
 			renderer.shadowMap.enabled = true;
 			//renderer.setPixelRatio( window.devicePixelRatio );
 			renderer.setSize( window.innerWidth, window.innerHeight );
-			renderer.setAnimationLoop( animate );
 			document.body.appendChild( renderer.domElement );
 
 			composer = new EffectComposer( renderer );
@@ -171,6 +171,8 @@
 		}
 
 		function animate() {
+
+			requestAnimationFrame( animate );
 
 			const t = clock.getElapsedTime();
 

--- a/examples/webgl_postprocessing_procedural.html
+++ b/examples/webgl_postprocessing_procedural.html
@@ -77,6 +77,16 @@
 			const params = { procedure: 'noiseRandom3D' };
 
 			init();
+			animate();
+			initGui();
+
+			// Init gui
+			function initGui() {
+
+				const gui = new GUI();
+				gui.add( params, 'procedure', [ 'noiseRandom1D', 'noiseRandom2D', 'noiseRandom3D' ] );
+
+			}
 
 			function init() {
 
@@ -85,7 +95,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				stats = new Stats();
@@ -113,11 +122,6 @@
 
 				window.addEventListener( 'resize', onWindowResize );
 
-				//
-
-				const gui = new GUI();
-				gui.add( params, 'procedure', [ 'noiseRandom1D', 'noiseRandom2D', 'noiseRandom3D' ] );
-
 			}
 
 			function onWindowResize() {
@@ -127,6 +131,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				switch ( params.procedure ) {
 

--- a/examples/webgl_postprocessing_rgb_halftone.html
+++ b/examples/webgl_postprocessing_rgb_halftone.html
@@ -40,13 +40,13 @@
 			let composer, group;
 
 			init();
+			animate();
 
 			function init() {
 
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 
 				clock = new THREE.Clock();
 
@@ -192,6 +192,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				const delta = clock.getDelta();
 				stats.update();

--- a/examples/webgl_postprocessing_sao.html
+++ b/examples/webgl_postprocessing_sao.html
@@ -39,6 +39,7 @@
 			let group;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -48,10 +49,9 @@
 				const width = window.innerWidth;
 				const height = window.innerHeight;
 
-				renderer = new THREE.WebGLRenderer();
+				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( width, height );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				camera = new THREE.PerspectiveCamera( 65, width / height, 3, 10 );
@@ -157,6 +157,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				stats.begin();
 				render();

--- a/examples/webgl_postprocessing_smaa.html
+++ b/examples/webgl_postprocessing_smaa.html
@@ -43,6 +43,7 @@
 			};
 
 			init();
+			animate();
 
 			function init() {
 
@@ -51,7 +52,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				stats = new Stats();
@@ -118,6 +118,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				stats.begin();
 

--- a/examples/webgl_postprocessing_sobel.html
+++ b/examples/webgl_postprocessing_sobel.html
@@ -46,6 +46,7 @@
 			};
 
 			init();
+			animate();
 
 			function init() {
 
@@ -79,7 +80,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				// postprocessing
@@ -133,6 +133,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				if ( params.enable === true ) {
 

--- a/examples/webgl_postprocessing_ssaa.html
+++ b/examples/webgl_postprocessing_ssaa.html
@@ -52,6 +52,7 @@
 			};
 
 			init();
+			animate();
 
 			clearGui();
 
@@ -92,7 +93,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( devicePixelRatio );
 				renderer.setSize( width, height );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				stats = new Stats();
@@ -196,6 +196,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				stats.begin();
 

--- a/examples/webgl_postprocessing_ssao.html
+++ b/examples/webgl_postprocessing_ssao.html
@@ -43,6 +43,7 @@
 			let group;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -51,7 +52,6 @@
 
 				renderer = new THREE.WebGLRenderer();
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				camera = new THREE.PerspectiveCamera( 65, window.innerWidth / window.innerHeight, 100, 700 );
@@ -141,6 +141,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				stats.begin();
 				render();

--- a/examples/webgl_postprocessing_ssr.html
+++ b/examples/webgl_postprocessing_ssr.html
@@ -65,6 +65,7 @@
 		dracoLoader.setDecoderConfig( { type: 'js' } );
 
 		init();
+		animate();
 
 		function init() {
 
@@ -154,7 +155,6 @@
 			// renderer
 			renderer = new THREE.WebGLRenderer( { antialias: false } );
 			renderer.setSize( window.innerWidth, window.innerHeight );
-			renderer.setAnimationLoop( animate );
 			container.appendChild( renderer.domElement );
 
 			//
@@ -288,6 +288,8 @@
 		}
 
 		function animate() {
+
+			requestAnimationFrame( animate );
 
 			stats.begin();
 			render();

--- a/examples/webgl_postprocessing_taa.html
+++ b/examples/webgl_postprocessing_taa.html
@@ -44,6 +44,7 @@
 			const param = { TAAEnabled: '1', TAASampleLevel: 0 };
 
 			init();
+			animate();
 
 			clearGui();
 
@@ -95,7 +96,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				stats = new Stats();
@@ -161,6 +161,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				index ++;
 

--- a/examples/webgl_postprocessing_transition.html
+++ b/examples/webgl_postprocessing_transition.html
@@ -62,7 +62,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				composer = new EffectComposer( renderer );
@@ -76,6 +75,8 @@
 
 				const outputPass = new OutputPass();
 				composer.addPass( outputPass );
+
+				renderer.setAnimationLoop( animate );
 
 			}
 
@@ -116,15 +117,15 @@
 
 			function animate() {
 
-				// Transition animation
-				if ( params.transitionAnimate ) TWEEN.update();
-
 				const delta = clock.getDelta();
 				fxSceneA.render( delta );
 				fxSceneB.render( delta );
 
 				render();
 				stats.update();
+
+				// Transition animation
+				if ( params.transitionAnimate ) TWEEN.update();
 
 			}
 

--- a/examples/webgl_postprocessing_unreal_bloom.html
+++ b/examples/webgl_postprocessing_unreal_bloom.html
@@ -59,11 +59,20 @@
 
 			init();
 
-			async function init() {
+			function init() {
 
 				const container = document.getElementById( 'container' );
 
+				stats = new Stats();
+				container.appendChild( stats.dom );
+
 				clock = new THREE.Clock();
+
+				renderer = new THREE.WebGLRenderer( { antialias: true } );
+				renderer.setPixelRatio( window.devicePixelRatio );
+				renderer.setSize( window.innerWidth, window.innerHeight );
+				renderer.toneMapping = THREE.ReinhardToneMapping;
+				container.appendChild( renderer.domElement );
 
 				const scene = new THREE.Scene();
 
@@ -71,31 +80,15 @@
 				camera.position.set( - 5, 2.5, - 3.5 );
 				scene.add( camera );
 
+				const controls = new OrbitControls( camera, renderer.domElement );
+				controls.maxPolarAngle = Math.PI * 0.5;
+				controls.minDistance = 3;
+				controls.maxDistance = 8;
+
 				scene.add( new THREE.AmbientLight( 0xcccccc ) );
 
 				const pointLight = new THREE.PointLight( 0xffffff, 100 );
 				camera.add( pointLight );
-
-				const loader = new GLTFLoader();
-				const gltf = await loader.loadAsync( 'models/gltf/PrimaryIonDrive.glb' );
-
-				const model = gltf.scene;
-				scene.add( model );
-
-				mixer = new THREE.AnimationMixer( model );
-				const clip = gltf.animations[ 0 ];
-				mixer.clipAction( clip.optimize() ).play();
-
-				//
-
-				renderer = new THREE.WebGLRenderer( { antialias: true } );
-				renderer.setPixelRatio( window.devicePixelRatio );
-				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
-				renderer.toneMapping = THREE.ReinhardToneMapping;
-				container.appendChild( renderer.domElement );
-
-				//
 
 				const renderScene = new RenderPass( scene, camera );
 
@@ -111,19 +104,19 @@
 				composer.addPass( bloomPass );
 				composer.addPass( outputPass );
 
-				//
+				new GLTFLoader().load( 'models/gltf/PrimaryIonDrive.glb', function ( gltf ) {
 
-				stats = new Stats();
-				container.appendChild( stats.dom );
+					const model = gltf.scene;
 
-				//
+					scene.add( model );
 
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.maxPolarAngle = Math.PI * 0.5;
-				controls.minDistance = 3;
-				controls.maxDistance = 8;
+					mixer = new THREE.AnimationMixer( model );
+					const clip = gltf.animations[ 0 ];
+					mixer.clipAction( clip.optimize() ).play();
 
-				//
+					animate();
+
+				} );
 
 				const gui = new GUI();
 
@@ -173,6 +166,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				const delta = clock.getDelta();
 

--- a/examples/webgl_raycaster_bvh.html
+++ b/examples/webgl_raycaster_bvh.html
@@ -75,6 +75,7 @@
 			};
 
 			init();
+			animate();
 
 			function init() {
 
@@ -92,7 +93,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				stats = new Stats();
@@ -265,6 +265,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/webgl_raycaster_sprite.html
+++ b/examples/webgl_raycaster_sprite.html
@@ -41,6 +41,7 @@
 		const pointer = new THREE.Vector2();
 
 		init();
+		animate();
 
 		function init() {
 
@@ -48,7 +49,6 @@
 			renderer = new THREE.WebGLRenderer( { antialias: true } );
 			renderer.setPixelRatio( window.devicePixelRatio );
 			renderer.setSize( window.innerWidth, window.innerHeight );
-			renderer.setAnimationLoop( animate );
 			document.body.appendChild( renderer.domElement );
 
 			// init scene
@@ -102,6 +102,7 @@
 		function animate() {
 
 			renderer.render( scene, camera );
+			requestAnimationFrame( animate );
 
 		}
 

--- a/examples/webgl_raycaster_texture.html
+++ b/examples/webgl_raycaster_texture.html
@@ -179,6 +179,7 @@
 			const onClickPosition = new THREE.Vector2();
 
 			init();
+			render();
 
 			function init() {
 
@@ -196,7 +197,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( width, height );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				// A cube, in the middle.
@@ -329,7 +329,9 @@
 
 			}
 
-			function animate() {
+			function render() {
+
+				requestAnimationFrame( render );
 
 				// update texture parameters
 

--- a/examples/webgl_raymarching_reflect.html
+++ b/examples/webgl_raymarching_reflect.html
@@ -271,13 +271,13 @@
 			};
 
 			init();
+			render();
 
 			function init() {
 
 				renderer = new THREE.WebGLRenderer( { canvas: canvas } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( parseInt( config.resolution ), parseInt( config.resolution ) );
-				renderer.setAnimationLoop( animate );
 
 				window.addEventListener( 'resize', onWindowResize );
 
@@ -341,7 +341,7 @@
 
 			}
 
-			function animate() {
+			function render() {
 
 				stats.begin();
 
@@ -352,6 +352,7 @@
 				renderer.render( scene, camera );
 
 				stats.end();
+				requestAnimationFrame( render );
 
 			}
 

--- a/examples/webgl_read_float_buffer.html
+++ b/examples/webgl_read_float_buffer.html
@@ -89,6 +89,7 @@
 			let valueNode;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -158,7 +159,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.autoClear = false;
 
 				container.appendChild( renderer.domElement );
@@ -182,6 +182,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/webgl_refraction.html
+++ b/examples/webgl_refraction.html
@@ -44,11 +44,17 @@
 
 			init();
 
-			async function init() {
+			function init() {
 
 				const container = document.getElementById( 'container' );
 
 				clock = new THREE.Clock();
+
+				// renderer
+				renderer = new THREE.WebGLRenderer( { antialias: true } );
+				renderer.setPixelRatio( window.devicePixelRatio );
+				renderer.setSize( window.innerWidth, window.innerHeight );
+				container.appendChild( renderer.domElement );
 
 				// scene
 				scene = new THREE.Scene();
@@ -56,6 +62,12 @@
 				// camera
 				camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 1, 500 );
 				camera.position.set( 0, 75, 160 );
+
+				const controls = new OrbitControls( camera, renderer.domElement );
+				controls.target.set( 0, 40, 0 );
+				controls.maxDistance = 400;
+				controls.minDistance = 10;
+				controls.update();
 
 				// refractor
 
@@ -74,8 +86,11 @@
 
 				// load dudv map for distortion effect
 
-				const loader = new THREE.TextureLoader();
-				const dudvMap = await loader.loadAsync( 'textures/waterdudv.jpg' );
+				const dudvMap = new THREE.TextureLoader().load( 'textures/waterdudv.jpg', function () {
+
+					animate();
+
+				} );
 
 				dudvMap.wrapS = dudvMap.wrapT = THREE.RepeatWrapping;
 				refractor.material.uniforms.tDudv.value = dudvMap;
@@ -133,20 +148,6 @@
 				blueLight.position.set( 0, 50, 550 );
 				scene.add( blueLight );
 
-				// renderer
-				renderer = new THREE.WebGLRenderer( { antialias: true } );
-				renderer.setPixelRatio( window.devicePixelRatio );
-				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
-				container.appendChild( renderer.domElement );
-
-				// controls
-				const controls = new OrbitControls( camera, renderer.domElement );
-				controls.target.set( 0, 40, 0 );
-				controls.maxDistance = 400;
-				controls.minDistance = 10;
-				controls.update();
-
 				window.addEventListener( 'resize', onWindowResize );
 
 			}
@@ -161,6 +162,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				const time = clock.getElapsedTime();
 

--- a/examples/webgl_renderer_pathtracer.html
+++ b/examples/webgl_renderer_pathtracer.html
@@ -263,8 +263,7 @@
 				updateProgressBar( 0 );
 
 				pathTracer.setScene( scene, camera );
-			
-				renderer.setAnimationLoop( animate );
+				render();
 
 			}
 
@@ -341,7 +340,9 @@
 
 			//
 
-			function animate() {
+			function render() {
+
+				requestAnimationFrame( render );
 
 				renderer.toneMapping = params.toneMapping ? THREE.ACESFilmicToneMapping : THREE.NoToneMapping;
 

--- a/examples/webgl_rtt.html
+++ b/examples/webgl_rtt.html
@@ -85,6 +85,7 @@
 			let delta = 0.01;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -180,7 +181,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.autoClear = false;
 
 				container.appendChild( renderer.domElement );
@@ -202,6 +202,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/webgl_shader.html
+++ b/examples/webgl_shader.html
@@ -81,6 +81,7 @@
 			let uniforms;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -110,7 +111,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				window.addEventListener( 'resize', onWindowResize );
@@ -126,6 +126,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				uniforms[ 'time' ].value = performance.now() / 1000;
 

--- a/examples/webgl_shader_lava.html
+++ b/examples/webgl_shader_lava.html
@@ -97,6 +97,7 @@
 			let uniforms, mesh;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -146,10 +147,8 @@
 
 				//
 
-				renderer = new THREE.WebGLRenderer();
+				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
-				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.autoClear = false;
 				container.appendChild( renderer.domElement );
 
@@ -166,6 +165,8 @@
 				composer.addPass( outputPass );
 
 				//
+
+				onWindowResize();
 
 				window.addEventListener( 'resize', onWindowResize );
 
@@ -184,6 +185,14 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
+
+				render();
+
+			}
+
+			function render() {
 
 				const delta = 5 * clock.getDelta();
 

--- a/examples/webgl_shaders_ocean.html
+++ b/examples/webgl_shaders_ocean.html
@@ -38,6 +38,7 @@
 			let controls, water, sun, mesh;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -48,7 +49,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				renderer.toneMappingExposure = 0.5;
 				container.appendChild( renderer.domElement );
@@ -190,6 +190,7 @@
 
 			function animate() {
 
+				requestAnimationFrame( animate );
 				render();
 				stats.update();
 

--- a/examples/webgl_shadow_contact.html
+++ b/examples/webgl_shadow_contact.html
@@ -64,6 +64,7 @@
 			let plane, blurPlane, fillPlane;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -232,7 +233,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				//
@@ -276,6 +276,10 @@
 			}
 
 			function animate( ) {
+
+				requestAnimationFrame( animate );
+
+				//
 
 				meshes.forEach( mesh => {
 

--- a/examples/webgl_shadowmap.html
+++ b/examples/webgl_shadowmap.html
@@ -59,6 +59,8 @@
 			let showHUD = false;
 
 			init();
+			animate();
+
 
 			function init() {
 
@@ -105,7 +107,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( SCREEN_WIDTH, SCREEN_HEIGHT );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				renderer.autoClear = false;
@@ -332,6 +333,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				render();
 				stats.update();

--- a/examples/webgl_shadowmap_csm.html
+++ b/examples/webgl_shadowmap_csm.html
@@ -55,6 +55,7 @@
 			};
 
 			init();
+			animate();
 
 			function updateOrthoCamera() {
 
@@ -81,7 +82,6 @@
 
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 				renderer.shadowMap.enabled = params.shadows;
 				renderer.shadowMap.type = THREE.PCFSoftShadowMap;
@@ -283,6 +283,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				camera.updateMatrixWorld();
 				csm.update();

--- a/examples/webgl_shadowmap_pcss.html
+++ b/examples/webgl_shadowmap_pcss.html
@@ -141,6 +141,7 @@
 			let group;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -246,7 +247,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.setClearColor( scene.fog.color );
 
 				container.appendChild( renderer.domElement );
@@ -302,6 +302,8 @@
 				renderer.render( scene, camera );
 
 				stats.update();
+
+				requestAnimationFrame( animate );
 
 			}
 

--- a/examples/webgl_shadowmap_performance.html
+++ b/examples/webgl_shadowmap_performance.html
@@ -54,6 +54,8 @@
 			const clock = new THREE.Clock();
 
 			init();
+			animate();
+
 
 			function init() {
 
@@ -99,7 +101,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( SCREEN_WIDTH, SCREEN_HEIGHT );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				renderer.autoClear = false;
@@ -302,6 +303,8 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				stats.begin();
 				render();

--- a/examples/webgl_shadowmap_pointlight.html
+++ b/examples/webgl_shadowmap_pointlight.html
@@ -32,6 +32,7 @@
 			let pointLight, pointLight2;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -105,7 +106,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.shadowMap.enabled = true;
 				renderer.shadowMap.type = THREE.BasicShadowMap;
 				document.body.appendChild( renderer.domElement );
@@ -147,6 +147,13 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
+				render();
+
+			}
+
+			function render() {
 
 				let time = performance.now() * 0.001;
 

--- a/examples/webgl_shadowmap_progressive.html
+++ b/examples/webgl_shadowmap_progressive.html
@@ -39,6 +39,7 @@
 							 'Light Radius': 50, 'Ambient Weight': 0.5, 'Debug Lightmap': false };
 			init();
 			createGUI();
+			animate();
 
 			function init() {
 
@@ -46,7 +47,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.shadowMap.enabled = true;
 				document.body.appendChild( renderer.domElement );
 
@@ -153,6 +153,16 @@
 
 					object.add( lightTarget );
 
+					if ( typeof TESTING !== 'undefined' ) {
+
+						for ( let i = 0; i < 300; i ++ ) {
+
+							render();
+
+						}
+
+					}
+
 				}
 
 				const manager = new THREE.LoadingManager( loadModel );
@@ -172,7 +182,6 @@
 				controls.maxDistance = 500;
 				controls.maxPolarAngle = Math.PI / 1.5;
 				controls.target.set( 0, 100, 0 );
-			
 				window.addEventListener( 'resize', onWindowResize );
 
 			}
@@ -197,7 +206,7 @@
 
 			}
 
-			function animate() {
+			function render() {
 
 				// Update the inertia on the orbit controls
 				controls.update();
@@ -247,6 +256,12 @@
 
 			}
 
+			function animate() {
+
+				requestAnimationFrame( animate );
+				render();
+
+			}
 		</script>
 	</body>
 </html>

--- a/examples/webgl_shadowmap_viewer.html
+++ b/examples/webgl_shadowmap_viewer.html
@@ -35,6 +35,8 @@
 			let dirLightShadowMapViewer, spotLightShadowMapViewer;
 
 			init();
+			animate();
+
 
 			function init() {
 
@@ -138,7 +140,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.shadowMap.enabled = true;
 				renderer.shadowMap.type = THREE.BasicShadowMap;
 
@@ -185,6 +186,7 @@
 
 			function animate() {
 
+				requestAnimationFrame( animate );
 				render();
 
 				stats.update();

--- a/examples/webgl_shadowmap_vsm.html
+++ b/examples/webgl_shadowmap_vsm.html
@@ -34,6 +34,7 @@
 			let torusKnot, dirGroup;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -184,7 +185,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.shadowMap.enabled = true;
 				renderer.shadowMap.type = THREE.VSMShadowMap;
 
@@ -210,6 +210,8 @@
 			}
 
 			function animate( time ) {
+
+				requestAnimationFrame( animate );
 
 				const delta = clock.getDelta();
 

--- a/examples/webgl_shadowmesh.html
+++ b/examples/webgl_shadowmesh.html
@@ -61,6 +61,7 @@
 			const TWO_PI = Math.PI * 2;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -68,9 +69,7 @@
 
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( SCREEN_WIDTH, SCREEN_HEIGHT );
-				renderer.setAnimationLoop( animate );
 				document.getElementById( 'container' ).appendChild( renderer.domElement );
-			
 				window.addEventListener( 'resize', onWindowResize );
 
 				camera.position.set( 0, 2.5, 10 );
@@ -178,6 +177,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				frameTime = clock.getDelta();
 

--- a/examples/webgl_simple_gi.html
+++ b/examples/webgl_simple_gi.html
@@ -154,6 +154,7 @@
 			let camera, scene, renderer;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -190,7 +191,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				new SimpleGI( renderer, scene );
@@ -213,6 +213,8 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
 
 				renderer.setRenderTarget( null );
 				renderer.render( scene, camera );

--- a/examples/webgl_sprites.html
+++ b/examples/webgl_sprites.html
@@ -35,6 +35,7 @@
 			let group;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -109,7 +110,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.autoClear = false; // To allow render overlay on top of sprited sphere
 
 				document.body.appendChild( renderer.domElement );
@@ -192,6 +192,13 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
+				render();
+
+			}
+
+			function render() {
 
 				const time = Date.now() / 1000;
 

--- a/examples/webgl_test_memory.html
+++ b/examples/webgl_test_memory.html
@@ -37,6 +37,7 @@
 			let camera, scene, renderer;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -52,7 +53,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 			}
@@ -74,6 +74,14 @@
 			//
 
 			function animate() {
+
+				requestAnimationFrame( animate );
+
+				render();
+
+			}
+
+			function render() {
 
 				const geometry = new THREE.SphereGeometry( 50, Math.random() * 64, Math.random() * 32 );
 

--- a/examples/webgl_test_wide_gamut.html
+++ b/examples/webgl_test_wide_gamut.html
@@ -103,8 +103,8 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.setScissorTest( true );
+				renderer.setAnimationLoop( render );
 				container.appendChild( renderer.domElement );
 
 				if ( isP3Context && window.matchMedia( '( color-gamut: p3 )' ).matches ) {
@@ -189,7 +189,7 @@
 
 			}
 
-			function containTexture( aspect, target ) {
+			function containTexture ( aspect, target ) {
 
 				// Sets the matrix uv transform so the texture image is contained in a region having the specified aspect ratio,
 				// and does so without distortion. Akin to CSS object-fit: contain.
@@ -213,7 +213,7 @@
 
 			}
 
-			function animate() {
+			function render() {
 
 				renderer.setScissor( 0, 0, sliderPos, window.innerHeight );
 				renderer.render( sceneL, camera );

--- a/examples/webgl_video_kinect.html
+++ b/examples/webgl_video_kinect.html
@@ -88,6 +88,7 @@
 			let mouse, center;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -165,7 +166,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				mouse = new THREE.Vector3( 0, 0, 1 );
@@ -195,6 +195,14 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
+
+				render();
+
+			}
+
+			function render() {
 
 				camera.position.x += ( mouse.x - camera.position.x ) * 0.05;
 				camera.position.y += ( - mouse.y - camera.position.y ) * 0.05;

--- a/examples/webgl_video_panorama_equirectangular.html
+++ b/examples/webgl_video_panorama_equirectangular.html
@@ -49,6 +49,7 @@
 			const distance = .5;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -75,7 +76,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
 				document.addEventListener( 'pointerdown', onPointerDown );
@@ -127,6 +127,13 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
+				update();
+
+			}
+
+			function update() {
 
 				lat = Math.max( - 85, Math.min( 85, lat ) );
 				phi = THREE.MathUtils.degToRad( 90 - lat );

--- a/examples/webgl_water.html
+++ b/examples/webgl_water.html
@@ -42,6 +42,7 @@
 			};
 
 			init();
+			animate();
 
 			function init() {
 
@@ -133,7 +134,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setPixelRatio( window.devicePixelRatio );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				// gui
@@ -186,6 +186,14 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
+
+				render();
+
+			}
+
+			function render() {
 
 				const delta = clock.getDelta();
 

--- a/examples/webgl_water_flowmap.html
+++ b/examples/webgl_water_flowmap.html
@@ -33,6 +33,7 @@
 			let scene, camera, renderer, water;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -98,7 +99,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setPixelRatio( window.devicePixelRatio );
-				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
 				//
@@ -128,6 +128,14 @@
 			}
 
 			function animate() {
+
+				requestAnimationFrame( animate );
+
+				render();
+
+			}
+
+			function render() {
 
 				renderer.render( scene, camera );
 

--- a/examples/webxr_ar_cones.html
+++ b/examples/webxr_ar_cones.html
@@ -30,6 +30,7 @@
 			let controller;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -49,7 +50,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true, alpha: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.xr.enabled = true;
 				container.appendChild( renderer.domElement );
 
@@ -93,6 +93,12 @@
 			//
 
 			function animate() {
+
+				renderer.setAnimationLoop( render );
+
+			}
+
+			function render() {
 
 				renderer.render( scene, camera );
 

--- a/examples/webxr_ar_hittest.html
+++ b/examples/webxr_ar_hittest.html
@@ -36,6 +36,7 @@
 			let hitTestSourceRequested = false;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -55,7 +56,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true, alpha: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.xr.enabled = true;
 				container.appendChild( renderer.domElement );
 
@@ -110,7 +110,13 @@
 
 			//
 
-			function animate( timestamp, frame ) {
+			function animate() {
+
+				renderer.setAnimationLoop( render );
+
+			}
+
+			function render( timestamp, frame ) {
 
 				if ( frame ) {
 

--- a/examples/webxr_ar_lighting.html
+++ b/examples/webxr_ar_lighting.html
@@ -34,6 +34,7 @@
 			let defaultEnvironment;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -53,7 +54,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true, alpha: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.xr.enabled = true;
 				container.appendChild( renderer.domElement );
 
@@ -166,6 +166,12 @@
 			//
 
 			function animate() {
+
+				renderer.setAnimationLoop( render );
+
+			}
+
+			function render() {
 
 				renderer.render( scene, camera );
 

--- a/examples/webxr_ar_plane_detection.html
+++ b/examples/webxr_ar_plane_detection.html
@@ -32,7 +32,7 @@
 			const renderer = new THREE.WebGLRenderer( { antialias: true, alpha: true } );
 			renderer.setPixelRatio( window.devicePixelRatio );
 			renderer.setSize( window.innerWidth, window.innerHeight );
-			renderer.setAnimationLoop( animate );
+			renderer.setAnimationLoop( render );
 			renderer.xr.enabled = true;
 			document.body.appendChild( renderer.domElement );
 
@@ -66,7 +66,7 @@
 
 			}
 
-			function animate() {
+			function render() {
 
 				renderer.render( scene, camera );
 

--- a/examples/webxr_vr_handinput.html
+++ b/examples/webxr_vr_handinput.html
@@ -39,6 +39,7 @@
 			let controls;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -79,7 +80,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.shadowMap.enabled = true;
 				renderer.xr.enabled = true;
 
@@ -149,6 +149,12 @@
 			//
 
 			function animate() {
+
+				renderer.setAnimationLoop( render );
+
+			}
+
+			function render() {
 
 				renderer.render( scene, camera );
 

--- a/examples/webxr_vr_handinput_cubes.html
+++ b/examples/webxr_vr_handinput_cubes.html
@@ -52,6 +52,7 @@
 			const spheres = [];
 
 			init();
+			animate();
 
 			function init() {
 
@@ -92,7 +93,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.shadowMap.enabled = true;
 				renderer.xr.enabled = true;
 
@@ -272,6 +272,12 @@
 			//
 
 			function animate() {
+
+				renderer.setAnimationLoop( render );
+
+			}
+
+			function render() {
 
 				if ( scaling.active ) {
 

--- a/examples/webxr_vr_handinput_pointerclick.html
+++ b/examples/webxr_vr_handinput_pointerclick.html
@@ -275,6 +275,7 @@
 		let camera, scene, renderer;
 
 		init();
+		animate();
 
 		function makeButtonMesh( x, y, z, color ) {
 
@@ -313,7 +314,6 @@
 			renderer = new THREE.WebGLRenderer( { antialias: true } );
 			renderer.setPixelRatio( window.devicePixelRatio );
 			renderer.setSize( window.innerWidth, window.innerHeight );
-			renderer.setAnimationLoop( animate );
 			renderer.shadowMap.enabled = true;
 			renderer.xr.enabled = true;
 			renderer.xr.cameraAutoUpdate = false;
@@ -507,6 +507,12 @@
 		}
 
 		function animate() {
+
+			renderer.setAnimationLoop( render );
+
+		}
+
+		function render() {
 
 			const delta = clock.getDelta();
 			const elapsedTime = clock.elapsedTime;

--- a/examples/webxr_vr_handinput_pointerdrag.html
+++ b/examples/webxr_vr_handinput_pointerdrag.html
@@ -380,6 +380,7 @@
 		let camera, scene, renderer;
 
 		init();
+		animate();
 
 		function makeButtonMesh( x, y, z, color ) {
 
@@ -416,7 +417,6 @@
 			renderer = new THREE.WebGLRenderer( { antialias: true } );
 			renderer.setPixelRatio( window.devicePixelRatio );
 			renderer.setSize( window.innerWidth, window.innerHeight );
-			renderer.setAnimationLoop( animate );
 			renderer.shadowMap.enabled = true;
 			renderer.xr.enabled = true;
 			renderer.xr.cameraAutoUpdate = false;
@@ -585,6 +585,12 @@
 		}
 
 		function animate() {
+
+			renderer.setAnimationLoop( render );
+
+		}
+
+		function render() {
 
 			const delta = clock.getDelta();
 			const elapsedTime = clock.elapsedTime;

--- a/examples/webxr_vr_handinput_pressbutton.html
+++ b/examples/webxr_vr_handinput_pressbutton.html
@@ -335,6 +335,7 @@
 		let camera, scene, renderer;
 
 		init();
+		animate();
 
 		function makeButtonMesh( x, y, z, color ) {
 
@@ -373,7 +374,6 @@
 			renderer = new THREE.WebGLRenderer( { antialias: true } );
 			renderer.setPixelRatio( window.devicePixelRatio );
 			renderer.setSize( window.innerWidth, window.innerHeight );
-			renderer.setAnimationLoop( animate );
 			renderer.shadowMap.enabled = true;
 			renderer.xr.enabled = true;
 			renderer.xr.cameraAutoUpdate = false;
@@ -564,6 +564,12 @@
 		}
 
 		function animate() {
+
+			renderer.setAnimationLoop( render );
+
+		}
+
+		function render() {
 
 			const delta = clock.getDelta();
 			const elapsedTime = clock.elapsedTime;

--- a/examples/webxr_vr_handinput_profiles.html
+++ b/examples/webxr_vr_handinput_profiles.html
@@ -44,6 +44,8 @@
 			let controls;
 
 			init();
+			animate();
+
 
 			function init() {
 
@@ -85,7 +87,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.shadowMap.enabled = true;
 				renderer.xr.enabled = true;
 
@@ -200,6 +201,12 @@
 			//
 
 			function animate() {
+
+				renderer.setAnimationLoop( render );
+
+			}
+
+			function render() {
 
 				renderer.render( scene, camera );
 

--- a/examples/webxr_vr_layers.html
+++ b/examples/webxr_vr_layers.html
@@ -106,6 +106,7 @@
 			snellenConfig.quadHeight = .5 * snellenConfig.heightMeters / snellenConfig.cropY;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -122,10 +123,9 @@
 
 				renderer = new THREE.WebGLRenderer( { antialias: false } );
 				renderer.setPixelRatio( window.devicePixelRatio );
-				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.setClearAlpha( 1 );
 				renderer.setClearColor( new THREE.Color( 0 ), 0 );
+				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.xr.enabled = true;
 
 				document.body.appendChild( renderer.domElement );
@@ -298,7 +298,13 @@
 			}
 			//
 
-			function animate( t, frame ) {
+			function animate() {
+
+				renderer.setAnimationLoop( render );
+
+			}
+
+			function render( t, frame ) {
 
 				const xr = renderer.xr;
 				const session = xr.getSession();

--- a/examples/webxr_vr_panorama.html
+++ b/examples/webxr_vr_panorama.html
@@ -26,13 +26,13 @@
 			let scene;
 
 			init();
+			animate();
 
 			function init() {
 
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.xr.enabled = true;
 				renderer.xr.setReferenceSpaceType( 'local' );
 				document.body.appendChild( renderer.domElement );
@@ -125,6 +125,12 @@
 			}
 
 			function animate() {
+
+				renderer.setAnimationLoop( render );
+
+			}
+
+			function render() {
 
 				renderer.render( scene, camera );
 

--- a/examples/webxr_vr_panorama_depth.html
+++ b/examples/webxr_vr_panorama_depth.html
@@ -31,6 +31,7 @@
 			let camera, scene, renderer, sphere, clock;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -90,7 +91,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.xr.enabled = true;
 				renderer.xr.setReferenceSpaceType( 'local' );
 				container.appendChild( renderer.domElement );
@@ -113,6 +113,12 @@
 			}
 
 			function animate() {
+
+				renderer.setAnimationLoop( render );
+
+			}
+
+			function render() {
 
 				// If we are not presenting move the camera a little so the effect is visible
 

--- a/examples/webxr_vr_rollercoaster.html
+++ b/examples/webxr_vr_rollercoaster.html
@@ -34,7 +34,6 @@
 			const renderer = new THREE.WebGLRenderer( { antialias: true } );
 			renderer.setPixelRatio( window.devicePixelRatio );
 			renderer.setSize( window.innerWidth, window.innerHeight );
-			renderer.setAnimationLoop( animate );
 			renderer.xr.enabled = true;
 			renderer.xr.setReferenceSpaceType( 'local' );
 			document.body.appendChild( renderer.domElement );
@@ -208,7 +207,7 @@
 
 			let prevTime = performance.now();
 
-			function animate() {
+			function render() {
 
 				const time = performance.now();
 				const delta = time - prevTime;
@@ -243,6 +242,8 @@
 				prevTime = time;
 
 			}
+
+			renderer.setAnimationLoop( render );
 
 		</script>
 

--- a/examples/webxr_vr_sandbox.html
+++ b/examples/webxr_vr_sandbox.html
@@ -46,6 +46,7 @@
 			};
 
 			init();
+			animate();
 
 			function init() {
 
@@ -107,7 +108,6 @@
 				renderer.autoClear = false;
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.xr.enabled = true;
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				renderer.toneMappingExposure = 1;
@@ -208,6 +208,12 @@
 			}
 
 			function animate() {
+
+				renderer.setAnimationLoop( render );
+
+			}
+
+			function render() {
 
 				const time = performance.now() * 0.0002;
 				const torus = scene.getObjectByName( 'torus' );

--- a/examples/webxr_vr_teleport.html
+++ b/examples/webxr_vr_teleport.html
@@ -39,6 +39,7 @@
 			const tempMatrix = new THREE.Matrix4();
 
 			init();
+			animate();
 
 			function init() {
 
@@ -77,7 +78,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 
 				renderer.xr.addEventListener( 'sessionstart', () => baseReferenceSpace = renderer.xr.getReferenceSpace() );
 				renderer.xr.enabled = true;
@@ -199,6 +199,12 @@
 			//
 
 			function animate() {
+
+				renderer.setAnimationLoop( render );
+
+			}
+
+			function render() {
 
 				INTERSECTION = undefined;
 

--- a/examples/webxr_vr_video.html
+++ b/examples/webxr_vr_video.html
@@ -36,6 +36,7 @@
 			let camera, scene, renderer;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -107,7 +108,6 @@
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.xr.enabled = true;
 				renderer.xr.setReferenceSpaceType( 'local' );
 				container.appendChild( renderer.domElement );
@@ -130,6 +130,12 @@
 			}
 
 			function animate() {
+
+				renderer.setAnimationLoop( render );
+
+			}
+
+			function render() {
 
 				renderer.render( scene, camera );
 

--- a/examples/webxr_xr_ballshooter.html
+++ b/examples/webxr_xr_ballshooter.html
@@ -36,8 +36,8 @@
 			let controller1, controller2;
 			let controllerGrip1, controllerGrip2;
 
-			let room, spheres, physics;
-			const velocity = new THREE.Vector3();
+			let room, spheres;
+			let physics, velocity = new THREE.Vector3();
 
 			let count = 0;
 
@@ -70,7 +70,7 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
+				renderer.setAnimationLoop( render );
 				renderer.xr.enabled = true;
 				document.body.appendChild( renderer.domElement );
 
@@ -277,7 +277,7 @@
 
 			}
 
-			function animate() {
+			function render() {
 
 				handleController( controller1 );
 				handleController( controller2 );

--- a/examples/webxr_xr_controls_transform.html
+++ b/examples/webxr_xr_controls_transform.html
@@ -38,6 +38,7 @@
 			let controls, group;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -113,7 +114,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.shadowMap.enabled = true;
 				renderer.xr.enabled = true;
 				container.appendChild( renderer.domElement );
@@ -242,6 +242,12 @@
 			//
 
 			function animate() {
+
+				renderer.setAnimationLoop( render );
+
+			}
+
+			function render() {
 
 				renderer.render( scene, camera );
 

--- a/examples/webxr_xr_cubes.html
+++ b/examples/webxr_xr_cubes.html
@@ -40,6 +40,7 @@
 			let INTERSECTED;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -97,7 +98,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.xr.enabled = true;
 				container.appendChild( renderer.domElement );
 
@@ -140,7 +140,7 @@
 
 				//
 
-				document.body.appendChild( XRButton.createButton( renderer, { 'optionalFeatures': [ 'depth-sensing' ] } ) );
+				document.body.appendChild( XRButton.createButton( renderer, { 'optionalFeatures': [ 'depth-sensing'] } ) );
 
 			}
 
@@ -182,6 +182,12 @@
 			//
 
 			function animate() {
+
+				renderer.setAnimationLoop( render );
+
+			}
+
+			function render() {
 
 				const delta = clock.getDelta() * 60;
 

--- a/examples/webxr_xr_dragging.html
+++ b/examples/webxr_xr_dragging.html
@@ -40,6 +40,7 @@
 			let controls, group;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -119,12 +120,11 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.shadowMap.enabled = true;
 				renderer.xr.enabled = true;
 				container.appendChild( renderer.domElement );
 
-				document.body.appendChild( XRButton.createButton( renderer, { 'optionalFeatures': [ 'depth-sensing' ] } ) );
+				document.body.appendChild( XRButton.createButton( renderer, { 'optionalFeatures': [ 'depth-sensing'] } ) );
 
 				// controllers
 
@@ -269,6 +269,12 @@
 			//
 
 			function animate() {
+
+				renderer.setAnimationLoop( render );
+
+			}
+
+			function render() {
 
 				cleanIntersected();
 

--- a/examples/webxr_xr_haptics.html
+++ b/examples/webxr_xr_haptics.html
@@ -43,6 +43,7 @@
 			const musicScale = [ 0, 3, 5, 7, 10 ];
 
 			init();
+			animate();
 
 			function initAudio() {
 
@@ -139,7 +140,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.shadowMap.enabled = true;
 				renderer.xr.enabled = true;
 				container.appendChild( renderer.domElement );
@@ -208,6 +208,12 @@
 			}
 
 			//
+
+			function animate() {
+
+				renderer.setAnimationLoop( render );
+
+			}
 
 			function handleCollisions() {
 
@@ -294,7 +300,7 @@
 
 			}
 
-			function animate() {
+			function render() {
 
 				handleCollisions();
 

--- a/examples/webxr_xr_paint.html
+++ b/examples/webxr_xr_paint.html
@@ -36,6 +36,7 @@
 			let controls;
 
 			init();
+			animate();
 
 			function init() {
 
@@ -74,7 +75,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.xr.enabled = true;
 				container.appendChild( renderer.domElement );
 
@@ -192,6 +192,12 @@
 			}
 
 			function animate() {
+
+				renderer.setAnimationLoop( render );
+
+			}
+
+			function render() {
 
 				handleController( controller1 );
 				handleController( controller2 );

--- a/examples/webxr_xr_sculpt.html
+++ b/examples/webxr_xr_sculpt.html
@@ -38,6 +38,7 @@
 
 			init();
 			initBlob();
+			animate();
 
 			function init() {
 
@@ -68,7 +69,6 @@
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( animate );
 				renderer.xr.enabled = true;
 				container.appendChild( renderer.domElement );
 
@@ -168,6 +168,12 @@
 
 			//
 
+			function animate() {
+
+				renderer.setAnimationLoop( render );
+
+			}
+
 			function transformPoint( vector ) {
 
 				vector.x = ( vector.x + 1.0 ) / 2.0;
@@ -221,7 +227,7 @@
 
 			}
 
-			function animate() {
+			function render() {
 
 				handleController( controller1 );
 				handleController( controller2 );


### PR DESCRIPTION
Related issue: #28296

**Description**

As suggested https://github.com/mrdoob/three.js/issues/28296#issuecomment-2101845489 this PR reverts the usage of `setAnimationLoop()` in the examples to restore E2E testing.
