### PR TITLE
MaterialXLoader: added invert implementation

### DIFF
--- a/examples/jsm/loaders/MaterialXLoader.js
+++ b/examples/jsm/loaders/MaterialXLoader.js
@@ -1,4 +1,4 @@
-import { FileLoader, Loader, TextureLoader, MeshBasicNodeMaterial, MeshPhysicalNodeMaterial, RepeatWrapping } from 'three';
+import { Color, FileLoader, Loader, TextureLoader, MeshBasicNodeMaterial, MeshPhysicalNodeMaterial, RepeatWrapping, Vector2, Vector3, Vector4 } from 'three';
 
 import {
 	float, bool, int, vec2, vec3, vec4, color, texture,
@@ -44,6 +44,37 @@ const mx_power = ( in1, in2 = float( 1 ) ) => pow( in1, in2 );
 const mx_atan2 = ( in1 = float( 0 ), in2 = float( 1 ) ) => atan2( in1, in2 );
 const mx_timer = () => timerLocal();
 const mx_frame = () => frameId;
+const mx_invert = ( in1, amount = null ) => {
+
+	if ( amount === null ) {
+
+		if ( typeof in1.value === 'number' ) {
+
+			amount = 1.0;
+
+		} else if ( in1.value.isVector2 ) {
+
+			amount = new Vector2( 1, 1 );
+
+		} else if ( in1.value.isVector3 ) {
+
+			amount = new Vector3( 1, 1, 1 );
+
+		} else if ( in1.value.isVector4 ) {
+
+			amount = new Vector4( 1, 1, 1, 1 );
+
+		} else if ( in1.value.isColor ) {
+
+			amount = new Color( 1, 1, 1 );
+
+		}
+
+	}
+
+	return sub( amount, in1 );
+
+};
 
 const MXElements = [
 
@@ -131,6 +162,7 @@ const MXElements = [
 	//new MtlXElement( 'separate2', ... ),
 	//new MtlXElement( 'separate3', ... ),
 	//new MtlXElement( 'separate4', ... )
+	new MXElement( 'invert', mx_invert, [ 'in', 'amount' ] ),
 
 	new MXElement( 'time', mx_timer ),
 	new MXElement( 'frame', mx_frame )

--- a/examples/jsm/loaders/MaterialXLoader.js
+++ b/examples/jsm/loaders/MaterialXLoader.js
@@ -1,4 +1,4 @@
-import { Color, FileLoader, Loader, TextureLoader, MeshBasicNodeMaterial, MeshPhysicalNodeMaterial, RepeatWrapping, Vector2, Vector3, Vector4 } from 'three';
+import { FileLoader, Loader, TextureLoader, MeshBasicNodeMaterial, MeshPhysicalNodeMaterial, RepeatWrapping } from 'three';
 
 import {
 	float, bool, int, vec2, vec3, vec4, color, texture,
@@ -44,37 +44,7 @@ const mx_power = ( in1, in2 = float( 1 ) ) => pow( in1, in2 );
 const mx_atan2 = ( in1 = float( 0 ), in2 = float( 1 ) ) => atan2( in1, in2 );
 const mx_timer = () => timerLocal();
 const mx_frame = () => frameId;
-const mx_invert = ( in1, amount = null ) => {
-
-	if ( amount === null ) {
-
-		if ( typeof in1.value === 'number' ) {
-
-			amount = 1.0;
-
-		} else if ( in1.value.isVector2 ) {
-
-			amount = new Vector2( 1, 1 );
-
-		} else if ( in1.value.isVector3 ) {
-
-			amount = new Vector3( 1, 1, 1 );
-
-		} else if ( in1.value.isVector4 ) {
-
-			amount = new Vector4( 1, 1, 1, 1 );
-
-		} else if ( in1.value.isColor ) {
-
-			amount = new Color( 1, 1, 1 );
-
-		}
-
-	}
-
-	return sub( amount, in1 );
-
-};
+const mx_invert = ( in1, amount = float( 1 ) ) => sub( amount, in1 );
 
 const MXElements = [
 
@@ -106,6 +76,7 @@ const MXElements = [
 	new MXElement( 'magnitude', length, [ 'in1', 'in2' ] ),
 	new MXElement( 'dotproduct', dot, [ 'in1', 'in2' ] ),
 	new MXElement( 'crossproduct', cross, [ 'in' ] ),
+	new MXElement( 'invert', mx_invert, [ 'in', 'amount' ] ),
 	//new MtlXElement( 'transformpoint', ... ),
 	//new MtlXElement( 'transformvector', ... ),
 	//new MtlXElement( 'transformnormal', ... ),
@@ -162,7 +133,6 @@ const MXElements = [
 	//new MtlXElement( 'separate2', ... ),
 	//new MtlXElement( 'separate3', ... ),
 	//new MtlXElement( 'separate4', ... )
-	new MXElement( 'invert', mx_invert, [ 'in', 'amount' ] ),
 
 	new MXElement( 'time', mx_timer ),
 	new MXElement( 'frame', mx_frame )


### PR DESCRIPTION
- allow invert to be a number, vec 2|3|4, or color, subtracting the value from an optionally inputted amount field (which is defaulted to all parts 1 of the input type)

Related issue: #29432

**Description**

Implemented the invert node for the MaterialXLoader

*This contribution is funded by [Needle](https://needle.tools)*
