### PR TITLE
DepthTexture: Update depth + stencil textures to work with multi sample RTT, make formats consistent

### DIFF
--- a/docs/api/en/textures/DepthTexture.html
+++ b/docs/api/en/textures/DepthTexture.html
@@ -33,10 +33,7 @@
 
 			[page:Number height] -- height of the texture.<br />
 
-			[page:Constant type] -- Default is [page:Textures THREE.UnsignedIntType]
-			when using [page:Textures DepthFormat] and [page:Textures THREE.UnsignedInt248Type] 
-			when using [page:Textures DepthStencilFormat].
-			See [page:Textures type constants] for other choices.<br />
+			[page:Constant type] -- Default is [page:Textures THREE.UnsignedIntType]. See [page:DepthTexture DepthTexture.type] for other choices.<br />
 
 			[page:Constant mapping] -- See [page:Textures mapping mode constants] for
 			details.<br />
@@ -87,10 +84,14 @@
 
 		<h3>[page:Texture.type type]</h3>
 		<p>
-			Default is [page:Textures THREE.UnsignedIntType] when using [page:Textures DepthFormat] 
-			and [page:Textures THREE.UnsignedInt248Type] when using
-			[page:Textures DepthStencilFormat]. See [page:Textures format constants]
-			for details.<br />
+			Default is [page:Textures THREE.UnsignedIntType]. The following are options and how they map to internal
+			gl depth format types depending on the stencil format, as well:
+
+			[page:Textures THREE.UnsignedIntType] -- Uses DEPTH_COMPONENT24 or DEPTH24_STENCIL8 internally.<br />
+
+			[page:Textures THREE.FloatType] -- Uses DEPTH_COMPONENT32F or DEPTH32F_STENCIL8 internally.<br />
+
+			[page:Textures THREE.UnsignedShortType] -- Uses DEPTH_COMPONENT16 internally. Stencil buffer is unsupported when using this type.<br />
 		</p>
 
 		<h3>[page:Texture.magFilter magFilter]</h3>

--- a/examples/webgl_depth_texture.html
+++ b/examples/webgl_depth_texture.html
@@ -86,11 +86,12 @@
 
 			const params = {
 				format: THREE.DepthFormat,
-				type: THREE.UnsignedShortType
+				type: THREE.UnsignedShortType,
+				samples: 0,
 			};
 
 			const formats = { DepthFormat: THREE.DepthFormat, DepthStencilFormat: THREE.DepthStencilFormat };
-			const types = { UnsignedShortType: THREE.UnsignedShortType, UnsignedIntType: THREE.UnsignedIntType, UnsignedInt248Type: THREE.UnsignedInt248Type };
+			const types = { UnsignedShortType: THREE.UnsignedShortType, UnsignedIntType: THREE.UnsignedIntType, FloatType: THREE.FloatType };
 
 			init();
 
@@ -130,6 +131,7 @@
 
 				gui.add( params, 'format', formats ).onChange( setupRenderTarget );
 				gui.add( params, 'type', types ).onChange( setupRenderTarget );
+				gui.add( params, 'samples', 0, 16, 1 ).onChange( setupRenderTarget );
 				gui.open();
 
 			}
@@ -138,13 +140,17 @@
 
 				if ( target ) target.dispose();
 
-				const format = parseFloat( params.format );
-				const type = parseFloat( params.type );
+				const format = parseInt( params.format );
+				const type = parseInt( params.type );
+				const samples = parseInt( params.samples );
 
-				target = new THREE.WebGLRenderTarget( window.innerWidth, window.innerHeight );
+				const dpr = renderer.getPixelRatio();
+				target = new THREE.WebGLRenderTarget( window.innerWidth * dpr, window.innerHeight * dpr );
 				target.texture.minFilter = THREE.NearestFilter;
 				target.texture.magFilter = THREE.NearestFilter;
 				target.stencilBuffer = ( format === THREE.DepthStencilFormat ) ? true : false;
