### PR TITLE
Vector: Use `MathUtils.clamp()` internally

### DIFF
--- a/src/math/Vector2.js
+++ b/src/math/Vector2.js
@@ -240,8 +240,8 @@ class Vector2 {
 
 		// assumes min < max, componentwise
 
-		this.x = Math.max( min.x, Math.min( max.x, this.x ) );
-		this.y = Math.max( min.y, Math.min( max.y, this.y ) );
+		this.x = MathUtils.clamp( this.x, min.x, max.x );
+		this.y = MathUtils.clamp( this.y, min.y, max.y );
 
 		return this;
 
@@ -249,8 +249,8 @@ class Vector2 {
 
 	clampScalar( minVal, maxVal ) {
 
-		this.x = Math.max( minVal, Math.min( maxVal, this.x ) );
-		this.y = Math.max( minVal, Math.min( maxVal, this.y ) );
+		this.x = MathUtils.clamp( this.x, minVal, maxVal );
+		this.y = MathUtils.clamp( this.y, minVal, maxVal );
 
 		return this;
 
@@ -260,7 +260,7 @@ class Vector2 {
 
 		const length = this.length();
 
-		return this.divideScalar( length || 1 ).multiplyScalar( Math.max( min, Math.min( max, length ) ) );
+		return this.divideScalar( length || 1 ).multiplyScalar( MathUtils.clamp( length, min, max ) );
 
 	}
 

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -338,9 +338,9 @@ class Vector3 {
 
 		// assumes min < max, componentwise
 
-		this.x = Math.max( min.x, Math.min( max.x, this.x ) );
-		this.y = Math.max( min.y, Math.min( max.y, this.y ) );
-		this.z = Math.max( min.z, Math.min( max.z, this.z ) );
+		this.x = MathUtils.clamp( this.x, min.x, max.x );
+		this.y = MathUtils.clamp( this.y, min.y, max.y );
+		this.z = MathUtils.clamp( this.z, min.z, max.z );
 
 		return this;
 
@@ -348,9 +348,9 @@ class Vector3 {
 
 	clampScalar( minVal, maxVal ) {
 
-		this.x = Math.max( minVal, Math.min( maxVal, this.x ) );
-		this.y = Math.max( minVal, Math.min( maxVal, this.y ) );
-		this.z = Math.max( minVal, Math.min( maxVal, this.z ) );
+		this.x = MathUtils.clamp( this.x, minVal, maxVal );
+		this.y = MathUtils.clamp( this.y, minVal, maxVal );
+		this.z = MathUtils.clamp( this.z, minVal, maxVal );
 
 		return this;
 
@@ -360,7 +360,7 @@ class Vector3 {
 
 		const length = this.length();
 
-		return this.divideScalar( length || 1 ).multiplyScalar( Math.max( min, Math.min( max, length ) ) );
+		return this.divideScalar( length || 1 ).multiplyScalar( MathUtils.clamp( length, min, max ) );
 
 	}
 

--- a/src/math/Vector4.js
+++ b/src/math/Vector4.js
@@ -1,3 +1,5 @@
+import * as MathUtils from './MathUtils.js';
+
 class Vector4 {
 
 	constructor( x = 0, y = 0, z = 0, w = 1 ) {
@@ -463,10 +465,10 @@ class Vector4 {
 
 		// assumes min < max, componentwise
 
-		this.x = Math.max( min.x, Math.min( max.x, this.x ) );
-		this.y = Math.max( min.y, Math.min( max.y, this.y ) );
-		this.z = Math.max( min.z, Math.min( max.z, this.z ) );
-		this.w = Math.max( min.w, Math.min( max.w, this.w ) );
+		this.x = MathUtils.clamp( this.x, min.x, max.x );
+		this.y = MathUtils.clamp( this.y, min.y, max.y );
+		this.z = MathUtils.clamp( this.z, min.z, max.z );
+		this.w = MathUtils.clamp( this.w, min.w, max.w );
 
 		return this;
 
@@ -474,10 +476,10 @@ class Vector4 {
 
 	clampScalar( minVal, maxVal ) {
 
-		this.x = Math.max( minVal, Math.min( maxVal, this.x ) );
-		this.y = Math.max( minVal, Math.min( maxVal, this.y ) );
-		this.z = Math.max( minVal, Math.min( maxVal, this.z ) );
-		this.w = Math.max( minVal, Math.min( maxVal, this.w ) );
+		this.x = MathUtils.clamp( this.x, minVal, maxVal );
+		this.y = MathUtils.clamp( this.y, minVal, maxVal );
+		this.z = MathUtils.clamp( this.z, minVal, maxVal );
+		this.w = MathUtils.clamp( this.w, minVal, maxVal );
 
 		return this;
 
@@ -487,7 +489,7 @@ class Vector4 {
 
 		const length = this.length();
 
-		return this.divideScalar( length || 1 ).multiplyScalar( Math.max( min, Math.min( max, length ) ) );
+		return this.divideScalar( length || 1 ).multiplyScalar( MathUtils.clamp( length, min, max ) );
 
 	}
 


### PR DESCRIPTION
**Description**

Consume `MathUtils.clamp` everywhere inside `VectorN` implementations for better readability