### PR TITLE
WebGPURenderer: fix createBindGroup warnings when use videoTexture in webgpu mode [Draft]

### DIFF
--- a/examples/jsm/renderers/webgpu/utils/WebGPUBindingUtils.js
+++ b/examples/jsm/renderers/webgpu/utils/WebGPUBindingUtils.js
@@ -210,14 +210,21 @@ class WebGPUBindingUtils {
 
 				let resourceGPU;
 
-				if ( binding.texture.source !== undefined && binding.texture.source.data !== undefined ) {
+				if ( textureData.externalTexture !== undefined ) {
 
-					textureData.externalTexture = binding.texture.source.data;
+					// When textureData.externalTexture is set by updateTexture, we can use it directly
 
 					resourceGPU = device.importExternalTexture( { source: textureData.externalTexture } );
 
+				} else if ( binding.texture.source.data.readyState >= binding.texture.source.data.HAVE_CURRENT_DATA ) {
+
+					// When textureData.externalTexture is empty, but video is already ready, we can set it directly to avoid warnings
+
+					resourceGPU = device.importExternalTexture( { source: binding.texture.source.data } );
+
 				} else {
 
+					// Default
 					resourceGPU = textureData.texture.createView( { aspect: GPUTextureAspect.All, dimension: GPUTextureViewDimension.TwoD, mipLevelCount: binding.store ? 1 : textureData.mipLevelCount } );
 
 				}

--- a/examples/jsm/renderers/webgpu/utils/WebGPUBindingUtils.js
+++ b/examples/jsm/renderers/webgpu/utils/WebGPUBindingUtils.js
@@ -204,6 +204,27 @@ class WebGPUBindingUtils {
 
 				entriesGPU.push( { binding: bindingPoint, resource: textureGPU.sampler } );
 
+			} else if ( binding.isSampledTexture && binding.texture.isVideoTexture ) {
+
+				const textureData = backend.get( binding.texture );
+
+				let resourceGPU;
+
+				if ( binding.texture.source !== undefined && binding.texture.source.data !== undefined ) {
+
+					textureData.externalTexture = binding.texture.source.data;
+
+					resourceGPU = device.importExternalTexture( { source: textureData.externalTexture } );
+
+				} else {
+
+					resourceGPU = textureData.texture.createView( { aspect: GPUTextureAspect.All, dimension: GPUTextureViewDimension.TwoD, mipLevelCount: binding.store ? 1 : textureData.mipLevelCount } );
+
+				}
+
+
+				entriesGPU.push( { binding: bindingPoint, resource: resourceGPU } );
+
 			} else if ( binding.isSampledTexture ) {
 
 				const textureData = backend.get( binding.texture );

--- a/examples/webgpu_materials_video.html
+++ b/examples/webgpu_materials_video.html
@@ -60,9 +60,14 @@
 				ygrid = 10;
 
 			const startButton = document.getElementById( 'startButton' );
-			startButton.addEventListener( 'click', function () {
 
-				init();
+			startButton.addEventListener( 'click', async function () {
+
+        video = document.getElementById( 'video' );
+
+        await video.play()
+
+        init()
 
 			} );
 
@@ -88,14 +93,6 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setAnimationLoop( render );
 				container.appendChild( renderer.domElement );
-
-				video = document.getElementById( 'video' );
-				video.play();
-				video.addEventListener( 'play', function () {
-
-					this.currentTime = 3;
-
-				} );
 
 				texture = new THREE.VideoTexture( video );
 


### PR DESCRIPTION
Related issue: #27690 

**Description**

When open [exmaples ](https://threejs.org/examples/?q=video#webgpu_materials_video), multi warnings will be printed

![img_v3_02as_8632e46e-1af7-4fe2-af59-d1769d002bfg](https://github.com/mrdoob/three.js/assets/13222615/4b2be593-e0a7-4c84-8c5f-554f4d7e308d)

The reason is, in the beginning, video texture is not set correctly. it should be an external texture, but it is initialed as a normal texture view. 
![image](https://github.com/mrdoob/three.js/assets/13222615/86473fbb-ec05-474f-aa44-5e14a1688253)

Later, the external texture is set in WebGPUTextureUtils.js. So the second frame is correct.
```
else if ( texture.isVideoTexture ) {

	const video = texture.source.data;

	textureData.externalTexture = video;

}
```
To solve this problem, we should set external texture correctly in the first frame.
