### PR TITLE
NodeMaterial: Honor `ambientOcclusion` in basic, lambert and phong.

### DIFF
--- a/src/nodes/functions/BasicLightingModel.js
+++ b/src/nodes/functions/BasicLightingModel.js
@@ -12,9 +12,11 @@ class BasicLightingModel extends LightingModel {
 
 	}
 
-	indirectDiffuse( { reflectedLight } ) {
+	indirectDiffuse( { ambientOcclusion, reflectedLight } ) {
 
-		reflectedLight.indirectDiffuse.assign( diffuseColor.rgb );
+		reflectedLight.indirectDiffuse.addAssign( diffuseColor.rgb );
+
+		reflectedLight.indirectDiffuse.mulAssign( ambientOcclusion );
 
 	}
 

--- a/src/nodes/functions/PhongLightingModel.js
+++ b/src/nodes/functions/PhongLightingModel.js
@@ -56,9 +56,11 @@ class PhongLightingModel extends BasicLightingModel {
 
 	}
 
-	indirectDiffuse( { irradiance, reflectedLight } ) {
+	indirectDiffuse( { ambientOcclusion, irradiance, reflectedLight } ) {
 
 		reflectedLight.indirectDiffuse.addAssign( irradiance.mul( BRDF_Lambert( { diffuseColor } ) ) );
+
+		reflectedLight.indirectDiffuse.mulAssign( ambientOcclusion );
 
 	}
 


### PR DESCRIPTION
Related issue: #28785

**Description**

Basic, lambert and phong materials now support ambient occlusion.
