### PR TITLE
Examples: Rename *NodeMaterial to THREE.*NodeMaterial

### DIFF
--- a/examples/webgpu_refraction.html
+++ b/examples/webgpu_refraction.html
@@ -25,7 +25,7 @@
 		<script type="module">
 
 			import * as THREE from 'three';
-			import { MeshBasicNodeMaterial, viewportSharedTexture, texture, uv } from 'three/tsl';
+			import { viewportSharedTexture, texture, uv } from 'three/tsl';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 
@@ -71,7 +71,7 @@
 
 				const planeGeo = new THREE.PlaneGeometry( 100.1, 100.1 );
 
-				const planeRefractor = new THREE.Mesh( planeGeo, new MeshBasicNodeMaterial( {
+				const planeRefractor = new THREE.Mesh( planeGeo, new THREE.MeshBasicNodeMaterial( {
 					backdropNode: verticalRefractor
 				} ) );
 				planeRefractor.material.transparent = true;


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/28650, https://github.com/mrdoob/three.js/pull/28766

**Description**

Now we can bring the `*NodeMateria` to `THREE.*NodeMaterial`, the others examples already updated in https://github.com/mrdoob/three.js/pull/28650. The plan that `three/tsl` could be reserved just for TLS.
