### PR TITLE
Make getStaticAdapter async

### DIFF
--- a/examples/jsm/capabilities/WebGPU.js
+++ b/examples/jsm/capabilities/WebGPU.js
@@ -6,14 +6,7 @@ if ( self.GPUShaderStage === undefined ) {
 
 // statics
 
-let isAvailable = navigator.gpu !== undefined;
-
-
-if ( typeof window !== 'undefined' && isAvailable ) {
-
-	isAvailable = await navigator.gpu.requestAdapter();
-
-}
+const isAvailable = navigator.gpu !== undefined;
 
 class WebGPU {
 
@@ -23,9 +16,15 @@ class WebGPU {
 
 	}
 
-	static getStaticAdapter() {
+	static async getStaticAdapter() {
 
-		return isAvailable;
+		if ( typeof window !== 'undefined' && isAvailable ) {
+
+			return await navigator.gpu.requestAdapter();
+
+		}
+
+		return false;
 
 	}
 


### PR DESCRIPTION
Related issues:
#28107
#26626
#28124

**Description**

We run three.js in an environnement where top-level await is not available. Making `getStaticAdapter` async fixes the issue. I couldn't find places where this method is used. Not sure if this approach is sensible, I'd love to hear your thoughts on this.

cc @RenaudRohlinger 
