### PR TITLE
WebGPURenderer: Per "texture set" bindGroup caching.

### DIFF
--- a/examples/jsm/tsl/display/GaussianBlurNode.js
+++ b/examples/jsm/tsl/display/GaussianBlurNode.js
@@ -4,8 +4,7 @@ import { TempNode, nodeObject, Fn, If, float, NodeUpdateType, uv, uniform, conve
 // WebGPU: The use of a single QuadMesh for both gaussian blur passes results in a single RenderObject with a SampledTexture binding that
 // alternates between source textures and triggers creation of new BindGroups and BindGroupLayouts every frame.
 
-const _quadMesh1 = /*@__PURE__*/ new QuadMesh();
-const _quadMesh2 = /*@__PURE__*/ new QuadMesh();
+const _quadMesh = /*@__PURE__*/ new QuadMesh();
 
 let _rendererState;
 
@@ -108,8 +107,7 @@ class GaussianBlurNode extends TempNode {
 
 		const currentTexture = textureNode.value;
 
-		_quadMesh1.material = this._material;
-		_quadMesh2.material = this._material;
+		_quadMesh.material = this._material;
 
 		this.setSize( map.image.width, map.image.height );
 
@@ -124,7 +122,7 @@ class GaussianBlurNode extends TempNode {
 
 		this._passDirection.value.set( 1, 0 );
 
-		_quadMesh1.render( renderer );
+		_quadMesh.render( renderer );
 
 		// vertical
 
@@ -133,7 +131,7 @@ class GaussianBlurNode extends TempNode {
 
 		this._passDirection.value.set( 0, 1 );
 
-		_quadMesh2.render( renderer );
+		_quadMesh.render( renderer );
 
 		// restore
 

--- a/src/renderers/common/Bindings.js
+++ b/src/renderers/common/Bindings.js
@@ -118,6 +118,7 @@ class Bindings extends DataMap {
 		let needsBindingsUpdate = false;
 		let cacheBindings = true;
 		let cacheIndex = 0;
+		let version = 0;
 
 		// iterate over all bindings and check if buffer updates or a new binding group is required
 
@@ -169,7 +170,8 @@ class Bindings extends DataMap {
 
 				} else {
 
-					cacheIndex = cacheIndex * 10 + texture.id * 10 + texture.version;
+					cacheIndex = cacheIndex * 10 + texture.id;
+					version += texture.version;
 
 				}
 
@@ -207,7 +209,7 @@ class Bindings extends DataMap {
 
 		if ( needsBindingsUpdate === true ) {
 
-			this.backend.updateBindings( bindGroup, bindings, cacheBindings ? cacheIndex : 0 );
+			this.backend.updateBindings( bindGroup, bindings, cacheBindings ? cacheIndex : 0, version );
 
 		}
 

--- a/src/renderers/common/Bindings.js
+++ b/src/renderers/common/Bindings.js
@@ -163,13 +163,14 @@ class Bindings extends DataMap {
 
 				const textureData = backend.get( texture );
 
-				if ( textureData.externalTexture !== undefined || texturesTextureData.isDefaultTexture) {
+				if ( textureData.externalTexture !== undefined || texturesTextureData.isDefaultTexture ) {
 
 					cacheBindings = false;
 
 				} else {
 
 					cacheIndex = cacheIndex * 10 + texture.id * 10 + texture.version;
+
 				}
 
 				if ( backend.isWebGPUBackend === true && textureData.texture === undefined && textureData.externalTexture === undefined ) {

--- a/src/renderers/common/Bindings.js
+++ b/src/renderers/common/Bindings.js
@@ -32,7 +32,7 @@ class Bindings extends DataMap {
 
 				this._init( bindGroup );
 
-				this.backend.createBindings( bindGroup, bindings );
+				this.backend.createBindings( bindGroup, bindings, 0 );
 
 				groupData.bindGroup = bindGroup;
 
@@ -56,7 +56,7 @@ class Bindings extends DataMap {
 
 				this._init( bindGroup );
 
-				this.backend.createBindings( bindGroup, bindings );
+				this.backend.createBindings( bindGroup, bindings, 0 );
 
 				groupData.bindGroup = bindGroup;
 
@@ -116,6 +116,8 @@ class Bindings extends DataMap {
 		const { backend } = this;
 
 		let needsBindingsUpdate = false;
+		let cacheBindings = true;
+		let cacheIndex = 0;
 
 		// iterate over all bindings and check if buffer updates or a new binding group is required
 
@@ -145,7 +147,9 @@ class Bindings extends DataMap {
 
 			} else if ( binding.isSampledTexture ) {
 
-				if ( binding.needsBindingsUpdate( this.textures.get( binding.texture ).generation ) ) needsBindingsUpdate = true;
+				const texturesTextureData = this.textures.get( binding.texture );
+
+				if ( binding.needsBindingsUpdate( texturesTextureData.generation ) ) needsBindingsUpdate = true;
 
 				const updated = binding.update();
 
@@ -158,6 +162,15 @@ class Bindings extends DataMap {
 				}
 
 				const textureData = backend.get( texture );
+
+				if ( textureData.externalTexture !== undefined || texturesTextureData.isDefaultTexture) {
+
+					cacheBindings = false;
+
+				} else {
+
+					cacheIndex = cacheIndex * 10 + texture.id * 10 + texture.version;
+				}
 
 				if ( backend.isWebGPUBackend === true && textureData.texture === undefined && textureData.externalTexture === undefined ) {
 
@@ -193,7 +206,7 @@ class Bindings extends DataMap {
 
 		if ( needsBindingsUpdate === true ) {
 
-			this.backend.updateBindings( bindGroup, bindings );
+			this.backend.updateBindings( bindGroup, bindings, cacheBindings ? cacheIndex : 0 );
 
 		}
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -1341,15 +1341,15 @@ class WebGPUBackend extends Backend {
 
 	// bindings
 
-	createBindings( bindGroup, bindings, cacheIndex ) {
+	createBindings( bindGroup, bindings, cacheIndex, version ) {
 
-		this.bindingUtils.createBindings( bindGroup, bindings, cacheIndex );
+		this.bindingUtils.createBindings( bindGroup, bindings, cacheIndex, version );
 
 	}
 
-	updateBindings( bindGroup, bindings, cacheIndex ) {
+	updateBindings( bindGroup, bindings, cacheIndex, version ) {
 
-		this.bindingUtils.createBindings( bindGroup, bindings, cacheIndex );
+		this.bindingUtils.createBindings( bindGroup, bindings, cacheIndex, version );
 
 	}
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -1341,15 +1341,15 @@ class WebGPUBackend extends Backend {
 
 	// bindings
 
-	createBindings( bindGroup ) {
+	createBindings( bindGroup, bindings, cacheIndex ) {
 
-		this.bindingUtils.createBindings( bindGroup );
+		this.bindingUtils.createBindings( bindGroup, bindings, cacheIndex );
 
 	}
 
-	updateBindings( bindGroup ) {
+	updateBindings( bindGroup, bindings, cacheIndex ) {
 
-		this.bindingUtils.createBindings( bindGroup );
+		this.bindingUtils.createBindings( bindGroup, bindings, cacheIndex );
 
 	}
 

--- a/src/renderers/webgpu/utils/WebGPUBindingUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUBindingUtils.js
@@ -140,7 +140,7 @@ class WebGPUBindingUtils {
 
 	}
 
-	createBindings( bindGroup, bindings, cacheIndex ) {
+	createBindings( bindGroup, bindings, cacheIndex, version = 0 ) {
 
 		const { backend, bindGroupLayoutCache } = this;
 		const bindingsData = backend.get( bindGroup );
@@ -160,16 +160,31 @@ class WebGPUBindingUtils {
 
 		if ( cacheIndex > 0 ) {
 
-			if ( bindingsData.groups === undefined ) bindingsData.groups = [];
+			if ( bindingsData.groups === undefined ) {
 
-			bindGroupGPU = bindingsData.groups[ cacheIndex ];
+				bindingsData.groups = [];
+				bindingsData.versions = [];
+
+			}
+
+			if ( bindingsData.versions[ cacheIndex ] === version ) {
+
+				bindGroupGPU = bindingsData.groups[ cacheIndex ];
+
+			}
 
 		}
 
 		if ( bindGroupGPU === undefined ) {
 
 			bindGroupGPU = this.createBindGroup( bindGroup, bindLayoutGPU );
-			if ( cacheIndex > 0 ) bindingsData.groups[ cacheIndex ] = bindGroupGPU;
+
+			if ( cacheIndex > 0 ) {
+
+				bindingsData.groups[ cacheIndex ] = bindGroupGPU;
+				bindingsData.versions[ cacheIndex ] = version;
+
+			}
 
 		}
 

--- a/src/renderers/webgpu/utils/WebGPUBindingUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUBindingUtils.js
@@ -140,7 +140,7 @@ class WebGPUBindingUtils {
 
 	}
 
-	createBindings( bindGroup ) {
+	createBindings( bindGroup, bindings, cacheIndex ) {
 
 		const { backend, bindGroupLayoutCache } = this;
 		const bindingsData = backend.get( bindGroup );
@@ -156,10 +156,25 @@ class WebGPUBindingUtils {
 
 		}
 
-		const bindGroupGPU = this.createBindGroup( bindGroup, bindLayoutGPU );
+		let bindGroupGPU;
 
-		bindingsData.layout = bindLayoutGPU;
+		if ( cacheIndex > 0 ) {
+
+			if ( bindingsData.groups === undefined ) bindingsData.groups = [];
+
+			bindGroupGPU = bindingsData.groups[ cacheIndex ];
+
+		}
+
+		if ( bindGroupGPU === undefined ) {
+
+			bindGroupGPU = this.createBindGroup( bindGroup, bindLayoutGPU );
+			if ( cacheIndex > 0 ) bindingsData.groups[ cacheIndex ] = bindGroupGPU;
+
+		}
+
 		bindingsData.group = bindGroupGPU;
+		bindingsData.layout = bindLayoutGPU;
 
 	}
 


### PR DESCRIPTION
Related issue: #29198, #27447

Alternative mechanism to avoid excessive bindGroup creation. Use a cache keyed by a value derived from the texture(s) used in a bindGroup to handle the situation where a material alternates between two or more textures. This caching only takes place for bindGroups that would be updated after the first pass.

BindGroups referencing defaultTextures or external textures are not cached.