### PR TITLE
Addons: Deprecate MMD modules.

### DIFF
--- a/examples/jsm/animation/MMDAnimationHelper.js
+++ b/examples/jsm/animation/MMDAnimationHelper.js
@@ -61,6 +61,8 @@ class MMDAnimationHelper {
 		this.sharedPhysics = false;
 		this.masterPhysics = null;
 
+		console.warn( 'THREE.MMDAnimationHelper: The module has been deprecated and will be removed with r172. Please migrate to __externalMMD_ instead.' );
+
 	}
 
 	/**

--- a/examples/jsm/animation/MMDAnimationHelper.js
+++ b/examples/jsm/animation/MMDAnimationHelper.js
@@ -61,7 +61,7 @@ class MMDAnimationHelper {
 		this.sharedPhysics = false;
 		this.masterPhysics = null;
 
-		console.warn( 'THREE.MMDAnimationHelper: The module has been deprecated and will be removed with r172. Please migrate to __externalMMD_ instead.' );
+		console.warn( 'THREE.MMDAnimationHelper: The module has been deprecated and will be removed with r172. Please migrate to https://github.com/takahirox/three-mmd-loader instead.' );
 
 	}
 

--- a/examples/jsm/animation/MMDPhysics.js
+++ b/examples/jsm/animation/MMDPhysics.js
@@ -68,6 +68,8 @@ class MMDPhysics {
 
 		this._init( mesh, rigidBodyParams, constraintParams );
 
+		console.warn( 'THREE.MMDPhysics: The module has been deprecated and will be removed with r172. Please migrate to __externalMMD_ instead.' );
+
 	}
 
 	/**

--- a/examples/jsm/animation/MMDPhysics.js
+++ b/examples/jsm/animation/MMDPhysics.js
@@ -68,7 +68,7 @@ class MMDPhysics {
 
 		this._init( mesh, rigidBodyParams, constraintParams );
 
-		console.warn( 'THREE.MMDPhysics: The module has been deprecated and will be removed with r172. Please migrate to __externalMMD_ instead.' );
+		console.warn( 'THREE.MMDPhysics: The module has been deprecated and will be removed with r172. Please migrate to https://github.com/takahirox/three-mmd-loader instead.' );
 
 	}
 

--- a/examples/jsm/exporters/MMDExporter.js
+++ b/examples/jsm/exporters/MMDExporter.js
@@ -12,6 +12,12 @@ import { MMDParser } from '../libs/mmdparser.module.js';
 
 class MMDExporter {
 
+	constructor() {
+
+		console.warn( 'THREE.MMDExporter: The module has been deprecated and will be removed with r172. Please migrate to __externalMMD_ instead.' );
+
+	}
+
 	/* TODO: implement
 	// mesh -> pmd
 	this.parsePmd = function ( object ) {

--- a/examples/jsm/exporters/MMDExporter.js
+++ b/examples/jsm/exporters/MMDExporter.js
@@ -14,7 +14,7 @@ class MMDExporter {
 
 	constructor() {
 
-		console.warn( 'THREE.MMDExporter: The module has been deprecated and will be removed with r172. Please migrate to __externalMMD_ instead.' );
+		console.warn( 'THREE.MMDExporter: The module has been deprecated and will be removed with r172. Please migrate to https://github.com/takahirox/three-mmd-loader instead.' );
 
 	}
 

--- a/examples/jsm/loaders/MMDLoader.js
+++ b/examples/jsm/loaders/MMDLoader.js
@@ -86,6 +86,8 @@ class MMDLoader extends Loader {
 		this.meshBuilder = new MeshBuilder( this.manager );
 		this.animationBuilder = new AnimationBuilder();
 
+		console.warn( 'THREE.MMDLoader: The module has been deprecated and will be removed with r172. Please migrate to __externalMMD_ instead.' );
+
 	}
 
 	/**

--- a/examples/jsm/loaders/MMDLoader.js
+++ b/examples/jsm/loaders/MMDLoader.js
@@ -86,7 +86,7 @@ class MMDLoader extends Loader {
 		this.meshBuilder = new MeshBuilder( this.manager );
 		this.animationBuilder = new AnimationBuilder();
 
-		console.warn( 'THREE.MMDLoader: The module has been deprecated and will be removed with r172. Please migrate to __externalMMD_ instead.' );
+		console.warn( 'THREE.MMDLoader: The module has been deprecated and will be removed with r172. Please migrate to https://github.com/takahirox/three-mmd-loader instead.' );
 
 	}
 


### PR DESCRIPTION
Related issue: -

**Description**

The development of `WebGPURenderer` adds a lot of new code to the repository. It was previously mentioned in #29171 that we should revisit what we currently support as addons and example code. Certain addons like `SDFGeometryGenerator`, `TiltLoader` or `PackedPhongMaterial` have already been removed during this process.

The PR deprecates all modules which are related to the MMD (MikuMikuDance) format. This includes `MMDLoader`, `MMDExporter`, `MMDAnimationHelper` and `MMDPhysics`.

@takahirox put a lot of effort in developing these modules but unfortunately no collaborator is even remotely familiar with MMD. Given the huge and complex code base, the requirement for a custom toon material, the need for a separate parser (`libs/mmdparser.module.js`) and MMD's very specific character, I think the MMD suite should be moved to a third-party repository. 

When done, the examples can be added back as external ones (meaning they include MMD modules from a different repository via `jsdelivr`).

Edit: New third-party repository: https://github.com/takahirox/three-mmd-loader
