### PR TITLE
Examples: Fix onWindowResize

### DIFF
--- a/examples/webgpu_tsl_interoperability.html
+++ b/examples/webgpu_tsl_interoperability.html
@@ -46,8 +46,6 @@
 
 			function onWindowResize() {
 
-				camera.aspect = window.innerWidth / window.innerHeight;
-				camera.updateProjectionMatrix();
 				renderer.setSize( window.innerWidth, window.innerHeight );
 
 			}
@@ -92,7 +90,7 @@
 						vUv: vec2f,
 						tex: texture_2d<f32>,
 						texSampler: sampler,
-						crtWidth: f32, 
+						crtWidth: f32,
 						crtHeight: f32,
 						cellOffset: f32,
 						cellSize: f32,
@@ -105,7 +103,7 @@
 					) -> vec3<f32> {
 						// Convert uv into map of pixels
 						var pixel = ( vUv * 0.5 + 0.5 ) * vec2<f32>(
-							crtWidth, 
+							crtWidth,
 							crtHeight
 						);
 						// Coordinate for each cell in the pixel map
@@ -130,8 +128,8 @@
 						let ind = floor( subcoord.x ) % 3;
 
 						var maskColor = vec3<f32>(
-							f32( ind == 0.0 ), 
-							f32( ind == 1.0 ), 
+							f32( ind == 0.0 ),
+							f32( ind == 1.0 ),
 							f32( ind == 2.0 )
 						) * 3.0;
 


### PR DESCRIPTION
Related issue: N/A

**Description**

The camera is an `OrthographicCamera`, not a `PerspectiveCamera`, so setting the `aspect` property is ineffectual. The orthographic camera's planes are not based on the window's aspect ratio, so no updates to the camera are necessary on window resize.