### PR TITLE
Renderer: Added sync `.compute()` support

### DIFF
--- a/examples/webgpu_compute_geometry.html
+++ b/examples/webgpu_compute_geometry.html
@@ -132,7 +132,7 @@
 
 			async function animate() {
 
-				if ( computeUpdate ) await renderer.computeAsync( computeUpdate );
+				if ( computeUpdate ) renderer.compute( computeUpdate );
 
 				renderer.render( scene, camera );
 

--- a/examples/webgpu_compute_particles.html
+++ b/examples/webgpu_compute_particles.html
@@ -178,7 +178,7 @@
 
 				//
 
-				renderer.compute( computeInit );
+				renderer.computeAsync( computeInit );
 
 				// click event
 
@@ -219,7 +219,7 @@
 
 						// compute
 
-						renderer.compute( computeHit );
+						renderer.computeAsync( computeHit );
 
 					}
 

--- a/examples/webgpu_compute_particles_rain.html
+++ b/examples/webgpu_compute_particles_rain.html
@@ -292,7 +292,7 @@
 
 				//
 
-				renderer.compute( computeInit );
+				renderer.computeAsync( computeInit );
 
 				//
 

--- a/examples/webgpu_compute_points.html
+++ b/examples/webgpu_compute_points.html
@@ -83,7 +83,7 @@
 				// compute
 
 				computeNode = computeShaderFn().compute( particleNum );
-				computeNode.onInit = ( { renderer } ) => {
+				computeNode.onInit( ( { renderer } ) => {
 
 					const precomputeShaderNode = Fn( () => {
 
@@ -101,9 +101,9 @@
 
 					} );
 
-					renderer.compute( precomputeShaderNode().compute( particleNum ) );
+					renderer.computeAsync( precomputeShaderNode().compute( particleNum ) );
 
-				};
+				} );
 
 				// use a compute shader to animate the point cloud's vertex data.
 

--- a/examples/webgpu_compute_texture.html
+++ b/examples/webgpu_compute_texture.html
@@ -99,7 +99,7 @@
 				document.body.appendChild( renderer.domElement );
 
 				// compute texture
-				renderer.compute( computeNode );
+				renderer.computeAsync( computeNode );
 
 				window.addEventListener( 'resize', onWindowResize );
 

--- a/examples/webgpu_compute_water.html
+++ b/examples/webgpu_compute_water.html
@@ -411,7 +411,7 @@
 				const buttonCompute = {
 					smoothWater: function () {
 
-						renderer.compute( computeSmooth );
+						renderer.computeAsync( computeSmooth );
 
 					}
 				};
@@ -488,11 +488,11 @@
 
 				}
 			
-				renderer.compute( computeHeight );
+				renderer.computeAsync( computeHeight );
 
 				if ( effectController.spheresEnabled ) {
 
-					renderer.compute( computeSphere );
+					renderer.computeAsync( computeSphere );
 
 				}
 

--- a/examples/webgpu_tsl_compute_attractors_particles.html
+++ b/examples/webgpu_tsl_compute_attractors_particles.html
@@ -194,7 +194,7 @@
 
 				const reset = () => {
 
-					renderer.compute( initCompute );
+					renderer.computeAsync( initCompute );
 			
 				};
 

--- a/examples/webgpu_tsl_vfx_linkedparticles.html
+++ b/examples/webgpu_tsl_vfx_linkedparticles.html
@@ -108,7 +108,7 @@
 				const particleVelocities = storage( new THREE.StorageInstancedBufferAttribute( nbParticles, 4 ), 'vec4', nbParticles );
 
 				// init particles buffers
-				renderer.compute( /*#__PURE__*/ Fn( () => {
+				renderer.computeAsync( /*#__PURE__*/ Fn( () => {
 
 					particlePositions.element( instanceIndex ).xyz.assign( vec3( 10000.0 ) );
 					particlePositions.element( instanceIndex ).w.assign( vec3( - 1.0 ) ); // life is stored in w component; x<0 means dead

--- a/src/nodes/gpgpu/ComputeNode.js
+++ b/src/nodes/gpgpu/ComputeNode.js
@@ -25,6 +25,8 @@ class ComputeNode extends Node {
 		this.version = 1;
 		this.updateBeforeType = NodeUpdateType.OBJECT;
 
+		this.onInitFunction = null;
+
 		this.updateDispatchCount();
 
 	}
@@ -54,7 +56,13 @@ class ComputeNode extends Node {
 
 	}
 
-	onInit() { }
+	onInit( callback ) {
+
+		this.onInitFunction = callback;
+
+		return this;
+
+	}
 
 	updateBefore( { renderer } ) {
 

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -1210,7 +1210,13 @@ class Renderer {
 
 				//
 
-				computeNode.onInit( { renderer: this } );
+				const onInitFn = computeNode.onInitFunction;
+
+				if ( onInitFn !== null ) {
+
+					onInitFn.call( computeNode, { renderer: this } );
+
+				}
 
 			}
 

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -1149,9 +1149,17 @@ class Renderer {
 
 	}
 
-	async computeAsync( computeNodes ) {
+	compute( computeNodes ) {
 
-		if ( this._initialized === false ) await this.init();
+		if ( this._initialized === false ) {
+
+			console.warn( 'THREE.Renderer: .compute() called before the backend is initialized. Try using .computeAsync() instead.' );
+
+			return this.computeAsync( computeNodes );
+
+		}
+
+		//
 
 		const nodeFrame = this._nodes.nodeFrame;
 
@@ -1218,11 +1226,19 @@ class Renderer {
 
 		backend.finishCompute( computeNodes );
 
-		await this.backend.resolveTimestampAsync( computeNodes, 'compute' );
-
 		//
 
 		nodeFrame.renderId = previousRenderId;
+
+	}
+
+	async computeAsync( computeNodes ) {
+
+		if ( this._initialized === false ) await this.init();
+
+		this.compute( computeNodes );
+
+		await this.backend.resolveTimestampAsync( computeNodes, 'compute' );
 
 	}
 
@@ -1630,12 +1646,6 @@ class Renderer {
 		this._pipelines.getForRender( renderObject, this._compilationPromises );
 
 		this._nodes.updateAfter( renderObject );
-
-	}
-
-	get compute() {
-
-		return this.computeAsync;
 
 	}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/29503#issuecomment-2380630063

**Description**

I'm thinking about improving the computational geometry example with `material.geometryNode` to handle computation only when the object is rendered. Among some other benefits we can get like https://github.com/mrdoob/three.js/pull/29503#issuecomment-2380630063 we will need synchronous computation to avoid race condition problem.

- [x] [Renderer: Added sync `compute()`](https://github.com/mrdoob/three.js/pull/29547/commits/a0d0da86da8ebdf212bc551aaaf8e491d297882e)
- [x] [ComputeNode: Use `.onInit( fn )` instead of `.onInit=fn`](https://github.com/mrdoob/three.js/pull/29547/commits/fcd243c54c903303e3d9762fb79df3d9ba9bdfd0)
- [x] [Update examples](https://github.com/mrdoob/three.js/pull/29547/commits/20c47381dc22437dff355a062bddb759a50d9ebf)
