### PR TITLE
Fix loop bounds in BatchedMesh#computeBoundingBox to properly cover a…

### DIFF
--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -300,12 +300,11 @@ class BatchedMesh extends Mesh {
 
 		}
 
-		const geometryCount = this._geometryCount;
 		const boundingBox = this.boundingBox;
 		const drawInfo = this._drawInfo;
 
 		boundingBox.makeEmpty();
-		for ( let i = 0; i < geometryCount; i ++ ) {
+		for ( let i = 0, l = drawInfo.length; i < l; i ++ ) {
 
 			if ( drawInfo[ i ].active === false ) continue;
 


### PR DESCRIPTION
Related issue: [#29242 ](https://github.com/mrdoob/three.js/issues/29242)

**Description**

Fixes issue with BatchedMesh bounding box computation when instancing geometries.