### PR TITLE
Nodes: Cache linear depth and viewZ of depth textures in PassNode

### DIFF
--- a/src/nodes/display/PassNode.js
+++ b/src/nodes/display/PassNode.js
@@ -188,7 +188,7 @@ class PassNode extends TempNode {
 
 	getLinearDepthNode( name = 'depth' ) {
 
-		let linearDepthNode = this._linearDepthNodes( name );
+		let linearDepthNode = this._linearDepthNodes[ name ];
 
 		if ( linearDepthNode === undefined ) {
 

--- a/src/nodes/display/PassNode.js
+++ b/src/nodes/display/PassNode.js
@@ -196,6 +196,8 @@ class PassNode extends TempNode {
 			const cameraFar = this._cameraFar;
 			const viewZNode = this.getViewZNode( name );
 
+			// TODO: just if ( builder.camera.isPerspectiveCamera )
+
 			this._linearDepthNodes[ name ] = linearDepthNode = viewZToOrthographicDepth( viewZNode, cameraNear, cameraFar );
 
 		}

--- a/src/nodes/display/PassNode.js
+++ b/src/nodes/display/PassNode.js
@@ -173,12 +173,6 @@ class PassNode extends TempNode {
 
 		const depthTextureNode = this.getTextureNode( name );
 
-		if ( ! depthTextureNode.value.isDepthTexture ) {
-
-			throw new Error( 'PassNode: getViewZNode expects a depth texture' );
-
-		}
-
 		const cameraNear = this._cameraNear;
 		const cameraFar = this._cameraFar;
 

--- a/src/nodes/display/PassNode.js
+++ b/src/nodes/display/PassNode.js
@@ -171,33 +171,53 @@ class PassNode extends TempNode {
 
 	getViewZNode( name = 'depth' ) {
 
-		if ( this._viewZNode === null ) {
+		const depthTextureNode = this.getTextureNode( name );
 
-			const cameraNear = this._cameraNear;
-			const cameraFar = this._cameraFar;
+		if ( ! depthTextureNode.value.isDepthTexture ) {
 
-			this._viewZNode = perspectiveDepthToViewZ( this.getTextureNode( name ), cameraNear, cameraFar );
+			throw new Error( 'PassNode: getViewZNode expects a depth texture' );
 
 		}
 
-		return this._viewZNode;
+		const cameraNear = this._cameraNear;
+		const cameraFar = this._cameraFar;
+
+		if ( name === 'depth' ) {
+
+			if ( this._viewZNode === null ) {
+
+				this._viewZNode = perspectiveDepthToViewZ( depthTextureNode, cameraNear, cameraFar );
+
+			}
+
+			return this._viewZNode;
+
+		}
+
+		return perspectiveDepthToViewZ( depthTextureNode, cameraNear, cameraFar );
 
 	}
 
 	getLinearDepthNode( name = 'depth' ) {
 
-		if ( this._linearDepthNode === null ) {
+		const viewZNode = this.getViewZNode( name );
 
-			const cameraNear = this._cameraNear;
-			const cameraFar = this._cameraFar;
+		const cameraNear = this._cameraNear;
+		const cameraFar = this._cameraFar;
 
-			// TODO: just if ( builder.camera.isPerspectiveCamera )
+		if ( name === 'depth' ) {
 
-			this._linearDepthNode = viewZToOrthographicDepth( this.getViewZNode( name ), cameraNear, cameraFar );
+			if ( this._linearDepthNode === null ) {
+
+				this._linearDepthNode = viewZToOrthographicDepth( viewZNode, cameraNear, cameraFar );
+
+			}
+
+			return this._linearDepthNode;
 
 		}
 
-		return this._linearDepthNode;
+		return viewZToOrthographicDepth( viewZNode, cameraNear, cameraFar );
 
 	}
 

--- a/src/nodes/display/PassNode.js
+++ b/src/nodes/display/PassNode.js
@@ -100,10 +100,10 @@ class PassNode extends TempNode {
 			depth: depthTexture
 		};
 
-		this._nodes = {};
+		this._textureNodes = {};
+		this._linearDepthNodes = {};
+		this._viewZNodes = {};
 
-		this._linearDepthNode = null;
-		this._viewZNode = null;
 		this._cameraNear = uniform( 0 );
 		this._cameraFar = uniform( 0 );
 
@@ -157,11 +157,11 @@ class PassNode extends TempNode {
 
 	getTextureNode( name = 'output' ) {
 
-		let textureNode = this._nodes[ name ];
+		let textureNode = this._textureNodes[ name ];
 
 		if ( textureNode === undefined ) {
 
-			this._nodes[ name ] = textureNode = nodeObject( new PassMultipleTextureNode( this, name ) );
+			this._textureNodes[ name ] = textureNode = nodeObject( new PassMultipleTextureNode( this, name ) );
 
 		}
 
@@ -171,47 +171,36 @@ class PassNode extends TempNode {
 
 	getViewZNode( name = 'depth' ) {
 
-		const depthTextureNode = this.getTextureNode( name );
+		let viewZNode = this._viewZNodes[ name ];
 
-		const cameraNear = this._cameraNear;
-		const cameraFar = this._cameraFar;
+		if ( viewZNode === undefined ) {
 
-		if ( name === 'depth' ) {
+			const cameraNear = this._cameraNear;
+			const cameraFar = this._cameraFar;
 
-			if ( this._viewZNode === null ) {
-
-				this._viewZNode = perspectiveDepthToViewZ( depthTextureNode, cameraNear, cameraFar );
-
-			}
-
-			return this._viewZNode;
+			this._viewZNodes[ name ] = viewZNode = perspectiveDepthToViewZ( this.getTextureNode( name ), cameraNear, cameraFar );
 
 		}
 
-		return perspectiveDepthToViewZ( depthTextureNode, cameraNear, cameraFar );
+		return viewZNode;
 
 	}
 
 	getLinearDepthNode( name = 'depth' ) {
 
-		const viewZNode = this.getViewZNode( name );
+		let linearDepthNode = this._linearDepthNodes( name );
 
-		const cameraNear = this._cameraNear;
-		const cameraFar = this._cameraFar;
+		if ( linearDepthNode === undefined ) {
 
-		if ( name === 'depth' ) {
+			const cameraNear = this._cameraNear;
+			const cameraFar = this._cameraFar;
+			const viewZNode = this.getViewZNode( name );
 
-			if ( this._linearDepthNode === null ) {
-
-				this._linearDepthNode = viewZToOrthographicDepth( viewZNode, cameraNear, cameraFar );
-
-			}
-
-			return this._linearDepthNode;
+			this._linearDepthNodes[ name ] = linearDepthNode = viewZToOrthographicDepth( viewZNode, cameraNear, cameraFar );
 
 		}
 
-		return viewZToOrthographicDepth( viewZNode, cameraNear, cameraFar );
+		return linearDepthNode;
 
 	}
 

--- a/src/nodes/display/PassNode.js
+++ b/src/nodes/display/PassNode.js
@@ -169,14 +169,14 @@ class PassNode extends TempNode {
 
 	}
 
-	getViewZNode() {
+	getViewZNode( name = 'depth' ) {
 
 		if ( this._viewZNode === null ) {
 
 			const cameraNear = this._cameraNear;
 			const cameraFar = this._cameraFar;
 
-			this._viewZNode = perspectiveDepthToViewZ( this.getTextureNode( 'depth' ), cameraNear, cameraFar );
+			this._viewZNode = perspectiveDepthToViewZ( this.getTextureNode( name ), cameraNear, cameraFar );
 
 		}
 
@@ -184,7 +184,7 @@ class PassNode extends TempNode {
 
 	}
 
-	getLinearDepthNode() {
+	getLinearDepthNode( name = 'depth' ) {
 
 		if ( this._linearDepthNode === null ) {
 
@@ -193,7 +193,7 @@ class PassNode extends TempNode {
 
 			// TODO: just if ( builder.camera.isPerspectiveCamera )
 
-			this._linearDepthNode = viewZToOrthographicDepth( this.getViewZNode(), cameraNear, cameraFar );
+			this._linearDepthNode = viewZToOrthographicDepth( this.getViewZNode( name ), cameraNear, cameraFar );
 
 		}
 


### PR DESCRIPTION
**Description**

Following on from some work I'm doing porting the outline pass, this PR allows the user to access the linear depth and viewZ of multiple relevant depth textures within any class that extends PassNode. This can be helpful for debugging or accessing the linear depth of relevant depth passes to be forwarded to other post-processing steps.

Example usage below:

```
// Create a class that extends PassNodee
class PostPassNode extends PassNode {

	constructor( scene, camera ) {

		super( 'color', scene, camera );

		// Create Render Target Pass with color and depth
		let passName;

		this._prePassRT = new RenderTarget();
		passName = 'PostPassNode.prePassColor';
		this._prePassRT.texture.name = passName;
		this._textures[ passName ] = this._prePassRT.texture;

	        const prePassDepth = new DepthTexture();
	        passName = 'PostPassNode.prePassDepth';
		prePassDepth.name = passName;
	        prePassDepth.isRenderTargetTexture = true;
		this._prePassRT.depthTexture = prePassDepth;
		this._textures[ passName ] = this._prePassRT.depthTexture;

	}

	updateBefore( frame ) {

		const { renderer } = frame;
		const { scene, camera } = this;

		// Random configuration

		// Render to any number of render targets
		renderer.setRenderTarget( this._prePassRT );
		renderer.setMRT( null );
		renderer.render( scene, camera );

		// Render to final output
		renderer.setRenderTarget( this.renderTarget );
		renderer.setMRT( this._mrt );
		renderer.render( scene, camera );

	}

	setup() {

		// # Use Case 1: Debug depth output of texture

		return super.getLinearDepthNode(  'PostPassNode.prePassDepth'  );
                // return postProcess( ..... )

		// # Use Case 2: Apply depth or linear depth to shader post process node

		const color = super.getTextureNode( 'output' );
		const depth = super.getTextureNode( 'depth' ); 
                const linearDepth = super.getLinearDepth(); // 
		const prePassDepth = super.getTextureNode(  this._prePassRT.depthTexture.name );
		const prePassLinearDepth = super.getLinearDepthNode( this._prePassRT.depthTexture.name );

		return postProcess( color, depth, linearDepth, prePassDepth, prePassLinearDepth, uniformX, ...etc );

	}

}