### PR TITLE
Renderer: Use output color space conversion only when rendering to screen.

### DIFF
--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -457,7 +457,7 @@ class Renderer {
 		const { currentColorSpace } = this;
 
 		const useToneMapping = this._renderTarget === null && ( this.toneMapping !== NoToneMapping );
-		const useColorSpace = currentColorSpace !== LinearSRGBColorSpace && currentColorSpace !== NoColorSpace;
+		const useColorSpace = this._renderTarget === null && ( currentColorSpace !== LinearSRGBColorSpace && currentColorSpace !== NoColorSpace );
 
 		if ( useToneMapping === false && useColorSpace === false ) return null;
 


### PR DESCRIPTION
Fixed #28826.

**Description**

This PR ensures output tone mapping and color space conversion follow the same policy. They are only used when rendering to screen.
