### PR TITLE
WebGLRenderer: Correctly generate mipmaps for 3D & Array RenderTargets 

### DIFF
--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -123,7 +123,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 		if ( texture.isWebGL3DRenderTarget ) return _gl.TEXTURE_3D;
 		if ( texture.isWebGLArrayRenderTarget || texture.isCompressedArrayTexture ) return _gl.TEXTURE_2D_ARRAY;
 		return _gl.TEXTURE_2D;
-		
+
 	}
 
 	function getInternalFormat( internalFormatName, glFormat, glType, colorSpace, forceLinearTransfer = false ) {

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -117,6 +117,15 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 	}
 
+	function getTextureType( texture ) {
+
+		if ( texture.isWebGLCubeRenderTarget ) return _gl.TEXTURE_CUBE_MAP;
+		if ( texture.isWebGL3DRenderTarget ) return _gl.TEXTURE_3D;
+		if ( texture.isWebGLArrayRenderTarget || texture.isCompressedArrayTexture ) return _gl.TEXTURE_2D_ARRAY;
+		return _gl.TEXTURE_2D;
+		
+	}
+
 	function getInternalFormat( internalFormatName, glFormat, glType, colorSpace, forceLinearTransfer = false ) {
 
 		if ( internalFormatName !== null ) {
@@ -1927,11 +1936,11 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 			if ( textureNeedsGenerateMipmaps( texture ) ) {
 
-				const target = renderTarget.isWebGLCubeRenderTarget ? _gl.TEXTURE_CUBE_MAP : _gl.TEXTURE_2D;
+				const textureType = getTextureType( texture );
 				const webglTexture = properties.get( texture ).__webglTexture;
 
-				state.bindTexture( target, webglTexture );
-				generateMipmap( target );
+				state.bindTexture( textureType, webglTexture );
+				generateMipmap( textureType );
 				state.unbindTexture();
 
 			}

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -117,7 +117,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 	}
 
-	function getTextureType( texture ) {
+	function getTargetType( texture ) {
 
 		if ( texture.isWebGLCubeRenderTarget ) return _gl.TEXTURE_CUBE_MAP;
 		if ( texture.isWebGL3DRenderTarget ) return _gl.TEXTURE_3D;
@@ -1936,11 +1936,11 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 			if ( textureNeedsGenerateMipmaps( texture ) ) {
 
-				const textureType = getTextureType( texture );
+				const targetType = getTargetType( renderTarget );
 				const webglTexture = properties.get( texture ).__webglTexture;
 
-				state.bindTexture( textureType, webglTexture );
-				generateMipmap( textureType );
+				state.bindTexture( targetType, webglTexture );
+				generateMipmap( targetType );
 				state.unbindTexture();
 
 			}


### PR DESCRIPTION
Fixed #29628

**Description**

This PR ensures that the correct target type is passed into "bindTexture" for array and 3d render targets.

I've tested this with my 3d tiles use case and it works but the downside is that it's _extremely_ slow and causes noticeable stalls (sometimes for what feels like almost a second or more) since `gl.generateMipmap` will regenerate the mipmaps for the _whole_ volume target when just a single layer has been rendered to. This is especially problematic when rendering multiple layers per frame since that means the mip chain for the whole 3d texture will be generated every render (in this case ~256x256x900px). So for my use case I'll need something a bit different. Jotting a few potential thoughts down - maybe others have some better ideas:

- Only regenerate the mipmap after all layers have been rendered for a single frame (probably still too expensive for this particular case but probably useful for other 3d render target use cases).
- Copy texture data to a 2d render target to generate mipmaps and then copy the whole mip change to the target layer (only works for array texture targets).