### PR TITLE
DragControls: Refactor API.

### DIFF
--- a/docs/examples/en/controls/DragControls.html
+++ b/docs/examples/en/controls/DragControls.html
@@ -7,7 +7,7 @@
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>
 	<body>
-		[page:EventDispatcher] &rarr;
+		[page:Controls] &rarr;
 
 		<h1>[name]</h1>
 
@@ -95,14 +95,26 @@
 
 		<h2>Properties</h2>
 
-		<h3>[property:Boolean enabled]</h3>
+		<p>See the base [page:Controls] class for common properties.</p>
+
+		<h3>[property:Array objects]</h3>
 		<p>
-			Whether or not the controls are enabled.
+			An array of draggable 3D objects.
+		</p>
+
+		<h3>[property:Raycaster raycaster]</h3>
+		<p>
+			The internal raycaster used for detecting 3D objects.
 		</p>
 
 		<h3>[property:Boolean recursive]</h3>
 		<p>
 			Whether children of draggable objects can be dragged independently from their parent. Default is `true`.
+		</p>
+
+		<h3>[property:Float rotateSpeed]</h3>
+		<p>
+			The speed at which the object will rotate when dragged in `rotate` mode. The higher the number the faster the rotation. Default is `1`.
 		</p>
 
 		<h3>[property:Boolean transformGroup]</h3>
@@ -111,26 +123,16 @@
 			If set to `true`, [name] does not transform individual objects but the entire group. Default is `false`.
 		</p>
 
-		<h3>[property:String mode]</h3>
-		<p>
-			The current transformation mode. Possible values are `translate`, and `rotate`. Default is `translate`.
-		</p>
-
-		<h3>[property:Float rotateSpeed]</h3>
-		<p>
-			The speed at which the object will rotate when dragged in `rotate` mode. The higher the number the faster the rotation. Default is `1`.
-		</p>
-
 		<h2>Methods</h2>
 
-		<p>See the base [page:EventDispatcher] class for common methods.</p>
+		<p>See the base [page:Controls] class for common methods.</p>
 
-		<h3>[method:undefined activate] ()</h3>
+		<h3>[method:undefined connect] ()</h3>
 		<p>
 			Adds the event listeners of the controls.
 		</p>
 
-		<h3>[method:undefined deactivate] ()</h3>
+		<h3>[method:undefined disconnect] ()</h3>
 		<p>
 			Removes the event listeners of the controls.
 		</p>
@@ -138,21 +140,6 @@
 		<h3>[method:undefined dispose] ()</h3>
 		<p>
 			Should be called if the controls is no longer required.
-		</p>
-
-		<h3>[method:Array getObjects] ()</h3>
-		<p>
-			Returns the array of draggable objects.
-		</p>
-
-		<h3>[method:Raycaster getRaycaster] ()</h3>
-		<p>
-			Returns the internal [page:Raycaster] instance that is used for intersection tests.
-		</p>
-
-		<h3>[method:undefined setObjects] ( [param:Array objects] )</h3>
-		<p>
-			Sets an array of draggable objects by overwriting the existing one.
 		</p>
 
 		<h2>Source</h2>

--- a/examples/jsm/controls/Controls.js
+++ b/examples/jsm/controls/Controls.js
@@ -1,0 +1,32 @@
+import { EventDispatcher } from 'three';
+
+class Controls extends EventDispatcher {
+
+	constructor( object, domElement ) {
+
+		super();
+
+		this.object = object;
+		this.domElement = domElement;
+
+		this.enabled = true;
+
+		this.state = - 1;
+
+		this.keys = {};
+		this.mouseButtons = { LEFT: null, MIDDLE: null, RIGHT: null };
+		this.touches = { ONE: null, TWO: null };
+
+	}
+
+	connect() {}
+
+	disconnect() {}
+
+	dispose() {}
+
+	update() {}
+
+}
+
+export { Controls };

--- a/examples/jsm/controls/DragControls.js
+++ b/examples/jsm/controls/DragControls.js
@@ -1,14 +1,15 @@
 import {
-	EventDispatcher,
 	Matrix4,
 	Plane,
 	Raycaster,
 	Vector2,
-	Vector3
+	Vector3,
+	MOUSE,
+	TOUCH
 } from 'three';
