### PR TITLE
Editor: Remove `accept` field in file importer.

### DIFF
--- a/editor/js/Menubar.File.js
+++ b/editor/js/Menubar.File.js
@@ -192,7 +192,6 @@ function MenubarFile( editor ) {
 	const fileInput = document.createElement( 'input' );
 	fileInput.multiple = true;
 	fileInput.type = 'file';
-	fileInput.accept = Loader.getSupportedFileFormats().map( format => '.' + format ).join( ', ' );
 	fileInput.addEventListener( 'change', function () {
 
 		editor.loader.loadFiles( fileInput.files );


### PR DESCRIPTION
Fixed #28394.

**Description**

This PR reverts the `accept` usage in the file importer component since it was possible anymore to select assets with resource files. E.g. .gltf + .bin + textures.