### PR TITLE
WebXRManager: Inherit active layers from camera

### DIFF
--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -51,18 +51,14 @@ class WebXRManager extends EventDispatcher {
 		//
 
 		const cameraL = new PerspectiveCamera();
-		cameraL.layers.enable( 1 );
 		cameraL.viewport = new Vector4();
 
 		const cameraR = new PerspectiveCamera();
-		cameraR.layers.enable( 2 );
 		cameraR.viewport = new Vector4();
 
 		const cameras = [ cameraL, cameraR ];
 
 		const cameraXR = new ArrayCamera();
-		cameraXR.layers.enable( 1 );
-		cameraXR.layers.enable( 2 );
 
 		let _currentDepthNear = null;
 		let _currentDepthFar = null;
@@ -571,6 +567,10 @@ class WebXRManager extends EventDispatcher {
 				_currentDepthFar = cameraXR.far;
 
 			}
+
+			cameraL.layers.mask = camera.layers.mask | 0b010;
+			cameraR.layers.mask = camera.layers.mask | 0b100;
+			cameraXR.layers.mask = cameraL.layers.mask | cameraR.layers.mask;
 
 			const parent = camera.parent;
 			const cameras = cameraXR.cameras;


### PR DESCRIPTION
Fixed #24354

**Description**

This PR updates the `WebXRManager` to copy over the layers mask to the XR cameras. The respective eye layer (1 for left, 2 for right) is always enabled in addition.

- A default scene setup behaves identical to before
- Calling `renderer.render(scene, camera)` now always respects `camera.layers` whether XR is active or not
- Users that manually enabled layers on the XR cameras will now have to enable them on the main camera instead.
- Users will have to be careful with layers 1 and 2 as these are used for the eyes (even before this PR)

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Fern Solutions](https://fern.solutions)*
