### PR TITLE
Examples: Clean up.

### DIFF
--- a/examples/webgpu_postprocessing_3dlut.html
+++ b/examples/webgpu_postprocessing_3dlut.html
@@ -158,7 +158,7 @@
 				controls.target.set( 0, 0, - 0.2 );
 				controls.update();
 
-				gui = new GUI( { width: 350 } );
+				gui = new GUI();
 				gui.add( params, 'lut', Object.keys( lutMap ) );
 				gui.add( params, 'intensity' ).min( 0 ).max( 1 );
 

--- a/examples/webgpu_postprocessing_3dlut.html
+++ b/examples/webgpu_postprocessing_3dlut.html
@@ -158,8 +158,7 @@
 				controls.target.set( 0, 0, - 0.2 );
 				controls.update();
 
-				gui = new GUI();
-				gui.width = 350;
+				gui = new GUI( { width: 350 } );
 				gui.add( params, 'lut', Object.keys( lutMap ) );
 				gui.add( params, 'intensity' ).min( 0 ).max( 1 );
 


### PR DESCRIPTION
Related issue: N/A

**Description**

`GUI` has no `width` property, it's only accepted [through the constructor](https://github.com/georgealways/lil-gui/blob/master/src/GUI.js#L180-L182).