### PR TITLE
Editor: three-gpu-pathtracer -> 0.0.23

### DIFF
--- a/editor/index.html
+++ b/editor/index.html
@@ -52,7 +52,7 @@
 					"three/addons/": "../examples/jsm/",
 
 					"three/examples/": "../examples/",
-					"three-gpu-pathtracer": "https://cdn.jsdelivr.net/npm/three-gpu-pathtracer@0.0.22/build/index.module.js",
+					"three-gpu-pathtracer": "https://cdn.jsdelivr.net/npm/three-gpu-pathtracer@0.0.23/build/index.module.js",
 					"three-mesh-bvh": "https://cdn.jsdelivr.net/npm/three-mesh-bvh@0.7.4/build/index.module.js"
 				}
 			}


### PR DESCRIPTION
This PR bumps three-gpu-pathtracer from 0.0.22 to 0.0.23 which now honors geometry changes:

0.0.22:


https://github.com/mrdoob/three.js/assets/1063018/62975d6d-552d-4a1b-8ae7-e500481d7528



0.0.23:

https://github.com/mrdoob/three.js/assets/1063018/f64e11cd-ff40-417e-bd6a-8d47b9c56935

