### PR TITLE
WebGPURenderer: Fix ArrayCamera viewports

### DIFF
--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -1376,7 +1376,7 @@ class Renderer {
 						const maxDepth = ( vp.maxDepth === undefined ) ? 1 : vp.maxDepth;
 
 						const viewportValue = this._currentRenderContext.viewportValue;
-						viewportValue.copy( vp ).multiplyScalar( this._pixelRatio ).floor();
+						viewportValue.copy( vp );
 						viewportValue.minDepth = minDepth;
 						viewportValue.maxDepth = maxDepth;
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -575,7 +575,7 @@ class WebGPUBackend extends Backend {
 		let { x, y, width, height, minDepth, maxDepth } = renderContext.viewportValue;
 
 		width = x + width > renderContext.width ? width - 1 : width;
-		y = Math.max( 0, renderContext.height - height - y );
+		height = y + height > renderContext.height ? height - 1 : height;
 
 		currentPass.setViewport( x, y, width, height, minDepth, maxDepth );
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -577,7 +577,7 @@ class WebGPUBackend extends Backend {
 		width = x + width > renderContext.width ? width - 1 : width;
 		y = Math.max( 0, renderContext.height - height - y );
 
-		currentPass.setViewport( x, renderContext.height - height - y, width, height, minDepth, maxDepth );
+		currentPass.setViewport( x, y, width, height, minDepth, maxDepth );
 
 	}
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -574,7 +574,9 @@ class WebGPUBackend extends Backend {
 		const { currentPass } = this.get( renderContext );
 		const { x, y, width, height, minDepth, maxDepth } = renderContext.viewportValue;
 
-		currentPass.setViewport( x, renderContext.height - height - y, width, height, minDepth, maxDepth );
+		const fixWidth = x + width > renderContext.width ? width - 1 : width;
+
+		currentPass.setViewport( x, renderContext.height - height - y, fixWidth, height, minDepth, maxDepth );
 
 	}
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -572,12 +572,12 @@ class WebGPUBackend extends Backend {
 	updateViewport( renderContext ) {
 
 		const { currentPass } = this.get( renderContext );
-		let { x, y, width, height, minDepth, maxDepth } = renderContext.viewportValue;
+		const { x, y, width, height, minDepth, maxDepth } = renderContext.viewportValue;
 
-		width = x + width > renderContext.width ? width - 1 : width;
-		height = y + height > renderContext.height ? height - 1 : height;
+		const w = x + width > renderContext.width ? width - 1 : width;
+		const h = y + height > renderContext.height ? height - 1 : height;
 
-		currentPass.setViewport( x, y, width, height, minDepth, maxDepth );
+		currentPass.setViewport( x, y, w, h, minDepth, maxDepth );
 
 	}
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -572,11 +572,12 @@ class WebGPUBackend extends Backend {
 	updateViewport( renderContext ) {
 
 		const { currentPass } = this.get( renderContext );
-		const { x, y, width, height, minDepth, maxDepth } = renderContext.viewportValue;
+		let { x, y, width, height, minDepth, maxDepth } = renderContext.viewportValue;
 
-		const fixWidth = x + width > renderContext.width ? width - 1 : width;
+		width = x + width > renderContext.width ? width - 1 : width;
+		y = Math.max( 0, renderContext.height - height - y );
 
-		currentPass.setViewport( x, renderContext.height - height - y, fixWidth, height, minDepth, maxDepth );
+		currentPass.setViewport( x, renderContext.height - height - y, width, height, minDepth, maxDepth );
 
 	}
 


### PR DESCRIPTION
When switching from Three.WebGLRenderer() to WebGPURenderer in the webgl_camera_array.html example, the WebGPUBackend consistently specified viewport dimensions that exceeded the maximum dimensions of the canvas. Removing the multiplyScalar() command on the viewportValue in Renderer.js partially solved this issue, presumably because the RenderPassEncoder's setViewport command. I presume this is because setViewport only needs to have its arguments specified in pixel coordinates, but I might be wrong. It doesn't seem like a separate function is modifying the viewport value before it is sent to the WebGPU backend...

Additionally, since the viewport dimensions seems to only exist in an integer format, when adjusting the window size, it's common for the specified viewport to exceed the valid dimensions of the canvas by 1 pixel, so a check has been added to the width and  account for this behavior. 

I looked through the WebGL backend, and it doesn't seem like similar issues popup despite both backends receiving the same viewport values from the example, so further investigation of the issue might be warranted. 