### PR TITLE
WebGPURenderer: ChainMap - Clean up.

### DIFF
--- a/examples/jsm/renderers/common/ChainMap.js
+++ b/examples/jsm/renderers/common/ChainMap.js
@@ -8,81 +8,51 @@ export default class ChainMap {
 
 	get( keys ) {
 
-		if ( Array.isArray( keys ) ) {
+		let map = this.weakMap;
 
-			let map = this.weakMap;
+		for ( let i = 0; i < keys.length; i ++ ) {
 
-			for ( let i = 0; i < keys.length; i ++ ) {
+			map = map.get( keys[ i ] );
 
-				map = map.get( keys[ i ] );
-
-				if ( map === undefined ) return undefined;
-
-			}
-
-			return map.get( keys[ keys.length - 1 ] );
-
-		} else {
-
-			return super.get( keys );
+			if ( map === undefined ) return undefined;
 
 		}
+
+		return map.get( keys[ keys.length - 1 ] );
 
 	}
 
 	set( keys, value ) {
 
-		if ( Array.isArray( keys ) ) {
+		let map = this.weakMap;
 
-			let map = this.weakMap;
+		for ( let i = 0; i < keys.length; i ++ ) {
 
-			for ( let i = 0; i < keys.length; i ++ ) {
+			const key = keys[ i ];
 
-				const key = keys[ i ];
+			if ( map.has( key ) === false ) map.set( key, new WeakMap() );
 
-				if ( map.has( key ) === false ) map.set( key, new WeakMap() );
-
-				map = map.get( key );
-
-			}
-
-			return map.set( keys[ keys.length - 1 ], value );
-
-		} else {
-
-			return super.set( keys, value );
+			map = map.get( key );
 
 		}
+
+		return map.set( keys[ keys.length - 1 ], value );
 
 	}
 
 	delete( keys ) {
 
-		if ( Array.isArray( keys ) ) {
+		let map = this.weakMap;
 
-			let map = this.weakMap;
+		for ( let i = 0; i < keys.length; i ++ ) {
 
-			for ( let i = 0; i < keys.length; i ++ ) {
+			map = map.get( keys[ i ] );
 
-				map = map.get( keys[ i ] );
-
-				if ( map === undefined ) return false;
-
-			}
-
-			return map.delete( keys[ keys.length - 1 ] );
-
-		} else {
-
-			return super.delete( keys );
+			if ( map === undefined ) return false;
 
 		}
 
-	}
-
-	dispose() {
-
-		this.weakMap.clear();
+		return map.delete( keys[ keys.length - 1 ] );
 
 	}
 


### PR DESCRIPTION
Related issue: N/A

**Description**

Removed the dead branches that call `super`, since `ChainMap` no longer extends `WeakMap` (as of https://github.com/mrdoob/three.js/pull/26079). Also removed the unused `ChainMap.dispose()` method since it was calling the deprecated/removed `WeakMap.clear()`. `ChaingMap.dispose()` was never getting called because all usages of `ChainMap` just dereference the `ChainMap` when disposing.
