### PR TITLE
Quaternion: Add "toAxisAngle" function

### DIFF
--- a/docs/api/en/math/Quaternion.html
+++ b/docs/api/en/math/Quaternion.html
@@ -249,6 +249,16 @@
 		</p>
 
 		<h3>
+			[method:Number toAxisAngle]( [param:Vector3 axisTarget] )
+		</h3>
+		<p>
+			Sets the [page:Vector3 axisTarget] to the rotation axis of this quaternion and returns the signed
+			[page:Float angle] of rotation about that axis.<br />
+			Adapted from the method
+			[link:https://www.euclideanspace.com/maths/geometry/rotations/conversions/quaternionToAngle/index.htm here].
+		</p>
+
+		<h3>
 			[method:Array toArray]( [param:Array array], [param:Integer offset] )
 		</h3>
 		<p>

--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -272,6 +272,25 @@ class Quaternion {
 
 	}
 
+	toAxisAngle( axisTarget ) {
+
+		// https://www.euclideanspace.com/maths/geometry/rotations/conversions/quaternionToAngle/index.htm
+
+		const qx = this.x;
+		const qy = this.y;
+		const qz = this.z;
+		const qw = this.w;
+
+		const angle = 2 * Math.acos( qw );
+		const x = qx / Math.sqrt( 1 - qw * qw );
+		const y = qy / Math.sqrt( 1 - qw * qw );
+		const z = qz / Math.sqrt( 1 - qw * qw );
+
+		axisTarget.set( x, y, z );
+		return angle;
+
+	}
+
 	setFromAxisAngle( axis, angle ) {
 
 		// http://www.euclideanspace.com/maths/geometry/rotations/conversions/angleToQuaternion/index.htm


### PR DESCRIPTION
Related issue: --

**Description**

Adds a `Quaternion.toAxisAngle` function that returns the axis of rotation and rotation angle about that axis. Based on the equations from [here](https://www.euclideanspace.com/maths/geometry/rotations/conversions/quaternionToAngle/index.htm)

I needed this for implementing this inertial animation for GlobeControls in 3D Tiles Renderer so I figured I'd add it here (https://github.com/NASA-AMMOS/3DTilesRendererJS/pull/703).