### PR TITLE
Nodes: Add missing `dispose()` methods.

### DIFF
--- a/src/nodes/display/AfterImageNode.js
+++ b/src/nodes/display/AfterImageNode.js
@@ -135,6 +135,13 @@ class AfterImageNode extends TempNode {
 
 	}
 
+	dispose() {
+
+		this._compRT.dispose();
+		this._oldRT.dispose();
+
+	}
+
 }
 
 export const afterImage = ( node, damp ) => nodeObject( new AfterImageNode( nodeObject( node ).toTexture(), damp ) );

--- a/src/nodes/display/AnamorphicNode.js
+++ b/src/nodes/display/AnamorphicNode.js
@@ -129,6 +129,12 @@ class AnamorphicNode extends TempNode {
 
 	}
 
+	dispose() {
+
+		this._renderTarget.dispose();
+
+	}
+
 }
 
 export const anamorphic = ( node, threshold = .9, scale = 3, samples = 32 ) => nodeObject( new AnamorphicNode( nodeObject( node ).toTexture(), nodeObject( threshold ), nodeObject( scale ), samples ) );

--- a/src/nodes/display/GTAONode.js
+++ b/src/nodes/display/GTAONode.js
@@ -225,6 +225,12 @@ class GTAONode extends TempNode {
 
 	}
 
+	dispose() {
+
+		this._aoRenderTarget.dispose();
+
+	}
+
 }
 
 function generateMagicSquareNoise( size = 5 ) {

--- a/src/nodes/display/GaussianBlurNode.js
+++ b/src/nodes/display/GaussianBlurNode.js
@@ -176,6 +176,13 @@ class GaussianBlurNode extends TempNode {
 
 	}
 
+	dispose() {
+
+		this._horizontalRT.dispose();
+		this._verticalRT.dispose();
+
+	}
+
 	_getCoefficients( kernelRadius ) {
 
 		const coefficients = [];


### PR DESCRIPTION
Related issue: -

**Description**

This PR adds some missing `dispose()` methods in effects classes to free internal render targets.
