### PR TITLE
RoomEnvironment: Remove obsolete `renderer` parameter.

### DIFF
--- a/examples/jsm/environments/RoomEnvironment.js
+++ b/examples/jsm/environments/RoomEnvironment.js
@@ -14,7 +14,7 @@ import {
 
 class RoomEnvironment extends Scene {
 
-	constructor( renderer = null ) {
+	constructor() {
 
 		super();
 

--- a/examples/misc_exporter_usdz.html
+++ b/examples/misc_exporter_usdz.html
@@ -79,7 +79,7 @@
 
 				scene = new THREE.Scene();
 				scene.background = new THREE.Color( 0xf0f0f0 );
-				scene.environment = pmremGenerator.fromScene( new RoomEnvironment( renderer ), 0.04 ).texture;
+				scene.environment = pmremGenerator.fromScene( new RoomEnvironment(), 0.04 ).texture;
 
 				const loader = new GLTFLoader().setPath( 'models/gltf/DamagedHelmet/glTF/' );
 				loader.load( 'DamagedHelmet.gltf', async function ( gltf ) {

--- a/examples/webgl_animation_keyframes.html
+++ b/examples/webgl_animation_keyframes.html
@@ -65,7 +65,7 @@
 
 			const scene = new THREE.Scene();
 			scene.background = new THREE.Color( 0xbfe3dd );
-			scene.environment = pmremGenerator.fromScene( new RoomEnvironment( renderer ), 0.04 ).texture;
+			scene.environment = pmremGenerator.fromScene( new RoomEnvironment(), 0.04 ).texture;
 
 			const camera = new THREE.PerspectiveCamera( 40, window.innerWidth / window.innerHeight, 1, 100 );
 			camera.position.set( 5, 2, 8 );

--- a/examples/webgl_loader_gltf_compressed.html
+++ b/examples/webgl_loader_gltf_compressed.html
@@ -54,7 +54,7 @@
 				camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 1, 2000 );
 				camera.position.set( 0, 100, 0 );
 
-				const environment = new RoomEnvironment( renderer );
+				const environment = new RoomEnvironment();
 				const pmremGenerator = new THREE.PMREMGenerator( renderer );
 
 				scene = new THREE.Scene();

--- a/examples/webgl_loader_gltf_dispersion.html
+++ b/examples/webgl_loader_gltf_dispersion.html
@@ -50,7 +50,7 @@
 				renderer.toneMappingExposure = 1;
 				container.appendChild( renderer.domElement );
 
-				const environment = new RoomEnvironment( renderer );
+				const environment = new RoomEnvironment();
 				const pmremGenerator = new THREE.PMREMGenerator( renderer );
 
 				scene = new THREE.Scene();

--- a/examples/webgl_loader_gltf_sheen.html
+++ b/examples/webgl_loader_gltf_sheen.html
@@ -76,7 +76,7 @@
 				renderer.toneMappingExposure = 1;
 				container.appendChild( renderer.domElement );
 
-				const environment = new RoomEnvironment( renderer );
+				const environment = new RoomEnvironment();
 				const pmremGenerator = new THREE.PMREMGenerator( renderer );
 
 				scene.background = new THREE.Color( 0xbbbbbb );

--- a/examples/webgl_loader_ldraw.html
+++ b/examples/webgl_loader_ldraw.html
@@ -93,7 +93,7 @@
 
 				scene = new THREE.Scene();
 				scene.background = new THREE.Color( 0xdeebed );
-				scene.environment = pmremGenerator.fromScene( new RoomEnvironment( renderer ) ).texture;
+				scene.environment = pmremGenerator.fromScene( new RoomEnvironment() ).texture;
 
 				controls = new OrbitControls( camera, renderer.domElement );
 				controls.enableDamping = true;

--- a/examples/webgl_loader_texture_lottie.html
+++ b/examples/webgl_loader_texture_lottie.html
@@ -64,7 +64,7 @@
 				renderer.setAnimationLoop( animate );
 				document.body.appendChild( renderer.domElement );
 
-				const environment = new RoomEnvironment( renderer );
+				const environment = new RoomEnvironment();
 				const pmremGenerator = new THREE.PMREMGenerator( renderer );
 
 				scene.environment = pmremGenerator.fromScene( environment ).texture;

--- a/examples/webgl_materials_alphahash.html
+++ b/examples/webgl_materials_alphahash.html
@@ -104,7 +104,7 @@
 
 				//
 
-				const environment = new RoomEnvironment( renderer );
+				const environment = new RoomEnvironment();
 				const pmremGenerator = new THREE.PMREMGenerator( renderer );
 
 				scene.environment = pmremGenerator.fromScene( environment ).texture;

--- a/examples/webgl_morphtargets_face.html
+++ b/examples/webgl_morphtargets_face.html
@@ -102,7 +102,7 @@
 
 					} );
 
-				const environment = new RoomEnvironment( renderer );
+				const environment = new RoomEnvironment();
 				const pmremGenerator = new THREE.PMREMGenerator( renderer );
 
 				scene.background = new THREE.Color( 0x666666 );

--- a/examples/webgl_morphtargets_webcam.html
+++ b/examples/webgl_morphtargets_webcam.html
@@ -116,7 +116,7 @@
 			const scene = new THREE.Scene();
 			scene.scale.x = - 1;
 
-			const environment = new RoomEnvironment( renderer );
+			const environment = new RoomEnvironment();
 			const pmremGenerator = new THREE.PMREMGenerator( renderer );
 
 			scene.background = new THREE.Color( 0x666666 );

--- a/examples/webgl_postprocessing_gtao.html
+++ b/examples/webgl_postprocessing_gtao.html
@@ -72,7 +72,7 @@
 
 				scene = new THREE.Scene();
 				scene.background = new THREE.Color( 0xbfe3dd );
-				scene.environment = pmremGenerator.fromScene( new RoomEnvironment( renderer ), 0.04 ).texture;
+				scene.environment = pmremGenerator.fromScene( new RoomEnvironment(), 0.04 ).texture;
 
 				camera = new THREE.PerspectiveCamera( 40, window.innerWidth / window.innerHeight, 1, 100 );
 				camera.position.set( 5, 2, 8 );

--- a/examples/webgpu_morphtargets_face.html
+++ b/examples/webgpu_morphtargets_face.html
@@ -66,7 +66,7 @@
 
 				await renderer.init();
 
-				const environment = new RoomEnvironment( renderer );
+				const environment = new RoomEnvironment();
 				const pmremGenerator = new THREE.PMREMGenerator( renderer );
 
 				scene.background = new THREE.Color( 0x666666 );


### PR DESCRIPTION
Related issue: -

**Description**

After the removal of `legacyLights` `RoomEnvironment` does no longer require a reference to the renderer.
