### PR TITLE
Nodes: StorageArrayElementNode - Remove check for non-existant property.

### DIFF
--- a/src/nodes/utils/StorageArrayElementNode.js
+++ b/src/nodes/utils/StorageArrayElementNode.js
@@ -50,15 +50,13 @@ class StorageArrayElementNode extends ArrayElementNode {
 
 		if ( builder.isAvailable( 'storageBuffer' ) === false ) {
 
-			const { node } = this;
-
 			if ( this.node.bufferObject === true && isAssignContext !== true ) {
 
 				snippet = builder.generatePBO( this );
 
 			} else {
 
-				snippet = node.build( builder );
+				snippet = this.node.build( builder );
 
 			}
 

--- a/src/nodes/utils/StorageArrayElementNode.js
+++ b/src/nodes/utils/StorageArrayElementNode.js
@@ -28,7 +28,7 @@ class StorageArrayElementNode extends ArrayElementNode {
 
 		if ( builder.isAvailable( 'storageBuffer' ) === false ) {
 
-			if ( ! this.node.instanceIndex && this.node.bufferObject === true ) {
+			if ( this.node.bufferObject === true ) {
 
 				builder.setupPBO( this.node );
 
@@ -52,7 +52,7 @@ class StorageArrayElementNode extends ArrayElementNode {
 
 			const { node } = this;
 
-			if ( ! node.instanceIndex && this.node.bufferObject === true && isAssignContext !== true ) {
+			if ( this.node.bufferObject === true && isAssignContext !== true ) {
 
 				snippet = builder.generatePBO( this );
 


### PR DESCRIPTION
**Description**

StorageArrayElementNode will query its parent node for it's .instanceIndex property, which doesn't appear to be an existing property or get method.
