### PR TITLE
PCDLoader: Fix regex to match header fields at line start

### DIFF
--- a/examples/jsm/loaders/PCDLoader.js
+++ b/examples/jsm/loaders/PCDLoader.js
@@ -127,15 +127,15 @@ class PCDLoader extends Loader {
 
 			// parse
 
-			PCDheader.version = /VERSION (.*)/i.exec( PCDheader.str );
-			PCDheader.fields = /FIELDS (.*)/i.exec( PCDheader.str );
-			PCDheader.size = /SIZE (.*)/i.exec( PCDheader.str );
-			PCDheader.type = /TYPE (.*)/i.exec( PCDheader.str );
-			PCDheader.count = /COUNT (.*)/i.exec( PCDheader.str );
-			PCDheader.width = /WIDTH (.*)/i.exec( PCDheader.str );
-			PCDheader.height = /HEIGHT (.*)/i.exec( PCDheader.str );
-			PCDheader.viewpoint = /VIEWPOINT (.*)/i.exec( PCDheader.str );
-			PCDheader.points = /POINTS (.*)/i.exec( PCDheader.str );
+			PCDheader.version = /^VERSION (.*)/mi.exec( PCDheader.str );
+			PCDheader.fields = /^FIELDS (.*)/im.exec( PCDheader.str );
+			PCDheader.size = /^SIZE (.*)/i.emxec( PCDheader.str );
+			PCDheader.type = /^TYPE (.*)/i.emxec( PCDheader.str );
+			PCDheader.count = /^COUNT (.*)/i.mexec( PCDheader.str );
+			PCDheader.width = /^WIDTH (.*)/i.mexec( PCDheader.str );
+			PCDheader.height = /^HEIGHT (.*)/im.exec( PCDheader.str );
+			PCDheader.viewpoint = /^VIEWPOINT (.*m)/i.exec( PCDheader.str );
+			PCDheader.points = /^POINTS (.*)/im.exec( PCDheader.str );
 
 			// evaluate
 

--- a/examples/jsm/loaders/PCDLoader.js
+++ b/examples/jsm/loaders/PCDLoader.js
@@ -127,14 +127,14 @@ class PCDLoader extends Loader {
 
 			// parse
 
-			PCDheader.version = /^VERSION (.*)/mi.exec( PCDheader.str );
+			PCDheader.version = /^VERSION (.*)/im.exec( PCDheader.str );
 			PCDheader.fields = /^FIELDS (.*)/im.exec( PCDheader.str );
-			PCDheader.size = /^SIZE (.*)/i.emxec( PCDheader.str );
-			PCDheader.type = /^TYPE (.*)/i.emxec( PCDheader.str );
-			PCDheader.count = /^COUNT (.*)/i.mexec( PCDheader.str );
-			PCDheader.width = /^WIDTH (.*)/i.mexec( PCDheader.str );
+			PCDheader.size = /^SIZE (.*)/im.exec( PCDheader.str );
+			PCDheader.type = /^TYPE (.*)/im.exec( PCDheader.str );
+			PCDheader.count = /^COUNT (.*)/im.exec( PCDheader.str );
+			PCDheader.width = /^WIDTH (.*)/im.exec( PCDheader.str );
 			PCDheader.height = /^HEIGHT (.*)/im.exec( PCDheader.str );
-			PCDheader.viewpoint = /^VIEWPOINT (.*m)/i.exec( PCDheader.str );
+			PCDheader.viewpoint = /^VIEWPOINT (.*)/im.exec( PCDheader.str );
 			PCDheader.points = /^POINTS (.*)/im.exec( PCDheader.str );
 
 			// evaluate


### PR DESCRIPTION
**Description**

This PR improves the robustness of the `PCDLoader` by refining how header information is parsed from PCD files. The update addresses an issue where the regex patterns used to extract header fields such as `VERSION`, `FIELDS`, `SIZE`, and others did not account for multi-line strings. This could lead to incorrect parsing, especially when the header data wasn't at the start of the entire string.

The need for this fix arose due to the addition of new, extended custom fields in PCD files. These custom fields introduced more complex formatting, causing the previous regex patterns to fail in certain cases.

**Changes include:**
- Modified regex patterns to use the `^` anchor combined with the `m` (multiline) flag, ensuring that each pattern matches the beginning of each line within the header string.
- This update prevents potential mismatches and enhances the accuracy of the PCD file parsing process.

These improvements are essential for handling PCD files with complex or non-standard formatting, including those with extended custom fields, ensuring that the loader remains reliable across different datasets.

Tests have been run on various PCD files, including those with custom fields, to confirm that these changes work as expected.