### PR TITLE
WebGPURenderer: Fix BatchedMesh with indexed geometry

### DIFF
--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -955,14 +955,14 @@ class WebGPUBackend extends Backend {
 			const drawCount = object._multiDrawCount;
 			const drawInstances = object._multiDrawInstances;
 
-			const bytesPerElement = hasIndex ? index.bytesPerElement : 1;
+			const bytesPerElement = hasIndex ? index.array.BYTES_PER_ELEMENT : 1;
 
 			for ( let i = 0; i < drawCount; i ++ ) {
 
 				const count = drawInstances ? drawInstances[ i ] : 1;
 				const firstInstance = count > 1 ? 0 : i;
 
-				passEncoderGPU.drawIndexed( counts[ i ] / bytesPerElement, count, starts[ i ] / 4, 0, firstInstance );
+				passEncoderGPU.drawIndexed( counts[ i ], count, starts[ i ] / bytesPerElement, 0, firstInstance );
 
 			}
 


### PR DESCRIPTION
Related issue: #29140

**Description**

The recent change in #29140 broke the BatchedMesh in the WebGPUBackend (example included). The issue is that `attribute.bytesPerElement`, for example `index.bytesPerElement` doesn't exist in the WebGPUBackend and the way `drawIndexed` was called wasn't actually correct. This PR fixes these issues.


*This contribution is funded by [Utsubo](https://utsubo.com)*
