### PR TITLE
Editor: Removes `<!-- includes -->` replacement code when emits app

### DIFF
--- a/editor/js/Sidebar.Project.App.js
+++ b/editor/js/Sidebar.Project.App.js
@@ -115,10 +115,6 @@ function SidebarProjectApp( editor ) {
 
 			content = content.replace( '<!-- title -->', title );
 
-			const includes = [];
-
-			content = content.replace( '<!-- includes -->', includes.join( '\n\t\t' ) );
-
 			let editButton = '';
 
 			if ( config.getKey( 'project/editable' ) ) {


### PR DESCRIPTION
**Description**

This token `<!-- includes -->` is not present at [editor/js/libs/app/index.html](https://github.com/mrdoob/three.js/blob/dev/editor/js/libs/app/index.html), so removes the replacement code.