### PR TITLE
WebGPURenderer: Fix Light+NormalMaterial

### DIFF
--- a/examples/jsm/nodes/materials/MeshMatcapNodeMaterial.js
+++ b/examples/jsm/nodes/materials/MeshMatcapNodeMaterial.js
@@ -14,9 +14,9 @@ class MeshMatcapNodeMaterial extends NodeMaterial {
 
 		super();
 
-		this.isMeshMatcapNodeMaterial = true;
-
 		this.lights = false;
+
+		this.isMeshMatcapNodeMaterial = true;
 
 		this.setDefaultValues( defaultValues );
 

--- a/examples/jsm/nodes/materials/MeshNormalNodeMaterial.js
+++ b/examples/jsm/nodes/materials/MeshNormalNodeMaterial.js
@@ -15,6 +15,8 @@ class MeshNormalNodeMaterial extends NodeMaterial {
 
 		super();
 
+		this.lights = false;
+
 		this.isMeshNormalNodeMaterial = true;
 
 		this.setDefaultValues( defaultValues );


### PR DESCRIPTION
Related issue: Closes https://github.com/mrdoob/three.js/issues/28736

**Description**

Fix missing `.lights=false`.