### PR TITLE
TSL: UniformNode Support Int/Uint

### DIFF
--- a/examples/jsm/nodes/accessors/BufferAttributeNode.js
+++ b/examples/jsm/nodes/accessors/BufferAttributeNode.js
@@ -35,7 +35,7 @@ class BufferAttributeNode extends InputNode {
 
 	getHash( builder ) {
 
-		if ( this.bufferStride === 0 && this.bufferOffset === 0) {
+		if ( this.bufferStride === 0 && this.bufferOffset === 0 ) {
 
 			let bufferData = builder.globalCache.getData( this.value );
 

--- a/examples/jsm/nodes/core/NodeBuilder.js
+++ b/examples/jsm/nodes/core/NodeBuilder.js
@@ -11,7 +11,7 @@ import { createNodeMaterialFromType, default as NodeMaterial } from '../material
 import { NodeUpdateType, defaultBuildStages, shaderStages } from './constants.js';
 
 import {
-	FloatNodeUniform, Vector2NodeUniform, Vector3NodeUniform, Vector4NodeUniform,
+	ScalarNodeUniform, Vector2NodeUniform, Vector3NodeUniform, Vector4NodeUniform,
 	ColorNodeUniform, Matrix3NodeUniform, Matrix4NodeUniform
 } from '../../renderers/common/nodes/NodeUniform.js';
 
@@ -1181,10 +1181,10 @@ class NodeBuilder {
 
 	getNodeUniform( uniformNode, type ) {
 
-		if ( type === 'float' ) return new FloatNodeUniform( uniformNode );
-		if ( type === 'vec2' ) return new Vector2NodeUniform( uniformNode );
-		if ( type === 'vec3' ) return new Vector3NodeUniform( uniformNode );
-		if ( type === 'vec4' ) return new Vector4NodeUniform( uniformNode );
+		if ( type === 'float' || type === 'int' || type === 'uint' ) return new ScalarNodeUniform( uniformNode );
+		if ( type === 'vec2' || type === 'ivec2' || type === 'uvec2' ) return new Vector2NodeUniform( uniformNode );
+		if ( type === 'vec3' || type === 'ivec3' || type === 'uvec3' ) return new Vector3NodeUniform( uniformNode );
+		if ( type === 'vec4' || type === 'ivec4' || type === 'uvec4' ) return new Vector4NodeUniform( uniformNode );
 		if ( type === 'color' ) return new ColorNodeUniform( uniformNode );
 		if ( type === 'mat3' ) return new Matrix3NodeUniform( uniformNode );
 		if ( type === 'mat4' ) return new Matrix4NodeUniform( uniformNode );

--- a/examples/jsm/nodes/core/NodeBuilder.js
+++ b/examples/jsm/nodes/core/NodeBuilder.js
@@ -11,7 +11,7 @@ import { createNodeMaterialFromType, default as NodeMaterial } from '../material
 import { NodeUpdateType, defaultBuildStages, shaderStages } from './constants.js';
 
 import {
-	ScalarNodeUniform, Vector2NodeUniform, Vector3NodeUniform, Vector4NodeUniform,
+	NumberNodeUniform, Vector2NodeUniform, Vector3NodeUniform, Vector4NodeUniform,
 	ColorNodeUniform, Matrix3NodeUniform, Matrix4NodeUniform
 } from '../../renderers/common/nodes/NodeUniform.js';
 
@@ -1181,7 +1181,7 @@ class NodeBuilder {
 
 	getNodeUniform( uniformNode, type ) {
 
-		if ( type === 'float' || type === 'int' || type === 'uint' ) return new ScalarNodeUniform( uniformNode );
+		if ( type === 'float' || type === 'int' || type === 'uint' ) return new NumberNodeUniform( uniformNode );
 		if ( type === 'vec2' || type === 'ivec2' || type === 'uvec2' ) return new Vector2NodeUniform( uniformNode );
 		if ( type === 'vec3' || type === 'ivec3' || type === 'uvec3' ) return new Vector3NodeUniform( uniformNode );
 		if ( type === 'vec4' || type === 'ivec4' || type === 'uvec4' ) return new Vector4NodeUniform( uniformNode );

--- a/examples/jsm/renderers/common/Uniform.js
+++ b/examples/jsm/renderers/common/Uniform.js
@@ -28,13 +28,13 @@ class Uniform {
 
 }
 
-class ScalarUniform extends Uniform {
+class NumberUniform extends Uniform {
 
 	constructor( name, value = 0 ) {
 
 		super( name, value );
 
-		this.isScalarUniform = true;
+		this.isNumberUniform = true;
 
 		this.boundary = 4;
 		this.itemSize = 1;
@@ -134,7 +134,7 @@ class Matrix4Uniform extends Uniform {
 }
 
 export {
-	ScalarUniform,
+	NumberUniform,
 	Vector2Uniform, Vector3Uniform, Vector4Uniform, ColorUniform,
 	Matrix3Uniform, Matrix4Uniform
 };

--- a/examples/jsm/renderers/common/Uniform.js
+++ b/examples/jsm/renderers/common/Uniform.js
@@ -28,13 +28,13 @@ class Uniform {
 
 }
 
-class FloatUniform extends Uniform {
+class ScalarUniform extends Uniform {
 
 	constructor( name, value = 0 ) {
 
 		super( name, value );
 
-		this.isFloatUniform = true;
+		this.isScalarUniform = true;
 
 		this.boundary = 4;
 		this.itemSize = 1;
@@ -134,7 +134,7 @@ class Matrix4Uniform extends Uniform {
 }
 
 export {
-	FloatUniform,
+	ScalarUniform,
 	Vector2Uniform, Vector3Uniform, Vector4Uniform, ColorUniform,
 	Matrix3Uniform, Matrix4Uniform
 };

--- a/examples/jsm/renderers/common/UniformsGroup.js
+++ b/examples/jsm/renderers/common/UniformsGroup.js
@@ -116,7 +116,7 @@ class UniformsGroup extends UniformBuffer {
 
 	updateByType( uniform ) {
 
-		if ( uniform.isFloatUniform ) return this.updateNumber( uniform );
+		if ( uniform.isScalarUniform ) return this.updateNumber( uniform );
 		if ( uniform.isVector2Uniform ) return this.updateVector2( uniform );
 		if ( uniform.isVector3Uniform ) return this.updateVector3( uniform );
 		if ( uniform.isVector4Uniform ) return this.updateVector4( uniform );

--- a/examples/jsm/renderers/common/UniformsGroup.js
+++ b/examples/jsm/renderers/common/UniformsGroup.js
@@ -116,7 +116,7 @@ class UniformsGroup extends UniformBuffer {
 
 	updateByType( uniform ) {
 
-		if ( uniform.isScalarUniform ) return this.updateNumber( uniform );
+		if ( uniform.isNumberUniform ) return this.updateNumber( uniform );
 		if ( uniform.isVector2Uniform ) return this.updateVector2( uniform );
 		if ( uniform.isVector3Uniform ) return this.updateVector3( uniform );
 		if ( uniform.isVector4Uniform ) return this.updateVector4( uniform );

--- a/examples/jsm/renderers/common/nodes/NodeUniform.js
+++ b/examples/jsm/renderers/common/nodes/NodeUniform.js
@@ -1,9 +1,9 @@
 import {
-	ScalarUniform, Vector2Uniform, Vector3Uniform, Vector4Uniform,
+	NumberUniform, Vector2Uniform, Vector3Uniform, Vector4Uniform,
 	ColorUniform, Matrix3Uniform, Matrix4Uniform
 } from '../Uniform.js';
 
-class ScalarNodeUniform extends ScalarUniform {
+class NumberNodeUniform extends NumberUniform {
 
 	constructor( nodeUniform ) {
 
@@ -130,6 +130,6 @@ class Matrix4NodeUniform extends Matrix4Uniform {
 }
 
 export {
-	ScalarNodeUniform, Vector2NodeUniform, Vector3NodeUniform, Vector4NodeUniform,
+	NumberNodeUniform, Vector2NodeUniform, Vector3NodeUniform, Vector4NodeUniform,
 	ColorNodeUniform, Matrix3NodeUniform, Matrix4NodeUniform
 };

--- a/examples/jsm/renderers/common/nodes/NodeUniform.js
+++ b/examples/jsm/renderers/common/nodes/NodeUniform.js
@@ -1,9 +1,9 @@
 import {
-	FloatUniform, Vector2Uniform, Vector3Uniform, Vector4Uniform,
+	ScalarUniform, Vector2Uniform, Vector3Uniform, Vector4Uniform,
 	ColorUniform, Matrix3Uniform, Matrix4Uniform
 } from '../Uniform.js';
 
-class FloatNodeUniform extends FloatUniform {
+class ScalarNodeUniform extends ScalarUniform {
 
 	constructor( nodeUniform ) {
 
@@ -130,6 +130,6 @@ class Matrix4NodeUniform extends Matrix4Uniform {
 }
 
 export {
-	FloatNodeUniform, Vector2NodeUniform, Vector3NodeUniform, Vector4NodeUniform,
+	ScalarNodeUniform, Vector2NodeUniform, Vector3NodeUniform, Vector4NodeUniform,
 	ColorNodeUniform, Matrix3NodeUniform, Matrix4NodeUniform
 };


### PR DESCRIPTION
**Description**

Currently only float uniforms were supported. This PR adds int/uint formats.

Example usage:
```js
uniform( count, 'uint' )
uniform( coords, 'ivec2' )

```

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Utsubo](https://utsubo.com)*
