### PR TITLE
Nodes: Prettify Cache Key

### DIFF
--- a/src/nodes/core/NodeUtils.js
+++ b/src/nodes/core/NodeUtils.js
@@ -9,17 +9,23 @@ export function getCacheKey( object, force = false ) {
 
 	let cacheKey = '{';
 
+	const snippets = [];
+
 	if ( object.isNode === true ) {
 
-		cacheKey += object.id;
+		snippets.push( `${object.id}` );
 
 	}
 
 	for ( const { property, childNode } of getNodeChildren( object ) ) {
 
-		cacheKey += ',' + property.slice( 0, - 4 ) + ':' + childNode.getCacheKey( force );
+		const prop = property.slice( 0, - 4 ) || 'node';
+
+		snippets.push( prop + ':' + childNode.getCacheKey( force ) );
 
 	}
+
+	cacheKey += snippets.join( ',' );
 
 	cacheKey += '}';
 


### PR DESCRIPTION
**Description**

Cleans up the output of getCacheKey(). Makes two changes:

1. Gets rid of the dangling comma after an object's id if the object has no children. 

2. Provides 'node' when the value of property.slice( 0, -4 ) is false. While this doesn't really encode any more information than an empty string would, if you're using the cache key for debug purposes, it does at least point the debugger to the subset of nodes that have this.node as a property. Ideally, nodes with this.node values would provide more unique and informative names, but assuming that each node has a unique id, it shouldn't affect the program either way. 