### PR TITLE
TSL: Add isWebGPU method in the NodeBuilder

### DIFF
--- a/examples/jsm/nodes/core/NodeBuilder.js
+++ b/examples/jsm/nodes/core/NodeBuilder.js
@@ -469,6 +469,12 @@ class NodeBuilder {
 
 	}
 
+	isWebGPU() {
+
+		return true;
+
+	}
+
 	generateTexture( /* texture, textureProperty, uvSnippet */ ) {
 
 		console.warn( 'Abstract function.' );

--- a/examples/jsm/renderers/webgl/nodes/GLSLNodeBuilder.js
+++ b/examples/jsm/renderers/webgl/nodes/GLSLNodeBuilder.js
@@ -649,6 +649,12 @@ ${ flowData.code }
 
 	}
 
+	isWebGPU() {
+
+		return false;
+
+	}
+
 	registerTransform( varyingName, attributeNode ) {
 
 		this.transforms.push( { varyingName, attributeNode } );

--- a/examples/jsm/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/examples/jsm/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -627,6 +627,12 @@ ${ flowData.code }
 
 	}
 
+	isWebGPU() {
+
+		return true;
+
+	}
+
 	getBuiltins( shaderStage ) {
 
 		const snippets = [];


### PR DESCRIPTION
Related issue: #28731 

**Description**

Related comment: https://github.com/mrdoob/three.js/issues/28731#issuecomment-2186342825

GLSLNodeBuilder can only be created in the WebGLBackend so this should be good enough to determine if we're in the WebGPU or WebGL Backend.

/cc @Mugen87 @sunag


*This contribution is funded by [Utsubo](https://utsubo.com)*