### PR TITLE
GLTFLoader: Remove deprecated code.

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -267,16 +267,6 @@ class GLTFLoader extends Loader {
 
 	}
 
-	setDDSLoader() {
-
-		throw new Error(
-
-			'THREE.GLTFLoader: "MSFT_texture_dds" no longer supported. Please update to "KHR_texture_basisu".'
-
-		);
-
-	}
-
 	setKTX2Loader( ktx2Loader ) {
 
 		this.ktx2Loader = ktx2Loader;


### PR DESCRIPTION
Related issue: #21271

**Description**

`GLTFLoader.setDDSLoader()` has been deprecated long time ago (`r126`) and according to our deprecation policy the code can safely be removed now.