### PR TITLE
TransformControls: Fix `dispose()`.

### DIFF
--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -536,12 +536,7 @@ class TransformControls extends Controls {
 
 		this.disconnect();
 
-		this.traverse( function ( child ) {
-
-			if ( child.geometry ) child.geometry.dispose();
-			if ( child.material ) child.material.dispose();
-
-		} );
+		this._root.dispose();
 
 	}
 
@@ -808,6 +803,17 @@ class TransformControlsRoot extends Object3D {
 		}
 
 		super.updateMatrixWorld( force );
+
+	}
+
+	dispose() {
+
+		this.traverse( function ( child ) {
+
+			if ( child.geometry ) child.geometry.dispose();
+			if ( child.material ) child.material.dispose();
+
+		} );
 
 	}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/29146#issuecomment-2378858450

**Description**

The PR fixes the broken `dispose()` method in `TransformControls`.
