### PR TITLE
CSMShadowNode: Remove name collision.

### DIFF
--- a/examples/jsm/csm/CSMShadowNode.js
+++ b/examples/jsm/csm/CSMShadowNode.js
@@ -253,7 +253,7 @@ class CSMShadowNode extends Node {
 
 	setupFade() {
 
-		const cameraNear = reference( 'camera.near', 'float', this ).setGroup( renderGroup ).label( 'cameraNear' );
+		const cameraNear = reference( 'camera.near', 'float', this ).setGroup( renderGroup );
 		const cascades = reference( '_cascades', 'vec2', this ).setGroup( renderGroup ).label( 'cacades' );
 
 		const shadowFar = uniform( 'float' ).setGroup( renderGroup ).label( 'shadowFar' )
@@ -327,7 +327,7 @@ class CSMShadowNode extends Node {
 
 	setupStandard() {
 
-		const cameraNear = reference( 'camera.near', 'float', this ).setGroup( renderGroup ).label( 'cameraNear' );
+		const cameraNear = reference( 'camera.near', 'float', this ).setGroup( renderGroup );
 		const cascades = reference( '_cascades', 'vec2', this ).setGroup( renderGroup ).label( 'cacades' );
 
 		const shadowFar = uniform( 'float' ).setGroup( renderGroup ).label( 'shadowFar' )


### PR DESCRIPTION
Fixed #29810.

**Description**

The PR fixes a naming collision which occurs in `CSMShadowNode` when using logarithmic depth buffer. The name `cameraNear` is a reserved uniform name in `nodes/accessors/Camera.js`.

I consider this PR as a quick fix. Ideally, the node system can detect such collisions and fix them automatically (e.g. by using a number suffix like `cameraNear_1`).