### PR TITLE
TSL: Export color space, tone mapping methods

### DIFF
--- a/src/nodes/TSL.js
+++ b/src/nodes/TSL.js
@@ -23,136 +23,133 @@ export * from './math/MathUtils.js';
 export * from './math/TriNoise3D.js';
 
 // utils
-export { default as EquirectUVNode, equirectUV } from './utils/EquirectUVNode.js';
-export { default as FunctionOverloadingNode, overloadingFn } from './utils/FunctionOverloadingNode.js';
-export { default as LoopNode, Loop, Continue, Break } from './utils/LoopNode.js';
-export { default as MatcapUVNode, matcapUV } from './utils/MatcapUVNode.js';
-export { default as MaxMipLevelNode, maxMipLevel } from './utils/MaxMipLevelNode.js';
-export { default as OscNode, oscSine, oscSquare, oscTriangle, oscSawtooth } from './utils/OscNode.js';
+export * from './utils/EquirectUVNode.js';
+export * from './utils/FunctionOverloadingNode.js';
+export * from './utils/LoopNode.js';
+export * from './utils/MatcapUVNode.js';
+export * from './utils/MaxMipLevelNode.js';
+export * from './utils/OscNode.js';
 export * from './utils/Packing.js';
-export { default as RemapNode, remap, remapClamp } from './utils/RemapNode.js';
+export * from './utils/RemapNode.js';
 export * from './utils/UVUtils.js';
 export * from './utils/SpriteUtils.js';
 export * from './utils/ViewportUtils.js';
-export { default as RotateNode, rotate } from './utils/RotateNode.js';
-export { default as SpriteSheetUVNode, spritesheetUV } from './utils/SpriteSheetUVNode.js';
-export { default as TimerNode, timerLocal, timerGlobal, timerDelta, frameId } from './utils/TimerNode.js';
-export { default as TriplanarTexturesNode, triplanarTextures, triplanarTexture } from './utils/TriplanarTexturesNode.js';
-export { default as ReflectorNode, reflector } from './utils/ReflectorNode.js';
-export { default as RTTNode, rtt, convertToTexture } from './utils/RTTNode.js';
+export * from './utils/RotateNode.js';
+export * from './utils/SpriteSheetUVNode.js';
+export * from './utils/TimerNode.js';
+export * from './utils/TriplanarTexturesNode.js';
+export * from './utils/ReflectorNode.js';
+export * from './utils/RTTNode.js';
 
 // three.js shading language
 export * from './tsl/TSLBase.js';
 
 // accessors
 export * from './accessors/AccessorsUtils.js';
-export { default as UniformArrayNode, uniformArray } from './accessors/UniformArrayNode.js';
+export * from './accessors/UniformArrayNode.js';
 export * from './accessors/Bitangent.js';
-export { default as BufferAttributeNode, bufferAttribute, dynamicBufferAttribute, instancedBufferAttribute, instancedDynamicBufferAttribute } from './accessors/BufferAttributeNode.js';
-export { default as BufferNode, buffer } from './accessors/BufferNode.js';
+export * from './accessors/BufferAttributeNode.js';
+export * from './accessors/BufferNode.js';
 export * from './accessors/Camera.js';
-export { default as VertexColorNode, vertexColor } from './accessors/VertexColorNode.js';
-export { default as CubeTextureNode, cubeTexture } from './accessors/CubeTextureNode.js';
-export { default as InstanceNode, instance } from './accessors/InstanceNode.js';
-export { default as BatchNode, batch } from './accessors/BatchNode.js';
-export { default as MaterialNode, materialAlphaTest, materialColor, materialShininess, materialEmissive, materialOpacity, materialSpecular, materialSpecularStrength, materialReflectivity, materialRoughness, materialMetalness, materialNormal, materialClearcoat, materialClearcoatRoughness, materialClearcoatNormal, materialRotation, materialSheen, materialSheenRoughness, materialIridescence, materialIridescenceIOR, materialIridescenceThickness, materialLineScale, materialLineDashSize, materialLineGapSize, materialLineWidth, materialLineDashOffset, materialPointWidth, materialAnisotropy, materialAnisotropyVector, materialDispersion, materialLightMap, materialAOMap } from './accessors/MaterialNode.js';
+export * from './accessors/VertexColorNode.js';
+export * from './accessors/CubeTextureNode.js';
+export * from './accessors/InstanceNode.js';
+export * from './accessors/BatchNode.js';
+export * from './accessors/MaterialNode.js';
 export * from './accessors/MaterialProperties.js';
