### PR TITLE
Editor: bring back axis names

### DIFF
--- a/editor/js/Viewport.ViewHelper.js
+++ b/editor/js/Viewport.ViewHelper.js
@@ -30,6 +30,8 @@ class ViewHelper extends ViewHelperBase {
 
 		} );
 
+		this.setLabel( 'x', 'y', 'z' );
+
 		container.add( panel );
 
 	}


### PR DESCRIPTION
On the editor view, we used to have an axis helper with the name of the different axes on it. Due to [this change](https://github.com/mrdoob/three.js/commit/96ba72e5e5464bebd77a61ad25c3a8850883944a) it is not the case anymore so I just bring back the axis names.
I think the naming makes the editor interface more userfriendly especially for beginners.

Small fiddle to try : https://jsfiddle.net/mwcfxn1t/1/ 