### PR TITLE
CompressedArrayTexture: Rename `addLayerUpdates` to `addLayerUpdate`.

### DIFF
--- a/src/textures/CompressedArrayTexture.js
+++ b/src/textures/CompressedArrayTexture.js
@@ -15,7 +15,7 @@ class CompressedArrayTexture extends CompressedTexture {
 
 	}
 
-	addLayerUpdates( layerIndex ) {
+	addLayerUpdate( layerIndex ) {
 
 		this.layerUpdates.add( layerIndex );
 


### PR DESCRIPTION
It looks like there's a typo added in https://github.com/mrdoob/three.js/pull/27972 

The documentation describes the new method `addLayerUpdate` which is correctly added to `DataArrayTexture` but is incorrectly named `addLayerUpdates` in `CompressedArrayTexture`.

Normally I'd be worried about making a backwards incompatible change, however, this feature has only been in the wild for ~2 weeks, is documented under the name `addLayerUpdate` and any typescript users will not be able to use the feature at all due to a [mismatch between the typescript definition and actual code](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/three/src/textures/CompressedArrayTexture.d.ts#L62). Knowing this, I'd recommend we fix the typo.