-export { default as MaterialReferenceNode, materialReference } from './accessors/MaterialReferenceNode.js';
-export { default as RendererReferenceNode, rendererReference } from './accessors/RendererReferenceNode.js';
-export { default as MorphNode, morphReference } from './accessors/MorphNode.js';
+export * from './accessors/MaterialReferenceNode.js';
+export * from './accessors/RendererReferenceNode.js';
+export * from './accessors/MorphNode.js';
 export * from './accessors/TextureBicubic.js';
-export { default as ModelNode, modelDirection, modelViewMatrix, modelNormalMatrix, modelWorldMatrix, modelPosition, modelViewPosition, modelScale, modelWorldMatrixInverse } from './accessors/ModelNode.js';
-export { default as ModelViewProjectionNode, modelViewProjection } from './accessors/ModelViewProjectionNode.js';
+export * from './accessors/ModelNode.js';
+export * from './accessors/ModelViewProjectionNode.js';
 export * from './accessors/Normal.js';
-export { default as Object3DNode, objectDirection, objectViewMatrix, objectNormalMatrix, objectWorldMatrix, objectPosition, objectScale, objectViewPosition } from './accessors/Object3DNode.js';
-export { default as PointUVNode, pointUV } from './accessors/PointUVNode.js';
+export * from './accessors/Object3DNode.js';
+export * from './accessors/PointUVNode.js';
 export * from './accessors/Position.js';
-export { default as ReferenceNode, reference, referenceBuffer } from './accessors/ReferenceNode.js';
+export * from './accessors/ReferenceNode.js';
 export * from './accessors/ReflectVector.js';
-export { default as SkinningNode, skinning, skinningReference } from './accessors/SkinningNode.js';
-export { default as SceneNode, backgroundBlurriness, backgroundIntensity } from './accessors/SceneNode.js';
-export { default as StorageBufferNode, storage, storageObject } from './accessors/StorageBufferNode.js';
+export * from './accessors/SkinningNode.js';
+export * from './accessors/SceneNode.js';
+export * from './accessors/StorageBufferNode.js';
 export * from './accessors/Tangent.js';
-export { default as TextureNode, texture, textureLoad, /*textureLevel,*/ sampler } from './accessors/TextureNode.js';
-export { default as TextureSizeNode, textureSize } from './accessors/TextureSizeNode.js';
-export { default as StorageTextureNode, storageTexture, textureStore } from './accessors/StorageTextureNode.js';
-export { default as Texture3DNode, texture3D } from './accessors/Texture3DNode.js';
+export * from './accessors/TextureNode.js';
+export * from './accessors/TextureSizeNode.js';
+export * from './accessors/StorageTextureNode.js';
+export * from './accessors/Texture3DNode.js';
 export * from './accessors/UV.js';
-export { default as UserDataNode, userData } from './accessors/UserDataNode.js';
+export * from './accessors/UserDataNode.js';
 export * from './accessors/VelocityNode.js';
 
 // display
 export * from './display/BlendMode.js';
-export { default as BumpMapNode, bumpMap } from './display/BumpMapNode.js';
+export * from './display/BumpMapNode.js';
 export * from './display/ColorAdjustment.js';
