### PR TITLE
ToneMappingNode: Remove the default value for `toneMapping`

### DIFF
--- a/src/nodes/display/ToneMappingNode.js
+++ b/src/nodes/display/ToneMappingNode.js
@@ -167,7 +167,7 @@ const toneMappingLib = {
 
 class ToneMappingNode extends TempNode {
 
-	constructor( toneMapping = NoToneMapping, exposureNode = toneMappingExposure, colorNode = null ) {
+	constructor( toneMapping, exposureNode = toneMappingExposure, colorNode = null ) {
 
 		super( 'vec3' );
 


### PR DESCRIPTION
As suggested in https://github.com/mrdoob/three.js/pull/29091#issuecomment-2276937795.

Fixes https://github.com/mrdoob/three.js/pull/29091#issuecomment-2276652915.