### PR TITLE
#28440 Fixed BufferGeometryUtils.mergeVertices to handle morphAttributes

### DIFF
--- a/examples/jsm/utils/BufferGeometryUtils.js
+++ b/examples/jsm/utils/BufferGeometryUtils.js
@@ -629,11 +629,11 @@ function mergeVertices( geometry, tolerance = 1e-4 ) {
 			attr.normalized
 		);
 
-		const morphAttrCollection = geometry.morphAttributes[ name ];
-		if ( morphAttrCollection ) {
+		const morphAttributes = geometry.morphAttributes[ name ];
+		if ( morphAttributes ) {
 
 			if ( ! tmpMorphAttributes[ name ] ) tmpMorphAttributes[ name ] = [];
-			morphAttrCollection.forEach( ( morphAttr, i ) => {
+			morphAttributes.forEach( ( morphAttr, i ) => {
 
 				const array = new morphAttr.array.constructor( morphAttr.count * morphAttr.itemSize );
 				tmpMorphAttributes[ name ][ i ] = new morphAttr.constructor( array, morphAttr.itemSize, morphAttr.normalized );
@@ -683,7 +683,7 @@ function mergeVertices( geometry, tolerance = 1e-4 ) {
 
 				const name = attributeNames[ j ];
 				const attribute = geometry.getAttribute( name );
-				const morphAttrCollection = geometry.morphAttributes[ name ];
+				const morphAttributes = geometry.morphAttributes[ name ];
 				const itemSize = attribute.itemSize;
 				const newArray = tmpAttributes[ name ];
 				const newMorphArrays = tmpMorphAttributes[ name ];
@@ -694,11 +694,11 @@ function mergeVertices( geometry, tolerance = 1e-4 ) {
 					const setterFunc = setters[ k ];
 					newArray[ setterFunc ]( nextIndex, attribute[ getterFunc ]( index ) );
 
-					if ( morphAttrCollection ) {
+					if ( morphAttributes ) {
 
-						for ( let m = 0, ml = morphAttrCollection.length; m < ml; m ++ ) {
+						for ( let m = 0, ml = morphAttributes.length; m < ml; m ++ ) {
 
-							newMorphArrays[ m ][ setterFunc ]( nextIndex, morphAttrCollection[ m ][ getterFunc ]( index ) );
+							newMorphArrays[ m ][ setterFunc ]( nextIndex, morphAttributes[ m ][ getterFunc ]( index ) );
 
 						}
 

--- a/examples/jsm/utils/BufferGeometryUtils.js
+++ b/examples/jsm/utils/BufferGeometryUtils.js
@@ -623,20 +623,22 @@ function mergeVertices( geometry, tolerance = 1e-4 ) {
 		const name = attributeNames[ i ];
 		const attr = geometry.attributes[ name ];
 
-		tmpAttributes[ name ] = new BufferAttribute(
+		tmpAttributes[ name ] = new attr.constructor(
 			new attr.array.constructor( attr.count * attr.itemSize ),
 			attr.itemSize,
 			attr.normalized
 		);
 
-		const morphAttr = geometry.morphAttributes[ name ];
-		if ( morphAttr ) {
+		const morphAttrCollection = geometry.morphAttributes[ name ];
+		if ( morphAttrCollection ) {
 
-			tmpMorphAttributes[ name ] = new BufferAttribute(
-				new morphAttr.array.constructor( morphAttr.count * morphAttr.itemSize ),
-				morphAttr.itemSize,
-				morphAttr.normalized
-			);
+			if ( ! tmpMorphAttributes[ name ] ) tmpMorphAttributes[ name ] = [];
+			morphAttrCollection.forEach( ( morphAttr, i ) => {
+
+				const array = new morphAttr.array.constructor( morphAttr.count * morphAttr.itemSize );
+				tmpMorphAttributes[ name ][ i ] = new morphAttr.constructor( array, morphAttr.itemSize, morphAttr.normalized );
+
+			} );
 
 		}
 
@@ -681,22 +683,22 @@ function mergeVertices( geometry, tolerance = 1e-4 ) {
 
 				const name = attributeNames[ j ];
 				const attribute = geometry.getAttribute( name );
-				const morphAttr = geometry.morphAttributes[ name ];
+				const morphAttrCollection = geometry.morphAttributes[ name ];
 				const itemSize = attribute.itemSize;
-				const newarray = tmpAttributes[ name ];
+				const newArray = tmpAttributes[ name ];
 				const newMorphArrays = tmpMorphAttributes[ name ];
 
 				for ( let k = 0; k < itemSize; k ++ ) {
 
 					const getterFunc = getters[ k ];
 					const setterFunc = setters[ k ];
-					newarray[ setterFunc ]( nextIndex, attribute[ getterFunc ]( index ) );
+					newArray[ setterFunc ]( nextIndex, attribute[ getterFunc ]( index ) );
 
-					if ( morphAttr ) {
+					if ( morphAttrCollection ) {
 
-						for ( let m = 0, ml = morphAttr.length; m < ml; m ++ ) {
+						for ( let m = 0, ml = morphAttrCollection.length; m < ml; m ++ ) {
 
-							newMorphArrays[ m ][ setterFunc ]( nextIndex, morphAttr[ m ][ getterFunc ]( index ) );
+							newMorphArrays[ m ][ setterFunc ]( nextIndex, morphAttrCollection[ m ][ getterFunc ]( index ) );
 
 						}
 
@@ -720,7 +722,7 @@ function mergeVertices( geometry, tolerance = 1e-4 ) {
 
 		const tmpAttribute = tmpAttributes[ name ];
 
-		result.setAttribute( name, new BufferAttribute(
+		result.setAttribute( name, new tmpAttribute.constructor(
 			tmpAttribute.array.slice( 0, nextIndex * tmpAttribute.itemSize ),
 			tmpAttribute.itemSize,
 			tmpAttribute.normalized,
@@ -732,7 +734,7 @@ function mergeVertices( geometry, tolerance = 1e-4 ) {
 
 			const tmpMorphAttribute = tmpMorphAttributes[ name ][ j ];
 
-			result.morphAttributes[ name ][ j ] = new BufferAttribute(
+			result.morphAttributes[ name ][ j ] = new tmpMorphAttribute.constructor(
 				tmpMorphAttribute.array.slice( 0, nextIndex * tmpMorphAttribute.itemSize ),
 				tmpMorphAttribute.itemSize,
 				tmpMorphAttribute.normalized,

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   ],
   "scripts": {
     "start": "npm run dev",
-    "test": "npm run lint && npm run test-unit",
+    "test": "npm run lint && npm run test-unit && npm run test-unit-addons",
     "build": "rollup -c utils/build/rollup.config.js",
     "build-module": "rollup -c utils/build/rollup.config.js --configOnlyModule",
     "dev": "concurrently --names \"ROLLUP,HTTP\" -c \"bgBlue.bold,bgGreen.bold\" \"rollup -c utils/build/rollup.config.js -w -m inline\" \"servez -p 8080\"",
@@ -58,6 +58,7 @@
     "lint": "npm run lint-core",
     "lint-fix": "npm run lint-core -- --fix && npm run lint-addons -- --fix && npm run lint-examples -- --fix && npm run lint-docs -- --fix && npm run lint-editor -- --fix && npm run lint-playground -- --fix && npm run lint-manual -- --fix && npm run lint-test -- --fix && npm run lint-utils -- --fix",
     "test-unit": "qunit -r failonlyreporter -f !-webonly test/unit/three.source.unit.js",
+    "test-unit-addons": "qunit -r failonlyreporter -f !-webonly test/unit/three.addons.unit.js",
     "test-e2e": "node test/e2e/puppeteer.js",
     "test-e2e-cov": "node test/e2e/check-coverage.js",
     "test-treeshake": "rollup -c test/rollup.treeshake.config.js",

--- a/test/unit/addons/utils/BufferGeometryUtils.tests.js
+++ b/test/unit/addons/utils/BufferGeometryUtils.tests.js
@@ -1,0 +1,60 @@
+import { BufferGeometry } from '../../../../src/core/BufferGeometry.js';
+import { BufferAttribute } from '../../../../src/core/BufferAttribute.js';
+import * as BufferGeometryUtils from '../../../../examples/jsm/utils/BufferGeometryUtils.js';
+
+const getGeometry = () => {
+
+	const geometry = new BufferGeometry();
+
+	// square
+	const vertices = new Float32Array( [
+		- 1.0, - 1.0, 0.0, // Bottom left
+		1.0, - 1.0, 0.0, // Bottom right
+		1.0, 1.0, 0.0, // Top right
+		- 1.0, 1.0, 0.0 // Top left
+	] );
+
+	const morphVertices = new Float32Array( [
+		0.0, - 1.0, 0.0, // Bottom
+		1.0, 0.0, 0.0, // Right
+		0.0, 1.0, 0.0, // Top
+		- 1.0, 0.0, 0.0 // Left
+	] );
+
+	geometry.setAttribute( 'position', new BufferAttribute( vertices, 3 ) );
+
+	geometry.morphAttributes.position = [
+		new BufferAttribute( morphVertices, 3 )
+	];
+
+	return geometry;
+
+};
+
+export default QUnit.module( 'Addons', () => {
+
+	QUnit.module( 'Utils', () => {
+
+		QUnit.module( 'BufferGeometryUtils', () => {
+
+			QUnit.module( 'mergeVertices', () => {
+
+				QUnit.test( 'can handle morphAttributes without crashing', ( assert ) => {
+
+					const geometry = getGeometry();
+
+					const indexedGeometry = BufferGeometryUtils.mergeVertices( geometry );
+
+					assert.deepEqual( geometry.morphAttributes.position[ 0 ], indexedGeometry.morphAttributes.position[ 0 ], 'morphAttributes were handled' );
+					assert.ok( indexedGeometry.index, 'has index' );
+
+				} );
+
+			} );
+
+		} );
+
+	} );
+
+
+} );

--- a/test/unit/three.addons.unit.js
+++ b/test/unit/three.addons.unit.js
@@ -1,0 +1,3 @@
+
+//addons/utils
+import './addons/utils/BufferGeometryUtils.tests.js';

--- a/test/unit/three.source.unit.js
+++ b/test/unit/three.source.unit.js
@@ -285,5 +285,3 @@ import './src/textures/Source.tests.js';
 import './src/textures/Texture.tests.js';
 import './src/textures/VideoTexture.tests.js';
 
-//addons
-import './addons/utils/BufferGeometryUtils.tests.js';

--- a/test/unit/three.source.unit.js
+++ b/test/unit/three.source.unit.js
@@ -284,3 +284,6 @@ import './src/textures/FramebufferTexture.tests.js';
 import './src/textures/Source.tests.js';
 import './src/textures/Texture.tests.js';
 import './src/textures/VideoTexture.tests.js';
+
+//addons
+import './addons/utils/BufferGeometryUtils.tests.js';

--- a/test/unit/three.source.unit.js
+++ b/test/unit/three.source.unit.js
@@ -284,4 +284,3 @@ import './src/textures/FramebufferTexture.tests.js';
 import './src/textures/Source.tests.js';
 import './src/textures/Texture.tests.js';
 import './src/textures/VideoTexture.tests.js';
-


### PR DESCRIPTION
Fixed #28440

**Description**

Reverted `morphAttr` to be a collection of BufferAttributes from being currently a BufferAttribute by itself.

