### PR TITLE
Update Line.js

### DIFF
--- a/src/objects/Line.js
+++ b/src/objects/Line.js
@@ -100,7 +100,7 @@ class Line extends Object3D {
 		_inverseMatrix.copy( matrixWorld ).invert();
 		_ray.copy( raycaster.ray ).applyMatrix4( _inverseMatrix );
 
-    const scaleMax = matrixWorld.getMaxScaleOnAxis();
+		const scaleMax = matrixWorld.getMaxScaleOnAxis();
 		const localThreshold = threshold / scaleMax;
 		const localThresholdSq = localThreshold * localThreshold;
 

--- a/src/objects/Line.js
+++ b/src/objects/Line.js
@@ -100,7 +100,8 @@ class Line extends Object3D {
 		_inverseMatrix.copy( matrixWorld ).invert();
 		_ray.copy( raycaster.ray ).applyMatrix4( _inverseMatrix );
 
-		const localThreshold = threshold / ( ( this.scale.x + this.scale.y + this.scale.z ) / 3 );
+    const scaleMax = matrixWorld.getMaxScaleOnAxis();
+		const localThreshold = threshold / scaleMax;
 		const localThresholdSq = localThreshold * localThreshold;
 
 		const step = this.isLineSegments ? 2 : 1;


### PR DESCRIPTION
Modify a bug in ray intersection for line objects

Related issue: #If a sub object of a group object contains polylines, and the group object is scaled larger by the thi.scale parameter, the threshold parameter applied during ray intersection is not synchronously scaled larger, resulting in errors in ray intersection to many line segments.Sorry, my English is very poor.

**Description**
Calculate the correct threshold value using the scaling factor of the matrixWorld. Previously, we used the scaling factor of the local matrix, but there was no valid scaling factor for the children nodes in the local matrix. The original scaling calculation method was too rough and inaccurate:
'const localThreshold = threshold / ( ( this.scale.x + this.scale.y + this.scale.z ) / 3 );'

The new way is:
const scaleMax = matrixWorld.getMaxScaleOnAxis();//
const localThreshold = threshold / scaleMax;

Use the world matrix and find the maximum coefficient


