### PR TITLE
Nodes: More serialization/deserialization fixes.

### DIFF
--- a/examples/webgpu_materials.html
+++ b/examples/webgpu_materials.html
@@ -333,7 +333,7 @@
 
 				material = new THREE.MeshBasicNodeMaterial();
 				material.colorNode = scriptableNode;
-				//materials.push( material );
+				materials.push( material );
 
 				scriptableNode.setLocal( 'material', material );
 
@@ -349,7 +349,7 @@
 
 				}
 
-				// const serializeMesh = scene.children[ scene.children.length - 1 ];
+				const serializeMesh = scene.children[ scene.children.length - 1 ];
 
 				//
 
@@ -370,7 +370,7 @@
 
 				//
 
-				// setTimeout( () => testSerialization( serializeMesh ), 1000 ); // FIXME, see #28933
+				setTimeout( () => testSerialization( serializeMesh ), 1000 ); // FIXME, see #28933
 
 			}
 
@@ -391,26 +391,26 @@
 
 			}
 
-			// function testSerialization( mesh ) {
+			function testSerialization( mesh ) {
 
-			// 	const json = mesh.toJSON();
-			// 	const loader = new THREE.NodeObjectLoader();
-			// 	const serializedMesh = loader.parse( json );
+				const json = mesh.toJSON();
+				const loader = new THREE.NodeObjectLoader();
+				const serializedMesh = loader.parse( json );
 
-			// 	serializedMesh.position.x = ( objects.length % 4 ) * 200 - 400;
-			// 	serializedMesh.position.z = Math.floor( objects.length / 4 ) * 200 - 200;
+				serializedMesh.position.x = ( objects.length % 4 ) * 200 - 400;
+				serializedMesh.position.z = Math.floor( objects.length / 4 ) * 200 - 200;
 
-			// 	const scriptableNode = serializedMesh.material.colorNode;
+				const scriptableNode = serializedMesh.material.colorNode;
 
-			// 	// it's because local.get( 'material' ) is used in the example ( local/global is unserializable )
-			// 	scriptableNode.setLocal( 'material', serializedMesh.material );
-			// 	scriptableNode.setParameter( 'execFrom', 'serialized' );
+				// it's because local.get( 'material' ) is used in the example ( local/global is unserializable )
+				scriptableNode.setLocal( 'material', serializedMesh.material );
+				scriptableNode.setParameter( 'execFrom', 'serialized' );
 
-			// 	objects.push( serializedMesh );
+				objects.push( serializedMesh );
 
-			// 	scene.add( serializedMesh );
+				scene.add( serializedMesh );
 
-			// }
+			}
 
 			function onWindowResize() {
 

--- a/examples/webgpu_multisampled_renderbuffers.html
+++ b/examples/webgpu_multisampled_renderbuffers.html
@@ -85,8 +85,8 @@
 				// textured mesh
 
 				const geometryBox = new THREE.BoxGeometry( 7, 7, 7, 12, 12, 12 );
-				const materialBox = new THREE.MeshPhongNodeMaterial();
-				const materialBoxInner = new THREE.MeshPhongNodeMaterial( { color: 0xff0000 } );
+				const materialBox = new THREE.MeshBasicNodeMaterial();
+				const materialBoxInner = new THREE.MeshBasicNodeMaterial( { color: 0xff0000 } );
 
 				materialBox.wireframe = true;
 

--- a/src/nodes/accessors/TextureNode.js
+++ b/src/nodes/accessors/TextureNode.js
@@ -387,6 +387,9 @@ class TextureNode extends UniformNode {
 		super.serialize( data );
 
 		data.value = this.value.toJSON( data.meta ).uuid;
+		data.sampler = this.sampler;
+		data.updateMatrix = this.updateMatrix;
+		data.updateType = this.updateType;
 
 	}
 
@@ -395,6 +398,9 @@ class TextureNode extends UniformNode {
 		super.deserialize( data );
 
 		this.value = data.meta.textures[ data.value ];
+		this.sampler = data.sampler;
+		this.updateMatrix = data.updateMatrix;
+		this.updateType = data.updateType;
 
 	}
 

--- a/src/nodes/core/UniformGroupNode.js
+++ b/src/nodes/core/UniformGroupNode.js
@@ -22,6 +22,26 @@ class UniformGroupNode extends Node {
 
 	}
 
+	serialize( data ) {
+
+		super.serialize( data );
+
+		data.name = this.name;
+		data.version = this.version;
+		data.shared = this.shared;
+
+	}
+
+	deserialize( data ) {
+
+		super.deserialize( data );
+
+		this.name = data.name;
+		this.version = data.version;
+		this.shared = data.shared;
+
+	}
+
 }
 
 export const uniformGroup = ( name ) => new UniformGroupNode( name );


### PR DESCRIPTION
Fixed #28933.

**Description**

This PR adds the `scriptableNode` material back in `webgpu_materials` and fixes the actual root cause of #28933.

`TextureNode` and `UniformGroupNode` had an incomplete serialization/deserialization.