### PR TITLE
update loader docs to mention Request and ProgressEvent instead of XMLHttpRequest

### DIFF
--- a/docs/api/ar/loaders/AnimationLoader.html
+++ b/docs/api/ar/loaders/AnimationLoader.html
@@ -33,8 +33,8 @@
 			},
 	
 			// onProgress callback
-			function ( xhr ) {
-				console.log( (xhr.loaded / xhr.total * 100) + '% loaded' );
+			function ( event ) {
+				console.log( (event.loaded / event.total * 100) + '% loaded' );
 			},
 	
 			// onError callback

--- a/docs/api/ar/loaders/AudioLoader.html
+++ b/docs/api/ar/loaders/AudioLoader.html
@@ -51,8 +51,8 @@
 			},
 	
 			// onProgress callback
-			function ( xhr ) {
-				console.log( (xhr.loaded / xhr.total * 100) + '% loaded' );
+			function ( event ) {
+				console.log( (event.loaded / event.total * 100) + '% loaded' );
 			},
 	
 			// onError callback
@@ -87,7 +87,7 @@
 		[page:Function onLoad] — سيتم استدعاؤه عند اكتمال التحميل. الحجة
 		ستكون الاستجابة المحملة للنص.<br />
 		[page:Function onProgress] (اختياري) — سيتم استدعاؤه أثناء التقدم في التحميل
-		يتقدم. الحجة ستكون نسخة ProgressEvent، والتي
+		يتقدم. الحجة ستكون نسخة [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent ProgressEvent]، والتي
 		يحتوي على .[page:Boolean lengthComputable]، .[page:Integer total] و
 		.[page:Integer loaded]. إذا لم يضبط الخادم رأس Content-Length
 		.[page:Integer total] سيكون 0.<br />

--- a/docs/api/ar/loaders/BufferGeometryLoader.html
+++ b/docs/api/ar/loaders/BufferGeometryLoader.html
@@ -35,8 +35,8 @@
 			},
 	
 			// onProgress callback
-			function ( xhr ) {
-				console.log( (xhr.loaded / xhr.total * 100) + '% loaded' );
+			function ( event ) {
+				console.log( (event.loaded / event.total * 100) + '% loaded' );
 			},
 	
 			// onError callback
@@ -70,7 +70,7 @@
 		[page:Function onLoad] — سيتم استدعاؤه عند اكتمال التحميل. الحجة
 		ستكون المحمَّلة [page:BufferGeometry].<br />
 		[page:Function onProgress] (اختياري) — سيتم استدعاؤه أثناء التقدم في التحميل
-		يتقدم. الحجة ستكون نسخة ProgressEvent، والتي
+		يتقدم. الحجة ستكون نسخة [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent ProgressEvent]، والتي
 		يحتوي على .[page:Boolean lengthComputable]، .[page:Integer total] و
 		.[page:Integer loaded]. إذا لم يضبط الخادم رأس Content-Length
 		.[page:Integer total] سيكون 0.<br />

--- a/docs/api/ar/loaders/CompressedTextureLoader.html
+++ b/docs/api/ar/loaders/CompressedTextureLoader.html
@@ -50,7 +50,7 @@
 		[page:Function onLoad] (اختياري) — سيتم استدعاؤه عند اكتمال التحميل.
 		الحجة ستكون القوام المحمَّل.<br />
 		[page:Function onProgress] (اختياري) — سيتم استدعاؤه أثناء التقدم في التحميل
-		يتقدم. الحجة ستكون نسخة ProgressEvent، والتي
+		يتقدم. الحجة ستكون نسخة [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent ProgressEvent]، والتي
 		يحتوي على .[page:Boolean lengthComputable]، .[page:Integer total] و
 		.[page:Integer loaded]. إذا لم يضبط الخادم رأس Content-Length
 		.[page:Integer total] سيكون 0.<br />

--- a/docs/api/ar/loaders/DataTextureLoader.html
+++ b/docs/api/ar/loaders/DataTextureLoader.html
@@ -48,7 +48,7 @@
 		[page:Function onLoad] (اختياري) — سيتم استدعاؤه عند اكتمال التحميل.
 		الحجة ستكون القوام المحمَّلة.<br />
 		[page:Function onProgress] (اختياري) — سيتم استدعاؤه أثناء التقدم في التحميل
-		يتقدم. الحجة ستكون نسخة ProgressEvent، والتي تحتوي على
+		يتقدم. الحجة ستكون نسخة [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent ProgressEvent]، والتي تحتوي على
 		.[page:Boolean lengthComputable]، .[page:Integer total] و .[page:Integer loaded].
 		 إذا لم يضبط الخادم رأس Content-Length؛
 		.[page:Integer total] سيكون 0.<br />

--- a/docs/api/ar/loaders/FileLoader.html
+++ b/docs/api/ar/loaders/FileLoader.html
@@ -33,8 +33,8 @@
 			},
 	
 			// onProgress callback
