### PR TITLE
WebGPURenderer: Remove `.isInstancedMesh` needs

### DIFF
--- a/examples/jsm/nodes/accessors/MorphNode.js
+++ b/examples/jsm/nodes/accessors/MorphNode.js
@@ -190,7 +190,7 @@ class MorphNode extends Node {
 
 			const influence = float( 0 ).toVar();
 
-			if ( this.mesh.isInstancedMesh === true && ( this.mesh.morphTexture !== null && this.mesh.morphTexture !== undefined ) ) {
+			if ( this.mesh.count > 1 && ( this.mesh.morphTexture !== null && this.mesh.morphTexture !== undefined ) ) {
 
 				influence.assign( textureLoad( this.mesh.morphTexture, ivec2( int( i ).add( 1 ), int( instanceIndex ) ) ).r );
 

--- a/examples/jsm/nodes/geometry/RangeNode.js
+++ b/examples/jsm/nodes/geometry/RangeNode.js
@@ -32,7 +32,7 @@ class RangeNode extends Node {
 
 	getNodeType( builder ) {
 
-		return builder.object.isInstancedMesh === true ? builder.getTypeFromLength( this.getVectorLength( builder ) ) : 'float';
+		return builder.object.count > 1 ? builder.getTypeFromLength( this.getVectorLength( builder ) ) : 'float';
 
 	}
 
@@ -42,7 +42,7 @@ class RangeNode extends Node {
 
 		let output = null;
 
-		if ( object.isInstancedMesh === true ) {
+		if ( object.count > 1 ) {
 
 			const minValue = this.minNode.value;
 			const maxValue = this.maxNode.value;

--- a/examples/jsm/renderers/common/Backend.js
+++ b/examples/jsm/renderers/common/Backend.js
@@ -100,7 +100,7 @@ class Backend {
 
 		const { object, geometry } = renderObject;
 
-		return geometry.isInstancedBufferGeometry ? geometry.instanceCount : ( object.isInstancedMesh ? object.count : 1 );
+		return geometry.isInstancedBufferGeometry ? geometry.instanceCount : ( object.count > 1 ? object.count : 1 );
 
 	}
 

--- a/examples/jsm/renderers/common/RenderObject.js
+++ b/examples/jsm/renderers/common/RenderObject.js
@@ -234,7 +234,7 @@ export default class RenderObject {
 
 		}
 
-		if ( object.isInstancedMesh ) {
+		if ( object.count > 1 ) {
 
 			cacheKey += object.count + ',';
 

--- a/examples/webgpu_compute_particles.html
+++ b/examples/webgpu_compute_particles.html
@@ -160,7 +160,6 @@
 				particleMaterial.transparent = true;
 
 				const particles = new THREE.Mesh( new THREE.PlaneGeometry( 1, 1 ), particleMaterial );
-				particles.isInstancedMesh = true;
 				particles.count = particleCount;
 				particles.frustumCulled = false;
 				scene.add( particles );

--- a/examples/webgpu_compute_particles_rain.html
+++ b/examples/webgpu_compute_particles_rain.html
@@ -233,7 +233,6 @@
 				rainMaterial.transparent = true;
 
 				const rainParticles = new THREE.Mesh( new THREE.PlaneGeometry( .1, 2 ), rainMaterial );
-				rainParticles.isInstancedMesh = true;
 				rainParticles.count = instanceCount;
 				scene.add( rainParticles );
 
@@ -273,7 +272,6 @@
 				const rippleGeometry = BufferGeometryUtils.mergeGeometries( [ surfaceRippleGeometry, xRippleGeometry, zRippleGeometry ] );
 
 				const rippleParticles = new THREE.Mesh( rippleGeometry, rippleMaterial );
-				rippleParticles.isInstancedMesh = true;
 				rippleParticles.count = instanceCount;
 				scene.add( rippleParticles );
 

--- a/examples/webgpu_compute_particles_snow.html
+++ b/examples/webgpu_compute_particles_snow.html
@@ -198,7 +198,6 @@
 					staticMaterial.positionNode = positionLocal.mul( scaleBuffer.toAttribute() ).add( posBuffer.toAttribute() );
 
 					const rainParticles = new THREE.Mesh( geometry, staticMaterial );
-					rainParticles.isInstancedMesh = true;
 					rainParticles.count = maxParticleCount;
 					rainParticles.castShadow = true;
 					rainParticles.layers.disableAll();

--- a/examples/webgpu_compute_points.html
+++ b/examples/webgpu_compute_points.html
@@ -133,7 +133,6 @@
 				pointsMaterial.positionNode = particleNode;
 
 				const mesh = new THREE.Points( pointsGeometry, pointsMaterial );
-				mesh.isInstancedMesh = true;
 				mesh.count = particleNum;
 				scene.add( mesh );
 

--- a/examples/webgpu_particles.html
+++ b/examples/webgpu_particles.html
@@ -96,7 +96,6 @@
 
 				const smokeInstancedSprite = new THREE.Mesh( new THREE.PlaneGeometry( 1, 1 ), smokeNodeMaterial );
 				smokeInstancedSprite.scale.setScalar( 400 );
-				smokeInstancedSprite.isInstancedMesh = true;
 				smokeInstancedSprite.count = 2000;
 				scene.add( smokeInstancedSprite );
 
@@ -113,7 +112,6 @@
 
 				const fireInstancedSprite = new THREE.Mesh( new THREE.PlaneGeometry( 1, 1 ), fireNodeMaterial );
 				fireInstancedSprite.scale.setScalar( 400 );
-				fireInstancedSprite.isInstancedMesh = true;
 				fireInstancedSprite.count = 100;
 				fireInstancedSprite.position.y = - 100;
 				fireInstancedSprite.renderOrder = 1;


### PR DESCRIPTION
**Description**

Many TSL examples were created to be used with instances, but without needing the `instanceMatrix` and `InstancedMesh` class... This makes it more intuitive to create instances using TSL, as it is simply necessary to define `.count=` in any meshes, sprites or skinning meshes.