### PR TITLE
XRHandModelFactory: Fix Inverted Hands on the Apple Vision Pro

### DIFF
--- a/examples/jsm/webxr/XRHandMeshModel.js
+++ b/examples/jsm/webxr/XRHandMeshModel.js
@@ -8,6 +8,7 @@ class XRHandMeshModel {
 
 		this.controller = controller;
 		this.handModel = handModel;
+		this.handedness = handedness;
 
 		this.bones = [];
 
@@ -106,6 +107,19 @@ class XRHandMeshModel {
 			}
 
 		}
+
+	}
+
+	dispose() {
+
+		this.handModel.children[ 0 ].traverse((obj) => {
+			if ( obj.isMesh || obj.isSkinnedMesh || obj.isInstancedMesh ) {
+				obj.geometry.dispose();
+				obj.material.dispose();
+			}
+		});
+
+		this.handModel.remove( this.handModel.children[ 0 ] );
 
 	}
 

--- a/examples/jsm/webxr/XRHandModelFactory.js
+++ b/examples/jsm/webxr/XRHandModelFactory.js
@@ -64,6 +64,13 @@ class XRHandModelFactory {
 
 			const xrInputSource = event.data;
 
+			if ( handModel.motionController && handModel.motionController.handedness !== xrInputSource.handedness ) {
+				
+				handModel.motionController.dispose();
+				handModel.motionController = null;
+
+			}
+
 			if ( xrInputSource.hand && ! handModel.motionController ) {
 
 				handModel.xrInputSource = xrInputSource;

--- a/examples/jsm/webxr/XRHandPrimitiveModel.js
+++ b/examples/jsm/webxr/XRHandPrimitiveModel.js
@@ -19,21 +19,19 @@ class XRHandPrimitiveModel {
 		this.handModel = handModel;
 		this.envMap = null;
 
-		let geometry;
-
 		if ( ! options || ! options.primitive || options.primitive === 'sphere' ) {
 
-			geometry = new SphereGeometry( 1, 10, 10 );
+			this.geometry = new SphereGeometry( 1, 10, 10 );
 
 		} else if ( options.primitive === 'box' ) {
 
-			geometry = new BoxGeometry( 1, 1, 1 );
+			this.geometry = new BoxGeometry( 1, 1, 1 );
 
 		}
 
-		const material = new MeshStandardMaterial();
+		this.material = new MeshStandardMaterial();
 
-		this.handMesh = new InstancedMesh( geometry, material, 30 );
+		this.handMesh = new InstancedMesh( this.geometry, this.material, 30 );
 		this.handMesh.frustumCulled = false;
 		this.handMesh.instanceMatrix.setUsage( DynamicDrawUsage ); // will be updated every frame
 		this.handMesh.castShadow = true;
@@ -95,6 +93,16 @@ class XRHandPrimitiveModel {
 
 		this.handMesh.count = count;
 		this.handMesh.instanceMatrix.needsUpdate = true;
+
+	}
+
+	dispose() {
+
+		this.handModel.remove( this.handMesh );
+
+		this.geometry.dispose();
+
+		this.material.dispose();
 
 	}
 

--- a/examples/jsm/webxr/XRHandPrimitiveModel.js
+++ b/examples/jsm/webxr/XRHandPrimitiveModel.js
@@ -17,6 +17,7 @@ class XRHandPrimitiveModel {
 
 		this.controller = controller;
 		this.handModel = handModel;
+		this.handedness = handedness;
 		this.envMap = null;
 
 		if ( ! options || ! options.primitive || options.primitive === 'sphere' ) {


### PR DESCRIPTION
On the Apple Vision Pro, hand/controller indices are assigned by the order they appear, and unassigned when they disappear.

This can cause hands that initially appeared as one handedness to later appear as another handedness.
This causes the Mesh Hands to appear inverted, as the `SkinnedMesh` is contorted to the mirror bone structure.

This PR detects handedness flips and re-initializes those meshes when it occurs.

I'm including the same logic for the Primitive Hands for conceptual purity, though they are currently unaffected by this issue due to their simplistic appearance.   I'd like to add slightly [more flair](https://github.com/leapmotion/LeapShape?tab=readme-ov-file#a-simple-and-powerful-3d-modelling-tool) to the humble primitive hands someday, but not in this PR...

Here is a video of the old behavior:

https://github.com/mrdoob/three.js/assets/174475/67771b82-4d67-48c1-8797-87f9928fa3ce

And here's a video of the fixed behavior:

https://github.com/mrdoob/three.js/assets/174475/af7991ae-87b4-4a6f-b957-085dc4e49ce7

[I've also submitted a bug to Apple](https://feedbackassistant.apple.com/feedback/13818773), but usually they're pretty stubborn about ensuring their browser stays broken.   
If they do ever fix this behavior, then this PR becomes a no-op.

(Also the WebGPU Reflections E2E Test has a Stats window that stochastically appears in the corner, causing the test to succeed or fail randomly. Kind of annoying...)