### PR TITLE
ViewportNode: Honor the renderer pixel ratio when using `viewport`.

### DIFF
--- a/src/nodes/display/ViewportNode.js
+++ b/src/nodes/display/ViewportNode.js
@@ -50,6 +50,9 @@ class ViewportNode extends Node {
 
 			renderer.getViewport( viewportResult );
 
+			const ratio = renderer.getPixelRatio();
+			viewportResult.multiplyScalar( ratio );
+
 		} else {
 
 			renderer.getDrawingBufferSize( resolution );


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/29162

**Description**

Honor the renderer pixel ratio when using `viewport`.

/cc @WestLangley 