### PR TITLE
Editor: Use generated list for File>Import `accept` 

### DIFF
--- a/editor/js/Menubar.File.js
+++ b/editor/js/Menubar.File.js
@@ -1,4 +1,5 @@
 import { UIPanel, UIRow, UIHorizontalRule } from './libs/ui.js';
+import { Loader } from './Loader.js';
 
 function MenubarFile( editor ) {
 
@@ -111,7 +112,7 @@ function MenubarFile( editor ) {
 	const fileInput = document.createElement( 'input' );
 	fileInput.multiple = true;
 	fileInput.type = 'file';
-	fileInput.accept = '.3dm, .3ds, .3mf, .amf, .dae, .drc, .fbx, .glb, .gltf, .js, .json, .kmz, .ldr, .md2, .mpd, .obj, .pcd, .ply, .stl, .svg, .usdz, .vox, .vtk, .vtp, .wrl, .xyz, .zip';
+	fileInput.accept = Loader.getSupportedFileFormats().map( format => '.' + format ).join( ', ' );
 	fileInput.addEventListener( 'change', function () {
 
 		editor.loader.loadFiles( fileInput.files );


### PR DESCRIPTION
Related: #28324

This PR uses `Loader.getSupportedFileFormats()` to setup `accept` value instead of using hardcoded list.