### PR TITLE
Spherical: Use `MathUtils.clamp()` for `makeSafe()`.

### DIFF
--- a/src/math/Spherical.js
+++ b/src/math/Spherical.js
@@ -42,7 +42,7 @@ class Spherical {
 	makeSafe() {
 
 		const EPS = 0.000001;
-		this.phi = Math.max( EPS, Math.min( Math.PI - EPS, this.phi ) );
+		this.phi = MathUtils.clamp( this.phi, EPS, Math.PI - EPS );
 
 		return this;
 


### PR DESCRIPTION
Related issue: #29812

**Description**

As the title says.