### PR TITLE
Editor: Introduce FileImporter

### DIFF
--- a/editor/index.html
+++ b/editor/index.html
@@ -181,7 +181,7 @@
 
 			} );
 
-			document.addEventListener( 'drop', function ( event ) {
+			document.addEventListener( 'drop', async function ( event ) {
 
 				event.preventDefault();
 
@@ -191,11 +191,12 @@
 
 					// DataTransferItemList supports folders
 
-					editor.loader.loadItemList( event.dataTransfer.items );
+					await editor.fileImporter.import( event.dataTransfer.items );
+			
 
 				} else {
 
-					editor.loader.loadFiles( event.dataTransfer.files );
+					await editor.fileImporter.import( event.dataTransfer.files );
 
 				}
 

--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 
 import { Config } from './Config.js';
-import { Loader } from './Loader.js';
+import { FileImporter } from './file/FileImporter.js';
 import { History as _History } from './History.js';
 import { Strings } from './Strings.js';
 import { Storage as _Storage } from './Storage.js';
@@ -101,7 +101,7 @@ function Editor() {
 	this.storage = new _Storage();
 	this.strings = new Strings( this.config );
 
-	this.loader = new Loader( this );
+	this.fileImporter = new FileImporter( this );
 
 	this.camera = _DEFAULT_CAMERA.clone();
 

--- a/editor/js/Menubar.File.js
+++ b/editor/js/Menubar.File.js
@@ -1,5 +1,5 @@
+import { FileImporter } from './file/FileImporter.js';
 import { UIPanel, UIRow, UIHorizontalRule } from './libs/ui.js';
-import { Loader } from './Loader.js';
 
 function MenubarFile( editor ) {
 
@@ -112,10 +112,10 @@ function MenubarFile( editor ) {
 	const fileInput = document.createElement( 'input' );
 	fileInput.multiple = true;
 	fileInput.type = 'file';
-	fileInput.accept = Loader.getSupportedFileFormats().map( format => '.' + format ).join( ', ' );
-	fileInput.addEventListener( 'change', function () {
+	fileInput.accept = FileImporter.getAcceptedFileExts().join( ', ' );
+	fileInput.addEventListener( 'change', async function () {
 
-		editor.loader.loadFiles( fileInput.files );
+		await editor.fileImporter.import( fileInput.files );
 		form.reset();
 
 	} );

--- a/editor/js/file/FileImporter.js
+++ b/editor/js/file/FileImporter.js
@@ -1,0 +1,48 @@
+import { FileHandlers } from './handlers/FileHandlers.js';
+import { getFileExt, getFilesFromItemList } from './FileUtils.js';
+import { FileManager } from './FileManager.js';
+
+class FileImporter {
+
+	constructor( editor ) {
+
+		this.editor = editor;
+
+	}
+
+	async import( files, manager ) {
+
+		if ( files instanceof DataTransferItemList ) {
+
+			files = await getFilesFromItemList( files );
+
+		}
+
+		manager = manager || new FileManager( files );
+
+		for ( const file of files ) {
+
+			if ( ! FileImporter.canImport( file ) ) continue;
+
+			const handler = FileHandlers.getImportHandler( file, this.editor, manager );
+			await handler.import( file );
+
+		}
+
+	}
+
+	static getAcceptedFileExts() {
+
+		return Object.keys( FileHandlers.ImportableHandlers ).sort();
+
+	}
+
+	static canImport( file ) {
+
+		return getFileExt( file ) in FileHandlers.ImportableHandlers;
+
+	}
+
+}
+
+export { FileImporter };

--- a/editor/js/file/FileManager.js
+++ b/editor/js/file/FileManager.js
@@ -1,0 +1,37 @@
+import { LoadingManager } from 'three';
+import { TGALoader } from 'three/addons/loaders/TGALoader.js';
+
+class FileManager extends LoadingManager {
+
+	constructor( files ) { // File[] | FileList
+
+		super();
+
+		const fileEntries = Array.prototype.map.call( files, file => [ file.name, file ] );
+		const filesMap = Object.fromEntries( fileEntries );
+
+		this.setURLModifier( url => {
+
+			url = url.replace( /^(\.?\/)/, '' ); // remove './'
+
+			const file = filesMap[ url ];
+
+			if ( file ) {
+
+				console.log( 'Loading', url );
+
+				return URL.createObjectURL( file );
+
+			}
+
+			return url;
+
+		} );
+
+		this.addHandler( /\.tga$/i, new TGALoader() );
+
+	}
+
+}
+
+export { FileManager };

--- a/editor/js/file/FileUtils.js
+++ b/editor/js/file/FileUtils.js
@@ -1,0 +1,155 @@
+function getFileStem( file ) {
+
+	const pathname = ( file instanceof File ) ? file.name : file;
+	const basename = pathname.split( '/' ).pop();
+	const index = basename.lastIndexOf( '.' );
+
+	return index < 0 ? basename : basename.slice( 0, index );
+
+}
+
+function getFileExt( file ) {
+
+	const pathname = ( file instanceof File ) ? file.name : file;
+
+	return '.' + pathname.split( '/' ).pop().split( '.' ).pop().toLowerCase();
+
+}
+
+//
+
+function formatFileSize( sizeB, K = 1024 ) {
+
+	if ( sizeB === 0 ) return '0B';
+
+	const sizes = [ sizeB, sizeB / K, sizeB / K / K ].reverse();
+	const units = [ 'B', 'KB', 'MB' ].reverse();
+	const index = sizes.findIndex( size => size >= 1 );
+
+	return new Intl.NumberFormat( 'en-us', { useGrouping: true, maximumFractionDigits: 1 } )
+		.format( sizes[ index ] ) + units[ index ];
+
+}
+
+//
+
+function defaultOnProgress( event, file ) {
+
+	const loaded = Math.floor( event.loaded / event.total ) * 100;
+
+	const fileSize = formatFileSize( event.loaded );
+
+	console.log( `Reading ${ file.name } (${ fileSize }) ${ loaded }%` );
+
+}
+
+function readAsArrayBuffer( file, onProgress = defaultOnProgress ) {
+
+	return new Promise( ( resolve, reject ) => {
+
+		const reader = new FileReader();
+		reader.addEventListener( 'progress', ( event ) => onProgress( event, file ) );
+		reader.addEventListener( 'error', reject );
+		reader.addEventListener( 'load', ( event ) => resolve( event.target.result ) );
+		reader.readAsArrayBuffer( file );
+
+	} );
+
+}
+
+function readAsText( file, encoding = 'utf-8', onProgress = defaultOnProgress ) {
+
+	return new Promise( ( resolve, reject ) => {
+
+		const reader = new FileReader();
+		reader.addEventListener( 'progress', ( event ) => onProgress( event, file ) );
+		reader.addEventListener( 'error', reject );
+		reader.addEventListener( 'load', ( event ) => resolve( event.target.result ) );
+		reader.readAsText( file, encoding );
+
+	} );
+
+}
+
+//
+
+function getFilesFromItemList( dataTransferItems ) {
+
+	return new Promise( ( resolve /*, reject */ ) => {
+
+		// TOFIX: setURLModifier() breaks when the file being loaded is not in root
+
+		let itemsCount = 0;
+		let itemsTotal = 0;
+
+		const files = [];
+
+		function onEntryHandled() {
+
+			itemsCount ++;
+
+			if ( itemsCount === itemsTotal ) {
+
+				resolve( files );
+
+			}
+
+		}
+
+		function handleEntry( entry ) {
+
+			if ( entry.isDirectory ) {
+
+				const reader = entry.createReader();
+				reader.readEntries( function ( entries ) {
+
+					for ( let i = 0; i < entries.length; i ++ ) {
+
+						handleEntry( entries[ i ] );
+
+					}
+
+					onEntryHandled();
+
+				} );
+
+			} else if ( entry.isFile ) {
+
+				entry.file( function ( file ) {
+
+					files.push( file );
+
+					onEntryHandled();
+
+				} );
+
+			}
+
+			itemsTotal ++;
+
+		}
+
+		for ( let i = 0; i < dataTransferItems.length; i ++ ) {
+
+			const item = dataTransferItems[ i ];
+
+			if ( item.kind === 'file' ) {
+
+				handleEntry( item.webkitGetAsEntry() );
+
+			}
+
+		}
+
+	} );
+
+}
+
+//
+
+export {
+	getFileStem, getFileExt,
+	formatFileSize,
+	readAsArrayBuffer, readAsText,
+	getFilesFromItemList
+};

--- a/editor/js/file/handlers/FileHandler.js
+++ b/editor/js/file/handlers/FileHandler.js
@@ -1,0 +1,24 @@
+import { getFileStem } from '../FileUtils.js';
+
+class FileHandler {
+
+	constructor( editor, manager ) {
+
+		this.editor = editor;
+		this.manager = manager;
+
+	}
+
+	async instantiate( loaderPath, loaderName = '' ) {
+
+		const module = await import( loaderPath );
+
+		loaderName = loaderName || getFileStem( loaderPath );
+
+		return new module[ loaderName ]( this.manager );
+
+	}
+
+}
+
+export { FileHandler };

--- a/editor/js/file/handlers/FileHandler_3DM.js
+++ b/editor/js/file/handlers/FileHandler_3DM.js
@@ -1,0 +1,40 @@
+import { AddObjectCommand } from '../../commands/AddObjectCommand.js';
+import { readAsArrayBuffer } from '../FileUtils.js';
+import { FileHandler } from './FileHandler.js';
+
+class FileHandler_3DM extends FileHandler {
+
+	constructor( editor, manager ) {
+
+		super( editor, manager );
+
+	}
+
+	async import( file ) {
+
+		const loader = await this.instantiate( 'three/addons/loaders/3DMLoader.js', 'Rhino3dmLoader' );
+		loader.setLibraryPath( '../examples/jsm/libs/rhino3dm/' );
+
+		const contents = await readAsArrayBuffer( file );
+
+		const object = await parseAsync( loader, contents );
+
+		object.name = file.name;
+
+		this.editor.execute( new AddObjectCommand( this.editor, object ) );
+
+	}
+
+}
+
+//
+
+function parseAsync( loader, contents ) {
+
+	return new Promise( ( resolve, reject ) => loader.parse( contents, resolve, reject ) );
+
+}
+
+//
+
+export { FileHandler_3DM };

--- a/editor/js/file/handlers/FileHandler_3DS.js
+++ b/editor/js/file/handlers/FileHandler_3DS.js
@@ -1,0 +1,27 @@
+import { AddObjectCommand } from '../../commands/AddObjectCommand.js';
+import { readAsArrayBuffer } from '../FileUtils.js';
+import { FileHandler } from './FileHandler.js';
+
+class FileHandler_3DS extends FileHandler {
+
+	constructor( editor, manager ) {
+
+		super( editor, manager );
+
+	}
+
+	async import( file ) {
+
+		const loader = await this.instantiate( 'three/addons/loaders/TDSLoader.js' );
+
+		const contents = await readAsArrayBuffer( file );
+
+		const object = loader.parse( contents );
+
+		this.editor.execute( new AddObjectCommand( this.editor, object ) );
+
+	}
+
+}
+
+export { FileHandler_3DS };

--- a/editor/js/file/handlers/FileHandler_3MF.js
+++ b/editor/js/file/handlers/FileHandler_3MF.js
@@ -1,0 +1,27 @@
+import { AddObjectCommand } from '../../commands/AddObjectCommand.js';
+import { readAsArrayBuffer } from '../FileUtils.js';
+import { FileHandler } from './FileHandler.js';
+
+class FileHandler_3MF extends FileHandler {
+
+	constructor( editor, manager ) {
+
+		super( editor, manager );
+
+	}
+
+	async import( file ) {
+
+		const loader = await this.instantiate( 'three/addons/loaders/3MFLoader.js', 'ThreeMFLoader' );
+
+		const contents = await readAsArrayBuffer( file );
+
+		const object = loader.parse( contents );
+
+		this.editor.execute( new AddObjectCommand( this.editor, object ) );
+
+	}
+
+}
+
+export { FileHandler_3MF };

--- a/editor/js/file/handlers/FileHandler_AMF.js
+++ b/editor/js/file/handlers/FileHandler_AMF.js
@@ -1,0 +1,27 @@
+import { AddObjectCommand } from '../../commands/AddObjectCommand.js';
+import { readAsArrayBuffer } from '../FileUtils.js';
+import { FileHandler } from './FileHandler.js';
+
+class FileHandler_AMF extends FileHandler {
+
+	constructor( editor, manager ) {
+
+		super( editor, manager );
+
+	}
+
+	async import( file ) {
+
+		const loader = await this.instantiate( 'three/addons/loaders/AMFLoader.js' );
+
+		const contents = await readAsArrayBuffer( file );
+
+		const object = loader.parse( contents );
+
+		this.editor.execute( new AddObjectCommand( this.editor, object ) );
+
+	}
+
+}
+
+export { FileHandler_AMF };

--- a/editor/js/file/handlers/FileHandler_COLLADA.js
+++ b/editor/js/file/handlers/FileHandler_COLLADA.js
@@ -1,0 +1,29 @@
+import { AddObjectCommand } from '../../commands/AddObjectCommand.js';
+import { readAsText } from '../FileUtils.js';
+import { FileHandler } from './FileHandler.js';
+
+class FileHandler_COLLADA extends FileHandler {
+
+	constructor( editor, manager ) {
+
+		super( editor, manager );
+
+	}
+
+	async import( file ) {
+
+		const loader = await this.instantiate( 'three/addons/loaders/ColladaLoader.js' );
+
+		const contents = await readAsText( file );
+
+		const object = loader.parse( contents );
+
+		object.scene.name = file.name;
+
+		this.editor.execute( new AddObjectCommand( this.editor, object.scene ) );
+
+	}
+
+}
+
+export { FileHandler_COLLADA };

--- a/editor/js/file/handlers/FileHandler_DRACO.js
+++ b/editor/js/file/handlers/FileHandler_DRACO.js
@@ -1,0 +1,55 @@
+import { AddObjectCommand } from '../../commands/AddObjectCommand.js';
+import { readAsArrayBuffer } from '../FileUtils.js';
+import { FileHandler } from './FileHandler.js';
+import * as THREE from 'three';
+
+class FileHandler_DRACO extends FileHandler {
+
+	constructor( editor, manager ) {
+
+		super( editor, manager );
+
+	}
+
+	async import( file ) {
+
+		const loader = await this.instantiate( 'three/addons/loaders/DRACOLoader.js' );
+		loader.setDecoderPath( '../examples/jsm/libs/draco/' );
+
+		const contents = await readAsArrayBuffer( file );
+
+		const geometry = await parseAsync( loader, contents );
+
+		let object;
+
+		if ( geometry.index !== null ) {
+
+			const material = new THREE.MeshStandardMaterial();
+
+			object = new THREE.Mesh( geometry, material );
+			object.name = file.name;
+
+		} else {
+
+			const material = new THREE.PointsMaterial( { size: 0.01 } );
+			material.vertexColors = geometry.hasAttribute( 'color' );
+
+			object = new THREE.Points( geometry, material );
+			object.name = file.name;
+
+		}
+
+		loader.dispose();
+		this.editor.execute( new AddObjectCommand( this.editor, object ) );
+
+	}
+
+}
+
+function parseAsync( loader, contents ) {
+
+	return new Promise( ( resolve, reject ) => loader.parse( contents, resolve, reject ) );
+
+}
+
+export { FileHandler_DRACO };

--- a/editor/js/file/handlers/FileHandler_FBX.js
+++ b/editor/js/file/handlers/FileHandler_FBX.js
@@ -1,0 +1,27 @@
+import { AddObjectCommand } from '../../commands/AddObjectCommand.js';
+import { readAsArrayBuffer } from '../FileUtils.js';
+import { FileHandler } from './FileHandler.js';
+
+class FileHandler_FBX extends FileHandler {
+
+	constructor( editor, manager ) {
+
+		super( editor, manager );
+
+	}
+
+	async import( file ) {
+
+		const loader = await this.instantiate( 'three/addons/loaders/FBXLoader.js' );
+
+		const contents = await readAsArrayBuffer( file );
+
+		const object = loader.parse( contents );
+
+		this.editor.execute( new AddObjectCommand( this.editor, object ) );
+
+	}
+
+}
+
+export { FileHandler_FBX };

--- a/editor/js/file/handlers/FileHandler_GLB.js
+++ b/editor/js/file/handlers/FileHandler_GLB.js
@@ -1,0 +1,35 @@
+import { AddObjectCommand } from '../../commands/AddObjectCommand.js';
+import { readAsArrayBuffer } from '../FileUtils.js';
+import { FileHandler } from './FileHandler.js';
+import { createGLTFLoader } from './FileHandler_GLTF.js';
+
+class FileHandler_GLB extends FileHandler {
+
+	constructor( editor, manager ) {
+
+		super( editor, manager );
+
+	}
+
+	async import( file ) {
+
+		const loader = await createGLTFLoader( this.editor, this.manager );
+
+		const contents = await readAsArrayBuffer( file );
+
+		const result = await loader.parseAsync( contents );
+
+		const scene = result.scene;
+		scene.name = file.name;
+
+		scene.animations.push( ...result.animations );
+		this.editor.execute( new AddObjectCommand( this.editor, scene ) );
+
+		loader.dracoLoader.dispose();
+		loader.ktx2Loader.dispose();
+
+	}
+
+}
+
+export { FileHandler_GLB };

--- a/editor/js/file/handlers/FileHandler_GLTF.js
+++ b/editor/js/file/handlers/FileHandler_GLTF.js
@@ -1,0 +1,58 @@
+import { AddObjectCommand } from '../../commands/AddObjectCommand.js';
+import { readAsArrayBuffer } from '../FileUtils.js';
+import { FileHandler } from './FileHandler.js';
+
+class FileHandler_GLTF extends FileHandler {
+
+	constructor( editor, manager ) {
+
+		super( editor, manager );
+
+	}
+
+	async import( file ) {
+
+		const loader = await createGLTFLoader( this.editor, this.manager );
+
+		const contents = await readAsArrayBuffer( file );
+
+		const result = await loader.parseAsync( contents );
+
+		const scene = result.scene;
+		scene.name = file.name;
+
+		scene.animations.push( ...result.animations );
+		this.editor.execute( new AddObjectCommand( this.editor, scene ) );
+
+		loader.dracoLoader.dispose();
+		loader.ktx2Loader.dispose();
+
+	}
+
+}
+
+async function createGLTFLoader( editor, manager ) {
+
+	const { GLTFLoader } = await import( 'three/addons/loaders/GLTFLoader.js' );
+	const { DRACOLoader } = await import( 'three/addons/loaders/DRACOLoader.js' );
+	const { KTX2Loader } = await import( 'three/addons/loaders/KTX2Loader.js' );
+	const { MeshoptDecoder } = await import( 'three/addons/libs/meshopt_decoder.module.js' );
+
+	const dracoLoader = new DRACOLoader();
+	dracoLoader.setDecoderPath( '../examples/jsm/libs/draco/gltf/' );
+
+	const ktx2Loader = new KTX2Loader( manager );
+	ktx2Loader.setTranscoderPath( '../examples/jsm/libs/basis/' );
+
+	editor.signals.rendererDetectKTX2Support.dispatch( ktx2Loader );
+
+	const loader = new GLTFLoader( manager );
+	loader.setDRACOLoader( dracoLoader );
+	loader.setKTX2Loader( ktx2Loader );
+	loader.setMeshoptDecoder( MeshoptDecoder );
+
+	return loader;
+
+}
+
+export { FileHandler_GLTF, createGLTFLoader };

--- a/editor/js/file/handlers/FileHandler_JS.js
+++ b/editor/js/file/handlers/FileHandler_JS.js
@@ -1,0 +1,152 @@
+import { AddObjectCommand } from '../../commands/AddObjectCommand.js';
+import { readAsText } from '../FileUtils.js';
+import { FileHandler } from './FileHandler.js';
+import * as THREE from 'three';
+
+class FileHandler_JS extends FileHandler {
+
+	constructor( editor, manager ) {
+
+		super( editor, manager );
+
+		this.texturePath = '';
+
+	}
+
+	async import( file ) {
+
+		const contents = await readAsText( file );
+
+		// 2.0
+
+		if ( contents.indexOf( 'postMessage' ) !== - 1 ) {
+
+			await parseAsync( this.editor, this.texturePath, contents );
+
+			return;
+
+		}
+
+		// >= 3.0
+
+		let data;
+
+		try {
+
+			data = JSON.parse( contents );
+
+		} catch ( error ) {
+
+			alert( error );
+			return;
+
+		}
+
+		handleJSON( this.editor, this.texturePath, data );
+
+	}
+
+}
+
+//
+
+function parseAsync( editor, texturePath, contents ) {
+
+	return new Promise( ( resolve, reject ) => {
+
+		const blob = new Blob( [ contents ], { type: 'text/javascript' } );
+		const url = URL.createObjectURL( blob );
+
+		const worker = new Worker( url );
+
+		worker.onmessage = function ( event ) {
+
+			event.data.metadata = { version: 2 };
+			handleJSON( editor, texturePath, event.data );
+			resolve();
+
+		};
+
+		worker.postMessage( Date.now() );
+
+		worker.onerror = reject;
+
+	} );
+
+}
+
+//
+
+function handleJSON( editor, texturePath, data ) {
+
+	if ( data.metadata === undefined ) { // 2.0
+
+		data.metadata = { type: 'Geometry' };
+
+	}
+
+	if ( data.metadata.type === undefined ) { // 3.0
+
+		data.metadata.type = 'Geometry';
+
+	}
+
+	if ( data.metadata.formatVersion !== undefined ) {
+
+		data.metadata.version = data.metadata.formatVersion;
+
+	}
+
+	switch ( data.metadata.type.toLowerCase() ) {
+
+		case 'buffergeometry':
+
+		{
+
+			const loader = new THREE.BufferGeometryLoader();
+			const result = loader.parse( data );
+
+			const mesh = new THREE.Mesh( result );
+
+			editor.execute( new AddObjectCommand( editor, mesh ) );
+
+			break;
+
+		}
+
+		case 'geometry':
+
+			console.error( 'Loader: "Geometry" is no longer supported.' );
+
+			break;
+
+		case 'object':
+
+		{
+
+			const loader = new THREE.ObjectLoader();
+			loader.setResourcePath( texturePath );
+
+			loader.parse( data, function ( result ) {
+
+				editor.execute( new AddObjectCommand( editor, result ) );
+
+			} );
+
+			break;
+
+		}
+
+		case 'app':
+
+			editor.fromJSON( data );
+
+			break;
+
+	}
+
+}
+
+//
+
+export { FileHandler_JS };

--- a/editor/js/file/handlers/FileHandler_KMZ.js
+++ b/editor/js/file/handlers/FileHandler_KMZ.js
@@ -1,0 +1,29 @@
+import { AddObjectCommand } from '../../commands/AddObjectCommand.js';
+import { readAsArrayBuffer } from '../FileUtils.js';
+import { FileHandler } from './FileHandler.js';
+
+class FileHandler_KMZ extends FileHandler {
+
+	constructor( editor, manager ) {
+
+		super( editor, manager );
+
+	}
+
+	async import( file ) {
+
+		const loader = await this.instantiate( 'three/addons/loaders/KMZLoader.js' );
+
+		const contents = await readAsArrayBuffer( file );
+
+		const collada = loader.parse( contents );
+
+		collada.scene.name = file.name;
+
+		this.editor.execute( new AddObjectCommand( this.editor, collada.scene ) );
+
+	}
+
+}
+
+export { FileHandler_KMZ };

--- a/editor/js/file/handlers/FileHandler_LDRAW.js
+++ b/editor/js/file/handlers/FileHandler_LDRAW.js
@@ -1,0 +1,42 @@
+import { AddObjectCommand } from '../../commands/AddObjectCommand.js';
+import { readAsText } from '../FileUtils.js';
+import { FileHandler } from './FileHandler.js';
+
+class FileHandler_LDRAW extends FileHandler {
+
+	constructor( editor, manager ) {
+
+		super( editor, manager );
+
+	}
+
+	async import( file ) {
+
+		const loader = await this.instantiate( 'three/addons/loaders/LDrawLoader.js' );
+		loader.setPath( '../../examples/models/ldraw/officialLibrary/' );
+
+		const contents = await readAsText( file );
+
+		const group = await parseAsync( loader, contents );
+
+		group.name = file.name;
+		// Convert from LDraw coordinates: rotate 180 degrees around OX
+		group.rotation.x = Math.PI;
+
+		this.editor.execute( new AddObjectCommand( this.editor, group ) );
+
+	}
+
+}
+
+//
+
+function parseAsync( loader, contents ) {
+
+	return new Promise( ( resolve, reject ) => loader.parse( contents, resolve, reject ) );
+
+}
+
+//
+
+export { FileHandler_LDRAW };

--- a/editor/js/file/handlers/FileHandler_MD2.js
+++ b/editor/js/file/handlers/FileHandler_MD2.js
@@ -1,0 +1,34 @@
+import { AddObjectCommand } from '../../commands/AddObjectCommand.js';
+import { readAsArrayBuffer } from '../FileUtils.js';
+import { FileHandler } from './FileHandler.js';
+import * as THREE from 'three';
+
+class FileHandler_MD2 extends FileHandler {
+
+	constructor( editor, manager ) {
+
+		super( editor, manager );
+
+	}
+
+	async import( file ) {
+
+		const loader = await this.instantiate( 'three/addons/loaders/MD2Loader.js' );
+
+		const contents = await readAsArrayBuffer( file );
+
+		const geometry = loader.parse( contents );
+		const material = new THREE.MeshStandardMaterial();
+
+		const mesh = new THREE.Mesh( geometry, material );
+		mesh.mixer = new THREE.AnimationMixer( mesh );
+		mesh.name = file.name;
+
+		mesh.animations.push( ...geometry.animations );
+		this.editor.execute( new AddObjectCommand( this.editor, mesh ) );
+
+	}
+
+}
+
+export { FileHandler_MD2 };

--- a/editor/js/file/handlers/FileHandler_OBJ.js
+++ b/editor/js/file/handlers/FileHandler_OBJ.js
@@ -1,0 +1,28 @@
+import { AddObjectCommand } from '../../commands/AddObjectCommand.js';
+import { readAsText } from '../FileUtils.js';
+import { FileHandler } from './FileHandler.js';
+
+class FileHandler_OBJ extends FileHandler {
+
+	constructor( editor, manager ) {
+
+		super( editor, manager );
+
+	}
+
+	async import( file ) {
+
+		const loader = await this.instantiate( 'three/addons/loaders/OBJLoader.js' );
+
+		const contents = await readAsText( file );
+
+		const object = loader.parse( contents );
+		object.name = file.name;
+
+		this.editor.execute( new AddObjectCommand( this.editor, object ) );
+
+	}
+
+}
+
+export { FileHandler_OBJ };

--- a/editor/js/file/handlers/FileHandler_PCD.js
+++ b/editor/js/file/handlers/FileHandler_PCD.js
@@ -1,0 +1,28 @@
+import { AddObjectCommand } from '../../commands/AddObjectCommand.js';
+import { readAsArrayBuffer } from '../FileUtils.js';
+import { FileHandler } from './FileHandler.js';
+
+class FileHandler_PCD extends FileHandler {
+
+	constructor( editor, manager ) {
+
+		super( editor, manager );
+
+	}
+
+	async import( file ) {
+
+		const loader = await this.instantiate( 'three/addons/loaders/PCDLoader.js' );
+
+		const contents = await readAsArrayBuffer( file );
+
+		const points = loader.parse( contents );
+		points.name = file.name;
+
+		this.editor.execute( new AddObjectCommand( this.editor, points ) );
+
+	}
+
+}
+
+export { FileHandler_PCD };

--- a/editor/js/file/handlers/FileHandler_PLY.js
+++ b/editor/js/file/handlers/FileHandler_PLY.js
@@ -1,0 +1,47 @@
+import { AddObjectCommand } from '../../commands/AddObjectCommand.js';
+import { readAsArrayBuffer } from '../FileUtils.js';
+import { FileHandler } from './FileHandler.js';
+import * as THREE from 'three';
+
+class FileHandler_PLY extends FileHandler {
+
+	constructor( editor, manager ) {
+
+		super( editor, manager );
+
+	}
+
+	async import( file ) {
+
+		const loader = await this.instantiate( 'three/addons/loaders/PLYLoader.js' );
+
+		const contents = await readAsArrayBuffer( file );
+
+		const geometry = loader.parse( contents );
+
+		let object;
+
+		if ( geometry.index !== null ) {
+
+			const material = new THREE.MeshStandardMaterial();
+
+			object = new THREE.Mesh( geometry, material );
+			object.name = file.name;
+
+		} else {
+
+			const material = new THREE.PointsMaterial( { size: 0.01 } );
+			material.vertexColors = geometry.hasAttribute( 'color' );
+
+			object = new THREE.Points( geometry, material );
+			object.name = file.name;
+
+		}
+
+		this.editor.execute( new AddObjectCommand( this.editor, object ) );
+
+	}
+
+}
+
+export { FileHandler_PLY };

--- a/editor/js/file/handlers/FileHandler_STL.js
+++ b/editor/js/file/handlers/FileHandler_STL.js
@@ -1,0 +1,32 @@
+import { AddObjectCommand } from '../../commands/AddObjectCommand.js';
+import { readAsArrayBuffer } from '../FileUtils.js';
+import { FileHandler } from './FileHandler.js';
+import * as THREE from 'three';
+
+class FileHandler_STL extends FileHandler {
+
+	constructor( editor, manager ) {
+
+		super( editor, manager );
+
+	}
+
+	async import( file ) {
+
+		const loader = await this.instantiate( 'three/addons/loaders/STLLoader.js' );
+
+		const contents = await readAsArrayBuffer( file );
+
+		const geometry = loader.parse( contents );
+		const material = new THREE.MeshStandardMaterial();
+
+		const mesh = new THREE.Mesh( geometry, material );
+		mesh.name = file.name;
+
+		this.editor.execute( new AddObjectCommand( this.editor, mesh ) );
+
+	}
+
+}
+
+export { FileHandler_STL };

--- a/editor/js/file/handlers/FileHandler_SVG.js
+++ b/editor/js/file/handlers/FileHandler_SVG.js
@@ -1,0 +1,59 @@
+import { AddObjectCommand } from '../../commands/AddObjectCommand.js';
+import { readAsText } from '../FileUtils.js';
+import { FileHandler } from './FileHandler.js';
+import * as THREE from 'three';
+
+class FileHandler_SVG extends FileHandler {
+
+	constructor( editor, manager ) {
+
+		super( editor, manager );
+
+	}
+
+	async import( file ) {
+
+		const loader = await this.instantiate( 'three/addons/loaders/SVGLoader.js' );
+
+		const contents = await readAsText( file );
+
+		const paths = loader.parse( contents ).paths;
+
+		//
+
+		const group = new THREE.Group();
+		group.name = file.name;
+		group.scale.multiplyScalar( 0.1 );
+		group.scale.y *= - 1;
+
+		for ( let i = 0; i < paths.length; i ++ ) {
+
+			const path = paths[ i ];
+
+			const material = new THREE.MeshBasicMaterial( {
+				color: path.color,
+				depthWrite: false
+			} );
+
+			const shapes = loader.constructor.createShapes( path );
+
+			for ( let j = 0; j < shapes.length; j ++ ) {
+
+				const shape = shapes[ j ];
+
+				const geometry = new THREE.ShapeGeometry( shape );
+				const mesh = new THREE.Mesh( geometry, material );
+
+				group.add( mesh );
+
+			}
+
+		}
+
+		this.editor.execute( new AddObjectCommand( this.editor, group ) );
+
+	}
+
+}
+
+export { FileHandler_SVG };

--- a/editor/js/file/handlers/FileHandler_USDZ.js
+++ b/editor/js/file/handlers/FileHandler_USDZ.js
@@ -1,0 +1,28 @@
+import { AddObjectCommand } from '../../commands/AddObjectCommand.js';
+import { readAsArrayBuffer } from '../FileUtils.js';
+import { FileHandler } from './FileHandler.js';
+
+class FileHandler_USDZ extends FileHandler {
+
+	constructor( editor, manager ) {
+
+		super( editor, manager );
+
+	}
+
+	async import( file ) {
+
+		const loader = await this.instantiate( 'three/addons/loaders/USDZLoader.js' );
+
+		const contents = await readAsArrayBuffer( file );
+
+		const group = loader.parse( contents );
+		group.name = file.name;
+
+		this.editor.execute( new AddObjectCommand( this.editor, group ) );
+
+	}
+
+}
+
+export { FileHandler_USDZ };

--- a/editor/js/file/handlers/FileHandler_VOX.js
+++ b/editor/js/file/handlers/FileHandler_VOX.js
@@ -1,0 +1,40 @@
+import { AddObjectCommand } from '../../commands/AddObjectCommand.js';
+import { readAsArrayBuffer } from '../FileUtils.js';
+import { FileHandler } from './FileHandler.js';
+import * as THREE from 'three';
+
+class FileHandler_VOX extends FileHandler {
+
+	constructor( editor, manager ) {
+
+		super( editor, manager );
+
+	}
+
+	async import( file ) {
+
+		const { VOXLoader, VOXMesh } = await import( 'three/addons/loaders/VOXLoader.js' );
+
+		const contents = await readAsArrayBuffer( file );
+
+		const chunks = new VOXLoader( this.manager ).parse( contents );
+
+		const group = new THREE.Group();
+		group.name = file.name;
+
+		for ( let i = 0; i < chunks.length; i ++ ) {
+
+			const chunk = chunks[ i ];
+
+			const mesh = new VOXMesh( chunk );
+			group.add( mesh );
+
+		}
+
+		this.editor.execute( new AddObjectCommand( this.editor, group ) );
+
+	}
+
+}
+
+export { FileHandler_VOX };

--- a/editor/js/file/handlers/FileHandler_VRML.js
+++ b/editor/js/file/handlers/FileHandler_VRML.js
@@ -1,0 +1,27 @@
+import { AddObjectCommand } from '../../commands/AddObjectCommand.js';
+import { readAsText } from '../FileUtils.js';
+import { FileHandler } from './FileHandler.js';
+
+class FileHandler_VRML extends FileHandler {
+
+	constructor( editor, manager ) {
+
+		super( editor, manager );
+
+	}
+
+	async import( file ) {
+
+		const loader = await this.instantiate( 'three/addons/loaders/VRMLLoader.js' );
+
+		const contents = await readAsText( file );
+
+		const object = loader.parse( contents );
+
+		this.editor.execute( new AddObjectCommand( this.editor, object ) );
+
+	}
+
+}
+
+export { FileHandler_VRML };

--- a/editor/js/file/handlers/FileHandler_VTK.js
+++ b/editor/js/file/handlers/FileHandler_VTK.js
@@ -1,0 +1,32 @@
+import { AddObjectCommand } from '../../commands/AddObjectCommand.js';
+import { readAsArrayBuffer } from '../FileUtils.js';
+import { FileHandler } from './FileHandler.js';
+import * as THREE from 'three';
+
+class FileHandler_VTK extends FileHandler {
+
+	constructor( editor, manager ) {
+
+		super( editor, manager );
+
+	}
+
+	async import( file ) {
+
+		const loader = await this.instantiate( 'three/addons/loaders/VTKLoader.js' );
+
+		const contents = await readAsArrayBuffer( file );
+
+		const geometry = loader.parse( contents );
+		const material = new THREE.MeshStandardMaterial();
+
+		const mesh = new THREE.Mesh( geometry, material );
+		mesh.name = file.name;
+
+		this.editor.execute( new AddObjectCommand( this.editor, mesh ) );
+
+	}
+
+}
+
+export { FileHandler_VTK };

--- a/editor/js/file/handlers/FileHandler_XYZ.js
+++ b/editor/js/file/handlers/FileHandler_XYZ.js
@@ -1,0 +1,35 @@
+import { AddObjectCommand } from '../../commands/AddObjectCommand.js';
+import { readAsText } from '../FileUtils.js';
+import { FileHandler } from './FileHandler.js';
+import * as THREE from 'three';
+
+class FileHandler_XYZ extends FileHandler {
+
+	constructor( editor, manager ) {
+
+		super( editor, manager );
+
+	}
+
+	async import( file ) {
+
+		const loader = await this.instantiate( 'three/addons/loaders/XYZLoader.js' );
+
+		const contents = await readAsText( file );
+
+		const geometry = loader.parse( contents );
+
+		const material = new THREE.PointsMaterial();
+		material.vertexColors = geometry.hasAttribute( 'color' );
+
+		const points = new THREE.Points( geometry, material );
+		points.name = file.name;
+
+
+		this.editor.execute( new AddObjectCommand( this.editor, points ) );
+
+	}
+
+}
+
+export { FileHandler_XYZ };

--- a/editor/js/file/handlers/FileHandler_ZIP.js
+++ b/editor/js/file/handlers/FileHandler_ZIP.js
@@ -1,0 +1,51 @@
+import { AddObjectCommand } from '../../commands/AddObjectCommand.js';
+import { FileHandler } from './FileHandler.js';
+import { unzipSync, strFromU8 } from 'three/addons/libs/fflate.module.js';
+import { FileManager } from '../FileManager.js';
+import { FileImporter } from '../FileImporter.js';
+import { readAsArrayBuffer } from '../FileUtils.js';
+
+class FileHandler_ZIP extends FileHandler {
+
+	constructor( editor, manager ) {
+
+		super( editor, manager );
+
+	}
+
+	async import( file ) {
+
+		const contents = await readAsArrayBuffer( file );
+
+		const zip = unzipSync( new Uint8Array( contents ) );
+
+		const files = Object.entries( zip ).map( ( [ pathname, u8a ] ) => new File( [ u8a ], pathname ) );
+
+		const manager = new FileManager( files );
+
+		// Poly
+
+		if ( zip[ 'model.obj' ] && zip[ 'materials.mtl' ] ) {
+
+			const { MTLLoader } = await import( 'three/addons/loaders/MTLLoader.js' );
+			const { OBJLoader } = await import( 'three/addons/loaders/OBJLoader.js' );
+
+			const materials = new MTLLoader( manager ).parse( strFromU8( zip[ 'materials.mtl' ] ) );
+			const object = new OBJLoader().setMaterials( materials ).parse( strFromU8( zip[ 'model.obj' ] ) );
+
+			this.editor.execute( new AddObjectCommand( this.editor, object ) );
+			return;
+
+		}
+
+		//
+
+		const importer = new FileImporter( this.editor );
+
+		await importer.import( files, manager );
+
+	}
+
+}
+
+export { FileHandler_ZIP };

--- a/editor/js/file/handlers/FileHandlers.js
+++ b/editor/js/file/handlers/FileHandlers.js
@@ -1,0 +1,76 @@
+import { getFileExt } from '../FileUtils.js';
+import { FileHandler_3DM } from './FileHandler_3DM.js';
+import { FileHandler_3DS } from './FileHandler_3DS.js';
+import { FileHandler_3MF } from './FileHandler_3MF.js';
+import { FileHandler_AMF } from './FileHandler_AMF.js';
+import { FileHandler_COLLADA } from './FileHandler_COLLADA.js';
+import { FileHandler_DRACO } from './FileHandler_DRACO.js';
+import { FileHandler_FBX } from './FileHandler_FBX.js';
+import { FileHandler_GLB } from './FileHandler_GLB.js';
+import { FileHandler_GLTF } from './FileHandler_GLTF.js';
+import { FileHandler_JS } from './FileHandler_JS.js';
+import { FileHandler_KMZ } from './FileHandler_KMZ.js';
+import { FileHandler_LDRAW } from './FileHandler_LDRAW.js';
+import { FileHandler_MD2 } from './FileHandler_MD2.js';
+import { FileHandler_OBJ } from './FileHandler_OBJ.js';
+import { FileHandler_PCD } from './FileHandler_PCD.js';
+import { FileHandler_PLY } from './FileHandler_PLY.js';
+import { FileHandler_STL } from './FileHandler_STL.js';
+import { FileHandler_SVG } from './FileHandler_SVG.js';
+import { FileHandler_USDZ } from './FileHandler_USDZ.js';
+import { FileHandler_VOX } from './FileHandler_VOX.js';
+import { FileHandler_VTK } from './FileHandler_VTK.js';
+import { FileHandler_VRML } from './FileHandler_VRML.js';
+import { FileHandler_XYZ } from './FileHandler_XYZ.js';
+import { FileHandler_ZIP } from './FileHandler_ZIP.js';
+
+
+class FileHandlers {
+
+	static getImportHandler( file, editor, manager ) {
+
+		const Handler = FileHandlers.ImportableHandlers[ getFileExt( file ) ];
+
+		return new Handler( editor, manager );
+
+	}
+
+	static get ImportableHandlers() {
+
+		return {
+
+			'.3dm': FileHandler_3DM,
+			'.3ds': FileHandler_3DS,
+			'.3mf': FileHandler_3MF,
+			'.amf': FileHandler_AMF,
+			'.dae': FileHandler_COLLADA,
+			'.drc': FileHandler_DRACO,
+			'.fbx': FileHandler_FBX,
+			'.glb': FileHandler_GLB,
+			'.gltf': FileHandler_GLTF,
+			'.js': FileHandler_JS,
+			'.json': FileHandler_JS,
+			'.kmz': FileHandler_KMZ,
+			'.ldr': FileHandler_LDRAW,
+			'.mpd': FileHandler_LDRAW,
+			'.md2': FileHandler_MD2,
+			'.obj': FileHandler_OBJ,
+			'.pcd': FileHandler_PCD,
+			'.ply': FileHandler_PLY,
+			'.stl': FileHandler_STL,
+			'.svg': FileHandler_SVG,
+			'.usdz': FileHandler_USDZ,
+			'.vox': FileHandler_VOX,
+			'.vtk': FileHandler_VTK,
+			'.vtp': FileHandler_VTK,
+			'.wrl': FileHandler_VRML,
+			'.xyz': FileHandler_XYZ,
+			'.zip': FileHandler_ZIP
+
+		};
+
+	}
+
+}
+
+export { FileHandlers };


### PR DESCRIPTION
## About this PR

In order to make file-importing **maintainable and readable**, I created `FileImporter`, and bunch of file handler classes(in [file/handlers/](https://github.com/ycw/three.js/tree/editor-new-import-export-system/editor/js/file/handlers)) instead of using single giant file `Loader`

## The end goals

- Flattens the import flow in each file handler; easier to track async bugs:

```js
async import( file ) {

	const loader = await this.instantiate( 'three/addons/loaders/ColladaLoader.js' );

	const contents = await readAsText( file );

	const object = loader.parse( contents );

	object.scene.name = file.name;

	this.editor.execute( new AddObjectCommand( this.editor, object.scene ) );

}
```

- Easier to trap parsing error in each file handler for better UI Feedback, help distinguish from unsupported file format error: (not included in this PR)

```js
async import( file ) {

	const loader = await this.instantiate( 'three/addons/loaders/ColladaLoader.js' );

	const contents = await readAsText( file );
// try
	const object = loader.parse( contents );
// catch
	object.scene.name = file.name;

	this.editor.execute( new AddObjectCommand( this.editor, object.scene ) );

}
```

- Easier to extend, say for 'export' in some file formats: (not included in this PR):

```js
class FileHandler_OBJ extends FileHandler {
  async import( file ) { .. } 
  async export( object ) { .. }  // <<<
} 
```

- File-related utils all goes to single place FileUtils, easier to maintain: 
  - [FileUtils.formatFileSize](https://github.com/ycw/three.js/blob/48d4fdeba6815a3f1ff86d018a6a7554e99a378a/editor/js/file/FileUtils.js#L21) instead of [editor.utils.formatNumber](https://github.com/ycw/three.js/blob/48d4fdeba6815a3f1ff86d018a6a7554e99a378a/editor/js/Editor.js#L767)
  - FileUtils.getFileExt instead of implementing it sparsely in Loader
  - FileUtils.readAsText a wrapper of reader, returning promise, help flattens the import flow(see above code snippet)
  - ...

- Adds introspection of supported file extensions, i.e. no hardcoded list, easier to maintain:
  - FileImporter.getAcceptedFileExt ...  e.g. generate hint in UI Feedback when users inputted unsupported file formats

- Adds FileManager, an abstraction of files cache, can normalize all file-import paths by building an artificial FileManager from `FileList`(File>Import), `DataTransferItemList`(Drag n Drop), or `unzipped File[]`(when user inputted a ZIP via File>Import or DnD), easier to maintain.

- Each file handle in standalone class, easier to read and maintain, in particular when searching symbols, fewer irrelevant matches.


----

## QA

<details>
  <summary> Why introduce new class instead of improving Loader </summary>

The name 'FileImoprter' is chosen because it has better semantic, i.e. files will be imported to the scene, instead of 'Loader' which only loads file into memory and not add to the scene. 

</details>

<details>
  <summary> Why file handler in (file/handlers) has FileHandler_XXX name pattern </summary>

Because some file extensions start with a number, for example `.3ds`, so instead of aliasing like `ThreeDSFileHandler`, simply putting the ext name at the tail, `FileHandler_3DS`.
 
</details>

<details>
   <summary> Why only one `import()` method in FileImporter </summary>

In Loader, there're 3 methods, one for loading single file, one for loading multiple files, one for loading DataTransferItemList.
However, there's no use cases of loading single file: file input `.files` is `FileList`, drag n drop yields DataTransferItemList, so FileImporter has only one import method `import( files )` which covers `File[], FileList, and DataTransferItemList`.  

</details>

<details>
  <summary> Why file handler is a class not a function </summary>

- More intuitive comparing to [function interface](https://github.com/ycw/three.js/blob/48d4fdeba6815a3f1ff86d018a6a7554e99a378a/editor/js/Loader.js#L85), as you can see using functions required passing many arguments, some is just stub values in order to satisfy the fn interface. In contrast, FileImporter will delegate file-import to specific handler, e.g. call `FileHandler_GLTF.import(file)` to handle a gltf file, i.e. just the `file` is passing around, no stub values.

- Easier to extend for the future, for example, file handler `FileHandler_GLTF` may implements `export(object)`, and then FileExporter delegates file-export of gltf to it.
 
</details>

<details>
  <summary> Whats the value of .instantiate() in FileHandler (base class) </summary>

`.instantiate()` is simple and is 'great to have' because:
1. It simplified the two-step `import Loader + new Loader`.
1. It ensures that **the FileHandler's FileManager must be propagated to the loader**


`.instantiate()` plus other FileUtils creates a flat import() flow, it helps debugging, in future PR, try/catch is made to trap parsing error and showing proper UI feedback:

```
async import( file ) {

	const loader = await this.instantiate( 'three/addons/loaders/ColladaLoader.js' );

	const contents = await readAsText( file );
//try
	const object = loader.parse( contents );
//catch
	object.scene.name = file.name;

	this.editor.execute( new AddObjectCommand( this.editor, object.scene ) );

}
```

</details>

<details>
  <summary> What is FileManager </summary>

[FileManager](https://github.com/ycw/three.js/blob/editor-new-import-export-system/editor/js/file/FileManager.js) is just a LoadingManager, it abstracted "files cache", When calling `FileImporter.import( files )`, a FileManager can be provided in the 2nd parameter, in this case, FileImporter will try 'loading files from the "file cache"' before trying `fetch` files from the internet.

This mechanics normalized different ways of file-import, via creates a artificial FileManager for loaded files, while these files may come from file input, drag n drop, or even extracted from a ZIP: 

- File input (menubar.file.js) -> `editor.fileImporter.import( files )` ([changes included in this PR](https://github.com/ycw/three.js/blob/48d4fdeba6815a3f1ff86d018a6a7554e99a378a/editor/js/Menubar.File.js#L118))
- Drag n drop (index.html) -> `editor.fileImporter.import( files )` ([changes included in this PR](https://github.com/ycw/three.js/blob/48d4fdeba6815a3f1ff86d018a6a7554e99a378a/editor/index.html#L194-L199))
- UnZIP (FileHandler_ZIP.js) -> `fileImporter().import( files )` ([changes included in this PR](https://github.com/ycw/three.js/blob/48d4fdeba6815a3f1ff86d018a6a7554e99a378a/editor/js/file/handlers/FileHandler_ZIP.js#L43-L45))

i.e. With FileManager, users can import a ZIP of any supported file formats, as long as the corresponding loaders honors `loadingManager`.  

</details>

<details>
  <summary> Alternatives of Loader.getSupportedFileFormat </summary>

Accepted file format is now `FileImporter.getAcceptedFileExts()`, extension includes dot e.g. '.md2' not 'md2', so Menubar.file.js needs a subtle change ([included in this PR](https://github.com/ycw/three.js/blob/48d4fdeba6815a3f1ff86d018a6a7554e99a378a/editor/js/Menubar.File.js#L115)) 

</details>

<details>

   <summary> Details </summary>

## LoaderUtils

(fn) `createFilesMap`: no needed, implemented in FileManager

(fn) `getFilesFromItemList`: moved to FileUtils (now returns Promise)


## Loader.js

(utils) `handleJSON`: moved to FileHandler_JS

(utils) `handleZIP`: no needed, rewrote in FileHandler_ZIP

(utils) `createGLTFLoader`: moved to FileHandler_GLTF

(static) `getSupportedFileFormats`: no needed, uses `FileImporter.getAcceptedFileExts()` instead

(method) `loadItemList`: no needed, uses `new FileImporter().import()` instead (covered `DataTransferItemList`)

(method) `loadFiles`: no needed, uses `new FileImporter().import( files )` instead

(method) `loadFile`: no needed, uses `new FileImporter().import( [ file ] )` instead




## FileImporter and FileManager

file/FileManager

- is-a LoadingManager; act as files cache store, an abstraction of

  - files selected via file input
  - files via drag n drop
  - files extracted from ZIP

file/FileImporter

- `import(..)`: imports files to editor (delegates to specific handler)

- `canImport(..)`: check if any handler can handle the file

- `getAcceptedFileExts()`: arr of accepted file exts, ext incl dot, e.g '.md2'


## FileHandler, FileHandler_XXX and FileHandlers

file/handlers/FileHandler:

- base class; with a handy `instantiate()` simplified `import + new`

file/handlers/FileHandler_XXX:

- derived classes; implements `import(file)` returning promise.

file/handlers/FileHandlers:

- index class; with a handy `getImportHandler(..)` to get proper handler for given file


</details>

<details>
  <summary> Previews </summary>

Preview: https://raw.githack.com/ycw/three.js/editor-new-import-export-system/editor/index.html

Code: https://github.com/ycw/three.js/tree/editor-new-import-export-system/editor/js/file

</details>

https://github.com/mrdoob/three.js/pull/28324#issuecomment-2103104534 Solved. 



