### PR TITLE
WebGPURenderer: fix rendering to depth textures with multiple color attachments (MRT - WGSL)

### DIFF
--- a/examples/jsm/nodes/core/OutputStructNode.js
+++ b/examples/jsm/nodes/core/OutputStructNode.js
@@ -33,7 +33,7 @@ class OutputStructNode extends Node {
 
 	generate( builder, output ) {
 
-		const propertyName = builder.getOutputName();
+		const propertyName = builder.getOutputStructName();
 		const members = this.members;
 
 		const structPrefix = propertyName !== '' ? propertyName + '.' : '';

--- a/examples/jsm/nodes/core/OutputStructNode.js
+++ b/examples/jsm/nodes/core/OutputStructNode.js
@@ -33,11 +33,7 @@ class OutputStructNode extends Node {
 
 	generate( builder, output ) {
 
-		const nodeVar = builder.getVarFromNode( this );
-		nodeVar.isOutputStructVar = true;
-
-		const propertyName = builder.getPropertyName( nodeVar );
-
+		const propertyName = builder.getOutputName();
 		const members = this.members;
 
 		const structPrefix = propertyName !== '' ? propertyName + '.' : '';

--- a/examples/jsm/renderers/webgl/nodes/GLSLNodeBuilder.js
+++ b/examples/jsm/renderers/webgl/nodes/GLSLNodeBuilder.js
@@ -55,7 +55,7 @@ class GLSLNodeBuilder extends NodeBuilder {
 
 	}
 
-	getOutputName() {
+	getOutputStructName() {
 
 		return '';
 

--- a/examples/jsm/renderers/webgl/nodes/GLSLNodeBuilder.js
+++ b/examples/jsm/renderers/webgl/nodes/GLSLNodeBuilder.js
@@ -51,9 +51,13 @@ class GLSLNodeBuilder extends NodeBuilder {
 
 	getPropertyName( node, shaderStage ) {
 
-		if ( node.isOutputStructVar ) return '';
-
 		return super.getPropertyName( node, shaderStage );
+
+	}
+
+	getOutputName() {
+
+		return '';
 
 	}
 
@@ -276,8 +280,6 @@ ${ flowData.code }
 		if ( vars !== undefined ) {
 
 			for ( const variable of vars ) {
-
-				if ( variable.isOutputStructVar ) continue;
 
 				snippets.push( `${ this.getVar( variable.type, variable.name ) };` );
 

--- a/examples/jsm/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/examples/jsm/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -336,6 +336,12 @@ class WGSLNodeBuilder extends NodeBuilder {
 
 	}
 
+	getOutputName() {
+
+		return 'output';
+
+	}
+
 	_getUniformGroupCount( shaderStage ) {
 
 		return Object.keys( this.uniforms[ shaderStage ] ).length;
@@ -622,6 +628,10 @@ ${ flowData.code }
 
 		}
 
+		const builtins = this.getBuiltins( 'output' );
+
+		if ( builtins ) snippets.push( builtins );
+
 		return snippets.join( ',\n' );
 
 	}
@@ -641,6 +651,8 @@ ${ flowData.code }
 			snippet += '\n}';
 
 			snippets.push( snippet );
+
+			snippets.push( `\nvar<private> output : ${ name };\n\n`);
 
 		}
 

--- a/examples/jsm/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/examples/jsm/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -336,7 +336,7 @@ class WGSLNodeBuilder extends NodeBuilder {
 
 	}
 
-	getOutputName() {
+	getOutputStructName() {
 
 		return 'output';
 


### PR DESCRIPTION
Related issue: Closes #28519 

Rendering using outputStruct() to multiple render targets doesn't handle depth with WGSL because @builtin('frag_depth') not included in the output struct definition. (GLSL unaffected).

Include builtins as required and simplify, avoiding the var in main fragment shader function and aligning with standard code with the output named 'output'. 
