### PR TITLE
WebGLTextures: Ensure depth texture properties are deleted.

### DIFF
--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -385,6 +385,8 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 			renderTarget.depthTexture.dispose();
 
+			properties.remove( renderTarget.depthTexture );
+
 		}
 
 		if ( renderTarget.isWebGLCubeRenderTarget ) {


### PR DESCRIPTION
Related issue: -

**Description**

The PR makes sure the texture properties of a depth texture are correctly deleted when `dispose()` is called on the render target.