### PR TITLE
E2E: add `test-e2e-webgpu`

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "test-unit-addons": "qunit -r failonlyreporter -f !-webonly test/unit/three.addons.unit.js",
     "test-e2e": "node test/e2e/puppeteer.js",
     "test-e2e-cov": "node test/e2e/check-coverage.js",
+    "test-e2e-webgpu": "node test/e2e/puppeteer.js --webgpu",
     "test-treeshake": "rollup -c test/rollup.treeshake.config.js",
     "test-circular-deps": "dpdm --no-warning --no-tree --exit-code circular:1 src/nodes/Nodes.js",
     "make-screenshot": "node test/e2e/puppeteer.js --make"

--- a/test/e2e/puppeteer.js
+++ b/test/e2e/puppeteer.js
@@ -201,9 +201,26 @@ async function main() {
 
 	/* Find files */
 
-	const isMakeScreenshot = process.argv[ 2 ] === '--make';
+	let isMakeScreenshot = false;
+	let isWebGPU = false;
 
-	const exactList = process.argv.slice( isMakeScreenshot ? 3 : 2 )
+	let argvIndex = 2;
+
+	if ( process.argv[ argvIndex ] === '--webgpu' ) {
+
+		isWebGPU = true;
+		argvIndex ++;
+
+	}
+
+	if ( process.argv[ argvIndex ] === '--make' ) {
+
+		isMakeScreenshot = true;
+		argvIndex ++;
+
+	}
+
+	const exactList = process.argv.slice( argvIndex )
 		.map( f => f.replace( '.html', '' ) );
 
 	const isExactList = exactList.length !== 0;
@@ -226,6 +243,8 @@ async function main() {
 		}
 
 	}
+
+	if ( isWebGPU ) files = files.filter( f => f.includes( 'webgpu_' ) );
 
 	/* CI parallelism */
 


### PR DESCRIPTION
**Description**

Introduce `npm run test-e2e-webgpu` command.

This should make it fast to test the WebGPU examples once that testing all the others WebGL examples first can take a few minutes.

