### PR TITLE
WebGPURenderer: Fix storage buffer example

### DIFF
--- a/examples/jsm/nodes/core/NodeBuilder.js
+++ b/examples/jsm/nodes/core/NodeBuilder.js
@@ -30,7 +30,7 @@ import ChainMap from '../../renderers/common/ChainMap.js';
 
 import PMREMGenerator from '../../renderers/common/extras/PMREMGenerator.js';
 
-const bindGroupsCache = new ChainMap();
+const rendererCache = new WeakMap();
 
 const typeFromLength = new Map( [
 	[ 2, 'vec2' ],
@@ -122,6 +122,22 @@ class NodeBuilder {
 
 	}
 
+	getBingGroupsCache() {
+
+		let bindGroupsCache = rendererCache.get( this.renderer );
+
+		if ( bindGroupsCache === undefined ) {
+
+			bindGroupsCache = new ChainMap();
+
+			rendererCache.set( this.renderer, bindGroupsCache );
+
+		}
+
+		return bindGroupsCache;
+
+	}
+
 	createRenderTarget( width, height, options ) {
 
 		return new RenderTarget( width, height, options );
@@ -149,6 +165,8 @@ class NodeBuilder {
 	}
 
 	_getBindGroup( groupName, bindings ) {
+
+		const bindGroupsCache = this.getBingGroupsCache();
 
 		// cache individual uniforms group
 

--- a/examples/jsm/nodes/core/NodeBuilder.js
+++ b/examples/jsm/nodes/core/NodeBuilder.js
@@ -30,7 +30,7 @@ import ChainMap from '../../renderers/common/ChainMap.js';
 
 import PMREMGenerator from '../../renderers/common/extras/PMREMGenerator.js';
 
-const rendererCache = new WeakMap();
+const bindGroupsCache = new ChainMap();
 
 const typeFromLength = new Map( [
 	[ 2, 'vec2' ],
@@ -122,22 +122,6 @@ class NodeBuilder {
 
 	}
 
-	getBingGroupsCache() {
-
-		let bindGroupsCache = rendererCache.get( this.renderer );
-
-		if ( bindGroupsCache === undefined ) {
-
-			bindGroupsCache = new ChainMap();
-
-			rendererCache.set( this.renderer, bindGroupsCache );
-
-		}
-
-		return bindGroupsCache;
-
-	}
-
 	createRenderTarget( width, height, options ) {
 
 		return new RenderTarget( width, height, options );
@@ -165,8 +149,6 @@ class NodeBuilder {
 	}
 
 	_getBindGroup( groupName, bindings ) {
-
-		const bindGroupsCache = this.getBingGroupsCache();
 
 		// cache individual uniforms group
 

--- a/examples/webgpu_storage_buffer.html
+++ b/examples/webgpu_storage_buffer.html
@@ -78,10 +78,10 @@
 
 				// texture
 
-				const size = 1024; // non power of two buffer size is not well supported in WebGPU
+				const size = 32; // non power of two buffer size is not well supported in WebGPU
+				const barCount = 32;
 
 				const type = [ 'float', 'vec2', 'vec3', 'vec4' ];
-
 
 				const arrayBufferNodes = [];
 
@@ -110,7 +110,7 @@
 
 					for ( let i = 0; i < type.length; i ++ ) {
 
-						const invertIndex = arrayBufferNodes[ i ].element( uint( size ).sub( instanceIndex ) );
+						const invertIndex = arrayBufferNodes[ i ].element( uint( size - 1 ).sub( instanceIndex ) );
 						arrayBufferNodes[ i ].element( instanceIndex ).assign( invertIndex );
 
 					}
@@ -140,7 +140,7 @@
 					If( uv().y.greaterThan( 0.0 ), () => {
 
 						const indexValue = arrayBufferNodes[ 0 ].element( index ).toVar();
-						const value = float( indexValue ).div( float( size ) ).mul( 20 ).floor().div( 20 );
+						const value = float( indexValue ).div( float( size ) ).mul( barCount ).floor().div( barCount );
 			
 						color.assign( vec3( value, 0, 0 ) );
 
@@ -149,7 +149,7 @@
 					If( uv().y.greaterThan( 0.25 ), () => {
 
 						const indexValue = arrayBufferNodes[ 1 ].element( index ).toVar();
-						const value = float( indexValue ).div( float( size ) ).mul( 20 ).floor().div( 20 );
+						const value = float( indexValue ).div( float( size ) ).mul( barCount ).floor().div( barCount );
 			
 						color.assign( vec3( 0, value, 0 ) );
 
@@ -158,7 +158,7 @@
 					If( uv().y.greaterThan( 0.5 ), () => {
 
 						const indexValue = arrayBufferNodes[ 2 ].element( index ).toVar();
-						const value = float( indexValue ).div( float( size ) ).mul( 20 ).floor().div( 20 );
+						const value = float( indexValue ).div( float( size ) ).mul( barCount ).floor().div( barCount );
 			
 						color.assign( vec3( 0, 0, value ) );
 
@@ -167,7 +167,7 @@
 					If( uv().y.greaterThan( 0.75 ), () => {
 
 						const indexValue = arrayBufferNodes[ 3 ].element( index ).toVar();
-						const value = float( indexValue ).div( float( size ) ).mul( 20 ).floor().div( 20 );
+						const value = float( indexValue ).div( float( size ) ).mul( barCount ).floor().div( barCount );
 			
 						color.assign( vec3( value, value, value ) );
 


### PR DESCRIPTION
**Description**

After a few seconds we can see overlapping pixels in the webgpu version, this is because ( size - instanceIndex ) will return the total value of the array and not the last index, ( size - 1 ) should fix this. There was an optimization in the amount of computations performed.

![image](https://github.com/mrdoob/three.js/assets/502810/8ce877ca-c376-494a-8b05-e925cab4791b)

/cc @RenaudRohlinger 
