### PR TITLE
#28572 Run unit tests in browser with puppeteer & express

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,12 +13,14 @@
         "@rollup/plugin-terser": "^0.4.0",
         "chalk": "^5.2.0",
         "concurrently": "^8.0.1",
+        "cross-env": "^7.0.3",
         "dpdm": "^3.14.0",
         "eslint": "^8.37.0",
         "eslint-config-mdcs": "^5.0.0",
         "eslint-plugin-compat": "^4.1.2",
         "eslint-plugin-html": "^8.0.0",
         "eslint-plugin-import": "^2.27.5",
+        "express": "^4.17.2",
         "failonlyreporter": "^1.0.0",
         "jimp": "^0.22.7",
         "magic-string": "^0.30.0",
@@ -27,8 +29,7 @@
         "qunit": "^2.19.4",
         "rollup": "^4.6.0",
         "rollup-plugin-filesize": "^10.0.0",
-        "rollup-plugin-visualizer": "^5.9.0",
-        "servez": "^2.0.0"
+        "rollup-plugin-visualizer": "^5.9.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1617,15 +1618,6 @@
       "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
       "dev": true
     },
-    "node_modules/@types/node-forge": {
-      "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.9.tgz",
-      "integrity": "sha512-meK88cx/sTalPSLSoCzkiUB4VPIFHmxtXm5FaaqRDqBX2i/Sy8bJ4odsan0b20RBjPh06dAQ+OTTdnyQyhJZyQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
@@ -1768,15 +1760,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/ansi-colors": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/ansi-regex": {
@@ -2047,24 +2030,6 @@
         }
       ]
     },
-    "node_modules/basic-auth": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
-      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "5.1.2"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/basic-auth/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
-    },
     "node_modules/basic-ftp": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.4.tgz",
@@ -2073,12 +2038,6 @@
       "engines": {
         "node": ">=10.0.0"
       }
-    },
-    "node_modules/batch": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
-      "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
-      "dev": true
     },
     "node_modules/bl": {
       "version": "4.1.0",
@@ -2838,19 +2797,6 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "dev": true
     },
-    "node_modules/cors": {
-      "version": "2.8.5",
-      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
-      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-      "dev": true,
-      "dependencies": {
-        "object-assign": "^4",
-        "vary": "^1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/cosmiconfig": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
@@ -2875,6 +2821,24 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {
@@ -6080,15 +6044,6 @@
         }
       }
     },
-    "node_modules/node-forge": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6.13.0"
-      }
-    },
     "node_modules/node-gyp": {
       "version": "9.4.1",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-9.4.1.tgz",
@@ -6408,15 +6363,6 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {
@@ -7627,25 +7573,6 @@
       "integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==",
       "dev": true
     },
-    "node_modules/secure-compare": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
-      "integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==",
-      "dev": true
-    },
-    "node_modules/selfsigned": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.4.1.tgz",
-      "integrity": "sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==",
-      "dev": true,
-      "dependencies": {
-        "@types/node-forge": "^1.3.0",
-        "node-forge": "^1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/semver": {
       "version": "7.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
@@ -7727,84 +7654,6 @@
         "randombytes": "^2.1.0"
       }
     },
