### PR TITLE
Fix Compressed 3D Textures failing on Android and Meta Quest

### DIFF
--- a/src/renderers/webgl-fallback/utils/WebGLTextureUtils.js
+++ b/src/renderers/webgl-fallback/utils/WebGLTextureUtils.js
@@ -445,8 +445,7 @@ class WebGLTextureUtils {
 
 						if ( glFormat !== null ) {
 
-							gl.compressedTexSubImage3D( gl.TEXTURE_2D_ARRAY, i, 0, 0, 0, mipmap.width, mipmap.height, image.depth, glFormat, mipmap.data, 0, 0 );
-
+							gl.compressedTexSubImage3D( gl.TEXTURE_2D_ARRAY, i, 0, 0, 0, mipmap.width, mipmap.height, image.depth, glFormat, mipmap.data );
 
 						} else {
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -885,7 +885,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 													layerIndex * layerByteLength / mipmap.data.BYTES_PER_ELEMENT,
 													( layerIndex + 1 ) * layerByteLength / mipmap.data.BYTES_PER_ELEMENT
 												);
-												state.compressedTexSubImage3D( _gl.TEXTURE_2D_ARRAY, i, 0, 0, layerIndex, mipmap.width, mipmap.height, 1, glFormat, layerData, 0, 0 );
+												state.compressedTexSubImage3D( _gl.TEXTURE_2D_ARRAY, i, 0, 0, layerIndex, mipmap.width, mipmap.height, 1, glFormat, layerData );
 
 											}
 
@@ -893,7 +893,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 										} else {
 
-											state.compressedTexSubImage3D( _gl.TEXTURE_2D_ARRAY, i, 0, 0, 0, mipmap.width, mipmap.height, image.depth, glFormat, mipmap.data, 0, 0 );
+											state.compressedTexSubImage3D( _gl.TEXTURE_2D_ARRAY, i, 0, 0, 0, mipmap.width, mipmap.height, image.depth, glFormat, mipmap.data );
 
 										}
 


### PR DESCRIPTION
Fixed #29539

**Description**
On Android and Oculus devices, calling gl.compressedTexSubImage3D with the extra srcOffset and srcLengthOverride parameters to default (0,0) results in the following error:
`[.WebGL-0x2032d0d00]GL ERROR :GL_INVALID_VALUE : glCompressedTexSubImage3D: size is not correct for dimensions`

The function `gl.compressedTexSubImage3D` was being called with two extra parameters (0, 0) at the end:
```js
gl.compressedTexSubImage3D(
  gl.TEXTURE_2D_ARRAY,
  i,
  0,
  0,
  0,
  mipmap.width,
  mipmap.height,
  image.depth,
  glFormat,
  mipmap.data,
  0, // Optional parameter (srcOffset)
  0  // Optional parameter (srcLengthOverride)
);
```

When supplying image data directly via an ArrayBufferView (e.g., mipmap.data), the function's signature does not require srcOffset and srcLengthOverride parameters. These extra parameters are only valid when specifying a sub-range of the source data. Including them with default values (0, 0) can cause issues on platforms that strictly adhere to the OpenGL ES specification, which does not support these parameters in the same way based on my understanding of the code: https://chromium.googlesource.com/chromium/src/+/6682b1c4aac00aee61b09ba8f6084f1790429315/gpu/command_buffer/service/gles2_cmd_decoder.cc

While some platforms may read these extra parameters as offset and length override, Android and Oculus implementations probably strictly follow the OpenGL ES standards, leading to a GL_INVALID_VALUE error.

The gl.compressedTexSubImage3D API can be confusing due to the multiple ways to call it between WebGL and OpenGL ES, which might have caused this issue. More here:
https://developer.mozilla.org/en-US/docs/Web/API/WebGL2RenderingContext/compressedTexSubImage3D
https://registry.khronos.org/OpenGL-Refpages/es3.0/html/glCompressedTexSubImage3D.xhtml

Since both optional parameters were not currently being used I believe it should be safe for the moment to simply remove them in order to fix #29539.

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Utsubo](https://utsubo.com)*
