### PR TITLE
WebGPURenderer: Ignore `diagnostic()` method in Deno.

### DIFF
--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -1319,13 +1319,10 @@ fn main( ${shaderData.attributes} ) -> VaryingsStruct {
 	}
 
 	_getWGSLFragmentCode( shaderData ) {
-		const diagnostic = typeof Deno === 'object' ? '' : 'diagnostic( off, derivative_uniformity );';
 
 		return `${ this.getSignature() }
 // global
 ${ diagnostics }
-
-${diagnostic}
 
 // uniforms
 ${shaderData.uniforms}

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -152,7 +152,7 @@ if ( /Windows/g.test( navigator.userAgent ) ) {
 
 let diagnostics = '';
 
-if ( /Firefox/g.test( navigator.userAgent ) !== true ) {
+if ( /Firefox|Deno/g.test( navigator.userAgent ) !== true ) {
 
 	diagnostics += 'diagnostic( off, derivative_uniformity );\n';
 

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -1319,10 +1319,13 @@ fn main( ${shaderData.attributes} ) -> VaryingsStruct {
 	}
 
 	_getWGSLFragmentCode( shaderData ) {
+		const diagnostic = typeof Deno === 'object' ? '' : 'diagnostic( off, derivative_uniformity );';
 
 		return `${ this.getSignature() }
 // global
 ${ diagnostics }
+
+${diagnostic}
 
 // uniforms
 ${shaderData.uniforms}


### PR DESCRIPTION
I've ported a [game](https://github.com/Mutefish0/rega/tree/main/celeste) to Deno using Three.js. However, diagnostic filters aren’t supported in wgpu, which Deno's WebGPU is based on.

Tracking issue:
https://github.com/gfx-rs/wgpu/issues/5320
