### PR TITLE
RenderPass: Make the render background get the correct Alpha

### DIFF
--- a/examples/jsm/postprocessing/RenderPass.js
+++ b/examples/jsm/postprocessing/RenderPass.js
@@ -42,13 +42,14 @@ class RenderPass extends Pass {
 		if ( this.clearColor !== null ) {
 
 			renderer.getClearColor( this._oldClearColor );
-			renderer.setClearColor( this.clearColor );
+			oldClearAlpha = renderer.getClearAlpha();
+
+			renderer.setClearColor( this.clearColor, oldClearAlpha );
 
 		}
 
 		if ( this.clearAlpha !== null ) {
 
-			oldClearAlpha = renderer.getClearAlpha();
 			renderer.setClearAlpha( this.clearAlpha );
 
 		}

--- a/examples/jsm/postprocessing/RenderPass.js
+++ b/examples/jsm/postprocessing/RenderPass.js
@@ -42,14 +42,13 @@ class RenderPass extends Pass {
 		if ( this.clearColor !== null ) {
 
 			renderer.getClearColor( this._oldClearColor );
-			oldClearAlpha = renderer.getClearAlpha();
-
-			renderer.setClearColor( this.clearColor, oldClearAlpha );
+			renderer.setClearColor( this.clearColor, renderer.getClearAlpha() );
 
 		}
 
 		if ( this.clearAlpha !== null ) {
 
+			oldClearAlpha = renderer.getClearAlpha();
 			renderer.setClearAlpha( this.clearAlpha );
 
 		}


### PR DESCRIPTION

Description

There is a bug in **`RenderPass`** ，The method `renderer.setClearColor( this.clearColor )` was called before `renderer.getClearAlpha(),` making the `oldClearAlpha = 1` .
