### PR TITLE
WebGPURenderer: Fix instance meshes that shares the same count

### DIFF
--- a/src/renderers/common/RenderObject.js
+++ b/src/renderers/common/RenderObject.js
@@ -191,7 +191,7 @@ export default class RenderObject {
 
 		for ( const property of getKeys( material ) ) {
 
-			if ( /^(is[A-Z]|_)|^(visible|version|uuid|name|opacity|userData)$/.test( property ) ) continue;
+			if ( /^(is[A-Z]|_)|^(visible|version|name|opacity|userData)$/.test( property ) ) continue;
 
 			const value = material[ property ];
 

--- a/src/renderers/common/RenderObject.js
+++ b/src/renderers/common/RenderObject.js
@@ -191,7 +191,7 @@ export default class RenderObject {
 
 		for ( const property of getKeys( material ) ) {
 
-			if ( /^(is[A-Z]|_)|^(visible|version|name|opacity|userData)$/.test( property ) ) continue;
+			if ( /^(is[A-Z]|_)|^(visible|version|uuid|name|opacity|userData)$/.test( property ) ) continue;
 
 			const value = material[ property ];
 
@@ -263,7 +263,7 @@ export default class RenderObject {
 
 		if ( object.count > 1 ) {
 
-			cacheKey += object.count + ',';
+			cacheKey += object.count + ',' + object.uuid + ',';
 
 		}
 


### PR DESCRIPTION
**Description**
Currently, if two InstancedMesh objects have the same count, the second InstancedMesh incorrectly inherits the matrices of the first due to a shared cacheKey. This happens because the cacheKey is solely based on object.count.

Fix:
By incorporating the uuid of the InstancedMesh into the cacheKey, we ensure that each InstancedMesh maintains its own unique cache, preventing the unintended sharing of matrices.

Example for test if needed:
[instance_webgpu_issue.glb.zip](https://github.com/user-attachments/files/16498878/instance_webgpu_issue.glb.zip)



<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Utsubo](https://utsubo.com)*
