### PR TITLE
TSL: Introduce `.flip*()` syntax

### DIFF
--- a/src/nodes/shadernode/ShaderNode.js
+++ b/src/nodes/shadernode/ShaderNode.js
@@ -4,6 +4,7 @@ import ConvertNode from '../utils/ConvertNode.js';
 import JoinNode from '../utils/JoinNode.js';
 import SplitNode from '../utils/SplitNode.js';
 import SetNode from '../utils/SetNode.js';
+import FlipNode from '../utils/FlipNode.js';
 import ConstNode from '../core/ConstNode.js';
 import { getValueFromType, getValueType } from '../core/NodeUtils.js';
 
@@ -29,6 +30,7 @@ export function addNodeElement( name, nodeElement ) {
 }
 
 const parseSwizzle = ( props ) => props.replace( /r|s/g, 'x' ).replace( /g|t/g, 'y' ).replace( /b|p/g, 'z' ).replace( /a|q/g, 'w' );
+const parseSwizzleAndSort = ( props ) => parseSwizzle( props ).split( '' ).sort().join( '' );
 
 const shaderNodeHandler = {
 
@@ -80,15 +82,19 @@ const shaderNodeHandler = {
 
 			} else if ( /^set[XYZWRGBASTPQ]{1,4}$/.test( prop ) === true ) {
 
-				// set properties ( swizzle )
+				// set properties ( swizzle ) and sort to xyzw sequence
 
-				prop = parseSwizzle( prop.slice( 3 ).toLowerCase() );
-
-				// sort to xyzw sequence
-
-				prop = prop.split( '' ).sort().join( '' );
+				prop = parseSwizzleAndSort( prop.slice( 3 ).toLowerCase() );
 
 				return ( value ) => nodeObject( new SetNode( node, prop, value ) );
+
+			} else if ( /^flip[XYZWRGBASTPQ]{1,4}$/.test( prop ) === true ) {
+
+				// set properties ( swizzle ) and sort to xyzw sequence
+
+				prop = parseSwizzleAndSort( prop.slice( 4 ).toLowerCase() );
+
+				return () => nodeObject( new FlipNode( nodeObject( node ), prop ) );
 
 			} else if ( prop === 'width' || prop === 'height' || prop === 'depth' ) {
 

--- a/src/nodes/utils/FlipNode.js
+++ b/src/nodes/utils/FlipNode.js
@@ -1,0 +1,62 @@
+import TempNode from '../core/TempNode.js';
+import { vectorComponents } from '../core/constants.js';
+
+class FlipNode extends TempNode {
+
+	constructor( sourceNode, components ) {
+
+		super();
+
+		this.sourceNode = sourceNode;
+		this.components = components;
+
+	}
+
+	getNodeType( builder ) {
+
+		return this.sourceNode.getNodeType( builder );
+
+	}
+
+	generate( builder ) {
+
+		const { components, sourceNode } = this;
+
+		const sourceType = this.getNodeType( builder );
+		const sourceSnippet = sourceNode.build( builder );
+
+		const sourceCache = builder.getVarFromNode( this );
+		const sourceProperty = builder.getPropertyName( sourceCache );
+
+		builder.addLineFlowCode( sourceProperty + ' = ' + sourceSnippet );
+
+		const length = builder.getTypeLength( sourceType );
+		const snippetValues = [];
+
+		let componentIndex = 0;
+
+		for ( let i = 0; i < length; i ++ ) {
+
+			const component = vectorComponents[ i ];
+
+			if ( component === components[ componentIndex ] ) {
+
+				snippetValues.push( '1.0 - ' + ( sourceProperty + '.' + component ) );
+
+				componentIndex ++;
+
+			} else {
+
+				snippetValues.push( sourceProperty + '.' + component );
+
+			}
+
+		}
+
+		return `${ builder.getType( sourceType ) }( ${ snippetValues.join( ', ' ) } )`;
+
+	}
+
+}
+
+export default FlipNode;


### PR DESCRIPTION
**Description**

Introducing the `flip*()` syntax: This feature allows you to easily flip texture coordinates. You can apply it either individually component or in combination. For example, use `node.flipY()` to flip along the Y-axis or `node.flipXY()` to flip along both the X and Y axes.
