### PR TITLE
CacheNode: Fix `parent` reference.

### DIFF
--- a/src/nodes/core/CacheNode.js
+++ b/src/nodes/core/CacheNode.js
@@ -29,7 +29,7 @@ class CacheNode extends Node {
 	build( builder, ...params ) {
 
 		const previousCache = builder.getCache();
-		const cache = builder.getCacheFromNode( this, parent );
+		const cache = builder.getCacheFromNode( this, this.parent );
 
 		builder.setCache( cache );
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/28950#issuecomment-2336818578

**Description**

Ensure a correct `parent` reference in `CacheNode.build()`. 