### PR TITLE
WebGPU Bloom Examples: Clean up

### DIFF
--- a/examples/webgpu_postprocessing_bloom.html
+++ b/examples/webgpu_postprocessing_bloom.html
@@ -97,13 +97,15 @@
 				//
 
 				postProcessing = new THREE.PostProcessing( renderer );
+				postProcessing.outputColorTransform = false;
 
 				const scenePass = pass( scene, camera );
-				const scenePassColor = scenePass.getTextureNode( 'output' );
 
-				const bloomPass = bloom( scenePassColor );
+				const outputPass = scenePass.getTextureNode();
 
-				postProcessing.outputNode = scenePassColor.add( bloomPass );
+				const bloomPass = outputPass.bloom();
+
+				postProcessing.outputNode = outputPass.add( bloomPass ).renderOutput();
 
 				//
 

--- a/examples/webgpu_postprocessing_bloom_selective.html
+++ b/examples/webgpu_postprocessing_bloom_selective.html
@@ -74,19 +74,22 @@
 
 			// post processing
 
+			const postProcessing = new THREE.PostProcessing( renderer );
+			postProcessing.outputColorTransform = false;
+
 			const scenePass = pass( scene, camera );
+
 			scenePass.setMRT( mrt( {
 				output,
 				bloomIntensity: float( 0 ) // default bloom intensity
 			} ) );
 
 			const outputPass = scenePass.getTextureNode();
+
 			const bloomIntensityPass = scenePass.getTextureNode( 'bloomIntensity' );
 
 			const bloomPass = outputPass.mul( bloomIntensityPass ).bloom();
 
-			const postProcessing = new THREE.PostProcessing( renderer );
-			postProcessing.outputColorTransform = false;
 			postProcessing.outputNode = outputPass.add( bloomPass ).renderOutput();
 
 			// controls


### PR DESCRIPTION
Adhering to the nomenclature of the later example, under the assumption that nomenclature is preferred.

Also, and more importantly, applying bloom in linear space -- i.e., prior to tone mapping.
