### PR TITLE
Editor: Fixed wrong camera aspect ratio when window resized for REALISTIC shading

### DIFF
--- a/editor/js/Viewport.Pathtracer.js
+++ b/editor/js/Viewport.Pathtracer.js
@@ -22,7 +22,7 @@ function ViewportPathtracer( renderer ) {
 		if ( pathTracer === null ) return;
 
 		// path tracer size automatically updates based on the canvas
-		pathTracer.reset();
+		pathTracer.updateCamera();
 
 	}
 


### PR DESCRIPTION
The issue: viewport rendering doesn't update aspect ratio on window resize when shading is REALISTIC 

https://github.com/mrdoob/three.js/assets/1063018/0e36c0df-133a-48c7-81ef-bf663d811be1

The PR fixed that by updating pathtracer's camera on resize

preview: https://raw.githack.com/ycw/three.js/editor-pathtracer-aspectratio-on-resize/editor/index.html

