### PR TITLE
performance-fix VideoTexture.js: don't keep updating texture when video is not playing

### DIFF
--- a/src/textures/VideoTexture.js
+++ b/src/textures/VideoTexture.js
@@ -42,10 +42,10 @@ class VideoTexture extends Texture {
 		const video = this.image;
 		const hasVideoFrameCallback = 'requestVideoFrameCallback' in video;
 
-		if ( hasVideoFrameCallback === false && video.readyState >= video.HAVE_CURRENT_DATA && (!video.paused || !this.firstFrame) ) {
+		if ( hasVideoFrameCallback === false && video.readyState >= video.HAVE_CURRENT_DATA && ( ! video.paused || ! this.firstFrame) ) {
 
 			this.needsUpdate = true;
-			this.firstFrame  = true;
+			this.firstFrame = true;
 
 		}
 

--- a/src/textures/VideoTexture.js
+++ b/src/textures/VideoTexture.js
@@ -42,7 +42,7 @@ class VideoTexture extends Texture {
 		const video = this.image;
 		const hasVideoFrameCallback = 'requestVideoFrameCallback' in video;
 
-		if ( hasVideoFrameCallback === false && video.readyState >= video.HAVE_CURRENT_DATA && ( ! video.paused || ! this.firstFrame) ) {
+		if ( hasVideoFrameCallback === false && video.readyState >= video.HAVE_CURRENT_DATA && ( ! video.paused || ! this.firstFrame ) ) {
 
 			this.needsUpdate = true;
 			this.firstFrame = true;

--- a/src/textures/VideoTexture.js
+++ b/src/textures/VideoTexture.js
@@ -42,9 +42,10 @@ class VideoTexture extends Texture {
 		const video = this.image;
 		const hasVideoFrameCallback = 'requestVideoFrameCallback' in video;
 
-		if ( hasVideoFrameCallback === false && video.readyState >= video.HAVE_CURRENT_DATA ) {
+		if ( hasVideoFrameCallback === false && video.readyState >= video.HAVE_CURRENT_DATA && (!video.paused || !this.firstFrame) ) {
 
 			this.needsUpdate = true;
+			this.firstFrame  = true;
 
 		}
 


### PR DESCRIPTION
This fixes an issue which causes significant framerate drops (cumulative) when loading videotexture(s) which are not playing.

This fix is more gentle for videotextures which should not play automatically (but just display the video-thumbnail) and will play later (via a user interaction).

> Usecase Example: Hypermedia players which support XR URI Fragments (xrfragment.org) should be able to render the 1st frame, but only autoplay them when the W3C Media Fragment (`#t=0`) is part of the video URL (or triggered via URI Template variable).

note: commits can be squashed (1st commit is fix, later commits are lint-fixes)