### PR TITLE
DOC: Update intro to post processing imports

### DIFF
--- a/docs/manual/ar/introduction/How-to-use-post-processing.html
+++ b/docs/manual/ar/introduction/How-to-use-post-processing.html
@@ -24,9 +24,10 @@
 		</p>
 
 		<code>
-		import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
-		import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
-		import { GlitchPass } from 'three/addons/postprocessing/GlitchPass.js';
+		import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js';
+		import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js'; 
+		import { GlitchPass } from 'three/examples/jsm/postprocessing/GlitchPass.js';
+		import { OutputPass } from 'three/examples/jsm/postprocessing/OutputPass.js';
 		</code>
 
 		<p>
@@ -80,8 +81,8 @@
 		</p>
 
 		<code>
-		import { ShaderPass } from 'three/addons/postprocessing/ShaderPass.js';
-		import { LuminosityShader } from 'three/addons/shaders/LuminosityShader.js';
+		import { ShaderPass } from 'three/examples/jsm/postprocessing/ShaderPass.js';
+		import { LuminosityShader } from 'three/examples/jsm/postprocessing/shaders/LuminosityShader.js';
 
 		// later in your init routine
 
@@ -92,6 +93,5 @@
 		<p>
 			يوفر المستودع ملفًا يسمى [link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/shaders/CopyShader.js CopyShader] وهو رمز بداية جيد للتظليل المخصص الخاص بك. *CopyShader* فقط ينسخ محتويات الصورة من مخزن قراءة [page:EffectComposer] إلى مخزن الكتابة المؤقت الخاص به دون تطبيق أي تأثيرات.
 		</p>
-
 	</body>
 </html>

--- a/docs/manual/en/introduction/How-to-use-post-processing.html
+++ b/docs/manual/en/introduction/How-to-use-post-processing.html
@@ -28,10 +28,10 @@
 		</p>
 
 		<code>
-		import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
-		import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
-		import { GlitchPass } from 'three/addons/postprocessing/GlitchPass.js';
-		import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
+		import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js';
+		import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js'; 
+		import { GlitchPass } from 'three/examples/jsm/postprocessing/GlitchPass.js';
+		import { OutputPass } from 'three/examples/jsm/postprocessing/OutputPass.js';
 		</code>
 
 		<p>
@@ -96,8 +96,8 @@
 		</p>
 
 		<code>
-		import { ShaderPass } from 'three/addons/postprocessing/ShaderPass.js';
-		import { LuminosityShader } from 'three/addons/shaders/LuminosityShader.js';
+		import { ShaderPass } from 'three/examples/jsm/postprocessing/ShaderPass.js';
+		import { LuminosityShader } from 'three/examples/jsm/postprocessing/shaders/LuminosityShader.js';
 
 		// later in your init routine
 

--- a/docs/manual/fr/introduction/How-to-use-post-processing.html
+++ b/docs/manual/fr/introduction/How-to-use-post-processing.html
@@ -28,10 +28,10 @@
 		</p>
 
 		<code>
-		import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
-		import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
-		import { GlitchPass } from 'three/addons/postprocessing/GlitchPass.js';
-		import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
+		import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js';
+		import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js'; 
+		import { GlitchPass } from 'three/examples/jsm/postprocessing/GlitchPass.js';
+		import { OutputPass } from 'three/examples/jsm/postprocessing/OutputPass.js';
 		</code>
 
 		<p>
@@ -96,8 +96,8 @@
 		</p>
 
 		<code>
-		import { ShaderPass } from 'three/addons/postprocessing/ShaderPass.js';
-		import { LuminosityShader } from 'three/addons/shaders/LuminosityShader.js';
+		import { ShaderPass } from 'three/examples/jsm/postprocessing/ShaderPass.js';
+		import { LuminosityShader } from 'three/examples/jsm/postprocessing/shaders/LuminosityShader.js';
 
 		// later in your init routine
 

--- a/docs/manual/it/introduction/How-to-use-post-processing.html
+++ b/docs/manual/it/introduction/How-to-use-post-processing.html
@@ -29,10 +29,10 @@
 		</p>
 
 		<code>
-		import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
-		import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
-		import { GlitchPass } from 'three/addons/postprocessing/GlitchPass.js';
-		import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
+		import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js';
+		import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js'; 
+		import { GlitchPass } from 'three/examples/jsm/postprocessing/GlitchPass.js';
+		import { OutputPass } from 'three/examples/jsm/postprocessing/OutputPass.js';
 		</code>
 
 		<p>
@@ -98,8 +98,8 @@
 		</p>
 
 		<code>
-		import { ShaderPass } from 'three/addons/postprocessing/ShaderPass.js';
-		import { LuminosityShader } from 'three/addons/shaders/LuminosityShader.js';
+		import { ShaderPass } from 'three/examples/jsm/postprocessing/ShaderPass.js';
+		import { LuminosityShader } from 'three/examples/jsm/postprocessing/shaders/LuminosityShader.js';
 
 		// later in your init routine
 

