### PR TITLE
WebGLRenderer: Update `copyFramebufferToTexture` function signature

### DIFF
--- a/docs/api/ar/renderers/WebGLRenderer.html
+++ b/docs/api/ar/renderers/WebGLRenderer.html
@@ -369,7 +369,7 @@
 		</p>
 		 
 		<h3>
-		[method:undefined copyFramebufferToTexture]( [param:Vector2 position], [param:FramebufferTexture texture], [param:Number level] )
+		[method:undefined copyFramebufferToTexture]( [param:FramebufferTexture texture], [param:Vector2 position], [param:Number level] )
 		</h3>
 		<p>
 		ينسخ بكسلات من WebGLFramebuffer الحالي إلى قوام ثنائي الأبعاد. يتيح

--- a/docs/api/en/renderers/WebGLRenderer.html
+++ b/docs/api/en/renderers/WebGLRenderer.html
@@ -367,7 +367,7 @@ document.body.appendChild( renderer.domElement );
 		</p>
 
 		<h3>
-			[method:undefined copyFramebufferToTexture]( [param:Vector2 position], [param:FramebufferTexture texture], [param:Number level] )
+			[method:undefined copyFramebufferToTexture]( [param:FramebufferTexture texture], [param:Vector2 position], [param:Number level] )
 		</h3>
 		<p>
 			Copies pixels from the current WebGLFramebuffer into a 2D texture. Enables

--- a/docs/api/en/textures/FramebufferTexture.html
+++ b/docs/api/en/textures/FramebufferTexture.html
@@ -33,7 +33,7 @@ renderer.clear();
 renderer.render( scene, camera );
 
 // copy part of the rendered frame into the framebuffer texture
-renderer.copyFramebufferToTexture( vector, frameTexture );
+renderer.copyFramebufferToTexture( frameTexture, vector );
 		</code>
 
 		<h2>Examples</h2>

--- a/docs/api/it/renderers/WebGLRenderer.html
+++ b/docs/api/it/renderers/WebGLRenderer.html
@@ -321,7 +321,7 @@
 			Questo metodo utilizza *KHR_parallel_shader_compile*.
 		</p>
 
-		<h3>[method:undefined copyFramebufferToTexture]( [param:Vector2 position], [param:FramebufferTexture texture], [param:Number level] )</h3>
+		<h3>[method:undefined copyFramebufferToTexture]( [param:FramebufferTexture texture], [param:Vector2 position], [param:Number level] )</h3>
 		<p>
 			Copia i pixel dal WebGLFramebuffer corrente in una texture 2D. Abilita l'accesso a 
 			[link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/copyTexImage2D WebGLRenderingContext.copyTexImage2D].

--- a/docs/api/zh/renderers/WebGLRenderer.html
+++ b/docs/api/zh/renderers/WebGLRenderer.html
@@ -281,7 +281,7 @@
 			此方法利用 *KHR_parallel_shader_compile*。
 		</p>
 
-		<h3>[method:undefined copyFramebufferToTexture]( [param:Vector2 position], [param:FramebufferTexture texture], [param:Number level] )</h3>
+		<h3>[method:undefined copyFramebufferToTexture]( [param:FramebufferTexture texture], [param:Vector2 position], [param:Number level] )</h3>
 		<p>将当前WebGLFramebuffer中的像素复制到2D纹理中。可访问[link:https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/copyTexImage2D WebGLRenderingContext.copyTexImage2D].</p>
 
 		<h3>[method:undefined copyTextureToTexture]( [param:Texture srcTexture], [param:Texture dstTexture], [param:Box2 srcRegion], [param:Vector2 dstPosition], [param:Number level] )</h3>

--- a/docs/api/zh/textures/FramebufferTexture.html
+++ b/docs/api/zh/textures/FramebufferTexture.html
@@ -32,7 +32,7 @@
 		renderer.render( scene, camera );
 
 		// copy part of the rendered frame into the framebuffer texture
-		renderer.copyFramebufferToTexture( vector, frameTexture );
+		renderer.copyFramebufferToTexture( frameTexture, vector );
 		</code>
 
 		<h2>例子</h2>

--- a/examples/jsm/objects/Lensflare.js
+++ b/examples/jsm/objects/Lensflare.js
@@ -210,7 +210,7 @@ class Lensflare extends Mesh {
 
 				// save current RGB to temp texture
 
-				renderer.copyFramebufferToTexture( screenPositionPixels, tempMap );
+				renderer.copyFramebufferToTexture( tempMap, screenPositionPixels );
 
 				// render pink quad
 
@@ -222,7 +222,7 @@ class Lensflare extends Mesh {
 
 				// copy result to occlusionMap
 
-				renderer.copyFramebufferToTexture( screenPositionPixels, occlusionMap );
+				renderer.copyFramebufferToTexture( occlusionMap, screenPositionPixels );
 
 				// restore graphics
 

--- a/examples/webgl_framebuffer_texture.html
+++ b/examples/webgl_framebuffer_texture.html
@@ -182,7 +182,7 @@
 				vector.x = ( window.innerWidth * dpr / 2 ) - ( textureSize / 2 );
 				vector.y = ( window.innerHeight * dpr / 2 ) - ( textureSize / 2 );
 
-				renderer.copyFramebufferToTexture( vector, texture );
+				renderer.copyFramebufferToTexture( texture, vector );
 
 				renderer.clearDepth();
 				renderer.render( sceneOrtho, cameraOrtho );

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2453,9 +2453,12 @@ class WebGLRenderer {
 			const width = Math.floor( texture.image.width * levelScale );
 			const height = Math.floor( texture.image.height * levelScale );
 
+			const x = position !== null ? position.x : 0;
+			const y = position !== null ? position.y : 0;
+
 			textures.setTexture2D( texture, 0 );
 
-			_gl.copyTexSubImage2D( _gl.TEXTURE_2D, level, 0, 0, position.x, position.y, width, height );
+			_gl.copyTexSubImage2D( _gl.TEXTURE_2D, level, 0, 0, x, y, width, height );
 
 			state.unbindTexture();
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2436,7 +2436,18 @@ class WebGLRenderer {
 
 		};
 
-		this.copyFramebufferToTexture = function ( position, texture, level = 0 ) {
+		this.copyFramebufferToTexture = function ( texture, position = null, level = 0 ) {
+
+			// support previous signature with position first
+			if ( texture.isTexture !== true ) {
+
+				// @deprecated, r165
+				console.warn( 'WebGLRenderer: copyFramebufferToTexture function signature has changed.' );
+
+				position = arguments[ 0 ] || null;
+				texture = arguments[ 1 ];
+
+			}
 
 			const levelScale = Math.pow( 2, - level );
 			const width = Math.floor( texture.image.width * levelScale );


### PR DESCRIPTION
Related issue: #28281 #28315

**Description**
This PR update the function signature of `copyFramebufferToTexture` to align with the new `copyTextureToTexture` and `copyTextureToTexture3D`.

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Utsubo](https://utsubo.com)*
