### PR TITLE
Editor: Remove unused method moveObject

### DIFF
--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -196,30 +196,6 @@ Editor.prototype = {
 
 	},
 
-	moveObject: function ( object, parent, before ) {
-
-		if ( parent === undefined ) {
-
-			parent = this.scene;
-
-		}
-
-		parent.add( object );
-
-		// sort children array
-
-		if ( before !== undefined ) {
-
-			var index = parent.children.indexOf( before );
-			parent.children.splice( index, 0, object );
-			parent.children.pop();
-
-		}
-
-		this.signals.sceneGraphChanged.dispatch();
-
-	},
-
 	nameObject: function ( object, name ) {
 
 		object.name = name;


### PR DESCRIPTION
Hello 🙂

I'm currently using the editor as a base source code for a personal project. I just noted that the `Editor.moveObject()` method is not used. 

The logic is already implemented in both `UIOutliner` and `MoveObjectCommand`. But I personally find the name `moveObject` (even for the command name) a bit misleading as I expect the Object3D to physically move in the scene as a first though, maybe renaming the `MoveObjectCommand` might be a good thing to do if you agree.