-    "node_modules/serve-index": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
-      "integrity": "sha512-pXHfKNP4qujrtteMrSBb0rc8HJ9Ms/GrXwcUtUtD5s4ewDJI8bT3Cz2zTVRMKtri49pLx2e0Ya8ziP5Ya2pZZw==",
-      "dev": true,
-      "dependencies": {
-        "accepts": "~1.3.4",
-        "batch": "0.6.1",
-        "debug": "2.6.9",
-        "escape-html": "~1.0.3",
-        "http-errors": "~1.6.2",
-        "mime-types": "~2.1.17",
-        "parseurl": "~1.3.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/serve-index/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/serve-index/node_modules/depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/serve-index/node_modules/http-errors": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-      "integrity": "sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==",
-      "dev": true,
-      "dependencies": {
-        "depd": "~1.1.2",
-        "inherits": "2.0.3",
-        "setprototypeof": "1.1.0",
-        "statuses": ">= 1.4.0 < 2"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/serve-index/node_modules/inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
-      "dev": true
-    },
-    "node_modules/serve-index/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
-    },
-    "node_modules/serve-index/node_modules/setprototypeof": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-      "dev": true
-    },
-    "node_modules/serve-index/node_modules/statuses": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/serve-static": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
@@ -7818,55 +7667,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/server-destroy": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
-      "integrity": "sha512-rb+9B5YBIEzYcD6x2VKidaa+cqYBJQKnU4oe4E3ANwRRN56yk/ua1YCJT1n21NTS8w6CcOclAKNP3PhdCXKYtQ==",
-      "dev": true
-    },
-    "node_modules/servez": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/servez/-/servez-2.1.6.tgz",
-      "integrity": "sha512-0ftF6U5mfhHG/dJk6Lu6jglI83eSMazHdpdCcyGgEbEoT1GP7A/PSZxm1b2uo2BYKzP2Zq6hJnGR5e3EcDsSmA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-colors": "^4.1.1",
-        "color-support": "^1.1.3",
-        "commander": "^11.0.0",
-        "servez-lib": "^2.8.5"
-      },
-      "bin": {
-        "servez": "bin/servez"
-      }
-    },
-    "node_modules/servez-lib": {
-      "version": "2.8.5",
-      "resolved": "https://registry.npmjs.org/servez-lib/-/servez-lib-2.8.5.tgz",
-      "integrity": "sha512-6QNqjCVX6t17CQfJfg6f1XtMtdWxXx2maqdrZ+uJYpCDUQinyeDicF4WR7G3hDUnTv2HTp/C9T8kE0aDOVObqw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "basic-auth": "^2.0.1",
-        "cors": "^2.8.5",
-        "debug": "^4.3.4",
-        "express": "^4.19.2",
-        "secure-compare": "^3.0.1",
-        "selfsigned": "^2.4.1",
-        "serve-index": "^1.9.1",
-        "server-destroy": "^1.0.1"
-      }
-    },
-    "node_modules/servez/node_modules/commander": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
-      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
       }
     },
     "node_modules/set-blocking": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,8 @@
         "qunit": "^2.19.4",
         "rollup": "^4.6.0",
         "rollup-plugin-filesize": "^10.0.0",
-        "rollup-plugin-visualizer": "^5.9.0"
+        "rollup-plugin-visualizer": "^5.9.0",
+        "servez": "^2.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1618,6 +1619,15 @@
       "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
       "dev": true
     },
+    "node_modules/@types/node-forge": {
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.11.tgz",
+      "integrity": "sha512-FQx220y22OKNTqaByeBGqHWYz4cl94tpcxeFdvBo3wjG6XPBuZ0BNgNZRV5J5TFmmcsJ4IzsLkmGRiQbnYsBEQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
@@ -1760,6 +1770,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/ansi-regex": {
@@ -2030,6 +2049,24 @@
         }
       ]
     },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/basic-auth/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
     "node_modules/basic-ftp": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.4.tgz",
@@ -2038,6 +2075,12 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/batch": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
+      "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
+      "dev": true
     },
     "node_modules/bl": {
       "version": "4.1.0",
@@ -2796,6 +2839,19 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "dev": true
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dev": true,
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/cosmiconfig": {
       "version": "9.0.0",
@@ -6044,6 +6100,15 @@
         }
       }
     },
+    "node_modules/node-forge": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
     "node_modules/node-gyp": {
       "version": "9.4.1",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-9.4.1.tgz",
@@ -6363,6 +6428,15 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {
@@ -7573,6 +7647,25 @@
       "integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==",
       "dev": true
     },
+    "node_modules/secure-compare": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
+      "integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==",
+      "dev": true
+    },
+    "node_modules/selfsigned": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.4.1.tgz",
+      "integrity": "sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/node-forge": "^1.3.0",
+        "node-forge": "^1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/semver": {
       "version": "7.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
@@ -7654,6 +7747,84 @@
         "randombytes": "^2.1.0"
       }
     },
