### PR TITLE
WebGLRenderer: Simplify morph target code.

### DIFF
--- a/src/renderers/shaders/ShaderChunk/morphcolor_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/morphcolor_vertex.glsl.js
@@ -1,5 +1,5 @@
 export default /* glsl */`
-#if defined( USE_MORPHCOLORS ) && defined( MORPHTARGETS_TEXTURE )
+#if defined( USE_MORPHCOLORS )
 
 	// morphTargetBaseInfluence is set based on BufferGeometry.morphTargetsRelative value:
 	// When morphTargetsRelative is false, this is set to 1 - sum(influences); this results in normal = sum((target - base) * influence)

--- a/src/renderers/shaders/ShaderChunk/morphinstance_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/morphinstance_vertex.glsl.js
@@ -1,7 +1,7 @@
 export default /* glsl */`
 #ifdef USE_INSTANCING_MORPH
 
-	float morphTargetInfluences[MORPHTARGETS_COUNT];
+	float morphTargetInfluences[ MORPHTARGETS_COUNT ];
 
 	float morphTargetBaseInfluence = texelFetch( morphTexture, ivec2( 0, gl_InstanceID ), 0 ).r;
 

--- a/src/renderers/shaders/ShaderChunk/morphnormal_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/morphnormal_vertex.glsl.js
@@ -6,22 +6,11 @@ export default /* glsl */`
 	// When morphTargetsRelative is true, this is set to 1; as a result, all morph targets are simply added to the base after weighting
 	objectNormal *= morphTargetBaseInfluence;
 
-	#ifdef MORPHTARGETS_TEXTURE
+	for ( int i = 0; i < MORPHTARGETS_COUNT; i ++ ) {
 
-		for ( int i = 0; i < MORPHTARGETS_COUNT; i ++ ) {
+		if ( morphTargetInfluences[ i ] != 0.0 ) objectNormal += getMorph( gl_VertexID, i, 1 ).xyz * morphTargetInfluences[ i ];
 
-			if ( morphTargetInfluences[ i ] != 0.0 ) objectNormal += getMorph( gl_VertexID, i, 1 ).xyz * morphTargetInfluences[ i ];
-
-		}
-
-	#else
-
-		objectNormal += morphNormal0 * morphTargetInfluences[ 0 ];
-		objectNormal += morphNormal1 * morphTargetInfluences[ 1 ];
-		objectNormal += morphNormal2 * morphTargetInfluences[ 2 ];
-		objectNormal += morphNormal3 * morphTargetInfluences[ 3 ];
-
-	#endif
+	}
 
 #endif
 `;

--- a/src/renderers/shaders/ShaderChunk/morphtarget_pars_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/morphtarget_pars_vertex.glsl.js
@@ -4,44 +4,23 @@ export default /* glsl */`
 	#ifndef USE_INSTANCING_MORPH
 
 		uniform float morphTargetBaseInfluence;
+		uniform float morphTargetInfluences[ MORPHTARGETS_COUNT ];
 
 	#endif
 
-	#ifdef MORPHTARGETS_TEXTURE
+	uniform sampler2DArray morphTargetsTexture;
+	uniform ivec2 morphTargetsTextureSize;
 
-		#ifndef USE_INSTANCING_MORPH
+	vec4 getMorph( const in int vertexIndex, const in int morphTargetIndex, const in int offset ) {
 
-			uniform float morphTargetInfluences[ MORPHTARGETS_COUNT ];
+		int texelIndex = vertexIndex * MORPHTARGETS_TEXTURE_STRIDE + offset;
+		int y = texelIndex / morphTargetsTextureSize.x;
+		int x = texelIndex - y * morphTargetsTextureSize.x;
 
-		#endif
+		ivec3 morphUV = ivec3( x, y, morphTargetIndex );
+		return texelFetch( morphTargetsTexture, morphUV, 0 );
 
-		uniform sampler2DArray morphTargetsTexture;
-		uniform ivec2 morphTargetsTextureSize;
-
-		vec4 getMorph( const in int vertexIndex, const in int morphTargetIndex, const in int offset ) {
-
-			int texelIndex = vertexIndex * MORPHTARGETS_TEXTURE_STRIDE + offset;
-			int y = texelIndex / morphTargetsTextureSize.x;
-			int x = texelIndex - y * morphTargetsTextureSize.x;
-
-			ivec3 morphUV = ivec3( x, y, morphTargetIndex );
-			return texelFetch( morphTargetsTexture, morphUV, 0 );
-
-		}
-
-	#else
-
-		#ifndef USE_MORPHNORMALS
-
-			uniform float morphTargetInfluences[ 8 ];
-
-		#else
-
-			uniform float morphTargetInfluences[ 4 ];
-
-		#endif
-
-	#endif
+	}
 
 #endif
 `;

