### PR TITLE
WebGLRenderer: Add support for changing the assigned render target depth texture

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2268,6 +2268,22 @@ class WebGLRenderer {
 					// Color and depth texture must be rebound in order for the swapchain to update.
 					textures.rebindTextures( renderTarget, properties.get( renderTarget.texture ).__webglTexture, properties.get( renderTarget.depthTexture ).__webglTexture );
 
+				} else {
+
+					// Swap the depth buffer to the currently attached one
+					const depthTexture = renderTarget.depthTexture;
+					if (
+						depthTexture &&
+						properties.has( depthTexture ) &&
+						( renderTarget.width !== depthTexture.image.width || renderTarget.height !== depthTexture.image.height )
+					) {
+
+						throw new Error( 'WebGLRenderTarget: Attached DepthTexture is initialized to the incorrect size.' );
+
+					}
+
+					textures.setupDepthRenderbuffer( renderTarget );
+
 				}
 
 				const texture = renderTarget.texture;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2268,7 +2268,7 @@ class WebGLRenderer {
 					// Color and depth texture must be rebound in order for the swapchain to update.
 					textures.rebindTextures( renderTarget, properties.get( renderTarget.texture ).__webglTexture, properties.get( renderTarget.depthTexture ).__webglTexture );
 
-				} else if ( ! renderTarget.isWebGLCubeRenderTarget ) {
+				} else if ( renderTarget.depthBuffer || renderTarget.depthTexture ) {
 
 					// Swap the depth buffer to the currently attached one
 					const depthTexture = renderTarget.depthTexture;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2268,7 +2268,7 @@ class WebGLRenderer {
 					// Color and depth texture must be rebound in order for the swapchain to update.
 					textures.rebindTextures( renderTarget, properties.get( renderTarget.texture ).__webglTexture, properties.get( renderTarget.depthTexture ).__webglTexture );
 
-				} else {
+				} else if ( ! renderTarget.isWebGLCubeRenderTarget ) {
 
 					// Swap the depth buffer to the currently attached one
 					const depthTexture = renderTarget.depthTexture;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2268,7 +2268,7 @@ class WebGLRenderer {
 					// Color and depth texture must be rebound in order for the swapchain to update.
 					textures.rebindTextures( renderTarget, properties.get( renderTarget.texture ).__webglTexture, properties.get( renderTarget.depthTexture ).__webglTexture );
 
-				} else if ( renderTarget.depthBuffer || renderTarget.depthTexture ) {
+				} else if ( renderTarget.depthBuffer ) {
 
 					// Swap the depth buffer to the currently attached one
 					const depthTexture = renderTarget.depthTexture;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2270,19 +2270,25 @@ class WebGLRenderer {
 
 				} else if ( renderTarget.depthBuffer ) {
 
-					// Swap the depth buffer to the currently attached one
+					// check if the depth texture is already bound to the frame buffer and that it's been initialized
 					const depthTexture = renderTarget.depthTexture;
-					if (
-						depthTexture &&
-						properties.has( depthTexture ) &&
-						( renderTarget.width !== depthTexture.image.width || renderTarget.height !== depthTexture.image.height )
-					) {
+					if ( renderTargetProperties.__boundDepthTexture !== depthTexture ) {
 
-						throw new Error( 'WebGLRenderTarget: Attached DepthTexture is initialized to the incorrect size.' );
+						// check if the depth texture is compatible
+						if (
+							depthTexture !== null &&
+							properties.has( depthTexture ) &&
+							( renderTarget.width !== depthTexture.image.width || renderTarget.height !== depthTexture.image.height )
+						) {
+
+							throw new Error( 'WebGLRenderTarget: Attached DepthTexture is initialized to the incorrect size.' );
+
+						}
+
+						// Swap the depth buffer to the currently attached one
+						textures.setupDepthRenderbuffer( renderTarget );
 
 					}
-
-					textures.setupDepthRenderbuffer( renderTarget );
 
 				}
 

--- a/src/renderers/webgl/WebGLProperties.js
+++ b/src/renderers/webgl/WebGLProperties.js
@@ -2,6 +2,12 @@ function WebGLProperties() {
 
 	let properties = new WeakMap();
 
+	function has( object ) {
+
+		return properties.has( object );
+
+	}
+
 	function get( object ) {
 
 		let map = properties.get( object );
@@ -36,6 +42,7 @@ function WebGLProperties() {
 	}
 
 	return {
+		has: has,
 		get: get,
 		remove: remove,
 		update: update,

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -1792,7 +1792,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 				if ( renderTarget.depthBuffer && renderTargetProperties.__webglDepthRenderbuffer === undefined ) {
 
 					renderTargetProperties.__webglDepthRenderbuffer = _gl.createRenderbuffer();
-					setupRenderBufferStorage( renderTargetProperties.__webglDepthRenderbuffer, renderTarget, true, true );
+					setupRenderBufferStorage( renderTargetProperties.__webglDepthRenderbuffer, renderTarget, true );
 
 				}
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -1609,7 +1609,13 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 				for ( let i = 0; i < 6; i ++ ) {
 
 					state.bindFramebuffer( _gl.FRAMEBUFFER, renderTargetProperties.__webglFramebuffer[ i ] );
-					renderTargetProperties.__webglDepthbuffer[ i ] = _gl.createRenderbuffer();
+
+					if ( renderTargetProperties.__webglDepthbuffer[ i ] === undefined ) {
+
+						renderTargetProperties.__webglDepthbuffer[ i ] = _gl.createRenderbuffer();
+
+					}
+
 					setupRenderBufferStorage( renderTargetProperties.__webglDepthbuffer[ i ], renderTarget, false );
 
 				}
@@ -1617,7 +1623,13 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 			} else {
 
 				state.bindFramebuffer( _gl.FRAMEBUFFER, renderTargetProperties.__webglFramebuffer );
-				renderTargetProperties.__webglDepthbuffer = _gl.createRenderbuffer();
+
+				if ( renderTargetProperties.__webglDepthbuffer === undefined ) {
+
+					renderTargetProperties.__webglDepthbuffer = _gl.createRenderbuffer();
+
+				}
+
 				setupRenderBufferStorage( renderTargetProperties.__webglDepthbuffer, renderTarget, false );
 
 			}
@@ -1763,7 +1775,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 				_gl.bindRenderbuffer( _gl.RENDERBUFFER, null );
 
-				if ( renderTarget.depthBuffer ) {
+				if ( renderTarget.depthBuffer && renderTargetProperties.__webglDepthRenderbuffer === undefined ) {
 
 					renderTargetProperties.__webglDepthRenderbuffer = _gl.createRenderbuffer();
 					setupRenderBufferStorage( renderTargetProperties.__webglDepthRenderbuffer, renderTarget, true );

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -1613,10 +1613,17 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 					if ( renderTargetProperties.__webglDepthbuffer[ i ] === undefined ) {
 
 						renderTargetProperties.__webglDepthbuffer[ i ] = _gl.createRenderbuffer();
+						setupRenderBufferStorage( renderTargetProperties.__webglDepthbuffer[ i ], renderTarget, false );
+
+					} else {
+
+						// attach buffer if it's been created already
+						const glAttachmentType = renderTarget.stencilBuffer ? _gl.DEPTH_STENCIL_ATTACHMENT : _gl.DEPTH_ATTACHMENT;
+						const renderbuffer = renderTargetProperties.__webglDepthbuffer[ i ];
+						_gl.bindRenderbuffer( _gl.RENDERBUFFER, renderbuffer );
+						_gl.framebufferRenderbuffer( _gl.FRAMEBUFFER, glAttachmentType, _gl.RENDERBUFFER, renderbuffer );
 
 					}
-
-					setupRenderBufferStorage( renderTargetProperties.__webglDepthbuffer[ i ], renderTarget, false );
 
 				}
 
@@ -1627,10 +1634,17 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 				if ( renderTargetProperties.__webglDepthbuffer === undefined ) {
 
 					renderTargetProperties.__webglDepthbuffer = _gl.createRenderbuffer();
+					setupRenderBufferStorage( renderTargetProperties.__webglDepthbuffer, renderTarget, false );
+
+				} else {
+
+					// attach buffer if it's been created already
+					const glAttachmentType = renderTarget.stencilBuffer ? _gl.DEPTH_STENCIL_ATTACHMENT : _gl.DEPTH_ATTACHMENT;
+					const renderbuffer = renderTargetProperties.__webglDepthbuffer;
+					_gl.bindRenderbuffer( _gl.RENDERBUFFER, renderbuffer );
+					_gl.framebufferRenderbuffer( _gl.FRAMEBUFFER, glAttachmentType, _gl.RENDERBUFFER, renderbuffer );
 
 				}
-
-				setupRenderBufferStorage( renderTargetProperties.__webglDepthbuffer, renderTarget, false );
 
 			}
 
@@ -1778,7 +1792,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 				if ( renderTarget.depthBuffer && renderTargetProperties.__webglDepthRenderbuffer === undefined ) {
 
 					renderTargetProperties.__webglDepthRenderbuffer = _gl.createRenderbuffer();
-					setupRenderBufferStorage( renderTargetProperties.__webglDepthRenderbuffer, renderTarget, true );
+					setupRenderBufferStorage( renderTargetProperties.__webglDepthRenderbuffer, renderTarget, true, true );
 
 				}
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -1594,6 +1594,15 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 		const renderTargetProperties = properties.get( renderTarget );
 		const isCube = ( renderTarget.isWebGLCubeRenderTarget === true );
 
+		// check if the depth texture is already bound to the frame buffer and that it's been initialized
+		if ( renderTargetProperties.__boundDepthTexture === renderTarget.depthTexture && properties.has( renderTarget.depthTexture ) ) {
+
+			return;
+
+		}
+
+		renderTargetProperties.__boundDepthTexture = renderTarget.depthTexture;
+
 		if ( renderTarget.depthTexture && ! renderTargetProperties.__autoAllocateDepthBuffer ) {
 
 			if ( isCube ) throw new Error( 'target.depthTexture not supported in Cube render targets' );


### PR DESCRIPTION
Related issue: #19447, #15490, other [depth peeling discussions](https://github.com/mrdoob/three.js/issues?q=depth+peeling)

**Description**

This PR adjusts the `setRenderTarget` function to rebind the depth attachment so that it can be re assigned, unbound, and shared between multiple different render targets. If you set the render target and _then_ set `.depthTexture`, though, it will not take effect until `setRenderTarget` is called again.

This allows a lot more flexibility in the reuse of render targets and depth textures while avoiding texture read / write feedback loops. For example it allows for implementing depth peeling without having to manually copy data between textures to avoid this kind of feedback.

There's a demo [here](https://gkjohnson.github.io/depth-peeling-demo/) and [here](https://gkjohnson.github.io/depth-peeling-demo/#drone) demonstrating this PRs use for depth peeling:

| Before | After |
|---|---|
| <img width="300" alt="image" src="https://github.com/mrdoob/three.js/assets/734200/615febf6-8b21-4c4b-98d6-742df4971a06"> | <img width="300" alt="image" src="https://github.com/mrdoob/three.js/assets/734200/a7b3175b-7be1-4301-bb16-ec509f5aa4b5"> |
| <img width="300" alt="image" src="https://github.com/mrdoob/three.js/assets/734200/483a37a5-8770-4a0f-9ba6-68c280bf0e8f"> | <img width="300" alt="image" src="https://github.com/mrdoob/three.js/assets/734200/036e50ab-ee7b-4606-b4ee-c16ad2ab2a05"> |
| <img width="300" alt="image" src="https://github.com/mrdoob/three.js/assets/734200/6107b013-df7e-45f1-87a6-8ba5425f1c3c"> | <img width="300" alt="image" src="https://github.com/mrdoob/three.js/assets/734200/7d412a66-a904-4749-a900-3b99a75201e6"> |

cc @donmccurdy I know you've expressed interest in this kind of OIT previously.