--- a/docs/manual/ja/introduction/How-to-use-post-processing.html
+++ b/docs/manual/ja/introduction/How-to-use-post-processing.html
@@ -30,11 +30,11 @@
 	</p>
 
 	<code>
-		import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
-		import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
-		import { GlitchPass } from 'three/addons/postprocessing/GlitchPass.js';
-		import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
-		</code>
+	import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js';
+	import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js'; 
+	import { GlitchPass } from 'three/examples/jsm/postprocessing/GlitchPass.js';
+	import { OutputPass } from 'three/examples/jsm/postprocessing/OutputPass.js';
+	</code>
 
 	<p>
 		全てのファイルのimportが成功したのちに、[page:WebGLRenderer]のインスタンスを渡すことでcomposerを作成します。
@@ -101,8 +101,8 @@
 	</p>
 
 	<code>
-		import { ShaderPass } from 'three/addons/postprocessing/ShaderPass.js';
-		import { LuminosityShader } from 'three/addons/shaders/LuminosityShader.js';
+		import { ShaderPass } from 'three/examples/jsm/postprocessing/ShaderPass.js';
+		import { LuminosityShader } from 'three/examples/jsm/postprocessing/shaders/LuminosityShader.js';
 
 		// later in your init routine
 

--- a/docs/manual/ko/introduction/How-to-use-post-processing.html
+++ b/docs/manual/ko/introduction/How-to-use-post-processing.html
@@ -28,10 +28,10 @@
 		</p>
 
 		<code>
-		import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
-		import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
-		import { GlitchPass } from 'three/addons/postprocessing/GlitchPass.js';
-		import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
+		import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js';
+		import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js'; 
+		import { GlitchPass } from 'three/examples/jsm/postprocessing/GlitchPass.js';
+		import { OutputPass } from 'three/examples/jsm/postprocessing/OutputPass.js';
 		</code>
 
 		<p>
@@ -97,8 +97,8 @@
 		</p>
 
 		<code>
-		import { ShaderPass } from 'three/addons/postprocessing/ShaderPass.js';
-		import { LuminosityShader } from 'three/addons/shaders/LuminosityShader.js';
+		import { ShaderPass } from 'three/examples/jsm/postprocessing/ShaderPass.js';
+		import { LuminosityShader } from 'three/examples/jsm/postprocessing/shaders/LuminosityShader.js';
 
 		// later in your init routine
 

--- a/docs/manual/pt-br/introduction/How-to-use-post-processing.html
+++ b/docs/manual/pt-br/introduction/How-to-use-post-processing.html
@@ -28,10 +28,10 @@
 		</p>
 
 		<code>
-		import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
-		import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
-		import { GlitchPass } from 'three/addons/postprocessing/GlitchPass.js';
-		import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
+		import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js';
+		import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js'; 
+		import { GlitchPass } from 'three/examples/jsm/postprocessing/GlitchPass.js';
+		import { OutputPass } from 'three/examples/jsm/postprocessing/OutputPass.js';
 		</code>
 
 		<p>
@@ -97,8 +97,8 @@
 		</p>
 
 		<code>
-		import { ShaderPass } from 'three/addons/postprocessing/ShaderPass.js';
-		import { LuminosityShader } from 'three/addons/shaders/LuminosityShader.js';
+		import { ShaderPass } from 'three/examples/jsm/postprocessing/ShaderPass.js';
+		import { LuminosityShader } from 'three/examples/jsm/postprocessing/shaders/LuminosityShader.js';
 
 		// later in your init routine
 

--- a/docs/manual/zh/introduction/How-to-use-post-processing.html
+++ b/docs/manual/zh/introduction/How-to-use-post-processing.html
@@ -28,10 +28,10 @@
 		</p>
 
 		<code>
-		import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
-		import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
-		import { GlitchPass } from 'three/addons/postprocessing/GlitchPass.js';
-		import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
+		import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js';
+		import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js'; 
+		import { GlitchPass } from 'three/examples/jsm/postprocessing/GlitchPass.js';
+		import { OutputPass } from 'three/examples/jsm/postprocessing/OutputPass.js';
 		</code>
 
 		<p>
@@ -97,8 +97,8 @@
 		</p>
 
 		<code>
-		import { ShaderPass } from 'three/addons/postprocessing/ShaderPass.js';
-		import { LuminosityShader } from 'three/addons/shaders/LuminosityShader.js';
+		import { ShaderPass } from 'three/examples/jsm/postprocessing/ShaderPass.js';
+		import { LuminosityShader } from 'three/examples/jsm/postprocessing/shaders/LuminosityShader.js';
 
 		// later in your init routine
 


### PR DESCRIPTION
Related issue: Imports path are differnt in current threejs verison

Description

changed the import path to three/examples/jsm/postprocessing/..
