### PR TITLE
WebGLBackground: Make sure buffers are writable before clear.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1533,12 +1533,6 @@ class WebGLRenderer {
 
 			_this.toneMapping = currentToneMapping;
 
-			// buffers might not be writable after rendering transmission which is required to ensure a correct clear
-
-			state.buffers.depth.setTest( true );
-			state.buffers.depth.setMask( true );
-			state.buffers.color.setMask( true );
-
 		}
 
 		function renderObjects( renderList, scene, camera ) {

--- a/src/renderers/webgl/WebGLBackground.js
+++ b/src/renderers/webgl/WebGLBackground.js
@@ -71,6 +71,12 @@ function WebGLBackground( renderer, cubemaps, cubeuvmaps, state, objects, alpha,
 
 		if ( renderer.autoClear || forceClear ) {
 
+			// buffers might not be writable which is required to ensure a correct clear
+
+			state.buffers.depth.setTest( true );
+			state.buffers.depth.setMask( true );
+			state.buffers.color.setMask( true );
+
 			renderer.clear( renderer.autoClearColor, renderer.autoClearDepth, renderer.autoClearStencil );
 
 		}


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/28445

**Description**

As suggested in https://github.com/mrdoob/three.js/pull/28445#issuecomment-2121150156, ensuring a correct WebGL state before the background is rendered is now part of `WebGLBackground.render()`. 