### PR TITLE
Editor: Create a new adjustable target when creating a DirectionalLight at the same time in the editor.

### DIFF
--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -399,6 +399,8 @@ Editor.prototype = {
 				} else if ( object.isDirectionalLight ) {
 
 					helper = new THREE.DirectionalLightHelper( object, 1 );
+					
+					object.helper = helper;
 
 				} else if ( object.isSpotLight ) {
 

--- a/editor/js/Menubar.Add.js
+++ b/editor/js/Menubar.Add.js
@@ -381,6 +381,13 @@ function MenubarAdd( editor ) {
 
 		editor.execute( new AddObjectCommand( editor, light ) );
 
+		const lightTarget = new THREE.Object3D();
+		lightTarget.name = 'DirectionalLight Target';
+		editor.execute( new AddObjectCommand( editor, lightTarget ) );
+
+		light.target = lightTarget;
+		lightTarget.userData[ 'fatherLightUUID' ] = light.uuid;
+
 	} );
 	lightSubmenu.add( option );
 

--- a/editor/js/Sidebar.Object.js
+++ b/editor/js/Sidebar.Object.js
@@ -870,6 +870,14 @@ function SidebarObject( editor ) {
 
 		}
 
+		if ( object.userData[ 'fatherLightUUID' ] ) {
+
+			const fatherLight = editor.objectByUuid( object.userData[ 'fatherLightUUID' ] );
+			fatherLight.helper.update();
+			signals.sceneGraphChanged.dispatch();
+
+		}
+
 		objectVisible.setValue( object.visible );
 		objectFrustumCulled.setValue( object.frustumCulled );
 		objectRenderOrder.setValue( object.renderOrder );


### PR DESCRIPTION
Create a new adjustable target when creating a DirectionalLight at the same time in the editor.

**Description**

Sometimes artists need to set the target of a directional light, but it cannot be set temporarily in the editor. According to my own understanding, I added the function of creating the target of the directional light at the same time when creating the directional light.
