### PR TITLE
Clock, Timer: Drop fallback to `Date.now()`.

### DIFF
--- a/examples/jsm/misc/Timer.js
+++ b/examples/jsm/misc/Timer.js
@@ -115,7 +115,7 @@ class FixedTimer extends Timer {
 
 function now() {
 
-	return ( typeof performance === 'undefined' ? Date : performance ).now();
+	return performance.now();
 
 }
 

--- a/src/core/Clock.js
+++ b/src/core/Clock.js
@@ -67,7 +67,7 @@ class Clock {
 
 function now() {
 
-	return ( typeof performance === 'undefined' ? Date : performance ).now(); // see #10732
+	return performance.now();
 
 }
 


### PR DESCRIPTION
Related issue: #8112

**Description**

It's probably a time to drop `Date.now` fallback in `Clock` & `Timer` classes, because the support for high resolution timestamp has already been good for years.

Browser: https://developer.mozilla.org/en-US/docs/Web/API/Performance/now
Node: https://nodejs.org/docs/latest-v8.x/api/perf_hooks.html#perf_hooks_performance_now (supported since v8.5.0)
