### PR TITLE
GLTFLoader: Use `ImageBitmapLoader` in for Safari >= 17.

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2580,18 +2580,20 @@ class GLTFParser {
 		// expensive work of uploading a texture to the GPU off the main thread.
 
 		let isSafari = false;
+		let safariVersion = - 1;
 		let isFirefox = false;
 		let firefoxVersion = - 1;
 
 		if ( typeof navigator !== 'undefined' ) {
 
 			isSafari = /^((?!chrome|android).)*safari/i.test( navigator.userAgent ) === true;
+			safariVersion = isSafari ? navigator.userAgent.match( /Version\/(\d+)/ )[ 1 ] : - 1;
 			isFirefox = navigator.userAgent.indexOf( 'Firefox' ) > - 1;
 			firefoxVersion = isFirefox ? navigator.userAgent.match( /Firefox\/([0-9]+)\./ )[ 1 ] : - 1;
 
 		}
 
-		if ( typeof createImageBitmap === 'undefined' || isSafari || ( isFirefox && firefoxVersion < 98 ) ) {
+		if ( typeof createImageBitmap === 'undefined' || ( isSafari && safariVersion < 17 ) || ( isFirefox && firefoxVersion < 98 ) ) {
 
 			this.textureLoader = new TextureLoader( this.options.manager );
 


### PR DESCRIPTION
**Description**

Start using ImageBitmapLoader for Safari >= 17 to fix texture loading in a web worker. Also makes Safari three.js texture loading performance better.

**Note**

I have only tested this on Safari 17.5 as I don't have older one available. Partial support for CreateImageBitmap in Safari has been around for a longer time but it would be great if someone could make sure that textures still load fine with GLTFLoader when using Safari 17.0. If not, we can change the version limit to 17.5.

The currently used TextureLoader cannot be used in a web-worker and will fail with an error.