### PR TITLE
Docs: Improve `GLTFExporter` page.

### DIFF
--- a/docs/examples/en/exporters/GLTFExporter.html
+++ b/docs/examples/en/exporters/GLTFExporter.html
@@ -52,6 +52,8 @@
 			<li>KHR_materials_volume</li>
 			<li>KHR_mesh_quantization</li>
 			<li>KHR_texture_transform</li>
+			<li>EXT_materials_bump</li>
+			<li>EXT_mesh_gpu_instancing</li>
 		</ul>
 
 		<p>

--- a/docs/examples/zh/exporters/GLTFExporter.html
+++ b/docs/examples/zh/exporters/GLTFExporter.html
@@ -50,6 +50,8 @@
 		<li>KHR_materials_volume</li>
 		<li>KHR_mesh_quantization</li>
 		<li>KHR_texture_transform</li>
+		<li>EXT_materials_bump</li>
+		<li>EXT_mesh_gpu_instancing</li>
 	</ul>
 
 	<p>


### PR DESCRIPTION
Fixed #29778.

**Description**

Adds missing extensions to the `GLTFExporter` documentation page.
