### PR TITLE
Editor: UIPoints honors UNDO/REDO  

### DIFF
--- a/editor/js/Sidebar.Geometry.LatheGeometry.js
+++ b/editor/js/Sidebar.Geometry.LatheGeometry.js
@@ -61,6 +61,7 @@ function GeometryParametersPanel( editor, object ) {
 
 		const parameters = object.geometry.parameters;
 
+		points.setValue( parameters.points );
 		segments.setValue( parameters.segments );
 		phiStart.setValue( parameters.phiStart * THREE.MathUtils.RAD2DEG );
 		phiLength.setValue( parameters.phiLength * THREE.MathUtils.RAD2DEG );

--- a/editor/js/Sidebar.Geometry.LatheGeometry.js
+++ b/editor/js/Sidebar.Geometry.LatheGeometry.js
@@ -61,7 +61,10 @@ function GeometryParametersPanel( editor, object ) {
 
 		const parameters = object.geometry.parameters;
 
+		points.onChange( null );
 		points.setValue( parameters.points );
+		points.onChange( update );
+
 		segments.setValue( parameters.segments );
 		phiStart.setValue( parameters.phiStart * THREE.MathUtils.RAD2DEG );
 		phiLength.setValue( parameters.phiLength * THREE.MathUtils.RAD2DEG );

--- a/editor/js/Sidebar.Geometry.TubeGeometry.js
+++ b/editor/js/Sidebar.Geometry.TubeGeometry.js
@@ -96,6 +96,7 @@ function GeometryParametersPanel( editor, object ) {
 
 		curveType.setValue( parameters.path.curveType );
 		tension.setValue( parameters.path.tension );
+		points.setValue( parameters.path.points );
 
 		tensionRow.setDisplay( curveType.getValue() == 'catmullrom' ? '' : 'none' );
 

--- a/editor/js/Sidebar.Geometry.TubeGeometry.js
+++ b/editor/js/Sidebar.Geometry.TubeGeometry.js
@@ -96,7 +96,10 @@ function GeometryParametersPanel( editor, object ) {
 
 		curveType.setValue( parameters.path.curveType );
 		tension.setValue( parameters.path.tension );
+
+		points.onChange( null );
 		points.setValue( parameters.path.points );
+		points.onChange( update );
 
 		tensionRow.setDisplay( curveType.getValue() == 'catmullrom' ? '' : 'none' );
 

--- a/editor/js/libs/ui.three.js
+++ b/editor/js/libs/ui.three.js
@@ -571,17 +571,11 @@ class UIPoints extends UISpan {
 
 	clear() {
 
-		for ( let i = 0; i < this.pointsUI.length; ++ i ) {
+		for ( let i = this.pointsUI.length - 1; i >= 0; -- i ) {
 
-			if ( this.pointsUI[ i ] ) {
-
-				this.deletePointRow( i, true );
-
-			}
+			this.deletePointRow( i, true );
 
 		}
-
-		this.lastPointIdx = 0;
 
 	}
 
@@ -600,6 +594,25 @@ class UIPoints extends UISpan {
 		}
 
 		this.lastPointIdx --;
+
+	}
+
+	isPointsIdentical( newPoints ) {
+
+		const oldPoints = this.getValue();
+
+		if ( oldPoints.length !== newPoints.length ) return false;
+
+		for ( let i = 0; i < oldPoints.length; i ++ ) {
+
+			const oldPoint = oldPoints[ i ];
+			const newPoint = newPoints[ i ];
+
+			if ( oldPoint.equals( newPoint ) === false ) return false;
+
+		}
+
+		return true;
 
 	}
 
@@ -660,6 +673,8 @@ class UIPoints2 extends UIPoints {
 
 	setValue( points ) {
 
+		if ( this.isPointsIdentical( points ) === true ) return this;
+
 		this.clear();
 
 		for ( let i = 0; i < points.length; i ++ ) {
@@ -669,7 +684,6 @@ class UIPoints2 extends UIPoints {
 
 		}
 
-		this.update();
 		return this;
 
 	}
@@ -755,6 +769,8 @@ class UIPoints3 extends UIPoints {
 
 	setValue( points ) {
 
+		if ( this.isPointsIdentical( points ) === true ) return this;
+
 		this.clear();
 
 		for ( let i = 0; i < points.length; i ++ ) {
@@ -764,7 +780,6 @@ class UIPoints3 extends UIPoints {
 
 		}
 
-		this.update();
 		return this;
 
 	}

--- a/editor/js/libs/ui.three.js
+++ b/editor/js/libs/ui.three.js
@@ -684,6 +684,7 @@ class UIPoints2 extends UIPoints {
 
 		}
 
+		this.update();
 		return this;
 
 	}
@@ -780,6 +781,7 @@ class UIPoints3 extends UIPoints {
 
 		}
 
+		this.update();
 		return this;
 
 	}


### PR DESCRIPTION
**Description**

With this PR, LatheGeometry's `Points` input and TubeGeometry's `Path` input will honor UNDO/REDO.

- Fixed `UIPoints.clear()` 
  - Deletes point rows one by one from tail
  - Deletes `this.lastPointIdx=0` (redundant) 
- Fixed `UIPoints2.setValue()`, and `UIPoints3.setValue()`
  - Re-generate point rows only if needed

Preview: https://raw.githack.com/ycw/three.js/editor-uipoints-honors-undo-redo/editor/index.html