### PR TITLE
WebGPURenderer: don't create duplicate shader programs in the WebGL fallback renderer

### DIFF
--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -747,9 +747,9 @@ class WebGLBackend extends Backend {
 
 	}
 
-	getRenderCacheKey( renderObject ) {
+	getRenderCacheKey( /*renderObject*/ ) {
 
-		return renderObject.id;
+		return '';
 
 	}
 


### PR DESCRIPTION
Since #27367 the WebGL fallback renderer has equated the pipeline object to the  WebGLProgram object but is cached per renderObject.id (previously the VAO was included in the pipeline state).

This results in the creation of redundant program objects, as demonstrated in the webgpu_performance example where over 700 are created. 

Remove renderObject.id from the cache key to fix this issue.

@sunag @RenaudRohlinger 