### PR TITLE
Editor: Fixed unhandled material array when exporting JSON

### DIFF
--- a/editor/js/Sidebar.Material.js
+++ b/editor/js/Sidebar.Material.js
@@ -430,7 +430,7 @@ function SidebarMaterial( editor ) {
 	exportJson.onClick( function () {
 
 		const object = editor.selected;
-		const material = object.material;
+		const material = Array.isArray( object.material ) ? object.material[ currentMaterialSlot ] : object.material;
 
 		let output = material.toJSON();
 


### PR DESCRIPTION
This PR fixed an issue about `EXPORT JSON` in MATERIAL tab, which doesn't honor material array, it will throw if doing so:

![image](https://github.com/mrdoob/three.js/assets/1063018/7c8f8e6a-0ab8-4156-a494-49e605fe077e)

To reproduce: 

1. Drops https://github.com/mrdoob/three.js/tree/dev/examples/models/collada/elf in editor
2. Opens console
3. Navigates to MATERIAL tab, presses EXPORT JSON.