### PR TITLE
TSL: Node - Introduce `getElementType()`

### DIFF
--- a/examples/jsm/nodes/accessors/BufferNode.js
+++ b/examples/jsm/nodes/accessors/BufferNode.js
@@ -15,6 +15,12 @@ class BufferNode extends UniformNode {
 
 	}
 
+	getElementType( builder ) {
+
+		return this.getNodeType( builder );
+
+	}
+
 	getInputType( /*builder*/ ) {
 
 		return 'buffer';

--- a/examples/jsm/nodes/core/Node.js
+++ b/examples/jsm/nodes/core/Node.js
@@ -163,6 +163,15 @@ class Node extends EventDispatcher {
 
 	}
 
+	getElementType( builder ) {
+
+		const type = this.getNodeType( builder );
+		const elementType = builder.getElementType( type );
+
+		return elementType;
+
+	}
+
 	getNodeType( builder ) {
 
 		const nodeProperties = builder.getNodeProperties( this );

--- a/examples/jsm/nodes/core/NodeBuilder.js
+++ b/examples/jsm/nodes/core/NodeBuilder.js
@@ -498,6 +498,16 @@ class NodeBuilder {
 
 	}
 
+	getElementType( type ) {
+
+		if ( type === 'mat2' ) return 'vec2';
+		if ( type === 'mat3' ) return 'vec3';
+		if ( type === 'mat4' ) return 'vec4';
+
+		return this.getComponentType( type );
+
+	}
+
 	getComponentType( type ) {
 
 		type = this.getVectorType( type );

--- a/examples/jsm/nodes/utils/ArrayElementNode.js
+++ b/examples/jsm/nodes/utils/ArrayElementNode.js
@@ -15,7 +15,10 @@ class ArrayElementNode extends Node { // @TODO: If extending from TempNode it br
 
 	getNodeType( builder ) {
 
-		return this.node.getNodeType( builder );
+		const type = this.node.getNodeType( builder );
+		const elementType = builder.getElementType( type );
+
+		return elementType;
 
 	}
 

--- a/examples/jsm/nodes/utils/ArrayElementNode.js
+++ b/examples/jsm/nodes/utils/ArrayElementNode.js
@@ -15,10 +15,7 @@ class ArrayElementNode extends Node { // @TODO: If extending from TempNode it br
 
 	getNodeType( builder ) {
 
-		const type = this.node.getNodeType( builder );
-		const elementType = builder.getElementType( type );
-
-		return elementType;
+		return this.node.getElementType( builder );
 
 	}
 


### PR DESCRIPTION
**Description**

It's PR fix the use of `node.element( i )` in `mat*` and `vec*`.
