### PR TITLE
WebGLUniforms: Assign `compareFunction` lazily to retain tree-shaking.

### DIFF
--- a/src/renderers/webgl/WebGLUniforms.js
+++ b/src/renderers/webgl/WebGLUniforms.js
@@ -572,7 +572,7 @@ function setValueT1( gl, v, textures ) {
 
 	if ( this.type === gl.SAMPLER_2D_SHADOW ) {
 
-		emptyShadowTexture.compareFunction = LessEqualCompare;
+		emptyShadowTexture.compareFunction = LessEqualCompare; // #28670
 		emptyTexture2D = emptyShadowTexture;
 
 	} else {

--- a/src/renderers/webgl/WebGLUniforms.js
+++ b/src/renderers/webgl/WebGLUniforms.js
@@ -50,7 +50,7 @@ import { LessEqualCompare } from '../../constants.js';
 
 const emptyTexture = /*@__PURE__*/ new Texture();
 
-let emptyShadowTexture = null;
+const emptyShadowTexture = /*@__PURE__*/ new DepthTexture( 1, 1 );
 
 const emptyArrayTexture = /*@__PURE__*/ new DataArrayTexture();
 const empty3dTexture = /*@__PURE__*/ new Data3DTexture();
@@ -568,14 +568,18 @@ function setValueT1( gl, v, textures ) {
 
 	}
 
-	if ( this.type === gl.SAMPLER_2D_SHADOW && emptyShadowTexture === null ) {
+	let emptyTexture2D = null;
 
-		emptyShadowTexture = new DepthTexture( 1, 1 );
+	if ( this.type === gl.SAMPLER_2D_SHADOW ) {
+
 		emptyShadowTexture.compareFunction = LessEqualCompare;
+		emptyTexture2D = emptyShadowTexture;
+
+	} else {
+
+		emptyTexture2D = emptyTexture;
 
 	}
-
-	const emptyTexture2D = ( this.type === gl.SAMPLER_2D_SHADOW ) ? emptyShadowTexture : emptyTexture;
 
 	textures.setTexture2D( v || emptyTexture2D, unit );
 

--- a/src/renderers/webgl/WebGLUniforms.js
+++ b/src/renderers/webgl/WebGLUniforms.js
@@ -50,8 +50,7 @@ import { LessEqualCompare } from '../../constants.js';
 
 const emptyTexture = /*@__PURE__*/ new Texture();
 
-const emptyShadowTexture = /*@__PURE__*/ new DepthTexture( 1, 1 );
-emptyShadowTexture.compareFunction = LessEqualCompare;
+let emptyShadowTexture = null;
 
 const emptyArrayTexture = /*@__PURE__*/ new DataArrayTexture();
 const empty3dTexture = /*@__PURE__*/ new Data3DTexture();
@@ -566,6 +565,13 @@ function setValueT1( gl, v, textures ) {
 
 		gl.uniform1i( this.addr, unit );
 		cache[ 0 ] = unit;
+
+	}
+
+	if ( this.type === gl.SAMPLER_2D_SHADOW && emptyShadowTexture === null ) {
+
+		emptyShadowTexture = new DepthTexture( 1, 1 );
+		emptyShadowTexture.compareFunction = LessEqualCompare;
 
 	}
 


### PR DESCRIPTION
Related issue: #24199

**Description**

Did a quick test for tree-shaking in core (importing a constant), and found the usual expected culprits (mutations from setting static properties in `Texture`, `Euler`, `Object3D`, and devtools), but also a seemingly low hanging fruit in WebGL source. Everything else is both annoying to fix and expected to be present in user-land code for rendering.