### PR TITLE
WebGLRenderer: Merge update ranges before issuing updates to the GPU.

### DIFF
--- a/src/renderers/webgl/WebGLAttributes.js
+++ b/src/renderers/webgl/WebGLAttributes.js
@@ -90,6 +90,50 @@ function WebGLAttributes( gl ) {
 
 		if ( updateRanges.length !== 0 ) {
 
+			// Before applying update ranges, we merge any adjacent / overlapping
+			// ranges to reduce load on `gl.bufferSubData`. Empirically, this has lead
+			// to performance improvements for applications which make heavy use of
+			// update ranges. Likely due to GPU command overhead.
+			//
+			// Note that to reduce garbage collection between frames, we merge the
+			// update ranges in-place. This is safe because this method will clear the
+			// update ranges once updated.
+
+			updateRanges.sort( ( a, b ) => a.start - b.start );
+
+			// To merge the update ranges in-place, we work from left to right in the
+			// existing updateRanges array, merging ranges. This may result in a final
+			// array which is smaller than the original. This index tracks the last
+			// index representing a merged range, any data after this index can be
+			// trimmed once the merge algorithm is completed.
+			let mergeIndex = 0;
+
+			for ( let i = 1; i < updateRanges.length; i ++ ) {
+
+				const previousRange = updateRanges[ mergeIndex ];
+				const range = updateRanges[ i ];
+
+				// We add one here to merge adjacent ranges. This is safe because ranges
+				// operate over positive integers.
+				if ( range.start <= previousRange.start + previousRange.count + 1 ) {
+
+					previousRange.count = Math.max(
+						previousRange.count,
+						range.start + range.count - previousRange.start
+					);
+
+				} else {
+
+					++ mergeIndex;
+					updateRanges[ mergeIndex ] = range;
+
+				}
+
+			}
+
+			// Trim the array to only contain the merged ranges.
+			updateRanges.length = mergeIndex + 1;
+
 			for ( let i = 0, l = updateRanges.length; i < l; i ++ ) {
 
 				const range = updateRanges[ i ];

--- a/src/renderers/webgl/WebGLAttributes.js
+++ b/src/renderers/webgl/WebGLAttributes.js
@@ -91,7 +91,7 @@ function WebGLAttributes( gl ) {
 		if ( updateRanges.length !== 0 ) {
 
 			// Before applying update ranges, we merge any adjacent / overlapping
-			// ranges to reduce load on `gl.bufferSubData`. Empirically, this has lead
+			// ranges to reduce load on `gl.bufferSubData`. Empirically, this has led
 			// to performance improvements for applications which make heavy use of
 			// update ranges. Likely due to GPU command overhead.
 			//


### PR DESCRIPTION
TLDR: this PR achieves up to 3 orders of magnitude performance improvement when updating a large number of adjacent ranges within `InstancedBufferAttribute` which is a common use case for projects heavily leveraging instancing.

**Description**

[BufferAttribute#addUpdateRange](https://threejs.org/docs/#api/en/core/BufferAttribute.addUpdateRange) can be used with `needsUpdate` so that three only transfers subsections of data to the GPU. This is a powerful feature which allows clients to better manage CPU<>GPU bandwidth. For example, in cases where a BufferAttribute may be several MB large and only a few bytes change per frame, clients can transfer only the changed bytes instead of the entire buffer.

In our product we've seen large improvement gains using update ranges, but frame drops in cases where many update ranges are present in a single frame. This can easily be observed with [InstancedBufferAttribute](https://threejs.org/docs/#api/en/core/InstancedBufferAttribute). In a project which heavily leverages `InstancedMesh` and therefore `InstancedBufferAttribute` to represent instance data, it's commonly required that individual instances are updated using `addUpdateRange`. In a frame where all instances need to be updated, this can create a large number of update ranges which are nearly all adjacent. As a result we observe a large number of avoidable `gl.bufferSubData` calls and frame drops (I imagine due to GPU command overhead).

This PR automatically merges overlapping / adjacent update ranges _before_ calling `gl.bufferSubData` and results in up to a 99.78% wall time reduction rendering our project (see below for details)

**Impact**

In a toy example within our company, I created a scene with 10k plane geometries (via `InstancedMesh`) which are positioned by vec3's interleaved via `InstancedBufferAttribute`. Updating all 10k positions in a single frame on a 2021 M1 Macbook Pro takes 112.21ms in three.js today, when run on this this PR it takes 0.25ms instead.

**Design Notes**

1. I added this logic in the renderers code as opposed to `addUpdateRange` where we could amortize the merging costs because clients are allowed to directly manipulate the `updateRanges` array. Adding this logic to the renderers ensures robustness regardless of how clients interact with update ranges.
2. I'd be happy to apply this change to WebGPU and WebGL-Fallback if there's interest.
3. I'd love to add unit tests, but there are currently no unit tests for `WebGLAttributes` making it challenging to envision how we'd mock `gl` when instantiating `WebGLAttributes`. If there's a suggestion here, I'd love to hear it.

*This contribution is funded by [SOOT](https://soot.com)*