### PR TITLE
WebGPURenderer: Fix WebGPU Custom Blending

### DIFF
--- a/examples/jsm/renderers/webgpu/utils/WebGPUPipelineUtils.js
+++ b/examples/jsm/renderers/webgpu/utils/WebGPUPipelineUtils.js
@@ -225,17 +225,21 @@ class WebGPUPipelineUtils {
 		let color, alpha;
 
 		const blending = material.blending;
+		const blendSrc = material.blendSrc;
+		const blendDst = material.blendDst;
+		const blendEquation = material.blendEquation;
+
 
 		if ( blending === CustomBlending ) {
 
-			const blendSrcAlpha = material.blendSrcAlpha !== null ? material.blendSrcAlpha : GPUBlendFactor.One;
-			const blendDstAlpha = material.blendDstAlpha !== null ? material.blendDstAlpha : GPUBlendFactor.Zero;
-			const blendEquationAlpha = material.blendEquationAlpha !== null ? material.blendEquationAlpha : GPUBlendFactor.Add;
+			const blendSrcAlpha = material.blendSrcAlpha !== null ? material.blendSrcAlpha : blendSrc;
+			const blendDstAlpha = material.blendDstAlpha !== null ? material.blendDstAlpha : blendDst;
+			const blendEquationAlpha = material.blendEquationAlpha !== null ? material.blendEquationAlpha : blendEquation;
 
 			color = {
-				srcFactor: this._getBlendFactor( material.blendSrc ),
-				dstFactor: this._getBlendFactor( material.blendDst ),
-				operation: this._getBlendOperation( material.blendEquation )
+				srcFactor: this._getBlendFactor( blendSrc ),
+				dstFactor: this._getBlendFactor( blendDst ),
+				operation: this._getBlendOperation( blendEquation )
 			};
 
 			alpha = {


### PR DESCRIPTION
**Description**
![image](https://github.com/mrdoob/three.js/assets/15867665/46e22c1e-6a55-47da-a6fd-e6d3b43908fc)

This PR fix an issue where the WebGPU backend was trying to use native values such as `GPUBlendFactor.One` and `GPUBlendFactor.Add` as fallback instead of Threejs constants. The changes also reflects the WebGLRenderer by falling back to `blendSrc`, `blendDst`, and `blendEquation` instead.

*This contribution is funded by [Utsubo](https://utsubo.com)*
