### PR TITLE
WebGPURenderer: Make `Animation` WebXR compatible.

### DIFF
--- a/src/renderers/common/Animation.js
+++ b/src/renderers/common/Animation.js
@@ -5,18 +5,17 @@ class Animation {
 		this.nodes = nodes;
 		this.info = info;
 
-		this.animationLoop = null;
-		this.requestId = null;
-
-		this._init();
+		this._context = self;
+		this._animationLoop = null;
+		this._requestId = null;
 
 	}
 
-	_init() {
+	start() {
 
 		const update = ( time, frame ) => {
 
-			this.requestId = self.requestAnimationFrame( update );
+			this._requestId = this._context.requestAnimationFrame( update );
 
 			if ( this.info.autoReset === true ) this.info.reset();
 
@@ -24,7 +23,7 @@ class Animation {
 
 			this.info.frame = this.nodes.nodeFrame.frameId;
 
-			if ( this.animationLoop !== null ) this.animationLoop( time, frame );
+			if ( this._animationLoop !== null ) this._animationLoop( time, frame );
 
 		};
 
@@ -32,16 +31,29 @@ class Animation {
 
 	}
 
-	dispose() {
+	stop() {
 
-		self.cancelAnimationFrame( this.requestId );
-		this.requestId = null;
+		this._context.cancelAnimationFrame( this._requestId );
+
+		this._requestId = null;
 
 	}
 
 	setAnimationLoop( callback ) {
 
-		this.animationLoop = callback;
+		this._animationLoop = callback;
+
+	}
+
+	setContext( context ) {
+
+		this._context = context;
+
+	}
+
+	dispose() {
+
+		this.stop();
 
 	}
 

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -250,6 +250,7 @@ class Renderer {
 
 			//
 
+			this._animation.start();
 			this._initialized = true;
 
 			resolve();


### PR DESCRIPTION
Related issue: #28968

**Description**

This is a first gentle step towards WebXR support in `WebGPURenderer`. The internal `Animation` module must be refactored a bit so it can be used in an upcoming `XRManager` module. 

A native `XRSession` object offers similar to `window` a `requestAnimationFrame()` function. When presenting, it must be used instead of the `window` version. `WebXRManager` also overwrites the animation loop which is set on app level (via `renderer.setAnimationLoop()`) which is why the module currently uses an own instance of `Animation`.

To make this work, `Animation` requires `start()` and `stop()` methods as well as `setContext()`. `setContext()` is later used in `XRManager` with the current XR session object. `_init()` is replaced with `start()`.
