### PR TITLE
Editor: Makes duplicate shortcut keys impossible

### DIFF
--- a/editor/js/Sidebar.Settings.Shortcuts.js
+++ b/editor/js/Sidebar.Settings.Shortcuts.js
@@ -24,6 +24,7 @@ function SidebarSettingsShortcuts( editor ) {
 	container.add( headerRow );
 
 	const shortcuts = [ 'translate', 'rotate', 'scale', 'undo', 'focus' ];
+	const shortcutInputs = [];
 
 	function createShortcutInput( name ) {
 
@@ -40,6 +41,23 @@ function SidebarSettingsShortcuts( editor ) {
 			if ( isValidKeyBinding( value ) ) {
 
 				config.setKey( configName, value );
+
+				const otherShortcuts = shortcuts.filter( shortcut => shortcut !== name );
+				for ( let i = 0; i < otherShortcuts.length; i ++ ) {
+
+					const shortcut = otherShortcuts[ i ];
+					const configName = 'settings/shortcuts/' + shortcut;
+					const hotkey = config.getKey( configName );
+
+					if ( hotkey === value ) {
+
+						config.setKey( configName, '' );
+
+					}
+
+				}
+
+				refreshUI();
 
 			}
 
@@ -82,6 +100,9 @@ function SidebarSettingsShortcuts( editor ) {
 		}
 
 		shortcutInput.dom.maxLength = 1;
+
+		shortcutInputs.push( shortcutInput );
+
 		shortcutRow.add( new UIText( strings.getKey( 'sidebar/settings/shortcuts/' + name ) ).setTextTransform( 'capitalize' ).setClass( 'Label' ) );
 		shortcutRow.add( shortcutInput );
 
@@ -167,6 +188,20 @@ function SidebarSettingsShortcuts( editor ) {
 		}
 
 	} );
+
+
+	function refreshUI() {
+
+		for ( let i = 0; i < shortcuts.length; i ++ ) {
+
+			const shortcut = shortcuts[ i ];
+			const shortcutInput = shortcutInputs[ i ];
+
+			shortcutInput.setValue( config.getKey( 'settings/shortcuts/' + shortcut ) );
+
+		}
+
+	}
 
 	return container;
 


### PR DESCRIPTION
**Description**

This PR ensures that 1 shortcut key can only be mapped to 1 action. If users entered a shortcut key which was assigned for another action, that key will be unassigned from that action:

https://github.com/mrdoob/three.js/assets/1063018/6f3b30c1-109a-49d7-b995-7491018bf40f

Preview: https://raw.githack.com/ycw/three.js/editor-no-duplicate-hotkey/editor/index.html
 