### PR TITLE
NodeMaterial: Use `materialReference()` for env maps.

### DIFF
--- a/src/nodes/Nodes.js
+++ b/src/nodes/Nodes.js
@@ -88,6 +88,7 @@ export { default as CubeTextureNode, cubeTexture } from './accessors/CubeTexture
 export { default as InstanceNode, instance } from './accessors/InstanceNode.js';
 export { default as BatchNode, batch } from './accessors/BatchNode.js';
 export { default as MaterialNode, materialAlphaTest, materialColor, materialShininess, materialEmissive, materialOpacity, materialSpecular, materialSpecularStrength, materialReflectivity, materialRoughness, materialMetalness, materialNormal, materialClearcoat, materialClearcoatRoughness, materialClearcoatNormal, materialRotation, materialSheen, materialSheenRoughness, materialIridescence, materialIridescenceIOR, materialIridescenceThickness, materialLineScale, materialLineDashSize, materialLineGapSize, materialLineWidth, materialLineDashOffset, materialPointWidth, materialAnisotropy, materialAnisotropyVector, materialDispersion, materialLightMap, materialAOMap } from './accessors/MaterialNode.js';
+export * from './accessors/MaterialProperties.js';
 export { default as MaterialReferenceNode, materialReference } from './accessors/MaterialReferenceNode.js';
 export { default as RendererReferenceNode, rendererReference } from './accessors/RendererReferenceNode.js';
 export { default as MorphNode, morphReference } from './accessors/MorphNode.js';

