### PR TITLE
TSL: Introduce `.toGlobal`

### DIFF
--- a/examples/jsm/nodes/core/Node.js
+++ b/examples/jsm/nodes/core/Node.js
@@ -25,6 +25,8 @@ class Node extends EventDispatcher {
 		this._cacheKey = null;
 		this._cacheKeyVersion = 0;
 
+		this.global = false;
+
 		this.isNode = true;
 
 		Object.defineProperty( this, 'id', { value: _nodeId ++ } );
@@ -98,7 +100,7 @@ class Node extends EventDispatcher {
 
 	isGlobal( /*builder*/ ) {
 
-		return false;
+		return this.global;
 
 	}
 

--- a/examples/jsm/nodes/shadernode/ShaderNode.js
+++ b/examples/jsm/nodes/shadernode/ShaderNode.js
@@ -531,6 +531,16 @@ addNodeClass( 'ShaderNode', ShaderNode );
 
 //
 
+addNodeElement( 'toGlobal', ( node ) => {
+
+	node.global = true;
+
+	return node;
+
+} );
+
+//
+
 export const setCurrentStack = ( stack ) => {
 
 	if ( currentStack === stack ) {


### PR DESCRIPTION
**Description**

`toGlobal` is a shortcut that will flag the system to not create more than one cache for the Node, cases that could occur when using multiple IBL, and ClearCoat where the same code flow is executed just with a different context.
