### PR TITLE
CylinderGeometry: Don't add degenerate triangles

### DIFF
--- a/src/geometries/CylinderGeometry.js
+++ b/src/geometries/CylinderGeometry.js
@@ -133,14 +133,14 @@ class CylinderGeometry extends BufferGeometry {
 
 					// faces
 
-					if ( radiusTop !== 0 ) {
+					if ( radiusTop > 0 ) {
 
 						indices.push( a, b, d );
 						groupCount += 3;
 
 					}
 
-					if ( radiusBottom !== 0 ) {
+					if ( radiusBottom > 0 ) {
 
 						indices.push( b, c, d );
 						groupCount += 3;

--- a/src/geometries/CylinderGeometry.js
+++ b/src/geometries/CylinderGeometry.js
@@ -133,12 +133,19 @@ class CylinderGeometry extends BufferGeometry {
 
 					// faces
 
-					indices.push( a, b, d );
-					indices.push( b, c, d );
+					if ( radiusTop !== 0 ) {
 
-					// update group counter
+						indices.push( a, b, d );
+						groupCount += 3;
 
-					groupCount += 6;
+					}
+
+					if ( radiusBottom !== 0 ) {
+
+						indices.push( b, c, d );
+						groupCount += 3;
+
+					}
 
 				}
 


### PR DESCRIPTION
Fixed #29454

**Description**

Don't add degenerate triangles when generating a cylinder.