### PR TITLE
Webxr cpu

### DIFF
--- a/src/renderers/webxr/WebXRDepthSensing.js
+++ b/src/renderers/webxr/WebXRDepthSensing.js
@@ -107,4 +107,42 @@ class WebXRDepthSensing {
 
 }
 
-export { WebXRDepthSensing };
+class WebXRDepthSensingCpu {
+
+	init( session, frame, depthSensingCpuInfo ) {
+
+		this.session = session;
+		this.frame = frame;
+		this.depthSensingCpuInfo = depthSensingCpuInfo;
+
+	}
+
+	getDepthData() {
+
+		if ( ! this.session || ! this.depthSensingCpuInfo || ! this.frame ) return undefined;
+
+		if ( this.session.depthDataFormat === 'luminance-alpha' ) {
+
+			return { depthSensingCpuInfo: this.depthSensingCpuInfo, type: 'uint16' };
+
+		} else if ( this.session.depthDataFormat === 'float32' ) {
+
+			return { depthSensingCpuInfo: this.depthSensingCpuInfo, type: 'float32' };
+
+		}
+
+		return undefined;
+
+	}
+
+	reset() {
+
+		this.session = null;
+		this.depthSensingCpuInfo = null;
+		this.frame = null;
+
+	}
+
+}
+
+export { WebXRDepthSensing, WebXRDepthSensingCpu };

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -10,7 +10,7 @@ import { WebGLRenderTarget } from '../WebGLRenderTarget.js';
 import { WebXRController } from './WebXRController.js';
 import { DepthTexture } from '../../textures/DepthTexture.js';
 import { DepthFormat, DepthStencilFormat, RGBAFormat, UnsignedByteType, UnsignedIntType, UnsignedInt248Type } from '../../constants.js';
-import { WebXRDepthSensing } from './WebXRDepthSensing.js';
+import { WebXRDepthSensing, WebXRDepthSensingCpu } from './WebXRDepthSensing.js';
 
 class WebXRManager extends EventDispatcher {
 
@@ -37,6 +37,7 @@ class WebXRManager extends EventDispatcher {
 		let xrFrame = null;
 
 		const depthSensing = new WebXRDepthSensing();
+		const depthSensingCpu = new WebXRDepthSensingCpu();
 		const attributes = gl.getContextAttributes();
 
 		let initialRenderTarget = null;
@@ -386,6 +387,12 @@ class WebXRManager extends EventDispatcher {
 		this.getDepthTexture = function () {
 
 			return depthSensing.getDepthTexture();
+
+		};
+
+		this.getDepthDataCpu = function () {
+
+			return depthSensingCpu.getDepthData();
 
 		};
 
@@ -778,13 +785,28 @@ class WebXRManager extends EventDispatcher {
 
 				if ( enabledFeatures && enabledFeatures.includes( 'depth-sensing' ) ) {
 
-					const depthData = glBinding.getDepthInformation( views[ 0 ] );
+					if ( session.depthUsage === 'gpu-optimized' ) {
 
-					if ( depthData && depthData.isValid && depthData.texture ) {
+						const depthData = glBinding.getDepthInformation( views[ 0 ] );
 
-						depthSensing.init( renderer, depthData, session.renderState );
+						if ( depthData && depthData.isValid && depthData.texture ) {
+
+							depthSensing.init( renderer, depthData, session.renderState );
+
+						}
+
+					} else {
+
+						const depthSensingCpuInfo = frame.getDepthInformation( views[ 0 ] );
+
+						if ( depthSensingCpuInfo ) {
+
+							depthSensingCpu.init( session, frame, depthSensingCpuInfo );
+
+						}
 
 					}
+
 
 				}
 

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -279,6 +279,12 @@ class WebXRManager extends EventDispatcher {
 				currentPixelRatio = renderer.getPixelRatio();
 				renderer.getSize( currentSize );
 
+				if ( typeof XRWebGLBinding !== 'undefined' ) {
+
+					glBinding = new XRWebGLBinding( session, gl );
+
+				}
+
 				if ( session.renderState.layers === undefined ) {
 
 					const layerInit = {
@@ -326,8 +332,6 @@ class WebXRManager extends EventDispatcher {
 						depthFormat: glDepthFormat,
 						scaleFactor: framebufferScaleFactor
 					};
-
-					glBinding = new XRWebGLBinding( session, gl );
 
 					glProjLayer = glBinding.createProjectionLayer( projectionlayerInit );
 
@@ -823,7 +827,7 @@ class WebXRManager extends EventDispatcher {
 
 		};
 
-		this.dispose = function () {};
+		this.dispose = function () { };
 
 	}
 

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -170,6 +170,7 @@ class WebXRManager extends EventDispatcher {
 			_currentDepthFar = null;
 
 			depthSensing.reset();
+			depthSensingCpu.reset();
 
 			// restore framebuffer/rendering state
 


### PR DESCRIPTION
It seems that, as for now, threejs doesn't support `cpu-optimized` WebXR depth-sensing. 

I'm using an older device (a Pixel 3) and found that a lot of the WebXR examples don't work on this phone.
I think there are two issues with supporting this device (and probably a few other order devices, too), but please do correct my if I've misunderstood anything:

1. Currently, threejs only instantiates `glBinding = new XRWebGLBinding` if `session.renderState.layers` exists, that is, if the [WebXR-layers module is being supported](https://immersive-web.github.io/layers/#xrrenderstatechanges) ([code here](https://github.com/mrdoob/three.js/blob/0dd714ecc918c914c7d39478911839dbe4c2abf0/src/renderers/webxr/WebXRManager.js#L282)). 
2.  My device can only handle `cpu-optimized` depth sensing; but currently threejs seems to only use the gpu-optimized access method ([code here](https://github.com/mrdoob/three.js/blob/0dd714ecc918c914c7d39478911839dbe4c2abf0/src/renderers/webxr/WebXRManager.js#L775), cpu-style access method [described here](https://github.com/immersive-web/depth-sensing/blob/main/explainer.md))

So I've been playing around with this a little bit - I hope that this PR  can serve as a basis for discussion.

I guess we'd have to figure out a few questions, though:
1. Does threejs want to support cpu-optimized depth-sensing?
2. If so, one reasonable way to go about this would be to create a cpu-equivalent of the current `WebXRDepthSensing` class - this PR creates a `WebXRDepthSensingCpu` class.
3. Since the cpu based depth-data is not provided as a WebGL texture but as an array on the cpu, I don't think one could mirror the `WebXRDepthSensing` API surface perfectly: for example, we *could* create a WebGL texture from the cpu-array to mirror the `getDepthTexture` method, but that would involve a lot of copying of data from cpu to gpu.
4. So in the most general form: what should a possible `WebXRDepthSensingCpu` look like?

With or without cpu-optimized depth-sensing, threejs has pretty nice WebXR support - thanks btw for all those examples! For now I've refrained from creating a concrete example for cpu-based depth-sensing, just because I guess that from this discussion some significant changes might still come about. 

Cheers!

