### PR TITLE
WebGPURenderer: Allow using StorageBuffer directly as attribute in nodes

### DIFF
--- a/examples/jsm/renderers/common/Geometries.js
+++ b/examples/jsm/renderers/common/Geometries.js
@@ -146,7 +146,15 @@ class Geometries extends DataMap {
 
 		for ( const attribute of attributes ) {
 
-			this.updateAttribute( attribute, AttributeType.VERTEX );
+			if ( attribute.isStorageBufferAttribute || attribute.isStorageInstancedBufferAttribute ) {
+
+				this.updateAttribute( attribute, AttributeType.STORAGE );
+
+			} else {
+
+				this.updateAttribute( attribute, AttributeType.VERTEX );
+
+			}
 
 		}
 


### PR DESCRIPTION

**Description**
When using storage buffers directly as vertex node it will consume them as basic attribute and generates this type of error (in both backend):
![Screenshot 2024-06-11 at 16 56 43](https://github.com/mrdoob/three.js/assets/15867665/c726a40e-c2fe-403e-870e-69619c065258)

This PR fixes the issue as properly binding the attribute as storage buffer instead of VERTEX | COPY_SRC | COPY_DST

*This contribution is funded by [Utsubo](https://utsubo.com)*
