### PR TITLE
Fix sorting for objects with positive view z

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1306,7 +1306,7 @@ class WebGLRenderer {
 						if ( sortObjects ) {
 
 							_vector3.setFromMatrixPosition( object.matrixWorld )
-								.applyMatrix4( _projScreenMatrix );
+								.applyMatrix4( camera.matrixWorldInverse );
 
 						}
 
@@ -1315,7 +1315,7 @@ class WebGLRenderer {
 
 						if ( material.visible ) {
 
-							currentRenderList.push( object, geometry, material, groupOrder, _vector3.z, null );
+							currentRenderList.push( object, geometry, material, groupOrder, - _vector3.z, null );
 
 						}
 
@@ -1344,7 +1344,7 @@ class WebGLRenderer {
 
 							_vector3
 								.applyMatrix4( object.matrixWorld )
-								.applyMatrix4( _projScreenMatrix );
+								.applyMatrix4( camera.matrixWorldInverse );
 
 						}
 
@@ -1359,7 +1359,7 @@ class WebGLRenderer {
 
 								if ( groupMaterial && groupMaterial.visible ) {
 
-									currentRenderList.push( object, geometry, groupMaterial, groupOrder, _vector3.z, group );
+									currentRenderList.push( object, geometry, groupMaterial, groupOrder, - _vector3.z, group );
 
 								}
 
@@ -1367,7 +1367,7 @@ class WebGLRenderer {
 
 						} else if ( material.visible ) {
 
-							currentRenderList.push( object, geometry, material, groupOrder, _vector3.z, null );
+							currentRenderList.push( object, geometry, material, groupOrder, - _vector3.z, null );
 
 						}
 


### PR DESCRIPTION
**Description**

Currently, if an object with positive z<sub>view</sub> (i.e. center "behind" the camera, but bounds still intersect frustum) is rendered using perspective projection, the computed z<sub>ndc</sub> will be positive, and sorting will not work as intended. This means it'll likely be drawn at the very end, leading to sub-optimal early depth testing and occlusion queries.

This PR changes the sorting input from z<sub>ndc</sub> to -z<sub>view</sub>, which I _think_ will work without breaking existing default and (hopefully) custom sorting.

Thoughts?

![sorting_issue](https://github.com/mrdoob/three.js/assets/115703748/4dc18fcc-57bb-4fbc-9920-874f5fca6a20)

