### PR TITLE
Controls: Add `null` as default parameter for `domElement`.

### DIFF
--- a/src/extras/Controls.js
+++ b/src/extras/Controls.js
@@ -2,7 +2,7 @@ import { EventDispatcher } from '../core/EventDispatcher.js';
 
 class Controls extends EventDispatcher {
 
-	constructor( object, domElement ) {
+	constructor( object, domElement = null ) {
 
 		super();
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/29079#discussion_r1749504152

**Description**

This makes the default value of `Controls` more consistent with the default value of sub classes.