### PR TITLE
Materials: Revert static types of builtins materials

### DIFF
--- a/examples/jsm/lines/LineMaterial.js
+++ b/examples/jsm/lines/LineMaterial.js
@@ -405,17 +405,11 @@ ShaderLib[ 'line' ] = {
 
 class LineMaterial extends ShaderMaterial {
 
-
-	static get type() {
-
-		return 'LineMaterial';
-
-	}
-
 	constructor( parameters ) {
 
 		super( {
 
+			type: 'LineMaterial',
 			uniforms: UniformsUtils.clone( ShaderLib[ 'line' ].uniforms ),
 
 			vertexShader: ShaderLib[ 'line' ].vertexShader,

--- a/examples/jsm/loaders/MMDLoader.js
+++ b/examples/jsm/loaders/MMDLoader.js
@@ -2131,17 +2131,13 @@ class CubicBezierInterpolation extends Interpolant {
 
 class MMDToonMaterial extends ShaderMaterial {
 
-	static get type() {
-
-		return 'MMDToonMaterial';
-
-	}
-
 	constructor( parameters ) {
 
 		super();
 
 		this.isMMDToonMaterial = true;
+
+		this.type = 'MMDToonMaterial';
 
 		this._matcapCombine = AddOperation;
 		this.emissiveIntensity = 1.0;

--- a/examples/jsm/materials/MeshGouraudMaterial.js
+++ b/examples/jsm/materials/MeshGouraudMaterial.js
@@ -315,17 +315,13 @@ const GouraudShader = {
 
 class MeshGouraudMaterial extends ShaderMaterial {
 
-	static get type() {
-
-		return 'MeshGouraudMaterial';
-
-	}
-
 	constructor( parameters ) {
 
 		super();
 
 		this.isMeshGouraudMaterial = true;
+
+		this.type = 'MeshGouraudMaterial';
 
 		//this.color = new THREE.Color( 0xffffff ); // diffuse
 

--- a/src/materials/LineBasicMaterial.js
+++ b/src/materials/LineBasicMaterial.js
@@ -3,17 +3,13 @@ import { Color } from '../math/Color.js';
 
 class LineBasicMaterial extends Material {
 
-	static get type() {
-
-		return 'LineBasicMaterial';
-
-	}
-
 	constructor( parameters ) {
 
 		super();
 
 		this.isLineBasicMaterial = true;
+
+		this.type = 'LineBasicMaterial';
 
 		this.color = new Color( 0xffffff );
 

--- a/src/materials/LineDashedMaterial.js
+++ b/src/materials/LineDashedMaterial.js
@@ -2,17 +2,12 @@ import { LineBasicMaterial } from './LineBasicMaterial.js';
 
 class LineDashedMaterial extends LineBasicMaterial {
 
-	static get type() {
-
-		return 'LineDashedMaterial';
-
-	}
-
 	constructor( parameters ) {
 
 		super();
 
 		this.isLineDashedMaterial = true;
+		this.type = 'LineDashedMaterial';
 
 		this.scale = 1;
 		this.dashSize = 3;

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -7,20 +7,6 @@ let _materialId = 0;
 
 class Material extends EventDispatcher {
 
-	static get type() {
-
-		return 'Material';
-
-	}
-
-	get type() {
-
-		return this.constructor.type;
-
-	}
-
-	set type( _value ) { /* */ }
-
 	constructor() {
 
 		super();
@@ -32,6 +18,7 @@ class Material extends EventDispatcher {
 		this.uuid = MathUtils.generateUUID();
 
 		this.name = '';
+		this.type = 'Material';
 
 		this.blending = NormalBlending;
 		this.side = FrontSide;

--- a/src/materials/MeshBasicMaterial.js
+++ b/src/materials/MeshBasicMaterial.js
@@ -1,6 +1,7 @@
 import { Material } from './Material.js';
 import { MultiplyOperation } from '../constants.js';
 import { Color } from '../math/Color.js';
+import { Euler } from '../math/Euler.js';
 
 class MeshBasicMaterial extends Material {
 
@@ -27,6 +28,7 @@ class MeshBasicMaterial extends Material {
 		this.alphaMap = null;
 
 		this.envMap = null;
+		this.envMapRotation = new Euler();
 		this.combine = MultiplyOperation;
 		this.reflectivity = 1;
 		this.refractionRatio = 0.98;
@@ -61,6 +63,7 @@ class MeshBasicMaterial extends Material {
 		this.alphaMap = source.alphaMap;
 
 		this.envMap = source.envMap;
+		this.envMapRotation.copy( source.envMapRotation );
 		this.combine = source.combine;
 		this.reflectivity = source.reflectivity;
 		this.refractionRatio = source.refractionRatio;

--- a/src/materials/MeshBasicMaterial.js
+++ b/src/materials/MeshBasicMaterial.js
@@ -1,21 +1,16 @@
 import { Material } from './Material.js';
 import { MultiplyOperation } from '../constants.js';
 import { Color } from '../math/Color.js';
-import { Euler } from '../math/Euler.js';
 
 class MeshBasicMaterial extends Material {
-
-	static get type() {
-
-		return 'MeshBasicMaterial';
-
-	}
 
 	constructor( parameters ) {
 
 		super();
 
 		this.isMeshBasicMaterial = true;
+
+		this.type = 'MeshBasicMaterial';
 
 		this.color = new Color( 0xffffff ); // emissive
 
@@ -32,7 +27,6 @@ class MeshBasicMaterial extends Material {
 		this.alphaMap = null;
 
 		this.envMap = null;
-		this.envMapRotation = new Euler();
 		this.combine = MultiplyOperation;
 		this.reflectivity = 1;
 		this.refractionRatio = 0.98;
@@ -67,7 +61,6 @@ class MeshBasicMaterial extends Material {
 		this.alphaMap = source.alphaMap;
 
 		this.envMap = source.envMap;
-		this.envMapRotation.copy( source.envMapRotation );
 		this.combine = source.combine;
 		this.reflectivity = source.reflectivity;
 		this.refractionRatio = source.refractionRatio;

--- a/src/materials/MeshDepthMaterial.js
+++ b/src/materials/MeshDepthMaterial.js
@@ -3,17 +3,13 @@ import { BasicDepthPacking } from '../constants.js';
 
 class MeshDepthMaterial extends Material {
 
-	static get type() {
-
-		return 'MeshDepthMaterial';
-
-	}
-
 	constructor( parameters ) {
 
 		super();
 
 		this.isMeshDepthMaterial = true;
+
+		this.type = 'MeshDepthMaterial';
 
 		this.depthPacking = BasicDepthPacking;
 

--- a/src/materials/MeshDistanceMaterial.js
+++ b/src/materials/MeshDistanceMaterial.js
@@ -1,5 +1,4 @@
 import { Material } from './Material.js';
-import { Vector3 } from '../math/Vector3.js';
 
 class MeshDistanceMaterial extends Material {
 
@@ -10,10 +9,6 @@ class MeshDistanceMaterial extends Material {
 		this.isMeshDistanceMaterial = true;
 
 		this.type = 'MeshDistanceMaterial';
-
-		this.referencePosition = new Vector3();
-		this.nearDistance = 1;
-		this.farDistance = 1000;
 
 		this.map = null;
 
@@ -30,10 +25,6 @@ class MeshDistanceMaterial extends Material {
 	copy( source ) {
 
 		super.copy( source );
-
-		this.referencePosition.copy( source.referencePosition );
-		this.nearDistance = source.nearDistance;
-		this.farDistance = source.farDistance;
 
 		this.map = source.map;
 

--- a/src/materials/MeshDistanceMaterial.js
+++ b/src/materials/MeshDistanceMaterial.js
@@ -1,18 +1,19 @@
 import { Material } from './Material.js';
+import { Vector3 } from '../math/Vector3.js';
 
 class MeshDistanceMaterial extends Material {
-
-	static get type() {
-
-		return 'MeshDistanceMaterial';
-
-	}
 
 	constructor( parameters ) {
 
 		super();
 
 		this.isMeshDistanceMaterial = true;
+
+		this.type = 'MeshDistanceMaterial';
+
+		this.referencePosition = new Vector3();
+		this.nearDistance = 1;
+		this.farDistance = 1000;
 
 		this.map = null;
 
@@ -29,6 +30,10 @@ class MeshDistanceMaterial extends Material {
 	copy( source ) {
 
 		super.copy( source );
+
+		this.referencePosition.copy( source.referencePosition );
+		this.nearDistance = source.nearDistance;
+		this.farDistance = source.farDistance;
 
 		this.map = source.map;
 

--- a/src/materials/MeshLambertMaterial.js
+++ b/src/materials/MeshLambertMaterial.js
@@ -1,6 +1,8 @@
+import { MultiplyOperation, TangentSpaceNormalMap } from '../constants.js';
 import { Material } from './Material.js';
-import { MultiplyOperation } from '../constants.js';
+import { Vector2 } from '../math/Vector2.js';
 import { Color } from '../math/Color.js';
+import { Euler } from '../math/Euler.js';
 
 class MeshLambertMaterial extends Material {
 
@@ -26,11 +28,23 @@ class MeshLambertMaterial extends Material {
 		this.emissiveIntensity = 1.0;
 		this.emissiveMap = null;
 
+		this.bumpMap = null;
+		this.bumpScale = 1;
+
+		this.normalMap = null;
+		this.normalMapType = TangentSpaceNormalMap;
+		this.normalScale = new Vector2( 1, 1 );
+
+		this.displacementMap = null;
+		this.displacementScale = 1;
+		this.displacementBias = 0;
+
 		this.specularMap = null;
 
 		this.alphaMap = null;
 
 		this.envMap = null;
+		this.envMapRotation = new Euler();
 		this.combine = MultiplyOperation;
 		this.reflectivity = 1;
 		this.refractionRatio = 0.98;
@@ -39,6 +53,8 @@ class MeshLambertMaterial extends Material {
 		this.wireframeLinewidth = 1;
 		this.wireframeLinecap = 'round';
 		this.wireframeLinejoin = 'round';
+
+		this.flatShading = false;
 
 		this.fog = true;
 
@@ -64,11 +80,23 @@ class MeshLambertMaterial extends Material {
 		this.emissiveMap = source.emissiveMap;
 		this.emissiveIntensity = source.emissiveIntensity;
 
+		this.bumpMap = source.bumpMap;
+		this.bumpScale = source.bumpScale;
+
+		this.normalMap = source.normalMap;
+		this.normalMapType = source.normalMapType;
+		this.normalScale.copy( source.normalScale );
+
+		this.displacementMap = source.displacementMap;
+		this.displacementScale = source.displacementScale;
+		this.displacementBias = source.displacementBias;
+
 		this.specularMap = source.specularMap;
 
 		this.alphaMap = source.alphaMap;
 
 		this.envMap = source.envMap;
+		this.envMapRotation.copy( source.envMapRotation );
 		this.combine = source.combine;
 		this.reflectivity = source.reflectivity;
 		this.refractionRatio = source.refractionRatio;
@@ -77,6 +105,8 @@ class MeshLambertMaterial extends Material {
 		this.wireframeLinewidth = source.wireframeLinewidth;
 		this.wireframeLinecap = source.wireframeLinecap;
 		this.wireframeLinejoin = source.wireframeLinejoin;
+
+		this.flatShading = source.flatShading;
 
 		this.fog = source.fog;
 

--- a/src/materials/MeshLambertMaterial.js
+++ b/src/materials/MeshLambertMaterial.js
@@ -1,22 +1,16 @@
-import { MultiplyOperation, TangentSpaceNormalMap } from '../constants.js';
 import { Material } from './Material.js';
-import { Vector2 } from '../math/Vector2.js';
+import { MultiplyOperation } from '../constants.js';
 import { Color } from '../math/Color.js';
-import { Euler } from '../math/Euler.js';
 
 class MeshLambertMaterial extends Material {
-
-	static get type() {
-
-		return 'MeshLambertMaterial';
-
-	}
 
 	constructor( parameters ) {
 
 		super();
 
 		this.isMeshLambertMaterial = true;
+
+		this.type = 'MeshLambertMaterial';
 
 		this.color = new Color( 0xffffff ); // diffuse
 
@@ -32,23 +26,11 @@ class MeshLambertMaterial extends Material {
 		this.emissiveIntensity = 1.0;
 		this.emissiveMap = null;
 
-		this.bumpMap = null;
-		this.bumpScale = 1;
-
-		this.normalMap = null;
-		this.normalMapType = TangentSpaceNormalMap;
-		this.normalScale = new Vector2( 1, 1 );
-
-		this.displacementMap = null;
-		this.displacementScale = 1;
-		this.displacementBias = 0;
-
 		this.specularMap = null;
 
 		this.alphaMap = null;
 
 		this.envMap = null;
-		this.envMapRotation = new Euler();
 		this.combine = MultiplyOperation;
 		this.reflectivity = 1;
 		this.refractionRatio = 0.98;
@@ -57,8 +39,6 @@ class MeshLambertMaterial extends Material {
 		this.wireframeLinewidth = 1;
 		this.wireframeLinecap = 'round';
 		this.wireframeLinejoin = 'round';
-
-		this.flatShading = false;
 
 		this.fog = true;
 
@@ -84,23 +64,11 @@ class MeshLambertMaterial extends Material {
 		this.emissiveMap = source.emissiveMap;
 		this.emissiveIntensity = source.emissiveIntensity;
 
-		this.bumpMap = source.bumpMap;
-		this.bumpScale = source.bumpScale;
-
-		this.normalMap = source.normalMap;
-		this.normalMapType = source.normalMapType;
-		this.normalScale.copy( source.normalScale );
-
-		this.displacementMap = source.displacementMap;
-		this.displacementScale = source.displacementScale;
-		this.displacementBias = source.displacementBias;
-
 		this.specularMap = source.specularMap;
 
 		this.alphaMap = source.alphaMap;
 
 		this.envMap = source.envMap;
-		this.envMapRotation.copy( source.envMapRotation );
 		this.combine = source.combine;
 		this.reflectivity = source.reflectivity;
 		this.refractionRatio = source.refractionRatio;
@@ -109,8 +77,6 @@ class MeshLambertMaterial extends Material {
 		this.wireframeLinewidth = source.wireframeLinewidth;
 		this.wireframeLinecap = source.wireframeLinecap;
 		this.wireframeLinejoin = source.wireframeLinejoin;
-
-		this.flatShading = source.flatShading;
 
 		this.fog = source.fog;
 

--- a/src/materials/MeshMatcapMaterial.js
+++ b/src/materials/MeshMatcapMaterial.js
@@ -5,12 +5,6 @@ import { Color } from '../math/Color.js';
 
 class MeshMatcapMaterial extends Material {
 
-	static get type() {
-
-		return 'MeshMatcapMaterial';
-
-	}
-
 	constructor( parameters ) {
 
 		super();
@@ -18,6 +12,8 @@ class MeshMatcapMaterial extends Material {
 		this.isMeshMatcapMaterial = true;
 
 		this.defines = { 'MATCAP': '' };
+
+		this.type = 'MeshMatcapMaterial';
 
 		this.color = new Color( 0xffffff ); // diffuse
 

--- a/src/materials/MeshNormalMaterial.js
+++ b/src/materials/MeshNormalMaterial.js
@@ -4,17 +4,13 @@ import { Vector2 } from '../math/Vector2.js';
 
 class MeshNormalMaterial extends Material {
 
-	static get type() {
-
-		return 'MeshNormalMaterial';
-
-	}
-
 	constructor( parameters ) {
 
 		super();
 
 		this.isMeshNormalMaterial = true;
+
+		this.type = 'MeshNormalMaterial';
 
 		this.bumpMap = null;
 		this.bumpScale = 1;

--- a/src/materials/MeshPhongMaterial.js
+++ b/src/materials/MeshPhongMaterial.js
@@ -2,7 +2,7 @@ import { MultiplyOperation, TangentSpaceNormalMap } from '../constants.js';
 import { Material } from './Material.js';
 import { Vector2 } from '../math/Vector2.js';
 import { Color } from '../math/Color.js';
-
+import { Euler } from '../math/Euler.js';
 class MeshPhongMaterial extends Material {
 
 	constructor( parameters ) {
@@ -45,6 +45,8 @@ class MeshPhongMaterial extends Material {
 		this.alphaMap = null;
 
 		this.envMap = null;
+		this.envMapRotation = new Euler();
+
 		this.combine = MultiplyOperation;
 		this.reflectivity = 1;
 		this.refractionRatio = 0.98;
@@ -98,6 +100,7 @@ class MeshPhongMaterial extends Material {
 		this.alphaMap = source.alphaMap;
 
 		this.envMap = source.envMap;
+		this.envMapRotation.copy( source.envMapRotation );
 		this.combine = source.combine;
 		this.reflectivity = source.reflectivity;
 		this.refractionRatio = source.refractionRatio;

--- a/src/materials/MeshPhongMaterial.js
+++ b/src/materials/MeshPhongMaterial.js
@@ -2,21 +2,16 @@ import { MultiplyOperation, TangentSpaceNormalMap } from '../constants.js';
 import { Material } from './Material.js';
 import { Vector2 } from '../math/Vector2.js';
 import { Color } from '../math/Color.js';
-import { Euler } from '../math/Euler.js';
 
 class MeshPhongMaterial extends Material {
-
-	static get type() {
-
-		return 'MeshPhongMaterial';
-
-	}
 
 	constructor( parameters ) {
 
 		super();
 
 		this.isMeshPhongMaterial = true;
+
+		this.type = 'MeshPhongMaterial';
 
 		this.color = new Color( 0xffffff ); // diffuse
 		this.specular = new Color( 0x111111 );
@@ -50,7 +45,6 @@ class MeshPhongMaterial extends Material {
 		this.alphaMap = null;
 
 		this.envMap = null;
-		this.envMapRotation = new Euler();
 		this.combine = MultiplyOperation;
 		this.reflectivity = 1;
 		this.refractionRatio = 0.98;
@@ -104,7 +98,6 @@ class MeshPhongMaterial extends Material {
 		this.alphaMap = source.alphaMap;
 
 		this.envMap = source.envMap;
-		this.envMapRotation.copy( source.envMapRotation );
 		this.combine = source.combine;
 		this.reflectivity = source.reflectivity;
 		this.refractionRatio = source.refractionRatio;

--- a/src/materials/MeshPhysicalMaterial.js
+++ b/src/materials/MeshPhysicalMaterial.js
@@ -20,6 +20,9 @@ class MeshPhysicalMaterial extends MeshStandardMaterial {
 
 		this.type = 'MeshPhysicalMaterial';
 
+		this.anisotropyRotation = 0;
+		this.anisotropyMap = null;
+
 		this.clearcoatMap = null;
 		this.clearcoatRoughness = 0.0;
 		this.clearcoatRoughnessMap = null;
@@ -41,6 +44,11 @@ class MeshPhysicalMaterial extends MeshStandardMaterial {
 			}
 		} );
 
+		this.iridescenceMap = null;
+		this.iridescenceIOR = 1.3;
+		this.iridescenceThicknessRange = [ 100, 400 ];
+		this.iridescenceThicknessMap = null;
+
 		this.sheenColor = new Color( 0x000000 );
 		this.sheenColorMap = null;
 		this.sheenRoughness = 1.0;
@@ -50,7 +58,7 @@ class MeshPhysicalMaterial extends MeshStandardMaterial {
 
 		this.thickness = 0;
 		this.thicknessMap = null;
-		this.attenuationDistance = 0.0;
+		this.attenuationDistance = Infinity;
 		this.attenuationColor = new Color( 1, 1, 1 );
 
 		this.specularIntensity = 1.0;
@@ -58,29 +66,32 @@ class MeshPhysicalMaterial extends MeshStandardMaterial {
 		this.specularColor = new Color( 1, 1, 1 );
 		this.specularColorMap = null;
 
-		this._sheen = 0.0;
+		this._anisotropy = 0;
 		this._clearcoat = 0;
+		this._dispersion = 0;
+		this._iridescence = 0;
+		this._sheen = 0.0;
 		this._transmission = 0;
 
 		this.setValues( parameters );
 
 	}
 
-	get sheen() {
+	get anisotropy() {
 
-		return this._sheen;
+		return this._anisotropy;
 
 	}
 
-	set sheen( value ) {
+	set anisotropy( value ) {
 
-		if ( this._sheen > 0 !== value > 0 ) {
+		if ( this._anisotropy > 0 !== value > 0 ) {
 
 			this.version ++;
 
 		}
 
-		this._sheen = value;
+		this._anisotropy = value;
 
 	}
 
@@ -99,6 +110,60 @@ class MeshPhysicalMaterial extends MeshStandardMaterial {
 		}
 
 		this._clearcoat = value;
+
+	}
+
+	get iridescence() {
+
+		return this._iridescence;
+
+	}
+
+	set iridescence( value ) {
+
+		if ( this._iridescence > 0 !== value > 0 ) {
+
+			this.version ++;
+
+		}
+
+		this._iridescence = value;
+
+	}
+
+	get dispersion() {
+
+		return this._dispersion;
+
+	}
+
+	set dispersion( value ) {
+
+		if ( this._dispersion > 0 !== value > 0 ) {
+
+			this.version ++;
+
+		}
+
+		this._dispersion = value;
+
+	}
+
+	get sheen() {
+
+		return this._sheen;
+
+	}
+
+	set sheen( value ) {
+
+		if ( this._sheen > 0 !== value > 0 ) {
+
+			this.version ++;
+
+		}
+
+		this._sheen = value;
 
 	}
 
@@ -131,6 +196,10 @@ class MeshPhysicalMaterial extends MeshStandardMaterial {
 
 		};
 
+		this.anisotropy = source.anisotropy;
+		this.anisotropyRotation = source.anisotropyRotation;
+		this.anisotropyMap = source.anisotropyMap;
+
 		this.clearcoat = source.clearcoat;
 		this.clearcoatMap = source.clearcoatMap;
 		this.clearcoatRoughness = source.clearcoatRoughness;
@@ -138,7 +207,14 @@ class MeshPhysicalMaterial extends MeshStandardMaterial {
 		this.clearcoatNormalMap = source.clearcoatNormalMap;
 		this.clearcoatNormalScale.copy( source.clearcoatNormalScale );
 
+		this.dispersion = source.dispersion;
 		this.ior = source.ior;
+
+		this.iridescence = source.iridescence;
+		this.iridescenceMap = source.iridescenceMap;
+		this.iridescenceIOR = source.iridescenceIOR;
+		this.iridescenceThicknessRange = [ ...source.iridescenceThicknessRange ];
+		this.iridescenceThicknessMap = source.iridescenceThicknessMap;
 
 		this.sheen = source.sheen;
 		this.sheenColor.copy( source.sheenColor );

--- a/src/materials/MeshPhysicalMaterial.js
+++ b/src/materials/MeshPhysicalMaterial.js
@@ -5,12 +5,6 @@ import * as MathUtils from '../math/MathUtils.js';
 
 class MeshPhysicalMaterial extends MeshStandardMaterial {
 
-	static get type() {
-
-		return 'MeshPhysicalMaterial';
-
-	}
-
 	constructor( parameters ) {
 
 		super();
@@ -24,8 +18,7 @@ class MeshPhysicalMaterial extends MeshStandardMaterial {
 
 		};
 
-		this.anisotropyRotation = 0;
-		this.anisotropyMap = null;
+		this.type = 'MeshPhysicalMaterial';
 
 		this.clearcoatMap = null;
 		this.clearcoatRoughness = 0.0;
@@ -48,11 +41,6 @@ class MeshPhysicalMaterial extends MeshStandardMaterial {
 			}
 		} );
 
-		this.iridescenceMap = null;
-		this.iridescenceIOR = 1.3;
-		this.iridescenceThicknessRange = [ 100, 400 ];
-		this.iridescenceThicknessMap = null;
-
 		this.sheenColor = new Color( 0x000000 );
 		this.sheenColorMap = null;
 		this.sheenRoughness = 1.0;
@@ -62,7 +50,7 @@ class MeshPhysicalMaterial extends MeshStandardMaterial {
 
 		this.thickness = 0;
 		this.thicknessMap = null;
-		this.attenuationDistance = Infinity;
+		this.attenuationDistance = 0.0;
 		this.attenuationColor = new Color( 1, 1, 1 );
 
 		this.specularIntensity = 1.0;
@@ -70,86 +58,11 @@ class MeshPhysicalMaterial extends MeshStandardMaterial {
 		this.specularColor = new Color( 1, 1, 1 );
 		this.specularColorMap = null;
 
-		this._anisotropy = 0;
-		this._clearcoat = 0;
-		this._dispersion = 0;
-		this._iridescence = 0;
 		this._sheen = 0.0;
+		this._clearcoat = 0;
 		this._transmission = 0;
 
 		this.setValues( parameters );
-
-	}
-
-	get anisotropy() {
-
-		return this._anisotropy;
-
-	}
-
-	set anisotropy( value ) {
-
-		if ( this._anisotropy > 0 !== value > 0 ) {
-
-			this.version ++;
-
-		}
-
-		this._anisotropy = value;
-
-	}
-
-	get clearcoat() {
-
-		return this._clearcoat;
-
-	}
-
-	set clearcoat( value ) {
-
-		if ( this._clearcoat > 0 !== value > 0 ) {
-
-			this.version ++;
-
-		}
-
-		this._clearcoat = value;
-
-	}
-
-	get iridescence() {
-
-		return this._iridescence;
-
-	}
-
-	set iridescence( value ) {
-
-		if ( this._iridescence > 0 !== value > 0 ) {
-
-			this.version ++;
-
-		}
-
-		this._iridescence = value;
-
-	}
-
-	get dispersion() {
-
-		return this._dispersion;
-
-	}
-
-	set dispersion( value ) {
-
-		if ( this._dispersion > 0 !== value > 0 ) {
-
-			this.version ++;
-
-		}
-
-		this._dispersion = value;
 
 	}
 
@@ -168,6 +81,24 @@ class MeshPhysicalMaterial extends MeshStandardMaterial {
 		}
 
 		this._sheen = value;
+
+	}
+
+	get clearcoat() {
+
+		return this._clearcoat;
+
+	}
+
+	set clearcoat( value ) {
+
+		if ( this._clearcoat > 0 !== value > 0 ) {
+
+			this.version ++;
+
+		}
+
+		this._clearcoat = value;
 
 	}
 
@@ -200,10 +131,6 @@ class MeshPhysicalMaterial extends MeshStandardMaterial {
 
 		};
 
-		this.anisotropy = source.anisotropy;
-		this.anisotropyRotation = source.anisotropyRotation;
-		this.anisotropyMap = source.anisotropyMap;
-
 		this.clearcoat = source.clearcoat;
 		this.clearcoatMap = source.clearcoatMap;
 		this.clearcoatRoughness = source.clearcoatRoughness;
@@ -211,14 +138,7 @@ class MeshPhysicalMaterial extends MeshStandardMaterial {
 		this.clearcoatNormalMap = source.clearcoatNormalMap;
 		this.clearcoatNormalScale.copy( source.clearcoatNormalScale );
 
-		this.dispersion = source.dispersion;
 		this.ior = source.ior;
-
-		this.iridescence = source.iridescence;
-		this.iridescenceMap = source.iridescenceMap;
-		this.iridescenceIOR = source.iridescenceIOR;
-		this.iridescenceThicknessRange = [ ...source.iridescenceThicknessRange ];
-		this.iridescenceThicknessMap = source.iridescenceThicknessMap;
 
 		this.sheen = source.sheen;
 		this.sheenColor.copy( source.sheenColor );

--- a/src/materials/MeshStandardMaterial.js
+++ b/src/materials/MeshStandardMaterial.js
@@ -2,6 +2,7 @@ import { TangentSpaceNormalMap } from '../constants.js';
 import { Material } from './Material.js';
 import { Vector2 } from '../math/Vector2.js';
 import { Color } from '../math/Color.js';
+import { Euler } from '../math/Euler.js';
 
 class MeshStandardMaterial extends Material {
 
@@ -11,9 +12,9 @@ class MeshStandardMaterial extends Material {
 
 		this.isMeshStandardMaterial = true;
 
-		this.defines = { 'STANDARD': '' };
-
 		this.type = 'MeshStandardMaterial';
+
+		this.defines = { 'STANDARD': '' };
 
 		this.color = new Color( 0xffffff ); // diffuse
 		this.roughness = 1.0;
@@ -49,6 +50,7 @@ class MeshStandardMaterial extends Material {
 		this.alphaMap = null;
 
 		this.envMap = null;
+		this.envMapRotation = new Euler();
 		this.envMapIntensity = 1.0;
 
 		this.wireframe = false;
@@ -104,6 +106,7 @@ class MeshStandardMaterial extends Material {
 		this.alphaMap = source.alphaMap;
 
 		this.envMap = source.envMap;
+		this.envMapRotation.copy( source.envMapRotation );
 		this.envMapIntensity = source.envMapIntensity;
 
 		this.wireframe = source.wireframe;

--- a/src/materials/MeshStandardMaterial.js
+++ b/src/materials/MeshStandardMaterial.js
@@ -2,15 +2,8 @@ import { TangentSpaceNormalMap } from '../constants.js';
 import { Material } from './Material.js';
 import { Vector2 } from '../math/Vector2.js';
 import { Color } from '../math/Color.js';
-import { Euler } from '../math/Euler.js';
 
 class MeshStandardMaterial extends Material {
-
-	static get type() {
-
-		return 'MeshStandardMaterial';
-
-	}
 
 	constructor( parameters ) {
 
@@ -19,6 +12,8 @@ class MeshStandardMaterial extends Material {
 		this.isMeshStandardMaterial = true;
 
 		this.defines = { 'STANDARD': '' };
+
+		this.type = 'MeshStandardMaterial';
 
 		this.color = new Color( 0xffffff ); // diffuse
 		this.roughness = 1.0;
@@ -54,7 +49,6 @@ class MeshStandardMaterial extends Material {
 		this.alphaMap = null;
 
 		this.envMap = null;
-		this.envMapRotation = new Euler();
 		this.envMapIntensity = 1.0;
 
 		this.wireframe = false;
@@ -110,7 +104,6 @@ class MeshStandardMaterial extends Material {
 		this.alphaMap = source.alphaMap;
 
 		this.envMap = source.envMap;
-		this.envMapRotation.copy( source.envMapRotation );
 		this.envMapIntensity = source.envMapIntensity;
 
 		this.wireframe = source.wireframe;

--- a/src/materials/MeshToonMaterial.js
+++ b/src/materials/MeshToonMaterial.js
@@ -5,12 +5,6 @@ import { Color } from '../math/Color.js';
 
 class MeshToonMaterial extends Material {
 
-	static get type() {
-
-		return 'MeshToonMaterial';
-
-	}
-
 	constructor( parameters ) {
 
 		super();
@@ -18,6 +12,8 @@ class MeshToonMaterial extends Material {
 		this.isMeshToonMaterial = true;
 
 		this.defines = { 'TOON': '' };
+
+		this.type = 'MeshToonMaterial';
 
 		this.color = new Color( 0xffffff );
 

--- a/src/materials/PointsMaterial.js
+++ b/src/materials/PointsMaterial.js
@@ -3,17 +3,13 @@ import { Color } from '../math/Color.js';
 
 class PointsMaterial extends Material {
 
-	static get type() {
-
-		return 'PointsMaterial';
-
-	}
-
 	constructor( parameters ) {
 
 		super();
 
 		this.isPointsMaterial = true;
+
+		this.type = 'PointsMaterial';
 
 		this.color = new Color( 0xffffff );
 

--- a/src/materials/RawShaderMaterial.js
+++ b/src/materials/RawShaderMaterial.js
@@ -2,17 +2,13 @@ import { ShaderMaterial } from './ShaderMaterial.js';
 
 class RawShaderMaterial extends ShaderMaterial {
 
-	static get type() {
-
-		return 'RawShaderMaterial';
-
-	}
-
 	constructor( parameters ) {
 
 		super( parameters );
 
 		this.isRawShaderMaterial = true;
+
+		this.type = 'RawShaderMaterial';
 
 	}
 

--- a/src/materials/ShaderMaterial.js
+++ b/src/materials/ShaderMaterial.js
@@ -6,17 +6,13 @@ import default_fragment from '../renderers/shaders/ShaderChunk/default_fragment.
 
 class ShaderMaterial extends Material {
 
-	static get type() {
-
-		return 'ShaderMaterial';
-
-	}
-
 	constructor( parameters ) {
 
 		super();
 
 		this.isShaderMaterial = true;
+
+		this.type = 'ShaderMaterial';
 
 		this.defines = {};
 		this.uniforms = {};

--- a/src/materials/ShadowMaterial.js
+++ b/src/materials/ShadowMaterial.js
@@ -3,17 +3,13 @@ import { Color } from '../math/Color.js';
 
 class ShadowMaterial extends Material {
 
-	static get type() {
-
-		return 'ShadowMaterial';
-
-	}
-
 	constructor( parameters ) {
 
 		super();
 
 		this.isShadowMaterial = true;
+
+		this.type = 'ShadowMaterial';
 
 		this.color = new Color( 0x000000 );
 		this.transparent = true;

--- a/src/materials/SpriteMaterial.js
+++ b/src/materials/SpriteMaterial.js
@@ -3,17 +3,13 @@ import { Color } from '../math/Color.js';
 
 class SpriteMaterial extends Material {
 
-	static get type() {
-
-		return 'SpriteMaterial';
-
-	}
-
 	constructor( parameters ) {
 
 		super();
 
 		this.isSpriteMaterial = true;
+
+		this.type = 'SpriteMaterial';
 
 		this.color = new Color( 0xffffff );
 

--- a/src/materials/nodes/NodeMaterial.js
+++ b/src/materials/nodes/NodeMaterial.js
@@ -32,13 +32,19 @@ class NodeMaterial extends Material {
 
 	}
 
+	get type() {
+
+		return this.constructor.type;
+
+	}
+
+	set type( _value ) { /* */ }
+
 	constructor() {
 
 		super();
 
 		this.isNodeMaterial = true;
-
-		this.type = this.constructor.type;
 
 		this.forceSinglePass = false;
 

--- a/src/renderers/common/nodes/NodeLibrary.js
+++ b/src/renderers/common/nodes/NodeLibrary.js
@@ -50,9 +50,9 @@ class NodeLibrary {
 
 	}
 
-	addMaterial( materialNodeClass, materialClass ) {
+	addMaterial( materialNodeClass, materialClassType ) {
 
-		this.addType( materialNodeClass, materialClass.type, this.materialNodes );
+		this.addType( materialNodeClass, materialClassType, this.materialNodes );
 
 	}
 

--- a/src/renderers/webgpu/nodes/StandardNodeLibrary.js
+++ b/src/renderers/webgpu/nodes/StandardNodeLibrary.js
@@ -1,31 +1,18 @@
 import NodeLibrary from '../../common/nodes/NodeLibrary.js';
 
 // Materials
-import { MeshPhongMaterial } from '../../../materials/MeshPhongMaterial.js';
 import MeshPhongNodeMaterial from '../../../materials/nodes/MeshPhongNodeMaterial.js';
-import { MeshStandardMaterial } from '../../../materials/MeshStandardMaterial.js';
 import MeshStandardNodeMaterial from '../../../materials/nodes/MeshStandardNodeMaterial.js';
-import { MeshPhysicalMaterial } from '../../../materials/MeshPhysicalMaterial.js';
 import MeshPhysicalNodeMaterial from '../../../materials/nodes/MeshPhysicalNodeMaterial.js';
-import { MeshToonMaterial } from '../../../materials/MeshToonMaterial.js';
 import MeshToonNodeMaterial from '../../../materials/nodes/MeshToonNodeMaterial.js';
-import { MeshBasicMaterial } from '../../../materials/MeshBasicMaterial.js';
 import MeshBasicNodeMaterial from '../../../materials/nodes/MeshBasicNodeMaterial.js';
-import { MeshLambertMaterial } from '../../../materials/MeshLambertMaterial.js';
 import MeshLambertNodeMaterial from '../../../materials/nodes/MeshLambertNodeMaterial.js';
-import { MeshNormalMaterial } from '../../../materials/MeshNormalMaterial.js';
 import MeshNormalNodeMaterial from '../../../materials/nodes/MeshNormalNodeMaterial.js';
-import { MeshMatcapMaterial } from '../../../materials/MeshMatcapMaterial.js';
 import MeshMatcapNodeMaterial from '../../../materials/nodes/MeshMatcapNodeMaterial.js';
-import { LineBasicMaterial } from '../../../materials/LineBasicMaterial.js';
 import LineBasicNodeMaterial from '../../../materials/nodes/LineBasicNodeMaterial.js';
-import { LineDashedMaterial } from '../../../materials/LineDashedMaterial.js';
 import LineDashedNodeMaterial from '../../../materials/nodes/LineDashedNodeMaterial.js';
-import { PointsMaterial } from '../../../materials/PointsMaterial.js';
 import PointsNodeMaterial from '../../../materials/nodes/PointsNodeMaterial.js';
-import { SpriteMaterial } from '../../../materials/SpriteMaterial.js';
 import SpriteNodeMaterial from '../../../materials/nodes/SpriteNodeMaterial.js';
-import { ShadowMaterial } from '../../../materials/ShadowMaterial.js';
 import ShadowNodeMaterial from '../../../materials/nodes/ShadowNodeMaterial.js';
 //import { MeshDepthMaterial } from '../../../materials/MeshDepthMaterial.js';
 //import MeshDepthNodeMaterial from '../../../materials/nodes/MeshDepthNodeMaterial.js';
@@ -60,19 +47,19 @@ class StandardNodeLibrary extends NodeLibrary {
 
 		super();
 
-		this.addMaterial( MeshPhongNodeMaterial, MeshPhongMaterial );
-		this.addMaterial( MeshStandardNodeMaterial, MeshStandardMaterial );
-		this.addMaterial( MeshPhysicalNodeMaterial, MeshPhysicalMaterial );
-		this.addMaterial( MeshToonNodeMaterial, MeshToonMaterial );
-		this.addMaterial( MeshBasicNodeMaterial, MeshBasicMaterial );
-		this.addMaterial( MeshLambertNodeMaterial, MeshLambertMaterial );
-		this.addMaterial( MeshNormalNodeMaterial, MeshNormalMaterial );
-		this.addMaterial( MeshMatcapNodeMaterial, MeshMatcapMaterial );
-		this.addMaterial( LineBasicNodeMaterial, LineBasicMaterial );
-		this.addMaterial( LineDashedNodeMaterial, LineDashedMaterial );
-		this.addMaterial( PointsNodeMaterial, PointsMaterial );
-		this.addMaterial( SpriteNodeMaterial, SpriteMaterial );
-		this.addMaterial( ShadowNodeMaterial, ShadowMaterial );
+		this.addMaterial( MeshPhongNodeMaterial, 'MeshPhongMaterial' );
+		this.addMaterial( MeshStandardNodeMaterial, 'MeshStandardMaterial' );
+		this.addMaterial( MeshPhysicalNodeMaterial, 'MeshPhysicalMaterial' );
+		this.addMaterial( MeshToonNodeMaterial, 'MeshToonMaterial' );
+		this.addMaterial( MeshBasicNodeMaterial, 'MeshBasicMaterial' );
+		this.addMaterial( MeshLambertNodeMaterial, 'MeshLambertMaterial' );
+		this.addMaterial( MeshNormalNodeMaterial, 'MeshNormalMaterial' );
+		this.addMaterial( MeshMatcapNodeMaterial, 'MeshMatcapMaterial' );
+		this.addMaterial( LineBasicNodeMaterial, 'LineBasicMaterial' );
+		this.addMaterial( LineDashedNodeMaterial, 'LineDashedMaterial' );
+		this.addMaterial( PointsNodeMaterial, 'PointsMaterial' );
+		this.addMaterial( SpriteNodeMaterial, 'SpriteMaterial' );
+		this.addMaterial( ShadowNodeMaterial, 'ShadowMaterial' );
 
 		this.addLight( PointLightNode, PointLight );
 		this.addLight( DirectionalLightNode, DirectionalLight );


### PR DESCRIPTION
Related issue:  #29501 https://github.com/mrdoob/three.js/commit/ac963e25c6ddf9ea1f5f070e90e78529db96f701#r148635345

Description:
Found a solution for NodeLibrary that avoids breaking changes from static types by referencing the built-in material type as a string. This approach maintains existing functionality and ensures backward compatibility.

Tested the build in a production setup with Vite, confirming everything works smoothly.
This PR even reduces a bit the bundle size. 😄 

/cc @Mugen87 @FarazzShaikh @sunag 

*This contribution is funded by [Utsubo](https://utsubo.com)*
