### PR TITLE
Nodes: Honor pixel ratio in effects.

### DIFF
--- a/src/nodes/display/DotScreenNode.js
+++ b/src/nodes/display/DotScreenNode.js
@@ -29,7 +29,7 @@ class DotScreenNode extends TempNode {
 
 		const { renderer } = frame;
 
-		renderer.getSize( this._size.value );
+		renderer.getDrawingBufferSize( this._size.value );
 
 	}
 

--- a/src/nodes/display/GTAONode.js
+++ b/src/nodes/display/GTAONode.js
@@ -70,7 +70,7 @@ class GTAONode extends TempNode {
 
 		const { renderer } = frame;
 
-		const size = renderer.getSize( _size );
+		const size = renderer.getDrawingBufferSize( _size );
 
 		const currentRenderTarget = renderer.getRenderTarget();
 		const currentMRT = renderer.getMRT();


### PR DESCRIPTION
Related issue: #28885

**Description**

Slight correction to #28885. We must use `getDrawingBufferSize()` otherwise the pixel ratio isn't honored.
