### PR TITLE
WebGPURenderer: Make sure default instance of `CompressedTexture` works.

### DIFF
--- a/src/renderers/common/Textures.js
+++ b/src/renderers/common/Textures.js
@@ -300,8 +300,8 @@ class Textures extends DataMap {
 
 			if ( image.image !== undefined ) image = image.image;
 
-			target.width = image.width;
-			target.height = image.height;
+			target.width = image.width || 1;
+			target.height = image.height || 1;
 			target.depth = texture.isCubeTexture ? 6 : ( image.depth || 1 );
 
 		} else {
@@ -320,7 +320,15 @@ class Textures extends DataMap {
 
 		if ( texture.isCompressedTexture ) {
 
-			mipLevelCount = texture.mipmaps.length;
+			if ( texture.mipmaps ) {
+
+				mipLevelCount = texture.mipmaps.length;
+
+			} else {
+
+				mipLevelCount = 1;
+
+			}
 
 		} else {
 

--- a/src/renderers/webgpu/utils/WebGPUTextureUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUTextureUtils.js
@@ -952,6 +952,10 @@ export function getFormat( texture, device = null ) {
 				formatGPU = ( colorSpace === SRGBColorSpace ) ? GPUTextureFormat.ASTC12x12UnormSRGB : GPUTextureFormat.ASTC12x12Unorm;
 				break;
 
+			case RGBAFormat:
+				formatGPU = ( colorSpace === SRGBColorSpace ) ? GPUTextureFormat.RGBA8UnormSRGB : GPUTextureFormat.RGBA8Unorm;
+				break;
+
 			default:
 				console.error( 'WebGPURenderer: Unsupported texture format.', format );
 


### PR DESCRIPTION
Fixed #29785.

**Description**

The PR makes sure a default instance of `CompressedTexture` does not throw any runtime errors in `WebGPURenderer`.
