### PR TITLE
WebGPURenderer: Introduce hash-based cache key

### DIFF
--- a/examples/webgpu_performance.html
+++ b/examples/webgpu_performance.html
@@ -30,6 +30,8 @@
 
 			import Stats from 'three/addons/libs/stats.module.js';
 
+			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
+
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 			import { DRACOLoader } from 'three/addons/loaders/DRACOLoader.js';
@@ -37,8 +39,25 @@
 			import { RGBELoader } from 'three/addons/loaders/RGBELoader.js';
 
 			let camera, scene, renderer, stats;
+			let model;
+
+			const options = { static: true };
 
 			init();
+
+			function setStatic( object, value ) {
+
+				object.traverse( child => {
+
+					if ( child.isMesh ) {
+
+						child.static = value;
+
+					}
+
+				} );
+
+			}
 
 			function init() {
 
@@ -83,19 +102,21 @@
 
 						loader.load( 'dungeon_warkarma.glb', async function ( gltf ) {
 
-							const model = gltf.scene;
+							model = gltf.scene;
 
 							// wait until the model can be added to the scene without blocking due to shader compilation
 
 							await renderer.compileAsync( model, camera, scene );
 
 							scene.add( model );
+
+							//
+
+							setStatic( model, options.static );
 			
 						} );
 
 					} );
-
-			
 
 				const controls = new OrbitControls( camera, renderer.domElement );
 				controls.minDistance = 2;
@@ -103,6 +124,14 @@
 				controls.target.set( 0, 0, - 0.2 );
 				controls.update();
 
+				// gui
+
+				const gui = new GUI();
+				gui.add( options, 'static' ).onChange( () => {
+
+					setStatic( model, options.static );
+
+				} );
 
 				window.addEventListener( 'resize', onWindowResize );
 

--- a/src/nodes/code/ScriptableNode.js
+++ b/src/nodes/code/ScriptableNode.js
@@ -1,7 +1,7 @@
 import Node from '../core/Node.js';
 import { scriptableValue } from './ScriptableValueNode.js';
 import { nodeProxy, float } from '../tsl/TSLBase.js';