-export { default as ColorSpaceNode, toOutputColorSpace, toWorkingColorSpace } from './display/ColorSpaceNode.js';
-export { default as FrontFacingNode, frontFacing, faceDirection } from './display/FrontFacingNode.js';
-export { default as NormalMapNode, normalMap } from './display/NormalMapNode.js';
-export { default as PosterizeNode, posterize } from './display/PosterizeNode.js';
-export { default as ToneMappingNode, toneMapping } from './display/ToneMappingNode.js';
-export { default as ViewportNode, viewport, viewportCoordinate, viewportResolution, viewportUV, viewportTopLeft, viewportBottomLeft } from './display/ViewportNode.js';
-export { default as ViewportTextureNode, viewportTexture, viewportMipTexture } from './display/ViewportTextureNode.js';
-export { default as ViewportSharedTextureNode, viewportSharedTexture } from './display/ViewportSharedTextureNode.js';
-export { default as ViewportDepthTextureNode, viewportDepthTexture } from './display/ViewportDepthTextureNode.js';
-export { default as ViewportDepthNode, viewZToOrthographicDepth, orthographicDepthToViewZ, viewZToPerspectiveDepth, perspectiveDepthToViewZ, depth, linearDepth, viewportLinearDepth } from './display/ViewportDepthNode.js';
-export { default as GaussianBlurNode, gaussianBlur } from './display/GaussianBlurNode.js';
-export { default as AfterImageNode, afterImage } from './display/AfterImageNode.js';
-export { default as AnamorphicNode, anamorphic } from './display/AnamorphicNode.js';
-export { default as SobelOperatorNode, sobel } from './display/SobelOperatorNode.js';
-export { default as DepthOfFieldNode, dof } from './display/DepthOfFieldNode.js';
-export { default as DotScreenNode, dotScreen } from './display/DotScreenNode.js';
-export { default as RGBShiftNode, rgbShift } from './display/RGBShiftNode.js';
-export { default as FilmNode, film } from './display/FilmNode.js';
-export { default as Lut3DNode, lut3D } from './display/Lut3DNode.js';
+export * from './display/ColorSpaceNode.js';
+export * from './display/FrontFacingNode.js';
+export * from './display/NormalMapNode.js';
+export * from './display/PosterizeNode.js';
+export * from './display/ToneMappingNode.js';
+export * from './display/ViewportNode.js';
+export * from './display/ViewportTextureNode.js';
+export * from './display/ViewportSharedTextureNode.js';
+export * from './display/ViewportDepthTextureNode.js';
+export * from './display/ViewportDepthNode.js';
+export * from './display/GaussianBlurNode.js';
+export * from './display/AfterImageNode.js';
+export * from './display/AnamorphicNode.js';
+export * from './display/SobelOperatorNode.js';
+export * from './display/DepthOfFieldNode.js';
+export * from './display/DotScreenNode.js';
+export * from './display/RGBShiftNode.js';
+export * from './display/FilmNode.js';
+export * from './display/Lut3DNode.js';
 export * from './display/MotionBlur.js';
-export { default as GTAONode, ao } from './display/GTAONode.js';
-export { default as DenoiseNode, denoise } from './display/DenoiseNode.js';
-export { default as FXAANode, fxaa } from './display/FXAANode.js';
-export { default as BloomNode, bloom } from './display/BloomNode.js';
-export { default as TransitionNode, transition } from './display/TransitionNode.js';
-export { default as RenderOutputNode, renderOutput } from './display/RenderOutputNode.js';
-export { default as PixelationPassNode, pixelationPass } from './display/PixelationPassNode.js';
-export { default as SSAAPassNode, ssaaPass } from './display/SSAAPassNode.js';
-export { default as StereoPassNode, stereoPass } from './display/StereoPassNode.js';
-export { default as AnaglyphPassNode, anaglyphPass } from './display/AnaglyphPassNode.js';
-export { default as ParallaxBarrierPassNode, parallaxBarrierPass } from './display/ParallaxBarrierPassNode.js';
-export { bleach } from './display/BleachBypass.js';
-export { sepia } from './display/Sepia.js';
+export * from './display/GTAONode.js';
+export * from './display/DenoiseNode.js';
+export * from './display/FXAANode.js';
+export * from './display/BloomNode.js';
+export * from './display/TransitionNode.js';
+export * from './display/RenderOutputNode.js';
+export * from './display/PixelationPassNode.js';
+export * from './display/SSAAPassNode.js';
+export * from './display/StereoPassNode.js';
+export * from './display/AnaglyphPassNode.js';
+export * from './display/ParallaxBarrierPassNode.js';
+export * from './display/BleachBypass.js';
+export * from './display/Sepia.js';
 
-export { default as PassNode, pass, passTexture, depthPass } from './display/PassNode.js';
+export * from './display/PassNode.js';
 
-import * as ColorSpaceFunctions from './display/ColorSpaceFunctions.js';
-export { ColorSpaceFunctions };
-
-import * as ToneMappingFunctions from './display/ToneMappingFunctions.js';
-export { ToneMappingFunctions };
+export * from './display/ColorSpaceFunctions.js';
+export * from './display/ToneMappingFunctions.js';
 
 // code
