### PR TITLE
RGBShiftNode: Clean up.

### DIFF
--- a/src/nodes/display/RGBShiftNode.js
+++ b/src/nodes/display/RGBShiftNode.js
@@ -1,7 +1,6 @@
 import TempNode from '../core/TempNode.js';
 import { nodeObject, addNodeElement, tslFn, vec2, vec4 } from '../shadernode/ShaderNode.js';
 import { uniform } from '../core/UniformNode.js';
-import { NodeUpdateType } from '../core/constants.js';
 import { uv } from '../accessors/UVNode.js';
 import { sin, cos } from '../math/MathNode.js';
 
@@ -14,12 +13,6 @@ class RGBShiftNode extends TempNode {
 		this.textureNode = textureNode;
 		this.amount = uniform( amount );
 		this.angle = uniform( angle );
-
-		this.updateBeforeType = NodeUpdateType.RENDER;
-
-	}
-
-	updateBefore() {
 
 	}
 


### PR DESCRIPTION
Related issue: -

**Description**

Removes empty `updateBefore()`.