### PR TITLE
WebGPURenderer: Add `debug.getRawShaderAsync()`.

### DIFF
--- a/examples/webgpu_tsl_editor.html
+++ b/examples/webgpu_tsl_editor.html
@@ -52,10 +52,6 @@
 
 			import * as THREE from 'three';
 
-			import WebGPURenderer from '../src/renderers/webgpu/WebGPURenderer.js';
-			import WGSLNodeBuilder from '../src/renderers/webgpu/nodes/WGSLNodeBuilder.js';
-			import GLSLNodeBuilder from '../src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js';
-
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 
 			init();
@@ -76,7 +72,7 @@
 
 				const rendererDOM = document.getElementById( 'renderer' );
 
-				const renderer = new WebGPURenderer( { antialias: true } );
+				const renderer = new THREE.WebGPURenderer( { antialias: true } );
 				renderer.outputColorSpace = THREE.LinearSRGBColorSpace;
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( 200, 200 );
@@ -108,7 +104,7 @@
 					};
 
 					let timeout = null;
-					let nodeBuilder = null;
+					let rawShader = null;
 
 					const editorDOM = document.getElementById( 'source' );
 					const resultDOM = document.getElementById( 'result' );
@@ -158,10 +154,13 @@ output = vec4( finalColor, opacity );
 
 					const showCode = () => {
 
-						result.setValue( nodeBuilder[ options.shader + 'Shader' ] );
+						result.setValue( rawShader[ options.shader + 'Shader' ] );
 						result.revealLine( 1 );
 
 					};
