### PR TITLE
GPUStatsPanel: Remove the query upon completion

### DIFF
--- a/examples/jsm/utils/GPUStatsPanel.js
+++ b/examples/jsm/utils/GPUStatsPanel.js
@@ -56,6 +56,8 @@ export class GPUStatsPanel extends Stats.Panel {
 
 					}
 
+					gl.deleteQuery( query );
+
 					this.activeQueries --;
 
 


### PR DESCRIPTION
**Description**

Remove the timer query upon completion. Forgetting to do so on my Intel GPU results in a `GL_INVALID_OPERATION: Invalid query Id` error.
![Screenshot](https://github.com/mrdoob/three.js/assets/691945/b2997855-8be6-4c44-9eeb-83791a9d81f5)

