### PR TITLE
PostProcessing: Only request depth buffer when necessary.

### DIFF
--- a/examples/jsm/tsl/display/AfterImageNode.js
+++ b/examples/jsm/tsl/display/AfterImageNode.js
@@ -21,10 +21,10 @@ class AfterImageNode extends TempNode {
 		this.textureNodeOld = texture();
 		this.damp = uniform( damp );
 
-		this._compRT = new RenderTarget();
+		this._compRT = new RenderTarget( 1, 1, { depthBuffer: false } );
 		this._compRT.texture.name = 'AfterImageNode.comp';
 
-		this._oldRT = new RenderTarget();
+		this._oldRT = new RenderTarget( 1, 1, { depthBuffer: false } );
 		this._oldRT.texture.name = 'AfterImageNode.old';
 
 		this._textureNode = passTexture( this, this._compRT.texture );

--- a/examples/jsm/tsl/display/AnamorphicNode.js
+++ b/examples/jsm/tsl/display/AnamorphicNode.js
@@ -22,7 +22,7 @@ class AnamorphicNode extends TempNode {
 		this.samples = samples;
 		this.resolution = new Vector2( 1, 1 );
 
-		this._renderTarget = new RenderTarget();
+		this._renderTarget = new RenderTarget( 1, 1, { depthBuffer: false } );
 		this._renderTarget.texture.name = 'anamorphic';
 
 		this._invSize = uniform( new Vector2() );

--- a/examples/jsm/tsl/display/BloomNode.js
+++ b/examples/jsm/tsl/display/BloomNode.js
@@ -37,20 +37,20 @@ class BloomNode extends TempNode {
 
 		// render targets
 
-		this._renderTargetBright = new RenderTarget( 1, 1, { type: HalfFloatType } );
+		this._renderTargetBright = new RenderTarget( 1, 1, { depthBuffer: false, type: HalfFloatType } );
 		this._renderTargetBright.texture.name = 'UnrealBloomPass.bright';
 		this._renderTargetBright.texture.generateMipmaps = false;
 
 		for ( let i = 0; i < this._nMips; i ++ ) {
 
-			const renderTargetHorizontal = new RenderTarget( 1, 1, { type: HalfFloatType } );
+			const renderTargetHorizontal = new RenderTarget( 1, 1, { depthBuffer: false, type: HalfFloatType } );
 
 			renderTargetHorizontal.texture.name = 'UnrealBloomPass.h' + i;
 			renderTargetHorizontal.texture.generateMipmaps = false;
 
 			this._renderTargetsHorizontal.push( renderTargetHorizontal );
 
-			const renderTargetVertical = new RenderTarget( 1, 1, { type: HalfFloatType } );
+			const renderTargetVertical = new RenderTarget( 1, 1, { depthBuffer: false, type: HalfFloatType } );
 
 			renderTargetVertical.texture.name = 'UnrealBloomPass.v' + i;
 			renderTargetVertical.texture.generateMipmaps = false;

--- a/examples/jsm/tsl/display/GTAONode.js
+++ b/examples/jsm/tsl/display/GTAONode.js
@@ -33,7 +33,7 @@ class GTAONode extends TempNode {
 
 		this.SAMPLES = uniform( 16 );
 
-		this._aoRenderTarget = new RenderTarget();
+		this._aoRenderTarget = new RenderTarget( 1, 1, { depthBuffer: false } );
 		this._aoRenderTarget.texture.name = 'GTAONode.AO';
 
 		this._material = null;

--- a/examples/jsm/tsl/display/GaussianBlurNode.js
+++ b/examples/jsm/tsl/display/GaussianBlurNode.js
@@ -26,9 +26,9 @@ class GaussianBlurNode extends TempNode {
 		this._invSize = uniform( new Vector2() );
 		this._passDirection = uniform( new Vector2() );
 
-		this._horizontalRT = new RenderTarget();
+		this._horizontalRT = new RenderTarget( 1, 1, { depthBuffer: false } );
 		this._horizontalRT.texture.name = 'GaussianBlurNode.horizontal';
-		this._verticalRT = new RenderTarget();
+		this._verticalRT = new RenderTarget( 1, 1, { depthBuffer: false } );
 		this._verticalRT.texture.name = 'GaussianBlurNode.vertical';
 
 		this._textureNode = passTexture( this, this._verticalRT.texture );

--- a/examples/jsm/tsl/display/SMAANode.js
+++ b/examples/jsm/tsl/display/SMAANode.js
@@ -29,13 +29,13 @@ class SMAANode extends TempNode {
 
 		// render targets
 
-		this._renderTargetEdges = new RenderTarget( 1, 1, { type: HalfFloatType } );
+		this._renderTargetEdges = new RenderTarget( 1, 1, { depthBuffer: false, type: HalfFloatType } );
 		this._renderTargetEdges.texture.name = 'SMAANode.edges';
 
-		this._renderTargetWeights = new RenderTarget( 1, 1, { type: HalfFloatType } );
+		this._renderTargetWeights = new RenderTarget( 1, 1, { depthBuffer: false, type: HalfFloatType } );
 		this._renderTargetWeights.texture.name = 'SMAANode.weights';
 
-		this._renderTargetBlend = new RenderTarget( 1, 1, { type: HalfFloatType } );
+		this._renderTargetBlend = new RenderTarget( 1, 1, { depthBuffer: false, type: HalfFloatType } );
 		this._renderTargetBlend.texture.name = 'SMAANode.blend';
 
 		// textures


### PR DESCRIPTION
Related issue: -

**Description**

This PR introduces a small memory optimization for new node based post processing modules.

Certain intermediate render targets used with `QuadMesh` do not require a depth render buffer since every fragment location is only rendered once. In this case, the render targets can be created with `depthBuffer: false`.
