### PR TITLE
Editor: Fixed TODO: Bind lexical this 

### DIFF
--- a/editor/js/libs/ui.three.js
+++ b/editor/js/libs/ui.three.js
@@ -549,9 +549,7 @@ class UIPoints extends UISpan {
 		this.lastPointIdx = 0;
 		this.onChangeCallback = null;
 
-		// TODO Remove this bind() stuff
-
-		this.update = function () {
+		this.update = () => { // bind lexical this
 
 			if ( this.onChangeCallback !== null ) {
 
@@ -559,7 +557,7 @@ class UIPoints extends UISpan {
 
 			}
 
-		}.bind( this );
+		};
 
 	}
 


### PR DESCRIPTION
This PR fixed a TODO in ui.three.js about binding this without `.bind()`; `this.update` is consumed here:

UIPoints2

https://github.com/mrdoob/three.js/blob/db0a63d4f0c5819267c88a4507471913ad57184f/editor/js/libs/ui.three.js#L683-L684

UIPoints3

https://github.com/mrdoob/three.js/blob/db0a63d4f0c5819267c88a4507471913ad57184f/editor/js/libs/ui.three.js#L778-L780