### PR TITLE
WebGPURenderer: Revert "Fix SampledTexture not correctly bound (#28289)"

### DIFF
--- a/examples/jsm/renderers/common/Bindings.js
+++ b/examples/jsm/renderers/common/Bindings.js
@@ -144,7 +144,7 @@ class Bindings extends DataMap {
 
 				const isTextureGPUNotAvailable = textureData.texture === undefined && textureData.externalTexture === undefined;
 
-				if ( isTextureGPUNotAvailable ) {
+				if ( backend.isWebGPUBackend && isTextureGPUNotAvailable ) {
 
 					// TODO: Remove this once we found why updated === false doesn't generate a texture in the WebGPU backend
 					console.error( 'Bindings._update: binding should be available:', binding, updated, binding.texture, binding.textureNode.value );

--- a/examples/jsm/renderers/common/Bindings.js
+++ b/examples/jsm/renderers/common/Bindings.js
@@ -128,17 +128,32 @@ class Bindings extends DataMap {
 
 			} else if ( binding.isSampledTexture ) {
 
+				const texture = binding.texture;
+
+				if ( binding.needsBindingsUpdate ) needsBindingsUpdate = true;
+
 				const updated = binding.update();
 
 				if ( updated ) {
 
 					this.textures.updateTexture( binding.texture );
 
+				}
+
+				const textureData = backend.get( binding.texture );
+
+				const isTextureGPUNotAvailable = textureData.texture === undefined && textureData.externalTexture === undefined;
+
+				if ( isTextureGPUNotAvailable ) {
+
+					// TODO: Remove this once we found why updated === false doesn't generate a texture in the WebGPU backend
+					console.error( 'Bindings._update: binding should be available:', binding, updated, binding.texture, binding.textureNode.value );
+
+					this.textures.updateTexture( binding.texture );
 					needsBindingsUpdate = true;
 
 				}
 
-				const texture = binding.texture;
 
 				if ( texture.isStorageTexture === true ) {
 

--- a/examples/jsm/renderers/common/Bindings.js
+++ b/examples/jsm/renderers/common/Bindings.js
@@ -142,11 +142,9 @@ class Bindings extends DataMap {
 
 				const textureData = backend.get( binding.texture );
 
-				const isTextureGPUNotAvailable = textureData.texture === undefined && textureData.externalTexture === undefined;
+				if ( backend.isWebGPUBackend === true && textureData.texture === undefined && textureData.externalTexture === undefined ) {
 
-				if ( backend.isWebGPUBackend && isTextureGPUNotAvailable ) {
-
-					// TODO: Remove this once we found why updated === false doesn't generate a texture in the WebGPU backend
+					// TODO: Remove this once we found why updated === false isn't bound to a texture in the WebGPU backend
 					console.error( 'Bindings._update: binding should be available:', binding, updated, binding.texture, binding.textureNode.value );
 
 					this.textures.updateTexture( binding.texture );

--- a/examples/jsm/renderers/common/SampledTexture.js
+++ b/examples/jsm/renderers/common/SampledTexture.js
@@ -18,6 +18,14 @@ class SampledTexture extends Binding {
 
 	}
 
+	get needsBindingsUpdate() {
+
+		const { texture, version } = this;
+
+		return texture.isVideoTexture ? true : version !== texture.version; // @TODO: version === 0 && texture.version > 0 ( add it just to External Textures like PNG,JPG )
+
+	}
+
 	update() {
 
 		const { texture, version } = this;

--- a/examples/jsm/renderers/common/nodes/NodeSampledTexture.js
+++ b/examples/jsm/renderers/common/nodes/NodeSampledTexture.js
@@ -10,6 +10,12 @@ class NodeSampledTexture extends SampledTexture {
 
 	}
 
+	get needsBindingsUpdate() {
+
+		return this.textureNode.value !== this.texture || super.needsBindingsUpdate;
+
+	}
+
 	update() {
 
 		const { textureNode } = this;


### PR DESCRIPTION
Related issue: #28289

**Description**

This PR reverts #28289, which, after further investigation, appears to have been an incorrect fix. In addition to reverting the changes, this PR adds a patch to prevent the initial error and assist in debugging the original issue as mentioned in this comment: https://github.com/mrdoob/three.js/pull/28392#issuecomment-2116849253. /cc @sunag

Good news, the original issue is 100% reproductible without the `backend.isWebGPUBackend === true` condition  in the patch in the `webgpu_loader_gltf_transmission` example in Safari in the WebGLBackend (not Chrome).

*This contribution is funded by [Utsubo](https://utsubo.com)*
