### PR TITLE
Manual: Fix `loaderArrayLoadRE` regex to allow spaces before square bracket.

### DIFF
--- a/manual/examples/resources/editor-settings.js
+++ b/manual/examples/resources/editor-settings.js
@@ -70,7 +70,7 @@
 		const linkRE = /(href=)(")(.*?)(")()/g;
 		const imageSrcRE = /((?:image|img)\.src = )(")(.*?)(")()/g;
 		const loaderLoadRE = /(loader\.load[a-z]*\s*\(\s*)('|")(.*?)('|")/ig;
-		const loaderArrayLoadRE = /(loader\.load[a-z]*\(\[)([\s\S]*?)(\])/ig;
+		const loaderArrayLoadRE = /(loader\.load[a-z]*\(\s*\[)([\s\S]*?)(\])/ig;
 		const loadFileRE = /(loadFile\s*\(\s*)('|")(.*?)('|")/ig;
 		const threejsUrlRE = /(.*?)('|")([^"']*?)('|")([^'"]*?)(\/\*\s+threejs.org:\s+url\s+\*\/)/ig;
 		const arrayLineRE = /^(\s*["|'])([\s\S]*?)(["|']*$)/;


### PR DESCRIPTION
Related issue: #29819

**Description**

The regex used to detect and re-write URLs in the manual when loading an array did not account for any spaces between the opening bracket and the opening square bracket. As a result these would not be rewritten and failed to load when viewing the example on the manual page it's embedded.

This PR simply expands the regex to match against zero or more spaces, resolving the issue.