### PR TITLE
TSL: NodeKeywords - Cleanup

### DIFF
--- a/examples/jsm/nodes/core/NodeKeywords.js
+++ b/examples/jsm/nodes/core/NodeKeywords.js
@@ -3,7 +3,7 @@ class NodeKeywords {
 	constructor() {
 
 		this.keywords = [];
-		this.nodes = [];
+		this.nodes = {};
 		this.keywordsCallback = {};
 
 	}


### PR DESCRIPTION
Related issue: N/A

**Description**

Looks like `NodeKeywords.nodes` is used more as an object than as an array since it's accessed with a `name` which I assume is a `string`.