### PR TITLE
TSL: Avoid vector reuse in luminance() input

### DIFF
--- a/src/nodes/display/ColorAdjustment.js
+++ b/src/nodes/display/ColorAdjustment.js
@@ -39,7 +39,7 @@ export const hue = /*@__PURE__*/ Fn( ( [ color, adjustment = float( 1 ) ] ) => {
 
 export const luminance = (
 	color,
-	luminanceCoefficients = vec3( ... ColorManagement.getLuminanceCoefficients( new Vector3() ) )
+	luminanceCoefficients = vec3( ColorManagement.getLuminanceCoefficients( new Vector3() ) )
 ) => dot( color, luminanceCoefficients );
 
 export const threshold = ( color, threshold ) => mix( vec3( 0.0 ), color, luminance( color ).sub( threshold ).max( 0 ) );

--- a/src/nodes/display/ColorAdjustment.js
+++ b/src/nodes/display/ColorAdjustment.js
@@ -37,10 +37,9 @@ export const hue = /*@__PURE__*/ Fn( ( [ color, adjustment = float( 1 ) ] ) => {
 
 } );
 
-const _luminanceCoefficients = /*@__PURE__*/ new Vector3();
 export const luminance = (
 	color,
-	luminanceCoefficients = vec3( ... ColorManagement.getLuminanceCoefficients( _luminanceCoefficients ) )
+	luminanceCoefficients = vec3( ... ColorManagement.getLuminanceCoefficients( new Vector3() ) )
 ) => dot( color, luminanceCoefficients );
 
 export const threshold = ( color, threshold ) => mix( vec3( 0.0 ), color, luminance( color ).sub( threshold ).max( 0 ) );


### PR DESCRIPTION
Since the luminance() function could be called multiple times with different coefficients, and I'm not sure whether the vector is stored internally by `vec3(vector)`, perhaps it's better not to reuse a local variable here.

/cc @sunag does this sound correct?