### PR TITLE
DRACOLoader: Fixed "onError doesn't propagate" when parsing file

### DIFF
--- a/examples/jsm/loaders/DRACOLoader.js
+++ b/examples/jsm/loaders/DRACOLoader.js
@@ -85,7 +85,7 @@ class DRACOLoader extends Loader {
 
 	parse( buffer, onLoad, onError = ()=>{} ) {
 
-		this.decodeDracoFile( buffer, onLoad, null, null, SRGBColorSpace ).catch( onError );
+		this.decodeDracoFile( buffer, onLoad, null, null, SRGBColorSpace, onError ).catch( onError );
 
 	}
 


### PR DESCRIPTION
Currently the onError doesn't propagate in here: (missing the 6th argument)

https://github.com/mrdoob/three.js/blob/7e74aa548eff1b6accd60fd42dd0c5022c63ba79/examples/jsm/loaders/DRACOLoader.js#L86-L90

while the onError is consumed here, see L101

https://github.com/mrdoob/three.js/blob/7e74aa548eff1b6accd60fd42dd0c5022c63ba79/examples/jsm/loaders/DRACOLoader.js#L92-L103

This PR fixed that by adding onError to the 6th argument of `decodeDracoFile()`