### PR TITLE
WebGPURenderer: remove deprecated method getArrayBuffer

### DIFF
--- a/examples/jsm/renderers/common/Renderer.js
+++ b/examples/jsm/renderers/common/Renderer.js
@@ -708,14 +708,6 @@ class Renderer {
 
 	}
 
-	getArrayBuffer( attribute ) { // @deprecated, r155
-
-		console.warn( 'THREE.Renderer: getArrayBuffer() is deprecated. Use getArrayBufferAsync() instead.' );
-
-		return this.getArrayBufferAsync( attribute );
-
-	}
-
 	async getArrayBufferAsync( attribute ) {
 
 		return await this.backend.getArrayBufferAsync( attribute );


### PR DESCRIPTION
Marked for deprecation r155. Remove for r165.
