### PR TITLE
CI: Remove merge command.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,16 +96,6 @@ jobs:
           path: test/e2e/output-screenshots
           if-no-files-found: ignore
 
-  merge:
-    runs-on: ${{ matrix.os }}
-    needs: [ e2e ]
-    steps:
-      - name: Merge Artifacts
-        uses: actions/upload-artifact/merge@65462800fd760344b1a7b4382951275a0abb4808 # v4
-        with:
-          name: artifacts
-          pattern: Output screenshots-*
-
   e2e-cov:
     name: Examples ready for release
     runs-on: ubuntu-latest


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/28401#issuecomment-2116630533

**Description**

It seems the CI is reported as failed because of the merge command. Trying to remove it to see if it solves the issue.