### PR TITLE
TSL: Fix texture matrix reference

### DIFF
--- a/src/nodes/accessors/TextureNode.js
+++ b/src/nodes/accessors/TextureNode.js
@@ -6,7 +6,6 @@ import { expression } from '../code/ExpressionNode.js';
 import { addNodeClass } from '../core/Node.js';
 import { maxMipLevel } from '../utils/MaxMipLevelNode.js';
 import { addNodeElement, nodeProxy, vec3, nodeObject } from '../shadernode/ShaderNode.js';
-import { reference } from '../accessors/ReferenceNode.js';
 import { NodeUpdateType } from '../core/constants.js';
 
 import { IntType, UnsignedIntType } from '../../constants.js';

--- a/src/nodes/accessors/TextureNode.js
+++ b/src/nodes/accessors/TextureNode.js
@@ -1,4 +1,4 @@
-import UniformNode from '../core/UniformNode.js';
+import UniformNode, { uniform } from '../core/UniformNode.js';
 import { uv } from './UVNode.js';
 import { textureSize } from './TextureSizeNode.js';
 import { colorSpaceToLinear } from '../display/ColorSpaceNode.js';
@@ -33,6 +33,7 @@ class TextureNode extends UniformNode {
 		this.referenceNode = null;
 
 		this._value = value;
+		this._matrixValue = null;
 
 		this.setUpdateMatrix( uvNode === null );
 
@@ -102,7 +103,10 @@ class TextureNode extends UniformNode {
 
 	getTransformedUV( uvNode ) {
 
-		return reference( 'value.matrix', 'mat3', this ).mul( vec3( uvNode, 1 ) ).xy;
+		if ( this._matrixValue === null ) this._matrixValue = uniform( this.value.matrix );
+
+		return this._matrixValue.mul( vec3( uvNode, 1 ) ).xy;
+
 
 	}
 
@@ -398,6 +402,9 @@ class TextureNode extends UniformNode {
 	update() {
 
 		const texture = this.value;
+		const matrixTexture = this._matrixValue;
+
+		if ( matrixTexture !== null ) matrixTexture.value = texture.matrix;
 
 		if ( texture.matrixAutoUpdate === true ) {
 

--- a/src/nodes/accessors/TextureNode.js
+++ b/src/nodes/accessors/TextureNode.js
@@ -1,4 +1,4 @@
-import UniformNode, { uniform } from '../core/UniformNode.js';
+import UniformNode from '../core/UniformNode.js';
 import { uv } from './UVNode.js';
 import { textureSize } from './TextureSizeNode.js';
 import { colorSpaceToLinear } from '../display/ColorSpaceNode.js';
@@ -6,6 +6,7 @@ import { expression } from '../code/ExpressionNode.js';
 import { addNodeClass } from '../core/Node.js';
 import { maxMipLevel } from '../utils/MaxMipLevelNode.js';
 import { addNodeElement, nodeProxy, vec3, nodeObject } from '../shadernode/ShaderNode.js';
+import { reference } from '../accessors/ReferenceNode.js';
 import { NodeUpdateType } from '../core/constants.js';
 
 import { IntType, UnsignedIntType } from '../../constants.js';
@@ -101,9 +102,7 @@ class TextureNode extends UniformNode {
 
 	getTransformedUV( uvNode ) {
 
-		const texture = this.value;
-
-		return uniform( texture.matrix ).mul( vec3( uvNode, 1 ) ).xy;
+		return reference( 'value.matrix', 'mat3', this ).mul( vec3( uvNode, 1 ) ).xy;
 
 	}
 


### PR DESCRIPTION
Related issue: Closes https://github.com/mrdoob/three.js/issues/28758

**Description**

The matrix reference was lost when the texture was replaced by another one in the `reference()` node, this ensures that the matrix is ​​updated when the texture is updated.