### PR TITLE
ContextNode: Rename `.context` -> `.value`

### DIFF
--- a/src/nodes/core/ContextNode.js
+++ b/src/nodes/core/ContextNode.js
@@ -3,14 +3,14 @@ import { addNodeElement, nodeProxy } from '../shadernode/ShaderNode.js';
 
 class ContextNode extends Node {
 
-	constructor( node, context = {} ) {
+	constructor( node, value = {} ) {
 
 		super();
 
 		this.isContextNode = true;
 
 		this.node = node;
-		this.context = context;
+		this.value = value;
 
 	}
 
@@ -30,7 +30,7 @@ class ContextNode extends Node {
 
 		const previousContext = builder.getContext();
 
-		builder.setContext( { ...builder.context, ...this.context } );
+		builder.setContext( { ...builder.context, ...this.value } );
 
 		const node = this.node.build( builder );
 
@@ -44,7 +44,7 @@ class ContextNode extends Node {
 
 		const previousContext = builder.getContext();
 
-		builder.setContext( { ...builder.context, ...this.context } );
+		builder.setContext( { ...builder.context, ...this.value } );
 
 		const snippet = this.node.build( builder, output );
 

--- a/src/nodes/lighting/LightingContextNode.js
+++ b/src/nodes/lighting/LightingContextNode.js
@@ -12,7 +12,7 @@ class LightingContextNode extends ContextNode {
 		this.backdropNode = backdropNode;
 		this.backdropAlphaNode = backdropAlphaNode;
 
-		this._context = null;
+		this._value = null;
 
 	}
 
@@ -48,8 +48,8 @@ class LightingContextNode extends ContextNode {
 
 	setup( builder ) {
 
-		this.context = this._context || ( this._context = this.getContext() );
-		this.context.lightingModel = this.lightingModel || builder.context.lightingModel;
+		this.value = this._value || ( this._value = this.getContext() );
+		this.value.lightingModel = this.lightingModel || builder.context.lightingModel;
 
 		return super.setup( builder );
 


### PR DESCRIPTION
**Description**

`.context` property should be a reserved work for that users can use `anyNode.context( {} )`