### PR TITLE
Add Giro3D to libraries and plugins

### DIFF
--- a/docs/manual/ar/introduction/Libraries-and-Plugins.html
+++ b/docs/manual/ar/introduction/Libraries-and-Plugins.html
@@ -107,6 +107,7 @@
 			<li>[link:https://threlte.xyz/ Threlte] - Svelte components for 3D graphics built on Three.</li>
 			<li>[link:https://needle.tools/ Needle Engine]</li>
 			<li>[link:https://tresjs.org/ tresjs] - Vue components for 3D graphics built on Three.</li>
+			<li>[link:https://giro3d.org Giro3D] - Versatile framework built on Three for visualizing and interacting with Geospatial 2D, 2.5D and 3D data.</li>			
 		</ul>
 
 	</body>

--- a/docs/manual/en/introduction/Libraries-and-Plugins.html
+++ b/docs/manual/en/introduction/Libraries-and-Plugins.html
@@ -111,6 +111,7 @@
 			<li>[link:https://threlte.xyz/ Threlte] - Svelte components for 3D graphics built on Three.</li>
 			<li>[link:https://needle.tools/ Needle Engine]</li>
 			<li>[link:https://tresjs.org/ tresjs] - Vue components for 3D graphics built on Three.</li>
+			<li>[link:https://giro3d.org Giro3D] - Versatile framework built on Three for visualizing and interacting with Geospatial 2D, 2.5D and 3D data.</li>
 		</ul>
 
 	</body>

--- a/docs/manual/fr/introduction/Libraries-and-Plugins.html
+++ b/docs/manual/fr/introduction/Libraries-and-Plugins.html
@@ -110,6 +110,7 @@
 			<li>[link:https://threlte.xyz/ Threlte] - Svelte components for 3D graphics built on Three.</li>
 			<li>[link:https://needle.tools/ Needle Engine]</li>
 			<li>[link:https://tresjs.org/ tresjs] - Vue components for 3D graphics built on Three.</li>
+			<li>[link:https://giro3d.org Giro3D] - Versatile framework built on Three for visualizing and interacting with Geospatial 2D, 2.5D and 3D data.</li>
 		</ul>
 
 	</body>

--- a/docs/manual/it/introduction/Libraries-and-Plugins.html
+++ b/docs/manual/it/introduction/Libraries-and-Plugins.html
@@ -110,6 +110,7 @@
 			<li>[link:https://threlte.xyz/ Threlte] - Svelte components for 3D graphics built on Three.</li>
 			<li>[link:https://needle.tools/ Needle Engine]</li>
 			<li>[link:https://tresjs.org/ tresjs] - Vue components for 3D graphics built on Three.</li>
+			<li>[link:https://giro3d.org Giro3D] - Versatile framework built on Three for visualizing and interacting with Geospatial 2D, 2.5D and 3D data.</li>			
 		</ul>
 
 	</body>

--- a/docs/manual/ja/introduction/Libraries-and-Plugins.html
+++ b/docs/manual/ja/introduction/Libraries-and-Plugins.html
@@ -103,6 +103,7 @@
         <li>[link:https://threlte.xyz/ Threlte] - Svelte components for 3D graphics built on Three.</li>
         <li>[link:https://needle.tools/ Needle Engine]</li>
         <li>[link:https://tresjs.org/ tresjs] - Vue components for 3D graphics built on Three.</li>
+		<li>[link:https://giro3d.org Giro3D] - Versatile framework built on Three for visualizing and interacting with Geospatial 2D, 2.5D and 3D data.</li>        
     </ul>
 
 </body>

--- a/docs/manual/pt-br/introduction/Libraries-and-Plugins.html
+++ b/docs/manual/pt-br/introduction/Libraries-and-Plugins.html
@@ -110,6 +110,7 @@
 			<li>[link:https://threlte.xyz/ Threlte] - Svelte components for 3D graphics built on Three.</li>
 			<li>[link:https://needle.tools/ Needle Engine]</li>
 			<li>[link:https://tresjs.org/ tresjs] - Vue components for 3D graphics built on Three.</li>
+			<li>[link:https://giro3d.org Giro3D] - Versatile framework built on Three for visualizing and interacting with Geospatial 2D, 2.5D and 3D data.</li>			
 		</ul>
 
 	</body>

--- a/docs/manual/ru/introduction/Libraries-and-Plugins.html
+++ b/docs/manual/ru/introduction/Libraries-and-Plugins.html
@@ -109,6 +109,7 @@
 			<li>[link:https://threlte.xyz/ Threlte] - Svelte components for 3D graphics built on Three.</li>
 			<li>[link:https://needle.tools/ Needle Engine]</li>
 			<li>[link:https://tresjs.org/ tresjs] - Vue components for 3D graphics built on Three.</li>
+			<li>[link:https://giro3d.org Giro3D] - Versatile framework built on Three for visualizing and interacting with Geospatial 2D, 2.5D and 3D data.</li>
 		</ul>
 
 	</body>

--- a/docs/manual/zh/introduction/Libraries-and-Plugins.html
+++ b/docs/manual/zh/introduction/Libraries-and-Plugins.html
@@ -106,6 +106,7 @@
 			<li>[link:https://threlte.xyz/ Threlte] - Svelte components for 3D graphics built on Three.</li>
 			<li>[link:https://needle.tools/ Needle Engine]</li>
 			<li>[link:https://tresjs.org/ tresjs] - Vue components for 3D graphics built on Three.</li>
+			<li>[link:https://giro3d.org Giro3D] - Versatile framework built on Three for visualizing and interacting with Geospatial 2D, 2.5D and 3D data.</li>
 		</ul>
 
 	</body>


### PR DESCRIPTION
**Description**

Mention Giro3D as a Geospatial framework based on Three ( giro3d.org ), in the libraries and plugins documentation page.



