### PR TITLE
Material: Add docs for .onBeforeRender function

### DIFF
--- a/docs/api/en/materials/Material.html
+++ b/docs/api/en/materials/Material.html
@@ -412,6 +412,14 @@
 		</p>
 
 		<h3>
+			[method:undefined onBeforeRender]( [param:WebGLRenderer renderer], [param:Scene scene], [param:Camera camera], [param:BufferGeometry geometry], [param:Object3D object], [param:Integer group] )
+		</h3>
+		<p>
+			An optional callback that is executed immediately before this material is
+			rendered for each object.
+		</p>
+
+		<h3>
 			[method:undefined onBeforeCompile]( [param:Shader shader], [param:WebGLRenderer renderer] )
 		</h3>
 		<p>


### PR DESCRIPTION
Related issue: --

**Description**

Add docs for Material.onBeforeRender