### PR TITLE
Material: Add `onBeforeRender()` back.

### DIFF
--- a/docs/api/ar/materials/Material.html
+++ b/docs/api/ar/materials/Material.html
@@ -401,6 +401,24 @@
 		على عكس الخصائص، لا يتم دعم رد الاتصال بواسطة [page:Material.clone .clone]()، 
 		[page:Material.copy .copy]() و [page:Material.toJSON .toJSON]().
 		</p>
+		<p>
+			This callback is only supported in `WebGLRenderer` (not `WebGPURenderer`). 
+		</p>
+
+		<h3>
+			[method:undefined onBeforeRender]( [param:WebGLRenderer renderer], [param:Scene scene], [param:Camera camera], [param:BufferGeometry geometry], [param:Object3D object], [param:Group group] )
+		</h3>
+		<p>
+			An optional callback that is executed immediately before the material is used to 
+			render a 3D object.
+		</p>
+		<p>
+			Unlike properties, the callback is not supported by [page:Material.clone .clone](), 
+			[page:Material.copy .copy]() and [page:Material.toJSON .toJSON]().
+		</p>
+		<p>
+			This callback is only supported in `WebGLRenderer` (not `WebGPURenderer`). 
+		</p>
 		 
 		<h3>[method:String customProgramCacheKey]()</h3>
 		<p>

--- a/docs/api/en/materials/Material.html
+++ b/docs/api/en/materials/Material.html
@@ -423,6 +423,24 @@
 			Unlike properties, the callback is not supported by [page:Material.clone .clone](), 
 			[page:Material.copy .copy]() and [page:Material.toJSON .toJSON]().
 		</p>
+		<p>
+			This callback is only supported in `WebGLRenderer` (not `WebGPURenderer`). 
+		</p>
+
+		<h3>
+			[method:undefined onBeforeRender]( [param:WebGLRenderer renderer], [param:Scene scene], [param:Camera camera], [param:BufferGeometry geometry], [param:Object3D object], [param:Group group] )
+		</h3>
+		<p>
+			An optional callback that is executed immediately before the material is used to 
+			render a 3D object.
+		</p>
+		<p>
+			Unlike properties, the callback is not supported by [page:Material.clone .clone](), 
+			[page:Material.copy .copy]() and [page:Material.toJSON .toJSON]().
+		</p>
+		<p>
+			This callback is only supported in `WebGLRenderer` (not `WebGPURenderer`). 
+		</p>
 
 		<h3>[method:String customProgramCacheKey]()</h3>
 		<p>

--- a/docs/api/fr/materials/Material.html
+++ b/docs/api/fr/materials/Material.html
@@ -355,6 +355,24 @@
 		<p>
 			Contrairement aux propriétés, le callback n'est pas pris en charge par [page:Material.clone .clone](), [page:Material.copy .copy]() et [page:Material.toJSON .toJSON]().
 		</p>
+		<p>
+			This callback is only supported in `WebGLRenderer` (not `WebGPURenderer`). 
+		</p>
+
+		<h3>
+			[method:undefined onBeforeRender]( [param:WebGLRenderer renderer], [param:Scene scene], [param:Camera camera], [param:BufferGeometry geometry], [param:Object3D object], [param:Group group] )
+		</h3>
+		<p>
+			An optional callback that is executed immediately before the material is used to 
+			render a 3D object.
+		</p>
+		<p>
+			Unlike properties, the callback is not supported by [page:Material.clone .clone](), 
+			[page:Material.copy .copy]() and [page:Material.toJSON .toJSON]().
+		</p>
+		<p>
+			This callback is only supported in `WebGLRenderer` (not `WebGPURenderer`). 
+		</p>
 
 		<h3>[method:String customProgramCacheKey]()</h3>
 		<p>

--- a/docs/api/it/materials/Material.html
+++ b/docs/api/it/materials/Material.html
@@ -373,6 +373,24 @@
 		<p>
 			A differenza delle proprietà, la callback non è supportata da [page:Material.clone .clone](), [page:Material.copy .copy]() e [page:Material.toJSON .toJSON]().
 		</p>
