### PR TITLE
TSL: Deprecated `.temp()`

### DIFF
--- a/examples/webgpu_compute_points.html
+++ b/examples/webgpu_compute_points.html
@@ -66,7 +66,7 @@
 					const pointer = uniform( pointerVector );
 					const limit = uniform( scaleVector );
 
-					const position = particle.add( velocity ).temp();
+					const position = particle.add( velocity ).toVar();
 
 					velocity.x = position.x.abs().greaterThanEqual( limit.x ).select( velocity.x.negate(), velocity.x );
 					velocity.y = position.y.abs().greaterThanEqual( limit.y ).select( velocity.y.negate(), velocity.y );

--- a/examples/webgpu_materials.html
+++ b/examples/webgpu_materials.html
@@ -218,7 +218,7 @@
 				const loopCount = 10;
 				material.colorNode = Loop( loopCount, ( { i } ) => {
 
-					const output = vec4().temp();
+					const output = vec4().toVar();
 					const scale = oscSine().mul( .09 ); // just a value to test
 
 					const scaleI = scale.mul( i );

--- a/src/nodes/core/VarNode.js
+++ b/src/nodes/core/VarNode.js
@@ -54,7 +54,19 @@ class VarNode extends Node {
 
 export default VarNode;
 
-export const temp = /*@__PURE__*/ nodeProxy( VarNode );
+export const createVar = /*@__PURE__*/ nodeProxy( VarNode );
 
-addMethodChaining( 'temp', temp ); // @TODO: Will be removed in the future
 addMethodChaining( 'toVar', ( ...params ) => temp( ...params ).append() );
+
+// Deprecated
+
+export const temp = ( node ) => { // @deprecated, r170
+
+	console.warn( 'TSL: "temp" is deprecated. Use ".toVar()" or "createVar()" instead.' );
+
+	return createVar( node );
+
+};
+
+addMethodChaining( 'temp', temp );
+

--- a/src/nodes/core/VarNode.js
+++ b/src/nodes/core/VarNode.js
@@ -56,7 +56,7 @@ export default VarNode;
 
 const createVar = /*@__PURE__*/ nodeProxy( VarNode );
 
-addMethodChaining( 'toVar', ( ...params ) => temp( ...params ).append() );
+addMethodChaining( 'toVar', ( ...params ) => createVar( ...params ).append() );
 
 // Deprecated
 

--- a/src/nodes/core/VarNode.js
+++ b/src/nodes/core/VarNode.js
@@ -54,7 +54,7 @@ class VarNode extends Node {
 
 export default VarNode;
 
-export const createVar = /*@__PURE__*/ nodeProxy( VarNode );
+const createVar = /*@__PURE__*/ nodeProxy( VarNode );
 
 addMethodChaining( 'toVar', ( ...params ) => temp( ...params ).append() );
 

--- a/src/nodes/core/VarNode.js
+++ b/src/nodes/core/VarNode.js
@@ -62,7 +62,7 @@ addMethodChaining( 'toVar', ( ...params ) => createVar( ...params ).append() );
 
 export const temp = ( node ) => { // @deprecated, r170
 
-	console.warn( 'TSL: "temp" is deprecated. Use ".toVar()" or "createVar()" instead.' );
+	console.warn( 'TSL: "temp" is deprecated. Use ".toVar()" instead.' );
 
 	return createVar( node );
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/29495#issuecomment-2376228825

**Description**

Deprecated `.temp()`