### PR TITLE
WebGPURenderer: Fix NodeLibrary Logic for Minified Builds

### DIFF
--- a/examples/jsm/lines/LineMaterial.js
+++ b/examples/jsm/lines/LineMaterial.js
@@ -405,11 +405,16 @@ ShaderLib[ 'line' ] = {
 
 class LineMaterial extends ShaderMaterial {
 
+
+	static get type() {
+
+		return 'LineMaterial';
+
+	}
+
 	constructor( parameters ) {
 
 		super( {
-
-			type: 'LineMaterial',
 
 			uniforms: UniformsUtils.clone( ShaderLib[ 'line' ].uniforms ),
 

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -47,6 +47,12 @@ const _tempVec1 = new Vector3();
 
 class LDrawConditionalLineMaterial extends ShaderMaterial {
 
+	static get type() {
+
+		return 'LDrawConditionalLineMaterial';
+
+	}
+
 	constructor( parameters ) {
 
 		super( {

--- a/examples/jsm/loaders/MMDLoader.js
+++ b/examples/jsm/loaders/MMDLoader.js
@@ -2128,13 +2128,17 @@ class CubicBezierInterpolation extends Interpolant {
 
 class MMDToonMaterial extends ShaderMaterial {
 
+	static get type() {
+
+		return 'MMDToonMaterial';
+
+	}
+
 	constructor( parameters ) {
 
 		super();
 
 		this.isMMDToonMaterial = true;
-
-		this.type = 'MMDToonMaterial';
 
 		this._matcapCombine = AddOperation;
 		this.emissiveIntensity = 1.0;

--- a/examples/jsm/materials/MeshGouraudMaterial.js
+++ b/examples/jsm/materials/MeshGouraudMaterial.js
@@ -315,13 +315,17 @@ const GouraudShader = {
 
 class MeshGouraudMaterial extends ShaderMaterial {
 
+	static get type() {
+
+		return 'MeshGouraudMaterial';
+
+	}
+
 	constructor( parameters ) {
 
 		super();
 
 		this.isMeshGouraudMaterial = true;
-
-		this.type = 'MeshGouraudMaterial';
 
 		//this.color = new THREE.Color( 0xffffff ); // diffuse
 

--- a/src/materials/LineBasicMaterial.js
+++ b/src/materials/LineBasicMaterial.js
@@ -3,13 +3,17 @@ import { Color } from '../math/Color.js';
 
 class LineBasicMaterial extends Material {
 
+	static get type() {
+
+		return 'LineBasicMaterial';
+
+	}
+
 	constructor( parameters ) {
 
 		super();
 
 		this.isLineBasicMaterial = true;
-
-		this.type = 'LineBasicMaterial';
 
 		this.color = new Color( 0xffffff );
 

--- a/src/materials/LineDashedMaterial.js
+++ b/src/materials/LineDashedMaterial.js
@@ -2,13 +2,17 @@ import { LineBasicMaterial } from './LineBasicMaterial.js';
 
 class LineDashedMaterial extends LineBasicMaterial {
 
+	static get type() {
+
+		return 'LineDashedMaterial';
+
+	}
+
 	constructor( parameters ) {
 
 		super();
 
 		this.isLineDashedMaterial = true;
-
-		this.type = 'LineDashedMaterial';
 
 		this.scale = 1;
 		this.dashSize = 3;

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -21,7 +21,7 @@ class Material extends EventDispatcher {
 
 	set type( value ) {
 
-		return this.type;
+		console.warn( `THREE.Material: .type is now read-only. Use the syntax "static get type() return ${value}" instead.` );
 
 	}
 

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -7,6 +7,24 @@ let _materialId = 0;
 
 class Material extends EventDispatcher {
 
+	static get type() {
+
+		return 'Material';
+
+	}
+
+	get type() {
+
+		return this.constructor.type;
+
+	}
+
+	set type( value ) {
+
+		return this.type;
+
+	}
+
 	constructor() {
 
 		super();
@@ -18,7 +36,6 @@ class Material extends EventDispatcher {
 		this.uuid = MathUtils.generateUUID();
 
 		this.name = '';
-		this.type = 'Material';
 
 		this.blending = NormalBlending;
 		this.side = FrontSide;

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -21,7 +21,7 @@ class Material extends EventDispatcher {
 
 	set type( value ) {
 
-		console.warn( `THREE.Material: .type is now read-only. Use the syntax "static get type() return ${value}" instead.` );
+		console.warn( `THREE.Material: .type is now read-only. Use the syntax "static get type() return '${value}'" instead.` );
 
 	}
 

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -19,11 +19,7 @@ class Material extends EventDispatcher {
 
 	}
 
-	set type( value ) {
-
-		console.warn( `THREE.Material: .type is now read-only. Use the syntax "static get type() return '${value}'" instead.` );
-
-	}
+	set type( _value ) { /* */ }
 
 	constructor() {
 

--- a/src/materials/MeshBasicMaterial.js
+++ b/src/materials/MeshBasicMaterial.js
@@ -5,13 +5,17 @@ import { Euler } from '../math/Euler.js';
 
 class MeshBasicMaterial extends Material {
 
+	static get type() {
+
+		return 'MeshBasicMaterial';
+
+	}
+
 	constructor( parameters ) {
 
 		super();
 
 		this.isMeshBasicMaterial = true;
-
-		this.type = 'MeshBasicMaterial';
 
 		this.color = new Color( 0xffffff ); // emissive
 

--- a/src/materials/MeshDepthMaterial.js
+++ b/src/materials/MeshDepthMaterial.js
@@ -3,7 +3,7 @@ import { BasicDepthPacking } from '../constants.js';
 
 class MeshDepthMaterial extends Material {
 
-	static get name() {
+	static get type() {
 
 		return 'MeshDepthMaterial';
 

--- a/src/materials/MeshDepthMaterial.js
+++ b/src/materials/MeshDepthMaterial.js
@@ -3,6 +3,12 @@ import { BasicDepthPacking } from '../constants.js';
 
 class MeshDepthMaterial extends Material {
 
+	static get name() {
+
+		return 'MeshDepthMaterial';
+
+	}
+
 	constructor( parameters ) {
 
 		super();

--- a/src/materials/MeshDepthMaterial.js
+++ b/src/materials/MeshDepthMaterial.js
@@ -15,8 +15,6 @@ class MeshDepthMaterial extends Material {
 
 		this.isMeshDepthMaterial = true;
 
-		this.type = 'MeshDepthMaterial';
-
 		this.depthPacking = BasicDepthPacking;
 
 		this.map = null;

--- a/src/materials/MeshDistanceMaterial.js
+++ b/src/materials/MeshDistanceMaterial.js
@@ -2,13 +2,17 @@ import { Material } from './Material.js';
 
 class MeshDistanceMaterial extends Material {
 
+	static get type() {
+
+		return 'MeshDistanceMaterial';
+
+	}
+
 	constructor( parameters ) {
 
 		super();
 
 		this.isMeshDistanceMaterial = true;
-
-		this.type = 'MeshDistanceMaterial';
 
 		this.map = null;
 

--- a/src/materials/MeshLambertMaterial.js
+++ b/src/materials/MeshLambertMaterial.js
@@ -6,13 +6,17 @@ import { Euler } from '../math/Euler.js';
 
 class MeshLambertMaterial extends Material {
 
+	static get type() {
+
+		return 'MeshLambertMaterial';
+
+	}
+
 	constructor( parameters ) {
 
 		super();
 
 		this.isMeshLambertMaterial = true;
-
-		this.type = 'MeshLambertMaterial';
 
 		this.color = new Color( 0xffffff ); // diffuse
 

--- a/src/materials/MeshMatcapMaterial.js
+++ b/src/materials/MeshMatcapMaterial.js
@@ -5,6 +5,12 @@ import { Color } from '../math/Color.js';
 
 class MeshMatcapMaterial extends Material {
 
+	static get type() {
+
+		return 'MeshMatcapMaterial';
+
+	}
+
 	constructor( parameters ) {
 
 		super();
@@ -12,8 +18,6 @@ class MeshMatcapMaterial extends Material {
 		this.isMeshMatcapMaterial = true;
 
 		this.defines = { 'MATCAP': '' };
-
-		this.type = 'MeshMatcapMaterial';
 
 		this.color = new Color( 0xffffff ); // diffuse
 

--- a/src/materials/MeshNormalMaterial.js
+++ b/src/materials/MeshNormalMaterial.js
@@ -4,13 +4,17 @@ import { Vector2 } from '../math/Vector2.js';
 
 class MeshNormalMaterial extends Material {
 
+	static get type() {
+
+		return 'MeshNormalMaterial';
+
+	}
+
 	constructor( parameters ) {
 
 		super();
 
 		this.isMeshNormalMaterial = true;
-
-		this.type = 'MeshNormalMaterial';
 
 		this.bumpMap = null;
 		this.bumpScale = 1;

--- a/src/materials/MeshPhongMaterial.js
+++ b/src/materials/MeshPhongMaterial.js
@@ -6,13 +6,17 @@ import { Euler } from '../math/Euler.js';
 
 class MeshPhongMaterial extends Material {
 
+	static get type() {
+
+		return 'MeshPhongMaterial';
+
+	}
+
 	constructor( parameters ) {
 
 		super();
 
 		this.isMeshPhongMaterial = true;
-
-		this.type = 'MeshPhongMaterial';
 
 		this.color = new Color( 0xffffff ); // diffuse
 		this.specular = new Color( 0x111111 );

--- a/src/materials/MeshPhysicalMaterial.js
+++ b/src/materials/MeshPhysicalMaterial.js
@@ -5,6 +5,12 @@ import * as MathUtils from '../math/MathUtils.js';
 
 class MeshPhysicalMaterial extends MeshStandardMaterial {
 
+	static get type() {
+
+		return 'MeshPhysicalMaterial';
+
+	}
+
 	constructor( parameters ) {
 
 		super();
@@ -17,8 +23,6 @@ class MeshPhysicalMaterial extends MeshStandardMaterial {
 			'PHYSICAL': ''
 
 		};
-
-		this.type = 'MeshPhysicalMaterial';
 
 		this.anisotropyRotation = 0;
 		this.anisotropyMap = null;

--- a/src/materials/MeshStandardMaterial.js
+++ b/src/materials/MeshStandardMaterial.js
@@ -6,6 +6,12 @@ import { Euler } from '../math/Euler.js';
 
 class MeshStandardMaterial extends Material {
 
+	static get type() {
+
+		return 'MeshStandardMaterial';
+
+	}
+
 	constructor( parameters ) {
 
 		super();
@@ -13,8 +19,6 @@ class MeshStandardMaterial extends Material {
 		this.isMeshStandardMaterial = true;
 
 		this.defines = { 'STANDARD': '' };
-
-		this.type = 'MeshStandardMaterial';
 
 		this.color = new Color( 0xffffff ); // diffuse
 		this.roughness = 1.0;

--- a/src/materials/MeshToonMaterial.js
+++ b/src/materials/MeshToonMaterial.js
@@ -5,6 +5,12 @@ import { Color } from '../math/Color.js';
 
 class MeshToonMaterial extends Material {
 
+	static get type() {
+
+		return 'MeshToonMaterial';
+
+	}
+
 	constructor( parameters ) {
 
 		super();
@@ -12,8 +18,6 @@ class MeshToonMaterial extends Material {
 		this.isMeshToonMaterial = true;
 
 		this.defines = { 'TOON': '' };
-
-		this.type = 'MeshToonMaterial';
 
 		this.color = new Color( 0xffffff );
 

--- a/src/materials/PointsMaterial.js
+++ b/src/materials/PointsMaterial.js
@@ -3,13 +3,17 @@ import { Color } from '../math/Color.js';
 
 class PointsMaterial extends Material {
 
+	static get type() {
+
+		return 'PointsMaterial';
+
+	}
+
 	constructor( parameters ) {
 
 		super();
 
 		this.isPointsMaterial = true;
-
-		this.type = 'PointsMaterial';
 
 		this.color = new Color( 0xffffff );
 

--- a/src/materials/RawShaderMaterial.js
+++ b/src/materials/RawShaderMaterial.js
@@ -2,13 +2,17 @@ import { ShaderMaterial } from './ShaderMaterial.js';
 
 class RawShaderMaterial extends ShaderMaterial {
 
+	static get type() {
+
+		return 'RawShaderMaterial';
+
+	}
+
 	constructor( parameters ) {
 
 		super( parameters );
 
 		this.isRawShaderMaterial = true;
-
-		this.type = 'RawShaderMaterial';
 
 	}
 

--- a/src/materials/ShaderMaterial.js
+++ b/src/materials/ShaderMaterial.js
@@ -6,13 +6,17 @@ import default_fragment from '../renderers/shaders/ShaderChunk/default_fragment.
 
 class ShaderMaterial extends Material {
 
+	static get type() {
+
+		return 'ShaderMaterial';
+
+	}
+
 	constructor( parameters ) {
 
 		super();
 
 		this.isShaderMaterial = true;
-
-		this.type = 'ShaderMaterial';
 
 		this.defines = {};
 		this.uniforms = {};

--- a/src/materials/ShadowMaterial.js
+++ b/src/materials/ShadowMaterial.js
@@ -3,13 +3,17 @@ import { Color } from '../math/Color.js';
 
 class ShadowMaterial extends Material {
 
+	static get type() {
+
+		return 'ShadowMaterial';
+
+	}
+
 	constructor( parameters ) {
 
 		super();
 
 		this.isShadowMaterial = true;
-
-		this.type = 'ShadowMaterial';
 
 		this.color = new Color( 0x000000 );
 		this.transparent = true;

--- a/src/materials/SpriteMaterial.js
+++ b/src/materials/SpriteMaterial.js
@@ -3,13 +3,17 @@ import { Color } from '../math/Color.js';
 
 class SpriteMaterial extends Material {
 
+	static get type() {
+
+		return 'SpriteMaterial';
+
+	}
+
 	constructor( parameters ) {
 
 		super();
 
 		this.isSpriteMaterial = true;
-
-		this.type = 'SpriteMaterial';
 
 		this.color = new Color( 0xffffff );
 

--- a/src/renderers/common/nodes/NodeLibrary.js
+++ b/src/renderers/common/nodes/NodeLibrary.js
@@ -65,7 +65,7 @@ class NodeLibrary {
 
 	addMaterial( materialNodeClass, materialClass ) {
 
-		this.addType( materialNodeClass, materialClass.name, this.materialNodes );
+		this.addType( materialNodeClass, materialClass.type, this.materialNodes );
 
 	}
 


### PR DESCRIPTION
Related issue: #29187

**Description**

Issue:

Minifiers mangle class names like MeshStandardMaterial.name to shorter identifiers (e.g., a2), causing errors such as:

NodeMaterial: Material "MeshStandardMaterial" is not compatible.

Solution:

This PR fixes the issue by introducing a static type property on material classes. By using materialClass.type instead of materialClass.name, we prevent minification from breaking material compatibility checks.

PS:
Note: I strongly recommend merging this or a similar fix before releasing r169, as this issue currently breaks all Vite applications using the WebGPURenderer.


*This contribution is funded by [Utsubo](https://utsubo.com)*
