### PR TITLE
WebGPURenderer: handle BatchMesh objects without a color texture.

### DIFF
--- a/examples/jsm/renderers/common/RenderObject.js
+++ b/examples/jsm/renderers/common/RenderObject.js
@@ -225,7 +225,12 @@ export default class RenderObject {
 		if ( object.isBatchedMesh ) {
 
 			cacheKey += object._matricesTexture.uuid + ',';
-			cacheKey += object._colorsTexture.uuid + ',';
+
+			if ( object._colorsTexture !== null ) {
+
+				cacheKey += object._colorsTexture.uuid + ',';
+
+			}
 
 		}
 


### PR DESCRIPTION
Related issue: #28255 

Above PR broke the webgpu_mesh_batch example which uses a BatchMesh object without a color texture. Handle this case.

