### PR TITLE
Editor: Fixed wrong UI element for "Cap Seg"

### DIFF
--- a/editor/js/Sidebar.Geometry.CapsuleGeometry.js
+++ b/editor/js/Sidebar.Geometry.CapsuleGeometry.js
@@ -37,7 +37,7 @@ function GeometryParametersPanel( editor, object ) {
 	// capSegments
 
 	const capSegmentsRow = new UIRow();
-	const capSegments = new UINumber( parameters.capSegments ).onChange( update );
+	const capSegments = new UIInteger( parameters.capSegments ).setRange( 1, Infinity ).onChange( update );
 
 	capSegmentsRow.add( new UIText( strings.getKey( 'sidebar/geometry/capsule_geometry/capseg' ) ).setClass( 'Label' ) );
 	capSegmentsRow.add( capSegments );


### PR DESCRIPTION
**Description**

According to [CapsuleGeometry docs](https://threejs.org/docs/#api/en/geometries/CapsuleGeometry), capSegments is an Integer, so "Cap Seg" input should be an `UIInteger`