### PR TITLE
WebGPURenderer: Fix `viewportCoordinate` in WebGLBackend

### DIFF
--- a/src/nodes/display/ViewportNode.js
+++ b/src/nodes/display/ViewportNode.js
@@ -57,7 +57,18 @@ class ViewportNode extends Node {
 
 		} else {
 
-			renderer.getDrawingBufferSize( resolution );
+			const renderTarget = renderer.getRenderTarget();
+
+			if ( renderTarget !== null ) {
+
+				resolution.width = renderTarget.width;
+				resolution.height = renderTarget.height;
+
+			} else {
+
+				renderer.getDrawingBufferSize( resolution );
+
+			}
 
 		}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/29225

**Description**

Fix `viewportCoordinate` if used `RenderTaget` in `WebGLBackend`.
