### PR TITLE
TSL: add mat convert

### DIFF
--- a/src/nodes/accessors/BatchNode.js
+++ b/src/nodes/accessors/BatchNode.js
@@ -69,11 +69,7 @@ class BatchNode extends Node {
 			textureLoad( matriceTexture, ivec2( x.add( 3 ), y ) )
 		);
 
-		const bm = mat3(
-			batchingMatrix[ 0 ].xyz,
-			batchingMatrix[ 1 ].xyz,
-			batchingMatrix[ 2 ].xyz
-		 );
+		const bm = mat3( batchingMatrix );
 
 		positionLocal.assign( batchingMatrix.mul( positionLocal ) );
 

--- a/src/nodes/accessors/InstanceNode.js
+++ b/src/nodes/accessors/InstanceNode.js
@@ -75,7 +75,7 @@ class InstanceNode extends Node {
 
 		// NORMAL
 
-		const m = mat3( instanceMatrixNode[ 0 ].xyz, instanceMatrixNode[ 1 ].xyz, instanceMatrixNode[ 2 ].xyz );
+		const m = mat3( instanceMatrixNode );
 
 		const transformedNormal = normalLocal.div( vec3( m[ 0 ].dot( m[ 0 ] ), m[ 1 ].dot( m[ 1 ] ), m[ 2 ].dot( m[ 2 ] ) ) );
 

--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -1323,18 +1323,18 @@ class NodeBuilder {
 		const fromTypeLength = this.getTypeLength( fromType );
 		const toTypeLength = this.getTypeLength( toType );
 
-    if ( fromTypeLength === 16 && toTypeLength === 9 ) {
+		if ( fromTypeLength === 16 && toTypeLength === 9 ) {
 
-      return `${ this.getType( toType ) }(${ snippet }[0].xyz, ${ snippet }[1].xyz, ${ snippet }[2].xyz)`;
-       
-    }
+			return `${ this.getType( toType ) }(${ snippet }[0].xyz, ${ snippet }[1].xyz, ${ snippet }[2].xyz)`;
 
-    if ( fromTypeLength === 9 && toTypeLength === 4 ) {
+		}
 
-      return `${ this.getType( toType ) }(${ snippet }[0].xy, ${ snippet }[1].xy)`;
+		if ( fromTypeLength === 9 && toTypeLength === 4 ) {
 
-    }
-      
+			return `${ this.getType( toType ) }(${ snippet }[0].xy, ${ snippet }[1].xy)`;
+
+		}
+
 
 		if ( fromTypeLength > 4 ) { // fromType is matrix-like
 

--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -1323,6 +1323,19 @@ class NodeBuilder {
 		const fromTypeLength = this.getTypeLength( fromType );
 		const toTypeLength = this.getTypeLength( toType );
 
+    if ( fromTypeLength === 16 && toTypeLength === 9 ) {
+
+      return `${ this.getType( toType ) }(${ snippet }[0].xyz, ${ snippet }[1].xyz, ${ snippet }[2].xyz)`;
+       
+    }
+
+    if ( fromTypeLength === 9 && toTypeLength === 4 ) {
+
+      return `${ this.getType( toType ) }(${ snippet }[0].xy, ${ snippet }[1].xy)`;
+
+    }
+      
+
 		if ( fromTypeLength > 4 ) { // fromType is matrix-like
 
 			// @TODO: ignore for now


### PR DESCRIPTION
Support mat4 to mat3 and mat3 to mat2 in TSL. 
In glsl, mat3(mat4) is a convinent method to convert matrix, it will help simpify code.

before 
``` 
const bm = mat3(
			batchingMatrix[ 0 ].xyz,
			batchingMatrix[ 1 ].xyz,
			batchingMatrix[ 2 ].xyz
		 );
```

after

``` 
const bm = mat3( batchingMatrix );
```

Because WGSL doesn't support code like [mat3(mat4)](https://github.com/gpuweb/gpuweb/issues/2399). So it will be split into different part in NodeBuilder.js
``` 
if ( fromTypeLength === 16 && toTypeLength === 9 ) {

      return `${ this.getType( toType ) }(${ snippet }[0].xyz, ${ snippet }[1].xyz, ${ snippet }[2].xyz)`;

    }
```



