### PR TITLE
Fixed smoothstep usage failing to compile in Chrome Beta

### DIFF
--- a/examples/webgpu_tsl_coffee_smoke.html
+++ b/examples/webgpu_tsl_coffee_smoke.html
@@ -29,7 +29,7 @@
 		<script type="module">
 
 			import * as THREE from 'three';
-			import { mix, mul, positionLocal, smoothstep, texture, timerLocal, rotateUV, Fn, uv, vec2, vec3, vec4 } from 'three/tsl';
+			import { mix, mul, oneMinus, positionLocal, smoothstep, texture, timerLocal, rotateUV, Fn, uv, vec2, vec3, vec4 } from 'three/tsl';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
@@ -115,9 +115,9 @@
 
 						// edges fade
 						smoothstep( 0, 0.1, uv().x ),
-						smoothstep( 1, 0.9, uv().x ),
+						smoothstep( 0, 0.1, oneMinus( uv().x ) ),
 						smoothstep( 0, 0.1, uv().y ),
-						smoothstep( 1, 0.9, uv().y )
+						smoothstep( 0, 0.1, oneMinus( uv().y ) )
 
 					);
 

--- a/examples/webgpu_tsl_vfx_tornado.html
+++ b/examples/webgpu_tsl_vfx_tornado.html
@@ -27,7 +27,7 @@
 		<script type="module">
 
 			import * as THREE from 'three';
-			import { luminance, cos, float, min, timerLocal, atan2, uniform, pass, bloom, PI, PI2, color, positionLocal, sin, texture, Fn, uv, vec2, vec3, vec4 } from 'three/tsl';
+			import { luminance, cos, float, min, timerLocal, atan2, uniform, pass, bloom, PI, PI2, color, positionLocal, oneMinus, sin, texture, Fn, uv, vec2, vec3, vec4 } from 'three/tsl';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
@@ -143,7 +143,7 @@
 					// outer fade
 					const distanceToCenter = uv().sub( 0.5 ).toVar();
 					const outerFade = min(
-						distanceToCenter.length().smoothstep( 0.5, 0.1 ),
+						oneMinus( distanceToCenter.length() ).smoothstep( 0.5, 0.9 ),
 						distanceToCenter.length().smoothstep( 0, 0.2 )
 					);
 
@@ -198,7 +198,7 @@
 					// outer fade
 					const outerFade = min(
 						uv().y.smoothstep( 0, 0.1 ),
-						uv().y.smoothstep( 1, 0.6 )
+						oneMinus( uv().y ).smoothstep( 0, 0.4 )
 					);
 
 					// effect
@@ -249,7 +249,7 @@
 					// outer fade
 					const outerFade = min(
 						uv().y.smoothstep( 0, 0.2 ),
-						uv().y.smoothstep( 1, 0.6 )
+						oneMinus( uv().y ).smoothstep( 0, 0.4 )
 					);
 
 					// effect
@@ -322,7 +322,7 @@
 			}
 
 			async function animate() {
-			
+
 				controls.update();
 
 				postProcessing.render();


### PR DESCRIPTION
**Description**

Some examples were crashing in Chrome Beta because they fixed a bug with [`smoothstep`](https://www.w3.org/TR/WGSL/#smoothstep-builtin) validation.

<img width="672" alt="Screenshot 2024-08-30 at 14 46 18" src="https://github.com/user-attachments/assets/0a7f9844-0eb4-4830-ab7c-21222a3b650f">

More info: https://issues.chromium.org/issues/362640711

As per my fix... It's a dont-know-what-Im-doing fix 😇

Feel free to improve/fix it!

/cc @brunosimon @sunag 