### PR TITLE
GLSLNodeBuilder: Remove `Int16Array` check from `getTypeFromAttribute()`.

### DIFF
--- a/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
+++ b/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
@@ -476,7 +476,7 @@ ${ flowData.code }
 
 			const array = dataAttribute.array;
 
-			if ( ( array instanceof Uint32Array || array instanceof Int32Array || array instanceof Int16Array ) === false ) {
+			if ( ( array instanceof Uint32Array || array instanceof Int32Array ) === false ) {
 
 				nodeType = nodeType.slice( 1 );
 


### PR DESCRIPTION
Related issue: #28918

**Description**

`Int16Array` or `gl.SHORT` is a float type by default in `WebGLRenderer`. It is only interpreted as integer input for attributes in the vertex shader if `attribute.gpuType` is `IntType`.
