### PR TITLE
WebGLRenderer: Clean up transmission clear statements

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1461,13 +1461,13 @@ class WebGLRenderer {
 			_this.getClearColor( _currentClearColor );
 			_currentClearAlpha = _this.getClearAlpha();
 
+			if ( _currentClearAlpha < 1 ) _this.setClearColor( 0xffffff, 0.5 );
+
 			if ( _renderBackground ) {
 
 				background.render( scene );
 
 			} else {
-
-				if ( _currentClearAlpha < 1 ) _this.setClearColor( 0xffffff, 0.5 );
 
 				_this.clear();
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1460,11 +1460,18 @@ class WebGLRenderer {
 
 			_this.getClearColor( _currentClearColor );
 			_currentClearAlpha = _this.getClearAlpha();
-			if ( _currentClearAlpha < 1 ) _this.setClearColor( 0xffffff, 0.5 );
 
-			_this.clear();
+			if ( _renderBackground ) {
 
-			if ( _renderBackground ) background.render( scene );
+				background.render( scene );
+
+			} else {
+
+				if ( _currentClearAlpha < 1 ) _this.setClearColor( 0xffffff, 0.5 );
+
+				_this.clear();
+
+			}
 
 			// Turn off the features which can affect the frag color for opaque objects pass.
 			// Otherwise they are applied twice in opaque objects pass and transmission objects pass.


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/28434#discussion_r1607948997

**Description**

Ensure clear is not called twice.