### PR TITLE
WebGLRenderer: Fix WebXR depth sensing.

### DIFF
--- a/examples/webxr_xr_ballshooter.html
+++ b/examples/webxr_xr_ballshooter.html
@@ -81,7 +81,10 @@
 				controls.target.y = 1.6;
 				controls.update();
 
-				document.body.appendChild( XRButton.createButton( renderer, { 'optionalFeatures': [ 'depth-sensing'] } ) );
+				document.body.appendChild( XRButton.createButton( renderer, {
+					'optionalFeatures': [ 'depth-sensing' ],
+					'depthSensing': { 'usagePreference': [ 'gpu-optimized' ], 'dataFormatPreference': [] }
+				} ) );
 
 				// controllers
 

--- a/examples/webxr_xr_cubes.html
+++ b/examples/webxr_xr_cubes.html
@@ -140,7 +140,10 @@
 
 				//
 
-				document.body.appendChild( XRButton.createButton( renderer, { 'optionalFeatures': [ 'depth-sensing' ] } ) );
+				document.body.appendChild( XRButton.createButton( renderer, {
+					'optionalFeatures': [ 'depth-sensing' ],
+					'depthSensing': { 'usagePreference': [ 'gpu-optimized' ], 'dataFormatPreference': [] }
+				} ) );
 
 			}
 

--- a/examples/webxr_xr_dragging.html
+++ b/examples/webxr_xr_dragging.html
@@ -124,7 +124,10 @@
 				renderer.xr.enabled = true;
 				container.appendChild( renderer.domElement );
 
-				document.body.appendChild( XRButton.createButton( renderer, { 'optionalFeatures': [ 'depth-sensing' ] } ) );
+				document.body.appendChild( XRButton.createButton( renderer, {
+					'optionalFeatures': [ 'depth-sensing' ],
+					'depthSensing': { 'usagePreference': [ 'gpu-optimized' ], 'dataFormatPreference': [] }
+				} ) );
 
 				// controllers
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1141,7 +1141,17 @@ class WebGLRenderer {
 
 			renderListStack.push( currentRenderList );
 
-			if ( _this.xr.getDepthSensingMesh() ) projectObject( _this.xr.getDepthSensingMesh(), camera, - Infinity, _this.sortObjects );
+			if ( xr.enabled === true && xr.isPresenting === true ) {
+
+				const depthSensingMesh = _this.xr.getDepthSensingMesh();
+
+				if ( depthSensingMesh !== null ) {
+
+					projectObject( depthSensingMesh, camera, - Infinity, _this.sortObjects );
+
+				}
+
+			}
 
 			projectObject( scene, camera, 0, _this.sortObjects );
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1141,6 +1141,8 @@ class WebGLRenderer {
 
 			renderListStack.push( currentRenderList );
 
+			if ( _this.xr.getDepthSensingMesh() ) projectObject( _this.xr.getDepthSensingMesh(), camera, - Infinity, _this.sortObjects );
+
 			projectObject( scene, camera, 0, _this.sortObjects );
 
 			currentRenderList.finish();

--- a/src/renderers/webxr/WebXRDepthSensing.js
+++ b/src/renderers/webxr/WebXRDepthSensing.js
@@ -65,7 +65,7 @@ class WebXRDepthSensing {
 
 	}
 
-	render( renderer, cameraXR ) {
+	getMesh( cameraXR ) {
 
 		if ( this.texture !== null ) {
 
@@ -86,9 +86,9 @@ class WebXRDepthSensing {
 
 			}
 
-			renderer.render( this.mesh, cameraXR );
-
 		}
+
+		return this.mesh;
 
 	}
 

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -664,6 +664,12 @@ class WebXRManager extends EventDispatcher {
 
 		};
 
+		this.getDepthSensingMesh = function () {
+
+			return depthSensing.getMesh( cameraXR );
+
+		};
+
 		// Animation Loop
 
 		let onAnimationFrameCallback = null;
@@ -788,8 +794,6 @@ class WebXRManager extends EventDispatcher {
 				}
 
 			}
-
-			depthSensing.render( renderer, cameraXR );
 
 			if ( onAnimationFrameCallback ) onAnimationFrameCallback( time, frame );
 


### PR DESCRIPTION
Depth sensing is broken in the current version of three.js. 
This change will restore depth sorting functionality and also removes the extra renderpass of the previous solution.

The samples also didn't add the depthSensing dictionary during session creation. Quest browser wasn't spec compliant so didn't pass this in. That will be fixed in a future version of the spec.

cc @Mugen87 
