### PR TITLE
Compile `three.webgpu.js` for e2e tests

### DIFF
--- a/utils/build/rollup.config.js
+++ b/utils/build/rollup.config.js
@@ -130,4 +130,4 @@ const builds = [
 	}
 ];
 
-export default ( args ) => args.configOnlyModule ? builds[ 0 ] : builds;
+export default ( args ) => args.configOnlyModule ? [ builds[ 0 ], builds[ 3 ] ] : builds;


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/28779#discussion_r1661435382

**Description**

Build `three.webgpu.js` for e2e tests.