### PR TITLE
Object3D: minimize rotation-quaternion conversions

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -83,8 +83,8 @@ class Object3D extends EventDispatcher {
 		const quaternion = new Quaternion();
 		const scale = new Vector3( 1, 1, 1 );
 
-		let rotationNeedsUpdate = false;
-		let quaternionNeedsUpdate = false;
+		let rotationNeedsUpdate = true;
+		let quaternionNeedsUpdate = true;
 
 		function onRotationWrite() {
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -28,6 +28,36 @@ const _removedEvent = { type: 'removed' };
 const _childaddedEvent = { type: 'childadded', child: null };
 const _childremovedEvent = { type: 'childremoved', child: null };
 
+function listenToProperties( object, properties, onReadCallback, onWriteCallback ) {
+
+	for ( let i = 0; i < properties.length; i ++ ) {
+
+		const property = properties[ i ];
+		let _value = object[ property ];
+
+		Object.defineProperty( object, property, {
+
+			get() {
+
+				onReadCallback();
+
+				return _value;
+
+			},
+			set( value ) {
+
+				_value = value;
+
+				onWriteCallback();
+
+			}
+
+		} );
+
+	}
+
+}
+
 class Object3D extends EventDispatcher {
 
 	constructor() {
@@ -53,20 +83,47 @@ class Object3D extends EventDispatcher {
 		const quaternion = new Quaternion();
 		const scale = new Vector3( 1, 1, 1 );
 
-		function onRotationChange() {
+		let rotationNeedsUpdate = false;
+		let quaternionNeedsUpdate = false;
 
-			quaternion.setFromEuler( rotation, false );
+		function onRotationWrite() {
 
-		}
-
-		function onQuaternionChange() {
-
-			rotation.setFromQuaternion( quaternion, undefined, false );
+			rotationNeedsUpdate = true;
 
 		}
 
-		rotation._onChange( onRotationChange );
-		quaternion._onChange( onQuaternionChange );
+		function onRotationRead() {
+
+			if ( quaternionNeedsUpdate === true ) {
+
+				quaternionNeedsUpdate = false;
+				rotation.setFromQuaternion( quaternion, undefined );
+				rotationNeedsUpdate = false;
+
+			}
+
+		}
+
+		function onQuaternionWrite() {
+
+			quaternionNeedsUpdate = true;
+
+		}
+
+		function onQuaternionRead() {
+
+			if ( rotationNeedsUpdate === true ) {
+
+				rotationNeedsUpdate = false;
+				quaternion.setFromEuler( rotation );
+				quaternionNeedsUpdate = false;
+
+			}
+
+		}
+
+		listenToProperties( rotation, [ 'x', 'y', 'z', 'order' ], onRotationRead, onRotationWrite );
+		listenToProperties( quaternion, [ 'x', 'y', 'z', 'w' ], onQuaternionRead, onQuaternionWrite );
 
 		Object.defineProperties( this, {
 			position: {

--- a/src/math/Euler.js
+++ b/src/math/Euler.js
@@ -11,73 +11,67 @@ class Euler {
 
 		this.isEuler = true;
 
-		this._x = x;
-		this._y = y;
-		this._z = z;
-		this._order = order;
+		this.x = x;
+		this.y = y;
+		this.z = z;
+		this.order = order;
 
 	}
 
-	get x() {
+	get _x() {
 
-		return this._x;
-
-	}
-
-	set x( value ) {
-
-		this._x = value;
-		this._onChangeCallback();
+		return this.x;
 
 	}
 
-	get y() {
+	set _x( value ) {
 
-		return this._y;
-
-	}
-
-	set y( value ) {
-
-		this._y = value;
-		this._onChangeCallback();
+		this.x = value;
 
 	}
 
-	get z() {
+	get _y() {
 
-		return this._z;
-
-	}
-
-	set z( value ) {
-
-		this._z = value;
-		this._onChangeCallback();
+		return this.y;
 
 	}
 
-	get order() {
+	set _y( value ) {
 
-		return this._order;
-
-	}
-
-	set order( value ) {
-
-		this._order = value;
-		this._onChangeCallback();
+		this.y = value;
 
 	}
 
-	set( x, y, z, order = this._order ) {
+	get _z() {
 
-		this._x = x;
-		this._y = y;
-		this._z = z;
-		this._order = order;
+		return this.z;
 
-		this._onChangeCallback();
+	}
+
+	set _z( value ) {
+
+		this.z = value;
+
+	}
+
+	get _order() {
+
+		return this.order;
+
+	}
+
+	set _order( value ) {
+
+		this.order = value;
+
+	}
+
+	set( x, y, z, order = this.order ) {
+
+		this.x = x;
+		this.y = y;
+		this.z = z;
+		this.order = order;
 
 		return this;
 
@@ -85,24 +79,22 @@ class Euler {
 
 	clone() {
 
-		return new this.constructor( this._x, this._y, this._z, this._order );
+		return new this.constructor( this.x, this.y, this.z, this.order );
 
 	}
 
 	copy( euler ) {
 
-		this._x = euler._x;
-		this._y = euler._y;
-		this._z = euler._z;
-		this._order = euler._order;
-
-		this._onChangeCallback();
+		this.x = euler.x;
+		this.y = euler.y;
+		this.z = euler.z;
+		this.order = euler.order;
 
 		return this;
 
 	}
 
-	setFromRotationMatrix( m, order = this._order, update = true ) {
+	setFromRotationMatrix( m, order = this.order ) {
 
 		// assumes the upper 3x3 of m is a pure rotation matrix (i.e, unscaled)
 
@@ -115,17 +107,17 @@ class Euler {
 
 			case 'XYZ':
 
-				this._y = Math.asin( clamp( m13, - 1, 1 ) );
+				this.y = Math.asin( clamp( m13, - 1, 1 ) );
 
 				if ( Math.abs( m13 ) < 0.9999999 ) {
 
-					this._x = Math.atan2( - m23, m33 );
-					this._z = Math.atan2( - m12, m11 );
+					this.x = Math.atan2( - m23, m33 );
+					this.z = Math.atan2( - m12, m11 );
 
 				} else {
 
-					this._x = Math.atan2( m32, m22 );
-					this._z = 0;
+					this.x = Math.atan2( m32, m22 );
+					this.z = 0;
 
 				}
 
@@ -133,17 +125,17 @@ class Euler {
 
 			case 'YXZ':
 
-				this._x = Math.asin( - clamp( m23, - 1, 1 ) );
+				this.x = Math.asin( - clamp( m23, - 1, 1 ) );
 
 				if ( Math.abs( m23 ) < 0.9999999 ) {
 
-					this._y = Math.atan2( m13, m33 );
-					this._z = Math.atan2( m21, m22 );
+					this.y = Math.atan2( m13, m33 );
+					this.z = Math.atan2( m21, m22 );
 
 				} else {
 
-					this._y = Math.atan2( - m31, m11 );
-					this._z = 0;
+					this.y = Math.atan2( - m31, m11 );
+					this.z = 0;
 
 				}
 
@@ -151,17 +143,17 @@ class Euler {
 
 			case 'ZXY':
 
-				this._x = Math.asin( clamp( m32, - 1, 1 ) );
+				this.x = Math.asin( clamp( m32, - 1, 1 ) );
 
 				if ( Math.abs( m32 ) < 0.9999999 ) {
 
-					this._y = Math.atan2( - m31, m33 );
-					this._z = Math.atan2( - m12, m22 );
+					this.y = Math.atan2( - m31, m33 );
+					this.z = Math.atan2( - m12, m22 );
 
 				} else {
 
-					this._y = 0;
-					this._z = Math.atan2( m21, m11 );
+					this.y = 0;
+					this.z = Math.atan2( m21, m11 );
 
 				}
 
@@ -169,17 +161,17 @@ class Euler {
 
 			case 'ZYX':
 
-				this._y = Math.asin( - clamp( m31, - 1, 1 ) );
+				this.y = Math.asin( - clamp( m31, - 1, 1 ) );
 
 				if ( Math.abs( m31 ) < 0.9999999 ) {
 
-					this._x = Math.atan2( m32, m33 );
-					this._z = Math.atan2( m21, m11 );
+					this.x = Math.atan2( m32, m33 );
+					this.z = Math.atan2( m21, m11 );
 
 				} else {
 
-					this._x = 0;
-					this._z = Math.atan2( - m12, m22 );
+					this.x = 0;
+					this.z = Math.atan2( - m12, m22 );
 
 				}
 
@@ -187,17 +179,17 @@ class Euler {
 
 			case 'YZX':
 
-				this._z = Math.asin( clamp( m21, - 1, 1 ) );
+				this.z = Math.asin( clamp( m21, - 1, 1 ) );
 
 				if ( Math.abs( m21 ) < 0.9999999 ) {
 
-					this._x = Math.atan2( - m23, m22 );
-					this._y = Math.atan2( - m31, m11 );
+					this.x = Math.atan2( - m23, m22 );
+					this.y = Math.atan2( - m31, m11 );
 
 				} else {
 
-					this._x = 0;
-					this._y = Math.atan2( m13, m33 );
+					this.x = 0;
+					this.y = Math.atan2( m13, m33 );
 
 				}
 
@@ -205,17 +197,17 @@ class Euler {
 
 			case 'XZY':
 
-				this._z = Math.asin( - clamp( m12, - 1, 1 ) );
+				this.z = Math.asin( - clamp( m12, - 1, 1 ) );
 
 				if ( Math.abs( m12 ) < 0.9999999 ) {
 
-					this._x = Math.atan2( m32, m22 );
-					this._y = Math.atan2( m13, m11 );
+					this.x = Math.atan2( m32, m22 );
+					this.y = Math.atan2( m13, m11 );
 
 				} else {
 
-					this._x = Math.atan2( - m23, m33 );
-					this._y = 0;
+					this.x = Math.atan2( - m23, m33 );
+					this.y = 0;
 
 				}
 
@@ -227,23 +219,21 @@ class Euler {
 
 		}
 
-		this._order = order;
-
-		if ( update === true ) this._onChangeCallback();
+		this.order = order;
 
 		return this;
 
 	}
 
-	setFromQuaternion( q, order, update ) {
+	setFromQuaternion( q, order ) {
 
 		_matrix.makeRotationFromQuaternion( q );
 
-		return this.setFromRotationMatrix( _matrix, order, update );
+		return this.setFromRotationMatrix( _matrix, order );
 
 	}
 
-	setFromVector3( v, order = this._order ) {
+	setFromVector3( v, order = this.order ) {
 
 		return this.set( v.x, v.y, v.z, order );
 
@@ -261,18 +251,16 @@ class Euler {
 
 	equals( euler ) {
 
-		return ( euler._x === this._x ) && ( euler._y === this._y ) && ( euler._z === this._z ) && ( euler._order === this._order );
+		return ( euler.x === this.x ) && ( euler.y === this.y ) && ( euler.z === this.z ) && ( euler.order === this.order );
 
 	}
 
 	fromArray( array ) {
 
-		this._x = array[ 0 ];
-		this._y = array[ 1 ];
-		this._z = array[ 2 ];
-		if ( array[ 3 ] !== undefined ) this._order = array[ 3 ];
-
-		this._onChangeCallback();
+		this.x = array[ 0 ];
+		this.y = array[ 1 ];
+		this.z = array[ 2 ];
+		if ( array[ 3 ] !== undefined ) this.order = array[ 3 ];
 
 		return this;
 
@@ -280,31 +268,33 @@ class Euler {
 
 	toArray( array = [], offset = 0 ) {
 
-		array[ offset ] = this._x;
-		array[ offset + 1 ] = this._y;
-		array[ offset + 2 ] = this._z;
-		array[ offset + 3 ] = this._order;
+		array[ offset ] = this.x;
+		array[ offset + 1 ] = this.y;
+		array[ offset + 2 ] = this.z;
+		array[ offset + 3 ] = this.order;
 
 		return array;
 
 	}
 
-	_onChange( callback ) {
+	toJSON() {
 
-		this._onChangeCallback = callback;
-
-		return this;
+		return {
+			isEuler: true,
+			_x: this.x,
+			_y: this.y,
+			_z: this.z,
+			_order: this.order
+		};
 
 	}
 
-	_onChangeCallback() {}
-
 	*[ Symbol.iterator ]() {
 
-		yield this._x;
-		yield this._y;
-		yield this._z;
-		yield this._order;
+		yield this.x;
+		yield this.y;
+		yield this.z;
+		yield this.order;
 
 	}
 

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -697,7 +697,7 @@ class Matrix4 {
 
 		const te = this.elements;
 
-		const x = quaternion._x, y = quaternion._y, z = quaternion._z, w = quaternion._w;
+		const x = quaternion.x, y = quaternion.y, z = quaternion.z, w = quaternion.w;
 		const x2 = x + x,	y2 = y + y, z2 = z + z;
 		const xx = x * x2, xy = x * y2, xz = x * z2;
 		const yy = y * y2, yz = y * z2, zz = z * z2;

--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -6,10 +6,58 @@ class Quaternion {
 
 		this.isQuaternion = true;
 
-		this._x = x;
-		this._y = y;
-		this._z = z;
-		this._w = w;
+		this.x = x;
+		this.y = y;
+		this.z = z;
+		this.w = w;
+
+	}
+
+	get _x() {
+
+		return this.x;
+
+	}
+
+	set _x( value ) {
+
+		this.x = value;
+
+	}
+
+	get _y() {
+
+		return this.y;
+
+	}
+
+	set _y( value ) {
+
+		this.y = value;
+
+	}
+
+	get _z() {
+
+		return this.z;
+
+	}
+
+	set _z( value ) {
+
+		this.z = value;
+
+	}
+
+	get _w() {
+
+		return this.w;
+
+	}
+
+	set _w( value ) {
+
+		this.w = value;
 
 	}
 
@@ -114,66 +162,12 @@ class Quaternion {
 
 	}
 
-	get x() {
-
-		return this._x;
-
-	}
-
-	set x( value ) {
-
-		this._x = value;
-		this._onChangeCallback();
-
-	}
-
-	get y() {
-
-		return this._y;
-
-	}
-
-	set y( value ) {
-
-		this._y = value;
-		this._onChangeCallback();
-
-	}
-
-	get z() {
-
-		return this._z;
-
-	}
-
-	set z( value ) {
-
-		this._z = value;
-		this._onChangeCallback();
-
-	}
-
-	get w() {
-
-		return this._w;
-
-	}
-
-	set w( value ) {
-
-		this._w = value;
-		this._onChangeCallback();
-
-	}
-
 	set( x, y, z, w ) {
 
-		this._x = x;
-		this._y = y;
-		this._z = z;
-		this._w = w;
-
-		this._onChangeCallback();
+		this.x = x;
+		this.y = y;
+		this.z = z;
+		this.w = w;
 
 		return this;
 
@@ -181,26 +175,24 @@ class Quaternion {
 
 	clone() {
 
-		return new this.constructor( this._x, this._y, this._z, this._w );
+		return new this.constructor( this.x, this.y, this.z, this.w );
 
 	}
 
 	copy( quaternion ) {
 
-		this._x = quaternion.x;
-		this._y = quaternion.y;
-		this._z = quaternion.z;
-		this._w = quaternion.w;
-
-		this._onChangeCallback();
+		this.x = quaternion.x;
+		this.y = quaternion.y;
+		this.z = quaternion.z;
+		this.w = quaternion.w;
 
 		return this;
 
 	}
 
-	setFromEuler( euler, update = true ) {
+	setFromEuler( euler ) {
 
-		const x = euler._x, y = euler._y, z = euler._z, order = euler._order;
+		const x = euler.x, y = euler.y, z = euler.z, order = euler.order;
 
 		// http://www.mathworks.com/matlabcentral/fileexchange/
 		// 	20696-function-to-convert-between-dcm-euler-angles-quaternions-and-euler-vectors/
@@ -220,53 +212,51 @@ class Quaternion {
 		switch ( order ) {
 
 			case 'XYZ':
-				this._x = s1 * c2 * c3 + c1 * s2 * s3;
-				this._y = c1 * s2 * c3 - s1 * c2 * s3;
-				this._z = c1 * c2 * s3 + s1 * s2 * c3;
-				this._w = c1 * c2 * c3 - s1 * s2 * s3;
+				this.x = s1 * c2 * c3 + c1 * s2 * s3;
+				this.y = c1 * s2 * c3 - s1 * c2 * s3;
+				this.z = c1 * c2 * s3 + s1 * s2 * c3;
+				this.w = c1 * c2 * c3 - s1 * s2 * s3;
 				break;
 
 			case 'YXZ':
-				this._x = s1 * c2 * c3 + c1 * s2 * s3;
-				this._y = c1 * s2 * c3 - s1 * c2 * s3;
-				this._z = c1 * c2 * s3 - s1 * s2 * c3;
-				this._w = c1 * c2 * c3 + s1 * s2 * s3;
+				this.x = s1 * c2 * c3 + c1 * s2 * s3;
+				this.y = c1 * s2 * c3 - s1 * c2 * s3;
+				this.z = c1 * c2 * s3 - s1 * s2 * c3;
+				this.w = c1 * c2 * c3 + s1 * s2 * s3;
 				break;
 
 			case 'ZXY':
-				this._x = s1 * c2 * c3 - c1 * s2 * s3;
-				this._y = c1 * s2 * c3 + s1 * c2 * s3;
-				this._z = c1 * c2 * s3 + s1 * s2 * c3;
-				this._w = c1 * c2 * c3 - s1 * s2 * s3;
+				this.x = s1 * c2 * c3 - c1 * s2 * s3;
+				this.y = c1 * s2 * c3 + s1 * c2 * s3;
+				this.z = c1 * c2 * s3 + s1 * s2 * c3;
+				this.w = c1 * c2 * c3 - s1 * s2 * s3;
 				break;
 
 			case 'ZYX':
-				this._x = s1 * c2 * c3 - c1 * s2 * s3;
-				this._y = c1 * s2 * c3 + s1 * c2 * s3;
-				this._z = c1 * c2 * s3 - s1 * s2 * c3;
-				this._w = c1 * c2 * c3 + s1 * s2 * s3;
+				this.x = s1 * c2 * c3 - c1 * s2 * s3;
+				this.y = c1 * s2 * c3 + s1 * c2 * s3;
+				this.z = c1 * c2 * s3 - s1 * s2 * c3;
+				this.w = c1 * c2 * c3 + s1 * s2 * s3;
 				break;
 
 			case 'YZX':
-				this._x = s1 * c2 * c3 + c1 * s2 * s3;
-				this._y = c1 * s2 * c3 + s1 * c2 * s3;
-				this._z = c1 * c2 * s3 - s1 * s2 * c3;
-				this._w = c1 * c2 * c3 - s1 * s2 * s3;
+				this.x = s1 * c2 * c3 + c1 * s2 * s3;
+				this.y = c1 * s2 * c3 + s1 * c2 * s3;
+				this.z = c1 * c2 * s3 - s1 * s2 * c3;
+				this.w = c1 * c2 * c3 - s1 * s2 * s3;
 				break;
 
 			case 'XZY':
-				this._x = s1 * c2 * c3 - c1 * s2 * s3;
-				this._y = c1 * s2 * c3 - s1 * c2 * s3;
-				this._z = c1 * c2 * s3 + s1 * s2 * c3;
-				this._w = c1 * c2 * c3 + s1 * s2 * s3;
+				this.x = s1 * c2 * c3 - c1 * s2 * s3;
+				this.y = c1 * s2 * c3 - s1 * c2 * s3;
+				this.z = c1 * c2 * s3 + s1 * s2 * c3;
+				this.w = c1 * c2 * c3 + s1 * s2 * s3;
 				break;
 
 			default:
 				console.warn( 'THREE.Quaternion: .setFromEuler() encountered an unknown order: ' + order );
 
 		}
-
-		if ( update === true ) this._onChangeCallback();
 
 		return this;
 
@@ -280,12 +270,10 @@ class Quaternion {
 
 		const halfAngle = angle / 2, s = Math.sin( halfAngle );
 
-		this._x = axis.x * s;
-		this._y = axis.y * s;
-		this._z = axis.z * s;
-		this._w = Math.cos( halfAngle );
-
-		this._onChangeCallback();
+		this.x = axis.x * s;
+		this.y = axis.y * s;
+		this.z = axis.z * s;
+		this.w = Math.cos( halfAngle );
 
 		return this;
 
@@ -309,41 +297,39 @@ class Quaternion {
 
 			const s = 0.5 / Math.sqrt( trace + 1.0 );
 
-			this._w = 0.25 / s;
-			this._x = ( m32 - m23 ) * s;
-			this._y = ( m13 - m31 ) * s;
-			this._z = ( m21 - m12 ) * s;
+			this.w = 0.25 / s;
+			this.x = ( m32 - m23 ) * s;
+			this.y = ( m13 - m31 ) * s;
+			this.z = ( m21 - m12 ) * s;
 
 		} else if ( m11 > m22 && m11 > m33 ) {
 
 			const s = 2.0 * Math.sqrt( 1.0 + m11 - m22 - m33 );
 
-			this._w = ( m32 - m23 ) / s;
-			this._x = 0.25 * s;
-			this._y = ( m12 + m21 ) / s;
-			this._z = ( m13 + m31 ) / s;
+			this.w = ( m32 - m23 ) / s;
+			this.x = 0.25 * s;
+			this.y = ( m12 + m21 ) / s;
+			this.z = ( m13 + m31 ) / s;
 
 		} else if ( m22 > m33 ) {
 
 			const s = 2.0 * Math.sqrt( 1.0 + m22 - m11 - m33 );
 
-			this._w = ( m13 - m31 ) / s;
-			this._x = ( m12 + m21 ) / s;
-			this._y = 0.25 * s;
-			this._z = ( m23 + m32 ) / s;
+			this.w = ( m13 - m31 ) / s;
+			this.x = ( m12 + m21 ) / s;
+			this.y = 0.25 * s;
+			this.z = ( m23 + m32 ) / s;
 
 		} else {
 
 			const s = 2.0 * Math.sqrt( 1.0 + m33 - m11 - m22 );
 
-			this._w = ( m21 - m12 ) / s;
-			this._x = ( m13 + m31 ) / s;
-			this._y = ( m23 + m32 ) / s;
-			this._z = 0.25 * s;
+			this.w = ( m21 - m12 ) / s;
+			this.x = ( m13 + m31 ) / s;
+			this.y = ( m23 + m32 ) / s;
+			this.z = 0.25 * s;
 
 		}
-
-		this._onChangeCallback();
 
 		return this;
 
@@ -363,17 +349,17 @@ class Quaternion {
 
 			if ( Math.abs( vFrom.x ) > Math.abs( vFrom.z ) ) {
 
-				this._x = - vFrom.y;
-				this._y = vFrom.x;
-				this._z = 0;
-				this._w = r;
+				this.x = - vFrom.y;
+				this.y = vFrom.x;
+				this.z = 0;
+				this.w = r;
 
 			} else {
 
-				this._x = 0;
-				this._y = - vFrom.z;
-				this._z = vFrom.y;
-				this._w = r;
+				this.x = 0;
+				this.y = - vFrom.z;
+				this.z = vFrom.y;
+				this.w = r;
 
 			}
 
@@ -381,10 +367,10 @@ class Quaternion {
 
 			// crossVectors( vFrom, vTo ); // inlined to avoid cyclic dependency on Vector3
 
-			this._x = vFrom.y * vTo.z - vFrom.z * vTo.y;
-			this._y = vFrom.z * vTo.x - vFrom.x * vTo.z;
-			this._z = vFrom.x * vTo.y - vFrom.y * vTo.x;
-			this._w = r;
+			this.x = vFrom.y * vTo.z - vFrom.z * vTo.y;
+			this.y = vFrom.z * vTo.x - vFrom.x * vTo.z;
+			this.z = vFrom.x * vTo.y - vFrom.y * vTo.x;
+			this.w = r;
 
 		}
 
@@ -428,11 +414,9 @@ class Quaternion {
 
 	conjugate() {
 
-		this._x *= - 1;
-		this._y *= - 1;
-		this._z *= - 1;
-
-		this._onChangeCallback();
+		this.x *= - 1;
+		this.y *= - 1;
+		this.z *= - 1;
 
 		return this;
 
@@ -440,19 +424,19 @@ class Quaternion {
 
 	dot( v ) {
 
-		return this._x * v._x + this._y * v._y + this._z * v._z + this._w * v._w;
+		return this.x * v.x + this.y * v.y + this.z * v.z + this.w * v.w;
 
 	}
 
 	lengthSq() {
 
-		return this._x * this._x + this._y * this._y + this._z * this._z + this._w * this._w;
+		return this.x * this.x + this.y * this.y + this.z * this.z + this.w * this.w;
 
 	}
 
 	length() {
 
-		return Math.sqrt( this._x * this._x + this._y * this._y + this._z * this._z + this._w * this._w );
+		return Math.sqrt( this.x * this.x + this.y * this.y + this.z * this.z + this.w * this.w );
 
 	}
 
@@ -462,23 +446,21 @@ class Quaternion {
 
 		if ( l === 0 ) {
 
-			this._x = 0;
-			this._y = 0;
-			this._z = 0;
-			this._w = 1;
+			this.x = 0;
+			this.y = 0;
+			this.z = 0;
+			this.w = 1;
 
 		} else {
 
 			l = 1 / l;
 
-			this._x = this._x * l;
-			this._y = this._y * l;
-			this._z = this._z * l;
-			this._w = this._w * l;
+			this.x = this.x * l;
+			this.y = this.y * l;
+			this.z = this.z * l;
+			this.w = this.w * l;
 
 		}
-
-		this._onChangeCallback();
 
 		return this;
 
@@ -500,15 +482,13 @@ class Quaternion {
 
 		// from http://www.euclideanspace.com/maths/algebra/realNormedAlgebra/quaternions/code/index.htm
 
-		const qax = a._x, qay = a._y, qaz = a._z, qaw = a._w;
-		const qbx = b._x, qby = b._y, qbz = b._z, qbw = b._w;
+		const qax = a.x, qay = a.y, qaz = a.z, qaw = a.w;
+		const qbx = b.x, qby = b.y, qbz = b.z, qbw = b.w;
 
-		this._x = qax * qbw + qaw * qbx + qay * qbz - qaz * qby;
-		this._y = qay * qbw + qaw * qby + qaz * qbx - qax * qbz;
-		this._z = qaz * qbw + qaw * qbz + qax * qby - qay * qbx;
-		this._w = qaw * qbw - qax * qbx - qay * qby - qaz * qbz;
-
-		this._onChangeCallback();
+		this.x = qax * qbw + qaw * qbx + qay * qbz - qaz * qby;
+		this.y = qay * qbw + qaw * qby + qaz * qbx - qax * qbz;
+		this.z = qaz * qbw + qaw * qbz + qax * qby - qay * qbx;
+		this.w = qaw * qbw - qax * qbx - qay * qby - qaz * qbz;
 
 		return this;
 
@@ -519,18 +499,18 @@ class Quaternion {
 		if ( t === 0 ) return this;
 		if ( t === 1 ) return this.copy( qb );
 
-		const x = this._x, y = this._y, z = this._z, w = this._w;
+		const x = this.x, y = this.y, z = this.z, w = this.w;
 
 		// http://www.euclideanspace.com/maths/algebra/realNormedAlgebra/quaternions/slerp/
 
-		let cosHalfTheta = w * qb._w + x * qb._x + y * qb._y + z * qb._z;
+		let cosHalfTheta = w * qb.w + x * qb.x + y * qb.y + z * qb.z;
 
 		if ( cosHalfTheta < 0 ) {
 
-			this._w = - qb._w;
-			this._x = - qb._x;
-			this._y = - qb._y;
-			this._z = - qb._z;
+			this.w = - qb.w;
+			this.x = - qb.x;
+			this.y = - qb.y;
+			this.z = - qb.z;
 
 			cosHalfTheta = - cosHalfTheta;
 
@@ -542,10 +522,10 @@ class Quaternion {
 
 		if ( cosHalfTheta >= 1.0 ) {
 
-			this._w = w;
-			this._x = x;
-			this._y = y;
-			this._z = z;
+			this.w = w;
+			this.x = x;
+			this.y = y;
+			this.z = z;
 
 			return this;
 
@@ -556,12 +536,12 @@ class Quaternion {
 		if ( sqrSinHalfTheta <= Number.EPSILON ) {
 
 			const s = 1 - t;
-			this._w = s * w + t * this._w;
-			this._x = s * x + t * this._x;
-			this._y = s * y + t * this._y;
-			this._z = s * z + t * this._z;
+			this.w = s * w + t * this.w;
+			this.x = s * x + t * this.x;
+			this.y = s * y + t * this.y;
+			this.z = s * z + t * this.z;
 
-			this.normalize(); // normalize calls _onChangeCallback()
+			this.normalize();
 
 			return this;
 
@@ -572,12 +552,10 @@ class Quaternion {
 		const ratioA = Math.sin( ( 1 - t ) * halfTheta ) / sinHalfTheta,
 			ratioB = Math.sin( t * halfTheta ) / sinHalfTheta;
 
-		this._w = ( w * ratioA + this._w * ratioB );
-		this._x = ( x * ratioA + this._x * ratioB );
-		this._y = ( y * ratioA + this._y * ratioB );
-		this._z = ( z * ratioA + this._z * ratioB );
-
-		this._onChangeCallback();
+		this.w = ( w * ratioA + this.w * ratioB );
+		this.x = ( x * ratioA + this.x * ratioB );
+		this.y = ( y * ratioA + this.y * ratioB );
+		this.z = ( z * ratioA + this.z * ratioB );
 
 		return this;
 
@@ -615,18 +593,16 @@ class Quaternion {
 
 	equals( quaternion ) {
 
-		return ( quaternion._x === this._x ) && ( quaternion._y === this._y ) && ( quaternion._z === this._z ) && ( quaternion._w === this._w );
+		return ( quaternion.x === this.x ) && ( quaternion.y === this.y ) && ( quaternion.z === this.z ) && ( quaternion.w === this.w );
 
 	}
 
 	fromArray( array, offset = 0 ) {
 
-		this._x = array[ offset ];
-		this._y = array[ offset + 1 ];
-		this._z = array[ offset + 2 ];
-		this._w = array[ offset + 3 ];
-
-		this._onChangeCallback();
+		this.x = array[ offset ];
+		this.y = array[ offset + 1 ];
+		this.z = array[ offset + 2 ];
+		this.w = array[ offset + 3 ];
 
 		return this;
 
@@ -634,10 +610,10 @@ class Quaternion {
 
 	toArray( array = [], offset = 0 ) {
 
-		array[ offset ] = this._x;
-		array[ offset + 1 ] = this._y;
-		array[ offset + 2 ] = this._z;
-		array[ offset + 3 ] = this._w;
+		array[ offset ] = this.x;
+		array[ offset + 1 ] = this.y;
+		array[ offset + 2 ] = this.z;
+		array[ offset + 3 ] = this.w;
 
 		return array;
 
@@ -645,12 +621,10 @@ class Quaternion {
 
 	fromBufferAttribute( attribute, index ) {
 
-		this._x = attribute.getX( index );
-		this._y = attribute.getY( index );
-		this._z = attribute.getZ( index );
-		this._w = attribute.getW( index );
-
-		this._onChangeCallback();
+		this.x = attribute.getX( index );
+		this.y = attribute.getY( index );
+		this.z = attribute.getZ( index );
+		this.w = attribute.getW( index );
 
 		return this;
 
@@ -662,22 +636,12 @@ class Quaternion {
 
 	}
 
-	_onChange( callback ) {
-
-		this._onChangeCallback = callback;
-
-		return this;
-
-	}
-
-	_onChangeCallback() {}
-
 	*[ Symbol.iterator ]() {
 
-		yield this._x;
-		yield this._y;
-		yield this._z;
-		yield this._w;
+		yield this.x;
+		yield this.y;
+		yield this.z;
+		yield this.w;
 
 	}
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -628,9 +628,9 @@ class Vector3 {
 
 	setFromEuler( e ) {
 
-		this.x = e._x;
-		this.y = e._y;
-		this.z = e._z;
+		this.x = e.x;
+		this.y = e.y;
+		this.z = e.z;
 
 		return this;
 

--- a/test/unit/src/math/Euler.tests.js
+++ b/test/unit/src/math/Euler.tests.js
@@ -82,17 +82,6 @@ export default QUnit.module( 'Maths', () => {
 			a.x = 10;
 			assert.ok( a.x === 10, 'Passed!' );
 
-			a = new Euler( 11, 12, 13, 'XYZ' );
-			let b = false;
-			a._onChange( function () {
-
-				b = true;
-
-			} );
-			a.x = 14;
-			assert.ok( b, 'Passed!' );
-			assert.ok( a.x === 14, 'Passed!' );
-
 		} );
 
 		QUnit.test( 'y', ( assert ) => {
@@ -110,17 +99,6 @@ export default QUnit.module( 'Maths', () => {
 			a = new Euler( 7, 8, 9, 'XYZ' );
 			a.y = 10;
 			assert.ok( a.y === 10, 'Passed!' );
-
-			a = new Euler( 11, 12, 13, 'XYZ' );
-			let b = false;
-			a._onChange( function () {
-
-				b = true;
-
-			} );
-			a.y = 14;
-			assert.ok( b, 'Passed!' );
-			assert.ok( a.y === 14, 'Passed!' );
 
 		} );
 
@@ -140,17 +118,6 @@ export default QUnit.module( 'Maths', () => {
 			a.z = 10;
 			assert.ok( a.z === 10, 'Passed!' );
 
-			a = new Euler( 11, 12, 13, 'XYZ' );
-			let b = false;
-			a._onChange( function () {
-
-				b = true;
-
-			} );
-			a.z = 14;
-			assert.ok( b, 'Passed!' );
-			assert.ok( a.z === 14, 'Passed!' );
-
 		} );
 
 		QUnit.test( 'order', ( assert ) => {
@@ -168,18 +135,6 @@ export default QUnit.module( 'Maths', () => {
 			a = new Euler( 7, 8, 9, 'YZX' );
 			a.order = 'ZXY';
 			assert.ok( a.order === 'ZXY', 'Passed!' );
-
-			a = new Euler( 11, 12, 13, 'YZX' );
-			let b = false;
-			a._onChange( function () {
-
-				b = true;
-
-			} );
-			a.order = 'ZXY';
-			assert.ok( b, 'Passed!' );
-			assert.ok( a.order === 'ZXY', 'Passed!' );
-
 
 		} );
 
@@ -242,7 +197,7 @@ export default QUnit.module( 'Maths', () => {
 
 		QUnit.todo( 'Euler.setFromVector3', ( assert ) => {
 
-			// setFromVector3( v, order = this._order )
+			// setFromVector3( v, order = this.order )
 			assert.ok( false, 'everything\'s gonna be alright' );
 
 		} );
@@ -264,62 +219,6 @@ export default QUnit.module( 'Maths', () => {
 				assert.ok( quatEquals( q, q3 ), 'Passed!' );
 
 			}
-
-		} );
-
-		QUnit.test( 'set/get properties, check callbacks', ( assert ) => {
-
-			const a = new Euler();
-			a._onChange( function () {
-
-				assert.step( 'set: onChange called' );
-
-			} );
-
-			a.x = 1;
-			a.y = 2;
-			a.z = 3;
-			a.order = 'ZYX';
-
-			assert.strictEqual( a.x, 1, 'get: check x' );
-			assert.strictEqual( a.y, 2, 'get: check y' );
-			assert.strictEqual( a.z, 3, 'get: check z' );
-			assert.strictEqual( a.order, 'ZYX', 'get: check order' );
-
-			assert.verifySteps( Array( 4 ).fill( 'set: onChange called' ) );
-
-		} );
-
-		QUnit.test( 'clone/copy, check callbacks', ( assert ) => {
-
-			let a = new Euler( 1, 2, 3, 'ZXY' );
-			const b = new Euler( 4, 5, 6, 'XZY' );
-			const cbSucceed = function () {
-
-				assert.ok( true );
-				assert.step( 'onChange called' );
-
-			};
-
-			const cbFail = function () {
-
-				assert.ok( false );
-
-			};
-
-			a._onChange( cbFail );
-			b._onChange( cbFail );
-
-			// clone doesn't trigger onChange
-			a = b.clone();
-			assert.ok( a.equals( b ), 'clone: check if a equals b' );
-
-			// copy triggers onChange once
-			a = new Euler( 1, 2, 3, 'ZXY' );
-			a._onChange( cbSucceed );
-			a.copy( b );
-			assert.ok( a.equals( b ), 'copy: check if a equals b' );
-			assert.verifySteps( [ 'onChange called' ] );
 
 		} );
 
@@ -355,13 +254,6 @@ export default QUnit.module( 'Maths', () => {
 
 			let a = new Euler();
 			let array = [ x, y, z ];
-			const cb = function () {
-
-				assert.step( 'onChange called' );
-
-			};
-
-			a._onChange( cb );
 
 			a.fromArray( array );
 			assert.strictEqual( a.x, x, 'No order: check x' );
@@ -371,46 +263,11 @@ export default QUnit.module( 'Maths', () => {
 
 			a = new Euler();
 			array = [ x, y, z, 'ZXY' ];
-			a._onChange( cb );
 			a.fromArray( array );
 			assert.strictEqual( a.x, x, 'With order: check x' );
 			assert.strictEqual( a.y, y, 'With order: check y' );
 			assert.strictEqual( a.z, z, 'With order: check z' );
 			assert.strictEqual( a.order, 'ZXY', 'With order: check order' );
-
-			assert.verifySteps( Array( 2 ).fill( 'onChange called' ) );
-
-		} );
-
-		QUnit.test( '_onChange', ( assert ) => {
-
-			const f = function () {
-
-			};
-
-			const a = new Euler( 11, 12, 13, 'XYZ' );
-			a._onChange( f );
-			assert.ok( a._onChangeCallback === f, 'Passed!' );
-
-		} );
-
-		QUnit.test( '_onChangeCallback', ( assert ) => {
-
-			let b = false;
-			const a = new Euler( 11, 12, 13, 'XYZ' );
-			const f = function () {
-
-				b = true;
-				assert.ok( a === this, 'Passed!' );
-
-			};
-
-			a._onChangeCallback = f;
-			assert.ok( a._onChangeCallback === f, 'Passed!' );
-
-
-			a._onChangeCallback();
-			assert.ok( b, 'Passed!' );
 
 		} );
 

--- a/test/unit/src/math/Quaternion.tests.js
+++ b/test/unit/src/math/Quaternion.tests.js
@@ -197,29 +197,6 @@ export default QUnit.module( 'Maths', () => {
 		} );
 
 		// PROPERTIES
-		QUnit.test( 'properties', ( assert ) => {
-
-			assert.expect( 8 );
-
-			const a = new Quaternion();
-			a._onChange( function () {
-
-				assert.ok( true, 'onChange called' );
-
-			} );
-
-			a.x = x;
-			a.y = y;
-			a.z = z;
-			a.w = w;
-
-			assert.strictEqual( a.x, x, 'Check x' );
-			assert.strictEqual( a.y, y, 'Check y' );
-			assert.strictEqual( a.z, z, 'Check z' );
-			assert.strictEqual( a.w, w, 'Check w' );
-
-		} );
-
 		QUnit.test( 'x', ( assert ) => {
 
 			let a = new Quaternion();
@@ -234,18 +211,6 @@ export default QUnit.module( 'Maths', () => {
 			a = new Quaternion( 7, 8, 9 );
 			a.x = 10;
 			assert.ok( a.x === 10, 'Passed!' );
-
-			a = new Quaternion( 11, 12, 13 );
-			let b = false;
-			a._onChange( function () {
-
-				b = true;
-
-			} );
-			assert.ok( ! b, 'Passed!' );
-			a.x = 14;
-			assert.ok( b, 'Passed!' );
-			assert.ok( a.x === 14, 'Passed!' );
 
 		} );
 
@@ -263,18 +228,6 @@ export default QUnit.module( 'Maths', () => {
 			a = new Quaternion( 7, 8, 9 );
 			a.y = 10;
 			assert.ok( a.y === 10, 'Passed!' );
-
-			a = new Quaternion( 11, 12, 13 );
-			let b = false;
-			a._onChange( function () {
-
-				b = true;
-
-			} );
-			assert.ok( ! b, 'Passed!' );
-			a.y = 14;
-			assert.ok( b, 'Passed!' );
-			assert.ok( a.y === 14, 'Passed!' );
 
 		} );
 
@@ -294,18 +247,6 @@ export default QUnit.module( 'Maths', () => {
 			a.z = 10;
 			assert.ok( a.z === 10, 'Passed!' );
 
-			a = new Quaternion( 11, 12, 13 );
-			let b = false;
-			a._onChange( function () {
-
-				b = true;
-
-			} );
-			assert.ok( ! b, 'Passed!' );
-			a.z = 14;
-			assert.ok( b, 'Passed!' );
-			assert.ok( a.z === 14, 'Passed!' );
-
 		} );
 
 		QUnit.test( 'w', ( assert ) => {
@@ -322,18 +263,6 @@ export default QUnit.module( 'Maths', () => {
 			a = new Quaternion( 7, 8, 9 );
 			a.w = 10;
 			assert.ok( a.w === 10, 'Passed!' );
-
-			a = new Quaternion( 11, 12, 13 );
-			let b = false;
-			a._onChange( function () {
-
-				b = true;
-
-			} );
-			assert.ok( ! b, 'Passed!' );
-			a.w = 14;
-			assert.ok( b, 'Passed!' );
-			assert.ok( a.w === 14, 'Passed!' );
 
 		} );
 
@@ -790,45 +719,6 @@ export default QUnit.module( 'Maths', () => {
 			assert.numEqual( a.y, .7, 'index 2, component y' );
 			assert.numEqual( a.z, 0, 'index 2, component z' );
 			assert.numEqual( a.w, .7, 'index 2, component w' );
-
-		} );
-
-		QUnit.test( '_onChange', ( assert ) => {
-
-			let b = false;
-			const f = function () {
-
-				b = true;
-
-			};
-
-			const a = new Quaternion( 11, 12, 13, 1 );
-			a._onChange( f );
-			assert.ok( a._onChangeCallback === f, 'Passed!' );
-
-			a._onChangeCallback();
-			assert.ok( b, 'Passed!' );
-
-
-		} );
-
-		QUnit.test( '_onChangeCallback', ( assert ) => {
-
-			let b = false;
-			const a = new Quaternion( 11, 12, 13, 1 );
-			const f = function () {
-
-				b = true;
-				assert.ok( a === this, 'Passed!' );
-
-			};
-
-			a._onChangeCallback = f;
-			assert.ok( a._onChangeCallback === f, 'Passed!' );
-
-
-			a._onChangeCallback();
-			assert.ok( b, 'Passed!' );
 
 		} );
 


### PR DESCRIPTION
**Description**

Breaks up rotation/quaternion optimizations from #28534, where the conversion is only performed both when data has changed and on the next read if at all (instead of unconditionally on member write which may be much higher frequency).
