### PR TITLE
WebGPURenderer: Revision texture filtering and rain example

### DIFF
--- a/examples/jsm/nodes/core/NodeBuilder.js
+++ b/examples/jsm/nodes/core/NodeBuilder.js
@@ -15,7 +15,10 @@ import {
 	ColorNodeUniform, Matrix3NodeUniform, Matrix4NodeUniform
 } from '../../renderers/common/nodes/NodeUniform.js';
 
-import { REVISION, RenderTarget, Color, Vector2, Vector3, Vector4, IntType, UnsignedIntType, Float16BufferAttribute } from 'three';
+import {
+	REVISION, RenderTarget, Color, Vector2, Vector3, Vector4, IntType, UnsignedIntType, Float16BufferAttribute,
+	LinearFilter, LinearMipmapNearestFilter, NearestMipmapLinearFilter, LinearMipmapLinearFilter
+} from 'three';
 
 import { stack } from './StackNode.js';
 import { getCurrentStack, setCurrentStack } from '../shadernode/ShaderNode.js';
@@ -243,6 +246,13 @@ class NodeBuilder {
 	get currentNode() {
 
 		return this.chaining[ this.chaining.length - 1 ];
+
+	}
+
+	isFilteredTexture( texture ) {
+
+		return ( texture.magFilter === LinearFilter || texture.magFilter === LinearMipmapNearestFilter || texture.magFilter === NearestMipmapLinearFilter || texture.magFilter === LinearMipmapLinearFilter ||
+			texture.minFilter === LinearFilter || texture.minFilter === LinearMipmapNearestFilter || texture.minFilter === NearestMipmapLinearFilter || texture.minFilter === LinearMipmapLinearFilter );
 
 	}
 

--- a/examples/jsm/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/examples/jsm/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -185,9 +185,13 @@ class WGSLNodeBuilder extends NodeBuilder {
 
 			}
 
-		} else {
+		} else if ( this.isFilteredTexture( texture ) ) {
 
 			return this.generateFilteredTexture( texture, textureProperty, uvSnippet );
+
+		} else {
+
+			return this.generateTextureLod( texture, textureProperty, uvSnippet, '0' );
 
 		}
 
@@ -213,9 +217,13 @@ class WGSLNodeBuilder extends NodeBuilder {
 
 			return `textureSampleLevel( ${ textureProperty }, ${ textureProperty }_sampler, ${ uvSnippet }, ${ levelSnippet } )`;
 
-		} else {
+		} else if ( this.isFilteredTexture( texture ) ) {
 
 			return this.generateFilteredTexture( texture, textureProperty, uvSnippet, levelSnippet );
+
+		} else {
+
+			return this.generateTextureLod( texture, textureProperty, uvSnippet, levelSnippet );
 
 		}
 

--- a/examples/webgpu_compute_particles_rain.html
+++ b/examples/webgpu_compute_particles_rain.html
@@ -97,6 +97,8 @@
 
 				collisionPosRT = new THREE.RenderTarget( 1024, 1024 );
 				collisionPosRT.texture.type = THREE.HalfFloatType;
+				collisionPosRT.texture.magFilter = THREE.NearestFilter;
+				collisionPosRT.texture.minFilter = THREE.NearestFilter;
 
 				collisionPosMaterial = new MeshBasicNodeMaterial();
 				collisionPosMaterial.colorNode = positionWorld;


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/28673, https://github.com/mrdoob/three.js/pull/27053

**Description**

There were some artifacts when example rain when executed in `WebGLBackend`, after the implementation of the texture filter https://github.com/mrdoob/three.js/pull/28673 the same happened in `WebGPUBackend` making it easier to detect the problem.

![image](https://github.com/mrdoob/three.js/assets/502810/51bcd1fb-7e1d-45c1-b571-e6fb47de57d2)

