### PR TITLE
WebGPURenderer: extract common draw call logic from backends

### DIFF
--- a/src/renderers/common/RenderObject.js
+++ b/src/renderers/common/RenderObject.js
@@ -203,6 +203,8 @@ export default class RenderObject {
 
 		drawParams.instanceCount = instanceCount;
 
+		if ( object.isBatchedMesh === true ) return drawParams;
+
 		let rangeFactor = 1;
 
 		if ( material.wireframe === true && ! object.isPoints && ! object.isLineSegments && ! object.isLine && ! object.isLineLoop ) {
@@ -221,18 +223,14 @@ export default class RenderObject {
 
 		}
 
-
-		firstVertex = Math.max( firstVertex, 0 );
-
-		if ( object.isBatchedMesh === true ) return drawParams;
-
 		const itemCount = hasIndex === true ? index.count : geometry.attributes.position.count;
 
+		firstVertex = Math.max( firstVertex, 0 );
 		lastVertex = Math.min( lastVertex, itemCount );
 
 		const count = lastVertex - firstVertex;
 
-		if ( count < 0 || count === Infinity ) null;
+		if ( count < 0 || count === Infinity ) return null;
 
 		drawParams.vertexCount = count;
 		drawParams.firstVertex = firstVertex;

--- a/src/renderers/common/RenderObject.js
+++ b/src/renderers/common/RenderObject.js
@@ -61,6 +61,7 @@ export default class RenderObject {
 		this.attributes = null;
 		this.pipeline = null;
 		this.vertexBuffers = null;
+		this.drawParams = null;
 
 		this.updateClipping( renderContext.clippingContext );
 
@@ -180,6 +181,63 @@ export default class RenderObject {
 		if ( this.vertexBuffers === null ) this.getAttributes();
 
 		return this.vertexBuffers;
+
+	}
+
+	getDrawParameters() {
+
+		const { object, material, geometry, group, drawRange } = this;
+
+		const drawParams = this.drawParams || ( this.drawParams = {
+			vertexCount: 0,
+			firstVertex: 0,
+			instanceCount: 0,
+			firstInstance: 0
+		} );
+
+		const index = this.getIndex();
+		const hasIndex = ( index !== null );
+		const instanceCount = geometry.isInstancedBufferGeometry ? geometry.instanceCount : ( object.count > 1 ? object.count : 1 );
+
+		if ( instanceCount === 0 ) return null;
+
+		drawParams.instanceCount = instanceCount;
+
+		let rangeFactor = 1;
+
+		if ( material.wireframe === true && ! object.isPoints && ! object.isLineSegments && ! object.isLine && ! object.isLineLoop ) {
+
+			rangeFactor = 2;
+
+		}
+
+		let firstVertex = drawRange.start * rangeFactor;
+		let lastVertex = ( drawRange.start + drawRange.count ) * rangeFactor;
+
+		if ( group !== null ) {
+
+			firstVertex = Math.max( firstVertex, group.start * rangeFactor );
+			lastVertex = Math.min( lastVertex, ( group.start + group.count ) * rangeFactor );
+
+		}
+
+
+		firstVertex = Math.max( firstVertex, 0 );
+
+		if ( object.isBatchedMesh === true ) return drawParams;
+
+		const itemCount = hasIndex === true ? index.count : geometry.attributes.position.count;
+
+		lastVertex = Math.min( lastVertex, itemCount );
+
+		const count = lastVertex - firstVertex;
+
+		if ( count < 0 || count === Infinity ) null;
+
+		drawParams.vertexCount = count;
+		drawParams.firstVertex = firstVertex;
+
+		return drawParams;
 
 	}
 


### PR DESCRIPTION
Add a new method `renderObject.getDrawParameters()` to provide draw call parameters to the backend renderer.

Most of the logic is identical, apart from multidraw which has been left as-is. The separation of this from the current draw path will allow indirect drawing without duplicating this code again.

