### PR TITLE
WebGL: Deprecate `isWebGLAvailable()` and `getWebGLErrorMessage()`.

### DIFF
--- a/examples/jsm/capabilities/WebGL.js
+++ b/examples/jsm/capabilities/WebGL.js
@@ -1,20 +1,5 @@
 class WebGL {
 
-	static isWebGLAvailable() {
-
-		try {
-
-			const canvas = document.createElement( 'canvas' );
-			return !! ( window.WebGLRenderingContext && ( canvas.getContext( 'webgl' ) || canvas.getContext( 'experimental-webgl' ) ) );
-
-		} catch ( e ) {
-
-			return false;
-
-		}
-
-	}
-
 	static isWebGL2Available() {
 
 		try {
@@ -44,12 +29,6 @@ class WebGL {
 			return false;
 
 		}
-
-	}
-
-	static getWebGLErrorMessage() {
-
-		return this.getErrorMessage( 1 );
 
 	}
 
@@ -100,6 +79,33 @@ class WebGL {
 		element.innerHTML = message;
 
 		return element;
+
+	}
+
+	// @deprecated, r168
+
+	static isWebGLAvailable() {
+
+		console.warn( 'isWebGLAvailable() has been deprecated and will be removed in r178. Use isWebGL2Available() instead.' );
+
+		try {
+
+			const canvas = document.createElement( 'canvas' );
+			return !! ( window.WebGLRenderingContext && ( canvas.getContext( 'webgl' ) || canvas.getContext( 'experimental-webgl' ) ) );
+
+		} catch ( e ) {
+
+			return false;
+
+		}
+
+	}
+
+	static getWebGLErrorMessage() {
+
+		console.warn( 'getWebGLErrorMessage() has been deprecated and will be removed in r178. Use getWebGL2ErrorMessage() instead.' );
+
+		return this.getErrorMessage( 1 );
 
 	}
 


### PR DESCRIPTION
Related issue: -

**Description**

Both methods have no purpose anymore since the engine can't be used with WebGL 1. Developers should use `isWebGL2Available()` and `getWebGL2ErrorMessage()` instead.