### PR TITLE
Editor: Submenu title should ignore active state

### DIFF
--- a/editor/css/main.css
+++ b/editor/css/main.css
@@ -409,7 +409,7 @@ select {
 					background-color: #08f;
 				}
 
-				#menubar .menu .options .option:active {
+				#menubar .menu .options .option:not(.submenu-title):active {
 					color: #666;
 					background: transparent;
 				}


### PR DESCRIPTION
The issue: Currently the subtitle title will be changed its style to reflect a submenu item is being pressed, which is misleading.

Before:

https://github.com/mrdoob/three.js/assets/1063018/a8554fad-b520-45f7-9329-892b2cfd1261


After: (This PR) 

https://github.com/mrdoob/three.js/assets/1063018/7a339596-7411-4246-9c81-99774a8cc136


Preview: https://raw.githack.com/ycw/three.js/editor-submenu-title-should-ignore-active/editor/index.html


