### PR TITLE
TSL: Add `mvpNode` to NodeMaterial for Custom Model-View-Projection

### DIFF
--- a/src/materials/nodes/NodeMaterial.js
+++ b/src/materials/nodes/NodeMaterial.js
@@ -50,6 +50,7 @@ class NodeMaterial extends Material {
 		this.alphaTestNode = null;
 
 		this.positionNode = null;
+		this.mvpNode = null;
 
 		this.depthNode = null;
 		this.shadowNode = null;
@@ -277,7 +278,7 @@ class NodeMaterial extends Material {
 
 		}
 
-		const mvp = modelViewProjection();
+		const mvp = this.mvpNode !== null ? this.mvpNode : modelViewProjection();
 
 		builder.context.vertex = builder.removeStack();
 		builder.context.mvp = mvp;
@@ -603,6 +604,7 @@ class NodeMaterial extends Material {
 		this.alphaTestNode = source.alphaTestNode;
 
 		this.positionNode = source.positionNode;
+		this.mvpNode = source.mvpNode;
 
 		this.depthNode = source.depthNode;
 		this.shadowNode = source.shadowNode;

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -1463,6 +1463,7 @@ class Renderer {
 	renderObject( object, scene, camera, geometry, material, group, lightsNode ) {
 
 		let overridePositionNode;
+		let overrideMvpNode;
 		let overrideFragmentNode;
 		let overrideDepthNode;
 
@@ -1482,6 +1483,14 @@ class Renderer {
 				overrideMaterial.positionNode = material.positionNode;
 
 			}
+
+			if ( material.mvpNode && material.mvpNode.isNode ) {
+
+				overrideMvpNode = overrideMaterial.mvpNode;
+				overrideMaterial.mvpNode = material.mvpNode;
+
+			}
+
 
 			if ( overrideMaterial.isShadowNodeMaterial ) {
 
@@ -1557,6 +1566,12 @@ class Renderer {
 		if ( overridePositionNode !== undefined ) {
 
 			scene.overrideMaterial.positionNode = overridePositionNode;
+
+		}
+
+		if ( overrideMvpNode !== undefined ) {
+
+			scene.overrideMaterial.mvpNode = overrideMvpNode;
 
 		}
 


### PR DESCRIPTION
**Description**
Currently, the model-view-projection (MVP) of a mesh cannot be overridden in node materials. This PR introduces a new `mvpNode`, enabling the use of a custom MVP for any mesh.

For example, this allows for easily rendering a specific mesh with a different camera. Without this custom `mvpNode`, achieving this was challenging because the cameraProjectionMatrix and modelViewMatrix used in the MVP could not be overridden on a per-mesh basis.

*This contribution is funded by [Utsubo](https://utsubo.com)*