### PR TITLE
WebGPURenderer: Reduce bindingGroup creation for data texture content updates.

### DIFF
--- a/src/renderers/common/Backend.js
+++ b/src/renderers/common/Backend.js
@@ -43,9 +43,9 @@ class Backend {
 
 	// bindings
 
-	createBindings( /*renderObject*/ ) { }
+	createBindings( /*bingGroup, bindings*/ ) { }
 
-	updateBindings( /*renderObject*/ ) { }
+	updateBindings( /*bingGroup, bindings*/ ) { }
 
 	// pipeline
 

--- a/src/renderers/common/Bindings.js
+++ b/src/renderers/common/Bindings.js
@@ -70,21 +70,21 @@ class Bindings extends DataMap {
 
 	updateForCompute( computeNode ) {
 
-		this._updateBindings( computeNode, this.getForCompute( computeNode ) );
+		this._updateBindings( this.getForCompute( computeNode ) );
 
 	}
 
 	updateForRender( renderObject ) {
 
-		this._updateBindings( renderObject, this.getForRender( renderObject ) );
+		this._updateBindings( this.getForRender( renderObject ) );
 
 	}
 
-	_updateBindings( object, bindings ) {
+	_updateBindings( bindings ) {
 
 		for ( const bindGroup of bindings ) {
 
-			this._update( object, bindGroup, bindings );
+			this._update( bindGroup, bindings );
 
 		}
 
@@ -110,7 +110,7 @@ class Bindings extends DataMap {
 
 	}
 
-	_update( object, bindGroup, bindings ) {
+	_update( bindGroup, bindings ) {
 
 		const { backend } = this;
 
@@ -144,26 +144,26 @@ class Bindings extends DataMap {
 
 			} else if ( binding.isSampledTexture ) {
 
-				const texture = binding.texture;
-
-				if ( binding.needsBindingsUpdate ) needsBindingsUpdate = true;
+				if ( binding.needsBindingsUpdate( this.textures.get( binding.texture ).generation ) ) needsBindingsUpdate = true;
 
 				const updated = binding.update();
 
+				const texture = binding.texture;
+
 				if ( updated ) {
 
-					this.textures.updateTexture( binding.texture );
+					this.textures.updateTexture( texture );
 
 				}
 
-				const textureData = backend.get( binding.texture );
+				const textureData = backend.get( texture );
 
 				if ( backend.isWebGPUBackend === true && textureData.texture === undefined && textureData.externalTexture === undefined ) {
 
 					// TODO: Remove this once we found why updated === false isn't bound to a texture in the WebGPU backend
-					console.error( 'Bindings._update: binding should be available:', binding, updated, binding.texture, binding.textureNode.value );
+					console.error( 'Bindings._update: binding should be available:', binding, updated, texture, binding.textureNode.value, needsBindingsUpdate );
 
-					this.textures.updateTexture( binding.texture );
+					this.textures.updateTexture( texture );
 					needsBindingsUpdate = true;
 
 				}
@@ -192,9 +192,7 @@ class Bindings extends DataMap {
 
 		if ( needsBindingsUpdate === true ) {
 
-			const pipeline = this.pipelines.getForRender( object );
-
-			this.backend.updateBindings( bindGroup, bindings, pipeline );
+			this.backend.updateBindings( bindGroup, bindings );
 
 		}
 

--- a/src/renderers/common/SampledTexture.js
+++ b/src/renderers/common/SampledTexture.js
@@ -13,16 +13,25 @@ class SampledTexture extends Binding {
 		this.texture = texture;
 		this.version = texture ? texture.version : 0;
 		this.store = false;
+		this.generation = null;
 
 		this.isSampledTexture = true;
 
 	}
 
-	get needsBindingsUpdate() {
+	needsBindingsUpdate( generation ) {
 
-		const { texture, version } = this;
+		const { texture } = this;
 
-		return texture.isVideoTexture ? true : version !== texture.version; // @TODO: version === 0 && texture.version > 0 ( add it just to External Textures like PNG,JPG )
+		if ( generation !== this.generation ) {
+
+			this.generation = generation;
+
+			return true;
+
+		}
+
+		return texture.isVideoTexture;
 
 	}
 

--- a/src/renderers/common/Textures.js
+++ b/src/renderers/common/Textures.js
@@ -173,6 +173,8 @@ class Textures extends DataMap {
 			backend.createSampler( texture );
 			backend.createTexture( texture, options );
 
+			textureData.generation = texture.version;
+
 		} else {
 
 			const needsCreate = textureData.initialized !== true;
@@ -216,6 +218,7 @@ class Textures extends DataMap {
 						backend.createTexture( texture, options );
 
 						textureData.isDefaultTexture = false;
+						textureData.generation = texture.version;
 
 					}
 
@@ -232,6 +235,7 @@ class Textures extends DataMap {
 				backend.createDefaultTexture( texture );
 
 				textureData.isDefaultTexture = true;
+				textureData.generation = texture.version;
 
 			}
 
@@ -242,6 +246,7 @@ class Textures extends DataMap {
 		if ( textureData.initialized !== true ) {
 
 			textureData.initialized = true;
+			textureData.generation = texture.version;
 
 			//
 

--- a/src/renderers/common/nodes/NodeSampledTexture.js
+++ b/src/renderers/common/nodes/NodeSampledTexture.js
@@ -13,9 +13,9 @@ class NodeSampledTexture extends SampledTexture {
 
 	}
 
-	get needsBindingsUpdate() {
+	needsBindingsUpdate( generation ) {
 
-		return this.textureNode.value !== this.texture || super.needsBindingsUpdate;
+		return this.textureNode.value !== this.texture || super.needsBindingsUpdate( generation );
 
 	}
 


### PR DESCRIPTION

The example webgpu_instancing_morph creates a new bindingGroup and textureView each frame when the DataArrayTexture contents are updated, which is redundant.

Rework the conditions for recreating a binding group, such that texture content only changes are ignored.

Also the backend updateBindings() and createBindings() methods do not take a pipeline object, update the base backend class and  calling functions.