+    "node_modules/serve-index": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
+      "integrity": "sha512-pXHfKNP4qujrtteMrSBb0rc8HJ9Ms/GrXwcUtUtD5s4ewDJI8bT3Cz2zTVRMKtri49pLx2e0Ya8ziP5Ya2pZZw==",
+      "dev": true,
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "batch": "0.6.1",
+        "debug": "2.6.9",
+        "escape-html": "~1.0.3",
+        "http-errors": "~1.6.2",
+        "mime-types": "~2.1.17",
+        "parseurl": "~1.3.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/serve-index/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/serve-index/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/serve-index/node_modules/http-errors": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "integrity": "sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==",
+      "dev": true,
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.0",
+        "statuses": ">= 1.4.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/serve-index/node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
+      "dev": true
+    },
+    "node_modules/serve-index/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true
+    },
+    "node_modules/serve-index/node_modules/setprototypeof": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+      "dev": true
+    },
+    "node_modules/serve-index/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/serve-static": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
@@ -7667,6 +7838,52 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/server-destroy": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
+      "integrity": "sha512-rb+9B5YBIEzYcD6x2VKidaa+cqYBJQKnU4oe4E3ANwRRN56yk/ua1YCJT1n21NTS8w6CcOclAKNP3PhdCXKYtQ==",
+      "dev": true
+    },
+    "node_modules/servez": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/servez/-/servez-2.1.6.tgz",
+      "integrity": "sha512-0ftF6U5mfhHG/dJk6Lu6jglI83eSMazHdpdCcyGgEbEoT1GP7A/PSZxm1b2uo2BYKzP2Zq6hJnGR5e3EcDsSmA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-colors": "^4.1.1",
+        "color-support": "^1.1.3",
+        "commander": "^11.0.0",
+        "servez-lib": "^2.8.5"
+      },
+      "bin": {
+        "servez": "bin/servez"
+      }
+    },
+    "node_modules/servez-lib": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/servez-lib/-/servez-lib-2.8.5.tgz",
+      "integrity": "sha512-6QNqjCVX6t17CQfJfg6f1XtMtdWxXx2maqdrZ+uJYpCDUQinyeDicF4WR7G3hDUnTv2HTp/C9T8kE0aDOVObqw==",
+      "dev": true,
+      "dependencies": {
+        "basic-auth": "^2.0.1",
+        "cors": "^2.8.5",
+        "debug": "^4.3.4",
+        "express": "^4.19.2",
+        "secure-compare": "^3.0.1",
+        "selfsigned": "^2.4.1",
+        "serve-index": "^1.9.1",
+        "server-destroy": "^1.0.1"
+      }
+    },
+    "node_modules/servez/node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/set-blocking": {

--- a/package.json
+++ b/package.json
@@ -57,8 +57,10 @@
     "lint-utils": "eslint utils",
     "lint": "npm run lint-core",
     "lint-fix": "npm run lint-core -- --fix && npm run lint-addons -- --fix && npm run lint-examples -- --fix && npm run lint-docs -- --fix && npm run lint-editor -- --fix && npm run lint-playground -- --fix && npm run lint-manual -- --fix && npm run lint-test -- --fix && npm run lint-utils -- --fix",
-    "test-unit": "qunit -r failonlyreporter -f !-webonly test/unit/three.source.unit.js",
-    "test-unit-addons": "qunit -r failonlyreporter -f !-webonly test/unit/three.addons.unit.js",
+    "test-unit": "cross-env TEST_PAGE=UnitTests.html node test/unit/puppeteer.unit.js",
+    "test-unit-headful": "cross-env TEST_PAGE=UnitTests.html VISIBLE=true node test/unit/puppeteer.unit.js",
+    "test-unit-addons": "cross-env TEST_PAGE=UnitTestsAddons.html node test/unit/puppeteer.unit.js",
+    "test-unit-addons-headful": "cross-env TEST_PAGE=UnitTestsAddons.html VISIBLE=true node test/unit/puppeteer.unit.js",
     "test-e2e": "node test/e2e/puppeteer.js",
     "test-e2e-cov": "node test/e2e/check-coverage.js",
     "test-treeshake": "rollup -c test/rollup.treeshake.config.js",
@@ -107,7 +109,8 @@
     "rollup": "^4.6.0",
     "rollup-plugin-filesize": "^10.0.0",
     "rollup-plugin-visualizer": "^5.9.0",
-    "servez": "^2.0.0"
+    "express": "^4.17.2",
+    "cross-env": "^7.0.3"
   },
   "overrides": {
     "jpeg-js": "^0.4.4"

--- a/package.json
+++ b/package.json
@@ -110,7 +110,8 @@
     "rollup-plugin-filesize": "^10.0.0",
     "rollup-plugin-visualizer": "^5.9.0",
     "express": "^4.17.2",
-    "cross-env": "^7.0.3"
+    "cross-env": "^7.0.3",
+    "servez": "^2.0.0"
   },
   "overrides": {
     "jpeg-js": "^0.4.4"

--- a/package.json
+++ b/package.json
@@ -94,12 +94,14 @@
     "@rollup/plugin-terser": "^0.4.0",
     "chalk": "^5.2.0",
     "concurrently": "^8.0.1",
+    "cross-env": "^7.0.3",
     "dpdm": "^3.14.0",
     "eslint": "^8.37.0",
     "eslint-config-mdcs": "^5.0.0",
     "eslint-plugin-compat": "^4.1.2",
     "eslint-plugin-html": "^8.0.0",
     "eslint-plugin-import": "^2.27.5",
+    "express": "^4.17.2",
     "failonlyreporter": "^1.0.0",
     "jimp": "^0.22.7",
     "magic-string": "^0.30.0",
@@ -109,8 +111,6 @@
     "rollup": "^4.6.0",
     "rollup-plugin-filesize": "^10.0.0",
     "rollup-plugin-visualizer": "^5.9.0",
-    "express": "^4.17.2",
-    "cross-env": "^7.0.3",
     "servez": "^2.0.0"
   },
   "overrides": {

--- a/test/unit/README.md
+++ b/test/unit/README.md
@@ -4,18 +4,16 @@
 
 ## Run
 
-You can run the unit tests in two environments:
+You can run the unit tests in two ways:
 
-- Node.js: Execute `npm run test-unit` from the root folder
-- Browser: Execute `npx servez -p 8080 --ssl` (or run any other local web sever) from the root folder and access `https://localhost:8080/test/unit/UnitTests.html` in a web browser. 
+- Headless: Execute `npm run test-unit`, `npm run test-unit-addons` from the root folder.  
+  In headless mode the tests will run in a headless browser.  
+- Headful: Execute `npm run test-unit-headful`, `npm run test-unit-addons-headful` from the root folder.  
+  In headful mode, a browser window will open, and you can see the tests running.  
+  While the headful mode is running you can also use any browser to navigate to http://localhost:1234/test/unit/UnitTests.html or http://localhost:1234/test/unit/UnitTestsAddons.html to run the tests in that browser.  
+  Further changes to the library will not be reflected until the page is refreshed.
 
 See [Installation](https://threejs.org/docs/#manual/introduction/Installation) for more information.
-
-## Notes
-
-A small number of tests can only be run in a browser environment.
-
-For browser tests, futher changes to the library will not be reflected until the page is refreshed.
 
 ## Troubleshooting
 
@@ -25,5 +23,5 @@ An error that indicates "no tests were found" means that an import statement cou
 
 ## Debugging
 
-To debug a test, add `debugger;` to the test code. Then, run the test in a browser and open the developer tools. The test will stop at the `debugger` statement and you can inspect the code.
+To debug a test, add `debugger;` to the test code. Then, run the test in a browser and open the developer tools. The test will stop at the `debugger` statement, and you can inspect the code.
 

--- a/test/unit/UnitTestsAddons.html
+++ b/test/unit/UnitTestsAddons.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 	<head>
-		<meta charset="utf-8">
-		<title>ThreeJS Unit Tests - Using Files in /src</title>
+		<meta charset="UTF-8">
+		<title>ThreeJS Unit Tests - Using Files in /examples/jsm</title>
 		<link rel="stylesheet" href="../../node_modules/qunit/qunit/qunit.css">
 		<!-- if we don't set favicon here we have to intercept the request for it in puppeteer page to prevent console error -->
 		<link rel="icon" type="image/x-icon" href="/files/favicon.ico" />
@@ -17,11 +17,12 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "../../build/three.module.js"
+					"three": "../../build/three.module.js",
+					"three/addons/": "../../examples/jsm/"
 				}
 			}
 		</script>
