### PR TITLE
Docs: Loaders - "progresses" typo

### DIFF
--- a/docs/examples/en/loaders/MMDLoader.html
+++ b/docs/examples/en/loaders/MMDLoader.html
@@ -44,7 +44,7 @@
 				scene.add( mesh );
 
 			},
-			// called when loading is in progresses
+			// called when loading is in progress
 			function ( xhr ) {
 
 				console.log( ( xhr.loaded / xhr.total * 100 ) + '% loaded' );

--- a/docs/examples/en/loaders/OBJLoader.html
+++ b/docs/examples/en/loaders/OBJLoader.html
@@ -45,7 +45,7 @@
 				scene.add( object );
 
 			},
-			// called when loading is in progresses
+			// called when loading is in progress
 			function ( xhr ) {
 
 				console.log( ( xhr.loaded / xhr.total * 100 ) + '% loaded' );

--- a/docs/examples/en/loaders/PCDLoader.html
+++ b/docs/examples/en/loaders/PCDLoader.html
@@ -50,7 +50,7 @@
 				scene.add( points );
 
 			},
-			// called when loading is in progresses
+			// called when loading is in progress
 			function ( xhr ) {
 
 				console.log( ( xhr.loaded / xhr.total * 100 ) + '% loaded' );

--- a/docs/examples/en/loaders/PDBLoader.html
+++ b/docs/examples/en/loaders/PDBLoader.html
@@ -46,7 +46,7 @@
 				console.log( 'This molecule has ' + json.atoms.length + ' atoms' );
 
 			},
-			// called when loading is in progresses
+			// called when loading is in progress
 			function ( xhr ) {
 
 				console.log( ( xhr.loaded / xhr.total * 100 ) + '% loaded' );

--- a/docs/examples/en/loaders/SVGLoader.html
+++ b/docs/examples/en/loaders/SVGLoader.html
@@ -68,7 +68,7 @@
 				scene.add( group );
 
 			},
-			// called when loading is in progresses
+			// called when loading is in progress
 			function ( xhr ) {
 
 				console.log( ( xhr.loaded / xhr.total * 100 ) + '% loaded' );

--- a/docs/examples/en/loaders/TGALoader.html
+++ b/docs/examples/en/loaders/TGALoader.html
@@ -42,7 +42,7 @@
 				console.log( 'Texture is loaded' );
 
 			},
-			// called when the loading is in progresses
+			// called when the loading is in progress
 			function ( xhr ) {
 
 				console.log( ( xhr.loaded / xhr.total * 100 ) + '% loaded' );

--- a/docs/examples/zh/loaders/MMDLoader.html
+++ b/docs/examples/zh/loaders/MMDLoader.html
@@ -44,7 +44,7 @@
 				scene.add( mesh );
 
 			},
-			// called when loading is in progresses
+			// called when loading is in progress
 			function ( xhr ) {
 
 				console.log( ( xhr.loaded / xhr.total * 100 ) + '% loaded' );

--- a/docs/examples/zh/loaders/OBJLoader.html
+++ b/docs/examples/zh/loaders/OBJLoader.html
@@ -44,7 +44,7 @@
 				scene.add( object );
 
 			},
-			// called when loading is in progresses
+			// called when loading is in progress
 			function ( xhr ) {
 
 				console.log( ( xhr.loaded / xhr.total * 100 ) + '% loaded' );

--- a/docs/examples/zh/loaders/PCDLoader.html
+++ b/docs/examples/zh/loaders/PCDLoader.html
@@ -50,7 +50,7 @@
 				scene.add( points );
 
 			},
-			// called when loading is in progresses
+			// called when loading is in progress
 			function ( xhr ) {
 
 				console.log( ( xhr.loaded / xhr.total * 100 ) + '% loaded' );

--- a/docs/examples/zh/loaders/PDBLoader.html
+++ b/docs/examples/zh/loaders/PDBLoader.html
@@ -47,7 +47,7 @@
 				console.log( 'This molecule has ' + json.atoms.length + ' atoms' );
 
 			},
-			// called when loading is in progresses
+			// called when loading is in progress
 			function ( xhr ) {
 
 				console.log( ( xhr.loaded / xhr.total * 100 ) + '% loaded' );

--- a/docs/examples/zh/loaders/SVGLoader.html
+++ b/docs/examples/zh/loaders/SVGLoader.html
@@ -68,7 +68,7 @@
 				scene.add( group );
 
 			},
-			// called when loading is in progresses
+			// called when loading is in progress
 			function ( xhr ) {
 
 				console.log( ( xhr.loaded / xhr.total * 100 ) + '% loaded' );

--- a/docs/examples/zh/loaders/TGALoader.html
+++ b/docs/examples/zh/loaders/TGALoader.html
@@ -41,7 +41,7 @@
 				console.log( 'Texture is loaded' );
 
 			},
-			// called when the loading is in progresses
+			// called when the loading is in progress
 			function ( xhr ) {
 
 				console.log( ( xhr.loaded / xhr.total * 100 ) + '% loaded' );


### PR DESCRIPTION
**Description**

Fixing small typo met in the docs:

```diff
- loading is in progresses
+ loading is in progress
```