### PR TITLE
support direct use of gpu frames such as from webcodecs by library users

### DIFF
--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -767,8 +767,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 			let mipmap;
 			const mipmaps = texture.mipmaps;
-
-			const useTexStorage = ( texture.isVideoTexture !== true );
+			const useTexStorage = ( texture.isGPU !== true );
 			const allocateMemory = ( sourceProperties.__version === undefined ) || ( forceUpload === true );
 			const dataReady = source.dataReady;
 			const levels = getMipLevels( texture, image );
@@ -1212,7 +1211,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 				glType = utils.convert( texture.type ),
 				glInternalFormat = getInternalFormat( texture.internalFormat, glFormat, glType, texture.colorSpace );
 
-			const useTexStorage = ( texture.isVideoTexture !== true );
+			const useTexStorage = ( texture.isGPU !== true );
 			const allocateMemory = ( sourceProperties.__version === undefined ) || ( forceUpload === true );
 			const dataReady = source.dataReady;
 			let levels = getMipLevels( texture, image );

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -72,6 +72,8 @@ class Texture extends EventDispatcher {
 		this.isRenderTargetTexture = false; // indicates whether a texture belongs to a render target or not
 		this.pmremVersion = 0; // indicates whether this texture should be processed by PMREMGenerator or not (only relevant for render target textures)
 
+		this.isGPU = false;
+
 	}
 
 	get image() {

--- a/src/textures/VideoTexture.js
+++ b/src/textures/VideoTexture.js
@@ -13,6 +13,7 @@ class VideoTexture extends Texture {
 		this.magFilter = magFilter !== undefined ? magFilter : LinearFilter;
 
 		this.generateMipmaps = false;
+		this.isGPU = true;
 
 		const scope = this;
 


### PR DESCRIPTION
**Description**

This introduces a user accessible isGPU flag that avoids pixel storage allocation and forces use of only the TexImage api. Previously this was only conceived for the VideoTexture class of three.js, but it is also desirable for example when using the WebCodecs api and feeding resulting frames to three.js
