### PR TITLE
WebGPU: Logarithmic Depth Buffer Rename/Revision + GTAONode Fixes

### DIFF
--- a/examples/jsm/tsl/display/GTAONode.js
+++ b/examples/jsm/tsl/display/GTAONode.js
@@ -1,5 +1,5 @@
-import { DataTexture, RenderTarget, RepeatWrapping, Vector2, Vector3, logarithmicDepthToViewZ, viewZToPerspectiveDepth } from 'three';
-import { getNormalFromDepth, getScreenPosition, getViewPosition, QuadMesh, TempNode, nodeObject, Fn, float, NodeUpdateType, uv, uniform, Loop, vec2, vec3, vec4, int, dot, max, pow, abs, If, textureSize, sin, cos, PI, texture, passTexture, mat3, add, normalize, mul, cross, div, mix, sqrt, sub, acos, clamp, NodeMaterial, PostProcessingUtils } from 'three/tsl';
+import { DataTexture, RenderTarget, RepeatWrapping, Vector2, Vector3 } from 'three';
+import { reference, logarithmicDepthToViewZ, viewZToPerspectiveDepth, getNormalFromDepth, getScreenPosition, getViewPosition, QuadMesh, TempNode, nodeObject, Fn, float, NodeUpdateType, uv, uniform, Loop, vec2, vec3, vec4, int, dot, max, pow, abs, If, textureSize, sin, cos, PI, texture, passTexture, mat3, add, normalize, mul, cross, div, mix, sqrt, sub, acos, clamp, NodeMaterial, PostProcessingUtils } from 'three/tsl';
 
 const _quadMesh = /*@__PURE__*/ new QuadMesh();
 const _size = /*@__PURE__*/ new Vector2();
