### PR TITLE
SimplifyModifier: Fix missing import

### DIFF
--- a/examples/jsm/modifiers/SimplifyModifier.js
+++ b/examples/jsm/modifiers/SimplifyModifier.js
@@ -1,5 +1,6 @@
 import {
 	BufferGeometry,
+	Color,
 	Float32BufferAttribute,
 	Vector2,
 	Vector3,
@@ -81,7 +82,7 @@ class SimplifyModifier {
 
 			if ( colorAttribute ) {
 
-				col = new THREE.Color().fromBufferAttribute( colorAttribute, i );
+				col = new Color().fromBufferAttribute( colorAttribute, i );
 
 			}
 


### PR DESCRIPTION
Related issue: -

**Description**

`SimplifyModifier` currently tries to use `THREE.Color` without actually importing the library as `THREE`. This causes a `ReferenceError` to be thrown if the geometry has a color attribute ([live example](https://jsfiddle.net/qakvbp50)).

This PR resolves this issue by updating the existing import to include `Color`.