### PR TITLE
Editor: Creates stub command during restore

### DIFF
--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -671,10 +671,11 @@ Editor.prototype = {
 
 		this.signals.cameraResetted.dispatch();
 
-		this.history.fromJSON( json.history );
 		this.scripts = json.scripts;
 
 		this.setScene( await loader.parseAsync( json.scene ) );
+
+		this.history.fromJSON( json.history );
 
 		if ( json.environment === 'ModelViewer' ) {
 

--- a/editor/js/History.js
+++ b/editor/js/History.js
@@ -198,13 +198,24 @@ class History {
 
 		if ( json === undefined ) return;
 
+		function createCommand( editor, json ) {
+
+			const cmd = Object.create( Commands[ json.type ].prototype );
+			cmd.editor = editor;
+			cmd.type = json.type;
+			cmd.fromJSON( json );
+			cmd.json = json;
+			cmd.id = json.id;
+			cmd.name = json.name;
+
+			return cmd;
+
+		}
+
 		for ( let i = 0; i < json.undos.length; i ++ ) {
 
 			const cmdJSON = json.undos[ i ];
-			const cmd = new Commands[ cmdJSON.type ]( this.editor ); // creates a new object of type "json.type"
-			cmd.json = cmdJSON;
-			cmd.id = cmdJSON.id;
-			cmd.name = cmdJSON.name;
+			const cmd = createCommand( this.editor, cmdJSON );
 			this.undos.push( cmd );
 			this.idCounter = ( cmdJSON.id > this.idCounter ) ? cmdJSON.id : this.idCounter; // set last used idCounter
 
@@ -213,10 +224,7 @@ class History {
 		for ( let i = 0; i < json.redos.length; i ++ ) {
 
 			const cmdJSON = json.redos[ i ];
-			const cmd = new Commands[ cmdJSON.type ]( this.editor ); // creates a new object of type "json.type"
-			cmd.json = cmdJSON;
-			cmd.id = cmdJSON.id;
-			cmd.name = cmdJSON.name;
+			const cmd = createCommand( this.editor, cmdJSON );
 			this.redos.push( cmd );
 			this.idCounter = ( cmdJSON.id > this.idCounter ) ? cmdJSON.id : this.idCounter; // set last used idCounter
 


### PR DESCRIPTION
Related: #28345 ( issue 1 )

This PR solved issue 1 in #28345, by creating a stub command when commands get restored from json, in this way we bypassed the constructor. This approach is enlightened by https://github.com/mrdoob/three.js/pull/28360#issuecomment-2114874992 :D 

can close #28360