### PR TITLE
RectAreaLightNode: Fix `update()`.

### DIFF
--- a/src/nodes/lighting/RectAreaLightNode.js
+++ b/src/nodes/lighting/RectAreaLightNode.js
@@ -6,6 +6,7 @@ import { renderGroup } from '../core/UniformGroupNode.js';
 
 import { Matrix4 } from '../../math/Matrix4.js';
 import { Vector3 } from '../../math/Vector3.js';
+import { NodeUpdateType } from '../core/constants.js';
 
 const _matrix41 = /*@__PURE__*/ new Matrix4();
 const _matrix42 = /*@__PURE__*/ new Matrix4();
@@ -26,6 +27,8 @@ class RectAreaLightNode extends AnalyticLightNode {
 
 		this.halfHeight = uniform( new Vector3() ).setGroup( renderGroup );
 		this.halfWidth = uniform( new Vector3() ).setGroup( renderGroup );
+
+		this.updateType = NodeUpdateType.RENDER;
 
 	}
 


### PR DESCRIPTION
Related issue: -

**Description**

The PR fixes a bug in `RectAreaLightNode` that appears when you produce a frame with more than one `render()` call and different cameras. My use case was updating a `CubeCamera` per frame and using its cube render target as a texture for objects.

The default update type of analytical light nodes in `FRAME`. This is fine for most modules but `RectAreaLightNode` depends on the view matrix in its `update()` method. If there is only a single update per frame, `RectAreaLightNode` uses wrong uniform values when rendering the scene with subsequent cameras.