### PR TITLE
MeshBasicNodeMaterial: Fix `transformedNormalView`.

### DIFF
--- a/src/nodes/materials/MeshBasicNodeMaterial.js
+++ b/src/nodes/materials/MeshBasicNodeMaterial.js
@@ -4,6 +4,7 @@ import { MeshBasicMaterial } from '../../materials/MeshBasicMaterial.js';
 import BasicEnvironmentNode from '../lighting/BasicEnvironmentNode.js';
 import BasicLightMapNode from '../lighting/BasicLightMapNode.js';
 import BasicLightingModel from '../functions/BasicLightingModel.js';
+import { transformedNormalView, normalView } from '../accessors/NormalNode.js';
 
 const defaultValues = new MeshBasicMaterial();
 
@@ -21,6 +22,12 @@ class MeshBasicNodeMaterial extends NodeMaterial {
 		this.setDefaultValues( defaultValues );
 
 		this.setValues( parameters );
+
+	}
+
+	setupNormal() {
+
+		transformedNormalView.assign( normalView ); // see #28839
 
 	}
 


### PR DESCRIPTION
Related issue: -

**Description**

This makes sure `MeshBasicNodeMaterial` does not react on normal or bump maps by overwriting the computation of `transformedNormalView`.
