### PR TITLE
Docs: Fix broken link in `Useful-links`.

### DIFF
--- a/docs/manual/ar/introduction/Useful-links.html
+++ b/docs/manual/ar/introduction/Useful-links.html
@@ -48,7 +48,7 @@
 				[link:https://medium.com/soffritti.pierfrancesco/glossy-spheres-in-three-js-bfd2785d4857 Glossy spheres in three.js].
 			</li>
 		 <li>
-			 [link:https://www.udacity.com/course/cs291 Interactive 3D Graphics] - دورة مجانية على Udacity تُعلِّم أساسيات الرسومات ثلاثية الأبعاد ، وتستخدم three.js كأداة تشفير لها.
+			 [link:https://www.udacity.com/course/interactive-3d-graphics--cs291 Interactive 3D Graphics] - دورة مجانية على Udacity تُعلِّم أساسيات الرسومات ثلاثية الأبعاد ، وتستخدم three.js كأداة تشفير لها.
 		 </li>
 		 <li>
 			[Link:https://aerotwist.com/tutorials/ Aerotwist] tutorials by [link:https://github.com/paullewis/ Paul Lewis].

--- a/docs/manual/en/introduction/Useful-links.html
+++ b/docs/manual/en/introduction/Useful-links.html
@@ -55,7 +55,7 @@
 				[link:https://medium.com/soffritti.pierfrancesco/glossy-spheres-in-three-js-bfd2785d4857 Glossy spheres in three.js].
 			</li>
 		 <li>
-			 [link:https://www.udacity.com/course/cs291 Interactive 3D Graphics] - a free course on Udacity that teaches the fundamentals of 3D Graphics,
+			 [link:https://www.udacity.com/course/interactive-3d-graphics--cs291 Interactive 3D Graphics] - a free course on Udacity that teaches the fundamentals of 3D Graphics,
 			 and uses three.js as its coding tool.
 		 </li>
 		 <li>

--- a/docs/manual/fr/introduction/Useful-links.html
+++ b/docs/manual/fr/introduction/Useful-links.html
@@ -55,7 +55,7 @@
 				[link:https://medium.com/soffritti.pierfrancesco/glossy-spheres-in-three-js-bfd2785d4857 Glossy spheres in three.js].
 			</li>
 		 <li>
-			 [link:https://www.udacity.com/course/cs291 Interactive 3D Graphics] - un cours gratuit sur Udacity qui enseigne les fondamentaux de l'infographie 3D,
+			 [link:https://www.udacity.com/course/interactive-3d-graphics--cs291 Interactive 3D Graphics] - un cours gratuit sur Udacity qui enseigne les fondamentaux de l'infographie 3D,
 			 et qui utilise three.js comme outil de code.
 		 </li>
 		 <li>

--- a/docs/manual/it/introduction/Useful-links.html
+++ b/docs/manual/it/introduction/Useful-links.html
@@ -55,7 +55,7 @@
 				[link:https://medium.com/soffritti.pierfrancesco/glossy-spheres-in-three-js-bfd2785d4857 Glossy spheres in three.js].
 			</li>
 		  <li>
-			 [link:https://www.udacity.com/course/cs291 Interactive 3D Graphics] - un corso gratuito su Udacity che insegna i fondamenti della grafica 3D,
+			 [link:https://www.udacity.com/course/interactive-3d-graphics--cs291 Interactive 3D Graphics] - un corso gratuito su Udacity che insegna i fondamenti della grafica 3D,
        utilizza three.js come strumenti di coding.
 		  </li>
 		  <li>

--- a/docs/manual/ja/introduction/Useful-links.html
+++ b/docs/manual/ja/introduction/Useful-links.html
@@ -50,7 +50,7 @@
 				[link:https://medium.com/soffritti.pierfrancesco/glossy-spheres-in-three-js-bfd2785d4857 Glossy spheres in three.js].
 			</li>
 		 <li>
-			 [link:https://www.udacity.com/course/cs291 Interactive 3D Graphics] - a free course on Udacity that teaches the fundamentals of 3D Graphics,
+			 [link:https://www.udacity.com/course/interactive-3d-graphics--cs291 Interactive 3D Graphics] - a free course on Udacity that teaches the fundamentals of 3D Graphics,
 			 and uses three.js as its coding tool.
 		 </li>
 		 <li>

--- a/docs/manual/ko/introduction/Useful-links.html
+++ b/docs/manual/ko/introduction/Useful-links.html
@@ -51,7 +51,7 @@
 				[link:https://medium.com/soffritti.pierfrancesco/glossy-spheres-in-three-js-bfd2785d4857 Glossy spheres in three.js].
 			</li>
 		 <li>
-			 [link:https://www.udacity.com/course/cs291 Interactive 3D Graphics] - a free course on Udacity that teaches the fundamentals of 3D Graphics,
+			 [link:https://www.udacity.com/course/interactive-3d-graphics--cs291 Interactive 3D Graphics] - a free course on Udacity that teaches the fundamentals of 3D Graphics,
 			 and uses three.js as its coding tool.
 		 </li>
 		 <li>

--- a/docs/manual/pt-br/introduction/Useful-links.html
+++ b/docs/manual/pt-br/introduction/Useful-links.html
@@ -58,7 +58,7 @@
 				[link:https://medium.com/soffritti.pierfrancesco/glossy-spheres-in-three-js-bfd2785d4857 Glossy spheres in three.js].
 			</li>
 		 <li>
-			 [link:https://www.udacity.com/course/cs291 Interactive 3D Graphics] - um curso gratuito da Udacity que ensina os fundamentos de gráficos 3D,
+			 [link:https://www.udacity.com/course/interactive-3d-graphics--cs291 Interactive 3D Graphics] - um curso gratuito da Udacity que ensina os fundamentos de gráficos 3D,
 			 e usa three.js como sua ferramenta de codificação.
 		 </li>
 		 <li>

--- a/docs/manual/ru/introduction/Useful-links.html
+++ b/docs/manual/ru/introduction/Useful-links.html
@@ -55,7 +55,7 @@
 				[link:https://medium.com/soffritti.pierfrancesco/glossy-spheres-in-three-js-bfd2785d4857 Glossy spheres in three.js].
 			</li>
 		 <li>
-			 [link:https://www.udacity.com/course/cs291 Interactive 3D Graphics] - a free course on Udacity that teaches the fundamentals of 3D Graphics,
+			 [link:https://www.udacity.com/course/interactive-3d-graphics--cs291 Interactive 3D Graphics] - a free course on Udacity that teaches the fundamentals of 3D Graphics,
 			 and uses three.js as its coding tool.
 		 </li>
 		 <li>

--- a/docs/manual/zh/introduction/Useful-links.html
+++ b/docs/manual/zh/introduction/Useful-links.html
@@ -54,7 +54,7 @@
 				[link:https://medium.com/soffritti.pierfrancesco/glossy-spheres-in-three-js-bfd2785d4857 Glossy spheres in three.js].
 			</li>
 		 <li>
-			 [link:https://www.udacity.com/course/cs291 Interactive 3D Graphics] - a free course on Udacity that teaches the fundamentals of 3D Graphics,
+			 [link:https://www.udacity.com/course/interactive-3d-graphics--cs291 Interactive 3D Graphics] - a free course on Udacity that teaches the fundamentals of 3D Graphics,
 			 and uses three.js as its coding tool.
 		 </li>
 		 <li>


### PR DESCRIPTION
Moved the `Udacity`'s course - `Interactive 3D Graphics` - link to a new URL.

Related issue: none

**Description**

The link to the mentioned course is moved to a new URL and the current URL leads to the 404 page on Udacity.
