### PR TITLE
RFC: Multiple bindgroups for WebGPU - breaks WebGL currently

### DIFF
--- a/examples/jsm/nodes/accessors/CameraNode.js
+++ b/examples/jsm/nodes/accessors/CameraNode.js
@@ -1,12 +1,33 @@
 import { uniform } from '../core/UniformNode.js';
+import { renderGroup } from '../core/UniformGroupNode.js';
 import { Vector3 } from 'three';
 
-export const cameraNear = /*#__PURE__*/ uniform( 'float' ).onRenderUpdate( ( { camera } ) => camera.near );
-export const cameraFar = /*#__PURE__*/ uniform( 'float' ).onRenderUpdate( ( { camera } ) => camera.far );
-export const cameraLogDepth = /*#__PURE__*/ uniform( 'float' ).onRenderUpdate( ( { camera } ) => 2.0 / ( Math.log( camera.far + 1.0 ) / Math.LN2 ) );
-export const cameraProjectionMatrix = /*#__PURE__*/ uniform( 'mat4' ).onRenderUpdate( ( { camera } ) => camera.projectionMatrix );
-export const cameraProjectionMatrixInverse = /*#__PURE__*/ uniform( 'mat4' ).onRenderUpdate( ( { camera } ) => camera.projectionMatrixInverse );
-export const cameraViewMatrix = /*#__PURE__*/ uniform( 'mat4' ).onRenderUpdate( ( { camera } ) => camera.matrixWorldInverse );
-export const cameraWorldMatrix = /*#__PURE__*/ uniform( 'mat4' ).onRenderUpdate( ( { camera } ) => camera.matrixWorld );
-export const cameraNormalMatrix = /*#__PURE__*/ uniform( 'mat3' ).onRenderUpdate( ( { camera } ) => camera.normalMatrix );
-export const cameraPosition = /*#__PURE__*/ uniform( new Vector3() ).onRenderUpdate( ( { camera }, self ) => self.value.setFromMatrixPosition( camera.matrixWorld ) );
+const updateNear = ( { camera } ) => camera.near;
+const updateFar = ( { camera } ) => camera.far;
+const updateViewMatrix = ( { camera } ) => camera.matrixWorldInverse;
+const updateWorldMatrix =  ( { camera } ) => camera.matrixWorld;
+const updateLogDepth = ( { camera } ) => 2.0 / ( Math.log( camera.far + 1.0 ) / Math.LN2 );
+const updateProjectionMatrix =  ( { camera } ) => camera.projectionMatrix;
+const updateProjectionMatrixInverse =  ( { camera } ) => camera.projectionMatrixInverse;
+const updateCameraPosition = ( { camera }, self ) => self.value.setFromMatrixPosition( camera.matrixWorld );
+const updateNormalMatrix = ( { camera } ) => camera.normalMatrix;
+
+export const cameraNear = /*#__PURE__*/ uniform( 'float' ).label( 'cameraNear' ).setGroup( renderGroup ).onRenderUpdate( updateNear );
+export const cameraFar = /*#__PURE__*/ uniform( 'float' ).label( 'cameraFar' ).setGroup( renderGroup ).onRenderUpdate( updateFar );
+export const cameraLogDepth = /*#__PURE__*/ uniform( 'float' ).label( 'cameraLogDepth' ).setGroup( renderGroup ).onRenderUpdate( updateLogDepth );
+export const cameraProjectionMatrix = /*#__PURE__*/ uniform( 'mat4' ).label( 'cameraProjectionMatrix' ).setGroup( renderGroup ).onRenderUpdate( updateProjectionMatrix );
+export const cameraProjectionMatrixInverse = /*#__PURE__*/ uniform( 'mat4' ).label( 'cameraProjectionMatrixInverse' ).setGroup( renderGroup ).onRenderUpdate( updateProjectionMatrix );
+export const cameraViewMatrix = /*#__PURE__*/ uniform( 'mat4' ).label( 'cameraViewMatrix' ).setGroup( renderGroup ).onRenderUpdate( updateViewMatrix );
+export const cameraWorldMatrix = /*#__PURE__*/ uniform( 'mat4' ).label( 'cameraWorldMatrix' ).setGroup( renderGroup ).onRenderUpdate( updateWorldMatrix );
+export const cameraNormalMatrix = /*#__PURE__*/ uniform( 'mat3' ).label( 'cameraNormalMatrix' ).setGroup( renderGroup ).onRenderUpdate( updateNormalMatrix );
+export const cameraPosition = /*#__PURE__*/ uniform( new Vector3() ).label( 'cameraPosition' ).setGroup( renderGroup ).onRenderUpdate( ( { camera }, self ) => self.value.setFromMatrixPosition( camera.matrixWorld ) );
+
+renderGroup.register( 'cameraViewMatrix', 'mat4', updateViewMatrix );
+renderGroup.register( 'cameraWorldMatrix', 'mat4', updateWorldMatrix );
+renderGroup.register( 'cameraProjectionMatrix', 'mat4', updateProjectionMatrix );
+renderGroup.register( 'cameraProjectionMatrixInverse', 'mat4', updateProjectionMatrixInverse );
+renderGroup.register( 'cameraNormalMatrix', 'mat3', updateNormalMatrix );
+renderGroup.register( 'cameraPosition', 'vec3' );
+renderGroup.register( 'cameraNear', 'float', updateNear );
+renderGroup.register( 'cameraFar', 'float', updateFar );
+renderGroup.register( 'cameraLogDepth', 'float', updateLogDepth );

