### PR TITLE
WebGPURenderer: Fix InstancedMesh init with 0 instance

### DIFF
--- a/src/nodes/accessors/InstanceNode.js
+++ b/src/nodes/accessors/InstanceNode.js
@@ -52,7 +52,7 @@ class InstanceNode extends Node {
 
 			if ( instanceMesh.count <= 1000 ) {
 
-				instanceMatrixNode = buffer( instanceAttribute.array, 'mat4', instanceMesh.count ).element( instanceIndex );
+				instanceMatrixNode = buffer( instanceAttribute.array, 'mat4', Math.max( instanceMesh.count, 1 ) ).element( instanceIndex );
 
 			} else {
 


### PR DESCRIPTION
**Description**
Initializing an `InstancedMesh` with `count = 0` breaks in both backends. This PR fixes the issue by creating a uniform buffer of a minimum of size 1.
<img width="609" alt="image" src="https://github.com/user-attachments/assets/0499abdf-349a-40f2-9019-f48bc621db7b">


*This contribution is funded by [Segments.AI](https://segments.ai) & [Utsubo](https://utsubo.com)*