### PR TITLE
DecalGeometry: Transform normal with normal matrix

### DIFF
--- a/examples/jsm/geometries/DecalGeometry.js
+++ b/examples/jsm/geometries/DecalGeometry.js
@@ -1,6 +1,7 @@
 import {
 	BufferGeometry,
 	Float32BufferAttribute,
+	Matrix3,
 	Matrix4,
 	Vector3
 } from 'three';
@@ -35,6 +36,8 @@ class DecalGeometry extends BufferGeometry {
 		// helpers
 
 		const plane = new Vector3();
+
+		const normalMatrix = new Matrix3().getNormalMatrix( mesh.matrixWorld );
 
 		// this matrix represents the transformation of the decal projector
 
@@ -146,7 +149,7 @@ class DecalGeometry extends BufferGeometry {
 			vertex.applyMatrix4( mesh.matrixWorld );
 			vertex.applyMatrix4( projectorMatrixInverse );
 
-			normal.transformDirection( mesh.matrixWorld );
+			normal.applyNormalMatrix( normalMatrix );
 
 			decalVertices.push( new DecalVertex( vertex.clone(), normal.clone() ) );
 

--- a/examples/webgl_decals.html
+++ b/examples/webgl_decals.html
@@ -187,8 +187,10 @@
 						mouseHelper.position.copy( p );
 						intersection.point.copy( p );
 
+						const normalMatrix = new THREE.Matrix3().getNormalMatrix( mesh.matrixWorld );
+
 						const n = intersects[ 0 ].face.normal.clone();
-						n.transformDirection( mesh.matrixWorld );
+						n.applyNormalMatrix( normalMatrix );
 						n.multiplyScalar( 10 );
 						n.add( intersects[ 0 ].point );
 


### PR DESCRIPTION
`transformDirection()` should not be applied to normal vectors, unless under certain conditions. The normal map should be applied, instead.
