### PR TITLE
`texture.objectFit(800/600, "cover")`

### DIFF
--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -290,6 +290,66 @@ class Texture extends EventDispatcher {
 
 	}
 
+	objectFit( R, size = 'fill' ) {
+
+		const r = this.image.width / this.image.height;
+
+		switch ( size ) {
+
+			case 'cover':
+				if ( r > R ) {
+
+					this.repeat.x = R / r;
+					this.repeat.y = 1;
+
+					this.offset.x = ( 1 - this.repeat.x ) / 2;
+					this.offset.y = 0;
+
+				} else {
+
+					this.repeat.x = 1;
+					this.repeat.y = r / R;
+
+					this.offset.x = 0;
+					this.offset.y = ( 1 - this.repeat.y ) / 2;
+
+				}
+
+				break;
+
+			case 'contain':
+				if ( r > R ) {
+
+					this.repeat.x = 1;
+					this.repeat.y = r / R;
+
+					this.offset.x = 0;
+					this.offset.y = ( 1 - this.repeat.y ) / 2;
+
+				} else {
+
+					this.repeat.x = R / r;
+					this.repeat.y = 1;
+
+					this.offset.x = ( 1 - this.repeat.x ) / 2;
+					this.offset.y = 0;
+
+				}
+
+				break;
+
+			case 'fill':
+			default:
+				this.repeat.x = 1;
+				this.repeat.y = 1;
+
+				this.offset.x = 0;
+				this.offset.y = 0;
+
+		}
+
+	}
+
 	set needsUpdate( value ) {
 
 		if ( value === true ) {


### PR DESCRIPTION
**Description**

A utility-method, that partially implements https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit for `THREE.Texture`

given:
```js
const w = 4
const h = 3
const geometry = new THREE.PlaneGeometry( w, h );
const material = new THREE.MeshBasicMaterial( {color: 0xffff00, side: THREE.DoubleSide} );
const plane = new THREE.Mesh( geometry, material );

const texture = new THREE.TextureLoader().load( "textures/water.jpg" );
material.map = texture
```

like in CSS, it could be handy to "cover" the plane with the texture:
```js
texture.objectFit(w/h, "cover"); // 👈🏻 THIS
```

TODO:
- [ ] update doc
- [ ] an example?
