### PR TITLE
WebGPUBackend: BatchedMesh in WebGPU throw Error: reading "bytesPerElement" of …

### DIFF
--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -955,7 +955,7 @@ class WebGPUBackend extends Backend {
 			const drawCount = object._multiDrawCount;
 			const drawInstances = object._multiDrawInstances;
 
-			const bytesPerElement = index.bytesPerElement || 1;
+			const bytesPerElement = hasIndex ? index.bytesPerElement : 1;
 
 			for ( let i = 0; i < drawCount; i ++ ) {
 


### PR DESCRIPTION
**Description**
when using batchedMesh in WebGPURenderer, implement WebGPUBackend draw function, browser will throw Error.
The Error content is : reading "bytesPerElement" of null.
Because the value of bytesPerElement is read from index, it should actually be read from object.