### PR TITLE
Revert "TSL: Add isWebGPU method in the NodeBuilder (#28734)"

### DIFF
--- a/examples/jsm/nodes/core/NodeBuilder.js
+++ b/examples/jsm/nodes/core/NodeBuilder.js
@@ -469,12 +469,6 @@ class NodeBuilder {
 
 	}
 
-	isWebGPU() {
-
-		return true;
-
-	}
-
 	generateTexture( /* texture, textureProperty, uvSnippet */ ) {
 
 		console.warn( 'Abstract function.' );

--- a/examples/jsm/renderers/webgl/nodes/GLSLNodeBuilder.js
+++ b/examples/jsm/renderers/webgl/nodes/GLSLNodeBuilder.js
@@ -649,12 +649,6 @@ ${ flowData.code }
 
 	}
 
-	isWebGPU() {
-
-		return false;
-
-	}
-
 	registerTransform( varyingName, attributeNode ) {
 
 		this.transforms.push( { varyingName, attributeNode } );

--- a/examples/jsm/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/examples/jsm/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -627,12 +627,6 @@ ${ flowData.code }
 
 	}
 
-	isWebGPU() {
-
-		return true;
-
-	}
-
 	getBuiltins( shaderStage ) {
 
 		const snippets = [];


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/28731#issuecomment-2186912338

**Description**

I think we can remove it once we can access the renderer, for example:

```js
generate( builder ) {

	if ( builder.renderer.coordinateSystem === WebGPUCoordinateSystem ) {


	}

}
```