### PR TITLE
ViewportDepthNode: Fix `material.depthNode=depth` assign

### DIFF
--- a/src/nodes/display/RenderOutputNode.js
+++ b/src/nodes/display/RenderOutputNode.js
@@ -2,7 +2,7 @@ import TempNode from '../core/TempNode.js';
 import { addNodeClass } from '../core/Node.js';
 import { addNodeElement, nodeObject } from '../shadernode/ShaderNode.js';
 
-import { SRGBColorSpace, NoToneMapping } from '../../constants.js';
+import { LinearSRGBColorSpace, SRGBColorSpace, NoToneMapping } from '../../constants.js';
 
 class RenderOutputNode extends TempNode {
 
@@ -24,8 +24,8 @@ class RenderOutputNode extends TempNode {
 
 		// tone mapping
 
-		const toneMapping = this.toneMapping !== null ? this.toneMapping : context.toneMapping;
-		const outputColorSpace = this.outputColorSpace !== null ? this.outputColorSpace : context.outputColorSpace;
+		const toneMapping = ( this.toneMapping !== null ? this.toneMapping : context.toneMapping ) || NoToneMapping;
+		const outputColorSpace = ( this.outputColorSpace !== null ? this.outputColorSpace : context.outputColorSpace ) || LinearSRGBColorSpace;
 
 		if ( toneMapping !== NoToneMapping ) {
 

--- a/src/nodes/display/ViewportDepthNode.js
+++ b/src/nodes/display/ViewportDepthNode.js
@@ -21,7 +21,7 @@ class ViewportDepthNode extends Node {
 
 		const { scope } = this;
 
-		if ( scope === ViewportDepthNode.DEPTH ) {
+		if ( scope === ViewportDepthNode.DEPTH_BASE ) {
 
 			return builder.getFragDepth();
 
@@ -34,43 +34,43 @@ class ViewportDepthNode extends Node {
 	setup( { camera } ) {
 
 		const { scope } = this;
-		const texture = this.valueNode;
+		const value = this.valueNode;
 
 		let node = null;
 
-		if ( scope === ViewportDepthNode.DEPTH ) {
+		if ( scope === ViewportDepthNode.DEPTH_BASE ) {
 
-			if ( texture !== null ) {
+			if ( value !== null ) {
 
- 				node = depthBase().assign( texture );
+ 				node = depthBase().assign( value );
+
+			}
+
+		} else if ( scope === ViewportDepthNode.DEPTH ) {
+
+			if ( camera.isPerspectiveCamera ) {
+
+				node = viewZToPerspectiveDepth( positionView.z, cameraNear, cameraFar );
 
 			} else {
 
-				if ( camera.isPerspectiveCamera ) {
-
-					node = viewZToPerspectiveDepth( positionView.z, cameraNear, cameraFar );
-
-				} else {
-
-					node = viewZToOrthographicDepth( positionView.z, cameraNear, cameraFar );
-
-				}
+				node = viewZToOrthographicDepth( positionView.z, cameraNear, cameraFar );
 
 			}
 
 		} else if ( scope === ViewportDepthNode.LINEAR_DEPTH ) {
 
-			if ( texture !== null ) {
+			if ( value !== null ) {
 
 				if ( camera.isPerspectiveCamera ) {
 
-					const viewZ = perspectiveDepthToViewZ( texture, cameraNear, cameraFar );
+					const viewZ = perspectiveDepthToViewZ( value, cameraNear, cameraFar );
 
 					node = viewZToOrthographicDepth( viewZ, cameraNear, cameraFar );
 
 				} else {
 
-					node = texture;
+					node = value;
 
 				}
 
@@ -104,12 +104,13 @@ export const viewZToPerspectiveDepth = ( viewZ, near, far ) => near.add( viewZ )
 // maps perspective depth in [ 0, 1 ] to viewZ
 export const perspectiveDepthToViewZ = ( depth, near, far ) => near.mul( far ).div( far.sub( near ).mul( depth ).sub( far ) );
 
+ViewportDepthNode.DEPTH_BASE = 'depthBase';
 ViewportDepthNode.DEPTH = 'depth';
 ViewportDepthNode.LINEAR_DEPTH = 'linearDepth';
 
 export default ViewportDepthNode;
 
-const depthBase = nodeProxy( ViewportDepthNode, ViewportDepthNode.DEPTH );
+const depthBase = nodeProxy( ViewportDepthNode, ViewportDepthNode.DEPTH_BASE );
 
 export const depth = nodeImmutable( ViewportDepthNode, ViewportDepthNode.DEPTH );
 export const linearDepth = nodeProxy( ViewportDepthNode, ViewportDepthNode.LINEAR_DEPTH );


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/28720

**Description**

The value of `depth` was incorrect because `generate()` was overwriting it.