### PR TITLE
WebGPURenderer: Premultiply alpha for clear color.

### DIFF
--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -441,6 +441,12 @@ class WebGLBackend extends Backend {
 
 			const clearColor = descriptor.clearColorValue || this.getClearColor();
 
+			// premultiply alpha
+
+			clearColor.r *= clearColor.a;
+			clearColor.g *= clearColor.a;
+			clearColor.b *= clearColor.a;
+
 			if ( depth ) this.state.setDepthMask( true );
 
 			if ( descriptor.textures === null ) {

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -604,11 +604,19 @@ class WebGPUBackend extends Backend {
 
 			const clearColor = this.getClearColor();
 
-			// premultiply alpha
+			if ( this.renderer.alpha === true ) {
 
-			const a = clearColor.a;
+				// premultiply alpha
 
-			clearValue = { r: clearColor.r * a, g: clearColor.g * a, b: clearColor.b * a, a: a };
+				const a = clearColor.a;
+
+				clearValue = { r: clearColor.r * a, g: clearColor.g * a, b: clearColor.b * a, a: a };
+
+			} else {
+
+				clearValue = { r: clearColor.r, g: clearColor.g, b: clearColor.b, a: clearColor.a };
+
+			}
 
 		}
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -604,7 +604,11 @@ class WebGPUBackend extends Backend {
 
 			const clearColor = this.getClearColor();
 
-			clearValue = { r: clearColor.r, g: clearColor.g, b: clearColor.b, a: clearColor.a };
+			// premultiply alpha
+
+			const a = clearColor.a;
+
+			clearValue = { r: clearColor.r * a, g: clearColor.g * a, b: clearColor.b * a, a: a };
 
 		}
 


### PR DESCRIPTION
Related issue: -

**Description**

Semi transparent clear values do not work as expected with `WebGPURenderer`.

`WebGLRenderer` (correct): https://jsfiddle.net/uq8wbo26/1/
`WebGPURenderer` (incorrect): https://jsfiddle.net/v70u128x/

That's because `WebGPURenderer` does not premultiply the clear alpha with the clear color. The PR fixes that for both backends.