### PR TITLE
NodeMaterial: Added support to custom MRT depth

### DIFF
--- a/src/nodes/materials/NodeMaterial.js
+++ b/src/nodes/materials/NodeMaterial.js
@@ -206,11 +206,21 @@ class NodeMaterial extends Material {
 
 		let depthNode = this.depthNode;
 
-		if ( depthNode === null && renderer.logarithmicDepthBuffer === true ) {
+		if ( depthNode === null ) {
 
-			const fragDepth = modelViewProjection().w.add( 1 );
+			const mrt = renderer.getMRT();
 
-			depthNode = fragDepth.log2().mul( cameraLogDepth ).mul( 0.5 );
+			if ( mrt && mrt.has( 'depth' ) ) {
+
+				depthNode = mrt.get( 'depth' );
+
+			} else if ( renderer.logarithmicDepthBuffer === true ) {
+
+				const fragDepth = modelViewProjection().w.add( 1 );
+
+				depthNode = fragDepth.log2().mul( cameraLogDepth ).mul( 0.5 );
+
+			}
 
 		}
 

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -795,7 +795,7 @@ ${ flowData.code }
 
 		const builtins = this.getBuiltins( 'output' );
 
-		if ( builtins ) snippets.push( builtins );
+		if ( builtins ) snippets.push( '\t' + builtins );
 
 		return snippets.join( ',\n' );
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/29106#issuecomment-2282913287

**Description**

Added support to custom MRT depth:

```js
const scenePass = pass( scene, camera );

scenePass.setMRT( mrt( {
	output,
	depth: depth // change depth output pass if you want
} ) );
```