### PR TITLE
WebGPURenderer: Restore instanced multi-draw API and add WebGPU support

### DIFF
--- a/examples/jsm/renderers/webgl/WebGLBackend.js
+++ b/examples/jsm/renderers/webgl/WebGLBackend.js
@@ -704,13 +704,13 @@ class WebGLBackend extends Backend {
 
 		if ( object.isBatchedMesh ) {
 
-			if ( ! this.hasFeature( 'WEBGL_multi_draw' ) ) {
-
-				warnOnce( 'THREE.WebGLRenderer: WEBGL_multi_draw not supported.' );
-
-			} else if ( object._multiDrawInstances !== null ) {
+			if ( object._multiDrawInstances !== null ) {
 
 				renderer.renderMultiDrawInstances( object._multiDrawStarts, object._multiDrawCounts, object._multiDrawCount, object._multiDrawInstances );
+
+			} else if ( ! this.hasFeature( 'WEBGL_multi_draw' ) ) {
+
+				warnOnce( 'THREE.WebGLRenderer: WEBGL_multi_draw not supported.' );
 
 			} else {
 

--- a/examples/jsm/renderers/webgl/WebGLBackend.js
+++ b/examples/jsm/renderers/webgl/WebGLBackend.js
@@ -708,6 +708,10 @@ class WebGLBackend extends Backend {
 
 				warnOnce( 'THREE.WebGLRenderer: WEBGL_multi_draw not supported.' );
 
+			} else if ( object._multiDrawInstances !== null ) {
+
+				renderer.renderMultiDrawInstances( object._multiDrawStarts, object._multiDrawCounts, object._multiDrawCount, object._multiDrawInstances );
+
 			} else {
 
 				renderer.renderMultiDraw( object._multiDrawStarts, object._multiDrawCounts, object._multiDrawCount );

--- a/examples/jsm/renderers/webgpu/WebGPUBackend.js
+++ b/examples/jsm/renderers/webgpu/WebGPUBackend.js
@@ -923,12 +923,16 @@ class WebGPUBackend extends Backend {
 			const starts = object._multiDrawStarts;
 			const counts = object._multiDrawCounts;
 			const drawCount = object._multiDrawCount;
+			const drawInstances = object._multiDrawInstances;
 
 			const bytesPerElement = index.bytesPerElement || 1;
 
 			for ( let i = 0; i < drawCount; i ++ ) {
 
-				passEncoderGPU.drawIndexed( counts[ i ] / bytesPerElement, 1, starts[ i ] / 4, 0, i );
+				const count = drawInstances ? drawInstances[ i ] : 1;
+				const firstInstance = count > 1 ? 0 : i;
+
+				passEncoderGPU.drawIndexed( counts[ i ] / bytesPerElement, count, starts[ i ] / 4, 0, firstInstance );
 
 			}
 


### PR DESCRIPTION
Related issue: #28103, #28753

**Description**

This PR aligns behavior with the `WebGLRenderer`. I mistakenly removed the `object._multiDrawInstances` condition in #28753 and it seems that some developers/companies might have already implemented custom multi-draw classes in user-land, and `object._multiDrawInstances` will provide such an alternative as mentioned in #28103.
This increases flexibility for developers by not limiting the use of the multi-draw API to the current BatchMesh system, which can be restrictive. 

Regarding TSL, no action is needed as this is already a quite advanced use case. Developers can override the `BatchNode` for their custom implementation via `setupPosition`.

*This contribution is funded by [Utsubo](https://utsubo.com)*
