### PR TITLE
WebGPURenderer: Uniform - Clean up.

### DIFF
--- a/examples/jsm/renderers/common/Uniform.js
+++ b/examples/jsm/renderers/common/Uniform.js
@@ -2,7 +2,7 @@ import { Color, Matrix3, Matrix4, Vector2, Vector3, Vector4 } from 'three';
 
 class Uniform {
 
-	constructor( name, value = null ) {
+	constructor( name, value ) {
 
 		this.name = name;
 		this.value = value;


### PR DESCRIPTION
Related issue: N/A

**Description**

The `null` default is never used since all inheritors have their own default value and the `Uniform` class is not exported. This makes it more clear that an inheriting class is responsible for passing its own default.