### PR TITLE
WebGPURenderer: Avoid using proxy in rendering cycle

### DIFF
--- a/src/nodes/accessors/ReferenceNode.js
+++ b/src/nodes/accessors/ReferenceNode.js
@@ -89,7 +89,7 @@ class ReferenceNode extends Node {
 
 		}
 
-		this.node = node;
+		this.node = node.getSelf();
 
 	}
 

--- a/src/nodes/accessors/TextureNode.js
+++ b/src/nodes/accessors/TextureNode.js
@@ -307,7 +307,7 @@ class TextureNode extends UniformNode {
 
 		const textureNode = this.clone();
 		textureNode.uvNode = nodeObject( uvNode );
-		textureNode.referenceNode = this;
+		textureNode.referenceNode = this.getSelf();
 
 		return nodeObject( textureNode );
 
@@ -317,7 +317,7 @@ class TextureNode extends UniformNode {
 
 		const textureNode = this.clone();
 		textureNode.biasNode = nodeObject( amountNode ).mul( maxMipLevel( textureNode ) );
-		textureNode.referenceNode = this;
+		textureNode.referenceNode = this.getSelf();
 
 		return nodeObject( textureNode );
 
@@ -327,7 +327,7 @@ class TextureNode extends UniformNode {
 
 		const textureNode = this.clone();
 		textureNode.levelNode = nodeObject( levelNode );
-		textureNode.referenceNode = this;
+		textureNode.referenceNode = this.getSelf();
 
 		return nodeObject( textureNode );
 
@@ -343,7 +343,7 @@ class TextureNode extends UniformNode {
 
 		const textureNode = this.clone();
 		textureNode.biasNode = nodeObject( biasNode );
-		textureNode.referenceNode = this;
+		textureNode.referenceNode = this.getSelf();
 
 		return nodeObject( textureNode );
 
@@ -353,7 +353,7 @@ class TextureNode extends UniformNode {
 
 		const textureNode = this.clone();
 		textureNode.compareNode = nodeObject( compareNode );
-		textureNode.referenceNode = this;
+		textureNode.referenceNode = this.getSelf();
 
 		return nodeObject( textureNode );
 
@@ -363,8 +363,7 @@ class TextureNode extends UniformNode {
 
 		const textureNode = this.clone();
 		textureNode.gradNode = [ nodeObject( gradNodeX ), nodeObject( gradNodeY ) ];
-
-		textureNode.referenceNode = this;
+		textureNode.referenceNode = this.getSelf();
 
 		return nodeObject( textureNode );
 
@@ -374,7 +373,7 @@ class TextureNode extends UniformNode {
 
 		const textureNode = this.clone();
 		textureNode.depthNode = nodeObject( depthNode );
-		textureNode.referenceNode = this;
+		textureNode.referenceNode = this.getSelf();
 
 		return nodeObject( textureNode );
 

--- a/src/nodes/utils/CubeMapNode.js
+++ b/src/nodes/utils/CubeMapNode.js
@@ -5,7 +5,7 @@ import { nodeProxy } from '../shadernode/ShaderNode.js';
 import { CubeTexture } from '../../textures/CubeTexture.js';
 import { cubeTexture } from '../accessors/CubeTextureNode.js';
 import CubeRenderTarget from '../../renderers/common/CubeRenderTarget.js';
-import { CubeReflectionMapping, CubeRefractionMapping, EquirectangularReflectionMapping, EquirectangularRefractionMapping } from '../../constants';
+import { CubeReflectionMapping, CubeRefractionMapping, EquirectangularReflectionMapping, EquirectangularRefractionMapping } from '../../constants.js';
 
 const _cache = new WeakMap();
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/29066#issuecomment-2270384667

**Description**

`Proxy` should be avoided in the rendering cycle as they harm performance.