### PR TITLE
Examples: replace  "./jsm/"  in import statements to "three/addon"

### DIFF
--- a/examples/webgl_animation_skinning_ik.html
+++ b/examples/webgl_animation_skinning_ik.html
@@ -35,7 +35,7 @@
 		import { TransformControls } from 'three/addons/controls/TransformControls.js';
 		import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 		import { DRACOLoader } from 'three/addons/loaders/DRACOLoader.js';
-		import { CCDIKSolver, CCDIKHelper } from './jsm/animation/CCDIKSolver.js';
+		import { CCDIKSolver, CCDIKHelper } from 'three/addons/animation/CCDIKSolver.js';
 		import Stats from 'three/addons/libs/stats.module.js';
 		import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 

--- a/examples/webgl_geometry_sdf.html
+++ b/examples/webgl_geometry_sdf.html
@@ -24,7 +24,7 @@
 
 		<script type="module">
 			import * as THREE from 'three';
-			import { OrbitControls } from './jsm/controls/OrbitControls.js';
+			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { SDFGeometryGenerator } from 'three/addons/geometries/SDFGeometryGenerator.js';
 			import Stats from 'three/addons/libs/stats.module.js';
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';

--- a/examples/webgpu_lights_ies_spotlight.html
+++ b/examples/webgpu_lights_ies_spotlight.html
@@ -33,9 +33,9 @@
 
 			import IESSpotLight from 'three/addons/lights/IESSpotLight.js';
 
-			import { OrbitControls } from './jsm/controls/OrbitControls.js';
+			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 
-			import { IESLoader } from './jsm/loaders/IESLoader.js';
+			import { IESLoader } from 'three/addons/loaders/IESLoader.js';
 
 			let renderer, scene, camera;
 			let lights;

--- a/examples/webgpu_loader_materialx.html
+++ b/examples/webgpu_loader_materialx.html
@@ -31,10 +31,10 @@
 
 			import * as THREE from 'three';
 
-			import { MaterialXLoader } from './jsm/loaders/MaterialXLoader.js';
-			import { OrbitControls } from './jsm/controls/OrbitControls.js';
-			import { RGBELoader } from './jsm/loaders/RGBELoader.js';
-			import { GLTFLoader } from './jsm/loaders/GLTFLoader.js';
+			import { MaterialXLoader } from 'three/addons/loaders/MaterialXLoader.js';
+			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import { RGBELoader } from 'three/addons/loaders/RGBELoader.js';
+			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 
 			import WebGPURenderer from 'three/addons/renderers/webgpu/WebGPURenderer.js';
 

--- a/examples/webgpu_shadertoy.html
+++ b/examples/webgpu_shadertoy.html
@@ -169,9 +169,9 @@
 			import * as THREE from 'three';
 			import * as Nodes from 'three/nodes';
 
-			import Transpiler from './jsm/transpiler/Transpiler.js';
-			import ShaderToyDecoder from './jsm/transpiler/ShaderToyDecoder.js';
-			import TSLEncoder from './jsm/transpiler/TSLEncoder.js';
+			import Transpiler from 'three/addons/transpiler/Transpiler.js';
+			import ShaderToyDecoder from 'three/addons/transpiler/ShaderToyDecoder.js';
+			import TSLEncoder from 'three/addons/transpiler/TSLEncoder.js';
 
 			import WebGPU from 'three/addons/capabilities/WebGPU.js';
 			import WebGL from 'three/addons/capabilities/WebGL.js';

--- a/examples/webgpu_tsl_transpiler.html
+++ b/examples/webgpu_tsl_transpiler.html
@@ -40,9 +40,9 @@
 
 		<script type="module">
 
-			import Transpiler from './jsm/transpiler/Transpiler.js';
-			import GLSLDecoder from './jsm/transpiler/GLSLDecoder.js';
-			import TSLEncoder from './jsm/transpiler/TSLEncoder.js';
+			import Transpiler from 'three/addons/transpiler/Transpiler.js';
+			import GLSLDecoder from 'three/addons/transpiler/GLSLDecoder.js';
+			import TSLEncoder from 'three/addons/transpiler/TSLEncoder.js';
 
 			init();
 


### PR DESCRIPTION
**Description**

They are equivalent, but the replaced is more convenient for reusing sample code elsewhere.
