### PR TITLE
RenderPass: Make the render background get the correct Alpha

### DIFF
--- a/examples/jsm/postprocessing/RenderPass.js
+++ b/examples/jsm/postprocessing/RenderPass.js
@@ -42,7 +42,7 @@ class RenderPass extends Pass {
 		if ( this.clearColor !== null ) {
 
 			renderer.getClearColor( this._oldClearColor );
-			renderer.setClearColor( this.clearColor );
+			renderer.setClearColor( this.clearColor, renderer.getClearAlpha() );
 
 		}
 


### PR DESCRIPTION
Description

There's a bug in `RenderPass`.Before getting the `oldClearAlpha = renderer.getClearAlpha()`, the method `renderer.setClearColor` was called to make the `oldClearAlpha=1`.

