### PR TITLE
WebGPURenderer: Use renderBundles for repeated mipmap creation.

### DIFF
--- a/src/renderers/webgpu/utils/WebGPUTexturePassUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUTexturePassUtils.js
@@ -102,6 +102,7 @@ fn main( @location( 0 ) vTex : vec2<f32> ) -> @location( 0 ) vec4<f32> {
 		if ( pipeline === undefined ) {
 
 			pipeline = this.device.createRenderPipeline( {
+				label: `mipmap-${ format }`,
 				vertex: {
 					module: this.mipmapVertexShaderModule,
 					entryPoint: 'main'
@@ -133,6 +134,7 @@ fn main( @location( 0 ) vTex : vec2<f32> ) -> @location( 0 ) vec4<f32> {
 		if ( pipeline === undefined ) {
 
 			pipeline = this.device.createRenderPipeline( {
+				label: `flipY-${ format }`,
 				vertex: {
 					module: this.mipmapVertexShaderModule,
 					entryPoint: 'main'

--- a/src/renderers/webgpu/utils/WebGPUTexturePassUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUTexturePassUtils.js
@@ -232,8 +232,10 @@ fn main( @location( 0 ) vTex : vec2<f32> ) -> @location( 0 ) vec4<f32> {
 		const textureData = this.get( textureGPU );
 
 		if ( textureData.useCount === undefined ) {
+
 			textureData.useCount = 0;
 			textureData.layers = [];
+
 		}
 
 		const commandEncoder = this.device.createCommandEncoder( {} );


### PR DESCRIPTION
The example webgpu_backdrop_area requires regeneration of a texture mipmap for each frame, using bundles allows the overhead to be reduced.

The renderBundles are only cached when a texture is mipmapped more than once. 

