### PR TITLE
TSL: Fix WGSL Functions using wrong type

### DIFF
--- a/examples/jsm/nodes/code/FunctionNode.js
+++ b/examples/jsm/nodes/code/FunctionNode.js
@@ -63,7 +63,7 @@ class FunctionNode extends CodeNode {
 
 		const propertyName = builder.getPropertyName( nodeCode );
 
-		let code = this.getNodeFunction( builder ).getCode( propertyName );
+		let code = this.getNodeFunction( builder ).getCode( propertyName, builder.getType(type) );
 
 		const keywords = this.keywords;
 		const keywordsProperties = Object.keys( keywords );

--- a/examples/jsm/nodes/code/FunctionNode.js
+++ b/examples/jsm/nodes/code/FunctionNode.js
@@ -63,7 +63,7 @@ class FunctionNode extends CodeNode {
 
 		const propertyName = builder.getPropertyName( nodeCode );
 
-		let code = this.getNodeFunction( builder ).getCode( propertyName, builder.getType(type) );
+		let code = this.getNodeFunction( builder ).getCode( propertyName );
 
 		const keywords = this.keywords;
 		const keywordsProperties = Object.keys( keywords );

--- a/examples/jsm/renderers/webgpu/nodes/WGSLNodeFunction.js
+++ b/examples/jsm/renderers/webgpu/nodes/WGSLNodeFunction.js
@@ -1,7 +1,7 @@
 import NodeFunction from '../../../nodes/core/NodeFunction.js';
 import NodeFunctionInput from '../../../nodes/core/NodeFunctionInput.js';
 
-const declarationRegexp = /^[fn]*\s*([a-z_0-9]+)?\s*\(([\s\S]*?)\)\s*[\-\>]*\s*([a-z_0-9]+)?/i;
+const declarationRegexp = /^[fn]*\s*([a-z_0-9]+)?\s*\(([\s\S]*?)\)\s*[\-\>]*\s*([a-z_0-9]+(?:<[\s\S]+?>)?)/i;
 const propertiesRegexp = /([a-z_0-9]+)\s*:\s*([a-z_0-9]+(?:<[\s\S]+?>)?)/ig;
 
 const wgslTypeLib = {
@@ -99,7 +99,9 @@ const parse = ( source ) => {
 		const blockCode = source.substring( declaration[ 0 ].length );
 
 		const name = declaration[ 1 ] !== undefined ? declaration[ 1 ] : '';
-		const type = declaration[ 3 ] || 'void';
+		let type = declaration[ 3 ] || 'void';
+
+		type = wgslTypeLib[type] || type;
 
 		return {
 			type,
@@ -130,9 +132,9 @@ class WGSLNodeFunction extends NodeFunction {
 
 	}
 
-	getCode( name = this.name ) {
+	getCode( name = this.name, outputType = this.type ) {
 
-		const type = this.type !== 'void' ? '-> ' + this.type : '';
+		const type = outputType !== 'void' ? '-> ' + outputType : '';
 
 		return `fn ${ name } ( ${ this.inputsCode.trim() } ) ${ type }` + this.blockCode;
 

--- a/examples/jsm/renderers/webgpu/nodes/WGSLNodeFunction.js
+++ b/examples/jsm/renderers/webgpu/nodes/WGSLNodeFunction.js
@@ -97,18 +97,18 @@ const parse = ( source ) => {
 		}
 
 		const blockCode = source.substring( declaration[ 0 ].length );
+		const outputType = declaration[ 3 ] || 'void';
 
 		const name = declaration[ 1 ] !== undefined ? declaration[ 1 ] : '';
-		let type = declaration[ 3 ] || 'void';
-
-		type = wgslTypeLib[type] || type;
+		const type = wgslTypeLib[ outputType ] || outputType;
 
 		return {
 			type,
 			inputs,
 			name,
 			inputsCode,
-			blockCode
+			blockCode,
+			outputType
 		};
 
 	} else {
@@ -123,20 +123,21 @@ class WGSLNodeFunction extends NodeFunction {
 
 	constructor( source ) {
 
-		const { type, inputs, name, inputsCode, blockCode } = parse( source );
+		const { type, inputs, name, inputsCode, blockCode, outputType } = parse( source );
 
 		super( type, inputs, name );
 
 		this.inputsCode = inputsCode;
 		this.blockCode = blockCode;
+		this.outputType = outputType;
 
 	}
 
-	getCode( name = this.name, outputType = this.type ) {
+	getCode( name = this.name ) {
 
-		const type = outputType !== 'void' ? '-> ' + outputType : '';
+		const outputType = this.outputType !== 'void' ? '-> ' + this.outputType : '';
 
-		return `fn ${ name } ( ${ this.inputsCode.trim() } ) ${ type }` + this.blockCode;
+		return `fn ${ name } ( ${ this.inputsCode.trim() } ) ${ outputType }` + this.blockCode;
 
 	}
 


### PR DESCRIPTION
Related issue: #28669

**Description**

We just fixed the types of properties for WGSL functions, the type of declaration needed the same treatment.

Example:
```js
const a = tslFn( ( [] ) => {

return ivec2();

}).setLayout({ type: 'ivec2', ... })

const b = uniforms([], 'ivec4')

// Later in the shader:
const c = a().x.add(b.x)

// ----- Transpilation ------
// Before this PR, some operations were casting some nodes to float:
const c = a().x.add( float( vec4<i32>(b).x ) ) // <-- breaks because int32 + float32


// After this PR
const c = a().x.add( vec4<i32>(b).x ) // <-- works because int32 + int32
```

*This contribution is funded by [Utsubo](https://utsubo.com)*