-			function ( xhr ) {
-				console.log( (xhr.loaded / xhr.total * 100) + '% loaded' );
+			function ( event ) {
+				console.log( (event.loaded / event.total * 100) + '% loaded' );
 			},
 	
 			// onError callback
@@ -89,7 +89,7 @@
 		[page:Function onLoad] (اختياري) - سيتم استدعاؤه عند اكتمال التحميل.
 		الوسيطة ستكون الاستجابة المحملة.<br />
 		[page:Function onProgress] (اختياري) - سيتم استدعاؤه أثناء تقدم التحميل.
-		الوسيطة ستكون مثيل ProgressEvent ، والذي
+		الوسيطة ستكون مثيل [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent ProgressEvent] ، والذي
 		يحتوي على .[page:Boolean lengthComputable]، .[page:Integer total] و
 		.[page:Integer loaded]. إذا لم يضع الخادم رأس Content-Length
 		؛ .[page:Integer total] ستكون 0.<br />

--- a/docs/api/ar/loaders/ImageBitmapLoader.html
+++ b/docs/api/ar/loaders/ImageBitmapLoader.html
@@ -44,8 +44,8 @@
 			},
 	
 			// onProgress callback
-			function ( xhr ) {
-				console.log( (xhr.loaded / xhr.total * 100) + '% loaded' );
+			function ( event ) {
+				console.log( (event.loaded / event.total * 100) + '% loaded' );
 			},
 	
 			// onError callback

--- a/docs/api/ar/loaders/Loader.html
+++ b/docs/api/ar/loaders/Loader.html
@@ -30,7 +30,7 @@
 	 
 		<h3>[property:Boolean withCredentials]</h3>
 		<p>
-		ما إذا كان XMLHttpRequest يستخدم بيانات الاعتماد. انظر
+		ما إذا كان Request يستخدم بيانات الاعتماد. انظر
 		[page:.setWithCredentials]. الافتراضي هو `false`.
 		</p>
 	 
@@ -74,7 +74,7 @@
 		[page:String url] — سلسلة تحتوي على مسار / عنوان URL للملف المراد
 		تحميله.<br />
 		[page:Function onProgress] (اختياري) — وظيفة يتم استدعاؤها أثناء
-		التحميل قيد التقدم. ستكون الوسيطة هي مثيل ProgressEvent ،
+		التحميل قيد التقدم. ستكون الوسيطة هي مثيل [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent ProgressEvent] ،
 		الذي يحتوي على .[page:Boolean lengthComputable] ، .[page:Integer total] و
 		.[page:Integer loaded]. إذا لم يقم الخادم بتعيين رأس Content-Length ؛
 		.[page:Integer total] ستكون 0.<br />
@@ -104,9 +104,9 @@
 	 
 		<h3>[method:this setWithCredentials]( [param:Boolean value] )</h3>
 		<p>
-		ما إذا كان XMLHttpRequest يستخدم بيانات اعتماد مثل ملفات تعريف الارتباط ، ورؤوس التفويض
+		ما إذا كان Request يستخدم بيانات اعتماد مثل ملفات تعريف الارتباط ، ورؤوس التفويض
 		أو شهادات عميل TLS. انظر
-		[link:https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials XMLHttpRequest.withCredentials].<br />
+		[link:https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials Request.credentials].<br />
 		لاحظ أن هذا لا يؤثر إذا كنت تقوم بتحميل الملفات محليًا أو من
 		نفس المجال.
 		</p>

--- a/docs/api/ar/loaders/MaterialLoader.html
+++ b/docs/api/ar/loaders/MaterialLoader.html
@@ -33,8 +33,8 @@
 			},
 		
 			// onProgress callback
