### PR TITLE
WebGPURenderer: Add cache hierachy to StorageBufferNode

### DIFF
--- a/examples/jsm/nodes/accessors/StorageBufferNode.js
+++ b/examples/jsm/nodes/accessors/StorageBufferNode.js
@@ -14,9 +14,12 @@ class StorageBufferNode extends BufferNode {
 		this.isStorageBufferNode = true;
 
 		this.bufferObject = false;
+		this.bufferCount = bufferCount;
 
 		this._attribute = null;
 		this._varying = null;
+
+		this.global = true;
 
 		if ( value.isStorageBufferAttribute !== true && value.isStorageInstancedBufferAttribute !== true ) {
 
@@ -26,6 +29,30 @@ class StorageBufferNode extends BufferNode {
 			else value.isStorageBufferAttribute = true;
 
 		}
+
+	}
+
+	getHash( builder ) {
+
+		if ( this.bufferCount === 0 ) {
+
+			let bufferData = builder.globalCache.getData( this.value );
+
+			if ( bufferData === undefined ) {
+
+				bufferData = {
+					node: this
+				};
+
+				builder.globalCache.setData( this.value, bufferData );
+
+			}
+
+			return bufferData.node.uuid;
+
+		}
+
+		return this.uuid;
 
 	}
 


### PR DESCRIPTION
Related issue: #28585

**Description**

Following #28585 this PR add the new cache system to the `StorageBufferNode`.
This PR also fixes all the compute examples in the WebGLBackend so I will just merge it as it is. /cc @sunag 

*This contribution is funded by [Utsubo](https://utsubo.com)*
