### PR TITLE
ScriptableNode: Rename `global` to `ScriptableNodeResources`

### DIFF
--- a/examples/webgpu_materials.html
+++ b/examples/webgpu_materials.html
@@ -27,7 +27,7 @@
 			import * as THREE from 'three';
 			import * as TSL from 'three/tsl';
 
-			import { Fn, wgslFn, positionLocal, scriptable, positionWorld, normalLocal, normalWorld, normalView, color, texture, uv, float, vec2, vec3, vec4, oscSine, triplanarTexture, screenUV, js, string, Loop, cameraProjectionMatrix, ScriptableResources } from 'three/tsl';
+			import { Fn, wgslFn, positionLocal, scriptable, positionWorld, normalLocal, normalWorld, normalView, color, texture, uv, float, vec2, vec3, vec4, oscSine, triplanarTexture, screenUV, js, string, Loop, cameraProjectionMatrix, ScriptableNodeResources } from 'three/tsl';
 
 			import { TeapotGeometry } from 'three/addons/geometries/TeapotGeometry.js';
 
@@ -240,8 +240,8 @@
 
 				// Scriptable
 
-				ScriptableResources.set( 'THREE', THREE );
-				ScriptableResources.set( 'TSL', TSL );
+				ScriptableNodeResources.set( 'THREE', THREE );
+				ScriptableNodeResources.set( 'TSL', TSL );
 
 				const asyncNode = scriptable( js( `
 

--- a/examples/webgpu_materials.html
+++ b/examples/webgpu_materials.html
@@ -27,7 +27,7 @@
 			import * as THREE from 'three';
 			import * as TSL from 'three/tsl';
 
-			import { Fn, wgslFn, positionLocal, scriptable, positionWorld, normalLocal, normalWorld, normalView, color, texture, uv, float, vec2, vec3, vec4, oscSine, triplanarTexture, screenUV, js, string, global, Loop, cameraProjectionMatrix } from 'three/tsl';
+			import { Fn, wgslFn, positionLocal, scriptable, positionWorld, normalLocal, normalWorld, normalView, color, texture, uv, float, vec2, vec3, vec4, oscSine, triplanarTexture, screenUV, js, string, Loop, cameraProjectionMatrix, ScriptableResources } from 'three/tsl';
 
 			import { TeapotGeometry } from 'three/addons/geometries/TeapotGeometry.js';
 
@@ -240,8 +240,8 @@
 
 				// Scriptable
 
-				global.set( 'THREE', THREE );
-				global.set( 'TSL', TSL );
+				ScriptableResources.set( 'THREE', THREE );
+				ScriptableResources.set( 'TSL', TSL );
 
 				const asyncNode = scriptable( js( `
 

--- a/playground/NodeEditor.js
+++ b/playground/NodeEditor.js
@@ -24,14 +24,14 @@ export class NodeEditor extends THREE.EventDispatcher {
 		this.scene = scene;
 		this.renderer = renderer;
 
-		const { global } = Nodes;
+		const { ScriptableResources } = Nodes;
 
-		global.set( 'THREE', THREE );
-		global.set( 'TSL', Nodes );
+		ScriptableResources.set( 'THREE', THREE );
+		ScriptableResources.set( 'TSL', Nodes );
 
-		global.set( 'scene', scene );
-		global.set( 'renderer', renderer );
-		global.set( 'composer', composer );
+		ScriptableResources.set( 'scene', scene );
+		ScriptableResources.set( 'renderer', renderer );
+		ScriptableResources.set( 'composer', composer );
 
 		this.nodeClasses = [];
 

--- a/playground/NodeEditor.js
+++ b/playground/NodeEditor.js
@@ -24,14 +24,14 @@ export class NodeEditor extends THREE.EventDispatcher {
 		this.scene = scene;
 		this.renderer = renderer;
 
-		const { ScriptableResources } = Nodes;
+		const { ScriptableNodeResources } = Nodes;
 
-		ScriptableResources.set( 'THREE', THREE );
-		ScriptableResources.set( 'TSL', Nodes );
+		ScriptableNodeResources.set( 'THREE', THREE );
+		ScriptableNodeResources.set( 'TSL', Nodes );
 
-		ScriptableResources.set( 'scene', scene );
-		ScriptableResources.set( 'renderer', renderer );
-		ScriptableResources.set( 'composer', composer );
+		ScriptableNodeResources.set( 'scene', scene );
+		ScriptableNodeResources.set( 'renderer', renderer );
+		ScriptableNodeResources.set( 'composer', composer );
 
 		this.nodeClasses = [];
 

--- a/playground/editors/ScriptableEditor.js
+++ b/playground/editors/ScriptableEditor.js
@@ -1,7 +1,7 @@
 import { BaseNodeEditor } from '../BaseNodeEditor.js';
 import { CodeEditorElement } from '../elements/CodeEditorElement.js';
 import { disposeScene, resetScene, createElementFromJSON, isGPUNode, onValidType } from '../NodeEditorUtils.js';
-import { ScriptableResources, scriptable, js, scriptableValue } from 'three/tsl';
+import { ScriptableNodeResources, scriptable, js, scriptableValue } from 'three/tsl';
 import { getColorFromType, setInputAestheticsFromType, setOutputAestheticsFromType } from '../DataTypeLib.js';
 
 const defaultTitle = 'Scriptable';
@@ -189,8 +189,8 @@ export class ScriptableEditor extends BaseNodeEditor {
 
 		if ( editor && editorOutput === editorOutputAdded ) return;
 
-		const scene = ScriptableResources.get( 'scene' );
-		const composer = ScriptableResources.get( 'composer' );
+		const scene = ScriptableNodeResources.get( 'scene' );
+		const composer = ScriptableNodeResources.get( 'composer' );
 
 		if ( editor ) {
 

--- a/playground/editors/ScriptableEditor.js
+++ b/playground/editors/ScriptableEditor.js
@@ -1,7 +1,7 @@
 import { BaseNodeEditor } from '../BaseNodeEditor.js';
 import { CodeEditorElement } from '../elements/CodeEditorElement.js';
 import { disposeScene, resetScene, createElementFromJSON, isGPUNode, onValidType } from '../NodeEditorUtils.js';
-import { global, scriptable, js, scriptableValue } from 'three/tsl';
+import { ScriptableResources, scriptable, js, scriptableValue } from 'three/tsl';
 import { getColorFromType, setInputAestheticsFromType, setOutputAestheticsFromType } from '../DataTypeLib.js';
 
 const defaultTitle = 'Scriptable';
@@ -189,8 +189,8 @@ export class ScriptableEditor extends BaseNodeEditor {
 
 		if ( editor && editorOutput === editorOutputAdded ) return;
 
-		const scene = global.get( 'scene' );
-		const composer = global.get( 'composer' );
+		const scene = ScriptableResources.get( 'scene' );
+		const composer = ScriptableResources.get( 'composer' );
 
 		if ( editor ) {
 

--- a/src/nodes/code/ScriptableNode.js
+++ b/src/nodes/code/ScriptableNode.js
@@ -58,7 +58,9 @@ class Parameters {
 
 }
 
-export const global = new Resources();
+const localGlobal = new Resources();
+
+export { localGlobal as global };
 
 class ScriptableNode extends Node {
 
@@ -299,11 +301,11 @@ class ScriptableNode extends Node {
 
 		const parameters = new Parameters( this );
 
-		const THREE = global.get( 'THREE' );
-		const TSL = global.get( 'TSL' );
+		const THREE = localGlobal.get( 'THREE' );
+		const TSL = localGlobal.get( 'TSL' );
 
 		const method = this.getMethod( this.codeNode );
-		const params = [ parameters, this._local, global, refresh, setOutput, THREE, TSL ];
+		const params = [ parameters, this._local, localGlobal, refresh, setOutput, THREE, TSL ];
 
 		this._object = method( ...params );
 

--- a/src/nodes/code/ScriptableNode.js
+++ b/src/nodes/code/ScriptableNode.js
@@ -58,9 +58,7 @@ class Parameters {
 
 }
 
-const localGlobal = new Resources();
-
-export { localGlobal as global };
+export const ScriptableResources = new Resources();
 
 class ScriptableNode extends Node {
 
@@ -301,11 +299,11 @@ class ScriptableNode extends Node {
 
 		const parameters = new Parameters( this );
 
-		const THREE = localGlobal.get( 'THREE' );
-		const TSL = localGlobal.get( 'TSL' );
+		const THREE = ScriptableResources.get( 'THREE' );
+		const TSL = ScriptableResources.get( 'TSL' );
 
 		const method = this.getMethod( this.codeNode );
-		const params = [ parameters, this._local, localGlobal, refresh, setOutput, THREE, TSL ];
+		const params = [ parameters, this._local, ScriptableResources, refresh, setOutput, THREE, TSL ];
 
 		this._object = method( ...params );
 

--- a/src/nodes/code/ScriptableNode.js
+++ b/src/nodes/code/ScriptableNode.js
@@ -58,7 +58,7 @@ class Parameters {
 
 }
 
-export const ScriptableResources = new Resources();
+export const ScriptableNodeResources = new Resources();
 
 class ScriptableNode extends Node {
 
@@ -299,11 +299,11 @@ class ScriptableNode extends Node {
 
 		const parameters = new Parameters( this );
 
-		const THREE = ScriptableResources.get( 'THREE' );
-		const TSL = ScriptableResources.get( 'TSL' );
+		const THREE = ScriptableNodeResources.get( 'THREE' );
+		const TSL = ScriptableNodeResources.get( 'TSL' );
 
 		const method = this.getMethod( this.codeNode );
-		const params = [ parameters, this._local, ScriptableResources, refresh, setOutput, THREE, TSL ];
+		const params = [ parameters, this._local, ScriptableNodeResources, refresh, setOutput, THREE, TSL ];
 
 		this._object = method( ...params );
 


### PR DESCRIPTION
Related issue: NA

**Description**

When running a multiplatform React Native app on the web, the bundler declares a local variable `global` which exists to increase compatibility with different ecosystems such as react-native ios/android or node. I have renamed the `global` variable inside ScriptableNode.js so that locally it is simply `localGlobal`. The export remains the same however, so it should have no downstream implications.  