### PR TITLE
Eslint: Add `no-irregular-whitespace` rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -57,6 +57,9 @@
         "destructuring": "any",
         "ignoreReadBeforeAssign": false
       }
+    ],
+    "no-irregular-whitespace": [
+      "error"
     ]
   }
 }

--- a/src/math/ColorManagement.js
+++ b/src/math/ColorManagement.js
@@ -11,7 +11,7 @@ export const ColorManagement = {
 	 * Implementations of supported color spaces.
 	 *
 	 * Required:
-	 *	- primaries: chromaticity coordinates [ rx ry gx gy bx by ]
+	 *	- primaries: chromaticity coordinates [ rx ry gx gy bx by ]
 	 *	- whitePoint: reference white [ x y ]
 	 *	- transfer: transfer function (pre-defined)
 	 *	- toXYZ: Matrix3 RGB to XYZ transform


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/29600#issuecomment-2404385319

**Description**

Add `no-irregular-whitespace` rule for `.eslintrc.json`.

`no-irregular-whitespace` has options, I think we not need it for now.

https://eslint.org/docs/latest/rules/no-irregular-whitespace
