### PR TITLE
Editor: Copy values when converting from standard material to physical

### DIFF
--- a/editor/js/Sidebar.Material.js
+++ b/editor/js/Sidebar.Material.js
@@ -502,7 +502,7 @@ function SidebarMaterial( editor ) {
 
 						if ( value === null ) continue;
 						
-						if ( value[ 'copy' ] !== undefined ) {
+						if ( value[ 'clone' ] !== undefined ) {
 
 							material[ property ] = value.clone();
 

--- a/editor/js/Sidebar.Material.js
+++ b/editor/js/Sidebar.Material.js
@@ -484,15 +484,47 @@ function SidebarMaterial( editor ) {
 
 				}
 
-				if ( Array.isArray( currentObject.material ) ) {
+				const currentMaterial = currentObject.material;
+
+				if ( material.type === 'MeshPhysicalMaterial' && currentMaterial.type === 'MeshStandardMaterial' ) {
+
+					// TODO Find a easier to maintain approach
+
+					const properties = [
+						'color', 'emissive', 'roughness', 'metalness', 'map', 'emissiveMap', 'alphaMap',
+						'bumpMap', 'normalMap', 'normalScale', 'displacementMap', 'roughnessMap', 'metalnessMap',
+						'envMap', 'lightMap', 'aoMap', 'side'
+					];
+
+					for ( const property of properties ) {
+
+						const value = currentMaterial[ property ];
+
+						if ( value === null ) continue;
+						
+						if ( value[ 'copy' ] !== undefined ) {
+
+							material[ property ] = value.clone();
+
+						} else {
+
+							material[ property ] = value;
+
+						}
+
+					}
+
+				}
+
+				if ( Array.isArray( currentMaterial ) ) {
 
 					// don't remove the entire multi-material. just the material of the selected slot
 
-					editor.removeMaterial( currentObject.material[ currentMaterialSlot ] );
+					editor.removeMaterial( currentMaterial[ currentMaterialSlot ] );
 
 				} else {
 
-					editor.removeMaterial( currentObject.material );
+					editor.removeMaterial( currentMaterial );
 
 				}
 


### PR DESCRIPTION
**Description**

It's pretty annoying when you just want to add `transmission` to a `MeshStandardMaterial` and losing all the properties when changing material types.

I don't think we should try to copy values between all types of materials, but I think it makes sense between these two.