### PR TITLE
WebGPURenderer: fix renderGroup.needs update logic

### DIFF
--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -424,7 +424,8 @@ class Renderer {
 
 		//
 
-		const renderBundleNeedsUpdate = renderBundleData.renderContexts.has( renderContext ) === false || bundleGroup.needsUpdate === true;
+		const needsUpdate = bundleGroup.version !== renderBundleData.version;
+		const renderBundleNeedsUpdate = renderBundleData.renderContexts.has( renderContext ) === false || needsUpdate;
 
 		renderBundleData.renderContexts.add( renderContext );
 
@@ -432,7 +433,7 @@ class Renderer {
 
 			this.backend.beginBundle( renderContext );
 
-			if ( renderBundleData.renderObjects === undefined || bundleGroup.needsUpdate === true ) {
+			if ( renderBundleData.renderObjects === undefined || needsUpdate ) {
 
 				renderBundleData.renderObjects = [];
 
@@ -450,7 +451,7 @@ class Renderer {
 
 			this.backend.finishBundle( renderContext, renderBundle );
 
-			bundleGroup.needsUpdate = false;
+			renderBundleData.version = bundleGroup.version;
 
 		} else {
 


### PR DESCRIPTION
Related issue: #29386

Minor breakage from change in needsUpdate logic.

Note: the performance examples are now broken with the fallback renderer, presumably from the lack of shared UBOs.  I'll take a look at that. (only one object in the renderBundle rotates, and only some of the game model objects rotate)


