### PR TITLE
WebGPURenderer: Handle OutOfMemory in Timestamp Tracking

### DIFF
--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -1199,15 +1199,13 @@ class WebGPUBackend extends Backend {
 
 			const timestampWrites = {
 				querySet: timeStampQuerySet,
-				beginningOfPassWriteIndex: 0, // Write timestamp in index 0 when pass begins
-				endOfPassWriteIndex: 1, // Write timestamp in index 1 when pass ends
+				beginningOfPassWriteIndex: 0, // Write timestamp in index 0 when pass begins.
+				endOfPassWriteIndex: 1, // Write timestamp in index 1 when pass ends.
 			};
 
 			Object.assign( descriptor, { timestampWrites } );
 
 			renderContextData.timeStampQuerySet = timeStampQuerySet;
-
-			renderContextData.attemptingTimeStampQuerySet = false;
 
 		}
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -332,7 +332,7 @@ class WebGPUBackend extends Backend {
 
 			//
 
-			occlusionQuerySet = device.createQuerySet( { type: 'occlusion', count: occlusionQueryCount } );
+			occlusionQuerySet = device.createQuerySet( { type: 'occlusion', count: occlusionQueryCount, label: `occlusionQuerySet_${ renderContext.id }` } );
 
 			renderContextData.occlusionQuerySet = occlusionQuerySet;
 			renderContextData.occlusionQueryIndex = 0;
@@ -1178,7 +1178,7 @@ class WebGPUBackend extends Backend {
 			// Push an error scope to catch any errors during query set creation
 			this.device.pushErrorScope( 'out-of-memory' );
 
-			const timeStampQuerySet = await this.device.createQuerySet( { type: 'timestamp', count: 2 } );
+			const timeStampQuerySet = await this.device.createQuerySet( { type: 'timestamp', count: 2, label: `timestamp_renderContext_${renderContext.id}` } );
 
 			// Pop the error scope and check for errors
 			const error = await this.device.popErrorScope();

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -1187,7 +1187,7 @@ class WebGPUBackend extends Backend {
 
 				if ( ! renderContextData.attemptingTimeStampQuerySetFailed ) {
 
-					console.error( '[GPUOutOfMemoryError] Failed to create timestamp query set. This may be because timestamp queries are already running in other tabs. To enable timestamp measurements, please close other tabs using GPU resources and reload the page.' );
+					console.error( `[GPUOutOfMemoryError][renderContext_${renderContext.id}]:\nFailed to create timestamp query set. This may be because timestamp queries are already running in other tabs.` );
 					renderContextData.attemptingTimeStampQuerySetFailed = true;
 
 				}

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -1166,7 +1166,7 @@ class WebGPUBackend extends Backend {
 	}
 
 
-	initTimestampQuery( renderContext, descriptor ) {
+	async initTimestampQuery( renderContext, descriptor ) {
 
 		if ( ! this.trackTimestamp ) return;
 
@@ -1174,21 +1174,40 @@ class WebGPUBackend extends Backend {
 
 		if ( ! renderContextData.timeStampQuerySet ) {
 
-			// Create a GPUQuerySet which holds 2 timestamp query results: one for the
-			// beginning and one for the end of compute pass execution.
-			const timeStampQuerySet = this.device.createQuerySet( { type: 'timestamp', count: 2 } );
+
+			// Push an error scope to catch any errors during query set creation
+			this.device.pushErrorScope( 'out-of-memory' );
+
+			const timeStampQuerySet = await this.device.createQuerySet( { type: 'timestamp', count: 2 } );
+
+			// Pop the error scope and check for errors
+			const error = await this.device.popErrorScope();
+
+			if ( error ) {
+
+				if ( ! renderContextData.attemptingTimeStampQuerySetFailed ) {
+
+					console.error( '[GPUOutOfMemoryError] Failed to create timestamp query set. This may be because timestamp queries are already running in other tabs. To enable timestamp measurements, please close other tabs using GPU resources and reload the page.' );
+					renderContextData.attemptingTimeStampQuerySetFailed = true;
+
+				}
+
+				renderContextData.timeStampQuerySet = null; // Mark as unavailable
+				return;
+
+			}
 
 			const timestampWrites = {
 				querySet: timeStampQuerySet,
-				beginningOfPassWriteIndex: 0, // Write timestamp in index 0 when pass begins.
-				endOfPassWriteIndex: 1, // Write timestamp in index 1 when pass ends.
+				beginningOfPassWriteIndex: 0, // Write timestamp in index 0 when pass begins
+				endOfPassWriteIndex: 1, // Write timestamp in index 1 when pass ends
 			};
 
-			Object.assign( descriptor, {
-				timestampWrites,
-			} );
+			Object.assign( descriptor, { timestampWrites } );
 
 			renderContextData.timeStampQuerySet = timeStampQuerySet;
+
+			renderContextData.attemptingTimeStampQuerySet = false;
 
 		}
 
@@ -1202,6 +1221,7 @@ class WebGPUBackend extends Backend {
 
 		const renderContextData = this.get( renderContext );
 
+		if ( ! renderContextData.timeStampQuerySet ) return;
 
 		const size = 2 * BigInt64Array.BYTES_PER_ELEMENT;
 
@@ -1237,6 +1257,8 @@ class WebGPUBackend extends Backend {
 		if ( ! this.trackTimestamp ) return;
 
 		const renderContextData = this.get( renderContext );
+
+		if ( ! renderContextData.timeStampQuerySet ) return;
 
 		if ( renderContextData.currentTimestampQueryBuffers === undefined ) return;
 


### PR DESCRIPTION
**Description**

Add fallback for GPUOutOfMemoryError via `device.pushErrorScope( 'out-of-memory' )` when creating timestamp query set. This prevents renderer breakage caused by failed sample buffer allocation.
Also added an error message suggesting users close other GPU-intensive tabs to enable timestamp measurements as it's in most case the issue triggering the error.

Before (crashing the renderer):
<img width="507" alt="image" src="https://github.com/user-attachments/assets/27d4088f-a137-40b4-9eca-2f632bd74d55">

After (handle error, nothing breaks):
<img width="540" alt="image" src="https://github.com/user-attachments/assets/d3ce6e87-3f8a-4b67-8594-41cdae97ef5f">


*This contribution is funded by [Utsubo](https://utsubo.com)*
