### PR TITLE
Docs: Expand .aoMapIntensity description

### DIFF
--- a/docs/api/en/materials/MeshBasicMaterial.html
+++ b/docs/api/en/materials/MeshBasicMaterial.html
@@ -78,8 +78,8 @@
 
 		<h3>[property:Float aoMapIntensity]</h3>
 		<p>
-			Intensity of the ambient occlusion effect. Typical ranges are 0-1, where
-			`0` disables ambient occlusion. Where intensity is `1` and the [page:.aoMap]
+			Intensity of the ambient occlusion effect. Range is 0-1, where `0`
+			disables ambient occlusion. Where intensity is `1` and the [page:.aoMap]
 			red channel is also `1`, ambient light is fully occluded on a surface.
 			Default is `1`.
 		</p>

--- a/docs/api/en/materials/MeshBasicMaterial.html
+++ b/docs/api/en/materials/MeshBasicMaterial.html
@@ -78,8 +78,10 @@
 
 		<h3>[property:Float aoMapIntensity]</h3>
 		<p>
-			Intensity of the ambient occlusion effect. Default is `1`. Zero is no
-			occlusion effect.
+			Intensity of the ambient occlusion effect. Typical ranges are 0-1, where
+			`0` disables ambient occlusion. Where intensity is `1` and the [page:.aoMap]
+			red channel is also `1`, ambient light is fully occluded on a surface.
+			Default is `1`.
 		</p>
 
 		<h3>[property:Color color]</h3>

--- a/docs/api/en/materials/MeshLambertMaterial.html
+++ b/docs/api/en/materials/MeshLambertMaterial.html
@@ -87,8 +87,10 @@
 
 		<h3>[property:Float aoMapIntensity]</h3>
 		<p>
-			Intensity of the ambient occlusion effect. Default is `1`. Zero is no
-			occlusion effect.
+			Intensity of the ambient occlusion effect. Typical ranges are 0-1, where
+			`0` disables ambient occlusion. Where intensity is `1` and the [page:.aoMap]
+			red channel is also `1`, ambient light is fully occluded on a surface.
+			Default is `1`.
 		</p>
 
 		<h3>[property:Texture bumpMap]</h3>

--- a/docs/api/en/materials/MeshLambertMaterial.html
+++ b/docs/api/en/materials/MeshLambertMaterial.html
@@ -87,8 +87,8 @@
 
 		<h3>[property:Float aoMapIntensity]</h3>
 		<p>
-			Intensity of the ambient occlusion effect. Typical ranges are 0-1, where
-			`0` disables ambient occlusion. Where intensity is `1` and the [page:.aoMap]
+			Intensity of the ambient occlusion effect. Range is 0-1, where `0`
+			disables ambient occlusion. Where intensity is `1` and the [page:.aoMap]
 			red channel is also `1`, ambient light is fully occluded on a surface.
 			Default is `1`.
 		</p>

--- a/docs/api/en/materials/MeshPhongMaterial.html
+++ b/docs/api/en/materials/MeshPhongMaterial.html
@@ -85,8 +85,10 @@
 
 		<h3>[property:Float aoMapIntensity]</h3>
 		<p>
-			Intensity of the ambient occlusion effect. Default is `1`. Zero is no
-			occlusion effect.
+			Intensity of the ambient occlusion effect. Typical ranges are 0-1, where
+			`0` disables ambient occlusion. Where intensity is `1` and the [page:.aoMap]
+			red channel is also `1`, ambient light is fully occluded on a surface.
+			Default is `1`.
 		</p>
 
 		<h3>[property:Texture bumpMap]</h3>

--- a/docs/api/en/materials/MeshPhongMaterial.html
+++ b/docs/api/en/materials/MeshPhongMaterial.html
@@ -85,8 +85,8 @@
 
 		<h3>[property:Float aoMapIntensity]</h3>
 		<p>
-			Intensity of the ambient occlusion effect. Typical ranges are 0-1, where
-			`0` disables ambient occlusion. Where intensity is `1` and the [page:.aoMap]
+			Intensity of the ambient occlusion effect. Range is 0-1, where `0`
+			disables ambient occlusion. Where intensity is `1` and the [page:.aoMap]
 			red channel is also `1`, ambient light is fully occluded on a surface.
 			Default is `1`.
 		</p>

--- a/docs/api/en/materials/MeshStandardMaterial.html
+++ b/docs/api/en/materials/MeshStandardMaterial.html
@@ -114,8 +114,8 @@
 
 		<h3>[property:Float aoMapIntensity]</h3>
 		<p>
-			Intensity of the ambient occlusion effect. Typical ranges are 0-1, where
-			`0` disables ambient occlusion. Where intensity is `1` and the [page:.aoMap]
+			Intensity of the ambient occlusion effect. Range is 0-1, where `0`
+			disables ambient occlusion. Where intensity is `1` and the [page:.aoMap]
 			red channel is also `1`, ambient light is fully occluded on a surface.
 			Default is `1`.
 		</p>

--- a/docs/api/en/materials/MeshStandardMaterial.html
+++ b/docs/api/en/materials/MeshStandardMaterial.html
@@ -114,8 +114,10 @@
 
 		<h3>[property:Float aoMapIntensity]</h3>
 		<p>
-			Intensity of the ambient occlusion effect. Default is `1`. Zero is no
-			occlusion effect.
+			Intensity of the ambient occlusion effect. Typical ranges are 0-1, where
+			`0` disables ambient occlusion. Where intensity is `1` and the [page:.aoMap]
+			red channel is also `1`, ambient light is fully occluded on a surface.
+			Default is `1`.
 		</p>
 
 		<h3>[property:Texture bumpMap]</h3>

--- a/docs/api/en/materials/MeshToonMaterial.html
+++ b/docs/api/en/materials/MeshToonMaterial.html
@@ -78,8 +78,8 @@
 
 		<h3>[property:Float aoMapIntensity]</h3>
 		<p>
-			Intensity of the ambient occlusion effect. Typical ranges are 0-1, where
-			`0` disables ambient occlusion. Where intensity is `1` and the [page:.aoMap]
+			Intensity of the ambient occlusion effect. Range is 0-1, where `0`
+			disables ambient occlusion. Where intensity is `1` and the [page:.aoMap]
 			red channel is also `1`, ambient light is fully occluded on a surface.
 			Default is `1`.
 		</p>

--- a/docs/api/en/materials/MeshToonMaterial.html
+++ b/docs/api/en/materials/MeshToonMaterial.html
@@ -78,8 +78,10 @@
 
 		<h3>[property:Float aoMapIntensity]</h3>
 		<p>
-			Intensity of the ambient occlusion effect. Default is `1`. Zero is no
-			occlusion effect.
+			Intensity of the ambient occlusion effect. Typical ranges are 0-1, where
+			`0` disables ambient occlusion. Where intensity is `1` and the [page:.aoMap]
+			red channel is also `1`, ambient light is fully occluded on a surface.
+			Default is `1`.
 		</p>
 
 		<h3>[property:Texture bumpMap]</h3>


### PR DESCRIPTION
Clarification of the typical range for `.aoMapIntensity`.

Related: 

- https://discourse.threejs.org/t/ambient-occlusion-wrong-with-khronos-neutral-tone-mapper/68192/5

/cc @WestLangley 