### PR TITLE
WebGLRenderer: Sort objects in clip space.

### DIFF
--- a/docs/api/en/math/Vector4.html
+++ b/docs/api/en/math/Vector4.html
@@ -321,6 +321,12 @@
 			and [page:.w w] to the angle.
 		</p>
 
+		<h3>[method:this setFromMatrixPosition]( [param:Matrix4 m] )</h3>
+		<p>
+			Sets this vector to the position elements of the
+			[link:https://en.wikipedia.org/wiki/Transformation_matrix transformation matrix] [page:Matrix4 m].
+		</p>
+
 		<h3>
 			[method:this setComponent]( [param:Integer index], [param:Float value] )
 		</h3>

--- a/src/math/Vector4.js
+++ b/src/math/Vector4.js
@@ -413,6 +413,19 @@ class Vector4 {
 
 	}
 
+	setFromMatrixPosition( m ) {
+
+		const e = m.elements;
+
+		this.x = e[ 12 ];
+		this.y = e[ 13 ];
+		this.z = e[ 14 ];
+		this.w = e[ 15 ];
+
+		return this;
+
+	}
+
 	min( v ) {
 
 		this.x = Math.min( this.x, v.x );

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1308,7 +1308,9 @@ class WebGLRenderer {
 						if ( sortObjects ) {
 
 							_vector4.setFromMatrixPosition( object.matrixWorld )
-								.applyMatrix4( _projScreenMatrix );
+								.applyMatrix4( camera.matrixWorldInverse );
+							_vector4.divideScalar( _vector4 )
+								.applyMatrix4( camera.projectionMatrix );
 
 						}
 
@@ -1346,7 +1348,9 @@ class WebGLRenderer {
 
 							_vector4
 								.applyMatrix4( object.matrixWorld )
-								.applyMatrix4( _projScreenMatrix );
+								.applyMatrix4( camera.matrixWorldInverse );
+							_vector4.divideScalar( _vector4 )
+								.applyMatrix4( camera.projectionMatrix );
 
 						}
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1307,10 +1307,9 @@ class WebGLRenderer {
 
 						if ( sortObjects ) {
 
-							_vector4.setFromMatrixPosition( object.matrixWorld )
-								.applyMatrix4( camera.matrixWorldInverse );
-							_vector4.divideScalar( _vector4 )
-								.applyMatrix4( camera.projectionMatrix );
+							_vector3.setFromMatrixPosition( object.matrixWorld );
+							_vector4.copy( _vector3 )
+								.applyMatrix4( _projScreenMatrix );
 
 						}
 
@@ -1348,9 +1347,7 @@ class WebGLRenderer {
 
 							_vector4
 								.applyMatrix4( object.matrixWorld )
-								.applyMatrix4( camera.matrixWorldInverse );
-							_vector4.divideScalar( _vector4 )
-								.applyMatrix4( camera.projectionMatrix );
+								.applyMatrix4( _projScreenMatrix );
 
 						}
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1307,8 +1307,7 @@ class WebGLRenderer {
 
 						if ( sortObjects ) {
 
-							_vector3.setFromMatrixPosition( object.matrixWorld );
-							_vector4.copy( _vector3 )
+							_vector4.setFromMatrixPosition( object.matrixWorld )
 								.applyMatrix4( _projScreenMatrix );
 
 						}

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -204,6 +204,8 @@ class WebGLRenderer {
 
 		const _vector3 = new Vector3();
 
+		const _vector4 = new Vector4();
+
 		const _emptyScene = { background: null, fog: null, environment: null, overrideMaterial: null, isScene: true };
 
 		let _renderBackground = false;
@@ -1305,8 +1307,8 @@ class WebGLRenderer {
 
 						if ( sortObjects ) {
 
-							_vector3.setFromMatrixPosition( object.matrixWorld )
-								.applyMatrix4( camera.matrixWorldInverse );
+							_vector4.setFromMatrixPosition( object.matrixWorld )
+								.applyMatrix4( _projScreenMatrix );
 
 						}
 
@@ -1315,7 +1317,7 @@ class WebGLRenderer {
 
 						if ( material.visible ) {
 
-							currentRenderList.push( object, geometry, material, groupOrder, - _vector3.z, null );
+							currentRenderList.push( object, geometry, material, groupOrder, _vector4.z, null );
 
 						}
 
@@ -1333,18 +1335,18 @@ class WebGLRenderer {
 							if ( object.boundingSphere !== undefined ) {
 
 								if ( object.boundingSphere === null ) object.computeBoundingSphere();
-								_vector3.copy( object.boundingSphere.center );
+								_vector4.copy( object.boundingSphere.center );
 
 							} else {
 
 								if ( geometry.boundingSphere === null ) geometry.computeBoundingSphere();
-								_vector3.copy( geometry.boundingSphere.center );
+								_vector4.copy( geometry.boundingSphere.center );
 
 							}
 
-							_vector3
+							_vector4
 								.applyMatrix4( object.matrixWorld )
-								.applyMatrix4( camera.matrixWorldInverse );
+								.applyMatrix4( _projScreenMatrix );
 
 						}
 
@@ -1359,7 +1361,7 @@ class WebGLRenderer {
 
 								if ( groupMaterial && groupMaterial.visible ) {
 
-									currentRenderList.push( object, geometry, groupMaterial, groupOrder, - _vector3.z, group );
+									currentRenderList.push( object, geometry, groupMaterial, groupOrder, _vector4.z, group );
 
 								}
 
@@ -1367,7 +1369,7 @@ class WebGLRenderer {
 
 						} else if ( material.visible ) {
 
-							currentRenderList.push( object, geometry, material, groupOrder, - _vector3.z, null );
+							currentRenderList.push( object, geometry, material, groupOrder, _vector4.z, null );
 
 						}
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1306,7 +1306,7 @@ class WebGLRenderer {
 						if ( sortObjects ) {
 
 							_vector3.setFromMatrixPosition( object.matrixWorld )
-								.applyMatrix4( _projScreenMatrix );
+								.applyMatrix4( camera.matrixWorldInverse );
 
 						}
 
@@ -1315,7 +1315,7 @@ class WebGLRenderer {
 
 						if ( material.visible ) {
 
-							currentRenderList.push( object, geometry, material, groupOrder, _vector3.z, null );
+							currentRenderList.push( object, geometry, material, groupOrder, - _vector3.z, null );
 
 						}
 
@@ -1344,7 +1344,7 @@ class WebGLRenderer {
 
 							_vector3
 								.applyMatrix4( object.matrixWorld )
-								.applyMatrix4( _projScreenMatrix );
+								.applyMatrix4( camera.matrixWorldInverse );
 
 						}
 
@@ -1359,7 +1359,7 @@ class WebGLRenderer {
 
 								if ( groupMaterial && groupMaterial.visible ) {
 
-									currentRenderList.push( object, geometry, groupMaterial, groupOrder, _vector3.z, group );
+									currentRenderList.push( object, geometry, groupMaterial, groupOrder, - _vector3.z, group );
 
 								}
 
@@ -1367,7 +1367,7 @@ class WebGLRenderer {
 
 						} else if ( material.visible ) {
 
-							currentRenderList.push( object, geometry, material, groupOrder, _vector3.z, null );
+							currentRenderList.push( object, geometry, material, groupOrder, - _vector3.z, null );
 
 						}
 

--- a/test/unit/src/math/Vector4.tests.js
+++ b/test/unit/src/math/Vector4.tests.js
@@ -290,6 +290,19 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
+		QUnit.test( 'setFromMatrixPosition', ( assert ) => {
+
+			const a = new Vector4();
+			const m = new Matrix4().set( 2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53 );
+
+			a.setFromMatrixPosition( m );
+			assert.strictEqual( a.x, 7, 'Check x' );
+			assert.strictEqual( a.y, 19, 'Check y' );
+			assert.strictEqual( a.z, 37, 'Check z' );
+			assert.strictEqual( a.w, 53, 'Check w' );
+
+		} );
+
 		QUnit.todo( 'min', ( assert ) => {
 
 			assert.ok( false, 'everything\'s gonna be alright' );


### PR DESCRIPTION
Original PR #28474 was merged slightly early; here's the changes that the discussion in that PR landed on.

This PR changes the space in which objects are sorted from NDC to clip space, as well as adds `Vector4.setFromMatrixPosition` for convenience.