### PR TITLE
WebGPURenderer: Improve performances for trackTimestamp in WebGPU

### DIFF
--- a/examples/jsm/renderers/webgpu/WebGPUBackend.js
+++ b/examples/jsm/renderers/webgpu/WebGPUBackend.js
@@ -1120,44 +1120,56 @@ class WebGPUBackend extends Backend {
 		const renderContextData = this.get( renderContext );
 
 		const size = 2 * BigInt64Array.BYTES_PER_ELEMENT;
-		const resolveBuffer = this.device.createBuffer( {
-			size,
-			usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.COPY_SRC,
-		} );
 
-		const resultBuffer = this.device.createBuffer( {
-			size,
-			usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
-		} );
+		if ( renderContextData.currentTimestampQueryBuffers === undefined ) {
+
+			renderContextData.currentTimestampQueryBuffers = {
+				resolveBuffer: this.device.createBuffer({
+					label: 'timestamp resolve buffer',
+					size: size,
+					usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.COPY_SRC,
+				}),
+				resultBuffer: this.device.createBuffer({
+					label: 'timestamp result buffer',
+					size: size,
+					usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+				}),
+				isMappingPending: false,
+			}
+
+		}
+
+		const { resolveBuffer, resultBuffer, isMappingPending } = renderContextData.currentTimestampQueryBuffers
+
+
+        if ( isMappingPending === true ) return;
 
 		encoder.resolveQuerySet( renderContextData.timeStampQuerySet, 0, 2, resolveBuffer, 0 );
 		encoder.copyBufferToBuffer( resolveBuffer, 0, resultBuffer, 0, size );
 
-		renderContextData.currentTimestampQueryBuffer = resultBuffer;
-
 	}
 
-	async resolveTimestampAsync(renderContext, type = 'render') {
-		if (!this.hasFeature(GPUFeatureName.TimestampQuery) || !this.trackTimestamp) return;
+	async resolveTimestampAsync( renderContext, type = 'render' ) {
+
+		if ( ! this.hasFeature( GPUFeatureName.TimestampQuery ) || !this.trackTimestamp ) return;
 	
 		const renderContextData = this.get(renderContext);
-		const { currentTimestampQueryBuffer } = renderContextData;
-	
-		if (currentTimestampQueryBuffer === undefined) return;
 
-		const buffer = currentTimestampQueryBuffer;
+		if ( renderContextData.currentTimestampQueryBuffers === undefined ) return;
 
-		try {
-			await buffer.mapAsync(GPUMapMode.READ);
-			const times = new BigUint64Array(buffer.getMappedRange());
-			const duration = Number(times[1] - times[0]) / 1000000;
-			this.renderer.info.updateTimestamp(type, duration);
-		} catch (error) {
-			console.error(`Error mapping buffer: ${error}`);
-			// Optionally handle the error, e.g., re-queue the buffer or skip it
-		} finally {
-			buffer.unmap(); 
-		}
+		const { resultBuffer, isMappingPending } = renderContextData.currentTimestampQueryBuffers
+
+        if ( isMappingPending === true ) return;
+
+        renderContextData.currentTimestampQueryBuffers.isMappingPending = true;
+
+		await resultBuffer.mapAsync( GPUMapMode.READ );
+		const times = new BigUint64Array( resultBuffer.getMappedRange() );
+		const duration = Number( times[ 1 ] - times[ 0 ] ) / 1000000;
+		this.renderer.info.updateTimestamp( type, duration );
+		resultBuffer.unmap();
+		renderContextData.currentTimestampQueryBuffers.isMappingPending = false;
+
 	}
 	
 

--- a/examples/jsm/renderers/webgpu/WebGPUBackend.js
+++ b/examples/jsm/renderers/webgpu/WebGPUBackend.js
@@ -1151,23 +1151,26 @@ class WebGPUBackend extends Backend {
 
 	async resolveTimestampAsync( renderContext, type = 'render' ) {
 
-		if ( ! this.hasFeature( GPUFeatureName.TimestampQuery ) || !this.trackTimestamp ) return;
+		if ( ! this.hasFeature( GPUFeatureName.TimestampQuery ) || ! this.trackTimestamp ) return;
 	
 		const renderContextData = this.get(renderContext);
 
 		if ( renderContextData.currentTimestampQueryBuffers === undefined ) return;
 
-		const { resultBuffer, isMappingPending } = renderContextData.currentTimestampQueryBuffers
+		const { resultBuffer, isMappingPending } = renderContextData.currentTimestampQueryBuffers;
 
         if ( isMappingPending === true ) return;
 
         renderContextData.currentTimestampQueryBuffers.isMappingPending = true;
 
 		await resultBuffer.mapAsync( GPUMapMode.READ );
+
 		const times = new BigUint64Array( resultBuffer.getMappedRange() );
 		const duration = Number( times[ 1 ] - times[ 0 ] ) / 1000000;
+
 		this.renderer.info.updateTimestamp( type, duration );
 		resultBuffer.unmap();
+
 		renderContextData.currentTimestampQueryBuffers.isMappingPending = false;
 
 	}


### PR DESCRIPTION
**Description**

This PR fixes 2 performances issue in the `trackTimestamp` feature in the WebGPU Backend. It Reuses the buffer each frame and do not stack the query if one is already trying to get resolved.

By skipping timestamp queries when a previous one is still resolving, we may miss some frame data (visible as small spikes in the GPU monitor). However, this prevents potential stalls in the rendering pipeline caused by accumulating unresolved async operations.
This tradeoff ensures smoother overall performance, especially in complex scenes where the overhead of constant timestamp querying could significantly impact frame rates and so make meaningless the trackTimestamp feature.


It was especially noticeable on complex simulations with multiple compute shaders in the pipeline. For example:

Before PR:
![Screenshot 2024-06-25 at 18 46 09](https://github.com/mrdoob/three.js/assets/15867665/f48b6c45-f6f9-46b0-854d-798d589ab751)

After PR:
![Screenshot 2024-06-25 at 18 46 27](https://github.com/mrdoob/three.js/assets/15867665/700f64e1-db2e-4257-8b90-d27a8fa6c706)


<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Utsubo](https://utsubo.com)*
