### PR TITLE
AttributeNode: Fix serialization/deserialization.

### DIFF
--- a/src/nodes/core/AttributeNode.js
+++ b/src/nodes/core/AttributeNode.js
@@ -107,6 +107,24 @@ class AttributeNode extends Node {
 
 	}
 
+	serialize( data ) {
+
+		super.serialize( data );
+
+		data.global = this.global;
+		data._attributeName = this._attributeName;
+
+	}
+
+	deserialize( data ) {
+
+		super.deserialize( data );
+
+		this.global = data.global;
+		this._attributeName = data._attributeName;
+
+	}
+
 }
 
 export default AttributeNode;


### PR DESCRIPTION
Related issue: #28943

**Description**

The  serialization/deserialization of node materials relying on `AttributeNode` fails at the moment.

Fiddle for reproduction: https://jsfiddle.net/anqx4whk/

The PR overwrites `Node.serialize()` and `Node.deserialize()` and honors the missing properties.

@sunag Is this the right approach? When I understand the code in the upper class correctly, private properties and properties holding primitive values are not honored so far and must be handled in the sub class.