### PR TITLE
WebGLRenderer: Add .setLookCDL()

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -507,7 +507,7 @@ class WebGLRenderer {
 
 			this._primaryGradingCDL.set( slope, offset, power, saturation );
 
-		}
+		};
 
 		// Clearing
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -145,10 +145,12 @@ class WebGLRenderer {
 
 		this._outputColorSpace = SRGBColorSpace;
 
-		// tone mapping
+		// image formation
 
 		this.toneMapping = NoToneMapping;
 		this.toneMappingExposure = 1.0;
+
+		this._primaryGradingCDL = new Vector4( 1, 0, 1, 1 );
 
 		// internal properties
 
@@ -500,6 +502,12 @@ class WebGLRenderer {
 			_transparentSort = method;
 
 		};
+
+		this.setPrimaryGradingCDL = function ( slope = 1, offset = 0, power = 1, saturation = 1 ) {
+
+			this._primaryGradingCDL.set( slope, offset, power, saturation );
+
+		}
 
 		// Clearing
 
@@ -1643,6 +1651,7 @@ class WebGLRenderer {
 			materialProperties.fog = scene.fog;
 			materialProperties.envMap = ( material.isMeshStandardMaterial ? cubeuvmaps : cubemaps ).get( material.envMap || materialProperties.environment );
 			materialProperties.envMapRotation = ( materialProperties.environment !== null && material.envMap === null ) ? scene.environmentRotation : material.envMapRotation;
+			materialProperties.primaryGradingCDL = _this._primaryGradingCDL;
 
 			if ( programs === undefined ) {
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -150,7 +150,7 @@ class WebGLRenderer {
 		this.toneMapping = NoToneMapping;
 		this.toneMappingExposure = 1.0;
 
-		this._primaryGradingCDL = new Vector4( 1, 0, 1, 1 );
+		this._lookCDL = new Vector4( 1, 0, 1, 1 );
 
 		// internal properties
 
@@ -503,9 +503,9 @@ class WebGLRenderer {
 
 		};
 
-		this.setPrimaryGradingCDL = function ( slope = 1, offset = 0, power = 1, saturation = 1 ) {
+		this.setLookCDL = function ( slope = 1, offset = 0, power = 1, saturation = 1 ) {
 
-			this._primaryGradingCDL.set( slope, offset, power, saturation );
+			this._lookCDL.set( slope, offset, power, saturation );
 
 		};
 
@@ -1651,7 +1651,7 @@ class WebGLRenderer {
 			materialProperties.fog = scene.fog;
 			materialProperties.envMap = ( material.isMeshStandardMaterial ? cubeuvmaps : cubemaps ).get( material.envMap || materialProperties.environment );
 			materialProperties.envMapRotation = ( materialProperties.environment !== null && material.envMap === null ) ? scene.environmentRotation : material.envMapRotation;
-			materialProperties.primaryGradingCDL = _this._primaryGradingCDL;
+			materialProperties.lookCDL = _this._lookCDL;
 
 			if ( programs === undefined ) {
 

--- a/src/renderers/shaders/ShaderChunk/tonemapping_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/tonemapping_pars_fragment.glsl.js
@@ -1,4 +1,4 @@
-export default /* glsl */ `
+export default /* glsl */`
 #ifndef saturate
 // <common> may have defined saturate() already
 #define saturate( a ) clamp( a, 0.0, 1.0 )
@@ -81,7 +81,8 @@ vec3 ACESFilmicToneMapping( vec3 color ) {
 
 	color = ACESInputMat * color;
 
-	color = applyPrimaryGradingCDL( color );
+	// TODO: Convert to ACEScc or ACEScct, apply CDL, and convert back.
+	// color = applyPrimaryGradingCDL( color );
 
 	// Apply RRT and ODT
 	color = RRTAndODTFit( color );

--- a/src/renderers/shaders/ShaderChunk/tonemapping_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/tonemapping_pars_fragment.glsl.js
@@ -5,15 +5,15 @@ export default /* glsl */`
 #endif
 
 uniform float toneMappingExposure;
-uniform vec4 primaryGradingCDL;
+uniform vec4 lookCDL;
 
 // Applies ASC CDL v1.2 color grade to input color in an unspecified log or linear space.
-vec3 applyPrimaryGradingCDL( vec3 color ) {
+vec3 applyLookCDL( vec3 color ) {
 
-	float slope = primaryGradingCDL.x;
-	float offset = primaryGradingCDL.y;
-	float power = primaryGradingCDL.z;
-	float saturation = primaryGradingCDL.w;
+	float slope = lookCDL.x;
+	float offset = lookCDL.y;
+	float power = lookCDL.z;
+	float saturation = lookCDL.w;
 
 	// Fixed Rec. 709 weights for saturation as specified by ASC CDL v1.2.
 	float luma = dot( color, vec3( 0.2126, 0.7152, 0.0722 ) );
@@ -82,7 +82,7 @@ vec3 ACESFilmicToneMapping( vec3 color ) {
 	color = ACESInputMat * color;
 
 	// TODO: Convert to ACEScc or ACEScct, apply CDL, and convert back.
-	// color = applyPrimaryGradingCDL( color );
+	// color = applyLookCDL( color );
 
 	// Apply RRT and ODT
 	color = RRTAndODTFit( color );
@@ -170,7 +170,7 @@ vec3 AgXToneMapping( vec3 color ) {
 	color = agxDefaultContrastApprox( color );
 
 	// Apply AgX look
-	color = applyPrimaryGradingCDL( color );
+	color = applyLookCDL( color );
 
 	color = AgXOutsetMatrix * color;
 

--- a/src/renderers/shaders/UniformsLib.js
+++ b/src/renderers/shaders/UniformsLib.js
@@ -1,6 +1,7 @@
 import { Color } from '../../math/Color.js';
 import { Vector2 } from '../../math/Vector2.js';
 import { Matrix3 } from '../../math/Matrix3.js';
+import { Vector4 } from '../../math/Vector4.js';
 
 /**
  * Uniforms library for shared webgl shaders
@@ -19,7 +20,9 @@ const UniformsLib = {
 		alphaMap: { value: null },
 		alphaMapTransform: { value: /*@__PURE__*/ new Matrix3() },
 
-		alphaTest: { value: 0 }
+		alphaTest: { value: 0 },
+
+		primaryGradingCDL: { value: /*@__PURE__*/ new Vector4() },
 
 	},
 

--- a/src/renderers/shaders/UniformsLib.js
+++ b/src/renderers/shaders/UniformsLib.js
@@ -22,7 +22,7 @@ const UniformsLib = {
 
 		alphaTest: { value: 0 },
 
-		primaryGradingCDL: { value: /*@__PURE__*/ new Vector4() },
+		lookCDL: { value: /*@__PURE__*/ new Vector4() },
 
 	},
 

--- a/src/renderers/webgl/WebGLMaterials.js
+++ b/src/renderers/webgl/WebGLMaterials.js
@@ -121,6 +121,10 @@ function WebGLMaterials( renderer, properties ) {
 
 		uniforms.opacity.value = material.opacity;
 
+		const materialProperties = properties.get( material );
+
+		uniforms.primaryGradingCDL.value.copy( materialProperties.primaryGradingCDL );
+
 		if ( material.color ) {
 
 			uniforms.diffuse.value.copy( material.color );
@@ -213,8 +217,6 @@ function WebGLMaterials( renderer, properties ) {
 			uniforms.alphaTest.value = material.alphaTest;
 
 		}
-
-		const materialProperties = properties.get( material );
 
 		const envMap = materialProperties.envMap;
 		const envMapRotation = materialProperties.envMapRotation;

--- a/src/renderers/webgl/WebGLMaterials.js
+++ b/src/renderers/webgl/WebGLMaterials.js
@@ -123,7 +123,7 @@ function WebGLMaterials( renderer, properties ) {
 
 		const materialProperties = properties.get( material );
 
-		uniforms.primaryGradingCDL.value.copy( materialProperties.primaryGradingCDL );
+		uniforms.lookCDL.value.copy( materialProperties.lookCDL );
 
 		if ( material.color ) {
 


### PR DESCRIPTION
- Alternative to https://github.com/mrdoob/three.js/pull/27618

Adds a basic primary color grading API to THREE.WebGLRenderer, based on [ASC CDL v1.2](https://en.wikipedia.org/wiki/ASC_CDL). Ultimately, I think full-featured color grading APIs belong in post-processing effects and/or TSL nodes, not THREE.WebGLRenderer... but our tone mapping implementations are very limited today by not having anything comparable to Blender's “Looks”. Without that, we need the hard-coded brightness boost for ACES Filmic, and AgX is stuck at a base contrast never intended as a one-size-fits-all look.

This PR offers a more flexible API than just a list of preset Looks, and is meant to be fully compatible with AgX and ACES Filmic tone mapping. Basic support in our other tone mappers is possible, but I'm not confident the other tone mapping methods were designed to handle color grading robustly, so issues like hue shifting may occur.

For our purposes, “primary color grading” means:

1. The first step in a color correction workflow
2. Affects the entire image[^1], no masks or power windows
3. Applied before tone mapping, minimizing information loss
4. Supports open domain [0,∞] input and output, compatible with “HDR” workflows
5. Efficient enough to run on any WebGL-compatible device

The CDL, chosen to keep the implementation lightweight, is represented as a single vec4 uniform, representing: `slope`, `offset`, `power`, and `saturation`. In a full CDL implementation, the slope+offset+power (SOP) parameters would each be of type vec3 (a value for each RGB channel). I did not include per-channel SOP values, as they are not required to match Blender's default Looks.

Usage:

```javascript
renderer.toneMapping = THREE.AgXToneMapping;
renderer.setLookCDL( 1.0, 0.0, 1.35, 1.4 ); // AgX Punchy
```

***

<details>

<summary><h2>Parameters</h2></summary>

Admittedly, CDL parameters are not the most “artist-friendly” color grading API, but their advantages are important. The CDL's implementation is precisely defined, and consistent across implementations, requiring only that it be applied to inputs with the same color space on both sides. The CDL is valid for open domain [0, ∞] inputs, and can be safely applied before tone mapping. The CDL can be applied to either linear or log inputs: the results differ, but are useful for different things in each case. From an [excellent answer on Blender Stack Exchange](https://blender.stackexchange.com/a/55239/43930) ...

> Many formulas passed down through Stack Exchange and other sites with information all too frequently assume things about RGB that shouldn't be assumed. While Lift, Gamma, Gain is one such display referred assumed formula, there are many other traps like this. The AdobePDF specification lists many of them, and many of those formulas have sadly ended up in scene referred image manipulation applications.
> ...
> The CDL has no such limitation. It can work on RGB values of any range.

While the SOP parameters will need some explanation, they're capable of representing more artist-friendly concepts, if placed in an appropriate UI. For example, 'contrast' control might be implemented as:

```javascript
const slope = contrast;
const offset = ( 1 - contrast ) x pivot;
const power = 1;
```

A pivot of 0.2 will match the contrast changes found in Blender's looks.

</details>

<details>

<summary><h2>Tone mapping</h2></summary>

_Currently, these changes are enabled only with AgX tone mapping._

Of our current tone mapping implementations, I'm confident that **AgX** and **ACES Filmic** can be combined with color grading and wide gamut color management correctly. Both provide a corresponding log space (AgX Log and ACEScc respectively) in which to apply the CDL. I have some remaining questions about ACES Filmic, so that step is commented out for now.

Other tone mappers (or even no tone mapping) could be optionally supported by the CDL, but we'd want to choose some log space in which to apply the CDL. My inclination is that for fully-supported color management, color grading, and future wide gamut support, efforts should be focused on AgX and ACES Filmic.

</details>

<details>

<summary><h2>Looks</h2></summary>

With these four CDL parameters we can support Blender's default color management looks. Derived parameters for each look are included below.

| look                 | slope  | offset | power | saturation |
|:---------------------|------:|--------:|------:|-----------:|
| Punchy               | 1.00  | 0.000  | 1.35   | 1.40       |
| |
| Very High Contrast   | 1.57  | -0.114 | 1.00   | 0.90       |
| High Contrast        | 1.40  | -0.080 | 1.00   | 0.95       |
| Medium High Contrast | 1.20  | -0.040 | 1.00   | 1.00       |
| Base Contrast        | 1.00  | 0.000  | 1.00   | 1.00       |
| Medium Low Contrast  | 0.90  | 0.020  | 1.00   | 1.05       |
| Low Contrast         | 0.80  | 0.040  | 1.00   | 1.10       |
| Very Low Contrast    | 0.70  | 0.060  | 1.00   | 1.15       |

These looks were designed for AgX. While they could be used with ACES Filmic, looks like "High Contrast" cannot guarantee consistent contrast from one tone mapper to another.

_Base Contrast_ — the AgX default — is a good choice for [shooting flat](https://blog.frame.io/2017/05/30/emulate-any-film-look-with-basic-color-correction/), offering an excellent baseline for additional color grading. Starting from highly-saturated colors can make later color grading more difficult. However, users who just want a satisfying image “out of the box” will probably want to choose a look with higher contrast.

_Punchy_ — AgX preset with greater saturation and contrast, and more likely to match the expectations of users switching over from ACES Filmic or Khronos PBR Neutral to AgX. See below, a comparison between Khronos PBR Neutral (left) and AgX Punchy (right).

![two 3D blender models, both fairly similar in hue and contrast](https://github.com/mrdoob/three.js/assets/1848368/4785cc49-9f78-4c1c-9d2a-a48f12df9212)

_Golden_ — included in some AgX implementations, but not in Blender — requires per-channel controls over the SOP parameters, and so is omitted here.

_Greyscale_ — no exact match with the CDL, but simply reducing saturation to 0 will create a greyscale image, and the remaining parameters work as before, e.g. for contrast adjustments.

</details>

***

The CDL is not intend to be the complete color grading workflow, but to complement tone mapping in getting close to the desired look, before making other (potentially lossy) color grading changes. A more flexible color grading workflow would look something like Filament's [ColorGrading](https://github.com/google/filament/blob/main/filament/src/details/ColorGrading.cpp), or OCIO's [GradingPrimaryTransform](https://opencolorio.readthedocs.io/en/latest/api/grading_transforms.html). These might be good goals for us to support at some point, but I wasn't confident the added complexity would be welcome or necessary in WebGLRenderer. More high-level APIs could remain in post-processing effects, or be expressed as a set of color correction nodes with TSL.

I'll open a new PR, separately, for a usage example.

/cc @gkjohnson @WestLangley 

[^1]: One notable exception, materials excluded from tone mapping are not affected by primary color grading. Un-tonemapped materials could be included in the future, but this requires some complex decisions.

