### PR TITLE
DotScreenNode: Fix  `updateBefore()`.

### DIFF
--- a/src/nodes/display/DotScreenNode.js
+++ b/src/nodes/display/DotScreenNode.js
@@ -25,11 +25,11 @@ class DotScreenNode extends TempNode {
 
 	}
 
-	updateBefore() {
+	updateBefore( frame ) {
 
-		const map = this.inputNode.value;
+		const { renderer } = frame;
 
-		this._size.value.set( map.image.width, map.image.height );
+		renderer.getSize( this._size.value );
 
 	}
 


### PR DESCRIPTION
Related issue: -

**Description**

The input node of `DotScreenNode` might not be a `TextureNode` so it is not safe to use the `map` reference to extract the dimensions of the post processing. This is now done via the renderer which should always work.

I've seen this approach in #28863, btw^^ (thanks @sunag).
