### PR TITLE
Nodes: Add SepiaNode

### DIFF
--- a/src/nodes/Nodes.js
+++ b/src/nodes/Nodes.js
@@ -141,7 +141,7 @@ export { default as BloomNode, bloom } from './display/BloomNode.js';
 export { default as TransitionNode, transition } from './display/TransitionNode.js';
 export { default as RenderOutputNode, renderOutput } from './display/RenderOutputNode.js';
 export { default as PixelationPassNode, pixelationPass } from './display/PixelationPassNode.js';
-export { default as SepiaNode, sepia } from './display/SepiaNode.js';
+export { sepia } from './display/SepiaNode.js';
 
 export { default as PassNode, pass, passTexture, depthPass } from './display/PassNode.js';
 

--- a/src/nodes/Nodes.js
+++ b/src/nodes/Nodes.js
@@ -141,6 +141,7 @@ export { default as BloomNode, bloom } from './display/BloomNode.js';
 export { default as TransitionNode, transition } from './display/TransitionNode.js';
 export { default as RenderOutputNode, renderOutput } from './display/RenderOutputNode.js';
 export { default as PixelationPassNode, pixelationPass } from './display/PixelationPassNode.js';
+export { default as SepiaNode, sepia } from './display/SepiaNode.js';
 
 export { default as PassNode, pass, passTexture, depthPass } from './display/PassNode.js';
 

