### PR TITLE
WebGPURenderer: Fix StorageBuffer fallback in WebGLBackend

### DIFF
--- a/examples/jsm/renderers/webgl/nodes/GLSLNodeBuilder.js
+++ b/examples/jsm/renderers/webgl/nodes/GLSLNodeBuilder.js
@@ -1,4 +1,4 @@
-import { MathNode, GLSLNodeParser, NodeBuilder, UniformNode, vectorComponents } from '../../../nodes/Nodes.js';
+import { MathNode, GLSLNodeParser, NodeBuilder, TextureNode, vectorComponents } from '../../../nodes/Nodes.js';
 
 import NodeUniformBuffer from '../../common/nodes/NodeUniformBuffer.js';
 import NodeUniformsGroup from '../../common/nodes/NodeUniformsGroup.js';
@@ -157,7 +157,7 @@ ${ flowData.code }
 			pboTexture.needsUpdate = true;
 			pboTexture.isPBOTexture = true;
 
-			const pbo = new UniformNode( pboTexture );
+			const pbo = new TextureNode( pboTexture );
 			pbo.setPrecision( 'high' );
 
 			attribute.pboNode = pbo;


### PR DESCRIPTION
Related issue: #28705

**Description**

The #28705 PR highlighted an existing issue where the PBO system used as the StorageBuffer fallback in the WebGLBackend was using UniformNode instead of TextureNode:
![image](https://github.com/mrdoob/three.js/assets/15867665/b0d81c47-9bb6-4359-8315-a959ae1f7336)


<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Utsubo](https://utsubo.com)*
