### PR TITLE
WebGPURenderer: Enable Subgroup Directives/Builtins

### DIFF
--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -648,6 +648,7 @@ ${ flowData.code }
 	getSubgroupSize() {
 
 		this.enableSubGroups();
+
 		return this.getBuiltin( 'subgroup_size', 'subgroupSize', 'u32', 'attribute' );
 
 	}
@@ -655,6 +656,7 @@ ${ flowData.code }
 	getSubgroupIndex() {
 
 		this.enableSubGroups();
+
 		return this.getBuiltin( 'subgroup_invocation_id', 'subgroupIndex', 'u32', 'attribute' );
 
 	}

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -645,6 +645,18 @@ ${ flowData.code }
 
 	}
 
+	getSubgroupSize() {
+
+		return this.getBuiltin( 'subgroup_size', 'subgroupSize', 'u32', 'attribute' );
+
+	}
+
+	getSubgroupIndex() {
+
+		return this.getBuiltin( 'subgroup_invocation_id', 'subgroupIndex', 'u32', 'attribute' );
+
+	}
+
 	getDrawIndex() {
 
 		return null;
@@ -701,6 +713,18 @@ ${ flowData.code }
 
 	}
 
+	enableSubGroups() {
+
+		this.enableDirective( 'subgroups' );
+
+	}
+
+	enableSubgroupsF16() {
+
+		this.enableDirective( 'subgroups-f16' );
+
+	}
+
 	enableClipDistances() {
 
 		this.enableDirective( 'clip_distances' );
@@ -748,6 +772,7 @@ ${ flowData.code }
 			this.getBuiltin( 'workgroup_id', 'workgroupId', 'vec3<u32>', 'attribute' );
 			this.getBuiltin( 'local_invocation_id', 'localId', 'vec3<u32>', 'attribute' );
 			this.getBuiltin( 'num_workgroups', 'numWorkgroups', 'vec3<u32>', 'attribute' );
+			this.getBuildStage( 'subgroup_size' );
 
 		}
 

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -647,12 +647,14 @@ ${ flowData.code }
 
 	getSubgroupSize() {
 
+		this.enableSubGroups();
 		return this.getBuiltin( 'subgroup_size', 'subgroupSize', 'u32', 'attribute' );
 
 	}
 
 	getSubgroupIndex() {
 
+		this.enableSubGroups();
 		return this.getBuiltin( 'subgroup_invocation_id', 'subgroupIndex', 'u32', 'attribute' );
 
 	}
@@ -689,8 +691,8 @@ ${ flowData.code }
 
 	enableDirective( name, shaderStage = this.shaderStage ) {
 
-		const stage = this.directives[ shaderStage ] || ( this.directives[ shaderStage ] = [] );
-		stage.push( name );
+		const stage = this.directives[ shaderStage ] || ( this.directives[ shaderStage ] = new Set() );
+		stage.add( name );
 
 	}
 

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -772,7 +772,6 @@ ${ flowData.code }
 			this.getBuiltin( 'workgroup_id', 'workgroupId', 'vec3<u32>', 'attribute' );
 			this.getBuiltin( 'local_invocation_id', 'localId', 'vec3<u32>', 'attribute' );
 			this.getBuiltin( 'num_workgroups', 'numWorkgroups', 'vec3<u32>', 'attribute' );
-			this.getBuildStage( 'subgroup_size' );
 
 		}
 

--- a/src/renderers/webgpu/utils/WebGPUConstants.js
+++ b/src/renderers/webgpu/utils/WebGPUConstants.js
@@ -328,5 +328,6 @@ export const GPUFeatureName = {
 	BGRA8UNormStorage: 'bgra8unorm-storage',
 	Float32Filterable: 'float32-filterable',
 	ClipDistances: 'clip-distances',
-	DualSourceBlending: 'dual-source-blending'
+	DualSourceBlending: 'dual-source-blending',
+	Subgroups: 'subgroups'
 };


### PR DESCRIPTION
Add ability to generate the subgroup directives and subgroup attributes in WGSLNodeBuilder. Support for enabling the directive and utilizing subgroup builtins will be available in Chrome 128. 