### PR TITLE
WebGPU Storage buffer extension for matrices

### DIFF
--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -1065,7 +1065,19 @@ ${ flowData.code }
 
 				const bufferCountSnippet = bufferCount > 0 && uniform.type === 'buffer' ? ', ' + bufferCount : '';
 				const bufferTypeSnippet = bufferNode.isAtomic ? `atomic<${bufferType}>` : `${bufferType}`;
-				const bufferSnippet = `\t${ uniform.name } : array< ${ bufferTypeSnippet }${ bufferCountSnippet } >\n`;
+
+				let bufferSnippet;
+
+				if ( bufferType === 'mat3x3<f32>' || bufferType === 'mat4x4<f32>' ) {
+
+					bufferSnippet = `\t${ uniform.name } : ${ bufferTypeSnippet }${ bufferCountSnippet } \n`;
+
+				} else {
+
+					bufferSnippet = `\t${ uniform.name } : array< ${ bufferTypeSnippet }${ bufferCountSnippet } >\n`;
+
+				}
+				
 				const bufferAccessMode = bufferNode.isStorageBufferNode ? `storage, ${ this.getStorageAccess( bufferNode ) }` : 'uniform';
 
 				bufferSnippets.push( this._getWGSLStructBinding( 'NodeBuffer_' + bufferNode.id, bufferSnippet, bufferAccessMode, uniformIndexes.binding ++, uniformIndexes.group ) );

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -1077,7 +1077,7 @@ ${ flowData.code }
 					bufferSnippet = `\t${ uniform.name } : array< ${ bufferTypeSnippet }${ bufferCountSnippet } >\n`;
 
 				}
-				
+
 				const bufferAccessMode = bufferNode.isStorageBufferNode ? `storage, ${ this.getStorageAccess( bufferNode ) }` : 'uniform';
 
 				bufferSnippets.push( this._getWGSLStructBinding( 'NodeBuffer_' + bufferNode.id, bufferSnippet, bufferAccessMode, uniformIndexes.binding ++, uniformIndexes.group ) );


### PR DESCRIPTION
Related issue: #29760

**Description**

I added mat3 and mat4 to the storagebuffers. 
So far you can use scalars and vectors but it is also desirable to store matrices in storage buffers.
This means that object calculations for which matrices are necessary can be carried out in the GPU with compute shaders instead of in the CPU. This is very useful for drawIndirect topics.

code produced by WGSLNodeBuilder.js
```
my new mat 3 and mat 4 test storage buffers
struct NodeBuffer_566Struct {
	nodeUniform0 : mat4x4<f32> 

};
@binding( 1 ) @group( 0 )
var<storage, read> NodeBuffer_566 : NodeBuffer_566Struct;

struct NodeBuffer_567Struct {
	nodeUniform1 : mat3x3<f32> 

};
@binding( 3 ) @group( 0 )
var<storage, read> NodeBuffer_567 : NodeBuffer_567Struct;

my previous other storage buffers for position, normal, uv
struct NodeBuffer_550Struct {
	nodeUniform4 : array< vec3<f32> >

};
@binding( 2 ) @group( 1 )
var<storage, read> NodeBuffer_550 : NodeBuffer_550Struct;

struct NodeBuffer_551Struct {
	nodeUniform5 : array< vec3<f32> >

};
@binding( 4 ) @group( 1 )
var<storage, read> NodeBuffer_551 : NodeBuffer_551Struct;

struct NodeBuffer_552Struct {
	nodeUniform6 : array< vec2<f32> >

};
@binding( 6 ) @group( 1 )
var<storage, read> NodeBuffer_552 : NodeBuffer_552Struct;
```