### PR TITLE
Nodes: Introduce static type

### DIFF
--- a/examples/webgpu_materials.html
+++ b/examples/webgpu_materials.html
@@ -398,10 +398,28 @@
 
 			}
 
+			function moduleToLib( module ) {
+
+				const lib = {};
+
+				for ( const nodeElement of Object.values( module ) ) {
+
+					if ( typeof nodeElement === 'function' && nodeElement.type !== undefined ) {
+
+						lib[ nodeElement.type ] = nodeElement;
+
+					}
+
+				}
+
+				return lib;
+
+			}
+
 			function testSerialization( mesh ) {
 
 				const json = mesh.toJSON();
-				const loader = new THREE.NodeObjectLoader();
+				const loader = new THREE.NodeObjectLoader().setNodes( moduleToLib( TSL ) );
 				const serializedMesh = loader.parse( json );
 
 				serializedMesh.position.x = ( objects.length % 4 ) * 200 - 400;

--- a/src/loaders/MaterialLoader.js
+++ b/src/loaders/MaterialLoader.js
@@ -86,7 +86,7 @@ class MaterialLoader extends Loader {
 
 		}
 
-		const material = MaterialLoader.createMaterialFromType( json.type );
+		const material = this.createMaterialFromType( json.type );
 
 		if ( json.uuid !== undefined ) material.uuid = json.uuid;
 		if ( json.name !== undefined ) material.name = json.name;
@@ -339,6 +339,12 @@ class MaterialLoader extends Loader {
 
 		this.textures = value;
 		return this;
+
+	}
+
+	createMaterialFromType( type ) {
+
+		return MaterialLoader.createMaterialFromType( type );
 
 	}
 

--- a/src/loaders/nodes/NodeLoader.js
+++ b/src/loaders/nodes/NodeLoader.js
@@ -1,5 +1,4 @@
-import { createNodeFromType } from '../../nodes/core/Node.js';
-import { nodeObject } from '../../nodes/tsl/TSLBase.js';
+import { nodeObject, float } from '../../nodes/tsl/TSLBase.js';
 
 import { Loader } from '../Loader.js';
 import { FileLoader } from '../../loaders/FileLoader.js';
@@ -11,6 +10,7 @@ class NodeLoader extends Loader {
 		super( manager );
 
 		this.textures = {};
+		this.nodes = {};
 
 	}
 
@@ -56,7 +56,7 @@ class NodeLoader extends Loader {
 
 				const { uuid, type } = nodeJSON;
 
-				nodes[ uuid ] = nodeObject( createNodeFromType( type ) );
+				nodes[ uuid ] = this.createNodeFromType( type );
 				nodes[ uuid ].uuid = uuid;
 
 			}
@@ -82,7 +82,7 @@ class NodeLoader extends Loader {
 
 	parse( json ) {
 
-		const node = nodeObject( createNodeFromType( json.type ) );
+		const node = this.createNodeFromType( json.type );
 		node.uuid = json.uuid;
 
 		const nodes = this.parseNodes( json.nodes );
@@ -102,6 +102,26 @@ class NodeLoader extends Loader {
 
 		this.textures = value;
 		return this;
+
+	}
+
+	setNodes( value ) {
+
+		this.nodes = value;
+		return this;
+
+	}
+
+	createNodeFromType( type ) {
+
+		if ( this.nodes[ type ] === undefined ) {
+
+			console.error( 'THREE.NodeLoader: Node type not found:', type );
+			return float();
+
+		}
+
+		return nodeObject( new this.nodes[ type ]() );
 
 	}
 

--- a/src/loaders/nodes/NodeMaterialLoader.js
+++ b/src/loaders/nodes/NodeMaterialLoader.js
@@ -1,21 +1,4 @@
 import { MaterialLoader } from '../../loaders/MaterialLoader.js';
-import { createNodeMaterialFromType } from '../../materials/nodes/NodeMaterial.js';
-
-const superFromTypeFunction = MaterialLoader.createMaterialFromType;
-
-MaterialLoader.createMaterialFromType = function ( type ) {
-
-	const material = createNodeMaterialFromType( type );
-
-	if ( material !== undefined ) {
-
-		return material;
-
-	}
-
-	return superFromTypeFunction.call( this, type );
-
-};
 
 class NodeMaterialLoader extends MaterialLoader {
 
@@ -24,6 +7,7 @@ class NodeMaterialLoader extends MaterialLoader {
 		super( manager );
 
 		this.nodes = {};
+		this.nodeMaterials = {};
 
 	}
 
@@ -49,8 +33,28 @@ class NodeMaterialLoader extends MaterialLoader {
 	setNodes( value ) {
 
 		this.nodes = value;
-
 		return this;
+
+	}
+
+	setNodeMaterials( value ) {
+
+		this.nodeMaterials = value;
+		return this;
+
+	}
+
+	createMaterialFromType( type ) {
+
+		const materialClass = this.nodeMaterials[ type ];
+
+		if ( materialClass !== undefined ) {
+
+			return new materialClass();
+
+		}
+
+		return super.createMaterialFromType( type );
 
 	}
 

--- a/src/loaders/nodes/NodeObjectLoader.js
+++ b/src/loaders/nodes/NodeObjectLoader.js
@@ -9,7 +9,16 @@ class NodeObjectLoader extends ObjectLoader {
 
 		super( manager );
 
+		this.nodes = {};
+
 		this._nodesJSON = null;
+
+	}
+
+	setNodes( value ) {
+
+		this.nodes = value;
+		return this;
 
 	}
 
@@ -30,6 +39,7 @@ class NodeObjectLoader extends ObjectLoader {
 		if ( json !== undefined ) {
 
 			const loader = new NodeLoader();
+			loader.setNodes( this.nodes );
 			loader.setTextures( textures );
 
 			return loader.parseNodes( json );

--- a/src/loaders/nodes/NodeObjectLoader.js
+++ b/src/loaders/nodes/NodeObjectLoader.js
@@ -10,6 +10,7 @@ class NodeObjectLoader extends ObjectLoader {
 		super( manager );
 
 		this.nodes = {};
+		this.nodeMaterials = {};
 
 		this._nodesJSON = null;
 
@@ -18,6 +19,13 @@ class NodeObjectLoader extends ObjectLoader {
 	setNodes( value ) {
 
 		this.nodes = value;
+		return this;
+
+	}
+
+	setNodeMaterials( value ) {
+
+		this.nodeMaterials = value;
 		return this;
 
 	}
@@ -61,6 +69,7 @@ class NodeObjectLoader extends ObjectLoader {
 			const loader = new NodeMaterialLoader();
 			loader.setTextures( textures );
 			loader.setNodes( nodes );
+			loader.setNodeMaterials( this.nodeMaterials );
 
 			for ( let i = 0, l = json.length; i < l; i ++ ) {
 

--- a/src/materials/nodes/InstancedPointsNodeMaterial.js
+++ b/src/materials/nodes/InstancedPointsNodeMaterial.js
@@ -1,4 +1,4 @@
-import NodeMaterial, { registerNodeMaterial } from './NodeMaterial.js';
+import NodeMaterial from './NodeMaterial.js';
 import { property } from '../../nodes/core/PropertyNode.js';
 import { attribute } from '../../nodes/core/AttributeNode.js';
 import { cameraProjectionMatrix } from '../../nodes/accessors/Camera.js';
@@ -15,6 +15,12 @@ import { PointsMaterial } from '../PointsMaterial.js';
 const _defaultValues = /*@__PURE__*/ new PointsMaterial();
 
 class InstancedPointsNodeMaterial extends NodeMaterial {
+
+	static get type() {
+
+		return 'InstancedPointsNodeMaterial';
+
+	}
 
 	constructor( params = {} ) {
 
@@ -167,5 +173,3 @@ class InstancedPointsNodeMaterial extends NodeMaterial {
 }
 
 export default InstancedPointsNodeMaterial;
-
-InstancedPointsNodeMaterial.type = /*@__PURE__*/ registerNodeMaterial( 'InstancedPoints', InstancedPointsNodeMaterial );

--- a/src/materials/nodes/Line2NodeMaterial.js
+++ b/src/materials/nodes/Line2NodeMaterial.js
@@ -1,4 +1,4 @@
-import NodeMaterial, { registerNodeMaterial } from './NodeMaterial.js';
+import NodeMaterial from './NodeMaterial.js';
 import { property, varyingProperty } from '../../nodes/core/PropertyNode.js';
 import { attribute } from '../../nodes/core/AttributeNode.js';
 import { cameraProjectionMatrix } from '../../nodes/accessors/Camera.js';
@@ -16,6 +16,12 @@ import { LineDashedMaterial } from '../LineDashedMaterial.js';
 const _defaultValues = /*@__PURE__*/ new LineDashedMaterial();
 
 class Line2NodeMaterial extends NodeMaterial {
+
+	static get type() {
+
+		return 'Line2NodeMaterial';
+
+	}
 
 	constructor( params = {} ) {
 
@@ -433,5 +439,3 @@ class Line2NodeMaterial extends NodeMaterial {
 }
 
 export default Line2NodeMaterial;
-
-Line2NodeMaterial.type = /*@__PURE__*/ registerNodeMaterial( 'Line2', Line2NodeMaterial );

--- a/src/materials/nodes/LineBasicNodeMaterial.js
+++ b/src/materials/nodes/LineBasicNodeMaterial.js
@@ -1,10 +1,16 @@
-import NodeMaterial, { registerNodeMaterial } from './NodeMaterial.js';
+import NodeMaterial from './NodeMaterial.js';
 
 import { LineBasicMaterial } from '../LineBasicMaterial.js';
 
 const _defaultValues = /*@__PURE__*/ new LineBasicMaterial();
 
 class LineBasicNodeMaterial extends NodeMaterial {
+
+	static get type() {
+
+		return 'LineBasicNodeMaterial';
+
+	}
 
 	constructor( parameters ) {
 
@@ -23,5 +29,3 @@ class LineBasicNodeMaterial extends NodeMaterial {
 }
 
 export default LineBasicNodeMaterial;
-
-LineBasicNodeMaterial.type = /*@__PURE__*/ registerNodeMaterial( 'LineBasic', LineBasicNodeMaterial );

--- a/src/materials/nodes/LineDashedNodeMaterial.js
+++ b/src/materials/nodes/LineDashedNodeMaterial.js
@@ -1,4 +1,4 @@
-import NodeMaterial, { registerNodeMaterial } from './NodeMaterial.js';
+import NodeMaterial from './NodeMaterial.js';
 import { attribute } from '../../nodes/core/AttributeNode.js';
 import { materialLineDashSize, materialLineGapSize, materialLineScale } from '../../nodes/accessors/MaterialNode.js';
 import { dashSize, gapSize } from '../../nodes/core/PropertyNode.js';
@@ -9,6 +9,12 @@ import { LineDashedMaterial } from '../LineDashedMaterial.js';
 const _defaultValues = /*@__PURE__*/ new LineDashedMaterial();
 
 class LineDashedNodeMaterial extends NodeMaterial {
+
+	static get type() {
+
+		return 'LineDashedNodeMaterial';
+
+	}
 
 	constructor( parameters ) {
 
@@ -49,5 +55,3 @@ class LineDashedNodeMaterial extends NodeMaterial {
 }
 
 export default LineDashedNodeMaterial;
-
-LineDashedNodeMaterial.type = /*@__PURE__*/ registerNodeMaterial( 'LineDashed', LineDashedNodeMaterial );

--- a/src/materials/nodes/MeshBasicNodeMaterial.js
+++ b/src/materials/nodes/MeshBasicNodeMaterial.js
@@ -1,4 +1,4 @@
-import NodeMaterial, { registerNodeMaterial } from './NodeMaterial.js';
+import NodeMaterial from './NodeMaterial.js';
 import { materialLightMap } from '../../nodes/accessors/MaterialNode.js';
 import BasicEnvironmentNode from '../../nodes/lighting/BasicEnvironmentNode.js';
 import BasicLightMapNode from '../../nodes/lighting/BasicLightMapNode.js';
@@ -11,6 +11,12 @@ import { MeshBasicMaterial } from '../MeshBasicMaterial.js';
 const _defaultValues = /*@__PURE__*/ new MeshBasicMaterial();
 
 class MeshBasicNodeMaterial extends NodeMaterial {
+
+	static get type() {
+
+		return 'MeshBasicNodeMaterial';
+
+	}
 
 	constructor( parameters ) {
 
@@ -69,5 +75,3 @@ class MeshBasicNodeMaterial extends NodeMaterial {
 }
 
 export default MeshBasicNodeMaterial;
-
-MeshBasicNodeMaterial.type = /*@__PURE__*/ registerNodeMaterial( 'MeshBasic', MeshBasicNodeMaterial );

--- a/src/materials/nodes/MeshLambertNodeMaterial.js
+++ b/src/materials/nodes/MeshLambertNodeMaterial.js
@@ -1,4 +1,4 @@
-import NodeMaterial, { registerNodeMaterial } from './NodeMaterial.js';
+import NodeMaterial from './NodeMaterial.js';
 import BasicEnvironmentNode from '../../nodes/lighting/BasicEnvironmentNode.js';
 import PhongLightingModel from '../../nodes/functions/PhongLightingModel.js';
 
@@ -7,6 +7,12 @@ import { MeshLambertMaterial } from '../MeshLambertMaterial.js';
 const _defaultValues = /*@__PURE__*/ new MeshLambertMaterial();
 
 class MeshLambertNodeMaterial extends NodeMaterial {
+
+	static get type() {
+
+		return 'MeshLambertNodeMaterial';
+
+	}
 
 	constructor( parameters ) {
 
@@ -39,5 +45,3 @@ class MeshLambertNodeMaterial extends NodeMaterial {
 }
 
 export default MeshLambertNodeMaterial;
-
-MeshLambertNodeMaterial.type = /*@__PURE__*/ registerNodeMaterial( 'MeshLambert', MeshLambertNodeMaterial );

--- a/src/materials/nodes/MeshMatcapNodeMaterial.js
+++ b/src/materials/nodes/MeshMatcapNodeMaterial.js
@@ -1,4 +1,4 @@
-import NodeMaterial, { registerNodeMaterial } from './NodeMaterial.js';
+import NodeMaterial from './NodeMaterial.js';
 import { materialReference } from '../../nodes/accessors/MaterialReferenceNode.js';
 import { diffuseColor } from '../../nodes/core/PropertyNode.js';
 import { vec3 } from '../../nodes/tsl/TSLBase.js';
@@ -10,6 +10,12 @@ import { MeshMatcapMaterial } from '../MeshMatcapMaterial.js';
 const _defaultValues = /*@__PURE__*/ new MeshMatcapMaterial();
 
 class MeshMatcapNodeMaterial extends NodeMaterial {
+
+	static get type() {
+
+		return 'MeshMatcapNodeMaterial';
+
+	}
 
 	constructor( parameters ) {
 
@@ -49,5 +55,3 @@ class MeshMatcapNodeMaterial extends NodeMaterial {
 
 
 export default MeshMatcapNodeMaterial;
-
-MeshMatcapNodeMaterial.type = /*@__PURE__*/ registerNodeMaterial( 'MeshMatcap', MeshMatcapNodeMaterial );

--- a/src/materials/nodes/MeshNormalNodeMaterial.js
+++ b/src/materials/nodes/MeshNormalNodeMaterial.js
@@ -1,4 +1,4 @@
-import NodeMaterial, { registerNodeMaterial } from './NodeMaterial.js';
+import NodeMaterial from './NodeMaterial.js';
 import { diffuseColor } from '../../nodes/core/PropertyNode.js';
 import { directionToColor } from '../../nodes/utils/Packing.js';
 import { materialOpacity } from '../../nodes/accessors/MaterialNode.js';
@@ -10,6 +10,12 @@ import { MeshNormalMaterial } from '../MeshNormalMaterial.js';
 const _defaultValues = /*@__PURE__*/ new MeshNormalMaterial();
 
 class MeshNormalNodeMaterial extends NodeMaterial {
+
+	static get type() {
+
+		return 'MeshNormalNodeMaterial';
+
+	}
 
 	constructor( parameters ) {
 
@@ -36,5 +42,3 @@ class MeshNormalNodeMaterial extends NodeMaterial {
 }
 
 export default MeshNormalNodeMaterial;
-
-MeshNormalNodeMaterial.type = /*@__PURE__*/ registerNodeMaterial( 'MeshNormal', MeshNormalNodeMaterial );

--- a/src/materials/nodes/MeshPhongNodeMaterial.js
+++ b/src/materials/nodes/MeshPhongNodeMaterial.js
@@ -1,4 +1,4 @@
-import NodeMaterial, { registerNodeMaterial } from './NodeMaterial.js';
+import NodeMaterial from './NodeMaterial.js';
 import { shininess, specularColor } from '../../nodes/core/PropertyNode.js';
 import { materialShininess, materialSpecular } from '../../nodes/accessors/MaterialNode.js';
 import { float } from '../../nodes/tsl/TSLBase.js';
@@ -10,6 +10,12 @@ import { MeshPhongMaterial } from '../MeshPhongMaterial.js';
 const _defaultValues = /*@__PURE__*/ new MeshPhongMaterial();
 
 class MeshPhongNodeMaterial extends NodeMaterial {
+
+	static get type() {
+
+		return 'MeshPhongNodeMaterial';
+
+	}
 
 	constructor( parameters ) {
 
@@ -70,5 +76,3 @@ class MeshPhongNodeMaterial extends NodeMaterial {
 }
 
 export default MeshPhongNodeMaterial;
-
-MeshPhongNodeMaterial.type = /*@__PURE__*/ registerNodeMaterial( 'MeshPhong', MeshPhongNodeMaterial );

--- a/src/materials/nodes/MeshPhysicalNodeMaterial.js
+++ b/src/materials/nodes/MeshPhysicalNodeMaterial.js
@@ -8,11 +8,16 @@ import MeshStandardNodeMaterial from './MeshStandardNodeMaterial.js';
 import { mix, pow2, min } from '../../nodes/math/MathNode.js';
 
 import { MeshPhysicalMaterial } from '../MeshPhysicalMaterial.js';
-import { registerNodeMaterial } from './NodeMaterial.js';
 
 const _defaultValues = /*@__PURE__*/ new MeshPhysicalMaterial();
 
 class MeshPhysicalNodeMaterial extends MeshStandardNodeMaterial {
+
+	static get type() {
+
+		return 'MeshPhysicalNodeMaterial';
+
+	}
 
 	constructor( parameters ) {
 
@@ -241,5 +246,3 @@ class MeshPhysicalNodeMaterial extends MeshStandardNodeMaterial {
 }
 
 export default MeshPhysicalNodeMaterial;
-
-MeshPhysicalNodeMaterial.type = /*@__PURE__*/ registerNodeMaterial( 'MeshPhysical', MeshPhysicalNodeMaterial );

--- a/src/materials/nodes/MeshSSSNodeMaterial.js
+++ b/src/materials/nodes/MeshSSSNodeMaterial.js
@@ -3,7 +3,6 @@ import PhysicalLightingModel from '../../nodes/functions/PhysicalLightingModel.j
 import { transformedNormalView } from '../../nodes/accessors/Normal.js';
 import { positionViewDirection } from '../../nodes/accessors/Position.js';
 import { float, vec3 } from '../../nodes/tsl/TSLBase.js';
-import { registerNodeMaterial } from './NodeMaterial.js';
 
 class SSSLightingModel extends PhysicalLightingModel {
 
@@ -38,6 +37,12 @@ class SSSLightingModel extends PhysicalLightingModel {
 }
 
 class MeshSSSNodeMaterial extends MeshPhysicalNodeMaterial {
+
+	static get type() {
+
+		return 'MeshSSSNodeMaterial';
+
+	}
 
 	constructor( parameters ) {
 
@@ -80,5 +85,3 @@ class MeshSSSNodeMaterial extends MeshPhysicalNodeMaterial {
 }
 
 export default MeshSSSNodeMaterial;
-
-MeshSSSNodeMaterial.type = /*@__PURE__*/ registerNodeMaterial( 'MeshSSS', MeshSSSNodeMaterial );

--- a/src/materials/nodes/MeshStandardNodeMaterial.js
+++ b/src/materials/nodes/MeshStandardNodeMaterial.js
@@ -1,4 +1,4 @@
-import NodeMaterial, { registerNodeMaterial } from './NodeMaterial.js';
+import NodeMaterial from './NodeMaterial.js';
 import { diffuseColor, metalness, roughness, specularColor, specularF90 } from '../../nodes/core/PropertyNode.js';
 import { mix } from '../../nodes/math/MathNode.js';
 import { materialRoughness, materialMetalness } from '../../nodes/accessors/MaterialNode.js';
@@ -12,6 +12,12 @@ import { MeshStandardMaterial } from '../MeshStandardMaterial.js';
 const _defaultValues = /*@__PURE__*/ new MeshStandardMaterial();
 
 class MeshStandardNodeMaterial extends NodeMaterial {
+
+	static get type() {
+
+		return 'MeshStandardNodeMaterial';
+
+	}
 
 	constructor( parameters ) {
 
@@ -100,5 +106,3 @@ class MeshStandardNodeMaterial extends NodeMaterial {
 }
 
 export default MeshStandardNodeMaterial;
-
-MeshStandardNodeMaterial.type = /*@__PURE__*/ registerNodeMaterial( 'MeshStandard', MeshStandardNodeMaterial );

--- a/src/materials/nodes/MeshToonNodeMaterial.js
+++ b/src/materials/nodes/MeshToonNodeMaterial.js
@@ -1,4 +1,4 @@
-import NodeMaterial, { registerNodeMaterial } from './NodeMaterial.js';
+import NodeMaterial from './NodeMaterial.js';
 import ToonLightingModel from '../../nodes/functions/ToonLightingModel.js';
 
 import { MeshToonMaterial } from '../MeshToonMaterial.js';
@@ -6,6 +6,12 @@ import { MeshToonMaterial } from '../MeshToonMaterial.js';
 const _defaultValues = /*@__PURE__*/ new MeshToonMaterial();
 
 class MeshToonNodeMaterial extends NodeMaterial {
+
+	static get type() {
+
+		return 'MeshToonNodeMaterial';
+
+	}
 
 	constructor( parameters ) {
 
@@ -30,5 +36,3 @@ class MeshToonNodeMaterial extends NodeMaterial {
 }
 
 export default MeshToonNodeMaterial;
-
-MeshToonNodeMaterial.type = /*@__PURE__*/ registerNodeMaterial( 'MeshToon', MeshToonNodeMaterial );

--- a/src/materials/nodes/NodeMaterial.js
+++ b/src/materials/nodes/NodeMaterial.js
@@ -23,9 +23,13 @@ import { depth } from '../../nodes/display/ViewportDepthNode.js';
 import { cameraLogDepth } from '../../nodes/accessors/Camera.js';
 import { clipping, clippingAlpha } from '../../nodes/accessors/ClippingNode.js';
 
-const NodeMaterials = new Map();
-
 class NodeMaterial extends Material {
+
+	static get type() {
+
+		return 'NodeMaterial';
+
+	}
 
 	constructor() {
 
@@ -623,45 +627,3 @@ class NodeMaterial extends Material {
 }
 
 export default NodeMaterial;
-
-NodeMaterial.type = /*@__PURE__*/ registerNodeMaterial( '', NodeMaterial );
-
-export function registerNodeMaterial( type, nodeMaterialClass ) {
-
-	const suffix = 'NodeMaterial';
-	const nodeMaterialType = type + suffix;
-
-	if ( typeof nodeMaterialClass !== 'function' ) throw new Error( `THREE.Node: NodeMaterial class "${ type }" is not a class.` );
-
-	if ( NodeMaterials.has( nodeMaterialType ) ) {
-
-		console.warn( `THREE.Node: Redefinition of NodeMaterial class "${ nodeMaterialType }".` );
-		return;
-
-	}
-
-	if ( type.slice( - suffix.length ) === suffix ) {
-
-		console.warn( `THREE.NodeMaterial: NodeMaterial class ${ nodeMaterialType } should not have '${ suffix }' suffix.` );
-		return;
-
-	}
-
-	NodeMaterials.set( nodeMaterialType, nodeMaterialClass );
-	nodeMaterialClass.type = nodeMaterialType;
-
-	return nodeMaterialType;
-
-}
-
-export function createNodeMaterialFromType( type ) {
-
-	const Material = NodeMaterials.get( type );
-
-	if ( Material !== undefined ) {
-
-		return new Material();
-
-	}
-
-}

--- a/src/materials/nodes/PointsNodeMaterial.js
+++ b/src/materials/nodes/PointsNodeMaterial.js
@@ -1,10 +1,16 @@
-import NodeMaterial, { registerNodeMaterial } from './NodeMaterial.js';
+import NodeMaterial from './NodeMaterial.js';
 
 import { PointsMaterial } from '../PointsMaterial.js';
 
 const _defaultValues = /*@__PURE__*/ new PointsMaterial();
 
 class PointsNodeMaterial extends NodeMaterial {
+
+	static get type() {
+
+		return 'PointsNodeMaterial';
+
+	}
 
 	constructor( parameters ) {
 
@@ -34,5 +40,3 @@ class PointsNodeMaterial extends NodeMaterial {
 }
 
 export default PointsNodeMaterial;
-
-PointsNodeMaterial.type = /*@__PURE__*/ registerNodeMaterial( 'Points', PointsNodeMaterial );

--- a/src/materials/nodes/ShadowNodeMaterial.js
+++ b/src/materials/nodes/ShadowNodeMaterial.js
@@ -1,4 +1,4 @@
-import NodeMaterial, { registerNodeMaterial } from './NodeMaterial.js';
+import NodeMaterial from './NodeMaterial.js';
 import ShadowMaskModel from '../../nodes/functions/ShadowMaskModel.js';
 
 import { ShadowMaterial } from '../ShadowMaterial.js';
@@ -6,6 +6,12 @@ import { ShadowMaterial } from '../ShadowMaterial.js';
 const _defaultValues = /*@__PURE__*/ new ShadowMaterial();
 
 class ShadowNodeMaterial extends NodeMaterial {
+
+	static get type() {
+
+		return 'ShadowNodeMaterial';
+
+	}
 
 	constructor( parameters ) {
 
@@ -30,5 +36,3 @@ class ShadowNodeMaterial extends NodeMaterial {
 }
 
 export default ShadowNodeMaterial;
-
-ShadowNodeMaterial.type = /*@__PURE__*/ registerNodeMaterial( 'Shadow', ShadowNodeMaterial );

--- a/src/materials/nodes/SpriteNodeMaterial.js
+++ b/src/materials/nodes/SpriteNodeMaterial.js
@@ -1,4 +1,4 @@
-import NodeMaterial, { registerNodeMaterial } from './NodeMaterial.js';
+import NodeMaterial from './NodeMaterial.js';
 import { uniform } from '../../nodes/core/UniformNode.js';
 import { cameraProjectionMatrix } from '../../nodes/accessors/Camera.js';
 import { materialRotation } from '../../nodes/accessors/MaterialNode.js';
@@ -12,6 +12,12 @@ import { SpriteMaterial } from '../SpriteMaterial.js';
 const _defaultValues = /*@__PURE__*/ new SpriteMaterial();
 
 class SpriteNodeMaterial extends NodeMaterial {
+
+	static get type() {
+
+		return 'SpriteNodeMaterial';
+
+	}
 
 	constructor( parameters ) {
 
@@ -86,5 +92,3 @@ class SpriteNodeMaterial extends NodeMaterial {
 }
 
 export default SpriteNodeMaterial;
-
-SpriteNodeMaterial.type = /*@__PURE__*/ registerNodeMaterial( 'Sprite', SpriteNodeMaterial );

--- a/src/materials/nodes/VolumeNodeMaterial.js
+++ b/src/materials/nodes/VolumeNodeMaterial.js
@@ -100,3 +100,5 @@ class VolumeNodeMaterial extends NodeMaterial {
 }
 
 export default VolumeNodeMaterial;
+
+VolumeNodeMaterial.type = /*@__PURE__*/ registerNodeMaterial( 'Volume', VolumeNodeMaterial );

--- a/src/materials/nodes/VolumeNodeMaterial.js
+++ b/src/materials/nodes/VolumeNodeMaterial.js
@@ -1,4 +1,4 @@
-import NodeMaterial, { registerNodeMaterial } from './NodeMaterial.js';
+import NodeMaterial from './NodeMaterial.js';
 import { property } from '../../nodes/core/PropertyNode.js';
 import { materialReference } from '../../nodes/accessors/MaterialReferenceNode.js';
 import { modelWorldMatrixInverse } from '../../nodes/accessors/ModelNode.js';
@@ -10,6 +10,12 @@ import { Loop, Break } from '../../nodes/utils/LoopNode.js';
 import { texture3D } from '../../nodes/accessors/Texture3DNode.js';
 
 class VolumeNodeMaterial extends NodeMaterial {
+
+	static get type() {
+
+		return 'VolumeNodeMaterial';
+
+	}
 
 	constructor( params = {} ) {
 
@@ -100,5 +106,3 @@ class VolumeNodeMaterial extends NodeMaterial {
 }
 
 export default VolumeNodeMaterial;
-
-VolumeNodeMaterial.type = /*@__PURE__*/ registerNodeMaterial( 'Volume', VolumeNodeMaterial );

--- a/src/materials/nodes/VolumeNodeMaterial.js
+++ b/src/materials/nodes/VolumeNodeMaterial.js
@@ -100,5 +100,3 @@ class VolumeNodeMaterial extends NodeMaterial {
 }
 
 export default VolumeNodeMaterial;
-
-VolumeNodeMaterial.type = /*@__PURE__*/ registerNodeMaterial( 'Volume', VolumeNodeMaterial );

--- a/src/nodes/Nodes.js
+++ b/src/nodes/Nodes.js
@@ -10,7 +10,7 @@ export { default as ConstNode } from './core/ConstNode.js';
 export { default as ContextNode } from './core/ContextNode.js';
 export { default as IndexNode } from './core/IndexNode.js';
 export { default as LightingModel } from './core/LightingModel.js';
-export { default as Node, registerNode } from './core/Node.js';
+export { default as Node } from './core/Node.js';
 export { default as VarNode } from './core/VarNode.js';
 export { default as NodeAttribute } from './core/NodeAttribute.js';
 export { default as NodeBuilder } from './core/NodeBuilder.js';

--- a/src/nodes/accessors/BatchNode.js
+++ b/src/nodes/accessors/BatchNode.js
@@ -1,4 +1,4 @@
-import Node, { registerNode } from '../core/Node.js';
+import Node from '../core/Node.js';
 import { normalLocal } from './Normal.js';
 import { positionLocal } from './Position.js';
 import { nodeProxy, vec3, mat3, mat4, int, ivec2, float, Fn } from '../tsl/TSLBase.js';
@@ -9,6 +9,12 @@ import { instanceIndex, drawIndex } from '../core/IndexNode.js';
 import { varyingProperty } from '../core/PropertyNode.js';
 
 class BatchNode extends Node {
+
+	static get type() {
+
+		return 'BatchNode';
+
+	}
 
 	constructor( batchMesh ) {
 
@@ -118,7 +124,5 @@ class BatchNode extends Node {
 }
 
 export default BatchNode;
-
-BatchNode.type = /*@__PURE__*/ registerNode( 'Batch', BatchNode );
 
 export const batch = /*@__PURE__*/ nodeProxy( BatchNode );

--- a/src/nodes/accessors/BufferAttributeNode.js
+++ b/src/nodes/accessors/BufferAttributeNode.js
@@ -1,4 +1,3 @@
-import { registerNode } from '../core/Node.js';
 import InputNode from '../core/InputNode.js';
 import { nodeObject, addMethodChaining } from '../tsl/TSLCore.js';
 import { varying } from '../core/VaryingNode.js';
@@ -8,6 +7,12 @@ import { InterleavedBuffer } from '../../core/InterleavedBuffer.js';
 import { StaticDrawUsage, DynamicDrawUsage } from '../../constants.js';
 
 class BufferAttributeNode extends InputNode {
+
+	static get type() {
+
+		return 'BufferAttributeNode';
+
+	}
 
 	constructor( value, bufferType = null, bufferStride = 0, bufferOffset = 0 ) {
 
@@ -150,8 +155,6 @@ class BufferAttributeNode extends InputNode {
 }
 
 export default BufferAttributeNode;
-
-BufferAttributeNode.type = /*@__PURE__*/ registerNode( 'BufferAttribute', BufferAttributeNode );
 
 export const bufferAttribute = ( array, type, stride, offset ) => nodeObject( new BufferAttributeNode( array, type, stride, offset ) );
 export const dynamicBufferAttribute = ( array, type, stride, offset ) => bufferAttribute( array, type, stride, offset ).setUsage( DynamicDrawUsage );

--- a/src/nodes/accessors/BufferNode.js
+++ b/src/nodes/accessors/BufferNode.js
@@ -1,8 +1,13 @@
-import { registerNode } from '../core/Node.js';
 import UniformNode from '../core/UniformNode.js';
 import { nodeObject } from '../tsl/TSLBase.js';
 
 class BufferNode extends UniformNode {
+
+	static get type() {
+
+		return 'BufferNode';
+
+	}
 
 	constructor( value, bufferType, bufferCount = 0 ) {
 
@@ -30,7 +35,5 @@ class BufferNode extends UniformNode {
 }
 
 export default BufferNode;
-
-BufferNode.type = /*@__PURE__*/ registerNode( 'Buffer', BufferNode );
 
 export const buffer = ( value, type, count ) => nodeObject( new BufferNode( value, type, count ) );

--- a/src/nodes/accessors/ClippingNode.js
+++ b/src/nodes/accessors/ClippingNode.js
@@ -1,5 +1,5 @@
 
-import Node, { registerNode } from '../core/Node.js';
+import Node from '../core/Node.js';
 import { nodeObject } from '../tsl/TSLBase.js';
 import { positionView } from './Position.js';
 import { diffuseColor, property } from '../core/PropertyNode.js';
@@ -9,6 +9,12 @@ import { smoothstep } from '../math/MathNode.js';
 import { uniformArray } from './UniformArrayNode.js';
 
 class ClippingNode extends Node {
+
+	static get type() {
+
+		return 'ClippingNode';
+
+	}
 
 	constructor( scope = ClippingNode.DEFAULT ) {
 
@@ -139,8 +145,6 @@ ClippingNode.ALPHA_TO_COVERAGE = 'alphaToCoverage';
 ClippingNode.DEFAULT = 'default';
 
 export default ClippingNode;
-
-ClippingNode.type = /*@__PURE__*/ registerNode( 'Clipping', ClippingNode );
 
 export const clipping = () => nodeObject( new ClippingNode() );
 

--- a/src/nodes/accessors/CubeTextureNode.js
+++ b/src/nodes/accessors/CubeTextureNode.js
@@ -1,4 +1,3 @@
-import { registerNode } from '../core/Node.js';
 import TextureNode from './TextureNode.js';
 import { reflectVector, refractVector } from './ReflectVector.js';
 import { nodeProxy, vec3 } from '../tsl/TSLBase.js';
@@ -6,6 +5,12 @@ import { nodeProxy, vec3 } from '../tsl/TSLBase.js';
 import { CubeReflectionMapping, CubeRefractionMapping, WebGPUCoordinateSystem } from '../../constants.js';
 
 class CubeTextureNode extends TextureNode {
+
+	static get type() {
+
+		return 'CubeTextureNode';
+
+	}
 
 	constructor( value, uvNode = null, levelNode = null, biasNode = null ) {
 
@@ -70,7 +75,5 @@ class CubeTextureNode extends TextureNode {
 }
 
 export default CubeTextureNode;
-
-CubeTextureNode.type = /*@__PURE__*/ registerNode( 'CubeTexture', CubeTextureNode );
 
 export const cubeTexture = /*@__PURE__*/ nodeProxy( CubeTextureNode );

--- a/src/nodes/accessors/InstanceNode.js
+++ b/src/nodes/accessors/InstanceNode.js
@@ -1,4 +1,4 @@
-import Node, { registerNode } from '../core/Node.js';
+import Node from '../core/Node.js';
 import { varyingProperty } from '../core/PropertyNode.js';
 import { instancedBufferAttribute, instancedDynamicBufferAttribute } from './BufferAttributeNode.js';
 import { normalLocal } from './Normal.js';
@@ -13,6 +13,12 @@ import { InstancedBufferAttribute } from '../../core/InstancedBufferAttribute.js
 import { DynamicDrawUsage } from '../../constants.js';
 
 class InstanceNode extends Node {
+
+	static get type() {
+
+		return 'InstanceNode';
+
+	}
 
 	constructor( instanceMesh ) {
 
@@ -138,7 +144,5 @@ class InstanceNode extends Node {
 }
 
 export default InstanceNode;
-
-InstanceNode.type = /*@__PURE__*/ registerNode( 'Instance', InstanceNode );
 
 export const instance = /*@__PURE__*/ nodeProxy( InstanceNode );

--- a/src/nodes/accessors/InstancedPointsMaterialNode.js
+++ b/src/nodes/accessors/InstancedPointsMaterialNode.js
@@ -1,8 +1,13 @@
-import { registerNode } from '../core/Node.js';
 import MaterialNode from './MaterialNode.js';
 import { nodeImmutable } from '../tsl/TSLBase.js';
 
 class InstancedPointsMaterialNode extends MaterialNode {
+
+	static get type() {
+
+		return 'InstancedPointsMaterialNode';
+
+	}
 
 	setup( /*builder*/ ) {
 
@@ -15,7 +20,5 @@ class InstancedPointsMaterialNode extends MaterialNode {
 InstancedPointsMaterialNode.POINT_WIDTH = 'pointWidth';
 
 export default InstancedPointsMaterialNode;
-
-InstancedPointsMaterialNode.type = /*@__PURE__*/ registerNode( 'InstancedPointsMaterial', InstancedPointsMaterialNode );
 
 export const materialPointWidth = /*@__PURE__*/ nodeImmutable( InstancedPointsMaterialNode, InstancedPointsMaterialNode.POINT_WIDTH );

--- a/src/nodes/accessors/MaterialNode.js
+++ b/src/nodes/accessors/MaterialNode.js
@@ -1,4 +1,4 @@
-import Node, { registerNode } from '../core/Node.js';
+import Node from '../core/Node.js';
 import { reference } from './ReferenceNode.js';
 import { materialReference } from './MaterialReferenceNode.js';
 import { normalView } from './Normal.js';
@@ -12,6 +12,12 @@ import { Vector2 } from '../../math/Vector2.js';
 const _propertyCache = new Map();
 
 class MaterialNode extends Node {
+
+	static get type() {
+
+		return 'MaterialNode';
+
+	}
 
 	constructor( scope ) {
 
@@ -383,8 +389,6 @@ MaterialNode.LIGHT_MAP = 'light';
 MaterialNode.AO_MAP = 'ao';
 
 export default MaterialNode;
-
-MaterialNode.type = /*@__PURE__*/ registerNode( 'Material', MaterialNode );
 
 export const materialAlphaTest = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.ALPHA_TEST );
 export const materialColor = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.COLOR );

--- a/src/nodes/accessors/MaterialReferenceNode.js
+++ b/src/nodes/accessors/MaterialReferenceNode.js
@@ -1,10 +1,15 @@
-import { registerNode } from '../core/Node.js';
 import ReferenceNode from './ReferenceNode.js';
 //import { renderGroup } from '../core/UniformGroupNode.js';
 //import { NodeUpdateType } from '../core/constants.js';
 import { nodeObject } from '../tsl/TSLBase.js';
 
 class MaterialReferenceNode extends ReferenceNode {
+
+	static get type() {
+
+		return 'MaterialReferenceNode';
+
+	}
 
 	constructor( property, inputType, material = null ) {
 
@@ -37,7 +42,5 @@ class MaterialReferenceNode extends ReferenceNode {
 }
 
 export default MaterialReferenceNode;
-
-MaterialReferenceNode.type = /*@__PURE__*/ registerNode( 'MaterialReference', MaterialReferenceNode );
 
 export const materialReference = ( name, type, material ) => nodeObject( new MaterialReferenceNode( name, type, material ) );

--- a/src/nodes/accessors/ModelNode.js
+++ b/src/nodes/accessors/ModelNode.js
@@ -1,4 +1,3 @@
-import { registerNode } from '../core/Node.js';
 import Object3DNode from './Object3DNode.js';
 import { nodeImmutable } from '../tsl/TSLBase.js';
 import { uniform } from '../core/UniformNode.js';
@@ -6,6 +5,12 @@ import { uniform } from '../core/UniformNode.js';
 import { Matrix4 } from '../../math/Matrix4.js';
 
 class ModelNode extends Object3DNode {
+
+	static get type() {
+
+		return 'ModelNode';
+
+	}
 
 	constructor( scope = ModelNode.VIEW_MATRIX ) {
 
@@ -24,8 +29,6 @@ class ModelNode extends Object3DNode {
 }
 
 export default ModelNode;
-
-ModelNode.type = /*@__PURE__*/ registerNode( 'Model', ModelNode );
 
 export const modelDirection = /*@__PURE__*/ nodeImmutable( ModelNode, ModelNode.DIRECTION );
 export const modelViewMatrix = /*@__PURE__*/ nodeImmutable( ModelNode, ModelNode.VIEW_MATRIX ).label( 'modelViewMatrix' ).toVar( 'ModelViewMatrix' );

--- a/src/nodes/accessors/ModelViewProjectionNode.js
+++ b/src/nodes/accessors/ModelViewProjectionNode.js
@@ -1,4 +1,3 @@
-import { registerNode } from '../core/Node.js';
 import TempNode from '../core/TempNode.js';
 import { cameraProjectionMatrix } from './Camera.js';
 import { modelViewMatrix } from './ModelNode.js';
@@ -6,6 +5,12 @@ import { positionLocal } from './Position.js';
 import { nodeProxy, varying } from '../tsl/TSLBase.js';
 
 class ModelViewProjectionNode extends TempNode {
+
+	static get type() {
+
+		return 'ModelViewProjectionNode';
+
+	}
 
 	constructor( positionNode = null ) {
 
@@ -32,7 +37,5 @@ class ModelViewProjectionNode extends TempNode {
 }
 
 export default ModelViewProjectionNode;
-
-ModelViewProjectionNode.type = /*@__PURE__*/ registerNode( 'ModelViewProjection', ModelViewProjectionNode );
 
 export const modelViewProjection = /*@__PURE__*/ nodeProxy( ModelViewProjectionNode );

--- a/src/nodes/accessors/MorphNode.js
+++ b/src/nodes/accessors/MorphNode.js
@@ -1,4 +1,4 @@
-import Node, { registerNode } from '../core/Node.js';
+import Node from '../core/Node.js';
 import { NodeUpdateType } from '../core/constants.js';
 import { float, nodeProxy, Fn } from '../tsl/TSLBase.js';
 import { uniform } from '../core/UniformNode.js';
@@ -160,6 +160,12 @@ function getEntry( geometry ) {
 
 class MorphNode extends Node {
 
+	static get type() {
+
+		return 'MorphNode';
+
+	}
+
 	constructor( mesh ) {
 
 		super( 'void' );
@@ -253,7 +259,5 @@ class MorphNode extends Node {
 }
 
 export default MorphNode;
-
-MorphNode.type = /*@__PURE__*/ registerNode( 'Morph', MorphNode );
 
 export const morphReference = /*@__PURE__*/ nodeProxy( MorphNode );

--- a/src/nodes/accessors/Object3DNode.js
+++ b/src/nodes/accessors/Object3DNode.js
@@ -1,4 +1,4 @@
-import Node, { registerNode } from '../core/Node.js';
+import Node from '../core/Node.js';
 import { NodeUpdateType } from '../core/constants.js';
 import UniformNode from '../core/UniformNode.js';
 import { nodeProxy } from '../tsl/TSLBase.js';
@@ -6,6 +6,12 @@ import { nodeProxy } from '../tsl/TSLBase.js';
 import { Vector3 } from '../../math/Vector3.js';
 
 class Object3DNode extends Node {
+
+	static get type() {
+
+		return 'Object3DNode';
+
+	}
 
 	constructor( scope = Object3DNode.VIEW_MATRIX, object3d = null ) {
 
@@ -138,8 +144,6 @@ Object3DNode.VIEW_POSITION = 'viewPosition';
 Object3DNode.DIRECTION = 'direction';
 
 export default Object3DNode;
-
-Object3DNode.type = /*@__PURE__*/ registerNode( 'Object3D', Object3DNode );
 
 export const objectDirection = /*@__PURE__*/ nodeProxy( Object3DNode, Object3DNode.DIRECTION );
 export const objectViewMatrix = /*@__PURE__*/ nodeProxy( Object3DNode, Object3DNode.VIEW_MATRIX );

--- a/src/nodes/accessors/PointUVNode.js
+++ b/src/nodes/accessors/PointUVNode.js
@@ -1,7 +1,13 @@
-import Node, { registerNode } from '../core/Node.js';
+import Node from '../core/Node.js';
 import { nodeImmutable } from '../tsl/TSLBase.js';
 
 class PointUVNode extends Node {
+
+	static get type() {
+
+		return 'PointUVNode';
+
+	}
 
 	constructor() {
 
@@ -20,7 +26,5 @@ class PointUVNode extends Node {
 }
 
 export default PointUVNode;
-
-PointUVNode.type = /*@__PURE__*/ registerNode( 'PointUV', PointUVNode );
 
 export const pointUV = /*@__PURE__*/ nodeImmutable( PointUVNode );

--- a/src/nodes/accessors/ReferenceBaseNode.js
+++ b/src/nodes/accessors/ReferenceBaseNode.js
@@ -1,10 +1,16 @@
-import Node, { registerNode } from '../core/Node.js';
+import Node from '../core/Node.js';
 import { NodeUpdateType } from '../core/constants.js';
 import { uniform } from '../core/UniformNode.js';
 import { nodeObject } from '../tsl/TSLCore.js';
 import ArrayElementNode from '../utils/ArrayElementNode.js';
 
 class ReferenceElementNode extends ArrayElementNode {
+
+	static get type() {
+
+		return 'ReferenceElementNode';
+
+	}
 
 	constructor( referenceNode, indexNode ) {
 
@@ -35,6 +41,12 @@ class ReferenceElementNode extends ArrayElementNode {
 }
 
 class ReferenceBaseNode extends Node {
+
+	static get type() {
+
+		return 'ReferenceBaseNode';
+
+	}
 
 	constructor( property, uniformType, object = null, count = null ) {
 
@@ -136,8 +148,6 @@ class ReferenceBaseNode extends Node {
 }
 
 export default ReferenceBaseNode;
-
-ReferenceBaseNode.type = /*@__PURE__*/ registerNode( 'ReferenceBase', ReferenceBaseNode );
 
 export const reference = ( name, type, object ) => nodeObject( new ReferenceBaseNode( name, type, object ) );
 export const referenceBuffer = ( name, type, count, object ) => nodeObject( new ReferenceBaseNode( name, type, object, count ) );

--- a/src/nodes/accessors/ReferenceNode.js
+++ b/src/nodes/accessors/ReferenceNode.js
@@ -1,4 +1,4 @@
-import Node, { registerNode } from '../core/Node.js';
+import Node from '../core/Node.js';
 import { NodeUpdateType } from '../core/constants.js';
 import { uniform } from '../core/UniformNode.js';
 import { texture } from './TextureNode.js';
@@ -9,6 +9,12 @@ import { uniformArray } from './UniformArrayNode.js';
 import ArrayElementNode from '../utils/ArrayElementNode.js';
 
 class ReferenceElementNode extends ArrayElementNode {
+
+	static get type() {
+
+		return 'ReferenceElementNode';
+
+	}
 
 	constructor( referenceNode, indexNode ) {
 
@@ -40,6 +46,12 @@ class ReferenceElementNode extends ArrayElementNode {
 
 // TODO: Extends this from ReferenceBaseNode
 class ReferenceNode extends Node {
+
+	static get type() {
+
+		return 'ReferenceNode';
+
+	}
 
 	constructor( property, uniformType, object = null, count = null ) {
 
@@ -165,8 +177,6 @@ class ReferenceNode extends Node {
 }
 
 export default ReferenceNode;
-
-ReferenceNode.type = /*@__PURE__*/ registerNode( 'Reference', ReferenceNode );
 
 export const reference = ( name, type, object ) => nodeObject( new ReferenceNode( name, type, object ) );
 export const referenceBuffer = ( name, type, count, object ) => nodeObject( new ReferenceNode( name, type, object, count ) );

--- a/src/nodes/accessors/RendererReferenceNode.js
+++ b/src/nodes/accessors/RendererReferenceNode.js
@@ -1,8 +1,13 @@
-import { registerNode } from '../core/Node.js';
 import ReferenceBaseNode from './ReferenceBaseNode.js';
 import { nodeObject } from '../tsl/TSLCore.js';
 
 class RendererReferenceNode extends ReferenceBaseNode {
+
+	static get type() {
+
+		return 'RendererReferenceNode';
+
+	}
 
 	constructor( property, inputType, renderer = null ) {
 
@@ -23,7 +28,5 @@ class RendererReferenceNode extends ReferenceBaseNode {
 }
 
 export default RendererReferenceNode;
-
-RendererReferenceNode.type = /*@__PURE__*/ registerNode( 'RendererReference', RendererReferenceNode );
 
 export const rendererReference = ( name, type, renderer ) => nodeObject( new RendererReferenceNode( name, type, renderer ) );

--- a/src/nodes/accessors/SceneNode.js
+++ b/src/nodes/accessors/SceneNode.js
@@ -1,8 +1,14 @@
-import Node, { registerNode } from '../core/Node.js';
+import Node from '../core/Node.js';
 import { nodeImmutable } from '../tsl/TSLBase.js';
 import { reference } from './ReferenceNode.js';
 
 class SceneNode extends Node {
+
+	static get type() {
+
+		return 'SceneNode';
+
+	}
 
 	constructor( scope = SceneNode.BACKGROUND_BLURRINESS, scene = null ) {
 
@@ -44,8 +50,6 @@ SceneNode.BACKGROUND_BLURRINESS = 'backgroundBlurriness';
 SceneNode.BACKGROUND_INTENSITY = 'backgroundIntensity';
 
 export default SceneNode;
-
-SceneNode.type = /*@__PURE__*/ registerNode( 'Scene', SceneNode );
 
 export const backgroundBlurriness = /*@__PURE__*/ nodeImmutable( SceneNode, SceneNode.BACKGROUND_BLURRINESS );
 export const backgroundIntensity = /*@__PURE__*/ nodeImmutable( SceneNode, SceneNode.BACKGROUND_INTENSITY );

--- a/src/nodes/accessors/SkinningNode.js
+++ b/src/nodes/accessors/SkinningNode.js
@@ -1,4 +1,4 @@
-import Node, { registerNode } from '../core/Node.js';
+import Node from '../core/Node.js';
 import { NodeUpdateType } from '../core/constants.js';
 import { nodeObject } from '../tsl/TSLBase.js';
 import { attribute } from '../core/AttributeNode.js';
@@ -13,6 +13,12 @@ import { buffer } from './BufferNode.js';
 const _frameId = new WeakMap();
 
 class SkinningNode extends Node {
+
+	static get type() {
+
+		return 'SkinningNode';
+
+	}
 
 	constructor( skinnedMesh, useReference = false ) {
 
@@ -180,8 +186,6 @@ class SkinningNode extends Node {
 }
 
 export default SkinningNode;
-
-SkinningNode.type = /*@__PURE__*/ registerNode( 'Skinning', SkinningNode );
 
 export const skinning = ( skinnedMesh ) => nodeObject( new SkinningNode( skinnedMesh ) );
 export const skinningReference = ( skinnedMesh ) => nodeObject( new SkinningNode( skinnedMesh, true ) );

--- a/src/nodes/accessors/StorageBufferNode.js
+++ b/src/nodes/accessors/StorageBufferNode.js
@@ -1,4 +1,3 @@
-import { registerNode } from '../core/Node.js';
 import BufferNode from './BufferNode.js';
 import { bufferAttribute } from './BufferAttributeNode.js';
 import { nodeObject, varying } from '../tsl/TSLBase.js';
@@ -6,6 +5,12 @@ import { storageElement } from '../utils/StorageArrayElementNode.js';
 import { GPUBufferBindingType } from '../../renderers/webgpu/utils/WebGPUConstants.js';
 
 class StorageBufferNode extends BufferNode {
+
+	static get type() {
+
+		return 'StorageBufferNode';
+
+	}
 
 	constructor( value, bufferType, bufferCount = 0 ) {
 
@@ -121,8 +126,6 @@ class StorageBufferNode extends BufferNode {
 }
 
 export default StorageBufferNode;
-
-StorageBufferNode.type = /*@__PURE__*/ registerNode( 'StorageBuffer', StorageBufferNode );
 
 // Read-Write Storage
 export const storage = ( value, type, count ) => nodeObject( new StorageBufferNode( value, type, count ) );

--- a/src/nodes/accessors/StorageTextureNode.js
+++ b/src/nodes/accessors/StorageTextureNode.js
@@ -1,9 +1,14 @@
-import { registerNode } from '../core/Node.js';
 import TextureNode from './TextureNode.js';
 import { nodeProxy } from '../tsl/TSLBase.js';
 import { GPUStorageTextureAccess } from '../../renderers/webgpu/utils/WebGPUConstants.js';
 
 class StorageTextureNode extends TextureNode {
+
+	static get type() {
+
+		return 'StorageTextureNode';
+
+	}
 
 	constructor( value, uvNode, storeNode = null ) {
 
@@ -88,8 +93,6 @@ class StorageTextureNode extends TextureNode {
 }
 
 export default StorageTextureNode;
-
-StorageTextureNode.type = /*@__PURE__*/ registerNode( 'StorageTexture', StorageTextureNode );
 
 export const storageTexture = /*@__PURE__*/ nodeProxy( StorageTextureNode );
 

--- a/src/nodes/accessors/Texture3DNode.js
+++ b/src/nodes/accessors/Texture3DNode.js
@@ -1,4 +1,3 @@
-import { registerNode } from '../core/Node.js';
 import TextureNode from './TextureNode.js';
 import { nodeProxy, vec3, Fn, If } from '../tsl/TSLBase.js';
 
@@ -51,6 +50,12 @@ const normal = Fn( ( { texture, uv } ) => {
 
 class Texture3DNode extends TextureNode {
 
+	static get type() {
+
+		return 'Texture3DNode';
+
+	}
+
 	constructor( value, uvNode = null, levelNode = null ) {
 
 		super( value, uvNode, levelNode );
@@ -94,7 +99,5 @@ class Texture3DNode extends TextureNode {
 }
 
 export default Texture3DNode;
-
-Texture3DNode.type = /*@__PURE__*/ registerNode( 'Texture3D', Texture3DNode );
 
 export const texture3D = /*@__PURE__*/ nodeProxy( Texture3DNode );

--- a/src/nodes/accessors/TextureNode.js
+++ b/src/nodes/accessors/TextureNode.js
@@ -1,4 +1,3 @@
-import { registerNode } from '../core/Node.js';
 import UniformNode, { uniform } from '../core/UniformNode.js';
 import { uv } from './UV.js';
 import { textureSize } from './TextureSizeNode.js';
@@ -11,6 +10,12 @@ import { NodeUpdateType } from '../core/constants.js';
 import { IntType, UnsignedIntType } from '../../constants.js';
 
 class TextureNode extends UniformNode {
+
+	static get type() {
+
+		return 'TextureNode';
+
+	}
 
 	constructor( value, uvNode = null, levelNode = null, biasNode = null ) {
 
@@ -429,8 +434,6 @@ class TextureNode extends UniformNode {
 }
 
 export default TextureNode;
-
-TextureNode.type = /*@__PURE__*/ registerNode( 'Texture', TextureNode );
 
 export const texture = /*@__PURE__*/ nodeProxy( TextureNode );
 export const textureLoad = ( ...params ) => texture( ...params ).setSampler( false );

--- a/src/nodes/accessors/TextureSizeNode.js
+++ b/src/nodes/accessors/TextureSizeNode.js
@@ -1,8 +1,13 @@
-import { registerNode } from '../core/Node.js';
 import Node from '../core/Node.js';
 import { nodeProxy } from '../tsl/TSLBase.js';
 
 class TextureSizeNode extends Node {
+
+	static get type() {
+
+		return 'TextureSizeNode';
+
+	}
 
 	constructor( textureNode, levelNode = null ) {
 
@@ -27,7 +32,5 @@ class TextureSizeNode extends Node {
 }
 
 export default TextureSizeNode;
-
-TextureSizeNode.type = /*@__PURE__*/ registerNode( 'TextureSize', TextureSizeNode );
 
 export const textureSize = /*@__PURE__*/ nodeProxy( TextureSizeNode );

--- a/src/nodes/accessors/UniformArrayNode.js
+++ b/src/nodes/accessors/UniformArrayNode.js
@@ -1,4 +1,3 @@
-import { registerNode } from '../core/Node.js';
 import { nodeObject } from '../tsl/TSLBase.js';
 import { NodeUpdateType } from '../core/constants.js';
 import { getValueType } from '../core/NodeUtils.js';
@@ -6,6 +5,12 @@ import ArrayElementNode from '../utils/ArrayElementNode.js';
 import BufferNode from './BufferNode.js';
 
 class UniformArrayElementNode extends ArrayElementNode {
+
+	static get type() {
+
+		return 'UniformArrayElementNode';
+
+	}
 
 	constructor( arrayBuffer, indexNode ) {
 
@@ -33,6 +38,12 @@ class UniformArrayElementNode extends ArrayElementNode {
 }
 
 class UniformArrayNode extends BufferNode {
+
+	static get type() {
+
+		return 'UniformArrayNode';
+
+	}
 
 	constructor( value, elementType = null ) {
 
@@ -140,8 +151,6 @@ class UniformArrayNode extends BufferNode {
 }
 
 export default UniformArrayNode;
-
-UniformArrayNode.type = /*@__PURE__*/ registerNode( 'UniformArray', UniformArrayNode );
 
 export const uniformArray = ( values, nodeType ) => nodeObject( new UniformArrayNode( values, nodeType ) );
 

--- a/src/nodes/accessors/UserDataNode.js
+++ b/src/nodes/accessors/UserDataNode.js
@@ -1,8 +1,13 @@
-import { registerNode } from '../core/Node.js';
 import ReferenceNode from './ReferenceNode.js';
 import { nodeObject } from '../tsl/TSLBase.js';
 
 class UserDataNode extends ReferenceNode {
+
+	static get type() {
+
+		return 'UserDataNode';
+
+	}
 
 	constructor( property, inputType, userData = null ) {
 
@@ -23,7 +28,5 @@ class UserDataNode extends ReferenceNode {
 }
 
 export default UserDataNode;
-
-UserDataNode.type = /*@__PURE__*/ registerNode( 'UserData', UserDataNode );
 
 export const userData = ( name, inputType, userData ) => nodeObject( new UserDataNode( name, inputType, userData ) );

--- a/src/nodes/accessors/VelocityNode.js
+++ b/src/nodes/accessors/VelocityNode.js
@@ -1,4 +1,3 @@
-import { registerNode } from '../core/Node.js';
 import TempNode from '../core/TempNode.js';
 import { modelViewMatrix } from './ModelNode.js';
 import { positionLocal, positionPrevious } from './Position.js';
@@ -12,6 +11,12 @@ import { cameraProjectionMatrix } from './Camera.js';
 const _matrixCache = new WeakMap();
 
 class VelocityNode extends TempNode {
+
+	static get type() {
+
+		return 'VelocityNode';
+
+	}
 
 	constructor() {
 
@@ -77,7 +82,5 @@ function getPreviousMatrix( object ) {
 }
 
 export default VelocityNode;
-
-VelocityNode.type = /*@__PURE__*/ registerNode( 'Velocity', VelocityNode );
 
 export const velocity = /*@__PURE__*/ nodeImmutable( VelocityNode );

--- a/src/nodes/accessors/VertexColorNode.js
+++ b/src/nodes/accessors/VertexColorNode.js
@@ -1,10 +1,15 @@
-import { registerNode } from '../core/Node.js';
 import AttributeNode from '../core/AttributeNode.js';
 import { nodeObject } from '../tsl/TSLBase.js';
 
 import { Vector4 } from '../../math/Vector4.js';
 
 class VertexColorNode extends AttributeNode {
+
+	static get type() {
+
+		return 'VertexColorNode';
+
+	}
 
 	constructor( index = 0 ) {
 
@@ -65,7 +70,5 @@ class VertexColorNode extends AttributeNode {
 }
 
 export default VertexColorNode;
-
-VertexColorNode.type = /*@__PURE__*/ registerNode( 'VertexColor', VertexColorNode );
 
 export const vertexColor = ( ...params ) => nodeObject( new VertexColorNode( ...params ) );

--- a/src/nodes/code/CodeNode.js
+++ b/src/nodes/code/CodeNode.js
@@ -1,7 +1,13 @@
-import Node, { registerNode } from '../core/Node.js';
+import Node from '../core/Node.js';
 import { nodeProxy } from '../tsl/TSLBase.js';
 
 class CodeNode extends Node {
+
+	static get type() {
+
+		return 'CodeNode';
+
+	}
 
 	constructor( code = '', includes = [], language = '' ) {
 
@@ -74,8 +80,6 @@ class CodeNode extends Node {
 }
 
 export default CodeNode;
-
-CodeNode.type = /*@__PURE__*/ registerNode( 'Code', CodeNode );
 
 export const code = /*@__PURE__*/ nodeProxy( CodeNode );
 

--- a/src/nodes/code/ExpressionNode.js
+++ b/src/nodes/code/ExpressionNode.js
@@ -1,7 +1,13 @@
-import Node, { registerNode } from '../core/Node.js';
+import Node from '../core/Node.js';
 import { nodeProxy } from '../tsl/TSLCore.js';
 
 class ExpressionNode extends Node {
+
+	static get type() {
+
+		return 'ExpressionNode';
+
+	}
 
 	constructor( snippet = '', nodeType = 'void' ) {
 
@@ -31,7 +37,5 @@ class ExpressionNode extends Node {
 }
 
 export default ExpressionNode;
-
-ExpressionNode.type = /*@__PURE__*/ registerNode( 'Expression', ExpressionNode );
 
 export const expression = /*@__PURE__*/ nodeProxy( ExpressionNode );

--- a/src/nodes/code/FunctionCallNode.js
+++ b/src/nodes/code/FunctionCallNode.js
@@ -1,8 +1,13 @@
-import { registerNode } from '../core/Node.js';
 import TempNode from '../core/TempNode.js';
 import { addMethodChaining, nodeArray, nodeObject, nodeObjects } from '../tsl/TSLCore.js';
 
 class FunctionCallNode extends TempNode {
+
+	static get type() {
+
+		return 'FunctionCallNode';
+
+	}
 
 	constructor( functionNode = null, parameters = {} ) {
 
@@ -82,8 +87,6 @@ class FunctionCallNode extends TempNode {
 }
 
 export default FunctionCallNode;
-
-FunctionCallNode.type = /*@__PURE__*/ registerNode( 'FunctionCall', FunctionCallNode );
 
 export const call = ( func, ...params ) => {
 

--- a/src/nodes/code/FunctionNode.js
+++ b/src/nodes/code/FunctionNode.js
@@ -1,8 +1,13 @@
-import { registerNode } from '../core/Node.js';
 import CodeNode from './CodeNode.js';
 import { nodeObject } from '../tsl/TSLBase.js';
 
 class FunctionNode extends CodeNode {
+
+	static get type() {
+
+		return 'FunctionNode';
+
+	}
 
 	constructor( code = '', includes = [], language = '' ) {
 
@@ -80,8 +85,6 @@ class FunctionNode extends CodeNode {
 }
 
 export default FunctionNode;
-
-FunctionNode.type = /*@__PURE__*/ registerNode( 'Function', FunctionNode );
 
 const nativeFn = ( code, includes = [], language = '' ) => {
 

--- a/src/nodes/code/ScriptableNode.js
+++ b/src/nodes/code/ScriptableNode.js
@@ -1,4 +1,4 @@
-import Node, { registerNode } from '../core/Node.js';
+import Node from '../core/Node.js';
 import { scriptableValue } from './ScriptableValueNode.js';
 import { nodeProxy, float } from '../tsl/TSLBase.js';
 
@@ -60,6 +60,12 @@ class Parameters {
 export const global = new Resources();
 
 class ScriptableNode extends Node {
+
+	static get type() {
+
+		return 'ScriptableNode';
+
+	}
 
 	constructor( codeNode = null, parameters = {} ) {
 
@@ -494,7 +500,5 @@ class ScriptableNode extends Node {
 }
 
 export default ScriptableNode;
-
-ScriptableNode.type = /*@__PURE__*/ registerNode( 'Scriptable', ScriptableNode );
 
 export const scriptable = /*@__PURE__*/ nodeProxy( ScriptableNode );

--- a/src/nodes/code/ScriptableValueNode.js
+++ b/src/nodes/code/ScriptableValueNode.js
@@ -1,10 +1,16 @@
-import Node, { registerNode } from '../core/Node.js';
+import Node from '../core/Node.js';
 import { arrayBufferToBase64, base64ToArrayBuffer } from '../core/NodeUtils.js';
 import { nodeProxy, float } from '../tsl/TSLBase.js';
 
 import { EventDispatcher } from '../../core/EventDispatcher.js';
 
 class ScriptableValueNode extends Node {
+
+	static get type() {
+
+		return 'ScriptableValueNode';
+
+	}
 
 	constructor( value = null ) {
 
@@ -160,7 +166,5 @@ class ScriptableValueNode extends Node {
 }
 
 export default ScriptableValueNode;
-
-ScriptableValueNode.type = /*@__PURE__*/ registerNode( 'ScriptableValue', ScriptableValueNode );
 
 export const scriptableValue = /*@__PURE__*/ nodeProxy( ScriptableValueNode );

--- a/src/nodes/core/AssignNode.js
+++ b/src/nodes/core/AssignNode.js
@@ -1,9 +1,14 @@
-import { registerNode } from '../core/Node.js';
 import TempNode from '../core/TempNode.js';
 import { addMethodChaining, nodeProxy } from '../tsl/TSLCore.js';
 import { vectorComponents } from '../core/constants.js';
 
 class AssignNode extends TempNode {
+
+	static get type() {
+
+		return 'AssignNode';
+
+	}
 
 	constructor( targetNode, sourceNode ) {
 
@@ -120,8 +125,6 @@ class AssignNode extends TempNode {
 }
 
 export default AssignNode;
-
-AssignNode.type = /*@__PURE__*/ registerNode( 'Assign', AssignNode );
 
 export const assign = /*@__PURE__*/ nodeProxy( AssignNode );
 

--- a/src/nodes/core/AttributeNode.js
+++ b/src/nodes/core/AttributeNode.js
@@ -1,7 +1,13 @@
-import Node, { registerNode } from './Node.js';
+import Node from './Node.js';
 import { nodeObject, varying } from '../tsl/TSLBase.js';
 
 class AttributeNode extends Node {
+
+	static get type() {
+
+		return 'AttributeNode';
+
+	}
 
 	constructor( attributeName, nodeType = null ) {
 
@@ -115,7 +121,5 @@ class AttributeNode extends Node {
 }
 
 export default AttributeNode;
-
-AttributeNode.type = /*@__PURE__*/ registerNode( 'Attribute', AttributeNode );
 
 export const attribute = ( name, nodeType ) => nodeObject( new AttributeNode( name, nodeType ) );

--- a/src/nodes/core/BypassNode.js
+++ b/src/nodes/core/BypassNode.js
@@ -1,7 +1,13 @@
-import Node, { registerNode } from './Node.js';
+import Node from './Node.js';
 import { addMethodChaining, nodeProxy } from '../tsl/TSLCore.js';
 
 class BypassNode extends Node {
+
+	static get type() {
+
+		return 'BypassNode';
+
+	}
 
 	constructor( returnNode, callNode ) {
 
@@ -37,8 +43,6 @@ class BypassNode extends Node {
 }
 
 export default BypassNode;
-
-BypassNode.type = /*@__PURE__*/ registerNode( 'Bypass', BypassNode );
 
 export const bypass = /*@__PURE__*/ nodeProxy( BypassNode );
 

--- a/src/nodes/core/CacheNode.js
+++ b/src/nodes/core/CacheNode.js
@@ -1,7 +1,13 @@
-import Node, { registerNode } from './Node.js';
+import Node from './Node.js';
 import { addMethodChaining, nodeObject } from '../tsl/TSLCore.js';
 
 class CacheNode extends Node {
+
+	static get type() {
+
+		return 'CacheNode';
+
+	}
 
 	constructor( node, parent = true ) {
 
@@ -38,8 +44,6 @@ class CacheNode extends Node {
 }
 
 export default CacheNode;
-
-CacheNode.type = /*@__PURE__*/ registerNode( 'Cache', CacheNode );
 
 export const cache = ( node, ...params ) => nodeObject( new CacheNode( nodeObject( node ), ...params ) );
 

--- a/src/nodes/core/ConstNode.js
+++ b/src/nodes/core/ConstNode.js
@@ -1,7 +1,12 @@
-import { registerNode } from './Node.js';
 import InputNode from './InputNode.js';
 
 class ConstNode extends InputNode {
+
+	static get type() {
+
+		return 'ConstNode';
+
+	}
 
 	constructor( value, nodeType = null ) {
 
@@ -28,5 +33,3 @@ class ConstNode extends InputNode {
 }
 
 export default ConstNode;
-
-ConstNode.type = /*@__PURE__*/ registerNode( 'Const', ConstNode );

--- a/src/nodes/core/ContextNode.js
+++ b/src/nodes/core/ContextNode.js
@@ -1,7 +1,13 @@
-import Node, { registerNode } from './Node.js';
+import Node from './Node.js';
 import { addMethodChaining, nodeProxy } from '../tsl/TSLCore.js';
 
 class ContextNode extends Node {
+
+	static get type() {
+
+		return 'ContextNode';
+
+	}
 
 	constructor( node, value = {} ) {
 
@@ -63,8 +69,6 @@ class ContextNode extends Node {
 }
 
 export default ContextNode;
-
-ContextNode.type = /*@__PURE__*/ registerNode( 'Context', ContextNode );
 
 export const context = /*@__PURE__*/ nodeProxy( ContextNode );
 export const label = ( node, name ) => context( node, { label: name } );

--- a/src/nodes/core/IndexNode.js
+++ b/src/nodes/core/IndexNode.js
@@ -1,7 +1,13 @@
-import Node, { registerNode } from './Node.js';
+import Node from './Node.js';
 import { nodeImmutable, varying } from '../tsl/TSLBase.js';
 
 class IndexNode extends Node {
+
+	static get type() {
+
+		return 'IndexNode';
+
+	}
 
 	constructor( scope ) {
 
@@ -68,8 +74,6 @@ IndexNode.INVOCATION_LOCAL = 'invocationLocal';
 IndexNode.DRAW = 'draw';
 
 export default IndexNode;
-
-IndexNode.type = /*@__PURE__*/ registerNode( 'Index', IndexNode );
 
 export const vertexIndex = /*@__PURE__*/ nodeImmutable( IndexNode, IndexNode.VERTEX );
 export const instanceIndex = /*@__PURE__*/ nodeImmutable( IndexNode, IndexNode.INSTANCE );

--- a/src/nodes/core/InputNode.js
+++ b/src/nodes/core/InputNode.js
@@ -1,7 +1,13 @@
-import Node, { registerNode } from './Node.js';
+import Node from './Node.js';
 import { getValueType, getValueFromType, arrayBufferToBase64 } from './NodeUtils.js';
 
 class InputNode extends Node {
+
+	static get type() {
+
+		return 'InputNode';
+
+	}
 
 	constructor( value, nodeType = null ) {
 
@@ -79,5 +85,3 @@ class InputNode extends Node {
 }
 
 export default InputNode;
-
-InputNode.type = /*@__PURE__*/ registerNode( 'Input', InputNode );

--- a/src/nodes/core/MRTNode.js
+++ b/src/nodes/core/MRTNode.js
@@ -1,4 +1,3 @@
-import { registerNode } from './Node.js';
 import OutputStructNode from './OutputStructNode.js';
 import { nodeProxy, vec4 } from '../tsl/TSLBase.js';
 
@@ -19,6 +18,12 @@ export function getTextureIndex( textures, name ) {
 }
 
 class MRTNode extends OutputStructNode {
+
+	static get type() {
+
+		return 'MRTNode';
+
+	}
 
 	constructor( outputNodes ) {
 
@@ -76,7 +81,5 @@ class MRTNode extends OutputStructNode {
 }
 
 export default MRTNode;
-
-MRTNode.type = /*@__PURE__*/ registerNode( 'MRT', MRTNode );
 
 export const mrt = /*@__PURE__*/ nodeProxy( MRTNode );

--- a/src/nodes/core/Node.js
+++ b/src/nodes/core/Node.js
@@ -4,11 +4,15 @@ import { getNodeChildren, getCacheKey } from './NodeUtils.js';
 import { EventDispatcher } from '../../core/EventDispatcher.js';
 import { MathUtils } from '../../math/MathUtils.js';
 
-const Nodes = new Map();
-
 let _nodeId = 0;
 
 class Node extends EventDispatcher {
+
+	static get type() {
+
+		return 'Node';
+
+	}
 
 	constructor( nodeType = null ) {
 
@@ -540,52 +544,3 @@ class Node extends EventDispatcher {
 }
 
 export default Node;
-
-Node.type = /*@__PURE__*/ registerNode( '', Node );
-
-export function registerNode( type, nodeClass ) {
-
-	const suffix = 'Node';
-	const nodeType = type + suffix;
-
-	if ( typeof nodeClass !== 'function' ) throw new Error( `TSL.Node: Node class ${ type } is not a class` );
-
-	if ( Nodes.has( nodeType ) ) {
-
-		console.warn( `TSL.Node: Redefinition of node class ${ nodeType }` );
-		return;
-
-	}
-
-	if ( type.slice( - suffix.length ) === suffix ) {
-
-		console.warn( `TSL.Node: Node class ${ nodeType } should not have '${ suffix }' suffix.` );
-		return;
-
-	}
-
-	Nodes.set( nodeType, nodeClass );
-	nodeClass.type = nodeType;
-
-	return nodeType;
-
-}
-
-export function createNodeFromType( type ) {
-
-	const Class = Nodes.get( type );
-
-	if ( Class !== undefined ) {
-
-		return new Class();
-
-	}
-
-}
-
-export function addNodeClass( type, nodeClass ) {
-
-	console.warn( 'TSL.Node: Function addNodeClass() is deprecated. Use /*@__PURE__*/ registerNode() instead.' );
-	/*@__PURE__*/ registerNode( type.slice( 0, - 4 ), nodeClass );
-
-}

--- a/src/nodes/core/OutputStructNode.js
+++ b/src/nodes/core/OutputStructNode.js
@@ -1,8 +1,14 @@
-import Node, { registerNode } from './Node.js';
+import Node from './Node.js';
 import StructTypeNode from './StructTypeNode.js';
 import { nodeProxy } from '../tsl/TSLBase.js';
 
 class OutputStructNode extends Node {
+
+	static get type() {
+
+		return 'OutputStructNode';
+
+	}
 
 	constructor( ...members ) {
 
@@ -53,7 +59,5 @@ class OutputStructNode extends Node {
 }
 
 export default OutputStructNode;
-
-OutputStructNode.type = /*@__PURE__*/ registerNode( 'OutputStruct', OutputStructNode );
 
 export const outputStruct = /*@__PURE__*/ nodeProxy( OutputStructNode );

--- a/src/nodes/core/ParameterNode.js
+++ b/src/nodes/core/ParameterNode.js
@@ -1,8 +1,13 @@
-import { registerNode } from './Node.js';
 import { nodeObject } from '../tsl/TSLBase.js';
 import PropertyNode from './PropertyNode.js';
 
 class ParameterNode extends PropertyNode {
+
+	static get type() {
+
+		return 'ParameterNode';
+
+	}
 
 	constructor( nodeType, name = null ) {
 
@@ -27,7 +32,5 @@ class ParameterNode extends PropertyNode {
 }
 
 export default ParameterNode;
-
-ParameterNode.type = /*@__PURE__*/ registerNode( 'Parameter', ParameterNode );
 
 export const parameter = ( type, name ) => nodeObject( new ParameterNode( type, name ) );

--- a/src/nodes/core/PropertyNode.js
+++ b/src/nodes/core/PropertyNode.js
@@ -1,7 +1,13 @@
-import Node, { registerNode } from './Node.js';
+import Node from './Node.js';
 import { nodeImmutable, nodeObject } from '../tsl/TSLCore.js';
 
 class PropertyNode extends Node {
+
+	static get type() {
+
+		return 'PropertyNode';
+
+	}
 
 	constructor( nodeType, name = null, varying = false ) {
 
@@ -48,8 +54,6 @@ class PropertyNode extends Node {
 }
 
 export default PropertyNode;
-
-PropertyNode.type = /*@__PURE__*/ registerNode( 'Property', PropertyNode );
 
 export const property = ( type, name ) => nodeObject( new PropertyNode( type, name ) );
 export const varyingProperty = ( type, name ) => nodeObject( new PropertyNode( type, name, true ) );

--- a/src/nodes/core/StackNode.js
+++ b/src/nodes/core/StackNode.js
@@ -1,8 +1,14 @@
-import Node, { registerNode } from './Node.js';
+import Node from './Node.js';
 import { select } from '../math/ConditionalNode.js';
 import { ShaderNode, nodeProxy, getCurrentStack, setCurrentStack } from '../tsl/TSLBase.js';
 
 class StackNode extends Node {
+
+	static get type() {
+
+		return 'StackNode';
+
+	}
 
 	constructor( parent = null ) {
 
@@ -99,7 +105,5 @@ class StackNode extends Node {
 }
 
 export default StackNode;
-
-StackNode.type = /*@__PURE__*/ registerNode( 'Stack', StackNode );
 
 export const stack = /*@__PURE__*/ nodeProxy( StackNode );

--- a/src/nodes/core/StructTypeNode.js
+++ b/src/nodes/core/StructTypeNode.js
@@ -1,6 +1,12 @@
-import Node, { registerNode } from './Node.js';
+import Node from './Node.js';
 
 class StructTypeNode extends Node {
+
+	static get type() {
+
+		return 'StructTypeNode';
+
+	}
 
 	constructor( types ) {
 
@@ -20,5 +26,3 @@ class StructTypeNode extends Node {
 }
 
 export default StructTypeNode;
-
-StructTypeNode.type = /*@__PURE__*/ registerNode( 'StructType', StructTypeNode );

--- a/src/nodes/core/TempNode.js
+++ b/src/nodes/core/TempNode.js
@@ -1,6 +1,12 @@
-import Node, { registerNode } from './Node.js';
+import Node from './Node.js';
 
 class TempNode extends Node {
+
+	static get type() {
+
+		return 'TempNode';
+
+	}
 
 	constructor( type ) {
 
@@ -54,5 +60,3 @@ class TempNode extends Node {
 }
 
 export default TempNode;
-
-TempNode.type = /*@__PURE__*/ registerNode( 'Temp', TempNode );

--- a/src/nodes/core/UniformGroupNode.js
+++ b/src/nodes/core/UniformGroupNode.js
@@ -1,6 +1,12 @@
-import Node, { registerNode } from './Node.js';
+import Node from './Node.js';
 
 class UniformGroupNode extends Node {
+
+	static get type() {
+
+		return 'UniformGroupNode';
+
+	}
 
 	constructor( name, shared = false ) {
 
@@ -44,8 +50,6 @@ class UniformGroupNode extends Node {
 }
 
 export default UniformGroupNode;
-
-UniformGroupNode.type = /*@__PURE__*/ registerNode( 'UniformGroup', UniformGroupNode );
 
 export const uniformGroup = ( name ) => new UniformGroupNode( name );
 export const sharedUniformGroup = ( name ) => new UniformGroupNode( name, true );

--- a/src/nodes/core/UniformNode.js
+++ b/src/nodes/core/UniformNode.js
@@ -1,9 +1,14 @@
-import { registerNode } from './Node.js';
 import InputNode from './InputNode.js';
 import { objectGroup } from './UniformGroupNode.js';
 import { nodeObject, getConstNodeType } from '../tsl/TSLCore.js';
 
 class UniformNode extends InputNode {
+
+	static get type() {
+
+		return 'UniformNode';
+
+	}
 
 	constructor( value, nodeType = null ) {
 
@@ -94,8 +99,6 @@ class UniformNode extends InputNode {
 }
 
 export default UniformNode;
-
-UniformNode.type = /*@__PURE__*/ registerNode( 'Uniform', UniformNode );
 
 export const uniform = ( arg1, arg2 ) => {
 

--- a/src/nodes/core/VarNode.js
+++ b/src/nodes/core/VarNode.js
@@ -1,7 +1,13 @@
-import Node, { registerNode } from './Node.js';
+import Node from './Node.js';
 import { addMethodChaining, nodeProxy } from '../tsl/TSLCore.js';
 
 class VarNode extends Node {
+
+	static get type() {
+
+		return 'VarNode';
+
+	}
 
 	constructor( node, name = null ) {
 
@@ -47,8 +53,6 @@ class VarNode extends Node {
 }
 
 export default VarNode;
-
-VarNode.type = /*@__PURE__*/ registerNode( 'Var', VarNode );
 
 export const temp = /*@__PURE__*/ nodeProxy( VarNode );
 

--- a/src/nodes/core/VaryingNode.js
+++ b/src/nodes/core/VaryingNode.js
@@ -1,8 +1,14 @@
-import Node, { registerNode } from './Node.js';
+import Node from './Node.js';
 import { NodeShaderStage } from './constants.js';
 import { addMethodChaining, nodeProxy } from '../tsl/TSLCore.js';
 
 class VaryingNode extends Node {
+
+	static get type() {
+
+		return 'VaryingNode';
+
+	}
 
 	constructor( node, name = null ) {
 
@@ -96,8 +102,6 @@ class VaryingNode extends Node {
 }
 
 export default VaryingNode;
-
-VaryingNode.type = /*@__PURE__*/ registerNode( 'Varying', VaryingNode );
 
 export const varying = /*@__PURE__*/ nodeProxy( VaryingNode );
 

--- a/src/nodes/display/AfterImageNode.js
+++ b/src/nodes/display/AfterImageNode.js
@@ -19,6 +19,12 @@ const _quadMeshComp = /*@__PURE__*/ new QuadMesh();
 
 class AfterImageNode extends TempNode {
 
+	static get type() {
+
+		return 'AfterImageNode';
+
+	}
+
 	constructor( textureNode, damp = 0.96 ) {
 
 		super( textureNode );

--- a/src/nodes/display/AnaglyphPassNode.js
+++ b/src/nodes/display/AnaglyphPassNode.js
@@ -8,6 +8,12 @@ import NodeMaterial from '../../materials/nodes/NodeMaterial.js';
 
 class AnaglyphPassNode extends StereoCompositePassNode {
 
+	static get type() {
+
+		return 'AnaglyphPassNode';
+
+	}
+
 	constructor( scene, camera ) {
 
 		super( scene, camera );

--- a/src/nodes/display/AnamorphicNode.js
+++ b/src/nodes/display/AnamorphicNode.js
@@ -17,6 +17,12 @@ const _quadMesh = /*@__PURE__*/ new QuadMesh();
 
 class AnamorphicNode extends TempNode {
 
+	static get type() {
+
+		return 'AnamorphicNode';
+
+	}
+
 	constructor( textureNode, tresholdNode, scaleNode, samples ) {
 
 		super( 'vec4' );

--- a/src/nodes/display/BloomNode.js
+++ b/src/nodes/display/BloomNode.js
@@ -29,6 +29,12 @@ const _BlurDirectionY = /*@__PURE__*/ new Vector2( 0.0, 1.0 );
 
 class BloomNode extends TempNode {
 
+	static get type() {
+
+		return 'BloomNode';
+
+	}
+
 	constructor( inputNode, strength = 1, radius = 0, threshold = 0 ) {
 
 		super();

--- a/src/nodes/display/BumpMapNode.js
+++ b/src/nodes/display/BumpMapNode.js
@@ -46,6 +46,12 @@ const perturbNormalArb = Fn( ( inputs ) => {
 
 class BumpMapNode extends TempNode {
 
+	static get type() {
+
+		return 'BumpMapNode';
+
+	}
+
 	constructor( textureNode, scaleNode = null ) {
 
 		super( 'vec3' );

--- a/src/nodes/display/ColorSpaceNode.js
+++ b/src/nodes/display/ColorSpaceNode.js
@@ -1,4 +1,3 @@
-import { registerNode } from '../core/Node.js';
 import TempNode from '../core/TempNode.js';
 import { addMethodChaining, nodeObject, vec4 } from '../tsl/TSLCore.js';
 
@@ -29,6 +28,12 @@ export const getColorSpaceMethod = ( source, target ) => {
 };
 
 class ColorSpaceNode extends TempNode {
+
+	static get type() {
+
+		return 'ColorSpaceNode';
+
+	}
 
 	constructor( colorNode, target = null, source = null ) {
 
@@ -75,8 +80,6 @@ class ColorSpaceNode extends TempNode {
 }
 
 export default ColorSpaceNode;
-
-ColorSpaceNode.type = /*@__PURE__*/ registerNode( 'ColorSpace', ColorSpaceNode );
 
 export const toOutputColorSpace = ( node, colorSpace = null ) => nodeObject( new ColorSpaceNode( nodeObject( node ), colorSpace, LinearSRGBColorSpace ) );
 export const toWorkingColorSpace = ( node, colorSpace = null ) => nodeObject( new ColorSpaceNode( nodeObject( node ), LinearSRGBColorSpace, colorSpace ) );

--- a/src/nodes/display/DenoiseNode.js
+++ b/src/nodes/display/DenoiseNode.js
@@ -1,4 +1,3 @@
-import { registerNode } from '../core/Node.js';
 import TempNode from '../core/TempNode.js';
 import { uv } from '../accessors/UV.js';
 import { Fn, nodeObject, float, int, vec2, vec3, vec4, mat2, If } from '../tsl/TSLBase.js';
@@ -15,6 +14,12 @@ import { Vector2 } from '../../math/Vector2.js';
 import { Vector3 } from '../../math/Vector3.js';
 
 class DenoiseNode extends TempNode {
+
+	static get type() {
+
+		return 'DenoiseNode';
+
+	}
 
 	constructor( textureNode, depthNode, normalNode, noiseNode, camera ) {
 
@@ -162,8 +167,6 @@ class DenoiseNode extends TempNode {
 }
 
 export default DenoiseNode;
-
-DenoiseNode.type = /*@__PURE__*/ registerNode( 'Denoise', DenoiseNode );
 
 function generatePdSamplePointInitializer( samples, rings, radiusExponent ) {
 

--- a/src/nodes/display/DepthOfFieldNode.js
+++ b/src/nodes/display/DepthOfFieldNode.js
@@ -1,4 +1,3 @@
-import { registerNode } from '../core/Node.js';
 import TempNode from '../core/TempNode.js';
 import { uv } from '../accessors/UV.js';
 import { Fn, nodeObject, vec2, vec4 } from '../tsl/TSLBase.js';
@@ -8,6 +7,12 @@ import { clamp } from '../math/MathNode.js';
 import { convertToTexture } from '../utils/RTTNode.js';
 
 class DepthOfFieldNode extends TempNode {
+
+	static get type() {
+
+		return 'DepthOfFieldNode';
+
+	}
 
 	constructor( textureNode, viewZNode, focusNode, apertureNode, maxblurNode ) {
 
@@ -115,7 +120,5 @@ class DepthOfFieldNode extends TempNode {
 }
 
 export default DepthOfFieldNode;
-
-DepthOfFieldNode.type = /*@__PURE__*/ registerNode( 'DepthOfField', DepthOfFieldNode );
 
 export const dof = ( node, viewZNode, focus = 1, aperture = 0.025, maxblur = 1 ) => nodeObject( new DepthOfFieldNode( convertToTexture( node ), nodeObject( viewZNode ), nodeObject( focus ), nodeObject( aperture ), nodeObject( maxblur ) ) );

--- a/src/nodes/display/DotScreenNode.js
+++ b/src/nodes/display/DotScreenNode.js
@@ -1,4 +1,3 @@
-import { registerNode } from '../core/Node.js';
 import TempNode from '../core/TempNode.js';
 import { nodeObject, Fn, vec2, vec3, vec4 } from '../tsl/TSLBase.js';
 import { uniform } from '../core/UniformNode.js';
@@ -10,6 +9,12 @@ import { viewportResolution } from '../display/ViewportNode.js';
 import { Vector2 } from '../../math/Vector2.js';
 
 class DotScreenNode extends TempNode {
+
+	static get type() {
+
+		return 'DotScreenNode';
+
+	}
 
 	constructor( inputNode, center = new Vector2( 0.5, 0.5 ), angle = 1.57, scale = 1 ) {
 
@@ -57,7 +62,5 @@ class DotScreenNode extends TempNode {
 }
 
 export default DotScreenNode;
-
-DotScreenNode.type = /*@__PURE__*/ registerNode( 'DotScreen', DotScreenNode );
 
 export const dotScreen = ( node, center, angle, scale ) => nodeObject( new DotScreenNode( nodeObject( node ), center, angle, scale ) );

--- a/src/nodes/display/FXAANode.js
+++ b/src/nodes/display/FXAANode.js
@@ -1,4 +1,3 @@
-import { registerNode } from '../core/Node.js';
 import TempNode from '../core/TempNode.js';
 import { uv } from '../accessors/UV.js';
 import { Fn, nodeObject, float, vec2, vec4, int, If } from '../tsl/TSLBase.js';
@@ -12,6 +11,12 @@ import { convertToTexture } from '../utils/RTTNode.js';
 import { Vector2 } from '../../math/Vector2.js';
 
 class FXAANode extends TempNode {
+
+	static get type() {
+
+		return 'FXAANode';
+
+	}
 
 	constructor( textureNode ) {
 
@@ -323,7 +328,5 @@ class FXAANode extends TempNode {
 }
 
 export default FXAANode;
-
-FXAANode.type = /*@__PURE__*/ registerNode( 'FXAA', FXAANode );
 
 export const fxaa = ( node ) => nodeObject( new FXAANode( convertToTexture( node ) ) );

--- a/src/nodes/display/FilmNode.js
+++ b/src/nodes/display/FilmNode.js
@@ -1,4 +1,3 @@
-import { registerNode } from '../core/Node.js';
 import TempNode from '../core/TempNode.js';
 import { uv } from '../accessors/UV.js';
 import { Fn, nodeProxy, vec4 } from '../tsl/TSLBase.js';
@@ -6,6 +5,12 @@ import { mix, fract, clamp, rand } from '../math/MathNode.js';
 import { timerLocal } from '../utils/TimerNode.js';
 
 class FilmNode extends TempNode {
+
+	static get type() {
+
+		return 'FilmNode';
+
+	}
 
 	constructor( inputNode, intensityNode = null, uvNode = null ) {
 
@@ -47,7 +52,5 @@ class FilmNode extends TempNode {
 }
 
 export default FilmNode;
-
-FilmNode.type = /*@__PURE__*/ registerNode( 'Film', FilmNode );
 
 export const film = /*@__PURE__*/ nodeProxy( FilmNode );

--- a/src/nodes/display/FrontFacingNode.js
+++ b/src/nodes/display/FrontFacingNode.js
@@ -1,9 +1,15 @@
-import Node, { registerNode } from '../core/Node.js';
+import Node from '../core/Node.js';
 import { nodeImmutable, float } from '../tsl/TSLBase.js';
 
 import { BackSide, WebGLCoordinateSystem } from '../../constants.js';
 
 class FrontFacingNode extends Node {
+
+	static get type() {
+
+		return 'FrontFacingNode';
+
+	}
 
 	constructor() {
 
@@ -34,8 +40,6 @@ class FrontFacingNode extends Node {
 }
 
 export default FrontFacingNode;
-
-FrontFacingNode.type = /*@__PURE__*/ registerNode( 'FrontFacing', FrontFacingNode );
 
 export const frontFacing = /*@__PURE__*/ nodeImmutable( FrontFacingNode );
 export const faceDirection = /*@__PURE__*/ float( frontFacing ).mul( 2.0 ).sub( 1.0 );

--- a/src/nodes/display/GTAONode.js
+++ b/src/nodes/display/GTAONode.js
@@ -1,4 +1,3 @@
-import { registerNode } from '../core/Node.js';
 import TempNode from '../core/TempNode.js';
 import { texture } from '../accessors/TextureNode.js';
 import { textureSize } from '../accessors/TextureSizeNode.js';
@@ -25,6 +24,12 @@ const _currentClearColor = /*@__PURE__*/ new Color();
 const _size = /*@__PURE__*/ new Vector2();
 
 class GTAONode extends TempNode {
+
+	static get type() {
+
+		return 'GTAONode';
+
+	}
 
 	constructor( depthNode, normalNode, camera ) {
 
@@ -238,8 +243,6 @@ class GTAONode extends TempNode {
 }
 
 export default GTAONode;
-
-GTAONode.type = /*@__PURE__*/ registerNode( 'GTAO', GTAONode );
 
 function generateMagicSquareNoise( size = 5 ) {
 

--- a/src/nodes/display/GaussianBlurNode.js
+++ b/src/nodes/display/GaussianBlurNode.js
@@ -1,4 +1,3 @@
-import { registerNode } from '../core/Node.js';
 import TempNode from '../core/TempNode.js';
 import { nodeObject, Fn, float, vec2, vec4 } from '../tsl/TSLBase.js';
 import { NodeUpdateType } from '../core/constants.js';
@@ -20,6 +19,12 @@ const _quadMesh1 = /*@__PURE__*/ new QuadMesh();
 const _quadMesh2 = /*@__PURE__*/ new QuadMesh();
 
 class GaussianBlurNode extends TempNode {
+
+	static get type() {
+
+		return 'GaussianBlurNode';
+
+	}
 
 	constructor( textureNode, directionNode = null, sigma = 2 ) {
 
@@ -204,7 +209,5 @@ class GaussianBlurNode extends TempNode {
 }
 
 export default GaussianBlurNode;
-
-GaussianBlurNode.type = /*@__PURE__*/ registerNode( 'GaussianBlur', GaussianBlurNode );
 
 export const gaussianBlur = ( node, directionNode, sigma ) => nodeObject( new GaussianBlurNode( convertToTexture( node ), directionNode, sigma ) );

--- a/src/nodes/display/Lut3DNode.js
+++ b/src/nodes/display/Lut3DNode.js
@@ -1,10 +1,15 @@
-import { registerNode } from '../core/Node.js';
 import TempNode from '../core/TempNode.js';
 import { Fn, nodeObject, vec3, vec4, float } from '../tsl/TSLBase.js';
 import { uniform } from '../core/UniformNode.js';
 import { mix } from '../math/MathNode.js';
 
 class Lut3DNode extends TempNode {
+
+	static get type() {
+
+		return 'Lut3DNode';
+
+	}
 
 	constructor( inputNode, lutNode, size, intensityNode ) {
 
@@ -48,7 +53,5 @@ class Lut3DNode extends TempNode {
 }
 
 export default Lut3DNode;
-
-Lut3DNode.type = /*@__PURE__*/ registerNode( 'Lut3D', Lut3DNode );
 
 export const lut3D = ( node, lut, size, intensity ) => nodeObject( new Lut3DNode( nodeObject( node ), nodeObject( lut ), size, nodeObject( intensity ) ) );

--- a/src/nodes/display/NormalMapNode.js
+++ b/src/nodes/display/NormalMapNode.js
@@ -1,4 +1,3 @@
-import { registerNode } from '../core/Node.js';
 import TempNode from '../core/TempNode.js';
 import { add } from '../math/OperatorNode.js';
 
@@ -40,6 +39,12 @@ const perturbNormal2Arb = /*@__PURE__*/ Fn( ( inputs ) => {
 } );
 
 class NormalMapNode extends TempNode {
+
+	static get type() {
+
+		return 'NormalMapNode';
+
+	}
 
 	constructor( node, scaleNode = null ) {
 
@@ -98,7 +103,5 @@ class NormalMapNode extends TempNode {
 }
 
 export default NormalMapNode;
-
-NormalMapNode.type = /*@__PURE__*/ registerNode( 'NormalMap', NormalMapNode );
 
 export const normalMap = /*@__PURE__*/ nodeProxy( NormalMapNode );

--- a/src/nodes/display/ParallaxBarrierPassNode.js
+++ b/src/nodes/display/ParallaxBarrierPassNode.js
@@ -1,4 +1,3 @@
-import { registerNode } from '../core/Node.js';
 import { Fn, If, nodeObject, vec4 } from '../tsl/TSLBase.js';
 import { uv } from '../accessors/UV.js';
 import { mod } from '../math/MathNode.js';
@@ -7,6 +6,12 @@ import StereoCompositePassNode from './StereoCompositePassNode.js';
 import NodeMaterial from '../../materials/nodes/NodeMaterial.js';
 
 class ParallaxBarrierPassNode extends StereoCompositePassNode {
+
+	static get type() {
+
+		return 'ParallaxBarrierPassNode';
+
+	}
 
 	constructor( scene, camera ) {
 
@@ -49,7 +54,5 @@ class ParallaxBarrierPassNode extends StereoCompositePassNode {
 }
 
 export default ParallaxBarrierPassNode;
-
-ParallaxBarrierPassNode.type = /*@__PURE__*/ registerNode( 'ParallaxBarrierPass', ParallaxBarrierPassNode );
 
 export const parallaxBarrierPass = ( scene, camera ) => nodeObject( new ParallaxBarrierPassNode( scene, camera ) );

--- a/src/nodes/display/PassNode.js
+++ b/src/nodes/display/PassNode.js
@@ -1,4 +1,3 @@
-import { registerNode } from '../core/Node.js';
 import TempNode from '../core/TempNode.js';
 import { default as TextureNode/*, texture*/ } from '../accessors/TextureNode.js';
 import { NodeUpdateType } from '../core/constants.js';
@@ -14,6 +13,12 @@ import { RenderTarget } from '../../core/RenderTarget.js';
 const _size = /*@__PURE__*/ new Vector2();
 
 class PassTextureNode extends TextureNode {
+
+	static get type() {
+
+		return 'PassTextureNode';
+
+	}
 
 	constructor( passNode, texture ) {
 
@@ -41,9 +46,13 @@ class PassTextureNode extends TextureNode {
 
 }
 
-PassTextureNode.type = /*@__PURE__*/ registerNode( 'PassTexture', PassTextureNode );
-
 class PassMultipleTextureNode extends PassTextureNode {
+
+	static get type() {
+
+		return 'PassMultipleTextureNode';
+
+	}
 
 	constructor( passNode, textureName, previousTexture = false ) {
 
@@ -76,9 +85,13 @@ class PassMultipleTextureNode extends PassTextureNode {
 
 }
 
-PassMultipleTextureNode.type = /*@__PURE__*/ registerNode( 'PassMultipleTexture', PassMultipleTextureNode );
-
 class PassNode extends TempNode {
+
+	static get type() {
+
+		return 'PassNode';
+
+	}
 
 	constructor( scope, scene, camera, options = {} ) {
 
@@ -359,8 +372,6 @@ PassNode.COLOR = 'color';
 PassNode.DEPTH = 'depth';
 
 export default PassNode;
-
-PassNode.type = /*@__PURE__*/ registerNode( 'Pass', PassNode );
 
 export const pass = ( scene, camera, options ) => nodeObject( new PassNode( PassNode.COLOR, scene, camera, options ) );
 export const passTexture = ( pass, texture ) => nodeObject( new PassTextureNode( pass, texture ) );

--- a/src/nodes/display/PixelationPassNode.js
+++ b/src/nodes/display/PixelationPassNode.js
@@ -1,4 +1,3 @@
-import { registerNode } from '../core/Node.js';
 import TempNode from '../core/TempNode.js';
 import { uv } from '../accessors/UV.js';
 import { Fn, nodeObject, vec2, vec3, float, If } from '../tsl/TSLBase.js';
@@ -15,6 +14,12 @@ import { convertToTexture } from '../utils/RTTNode.js';
 import { NearestFilter } from '../../constants.js';
 
 class PixelationNode extends TempNode {
+
+	static get type() {
+
+		return 'PixelationNode';
+
+	}
 
 	constructor( textureNode, depthNode, normalNode, pixelSize, normalEdgeStrength, depthEdgeStrength ) {
 
@@ -153,11 +158,15 @@ class PixelationNode extends TempNode {
 
 }
 
-PixelationNode.type = /*@__PURE__*/ registerNode( 'Pixelation', PixelationNode );
-
 const pixelation = ( node, depthNode, normalNode, pixelSize = 6, normalEdgeStrength = 0.3, depthEdgeStrength = 0.4 ) => nodeObject( new PixelationNode( convertToTexture( node ), convertToTexture( depthNode ), convertToTexture( normalNode ), nodeObject( pixelSize ), nodeObject( normalEdgeStrength ), nodeObject( depthEdgeStrength ) ) );
 
 class PixelationPassNode extends PassNode {
+
+	static get type() {
+
+		return 'PixelationPassNode';
+
+	}
 
 	constructor( scene, camera, pixelSize = 6, normalEdgeStrength = 0.3, depthEdgeStrength = 0.4 ) {
 
@@ -202,5 +211,3 @@ class PixelationPassNode extends PassNode {
 export const pixelationPass = ( scene, camera, pixelSize, normalEdgeStrength, depthEdgeStrength ) => nodeObject( new PixelationPassNode( scene, camera, pixelSize, normalEdgeStrength, depthEdgeStrength ) );
 
 export default PixelationPassNode;
-
-PixelationPassNode.type = /*@__PURE__*/ registerNode( 'PixelationPass', PixelationPassNode );

--- a/src/nodes/display/PosterizeNode.js
+++ b/src/nodes/display/PosterizeNode.js
@@ -1,8 +1,13 @@
-import { registerNode } from '../core/Node.js';
 import TempNode from '../core/TempNode.js';
 import { nodeProxy } from '../tsl/TSLBase.js';
 
 class PosterizeNode extends TempNode {
+
+	static get type() {
+
+		return 'PosterizeNode';
+
+	}
 
 	constructor( sourceNode, stepsNode ) {
 
@@ -24,7 +29,5 @@ class PosterizeNode extends TempNode {
 }
 
 export default PosterizeNode;
-
-PosterizeNode.type = /*@__PURE__*/ registerNode( 'Posterize', PosterizeNode );
 
 export const posterize = /*@__PURE__*/ nodeProxy( PosterizeNode );

--- a/src/nodes/display/RGBShiftNode.js
+++ b/src/nodes/display/RGBShiftNode.js
@@ -1,4 +1,3 @@
-import { registerNode } from '../core/Node.js';
 import TempNode from '../core/TempNode.js';
 import { nodeObject, Fn, vec2, vec4 } from '../tsl/TSLBase.js';
 import { uniform } from '../core/UniformNode.js';
@@ -7,6 +6,12 @@ import { sin, cos } from '../math/MathNode.js';
 import { convertToTexture } from '../utils/RTTNode.js';
 
 class RGBShiftNode extends TempNode {
+
+	static get type() {
+
+		return 'RGBShiftNode';
+
+	}
 
 	constructor( textureNode, amount = 0.005, angle = 0 ) {
 
@@ -44,7 +49,5 @@ class RGBShiftNode extends TempNode {
 }
 
 export default RGBShiftNode;
-
-RGBShiftNode.type = /*@__PURE__*/ registerNode( 'RGBShift', RGBShiftNode );
 
 export const rgbShift = ( node, amount, angle ) => nodeObject( new RGBShiftNode( convertToTexture( node ), amount, angle ) );

--- a/src/nodes/display/RenderOutputNode.js
+++ b/src/nodes/display/RenderOutputNode.js
@@ -1,10 +1,15 @@
-import { registerNode } from '../core/Node.js';
 import TempNode from '../core/TempNode.js';
 import { addMethodChaining, nodeObject } from '../tsl/TSLCore.js';
 
 import { LinearSRGBColorSpace, SRGBColorSpace, NoToneMapping } from '../../constants.js';
 
 class RenderOutputNode extends TempNode {
+
+	static get type() {
+
+		return 'RenderOutputNode';
+
+	}
 
 	constructor( colorNode, toneMapping, outputColorSpace ) {
 
@@ -48,8 +53,6 @@ class RenderOutputNode extends TempNode {
 }
 
 export default RenderOutputNode;
-
-RenderOutputNode.type = /*@__PURE__*/ registerNode( 'RenderOutput', RenderOutputNode );
 
 export const renderOutput = ( color, toneMapping = null, outputColorSpace = null ) => nodeObject( new RenderOutputNode( nodeObject( color ), toneMapping, outputColorSpace ) );
 

--- a/src/nodes/display/SSAAPassNode.js
+++ b/src/nodes/display/SSAAPassNode.js
@@ -1,4 +1,3 @@
-import { registerNode } from '../core/Node.js';
 import { nodeObject } from '../tsl/TSLBase.js';
 import PassNode from './PassNode.js';
 import { Color } from '../../math/Color.js';
@@ -23,6 +22,12 @@ const _size = /*@__PURE__*/ new Vector2();
 */
 
 class SSAAPassNode extends PassNode {
+
+	static get type() {
+
+		return 'SSAAPassNode';
+
+	}
 
 	constructor( scene, camera ) {
 
@@ -241,8 +246,6 @@ class SSAAPassNode extends PassNode {
 }
 
 export default SSAAPassNode;
-
-SSAAPassNode.type = /*@__PURE__*/ registerNode( 'SSAAPass', SSAAPassNode );
 
 // These jitter vectors are specified in integers because it is easier.
 // I am assuming a [-8,8) integer grid, but it needs to be mapped onto [-0.5,0.5)

--- a/src/nodes/display/SobelOperatorNode.js
+++ b/src/nodes/display/SobelOperatorNode.js
@@ -1,4 +1,3 @@
-import { registerNode } from '../core/Node.js';
 import TempNode from '../core/TempNode.js';
 import { uv } from '../accessors/UV.js';
 import { luminance } from './ColorAdjustment.js';
@@ -11,6 +10,12 @@ import { convertToTexture } from '../utils/RTTNode.js';
 import { Vector2 } from '../../math/Vector2.js';
 
 class SobelOperatorNode extends TempNode {
+
+	static get type() {
+
+		return 'SobelOperatorNode';
+
+	}
 
 	constructor( textureNode ) {
 
@@ -117,7 +122,5 @@ class SobelOperatorNode extends TempNode {
 }
 
 export default SobelOperatorNode;
-
-SobelOperatorNode.type = /*@__PURE__*/ registerNode( 'SobelOperator', SobelOperatorNode );
 
 export const sobel = ( node ) => nodeObject( new SobelOperatorNode( convertToTexture( node ) ) );

--- a/src/nodes/display/StereoCompositePassNode.js
+++ b/src/nodes/display/StereoCompositePassNode.js
@@ -1,5 +1,4 @@
 
-import { registerNode } from '../core/Node.js';
 import PassNode from './PassNode.js';
 import { StereoCamera } from '../../cameras/StereoCamera.js';
 import { HalfFloatType, LinearFilter, NearestFilter } from '../../constants.js';
@@ -12,6 +11,12 @@ const _size = /*@__PURE__*/ new Vector2();
 const _quadMesh = /*@__PURE__*/ new QuadMesh();
 
 class StereoCompositePassNode extends PassNode {
+
+	static get type() {
+
+		return 'StereoCompositePassNode';
+
+	}
 
 	constructor( scene, camera ) {
 
@@ -103,5 +108,3 @@ class StereoCompositePassNode extends PassNode {
 }
 
 export default StereoCompositePassNode;
-
-StereoCompositePassNode.type = /*@__PURE__*/ registerNode( 'StereoCompositePass', StereoCompositePassNode );

--- a/src/nodes/display/StereoPassNode.js
+++ b/src/nodes/display/StereoPassNode.js
@@ -1,4 +1,3 @@
-import { registerNode } from '../core/Node.js';
 import { nodeObject } from '../tsl/TSLBase.js';
 import PassNode from './PassNode.js';
 import { Vector2 } from '../../math/Vector2.js';
@@ -7,6 +6,12 @@ import { StereoCamera } from '../../cameras/StereoCamera.js';
 const _size = /*@__PURE__*/ new Vector2();
 
 class StereoPassNode extends PassNode {
+
+	static get type() {
+
+		return 'StereoPassNode';
+
+	}
 
 	constructor( scene, camera ) {
 
@@ -74,7 +79,5 @@ class StereoPassNode extends PassNode {
 }
 
 export default StereoPassNode;
-
-StereoPassNode.type = /*@__PURE__*/ registerNode( 'StereoPass', StereoPassNode );
 
 export const stereoPass = ( scene, camera ) => nodeObject( new StereoPassNode( scene, camera ) );

--- a/src/nodes/display/ToneMappingNode.js
+++ b/src/nodes/display/ToneMappingNode.js
@@ -1,4 +1,3 @@
-import { registerNode } from '../core/Node.js';
 import TempNode from '../core/TempNode.js';
 import { addMethodChaining, nodeObject, vec4 } from '../tsl/TSLCore.js';
 import { rendererReference } from '../accessors/RendererReferenceNode.js';
@@ -6,6 +5,12 @@ import { rendererReference } from '../accessors/RendererReferenceNode.js';
 import { NoToneMapping } from '../../constants.js';
 
 class ToneMappingNode extends TempNode {
+
+	static get type() {
+
+		return 'ToneMappingNode';
+
+	}
 
 	constructor( toneMapping, exposureNode = toneMappingExposure, colorNode = null ) {
 
@@ -57,8 +62,6 @@ class ToneMappingNode extends TempNode {
 }
 
 export default ToneMappingNode;
-
-ToneMappingNode.type = /*@__PURE__*/ registerNode( 'ToneMapping', ToneMappingNode );
 
 export const toneMapping = ( mapping, exposure, color ) => nodeObject( new ToneMappingNode( mapping, nodeObject( exposure ), nodeObject( color ) ) );
 export const toneMappingExposure = /*@__PURE__*/ rendererReference( 'toneMappingExposure', 'float' );

--- a/src/nodes/display/TransitionNode.js
+++ b/src/nodes/display/TransitionNode.js
@@ -1,4 +1,3 @@
-import { registerNode } from '../core/Node.js';
 import TempNode from '../core/TempNode.js';
 import { uv } from '../accessors/UV.js';
 import { Fn, nodeObject, float, int, vec4, If } from '../tsl/TSLBase.js';
@@ -7,6 +6,12 @@ import { sub } from '../math/OperatorNode.js';
 import { convertToTexture } from '../utils/RTTNode.js';
 
 class TransitionNode extends TempNode {
+
+	static get type() {
+
+		return 'TransitionNode';
+
+	}
 
 	constructor( textureNodeA, textureNodeB, mixTextureNode, mixRatioNode, thresholdNode, useTextureNode ) {
 
@@ -71,7 +76,5 @@ class TransitionNode extends TempNode {
 }
 
 export default TransitionNode;
-
-TransitionNode.type = /*@__PURE__*/ registerNode( 'Transition', TransitionNode );
 
 export const transition = ( nodeA, nodeB, mixTexture, mixRatio = 0.0, threshold = 0.1, useTexture = 0 ) => nodeObject( new TransitionNode( convertToTexture( nodeA ), convertToTexture( nodeB ), convertToTexture( mixTexture ), nodeObject( mixRatio ), nodeObject( threshold ), nodeObject( useTexture ) ) );

--- a/src/nodes/display/ViewportDepthNode.js
+++ b/src/nodes/display/ViewportDepthNode.js
@@ -1,10 +1,16 @@
-import Node, { registerNode } from '../core/Node.js';
+import Node from '../core/Node.js';
 import { nodeImmutable, nodeProxy } from '../tsl/TSLBase.js';
 import { cameraNear, cameraFar } from '../accessors/Camera.js';
 import { positionView } from '../accessors/Position.js';
 import { viewportDepthTexture } from './ViewportDepthTextureNode.js';
 
 class ViewportDepthNode extends Node {
+
+	static get type() {
+
+		return 'ViewportDepthNode';
+
+	}
 
 	constructor( scope, valueNode = null ) {
 
@@ -93,8 +99,6 @@ ViewportDepthNode.DEPTH = 'depth';
 ViewportDepthNode.LINEAR_DEPTH = 'linearDepth';
 
 export default ViewportDepthNode;
-
-ViewportDepthNode.type = /*@__PURE__*/ registerNode( 'ViewportDepth', ViewportDepthNode );
 
 // NOTE: viewZ, the z-coordinate in camera space, is negative for points in front of the camera
 

--- a/src/nodes/display/ViewportDepthTextureNode.js
+++ b/src/nodes/display/ViewportDepthTextureNode.js
@@ -1,4 +1,3 @@
-import { registerNode } from '../core/Node.js';
 import ViewportTextureNode from './ViewportTextureNode.js';
 import { nodeProxy } from '../tsl/TSLBase.js';
 import { viewportUV } from './ViewportNode.js';
@@ -8,6 +7,12 @@ import { DepthTexture } from '../../textures/DepthTexture.js';
 let sharedDepthbuffer = null;
 
 class ViewportDepthTextureNode extends ViewportTextureNode {
+
+	static get type() {
+
+		return 'ViewportDepthTextureNode';
+
+	}
 
 	constructor( uvNode = viewportUV, levelNode = null ) {
 
@@ -24,7 +29,5 @@ class ViewportDepthTextureNode extends ViewportTextureNode {
 }
 
 export default ViewportDepthTextureNode;
-
-ViewportDepthTextureNode.type = /*@__PURE__*/ registerNode( 'ViewportDepthTexture', ViewportDepthTextureNode );
 
 export const viewportDepthTexture = /*@__PURE__*/ nodeProxy( ViewportDepthTextureNode );

--- a/src/nodes/display/ViewportNode.js
+++ b/src/nodes/display/ViewportNode.js
@@ -1,4 +1,4 @@
-import Node, { registerNode } from '../core/Node.js';
+import Node from '../core/Node.js';
 import { NodeUpdateType } from '../core/constants.js';
 import { uniform } from '../core/UniformNode.js';
 import { Fn, nodeImmutable, vec2 } from '../tsl/TSLBase.js';
@@ -9,6 +9,12 @@ import { Vector4 } from '../../math/Vector4.js';
 let resolution, viewportResult;
 
 class ViewportNode extends Node {
+
+	static get type() {
+
+		return 'ViewportNode';
+
+	}
 
 	constructor( scope ) {
 
@@ -113,8 +119,6 @@ ViewportNode.VIEWPORT = 'viewport';
 ViewportNode.UV = 'uv';
 
 export default ViewportNode;
-
-ViewportNode.type = /*@__PURE__*/ registerNode( 'Viewport', ViewportNode );
 
 export const viewportCoordinate = /*@__PURE__*/ nodeImmutable( ViewportNode, ViewportNode.COORDINATE );
 export const viewportResolution = /*@__PURE__*/ nodeImmutable( ViewportNode, ViewportNode.RESOLUTION );

--- a/src/nodes/display/ViewportSharedTextureNode.js
+++ b/src/nodes/display/ViewportSharedTextureNode.js
@@ -3,11 +3,16 @@ import { nodeProxy } from '../tsl/TSLBase.js';
 import { viewportUV } from './ViewportNode.js';
 
 import { FramebufferTexture } from '../../textures/FramebufferTexture.js';
-import { registerNode } from '../core/Node.js';
 
 let _sharedFramebuffer = null;
 
 class ViewportSharedTextureNode extends ViewportTextureNode {
+
+	static get type() {
+
+		return 'ViewportSharedTextureNode';
+
+	}
 
 	constructor( uvNode = viewportUV, levelNode = null ) {
 
@@ -30,7 +35,5 @@ class ViewportSharedTextureNode extends ViewportTextureNode {
 }
 
 export default ViewportSharedTextureNode;
-
-ViewportSharedTextureNode.type = /*@__PURE__*/ registerNode( 'ViewportSharedTexture', ViewportSharedTextureNode );
 
 export const viewportSharedTexture = /*@__PURE__*/ nodeProxy( ViewportSharedTextureNode );

--- a/src/nodes/display/ViewportTextureNode.js
+++ b/src/nodes/display/ViewportTextureNode.js
@@ -1,4 +1,3 @@
-import { registerNode } from '../core/Node.js';
 import TextureNode from '../accessors/TextureNode.js';
 import { NodeUpdateType } from '../core/constants.js';
 import { nodeProxy } from '../tsl/TSLBase.js';
@@ -11,6 +10,12 @@ import { LinearMipmapLinearFilter } from '../../constants.js';
 const _size = /*@__PURE__*/ new Vector2();
 
 class ViewportTextureNode extends TextureNode {
+
+	static get type() {
+
+		return 'ViewportTextureNode';
+
+	}
 
 	constructor( uvNode = viewportUV, levelNode = null, framebufferTexture = null ) {
 
@@ -71,8 +76,6 @@ class ViewportTextureNode extends TextureNode {
 }
 
 export default ViewportTextureNode;
-
-ViewportTextureNode.type = /*@__PURE__*/ registerNode( 'ViewportTexture', ViewportTextureNode );
 
 export const viewportTexture = /*@__PURE__*/ nodeProxy( ViewportTextureNode );
 export const viewportMipTexture = /*@__PURE__*/ nodeProxy( ViewportTextureNode, null, null, { generateMipmaps: true } );

--- a/src/nodes/fog/FogExp2Node.js
+++ b/src/nodes/fog/FogExp2Node.js
@@ -1,8 +1,13 @@
-import { registerNode } from '../core/Node.js';
 import FogNode from './FogNode.js';
 import { nodeProxy } from '../tsl/TSLBase.js';
 
 class FogExp2Node extends FogNode {
+
+	static get type() {
+
+		return 'FogExp2Node';
+
+	}
 
 	constructor( colorNode, densityNode ) {
 
@@ -26,7 +31,5 @@ class FogExp2Node extends FogNode {
 }
 
 export default FogExp2Node;
-
-FogExp2Node.type = /*@__PURE__*/ registerNode( 'FogExp2', FogExp2Node );
 
 export const densityFog = /*@__PURE__*/ nodeProxy( FogExp2Node );

--- a/src/nodes/fog/FogNode.js
+++ b/src/nodes/fog/FogNode.js
@@ -1,8 +1,14 @@
-import Node, { registerNode } from '../core/Node.js';
+import Node from '../core/Node.js';
 import { positionView } from '../accessors/Position.js';
 import { nodeProxy } from '../tsl/TSLBase.js';
 
 class FogNode extends Node {
+
+	static get type() {
+
+		return 'FogNode';
+
+	}
 
 	constructor( colorNode, factorNode ) {
 
@@ -40,7 +46,5 @@ class FogNode extends Node {
 }
 
 export default FogNode;
-
-FogNode.type = /*@__PURE__*/ registerNode( 'Fog', FogNode );
 
 export const fog = /*@__PURE__*/ nodeProxy( FogNode );

--- a/src/nodes/fog/FogRangeNode.js
+++ b/src/nodes/fog/FogRangeNode.js
@@ -1,9 +1,14 @@
-import { registerNode } from '../core/Node.js';
 import FogNode from './FogNode.js';
 import { smoothstep } from '../math/MathNode.js';
 import { nodeProxy } from '../tsl/TSLBase.js';
 
 class FogRangeNode extends FogNode {
+
+	static get type() {
+
+		return 'FogRangeNode';
+
+	}
 
 	constructor( colorNode, nearNode, farNode ) {
 
@@ -27,7 +32,5 @@ class FogRangeNode extends FogNode {
 }
 
 export default FogRangeNode;
-
-FogRangeNode.type = /*@__PURE__*/ registerNode( 'FogRange', FogRangeNode );
 
 export const rangeFog = /*@__PURE__*/ nodeProxy( FogRangeNode );

--- a/src/nodes/geometry/RangeNode.js
+++ b/src/nodes/geometry/RangeNode.js
@@ -1,4 +1,4 @@
-import Node, { registerNode } from '../core/Node.js';
+import Node from '../core/Node.js';
 import { getValueType } from '../core/NodeUtils.js';
 import { buffer } from '../accessors/BufferNode.js';
 import { instancedBufferAttribute } from '../accessors/BufferAttributeNode.js';
@@ -13,6 +13,12 @@ let min = null;
 let max = null;
 
 class RangeNode extends Node {
+
+	static get type() {
+
+		return 'RangeNode';
+
+	}
 
 	constructor( minNode = float(), maxNode = float() ) {
 
@@ -111,7 +117,5 @@ class RangeNode extends Node {
 }
 
 export default RangeNode;
-
-RangeNode.type = /*@__PURE__*/ registerNode( 'Range', RangeNode );
 
 export const range = /*@__PURE__*/ nodeProxy( RangeNode );

--- a/src/nodes/gpgpu/ComputeNode.js
+++ b/src/nodes/gpgpu/ComputeNode.js
@@ -1,8 +1,14 @@
-import Node, { registerNode } from '../core/Node.js';
+import Node from '../core/Node.js';
 import { NodeUpdateType } from '../core/constants.js';
 import { addMethodChaining, nodeObject } from '../tsl/TSLCore.js';
 
 class ComputeNode extends Node {
+
+	static get type() {
+
+		return 'ComputeNode';
+
+	}
 
 	constructor( computeNode, count, workgroupSize = [ 64 ] ) {
 
@@ -77,8 +83,6 @@ class ComputeNode extends Node {
 }
 
 export default ComputeNode;
-
-ComputeNode.type = /*@__PURE__*/ registerNode( 'Compute', ComputeNode );
 
 export const compute = ( node, count, workgroupSize ) => nodeObject( new ComputeNode( nodeObject( node ), count, workgroupSize ) );
 

--- a/src/nodes/lighting/AONode.js
+++ b/src/nodes/lighting/AONode.js
@@ -1,7 +1,12 @@
-import { registerNode } from '../core/Node.js';
 import LightingNode from './LightingNode.js';
 
 class AONode extends LightingNode {
+
+	static get type() {
+
+		return 'AONode';
+
+	}
 
 	constructor( aoNode = null ) {
 
@@ -20,5 +25,3 @@ class AONode extends LightingNode {
 }
 
 export default AONode;
-
-AONode.type = /*@__PURE__*/ registerNode( 'AO', AONode );

--- a/src/nodes/lighting/AmbientLightNode.js
+++ b/src/nodes/lighting/AmbientLightNode.js
@@ -1,7 +1,12 @@
-import { registerNode } from '../core/Node.js';
 import AnalyticLightNode from './AnalyticLightNode.js';
 
 class AmbientLightNode extends AnalyticLightNode {
+
+	static get type() {
+
+		return 'AmbientLightNode';
+
+	}
 
 	constructor( light = null ) {
 
@@ -18,5 +23,3 @@ class AmbientLightNode extends AnalyticLightNode {
 }
 
 export default AmbientLightNode;
-
-AmbientLightNode.type = /*@__PURE__*/ registerNode( 'AmbientLight', AmbientLightNode );

--- a/src/nodes/lighting/AnalyticLightNode.js
+++ b/src/nodes/lighting/AnalyticLightNode.js
@@ -1,4 +1,3 @@
-import { registerNode } from '../core/Node.js';
 import LightingNode from './LightingNode.js';
 import { NodeUpdateType } from '../core/constants.js';
 import { uniform } from '../core/UniformNode.js';
@@ -123,6 +122,12 @@ const shadowFilterLib = [ BasicShadowMap, PCFShadowMap, PCFSoftShadowMap ];
 let overrideMaterial = null;
 
 class AnalyticLightNode extends LightingNode {
+
+	static get type() {
+
+		return 'AnalyticLightNode';
+
+	}
 
 	constructor( light = null ) {
 
@@ -350,5 +355,3 @@ class AnalyticLightNode extends LightingNode {
 }
 
 export default AnalyticLightNode;
-
-AnalyticLightNode.type = /*@__PURE__*/ registerNode( 'AnalyticLight', AnalyticLightNode );

--- a/src/nodes/lighting/BasicEnvironmentNode.js
+++ b/src/nodes/lighting/BasicEnvironmentNode.js
@@ -1,8 +1,13 @@
-import { registerNode } from '../core/Node.js';
 import LightingNode from './LightingNode.js';
 import { cubeMapNode } from '../utils/CubeMapNode.js';
 
 class BasicEnvironmentNode extends LightingNode {
+
+	static get type() {
+
+		return 'BasicEnvironmentNode';
+
+	}
 
 	constructor( envNode = null ) {
 
@@ -23,5 +28,3 @@ class BasicEnvironmentNode extends LightingNode {
 }
 
 export default BasicEnvironmentNode;
-
-BasicEnvironmentNode.type = /*@__PURE__*/ registerNode( 'BasicEnvironment', BasicEnvironmentNode );

--- a/src/nodes/lighting/BasicLightMapNode.js
+++ b/src/nodes/lighting/BasicLightMapNode.js
@@ -1,8 +1,13 @@
-import { registerNode } from '../core/Node.js';
 import LightingNode from './LightingNode.js';
 import { float } from '../tsl/TSLBase.js';
 
 class BasicLightMapNode extends LightingNode {
+
+	static get type() {
+
+		return 'BasicLightMapNode';
+
+	}
 
 	constructor( lightMapNode = null ) {
 
@@ -25,5 +30,3 @@ class BasicLightMapNode extends LightingNode {
 }
 
 export default BasicLightMapNode;
-
-BasicLightMapNode.type = /*@__PURE__*/ registerNode( 'BasicLightMap', BasicLightMapNode );

--- a/src/nodes/lighting/DirectionalLightNode.js
+++ b/src/nodes/lighting/DirectionalLightNode.js
@@ -1,8 +1,13 @@
-import { registerNode } from '../core/Node.js';
 import AnalyticLightNode from './AnalyticLightNode.js';
 import { lightTargetDirection } from './LightNode.js';
 
 class DirectionalLightNode extends AnalyticLightNode {
+
+	static get type() {
+
+		return 'DirectionalLightNode';
+
+	}
 
 	constructor( light = null ) {
 
@@ -31,5 +36,3 @@ class DirectionalLightNode extends AnalyticLightNode {
 }
 
 export default DirectionalLightNode;
-
-DirectionalLightNode.type = /*@__PURE__*/ registerNode( 'DirectionalLight', DirectionalLightNode );

--- a/src/nodes/lighting/EnvironmentNode.js
+++ b/src/nodes/lighting/EnvironmentNode.js
@@ -1,4 +1,3 @@
-import { registerNode } from '../core/Node.js';
 import LightingNode from './LightingNode.js';
 import { cache } from '../core/CacheNode.js';
 import { roughness, clearcoatRoughness } from '../core/PropertyNode.js';
@@ -13,6 +12,12 @@ import { pmremTexture } from '../pmrem/PMREMNode.js';
 const _envNodeCache = new WeakMap();
 
 class EnvironmentNode extends LightingNode {
+
+	static get type() {
+
+		return 'EnvironmentNode';
+
+	}
 
 	constructor( envNode = null ) {
 
@@ -84,8 +89,6 @@ class EnvironmentNode extends LightingNode {
 }
 
 export default EnvironmentNode;
-
-EnvironmentNode.type = /*@__PURE__*/ registerNode( 'Environment', EnvironmentNode );
 
 const createRadianceContext = ( roughnessNode, normalViewNode ) => {
 

--- a/src/nodes/lighting/HemisphereLightNode.js
+++ b/src/nodes/lighting/HemisphereLightNode.js
@@ -1,4 +1,3 @@
-import { registerNode } from '../core/Node.js';
 import AnalyticLightNode from './AnalyticLightNode.js';
 import { uniform } from '../core/UniformNode.js';
 import { mix } from '../math/MathNode.js';
@@ -8,6 +7,12 @@ import { objectPosition } from '../accessors/Object3DNode.js';
 import { Color } from '../../math/Color.js';
 
 class HemisphereLightNode extends AnalyticLightNode {
+
+	static get type() {
+
+		return 'HemisphereLightNode';
+
+	}
 
 	constructor( light = null ) {
 
@@ -48,5 +53,3 @@ class HemisphereLightNode extends AnalyticLightNode {
 }
 
 export default HemisphereLightNode;
-
-HemisphereLightNode.type = /*@__PURE__*/ registerNode( 'HemisphereLight', HemisphereLightNode );

--- a/src/nodes/lighting/IESSpotLightNode.js
+++ b/src/nodes/lighting/IESSpotLightNode.js
@@ -1,9 +1,14 @@
-import { registerNode } from '../core/Node.js';
 import SpotLightNode from './SpotLightNode.js';
 import { texture } from '../accessors/TextureNode.js';
 import { vec2 } from '../tsl/TSLBase.js';
 
 class IESSpotLightNode extends SpotLightNode {
+
+	static get type() {
+
+		return 'IESSpotLightNode';
+
+	}
 
 	getSpotAttenuation( angleCosine ) {
 
@@ -30,5 +35,3 @@ class IESSpotLightNode extends SpotLightNode {
 }
 
 export default IESSpotLightNode;
-
-IESSpotLightNode.type = /*@__PURE__*/ registerNode( 'IESSpotLight', IESSpotLightNode );

--- a/src/nodes/lighting/IrradianceNode.js
+++ b/src/nodes/lighting/IrradianceNode.js
@@ -1,7 +1,12 @@
-import { registerNode } from '../core/Node.js';
 import LightingNode from './LightingNode.js';
 
 class IrradianceNode extends LightingNode {
+
+	static get type() {
+
+		return 'IrradianceNode';
+
+	}
 
 	constructor( node ) {
 
@@ -20,5 +25,3 @@ class IrradianceNode extends LightingNode {
 }
 
 export default IrradianceNode;
-
-IrradianceNode.type = /*@__PURE__*/ registerNode( 'Irradiance', IrradianceNode );

--- a/src/nodes/lighting/LightNode.js
+++ b/src/nodes/lighting/LightNode.js
@@ -1,9 +1,15 @@
-import Node, { registerNode } from '../core/Node.js';
+import Node from '../core/Node.js';
 import { nodeProxy } from '../tsl/TSLBase.js';
 import { objectPosition } from '../accessors/Object3DNode.js';
 import { cameraViewMatrix } from '../accessors/Camera.js';
 
 class LightNode extends Node {
+
+	static get type() {
+
+		return 'LightNode';
+
+	}
 
 	constructor( scope = LightNode.TARGET_DIRECTION, light = null ) {
 
@@ -51,7 +57,5 @@ class LightNode extends Node {
 LightNode.TARGET_DIRECTION = 'targetDirection';
 
 export default LightNode;
-
-LightNode.type = /*@__PURE__*/ registerNode( 'Light', LightNode );
 
 export const lightTargetDirection = /*@__PURE__*/ nodeProxy( LightNode, LightNode.TARGET_DIRECTION );

--- a/src/nodes/lighting/LightProbeNode.js
+++ b/src/nodes/lighting/LightProbeNode.js
@@ -1,4 +1,3 @@
-import { registerNode } from '../core/Node.js';
 import AnalyticLightNode from './AnalyticLightNode.js';
 import { normalWorld } from '../accessors/Normal.js';
 import { uniformArray } from '../accessors/UniformArrayNode.js';
@@ -7,6 +6,12 @@ import { mul } from '../math/OperatorNode.js';
 import { Vector3 } from '../../math/Vector3.js';
 
 class LightProbeNode extends AnalyticLightNode {
+
+	static get type() {
+
+		return 'LightProbeNode';
+
+	}
 
 	constructor( light = null ) {
 
@@ -47,8 +52,6 @@ class LightProbeNode extends AnalyticLightNode {
 }
 
 export default LightProbeNode;
-
-LightProbeNode.type = /*@__PURE__*/ registerNode( 'LightProbe', LightProbeNode );
 
 const shGetIrradianceAt = /*@__PURE__*/ Fn( ( [ normal, shCoefficients ] ) => {
 

--- a/src/nodes/lighting/LightingContextNode.js
+++ b/src/nodes/lighting/LightingContextNode.js
@@ -1,8 +1,13 @@
-import { registerNode } from '../core/Node.js';
 import ContextNode from '../core/ContextNode.js';
 import { nodeProxy, float, vec3 } from '../tsl/TSLBase.js';
 
 class LightingContextNode extends ContextNode {
+
+	static get type() {
+
+		return 'LightingContextNode';
+
+	}
 
 	constructor( node, lightingModel = null, backdropNode = null, backdropAlphaNode = null ) {
 
@@ -58,7 +63,5 @@ class LightingContextNode extends ContextNode {
 }
 
 export default LightingContextNode;
-
-LightingContextNode.type = /*@__PURE__*/ registerNode( 'LightingContext', LightingContextNode );
 
 export const lightingContext = /*@__PURE__*/ nodeProxy( LightingContextNode );

--- a/src/nodes/lighting/LightingNode.js
+++ b/src/nodes/lighting/LightingNode.js
@@ -1,6 +1,12 @@
-import Node, { registerNode } from '../core/Node.js';
+import Node from '../core/Node.js';
 
 class LightingNode extends Node {
+
+	static get type() {
+
+		return 'LightingNode';
+
+	}
 
 	constructor() {
 
@@ -19,5 +25,3 @@ class LightingNode extends Node {
 }
 
 export default LightingNode;
-
-LightingNode.type = /*@__PURE__*/ registerNode( 'Lighting', LightingNode );

--- a/src/nodes/lighting/LightsNode.js
+++ b/src/nodes/lighting/LightsNode.js
@@ -1,4 +1,4 @@
-import Node, { registerNode } from '../core/Node.js';
+import Node from '../core/Node.js';
 import { nodeObject, nodeProxy, vec3 } from '../tsl/TSLBase.js';
 
 const sortLights = ( lights ) => {
@@ -24,6 +24,12 @@ const getLightNodeById = ( id, lightNodes ) => {
 };
 
 class LightsNode extends Node {
+
+	static get type() {
+
+		return 'LightsNode';
+
+	}
 
 	constructor( lights = [] ) {
 
@@ -225,7 +231,5 @@ class LightsNode extends Node {
 }
 
 export default LightsNode;
-
-LightsNode.type = /*@__PURE__*/ registerNode( 'Lights', LightsNode );
 
 export const lights = /*@__PURE__*/ nodeProxy( LightsNode );

--- a/src/nodes/lighting/PointLightNode.js
+++ b/src/nodes/lighting/PointLightNode.js
@@ -1,4 +1,3 @@
-import { registerNode } from '../core/Node.js';
 import AnalyticLightNode from './AnalyticLightNode.js';
 import { getDistanceAttenuation } from './LightUtils.js';
 import { uniform } from '../core/UniformNode.js';
@@ -6,6 +5,12 @@ import { objectViewPosition } from '../accessors/Object3DNode.js';
 import { positionView } from '../accessors/Position.js';
 
 class PointLightNode extends AnalyticLightNode {
+
+	static get type() {
+
+		return 'PointLightNode';
+
+	}
 
 	constructor( light = null ) {
 
@@ -59,5 +64,3 @@ class PointLightNode extends AnalyticLightNode {
 }
 
 export default PointLightNode;
-
-PointLightNode.type = /*@__PURE__*/ registerNode( 'PointLight', PointLightNode );

--- a/src/nodes/lighting/RectAreaLightNode.js
+++ b/src/nodes/lighting/RectAreaLightNode.js
@@ -1,4 +1,3 @@
-import { registerNode } from '../core/Node.js';
 import AnalyticLightNode from './AnalyticLightNode.js';
 import { texture } from '../accessors/TextureNode.js';
 import { uniform } from '../core/UniformNode.js';
@@ -13,6 +12,12 @@ const _matrix42 = /*@__PURE__*/ new Matrix4();
 let ltcLib = null;
 
 class RectAreaLightNode extends AnalyticLightNode {
+
+	static get type() {
+
+		return 'RectAreaLightNode';
+
+	}
 
 	constructor( light = null ) {
 
@@ -89,5 +94,3 @@ class RectAreaLightNode extends AnalyticLightNode {
 }
 
 export default RectAreaLightNode;
-
-RectAreaLightNode.type = /*@__PURE__*/ registerNode( 'RectAreaLight', RectAreaLightNode );

--- a/src/nodes/lighting/SpotLightNode.js
+++ b/src/nodes/lighting/SpotLightNode.js
@@ -1,4 +1,3 @@
-import { registerNode } from '../core/Node.js';
 import AnalyticLightNode from './AnalyticLightNode.js';
 import { lightTargetDirection } from './LightNode.js';
 import { getDistanceAttenuation } from './LightUtils.js';
@@ -8,6 +7,12 @@ import { objectViewPosition } from '../accessors/Object3DNode.js';
 import { positionView } from '../accessors/Position.js';
 
 class SpotLightNode extends AnalyticLightNode {
+
+	static get type() {
+
+		return 'SpotLightNode';
+
+	}
 
 	constructor( light = null ) {
 
@@ -80,5 +85,3 @@ class SpotLightNode extends AnalyticLightNode {
 }
 
 export default SpotLightNode;
-
-SpotLightNode.type = /*@__PURE__*/ registerNode( 'SpotLight', SpotLightNode );

--- a/src/nodes/math/ConditionalNode.js
+++ b/src/nodes/math/ConditionalNode.js
@@ -1,8 +1,14 @@
-import Node, { registerNode } from '../core/Node.js';
+import Node from '../core/Node.js';
 import { property } from '../core/PropertyNode.js';
 import { addMethodChaining, nodeProxy } from '../tsl/TSLCore.js';
 
 class ConditionalNode extends Node {
+
+	static get type() {
+
+		return 'ConditionalNode';
+
+	}
 
 	constructor( condNode, ifNode, elseNode = null ) {
 
@@ -120,8 +126,6 @@ class ConditionalNode extends Node {
 }
 
 export default ConditionalNode;
-
-ConditionalNode.type = /*@__PURE__*/ registerNode( 'Conditional', ConditionalNode );
 
 export const select = /*@__PURE__*/ nodeProxy( ConditionalNode );
 

--- a/src/nodes/math/MathNode.js
+++ b/src/nodes/math/MathNode.js
@@ -1,9 +1,14 @@
-import { registerNode } from '../core/Node.js';
 import TempNode from '../core/TempNode.js';
 import { sub, mul, div } from './OperatorNode.js';
 import { addMethodChaining, nodeObject, nodeProxy, float, vec2, vec3, vec4, Fn } from '../tsl/TSLCore.js';
 
 class MathNode extends TempNode {
+
+	static get type() {
+
+		return 'MathNode';
+
+	}
 
 	constructor( method, aNode, bNode = null, cNode = null ) {
 
@@ -263,8 +268,6 @@ MathNode.SMOOTHSTEP = 'smoothstep';
 MathNode.FACEFORWARD = 'faceforward';
 
 export default MathNode;
-
-MathNode.type = /*@__PURE__*/ registerNode( 'Math', MathNode );
 
 export const EPSILON = /*@__PURE__*/ float( 1e-6 );
 export const INFINITY = /*@__PURE__*/ float( 1e6 );

--- a/src/nodes/math/OperatorNode.js
+++ b/src/nodes/math/OperatorNode.js
@@ -1,8 +1,13 @@
-import { registerNode } from '../core/Node.js';
 import TempNode from '../core/TempNode.js';
 import { addMethodChaining, nodeProxy } from '../tsl/TSLCore.js';
 
 class OperatorNode extends TempNode {
+
+	static get type() {
+
+		return 'OperatorNode';
+
+	}
 
 	constructor( op, aNode, bNode, ...params ) {
 
@@ -258,8 +263,6 @@ class OperatorNode extends TempNode {
 }
 
 export default OperatorNode;
-
-OperatorNode.type = /*@__PURE__*/ registerNode( 'Operator', OperatorNode );
 
 export const add = /*@__PURE__*/ nodeProxy( OperatorNode, '+' );
 export const sub = /*@__PURE__*/ nodeProxy( OperatorNode, '-' );

--- a/src/nodes/pmrem/PMREMNode.js
+++ b/src/nodes/pmrem/PMREMNode.js
@@ -1,4 +1,3 @@
-import { registerNode } from '../core/Node.js';
 import TempNode from '../core/TempNode.js';
 import { texture } from '../accessors/TextureNode.js';
 import { textureCubeUV } from './PMREMUtils.js';
@@ -73,6 +72,12 @@ function _getPMREMFromTexture( texture ) {
 }
 
 class PMREMNode extends TempNode {
+
+	static get type() {
+
+		return 'PMREMNode';
+
+	}
 
 	constructor( value, uvNode = null, levelNode = null ) {
 
@@ -205,8 +210,6 @@ class PMREMNode extends TempNode {
 }
 
 export default PMREMNode;
-
-PMREMNode.type = /*@__PURE__*/ registerNode( 'PMREM', PMREMNode );
 
 function isCubeMapReady( image ) {
 

--- a/src/nodes/utils/ArrayElementNode.js
+++ b/src/nodes/utils/ArrayElementNode.js
@@ -1,6 +1,12 @@
-import Node, { registerNode } from '../core/Node.js';
+import Node from '../core/Node.js';
 
-class ArrayElementNode extends Node { // @TODO: If extending from TempNode it breaks webgpu_compute
+class ArrayElementNode extends Node {
+
+	static get type() {
+
+		return 'ArrayElementNode';
+
+	} // @TODO: If extending from TempNode it breaks webgpu_compute
 
 	constructor( node, indexNode ) {
 
@@ -31,5 +37,3 @@ class ArrayElementNode extends Node { // @TODO: If extending from TempNode it br
 }
 
 export default ArrayElementNode;
-
-ArrayElementNode.type = /*@__PURE__*/ registerNode( 'ArrayElement', ArrayElementNode );

--- a/src/nodes/utils/ConvertNode.js
+++ b/src/nodes/utils/ConvertNode.js
@@ -1,6 +1,12 @@
-import Node, { registerNode } from '../core/Node.js';
+import Node from '../core/Node.js';
 
 class ConvertNode extends Node {
+
+	static get type() {
+
+		return 'ConvertNode';
+
+	}
 
 	constructor( node, convertTo ) {
 
@@ -61,5 +67,3 @@ class ConvertNode extends Node {
 }
 
 export default ConvertNode;
-
-ConvertNode.type = /*@__PURE__*/ registerNode( 'Convert', ConvertNode );

--- a/src/nodes/utils/CubeMapNode.js
+++ b/src/nodes/utils/CubeMapNode.js
@@ -1,4 +1,3 @@
-import { registerNode } from '../core/Node.js';
 import TempNode from '../core/TempNode.js';
 import { NodeUpdateType } from '../core/constants.js';
 import { nodeProxy } from '../tsl/TSLBase.js';
@@ -10,6 +9,12 @@ import { CubeReflectionMapping, CubeRefractionMapping, EquirectangularReflection
 const _cache = new WeakMap();
 
 class CubeMapNode extends TempNode {
+
+	static get type() {
+
+		return 'CubeMapNode';
+
+	}
 
 	constructor( envNode ) {
 
@@ -111,8 +116,6 @@ class CubeMapNode extends TempNode {
 }
 
 export default CubeMapNode;
-
-CubeMapNode.type = /*@__PURE__*/ registerNode( 'CubeMap', CubeMapNode );
 
 function isEquirectangularMapReady( image ) {
 

--- a/src/nodes/utils/EquirectUVNode.js
+++ b/src/nodes/utils/EquirectUVNode.js
@@ -1,9 +1,14 @@
-import { registerNode } from '../core/Node.js';
 import TempNode from '../core/TempNode.js';
 import { positionWorldDirection } from '../accessors/Position.js';
 import { nodeProxy, vec2 } from '../tsl/TSLBase.js';
 
 class EquirectUVNode extends TempNode {
+
+	static get type() {
+
+		return 'EquirectUVNode';
+
+	}
 
 	constructor( dirNode = positionWorldDirection ) {
 
@@ -27,7 +32,5 @@ class EquirectUVNode extends TempNode {
 }
 
 export default EquirectUVNode;
-
-EquirectUVNode.type = /*@__PURE__*/ registerNode( 'EquirectUV', EquirectUVNode );
 
 export const equirectUV = /*@__PURE__*/ nodeProxy( EquirectUVNode );

--- a/src/nodes/utils/FlipNode.js
+++ b/src/nodes/utils/FlipNode.js
@@ -1,8 +1,13 @@
-import { registerNode } from '../core/Node.js';
 import TempNode from '../core/TempNode.js';
 import { vectorComponents } from '../core/constants.js';
 
 class FlipNode extends TempNode {
+
+	static get type() {
+
+		return 'FlipNode';
+
+	}
 
 	constructor( sourceNode, components ) {
 
@@ -61,5 +66,3 @@ class FlipNode extends TempNode {
 }
 
 export default FlipNode;
-
-FlipNode.type = /*@__PURE__*/ registerNode( 'Flip', FlipNode );

--- a/src/nodes/utils/FunctionOverloadingNode.js
+++ b/src/nodes/utils/FunctionOverloadingNode.js
@@ -1,7 +1,13 @@
-import Node, { registerNode } from '../core/Node.js';
+import Node from '../core/Node.js';
 import { nodeProxy } from '../tsl/TSLBase.js';
 
 class FunctionOverloadingNode extends Node {
+
+	static get type() {
+
+		return 'FunctionOverloadingNode';
+
+	}
 
 	constructor( functionNodes = [], ...parametersNodes ) {
 
@@ -89,8 +95,6 @@ class FunctionOverloadingNode extends Node {
 }
 
 export default FunctionOverloadingNode;
-
-FunctionOverloadingNode.type = /*@__PURE__*/ registerNode( 'FunctionOverloading', FunctionOverloadingNode );
 
 const overloadingBaseFn = /*@__PURE__*/ nodeProxy( FunctionOverloadingNode );
 

--- a/src/nodes/utils/JoinNode.js
+++ b/src/nodes/utils/JoinNode.js
@@ -1,7 +1,12 @@
-import { registerNode } from '../core/Node.js';
 import TempNode from '../core/TempNode.js';
 
 class JoinNode extends TempNode {
+
+	static get type() {
+
+		return 'JoinNode';
+
+	}
 
 	constructor( nodes = [], nodeType = null ) {
 
@@ -57,5 +62,3 @@ class JoinNode extends TempNode {
 }
 
 export default JoinNode;
-
-JoinNode.type = /*@__PURE__*/ registerNode( 'Join', JoinNode );

--- a/src/nodes/utils/LoopNode.js
+++ b/src/nodes/utils/LoopNode.js
@@ -1,8 +1,14 @@
-import Node, { registerNode } from '../core/Node.js';
+import Node from '../core/Node.js';
 import { expression } from '../code/ExpressionNode.js';
 import { nodeObject, nodeArray } from '../tsl/TSLBase.js';
 
 class LoopNode extends Node {
+
+	static get type() {
+
+		return 'LoopNode';
+
+	}
 
 	constructor( params = [] ) {
 
@@ -190,8 +196,6 @@ class LoopNode extends Node {
 }
 
 export default LoopNode;
-
-LoopNode.type = /*@__PURE__*/ registerNode( 'Loop', LoopNode );
 
 export const Loop = ( ...params ) => nodeObject( new LoopNode( nodeArray( params, 'int' ) ) ).append();
 export const Continue = () => expression( 'continue' ).append();

--- a/src/nodes/utils/MatcapUVNode.js
+++ b/src/nodes/utils/MatcapUVNode.js
@@ -1,10 +1,15 @@
-import { registerNode } from '../core/Node.js';
 import TempNode from '../core/TempNode.js';
 import { transformedNormalView } from '../accessors/Normal.js';
 import { positionViewDirection } from '../accessors/Position.js';
 import { nodeImmutable, vec2, vec3 } from '../tsl/TSLBase.js';
 
 class MatcapUVNode extends TempNode {
+
+	static get type() {
+
+		return 'MatcapUVNode';
+
+	}
 
 	constructor() {
 
@@ -24,7 +29,5 @@ class MatcapUVNode extends TempNode {
 }
 
 export default MatcapUVNode;
-
-MatcapUVNode.type = /*@__PURE__*/ registerNode( 'MatcapUV', MatcapUVNode );
 
 export const matcapUV = /*@__PURE__*/ nodeImmutable( MatcapUVNode );

--- a/src/nodes/utils/MaxMipLevelNode.js
+++ b/src/nodes/utils/MaxMipLevelNode.js
@@ -1,9 +1,14 @@
-import { registerNode } from '../core/Node.js';
 import UniformNode from '../core/UniformNode.js';
 import { NodeUpdateType } from '../core/constants.js';
 import { nodeProxy } from '../tsl/TSLBase.js';
 
 class MaxMipLevelNode extends UniformNode {
+
+	static get type() {
+
+		return 'MaxMipLevelNode';
+
+	}
 
 	constructor( textureNode ) {
 
@@ -46,7 +51,5 @@ class MaxMipLevelNode extends UniformNode {
 }
 
 export default MaxMipLevelNode;
-
-MaxMipLevelNode.type = /*@__PURE__*/ registerNode( 'MaxMipLevel', MaxMipLevelNode );
 
 export const maxMipLevel = /*@__PURE__*/ nodeProxy( MaxMipLevelNode );

--- a/src/nodes/utils/OscNode.js
+++ b/src/nodes/utils/OscNode.js
@@ -1,8 +1,14 @@
-import Node, { registerNode } from '../core/Node.js';
+import Node from '../core/Node.js';
 import { timerLocal } from './TimerNode.js';
 import { nodeObject, nodeProxy } from '../tsl/TSLBase.js';
 
 class OscNode extends Node {
+
+	static get type() {
+
+		return 'OscNode';
+
+	}
 
 	constructor( method = OscNode.SINE, timeNode = timerLocal() ) {
 
@@ -72,8 +78,6 @@ OscNode.TRIANGLE = 'triangle';
 OscNode.SAWTOOTH = 'sawtooth';
 
 export default OscNode;
-
-OscNode.type = /*@__PURE__*/ registerNode( 'Osc', OscNode );
 
 export const oscSine = /*@__PURE__*/ nodeProxy( OscNode, OscNode.SINE );
 export const oscSquare = /*@__PURE__*/ nodeProxy( OscNode, OscNode.SQUARE );

--- a/src/nodes/utils/RTTNode.js
+++ b/src/nodes/utils/RTTNode.js
@@ -1,4 +1,3 @@
-import { registerNode } from '../core/Node.js';
 import { nodeObject } from '../tsl/TSLCore.js';
 import TextureNode from '../accessors/TextureNode.js';
 import { NodeUpdateType } from '../core/constants.js';
@@ -13,6 +12,12 @@ import { HalfFloatType } from '../../constants.js';
 const _size = /*@__PURE__*/ new Vector2();
 
 class RTTNode extends TextureNode {
+
+	static get type() {
+
+		return 'RTTNode';
+
+	}
 
 	constructor( node, width = null, height = null, options = { type: HalfFloatType } ) {
 
@@ -123,8 +128,6 @@ class RTTNode extends TextureNode {
 }
 
 export default RTTNode;
-
-RTTNode.type = /*@__PURE__*/ registerNode( 'RTT', RTTNode );
 
 export const rtt = ( node, ...params ) => nodeObject( new RTTNode( nodeObject( node ), ...params ) );
 export const convertToTexture = ( node, ...params ) => node.isTextureNode ? node : rtt( node, ...params );

--- a/src/nodes/utils/ReflectorNode.js
+++ b/src/nodes/utils/ReflectorNode.js
@@ -1,4 +1,3 @@
-import { registerNode } from '../core/Node.js';
 import TextureNode from '../accessors/TextureNode.js';
 import { nodeObject } from '../tsl/TSLBase.js';
 import { NodeUpdateType } from '../core/constants.js';
@@ -33,6 +32,12 @@ const _defaultUV = viewportUV.flipX();
 let _inReflector = false;
 
 class ReflectorNode extends TextureNode {
+
+	static get type() {
+
+		return 'ReflectorNode';
+
+	}
 
 	constructor( parameters = {} ) {
 
@@ -236,5 +241,3 @@ class ReflectorNode extends TextureNode {
 export const reflector = ( parameters ) => nodeObject( new ReflectorNode( parameters ) );
 
 export default ReflectorNode;
-
-ReflectorNode.type = /*@__PURE__*/ registerNode( 'Reflector', ReflectorNode );

--- a/src/nodes/utils/RemapNode.js
+++ b/src/nodes/utils/RemapNode.js
@@ -1,7 +1,13 @@
-import Node, { registerNode } from '../core/Node.js';
+import Node from '../core/Node.js';
 import { float, addMethodChaining, nodeProxy } from '../tsl/TSLCore.js';
 
 class RemapNode extends Node {
+
+	static get type() {
+
+		return 'RemapNode';
+
+	}
 
 	constructor( node, inLowNode, inHighNode, outLowNode = float( 0 ), outHighNode = float( 1 ) ) {
 
@@ -32,8 +38,6 @@ class RemapNode extends Node {
 }
 
 export default RemapNode;
-
-RemapNode.type = /*@__PURE__*/ registerNode( 'Remap', RemapNode );
 
 export const remap = /*@__PURE__*/ nodeProxy( RemapNode, null, null, { doClamp: false } );
 export const remapClamp = /*@__PURE__*/ nodeProxy( RemapNode );

--- a/src/nodes/utils/RotateNode.js
+++ b/src/nodes/utils/RotateNode.js
@@ -1,9 +1,14 @@
-import { registerNode } from '../core/Node.js';
 import TempNode from '../core/TempNode.js';
 import { nodeProxy, vec4, mat2, mat4 } from '../tsl/TSLBase.js';
 import { cos, sin } from '../math/MathNode.js';
 
 class RotateNode extends TempNode {
+
+	static get type() {
+
+		return 'RotateNode';
+
+	}
 
 	constructor( positionNode, rotationNode ) {
 
@@ -54,7 +59,5 @@ class RotateNode extends TempNode {
 }
 
 export default RotateNode;
-
-RotateNode.type = /*@__PURE__*/ registerNode( 'Rotate', RotateNode );
 
 export const rotate = /*@__PURE__*/ nodeProxy( RotateNode );

--- a/src/nodes/utils/SetNode.js
+++ b/src/nodes/utils/SetNode.js
@@ -1,8 +1,13 @@
-import { registerNode } from '../core/Node.js';
 import TempNode from '../core/TempNode.js';
 import { vectorComponents } from '../core/constants.js';
 
 class SetNode extends TempNode {
+
+	static get type() {
+
+		return 'SetNode';
+
+	}
 
 	constructor( sourceNode, components, targetNode ) {
 
@@ -58,5 +63,3 @@ class SetNode extends TempNode {
 }
 
 export default SetNode;
-
-SetNode.type = /*@__PURE__*/ registerNode( 'Set', SetNode );

--- a/src/nodes/utils/SplitNode.js
+++ b/src/nodes/utils/SplitNode.js
@@ -1,9 +1,15 @@
-import Node, { registerNode } from '../core/Node.js';
+import Node from '../core/Node.js';
 import { vectorComponents } from '../core/constants.js';
 
 const stringVectorComponents = vectorComponents.join( '' );
 
 class SplitNode extends Node {
+
+	static get type() {
+
+		return 'SplitNode';
+
+	}
 
 	constructor( node, components = 'x' ) {
 
@@ -108,5 +114,3 @@ class SplitNode extends Node {
 }
 
 export default SplitNode;
-
-SplitNode.type = /*@__PURE__*/ registerNode( 'Split', SplitNode );

--- a/src/nodes/utils/SpriteSheetUVNode.js
+++ b/src/nodes/utils/SpriteSheetUVNode.js
@@ -1,8 +1,14 @@
-import Node, { registerNode } from '../core/Node.js';
+import Node from '../core/Node.js';
 import { uv } from '../accessors/UV.js';
 import { nodeProxy, float, vec2 } from '../tsl/TSLBase.js';
 
 class SpriteSheetUVNode extends Node {
+
+	static get type() {
+
+		return 'SpriteSheetUVNode';
+
+	}
 
 	constructor( countNode, uvNode = uv(), frameNode = float( 0 ) ) {
 
@@ -35,7 +41,5 @@ class SpriteSheetUVNode extends Node {
 }
 
 export default SpriteSheetUVNode;
-
-SpriteSheetUVNode.type = /*@__PURE__*/ registerNode( 'SpriteSheetUV', SpriteSheetUVNode );
 
 export const spritesheetUV = /*@__PURE__*/ nodeProxy( SpriteSheetUVNode );

--- a/src/nodes/utils/StorageArrayElementNode.js
+++ b/src/nodes/utils/StorageArrayElementNode.js
@@ -1,8 +1,13 @@
-import { registerNode } from '../core/Node.js';
 import { nodeProxy } from '../tsl/TSLBase.js';
 import ArrayElementNode from './ArrayElementNode.js';
 
 class StorageArrayElementNode extends ArrayElementNode {
+
+	static get type() {
+
+		return 'StorageArrayElementNode';
+
+	}
 
 	constructor( storageBufferNode, indexNode ) {
 
@@ -83,7 +88,5 @@ class StorageArrayElementNode extends ArrayElementNode {
 }
 
 export default StorageArrayElementNode;
-
-StorageArrayElementNode.type = /*@__PURE__*/ registerNode( 'StorageArrayElement', StorageArrayElementNode );
 
 export const storageElement = /*@__PURE__*/ nodeProxy( StorageArrayElementNode );

--- a/src/nodes/utils/TimerNode.js
+++ b/src/nodes/utils/TimerNode.js
@@ -1,9 +1,14 @@
-import { registerNode } from '../core/Node.js';
 import UniformNode from '../core/UniformNode.js';
 import { NodeUpdateType } from '../core/constants.js';
 import { nodeObject, nodeImmutable } from '../tsl/TSLBase.js';
 
 class TimerNode extends UniformNode {
+
+	static get type() {
+
+		return 'TimerNode';
+
+	}
 
 	constructor( scope = TimerNode.LOCAL, scale = 1, value = 0 ) {
 
@@ -84,8 +89,6 @@ TimerNode.DELTA = 'delta';
 TimerNode.FRAME = 'frame';
 
 export default TimerNode;
-
-TimerNode.type = /*@__PURE__*/ registerNode( 'Timer', TimerNode );
 
 // @TODO: add support to use node in timeScale
 export const timerLocal = ( timeScale, value = 0 ) => nodeObject( new TimerNode( TimerNode.LOCAL, timeScale, value ) );

--- a/src/nodes/utils/TriplanarTexturesNode.js
+++ b/src/nodes/utils/TriplanarTexturesNode.js
@@ -1,4 +1,4 @@
-import Node, { registerNode } from '../core/Node.js';
+import Node from '../core/Node.js';
 import { add } from '../math/OperatorNode.js';
 import { normalLocal } from '../accessors/Normal.js';
 import { positionLocal } from '../accessors/Position.js';
@@ -6,6 +6,12 @@ import { texture } from '../accessors/TextureNode.js';
 import { nodeProxy, float, vec3 } from '../tsl/TSLBase.js';
 
 class TriplanarTexturesNode extends Node {
+
+	static get type() {
+
+		return 'TriplanarTexturesNode';
+
+	}
 
 	constructor( textureXNode, textureYNode = null, textureZNode = null, scaleNode = float( 1 ), positionNode = positionLocal, normalNode = normalLocal ) {
 
@@ -53,8 +59,6 @@ class TriplanarTexturesNode extends Node {
 }
 
 export default TriplanarTexturesNode;
-
-TriplanarTexturesNode.type = /*@__PURE__*/ registerNode( 'TriplanarTextures', TriplanarTexturesNode );
 
 export const triplanarTextures = /*@__PURE__*/ nodeProxy( TriplanarTexturesNode );
 export const triplanarTexture = ( ...params ) => triplanarTextures( ...params );


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/29187, https://github.com/mrdoob/three.js/pull/29250

**Description**

Introduce static type for Nodes. 

- [x] Added `static type` in `Node` and `NodeMaterial`
- [x] Removed `registerNode()` from `Node`
- [x] Removed `registerNodeMaterial()` from `NodeMaterial`
- [x] `NodeLoader`, `NodeObjectLoader` and `NodeMaterialLoader` -- added `.setNodes()`, `setNodeMaterials()`
- [x] Added instance method `createMaterialFromType()` in `MaterialLoader`


Making progress in tree shaking 🌳

![image](https://github.com/user-attachments/assets/f9cdab92-7f1b-4f88-b13a-a0dfbada8106)
