### PR TITLE
WebGPURenderer: Int/Uint Support to StorageBufferNode in WebGLBackend

### DIFF
--- a/examples/jsm/nodes/accessors/StorageBufferNode.js
+++ b/examples/jsm/nodes/accessors/StorageBufferNode.js
@@ -14,9 +14,12 @@ class StorageBufferNode extends BufferNode {
 		this.isStorageBufferNode = true;
 
 		this.bufferObject = false;
+		this.bufferCount = bufferCount;
 
 		this._attribute = null;
 		this._varying = null;
+
+		this.global = true;
 
 		if ( value.isStorageBufferAttribute !== true && value.isStorageInstancedBufferAttribute !== true ) {
 
@@ -26,6 +29,30 @@ class StorageBufferNode extends BufferNode {
 			else value.isStorageBufferAttribute = true;
 
 		}
+
+	}
+
+	getHash( builder ) {
+
+		if ( this.bufferCount === 0 ) {
+
+			let bufferData = builder.globalCache.getData( this.value );
+
+			if ( bufferData === undefined ) {
+
+				bufferData = {
+					node: this
+				};
+
+				builder.globalCache.setData( this.value, bufferData );
+
+			}
+
+			return bufferData.node.uuid;
+
+		}
+
+		return this.uuid;
 
 	}
 

--- a/examples/jsm/nodes/accessors/StorageBufferNode.js
+++ b/examples/jsm/nodes/accessors/StorageBufferNode.js
@@ -14,12 +14,9 @@ class StorageBufferNode extends BufferNode {
 		this.isStorageBufferNode = true;
 
 		this.bufferObject = false;
-		this.bufferCount = bufferCount;
 
 		this._attribute = null;
 		this._varying = null;
-
-		this.global = true;
 
 		if ( value.isStorageBufferAttribute !== true && value.isStorageInstancedBufferAttribute !== true ) {
 
@@ -29,30 +26,6 @@ class StorageBufferNode extends BufferNode {
 			else value.isStorageBufferAttribute = true;
 
 		}
-
-	}
-
-	getHash( builder ) {
-
-		if ( this.bufferCount === 0 ) {
-
-			let bufferData = builder.globalCache.getData( this.value );
-
-			if ( bufferData === undefined ) {
-
-				bufferData = {
-					node: this
-				};
-
-				builder.globalCache.setData( this.value, bufferData );
-
-			}
-
-			return bufferData.node.uuid;
-
-		}
-
-		return this.uuid;
 
 	}
 

--- a/examples/jsm/renderers/webgl/nodes/GLSLNodeBuilder.js
+++ b/examples/jsm/renderers/webgl/nodes/GLSLNodeBuilder.js
@@ -30,17 +30,17 @@ precision highp int;
 precision highp sampler2D;
 precision highp sampler3D;
 precision highp samplerCube;
-precision mediump sampler2DArray;
+precision highp sampler2DArray;
 
 precision highp usampler2D;
 precision highp usampler3D;
 precision highp usamplerCube;
-precision mediump usampler2DArray;
+precision highp usampler2DArray;
 
 precision highp isampler2D;
 precision highp isampler3D;
 precision highp isamplerCube;
-precision mediump isampler2DArray;
+precision highp isampler2DArray;
 
 precision lowp sampler2DShadow;
 `;

--- a/examples/jsm/renderers/webgl/nodes/GLSLNodeBuilder.js
+++ b/examples/jsm/renderers/webgl/nodes/GLSLNodeBuilder.js
@@ -351,7 +351,7 @@ ${ flowData.code }
 
 				let typePrefix = '';
 
-				if ( texture.isDataTexture === true ) {
+				if ( texture.isPBOTexture === true ) {
 
 					const prefix = texture.source.data.data.constructor.name.toLowerCase().charAt( 0 );
 

--- a/examples/jsm/renderers/webgl/utils/WebGLTextureUtils.js
+++ b/examples/jsm/renderers/webgl/utils/WebGLTextureUtils.js
@@ -147,6 +147,16 @@ class WebGLTextureUtils {
 			if ( glType === gl.SHORT ) internalFormat = gl.RG16I;
 			if ( glType === gl.INT ) internalFormat = gl.RG32I;
 
+		}
+
+		if ( glFormat === gl.RG_INTEGER ) {
+
+			if ( glType === gl.UNSIGNED_BYTE ) internalFormat = gl.RG8UI;
+			if ( glType === gl.UNSIGNED_SHORT ) internalFormat = gl.RG16UI;
+			if ( glType === gl.UNSIGNED_INT ) internalFormat = gl.RG32UI;
+			if ( glType === gl.BYTE ) internalFormat = gl.RG8I;
+			if ( glType === gl.SHORT ) internalFormat = gl.RG16I;
+			if ( glType === gl.INT ) internalFormat = gl.RG32I;
 
 		}
 
@@ -168,6 +178,17 @@ class WebGLTextureUtils {
 
 		}
 
+		if ( glFormat === gl.RGB_INTEGER ) {
+
+			if ( glType === gl.UNSIGNED_BYTE ) internalFormat = gl.RGB8UI;
+			if ( glType === gl.UNSIGNED_SHORT ) internalFormat = gl.RGB16UI;
+			if ( glType === gl.UNSIGNED_INT ) internalFormat = gl.RGB32UI;
+			if ( glType === gl.BYTE ) internalFormat = gl.RGB8I;
+			if ( glType === gl.SHORT ) internalFormat = gl.RGB16I;
+			if ( glType === gl.INT ) internalFormat = gl.RGB32I;
+
+		}
+
 		if ( glFormat === gl.RGBA ) {
 
 			if ( glType === gl.FLOAT ) internalFormat = gl.RGBA32F;
@@ -181,6 +202,17 @@ class WebGLTextureUtils {
 			if ( glType === gl.UNSIGNED_BYTE ) internalFormat = ( colorSpace === SRGBColorSpace && forceLinearTransfer === false ) ? gl.SRGB8_ALPHA8 : gl.RGBA8;
 			if ( glType === gl.UNSIGNED_SHORT_4_4_4_4 ) internalFormat = gl.RGBA4;
 			if ( glType === gl.UNSIGNED_SHORT_5_5_5_1 ) internalFormat = gl.RGB5_A1;
+
+		}
+
+		if ( glFormat === gl.RGBA_INTEGER ) {
+
+			if ( glType === gl.UNSIGNED_BYTE ) internalFormat = gl.RGBA8UI;
+			if ( glType === gl.UNSIGNED_SHORT ) internalFormat = gl.RGBA16UI;
+			if ( glType === gl.UNSIGNED_INT ) internalFormat = gl.RGBA32UI;
+			if ( glType === gl.BYTE ) internalFormat = gl.RGBA8I;
+			if ( glType === gl.SHORT ) internalFormat = gl.RGBA16I;
+			if ( glType === gl.INT ) internalFormat = gl.RGBA32I;
 
 		}
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -103,6 +103,7 @@ export const RedFormat = 1028;
 export const RedIntegerFormat = 1029;
 export const RGFormat = 1030;
 export const RGIntegerFormat = 1031;
+export const RGBIntegerFormat = 1032;
 export const RGBAIntegerFormat = 1033;
 
 export const RGB_S3TC_DXT1_Format = 33776;


### PR DESCRIPTION
Related: #27661

**Description**

Following #27661 this PR extends the `Int` and `Uint` support to the StorageBufferNode fallback in the WebGLBackend.

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Utsubo](https://utsubo.com)*
