### PR TITLE
Docs: Improve Korean translation.

### DIFF
--- a/docs/api/ko/core/Object3D.html
+++ b/docs/api/ko/core/Object3D.html
@@ -197,7 +197,7 @@
 		<h3>[property:String uuid]</h3>
 		<p>
 		이 객체 인스턴스의 [link:http://en.wikipedia.org/wiki/Universally_unique_identifier UUID]입니다.
-		자동으로 할당되며, 수정할 수 없습니다.
+		자동으로 할당되니 수정하지 마십시오.
 		</p>
 
 		<h3>[property:Boolean visible]</h3>


### PR DESCRIPTION
**Description**

The translation of `uuid` in Korean says that it **cannot** be edited. 
This may be misleading that even when you assign a value it gets ignored, when it actually can be set.
The fix changes the translation so it reads you **should not** edit the field.