--- a/src/renderers/shaders/ShaderChunk/morphtarget_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/morphtarget_vertex.glsl.js
@@ -6,31 +6,11 @@ export default /* glsl */`
 	// When morphTargetsRelative is true, this is set to 1; as a result, all morph targets are simply added to the base after weighting
 	transformed *= morphTargetBaseInfluence;
 
-	#ifdef MORPHTARGETS_TEXTURE
+	for ( int i = 0; i < MORPHTARGETS_COUNT; i ++ ) {
 
-		for ( int i = 0; i < MORPHTARGETS_COUNT; i ++ ) {
+		if ( morphTargetInfluences[ i ] != 0.0 ) transformed += getMorph( gl_VertexID, i, 0 ).xyz * morphTargetInfluences[ i ];
 
-			if ( morphTargetInfluences[ i ] != 0.0 ) transformed += getMorph( gl_VertexID, i, 0 ).xyz * morphTargetInfluences[ i ];
-
-		}
-
-	#else
-
-		transformed += morphTarget0 * morphTargetInfluences[ 0 ];
-		transformed += morphTarget1 * morphTargetInfluences[ 1 ];
-		transformed += morphTarget2 * morphTargetInfluences[ 2 ];
-		transformed += morphTarget3 * morphTargetInfluences[ 3 ];
-
-		#ifndef USE_MORPHNORMALS
-
-			transformed += morphTarget4 * morphTargetInfluences[ 4 ];
-			transformed += morphTarget5 * morphTargetInfluences[ 5 ];
-			transformed += morphTarget6 * morphTargetInfluences[ 6 ];
-			transformed += morphTarget7 * morphTargetInfluences[ 7 ];
-
-		#endif
-
-	#endif
+	}
 
 #endif
 `;

--- a/src/renderers/webgl/WebGLMorphtargets.js
+++ b/src/renderers/webgl/WebGLMorphtargets.js
@@ -12,8 +12,7 @@ function WebGLMorphtargets( gl, capabilities, textures ) {
 
 		const objectInfluences = object.morphTargetInfluences;
 
-		// instead of using attributes, the WebGL 2 code path encodes morph targets
-		// into an array of data textures. Each layer represents a single morph target.
+		// the following encodes morph targets into an array of data textures. Each layer represents a single morph target.
 
 		const morphAttribute = geometry.morphAttributes.position || geometry.morphAttributes.normal || geometry.morphAttributes.color;
 		const morphTargetsCount = ( morphAttribute !== undefined ) ? morphAttribute.length : 0;

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -618,7 +618,6 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 			parameters.morphTargets ? '#define USE_MORPHTARGETS' : '',
 			parameters.morphNormals && parameters.flatShading === false ? '#define USE_MORPHNORMALS' : '',
 			( parameters.morphColors ) ? '#define USE_MORPHCOLORS' : '',
-			( parameters.morphTargetsCount > 0 ) ? '#define MORPHTARGETS_TEXTURE' : '',
 			( parameters.morphTargetsCount > 0 ) ? '#define MORPHTARGETS_TEXTURE_STRIDE ' + parameters.morphTextureStride : '',
 			( parameters.morphTargetsCount > 0 ) ? '#define MORPHTARGETS_COUNT ' + parameters.morphTargetsCount : '',
 			parameters.doubleSided ? '#define DOUBLE_SIDED' : '',
@@ -696,31 +695,6 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 			'#elif defined( USE_COLOR )',
 
 			'	attribute vec3 color;',
-
-			'#endif',
-
-			'#if ( defined( USE_MORPHTARGETS ) && ! defined( MORPHTARGETS_TEXTURE ) )',
-
-			'	attribute vec3 morphTarget0;',
-			'	attribute vec3 morphTarget1;',
-			'	attribute vec3 morphTarget2;',
-			'	attribute vec3 morphTarget3;',
-
-			'	#ifdef USE_MORPHNORMALS',
-
-			'		attribute vec3 morphNormal0;',
-			'		attribute vec3 morphNormal1;',
-			'		attribute vec3 morphNormal2;',
-			'		attribute vec3 morphNormal3;',
-
-			'	#else',
-
-			'		attribute vec3 morphTarget4;',
-			'		attribute vec3 morphTarget5;',
-			'		attribute vec3 morphTarget6;',
-			'		attribute vec3 morphTarget7;',
-
-			'	#endif',
 
 			'#endif',
 


### PR DESCRIPTION
Related issue: -

**Description**

With WebGL 1 out of the way, we can further simplify the morph target related code base in `WebGLRenderer`.
