### PR TITLE
Revert "TSL: Added type conversions to `WGSLNodeFunction` and fleshed…

### DIFF
--- a/examples/jsm/renderers/webgpu/nodes/WGSLNodeFunction.js
+++ b/examples/jsm/renderers/webgpu/nodes/WGSLNodeFunction.js
@@ -5,42 +5,8 @@ const declarationRegexp = /^[fn]*\s*([a-z_0-9]+)?\s*\(([\s\S]*?)\)\s*[\-\>]*\s*(
 const propertiesRegexp = /[a-z_0-9]+|<(.*?)>+/ig;
 
 const wgslTypeLib = {
-	'f32': 'float',
-	'i32': 'int',
-	'u32': 'uint',
-	'bool': 'bool',
-
-	'vec2<f32>': 'vec2',
- 	'vec2<i32>': 'ivec2',
- 	'vec2<u32>': 'uvec2',
- 	'vec2<bool>': 'bvec2',
-
-	'vec3<f32>': 'vec3',
-	'vec3<i32>': 'ivec3',
-	'vec3<u32>': 'uvec3',
-	'vec3<bool>': 'bvec3',
-
-	'vec4<f32>': 'vec4',
-	'vec4<i32>': 'ivec4',
-	'vec4<u32>': 'uvec4',
-	'vec4<bool>': 'bvec4',
-
-	'mat2x2<f32>': 'mat2',
-	'mat2x2<i32>': 'imat2',
-	'mat2x2<u32>': 'umat2',
-	'mat2x2<bool>': 'bmat2',
-
-	'mat3x3<f32>': 'mat3',
-	'mat3x3<i32>': 'imat3',
-	'mat3x3<u32>': 'umat3',
-	'mat3x3<bool>': 'bmat3',
-
-	'mat4x4<f32>': 'mat4',
-	'mat4x4<i32>': 'imat4',
-	'mat4x4<u32>': 'umat4',
-	'mat4x4<bool>': 'bmat4'
+	f32: 'float'
 };
-
 
 const parse = ( source ) => {
 
@@ -76,24 +42,15 @@ const parse = ( source ) => {
 			const name = propsMatches[ i ++ ][ 0 ];
 			let type = propsMatches[ i ++ ][ 0 ];
 
-			// precision
-
-			if ( i < propsMatches.length && propsMatches[ i ][ 0 ].startsWith( '<' ) === true ) {
-
-				const elementType = propsMatches[ i ++ ][ 0 ];
-
-				// If primitive data type
-				if ( ! elementType.includes( ',' ) ) {
-
-					type += elementType;
-
-				}
-
-			}
-
 			type = wgslTypeLib[ type ] || type;
 
+			// precision
+
+			if ( i < propsMatches.length && propsMatches[ i ][ 0 ].startsWith( '<' ) === true )
+				i ++;
+
 			// add input
+
 			inputs.push( new NodeFunctionInput( type, name ) );
 
 		}


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/28577

**Description**

This broken [that PR and example](https://github.com/mrdoob/three.js/pull/28379), because the approach did not filter `<type>` of the textures.

I think we can reimplement again after this fix.