### PR TITLE
NodeMaterial: Fix env map for lambert and phong.

### DIFF
--- a/src/nodes/materials/MeshLambertNodeMaterial.js
+++ b/src/nodes/materials/MeshLambertNodeMaterial.js
@@ -1,4 +1,5 @@
 import NodeMaterial, { addNodeMaterial } from './NodeMaterial.js';
+import BasicEnvironmentNode from '../lighting/BasicEnvironmentNode.js';
 import PhongLightingModel from '../functions/PhongLightingModel.js';
 
 import { MeshLambertMaterial } from '../../materials/MeshLambertMaterial.js';
@@ -18,6 +19,14 @@ class MeshLambertNodeMaterial extends NodeMaterial {
 		this.setDefaultValues( defaultValues );
 
 		this.setValues( parameters );
+
+	}
+
+	setupEnvironment( builder ) {
+
+		const envNode = super.setupEnvironment( builder );
+
+		return envNode ? new BasicEnvironmentNode( envNode ) : null;
 
 	}
 

--- a/src/nodes/materials/MeshPhongNodeMaterial.js
+++ b/src/nodes/materials/MeshPhongNodeMaterial.js
@@ -2,6 +2,7 @@ import NodeMaterial, { addNodeMaterial } from './NodeMaterial.js';
 import { shininess, specularColor } from '../core/PropertyNode.js';
 import { materialShininess, materialSpecular } from '../accessors/MaterialNode.js';
 import { float } from '../shadernode/ShaderNode.js';
+import BasicEnvironmentNode from '../lighting/BasicEnvironmentNode.js';
 import PhongLightingModel from '../functions/PhongLightingModel.js';
 
 import { MeshPhongMaterial } from '../../materials/MeshPhongMaterial.js';
@@ -27,6 +28,13 @@ class MeshPhongNodeMaterial extends NodeMaterial {
 
 	}
 
+	setupEnvironment( builder ) {
+
+		const envNode = super.setupEnvironment( builder );
+
+		return envNode ? new BasicEnvironmentNode( envNode ) : null;
+
+	}
 	setupLightingModel( /*builder*/ ) {
 
 		return new PhongLightingModel();


### PR DESCRIPTION
Related issue: #28798

**Description**

`MeshLambertNodeMaterial` and `MeshPhongNodeMaterial` do not inherit from `MeshBasicNodeMaterial` so they must implement `setupEnvironment()` as well. Otherwise env maps do not work. 
