### PR TITLE
WebGPURenderer: fix instance error when object has same key

### DIFF
--- a/examples/jsm/renderers/common/RenderObject.js
+++ b/examples/jsm/renderers/common/RenderObject.js
@@ -234,6 +234,12 @@ export default class RenderObject {
 
 		}
 
+		if ( object.isInstancedMesh ) {
+
+			cacheKey += object.count + ',';
+
+		}
+
 		return cacheKey;
 
 	}


### PR DESCRIPTION
Related issue: #28386

**Description**

If a non instance mesh has same material key as instance mesh, instance mesh will not be rendered correctly.

In the first image below, two mesh can have same nodeBuilderState even though one is instance mesh.
![image](https://github.com/mrdoob/three.js/assets/13222615/ff003523-5f20-42b5-90ae-52c99648f013)

Then the code about instance mesh will not be executed. And the code in InstanceNode.js will be ignored 
![image](https://github.com/mrdoob/three.js/assets/13222615/44300f64-4574-4d89-ac93-d06baace4b24)

On the other hand, I think skeleton and morph mesh should not set material key by bones length and  morphTargetInfluences length. Because two different mesh may have same material, and same animation. It may casue problem. So does instance mesh.

May be I can fix it later.
![image](https://github.com/mrdoob/three.js/assets/13222615/58059875-5f5b-4d9f-8219-439bc0b3d77b)




