### PR TITLE
Change CurveModifier splineTexture filtering to Linear for smoother path

### DIFF
--- a/examples/jsm/modifiers/CurveModifier.js
+++ b/examples/jsm/modifiers/CurveModifier.js
@@ -10,7 +10,7 @@ import {
 	RepeatWrapping,
 	Mesh,
 	InstancedMesh,
-	NearestFilter,
+	LinearFilter,
 	DynamicDrawUsage,
 	Matrix4
 } from 'three';
@@ -33,7 +33,7 @@ export function initSplineTexture( numberOfCurves = 1 ) {
 
 	dataTexture.wrapS = RepeatWrapping;
 	dataTexture.wrapY = RepeatWrapping;
-	dataTexture.magFilter = NearestFilter;
+	dataTexture.magFilter = LinearFilter;
 	dataTexture.needsUpdate = true;
 
 	return dataTexture;


### PR DESCRIPTION
Related issue: #28376

A clear and concise description of what the problem was and how this pull request solves it.

In the CurveModifier examples there is a lot of jitter and distortionwhen meshes go around the sharper curves:

In the:
https://threejs.org/examples/?q=curve#webgl_modifier_curve_instanced
and:
https://136.24.178.125/three.js/examples/webgl_modifier_curve.html

examples, you can see shimmering as the text instances are curved along their paths around corners.

This is because the splineTexture magFilter is explicitly set to NearestFilter instead of LinearFilter , causing snapping in the splineTexture sampling.


This PR changes the default splineTexture .magFiltering to LinearFiltering to fix this issue.

Here is a glitch that allows changing the magFilter between Linear and Nearest to show the issue:

https://atlantic-warp-sweater.glitch.me/

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Example](https://example.com)*
