### PR TITLE
DragControls: Add `mouseButtons`

### DIFF
--- a/docs/examples/en/controls/DragControls.html
+++ b/docs/examples/en/controls/DragControls.html
@@ -102,12 +102,12 @@
 
 		<h3>[property:Object mouseButtons]</h3>
 		<p>
-			This object contains references to the mouse button used by the controls. 
+			This object contains references to the mouse actions used by the controls.
 			<code>
 				controls.mouseButtons = {
-					LEFT: true,
-					MIDDLE: true,
-					RIGHT: true
+					LEFT: THREE.MOUSE.DRAG,
+					MIDDLE: null,
+					RIGHT: THREE.MOUSE.ROTATE
 				}
 			</code>
 		</p>
@@ -125,7 +125,7 @@
 
 		<h3>[property:String mode]</h3>
 		<p>
-			The current transformation mode. Possible values are `translate`, and `rotate`. Default is `translate`.
+			The current transformation mode for pen and touch events. Possible values are `translate`, and `rotate`. Default is `translate`.
 		</p>
 
 		<h3>[property:Float rotateSpeed]</h3>

--- a/docs/examples/en/controls/DragControls.html
+++ b/docs/examples/en/controls/DragControls.html
@@ -95,6 +95,13 @@
 
 		<h2>Properties</h2>
 
+		<h3>[property:Array mouseButtons]</h3>
+		<p>
+			The array of allowed MouseEvent.button values for drag interactions. 
+			<br>
+			Default is [ THREE.MOUSE.LEFT, THREE.MOUSE.RIGHT, THREE.MOUSE.MIDDLE ].
+		</p>
+
 		<h3>[property:Boolean enabled]</h3>
 		<p>
 			Whether or not the controls are enabled.

--- a/docs/examples/en/controls/DragControls.html
+++ b/docs/examples/en/controls/DragControls.html
@@ -95,16 +95,21 @@
 
 		<h2>Properties</h2>
 
-		<h3>[property:Array mouseButtons]</h3>
-		<p>
-			The array of allowed MouseEvent.button values for drag interactions. 
-			<br>
-			Default is [ THREE.MOUSE.LEFT, THREE.MOUSE.RIGHT, THREE.MOUSE.MIDDLE ].
-		</p>
-
 		<h3>[property:Boolean enabled]</h3>
 		<p>
 			Whether or not the controls are enabled.
+		</p>
+
+		<h3>[property:Object mouseButtons]</h3>
+		<p>
+			This object contains references to the mouse button used by the controls. 
+			<code>
+				controls.mouseButtons = {
+					LEFT: true,
+					MIDDLE: true,
+					RIGHT: true
+				}
+			</code>
 		</p>
 
 		<h3>[property:Boolean recursive]</h3>

--- a/docs/examples/zh/controls/DragControls.html
+++ b/docs/examples/zh/controls/DragControls.html
@@ -97,6 +97,13 @@
 
 		<h2>属性</h2>
 
+		<h3>[property:Array mouseButtons]</h3>
+		<p>
+			鼠标事件中允许响应的按键值数组。 
+			<br>
+			默认值为 [ THREE.MOUSE.LEFT, THREE.MOUSE.RIGHT, THREE.MOUSE.MIDDLE ]。
+		</p>
+
 		<h3>[property:Boolean enabled]</h3>
 		<p>
 			是否启用控制器。
@@ -109,7 +116,7 @@
 
 		<h3>[property:String mode]</h3>
 		<p>
-			The current transformation mode. Possible values are `translate`, and `rotate`. Default is `translate`.
+			当前的变换模式，该值可以是 `translate` 或 `rotate`。 默认值为 `translate`。
 		</p>
 
 		<h2>方法</h2>
@@ -143,7 +150,7 @@
 
 		<h3>[method:undefined setObjects] ( [param:Array objects] )</h3>
 		<p>
-			Sets an array of draggable objects by overwriting the existing one.
+			通过覆盖现有数组来设置可拖动对象数组。
 		</p>
 
 		<h2>源代码</h2>

--- a/docs/examples/zh/controls/DragControls.html
+++ b/docs/examples/zh/controls/DragControls.html
@@ -104,12 +104,12 @@
 
 		<h3>[property:Object mouseButtons]</h3>
 		<p>
-			鼠标事件中允许响应的按键。 
+			该对象包含由控件所使用的鼠标操作的引用。 
 			<code>
 				controls.mouseButtons = {
-					LEFT: true,
-					MIDDLE: true,
-					RIGHT: true
+					LEFT: THREE.MOUSE.DRAG,
+					MIDDLE: null,
+					RIGHT: THREE.MOUSE.ROTATE
 				}
 			</code>
 		</p>
