### PR TITLE
LightProbeHelperGPU: Fix uniform update.

### DIFF
--- a/examples/jsm/helpers/LightProbeHelperGPU.js
+++ b/examples/jsm/helpers/LightProbeHelperGPU.js
@@ -56,7 +56,7 @@ class LightProbeHelper extends Mesh {
 		this.scale.set( 1, 1, 1 ).multiplyScalar( this.size );
 
 		this._intensity.value = this.lightProbe.intensity;
-		this._sh.value = this.lightProbe.sh.coefficients;
+		this._sh.array = this.lightProbe.sh.coefficients;
 
 	}
 

--- a/examples/jsm/helpers/LightProbeHelperGPU.js
+++ b/examples/jsm/helpers/LightProbeHelperGPU.js
@@ -35,8 +35,6 @@ class LightProbeHelper extends Mesh {
 		this.size = size;
 		this.type = 'LightProbeHelper';
 
-		this._intensity = intensity;
-
 		this.onBeforeRender();
 
 	}

--- a/examples/jsm/helpers/LightProbeHelperGPU.js
+++ b/examples/jsm/helpers/LightProbeHelperGPU.js
@@ -35,6 +35,9 @@ class LightProbeHelper extends Mesh {
 		this.size = size;
 		this.type = 'LightProbeHelper';
 
+		this._intensity = intensity;
+		this._sh = sh;
+
 		this.onBeforeRender();
 
 	}
@@ -51,6 +54,9 @@ class LightProbeHelper extends Mesh {
 		this.position.copy( this.lightProbe.position );
 
 		this.scale.set( 1, 1, 1 ).multiplyScalar( this.size );
+
+		this._intensity.value = this.lightProbe.intensity;
+		this._sh.value = this.lightProbe.sh.coefficients;
 
 	}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/29301#discussion_r1741764277

**Description**

Makes sure uniforms are properly updated in `onBeforeRender()`.