+		<p>
+			This callback is only supported in `WebGLRenderer` (not `WebGPURenderer`). 
+		</p>
+
+		<h3>
+			[method:undefined onBeforeRender]( [param:WebGLRenderer renderer], [param:Scene scene], [param:Camera camera], [param:BufferGeometry geometry], [param:Object3D object], [param:Group group] )
+		</h3>
+		<p>
+			An optional callback that is executed immediately before the material is used to 
+			render a 3D object.
+		</p>
+		<p>
+			Unlike properties, the callback is not supported by [page:Material.clone .clone](), 
+			[page:Material.copy .copy]() and [page:Material.toJSON .toJSON]().
+		</p>
+		<p>
+			This callback is only supported in `WebGLRenderer` (not `WebGPURenderer`). 
+		</p>
 
 		<h3>[method:String customProgramCacheKey]()</h3>
 		<p>

--- a/docs/api/zh/materials/Material.html
+++ b/docs/api/zh/materials/Material.html
@@ -312,6 +312,24 @@
 <p>
 和其他属性不一样的是，这个回调在[page:Material.clone .clone]()，[page:Material.copy .copy]() 和 [page:Material.toJSON .toJSON]() 中不支持。
 </p>
+<p>
+	This callback is only supported in `WebGLRenderer` (not `WebGPURenderer`). 
+</p>
+
+<h3>
+	[method:undefined onBeforeRender]( [param:WebGLRenderer renderer], [param:Scene scene], [param:Camera camera], [param:BufferGeometry geometry], [param:Object3D object], [param:Group group] )
+</h3>
+<p>
+	An optional callback that is executed immediately before the material is used to 
+	render a 3D object.
+</p>
+<p>
+	Unlike properties, the callback is not supported by [page:Material.clone .clone](), 
+	[page:Material.copy .copy]() and [page:Material.toJSON .toJSON]().
+</p>
+<p>
+	This callback is only supported in `WebGLRenderer` (not `WebGPURenderer`). 
+</p>
 
 <h3>[method:String customProgramCacheKey]()</h3>
 <p>

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -100,6 +100,10 @@ class Material extends EventDispatcher {
 
 	}
 
+	// onBeforeRender and onBeforeCompile only supported in WebGLRenderer
+
+	onBeforeRender( /* renderer, scene, camera, geometry, object, group */ ) {}
+
 	onBeforeCompile( /* shaderobject, renderer */ ) {}
 
 	customProgramCacheKey() {
@@ -521,13 +525,6 @@ class Material extends EventDispatcher {
 		console.warn( 'Material: onBuild() has been removed.' ); // @deprecated, r166
 
 	}
-
-	onBeforeRender( /* renderer, scene, camera, geometry, object, group */ ) {
-
-		console.warn( 'Material: onBeforeRender() has been removed.' ); // @deprecated, r166
-
-	}
-
 
 }
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1593,6 +1593,8 @@ class WebGLRenderer {
 			object.modelViewMatrix.multiplyMatrices( camera.matrixWorldInverse, object.matrixWorld );
 			object.normalMatrix.getNormalMatrix( object.modelViewMatrix );
 
+			material.onBeforeRender( _this, scene, camera, geometry, object, group );
+
 			if ( material.transparent === true && material.side === DoubleSide && material.forceSinglePass === false ) {
 
 				material.side = BackSide;


### PR DESCRIPTION
Related issue: #28702

**Description**

After deprecating `Material.onBeforeRender()` via #28702 multiple devs complained about this change.

As compromise I suggest to restore `onBeforeRender()` but make it absolutely clear that this callback will only be supported with `WebGLRenderer`. Similar to `onBeforeCompile()`. `WebGPURenderer` with its node material provide alternative workflows.

I've added a comment about this in the documentation and the code (just to be on the safe side).