### PR TITLE
Add parseAsync to GLTFExporter doc

### DIFF
--- a/docs/examples/en/exporters/GLTFExporter.html
+++ b/docs/examples/en/exporters/GLTFExporter.html
@@ -156,8 +156,7 @@
 		<p>
 			This is just like the [page:.parse]() method, but instead of
 			accepting callbacks it returns a promise that resolves with the
-			result, and otherwise accepts the same options. Use try-catch around
-			the promise, or `promise.catch()`, to catch errors.
+			result, and otherwise accepts the same options.
 		</p>
 
 		<h2>Source</h2>

--- a/docs/examples/en/exporters/GLTFExporter.html
+++ b/docs/examples/en/exporters/GLTFExporter.html
@@ -136,16 +136,28 @@
 		[page:Function onError] — Will be called if there are any errors during the gltf generation.<br />
 		[page:Options options] — Export options<br />
 		<ul>
-			<li>trs - bool. Export position, rotation and scale instead of matrix per node. Default is false</li>
-			<li>onlyVisible - bool. Export only visible objects. Default is true.</li>
-			<li>binary - bool. Export in binary (.glb) format, returning an ArrayBuffer. Default is false.</li>
-			<li>maxTextureSize - int. Restricts the image maximum size (both width and height) to the given value. Default is Infinity.</li>
-			<li>animations - Array<[page:AnimationClip AnimationClip]>. List of animations to be included in the export.</li>
-			<li>includeCustomExtensions - bool. Export custom glTF extensions defined on an object's `userData.gltfExtensions` property. Default is false.</li>
+			<li>`trs` - bool. Export position, rotation and scale instead of matrix per node. Default is false</li>
+			<li>`onlyVisible` - bool. Export only visible objects. Default is true.</li>
+			<li>`binary` - bool. Export in binary (.glb) format, returning an ArrayBuffer. Default is false.</li>
+			<li>`maxTextureSize` - int. Restricts the image maximum size (both width and height) to the given value. Default is Infinity.</li>
+			<li>`animations` - Array<[page:AnimationClip AnimationClip]>. List of animations to be included in the export.</li>
+			<li>`includeCustomExtensions` - bool. Export custom glTF extensions defined on an object's `userData.gltfExtensions` property. Default is false.</li>
 		</ul>
 		</p>
 		<p>
 		Generates a .gltf (JSON) or .glb (binary) output from the input (Scenes or Objects)
+		</p>
+
+		<h3>[method:Promise parseAsync]( [param:Object3D input], [param:Object options] )</h3>
+
+		<p>
+			Generates a .gltf (JSON) or .glb (binary) output from the input (Scenes or Objects).
+		</p>
+		<p>
+			This is just like the [page:.parse]() method, but instead of
+			accepting callbacks it returns a promise that resolves with the
+			result, and otherwise accepts the same options. Use try-catch around
+			the promise, or `promise.catch()`, to catch errors.
 		</p>
 
 		<h2>Source</h2>


### PR DESCRIPTION
Related issue: n/a

**Description**

Add entry for `parseAsync()` method in `GLTFExporter` doc.

<img width="722" alt="Screenshot 2024-06-13 at 10 55 32 AM" src="https://github.com/mrdoob/three.js/assets/297678/4f85326c-776a-4378-b2b8-4820a14668cb">



*This contribution is funded by [Lume](https://lume.io), a 3D HTML framework.*
