### PR TITLE
WebGPURenderer: Ignore `diagnostic()` method in firefox

### DIFF
--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -149,6 +149,16 @@ if ( /Windows/g.test( navigator.userAgent ) ) {
 
 //
 
+let diagnostics = '';
+
+if ( /Firefox/g.test( navigator.userAgent ) !== true ) {
+
+	diagnostics += 'diagnostic( off, derivative_uniformity );\n';
+
+}
+
+//
+
 class WGSLNodeBuilder extends NodeBuilder {
 
 	constructor( object, renderer ) {
@@ -1246,8 +1256,8 @@ fn main( ${shaderData.attributes} ) -> VaryingsStruct {
 	_getWGSLFragmentCode( shaderData ) {
 
 		return `${ this.getSignature() }
-
-diagnostic( off, derivative_uniformity );
+// global
+${ diagnostics }
 
 // uniforms
 ${shaderData.uniforms}


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/29258

Not all examples need it, so we can disable it for Firefox for as needed.