### PR TITLE
NodeMaterial: Added `.castShadowNode` and `.receivedShadowNode`

### DIFF
--- a/examples/webgpu_shadowmap.html
+++ b/examples/webgpu_shadowmap.html
@@ -104,7 +104,7 @@
 				} )();
 
 
-				materialCustomShadow.shadowNode = Fn( () => {
+				materialCustomShadow.castShadowNode = Fn( () => {
 
 					discardNode.discard();
 

--- a/examples/webgpu_shadowmap_opacity.html
+++ b/examples/webgpu_shadowmap_opacity.html
@@ -112,8 +112,8 @@
 				dragon.castShadow = dragon2.castShadow = true;
 				dragon.receiveShadow = dragon2.receiveShadow = true;
 
-				dragon.material.shadowNode = customShadow( dragon.material.attenuationColor );
-				dragon2.material.shadowNode = customShadow( dragon2.material.attenuationColor );
+				dragon.material.castShadowNode = customShadow( dragon.material.attenuationColor );
+				dragon2.material.castShadowNode = customShadow( dragon2.material.attenuationColor );
 
 				//
 

--- a/examples/webgpu_tsl_angular_slicing.html
+++ b/examples/webgpu_tsl_angular_slicing.html
@@ -136,7 +136,7 @@
 
 				// shadow
 
-				slicedMaterial.shadowNode = Fn( () => {
+				slicedMaterial.castShadowNode = Fn( () => {
 
 					// discard
 

--- a/src/materials/nodes/NodeMaterial.js
+++ b/src/materials/nodes/NodeMaterial.js
@@ -67,8 +67,9 @@ class NodeMaterial extends Material {
 		this.geometryNode = null;
 
 		this.depthNode = null;
-		this.shadowNode = null;
 		this.shadowPositionNode = null;
+		this.receivedShadowNode = null;
+		this.castShadowNode = null;
 
 		this.outputNode = null;
 		this.mrtNode = null;
@@ -692,8 +693,9 @@ class NodeMaterial extends Material {
 		this.geometryNode = source.geometryNode;
 
 		this.depthNode = source.depthNode;
-		this.shadowNode = source.shadowNode;
 		this.shadowPositionNode = source.shadowPositionNode;
+		this.receivedShadowNode = source.receivedShadowNode;
+		this.castShadowNode = source.castShadowNode;
 
 		this.outputNode = source.outputNode;
 		this.mrtNode = source.mrtNode;

--- a/src/nodes/lighting/ShadowNode.js
+++ b/src/nodes/lighting/ShadowNode.js
@@ -365,7 +365,17 @@ class ShadowNode extends Node {
 
 		}
 
-		shadowsTotal.mulAssign( node );
+		if ( builder.material.shadowNode ) { // @deprecated, r171
+
+			console.warn( 'THREE.NodeMaterial: ".shadowNode" is deprecated. Use ".receivedShadowNode" instead.' );
+
+		}
+
+		if ( builder.material.receivedShadowNode ) {
+
+			node = builder.material.receivedShadowNode( node );
+
+		}
 
 		return node;
 
@@ -492,7 +502,4 @@ class ShadowNode extends Node {
 
 export default ShadowNode;
 
-const shadowsTotal = /*@__PURE__*/ float( 1 ).toVar();
-
 export const shadow = ( light, shadow ) => nodeObject( new ShadowNode( light, shadow ) );
-export const shadows = /*@__PURE__*/ shadowsTotal.oneMinus().toVar( 'shadows' );

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -1637,10 +1637,10 @@ class Renderer {
 				}
 
 
-				if ( material.shadowNode && material.shadowNode.isNode ) {
+				if ( material.castShadowNode && material.castShadowNode.isNode ) {
 
 					overrideFragmentNode = overrideMaterial.fragmentNode;
-					overrideMaterial.fragmentNode = material.shadowNode;
+					overrideMaterial.fragmentNode = material.castShadowNode;
 
 				}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/29838#issuecomment-2463662700

**Description**

Renaming `.shadowNode` to `.castShadowNode` seems like a better name and more in line with the Three.js API regarding shadow casting.

`.receivedShadowNode` is the new input, and should use TSL `Fn` as input, where the manipulation of the received shadow can be performed. Using `Fn` we can also create the `shadows` mask manually, so I removed the node `shadows` to avoid redundancy.

- Added `material.castShadowNode` and `material.receivedShadowNode`
- Removed `shadows`

Manual way to add `shadows`
```js
const totalShadows = float( 1 ).toVar();

ground.material.receivedShadowNode = Fn( ( [ shadow ] ) => {

	totalShadows.mulAssign( shadow );

	//return float( 1 ); // bypass received shadows
	return shadow.mix( color( 0xff0000 ), 1 ); // modify shadow color

} );

// ground.material.outputNode = output.add( totalShadows.oneMinus() ); // shadow mask output
```