### PR TITLE
Background: Fix update when changing env map.

### DIFF
--- a/src/renderers/common/Background.js
+++ b/src/renderers/common/Background.js
@@ -90,6 +90,7 @@ class Background extends DataMap {
 			if ( sceneData.backgroundCacheKey !== backgroundCacheKey ) {
 
 				sceneData.backgroundMeshNode.node = vec4( backgroundNode ).mul( backgroundIntensity );
+				sceneData.backgroundMeshNode.needsUpdate = true;
 
 				backgroundMesh.material.needsUpdate = true;
 


### PR DESCRIPTION
Related issue: -

**Description**

Similar to `WebGLRenderer`, `WebGPURenderer` should automatically update the background when the environment map assigned to `Scene.background` changes. The existing check in `Background` was not 100% correct.

For reproduction: https://jsfiddle.net/1pxtb75k/ (the background does not change to the equirect version)
