### PR TITLE
Nodes: OperatorNode - Maintain Variable Types In Comparison 

### DIFF
--- a/src/nodes/math/OperatorNode.js
+++ b/src/nodes/math/OperatorNode.js
@@ -116,7 +116,7 @@ class OperatorNode extends TempNode {
 
 					typeB = typeA;
 
-				} else {
+				} else if ( typeA !== typeB ) {
 
 					typeA = typeB = 'float';
 


### PR DESCRIPTION
**Description**

Maintains the types of variables used in a comparison operation unless they are different, in which case they are converted to floats.

This prevents TSL code where the user explicitly defines a non-float comparison between two values from resolving to a float comparison.

TSL Code: 
```typescript

const uTest = uniform( uint( 1 ) )
// etc
If( uTest.equal( uint( 1 ) ), () => {

```

WGSL Output: 
```typescript

// uTest variable
nodeUniform1: u32 

// Current Code
if ( ( f32( object.nodeUniform1 ) == f32( 1u ) )

// Changed Code
if ( ( object.nodeUniform1 == 1u ) )

```