### PR TITLE
Docs:Unifies translation of "Source" in zh

### DIFF
--- a/docs/examples/zh/controls/DragControls.html
+++ b/docs/examples/zh/controls/DragControls.html
@@ -146,7 +146,7 @@
 			Sets an array of draggable objects by overwriting the existing one.
 		</p>
 
-		<h2>Source</h2>
+		<h2>源代码</h2>
 
 		<p>
 			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/controls/DragControls.js examples/jsm/controls/DragControls.js]

--- a/docs/examples/zh/helpers/LightProbeHelper.html
+++ b/docs/examples/zh/helpers/LightProbeHelper.html
@@ -63,7 +63,7 @@
 		<p>释放内部资源。</p>
 
 
-		<h2>源码</h2>
+		<h2>源代码</h2>
 
 		<p>
 			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/helpers/LightProbeHelper.js examples/jsm/helpers/LightProbeHelper.js]

--- a/docs/examples/zh/helpers/RectAreaLightHelper.html
+++ b/docs/examples/zh/helpers/RectAreaLightHelper.html
@@ -64,7 +64,7 @@
 		<h3>[method:undefined dispose]()</h3>
 		<p>销毁该区域光源辅助对象.</p>
 
-		<h2>源码</h2>
+		<h2>源代码</h2>
 
 		<p>
 			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/helpers/RectAreaLightHelper.js examples/jsm/helpers/RectAreaLightHelper.js]

--- a/docs/examples/zh/helpers/VertexNormalsHelper.html
+++ b/docs/examples/zh/helpers/VertexNormalsHelper.html
@@ -82,7 +82,7 @@
 		<p>基于对象的运动更新顶点法线辅助对象.</p>
 
 
-		<h2>源码</h2>
+		<h2>源代码</h2>
 
 		<p>
 			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/helpers/VertexNormalsHelper.js examples/jsm/helpers/VertexNormalsHelper.js]

--- a/docs/examples/zh/lights/LightProbeGenerator.html
+++ b/docs/examples/zh/lights/LightProbeGenerator.html
@@ -47,7 +47,7 @@
 			立方体渲染目标的 [page:Texture.format format] 必须被设为 *RGBA*。
 		</p>
 
-		<h2>源码</h2>
+		<h2>源代码</h2>
 
 		<p>
 			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/lights/LightProbeGenerator.js examples/jsm/lights/LightProbeGenerator.js]

--- a/docs/examples/zh/loaders/DRACOLoader.html
+++ b/docs/examples/zh/loaders/DRACOLoader.html
@@ -150,7 +150,7 @@
 		[link:https://github.com/google/draco/issues/349 不能重新加载].
 		</p>
 
-		<h2>源码</h2>
+		<h2>源代码</h2>
 
 		<p>
 			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/loaders/DRACOLoader.js examples/jsm/loaders/DRACOLoader.js]

--- a/docs/examples/zh/loaders/FontLoader.html
+++ b/docs/examples/zh/loaders/FontLoader.html
@@ -93,7 +93,7 @@
 		解析一个<em>JSON</em>>格式的对象，并返回一个font。
 		</p>
 
-		<h2>源</h2>
+		<h2>源代码</h2>
 
 		<p>
 			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/loaders/FontLoader.js examples/jsm/loaders/FontLoader.js]

--- a/docs/examples/zh/loaders/MTLLoader.html
+++ b/docs/examples/zh/loaders/MTLLoader.html
@@ -80,7 +80,7 @@
 		</p>
 
 
-		<h2>源码</h2>
+		<h2>源代码</h2>
 
 		<p>
 			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/loaders/[name].js examples/jsm/loaders/[name].js]

--- a/docs/examples/zh/loaders/OBJLoader.html
+++ b/docs/examples/zh/loaders/OBJLoader.html
@@ -109,7 +109,7 @@
 		设置由 MTLLoader 载入的材质，或是其它由 [page:MTLLoaderMaterialCreator MTLLoader.MaterialCreator] 提供的材质。
 		</p>
 
-		<h2>源码</h2>
+		<h2>源代码</h2>
 
 		<p>
 			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/loaders/OBJLoader.js examples/jsm/loaders/OBJLoader.js]

--- a/docs/examples/zh/loaders/PCDLoader.html
+++ b/docs/examples/zh/loaders/PCDLoader.html
@@ -114,7 +114,7 @@
 		该 Object3D 实例实际类型为 [page:Points]，由一个 [page:BufferGeometry] 实例和一个 [page:PointsMaterial] 实例作为参数构造而成。
 		</p>
 
-		<h2>源码</h2>
+		<h2>源代码</h2>
 
 		<p>
 			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/loaders/PCDLoader.js examples/jsm/loaders/PCDLoader.js]

--- a/docs/examples/zh/loaders/SVGLoader.html
+++ b/docs/examples/zh/loaders/SVGLoader.html
@@ -126,7 +126,7 @@
 			返回一个或多个基于[param:ShapePath shape]的[page:Shape]对象，并作为该函数的一个参数返回。
 		</p>
 
-		<h2>源码</h2>
+		<h2>源代码</h2>
 
 		<p>
 			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/loaders/SVGLoader.js examples/jsm/loaders/SVGLoader.js]

--- a/docs/examples/zh/loaders/TGALoader.html
+++ b/docs/examples/zh/loaders/TGALoader.html
@@ -94,7 +94,7 @@
 			开始加载[page:DataTexture texture]并传递给onLoad。即时引用会将[page:DataTexture texture]直接返回(不一定加载完成)。
 		</p>
 
-		<h2>源码</h2>
+		<h2>源代码</h2>
 
 		<p>
 			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/loaders/TGALoader.js examples/jsm/loaders/TGALoader.js]

--- a/docs/examples/zh/utils/BufferGeometryUtils.html
+++ b/docs/examples/zh/utils/BufferGeometryUtils.html
@@ -143,7 +143,7 @@
 		Returns a new indexed geometry based on `THREE.TrianglesDrawMode` draw mode. This mode corresponds to the `gl.TRIANGLES` WebGL primitive.
 		</p>
 
-		<h2>Source</h2>
+		<h2>源代码</h2>
 
 		<p>
 			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/utils/BufferGeometryUtils.js examples/jsm/utils/BufferGeometryUtils.js]


### PR DESCRIPTION
This has already translated all the words "Source" as "源代码".