### PR TITLE
Docs: Fixed wrong html lang in LightProbeGenerator.html

### DIFF
--- a/docs/examples/zh/lights/LightProbeGenerator.html
+++ b/docs/examples/zh/lights/LightProbeGenerator.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh">
 	<head>
 		<meta charset="utf-8" />
 		<base href="../../../" />


### PR DESCRIPTION
The `<html lang=` should be `zh`, not `en` in `docs/examples/zh/lights/LightProbeGenerator.html`
