### PR TITLE
CSSRenderer: Ensure removing CSS objects works within iFrames.

### DIFF
--- a/examples/jsm/renderers/CSS2DRenderer.js
+++ b/examples/jsm/renderers/CSS2DRenderer.js
@@ -26,7 +26,10 @@ class CSS2DObject extends Object3D {
 
 			this.traverse( function ( object ) {
 
-				if ( object.element instanceof Element && object.element.parentNode !== null ) {
+				if (
+					object.element instanceof object.element.ownerDocument.defaultView.Element &&
+					object.element.parentNode !== null
+				) {
 
 					object.element.parentNode.removeChild( object.element );
 
@@ -135,7 +138,7 @@ class CSS2DRenderer {
 				return;
 
 			}
-			
+
 			if ( object.isCSS2DObject ) {
 
 				_vector.setFromMatrixPosition( object.matrixWorld );

--- a/examples/jsm/renderers/CSS2DRenderer.js
+++ b/examples/jsm/renderers/CSS2DRenderer.js
@@ -31,7 +31,7 @@ class CSS2DObject extends Object3D {
 					object.element.parentNode !== null
 				) {
 
-					object.element.parentNode.removeChild( object.element );
+					object.element.remove();
 
 				}
 

--- a/examples/jsm/renderers/CSS3DRenderer.js
+++ b/examples/jsm/renderers/CSS3DRenderer.js
@@ -32,7 +32,10 @@ class CSS3DObject extends Object3D {
 
 			this.traverse( function ( object ) {
 
-				if ( object.element instanceof Element && object.element.parentNode !== null ) {
+				if (
+					object.element instanceof object.element.ownerDocument.defaultView.Element &&
+					object.element.parentNode !== null
+				) {
 
 					object.element.parentNode.removeChild( object.element );
 
@@ -254,7 +257,7 @@ class CSS3DRenderer {
 		function hideObject( object ) {
 
 			if ( object.isCSS3DObject ) object.element.style.display = 'none';
-	  
+
 			for ( let i = 0, l = object.children.length; i < l; i ++ ) {
 
 			  hideObject( object.children[ i ] );

--- a/examples/jsm/renderers/CSS3DRenderer.js
+++ b/examples/jsm/renderers/CSS3DRenderer.js
@@ -37,7 +37,7 @@ class CSS3DObject extends Object3D {
 					object.element.parentNode !== null
 				) {
 
-					object.element.parentNode.removeChild( object.element );
+					object.element.remove();
 
 				}
 
@@ -260,7 +260,7 @@ class CSS3DRenderer {
 
 			for ( let i = 0, l = object.children.length; i < l; i ++ ) {
 
-			  hideObject( object.children[ i ] );
+				hideObject( object.children[ i ] );
 
 			}
 


### PR DESCRIPTION
Fixed #29660

**Description**

`scene.remove(CSS2DObjectInstance)` may not work correctly if the CSS2DRenderer is inside an iframe.
Here is the demo of the problem:
https://jsfiddle.net/87f9azgn/

This PR is to fix it.

As I mentioned https://github.com/mrdoob/three.js/issues/29660#issuecomment-2413786154 ,
The constructor of DOM element depends on its window.
Therefore `object.element instanceof Element` may not work in an iframe.
`Element` is actually `window.Element` and not a `iframeWindow.Element`.