### PR TITLE
src: Simplify nomenclature

### DIFF
--- a/examples/jsm/shaders/OutputShader.js
+++ b/examples/jsm/shaders/OutputShader.js
@@ -54,7 +54,7 @@ const OutputShader = {
 
 			#elif defined( CINEON_TONE_MAPPING )
 
-				gl_FragColor.rgb = OptimizedCineonToneMapping( gl_FragColor.rgb );
+				gl_FragColor.rgb = CineonToneMapping( gl_FragColor.rgb );
 
 			#elif defined( ACES_FILMIC_TONE_MAPPING )
 

--- a/src/nodes/display/ToneMappingNode.js
+++ b/src/nodes/display/ToneMappingNode.js
@@ -25,9 +25,9 @@ const ReinhardToneMappingNode = Fn( ( { color, exposure } ) => {
 } );
 
 // source: http://filmicworlds.com/blog/filmic-tonemapping-operators/
-const OptimizedCineonToneMappingNode = Fn( ( { color, exposure } ) => {
+const CineonToneMappingNode = Fn( ( { color, exposure } ) => {
 
-	// optimized filmic operator by Jim Hejl and Richard Burgess-Dawson
+	// filmic operator by Jim Hejl and Richard Burgess-Dawson
 	color = color.mul( exposure );
 	color = color.sub( 0.004 ).max( 0.0 );
 
@@ -159,7 +159,7 @@ const NeutralToneMappingNode = Fn( ( { color, exposure } ) => {
 const toneMappingLib = {
 	[ LinearToneMapping ]: LinearToneMappingNode,
 	[ ReinhardToneMapping ]: ReinhardToneMappingNode,
-	[ CineonToneMapping ]: OptimizedCineonToneMappingNode,
+	[ CineonToneMapping ]: CineonToneMappingNode,
 	[ ACESFilmicToneMapping ]: ACESFilmicToneMappingNode,
 	[ AgXToneMapping ]: AgXToneMappingNode,
 	[ NeutralToneMapping ]: NeutralToneMappingNode

--- a/src/renderers/shaders/ShaderChunk/tonemapping_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/tonemapping_pars_fragment.glsl.js
@@ -22,9 +22,9 @@ vec3 ReinhardToneMapping( vec3 color ) {
 }
 
 // source: http://filmicworlds.com/blog/filmic-tonemapping-operators/
-vec3 OptimizedCineonToneMapping( vec3 color ) {
+vec3 CineonToneMapping( vec3 color ) {
 
-	// optimized filmic operator by Jim Hejl and Richard Burgess-Dawson
+	// filmic operator by Jim Hejl and Richard Burgess-Dawson
 	color *= toneMappingExposure;
 	color = max( vec3( 0.0 ), color - 0.004 );
 	return pow( ( color * ( 6.2 * color + 0.5 ) ) / ( color * ( 6.2 * color + 1.7 ) + 0.06 ), vec3( 2.2 ) );

--- a/src/renderers/webgl/WebGLProgram.js
+++ b/src/renderers/webgl/WebGLProgram.js
@@ -114,7 +114,7 @@ function getToneMappingFunction( functionName, toneMapping ) {
 			break;
 
 		case CineonToneMapping:
-			toneMappingName = 'OptimizedCineon';
+			toneMappingName = 'Cineon';
 			break;
 
 		case ACESFilmicToneMapping:


### PR DESCRIPTION
`OptimizedCineonToneMapping` => `CineonToneMapping`

This change is internal to the library. Externally, it remains `THREE.CineonToneMapping`.

There is no need to have two names referring to the same thing.

This tone mapping function is from a 2010 SIGGRAPH course, and does not appear to be standardized.

