### PR TITLE
Manual: Spaces cause path parsing errors

### DIFF
--- a/manual/examples/background-cubemap.html
+++ b/manual/examples/background-cubemap.html
@@ -88,14 +88,14 @@ function main() {
 	{
 
 		const loader = new THREE.CubeTextureLoader();
-		const texture = loader.load( [
+		const texture = loader.load([
 			'resources/images/cubemaps/computer-history-museum/pos-x.jpg',
 			'resources/images/cubemaps/computer-history-museum/neg-x.jpg',
 			'resources/images/cubemaps/computer-history-museum/pos-y.jpg',
 			'resources/images/cubemaps/computer-history-museum/neg-y.jpg',
 			'resources/images/cubemaps/computer-history-museum/pos-z.jpg',
 			'resources/images/cubemaps/computer-history-museum/neg-z.jpg',
-		] );
+		]);
 		scene.background = texture;
 
 	}


### PR DESCRIPTION
**Description**
When I clicked on the button called 'click here to open in a separate window', the image loaded normally, so I suspected it was a formatting issue causing the parsing error. Finally, I deleted the spaces and it worked fine.

Before:
![chrome_gIac3wcBG0](https://github.com/user-attachments/assets/a3bf7a86-f1dd-443d-891c-edbc5b8ae23e)

Now:
![chrome_MP2XtbSClX](https://github.com/user-attachments/assets/d978cccb-c4d7-43f5-a3a4-f2469bd93530)

