### PR TITLE
GLTFLoader: Fix sparse normalized.

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -3153,6 +3153,9 @@ class GLTFParser {
 
 				}
 
+				// Ignore normalized since we copy from sparse
+				bufferAttribute.normalized = false;
+
 				for ( let i = 0, il = sparseIndices.length; i < il; i ++ ) {
 
 					const index = sparseIndices[ i ];
@@ -3164,6 +3167,8 @@ class GLTFParser {
 					if ( itemSize >= 5 ) throw new Error( 'THREE.GLTFLoader: Unsupported itemSize in sparse BufferAttribute.' );
 
 				}
+
+				bufferAttribute.normalized = normalized;
 
 			}
 


### PR DESCRIPTION
`bufferAttribute.setX` will apply the normalisation when it should not when we copy from the sparse array.

---

Simple file with morph target and color attributes (using sparse):
[sparse.glb.zip](https://github.com/user-attachments/files/16886602/sparse.glb.zip)
