### PR TITLE
Docs: Unifies translation of "Import" in zh

### DIFF
--- a/docs/examples/zh/loaders/SVGLoader.html
+++ b/docs/examples/zh/loaders/SVGLoader.html
@@ -15,7 +15,7 @@
 		[link:https://en.wikipedia.org/wiki/Scalable_Vector_Graphics 可伸缩向量图形]是XML形式的矢量图形格式，用来描述二维矢量图形并支持交互和动画。
 		</p>
 
-		<h2>引用</h2>
+		<h2>导入</h2>
 
 		<p>
 			[name]是附加功能，必须显示引用。

--- a/docs/examples/zh/loaders/TGALoader.html
+++ b/docs/examples/zh/loaders/TGALoader.html
@@ -15,7 +15,7 @@
 		[link:https://en.wikipedia.org/wiki/Truevision_TGA TGA]是光栅图形，图形文件格式。
 		</p>
 
-		<h2>引用</h2>
+		<h2>导入</h2>
 
 		<p>
 			[name]是附加项，必须显示的引用。请参考[link:#manual/introduction/Installation Installation / Addons]。

--- a/docs/examples/zh/objects/Lensflare.html
+++ b/docs/examples/zh/objects/Lensflare.html
@@ -15,6 +15,8 @@
 			创建一个模拟追踪着灯光的镜头光晕。 [name] can only be used when setting the *alpha* context parameter of [page:WebGLRenderer] to *true*.
 		</p>
 
+		<h2>导入</h2>
+
 		<p>
 			[name] 是一个附加组件，必须显式导入。
 			See [link:#manual/introduction/Installation Installation / Addons].


### PR DESCRIPTION
extends #28621 

**Description**

- `引用` -> `导入`
- Added missing `<h2>导入</h2>` in docs/examples/zh/objects/Lensflare.html

