### PR TITLE
ObjectLoader: Add missing call in `parseAsync()`.

### DIFF
--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -206,6 +206,7 @@ class ObjectLoader extends Loader {
 		const skeletons = this.parseSkeletons( json.skeletons, object );
 
 		this.bindSkeletons( object, skeletons );
+		this.bindLightTargets( object );
 
 		return object;
 


### PR DESCRIPTION
Fixed #28775.

**Description**

Ensures `parseAsync()` also calls `bindLightTargets()` like `parse()`.