### PR TITLE
WebGPURenderer: WGSL Fix calculation of instanceIndex in compute shaders

### DIFF
--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -681,6 +681,9 @@ ${ flowData.code }
 		if ( shaderStage === 'compute' ) {
 
 			this.getBuiltin( 'global_invocation_id', 'id', 'vec3<u32>', 'attribute' );
+			this.getBuiltin( 'workgroup_id', 'workgroupId', 'vec3<u32>', 'attribute' );
+			this.getBuiltin( 'local_invocation_id', 'localId', 'vec3<u32>', 'attribute' );
+			this.getBuiltin( 'num_workgroups', 'numWorkgroups', 'vec3<u32>', 'attribute' );
 
 		}
 
@@ -1198,7 +1201,7 @@ ${shaderData.codes}
 fn main( ${shaderData.attributes} ) {
 
 	// system
-	instanceIndex = id.x;
+	instanceIndex = id.x + id.y * numWorkgroups.x * u32(${workgroupSize}) + id.z * numWorkgroups.x * numWorkgroups.y * u32(${workgroupSize});
 
 	// vars
 	${shaderData.vars}


### PR DESCRIPTION
Related issue: #28846

**Description**

The current implementation of `instanceIndex` only uses `global_invocation_id.x`, which doesn't work with the new Y and Z dimensions. This PR addresses the issue by updating the WGSL behavior of `dispatchWorkgroups` in the WebGPU backend. This ensures correct functionality when the number of particles exceeds `maxComputeWorkgroupsPerDimension`.

*This contribution is funded by [Utsubo](https://utsubo.com)*
