### PR TITLE
CylinderGeometry: Fix case where triangles are missing with multiple height segments

### DIFF
--- a/src/geometries/CylinderGeometry.js
+++ b/src/geometries/CylinderGeometry.js
@@ -133,14 +133,14 @@ class CylinderGeometry extends BufferGeometry {
 
 					// faces
 
-					if ( radiusTop > 0 ) {
+					if ( radiusTop > 0 || y !== 0 ) {
 
 						indices.push( a, b, d );
 						groupCount += 3;
 
 					}
 
-					if ( radiusBottom > 0 ) {
+					if ( radiusBottom > 0 || y !== heightSegments - 1 ) {
 
 						indices.push( b, c, d );
 						groupCount += 3;


### PR DESCRIPTION
Fixed #29721

**Description**

Check for whether the triangles connect to the converging point before merging triangles.

**Top Pinch**

| Before | After |
|---|---|
| <img width="250" alt="image" src="https://github.com/user-attachments/assets/998416aa-6b84-463a-9831-f77e0fb03bba"> | <img width="250" alt="image" src="https://github.com/user-attachments/assets/c24bfb19-4b84-4a78-9c04-30b5e6ab55ed"> |

**Bottom Pinch**

| Before | After |
|---|---|
| <img width="250" alt="image" src="https://github.com/user-attachments/assets/58b5bece-df71-4e2c-9a84-c11e403a21dc"> | <img width="250" alt="image" src="https://github.com/user-attachments/assets/c43de20e-b8f6-4f98-82b9-1a11f84b67ca"> |
