### PR TITLE
Editor: Enhance SetValueCommand to support nested attributeName

### DIFF
--- a/editor/js/Sidebar.Object.js
+++ b/editor/js/Sidebar.Object.js
@@ -593,25 +593,25 @@ function SidebarObject( editor ) {
 
 				if ( object.shadow.intensity !== objectShadowIntensity.getValue() ) {
 
-					editor.execute( new SetValueCommand( editor, object.shadow, 'intensity', objectShadowIntensity.getValue() ) );
+					editor.execute( new SetValueCommand( editor, object, 'shadow.intensity', objectShadowIntensity.getValue() ) );
 
 				}
 
 				if ( object.shadow.bias !== objectShadowBias.getValue() ) {
 
-					editor.execute( new SetValueCommand( editor, object.shadow, 'bias', objectShadowBias.getValue() ) );
+					editor.execute( new SetValueCommand( editor, object, 'shadow.bias', objectShadowBias.getValue() ) );
 
 				}
 
 				if ( object.shadow.normalBias !== objectShadowNormalBias.getValue() ) {
 
-					editor.execute( new SetValueCommand( editor, object.shadow, 'normalBias', objectShadowNormalBias.getValue() ) );
+					editor.execute( new SetValueCommand( editor, object, 'shadow.normalBias', objectShadowNormalBias.getValue() ) );
 
 				}
 
 				if ( object.shadow.radius !== objectShadowRadius.getValue() ) {
 
-					editor.execute( new SetValueCommand( editor, object.shadow, 'radius', objectShadowRadius.getValue() ) );
+					editor.execute( new SetValueCommand( editor, object, 'shadow.radius', objectShadowRadius.getValue() ) );
 
 				}
 

--- a/editor/js/commands/SetValueCommand.js
+++ b/editor/js/commands/SetValueCommand.js
@@ -1,5 +1,39 @@
 import { Command } from '../Command.js';
 
+function setValue( object, path, value ) {
+
+	const keys = path.split( '.' );
+	const key = keys.shift();
+
+	if ( keys.length === 0 ) {
+
+		object[ key ] = value;
+
+	} else {
+
+		setValue( object[ key ], keys.join( '.' ), value );
+
+	}
+
+}
+
+function getValue( object, path ) {
+
+	const keys = path.split( '.' );
+	const key = keys.shift();
+
+	if ( keys.length === 0 ) {
+
+		return object[ key ];
+
+	} else {
+
+		return getValue( object[ key ], keys.join( '.' ) );
+
+	}
+
+}
+
 /**
  * @param editor Editor
  * @param object THREE.Object3D
@@ -19,14 +53,14 @@ class SetValueCommand extends Command {
 
 		this.object = object;
 		this.attributeName = attributeName;
-		this.oldValue = ( object !== null ) ? object[ attributeName ] : null;
+		this.oldValue = ( object !== null ) ? getValue( object, attributeName ) : null;
 		this.newValue = newValue;
 
 	}
 
 	execute() {
 
-		this.object[ this.attributeName ] = this.newValue;
+		setValue( this.object, this.attributeName, this.newValue );
 		this.editor.signals.objectChanged.dispatch( this.object );
 		// this.editor.signals.sceneGraphChanged.dispatch();
 
@@ -34,7 +68,7 @@ class SetValueCommand extends Command {
 
 	undo() {
 
-		this.object[ this.attributeName ] = this.oldValue;
+		setValue( this.object, this.attributeName, this.oldValue );
 		this.editor.signals.objectChanged.dispatch( this.object );
 		// this.editor.signals.sceneGraphChanged.dispatch();
 


### PR DESCRIPTION
fix: #28601

This PR enhances `SetValueCommand` to support nested `attributeName`, s.t. editor will dispatch objectChanged on `object`(which is the selected object), not `object.shadow`(which can never be a selected object) ...

```js
// do this
new SetValueCommand(editor, object, 'shadow.intensity',...) // dispatch objectChanged on `object`

// instead of this
new SetValueCommand(editor, object.shadow, 'intensity',...) // disptach objectChanged on `object.shadow`
```

... which in turn UI will get refresh:

https://github.com/mrdoob/three.js/blob/8eccd730af8692f07b3960237cf2a12f58b9bfb8/editor/js/Sidebar.Object.js#L733-L739

Preview: https://raw.githack.com/ycw/three.js/editor-setvaluecommand-attributename-supports-nested-props/editor/index.html
Test file: File>Open [project.json](https://github.com/user-attachments/files/15765127/project.json) 
Test: 
1. Select DirectionalLight in SCENE outliner
2. Change shadow intensity from 1.0 to 0.2 in OBJECT tab
3. Edit>Undo
4. You should see shadow intensity field is 1.0

https://github.com/mrdoob/three.js/assets/1063018/30abcd54-8f1b-433b-8b14-fa99e30867a8


