### PR TITLE
WebGPURenderer: Fix ImageBitmap flip in WebGLBackend

### DIFF
--- a/src/nodes/accessors/TextureNode.js
+++ b/src/nodes/accessors/TextureNode.js
@@ -126,9 +126,9 @@ class TextureNode extends UniformNode {
 
 		const texture = this.value;
 
-		if ( builder.isFlipY() && ( texture.isRenderTargetTexture === true || texture.isFramebufferTexture === true || texture.isDepthTexture === true ) ) {
+		if ( builder.isFlipY() && ( texture.image instanceof ImageBitmap || texture.isRenderTargetTexture === true || texture.isFramebufferTexture === true || texture.isDepthTexture === true ) ) {
 
-			if ( this.sampler ) {
+			if ( this.sampler || texture.image instanceof ImageBitmap ) {
 
 				uvNode = uvNode.flipY();
 

--- a/src/nodes/accessors/TextureNode.js
+++ b/src/nodes/accessors/TextureNode.js
@@ -126,9 +126,9 @@ class TextureNode extends UniformNode {
 
 		const texture = this.value;
 
-		if ( builder.isFlipY() && ( texture.image instanceof ImageBitmap || texture.isRenderTargetTexture === true || texture.isFramebufferTexture === true || texture.isDepthTexture === true ) ) {
+		if ( builder.isFlipY() && ( ( texture.image instanceof ImageBitmap && texture.flipY === true ) || texture.isRenderTargetTexture === true || texture.isFramebufferTexture === true || texture.isDepthTexture === true ) ) {
 
-			if ( this.sampler || texture.image instanceof ImageBitmap ) {
+			if ( this.sampler ) {
 
 				uvNode = uvNode.flipY();
 


### PR DESCRIPTION

**Description**

There is an inconsistency between WebGL and WebGPU, where ImageBitmap textures are unflipped by default. 
In WebGL 2.0, `gl.UNPACK_FLIP_Y_WEBGL` has no effect on ImageBitmap uploads, so we cannot flip the texture during upload.
To resolve this, I added a condition in TextureNode to flip the UV for ImageBitmap, similar to how we handle sampler textures.

*This contribution is funded by [Utsubo](https://utsubo.com)*
