### PR TITLE
Docs: Fix broken links.

### DIFF
--- a/docs/api/ar/materials/RawShaderMaterial.html
+++ b/docs/api/ar/materials/RawShaderMaterial.html
@@ -36,9 +36,9 @@
 		[example:webgl_buffergeometry_instancing_billboards WebGL / buffergeometry / instancing / billboards]<br />
 		[example:webgl_buffergeometry_instancing WebGL / buffergeometry / instancing]<br />
 		[example:webgl_raymarching_reflect WebGL / raymarching / reflect]<br />
-		[example:webgl2_volume_cloud WebGL 2 / volume / cloud]<br />
-		[example:webgl2_volume_instancing WebGL 2 / volume / instancing]<br />
-		[example:webgl2_volume_perlin WebGL 2 / volume / perlin]
+		[example:webgl_volume_cloud WebGL / volume / cloud]<br />
+		[example:webgl_volume_instancing WebGL / volume / instancing]<br />
+		[example:webgl_volume_perlin WebGL / volume / perlin]
 		</p>
 		 
 		<h2>المنشئ (Constructor)</h2>

--- a/docs/api/ar/renderers/WebGLArrayRenderTarget.html
+++ b/docs/api/ar/renderers/WebGLArrayRenderTarget.html
@@ -18,7 +18,7 @@
 		<h2>أمثلة (Examples)</h2>
 		 
 		<p>
-		[example:webgl2_rendertarget_texture2darray WebGL 2 / render target / array]<br />
+		[example:webgl_rendertarget_texture2darray WebGL / render target / array]<br />
 		</p>
 		 
 		<h2>المنشئ (Constructor)</h2>

--- a/docs/api/en/materials/RawShaderMaterial.html
+++ b/docs/api/en/materials/RawShaderMaterial.html
@@ -36,9 +36,9 @@
 			[example:webgl_buffergeometry_instancing_billboards WebGL / buffergeometry / instancing / billboards]<br />
 			[example:webgl_buffergeometry_instancing WebGL / buffergeometry / instancing]<br />
 			[example:webgl_raymarching_reflect WebGL / raymarching / reflect]<br />
-			[example:webgl2_volume_cloud WebGL 2 / volume / cloud]<br />
-			[example:webgl2_volume_instancing WebGL 2 / volume / instancing]<br />
-			[example:webgl2_volume_perlin WebGL 2 / volume / perlin]
+			[example:webgl_volume_cloud WebGL / volume / cloud]<br />
+			[example:webgl_volume_instancing WebGL / volume / instancing]<br />
+			[example:webgl_volume_perlin WebGL / volume / perlin]
 		</p>
 
 		<h2>Constructor</h2>

--- a/docs/api/en/renderers/WebGLArrayRenderTarget.html
+++ b/docs/api/en/renderers/WebGLArrayRenderTarget.html
@@ -18,7 +18,7 @@
 		<h2>Examples</h2>
 
 		<p>
-			[example:webgl2_rendertarget_texture2darray WebGL 2 / render target / array]<br />
+			[example:webgl_rendertarget_texture2darray WebGL / render target / array]<br />
 		</p>
 
 		<h2>Constructor</h2>

--- a/docs/api/en/textures/Data3DTexture.html
+++ b/docs/api/en/textures/Data3DTexture.html
@@ -62,10 +62,10 @@
 		<h2>Examples</h2>
 
 		<p>
-			[example:webgl2_materials_texture3d WebGL2 / materials / texture3d]<br />
-			[example:webgl2_materials_texture3d_partialupdate WebGL2 / materials / texture3d / partialupdate]<br />
-			[example:webgl2_volume_cloud WebGL2 / volume / cloud]<br />
-			[example:webgl2_volume_perlin WebGL2 / volume / perlin]
+			[example:webgl_texture3d WebGL / texture3d]<br />
+			[example:webgl_texture3d_partialupdate WebGL / texture3d / partialupdate]<br />
+			[example:webgl_volume_cloud WebGL / volume / cloud]<br />
+			[example:webgl_volume_perlin WebGL / volume / perlin]
 		</p>
 
 		<h2>Properties</h2>

--- a/docs/api/en/textures/DataArrayTexture.html
+++ b/docs/api/en/textures/DataArrayTexture.html
@@ -80,8 +80,8 @@
 		<h2>Examples</h2>
 
 		<p>
-			[example:webgl2_materials_texture2darray WebGL2 / materials / texture2darray] 
-			[example:webgl2_rendertarget_texture2darray WebGL2 / rendertarget / texture2darray]
+			[example:webgl_texture2darray WebGL / texture2darray]<br />
+			[example:webgl_rendertarget_texture2darray WebGL / rendertarget / texture2darray]
 		</p>
 
 		<h2>Properties</h2>

--- a/docs/api/fr/materials/RawShaderMaterial.html
+++ b/docs/api/fr/materials/RawShaderMaterial.html
@@ -35,9 +35,9 @@
 			[example:webgl_buffergeometry_instancing_billboards WebGL / buffergeometry / instancing / billboards]<br />
 			[example:webgl_buffergeometry_instancing WebGL / buffergeometry / instancing]<br />
 			[example:webgl_raymarching_reflect WebGL / raymarching / reflect]<br />
