### PR TITLE
Editor: Fixed bouncy view in sidebar caused by `scrollIntoView()`

### DIFF
--- a/editor/js/Sidebar.Properties.js
+++ b/editor/js/Sidebar.Properties.js
@@ -28,7 +28,6 @@ function SidebarProperties( editor ) {
 
 	}
 
-	const objectTab = getTabByTabId( container.tabs, 'objectTab' );
 	const geometryTab = getTabByTabId( container.tabs, 'geometryTab' );
 	const materialTab = getTabByTabId( container.tabs, 'materialTab' );
 	const scriptTab = getTabByTabId( container.tabs, 'scriptTab' );

--- a/editor/js/Sidebar.Properties.js
+++ b/editor/js/Sidebar.Properties.js
@@ -28,6 +28,7 @@ function SidebarProperties( editor ) {
 
 	}
 
+	const objectTab = getTabByTabId( container.tabs, 'objectTab' );
 	const geometryTab = getTabByTabId( container.tabs, 'geometryTab' );
 	const materialTab = getTabByTabId( container.tabs, 'materialTab' );
 	const scriptTab = getTabByTabId( container.tabs, 'scriptTab' );
@@ -49,17 +50,14 @@ function SidebarProperties( editor ) {
 		if ( container.selected === 'geometryTab' ) {
 
 			container.select( geometryTab.isHidden() ? 'objectTab' : 'geometryTab' );
-			geometryTab.dom.scrollIntoView( { inline: 'center', behavior: 'smooth' } );
 
 		} else if ( container.selected === 'materialTab' ) {
 
 			container.select( materialTab.isHidden() ? 'objectTab' : 'materialTab' );
-			materialTab.dom.scrollIntoView( { inline: 'center', behavior: 'smooth' } );
 
 		} else if ( container.selected === 'scriptTab' ) {
 
 			container.select( scriptTab.isHidden() ? 'objectTab' : 'scriptTab' );
-			scriptTab.dom.scrollIntoView( { inline: 'center', behavior: 'smooth' } );
 
 		}
 

--- a/editor/js/libs/ui.js
+++ b/editor/js/libs/ui.js
@@ -1130,7 +1130,6 @@ class UITabbedPanel extends UIDiv {
 		if ( tab ) {
 
 			tab.addClass( 'selected' );
-			tab.dom.scrollIntoView( { inline: 'center', behavior: 'smooth' } );
 
 		}
 
@@ -1141,6 +1140,26 @@ class UITabbedPanel extends UIDiv {
 		}
 
 		this.selected = id;
+
+		// Scrolls to tab
+		if ( tab ) {
+
+			const tabOffsetRight = tab.dom.offsetLeft + tab.dom.offsetWidth;
+			const containerWidth = this.tabsDiv.dom.getBoundingClientRect().width;
+
+			if ( tabOffsetRight > containerWidth ) {
+
+				this.tabsDiv.dom.scrollTo( { left: tabOffsetRight - containerWidth, behavior: 'smooth' } );
+
+			}
+
+			if ( tab.dom.offsetLeft < this.tabsDiv.dom.scrollLeft ) {
+
+				this.tabsDiv.dom.scrollTo( { left: 0, behavior: 'smooth' } );
+
+			}
+
+		}
 
 		return this;
 


### PR DESCRIPTION
The issue: Currently when users selected an object in a long outliner(or simply add objects), the sidebar will be scrolled way up to show active property tab (e.g. SCRIPT) into view, this causes a bouncy view. The expected behavior should be scrolling the active property tabs inside the tabsDiv container only:


https://github.com/mrdoob/three.js/assets/1063018/f232e948-20af-46d7-ad05-f169d852bd4f


This PR fixed that issue, by using `scrollTo()`, instead of `scrollIntoView()`. 


https://github.com/mrdoob/three.js/assets/1063018/cc47418a-1d75-40a8-84ae-113f1b37e882

Preview: https://raw.githack.com/ycw/three.js/editor-uitabbedpanel-no-scrollintoview/editor/index.html

Details:
- 'Scrolls to tab' performs right after panel is displayed
- 'Scrolls to tab' honors bidirectional in order to match the original `scrollIntoView` behavior:

https://github.com/mrdoob/three.js/assets/1063018/b758d315-c2ad-4871-90ab-5d7dce09e462




