### PR TITLE
E2E: Adding `webgpu_texturegrad` to exception list.

### DIFF
--- a/test/e2e/puppeteer.js
+++ b/test/e2e/puppeteer.js
@@ -144,6 +144,7 @@ const exceptionList = [
 	'webgpu_custom_fog',
 	'webgpu_instancing_morph',
 	'webgpu_mesh_batch',
+	'webgpu_texturegrad',
 
 	// WebGPU idleTime and parseTime too low
 	'webgpu_compute_particles',


### PR DESCRIPTION
Related issue: -

**Description**

`webgpu_texturegrad` frequently fails in E2E testing. Adding it to the exception list for now.
