### PR TITLE
Examples: Clean up

### DIFF
--- a/examples/webgpu_tsl_procedural_terrain.html
+++ b/examples/webgpu_tsl_procedural_terrain.html
@@ -219,7 +219,7 @@
 				const waterGui = gui.addFolder( '💧 water' );
 
 				waterGui.add( water.material, 'roughness', 0, 1, 0.01 );
-				waterGui.add( water.material, 'ior' ).min( 1 ).max( 10 ).step( 0.0001 );
+				waterGui.add( water.material, 'ior' ).min( 1 ).max( 2 ).step( 0.001 );
 				waterGui.addColor( { color: water.material.color.getHexString( THREE.SRGBColorSpace ) }, 'color' ).name( 'color' ).onChange( value => water.material.color.set( value ) );
 
 				// renderer


### PR DESCRIPTION
Limit `ior` to a valid range.