### PR TITLE
Editor: Fixed SetGeometryCommand failed to UNDO/REDO

### DIFF
--- a/editor/js/commands/SetGeometryCommand.js
+++ b/editor/js/commands/SetGeometryCommand.js
@@ -57,7 +57,7 @@ class SetGeometryCommand extends Command {
 		const output = super.toJSON( this );
 
 		output.objectUuid = this.object.uuid;
-		output.oldGeometry = this.object.geometry.toJSON();
+		output.oldGeometry = this.oldGeometry.toJSON();
 		output.newGeometry = this.newGeometry.toJSON();
 
 		return output;


### PR DESCRIPTION
Related issue: #28345 ( issue 2 )

## Issue: `SetGeometryCommand` failed to UNDO/REDO

Because it wrongly serializes `oldGeometry` as current object's geometry.

To reproduce:

1. Go to https://threejs.org/editor/
2. In SETTINGS tab, enable persistent in History section
3. Add a Box
4. Select Box in outliner, then in GEOMETRY tab, update Width from 1 to 2 
5. Refresh the page
6. Press Edit>Undo 
7. You should see the box's width is of 2, not 1

## Solution (This PR)

Fixed that by serializing the `this.oldGeometry.toJSON()` instead
