### PR TITLE
RenderObject: Introduce `getGeometryCacheKey()`

### DIFF
--- a/src/materials/nodes/manager/NodeMaterialObserver.js
+++ b/src/materials/nodes/manager/NodeMaterialObserver.js
@@ -57,6 +57,7 @@ class NodeMaterialObserver {
 
 		this.renderObjects = new WeakMap();
 		this.hasNode = this.containsNode( builder );
+		this.hasAnimation = builder.object.isSkinnedMesh === true;
 		this.refreshUniforms = refreshUniforms;
 		this.renderId = 0;
 
@@ -88,6 +89,12 @@ class NodeMaterialObserver {
 				material: this.getMaterialData( renderObject.material ),
 				worldMatrix: renderObject.object.matrixWorld.clone()
 			};
+
+			if ( renderObject.object.morphTargetInfluences ) {
+
+				data.morphTargetInfluences = renderObject.object.morphTargetInfluences.slice();
+
+			}
 
 			if ( renderObject.bundle !== null ) {
 
@@ -158,13 +165,15 @@ class NodeMaterialObserver {
 
 	equals( renderObject ) {
 
+		const { object, material } = renderObject;
+
 		const renderObjectData = this.getRenderObjectData( renderObject );
 
 		// world matrix
 
-		if ( renderObjectData.worldMatrix.equals( renderObject.object.matrixWorld ) !== true ) {
+		if ( renderObjectData.worldMatrix.equals( object.matrixWorld ) !== true ) {
 
-			renderObjectData.worldMatrix.copy( renderObject.object.matrixWorld );
+			renderObjectData.worldMatrix.copy( object.matrixWorld );
 
 			return false;
 
@@ -173,7 +182,6 @@ class NodeMaterialObserver {
 		// material
 
 		const materialData = renderObjectData.material;
-		const material = renderObject.material;
 
 		for ( const property in materialData ) {
 
@@ -211,6 +219,26 @@ class NodeMaterialObserver {
 
 		}
 
+		// morph targets
+
+		if ( renderObjectData.morphTargetInfluences ) {
+
+			let morphChanged = false;
+
+			for ( let i = 0; i < renderObjectData.morphTargetInfluences.length; i ++ ) {
+
+				if ( renderObjectData.morphTargetInfluences[ i ] !== object.morphTargetInfluences[ i ] ) {
+
+					morphChanged = true;
+
+				}
+
+			}
+
+			if ( morphChanged ) return true;
+
+		}
+
 		// bundle
 
 		if ( renderObject.bundle !== null ) {
@@ -225,7 +253,7 @@ class NodeMaterialObserver {
 
 	needsRefresh( renderObject, nodeFrame ) {
 
-		if ( this.hasNode || this.firstInitialization( renderObject ) )
+		if ( this.hasNode || this.hasAnimation || this.firstInitialization( renderObject ) )
 			return true;
 
 		const { renderId } = nodeFrame;

--- a/src/renderers/common/RenderObject.js
+++ b/src/renderers/common/RenderObject.js
@@ -248,6 +248,35 @@ export default class RenderObject {
 
 	}
 
+	getGeometryCacheKey() {
+
+		const { geometry } = this;
+
+		let cacheKey = '';
+
+		for ( const name of Object.keys( geometry.attributes ).sort() ) {
+
+			const attribute = geometry.attributes[ name ];
+
+			cacheKey += name + ',';
+
+			if ( attribute.data ) cacheKey += attribute.data.stride + ',';
+			if ( attribute.offset ) cacheKey += attribute.offset + ',';
+			if ( attribute.itemSize ) cacheKey += attribute.itemSize + ',';
+			if ( attribute.normalized ) cacheKey += 'n,';
+
+		}
+
+		if ( geometry.index ) {
+
+			cacheKey += 'index,';
+
+		}
+
+		return cacheKey;
+
+	}
+
 	getMaterialCacheKey() {
 
 		const { object, material } = this;
@@ -304,7 +333,7 @@ export default class RenderObject {
 
 		if ( object.geometry ) {
 
-			cacheKey += object.geometry.id + ',';
+			cacheKey += this.getGeometryCacheKey();
 
 		}
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -1061,7 +1061,6 @@ class WebGPUBackend extends Backend {
 
 	}
 
-
 	// textures
 
 	createSampler( texture ) {


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/29427#issuecomment-2360999831

**Description**

This PR maintains the material/pipeline creation fix related to PR https://github.com/mrdoob/three.js/pull/29427 and also preserves previous performance by reusing a geometry signature.

- [x] [RenderObject: Added getGeometryCacheKey()](https://github.com/mrdoob/three.js/commit/5b778d0b28de43b667c5ec5dfc9c13f76bd96797)
- [x] [NodeMaterialObserver: Improve SkinnedMesh and morph supports](https://github.com/mrdoob/three.js/commit/84e632f0c340c581887988fc10eca536b8b476ff)