### PR TITLE
WebGPURenderer: Bind groups cache per renderer

### DIFF
--- a/examples/jsm/nodes/core/NodeBuilder.js
+++ b/examples/jsm/nodes/core/NodeBuilder.js
@@ -30,7 +30,7 @@ import ChainMap from '../../renderers/common/ChainMap.js';
 
 import PMREMGenerator from '../../renderers/common/extras/PMREMGenerator.js';
 
-const bindGroupsCache = new ChainMap();
+const rendererCache = new WeakMap();
 
 const typeFromLength = new Map( [
 	[ 2, 'vec2' ],
@@ -122,6 +122,22 @@ class NodeBuilder {
 
 	}
 
+	getBingGroupsCache() {
+
+		let bindGroupsCache = rendererCache.get( this.renderer );
+
+		if ( bindGroupsCache === undefined ) {
+
+			bindGroupsCache = new ChainMap();
+
+			rendererCache.set( this.renderer, bindGroupsCache );
+
+		}
+
+		return bindGroupsCache;
+
+	}
+
 	createRenderTarget( width, height, options ) {
 
 		return new RenderTarget( width, height, options );
@@ -149,6 +165,8 @@ class NodeBuilder {
 	}
 
 	_getBindGroup( groupName, bindings ) {
+
+		const bindGroupsCache = this.getBingGroupsCache();
 
 		// cache individual uniforms group
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/28705#issuecomment-2184040449, https://github.com/mrdoob/three.js/pull/28705

**Description**

Caching bing groups per renderer should bring more stability.