### PR TITLE
Nodes: IndexNode - `invocationLocalIndex`

### DIFF
--- a/src/nodes/Nodes.js
+++ b/src/nodes/Nodes.js
@@ -11,7 +11,7 @@ export { default as BypassNode, bypass } from './core/BypassNode.js';
 export { default as CacheNode, cache } from './core/CacheNode.js';
 export { default as ConstNode } from './core/ConstNode.js';
 export { default as ContextNode, context, label } from './core/ContextNode.js';
-export { default as IndexNode, vertexIndex, instanceIndex, drawIndex } from './core/IndexNode.js';
+export { default as IndexNode, vertexIndex, instanceIndex, localInstanceIndex, drawIndex } from './core/IndexNode.js';
 export { default as LightingModel } from './core/LightingModel.js';
 export { default as Node, addNodeClass, createNodeFromType } from './core/Node.js';
 export { default as VarNode, temp } from './core/VarNode.js';

--- a/src/nodes/Nodes.js
+++ b/src/nodes/Nodes.js
@@ -11,7 +11,7 @@ export { default as BypassNode, bypass } from './core/BypassNode.js';
 export { default as CacheNode, cache } from './core/CacheNode.js';
 export { default as ConstNode } from './core/ConstNode.js';
 export { default as ContextNode, context, label } from './core/ContextNode.js';
-export { default as IndexNode, vertexIndex, instanceIndex, localInstanceIndex, drawIndex } from './core/IndexNode.js';
+export { default as IndexNode, vertexIndex, instanceIndex, instanceLocalIndex, drawIndex } from './core/IndexNode.js';
 export { default as LightingModel } from './core/LightingModel.js';
 export { default as Node, addNodeClass, createNodeFromType } from './core/Node.js';
 export { default as VarNode, temp } from './core/VarNode.js';

--- a/src/nodes/Nodes.js
+++ b/src/nodes/Nodes.js
@@ -11,7 +11,7 @@ export { default as BypassNode, bypass } from './core/BypassNode.js';
 export { default as CacheNode, cache } from './core/CacheNode.js';
 export { default as ConstNode } from './core/ConstNode.js';
 export { default as ContextNode, context, label } from './core/ContextNode.js';
-export { default as IndexNode, vertexIndex, instanceIndex, instanceLocalIndex, drawIndex } from './core/IndexNode.js';
+export { default as IndexNode, vertexIndex, instanceIndex, invocationLocalIndex, drawIndex } from './core/IndexNode.js';
 export { default as LightingModel } from './core/LightingModel.js';
 export { default as Node, addNodeClass, createNodeFromType } from './core/Node.js';
 export { default as VarNode, temp } from './core/VarNode.js';

