### PR TITLE
Builds: `three.webgpu.nodes.js` -- Remove WebGL2 Fallback

### DIFF
--- a/src/renderers/webgpu/WebGPURenderer.Nodes.js
+++ b/src/renderers/webgpu/WebGPURenderer.Nodes.js
@@ -1,5 +1,4 @@
 import Renderer from '../common/Renderer.js';
-import WebGLBackend from '../webgl-fallback/WebGLBackend.js';
 import WebGPUBackend from './WebGPUBackend.js';
 import BasicNodeLibrary from './nodes/BasicNodeLibrary.js';
 
@@ -7,27 +6,7 @@ class WebGPURenderer extends Renderer {
 
 	constructor( parameters = {} ) {
 
-		let BackendClass;
-
-		if ( parameters.forceWebGL ) {
-
-			BackendClass = WebGLBackend;
-
-		} else {
-
-			BackendClass = WebGPUBackend;
-
-			parameters.getFallback = () => {
-
-				console.warn( 'THREE.WebGPURenderer: WebGPU is not available, running under WebGL2 backend.' );
-
-				return new WebGLBackend( parameters );
-
-			};
-
-		}
-
-		const backend = new BackendClass( parameters );
+		const backend = new WebGPUBackend( parameters );
 
 		super( backend, parameters );
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/28328#issuecomment-2136541224

**Description**

It's not sure if we need the fallback of WebGL2 for `three.webgpu.nodes.js` version, maybe user can externally add the `WebGLBackend` if required? This would be more within the purpose of fully tree-shakeable.

I'll leave it open so we have visibility of tree-shaking as well.