### PR TITLE
TSL: NodeBuilder - Cleanup

### DIFF
--- a/examples/jsm/nodes/core/NodeBuilder.js
+++ b/examples/jsm/nodes/core/NodeBuilder.js
@@ -80,7 +80,7 @@ class NodeBuilder {
 		this.computeShader = null;
 
 		this.flowNodes = { vertex: [], fragment: [], compute: [] };
-		this.flowCode = { vertex: '', fragment: '', compute: [] };
+		this.flowCode = { vertex: '', fragment: '', compute: '' };
 		this.uniforms = { vertex: [], fragment: [], compute: [], index: 0 };
 		this.structs = { vertex: [], fragment: [], compute: [], index: 0 };
 		this.bindings = { vertex: [], fragment: [], compute: [] };


### PR DESCRIPTION
Related issue: N/A

**Description**

As far as I can tell, it's just a copy-paste error that `NodeBuilder.flowCode.compute` is initialized as an array instead of a string (and happens to not be a problem because an array + a string = a string).