### PR TITLE
Docs: clarify LineMaterial.linewidth units in relation to worldUnits …

### DIFF
--- a/docs/examples/en/lines/LineMaterial.html
+++ b/docs/examples/en/lines/LineMaterial.html
@@ -64,7 +64,7 @@
 		<p>The size of the gap. Default is `1`.</p>
 
 		<h3>[property:Float linewidth]</h3>
-		<p>Controls line thickness in screen pixels when [page:worldUnits] is `false` (default), or in world units when [page:worldUnits] is `true`. Default is `1`. Values less than 1 pixel may not be visible when using screen space units.</p>
+		<p>Controls line thickness in CSS pixel units when [page:worldUnits] is `false` (default), or in world units when [page:worldUnits] is `true`. Default is `1`.</p>
 
 		<h3>[property:Vector2 resolution]</h3>
 		<p>

--- a/docs/examples/en/lines/LineMaterial.html
+++ b/docs/examples/en/lines/LineMaterial.html
@@ -64,7 +64,7 @@
 		<p>The size of the gap. Default is `1`.</p>
 
 		<h3>[property:Float linewidth]</h3>
-		<p>Controls line thickness. Default is `1`.</p>
+		<p>Controls line thickness in screen pixels when [page:worldUnits] is `false` (default), or in world units when [page:worldUnits] is `true`. Default is `1`. Values less than 1 pixel may not be visible when using screen space units.</p>
 
 		<h3>[property:Vector2 resolution]</h3>
 		<p>


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/29863

**Description**

Clarifies that LineWidth uses screen pixels by default (when worldUnits is false). This helps prevent confusion around small values (<1) which may appear invisible in screen space mode.