+				target.samples = samples;
+
 				target.depthTexture = new THREE.DepthTexture();
 				target.depthTexture.format = format;
 				target.depthTexture.type = type;

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -1441,15 +1441,15 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		if ( renderTarget.depthBuffer ) {
 
+			const samples = getRenderTargetSamples( renderTarget );
+			const isUseMultisampledRTT = useMultisampledRTT( renderTarget );
 			if ( renderTarget.stencilBuffer ) {
 
-				const samples = getRenderTargetSamples( renderTarget );
-
-				if ( isMultisample && useMultisampledRTT( renderTarget ) === false ) {
+				if ( isMultisample && isUseMultisampledRTT === false ) {
 
 					_gl.renderbufferStorageMultisample( _gl.RENDERBUFFER, samples, _gl.DEPTH24_STENCIL8, renderTarget.width, renderTarget.height );
 
-				} else if ( useMultisampledRTT( renderTarget ) ) {
+				} else if ( isUseMultisampledRTT ) {
 
 					multisampledRTTExt.renderbufferStorageMultisampleEXT( _gl.RENDERBUFFER, samples, _gl.DEPTH24_STENCIL8, renderTarget.width, renderTarget.height );
 
@@ -1459,14 +1459,13 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 				}
 
-
 				_gl.framebufferRenderbuffer( _gl.FRAMEBUFFER, _gl.DEPTH_STENCIL_ATTACHMENT, _gl.RENDERBUFFER, renderbuffer );
 
 			} else {
 
 				let glInternalFormat = _gl.DEPTH_COMPONENT24;
 
-				if ( isMultisample || useMultisampledRTT( renderTarget ) ) {
+				if ( isMultisample || isUseMultisampledRTT ) {
 
 					const depthTexture = renderTarget.depthTexture;
 
@@ -1484,9 +1483,8 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 					}
 
-					const samples = getRenderTargetSamples( renderTarget );
 
-					if ( useMultisampledRTT( renderTarget ) ) {
+					if ( isUseMultisampledRTT ) {
 
 						multisampledRTTExt.renderbufferStorageMultisampleEXT( _gl.RENDERBUFFER, samples, glInternalFormat, renderTarget.width, renderTarget.height );
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -1439,68 +1439,72 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		_gl.bindRenderbuffer( _gl.RENDERBUFFER, renderbuffer );
 
-		if ( renderTarget.depthBuffer && ! renderTarget.stencilBuffer ) {
+		if ( renderTarget.depthBuffer ) {
 
-			let glInternalFormat = _gl.DEPTH_COMPONENT24;
-
-			if ( isMultisample || useMultisampledRTT( renderTarget ) ) {
-
-				const depthTexture = renderTarget.depthTexture;
-
-				if ( depthTexture && depthTexture.isDepthTexture ) {
-
-					if ( depthTexture.type === FloatType ) {
-
-						glInternalFormat = _gl.DEPTH_COMPONENT32F;
-
-					} else if ( depthTexture.type === UnsignedIntType ) {
-
-						glInternalFormat = _gl.DEPTH_COMPONENT24;
-
-					}
-
-				}
+			if ( renderTarget.stencilBuffer ) {
 
 				const samples = getRenderTargetSamples( renderTarget );
 
-				if ( useMultisampledRTT( renderTarget ) ) {
+				if ( isMultisample && useMultisampledRTT( renderTarget ) === false ) {
 
-					multisampledRTTExt.renderbufferStorageMultisampleEXT( _gl.RENDERBUFFER, samples, glInternalFormat, renderTarget.width, renderTarget.height );
+					_gl.renderbufferStorageMultisample( _gl.RENDERBUFFER, samples, _gl.DEPTH24_STENCIL8, renderTarget.width, renderTarget.height );
+
+				} else if ( useMultisampledRTT( renderTarget ) ) {
+
+					multisampledRTTExt.renderbufferStorageMultisampleEXT( _gl.RENDERBUFFER, samples, _gl.DEPTH24_STENCIL8, renderTarget.width, renderTarget.height );
 
 				} else {
 
-					_gl.renderbufferStorageMultisample( _gl.RENDERBUFFER, samples, glInternalFormat, renderTarget.width, renderTarget.height );
+					_gl.renderbufferStorage( _gl.RENDERBUFFER, _gl.DEPTH_STENCIL, renderTarget.width, renderTarget.height );
 
 				}
 
-			} else {
 
-				_gl.renderbufferStorage( _gl.RENDERBUFFER, glInternalFormat, renderTarget.width, renderTarget.height );
-
-			}
-
-			_gl.framebufferRenderbuffer( _gl.FRAMEBUFFER, _gl.DEPTH_ATTACHMENT, _gl.RENDERBUFFER, renderbuffer );
-
-		} else if ( renderTarget.depthBuffer && renderTarget.stencilBuffer ) {
-
-			const samples = getRenderTargetSamples( renderTarget );
-
-			if ( isMultisample && useMultisampledRTT( renderTarget ) === false ) {
-
-				_gl.renderbufferStorageMultisample( _gl.RENDERBUFFER, samples, _gl.DEPTH24_STENCIL8, renderTarget.width, renderTarget.height );
-
-			} else if ( useMultisampledRTT( renderTarget ) ) {
-
-				multisampledRTTExt.renderbufferStorageMultisampleEXT( _gl.RENDERBUFFER, samples, _gl.DEPTH24_STENCIL8, renderTarget.width, renderTarget.height );
+				_gl.framebufferRenderbuffer( _gl.FRAMEBUFFER, _gl.DEPTH_STENCIL_ATTACHMENT, _gl.RENDERBUFFER, renderbuffer );
 
 			} else {
 
-				_gl.renderbufferStorage( _gl.RENDERBUFFER, _gl.DEPTH_STENCIL, renderTarget.width, renderTarget.height );
+				let glInternalFormat = _gl.DEPTH_COMPONENT24;
+
+				if ( isMultisample || useMultisampledRTT( renderTarget ) ) {
+
+					const depthTexture = renderTarget.depthTexture;
+
+					if ( depthTexture && depthTexture.isDepthTexture ) {
+
+						if ( depthTexture.type === FloatType ) {
+
+							glInternalFormat = _gl.DEPTH_COMPONENT32F;
+
+						} else if ( depthTexture.type === UnsignedIntType ) {
+
+							glInternalFormat = _gl.DEPTH_COMPONENT24;
+
+						}
+
+					}
+
+					const samples = getRenderTargetSamples( renderTarget );
+
+					if ( useMultisampledRTT( renderTarget ) ) {
+
+						multisampledRTTExt.renderbufferStorageMultisampleEXT( _gl.RENDERBUFFER, samples, glInternalFormat, renderTarget.width, renderTarget.height );
+
+					} else {
+
+						_gl.renderbufferStorageMultisample( _gl.RENDERBUFFER, samples, glInternalFormat, renderTarget.width, renderTarget.height );
+
+					}
+
+				} else {
+
+					_gl.renderbufferStorage( _gl.RENDERBUFFER, glInternalFormat, renderTarget.width, renderTarget.height );
+
+				}
+
+				_gl.framebufferRenderbuffer( _gl.FRAMEBUFFER, _gl.DEPTH_ATTACHMENT, _gl.RENDERBUFFER, renderbuffer );
 
 			}
-
-
-			_gl.framebufferRenderbuffer( _gl.FRAMEBUFFER, _gl.DEPTH_STENCIL_ATTACHMENT, _gl.RENDERBUFFER, renderbuffer );
 
 		} else {
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -1,4 +1,4 @@
-import { LinearFilter, LinearMipmapLinearFilter, LinearMipmapNearestFilter, NearestFilter, NearestMipmapLinearFilter, NearestMipmapNearestFilter, RGBAFormat, DepthFormat, DepthStencilFormat, UnsignedIntType, FloatType, MirroredRepeatWrapping, ClampToEdgeWrapping, RepeatWrapping, UnsignedByteType, NoColorSpace, LinearSRGBColorSpace, NeverCompare, AlwaysCompare, LessCompare, LessEqualCompare, EqualCompare, GreaterEqualCompare, GreaterCompare, NotEqualCompare, SRGBTransfer, LinearTransfer, UnsignedShortType } from '../../constants.js';
+import { LinearFilter, LinearMipmapLinearFilter, LinearMipmapNearestFilter, NearestFilter, NearestMipmapLinearFilter, NearestMipmapNearestFilter, RGBAFormat, DepthFormat, DepthStencilFormat, UnsignedIntType, FloatType, MirroredRepeatWrapping, ClampToEdgeWrapping, RepeatWrapping, UnsignedByteType, NoColorSpace, LinearSRGBColorSpace, NeverCompare, AlwaysCompare, LessCompare, LessEqualCompare, EqualCompare, GreaterEqualCompare, GreaterCompare, NotEqualCompare, SRGBTransfer, LinearTransfer, UnsignedShortType, UnsignedInt248Type } from '../../constants.js';
 import { createElementNS } from '../../utils.js';
 import { ColorManagement } from '../../math/ColorManagement.js';
 import { Vector2 } from '../../math/Vector2.js';
@@ -201,7 +201,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 		let glInternalFormat;
 		if ( useStencil ) {
 
-			if ( depthType === null || depthType === UnsignedIntType ) {
+			if ( depthType === null || depthType === UnsignedIntType || depthType === UnsignedInt248Type ) {
 
 				glInternalFormat = _gl.DEPTH24_STENCIL8;
 
@@ -218,7 +218,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		} else {
 
-			if ( depthType === null || depthType === UnsignedIntType ) {
+			if ( depthType === null || depthType === UnsignedIntType || depthType === UnsignedInt248Type ) {
 
 				glInternalFormat = _gl.DEPTH_COMPONENT24;
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -1459,7 +1459,6 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 	}
 
-
 	// Setup storage for internal depth/stencil buffers and bind to correct framebuffer
 	function setupRenderBufferStorage( renderbuffer, renderTarget, isMultisample ) {
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -1446,6 +1446,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 			const depthTexture = renderTarget.depthTexture;
 			if ( renderTarget.stencilBuffer ) {
 
+				// TODO: enable other attach types
 				glInternalFormat = _gl.DEPTH24_STENCIL8;
 				glAttachmentType = _gl.DEPTH_STENCIL_ATTACHMENT;
 
@@ -1457,41 +1458,17 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 			const samples = getRenderTargetSamples( renderTarget );
 			const isUseMultisampledRTT = useMultisampledRTT( renderTarget );
-			if ( renderTarget.stencilBuffer ) {
+			if ( isMultisample && isUseMultisampledRTT === false ) {
 
-				if ( isMultisample && isUseMultisampledRTT === false ) {
+				_gl.renderbufferStorageMultisample( _gl.RENDERBUFFER, samples, glInternalFormat, renderTarget.width, renderTarget.height );
 
-					_gl.renderbufferStorageMultisample( _gl.RENDERBUFFER, samples, glInternalFormat, renderTarget.width, renderTarget.height );
+			} else if ( isUseMultisampledRTT ) {
 
-				} else if ( isUseMultisampledRTT ) {
-
-					multisampledRTTExt.renderbufferStorageMultisampleEXT( _gl.RENDERBUFFER, samples, glInternalFormat, renderTarget.width, renderTarget.height );
-
-				} else {
-
-					_gl.renderbufferStorage( _gl.RENDERBUFFER, glInternalFormat, renderTarget.width, renderTarget.height );
-
-				}
+				multisampledRTTExt.renderbufferStorageMultisampleEXT( _gl.RENDERBUFFER, samples, glInternalFormat, renderTarget.width, renderTarget.height );
 
 			} else {
 
-				if ( isMultisample || isUseMultisampledRTT ) {
-
-					if ( isUseMultisampledRTT ) {
-
-						multisampledRTTExt.renderbufferStorageMultisampleEXT( _gl.RENDERBUFFER, samples, glInternalFormat, renderTarget.width, renderTarget.height );
-
-					} else {
-
-						_gl.renderbufferStorageMultisample( _gl.RENDERBUFFER, samples, glInternalFormat, renderTarget.width, renderTarget.height );
-
-					}
-
-				} else {
-
-					_gl.renderbufferStorage( _gl.RENDERBUFFER, glInternalFormat, renderTarget.width, renderTarget.height );
-
-				}
+				_gl.renderbufferStorage( _gl.RENDERBUFFER, glInternalFormat, renderTarget.width, renderTarget.height );
 
 			}
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -1469,11 +1469,9 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 				} else {
 
-					_gl.renderbufferStorage( _gl.RENDERBUFFER, _gl.DEPTH_STENCIL, renderTarget.width, renderTarget.height );
+					_gl.renderbufferStorage( _gl.RENDERBUFFER, glInternalFormat, renderTarget.width, renderTarget.height );
 
 				}
-
-				_gl.framebufferRenderbuffer( _gl.FRAMEBUFFER, glAttachmentType, _gl.RENDERBUFFER, renderbuffer );
 
 			} else {
 
@@ -1495,9 +1493,9 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 				}
 
-				_gl.framebufferRenderbuffer( _gl.FRAMEBUFFER, glAttachmentType, _gl.RENDERBUFFER, renderbuffer );
-
 			}
+
+			_gl.framebufferRenderbuffer( _gl.FRAMEBUFFER, glAttachmentType, _gl.RENDERBUFFER, renderbuffer );
 
 		} else {
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -710,21 +710,40 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 			if ( texture.isDepthTexture ) {
 
-				// populate depth texture with dummy data
+				// retrieve the depth attachment types
+				const depthType = texture.type;
+				if ( texture.format === DepthStencilFormat ) {
 
-				glInternalFormat = _gl.DEPTH_COMPONENT16;
+					if ( depthType === null || depthType === UnsignedIntType ) {
 
-				if ( texture.type === FloatType ) {
+						glInternalFormat = _gl.DEPTH24_STENCIL8;
 
-					glInternalFormat = _gl.DEPTH_COMPONENT32F;
+					} else if ( depthType === FloatType ) {
 
-				} else if ( texture.type === UnsignedIntType ) {
+						glInternalFormat = _gl.DEPTH32F_STENCIL8;
 
-					glInternalFormat = _gl.DEPTH_COMPONENT24;
+					} else if ( depthType === UnsignedShortType ) {
 
-				} else if ( texture.type === UnsignedInt248Type ) {
+						glInternalFormat = _gl.DEPTH24_STENCIL8;
+						console.warn( 'DepthTexture: 16 bit depth attachment is not supported with stencil. Using 24-bit attachment.' );
 
-					glInternalFormat = _gl.DEPTH24_STENCIL8;
+					}
+
+				} else {
+
+					if ( depthType === null || depthType === UnsignedIntType ) {
+
+						glInternalFormat = _gl.DEPTH_COMPONENT24;
+
+					} else if ( depthType === FloatType ) {
+
+						glInternalFormat = _gl.DEPTH_COMPONENT32F;
+
+					} else if ( depthType === UnsignedShortType ) {
+
+						glInternalFormat = _gl.DEPTH_COMPONENT16;
+
+					}
 
 				}
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -1441,17 +1441,31 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		if ( renderTarget.depthBuffer ) {
 
+			let glInternalFormat = _gl.DEPTH_COMPONENT24;
+			let glAttachmentType = _gl.DEPTH_ATTACHMENT;
+			const depthTexture = renderTarget.depthTexture;
+			if ( renderTarget.stencilBuffer ) {
+
+				glInternalFormat = _gl.DEPTH24_STENCIL8;
+				glAttachmentType = _gl.DEPTH_STENCIL_ATTACHMENT;
+
+			} else if ( depthTexture && depthTexture.isDepthTexture && depthTexture.type === FloatType ) {
+
+				glInternalFormat = _gl.DEPTH_COMPONENT32F;
+
+			}
+
 			const samples = getRenderTargetSamples( renderTarget );
 			const isUseMultisampledRTT = useMultisampledRTT( renderTarget );
 			if ( renderTarget.stencilBuffer ) {
 
 				if ( isMultisample && isUseMultisampledRTT === false ) {
 
-					_gl.renderbufferStorageMultisample( _gl.RENDERBUFFER, samples, _gl.DEPTH24_STENCIL8, renderTarget.width, renderTarget.height );
+					_gl.renderbufferStorageMultisample( _gl.RENDERBUFFER, samples, glInternalFormat, renderTarget.width, renderTarget.height );
 
 				} else if ( isUseMultisampledRTT ) {
 
-					multisampledRTTExt.renderbufferStorageMultisampleEXT( _gl.RENDERBUFFER, samples, _gl.DEPTH24_STENCIL8, renderTarget.width, renderTarget.height );
+					multisampledRTTExt.renderbufferStorageMultisampleEXT( _gl.RENDERBUFFER, samples, glInternalFormat, renderTarget.width, renderTarget.height );
 
 				} else {
 
@@ -1459,30 +1473,11 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 				}
 
-				_gl.framebufferRenderbuffer( _gl.FRAMEBUFFER, _gl.DEPTH_STENCIL_ATTACHMENT, _gl.RENDERBUFFER, renderbuffer );
+				_gl.framebufferRenderbuffer( _gl.FRAMEBUFFER, glAttachmentType, _gl.RENDERBUFFER, renderbuffer );
 
 			} else {
 
-				let glInternalFormat = _gl.DEPTH_COMPONENT24;
-
 				if ( isMultisample || isUseMultisampledRTT ) {
-
-					const depthTexture = renderTarget.depthTexture;
-
-					if ( depthTexture && depthTexture.isDepthTexture ) {
-
-						if ( depthTexture.type === FloatType ) {
-
-							glInternalFormat = _gl.DEPTH_COMPONENT32F;
-
-						} else if ( depthTexture.type === UnsignedIntType ) {
-
-							glInternalFormat = _gl.DEPTH_COMPONENT24;
-
-						}
-
-					}
-
 
 					if ( isUseMultisampledRTT ) {
 
@@ -1500,7 +1495,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 				}
 
-				_gl.framebufferRenderbuffer( _gl.FRAMEBUFFER, _gl.DEPTH_ATTACHMENT, _gl.RENDERBUFFER, renderbuffer );
+				_gl.framebufferRenderbuffer( _gl.FRAMEBUFFER, glAttachmentType, _gl.RENDERBUFFER, renderbuffer );
 
 			}
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -1441,30 +1441,51 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		if ( renderTarget.depthBuffer ) {
 
-			let glInternalFormat = _gl.DEPTH_COMPONENT24;
-			let glAttachmentType = _gl.DEPTH_ATTACHMENT;
+			// retrieve the depth attachment types
+			let glInternalFormat;
+			let glAttachmentType;
 			const depthTexture = renderTarget.depthTexture;
+			const requiresFloat = depthTexture && depthTexture.isDepthTexture && depthTexture.type === FloatType;
 			if ( renderTarget.stencilBuffer ) {
 
-				// TODO: enable other attach types
-				glInternalFormat = _gl.DEPTH24_STENCIL8;
 				glAttachmentType = _gl.DEPTH_STENCIL_ATTACHMENT;
 
-			} else if ( depthTexture && depthTexture.isDepthTexture && depthTexture.type === FloatType ) {
+				if ( requiresFloat ) {
 
-				glInternalFormat = _gl.DEPTH_COMPONENT32F;
+					glInternalFormat = _gl.DEPTH32F_STENCIL8;
+
+				} else {
+
+					glInternalFormat = _gl.DEPTH24_STENCIL8;
+
+				}
+
+			} else {
+
+				glAttachmentType = _gl.DEPTH_ATTACHMENT;
+
+				if ( requiresFloat ) {
+
+					glInternalFormat = _gl.DEPTH_COMPONENT32F;
+
+				} else {
+
+					glInternalFormat = _gl.DEPTH_COMPONENT24;
+
+				}
 
 			}
 
+			// set up the attachment
 			const samples = getRenderTargetSamples( renderTarget );
 			const isUseMultisampledRTT = useMultisampledRTT( renderTarget );
-			if ( isMultisample && isUseMultisampledRTT === false ) {
-
-				_gl.renderbufferStorageMultisample( _gl.RENDERBUFFER, samples, glInternalFormat, renderTarget.width, renderTarget.height );
-
-			} else if ( isUseMultisampledRTT ) {
+			if ( isUseMultisampledRTT ) {
 
 				multisampledRTTExt.renderbufferStorageMultisampleEXT( _gl.RENDERBUFFER, samples, glInternalFormat, renderTarget.width, renderTarget.height );
+
+			} else if ( isMultisample ) {
+
+				_gl.renderbufferStorageMultisample( _gl.RENDERBUFFER, samples, glInternalFormat, renderTarget.width, renderTarget.height );
 
 			} else {
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -1,4 +1,4 @@
-import { LinearFilter, LinearMipmapLinearFilter, LinearMipmapNearestFilter, NearestFilter, NearestMipmapLinearFilter, NearestMipmapNearestFilter, RGBAFormat, DepthFormat, DepthStencilFormat, UnsignedIntType, UnsignedInt248Type, FloatType, MirroredRepeatWrapping, ClampToEdgeWrapping, RepeatWrapping, UnsignedByteType, NoColorSpace, LinearSRGBColorSpace, NeverCompare, AlwaysCompare, LessCompare, LessEqualCompare, EqualCompare, GreaterEqualCompare, GreaterCompare, NotEqualCompare, SRGBTransfer, LinearTransfer } from '../../constants.js';
+import { LinearFilter, LinearMipmapLinearFilter, LinearMipmapNearestFilter, NearestFilter, NearestMipmapLinearFilter, NearestMipmapNearestFilter, RGBAFormat, DepthFormat, DepthStencilFormat, UnsignedIntType, UnsignedInt248Type, FloatType, MirroredRepeatWrapping, ClampToEdgeWrapping, RepeatWrapping, UnsignedByteType, NoColorSpace, LinearSRGBColorSpace, NeverCompare, AlwaysCompare, LessCompare, LessEqualCompare, EqualCompare, GreaterEqualCompare, GreaterCompare, NotEqualCompare, SRGBTransfer, LinearTransfer, UnsignedShortType } from '../../constants.js';
 import { createElementNS } from '../../utils.js';
 import { ColorManagement } from '../../math/ColorManagement.js';
 import { Vector2 } from '../../math/Vector2.js';
@@ -1445,18 +1445,23 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 			let glInternalFormat;
 			let glAttachmentType;
 			const depthTexture = renderTarget.depthTexture;
-			const requiresFloat = depthTexture && depthTexture.isDepthTexture && depthTexture.type === FloatType;
+			const depthType = depthTexture && depthTexture.isDepthTexture ? depthTexture.type : null;
 			if ( renderTarget.stencilBuffer ) {
 
 				glAttachmentType = _gl.DEPTH_STENCIL_ATTACHMENT;
 
-				if ( requiresFloat ) {
+				if ( depthType === null || depthType === UnsignedIntType ) {
+
+					glInternalFormat = _gl.DEPTH24_STENCIL8;
+
+				} else if ( depthType === FloatType ) {
 
 					glInternalFormat = _gl.DEPTH32F_STENCIL8;
 
-				} else {
+				} else if ( depthType === UnsignedShortType ) {
 
 					glInternalFormat = _gl.DEPTH24_STENCIL8;
+					console.warn( 'DepthTexture: 16 bit depth attachment is not supported with stencil. Using 24-bit attachment.' );
 
 				}
 
@@ -1464,13 +1469,17 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 				glAttachmentType = _gl.DEPTH_ATTACHMENT;
 
-				if ( requiresFloat ) {
+				if ( depthType === null || depthType === UnsignedIntType ) {
+
+					glInternalFormat = _gl.DEPTH_COMPONENT24;
+
+				} else if ( depthType === FloatType ) {
 
 					glInternalFormat = _gl.DEPTH_COMPONENT32F;
 
-				} else {
+				} else if ( depthType === UnsignedShortType ) {
 
-					glInternalFormat = _gl.DEPTH_COMPONENT24;
+					glInternalFormat = _gl.DEPTH_COMPONENT16;
 
 				}
 


### PR DESCRIPTION
Related issue: --

**Description**

I expect this hasn't been touched much since WebGL has been removed but there were a few issues I noticed with DepthTextures when I was experimenting with them for #28423:

- A stencil attachment could not be used with a 32F depth type.
- A stencil attachment could not be used when a multi sample render target is used.
- Using a stencil format didn't work at all unless using UnsignedInt248 type

You can see in the current [depth texture example](https://threejs.org/examples/?q=depth#webgl_depth_texture) that using a stencil buffer breaks the page. With this PR:

- DepthTexture.type is allowed to be set to FloatType, UnsignedIntType, and UnsignedShortType. If a stencil attachment is required then the appropriate internal type is selected. Stencil is unsupported for UnsignedShortType. The UnsignedInt248Type remains for backwards compatibility and does the same as UnsignedIntType.
- The internal depth attachment for the multi sample textures is now created with the same format as the assigned depth texture.
- Code redundancy has been reduced in WebGLTextures.
- The depth texture demo has been modified to test all the new options including render target samples option.