### PR TITLE
Fix for NodeMaterial import in objects folder

### DIFF
--- a/examples/jsm/objects/SkyMesh.js
+++ b/examples/jsm/objects/SkyMesh.js
@@ -2,10 +2,10 @@ import {
 	BackSide,
 	BoxGeometry,
 	Mesh,
-	NodeMaterial,
 	Vector3
 } from 'three';
 import { float, Fn, vec3, acos, add, mul, clamp, cos, dot, exp, max, mix, modelViewProjection, normalize, positionWorld, pow, smoothstep, sub, varying, varyingProperty, vec4, uniform, cameraPosition } from 'three/tsl';
+import { NodeMaterial } from 'three/webgpu';
 
 /**
  * Based on "A Practical Analytic Model for Daylight"

--- a/examples/jsm/objects/Water2Mesh.js
+++ b/examples/jsm/objects/Water2Mesh.js
@@ -1,11 +1,11 @@
 import {
 	Color,
 	Mesh,
-	NodeMaterial,
 	Vector2,
 	Vector3
 } from 'three';
 import { vec2, viewportSafeUV, viewportSharedTexture, reflector, pow, float, abs, texture, uniform, TempNode, NodeUpdateType, vec4, Fn, cameraPosition, positionWorld, uv, mix, vec3, normalize, max, dot, screenUV } from 'three/tsl';
+import { NodeMaterial } from 'three/webgpu';
 
 /**
  * References:

--- a/examples/jsm/objects/WaterMesh.js
+++ b/examples/jsm/objects/WaterMesh.js
@@ -1,10 +1,10 @@
 import {
 	Color,
 	Mesh,
-	NodeMaterial,
 	Vector3
 } from 'three';
 import { add, cameraPosition, div, normalize, positionWorld, sub, timerLocal, Fn, texture, vec2, vec3, vec4, max, dot, reflect, pow, length, float, uniform, reflector, mul, mix } from 'three/tsl';
+import { NodeMaterial } from 'three/webgpu';
 
 /**
  * Work based on :


### PR DESCRIPTION
Related issue: `No matching export in “./three.module.js” for import “NodeMaterial”`

**Description**

Simple fix for imports of `NodeMaterial` to correct build failures.

