### PR TITLE
WebGPURenderer: cache textureViews for reuse in bindGroup

### DIFF
--- a/src/renderers/webgpu/utils/WebGPUBindingUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUBindingUtils.js
@@ -244,7 +244,7 @@ class WebGPUBindingUtils {
 
 					const mipLevelCount = binding.store ? 1 : textureData.texture.mipLevelCount;
 					const propertyName = `view-${ mipLevelCount }`;
-console.log( propertyName );
+
 					resourceGPU = textureData[ propertyName ];
 
 					if ( resourceGPU === undefined ) {

--- a/src/renderers/webgpu/utils/WebGPUBindingUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUBindingUtils.js
@@ -234,37 +234,46 @@ class WebGPUBindingUtils {
 
 				const textureData = backend.get( binding.texture );
 
-				let dimensionViewGPU;
+				const mipLevelCount = binding.store ? 1 : textureData.mipLevelCount;
 
-				if ( binding.isSampledCubeTexture ) {
+				// todo lebel count
+				const propertyName = `view-${ mipLevelCount }`;
 
-					dimensionViewGPU = GPUTextureViewDimension.Cube;
+				let resourceGPU = textureData[ propertyName ];
 
-				} else if ( binding.isSampledTexture3D ) {
+				if ( resourceGPU === undefined ) {
 
-					dimensionViewGPU = GPUTextureViewDimension.ThreeD;
+					let dimensionViewGPU;
 
-				} else if ( binding.texture.isDataArrayTexture || binding.texture.isCompressedArrayTexture ) {
+					if ( binding.isSampledCubeTexture ) {
 
-					dimensionViewGPU = GPUTextureViewDimension.TwoDArray;
+						dimensionViewGPU = GPUTextureViewDimension.Cube;
 
-				} else {
+					} else if ( binding.isSampledTexture3D ) {
 
-					dimensionViewGPU = GPUTextureViewDimension.TwoD;
+						dimensionViewGPU = GPUTextureViewDimension.ThreeD;
 
-				}
+					} else if ( binding.texture.isDataArrayTexture || binding.texture.isCompressedArrayTexture ) {
 
-				let resourceGPU;
+						dimensionViewGPU = GPUTextureViewDimension.TwoDArray;
 
-				if ( textureData.externalTexture !== undefined ) {
+					} else {
 
-					resourceGPU = device.importExternalTexture( { source: textureData.externalTexture } );
+						dimensionViewGPU = GPUTextureViewDimension.TwoD;
 
-				} else {
+					}
 
-					const aspectGPU = GPUTextureAspect.All;
+					if ( textureData.externalTexture !== undefined ) {
 
-					resourceGPU = textureData.texture.createView( { aspect: aspectGPU, dimension: dimensionViewGPU, mipLevelCount: binding.store ? 1 : textureData.mipLevelCount } );
+						resourceGPU = device.importExternalTexture( { source: textureData.externalTexture } );
+
+					} else {
+
+						const aspectGPU = GPUTextureAspect.All;
+
+						resourceGPU = textureData[ propertyName ] = textureData.texture.createView( { aspect: aspectGPU, dimension: dimensionViewGPU, mipLevelCount } );
+
+					}
 
 				}
 

--- a/src/renderers/webgpu/utils/WebGPUBindingUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUBindingUtils.js
@@ -242,9 +242,9 @@ class WebGPUBindingUtils {
 
 				} else {
 
-					const mipLevelCount = binding.store ? 1 : textureData.mipLevelCount;
+					const mipLevelCount = binding.store ? 1 : textureData.texture.mipLevelCount;
 					const propertyName = `view-${ mipLevelCount }`;
-
+console.log( propertyName );
 					resourceGPU = textureData[ propertyName ];
 
 					if ( resourceGPU === undefined ) {

--- a/src/renderers/webgpu/utils/WebGPUBindingUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUBindingUtils.js
@@ -234,42 +234,42 @@ class WebGPUBindingUtils {
 
 				const textureData = backend.get( binding.texture );
 
-				const mipLevelCount = binding.store ? 1 : textureData.mipLevelCount;
+				let resourceGPU;
 
-				// todo lebel count
-				const propertyName = `view-${ mipLevelCount }`;
+				if ( textureData.externalTexture !== undefined ) {
 
-				let resourceGPU = textureData[ propertyName ];
+					resourceGPU = device.importExternalTexture( { source: textureData.externalTexture } );
 
-				if ( resourceGPU === undefined ) {
+				} else {
 
-					let dimensionViewGPU;
+					const mipLevelCount = binding.store ? 1 : textureData.mipLevelCount;
+					const propertyName = `view-${ mipLevelCount }`;
 
-					if ( binding.isSampledCubeTexture ) {
+					resourceGPU = textureData[ propertyName ];
 
-						dimensionViewGPU = GPUTextureViewDimension.Cube;
-
-					} else if ( binding.isSampledTexture3D ) {
-
-						dimensionViewGPU = GPUTextureViewDimension.ThreeD;
-
-					} else if ( binding.texture.isDataArrayTexture || binding.texture.isCompressedArrayTexture ) {
-
-						dimensionViewGPU = GPUTextureViewDimension.TwoDArray;
-
-					} else {
-
-						dimensionViewGPU = GPUTextureViewDimension.TwoD;
-
-					}
-
-					if ( textureData.externalTexture !== undefined ) {
-
-						resourceGPU = device.importExternalTexture( { source: textureData.externalTexture } );
-
-					} else {
+					if ( resourceGPU === undefined ) {
 
 						const aspectGPU = GPUTextureAspect.All;
+
+						let dimensionViewGPU;
+
+						if ( binding.isSampledCubeTexture ) {
+
+							dimensionViewGPU = GPUTextureViewDimension.Cube;
+
+						} else if ( binding.isSampledTexture3D ) {
+
+							dimensionViewGPU = GPUTextureViewDimension.ThreeD;
+
+						} else if ( binding.texture.isDataArrayTexture || binding.texture.isCompressedArrayTexture ) {
+
+							dimensionViewGPU = GPUTextureViewDimension.TwoDArray;
+
+						} else {
+
+							dimensionViewGPU = GPUTextureViewDimension.TwoD;
+
+						}
 
 						resourceGPU = textureData[ propertyName ] = textureData.texture.createView( { aspect: aspectGPU, dimension: dimensionViewGPU, mipLevelCount } );
 


### PR DESCRIPTION
As title. 

Reduces duplicate textureView creation (webgpu_performance example from over 5000 textureViews to less than 200).

Also reordered to remove unrequired dimension selection from video texture path.


