### PR TITLE
MeshBasicNodeMaterial: Add `envMap` support.

### DIFF
--- a/src/nodes/materials/MeshBasicNodeMaterial.js
+++ b/src/nodes/materials/MeshBasicNodeMaterial.js
@@ -1,6 +1,9 @@
 import NodeMaterial, { addNodeMaterial } from './NodeMaterial.js';
-
+import { diffuseColor } from '../core/PropertyNode.js';
+import { materialSpecularStrength, materialReflectivity } from '../accessors/MaterialNode.js';
 import { MeshBasicMaterial } from '../../materials/MeshBasicMaterial.js';
+import { MultiplyOperation, MixOperation, AddOperation } from '../../constants.js';
+import { mix } from '../math/MathNode.js';
 
 const defaultValues = new MeshBasicMaterial();
 
@@ -18,6 +21,37 @@ class MeshBasicNodeMaterial extends NodeMaterial {
 		this.setDefaultValues( defaultValues );
 
 		this.setValues( parameters );
+
+	}
+
+	setupVariants( builder ) {
+
+		const envNode = this.getEnvNode( builder );
+
+		if ( envNode !== null ) {
+
+			switch ( this.combine ) {
+
+				case MultiplyOperation:
+					diffuseColor.assign( mix( diffuseColor.rgb, diffuseColor.rgb.mul( envNode.rgb ), materialSpecularStrength.mul( materialReflectivity ) ) );
+					break;
+
+				case MixOperation:
+					diffuseColor.assign( mix( diffuseColor.rgb, envNode.rgb, materialSpecularStrength.mul( materialReflectivity ) ) );
+					break;
+
+				case AddOperation:
+					diffuseColor.addAssign( envNode.rgb.mul( materialSpecularStrength.mul( materialReflectivity ) ) );
+					break;
+
+				default:
+					console.warn( 'THREE.MeshBasicNodeMaterial: Unsupported .combine value:', this.combine );
+					break;
+
+			}
+
+		}
+
 
 	}
 


### PR DESCRIPTION
Related issue: #28785

**Description**

I thought I give it a go and add `envMap` support to `MeshBasicNodeMaterial`.

It seems a similar change must be implemented for `MeshLambertNodeMaterial` and `MeshPhongNodeMaterial` since both materials types should sample environment maps in the same fashion.

BTW: `NodeMaterial` must distinct somehow which materials should use `EnvironmentNode` and which should use the code from this PR. Only PBR materials support `Scene.environment` and PMREM and that is what `EnvironmentNode` is about.