--- a/src/nodes/core/IndexNode.js
+++ b/src/nodes/core/IndexNode.js
@@ -33,6 +33,10 @@ class IndexNode extends Node {
 
 			propertyName = builder.getDrawIndex();
 
+		} else if ( scope === IndexNode.LOCAL ) {
+
+			propertyName = builder.getLocalInstanceIndex();
+
 		} else {
 
 			throw new Error( 'THREE.IndexNode: Unknown scope: ' + scope );
@@ -62,11 +66,13 @@ class IndexNode extends Node {
 IndexNode.VERTEX = 'vertex';
 IndexNode.INSTANCE = 'instance';
 IndexNode.DRAW = 'draw';
+IndexNode.LOCAL = 'local';
 
 export default IndexNode;
 
 export const vertexIndex = nodeImmutable( IndexNode, IndexNode.VERTEX );
 export const instanceIndex = nodeImmutable( IndexNode, IndexNode.INSTANCE );
+export const localInstanceIndex = nodeImmutable( IndexNode, IndexNode.LOCAL );
 export const drawIndex = nodeImmutable( IndexNode, IndexNode.DRAW );
 
 addNodeClass( 'IndexNode', IndexNode );

--- a/src/nodes/core/IndexNode.js
+++ b/src/nodes/core/IndexNode.js
@@ -35,7 +35,7 @@ class IndexNode extends Node {
 
 		} else if ( scope === IndexNode.LOCAL ) {
 
-			propertyName = builder.getLocalInstanceIndex();
+			propertyName = builder.getInstanceLocalIndex();
 
 		} else {
 
@@ -72,7 +72,7 @@ export default IndexNode;
 
 export const vertexIndex = nodeImmutable( IndexNode, IndexNode.VERTEX );
 export const instanceIndex = nodeImmutable( IndexNode, IndexNode.INSTANCE );
-export const localInstanceIndex = nodeImmutable( IndexNode, IndexNode.LOCAL );
+export const instanceLocalIndex = nodeImmutable( IndexNode, IndexNode.LOCAL );
 export const drawIndex = nodeImmutable( IndexNode, IndexNode.DRAW );
 
 addNodeClass( 'IndexNode', IndexNode );

--- a/src/nodes/core/IndexNode.js
+++ b/src/nodes/core/IndexNode.js
@@ -33,9 +33,9 @@ class IndexNode extends Node {
 
 			propertyName = builder.getDrawIndex();
 
-		} else if ( scope === IndexNode.LOCAL ) {
+		} else if ( scope === IndexNode.INVOCATION_LOCAL ) {
 
-			propertyName = builder.getInstanceLocalIndex();
+			propertyName = builder.getInvocationLocalIndex();
 
 		} else {
 
@@ -65,14 +65,14 @@ class IndexNode extends Node {
 
 IndexNode.VERTEX = 'vertex';
 IndexNode.INSTANCE = 'instance';
+IndexNode.INVOCATION_LOCAL = 'invocationLocal';
 IndexNode.DRAW = 'draw';
-IndexNode.LOCAL = 'local';
 
 export default IndexNode;
 
 export const vertexIndex = nodeImmutable( IndexNode, IndexNode.VERTEX );
 export const instanceIndex = nodeImmutable( IndexNode, IndexNode.INSTANCE );
-export const instanceLocalIndex = nodeImmutable( IndexNode, IndexNode.LOCAL );
+export const invocationLocalIndex = nodeImmutable( IndexNode, IndexNode.INVOCATION_LOCAL );
 export const drawIndex = nodeImmutable( IndexNode, IndexNode.DRAW );
 
 addNodeClass( 'IndexNode', IndexNode );

--- a/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
+++ b/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
@@ -915,7 +915,6 @@ void main() {
 		} else {
 
 			this.computeShader = this._getGLSLVertexCode( shadersData.compute );
-			console.log( this.computeShader );
 
 		}
 

--- a/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
+++ b/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
@@ -607,7 +607,7 @@ ${ flowData.code }
 
 	}
 
-	getInstanceLocalIndex() {
+	getInvocationLocalIndex() {
 
 		const workgroupSize = this.object.workgroupSize;
 

--- a/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
+++ b/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
@@ -607,6 +607,16 @@ ${ flowData.code }
 
 	}
 
+	getLocalInstanceIndex() {
+
+		const workgroupSize = this.object.workgroupSize;
+
+		const size = workgroupSize.reduce( ( acc, curr ) => acc * curr, 1 );
+
+		return `uint( gl_InstanceID ) % ${size}u`;
+
+	}
+
 	getDrawIndex() {
 
 		const extensions = this.renderer.backend.extensions;
@@ -905,6 +915,7 @@ void main() {
 		} else {
 
 			this.computeShader = this._getGLSLVertexCode( shadersData.compute );
+			console.log( this.computeShader );
 
 		}
 

--- a/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
+++ b/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
@@ -607,7 +607,7 @@ ${ flowData.code }
 
 	}
 
-	getLocalInstanceIndex() {
+	getInstanceLocalIndex() {
 
 		const workgroupSize = this.object.workgroupSize;
 

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -629,6 +629,12 @@ ${ flowData.code }
 
 	}
 
+	getLocalInstanceIndex() {
+
+		return this.getBuiltin( 'local_invocation_index', 'localInstanceIndex', 'u32', 'attribute' );
+
+	}
+
 	getSubgroupSize() {
 
 		this.enableSubGroups();

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -629,9 +629,9 @@ ${ flowData.code }
 
 	}
 
-	getInstanceLocalIndex() {
+	getInvocationLocalIndex() {
 
-		return this.getBuiltin( 'local_invocation_index', 'instanceLocalIndex', 'u32', 'attribute' );
+		return this.getBuiltin( 'local_invocation_index', 'invocationLocalIndex', 'u32', 'attribute' );
 
 	}
 

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -629,9 +629,9 @@ ${ flowData.code }
 
 	}
 
-	getLocalInstanceIndex() {
+	getInstanceLocalIndex() {
 
-		return this.getBuiltin( 'local_invocation_index', 'localInstanceIndex', 'u32', 'attribute' );
+		return this.getBuiltin( 'local_invocation_index', 'instanceLocalIndex', 'u32', 'attribute' );
 
 	}
 


### PR DESCRIPTION
**Description**

Adds a new LOCAL scope to IndexNode. This scope allows the user to access the local_invocation_index builtin as a node within a TSL function. While this functionality is primarily intended for use in applications targeting WebGPU, I'm investigating whether parity with the WebGLBackend could potentially be maintained by taking the modulus of the gl_instanceID by a compute shader's workgroup size.

Reference definition here:
https://www.w3.org/TR/WGSL/#local-invocation-index-builtin-value