### PR TITLE
Editor: Refreshs Geometry UI only if needed

### DIFF
--- a/editor/js/Sidebar.Geometry.BoxGeometry.js
+++ b/editor/js/Sidebar.Geometry.BoxGeometry.js
@@ -89,7 +89,15 @@ function GeometryParametersPanel( editor, object ) {
 
 	}
 
-	signals.geometryChanged.add( refreshUI );
+	signals.geometryChanged.add( function ( mesh ) {
+
+		if ( mesh === object ) {
+
+			refreshUI();
+
+		}
+
+	} );
 
 	//
 

--- a/editor/js/Sidebar.Geometry.CapsuleGeometry.js
+++ b/editor/js/Sidebar.Geometry.CapsuleGeometry.js
@@ -67,7 +67,15 @@ function GeometryParametersPanel( editor, object ) {
 
 	}
 
-	signals.geometryChanged.add( refreshUI );
+	signals.geometryChanged.add( function ( mesh ) {
+
+		if ( mesh === object ) {
+
+			refreshUI();
+
+		}
+
+	} );
 
 	//
 

--- a/editor/js/Sidebar.Geometry.CircleGeometry.js
+++ b/editor/js/Sidebar.Geometry.CircleGeometry.js
@@ -67,7 +67,15 @@ function GeometryParametersPanel( editor, object ) {
 
 	}
 
-	signals.geometryChanged.add( refreshUI );
+	signals.geometryChanged.add( function ( mesh ) {
+
+		if ( mesh === object ) {
+
+			refreshUI();
+
+		}
+
+	} );
 
 	//
 

--- a/editor/js/Sidebar.Geometry.CylinderGeometry.js
+++ b/editor/js/Sidebar.Geometry.CylinderGeometry.js
@@ -89,7 +89,15 @@ function GeometryParametersPanel( editor, object ) {
 
 	}
 
-	signals.geometryChanged.add( refreshUI );
+	signals.geometryChanged.add( function ( mesh ) {
+
+		if ( mesh === object ) {
+
+			refreshUI();
+
+		}
+
+	} );
 
 	//
 

--- a/editor/js/Sidebar.Geometry.DodecahedronGeometry.js
+++ b/editor/js/Sidebar.Geometry.DodecahedronGeometry.js
@@ -45,7 +45,15 @@ function GeometryParametersPanel( editor, object ) {
 
 	}
 
-	signals.geometryChanged.add( refreshUI );
+	signals.geometryChanged.add( function ( mesh ) {
+
+		if ( mesh === object ) {
+
+			refreshUI();
+
+		}
+
+	} );
 
 	//
 

--- a/editor/js/Sidebar.Geometry.ExtrudeGeometry.js
+++ b/editor/js/Sidebar.Geometry.ExtrudeGeometry.js
@@ -148,7 +148,15 @@ function GeometryParametersPanel( editor, object ) {
 
 	}
 
-	signals.geometryChanged.add( refreshUI );
+	signals.geometryChanged.add( function ( mesh ) {
+
+		if ( mesh === object ) {
+
+			refreshUI();
+
+		}
+
+	} );
 
 	//
 

--- a/editor/js/Sidebar.Geometry.IcosahedronGeometry.js
+++ b/editor/js/Sidebar.Geometry.IcosahedronGeometry.js
@@ -45,7 +45,15 @@ function GeometryParametersPanel( editor, object ) {
 
 	}
 
-	signals.geometryChanged.add( refreshUI );
+	signals.geometryChanged.add( function ( mesh ) {
+
+		if ( mesh === object ) {
+
+			refreshUI();
+
+		}
+
+	} );
 
 	//
 

--- a/editor/js/Sidebar.Geometry.LatheGeometry.js
+++ b/editor/js/Sidebar.Geometry.LatheGeometry.js
@@ -67,7 +67,17 @@ function GeometryParametersPanel( editor, object ) {
 
 	}
 
