### PR TITLE
Core: Move builders into `THREE` namespace.

### DIFF
--- a/examples/webgpu_tsl_editor.html
+++ b/examples/webgpu_tsl_editor.html
@@ -52,10 +52,6 @@
 
 			import * as THREE from 'three';
 
-			import WebGPURenderer from '../src/renderers/webgpu/WebGPURenderer.js';
-			import WGSLNodeBuilder from '../src/renderers/webgpu/nodes/WGSLNodeBuilder.js';
-			import GLSLNodeBuilder from '../src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js';
-
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 
 			init();
@@ -76,7 +72,7 @@
 
 				const rendererDOM = document.getElementById( 'renderer' );
 
-				const renderer = new WebGPURenderer( { antialias: true } );
+				const renderer = new THREE.WebGPURenderer( { antialias: true } );
 				renderer.outputColorSpace = THREE.LinearSRGBColorSpace;
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( 200, 200 );
@@ -177,11 +173,11 @@ output = vec4( finalColor, opacity );
 
 							if ( options.output === 'WGSL' ) {
 
-								NodeBuilder = WGSLNodeBuilder;
+								NodeBuilder = THREE.WGSLNodeBuilder;
 
 							} else if ( options.output === 'GLSL ES 3.0' ) {
 
-								NodeBuilder = GLSLNodeBuilder;
+								NodeBuilder = THREE.GLSLNodeBuilder;
 
 							}
 

--- a/src/Three.WebGPU.js
+++ b/src/Three.WebGPU.js
@@ -162,6 +162,8 @@ export * from './constants.js';
 export * from './Three.Legacy.js';
 
 export { default as WebGPURenderer } from './renderers/webgpu/WebGPURenderer.js';
+export { default as WGSLNodeBuilder } from './renderers/webgpu/nodes/WGSLNodeBuilder.js';
+export { default as GLSLNodeBuilder } from './renderers/webgl-fallback/nodes/GLSLNodeBuilder.js';
 export { default as QuadMesh } from './renderers/common/QuadMesh.js';
 export { default as PMREMGenerator } from './renderers/common/extras/PMREMGenerator.js';
 export { default as PostProcessing } from './renderers/common/PostProcessing.js';


### PR DESCRIPTION
Fixed #28984.

**Description**

This PR moves the builders into `THREE` namespace. This allows to simplify the imports in `webgpu_tsl_editor`.