### PR TITLE
Editor: Fixed mismatched UITabs scrollbar background color in dark mode

### DIFF
--- a/editor/css/main.css
+++ b/editor/css/main.css
@@ -762,7 +762,7 @@ select {
 	}
 
 		.TabbedPanel .Tabs::-webkit-scrollbar {
-			background: #222;
+			background: #111;
 		}
 
 		.TabbedPanel .Tab {


### PR DESCRIPTION
The tabsbar's scrollbar background color should be equal to active tab's background color, or else there's a visual river between tabs and the panel:

light mode: (no river issue)

![no river](https://github.com/mrdoob/three.js/assets/1063018/e1f4970a-df96-41d1-995b-bf44f756b8d6)

dark mode: (river issue) 

![river](https://github.com/mrdoob/three.js/assets/1063018/4f4835d2-fc01-4dda-9187-ceed0a67b72f)

dark mode: (no river issue with this PR)

![no river in dark](https://github.com/mrdoob/three.js/assets/1063018/94df4cf9-0266-415c-ad69-165400fcc892)

