### PR TITLE
WebGPURenderer: Handle Device Lost Event

### DIFF
--- a/src/renderers/common/Backend.js
+++ b/src/renderers/common/Backend.js
@@ -193,6 +193,8 @@ class Backend {
 
 	}
 
+	dispose() { }
+
 }
 
 export default Backend;

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -143,7 +143,7 @@ class Renderer {
 
 		this._handleObjectFunction = this._renderObjectDirect;
 
-		this._isDeviceLost = null;
+		this._isDeviceLost = false;
 		this.onDeviceLost = this._onDeviceLost;
 
 		this._initialized = false;
@@ -267,6 +267,8 @@ class Renderer {
 	}
 
 	async compileAsync( scene, camera, targetScene = null ) {
+
+		if ( this._isDeviceLost === true ) return;
 
 		if ( this._initialized === false ) await this.init();
 
@@ -433,7 +435,7 @@ class Renderer {
 
 		console.error( errorMessage );
 
-		this.isDeviceLost = true;
+		this._isDeviceLost = true;
 
 	}
 
@@ -572,7 +574,7 @@ class Renderer {
 
 	_renderScene( scene, camera, useFrameBufferTarget = true ) {
 
-		if ( this.isDeviceLost === true ) return;
+		if ( this._isDeviceLost === true ) return;
 
 		const frameBufferTarget = useFrameBufferTarget ? this._getFrameBufferTarget() : null;
 
@@ -1142,6 +1144,7 @@ class Renderer {
 	dispose() {
 
 		this.info.dispose();
+		this.backend.dispose();
 
 		this._animation.dispose();
 		this._objects.dispose();

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -143,6 +143,9 @@ class Renderer {
 
 		this._handleObjectFunction = this._renderObjectDirect;
 
+		this._isDeviceLost = null;
+		this.onDeviceLost = this._onDeviceLost;
+
 		this._initialized = false;
 		this._initPromise = null;
 
@@ -418,6 +421,23 @@ class Renderer {
 
 	}
 
+	_onDeviceLost( info ) {
+
+		let errorMessage = `THREE.WebGPURenderer: ${info.api} Device Lost:\n\nMessage: ${info.message}`;
+
+		if ( info.reason ) {
+
+			errorMessage += `\nReason: ${info.reason}`;
+
+		}
+
+		console.error( errorMessage );
+
+		this.isDeviceLost = true;
+
+	}
+
+
 	_renderBundle( bundle, sceneRef, lightsNode ) {
 
 		const { bundleGroup, camera, renderList } = bundle;
@@ -551,6 +571,8 @@ class Renderer {
 	}
 
 	_renderScene( scene, camera, useFrameBufferTarget = true ) {
+
+		if ( this.isDeviceLost === true ) return;
 
 		const frameBufferTarget = useFrameBufferTarget ? this._getFrameBufferTarget() : null;
 
@@ -1162,6 +1184,8 @@ class Renderer {
 	}
 
 	compute( computeNodes ) {
+
+		if ( this.isDeviceLost === true ) return;
 
 		if ( this._initialized === false ) {
 

--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -48,6 +48,7 @@ class WebGLBackend extends Backend {
 			};
 
 			renderer.onDeviceLost( contextLossInfo );
+			renderer.domElement.removeEventListener( 'webglcontextlost', onContextLost, false );
 
 		}
 

--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -36,7 +36,7 @@ class WebGLBackend extends Backend {
 
 		const glContext = ( parameters.context !== undefined ) ? parameters.context : renderer.domElement.getContext( 'webgl2' );
 
-		function onContextLost( event ) {
+	 	function onContextLost( event ) {
 
 			event.preventDefault();
 
@@ -48,9 +48,10 @@ class WebGLBackend extends Backend {
 			};
 
 			renderer.onDeviceLost( contextLossInfo );
-			renderer.domElement.removeEventListener( 'webglcontextlost', onContextLost, false );
 
 		}
+
+		this._onContextLost = onContextLost.bind( this );
 
 		renderer.domElement.addEventListener( 'webglcontextlost', onContextLost, false );
 
@@ -1671,6 +1672,12 @@ class WebGLBackend extends Backend {
 			}
 
 		}
+
+	}
+
+	dispose() {
+
+		this.renderer.domElement.removeEventListener( 'webglcontextlost', this._onContextLost );
 
 	}
 

--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -36,6 +36,23 @@ class WebGLBackend extends Backend {
 
 		const glContext = ( parameters.context !== undefined ) ? parameters.context : renderer.domElement.getContext( 'webgl2' );
 
+		function onContextLost( event ) {
+
+			event.preventDefault();
+
+			const contextLossInfo = {
+				api: 'WebGL',
+				message: event.statusMessage || 'Unknown reason',
+				reason: null,
+				originalEvent: event
+			};
+
+			renderer.onDeviceLost( contextLossInfo );
+
+		}
+
+		renderer.domElement.addEventListener( 'webglcontextlost', onContextLost, false );
+
 		this.gl = glContext;
 
 		this.extensions = new WebGLExtensions( this );

--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -51,7 +51,7 @@ class WebGLBackend extends Backend {
 
 		}
 
-		this._onContextLost = onContextLost.bind( this );
+		this._onContextLost = onContextLost;
 
 		renderer.domElement.addEventListener( 'webglcontextlost', onContextLost, false );
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -101,6 +101,19 @@ class WebGPUBackend extends Backend {
 
 		}
 
+		device.lost.then( ( info ) => {
+
+			const contextLossInfo = {
+				api: 'WebGPU',
+				message: info.message || 'Unknown reason',
+				reason: info.reason || null,
+				originalEvent: info
+			};
+
+			renderer.onDeviceLost( contextLossInfo );
+
+		} );
+
 		const context = ( parameters.context !== undefined ) ? parameters.context : renderer.domElement.getContext( 'webgpu' );
 
 		this.device = device;

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -103,14 +103,14 @@ class WebGPUBackend extends Backend {
 
 		device.lost.then( ( info ) => {
 
-			const contextLossInfo = {
+			const deviceLossInfo = {
 				api: 'WebGPU',
 				message: info.message || 'Unknown reason',
 				reason: info.reason || null,
 				originalEvent: info
 			};
 
-			renderer.onDeviceLost( contextLossInfo );
+			renderer.onDeviceLost( deviceLossInfo );
 
 		} );
 


### PR DESCRIPTION
**Description**
Handle device/context Lost Event on both backends of the WebGPURenderer.

By default a formatted error will appear like so:
![Screenshot 2024-10-30 at 11 37 31](https://github.com/user-attachments/assets/7da5c772-67fb-4271-99a2-6b380dda78fa)
And just like in the `WebGLRenderer`, both loop will throw an early return.


Also added a way to easily handle the error for the developer:
```js
renderer.onDeviceLost = ( info ) => console.log( 'Device Lost', info );
```
![Screenshot 2024-10-30 at 11 38 08](https://github.com/user-attachments/assets/76fd9ddc-6247-4586-bafa-194250559a36)

Even better, unlike WebGL, we could even gracefully restart the app/device in WebGPU:
```js
renderer.onDeviceLost = ( _info ) => await renderer.init()
```

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Utsubo](https://utsubo.com)*