@@ -126,7 +126,12 @@
 
 		<h3>[property:String mode]</h3>
 		<p>
-			当前的变换模式，该值可以是 `translate` 或 `rotate`。 默认值为 `translate`。
+			在 `pen` 或 `touch` 事件中当前的变换模式，该值可以是 `translate` 或 `rotate`。 默认值为 `translate`。
+		</p>
+
+		<h3>[property:Float rotateSpeed]</h3>
+		<p>
+			执行 `rotate` 时的旋转速度。该值越大旋转速度越快。 默认值为 `1`。
 		</p>
 
 		<h2>方法</h2>

--- a/docs/examples/zh/controls/DragControls.html
+++ b/docs/examples/zh/controls/DragControls.html
@@ -97,16 +97,26 @@
 
 		<h2>属性</h2>
 
-		<h3>[property:Array mouseButtons]</h3>
-		<p>
-			鼠标事件中允许响应的按键值数组。 
-			<br>
-			默认值为 [ THREE.MOUSE.LEFT, THREE.MOUSE.RIGHT, THREE.MOUSE.MIDDLE ]。
-		</p>
-
 		<h3>[property:Boolean enabled]</h3>
 		<p>
 			是否启用控制器。
+		</p>
+
+		<h3>[property:Object mouseButtons]</h3>
+		<p>
+			鼠标事件中允许响应的按键。 
+			<code>
+				controls.mouseButtons = {
+					LEFT: true,
+					MIDDLE: true,
+					RIGHT: true
+				}
+			</code>
+		</p>
+
+		<h3>[property:Boolean recursive]</h3>
+		<p>
+			可拖动对象的子对象是否可以独立于其父对象进行拖动。默认值为 `true`。
 		</p>
 
 		<h3>[property:Boolean transformGroup]</h3>

