### PR TITLE
Examples: Clean up.

### DIFF
--- a/examples/webgpu_postprocessing_3dlut.html
+++ b/examples/webgpu_postprocessing_3dlut.html
@@ -103,9 +103,9 @@
 						lutMap[ name ] = lutCubeLoader.loadAsync( 'luts/' + name );
 
 					} else if ( /\LUT$/i.test( name ) ) {
-			
+
 						lutMap[ name ] = lutImageLoader.loadAsync( `luts/${name}.png` );
-			
+
 					} else {
 
 						lutMap[ name ] = lut3dlLoader.loadAsync( 'luts/' + name );
@@ -144,9 +144,8 @@
 				const scenePass = pass( scene, camera );
 				const outputPass = renderOutput( scenePass );
 
-				lutPass = outputPass.lut3D();
-				lutPass.lutNode = texture3D( lutMap[ params.lut ] );
-				lutPass.intensityNode = uniform( 1 );
+				const lut = lutMap[ params.lut ];
+				lutPass = outputPass.lut3D( texture3D( lut.texture3D ), lut.texture3D.image.width, uniform( 1 ) );
 
 				postProcessing.outputNode = lutPass;
 


### PR DESCRIPTION
Related issue: N/A

**Description**

This line is incorrect:

```js
lutPass.lutNode = texture3D( lutMap[ params.lut ] );
```

it should be:

```js
lutPass.lutNode = texture3D( lutMap[ params.lut ].texture3D );
```


Additionally the `Lut3DNode`s size is not initialized, so I fixed that as well.