### PR TITLE
USDZLoader: Fix geometry and material parsing.

### DIFF
--- a/examples/jsm/loaders/USDZLoader.js
+++ b/examples/jsm/loaders/USDZLoader.js
@@ -514,9 +514,11 @@ class USDZLoader extends Loader {
 
 			if ( data !== undefined ) {
 
-				if ( 'def Shader "PreviewSurface"' in data ) {
+				const surfaceConnection = data[ 'token outputs:surface.connect' ];
+				const surfaceName = /(\w+).output/.exec( surfaceConnection )[ 1 ];
+				const surface = data[ `def Shader "${surfaceName}"` ];
 
-					const surface = data[ 'def Shader "PreviewSurface"' ];
+				if ( surface !== undefined ) {
 
 					if ( 'color3f inputs:diffuseColor.connect' in surface ) {
 
@@ -682,24 +684,6 @@ class USDZLoader extends Loader {
 						}
 
 					}
-
-				}
-
-				if ( 'def Shader "diffuseColor_texture"' in data ) {
-
-					const sampler = data[ 'def Shader "diffuseColor_texture"' ];
-
-					material.map = buildTexture( sampler );
-					material.map.colorSpace = SRGBColorSpace;
-
-				}
-
-				if ( 'def Shader "normal_texture"' in data ) {
-
-					const sampler = data[ 'def Shader "normal_texture"' ];
-
-					material.normalMap = buildTexture( sampler );
-					material.normalMap.colorSpace = NoColorSpace;
 
 				}
 


### PR DESCRIPTION
Related issue: -

**Description**

This PR adds two fixes. It ensures `buildMaterial()` does not always use the name `PreviewSurface` to select the surface shader but uses the real name from the connection definition. Besides, it rearranges index processing in `buildGeometry()` to fix normal generation with assets exported from `USDZExporter`.
