### PR TITLE
TSL: Remove `stack` parameter of `Fn()`

### DIFF
--- a/src/nodes/accessors/TangentNode.js
+++ b/src/nodes/accessors/TangentNode.js
@@ -4,7 +4,7 @@ import { cameraViewMatrix } from './CameraNode.js';
 import { modelViewMatrix } from './ModelNode.js';
 import { Fn, vec4 } from '../shadernode/ShaderNode.js';
 
-export const tangentGeometry = /*#__PURE__*/ Fn( ( stack, builder ) => {
+export const tangentGeometry = /*#__PURE__*/ Fn( ( builder ) => {
 
 	if ( builder.geometry.hasAttribute( 'tangent' ) === false ) {
 

--- a/src/nodes/shadernode/ShaderNode.js
+++ b/src/nodes/shadernode/ShaderNode.js
@@ -300,7 +300,7 @@ class ShaderCallNodeInternal extends Node {
 		}
 
 		const jsFunc = shaderNode.jsFunc;
-		const outputNode = inputNodes !== null ? jsFunc( inputNodes, builder.stack, builder ) : jsFunc( builder.stack, builder );
+		const outputNode = inputNodes !== null ? jsFunc( inputNodes, builder ) : jsFunc( builder );
 
 		return nodeObject( outputNode );
 


### PR DESCRIPTION
**Description**

After several improvements in flow control through direct functions, I think we can remove `stack` as a parameter since it has fallen into disuse.