### PR TITLE
Examples: scroll to currently selected example in the sidebar

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -106,6 +106,8 @@
 
 				if ( validRedirects.has( file ) === true ) {
 
+					content.querySelector( `a[href="${ file }.html"]` ).scrollIntoView();
+
 					selectFile( file );
 					viewer.src = validRedirects.get( file );
 					viewer.style.display = 'unset';


### PR DESCRIPTION

When an example is selected in the sidebar, and the page is refreshed, the sidebar reverts to the default positioning, 

Scroll the sidebar so that the selected example name and thumbnail are visible.
