### PR TITLE
Nodes: Unify uniform() and uniforms() functions

### DIFF
--- a/src/nodes/Nodes.js
+++ b/src/nodes/Nodes.js
@@ -30,7 +30,7 @@ export { default as PropertyNode, property, varyingProperty, output, diffuseColo
 export { default as StackNode, stack } from './core/StackNode.js';
 export { default as TempNode } from './core/TempNode.js';
 export { default as UniformGroupNode, uniformGroup, objectGroup, renderGroup, frameGroup } from './core/UniformGroupNode.js';
-export { default as UniformNode, uniform } from './core/UniformNode.js';
+export { default as UniformNode } from './core/UniformNode.js';
 export { default as VaryingNode, varying } from './core/VaryingNode.js';
 export { default as OutputStructNode, outputStruct } from './core/OutputStructNode.js';
 export { default as MRTNode, mrt } from './core/MRTNode.js';
@@ -78,7 +78,7 @@ export * from './shadernode/ShaderNode.js';
 
 // accessors
 export { TBNViewMatrix, parallaxDirection, parallaxUV, transformedBentNormalView } from './accessors/AccessorsUtils.js';
-export { default as UniformsNode, uniforms } from './accessors/UniformsNode.js';
+export { default as UniformsNode, uniform } from './accessors/UniformsNode.js';
 export * from './accessors/BitangentNode.js';
 export { default as BufferAttributeNode, bufferAttribute, dynamicBufferAttribute, instancedBufferAttribute, instancedDynamicBufferAttribute } from './accessors/BufferAttributeNode.js';
 export { default as BufferNode, buffer } from './accessors/BufferNode.js';

--- a/src/nodes/accessors/CameraNode.js
+++ b/src/nodes/accessors/CameraNode.js
@@ -1,4 +1,4 @@
-import { uniform } from '../core/UniformNode.js';
+import { uniform } from '../accessors/UniformsNode.js';
 import { sharedUniformGroup } from '../core/UniformGroupNode.js';
 import { Vector3 } from '../../math/Vector3.js';
 

--- a/src/nodes/accessors/ClippingNode.js
+++ b/src/nodes/accessors/ClippingNode.js
@@ -6,7 +6,7 @@ import { diffuseColor, property } from '../core/PropertyNode.js';
 import { tslFn } from '../shadernode/ShaderNode.js';
 import { loop } from '../utils/LoopNode.js';
 import { smoothstep } from '../math/MathNode.js';
-import { uniforms } from './UniformsNode.js';
+import { uniform } from '../accessors/UniformsNode.js';
 
 class ClippingNode extends Node {
 
@@ -44,7 +44,7 @@ class ClippingNode extends Node {
 
 		return tslFn( () => {
 
-			const clippingPlanes = uniforms( planes );
+			const clippingPlanes = uniform( planes );
 
 			const distanceToPlane = property( 'float', 'distanceToPlane' );
 			const distanceGradient = property( 'float', 'distanceToGradient' );
@@ -101,7 +101,7 @@ class ClippingNode extends Node {
 
 		return tslFn( () => {
 
-			const clippingPlanes = uniforms( planes );
+			const clippingPlanes = uniform( planes );
 
 			let plane;
 

--- a/src/nodes/accessors/MaterialNode.js
+++ b/src/nodes/accessors/MaterialNode.js
@@ -3,7 +3,7 @@ import { reference } from './ReferenceNode.js';
 import { materialReference } from './MaterialReferenceNode.js';
 import { normalView } from './NormalNode.js';
 import { nodeImmutable, float, vec2, mat2 } from '../shadernode/ShaderNode.js';
-import { uniform } from '../core/UniformNode.js';
+import { uniform } from '../accessors/UniformsNode.js';
 
 import { Vector2 } from '../../math/Vector2.js';
 

--- a/src/nodes/accessors/ModelNode.js
+++ b/src/nodes/accessors/ModelNode.js
@@ -1,7 +1,7 @@
 import Object3DNode from './Object3DNode.js';
 import { addNodeClass } from '../core/Node.js';
 import { nodeImmutable } from '../shadernode/ShaderNode.js';
-import { uniform } from '../core/UniformNode.js';
+import { uniform } from '../accessors/UniformsNode.js';
 
 import { Matrix4 } from '../../math/Matrix4.js';
 

--- a/src/nodes/accessors/MorphNode.js
+++ b/src/nodes/accessors/MorphNode.js
@@ -1,7 +1,7 @@
 import Node, { addNodeClass } from '../core/Node.js';
 import { NodeUpdateType } from '../core/constants.js';
 import { float, nodeProxy, tslFn } from '../shadernode/ShaderNode.js';
-import { uniform } from '../core/UniformNode.js';
+import { uniform } from '../accessors/UniformsNode.js';
 import { reference } from './ReferenceNode.js';
 import { positionLocal } from './PositionNode.js';
 import { normalLocal } from './NormalNode.js';

--- a/src/nodes/accessors/ReferenceNode.js
+++ b/src/nodes/accessors/ReferenceNode.js
@@ -1,10 +1,9 @@
 import Node, { addNodeClass } from '../core/Node.js';
 import { NodeUpdateType } from '../core/constants.js';
-import { uniform } from '../core/UniformNode.js';
+import { uniform } from '../accessors/UniformsNode.js';
 import { texture } from './TextureNode.js';
 import { buffer } from './BufferNode.js';
 import { nodeObject } from '../shadernode/ShaderNode.js';
-import { uniforms } from './UniformsNode.js';
 import ArrayElementNode from '../utils/ArrayElementNode.js';
 
 class ReferenceElementNode extends ArrayElementNode {
@@ -72,7 +71,7 @@ class ReferenceNode extends Node {
 
 		} else if ( Array.isArray( this.getValueFromReference() ) ) {
 
-			node = uniforms( null, uniformType );
+			node = uniform( null, uniformType );
 
 		} else if ( uniformType === 'texture' ) {
 

--- a/src/nodes/accessors/ReferenceNode.js
+++ b/src/nodes/accessors/ReferenceNode.js
@@ -42,6 +42,10 @@ class ReferenceNode extends Node {
 
 		super();
 
+		console.log( property );
+		console.log( uniformType );
+		console.log( object )
+
 		this.property = property;
 		this.uniformType = uniformType;
 		this.object = object;
@@ -71,7 +75,7 @@ class ReferenceNode extends Node {
 
 		} else if ( Array.isArray( this.getValueFromReference() ) ) {
 
-			node = uniform( null, uniformType );
+			node = uniform( [], uniformType );
 
 		} else if ( uniformType === 'texture' ) {
 

--- a/src/nodes/accessors/ReferenceNode.js
+++ b/src/nodes/accessors/ReferenceNode.js
@@ -44,7 +44,7 @@ class ReferenceNode extends Node {
 
 		console.log( property );
 		console.log( uniformType );
-		console.log( object )
+		console.log( object );
 
 		this.property = property;
 		this.uniformType = uniformType;

--- a/src/nodes/accessors/ReferenceNode.js
+++ b/src/nodes/accessors/ReferenceNode.js
@@ -42,10 +42,6 @@ class ReferenceNode extends Node {
 
 		super();
 
-		console.log( property );
-		console.log( uniformType );
-		console.log( object );
-
 		this.property = property;
 		this.uniformType = uniformType;
 		this.object = object;

--- a/src/nodes/accessors/SkinningNode.js
+++ b/src/nodes/accessors/SkinningNode.js
@@ -7,7 +7,7 @@ import { add } from '../math/OperatorNode.js';
 import { normalLocal } from './NormalNode.js';
 import { positionLocal } from './PositionNode.js';
 import { tangentLocal } from './TangentNode.js';
-import { uniform } from '../core/UniformNode.js';
+import { uniform } from '../accessors/UniformsNode.js';
 import { buffer } from './BufferNode.js';
 
 class SkinningNode extends Node {

--- a/src/nodes/accessors/TextureNode.js
+++ b/src/nodes/accessors/TextureNode.js
@@ -1,4 +1,5 @@
-import UniformNode, { uniform } from '../core/UniformNode.js';
+import UniformNode from '../core/UniformNode.js'
+import { uniform } from '../accessors/UniformsNode.js';
 import { uv } from './UVNode.js';
 import { textureSize } from './TextureSizeNode.js';
 import { colorSpaceToLinear } from '../display/ColorSpaceNode.js';

--- a/src/nodes/accessors/TextureNode.js
+++ b/src/nodes/accessors/TextureNode.js
@@ -1,4 +1,4 @@
-import UniformNode from '../core/UniformNode.js'
+import UniformNode from '../core/UniformNode.js';
 import { uniform } from '../accessors/UniformsNode.js';
 import { uv } from './UVNode.js';
 import { textureSize } from './TextureSizeNode.js';

--- a/src/nodes/accessors/UniformsNode.js
+++ b/src/nodes/accessors/UniformsNode.js
@@ -146,10 +146,10 @@ export default UniformsNode;
 export const uniform = ( uniformValue, elementType ) => {
 
 	if ( Array.isArray( uniformValue ) ) {
-		
-		return nodeObject( new UniformsNode( uniformValue, elementType ) )
 
-	} 
+		return nodeObject( new UniformsNode( uniformValue, elementType ) );
+
+	}
 
 	const nodeType = getConstNodeType( elementType || uniformValue );
 

--- a/src/nodes/accessors/UniformsNode.js
+++ b/src/nodes/accessors/UniformsNode.js
@@ -4,6 +4,8 @@ import { NodeUpdateType } from '../core/constants.js';
 import { getValueType } from '../core/NodeUtils.js';
 import ArrayElementNode from '../utils/ArrayElementNode.js';
 import BufferNode from './BufferNode.js';
+import { getConstNodeType } from '../shadernode/ShaderNode.js';
+import UniformNode from '../core/UniformNode.js';
 
 class UniformsElementNode extends ArrayElementNode {
 
@@ -141,6 +143,21 @@ class UniformsNode extends BufferNode {
 
 export default UniformsNode;
 
-export const uniforms = ( values, nodeType ) => nodeObject( new UniformsNode( values, nodeType ) );
+export const uniform = ( uniformValue, elementType ) => {
+
+	if ( Array.isArray( uniformValue ) ) {
+		
+		return nodeObject( new UniformsNode( uniformValue, elementType ) )
+
+	} 
+
+	const nodeType = getConstNodeType( elementType || uniformValue );
+
+	// @TODO: get ConstNode from .traverse() in the future
+	const value = ( uniformValue && uniformValue.isNode === true ) ? ( uniformValue.node && uniformValue.node.value ) || uniformValue.value : uniformValue;
+
+	return nodeObject( new UniformNode( value, nodeType ) );
+
+};
 
 addNodeClass( 'UniformsNode', UniformsNode );

--- a/src/nodes/core/UniformNode.js
+++ b/src/nodes/core/UniformNode.js
@@ -1,7 +1,6 @@
 import InputNode from './InputNode.js';
 import { objectGroup } from './UniformGroupNode.js';
 import { addNodeClass } from './Node.js';
-import { nodeObject, getConstNodeType } from '../shadernode/ShaderNode.js';
 
 class UniformNode extends InputNode {
 
@@ -94,16 +93,5 @@ class UniformNode extends InputNode {
 }
 
 export default UniformNode;
-
-export const uniform = ( arg1, arg2 ) => {
-
-	const nodeType = getConstNodeType( arg2 || arg1 );
-
-	// @TODO: get ConstNode from .traverse() in the future
-	const value = ( arg1 && arg1.isNode === true ) ? ( arg1.node && arg1.node.value ) || arg1.value : arg1;
-
-	return nodeObject( new UniformNode( value, nodeType ) );
-
-};
 
 addNodeClass( 'UniformNode', UniformNode );

--- a/src/nodes/display/AfterImageNode.js
+++ b/src/nodes/display/AfterImageNode.js
@@ -4,7 +4,7 @@ import { NodeUpdateType } from '../core/constants.js';
 import { uv } from '../accessors/UVNode.js';
 import { texture } from '../accessors/TextureNode.js';
 import { passTexture } from './PassNode.js';
-import { uniform } from '../core/UniformNode.js';
+import { uniform } from '../accessors/UniformsNode.js';
 import { sign, max } from '../math/MathNode.js';
 import QuadMesh from '../../renderers/common/QuadMesh.js';
 

--- a/src/nodes/display/AnamorphicNode.js
+++ b/src/nodes/display/AnamorphicNode.js
@@ -1,7 +1,7 @@
 import TempNode from '../core/TempNode.js';
 import { nodeObject, addNodeElement, tslFn, float, vec2, vec3 } from '../shadernode/ShaderNode.js';
 import { loop } from '../utils/LoopNode.js';
-import { uniform } from '../core/UniformNode.js';
+import { uniform } from '../accessors/UniformsNode.js';
 import { NodeUpdateType } from '../core/constants.js';
 import { threshold } from './ColorAdjustmentNode.js';
 import { uv } from '../accessors/UVNode.js';

--- a/src/nodes/display/DenoiseNode.js
+++ b/src/nodes/display/DenoiseNode.js
@@ -2,8 +2,7 @@ import TempNode from '../core/TempNode.js';
 import { uv } from '../accessors/UVNode.js';
 import { addNodeElement, tslFn, nodeObject, float, int, vec2, vec3, vec4, mat2, If } from '../shadernode/ShaderNode.js';
 import { NodeUpdateType } from '../core/constants.js';
-import { uniform } from '../core/UniformNode.js';
-import { uniforms } from '../accessors/UniformsNode.js';
+import { uniform } from '../accessors/UniformsNode.js';
 import { abs, dot, sin, cos, PI, pow, max } from '../math/MathNode.js';
 import { loop } from '../utils/LoopNode.js';
 import { luminance } from './ColorAdjustmentNode.js';
@@ -30,7 +29,7 @@ class DenoiseNode extends TempNode {
 		this.index = uniform( 0 );
 
 		this._resolution = uniform( new Vector2() );
-		this._sampleVectors = uniforms( generatePdSamplePointInitializer( 16, 2, 1 ) );
+		this._sampleVectors = uniform( generatePdSamplePointInitializer( 16, 2, 1 ) );
 
 		this.updateBeforeType = NodeUpdateType.RENDER;
 

--- a/src/nodes/display/DepthOfFieldNode.js
+++ b/src/nodes/display/DepthOfFieldNode.js
@@ -2,7 +2,7 @@ import TempNode from '../core/TempNode.js';
 import { uv } from '../accessors/UVNode.js';
 import { addNodeElement, tslFn, nodeObject, vec2, vec4 } from '../shadernode/ShaderNode.js';
 import { NodeUpdateType } from '../core/constants.js';
-import { uniform } from '../core/UniformNode.js';
+import { uniform } from '../accessors/UniformsNode.js';
 import { clamp } from '../math/MathNode.js';
 
 class DepthOfFieldNode extends TempNode {

--- a/src/nodes/display/DotScreenNode.js
+++ b/src/nodes/display/DotScreenNode.js
@@ -1,6 +1,6 @@
 import TempNode from '../core/TempNode.js';
 import { nodeObject, addNodeElement, tslFn, vec2, vec3, vec4 } from '../shadernode/ShaderNode.js';
-import { uniform } from '../core/UniformNode.js';
+import { uniform } from '../accessors/UniformsNode.js';
 import { NodeUpdateType } from '../core/constants.js';
 import { uv } from '../accessors/UVNode.js';
 import { sin, cos } from '../math/MathNode.js';

--- a/src/nodes/display/FXAANode.js
+++ b/src/nodes/display/FXAANode.js
@@ -2,7 +2,7 @@ import TempNode from '../core/TempNode.js';
 import { uv } from '../accessors/UVNode.js';
 import { addNodeElement, tslFn, nodeObject, float, vec2, vec4, int, If } from '../shadernode/ShaderNode.js';
 import { NodeUpdateType } from '../core/constants.js';
-import { uniform } from '../core/UniformNode.js';
+import { uniform } from '../accessors/UniformsNode.js';
 import { abs, max, min, mix, pow } from '../math/MathNode.js';
 import { sub } from '../math/OperatorNode.js';
 import { loop, Break } from '../utils/LoopNode.js';

--- a/src/nodes/display/GTAONode.js
+++ b/src/nodes/display/GTAONode.js
@@ -4,7 +4,7 @@ import { textureSize } from '../accessors/TextureSizeNode.js';
 import { uv } from '../accessors/UVNode.js';
 import { addNodeElement, nodeObject, tslFn, mat3, vec2, vec3, vec4, float, int, If } from '../shadernode/ShaderNode.js';
 import { NodeUpdateType } from '../core/constants.js';
-import { uniform } from '../core/UniformNode.js';
+import { uniform } from '../accessors/UniformsNode.js';
 import { DataTexture } from '../../textures/DataTexture.js';
 import { Vector2 } from '../../math/Vector2.js';
 import { Vector3 } from '../../math/Vector3.js';

--- a/src/nodes/display/GaussianBlurNode.js
+++ b/src/nodes/display/GaussianBlurNode.js
@@ -4,7 +4,7 @@ import { NodeUpdateType } from '../core/constants.js';
 import { mul } from '../math/OperatorNode.js';
 import { uv } from '../accessors/UVNode.js';
 import { passTexture } from './PassNode.js';
-import { uniform } from '../core/UniformNode.js';
+import { uniform } from '../accessors/UniformsNode.js';
 import QuadMesh from '../../renderers/common/QuadMesh.js';
 
 import { Vector2 } from '../../math/Vector2.js';

--- a/src/nodes/display/Lut3DNode.js
+++ b/src/nodes/display/Lut3DNode.js
@@ -1,6 +1,6 @@
 import TempNode from '../core/TempNode.js';
 import { addNodeElement, tslFn, nodeObject, vec3, vec4, float } from '../shadernode/ShaderNode.js';
-import { uniform } from '../core/UniformNode.js';
+import { uniform } from '../accessors/UniformsNode.js';
 import { mix } from '../math/MathNode.js';
 
 class Lut3DNode extends TempNode {

--- a/src/nodes/display/PassNode.js
+++ b/src/nodes/display/PassNode.js
@@ -3,7 +3,7 @@ import TempNode from '../core/TempNode.js';
 import { default as TextureNode/*, texture*/ } from '../accessors/TextureNode.js';
 import { NodeUpdateType } from '../core/constants.js';
 import { nodeObject } from '../shadernode/ShaderNode.js';
-import { uniform } from '../core/UniformNode.js';
+import { uniform } from '../accessors/UniformsNode.js';
 import { viewZToOrthographicDepth, perspectiveDepthToViewZ } from './ViewportDepthNode.js';
 
 import { HalfFloatType/*, FloatType*/ } from '../../constants.js';

--- a/src/nodes/display/PixelationPassNode.js
+++ b/src/nodes/display/PixelationPassNode.js
@@ -2,7 +2,7 @@ import TempNode from '../core/TempNode.js';
 import { uv } from '../accessors/UVNode.js';
 import { addNodeElement, tslFn, nodeObject, vec2, vec3, float, If } from '../shadernode/ShaderNode.js';
 import { NodeUpdateType } from '../core/constants.js';
-import { uniform } from '../core/UniformNode.js';
+import { uniform } from '../accessors/UniformsNode.js';
 import { dot, clamp, smoothstep, sign, step, floor } from '../math/MathNode.js';
 import { Vector4 } from '../../math/Vector4.js';
 import { output, property } from '../core/PropertyNode.js';

--- a/src/nodes/display/RGBShiftNode.js
+++ b/src/nodes/display/RGBShiftNode.js
@@ -1,6 +1,6 @@
 import TempNode from '../core/TempNode.js';
 import { nodeObject, addNodeElement, tslFn, vec2, vec4 } from '../shadernode/ShaderNode.js';
-import { uniform } from '../core/UniformNode.js';
+import { uniform } from '../accessors/UniformsNode.js';
 import { uv } from '../accessors/UVNode.js';
 import { sin, cos } from '../math/MathNode.js';
 

--- a/src/nodes/display/SobelOperatorNode.js
+++ b/src/nodes/display/SobelOperatorNode.js
@@ -3,7 +3,7 @@ import { uv } from '../accessors/UVNode.js';
 import { luminance } from './ColorAdjustmentNode.js';
 import { addNodeElement, tslFn, nodeObject, vec2, vec3, vec4, mat3 } from '../shadernode/ShaderNode.js';
 import { NodeUpdateType } from '../core/constants.js';
-import { uniform } from '../core/UniformNode.js';
+import { uniform } from '../accessors/UniformsNode.js';
 import { add } from '../math/OperatorNode.js';
 
 import { Vector2 } from '../../math/Vector2.js';

--- a/src/nodes/display/ViewportNode.js
+++ b/src/nodes/display/ViewportNode.js
@@ -1,6 +1,6 @@
 import Node, { addNodeClass } from '../core/Node.js';
 import { NodeUpdateType } from '../core/constants.js';
-import { uniform } from '../core/UniformNode.js';
+import { uniform } from '../accessors/UniformsNode.js';
 import { nodeImmutable, vec2 } from '../shadernode/ShaderNode.js';
 
 import { Vector2 } from '../../math/Vector2.js';

--- a/src/nodes/lighting/AnalyticLightNode.js
+++ b/src/nodes/lighting/AnalyticLightNode.js
@@ -1,6 +1,6 @@
 import LightingNode from './LightingNode.js';
 import { NodeUpdateType } from '../core/constants.js';
-import { uniform } from '../core/UniformNode.js';
+import { uniform } from '../accessors/UniformsNode.js';
 import { addNodeClass } from '../core/Node.js';
 import { vec3, vec4 } from '../shadernode/ShaderNode.js';
 import { reference } from '../accessors/ReferenceNode.js';

--- a/src/nodes/lighting/HemisphereLightNode.js
+++ b/src/nodes/lighting/HemisphereLightNode.js
@@ -1,6 +1,6 @@
 import AnalyticLightNode from './AnalyticLightNode.js';
 import { addLightNode } from './LightsNode.js';
-import { uniform } from '../core/UniformNode.js';
+import { uniform } from '../accessors/UniformsNode.js';
 import { mix } from '../math/MathNode.js';
 import { normalView } from '../accessors/NormalNode.js';
 import { objectPosition } from '../accessors/Object3DNode.js';

--- a/src/nodes/lighting/PointLightNode.js
+++ b/src/nodes/lighting/PointLightNode.js
@@ -1,7 +1,7 @@
 import AnalyticLightNode from './AnalyticLightNode.js';
 import { addLightNode } from './LightsNode.js';
 import { getDistanceAttenuation } from './LightUtils.js';
-import { uniform } from '../core/UniformNode.js';
+import { uniform } from '../accessors/UniformsNode.js';
 import { objectViewPosition } from '../accessors/Object3DNode.js';
 import { positionView } from '../accessors/PositionNode.js';
 import { addNodeClass } from '../core/Node.js';

--- a/src/nodes/lighting/RectAreaLightNode.js
+++ b/src/nodes/lighting/RectAreaLightNode.js
@@ -1,7 +1,7 @@
 import AnalyticLightNode from './AnalyticLightNode.js';
 import { addLightNode } from './LightsNode.js';
 import { texture } from '../accessors/TextureNode.js';
-import { uniform } from '../core/UniformNode.js';
+import { uniform } from '../accessors/UniformsNode.js';
 import { objectViewPosition } from '../accessors/Object3DNode.js';
 import { addNodeClass } from '../core/Node.js';
 

--- a/src/nodes/lighting/SpotLightNode.js
+++ b/src/nodes/lighting/SpotLightNode.js
@@ -2,7 +2,7 @@ import AnalyticLightNode from './AnalyticLightNode.js';
 import { lightTargetDirection } from './LightNode.js';
 import { addLightNode } from './LightsNode.js';
 import { getDistanceAttenuation } from './LightUtils.js';
-import { uniform } from '../core/UniformNode.js';
+import { uniform } from '../accessors/UniformsNode.js';
 import { smoothstep } from '../math/MathNode.js';
 import { objectViewPosition } from '../accessors/Object3DNode.js';
 import { positionView } from '../accessors/PositionNode.js';

--- a/src/nodes/materials/SpriteNodeMaterial.js
+++ b/src/nodes/materials/SpriteNodeMaterial.js
@@ -1,5 +1,5 @@
 import NodeMaterial, { addNodeMaterial } from './NodeMaterial.js';
-import { uniform } from '../core/UniformNode.js';
+import { uniform } from '../accessors/UniformsNode.js';
 import { cameraProjectionMatrix } from '../accessors/CameraNode.js';
 import { materialRotation } from '../accessors/MaterialNode.js';
 import { modelViewMatrix, modelWorldMatrix } from '../accessors/ModelNode.js';

--- a/src/nodes/pmrem/PMREMNode.js
+++ b/src/nodes/pmrem/PMREMNode.js
@@ -2,7 +2,7 @@ import TempNode from '../core/TempNode.js';
 import { addNodeClass } from '../core/Node.js';
 import { texture } from '../accessors/TextureNode.js';
 import { textureCubeUV } from './PMREMUtils.js';
-import { uniform } from '../core/UniformNode.js';
+import { uniform } from '../accessors/UniformsNode.js';
 import { NodeUpdateType } from '../core/constants.js';
 import { nodeProxy, vec3 } from '../shadernode/ShaderNode.js';
 

--- a/src/renderers/common/extras/PMREMGenerator.js
+++ b/src/renderers/common/extras/PMREMGenerator.js
@@ -1,8 +1,7 @@
 import NodeMaterial from '../../../nodes/materials/NodeMaterial.js';
 import { getDirection, blur } from '../../../nodes/pmrem/PMREMUtils.js';
 import { equirectUV } from '../../../nodes/utils/EquirectUVNode.js';
-import { uniform } from '../../../nodes/core/UniformNode.js';
-import { uniforms } from '../../../nodes/accessors/UniformsNode.js';
+import { uniform } from '../../../nodes/accessors/UniformsNode.js';
 import { texture } from '../../../nodes/accessors/TextureNode.js';
 import { cubeTexture } from '../../../nodes/accessors/CubeTextureNode.js';
 import { float, vec3 } from '../../../nodes/shadernode/ShaderNode.js';
@@ -718,7 +717,7 @@ function _getMaterial() {
 
 function _getBlurShader( lodMax, width, height ) {
 
-	const weights = uniforms( new Array( MAX_SAMPLES ).fill( 0 ) );
+	const weights = uniform( new Array( MAX_SAMPLES ).fill( 0 ) );
 	const poleAxis = uniform( new Vector3( 0, 1, 0 ) );
 	const dTheta = uniform( 0 );
 	const n = float( MAX_SAMPLES );


### PR DESCRIPTION
Related issue: #28878
**Description**

A follow-up from a discussion with @Mugen87. Although I don't really like the organization of the uniform() function being imported from the UniformsNode (which imports from a UniformNode derived class ), I think this removes a minor syntax hiccup on the developer side and is easy enough to understand for maintainers. 

Since this needs to be tested first, and would necessitate syntax and import changes for any incoming samples or contributions, this should be merged in after r167 is complete.