### PR TITLE
WebGPURenderer: Align integer attribute check of WebGL backend.

### DIFF
--- a/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
+++ b/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
@@ -476,7 +476,7 @@ ${ flowData.code }
 
 			const array = dataAttribute.array;
 
-			if ( ( array instanceof Uint32Array || array instanceof Int32Array || array instanceof Uint16Array || array instanceof Int16Array ) === false ) {
+			if ( ( array instanceof Uint32Array || array instanceof Int32Array || array instanceof Int16Array ) === false ) {
 
 				nodeType = nodeType.slice( 1 );
 

--- a/src/renderers/webgl-fallback/utils/WebGLAttributeUtils.js
+++ b/src/renderers/webgl-fallback/utils/WebGLAttributeUtils.js
@@ -135,7 +135,7 @@ class WebGLAttributeUtils {
 			bytesPerElement: array.BYTES_PER_ELEMENT,
 			version: attribute.version,
 			pbo: attribute.pbo,
-			isInteger: type === gl.INT || type === gl.UNSIGNED_INT || type === gl.UNSIGNED_SHORT || attribute.gpuType === IntType,
+			isInteger: type === gl.INT || type === gl.UNSIGNED_INT || attribute.gpuType === IntType,
 			id: _id ++
 		};
 


### PR DESCRIPTION
Fixed #28898.

**Description**

This PR aligns the WebGL backend of `WebGPURenderer` to `WebGLRenderer` when deciding whether buffer data are integer or not.

Only `gl.INT` or  `gl.UNSIGNED_INT` are integer data input or when `attribute.gpuType` is set to `IntType`.

https://github.com/mrdoob/three.js/blob/98341133faa4ebfebb71fbc870099f7c99b9ce34/src/renderers/webgl/WebGLBindingStates.js#L345
