### PR TITLE
Nodes: Rename `uniforms()` to `uniformArray()`. 

### DIFF
--- a/src/nodes/Nodes.js
+++ b/src/nodes/Nodes.js
@@ -78,7 +78,7 @@ export * from './shadernode/ShaderNode.js';
 
 // accessors
 export { TBNViewMatrix, parallaxDirection, parallaxUV, transformedBentNormalView } from './accessors/AccessorsUtils.js';
-export { default as UniformsNode, uniforms } from './accessors/UniformsNode.js';
+export { default as UniformsNode, uniformsArray } from './accessors/UniformsNode.js';
 export * from './accessors/BitangentNode.js';
 export { default as BufferAttributeNode, bufferAttribute, dynamicBufferAttribute, instancedBufferAttribute, instancedDynamicBufferAttribute } from './accessors/BufferAttributeNode.js';
 export { default as BufferNode, buffer } from './accessors/BufferNode.js';

--- a/src/nodes/Nodes.js
+++ b/src/nodes/Nodes.js
@@ -78,7 +78,7 @@ export * from './shadernode/ShaderNode.js';
 
 // accessors
 export { TBNViewMatrix, parallaxDirection, parallaxUV, transformedBentNormalView } from './accessors/AccessorsUtils.js';
-export { default as UniformsNode, uniformsArray } from './accessors/UniformsNode.js';
+export { default as UniformArrayNode, uniformArray } from './accessors/UniformArrayNode.js';
 export * from './accessors/BitangentNode.js';
 export { default as BufferAttributeNode, bufferAttribute, dynamicBufferAttribute, instancedBufferAttribute, instancedDynamicBufferAttribute } from './accessors/BufferAttributeNode.js';
 export { default as BufferNode, buffer } from './accessors/BufferNode.js';

--- a/src/nodes/accessors/ClippingNode.js
+++ b/src/nodes/accessors/ClippingNode.js
@@ -6,7 +6,7 @@ import { diffuseColor, property } from '../core/PropertyNode.js';
 import { tslFn } from '../shadernode/ShaderNode.js';
 import { loop } from '../utils/LoopNode.js';
 import { smoothstep } from '../math/MathNode.js';
