### PR TITLE
Editor: Fixed warning message typo in sw.js 

### DIFF
--- a/editor/sw.js
+++ b/editor/sw.js
@@ -237,7 +237,7 @@ self.addEventListener( 'install', async function () {
 
 		} catch {
 
-			console.warn( '[SW] Cound\'t cache:', asset );
+			console.warn( '[SW] Couldn\'t cache:', asset );
 
 		}
 


### PR DESCRIPTION
`Cound't` -> `Couldn't`