### PR TITLE
WebGPURenderer: Add Enable Directive/Enable-Extension Support

### DIFF
--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -657,10 +657,10 @@ ${ flowData.code }
 
 	}
 
-	getDirective( name, shaderStage = this.shaderStage) {
+	getDirective( name, shaderStage = this.shaderStage ) {
 
 		const stage = this.directives[ shaderStage ] || ( this.directives[ shaderStage ] = [] );
-		stage.push(name);
+		stage.push( name );
 
 	}
 
@@ -673,25 +673,25 @@ ${ flowData.code }
 
 			for ( const directive of directives ) {
 
-				snippets.push(`enable ${directive}`);
+				snippets.push( `enable ${directive}` );
 
 			}
 
 		}
 
-		return snippets.join('\n');
+		return snippets.join( '\n' );
 
 	}
 
 	enableClipDistances() {
 
-		this.getDirective('clip_distances');
+		this.getDirective( 'clip_distances' );
 
 	}
 
 	enableShaderF16() {
 
-		this.getDirective('f16');
+		this.getDirective( 'f16' );
 
 	}
 

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -163,6 +163,8 @@ class WGSLNodeBuilder extends NodeBuilder {
 
 		this.builtins = {};
 
+		this.directives = {};
+
 	}
 
 	needsColorSpaceToLinear( texture ) {
@@ -655,6 +657,44 @@ ${ flowData.code }
 
 	}
 
+	getDirective( name, shaderStage = this.shaderStage) {
+
+		const stage = this.directives[ shaderStage ] || ( this.directives[ shaderStage ] = [] );
+		stage.push(name);
+
+	}
+
+	getDirectives( shaderStage ) {
+
+		const snippets = [];
+		const directives = this.directives[ shaderStage ];
+
+		if ( directives !== undefined ) {
+
+			for ( const directive of directives ) {
+
+				snippets.push(`enable ${directive}`);
+
+			}
+
+		}
+
+		return snippets.join('\n');
+
+	}
+
+	enableClipDistances() {
+
+		this.getDirective('clip_distances');
+
+	}
+
+	enableShaderF16() {
+
+		this.getDirective('f16');
+
+	}
+
 	getBuiltins( shaderStage ) {
 
 		const snippets = [];
@@ -967,6 +1007,7 @@ ${ flowData.code }
 			stageData.structs = this.getStructs( shaderStage );
 			stageData.vars = this.getVars( shaderStage );
 			stageData.codes = this.getCodes( shaderStage );
+			stageData.directives = this.getDirectives( shaderStage );
 
 			//
 
@@ -1126,6 +1167,8 @@ ${ flowData.code }
 	_getWGSLVertexCode( shaderData ) {
 
 		return `${ this.getSignature() }
+// directives
+${shaderData.directives};
 
 // uniforms
 ${shaderData.uniforms}
@@ -1183,6 +1226,9 @@ fn main( ${shaderData.varyings} ) -> ${shaderData.returnType} {
 	_getWGSLComputeCode( shaderData, workgroupSize ) {
 
 		return `${ this.getSignature() }
+// Directives
+${shaderData.directives}
+
 // system
 var<private> instanceIndex : u32;
 

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -657,7 +657,7 @@ ${ flowData.code }
 
 	}
 
-	getDirective( name, shaderStage = this.shaderStage ) {
+	enableDirective( name, shaderStage = this.shaderStage ) {
 
 		const stage = this.directives[ shaderStage ] || ( this.directives[ shaderStage ] = [] );
 		stage.push( name );
@@ -685,13 +685,19 @@ ${ flowData.code }
 
 	enableClipDistances() {
 
-		this.getDirective( 'clip_distances' );
+		this.enableDirective( 'clip_distances' );
 
 	}
 
 	enableShaderF16() {
 
-		this.getDirective( 'f16' );
+		this.enableDirective( 'f16' );
+
+	}
+
+	enableDualSourceBlending() {
+
+		this.enableDirective( 'dual_source_blending' );
 
 	}
 

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -1232,7 +1232,7 @@ fn main( ${shaderData.varyings} ) -> ${shaderData.returnType} {
 	_getWGSLComputeCode( shaderData, workgroupSize ) {
 
 		return `${ this.getSignature() }
-// Directives
+// directives
 ${shaderData.directives}
 
 // system

--- a/src/renderers/webgpu/utils/WebGPUConstants.js
+++ b/src/renderers/webgpu/utils/WebGPUConstants.js
@@ -328,4 +328,5 @@ export const GPUFeatureName = {
 	BGRA8UNormStorage: 'bgra8unorm-storage',
 	Float32Filterable: 'float32-filterable',
 	ClipDistances: 'clip-distances',
+	DualSourceBlending: 'dual-source-blending'
 };

--- a/src/renderers/webgpu/utils/WebGPUConstants.js
+++ b/src/renderers/webgpu/utils/WebGPUConstants.js
@@ -326,5 +326,6 @@ export const GPUFeatureName = {
 	ShaderF16: 'shader-f16',
 	RG11B10UFloat: 'rg11b10ufloat-renderable',
 	BGRA8UNormStorage: 'bgra8unorm-storage',
-	Float32Filterable: 'float32-filterable'
+	Float32Filterable: 'float32-filterable',
+	ClipDistances: 'clip-distances',
 };


### PR DESCRIPTION
Related issue: #28578

According to the WGSL specification, enable extensions are features required to utilize certain features like f16 floats and clip_distances. These extensions can be utilized within a shader if the shader calls its corresponding enable directive and the corresponding feature is enabled on the GPUDevice. There are a few upsides and downsides to providing WGSLNodeBuilder the ability to create shaders with enable directives.

Downsides: 

- As WGSL continues to develop, features only accessible through enable extensions may become standard features, no longer necessitating explicit requests via enable directives. 
- Enable extensions are often only available on the latest versions of Chromium. Older versions will not be able to access them.
- Potential need to sync available device features with shader language, or fallback to different graphics backend if a Three.js application requires an enable-extension that the device does not support (i.e if the current GPUDevice does not support clip-distances, fallback to the WebGPURenderer's WebGLBackend or throw an error). 

Upsides:
- Supporting enable extensions helps facilitate the development of new features before they're widely available. 
- Helps with back-porting. If an enable extension becomes a standard feature in a newer version of Chromium or WGSL, applications using older versions will still have access to that feature. 

**Description**

The implementation is effectively just a simplified version of WGSLNodeBuilders' builtins code. Directives were only added to vertex and compute shaders since they seem to be the only shader stages that currently have directives associated with them.