### PR TITLE
WebGPURenderer: Fix shadows on objects with receiveShadow=false

### DIFF
--- a/src/nodes/lighting/AnalyticLightNode.js
+++ b/src/nodes/lighting/AnalyticLightNode.js
@@ -54,7 +54,13 @@ class AnalyticLightNode extends LightingNode {
 
 		const { object } = builder;
 
-		if ( object.receiveShadow === false ) return;
+		if ( object.receiveShadow === false ) {
+
+			this.colorNode = this._defaultColorNode;
+
+			return;
+
+		}
 
 		let shadowNode = this.shadowNode;
 


### PR DESCRIPTION
**Description**
Currently the meshes will always receive shadows if their `castShadow` property is `true` regardless if `receiveShadow` is `false`. This PR fixes the issue by resetting the `colorNode` in `AnalyticLightNode` when the shadow map is not needed.

For example, here the box is defined with the following properties:
```js
box.castShadow = true;
box.receiveShadow = false;
```

Before:
<img width="1075" alt="Screenshot 2024-07-15 at 17 27 39" src="https://github.com/user-attachments/assets/e4fa0753-9754-47b0-9d9b-37cdc8953864">


After:
<img width="1075" alt="Screenshot 2024-07-15 at 17 27 19" src="https://github.com/user-attachments/assets/ce840513-cc3e-4a3f-877f-8436ef049dd1">




*This contribution is funded by [Utsubo](https://utsubo.com)*
