### PR TITLE
Examples: Fix shadow map enabled in `webgpu_instancing_morph`

### DIFF
--- a/examples/webgpu_instancing_morph.html
+++ b/examples/webgpu_instancing_morph.html
@@ -140,6 +140,7 @@
 				renderer.setAnimationLoop( animate );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
+				renderer.shadowMap.enabled = true;
 				document.body.appendChild( renderer.domElement );
 
 				window.addEventListener( 'resize', onWindowResize );


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/29520
