### PR TITLE
TSL: Fix exponential float conversion

### DIFF
--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -55,9 +55,17 @@ const typeFromArray = new Map( [
 
 const toFloat = ( value ) => {
 
-	value = Number( value );
+	if ( /e/g.test( value ) ) {
 
-	return value + ( value % 1 ? '' : '.0' );
+		return String( value ).replace( /\+/g, '' );
+
+	} else {
+
+		value = Number( value );
+
+		return value + ( value % 1 ? '' : '.0' );
+
+	}
 
 };
 


### PR DESCRIPTION
Related issue: Closes https://github.com/mrdoob/three.js/issues/29560

**Description**

Fix exponentional JS to shader language conversion. For example: `float(1e21)`
