### PR TITLE
Examples: Fix `webgpu_materials` example using NodeMaterials lib

### DIFF
--- a/examples/webgpu_instance_mesh.html
+++ b/examples/webgpu_instance_mesh.html
@@ -69,7 +69,7 @@
 					//
 
 					const gui = new GUI();
-					gui.add( mesh, 'count', 0, count );
+					gui.add( mesh, 'count', 1, count );
 
 				} );
 

--- a/examples/webgpu_materials.html
+++ b/examples/webgpu_materials.html
@@ -419,7 +419,7 @@
 			function testSerialization( mesh ) {
 
 				const json = mesh.toJSON();
-				const loader = new THREE.NodeObjectLoader().setNodes( moduleToLib( TSL ) );
+				const loader = new THREE.NodeObjectLoader().setNodes( moduleToLib( TSL ) ).setNodeMaterials( moduleToLib( THREE ) );
 				const serializedMesh = loader.parse( json );
 
 				serializedMesh.position.x = ( objects.length % 4 ) * 200 - 400;


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/29282

**Description**

Fix `webgpu_materials` after https://github.com/mrdoob/three.js/pull/29282