### PR TITLE
WebGPURenderer: fix cache textureViews

### DIFF
--- a/src/renderers/webgpu/utils/WebGPUBindingUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUBindingUtils.js
@@ -243,7 +243,7 @@ class WebGPUBindingUtils {
 				} else {
 
 					const mipLevelCount = binding.store ? 1 : textureData.texture.mipLevelCount;
-					const propertyName = `view-${ mipLevelCount }`;
+					const propertyName = `view-${ textureData.texture.width }-${ textureData.texture.height }-${ mipLevelCount }`;
 
 					resourceGPU = textureData[ propertyName ];
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/29257#issuecomment-2319181461

**Description**

Fix view dimension if shared the property.
