### PR TITLE
TransformControls: Add min/max constraints.

### DIFF
--- a/docs/examples/en/controls/TransformControls.html
+++ b/docs/examples/en/controls/TransformControls.html
@@ -132,6 +132,36 @@
 			steps the 3D object should be translated. Default is `null`.
 		</p>
 
+		<h3>[property:Number minX]</h3>
+		<p>
+			The minimum allowed X position during translation. Default is `-Infinity`.
+		</p>
+
+		<h3>[property:Number maxX]</h3>
+		<p>
+			The maximum allowed X position during translation. Default is `Infinity`.
+		</p>
+
+		<h3>[property:Number minY]</h3>
+		<p>
+			The minimum allowed Y position during translation. Default is `-Infinity`.
+		</p>
+
+		<h3>[property:Number maxY]</h3>
+		<p>
+			The maximum allowed Y position during translation. Default is `Infinity`.
+		</p>
+
+		<h3>[property:Number minZ]</h3>
+		<p>
+			The minimum allowed Z position during translation. Default is `-Infinity`.
+		</p>
+
+		<h3>[property:Number maxZ]</h3>
+		<p>
+			The maximum allowed Z position during translation. Default is `Infinity`.
+		</p>
+
 		<h2>Methods</h2>
 
 		<p>See the base [page:Controls] class for common methods.</p>

--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -110,6 +110,12 @@ class TransformControls extends Controls {
 		defineProperty( 'showX', true );
 		defineProperty( 'showY', true );
 		defineProperty( 'showZ', true );
+		defineProperty( 'minX', - Infinity );
+		defineProperty( 'maxX', Infinity );
+		defineProperty( 'minY', - Infinity );
+		defineProperty( 'maxY', Infinity );
+		defineProperty( 'minZ', - Infinity );
+		defineProperty( 'maxZ', Infinity );
 
 		// Reusable utility variables
 
@@ -371,6 +377,10 @@ class TransformControls extends Controls {
 				}
 
 			}
+
+			object.position.x = Math.max( this.minX, Math.min( this.maxX, object.position.x ) );
+			object.position.y = Math.max( this.minY, Math.min( this.maxY, object.position.y ) );
+			object.position.z = Math.max( this.minZ, Math.min( this.maxZ, object.position.z ) );
 
 		} else if ( mode === 'scale' ) {
 


### PR DESCRIPTION
**Description**

Add min / max constraints to TransformControls, usefull for editor with limited area.

Example : 
```
control = new TransformControls(camera, domElement)

control.minX = -10
control.maxX = 10
control.minY = 0
control.maxY = 0 // blocked in Y 
control.minZ = -90
control.maxZ = 0
```