-			function ( xhr ) {
-				console.log( (xhr.loaded / xhr.total * 100) + '% loaded' );
+			function ( event ) {
+				console.log( (event.loaded / event.total * 100) + '% loaded' );
 			},
 		
 			// onError callback
@@ -73,7 +73,7 @@
 		[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />
 		[page:Function onLoad] — سيتم استدعاؤه عند اكتمال التحميل. الحجة
 		سيكون ال [page:Material] المحمّل.<br />
-		[page:Function onProgress] (اختياري) — سيتم استدعاؤه أثناء تقدم التحميل. الحجة ستكون مثيل ProgressEvent، والذي
+		[page:Function onProgress] (اختياري) — سيتم استدعاؤه أثناء تقدم التحميل. الحجة ستكون مثيل [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent ProgressEvent]، والذي
 		يحتوي على .[page:Boolean lengthComputable]، .[page:Integer total] و
 		.[page:Integer loaded]. إذا لم يضبط الخادم رأس Content-Length
 		؛ سيكون .[page:Integer total] 0.<br />

--- a/docs/api/ar/loaders/ObjectLoader.html
+++ b/docs/api/ar/loaders/ObjectLoader.html
@@ -34,8 +34,8 @@
 			},
 	
 			// onProgress callback
-			function ( xhr ) {
-				console.log( (xhr.loaded / xhr.total * 100) + '% loaded' );
+			function ( event ) {
+				console.log( (event.loaded / event.total * 100) + '% loaded' );
 			},
 	
 			// onError callback
@@ -78,7 +78,7 @@
 		[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />
 		[page:Function onLoad] — سيتم استدعاؤه عند اكتمال التحميل. الحجة
 		سيكون ال [page:Object3D object] المحمّل.<br />
-		[page:Function onProgress] (اختياري) — سيتم استدعاؤه أثناء تقدم التحميل. الحجة ستكون مثيل ProgressEvent، والذي
+		[page:Function onProgress] (اختياري) — سيتم استدعاؤه أثناء تقدم التحميل. الحجة ستكون مثيل [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent ProgressEvent]، والذي
 		يحتوي على .[page:Boolean lengthComputable]، .[page:Integer total] و
 		.[page:Integer loaded]. إذا لم يضبط الخادم رأس Content-Length
 		؛ سيكون .[page:Integer total] 0.<br />

--- a/docs/api/en/loaders/AnimationLoader.html
+++ b/docs/api/en/loaders/AnimationLoader.html
@@ -33,8 +33,8 @@
 			},
 
 			// onProgress callback
-			function ( xhr ) {
-				console.log( (xhr.loaded / xhr.total * 100) + '% loaded' );
+			function ( event ) {
+				console.log( (event.loaded / event.total * 100) + '% loaded' );
 			},
 
 			// onError callback
@@ -67,11 +67,7 @@
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />
 			[page:Function onLoad] — Will be called when load completes. The argument
 			will be the loaded [page:AnimationClip animation clips].<br />
-			[page:Function onProgress] (optional) — Will be called while load
-			progresses. The argument will be the ProgressEvent instance, which
-			contains .[page:Boolean lengthComputable], .[page:Integer total] and
-			.[page:Integer loaded]. If the server does not set the Content-Length
-			header; .[page:Integer total] will be 0.<br />
+			[page:Function onProgress] (optional) — Will be called while load progresses. The argument will be a [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent ProgressEvent] instance, which contains .[page:Boolean lengthComputable] if the length is known, .[page:Integer total] in bytes, and .[page:Integer loaded] in bytes. If the server does not set the "Content-Length" header, .[page:Integer total] will be 0.<br />
 			[page:Function onError] (optional) — Will be called if load errors.<br /><br />
 			Begin loading from url and pass the loaded animation to onLoad.
 		</p>

--- a/docs/api/en/loaders/AudioLoader.html
+++ b/docs/api/en/loaders/AudioLoader.html
@@ -51,8 +51,8 @@
 			},
 
 			// onProgress callback
-			function ( xhr ) {
-				console.log( (xhr.loaded / xhr.total * 100) + '% loaded' );
+			function ( event ) {
+				console.log( (event.loaded / event.total * 100) + '% loaded' );
 			},
 
 			// onError callback
@@ -86,11 +86,7 @@
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />
 			[page:Function onLoad] — Will be called when load completes. The argument
 			will be the loaded text response.<br />
-			[page:Function onProgress] (optional) — Will be called while load
-			progresses. The argument will be the ProgressEvent instance, which
-			contains .[page:Boolean lengthComputable], .[page:Integer total] and
-			.[page:Integer loaded]. If the server does not set the Content-Length
-			header; .[page:Integer total] will be 0.<br />
+			[page:Function onProgress] (optional) — Will be called while load progresses. The argument will be a [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent ProgressEvent] instance, which contains .[page:Boolean lengthComputable] if the length is known, .[page:Integer total] in bytes, and .[page:Integer loaded] in bytes. If the server does not set the "Content-Length" header, .[page:Integer total] will be 0.<br />
 			[page:Function onError] (optional) — Will be called when load errors.<br />
 		</p>
 		<p>

--- a/docs/api/en/loaders/BufferGeometryLoader.html
+++ b/docs/api/en/loaders/BufferGeometryLoader.html
@@ -35,8 +35,8 @@
 			},
 
 			// onProgress callback
-			function ( xhr ) {
-				console.log( (xhr.loaded / xhr.total * 100) + '% loaded' );
+			function ( event ) {
+				console.log( (event.loaded / event.total * 100) + '% loaded' );
 			},
 
 			// onError callback
@@ -69,11 +69,7 @@
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].d<br />
 			[page:Function onLoad] — Will be called when load completes. The argument
 			will be the loaded [page:BufferGeometry].<br />
-			[page:Function onProgress] (optional) — Will be called while load
-			progresses. The argument will be the ProgressEvent instance, which
-			contains .[page:Boolean lengthComputable], .[page:Integer total] and
-			.[page:Integer loaded]. If the server does not set the Content-Length
-			header; .[page:Integer total] will be 0.<br />
+			[page:Function onProgress] (optional) — Will be called while load progresses. The argument will be a [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent ProgressEvent] instance, which contains .[page:Boolean lengthComputable] if the length is known, .[page:Integer total] in bytes, and .[page:Integer loaded] in bytes. If the server does not set the "Content-Length" header, .[page:Integer total] will be 0.<br />
 			[page:Function onError] (optional) — Will be called when load errors.<br />
 		</p>
 		<p>

--- a/docs/api/en/loaders/FileLoader.html
+++ b/docs/api/en/loaders/FileLoader.html
@@ -33,8 +33,8 @@
 			},
 
 			// onProgress callback
-			function ( xhr ) {
-				console.log( (xhr.loaded / xhr.total * 100) + '% loaded' );
+			function ( event ) {
+				console.log( (event.loaded / event.total * 100) + '% loaded' );
 			},
 
 			// onError callback
@@ -88,11 +88,7 @@
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />
 			[page:Function onLoad] (optional) — Will be called when loading completes.
 			The argument will be the loaded response.<br />
-			[page:Function onProgress] (optional) — Will be called while load
-			progresses. The argument will be the ProgressEvent instance, which
-			contains .[page:Boolean lengthComputable], .[page:Integer total] and
-			.[page:Integer loaded]. If the server does not set the Content-Length
-			header; .[page:Integer total] will be 0.<br />
+			[page:Function onProgress] (optional) — Will be called while load progresses. The argument will be a [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent ProgressEvent] instance, which contains .[page:Boolean lengthComputable] if the length is known, .[page:Integer total] in bytes, and .[page:Integer loaded] in bytes. If the server does not set the "Content-Length" header, .[page:Integer total] will be 0.<br />
 			[page:Function onError] (optional) — Will be called if an error occurs.<br /><br />
 
 			Load the URL and pass the response to the onLoad function.

--- a/docs/api/en/loaders/Loader.html
+++ b/docs/api/en/loaders/Loader.html
@@ -30,7 +30,7 @@
 
 		<h3>[property:Boolean withCredentials]</h3>
 		<p>
-			Whether the XMLHttpRequest uses credentials. See
+			Whether the request uses credentials. See
 			[page:.setWithCredentials]. Default is `false`.
 		</p>
 
@@ -104,9 +104,9 @@
 
 		<h3>[method:this setWithCredentials]( [param:Boolean value] )</h3>
 		<p>
-			Whether the XMLHttpRequest uses credentials such as cookies, authorization
+			Whether the request uses credentials such as cookies, authorization
 			headers or TLS client certificates. See
-			[link:https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials XMLHttpRequest.withCredentials].<br />
+			[link:https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials Request.credentials].<br />
 			Note that this has no effect if you are loading files locally or from the
 			same domain.
 		</p>

--- a/docs/api/en/loaders/MaterialLoader.html
+++ b/docs/api/en/loaders/MaterialLoader.html
@@ -33,8 +33,8 @@
 			},
 
 			// onProgress callback
-			function ( xhr ) {
-				console.log( (xhr.loaded / xhr.total * 100) + '% loaded' );
+			function ( event ) {
+				console.log( (event.loaded / event.total * 100) + '% loaded' );
 			},
 
 			// onError callback
@@ -72,11 +72,7 @@
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />
 			[page:Function onLoad] — Will be called when load completes. The argument
 			will be the loaded [page:Material].<br />
-			[page:Function onProgress] (optional) — Will be called while load
-			progresses. The argument will be the ProgressEvent instance, which
-			contains .[page:Boolean lengthComputable], .[page:Integer total] and
-			.[page:Integer loaded]. If the server does not set the Content-Length
-			header; .[page:Integer total] will be 0.<br />
+			[page:Function onProgress] (optional) — Will be called while load progresses. The argument will be a [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent ProgressEvent] instance, which contains .[page:Boolean lengthComputable] if the length is known, .[page:Integer total] in bytes, and .[page:Integer loaded] in bytes. If the server does not set the "Content-Length" header, .[page:Integer total] will be 0.<br />
 			[page:Function onError] (optional) — Will be called when load errors.<br /><br />
 
 			Begin loading from url.

--- a/docs/api/en/loaders/ObjectLoader.html
+++ b/docs/api/en/loaders/ObjectLoader.html
@@ -34,8 +34,8 @@
 			},
 
 			// onProgress callback
-			function ( xhr ) {
-				console.log( (xhr.loaded / xhr.total * 100) + '% loaded' );
+			function ( event ) {
+				console.log( (event.loaded / event.total * 100) + '% loaded' );
 			},
 
 			// onError callback
@@ -78,11 +78,7 @@
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />
 			[page:Function onLoad] — Will be called when load completes. The argument
 			will be the loaded [page:Object3D object].<br />
-			[page:Function onProgress] (optional) — Will be called while load
-			progresses. The argument will be the ProgressEvent instance, which
-			contains .[page:Boolean lengthComputable], .[page:Integer total] and
-			.[page:Integer loaded]. If the server does not set the Content-Length
-			header; .[page:Integer total] will be 0.<br />
+			[page:Function onProgress] (optional) — Will be called while load progresses. The argument will be a [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent ProgressEvent] instance, which contains .[page:Boolean lengthComputable] if the length is known, .[page:Integer total] in bytes, and .[page:Integer loaded] in bytes. If the server does not set the "Content-Length" header, .[page:Integer total] will be 0.<br />
 			[page:Function onError] (optional) — Will be called when load errors.<br />
 		</p>
 		<p>

--- a/docs/api/it/loaders/AnimationLoader.html
+++ b/docs/api/it/loaders/AnimationLoader.html
@@ -33,8 +33,8 @@
 			},
 
 			// onProgress callback
-			function ( xhr ) {
-				console.log( (xhr.loaded / xhr.total * 100) + '% loaded' );
+			function ( event ) {
+				console.log( (event.loaded / event.total * 100) + '% loaded' );
 			},
 
 			// onError callback
@@ -64,7 +64,7 @@
 		[page:String url] — Il path o URL del file. Questo può anche essere un
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />
 		[page:Function onLoad] — Verrà chiamato quando il caricamento sarà completato. L'argomento saranno le [page:AnimationClip animation clip] caricate.<br />
-		[page:Function onProgress] (opzionale) — Verrà chiamato durante il caricamento. L'argomento sarà l'istanza ProgressEvent, la quale contiene .[page:Boolean lengthComputable], 
+		[page:Function onProgress] (opzionale) — Verrà chiamato durante il caricamento. L'argomento sarà l'istanza [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent ProgressEvent], la quale contiene .[page:Boolean lengthComputable], 
     .[page:Integer total] e .[page:Integer loaded]. Se il server non imposta l'header Content-Length; .[page:Integer total] sarà 0.<br />
 		[page:Function onError] (opzionale) — Verrà chiamato in caso di errori di caricamento.<br /><br />
 

--- a/docs/api/it/loaders/AudioLoader.html
+++ b/docs/api/it/loaders/AudioLoader.html
@@ -49,8 +49,8 @@
 			},
 
 			// onProgress callback
-			function ( xhr ) {
-				console.log( (xhr.loaded / xhr.total * 100) + '% loaded' );
+			function ( event ) {
+				console.log( (event.loaded / event.total * 100) + '% loaded' );
 			},
 
 			// onError callback
@@ -80,7 +80,7 @@
 		[page:String url] — Il path o URL del file. Questo può anche essere un
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />
 		[page:Function onLoad] —  Verrà chiamato quando il caricamento sarà completato. L'argomento sarà la risposta del testo caricato.<br />
-		[page:Function onProgress] (opzionale) — Verrà chiamato durante il caricamento. L'argomento sarà l'istanza ProgressEvent, la quale contiene
+		[page:Function onProgress] (opzionale) — Verrà chiamato durante il caricamento. L'argomento sarà l'istanza [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent ProgressEvent], la quale contiene
     .[page:Boolean lengthComputable], .[page:Integer total] e .[page:Integer loaded]. Se il server non imposta l'header Content-Length; .[page:Integer total] sarà 0.<br />
 		[page:Function onError] (opzionale) — Verrà chiamato in caso di errori di caricamento.<br />
 		</p>

--- a/docs/api/it/loaders/BufferGeometryLoader.html
+++ b/docs/api/it/loaders/BufferGeometryLoader.html
@@ -35,8 +35,8 @@
 			},
 
 			// onProgress callback
-			function ( xhr ) {
-				console.log( (xhr.loaded / xhr.total * 100) + '% loaded' );
+			function ( event ) {
+				console.log( (event.loaded / event.total * 100) + '% loaded' );
 			},
 
 			// onError callback
@@ -67,7 +67,7 @@
 		[page:String url] — Il path o URL del file. Questo può anche essere un
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />
 		[page:Function onLoad] —  Verrà chiamato quando il caricamento sarà completato. L'argomento sarà la [page:BufferGeometry] caricata.<br />
-		[page:Function onProgress] (opzionale) — Verrà chiamato durante il caricamento. L'argomento sarà l'istanza ProgressEvent, la quale contiene
+		[page:Function onProgress] (opzionale) — Verrà chiamato durante il caricamento. L'argomento sarà l'istanza [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent ProgressEvent], la quale contiene
      .[page:Boolean lengthComputable], .[page:Integer total] e .[page:Integer loaded]. Se il server non imposta l'header Content-Length; .[page:Integer total] sarà 0.<br />
 		[page:Function onError] (opzionale) — Verrà chiamato in caso di errori di caricamento.<br />
 		</p>

--- a/docs/api/it/loaders/CompressedTextureLoader.html
+++ b/docs/api/it/loaders/CompressedTextureLoader.html
@@ -45,7 +45,7 @@
 		[page:String url] — Il path o URL del file. Questo può anche essere un
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />
 		[page:Function onLoad] (opzionale) — Verrà chiamato quando il caricamento sarà completato. L'argomento sarà la texture caricata.<br />
-		[page:Function onProgress] (opzionale) — Verrà chiamato durante il caricamento. L'argomento sarà l'istanza ProgressEvent, la quale contiene 
+		[page:Function onProgress] (opzionale) — Verrà chiamato durante il caricamento. L'argomento sarà l'istanza [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent ProgressEvent], la quale contiene 
     .[page:Boolean lengthComputable], .[page:Integer total] e .[page:Integer loaded]. Se il server non imposta l'header Content-Length; .[page:Integer total] sarà 0.<br />
 		[page:Function onError] (opzionale) — Verrà chiamato in caso di errori di caricamento.<br />
 		</p>

--- a/docs/api/it/loaders/DataTextureLoader.html
+++ b/docs/api/it/loaders/DataTextureLoader.html
@@ -44,7 +44,7 @@
 		[page:String url] — Il path o URL del file. Questo può anche essere un
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />
 		[page:Function onLoad] (opzionale) — Verrà chiamato quando il caricamento sarà completato. L'argomento sarà la texture caricata.<br />
-		[page:Function onProgress] (opzionale) — Verrà chiamato durante il caricamento. L'argomento sarà l'istanza ProgressEvent, la quale contiene 
+		[page:Function onProgress] (opzionale) — Verrà chiamato durante il caricamento. L'argomento sarà l'istanza [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent ProgressEvent], la quale contiene 
     .[page:Boolean lengthComputable], .[page:Integer total] e .[page:Integer loaded]. Se il server non imposta l'header Content-Length; .[page:Integer total] sarà 0.<br />
 		[page:Function onError] (opzionale) — Verrà chiamato in caso di errori di caricamento.<br />
 		</p>

--- a/docs/api/it/loaders/FileLoader.html
+++ b/docs/api/it/loaders/FileLoader.html
@@ -33,8 +33,8 @@
 			},
 
 			// onProgress callback
-			function ( xhr ) {
-				console.log( (xhr.loaded / xhr.total * 100) + '% loaded' );
+			function ( event ) {
+				console.log( (event.loaded / event.total * 100) + '% loaded' );
 			},
 
 			// onError callback
@@ -80,7 +80,7 @@
 			[page:String url] — Il path o URL del file. Questo può anche essere un
 				[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />
 			[page:Function onLoad] (opzionale) — Verrà chiamato quando il caricamento sarà completato. L'argomento sarà la risposta caricata.<br />
-			[page:Function onProgress] (opzionale) — Verrà chiamato durante il caricamento. L'argomento sarà l'istanza ProgressEvent, che contiene
+			[page:Function onProgress] (opzionale) — Verrà chiamato durante il caricamento. L'argomento sarà l'istanza [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent ProgressEvent], che contiene
       .[page:Boolean lengthComputable], .[page:Integer total] e .[page:Integer loaded]. Se il server non imposta l'header Content-Length; .[page:Integer total] sarà 0.<br />
 			[page:Function onError] (opzionale) — Verrà chiamato in caso di errori di caricamento.<br /><br />
 

--- a/docs/api/it/loaders/Loader.html
+++ b/docs/api/it/loaders/Loader.html
@@ -34,7 +34,7 @@
 
 		<h3>[property:Boolean withCredentials]</h3>
 		<p>
-      Indica se XMLHttpRequest utilizza le credenziali. Vedi [page:.setWithCredentials].
+      Indica se Request utilizza le credenziali. Vedi [page:.setWithCredentials].
       Il valore predefinito è `false`.
 		</p>
 
@@ -71,7 +71,7 @@
 		<h3>[method:Promise loadAsync]( [param:String url], [param:Function onProgress] )</h3>
 		<p>
 		[page:String url] — Una stringa contenente il percorso/URL del file che deve essere caricato.<br />
-		[page:Function onProgress] (opzionale) — Una funzione da chiamare mentre il caricamento è in corso.  L'argomento sarà l'istanza ProgressEvent, la quale contiene
+		[page:Function onProgress] (opzionale) — Una funzione da chiamare mentre il caricamento è in corso.  L'argomento sarà l'istanza [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent ProgressEvent], la quale contiene
     .[page:Boolean lengthComputable], .[page:Integer total] e .[page:Integer loaded]. Se il server non imposta l'header Content-Length; .[page:Integer total] sarà 0.<br />
 		</p>
 		<p>
@@ -94,8 +94,8 @@
 
 		<h3>[method:this setWithCredentials]( [param:Boolean value] )</h3>
 		<p>
-      Indica se XMLHttpRequest utilizza le credenziali come cookie, header di autorizzazione o
-      certificati client TLS. Vedi [link:https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials XMLHttpRequest.withCredentials].<br />
+      Indica se Request utilizza le credenziali come cookie, header di autorizzazione o
+      certificati client TLS. Vedi [link:https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials Request.credentials].<br />
       Si noti che non ha effetti se stai caricando file localmente o dallo stesso dominio.
 		</p>
 

--- a/docs/api/it/loaders/MaterialLoader.html
+++ b/docs/api/it/loaders/MaterialLoader.html
@@ -33,8 +33,8 @@
 			},
 
 			// onProgress callback
-			function ( xhr ) {
-				console.log( (xhr.loaded / xhr.total * 100) + '% loaded' );
+			function ( event ) {
+				console.log( (event.loaded / event.total * 100) + '% loaded' );
 			},
 
 			// onError callback
@@ -67,7 +67,7 @@
 		[page:String url] — Il path o URL del file. Questo può anche essere un
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />
 		[page:Function onLoad] — Verrà chiamato quando il caricamento sarà completato. L'argomento sarà il [page:Material Materiale] caricato.<br />
-		[page:Function onProgress] (opzionale) — Verrà chiamato durante il caricamento. L'argomento sarà l'istanza ProgressEvent, la quale contiene 
+		[page:Function onProgress] (opzionale) — Verrà chiamato durante il caricamento. L'argomento sarà l'istanza [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent ProgressEvent], la quale contiene 
     .[page:Boolean lengthComputable], .[page:Integer total] e .[page:Integer loaded]. 
     Se il server non imposta l'header Content-Length; .[page:Integer total] sarà 0.<br />
 		[page:Function onError] (opzionale) — Verrà chiamato in caso di errori di caricamento.<br /><br />

--- a/docs/api/it/loaders/ObjectLoader.html
+++ b/docs/api/it/loaders/ObjectLoader.html
@@ -36,8 +36,8 @@
 			},
 
 			// onProgress callback
-			function ( xhr ) {
-				console.log( (xhr.loaded / xhr.total * 100) + '% loaded' );
+			function ( event ) {
+				console.log( (event.loaded / event.total * 100) + '% loaded' );
 			},
 
 			// onError callback
@@ -79,7 +79,7 @@
 		[page:String url] — Il path o URL del file. Questo può anche essere un
 			[link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs Data URI].<br />
 		[page:Function onLoad] — Verrà chiamato quando il caricamento sarà completato. L'argomento sarà l'[page:Object3D oggetto] caricato.<br />
-		[page:Function onProgress] (opzionale) — Verrà chiamato durante il caricamento. L'argomento sarà l'istanza ProgressEvent, la quale contiene 
+		[page:Function onProgress] (opzionale) — Verrà chiamato durante il caricamento. L'argomento sarà l'istanza [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent ProgressEvent], la quale contiene 
     .[page:Boolean lengthComputable], .[page:Integer total] e .[page:Integer loaded]. 
     Se il server non imposta l'header Content-Length; .[page:Integer total] sarà 0.<br />
 		[page:Function onError] (opzionale) — Verrà chiamato in caso di errori di caricamento.<br />

--- a/docs/api/zh/loaders/AnimationLoader.html
+++ b/docs/api/zh/loaders/AnimationLoader.html
@@ -33,8 +33,8 @@
 			},
 
 			// onProgress回调
-			function ( xhr ) {
-				console.log( (xhr.loaded / xhr.total * 100) + '% loaded' );
+			function ( event ) {
+				console.log( (event.loaded / event.total * 100) + '% loaded' );
 			},
 
 			// onError回调

--- a/docs/api/zh/loaders/AudioLoader.html
+++ b/docs/api/zh/loaders/AudioLoader.html
@@ -50,8 +50,8 @@
 			},
 
 			// onProgress回调
-			function ( xhr ) {
-				console.log( (xhr.loaded / xhr.total * 100) + '% loaded' );
+			function ( event ) {
+				console.log( (event.loaded / event.total * 100) + '% loaded' );
 			},
 
 			// onError回调

--- a/docs/api/zh/loaders/BufferGeometryLoader.html
+++ b/docs/api/zh/loaders/BufferGeometryLoader.html
@@ -35,8 +35,8 @@
 			},
 
 			// onProgress回调
-			function ( xhr ) {
-				console.log( (xhr.loaded / xhr.total * 100) + '% loaded' );
+			function ( event ) {
+				console.log( (event.loaded / event.total * 100) + '% loaded' );
 			},
 
 			// onError回调

--- a/docs/api/zh/loaders/FileLoader.html
+++ b/docs/api/zh/loaders/FileLoader.html
@@ -32,8 +32,8 @@
 			},
 
 			// onProgress回调
-			function ( xhr ) {
-				console.log( (xhr.loaded / xhr.total * 100) + '% loaded' );
+			function ( event ) {
+				console.log( (event.loaded / event.total * 100) + '% loaded' );
 			},
 
 			// onError回调

--- a/docs/api/zh/loaders/MaterialLoader.html
+++ b/docs/api/zh/loaders/MaterialLoader.html
@@ -33,8 +33,8 @@
 			},
 
 			// onProgress回调
-			function ( xhr ) {
-				console.log( (xhr.loaded / xhr.total * 100) + '% loaded' );
+			function ( event ) {
+				console.log( (event.loaded / event.total * 100) + '% loaded' );
 			},
 
 			// onError回调

--- a/docs/api/zh/loaders/ObjectLoader.html
+++ b/docs/api/zh/loaders/ObjectLoader.html
@@ -34,8 +34,8 @@
 			},
 
 			// onProgress回调
-			function ( xhr ) {
-				console.log( (xhr.loaded / xhr.total * 100) + '% loaded' );
+			function ( event ) {
+				console.log( (event.loaded / event.total * 100) + '% loaded' );
 			},
 
 			// onError回调

--- a/docs/examples/en/loaders/GLTFLoader.html
+++ b/docs/examples/en/loaders/GLTFLoader.html
@@ -103,9 +103,9 @@
 
 			},
 			// called while loading is progressing
-			function ( xhr ) {
+			function ( event ) {
 
-				console.log( ( xhr.loaded / xhr.total * 100 ) + '% loaded' );
+				console.log( ( event.loaded / event.total * 100 ) + '% loaded' );
 
 			},
 			// called when loading has errors
@@ -182,7 +182,7 @@
 		<p>
 		[page:String url] — A string containing the path/URL of the `.gltf` or `.glb` file.<br />
 		[page:Function onLoad] — A function to be called after the loading is successfully completed. The function receives the loaded JSON response returned from [page:Function parse].<br />
-		[page:Function onProgress] — (optional) A function to be called while the loading is in progress. The argument will be the XMLHttpRequest instance, that contains .[page:Integer total] and .[page:Integer loaded] bytes. If the server does not set the Content-Length header; .[page:Integer total] will be 0.<br />
+		[page:Function onProgress] (optional) — Will be called while load progresses. The argument will be a [link:https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent ProgressEvent] instance, which contains .[page:Boolean lengthComputable] if the length is known, .[page:Integer total] in bytes, and .[page:Integer loaded] in bytes. If the server does not set the "Content-Length" header, .[page:Integer total] will be 0.<br />
 		[page:Function onError] — (optional) A function to be called if an error occurs during loading. The function receives error as an argument.<br />
 		</p>
 		<p>


### PR DESCRIPTION

**Description**

Some docs had dated info about XMLHttpRequest, but loaders now use `fetch()` with `ProgressEvent`s.

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Lume, an ever-modern next-gen 3D HTML framework](https://lume.io)*
