### PR TITLE
WebGLRenderer: Add missing parameters to copyTextureToTexture

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2604,7 +2604,7 @@ class WebGLRenderer {
 
 				} else {
 
-					_gl.texSubImage2D( _gl.TEXTURE_2D, level, dstX, dstY, glFormat, glType, image );
+					_gl.texSubImage2D( _gl.TEXTURE_2D, level, dstX, dstY, width, height, glFormat, glType, image );
 
 				}
 


### PR DESCRIPTION
Related issue: #28281 

**Description**

Add missing "width" and "height" arguments to `texSubImage2D` function in the `copyTextureToTexture` function. It looks like this was missing before #28281 but it looks like an oversight. These arguments aren't missing in the 3d variant of the function.

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Cesium GIS Ecosystem Grant](https://cesium.com/cesium-ecosystem-grants/)*
