### PR TITLE
Add GLTFExporter plugin hooks for beforeWriteNode, beforeWriteMesh …

### DIFF
--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -1412,6 +1412,18 @@ class GLTFWriter {
 
 		if ( cache.textures.has( map ) ) return cache.textures.get( map );
 
+		const beforeWriteArgs = { keep: true, newTexture: null };
+	
+		this._invokeAll( function ( ext ) {
+
+			ext.beforeWriteTexture && ext.beforeWriteTexture( map, beforeWriteArgs );
+
+		} );
+
+		if ( beforeWriteArgs.keep === false ) return null;
+
+		if ( beforeWriteArgs.newTexture != null ) map = beforeWriteArgs.newTexture;
+
 		if ( ! json.textures ) json.textures = [];
 
 		// make non-readable textures (e.g. CompressedTexture) readable by blitting them into a new texture
@@ -1626,6 +1638,20 @@ class GLTFWriter {
 	 * @return {Integer|null} Index of the processed mesh in the "meshes" array
 	 */
 	processMesh( mesh ) {
+
+		const beforeWriteArgs = { keep: true }
+
+		this._invokeAll( function ( ext ) {
+
+			ext.beforeWriteMesh && ext.beforeWriteMesh( mesh, beforeWriteArgs );
+
+		} );
+
+		if ( beforeWriteArgs.keep != true ) { 
+			
+			return null;
+
+		}
 
 		const cache = this.cache;
 		const json = this.json;
@@ -2225,6 +2251,20 @@ class GLTFWriter {
 	 * @return {Integer} Index of the node in the nodes list
 	 */
 	processNode( object ) {
+
+		const beforeWriteArgs = { keep: true }
+
+		this._invokeAll( function ( ext ) {
+
+			ext.beforeWriteNode && ext.beforeWriteNode( object, beforeWriteArgs );
+
+		} );
+
+		if ( beforeWriteArgs.keep != true ) { 
+			
+			return null;
+
+		}
 
 		const json = this.json;
 		const options = this.options;


### PR DESCRIPTION
…and beforeWriteTexture

**Description**

Currently it's not easily possible to modify or omit parts of the exported scene using GLTFExporter.

The only way to do that is to traverse the whole scene before export and then reverting changes after.   
Besides being wasteful for large and complex scenes it's also error prone since the export process can take a few frames or seconds to complete during which the exported objects could again be modified by unrelated code (e.g. an object might have been moved or added to the hierarchy that was not there before export. One example of this are debug gizmos that might be added to the renderstack every frame).

This change adds callback hooks for `beforeWriteNode`, `beforeWriteMesh` and `beforeWriteTexture`. 
Each callback receives the object that should be exported as well as an options argument which contains a bool to allow extensions to skip objects ( by setting `{ keep: false }` ).
Additionally `beforeWriteTexture` contains a `newTexture` property which allows extensions to change what texture should be exported (this would make https://github.com/mrdoob/three.js/pull/28653 obsolete)

Generally a better approach for the whole exporter would be to first parse the whole scene and collect the data that will get exported - then adding once callback that allows extensions to filter parts of the hierarchy - and then actually writing any data. That would be similar to how the GLTFExporter in Blender works (or the USDZExporter in Needle Engine)

*This contribution is funded by [Needle](https://needle.tools)*
