### PR TITLE
Editor: Fix undo/redo of points.

### DIFF
--- a/editor/js/Sidebar.Geometry.LatheGeometry.js
+++ b/editor/js/Sidebar.Geometry.LatheGeometry.js
@@ -61,6 +61,7 @@ function GeometryParametersPanel( editor, object ) {
 
 		const parameters = object.geometry.parameters;
 
+		points.setValue( parameters.points, false );
 		segments.setValue( parameters.segments );
 		phiStart.setValue( parameters.phiStart * THREE.MathUtils.RAD2DEG );
 		phiLength.setValue( parameters.phiLength * THREE.MathUtils.RAD2DEG );

--- a/editor/js/Sidebar.Geometry.TubeGeometry.js
+++ b/editor/js/Sidebar.Geometry.TubeGeometry.js
@@ -94,6 +94,7 @@ function GeometryParametersPanel( editor, object ) {
 		radialSegments.setValue( parameters.radialSegments );
 		closed.setValue( parameters.closed );
 
+		points.setValue( parameters.path.points, false );
 		curveType.setValue( parameters.path.curveType );
 		tension.setValue( parameters.path.tension );
 

--- a/editor/js/libs/ui.three.js
+++ b/editor/js/libs/ui.three.js
@@ -571,13 +571,9 @@ class UIPoints extends UISpan {
 
 	clear() {
 
-		for ( let i = 0; i < this.pointsUI.length; ++ i ) {
+		for ( let i = this.pointsUI.length - 1; i >= 0; -- i ) {
 
-			if ( this.pointsUI[ i ] ) {
-
-				this.deletePointRow( i, true );
-
-			}
+			this.deletePointRow( i, false );
 
 		}
 
@@ -585,7 +581,7 @@ class UIPoints extends UISpan {
 
 	}
 
-	deletePointRow( idx, dontUpdate ) {
+	deletePointRow( idx, needsUpdate = true ) {
 
 		if ( ! this.pointsUI[ idx ] ) return;
 
@@ -593,7 +589,7 @@ class UIPoints extends UISpan {
 
 		this.pointsUI.splice( idx, 1 );
 
-		if ( dontUpdate !== true ) {
+		if ( needsUpdate === true ) {
 
 			this.update();
 
@@ -658,7 +654,7 @@ class UIPoints2 extends UIPoints {
 
 	}
 
-	setValue( points ) {
+	setValue( points, needsUpdate = true ) {
 
 		this.clear();
 
@@ -669,7 +665,8 @@ class UIPoints2 extends UIPoints {
 
 		}
 
-		this.update();
+		if ( needsUpdate === true ) this.update();
+
 		return this;
 
 	}
@@ -753,7 +750,7 @@ class UIPoints3 extends UIPoints {
 
 	}
 
-	setValue( points ) {
+	setValue( points, update = true ) {
 
 		this.clear();
 
@@ -764,7 +761,8 @@ class UIPoints3 extends UIPoints {
 
 		}
 
-		this.update();
+		if ( update === true ) this.update();
+
 		return this;
 
 	}


### PR DESCRIPTION
Related issue: #28611

**Description**

This PR makes sure undo/redo commands in context of points (`LatheGeometry` and `TubeGeometry`) works as expected. It tries to fix the issue with a more simplified approach than #28611.