--- a/src/nodes/accessors/MaterialNode.js
+++ b/src/nodes/accessors/MaterialNode.js
@@ -320,10 +320,6 @@ class MaterialNode extends Node {
 
 			node = this.getFloat( scope );
 
-		} else if ( scope === MaterialNode.REFRACTION_RATIO ) {
-
-			node = this.getFloat( scope );
-
 		} else if ( scope === MaterialNode.LIGHT_MAP ) {
 
 			node = this.getTexture( scope ).rgb.mul( this.getFloat( 'lightMapIntensity' ) );
@@ -383,7 +379,6 @@ MaterialNode.POINT_WIDTH = 'pointWidth';
 MaterialNode.DISPERSION = 'dispersion';
 MaterialNode.LIGHT_MAP = 'light';
 MaterialNode.AO_MAP = 'ao';
-MaterialNode.REFRACTION_RATIO = 'refractionRatio';
 
 export default MaterialNode;
 

--- a/src/nodes/accessors/MaterialProperties.js
+++ b/src/nodes/accessors/MaterialProperties.js
@@ -1,0 +1,3 @@
+import { uniform } from '../core/UniformNode.js';
+
+export const materialRefractionRatio = /*@__PURE__*/ uniform( 0 ).onReference( ( { material } ) => material ).onRenderUpdate( ( { material } ) => material.refractionRatio );

--- a/src/nodes/accessors/MaterialReferenceNode.js
+++ b/src/nodes/accessors/MaterialReferenceNode.js
@@ -14,6 +14,8 @@ class MaterialReferenceNode extends ReferenceNode {
 
 		//this.updateType = NodeUpdateType.RENDER;
 
+		this.isMaterialReferenceNode = true;
+
 	}
 
 	/*setNodeType( node ) {

--- a/src/nodes/accessors/ReferenceNode.js
+++ b/src/nodes/accessors/ReferenceNode.js
@@ -2,6 +2,7 @@ import Node, { addNodeClass } from '../core/Node.js';
 import { NodeUpdateType } from '../core/constants.js';
 import { uniform } from '../core/UniformNode.js';
 import { texture } from './TextureNode.js';
+import { cubeTexture } from './CubeTextureNode.js';
 import { buffer } from './BufferNode.js';
 import { nodeObject } from '../shadernode/ShaderNode.js';
 import { uniformArray } from './UniformArrayNode.js';
@@ -77,6 +78,10 @@ class ReferenceNode extends Node {
 		} else if ( uniformType === 'texture' ) {
 
 			node = texture( null );
+
+		} else if ( uniformType === 'cubeTexture' ) {
+
+			node = cubeTexture( null );
 
 		} else {
 

--- a/src/nodes/accessors/ReflectVectorNode.js
+++ b/src/nodes/accessors/ReflectVectorNode.js
@@ -1,7 +1,7 @@
 import { cameraViewMatrix } from './CameraNode.js';
 import { transformedNormalView } from './NormalNode.js';
 import { positionViewDirection } from './PositionNode.js';
-import { materialRefractionRatio } from './MaterialNode.js';
+import { materialRefractionRatio } from './MaterialProperties.js';
 
 export const reflectView = /*#__PURE__*/ positionViewDirection.negate().reflect( transformedNormalView );
 export const refractView = /*#__PURE__*/ positionViewDirection.negate().refract( transformedNormalView, materialRefractionRatio );

--- a/src/nodes/lighting/EnvironmentNode.js
+++ b/src/nodes/lighting/EnvironmentNode.js
@@ -25,17 +25,21 @@ class EnvironmentNode extends LightingNode {
 
 	setup( builder ) {
 
+		const { material } = builder;
+
 		let envNode = this.envNode;
 
-		if ( envNode.isTextureNode ) {
+		if ( envNode.isTextureNode || envNode.isMaterialReferenceNode ) {
 
-			let cacheEnvNode = _envNodeCache.get( envNode.value );
+			const value = ( envNode.isTextureNode ) ? envNode.value : material[ envNode.property ];
+
+			let cacheEnvNode = _envNodeCache.get( value );
 
 			if ( cacheEnvNode === undefined ) {
 
-				cacheEnvNode = pmremTexture( envNode.value );
+				cacheEnvNode = pmremTexture( value );
 
-				_envNodeCache.set( envNode.value, cacheEnvNode );
+				_envNodeCache.set( value, cacheEnvNode );
 
 			}
 
@@ -44,8 +48,6 @@ class EnvironmentNode extends LightingNode {
 		}
 
 		//
-
-		const { material } = builder;
 
 		const envMap = material.envMap;
 		const intensity = envMap ? reference( 'envMapIntensity', 'float', builder.material ) : reference( 'environmentIntensity', 'float', builder.scene ); // @TODO: Add materialEnvIntensity in MaterialNode

--- a/src/nodes/materials/NodeMaterial.js
+++ b/src/nodes/materials/NodeMaterial.js
@@ -13,8 +13,6 @@ import { materialReference } from '../accessors/MaterialReferenceNode.js';
 import { positionLocal, positionView } from '../accessors/PositionNode.js';
 import { skinningReference } from '../accessors/SkinningNode.js';
 import { morphReference } from '../accessors/MorphNode.js';
-import { texture } from '../accessors/TextureNode.js';
-import { cubeTexture } from '../accessors/CubeTextureNode.js';
 import { lightsNode } from '../lighting/LightsNode.js';
 import { mix } from '../math/MathNode.js';
 import { float, vec3, vec4 } from '../shadernode/ShaderNode.js';
@@ -374,7 +372,7 @@ class NodeMaterial extends Material {
 
 		} else if ( this.envMap ) {
 
-			node = this.envMap.isCubeTexture ? cubeTexture( this.envMap ) : texture( this.envMap );
+			node = this.envMap.isCubeTexture ? materialReference( 'envMap', 'cubeTexture' ) : materialReference( 'envMap', 'texture' );
 
 		} else if ( builder.environmentNode ) {
 


### PR DESCRIPTION
Related issue: -

**Description**

It is currently not possible to dynamically update `material.envMap`: https://jsfiddle.net/br8ezgfw/1/

That works in `WebGLRenderer` and it also works to exchange normal textures (e.g. `material.map`) with `WebGPURenderer` .

The issue can be resolved by using `materialReference()` when setting up the env node in `NodeMaterial` but that leads unfortunately to a cyclic dependency:
```
src/nodes/accessors/MaterialNode.js -> 
src/nodes/accessors/ReferenceNode.js -> 
src/nodes/accessors/CubeTextureNode.js -> 
src/nodes/accessors/ReflectVectorNode.js -> 
src/nodes/accessors/MaterialNode.js
```
@sunag I wonder if you have any ideas to solve this issue. What I find not optimal is the fact that `CubeTextureNode.getDefaultUV()` has a material dependency since `refractVector` relies on the refraction ratio of the material. 

Would it be an option to move the uv computation into the place where the sampling actually happens (that is `BasicLightingModel`)? However, without proper default uvs, it might be inconvenient to use `cubeTexture()` elsewhere in the code base and on app level.
