### PR TITLE
TeapotGeometry: Add documentation

### DIFF
--- a/docs/examples/en/geometries/TeapotGeometry.html
+++ b/docs/examples/en/geometries/TeapotGeometry.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<base href="../../../" />
+		<script src="page.js"></script>
+		<link type="text/css" rel="stylesheet" href="page.css" />
+	</head>
+	<body>
+		[page:BufferGeometry] &rarr;
+
+		<h1>[name]</h1>
+
+		<p class="desc">
+			[name] tesselates the famous Utah teapot database by Martin Newell.
+		</p>
+
+		<h2>Import</h2>
+
+		<p>
+			[name] is an add-on, and must be imported explicitly.
+			See [link:#manual/introduction/Installation Installation / Addons].
+		</p>
+
+		<code>
+			import { TeapotGeometry } from 'three/addons/geometries/TeapotGeometry.js';
+		</code>
+
+		<h2>Code Example</h2>
+
+		<code>
+		const geometry = new TeapotGeometry( 50, 10, true, true, true, false, true );
+		const material = new THREE.MeshBasicMaterial( { color: 0x00ff00 } );
+		const teapot = new THREE.Mesh( geometry, material );
+		scene.add( teapot );
+		</code>
+
+		<h2>Constructor</h2>
+
+		<h3>[name]([param:Integer size], [param:Integer segments], [param:Boolean bottom], [param:Boolean lid], [param:Boolean body], [param:Boolean fitLid], [param:Boolean blinn])</h3>
+		<p>
+		size — Relative scale of the teapot. Optional; Defaults to '50'.<br>
+		segments — Number of line segments to subdivide each patch edge. Optional; Defaults to '10'.<br>
+		bottom — Is the bottom of the teapot generated. Optional; Defaults to 'true'.<br>
+		lid — Is the lid removed. Optional; Defaults to 'true'.<br>
+		body — Is the body generated. Optional; Defaults to 'true'.<br>
+		fitLid — Is the lid slightly stretched to prevent gaps between the body and lid. Optional; Defaults to 'false'.<br>
+		blinn — Is the teapot scaled vertically by dividing by 1.3 for better aesthetics. Optional; Defaults to 'true'.
+		</p>
+
+		<h2>Properties</h2>
+		<p>See the base [page:BufferGeometry] class for common properties.</p>
+
+		<h3>[property:Object parameters]</h3>
+		<p>
+		  An object with a property for each of the constructor parameters. Any
+		  modification after instantiation does not change the geometry.
+		</p>
+
+		<h2>Methods</h2>
+		<p>See the base [page:BufferGeometry] class for common methods.</p>
+
+		<h2>Source</h2>
+
+		<p>
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/geometries/TeapotGeometry.js examples/jsm/geometries/TeapotGeometry.js]
+		</p>
+	</body>
+</html>

--- a/docs/examples/en/geometries/TeapotGeometry.html
+++ b/docs/examples/en/geometries/TeapotGeometry.html
@@ -29,23 +29,26 @@
 		<h2>Code Example</h2>
 
 		<code>
-		const geometry = new TeapotGeometry( 50, 10, true, true, true, false, true );
-		const material = new THREE.MeshBasicMaterial( { color: 0x00ff00 } );
-		const teapot = new THREE.Mesh( geometry, material );
-		scene.add( teapot );
+			const geometry = new TeapotGeometry( 50, 10, true, true, true, false, true );
+			const material = new THREE.MeshBasicMaterial( { color: 0x00ff00 } );
+			const teapot = new THREE.Mesh( geometry, material );
+			scene.add( teapot );
 		</code>
 
 		<h2>Constructor</h2>
 
-		<h3>[name]([param:Integer size], [param:Integer segments], [param:Boolean bottom], [param:Boolean lid], [param:Boolean body], [param:Boolean fitLid], [param:Boolean blinn])</h3>
+		<h3>
+			[name]([param:Integer size], [param:Integer segments], [param:Boolean bottom], [param:Boolean lid], [param:Boolean body], 
+			[param:Boolean fitLid], [param:Boolean blinn])
+		</h3>
 		<p>
-		size — Relative scale of the teapot. Optional; Defaults to '50'.<br>
-		segments — Number of line segments to subdivide each patch edge. Optional; Defaults to '10'.<br>
-		bottom — Is the bottom of the teapot generated. Optional; Defaults to 'true'.<br>
-		lid — Is the lid removed. Optional; Defaults to 'true'.<br>
-		body — Is the body generated. Optional; Defaults to 'true'.<br>
-		fitLid — Is the lid slightly stretched to prevent gaps between the body and lid. Optional; Defaults to 'false'.<br>
-		blinn — Is the teapot scaled vertically by dividing by 1.3 for better aesthetics. Optional; Defaults to 'true'.
+			size — Relative scale of the teapot. Optional; Defaults to '50'.<br>
+			segments — Number of line segments to subdivide each patch edge. Optional; Defaults to '10'.<br>
+			bottom — Is the bottom of the teapot generated. Optional; Defaults to 'true'.<br>
+			lid — Is the lid removed. Optional; Defaults to 'true'.<br>
+			body — Is the body generated. Optional; Defaults to 'true'.<br>
+			fitLid — Is the lid slightly stretched to prevent gaps between the body and lid. Optional; Defaults to 'false'.<br>
+			blinn — Is the teapot scaled vertically by dividing by 1.3 for better aesthetics. Optional; Defaults to 'true'.
 		</p>
 
 		<h2>Properties</h2>
@@ -53,8 +56,8 @@
 
 		<h3>[property:Object parameters]</h3>
 		<p>
-		  An object with a property for each of the constructor parameters. Any
-		  modification after instantiation does not change the geometry.
+			An object with a property for each of the constructor parameters. Any
+			modification after instantiation does not change the geometry.
 		</p>
 
 		<h2>Methods</h2>
@@ -63,7 +66,8 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/geometries/TeapotGeometry.js examples/jsm/geometries/TeapotGeometry.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/geometries/TeapotGeometry.js 
+			examples/jsm/geometries/TeapotGeometry.js]
 		</p>
 	</body>
 </html>


### PR DESCRIPTION
Related issue: #27034 

**Description**

Adds a docs page for TeapotGeometry add-on. 

