### PR TITLE
TSL: Fix `tslFn()` output type called before build

### DIFF
--- a/examples/jsm/nodes/shadernode/ShaderNode.js
+++ b/examples/jsm/nodes/shadernode/ShaderNode.js
@@ -251,9 +251,15 @@ class ShaderCallNodeInternal extends Node {
 
 	getNodeType( builder ) {
 
-		const { outputNode } = builder.getNodeProperties( this );
+		const properties = builder.getNodeProperties( this );
 
-		return outputNode ? outputNode.getNodeType( builder ) : super.getNodeType( builder );
+		if ( properties.outputNode === null ) {
+
+			properties.outputNode = this.setupOutput( builder );
+
+		}
+
+		return properties.outputNode.getNodeType( builder );
 
 	}
 
@@ -301,6 +307,14 @@ class ShaderCallNodeInternal extends Node {
 	}
 
 	setup( builder ) {
+
+		const { outputNode } = builder.getNodeProperties( this );
+
+		return outputNode || this.setupOutput( builder );
+
+	}
+
+	setupOutput( builder ) {
 
 		builder.addStack();
 


### PR DESCRIPTION
**Description**

This fix allows you to use function calls before the build process, allowing you to provide the correct output type from the function. In the example below `tangentGeometry` is the return of `attribute( 'tangent', 'vec4' )` and not a function because this is called at the end of the function, like `tslFn( ... )()` the function will return `ShaderCallNodeInternal `, the call is executed only in the building process.

```js
export const tangentGeometry = /*#__PURE__*/ tslFn( ( stack, builder ) => {

	if ( builder.geometry.hasAttribute( 'tangent' ) === false ) {

		builder.geometry.computeTangents();

	}

	return attribute( 'tangent', 'vec4' );

} )();
```