### PR TITLE
TSL: Added type conversions to WGSLNodeFunction and fleshed out precision.

### DIFF
--- a/examples/jsm/renderers/webgpu/nodes/WGSLNodeFunction.js
+++ b/examples/jsm/renderers/webgpu/nodes/WGSLNodeFunction.js
@@ -5,8 +5,42 @@ const declarationRegexp = /^[fn]*\s*([a-z_0-9]+)?\s*\(([\s\S]*?)\)\s*[\-\>]*\s*(
 const propertiesRegexp = /[a-z_0-9]+|<(.*?)>+/ig;
 
 const wgslTypeLib = {
-	f32: 'float'
+	'f32': 'float',
+	'i32': 'int',
+	'u32': 'uint',
+	'bool': 'bool',
+
+	'vec2<f32>': 'vec2',
+ 	'vec2<i32>': 'ivec2',
+ 	'vec2<u32>': 'uvec2',
+ 	'vec2<bool>': 'bvec2',
+
+	'vec3<f32>': 'vec3',
+	'vec3<i32>': 'ivec3',
+	'vec3<u32>': 'uvec3',
+	'vec3<bool>': 'bvec3',
+
+	'vec4<f32>': 'vec4',
+	'vec4<i32>': 'ivec4',
+	'vec4<u32>': 'uvec4',
+	'vec4<bool>': 'bvec4',
+
+	'mat2x2<f32>': 'mat2',
+	'mat2x2<i32>': 'imat2',
+	'mat2x2<u32>': 'umat2',
+	'mat2x2<bool>': 'bmat2',
+
+	'mat3x3<f32>': 'mat3',
+	'mat3x3<i32>': 'imat3',
+	'mat3x3<u32>': 'umat3',
+	'mat3x3<bool>': 'bmat3',
+
+	'mat4x4<f32>': 'mat4',
+	'mat4x4<i32>': 'imat4',
+	'mat4x4<u32>': 'umat4',
+	'mat4x4<bool>': 'bmat4'
 };
+
 
 const parse = ( source ) => {
 
@@ -35,6 +69,8 @@ const parse = ( source ) => {
 
 		let i = 0;
 
+		console.log(propsMatches)
+
 		while ( i < propsMatches.length ) {
 
 			// default
@@ -42,14 +78,26 @@ const parse = ( source ) => {
 			const name = propsMatches[ i ++ ][ 0 ];
 			let type = propsMatches[ i ++ ][ 0 ];
 
-			type = wgslTypeLib[ type ] || type;
-
 			// precision
 
-			if ( i < propsMatches.length && propsMatches[ i ][ 0 ].startsWith( '<' ) === true )
-				i ++;
+			if ( i < propsMatches.length && propsMatches[ i ][ 0 ].startsWith( '<' ) === true) {
+				
+				const elementType = propsMatches[ i++ ][ 0 ];
+
+				// If primitive data type
+				if (!elementType.includes(',')) {
+
+					type += elementType;
+
+				}
+
+			}
+
+			type = wgslTypeLib[ type ] || type;
 
 			// add input
+
+			console.log(name, type, i);
 
 			inputs.push( new NodeFunctionInput( type, name ) );
 

--- a/examples/jsm/renderers/webgpu/nodes/WGSLNodeFunction.js
+++ b/examples/jsm/renderers/webgpu/nodes/WGSLNodeFunction.js
@@ -69,8 +69,6 @@ const parse = ( source ) => {
 
 		let i = 0;
 
-		console.log(propsMatches)
-
 		while ( i < propsMatches.length ) {
 
 			// default
@@ -80,12 +78,12 @@ const parse = ( source ) => {
 
 			// precision
 
-			if ( i < propsMatches.length && propsMatches[ i ][ 0 ].startsWith( '<' ) === true) {
-				
-				const elementType = propsMatches[ i++ ][ 0 ];
+			if ( i < propsMatches.length && propsMatches[ i ][ 0 ].startsWith( '<' ) === true ) {
+
+				const elementType = propsMatches[ i ++ ][ 0 ];
 
 				// If primitive data type
-				if (!elementType.includes(',')) {
+				if ( ! elementType.includes( ',' ) ) {
 
 					type += elementType;
 
@@ -96,9 +94,6 @@ const parse = ( source ) => {
 			type = wgslTypeLib[ type ] || type;
 
 			// add input
-
-			console.log(name, type, i);
-
 			inputs.push( new NodeFunctionInput( type, name ) );
 
 		}


### PR DESCRIPTION
Added conversions between WGSL types and their equivalent Threejs in the WGSLNodeFunction.js file. This commit should help resolve particular parsing and conversion issues when creating shaders using wgslFn blocks. 

For instance, in the existing code, let's say we wanted to define an argument with this function signature...

```
const testWGSL = wgslFn( ` fn testFunction(
     workgroupId: vec3<u32>,
     localId: vec3<u32>,
     testVec: vec2<u32>
....
```

The generated WGSL code to invoke this function might look something like this. 

```
testWGSL(vec3<f32>(workgroupId), vec3<f32>(localId), vec2<f32>(testVec))
```

While this behavior might be acceptable if we're only passing in arguments to be used in numerical operations, it prevents particular inputs from being used in scenarios where u32s or integers may be required for instance, indexing into a storage buffer. 

When this code is implemented, the function will instead pass the parameters as the programmer might expect them to be passed.

```|
testWGSL(nodeUniform0, nodeUniform1, nodeUniform2)
```

This change should only apply to the types already represented in WGSLNodeBuilder's wgslTypeLib (such as primitive data types, vector types, and matrix types). This should not in anyway affect how other data types like textures or arrays are parsed.