### PR TITLE
WebGPURenderer: Override alpha channel to 1 for opaque materials

### DIFF
--- a/examples/jsm/nodes/materials/NodeMaterial.js
+++ b/examples/jsm/nodes/materials/NodeMaterial.js
@@ -294,6 +294,12 @@ class NodeMaterial extends Material {
 
 		}
 
+		if ( this.transparent === false ) {
+
+			diffuseColor.a.assign( 1.0 );
+
+		}
+
 	}
 
 	setupVariants( /*builder*/ ) {

--- a/examples/jsm/nodes/materials/NodeMaterial.js
+++ b/examples/jsm/nodes/materials/NodeMaterial.js
@@ -1,4 +1,4 @@
-import { Material } from 'three';
+import { Material, NormalBlending } from 'three';
 import { getNodeChildren, getCacheKey } from '../core/NodeUtils.js';
 import { attribute } from '../core/AttributeNode.js';
 import { output, diffuseColor, varyingProperty } from '../core/PropertyNode.js';
@@ -294,7 +294,7 @@ class NodeMaterial extends Material {
 
 		}
 
-		if ( this.transparent === false ) {
+		if ( this.transparent === false && this.blending === NormalBlending && this.alphaToCoverage === false ) {
 
 			diffuseColor.a.assign( 1.0 );
 


### PR DESCRIPTION
Related issue: #28645


Fix #28645. Respect the WebGLRenderer by overriding the diffuse alpha channel to 1 for opaque materials.

*This contribution is funded by [Utsubo](https://utsubo.com)*