+import { Controls } from './Controls.js';
 
 const _plane = new Plane();
-const _raycaster = new Raycaster();
 
 const _pointer = new Vector2();
 const _offset = new Vector3();
@@ -21,261 +22,371 @@ const _inverseMatrix = new Matrix4();
 const _up = new Vector3();
 const _right = new Vector3();
 
-class DragControls extends EventDispatcher {
+let _selected = null, _hovered = null;
+const _intersections = [];
 
-	constructor( _objects, _camera, _domElement ) {
+const STATE = {
+	NONE: - 1,
+	PAN: 0,
+	ROTATE: 1
+};
 
-		super();
+class DragControls extends Controls {
 
-		_domElement.style.touchAction = 'none'; // disable touch scroll
+	constructor( objects, camera, domElement ) {
 
-		let _selected = null, _hovered = null;
+		super( camera, domElement );
 
-		const _intersections = [];
+		this.objects = objects;
 
-		this.mode = 'translate';
-
+		this.recursive = true;
+		this.transformGroup = false;
 		this.rotateSpeed = 1;
+
+		this.raycaster = new Raycaster();
+
+		// interaction
+
+		this.mouseButtons = { LEFT: MOUSE.PAN, MIDDLE: MOUSE.PAN, RIGHT: MOUSE.ROTATE };
+		this.touches = { ONE: TOUCH.PAN };
+
+		// event listeners
+
+		this._onPointerMove = onPointerMove.bind( this );
+		this._onPointerDown = onPointerDown.bind( this );
+		this._onPointerCancel = onPointerCancel.bind( this );
+		this._onContextMenu = onContextMenu.bind( this );
 
 		//
 
-		const scope = this;
+		domElement.style.touchAction = 'none'; // disable touch scroll
 
-		function activate() {
+		this.connect();
 
-			_domElement.addEventListener( 'pointermove', onPointerMove );
-			_domElement.addEventListener( 'pointerdown', onPointerDown );
-			_domElement.addEventListener( 'pointerup', onPointerCancel );
-			_domElement.addEventListener( 'pointerleave', onPointerCancel );
+	}
 
-		}
+	connect() {
 
-		function deactivate() {
+		this.domElement.addEventListener( 'pointermove', this._onPointerMove );
+		this.domElement.addEventListener( 'pointerdown', this._onPointerDown );
+		this.domElement.addEventListener( 'pointerup', this._onPointerCancel );
+		this.domElement.addEventListener( 'pointerleave', this._onPointerCancel );
+		this.domElement.addEventListener( 'contextmenu', this._onContextMenu );
 
-			_domElement.removeEventListener( 'pointermove', onPointerMove );
-			_domElement.removeEventListener( 'pointerdown', onPointerDown );
-			_domElement.removeEventListener( 'pointerup', onPointerCancel );
-			_domElement.removeEventListener( 'pointerleave', onPointerCancel );
+	}
 
-			_domElement.style.cursor = '';
+	disconnect() {
 
-		}
+		this.domElement.removeEventListener( 'pointermove', this._onPointerMove );
+		this.domElement.removeEventListener( 'pointerdown', this._onPointerDown );
+		this.domElement.removeEventListener( 'pointerup', this._onPointerCancel );
+		this.domElement.removeEventListener( 'pointerleave', this._onPointerCancel );
+		this.domElement.removeEventListener( 'contextmenu', this._onContextMenu );
 
-		function dispose() {
+		this.domElement.style.cursor = '';
 
-			deactivate();
+	}
 
-		}
+	dispose() {
 
-		function getObjects() {
+		this.disconnect();
 
-			return _objects;
+	}
 
-		}
+	updatePointer( event ) {
 
-		function setObjects( objects ) {
+		const rect = this.domElement.getBoundingClientRect();
 
-			_objects = objects;
+		_pointer.x = ( event.clientX - rect.left ) / rect.width * 2 - 1;
+		_pointer.y = - ( event.clientY - rect.top ) / rect.height * 2 + 1;
 
-		}
+	}
 
-		function getRaycaster() {
+	updateState( event ) {
 
-			return _raycaster;
+		// determine action
 
-		}
+		let action;
 
-		function onPointerMove( event ) {
+		if ( event.pointerType === 'touch' ) {
 
-			if ( scope.enabled === false ) return;
+			action = this.touches.ONE;
 
-			updatePointer( event );
+		} else {
 
-			_raycaster.setFromCamera( _pointer, _camera );
+			switch ( event.button ) {
 
-			if ( _selected ) {
+				case 0:
 
-				if ( scope.mode === 'translate' ) {
+					action = this.mouseButtons.LEFT;
+					break;
 
-					if ( _raycaster.ray.intersectPlane( _plane, _intersection ) ) {
+				case 1:
 
-						_selected.position.copy( _intersection.sub( _offset ).applyMatrix4( _inverseMatrix ) );
+					action = this.mouseButtons.MIDDLE;
+					break;
 
-					}
+				case 2:
 
-				} else if ( scope.mode === 'rotate' ) {
+					action = this.mouseButtons.RIGHT;
+					break;
 
-					_diff.subVectors( _pointer, _previousPointer ).multiplyScalar( scope.rotateSpeed );
-					_selected.rotateOnWorldAxis( _up, _diff.x );
-					_selected.rotateOnWorldAxis( _right.normalize(), - _diff.y );
+				default:
 
-				}
-
-				scope.dispatchEvent( { type: 'drag', object: _selected } );
-
-				_previousPointer.copy( _pointer );
-
-			} else {
-
-				// hover support
-
-				if ( event.pointerType === 'mouse' || event.pointerType === 'pen' ) {
-
-					_intersections.length = 0;
-
-					_raycaster.setFromCamera( _pointer, _camera );
-					_raycaster.intersectObjects( _objects, scope.recursive, _intersections );
-
-					if ( _intersections.length > 0 ) {
-
-						const object = _intersections[ 0 ].object;
-
-						_plane.setFromNormalAndCoplanarPoint( _camera.getWorldDirection( _plane.normal ), _worldPosition.setFromMatrixPosition( object.matrixWorld ) );
-
-						if ( _hovered !== object && _hovered !== null ) {
-
-							scope.dispatchEvent( { type: 'hoveroff', object: _hovered } );
-
-							_domElement.style.cursor = 'auto';
-							_hovered = null;
-
-						}
-
-						if ( _hovered !== object ) {
-
-							scope.dispatchEvent( { type: 'hoveron', object: object } );
-
-							_domElement.style.cursor = 'pointer';
-							_hovered = object;
-
-						}
-
-					} else {
-
-						if ( _hovered !== null ) {
-
-							scope.dispatchEvent( { type: 'hoveroff', object: _hovered } );
-
-							_domElement.style.cursor = 'auto';
-							_hovered = null;
-
-						}
-
-					}
-
-				}
+					action = null;
 
 			}
 
-			_previousPointer.copy( _pointer );
+		}
+
+		// determine state
+
+		switch ( action ) {
+
+			case MOUSE.PAN:
+			case TOUCH.PAN:
+
+				this.state = STATE.PAN;
+
+				break;
+
+			case MOUSE.ROTATE:
+			case TOUCH.ROTATE:
+
+				this.state = STATE.ROTATE;
+
+				break;
+
+			default:
+
+				this.state = STATE.NONE;
 
 		}
 
-		function onPointerDown( event ) {
+	}
 
-			if ( scope.enabled === false ) return;
+	getRaycaster() {
 
-			updatePointer( event );
+		console.warn( 'THREE.DragControls: getRaycaster() has been deprecated. Use controls.raycaster instead.' ); // @deprecated r169
+
+		return this.raycaster;
+
+	}
+
+	setObjects( objects ) {
+
+		console.warn( 'THREE.DragControls: setObjects() has been deprecated. Use controls.objects instead.' ); // @deprecated r169
+
+		this.objects = objects;
+
+	}
+
+	getObjects() {
+
+		console.warn( 'THREE.DragControls: getObjects() has been deprecated. Use controls.objects instead.' ); // @deprecated r169
+
+		return this.objects;
+
+	}
+
+	activate() {
+
+		console.warn( 'THREE.DragControls: activate() has been renamed to connect().' ); // @deprecated r169
+		this.connect();
+
+	}
+
+	deactivate() {
+
+		console.warn( 'THREE.DragControls: deactivate() has been renamed to disconnect().' ); // @deprecated r169
+		this.disconnect();
+
+	}
+
+}
+
+function onPointerMove( event ) {
+
+	const camera = this.object;
+	const domElement = this.domElement;
+	const raycaster = this.raycaster;
+
+	if ( this.enabled === false ) return;
+
+	this.updatePointer( event );
+
+	raycaster.setFromCamera( _pointer, camera );
+
+	if ( _selected ) {
+
+		if ( this.state === STATE.PAN ) {
+
+			if ( raycaster.ray.intersectPlane( _plane, _intersection ) ) {
+
+				_selected.position.copy( _intersection.sub( _offset ).applyMatrix4( _inverseMatrix ) );
+
+			}
+
+		} else if ( this.state === STATE.ROTATE ) {
+
+			_diff.subVectors( _pointer, _previousPointer ).multiplyScalar( this.rotateSpeed );
+			_selected.rotateOnWorldAxis( _up, _diff.x );
+			_selected.rotateOnWorldAxis( _right.normalize(), - _diff.y );
+
+		}
+
+		this.dispatchEvent( { type: 'drag', object: _selected } );
+
+		_previousPointer.copy( _pointer );
+
+	} else {
+
+		// hover support
+
+		if ( event.pointerType === 'mouse' || event.pointerType === 'pen' ) {
 
 			_intersections.length = 0;
 
-			_raycaster.setFromCamera( _pointer, _camera );
-			_raycaster.intersectObjects( _objects, scope.recursive, _intersections );
+			raycaster.setFromCamera( _pointer, camera );
+			raycaster.intersectObjects( this.objects, this.recursive, _intersections );
 
 			if ( _intersections.length > 0 ) {
 
-				if ( scope.transformGroup === true ) {
+				const object = _intersections[ 0 ].object;
 
-					// look for the outermost group in the object's upper hierarchy
+				_plane.setFromNormalAndCoplanarPoint( camera.getWorldDirection( _plane.normal ), _worldPosition.setFromMatrixPosition( object.matrixWorld ) );
 
-					_selected = findGroup( _intersections[ 0 ].object );
+				if ( _hovered !== object && _hovered !== null ) {
 
-				} else {
+					this.dispatchEvent( { type: 'hoveroff', object: _hovered } );
 
-					_selected = _intersections[ 0 ].object;
-
-				}
-
-				_plane.setFromNormalAndCoplanarPoint( _camera.getWorldDirection( _plane.normal ), _worldPosition.setFromMatrixPosition( _selected.matrixWorld ) );
-
-				if ( _raycaster.ray.intersectPlane( _plane, _intersection ) ) {
-
-					if ( scope.mode === 'translate' ) {
-
-						_inverseMatrix.copy( _selected.parent.matrixWorld ).invert();
-						_offset.copy( _intersection ).sub( _worldPosition.setFromMatrixPosition( _selected.matrixWorld ) );
-
-					} else if ( scope.mode === 'rotate' ) {
-
-						// the controls only support Y+ up
-						_up.set( 0, 1, 0 ).applyQuaternion( _camera.quaternion ).normalize();
-						_right.set( 1, 0, 0 ).applyQuaternion( _camera.quaternion ).normalize();
-
-					}
+					domElement.style.cursor = 'auto';
+					_hovered = null;
 
 				}
 
-				_domElement.style.cursor = 'move';
+				if ( _hovered !== object ) {
 
-				scope.dispatchEvent( { type: 'dragstart', object: _selected } );
+					this.dispatchEvent( { type: 'hoveron', object: object } );
+
+					domElement.style.cursor = 'pointer';
+					_hovered = object;
+
+				}
+
+			} else {
+
+				if ( _hovered !== null ) {
+
+					this.dispatchEvent( { type: 'hoveroff', object: _hovered } );
+
+					domElement.style.cursor = 'auto';
+					_hovered = null;
+
+				}
 
 			}
 
-			_previousPointer.copy( _pointer );
-
 		}
-
-		function onPointerCancel() {
-
-			if ( scope.enabled === false ) return;
-
-			if ( _selected ) {
-
-				scope.dispatchEvent( { type: 'dragend', object: _selected } );
-
-				_selected = null;
-
-			}
-
-			_domElement.style.cursor = _hovered ? 'pointer' : 'auto';
-
-		}
-
-		function updatePointer( event ) {
-
-			const rect = _domElement.getBoundingClientRect();
-
-			_pointer.x = ( event.clientX - rect.left ) / rect.width * 2 - 1;
-			_pointer.y = - ( event.clientY - rect.top ) / rect.height * 2 + 1;
-
-		}
-
-		function findGroup( obj, group = null ) {
-
-			if ( obj.isGroup ) group = obj;
-
-			if ( obj.parent === null ) return group;
-
-			return findGroup( obj.parent, group );
-
-		}
-
-		activate();
-
-		// API
-
-		this.enabled = true;
-		this.recursive = true;
-		this.transformGroup = false;
-
-		this.activate = activate;
-		this.deactivate = deactivate;
-		this.dispose = dispose;
-		this.getObjects = getObjects;
-		this.getRaycaster = getRaycaster;
-		this.setObjects = setObjects;
 
 	}
+
+	_previousPointer.copy( _pointer );
+
+}
+
+function onPointerDown( event ) {
+
+	const camera = this.object;
+	const domElement = this.domElement;
+	const raycaster = this.raycaster;
+
+	if ( this.enabled === false ) return;
+
+	this.updatePointer( event );
+	this.updateState( event );
+
+	_intersections.length = 0;
+
+	raycaster.setFromCamera( _pointer, camera );
+	raycaster.intersectObjects( this.objects, this.recursive, _intersections );
+
+	if ( _intersections.length > 0 ) {
+
+		if ( this.transformGroup === true ) {
+
+			// look for the outermost group in the object's upper hierarchy
+
+			_selected = findGroup( _intersections[ 0 ].object );
+
+		} else {
+
+			_selected = _intersections[ 0 ].object;
+
+		}
+
+		_plane.setFromNormalAndCoplanarPoint( camera.getWorldDirection( _plane.normal ), _worldPosition.setFromMatrixPosition( _selected.matrixWorld ) );
+
+		if ( raycaster.ray.intersectPlane( _plane, _intersection ) ) {
+
+			if ( this.state === STATE.PAN ) {
+
+				_inverseMatrix.copy( _selected.parent.matrixWorld ).invert();
+				_offset.copy( _intersection ).sub( _worldPosition.setFromMatrixPosition( _selected.matrixWorld ) );
+
+			} else if ( this.state === STATE.ROTATE ) {
+
+				// the controls only support Y+ up
+				_up.set( 0, 1, 0 ).applyQuaternion( camera.quaternion ).normalize();
+				_right.set( 1, 0, 0 ).applyQuaternion( camera.quaternion ).normalize();
+
+			}
+
+		}
+
+		domElement.style.cursor = 'move';
+
+		this.dispatchEvent( { type: 'dragstart', object: _selected } );
+
+	}
+
+	_previousPointer.copy( _pointer );
+
+}
+
+function onPointerCancel() {
+
+	if ( this.enabled === false ) return;
+
+	if ( _selected ) {
+
+		this.dispatchEvent( { type: 'dragend', object: _selected } );
+
+		_selected = null;
+
+	}
+
+	this.domElement.style.cursor = _hovered ? 'pointer' : 'auto';
+
+	this.state = STATE.NONE;
+
+}
+
+function onContextMenu( event ) {
+
+	if ( this.enabled === false ) return;
+
+	event.preventDefault();
+
+}
+
+function findGroup( obj, group = null ) {
+
+	if ( obj.isGroup ) group = obj;
+
+	if ( obj.parent === null ) return group;
+
+	return findGroup( obj.parent, group );
 
 }
 

--- a/examples/jsm/controls/DragControls.js
+++ b/examples/jsm/controls/DragControls.js
@@ -98,7 +98,7 @@ class DragControls extends Controls {
 
 	}
 
-	updatePointer( event ) {
+	_updatePointer( event ) {
 
 		const rect = this.domElement.getBoundingClientRect();
 
@@ -107,7 +107,7 @@ class DragControls extends Controls {
 
 	}
 
-	updateState( event ) {
+	_updateState( event ) {
 
 		// determine action
 
@@ -230,7 +230,7 @@ function onPointerMove( event ) {
 
 	if ( this.enabled === false ) return;
 
-	this.updatePointer( event );
+	this._updatePointer( event );
 
 	raycaster.setFromCamera( _pointer, camera );
 
@@ -320,8 +320,8 @@ function onPointerDown( event ) {
 
 	if ( this.enabled === false ) return;
 
-	this.updatePointer( event );
-	this.updateState( event );
+	this._updatePointer( event );
+	this._updateState( event );
 
 	_intersections.length = 0;
 

--- a/examples/jsm/controls/DragControls.js
+++ b/examples/jsm/controls/DragControls.js
@@ -33,7 +33,7 @@ const STATE = {
 
 class DragControls extends Controls {
 
-	constructor( objects, camera, domElement ) {
+	constructor( objects, camera, domElement = null ) {
 
 		super( camera, domElement );
 
@@ -59,7 +59,11 @@ class DragControls extends Controls {
 
 		//
 
-		this.connect();
+		if ( domElement !== null ) {
+
+			this.connect();
+
+		}
 
 	}
 

--- a/examples/jsm/controls/DragControls.js
+++ b/examples/jsm/controls/DragControls.js
@@ -208,6 +208,18 @@ class DragControls extends Controls {
 
 	}
 
+	set mode( value ) {
+
+		console.warn( 'THREE.DragControls: The .mode property has been removed. Define the type of transformation via the .mouseButtons or .touches properties.' ); // @deprecated r169
+
+	}
+
+	get mode() {
+
+		console.warn( 'THREE.DragControls: The .mode property has been removed. Define the type of transformation via the .mouseButtons or .touches properties.' ); // @deprecated r169
+
+	}
+
 }
 
 function onPointerMove( event ) {

--- a/examples/jsm/controls/DragControls.js
+++ b/examples/jsm/controls/DragControls.js
@@ -59,8 +59,6 @@ class DragControls extends Controls {
 
 		//
 
-		domElement.style.touchAction = 'none'; // disable touch scroll
-
 		this.connect();
 
 	}
@@ -73,6 +71,8 @@ class DragControls extends Controls {
 		this.domElement.addEventListener( 'pointerleave', this._onPointerCancel );
 		this.domElement.addEventListener( 'contextmenu', this._onContextMenu );
 
+		this.domElement.style.touchAction = 'none'; // disable touch scroll
+
 	}
 
 	disconnect() {
@@ -83,6 +83,7 @@ class DragControls extends Controls {
 		this.domElement.removeEventListener( 'pointerleave', this._onPointerCancel );
 		this.domElement.removeEventListener( 'contextmenu', this._onContextMenu );
 
+		this.domElement.style.touchAction = 'auto';
 		this.domElement.style.cursor = '';
 
 	}

--- a/examples/misc_controls_drag.html
+++ b/examples/misc_controls_drag.html
@@ -164,7 +164,7 @@
 
 				if ( enableSelection === true ) {
 
-					const draggableObjects = controls.getObjects();
+					const draggableObjects = controls.objects;
 					draggableObjects.length = 0;
 
 					mouse.x = ( event.clientX / window.innerWidth ) * 2 - 1;

--- a/examples/misc_controls_drag.html
+++ b/examples/misc_controls_drag.html
@@ -20,7 +20,7 @@
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> webgl - drag controls<br />
 			Use "Shift+Click" to add/remove objects to/from a group.<br />
-			Use "M" to toggle between rotate and translate mode.<br />
+			Use "M" to toggle between rotate and pan mode (touch only).<br />
 			Grouped objects can be transformed as a union.
 		</div>
 
@@ -143,10 +143,10 @@
 			function onKeyDown( event ) {
 
 				enableSelection = ( event.keyCode === 16 ) ? true : false;
-				
+			
 				if ( event.keyCode === 77 ) {
 
-					controls.mode = ( controls.mode === 'translate' ) ? 'rotate' : 'translate';
+					controls.touches.ONE = ( controls.touches.ONE === THREE.TOUCH.PAN ) ? THREE.TOUCH.ROTATE : THREE.TOUCH.PAN;
 			
 				}
 


### PR DESCRIPTION
Related issue: #29072, #20575

**Description**

This PR refactors the API of `DragControls`.

- `THREE.Controls` is introduced which defines a basic control interface. `DragControls` is now derived from this class.
- Side effects in the ctor are moved into a `connect()` method.
- `domElement` is now optional. If required, an instance of `DragControls` can now be created without a DOM element. When the element is set at a later point, a manual call of `connect()` configures the event listeners.
