### PR TITLE
Box3: Use index in Box3#setFromObject

### DIFF
--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -170,15 +170,20 @@ class Box3 {
 
 			if ( precise === true && positionAttribute !== undefined && object.isInstancedMesh !== true ) {
 
-				for ( let i = 0, l = positionAttribute.count; i < l; i ++ ) {
+				const indexAttribute = geometry.getIndex();
+				const vertexCount = indexAttribute ? indexAttribute.count : positionAttribute.count;
+
+				for ( let i = 0, l = vertexCount; i < l; i ++ ) {
+
+					const index = indexAttribute ? indexAttribute.getX( i ) : i;
 
 					if ( object.isMesh === true ) {
 
-						object.getVertexPosition( i, _vector );
+						object.getVertexPosition( index, _vector );
 
 					} else {
 
-						_vector.fromBufferAttribute( positionAttribute, i );
+						_vector.fromBufferAttribute( positionAttribute, index );
 
 					}
 

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -170,20 +170,20 @@ class Box3 {
 
 			if ( precise === true && positionAttribute !== undefined && object.isInstancedMesh !== true ) {
 
-				const indexAttribute = geometry.getIndex();
-				const vertexCount = indexAttribute ? indexAttribute.count : positionAttribute.count;
+				const index = geometry.getIndex();
+				const vertexCount = index ? index.count : positionAttribute.count;
 
 				for ( let i = 0, l = vertexCount; i < l; i ++ ) {
 
-					const index = indexAttribute ? indexAttribute.getX( i ) : i;
+					const vertexIndex = index ? index.getX( i ) : i;
 
 					if ( object.isMesh === true ) {
 
-						object.getVertexPosition( index, _vector );
+						object.getVertexPosition( vertexIndex, _vector );
 
 					} else {
 
-						_vector.fromBufferAttribute( positionAttribute, index );
+						_vector.fromBufferAttribute( positionAttribute, vertexIndex );
 
 					}
 


### PR DESCRIPTION
Related:

- #27926 

Ideally, three.js would not be constrained to >=1 buffer per geometry. Buffer attributes or interleaved buffers could be shared between multiple geometries. See #27926 and #17089.

One relevant limitation today is that `Box3#setFromObject` and other methods iterate over buffer attributes without using the index. Doing so is slower and will overestimate the bounds, when the mesh uses only a small subset of the vertices in the buffer.

If this approach looks OK, I'd like to make similar PRs for `BufferGeometry#computeBoundingBox` etc.

/cc @takahirox @gkjohnson 