### PR TITLE
WebGPURenderer: remove obsolete code

### DIFF
--- a/src/renderers/common/RenderList.js
+++ b/src/renderers/common/RenderList.js
@@ -150,12 +150,6 @@ class RenderList {
 
 	}
 
-	getLightsNode() {
-
-		return this.lightsNode.fromLights( this.lightsArray );
-
-	}
-
 	sort( customOpaqueSort, customTransparentSort ) {
 
 		if ( this.opaque.length > 1 ) this.opaque.sort( customOpaqueSort || painterSortStable );


### PR DESCRIPTION
RenderList.getLightsNode() has no callers and calls a LightsNode method that has been removed.
Remove obsolete method.