### PR TITLE
NodeEditor: Make sure scene is properly resetted.

### DIFF
--- a/playground/NodeEditorUtils.js
+++ b/playground/NodeEditorUtils.js
@@ -1,5 +1,6 @@
 import { StringInput, NumberInput, ColorInput, Element, LabelElement } from 'flow';
 import { string, float, vec2, vec3, vec4, color } from 'three/tsl';
+import { Color } from 'three';
 import { setInputAestheticsFromType, setOutputAestheticsFromType } from './DataTypeLib.js';
 
 export function exportJSON( object, name ) {
@@ -38,6 +39,25 @@ export function disposeScene( scene ) {
 		}
 
 	} );
+
+}
+
+export function resetScene( scene ) {
+
+	if ( scene.environment !== null ) {
+
+		scene.environment.dispose();
+		scene.environment = null;
+
+	}
+
+	if ( scene.background !== null ) {
+
+		if ( scene.background.isTexture ) scene.background.dispose();
+
+	}
+
+	scene.background = new Color( 0x333333 );
 
 }
 

--- a/playground/editors/ScriptableEditor.js
+++ b/playground/editors/ScriptableEditor.js
@@ -1,6 +1,6 @@
 import { BaseNodeEditor } from '../BaseNodeEditor.js';
 import { CodeEditorElement } from '../elements/CodeEditorElement.js';
-import { disposeScene, createElementFromJSON, isGPUNode, onValidType } from '../NodeEditorUtils.js';
+import { disposeScene, resetScene, createElementFromJSON, isGPUNode, onValidType } from '../NodeEditorUtils.js';
 import { global, scriptable, js, scriptableValue } from 'three/tsl';
 import { getColorFromType, setInputAestheticsFromType, setOutputAestheticsFromType } from '../DataTypeLib.js';
 
@@ -200,6 +200,8 @@ export class ScriptableEditor extends BaseNodeEditor {
 
 				disposeScene( editorOutputAdded );
 
+				resetScene( scene );
+
 			} else if ( composer && editorOutputAdded && editorOutputAdded.isPass === true ) {
 
 				composer.removePass( editorOutputAdded );
@@ -225,6 +227,8 @@ export class ScriptableEditor extends BaseNodeEditor {
 				editorOutputAdded.removeFromParent();
 
 				disposeScene( editorOutputAdded );
+
+				resetScene( scene );
 
 			} else if ( composer && editorOutputAdded && editorOutputAdded.isPass === true ) {
 
@@ -408,7 +412,7 @@ export class ScriptableEditor extends BaseNodeEditor {
 
 	_initExternalConnection() {
 
-		setInputAestheticsFromType(this.title, 'CodeNode' ).onValid( onValidType( 'CodeNode' ) ).onConnect( () => {
+		setInputAestheticsFromType( this.title, 'CodeNode' ).onValid( onValidType( 'CodeNode' ) ).onConnect( () => {
 
 			this.hasExternalEditor ? this._toExternal() : this._toInternal();
 


### PR DESCRIPTION
Related issue: -

**Description**

When working at #28987 I've realized the examples using the basic material did not look right. 

The default teapot example defines an environment for its standard material. When you now switch to an example using the basic material, the environment is applied as well since the texture is never removed. That also happened in previous releases however the issue wasn't noticed since the basic material did not support env maps.
