### PR TITLE
PointerLockControls: Remove browser prefixes for "MouseEvent.movement" props

### DIFF
--- a/examples/jsm/controls/PointerLockControls.js
+++ b/examples/jsm/controls/PointerLockControls.js
@@ -127,14 +127,11 @@ function onMouseMove( event ) {
 
 	if ( this.enabled === false || this.isLocked === false ) return;
 
-	const movementX = event.movementX || event.mozMovementX || event.webkitMovementX || 0;
-	const movementY = event.movementY || event.mozMovementY || event.webkitMovementY || 0;
-
 	const camera = this.object;
 	_euler.setFromQuaternion( camera.quaternion );
 
-	_euler.y -= movementX * 0.002 * this.pointerSpeed;
-	_euler.x -= movementY * 0.002 * this.pointerSpeed;
+	_euler.y -= event.movementX * 0.002 * this.pointerSpeed;
+	_euler.x -= event.movementY * 0.002 * this.pointerSpeed;
 
 	_euler.x = Math.max( _PI_2 - this.maxPolarAngle, Math.min( _PI_2 - this.minPolarAngle, _euler.x ) );
 


### PR DESCRIPTION
**Description**

The browser support for these properties is stabilized for years (since 2015).

https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/movementX
https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/movementY