--- a/examples/jsm/controls/DragControls.js
+++ b/examples/jsm/controls/DragControls.js
@@ -1,6 +1,7 @@
 import {
 	EventDispatcher,
 	Matrix4,
+	MOUSE,
 	Plane,
 	Raycaster,
 	Vector2,
@@ -20,6 +21,9 @@ const _inverseMatrix = new Matrix4();
 
 const _up = new Vector3();
 const _right = new Vector3();
+
+const _mouseButtons = [ MOUSE.LEFT, MOUSE.RIGHT, MOUSE.MIDDLE ];
+const _mouseMoveButtons = [ 0, 1, 2, 4 ];
 
 class DragControls extends EventDispatcher {
 
@@ -88,6 +92,8 @@ class DragControls extends EventDispatcher {
 		function onPointerMove( event ) {
 
 			if ( scope.enabled === false ) return;
+
+			if ( event.pointerType === 'mouse' && _mouseMoveButtons.includes( event.buttons ) === false ) return;
 
 			updatePointer( event );
 
@@ -174,6 +180,8 @@ class DragControls extends EventDispatcher {
 		function onPointerDown( event ) {
 
 			if ( scope.enabled === false ) return;
+
+			if ( event.pointerType === 'mouse' && _mouseButtons.includes( event.button ) === false ) return;
 
 			updatePointer( event );
 
@@ -274,6 +282,28 @@ class DragControls extends EventDispatcher {
 		this.getObjects = getObjects;
 		this.getRaycaster = getRaycaster;
 		this.setObjects = setObjects;
+
+	}
+
+	get mouseButtons() {
+
+		return _mouseButtons;
+
+	}
+
+	set mouseButtons( arr ) {
+
+		_mouseButtons.length = 0;
+		arr.forEach( item => _mouseButtons.push( item ) );
+
+		_mouseMoveButtons.length = 0;
+		_mouseMoveButtons.push( 0 );
+
+		if ( _mouseButtons.includes( MOUSE.LEFT ) ) _mouseMoveButtons.push( 1 );
+
+		if ( _mouseButtons.includes( MOUSE.RIGHT ) ) _mouseMoveButtons.push( 2 );
+
+		if ( _mouseButtons.includes( MOUSE.MIDDLE ) ) _mouseMoveButtons.push( 4 );
 
 	}
 

--- a/examples/jsm/controls/DragControls.js
+++ b/examples/jsm/controls/DragControls.js
@@ -94,7 +94,7 @@ class DragControls extends EventDispatcher {
 
 		}
 
-		function isNonelike() {
+		function isNullish() {
 
 			return ( state === STATE.DRAG || state === STATE.ROTATE ) === false;
 
@@ -103,7 +103,7 @@ class DragControls extends EventDispatcher {
 		function onPointerMove( event ) {
 
 			if ( scope.enabled === false ) return;
-			if ( isNonelike() ) return;
+			if ( isNullish() ) return;
 
 			updatePointer( event );
 
@@ -238,7 +238,7 @@ class DragControls extends EventDispatcher {
 
 			}
 
-			if ( isNonelike() ) return;
+			if ( isNullish() ) return;
 
 			updatePointer( event );
 

--- a/examples/jsm/controls/DragControls.js
+++ b/examples/jsm/controls/DragControls.js
@@ -1,7 +1,6 @@
 import {
 	EventDispatcher,
 	Matrix4,
-	MOUSE,
 	Plane,
 	Raycaster,
 	Vector2,
@@ -22,9 +21,6 @@ const _inverseMatrix = new Matrix4();
 const _up = new Vector3();
 const _right = new Vector3();
 
-const _mouseButtons = [ MOUSE.LEFT, MOUSE.RIGHT, MOUSE.MIDDLE ];
-const _mouseMoveButtons = [ 0, 1, 2, 4 ];
-
 class DragControls extends EventDispatcher {
 
 	constructor( _objects, _camera, _domElement ) {
@@ -41,7 +37,7 @@ class DragControls extends EventDispatcher {
 
 		this.rotateSpeed = 1;
 
-		//
+		this.mouseButtons = { LEFT: true, MIDDLE: true, RIGHT: true };
 
 		const scope = this;
 
@@ -93,7 +89,44 @@ class DragControls extends EventDispatcher {
 
 			if ( scope.enabled === false ) return;
 
-			if ( event.pointerType === 'mouse' && _mouseMoveButtons.includes( event.buttons ) === false ) return;
+			if ( event.pointerType === 'mouse' ) {
+
+				switch ( event.buttons ) {
+
+					case 1:
+
+						if ( scope.mouseButtons.LEFT !== true ) {
+
+							return;
+
+						}
+
+						break;
+					case 2:
+
+						if ( scope.mouseButtons.RIGHT !== true ) {
+
+							return;
+
+						}
+
+						break;
+					case 4:
+
+						if ( scope.mouseButtons.MIDDLE !== true ) {
+
+							return;
+
+						}
+
+						break;
+					default:
+
+						break;
+
+				}
+
+			}
 
 			updatePointer( event );
 
@@ -181,7 +214,44 @@ class DragControls extends EventDispatcher {
 
 			if ( scope.enabled === false ) return;
 
-			if ( event.pointerType === 'mouse' && _mouseButtons.includes( event.button ) === false ) return;
+			if ( event.pointerType === 'mouse' ) {
+
+				switch ( event.button ) {
+
+					case 0:
+
+						if ( scope.mouseButtons.LEFT !== true ) {
+
+							return;
+
+						}
+
+						break;
+					case 1:
+
+						if ( scope.mouseButtons.MIDDLE !== true ) {
+
+							return;
+
+						}
+
+						break;
+					case 2:
+
+						if ( scope.mouseButtons.RIGHT !== true ) {
+
+							return;
+
+						}
+
+						break;
+					default:
+
+						break;
+
+				}
+
+			}
 
 			updatePointer( event );
 
@@ -282,28 +352,6 @@ class DragControls extends EventDispatcher {
 		this.getObjects = getObjects;
 		this.getRaycaster = getRaycaster;
 		this.setObjects = setObjects;
-
-	}
-
-	get mouseButtons() {
-
-		return _mouseButtons;
-
-	}
-
-	set mouseButtons( arr ) {
-
-		_mouseButtons.length = 0;
-		arr.forEach( item => _mouseButtons.push( item ) );
-
-		_mouseMoveButtons.length = 0;
-		_mouseMoveButtons.push( 0 );
-
-		if ( _mouseButtons.includes( MOUSE.LEFT ) ) _mouseMoveButtons.push( 1 );
-
-		if ( _mouseButtons.includes( MOUSE.RIGHT ) ) _mouseMoveButtons.push( 2 );
-
-		if ( _mouseButtons.includes( MOUSE.MIDDLE ) ) _mouseMoveButtons.push( 4 );
 
 	}
 

--- a/examples/jsm/controls/DragControls.js
+++ b/examples/jsm/controls/DragControls.js
@@ -94,7 +94,7 @@ class DragControls extends EventDispatcher {
 
 		}
 
-		function isNullish() {
+		function isStateInvalid() {
 
 			return ( state === STATE.DRAG || state === STATE.ROTATE ) === false;
 
@@ -103,7 +103,6 @@ class DragControls extends EventDispatcher {
 		function onPointerMove( event ) {
 
 			if ( scope.enabled === false ) return;
-			if ( isNullish() ) return;
 
 			updatePointer( event );
 
@@ -238,7 +237,7 @@ class DragControls extends EventDispatcher {
 
 			}
 
-			if ( isNullish() ) return;
+			if ( isStateInvalid() ) return;
 
 			updatePointer( event );
 
@@ -293,6 +292,8 @@ class DragControls extends EventDispatcher {
 		function onPointerCancel() {
 
 			if ( scope.enabled === false ) return;
+			
+			state = STATE.NONE;
 
 			if ( _selected ) {
 

--- a/examples/jsm/controls/DragControls.js
+++ b/examples/jsm/controls/DragControls.js
@@ -292,7 +292,7 @@ class DragControls extends EventDispatcher {
 		function onPointerCancel() {
 
 			if ( scope.enabled === false ) return;
-			
+
 			state = STATE.NONE;
 
 			if ( _selected ) {

--- a/examples/misc_controls_drag.html
+++ b/examples/misc_controls_drag.html
@@ -20,7 +20,7 @@
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> webgl - drag controls<br />
 			Use "Shift+Click" to add/remove objects to/from a group.<br />
-			Use "M" to toggle between rotate and translate mode.<br />
+			Use "M" to toggle between rotate and translate mode (applies to pen and touch events only).<br />
 			Grouped objects can be transformed as a union.
 		</div>
 
@@ -51,6 +51,12 @@
 			init();
 
 			function init() {
+
+				document.addEventListener( 'contextmenu', ( eve ) => {
+
+					eve.preventDefault();
+
+				} );
 
 				container = document.createElement( 'div' );
 				document.body.appendChild( container );
@@ -143,7 +149,7 @@
 			function onKeyDown( event ) {
 
 				enableSelection = ( event.keyCode === 16 ) ? true : false;
-				
+
 				if ( event.keyCode === 77 ) {
 
 					controls.mode = ( controls.mode === 'translate' ) ? 'rotate' : 'translate';

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,6 +1,6 @@
 export const REVISION = '168dev';
 
-export const MOUSE = { LEFT: 0, MIDDLE: 1, RIGHT: 2, ROTATE: 0, DOLLY: 1, PAN: 2 };
+export const MOUSE = { LEFT: 0, MIDDLE: 1, RIGHT: 2, ROTATE: 0, DOLLY: 1, PAN: 2, DRAG: 3 };
 export const TOUCH = { ROTATE: 0, PAN: 1, DOLLY_PAN: 2, DOLLY_ROTATE: 3 };
 export const CullFaceNone = 0;
 export const CullFaceBack = 1;

--- a/test/unit/src/constants.tests.js
+++ b/test/unit/src/constants.tests.js
@@ -6,7 +6,7 @@ export default QUnit.module( 'Constants', () => {
 
 	QUnit.test( 'default values', ( assert ) => {
 
-		assert.propEqual( Constants.MOUSE, { LEFT: 0, MIDDLE: 1, RIGHT: 2, ROTATE: 0, DOLLY: 1, PAN: 2 }, 'MOUSE equal { LEFT: 0, MIDDLE: 1, RIGHT: 2, ROTATE: 0, DOLLY: 1, PAN: 2 }' );
+		assert.propEqual( Constants.MOUSE, { LEFT: 0, MIDDLE: 1, RIGHT: 2, ROTATE: 0, DOLLY: 1, PAN: 2, DRAG: 3 }, 'MOUSE equal { LEFT: 0, MIDDLE: 1, RIGHT: 2, ROTATE: 0, DOLLY: 1, PAN: 2, DRAG: 3 }' );
 		assert.propEqual( Constants.TOUCH, { ROTATE: 0, PAN: 1, DOLLY_PAN: 2, DOLLY_ROTATE: 3 }, 'TOUCH equal { ROTATE: 0, PAN: 1, DOLLY_PAN: 2, DOLLY_ROTATE: 3 }' );
 
 		assert.equal( Constants.CullFaceNone, 0, 'CullFaceNone equal 0' );


### PR DESCRIPTION




This PR introduces a new property `mouseButtons` to DragControls. 

This enhancement allows users to customize which mouse button can trigger drag interactions.

This makes it easy to use DragControls with other controllers.



<br>

For example: `DragControls + OrbitControls`

```diff
const myOrbitControls = new OrbitControls(...)

const myDragControls = new DragControls(...)
+ myDragControls.mouseButtons = { LEFT: MOUSE.DRAG, MIDDLE: null, RIGHT: null }

myDragControls.addEventListener('dragstart', () =>{
  myOrbitControls.enabled = false
})

myDragControls.addEventListener('dragend', () =>{
  myOrbitControls.enabled = true
})
```



<br>

I can achieve the following results:

* `MOUSE.LEFT (selected)` - drag mesh
* `MOUSE.LEFT (no selected)` - rotation of the camera
* `MOUSE.RIGH` - camera panning
* `MOUSE.MIDDLE` - camera zooming 