### PR TITLE
Examples: Clean up.

### DIFF
--- a/examples/webgpu_postprocessing_outline.html
+++ b/examples/webgpu_postprocessing_outline.html
@@ -178,7 +178,7 @@
 				const edgeThickness = uniform( 1.0 );
 				const pulsePeriod = uniform( 0 );
 				const visibleEdgeColor = uniform( new THREE.Color( 0xffffff ) );
-				const hiddenEdgeColor = uniform( new THREE.Color( 0x190a05 ) );
+				const hiddenEdgeColor = uniform( new THREE.Color( 0x4e3636 ) );
 
 				outlinePass = outline( scene, camera, {
 					selectedObjects,
@@ -208,8 +208,16 @@
 				gui.add( edgeGlow, 'value', 0.0, 1 ).name( 'edgeGlow' );
 				gui.add( edgeThickness, 'value', 1, 4 ).name( 'edgeThickness' );
 				gui.add( pulsePeriod, 'value', 0.0, 5 ).name( 'pulsePeriod' );
-				gui.addColor( visibleEdgeColor, 'value' ).name( 'visibleEdgeColor' );
-				gui.addColor( hiddenEdgeColor, 'value' ).name( 'hiddenEdgeColor' );
+				gui.addColor( { color: visibleEdgeColor.value.getHex( THREE.SRGBColorSpace ) }, 'color' ).onChange( ( value ) => {
+
+					visibleEdgeColor.value.set( value );
+
+				} ).name( 'visibleEdgeColor' );
+				gui.addColor( { color: hiddenEdgeColor.value.getHex( THREE.SRGBColorSpace ) }, 'color' ).onChange( ( value ) => {
+
+					hiddenEdgeColor.value.set( value );
+
+				} ).name( 'hiddenEdgeColor' );
 
 				//
 


### PR DESCRIPTION
Related issue: -

**Description**

The PR updates the hidden edge color value in `webgpu_postprocessing_outline` so the hidden part of the outline is more visible. Besides, it ensures `lil-gui` actually shows sRGB values (they were in `linear-srgb` color space before).