-import { cyrb53 } from '../core/NodeUtils.js';
+import { hashArray, hashString } from '../core/NodeUtils.js';
 
 class Resources extends Map {
 
@@ -446,15 +446,15 @@ class ScriptableNode extends Node {
 
 	getCacheKey( force ) {
 
-		let cacheKey = cyrb53( this.source ) + this.getDefaultOutputNode().getCacheKey( force );
+		const values = [ hashString( this.source ), this.getDefaultOutputNode().getCacheKey( force ) ];
 
 		for ( const param in this.parameters ) {
 
-			cacheKey += this.parameters[ param ].getCacheKey( force );
+			values.push( this.parameters[ param ].getCacheKey( force ) );
 
 		}
 
-		return cacheKey;
+		return hashArray( values );
 
 	}
 

--- a/src/nodes/code/ScriptableNode.js
+++ b/src/nodes/code/ScriptableNode.js
@@ -1,6 +1,7 @@
 import Node from '../core/Node.js';
 import { scriptableValue } from './ScriptableValueNode.js';
 import { nodeProxy, float } from '../tsl/TSLBase.js';
+import { cyrb53 } from '../core/NodeUtils.js';
 
 class Resources extends Map {
 
@@ -445,15 +446,15 @@ class ScriptableNode extends Node {
 
 	getCacheKey( force ) {
 
-		const cacheKey = [ this.source, this.getDefaultOutputNode().getCacheKey( force ) ];
+		let cacheKey = cyrb53( this.source ) + this.getDefaultOutputNode().getCacheKey( force );
 
 		for ( const param in this.parameters ) {
 
-			cacheKey.push( this.parameters[ param ].getCacheKey( force ) );
+			cacheKey += this.parameters[ param ].getCacheKey( force );
 
 		}
 
-		return cacheKey.join( ',' );
+		return cacheKey;
 
 	}
 

--- a/src/nodes/core/NodeUtils.js
+++ b/src/nodes/core/NodeUtils.js
@@ -10,39 +10,29 @@ import { Vector4 } from '../../math/Vector4.js';
 // Largely inspired by MurmurHash2/3, but with a focus on speed/simplicity.
 // See https://stackoverflow.com/questions/7616461/generate-a-hash-from-string-in-javascript/52171480#52171480
 // https://github.com/bryc/code/blob/master/jshash/experimental/cyrb53.js
-export function hashString( str, seed = 0 ) {
+function cyrb53( value, seed = 0 ) {
 
 	let h1 = 0xdeadbeef ^ seed, h2 = 0x41c6ce57 ^ seed;
 
-	for ( let i = 0, ch; i < str.length; i ++ ) {
+	if ( value instanceof Array ) {
 
-		ch = str.charCodeAt( i );
-		h1 = Math.imul( h1 ^ ch, 2654435761 );
-		h2 = Math.imul( h2 ^ ch, 1597334677 );
+		for ( let i = 0, val; i < value.length; i ++ ) {
 
-	}
+			val = value[ i ];
+			h1 = Math.imul( h1 ^ val, 2654435761 );
+			h2 = Math.imul( h2 ^ val, 1597334677 );
 
-	h1 = Math.imul( h1 ^ ( h1 >>> 16 ), 2246822507 );
-	h1 ^= Math.imul( h2 ^ ( h2 >>> 13 ), 3266489909 );
-	h2 = Math.imul( h2 ^ ( h2 >>> 16 ), 2246822507 );
-	h2 ^= Math.imul( h1 ^ ( h1 >>> 13 ), 3266489909 );
+		}
 
-	return 4294967296 * ( 2097151 & h2 ) + ( h1 >>> 0 );
+	} else {
 
-}
+		for ( let i = 0, ch; i < value.length; i ++ ) {
 
-export function hashArray( array ) {
+			ch = value.charCodeAt( i );
+			h1 = Math.imul( h1 ^ ch, 2654435761 );
+			h2 = Math.imul( h2 ^ ch, 1597334677 );
 
-	const len = array.length;
-
-	let h1 = 0xdeadbeef ^ len, h2 = 0x41c6ce57 ^ len;
-
-	for ( let i = 0; i < len; i ++ ) {
-
-		const value = array[ i ];
-
-		h1 = Math.imul( h1 ^ value, 2654435761 );
-		h2 = Math.imul( h2 ^ value, 1597334677 );
+		}
 
 	}
 
@@ -55,7 +45,9 @@ export function hashArray( array ) {
 
 }
 
-export const hash = ( ...params ) => hashArray( params );
+export const hashString = ( str ) => cyrb53( str );
+export const hashArray = ( array ) => cyrb53( array );
+export const hash = ( ...params ) => cyrb53( params );
 
 export function getCacheKey( object, force = false ) {
 
@@ -70,11 +62,11 @@ export function getCacheKey( object, force = false ) {
 
 	for ( const { property, childNode } of getNodeChildren( object ) ) {
 
-		values.push( values, hashString( property.slice( 0, - 4 ) ), childNode.getCacheKey( force ) );
+		values.push( values, cyrb53( property.slice( 0, - 4 ) ), childNode.getCacheKey( force ) );
 
 	}
 
-	return hashArray( values );
+	return cyrb53( values );
 
 }
 

--- a/src/nodes/core/NodeUtils.js
+++ b/src/nodes/core/NodeUtils.js
@@ -55,6 +55,8 @@ export function hashArray( array ) {
 
 }
 
+export const hash = ( ...params ) => hashArray( params );
+
 export function getCacheKey( object, force = false ) {
 
 	const values = [];

--- a/src/nodes/core/NodeUtils.js
+++ b/src/nodes/core/NodeUtils.js
@@ -5,9 +5,35 @@ import { Vector2 } from '../../math/Vector2.js';
 import { Vector3 } from '../../math/Vector3.js';
 import { Vector4 } from '../../math/Vector4.js';
 
+// cyrb53 (c) 2018 bryc (github.com/bryc). License: Public domain. Attribution appreciated.
+// A fast and simple 64-bit (or 53-bit) string hash function with decent collision resistance.
+// Largely inspired by MurmurHash2/3, but with a focus on speed/simplicity.
+// See https://stackoverflow.com/questions/7616461/generate-a-hash-from-string-in-javascript/52171480#52171480
+// https://github.com/bryc/code/blob/master/jshash/experimental/cyrb53.js
+export function cyrb53( str, seed = 0 ) {
+
+	let h1 = 0xdeadbeef ^ seed, h2 = 0x41c6ce57 ^ seed;
+
+	for ( let i = 0, ch; i < str.length; i ++ ) {
+
+		ch = str.charCodeAt( i );
+		h1 = Math.imul( h1 ^ ch, 2654435761 );
+		h2 = Math.imul( h2 ^ ch, 1597334677 );
+
+	}
+
+	h1 = Math.imul( h1 ^ ( h1 >>> 16 ), 2246822507 );
+	h1 ^= Math.imul( h2 ^ ( h2 >>> 13 ), 3266489909 );
+	h2 = Math.imul( h2 ^ ( h2 >>> 16 ), 2246822507 );
+	h2 ^= Math.imul( h1 ^ ( h1 >>> 13 ), 3266489909 );
+
+	return 4294967296 * ( 2097151 & h2 ) + ( h1 >>> 0 );
+
+}
+
 export function getCacheKey( object, force = false ) {
 
-	let cacheKey = '{';
+	let cacheKey = 0;
 
 	if ( object.isNode === true ) {
 
@@ -18,11 +44,9 @@ export function getCacheKey( object, force = false ) {
 
 	for ( const { property, childNode } of getNodeChildren( object ) ) {
 
-		cacheKey += ',' + property.slice( 0, - 4 ) + ':' + childNode.getCacheKey( force );
+		cacheKey = Math.imul( cacheKey, cyrb53( property.slice( 0, - 4 ) + ':' + childNode.getCacheKey( force ) ) );
 
 	}
-
-	cacheKey += '}';
 
 	return cacheKey;
 

--- a/src/nodes/core/NodeUtils.js
+++ b/src/nodes/core/NodeUtils.js
@@ -44,7 +44,7 @@ export function getCacheKey( object, force = false ) {
 
 	for ( const { property, childNode } of getNodeChildren( object ) ) {
 
-		cacheKey = Math.imul( cacheKey, cyrb53( property.slice( 0, - 4 ) + ':' + childNode.getCacheKey( force ) ) );
+		cacheKey = Math.imul( cacheKey, cyrb53( property.slice( 0, - 4 ) ) ) + childNode.getCacheKey( force );
 
 	}
 

--- a/src/nodes/display/ToneMappingNode.js
+++ b/src/nodes/display/ToneMappingNode.js
@@ -3,6 +3,7 @@ import { addMethodChaining, nodeObject, vec4 } from '../tsl/TSLCore.js';
 import { rendererReference } from '../accessors/RendererReferenceNode.js';
 
 import { NoToneMapping } from '../../constants.js';
+import { hashArray } from '../core/NodeUtils.js';
 
 class ToneMappingNode extends TempNode {
 
@@ -25,7 +26,7 @@ class ToneMappingNode extends TempNode {
 
 	getCacheKey() {
 
-		return super.getCacheKey() + this.toneMapping;
+		return hashArray( [ super.getCacheKey(), this.toneMapping ] );
 
 	}
 

--- a/src/nodes/display/ToneMappingNode.js
+++ b/src/nodes/display/ToneMappingNode.js
@@ -25,10 +25,7 @@ class ToneMappingNode extends TempNode {
 
 	getCacheKey() {
 
-		let cacheKey = super.getCacheKey();
-		cacheKey = '{toneMapping:' + this.toneMapping + ',nodes:' + cacheKey + '}';
-
-		return cacheKey;
+		return super.getCacheKey() + this.toneMapping;
 
 	}
 

--- a/src/nodes/display/ToneMappingNode.js
+++ b/src/nodes/display/ToneMappingNode.js
@@ -3,7 +3,7 @@ import { addMethodChaining, nodeObject, vec4 } from '../tsl/TSLCore.js';
 import { rendererReference } from '../accessors/RendererReferenceNode.js';
 
 import { NoToneMapping } from '../../constants.js';
-import { hashArray } from '../core/NodeUtils.js';
+import { hash } from '../core/NodeUtils.js';
 
 class ToneMappingNode extends TempNode {
 
@@ -26,7 +26,7 @@ class ToneMappingNode extends TempNode {
 
 	getCacheKey() {
 
-		return hashArray( [ super.getCacheKey(), this.toneMapping ] );
+		return hash( super.getCacheKey(), this.toneMapping );
 
 	}
 

--- a/src/nodes/lighting/AnalyticLightNode.js
+++ b/src/nodes/lighting/AnalyticLightNode.js
@@ -16,7 +16,7 @@ import { Loop } from '../utils/LoopNode.js';
 import { screenCoordinate } from '../display/ScreenNode.js';
 import { HalfFloatType, LessCompare, RGFormat, VSMShadowMap, WebGPUCoordinateSystem } from '../../constants.js';
 import { renderGroup } from '../core/UniformGroupNode.js';
-import { hashArray } from '../core/NodeUtils.js';
+import { hash } from '../core/NodeUtils.js';
 
 const BasicShadowMap = Fn( ( { depthTexture, shadowCoord } ) => {
 
@@ -239,7 +239,7 @@ class AnalyticLightNode extends LightingNode {
 
 	getCacheKey() {
 
-		return hashArray( [ super.getCacheKey(), this.light.id, this.light.castShadow ? 1 : 0 ] );
+		return hash( super.getCacheKey(), this.light.id, this.light.castShadow ? 1 : 0 );
 
 	}
 

--- a/src/nodes/lighting/AnalyticLightNode.js
+++ b/src/nodes/lighting/AnalyticLightNode.js
@@ -16,6 +16,7 @@ import { Loop } from '../utils/LoopNode.js';
 import { screenCoordinate } from '../display/ScreenNode.js';
 import { HalfFloatType, LessCompare, RGFormat, VSMShadowMap, WebGPUCoordinateSystem } from '../../constants.js';
 import { renderGroup } from '../core/UniformGroupNode.js';
+import { hashArray } from '../core/NodeUtils.js';
 
 const BasicShadowMap = Fn( ( { depthTexture, shadowCoord } ) => {
 
@@ -238,7 +239,7 @@ class AnalyticLightNode extends LightingNode {
 
 	getCacheKey() {
 
-		return super.getCacheKey() + this.light.id + ( ( this.light.castShadow ? 1 : 0 ) << 16 );
+		return hashArray( super.getCacheKey(), this.light.id, this.light.castShadow ? 1 : 0 );
 
 	}
 

--- a/src/nodes/lighting/AnalyticLightNode.js
+++ b/src/nodes/lighting/AnalyticLightNode.js
@@ -238,7 +238,7 @@ class AnalyticLightNode extends LightingNode {
 
 	getCacheKey() {
 
-		return super.getCacheKey() + '-' + ( this.light.id + '-' + ( this.light.castShadow ? '1' : '0' ) );
+		return super.getCacheKey() + this.light.id + ( ( this.light.castShadow ? 1 : 0 ) << 16 );
 
 	}
 

--- a/src/nodes/lighting/AnalyticLightNode.js
+++ b/src/nodes/lighting/AnalyticLightNode.js
@@ -239,7 +239,7 @@ class AnalyticLightNode extends LightingNode {
 
 	getCacheKey() {
 
-		return hashArray( super.getCacheKey(), this.light.id, this.light.castShadow ? 1 : 0 );
+		return hashArray( [ super.getCacheKey(), this.light.id, this.light.castShadow ? 1 : 0 ] );
 
 	}
 

--- a/src/renderers/common/ClippingContext.js
+++ b/src/renderers/common/ClippingContext.js
@@ -20,7 +20,7 @@ class ClippingContext {
 
 		this.parentVersion = 0;
 		this.viewNormalMatrix = new Matrix3();
-		this.cacheKey = '';
+		this.cacheKey = 0;
 
 	}
 
@@ -95,7 +95,7 @@ class ClippingContext {
 		if ( update ) {
 
 			this.version ++;
-			this.cacheKey = `${ this.globalClippingCount }:${ this.localClippingEnabled === undefined ? false : this.localClippingEnabled }:`;
+			this.cacheKey = this.globalClippingCount << ( this.localClippingEnabled === undefined && this.localClippingEnabled ? 0 : 16 );
 
 		}
 
@@ -165,7 +165,7 @@ class ClippingContext {
 		if ( update ) {
 
 			this.version += parent.version;
-			this.cacheKey = parent.cacheKey + `:${ this.localClippingCount }:${ this.localClipIntersection === undefined ? false : this.localClipIntersection }`;
+			this.cacheKey = parent.cacheKey + ( this.localClippingCount << ( this.localClipIntersection === undefined && this.localClipIntersection ? 0 : 16 ) );
 
 		}
 

--- a/src/renderers/common/ClippingContext.js
+++ b/src/renderers/common/ClippingContext.js
@@ -95,7 +95,7 @@ class ClippingContext {
 		if ( update ) {
 
 			this.version ++;
-			this.cacheKey = this.globalClippingCount << ( this.localClippingEnabled === undefined && this.localClippingEnabled ? 0 : 16 );
+			this.cacheKey = this.globalClippingCount << ( this.localClippingEnabled === true ? 16 : 0 );
 
 		}
 
@@ -165,7 +165,7 @@ class ClippingContext {
 		if ( update ) {
 
 			this.version += parent.version;
-			this.cacheKey = parent.cacheKey + ( this.localClippingCount << ( this.localClipIntersection === undefined && this.localClipIntersection ? 0 : 16 ) );
+			this.cacheKey = parent.cacheKey + ( this.localClippingCount << ( this.localClipIntersection === true ? 16 : 0 ) );
 
 		}
 

--- a/src/renderers/common/ClippingContext.js
+++ b/src/renderers/common/ClippingContext.js
@@ -1,6 +1,7 @@
 import { Matrix3 } from '../../math/Matrix3.js';
 import { Plane } from '../../math/Plane.js';
 import { Vector4 } from '../../math/Vector4.js';
+import { hashArray } from '../../nodes/core/NodeUtils.js';
 
 const _plane = /*@__PURE__*/ new Plane();
 
@@ -95,7 +96,7 @@ class ClippingContext {
 		if ( update ) {
 
 			this.version ++;
-			this.cacheKey = this.globalClippingCount << ( this.localClippingEnabled === true ? 16 : 0 );
+			this.cacheKey = hashArray( [ this.globalClippingCount, this.localClippingEnabled === true ? 1 : 0 ] );
 
 		}
 
@@ -165,7 +166,7 @@ class ClippingContext {
 		if ( update ) {
 
 			this.version += parent.version;
-			this.cacheKey = parent.cacheKey + ( this.localClippingCount << ( this.localClipIntersection === true ? 16 : 0 ) );
+			this.cacheKey = hashArray( [ parent.cacheKey, this.localClippingCount, this.localClipIntersection === true ? 1 : 0 ] );
 
 		}
 

--- a/src/renderers/common/ClippingContext.js
+++ b/src/renderers/common/ClippingContext.js
@@ -1,7 +1,7 @@
 import { Matrix3 } from '../../math/Matrix3.js';
 import { Plane } from '../../math/Plane.js';
 import { Vector4 } from '../../math/Vector4.js';
-import { hashArray } from '../../nodes/core/NodeUtils.js';
+import { hash } from '../../nodes/core/NodeUtils.js';
 
 const _plane = /*@__PURE__*/ new Plane();
 
@@ -96,7 +96,7 @@ class ClippingContext {
 		if ( update ) {
 
 			this.version ++;
-			this.cacheKey = hashArray( [ this.globalClippingCount, this.localClippingEnabled === true ? 1 : 0 ] );
+			this.cacheKey = hash( this.globalClippingCount, this.localClippingEnabled === true ? 1 : 0 );
 
 		}
 
@@ -166,7 +166,7 @@ class ClippingContext {
 		if ( update ) {
 
 			this.version += parent.version;
-			this.cacheKey = hashArray( [ parent.cacheKey, this.localClippingCount, this.localClipIntersection === true ? 1 : 0 ] );
+			this.cacheKey = hash( parent.cacheKey, this.localClippingCount, this.localClipIntersection === true ? 1 : 0 );
 
 		}
 

--- a/src/renderers/common/RenderContext.js
+++ b/src/renderers/common/RenderContext.js
@@ -50,17 +50,15 @@ export function getCacheKey( renderContext ) {
 
 	const { textures, activeCubeFace } = renderContext;
 
-	let key = '';
+	let key = 0;
 
 	for ( const texture of textures ) {
 
-		key += texture.id + ',';
+		key = Math.imul( key, texture.id << 4 );
 
 	}
 
-	key += activeCubeFace;
-
-	return key;
+	return key + ( activeCubeFace << 16 );
 
 }
 

--- a/src/renderers/common/RenderContext.js
+++ b/src/renderers/common/RenderContext.js
@@ -1,4 +1,5 @@
 import { Vector4 } from '../../math/Vector4.js';
+import { hashArray } from '../../nodes/core/NodeUtils.js';
 
 let id = 0;
 
@@ -50,15 +51,15 @@ export function getCacheKey( renderContext ) {
 
 	const { textures, activeCubeFace } = renderContext;
 
-	let key = 0;
+	const values = [ activeCubeFace ];
 
 	for ( const texture of textures ) {
 
-		key = Math.imul( key, texture.id << 4 );
+		values.push( texture.id );
 
 	}
 
-	return key + ( activeCubeFace << 16 );
+	return hashArray( values );
 
 }
 

--- a/src/renderers/common/RenderObject.js
+++ b/src/renderers/common/RenderObject.js
@@ -1,4 +1,4 @@
-import { cyrb53 } from '../../nodes/core/NodeUtils.js';
+import { hashString } from '../../nodes/core/NodeUtils.js';
 import ClippingContext from './ClippingContext.js';
 
 let _id = 0;
@@ -370,7 +370,7 @@ export default class RenderObject {
 
 		}
 
-		return cyrb53( cacheKey );
+		return hashString( cacheKey );
 
 	}
 

--- a/src/renderers/common/RenderObject.js
+++ b/src/renderers/common/RenderObject.js
@@ -1,3 +1,4 @@
+import { cyrb53 } from '../../nodes/core/NodeUtils.js';
 import ClippingContext from './ClippingContext.js';
 
 let _id = 0;
@@ -369,7 +370,7 @@ export default class RenderObject {
 
 		}
 
-		return cacheKey;
+		return cyrb53( cacheKey );
 
 	}
 
@@ -383,13 +384,21 @@ export default class RenderObject {
 
 		// Environment Nodes Cache Key
 
-		return this.object.receiveShadow + ',' + this._nodes.getCacheKey( this.scene, this.lightsNode );
+		let cacheKey = this._nodes.getCacheKey( this.scene, this.lightsNode );
+
+		if ( this.object.receiveShadow ) {
+
+			cacheKey += 1;
+
+		}
+
+		return cacheKey;
 
 	}
 
 	getCacheKey() {
 
-		return this.getMaterialCacheKey() + ',' + this.getDynamicCacheKey();
+		return this.getMaterialCacheKey() + this.getDynamicCacheKey();
 
 	}
 

--- a/src/renderers/common/nodes/Nodes.js
+++ b/src/renderers/common/nodes/Nodes.js
@@ -6,6 +6,7 @@ import { NodeFrame } from '../../../nodes/Nodes.js';
 import { objectGroup, renderGroup, frameGroup, cubeTexture, texture, rangeFog, densityFog, reference, normalWorld, pmremTexture, screenUV } from '../../../nodes/TSL.js';
 
 import { CubeUVReflectionMapping, EquirectangularReflectionMapping, EquirectangularRefractionMapping } from '../../../constants.js';
+import { cyrb53 } from '../../../nodes/core/NodeUtils.js';
 
 const outputNodeMap = new WeakMap();
 
@@ -226,15 +227,15 @@ class Nodes extends DataMap {
 			const environmentNode = this.getEnvironmentNode( scene );
 			const fogNode = this.getFogNode( scene );
 
-			const cacheKey = [];
+			let cacheKey = 0;
 
-			if ( lightsNode ) cacheKey.push( lightsNode.getCacheKey( true ) );
-			if ( environmentNode ) cacheKey.push( environmentNode.getCacheKey() );
-			if ( fogNode ) cacheKey.push( fogNode.getCacheKey() );
+			if ( lightsNode ) cacheKey += lightsNode.getCacheKey( true );
+			if ( environmentNode ) cacheKey += environmentNode.getCacheKey();
+			if ( fogNode ) cacheKey += fogNode.getCacheKey();
 
 			cacheKeyData = {
 				callId,
-				cacheKey: cacheKey.join( ',' )
+				cacheKey
 			};
 
 			this.callHashCache.set( chain, cacheKeyData );

--- a/src/renderers/common/nodes/Nodes.js
+++ b/src/renderers/common/nodes/Nodes.js
@@ -6,6 +6,7 @@ import { NodeFrame } from '../../../nodes/Nodes.js';
 import { objectGroup, renderGroup, frameGroup, cubeTexture, texture, rangeFog, densityFog, reference, normalWorld, pmremTexture, screenUV } from '../../../nodes/TSL.js';
 
 import { CubeUVReflectionMapping, EquirectangularReflectionMapping, EquirectangularRefractionMapping } from '../../../constants.js';
+import { hashArray } from '../../../nodes/core/NodeUtils.js';
 
 const outputNodeMap = new WeakMap();
 
@@ -226,15 +227,15 @@ class Nodes extends DataMap {
 			const environmentNode = this.getEnvironmentNode( scene );
 			const fogNode = this.getFogNode( scene );
 
-			let cacheKey = 0;
+			const values = [];
 
-			if ( lightsNode ) cacheKey += lightsNode.getCacheKey( true );
-			if ( environmentNode ) cacheKey += environmentNode.getCacheKey();
-			if ( fogNode ) cacheKey += fogNode.getCacheKey();
+			if ( lightsNode ) values.push( lightsNode.getCacheKey( true ) );
+			if ( environmentNode ) values.push( environmentNode.getCacheKey() );
+			if ( fogNode ) values.push( fogNode.getCacheKey() );
 
 			cacheKeyData = {
 				callId,
-				cacheKey
+				cacheKey: hashArray( values )
 			};
 
 			this.callHashCache.set( chain, cacheKeyData );

--- a/src/renderers/common/nodes/Nodes.js
+++ b/src/renderers/common/nodes/Nodes.js
@@ -6,7 +6,6 @@ import { NodeFrame } from '../../../nodes/Nodes.js';
 import { objectGroup, renderGroup, frameGroup, cubeTexture, texture, rangeFog, densityFog, reference, normalWorld, pmremTexture, screenUV } from '../../../nodes/TSL.js';
 
 import { CubeUVReflectionMapping, EquirectangularReflectionMapping, EquirectangularRefractionMapping } from '../../../constants.js';
-import { cyrb53 } from '../../../nodes/core/NodeUtils.js';
 
 const outputNodeMap = new WeakMap();
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/29386, https://github.com/mrdoob/three.js/pull/29212#issuecomment-2307272523

**Description**

A numeric cache key brings a performance gain in the rendering cycle ( https://github.com/mrdoob/three.js/pull/29386 ) in addition to saving memory because it is just an integer instead of sometimes big strings.

As `RenderObjects` hashes inherited the individuality of `RenderContext`, the possibility of collision decreases, among other detail that can be improved in case of we encounter any collision issues.

I was thinking about using the `getHash` terminology but I had some conflicts with some existing functions.