### PR TITLE
BatchedMesh: Add `getGeometryRangeAt`

### DIFF
--- a/docs/api/en/objects/BatchedMesh.html
+++ b/docs/api/en/objects/BatchedMesh.html
@@ -167,8 +167,19 @@
 		<p>
 			[page:Integer instanceId]: The id of an instance to get the visibility state of.
 		</p>
-		<p>Get whether the given instance is marked as "visible" or not.</p>
+		<p>Get whether the given instance is marked as "visible" or not.</p>		
+
+		<h3>
+			[method:Object getGeometryRangeAt]( [param:Integer geometryId] )
+		</h3>
+		<p>
+			[page:Integer geometryId]: The id of the geometry to retrieve the geometry range.
+		</p>
 		
+		<p>Get range of the specified geometry or `null` if invalid.</p>
+		<p>Return an object of the form:</p>
+		<code>{ start: Integer, count: Integer }</code>
+	
 		<h3>
 			[method:Integer getGeometryIdAt]( [param:Integer instanceId] )
 		</h3>
@@ -176,7 +187,7 @@
 			[page:Integer instanceId]: The id of an instance to get the geometryIndex of.
 		</p>
 		<p>Get the geometryIndex of the defined instance.</p>
-	
+
 		<h3>
 			[method:undefined setColorAt]( [param:Integer instanceId], [param:Color color] )
 		</h3>

--- a/docs/api/en/objects/BatchedMesh.html
+++ b/docs/api/en/objects/BatchedMesh.html
@@ -170,12 +170,14 @@
 		<p>Get whether the given instance is marked as "visible" or not.</p>		
 
 		<h3>
-			[method:Object getGeometryRangeAt]( [param:Integer geometryId] )
+			[method:Object getGeometryRangeAt]( [param:Integer geometryId], [param:Object target] )
 		</h3>
 		<p>
 			[page:Integer geometryId]: The id of the geometry to get the range of.
 		</p>
-		
+		<p>
+			[page:Object target]: Optional target object to copy the range in to.
+		</p>
 		<p>Get the range representing the subset of triangles related to the attached geometry, indicating the starting offset and count, or `null` if invalid.</p>
 		<p>Return an object of the form:</p>
 		<code>{ start: Integer, count: Integer }</code>

--- a/docs/api/en/objects/BatchedMesh.html
+++ b/docs/api/en/objects/BatchedMesh.html
@@ -173,10 +173,10 @@
 			[method:Object getGeometryRangeAt]( [param:Integer geometryId] )
 		</h3>
 		<p>
-			[page:Integer geometryId]: The id of the geometry to retrieve the geometry range.
+			[page:Integer geometryId]: The id of the geometry to get the range of.
 		</p>
 		
-		<p>Get range of the specified geometry or `null` if invalid.</p>
+		<p>Get the range representing the subset of triangles related to the attached geometry, indicating the starting offset and count, or `null` if invalid.</p>
 		<p>Return an object of the form:</p>
 		<code>{ start: Integer, count: Integer }</code>
 	

--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -868,7 +868,7 @@ class BatchedMesh extends Mesh {
 
 	}
 
-	getGeometryRangeAt( geometryId ) {
+	getGeometryRangeAt( geometryId, target = {} ) {
 
 		if ( geometryId < 0 || geometryId >= this._geometryCount ) {
 
@@ -877,7 +877,11 @@ class BatchedMesh extends Mesh {
 		}
 
 		const drawRange = this._drawRanges[ geometryId ];
-		return { ...drawRange }; // cloned to avoid external changes
+
+		target.start = drawRange.start;
+		target.count = drawRange.count;
+
+		return target;
 
 	}
 

--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -878,6 +878,7 @@ class BatchedMesh extends Mesh {
 
 		const drawRange = this._drawRanges[ geometryId ];
 		return { ...drawRange }; // cloned to avoid external changes
+
 	}
 
 	raycast( raycaster, intersects ) {

--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -868,6 +868,18 @@ class BatchedMesh extends Mesh {
 
 	}
 
+	getGeometryRangeAt( geometryId ) {
+
+		if ( geometryId < 0 || geometryId >= this._geometryCount ) {
+
+			return null;
+
+		}
+
+		const drawRange = this._drawRanges[ geometryId ];
+		return { ...drawRange }; // cloned to avoid external changes
+	}
+
 	raycast( raycaster, intersects ) {
 
 		const drawInfo = this._drawInfo;


### PR DESCRIPTION
**Description**

By adding `getGeometryRangeAt` method, the user will not have to access the internal `_drawRanges` object.

To prevent the user from modifying the returned object, do you think it is okay to clone it?

**cc** @gkjohnson 
