### PR TITLE
WebGPURenderer: Logarithmic Depth Refinement

### DIFF
--- a/src/materials/nodes/NodeMaterial.js
+++ b/src/materials/nodes/NodeMaterial.js
@@ -233,12 +233,6 @@ class NodeMaterial extends Material {
 
 				if ( camera.isPerspectiveCamera ) {
 
-					// Note: normally we could use "float( camera.near )" and "float( camera.far )" for the near/far arguments, but
-					// there is currently a bug with TSL/Three Shading Language whereby a "float()" expression using a huge value
-					// in scientific notation like "float( 1e27 )" will output "1e+27.0" to the shader code, which is causing problems.
-					// Since it's possible that camera.near/camera.far values may be using huge values like this (such as the logarithmic
-					// depth buffer examples on threejs.org), we must use the cameraNear/cameraFar nodes for now.
-					// TODO: can the float() node be fixed to allow for expressions like "float( 1e27 )"?
 					depthNode = perspectiveDepthToLogarithmicDepth( modelViewProjection().w, cameraNear, cameraFar );
 
 				} else {

--- a/src/nodes/display/ViewportDepthNode.js
+++ b/src/nodes/display/ViewportDepthNode.js
@@ -139,7 +139,8 @@ export const perspectiveDepthToLogarithmicDepth = ( perspectiveW, near, far ) =>
 	// 1. Clamp the camera near plane so we don't divide by 0.
 	// 2. Use log2 instead of log to avoid an extra multiply (shaders implement log using log2).
 	// 3. Assume K is 1 (K = maximum value in depth buffer; see Ulrich's formula above).
-	near = near.max( 1e-6 );
+	// For visual representation of this depth value curve, see https://www.desmos.com/calculator/ibw0lhgac2
+	near = near.max( 1e-6 ).toVar();
 	const numerator = log2( perspectiveW.div( near ) );
 	const denominator = log2( far.div( near ) );
 	return numerator.div( denominator );

--- a/src/nodes/display/ViewportDepthNode.js
+++ b/src/nodes/display/ViewportDepthNode.js
@@ -135,7 +135,7 @@ export const perspectiveDepthToLogarithmicDepth = ( perspectiveW, near, far ) =>
 	// Outerra eventually made another improvement to their original "C-constant" variant,
 	// but it still does not incorporate the camera near plane (for this version,
 	// see https://outerra.blogspot.com/2013/07/logarithmic-depth-buffer-optimizations.html).
-	// Here we make 3 changes to Ulrich's formula:
+	// Here we make 4 changes to Ulrich's formula:
 	// 1. Clamp the camera near plane so we don't divide by 0.
 	// 2. Use log2 instead of log to avoid an extra multiply (shaders implement log using log2).
 	// 3. Assume K is 1 (K = maximum value in depth buffer; see Ulrich's formula above).

--- a/src/nodes/display/ViewportDepthNode.js
+++ b/src/nodes/display/ViewportDepthNode.js
@@ -139,10 +139,11 @@ export const perspectiveDepthToLogarithmicDepth = ( perspectiveW, near, far ) =>
 	// 1. Clamp the camera near plane so we don't divide by 0.
 	// 2. Use log2 instead of log to avoid an extra multiply (shaders implement log using log2).
 	// 3. Assume K is 1 (K = maximum value in depth buffer; see Ulrich's formula above).
-	// For visual representation of this depth value curve, see https://www.desmos.com/calculator/ibw0lhgac2
+	// 4. Add 1 to each division by cameraNear to ensure the depth curve is shifted to the left as cameraNear increases.
+	// For visual representation of this depth curve, see https://www.desmos.com/calculator/lz5rqfysih
 	near = near.max( 1e-6 ).toVar();
-	const numerator = log2( perspectiveW.div( near ) );
-	const denominator = log2( far.div( near ) );
+	const numerator = log2( perspectiveW.div( near ).add( 1 ) );
+	const denominator = log2( far.div( near ).add( 1 ) );
 	return numerator.div( denominator );
 
 };

--- a/src/nodes/lighting/AnalyticLightNode.js
+++ b/src/nodes/lighting/AnalyticLightNode.js
@@ -337,7 +337,7 @@ class AnalyticLightNode extends LightingNode {
 
 				// The normally available "cameraNear" and "cameraFar" nodes cannot be used here because they do not get
 				// updated to use the shadow camera. So, we have to declare our own "local" ones here.
-				// TODO: Can we fix cameraNear/cameraFar in src/nodes/accessors/Camera.js so we don't have to declare local ones here?
+				// TODO: How do we get the cameraNear/cameraFar nodes to use the shadow camera so we don't have to declare local ones here?
 				const cameraNearLocal = uniform( 'float' ).onRenderUpdate( () => shadow.camera.near );
 				const cameraFarLocal = uniform( 'float' ).onRenderUpdate( () => shadow.camera.far );
 


### PR DESCRIPTION
Small refinement to PR https://github.com/mrdoob/three.js/pull/29447:

1. Improved wording in a TODO comment in AnalyticLightNode.js.

3. Removed unnecessary comments in NodeMaterial.js. First, the cameraNear/cameraFar nodes **should** be used, so the comment stating that they shouldn't be used is inaccurate. Second, the comment describing the `float(1e27)` bug now has its own issue report https://github.com/mrdoob/three.js/issues/29560

5. Removed unnecessary ".add( 1 ).div( 2 )" operations from the log depth calculation and added more detail to the log depth comments in ViewportDepthNode.js.