### PR TITLE
Revert "ViewportNode: Honor the renderer pixel ratio when using `viewport`."

### DIFF
--- a/src/nodes/display/ViewportNode.js
+++ b/src/nodes/display/ViewportNode.js
@@ -50,9 +50,6 @@ class ViewportNode extends Node {
 
 			renderer.getViewport( viewportResult );
 
-			const ratio = renderer.getPixelRatio();
-			viewportResult.multiplyScalar( ratio );
-
 		} else {
 
 			renderer.getDrawingBufferSize( resolution );


### PR DESCRIPTION
Reverts mrdoob/three.js#29193
