### PR TITLE
PostProcessing: Harmonize node type.

### DIFF
--- a/examples/jsm/tsl/display/AfterImageNode.js
+++ b/examples/jsm/tsl/display/AfterImageNode.js
@@ -16,7 +16,7 @@ class AfterImageNode extends TempNode {
 
 	constructor( textureNode, damp = 0.96 ) {
 
-		super( textureNode );
+		super( 'vec4' );
 
 		this.textureNode = textureNode;
 		this.textureNodeOld = texture();

--- a/examples/jsm/tsl/display/BloomNode.js
+++ b/examples/jsm/tsl/display/BloomNode.js
@@ -19,7 +19,7 @@ class BloomNode extends TempNode {
 
 	constructor( inputNode, strength = 1, radius = 0, threshold = 0 ) {
 
-		super();
+		super( 'vec4' );
 
 		this.inputNode = inputNode;
 		this.strength = uniform( strength );

--- a/examples/jsm/tsl/display/DenoiseNode.js
+++ b/examples/jsm/tsl/display/DenoiseNode.js
@@ -11,7 +11,7 @@ class DenoiseNode extends TempNode {
 
 	constructor( textureNode, depthNode, normalNode, noiseNode, camera ) {
 
-		super();
+		super( 'vec4' );
 
 		this.textureNode = textureNode;
 		this.depthNode = depthNode;

--- a/examples/jsm/tsl/display/DepthOfFieldNode.js
+++ b/examples/jsm/tsl/display/DepthOfFieldNode.js
@@ -10,7 +10,7 @@ class DepthOfFieldNode extends TempNode {
 
 	constructor( textureNode, viewZNode, focusNode, apertureNode, maxblurNode ) {
 
-		super();
+		super( 'vec4' );
 
 		this.textureNode = textureNode;
 		this.viewZNode = viewZNode;

--- a/examples/jsm/tsl/display/FXAANode.js
+++ b/examples/jsm/tsl/display/FXAANode.js
@@ -11,7 +11,7 @@ class FXAANode extends TempNode {
 
 	constructor( textureNode ) {
 
-		super();
+		super( 'vec4' );
 
 		this.textureNode = textureNode;
 

--- a/examples/jsm/tsl/display/FilmNode.js
+++ b/examples/jsm/tsl/display/FilmNode.js
@@ -10,7 +10,7 @@ class FilmNode extends TempNode {
 
 	constructor( inputNode, intensityNode = null, uvNode = null ) {
 
-		super();
+		super( 'vec4' );
 
 		this.inputNode = inputNode;
 		this.intensityNode = intensityNode;

--- a/examples/jsm/tsl/display/GTAONode.js
+++ b/examples/jsm/tsl/display/GTAONode.js
@@ -6,6 +6,10 @@ const _size = /*@__PURE__*/ new Vector2();
 
 let _rendererState;
 
+/**
+ * References:
+ * https://www.activision.com/cdn/research/Practical_Real_Time_Strategies_for_Accurate_Indirect_Occlusion_NEW%20VERSION_COLOR.pdf
+ */
 class GTAONode extends TempNode {
 
 	static get type() {
@@ -16,7 +20,7 @@ class GTAONode extends TempNode {
 
 	constructor( depthNode, normalNode, camera ) {
 
-		super();
+		super( 'vec4' );
 
 		this.depthNode = depthNode;
 		this.normalNode = normalNode;

--- a/examples/jsm/tsl/display/LensflareNode.js
+++ b/examples/jsm/tsl/display/LensflareNode.js
@@ -20,7 +20,7 @@ class LensflareNode extends TempNode {
 
 	constructor( textureNode, params = {} ) {
 
-		super();
+		super( 'vec4' );
 
 		this.textureNode = textureNode;
 

--- a/examples/jsm/tsl/display/Lut3DNode.js
+++ b/examples/jsm/tsl/display/Lut3DNode.js
@@ -10,7 +10,7 @@ class Lut3DNode extends TempNode {
 
 	constructor( inputNode, lutNode, size, intensityNode ) {
 
-		super();
+		super( 'vec4' );
 
 		this.inputNode = inputNode;
 		this.lutNode = lutNode;

--- a/examples/jsm/tsl/display/PixelationPassNode.js
+++ b/examples/jsm/tsl/display/PixelationPassNode.js
@@ -11,7 +11,7 @@ class PixelationNode extends TempNode {
 
 	constructor( textureNode, depthNode, normalNode, pixelSize, normalEdgeStrength, depthEdgeStrength ) {
 
-		super();
+		super( 'vec4' );
 
 		// Input textures
 
@@ -158,7 +158,7 @@ class PixelationPassNode extends PassNode {
 
 	constructor( scene, camera, pixelSize = 6, normalEdgeStrength = 0.3, depthEdgeStrength = 0.4 ) {
 
-		super( 'color', scene, camera, { minFilter: NearestFilter, magFilter: NearestFilter } );
+		super( PassNode.COLOR, scene, camera, { minFilter: NearestFilter, magFilter: NearestFilter } );
 
 		this.pixelSize = pixelSize;
 		this.normalEdgeStrength = normalEdgeStrength;

--- a/examples/jsm/tsl/display/SMAANode.js
+++ b/examples/jsm/tsl/display/SMAANode.js
@@ -22,7 +22,7 @@ class SMAANode extends TempNode {
 
 	constructor( textureNode ) {
 
-		super();
+		super( 'vec4' );
 
 		this.textureNode = textureNode;
 

--- a/examples/jsm/tsl/display/SSRNode.js
+++ b/examples/jsm/tsl/display/SSRNode.js
@@ -19,7 +19,7 @@ class SSRNode extends TempNode {
 
 	constructor( colorNode, depthNode, normalNode, metalnessNode, camera ) {
 
-		super();
+		super( 'vec4' );
 
 		this.colorNode = colorNode;
 		this.depthNode = depthNode;

--- a/examples/jsm/tsl/display/SobelOperatorNode.js
+++ b/examples/jsm/tsl/display/SobelOperatorNode.js
@@ -11,7 +11,7 @@ class SobelOperatorNode extends TempNode {
 
 	constructor( textureNode ) {
 
-		super();
+		super( 'vec4' );
 
 		this.textureNode = textureNode;
 

--- a/examples/jsm/tsl/display/TransitionNode.js
+++ b/examples/jsm/tsl/display/TransitionNode.js
@@ -10,7 +10,7 @@ class TransitionNode extends TempNode {
 
 	constructor( textureNodeA, textureNodeB, mixTextureNode, mixRatioNode, thresholdNode, useTextureNode ) {
 
-		super();
+		super( 'vec4' );
 
 		// Input textures
 


### PR DESCRIPTION
Related issue: -

**Description**

This PR makes sure all node FX classes derived of `TempNode` define the correct node type when calling `super()`.