-import { uniforms } from './UniformsNode.js';
+import { uniformsArray } from './UniformsNode.js';
 
 class ClippingNode extends Node {
 
@@ -44,7 +44,7 @@ class ClippingNode extends Node {
 
 		return tslFn( () => {
 
-			const clippingPlanes = uniforms( planes );
+			const clippingPlanes = uniformsArray( planes );
 
 			const distanceToPlane = property( 'float', 'distanceToPlane' );
 			const distanceGradient = property( 'float', 'distanceToGradient' );
@@ -101,7 +101,7 @@ class ClippingNode extends Node {
 
 		return tslFn( () => {
 
-			const clippingPlanes = uniforms( planes );
+			const clippingPlanes = uniformsArray( planes );
 
 			let plane;
 

--- a/src/nodes/accessors/ClippingNode.js
+++ b/src/nodes/accessors/ClippingNode.js
@@ -6,7 +6,7 @@ import { diffuseColor, property } from '../core/PropertyNode.js';
 import { tslFn } from '../shadernode/ShaderNode.js';
 import { loop } from '../utils/LoopNode.js';
 import { smoothstep } from '../math/MathNode.js';
-import { uniformsArray } from './UniformsNode.js';
+import { uniformArray } from './UniformArrayNode.js';
 
 class ClippingNode extends Node {
 
@@ -44,7 +44,7 @@ class ClippingNode extends Node {
 
 		return tslFn( () => {
 
-			const clippingPlanes = uniformsArray( planes );
+			const clippingPlanes = uniformArray( planes );
 
 			const distanceToPlane = property( 'float', 'distanceToPlane' );
 			const distanceGradient = property( 'float', 'distanceToGradient' );
@@ -101,7 +101,7 @@ class ClippingNode extends Node {
 
 		return tslFn( () => {
 
-			const clippingPlanes = uniformsArray( planes );
+			const clippingPlanes = uniformArray( planes );
 
 			let plane;
 

--- a/src/nodes/accessors/ReferenceNode.js
+++ b/src/nodes/accessors/ReferenceNode.js
@@ -4,7 +4,7 @@ import { uniform } from '../core/UniformNode.js';
 import { texture } from './TextureNode.js';
 import { buffer } from './BufferNode.js';
 import { nodeObject } from '../shadernode/ShaderNode.js';
-import { uniforms } from './UniformsNode.js';
+import { uniformsArray } from './UniformsNode.js';
 import ArrayElementNode from '../utils/ArrayElementNode.js';
 
 class ReferenceElementNode extends ArrayElementNode {
@@ -72,7 +72,7 @@ class ReferenceNode extends Node {
 
 		} else if ( Array.isArray( this.getValueFromReference() ) ) {
 
-			node = uniforms( null, uniformType );
+			node = uniformsArray( null, uniformType );
 
 		} else if ( uniformType === 'texture' ) {
 

--- a/src/nodes/accessors/ReferenceNode.js
+++ b/src/nodes/accessors/ReferenceNode.js
@@ -4,7 +4,7 @@ import { uniform } from '../core/UniformNode.js';
 import { texture } from './TextureNode.js';
 import { buffer } from './BufferNode.js';
 import { nodeObject } from '../shadernode/ShaderNode.js';
-import { uniformsArray } from './UniformsNode.js';
+import { uniformArray } from './UniformArrayNode.js';
 import ArrayElementNode from '../utils/ArrayElementNode.js';
 
 class ReferenceElementNode extends ArrayElementNode {
@@ -72,7 +72,7 @@ class ReferenceNode extends Node {
 
 		} else if ( Array.isArray( this.getValueFromReference() ) ) {
 
-			node = uniformsArray( null, uniformType );
+			node = uniformArray( null, uniformType );
 
 		} else if ( uniformType === 'texture' ) {
 

--- a/src/nodes/accessors/UniformArrayNode.js
+++ b/src/nodes/accessors/UniformArrayNode.js
@@ -5,7 +5,7 @@ import { getValueType } from '../core/NodeUtils.js';
 import ArrayElementNode from '../utils/ArrayElementNode.js';
 import BufferNode from './BufferNode.js';
 
-class UniformsElementNode extends ArrayElementNode {
+class UniformArrayElementNode extends ArrayElementNode {
 
 	constructor( arrayBuffer, indexNode ) {
 
@@ -32,7 +32,7 @@ class UniformsElementNode extends ArrayElementNode {
 
 }
 
-class UniformsNode extends BufferNode {
+class UniformArrayNode extends BufferNode {
 
 	constructor( value, elementType = null ) {
 
@@ -133,14 +133,14 @@ class UniformsNode extends BufferNode {
 
 	element( indexNode ) {
 
-		return nodeObject( new UniformsElementNode( this, nodeObject( indexNode ) ) );
+		return nodeObject( new UniformArrayElementNode( this, nodeObject( indexNode ) ) );
 
 	}
 
 }
 
-export default UniformsNode;
+export default UniformArrayNode;
 
-export const uniformsArray = ( values, nodeType ) => nodeObject( new UniformsNode( values, nodeType ) );
+export const uniformArray = ( values, nodeType ) => nodeObject( new UniformArrayNode( values, nodeType ) );
 
-addNodeClass( 'UniformsNode', UniformsNode );
+addNodeClass( 'UniformArrayNode', UniformArrayNode );

--- a/src/nodes/accessors/UniformsNode.js
+++ b/src/nodes/accessors/UniformsNode.js
@@ -141,6 +141,6 @@ class UniformsNode extends BufferNode {
 
 export default UniformsNode;
 
-export const uniforms = ( values, nodeType ) => nodeObject( new UniformsNode( values, nodeType ) );
+export const uniformsArray = ( values, nodeType ) => nodeObject( new UniformsNode( values, nodeType ) );
 
 addNodeClass( 'UniformsNode', UniformsNode );

--- a/src/nodes/display/BloomNode.js
+++ b/src/nodes/display/BloomNode.js
@@ -3,7 +3,7 @@ import { addNodeElement, tslFn, nodeObject, float, vec4, int } from '../shaderno
 import { mix, smoothstep } from '../math/MathNode.js';
 import { luminance } from './ColorAdjustmentNode.js';
 import { uniform } from '../core/UniformNode.js';
-import { uniforms } from '../accessors/UniformsNode.js';
+import { uniformsArray } from '../accessors/UniformsNode.js';
 import { uv } from '../accessors/UVNode.js';
 import { Color } from '../../math/Color.js';
 import { passTexture } from './PassNode.js';
@@ -210,8 +210,8 @@ class BloomNode extends TempNode {
 
 		// composite material
 
-		const bloomFactors = uniforms( [ 1.0, 0.8, 0.6, 0.4, 0.2 ] );
-		const bloomTintColors = uniforms( [ new Vector3( 1, 1, 1 ), new Vector3( 1, 1, 1 ), new Vector3( 1, 1, 1 ), new Vector3( 1, 1, 1 ), new Vector3( 1, 1, 1 ) ] );
+		const bloomFactors = uniformsArray( [ 1.0, 0.8, 0.6, 0.4, 0.2 ] );
+		const bloomTintColors = uniformsArray( [ new Vector3( 1, 1, 1 ), new Vector3( 1, 1, 1 ), new Vector3( 1, 1, 1 ), new Vector3( 1, 1, 1 ), new Vector3( 1, 1, 1 ) ] );
 
 		const lerpBloomFactor = tslFn( ( [ factor, radius ] ) => {
 
@@ -283,7 +283,7 @@ class BloomNode extends TempNode {
 		//
 
 		const colorTexture = texture();
-		const gaussianCoefficients = uniforms( coefficients );
+		const gaussianCoefficients = uniformsArray( coefficients );
 		const invSize = uniform( new Vector2() );
 		const direction = uniform( new Vector2( 0.5, 0.5 ) );
 

--- a/src/nodes/display/BloomNode.js
+++ b/src/nodes/display/BloomNode.js
@@ -3,7 +3,7 @@ import { addNodeElement, tslFn, nodeObject, float, vec4, int } from '../shaderno
 import { mix, smoothstep } from '../math/MathNode.js';
 import { luminance } from './ColorAdjustmentNode.js';
 import { uniform } from '../core/UniformNode.js';
-import { uniformsArray } from '../accessors/UniformsNode.js';
+import { uniformArray } from '../accessors/UniformArrayNode.js';
 import { uv } from '../accessors/UVNode.js';
 import { Color } from '../../math/Color.js';
 import { passTexture } from './PassNode.js';
@@ -210,8 +210,8 @@ class BloomNode extends TempNode {
 
 		// composite material
 
-		const bloomFactors = uniformsArray( [ 1.0, 0.8, 0.6, 0.4, 0.2 ] );
-		const bloomTintColors = uniformsArray( [ new Vector3( 1, 1, 1 ), new Vector3( 1, 1, 1 ), new Vector3( 1, 1, 1 ), new Vector3( 1, 1, 1 ), new Vector3( 1, 1, 1 ) ] );
+		const bloomFactors = uniformArray( [ 1.0, 0.8, 0.6, 0.4, 0.2 ] );
+		const bloomTintColors = uniformArray( [ new Vector3( 1, 1, 1 ), new Vector3( 1, 1, 1 ), new Vector3( 1, 1, 1 ), new Vector3( 1, 1, 1 ), new Vector3( 1, 1, 1 ) ] );
 
 		const lerpBloomFactor = tslFn( ( [ factor, radius ] ) => {
 
@@ -283,7 +283,7 @@ class BloomNode extends TempNode {
 		//
 
 		const colorTexture = texture();
-		const gaussianCoefficients = uniformsArray( coefficients );
+		const gaussianCoefficients = uniformArray( coefficients );
 		const invSize = uniform( new Vector2() );
 		const direction = uniform( new Vector2( 0.5, 0.5 ) );
 

--- a/src/nodes/display/DenoiseNode.js
+++ b/src/nodes/display/DenoiseNode.js
@@ -3,7 +3,7 @@ import { uv } from '../accessors/UVNode.js';
 import { addNodeElement, tslFn, nodeObject, float, int, vec2, vec3, vec4, mat2, If } from '../shadernode/ShaderNode.js';
 import { NodeUpdateType } from '../core/constants.js';
 import { uniform } from '../core/UniformNode.js';
-import { uniforms } from '../accessors/UniformsNode.js';
+import { uniformsArray } from '../accessors/UniformsNode.js';
 import { abs, dot, sin, cos, PI, pow, max } from '../math/MathNode.js';
 import { loop } from '../utils/LoopNode.js';
 import { luminance } from './ColorAdjustmentNode.js';
@@ -30,7 +30,7 @@ class DenoiseNode extends TempNode {
 		this.index = uniform( 0 );
 
 		this._resolution = uniform( new Vector2() );
-		this._sampleVectors = uniforms( generatePdSamplePointInitializer( 16, 2, 1 ) );
+		this._sampleVectors = uniformsArray( generatePdSamplePointInitializer( 16, 2, 1 ) );
 
 		this.updateBeforeType = NodeUpdateType.RENDER;
 

--- a/src/nodes/display/DenoiseNode.js
+++ b/src/nodes/display/DenoiseNode.js
@@ -3,7 +3,7 @@ import { uv } from '../accessors/UVNode.js';
 import { addNodeElement, tslFn, nodeObject, float, int, vec2, vec3, vec4, mat2, If } from '../shadernode/ShaderNode.js';
 import { NodeUpdateType } from '../core/constants.js';
 import { uniform } from '../core/UniformNode.js';
-import { uniformsArray } from '../accessors/UniformsNode.js';
+import { uniformArray } from '../accessors/UniformArrayNode.js';
 import { abs, dot, sin, cos, PI, pow, max } from '../math/MathNode.js';
 import { loop } from '../utils/LoopNode.js';
 import { luminance } from './ColorAdjustmentNode.js';
@@ -30,7 +30,7 @@ class DenoiseNode extends TempNode {
 		this.index = uniform( 0 );
 
 		this._resolution = uniform( new Vector2() );
-		this._sampleVectors = uniformsArray( generatePdSamplePointInitializer( 16, 2, 1 ) );
+		this._sampleVectors = uniformArray( generatePdSamplePointInitializer( 16, 2, 1 ) );
 
 		this.updateBeforeType = NodeUpdateType.RENDER;
 

--- a/src/renderers/common/extras/PMREMGenerator.js
+++ b/src/renderers/common/extras/PMREMGenerator.js
@@ -2,7 +2,7 @@ import NodeMaterial from '../../../nodes/materials/NodeMaterial.js';
 import { getDirection, blur } from '../../../nodes/pmrem/PMREMUtils.js';
 import { equirectUV } from '../../../nodes/utils/EquirectUVNode.js';
 import { uniform } from '../../../nodes/core/UniformNode.js';
-import { uniforms } from '../../../nodes/accessors/UniformsNode.js';
+import { uniformsArray } from '../../../nodes/accessors/UniformsNode.js';
 import { texture } from '../../../nodes/accessors/TextureNode.js';
 import { cubeTexture } from '../../../nodes/accessors/CubeTextureNode.js';
 import { float, vec3 } from '../../../nodes/shadernode/ShaderNode.js';
@@ -718,7 +718,7 @@ function _getMaterial() {
 
 function _getBlurShader( lodMax, width, height ) {
 
-	const weights = uniforms( new Array( MAX_SAMPLES ).fill( 0 ) );
+	const weights = uniformsArray( new Array( MAX_SAMPLES ).fill( 0 ) );
 	const poleAxis = uniform( new Vector3( 0, 1, 0 ) );
 	const dTheta = uniform( 0 );
 	const n = float( MAX_SAMPLES );

--- a/src/renderers/common/extras/PMREMGenerator.js
+++ b/src/renderers/common/extras/PMREMGenerator.js
@@ -2,7 +2,7 @@ import NodeMaterial from '../../../nodes/materials/NodeMaterial.js';
 import { getDirection, blur } from '../../../nodes/pmrem/PMREMUtils.js';
 import { equirectUV } from '../../../nodes/utils/EquirectUVNode.js';
 import { uniform } from '../../../nodes/core/UniformNode.js';
-import { uniformsArray } from '../../../nodes/accessors/UniformsNode.js';
+import { uniformArray } from '../../../nodes/accessors/UniformArrayNode.js';
 import { texture } from '../../../nodes/accessors/TextureNode.js';
 import { cubeTexture } from '../../../nodes/accessors/CubeTextureNode.js';
 import { float, vec3 } from '../../../nodes/shadernode/ShaderNode.js';
@@ -718,7 +718,7 @@ function _getMaterial() {
 
 function _getBlurShader( lodMax, width, height ) {
 
-	const weights = uniformsArray( new Array( MAX_SAMPLES ).fill( 0 ) );
+	const weights = uniformArray( new Array( MAX_SAMPLES ).fill( 0 ) );
 	const poleAxis = uniform( new Vector3( 0, 1, 0 ) );
 	const dTheta = uniform( 0 );
 	const n = float( MAX_SAMPLES );


### PR DESCRIPTION
Related Issue: https://github.com/mrdoob/three.js/issues/28878
Related PR: #28897

**Description**

Rename the UniformsNode's uniforms() function to uniformArray(). This better communicates the difference in functionality and expected argument types between the uniform() and uniforms() functions.