### PR TITLE
WebGPURenderer: Fix uniform update tests

### DIFF
--- a/examples/jsm/renderers/common/UniformsGroup.js
+++ b/examples/jsm/renderers/common/UniformsGroup.js
@@ -9,6 +9,8 @@ class UniformsGroup extends UniformBuffer {
 
 		this.isUniformsGroup = true;
 
+		this._values = null;
+
 		// the order of uniforms in this array must match the order of uniforms in the shader
 
 		this.uniforms = [];
@@ -34,6 +36,18 @@ class UniformsGroup extends UniformBuffer {
 		}
 
 		return this;
+
+	}
+
+	get values() {
+
+		if ( this._values === null ) {
+
+			this._values = Array.from( this.buffer );
+
+		}
+
+		return this._values;
 
 	}
 
@@ -132,13 +146,15 @@ class UniformsGroup extends UniformBuffer {
 
 		let updated = false;
 
-		const a = this.buffer;
+		const a = this.values;
 		const v = uniform.getValue();
 		const offset = uniform.offset;
 
 		if ( a[ offset ] !== v ) {
 
-			a[ offset ] = v;
+			const b = this.buffer;
+
+			b[ offset ] = a[ offset ] = v;
 			updated = true;
 
 		}
@@ -151,14 +167,16 @@ class UniformsGroup extends UniformBuffer {
 
 		let updated = false;
 
-		const a = this.buffer;
+		const a = this.values;
 		const v = uniform.getValue();
 		const offset = uniform.offset;
 
 		if ( a[ offset + 0 ] !== v.x || a[ offset + 1 ] !== v.y ) {
 
-			a[ offset + 0 ] = v.x;
-			a[ offset + 1 ] = v.y;
+			const b = this.buffer;
+
+			b[ offset + 0 ] = a[ offset + 0 ] = v.x;
+			b[ offset + 1 ] = a[ offset + 1 ] = v.y;
 
 			updated = true;
 
@@ -172,15 +190,17 @@ class UniformsGroup extends UniformBuffer {
 
 		let updated = false;
 
-		const a = this.buffer;
+		const a = this.values;
 		const v = uniform.getValue();
 		const offset = uniform.offset;
 
 		if ( a[ offset + 0 ] !== v.x || a[ offset + 1 ] !== v.y || a[ offset + 2 ] !== v.z ) {
 
-			a[ offset + 0 ] = v.x;
-			a[ offset + 1 ] = v.y;
-			a[ offset + 2 ] = v.z;
+			const b = this.buffer;
+
+			b[ offset + 0 ] = a[ offset + 0 ] = v.x;
+			b[ offset + 1 ] = a[ offset + 1 ] = v.y;
+			b[ offset + 2 ] = a[ offset + 2 ] = v.z;
 
 			updated = true;
 
@@ -194,16 +214,18 @@ class UniformsGroup extends UniformBuffer {
 
 		let updated = false;
 
-		const a = this.buffer;
+		const a = this.values;
 		const v = uniform.getValue();
 		const offset = uniform.offset;
 
 		if ( a[ offset + 0 ] !== v.x || a[ offset + 1 ] !== v.y || a[ offset + 2 ] !== v.z || a[ offset + 4 ] !== v.w ) {
 
-			a[ offset + 0 ] = v.x;
-			a[ offset + 1 ] = v.y;
-			a[ offset + 2 ] = v.z;
-			a[ offset + 3 ] = v.w;
+			const b = this.buffer;
+
+			b[ offset + 0 ] = a[ offset + 0 ] = v.x;
+			b[ offset + 1 ] = a[ offset + 1 ] = v.y;
+			b[ offset + 2 ] = a[ offset + 2 ] = v.z;
+			b[ offset + 3 ] = a[ offset + 3 ] = v.w;
 
 			updated = true;
 
@@ -217,15 +239,17 @@ class UniformsGroup extends UniformBuffer {
 
 		let updated = false;
 
-		const a = this.buffer;
+		const a = this.values;
 		const c = uniform.getValue();
 		const offset = uniform.offset;
 
 		if ( a[ offset + 0 ] !== c.r || a[ offset + 1 ] !== c.g || a[ offset + 2 ] !== c.b ) {
 
-			a[ offset + 0 ] = c.r;
-			a[ offset + 1 ] = c.g;
-			a[ offset + 2 ] = c.b;
+			const b = this.buffer;
+
+			b[ offset + 0 ] = a[ offset + 0 ] = c.r;
+			b[ offset + 1 ] = a[ offset + 1 ] = c.g;
+			b[ offset + 2 ] = a[ offset + 2 ] = c.b;
 
 			updated = true;
 
@@ -239,7 +263,7 @@ class UniformsGroup extends UniformBuffer {
 
 		let updated = false;
 
-		const a = this.buffer;
+		const a = this.values;
 		const e = uniform.getValue().elements;
 		const offset = uniform.offset;
 
@@ -247,15 +271,17 @@ class UniformsGroup extends UniformBuffer {
 			a[ offset + 4 ] !== e[ 3 ] || a[ offset + 5 ] !== e[ 4 ] || a[ offset + 6 ] !== e[ 5 ] ||
 			a[ offset + 8 ] !== e[ 6 ] || a[ offset + 9 ] !== e[ 7 ] || a[ offset + 10 ] !== e[ 8 ] ) {
 
-			a[ offset + 0 ] = e[ 0 ];
-			a[ offset + 1 ] = e[ 1 ];
-			a[ offset + 2 ] = e[ 2 ];
-			a[ offset + 4 ] = e[ 3 ];
-			a[ offset + 5 ] = e[ 4 ];
-			a[ offset + 6 ] = e[ 5 ];
-			a[ offset + 8 ] = e[ 6 ];
-			a[ offset + 9 ] = e[ 7 ];
-			a[ offset + 10 ] = e[ 8 ];
+			const b = this.buffer;
+
+			b[ offset + 0 ] = a[ offset + 0 ] = e[ 0 ];
+			b[ offset + 1 ] = a[ offset + 1 ] = e[ 1 ];
+			b[ offset + 2 ] = a[ offset + 2 ] = e[ 2 ];
+			b[ offset + 4 ] = a[ offset + 4 ] = e[ 3 ];
+			b[ offset + 5 ] = a[ offset + 5 ] = e[ 4 ];
+			b[ offset + 6 ] = a[ offset + 6 ] = e[ 5 ];
+			b[ offset + 8 ] = a[ offset + 8 ] = e[ 6 ];
+			b[ offset + 9 ] = a[ offset + 9 ] = e[ 7 ];
+			b[ offset + 10 ] = a[ offset + 10 ] = e[ 8 ];
 
 			updated = true;
 
@@ -269,18 +295,30 @@ class UniformsGroup extends UniformBuffer {
 
 		let updated = false;
 
-		const a = this.buffer;
+		const a = this.values;
 		const e = uniform.getValue().elements;
 		const offset = uniform.offset;
 
 		if ( arraysEqual( a, e, offset ) === false ) {
 
-			a.set( e, offset );
+			const b = this.buffer;
+			b.set( e, offset );
+			setArray( a, e, offset );
 			updated = true;
 
 		}
 
 		return updated;
+
+	}
+
+}
+
+function setArray( a, b, offset ) {
+
+	for ( let i = 0, l = b.length; i < l; i ++ ) {
+
+		a[ offset + i ] = b[ i ];
 
 	}
 

--- a/examples/webgpu_sandbox.html
+++ b/examples/webgpu_sandbox.html
@@ -201,6 +201,9 @@
 
 				}
 
+				window.upCount = 0;
+				console.log( 'frame' );
+
 				renderer.render( scene, camera );
 
 			}

--- a/examples/webgpu_sandbox.html
+++ b/examples/webgpu_sandbox.html
@@ -201,9 +201,6 @@
 
 				}
 
-				window.upCount = 0;
-				console.log( 'frame' );
-
 				renderer.render( scene, camera );
 
 			}


### PR DESCRIPTION
**Description**

This PR fixed a precision issue that had been detected for a while, the uniforms were always updated because the default numerical precision of JS is 64-bit, while the comparison buffer is 32-bit, which resulted in something like

```js
console.log( new Float32Array( [ Math.PI ] )[ 0 ] === Math.PI ); // false

// instead of
console.log( [ Math.PI ][ 0 ] === Math.PI ) // true
```