### PR TITLE
Fix incorrect file name in documentation paragraph

### DIFF
--- a/docs/manual/en/introduction/Creating-a-scene.html
+++ b/docs/manual/en/introduction/Creating-a-scene.html
@@ -71,7 +71,7 @@
 
 		<h2>Rendering the scene</h2>
 
-		<p>If you copied the code from above into the HTML file we created earlier, you wouldn't be able to see anything. This is because we're not actually rendering anything yet. For that, we need what's called a render or animation loop.</p>
+		<p>If you copied the code from above into the main.js file we created earlier, you wouldn't be able to see anything. This is because we're not actually rendering anything yet. For that, we need what's called a render or animation loop.</p>
 
 		<code>
 		function animate() {


### PR DESCRIPTION
Corrected the file name mentioned in the documentation paragraph. The previous file name was incorrect, which could cause confusion for users.

Changes made:
- Fixed file name HTML in line no 74 of the documentation as main.js.

Related issue: #XXXX

**Description**

In line 74 it was written as "If you copied the code from above into the HTML file we created earlier". Actually we code we need to copy code into JavaScript file (main.js) not an HTML file. So, I updated the reference to the correct file name "If you copied the code from above into the main.js file we created earlier" to ensure accuracy and clarity.




