### PR TITLE
Addons: Rename `SkyGPU` and `WaterGPU`.

### DIFF
--- a/examples/jsm/Addons.js
+++ b/examples/jsm/Addons.js
@@ -173,6 +173,9 @@ export * from './objects/ShadowMesh.js';
 export * from './objects/Sky.js';
 export * from './objects/Water.js';
 export { Water as Water2 } from './objects/Water2.js';
+export * from './objects/SkyMesh.js';
+export * from './objects/WaterMesh.js';
+export { WaterMesh as Water2Mesh } from './objects/Water2.js';
 
 export * from './physics/AmmoPhysics.js';
 export * from './physics/RapierPhysics.js';

--- a/examples/jsm/Addons.js
+++ b/examples/jsm/Addons.js
@@ -175,7 +175,7 @@ export * from './objects/Water.js';
 export { Water as Water2 } from './objects/Water2.js';
 export * from './objects/SkyMesh.js';
 export * from './objects/WaterMesh.js';
-export { WaterMesh as Water2Mesh } from './objects/Water2.js';
+export { WaterMesh as Water2Mesh } from './objects/Water2Mesh.js';
 
 export * from './physics/AmmoPhysics.js';
 export * from './physics/RapierPhysics.js';

--- a/examples/jsm/objects/SkyMesh.js
+++ b/examples/jsm/objects/SkyMesh.js
@@ -21,7 +21,7 @@ import { float, tslFn, vec3, acos, add, mul, clamp, cos, dot, exp, max, mix, mod
  * Three.js integration by zz85 http://twitter.com/blurspline
 */
 
-class Sky extends Mesh {
+class SkyMesh extends Mesh {
 
 	constructor() {
 
@@ -186,4 +186,4 @@ class Sky extends Mesh {
 
 }
 
-export { Sky };
+export { SkyMesh };

--- a/examples/jsm/objects/WaterMesh.js
+++ b/examples/jsm/objects/WaterMesh.js
@@ -13,7 +13,7 @@ import { add, cameraPosition, div, normalize, positionWorld, sub, timerLocal, ts
  * http://29a.ch/ && http://29a.ch/slides/2012/webglwater/ : Water shader explanations in WebGL
  */
 
-class Water extends Mesh {
+class WaterMesh extends Mesh {
 
 	constructor( geometry, options ) {
 
@@ -100,4 +100,4 @@ class Water extends Mesh {
 
 }
 
-export { Water };
+export { WaterMesh };

--- a/examples/webgpu_ocean.html
+++ b/examples/webgpu_ocean.html
@@ -31,8 +31,8 @@
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
-			import { Water } from 'three/addons/objects/WaterGPU.js';
-			import { Sky } from 'three/addons/objects/SkyGPU.js';
+			import { WaterMesh } from 'three/addons/objects/WaterMesh.js';
+			import { SkyMesh } from 'three/addons/objects/SkyMesh.js';
 
 			let container, stats;
 			let camera, scene, renderer;
@@ -72,7 +72,7 @@
 				const waterNormals = loader.load( 'textures/waternormals.jpg' );
 				waterNormals.wrapS = waterNormals.wrapT = THREE.RepeatWrapping;
 
-				water = new Water(
+				water = new WaterMesh(
 					waterGeometry,
 					{
 						waterNormals: waterNormals,
@@ -89,7 +89,7 @@
 
 				// Skybox
 
-				const sky = new Sky();
+				const sky = new SkyMesh();
 				sky.scale.setScalar( 10000 );
 				scene.add( sky );
 

--- a/examples/webgpu_sky.html
+++ b/examples/webgpu_sky.html
@@ -27,7 +27,7 @@
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
-			import { Sky } from 'three/addons/objects/SkyGPU.js';
+			import { SkyMesh } from 'three/addons/objects/SkyMesh.js';
 
 			let camera, scene, renderer;
 
@@ -38,7 +38,7 @@
 			function initSky() {
 
 				// Add Sky
-				sky = new Sky();
+				sky = new SkyMesh();
 				sky.scale.setScalar( 450000 );
 				scene.add( sky );
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/29019#issuecomment-2259786334

**Description**

Like suggested in https://github.com/mrdoob/three.js/pull/29019#issuecomment-2259786334, the PR renames `SkyGPU` and `WaterGPU` to `SkyMesh` and `WaterMesh`.
