### PR TITLE
LineMaterial: fix segment clipping with reverse depth

### DIFF
--- a/examples/jsm/lines/LineMaterial.js
+++ b/examples/jsm/lines/LineMaterial.js
@@ -79,8 +79,8 @@ ShaderLib[ 'line' ] = {
 			float b = projectionMatrix[ 3 ][ 2 ]; // 3nd entry in 4th column
 
 			#ifdef USE_REVERSEDEPTHBUF
-				// ( - far * near ) / ( far - near )
-				float nearEstimate = b;
+				// - 0.5 * ( - far * near ) / ( far - near )
+				float nearEstimate = - 0.5 * b;
 			#else
 				// - 0.5 * ( ( - 2 * far * near ) / ( far - near ) ) / ( - ( far + near ) / ( far - near ) )
 				// ( - far * near ) / ( far + near )

--- a/examples/jsm/lines/LineMaterial.js
+++ b/examples/jsm/lines/LineMaterial.js
@@ -77,7 +77,15 @@ ShaderLib[ 'line' ] = {
 			// conservative estimate of the near plane
 			float a = projectionMatrix[ 2 ][ 2 ]; // 3nd entry in 3th column
 			float b = projectionMatrix[ 3 ][ 2 ]; // 3nd entry in 4th column
-			float nearEstimate = - 0.5 * b / a;
+
+			#ifdef USE_REVERSEDEPTHBUF
+				// ( - far * near ) / ( far - near )
+				float nearEstimate = b;
+			#else
+				// - 0.5 * ( ( - 2 * far * near ) / ( far - near ) ) / ( - ( far + near ) / ( far - near ) )
+				// ( - far * near ) / ( far + near )
+				float nearEstimate = - 0.5 * b / a;
+			#endif
 
 			float alpha = ( nearEstimate - start.z ) / ( end.z - start.z );
 


### PR DESCRIPTION
**Description**

Fixes software clipping for line segments in `LineMaterial` which is sensitive to both NDC range and the reversal of near/far values with reverse depth. This needs an example, but I noticed when using Line2 for axis helpers, axes appeared to be inverted.