### PR TITLE
WebGPURenderer: Rebind textureNode value post RenderTarget resize

### DIFF
--- a/examples/jsm/nodes/display/AfterImageNode.js
+++ b/examples/jsm/nodes/display/AfterImageNode.js
@@ -43,6 +43,7 @@ class AfterImageNode extends TempNode {
 
 		this._compRT.setSize( width, height );
 		this._oldRT.setSize( width, height );
+		this._textureNode.value = this._compRT.texture;
 
 	}
 

--- a/examples/jsm/nodes/display/AnamorphicNode.js
+++ b/examples/jsm/nodes/display/AnamorphicNode.js
@@ -49,6 +49,7 @@ class AnamorphicNode extends TempNode {
 		height = Math.max( Math.round( height * this.resolution.y ), 1 );
 
 		this._renderTarget.setSize( width, height );
+		this._textureNode.value = this._renderTarget.texture;
 
 	}
 

--- a/examples/jsm/nodes/display/GaussianBlurNode.js
+++ b/examples/jsm/nodes/display/GaussianBlurNode.js
@@ -49,6 +49,7 @@ class GaussianBlurNode extends TempNode {
 		this._invSize.value.set( 1 / width, 1 / height );
 		this._horizontalRT.setSize( width, height );
 		this._verticalRT.setSize( width, height );
+		this._textureNode.value = this._verticalRT.texture;
 
 	}
 

--- a/examples/jsm/nodes/display/PassNode.js
+++ b/examples/jsm/nodes/display/PassNode.js
@@ -167,6 +167,8 @@ class PassNode extends TempNode {
 		const effectiveHeight = this._height * this._pixelRatio;
 
 		this.renderTarget.setSize( effectiveWidth, effectiveHeight );
+		this._textureNode.value = this.renderTarget.texture;
+		this._depthTextureNode.value = this.renderTarget.depthTexture;
 
 	}
 


### PR DESCRIPTION
Related issue: #28289

**Description**

Additional fix to #28289, when resizing a `RenderTarget`, for example using a PostProcess pipeline with a `PassNode`, the resize will trigger` this.renderTarget.setSize()`, which will dispatch dispose, destroying the associated textures in the backend and then losing the proper binding on the GPU side.

This PR ensures the `textureNode.value` gets updated right after the resize event of the associated `RenderTarget`. Otherwise, if a resize event gets triggered after the updateBefore call and before `binding.update()`, the following error would be triggered because the condition in` binding.update()` (`this.texture !== textureNode.value`) would not be satisfied.
![image](https://github.com/mrdoob/three.js/assets/15867665/152aa2d8-0ea6-4989-b828-45ab0bc472f7)

This happens because the rebinding of `textureNode.value = rtt.texture` isn't triggered yet by `updateBefore`, which will occur in the next frame.


*This contribution is funded by [Utsubo](https://utsubo.com)*