### PR TITLE
Docs: Fixed parameters of Audio.getVolume

### DIFF
--- a/docs/api/ar/audio/Audio.html
+++ b/docs/api/ar/audio/Audio.html
@@ -136,7 +136,7 @@
 		ترجع القيمة الخاصة بـ[page:Audio.playbackRate playbackRate].
 		</p>
 
-		<h3>[method:Float getVolume]( value )</h3>
+		<h3>[method:Float getVolume]()</h3>
 		<p>
 		إعادة الحجم الحالي.
 		</p>

--- a/docs/api/en/audio/Audio.html
+++ b/docs/api/en/audio/Audio.html
@@ -159,7 +159,7 @@
 		<h3>[method:Float getPlaybackRate]()</h3>
 		<p>Return the value of [page:Audio.playbackRate playbackRate].</p>
 
-		<h3>[method:Float getVolume]( value )</h3>
+		<h3>[method:Float getVolume]()</h3>
 		<p>Return the current volume.</p>
 
 		<h3>[method:this play]( delay )</h3>

--- a/docs/api/fr/audio/Audio.html
+++ b/docs/api/fr/audio/Audio.html
@@ -147,7 +147,7 @@
 		Renvoie la valeur de [page:Audio.playbackRate playbackRate].
 		</p>
 
-		<h3>[method:Float getVolume]( value )</h3>
+		<h3>[method:Float getVolume]()</h3>
 		<p>
 		Renvoie le volume actuel.
 		</p>

--- a/docs/api/it/audio/Audio.html
+++ b/docs/api/it/audio/Audio.html
@@ -165,7 +165,7 @@
       Restituisce il valore di [page:Audio.playbackRate playbackRate].
 		</p>
 
-		<h3>[method:Float getVolume]( value )</h3>
+		<h3>[method:Float getVolume]()</h3>
 		<p>
       Restituisce il volume corrente.
 		</p>

--- a/docs/api/ko/audio/Audio.html
+++ b/docs/api/ko/audio/Audio.html
@@ -139,7 +139,7 @@
 		[page:Audio.playbackRate playbackRate]의 값을 리턴합니다.
 		</p>
 
-		<h3>[method:Float getVolume]( value )</h3>
+		<h3>[method:Float getVolume]()</h3>
 		<p>
 		현재 볼륨을 리턴합니다.
 		</p>

--- a/docs/api/pt-br/audio/Audio.html
+++ b/docs/api/pt-br/audio/Audio.html
@@ -147,7 +147,7 @@
 		Retorna o valor do [page:Audio.playbackRate playbackRate].
 		</p>
 
-		<h3>[method:Float getVolume]( value )</h3>
+		<h3>[method:Float getVolume]()</h3>
 		<p>
 		Retorna o volume atual.
 		</p>

--- a/docs/api/zh/audio/Audio.html
+++ b/docs/api/zh/audio/Audio.html
@@ -137,7 +137,7 @@
 		返回[page:Audio.playbackRate playbackRate]的值.
 		</p>
 
-		<h3>[method:Float getVolume]( value )</h3>
+		<h3>[method:Float getVolume]()</h3>
 		<p>
 		返回音量.
 		</p>


### PR DESCRIPTION
**Description**

While reading the docs, noticed that the `getVolume` method of the `Audio` class is reported to accept a `value` parameter, which it doesn't ([Audio.js#L384](https://github.com/mrdoob/three.js/blob/dev/src/audio/Audio.js#L384)). This PR removes it from the docs matching the method signature in the code.