-export { default as ExpressionNode, expression } from './code/ExpressionNode.js';
-export { default as CodeNode, code, js, wgsl, glsl } from './code/CodeNode.js';
-export { default as FunctionCallNode, call } from './code/FunctionCallNode.js';
-export { default as FunctionNode, wgslFn, glslFn } from './code/FunctionNode.js';
-export { default as ScriptableNode, scriptable, global } from './code/ScriptableNode.js';
-export { default as ScriptableValueNode, scriptableValue } from './code/ScriptableValueNode.js';
+export * from './code/ExpressionNode.js';
+export * from './code/CodeNode.js';
+export * from './code/FunctionCallNode.js';
+export * from './code/FunctionNode.js';
+export * from './code/ScriptableNode.js';
+export * from './code/ScriptableValueNode.js';
 
 // fog
-export { default as FogNode, fog } from './fog/FogNode.js';
-export { default as FogRangeNode, rangeFog } from './fog/FogRangeNode.js';
-export { default as FogExp2Node, densityFog } from './fog/FogExp2Node.js';
+export * from './fog/FogNode.js';
+export * from './fog/FogRangeNode.js';
+export * from './fog/FogExp2Node.js';
 
 // geometry
-export { default as RangeNode, range } from './geometry/RangeNode.js';
+export * from './geometry/RangeNode.js';
 
 // gpgpu
-export { default as ComputeNode, compute } from './gpgpu/ComputeNode.js';
+export * from './gpgpu/ComputeNode.js';
 
 // lighting
-export { default as LightNode, lightTargetDirection } from './lighting/LightNode.js';
-export { default as LightsNode, lights } from './lighting/LightsNode.js';
-export { default as LightingContextNode, lightingContext } from './lighting/LightingContextNode.js';
+export * from './lighting/LightNode.js';
+export * from './lighting/LightsNode.js';
+export * from './lighting/LightingContextNode.js';
 
 // pmrem
-export { default as PMREMNode, pmremTexture } from './pmrem/PMREMNode.js';
+export * from './pmrem/PMREMNode.js';
 export * from './pmrem/PMREMUtils.js';
 
 // procedural

--- a/src/nodes/accessors/MaterialNode.js
+++ b/src/nodes/accessors/MaterialNode.js
@@ -429,7 +429,6 @@ export const materialPointWidth = /*@__PURE__*/ nodeImmutable( MaterialNode, Mat
 export const materialDispersion = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.DISPERSION );
 export const materialLightMap = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.LIGHT_MAP );
 export const materialAOMap = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.AO_MAP );
