### PR TITLE
LineGeometry: Override `setFromPoints()`.

### DIFF
--- a/docs/examples/en/lines/LineGeometry.html
+++ b/docs/examples/en/lines/LineGeometry.html
@@ -75,6 +75,12 @@
 			The length must be a multiple of three.
 		</p>
 
+		<h3>[method:this setFromPoints]( [param:Array points] )</h3>
+		<p>
+			Replace the vertex positions with an array of points.
+			Can be either a `Vector3` or `Vector2` array.
+		</p>
+
 		<h2>Source</h2>
 
 		<p>

--- a/examples/jsm/lines/LineGeometry.js
+++ b/examples/jsm/lines/LineGeometry.js
@@ -62,6 +62,31 @@ class LineGeometry extends LineSegmentsGeometry {
 
 	}
 
+	setFromPoints( points ) {
+
+		// converts a vector3 or vector2 array to pairs format
+
+		const length = points.length - 1;
+		const positions = new Float32Array( 6 * length );
+
+		for ( let i = 0; i < length; i ++ ) {
+
+			positions[ 6 * i ] = points[ i ].x;
+			positions[ 6 * i + 1 ] = points[ i ].y;
+			positions[ 6 * i + 2 ] = points[ i ].z || 0;
+
+			positions[ 6 * i + 3 ] = points[ i + 1 ].x;
+			positions[ 6 * i + 4 ] = points[ i + 1 ].y;
+			positions[ 6 * i + 5 ] = points[ i + 1 ].z || 0;
+
+		}
+
+		super.setPositions( positions );
+
+		return this;
+
+	}
+
 	fromLine( line ) {
 
 		const geometry = line.geometry;


### PR DESCRIPTION
**Description**

This overrides the `setFromPoints` method inherited by `BufferGeometry` so that it can be used to set the vertex positions on a `LineGeometry`. 

```js
const points = curve.getPoints(100);

const geometry = new LineGeometry();
geometry.setFromPoints(points); // Takes Vector3[] or Vector2[]
```

I think this could be more intuitive since previously, `setFromPoints` would be suggested by intellisense but would not work.


