### PR TITLE
Nodes: Add flat shading fallback for vertex shader.

### DIFF
--- a/src/nodes/accessors/Normal.js
+++ b/src/nodes/accessors/Normal.js
@@ -30,7 +30,9 @@ export const normalView = /*@__PURE__*/ ( Fn( ( builder ) => {
 
 	if ( builder.material.flatShading === true ) {
 
-		node = normalFlat;
+		// dFdx/dFdy only available in fragment shader
+
+		node = ( builder.shaderStage === 'fragment' ) ? normalFlat : vec3( 0, 0, 0 );
 
 	} else {
 


### PR DESCRIPTION
Fixed #29325.

**Description**

The PR ensures the node material system does not try to use derivative functions for computing flat shaded normals in the vertex shader.