-	signals.geometryChanged.add( refreshUI );
+	signals.geometryChanged.add( function ( mesh ) {
+
+		if ( mesh === object ) {
+
+			refreshUI();
+
+		}
+
+	} );
+
+	//
 
 	function update() {
 

--- a/editor/js/Sidebar.Geometry.OctahedronGeometry.js
+++ b/editor/js/Sidebar.Geometry.OctahedronGeometry.js
@@ -46,7 +46,15 @@ function GeometryParametersPanel( editor, object ) {
 
 	}
 
-	signals.geometryChanged.add( refreshUI );
+	signals.geometryChanged.add( function ( mesh ) {
+
+		if ( mesh === object ) {
+
+			refreshUI();
+
+		}
+
+	} );
 
 	//
 

--- a/editor/js/Sidebar.Geometry.PlaneGeometry.js
+++ b/editor/js/Sidebar.Geometry.PlaneGeometry.js
@@ -67,7 +67,15 @@ function GeometryParametersPanel( editor, object ) {
 
 	}
 
-	signals.geometryChanged.add( refreshUI );
+	signals.geometryChanged.add( function ( mesh ) {
+
+		if ( mesh === object ) {
+
+			refreshUI();
+
+		}
+
+	} );
 
 	//
 

--- a/editor/js/Sidebar.Geometry.RingGeometry.js
+++ b/editor/js/Sidebar.Geometry.RingGeometry.js
@@ -89,7 +89,15 @@ function GeometryParametersPanel( editor, object ) {
 
 	}
 
-	signals.geometryChanged.add( refreshUI );
+	signals.geometryChanged.add( function ( mesh ) {
+
+		if ( mesh === object ) {
+
+			refreshUI();
+
+		}
+
+	} );
 
 	//
 

--- a/editor/js/Sidebar.Geometry.ShapeGeometry.js
+++ b/editor/js/Sidebar.Geometry.ShapeGeometry.js
@@ -38,7 +38,15 @@ function GeometryParametersPanel( editor, object ) {
 
 	}
 
-	signals.geometryChanged.add( refreshUI );
+	signals.geometryChanged.add( function ( mesh ) {
+
+		if ( mesh === object ) {
+
+			refreshUI();
+
+		}
+
+	} );
 
 	//
 

--- a/editor/js/Sidebar.Geometry.SphereGeometry.js
+++ b/editor/js/Sidebar.Geometry.SphereGeometry.js
@@ -100,7 +100,15 @@ function GeometryParametersPanel( editor, object ) {
 
 	}
 
-	signals.geometryChanged.add( refreshUI );
+	signals.geometryChanged.add( function ( mesh ) {
+
+		if ( mesh === object ) {
+
+			refreshUI();
+
+		}
+
+	} );
 
 	//
 

--- a/editor/js/Sidebar.Geometry.TetrahedronGeometry.js
+++ b/editor/js/Sidebar.Geometry.TetrahedronGeometry.js
@@ -46,7 +46,15 @@ function GeometryParametersPanel( editor, object ) {
 
 	}
 
-	signals.geometryChanged.add( refreshUI );
+	signals.geometryChanged.add( function ( mesh ) {
+
+		if ( mesh === object ) {
+
+			refreshUI();
+
+		}
+
+	} );
 
 	//
 

--- a/editor/js/Sidebar.Geometry.TorusGeometry.js
+++ b/editor/js/Sidebar.Geometry.TorusGeometry.js
@@ -78,7 +78,15 @@ function GeometryParametersPanel( editor, object ) {
 
 	}
 
-	signals.geometryChanged.add( refreshUI );
+	signals.geometryChanged.add( function ( mesh ) {
+
+		if ( mesh === object ) {
+
+			refreshUI();
+
+		}
+
+	} );
 
 	//
 

--- a/editor/js/Sidebar.Geometry.TorusKnotGeometry.js
+++ b/editor/js/Sidebar.Geometry.TorusKnotGeometry.js
@@ -89,7 +89,15 @@ function GeometryParametersPanel( editor, object ) {
 
 	}
 
-	signals.geometryChanged.add( refreshUI );
+	signals.geometryChanged.add( function ( mesh ) {
+
+		if ( mesh === object ) {
+
+			refreshUI();
+
+		}
+
+	} );
 
 	//
 

--- a/editor/js/Sidebar.Geometry.TubeGeometry.js
+++ b/editor/js/Sidebar.Geometry.TubeGeometry.js
@@ -101,7 +101,15 @@ function GeometryParametersPanel( editor, object ) {
 
 	}
 
-	signals.geometryChanged.add( refreshUI );
+	signals.geometryChanged.add( function ( mesh ) {
+
+		if ( mesh === object ) {
+
+			refreshUI();
+
+		}
+
+	} );
 
 	//
 


### PR DESCRIPTION
**Description**

The current `geometryChanged` handler in all sidebar.geometry.xxx.js components do not filter the initiator object, so for example, updating geometry props of an object will trigger UI refresh for all other objects in the scene, which is wasteful.

This PR fixed that by filtering the initiator object at that handler, only refreshes UI if initiator is self. 