### PR TITLE
BatchedMesh: Consolidate internal geometry information 

### DIFF
--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -78,7 +78,10 @@ class MultiDrawRenderList {
 }
 
 const _matrix = /*@__PURE__*/ new Matrix4();
+const _invMatrixWorld = /*@__PURE__*/ new Matrix4();
+const _identityMatrix = /*@__PURE__*/ new Matrix4();
 const _whiteColor = /*@__PURE__*/ new Color( 1, 1, 1 );
+const _projScreenMatrix = /*@__PURE__*/ new Matrix4();
 const _frustum = /*@__PURE__*/ new Frustum();
 const _box = /*@__PURE__*/ new Box3();
 const _sphere = /*@__PURE__*/ new Sphere();
@@ -422,7 +425,7 @@ class BatchedMesh extends Mesh {
 		}
 
 		const matricesTexture = this._matricesTexture;
-		_matrix.identity().toArray( matricesTexture.image.data, drawId * 16 );
+		_identityMatrix.toArray( matricesTexture.image.data, drawId * 16 );
 		matricesTexture.needsUpdate = true;
 
 		const colorsTexture = this._colorsTexture;
@@ -1264,11 +1267,11 @@ class BatchedMesh extends Mesh {
 		// prepare the frustum in the local frame
 		if ( perObjectFrustumCulled ) {
 
-			_matrix
+			_projScreenMatrix
 				.multiplyMatrices( camera.projectionMatrix, camera.matrixWorldInverse )
 				.multiply( this.matrixWorld );
 			_frustum.setFromProjectionMatrix(
-				_matrix,
+				_projScreenMatrix,
 				renderer.coordinateSystem
 			);
 
@@ -1278,9 +1281,9 @@ class BatchedMesh extends Mesh {
 		if ( this.sortObjects ) {
 
 			// get the camera position in the local frame
-			_matrix.copy( this.matrixWorld ).invert();
-			_vector.setFromMatrixPosition( camera.matrixWorld ).applyMatrix4( _matrix );
-			_forward.set( 0, 0, - 1 ).transformDirection( camera.matrixWorld ).transformDirection( _matrix );
+			_invMatrixWorld.copy( this.matrixWorld ).invert();
+			_vector.setFromMatrixPosition( camera.matrixWorld ).applyMatrix4( _invMatrixWorld );
+			_forward.set( 0, 0, - 1 ).transformDirection( camera.matrixWorld ).transformDirection( _invMatrixWorld );
 
 			for ( let i = 0, l = drawInfo.length; i < l; i ++ ) {
 

--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -721,7 +721,7 @@ class BatchedMesh extends Mesh {
 
 				}
 
-				nextIndexStart += geometryInfo.indexCount;
+				nextIndexStart += geometryInfo.reservedIndexCount;
 
 			}
 
@@ -743,7 +743,7 @@ class BatchedMesh extends Mesh {
 
 			}
 
-			nextVertexStart += geometryInfo.vertexCount;
+			nextVertexStart += geometryInfo.reservedVertexCount;
 
 			// step the next geometry points to the shifted position
 			this._nextIndexStart = geometry.index ? geometryInfo.indexStart + geometryInfo.reservedIndexCount : 0;

--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -152,7 +152,7 @@ class BatchedMesh extends Mesh {
 
 	get instanceCount() {
 
-		return this._drawInfo.length - this._availableInstanceIds.length;
+		return this._instanceInfo.length - this._availableInstanceIds.length;
 
 	}
 
@@ -180,7 +180,7 @@ class BatchedMesh extends Mesh {
 		this.customSort = null;
 
 		// stores visible, active, and geometry id per instance and reserved buffer ranges for geometries
-		this._drawInfo = [];
+		this._instanceInfo = [];
 		this._geometryInfo = [];
 
 		// instance, geometry ids that have been set as inactive, and are available to be overwritten
@@ -346,14 +346,14 @@ class BatchedMesh extends Mesh {
 		}
 
 		const boundingBox = this.boundingBox;
-		const drawInfo = this._drawInfo;
+		const instanceInfo = this._instanceInfo;
 
 		boundingBox.makeEmpty();
-		for ( let i = 0, l = drawInfo.length; i < l; i ++ ) {
+		for ( let i = 0, l = instanceInfo.length; i < l; i ++ ) {
 
-			if ( drawInfo[ i ].active === false ) continue;
+			if ( instanceInfo[ i ].active === false ) continue;
 
-			const geometryId = drawInfo[ i ].geometryIndex;
+			const geometryId = instanceInfo[ i ].geometryIndex;
 			this.getMatrixAt( i, _matrix );
 			this.getBoundingBoxAt( geometryId, _box ).applyMatrix4( _matrix );
 			boundingBox.union( _box );
@@ -371,14 +371,14 @@ class BatchedMesh extends Mesh {
 		}
 
 		const boundingSphere = this.boundingSphere;
-		const drawInfo = this._drawInfo;
+		const instanceInfo = this._instanceInfo;
 
 		boundingSphere.makeEmpty();
-		for ( let i = 0, l = drawInfo.length; i < l; i ++ ) {
+		for ( let i = 0, l = instanceInfo.length; i < l; i ++ ) {
 
-			if ( drawInfo[ i ].active === false ) continue;
+			if ( instanceInfo[ i ].active === false ) continue;
 
-			const geometryId = drawInfo[ i ].geometryIndex;
+			const geometryId = instanceInfo[ i ].geometryIndex;
 			this.getMatrixAt( i, _matrix );
 			this.getBoundingSphereAt( geometryId, _sphere ).applyMatrix4( _matrix );
 			boundingSphere.union( _sphere );
@@ -389,7 +389,7 @@ class BatchedMesh extends Mesh {
 
 	addInstance( geometryId ) {
 
-		const atCapacity = this._drawInfo.length >= this.maxInstanceCount;
+		const atCapacity = this._instanceInfo.length >= this.maxInstanceCount;
 
 		// ensure we're not over geometry
 		if ( atCapacity && this._availableInstanceIds.length === 0 ) {
@@ -398,7 +398,7 @@ class BatchedMesh extends Mesh {
 
 		}
 
-		const instanceDrawInfo = {
+		const instanceInfo = {
 			visible: true,
 			active: true,
 			geometryIndex: geometryId,
@@ -412,12 +412,12 @@ class BatchedMesh extends Mesh {
 			this._availableInstanceIds.sort( ascIdSort );
 
 			drawId = this._availableInstanceIds.shift();
-			this._drawInfo[ drawId ] = instanceDrawInfo;
+			this._instanceInfo[ drawId ] = instanceInfo;
 
 		} else {
 
-			drawId = this._drawInfo.length;
-			this._drawInfo.push( instanceDrawInfo );
+			drawId = this._instanceInfo.length;
+			this._instanceInfo.push( instanceInfo );
 
 		}
 
@@ -631,10 +631,10 @@ class BatchedMesh extends Mesh {
 		}
 
 		// delete any instances associated with this geometry
-		const drawInfo = this._drawInfo;
-		for ( let i = 0, l = drawInfo.length; i < l; i ++ ) {
+		const instanceInfo = this._instanceInfo;
+		for ( let i = 0, l = instanceInfo.length; i < l; i ++ ) {
 
-			if ( drawInfo[ i ].geometryIndex === geometryId ) {
+			if ( instanceInfo[ i ].geometryIndex === geometryId ) {
 
 				this.deleteInstance( i );
 
@@ -652,14 +652,14 @@ class BatchedMesh extends Mesh {
 
 	deleteInstance( instanceId ) {
 
-		const drawInfo = this._drawInfo;
-		if ( instanceId >= drawInfo.length || drawInfo[ instanceId ].active === false ) {
+		const instanceInfo = this._instanceInfo;
+		if ( instanceId >= instanceInfo.length || instanceInfo[ instanceId ].active === false ) {
 
 			return this;
 
 		}
 
-		drawInfo[ instanceId ].active = false;
+		instanceInfo[ instanceId ].active = false;
 		this._availableInstanceIds.push( instanceId );
 		this._visibilityChanged = true;
 
@@ -842,10 +842,10 @@ class BatchedMesh extends Mesh {
 
 	setMatrixAt( instanceId, matrix ) {
 
-		const drawInfo = this._drawInfo;
+		const instanceInfo = this._instanceInfo;
 		const matricesTexture = this._matricesTexture;
 		const matricesArray = this._matricesTexture.image.data;
-		if ( instanceId >= drawInfo.length || drawInfo[ instanceId ].active === false ) {
+		if ( instanceId >= instanceInfo.length || instanceInfo[ instanceId ].active === false ) {
 
 			return this;
 
@@ -860,9 +860,9 @@ class BatchedMesh extends Mesh {
 
 	getMatrixAt( instanceId, matrix ) {
 
-		const drawInfo = this._drawInfo;
+		const instanceInfo = this._instanceInfo;
 		const matricesArray = this._matricesTexture.image.data;
-		if ( instanceId >= drawInfo.length || drawInfo[ instanceId ].active === false ) {
+		if ( instanceId >= instanceInfo.length || instanceInfo[ instanceId ].active === false ) {
 
 			return null;
 
@@ -882,8 +882,8 @@ class BatchedMesh extends Mesh {
 
 		const colorsTexture = this._colorsTexture;
 		const colorsArray = this._colorsTexture.image.data;
-		const drawInfo = this._drawInfo;
-		if ( instanceId >= drawInfo.length || drawInfo[ instanceId ].active === false ) {
+		const instanceInfo = this._instanceInfo;
+		if ( instanceId >= instanceInfo.length || instanceInfo[ instanceId ].active === false ) {
 
 			return this;
 
@@ -899,8 +899,8 @@ class BatchedMesh extends Mesh {
 	getColorAt( instanceId, color ) {
 
 		const colorsArray = this._colorsTexture.image.data;
-		const drawInfo = this._drawInfo;
-		if ( instanceId >= drawInfo.length || drawInfo[ instanceId ].active === false ) {
+		const instanceInfo = this._instanceInfo;
+		if ( instanceId >= instanceInfo.length || instanceInfo[ instanceId ].active === false ) {
 
 			return null;
 
@@ -914,18 +914,18 @@ class BatchedMesh extends Mesh {
 
 		// if the geometry is out of range, not active, or visibility state
 		// does not change then return early
-		const drawInfo = this._drawInfo;
+		const instanceInfo = this._instanceInfo;
 		if (
-			instanceId >= drawInfo.length ||
-			drawInfo[ instanceId ].active === false ||
-			drawInfo[ instanceId ].visible === value
+			instanceId >= instanceInfo.length ||
+			instanceInfo[ instanceId ].active === false ||
+			instanceInfo[ instanceId ].visible === value
 		) {
 
 			return this;
 
 		}
 
-		drawInfo[ instanceId ].visible = value;
+		instanceInfo[ instanceId ].visible = value;
 		this._visibilityChanged = true;
 
 		return this;
@@ -935,23 +935,23 @@ class BatchedMesh extends Mesh {
 	getVisibleAt( instanceId ) {
 
 		// return early if the geometry is out of range or not active
-		const drawInfo = this._drawInfo;
-		if ( instanceId >= drawInfo.length || drawInfo[ instanceId ].active === false ) {
+		const instanceInfo = this._instanceInfo;
+		if ( instanceId >= instanceInfo.length || instanceInfo[ instanceId ].active === false ) {
 
 			return false;
 
 		}
 
-		return drawInfo[ instanceId ].visible;
+		return instanceInfo[ instanceId ].visible;
 
 	}
 
 	setGeometryIdAt( instanceId, geometryId ) {
 
 		// return early if the geometry is out of range or not active
-		const drawInfo = this._drawInfo;
+		const instanceInfo = this._instanceInfo;
 		const geometryInfoList = this._geometryInfo;
-		if ( instanceId >= drawInfo.length || drawInfo[ instanceId ].active === false ) {
+		if ( instanceId >= instanceInfo.length || instanceInfo[ instanceId ].active === false ) {
 
 			return null;
 
@@ -964,7 +964,7 @@ class BatchedMesh extends Mesh {
 
 		}
 
-		drawInfo[ instanceId ].geometryIndex = geometryId;
+		instanceInfo[ instanceId ].geometryIndex = geometryId;
 
 		return this;
 
@@ -972,14 +972,14 @@ class BatchedMesh extends Mesh {
 
 	getGeometryIdAt( instanceId ) {
 
-		const drawInfo = this._drawInfo;
-		if ( instanceId >= drawInfo.length || drawInfo[ instanceId ].active === false ) {
+		const instanceInfo = this._instanceInfo;
+		if ( instanceId >= instanceInfo.length || instanceInfo[ instanceId ].active === false ) {
 
 			return - 1;
 
 		}
 
-		return drawInfo[ instanceId ].geometryIndex;
+		return instanceInfo[ instanceId ].geometryIndex;
 
 	}
 
@@ -1011,17 +1011,17 @@ class BatchedMesh extends Mesh {
 
 		// shrink the available instances as much as possible
 		const availableInstanceIds = this._availableInstanceIds;
-		const drawInfo = this._drawInfo;
+		const instanceInfo = this._instanceInfo;
 		availableInstanceIds.sort( ascIdSort );
-		while ( availableInstanceIds[ availableInstanceIds.length - 1 ] === drawInfo.length ) {
+		while ( availableInstanceIds[ availableInstanceIds.length - 1 ] === instanceInfo.length ) {
 
-			drawInfo.pop();
+			instanceInfo.pop();
 			availableInstanceIds.pop();
 
 		}
 
 		// throw an error if it can't be shrunk to the desired size
-		if ( maxInstanceCount < drawInfo.length ) {
+		if ( maxInstanceCount < instanceInfo.length ) {
 
 			throw new Error( `BatchedMesh: Instance ids outside the range ${ maxInstanceCount } are being used. Cannot shrink instance count.` );
 
@@ -1115,7 +1115,7 @@ class BatchedMesh extends Mesh {
 
 	raycast( raycaster, intersects ) {
 
-		const drawInfo = this._drawInfo;
+		const instanceInfo = this._instanceInfo;
 		const geometryInfoList = this._geometryInfo;
 		const matrixWorld = this.matrixWorld;
 		const batchGeometry = this.geometry;
@@ -1136,15 +1136,15 @@ class BatchedMesh extends Mesh {
 
 		}
 
-		for ( let i = 0, l = drawInfo.length; i < l; i ++ ) {
+		for ( let i = 0, l = instanceInfo.length; i < l; i ++ ) {
 
-			if ( ! drawInfo[ i ].visible || ! drawInfo[ i ].active ) {
+			if ( ! instanceInfo[ i ].visible || ! instanceInfo[ i ].active ) {
 
 				continue;
 
 			}
 
-			const geometryId = drawInfo[ i ].geometryIndex;
+			const geometryId = instanceInfo[ i ].geometryIndex;
 			const geometryInfo = geometryInfoList[ geometryId ];
 			_mesh.geometry.setDrawRange( geometryInfo.start, geometryInfo.count );
 
@@ -1191,7 +1191,7 @@ class BatchedMesh extends Mesh {
 			boundingBox: info.boundingBox !== null ? info.boundingBox.clone() : null,
 			boundingSphere: info.boundingSphere !== null ? info.boundingSphere.clone() : null,
 		} ) );
-		this._drawInfo = source._drawInfo.map( info => ( { ...info } ) );
+		this._instanceInfo = source._instanceInfo.map( info => ( { ...info } ) );
 
 		this._maxInstanceCount = source._maxInstanceCount;
 		this._maxVertexCount = source._maxVertexCount;
@@ -1253,7 +1253,7 @@ class BatchedMesh extends Mesh {
 		const index = geometry.getIndex();
 		const bytesPerElement = index === null ? 1 : index.array.BYTES_PER_ELEMENT;
 
-		const drawInfo = this._drawInfo;
+		const instanceInfo = this._instanceInfo;
 		const multiDrawStarts = this._multiDrawStarts;
 		const multiDrawCounts = this._multiDrawCounts;
 		const geometryInfoList = this._geometryInfo;
@@ -1282,11 +1282,11 @@ class BatchedMesh extends Mesh {
 			_vector.setFromMatrixPosition( camera.matrixWorld ).applyMatrix4( _matrix );
 			_forward.set( 0, 0, - 1 ).transformDirection( camera.matrixWorld ).transformDirection( _matrix );
 
-			for ( let i = 0, l = drawInfo.length; i < l; i ++ ) {
+			for ( let i = 0, l = instanceInfo.length; i < l; i ++ ) {
 
-				if ( drawInfo[ i ].visible && drawInfo[ i ].active ) {
+				if ( instanceInfo[ i ].visible && instanceInfo[ i ].active ) {
 
-					const geometryId = drawInfo[ i ].geometryIndex;
+					const geometryId = instanceInfo[ i ].geometryIndex;
 
 					// get the bounds in world space
 					this.getMatrixAt( i, _matrix );
@@ -1340,11 +1340,11 @@ class BatchedMesh extends Mesh {
 
 		} else {
 
-			for ( let i = 0, l = drawInfo.length; i < l; i ++ ) {
+			for ( let i = 0, l = instanceInfo.length; i < l; i ++ ) {
 
-				if ( drawInfo[ i ].visible && drawInfo[ i ].active ) {
+				if ( instanceInfo[ i ].visible && instanceInfo[ i ].active ) {
 
-					const geometryId = drawInfo[ i ].geometryIndex;
+					const geometryId = instanceInfo[ i ].geometryIndex;
 
 					// determine whether the batched geometry is within the frustum
 					let culled = false;

--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -153,24 +153,6 @@ class BatchedMesh extends Mesh {
 
 	}
 
-	get instanceCount() {
-
-		return this._drawInfo.length - this._availableInstanceIds.length;
-
-	}
-
-	get unusedVertexCount() {
-
-		return this._maxVertexCount - this._nextVertexStart;
-
-	}
-
-	get unusedIndexCount() {
-
-		return this._maxIndexCount - this._nextIndexStart;
-
-	}
-
 	constructor( maxInstanceCount, maxVertexCount, maxIndexCount = maxVertexCount * 2, material ) {
 
 		super( new BufferGeometry(), material );

--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -40,7 +40,7 @@ class MultiDrawRenderList {
 
 	}
 
-	push( drawRange, z, index ) {
+	push( start, count, z, index ) {
 
 		const pool = this.pool;
 		const list = this.list;
@@ -61,8 +61,8 @@ class MultiDrawRenderList {
 		list.push( item );
 		this.index ++;
 
-		item.start = drawRange.start;
-		item.count = drawRange.count;
+		item.start = start;
+		item.count = count;
 		item.z = z;
 		item.index = index;
 
@@ -1306,8 +1306,11 @@ class BatchedMesh extends Mesh {
 					if ( ! culled ) {
 
 						// get the distance from camera used for sorting
+						const geometryInfo = geometryInfoList[ geometryId ];
 						const z = _temp.subVectors( _sphere.center, _vector ).dot( _forward );
-						_renderList.push( geometryInfoList[ geometryId ], z, i );
+						const start = index ? geometryInfo.indexStart : geometryInfo.vertexStart;
+						const count = index ? geometryInfo.indexCount : geometryInfo.vertexCount;
+						_renderList.push( start, count, z, i );
 
 					}
 
@@ -1331,11 +1334,9 @@ class BatchedMesh extends Mesh {
 			for ( let i = 0, l = list.length; i < l; i ++ ) {
 
 				const item = list[ i ];
-				const start = index ? item.indexStart : item.vertexStart;
-				const count = index ? item.indexCount : item.vertexCount;
-				multiDrawStarts[ multiDrawCount ] = start * bytesPerElement;
-				multiDrawCounts[ multiDrawCount ] = count;
-				indirectArray[ multiDrawCount ] = index;
+				multiDrawStarts[ multiDrawCount ] = item.start * bytesPerElement;
+				multiDrawCounts[ multiDrawCount ] = item.count;
+				indirectArray[ multiDrawCount ] = item.index;
 				multiDrawCount ++;
 
 			}

--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -1277,7 +1277,7 @@ class BatchedMesh extends Mesh {
 
 		}
 
-		let multiDrawCount = 0;
+		let count = 0;
 		if ( this.sortObjects ) {
 
 			// get the camera position in the local frame
@@ -1332,10 +1332,10 @@ class BatchedMesh extends Mesh {
 			for ( let i = 0, l = list.length; i < l; i ++ ) {
 
 				const item = list[ i ];
-				multiDrawStarts[ multiDrawCount ] = item.start * bytesPerElement;
-				multiDrawCounts[ multiDrawCount ] = item.count;
-				indirectArray[ multiDrawCount ] = item.index;
-				multiDrawCount ++;
+				multiDrawStarts[ count ] = item.start * bytesPerElement;
+				multiDrawCounts[ count ] = item.count;
+				indirectArray[ count ] = item.index;
+				count ++;
 
 			}
 
@@ -1363,10 +1363,10 @@ class BatchedMesh extends Mesh {
 					if ( ! culled ) {
 
 						const geometryInfo = geometryInfoList[ geometryId ];
-						multiDrawStarts[ multiDrawCount ] = geometryInfo.start * bytesPerElement;
-						multiDrawCounts[ multiDrawCount ] = geometryInfo.count;
-						indirectArray[ multiDrawCount ] = i;
-						multiDrawCount ++;
+						multiDrawStarts[ count ] = geometryInfo.start * bytesPerElement;
+						multiDrawCounts[ count ] = geometryInfo.count;
+						indirectArray[ count ] = i;
+						count ++;
 
 					}
 
@@ -1377,7 +1377,7 @@ class BatchedMesh extends Mesh {
 		}
 
 		indirectTexture.needsUpdate = true;
-		this._multiDrawCount = multiDrawCount;
+		this._multiDrawCount = count;
 		this._visibilityChanged = false;
 
 	}

--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -152,7 +152,7 @@ class BatchedMesh extends Mesh {
 
 	get instanceCount() {
 
-		return this._instanceInfo.length - this._availableInstanceIds.length;
+		return this._drawInfo.length - this._availableInstanceIds.length;
 
 	}
 
@@ -180,7 +180,7 @@ class BatchedMesh extends Mesh {
 		this.customSort = null;
 
 		// stores visible, active, and geometry id per instance and reserved buffer ranges for geometries
-		this._instanceInfo = [];
+		this._drawInfo = [];
 		this._geometryInfo = [];
 
 		// instance, geometry ids that have been set as inactive, and are available to be overwritten
@@ -346,14 +346,14 @@ class BatchedMesh extends Mesh {
 		}
 
 		const boundingBox = this.boundingBox;
-		const instanceInfo = this._instanceInfo;
+		const drawInfo = this._drawInfo;
 
 		boundingBox.makeEmpty();
-		for ( let i = 0, l = instanceInfo.length; i < l; i ++ ) {
+		for ( let i = 0, l = drawInfo.length; i < l; i ++ ) {
 
-			if ( instanceInfo[ i ].active === false ) continue;
+			if ( drawInfo[ i ].active === false ) continue;
 
-			const geometryId = instanceInfo[ i ].geometryIndex;
+			const geometryId = drawInfo[ i ].geometryIndex;
 			this.getMatrixAt( i, _matrix );
 			this.getBoundingBoxAt( geometryId, _box ).applyMatrix4( _matrix );
 			boundingBox.union( _box );
@@ -371,14 +371,14 @@ class BatchedMesh extends Mesh {
 		}
 
 		const boundingSphere = this.boundingSphere;
-		const instanceInfo = this._instanceInfo;
+		const drawInfo = this._drawInfo;
 
 		boundingSphere.makeEmpty();
-		for ( let i = 0, l = instanceInfo.length; i < l; i ++ ) {
+		for ( let i = 0, l = drawInfo.length; i < l; i ++ ) {
 
-			if ( instanceInfo[ i ].active === false ) continue;
+			if ( drawInfo[ i ].active === false ) continue;
 
-			const geometryId = instanceInfo[ i ].geometryIndex;
+			const geometryId = drawInfo[ i ].geometryIndex;
 			this.getMatrixAt( i, _matrix );
 			this.getBoundingSphereAt( geometryId, _sphere ).applyMatrix4( _matrix );
 			boundingSphere.union( _sphere );
@@ -389,7 +389,7 @@ class BatchedMesh extends Mesh {
 
 	addInstance( geometryId ) {
 
-		const atCapacity = this._instanceInfo.length >= this.maxInstanceCount;
+		const atCapacity = this._drawInfo.length >= this.maxInstanceCount;
 
 		// ensure we're not over geometry
 		if ( atCapacity && this._availableInstanceIds.length === 0 ) {
@@ -398,7 +398,7 @@ class BatchedMesh extends Mesh {
 
 		}
 
-		const instanceInfo = {
+		const drawInfo = {
 			visible: true,
 			active: true,
 			geometryIndex: geometryId,
@@ -412,12 +412,12 @@ class BatchedMesh extends Mesh {
 			this._availableInstanceIds.sort( ascIdSort );
 
 			drawId = this._availableInstanceIds.shift();
-			this._instanceInfo[ drawId ] = instanceInfo;
+			this._drawInfo[ drawId ] = drawInfo;
 
 		} else {
 
-			drawId = this._instanceInfo.length;
-			this._instanceInfo.push( instanceInfo );
+			drawId = this._drawInfo.length;
+			this._drawInfo.push( drawInfo );
 
 		}
 
@@ -631,10 +631,10 @@ class BatchedMesh extends Mesh {
 		}
 
 		// delete any instances associated with this geometry
-		const instanceInfo = this._instanceInfo;
-		for ( let i = 0, l = instanceInfo.length; i < l; i ++ ) {
+		const drawInfo = this._drawInfo;
+		for ( let i = 0, l = drawInfo.length; i < l; i ++ ) {
 
-			if ( instanceInfo[ i ].geometryIndex === geometryId ) {
+			if ( drawInfo[ i ].geometryIndex === geometryId ) {
 
 				this.deleteInstance( i );
 
@@ -652,14 +652,14 @@ class BatchedMesh extends Mesh {
 
 	deleteInstance( instanceId ) {
 
-		const instanceInfo = this._instanceInfo;
-		if ( instanceId >= instanceInfo.length || instanceInfo[ instanceId ].active === false ) {
+		const drawInfo = this._drawInfo;
+		if ( instanceId >= drawInfo.length || drawInfo[ instanceId ].active === false ) {
 
 			return this;
 
 		}
 
-		instanceInfo[ instanceId ].active = false;
+		drawInfo[ instanceId ].active = false;
 		this._availableInstanceIds.push( instanceId );
 		this._visibilityChanged = true;
 
@@ -842,10 +842,10 @@ class BatchedMesh extends Mesh {
 
 	setMatrixAt( instanceId, matrix ) {
 
-		const instanceInfo = this._instanceInfo;
+		const drawInfo = this._drawInfo;
 		const matricesTexture = this._matricesTexture;
 		const matricesArray = this._matricesTexture.image.data;
-		if ( instanceId >= instanceInfo.length || instanceInfo[ instanceId ].active === false ) {
+		if ( instanceId >= drawInfo.length || drawInfo[ instanceId ].active === false ) {
 
 			return this;
 
@@ -860,9 +860,9 @@ class BatchedMesh extends Mesh {
 
 	getMatrixAt( instanceId, matrix ) {
 
-		const instanceInfo = this._instanceInfo;
+		const drawInfo = this._drawInfo;
 		const matricesArray = this._matricesTexture.image.data;
-		if ( instanceId >= instanceInfo.length || instanceInfo[ instanceId ].active === false ) {
+		if ( instanceId >= drawInfo.length || drawInfo[ instanceId ].active === false ) {
 
 			return null;
 
@@ -882,8 +882,8 @@ class BatchedMesh extends Mesh {
 
 		const colorsTexture = this._colorsTexture;
 		const colorsArray = this._colorsTexture.image.data;
-		const instanceInfo = this._instanceInfo;
-		if ( instanceId >= instanceInfo.length || instanceInfo[ instanceId ].active === false ) {
+		const drawInfo = this._drawInfo;
+		if ( instanceId >= drawInfo.length || drawInfo[ instanceId ].active === false ) {
 
 			return this;
 
@@ -899,8 +899,8 @@ class BatchedMesh extends Mesh {
 	getColorAt( instanceId, color ) {
 
 		const colorsArray = this._colorsTexture.image.data;
-		const instanceInfo = this._instanceInfo;
-		if ( instanceId >= instanceInfo.length || instanceInfo[ instanceId ].active === false ) {
+		const drawInfo = this._drawInfo;
+		if ( instanceId >= drawInfo.length || drawInfo[ instanceId ].active === false ) {
 
 			return null;
 
@@ -914,18 +914,18 @@ class BatchedMesh extends Mesh {
 
 		// if the geometry is out of range, not active, or visibility state
 		// does not change then return early
-		const instanceInfo = this._instanceInfo;
+		const drawInfo = this._drawInfo;
 		if (
-			instanceId >= instanceInfo.length ||
-			instanceInfo[ instanceId ].active === false ||
-			instanceInfo[ instanceId ].visible === value
+			instanceId >= drawInfo.length ||
+			drawInfo[ instanceId ].active === false ||
+			drawInfo[ instanceId ].visible === value
 		) {
 
 			return this;
 
 		}
 
-		instanceInfo[ instanceId ].visible = value;
+		drawInfo[ instanceId ].visible = value;
 		this._visibilityChanged = true;
 
 		return this;
@@ -935,23 +935,23 @@ class BatchedMesh extends Mesh {
 	getVisibleAt( instanceId ) {
 
 		// return early if the geometry is out of range or not active
-		const instanceInfo = this._instanceInfo;
-		if ( instanceId >= instanceInfo.length || instanceInfo[ instanceId ].active === false ) {
+		const drawInfo = this._drawInfo;
+		if ( instanceId >= drawInfo.length || drawInfo[ instanceId ].active === false ) {
 
 			return false;
 
 		}
 
-		return instanceInfo[ instanceId ].visible;
+		return drawInfo[ instanceId ].visible;
 
 	}
 
 	setGeometryIdAt( instanceId, geometryId ) {
 
 		// return early if the geometry is out of range or not active
-		const instanceInfo = this._instanceInfo;
+		const drawInfo = this._drawInfo;
 		const geometryInfoList = this._geometryInfo;
-		if ( instanceId >= instanceInfo.length || instanceInfo[ instanceId ].active === false ) {
+		if ( instanceId >= drawInfo.length || drawInfo[ instanceId ].active === false ) {
 
 			return null;
 
@@ -964,7 +964,7 @@ class BatchedMesh extends Mesh {
 
 		}
 
-		instanceInfo[ instanceId ].geometryIndex = geometryId;
+		drawInfo[ instanceId ].geometryIndex = geometryId;
 
 		return this;
 
@@ -972,14 +972,14 @@ class BatchedMesh extends Mesh {
 
 	getGeometryIdAt( instanceId ) {
 
-		const instanceInfo = this._instanceInfo;
-		if ( instanceId >= instanceInfo.length || instanceInfo[ instanceId ].active === false ) {
+		const drawInfo = this._drawInfo;
+		if ( instanceId >= drawInfo.length || drawInfo[ instanceId ].active === false ) {
 
 			return - 1;
 
 		}
 
-		return instanceInfo[ instanceId ].geometryIndex;
+		return drawInfo[ instanceId ].geometryIndex;
 
 	}
 
@@ -1011,17 +1011,17 @@ class BatchedMesh extends Mesh {
 
 		// shrink the available instances as much as possible
 		const availableInstanceIds = this._availableInstanceIds;
-		const instanceInfo = this._instanceInfo;
+		const drawInfo = this._drawInfo;
 		availableInstanceIds.sort( ascIdSort );
-		while ( availableInstanceIds[ availableInstanceIds.length - 1 ] === instanceInfo.length ) {
+		while ( availableInstanceIds[ availableInstanceIds.length - 1 ] === drawInfo.length ) {
 
-			instanceInfo.pop();
+			drawInfo.pop();
 			availableInstanceIds.pop();
 
 		}
 
 		// throw an error if it can't be shrunk to the desired size
-		if ( maxInstanceCount < instanceInfo.length ) {
+		if ( maxInstanceCount < drawInfo.length ) {
 
 			throw new Error( `BatchedMesh: Instance ids outside the range ${ maxInstanceCount } are being used. Cannot shrink instance count.` );
 
@@ -1115,7 +1115,7 @@ class BatchedMesh extends Mesh {
 
 	raycast( raycaster, intersects ) {
 
-		const instanceInfo = this._instanceInfo;
+		const drawInfo = this._drawInfo;
 		const geometryInfoList = this._geometryInfo;
 		const matrixWorld = this.matrixWorld;
 		const batchGeometry = this.geometry;
@@ -1136,15 +1136,15 @@ class BatchedMesh extends Mesh {
 
 		}
 
-		for ( let i = 0, l = instanceInfo.length; i < l; i ++ ) {
+		for ( let i = 0, l = drawInfo.length; i < l; i ++ ) {
 
-			if ( ! instanceInfo[ i ].visible || ! instanceInfo[ i ].active ) {
+			if ( ! drawInfo[ i ].visible || ! drawInfo[ i ].active ) {
 
 				continue;
 
 			}
 
-			const geometryId = instanceInfo[ i ].geometryIndex;
+			const geometryId = drawInfo[ i ].geometryIndex;
 			const geometryInfo = geometryInfoList[ geometryId ];
 			_mesh.geometry.setDrawRange( geometryInfo.start, geometryInfo.count );
 
@@ -1191,7 +1191,7 @@ class BatchedMesh extends Mesh {
 			boundingBox: info.boundingBox !== null ? info.boundingBox.clone() : null,
 			boundingSphere: info.boundingSphere !== null ? info.boundingSphere.clone() : null,
 		} ) );
-		this._instanceInfo = source._instanceInfo.map( info => ( { ...info } ) );
+		this._drawInfo = source._drawInfo.map( info => ( { ...info } ) );
 
 		this._maxInstanceCount = source._maxInstanceCount;
 		this._maxVertexCount = source._maxVertexCount;
@@ -1253,7 +1253,7 @@ class BatchedMesh extends Mesh {
 		const index = geometry.getIndex();
 		const bytesPerElement = index === null ? 1 : index.array.BYTES_PER_ELEMENT;
 
-		const instanceInfo = this._instanceInfo;
+		const drawInfo = this._drawInfo;
 		const multiDrawStarts = this._multiDrawStarts;
 		const multiDrawCounts = this._multiDrawCounts;
 		const geometryInfoList = this._geometryInfo;
@@ -1282,11 +1282,11 @@ class BatchedMesh extends Mesh {
 			_vector.setFromMatrixPosition( camera.matrixWorld ).applyMatrix4( _matrix );
 			_forward.set( 0, 0, - 1 ).transformDirection( camera.matrixWorld ).transformDirection( _matrix );
 
-			for ( let i = 0, l = instanceInfo.length; i < l; i ++ ) {
+			for ( let i = 0, l = drawInfo.length; i < l; i ++ ) {
 
-				if ( instanceInfo[ i ].visible && instanceInfo[ i ].active ) {
+				if ( drawInfo[ i ].visible && drawInfo[ i ].active ) {
 
-					const geometryId = instanceInfo[ i ].geometryIndex;
+					const geometryId = drawInfo[ i ].geometryIndex;
 
 					// get the bounds in world space
 					this.getMatrixAt( i, _matrix );
@@ -1340,11 +1340,11 @@ class BatchedMesh extends Mesh {
 
 		} else {
 
-			for ( let i = 0, l = instanceInfo.length; i < l; i ++ ) {
+			for ( let i = 0, l = drawInfo.length; i < l; i ++ ) {
 
-				if ( instanceInfo[ i ].visible && instanceInfo[ i ].active ) {
+				if ( drawInfo[ i ].visible && drawInfo[ i ].active ) {
 
-					const geometryId = instanceInfo[ i ].geometryIndex;
+					const geometryId = drawInfo[ i ].geometryIndex;
 
 					// determine whether the batched geometry is within the frustum
 					let culled = false;

--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -425,6 +425,7 @@ class BatchedMesh extends Mesh {
 
 		}
 
+		this._visibilityChanged = true;
 		return drawId;
 
 	}

--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -92,11 +92,12 @@ const _renderList = /*@__PURE__*/ new MultiDrawRenderList();
 const _mesh = /*@__PURE__*/ new Mesh();
 const _batchIntersects = [];
 
-// @TODO: SkinnedMesh support?
-// @TODO: geometry.groups support?
-// @TODO: geometry.drawRange support?
-// @TODO: geometry.morphAttributes support?
-// @TODO: Support uniform parameter per geometry
+// TODO
+// - add instanceCount
+// - remove bounds, reserved ranges
+// - clean up
+// - rename fields for clarity
+// - remove unused fields
 
 // copies data from attribute "src" into "target" starting at "targetOffset"
 function copyAttributeData( src, target, targetOffset = 0 ) {
@@ -156,6 +157,12 @@ class BatchedMesh extends Mesh {
 	get maxInstanceCount() {
 
 		return this._maxInstanceCount;
+
+	}
+
+	get instanceCount() {
+
+		return this._drawInfo.length - this._availableInstanceIds.length;
 
 	}
 


### PR DESCRIPTION
Related issue: #29624, #29603

**Description**

Clean up for the BatchedMesh class to make things a little bit more clear and easier to manage:
- Consolidate the geometry data stored in `_bounds`, `_reservedRanges`, and `_drawRanges` into a common `_geometryInfo` member.
- Remove unnecessary comments
- Fixes #29603

(removed the following changes to reduce noise in the change set, will re-add them in a followup)
- ~Remove some unnecessary global fields~
- ~Rename "drawInfo" to "instanceInfo" for clarity~
- ~- Expose information about instance count, unused vertex & index count so applications can make decisions about whether geometries can be added.~

Once the class is finished and cleaned up I'll make an issue to discuss how we should move forward with the BatchedMesh implementation.