### PR TITLE
ToneMappingNode: properly handle alpha

### DIFF
--- a/src/nodes/display/ToneMappingNode.js
+++ b/src/nodes/display/ToneMappingNode.js
@@ -1,6 +1,6 @@
 import TempNode from '../core/TempNode.js';
 import { addNodeClass } from '../core/Node.js';
-import { addNodeElement, Fn, nodeObject, float, mat3, vec3, If } from '../shadernode/ShaderNode.js';
+import { addNodeElement, Fn, nodeObject, float, mat3, vec3, vec4, If } from '../shadernode/ShaderNode.js';
 import { rendererReference } from '../accessors/RendererReferenceNode.js';
 import { select } from '../math/CondNode.js';
 import { clamp, log2, max, min, pow, mix } from '../math/MathNode.js';
@@ -194,14 +194,14 @@ class ToneMappingNode extends TempNode {
 
 		if ( toneMapping === NoToneMapping ) return colorNode;
 
-		const toneMappingParams = { exposure: this.exposureNode, color: colorNode };
+		const toneMappingParams = { exposure: this.exposureNode, color: colorNode.rgb };
 		const toneMappingNode = toneMappingLib[ toneMapping ];
 
 		let outputNode = null;
 
 		if ( toneMappingNode ) {
 
-			outputNode = toneMappingNode( toneMappingParams );
+			outputNode = vec4( toneMappingNode( toneMappingParams ), colorNode.a );
 
 		} else {
 


### PR DESCRIPTION
For WebGLRenderer, the input to the tone mapping function is `vec3 color`.

However, for WebGPURenderer, the input is `vec4 color`. (And, since it is implemented as a post processing step, the RGB components have premultiplied alpha -- but that is not an issue here.)

The tone mapping operation and color space transform should be applied to the RGB channels only. The alpha channel should remain unchanged.

