### PR TITLE
Editor: Fixed recovery system

### DIFF
--- a/editor/js/commands/AddObjectCommand.js
+++ b/editor/js/commands/AddObjectCommand.js
@@ -14,10 +14,10 @@ class AddObjectCommand extends Command {
 
 		this.type = 'AddObjectCommand';
 
-		this.object = object;
-		if ( object !== undefined ) {
+		if ( arguments.length > 1 ) {
 
 			this.name = editor.strings.getKey( 'command/AddObject' ) + ': ' + object.name;
+			this.object = object;
 
 		}
 

--- a/editor/js/commands/AddScriptCommand.js
+++ b/editor/js/commands/AddScriptCommand.js
@@ -13,10 +13,14 @@ class AddScriptCommand extends Command {
 		super( editor );
 
 		this.type = 'AddScriptCommand';
-		this.name = editor.strings.getKey( 'command/AddScript' );
 
-		this.object = object;
-		this.script = script;
+		if ( arguments.length > 1 ) {
+
+			this.name = editor.strings.getKey( 'command/AddScript' );
+			this.object = object;
+			this.script = script;
+
+		}
 
 	}
 

--- a/editor/js/commands/Commands.js
+++ b/editor/js/commands/Commands.js
@@ -10,6 +10,7 @@ export { SetGeometryValueCommand } from './SetGeometryValueCommand.js';
 export { SetMaterialColorCommand } from './SetMaterialColorCommand.js';
 export { SetMaterialCommand } from './SetMaterialCommand.js';
 export { SetMaterialMapCommand } from './SetMaterialMapCommand.js';
+export { SetMaterialRangeCommand } from './SetMaterialRangeCommand.js';
 export { SetMaterialValueCommand } from './SetMaterialValueCommand.js';
 export { SetMaterialVectorCommand } from './SetMaterialVectorCommand.js';
 export { SetPositionCommand } from './SetPositionCommand.js';

--- a/editor/js/commands/MoveObjectCommand.js
+++ b/editor/js/commands/MoveObjectCommand.js
@@ -14,30 +14,35 @@ class MoveObjectCommand extends Command {
 		super( editor );
 
 		this.type = 'MoveObjectCommand';
-		this.name = editor.strings.getKey( 'command/MoveObject' );
 
-		this.object = object;
-		this.oldParent = ( object !== undefined ) ? object.parent : undefined;
-		this.oldIndex = ( this.oldParent !== undefined ) ? this.oldParent.children.indexOf( this.object ) : undefined;
-		this.newParent = newParent;
+		if ( arguments.length > 1 ) {
 
-		if ( newBefore !== undefined ) {
+			this.name = editor.strings.getKey( 'command/MoveObject' );
 
-			this.newIndex = ( newParent !== undefined ) ? newParent.children.indexOf( newBefore ) : undefined;
+			this.object = object;
+			this.oldParent = object.parent;
+			this.oldIndex = this.oldParent.children.indexOf( this.object );
+			this.newParent = newParent;
 
-		} else {
+			if ( newBefore !== undefined ) {
 
-			this.newIndex = ( newParent !== undefined ) ? newParent.children.length : undefined;
+				this.newIndex = ( newParent !== undefined ) ? newParent.children.indexOf( newBefore ) : undefined;
+
+			} else {
+
+				this.newIndex = ( newParent !== undefined ) ? newParent.children.length : undefined;
+
+			}
+
+			if ( this.oldParent === this.newParent && this.newIndex > this.oldIndex ) {
+
+				this.newIndex --;
+
+			}
+
+			this.newBefore = newBefore;
 
 		}
-
-		if ( this.oldParent === this.newParent && this.newIndex > this.oldIndex ) {
-
-			this.newIndex --;
-
-		}
-
-		this.newBefore = newBefore;
 
 	}
 

--- a/editor/js/commands/MultiCmdsCommand.js
+++ b/editor/js/commands/MultiCmdsCommand.js
@@ -12,9 +12,14 @@ class MultiCmdsCommand extends Command {
 		super( editor );
 
 		this.type = 'MultiCmdsCommand';
-		this.name = editor.strings.getKey( 'command/MultiCmds' );
 
-		this.cmdArray = ( cmdArray !== undefined ) ? cmdArray : [];
+		if ( arguments.length > 1 ) {
+
+			this.name = editor.strings.getKey( 'command/MultiCmds' );
+
+			this.cmdArray = cmdArray;
+
+		}
 
 	}
 

--- a/editor/js/commands/RemoveObjectCommand.js
+++ b/editor/js/commands/RemoveObjectCommand.js
@@ -14,12 +14,12 @@ class RemoveObjectCommand extends Command {
 		super( editor );
 
 		this.type = 'RemoveObjectCommand';
-		this.name = editor.strings.getKey( 'command/RemoveObject' ) + ': ' + object.name;
 
-		this.object = object;
-		this.parent = ( object !== undefined ) ? object.parent : undefined;
-		if ( this.parent !== undefined ) {
+		if ( arguments.length > 1 ) {
 
+			this.name = editor.strings.getKey( 'command/RemoveObject' ) + ': ' + object.name;
+			this.object = object;
+			this.parent = object.parent;
 			this.index = this.parent.children.indexOf( this.object );
 
 		}

--- a/editor/js/commands/RemoveScriptCommand.js
+++ b/editor/js/commands/RemoveScriptCommand.js
@@ -13,12 +13,12 @@ class RemoveScriptCommand extends Command {
 		super( editor );
 
 		this.type = 'RemoveScriptCommand';
-		this.name = editor.strings.getKey( 'command/RemoveScript' );
 
-		this.object = object;
-		this.script = script;
-		if ( this.object && this.script ) {
+		if ( arguments.length > 1 ) {
 
+			this.name = editor.strings.getKey( 'command/RemoveScript' );
+			this.object = object;
+			this.script = script;
 			this.index = this.editor.scripts[ this.object.uuid ].indexOf( this.script );
 
 		}

--- a/editor/js/commands/SetColorCommand.js
+++ b/editor/js/commands/SetColorCommand.js
@@ -14,13 +14,17 @@ class SetColorCommand extends Command {
 		super( editor );
 
 		this.type = 'SetColorCommand';
-		this.name = editor.strings.getKey( 'command/SetColor' ) + ': ' + attributeName;
 		this.updatable = true;
 
-		this.object = object;
-		this.attributeName = attributeName;
-		this.oldValue = ( object !== undefined ) ? this.object[ this.attributeName ].getHex() : undefined;
-		this.newValue = newValue;
+		if ( arguments.length > 1 ) {
+
+			this.name = editor.strings.getKey( 'command/SetColor' ) + ': ' + attributeName;
+			this.object = object;
+			this.attributeName = attributeName;
+			this.oldValue = this.object[ this.attributeName ].getHex();
+			this.newValue = newValue;
+
+		}
 
 	}
 

--- a/editor/js/commands/SetGeometryCommand.js
+++ b/editor/js/commands/SetGeometryCommand.js
@@ -15,12 +15,16 @@ class SetGeometryCommand extends Command {
 		super( editor );
 
 		this.type = 'SetGeometryCommand';
-		this.name = editor.strings.getKey( 'command/SetGeometry' );
 		this.updatable = true;
 
-		this.object = object;
-		this.oldGeometry = ( object !== undefined ) ? object.geometry : undefined;
-		this.newGeometry = newGeometry;
+		if ( arguments.length > 1 ) {
+
+			this.name = editor.strings.getKey( 'command/SetGeometry' );
+			this.object = object;
+			this.oldGeometry = object.geometry;
+			this.newGeometry = newGeometry;
+
+		}
 
 	}
 
@@ -57,7 +61,7 @@ class SetGeometryCommand extends Command {
 		const output = super.toJSON( this );
 
 		output.objectUuid = this.object.uuid;
-		output.oldGeometry = this.object.geometry.toJSON();
+		output.oldGeometry = this.oldGeometry.toJSON();
 		output.newGeometry = this.newGeometry.toJSON();
 
 		return output;

--- a/editor/js/commands/SetGeometryValueCommand.js
+++ b/editor/js/commands/SetGeometryValueCommand.js
@@ -14,12 +14,16 @@ class SetGeometryValueCommand extends Command {
 		super( editor );
 
 		this.type = 'SetGeometryValueCommand';
-		this.name = editor.strings.getKey( 'command/SetGeometryValue' ) + ': ' + attributeName;
 
-		this.object = object;
-		this.attributeName = attributeName;
-		this.oldValue = ( object !== undefined ) ? object.geometry[ attributeName ] : undefined;
-		this.newValue = newValue;
+		if ( arguments.length > 1 ) {
+
+			this.name = editor.strings.getKey( 'command/SetGeometryValue' ) + ': ' + attributeName;
+			this.object = object;
+			this.attributeName = attributeName;
+			this.oldValue = object.geometry[ attributeName ];
+			this.newValue = newValue;
+
+		}
 
 	}
 

--- a/editor/js/commands/SetMaterialColorCommand.js
+++ b/editor/js/commands/SetMaterialColorCommand.js
@@ -17,21 +17,27 @@ class SetMaterialColorCommand extends Command {
 		this.name = editor.strings.getKey( 'command/SetMaterialColor' ) + ': ' + attributeName;
 		this.updatable = true;
 
-		this.object = object;
-		this.materialSlot = materialSlot;
+		if ( arguments.length > 1 ) {
 
-		this.material = ( this.object !== undefined ) ? this.editor.getObjectMaterial( object, materialSlot ) : undefined;
+			this.object = object;
+			this.materialSlot = materialSlot;
 
-		this.oldValue = ( this.material !== undefined ) ? this.material[ attributeName ].getHex() : undefined;
-		this.newValue = newValue;
+			const oldMaterial = this.editor.getObjectMaterial( object, materialSlot );
 
-		this.attributeName = attributeName;
+			this.oldValue = oldMaterial[ attributeName ].getHex();
+			this.newValue = newValue;
+
+			this.attributeName = attributeName;
+
+		}
 
 	}
 
 	execute() {
 
-		this.material[ this.attributeName ].setHex( this.newValue );
+		const material = this.editor.getObjectMaterial( this.object, this.materialSlot );
+
+		material[ this.attributeName ].setHex( this.newValue );
 
 		this.editor.signals.materialChanged.dispatch( this.object, this.materialSlot );
 
@@ -39,7 +45,9 @@ class SetMaterialColorCommand extends Command {
 
 	undo() {
 
-		this.material[ this.attributeName ].setHex( this.oldValue );
+		const material = this.editor.getObjectMaterial( this.object, this.materialSlot );
+
+		material[ this.attributeName ].setHex( this.oldValue );
 
 		this.editor.signals.materialChanged.dispatch( this.object, this.materialSlot );
 
@@ -59,6 +67,7 @@ class SetMaterialColorCommand extends Command {
 		output.attributeName = this.attributeName;
 		output.oldValue = this.oldValue;
 		output.newValue = this.newValue;
+		output.materialSlot = this.materialSlot;
 
 		return output;
 
@@ -72,6 +81,7 @@ class SetMaterialColorCommand extends Command {
 		this.attributeName = json.attributeName;
 		this.oldValue = json.oldValue;
 		this.newValue = json.newValue;
+		this.materialSlot = this.materialSlot;
 
 	}
 

--- a/editor/js/commands/SetMaterialColorCommand.js
+++ b/editor/js/commands/SetMaterialColorCommand.js
@@ -81,7 +81,7 @@ class SetMaterialColorCommand extends Command {
 		this.attributeName = json.attributeName;
 		this.oldValue = json.oldValue;
 		this.newValue = json.newValue;
-		this.materialSlot = this.materialSlot;
+		this.materialSlot = json.materialSlot;
 
 	}
 

--- a/editor/js/commands/SetMaterialCommand.js
+++ b/editor/js/commands/SetMaterialCommand.js
@@ -14,13 +14,18 @@ class SetMaterialCommand extends Command {
 		super( editor );
 
 		this.type = 'SetMaterialCommand';
-		this.name = editor.strings.getKey( 'command/SetMaterial' );
 
-		this.object = object;
-		this.materialSlot = materialSlot;
+		if ( arguments.length > 1 ) {
 
-		this.oldMaterial = this.editor.getObjectMaterial( object, materialSlot );
-		this.newMaterial = newMaterial;
+			this.name = editor.strings.getKey( 'command/SetMaterial' );
+
+			this.object = object;
+			this.materialSlot = materialSlot;
+
+			this.oldMaterial = this.editor.getObjectMaterial( object, materialSlot );
+			this.newMaterial = newMaterial;
+
+		}
 
 	}
 
@@ -47,6 +52,7 @@ class SetMaterialCommand extends Command {
 		output.objectUuid = this.object.uuid;
 		output.oldMaterial = this.oldMaterial.toJSON();
 		output.newMaterial = this.newMaterial.toJSON();
+		output.materialSlot = this.materialSlot;
 
 		return output;
 
@@ -59,6 +65,7 @@ class SetMaterialCommand extends Command {
 		this.object = this.editor.objectByUuid( json.objectUuid );
 		this.oldMaterial = parseMaterial( json.oldMaterial );
 		this.newMaterial = parseMaterial( json.newMaterial );
+		this.materialSlot = json.materialSlot;
 
 		function parseMaterial( json ) {
 

--- a/editor/js/commands/SetMaterialMapCommand.js
+++ b/editor/js/commands/SetMaterialMapCommand.js
@@ -15,17 +15,22 @@ class SetMaterialMapCommand extends Command {
 		super( editor );
 
 		this.type = 'SetMaterialMapCommand';
-		this.name = editor.strings.getKey( 'command/SetMaterialMap' ) + ': ' + mapName;
 
-		this.object = object;
-		this.materialSlot = materialSlot;
+		if ( arguments.length > 1 ) {
 
-		this.material = this.editor.getObjectMaterial( object, materialSlot );
+			this.name = editor.strings.getKey( 'command/SetMaterialMap' ) + ': ' + mapName;
 
-		this.oldMap = ( object !== undefined ) ? this.material[ mapName ] : undefined;
-		this.newMap = newMap;
+			this.object = object;
+			this.materialSlot = materialSlot;
 
-		this.mapName = mapName;
+			const oldMaterial = this.editor.getObjectMaterial( object, materialSlot );
+
+			this.oldMap = oldMaterial[ mapName ];
+			this.newMap = newMap;
+
+			this.mapName = mapName;
+
+		}
 
 	}
 
@@ -33,8 +38,10 @@ class SetMaterialMapCommand extends Command {
 
 		if ( this.oldMap !== null && this.oldMap !== undefined ) this.oldMap.dispose();
 
-		this.material[ this.mapName ] = this.newMap;
-		this.material.needsUpdate = true;
+		const material = this.editor.getObjectMaterial( this.object, this.materialSlot );
+
+		material[ this.mapName ] = this.newMap;
+		material.needsUpdate = true;
 
 		this.editor.signals.materialChanged.dispatch( this.object, this.materialSlot );
 
@@ -42,8 +49,10 @@ class SetMaterialMapCommand extends Command {
 
 	undo() {
 
-		this.material[ this.mapName ] = this.oldMap;
-		this.material.needsUpdate = true;
+		const material = this.editor.getObjectMaterial( this.object, this.materialSlot );
+
+		material[ this.mapName ] = this.oldMap;
+		material.needsUpdate = true;
 
 		this.editor.signals.materialChanged.dispatch( this.object, this.materialSlot );
 
@@ -57,6 +66,7 @@ class SetMaterialMapCommand extends Command {
 		output.mapName = this.mapName;
 		output.newMap = serializeMap( this.newMap );
 		output.oldMap = serializeMap( this.oldMap );
+		output.materialSlot = this.materialSlot;
 
 		return output;
 
@@ -112,6 +122,7 @@ class SetMaterialMapCommand extends Command {
 		this.mapName = json.mapName;
 		this.oldMap = parseTexture( json.oldMap );
 		this.newMap = parseTexture( json.newMap );
+		this.materialSlot = json.materialSlot;
 
 		function parseTexture( json ) {
 

--- a/editor/js/commands/SetMaterialRangeCommand.js
+++ b/editor/js/commands/SetMaterialRangeCommand.js
@@ -15,25 +15,33 @@ class SetMaterialRangeCommand extends Command {
 		super( editor );
 
 		this.type = 'SetMaterialRangeCommand';
-		this.name = editor.strings.getKey( 'command/SetMaterialRange' ) + ': ' + attributeName;
 		this.updatable = true;
 
-		this.object = object;
-		this.materialSlot = materialSlot;
+		if ( arguments.length > 1 ) {
 
-		this.material = this.editor.getObjectMaterial( object, materialSlot );
+			this.name = editor.strings.getKey( 'command/SetMaterialRange' ) + ': ' + attributeName;
 
-		this.oldRange = ( this.material !== undefined && this.material[ attributeName ] !== undefined ) ? [ ...this.material[ attributeName ] ] : undefined;
-		this.newRange = [ newMinValue, newMaxValue ];
+			this.object = object;
+			this.materialSlot = materialSlot;
 
-		this.attributeName = attributeName;
+			const oldMaterial = this.editor.getObjectMaterial( object, materialSlot );
+
+			// this.oldRange = ( this.material !== undefined && this.material[ attributeName ] !== undefined ) ? [ ...this.material[ attributeName ] ] : undefined;
+			this.oldRange = [ ...oldMaterial[ attributeName ] ];
+			this.newRange = [ newMinValue, newMaxValue ];
+
+			this.attributeName = attributeName;
+
+		}
 
 	}
 
 	execute() {
 
-		this.material[ this.attributeName ] = [ ...this.newRange ];
-		this.material.needsUpdate = true;
+		const material = this.editor.getObjectMaterial( this.object, this.materialSlot );
+
+		material[ this.attributeName ] = [ ...this.newRange ];
+		material.needsUpdate = true;
 
 		this.editor.signals.objectChanged.dispatch( this.object );
 		this.editor.signals.materialChanged.dispatch( this.object, this.materialSlot );
@@ -42,8 +50,10 @@ class SetMaterialRangeCommand extends Command {
 
 	undo() {
 
-		this.material[ this.attributeName ] = [ ...this.oldRange ];
-		this.material.needsUpdate = true;
+		const material = this.editor.getObjectMaterial( this.object, this.materialSlot );
+
+		material[ this.attributeName ] = [ ...this.oldRange ];
+		material.needsUpdate = true;
 
 		this.editor.signals.objectChanged.dispatch( this.object );
 		this.editor.signals.materialChanged.dispatch( this.object, this.materialSlot );
@@ -64,6 +74,7 @@ class SetMaterialRangeCommand extends Command {
 		output.attributeName = this.attributeName;
 		output.oldRange = [ ...this.oldRange ];
 		output.newRange = [ ...this.newRange ];
+		output.materialSlot = this.materialSlot;
 
 		return output;
 
@@ -77,6 +88,7 @@ class SetMaterialRangeCommand extends Command {
 		this.oldRange = [ ...json.oldRange ];
 		this.newRange = [ ...json.newRange ];
 		this.object = this.editor.objectByUuid( json.objectUuid );
+		this.materialSlot = json.materialSlot;
 
 	}
 

--- a/editor/js/commands/SetMaterialValueCommand.js
+++ b/editor/js/commands/SetMaterialValueCommand.js
@@ -14,25 +14,31 @@ class SetMaterialValueCommand extends Command {
 		super( editor );
 
 		this.type = 'SetMaterialValueCommand';
-		this.name = editor.strings.getKey( 'command/SetMaterialValue' ) + ': ' + attributeName;
 		this.updatable = true;
 
-		this.object = object;
-		this.materialSlot = materialSlot;
+		if ( arguments.length > 1 ) {
 
-		this.material = this.editor.getObjectMaterial( object, materialSlot );
+			this.name = editor.strings.getKey( 'command/SetMaterialValue' ) + ': ' + attributeName;
+			this.object = object;
+			this.materialSlot = materialSlot;
 
-		this.oldValue = ( this.material !== undefined ) ? this.material[ attributeName ] : undefined;
-		this.newValue = newValue;
+			const oldMaterial = this.editor.getObjectMaterial( object, materialSlot );
 
-		this.attributeName = attributeName;
+			this.oldValue = oldMaterial[ attributeName ];
+			this.newValue = newValue;
+
+			this.attributeName = attributeName;
+
+		}
 
 	}
 
 	execute() {
 
-		this.material[ this.attributeName ] = this.newValue;
-		this.material.needsUpdate = true;
+		const material = this.editor.getObjectMaterial( this.object, this.materialSlot );
+
+		material[ this.attributeName ] = this.newValue;
+		material.needsUpdate = true;
 
 		this.editor.signals.objectChanged.dispatch( this.object );
 		this.editor.signals.materialChanged.dispatch( this.object, this.materialSlot );
@@ -41,8 +47,10 @@ class SetMaterialValueCommand extends Command {
 
 	undo() {
 
-		this.material[ this.attributeName ] = this.oldValue;
-		this.material.needsUpdate = true;
+		const material = this.editor.getObjectMaterial( this.object, this.materialSlot );
+
+		material[ this.attributeName ] = this.oldValue;
+		material.needsUpdate = true;
 
 		this.editor.signals.objectChanged.dispatch( this.object );
 		this.editor.signals.materialChanged.dispatch( this.object, this.materialSlot );
@@ -63,6 +71,7 @@ class SetMaterialValueCommand extends Command {
 		output.attributeName = this.attributeName;
 		output.oldValue = this.oldValue;
 		output.newValue = this.newValue;
+		output.materialSlot = this.materialSlot;
 
 		return output;
 
@@ -76,6 +85,7 @@ class SetMaterialValueCommand extends Command {
 		this.oldValue = json.oldValue;
 		this.newValue = json.newValue;
 		this.object = this.editor.objectByUuid( json.objectUuid );
+		this.materialSlot = json.materialSlot;
 
 	}
 

--- a/editor/js/commands/SetMaterialVectorCommand.js
+++ b/editor/js/commands/SetMaterialVectorCommand.js
@@ -7,24 +7,30 @@ class SetMaterialVectorCommand extends Command {
 		super( editor );
 
 		this.type = 'SetMaterialVectorCommand';
-		this.name = editor.strings.getKey( 'command/SetMaterialVector' ) + ': ' + attributeName;
 		this.updatable = true;
 
-		this.object = object;
-		this.materialSlot = materialSlot;
+		if ( arguments.length > 1 ) {
 
-		this.material = this.editor.getObjectMaterial( object, materialSlot );
+			this.name = editor.strings.getKey( 'command/SetMaterialVector' ) + ': ' + attributeName;
+			this.object = object;
+			this.materialSlot = materialSlot;
 
-		this.oldValue = ( this.material !== undefined ) ? this.material[ attributeName ].toArray() : undefined;
-		this.newValue = newValue;
+			const oldMaterial = this.editor.getObjectMaterial( object, materialSlot );
 
-		this.attributeName = attributeName;
+			this.oldValue = oldMaterial[ attributeName ].toArray();
+			this.newValue = newValue;
+
+			this.attributeName = attributeName;
+
+		}
 
 	}
 
 	execute() {
 
-		this.material[ this.attributeName ].fromArray( this.newValue );
+		const material = this.editor.getObjectMaterial( this.object, this.materialSlot );
+
+		material[ this.attributeName ].fromArray( this.newValue );
 
 		this.editor.signals.materialChanged.dispatch( this.object, this.materialSlot );
 
@@ -32,7 +38,9 @@ class SetMaterialVectorCommand extends Command {
 
 	undo() {
 
-		this.material[ this.attributeName ].fromArray( this.oldValue );
+		const material = this.editor.getObjectMaterial( this.object, this.materialSlot );
+
+		material[ this.attributeName ].fromArray( this.oldValue );
 
 		this.editor.signals.materialChanged.dispatch( this.object, this.materialSlot );
 
@@ -52,6 +60,7 @@ class SetMaterialVectorCommand extends Command {
 		output.attributeName = this.attributeName;
 		output.oldValue = this.oldValue;
 		output.newValue = this.newValue;
+		output.materialSlot = this.materialSlot;
 
 		return output;
 
@@ -65,6 +74,7 @@ class SetMaterialVectorCommand extends Command {
 		this.attributeName = json.attributeName;
 		this.oldValue = json.oldValue;
 		this.newValue = json.newValue;
+		this.materialSlot = json.materialSlot;
 
 	}
 

--- a/editor/js/commands/SetPositionCommand.js
+++ b/editor/js/commands/SetPositionCommand.js
@@ -15,21 +15,21 @@ class SetPositionCommand extends Command {
 		super( editor );
 
 		this.type = 'SetPositionCommand';
-		this.name = editor.strings.getKey( 'command/SetPosition' );
 		this.updatable = true;
 
-		this.object = object;
+		if ( arguments.length > 1 ) {
 
-		if ( object !== undefined && newPosition !== undefined ) {
+			this.name = editor.strings.getKey( 'command/SetPosition' );
+			this.object = object;
 
 			this.oldPosition = object.position.clone();
 			this.newPosition = newPosition.clone();
 
-		}
+			if ( optionalOldPosition !== undefined ) {
 
-		if ( optionalOldPosition !== undefined ) {
+				this.oldPosition = optionalOldPosition.clone();
 
-			this.oldPosition = optionalOldPosition.clone();
+			}
 
 		}
 

--- a/editor/js/commands/SetRotationCommand.js
+++ b/editor/js/commands/SetRotationCommand.js
@@ -15,21 +15,21 @@ class SetRotationCommand extends Command {
 		super( editor );
 
 		this.type = 'SetRotationCommand';
-		this.name = editor.strings.getKey( 'command/SetRotation' );
 		this.updatable = true;
 
-		this.object = object;
+		if ( arguments.length > 1 ) {
 
-		if ( object !== undefined && newRotation !== undefined ) {
+			this.name = editor.strings.getKey( 'command/SetRotation' );
+			this.object = object;
 
 			this.oldRotation = object.rotation.clone();
 			this.newRotation = newRotation.clone();
 
-		}
+			if ( optionalOldRotation !== undefined ) {
 
-		if ( optionalOldRotation !== undefined ) {
+				this.oldRotation = optionalOldRotation.clone();
 
-			this.oldRotation = optionalOldRotation.clone();
+			}
 
 		}
 

--- a/editor/js/commands/SetScaleCommand.js
+++ b/editor/js/commands/SetScaleCommand.js
@@ -15,21 +15,22 @@ class SetScaleCommand extends Command {
 		super( editor );
 
 		this.type = 'SetScaleCommand';
-		this.name = editor.strings.getKey( 'command/SetScale' );
 		this.updatable = true;
 
-		this.object = object;
+		if ( arguments.length > 1 ) {
 
-		if ( object !== undefined && newScale !== undefined ) {
+			this.name = editor.strings.getKey( 'command/SetScale' );
+
+			this.object = object;
 
 			this.oldScale = object.scale.clone();
 			this.newScale = newScale.clone();
 
-		}
+			if ( optionalOldScale !== undefined ) {
 
-		if ( optionalOldScale !== undefined ) {
+				this.oldScale = optionalOldScale.clone();
 
-			this.oldScale = optionalOldScale.clone();
+			}
 
 		}
 

--- a/editor/js/commands/SetSceneCommand.js
+++ b/editor/js/commands/SetSceneCommand.js
@@ -15,11 +15,12 @@ class SetSceneCommand extends Command {
 		super( editor );
 
 		this.type = 'SetSceneCommand';
-		this.name = editor.strings.getKey( 'command/SetScene' );
 
-		this.cmdArray = [];
+		if ( arguments.length > 1 ) {
 
-		if ( scene !== undefined ) {
+			this.name = editor.strings.getKey( 'command/SetScene' );
+
+			this.cmdArray = [];
 
 			this.cmdArray.push( new SetUuidCommand( this.editor, this.editor.scene, scene.uuid ) );
 			this.cmdArray.push( new SetValueCommand( this.editor, this.editor.scene, 'name', scene.name ) );

--- a/editor/js/commands/SetScriptValueCommand.js
+++ b/editor/js/commands/SetScriptValueCommand.js
@@ -15,15 +15,20 @@ class SetScriptValueCommand extends Command {
 		super( editor );
 
 		this.type = 'SetScriptValueCommand';
-		this.name = editor.strings.getKey( 'command/SetScriptValue' ) + ': ' + attributeName;
 		this.updatable = true;
 
-		this.object = object;
-		this.script = script;
+		if ( arguments.length > 1 ) {
 
-		this.attributeName = attributeName;
-		this.oldValue = ( script !== undefined ) ? script[ this.attributeName ] : undefined;
-		this.newValue = newValue;
+			this.name = editor.strings.getKey( 'command/SetScriptValue' ) + ': ' + attributeName;
+
+			this.object = object;
+			this.script = script;
+
+			this.attributeName = attributeName;
+			this.oldValue = script[ this.attributeName ];
+			this.newValue = newValue;
+
+		}
 
 	}
 

--- a/editor/js/commands/SetUuidCommand.js
+++ b/editor/js/commands/SetUuidCommand.js
@@ -13,12 +13,17 @@ class SetUuidCommand extends Command {
 		super( editor );
 
 		this.type = 'SetUuidCommand';
-		this.name = editor.strings.getKey( 'command/SetUuid' );
 
-		this.object = object;
+		if ( arguments.length > 1 ) {
 
-		this.oldUuid = ( object !== undefined ) ? object.uuid : undefined;
-		this.newUuid = newUuid;
+			this.name = editor.strings.getKey( 'command/SetUuid' );
+
+			this.object = object;
+
+			this.oldUuid = object.uuid;
+			this.newUuid = newUuid;
+
+		}
 
 	}
 

--- a/editor/js/commands/SetValueCommand.js
+++ b/editor/js/commands/SetValueCommand.js
@@ -14,13 +14,18 @@ class SetValueCommand extends Command {
 		super( editor );
 
 		this.type = 'SetValueCommand';
-		this.name = editor.strings.getKey( 'command/SetValue' ) + ': ' + attributeName;
 		this.updatable = true;
 
-		this.object = object;
-		this.attributeName = attributeName;
-		this.oldValue = ( object !== undefined ) ? object[ attributeName ] : undefined;
-		this.newValue = newValue;
+		if ( arguments.length > 1 ) {
+
+			this.name = editor.strings.getKey( 'command/SetValue' ) + ': ' + attributeName;
+
+			this.object = object;
+			this.attributeName = attributeName;
+			this.oldValue = object[ attributeName ];
+			this.newValue = newValue;
+
+		}
 
 	}
 


### PR DESCRIPTION
**Updates: This post has converted to draft, the below issues will be fixed in standalone PRs**

- [ ] Issue 1: Commands don't respect current recovery mechanics ~(#28360)~ (#28398)
- [x] Issue 2: `SetGeometryCommand` failed to UNDO/REDO (#28361)
- [ ] Issue 3: All material related commands `SetMaterialXXXCommand` are failed to UNDO/REDO (#28362)
- [ ] Issue 4: History entries don't honor newly changed locale (skipped)
--- 


The issues and solutions:


## Issue 1: Commands don't respect current recovery mechanics:

- in [fromJSON()](https://github.com/mrdoob/three.js/blob/12db96393fd0dbdd7ee22c739648c1436a34eff9/editor/js/History.js#L203-L204):

```
const cmd = new Commands[ cmdJSON.type ]( this.editor ); // (A)
```

A placeholder command is created in (A), however, some commands don't handle this case, i.e. commands may throw at (A), or some states may wrongly be assigned to `undefined` if they depends on constructor parameters but now missing, in this case the error will be thrown when Undo/Redo instead.

To reproduce:

1. Go to https://threejs.org/editor/
2. In SETTINGS tab, enable persistent in History section
3. Add a Box
4. Select Box in outliner, then in MATERIAL tab, update Color to red 
5. Refresh the page
6. Open console first, then press editor's Edit>Undo 
7. You should see an error about `Cannot read properties of undefined (reading 'color')` in console.

This PR fixed that by unifying all commands to have a guard in constructor in order to respect the recovery mechanics:

```
if (arguments.length > 1) { // guard
  // init states here
```



## Issue 2: `SetGeometryCommand` failed to UNDO/REDO

Because it wrongly serializes `oldGeometry` as current object's geometry.

To reproduce:

1. Go to https://threejs.org/editor/
2. In SETTINGS tab, enable persistent in History section
3. Add a Box
4. Select Box in outliner, then in GEOMETRY tab, update Width from 1 to 2 
5. Refresh the page
6. Press Edit>Undo 
7. You should see the box's width is of 2, not 1

This PR fixed that by serializing it as `this.oldGeometry.toJSON()`




## Isseu 3: All material related commands `SetMaterialXXXCommand` are failed to UNDO/REDO

In execute() and undo(), the material is referencing to the one cached at construction time, it may not be the same material that materialChanged signal is dispatching for.

This PR fixed that by getting material via given `object, materialSlot` in execute() and undo(), instead of using cached one, s.t. it must be the same material as the one materialChanged is dispatching for:

```
const material = this.editor.getObjectMaterial( this.object, this.materialSlot )

// do stuff with material

this.editor.signals.materialChanged.dispatch( this.object, this.materialSlot )
```

## Issue 4: History entries don't honor newly changed locale

When enabled persistent history, then make some changes, then changes SETTINGS>Language, then refresh the page; The history entries will be shown in previous language, not the current language.

The cause is that command name is restored from json, not re-computed during recovery, so it won't respect current editor's language settings.

This PR **doesn't** fixed this issue. I'll submit another PR after this PR get merged

---

## How to test

1. Make sure that 'persistent' is checked in SETTINGS>HISTORY section

5. Create new project (File>New Project>Empty)

3. Make changes, see below (editor will create commands for history)

6. Refresh the page (**make sure states have been stored to IndexedDB** before doing so, i.e. wait at least 0.5s :D)

8. Press Edit>Undo n times until no available Undos
   (in order to test commands' undo())

9. Press Edit>Redo n times until no available Redos
   (in order to test commands' execute())

----

Make changes to test `AddObjectCommand`:

1. Add>Mesh>Box

Make changes to test `AddScriptCommand`:

1. Select default scene in outliner
2. In SCRIPT tab, press 'NEW' to add a script

Make changes to test `MoveObjectCommand`:

1. Add>Mesh>Box
2. Add>Mesh>Ring
4. Reorder Ring to come before Box in outliner

Make changes to test `MultiCmdsCommand`:

(n/a, this command currently has no consumers; should work :D)

Make changes to test `RemoveObjectCommand`:

1. Add>Mesh>Box
2. Select the Box in outliner, press 'delete' key

Make changes to test `RemoveScriptCommand`:

1. Select default scene in outliner
2. In SCRIPT tab, press NEW to add a script, then press REMOVE to remove it

Make changes to test `SetColorCommand`:

1. Add>Light>Directional
2. In OBJECT tab, change Color to red

Make changes to test `SetGeometryCommand`:

1. Add>Mesh>Tube
2. In GEOMETRY tab, in 'Path' row, press '+' to add a point
3. Then, modify the newly added point's coords
4. (editor will create two SetGeometryCommands, adding+modifying)

Make changes to test `GeometryValueCommand`:

1. Add>Mesh>Box
2. In GEOMETRY tab, changes Name

Make changes to test `SetMaterialColorCommand`:

1. Add>Mesh>Box
2. In MATERIAL tab, changes Color to red

Make changes to test `SetMaterialCommand`:

1. Add>Mesh>Box
2. In MATERIAL tab, select MeshBasicMaterial for Type

Make changes to test `SetMaterialRangeCommand`:

1. Add>Mesh>Box
2. In MATERIAL tab, selet MeshPhysicalMaterial for Type
2. Changes 'Thin-Film Thickness Map' min/max

Make changes to test `SetMaterialValueCommand`:

1. Add>Mesh>Box
2. In MATERIAL tab, check Wireframe

Make changes to test `SetMaterialVectorCommand`:

1. Add>Mesh>Box
2. In MATERIAL tab, input an image for Normal Map
3. Enable Normal Map by checking the check box next to image input
4. Then change its scale x to 2

Make changes to test `SetPositionCommand`:

1. Add>Mesh>Box
2. In OBJECT tab, change Position x to 2

Make changes to test `SetRotationCommand`:

1. Add>Mesh>Box
2. In OBJECT tab, change Rotation x to 45deg

Make changes to test `SetScaleCommand`:

1. Add>Mesh>Box
2. In OBJECT tab, change Scale x 2

Make changes to test `SetSceneCommand`:

(tbd; should work :D)

Make changes to test `SetScriptValueCommand`:

1. Select default Scene in outliner
2. In SCRIPT tag, press NEW to add a script
3. Enter name for the script

Make changes to test `SetUuidCommand`:

1. Select default Scene in outliner
2. In OBJECT tab, in UUID row, press NEW

Make changes to test `SetValueCommand`:

1. Add>Mesh>Box
2. In OBJECT tab, check 'Visible'


## Thank You for Your Patience

👏