### PR TITLE
Nodes: Add `enableExtension()` Method to `GLSLNodeBuilder`

### DIFF
--- a/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
+++ b/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
@@ -637,7 +637,7 @@ ${ flowData.code }
 
 	}
 
-	enableExtension( name, mode, shaderStage = this.shaderStage ) {
+	enableExtension( name, behavior, shaderStage = this.shaderStage ) {
 
 		const map = this.extensions[ shaderStage ] || ( this.extensions[ shaderStage ] = new Map() );
 
@@ -645,7 +645,7 @@ ${ flowData.code }
 
 			map.set( name, {
 				name,
-				mode
+				behavior
 			} );
 
 		}
@@ -673,9 +673,9 @@ ${ flowData.code }
 
 		if ( extensions !== undefined ) {
 
-			for ( const { name, mode } of extensions.values() ) {
+			for ( const { name, behavior } of extensions.values() ) {
 
-				snippets.push( `#extension ${name} : ${mode}` );
+				snippets.push( `#extension ${name} : ${behavior}` );
 
 			}
 

--- a/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
+++ b/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
@@ -636,9 +636,24 @@ ${ flowData.code }
 
 	}
 
+	getExtension( name, mode, shaderStage = this.shaderStage ) {
+
+		const map = this.extensions[ shaderStage ] || ( this.extensions[ shaderStage ] = new Map() );
+
+		if ( map.has( name ) === false ) {
+
+			map.set( name, {
+				name,
+				mode
+			} );
+
+		}
+
+	}
+
 	getExtensions( shaderStage ) {
 
-		let extensions = '';
+		const snippets = [];
 
 		if ( shaderStage === 'vertex' ) {
 
@@ -647,13 +662,25 @@ ${ flowData.code }
 
 			if ( isBatchedMesh && ext.has( 'WEBGL_multi_draw' ) ) {
 
-				extensions += '#extension GL_ANGLE_multi_draw : require\n';
+				this.getExtension( 'GL_ANGLE_multi_draw', 'require', 'vertex' );
 
 			}
 
 		}
 
-		return extensions;
+		const extensions = this.extensions[ shaderStage ];
+
+		if ( extensions !== undefined ) {
+
+			for ( const { name, mode } of extensions.values() ) {
+
+				snippets.push( `#extension ${name} : ${mode}` );
+
+			}
+
+		}
+
+		return snippets.join( '\n' );
 
 	}
 

--- a/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
+++ b/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
@@ -637,7 +637,7 @@ ${ flowData.code }
 
 	}
 
-	getExtension( name, mode, shaderStage = this.shaderStage ) {
+	enableExtension( name, mode, shaderStage = this.shaderStage ) {
 
 		const map = this.extensions[ shaderStage ] || ( this.extensions[ shaderStage ] = new Map() );
 
@@ -663,7 +663,7 @@ ${ flowData.code }
 
 			if ( isBatchedMesh && ext.has( 'WEBGL_multi_draw' ) ) {
 
-				this.getExtension( 'GL_ANGLE_multi_draw', 'require', shaderStage );
+				this.enableExtension( 'GL_ANGLE_multi_draw', 'require' );
 
 			}
 

--- a/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
+++ b/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
@@ -884,7 +884,6 @@ void main() {
 			const stageData = shadersData[ shaderStage ];
 
 			stageData.extensions = this.getExtensions( shaderStage );
-			console.log( stageData.extensions );
 			stageData.uniforms = this.getUniforms( shaderStage );
 			stageData.attributes = this.getAttributes( shaderStage );
 			stageData.varyings = this.getVaryings( shaderStage );

--- a/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
+++ b/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
@@ -54,6 +54,7 @@ class GLSLNodeBuilder extends NodeBuilder {
 
 		this.uniformGroups = {};
 		this.transforms = [];
+		this.extensions = {};
 
 		this.instanceBindGroups = false;
 
@@ -662,7 +663,7 @@ ${ flowData.code }
 
 			if ( isBatchedMesh && ext.has( 'WEBGL_multi_draw' ) ) {
 
-				this.getExtension( 'GL_ANGLE_multi_draw', 'require', 'vertex' );
+				this.getExtension( 'GL_ANGLE_multi_draw', 'require', shaderStage );
 
 			}
 
@@ -883,6 +884,7 @@ void main() {
 			const stageData = shadersData[ shaderStage ];
 
 			stageData.extensions = this.getExtensions( shaderStage );
+			console.log( stageData.extensions );
 			stageData.uniforms = this.getUniforms( shaderStage );
 			stageData.attributes = this.getAttributes( shaderStage );
 			stageData.varyings = this.getVaryings( shaderStage );


### PR DESCRIPTION
Related issue: #28915 

Create a getExtension() function that allows for the conditional application of a GLSL extension when necessary to access a given feature within WebGPURenderer's webgl-fallback.

Example implementation: 

```typescript
enableClipDistances() {

    const extensions = this.renderer.backend.extensions;

    if ( extensions.has( 'WEBGL_clip_cull_distance' ) ) {

        extensions.get( 'WEBGL_clip_cull_distance' );

	this.getExtension( 'GL_ANGLE_clip_cull_distance', 'enable' );

    }

}
```
