### PR TITLE
Editor: Fixed the first history entry is no-op in history outliner

### DIFF
--- a/editor/js/History.js
+++ b/editor/js/History.js
@@ -266,7 +266,7 @@ class History {
 
 				cmd = this.undos[ this.undos.length - 1 ];	// next cmd to pop
 
-				if ( cmd === undefined || id === cmd.id ) break;
+				if ( cmd === undefined || id > cmd.id ) break;
 
 				this.undo();
 

--- a/editor/js/Menubar.Edit.js
+++ b/editor/js/Menubar.Edit.js
@@ -47,7 +47,7 @@ function MenubarEdit( editor ) {
 	} );
 	options.add( redo );
 
-	editor.signals.historyChanged.add( function () {
+	function onHistoryChanged() {
 
 		const history = editor.history;
 
@@ -66,7 +66,11 @@ function MenubarEdit( editor ) {
 
 		}
 
-	} );
+	}
+
+	editor.signals.historyChanged.add( onHistoryChanged );
+
+	onHistoryChanged();
 
 	// ---
 


### PR DESCRIPTION
The issue: Currently clicking the first history entry in SETTINGS' history outliner is no-op

With this PR, clicking on the first history entry can now undo/redo just like other entries:

https://github.com/mrdoob/three.js/assets/1063018/20782d1f-8899-4841-9cf8-b8ea6d8c9cb0


