### PR TITLE
TSL: support `uniformArrays` from `userData()` and `.label()` for `userData()` and `reference()`

### DIFF
--- a/src/nodes/accessors/ReferenceNode.js
+++ b/src/nodes/accessors/ReferenceNode.js
@@ -66,6 +66,7 @@ class ReferenceNode extends Node {
 		this.reference = object;
 		this.node = null;
 		this.group = null;
+		this.name = null;
 
 		this.updateType = NodeUpdateType.OBJECT;
 
@@ -80,6 +81,14 @@ class ReferenceNode extends Node {
 	setGroup( group ) {
 
 		this.group = group;
+
+		return this;
+
+	}
+
+	label( name ) {
+
+		this.name = name;
 
 		return this;
 
@@ -116,6 +125,8 @@ class ReferenceNode extends Node {
 			node.setGroup( this.group );
 
 		}
+
+		if ( this.name !== null ) node.label( this.name );
 
 		this.node = node.getSelf();
 

--- a/src/nodes/accessors/UniformArrayNode.js
+++ b/src/nodes/accessors/UniformArrayNode.js
@@ -20,12 +20,6 @@ class UniformArrayElementNode extends ArrayElementNode {
 
 	}
 
-	getNodeType( builder ) {
-
-		return this.node.getElementType( builder );
-
-	}
-
 	generate( builder ) {
 
 		const snippet = super.generate( builder );

--- a/src/nodes/accessors/UserDataNode.js
+++ b/src/nodes/accessors/UserDataNode.js
@@ -17,11 +17,11 @@ class UserDataNode extends ReferenceNode {
 
 	}
 
-	update( frame ) {
+	updateReference( state ) {
 
-		this.reference = this.userData !== null ? this.userData : frame.object.userData;
+		this.reference = this.userData !== null ? this.userData : state.object.userData;
 
-		super.update( frame );
+		return this.reference;
 
 	}
 


### PR DESCRIPTION

Added `updateReference()` method to `userDataNode` to enable use off array uniforms.
Add `label()` method to references() to aid debugging shaders.

Also remove redundant method from `UniformArrayNode`.