### PR TITLE
Editor: Set shortcut keys' `pointer-events` to `none`

### DIFF
--- a/editor/css/main.css
+++ b/editor/css/main.css
@@ -386,6 +386,7 @@ select {
 			font-size: 9px;
 			padding: 2px 4px;
 			right: 10px;
+			pointer-events: none;
 		}
 
 		#menubar .menu .options {


### PR DESCRIPTION
Before: (The issue: hovering on keys has different state than the submenu title, while the key is a member of the title)

https://github.com/mrdoob/three.js/assets/1063018/9bca169f-08e1-4cb8-8e83-be6c3b802b91

After: (This PR)

https://github.com/mrdoob/three.js/assets/1063018/efec314a-6782-47dd-849f-33778853f870

