### PR TITLE
Docs: Fix typos

### DIFF
--- a/docs/api/en/core/Object3D.html
+++ b/docs/api/en/core/Object3D.html
@@ -275,8 +275,8 @@
 
 		<h3>[property:Boolean DEFAULT_MATRIX_WORLD_AUTO_UPDATE]</h3>
 		<p>
-			The default setting for [page:.matrixWorldAutoUpdate
-			matrixWorldAutoUpdate] for newly created Object3Ds.<br />
+			The default setting for [page:.matrixWorldAutoUpdate matrixWorldAutoUpdate]
+			for newly created Object3Ds.<br />
 		</p>
 
 		<h2>Methods</h2>
@@ -311,7 +311,7 @@
 			Note: This method does not support scene graphs having
 			non-uniformly-scaled nodes(s).
 		</p>
-		
+
 		<h3>[method:this clear]()</h3>
 		<p>Removes all child objects.</p>
 
@@ -325,7 +325,7 @@
 
 		<h3>[method:this copy]( [param:Object3D object], [param:Boolean recursive] )</h3>
 		<p>
-			recursive -- If set to `true`, descendants of the object are copied next to the existing ones. 
+			recursive -- If set to `true`, descendants of the object are copied next to the existing ones.
 			If set to `false`, descendants are left unchanged. Default is `true`.<br /><br />
 
 			Copies the given object into this object. Note: Event listeners and

--- a/docs/api/en/math/Color.html
+++ b/docs/api/en/math/Color.html
@@ -20,7 +20,7 @@
 
 		<p>
 			<code>
-// converted automically from SRGBColorSpace to LinearSRGBColorSpace
+// converted automatically from SRGBColorSpace to LinearSRGBColorSpace
 const color = new THREE.Color().setHex( 0x112233 );
 			</code>
 		</p>

--- a/docs/api/fr/animation/AnimationAction.html
+++ b/docs/api/fr/animation/AnimationAction.html
@@ -29,7 +29,7 @@
             [page:AnimationClip clip] - l`AnimationClip` qui contient les données d'animation pour cette action.<br />
             [page:Object3D localRoot] - l'objet racine sur lequel est appliqué l'action.<br /><br />
 
-            Note: Au lieu d'appeler ce constructeur directement, vous devriez instantier un AnimationAction avec
+            Note: Au lieu d'appeler ce constructeur directement, vous devriez instancier un AnimationAction avec
             [page:AnimationMixer.clipAction] étant donné que cette méthode applique une mise en cache pour obtenir de meilleures performances.
         </p>
 
@@ -42,7 +42,7 @@
             Si `clampWhenFinished` est mis à true l'animation sera automatiquement [page:.paused mise en pause]
             à son dernier frame.<br /><br />
 
-            Si `clampWhenFinished` est mis à false, [page:.enabled enabled] sera automatiquement reglé sur
+            Si `clampWhenFinished` est mis à false, [page:.enabled enabled] sera automatiquement réglé sur
             false quand la dernière boucle de l'action sera terminée, afin que cette action n'ai pas plus
             d'impact.<br /><br />
 
@@ -68,14 +68,14 @@
 
         <h3>[property:Number loop]</h3>
         <p>
-            Le mode répeter (peut-être changé avec [page:.setLoop setLoop]). Sa valeur par défaut est
+            Le mode répéter (peut-être changé avec [page:.setLoop setLoop]). Sa valeur par défaut est
             [page:Animation THREE.LoopRepeat] (avec un nombre infini de répétitions [page:.repetitions repetitions])<br /><br />
 
             Doit être une de ces constantes:<br /><br />
             [page:Animation THREE.LoopOnce] - joue le clip une fois,<br />
-            [page:Animation THREE.LoopRepeat] - joue le clip le nombre choisi de `répetitions`,
+            [page:Animation THREE.LoopRepeat] - joue le clip le nombre choisi de `répétitions`,
             en sautant à chaque fois de la fin du clip à son début,<br />
-            [page:Animation THREE.LoopPingPong] - joue le clip le nombre choisi de `répetitions`,
+            [page:Animation THREE.LoopPingPong] - joue le clip le nombre choisi de `répétitions`,
             alternant entre lecture du début vers la fin et lecture de la fin vers le début.
         </p>
 
@@ -223,13 +223,13 @@
 			([page:.startAt startAt]).<br /><br />
 
 			Note: le fait que `isRunning` soit à true n'indique pas nécessairement que l'action est visible.
-			C'est seulement le cas si le [page:.weight weight] est reglé sur une valeur non-nulle.
+			C'est seulement le cas si le [page:.weight weight] est réglé sur une valeur non-nulle.
 		</p>
 
 		<h3>[method:Boolean isScheduled]()</h3>
 		<p>
 			Renvoie true, si cette action est activée dans le mixer.<br /><br />
-			Note: Cela n'indique pas nécessairement que l'action est en cours d'éxécution (voir les conditions additionnelles
+			Note: Cela n'indique pas nécessairement que l'action est en cours d'éxecution (voir les conditions additionnelles
 			pour [page:.isRunning isRunning]).
 		</p>
 
@@ -240,7 +240,7 @@
 			Note: Activer cette action ne signifie pas nécessairement que l'animation démarrera directement:
 			Si l'action s'était déjà terminée avant (en atteignant la fin de sa dernière boucle), ou si une durée
 			pour un départ différé a été renseignée (via [page:.startAt startAt]), un [page:.reset reset] doit être
-			éxécuté avant. Quelques autres paramètres ([page:.paused paused]=true, [page:.enabled enabled]=false,
+			exécuté avant. Quelques autres paramètres ([page:.paused paused]=true, [page:.enabled enabled]=false,
 			[page:.weight weight]=0, [page:.timeScale timeScale]=0) peuvent empêcher cette animation d'être jouée,
 			également.
 		</p>
@@ -267,7 +267,7 @@
 		<p>
 			Renseigne le [page:.timeScale timeScale] et stoppe tous les warpings programmés. Cette méthode peut être chaînée.<br /><br />
 
-			Si [page:.paused paused] est à false, l'échelle temporelle effective (propriété interne) sera également 
+			Si [page:.paused paused] est à false, l'échelle temporelle effective (propriété interne) sera également
 			mise à cette valeur; par ailleurs l'échelle temporelle effective (affectant directement l'animation à
 			cet instant) sera mis à `0`.<br /><br />
 
@@ -332,7 +332,7 @@
 			La synchronisation est faite en dupliquant les valeurs du [page:.time time] et du [page:.timeScale timeScale] de l'autre action
 			(stoppant tous les warpings programmés).<br /><br />
 
-			Note: Les changements futurs du `time` et du `timeScale` de l'autre action ne seront pas détéctés.
+			Note: Les changements futurs du `time` et du `timeScale` de l'autre action ne seront pas détectés.
 		</p>
 
 		<h3>[method:this warp]( [param:Number startTimeScale], [param:Number endTimeScale], [param:Number durationInSeconds] )</h3>

--- a/docs/api/fr/animation/AnimationClip.html
+++ b/docs/api/fr/animation/AnimationClip.html
@@ -84,7 +84,7 @@
 
 		<h3>[method:Object toJSON]()</h3>
 		<p>
-			Renvoie un objet JSON représentant le clip d'animation serialisé.
+			Renvoie un objet JSON représentant le clip d'animation sérialisé.
 		</p>
 
 		<h3>[method:this trim]()</h3>

--- a/docs/api/fr/animation/AnimationMixer.html
+++ b/docs/api/fr/animation/AnimationMixer.html
@@ -74,7 +74,7 @@
 
 		<h3>[method:this stopAllAction]()</h3>
 		<p>
-			Désactive toutes les actions précedemment programmées pour ce mixer.
+			Désactive toutes les actions précédemment programmées pour ce mixer.
 		</p>
 
 		<h3>[method:this update]([param:Number deltaTimeInSeconds]) </h3>

--- a/docs/api/fr/animation/AnimationUtils.html
+++ b/docs/api/fr/animation/AnimationUtils.html
@@ -44,7 +44,7 @@
 
 		<h3>[method:Array sortedArray]( values, stride, order )</h3>
 		<p>
-		Trie le tableau précedemment renvoyé par [page:AnimationUtils.getKeyframeOrder getKeyframeOrder].
+		Trie le tableau précédemment renvoyé par [page:AnimationUtils.getKeyframeOrder getKeyframeOrder].
 		</p>
 
 		<h3>[method:AnimationClip subclip]( [param:AnimationClip clip], [param:String name], [param:Number startFrame], [param:Number endFrame], [param:Number fps] )</h3>

