### PR TITLE
WebGPURenderer: correct shadows on material rebuilding. 

### DIFF
--- a/src/nodes/lighting/AnalyticLightNode.js
+++ b/src/nodes/lighting/AnalyticLightNode.js
@@ -241,6 +241,7 @@ class AnalyticLightNode extends LightingNode {
 
 		this.shadowNode = null;
 		this.shadowMaskNode = null;
+		this._shadowColorNode = null;
 		this.rtt = null;
 
 		this.colorNode = this._defaultColorNode;

--- a/src/nodes/lighting/AnalyticLightNode.js
+++ b/src/nodes/lighting/AnalyticLightNode.js
@@ -31,6 +31,7 @@ class AnalyticLightNode extends LightingNode {
 
 		this.color = new Color();
 		this._defaultColorNode = uniform( this.color );
+		this._shadowColorNode = null;
 
 		this.colorNode = this._defaultColorNode;
 
@@ -168,6 +169,7 @@ class AnalyticLightNode extends LightingNode {
 
 			this.rtt = rtt;
 			this.colorNode = this.colorNode.mul( mix( 1, shadowMaskNode, shadowIntensity ) );
+			this._shadowColorNode = this.colorNode;
 
 			this.shadowNode = shadowNode;
 			this.shadowMaskNode = shadowMaskNode;
@@ -175,6 +177,10 @@ class AnalyticLightNode extends LightingNode {
 			//
 
 			this.updateBeforeType = NodeUpdateType.RENDER;
+
+		} else {
+
+			this.colorNode = this._shadowColorNode;
 
 		}
 


### PR DESCRIPTION
Related issue: #28874

The above PR broke shadows when materials are rebuilt after initial use. This is exhibited in the webgpu_clipping example, where disabling the global clipping planes, the shadows on the 'ground' object are removed.

On the rebuild of a material receiving shadows, the colorNode is the _defaultColorNode, and is not replaced with the correct version because the shadowNode already exists.

This PR preserves the colorNode used for materials that receive shadows and reuses it on material rebuild if required.