### PR TITLE
Extension of the WebGPU copyTextureToTexture function for array textures

### DIFF
--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -1401,9 +1401,11 @@ class WebGPUBackend extends Backend {
 
 		let dstX = 0;
 		let dstY = 0;
+		let dstLayer = 0;
 
 		let srcX = 0;
 		let srcY = 0;
+		let srcLayer = 0;
 
 		let srcWidth = srcTexture.image.width;
 		let srcHeight = srcTexture.image.height;
@@ -1412,6 +1414,7 @@ class WebGPUBackend extends Backend {
 
 			srcX = srcRegion.x;
 			srcY = srcRegion.y;
+			srcLayer = srcRegion.z || 0;
 			srcWidth = srcRegion.width;
 			srcHeight = srcRegion.height;
 
@@ -1421,6 +1424,7 @@ class WebGPUBackend extends Backend {
 
 			dstX = dstPosition.x;
 			dstY = dstPosition.y;
+			dstLayer = dstPosition.z || 0;
 
 		}
 
@@ -1433,16 +1437,17 @@ class WebGPUBackend extends Backend {
 			{
 				texture: sourceGPU,
 				mipLevel: level,
-				origin: { x: srcX, y: srcY, z: 0 }
+				origin: { x: srcX, y: srcY, z: srcLayer }
 			},
 			{
 				texture: destinationGPU,
 				mipLevel: level,
-				origin: { x: dstX, y: dstY, z: 0 }
+				origin: { x: dstX, y: dstY, z: dstLayer }
 			},
 			[
 				srcWidth,
-				srcHeight
+				srcHeight,
+				1	
 			]
 		);
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -1447,7 +1447,7 @@ class WebGPUBackend extends Backend {
 			[
 				srcWidth,
 				srcHeight,
-				1	
+				1
 			]
 		);
 


### PR DESCRIPTION
So far you can only use the copyTextureToTexture function to copy from one simple texture to another simple texture. But it is also desirable to be able to copy from a simple texture to an array texture and vice versa. That's why I expanded the function a little bit to make this possible. I tested that straight away too. In my app I had no impact on the existing code, but I can now copy textures into array textures. The 1 in line 1450 means that only one layer should be copied.
