### PR TITLE
WebGPURenderer: Add signature to shader

### DIFF
--- a/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
+++ b/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
@@ -773,6 +773,8 @@ ${vars}
 
 		return `#version 300 es
 
+${ this.getSignature() }
+
 // extensions 
 ${shaderData.extensions}
 


### PR DESCRIPTION
Like so.

<img width="667" alt="Screenshot 2024-08-26 at 9 31 58 PM" src="https://github.com/user-attachments/assets/ec6877af-7b9c-4bb5-9c61-008c775afb4c">

It also applies the same injection to both vertex and fragment.

This PR only implements the change for the WebGL backend.
