### PR TITLE
SortUtils: fix termination condition & enforce unsigned value

### DIFF
--- a/examples/jsm/utils/SortUtils.js
+++ b/examples/jsm/utils/SortUtils.js
@@ -1,6 +1,9 @@
 // Hybrid radix sort from
 // - https://gist.github.com/sciecode/93ed864dd77c5c8803c6a86698d68dab
 // - https://github.com/mrdoob/three.js/pull/27202#issuecomment-1817640271
+//
+// expects unsigned 32b integer values
+
 const POWER = 3;
 const BIT_MAX = 32;
 const BIN_BITS = 1 << POWER;
@@ -102,11 +105,11 @@ export const radixSort = ( arr, opt ) => {
 
 		for ( let j = start + 1; j < start + len; j ++ ) {
 
-			const p = a[ j ], t = get( p );
+			const p = a[ j ], t = get( p ) >>> 0;
 			let i = j;
-			while ( i > 0 ) {
+			while ( i > start ) {
 
-				if ( compare( get( a[ i - 1 ] ), t ) )
+				if ( compare( get( a[ i - 1 ] ) >>> 0, t ) )
 					a[ i ] = a[ -- i ];
 				else
 					break;
@@ -140,14 +143,14 @@ export const radixSort = ( arr, opt ) => {
 		bin.fill( 0 );
 
 		for ( let j = start; j < end; j ++ )
-			bin[ ( get( a[ j ] ) >> shift ) & BIN_MAX ] ++;
+			bin[ ( get( a[ j ] ) >>> shift ) & BIN_MAX ] ++;
 
 		accumulate( bin );
 
 		cache.set( bin );
 
 		for ( let j = end - 1; j >= start; j -- )
-			b[ start + -- bin[ ( get( a[ j ] ) >> shift ) & BIN_MAX ] ] = a[ j ];
+			b[ start + -- bin[ ( get( a[ j ] ) >>> shift ) & BIN_MAX ] ] = a[ j ];
 
 		if ( depth == ITERATIONS - 1 ) return;
 


### PR DESCRIPTION
Fixes incorrect termination condition during insertion-sort block, exposed by #28401
Informs & enforces unsigned 32b integer sort.

----

There was a pretty nasty bug in the termination condition of insertion sort, fortunately, it didn't cause wrong results under expected input conditions (uint32). It only became apparent when used with signed values. Nonetheless, it was fixed and unsigned condition is enforced even if input values don't match expected range.
