### PR TITLE
Examples: Remove need for manually assigning Line2 material resolution

### DIFF
--- a/examples/jsm/lines/Line2.js
+++ b/examples/jsm/lines/Line2.js
@@ -1,7 +1,9 @@
 import { LineSegments2 } from '../lines/LineSegments2.js';
 import { LineGeometry } from '../lines/LineGeometry.js';
 import { LineMaterial } from '../lines/LineMaterial.js';
+import { Vector4 } from 'three';
 
+const _viewport = new Vector4();
 class Line2 extends LineSegments2 {
 
 	constructor( geometry = new LineGeometry(), material = new LineMaterial( { color: Math.random() * 0xffffff } ) ) {
@@ -11,6 +13,17 @@ class Line2 extends LineSegments2 {
 		this.isLine2 = true;
 
 		this.type = 'Line2';
+
+	}
+
+	onBeforeRender( renderer ) {
+
+		if ( this.material.uniforms.resolution ) {
+
+			renderer.getCurrentViewport( _viewport );
+			this.material.uniforms.resolution.value.set( _viewport.z, _viewport.w );
+
+		}
 
 	}
 

--- a/examples/jsm/lines/Line2.js
+++ b/examples/jsm/lines/Line2.js
@@ -1,9 +1,7 @@
 import { LineSegments2 } from '../lines/LineSegments2.js';
 import { LineGeometry } from '../lines/LineGeometry.js';
 import { LineMaterial } from '../lines/LineMaterial.js';
-import { Vector4 } from 'three';
 
-const _viewport = new Vector4();
 class Line2 extends LineSegments2 {
 
 	constructor( geometry = new LineGeometry(), material = new LineMaterial( { color: Math.random() * 0xffffff } ) ) {
@@ -13,17 +11,6 @@ class Line2 extends LineSegments2 {
 		this.isLine2 = true;
 
 		this.type = 'Line2';
-
-	}
-
-	onBeforeRender( renderer ) {
-
-		if ( this.material.uniforms.resolution ) {
-
-			renderer.getCurrentViewport( _viewport );
-			this.material.uniforms.resolution.value.set( _viewport.z, _viewport.w );
-
-		}
 
 	}
 

--- a/examples/jsm/lines/LineMaterial.js
+++ b/examples/jsm/lines/LineMaterial.js
@@ -1,16 +1,3 @@
-/**
- * parameters = {
- *  color: <hex>,
- *  linewidth: <float>,
- *  dashed: <boolean>,
- *  dashScale: <float>,
- *  dashSize: <float>,
- *  dashOffset: <float>,
- *  gapSize: <float>,
- *  resolution: <Vector2>,
- * }
- */
-
 import {
 	ShaderLib,
 	ShaderMaterial,

--- a/examples/jsm/lines/LineMaterial.js
+++ b/examples/jsm/lines/LineMaterial.js
@@ -7,7 +7,7 @@
  *  dashSize: <float>,
  *  dashOffset: <float>,
  *  gapSize: <float>,
- *  resolution: <Vector2>, // to be set by renderer
+ *  resolution: <Vector2>,
  * }
  */
 

--- a/examples/jsm/lines/LineMaterial.js
+++ b/examples/jsm/lines/LineMaterial.js
@@ -16,9 +16,11 @@ import {
 	ShaderMaterial,
 	UniformsLib,
 	UniformsUtils,
-	Vector2
+	Vector2,
+	Vector4,
 } from 'three';
 
+const _viewport = new Vector4();
 
 UniformsLib.line = {
 
@@ -437,6 +439,13 @@ class LineMaterial extends ShaderMaterial {
 		this.isLineMaterial = true;
 
 		this.setValues( parameters );
+
+	}
+
+	onBeforeRender( renderer ) {
+
+		renderer.getCurrentViewport( _viewport );
+		this.uniforms.resolution.value.set( _viewport.z, _viewport.w );
 
 	}
 

--- a/examples/jsm/lines/LineMaterial.js
+++ b/examples/jsm/lines/LineMaterial.js
@@ -17,10 +17,7 @@ import {
 	UniformsLib,
 	UniformsUtils,
 	Vector2,
-	Vector4,
 } from 'three';
-
-const _viewport = new Vector4();
 
 UniformsLib.line = {
 
@@ -439,13 +436,6 @@ class LineMaterial extends ShaderMaterial {
 		this.isLineMaterial = true;
 
 		this.setValues( parameters );
-
-	}
-
-	onBeforeRender( renderer ) {
-
-		renderer.getCurrentViewport( _viewport );
-		this.uniforms.resolution.value.set( _viewport.z, _viewport.w );
 
 	}
 

--- a/examples/jsm/lines/LineSegments2.js
+++ b/examples/jsm/lines/LineSegments2.js
@@ -362,7 +362,7 @@ class LineSegments2 extends Mesh {
 
 		if ( this.material.uniforms.resolution ) {
 
-			renderer.getCurrentViewport( _viewport );
+			renderer.getCurrentViewport( _viewport ).multiplyScalar( 1 / renderer.getPixelRatio() );
 			this.material.uniforms.resolution.value.set( _viewport.z, _viewport.w );
 
 		}

--- a/examples/jsm/lines/LineSegments2.js
+++ b/examples/jsm/lines/LineSegments2.js
@@ -360,7 +360,9 @@ class LineSegments2 extends Mesh {
 
 	onBeforeRender( renderer ) {
 
-		if ( this.material.uniforms.resolution ) {
+		const uniforms = this.material.uniforms;
+
+		if ( uniforms && uniforms.resolution ) {
 
 			renderer.getViewport( _viewport );
 			this.material.uniforms.resolution.value.set( _viewport.z, _viewport.w );

--- a/examples/jsm/lines/LineSegments2.js
+++ b/examples/jsm/lines/LineSegments2.js
@@ -13,6 +13,8 @@ import {
 import { LineSegmentsGeometry } from '../lines/LineSegmentsGeometry.js';
 import { LineMaterial } from '../lines/LineMaterial.js';
 
+const _viewport = new Vector4();
+
 const _start = new Vector3();
 const _end = new Vector3();
 
@@ -351,6 +353,17 @@ class LineSegments2 extends Mesh {
 		} else {
 
 			raycastScreenSpace( this, camera, intersects );
+
+		}
+
+	}
+
+	onBeforeRender( renderer ) {
+
+		if ( this.material.uniforms.resolution ) {
+
+			renderer.getCurrentViewport( _viewport );
+			this.material.uniforms.resolution.value.set( _viewport.z, _viewport.w );
 
 		}
 

--- a/examples/jsm/lines/LineSegments2.js
+++ b/examples/jsm/lines/LineSegments2.js
@@ -362,7 +362,7 @@ class LineSegments2 extends Mesh {
 
 		if ( this.material.uniforms.resolution ) {
 
-			renderer.getCurrentViewport( _viewport ).multiplyScalar( 1 / renderer.getPixelRatio() );
+			renderer.getViewport( _viewport );
 			this.material.uniforms.resolution.value.set( _viewport.z, _viewport.w );
 
 		}

--- a/examples/jsm/lines/Wireframe.js
+++ b/examples/jsm/lines/Wireframe.js
@@ -55,7 +55,9 @@ class Wireframe extends Mesh {
 
 	onBeforeRender( renderer ) {
 
-		if ( this.material.uniforms.resolution ) {
+		const uniforms = this.material.uniforms;
+
+		if ( uniforms && uniforms.resolution ) {
 
 			renderer.getViewport( _viewport );
 			this.material.uniforms.resolution.value.set( _viewport.z, _viewport.w );

--- a/examples/jsm/lines/Wireframe.js
+++ b/examples/jsm/lines/Wireframe.js
@@ -2,13 +2,15 @@ import {
 	InstancedInterleavedBuffer,
 	InterleavedBufferAttribute,
 	Mesh,
-	Vector3
+	Vector3,
+	Vector4
 } from 'three';
 import { LineSegmentsGeometry } from '../lines/LineSegmentsGeometry.js';
 import { LineMaterial } from '../lines/LineMaterial.js';
 
 const _start = new Vector3();
 const _end = new Vector3();
+const _viewport = new Vector4();
 
 class Wireframe extends Mesh {
 
@@ -48,6 +50,17 @@ class Wireframe extends Mesh {
 		geometry.setAttribute( 'instanceDistanceEnd', new InterleavedBufferAttribute( instanceDistanceBuffer, 1, 1 ) ); // d1
 
 		return this;
+
+	}
+
+	onBeforeRender( renderer ) {
+
+		if ( this.material.uniforms.resolution ) {
+
+			renderer.getCurrentViewport( _viewport );
+			this.material.uniforms.resolution.value.set( _viewport.z, _viewport.w );
+
+		}
 
 	}
 

--- a/examples/jsm/lines/Wireframe.js
+++ b/examples/jsm/lines/Wireframe.js
@@ -57,7 +57,7 @@ class Wireframe extends Mesh {
 
 		if ( this.material.uniforms.resolution ) {
 
-			renderer.getCurrentViewport( _viewport );
+			renderer.getCurrentViewport( _viewport ).multiplyScalar( 1 / renderer.getPixelRatio() );
 			this.material.uniforms.resolution.value.set( _viewport.z, _viewport.w );
 
 		}

--- a/examples/jsm/lines/Wireframe.js
+++ b/examples/jsm/lines/Wireframe.js
@@ -57,7 +57,7 @@ class Wireframe extends Mesh {
 
 		if ( this.material.uniforms.resolution ) {
 
-			renderer.getCurrentViewport( _viewport ).multiplyScalar( 1 / renderer.getPixelRatio() );
+			renderer.getViewport( _viewport );
 			this.material.uniforms.resolution.value.set( _viewport.z, _viewport.w );
 
 		}

--- a/examples/webgl_lines_fat.html
+++ b/examples/webgl_lines_fat.html
@@ -194,9 +194,6 @@
 				camera2.position.copy( camera.position );
 				camera2.quaternion.copy( camera.quaternion );
 
-				// renderer will set this eventually
-				matLine.resolution.set( insetWidth, insetHeight ); // resolution of the inset viewport
-
 				renderer.render( scene, camera2 );
 
 				renderer.setScissorTest( false );

--- a/examples/webgl_lines_fat.html
+++ b/examples/webgl_lines_fat.html
@@ -175,9 +175,6 @@
 
 				controls.update();
 
-				// renderer will set this eventually
-				matLine.resolution.set( window.innerWidth, window.innerHeight ); // resolution of the viewport
-
 				gpuPanel.startQuery();
 				renderer.render( scene, camera );
 				gpuPanel.endQuery();

--- a/examples/webgl_lines_fat.html
+++ b/examples/webgl_lines_fat.html
@@ -108,7 +108,6 @@
 					linewidth: 5, // in world units with size attenuation, pixels otherwise
 					vertexColors: true,
 
-					//resolution:  // to be set by renderer, eventually
 					dashed: false,
 					alphaToCoverage: true,
 

--- a/examples/webgl_lines_fat_raycasting.html
+++ b/examples/webgl_lines_fat_raycasting.html
@@ -60,7 +60,6 @@
 				worldUnits: true,
 				vertexColors: true,
 
-				//resolution:  // to be set by renderer, eventually
 				alphaToCoverage: true,
 
 			} );
@@ -75,7 +74,6 @@
 				opacity: 0.2,
 				depthTest: false,
 				visible: false,
-				//resolution:  // to be set by renderer, eventually
 
 			} );
 

--- a/examples/webgl_lines_fat_raycasting.html
+++ b/examples/webgl_lines_fat_raycasting.html
@@ -213,10 +213,6 @@
 
 				renderer.setSize( window.innerWidth, window.innerHeight );
 
-				// renderer will set this eventually
-				matLine.resolution.set( window.innerWidth, window.innerHeight );
-				matThresholdLine.resolution.set( window.innerWidth, window.innerHeight );
-
 			}
 
 			function onPointerMove( event ) {

--- a/examples/webgl_lines_fat_wireframe.html
+++ b/examples/webgl_lines_fat_wireframe.html
@@ -136,9 +136,6 @@
 
 				renderer.setViewport( 0, 0, window.innerWidth, window.innerHeight );
 
-				// renderer will set this eventually
-				matLine.resolution.set( window.innerWidth, window.innerHeight ); // resolution of the viewport
-
 				renderer.render( scene, camera );
 
 				// inset scene
@@ -155,9 +152,6 @@
 
 				camera2.position.copy( camera.position );
 				camera2.quaternion.copy( camera.quaternion );
-
-				// renderer will set this eventually
-				matLine.resolution.set( insetWidth, insetHeight ); // resolution of the inset viewport
 
 				renderer.render( scene, camera2 );
 

--- a/examples/webgl_lines_fat_wireframe.html
+++ b/examples/webgl_lines_fat_wireframe.html
@@ -78,7 +78,6 @@
 
 					color: 0x4080ff,
 					linewidth: 5, // in pixels
-					//resolution:  // to be set by renderer, eventually
 					dashed: false
 
 				} );


### PR DESCRIPTION
Related issue: #28335

**Description**

Remove the need to manually assign the resolution uniform for rendering Line2. If rendering to multiple resolutions of canvas or render targets then the resolution still needs to be set before performing raycasting.

