### PR TITLE
WebGPURenderer: `WebGLBackend` - Add missing parameters to `copyTextureToTexture`

### DIFF
--- a/examples/jsm/renderers/webgl/utils/WebGLTextureUtils.js
+++ b/examples/jsm/renderers/webgl/utils/WebGLTextureUtils.js
@@ -666,7 +666,7 @@ class WebGLTextureUtils {
 
 			} else {
 
-				gl.texSubImage2D( gl.TEXTURE_2D, level, dstX, dstY, glFormat, glType, image );
+				gl.texSubImage2D( gl.TEXTURE_2D, level, dstX, dstY, width, height, glFormat, glType, image );
 
 			}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/28663

Updating from WebGLRenderer.