### PR TITLE
GLTFExporter: Better defaults for metallic and roughness factors.

### DIFF
--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -1524,8 +1524,7 @@ class GLTFWriter {
 
 		} else {
 
-			materialDef.pbrMetallicRoughness.metallicFactor = 1;
-			materialDef.pbrMetallicRoughness.roughnessFactor = 1;
+			materialDef.pbrMetallicRoughness.metallicFactor = 0; // default roughness is 1
 
 		}
 

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -1524,8 +1524,8 @@ class GLTFWriter {
 
 		} else {
 
-			materialDef.pbrMetallicRoughness.metallicFactor = 0.5;
-			materialDef.pbrMetallicRoughness.roughnessFactor = 0.5;
+			materialDef.pbrMetallicRoughness.metallicFactor = 0;
+			materialDef.pbrMetallicRoughness.roughnessFactor = 1;
 
 		}
 

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -1524,7 +1524,7 @@ class GLTFWriter {
 
 		} else {
 
-			materialDef.pbrMetallicRoughness.metallicFactor = 0;
+			materialDef.pbrMetallicRoughness.metallicFactor = 1;
 			materialDef.pbrMetallicRoughness.roughnessFactor = 1;
 
 		}


### PR DESCRIPTION
Fixed #29664.

**Description**

If `GLTFExporter` encounters a material which is no PBR material, it uses the same defaults for `metallicFactor` and `roughnessFactor` like `metalness` and `roughness` of `MeshStandardMaterial`.
