### PR TITLE
WebGPURenderer: add Texture state tracking to `NodeMaterialObserver` 

### DIFF
--- a/src/materials/nodes/manager/NodeMaterialObserver.js
+++ b/src/materials/nodes/manager/NodeMaterialObserver.js
@@ -135,7 +135,7 @@ class NodeMaterialObserver {
 
 				data[ property ] = value.clone();
 
-				// clone increments the new texture's version, thus update
+//				// clone increments the new texture's version, thus update
 				if ( value.isTexture ) data[ property ].version --;
 
 			} else {
@@ -181,7 +181,22 @@ class NodeMaterialObserver {
 
 					value.copy( mtlValue );
 
-					if ( value.isTexture ) value.version = mtlValue.version;
+					return false;
+
+				}
+
+			} else if ( value.isTexture === true ) {
+
+				if ( value.uuid !== mtlValue.uuid ) {
+
+					materialData[ property ] = value.clone();
+					materialData[ property ].version --;
+
+					return false;
+
+				} else if ( value.version !== mtlValue.version ) {
+
+					value.version = mtlValue.version;
 
 					return false;
 
@@ -190,6 +205,8 @@ class NodeMaterialObserver {
 			} else if ( value !== mtlValue ) {
 
 				materialData[ property ] = mtlValue;
+
+				return false;
 
 			}
 

--- a/src/materials/nodes/manager/NodeMaterialObserver.js
+++ b/src/materials/nodes/manager/NodeMaterialObserver.js
@@ -133,10 +133,15 @@ class NodeMaterialObserver {
 
 			if ( typeof value === 'object' && value.clone !== undefined ) {
 
-				data[ property ] = value.clone();
+				if ( value.isTexture === true ) {
 
-				// clone increments the new texture's version, thus update
-				if ( value.isTexture ) data[ property ].version --;
+					data[ property ] = { id: value.id, version: value.version };
+
+				} else {
+
+					data[ property ] = value.clone();
+
+				}
 
 			} else {
 
@@ -185,17 +190,11 @@ class NodeMaterialObserver {
 
 				}
 
-			} else if ( value.isTexture === true ) {
+			} else if ( mtlValue.isTexture === true ) {
 
-				if ( value.uuid !== mtlValue.uuid ) {
+				if ( value.id !== mtlValue.id || value.version !== mtlValue.version ) {
 
-					materialData[ property ] = value.clone();
-					materialData[ property ].version --;
-
-					return false;
-
-				} else if ( value.version !== mtlValue.version ) {
-
+					value.id = mtlValue.id;
 					value.version = mtlValue.version;
 
 					return false;

--- a/src/materials/nodes/manager/NodeMaterialObserver.js
+++ b/src/materials/nodes/manager/NodeMaterialObserver.js
@@ -135,7 +135,7 @@ class NodeMaterialObserver {
 
 				data[ property ] = value.clone();
 
-//				// clone increments the new texture's version, thus update
+				// clone increments the new texture's version, thus update
 				if ( value.isTexture ) data[ property ].version --;
 
 			} else {

--- a/src/materials/nodes/manager/NodeMaterialObserver.js
+++ b/src/materials/nodes/manager/NodeMaterialObserver.js
@@ -135,6 +135,9 @@ class NodeMaterialObserver {
 
 				data[ property ] = value.clone();
 
+				// clone increments the new texture's version, thus update
+				if ( value.isTexture ) data[ property ].version --;
+
 			} else {
 
 				data[ property ] = value;
@@ -177,6 +180,8 @@ class NodeMaterialObserver {
 				if ( value.equals( mtlValue ) === false ) {
 
 					value.copy( mtlValue );
+
+					if ( value.isTexture ) value.version = mtlValue.version;
 
 					return false;
 

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -98,6 +98,12 @@ class Texture extends EventDispatcher {
 
 	}
 
+	equals( other ) {
+
+		return this.version === other.version && this.uuid === other.uuid;
+
+	}
+
 	copy( source ) {
 
 		this.name = source.name;

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -98,12 +98,6 @@ class Texture extends EventDispatcher {
 
 	}
 
-	equals( other ) {
-
-		return this.version === other.version && this.uuid === other.uuid;
-
-	}
-
 	copy( source ) {
 
 		this.name = source.name;


### PR DESCRIPTION
Related issue: #29386

A race exists where a `NodeMaterialObserver` captures a texture's state and the texture image is loaded/changed.
This was exposed in the webgpu_postprocessing_pixel example using WebGL.

Add an equals() method to Texture() and use this, with compensation for version changes from Texture.needsUpdate(). 
