### PR TITLE
Examples: Clean up.

### DIFF
--- a/examples/jsm/shaders/FXAAShader.js
+++ b/examples/jsm/shaders/FXAAShader.js
@@ -220,11 +220,9 @@ const FXAAShader = {
 			vec2 posN = posM;
 			vec2 posP = posM;
 
-			int iterationsUsed = 0;
 			int iterationsUsedN = 0;
 			int iterationsUsedP = 0;
 			for( int i = 0; i < NUM_SAMPLES; i++ ) {
-				iterationsUsed = i;
 
 				float increment = float(i + 1);
 

--- a/examples/jsm/shaders/GTAOShader.js
+++ b/examples/jsm/shaders/GTAOShader.js
@@ -203,7 +203,7 @@ const GTAOShader = {
 
 			const int DIRECTIONS = SAMPLES < 30 ? 3 : 5;
 			const int STEPS = (SAMPLES + DIRECTIONS - 1) / DIRECTIONS;
-			float ao = 0.0, totalWeight = 0.0;
+			float ao = 0.0;
 			for (int i = 0; i < DIRECTIONS; ++i) {
 				
 				float angle = float(i) / float(DIRECTIONS) * PI;


### PR DESCRIPTION
Related issue: -

**Description**

While working at the latest PRs, I've noticed two unused variables in `FXAAShader` and `GTAOShader`.
