### PR TITLE
Examples: Fix argument passed to copyTextureToTexture

### DIFF
--- a/examples/webgpu_materials_texture_partialupdate.html
+++ b/examples/webgpu_materials_texture_partialupdate.html
@@ -110,7 +110,7 @@
 
 					// perform copy from src to dest texture to a random position
 
-					renderer.copyTextureToTexture( dataTexture, diffuseMap, new THREE.Vector2(), position );
+					renderer.copyTextureToTexture( dataTexture, diffuseMap, null, position );
 
 				}
 


### PR DESCRIPTION
Related issue: N/A

**Description**

The third argument passed to `copyTextureToTexture` should be a `Box2` or `null`. I believe this is an oversight in https://github.com/mrdoob/three.js/pull/28315.