### PR TITLE
WebGPURenderer: cache the result of gl.getExtension() calls as intended.

### DIFF
--- a/examples/jsm/renderers/webgl/utils/WebGLExtensions.js
+++ b/examples/jsm/renderers/webgl/utils/WebGLExtensions.js
@@ -19,6 +19,8 @@ class WebGLExtensions {
 
 			extension = this.gl.getExtension( name );
 
+			this.extensions[ name ] = extension;
+
 		}
 
 		return extension;


### PR DESCRIPTION
As subject, the code obviously was intended to cache the result, but the result was not cached.
