### PR TITLE
chore(lint): Add eslint to renovate bot's denylist

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,6 +12,12 @@
       "matchUpdateTypes": ["patch", "minor", "pin", "digest"],
       "groupName": "devDependencies (non-major)",
       "automerge": true
+    },
+    {
+      "description": "ESLint v9 requires flat configs, not yet supported by our plugins. See https://github.com/mrdoob/three.js/pull/28354#issuecomment-2106528332",
+      "matchPackageNames": ["eslint"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
Prevents Renovate bot from attempting upgrades to ESLint v9 until we choose. It looks like we'll be using v8 for a while:

- https://github.com/mrdoob/three.js/pull/28354#issuecomment-2106528332