### PR TITLE
Editor: SetShadowValueCommand should be updatable

### DIFF
--- a/editor/js/commands/SetShadowValueCommand.js
+++ b/editor/js/commands/SetShadowValueCommand.js
@@ -15,6 +15,7 @@ class SetShadowValueCommand extends Command {
 
 		this.type = 'SetShadowValueCommand';
 		this.name = editor.strings.getKey( 'command/SetShadowValue' ) + ': ' + attributeName;
+		this.updatable = true;
 
 		this.object = object;
 		this.attributeName = attributeName;
@@ -34,6 +35,12 @@ class SetShadowValueCommand extends Command {
 
 		this.object.shadow[ this.attributeName ] = this.oldValue;
 		this.editor.signals.objectChanged.dispatch( this.object );
+
+	}
+
+	update( cmd ) {
+
+		this.newValue = cmd.newValue;
 
 	}
 


### PR DESCRIPTION
**Description**

`SetShadowValueCommand` currently is not "updatable" so when users set shadow properties by sliding the number input, editor  will create tons of history entries, and UNDO/REDO becomes unusable. 

This PR makes `SetShadowValueCommand` to be "updatable" just like the `SetValueCommand`.
