### PR TITLE
Editor: Remove reference to `targetInverse`.

### DIFF
--- a/editor/js/Sidebar.Object.js
+++ b/editor/js/Sidebar.Object.js
@@ -697,8 +697,7 @@ function SidebarObject( editor ) {
 
 	function updateTransformRows( object ) {
 
-		if ( object.isLight ||
-		   ( object.isObject3D && object.userData.targetInverse ) ) {
+		if ( object.isLight ) {
 
 			objectRotationRow.setDisplay( 'none' );
 			objectScaleRow.setDisplay( 'none' );


### PR DESCRIPTION
Related issue: -

**Description**

Removes a reference to `Object3D.userData.targetInverse` in `Sidebar.Object` which seemed to be part of early implementations of `DirectionalLight` and `SpotLight`.
