### PR TITLE
TransformControls: Derive from `Controls`.

### DIFF
--- a/docs/examples/en/controls/DragControls.html
+++ b/docs/examples/en/controls/DragControls.html
@@ -127,21 +127,6 @@
 
 		<p>See the base [page:Controls] class for common methods.</p>
 
-		<h3>[method:undefined connect] ()</h3>
-		<p>
-			Adds the event listeners of the controls.
-		</p>
-
-		<h3>[method:undefined disconnect] ()</h3>
-		<p>
-			Removes the event listeners of the controls.
-		</p>
-
-		<h3>[method:undefined dispose] ()</h3>
-		<p>
-			Should be called if the controls is no longer required.
-		</p>
-
 		<h2>Source</h2>
 
 		<p>

--- a/docs/examples/en/controls/TransformControls.html
+++ b/docs/examples/en/controls/TransformControls.html
@@ -95,11 +95,6 @@
 			The current transformation mode. Possible values are "translate", "rotate" and "scale". Default is `translate`.
 		</p>
 
-		<h3>[property:Object3D object]</h3>
-		<p>
-			The 3D object being controlled.
-		</p>
-
 		<h3>[property:Number rotationSnap]</h3>
 		<p>
 			By default, 3D objects are continuously rotated. If you set this property to a numeric value (radians), you can define in which

--- a/docs/examples/en/controls/TransformControls.html
+++ b/docs/examples/en/controls/TransformControls.html
@@ -80,6 +80,11 @@
 			The current transformation axis.
 		</p>
 
+		<h3>[property:Camera camera]</h3>
+		<p>
+			The camera of the rendered scene.
+		</p>
+
 		<h3>[property:Boolean dragging]</h3>
 		<p>
 			Whether or not dragging is currently performed. Read-only property.

--- a/docs/examples/en/controls/TransformControls.html
+++ b/docs/examples/en/controls/TransformControls.html
@@ -7,7 +7,7 @@
 		<link type="text/css" rel="stylesheet" href="page.css" />
 	</head>
 	<body>
-		[page:Object3D] &rarr;
+		[page:Controls] &rarr;
 
 		<h1>[name]</h1>
 
@@ -41,7 +41,7 @@
 				[page:Camera camera]: The camera of the rendered scene.
 			</p>
 			<p>
-				[page:HTMLDOMElement domElement]: The HTML element used for event listeners.
+				[page:HTMLDOMElement domElement]: The HTML element used for event listeners. (optional)
 			</p>
 			<p>
 				Creates a new instance of [name].
@@ -73,32 +73,16 @@
 
 		<h2>Properties</h2>
 
-		<p>See the base [page:Object3D] class for common properties.</p>
+		<p>See the base [page:Controls] class for common properties.</p>
 
 		<h3>[property:String axis]</h3>
 		<p>
 			The current transformation axis.
 		</p>
 
-		<h3>[property:Camera camera]</h3>
-		<p>
-			The camera of the rendered scene.
-		</p>
-
-		<h3>[property:HTMLDOMElement domElement]</h3>
-		<p>
-			The HTMLDOMElement used to listen for mouse / touch events. This must be passed in the constructor; changing it here will
-			not set up new event listeners.
-		</p>
-
 		<h3>[property:Boolean dragging]</h3>
 		<p>
 			Whether or not dragging is currently performed. Read-only property.
-		</p>
-
-		<h3>[property:Boolean enabled]</h3>
-		<p>
-			Whether or not the controls are enabled.
 		</p>
 
 		<h3>[property:String mode]</h3>
@@ -150,7 +134,7 @@
 
 		<h2>Methods</h2>
 
-		<p>See the base [page:Object3D] class for common methods.</p>
+		<p>See the base [page:Controls] class for common methods.</p>
 
 		<h3>[method:TransformControls attach] ( [param:Object3D object] )</h3>
 		<p>
@@ -167,9 +151,10 @@
 			Removes the current 3D object from the controls and makes the helper UI invisible.
 		</p>
 
-		<h3>[method:undefined dispose] ()</h3>
+		<h3>[method:Object3D getGizmo] ()</h3>
 		<p>
