### PR TITLE
TSL: UniformsNode support `int/uint`

### DIFF
--- a/examples/jsm/nodes/accessors/UniformsNode.js
+++ b/examples/jsm/nodes/accessors/UniformsNode.js
@@ -120,7 +120,6 @@ class UniformsNode extends BufferNode {
 
 		this.value = new Float32Array( length * 4 );
 		this.bufferCount = length;
-
 		this.bufferType = builder.changeComponentType( 'vec4', builder.getComponentType( this._elementType ) );
 
 		return super.setup( builder );

--- a/examples/jsm/nodes/accessors/UniformsNode.js
+++ b/examples/jsm/nodes/accessors/UniformsNode.js
@@ -34,9 +34,9 @@ class UniformsElementNode extends ArrayElementNode {
 
 class UniformsNode extends BufferNode {
 
-	constructor( value, elementType = null ) {
+	constructor( value, elementType = null, bufferType = 'vec4' ) {
 
-		super( null, 'vec4' );
+		super( null, bufferType );
 
 		this.array = value;
 		this.elementType = elementType;
@@ -135,6 +135,6 @@ class UniformsNode extends BufferNode {
 
 export default UniformsNode;
 
-export const uniforms = ( values, nodeType ) => nodeObject( new UniformsNode( values, nodeType ) );
+export const uniforms = ( values, nodeType, bufferType ) => nodeObject( new UniformsNode( values, nodeType, bufferType ) );
 
 addNodeClass( 'UniformsNode', UniformsNode );

--- a/examples/jsm/nodes/accessors/UniformsNode.js
+++ b/examples/jsm/nodes/accessors/UniformsNode.js
@@ -136,6 +136,6 @@ class UniformsNode extends BufferNode {
 
 export default UniformsNode;
 
-export const uniforms = ( values, nodeType, bufferType ) => nodeObject( new UniformsNode( values, nodeType, bufferType ) );
+export const uniforms = ( values, nodeType ) => nodeObject( new UniformsNode( values, nodeType ) );
 
 addNodeClass( 'UniformsNode', UniformsNode );

--- a/examples/jsm/nodes/accessors/UniformsNode.js
+++ b/examples/jsm/nodes/accessors/UniformsNode.js
@@ -34,9 +34,9 @@ class UniformsElementNode extends ArrayElementNode {
 
 class UniformsNode extends BufferNode {
 
-	constructor( value, elementType = null, bufferType = 'vec4' ) {
+	constructor( value, elementType = null ) {
 
-		super( null, bufferType );
+		super( null, 'vec4' );
 
 		this.array = value;
 		this.elementType = elementType;
@@ -120,6 +120,8 @@ class UniformsNode extends BufferNode {
 
 		this.value = new Float32Array( length * 4 );
 		this.bufferCount = length;
+
+		this.bufferType = builder.changeComponentType( 'vec4', builder.getComponentType( this._elementType ) );
 
 		return super.setup( builder );
 


### PR DESCRIPTION
Related issue: #27706

**Description**
```js
const vectors = uniforms( [
	new THREE.Vector4( 1, 0, 1, 1 ),
	new THREE.Vector4( 0, 1, 0, 1 ),
	new THREE.Vector4( 0, 0, 1, 1 )
], 'ivec4' );
```
Allow to specify the `bufferType` to `uniforms`. Without it, the struct in the WGSL backend was always generating float vec4 which would then break some operation when using layouts.


<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Utsubo](https://utsubo.com)*
