### PR TITLE
Docs Clock: Remove outdated description

### DIFF
--- a/docs/api/ar/core/Clock.html
+++ b/docs/api/ar/core/Clock.html
@@ -8,66 +8,64 @@
 	</head>
 	<body class="rtl">
 		<h1>[name]</h1>
-	 
+
 		<p class="desc">
 		كائن لتتبع الوقت. يستخدم هذا
-		[link:https://developer.mozilla.org/en-US/docs/Web/API/Performance/now performance.now] إذا كان متاحًا، وإلا فإنه يعود إلى
-		دقة أقل
-		[link:https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Date/now Date.now].
+		[link:https://developer.mozilla.org/en-US/docs/Web/API/Performance/now performance.now].
 		</p>
-	 
+
 		<h2>المنشئ (Constructor)</h2>
-	 
+
 		<h3>[name]( [param:Boolean autoStart] )</h3>
 		<p>
 		autoStart — (اختياري) ما إذا كان يجب تشغيل الساعة تلقائيًا عندما
 		[page:.getDelta]() يتم استدعاؤه لأول مرة. الافتراضي هو `true`.
 		</p>
-	 
+
 		<h2>الخصائص (Properties)</h2>
-	 
+
 		<h3>[property:Boolean autoStart]</h3>
 		<p>
 		إذا تم تعيينه، يبدأ الساعة تلقائيًا عندما يتم استدعاء [page:.getDelta]()
 		لأول مرة. الافتراضي هو `true`.
 		</p>
-	 
+
 		<h3>[property:Float startTime]</h3>
 		<p>
 		يحمل الوقت الذي تم فيه استدعاء طريقة [page:Clock.start start] للساعة
 		آخر مرة. الافتراضي هو `0`.
 		</p>
-	 
+
 		<h3>[property:Float oldTime]</h3>
 		<p>
 		يحمل الوقت الذي تم فيه استدعاء طرق [page:Clock.start start],
 		[page:.getElapsedTime]() أو [page:.getDelta]() للساعة آخر مرة.
 		الافتراضي هو `0`.
 		</p>
-	 
+
 		<h3>[property:Float elapsedTime]</h3>
 		<p>
 		يتبع المجموع الكلي للوقت الذي كانت تعمل فيه الساعة. الافتراضي هو
 		`0`.
 		</p>
-	 
+
 		<h3>[property:Boolean running]</h3>
 		<p>ما إذا كانت الساعة تعمل أم لا. الافتراضي هو `false`.</p>
-	 
+
 		<h2>الوظائف (Methods)</h2>
-	 
+
 		<h3>[method:undefined start]()</h3>
 		<p>
 		يبدأ الساعة. كما يضبط [page:.startTime] و [page:.oldTime] على
 		الوقت الحالي، ويضبط [page:.elapsedTime] على `0` و [page:.running] على
 		`true`.
 		</p>
-	 
+
 		<h3>[method:undefined stop]()</h3>
 		<p>
 		يوقف الساعة ويضبط [page:Clock.oldTime oldTime] على الوقت الحالي.
 		</p>
-	 
+
 		<h3>[method:Float getElapsedTime]()</h3>
 		<p>
 		احصل على المجموع الكلي للثواني التي مرت منذ بدء تشغيل الساعة وضبط [page:.oldTime] على
@@ -75,7 +73,7 @@
 		إذا كان [page:.autoStart] هو `true` والساعة لا تعمل، فإنه يبدأ أيضًا
 		ساعة.
 		</p>
-	 
+
 		<h3>[method:Float getDelta]()</h3>
 		<p>
 		احصل على المجموع الكلي للثواني التي مرت منذ ضبط [page:.oldTime] وضبط

--- a/docs/api/en/core/Clock.html
+++ b/docs/api/en/core/Clock.html
@@ -11,9 +11,7 @@
 
 		<p class="desc">
 			Object for keeping track of time. This uses
-			[link:https://developer.mozilla.org/en-US/docs/Web/API/Performance/now performance.now] if it is available, otherwise it reverts to the less
-			accurate
-			[link:https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Date/now Date.now].
+			[link:https://developer.mozilla.org/en-US/docs/Web/API/Performance/now performance.now].
 		</p>
 
 		<h2>Constructor</h2>

--- a/docs/api/it/core/Clock.html
+++ b/docs/api/it/core/Clock.html
@@ -10,8 +10,7 @@
 		<h1>[name]</h1>
 
 		<p class="desc">
-      Oggetto per tenere traccia del tempo. Questa classe utilizza [link:https://developer.mozilla.org/en-US/docs/Web/API/Performance/now performance.now]
-      se disponibile, altrimenti utilizza il meno accurato [link:https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Date/now Date.now].
+    	  Oggetto per tenere traccia del tempo. Questa classe utilizza [link:https://developer.mozilla.org/en-US/docs/Web/API/Performance/now performance.now].
 		</p>
 
 		<h2>Costruttore</h2>

--- a/docs/api/ko/core/Clock.html
+++ b/docs/api/ko/core/Clock.html
@@ -10,7 +10,7 @@
 		<h1>[name]</h1>
 
 		<p class="desc">
-		시간을 파악하는 객체입니다. [link:https://developer.mozilla.org/en-US/docs/Web/API/Performance/now performance.now]를 우선적으로 사용하며, 사용이 불가능할 때는 덜 정확한 [link:https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Date/now Date.now]를 사용합니다.
+		시간을 파악하는 객체입니다. [link:https://developer.mozilla.org/en-US/docs/Web/API/Performance/now performance.now]
 		</p>
 
 

--- a/docs/api/zh/core/Clock.html
+++ b/docs/api/zh/core/Clock.html
@@ -9,8 +9,7 @@
 	<body>
 		<h1>[name]</h1>
 		<p class="desc">
-			该对象用于跟踪时间。如果[link:https://developer.mozilla.org/en-US/docs/Web/API/Performance/now performance.now]可用，则
-			Clock 对象通过该方法实现，否则回落到使用略欠精准的[link:https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Date/now Date.now]来实现。
+			该对象用于跟踪时间。如果[link:https://developer.mozilla.org/en-US/docs/Web/API/Performance/now performance.now]。
 		</p>
 
 


### PR DESCRIPTION
Fallback for Date.now has been dropped in https://github.com/mrdoob/three.js/pull/29233