### PR TITLE
Addons.js: Remove WebGPU modules.

### DIFF
--- a/examples/jsm/Addons.js
+++ b/examples/jsm/Addons.js
@@ -58,7 +58,6 @@ export * from './geometries/TeapotGeometry.js';
 export * from './geometries/TextGeometry.js';
 
 export * from './helpers/LightProbeHelper.js';
-export { LightProbeHelper as LightProbeHelperGPU } from './helpers/LightProbeHelperGPU.js';
 export * from './helpers/OctreeHelper.js';
 export * from './helpers/PositionalAudioHelper.js';
 export * from './helpers/RectAreaLightHelper.js';
@@ -173,9 +172,6 @@ export * from './objects/ShadowMesh.js';
 export * from './objects/Sky.js';
 export * from './objects/Water.js';
 export { Water as Water2 } from './objects/Water2.js';
-export * from './objects/SkyMesh.js';
-export * from './objects/WaterMesh.js';
-export { WaterMesh as Water2Mesh } from './objects/Water2Mesh.js';
 
 export * from './physics/AmmoPhysics.js';
 export * from './physics/RapierPhysics.js';
@@ -278,7 +274,6 @@ export * from './utils/LDrawUtils.js';
 export * from './utils/PackedPhongMaterial.js';
 export * as SceneUtils from './utils/SceneUtils.js';
 export * from './utils/ShadowMapViewer.js';
-export { ShadowMapViewer as ShadowMapViewerGPU } from './utils/ShadowMapViewerGPU.js';
 export * as SkeletonUtils from './utils/SkeletonUtils.js';
 export * as SortUtils from './utils/SortUtils.js';
 export * from './utils/TextureUtils.js';


### PR DESCRIPTION
Fixed #29367.

**Description**

The addition of WebGPU modules into `Addons.js` leads to unwanted side effects with bundlers since the bare module specifier `three` is ambiguous.
