### PR TITLE
Examples: Clean up.

### DIFF
--- a/examples/misc_exporter_gltf.html
+++ b/examples/misc_exporter_gltf.html
@@ -369,10 +369,10 @@
 				// Ortho camera
 				// ---------------------------------------------------------------------
 
-				const frustumSize = 2000;
+				const height = 1000; // frustum height
 				const aspect = window.innerWidth / window.innerHeight;
 
-				const cameraOrtho = new THREE.OrthographicCamera( 0.5 * frustumSize * aspect / - 2, 0.5 * frustumSize * aspect / 2, frustumSize / 2, frustumSize / - 2, 0, 2000 );
+				const cameraOrtho = new THREE.OrthographicCamera( - height * aspect, height * aspect, height, - height, 0, 2000 );
 				cameraOrtho.position.set( 600, 400, 0 );
 				cameraOrtho.lookAt( 0, 0, 0 );
 				scene1.add( cameraOrtho );

--- a/examples/misc_exporter_gltf.html
+++ b/examples/misc_exporter_gltf.html
@@ -368,7 +368,13 @@
 				// ---------------------------------------------------------------------
 				// Ortho camera
 				// ---------------------------------------------------------------------
-				const cameraOrtho = new THREE.OrthographicCamera( window.innerWidth / - 2, window.innerWidth / 2, window.innerHeight / 2, window.innerHeight / - 2, 0.1, 10 );
+
+				const frustumSize = 2000;
+				const aspect = window.innerWidth / window.innerWidth;
+
+				const cameraOrtho = new THREE.OrthographicCamera( 0.5 * frustumSize * aspect / - 2, 0.5 * frustumSize * aspect / 2, frustumSize / 2, frustumSize / - 2, 0, 2000 );
+				cameraOrtho.position.set( 600, 400, 0 );
+				cameraOrtho.lookAt( 0, 0, 0 );
 				scene1.add( cameraOrtho );
 				cameraOrtho.name = 'OrthographicCamera';
 

--- a/examples/misc_exporter_gltf.html
+++ b/examples/misc_exporter_gltf.html
@@ -370,7 +370,7 @@
 				// ---------------------------------------------------------------------
 
 				const frustumSize = 2000;
-				const aspect = window.innerWidth / window.innerWidth;
+				const aspect = window.innerWidth / window.innerHeight;
 
 				const cameraOrtho = new THREE.OrthographicCamera( 0.5 * frustumSize * aspect / - 2, 0.5 * frustumSize * aspect / 2, frustumSize / 2, frustumSize / - 2, 0, 2000 );
 				cameraOrtho.position.set( 600, 400, 0 );


### PR DESCRIPTION
Related issue: #29024

**Description**

The PR makes sure the orthographic camera in `misc_exporter_gltf` is configured according to the suggestions in #29024. 

Next to using scene units and more appropriate far and near values, it was necessary to transform the camera in a way so you have a proper view on the scene.

If you now export `scene1` and import it in `gltf-viewer`, you eventually get a usable result.