### PR TITLE
OutlinePass: Improve performance of `VisibilityChangeCallBack()`.

### DIFF
--- a/examples/jsm/postprocessing/OutlinePass.js
+++ b/examples/jsm/postprocessing/OutlinePass.js
@@ -174,7 +174,7 @@ class OutlinePass extends Pass {
 	}
 
 	get selectedMeshes() {
-        
+
 		const meshes = this._selectedMeshes
 
 		function gatherSelectedMeshesCallBack( object ) {
@@ -198,7 +198,7 @@ class OutlinePass extends Pass {
 		}
 
 		return meshes
-        
+
 	}
 
 	changeVisibilityOfSelectedObjects( bVisible ) {
@@ -297,7 +297,7 @@ class OutlinePass extends Pass {
 			renderer.setClearColor( 0xffffff, 1 );
 
 			// set the selected meshes flag to recalculate selected meshes in case the selectedObjects array changed since last frame
-			this._selectedMeshesDirty = true
+			this._selectedMeshesDirty = true;
 			// Make selected objects invisible
 			this.changeVisibilityOfSelectedObjects( false );
 

--- a/examples/jsm/postprocessing/OutlinePass.js
+++ b/examples/jsm/postprocessing/OutlinePass.js
@@ -287,7 +287,7 @@ class OutlinePass extends Pass {
 
 			renderer.setClearColor( 0xffffff, 1 );
 
-			this.updateSelectionSet()
+			this.updateSelectionSet();
 			// Make selected objects invisible
 			this.changeVisibilityOfSelectedObjects( false );
 

--- a/examples/jsm/postprocessing/OutlinePass.js
+++ b/examples/jsm/postprocessing/OutlinePass.js
@@ -16,6 +16,8 @@ import {
 import { Pass, FullScreenQuad } from './Pass.js';
 import { CopyShader } from '../shaders/CopyShader.js';
 
+const _selectedMeshes = new Set();
+
 class OutlinePass extends Pass {
 
 	constructor( resolution, scene, camera, selectedObjects ) {
@@ -196,11 +198,11 @@ class OutlinePass extends Pass {
 
 		const cache = this._visibilityCache;
 
-		for(let mesh of _selectedMeshes) {
+		for ( const mesh of _selectedMeshes ) {
 
 			if ( bVisible === true ) {
 
-				mesh.visible = cache.get( mesh);
+				mesh.visible = cache.get( mesh );
 
 			} else {
 
@@ -224,7 +226,7 @@ class OutlinePass extends Pass {
 
 				// only meshes and sprites are supported by OutlinePass
 
-				if ( !selectedMeshes.has(object) ) {
+				if ( ! selectedMeshes.has( object ) ) {
 
 					const visibility = object.visible;
 
@@ -630,8 +632,6 @@ class OutlinePass extends Pass {
 	}
 
 }
-
-const _selectedMeshes = new Set();
 
 OutlinePass.BlurDirectionX = new Vector2( 1.0, 0.0 );
 OutlinePass.BlurDirectionY = new Vector2( 0.0, 1.0 );

--- a/examples/jsm/postprocessing/OutlinePass.js
+++ b/examples/jsm/postprocessing/OutlinePass.js
@@ -207,11 +207,11 @@ class OutlinePass extends Pass {
 	changeVisibilityOfNonSelectedObjects( bVisible ) {
 
 		const cache = this._visibilityCache;
-		const selectedMeshes = [];
+		const selectedMeshes = new Set();
 
 		function gatherSelectedMeshesCallBack( object ) {
 
-			if ( object.isMesh ) selectedMeshes.push( object );
+			if ( object.isMesh ) selectedMeshes.add( object.id );
 
 		}
 
@@ -228,22 +228,7 @@ class OutlinePass extends Pass {
 
 				// only meshes and sprites are supported by OutlinePass
 
-				let bFound = false;
-
-				for ( let i = 0; i < selectedMeshes.length; i ++ ) {
-
-					const selectedObjectId = selectedMeshes[ i ].id;
-
-					if ( selectedObjectId === object.id ) {
-
-						bFound = true;
-						break;
-
-					}
-
-				}
-
-				if ( bFound === false ) {
+				if ( !selectedMeshes.has(object.id) ) {
 
 					const visibility = object.visible;
 
@@ -462,7 +447,7 @@ class OutlinePass extends Pass {
 						worldPosition = instanceMatrix * worldPosition;
 
 					#endif
-					
+
 					worldPosition = modelMatrix * worldPosition;
 
 					projTexCoord = textureMatrix * worldPosition;

--- a/examples/jsm/postprocessing/OutlinePass.js
+++ b/examples/jsm/postprocessing/OutlinePass.js
@@ -173,7 +173,7 @@ class OutlinePass extends Pass {
 
 	updateSelectionSet() {
 
-		const meshes = _selectedMeshes
+		const meshes = _selectedMeshes;
 
 		function gatherSelectedMeshesCallBack( object ) {
 
@@ -181,7 +181,7 @@ class OutlinePass extends Pass {
 
 		}
 
-		meshes.clear()
+		meshes.clear();
 
 		for ( let i = 0; i < this.selectedObjects.length; i ++ ) {
 

--- a/examples/jsm/postprocessing/OutlinePass.js
+++ b/examples/jsm/postprocessing/OutlinePass.js
@@ -228,7 +228,7 @@ class OutlinePass extends Pass {
 
 				// only meshes and sprites are supported by OutlinePass
 
-				if ( !selectedMeshes.has(object.id) ) {
+				if ( selectedMeshes.has( object.id ) === false ) {
 
 					const visibility = object.visible;
 


### PR DESCRIPTION
During performance profiling i found that having selections with 500+ meshes where resulting in ~7ms twice per frame in the changeVisibilityOfNonSelectedObjects function due to the for loop and array setup.
I replaced the array with a set and now the function takes <1ms.

![beforeafter](https://github.com/user-attachments/assets/874b1534-5db9-4078-995b-bd350cf5c51c)

Thanks for the great library!
