### PR TITLE
GLTFExporter: export rendertarget

### DIFF
--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -2,6 +2,7 @@ import {
 	BufferAttribute,
 	ClampToEdgeWrapping,
 	Color,
+	DataTexture,
 	DoubleSide,
 	InterpolateDiscrete,
 	InterpolateLinear,
@@ -539,7 +540,8 @@ class GLTFWriter {
 			onlyVisible: true,
 			maxTextureSize: Infinity,
 			animations: [],
-			includeCustomExtensions: false
+			includeCustomExtensions: false,
+			renderer: null
 		}, options );
 
 		if ( this.options.animations.length > 0 ) {
@@ -1420,6 +1422,20 @@ class GLTFWriter {
 			map = decompress( map, options.maxTextureSize );
 
 		}
+		else if ( map.isRenderTargetTexture ) {
+			
+			if ( this.options.renderer ) {
+
+				const width = map.image.width;
+				const height = map.image.height;
+				const buffer = new Uint8Array(width * height * 4);
+				this.options.renderer.readRenderTargetPixels(map.renderTargetTexture, 0, 0, width, height, buffer);
+				map = new DataTexture(buffer, width, height);
+				map.needsUpdate = true;
+
+			}
+		}
+
 
 		let mimeType = map.userData.mimeType;
 

--- a/examples/misc_exporter_gltf.html
+++ b/examples/misc_exporter_gltf.html
@@ -30,6 +30,8 @@
 			import { MeshoptDecoder } from 'three/addons/libs/meshopt_decoder.module.js';
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 
+			let renderer;
+
 			function exportGLTF( input ) {
 
 				const gltfExporter = new GLTFExporter();
@@ -38,7 +40,8 @@
 					trs: params.trs,
 					onlyVisible: params.onlyVisible,
 					binary: params.binary,
-					maxTextureSize: params.maxTextureSize
+					maxTextureSize: params.maxTextureSize,
+					renderer: renderer
 				};
 				gltfExporter.parse(
 					input,
@@ -96,7 +99,7 @@
 
 			let container;
 
-			let camera, object, object2, material, geometry, scene1, scene2, renderer;
+			let camera, object, object2, material, geometry, scene1, scene2;
 			let gridHelper, sphere, model, coffeemat;
 
 			const params = {
@@ -468,6 +471,21 @@
 				renderer.toneMappingExposure = 1;
 
 				container.appendChild( renderer.domElement );
+
+
+				setTimeout(()=>{
+					
+					const renderTexture = new THREE.WebGLRenderTarget(256, 256);
+
+					renderer.setRenderTarget( renderTexture );
+					renderer.render( scene1, camera );
+					renderer.setRenderTarget( null );
+
+					// add the render texture to an object in the scene
+					const cube = new THREE.Mesh( new THREE.BoxGeometry( 200, 200, 200 ), new THREE.MeshBasicMaterial( { color: 0xffffff, map: renderTexture.texture } ) );				
+					scene1.add( cube );
+
+				}, 10)
 
 				//
 

--- a/src/core/RenderTarget.js
+++ b/src/core/RenderTarget.js
@@ -54,6 +54,7 @@ class RenderTarget extends EventDispatcher {
 
 			this.textures[ i ] = texture.clone();
 			this.textures[ i ].isRenderTargetTexture = true;
+			this.textures[ i ].renderTargetTexture = this;
 
 		}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/28652

**Description**

Currently exporting a scene that has a WebGLRendertarget Texture on any object breaks export altogether.   

This PR adds a reference to the original WebGLRenderTarget to the underlying textures - not sure if this coupling is something you'd consider keeping. 
  
Perhaps the same could be done by a writer plugin - but I'm not sure how how to 1) either get a reference to the WebGLRenderTarget to be able to readback the pixels or 2) if there's a different preferred solution (e.g. blitting the render target to a new texture like with compressed textures)

*This contribution is funded by [Needle](https://needle.tools)*
