### PR TITLE
Editor: Fixed Undo/Redo are both active when history is empty 

### DIFF
--- a/editor/js/Menubar.Edit.js
+++ b/editor/js/Menubar.Edit.js
@@ -47,7 +47,7 @@ function MenubarEdit( editor ) {
 	} );
 	options.add( redo );
 
-	editor.signals.historyChanged.add( function () {
+	function onHistoryChanged() {
 
 		const history = editor.history;
 
@@ -66,7 +66,10 @@ function MenubarEdit( editor ) {
 
 		}
 
-	} );
+	}
+
+	editor.signals.historyChanged.add( onHistoryChanged );
+	onHistoryChanged();
 
 	// ---
 


### PR DESCRIPTION
The issue: When editor starts and there's no history entries, Edit>Undo/Redo are both active (expected to be both inactive).

To reproduce: 

1. Go to https://raw.githack.com/mrdoob/three.js/dev/editor/index.html in incognito mode
2. Hover Edit
3. You should see Undo and Redo are both active.

The cause: Editor refreshes Edit>Undo/Redo on historyChanged, however, since there's no history, editor won't dispatch this siganl on start.

This PR fixed that by ... refreshing `Edit>Undo/Redo` once manually (not via signal) when editor starts.

Preview: (open in incognito mode) https://raw.githack.com/ycw/three.js/editor-init-undoRedo-on-start/editor/index.html