### PR TITLE
WebGLRenderer: Ensure correct clear after transmission.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1533,6 +1533,12 @@ class WebGLRenderer {
 
 			_this.toneMapping = currentToneMapping;
 
+			// buffers might not be writable after rendering transmission which is required to ensure a correct clear
+
+			state.buffers.depth.setTest( true );
+			state.buffers.depth.setMask( true );
+			state.buffers.color.setMask( true );
+
 		}
 
 		function renderObjects( renderList, scene, camera ) {


### PR DESCRIPTION
Fixed #28420.

**Description**

This PR fixes a regression introduced in #28118. 

After rendering the transmission, the depth (and color) buffer might not be writable which is required for the clear triggered via `background.render()`. Before #28118 the clear happened at the very beginning in `render()` so the buffer states were correct.

The issue mentioned in https://github.com/mrdoob/three.js/issues/28420#issuecomment-2120538236 is unrelated to this specific regression. When using `preserveDrawingBuffer: true` and setting `autoClear = false`, textured backgrounds are not compatible since they don't perform depth testing. That means they always overwrite what is present in the (preserved) color attachment which is unwanted if you head for a trails-like effects.

/cc @mrxz 