### PR TITLE
MeshBasicNodeMaterial: Fix `setupNormal()`.

### DIFF
--- a/src/nodes/materials/MeshBasicNodeMaterial.js
+++ b/src/nodes/materials/MeshBasicNodeMaterial.js
@@ -28,7 +28,11 @@ class MeshBasicNodeMaterial extends NodeMaterial {
 
 	setupNormal() {
 
-		transformedNormalView.assign( normalView ); // see #28839
+		if ( this.envNode || this.envMap ) {
+
+			transformedNormalView.assign( normalView ); // see #28839
+
+		}
 
 	}
 


### PR DESCRIPTION
Related issue: #28939

**Description**

This should remove the warning:

> AttributeNode: Vertex attribute "normal" not found on geometry.

that pops up when using `MeshBasicNodeMaterial` without a normal attribute.

As an unlit material `MeshBasicNodeMaterial` does actually not need normals but they are required for cube map sampling. The PR improves `MeshBasicNodeMaterial.setupNormal()` by only defining normals if an environment map is in place.
