### PR TITLE
Editor: Alerts if invalid material found when rendering image in REALISTIC

### DIFF
--- a/editor/js/Sidebar.Project.Image.js
+++ b/editor/js/Sidebar.Project.Image.js
@@ -98,7 +98,7 @@ function SidebarProjectImage( editor ) {
 
 			if ( isMaterialsValid === false ) {
 
-				alert( 'REALISTIC Shading: Only MeshStandardMaterial and MeshPhysicalMaterial are supported' ); // TODO: l10n
+				alert( strings.getKey( 'prompt/rendering/realistic/unsupportedMaterial' ) );
 				return;
 
 			}

--- a/editor/js/Sidebar.Project.Image.js
+++ b/editor/js/Sidebar.Project.Image.js
@@ -24,9 +24,9 @@ function SidebarProjectImage( editor ) {
 	shadingRow.add( new UIText( strings.getKey( 'sidebar/project/shading' ) ).setClass( 'Label' ) );
 
 	const shadingTypeSelect = new UISelect().setOptions( {
-		0: 'SOLID',
-		1: 'REALISTIC'
-	} ).setWidth( '170px' ).setTextTransform( 'unset' ).onChange( refreshShadingRow ).setValue( 0 );
+		'solid': 'SOLID',
+		'realistic': 'REALISTIC'
+	} ).setWidth( '170px' ).onChange( refreshShadingRow ).setValue( 'solid' );
 	shadingRow.add( shadingTypeSelect );
 
 	const pathTracerMinSamples = 3;
@@ -41,7 +41,7 @@ function SidebarProjectImage( editor ) {
 
 	function refreshShadingRow() {
 
-		samplesRow.setHidden( shadingTypeSelect.getValue() !== '1' );
+		samplesRow.setHidden( shadingTypeSelect.getValue() !== 'realistic' );
 
 	}
 
@@ -68,6 +68,44 @@ function SidebarProjectImage( editor ) {
 	renderButton.setWidth( '170px' );
 	renderButton.setMarginLeft( '120px' );
 	renderButton.onClick( async () => {
+
+		if ( shadingTypeSelect.getValue() === 'realistic' ) {
+
+			let isMaterialsValid = true;
+
+			editor.scene.traverseVisible( ( object ) => {
+
+				if ( object.isMesh ) {
+
+					const materials = Array.isArray( object.material ) ? object.material : [ object.material ];
+
+					for ( let i = 0; i < materials.length; i ++ ) {
+
+						const material = materials[ i ];
+
+						if ( ! material.isMeshStandardMaterial && ! material.isMeshPhysicalMaterial ) {
+
+							isMaterialsValid = false;
+							return;
+
+						}
+
+					}
+
+				}
+
+			} );
+
+			if ( isMaterialsValid === false ) {
+
+				alert( 'REALISTIC Shading: Only MeshStandardMaterial and MeshPhysicalMaterial are supported' ); // TODO: l10n
+				return;
+
+			}
+
+		}
+
+		//
 
 		const json = editor.toJSON();
 		const project = json.project;
@@ -117,16 +155,16 @@ function SidebarProjectImage( editor ) {
 
 		//
 
-		switch ( Number( shadingTypeSelect.getValue() ) ) {
+		switch ( shadingTypeSelect.getValue() ) {
 
-			case 0: // SOLID
+			case 'solid':
 
 				renderer.render( scene, camera );
 				renderer.dispose();
 
 				break;
 
-			case 1: // REALISTIC
+			case 'realistic':
 
 				const status = document.createElement( 'div' );
 				status.style.position = 'absolute';

--- a/editor/js/Sidebar.Project.Image.js
+++ b/editor/js/Sidebar.Project.Image.js
@@ -83,7 +83,7 @@ function SidebarProjectImage( editor ) {
 
 						const material = materials[ i ];
 
-						if ( ! material.isMeshStandardMaterial && ! material.isMeshPhysicalMaterial ) {
+						if ( ! material.isMeshStandardMaterial ) {
 
 							isMaterialsValid = false;
 							return;

--- a/editor/js/Strings.js
+++ b/editor/js/Strings.js
@@ -14,6 +14,7 @@ function Strings( config ) {
 			'prompt/history/clear': 'The Undo/Redo History will be cleared. Are you sure?',
 			'prompt/history/preserve': 'The history will be preserved across sessions.\nThis can have an impact on performance when working with textures.',
 			'prompt/history/forbid': 'Undo/Redo disabled while scene is playing.',
+			'prompt/rendering/realistic/unsupportedMaterial': 'REALISTIC Shading: Only MeshStandardMaterial and MeshPhysicalMaterial are supported',
 
 			'command/AddObject': 'Add Object',
 			'command/AddScript': 'Add Script',
@@ -413,6 +414,7 @@ function Strings( config ) {
 			'prompt/history/clear': 'L\'historique d\'annulation/rétablissement sera effacé Êtes-vous sûr ?',
 			'prompt/history/preserve': 'L\'histoire sera conservée entre les sessions.\nCela peut avoir un impact sur les performances lors de la manipulation des textures.',
 			'prompt/history/forbid': 'Les fonctions Annuler/Rétablir sont désactivées pendant la lecture de la scène.',
+			'prompt/rendering/realistic/unsupportedMaterial': 'Ombrage REALISTIC : seuls MeshStandardMaterial et MeshPhysicalMaterial sont pris en charge',
 
 			'command/AddObject': 'Ajouter un objet',
 			'command/AddScript': 'Ajouter un script',
@@ -812,6 +814,7 @@ function Strings( config ) {
 			'prompt/history/clear': '撤销/重做历史记录将被清除。您确定吗？',
 			'prompt/history/preserve': '历史将在会话之间保留。\n这可能会影响在处理纹理时的性能。',
 			'prompt/history/forbid': '在播放场景时，撤消/重做被禁用。',
+			'prompt/rendering/realistic/unsupportedMaterial': 'REALISTIC着色：仅支持 MeshStandardMaterial 和 MeshPhysicalMaterial',
 
 			'command/AddObject': '添加对象',
 			'command/AddScript': '添加脚本',
@@ -1211,6 +1214,7 @@ function Strings( config ) {
 			'prompt/history/clear': '元に戻す/やり直しの履歴が消去されます。 本気ですか？',
 			'prompt/history/preserve': '履歴はセッションをまたいで保存されます。\nこれは、テクスチャを操作する際のパフォーマンスに影響を与える可能性があります。',
 			'prompt/history/forbid': 'シーンの再生中は元に戻す/やり直しは無効になります。',
+			'prompt/rendering/realistic/unsupportedMaterial': 'REALISTIC シェーディング: MeshStandardmaterial と MeshPhysicalmaterial のみがサポートされています',
 
 			'command/AddObject': 'オブジェクトを追加',
 			'command/AddScript': 'スクリプトを追加',


### PR DESCRIPTION
[Pathtracer only supports MeshStandardMaterial and MeshPhysicalMaterial](https://github.com/gkjohnson/three-gpu-pathtracer?tab=readme-ov-file#gotchas), so when rendering image in REALISTIC, editor will popup a blank window if there're invalid materials in scene. This PR alerts users instead for this case.

Also, this PR updated UISelect's keys to use shading name in string, `'realistic'`, instead of number-but-actually-string `1`, the code is now easier to reason about