### PR TITLE
WebGPURenderer: Read-Only and Read-Write Storage Textures Access support in TSL

### DIFF
--- a/examples/jsm/nodes/accessors/StorageTextureNode.js
+++ b/examples/jsm/nodes/accessors/StorageTextureNode.js
@@ -66,8 +66,9 @@ class StorageTextureNode extends TextureNode {
 		const textureProperty = super.generate( builder, 'property' );
 		const uvSnippet = uvNode.build( builder, 'uvec2' );
 		const storeSnippet = storeNode.build( builder, 'vec4' );
+		const accessSnippet = builder.getStorageAccess( this );
 
-		const snippet = builder.generateTextureStore( builder, textureProperty, uvSnippet, storeSnippet );
+		const snippet = builder.generateTextureStore( builder, textureProperty, uvSnippet, storeSnippet, accessSnippet );
 
 		builder.addLineFlowCode( snippet );
 
@@ -85,6 +86,8 @@ export const storageTextureReadWrite = ( value, uvNode, storeNode ) => storageTe
 export const textureStore = ( value, uvNode, storeNode ) => {
 
 	const node = storageTexture( value, uvNode, storeNode );
+
+	if ( value.access !== undefined && value.access !== GPUStorageTextureAccess.WriteOnly ) node.setAccess( value.access );
 
 	if ( storeNode !== null ) node.append();
 

--- a/examples/jsm/nodes/accessors/StorageTextureNode.js
+++ b/examples/jsm/nodes/accessors/StorageTextureNode.js
@@ -32,13 +32,6 @@ class StorageTextureNode extends TextureNode {
 
 	}
 
-	setAccess( value ) {
-
-		this.access = value;
-		return this;
-
-	}
-
 	generate( builder, output ) {
 
 		let snippet;
@@ -83,11 +76,9 @@ export const storageTexture = nodeProxy( StorageTextureNode );
 export const storageTextureReadOnly = ( value, uvNode, storeNode ) => storageTexture( value, uvNode, storeNode ).setAccess( 'read-only' );
 export const storageTextureReadWrite = ( value, uvNode, storeNode ) => storageTexture( value, uvNode, storeNode ).setAccess( 'read-write' );
 
-export const textureStore = ( value, uvNode, storeNode ) => {
+export const textureStore = ( value, uvNode, storeNode, access ) => {
 
-	const node = storageTexture( value, uvNode, storeNode );
-
-	if ( value.access !== undefined && value.access !== GPUStorageTextureAccess.WriteOnly ) node.setAccess( value.access );
+	const node = storageTexture( value, uvNode, storeNode ).setAccess( access );
 
 	if ( storeNode !== null ) node.append();
 

--- a/examples/jsm/nodes/accessors/TextureNode.js
+++ b/examples/jsm/nodes/accessors/TextureNode.js
@@ -189,7 +189,7 @@ class TextureNode extends UniformNode {
 
 		} else if ( this.sampler === false ) {
 
-			snippet = builder.generateTextureLoad( texture, textureProperty, uvSnippet, depthSnippet, null, accessNode );
+			snippet = builder.generateTextureLoad( texture, textureProperty, uvSnippet, depthSnippet, undefined, accessNode );
 
 		} else {
 

--- a/examples/jsm/renderers/common/StorageTexture.js
+++ b/examples/jsm/renderers/common/StorageTexture.js
@@ -1,9 +1,8 @@
 import { Texture, LinearFilter } from 'three';
-import { GPUStorageTextureAccess } from '../webgpu/utils/WebGPUConstants.js';
 
 class StorageTexture extends Texture {
 
-	constructor( width = 1, height = 1, access = GPUStorageTextureAccess.WriteOnly ) {
+	constructor( width = 1, height = 1 ) {
 
 		super();
 
@@ -13,8 +12,6 @@ class StorageTexture extends Texture {
 		this.minFilter = LinearFilter;
 
 		this.isStorageTexture = true;
-
-		this.access = access;
 
 	}
 

--- a/examples/jsm/renderers/common/StorageTexture.js
+++ b/examples/jsm/renderers/common/StorageTexture.js
@@ -1,8 +1,9 @@
 import { Texture, LinearFilter } from 'three';
+import { GPUStorageTextureAccess } from '../webgpu/utils/WebGPUConstants.js';
 
 class StorageTexture extends Texture {
 
-	constructor( width = 1, height = 1 ) {
+	constructor( width = 1, height = 1, access = GPUStorageTextureAccess.WriteOnly ) {
 
 		super();
 
@@ -12,6 +13,8 @@ class StorageTexture extends Texture {
 		this.minFilter = LinearFilter;
 
 		this.isStorageTexture = true;
+
+		this.access = access;
 
 	}
 

--- a/examples/jsm/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/examples/jsm/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -372,7 +372,7 @@ class WGSLNodeBuilder extends NodeBuilder {
 
 	getStorageAccess( node ) {
 
-		if ( node.isStorageTextureNode ) {
+		if ( node.access !== undefined ) {
 
 			switch ( node.access ) {
 
@@ -399,7 +399,7 @@ class WGSLNodeBuilder extends NodeBuilder {
 		} else {
 
 			// @TODO: Account for future read-only storage buffer pull request
-			return 'read_write';
+			return 'write';
 
 		}
 
@@ -434,7 +434,7 @@ class WGSLNodeBuilder extends NodeBuilder {
 
 				}
 
-				texture.store = node.isStorageTextureNode === true;
+				texture.store = node.access !== undefined || node.isStorageTextureNode === true;
 				texture.setVisibility( gpuShaderStageLib[ shaderStage ] );
 
 				if ( shaderStage === 'fragment' && this.isUnfilterable( node.value ) === false && texture.store === false ) {
@@ -831,7 +831,7 @@ ${ flowData.code }
 
 					textureType = 'texture_3d<f32>';
 
-				} else if ( uniform.node.isStorageTextureNode === true ) {
+				} else if ( uniform.node.access !== undefined || uniform.node.isStorageTextureNode === true ) {
 
 					const format = getFormat( texture );
 					const access = this.getStorageAccess( uniform.node );

--- a/examples/jsm/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/examples/jsm/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -838,8 +838,6 @@ ${ flowData.code }
 
 					textureType = `texture_storage_2d<${ format }, ${access}>`;
 
-					console.log( textureType, format, access );
-
 				} else {
 
 					const componentPrefix = this.getComponentTypeFromTexture( texture ).charAt( 0 );

--- a/examples/jsm/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/examples/jsm/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -208,11 +208,15 @@ class WGSLNodeBuilder extends NodeBuilder {
 
 	}
 
-	generateTextureLoad( texture, textureProperty, uvIndexSnippet, depthSnippet, levelSnippet = '0u' ) {
+	generateTextureLoad( texture, textureProperty, uvIndexSnippet, depthSnippet, levelSnippet = '0u', accessSnippet ) {
 
 		if ( depthSnippet ) {
 
 			return `textureLoad( ${ textureProperty }, ${ uvIndexSnippet }, ${ depthSnippet }, ${ levelSnippet } )`;
+
+		} else if ( accessSnippet ) {
+
+			return `textureLoad( ${ textureProperty }, ${ uvIndexSnippet } )`;
 
 		} else {
 
@@ -689,7 +693,7 @@ ${ flowData.code }
 
 			snippets.push( snippet );
 
-			snippets.push( `\nvar<private> output : ${ name };\n\n`);
+			snippets.push( `\nvar<private> output : ${ name };\n\n` );
 
 		}
 
@@ -833,6 +837,8 @@ ${ flowData.code }
 					const access = this.getStorageAccess( uniform.node );
 
 					textureType = `texture_storage_2d<${ format }, ${access}>`;
+
+					console.log( textureType, format, access );
 
 				} else {
 
@@ -978,6 +984,8 @@ ${ flowData.code }
 		} else {
 
 			this.computeShader = this._getWGSLComputeCode( shadersData.compute, ( this.object.workgroupSize || [ 64 ] ).join( ', ' ) );
+
+			console.log( this.computeShader );
 
 		}
 

--- a/examples/jsm/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/examples/jsm/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -985,8 +985,6 @@ ${ flowData.code }
 
 			this.computeShader = this._getWGSLComputeCode( shadersData.compute, ( this.object.workgroupSize || [ 64 ] ).join( ', ' ) );
 
-			console.log( this.computeShader );
-
 		}
 
 	}

--- a/examples/jsm/renderers/webgpu/utils/WebGPUBindingUtils.js
+++ b/examples/jsm/renderers/webgpu/utils/WebGPUBindingUtils.js
@@ -62,9 +62,16 @@ class WebGPUBindingUtils {
 			} else if ( binding.isSampledTexture && binding.store ) {
 
 				const format = this.backend.get( binding.texture ).texture.format;
+
+				bindingGPU.storageTexture = { format }; // GPUStorageTextureBindingLayout
+
 				const access = binding.access;
 
-				bindingGPU.storageTexture = { format, access }; // GPUStorageTextureBindingLayout
+				if ( access ) {
+
+					bindingGPU.storageTexture.access = access;
+
+				}
 
 			} else if ( binding.isSampledTexture ) {
 


### PR DESCRIPTION
Related issue: #28455

**Description**

This PR adds support for Read Only and Read/Write Storage Textures access in TSL.

Example:
```js
const width = 512, height = 512;

const storageTexture = new StorageTexture( width, height );
storageTexture.format = THREE.RedFormat;
storageTexture.type = THREE.FloatType;

const computeTexture = tslFn( ( { storageTexture } ) => {

	const posX = instanceIndex.remainder( width );
	const posY = instanceIndex.div( width );
	const indexUV = uvec2( posX, posY );

	const oldTextureValue = textureLoad( storageTexture, indexUV ).setAccess('read-write')

	const newTextureValue = oldTextureValue.add( 0.1 );

	textureStore( storageTexture, indexUV, newTextureValue, 'read-write' );

} );
```

*This contribution is funded by [Utsubo](https://utsubo.com)*
