### PR TITLE
WebGPURenderer: Align WebGL backend extensions initialization with WebGLRenderer

### DIFF
--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -53,6 +53,11 @@ class WebGLBackend extends Backend {
 		this.trackTimestamp = ( parameters.trackTimestamp === true );
 
 		this.extensions.get( 'EXT_color_buffer_float' );
+		this.extensions.get( 'WEBGL_clip_cull_distance' );
+		this.extensions.get( 'OES_texture_float_linear' );
+		this.extensions.get( 'EXT_color_buffer_half_float' );
+		this.extensions.get( 'WEBGL_multisampled_render_to_texture' );
+		this.extensions.get( 'WEBGL_render_shared_exponent' );
 		this.extensions.get( 'WEBGL_multi_draw' );
 
 		this.disjoint = this.extensions.get( 'EXT_disjoint_timer_query_webgl2' );


### PR DESCRIPTION
**Description**

This PR align the behavior of the WebGLBackend with the WebGLRenderer (taken from `WebGLExtensions.init`).

This fixes multiple silent issues and improve compatibility for the upcoming migration, for instance, this change ensures that libraries relying on float32 textures with linear filtering do not break (as it depends on the `OES_texture_float_linear` extension).


<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Utsubo](https://utsubo.com)*
