### PR TITLE
Editor: Fixed wrong script title when editing shader

### DIFF
--- a/editor/js/Script.js
+++ b/editor/js/Script.js
@@ -359,16 +359,49 @@ function Script( editor ) {
 
 	} );
 
+	function setTitle( object, script ) {
+
+		if ( typeof script === 'object' ) {
+
+			title.setValue( object.name + ' / ' + script.name );
+
+		} else {
+
+			switch ( script ) {
+
+				case 'vertexShader':
+
+					title.setValue( object.material.name + ' / Vertex Shader' ); // TODO: l10n
+					break;
+
+				case 'fragmentShader':
+
+					title.setValue( object.material.name + ' / Fragment Shader' ); // TODO: l10n
+					break;
+
+				case 'programInfo':
+
+					title.setValue( object.material.name + ' / Program Properties ' ); // TODO: l10n
+					break;
+
+				default:
+
+					throw new Error( 'setTitle: Unknown script' );
+
+			}
+
+		}
+
+	}
+
 	signals.editScript.add( function ( object, script ) {
 
-		let mode, name, source;
+		let mode, source;
 
 		if ( typeof ( script ) === 'object' ) {
 
 			mode = 'javascript';
-			name = script.name;
 			source = script.source;
-			title.setValue( object.name + ' / ' + name );
 
 		} else {
 
@@ -377,7 +410,6 @@ function Script( editor ) {
 				case 'vertexShader':
 
 					mode = 'glsl';
-					name = 'Vertex Shader';
 					source = object.material.vertexShader || '';
 
 					break;
@@ -385,7 +417,6 @@ function Script( editor ) {
 				case 'fragmentShader':
 
 					mode = 'glsl';
-					name = 'Fragment Shader';
 					source = object.material.fragmentShader || '';
 
 					break;
@@ -393,7 +424,6 @@ function Script( editor ) {
 				case 'programInfo':
 
 					mode = 'json';
-					name = 'Program Properties';
 					const json = {
 						defines: object.material.defines,
 						uniforms: object.material.uniforms,
@@ -401,11 +431,17 @@ function Script( editor ) {
 					};
 					source = JSON.stringify( json, null, '\t' );
 
+					break;
+
+				default:
+
+					throw new Error( 'editScript: Unknown script' );
+
 			}
 
-			title.setValue( object.material.name + ' / ' + name );
-
 		}
+
+		setTitle( object, script );
 
 		currentMode = mode;
 		currentScript = script;
@@ -431,11 +467,11 @@ function Script( editor ) {
 
 	signals.objectChanged.add( function ( object ) {
 
-		if ( object === currentObject ) {
+		if ( object !== currentObject ) return;
 
-			title.setValue( currentObject.name + ' / ' + currentScript.name );
+		if ( [ 'programInfo', 'vertexShader', 'fragmentShader' ].includes( currentScript ) ) return;
 
-		}
+		setTitle( currentObject, currentScript );
 
 	} );
 
@@ -443,9 +479,19 @@ function Script( editor ) {
 
 		if ( script === currentScript ) {
 
-			title.setValue( currentObject.name + ' / ' + currentScript.name );
+			setTitle( currentObject, currentScript );
 
 		}
+
+	} );
+
+	signals.materialChanged.add( function ( object, slot ) {
+
+		if ( object !== currentObject ) return;
+
+		// TODO: Adds multi-material support
+
+		setTitle( currentObject, currentScript );
 
 	} );
 


### PR DESCRIPTION
The issue: When users edit shader in script editor, and then rename the material they're editing

then, the script title becomes  ... `{objectname} / undefined`,

which should be ... `{materialname} / XXX Shader`.

The bug demo:

https://github.com/mrdoob/three.js/assets/1063018/6b4a5a46-b895-4fa4-afdc-edd935a1632e

With this PR:


https://github.com/mrdoob/three.js/assets/1063018/e9050bac-9d82-4779-9000-b93a0dab0e5a



Details:

- Renaming material will dispatch materialChanged followed by objectChanged, so we've to guard objectChanged from setting title (this is the cause of the bug)

- Added setTitle to set title in single place (yet l10n)

- Added missing `default` in `switch`es, this is not related to the bug, but I found it helpful during debugging.


