### PR TITLE
Editor: Fixed camera UUID lost when recovering

### DIFF
--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -659,7 +659,16 @@ Editor.prototype = {
 		var loader = new THREE.ObjectLoader();
 		var camera = await loader.parseAsync( json.camera );
 
+		const existingUuid = this.camera.uuid;
+		const incomingUuid = camera.uuid;
+
+		// copy all properties, including uuid
 		this.camera.copy( camera );
+		this.camera.uuid = incomingUuid;
+
+		delete this.cameras[ existingUuid ]; // remove old entry [existingUuid, this.camera]
+		this.cameras[ incomingUuid ] = this.camera; // add new entry [incomingUuid, this.camera]
+
 		this.signals.cameraResetted.dispatch();
 
 		this.history.fromJSON( json.history );


### PR DESCRIPTION
The issue: When recovering from IndexedDB, [all properties are copied to existing default camera,](https://github.com/mrdoob/three.js/blob/4ec57f5014e57199fff3827972474e43cc9450ba/editor/js/Editor.js#L662) **except for** `.uuid` , in turn commands, which hold object uuid referencing to the default camera, will fail to undo/redo, because they wont be able to get back the camera by UUID during recovery, for example [SetValueCommand's `object` state will be `undefined`](https://github.com/mrdoob/three.js/blob/4ec57f5014e57199fff3827972474e43cc9450ba/editor/js/commands/SetValueCommand.js#L69C3-L69C61) after recovery.

This PR fixed that by copying `.uuid` to existing default camera, also updating `editor.cameras`.
