### PR TITLE
Editor: Fixed svg loader undefinedv variable `filename`

### DIFF
--- a/editor/js/Loader.js
+++ b/editor/js/Loader.js
@@ -543,10 +543,10 @@ fileHandlers[ 'svg' ] = function ( editor, manager, reader, file ) {
 
 		//
 
-					const group = new THREE.Group();
-					group.name = filename;
-					group.scale.multiplyScalar( 0.1 );
-					group.scale.y *= - 1;
+		const group = new THREE.Group();
+		group.name = file.name;
+		group.scale.multiplyScalar( 0.1 );
+		group.scale.y *= - 1;
 
 		for ( let i = 0; i < paths.length; i ++ ) {
 


### PR DESCRIPTION
The original fix about setting filename for imported SVG file, was submitted by @linbingquan in #28340, then, I merged that commit **incorrectly** in #28324, the SVG file name should now be `file.name`, not `filename`. Sorry for that 🙏🏻