### PR TITLE
TSL: Fix Math/Operators fail generate cache with same node

### DIFF
--- a/examples/jsm/nodes/core/Node.js
+++ b/examples/jsm/nodes/core/Node.js
@@ -199,9 +199,11 @@ class Node extends EventDispatcher {
 
 		const nodeProperties = builder.getNodeProperties( this );
 
+		let index = 0;
+
 		for ( const childNode of this.getChildren() ) {
 
-			nodeProperties[ '_node' + childNode.id ] = childNode;
+			nodeProperties[ 'node' + index ++ ] = childNode;
 
 		}
 


### PR DESCRIPTION
**Description**

It was not automatically generating cache if the same node was using more than one argument from the same node, e.g:

```js
const a = vector.normalize();

// The result of normalize is now stored in a variable to avoid redundancy due to it being used more than once.
// Without needs to use 'a.toVar()' for this

const b = a.mul( a );
```