### PR TITLE
TSL: Fix issue in wgslFn alias revision.

### DIFF
--- a/examples/jsm/renderers/webgpu/nodes/WGSLNodeFunction.js
+++ b/examples/jsm/renderers/webgpu/nodes/WGSLNodeFunction.js
@@ -53,7 +53,7 @@ const wgslTypeLib = {
 	'texture_2d': 'texture',
 	'texture_cube': 'textureCube',
 	'texture_depth_2d': 'textureDepth',
-	'texture_storage_2d': 'textureStorage',
+	'texture_storage_2d': 'storageTexture',
 	'texture_3d': 'texture3D'
 
 };


### PR DESCRIPTION
Related issue: #28680 

Fixes texture_storage_2d parsing in the compute ping pong texture sample by applying the correct TSL syntax for storage textures.
