### PR TITLE
WebGPURenderer: Move the `textures.updateRenderTarget` logic to `Renderer.setRenderTarget`

### DIFF
--- a/examples/jsm/renderers/common/Renderer.js
+++ b/examples/jsm/renderers/common/Renderer.js
@@ -948,7 +948,23 @@ class Renderer {
 
 	}
 
+	async setRenderTargetAsync( renderTarget, activeCubeFace = 0, activeMipmapLevel = 0 ) {
+
+		if ( this._initialized === false ) await this.init();
+
+		this.setRenderTarget( renderTarget, activeCubeFace, activeMipmapLevel );
+
+	}
+
 	setRenderTarget( renderTarget, activeCubeFace = 0, activeMipmapLevel = 0 ) {
+
+		if ( this._initialized === false ) {
+
+			console.warn( 'THREE.Renderer: .setRenderTarget() called before the backend is initialized. Try using .setRenderTargetAsync() instead.' );
+
+			return this.setRenderTargetAsync( renderTarget, activeCubeFace, activeMipmapLevel );
+
+		}
 
 		this._renderTarget = renderTarget;
 		this._activeCubeFace = activeCubeFace;

--- a/examples/jsm/renderers/common/Renderer.js
+++ b/examples/jsm/renderers/common/Renderer.js
@@ -212,7 +212,6 @@ class Renderer {
 
 		const renderTarget = this._renderTarget;
 		const renderContext = this._renderContexts.get( targetScene, camera, renderTarget );
-		const activeMipmapLevel = this._activeMipmapLevel;
 
 		const compilationPromises = [];
 
@@ -268,8 +267,6 @@ class Renderer {
 		//
 
 		if ( renderTarget !== null ) {
-
-			this._textures.updateRenderTarget( renderTarget, activeMipmapLevel );
 
 			const renderTargetData = this._textures.get( renderTarget );
 
@@ -519,7 +516,6 @@ class Renderer {
 
 		if ( renderTarget !== null ) {
 
-			this._textures.updateRenderTarget( renderTarget, activeMipmapLevel );
 
 			const renderTargetData = this._textures.get( renderTarget );
 
@@ -957,6 +953,12 @@ class Renderer {
 		this._renderTarget = renderTarget;
 		this._activeCubeFace = activeCubeFace;
 		this._activeMipmapLevel = activeMipmapLevel;
+
+		if ( renderTarget !== null ) {
+
+			this._textures.updateRenderTarget( renderTarget, activeMipmapLevel );
+
+		}
 
 	}
 

--- a/examples/jsm/renderers/webgpu/utils/WebGPUBindingUtils.js
+++ b/examples/jsm/renderers/webgpu/utils/WebGPUBindingUtils.js
@@ -206,7 +206,7 @@ class WebGPUBindingUtils {
 
 			} else if ( binding.isSampledTexture ) {
 
-				const textureData = backend.get( binding.texture );
+				let textureData = backend.get( binding.texture );
 
 				let dimensionViewGPU;
 
@@ -231,6 +231,26 @@ class WebGPUBindingUtils {
 					resourceGPU = device.importExternalTexture( { source: textureData.externalTexture } );
 
 				} else {
+
+					if ( textureData.texture === undefined ) {
+
+						const currentRenderTarget = backend.renderer.getRenderTarget();
+
+						if ( binding.texture.isRenderTargetTexture && currentRenderTarget !== null ) {
+
+							backend.renderer._textures.updateRenderTarget( currentRenderTarget, backend.renderer._activeMipmapLevel );
+
+							textureData = backend.get( binding.texture );
+
+						} else {
+
+							backend.createTexture( binding.texture );
+
+							textureData = backend.get( binding.texture );
+
+						}
+
+					}
 
 					const aspectGPU = GPUTextureAspect.All;
 

--- a/examples/jsm/renderers/webgpu/utils/WebGPUBindingUtils.js
+++ b/examples/jsm/renderers/webgpu/utils/WebGPUBindingUtils.js
@@ -95,6 +95,15 @@ class WebGPUBindingUtils {
 
 				}
 
+				const textureData = backend.get( binding.texture );
+
+				if ( textureData.externalTexture === undefined && textureData.texture === undefined ) {
+
+					console.error( 'WebGPUBindingUtils.createBindingsLayout: Texture bound is undefined', binding );
+					continue;
+
+				}
+
 				if ( binding.isSampledCubeTexture ) {
 
 					texture.viewDimension = GPUTextureViewDimension.Cube;
@@ -210,6 +219,13 @@ class WebGPUBindingUtils {
 
 				let dimensionViewGPU;
 
+				if ( textureData.externalTexture === undefined && textureData.texture === undefined ) {
+
+					console.error( 'WebGPUBindingUtils.createBindGroup: Texture bound is undefined', binding );
+					continue;
+
+				}
+
 				if ( binding.isSampledCubeTexture ) {
 
 					dimensionViewGPU = GPUTextureViewDimension.Cube;
@@ -232,7 +248,7 @@ class WebGPUBindingUtils {
 
 					entriesGPU.push( { binding: bindingPoint, resource: resourceGPU } );
 
-				} else if ( textureData.texture !== undefined ) {
+				} else {
 
 					const aspectGPU = GPUTextureAspect.All;
 
@@ -240,12 +256,7 @@ class WebGPUBindingUtils {
 
 					entriesGPU.push( { binding: bindingPoint, resource: resourceGPU } );
 
-				} else {
-
-					console.error( 'WebGPUBindingUtils: Texture bound is undefined', binding );
-
 				}
-
 
 			}
 

--- a/examples/jsm/renderers/webgpu/utils/WebGPUBindingUtils.js
+++ b/examples/jsm/renderers/webgpu/utils/WebGPUBindingUtils.js
@@ -234,21 +234,11 @@ class WebGPUBindingUtils {
 
 					if ( textureData.texture === undefined ) {
 
-						const currentRenderTarget = backend.renderer.getRenderTarget();
+						backend.createTexture( binding.texture );
 
-						if ( binding.texture.isRenderTargetTexture && currentRenderTarget !== null ) {
+						textureData = backend.get( binding.texture );
 
-							backend.renderer._textures.updateRenderTarget( currentRenderTarget, backend.renderer._activeMipmapLevel );
-
-							textureData = backend.get( binding.texture );
-
-						} else {
-
-							backend.createTexture( binding.texture );
-
-							textureData = backend.get( binding.texture );
-
-						}
+						console.warn( 'WebGPUBindingUtils: Texture is not initialized.', binding.texture );
 
 					}
 

--- a/examples/jsm/renderers/webgpu/utils/WebGPUBindingUtils.js
+++ b/examples/jsm/renderers/webgpu/utils/WebGPUBindingUtils.js
@@ -246,17 +246,16 @@ class WebGPUBindingUtils {
 
 					resourceGPU = device.importExternalTexture( { source: textureData.externalTexture } );
 
-					entriesGPU.push( { binding: bindingPoint, resource: resourceGPU } );
-
 				} else {
 
 					const aspectGPU = GPUTextureAspect.All;
 
 					resourceGPU = textureData.texture.createView( { aspect: aspectGPU, dimension: dimensionViewGPU, mipLevelCount: binding.store ? 1 : textureData.mipLevelCount } );
 
-					entriesGPU.push( { binding: bindingPoint, resource: resourceGPU } );
-
 				}
+
+				entriesGPU.push( { binding: bindingPoint, resource: resourceGPU } );
+
 
 			}
 

--- a/examples/jsm/renderers/webgpu/utils/WebGPUBindingUtils.js
+++ b/examples/jsm/renderers/webgpu/utils/WebGPUBindingUtils.js
@@ -206,7 +206,7 @@ class WebGPUBindingUtils {
 
 			} else if ( binding.isSampledTexture ) {
 
-				let textureData = backend.get( binding.texture );
+				const textureData = backend.get( binding.texture );
 
 				let dimensionViewGPU;
 
@@ -230,25 +230,22 @@ class WebGPUBindingUtils {
 
 					resourceGPU = device.importExternalTexture( { source: textureData.externalTexture } );
 
-				} else {
+					entriesGPU.push( { binding: bindingPoint, resource: resourceGPU } );
 
-					if ( textureData.texture === undefined ) {
-
-						backend.createTexture( binding.texture );
-
-						textureData = backend.get( binding.texture );
-
-						console.warn( 'WebGPUBindingUtils: Texture is not initialized.', binding.texture );
-
-					}
+				} else if ( textureData.texture !== undefined ) {
 
 					const aspectGPU = GPUTextureAspect.All;
 
 					resourceGPU = textureData.texture.createView( { aspect: aspectGPU, dimension: dimensionViewGPU, mipLevelCount: binding.store ? 1 : textureData.mipLevelCount } );
 
+					entriesGPU.push( { binding: bindingPoint, resource: resourceGPU } );
+
+				} else {
+
+					console.error( 'WebGPUBindingUtils: Texture bound is undefined', binding );
+
 				}
 
-				entriesGPU.push( { binding: bindingPoint, resource: resourceGPU } );
 
 			}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/28289 https://github.com/mrdoob/three.js/pull/28372

**Description**

This PR moves the logic of updating the textures bound to a renderTarget into the `setRenderTarget` method:
```js
setRenderTarget( renderTarget, activeCubeFace = 0, activeMipmapLevel = 0 ) {
    
    this._renderTarget = renderTarget;
    this._activeCubeFace = activeCubeFace;
    this._activeMipmapLevel = activeMipmapLevel;
    
    if ( renderTarget !== null ) {
    
	    this._textures.updateRenderTarget( renderTarget, activeMipmapLevel );
    
    }

}
```

At my company, we are currently working on a complex WebGPU project since months and have a deeply nested postprocessing setup. Occasionally, when the FPS drops or the CPU/GPU are under heavy load, when resizing the window a rare error occurs when trying to access the texture bound to the RTT in WebGPUBindingUtils, notably using RTT inside an `node.updateBefore` call:
```js
//  textureData.texture is not defined since textureData = {} as it was never initialized by the `Textures` class.
resourceGPU = textureData.texture.createView( { aspect: aspectGPU, dimension: dimensionViewGPU, mipLevelCount: binding.store ? 1 : textureData.mipLevelCount } );`
```

This PR is the 3rd attempt of trying to fix this issue as I'm now pretty sure it is an issue inside the core of the `WebGPURenderer` pipeline.
I believe relocating this logic to the `setRenderTarget` method of the `Renderer` pipeline make more sense as it is where we want to bind and allocate the proper ressources associated to a `RenderTarget`, additionally, this change appears to resolve my issue.


*This contribution is funded by [Utsubo](https://utsubo.com)*
