### PR TITLE
WebGPURenderer: fix occlusion when rendering to a texture with WebGL fallback

### DIFF
--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -230,6 +230,20 @@ class WebGLBackend extends Backend {
 		const renderContextData = this.get( renderContext );
 		const previousContext = renderContextData.previousContext;
 
+		const occlusionQueryCount = renderContext.occlusionQueryCount;
+
+		if ( occlusionQueryCount > 0 ) {
+
+			if ( occlusionQueryCount > renderContextData.occlusionQueryIndex ) {
+
+				gl.endQuery( gl.ANY_SAMPLES_PASSED );
+
+			}
+
+			this.resolveOccludedAsync( renderContext );
+
+		}
+
 		const textures = renderContext.textures;
 
 		if ( textures !== null ) {
@@ -249,7 +263,6 @@ class WebGLBackend extends Backend {
 		}
 
 		this._currentContext = previousContext;
-
 
 		if ( renderContext.textures !== null && renderContext.renderTarget ) {
 
@@ -288,7 +301,6 @@ class WebGLBackend extends Backend {
 
 					}
 
-
 				}
 
 			}
@@ -306,29 +318,9 @@ class WebGLBackend extends Backend {
 
 			} else {
 
-				const gl = this.gl;
-
 				gl.viewport( 0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight );
 
 			}
-
-		}
-
-		const occlusionQueryCount = renderContext.occlusionQueryCount;
-
-		if ( occlusionQueryCount > 0 ) {
-
-			const renderContextData = this.get( renderContext );
-
-			if ( occlusionQueryCount > renderContextData.occlusionQueryIndex ) {
-
-				const { gl } = this;
-
-				gl.endQuery( gl.ANY_SAMPLES_PASSED );
-
-			}
-
-			this.resolveOccludedAsync( renderContext );
 
 		}
 


### PR DESCRIPTION

The webgpu_occlusion example is currently broken, the blitFramebuffer operation is included in the scope of the query and produces an incorrect samples_passed count.

Fix this by moving endQuery() before other operations.

Also remove some duplicated consts. 