### PR TITLE
Editor: Fix persistent history.

### DIFF
--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -671,10 +671,11 @@ Editor.prototype = {
 
 		this.signals.cameraResetted.dispatch();
 
-		this.history.fromJSON( json.history );
 		this.scripts = json.scripts;
 
 		this.setScene( await loader.parseAsync( json.scene ) );
+
+		this.history.fromJSON( json.history );
 
 		if ( json.environment === 'ModelViewer' ) {
 

--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -671,11 +671,10 @@ Editor.prototype = {
 
 		this.signals.cameraResetted.dispatch();
 
+		this.history.fromJSON( json.history );
 		this.scripts = json.scripts;
 
 		this.setScene( await loader.parseAsync( json.scene ) );
-
-		this.history.fromJSON( json.history );
 
 		if ( json.environment === 'ModelViewer' ) {
 

--- a/editor/js/Sidebar.Scene.js
+++ b/editor/js/Sidebar.Scene.js
@@ -522,13 +522,13 @@ function SidebarScene( editor ) {
 
 	signals.scriptAdded.add( function () {
 
-		signals.objectChanged.dispatch( editor.selected );
+		if ( editor.selected !== null ) signals.objectChanged.dispatch( editor.selected );
 
 	} );
 
 	signals.scriptRemoved.add( function () {
 
-		signals.objectChanged.dispatch( editor.selected );
+		if ( editor.selected !== null ) signals.objectChanged.dispatch( editor.selected );
 
 	} );
 

--- a/editor/js/commands/AddObjectCommand.js
+++ b/editor/js/commands/AddObjectCommand.js
@@ -8,14 +8,15 @@ import { ObjectLoader } from 'three';
  */
 class AddObjectCommand extends Command {
 
-	constructor( editor, object ) {
+	constructor( editor, object = null ) {
 
 		super( editor );
 
 		this.type = 'AddObjectCommand';
 
 		this.object = object;
-		if ( object !== undefined ) {
+
+		if ( object !== null ) {
 
 			this.name = editor.strings.getKey( 'command/AddObject' ) + ': ' + object.name;
 

--- a/editor/js/commands/AddScriptCommand.js
+++ b/editor/js/commands/AddScriptCommand.js
@@ -8,7 +8,7 @@ import { Command } from '../Command.js';
  */
 class AddScriptCommand extends Command {
 
-	constructor( editor, object, script ) {
+	constructor( editor, object = null, script = '' ) {
 
 		super( editor );
 

--- a/editor/js/commands/MoveObjectCommand.js
+++ b/editor/js/commands/MoveObjectCommand.js
@@ -9,7 +9,7 @@ import { Command } from '../Command.js';
  */
 class MoveObjectCommand extends Command {
 
-	constructor( editor, object, newParent, newBefore ) {
+	constructor( editor, object = null, newParent = null, newBefore = null ) {
 
 		super( editor );
 
@@ -17,17 +17,17 @@ class MoveObjectCommand extends Command {
 		this.name = editor.strings.getKey( 'command/MoveObject' );
 
 		this.object = object;
-		this.oldParent = ( object !== undefined ) ? object.parent : undefined;
-		this.oldIndex = ( this.oldParent !== undefined ) ? this.oldParent.children.indexOf( this.object ) : undefined;
+		this.oldParent = ( object !== null ) ? object.parent : null;
+		this.oldIndex = ( this.oldParent !== null ) ? this.oldParent.children.indexOf( this.object ) : null;
 		this.newParent = newParent;
 
-		if ( newBefore !== undefined ) {
+		if ( newBefore !== null ) {
 
-			this.newIndex = ( newParent !== undefined ) ? newParent.children.indexOf( newBefore ) : undefined;
+			this.newIndex = ( newParent !== null ) ? newParent.children.indexOf( newBefore ) : null;
 
 		} else {
 
-			this.newIndex = ( newParent !== undefined ) ? newParent.children.length : undefined;
+			this.newIndex = ( newParent !== null ) ? newParent.children.length : null;
 
 		}
 

--- a/editor/js/commands/MultiCmdsCommand.js
+++ b/editor/js/commands/MultiCmdsCommand.js
@@ -7,14 +7,14 @@ import { Command } from '../Command.js';
  */
 class MultiCmdsCommand extends Command {
 
-	constructor( editor, cmdArray ) {
+	constructor( editor, cmdArray = [] ) {
 
 		super( editor );
 
 		this.type = 'MultiCmdsCommand';
 		this.name = editor.strings.getKey( 'command/MultiCmds' );
 
-		this.cmdArray = ( cmdArray !== undefined ) ? cmdArray : [];
+		this.cmdArray = cmdArray;
 
 	}
 

--- a/editor/js/commands/RemoveObjectCommand.js
+++ b/editor/js/commands/RemoveObjectCommand.js
@@ -9,18 +9,25 @@ import { ObjectLoader } from 'three';
  */
 class RemoveObjectCommand extends Command {
 
-	constructor( editor, object ) {
+	constructor( editor, object = null ) {
 
 		super( editor );
 
 		this.type = 'RemoveObjectCommand';
-		this.name = editor.strings.getKey( 'command/RemoveObject' ) + ': ' + object.name;
 
 		this.object = object;
-		this.parent = ( object !== undefined ) ? object.parent : undefined;
-		if ( this.parent !== undefined ) {
+		this.parent = ( object !== null ) ? object.parent : null;
+
+		if ( this.parent !== null ) {
 
 			this.index = this.parent.children.indexOf( this.object );
+
+		}
+
+		if ( object !== null ) {
+
+			this.name = editor.strings.getKey( 'command/RemoveObject' ) + ': ' + object.name;
+
 
 		}
 

--- a/editor/js/commands/RemoveScriptCommand.js
+++ b/editor/js/commands/RemoveScriptCommand.js
@@ -8,7 +8,7 @@ import { Command } from '../Command.js';
  */
 class RemoveScriptCommand extends Command {
 
-	constructor( editor, object, script ) {
+	constructor( editor, object = null, script = '' ) {
 
 		super( editor );
 
@@ -17,7 +17,8 @@ class RemoveScriptCommand extends Command {
 
 		this.object = object;
 		this.script = script;
-		if ( this.object && this.script ) {
+
+		if ( this.object !== null && this.script !== '' ) {
 
 			this.index = this.editor.scripts[ this.object.uuid ].indexOf( this.script );
 

--- a/editor/js/commands/SetColorCommand.js
+++ b/editor/js/commands/SetColorCommand.js
@@ -9,7 +9,7 @@ import { Command } from '../Command.js';
  */
 class SetColorCommand extends Command {
 
-	constructor( editor, object, attributeName, newValue ) {
+	constructor( editor, object = null, attributeName = '', newValue = null ) {
 
 		super( editor );
 
@@ -19,7 +19,7 @@ class SetColorCommand extends Command {
 
 		this.object = object;
 		this.attributeName = attributeName;
-		this.oldValue = ( object !== undefined ) ? this.object[ this.attributeName ].getHex() : undefined;
+		this.oldValue = ( object !== null ) ? this.object[ this.attributeName ].getHex() : null;
 		this.newValue = newValue;
 
 	}

--- a/editor/js/commands/SetGeometryCommand.js
+++ b/editor/js/commands/SetGeometryCommand.js
@@ -10,7 +10,7 @@ import { ObjectLoader } from 'three';
 
 class SetGeometryCommand extends Command {
 
-	constructor( editor, object, newGeometry ) {
+	constructor( editor, object = null, newGeometry = null ) {
 
 		super( editor );
 
@@ -19,7 +19,7 @@ class SetGeometryCommand extends Command {
 		this.updatable = true;
 
 		this.object = object;
-		this.oldGeometry = ( object !== undefined ) ? object.geometry : undefined;
+		this.oldGeometry = ( object !== null ) ? object.geometry : null;
 		this.newGeometry = newGeometry;
 
 	}

--- a/editor/js/commands/SetGeometryValueCommand.js
+++ b/editor/js/commands/SetGeometryValueCommand.js
@@ -9,7 +9,7 @@ import { Command } from '../Command.js';
  */
 class SetGeometryValueCommand extends Command {
 
-	constructor( editor, object, attributeName, newValue ) {
+	constructor( editor, object = null, attributeName = '', newValue = null ) {
 
 		super( editor );
 
@@ -18,7 +18,7 @@ class SetGeometryValueCommand extends Command {
 
 		this.object = object;
 		this.attributeName = attributeName;
-		this.oldValue = ( object !== undefined ) ? object.geometry[ attributeName ] : undefined;
+		this.oldValue = ( object !== null ) ? object.geometry[ attributeName ] : null;
 		this.newValue = newValue;
 
 	}

--- a/editor/js/commands/SetMaterialColorCommand.js
+++ b/editor/js/commands/SetMaterialColorCommand.js
@@ -9,7 +9,7 @@ import { Command } from '../Command.js';
  */
 class SetMaterialColorCommand extends Command {
 
-	constructor( editor, object, attributeName, newValue, materialSlot ) {
+	constructor( editor, object = null, attributeName = '', newValue = null, materialSlot = - 1 ) {
 
 		super( editor );
 
@@ -20,9 +20,9 @@ class SetMaterialColorCommand extends Command {
 		this.object = object;
 		this.materialSlot = materialSlot;
 
-		this.material = ( this.object !== undefined ) ? this.editor.getObjectMaterial( object, materialSlot ) : undefined;
+		const material = ( object !== null ) ? editor.getObjectMaterial( object, materialSlot ) : null;
 
-		this.oldValue = ( this.material !== undefined ) ? this.material[ attributeName ].getHex() : undefined;
+		this.oldValue = ( material !== null ) ? material[ attributeName ].getHex() : null;
 		this.newValue = newValue;
 
 		this.attributeName = attributeName;
@@ -31,7 +31,9 @@ class SetMaterialColorCommand extends Command {
 
 	execute() {
 
-		this.material[ this.attributeName ].setHex( this.newValue );
+		const material = this.editor.getObjectMaterial( this.object, this.materialSlot );
+
+		material[ this.attributeName ].setHex( this.newValue );
 
 		this.editor.signals.materialChanged.dispatch( this.object, this.materialSlot );
 
@@ -39,7 +41,9 @@ class SetMaterialColorCommand extends Command {
 
 	undo() {
 
-		this.material[ this.attributeName ].setHex( this.oldValue );
+		const material = this.editor.getObjectMaterial( this.object, this.materialSlot );
+
+		material[ this.attributeName ].setHex( this.oldValue );
 
 		this.editor.signals.materialChanged.dispatch( this.object, this.materialSlot );
 
@@ -59,6 +63,7 @@ class SetMaterialColorCommand extends Command {
 		output.attributeName = this.attributeName;
 		output.oldValue = this.oldValue;
 		output.newValue = this.newValue;
+		output.materialSlot = this.materialSlot;
 
 		return output;
 
@@ -72,6 +77,7 @@ class SetMaterialColorCommand extends Command {
 		this.attributeName = json.attributeName;
 		this.oldValue = json.oldValue;
 		this.newValue = json.newValue;
+		this.materialSlot = json.materialSlot;
 
 	}
 

--- a/editor/js/commands/SetMaterialCommand.js
+++ b/editor/js/commands/SetMaterialCommand.js
@@ -9,7 +9,7 @@ import { ObjectLoader } from 'three';
  */
 class SetMaterialCommand extends Command {
 
-	constructor( editor, object, newMaterial, materialSlot ) {
+	constructor( editor, object = null, newMaterial = null, materialSlot = - 1 ) {
 
 		super( editor );
 
@@ -19,7 +19,7 @@ class SetMaterialCommand extends Command {
 		this.object = object;
 		this.materialSlot = materialSlot;
 
-		this.oldMaterial = this.editor.getObjectMaterial( object, materialSlot );
+		this.oldMaterial = ( object !== null ) ? editor.getObjectMaterial( object, materialSlot ) : null;
 		this.newMaterial = newMaterial;
 
 	}
@@ -47,6 +47,7 @@ class SetMaterialCommand extends Command {
 		output.objectUuid = this.object.uuid;
 		output.oldMaterial = this.oldMaterial.toJSON();
 		output.newMaterial = this.newMaterial.toJSON();
+		output.materialSlot = this.materialSlot;
 
 		return output;
 
@@ -59,6 +60,7 @@ class SetMaterialCommand extends Command {
 		this.object = this.editor.objectByUuid( json.objectUuid );
 		this.oldMaterial = parseMaterial( json.oldMaterial );
 		this.newMaterial = parseMaterial( json.newMaterial );
+		this.materialSlot = json.materialSlot;
 
 		function parseMaterial( json ) {
 

--- a/editor/js/commands/SetMaterialMapCommand.js
+++ b/editor/js/commands/SetMaterialMapCommand.js
@@ -10,7 +10,7 @@ import { ObjectLoader } from 'three';
  */
 class SetMaterialMapCommand extends Command {
 
-	constructor( editor, object, mapName, newMap, materialSlot ) {
+	constructor( editor, object = null, mapName = '', newMap = null, materialSlot = - 1 ) {
 
 		super( editor );
 
@@ -20,9 +20,9 @@ class SetMaterialMapCommand extends Command {
 		this.object = object;
 		this.materialSlot = materialSlot;
 
-		this.material = this.editor.getObjectMaterial( object, materialSlot );
+		const material = ( object !== null ) ? editor.getObjectMaterial( object, materialSlot ) : null;
 
-		this.oldMap = ( object !== undefined ) ? this.material[ mapName ] : undefined;
+		this.oldMap = ( object !== null ) ? material[ mapName ] : undefined;
 		this.newMap = newMap;
 
 		this.mapName = mapName;
@@ -33,8 +33,10 @@ class SetMaterialMapCommand extends Command {
 
 		if ( this.oldMap !== null && this.oldMap !== undefined ) this.oldMap.dispose();
 
-		this.material[ this.mapName ] = this.newMap;
-		this.material.needsUpdate = true;
+		const material = this.editor.getObjectMaterial( this.object, this.materialSlot );
+
+		material[ this.mapName ] = this.newMap;
+		material.needsUpdate = true;
 
 		this.editor.signals.materialChanged.dispatch( this.object, this.materialSlot );
 
@@ -42,8 +44,10 @@ class SetMaterialMapCommand extends Command {
 
 	undo() {
 
-		this.material[ this.mapName ] = this.oldMap;
-		this.material.needsUpdate = true;
+		const material = this.editor.getObjectMaterial( this.object, this.materialSlot );
+
+		material[ this.mapName ] = this.oldMap;
+		material.needsUpdate = true;
 
 		this.editor.signals.materialChanged.dispatch( this.object, this.materialSlot );
 
@@ -57,6 +61,7 @@ class SetMaterialMapCommand extends Command {
 		output.mapName = this.mapName;
 		output.newMap = serializeMap( this.newMap );
 		output.oldMap = serializeMap( this.oldMap );
+		output.materialSlot = this.materialSlot;
 
 		return output;
 
@@ -112,6 +117,7 @@ class SetMaterialMapCommand extends Command {
 		this.mapName = json.mapName;
 		this.oldMap = parseTexture( json.oldMap );
 		this.newMap = parseTexture( json.newMap );
+		this.materialSlot = json.materialSlot;
 
 		function parseTexture( json ) {
 

--- a/editor/js/commands/SetMaterialRangeCommand.js
+++ b/editor/js/commands/SetMaterialRangeCommand.js
@@ -10,7 +10,7 @@ import { Command } from '../Command.js';
  */
 class SetMaterialRangeCommand extends Command {
 
-	constructor( editor, object, attributeName, newMinValue, newMaxValue, materialSlot ) {
+	constructor( editor, object = null, attributeName = '', newMinValue = - Infinity, newMaxValue = Infinity, materialSlot = - 1 ) {
 
 		super( editor );
 
@@ -21,9 +21,9 @@ class SetMaterialRangeCommand extends Command {
 		this.object = object;
 		this.materialSlot = materialSlot;
 
-		this.material = this.editor.getObjectMaterial( object, materialSlot );
+		const material = ( object !== null ) ? editor.getObjectMaterial( object, materialSlot ) : null;
 
-		this.oldRange = ( this.material !== undefined && this.material[ attributeName ] !== undefined ) ? [ ...this.material[ attributeName ] ] : undefined;
+		this.oldRange = ( material !== null && material[ attributeName ] !== undefined ) ? [ ...this.material[ attributeName ] ] : null;
 		this.newRange = [ newMinValue, newMaxValue ];
 
 		this.attributeName = attributeName;
@@ -32,8 +32,10 @@ class SetMaterialRangeCommand extends Command {
 
 	execute() {
 
-		this.material[ this.attributeName ] = [ ...this.newRange ];
-		this.material.needsUpdate = true;
+		const material = this.editor.getObjectMaterial( this.object, this.materialSlot );
+
+		material[ this.attributeName ] = [ ...this.newRange ];
+		material.needsUpdate = true;
 
 		this.editor.signals.objectChanged.dispatch( this.object );
 		this.editor.signals.materialChanged.dispatch( this.object, this.materialSlot );
@@ -42,8 +44,10 @@ class SetMaterialRangeCommand extends Command {
 
 	undo() {
 
-		this.material[ this.attributeName ] = [ ...this.oldRange ];
-		this.material.needsUpdate = true;
+		const material = this.editor.getObjectMaterial( this.object, this.materialSlot );
+
+		material[ this.attributeName ] = [ ...this.oldRange ];
+		material.needsUpdate = true;
 
 		this.editor.signals.objectChanged.dispatch( this.object );
 		this.editor.signals.materialChanged.dispatch( this.object, this.materialSlot );
@@ -64,6 +68,7 @@ class SetMaterialRangeCommand extends Command {
 		output.attributeName = this.attributeName;
 		output.oldRange = [ ...this.oldRange ];
 		output.newRange = [ ...this.newRange ];
+		output.materialSlot = this.materialSlot;
 
 		return output;
 
@@ -77,6 +82,7 @@ class SetMaterialRangeCommand extends Command {
 		this.oldRange = [ ...json.oldRange ];
 		this.newRange = [ ...json.newRange ];
 		this.object = this.editor.objectByUuid( json.objectUuid );
+		this.materialSlot = json.materialSlot;
 
 	}
 

--- a/editor/js/commands/SetMaterialValueCommand.js
+++ b/editor/js/commands/SetMaterialValueCommand.js
@@ -9,7 +9,7 @@ import { Command } from '../Command.js';
  */
 class SetMaterialValueCommand extends Command {
 
-	constructor( editor, object, attributeName, newValue, materialSlot ) {
+	constructor( editor, object = null, attributeName = '', newValue = null, materialSlot = - 1 ) {
 
 		super( editor );
 
@@ -20,9 +20,9 @@ class SetMaterialValueCommand extends Command {
 		this.object = object;
 		this.materialSlot = materialSlot;
 
-		this.material = this.editor.getObjectMaterial( object, materialSlot );
+		const material = ( object !== null ) ? editor.getObjectMaterial( object, materialSlot ) : null;
 
-		this.oldValue = ( this.material !== undefined ) ? this.material[ attributeName ] : undefined;
+		this.oldValue = ( material !== null ) ? material[ attributeName ] : null;
 		this.newValue = newValue;
 
 		this.attributeName = attributeName;
@@ -31,8 +31,10 @@ class SetMaterialValueCommand extends Command {
 
 	execute() {
 
-		this.material[ this.attributeName ] = this.newValue;
-		this.material.needsUpdate = true;
+		const material = this.editor.getObjectMaterial( this.object, this.materialSlot );
+
+		material[ this.attributeName ] = this.newValue;
+		material.needsUpdate = true;
 
 		this.editor.signals.objectChanged.dispatch( this.object );
 		this.editor.signals.materialChanged.dispatch( this.object, this.materialSlot );
@@ -41,8 +43,10 @@ class SetMaterialValueCommand extends Command {
 
 	undo() {
 
-		this.material[ this.attributeName ] = this.oldValue;
-		this.material.needsUpdate = true;
+		const material = this.editor.getObjectMaterial( this.object, this.materialSlot );
+
+		material[ this.attributeName ] = this.oldValue;
+		material.needsUpdate = true;
 
 		this.editor.signals.objectChanged.dispatch( this.object );
 		this.editor.signals.materialChanged.dispatch( this.object, this.materialSlot );
@@ -63,6 +67,7 @@ class SetMaterialValueCommand extends Command {
 		output.attributeName = this.attributeName;
 		output.oldValue = this.oldValue;
 		output.newValue = this.newValue;
+		output.materialSlot = this.materialSlot;
 
 		return output;
 
@@ -76,6 +81,7 @@ class SetMaterialValueCommand extends Command {
 		this.oldValue = json.oldValue;
 		this.newValue = json.newValue;
 		this.object = this.editor.objectByUuid( json.objectUuid );
+		this.materialSlot = json.materialSlot;
 
 	}
 

--- a/editor/js/commands/SetMaterialVectorCommand.js
+++ b/editor/js/commands/SetMaterialVectorCommand.js
@@ -2,7 +2,7 @@ import { Command } from '../Command.js';
 
 class SetMaterialVectorCommand extends Command {
 
-	constructor( editor, object, attributeName, newValue, materialSlot ) {
+	constructor( editor, object = null, attributeName = '', newValue = null, materialSlot = - 1 ) {
 
 		super( editor );
 
@@ -13,9 +13,9 @@ class SetMaterialVectorCommand extends Command {
 		this.object = object;
 		this.materialSlot = materialSlot;
 
-		this.material = this.editor.getObjectMaterial( object, materialSlot );
+		const material = ( object !== null ) ? editor.getObjectMaterial( object, materialSlot ) : null;
 
-		this.oldValue = ( this.material !== undefined ) ? this.material[ attributeName ].toArray() : undefined;
+		this.oldValue = ( material !== null ) ? material[ attributeName ].toArray() : null;
 		this.newValue = newValue;
 
 		this.attributeName = attributeName;
@@ -24,7 +24,9 @@ class SetMaterialVectorCommand extends Command {
 
 	execute() {
 
-		this.material[ this.attributeName ].fromArray( this.newValue );
+		const material = this.editor.getObjectMaterial( this.object, this.materialSlot );
+
+		material[ this.attributeName ].fromArray( this.newValue );
 
 		this.editor.signals.materialChanged.dispatch( this.object, this.materialSlot );
 
@@ -32,7 +34,9 @@ class SetMaterialVectorCommand extends Command {
 
 	undo() {
 
-		this.material[ this.attributeName ].fromArray( this.oldValue );
+		const material = this.editor.getObjectMaterial( this.object, this.materialSlot );
+
+		material[ this.attributeName ].fromArray( this.oldValue );
 
 		this.editor.signals.materialChanged.dispatch( this.object, this.materialSlot );
 
@@ -52,6 +56,7 @@ class SetMaterialVectorCommand extends Command {
 		output.attributeName = this.attributeName;
 		output.oldValue = this.oldValue;
 		output.newValue = this.newValue;
+		output.materialSlot = this.materialSlot;
 
 		return output;
 
@@ -65,6 +70,7 @@ class SetMaterialVectorCommand extends Command {
 		this.attributeName = json.attributeName;
 		this.oldValue = json.oldValue;
 		this.newValue = json.newValue;
+		this.materialSlot = json.materialSlot;
 
 	}
 

--- a/editor/js/commands/SetPositionCommand.js
+++ b/editor/js/commands/SetPositionCommand.js
@@ -10,7 +10,7 @@ import { Vector3 } from 'three';
  */
 class SetPositionCommand extends Command {
 
-	constructor( editor, object, newPosition, optionalOldPosition ) {
+	constructor( editor, object = null, newPosition = null, optionalOldPosition = null ) {
 
 		super( editor );
 
@@ -20,14 +20,14 @@ class SetPositionCommand extends Command {
 
 		this.object = object;
 
-		if ( object !== undefined && newPosition !== undefined ) {
+		if ( object !== null && newPosition !== null ) {
 
 			this.oldPosition = object.position.clone();
 			this.newPosition = newPosition.clone();
 
 		}
 
-		if ( optionalOldPosition !== undefined ) {
+		if ( optionalOldPosition !== null ) {
 
 			this.oldPosition = optionalOldPosition.clone();
 

--- a/editor/js/commands/SetRotationCommand.js
+++ b/editor/js/commands/SetRotationCommand.js
@@ -10,7 +10,7 @@ import { Euler } from 'three';
  */
 class SetRotationCommand extends Command {
 
-	constructor( editor, object, newRotation, optionalOldRotation ) {
+	constructor( editor, object = null, newRotation = null, optionalOldRotation = null ) {
 
 		super( editor );
 
@@ -20,14 +20,14 @@ class SetRotationCommand extends Command {
 
 		this.object = object;
 
-		if ( object !== undefined && newRotation !== undefined ) {
+		if ( object !== null && newRotation !== null ) {
 
 			this.oldRotation = object.rotation.clone();
 			this.newRotation = newRotation.clone();
 
 		}
 
-		if ( optionalOldRotation !== undefined ) {
+		if ( optionalOldRotation !== null ) {
 
 			this.oldRotation = optionalOldRotation.clone();
 

--- a/editor/js/commands/SetScaleCommand.js
+++ b/editor/js/commands/SetScaleCommand.js
@@ -10,7 +10,7 @@ import { Vector3 } from 'three';
  */
 class SetScaleCommand extends Command {
 
-	constructor( editor, object, newScale, optionalOldScale ) {
+	constructor( editor, object = null, newScale = null, optionalOldScale = null ) {
 
 		super( editor );
 
@@ -20,14 +20,14 @@ class SetScaleCommand extends Command {
 
 		this.object = object;
 
-		if ( object !== undefined && newScale !== undefined ) {
+		if ( object !== null && newScale !== null ) {
 
 			this.oldScale = object.scale.clone();
 			this.newScale = newScale.clone();
 
 		}
 
-		if ( optionalOldScale !== undefined ) {
+		if ( optionalOldScale !== null ) {
 
 			this.oldScale = optionalOldScale.clone();
 

--- a/editor/js/commands/SetSceneCommand.js
+++ b/editor/js/commands/SetSceneCommand.js
@@ -10,7 +10,7 @@ import { AddObjectCommand } from './AddObjectCommand.js';
  */
 class SetSceneCommand extends Command {
 
-	constructor( editor, scene ) {
+	constructor( editor, scene = null ) {
 
 		super( editor );
 
@@ -19,7 +19,7 @@ class SetSceneCommand extends Command {
 
 		this.cmdArray = [];
 
-		if ( scene !== undefined ) {
+		if ( scene !== null ) {
 
 			this.cmdArray.push( new SetUuidCommand( this.editor, this.editor.scene, scene.uuid ) );
 			this.cmdArray.push( new SetValueCommand( this.editor, this.editor.scene, 'name', scene.name ) );

--- a/editor/js/commands/SetScriptValueCommand.js
+++ b/editor/js/commands/SetScriptValueCommand.js
@@ -10,7 +10,7 @@ import { Command } from '../Command.js';
  */
 class SetScriptValueCommand extends Command {
 
-	constructor( editor, object, script, attributeName, newValue ) {
+	constructor( editor, object = null, script = '', attributeName = '', newValue = null ) {
 
 		super( editor );
 
@@ -22,7 +22,7 @@ class SetScriptValueCommand extends Command {
 		this.script = script;
 
 		this.attributeName = attributeName;
-		this.oldValue = ( script !== undefined ) ? script[ this.attributeName ] : undefined;
+		this.oldValue = ( script !== '' ) ? script[ this.attributeName ] : null;
 		this.newValue = newValue;
 
 	}

--- a/editor/js/commands/SetUuidCommand.js
+++ b/editor/js/commands/SetUuidCommand.js
@@ -8,7 +8,7 @@ import { Command } from '../Command.js';
  */
 class SetUuidCommand extends Command {
 
-	constructor( editor, object, newUuid ) {
+	constructor( editor, object = null, newUuid = null ) {
 
 		super( editor );
 
@@ -17,7 +17,7 @@ class SetUuidCommand extends Command {
 
 		this.object = object;
 
-		this.oldUuid = ( object !== undefined ) ? object.uuid : undefined;
+		this.oldUuid = ( object !== null ) ? object.uuid : null;
 		this.newUuid = newUuid;
 
 	}

--- a/editor/js/commands/SetValueCommand.js
+++ b/editor/js/commands/SetValueCommand.js
@@ -9,7 +9,7 @@ import { Command } from '../Command.js';
  */
 class SetValueCommand extends Command {
 
-	constructor( editor, object, attributeName, newValue ) {
+	constructor( editor, object = null, attributeName = '', newValue = null ) {
 
 		super( editor );
 
@@ -19,7 +19,7 @@ class SetValueCommand extends Command {
 
 		this.object = object;
 		this.attributeName = attributeName;
-		this.oldValue = ( object !== undefined ) ? object[ attributeName ] : undefined;
+		this.oldValue = ( object !== null ) ? object[ attributeName ] : null;
 		this.newValue = newValue;
 
 	}


### PR DESCRIPTION
Fixed #28395.

Closes #28360. Closes #28398. Closes #28362.

**Description**

This PR ensures commands can now properly serialized/deserialized when persistent history is enabled.

It makes sure all commands have proper default values and don't throw exceptions in their ctors when default parameters are used.

The PR also makes sure material commands use the correct material reference. This is done by not caching the material in the command but the material slot instead. With this information, the correct material can be requested with the object. Meaning this pattern:
```js
const material = editor.getObjectMaterial( object, materialSlot );
```
