### PR TITLE
WebGPURenderer: suppress console errors when video data is unavailable.

### DIFF
--- a/src/renderers/webgpu/utils/WebGPUTextureUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUTextureUtils.js
@@ -42,6 +42,7 @@ class WebGPUTextureUtils {
 
 		this.defaultTexture = {};
 		this.defaultCubeTexture = {};
+		this.defaultVideoFrame = null;
 
 		this.colorBuffer = null;
 
@@ -86,6 +87,10 @@ class WebGPUTextureUtils {
 		if ( texture.isCubeTexture ) {
 
 			textureGPU = this._getDefaultCubeTextureGPU( format );
+
+		} else if ( texture.isVideoTexture ) {
+
+			this.backend.get( texture ).externalTexture = this._getDefaultVideoFrame();
 
 		} else {
 
@@ -452,6 +457,27 @@ class WebGPUTextureUtils {
 		}
 
 		return this.backend.get( defaultCubeTexture ).texture;
+
+	}
+
+	_getDefaultVideoFrame() {
+
+		let defaultVideoFrame = this.defaultVideoFrame;
+
+		if ( defaultVideoFrame === null ) {
+
+			const init = {
+				timestamp: 0,
+				codedWidth: 1,
+				codedHeight: 1,
+				format: 'RGBA',
+			};
+
+		  this.defaultVideoFrame = defaultVideoFrame = new VideoFrame( new Uint8Array( [ 0, 0, 0, 0xff ] ), init );
+
+		}
+
+		return defaultVideoFrame;
 
 	}
 


### PR DESCRIPTION
Related issue: #27690, #28868

Using video textures often results in console errors while the video element or stream is unavailable. Add a default 1 x 1 default  black video frame to be used in this situation to prevent console errors, mirroring the use of default textures.