-export const materialRefractionRatio = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.REFRACTION_RATIO );
 export const materialAnisotropyVector = /*@__PURE__*/ uniform( new Vector2() ).onReference( function ( frame ) {
 
 	return frame.material;

--- a/src/nodes/display/ColorSpaceFunctions.js
+++ b/src/nodes/display/ColorSpaceFunctions.js
@@ -1,7 +1,7 @@
 import { mix } from '../math/MathNode.js';
 import { Fn } from '../tsl/TSLBase.js';
 
-export const sRGBToLinear = /*@__PURE__*/ Fn( ( [ color ] ) => {
+export const sRGBToLinearSRGB = /*@__PURE__*/ Fn( ( [ color ] ) => {
 
 	const a = color.mul( 0.9478672986 ).add( 0.0521327014 ).pow( 2.4 );
 	const b = color.mul( 0.0773993808 );
@@ -12,14 +12,14 @@ export const sRGBToLinear = /*@__PURE__*/ Fn( ( [ color ] ) => {
 	return rgbResult;
 
 } ).setLayout( {
-	name: 'sRGBToLinear',
+	name: 'sRGBToLinearSRGB',
 	type: 'vec3',
 	inputs: [
 		{ name: 'color', type: 'vec3' }
 	]
 } );
 
-export const LinearTosRGB = /*@__PURE__*/ Fn( ( [ color ] ) => {
+export const linearSRGBTosRGB = /*@__PURE__*/ Fn( ( [ color ] ) => {
 
 	const a = color.pow( 0.41666 ).mul( 1.055 ).sub( 0.055 );
 	const b = color.mul( 12.92 );
@@ -30,7 +30,7 @@ export const LinearTosRGB = /*@__PURE__*/ Fn( ( [ color ] ) => {
 	return rgbResult;
 
 } ).setLayout( {
-	name: 'LinearTosRGB',
+	name: 'linearSRGBTosRGB',
 	type: 'vec3',
 	inputs: [
 		{ name: 'color', type: 'vec3' }

--- a/src/nodes/display/ToneMappingFunctions.js
+++ b/src/nodes/display/ToneMappingFunctions.js
@@ -5,12 +5,12 @@ import { mul, sub, div } from '../math/OperatorNode.js';
 
 // exposure only
 
-export const LinearToneMapping = /*@__PURE__*/ Fn( ( [ color, exposure ] ) => {
+export const linearToneMapping = /*@__PURE__*/ Fn( ( [ color, exposure ] ) => {
 
 	return color.mul( exposure ).clamp();
 
 } ).setLayout( {
-	name: 'LinearToneMapping',
+	name: 'linearToneMapping',
 	type: 'vec3',
 	inputs: [
 		{ name: 'color', type: 'vec3' },
@@ -20,14 +20,14 @@ export const LinearToneMapping = /*@__PURE__*/ Fn( ( [ color, exposure ] ) => {
 
 // source: https://www.cs.utah.edu/docs/techreports/2002/pdf/UUCS-02-001.pdf
 
-export const ReinhardToneMapping = /*@__PURE__*/ Fn( ( [ color, exposure ] ) => {
+export const reinhardToneMapping = /*@__PURE__*/ Fn( ( [ color, exposure ] ) => {
 
 	color = color.mul( exposure );
 
 	return color.div( color.add( 1.0 ) ).clamp();
 
 } ).setLayout( {
-	name: 'ReinhardToneMapping',
+	name: 'reinhardToneMapping',
 	type: 'vec3',
 	inputs: [
 		{ name: 'color', type: 'vec3' },
@@ -37,7 +37,7 @@ export const ReinhardToneMapping = /*@__PURE__*/ Fn( ( [ color, exposure ] ) => 
 
 // source: http://filmicworlds.com/blog/filmic-tonemapping-operators/
 
-export const CineonToneMapping = /*@__PURE__*/ Fn( ( [ color, exposure ] ) => {
+export const cineonToneMapping = /*@__PURE__*/ Fn( ( [ color, exposure ] ) => {
 
 	// filmic operator by Jim Hejl and Richard Burgess-Dawson
 	color = color.mul( exposure );
@@ -49,7 +49,7 @@ export const CineonToneMapping = /*@__PURE__*/ Fn( ( [ color, exposure ] ) => {
 	return a.div( b ).pow( 2.2 );
 
 } ).setLayout( {
-	name: 'CineonToneMapping',
+	name: 'cineonToneMapping',
 	type: 'vec3',
 	inputs: [
 		{ name: 'color', type: 'vec3' },
@@ -70,7 +70,7 @@ const RRTAndODTFit = /*@__PURE__*/ Fn( ( [ color ] ) => {
 
 // source: https://github.com/selfshadow/ltc_code/blob/master/webgl/shaders/ltc/ltc_blit.fs
 
-export const ACESFilmicToneMapping = /*@__PURE__*/ Fn( ( [ color, exposure ] ) => {
+export const acesFilmicToneMapping = /*@__PURE__*/ Fn( ( [ color, exposure ] ) => {
 
 	// sRGB => XYZ => D65_2_D60 => AP1 => RRT_SAT
 	const ACESInputMat = mat3(
@@ -99,7 +99,7 @@ export const ACESFilmicToneMapping = /*@__PURE__*/ Fn( ( [ color, exposure ] ) =
 	return color.clamp();
 
 } ).setLayout( {
-	name: 'ACESFilmicToneMapping',
+	name: 'acesFilmicToneMapping',
 	type: 'vec3',
 	inputs: [
 		{ name: 'color', type: 'vec3' },
@@ -120,7 +120,7 @@ const agxDefaultContrastApprox = /*@__PURE__*/ Fn( ( [ x_immutable ] ) => {
 
 } );
 
-export const AgXToneMapping = /*@__PURE__*/ Fn( ( [ color, exposure ] ) => {
+export const agxToneMapping = /*@__PURE__*/ Fn( ( [ color, exposure ] ) => {
 
 	const colortone = vec3( color ).toVar();
 	const AgXInsetMatrix = mat3( vec3( 0.856627153315983, 0.137318972929847, 0.11189821299995 ), vec3( 0.0951212405381588, 0.761241990602591, 0.0767994186031903 ), vec3( 0.0482516061458583, 0.101439036467562, 0.811302368396859 ) );
@@ -143,7 +143,7 @@ export const AgXToneMapping = /*@__PURE__*/ Fn( ( [ color, exposure ] ) => {
 	return colortone;
 
 } ).setLayout( {
-	name: 'AgXToneMapping',
+	name: 'agxToneMapping',
 	type: 'vec3',
 	inputs: [
 		{ name: 'color', type: 'vec3' },
@@ -153,7 +153,7 @@ export const AgXToneMapping = /*@__PURE__*/ Fn( ( [ color, exposure ] ) => {
 
 // https://modelviewer.dev/examples/tone-mapping
 
-export const NeutralToneMapping = /*@__PURE__*/ Fn( ( [ color, exposure ] ) => {
+export const neutralToneMapping = /*@__PURE__*/ Fn( ( [ color, exposure ] ) => {
 
 	const StartCompression = float( 0.8 - 0.04 );
 	const Desaturation = float( 0.15 );
@@ -181,7 +181,7 @@ export const NeutralToneMapping = /*@__PURE__*/ Fn( ( [ color, exposure ] ) => {
 	return mix( color, vec3( newPeak ), g );
 
 } ).setLayout( {
-	name: 'NeutralToneMapping',
+	name: 'neutralToneMapping',
 	type: 'vec3',
 	inputs: [
 		{ name: 'color', type: 'vec3' },

--- a/src/renderers/webgpu/nodes/BasicNodeLibrary.js
+++ b/src/renderers/webgpu/nodes/BasicNodeLibrary.js
@@ -20,12 +20,12 @@ import { IESSpotLightNode } from '../../../nodes/Nodes.js';
 
 // Tone Mapping
 import { LinearToneMapping, ReinhardToneMapping, CineonToneMapping, ACESFilmicToneMapping, AgXToneMapping, NeutralToneMapping } from '../../../constants.js';
-import * as TMF from '../../../nodes/display/ToneMappingFunctions.js';
+import { linearToneMapping, reinhardToneMapping, cineonToneMapping, acesFilmicToneMapping, agxToneMapping, neutralToneMapping } from '../../../nodes/display/ToneMappingFunctions.js';
 
 // Color Space
 import { LinearSRGBColorSpace, SRGBColorSpace } from '../../../constants.js';
+import { linearSRGBTosRGB, sRGBToLinearSRGB } from '../../../nodes/display/ColorSpaceFunctions.js';
 import { getColorSpaceMethod } from '../../../nodes/display/ColorSpaceNode.js';
-import * as CSF from '../../../nodes/display/ColorSpaceFunctions.js';
 
 class BasicNodeLibrary extends NodeLibrary {
 
@@ -42,15 +42,15 @@ class BasicNodeLibrary extends NodeLibrary {
 		this.addLight( LightProbeNode, LightProbe );
 		this.addLight( IESSpotLightNode, IESSpotLight );
 
-		this.addToneMapping( TMF.LinearToneMapping, LinearToneMapping );
-		this.addToneMapping( TMF.ReinhardToneMapping, ReinhardToneMapping );
-		this.addToneMapping( TMF.CineonToneMapping, CineonToneMapping );
-		this.addToneMapping( TMF.ACESFilmicToneMapping, ACESFilmicToneMapping );
-		this.addToneMapping( TMF.AgXToneMapping, AgXToneMapping );
-		this.addToneMapping( TMF.NeutralToneMapping, NeutralToneMapping );
+		this.addToneMapping( linearToneMapping, LinearToneMapping );
+		this.addToneMapping( reinhardToneMapping, ReinhardToneMapping );
+		this.addToneMapping( cineonToneMapping, CineonToneMapping );
+		this.addToneMapping( acesFilmicToneMapping, ACESFilmicToneMapping );
+		this.addToneMapping( agxToneMapping, AgXToneMapping );
+		this.addToneMapping( neutralToneMapping, NeutralToneMapping );
 
-		this.addColorSpace( CSF.LinearTosRGB, getColorSpaceMethod( LinearSRGBColorSpace, SRGBColorSpace ) );
-		this.addColorSpace( CSF.sRGBToLinear, getColorSpaceMethod( SRGBColorSpace, LinearSRGBColorSpace ) );
+		this.addColorSpace( linearSRGBTosRGB, getColorSpaceMethod( LinearSRGBColorSpace, SRGBColorSpace ) );
+		this.addColorSpace( sRGBToLinearSRGB, getColorSpaceMethod( SRGBColorSpace, LinearSRGBColorSpace ) );
 
 	}
 

--- a/src/renderers/webgpu/nodes/StandardNodeLibrary.js
+++ b/src/renderers/webgpu/nodes/StandardNodeLibrary.js
@@ -52,12 +52,12 @@ import { IESSpotLightNode } from '../../../nodes/Nodes.js';
 
 // Tone Mapping
 import { LinearToneMapping, ReinhardToneMapping, CineonToneMapping, ACESFilmicToneMapping, AgXToneMapping, NeutralToneMapping } from '../../../constants.js';
-import * as TMF from '../../../nodes/display/ToneMappingFunctions.js';
+import { linearToneMapping, reinhardToneMapping, cineonToneMapping, acesFilmicToneMapping, agxToneMapping, neutralToneMapping } from '../../../nodes/display/ToneMappingFunctions.js';
 
 // Color Space
 import { LinearSRGBColorSpace, SRGBColorSpace } from '../../../constants.js';
+import { linearSRGBTosRGB, sRGBToLinearSRGB } from '../../../nodes/display/ColorSpaceFunctions.js';
 import { getColorSpaceMethod } from '../../../nodes/display/ColorSpaceNode.js';
-import * as CSF from '../../../nodes/display/ColorSpaceFunctions.js';
 
 class StandardNodeLibrary extends NodeLibrary {
 
@@ -88,15 +88,15 @@ class StandardNodeLibrary extends NodeLibrary {
 		this.addLight( LightProbeNode, LightProbe );
 		this.addLight( IESSpotLightNode, IESSpotLight );
 
-		this.addToneMapping( TMF.LinearToneMapping, LinearToneMapping );
-		this.addToneMapping( TMF.ReinhardToneMapping, ReinhardToneMapping );
-		this.addToneMapping( TMF.CineonToneMapping, CineonToneMapping );
-		this.addToneMapping( TMF.ACESFilmicToneMapping, ACESFilmicToneMapping );
-		this.addToneMapping( TMF.AgXToneMapping, AgXToneMapping );
-		this.addToneMapping( TMF.NeutralToneMapping, NeutralToneMapping );
+		this.addToneMapping( linearToneMapping, LinearToneMapping );
+		this.addToneMapping( reinhardToneMapping, ReinhardToneMapping );
+		this.addToneMapping( cineonToneMapping, CineonToneMapping );
+		this.addToneMapping( acesFilmicToneMapping, ACESFilmicToneMapping );
+		this.addToneMapping( agxToneMapping, AgXToneMapping );
+		this.addToneMapping( neutralToneMapping, NeutralToneMapping );
 
-		this.addColorSpace( CSF.LinearTosRGB, getColorSpaceMethod( LinearSRGBColorSpace, SRGBColorSpace ) );
-		this.addColorSpace( CSF.sRGBToLinear, getColorSpaceMethod( SRGBColorSpace, LinearSRGBColorSpace ) );
+		this.addColorSpace( linearSRGBTosRGB, getColorSpaceMethod( LinearSRGBColorSpace, SRGBColorSpace ) );
+		this.addColorSpace( sRGBToLinearSRGB, getColorSpaceMethod( SRGBColorSpace, LinearSRGBColorSpace ) );
 
 	}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/29259

**Description**

- [x] [export tone mapping methods](https://github.com/mrdoob/three.js/commit/8f70ed27ed672fdd5b3bcd90537a4ca3a2a982a1)
- [x] [export color space conversion methods](https://github.com/mrdoob/three.js/commit/ae8fbefc0bb6e6089e44f624ef3e816f87406f0b)
- [x] [Remove duplicated materialRefractionRatio](https://github.com/mrdoob/three.js/commit/77de719d965f2b176915ffd65129fd7831732c03)
- [x] [rev modules exports/imports](https://github.com/mrdoob/three.js/commit/e53e056033a1ff834f8b80e3a0b4bb36033c3dfc)
