### PR TITLE
Editor: Fixed script editor title out-of-sync

### DIFF
--- a/editor/js/Script.js
+++ b/editor/js/Script.js
@@ -429,6 +429,26 @@ function Script( editor ) {
 
 	} );
 
+	signals.objectChanged.add( function ( object ) {
+
+		if ( editor.scripts[ object.uuid ].includes( currentScript ) ) {
+
+			signals.editScript.dispatch( currentObject, currentScript );
+
+		}
+
+	} );
+
+	signals.scriptChanged.add( function ( script ) {
+
+		if ( script === currentScript ) {
+
+			signals.editScript.dispatch( currentObject, currentScript );
+
+		}
+
+	} );
+
 	return container;
 
 }

--- a/editor/js/Script.js
+++ b/editor/js/Script.js
@@ -431,9 +431,9 @@ function Script( editor ) {
 
 	signals.objectChanged.add( function ( object ) {
 
-		if ( editor.scripts[ object.uuid ].includes( currentScript ) ) {
+		if ( object === currentObject ) {
 
-			signals.editScript.dispatch( currentObject, currentScript );
+			title.setValue( currentObject.name + ' / ' + currentScript.name );
 
 		}
 
@@ -443,7 +443,7 @@ function Script( editor ) {
 
 		if ( script === currentScript ) {
 
-			signals.editScript.dispatch( currentObject, currentScript );
+			title.setValue( currentObject.name + ' / ' + currentScript.name );
 
 		}
 

--- a/editor/js/commands/SetScriptValueCommand.js
+++ b/editor/js/commands/SetScriptValueCommand.js
@@ -31,7 +31,7 @@ class SetScriptValueCommand extends Command {
 
 		this.script[ this.attributeName ] = this.newValue;
 
-		this.editor.signals.scriptChanged.dispatch();
+		this.editor.signals.scriptChanged.dispatch( this.script );
 
 	}
 
@@ -39,7 +39,7 @@ class SetScriptValueCommand extends Command {
 
 		this.script[ this.attributeName ] = this.oldValue;
 
-		this.editor.signals.scriptChanged.dispatch();
+		this.editor.signals.scriptChanged.dispatch( this.script );
 
 	}
 


### PR DESCRIPTION
The issue: When users update script name or rename object, the script editor title doesn't update its value

With this PR, the script editor title keeps in sync with script name and object name:

https://github.com/mrdoob/three.js/assets/1063018/14a6fda3-56f0-4f07-9f95-083245ea0eb3

Preview: https://raw.githack.com/ycw/three.js/editor-sync-script-name/editor/index.html