### PR TITLE
Editor: Added appearance submenu

### DIFF
--- a/editor/css/main.css
+++ b/editor/css/main.css
@@ -414,6 +414,21 @@ select {
 					background: transparent;
 				}
 
+				#menubar .menu .options .option.toggle::before {
+
+					content: ' ';
+					display: inline-block;
+					width: 16px;
+
+				}
+
+				#menubar .menu .options .option.toggle-on::before {
+
+					content: '✓';
+					font-size: 12px;
+
+				}
+
 				#menubar .submenu-title::after {
 					content: '⏵';
 					float: right;
@@ -426,6 +441,8 @@ select {
 			margin: 0 !important;
 			cursor: not-allowed;
 		}
+
+		
 
 #sidebar {
 	position: absolute;

--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -82,7 +82,6 @@ function Editor() {
 
 		windowResize: new Signal(),
 
-		showGridChanged: new Signal(),
 		showHelpersChanged: new Signal(),
 		refreshSidebarObject3D: new Signal(),
 		refreshSidebarEnvironment: new Signal(),

--- a/editor/js/Menubar.View.js
+++ b/editor/js/Menubar.View.js
@@ -1,4 +1,4 @@
-import { UIPanel, UIRow } from './libs/ui.js';
+import { UIHorizontalRule, UIPanel, UIRow } from './libs/ui.js';
 
 function MenubarView( editor ) {
 
@@ -19,7 +19,7 @@ function MenubarView( editor ) {
 
 	// Fullscreen
 
-	const option = new UIRow();
+	let option = new UIRow();
 	option.setClass( 'option' );
 	option.setTextContent( strings.getKey( 'menubar/view/fullscreen' ) );
 	option.onClick( function () {
@@ -102,6 +102,100 @@ function MenubarView( editor ) {
 		}
 
 	}
+
+	//
+
+	options.add( new UIHorizontalRule() );
+
+	// Appearance
+
+	const appearanceStates = {
+
+		gridHelper: true,
+		cameraHelpers: true,
+		lightHelpers: true,
+		skeletonHelpers: true
+
+	};
+
+	const appearanceSubmenuTitle = new UIRow().setTextContent( 'Appearance' ).addClass( 'option' ).addClass( 'submenu-title' );
+	appearanceSubmenuTitle.onMouseOver( function () {
+
+		const { top, right } = appearanceSubmenuTitle.dom.getBoundingClientRect();
+		const { paddingTop } = getComputedStyle( this.dom );
+		appearanceSubmenu.setLeft( right + 'px' );
+		appearanceSubmenu.setTop( top - parseFloat( paddingTop ) + 'px' );
+		appearanceSubmenu.setStyle( 'max-height', [ `calc( 100vh - ${top}px )` ] );
+		appearanceSubmenu.setDisplay( 'block' );
+
+	} );
+	appearanceSubmenuTitle.onMouseOut( function () {
+
+		appearanceSubmenu.setDisplay( 'none' );
+
+	} );
+	options.add( appearanceSubmenuTitle );
+
+	const appearanceSubmenu = new UIPanel().setPosition( 'fixed' ).addClass( 'options' ).setDisplay( 'none' );
+	appearanceSubmenuTitle.add( appearanceSubmenu );
+
+	// Appearance / Grid Helper
+
+	option = new UIRow().addClass( 'option' ).addClass( 'toggle' ).setTextContent( 'Grid Helper' ).onClick( function () {
+
+		appearanceStates.gridHelper = ! appearanceStates.gridHelper;
+
+		this.toggleClass( 'toggle-on', appearanceStates.gridHelper );
+
+		signals.showHelpersChanged.dispatch( appearanceStates );
+
+	} ).toggleClass( 'toggle-on', appearanceStates.gridHelper );
+
+	appearanceSubmenu.add( option );
+
+	// Appearance / Camera Helpers
+
+	option = new UIRow().addClass( 'option' ).addClass( 'toggle' ).setTextContent( 'Camera Helpers' ).onClick( function () {
+
+		appearanceStates.cameraHelpers = ! appearanceStates.cameraHelpers;
+
+		this.toggleClass( 'toggle-on', appearanceStates.cameraHelpers );
+
+		signals.showHelpersChanged.dispatch( appearanceStates );
+
+	} ).toggleClass( 'toggle-on', appearanceStates.cameraHelpers );
+
+	appearanceSubmenu.add( option );
+
+	// Appearance / Light Helpers
+
+	option = new UIRow().addClass( 'option' ).addClass( 'toggle' ).setTextContent( 'Light Helpers' ).onClick( function () {
+
+		appearanceStates.lightHelpers = ! appearanceStates.lightHelpers;
+
+		this.toggleClass( 'toggle-on', appearanceStates.lightHelpers );
+
+		signals.showHelpersChanged.dispatch( appearanceStates );
+
+	} ).toggleClass( 'toggle-on', appearanceStates.lightHelpers );
+
+	appearanceSubmenu.add( option );
+
+	// Appearance / Skeleton Helpers
+
+	option = new UIRow().addClass( 'option' ).addClass( 'toggle' ).setTextContent( 'Skeleton Helpers' ).onClick( function () {
+
+		appearanceStates.skeletonHelpers = ! appearanceStates.skeletonHelpers;
+
+		this.toggleClass( 'toggle-on', appearanceStates.skeletonHelpers );
+
+		signals.showHelpersChanged.dispatch( appearanceStates );
+
+	} ).toggleClass( 'toggle-on', appearanceStates.skeletonHelpers );
+
+	appearanceSubmenu.add( option );
+
+	//
 
 	return container;
 

--- a/editor/js/Viewport.Controls.js
+++ b/editor/js/Viewport.Controls.js
@@ -1,36 +1,14 @@
 import { UIPanel, UISelect } from './libs/ui.js';
-import { UIBoolean } from './libs/ui.three.js';
 
 function ViewportControls( editor ) {
 
 	const signals = editor.signals;
-	const strings = editor.strings;
 
 	const container = new UIPanel();
 	container.setPosition( 'absolute' );
 	container.setRight( '10px' );
 	container.setTop( '10px' );
 	container.setColor( '#ffffff' );
-
-	// grid
-
-	const gridCheckbox = new UIBoolean( true, strings.getKey( 'viewport/controls/grid' ) );
-	gridCheckbox.onChange( function () {
-
-		signals.showGridChanged.dispatch( this.getValue() );
-
-	} );
-	container.add( gridCheckbox );
-
-	// helpers
-
-	const helpersCheckbox = new UIBoolean( true, strings.getKey( 'viewport/controls/helpers' ) );
-	helpersCheckbox.onChange( function () {
-
-		signals.showHelpersChanged.dispatch( this.getValue() );
-
-	} );
-	container.add( helpersCheckbox );
 
 	// camera
 

--- a/editor/js/Viewport.js
+++ b/editor/js/Viewport.js
@@ -680,18 +680,56 @@ function Viewport( editor ) {
 
 	} );
 
-	signals.showGridChanged.add( function ( value ) {
+	signals.showHelpersChanged.add( function ( appearanceStates ) {
 
-		grid.visible = value;
+		grid.visible = appearanceStates.gridHelper;
 
-		render();
+		sceneHelpers.traverse( function ( object ) {
 
-	} );
+			switch ( object.type ) {
 
-	signals.showHelpersChanged.add( function ( value ) {
+				case 'CameraHelper':
 
-		sceneHelpers.visible = value;
-		transformControls.enabled = value;
+				{
+
+					object.visible = appearanceStates.cameraHelpers;
+					break;
+
+				}
+
+				case 'PointLightHelper':
+				case 'DirectionalLightHelper':
+				case 'SpotLightHelper':
+				case 'HemisphereLightHelper':
+
+				{
+
+					object.visible = appearanceStates.lightHelpers;
+					break;
+
+				}
+
+				case 'SkeletonHelper':
+
+				{
+
+					object.visible = appearanceStates.skeletonHelpers;
+					break;
+
+				}
+
+				default:
+
+				{
+
+					// not a helper, skip.
+
+				}
+
+			}
+
+		} );
+
 
 		render();
 

--- a/editor/js/libs/ui.js
+++ b/editor/js/libs/ui.js
@@ -98,6 +98,14 @@ class UIElement {
 
 	}
 
+	toggleClass( name, toggle ) {
+
+		this.dom.classList.toggle( name, toggle );
+
+		return this;
+
+	}
+
 	setStyle( style, array ) {
 
 		for ( let i = 0; i < array.length; i ++ ) {


### PR DESCRIPTION
The PR moves helpers toggling from viewport to View>Appearance>, and users can now toggle helpers by type:

https://github.com/mrdoob/three.js/assets/1063018/1574ff08-0c78-459c-bbad-f200a2066f0f

It's practical:

- "SkeletonHelper is always shown infront of everything" is of [WONT FIX](https://github.com/mrdoob/three.js/issues/28399#issuecomment-2122011244), meaning that SkeletonHelpers will be always shown even behind walls for example. This PR fixed 'depth perception lost' by offering an option to toggle all `SkeletionHelper`.

- CameraHelpers should be shown only if needed; There can be many cameras on scene(an example is `models/collada/pump/pump.dae`), in this case showing all CameraHelpers will hurt editing experience, in particular the CameraHelpers overlapped with the object that users are transforming. This PR fixed that by offering an option to toggle CameraHelpers seperately.

Unlike SkeletonHelper, bounding box and transform gizmo are needed to be always shown infront, because that is their sole purpose: spotting the selected object's location and size on the scene, because of that, they aren't included in `View>Appearance>` submenu.

The togglers(Grid, Helpers) are moved from viewport into menu bar `View>Appearance>`, s.t. from now on, users will be taught that it's the single place to show/hide things, currently only on-scene helpers; In the future, the submenu will be included overlays e.g. 'viewport info', and UI items, e.g. 'sidebar'.

Thanks.