### PR TITLE
WebGPUBindingUtils: Define `sampleType` for all data textures consistently.

### DIFF
--- a/src/renderers/webgpu/utils/WebGPUBindingUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUBindingUtils.js
@@ -81,7 +81,7 @@ class WebGPUBindingUtils {
 
 					texture.sampleType = GPUTextureSampleType.Depth;
 
-				} else if ( binding.texture.isDataTexture ) {
+				} else if ( binding.texture.isDataTexture || binding.texture.isDataArrayTexture || binding.texture.isData3DTexture ) {
 
 					const type = binding.texture.type;
 


### PR DESCRIPTION
Fixed #28921.

**Description**

The `sampleType` (a property of `GPUTextureBindingLayout`) is now defined consistently for all data texture types.