### PR TITLE
DecalGeometry: Check for existence of `normal` attribute.

### DIFF
--- a/examples/jsm/geometries/DecalGeometry.js
+++ b/examples/jsm/geometries/DecalGeometry.js
@@ -83,7 +83,8 @@ class DecalGeometry extends BufferGeometry {
 				for ( let i = 0; i < index.count; i ++ ) {
 
 					vertex.fromBufferAttribute( positionAttribute, index.getX( i ) );
-					if (normalAttribute) normal.fromBufferAttribute( normalAttribute, index.getX( i ) );
+
+					if ( normalAttribute ) normal.fromBufferAttribute( normalAttribute, index.getX( i ) );
 
 					pushDecalVertex( decalVertices, vertex, normal );
 
@@ -96,7 +97,8 @@ class DecalGeometry extends BufferGeometry {
 				for ( let i = 0; i < positionAttribute.count; i ++ ) {
 
 					vertex.fromBufferAttribute( positionAttribute, i );
-					if (normalAttribute) normal.fromBufferAttribute( normalAttribute, i );
+
+					if ( normalAttribute ) normal.fromBufferAttribute( normalAttribute, i );
 
 					pushDecalVertex( decalVertices, vertex, normal );
 

--- a/examples/jsm/geometries/DecalGeometry.js
+++ b/examples/jsm/geometries/DecalGeometry.js
@@ -83,7 +83,7 @@ class DecalGeometry extends BufferGeometry {
 				for ( let i = 0; i < index.count; i ++ ) {
 
 					vertex.fromBufferAttribute( positionAttribute, index.getX( i ) );
-					normal.fromBufferAttribute( normalAttribute, index.getX( i ) );
+					if (normalAttribute) normal.fromBufferAttribute( normalAttribute, index.getX( i ) );
 
 					pushDecalVertex( decalVertices, vertex, normal );
 
@@ -96,7 +96,7 @@ class DecalGeometry extends BufferGeometry {
 				for ( let i = 0; i < positionAttribute.count; i ++ ) {
 
 					vertex.fromBufferAttribute( positionAttribute, i );
-					normal.fromBufferAttribute( normalAttribute, i );
+					if (normalAttribute) normal.fromBufferAttribute( normalAttribute, i );
 
 					pushDecalVertex( decalVertices, vertex, normal );
 


### PR DESCRIPTION
Related issue: #XXXX

**Description**

fixes error when normal attribute isn't present

```
Uncaught TypeError: Cannot read properties of undefined (reading 'getX')
    at _Vector3.fromBufferAttribute
```

![image](https://github.com/user-attachments/assets/ec85aeea-bfe6-42c7-9f68-877d87a8538c)


