### PR TITLE
TSL: BatchNode - Fix BiasNode conflict

### DIFF
--- a/src/nodes/accessors/BatchNode.js
+++ b/src/nodes/accessors/BatchNode.js
@@ -45,7 +45,7 @@ class BatchNode extends Node {
 			const size = textureSize( textureLoad( this.batchMesh._indirectTexture ), 0 );
 			const x = int( id ).remainder( int( size ) );
 			const y = int( id ).div( int( size ) );
-			return textureLoad( this.batchMesh._indirectTexture, ivec2( x, y ), null ).x;
+			return textureLoad( this.batchMesh._indirectTexture, ivec2( x, y ) ).x;
 
 		} ).setLayout( {
 			name: 'getIndirectIndex',

--- a/src/nodes/accessors/BatchNode.js
+++ b/src/nodes/accessors/BatchNode.js
@@ -45,7 +45,7 @@ class BatchNode extends Node {
 			const size = textureSize( textureLoad( this.batchMesh._indirectTexture ), 0 );
 			const x = int( id ).remainder( int( size ) );
 			const y = int( id ).div( int( size ) );
-			return textureLoad( this.batchMesh._indirectTexture, ivec2( x, y ), null, 'uvec4' ).x;
+			return textureLoad( this.batchMesh._indirectTexture, ivec2( x, y ), null ).x;
 
 		} ).setLayout( {
 			name: 'getIndirectIndex',


### PR DESCRIPTION
Related issue: #28779

**Description**

Cleanup `BatchNode` that has a 4th parameter that was conflicting with the new `biasNode`. This fixes the `webgpu_mesh_batch` example too.


*This contribution is funded by [Utsubo](https://utsubo.com)*