### PR TITLE
ReflectorNode: Remove `getTextureNode()`.

### DIFF
--- a/src/nodes/utils/ReflectorNode.js
+++ b/src/nodes/utils/ReflectorNode.js
@@ -83,12 +83,6 @@ class ReflectorNode extends TextureNode {
 
 	}
 
-	getTextureNode() {
-
-		return this.textureNode;
-
-	}
-
 	getVirtualCamera( camera ) {
 
 		let virtualCamera = this.virtualCameras.get( camera );


### PR DESCRIPTION
Related issue: -

**Description**

This PR removes the method `getTextureNode()` from `ReflectorNode` since the class has no property `textureNode`.

`ReflectorNode` is extended from `TextureNode` so instances of `ReflectorNode` can directly be used without calling `getTextureNode()`.
