### PR TITLE
BatchedMesh setGeometryIdAt getGeometryIdAt

### DIFF
--- a/docs/api/en/objects/BatchedMesh.html
+++ b/docs/api/en/objects/BatchedMesh.html
@@ -168,7 +168,15 @@
 			[page:Integer instanceId]: The id of an instance to get the visibility state of.
 		</p>
 		<p>Get whether the given instance is marked as "visible" or not.</p>
-
+		
+		<h3>
+			[method:Integer getGeometryIdAt]( [param:Integer instanceId] )
+		</h3>
+		<p>
+			[page:Integer instanceId]: The id of an instance to get the geometryIndex of.
+		</p>
+		<p>Get the geometryIndex of the defined instance.</p>
+	
 		<h3>
 			[method:undefined setColorAt]( [param:Integer instanceId], [param:Color color] )
 		</h3>
@@ -205,6 +213,19 @@
 		</p>
 		<p>
 			Sets the visibility of the instance at the given index.
+		</p>
+
+		<h3>
+			[method:this setGeometryIdAt]( [param:Integer instanceId], [param:Integer geometryId] )
+		</h3>
+		<p>
+			[page:Integer instanceId]: The id of the instance to set the geometryIndex of.
+		</p>
+		<p>
+			[page:Integer geometryId]: The geometryIndex to be use by the instance.
+		</p>
+		<p>
+			Sets the geometryIndex of the instance at the given index.
 		</p>
 
 		<h3>

--- a/examples/webgpu_mesh_batch.html
+++ b/examples/webgpu_mesh_batch.html
@@ -68,6 +68,15 @@
 			perObjectFrustumCulled: true,
 			opacity: 1,
 			useCustomSort: true,
+			randomizeGeometry: ()=>{
+
+				for ( let i = 0; i < api.count; i ++ ) {
+
+					mesh.setGeometryIdAt( i, Math.floor( Math.random() * geometries.length ) );
+		
+				}
+		
+			}
 		};
 
 
@@ -187,8 +196,6 @@
 
 		}
 
-
-
 		function init( forceWebGL = false ) {
 
 			if ( renderer ) {
@@ -270,14 +277,12 @@
 			gui.add( api, 'sortObjects' );
 			gui.add( api, 'perObjectFrustumCulled' );
 			gui.add( api, 'useCustomSort' );
+			gui.add( api, 'randomizeGeometry' );
 
 
 			// listeners
 
 			window.addEventListener( 'resize', onWindowResize );
-
-
-
 
 			function onWindowResize() {
 

--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -832,6 +832,35 @@ class BatchedMesh extends Mesh {
 
 	}
 
+	setGeometryIdAt( instanceId, geometryId ) {
+
+		// return early if the geometry is out of range or not active
+		const drawInfo = this._drawInfo;
+		if ( instanceId >= drawInfo.length || drawInfo[ instanceId ].active === false ) {
+
+			return null;
+
+		}
+
+		drawInfo[ instanceId ].geometryIndex = geometryId;
+
+		return this;
+
+	}
+
+	getGeometryIdAt( instanceId ) {
+
+		const drawInfo = this._drawInfo;
+		if ( instanceId >= drawInfo.length ) {
+
+			return - 1;
+
+		}
+
+		return drawInfo[ instanceId ].geometryIndex;
+
+	}
+
 	raycast( raycaster, intersects ) {
 
 		const drawInfo = this._drawInfo;

--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -842,6 +842,14 @@ class BatchedMesh extends Mesh {
 
 		}
 
+		// check if the provided geometryId is within the valid range
+		if ( geometryId < 0 || geometryId >= this._geometryCount ) {
+
+			console.warn( 'BatchedMesh: Invalid geometryId.' );
+			return null;
+
+		}
+
 		drawInfo[ instanceId ].geometryIndex = geometryId;
 
 		return this;
@@ -851,7 +859,7 @@ class BatchedMesh extends Mesh {
 	getGeometryIdAt( instanceId ) {
 
 		const drawInfo = this._drawInfo;
-		if ( instanceId >= drawInfo.length ) {
+		if ( instanceId >= drawInfo.length || drawInfo[ instanceId ].active === false ) {
 
 			return - 1;
 

--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -845,7 +845,6 @@ class BatchedMesh extends Mesh {
 		// check if the provided geometryId is within the valid range
 		if ( geometryId < 0 || geometryId >= this._geometryCount ) {
 
-			console.warn( 'BatchedMesh: Invalid geometryId.' );
 			return null;
 
 		}


### PR DESCRIPTION
This PR add the possibility to switch the geometryId of an instance with setGeometryIdAt and to get the geometryId of an instance with getGeometryIdAt.

This PR implement this feature in the same way than set/get of matrix/color/visibility.

**Before the PR**
`batchedMesh._drawInfo[instanceId].geometryIndex = geometryId`
`X`

**After the PR**
`batchedMesh.setGeometryIdAt(instanceId, geometryId)`
`batchedMesh.getGeometryIdAt(instanceId)`

**Why ?**
Currently we can replace a geometry by another but we cant change the geometry use by an instance.

For example in game, while the player explore the level sometimes I needs more instance with rocks geometry and less with trees geometry and sometimes the opposite. In this case with this feature we can re-use the instance in a clever way updating only their geometryId.

