### PR TITLE
Cleanup: Update references to BatchedMesh.maxGeometryCount

### DIFF
--- a/docs/api/en/objects/BatchedMesh.html
+++ b/docs/api/en/objects/BatchedMesh.html
@@ -38,11 +38,11 @@
 		const sphereGeometryId = batchedMesh.addGeometry( sphere );
 
 		// create instances of those geometries
-		const boxInstancedId1 = batchedMesh.addInstance( boxGeometryId ); 
+		const boxInstancedId1 = batchedMesh.addInstance( boxGeometryId );
 		const boxInstancedId2 = batchedMesh.addInstance( boxGeometryId );
 
-		const sphereInstancedId1 = batchedMesh.addInstance( sphereGeometryId ); 
-		const sphereInstancedId2 = batchedMesh.addInstance( sphereGeometryId ); 
+		const sphereInstancedId1 = batchedMesh.addInstance( sphereGeometryId );
+		const sphereInstancedId2 = batchedMesh.addInstance( sphereGeometryId );
 
 		// position the geometries
 		batchedMesh.setMatrixAt( boxInstancedId1, boxMatrix1 );
@@ -100,9 +100,9 @@
 			rendered front to back. Default is `true`.
 		</p>
 
-		<h3>[property:Integer maxGeometryCount]</h3>
+		<h3>[property:Integer maxInstanceCount]</h3>
 		<p>
-			The maximum number of individual geometries that can be stored in the [name]. Read only.
+			The maximum number of individual instances that can be stored in the [name]. Read only.
 		</p>
 
 		<h3>[property:Boolean isBatchedMesh]</h3>
@@ -231,7 +231,7 @@
 			[method:Integer addInstance]( [param:Integer geometryId] )
 		</h3>
 		<p>
-			[page:Integer geometryId]: The id of a previously added geometry via "addGeometry" to add into the [name] to render. 
+			[page:Integer geometryId]: The id of a previously added geometry via "addGeometry" to add into the [name] to render.
 		</p>
 		<p>
 			Adds a new instance to the [name] using the geometry of the given geometryId and returns a new id referring to the new instance to be used

--- a/docs/api/zh/objects/BatchedMesh.html
+++ b/docs/api/zh/objects/BatchedMesh.html
@@ -49,12 +49,12 @@
 	<h2>构造函数</h2>
 	<h3>
 		[name](
-		[param:Integer maxGeometryCount], [param:Integer maxVertexCount],
+		[param:Integer maxInstanceCount], [param:Integer maxVertexCount],
 		[param:Integer maxIndexCount], [param:Material material],
 		)
 	</h3>
 	<p>
-		[page:Integer maxGeometryCount] - 计划添加的单个几何体的最大数量。<br />
+		[page:Integer maxInstanceCount] - 计划添加的单个几何体的最大数量。<br />
 		[page:Integer maxVertexCount] - 所有几何体使用的最大顶点数。<br />
 		[page:Integer maxIndexCount] - 所有几何图形使用的最大索引数。<br />
 		[page:Material material] - [page:Material] 的一个实例。默认是新的 [page:MeshBasicMaterial]。<br />
@@ -83,7 +83,7 @@
 		如果为 true，则对 [name] 中的各个对象进行排序以改善与过度绘制相关的工件。如果材质被标记为“透明”，则对象将从后到前渲染，如果没有，则它们从前到后渲染。默认为 `true`。
 	</p>
 
-	<h3>[property:Integer maxGeometryCount]</h3>
+	<h3>[property:Integer maxInstanceCount]</h3>
 	<p>
 		只读，[name] 中可以存储的单个几何体的最大数量。
 	</p>

--- a/examples/webgl_mesh_batch.html
+++ b/examples/webgl_mesh_batch.html
@@ -293,7 +293,7 @@
 			// initialize options
 			this._options = this._options || {
 				get: el => el.z,
-				aux: new Array( this.maxGeometryCount )
+				aux: new Array( this.maxInstanceCount )
 			};
 
 			const options = this._options;

--- a/examples/webgpu_mesh_batch.html
+++ b/examples/webgpu_mesh_batch.html
@@ -50,7 +50,7 @@
 		let gui;
 		let geometries, mesh, material;
 		const ids = [];
-		
+
 		const matrix = new THREE.Matrix4();
 
 		//
@@ -313,7 +313,7 @@
 
 				controls.update();
 
-		
+
 				if ( mesh.isBatchedMesh ) {
 
 					mesh.sortObjects = api.sortObjects;
@@ -355,7 +355,7 @@
 			// initialize options
 			this._options = this._options || {
 				get: el => el.z,
-				aux: new Array( this.maxGeometryCount )
+				aux: new Array( this.maxInstanceCount )
 			};
 
 			const options = this._options;

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -752,7 +752,7 @@ class Object3D extends EventDispatcher {
 				sphereCenter: bound.sphere.center.toArray()
 			} ) );
 
-			object.maxGeometryCount = this._maxGeometryCount;
+			object.maxInstanceCount = this._maxInstanceCount;
 			object.maxVertexCount = this._maxVertexCount;
 			object.maxIndexCount = this._maxIndexCount;
 

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -908,7 +908,7 @@ class ObjectLoader extends Loader {
 				geometry = getGeometry( data.geometry );
 				material = getMaterial( data.material );
 
-				object = new BatchedMesh( data.maxGeometryCount, data.maxVertexCount, data.maxIndexCount, material );
+				object = new BatchedMesh( data.maxInstanceCount, data.maxVertexCount, data.maxIndexCount, material );
 				object.geometry = geometry;
 				object.perObjectFrustumCulled = data.perObjectFrustumCulled;
 				object.sortObjects = data.sortObjects;
@@ -938,7 +938,7 @@ class ObjectLoader extends Loader {
 
 				} );
 
-				object._maxGeometryCount = data.maxGeometryCount;
+				object._maxInstanceCount = data.maxInstanceCount;
 				object._maxVertexCount = data.maxVertexCount;
 				object._maxIndexCount = data.maxIndexCount;
 


### PR DESCRIPTION
Related issue: N/A

**Description**

`BatchMeshed.maxGeometryCount` was renamed to `maxInstanceCount` in https://github.com/mrdoob/three.js/pull/28462, but not all references were updated. This PR updates those references.