### PR TITLE
WebGPURenderer: remove useless interleavedBuffer update

### DIFF
--- a/examples/jsm/renderers/common/Geometries.js
+++ b/examples/jsm/renderers/common/Geometries.js
@@ -172,11 +172,13 @@ class Geometries extends DataMap {
 
 		const callId = this.info.render.calls;
 
-		if ( this.attributeCall.get( attribute ) !== callId ) {
+		const attributeData = attribute.isInterleavedBufferAttribute ? attribute.data : attribute;
+
+		if ( this.attributeCall.get( attributeData ) !== callId ) {
 
 			this.attributes.update( attribute, type );
 
-			this.attributeCall.set( attribute, callId );
+			this.attributeCall.set( attributeData, callId );
 
 		}
 


### PR DESCRIPTION
**Description**

When debug instanceMesh, I found that instanceMesh's interleavedBuffer updates multi times even buffer not changed in one frame. 
![3a54b98b0369e0b047a78598de3e35c](https://github.com/mrdoob/three.js/assets/13222615/ce938327-61ed-464c-8e37-3ab2e2e0728c)

The reason is Attribute is split into four parts to pass into shader
![1718724177546](https://github.com/mrdoob/three.js/assets/13222615/76a05331-3f7b-4e76-a915-7a990f274145)

But the interleavedBuffer is same, they should not update multi time.

So I change change the buffer update code in Geometries.js. 
![image](https://github.com/mrdoob/three.js/assets/13222615/15cf18f0-2d4c-4d70-8a9f-e59aa779aa01)

InterleavedBuffer has nothing can effect buffer update.
![image](https://github.com/mrdoob/three.js/assets/13222615/4b39e7e1-7232-4546-b637-836d0a6a9d06)

Like what has been done in WebGPUAttributeUtils.
![image](https://github.com/mrdoob/three.js/assets/13222615/9c286459-1ecf-4ef1-b905-6ff9511a13c9)

Finally, other codes that use interleavedBuffer will also get optimization.
![afee25a8fb81855b80c8b3a4edd23ad](https://github.com/mrdoob/three.js/assets/13222615/a3e82451-71b3-4ed0-8118-15f78082a7f3)




