### PR TITLE
BatchedMesh: fix radix sort stability

### DIFF
--- a/examples/webgl_mesh_batch.html
+++ b/examples/webgl_mesh_batch.html
@@ -282,7 +282,7 @@
 
 		//
 
-		function sortFunction( list, camera ) {
+		function sortFunction( list ) {
 
 			// initialize options
 			this._options = this._options || {

--- a/examples/webgl_mesh_batch.html
+++ b/examples/webgl_mesh_batch.html
@@ -293,10 +293,22 @@
 			const options = this._options;
 			options.reversed = this.material.transparent;
 
-			// convert depth to unsigned 32 bit range
-			const factor = ( 2 ** 32 - 1 ) / camera.far; // UINT32_MAX / max_depth
+			let minZ = Infinity;
+			let maxZ = - Infinity;
 			for ( let i = 0, l = list.length; i < l; i ++ ) {
 
+				const z = list[ i ].z;
+				if ( z > maxZ ) maxZ = z;
+				if ( z < minZ ) minZ = z;
+
+			}
+
+			// convert depth to unsigned 32 bit range
+			const depthDelta = maxZ - minZ;
+			const factor = ( 2 ** 32 - 1 ) / depthDelta; // UINT32_MAX / z range
+			for ( let i = 0, l = list.length; i < l; i ++ ) {
+
+				list[ i ].z -= minZ;
 				list[ i ].z *= factor;
 
 			}

--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -76,6 +76,8 @@ const _frustum = /*@__PURE__*/ new Frustum();
 const _box = /*@__PURE__*/ new Box3();
 const _sphere = /*@__PURE__*/ new Sphere();
 const _vector = /*@__PURE__*/ new Vector3();
+const _forward = /*@__PURE__*/ new Vector3();
+const _temp = /*@__PURE__*/ new Vector3();
 const _renderList = /*@__PURE__*/ new MultiDrawRenderList();
 const _mesh = /*@__PURE__*/ new Mesh();
 const _batchIntersects = [];
@@ -942,6 +944,7 @@ class BatchedMesh extends Mesh {
 			// get the camera position in the local frame
 			_invMatrixWorld.copy( this.matrixWorld ).invert();
 			_vector.setFromMatrixPosition( camera.matrixWorld ).applyMatrix4( _invMatrixWorld );
+			_forward.set( 0, 0, - 1 ).transformDirection( camera.matrixWorld ).transformDirection( _invMatrixWorld );
 
 			for ( let i = 0, l = visibility.length; i < l; i ++ ) {
 
@@ -962,7 +965,7 @@ class BatchedMesh extends Mesh {
 					if ( ! culled ) {
 
 						// get the distance from camera used for sorting
-						const z = _vector.distanceTo( _sphere.center );
+						const z = _temp.subVectors( _sphere.center, _vector ).dot( _forward );
 						_renderList.push( drawRanges[ i ], z );
 
 					}


### PR DESCRIPTION
Related issue: #27213 

**Description**

I noticed that the batched mesh demo was flickering when using the radix sort from #27213. This was caused by the "z" values (used to sort) in the render list being negative or greater than camera.far at times, causing over / underflowing the Uint32 values used for radix.

This PR adjusts the z values to be the z distance along the camera forward vector (instead of just the distance between them). And the min and max values are calculated and used to map the values to the Uint32 range for sorting. The changes in the example add ~0.2-0.25 ms to the custom sort function (from ~0.8ms to ~1.0ms) when rendering 20,000 elements. The function could be sped up by using the boundingSphere if it exists to compute the relevant range to map but I'll leave that for another PR.

Here's an example of the flickering. You need to zoom the camera out a bit so the object is clipped by the camera far plane to see it:
 
https://github.com/mrdoob/three.js/assets/734200/bbf71c8a-a940-4530-bb8b-43bd80fa8b24

cc @sciecode 