### PR TITLE
WebGPURenderer: Introduce waitForGPU

### DIFF
--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -395,9 +395,9 @@ class Renderer {
 
 	}
 
-	async syncWithGPU() {
+	async waitForGPUWorkDone() {
 
-		await this.backend.syncWithGPU();
+		await this.backend.waitForGPUWorkDone();
 
 	}
 

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -395,6 +395,12 @@ class Renderer {
 
 	}
 
+	async syncWithGPU() {
+
+		await this.backend.syncWithGPU();
+
+	}
+
 	setMRT( mrt ) {
 
 		this._mrt = mrt;

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -395,9 +395,9 @@ class Renderer {
 
 	}
 
-	async waitForGPUWorkDone() {
+	async waitForGPU() {
 
-		await this.backend.waitForGPUWorkDone();
+		await this.backend.waitForGPU();
 
 	}
 

--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -81,6 +81,11 @@ class WebGLBackend extends Backend {
 
 	}
 
+	async syncWithGPU() {
+
+		await this.utils._clientWaitAsync();
+
+	}
 
 	initTimestampQuery( renderContext ) {
 

--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -81,7 +81,7 @@ class WebGLBackend extends Backend {
 
 	}
 
-	async waitForGPUWorkDone() {
+	async waitForGPU() {
 
 		await this.utils._clientWaitAsync();
 

--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -81,7 +81,7 @@ class WebGLBackend extends Backend {
 
 	}
 
-	async syncWithGPU() {
+	async waitForGPUWorkDone() {
 
 		await this.utils._clientWaitAsync();
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -835,7 +835,7 @@ class WebGPUBackend extends Backend {
 
 	}
 
-	async waitForGPUWorkDone() {
+	async waitForGPU() {
 
 		await this.device.queue.onSubmittedWorkDone();
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -823,7 +823,7 @@ class WebGPUBackend extends Backend {
 
 	}
 
-	finishCompute( computeGroup ) {
+	async finishCompute( computeGroup ) {
 
 		const groupData = this.get( computeGroup );
 
@@ -832,6 +832,12 @@ class WebGPUBackend extends Backend {
 		this.prepareTimestampBuffer( computeGroup, groupData.cmdEncoderGPU );
 
 		this.device.queue.submit( [ groupData.cmdEncoderGPU.finish() ] );
+
+	}
+
+	async syncWithGPU() {
+
+		await this.device.queue.onSubmittedWorkDone();
 
 	}
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -823,7 +823,7 @@ class WebGPUBackend extends Backend {
 
 	}
 
-	async finishCompute( computeGroup ) {
+	finishCompute( computeGroup ) {
 
 		const groupData = this.get( computeGroup );
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -835,7 +835,7 @@ class WebGPUBackend extends Backend {
 
 	}
 
-	async syncWithGPU() {
+	async waitForGPUWorkDone() {
 
 		await this.device.queue.onSubmittedWorkDone();
 


### PR DESCRIPTION
**Description**

This pull request introduces a new `waitForGPU` helper to the codebase, offering a unified method for synchronizing CPU operations with GPU tasks across both WebGPU and WebGL contexts.


Example usage:

```js
const compute = async (veryHeavyComputeProgram) => {

    renderer.compute(veryHeavyComputeProgram)
    await renderer.waitForGPU() // Ensures the CPU waits for the GPU to complete its operations
    await renderer.backend.resolveTimestampAsync( veryHeavyComputeProgram, 'compute' );
}
```

Note: 
- `waitForGPU` is not included in `computeAsync` and `renderAsync` by default due to potential performance implications. This method forces the CPU to wait for the GPU to fully resolve its operations, which can cause stalls, particularly in WebGL where fenceSync is used.
- The helper is designed for specific edge cases where precise synchronization is required between CPU and GPU, and not for typical rendering or compute loops. By leaving it out of core methods, we allow users to control synchronization manually and apply it only when absolutely necessary.
- This approach is particularly useful in WebGPU, where `onSubmittedWorkDone()` can achieve the desired behavior without stalling the CPU. However, in the case of WebGL it might cause main thread stalls due to the fenceSync logic.


*This contribution is funded by [Utsubo](https://utsubo.com)*
