### PR TITLE
BatchedMesh: fix colorsTexture size

### DIFF
--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -206,7 +206,7 @@ class BatchedMesh extends Mesh {
 
 	_initColorsTexture() {
 
-		let size = Math.sqrt( this._maxIndexCount );
+		let size = Math.sqrt( this._maxInstanceCount );
 		size = Math.ceil( size );
 
 		// 4 floats per RGBA pixel initialized to white


### PR DESCRIPTION
**Description**

The size of colorsTexture is bigger than necessary because it is created to store a color for each geometry index, instead of for each instance.
