### PR TITLE
MaterialXLoader: Implement separate(2|3|4) nodes

### DIFF
--- a/examples/jsm/loaders/MaterialXLoader.js
+++ b/examples/jsm/loaders/MaterialXLoader.js
@@ -375,7 +375,7 @@ class MaterialXNode {
 
 		let node = this.node;
 
-		if ( node !== null ) {
+		if ( node !== null && out === null ) {
 
 			return node;
 
@@ -392,6 +392,12 @@ class MaterialXNode {
 			node = nodeClass( ...this.getVector() );
 
 		} else if ( this.hasReference ) {
+
+			if ( this.element === 'output' && this.output && out === null  ) {
+
+				out = this.output;
+
+			}
 
 			node = this.materialX.getMaterialXNode( this.referencePath ).getNode( out );
 

--- a/examples/jsm/loaders/MaterialXLoader.js
+++ b/examples/jsm/loaders/MaterialXLoader.js
@@ -7,7 +7,7 @@ import {
 	add, sub, mul, div, mod, abs, sign, floor, ceil, round, pow, sin, cos, tan,
 	asin, acos, atan2, sqrt, exp, clamp, min, max, normalize, length, dot, cross, normalMap,
 	remap, smoothstep, luminance, mx_rgbtohsv, mx_hsvtorgb,
-	mix,
+	mix, split,
 	mx_ramplr, mx_ramptb, mx_splitlr, mx_splittb,
 	mx_fractal_noise_float, mx_noise_float, mx_cell_noise_float, mx_worley_noise_float,
 	mx_transform_uv,
@@ -44,6 +44,8 @@ const mx_power = ( in1, in2 = float( 1 ) ) => pow( in1, in2 );
 const mx_atan2 = ( in1 = float( 0 ), in2 = float( 1 ) ) => atan2( in1, in2 );
 const mx_timer = () => timerLocal();
 const mx_frame = () => frameId;
+
+const separate = ( in1, channel ) => split( in1, channel.at( - 1 ) );
 
 const MXElements = [
 
@@ -128,9 +130,9 @@ const MXElements = [
 	//new MtlXElement( 'hsvadjust', ... ),
 	new MXElement( 'saturate', saturation, [ 'in', 'amount' ] ),
 	//new MtlXElement( 'extract', ... ),
-	//new MtlXElement( 'separate2', ... ),
-	//new MtlXElement( 'separate3', ... ),
-	//new MtlXElement( 'separate4', ... )
+	new MXElement( 'separate2', separate, [ 'in' ] ),
+	new MXElement( 'separate3', separate, [ 'in' ] ),
+	new MXElement( 'separate4', separate, [ 'in' ] ),
 
 	new MXElement( 'time', mx_timer ),
 	new MXElement( 'frame', mx_frame )
@@ -369,7 +371,7 @@ class MaterialXNode {
 
 	}
 
-	getNode() {
+	getNode( out = null ) {
 
 		let node = this.node;
 
@@ -391,7 +393,7 @@ class MaterialXNode {
 
 		} else if ( this.hasReference ) {
 
-			node = this.materialX.getMaterialXNode( this.referencePath ).getNode();
+			node = this.materialX.getMaterialXNode( this.referencePath ).getNode( out );
 
 		} else {
 
@@ -474,7 +476,15 @@ class MaterialXNode {
 
 				const nodeElement = MtlXLibrary[ element ];
 
-				node = nodeElement.nodeFunc( ...this.getNodesByNames( ...nodeElement.params ) );
+				if ( out !== null ) {
+
+					node = nodeElement.nodeFunc( ...this.getNodesByNames( ...nodeElement.params ), out );
+
+				} else {
+
+					node = nodeElement.nodeFunc( ...this.getNodesByNames( ...nodeElement.params ) );
+
+				}
 
 			}
 
@@ -542,7 +552,7 @@ class MaterialXNode {
 
 		const child = this.getChildByName( name );
 
-		return child ? child.getNode() : undefined;
+		return child ? child.getNode( child.output ) : undefined;
 
 	}
 

--- a/examples/webgpu_loader_materialx.html
+++ b/examples/webgpu_loader_materialx.html
@@ -38,31 +38,30 @@
 
 			import { MaterialXLoader } from './jsm/loaders/MaterialXLoader.js';
 
-			const SAMPLE_PATH = 'https://raw.githubusercontent.com/beersandrew/MaterialX/separateNodeExample/resources/Materials/Examples/StandardSurface/';
+			const SAMPLE_PATH = 'https://raw.githubusercontent.com/materialx/MaterialX/main/resources/Materials/Examples/StandardSurface/';
 
 			const samples = [
-//				'standard_surface_brass_tiled.mtlx',
-//				'standard_surface_brick_procedural.mtlx',
-				'separate2.mtlx',
-//				'standard_surface_carpaint.mtlx',
-/				//'standard_surface_chess_set.mtlx',
-//				'standard_surface_chrome.mtlx',
-//				'standard_surface_copper.mtlx',
-//				//'standard_surface_default.mtlx',
-//				//'standard_surface_glass.mtlx',
-//				//'standard_surface_glass_tinted.mtlx',
-//				'standard_surface_gold.mtlx',
+				'standard_surface_brass_tiled.mtlx',
+				'standard_surface_brick_procedural.mtlx',
+				'standard_surface_carpaint.mtlx',
+				//'standard_surface_chess_set.mtlx',
+				'standard_surface_chrome.mtlx',
+				'standard_surface_copper.mtlx',
+				//'standard_surface_default.mtlx',
+				//'standard_surface_glass.mtlx',
+				//'standard_surface_glass_tinted.mtlx',
+				'standard_surface_gold.mtlx',
 				//'standard_surface_greysphere.mtlx',
 				//'standard_surface_greysphere_calibration.mtlx',
-//				'standard_surface_jade.mtlx',
+				'standard_surface_jade.mtlx',
 				//'standard_surface_look_brass_tiled.mtlx',
 				//'standard_surface_look_wood_tiled.mtlx',
-//				'standard_surface_marble_solid.mtlx',
-//				'standard_surface_metal_brushed.mtlx',
-//				'standard_surface_plastic.mtlx',
+				'standard_surface_marble_solid.mtlx',
+				'standard_surface_metal_brushed.mtlx',
+				'standard_surface_plastic.mtlx',
 				//'standard_surface_thin_film.mtlx',
-//				'standard_surface_velvet.mtlx',
-//				'standard_surface_wood_tiled.mtlx'
+				'standard_surface_velvet.mtlx',
+				'standard_surface_wood_tiled.mtlx'
 			];
 
 			let camera, scene, renderer, prefab;
@@ -121,7 +120,7 @@
 
 			function updateModelsAlign() {
 
-				const COLUMN_COUNT = 1;
+				const COLUMN_COUNT = 6;
 				const DIST_X = 3;
 				const DIST_Y = 4;
 

--- a/examples/webgpu_loader_materialx.html
+++ b/examples/webgpu_loader_materialx.html
@@ -38,30 +38,31 @@
 
 			import { MaterialXLoader } from './jsm/loaders/MaterialXLoader.js';
 
-			const SAMPLE_PATH = 'https://raw.githubusercontent.com/materialx/MaterialX/main/resources/Materials/Examples/StandardSurface/';
+			const SAMPLE_PATH = 'https://raw.githubusercontent.com/beersandrew/MaterialX/separateNodeExample/resources/Materials/Examples/StandardSurface/';
 
 			const samples = [
-				'standard_surface_brass_tiled.mtlx',
-				'standard_surface_brick_procedural.mtlx',
-				'standard_surface_carpaint.mtlx',
-				//'standard_surface_chess_set.mtlx',
-				'standard_surface_chrome.mtlx',
-				'standard_surface_copper.mtlx',
-				//'standard_surface_default.mtlx',
-				//'standard_surface_glass.mtlx',
-				//'standard_surface_glass_tinted.mtlx',
-				'standard_surface_gold.mtlx',
+//				'standard_surface_brass_tiled.mtlx',
+//				'standard_surface_brick_procedural.mtlx',
+				'separate2.mtlx',
+//				'standard_surface_carpaint.mtlx',
+/				//'standard_surface_chess_set.mtlx',
+//				'standard_surface_chrome.mtlx',
+//				'standard_surface_copper.mtlx',
+//				//'standard_surface_default.mtlx',
+//				//'standard_surface_glass.mtlx',
+//				//'standard_surface_glass_tinted.mtlx',
+//				'standard_surface_gold.mtlx',
 				//'standard_surface_greysphere.mtlx',
 				//'standard_surface_greysphere_calibration.mtlx',
-				'standard_surface_jade.mtlx',
+//				'standard_surface_jade.mtlx',
 				//'standard_surface_look_brass_tiled.mtlx',
 				//'standard_surface_look_wood_tiled.mtlx',
-				'standard_surface_marble_solid.mtlx',
-				'standard_surface_metal_brushed.mtlx',
-				'standard_surface_plastic.mtlx',
+//				'standard_surface_marble_solid.mtlx',
+//				'standard_surface_metal_brushed.mtlx',
+//				'standard_surface_plastic.mtlx',
 				//'standard_surface_thin_film.mtlx',
-				'standard_surface_velvet.mtlx',
-				'standard_surface_wood_tiled.mtlx'
+//				'standard_surface_velvet.mtlx',
+//				'standard_surface_wood_tiled.mtlx'
 			];
 
 			let camera, scene, renderer, prefab;
@@ -120,7 +121,7 @@
 
 			function updateModelsAlign() {
 
-				const COLUMN_COUNT = 6;
+				const COLUMN_COUNT = 1;
 				const DIST_X = 3;
 				const DIST_Y = 4;
 


### PR DESCRIPTION
Fixed #29426 

Implement separate(2|3|4) nodes, this is the first multi output node as far as I know so possibly incorrect.
Appears to work with provided test sample.

@beersandrew can you test?