### PR TITLE
WebGPURenderer: Fix Storage Buffer fallback in WebGLBackend

### DIFF
--- a/examples/jsm/renderers/webgl/WebGLBackend.js
+++ b/examples/jsm/renderers/webgl/WebGLBackend.js
@@ -1086,7 +1086,11 @@ class WebGLBackend extends Backend {
 
 	createStorageAttribute( attribute ) {
 
-		//console.warn( 'Abstract class.' );
+		if ( this.has( attribute ) ) return;
+
+		const gl = this.gl;
+
+		this.attributeUtils.createAttribute( attribute, gl.ARRAY_BUFFER );
 
 	}
 


### PR DESCRIPTION
Related issue: #28620

**Description**

Following #28620 we also needed to implement a fallback for WebGL. This prevent `no buffer is bound to enabled attribute` errors by considering storage buffer as classic attributes in the WebGL backend.

*This contribution is funded by [Utsubo](https://utsubo.com)*
