### PR TITLE
AnimationClipCreator: Fix timeStep logic in `CreateMaterialColorAnimation()`.

### DIFF
--- a/examples/jsm/animation/AnimationClipCreator.js
+++ b/examples/jsm/animation/AnimationClipCreator.js
@@ -92,7 +92,7 @@ class AnimationClipCreator {
 	static CreateMaterialColorAnimation( duration, colors ) {
 
 		const times = [], values = [],
-			timeStep = duration / colors.length;
+			timeStep = duration / ( colors.length - 1 );
 
 		for ( let i = 0; i < colors.length; i ++ ) {
 

--- a/examples/jsm/animation/AnimationClipCreator.js
+++ b/examples/jsm/animation/AnimationClipCreator.js
@@ -92,7 +92,7 @@ class AnimationClipCreator {
 	static CreateMaterialColorAnimation( duration, colors ) {
 
 		const times = [], values = [],
-			timeStep = duration / ( colors.length - 1 );
+			timeStep = ( colors.length > 1 ) ? duration / ( colors.length - 1 ) : 0;
 
 		for ( let i = 0; i < colors.length; i ++ ) {
 


### PR DESCRIPTION
**Description**

While trying to understand how to use ColorKeyframeTrack, I found an error in the example provided.

timeStep was incorrectly calculating the `times` array parameter, making the animation play faster and end before the targeted duration.

For duration = 5 and colors.length = 2, `times` would have been `[0, 2.5]` instead of `[0,5]`

Demo with the fix applied:

https://jsfiddle.net/y9kwfje8/