### PR TITLE
WebGPURenderer: Fix linear filter textures w/o mipmaps

### DIFF
--- a/src/renderers/webgl-fallback/utils/WebGLTextureUtils.js
+++ b/src/renderers/webgl-fallback/utils/WebGLTextureUtils.js
@@ -259,8 +259,10 @@ class WebGLTextureUtils {
 		gl.texParameteri( textureType, gl.TEXTURE_MAG_FILTER, filterToGL[ texture.magFilter ] );
 
 
+		const hasMipmaps = texture.mipmaps !== undefined && texture.mipmaps.length > 0;
+
 		// follow WebGPU backend mapping for texture filtering
-		const minFilter = ! texture.isVideoTexture && texture.minFilter === LinearFilter ? LinearMipmapLinearFilter : texture.minFilter;
+		const minFilter = texture.minFilter === LinearFilter && hasMipmaps ? LinearMipmapLinearFilter : texture.minFilter;
 
 		gl.texParameteri( textureType, gl.TEXTURE_MIN_FILTER, filterToGL[ minFilter ] );
 


### PR DESCRIPTION
Related issue: #27071

**Description**

This PR addresses an issue in the WebGL backend where textures using linear filtering without mipmaps are rendered as completely black. The problem was caused by incorrect filtering, specifically the use of `LinearMipmapLinearFilter` instead of the appropriate filter for non-mipmapped textures.

For more context, an initial fix was made to address video textures breaking in the examples. However, this fix was only partial, as it did not cover all cases and still affects any linear filtered texture without mipmaps. More details in the related PR: 
https://github.com/mrdoob/three.js/pull/27610


*This contribution is funded by [Utsubo](https://utsubo.com)*
