### PR TITLE
WebGPURenderer: Fix shadow layers

### DIFF
--- a/examples/jsm/nodes/lighting/AnalyticLightNode.js
+++ b/examples/jsm/nodes/lighting/AnalyticLightNode.js
@@ -182,7 +182,7 @@ class AnalyticLightNode extends LightingNode {
 	updateShadow( frame ) {
 
 		const { rtt, light } = this;
-		const { renderer, scene } = frame;
+		const { renderer, scene, camera } = frame;
 
 		const currentOverrideMaterial = scene.overrideMaterial;
 
@@ -191,7 +191,7 @@ class AnalyticLightNode extends LightingNode {
 		rtt.setSize( light.shadow.mapSize.width, light.shadow.mapSize.height );
 
 		light.shadow.updateMatrices( light );
-		light.shadow.camera.layers.mask = frame.camera.layers.mask;
+		light.shadow.camera.layers.mask = camera.layers.mask;
 
 		const currentToneMapping = renderer.toneMapping;
 		const currentRenderTarget = renderer.getRenderTarget();

--- a/examples/jsm/nodes/lighting/AnalyticLightNode.js
+++ b/examples/jsm/nodes/lighting/AnalyticLightNode.js
@@ -191,6 +191,7 @@ class AnalyticLightNode extends LightingNode {
 		rtt.setSize( light.shadow.mapSize.width, light.shadow.mapSize.height );
 
 		light.shadow.updateMatrices( light );
+		light.shadow.camera.layers.mask = frame.camera.layers.mask;
 
 		const currentToneMapping = renderer.toneMapping;
 		const currentRenderTarget = renderer.getRenderTarget();


### PR DESCRIPTION
Related issue: Closes https://github.com/mrdoob/three.js/issues/28438

**Description**

This fix prioritizes `camera.layers` during the renderer shadows instead of using the layers independently.
