### PR TITLE
Playground: Add `normalMap` node.

### DIFF
--- a/playground/Nodes.json
+++ b/playground/Nodes.json
@@ -1479,6 +1479,21 @@
 							]
 						},
 						{
+							"name": "Normal Map",
+							"icon": "photo",
+							"description": "Converts a normal map value to a normal vector.",
+							"shaderNode": "normalMap",
+							"nodeType": "node",
+							"properties": [
+								{
+									"name": "node",
+									"nodeType": "vec3",
+									"label": "normal",
+									"description": "Specifies the vector to convert."
+								}
+							]
+						},
+						{
 							"name": "Round",
 							"icon": "math-function",
 							"description": "Round returns a value equal to the nearest integer to x.",


### PR DESCRIPTION
Fixed #29650.

**Description**

Adds the so-far missing Normal Map node to convert from a 0..1 normal texture to -1..1 range.

This makes it far easier to use normal mapping in the playground, previously to the best of my knowledge one had to split the Texture output into three floats and remap them individually:
<img width="1494" alt="image" src="https://github.com/user-attachments/assets/a5376ac7-bb77-4e7a-98b4-6d8035b8393c">

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Needle](https://needle.tools)*
