### PR TITLE
WebGPURenderer: Apply `Scene.environment` only on PBR materials.

### DIFF
--- a/src/nodes/materials/MeshStandardNodeMaterial.js
+++ b/src/nodes/materials/MeshStandardNodeMaterial.js
@@ -34,7 +34,13 @@ class MeshStandardNodeMaterial extends NodeMaterial {
 
 	setupEnvironment( builder ) {
 
-		const envNode = super.setupEnvironment( builder );
+		let envNode = super.setupEnvironment( builder );
+
+		if ( envNode === null && builder.environmentNode ) {
+
+			envNode = builder.environmentNode;
+
+		}
 
 		return envNode ? new EnvironmentNode( envNode ) : null;
 

--- a/src/nodes/materials/NodeMaterial.js
+++ b/src/nodes/materials/NodeMaterial.js
@@ -364,7 +364,7 @@ class NodeMaterial extends Material {
 
 	}
 
-	setupEnvironment( builder ) {
+	setupEnvironment( /*builder*/ ) {
 
 		let node = null;
 
@@ -375,10 +375,6 @@ class NodeMaterial extends Material {
 		} else if ( this.envMap ) {
 
 			node = this.envMap.isCubeTexture ? cubeTexture( this.envMap ) : texture( this.envMap );
-
-		} else if ( builder.environmentNode ) {
-
-			node = builder.environmentNode;
 
 		}
 


### PR DESCRIPTION
Fixed #29031.

**Description**

This should make sure `Scene.environment` only affects physical materials.
