### PR TITLE
Editor: Makes all shadings modes honor the viewport camera

### DIFF
--- a/editor/js/Viewport.js
+++ b/editor/js/Viewport.js
@@ -622,8 +622,7 @@ function Viewport( editor ) {
 
 		if ( viewportCamera.isPerspectiveCamera ) {
 
-			viewportCamera.aspect = editor.camera.aspect;
-			viewportCamera.projectionMatrix.copy( editor.camera.projectionMatrix );
+			updateAspectRatio();
 
 		} else if ( viewportCamera.isOrthographicCamera ) {
 
@@ -635,6 +634,7 @@ function Viewport( editor ) {
 
 		controls.enabled = ( viewportCamera === editor.camera );
 
+		initPT();
 		render();
 
 	} );
@@ -646,7 +646,7 @@ function Viewport( editor ) {
 		switch ( viewportShading ) {
 
 			case 'realistic':
-				pathtracer.init( scene, camera );
+				pathtracer.init( scene, editor.viewportCamera );
 				break;
 
 			case 'solid':
@@ -757,7 +757,7 @@ function Viewport( editor ) {
 
 		if ( editor.viewportShading === 'realistic' ) {
 
-			pathtracer.init( scene, camera );
+			pathtracer.init( scene, editor.viewportCamera );
 
 		}
 


### PR DESCRIPTION
This PR makes all shading modes honor the viewport camera

Preview: https://raw.githack.com/ycw/three.js/editor-shading-honors-viewport-camera/editor/index.html (aspect ratio issue is fixed in another PR #28425)

With this PR:


https://github.com/mrdoob/three.js/assets/1063018/ed9dc389-e4dd-4232-ab0a-8eef311fa371

