### PR TITLE
GLSLNodeBuilder: Fix `GL_ANGLE_multi_draw` extension request.

### DIFF
--- a/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
+++ b/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
@@ -665,7 +665,7 @@ ${ flowData.code }
 
 			if ( isBatchedMesh && ext.has( 'WEBGL_multi_draw' ) ) {
 
-				this.enableExtension( 'GL_ANGLE_multi_draw', 'require' );
+				this.enableExtension( 'GL_ANGLE_multi_draw', 'require', shaderStage );
 
 			}
 


### PR DESCRIPTION
Related issue: #28952

**Description**

Properly passes the proper Batched Mesh extension to the vertex stage. Fixes webgpu_mesh_batch sample in WebGL mode.
