### PR TITLE
Examples: Add exposure control to `webgl_tonemapping.html`

### DIFF
--- a/examples/webgl_tonemapping.html
+++ b/examples/webgl_tonemapping.html
@@ -129,10 +129,11 @@
 				window.addEventListener( 'resize', onWindowResize );
 
 				gui = new GUI();
-				const toneMappingFolder = gui.addFolder( 'tone mapping' );
+				const toneMappingFolder = gui.addFolder( 'Tone Mapping' );
 
 				toneMappingFolder.add( params, 'toneMapping', Object.keys( toneMappingOptions ) )
 
+					.name( 'type' )
 					.onChange( function () {
 
 						updateGUI( toneMappingFolder );
@@ -142,7 +143,16 @@
 
 					} );
 
-				const backgroundFolder = gui.addFolder( 'background' );
+				guiExposure = toneMappingFolder.add( params, 'exposure', 0, 2 )
+
+					.onChange( function ( value ) {
+
+						renderer.toneMappingExposure = value;
+						render();
+
+					} );
+
+				const backgroundFolder = gui.addFolder( 'Background' );
 
 				backgroundFolder.add( params, 'blurriness', 0, 1 )
 
@@ -170,23 +180,13 @@
 
 			function updateGUI( folder ) {
 
-				if ( guiExposure !== null ) {
+				if ( params.toneMapping === 'None' ) {
 
-					guiExposure.destroy();
-					guiExposure = null;
+					guiExposure.hide();
 
-				}
+				} else {
 
-				if ( params.toneMapping !== 'None' ) {
-
-					guiExposure = folder.add( params, 'exposure', 0, 2 )
-
-						.onChange( function () {
-
-							renderer.toneMappingExposure = params.exposure;
-							render();
-
-						} );
+					guiExposure.show();
 
 				}
 


### PR DESCRIPTION
... and simplify the gui logic.