### PR TITLE
Editor: Ensures that video dimensions are divisible by 2 (requirement of libx264)

### DIFF
--- a/editor/js/Sidebar.Project.Video.js
+++ b/editor/js/Sidebar.Project.Video.js
@@ -16,17 +16,23 @@ function SidebarProjectVideo( editor ) {
 
 	// Resolution
 
+	function toDiv2() {
+
+		this.setValue( this.getValue() & 0xfffffffe );
+
+	}
+
 	const resolutionRow = new UIRow();
 	container.add( resolutionRow );
 
 	resolutionRow.add( new UIText( strings.getKey( 'sidebar/project/resolution' ) ).setClass( 'Label' ) );
 
-	const videoWidth = new UIInteger( 1024 ).setTextAlign( 'center' ).setWidth( '28px' );
+	const videoWidth = new UIInteger( 1024 ).setTextAlign( 'center' ).setWidth( '28px' ).setStep( 2 ).onChange( toDiv2 );
 	resolutionRow.add( videoWidth );
 
 	resolutionRow.add( new UIText( '×' ).setTextAlign( 'center' ).setFontSize( '12px' ).setWidth( '12px' ) );
 
-	const videoHeight = new UIInteger( 1024 ).setTextAlign( 'center' ).setWidth( '28px' );
+	const videoHeight = new UIInteger( 1024 ).setTextAlign( 'center' ).setWidth( '28px' ).setStep( 2 ).onChange( toDiv2 );
 	resolutionRow.add( videoHeight );
 
 	const videoFPS = new UIInteger( 30 ).setTextAlign( 'center' ).setWidth( '20px' );

--- a/editor/js/Sidebar.Project.Video.js
+++ b/editor/js/Sidebar.Project.Video.js
@@ -18,7 +18,7 @@ function SidebarProjectVideo( editor ) {
 
 	function toDiv2() {
 
-		this.setValue( this.getValue() & 0xfffffffe );
+		this.setValue( 2 * Math.floor( this.getValue() / 2 ) );
 
 	}
 

--- a/editor/js/Sidebar.Project.Video.js
+++ b/editor/js/Sidebar.Project.Video.js
@@ -18,6 +18,8 @@ function SidebarProjectVideo( editor ) {
 
 	function toDiv2() {
 
+		// Make sure dimensions are divisible by 2 (requirement of libx264)
+
 		this.setValue( 2 * Math.floor( this.getValue() / 2 ) );
 
 	}


### PR DESCRIPTION
libx264 requires frame width and height are divisible by 2

![image](https://github.com/mrdoob/three.js/assets/1063018/11eb6050-958d-485a-8665-001d31deccff)

This PR rounds down resolution inputs `width` and `height` to the multiplies of 2