### PR TITLE
XRControllerModelFactory: Prevent hand input source processing.

### DIFF
--- a/examples/jsm/webxr/XRControllerModelFactory.js
+++ b/examples/jsm/webxr/XRControllerModelFactory.js
@@ -239,7 +239,7 @@ class XRControllerModelFactory {
 
 			const xrInputSource = event.data;
 
-			if ( xrInputSource.targetRayMode !== 'tracked-pointer' || ! xrInputSource.gamepad ) return;
+			if ( xrInputSource.targetRayMode !== 'tracked-pointer' || ! xrInputSource.gamepad || xrInputSource.hand ) return;
 
 			fetchProfile( xrInputSource, this.path, DEFAULT_PROFILE ).then( ( { profile, assetPath } ) => {
 


### PR DESCRIPTION
**Description**

This fixes the `Could not find xr_standard_trigger_pressed_min in the model` warning seen in three.js examples that use hand inputs: e.g. [webxr_vr_handinput.html](https://github.com/mrdoob/three.js/blob/master/examples/webxr_vr_handinput.html).

It also prevents unnecessary processing by the device, since `XRControllerModelFactory` is meant for non-hand input sources: i.e. controller models. 

When hand tracking is enabled for a WebXR capable device and `new XRControllerModelFactory()` is used, its `connected` event listener does not currently prevent a hand input source from also calling `fetchProfile()`.  

This adds a check to prevent a hand input source from also calling `fetchProfile()`.