+
+					const webGLRenderer = new THREE.WebGPURenderer( { forceWebGL: true } );
+					webGLRenderer.init();
 
 					const build = () => {
 
@@ -173,20 +172,16 @@ output = vec4( finalColor, opacity );
 							mesh.material.fragmentNode = nodes.output;
 							mesh.material.needsUpdate = true;
 
-							let NodeBuilder;
-
 							if ( options.output === 'WGSL' ) {
 
-								NodeBuilder = WGSLNodeBuilder;
+								rawShader = renderer.debug.getRawShader( mesh );
+
 
 							} else if ( options.output === 'GLSL ES 3.0' ) {
 
-								NodeBuilder = GLSLNodeBuilder;
+								rawShader = webGLRenderer.debug.getRawShader( mesh );
 
 							}
-
-							nodeBuilder = new NodeBuilder( mesh, renderer );
-							nodeBuilder.build();
 
 							showCode();
 
@@ -195,9 +190,9 @@ output = vec4( finalColor, opacity );
 							/*const style = 'background-color: #333; color: white; font-style: italic; border: 2px solid #777; font-size: 22px;';
 
 							console.log( '%c  [ WGSL ] Vertex Shader      ', style );
-							console.log( nodeBuilder.vertexShader );
+							console.log( rawShader.vertexShader );
 							console.log( '%c  [ WGSL ] Fragment Shader    ', style );
-							console.log( nodeBuilder.fragmentShader );*/
+							console.log( rawShader.fragmentShader );*/
 
 						} catch ( e ) {
 

--- a/examples/webgpu_tsl_editor.html
+++ b/examples/webgpu_tsl_editor.html
@@ -84,7 +84,13 @@
 				const mesh = new THREE.Mesh( new THREE.PlaneGeometry( 1, 1 ), material );
 				scene.add( mesh );
 
+				//
+
+				let compiling = false;
+
 				renderer.setAnimationLoop( () => {
+
+					if ( compiling ) return;
 
 					renderer.render( scene, camera );
 
@@ -160,9 +166,8 @@ output = vec4( finalColor, opacity );
 					};
 
 					const webGLRenderer = new THREE.WebGPURenderer( { forceWebGL: true } );
-					webGLRenderer.init();
 
-					const build = () => {
+					const build = async () => {
 
 						try {
 
@@ -172,16 +177,20 @@ output = vec4( finalColor, opacity );
 							mesh.material.fragmentNode = nodes.output;
 							mesh.material.needsUpdate = true;
 
+							compiling = true;
+
 							if ( options.output === 'WGSL' ) {
 
-								rawShader = renderer.debug.getRawShader( mesh );
+								rawShader = await renderer.debug.getRawShaderAsync( scene, camera, mesh );
 
 
 							} else if ( options.output === 'GLSL ES 3.0' ) {
 
-								rawShader = webGLRenderer.debug.getRawShader( mesh );
+								rawShader = await webGLRenderer.debug.getRawShaderAsync( scene, camera, mesh );
 
 							}
+
+							compiling = false;
 
 							showCode();
 
@@ -192,7 +201,7 @@ output = vec4( finalColor, opacity );
 							console.log( '%c  [ WGSL ] Vertex Shader      ', style );
 							console.log( rawShader.vertexShader );
 							console.log( '%c  [ WGSL ] Fragment Shader    ', style );
-							console.log( rawShader.fragmentShader );*/
+							console.log( rawShader.fragmentShader );/**/
 
 						} catch ( e ) {
 

--- a/src/renderers/common/Backend.js
+++ b/src/renderers/common/Backend.js
@@ -99,6 +99,8 @@ class Backend {
 
 	hasFeature( /*name*/ ) { } // return Boolean
 
+	getRawShader( /*object*/ ) { } // return { vertexShader, fragmentShader }
+
 	getInstanceCount( renderObject ) {
 
 		const { object, geometry } = renderObject;

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -147,7 +147,12 @@ class Renderer {
 
 		this.debug = {
 			checkShaderErrors: true,
-			onShaderError: null
+			onShaderError: null,
+			getRawShader: ( object ) => {
+
+				return backend.getRawShader( object );
+
+			}
 		};
 
 	}

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -148,9 +148,20 @@ class Renderer {
 		this.debug = {
 			checkShaderErrors: true,
 			onShaderError: null,
-			getRawShader: ( object ) => {
+			getRawShaderAsync: async ( scene, camera, object ) => {
 
-				return backend.getRawShader( object );
+				await this.compileAsync( scene, camera );
+
+				const renderList = this._renderLists.get( scene, camera );
+				const renderContext = this._renderContexts.get( scene, camera, this._renderTarget );
+
+				const material = scene.overrideMaterial || object.material;
+
+				const renderObject = this._objects.get( object, material, scene, camera, renderList.lightsNode, renderContext );
+
+				const { fragmentShader, vertexShader } = renderObject.getNodeBuilderState();
+
+				return { fragmentShader, vertexShader };
 
 			}
 		};

--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -1218,15 +1218,6 @@ class WebGLBackend extends Backend {
 
 	}
 
-	getRawShader( object ) {
-
-		const nodeBuilder = new GLSLNodeBuilder( object, this.renderer );
-		nodeBuilder.build();
-
-		return { vertexShader: nodeBuilder.vertexShader, fragmentShader: nodeBuilder.fragmentShader };
-
-	}
-
 	getMaxAnisotropy() {
 
 		return this.capabilities.getMaxAnisotropy();

--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -1218,6 +1218,14 @@ class WebGLBackend extends Backend {
 
 	}
 
+	getRawShader( object ) {
+
+		const nodeBuilder = new GLSLNodeBuilder( object, this.renderer );
+		nodeBuilder.build();
+
+		return { vertexShader: nodeBuilder.vertexShader, fragmentShader: nodeBuilder.fragmentShader };
+
+	}
 
 	getMaxAnisotropy() {
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -1339,6 +1339,15 @@ class WebGPUBackend extends Backend {
 
 	}
 
+	getRawShader( object ) {
+
+		const nodeBuilder = new WGSLNodeBuilder( object, this.renderer );
+		nodeBuilder.build();
+
+		return { vertexShader: nodeBuilder.vertexShader, fragmentShader: nodeBuilder.fragmentShader };
+
+	}
+
 	copyTextureToTexture( srcTexture, dstTexture, srcRegion = null, dstPosition = null, level = 0 ) {
 
 		let dstX = 0;

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -1339,15 +1339,6 @@ class WebGPUBackend extends Backend {
 
 	}
 
-	getRawShader( object ) {
-
-		const nodeBuilder = new WGSLNodeBuilder( object, this.renderer );
-		nodeBuilder.build();
-
-		return { vertexShader: nodeBuilder.vertexShader, fragmentShader: nodeBuilder.fragmentShader };
-
-	}
-
 	copyTextureToTexture( srcTexture, dstTexture, srcRegion = null, dstPosition = null, level = 0 ) {
 
 		let dstX = 0;


### PR DESCRIPTION
Fixed #28984.

**Description**

This PR fixes `webgpu_tsl_editor` by adding `rendererer.debug.getRawShader()` which allows to get the raw shader (WGSL or GLSL) for a 3D object.


