### PR TITLE
JoltPhysics/RapierPhysics: Fix some warning messages

### DIFF
--- a/examples/jsm/physics/JoltPhysics.js
+++ b/examples/jsm/physics/JoltPhysics.js
@@ -61,7 +61,7 @@ async function JoltPhysics() {
 
 	if ( Jolt === null ) {
 
-		const { default: initJolt } = await import( JOLT_PATH );
+		const { default: initJolt } = await import( `${JOLT_PATH}` );
 		Jolt = await initJolt();
 
 	}

--- a/examples/jsm/physics/RapierPhysics.js
+++ b/examples/jsm/physics/RapierPhysics.js
@@ -58,7 +58,7 @@ async function RapierPhysics() {
 
 	if ( RAPIER === null ) {
 
-		RAPIER = await import( RAPIER_PATH );
+		RAPIER = await import( `${RAPIER_PATH}` );
 		await RAPIER.init();
 
 	}


### PR DESCRIPTION
If you use webpack/rspack, you will receive a warning message like this:

```
Module parse warning:
  ╰─▶   ⚠ Critical dependency: the request of a dependency is an expression
          ╭─[41:30]
       39 │     if (RAPIER === null) {
       40 │
       41 │         RAPIER = await import(RAPIER_PATH);
          ·                               ────────────
       42 │         await RAPIER.init();
       43 │
          ╰────
```



> Critical dependency: the request of a dependency is an expression

**Therefore we cannot use a constant directly.**

This warning can be resolved by using template strings.

