### PR TITLE
WebGLRenderer: Only compile renderable objects

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -979,6 +979,12 @@ class WebGLRenderer {
 
 			scene.traverse( function ( object ) {
 
+				if ( ! ( object.isMesh || object.isPoints || object.isLine || object.isSprite ) ) {
+
+					return;
+
+				}
+
 				const material = object.material;
 
 				if ( material ) {


### PR DESCRIPTION
**Description**

The methods `WebGLRenderer.compile()` and `WebGLRenderer.compileAsync()` fail when trying to compile custom objects that define a `material` property. My use case involves objects that manage child meshes. The composite objects provide access to an inner, shared material via a getter for convenience.

To reproduce the error, uncomment line 47 or 48 in the following example: https://jsfiddle.net/7nvcjwk8/

```
Uncaught (in promise) TypeError: geometry is undefined
    getParameters WebGLPrograms.js:77
    getProgram WebGLRenderer.js:1631
    prepareMaterial WebGLRenderer.js:921
    compile WebGLRenderer.js:999
    traverse Object3D.js:536
    traverse Object3D.js:542
    compile WebGLRenderer.js:980
    compileAsync WebGLRenderer.js:1019
    init webgl_geometry_cube.html:65
    <anonymous> webgl_geometry_cube.html:37
WebGLPrograms.js:77
```

This PR changes the `compile` method to only process renderable objects, similar to how it's done in `WebGLRenderer.projectObject()`.

Alternatively, `Object3D` could define `isRenderable` with a default value of `false` and the renderable sub classes could set this flag to `true`.