### PR TITLE
BatchedMesh: add support for points

### DIFF
--- a/src/renderers/shaders/ShaderLib/linedashed.glsl.js
+++ b/src/renderers/shaders/ShaderLib/linedashed.glsl.js
@@ -5,6 +5,7 @@ attribute float lineDistance;
 varying float vLineDistance;
 
 #include <common>
+#include <batching_pars_vertex>
 #include <uv_pars_vertex>
 #include <color_pars_vertex>
 #include <fog_pars_vertex>
@@ -20,6 +21,7 @@ void main() {
 	#include <color_vertex>
 	#include <morphinstance_vertex>
 	#include <morphcolor_vertex>
+	#include <batching_vertex>
 	#include <begin_vertex>
 	#include <morphtarget_vertex>
 	#include <project_vertex>

--- a/src/renderers/shaders/ShaderLib/points.glsl.js
+++ b/src/renderers/shaders/ShaderLib/points.glsl.js
@@ -3,6 +3,7 @@ uniform float size;
 uniform float scale;
 
 #include <common>
+#include <batching_pars_vertex>
 #include <color_pars_vertex>
 #include <fog_pars_vertex>
 #include <morphtarget_pars_vertex>
@@ -24,10 +25,10 @@ void main() {
 
 	#endif
 
-	#include <batching_vertex>
 	#include <color_vertex>
 	#include <morphinstance_vertex>
 	#include <morphcolor_vertex>
+	#include <batching_vertex>
 	#include <begin_vertex>
 	#include <morphtarget_vertex>
 	#include <project_vertex>

--- a/src/renderers/shaders/ShaderLib/points.glsl.js
+++ b/src/renderers/shaders/ShaderLib/points.glsl.js
@@ -24,6 +24,7 @@ void main() {
 
 	#endif
 
+	#include <batching_vertex>
 	#include <color_vertex>
 	#include <morphinstance_vertex>
 	#include <morphcolor_vertex>


### PR DESCRIPTION
Related issue: [BatchedMesh and gl.LINES, gl.POINTS](https://github.com/mrdoob/three.js/issues/29018)

**Description**

points.glsl.js will now worked with batched mesh
