### PR TITLE
BatchedMesh: add `deleteInstance()`

### DIFF
--- a/docs/api/en/objects/BatchedMesh.html
+++ b/docs/api/en/objects/BatchedMesh.html
@@ -258,6 +258,15 @@
 			Adds a new instance to the [name] using the geometry of the given geometryId and returns a new id referring to the new instance to be used
 			by other functions.
 		</p>
+		<h3>
+			[method:Integer deleteInstance]( [param:Integer instanceId] )
+		</h3>
+		<p>
+			[page:Integer instanceId]: The id of an instance to remove from the [name] that was previously added via "addInstance".
+		</p>
+		<p>
+			Removes an existing instance from the [name] using the given instanceId.
+		</p>
 
 		<h3>
 			[method:Integer setGeometryAt]( [param:Integer geometryId], [param:BufferGeometry geometry] )

--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -144,7 +144,9 @@ class BatchedMesh extends Mesh {
 
 		// stores visible, active, and geometry id per object
 		this._drawInfo = [];
-		this._fragInfo = [];
+
+		// instance ids that have been set as inactive, and are available to be overwritten
+		this._availableInstanceIds = [];
 
 		// geometry information
 		this._drawRanges = [];
@@ -348,7 +350,7 @@ class BatchedMesh extends Mesh {
 		const atCapacity = this._drawInfo.length >= this.maxInstanceCount;
 
 		// ensure we're not over geometry
-		if ( atCapacity && this._fragInfo.length === 0 ) {
+		if ( atCapacity && this._availableInstanceIds.length === 0 ) {
 
 			throw new Error( 'BatchedMesh: Maximum item count reached.' );
 
@@ -362,10 +364,10 @@ class BatchedMesh extends Mesh {
 
 		let drawId = null;
 
-		// If at capacity, rewrite over an inactive block
-		if ( atCapacity ) {
+		// Prioritize using previously freed instance ids
+		if ( this._availableInstanceIds.length > 0 ) {
 
-			drawId = this._fragInfo.pop();
+			drawId = this._availableInstanceIds.pop();
 			this._drawInfo[ drawId ] = instanceDrawInfo;
 
 		} else {
@@ -633,7 +635,7 @@ class BatchedMesh extends Mesh {
 		}
 
 		drawInfo[ instanceId ].active = false;
-		this._fragInfo.push( instanceId );
+		this._availableInstanceIds.push( instanceId );
 		this._visibilityChanged = true;
 
 		return this;


### PR DESCRIPTION
**Description**

The `BatchedMesh` currently has no way to remove an instance. 

**Solution** 

Adding the `deleteInstance()` method to the `BatchedMesh` class will allow users to remove instances easily from the `BatchedMesh`. 

The previous commented out code stated that we would need to implement an `optimize` function to be able to repack the data. Instead, I added a `_fragInfo` array to keep track of 'fragmented' or open blocks. The BatchedMesh will still fill the DataTexture the same way it did before, but once it is at capacity, then it will begin adding instances to open spots in the Texture. 

**Additional context**

The BatchedMesh has been a pleasure to work with, I just need the ability to remove existing instances. This is my first time opening a PR to three.js, so please let me know if I am missing anything. I am open to any additional changes or suggestions!
