### PR TITLE
Editor: Added samples info for REALISTIC shading

### DIFF
--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -93,6 +93,8 @@ function Editor() {
 
 		intersectionsDetected: new Signal(),
 
+		pathTracerUpdated: new Signal(),
+
 	};
 
 	this.config = new Config();

--- a/editor/js/Strings.js
+++ b/editor/js/Strings.js
@@ -384,10 +384,12 @@ function Strings( config ) {
 			'viewport/info/oneObject': 'Object',
 			'viewport/info/oneVertex': 'Vertex',
 			'viewport/info/oneTriangle': 'Triangle',
+			'viewport/info/oneSample': 'Sample',
 			'viewport/info/objects': 'Objects',
 			'viewport/info/vertices': 'Vertices',
 			'viewport/info/triangles': 'Triangles',
-			'viewport/info/rendertime': 'Render time'
+			'viewport/info/samples': 'Samples',
+			'viewport/info/rendertime': 'Render time',
 
 		},
 
@@ -771,9 +773,11 @@ function Strings( config ) {
 			'viewport/info/oneObject': 'Objet',
 			'viewport/info/oneVertex': 'Sommet',
 			'viewport/info/oneTriangle': 'Triangle',
+			'viewport/info/oneSample': 'Échantillon',
 			'viewport/info/objects': 'Objets',
 			'viewport/info/vertices': 'Sommets',
 			'viewport/info/triangles': 'Triangles',
+			'viewport/info/samples': 'Échantillons',
 			'viewport/info/rendertime': 'Temps de rendu'
 
 		},
@@ -1158,9 +1162,11 @@ function Strings( config ) {
 			'viewport/info/oneObject': '物体',
 			'viewport/info/oneVertex': '顶点',
 			'viewport/info/oneTriangle': '三角形',
+			'viewport/info/oneSample': '样本',
 			'viewport/info/objects': '物体',
 			'viewport/info/vertices': '顶点',
 			'viewport/info/triangles': '三角形',
+			'viewport/info/samples': '样本',
 			'viewport/info/rendertime': '渲染时间'
 
 		},
@@ -1545,9 +1551,11 @@ function Strings( config ) {
 			'viewport/info/oneObject': 'オブジェクト',
 			'viewport/info/oneVertex': '頂点',
 			'viewport/info/oneTriangle': '三角形',
+			'viewport/info/oneSample': 'サンプル',
 			'viewport/info/objects': 'オブジェクト',
 			'viewport/info/vertices': '頂点',
 			'viewport/info/triangles': '三角形',
+			'viewport/info/samples': 'サンプル',
 			'viewport/info/rendertime': 'レンダリング時間'
 
 		}

--- a/editor/js/Viewport.Info.js
+++ b/editor/js/Viewport.Info.js
@@ -18,20 +18,27 @@ function ViewportInfo( editor ) {
 	const verticesText = new UIText( '0' ).setTextAlign( 'right' ).setWidth( '60px' ).setMarginRight( '6px' );
 	const trianglesText = new UIText( '0' ).setTextAlign( 'right' ).setWidth( '60px' ).setMarginRight( '6px' );
 	const frametimeText = new UIText( '0' ).setTextAlign( 'right' ).setWidth( '60px' ).setMarginRight( '6px' );
+	const samplesText = new UIText( '0' ).setTextAlign( 'right' ).setWidth( '60px' ).setMarginRight( '6px' ).setHidden( true );
 
 	const objectsUnitText = new UIText( strings.getKey( 'viewport/info/objects' ) );
 	const verticesUnitText = new UIText( strings.getKey( 'viewport/info/vertices' ) );
 	const trianglesUnitText = new UIText( strings.getKey( 'viewport/info/triangles' ) );
+	const samplesUnitText = new UIText( strings.getKey( 'viewport/info/samples' ) ).setHidden( true );
 
 	container.add( objectsText, objectsUnitText, new UIBreak() );
 	container.add( verticesText, verticesUnitText, new UIBreak() );
 	container.add( trianglesText, trianglesUnitText, new UIBreak() );
 	container.add( frametimeText, new UIText( strings.getKey( 'viewport/info/rendertime' ) ), new UIBreak() );
+	container.add( samplesText, samplesUnitText, new UIBreak() );
 
 	signals.objectAdded.add( update );
 	signals.objectRemoved.add( update );
 	signals.geometryChanged.add( update );
 	signals.sceneRendered.add( updateFrametime );
+
+	//
+
+	const pluralRules = new Intl.PluralRules( editor.config.getKey( 'language' ) );
 
 	//
 
@@ -97,6 +104,30 @@ function ViewportInfo( editor ) {
 		frametimeText.setValue( Number( frametime ).toFixed( 2 ) );
 
 	}
+
+	//
+
+	editor.signals.pathTracerUpdated.add( function ( samples ) {
+
+		samples = Math.floor( samples );
+
+		samplesText.setValue( samples );
+
+		const samplesStringKey = ( pluralRules.select( samples ) === 'one' ) ? 'viewport/info/oneSample' : 'viewport/info/samples';
+		samplesUnitText.setValue( strings.getKey( samplesStringKey ) );
+
+	} );
+
+	editor.signals.viewportShadingChanged.add( function () {
+
+		const isRealisticShading = ( editor.viewportShading === 'realistic' );
+
+		samplesText.setHidden( ! isRealisticShading );
+		samplesUnitText.setHidden( ! isRealisticShading );
+
+		container.setBottom( isRealisticShading ? '32px' : '20px' );
+
+	} );
 
 	return container;
 

--- a/editor/js/Viewport.Pathtracer.js
+++ b/editor/js/Viewport.Pathtracer.js
@@ -67,6 +67,14 @@ function ViewportPathtracer( renderer ) {
 
 	}
 
+	function getSamples() {
+
+		if ( pathTracer === null ) return;
+
+		return pathTracer.samples;
+
+	}
+
 	return {
 		init: init,
 		setSize: setSize,
@@ -74,7 +82,8 @@ function ViewportPathtracer( renderer ) {
 		setEnvironment: setEnvironment,
 		updateMaterials: updateMaterials,
 		update: update,
-		reset: reset
+		reset: reset,
+		getSamples: getSamples
 	};
 
 }

--- a/editor/js/Viewport.js
+++ b/editor/js/Viewport.js
@@ -798,6 +798,7 @@ function Viewport( editor ) {
 		if ( editor.viewportShading === 'realistic' ) {
 
 			pathtracer.update();
+			editor.signals.pathTracerUpdated.dispatch( pathtracer.getSamples() );
 
 		}
 

--- a/editor/js/libs/ui.js
+++ b/editor/js/libs/ui.js
@@ -114,6 +114,8 @@ class UIElement {
 
 		this.dom.hidden = isHidden;
 
+		return this;
+
 	}
 
 	isHidden() {


### PR DESCRIPTION
This PR added samples info in the viewport info for REALISTIC shading:



https://github.com/mrdoob/three.js/assets/1063018/98e940d9-ecae-453b-90fa-c5d33a0dd338


Preview: https://raw.githack.com/ycw/three.js/editor-viewport-info-samples-info/editor/index.html