### PR TITLE
ToonLightingModel: Honor `ambientOcclusion`.

### DIFF
--- a/src/nodes/functions/ToonLightingModel.js
+++ b/src/nodes/functions/ToonLightingModel.js
@@ -38,9 +38,11 @@ class ToonLightingModel extends LightingModel {
 
 	}
 
-	indirectDiffuse( { irradiance, reflectedLight } ) {
+	indirectDiffuse( { ambientOcclusion, irradiance, reflectedLight } ) {
 
 		reflectedLight.indirectDiffuse.addAssign( irradiance.mul( BRDF_Lambert( { diffuseColor } ) ) );
+
+		reflectedLight.indirectDiffuse.mulAssign( ambientOcclusion );
 
 	}
 


### PR DESCRIPTION
Related issue: #28819

**Description**

The toon material also supports AO, it was missed in #28819.
