### PR TITLE
TSL: Respect types in WGSL Layouts

### DIFF
--- a/examples/jsm/renderers/webgpu/nodes/WGSLNodeFunction.js
+++ b/examples/jsm/renderers/webgpu/nodes/WGSLNodeFunction.js
@@ -2,7 +2,7 @@ import NodeFunction from '../../../nodes/core/NodeFunction.js';
 import NodeFunctionInput from '../../../nodes/core/NodeFunctionInput.js';
 
 const declarationRegexp = /^[fn]*\s*([a-z_0-9]+)?\s*\(([\s\S]*?)\)\s*[\-\>]*\s*([a-z_0-9]+)?/i;
-const propertiesRegexp = /[a-z_0-9]+|<(.*?)>+/ig;
+const propertiesRegexp = /([a-z_0-9]+(?:<[\s\S]+?>)?)|<(.*?)>+/ig;
 
 const wgslTypeLib = {
 	f32: 'float'

--- a/examples/jsm/renderers/webgpu/nodes/WGSLNodeFunction.js
+++ b/examples/jsm/renderers/webgpu/nodes/WGSLNodeFunction.js
@@ -6,20 +6,39 @@ const propertiesRegexp = /([a-z_0-9]+)\s*:\s*([a-z_0-9]+(?:<[\s\S]+?>)?)/ig;
 
 const wgslTypeLib = {
 	'f32': 'float',
-	'mat2x2': 'mat2',
-	'mat2x2': 'imat2',
-	'mat2x2': 'umat2',
-	'mat2x2': 'bmat2',
+	'i32': 'int',
+	'u32': 'uint',
+	'bool': 'bool',
 
-	'mat3x3': 'mat3',
-	'mat3x3': 'imat3',
-	'mat3x3': 'umat3',
-	'mat3x3': 'bmat3',
+	'vec2<f32>': 'vec2',
+ 	'vec2<i32>': 'ivec2',
+ 	'vec2<u32>': 'uvec2',
+ 	'vec2<bool>': 'bvec2',
 
-	'mat4x4': 'mat4',
-	'mat4x4': 'imat4',
-	'mat4x4': 'umat4',
-	'mat4x4': 'bmat4'
+	'vec3<f32>': 'vec3',
+	'vec3<i32>': 'ivec3',
+	'vec3<u32>': 'uvec3',
+	'vec3<bool>': 'bvec3',
+
+	'vec4<f32>': 'vec4',
+	'vec4<i32>': 'ivec4',
+	'vec4<u32>': 'uvec4',
+	'vec4<bool>': 'bvec4',
+
+	'mat2x2<f32>': 'mat2',
+	'mat2x2<i32>': 'imat2',
+	'mat2x2<u32>': 'umat2',
+	'mat2x2<bool>': 'bmat2',
+
+	'mat3x3<f32>': 'mat3',
+	'mat3x3<i32>': 'imat3',
+	'mat3x3<u32>': 'umat3',
+	'mat3x3<bool>': 'bmat3',
+
+	'mat4x4<f32>': 'mat4',
+	'mat4x4<i32>': 'imat4',
+	'mat4x4<u32>': 'umat4',
+	'mat4x4<bool>': 'bmat4'
 };
 
 const parse = ( source ) => {
@@ -46,11 +65,16 @@ const parse = ( source ) => {
 
 			const { name, type } = propsMatches[ i ];
 
-			let resolvedType = type.replace( /<[^>]+>/, '' );
+			let resolvedType = type;
+
+			if ( resolvedType.startsWith( 'texture' ) ) {
+
+				resolvedType = type.split( '<' )[ 0 ];
+
+			}
 
 			resolvedType = wgslTypeLib[ resolvedType ] || resolvedType;
 
-			// debugger;
 			inputs.push( new NodeFunctionInput( resolvedType, name ) );
 
 		}
@@ -80,7 +104,6 @@ class WGSLNodeFunction extends NodeFunction {
 	constructor( source ) {
 
 		const { type, inputs, name, inputsCode, blockCode } = parse( source );
-
 		super( type, inputs, name );
 
 		this.inputsCode = inputsCode;
@@ -91,7 +114,6 @@ class WGSLNodeFunction extends NodeFunction {
 	getCode( name = this.name ) {
 
 		const type = this.type !== 'void' ? '-> ' + this.type : '';
-
 		return `fn ${ name } ( ${ this.inputsCode.trim() } ) ${ type }` + this.blockCode;
 
 	}

--- a/examples/jsm/renderers/webgpu/nodes/WGSLNodeFunction.js
+++ b/examples/jsm/renderers/webgpu/nodes/WGSLNodeFunction.js
@@ -80,6 +80,7 @@ const parse = ( source ) => {
 		}
 
 		const blockCode = source.substring( declaration[ 0 ].length );
+
 		const name = declaration[ 1 ] !== undefined ? declaration[ 1 ] : '';
 		const type = declaration[ 3 ] || 'void';
 
@@ -104,6 +105,7 @@ class WGSLNodeFunction extends NodeFunction {
 	constructor( source ) {
 
 		const { type, inputs, name, inputsCode, blockCode } = parse( source );
+
 		super( type, inputs, name );
 
 		this.inputsCode = inputsCode;
@@ -114,6 +116,7 @@ class WGSLNodeFunction extends NodeFunction {
 	getCode( name = this.name ) {
 
 		const type = this.type !== 'void' ? '-> ' + this.type : '';
+
 		return `fn ${ name } ( ${ this.inputsCode.trim() } ) ${ type }` + this.blockCode;
 
 	}

--- a/examples/webgpu_tsl_interoperability.html
+++ b/examples/webgpu_tsl_interoperability.html
@@ -32,7 +32,7 @@
 			import WebGL from 'three/addons/capabilities/WebGL.js';
 
 			import WebGPURenderer from 'three/addons/renderers/webgpu/WebGPURenderer.js';
-			import { tslFn, attribute, varyingProperty, timerLocal, uniform, wgslFn, texture, uv, clamp, float, vec2, vec3, fract, floor, MeshBasicNodeMaterial, positionGeometry, sin } from 'three/nodes';
+			import { tslFn, sampler, attribute, varyingProperty, timerLocal, uniform, wgslFn, texture, uv, clamp, float, vec2, vec3, fract, floor, MeshBasicNodeMaterial, positionGeometry, sin } from 'three/nodes';
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 
@@ -109,12 +109,12 @@
 							crtHeight
 						);
 						// Coordinate for each cell in the pixel map
-						var coord = pixel / cellSize;
+						let coord = pixel / cellSize;
 						// Three color values for each cell (r, g, b)
-						var subcoord = coord * vec2f( 3.0, 1.0 );
-						var offset = vec2<f32>( 0, fract( floor( coord.x ) * cellOffset ) );
+						let subcoord = coord * vec2f( 3.0, 1.0 );
+						let offset = vec2<f32>( 0, fract( floor( coord.x ) * cellOffset ) );
 
-						var maskCoord = floor( coord + offset ) * cellSize;
+						let maskCoord = floor( coord + offset ) * cellSize;
 
 						var samplePoint = maskCoord / vec2<f32>(crtWidth, crtHeight);
 						samplePoint.x += fract( time * speed / 20 );
@@ -127,7 +127,7 @@
 
 						// Current implementation does not give an even amount of space to each r, g, b unit of a cell
 						// Fix/hack this by multiplying subCoord.x by cellSize at cellSizes below 6
-						var ind = floor( subcoord.x ) % 3;
+						let ind = floor( subcoord.x ) % 3;
 
 						var maskColor = vec3<f32>(
 							f32( ind == 0.0 ), 
@@ -135,7 +135,7 @@
 							f32( ind == 2.0 )
 						) * 3.0;
 
-						var cellUV = fract( subcoord + offset ) * 2.0 - 1.0;
+						let cellUV = fract( subcoord + offset ) * 2.0 - 1.0;
 						var border: vec2<f32> = 1.0 - cellUV * cellUV * borderMask;
 
 						maskColor *= vec3f( clamp( border.x, 0.0, 1.0 ) * clamp( border.y, 0.0, 1.0) );
@@ -180,7 +180,7 @@
 				wgslShaderMaterial.fragmentNode = wgslFragmentShader( {
 					vUv: vUv,
 					tex: texture( planetTexture ),
-					texSampler: texture( planetTexture ),
+					texSampler: sampler( planetTexture ),
 					crtWidth: crtWidthUniform,
 					crtHeight: crtHeightUniform,
 					cellOffset: cellOffsetUniform,


### PR DESCRIPTION
Maybe Related: #28659 #28577

**Description**
The regex function in the parsing method of `WGSLNodeFunction` was not taking in account the `<abc>` part resulting in not respecting the type properties. For example the type of `vec2<ivec2>` would be converted to `vec2` instead of `ivec2`.
This PR fixes the issue.

*This contribution is funded by [Utsubo](https://utsubo.com)*
