### PR TITLE
TSL: Introduce `Node.updateAfter`

### DIFF
--- a/examples/jsm/nodes/core/Node.js
+++ b/examples/jsm/nodes/core/Node.js
@@ -17,6 +17,7 @@ class Node extends EventDispatcher {
 
 		this.updateType = NodeUpdateType.NONE;
 		this.updateBeforeType = NodeUpdateType.NONE;
+		this.updateAfterType = NodeUpdateType.NONE;
 
 		this.uuid = MathUtils.generateUUID();
 
@@ -165,6 +166,12 @@ class Node extends EventDispatcher {
 
 	}
 
+	getUpdateAfterType() {
+
+		return this.updateAfterType;
+
+	}
+
 	getElementType( builder ) {
 
 		const type = this.getNodeType( builder );
@@ -268,6 +275,12 @@ class Node extends EventDispatcher {
 	}
 
 	updateBefore( /*frame*/ ) {
+
+		console.warn( 'Abstract function.' );
+
+	}
+
+	updateAfter( /*frame*/ ) {
 
 		console.warn( 'Abstract function.' );
 

--- a/examples/jsm/nodes/core/NodeBuilder.js
+++ b/examples/jsm/nodes/core/NodeBuilder.js
@@ -67,6 +67,7 @@ class NodeBuilder {
 		this.nodes = [];
 		this.updateNodes = [];
 		this.updateBeforeNodes = [];
+		this.updateAfterNodes = [];
 		this.hashNodes = {};
 
 		this.lightsNode = null;
@@ -215,6 +216,7 @@ class NodeBuilder {
 
 			const updateType = node.getUpdateType();
 			const updateBeforeType = node.getUpdateBeforeType();
+			const updateAfterType = node.getUpdateAfterType();
 
 			if ( updateType !== NodeUpdateType.NONE ) {
 
@@ -225,6 +227,12 @@ class NodeBuilder {
 			if ( updateBeforeType !== NodeUpdateType.NONE ) {
 
 				this.updateBeforeNodes.push( node );
+
+			}
+
+			if ( updateAfterType !== NodeUpdateType.NONE ) {
+
+				this.updateAfterNodes.push( node );
 
 			}
 

--- a/examples/jsm/nodes/core/NodeFrame.js
+++ b/examples/jsm/nodes/core/NodeFrame.js
@@ -14,6 +14,7 @@ class NodeFrame {
 
 		this.updateMap = new WeakMap();
 		this.updateBeforeMap = new WeakMap();
+		this.updateAfterMap = new WeakMap();
 
 		this.renderer = null;
 		this.material = null;
@@ -78,6 +79,47 @@ class NodeFrame {
 		} else if ( updateType === NodeUpdateType.OBJECT ) {
 
 			node.updateBefore( this );
+
+		}
+
+	}
+
+	updateAfterNode( node ) {
+
+		const updateType = node.getUpdateAfterType();
+		const reference = node.updateReference( this );
+
+		if ( updateType === NodeUpdateType.FRAME ) {
+
+			const { frameMap } = this._getMaps( this.updateAfterMap, reference );
+
+			if ( frameMap.get( reference ) !== this.frameId ) {
+
+				if ( node.updateAfter( this ) !== false ) {
+
+					frameMap.set( reference, this.frameId );
+
+				}
+
+			}
+
+		} else if ( updateType === NodeUpdateType.RENDER ) {
+
+			const { renderMap } = this._getMaps( this.updateAfterMap, reference );
+
+			if ( renderMap.get( reference ) !== this.renderId ) {
+
+				if ( node.updateAfter( this ) !== false ) {
+
+					renderMap.set( reference, this.renderId );
+
+				}
+
+			}
+
+		} else if ( updateType === NodeUpdateType.OBJECT ) {
+
+			node.updateAfter( this );
 
 		}
 

--- a/examples/jsm/renderers/common/Renderer.js
+++ b/examples/jsm/renderers/common/Renderer.js
@@ -399,6 +399,8 @@ class Renderer {
 
 				this.backend.draw( renderObject, this.info );
 
+				this._nodes.updateAfter( renderObject );
+
 			}
 
 		}
@@ -1527,6 +1529,8 @@ class Renderer {
 
 		}
 
+		this._nodes.updateAfter( renderObject );
+
 	}
 
 	_createObjectPipeline( object, material, scene, camera, lightsNode, passId ) {
@@ -1544,6 +1548,8 @@ class Renderer {
 		this._bindings.updateForRender( renderObject );
 
 		this._pipelines.getForRender( renderObject, this._compilationPromises );
+
+		this._nodes.updateAfter( renderObject );
 
 	}
 

--- a/examples/jsm/renderers/common/nodes/NodeBuilderState.js
+++ b/examples/jsm/renderers/common/nodes/NodeBuilderState.js
@@ -1,6 +1,6 @@
 class NodeBuilderState {
 
-	constructor( vertexShader, fragmentShader, computeShader, nodeAttributes, bindings, updateNodes, updateBeforeNodes, transforms = [] ) {
+	constructor( vertexShader, fragmentShader, computeShader, nodeAttributes, bindings, updateNodes, updateBeforeNodes, updateAfterNodes, transforms = [] ) {
 
 		this.vertexShader = vertexShader;
 		this.fragmentShader = fragmentShader;
@@ -12,6 +12,7 @@ class NodeBuilderState {
 
 		this.updateNodes = updateNodes;
 		this.updateBeforeNodes = updateBeforeNodes;
+		this.updateAfterNodes = updateAfterNodes;
 
 		this.usedTimes = 0;
 

--- a/examples/jsm/renderers/common/nodes/Nodes.js
+++ b/examples/jsm/renderers/common/nodes/Nodes.js
@@ -182,6 +182,7 @@ class Nodes extends DataMap {
 			nodeBuilder.getBindings(),
 			nodeBuilder.updateNodes,
 			nodeBuilder.updateBeforeNodes,
+			nodeBuilder.updateAfterNodes,
 			nodeBuilder.transforms
 		);
 
@@ -422,6 +423,19 @@ class Nodes extends DataMap {
 		for ( const node of nodeBuilder.updateBeforeNodes ) {
 
 			nodeFrame.updateBeforeNode( node );
+
+		}
+
+	}
+
+	updateAfter( renderObject ) {
+
+		const nodeFrame = this.getNodeFrameForRender( renderObject );
+		const nodeBuilder = renderObject.getNodeBuilderState();
+
+		for ( const node of nodeBuilder.updateAfterNodes ) {
+
+			nodeFrame.updateAfterNode( node );
 
 		}
 


### PR DESCRIPTION
**Description**

Just like `onAfterRender` in the `WebGLRenderer`, this PR adds a new callback to the node system that happens just after an object has been rendered. 

Example usage:
```js
const modelMatrixPrev = uniform( new Matrix4() );
modelMatrixPrev.updateAfterType = NodeUpdateType.OBJECT;
modelMatrixPrev.updateAfter = function ( { object } ) {

    this.value.copy( object.matrixWorld );

};
```
*This contribution is funded by [Utsubo](https://utsubo.com)*
