### PR TITLE
GLTFExporter: Set `willReadFrequently` to `true` when using `canvas2d`.

### DIFF
--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -871,7 +871,9 @@ class GLTFWriter {
 		canvas.width = width;
 		canvas.height = height;
 
-		const context = canvas.getContext( '2d' );
+		const context = canvas.getContext( '2d', {
+			willReadFrequently: true,
+		} );
 		context.fillStyle = '#00ffff';
 		context.fillRect( 0, 0, width, height );
 
@@ -1273,7 +1275,9 @@ class GLTFWriter {
 			canvas.width = Math.min( image.width, options.maxTextureSize );
 			canvas.height = Math.min( image.height, options.maxTextureSize );
 
-			const ctx = canvas.getContext( '2d' );
+			const ctx = canvas.getContext( '2d', {
+				willReadFrequently: true,
+			} );
 
 			if ( flipY === true ) {
 


### PR DESCRIPTION
Fixed #28887

**Description**

According to [spec](https://html.spec.whatwg.org/multipage/canvas.html#concept-canvas-will-read-frequently), GLTFExporter addon has been missing `willReadFrequently` context attribute set true for every `getContext` call. It leads to poor exporting performance and annoying warnings appearance. Changes solve it both. The last one, at least