-		<script>
+		<script type="module">
 			window.QUnit.on( 'runEnd', ( runEnd ) => {
 
 				// using these later in puppeteer.unit.js
@@ -31,7 +32,7 @@
 		</script>
 
 		<!-- add sources to test below -->
-		<script src="./three.source.unit.js" type="module"></script>
+		<script src="./three.addons.unit.js" type="module"></script>
 	</body>
 </html>
 

--- a/test/unit/addons/loaders/FBXLoader.tests.js
+++ b/test/unit/addons/loaders/FBXLoader.tests.js
@@ -1,0 +1,30 @@
+import { FBXLoader } from 'three/addons/loaders/FBXLoader.js';
+
+export default QUnit.module( 'Addons', () => {
+
+	QUnit.module( 'Loaders', () => {
+
+		QUnit.module( 'FBXLoader', () => {
+
+			QUnit.test( 'morphAttributes length match geometry position length', ( assert ) => {
+
+				const fbxLoader = new FBXLoader();
+				const done = assert.async();
+				fbxLoader.load( '/examples/models/fbx/morph_test.fbx', ( fbx ) => {
+
+					const mesh = fbx.children[ 0 ];
+					const baseGeometryLength = mesh.geometry.attributes.position.count;
+					const morphAttributesLength = mesh.geometry.morphAttributes.position[ 0 ].count;
+
+					assert.ok( baseGeometryLength === morphAttributesLength, 'length is the same' );
+					done();
+
+				} );
+
+			} );
+
+		} );
+
+	} );
+
+} );

--- a/test/unit/puppeteer.unit.js
+++ b/test/unit/puppeteer.unit.js
@@ -1,0 +1,143 @@
+// Purpose: Run QUnit tests in headless browser and serving assets through express,
+// allowing to unit-test loaders in particular, as they require a server to facilitate assets loading,
+// and some of them require a browser environment to run in (e.g. ImageLoader => createElementNS('img')).
+
+import puppeteer from 'puppeteer';
+import express from 'express';
+import chalk from 'chalk';
+import path from 'path';
+
+const networkTimeout = 5; // 5 minutes, set to 0 to disable
+const port = 1234;
+const width = 400;
+const height = 250;
+const viewScale = 2;
+const viewport = { width: width * viewScale, height: height * viewScale };
+
+let browser;
+
+const app = express();
+app.use( express.static( path.resolve() ) );
+const server = app.listen( port, main );
+
+// allows consoles from browser to be captured and displayed in CLI
+// https://stackoverflow.com/questions/51676159/puppeteer-console-log-how-to-look-inside-jshandleobject
+export const captureConsole = ( page ) => {
+
+	// make args accessible
+	const describe = ( jsHandle ) => {
+
+		return jsHandle.evaluate( ( obj ) => {
+
+			// serialize |obj| however you want
+			return `OBJ: ${typeof obj}, ${obj}`;
+
+		}, jsHandle );
+
+	};
+
+	const colors = {
+		LOG: chalk.white,
+		ERR: chalk.red,
+		WAR: chalk.yellow,
+		INF: chalk.cyan,
+	};
+
+	page.on( 'console', async ( message ) => {
+
+		const args = await Promise.all( ( message.args() ).map( async arg => describe( arg ) ) );
+		const type = message.type().substring( 0, 3 ).toUpperCase();
+		const color = colors[ type ] || chalk.blue;
+		let text = '';
+
+		for ( let i = 0; i < args.length; ++ i ) {
+
+			text += `[${i}] ${args[ i ]} `;
+
+		}
+
+		console.log( color( `CONSOLE.${type}: ${message.text()}\n${text} ` ) );
+
+	} );
+
+};
+
+
+function main() {
+
+	( async () => {
+
+		const flags = [ '--hide-scrollbars', '--enable-gpu' ];
+		// '--enable-chrome-browser-cloud-management'
+
+		const testPage = process.env.TEST_PAGE;
+		const testMode = process.env.VISIBLE ? 'headful' : 'headless';
+
+		browser = await puppeteer.launch( {
+			headless: testMode === 'headful' ? false : 'new',
+			args: flags,
+			defaultViewport: viewport,
+			handleSIGINT: false,
+			protocolTimeout: 0
+		} );
+
+		if ( testMode === 'headful' ) {
+
+			browser.on( 'targetdestroyed', target => {
+
+				// close the process when testing page is closed
+				if ( target.type() === 'page' ) close( 0 );
+
+			} );
+
+		}
+
+		const page = await browser.newPage();
+
+		captureConsole( page );
+
+		const testUrl = `http://localhost:${port}/test/unit/${testPage}`;
+
+		// Load the test page
+		await page.goto( testUrl, {
+			waitUntil: 'networkidle0',
+			timeout: networkTimeout * 60000
+		} );
+
+		// Wait for the QUnit test results
+		await page.waitForFunction( () => {
+
+			return window.QUnit && window.QUnit.done;
+
+		} );
+
+		// Get the test results
+		const stats = await page.evaluate( () => {
+
+			// these are set on window in the HTML test page
+			return window._QUnitStats;
+
+		} );
+
+		console.log( `1..${stats.total}` );
+		console.log( `# pass ${stats.passed}` );
+		console.log( chalk.yellow( `# skip ${stats.skipped}` ) );
+		console.log( chalk.cyan( `# todo ${stats.todo}` ) );
+		console.log( chalk.red( `# fail ${stats.failed}` ) );
+
+		// Keep the process running if testing in headful mode, otherwise close it.
+		testMode === 'headless' && close( stats.failed > 0 ? 1 : 0 );
+
+	} )();
+
+}
+
+process.on( 'SIGINT', () => close() );
+
+function close( exitCode = 1 ) {
+
+	browser.close();
+	server.close();
+	process.exit( exitCode );
+
+}

--- a/test/unit/three.addons.unit.js
+++ b/test/unit/three.addons.unit.js
@@ -1,3 +1,4 @@
 
 //addons/utils
 import './addons/utils/BufferGeometryUtils.tests.js';
+import './addons/loaders/FBXLoader.tests.js';


### PR DESCRIPTION
Related issue: #28572

**Description**

Configured unit tests to run in headless browser (launched by `puppeteer`) and used `express` to support assets loading.

Updated README for unit tests.

Added `express` as an explicit dev dependency (it was already used in existing puppeteer script without being declared in `package.json` - ESLint warned about that).

Added `cross-env` for setting ENV variables cross platform.

Updated test jobs to use the new `puppeteer.unit.js` script.

Added to new jobs (sufifxed with `'headful'`) for convenience when testing locally.

Created `puppeteer.unit.js` script, getting inspired from existing puppeteer script used in `e2e` tests. It accepts 2 ENV parameters: `TEST_PAGE` (for reusing it with core as well as addons tests) and `VISIBLE` which controls the test mode (`'headless'` / `'headful'`)

The tests results (final log) have the same format as before.
The `webonly` tests that were excluded before are now included.

Consoles are intercepted and printed in CLI.

Added a new test for `FBXLoader` (which I couldn't test before due to not being able to load `fbx` asset from disk).
I wanted to keep the changes in this PR focused on the configuration, and not clutter with other tests.

If this PR gets accepted I plan to add (soon) another FBXLoader test (about being able to use non native textures).


