### PR TITLE
UniformArrayNode: Add `uniforms()` fallback.

### DIFF
--- a/src/nodes/accessors/UniformArrayNode.js
+++ b/src/nodes/accessors/UniformArrayNode.js
@@ -143,4 +143,11 @@ export default UniformArrayNode;
 
 export const uniformArray = ( values, nodeType ) => nodeObject( new UniformArrayNode( values, nodeType ) );
 
+export const uniforms = ( values, nodeType ) => { // @deprecated, r168
+
+	console.warn( 'THREE.WebGPURenderer: uniforms() has been renamed to uniformArray().' );
+	return nodeObject( new UniformArrayNode( values, nodeType ) );
+
+};
+
 addNodeClass( 'UniformArrayNode', UniformArrayNode );


### PR DESCRIPTION
Related issue: #28910

**Description**

Since the node material and `WebGPURenderer` are now in core, we should be more strict when renaming or removing API and print respective warnings.

This PR makes sure devs are informed about the renaming of `uniforms()` to `uniformArray()`. Like with all other deprecation warnings, it can be removed in ten releases.