### PR TITLE
Examples: Clean up.

### DIFF
--- a/examples/jsm/objects/SkyMesh.js
+++ b/examples/jsm/objects/SkyMesh.js
@@ -175,7 +175,6 @@ class SkyMesh extends Mesh {
 
 		} )();
 
-		material.normals = false;
 		material.side = BackSide;
 		material.depthWrite = false;
 

--- a/examples/jsm/objects/Water2Mesh.js
+++ b/examples/jsm/objects/Water2Mesh.js
@@ -24,7 +24,6 @@ class WaterMesh extends Mesh {
 
 		this.isWater = true;
 
-		material.normals = false;
 		material.fragmentNode = new WaterNode( options, this );
 
 	}

--- a/examples/jsm/objects/WaterMesh.js
+++ b/examples/jsm/objects/WaterMesh.js
@@ -93,7 +93,6 @@ class WaterMesh extends Mesh {
 
 		} )();
 
-		material.normals = false;
 		material.fragmentNode = fragmentNode;
 
 	}


### PR DESCRIPTION
Related issue:  #29137

**Description**

Removes some remaining references to `NodeMaterial.normals`.