### PR TITLE
RenderObject: Added `.setGeometry()`

### DIFF
--- a/src/renderers/common/RenderObject.js
+++ b/src/renderers/common/RenderObject.js
@@ -147,6 +147,13 @@ export default class RenderObject {
 
 	}
 
+	setGeometry( geometry ) {
+
+		this.geometry = geometry;
+		this.attributes = null;
+
+	}
+
 	getAttributes() {
 
 		if ( this.attributes !== null ) return this.attributes;
@@ -373,6 +380,12 @@ export default class RenderObject {
 		}
 
 		return hashString( cacheKey );
+
+	}
+
+	get needsGeometryUpdate() {
+
+		return this.geometry.id !== this.object.geometry.id;
 
 	}
 

--- a/src/renderers/common/RenderObjects.js
+++ b/src/renderers/common/RenderObjects.js
@@ -40,12 +40,11 @@ class RenderObjects {
 
 			renderObject.updateClipping( clippingContext );
 
-			// force update if geometry has changed
-			const forceUpdate = renderObject.geometry.id !== renderObject.object.geometry.id;
+			const needsGeometryUpdate = renderObject.needsGeometryUpdate;
 
-			if ( forceUpdate || renderObject.version !== material.version || renderObject.needsUpdate ) {
+			if ( renderObject.version !== material.version || renderObject.needsUpdate || needsGeometryUpdate ) {
 
-				if ( forceUpdate || renderObject.initialCacheKey !== renderObject.getCacheKey() ) {
+				if ( renderObject.initialCacheKey !== renderObject.getCacheKey() ) {
 
 					renderObject.dispose();
 
@@ -54,6 +53,12 @@ class RenderObjects {
 				} else {
 
 					renderObject.version = material.version;
+
+					if ( needsGeometryUpdate ) {
+
+						renderObject.setGeometry( object.geometry );
+
+					}
 
 				}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/29795#issuecomment-2461686721

**Description**

An improvement from the [previous PR](https://github.com/mrdoob/three.js/pull/29807), the cachekey comparison will check if it is necessary to recreate the `RenderObject` otherwise just update the geometry.