### PR TITLE
WebGPURenderer: Get fallback approach

### DIFF
--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -45,7 +45,8 @@ class Renderer {
 			logarithmicDepthBuffer = false,
 			alpha = true,
 			antialias = false,
-			samples = 0
+			samples = 0,
+			getFallback = null
 		} = parameters;
 
 		// public
@@ -79,6 +80,8 @@ class Renderer {
 		this.info = new Info();
 
 		// internals
+
+		this._getFallback = getFallback;
 
 		this._pixelRatio = 1;
 		this._width = this.domElement.width;
@@ -184,7 +187,7 @@ class Renderer {
 
 		this._initPromise = new Promise( async ( resolve, reject ) => {
 
-			const backend = this.backend;
+			let backend = this.backend;
 
 			try {
 
@@ -192,8 +195,28 @@ class Renderer {
 
 			} catch ( error ) {
 
-				reject( error );
-				return;
+				if ( this._getFallback !== null ) {
+
+					// try the fallback
+
+					try {
+
+						this.backend = backend = this._getFallback( error );
+						await backend.init( this );
+
+					} catch ( error ) {
+
+						reject( error );
+						return;
+
+					}
+
+				} else {
+
+					reject( error );
+					return;
+
+				}
 
 			}
 

--- a/src/renderers/webgpu/WebGPURenderer.js
+++ b/src/renderers/webgpu/WebGPURenderer.js
@@ -1,5 +1,3 @@
-import WebGPU from '../../../examples/jsm/capabilities/WebGPU.js';
-
 import Renderer from '../common/Renderer.js';
 import WebGLBackend from '../webgl-fallback/WebGLBackend.js';
 import WebGPUBackend from './WebGPUBackend.js';
@@ -27,15 +25,17 @@ class WebGPURenderer extends Renderer {
 
 			BackendClass = WebGLBackend;
 
-		} else if ( WebGPU.isAvailable() ) {
+		} else {
 
 			BackendClass = WebGPUBackend;
 
-		} else {
+			parameters.getFallback = () => {
 
-			BackendClass = WebGLBackend;
+				console.warn( 'THREE.WebGPURenderer: WebGPU is not available, running under WebGL2 backend.' );
 
-			console.warn( 'THREE.WebGPURenderer: WebGPU is not available, running under WebGL2 backend.' );
+				return new WebGLBackend( parameters );
+
+			};
 
 		}
 


### PR DESCRIPTION
Related issue: Closes https://github.com/mrdoob/three.js/pull/29206#issuecomment-2306915925

**Description**

Improve fallback approach.  No need for `top-level await` and duplicate `adapter`.