### PR TITLE
Batchmesh: Fix cases where calling optimize can result in inconsistent state 

### DIFF
--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -685,12 +685,21 @@ class BatchedMesh extends Mesh {
 		// iterate over all geometry ranges
 		const drawRanges = this._drawRanges;
 		const reservedRanges = this._reservedRanges;
+		const indices = drawRanges
+			.map( ( e, i ) => i )
+			.sort( ( a, b ) => {
+
+				return this._reservedRanges[ a ].vertexStart - this._reservedRanges[ b ].vertexStart;
+
+			} );
+
 		const geometry = this.geometry;
 		for ( let i = 0, l = drawRanges.length; i < l; i ++ ) {
 
 			// if a geometry range is inactive then don't copy anything
-			const drawRange = drawRanges[ i ];
-			const reservedRange = reservedRanges[ i ];
+			const index = indices[ i ];
+			const drawRange = drawRanges[ index ];
+			const reservedRange = reservedRanges[ index ];
 			if ( drawRange.active === false ) {
 
 				reservedRange.vertexCount = 0;

--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -1066,14 +1066,17 @@ class BatchedMesh extends Mesh {
 		const matricesTexture = this._matricesTexture;
 		const colorsTexture = this._colorsTexture;
 
+		indirectTexture.dispose();
 		this._initIndirectTexture();
 		copyArrayContents( indirectTexture.image.data, this._indirectTexture.image.data );
 
+		matricesTexture.dispose();
 		this._initMatricesTexture();
 		copyArrayContents( matricesTexture.image.data, this._matricesTexture.image.data );
 
 		if ( colorsTexture ) {
 
+			colorsTexture.dispose();
 			this._initColorsTexture();
 			copyArrayContents( colorsTexture.image.data, this._colorsTexture.image.data );
 

--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -97,7 +97,6 @@ const _batchIntersects = [];
 // @TODO: geometry.drawRange support?
 // @TODO: geometry.morphAttributes support?
 // @TODO: Support uniform parameter per geometry
-// @TODO: Add an "optimize" function to pack geometry and remove data gaps
 
 // copies data from attribute "src" into "target" starting at "targetOffset"
 function copyAttributeData( src, target, targetOffset = 0 ) {
@@ -877,9 +876,6 @@ class BatchedMesh extends Mesh {
 
 	setMatrixAt( instanceId, matrix ) {
 
-		// @TODO: Map geometryId to index of the arrays because
-		//        optimize() can make geometryId mismatch the index
-
 		const drawInfo = this._drawInfo;
 		const matricesTexture = this._matricesTexture;
 		const matricesArray = this._matricesTexture.image.data;
@@ -917,9 +913,6 @@ class BatchedMesh extends Mesh {
 			this._initColorsTexture();
 
 		}
-
-		// @TODO: Map id to index of the arrays because
-		//        optimize() can make id mismatch the index
 
 		const colorsTexture = this._colorsTexture;
 		const colorsArray = this._colorsTexture.image.data;

--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -707,7 +707,7 @@ class BatchedMesh extends Mesh {
 			// if a geometry range is inactive then don't copy anything
 			const drawRange = drawRanges[ i ];
 			const reservedRange = reservedRanges[ i ];
-			if ( drawRange.active === false ) {
+			if ( drawRange.active ) {
 
 				continue;
 

--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -132,8 +132,21 @@ function copyAttributeData( src, target, targetOffset = 0 ) {
 // safely copies array contents to a potentially smaller array
 function copyArrayContents( src, target ) {
 
-	const len = Math.min( src.length, target.length );
-	target.set( new src.constructor( src.buffer, 0, len ) );
+	if ( src.constructor !== target.constructor ) {
+
+		const len = Math.min( src.length, target.length );
+		for ( let i = 0; i < len; i ++ ) {
+
+			target[ i ] = src[ i ];
+
+		}
+
+	} else {
+
+		const len = Math.min( src.length, target.length );
+		target.set( new src.constructor( src.buffer, 0, len ) );
+
+	}
 
 }
 

--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -1178,7 +1178,7 @@ class BatchedMesh extends Mesh {
 			const drawRange = drawRanges[ geometryId ];
 			_mesh.geometry.setDrawRange( drawRange.start, drawRange.count );
 
-			// ge the intersects
+			// get the intersects
 			this.getMatrixAt( i, _mesh.matrixWorld ).premultiply( matrixWorld );
 			this.getBoundingBoxAt( geometryId, _mesh.geometry.boundingBox );
 			this.getBoundingSphereAt( geometryId, _mesh.geometry.boundingSphere );


### PR DESCRIPTION
Related issue: #29527

**Description**

I found some issues while working on a batched mesh implementation for 3d tiles (https://github.com/NASA-AMMOS/3DTilesRendererJS/pull/800) that takes advantage of the new functions from #29527, #29577 and saw that calling optimize could result in geometry displaying incorrectly.

- Store the next insertion points for geometry as dedicated variables rather than using `reservedRanges` since there is now no guarantee of the ranges being presorted.
- Handle the case in expanding the geometry size in which the index buffer array can change array type (ie Uint16 before expanding to Uint32 afterward).
- Presort the order of the geometry ranges in the optimize function before shifting data since there's no guarantee of order.
- Update some comments and spelling.

Once I've gotten the 3d tiles BatchedMesh plugin completely working and merged I'll plan to submit a PR with some cleanup for BatchedMesh, as well.