### PR TITLE
SSRPass: Ensure metalness pass is not affected by fog and background.

### DIFF
--- a/examples/jsm/postprocessing/SSRPass.js
+++ b/examples/jsm/postprocessing/SSRPass.js
@@ -558,9 +558,13 @@ class SSRPass extends Pass {
 		this.originalClearColor.copy( renderer.getClearColor( this.tempColor ) );
 		const originalClearAlpha = renderer.getClearAlpha( this.tempColor );
 		const originalAutoClear = renderer.autoClear;
+		const originalBackground = this.scene.background;
+		const originalFog = this.scene.fog;
 
 		renderer.setRenderTarget( renderTarget );
 		renderer.autoClear = false;
+		this.scene.background = null;
+		this.scene.fog = null;
 
 		clearColor = overrideMaterial.clearColor || clearColor;
 		clearAlpha = overrideMaterial.clearAlpha || clearAlpha;
@@ -599,6 +603,8 @@ class SSRPass extends Pass {
 		renderer.autoClear = originalAutoClear;
 		renderer.setClearColor( this.originalClearColor );
 		renderer.setClearAlpha( originalClearAlpha );
+		this.scene.background = originalBackground;
+		this.scene.fog = originalFog;
 
 	}
 


### PR DESCRIPTION
Related issue: -

**Description**

The metalness pass of `SSRPass` should save the metalness of the scene's objects so it's possible to decide what objects are affected by SSR. However, the pass is not correctly configured since the scene's background and fog currently affects the metalness data which is wrong.