### PR TITLE
WebGPURenderer: apply color space/tonemapping if required in clear()

### DIFF
--- a/examples/jsm/renderers/common/Renderer.js
+++ b/examples/jsm/renderers/common/Renderer.js
@@ -944,6 +944,13 @@ class Renderer {
 
 		this.backend.clear( color, depth, stencil, renderTargetData );
 
+		if ( renderTarget !== null && this._renderTarget === null ) {
+
+			_quad.material.fragmentNode = this._nodes.getOutputNode( renderTarget.texture );
+			this._renderScene( _quad, _quad.camera, false );
+
+		}
+
 	}
 
 	clearColor() {

--- a/examples/jsm/renderers/common/Renderer.js
+++ b/examples/jsm/renderers/common/Renderer.js
@@ -946,6 +946,9 @@ class Renderer {
 
 		if ( renderTarget !== null && this._renderTarget === null ) {
 
+			// If a color space transform or tone mapping is required,
+			// the clear operation clears the intermediate renderTarget texture, but does not update the screen canvas.
+
 			_quad.material.fragmentNode = this._nodes.getOutputNode( renderTarget.texture );
 			this._renderScene( _quad, _quad.camera, false );
 


### PR DESCRIPTION
If a color space transform or tone mapping is required, the clear operation clears the intermediate renderTarget texture, but does not update the screen canvas.  
