### PR TITLE
RectAreaLightTextureLib: Fix DataTexture usage

### DIFF
--- a/examples/jsm/lights/RectAreaLightTexturesLib.js
+++ b/examples/jsm/lights/RectAreaLightTexturesLib.js
@@ -71,7 +71,7 @@ class RectAreaLightTexturesLib {
 		LTC_HALF_2.needsUpdate = true;
 
 		this.LTC_HALF_1 = LTC_HALF_1;
-		this.LTC_HALF_1 = LTC_HALF_2;
+		this.LTC_HALF_2 = LTC_HALF_2;
 
 		this.LTC_FLOAT_1 = LTC_FLOAT_1;
 		this.LTC_FLOAT_2 = LTC_FLOAT_2;


### PR DESCRIPTION
It seems to be a simple copy paste error to me.

 I tried the change locally on `webgpu_lights_rectarealight` but I couldn't identify a significal change. Maybe a new screenshot for the example should be generated but I'm not sure.
