### PR TITLE
GLTFExporter: Preventing to write `null` for `attenuationDistance`.

### DIFF
--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -2837,9 +2837,12 @@ class GLTFMaterialsVolumeExtension {
 
 		}
 
-		if (material.attenuationDistance !== Infinity) {
+		if ( material.attenuationDistance !== Infinity ) {
+
 			extensionDef.attenuationDistance = material.attenuationDistance;
+
 		}
+
 		extensionDef.attenuationColor = material.attenuationColor.toArray();
 
 		materialDef.extensions = materialDef.extensions || {};

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -2837,7 +2837,9 @@ class GLTFMaterialsVolumeExtension {
 
 		}
 
-		extensionDef.attenuationDistance = material.attenuationDistance;
+		if (material.attenuationDistance !== Infinity) {
+			extensionDef.attenuationDistance = material.attenuationDistance;
+		}
 		extensionDef.attenuationColor = material.attenuationColor.toArray();
 
 		materialDef.extensions = materialDef.extensions || {};


### PR DESCRIPTION
Fixed #29034 

**Description**

Having no `material.attenuationDistance` set in the material, defaults to `+Infitity`. `+Infitity` cannot explicitilly be set in GLTF file and automatically is set to NULL by Three.js. NULL property is not allowed in JSON and makes the file invalid. It then cannot be read by various softwares, for example - Blender 4 - > onwards.

According to [KHR_materials_volume](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_volume) in order to convey infinity, the value should be ommited. We propose adding check if the  `material.attenuationDistance !== Infinity` we either send that parameter if its set, or don't send it if its default.

