### PR TITLE
TextureUtils: Remove deprecated code.

### DIFF
--- a/examples/jsm/utils/TextureUtils.js
+++ b/examples/jsm/utils/TextureUtils.js
@@ -34,7 +34,7 @@ export function decompress( texture, maxTextureSize = Infinity, renderer = null 
 				gl_FragColor = vec4(vUv.xy, 0, 1);
 				
 				#ifdef IS_SRGB
-				gl_FragColor = LinearTosRGB( texture2D( blitTexture, vUv) );
+				gl_FragColor = sRGBTransferOETF( texture2D( blitTexture, vUv) );
 				#else
 				gl_FragColor = texture2D( blitTexture, vUv);
 				#endif


### PR DESCRIPTION
Fixed #28995.

**Description**

The deprecated color space conversion functions were removed last release via #28901. Unfortunately, `TextureUtils` which is used by `GLTFExporter` still relied on the old code.

This PR renames `LinearTosRGB()` to `sRGBTransferOETF()`.
