### PR TITLE
OrbitControl: Fixed rotation toggle in KeyDown handler

### DIFF
--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -783,12 +783,20 @@ class OrbitControls extends Controls {
 			case this.keys.UP:
 
 				if ( event.ctrlKey || event.metaKey || event.shiftKey ) {
+
 					if ( this.enableRotate ) {
+
 						this._rotateUp( _twoPI * this.rotateSpeed / this.domElement.clientHeight );
+
 					}
+
 				} else {
 
-					this._pan( 0, this.keyPanSpeed );
+					if ( this.enablePan ) {
+
+						this._pan( 0, this.keyPanSpeed );
+
+					}
 
 				}
 
@@ -798,12 +806,20 @@ class OrbitControls extends Controls {
 			case this.keys.BOTTOM:
 
 				if ( event.ctrlKey || event.metaKey || event.shiftKey ) {
+
 					if ( this.enableRotate ) {
+
 						this._rotateUp( - _twoPI * this.rotateSpeed / this.domElement.clientHeight );
+
 					}
+
 				} else {
 
-					this._pan( 0, - this.keyPanSpeed );
+					if ( this.enablePan ) {
+
+						this._pan( 0, - this.keyPanSpeed );
+
+					}
 
 				}
 
@@ -813,12 +829,20 @@ class OrbitControls extends Controls {
 			case this.keys.LEFT:
 
 				if ( event.ctrlKey || event.metaKey || event.shiftKey ) {
+
 					if ( this.enableRotate ) {
+
 						this._rotateLeft( _twoPI * this.rotateSpeed / this.domElement.clientHeight );
+
 					}
+
 				} else {
 
-					this._pan( this.keyPanSpeed, 0 );
+					if ( this.enablePan ) {
+
+						this._pan( this.keyPanSpeed, 0 );
+
+					}
 
 				}
 
@@ -828,12 +852,20 @@ class OrbitControls extends Controls {
 			case this.keys.RIGHT:
 
 				if ( event.ctrlKey || event.metaKey || event.shiftKey ) {
+
 					if ( this.enableRotate ) {
+
 						this._rotateLeft( - _twoPI * this.rotateSpeed / this.domElement.clientHeight );
+
 					}
+
 				} else {
 
-					this._pan( - this.keyPanSpeed, 0 );
+					if ( this.enablePan ) {
+
+						this._pan( - this.keyPanSpeed, 0 );
+
+					}
 
 				}
 
@@ -1340,7 +1372,7 @@ function onMouseWheel( event ) {
 
 function onKeyDown( event ) {
 
-	if ( this.enabled === false || this.enablePan === false ) return;
+	if ( this.enabled === false ) return;
 
 	this._handleKeyDown( event );
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -787,7 +787,6 @@ class OrbitControls extends Controls {
 					if ( this.enableRotate ) {
 
 						this._rotateUp( _twoPI * this.rotateSpeed / this.domElement.clientHeight );
-						needsUpdate = true;
 
 					}
 
@@ -796,12 +795,12 @@ class OrbitControls extends Controls {
 					if ( this.enablePan ) {
 
 						this._pan( 0, this.keyPanSpeed );
-						needsUpdate = true;
 
 					}
 
 				}
 
+				needsUpdate = true;
 				break;
 
 			case this.keys.BOTTOM:
@@ -811,7 +810,6 @@ class OrbitControls extends Controls {
 					if ( this.enableRotate ) {
 
 						this._rotateUp( - _twoPI * this.rotateSpeed / this.domElement.clientHeight );
-						needsUpdate = true;
 
 					}
 
@@ -820,12 +818,12 @@ class OrbitControls extends Controls {
 					if ( this.enablePan ) {
 
 						this._pan( 0, - this.keyPanSpeed );
-						needsUpdate = true;
 
 					}
 
 				}
 
+				needsUpdate = true;
 				break;
 
 			case this.keys.LEFT:
@@ -835,7 +833,6 @@ class OrbitControls extends Controls {
 					if ( this.enableRotate ) {
 
 						this._rotateLeft( _twoPI * this.rotateSpeed / this.domElement.clientHeight );
-						needsUpdate = true;
 
 					}
 
@@ -844,12 +841,12 @@ class OrbitControls extends Controls {
 					if ( this.enablePan ) {
 
 						this._pan( this.keyPanSpeed, 0 );
-						needsUpdate = true;
 
 					}
 
 				}
 
+				needsUpdate = true;
 				break;
 
 			case this.keys.RIGHT:
@@ -859,7 +856,6 @@ class OrbitControls extends Controls {
 					if ( this.enableRotate ) {
 
 						this._rotateLeft( - _twoPI * this.rotateSpeed / this.domElement.clientHeight );
-						needsUpdate = true;
 
 					}
 
@@ -868,12 +864,12 @@ class OrbitControls extends Controls {
 					if ( this.enablePan ) {
 
 						this._pan( - this.keyPanSpeed, 0 );
-						needsUpdate = true;
 
 					}
 
 				}
 
+				needsUpdate = true;
 				break;
 
 		}

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -787,6 +787,7 @@ class OrbitControls extends Controls {
 					if ( this.enableRotate ) {
 
 						this._rotateUp( _twoPI * this.rotateSpeed / this.domElement.clientHeight );
+						needsUpdate = true;
 
 					}
 
@@ -795,12 +796,12 @@ class OrbitControls extends Controls {
 					if ( this.enablePan ) {
 
 						this._pan( 0, this.keyPanSpeed );
+						needsUpdate = true;
 
 					}
 
 				}
 
-				needsUpdate = true;
 				break;
 
 			case this.keys.BOTTOM:
@@ -810,6 +811,7 @@ class OrbitControls extends Controls {
 					if ( this.enableRotate ) {
 
 						this._rotateUp( - _twoPI * this.rotateSpeed / this.domElement.clientHeight );
+						needsUpdate = true;
 
 					}
 
@@ -818,12 +820,12 @@ class OrbitControls extends Controls {
 					if ( this.enablePan ) {
 
 						this._pan( 0, - this.keyPanSpeed );
+						needsUpdate = true;
 
 					}
 
 				}
 
-				needsUpdate = true;
 				break;
 
 			case this.keys.LEFT:
@@ -833,6 +835,7 @@ class OrbitControls extends Controls {
 					if ( this.enableRotate ) {
 
 						this._rotateLeft( _twoPI * this.rotateSpeed / this.domElement.clientHeight );
+						needsUpdate = true;
 
 					}
 
@@ -841,12 +844,12 @@ class OrbitControls extends Controls {
 					if ( this.enablePan ) {
 
 						this._pan( this.keyPanSpeed, 0 );
+						needsUpdate = true;
 
 					}
 
 				}
 
-				needsUpdate = true;
 				break;
 
 			case this.keys.RIGHT:
@@ -856,6 +859,7 @@ class OrbitControls extends Controls {
 					if ( this.enableRotate ) {
 
 						this._rotateLeft( - _twoPI * this.rotateSpeed / this.domElement.clientHeight );
+						needsUpdate = true;
 
 					}
 
@@ -864,12 +868,12 @@ class OrbitControls extends Controls {
 					if ( this.enablePan ) {
 
 						this._pan( - this.keyPanSpeed, 0 );
+						needsUpdate = true;
 
 					}
 
 				}
 
-				needsUpdate = true;
 				break;
 
 		}

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -783,9 +783,9 @@ class OrbitControls extends Controls {
 			case this.keys.UP:
 
 				if ( event.ctrlKey || event.metaKey || event.shiftKey ) {
-
-					this._rotateUp( _twoPI * this.rotateSpeed / this.domElement.clientHeight );
-
+					if ( this.enableRotate ) {
+						this._rotateUp( _twoPI * this.rotateSpeed / this.domElement.clientHeight );
+					}
 				} else {
 
 					this._pan( 0, this.keyPanSpeed );
@@ -798,9 +798,9 @@ class OrbitControls extends Controls {
 			case this.keys.BOTTOM:
 
 				if ( event.ctrlKey || event.metaKey || event.shiftKey ) {
-
-					this._rotateUp( - _twoPI * this.rotateSpeed / this.domElement.clientHeight );
-
+					if ( this.enableRotate ) {
+						this._rotateUp( - _twoPI * this.rotateSpeed / this.domElement.clientHeight );
+					}
 				} else {
 
 					this._pan( 0, - this.keyPanSpeed );
@@ -813,9 +813,9 @@ class OrbitControls extends Controls {
 			case this.keys.LEFT:
 
 				if ( event.ctrlKey || event.metaKey || event.shiftKey ) {
-
-					this._rotateLeft( _twoPI * this.rotateSpeed / this.domElement.clientHeight );
-
+					if ( this.enableRotate ) {
+						this._rotateLeft( _twoPI * this.rotateSpeed / this.domElement.clientHeight );
+					}
 				} else {
 
 					this._pan( this.keyPanSpeed, 0 );
@@ -828,9 +828,9 @@ class OrbitControls extends Controls {
 			case this.keys.RIGHT:
 
 				if ( event.ctrlKey || event.metaKey || event.shiftKey ) {
-
-					this._rotateLeft( - _twoPI * this.rotateSpeed / this.domElement.clientHeight );
-
+					if ( this.enableRotate ) {
+						this._rotateLeft( - _twoPI * this.rotateSpeed / this.domElement.clientHeight );
+					}
 				} else {
 
 					this._pan( - this.keyPanSpeed, 0 );


### PR DESCRIPTION
Implemented the toggle via `enableRotate` also on `_handleKeyDown`. The previous behaviour seemed unexpected, allowing rotation via keys, even when rotating should be disabled if `enableRotate` was set to `false`.


**Description**

The previous implementation of `_handleKeyDown` did not take the `enableRotate` state into account. This seemed unexpected when `enableRotate` was set to `false`, but rotation was still possible with key events.
This commit guards the rotation of the `keydown` event additionally with the already available `enableRotate` variable and makes it more intuitive in its behavior again.
