### PR TITLE
Audio: Add `delay` parameter to `stop()`.

### DIFF
--- a/docs/api/en/audio/Audio.html
+++ b/docs/api/en/audio/Audio.html
@@ -164,6 +164,7 @@
 
 		<h3>[method:this play]( delay )</h3>
 		<p>
+			delay (optional) - The delay, in seconds, at which the sound should start playing.<br />
 			If [page:Audio.hasPlaybackControl hasPlaybackControl] is true, starts
 			playback.
 		</p>
@@ -244,8 +245,9 @@
 		<h3>[method:this setVolume]( [param:Float value] )</h3>
 		<p>Set the volume.</p>
 
-		<h3>[method:this stop]()</h3>
+		<h3>[method:this stop]( delay )</h3>
 		<p>
+			delay (optional) - The delay, in seconds, at which the sound should stop playing.<br />
 			If [page:Audio.hasPlaybackControl hasPlaybackControl] is enabled, stops
 			playback.
 		</p>

--- a/docs/api/en/audio/Audio.html
+++ b/docs/api/en/audio/Audio.html
@@ -164,7 +164,7 @@
 
 		<h3>[method:this play]( delay )</h3>
 		<p>
-			delay (optional) - The delay, in seconds, at which the sound should start playing.<br />
+			delay (optional) - The delay, in seconds, at which the audio should start playing.<br />
 			If [page:Audio.hasPlaybackControl hasPlaybackControl] is true, starts
 			playback.
 		</p>
@@ -247,7 +247,7 @@
 
 		<h3>[method:this stop]( delay )</h3>
 		<p>
-			delay (optional) - The delay, in seconds, at which the sound should stop playing.<br />
+			delay (optional) - The delay, in seconds, at which the audio should stop playing.<br />
 			If [page:Audio.hasPlaybackControl hasPlaybackControl] is enabled, stops
 			playback.
 		</p>

--- a/src/audio/Audio.js
+++ b/src/audio/Audio.js
@@ -171,7 +171,7 @@ class Audio extends Object3D {
 
 		if ( this.source !== null ) {
 
-			this.source.stop( this.context.currentTime + this.offset + delay );
+			this.source.stop( this.context.currentTime + delay );
 			this.source.onended = null;
 
 		}

--- a/src/audio/Audio.js
+++ b/src/audio/Audio.js
@@ -158,7 +158,7 @@ class Audio extends Object3D {
 
 	}
 
-	stop() {
+	stop( delay = 0 ) {
 
 		if ( this.hasPlaybackControl === false ) {
 
@@ -171,7 +171,7 @@ class Audio extends Object3D {
 
 		if ( this.source !== null ) {
 
-			this.source.stop();
+			this.source.stop( this.context.currentTime + this.offset + delay );
 			this.source.onended = null;
 
 		}


### PR DESCRIPTION
Fixed #29375

**Description**

- Added delay parameter for Audio.stop() to catch up with AudioNode interface
https://developer.mozilla.org/en-US/docs/Web/API/AudioScheduledSourceNode/stop
- Updated docs
