### PR TITLE
PMREMNode: Mark default texture as render target texture.

### DIFF
--- a/src/nodes/pmrem/PMREMNode.js
+++ b/src/nodes/pmrem/PMREMNode.js
@@ -85,7 +85,12 @@ class PMREMNode extends TempNode {
 		this.levelNode = levelNode;
 
 		this._generator = null;
-		this._texture = texture( new Texture() );
+
+		const defaultTexture = new Texture();
+		defaultTexture.isRenderTargetTexture = true;
+
+		this._texture = texture( defaultTexture );
+
 		this._width = uniform( 0 );
 		this._height = uniform( 0 );
 		this._maxMip = uniform( 0 );


### PR DESCRIPTION
Fixes https://github.com/mrdoob/three.js/pull/28970#issuecomment-2260012881

**Description**

When the defining the default placeholder texture for `PMREMNode`, it's important to set `isRenderTargetTexture` to `true` otherwise the uvs for the WebGL backend won't be correct. Generated PMREM textures are always render target textures and rely on the `isRenderTargetTexture` flag.