--- a/examples/jsm/nodes/accessors/CameraNode.js
+++ b/examples/jsm/nodes/accessors/CameraNode.js
@@ -20,14 +20,14 @@ export const cameraProjectionMatrixInverse = /*#__PURE__*/ uniform( 'mat4' ).lab
 export const cameraViewMatrix = /*#__PURE__*/ uniform( 'mat4' ).label( 'cameraViewMatrix' ).setGroup( renderGroup ).onRenderUpdate( updateViewMatrix );
 export const cameraWorldMatrix = /*#__PURE__*/ uniform( 'mat4' ).label( 'cameraWorldMatrix' ).setGroup( renderGroup ).onRenderUpdate( updateWorldMatrix );
 export const cameraNormalMatrix = /*#__PURE__*/ uniform( 'mat3' ).label( 'cameraNormalMatrix' ).setGroup( renderGroup ).onRenderUpdate( updateNormalMatrix );
-export const cameraPosition = /*#__PURE__*/ uniform( new Vector3() ).label( 'cameraPosition' ).setGroup( renderGroup ).onRenderUpdate( ( { camera }, self ) => self.value.setFromMatrixPosition( camera.matrixWorld ) );
+export const cameraPosition = /*#__PURE__*/ uniform( new Vector3() ).label( 'cameraPosition' ).setGroup( renderGroup ).onRenderUpdate( updateCameraPosition );
 
 renderGroup.register( 'cameraViewMatrix', 'mat4', updateViewMatrix );
 renderGroup.register( 'cameraWorldMatrix', 'mat4', updateWorldMatrix );
 renderGroup.register( 'cameraProjectionMatrix', 'mat4', updateProjectionMatrix );
 renderGroup.register( 'cameraProjectionMatrixInverse', 'mat4', updateProjectionMatrixInverse );
 renderGroup.register( 'cameraNormalMatrix', 'mat3', updateNormalMatrix );
-renderGroup.register( 'cameraPosition', 'vec3' );
+renderGroup.register( 'cameraPosition', 'vec3', updateCameraPosition );
 renderGroup.register( 'cameraNear', 'float', updateNear );
 renderGroup.register( 'cameraFar', 'float', updateFar );
 renderGroup.register( 'cameraLogDepth', 'float', updateLogDepth );

--- a/examples/jsm/nodes/core/NodeFrame.js
+++ b/examples/jsm/nodes/core/NodeFrame.js
@@ -162,6 +162,11 @@ class NodeFrame {
 
 			node.update( this );
 
+		} else if ( updateType === NodeUpdateType.ONCE ) {
+
+			node.update( this );
+			node.updateType = NodeUpdateType.NONE;
+
 		}
 
 	}

--- a/examples/jsm/nodes/core/UniformGroupNode.js
+++ b/examples/jsm/nodes/core/UniformGroupNode.js
@@ -14,11 +14,19 @@ class UniformGroupNode extends Node {
 
 		this.isUniformGroup = true;
 
+		this.registered = [];
+
 	}
 
 	set needsUpdate( value ) {
 
 		if ( value === true ) this.version ++;
+
+	}
+
+	register( name, type, callback = () => {} ) {
+
+		this.registered.push( { name, type, callback } );
 
 	}
 

