### PR TITLE
Example: Don't accumulate tiny translations in games_fps.html

### DIFF
--- a/examples/games_fps.html
+++ b/examples/games_fps.html
@@ -210,7 +210,11 @@
 
 					}
 
-					playerCollider.translate( result.normal.multiplyScalar( result.depth ) );
+					if ( result.depth >= 1e-10 ) {
+
+						playerCollider.translate( result.normal.multiplyScalar( result.depth ) );
+
+					}
 
 				}
 


### PR DESCRIPTION
fix: #28660

**Description**

The cause is that the example blindly pushes `playerCollider` away from the intersection `normal` by `depth` amount in every frame, so say when player is idling on ramp, the tiny offset will eventually add up >octree_threshold, then octree considers that the `playerCollider` is not intersecting with the ramp.

This PR fixed that by translating the `playerCollider` only if `intersection's depth >= octree_threshold` 