### PR TITLE
WebGPURenderer: remove useless call in WebGL fallback

### DIFF
--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -1085,8 +1085,6 @@ class WebGLBackend extends Backend {
 
 		// Bindings
 
-		this.createBindings( null, bindings );
-
 		this._setupBindings( bindings, programGPU );
 
 		const attributeNodes = computeProgram.attributes;
@@ -1157,8 +1155,6 @@ class WebGLBackend extends Backend {
 	}
 
 	updateBindings( bindGroup /*, bindings*/ ) {
-
-		if ( bindGroup === null ) return;
 
 		const { gl } = this;
 


### PR DESCRIPTION
Related issue: #29622

The call to createBindings() call doesn't do anything, bindings are already created at this point.
Remove call and also the now pointless check for this null.
