### PR TITLE
WebGPURenderer: Fix getArrayBufferAsync race condition and ensure proper buffer sequencing

### DIFF
--- a/src/renderers/webgl-fallback/utils/WebGLAttributeUtils.js
+++ b/src/renderers/webgl-fallback/utils/WebGLAttributeUtils.js
@@ -233,9 +233,15 @@ class WebGLAttributeUtils {
 
 		const dstBuffer = new attribute.array.constructor( array.length );
 
+		// Ensure the buffer is bound before reading
+		gl.bindBuffer( gl.COPY_WRITE_BUFFER, writeBuffer );
+
 		gl.getBufferSubData( gl.COPY_WRITE_BUFFER, 0, dstBuffer );
 
 		gl.deleteBuffer( writeBuffer );
+
+		gl.bindBuffer( gl.COPY_READ_BUFFER, null );
+		gl.bindBuffer( gl.COPY_WRITE_BUFFER, null );
 
 		return dstBuffer.buffer;
 

--- a/src/renderers/webgpu/utils/WebGPUAttributeUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUAttributeUtils.js
@@ -224,22 +224,12 @@ class WebGPUAttributeUtils {
 		const bufferGPU = data.buffer;
 		const size = bufferGPU.size;
 
-		let readBufferGPU = data.readBuffer;
-		let needsUnmap = true;
+		const readBufferGPU = device.createBuffer( {
+			label: attribute.name,
+			size,
+			usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+		} );
 
-		if ( readBufferGPU === undefined ) {
-
-			readBufferGPU = device.createBuffer( {
-				label: attribute.name,
-				size,
-				usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
-			} );
-
-			needsUnmap = false;
-
-			data.readBuffer = readBufferGPU;
-
-		}
 
 		const cmdEncoder = device.createCommandEncoder( {} );
 
@@ -251,7 +241,7 @@ class WebGPUAttributeUtils {
 			size
 		);
 
-		if ( needsUnmap ) readBufferGPU.unmap();
+		readBufferGPU.unmap();
 
 		const gpuCommands = cmdEncoder.finish();
 		device.queue.submit( [ gpuCommands ] );


### PR DESCRIPTION
Fixed #29270

WebGL Errors:
 - `performance warning: READ-usage buffer was read back without waiting on a fence. This caused a graphics pipeline stall.`
 - `GL_INVALID_OPERATION: A transform feedback buffer that would be written to is also bound to a non-transform-feedback target`


WebGPU Error:
- `Failed to execute 'mapAsync' on 'GPUBuffer': Buffer was unmapped before mapping was resolved.`

**Description**

Resolved #29270 by re-binding immediately after the fencing operation and correctly unbinding buffers post-operation in the WebGL backend.

Additionally, removed the readBufferGPU caching system in the WebGPU backend, which could cause race conditions during stress tests on subsequent calls.



*This contribution is funded by [Segments.AI](https://segments.ai) & [Utsubo](https://utsubo.com)*
