### PR TITLE
Editor: Disposes object's helper when removing helper

### DIFF
--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -469,6 +469,7 @@ Editor.prototype = {
 
 			var helper = this.helpers[ object.id ];
 			helper.parent.remove( helper );
+			helper.dispose();
 
 			delete this.helpers[ object.id ];
 


### PR DESCRIPTION
**Description**

This PR disposes the object's helper when `editor.removeHelper(object)`, s.t. it won't leak helper's geometry. 

VertexNormalHelper's geometry size is variant, and it casually holds thousands of f32s for example:

![image](https://github.com/mrdoob/three.js/assets/1063018/b26f799f-433a-401d-919a-bf37ac3a4ea1)
 

