### PR TITLE
USDZExporter: Make including anchoring properties optional.

### DIFF
--- a/examples/jsm/exporters/USDZExporter.js
+++ b/examples/jsm/exporters/USDZExporter.js
@@ -25,6 +25,7 @@ class USDZExporter {
 				anchoring: { type: 'plane' },
 				planeAnchoring: { alignment: 'horizontal' }
 			},
+			includeAnchoringProperties: true,
 			quickLookCompatible: false,
 			maxTextureSize: 1024,
 		}, options );
@@ -198,6 +199,10 @@ function buildHeader() {
 
 function buildSceneStart( options ) {
 
+	const alignment = options.includeAnchoringProperties === true ? `
+		token preliminary:anchoring:type = "${options.ar.anchoring.type}"
+		token preliminary:planeAnchoring:alignment = "${options.ar.planeAnchoring.alignment}"
+	` : '';
 	return `def Xform "Root"
 {
 	def Scope "Scenes" (
@@ -211,10 +216,7 @@ function buildSceneStart( options ) {
 			}
 			sceneName = "Scene"
 		)
-		{
-		token preliminary:anchoring:type = "${options.ar.anchoring.type}"
-		token preliminary:planeAnchoring:alignment = "${options.ar.planeAnchoring.alignment}"
-
+		{${alignment}
 `;
 
 }


### PR DESCRIPTION
**Description**

Quicklook actually supports anchoring a model on wall or floor (placing a fridge for example) when you don't include the anchoring and planeAnchoring properties in the generated usdz.
There was no way to do that with the options, you could only chose between horizontal and vertical. I propose here to be able to give `{ar: undefined}` in the options so we don't include those two properties when generating the usdz
Also when those properties are not present, the model is actually not auto rotated by 90 degrees compared to using `alignment: 'vertical'`, see discussion in https://github.com/google/model-viewer/issues/3989#issuecomment-2030217299
I have a branch of model-viewer 3.5.0 based on three r163 where I tested this change https://github.com/vincentfretin/model-viewer/tree/ios-placement-wall