### PR TITLE
Update UniformArrayNode.js

### DIFF
--- a/src/nodes/accessors/UniformArrayNode.js
+++ b/src/nodes/accessors/UniformArrayNode.js
@@ -129,7 +129,7 @@ class UniformArrayNode extends BufferNode {
 		this._elementLength = builder.getTypeLength( this._elementType );
 
 		let arrayType = Float32Array;
-		
+
 		if ( this._elementType.charAt( 0 ) === 'i' ) arrayType = Int32Array;
 		else if ( this._elementType.charAt( 0 ) === 'u' ) arrayType = Uint32Array;
 

--- a/src/nodes/accessors/UniformArrayNode.js
+++ b/src/nodes/accessors/UniformArrayNode.js
@@ -129,7 +129,7 @@ class UniformArrayNode extends BufferNode {
 		this._elementLength = builder.getTypeLength( this._elementType );
 
 		let arrayType = Float32Array;
-
+		//
 		if ( this._elementType.charAt( 0 ) === 'i' ) arrayType = Int32Array;
 		else if ( this._elementType.charAt( 0 ) === 'u' ) arrayType = Uint32Array;
 

--- a/src/nodes/accessors/UniformArrayNode.js
+++ b/src/nodes/accessors/UniformArrayNode.js
@@ -118,9 +118,14 @@ class UniformArrayNode extends BufferNode {
 
 	setup( builder ) {
 
-		const length = this.array.length;
-
 		this._elementType = this.elementType === null ? getValueType( this.array[ 0 ] ) : this.elementType;
+
+		const length = ( this._elementType === 'vec4' ) ? this.array.length : this.array.length * 4;
+
+		this.bufferCount = ( this._elementType === 'vec4' ) ? length / 4 : length;
+
+		this._elementType = ( this._elementType === 'vec4' ) ? 'float' : this._elementType;
+
 		this._elementLength = builder.getTypeLength( this._elementType );
 
 		let arrayType = Float32Array;
@@ -128,8 +133,8 @@ class UniformArrayNode extends BufferNode {
 		if ( this._elementType.charAt( 0 ) === 'i' ) arrayType = Int32Array;
 		else if ( this._elementType.charAt( 0 ) === 'u' ) arrayType = Uint32Array;
 
-		this.value = new arrayType( length * 4 );
-		this.bufferCount = length;
+		this.value = new arrayType( length );
+
 		this.bufferType = builder.changeComponentType( 'vec4', builder.getComponentType( this._elementType ) );
 
 		return super.setup( builder );

--- a/src/nodes/accessors/UniformArrayNode.js
+++ b/src/nodes/accessors/UniformArrayNode.js
@@ -129,7 +129,7 @@ class UniformArrayNode extends BufferNode {
 		this._elementLength = builder.getTypeLength( this._elementType );
 
 		let arrayType = Float32Array;
-		//
+		
 		if ( this._elementType.charAt( 0 ) === 'i' ) arrayType = Int32Array;
 		else if ( this._elementType.charAt( 0 ) === 'u' ) arrayType = Uint32Array;
 

--- a/src/nodes/accessors/UniformArrayNode.js
+++ b/src/nodes/accessors/UniformArrayNode.js
@@ -125,7 +125,7 @@ class UniformArrayNode extends BufferNode {
 
 		this.bufferCount = ( this._elementType === 'vec4' ) ? length / 4 : length;
 
-		this._elementStride = (this._elementType === 'vec4') ? 1 : 4;
+		this._elementStride = ( this._elementType === 'vec4' ) ? 1 : 4;
 
 		this._elementType = ( this._elementType === 'vec4' ) ? 'float' : this._elementType;
 

--- a/src/nodes/accessors/UniformArrayNode.js
+++ b/src/nodes/accessors/UniformArrayNode.js
@@ -48,6 +48,7 @@ class UniformArrayNode extends BufferNode {
 
 		this._elementType = null;
 		this._elementLength = 0;
+		this._elementStride = 4;
 
 		this.updateType = NodeUpdateType.RENDER;
 
@@ -78,7 +79,7 @@ class UniformArrayNode extends BufferNode {
 
 			for ( let i = 0; i < array.length; i ++ ) {
 
-				const index = i * 4;
+				const index = i * this._elementStride;
 
 				value[ index ] = array[ i ];
 
@@ -102,7 +103,7 @@ class UniformArrayNode extends BufferNode {
 
 			for ( let i = 0; i < array.length; i ++ ) {
 
-				const index = i * 4;
+				const index = i * this._elementStride;
 				const vector = array[ i ];
 
 				value[ index ] = vector.x;
@@ -123,6 +124,8 @@ class UniformArrayNode extends BufferNode {
 		const length = ( this._elementType === 'vec4' ) ? this.array.length : this.array.length * 4;
 
 		this.bufferCount = ( this._elementType === 'vec4' ) ? length / 4 : length;
+
+		this._elementStride = (this._elementType === 'vec4') ? 1 : 4;
 
 		this._elementType = ( this._elementType === 'vec4' ) ? 'float' : this._elementType;
 


### PR DESCRIPTION
The UniformArrayNode has so far only been designed for scalar arrays. However, it is desirable to have this also especially for the vec4, as this allows the buffer to be used more efficiently.

```
const shaderParams = {
   planes: uniformArray([
      1, 0, 0, 0,
      0, 1, 0, 0,
      0, 0, 1, 0,
      0, 0, 0, 1,
      1, 1, 0, 0,
      1, 0, 1, 0,         
   ], 'vec4' ),
};

const testShader = wgslFn(`
   fn compute(
      planes: array<vec4<f32>, 6>,
   ) -> void {
        
      var plane = planes[4].xyz;
   }
`);
```

this little example produces this:

![image](https://github.com/user-attachments/assets/f26bf8e4-ff0b-41b4-bb0c-7eab2c288185)
