### PR TITLE
Don't draw points when using a material that doesn't support points

### DIFF
--- a/examples/webgl_postprocessing_sao.html
+++ b/examples/webgl_postprocessing_sao.html
@@ -105,6 +105,28 @@
 
 				}
 
+
+				// Add points. Points don't affect SAO.
+
+				const pointsArray = [];
+
+				for ( let i = 0; i < 200; i ++ ) {
+
+					const x = Math.random() * 10 - 5;
+					const y = Math.random() * 10 - 5;
+					const z = Math.random() * 10 - 5;
+					pointsArray.push( x, y, z );
+
+				}
+
+				const pointsGeometry = new THREE.BufferGeometry();
+				const pointsBuffer = new Float32Array( pointsArray );
+				pointsGeometry.setAttribute( 'position', new THREE.BufferAttribute( pointsBuffer, 3 ) );
+
+				const pointsMesh = new THREE.Points( pointsGeometry, new THREE.PointsMaterial({ size: 0.02 }) );
+				group.add( pointsMesh );
+
+
 				stats = new Stats();
 				container.appendChild( stats.dom );
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -738,6 +738,15 @@ class WebGLRenderer {
 
 			const program = setProgram( camera, scene, geometry, material, object );
 
+			if ( object.isPoints && ! program.setsPointSize ) {
+
+				// Rendering points with a shader that doesn't set point size results in effectively randomly sized points on M-series Macs.
+				// It's easy to run into this by rendering a scene that includes points with an override material.
+
+				return;
+
+			}
+
 			state.setMaterial( material, frontFaceCW );
 
 			//

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -1053,6 +1053,8 @@ function WebGLProgram( renderer, cacheKey, parameters, bindingStates ) {
 	this.vertexShader = glVertexShader;
 	this.fragmentShader = glFragmentShader;
 
+	this.setsPointSize = /gl_PointSize\s*=/.test( vertexShader );
+
 	return this;
 
 }


### PR DESCRIPTION
Related issue: #28522

**Description**

Rendering points with a shader that doesn't write gl_PointSize generates random results on Mac M-series GPUs. This was apparent when rendering a scene with points with an override material, such as when rendering postprocessing effects. The solution is to skip rendering points if the current shader program does not support points.

*This contribution is funded by [Higharc](https://higharc.com)*
