### PR TITLE
RenderPass: Make the render background get the correct Alpha

### DIFF
--- a/examples/jsm/postprocessing/RenderPass.js
+++ b/examples/jsm/postprocessing/RenderPass.js
@@ -42,7 +42,7 @@ class RenderPass extends Pass {
 		if ( this.clearColor !== null ) {
 
 			renderer.getClearColor( this._oldClearColor );
-			renderer.setClearColor( this.clearColor );
+			renderer.setClearColor( this.clearColor, renderer.getClearAlpha());
 
 		}
 


### PR DESCRIPTION
Description

There is a bug in RenderPass ，The method renderer.setClearColor( this.clearColor ) was called before renderer.getClearAlpha(), making the oldClearAlpha = 1 .
