### PR TITLE
WebGPURenderer: Manual Shadow Update Control via `shadow.needsUpdate`

### DIFF
--- a/examples/webgpu_shadowmap_opacity.html
+++ b/examples/webgpu_shadowmap_opacity.html
@@ -71,6 +71,10 @@
 				dirLight.shadow.mapSize.height = 2048;
 				dirLight.shadow.radius = 4;
 				dirLight.shadow.bias = - 0.0005;
+
+				dirLight.shadow.autoUpdate = false;
+				dirLight.shadow.needsUpdate = true;
+
 				scene.add( dirLight );
 
 				//

--- a/src/nodes/lighting/AnalyticLightNode.js
+++ b/src/nodes/lighting/AnalyticLightNode.js
@@ -267,6 +267,10 @@ class AnalyticLightNode extends LightingNode {
 		const { shadowMap, light } = this;
 		const { renderer, scene, camera } = frame;
 
+
+		const depthVersion = shadowMap.depthTexture.version;
+		this._depthVersionCached = depthVersion;
+
 		const currentOverrideMaterial = scene.overrideMaterial;
 
 		scene.overrideMaterial = overrideMaterial;
@@ -315,7 +319,21 @@ class AnalyticLightNode extends LightingNode {
 
 	updateBefore( frame ) {
 
-		this.updateShadow( frame );
+		const shadow = this.light.shadow;
+
+		const needsUpdate = shadow.needsUpdate || shadow.autoUpdate;
+
+		if ( needsUpdate ) {
+
+			this.updateShadow( frame );
+
+			if ( this.shadowMap.depthTexture.version === this._depthVersionCached ) {
+
+				shadow.needsUpdate = false;
+
+			}
+
+		}
 
 	}
 


### PR DESCRIPTION
**Description**
This PR allows to manually control the update of a shadow through the already available `shadow.autoUpdate` and `shadow.needsUpdate` properties.

Usage:
```js
const dirLight = new THREE.DirectionalLight( 0xffffff, 10 );
dirLight.castShadow = true;
dirLight.shadow.autoUpdate = false;
dirLight.shadow.needsUpdate = true;
```

To demonstrate the feature, I updated the `webgpu_shadowmap_opacity` example:

Before:
<img width="1422" alt="Screenshot 2024-08-10 at 23 32 39" src="https://github.com/user-attachments/assets/26451018-c16e-44d1-a1e0-12e84a82d2e3">

After:
<img width="1422" alt="Screenshot 2024-08-10 at 23 31 33" src="https://github.com/user-attachments/assets/8337ea66-bd60-4aa5-b8b6-29bcda1d926c">

To ensure this feature works correctly, I had to account for the versioning of depthTexture. Without this, when the Renderer initialize the FBO in the first render loop, it updates the attached textures, leading to the incorrect shadowMap being bound to the meshes in subsequent renders.

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Utsubo](https://utsubo.com)*