-			Should be called if the controls is no longer required.
+			Returns the visual representation of the controls. Add the gizmo to your scene to visually transform the attached 
+			3D object.
 		</p>
 
 		<h3>[method:Raycaster getRaycaster] ()</h3>

--- a/editor/js/Viewport.js
+++ b/editor/js/Viewport.js
@@ -142,7 +142,7 @@ function Viewport( editor ) {
 
 	} );
 
-	sceneHelpers.add( transformControls );
+	sceneHelpers.add( transformControls.getGizmo() );
 
 	//
 

--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -1,6 +1,7 @@
 import {
 	BoxGeometry,
 	BufferGeometry,
+	Controls,
 	CylinderGeometry,
 	DoubleSide,
 	Euler,
@@ -36,32 +37,22 @@ const _mouseDownEvent = { type: 'mouseDown', mode: null };
 const _mouseUpEvent = { type: 'mouseUp', mode: null };
 const _objectChangeEvent = { type: 'objectChange' };
 
-class TransformControls extends Object3D {
+class TransformControls extends Controls {
 
-	constructor( camera, domElement ) {
+	constructor( camera, domElement = null ) {
 
-		super();
+		super( camera, domElement );
 
-		if ( domElement === undefined ) {
+		const root = new TransformControlsRoot( this );
+		this._root = root;
 
-			console.warn( 'THREE.TransformControls: The second parameter "domElement" is now mandatory.' );
-			domElement = document;
+		const gizmo = new TransformControlsGizmo();
+		this._gizmo = gizmo;
+		root.add( gizmo );
 
-		}
-
-		this.isTransformControls = true;
-
-		this.visible = false;
-		this.domElement = domElement;
-		this.domElement.style.touchAction = 'none'; // disable touch scroll
-
-		const _gizmo = new TransformControlsGizmo();
-		this._gizmo = _gizmo;
-		this.add( _gizmo );
-
-		const _plane = new TransformControlsPlane();
-		this._plane = _plane;
-		this.add( _plane );
+		const plane = new TransformControlsPlane();
+		this._plane = plane;
+		root.add( plane );
 
 		const scope = this;
 
@@ -83,8 +74,8 @@ class TransformControls extends Object3D {
 					if ( propValue !== value ) {
 
 						propValue = value;
-						_plane[ propName ] = value;
-						_gizmo[ propName ] = value;
+						plane[ propName ] = value;
+						gizmo[ propName ] = value;
 
 						scope.dispatchEvent( { type: propName + '-changed', value: value } );
 						scope.dispatchEvent( _changeEvent );
@@ -96,8 +87,8 @@ class TransformControls extends Object3D {
 			} );
 
 			scope[ propName ] = defaultValue;
-			_plane[ propName ] = defaultValue;
-			_gizmo[ propName ] = defaultValue;
+			plane[ propName ] = defaultValue;
+			gizmo[ propName ] = defaultValue;
 
 		}
 
@@ -172,50 +163,38 @@ class TransformControls extends Object3D {
 		this._onPointerMove = onPointerMove.bind( this );
 		this._onPointerUp = onPointerUp.bind( this );
 
+		if ( domElement !== null ) {
+
+			this.connect();
+
+		}
+
+	}
+
+	connect() {
+
 		this.domElement.addEventListener( 'pointerdown', this._onPointerDown );
 		this.domElement.addEventListener( 'pointermove', this._onPointerHover );
 		this.domElement.addEventListener( 'pointerup', this._onPointerUp );
 
+		this.domElement.style.touchAction = 'none'; // disable touch scroll
+
 	}
 
-	// updateMatrixWorld updates key transformation variables
-	updateMatrixWorld( force ) {
+	disconnect() {
 
-		if ( this.object !== undefined ) {
+		this.domElement.removeEventListener( 'pointerdown', this._onPointerDown );
+		this.domElement.removeEventListener( 'pointermove', this._onPointerHover );
+		this.domElement.removeEventListener( 'pointermove', this._onPointerMove );
+		this.domElement.removeEventListener( 'pointerup', this._onPointerUp );
 
-			this.object.updateMatrixWorld();
+		this.domElement.style.touchAction = 'auto';
 
-			if ( this.object.parent === null ) {
+	}
 
-				console.error( 'TransformControls: The attached 3D object must be a part of the scene graph.' );
+	getGizmo() {
 
-			} else {
-
-				this.object.parent.matrixWorld.decompose( this._parentPosition, this._parentQuaternion, this._parentScale );
-
-			}
-
-			this.object.matrixWorld.decompose( this.worldPosition, this.worldQuaternion, this._worldScale );
-
-			this._parentQuaternionInv.copy( this._parentQuaternion ).invert();
-			this._worldQuaternionInv.copy( this.worldQuaternion ).invert();
-
-		}
-
-		this.camera.updateMatrixWorld();
-		this.camera.matrixWorld.decompose( this.cameraPosition, this.cameraQuaternion, this._cameraScale );
-
-		if ( this.camera.isOrthographicCamera ) {
-
-			this.camera.getWorldDirection( this.eye ).negate();
-
-		} else {
-
-			this.eye.copy( this.cameraPosition ).sub( this.worldPosition ).normalize();
-
-		}
-
-		super.updateMatrixWorld( force );
+		return this._root;
 
 	}
 
@@ -555,10 +534,7 @@ class TransformControls extends Object3D {
 
 	dispose() {
 
-		this.domElement.removeEventListener( 'pointerdown', this._onPointerDown );
-		this.domElement.removeEventListener( 'pointermove', this._onPointerHover );
-		this.domElement.removeEventListener( 'pointermove', this._onPointerMove );
-		this.domElement.removeEventListener( 'pointerup', this._onPointerUp );
+		this.disconnect();
 
 		this.traverse( function ( child ) {
 
@@ -573,7 +549,7 @@ class TransformControls extends Object3D {
 	attach( object ) {
 
 		this.object = object;
-		this.visible = true;
+		this._root.visible = true;
 
 		return this;
 
@@ -583,8 +559,9 @@ class TransformControls extends Object3D {
 	detach() {
 
 		this.object = undefined;
-		this.visible = false;
 		this.axis = null;
+
+		this._root.visible = false;
 
 		return this;
 
@@ -777,6 +754,64 @@ const _unitZ = new Vector3( 0, 0, 1 );
 const _v1 = new Vector3();
 const _v2 = new Vector3();
 const _v3 = new Vector3();
+
+class TransformControlsRoot extends Object3D {
+
+	constructor( controls ) {
+
+		super();
+
+		this.isTransformControlsRoot = true;
+
+		this.controls = controls;
+		this.visible = false;
+
+	}
+
+	// updateMatrixWorld updates key transformation variables
+	updateMatrixWorld( force ) {
+
+		const controls = this.controls;
+
+		if ( controls.object !== undefined ) {
+
+			controls.object.updateMatrixWorld();
+
+			if ( controls.object.parent === null ) {
+
+				console.error( 'TransformControls: The attached 3D object must be a part of the scene graph.' );
+
+			} else {
+
+				controls.object.parent.matrixWorld.decompose( controls._parentPosition, controls._parentQuaternion, controls._parentScale );
+
+			}
+
+			controls.object.matrixWorld.decompose( controls.worldPosition, controls.worldQuaternion, controls._worldScale );
+
+			controls._parentQuaternionInv.copy( controls._parentQuaternion ).invert();
+			controls._worldQuaternionInv.copy( controls.worldQuaternion ).invert();
+
+		}
+
+		controls.camera.updateMatrixWorld();
+		controls.camera.matrixWorld.decompose( controls.cameraPosition, controls.cameraQuaternion, controls._cameraScale );
+
+		if ( controls.camera.isOrthographicCamera ) {
+
+			controls.camera.getWorldDirection( controls.eye ).negate();
+
+		} else {
+
+			controls.eye.copy( controls.cameraPosition ).sub( controls.worldPosition ).normalize();
+
+		}
+
+		super.updateMatrixWorld( force );
+
+	}
+
+}
 
 class TransformControlsGizmo extends Object3D {
 

--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -41,7 +41,7 @@ class TransformControls extends Controls {
 
 	constructor( camera, domElement = null ) {
 
-		super( camera, domElement );
+		super( undefined, domElement );
 
 		const root = new TransformControlsRoot( this );
 		this._root = root;

--- a/examples/misc_controls_transform.html
+++ b/examples/misc_controls_transform.html
@@ -78,7 +78,6 @@
 
 				control = new TransformControls( currentCamera, renderer.domElement );
 				control.addEventListener( 'change', render );
-
 				control.addEventListener( 'dragging-changed', function ( event ) {
 
 					orbit.enabled = ! event.value;
@@ -89,7 +88,9 @@
 				scene.add( mesh );
 
 				control.attach( mesh );
-				scene.add( control );
+
+				const gizmo = control.getGizmo();
+				scene.add( gizmo );
 
 				window.addEventListener( 'resize', onWindowResize );
 

--- a/examples/webgl_animation_skinning_ik.html
+++ b/examples/webgl_animation_skinning_ik.html
@@ -151,7 +151,7 @@
 			transformControls.showX = false;
 			transformControls.space = 'world';
 			transformControls.attach( OOI.target_hand_l );
-			scene.add( transformControls );
+			scene.add( transformControls.getGizmo() );
 
 			// disable orbitControls while using transformControls
 			transformControls.addEventListener( 'mouseDown', () => orbitControls.enabled = false );

--- a/examples/webgl_geometry_spline_editor.html
+++ b/examples/webgl_geometry_spline_editor.html
@@ -145,7 +145,7 @@
 					controls.enabled = ! event.value;
 
 				} );
-				scene.add( transformControl );
+				scene.add( transformControl.getGizmo() );
 
 				transformControl.addEventListener( 'objectChange', function () {
 

--- a/examples/webgl_modifier_curve.html
+++ b/examples/webgl_modifier_curve.html
@@ -191,7 +191,7 @@
 
 						const target = intersects[ 0 ].object;
 						control.attach( target );
-						scene.add( control );
+						scene.add( control.getGizmo() );
 
 					}
 

--- a/examples/webgl_modifier_curve_instanced.html
+++ b/examples/webgl_modifier_curve_instanced.html
@@ -221,7 +221,7 @@
 
 						const target = intersects[ 0 ].object;
 						control.attach( target );
-						scene.add( control );
+						scene.add( control.getGizmo() );
 
 					}
 

--- a/examples/webgl_shadowmap_progressive.html
+++ b/examples/webgl_shadowmap_progressive.html
@@ -76,7 +76,7 @@
 
 				} );
 				control.attach( lightOrigin );
-				scene.add( control );
+				scene.add( control.getGizmo() );
 
 				// create 8 directional lights to speed up the convergence
 				for ( let l = 0; l < lightCount; l ++ ) {
@@ -142,7 +142,7 @@
 
 					} );
 					control2.attach( object );
-					scene.add( control2 );
+					scene.add( control2.getGizmo() );
 					const lightTarget = new THREE.Group();
 					lightTarget.position.set( 0, 20, 0 );
 					for ( let l = 0; l < dirLights.length; l ++ ) {

--- a/examples/webgpu_tsl_compute_attractors_particles.html
+++ b/examples/webgpu_tsl_compute_attractors_particles.html
@@ -118,7 +118,7 @@
 					attractor.controls.attach( attractor.reference );
 					attractor.controls.visible = true;
 					attractor.controls.enabled = attractor.controls.visible;
-					scene.add( attractor.controls );
+					scene.add( attractor.controls.getGizmo() );
 			
 					attractor.controls.addEventListener( 'dragging-changed', ( event ) => {
 

--- a/examples/webxr_xr_controls_transform.html
+++ b/examples/webxr_xr_controls_transform.html
@@ -162,7 +162,7 @@
 
 				controls = new TransformControls( camera, renderer.domElement );
 				controls.attach( group.children[ 0 ] );
-				scene.add( controls );
+				scene.add( controls.getGizmo() );
 
 				//
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/29085

**Description**

Same as https://github.com/mrdoob/three.js/pull/29085.

This is a breaking change though. `TransformControls` was derived from `Object3D` so far which had pros and cons. You could add the controls directly to the scene to render the gizmo (the visual helpers) but the `Object3D` methods `attach()` and `detach()` were overwritten with control specific methods.

The new approach is conceptually cleaner and more consistent compared to all other controls. But since `TransformControls` is no 3D object anymore, developers must add the gizmo differently now. So instead of:
```js
scene.add( controls );
```
It is now:
```js
scene.add( controls.getGizmo() );
```