### PR TITLE
WebGPURenderer: Fix OffscreenCanvas Support in WebGL

### DIFF
--- a/src/renderers/webgl-fallback/utils/WebGLTextureUtils.js
+++ b/src/renderers/webgl-fallback/utils/WebGLTextureUtils.js
@@ -415,7 +415,10 @@ class WebGLTextureUtils {
 
 				return source.image.data;
 
-			} else if ( source instanceof ImageBitmap || source instanceof OffscreenCanvas || source instanceof HTMLImageElement || source instanceof HTMLCanvasElement ) {
+			} else if ( ( typeof HTMLImageElement !== 'undefined' && source instanceof HTMLImageElement ) ||
+				( typeof HTMLCanvasElement !== 'undefined' && source instanceof HTMLCanvasElement ) ||
+				( typeof ImageBitmap !== 'undefined' && source instanceof ImageBitmap ) ||
+				source instanceof OffscreenCanvas ) {
 
 				return source;
 


### PR DESCRIPTION

**Description**
The OffscreenCanvas support was broken in the WebGLBackend with https://github.com/mrdoob/three.js/pull/27463. This PR fixes the issue.
<img width="531" alt="image" src="https://github.com/user-attachments/assets/9ff8d77c-7fbe-47ba-b63d-785c609c9490">

*This contribution is funded by [Utsubo](https://utsubo.com)*
