### PR TITLE
TSL: Introduce `pointer` | WGSL `ptr` support

### DIFF
--- a/src/nodes/code/FunctionCallNode.js
+++ b/src/nodes/code/FunctionCallNode.js
@@ -47,14 +47,25 @@ class FunctionCallNode extends TempNode {
 		const inputs = functionNode.getInputs( builder );
 		const parameters = this.parameters;
 
+		const generateInput = ( node, inputNode ) => {
+
+			const type = inputNode.type;
+			const pointer = type === 'pointer';
+
+			let output;
+
+			if ( pointer ) output = '&' + node.build( builder );
+			else output = node.build( builder, type );
+
+			return output;
+
+		};
+
 		if ( Array.isArray( parameters ) ) {
 
 			for ( let i = 0; i < parameters.length; i ++ ) {
 
-				const inputNode = inputs[ i ];
-				const node = parameters[ i ];
-
-				params.push( node.build( builder, inputNode.type ) );
+				params.push( generateInput( parameters[ i ], inputs[ i ] ) );
 
 			}
 
@@ -66,7 +77,7 @@ class FunctionCallNode extends TempNode {
 
 				if ( node !== undefined ) {
 
-					params.push( node.build( builder, inputNode.type ) );
+					params.push( generateInput( node, inputNode ) );
 
 				} else {
 

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -1073,7 +1073,7 @@ ${ flowData.code }
 				const bufferType = this.getType( bufferNode.bufferType );
 				const bufferCount = bufferNode.bufferCount;
 
-				const bufferCountSnippet = bufferCount > 0 ? ', ' + bufferCount : '';
+				const bufferCountSnippet = bufferCount > 0 && uniform.type === 'buffer' ? ', ' + bufferCount : '';
 				const bufferTypeSnippet = bufferNode.isAtomic ? `atomic<${bufferType}>` : `${bufferType}`;
 				const bufferSnippet = `\t${ uniform.name } : array< ${ bufferTypeSnippet }${ bufferCountSnippet } >\n`;
 				const bufferAccessMode = bufferNode.isStorageBufferNode ? `storage, ${ this.getStorageAccess( bufferNode ) }` : 'uniform';

--- a/src/renderers/webgpu/nodes/WGSLNodeFunction.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeFunction.js
@@ -101,6 +101,10 @@ const parse = ( source ) => {
 
 				resolvedType = type.split( '<' )[ 0 ];
 
+			} else if ( resolvedType.startsWith( 'ptr' ) ) {
+
+				resolvedType = 'pointer';
+
 			}
 
 			resolvedType = wgslTypeLib[ resolvedType ] || resolvedType;


### PR DESCRIPTION
Related issue: Closes https://github.com/mrdoob/three.js/issues/29401

**Description**

Introduces `pointer` support, below is an example of how to use it for storage buffers, although it has many other applications.

```js
// buffer

const particleBuffer = new THREE.StorageInstancedBufferAttribute( particleNum, 2 );

// function

const getElement = wgslFn( `
fn main_vertex( vertexBuffer: ptr<storage, array<vec2<f32>>, read_write>, index: u32 ) -> vec2f {

	return vertexBuffer[ index ];

}
` );

// function call

const particle = getElement( particleBufferNode, instanceIndex );

```