### PR TITLE
Editor: Fixed sidebar glitches

### DIFF
--- a/editor/css/main.css
+++ b/editor/css/main.css
@@ -71,7 +71,6 @@ textarea, input { outline: none; } /* osx */
 	position: relative;
 	display: block;
 	width: 100%;
-	min-width: 335px;
 }
 
 .TabbedPanel .Tabs {
@@ -420,7 +419,7 @@ select {
 	right: 0;
 	top: 32px;
 	bottom: 0;
-	width: 350px;
+	min-width: var(--sidebar-min-width, 335px);
 	background: #eee;
 	overflow: auto;
 }

--- a/editor/index.html
+++ b/editor/index.html
@@ -201,15 +201,43 @@
 
 			} );
 
+			//
+
+			const language = editor.config.getKey( 'language' );
+			editor.config.setKey( 'sidebar/minWidth', editor.config.getSidebarMinWidth( language ) );
+
+			window.addEventListener( 'resize', onWindowResize );
+			window.dispatchEvent( new Event( 'resize' ) );
+
 			function onWindowResize() {
+
+				if ( window.innerWidth <= 600 ) { // @media all and ( max-width: 600px )
+
+					sidebar.setWidth( 'unset' );
+					viewport.setRight( '0' );
+					script.setRight( '0' );
+					player.setRight( '0' );
+					resizer.setRight( '0' );
+
+				} else {
+
+					const sidebarWidth = editor.config.getKey( 'sidebar/width' );
+					const sidebarMinWidth = editor.config.getKey( 'sidebar/minWidth' );
+					const effectiveSidebarWidth = Math.max( sidebarWidth, sidebarMinWidth );
+
+					sidebar.setWidth( effectiveSidebarWidth + 'px' );
+					viewport.setRight( effectiveSidebarWidth + 'px' );
+					script.setRight( effectiveSidebarWidth + 'px' );
+					player.setRight( effectiveSidebarWidth + 'px' );
+					resizer.setRight( effectiveSidebarWidth + 'px' );
+
+					sidebar.dom.style.setProperty( '--sidebar-min-width', sidebarMinWidth + 'px' );
+
+				}
 
 				editor.signals.windowResize.dispatch();
 
 			}
-
-			window.addEventListener( 'resize', onWindowResize );
-
-			onWindowResize();
 
 			//
 

--- a/editor/index.html
+++ b/editor/index.html
@@ -203,8 +203,39 @@
 
 			//
 
-			const language = editor.config.getKey( 'language' );
-			editor.config.setKey( 'sidebar/minWidth', editor.config.getSidebarMinWidth( language ) );
+			function getTabbedPanelWidth( tabbedPanel ) {
+
+				const oldTabbedPanelHiddenState = tabbedPanel.isHidden();
+				tabbedPanel.setHidden( false );
+
+				let sumWidth = 0;
+
+				for ( let i = 0; i < tabbedPanel.tabs.length; i ++ ) {
+
+					const tab = tabbedPanel.tabs[ i ];
+
+					const oldHiddenState = tab.isHidden();
+
+					tab.setHidden( false );
+
+					sumWidth += tab.dom.offsetWidth;
+
+					tab.setHidden( oldHiddenState );
+
+				}
+
+				tabbedPanel.setHidden( oldTabbedPanelHiddenState );
+
+				return sumWidth;
+
+			}
+
+			const scrollbarWidth = 22; // no specs, just guess
+			const sidebarTabbedPanelWidth = getTabbedPanelWidth( sidebar ) + scrollbarWidth;
+			const sidebarPropertiesTabbedPanelWidth = getTabbedPanelWidth( sidebar.sidebarProperties ) + scrollbarWidth;
+			const sidebarMinWidth = Math.max( 335, sidebarTabbedPanelWidth, sidebarPropertiesTabbedPanelWidth );
+
+			editor.config.setKey( 'sidebar/minWidth', sidebarMinWidth );
 
 			window.addEventListener( 'resize', onWindowResize );
 			window.dispatchEvent( new Event( 'resize' ) );

