### PR TITLE
Vector4: Add `divide()`.

### DIFF
--- a/docs/api/en/math/Vector4.html
+++ b/docs/api/en/math/Vector4.html
@@ -157,6 +157,9 @@
 			[page:.z z] and [page:.w w] properties to this Vector4.
 		</p>
 
+		<h3>[method:this divide]( [param:Vector4 v] )</h3>
+		<p>Divides this vector by [page:Vector4 v].</p>
+
 		<h3>[method:this divideScalar]( [param:Float s] )</h3>
 		<p>Divides this vector by scalar [page:Float s].</p>
 

--- a/src/math/Vector4.js
+++ b/src/math/Vector4.js
@@ -249,6 +249,17 @@ class Vector4 {
 
 	}
 
+	divide( v ) {
+
+		this.x /= v.x;
+		this.y /= v.y;
+		this.z /= v.z;
+		this.w /= v.w;
+
+		return this;
+
+	}
+
 	divideScalar( scalar ) {
 
 		return this.multiplyScalar( 1 / scalar );

--- a/test/unit/src/math/Vector4.tests.js
+++ b/test/unit/src/math/Vector4.tests.js
@@ -272,6 +272,19 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
+		QUnit.test( 'divide', ( assert) => {
+
+			const a = new Vector4( 7, 8, 9, 0 );
+			const b = new Vector4( 2, 2, 3, 4 );
+
+			a.divide( b );
+			assert.equal( a.x, 3.5, 'Check divide x' );
+			assert.equal( a.y, 4.0, 'Check divide y' );
+			assert.equal( a.z, 3.0, 'Check divide z' );
+			assert.equal( a.w, 0.0, 'Check divide w' );
+
+		} );
+
 		QUnit.todo( 'divideScalar', ( assert ) => {
 
 			assert.ok( false, 'everything\'s gonna be alright' );


### PR DESCRIPTION
Fixed #29751

**Description**

Adds the `divide` method to Vector4 class.
