### PR TITLE
GaussianBlurNode: Remove useless check.

### DIFF
--- a/examples/jsm/tsl/display/GaussianBlurNode.js
+++ b/examples/jsm/tsl/display/GaussianBlurNode.js
@@ -152,14 +152,6 @@ class GaussianBlurNode extends TempNode {
 
 		const textureNode = this.textureNode;
 
-		if ( textureNode.isTextureNode !== true ) {
-
-			console.error( 'GaussianBlurNode requires a TextureNode.' );
-
-			return vec4();
-
-		}
-
 		//
 
 		const uvNode = textureNode.uvNode || uv();


### PR DESCRIPTION
Related issue: -

**Description**

The PR removes a check in `GaussianBlurNode` that made sense when the node was originally developed. In the meanwhile though, `convertToTexture()` is in place which makes sure the input node ends up as a texture node.