--- a/editor/js/Config.js
+++ b/editor/js/Config.js
@@ -5,19 +5,6 @@ function Config() {
 	const userLanguage = navigator.language.split( '-' )[ 0 ];
 	const suggestedLanguage = [ 'fr', 'ja', 'zh' ].includes( userLanguage ) ? userLanguage : 'en';
 
-	function getSidebarMinWidth( language = suggestedLanguage ) {
-
-		return { // >= #sidebar min-width (335px)
-
-			'en': 350,
-			'fr': 355,
-			'ja': 395,
-			'zh': 335
-
-		}[ language ];
-
-	}
-
 	//
 
 	const storage = {
@@ -44,8 +31,8 @@ function Config() {
 		'settings/shortcuts/undo': 'z',
 		'settings/shortcuts/focus': 'f',
 
-		'sidebar/width': getSidebarMinWidth( suggestedLanguage ),
-		'sidebar/minWidth': getSidebarMinWidth( suggestedLanguage )
+		'sidebar/width': 335,
+		'sidebar/minWidth': 335
 
 	};
 
@@ -92,10 +79,6 @@ function Config() {
 			delete window.localStorage[ name ];
 
 		},
-
-		//
-
-		getSidebarMinWidth: getSidebarMinWidth
 
 	};
 

--- a/editor/js/Config.js
+++ b/editor/js/Config.js
@@ -3,10 +3,25 @@ function Config() {
 	const name = 'threejs-editor';
 
 	const userLanguage = navigator.language.split( '-' )[ 0 ];
-
 	const suggestedLanguage = [ 'fr', 'ja', 'zh' ].includes( userLanguage ) ? userLanguage : 'en';
 
+	function getSidebarMinWidth( language = suggestedLanguage ) {
+
+		return { // >= #sidebar min-width (335px)
+
+			'en': 350,
+			'fr': 355,
+			'ja': 395,
+			'zh': 335
+
+		}[ language ];
+
+	}
+
+	//
+
 	const storage = {
+
 		'language': suggestedLanguage,
 
 		'autosave': true,
@@ -27,7 +42,11 @@ function Config() {
 		'settings/shortcuts/rotate': 'e',
 		'settings/shortcuts/scale': 'r',
 		'settings/shortcuts/undo': 'z',
-		'settings/shortcuts/focus': 'f'
+		'settings/shortcuts/focus': 'f',
+
+		'sidebar/width': getSidebarMinWidth( suggestedLanguage ),
+		'sidebar/minWidth': getSidebarMinWidth( suggestedLanguage )
+
 	};
 
 	if ( window.localStorage[ name ] === undefined ) {
@@ -72,7 +91,11 @@ function Config() {
 
 			delete window.localStorage[ name ];
 
-		}
+		},
+
+		//
+
+		getSidebarMinWidth: getSidebarMinWidth
 
 	};
 

--- a/editor/js/Resizer.js
+++ b/editor/js/Resizer.js
@@ -34,9 +34,9 @@ function Resizer( editor ) {
 		const offsetWidth = document.body.offsetWidth;
 		const clientX = event.clientX;
 
-		const cX = clientX < 0 ? 0 : clientX > offsetWidth ? offsetWidth : clientX;
+		const cX = Math.max( 10, Math.min( clientX, offsetWidth ) ); // leaves 10px for showing resizer
 
-		const x = Math.max( 335, offsetWidth - cX ); // .TabbedPanel min-width: 335px
+		const x = Math.max( editor.config.getKey( 'sidebar/minWidth' ), offsetWidth - cX );
 
 		dom.style.right = x + 'px';
 
@@ -44,6 +44,8 @@ function Resizer( editor ) {
 		document.getElementById( 'player' ).style.right = x + 'px';
 		document.getElementById( 'script' ).style.right = x + 'px';
 		document.getElementById( 'viewport' ).style.right = x + 'px';
+
+		editor.config.setKey( 'sidebar/width', x );
 
 		signals.windowResize.dispatch();
 

--- a/editor/js/Sidebar.js
+++ b/editor/js/Sidebar.js
@@ -12,9 +12,11 @@ function Sidebar( editor ) {
 	const container = new UITabbedPanel();
 	container.setId( 'sidebar' );
 
+	const sidebarProperties = new SidebarProperties( editor );
+
 	const scene = new UISpan().add(
 		new SidebarScene( editor ),
-		new SidebarProperties( editor )
+		sidebarProperties
 	);
 	const project = new SidebarProject( editor );
 	const settings = new SidebarSettings( editor );
@@ -23,6 +25,8 @@ function Sidebar( editor ) {
 	container.addTab( 'project', strings.getKey( 'sidebar/project' ), project );
 	container.addTab( 'settings', strings.getKey( 'sidebar/settings' ), settings );
 	container.select( 'scene' );
+
+	container.sidebarProperties = sidebarProperties;
 
 	return container;
 


### PR DESCRIPTION
The issues: 

1. Editor's sidebar not wide enough for language `ja` , so on **first-run**, the property tabs will be wrapped:

![image](https://github.com/mrdoob/three.js/assets/1063018/b6fb59a2-591e-4ede-a87d-06dad3d1c08c)

2. Currently sidebar's width is unrecoverable, so say Japanese users have to resize the sidebar **every time** the editor restarted (including **refresh the page** for purging texture input's cache :D)

3. Resizer can be dragged way too far to the right, so for languages `fr` and `ja` the property tabs will be wrapped:

https://github.com/mrdoob/three.js/assets/1063018/4061c019-5e5b-4cb2-93d4-fb0590a6f9cc

4. Resizer can be dragged way too far to the left, so once users release the pointer, the resizer can't be dragged again because it's now out of window:

https://github.com/mrdoob/three.js/assets/1063018/d65a0869-e997-4d6b-80b9-cdfdd69ce330


This PR:

- Fixed 1 by detecting effective language on first-run, and then set proper width 
- Fixed 2 by (re)storing sidebar's width to Config
- Fixed 3 by restricting sidebar's min-width based on editor Settings>Language
- Fixed 4 by setting lower bound of sidebar's width to 10(px) instead of 0(px)
 
Preview: (open in incognito mode to mimic first-run) https://raw.githack.com/ycw/three.js/editor-sidebar-width-is-user-pref/editor/index.html



  