### PR TITLE
Editor: Fixed missing export of `setMaterialRangeCommand`

### DIFF
--- a/editor/js/commands/Commands.js
+++ b/editor/js/commands/Commands.js
@@ -10,6 +10,7 @@ export { SetGeometryValueCommand } from './SetGeometryValueCommand.js';
 export { SetMaterialColorCommand } from './SetMaterialColorCommand.js';
 export { SetMaterialCommand } from './SetMaterialCommand.js';
 export { SetMaterialMapCommand } from './SetMaterialMapCommand.js';
+export { SetMaterialRangeCommand } from './SetMaterialRangeCommand.js';
 export { SetMaterialValueCommand } from './SetMaterialValueCommand.js';
 export { SetMaterialVectorCommand } from './SetMaterialVectorCommand.js';
 export { SetPositionCommand } from './SetPositionCommand.js';


### PR DESCRIPTION
The issue: The `SetMaterialRangeCommand` doesn't get export from `Commands.js`, so Modification of 'Thin-Film Thickness Map' range of `MeshPhysicalMaterial` will be [unrecoverable](https://github.com/mrdoob/three.js/blob/4ec57f5014e57199fff3827972474e43cc9450ba/editor/js/History.js#L204).

This PR simply exported it :D
 