### PR TITLE
BatchedMesh: Avoid primitive restart values in index array

### DIFF
--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -239,6 +239,7 @@ class BatchedMesh extends Mesh {
 
 			if ( reference.getIndex() !== null ) {
 
+				// Reserve last u16 index for primitive restart.
 				const indexArray = maxVertexCount > 65535
 					? new Uint32Array( maxIndexCount )
 					: new Uint16Array( maxIndexCount );

--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -239,7 +239,7 @@ class BatchedMesh extends Mesh {
 
 			if ( reference.getIndex() !== null ) {
 
-				const indexArray = maxVertexCount > 65536
+				const indexArray = maxVertexCount > 65535
 					? new Uint32Array( maxIndexCount )
 					: new Uint16Array( maxIndexCount );
 


### PR DESCRIPTION
WebGL 2 uses the last index value (255 for u8, 65535 for u16, or 4294967295 for u32) as a [primitive restart value](https://registry.khronos.org/webgl/specs/latest/2.0/#NO_PRIMITIVE_RESTART_FIXED_INDEX), so we should avoid using that index for real vertices.