### PR TITLE
Box2, Box3: Escape ternary condition in "containsPoint" method

### DIFF
--- a/src/math/Box2.js
+++ b/src/math/Box2.js
@@ -119,8 +119,8 @@ class Box2 {
 
 	containsPoint( point ) {
 
-		return point.x < this.min.x || point.x > this.max.x ||
-			point.y < this.min.y || point.y > this.max.y ? false : true;
+		return point.x >= this.min.x && point.x <= this.max.x &&
+			point.y >= this.min.y && point.y <= this.max.y;
 
 	}
 

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -238,9 +238,9 @@ class Box3 {
 
 	containsPoint( point ) {
 
-		return point.x < this.min.x || point.x > this.max.x ||
-			point.y < this.min.y || point.y > this.max.y ||
-			point.z < this.min.z || point.z > this.max.z ? false : true;
+		return point.x >= this.min.x && point.x <= this.max.x &&
+			point.y >= this.min.y && point.y <= this.max.y &&
+			point.z >= this.min.z && point.z <= this.max.z;
 
 	}
 


### PR DESCRIPTION
**Description**

I was reading the source code and it was slightly inconvenient to see this condition being negated via ternary, so it might be worth to flip it to make it more concise.