### PR TITLE
Examples: add underwater transition `webgpu_backdrop_water`

### DIFF
--- a/examples/webgpu_backdrop_water.html
+++ b/examples/webgpu_backdrop_water.html
@@ -221,7 +221,7 @@
 				const scenePassColor = scenePass.getTextureNode();
 				const scenePassDepth = scenePass.getLinearDepthNode().remapClamp( .3, .5 );
 
-				const waterMask = objectPosition( camera ).y.greaterThan( 0 );
+				const waterMask = objectPosition( camera ).y.greaterThan( screenUV.y.sub( .5 ).mul( camera.near ) );
 
 				const scenePassColorBlurred = gaussianBlur( scenePassColor );
 				scenePassColorBlurred.directionNode = waterMask.select( scenePassDepth, scenePass.getLinearDepthNode().mul( 5 ) );


### PR DESCRIPTION
**Description**

It is now possible to visualize the post-processing being applied underwater and above in the same frame.

![image](https://github.com/user-attachments/assets/fe060aa2-1c08-42d3-ae20-82ddb86827a8)

