### PR TITLE
Nodes: Ensure that setBindGroup matches with @group in the shader.

### DIFF
--- a/examples/webgpu_materials.html
+++ b/examples/webgpu_materials.html
@@ -25,7 +25,7 @@
 		<script type="module">
 
 			import * as THREE from 'three';
-			import { tslFn, wgslFn, positionLocal, positionWorld, normalLocal, normalWorld, normalView, color, texture, uv, float, vec2, vec3, vec4, oscSine, triplanarTexture, viewportBottomLeft, js, string, global, loop } from 'three/tsl';
+			import { tslFn, wgslFn, positionLocal, positionWorld, normalLocal, normalWorld, normalView, color, texture, uv, float, vec2, vec3, vec4, oscSine, triplanarTexture, viewportBottomLeft, js, string, global, loop, cameraProjectionMatrix } from 'three/tsl';
 
 			import { TeapotGeometry } from 'three/addons/geometries/TeapotGeometry.js';
 
@@ -116,6 +116,12 @@
 				material.opacityNode = texture( opacityTexture );
 				material.alphaTestNode = 0.5;
 				materials.push( material );
+
+				// camera
+				material = new THREE.MeshBasicNodeMaterial();
+				material.colorNode = cameraProjectionMatrix.mul( positionLocal );
+				materials.push( material );
+
 
 				// Normal
 				material = new THREE.MeshNormalMaterial();

--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -197,14 +197,15 @@ class NodeBuilder {
 
 			if ( bindGroup === undefined ) {
 
-				bindGroup = new BindGroup( groupName, bindingsArray );
+				bindGroup = new BindGroup( groupName, bindingsArray, this.bindingsIndexes[ groupName ].group );
+
 				bindGroupsCache.set( bindingsArray, bindGroup );
 
 			}
 
 		} else {
 
-			bindGroup = new BindGroup( groupName, bindingsArray );
+			bindGroup = new BindGroup( groupName, bindingsArray, this.bindingsIndexes[ groupName ].group );
 
 		}
 

--- a/src/renderers/common/BindGroup.js
+++ b/src/renderers/common/BindGroup.js
@@ -2,12 +2,13 @@ let _id = 0;
 
 class BindGroup {
 
-	constructor( name = '', bindings = [], id = _id ++ ) {
+	constructor( name = '', bindings = [], index = 0 ) {
 
 		this.name = name;
 		this.bindings = bindings;
+		this.index = index;
 
-		this.id = id;
+		this.id = _id ++;
 
 	}
 

--- a/src/renderers/common/BindGroup.js
+++ b/src/renderers/common/BindGroup.js
@@ -2,12 +2,12 @@ let _id = 0;
 
 class BindGroup {
 
-	constructor( name = '', bindings = [] ) {
+	constructor( name = '', bindings = [], id = _id ++ ) {
 
 		this.name = name;
 		this.bindings = bindings;
 
-		this.id = _id ++;
+		this.id = id;
 
 	}
 

--- a/src/renderers/common/nodes/NodeBuilderState.js
+++ b/src/renderers/common/nodes/NodeBuilderState.js
@@ -32,7 +32,7 @@ class NodeBuilderState {
 
 			if ( shared !== true ) {
 
-				const bindingsGroup = new BindGroup( instanceGroup.name );
+				const bindingsGroup = new BindGroup( instanceGroup.name, [], instanceGroup.id );
 				bindings.push( bindingsGroup );
 
 				for ( const instanceBinding of instanceGroup.bindings ) {

--- a/src/renderers/common/nodes/NodeBuilderState.js
+++ b/src/renderers/common/nodes/NodeBuilderState.js
@@ -32,7 +32,7 @@ class NodeBuilderState {
 
 			if ( shared !== true ) {
 
-				const bindingsGroup = new BindGroup( instanceGroup.name, [], instanceGroup.id );
+				const bindingsGroup = new BindGroup( instanceGroup.name, [], instanceGroup.index );
 				bindings.push( bindingsGroup );
 
 				for ( const instanceBinding of instanceGroup.bindings ) {

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -858,7 +858,7 @@ class WebGPUBackend extends Backend {
 			const bindGroup = bindings[ i ];
 			const bindingsData = this.get( bindGroup );
 
-			passEncoderGPU.setBindGroup( i, bindingsData.group );
+			passEncoderGPU.setBindGroup( bindGroup.id, bindingsData.group );
 
 		}
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -858,7 +858,7 @@ class WebGPUBackend extends Backend {
 			const bindGroup = bindings[ i ];
 			const bindingsData = this.get( bindGroup );
 
-			passEncoderGPU.setBindGroup( bindGroup.id, bindingsData.group );
+			passEncoderGPU.setBindGroup( bindGroup.index, bindingsData.group );
 
 		}
 


### PR DESCRIPTION
**Description**

Currently, when attaching a `cameraProjectionMatrix` node to the colorNode, an issue occurs: 

<img width="1160" alt="截屏2024-07-24 下午2 48 32" src="https://github.com/user-attachments/assets/4ffc33cc-54b1-4d21-a272-daf3c86af571">

After investigating, I found that the issue was caused by a mismatch between `setBindGroup` and @group.

This PR should fix the issue.

**Reproduce**

- Add the code to `examples/webgpu_materials.html`
```js
material = new THREE.MeshBasicNodeMaterial();
material.colorNode = cameraProjectionMatrix.mul( positionLocal );
materials.push( material );
```
- Run `npm run start`
- Open `http://localhost:8080/examples/webgpu_materials`