### PR TITLE
update build setup to the simplest migration to WebGPU

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "./addons": "./examples/jsm/Addons.js",
     "./addons/*": "./examples/jsm/*",
     "./src/*": "./src/*",
+    "./webgl": "./build/three.webgl.js",
     "./webgpu": "./build/three.webgpu.js",
+    "./webgpu.nodes": "./build/three.webgpu.nodes.js",
     "./tsl": "./build/three.webgpu.js"
   },
   "repository": {

--- a/src/Three.WebGL.js
+++ b/src/Three.WebGL.js
@@ -1,4 +1,4 @@
-// This entry point exports all renderers.
+// This entry point exports only WebGLRenderer.
 
 import { REVISION } from './constants.js';
 
@@ -42,7 +42,7 @@ export { DepthTexture } from './textures/DepthTexture.js';
 export { Texture } from './textures/Texture.js';
 export * from './geometries/Geometries.js';
 export * from './materials/Materials.js';
-export { Material } from './materials/Material.js';
+// export { Material } from './materials/Material.js';
 export { AnimationLoader } from './loaders/AnimationLoader.js';
 export { CompressedTextureLoader } from './loaders/CompressedTextureLoader.js';
 export { CubeTextureLoader } from './loaders/CubeTextureLoader.js';
@@ -165,30 +165,30 @@ export { createCanvasElement } from './utils.js';
 export * from './constants.js';
 export * from './Three.Legacy.js';
 
-export * from './materials/nodes/NodeMaterials.js';
-export { default as WebGPURenderer } from './renderers/webgpu/WebGPURenderer.js';
-import StandardNodeLibrary from './nodes/StandardNodeLibrary.js';
-export { StandardNodeLibrary };
-import BasicNodeLibrary from './nodes/BasicNodeLibrary.js';
-export { BasicNodeLibrary };
-export { default as ClippingGroup } from './renderers/common/ClippingGroup.js';
-export { default as Lighting } from './renderers/common/Lighting.js';
-export { default as BundleGroup } from './renderers/common/BundleGroup.js';
-export { default as QuadMesh } from './renderers/common/QuadMesh.js';
-export { default as PMREMGenerator2 } from './renderers/common/extras/PMREMGenerator2.js';
-export { default as PostProcessing } from './renderers/common/PostProcessing.js';
-import * as PostProcessingUtils from './renderers/common/PostProcessingUtils.js';
-export { PostProcessingUtils };
-export { default as StorageTexture } from './renderers/common/StorageTexture.js';
-export { default as StorageBufferAttribute } from './renderers/common/StorageBufferAttribute.js';
-export { default as StorageInstancedBufferAttribute } from './renderers/common/StorageInstancedBufferAttribute.js';
-export { default as IndirectStorageBufferAttribute } from './renderers/common/IndirectStorageBufferAttribute.js';
-export { default as IESSpotLight } from './lights/webgpu/IESSpotLight.js';
-export { default as NodeLoader } from './loaders/nodes/NodeLoader.js';
-export { default as NodeObjectLoader } from './loaders/nodes/NodeObjectLoader.js';
-export { default as NodeMaterialLoader } from './loaders/nodes/NodeMaterialLoader.js';
-export * from './nodes/Nodes.js';
-export * from './nodes/TSL.js';
+//export * from './materials/nodes/NodeMaterials.js';
+//export { default as WebGPURenderer } from './renderers/webgpu/WebGPURenderer.js';
+//import StandardNodeLibrary from './nodes/StandardNodeLibrary.js';
+//export { StandardNodeLibrary };
+//import BasicNodeLibrary from './nodes/BasicNodeLibrary.js';
+//export { BasicNodeLibrary };
+//export { default as ClippingGroup } from './renderers/common/ClippingGroup.js';
+//export { default as Lighting } from './renderers/common/Lighting.js';
+//export { default as BundleGroup } from './renderers/common/BundleGroup.js';
+//export { default as QuadMesh } from './renderers/common/QuadMesh.js';
+//export { default as PMREMGenerator2 } from './renderers/common/extras/PMREMGenerator2.js';
+//export { default as PostProcessing } from './renderers/common/PostProcessing.js';
+//import * as PostProcessingUtils from './renderers/common/PostProcessingUtils.js';
+//export { PostProcessingUtils };
+//export { default as StorageTexture } from './renderers/common/StorageTexture.js';
+//export { default as StorageBufferAttribute } from './renderers/common/StorageBufferAttribute.js';
+//export { default as StorageInstancedBufferAttribute } from './renderers/common/StorageInstancedBufferAttribute.js';
+//export { default as IndirectStorageBufferAttribute } from './renderers/common/IndirectStorageBufferAttribute.js';
+//export { default as IESSpotLight } from './lights/webgpu/IESSpotLight.js';
+//export { default as NodeLoader } from './loaders/nodes/NodeLoader.js';
+//export { default as NodeObjectLoader } from './loaders/nodes/NodeObjectLoader.js';
+//export { default as NodeMaterialLoader } from './loaders/nodes/NodeMaterialLoader.js';
+//export * from './nodes/Nodes.js';
+//export * from './nodes/TSL.js';
 
 if ( typeof __THREE_DEVTOOLS__ !== 'undefined' ) {
 

--- a/src/Three.WebGPU.Nodes.js
+++ b/src/Three.WebGPU.Nodes.js
@@ -1,3 +1,5 @@
+// This entry point exports only WebGPURenderer.Nodes.
+
 import { REVISION } from './constants.js';
 
 export { WebGLArrayRenderTarget } from './renderers/WebGLArrayRenderTarget.js';
@@ -156,6 +158,7 @@ export { Controls } from './extras/Controls.js';
 export { DataUtils } from './extras/DataUtils.js';
 export { ImageUtils } from './extras/ImageUtils.js';
 export { ShapeUtils } from './extras/ShapeUtils.js';
+//export { TextureUtils } from './extras/TextureUtils.js';
 //export { PMREMGenerator } from './extras/PMREMGenerator.js';
 //export { WebGLUtils } from './renderers/webgl/WebGLUtils.js';
 export { createCanvasElement } from './utils.js';
@@ -164,9 +167,15 @@ export * from './Three.Legacy.js';
 
 export * from './materials/nodes/NodeMaterials.js';
 export { default as WebGPURenderer } from './renderers/webgpu/WebGPURenderer.Nodes.js';
+//import StandardNodeLibrary from './nodes/StandardNodeLibrary.js';
+//export { StandardNodeLibrary };
+import BasicNodeLibrary from './nodes/BasicNodeLibrary.js';
+export { BasicNodeLibrary };
+//export { default as ClippingGroup } from './renderers/common/ClippingGroup.js';
 export { default as Lighting } from './renderers/common/Lighting.js';
+//export { default as BundleGroup } from './renderers/common/BundleGroup.js';
 export { default as QuadMesh } from './renderers/common/QuadMesh.js';
-export { default as PMREMGenerator } from './renderers/common/extras/PMREMGenerator.js';
+export { default as PMREMGenerator2 } from './renderers/common/extras/PMREMGenerator2.js';
 export { default as PostProcessing } from './renderers/common/PostProcessing.js';
 import * as PostProcessingUtils from './renderers/common/PostProcessingUtils.js';
 export { PostProcessingUtils };

--- a/src/Three.WebGPU.js
+++ b/src/Three.WebGPU.js
@@ -1,3 +1,5 @@
+// This entry point exports only WebGPURenderer.
+
 import { REVISION } from './constants.js';
 
 export { WebGLArrayRenderTarget } from './renderers/WebGLArrayRenderTarget.js';
@@ -156,6 +158,7 @@ export { Controls } from './extras/Controls.js';
 export { DataUtils } from './extras/DataUtils.js';
 export { ImageUtils } from './extras/ImageUtils.js';
 export { ShapeUtils } from './extras/ShapeUtils.js';
+//export { TextureUtils } from './extras/TextureUtils.js';
 //export { PMREMGenerator } from './extras/PMREMGenerator.js';
 //export { WebGLUtils } from './renderers/webgl/WebGLUtils.js';
 export { createCanvasElement } from './utils.js';
@@ -164,11 +167,15 @@ export * from './Three.Legacy.js';
 
 export * from './materials/nodes/NodeMaterials.js';
 export { default as WebGPURenderer } from './renderers/webgpu/WebGPURenderer.js';
+import StandardNodeLibrary from './nodes/StandardNodeLibrary.js';
+export { StandardNodeLibrary };
+//import BasicNodeLibrary from './nodes/BasicNodeLibrary.js';
+//export { BasicNodeLibrary };
 export { default as ClippingGroup } from './renderers/common/ClippingGroup.js';
 export { default as Lighting } from './renderers/common/Lighting.js';
 export { default as BundleGroup } from './renderers/common/BundleGroup.js';
 export { default as QuadMesh } from './renderers/common/QuadMesh.js';
-export { default as PMREMGenerator } from './renderers/common/extras/PMREMGenerator.js';
+export { default as PMREMGenerator2 } from './renderers/common/extras/PMREMGenerator2.js';
 export { default as PostProcessing } from './renderers/common/PostProcessing.js';
 import * as PostProcessingUtils from './renderers/common/PostProcessingUtils.js';
 export { PostProcessingUtils };

--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -20,7 +20,7 @@ import { getCurrentStack, setCurrentStack } from '../tsl/TSLBase.js';
 import CubeRenderTarget from '../../renderers/common/CubeRenderTarget.js';
 import ChainMap from '../../renderers/common/ChainMap.js';
 
-import PMREMGenerator from '../../renderers/common/extras/PMREMGenerator.js';
+import PMREMGenerator2 from '../../renderers/common/extras/PMREMGenerator2.js';
 
 import BindGroup from '../../renderers/common/BindGroup.js';
 
@@ -168,7 +168,7 @@ class NodeBuilder {
 
 		// TODO: Move Materials.js to outside of the Nodes.js in order to remove this function and improve tree-shaking support
 
-		return new PMREMGenerator( this.renderer );
+		return new PMREMGenerator2( this.renderer );
 
 	}
 

--- a/src/renderers/common/extras/PMREMGenerator2.js
+++ b/src/renderers/common/extras/PMREMGenerator2.js
@@ -95,7 +95,7 @@ const outputDirection = vec3( direction.x, direction.y.negate(), direction.z );
  * https://drive.google.com/file/d/15y8r_UpKlU9SvV4ILb0C3qCPecS8pvLz/view
 */
 
-class PMREMGenerator {
+class PMREMGenerator2 {
 
 	constructor( renderer ) {
 
@@ -768,4 +768,4 @@ function _getEquirectMaterial( envTexture ) {
 
 }
 
-export default PMREMGenerator;
+export default PMREMGenerator2;

--- a/utils/build/rollup.config.js
+++ b/utils/build/rollup.config.js
@@ -75,6 +75,18 @@ const builds = [
 		]
 	},
 	{
+		input: 'src/Three.WebGL.js',
+		plugins: [
+			header()
+		],
+		output: [
+			{
+				format: 'esm',
+				file: 'build/three.webgl.js'
+			}
+		]
+	},
+	{
 		input: 'src/Three.WebGPU.js',
 		plugins: [
 			header()
@@ -109,6 +121,19 @@ const builds = [
 			{
 				format: 'esm',
 				file: 'build/three.module.min.js'
+			}
+		]
+	},
+	{
+		input: 'src/Three.WebGL.js',
+		plugins: [
+			header(),
+			terser()
+		],
+		output: [
+			{
+				format: 'esm',
+				file: 'build/three.webgl.min.js'
 			}
 		]
 	},


### PR DESCRIPTION
Related issue:

- #29156

**Description**

Updates the build setup

- export both WebGL and WebGPU renderers from 'three' module so that existing projects can update without needing to configure their existing builds
- provide separate optional WebGL-only and WebGPU-only entry points (and builds) by adding a new `Three.WebGL.js` entry point (and build) that allows people who really need the WebGL-only entry point (or build) to choose that option, while not requiring everyone else to do more work
- expose the WebGPU.Nodes build in package.json `exports` for consistency with other builds
- rename /src/renderers/extras/PMREMGenerator to PMREMGenerator2 to avoid confusion with src/extras/PMREMGenerator (it also caused a build error when trying to export two items of the same name)
- ensure that all entry points have the same lines, either commented or uncommented, for sanity checking how each entry point differs (some lines were missing in one or the other, making it less easy to tell the difference)
- I left the `three/tsl` path alone, which is redundant, but it could easily be deleted.

The new mental model for anyone importing would be

- `three` for the whole lib (same as before),
- or `three/*` for slimmer versions.

In my opinion this is a consistent way to do it, besides also being easier to consume.

This solution makes migration to WebGPU the _simplest_ because it requires no build configuration updates in downstream projects. All they need to do is update the `three` version number, and then import new `WebGPURenderer` and related APIs (unless there's something I overlooked, if so please let me know).

<!-- Remove the line below if is not relevant -->

*This contribution is funded by my time :)*
