### PR TITLE
WGSLNodeFunction: Ignore convertion of unknown types

### DIFF
--- a/src/renderers/webgpu/nodes/WGSLNodeFunction.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeFunction.js
@@ -97,17 +97,21 @@ const parse = ( source ) => {
 
 			let resolvedType = type;
 
-			if ( resolvedType.startsWith( 'texture' ) ) {
-
-				resolvedType = type.split( '<' )[ 0 ];
-
-			} else if ( resolvedType.startsWith( 'ptr' ) ) {
+			if ( resolvedType.startsWith( 'ptr' ) ) {
 
 				resolvedType = 'pointer';
 
-			}
+			} else {
 
-			resolvedType = wgslTypeLib[ resolvedType ] || resolvedType;
+				if ( resolvedType.startsWith( 'texture' ) ) {
+
+					resolvedType = type.split( '<' )[ 0 ];
+
+				}
+
+				resolvedType = wgslTypeLib[ resolvedType ];
+
+			}
 
 			inputs.push( new NodeFunctionInput( resolvedType, name ) );
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/29720

**Description**

 Ignore convertion of unknown types.