--- a/examples/jsm/nodes/core/constants.js
+++ b/examples/jsm/nodes/core/constants.js
@@ -7,7 +7,8 @@ export const NodeUpdateType = {
 	NONE: 'none',
 	FRAME: 'frame',
 	RENDER: 'render',
-	OBJECT: 'object'
+	OBJECT: 'object',
+	ONCE: 'once'
 };
 
 export const NodeType = {

--- a/examples/jsm/renderers/common/Renderer.js
+++ b/examples/jsm/renderers/common/Renderer.js
@@ -299,6 +299,7 @@ class Renderer {
 		//
 
 		this._background.update( sceneRef, renderList, renderContext );
+		this._nodes.updateRendererBindings( renderContext, camera );
 
 		// process render lists
 
@@ -638,6 +639,8 @@ class Renderer {
 		this._nodes.updateScene( sceneRef );
 
 		//
+
+		this._nodes.updateRendererBindings( renderContext, camera );
 
 		this._background.update( sceneRef, renderList, renderContext );
 

--- a/examples/jsm/renderers/common/UniformsGroup.js
+++ b/examples/jsm/renderers/common/UniformsGroup.js
@@ -270,7 +270,9 @@ class UniformsGroup extends UniformBuffer {
 		let updated = false;
 
 		const a = this.buffer;
+
 		const e = uniform.getValue().elements;
+
 		const offset = uniform.offset;
 
 		if ( arraysEqual( a, e, offset ) === false ) {

--- a/examples/jsm/renderers/common/nodes/Nodes.js
+++ b/examples/jsm/renderers/common/nodes/Nodes.js
@@ -255,8 +255,6 @@ class Nodes extends DataMap {
 
 	updateRendererBindings( renderContext, camera ) {
 
-		let initialUpdate = false;
-
 		if ( renderContext.bindings === undefined ) {
 
 			const registeredUniforms = renderGroup.registered;
@@ -282,8 +280,6 @@ class Nodes extends DataMap {
 
 			renderContext.bindings = [ group ];
 			this.backend.createBindings( renderContext.bindings, 'render' );
-
-			initialUpdate = true;
 
 		}
 

--- a/examples/jsm/renderers/webgpu/WebGPUBackend.js
+++ b/examples/jsm/renderers/webgpu/WebGPUBackend.js
@@ -446,6 +446,11 @@ class WebGPUBackend extends Backend {
 
 		}
 
+		const bindingsData = this.get( renderContext.bindings );
+		const bindGroupGPU = bindingsData.group;
+
+		currentPass.setBindGroup( 0, bindGroupGPU );
+
 	}
 
 	finishRender( renderContext ) {
@@ -747,7 +752,7 @@ class WebGPUBackend extends Backend {
 		const groupGPU = this.get( computeGroup );
 
 
-		const descriptor = {};
+		const descriptor = { label: 'compute_pass' };
 
 		this.initTimestampQuery( computeGroup, descriptor );
 
@@ -825,8 +830,15 @@ class WebGPUBackend extends Backend {
 
 		// bind group
 
+		if ( this.renderer._currentRenderBundle ) {
+
+			const bindGroupGPU = this.get( context.bindings ).group;
+			passEncoderGPU.setBindGroup( 0, bindGroupGPU );
+
+		}
+
 		const bindGroupGPU = bindingsData.group;
-		passEncoderGPU.setBindGroup( 0, bindGroupGPU );
+		passEncoderGPU.setBindGroup( 1, bindGroupGPU );
 
 		// attributes
 
@@ -1198,9 +1210,9 @@ class WebGPUBackend extends Backend {
 
 	// bindings
 
-	createBindings( bindings ) {
+	createBindings( bindings, label ) {
 
-		this.bindingUtils.createBindings( bindings );
+		this.bindingUtils.createBindings( bindings, label );
 
 	}
 
@@ -1282,7 +1294,7 @@ class WebGPUBackend extends Backend {
 			dstY = dstPosition.y;
 
 		}
-		
+
 		const encoder = this.device.createCommandEncoder( { label: 'copyTextureToTexture_' + srcTexture.id + '_' + dstTexture.id } );
 
 		const sourceGPU = this.get( srcTexture ).texture;
@@ -1377,6 +1389,11 @@ class WebGPUBackend extends Backend {
 
 		renderContextData.currentPass = encoder.beginRenderPass( descriptor );
 		renderContextData.currentSets = { attributes: {} };
+
+		const bindingsData = this.get( renderContext.bindings );
+		const bindGroupGPU = bindingsData.group;
+
+		renderContextData.currentPass.setBindGroup( 0, bindGroupGPU );
 
 	}
 

--- a/examples/jsm/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/examples/jsm/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -778,7 +778,6 @@ ${ flowData.code }
 
 						attributesSnippet += ' @interpolate( flat )';
 
-
 					}
 
 					snippets.push( `${ attributesSnippet } ${ varying.name } : ${ this.getType( varying.type ) }` );

--- a/examples/jsm/renderers/webgpu/utils/WebGPUBindingUtils.js
+++ b/examples/jsm/renderers/webgpu/utils/WebGPUBindingUtils.js
@@ -11,7 +11,7 @@ class WebGPUBindingUtils {
 
 	}
 
-	createBindingsLayout( bindings ) {
+	createBindingsLayout( bindings, label ) {
 
 		const backend = this.backend;
 		const device = backend.device;
@@ -122,19 +122,19 @@ class WebGPUBindingUtils {
 
 		}
 
-		return device.createBindGroupLayout( { entries } );
+		return device.createBindGroupLayout( { entries, label } );
 
 	}
 
-	createBindings( bindings ) {
+	createBindings( bindings, label = 'object' ) {
 
 		const backend = this.backend;
 		const bindingsData = backend.get( bindings );
 
 		// setup (static) binding layout and (dynamic) binding group
 
-		const bindLayoutGPU = this.createBindingsLayout( bindings );
-		const bindGroupGPU = this.createBindGroup( bindings, bindLayoutGPU );
+		const bindLayoutGPU = this.createBindingsLayout( bindings, label );
+		const bindGroupGPU = this.createBindGroup( bindings, bindLayoutGPU, label );
 
 		bindingsData.layout = bindLayoutGPU;
 		bindingsData.group = bindGroupGPU;
@@ -154,7 +154,7 @@ class WebGPUBindingUtils {
 
 	}
 
-	createBindGroup( bindings, layoutGPU ) {
+	createBindGroup( bindings, layoutGPU, label ) {
 
 		const backend = this.backend;
 		const device = backend.device;
@@ -257,7 +257,8 @@ class WebGPUBindingUtils {
 
 		return device.createBindGroup( {
 			layout: layoutGPU,
-			entries: entriesGPU
+			entries: entriesGPU,
+			label
 		} );
 
 	}

--- a/examples/jsm/renderers/webgpu/utils/WebGPUPipelineUtils.js
+++ b/examples/jsm/renderers/webgpu/utils/WebGPUPipelineUtils.js
@@ -55,6 +55,7 @@ class WebGPUPipelineUtils {
 
 		const pipelineData = backend.get( pipeline );
 		const bindingsData = backend.get( renderObject.getBindings() );
+		const renderBindingData = backend.get( renderObject.context.bindings );
 
 		// vertex buffers
 
@@ -145,7 +146,7 @@ class WebGPUPipelineUtils {
 				alphaToCoverageEnabled: material.alphaToCoverage
 			},
 			layout: device.createPipelineLayout( {
-				bindGroupLayouts: [ bindingsData.layout ]
+				bindGroupLayouts: [ renderBindingData.layout, bindingsData.layout ]
 			} )
 		};
 


### PR DESCRIPTION
Utilise the shared uniform group mechanism #27134 to enable shared uniform buffers for WebGPU - should be extendable to UBO in WebGL. 

Camera data is only stored once in the GPU side rather than in a uniform buffer per pipeline

Bind group 0: camera uniforms
Bind group 1: object and material uniforms

Because until all  materials have been seen, we don't know which camera uniforms are required.  The binding is set up for all camera uniforms and only those in use are attached on the fly to the correct update mechanism.  To keep single pass frame rendering working (for cube maps etc), a NodeUpdate type of ONCE is added that automatically resets to NONE after the first update.

Most examples work except BatchMesh.  The screenshot test failures are a symptom of the WebGL breakage.

 
