### PR TITLE
SkyMesh: Rename `up` property to avoid name collision

### DIFF
--- a/examples/jsm/objects/SkyMesh.js
+++ b/examples/jsm/objects/SkyMesh.js
@@ -34,7 +34,7 @@ class SkyMesh extends Mesh {
 		this.mieCoefficient = uniform( 0.005 );
 		this.mieDirectionalG = uniform( 0.8 );
 		this.sunPosition = uniform( new Vector3() );
-		this.up = uniform( new Vector3( 0, 1, 0 ) );
+		this.upUniform = uniform( new Vector3( 0, 1, 0 ) );
 
 		this.isSky = true;
 
@@ -70,7 +70,7 @@ class SkyMesh extends Mesh {
 
 			// varying sun intensity
 
-			const angle = dot( vSunDirection, this.up );
+			const angle = dot( vSunDirection, this.upUniform );
 			const zenithAngleCos = clamp( angle, - 1, 1 );
 			const sunIntensity = EE.mul( max( 0.0, float( 1.0 ).sub( pow( e, cutoffAngle.sub( acos( zenithAngleCos ) ).div( steepness ).negate() ) ) ) );
 			varyingProperty( 'float', 'vSunE' ).assign( sunIntensity );
@@ -132,7 +132,7 @@ class SkyMesh extends Mesh {
 
 			// optical length
 			// cutoff angle at 90 to avoid singularity in next formula.
-			const zenithAngle = acos( max( 0.0, dot( this.up, direction ) ) );
+			const zenithAngle = acos( max( 0.0, dot( this.upUniform, direction ) ) );
 			const inverse = float( 1.0 ).div( cos( zenithAngle ).add( float( 0.15 ).mul( pow( float( 93.885 ).sub( zenithAngle.mul( 180.0 ).div( pi ) ), - 1.253 ) ) ) );
 			const sR = rayleighZenithLength.mul( inverse );
 			const sM = mieZenithLength.mul( inverse );
@@ -157,7 +157,7 @@ class SkyMesh extends Mesh {
 			const betaMTheta = vBetaM.mul( mPhase );
 
 			const Lin = pow( vSunE.mul( add( betaRTheta, betaMTheta ).div( add( vBetaR, vBetaM ) ) ).mul( sub( 1.0, Fex ) ), vec3( 1.5 ) );
-			Lin.mulAssign( mix( vec3( 1.0 ), pow( vSunE.mul( add( betaRTheta, betaMTheta ).div( add( vBetaR, vBetaM ) ) ).mul( Fex ), vec3( 1.0 / 2.0 ) ), clamp( pow( sub( 1.0, dot( this.up, vSunDirection ) ), 5.0 ), 0.0, 1.0 ) ) );
+			Lin.mulAssign( mix( vec3( 1.0 ), pow( vSunE.mul( add( betaRTheta, betaMTheta ).div( add( vBetaR, vBetaM ) ) ).mul( Fex ), vec3( 1.0 / 2.0 ) ), clamp( pow( sub( 1.0, dot( this.upUniform, vSunDirection ) ), 5.0 ), 0.0, 1.0 ) ) );
 
 			// nightsky
 


### PR DESCRIPTION
Related issue: #29013

**Description**

`Object3D` already defines an `up` property that is a normal `Vector3`, so overriding it with a `UniformNode` could be problematic. This PR renames the `up` property to `upUniform` to avoid overriding the base property with a value of a different type.
