### PR TITLE
Editor: Fixed wrong aspect ratio for non default cameras on window resize

### DIFF
--- a/editor/js/Viewport.js
+++ b/editor/js/Viewport.js
@@ -152,8 +152,19 @@ function Viewport( editor ) {
 
 	function updateAspectRatio() {
 
-		camera.aspect = container.dom.offsetWidth / container.dom.offsetHeight;
-		camera.updateProjectionMatrix();
+		for ( const uuid in editor.cameras ) {
+
+			const camera = editor.cameras[ uuid ];
+
+			if ( camera.isPerspectiveCamera ) {
+
+				camera.aspect = container.dom.offsetWidth / container.dom.offsetHeight;
+
+				camera.updateProjectionMatrix();
+
+			}
+
+		}
 
 	}
 


### PR DESCRIPTION
The issue: non default cameras' aspect ratio doesn't get updated on resize:

https://github.com/mrdoob/three.js/assets/1063018/9bec82d5-dc28-4933-9d45-5bd20c7fa0a2


With this PR:

https://github.com/mrdoob/three.js/assets/1063018/ff818187-8731-4dae-b03c-bcb44ed7e1c3


Preview: https://raw.githack.com/ycw/three.js/editor-shading-with-correct-aspect-ratio/editor/index.html


