### PR TITLE
SpriteNodeMaterial: size attenuation support orthographic camera

### DIFF
--- a/src/materials/nodes/SpriteNodeMaterial.js
+++ b/src/materials/nodes/SpriteNodeMaterial.js
@@ -59,9 +59,18 @@ class SpriteNodeMaterial extends NodeMaterial {
 		}
 
 
-		if ( ! sizeAttenuation && camera.isPerspectiveCamera ) {
+		if ( ! sizeAttenuation ) {
 
-			scale = scale.mul( mvPosition.z.negate() );
+			if ( camera.isPerspectiveCamera ) {
+
+				scale = scale.mul( mvPosition.z.negate() );
+
+			} else {
+
+				const orthoScale = float( 2.0 ).div( cameraProjectionMatrix.element( 1 ).element( 1 ) );
+				scale = scale.mul( orthoScale.mul( 2 ) );
+
+			}
 
 		}
 


### PR DESCRIPTION
**Description**

Adjusted sprite scaling for orthographic cameras when sizeAttenuation is false by adding:
```js
const orthoScale = float(2.0).div(cameraProjectionMatrix.element(1).element(1));
scale = scale.mul(orthoScale.mul(2));
```

We calculate orthoScale as 2.0 / cameraProjectionMatrix[1][1] to obtain the camera's vertical size, and then multiply by 2 to adjust for the normalized device coordinate (NDC) space ranging from -1 to 1. This ensures sprites scale correctly in orthographic projections, maintaining consistent sizes on the screen regardless of the camera's zoom level.


*This contribution is funded by [Segments.AI](https://segments.ai) & [Utsubo](https://utsubo.com)*