### PR TITLE
PostProcessing: Harmonize node update type.

### DIFF
--- a/examples/jsm/tsl/display/AfterImageNode.js
+++ b/examples/jsm/tsl/display/AfterImageNode.js
@@ -29,7 +29,7 @@ class AfterImageNode extends TempNode {
 
 		this._textureNode = passTexture( this, this._compRT.texture );
 
-		this.updateBeforeType = NodeUpdateType.RENDER;
+		this.updateBeforeType = NodeUpdateType.FRAME;
 
 	}
 

--- a/examples/jsm/tsl/display/AnamorphicNode.js
+++ b/examples/jsm/tsl/display/AnamorphicNode.js
@@ -29,7 +29,7 @@ class AnamorphicNode extends TempNode {
 
 		this._textureNode = passTexture( this, this._renderTarget.texture );
 
-		this.updateBeforeType = NodeUpdateType.RENDER;
+		this.updateBeforeType = NodeUpdateType.FRAME;
 
 	}
 

--- a/examples/jsm/tsl/display/DenoiseNode.js
+++ b/examples/jsm/tsl/display/DenoiseNode.js
@@ -28,7 +28,7 @@ class DenoiseNode extends TempNode {
 		this._resolution = uniform( new Vector2() );
 		this._sampleVectors = uniformArray( generatePdSamplePointInitializer( 16, 2, 1 ) );
 
-		this.updateBeforeType = NodeUpdateType.RENDER;
+		this.updateBeforeType = NodeUpdateType.FRAME;
 
 	}
 

--- a/examples/jsm/tsl/display/DepthOfFieldNode.js
+++ b/examples/jsm/tsl/display/DepthOfFieldNode.js
@@ -21,7 +21,7 @@ class DepthOfFieldNode extends TempNode {
 
 		this._aspect = uniform( 0 );
 
-		this.updateBeforeType = NodeUpdateType.RENDER;
+		this.updateBeforeType = NodeUpdateType.FRAME;
 
 	}
 

--- a/examples/jsm/tsl/display/FXAANode.js
+++ b/examples/jsm/tsl/display/FXAANode.js
@@ -15,7 +15,7 @@ class FXAANode extends TempNode {
 
 		this.textureNode = textureNode;
 
-		this.updateBeforeType = NodeUpdateType.RENDER;
+		this.updateBeforeType = NodeUpdateType.FRAME;
 
 		this._invSize = uniform( new Vector2() );
 

--- a/examples/jsm/tsl/display/GaussianBlurNode.js
+++ b/examples/jsm/tsl/display/GaussianBlurNode.js
@@ -33,7 +33,7 @@ class GaussianBlurNode extends TempNode {
 
 		this._textureNode = passTexture( this, this._verticalRT.texture );
 
-		this.updateBeforeType = NodeUpdateType.RENDER;
+		this.updateBeforeType = NodeUpdateType.FRAME;
 
 		this.resolution = new Vector2( 1, 1 );
 

--- a/examples/jsm/tsl/display/PixelationPassNode.js
+++ b/examples/jsm/tsl/display/PixelationPassNode.js
@@ -29,7 +29,7 @@ class PixelationNode extends TempNode {
 
 		this._resolution = uniform( new Vector4() );
 
-		this.updateBeforeType = NodeUpdateType.RENDER;
+		this.updateBeforeType = NodeUpdateType.FRAME;
 
 	}
 

--- a/examples/jsm/tsl/display/SMAANode.js
+++ b/examples/jsm/tsl/display/SMAANode.js
@@ -25,7 +25,7 @@ class SMAANode extends TempNode {
 
 		this.textureNode = textureNode;
 
-		this.updateBeforeType = NodeUpdateType.RENDER;
+		this.updateBeforeType = NodeUpdateType.FRAME;
 
 		// render targets
 

--- a/examples/jsm/tsl/display/SobelOperatorNode.js
+++ b/examples/jsm/tsl/display/SobelOperatorNode.js
@@ -15,7 +15,7 @@ class SobelOperatorNode extends TempNode {
 
 		this.textureNode = textureNode;
 
-		this.updateBeforeType = NodeUpdateType.RENDER;
+		this.updateBeforeType = NodeUpdateType.FRAME;
 
 		this._invSize = uniform( new Vector2() );
 


### PR DESCRIPTION
Related issue: -

**Description**

Similar to `Pass`, `BloomPass` and `GTAOPass`, the PR ensures all other FX passes use `NodeUpdateType.FRAME` instead of `NodeUpdateType.RENDER`.