### PR TITLE
WebGPURenderer: remove redundant check for instance support

### DIFF
--- a/examples/jsm/nodes/materials/NodeMaterial.js
+++ b/examples/jsm/nodes/materials/NodeMaterial.js
@@ -232,7 +232,7 @@ class NodeMaterial extends Material {
 
 		}
 
-		if ( ( object.instanceMatrix && object.instanceMatrix.isInstancedBufferAttribute === true ) && builder.isAvailable( 'instance' ) === true ) {
+		if ( ( object.instanceMatrix && object.instanceMatrix.isInstancedBufferAttribute === true ) ) {
 
 			instance( object ).append();
 

--- a/examples/jsm/renderers/webgl/nodes/GLSLNodeBuilder.js
+++ b/examples/jsm/renderers/webgl/nodes/GLSLNodeBuilder.js
@@ -20,7 +20,6 @@ const precisionLib = {
 };
 
 const supports = {
-	instance: true,
 	swizzleAssign: true
 };
 

--- a/examples/jsm/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/examples/jsm/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -26,7 +26,6 @@ const gpuShaderStageLib = {
 };
 
 const supports = {
-	instance: true,
 	storageBuffer: true
 };
 


### PR DESCRIPTION
Instancing support always supported by WebGL2 and WebGPU, remove check for this support.
