### PR TITLE
WebGPURenderer: Reuse LightNode when available

### DIFF
--- a/src/nodes/lighting/LightsNode.js
+++ b/src/nodes/lighting/LightsNode.js
@@ -47,6 +47,8 @@ class LightsNode extends Node {
 		this._lightNodes = null;
 		this._lightNodesHash = null;
 
+		this.global = true;
+
 	}
 
 	getHash( builder ) {

--- a/src/nodes/lighting/LightsNode.js
+++ b/src/nodes/lighting/LightsNode.js
@@ -23,6 +23,8 @@ const getLightNodeById = ( id, lightNodes ) => {
 
 };
 
+const _lightsNodeRef = /*@__PURE__*/ new WeakMap();
+
 class LightsNode extends Node {
 
 	static get type() {
@@ -44,8 +46,6 @@ class LightsNode extends Node {
 
 		this._lightNodes = null;
 		this._lightNodesHash = null;
-
-		this.global = true;
 
 	}
 
@@ -119,7 +119,20 @@ class LightsNode extends Node {
 
 					}
 
-					lightNodes.push( nodeObject( new lightNodeClass( light ) ) );
+					let lightNode = null;
+
+					if ( ! _lightsNodeRef.has( light ) ) {
+
+						lightNode = new lightNodeClass( light );
+						_lightsNodeRef.set( light, lightNode );
+
+					} else {
+
+						lightNode = _lightsNodeRef.get( light );
+
+					}
+
+					lightNodes.push( lightNode );
 
 				}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/29187

**Description**

As mentioned in [#29187](https://github.com/mrdoob/three.js/pull/29187), LightsNode are duplicated for each AnalyticLightNode per RenderList.

For example, adding an environment map to a scene that has a light casting a shadow will create a duplicated instance of that LightNode. I have created a reproduction here: https://jsfiddle.net/v6cbhu5f/5/
[<img width="1717" alt="image" src="https://github.com/user-attachments/assets/80ab6c93-958d-45f6-8bb3-f2e9e4366303">](https://jsfiddle.net/v6cbhu5f/5/)


Using a high-quality environment map that generates many LODs (and thus multiple RenderLists, since each LOD is a scene by itself) will amplify the issue:
![image](https://github.com/user-attachments/assets/6cd4b49c-8623-438f-9baa-202134e1f5c3)

This PR fixes the issue by using a global reference of lights nodes via WeakMap outside of LightsNode. I'm not 100% satisfied with this solution, but at least it resolves the problem. Do you have any suggestions on the matter, @sunag?

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Utsubo](https://utsubo.com)*
