### PR TITLE
Fix misleading comment in How-to-update-things.html

### DIFF
--- a/docs/manual/en/introduction/How-to-update-things.html
+++ b/docs/manual/en/introduction/How-to-update-things.html
@@ -62,7 +62,7 @@ const MAX_POINTS = 500;
 const geometry = new THREE.BufferGeometry();
 
 // attributes
-const positions = new Float32Array( MAX_POINTS * 3 ); // 3 vertices per point
+const positions = new Float32Array( MAX_POINTS * 3 ); // 3 floats (x, y and z) per point
 geometry.setAttribute( 'position', new THREE.BufferAttribute( positions, 3 ) );
 
 // draw range


### PR DESCRIPTION
Related issue: Misleading comment in "Updating Resources" section in the docs.

**Description**

The docs say that each point need 3 vertices per point, while allocating a floats array with the size of three times the vertices/points, it should say three float per point instead.
