### PR TITLE
GLTFLoader: Fix safariVersion not found on chrome iOS

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2586,10 +2586,14 @@ class GLTFParser {
 
 		if ( typeof navigator !== 'undefined' ) {
 
-			isSafari = /^((?!chrome|android).)*safari/i.test( navigator.userAgent ) === true;
-			safariVersion = isSafari ? navigator.userAgent.match( /Version\/(\d+)/ )[ 1 ] : - 1;
-			isFirefox = navigator.userAgent.indexOf( 'Firefox' ) > - 1;
-			firefoxVersion = isFirefox ? navigator.userAgent.match( /Firefox\/([0-9]+)\./ )[ 1 ] : - 1;
+			const userAgent = navigator.userAgent;
+
+			isSafari = /^((?!chrome|android).)*safari/i.test( userAgent ) === true;
+			const safariMatch = userAgent.match( /Version\/(\d+)/ );
+			safariVersion = isSafari && safariMatch ? parseInt( safariMatch[ 1 ], 10 ) : - 1;
+
+			isFirefox = userAgent.indexOf( 'Firefox' ) > - 1;
+			firefoxVersion = isFirefox ? userAgent.match( /Firefox\/([0-9]+)\./ )[ 1 ] : - 1;
 
 		}
 


### PR DESCRIPTION
Related issue: #28560

**Description**
![Screenshot 2024-06-21 at 16 31 08](https://github.com/mrdoob/three.js/assets/15867665/b814a9d2-f4d3-4e24-8f53-2331560f2389)
Issue #28560 broke the GLTFLoader on Chrome for iOS because the user agent string is different:
`"Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/6.... (KHTML, like Gecko) CriOS/1...80 Mobile/15... Safari/604.3" = $1`

It is unclear if it's possible to identify the Safari version for Chrome, I think it would be possible using the OS version as the Safari browser version is related to the OS version on iOS.

In the meantime, this fix patches the GLTFLoader issue. 


*This contribution is funded by [Utsubo](https://utsubo.com)*