@@ -27,8 +27,8 @@ class GTAONode extends TempNode {
 
 		this.resolutionScale = 1;
 
-		this.cameraNear = uniform( 'float' ).onRenderUpdate( () => camera.near );
-		this.cameraFar = uniform( 'float' ).onRenderUpdate( () => camera.far );
+		this.cameraNear = reference( 'near', 'float', camera );
+		this.cameraFar = reference( 'far', 'float', camera );
 
 		this.radius = uniform( 0.25 );
 		this.resolution = uniform( new Vector2() );

--- a/src/materials/nodes/NodeMaterial.js
+++ b/src/materials/nodes/NodeMaterial.js
@@ -18,7 +18,7 @@ import { float, vec3, vec4 } from '../../nodes/tsl/TSLBase.js';
 import AONode from '../../nodes/lighting/AONode.js';
 import { lightingContext } from '../../nodes/lighting/LightingContextNode.js';
 import IrradianceNode from '../../nodes/lighting/IrradianceNode.js';
-import { depth, perspectiveDepthToLogarithmicDepth, viewZToOrthographicDepth } from '../../nodes/display/ViewportDepthNode.js';
+import { depth, viewZToLogarithmicDepth, viewZToOrthographicDepth } from '../../nodes/display/ViewportDepthNode.js';
 import { cameraFar, cameraNear } from '../../nodes/accessors/Camera.js';
 import { clipping, clippingAlpha, hardwareClipping } from '../../nodes/accessors/ClippingNode.js';
 import NodeMaterialObserver from './manager/NodeMaterialObserver.js';
@@ -285,7 +285,7 @@ class NodeMaterial extends Material {
 
 				if ( camera.isPerspectiveCamera ) {
 
-					depthNode = perspectiveDepthToLogarithmicDepth( modelViewProjection().w, cameraNear, cameraFar );
+					depthNode = viewZToLogarithmicDepth( positionView.z, cameraNear, cameraFar );
 
 				} else {
 

--- a/src/nodes/lighting/ShadowNode.js
+++ b/src/nodes/lighting/ShadowNode.js
@@ -313,8 +313,8 @@ class ShadowNode extends Node {
 			// The normally available "cameraNear" and "cameraFar" nodes cannot be used here because they do not get
 			// updated to use the shadow camera. So, we have to declare our own "local" ones here.
 			// TODO: How do we get the cameraNear/cameraFar nodes to use the shadow camera so we don't have to declare local ones here?
-			const cameraNearLocal = reference( 'near', 'float', shadow.camera ).setGroup( renderGroup );;
-			const cameraFarLocal = reference( 'far', 'float', shadow.camera ).setGroup( renderGroup );;
+			const cameraNearLocal = reference( 'near', 'float', shadow.camera ).setGroup( renderGroup );
+			const cameraFarLocal = reference( 'far', 'float', shadow.camera ).setGroup( renderGroup );
 
 			coordZ = viewZToLogarithmicDepth( w.negate(), cameraNearLocal, cameraFarLocal );
 

--- a/src/nodes/lighting/ShadowNode.js
+++ b/src/nodes/lighting/ShadowNode.js
@@ -15,7 +15,7 @@ import { Loop } from '../utils/LoopNode.js';
 import { screenCoordinate } from '../display/ScreenNode.js';
 import { HalfFloatType, LessCompare, RGFormat, VSMShadowMap, WebGPUCoordinateSystem } from '../../constants.js';
 import { renderGroup } from '../core/UniformGroupNode.js';
-import { perspectiveDepthToLogarithmicDepth } from '../display/ViewportDepthNode.js';
+import { viewZToLogarithmicDepth } from '../display/ViewportDepthNode.js';
 
 const BasicShadowMap = Fn( ( { depthTexture, shadowCoord } ) => {
 
@@ -316,7 +316,7 @@ class ShadowNode extends Node {
 			const cameraNearLocal = uniform( 'float' ).onRenderUpdate( () => shadow.camera.near );
 			const cameraFarLocal = uniform( 'float' ).onRenderUpdate( () => shadow.camera.far );
 
-			coordZ = perspectiveDepthToLogarithmicDepth( w, cameraNearLocal, cameraFarLocal );
+			coordZ = viewZToLogarithmicDepth( w.negate(), cameraNearLocal, cameraFarLocal );
 
 		}
 

--- a/src/nodes/lighting/ShadowNode.js
+++ b/src/nodes/lighting/ShadowNode.js
@@ -313,8 +313,8 @@ class ShadowNode extends Node {
 			// The normally available "cameraNear" and "cameraFar" nodes cannot be used here because they do not get
 			// updated to use the shadow camera. So, we have to declare our own "local" ones here.
 			// TODO: How do we get the cameraNear/cameraFar nodes to use the shadow camera so we don't have to declare local ones here?
-			const cameraNearLocal = uniform( 'float' ).onRenderUpdate( () => shadow.camera.near );
-			const cameraFarLocal = uniform( 'float' ).onRenderUpdate( () => shadow.camera.far );
+			const cameraNearLocal = reference( 'near', 'float', shadow.camera );
+			const cameraFarLocal = reference( 'far', 'float', shadow.camera );
 
 			coordZ = viewZToLogarithmicDepth( w.negate(), cameraNearLocal, cameraFarLocal );
 

--- a/src/nodes/lighting/ShadowNode.js
+++ b/src/nodes/lighting/ShadowNode.js
@@ -313,8 +313,8 @@ class ShadowNode extends Node {
 			// The normally available "cameraNear" and "cameraFar" nodes cannot be used here because they do not get
 			// updated to use the shadow camera. So, we have to declare our own "local" ones here.
 			// TODO: How do we get the cameraNear/cameraFar nodes to use the shadow camera so we don't have to declare local ones here?
-			const cameraNearLocal = reference( 'near', 'float', shadow.camera );
-			const cameraFarLocal = reference( 'far', 'float', shadow.camera );
+			const cameraNearLocal = reference( 'near', 'float', shadow.camera ).setGroup( renderGroup );;
+			const cameraFarLocal = reference( 'far', 'float', shadow.camera ).setGroup( renderGroup );;
 
 			coordZ = viewZToLogarithmicDepth( w.negate(), cameraNearLocal, cameraFarLocal );
 


### PR DESCRIPTION
Fixed #29797.

1. Renamed the function `perspectiveDepthToLogarithmicDepth` to `viewZToLogarithmicDepth` and modified it to expect a negative `viewZ` value in order maintain consistency with `viewZToOrthographicDepth` and `viewZToPerspectiveDepth`
2. Revised the logarithmic depth curve once more to ensure it maintains a full 0-to-1 range no matter the camera near/far values.
See new curves here on Desmos: https://www.desmos.com/calculator/uyqk0vex1u
4. Added function `logarithmicDepthToViewZ` for use in **GTAONode.js**
5. Fixed AO not working when `logarithmicDepthBuffer` is `true`

Related issue: #29797 

**Description**

The name of the function `perspectiveDepthToLogarithmicDepth` is misleading because it actually expects a `viewZ` value (i.e. `positionView.z`), and NOT a depth value (i.e. a number between 0 and 1). In addition, the `viewZ` value that it previously expected had to be a positive number, which differed from its sister functions `viewZToOrthographicDepth` and `viewZToPerspectiveDepth`, which both expect a negative `viewZ`. In this pull request, the function in question is now named `viewZToLogarithmicDepth`, and expects a negative `viewZ` like the rest in its family.

AO was not working properly in the **webgpu_postprocessing_ao** example when `logarithmicDepthBuffer` was `true`. The function `logarithmicDepthToViewZ` was added to **ViewportDepthNode.js**, so it can now be used in **GTAONode.js** to obtain the proper depth values required for AO.

Here is a JSFiddle I made to demonstrate how `viewZToLogarithmicDepth` relates to the rest of the depth functions:

https://jsfiddle.net/go6f2y4u

And here is an animation of the JSFiddle:

![depthfamily](https://github.com/user-attachments/assets/6d658af4-d714-40bd-b31d-5a4bcbe48e60)

![image](https://github.com/user-attachments/assets/ac29ac44-f7b2-469f-ac56-d5c3bc2f974b)

![image](https://github.com/user-attachments/assets/5f02bd92-308f-40b1-bd73-99f880c3d846)

