### PR TITLE
WebGPURenderer: Fix `webgpu_refraction` example

### DIFF
--- a/examples/webgpu_refraction.html
+++ b/examples/webgpu_refraction.html
@@ -15,9 +15,9 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "../build/three.module.js",
-					"three/addons/": "./jsm/",
-					"three/nodes": "./jsm/nodes/Nodes.js"
+					"three": "../build/three.webgpu.js",
+					"three/tsl": "../build/three.webgpu.js",
+					"three/addons/": "./jsm/"
 				}
 			}
 		</script>
@@ -25,9 +25,7 @@
 		<script type="module">
 
 			import * as THREE from 'three';
-			import { MeshBasicNodeMaterial, viewportSharedTexture, texture, uv } from 'three/nodes';
-
-			import WebGPURenderer from 'three/addons/renderers/webgpu/WebGPURenderer.js';
+			import { MeshBasicNodeMaterial, viewportSharedTexture, texture, uv } from 'three/tsl';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 
@@ -128,7 +126,7 @@
 
 				// renderer
 
-				renderer = new WebGPURenderer( { antialias: true } );
+				renderer = new THREE.WebGPURenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setAnimationLoop( animate );


### PR DESCRIPTION
Related issue: #28761

/cc @Mugen87 

*This contribution is funded by [Utsubo](https://utsubo.com)*
