### PR TITLE
SSAOPass: Remove one copy pass.

### DIFF
--- a/examples/jsm/postprocessing/SSAOPass.js
+++ b/examples/jsm/postprocessing/SSAOPass.js
@@ -39,6 +39,7 @@ class SSAOPass extends Pass {
 		this.height = ( height !== undefined ) ? height : 512;
 
 		this.clear = true;
+		this.needsSwap = false;
 
 		this.camera = camera;
 		this.scene = scene;
@@ -229,13 +230,9 @@ class SSAOPass extends Pass {
 
 			case SSAOPass.OUTPUT.Default:
 
-				this.copyMaterial.uniforms[ 'tDiffuse' ].value = readBuffer.texture;
-				this.copyMaterial.blending = NoBlending;
-				this.renderPass( renderer, this.copyMaterial, this.renderToScreen ? null : writeBuffer );
-
 				this.copyMaterial.uniforms[ 'tDiffuse' ].value = this.blurRenderTarget.texture;
 				this.copyMaterial.blending = CustomBlending;
-				this.renderPass( renderer, this.copyMaterial, this.renderToScreen ? null : writeBuffer );
+				this.renderPass( renderer, this.copyMaterial, this.renderToScreen ? null : readBuffer );
 
 				break;
 


### PR DESCRIPTION
Related issue: -

**Description**

Similar to `SAOPass` the AO is now blended on top of the existing read buffer which makes one copy pass redundant and thus improves performance.

The alternative would be to implement a composite/blend shader that blends `readBuffer.texture` with the AO into the write buffer. However, always reading from `readBuffer` and writing into `writeBuffer` has performance issues since copies are required like in the original version of `SSAOPass`. For certain FX passes, it makes sense if they blend/write their result on top of the "source" data without unnecessary copy or swap operations.