### PR TITLE
TransformControls: Rename `getGizmo()` to `getHelper()`.

### DIFF
--- a/docs/examples/en/controls/TransformControls.html
+++ b/docs/examples/en/controls/TransformControls.html
@@ -151,9 +151,9 @@
 			Removes the current 3D object from the controls and makes the helper UI invisible.
 		</p>
 
-		<h3>[method:Object3D getGizmo] ()</h3>
+		<h3>[method:Object3D getHelper] ()</h3>
 		<p>
-			Returns the visual representation of the controls. Add the gizmo to your scene to visually transform the attached 
+			Returns the visual representation of the controls. Add the helper to your scene to visually transform the attached 
 			3D object.
 		</p>
 

--- a/editor/js/Viewport.js
+++ b/editor/js/Viewport.js
@@ -142,7 +142,7 @@ function Viewport( editor ) {
 
 	} );
 
-	sceneHelpers.add( transformControls.getGizmo() );
+	sceneHelpers.add( transformControls.getHelper() );
 
 	//
 

--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -192,7 +192,7 @@ class TransformControls extends Controls {
 
 	}
 
-	getGizmo() {
+	getHelper() {
 
 		return this._root;
 

--- a/examples/misc_controls_transform.html
+++ b/examples/misc_controls_transform.html
@@ -89,7 +89,7 @@
 
 				control.attach( mesh );
 
-				const gizmo = control.getGizmo();
+				const gizmo = control.getHelper();
 				scene.add( gizmo );
 
 				window.addEventListener( 'resize', onWindowResize );

--- a/examples/webgl_animation_skinning_ik.html
+++ b/examples/webgl_animation_skinning_ik.html
@@ -151,7 +151,7 @@
 			transformControls.showX = false;
 			transformControls.space = 'world';
 			transformControls.attach( OOI.target_hand_l );
-			scene.add( transformControls.getGizmo() );
+			scene.add( transformControls.getHelper() );
 
 			// disable orbitControls while using transformControls
 			transformControls.addEventListener( 'mouseDown', () => orbitControls.enabled = false );

--- a/examples/webgl_geometry_spline_editor.html
+++ b/examples/webgl_geometry_spline_editor.html
@@ -145,7 +145,7 @@
 					controls.enabled = ! event.value;
 
 				} );
-				scene.add( transformControl.getGizmo() );
+				scene.add( transformControl.getHelper() );
 
 				transformControl.addEventListener( 'objectChange', function () {
 

--- a/examples/webgl_modifier_curve.html
+++ b/examples/webgl_modifier_curve.html
@@ -191,7 +191,7 @@
 
 						const target = intersects[ 0 ].object;
 						control.attach( target );
-						scene.add( control.getGizmo() );
+						scene.add( control.getHelper() );
 
 					}
 

--- a/examples/webgl_modifier_curve_instanced.html
+++ b/examples/webgl_modifier_curve_instanced.html
@@ -221,7 +221,7 @@
 
 						const target = intersects[ 0 ].object;
 						control.attach( target );
-						scene.add( control.getGizmo() );
+						scene.add( control.getHelper() );
 
 					}
 

--- a/examples/webgl_shadowmap_progressive.html
+++ b/examples/webgl_shadowmap_progressive.html
@@ -76,7 +76,7 @@
 
 				} );
 				control.attach( lightOrigin );
-				scene.add( control.getGizmo() );
+				scene.add( control.getHelper() );
 
 				// create 8 directional lights to speed up the convergence
 				for ( let l = 0; l < lightCount; l ++ ) {
@@ -142,7 +142,7 @@
 
 					} );
 					control2.attach( object );
-					scene.add( control2.getGizmo() );
+					scene.add( control2.getHelper() );
 					const lightTarget = new THREE.Group();
 					lightTarget.position.set( 0, 20, 0 );
 					for ( let l = 0; l < dirLights.length; l ++ ) {

--- a/examples/webgpu_tsl_compute_attractors_particles.html
+++ b/examples/webgpu_tsl_compute_attractors_particles.html
@@ -118,7 +118,7 @@
 					attractor.controls.attach( attractor.reference );
 					attractor.controls.visible = true;
 					attractor.controls.enabled = attractor.controls.visible;
-					scene.add( attractor.controls.getGizmo() );
+					scene.add( attractor.controls.getHelper() );
 			
 					attractor.controls.addEventListener( 'dragging-changed', ( event ) => {
 

--- a/examples/webxr_xr_controls_transform.html
+++ b/examples/webxr_xr_controls_transform.html
@@ -162,7 +162,7 @@
 
 				controls = new TransformControls( camera, renderer.domElement );
 				controls.attach( group.children[ 0 ] );
-				scene.add( controls.getGizmo() );
+				scene.add( controls.getHelper() );
 
 				//
 


### PR DESCRIPTION
Related issue: #29146

**Description**

As suggested in https://github.com/mrdoob/three.js/pull/29146#discussion_r1756583058, the PR renames  `TransformControls.getGizmo()` to `TransformControls.getHelper()`.
