### PR TITLE
WebGPUTextureUtils: Disable uv transform.

### DIFF
--- a/examples/jsm/utils/WebGPUTextureUtils.js
+++ b/examples/jsm/utils/WebGPUTextureUtils.js
@@ -19,6 +19,13 @@ export async function decompress( blitTexture, maxTextureSize = Infinity, render
 	}
 
 	const material = new NodeMaterial();
+
+	// disable uv transform
+	const currentTextureMatrix = blitTexture.matrix.clone();
+	const currentTextureMatrixAutoUpdate = blitTexture.matrixAutoUpdate;
+	blitTexture.matrix.identity();
+	blitTexture.matrixAutoUpdate = false;
+
 	material.fragmentNode = texture( blitTexture ).uv( uv().flipY() );
 
 	const width = Math.min( blitTexture.image.width, maxTextureSize );
@@ -57,6 +64,11 @@ export async function decompress( blitTexture, maxTextureSize = Infinity, render
 		_renderer = null;
 
 	}
+
+	// restore
+
+	blitTexture.matrix.copy( currentTextureMatrix );
+	blitTexture.matrixAutoUpdate = currentTextureMatrixAutoUpdate;
 
 	return readableTexture;
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/29509#issuecomment-2418373853

**Description**

When decompressing textures it's important to ignore the current uv transform of the texture since custom texture coordinates are used for the copy.
