### PR TITLE
LDrawLoader should accepts onError callback in `parse()`

### DIFF
--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -1974,7 +1974,7 @@ class LDrawLoader extends Loader {
 
 	}
 
-	parse( text, onLoad ) {
+	parse( text, onLoad, onError ) {
 
 		this.partsCache
 			.parseModel( text, this.materialLibrary )
@@ -1985,7 +1985,8 @@ class LDrawLoader extends Loader {
 				group.userData.fileName = '';
 				onLoad( group );
 
-			} );
+			} )
+			.catch( onError );
 
 	}
 


### PR DESCRIPTION
Currently there's no ways to trap the parse error, this PR added onError callback for `parse()` 