### PR TITLE
WebGPURenderer: correct texelFetch() texel coordinates in WebGL fallback

### DIFF
--- a/src/nodes/accessors/TextureNode.js
+++ b/src/nodes/accessors/TextureNode.js
@@ -130,7 +130,7 @@ class TextureNode extends UniformNode {
 
 			if ( this.sampler ) {
 
-				uvNode = uvNode.setY( uvNode.flipY() );
+				uvNode = uvNode.flipY();
 
 			} else {
 

--- a/src/nodes/accessors/TextureNode.js
+++ b/src/nodes/accessors/TextureNode.js
@@ -130,7 +130,7 @@ class TextureNode extends UniformNode {
 
 			if ( this.sampler ) {
 
-				uvNode = uvNode.setY( uvNode.y.oneMinus() );
+				uvNode = uvNode.setY( uvNode.flipY() );
 
 			} else {
 

--- a/src/nodes/accessors/TextureNode.js
+++ b/src/nodes/accessors/TextureNode.js
@@ -4,7 +4,7 @@ import { textureSize } from './TextureSizeNode.js';
 import { colorSpaceToWorking } from '../display/ColorSpaceNode.js';
 import { expression } from '../code/ExpressionNode.js';
 import { maxMipLevel } from '../utils/MaxMipLevelNode.js';
-import { nodeProxy, vec3, nodeObject } from '../tsl/TSLBase.js';
+import { nodeProxy, vec3, nodeObject, int } from '../tsl/TSLBase.js';
 import { NodeUpdateType } from '../core/constants.js';
 
 import { IntType, UnsignedIntType } from '../../constants.js';
@@ -128,7 +128,15 @@ class TextureNode extends UniformNode {
 
 		if ( builder.isFlipY() && ( texture.isRenderTargetTexture === true || texture.isFramebufferTexture === true || texture.isDepthTexture === true ) ) {
 
-			uvNode = uvNode.setY( uvNode.y.oneMinus() );
+			if ( this.sampler ) {
+
+				uvNode = uvNode.setY( uvNode.y.oneMinus() );
+
+			} else {
+
+				uvNode = uvNode.setY( int( textureSize( this, this.levelNode ).y ).sub( uvNode.y ).sub( 1) );
+
+			}
 
 		}
 

--- a/src/nodes/accessors/TextureNode.js
+++ b/src/nodes/accessors/TextureNode.js
@@ -134,7 +134,7 @@ class TextureNode extends UniformNode {
 
 			} else {
 
-				uvNode = uvNode.setY( int( textureSize( this, this.levelNode ).y ).sub( uvNode.y ).sub( 1) );
+				uvNode = uvNode.setY( int( textureSize( this, this.levelNode ).y ).sub( uvNode.y ).sub( 1 ) );
 
 			}
 

--- a/src/nodes/accessors/TextureSizeNode.js
+++ b/src/nodes/accessors/TextureSizeNode.js
@@ -23,9 +23,9 @@ class TextureSizeNode extends Node {
 	generate( builder, output ) {
 
 		const textureProperty = this.textureNode.build( builder, 'property' );
-		const levelNode = this.levelNode.build( builder, 'int' );
+		const level = this.levelNode === null ? '0' : this.levelNode.build( builder, 'int' );
 
-		return builder.format( `${ builder.getMethod( 'textureDimensions' ) }( ${ textureProperty }, ${ levelNode } )`, this.getNodeType( builder ), output );
+		return builder.format( `${ builder.getMethod( 'textureDimensions' ) }( ${ textureProperty }, ${ level } )`, this.getNodeType( builder ), output );
 
 	}
 

--- a/src/nodes/utils/SetNode.js
+++ b/src/nodes/utils/SetNode.js
@@ -30,7 +30,7 @@ class SetNode extends TempNode {
 		const { sourceNode, components, targetNode } = this;
 
 		const sourceType = this.getNodeType( builder );
-		const targetType = builder.getTypeFromLength( components.length );
+		const targetType = builder.getTypeFromLength( components.length, targetNode.getNodeType( builder ) );
 
 		const targetSnippet = targetNode.build( builder, targetType );
 		const sourceSnippet = sourceNode.build( builder, sourceType );


### PR DESCRIPTION
GLSL texelFetch requires integer texel coordinates corrected for coordinate direction using the texture dimensions.

setNode() incorrectly casts the result of  uv.setY( ... ) to 'float', attempt to fix that. 
