### PR TITLE
WebGPURenderer: `PostProcessing` - Introduce `.needsUpdate=true`

### DIFF
--- a/examples/jsm/renderers/common/PostProcessing.js
+++ b/examples/jsm/renderers/common/PostProcessing.js
@@ -28,6 +28,12 @@ class PostProcessing {
 
 	}
 
+	set needsUpdate( value ) {
+
+		quadMesh.material.needsUpdate = value;
+
+	}
+
 }
 
 export default PostProcessing;


### PR DESCRIPTION
**Description**

Update PostProcessing outputNode at runtime.

Usage:
```js
postProcessing.outputNode = otherNode...;
postProcessing.needsUpdate = true;
```