### PR TITLE
WebGPURenderer: NodeMaterial - Fix `fog=false` and snow example

### DIFF
--- a/examples/jsm/nodes/materials/NodeMaterial.js
+++ b/examples/jsm/nodes/materials/NodeMaterial.js
@@ -437,9 +437,13 @@ class NodeMaterial extends Material {
 
 		// FOG
 
-		const fogNode = builder.fogNode;
+		if ( this.fog === true ) {
 
-		if ( fogNode ) outputNode = vec4( fogNode.mix( outputNode.rgb, fogNode.colorNode ), outputNode.a );
+			const fogNode = builder.fogNode;
+
+			if ( fogNode ) outputNode = vec4( fogNode.mix( outputNode.rgb, fogNode.colorNode ), outputNode.a );
+
+		}
 
 		return outputNode;
 

--- a/examples/jsm/renderers/common/Backend.js
+++ b/examples/jsm/renderers/common/Backend.js
@@ -42,8 +42,6 @@ class Backend {
 
 	createBindings( renderObject ) { }
 
-	_setupBindingsIndexes( renderObject ) { }
-
 	// pipeline
 
 	createRenderPipeline( renderObject ) { }

--- a/examples/webgpu_compute_particles_snow.html
+++ b/examples/webgpu_compute_particles_snow.html
@@ -97,6 +97,8 @@
 
 				collisionPosRT = new THREE.RenderTarget( 1024, 1024 );
 				collisionPosRT.texture.type = THREE.HalfFloatType;
+				collisionPosRT.texture.magFilter = THREE.NearestFilter;
+				collisionPosRT.texture.minFilter = THREE.NearestFilter;
 
 				collisionPosMaterial = new MeshBasicNodeMaterial();
 				collisionPosMaterial.fog = false;


### PR DESCRIPTION
**Description**

Fix `material.fog=false` and fix snow example, when the snow hit in the tree.