### PR TITLE
WebGPURenderer: Improve performance tracking logic for better accuracy

### DIFF
--- a/examples/jsm/renderers/common/Info.js
+++ b/examples/jsm/renderers/common/Info.js
@@ -9,17 +9,22 @@ class Info {
 
 		this.render = {
 			calls: 0,
+			frameCalls: 0,
 			drawCalls: 0,
 			triangles: 0,
 			points: 0,
 			lines: 0,
-			timestamp: 0
+			timestamp: 0,
+			previousFrameCalls: 0,
+			timestampCalls: 0
 		};
 
 		this.compute = {
 			calls: 0,
-			computeCalls: 0,
-			timestamp: 0
+			frameCalls: 0,
+			timestamp: 0,
+			previousFrameCalls: 0,
+			timestampCalls: 0
 		};
 
 		this.memory = {
@@ -59,21 +64,44 @@ class Info {
 
 	updateTimestamp( type, time ) {
 
+		if ( this[ type ].timestampCalls === 0 ) {
+
+			this[ type ].timestamp = 0;
+
+		}
+
+
 		this[ type ].timestamp += time;
+
+		this[ type ].timestampCalls ++;
+
+
+		if ( this[ type ].timestampCalls >= this[ type ].previousFrameCalls ) {
+
+			this[ type ].timestampCalls = 0;
+
+		}
+
 
 	}
 
 	reset() {
 
+		const previousRenderFrameCalls = this.render.frameCalls;
+		this.render.previousFrameCalls = previousRenderFrameCalls;
+
+		const previousComputeFrameCalls = this.compute.frameCalls;
+		this.compute.previousFrameCalls = previousComputeFrameCalls;
+
+
 		this.render.drawCalls = 0;
-		this.compute.computeCalls = 0;
+		this.render.frameCalls = 0;
+		this.compute.frameCalls = 0;
 
 		this.render.triangles = 0;
 		this.render.points = 0;
 		this.render.lines = 0;
 
-		this.render.timestamp = 0;
-		this.compute.timestamp = 0;
 
 	}
 

--- a/examples/jsm/renderers/common/Renderer.js
+++ b/examples/jsm/renderers/common/Renderer.js
@@ -521,6 +521,7 @@ class Renderer {
 
 		this.info.calls ++;
 		this.info.render.calls ++;
+		this.info.render.frameCalls ++;
 
 		nodeFrame.renderId = this.info.calls;
 
@@ -1079,7 +1080,7 @@ class Renderer {
 
 		this.info.calls ++;
 		this.info.compute.calls ++;
-		this.info.compute.computeCalls ++;
+		this.info.compute.frameCalls ++;
 
 		nodeFrame.renderId = this.info.calls;
 

--- a/examples/jsm/renderers/webgpu/WebGPUBackend.js
+++ b/examples/jsm/renderers/webgpu/WebGPUBackend.js
@@ -1163,15 +1163,17 @@ class WebGPUBackend extends Backend {
 
         renderContextData.currentTimestampQueryBuffers.isMappingPending = true;
 
-		await resultBuffer.mapAsync( GPUMapMode.READ );
+		resultBuffer.mapAsync( GPUMapMode.READ ).then( () => {
+			const times = new BigUint64Array( resultBuffer.getMappedRange() );
+			const duration = Number( times[ 1 ] - times[ 0 ] ) / 1000000;
 
-		const times = new BigUint64Array( resultBuffer.getMappedRange() );
-		const duration = Number( times[ 1 ] - times[ 0 ] ) / 1000000;
 
-		this.renderer.info.updateTimestamp( type, duration );
-		resultBuffer.unmap();
+			this.renderer.info.updateTimestamp( type, duration );
 
-		renderContextData.currentTimestampQueryBuffers.isMappingPending = false;
+			resultBuffer.unmap();
+
+			renderContextData.currentTimestampQueryBuffers.isMappingPending = false;
+		})
 
 	}
 	

--- a/examples/webgpu_compute_particles.html
+++ b/examples/webgpu_compute_particles.html
@@ -291,7 +291,7 @@
 
 						timestamps.innerHTML = `
 
-							Compute ${renderer.info.compute.computeCalls} pass in ${renderer.info.compute.timestamp.toFixed( 6 )}ms<br>
+							Compute ${renderer.info.compute.frameCalls} pass in ${renderer.info.compute.timestamp.toFixed( 6 )}ms<br>
 							Draw ${renderer.info.render.drawCalls} pass in ${renderer.info.render.timestamp.toFixed( 6 )}ms`;
 
 					}

--- a/examples/webgpu_storage_buffer.html
+++ b/examples/webgpu_storage_buffer.html
@@ -221,7 +221,7 @@
 
 					timestamps[ forceWebGL ? 'webgl' : 'webgpu' ].innerHTML = `
 
-							Compute ${renderer.info.compute.computeCalls} pass in ${renderer.info.compute.timestamp.toFixed( 6 )}ms<br>
+							Compute ${renderer.info.compute.frameCalls} pass in ${renderer.info.compute.timestamp.toFixed( 6 )}ms<br>
 							Draw ${renderer.info.render.drawCalls} pass in ${renderer.info.render.timestamp.toFixed( 6 )}ms`;
 
 					setTimeout( stepAnimation, 1000 );


### PR DESCRIPTION
Related PR: #28741

**Description**

This is the second part of #28741, continuing my efforts to enhance performance tracking in the new Renderer:
> By skipping timestamp queries when a previous one is still resolving, we may miss some frame data (visible as small spikes in the GPU monitor). However, this prevents potential stalls in the rendering pipeline caused by accumulating unresolved async operations.
> This tradeoff ensures smoother overall performance, especially in complex scenes where the overhead of constant timestamp querying could significantly impact frame rates and so make meaningless the trackTimestamp feature.


This PR continues to enhance the accuracy of performance tracking. It now tracks performance more accurately without negatively impacting it. This is achieved by monitoring the number of compute programs executed per animation loop and resetting values only after the total timestamp has been correctly accumulated. This involves checking the total number of calls in each cycle using two new variables: previousFrameCalls and timestampCalls.

Basically the monitoring logic has been unwired from the renderer. The await behavior in resolveTimestampAsync has been updated to a simple promise as it was stalling the app loop, altering the array buffers consumed by the programs resulting in instability.

Before this PR (for a simulation with more than 90 compute shaders per frame):
![Screenshot 2024-06-26 at 15 17 34](https://github.com/mrdoob/three.js/assets/15867665/5b0f5009-c12d-45ee-b7f7-aa6adb3b3c84)

After this PR (the numbers regarding compute programs now make a lot more sense):
![Screenshot 2024-06-26 at 15 13 08](https://github.com/mrdoob/three.js/assets/15867665/7f671027-935b-4824-8f22-e56d3f6e0d8a)


By the way while testing the WebGL part I noticed some odd numbers in the `webgpu_compute_particles_snow.html` example. The WebGPU part runs at around 75 fps, whereas the WebGL backend easily runs at a full 144 fps+ on dev. This is previous to that PR, this PR just highlight the issue. /cc @sunag 

*This contribution is funded by [Utsubo](https://utsubo.com)*
