### PR TITLE
WebGPURenderer: respect the `renderer.shadowMap.enabled` property

### DIFF
--- a/examples/webgpu_postprocessing_motion_blur.html
+++ b/examples/webgpu_postprocessing_motion_blur.html
@@ -155,6 +155,7 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setAnimationLoop( animate );
+				renderer.shadowMap.enabled = true;
 				document.body.appendChild( renderer.domElement );
 
 				stats = new Stats();

--- a/examples/webgpu_reflection.html
+++ b/examples/webgpu_reflection.html
@@ -128,6 +128,7 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setAnimationLoop( animate );
+				renderer.shadowMap.enabled = true;
 				document.body.appendChild( renderer.domElement );
 
 				stats = new Stats();

--- a/examples/webgpu_shadowmap_opacity.html
+++ b/examples/webgpu_shadowmap_opacity.html
@@ -48,6 +48,7 @@
 				renderer.setAnimationLoop( render );
 				renderer.toneMapping = THREE.AgXToneMapping;
 				renderer.toneMappingExposure = 1.5;
+				renderer.shadowMap.enabled = true;
 				container.appendChild( renderer.domElement );
 
 				scene = new THREE.Scene();

--- a/examples/webgpu_tsl_angular_slicing.html
+++ b/examples/webgpu_tsl_angular_slicing.html
@@ -194,6 +194,7 @@
 				renderer = new THREE.WebGPURenderer( { antialias: true } );
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				renderer.toneMappingExposure = 1;
+				renderer.shadowMap.enabled = true;
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setAnimationLoop( animate );

--- a/examples/webgpu_tsl_procedural_terrain.html
+++ b/examples/webgpu_tsl_procedural_terrain.html
@@ -226,6 +226,7 @@
 
 				renderer = new THREE.WebGPURenderer( { antialias: true } );
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;
+				renderer.shadowMap.enabled = true;
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setAnimationLoop( animate );

--- a/src/nodes/lighting/AnalyticLightNode.js
+++ b/src/nodes/lighting/AnalyticLightNode.js
@@ -253,6 +253,8 @@ class AnalyticLightNode extends LightingNode {
 
 		const { object, renderer } = builder;
 
+		if ( renderer.shadowMap.enabled === false ) return;
+
 		let shadowColorNode = this.shadowColorNode;
 
 		if ( shadowColorNode === null ) {

--- a/src/renderers/common/nodes/Nodes.js
+++ b/src/renderers/common/nodes/Nodes.js
@@ -233,7 +233,7 @@ class Nodes extends DataMap {
 			if ( environmentNode ) values.push( environmentNode.getCacheKey() );
 			if ( fogNode ) values.push( fogNode.getCacheKey() );
 
-			values.push( this.renderer.shadowMap.enabled );
+			values.push( this.renderer.shadowMap.enabled ? 1 : 0 );
 
 			cacheKeyData = {
 				callId,

--- a/src/renderers/common/nodes/Nodes.js
+++ b/src/renderers/common/nodes/Nodes.js
@@ -233,6 +233,8 @@ class Nodes extends DataMap {
 			if ( environmentNode ) values.push( environmentNode.getCacheKey() );
 			if ( fogNode ) values.push( fogNode.getCacheKey() );
 
+			values.push( this.renderer.shadowMap.enabled );
+
 			cacheKeyData = {
 				callId,
 				cacheKey: hashArray( values )


### PR DESCRIPTION

The renderer.shadowMap.enabled property is ignored in updating shadowing. Add this to the lighting cache key and check when setting up lighting nodes.
