### PR TITLE
WebGPURenderer: Export texturePass node

### DIFF
--- a/examples/jsm/nodes/Nodes.js
+++ b/examples/jsm/nodes/Nodes.js
@@ -125,7 +125,7 @@ export { default as GaussianBlurNode, gaussianBlur } from './display/GaussianBlu
 export { default as AfterImageNode, afterImage } from './display/AfterImageNode.js';
 export { default as AnamorphicNode, anamorphic } from './display/AnamorphicNode.js';
 
-export { default as PassNode, pass, depthPass } from './display/PassNode.js';
+export { default as PassNode, pass, texturePass, depthPass } from './display/PassNode.js';
 
 // code
 export { default as ExpressionNode, expression } from './code/ExpressionNode.js';


### PR DESCRIPTION
Related issue: #27621

**Description**
`texturePass` node was not being exported.

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Utsubo](https://utsubo.com)*
