### PR TITLE
Texture: add setValues()

### DIFF
--- a/docs/api/en/textures/Texture.html
+++ b/docs/api/en/textures/Texture.html
@@ -315,6 +315,12 @@
 			ready.
 		</p>
 
+		<h3>[method:undefined setValues]( [param:Object values] )</h3>
+		<p>
+			values -- a container with parameters.<br />
+			Sets the properties based on the `values`.
+		</p>
+
 		<h3>[method:Object toJSON]( [param:Object meta] )</h3>
 		<p>
 			meta -- optional object containing metadata.<br />

--- a/docs/api/it/textures/Texture.html
+++ b/docs/api/it/textures/Texture.html
@@ -278,6 +278,12 @@
 			(l'origine dati) è completamente caricata o pronta.
 		</p>
 
+		<h3>[method:undefined setValues]( [param:Object values] )</h3>
+		<p>
+			values -- a container with parameters.<br />
+			Sets the properties based on the `values`.
+		</p>
+
 		<h3>[method:Object toJSON]( [param:Object meta] )</h3>
 		<p>
 		meta -- oggetto opzionale contenente i metadati.<br />

--- a/docs/api/zh/textures/Texture.html
+++ b/docs/api/zh/textures/Texture.html
@@ -258,6 +258,12 @@
 			除此之外，拷贝一个纹理并不会将此纹理自动标记并上传。你需要在图片的属性变更或者源数据完全加载完的时候并准备好的时候将[page:Texture.needsUpdate]设置为true。
 		</p>
 
+		<h3>[method:undefined setValues]( [param:Object values] )</h3>
+		<p>
+			values -- a container with parameters.<br />
+			Sets the properties based on the `values`.
+		</p>
+
 		<h3>[method:Object toJSON]( [param:Object meta] )</h3>
 		<p>
 		meta -- 可选，包含有元数据的对象。<br />

--- a/src/core/RenderTarget.js
+++ b/src/core/RenderTarget.js
@@ -28,7 +28,8 @@ class RenderTarget extends EventDispatcher {
 
 		const image = { width: width, height: height, depth: 1 };
 
-		options = Object.assign( {
+		const texture = new Texture( image );
+		texture.setValues( {
 			generateMipmaps: false,
 			internalFormat: null,
 			minFilter: LinearFilter,
@@ -38,34 +39,19 @@ class RenderTarget extends EventDispatcher {
 			resolveStencilBuffer: true,
 			depthTexture: null,
 			samples: 0,
-			count: 1
-		}, options );
-
-		const texture = new Texture( image, options.mapping, options.wrapS, options.wrapT, options.magFilter, options.minFilter, options.format, options.type, options.anisotropy, options.colorSpace );
-
-		texture.flipY = false;
-		texture.generateMipmaps = options.generateMipmaps;
-		texture.internalFormat = options.internalFormat;
+			flipY: false,
+			...options,
+		} );
 
 		this.textures = [];
 
-		const count = options.count;
+		const count = options.count !== undefined ? options.count : 1;
 		for ( let i = 0; i < count; i ++ ) {
 
 			this.textures[ i ] = texture.clone();
 			this.textures[ i ].isRenderTargetTexture = true;
 
 		}
-
-		this.depthBuffer = options.depthBuffer;
-		this.stencilBuffer = options.stencilBuffer;
-
-		this.resolveDepthBuffer = options.resolveDepthBuffer;
-		this.resolveStencilBuffer = options.resolveStencilBuffer;
-
-		this.depthTexture = options.depthTexture;
-
-		this.samples = options.samples;
 
 	}
 

--- a/src/renderers/WebGL3DRenderTarget.js
+++ b/src/renderers/WebGL3DRenderTarget.js
@@ -12,6 +12,7 @@ class WebGL3DRenderTarget extends WebGLRenderTarget {
 		this.depth = depth;
 
 		this.texture = new Data3DTexture( null, width, height, depth );
+		this.texture.setValues( options );
 
 		this.texture.isRenderTargetTexture = true;
 

--- a/src/renderers/WebGLArrayRenderTarget.js
+++ b/src/renderers/WebGLArrayRenderTarget.js
@@ -12,6 +12,7 @@ class WebGLArrayRenderTarget extends WebGLRenderTarget {
 		this.depth = depth;
 
 		this.texture = new DataArrayTexture( null, width, height, depth );
+		this.texture.setValues( options );
 
 		this.texture.isRenderTargetTexture = true;
 

--- a/src/renderers/WebGLCubeRenderTarget.js
+++ b/src/renderers/WebGLCubeRenderTarget.js
@@ -18,7 +18,8 @@ class WebGLCubeRenderTarget extends WebGLRenderTarget {
 		const image = { width: size, height: size, depth: 1 };
 		const images = [ image, image, image, image, image, image ];
 
-		this.texture = new CubeTexture( images, options.mapping, options.wrapS, options.wrapT, options.magFilter, options.minFilter, options.format, options.type, options.anisotropy, options.colorSpace );
+		this.texture = new CubeTexture( images );
+		this.texture.setValues( options );
 
 		// By convention -- likely based on the RenderMan spec from the 1990's -- cube maps are specified by WebGL (and three.js)
 		// in a coordinate system in which positive-x is to the right when looking up the positive-z axis -- in other words,
@@ -29,9 +30,6 @@ class WebGLCubeRenderTarget extends WebGLRenderTarget {
 		// as a cube texture (this is detected when isRenderTargetTexture is set to true for cube textures).
 
 		this.texture.isRenderTargetTexture = true;
-
-		this.texture.generateMipmaps = options.generateMipmaps !== undefined ? options.generateMipmaps : false;
-		this.texture.minFilter = options.minFilter !== undefined ? options.minFilter : LinearFilter;
 
 	}
 

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -142,6 +142,50 @@ class Texture extends EventDispatcher {
 
 	}
 
+	setValues( values ) {
+
+		for ( const key in values ) {
+
+			const newValue = values[ key ];
+
+			if ( newValue === undefined ) {
+
+				console.warn( `THREE.Texture.setValues(): parameter '${ key }' has value of undefined.` );
+				continue;
+
+			}
+
+			const currentValue = this[ key ];
+
+			if ( currentValue === undefined ) {
+
+				console.warn( `THREE.Texture.setValues(): property '${ key }' does not exist.` );
+				continue;
+
+			}
+
+			if ( ( currentValue && newValue ) && ( currentValue.isVector2 && newValue.isVector2 ) ) {
+
+				currentValue.copy( newValue );
+
+			} else if ( ( currentValue && newValue ) && ( currentValue.isVector3 && newValue.isVector3 ) ) {
+
+				currentValue.copy( newValue );
+
+			} else if ( ( currentValue && newValue ) && ( currentValue.isMatrix3 && newValue.isMatrix3 ) ) {
+
+				currentValue.copy( newValue );
+
+			} else {
+
+				this[ key ] = newValue;
+
+			}
+
+		}
+
+	}
+
 	toJSON( meta ) {
 
 		const isRootObject = ( meta === undefined || typeof meta === 'string' );


### PR DESCRIPTION
Related issue: #28100

**Description**

Adds a `setValues` method to `Texture`, and uses it in render target classes, some of which didn't set texture parameters before.