### PR TITLE
raytracer: add support for per-point pointsize

### DIFF
--- a/src/objects/Points.js
+++ b/src/objects/Points.js
@@ -65,8 +65,11 @@ class Points extends Object3D {
 		const attributes = geometry.attributes;
 		const positionAttribute = attributes.position;
 		const pointsizeAttribute = attributes.pointsize;
-		if (pointsizeAttribute) {
+
+		if ( pointsizeAttribute ) {
+
 			threshold = 1;
+
 		}
 
 		const localThreshold = threshold / ( ( this.scale.x + this.scale.y + this.scale.z ) / 3 );
@@ -87,7 +90,7 @@ class Points extends Object3D {
 
 			}
 
-		} else if (pointsizeAttribute) {
+		} else if ( pointsizeAttribute ) {
 
 			const start = Math.max( 0, drawRange.start );
 			const end = Math.min( positionAttribute.count, ( drawRange.start + drawRange.count ) );
@@ -96,7 +99,7 @@ class Points extends Object3D {
 
 				_position.fromBufferAttribute( positionAttribute, i );
 
-				let pointsize = pointsizeAttribute.getX( i );
+				const pointsize = pointsizeAttribute.getX( i );
 
 				testPoint( _position, i, localThresholdSq * pointsize * pointsize, matrixWorld, raycaster, intersects, this );
 

--- a/src/objects/Points.js
+++ b/src/objects/Points.js
@@ -43,7 +43,7 @@ class Points extends Object3D {
 
 		const geometry = this.geometry;
 		const matrixWorld = this.matrixWorld;
-		const threshold = raycaster.params.Points.threshold;
+		var threshold = raycaster.params.Points.threshold;
 		const drawRange = geometry.drawRange;
 
 		// Checking boundingSphere distance to ray
@@ -61,12 +61,16 @@ class Points extends Object3D {
 		_inverseMatrix.copy( matrixWorld ).invert();
 		_ray.copy( raycaster.ray ).applyMatrix4( _inverseMatrix );
 
-		const localThreshold = threshold / ( ( this.scale.x + this.scale.y + this.scale.z ) / 3 );
-		const localThresholdSq = localThreshold * localThreshold;
-
 		const index = geometry.index;
 		const attributes = geometry.attributes;
 		const positionAttribute = attributes.position;
+		const pointsizeAttribute = attributes.pointsize;
+		if (pointsizeAttribute) {
+			threshold = 1;
+		}
+
+		const localThreshold = threshold / ( ( this.scale.x + this.scale.y + this.scale.z ) / 3 );
+		const localThresholdSq = localThreshold * localThreshold;
 
 		if ( index !== null ) {
 
@@ -80,6 +84,21 @@ class Points extends Object3D {
 				_position.fromBufferAttribute( positionAttribute, a );
 
 				testPoint( _position, a, localThresholdSq, matrixWorld, raycaster, intersects, this );
+
+			}
+
+		} else if (pointsizeAttribute) {
+
+			const start = Math.max( 0, drawRange.start );
+			const end = Math.min( positionAttribute.count, ( drawRange.start + drawRange.count ) );
+
+			for ( let i = start, l = end; i < l; i ++ ) {
+
+				_position.fromBufferAttribute( positionAttribute, i );
+
+				let pointsize = pointsizeAttribute.getX( i );
+
+				testPoint( _position, i, localThresholdSq * pointsize * pointsize, matrixWorld, raycaster, intersects, this );
 
 			}
 


### PR DESCRIPTION
I created this patch to support pixel-perfect collision detection with individually sized points.

Here's an example vertex shader to use gl_Points with pointsize in world-coordinates:
```
      attribute float pointsize;
      uniform vec2 resolution;
      void main() {
         gl_Position = projectionMatrix * modelViewMatrix * vec4(position.x, position.y, position.z, 1.0);
         gl_PointSize = pointsize * resolution.y * projectionMatrix[1][1] / gl_Position.w;
      }
```