-			[example:webgl2_volume_cloud WebGL 2 / volume / cloud]<br />
-			[example:webgl2_volume_instancing WebGL 2 / volume / instancing]<br />
-			[example:webgl2_volume_perlin WebGL 2 / volume / perlin]
+			[example:webgl_volume_cloud WebGL / volume / cloud]<br />
+			[example:webgl_volume_instancing WebGL / volume / instancing]<br />
+			[example:webgl_volume_perlin WebGL / volume / perlin]
 		</p>
 
 		<h2>Constructeur</h2>

--- a/docs/api/it/materials/RawShaderMaterial.html
+++ b/docs/api/it/materials/RawShaderMaterial.html
@@ -36,9 +36,9 @@
 			[example:webgl_buffergeometry_instancing_billboards WebGL / buffergeometry / instancing / billboards]<br />
 			[example:webgl_buffergeometry_instancing WebGL / buffergeometry / instancing]<br />
 			[example:webgl_raymarching_reflect WebGL / raymarching / reflect]<br />
-			[example:webgl2_volume_cloud WebGL 2 / volume / cloud]<br />
-			[example:webgl2_volume_instancing WebGL 2 / volume / instancing]<br />
-			[example:webgl2_volume_perlin WebGL 2 / volume / perlin]
+			[example:webgl_volume_cloud WebGL / volume / cloud]<br />
+			[example:webgl_volume_instancing WebGL / volume / instancing]<br />
+			[example:webgl_volume_perlin WebGL / volume / perlin]
 		</p>
 
 		<h2>Costruttore</h2>

--- a/docs/api/it/renderers/WebGLArrayRenderTarget.html
+++ b/docs/api/it/renderers/WebGLArrayRenderTarget.html
@@ -18,7 +18,7 @@
 		<h2>Esempi</h2>
 
 		<p>
-			[example:webgl2_rendertarget_texture2darray WebGL 2 / render target / array]<br />
+			[example:webgl_rendertarget_texture2darray WebGL / render target / array]<br />
 		</p>
 
 		<h2>Costruttore</h2>

--- a/docs/api/it/textures/Data3DTexture.html
+++ b/docs/api/it/textures/Data3DTexture.html
@@ -29,7 +29,7 @@
 		<h2>Esempi</h2>
 
 		<p>
-			[example:webgl2_materials_texture3d WebGL2 / materials / texture3d]
+			[example:webgl_texture3d WebGL / materials / texture3d]
 		</p>
 
 		<h2>Proprietà</h2>

--- a/docs/api/it/textures/DataArrayTexture.html
+++ b/docs/api/it/textures/DataArrayTexture.html
@@ -79,7 +79,7 @@
 		<h2>Esempi</h2>
 
 		<p>
-			[example:webgl2_materials_texture2darray WebGL2 / materials / texture2darray]
+			[example:webgl_texture2darray WebGL / texture2darray]
 		</p>
 
 		<h2>Proprietà</h2>

--- a/docs/api/zh/materials/RawShaderMaterial.html
+++ b/docs/api/zh/materials/RawShaderMaterial.html
@@ -34,9 +34,9 @@
 			[example:webgl_buffergeometry_instancing_billboards WebGL / buffergeometry / instancing / billboards]<br />
 			[example:webgl_buffergeometry_instancing WebGL / buffergeometry / instancing]<br />
 			[example:webgl_raymarching_reflect WebGL / raymarching / reflect]<br />
-			[example:webgl2_volume_cloud WebGL 2 / volume / cloud]<br />
-			[example:webgl2_volume_instancing WebGL 2 / volume / instancing]<br />
-			[example:webgl2_volume_perlin WebGL 2 / volume / perlin]
+			[example:webgl_volume_cloud WebGL / volume / cloud]<br />
+			[example:webgl_volume_instancing WebGL / volume / instancing]<br />
+			[example:webgl_volume_perlin WebGL / volume / perlin]
 		</p>
 
 		<h2>构造函数(Constructor)</h2>

--- a/docs/api/zh/renderers/WebGLArrayRenderTarget.html
+++ b/docs/api/zh/renderers/WebGLArrayRenderTarget.html
@@ -18,7 +18,7 @@
 		<h2>示例</h2>
 
 		<p>
-			[example:webgl2_rendertarget_texture2darray WebGL 2 / render target / array]<br />
+			[example:webgl_rendertarget_texture2darray WebGL / render target / array]<br />
 		</p>
 
 		<h2>构造函数</h2>

--- a/docs/api/zh/textures/Data3DTexture.html
+++ b/docs/api/zh/textures/Data3DTexture.html
@@ -29,7 +29,7 @@
 		<h2>例子</h2>
 
 		<p>
-			[example:webgl2_materials_texture3d WebGL2 / materials / texture3d]
+			[example:webgl_texture3d WebGL / materials / texture3d]
 		</p>
 
 		<h2>属性</h2>

--- a/docs/api/zh/textures/DataArrayTexture.html
+++ b/docs/api/zh/textures/DataArrayTexture.html
@@ -74,8 +74,8 @@
 		<h2>示例(Examples)</h2>
 
 		<p>
-			[example:webgl2_materials_texture2darray WebGL2 / materials / texture2darray]
-			[example:webgl2_rendertarget_texture2darray WebGL2 / rendertarget / texture2darray]
+			[example:webgl_texture2darray WebGL / texture2darray]<br />
+			[example:webgl_rendertarget_texture2darray WebGL / rendertarget / texture2darray]
 		</p>
 
 		<h2>特性(Properties)</h2>


### PR DESCRIPTION
Related issue: -

**Description**

The PR fixes some broken links in the docs due to 1603f769f08bbff3cc875e074dc3f1e3b8022252.
