### PR TITLE
Editor: Fix default camera replaced by camera on scene

### DIFF
--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -703,7 +703,7 @@ Editor.prototype = {
 				toneMapping: this.config.getKey( 'project/renderer/toneMapping' ),
 				toneMappingExposure: this.config.getKey( 'project/renderer/toneMappingExposure' )
 			},
-			camera: this.viewportCamera.toJSON(),
+			camera: this.camera.toJSON(),
 			scene: this.scene.toJSON(),
 			scripts: this.scripts,
 			history: this.history.toJSON(),


### PR DESCRIPTION
**Description**

There is a problem with the online editor. The default camera is replaced by the camera added in the scene.

Procedure to reproduce the issue :
- In an empty scene, add a camera in the scene graph,
- Select this camera as viewport camera,
- Then add an another object like a Cube for instance,
- Finally, refresh the page : now, the default camera is gone and the scene camera replaced default camera.
 
![2024-09-13_14-52](https://github.com/user-attachments/assets/a4fd3ac7-2c4f-4273-9c33-dbf0a853ccd4)

I propose a simple fix to avoid this problem when refreshing editor page.
