### PR TITLE
Editor: Fixed submenu disappear for narrow screen

### DIFF
--- a/editor/css/main.css
+++ b/editor/css/main.css
@@ -368,6 +368,7 @@ select {
 
 		#menubar .menu .options {
 			position: fixed;
+			z-index: 1; /* higher than resizer */
 			display: none;
 			padding: 5px 0;
 			background: #eee;


### PR DESCRIPTION
The issue: When users hovering on a submenu, and then moving across the sidebar area, the submenu will disappear

The cause: The submenu is obscured by the resizer element.

This PR fixed that by using a higher z-index value for the submenu `.options`.

Before:

https://github.com/mrdoob/three.js/assets/1063018/1ee48866-5d43-4b62-8bd2-9494b2204d7f

After:

https://github.com/mrdoob/three.js/assets/1063018/e5096102-65ef-4576-b7f1-b2459c08341d