--- a/src/nodes/display/SepiaNode.js
+++ b/src/nodes/display/SepiaNode.js
@@ -22,13 +22,15 @@ class SepiaNode extends TempNode {
 
 	setup() {
 
-		const { textureNode, amount } = this.textureNode;
+		const textureNode = this.textureNode;
+		const amount = this.amount;
+		const uvNode = textureNode.uvNode || uv();
 
-		const uvNode = this.textureNode.uvNode || uv();
+		const sampleTexture = ( uv ) => textureNode.uv( uv );
 
 		const sepia = tslFn( () => {
 
-			const color = textureNode.uv( uvNode );
+			const color = sampleTexture( uvNode );
 			const c = property( 'vec3', 'c' ).assign( color.rgb );
 
 			color.r = dot( c, vec3( float( 1.0 ).sub( amount.mul( 0.607 ) ), amount.mul( 0.769 ), amount.mul( 0.189 ) ) );

--- a/src/nodes/display/SepiaNode.js
+++ b/src/nodes/display/SepiaNode.js
@@ -1,56 +1,19 @@
-import TempNode from '../core/TempNode.js';
-import { nodeObject, addNodeElement, tslFn, vec3, vec4, float } from '../shadernode/ShaderNode.js';
-import { NodeUpdateType } from '../core/constants.js';
-import { uv } from '../accessors/UVNode.js';
+import { addNodeElement, tslFn, vec3, vec4 } from '../shadernode/ShaderNode.js';
 import { min } from '../math/MathNode.js';
 import { dot } from '../math/MathNode.js';
 
 import { property } from '../core/PropertyNode.js';
 
-class SepiaNode extends TempNode {
+export const sepia = /*@__PURE__*/ tslFn( ( { color } ) => {
 
-	constructor( textureNode, amount ) {
+	const c = property( 'vec3', 'c' ).assign( color.rgb );
 
-		super( 'vec4' );
+	color.r = dot( c, vec3( 0.393, 0.769, 0.189 ) );
+	color.g = dot( c, vec3( 0.349, 0.686, 0.168 ) );
+	color.b = dot( c, vec3( 0.272, 0.534, 0.131 ) );
 
-		this.textureNode = textureNode;
-		this.amount = amount;
+	return vec4( min( vec3( 1.0 ), color.rgb ), 1.0 );
 
-		this.updateBeforeType = NodeUpdateType.RENDER;
-
-	}
-
-	setup() {
-
-		const textureNode = this.textureNode;
-		const amount = this.amount;
-		const uvNode = textureNode.uvNode || uv();
-
-		const sampleTexture = ( uv ) => textureNode.uv( uv );
-
-		const sepia = tslFn( () => {
-
-			const color = sampleTexture( uvNode );
-			const c = property( 'vec3', 'c' ).assign( color.rgb );
-
-			color.r = dot( c, vec3( float( 1.0 ).sub( amount.mul( 0.607 ) ), amount.mul( 0.769 ), amount.mul( 0.189 ) ) );
-			color.g = dot( c, vec3( amount.mul( 0.349 ), float( 1.0 ).sub( amount.mul( 0.314 ) ), amount.mul( 0.168 ) ) );
-			color.b = dot( c, vec3( amount.mul( 0.272 ), amount.mul( 0.534 ), float( 1.0 ).sub( amount.mul( 0.869 ) ) ) );
-
-			return vec4( min( vec3( 1.0 ), color.rgb ), color.a );
-
-		} );
-
-		const outputNode = sepia();
-
-		return outputNode;
-
-	}
-
-}
-
-export const sepia = ( node, amount ) => nodeObject( new SepiaNode( nodeObject( node ).toTexture(), nodeObject( amount ) ) );
+} );
 
 addNodeElement( 'sepia', sepia );
-
-export default SepiaNode;

--- a/src/nodes/display/SepiaNode.js
+++ b/src/nodes/display/SepiaNode.js
@@ -1,0 +1,54 @@
+import TempNode from '../core/TempNode.js';
+import { nodeObject, addNodeElement, tslFn, vec3, vec4, float } from '../shadernode/ShaderNode.js';
+import { NodeUpdateType } from '../core/constants.js';
+import { uv } from '../accessors/UVNode.js';
+import { min } from '../math/MathNode.js';
+import { dot } from '../math/MathNode.js';
+
+import { property } from '../core/PropertyNode.js';
+
+class SepiaNode extends TempNode {
+
+	constructor( textureNode, amount ) {
+
+		super( 'vec4' );
+
+		this.textureNode = textureNode;
+		this.amount = amount;
+
+		this.updateBeforeType = NodeUpdateType.RENDER;
+
+	}
+
+	setup() {
+
+		const { textureNode, amount } = this.textureNode;
+
+		const uvNode = this.textureNode.uvNode || uv();
+
+		const sepia = tslFn( () => {
+
+			const color = textureNode.uv( uvNode );
+			const c = property( 'vec3', 'c' ).assign( color.rgb );
+
+			color.r = dot( c, vec3( float( 1.0 ).sub( amount.mul( 0.607 ) ), amount.mul( 0.769 ), amount.mul( 0.189 ) ) );
+			color.g = dot( c, vec3( amount.mul( 0.349 ), float( 1.0 ).sub( amount.mul( 0.314 ) ), amount.mul( 0.168 ) ) );
+			color.b = dot( c, vec3( amount.mul( 0.272 ), amount.mul( 0.534 ), float( 1.0 ).sub( amount.mul( 0.869 ) ) ) );
+
+			return vec4( min( vec3( 1.0 ), color.rgb ), color.a );
+
+		} );
+
+		const outputNode = sepia();
+
+		return outputNode;
+
+	}
+
+}
+
+export const sepia = ( node, amount ) => nodeObject( new SepiaNode( nodeObject( node ).toTexture(), nodeObject( amount ) ) );
+
+addNodeElement( 'sepia', sepia );
+
+export default SepiaNode;

--- a/src/nodes/display/SepiaNode.js
+++ b/src/nodes/display/SepiaNode.js
@@ -8,6 +8,8 @@ export const sepia = /*@__PURE__*/ tslFn( ( { color } ) => {
 
 	const c = property( 'vec3', 'c' ).assign( color.rgb );
 
+	// https://github.com/evanw/glfx.js/blob/master/src/filters/adjust/sepia.js
+
 	color.r = dot( c, vec3( 0.393, 0.769, 0.189 ) );
 	color.g = dot( c, vec3( 0.349, 0.686, 0.168 ) );
 	color.b = dot( c, vec3( 0.272, 0.534, 0.131 ) );


### PR DESCRIPTION
Related issue: 

**Description**

Port of GLSL Sepia Shader to node system.

```typescript
postProcessing = new THREE.PostProcessing( renderer );
const scenePass = pixelationPass( scene, camera, effectController.pixelSize, 
effectController.normalEdgeStrength, effectController.depthEdgeStrength );
// scenePass.getTextureNode() returns pixelation.textureNode, renderOutput returns full effect
const sepiaPass = sepia( { color: scenePass.renderOutput() } );
postProcessing.outputNode = mix( scenePass, sepiaPass, effectController.mixValue );
```

[Live Example](https://raw.githack.com/cmhhelgeson/three.js/webgpu_post_test/examples/webgpu_postprocessing_pixel.html)
