### PR TITLE
ReferenceNode: Fix null reference using `getNodeType()`

### DIFF
--- a/src/materials/nodes/manager/NodeMaterialObserver.js
+++ b/src/materials/nodes/manager/NodeMaterialObserver.js
@@ -90,6 +90,12 @@ class NodeMaterialObserver {
 				worldMatrix: renderObject.object.matrixWorld.clone()
 			};
 
+			if ( renderObject.object.center ) {
+
+				data.center = renderObject.object.center.clone();
+
+			}
+
 			if ( renderObject.object.morphTargetInfluences ) {
 
 				data.morphTargetInfluences = renderObject.object.morphTargetInfluences.slice();
@@ -159,7 +165,6 @@ class NodeMaterialObserver {
 		}
 
 		return data;
-
 
 	}
 
@@ -236,6 +241,20 @@ class NodeMaterialObserver {
 			}
 
 			if ( morphChanged ) return true;
+
+		}
+
+		// center
+
+		if ( renderObjectData.center ) {
+
+			if ( renderObjectData.center.equals( object.center ) === false ) {
+
+				renderObjectData.center.copy( object.center );
+
+				return true;
+
+			}
 
 		}
 

--- a/src/nodes/accessors/ReferenceBaseNode.js
+++ b/src/nodes/accessors/ReferenceBaseNode.js
@@ -98,6 +98,7 @@ class ReferenceBaseNode extends Node {
 
 		if ( this.node === null ) {
 
+			this.updateReference( builder );
 			this.updateValue();
 
 		}

--- a/src/nodes/accessors/ReferenceNode.js
+++ b/src/nodes/accessors/ReferenceNode.js
@@ -136,6 +136,7 @@ class ReferenceNode extends Node {
 
 		if ( this.node === null ) {
 
+			this.updateReference( builder );
 			this.updateValue();
 
 		}


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/29394

**Description**

- [x] [Fix null reference using getNodeType()](https://github.com/mrdoob/three.js/commit/62ec3114fb757489d528b05c4af551f25708d6c5)
- [x] [NodeMaterialObserver: Add `sprite.center` check](https://github.com/mrdoob/three.js/commit/6c32aa24b9c1f7de03d696e94d41e115f49109a3)