### PR TITLE
BufferGeometry: Check for existing attribute in `setFromPoints()`.

### DIFF
--- a/docs/api/en/core/BufferGeometry.html
+++ b/docs/api/en/core/BufferGeometry.html
@@ -335,7 +335,12 @@
 		</p>
 
 		<h3>[method:this setFromPoints] ( [param:Array points] )</h3>
-		<p>Sets the attributes for this BufferGeometry from an array of points.</p>
+		<p>
+			Defines a geometry by creating a `position` attribute based on the given array of points. The array can hold 
+			instances of [page:Vector2] or [page:Vector3]. When using two-dimensional data, the `z` coordinate for all vertices is set to `0`.<br />
+			If the method is used with an existing `position` attribute, the vertex data are overwritten with the data from the array. The length of the 
+			array must match the vertex count.
+		</p>
 
 		<h3>[method:this setIndex] ( [param:BufferAttribute index] )</h3>
 		<p>Set the [page:.index] buffer.</p>

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -287,16 +287,33 @@ class BufferGeometry extends EventDispatcher {
 
 	setFromPoints( points ) {
 
-		const position = [];
+		const positionAttribute = this.getAttribute( 'position' );
 
-		for ( let i = 0, l = points.length; i < l; i ++ ) {
+		if ( positionAttribute === undefined ) {
 
-			const point = points[ i ];
-			position.push( point.x, point.y, point.z || 0 );
+			const position = [];
+
+			for ( let i = 0, l = points.length; i < l; i ++ ) {
+
+				const point = points[ i ];
+				position.push( point.x, point.y, point.z || 0 );
+
+			}
+
+			this.setAttribute( 'position', new Float32BufferAttribute( position, 3 ) );
+
+		} else {
+
+			for ( let i = 0, l = positionAttribute.count; i < l; i ++ ) {
+
+				const point = points[ i ];
+				positionAttribute.setXYZ( i, point.x, point.y, point.z || 0 );
+
+			}
+
+			positionAttribute.needsUpdate = true;
 
 		}
-
-		this.setAttribute( 'position', new Float32BufferAttribute( position, 3 ) );
 
 		return this;
 

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -313,7 +313,7 @@ class BufferGeometry extends EventDispatcher {
 
 			if ( points.length > positionAttribute.count ) {
 
-				console.warn( 'THREE.BufferGeometry: Buffer size too small for points data. Use .dispose() and create a new geoemtry.' );
+				console.warn( 'THREE.BufferGeometry: Buffer size too small for points data. Use .dispose() and create a new geometry.' );
 
 			}
 

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -311,6 +311,12 @@ class BufferGeometry extends EventDispatcher {
 
 			}
 
+			if ( points.length > positionAttribute.count ) {
+
+				console.warn( 'THREE.BufferGeometry: Buffer size too small for points data. Use .dispose() and create a new geoemtry.' );
+
+			}
+
 			positionAttribute.needsUpdate = true;
 
 		}


### PR DESCRIPTION
Related issue: #29452

**Description**

The curve modifier examples show that `BufferGeometry.setFromPoints()` might be used on existing data. In this case, the method should not overwrite an existing buffer attribute but update the existing one.