### PR TITLE
Removing unused property in BatchedMesh

### DIFF
--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -177,7 +177,6 @@ class BatchedMesh extends Mesh {
 		this._multiDrawCounts = new Int32Array( maxInstanceCount );
 		this._multiDrawStarts = new Int32Array( maxInstanceCount );
 		this._multiDrawCount = 0;
-		this._multiDrawInstances = null;
 		this._visibilityChanged = true;
 
 		// Local matrix per geometry by using data texture


### PR DESCRIPTION
This PR only removes `_multiDrawInstances` definition from BatchedMesh class, since PR #28404 removed all code that has been using it but kept the property definition.