--- a/docs/api/fr/animation/KeyframeTrack.html
+++ b/docs/api/fr/animation/KeyframeTrack.html
@@ -29,7 +29,7 @@
 		</p>
 
 		<p>
-			A la place, il y a toujours deux tableaux dans un `KeyframeTrack`: le tableau [page:.times times] 
+			A la place, il y a toujours deux tableaux dans un `KeyframeTrack`: le tableau [page:.times times]
 			stocke les durées pour chaque keyframes de ce track dans un ordre séquentiel, et le tableau
 			[page:.values values] array contient les valeurs modifiées correspondantes de la propriété animée.
 		</p>
@@ -96,7 +96,7 @@
 		</p>
 
 		<p>
-			Le nom peut spécifier le noeud en utilisant son nom ou son uuid (bien qu'il doive être dans le 
+			Le nom peut spécifier le noeud en utilisant son nom ou son uuid (bien qu'il doive être dans le
 			sous-arbre du noeud du graphe de scène passé dans le mixer). Ou, si le nom du track commence par un point,
 			le track s'applique au noeud racine qui a été passé en paramètre du mixer.
 		</p>
@@ -119,7 +119,7 @@
 
 		<p>
 			Note: Le nom de track ne doit pas nécessairement être unique. Plusieurs tracks peuvent gérer la même
-			propriété. Le résultat doit être basé sur un mélange pondéré entre les mutiples tracks selon
+			propriété. Le résultat doit être basé sur un mélange pondéré entre les multiples tracks selon
 			le poids de leurs actions respectives.
 		</p>
 
@@ -205,7 +205,7 @@
 
 		<h3>[method:this optimize]()</h3>
 		<p>
-			Retire les clés séquentielles équivalentse, qui sont communes dans les séquences de morph target.
+			Retire les clés séquentielles équivalentes, qui sont communes dans les séquences de morph target.
 		</p>
 
 		<h3>[method:this scale]()</h3>
@@ -240,8 +240,8 @@
 		</p>
 
 		<p>
-			Cette méthode envoie des erreurs à la console, si un track est vide, si la [page:.valueSize value taille] n'est pas valide, si un élémént
-			dans le tableau [page:.times times] ou [page:.values values] n'est pas un nombre valide ou si les éléménts du tableau `times` sont désorganisés.
+			Cette méthode envoie des erreurs à la console, si un track est vide, si la [page:.valueSize value taille] n'est pas valide, si un élément
+			dans le tableau [page:.times times] ou [page:.values values] n'est pas un nombre valide ou si les éléments du tableau `times` sont désorganisés.
 		</p>
 
 		<h2>Méthodes Statiques</h2>

--- a/docs/api/fr/animation/tracks/BooleanKeyframeTrack.html
+++ b/docs/api/fr/animation/tracks/BooleanKeyframeTrack.html
@@ -22,7 +22,7 @@
 
 		<h3>[name]( [param:String name], [param:Array times], [param:Array values] )</h3>
 		<p>
-			[page:String name] - (requis) indentifiant du KeyframeTrack.<br />
+			[page:String name] - (requis) identifiant du KeyframeTrack.<br />
 			[page:Array times] - (requis) tableau de durée des keyframes.<br />
 			[page:Array values] - valeurs des keyframes aux temps spécifiés.<br />
 		</p>

--- a/docs/api/fr/animation/tracks/ColorKeyframeTrack.html
+++ b/docs/api/fr/animation/tracks/ColorKeyframeTrack.html
@@ -24,7 +24,7 @@
 
 		<h3>[name]( [param:String name], [param:Array times], [param:Array values] )</h3>
 		<p>
-			[page:String name] - (requis) indentifiant du KeyframeTrack.<br />
+			[page:String name] - (requis) identifiant du KeyframeTrack.<br />
 			[page:Array times] - (requis) tableau de durée des keyframes.<br />
 			[page:Array values] - valeurs des keyframes aux temps spécifiés, un tableau à une dimension de composants de couleur entre 0 et 1.<br />
 			[page:Constant interpolation] - le type d'interpolation à utiliser. Voir

--- a/docs/api/fr/animation/tracks/NumberKeyframeTrack.html
+++ b/docs/api/fr/animation/tracks/NumberKeyframeTrack.html
@@ -22,7 +22,7 @@
 
 		<h3>[name]( [param:String name], [param:Array times], [param:Array values] )</h3>
 		<p>
-			[page:String name] - (requis) indentifiant du KeyframeTrack.<br />
+			[page:String name] - (requis) identifiant du KeyframeTrack.<br />
 			[page:Array times] - (requis) tableau de durée des keyframes.<br />
 			[page:Array values] - valeurs des keyframes aux temps spécifiés.<br />
 			[page:Constant interpolation] - le type d'interpolation à utiliser. Voir

--- a/docs/api/fr/animation/tracks/QuaternionKeyframeTrack.html
+++ b/docs/api/fr/animation/tracks/QuaternionKeyframeTrack.html
@@ -22,7 +22,7 @@
 
 		<h3>[name]( [param:String name], [param:Array times], [param:Array values] )</h3>
 		<p>
-			[page:String name] - (requis) indentifiant du KeyframeTrack.<br />
+			[page:String name] - (requis) identifiant du KeyframeTrack.<br />
 			[page:Array times] - (requis) tableau de durée des keyframes.<br />
 			[page:Array values] - valeurs des keyframes aux temps spécifiés, un tableau à une dimension de composants quaternaires.<br />
 			[page:Constant interpolation] - le type d'interpolation à utiliser. Voir

--- a/docs/api/fr/animation/tracks/StringKeyframeTrack.html
+++ b/docs/api/fr/animation/tracks/StringKeyframeTrack.html
@@ -22,7 +22,7 @@
 
 		<h3>[name]( [param:String name], [param:Array times], [param:Array values] )</h3>
 		<p>
-			[page:String name] - (requis) indentifiant du KeyframeTrack.<br />
+			[page:String name] - (requis) identifiant du KeyframeTrack.<br />
 			[page:Array times] - (requis) tableau de durée de keyframes.<br />
 			[page:Array values] - valeurs des keyframes aux temps spécifiés.<br />
 			[page:Constant interpolation] - le type d'interpolation à utiliser. Voir

--- a/docs/api/fr/animation/tracks/VectorKeyframeTrack.html
+++ b/docs/api/fr/animation/tracks/VectorKeyframeTrack.html
@@ -22,7 +22,7 @@
 
 		<h3>[name]( [param:String name], [param:Array times], [param:Array values] )</h3>
 		<p>
-			[page:String name] - (requis) indentifiant du KeyframeTrack.<br />
+			[page:String name] - (requis) identifiant du KeyframeTrack.<br />
 			[page:Array times] - (requis) tableau de durée des keyframes.<br />
 			[page:Array values] - valeurs des keyframes aux temps spécifiés, un tableau à une dimension de composants de vecteurs.<br />
 			[page:Constant interpolation] - le type d'interpolation à utiliser. Voir

--- a/docs/api/fr/audio/AudioAnalyser.html
+++ b/docs/api/fr/audio/AudioAnalyser.html
@@ -72,7 +72,7 @@
 
 		<h3>[property:Uint8Array data]</h3>
 		<p>
-		Un Uint8Array avec une taille determinée par [link:https://developer.mozilla.org/en-US/docs/Web/API/AnalyserNode/frequencyBinCount analyser.frequencyBinCount]
+		Un Uint8Array avec une taille déterminée par [link:https://developer.mozilla.org/en-US/docs/Web/API/AnalyserNode/frequencyBinCount analyser.frequencyBinCount]
 		utilisé pour stocker les données d'analyse.
 		</p>
 
@@ -88,7 +88,7 @@
 
 		<h3>[method:Number getAverageFrequency]()</h3>
 		<p>
-		Recupère la moyenne des fréquences retournées par la méthode [page:AudioAnalyser.getFrequencyData getFrequencyData].
+		Récupère la moyenne des fréquences retournées par la méthode [page:AudioAnalyser.getFrequencyData getFrequencyData].
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/fr/cameras/ArrayCamera.html
+++ b/docs/api/fr/cameras/ArrayCamera.html
@@ -38,7 +38,7 @@
 
 		<h3>[property:Boolean isArrayCamera]</h3>
 		<p>
-			Flag en lecture seul qui pemet de vérifier si un objet donné est de type [name].
+			Flag en lecture seul qui permet de vérifier si un objet donné est de type [name].
 		</p>
 
 		<h2>Méthodes</h2>

--- a/docs/api/fr/cameras/Camera.html
+++ b/docs/api/fr/cameras/Camera.html
@@ -21,7 +21,7 @@
 
 		<h3>[name]()</h3>
 		<p>
-			Crée une nouvelle [name]. Notez que cette classe n'est pas censée être appellée directement;
+			Crée une nouvelle [name]. Notez que cette classe n'est pas censée être appelée directement;
 			vous aurez sans doute besoin d'une [page:PerspectiveCamera] ou d'une [page:OrthographicCamera] à la place.
 		</p>
 
@@ -31,7 +31,7 @@
 
 		<h3>[property:Boolean isCamera]</h3>
 		<p>
-			Flag en lecture seul qui pemet de vérifier si un objet donné est de type [name].
+			Flag en lecture seul qui permet de vérifier si un objet donné est de type [name].
 		</p>
 
 		<h3>[property:Layers layers]</h3>

--- a/docs/api/fr/cameras/CubeCamera.html
+++ b/docs/api/fr/cameras/CubeCamera.html
@@ -76,7 +76,7 @@
 		scene -- La scène actuelle
 		</p>
 		<p>
-		Appellez cette méthode pour mettre à jour le [page:CubeCamera.renderTarget renderTarget].
+		Appelez cette méthode pour mettre à jour le [page:CubeCamera.renderTarget renderTarget].
 		</p>
 
 		<h2>Source</h2>

--- a/docs/api/fr/cameras/OrthographicCamera.html
+++ b/docs/api/fr/cameras/OrthographicCamera.html
@@ -75,7 +75,7 @@
 
 		<h3>[property:Boolean isOrthographicCamera]</h3>
 		<p>
-			Flag en lecture seul qui pemet de vérifier si un objet donné est de type [name].
+			Flag en lecture seul qui permet de vérifier si un objet donné est de type [name].
 		</p>
 
 		<h3>[property:Float left]</h3>
@@ -131,7 +131,7 @@
 
 		<h3>[method:Object toJSON]([param:Object meta])</h3>
 		<p>
-		meta -- objet contenant des metadatas comme des objets ou des textures dans des descendants des objets.<br />
+		meta -- objet contenant des métadonnées comme des objets ou des textures dans des descendants des objets.<br />
 		Convertis la caméra en [link:https://github.com/mrdoob/three.js/wiki/JSON-Object-Scene-format-4 JSON Object/Scene format] three.js.
 		</p>
 

--- a/docs/api/fr/cameras/PerspectiveCamera.html
+++ b/docs/api/fr/cameras/PerspectiveCamera.html
@@ -51,7 +51,7 @@
 		<h2>Propriétés</h2>
 		<p>
 			Voir la classe [page:Camera] pour connaître les propriétés communes.<br>
-			Notez qu'après avoir changé la grande majorité de ces propriétés vous devrez appeller
+			Notez qu'après avoir changé la grande majorité de ces propriétés vous devrez appeler
 			[page:PerspectiveCamera.updateProjectionMatrix .updateProjectionMatrix] afin que les changements prennent effet.
 		</p>
 
@@ -67,7 +67,7 @@
 
 		<h3>[property:Float filmGauge]</h3>
 		<p>Taille de la pellicule utilisée pour l'axe le plus grand. La valeur par défaut est 35 (millimètres). Ce paramètre n'influe pas sur la matrice de projection sauf si .filmOffset est à une valeur non-nulle </p>
-		
+
 		<h3>[property:Float filmOffset]</h3>
 		<p>Décalage horizontal dans la même unité que `.filmGauge`. La valeur par défaut est `0`.</p>
 
@@ -82,7 +82,7 @@
 
 		<h3>[property:Boolean isPerspectiveCamera]</h3>
 		<p>
-			Flag en lecture seul qui pemet de vérifier si un objet donné est de type [name].
+			Flag en lecture seul qui permet de vérifier si un objet donné est de type [name].
 		</p>
 
 
@@ -98,7 +98,7 @@
 		<h3>[property:Object view]</h3>
 		<p>
 			Spécification du frustum ou nul.
-			La valeur est fixée par la méthode [page:PerspectiveCamera.setViewOffset .setViewOffset] 
+			La valeur est fixée par la méthode [page:PerspectiveCamera.setViewOffset .setViewOffset]
 			et supprimée par la méthode [page:PerspectiveCamera.clearViewOffset .clearViewOffset].
 		</p>
 
@@ -113,7 +113,7 @@
 		<p>Retire tout décalage mis en place par la méthode [page:PerspectiveCamera.setViewOffset .setViewOffset].</p>
 
 		<h3>[method:Float getEffectiveFOV]()</h3>
-		<p>Retourne l'angle du champ de vision verticalen degrés en prenant en compte le .zoom.</p>
+		<p>Retourne l'angle du champ de vision vertical en degrés en prenant en compte le .zoom.</p>
 
 		<h3>[method:Float getFilmHeight]()</h3>
 		<p>
@@ -193,7 +193,7 @@ camera.setViewOffset( fullWidth, fullHeight, w * 2, h * 1, w, h );
 
 		<h3>[method:Object toJSON]([param:Object meta])</h3>
 		<p>
-		meta -- objet contenant des metadatas comme des objets ou des textures dans des descendants des objets.<br />
+		meta -- objet contenant des métadonnées comme des objets ou des textures dans des descendants des objets.<br />
 		Convertis la caméra en [link:https://github.com/mrdoob/three.js/wiki/JSON-Object-Scene-format-4 JSON Object/Scene format] three.js.
 		</p>
 

--- a/docs/api/fr/constants/CustomBlendingEquations.html
+++ b/docs/api/fr/constants/CustomBlendingEquations.html
@@ -50,7 +50,7 @@
 		THREE.SrcAlphaSaturateFactor
 		</code>
 
-		<h2>Facteur de déstination</h2>
+		<h2>Facteur de destination</h2>
 		<p>
 			Tous les facteurs source sont valides comme facteurs de destination, à l'exception de <code>THREE.SrcAlphaSaturateFactor</code>
 		</p>

--- a/docs/api/fr/constants/Textures.html
+++ b/docs/api/fr/constants/Textures.html
@@ -48,12 +48,12 @@
 		Ces constantes définissent les propriétés des textures [page:Texture.wrapS wrapS] et [page:Texture.wrapT wrapT],
 		qui définissent l'emballage de texture horizontal et vertical.<br /><br />
 
-		Avec [page:constant RepeatWrapping] la texure se répetera simplement à l'infini.<br /><br />
+		Avec [page:constant RepeatWrapping] la texure se répétera simplement à l'infini.<br /><br />
 
 		[page:constant ClampToEdgeWrapping] est la valeur par défaut.
 		Le dernier pixel de la texture s'étend jusqu'au bord du maillage.<br /><br />
 
-		Avec [page:constant MirroredRepeatWrapping] la texure se répetera à l'infini avec un effet mirroir à chaque répétition.
+		Avec [page:constant MirroredRepeatWrapping] la texure se répétera à l'infini avec un effet miroir à chaque répétition.
 		</p>
 
 		<h2>Filtres de grossissement</h2>
@@ -206,7 +206,7 @@
 		</code>
 		<p>
 		À utiliser avec la propriété [page:Texture.format format] d'une [page:CompressedTexture CompressedTexture],
-		ceux-ci doivent supporter l'extension 
+		ceux-ci doivent supporter l'extension
 		[link:https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_s3tc/ WEBGL_compressed_texture_s3tc] <br /><br />
 
 		Il existe 4 formats [link:https://en.wikipedia.org/wiki/S3_Texture_Compression S3TC] disponibles avec cette extension. Ce sont :<br />
@@ -350,23 +350,23 @@
 		[page:constante R8] stocke la composante rouge sur 8 bits.<br /><br />
 
 		[page:constant R8_SNORM] stocke la composante rouge sur 8 bits. Le composant est stocké comme normalisé. <br /><br />
-		
+
 		[page:constant R8I] stocke la composante rouge sur 8 bits. Le composant est stocké sous la forme d'un entier. <br /><br />
-		
+
 		[page:constant R8UI] stocke la composante rouge sur 8 bits. Le composant est stocké sous la forme d'un entier non signé. <br /><br />
-		
+
 		[page:constant R16I] stocke la composante rouge sur 16 bits. Le composant est stocké sous la forme d'un entier. <br /><br />
-		
+
 		[page:constant R16UI] stocke la composante rouge sur 16 bits. Le composant est stocké sous la forme d'un entier non signé. <br /><br />
-		
+
 		[page:constant R16F] stocke la composante rouge sur 16 bits. Le composant est stocké en point flottant. <br /><br />
-		
+
 		[page:constant R32I] stocke la composante rouge sur 32 bits. Le composant est stocké sous la forme d'un entier. <br /><br />
-		
+
 		[page:constant R32UI] stocke la composante rouge sur 32 bits. Le composant est stocké sous la forme d'un entier non signé. <br /><br />
-		
+
 		[page:constant R32F] stocke la composante rouge sur 32 bits. Le composant est stocké en point flottant. <br /><br />
-		
+
 		[page:constante RG8] stocke les composantes rouge et verte sur 8 bits chacune.<br /><br />
 
 		[page:constant RG8_SNORM] stocke les composantes rouge et verte sur 8 bits chacune.

--- a/docs/api/fr/geometries/BoxGeometry.html
+++ b/docs/api/fr/geometries/BoxGeometry.html
@@ -13,7 +13,7 @@
 
 		<p class="desc">
 			[name] est une classe de géométrie pour un cuboïde rectangulaire avec une largeur 'width', une hauteur 'height', et une profondeur 'depth' données.
-			À la création, le cuboïde est centré sur l'origine, chaque arrête est parallèle à l'un des axes. 
+			À la création, le cuboïde est centré sur l'origine, chaque arrête est parallèle à l'un des axes.
 		</p>
 
 		<iframe id="scene" src="scenes/geometry-browser.html#BoxGeometry"></iframe>
@@ -42,7 +42,7 @@
 		scene.add( cube );
 		</code>
 
-		<h2>Contructeur</h2>
+		<h2>Constructeur</h2>
 
 		<h3>[name]([param:Float width], [param:Float height], [param:Float depth], [param:Integer widthSegments], [param:Integer heightSegments], [param:Integer depthSegments])</h3>
 		<p>

--- a/docs/api/fr/geometries/CapsuleGeometry.html
+++ b/docs/api/fr/geometries/CapsuleGeometry.html
@@ -13,7 +13,7 @@
 
 		<p class="desc">
 			[name] est une classe de géométrie pour une capsule avec des rayons et une hauteur donnés.
-			Elle est construite à l'aide de demi-shpères.
+			Elle est construite à l'aide de demi-sphères.
 		</p>
 
 		<iframe id="scene" src="scenes/geometry-browser.html#CapsuleGeometry"></iframe>

--- a/docs/api/fr/materials/LineBasicMaterial.html
+++ b/docs/api/fr/materials/LineBasicMaterial.html
@@ -47,14 +47,14 @@
 
 		<p>
 		[page:Object parameters] - (optionnel) un objet avec une ou plusieurs propriétés définissant l'apparence du matériau.
-		Toute propriété du matériau (y compris toute proprioété héritée de [page:Material]) peut être passée dans l'objet.<br /><br />
+		Toute propriété du matériau (y compris toute propriété héritée de [page:Material]) peut être passée dans l'objet.<br /><br />
 
-		L'exception est la propriété [page:Hexadecimal color], qui peut être passée comme une chaine de caractères hexadécimale,
+		L'exception est la propriété [page:Hexadecimal color], qui peut être passée comme une chaîne de caractères hexadécimale,
 		 ayant la valeur `0xffffff` (blanc) par défaut. [page:Color.set]( color ) est appelée en interne.
 		</p>
 
 		<h2>Propriétés</h2>
-		<p>Voir la classe [page:Material] pour les prppriétés communes.</p>
+		<p>Voir la classe [page:Material] pour les propriétés communes.</p>
 
 		<h3>[property:Color color]</h3>
 		<p>[page:Color], couleur du matériau, par défaut en blanc (0xffffff).</p>
@@ -67,7 +67,7 @@
 			Contrôle l'épaisseur des lignes, la valeur par défaut est `1`.<br /><br />
 
 			A cause des limitations de [link:https://www.khronos.org/registry/OpenGL/specs/gl/glspec46.core.pdf OpenGL Core Profile]
-			avec le moteur de rendu [page:WebGLRenderer WebGL] sur la plupârt des plateformes, l'épaisseur de ligne (linewidth) sera toujours 
+			avec le moteur de rendu [page:WebGLRenderer WebGL] sur la plupart des plateformes, l'épaisseur de ligne (linewidth) sera toujours
 			à 1, indépendamment de la valeur définie.
 		</p>
 

--- a/docs/api/fr/materials/LineDashedMaterial.html
+++ b/docs/api/fr/materials/LineDashedMaterial.html
@@ -40,7 +40,7 @@
 		<h3>[name]( [param:Object parameters] )</h3>
 		<p>
 		[page:Object parameters] - (optionnel) un objet avec une ou plusieurs propriétés définissant l'apparence du matériau.
-		Toute propriété du matériau (y compris toute proprioété héritée de [page:LineBasicMaterial]) peut être passée dans l'objet.
+		Toute propriété du matériau (y compris toute propriété héritée de [page:LineBasicMaterial]) peut être passée dans l'objet.
 		</p>
 
 

--- a/docs/api/fr/materials/Material.html
+++ b/docs/api/fr/materials/Material.html
@@ -194,11 +194,11 @@
 		<p>Nombre unique pour cette instance de matériau.</p>
 
 		<h3>[property:String name]</h3>
-		<p>Nom optionnel de l'object (n'a pas besoin d'être unique). La valeur par défaut est une chaine de caractères vide.</p>
+		<p>Nom optionnel de l'object (n'a pas besoin d'être unique). La valeur par défaut est une chaîne de caractères vide.</p>
 
 		<h3>[property:Boolean needsUpdate]</h3>
 		<p>
-		Scécifie que le matériau doit être recompilé.
+		Spécifie que le matériau doit être recompilé.
 		</p>
 
 		<h3>[property:Float opacity]</h3>
@@ -356,22 +356,22 @@
 			Contrairement aux propriétés, le callback n'est pas pris en charge par [page:Material.clone .clone](), [page:Material.copy .copy]() et [page:Material.toJSON .toJSON]().
 		</p>
 		<p>
-			This callback is only supported in `WebGLRenderer` (not `WebGPURenderer`). 
+			This callback is only supported in `WebGLRenderer` (not `WebGPURenderer`).
 		</p>
 
 		<h3>
 			[method:undefined onBeforeRender]( [param:WebGLRenderer renderer], [param:Scene scene], [param:Camera camera], [param:BufferGeometry geometry], [param:Object3D object], [param:Group group] )
 		</h3>
 		<p>
-			An optional callback that is executed immediately before the material is used to 
+			An optional callback that is executed immediately before the material is used to
 			render a 3D object.
 		</p>
 		<p>
-			Unlike properties, the callback is not supported by [page:Material.clone .clone](), 
+			Unlike properties, the callback is not supported by [page:Material.clone .clone](),
 			[page:Material.copy .copy]() and [page:Material.toJSON .toJSON]().
 		</p>
 		<p>
-			This callback is only supported in `WebGLRenderer` (not `WebGPURenderer`). 
+			This callback is only supported in `WebGLRenderer` (not `WebGPURenderer`).
 		</p>
 
 		<h3>[method:String customProgramCacheKey]()</h3>

--- a/docs/api/fr/materials/MeshBasicMaterial.html
+++ b/docs/api/fr/materials/MeshBasicMaterial.html
@@ -41,9 +41,9 @@
 		<h3>[name]( [param:Object parameters] )</h3>
 		<p>
 			[page:Object parameters] - (optionnel) un objet avec une ou plusieurs propriétés définissant l'apparence du matériau.
-		Toute propriété du matériau (y compris toute proprioété héritée de [page:Material]) peut être passée dans l'objet.<br /><br />
+		Toute propriété du matériau (y compris toute propriété héritée de [page:Material]) peut être passée dans l'objet.<br /><br />
 
-			L'exception est la propriété [page:Hexadecimal color], qui peut être passée comme une chaine de caractères hexadécimale,
+			L'exception est la propriété [page:Hexadecimal color], qui peut être passée comme une chaîne de caractères hexadécimale,
 		 ayant la valeur `0xffffff` (blanc) par défaut. [page:Color.set]( color ) est appelée en interne.
 		</p>
 
@@ -53,11 +53,11 @@
 		<h3>[property:Texture alphaMap]</h3>
 		<p>La carte alpha est une texture en niveaux de gris qui contrôle l'opacité sur la surface
 			(noir : entièrement transparent ; blanc : entièrement opaque). La valeur par défaut est nulle.<br /><br />
-			
+
 			Seule la couleur de la texture est utilisée, en ignorant le canal alpha s'il en existe un.
 			Pour les textures RGB et RGBA, le moteur de rendu [page:WebGLRenderer WebGL] utilisera le
 			canal vert lors de l'échantillonnage de cette texture en raison du peu de précision supplémentaire fourni
-			pour le vert dans les formats RVB 565 compressés DXT et non compressés. 
+			pour le vert dans les formats RVB 565 compressés DXT et non compressés.
 			Les textures avec uniquement de la luminance ou les textures luminance/alpha fonctionneront également comme prévu.
 		</p>
 
@@ -138,7 +138,7 @@
 		<p>Contrôle l'épaisseur du filaire. La valeur par défaut est 1.<br /><br />
 
 			A cause des limitations de [link:https://www.khronos.org/registry/OpenGL/specs/gl/glspec46.core.pdf OpenGL Core Profile]
-			avec le moteur de rendu [page:WebGLRenderer WebGL] sur la plupârt des plateformes, l'épaisseur de ligne (linewidth) sera toujours 
+			avec le moteur de rendu [page:WebGLRenderer WebGL] sur la plupart des plateformes, l'épaisseur de ligne (linewidth) sera toujours
 			à 1, indépendamment de la valeur définie.
 		</p>
 

--- a/docs/api/fr/materials/MeshDepthMaterial.html
+++ b/docs/api/fr/materials/MeshDepthMaterial.html
@@ -36,7 +36,7 @@
 		<h3>[name]( [param:Object parameters] )</h3>
 		<p>
 			[page:Object parameters] - (optionnel) un objet avec une ou plusieurs propriétés définissant l'apparence du matériau.
-		Toute propriété du matériau (y compris toute proprioété héritée de [page:Material]) peut être passée dans l'objet.
+		Toute propriété du matériau (y compris toute propriété héritée de [page:Material]) peut être passée dans l'objet.
 		</p>
 
 		<h2>Propriétés</h2>
@@ -45,11 +45,11 @@
 		<h3>[property:Texture alphaMap]</h3>
 		<p>La carte alpha est une texture en niveaux de gris qui contrôle l'opacité sur la surface
 			(noir : entièrement transparent ; blanc : entièrement opaque). La valeur par défaut est nulle.<br /><br />
-			
+
 			Seule la couleur de la texture est utilisée, en ignorant le canal alpha s'il en existe un.
 			Pour les textures RGB et RGBA, le moteur de rendu [page:WebGLRenderer WebGL] utilisera le
 			canal vert lors de l'échantillonnage de cette texture en raison du peu de précision supplémentaire fourni
-			pour le vert dans les formats RVB 565 compressés DXT et non compressés. 
+			pour le vert dans les formats RVB 565 compressés DXT et non compressés.
 			Les textures avec uniquement de la luminance ou les textures luminance/alpha fonctionneront également comme prévu.
 		</p>
 
@@ -94,7 +94,7 @@
 		<p>Contrôle l'épaisseur du filaire. La valeur par défaut est 1.<br /><br />
 
 		A cause des limitations de [link:https://www.khronos.org/registry/OpenGL/specs/gl/glspec46.core.pdf OpenGL Core Profile]
-			avec le moteur de rendu [page:WebGLRenderer WebGL] sur la plupârt des plateformes, l'épaisseur de ligne (linewidth) sera toujours 
+			avec le moteur de rendu [page:WebGLRenderer WebGL] sur la plupart des plateformes, l'épaisseur de ligne (linewidth) sera toujours
 			à 1, indépendamment de la valeur définie.
 		</p>
 

--- a/docs/api/fr/materials/MeshDistanceMaterial.html
+++ b/docs/api/fr/materials/MeshDistanceMaterial.html
@@ -45,7 +45,7 @@
 		<h3>[name]( [param:Object parameters] )</h3>
 		<p>
 			[page:Object parameters] - (optionnel) un objet avec une ou plusieurs propriétés définissant l'apparence du matériau.
-		Toute propriété du matériau (y compris toute proprioété héritée de [page:Material]) peut être passée dans l'objet.
+		Toute propriété du matériau (y compris toute propriété héritée de [page:Material]) peut être passée dans l'objet.
 		</p>
 
 		<h2>Propriétés</h2>
@@ -54,11 +54,11 @@
 		<h3>[property:Texture alphaMap]</h3>
 		<p>La carte alpha est une texture en niveaux de gris qui contrôle l'opacité sur la surface
 			(noir : entièrement transparent ; blanc : entièrement opaque). La valeur par défaut est nulle.<br /><br />
-			
+
 			Seule la couleur de la texture est utilisée, en ignorant le canal alpha s'il en existe un.
 			Pour les textures RGB et RGBA, le moteur de rendu [page:WebGLRenderer WebGL] utilisera le
 			canal vert lors de l'échantillonnage de cette texture en raison du peu de précision supplémentaire fourni
-			pour le vert dans les formats RVB 565 compressés DXT et non compressés. 
+			pour le vert dans les formats RVB 565 compressés DXT et non compressés.
 			Les textures avec uniquement de la luminance ou les textures luminance/alpha fonctionneront également comme prévu.
 		</p>
 

--- a/docs/api/fr/materials/MeshLambertMaterial.html
+++ b/docs/api/fr/materials/MeshLambertMaterial.html
@@ -46,9 +46,9 @@
 		<h3>[name]( [param:Object parameters] )</h3>
 		<p>
 			[page:Object parameters] - (optionnel) un objet avec une ou plusieurs propriétés définissant l'apparence du matériau.
-		Toute propriété du matériau (y compris toute proprioété héritée de [page:Material]) peut être passée dans l'objet.<br /><br />
+		Toute propriété du matériau (y compris toute propriété héritée de [page:Material]) peut être passée dans l'objet.<br /><br />
 
-			L'exception est la propriété [page:Hexadecimal color], qui peut être passée comme une chaine de caractères hexadécimale,
+			L'exception est la propriété [page:Hexadecimal color], qui peut être passée comme une chaîne de caractères hexadécimale,
 		 ayant la valeur `0xffffff` (blanc) par défaut. [page:Color.set]( color ) est appelée en interne.
 		</p>
 
@@ -58,11 +58,11 @@
 		<h3>[property:Texture alphaMap]</h3>
 		<p>La carte alpha est une texture en niveaux de gris qui contrôle l'opacité sur la surface
 			(noir : entièrement transparent ; blanc : entièrement opaque). La valeur par défaut est nulle.<br /><br />
-			
+
 			Seule la couleur de la texture est utilisée, en ignorant le canal alpha s'il en existe un.
 			Pour les textures RGB et RGBA, le moteur de rendu [page:WebGLRenderer WebGL] utilisera le
 			canal vert lors de l'échantillonnage de cette texture en raison du peu de précision supplémentaire fourni
-			pour le vert dans les formats RVB 565 compressés DXT et non compressés. 
+			pour le vert dans les formats RVB 565 compressés DXT et non compressés.
 			Les textures avec uniquement de la luminance ou les textures luminance/alpha fonctionneront également comme prévu.
 		</p>
 
@@ -213,7 +213,7 @@
 		<p>Contrôle l'épaisseur du filaire. La valeur par défaut est 1.<br /><br />
 
 		A cause des limitations de [link:https://www.khronos.org/registry/OpenGL/specs/gl/glspec46.core.pdf OpenGL Core Profile]
-			avec le moteur de rendu [page:WebGLRenderer WebGL] sur la plupârt des plateformes, l'épaisseur de ligne (linewidth) sera toujours 
+			avec le moteur de rendu [page:WebGLRenderer WebGL] sur la plupart des plateformes, l'épaisseur de ligne (linewidth) sera toujours
 			à 1, indépendamment de la valeur définie.
 		</p>
 

--- a/docs/api/fr/materials/MeshMatcapMaterial.html
+++ b/docs/api/fr/materials/MeshMatcapMaterial.html
@@ -40,7 +40,7 @@
 		<h3>[name]( [param:Object parameters] )</h3>
 		<p>
 			[page:Object parameters] - (optionnel) un objet avec une ou plusieurs propriétés définissant l'apparence du matériau.
-		Toute propriété du matériau (y compris toute proprioété héritée de [page:Material]) peut être passée dans l'objet.<br /><br />
+		Toute propriété du matériau (y compris toute propriété héritée de [page:Material]) peut être passée dans l'objet.<br /><br />
 
 			L'exception est la propriété [page:Hexadecimal color], qui peut être passée comme une chaine de caractères hexadécimale,
 		 ayant la valeur `0xffffff` (blanc) par défaut. [page:Color.set]( color ) est appelée en interne.
@@ -52,11 +52,11 @@
 		<h3>[property:Texture alphaMap]</h3>
 		<p>La carte alpha est une texture en niveaux de gris qui contrôle l'opacité sur la surface
 			(noir : entièrement transparent ; blanc : entièrement opaque). La valeur par défaut est nulle.<br /><br />
-			
+
 			Seule la couleur de la texture est utilisée, en ignorant le canal alpha s'il en existe un.
 			Pour les textures RGB et RGBA, le moteur de rendu [page:WebGLRenderer WebGL] utilisera le
 			canal vert lors de l'échantillonnage de cette texture en raison du peu de précision supplémentaire fourni
-			pour le vert dans les formats RVB 565 compressés DXT et non compressés. 
+			pour le vert dans les formats RVB 565 compressés DXT et non compressés.
 			Les textures avec uniquement de la luminance ou les textures luminance/alpha fonctionneront également comme prévu.
 		</p>
 

--- a/docs/api/fr/materials/MeshNormalMaterial.html
+++ b/docs/api/fr/materials/MeshNormalMaterial.html
@@ -36,7 +36,7 @@
 		<h3>[name]( [param:Object parameters] )</h3>
 		<p>
 			[page:Object parameters] - (optionnel) un objet avec une ou plusieurs propriétés définissant l'apparence du matériau.
-		Toute propriété du matériau (y compris toute proprioété héritée de [page:Material]) peut être passée dans l'objet.
+		Toute propriété du matériau (y compris toute propriété héritée de [page:Material]) peut être passée dans l'objet.
 		</p>
 
 
@@ -112,7 +112,7 @@
 		<p>Contrôle l'épaisseur du filaire. La valeur par défaut est 1.<br /><br />
 
 		A cause des limitations de [link:https://www.khronos.org/registry/OpenGL/specs/gl/glspec46.core.pdf OpenGL Core Profile]
-			avec le moteur de rendu [page:WebGLRenderer WebGL] sur la plupârt des plateformes, l'épaisseur de ligne (linewidth) sera toujours 
+			avec le moteur de rendu [page:WebGLRenderer WebGL] sur la plupart des plateformes, l'épaisseur de ligne (linewidth) sera toujours
 			à 1, indépendamment de la valeur définie.
 		</p>
 

--- a/docs/api/fr/materials/MeshPhongMaterial.html
+++ b/docs/api/fr/materials/MeshPhongMaterial.html
@@ -42,12 +42,12 @@
 
 		<h2>Constructeur</h2>
 
-		<h3>[name]( [param:Object parameters] )</h3> 
+		<h3>[name]( [param:Object parameters] )</h3>
 		<p>
 			[page:Object parameters] - (optionnel) un objet avec une ou plusieurs propriétés définissant l'apparence du matériau.
-		Toute propriété du matériau (y compris toute proprioété héritée de [page:Material]) peut être passée dans l'objet.<br /><br />
+		Toute propriété du matériau (y compris toute propriété héritée de [page:Material]) peut être passée dans l'objet.<br /><br />
 
-			L'exception est la propriété [page:Hexadecimal color], qui peut être passée comme une chaine de caractères hexadécimale,
+			L'exception est la propriété [page:Hexadecimal color], qui peut être passée comme une chaîne de caractères hexadécimale,
 		 ayant la valeur `0xffffff` (blanc) par défaut. [page:Color.set]( color ) est appelée en interne.
 		</p>
 
@@ -57,11 +57,11 @@
 		<h3>[property:Texture alphaMap]</h3>
 		<p>La carte alpha est une texture en niveaux de gris qui contrôle l'opacité sur la surface
 			(noir : entièrement transparent ; blanc : entièrement opaque). La valeur par défaut est nulle.<br /><br />
-			
+
 			Seule la couleur de la texture est utilisée, en ignorant le canal alpha s'il en existe un.
 			Pour les textures RGB et RGBA, le moteur de rendu [page:WebGLRenderer WebGL] utilisera le
 			canal vert lors de l'échantillonnage de cette texture en raison du peu de précision supplémentaire fourni
-			pour le vert dans les formats RVB 565 compressés DXT et non compressés. 
+			pour le vert dans les formats RVB 565 compressés DXT et non compressés.
 			Les textures avec uniquement de la luminance ou les textures luminance/alpha fonctionneront également comme prévu.
 		</p>
 
@@ -231,7 +231,7 @@
 		<p>Contrôle l'épaisseur du filaire. La valeur par défaut est 1.<br /><br />
 
 		A cause des limitations de [link:https://www.khronos.org/registry/OpenGL/specs/gl/glspec46.core.pdf OpenGL Core Profile]
-			avec le moteur de rendu [page:WebGLRenderer WebGL] sur la plupârt des plateformes, l'épaisseur de ligne (linewidth) sera toujours 
+			avec le moteur de rendu [page:WebGLRenderer WebGL] sur la plupârt des plateformes, l'épaisseur de ligne (linewidth) sera toujours
 			à 1, indépendamment de la valeur définie.
 		</p>
 

--- a/docs/api/fr/materials/MeshStandardMaterial.html
+++ b/docs/api/fr/materials/MeshStandardMaterial.html
@@ -70,9 +70,9 @@
 		<h3>[name]( [param:Object parameters] )</h3>
 		<p>
 			[page:Object parameters] - (optionnel) un objet avec une ou plusieurs propriétés définissant l'apparence du matériau.
-		Toute propriété du matériau (y compris toute proprioété héritée de [page:Material]) peut être passée dans l'objet.<br /><br />
+		Toute propriété du matériau (y compris toute propriété héritée de [page:Material]) peut être passée dans l'objet.<br /><br />
 
-			L'exception est la propriété [page:Hexadecimal color], qui peut être passée comme une chaine de caractères hexadécimale,
+			L'exception est la propriété [page:Hexadecimal color], qui peut être passée comme une chaîne de caractères hexadécimale,
 		 ayant la valeur `0xffffff` (blanc) par défaut. [page:Color.set]( color ) est appelée en interne.
 		</p>
 
@@ -82,11 +82,11 @@
 		<h3>[property:Texture alphaMap]</h3>
 		<p>La carte alpha est une texture en niveaux de gris qui contrôle l'opacité sur la surface
 			(noir : entièrement transparent ; blanc : entièrement opaque). La valeur par défaut est nulle.<br /><br />
-			
+
 			Seule la couleur de la texture est utilisée, en ignorant le canal alpha s'il en existe un.
 			Pour les textures RGB et RGBA, le moteur de rendu [page:WebGLRenderer WebGL] utilisera le
 			canal vert lors de l'échantillonnage de cette texture en raison du peu de précision supplémentaire fourni
-			pour le vert dans les formats RVB 565 compressés DXT et non compressés. 
+			pour le vert dans les formats RVB 565 compressés DXT et non compressés.
 			Les textures avec uniquement de la luminance ou les textures luminance/alpha fonctionneront également comme prévu.
 		</p>
 
@@ -255,7 +255,7 @@
 		<p>Contrôle l'épaisseur du filaire. La valeur par défaut est 1.<br /><br />
 
 			A cause des limitations de [link:https://www.khronos.org/registry/OpenGL/specs/gl/glspec46.core.pdf OpenGL Core Profile]
-			avec le moteur de rendu [page:WebGLRenderer WebGL] sur la plupârt des plateformes, l'épaisseur de ligne (linewidth) sera toujours 
+			avec le moteur de rendu [page:WebGLRenderer WebGL] sur la plupart des plateformes, l'épaisseur de ligne (linewidth) sera toujours
 			à 1, indépendamment de la valeur définie.
 		</p>
 

--- a/docs/api/fr/materials/MeshToonMaterial.html
+++ b/docs/api/fr/materials/MeshToonMaterial.html
@@ -41,9 +41,9 @@
 		<h3>[name]( [param:Object parameters] )</h3>
 		<p>
 			[page:Object parameters] - (optionnel) un objet avec une ou plusieurs propriétés définissant l'apparence du matériau.
-		Toute propriété du matériau (y compris toute proprioété héritée de [page:Material]) peut être passée dans l'objet.<br /><br />
+		Toute propriété du matériau (y compris toute propriété héritée de [page:Material]) peut être passée dans l'objet.<br /><br />
 
-			L'exception est la propriété [page:Hexadecimal color], qui peut être passée comme une chaine de caractères hexadécimale,
+			L'exception est la propriété [page:Hexadecimal color], qui peut être passée comme une chaîne de caractères hexadécimale,
 		 ayant la valeur `0xffffff` (blanc) par défaut. [page:Color.set]( color ) est appelée en interne.
 		</p>
 
@@ -53,11 +53,11 @@
 		<h3>[property:Texture alphaMap]</h3>
 		<p>La carte alpha est une texture en niveaux de gris qui contrôle l'opacité sur la surface
 			(noir : entièrement transparent ; blanc : entièrement opaque). La valeur par défaut est nulle.<br /><br />
-			
+
 			Seule la couleur de la texture est utilisée, en ignorant le canal alpha s'il en existe un.
 			Pour les textures RGB et RGBA, le moteur de rendu [page:WebGLRenderer WebGL] utilisera le
 			canal vert lors de l'échantillonnage de cette texture en raison du peu de précision supplémentaire fourni
-			pour le vert dans les formats RVB 565 compressés DXT et non compressés. 
+			pour le vert dans les formats RVB 565 compressés DXT et non compressés.
 			Les textures avec uniquement de la luminance ou les textures luminance/alpha fonctionneront également comme prévu.
 		</p>
 
@@ -184,7 +184,7 @@ La valeur par défaut est un [page:Vector2] défini sur (1,1).
 		<p>Contrôle l'épaisseur du filaire. La valeur par défaut est 1.<br /><br />
 
 		A cause des limitations de [link:https://www.khronos.org/registry/OpenGL/specs/gl/glspec46.core.pdf OpenGL Core Profile]
-			avec le moteur de rendu [page:WebGLRenderer WebGL] sur la plupârt des plateformes, l'épaisseur de ligne (linewidth) sera toujours 
+			avec le moteur de rendu [page:WebGLRenderer WebGL] sur la plupart des plateformes, l'épaisseur de ligne (linewidth) sera toujours
 			à 1, indépendamment de la valeur définie.
 		</p>
 

--- a/docs/api/fr/materials/PointsMaterial.html
+++ b/docs/api/fr/materials/PointsMaterial.html
@@ -57,9 +57,9 @@
 		<h3>[name]( [param:Object parameters] )</h3>
 		<p>
 			[page:Object parameters] - (optionnel) un objet avec une ou plusieurs propriétés définissant l'apparence du matériau.
-		Toute propriété du matériau (y compris toute proprioété héritée de [page:Material]) peut être passée dans l'objet.<br /><br />
+		Toute propriété du matériau (y compris toute propriété héritée de [page:Material]) peut être passée dans l'objet.<br /><br />
 
-			L'exception est la propriété [page:Hexadecimal color], qui peut être passée comme une chaine de caractères hexadécimale,
+			L'exception est la propriété [page:Hexadecimal color], qui peut être passée comme une chaîne de caractères hexadécimale,
 		 ayant la valeur `0xffffff` (blanc) par défaut. [page:Color.set]( color ) est appelée en interne.
 		</p>
 
@@ -69,11 +69,11 @@
 		<h3>[property:Texture alphaMap]</h3>
 		<p>La carte alpha est une texture en niveaux de gris qui contrôle l'opacité sur la surface
 			(noir : entièrement transparent ; blanc : entièrement opaque). La valeur par défaut est nulle.<br /><br />
-			
+
 			Seule la couleur de la texture est utilisée, en ignorant le canal alpha s'il en existe un.
 			Pour les textures RGB et RGBA, le moteur de rendu [page:WebGLRenderer WebGL] utilisera le
 			canal vert lors de l'échantillonnage de cette texture en raison du peu de précision supplémentaire fourni
-			pour le vert dans les formats RVB 565 compressés DXT et non compressés. 
+			pour le vert dans les formats RVB 565 compressés DXT et non compressés.
 			Les textures avec uniquement de la luminance ou les textures luminance/alpha fonctionneront également comme prévu.
 		</p>
 

--- a/docs/api/fr/materials/RawShaderMaterial.html
+++ b/docs/api/fr/materials/RawShaderMaterial.html
@@ -45,7 +45,7 @@
 		<h3>[name]( [param:Object parameters] )</h3>
 		<p>
 			[page:Object parameters] - (optionnel) un objet avec une ou plusieurs propriétés définissant l'apparence du matériau.
-		Toute propriété du matériau (y compris toute proprioété héritée de [page:Material] and [page:ShaderMaterial]) peut être passée dans l'objet.<br /><br />
+		Toute propriété du matériau (y compris toute propriété héritée de [page:Material] and [page:ShaderMaterial]) peut être passée dans l'objet.<br /><br />
 		</p>
 
 

--- a/docs/api/fr/materials/ShaderMaterial.html
+++ b/docs/api/fr/materials/ShaderMaterial.html
@@ -262,7 +262,7 @@ et la page [page:BufferAttribute] pour un aperçu détaillé de l'API `BufferAtt
 		<h3>[name]( [param:Object parameters] )</h3>
 		<p>
 			[page:Object parameters] - (optionnel) un objet avec une ou plusieurs propriétés définissant l'apparence du matériau.
-		Toute propriété du matériau (y compris toute proprioété héritée de [page:Material]) peut être passée dans l'objet.
+		Toute propriété du matériau (y compris toute propriété héritée de [page:Material]) peut être passée dans l'objet.
 		</p>
 
 		<h2>Propriétés</h2>
@@ -361,7 +361,7 @@ et la page [page:BufferAttribute] pour un aperçu détaillé de l'API `BufferAtt
 		<p>Contrôle l'épaisseur du filaire. La valeur par défaut est 1.<br /><br />
 
 		A cause des limitations de [link:https://www.khronos.org/registry/OpenGL/specs/gl/glspec46.core.pdf OpenGL Core Profile]
-			avec le moteur de rendu [page:WebGLRenderer WebGL] sur la plupârt des plateformes, l'épaisseur de ligne (linewidth) sera toujours 
+			avec le moteur de rendu [page:WebGLRenderer WebGL] sur la plupârt des plateformes, l'épaisseur de ligne (linewidth) sera toujours
 			à 1, indépendamment de la valeur définie.
 		</p>
 
@@ -411,7 +411,7 @@ et la page [page:BufferAttribute] pour un aperçu détaillé de l'API `BufferAtt
 		<p>Contrôle l'épaisseur du filaire. La valeur par défaut est 1.<br /><br />
 
 		A cause des limitations de [link:https://www.khronos.org/registry/OpenGL/specs/gl/glspec46.core.pdf OpenGL Core Profile]
-			avec le moteur de rendu [page:WebGLRenderer WebGL] sur la plupârt des plateformes, l'épaisseur de ligne (linewidth) sera toujours 
+			avec le moteur de rendu [page:WebGLRenderer WebGL] sur la plupart des plateformes, l'épaisseur de ligne (linewidth) sera toujours
 			à 1, indépendamment de la valeur définie.
 		</p>
 

--- a/docs/api/fr/materials/ShadowMaterial.html
+++ b/docs/api/fr/materials/ShadowMaterial.html
@@ -41,7 +41,7 @@
 		<h3>[name]( [param:Object parameters] )</h3>
 		<p>
 			[page:Object parameters] - (optionnel) un objet avec une ou plusieurs propriétés définissant l'apparence du matériau.
-		Toute propriété du matériau (y compris toute proprioété héritée de [page:Material]) peut être passée dans l'objet.<br /><br />
+		Toute propriété du matériau (y compris toute propriété héritée de [page:Material]) peut être passée dans l'objet.<br /><br />
 		</p>
 
 

--- a/docs/api/fr/materials/SpriteMaterial.html
+++ b/docs/api/fr/materials/SpriteMaterial.html
@@ -36,9 +36,9 @@
 		<h3>[name]( [param:Object parameters] )</h3>
 		<p>
 			[page:Object parameters] - (optionnel) un objet avec une ou plusieurs propriétés définissant l'apparence du matériau.
-		Toute propriété du matériau (y compris toute proprioété héritée de [page:Material]) peut être passée dans l'objet.<br /><br />
+		Toute propriété du matériau (y compris toute propriété héritée de [page:Material]) peut être passée dans l'objet.<br /><br />
 
-			L'exception est la propriété [page:Hexadecimal color], qui peut être passée comme une chaine de caractères hexadécimale,
+			L'exception est la propriété [page:Hexadecimal color], qui peut être passée comme une chaîne de caractères hexadécimale,
 		 ayant la valeur `0xffffff` (blanc) par défaut. [page:Color.set]( color ) est appelée en interne.
 
 		 Les SpriteMaterials ne sont pas coupés en utilisant [page:Material.clippingPlanes].
@@ -51,11 +51,11 @@
 		<h3>[property:Texture alphaMap]</h3>
 		<p>La carte alpha est une texture en niveaux de gris qui contrôle l'opacité sur la surface
 			(noir : entièrement transparent ; blanc : entièrement opaque). La valeur par défaut est nulle.<br /><br />
-			
+
 			Seule la couleur de la texture est utilisée, en ignorant le canal alpha s'il en existe un.
 			Pour les textures RGB et RGBA, le moteur de rendu [page:WebGLRenderer WebGL] utilisera le
 			canal vert lors de l'échantillonnage de cette texture en raison du peu de précision supplémentaire fourni
-			pour le vert dans les formats RVB 565 compressés DXT et non compressés. 
+			pour le vert dans les formats RVB 565 compressés DXT et non compressés.
 			Les textures avec uniquement de la luminance ou les textures luminance/alpha fonctionneront également comme prévu.
 		</p>
 

--- a/docs/examples/en/animations/MMDAnimationHelper.html
+++ b/docs/examples/en/animations/MMDAnimationHelper.html
@@ -111,7 +111,7 @@
 		<p>A [page:WeakMap] which holds animation stuffs used in helper for objects added to helper. For example, you can access [page:AnimationMixer] for an added [page:SkinnedMesh] with "helper.objects.get( mesh ).mixer"</p>
 
 		<h3>[property:Function onBeforePhysics]</h3>
-		<p>An optional callback that is executed immediately before the physicis calculation for an [page:SkinnedMesh]. This function is called with the [page:SkinnedMesh].</p>
+		<p>An optional callback that is executed immediately before the physics calculation for an [page:SkinnedMesh]. This function is called with the [page:SkinnedMesh].</p>
 
 		<h2>Methods</h2>
 
@@ -130,7 +130,7 @@
 			<li>[page:Number delayTime] - Only for [page:Audio]. Default is 0.0.</li>
 		</ul>
 		<p>
-		Add an [page:SkinnedMesh], [page:Camera], or [page:Audio] to helper and setup animation. The anmation durations of added objects are synched.
+		Add an [page:SkinnedMesh], [page:Camera], or [page:Audio] to helper and setup animation. The animation durations of added objects are synched.
 		If camera/audio has already been added, it'll be replaced with a new one.
 		</p>
 

--- a/docs/examples/en/controls/ArcballControls.html
+++ b/docs/examples/en/controls/ArcballControls.html
@@ -106,7 +106,7 @@
 
 		<h3>[property:Boolean adjustNearFar]</h3>
 		<p>
-			If true, camera's near and far values will be adjusted every time zoom is performed trying to mantain the same visible portion
+			If true, camera's near and far values will be adjusted every time zoom is performed trying to maintain the same visible portion
 			given by initial near and far values ( [page:PerspectiveCamera] only ).
 			Default is false.
 		</p>

--- a/docs/examples/en/exporters/DRACOExporter.html
+++ b/docs/examples/en/exporters/DRACOExporter.html
@@ -69,7 +69,7 @@
 			<li>decodeSpeed - int. Indicates how to tune the encoder regarding decode speed (0 gives better speed but worst quality). Default is 5</li>
 			<li>encodeSpeed - int. Indicates how to tune the encoder parameters (0 gives better speed but worst quality). Default is 5.</li>
 			<li>encoderMethod - int. Either sequential (very little compression) or Edgebreaker. Edgebreaker traverses the triangles of the mesh in a deterministic, spiral-like way which provides most of the benefits of this data format. Default is DRACOExporter.MESH_EDGEBREAKER_ENCODING.</li>
-			<li>quantization - Array of int. Indicates the presision of each type of data stored in the draco file in the order (POSITION, NORMAL, COLOR, TEX_COORD, GENERIC). Default is [ 16, 8, 8, 8, 8 ]</li>
+			<li>quantization - Array of int. Indicates the precision of each type of data stored in the draco file in the order (POSITION, NORMAL, COLOR, TEX_COORD, GENERIC). Default is [ 16, 8, 8, 8, 8 ]</li>
 			<li>exportUvs - bool. Default is true.</li>
 			<li>exportNormals - bool. Default is true.</li>
 			<li>exportColor - bool. Default is false.</li>

--- a/docs/examples/en/geometries/TeapotGeometry.html
+++ b/docs/examples/en/geometries/TeapotGeometry.html
@@ -12,7 +12,7 @@
 		<h1>[name]</h1>
 
 		<p class="desc">
-			[name] tesselates the famous Utah teapot database by Martin Newell.
+			[name] tessellates the famous Utah teapot database by Martin Newell.
 		</p>
 
 		<h2>Import</h2>
@@ -38,7 +38,7 @@
 		<h2>Constructor</h2>
 
 		<h3>
-			[name]([param:Integer size], [param:Integer segments], [param:Boolean bottom], [param:Boolean lid], [param:Boolean body], 
+			[name]([param:Integer size], [param:Integer segments], [param:Boolean bottom], [param:Boolean lid], [param:Boolean body],
 			[param:Boolean fitLid], [param:Boolean blinn])
 		</h3>
 		<p>

--- a/docs/examples/en/math/convexhull/ConvexHull.html
+++ b/docs/examples/en/math/convexhull/ConvexHull.html
@@ -156,7 +156,7 @@
 			[page:Ray ray] - The given ray.<br />
 			[page:Vector3 target] - The target vector representing the intersection point.<br /><br />
 
-			Performs a ray intersection test with this convext hull. If no intersection is found, `null` is returned.
+			Performs a ray intersection test with this convex hull. If no intersection is found, `null` is returned.
 		</p>
 
 		<h3>[method:Boolean intersectsRay]( [param:Ray ray] )</h3>
@@ -210,7 +210,7 @@
 		<p>
 			[page:Object3D object] - [page:Object3D] to compute the convex hull of.<br /><br />
 
-			Computes the convex hull of an [page:Object3D] (including its children),accounting for the world transforms of both the object and its childrens.
+			Computes the convex hull of an [page:Object3D] (including its children),accounting for the world transforms of both the object and its children.
 		</p>
 
 		<h3>[method:this setFromPoints]( [param:Array points] )</h3>

--- a/docs/manual/en/introduction/How-to-update-things.html
+++ b/docs/manual/en/introduction/How-to-update-things.html
@@ -220,7 +220,7 @@ camera.updateProjectionMatrix();
 		<div>
 			<p>
 				`InstancedMesh` is a class for conveniently access instanced rendering in `three.js`. Certain library features like view frustum culling or
-				ray casting rely on up-to-date bounding volumes (bounding sphere and bounding box). Because of the way how `InstancedMesh` works, the class 
+				ray casting rely on up-to-date bounding volumes (bounding sphere and bounding box). Because of the way how `InstancedMesh` works, the class
 				has its own [page:InstancedMesh.boundingBox boundingBox] and [page:InstancedMesh.boundingSphere boundingSphere] properties that supersede
 				the bounding volumes on geometry level.
 			</p>
@@ -241,7 +241,7 @@ instancedMesh.computeBoundingSphere();
 				`SkinnedMesh` follows the same principles like `InstancedMesh` in context of bounding volumes. Meaning the class has its own version of
 				[page:SkinnedMesh.boundingBox boundingBox] and [page:SkinnedMesh.boundingSphere boundingSphere] to correctly enclose animated meshes.
 				When calling `computeBoundingBox()` and `computeBoundingSphere()`, the class computes the respective bounding volumes based on the current
-				bone tranformation (or in other words the current animation state).
+				bone transformation (or in other words the current animation state).
 			</p>
 		</div>
 


### PR DESCRIPTION
I used VSCode `Code Spell Checker` extension and some reading to:

* Fix some typos in `en` doc
* Fix some typos in `fr` doc
* Fix link for https://threejs.org/docs/#api/en/core/Object3D.DEFAULT_MATRIX_WORLD_AUTO_UPDATE