### PR TITLE
Examples: Restore look of particle snow demo.

### DIFF
--- a/examples/webgpu_compute_particles_snow.html
+++ b/examples/webgpu_compute_particles_snow.html
@@ -298,7 +298,7 @@
 				const vignet = viewportTopLeft.distance( .5 ).mul( 1.35 ).clamp().oneMinus();
 
 				const teapotTreePass = pass( teapotTree, camera ).getTextureNode();
-				const teapotTreePassBlurred = teapotTreePass.gaussianBlur( 3 );
+				const teapotTreePassBlurred = teapotTreePass.gaussianBlur( vec2( 1 ), 3 );
 				teapotTreePassBlurred.resolution = new THREE.Vector2( .2, .2 );
 
 				const scenePassColorBlurred = scenePassColor.gaussianBlur();


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/28784#issuecomment-2205406568

**Description**

When we have changed the signature from `GaussianBlurNode`, we've missed to update `webgpu_compute_particles_snow` so the ctor signature holds the intended values.
