### PR TITLE
ArcballControls: Add `enableFocus`.

### DIFF
--- a/docs/examples/en/controls/ArcballControls.html
+++ b/docs/examples/en/controls/ArcballControls.html
@@ -151,6 +151,10 @@
 		<p>
 			Enable or disable zooming of the camera.
 		</p>
+		<h3>[property:Boolean enableFocus]</h3>
+		<p>
+Set to true to enable camera focusing on double-tap (or click) operations. Default is true.
+		</p>
 
 		<h3>[property:Float focusAnimationTime]</h3>
 		<p>

--- a/docs/examples/en/controls/ArcballControls.html
+++ b/docs/examples/en/controls/ArcballControls.html
@@ -153,7 +153,7 @@
 		</p>
 		<h3>[property:Boolean enableFocus]</h3>
 		<p>
-      Set to true to enable camera focusing on double-tap (or click) operations. Default is true.
+			Enable or disable camera focusing on double-tap (or click) operations. Default is true.
 		</p>
 
 		<h3>[property:Float focusAnimationTime]</h3>

--- a/docs/examples/en/controls/ArcballControls.html
+++ b/docs/examples/en/controls/ArcballControls.html
@@ -132,6 +132,11 @@
 			Set to true to enable animations for rotation (damping) and focus operation. Default is true.
 		</p>
 
+		<h3>[property:Boolean enableFocus]</h3>
+		<p>
+			Enable or disable camera focusing on double-tap (or click) operations. Default is true.
+		</p>
+
 		<h3>[property:Boolean enableGrid]</h3>
 		<p>
 			When set to true, a grid will appear when panning operation is being performed (desktop interaction only). Default is false.
@@ -150,10 +155,6 @@
 		<h3>[property:Boolean enableZoom]</h3>
 		<p>
 			Enable or disable zooming of the camera.
-		</p>
-		<h3>[property:Boolean enableFocus]</h3>
-		<p>
-			Enable or disable camera focusing on double-tap (or click) operations. Default is true.
 		</p>
 
 		<h3>[property:Float focusAnimationTime]</h3>

--- a/docs/examples/en/controls/ArcballControls.html
+++ b/docs/examples/en/controls/ArcballControls.html
@@ -153,7 +153,7 @@
 		</p>
 		<h3>[property:Boolean enableFocus]</h3>
 		<p>
-Set to true to enable camera focusing on double-tap (or click) operations. Default is true.
+      Set to true to enable camera focusing on double-tap (or click) operations. Default is true.
 		</p>
 
 		<h3>[property:Float focusAnimationTime]</h3>

--- a/docs/examples/ko/controls/ArcballControls.html
+++ b/docs/examples/ko/controls/ArcballControls.html
@@ -151,6 +151,10 @@
 	<p>
 		카메라 줌을 사용하거나 사용하지 않습니다.
 	</p>
+<h3>[property:Boolean enableFocus]</h3>
+<p>
+	더블 탭(또는 클릭) 시 카메라 초점을 맞추는 기능을 활성화하려면 true로 설정합니다. 기본값은 true입니다.
+</p>
 
 	<h3>[property:Float focusAnimationTime]</h3>
 	<p>

--- a/docs/examples/ko/controls/ArcballControls.html
+++ b/docs/examples/ko/controls/ArcballControls.html
@@ -151,10 +151,11 @@
 	<p>
 		카메라 줌을 사용하거나 사용하지 않습니다.
 	</p>
-  <h3>[property:Boolean enableFocus]</h3>
-  <p>
-	  더블 탭(또는 클릭) 시 카메라 초점을 맞추는 기능을 활성화하려면 true로 설정합니다. 기본값은 true입니다.
-  </p>
+
+	<h3>[property:Boolean enableFocus]</h3>
+	<p>
+		더블 탭(또는 클릭) 시 카메라 초점을 맞추는 기능을 활성화하려면 true로 설정합니다. 기본값은 true입니다.
+	</p>
 
 	<h3>[property:Float focusAnimationTime]</h3>
 	<p>

--- a/docs/examples/ko/controls/ArcballControls.html
+++ b/docs/examples/ko/controls/ArcballControls.html
@@ -151,10 +151,10 @@
 	<p>
 		카메라 줌을 사용하거나 사용하지 않습니다.
 	</p>
-<h3>[property:Boolean enableFocus]</h3>
-<p>
-	더블 탭(또는 클릭) 시 카메라 초점을 맞추는 기능을 활성화하려면 true로 설정합니다. 기본값은 true입니다.
-</p>
+  <h3>[property:Boolean enableFocus]</h3>
+  <p>
+	  더블 탭(또는 클릭) 시 카메라 초점을 맞추는 기능을 활성화하려면 true로 설정합니다. 기본값은 true입니다.
+  </p>
 
 	<h3>[property:Float focusAnimationTime]</h3>
 	<p>

--- a/docs/examples/ko/controls/ArcballControls.html
+++ b/docs/examples/ko/controls/ArcballControls.html
@@ -132,6 +132,11 @@
 		true로 설정하여 회전 (감쇠)과 초점 맞추기 동작을 위한 애니메이션을 활성화합니다.기본값은 true입니다.
 	</p>
 
+	<h3>[property:Boolean enableFocus]</h3>
+	<p>
+		더블 탭(또는 클릭) 시 카메라 초점을 맞추는 기능을 활성화하려면 true로 설정합니다. 기본값은 true입니다.
+	</p>
+
 	<h3>[property:Boolean enableGrid]</h3>
 	<p>
 		true로 설정하면 패닝 동작을 할 때 모드가 나타날 것입니다 (데스크톱 상호 작용할 때만).기본값은 false입니다.
@@ -150,11 +155,6 @@
 	<h3>[property:Boolean enableZoom]</h3>
 	<p>
 		카메라 줌을 사용하거나 사용하지 않습니다.
-	</p>
-
-	<h3>[property:Boolean enableFocus]</h3>
-	<p>
-		더블 탭(또는 클릭) 시 카메라 초점을 맞추는 기능을 활성화하려면 true로 설정합니다. 기본값은 true입니다.
 	</p>
 
 	<h3>[property:Float focusAnimationTime]</h3>

--- a/docs/examples/zh/controls/ArcballControls.html
+++ b/docs/examples/zh/controls/ArcballControls.html
@@ -142,6 +142,10 @@
 	<p>
 		启用或禁用相机变焦。
 	</p>
+<h3>[property:Boolean enableFocus]</h3>
+<p>
+	设置为 true 以在双击（或点击）时启用相机聚焦功能。默认值为 true。
+</p>
 
 	<h3>[property:Float focusAnimationTime]</h3>
 	<p>

--- a/docs/examples/zh/controls/ArcballControls.html
+++ b/docs/examples/zh/controls/ArcballControls.html
@@ -142,10 +142,10 @@
 	<p>
 		启用或禁用相机变焦。
 	</p>
-<h3>[property:Boolean enableFocus]</h3>
-<p>
-	设置为 true 以在双击（或点击）时启用相机聚焦功能。默认值为 true。
-</p>
+  <h3>[property:Boolean enableFocus]</h3>
+  <p>
+	  设置为 true 以在双击（或点击）时启用相机聚焦功能。默认值为 true。
+  </p>
 
 	<h3>[property:Float focusAnimationTime]</h3>
 	<p>

--- a/docs/examples/zh/controls/ArcballControls.html
+++ b/docs/examples/zh/controls/ArcballControls.html
@@ -123,6 +123,11 @@
 		设置为 true 以启用旋转（阻尼）和聚焦操作的动画。默认为 true。
 	</p>
 
+	<h3>[property:Boolean enableFocus]</h3>
+	<p>
+		设置为 true 以在双击（或点击）时启用相机聚焦功能。默认值为 true。
+	</p>
+
 	<h3>[property:Boolean enableGrid]</h3>
 	<p>
 		设置为 true 时，执行平移操作时将出现网格（仅限桌面交互）。默认为 false。
@@ -141,11 +146,6 @@
 	<h3>[property:Boolean enableZoom]</h3>
 	<p>
 		启用或禁用相机变焦。
-	</p>
-
-	<h3>[property:Boolean enableFocus]</h3>
-	<p>
-		设置为 true 以在双击（或点击）时启用相机聚焦功能。默认值为 true。
 	</p>
 
 	<h3>[property:Float focusAnimationTime]</h3>

--- a/docs/examples/zh/controls/ArcballControls.html
+++ b/docs/examples/zh/controls/ArcballControls.html
@@ -142,10 +142,11 @@
 	<p>
 		启用或禁用相机变焦。
 	</p>
-  <h3>[property:Boolean enableFocus]</h3>
-  <p>
-	  设置为 true 以在双击（或点击）时启用相机聚焦功能。默认值为 true。
-  </p>
+
+	<h3>[property:Boolean enableFocus]</h3>
+	<p>
+		设置为 true 以在双击（或点击）时启用相机聚焦功能。默认值为 true。
+	</p>
 
 	<h3>[property:Float focusAnimationTime]</h3>
 	<p>

--- a/examples/jsm/controls/ArcballControls.js
+++ b/examples/jsm/controls/ArcballControls.js
@@ -2039,7 +2039,6 @@ class ArcballControls extends Controls {
 
 			state = JSON.stringify( {
 				arcballState: {
-
 					cameraFar: this.object.far,
 					cameraMatrix: this.object.matrix,
 					cameraNear: this.object.near,

--- a/examples/jsm/controls/ArcballControls.js
+++ b/examples/jsm/controls/ArcballControls.js
@@ -204,6 +204,7 @@ class ArcballControls extends Controls {
 		this.enableRotate = true;
 		this.enableZoom = true;
 		this.enableGizmos = true;
+		this.enableFocus = true;
 
 		this.minDistance = 0;
 		this.maxDistance = Infinity;
@@ -697,7 +698,7 @@ class ArcballControls extends Controls {
 
 	onDoubleTap( event ) {
 
-		if ( this.enabled && this.enablePan && this.scene != null ) {
+		if ( this.enabled && this.enablePan && this.enableFocus && this.scene != null ) {
 
 			this.dispatchEvent( _startEvent );
 
@@ -2036,29 +2037,33 @@ class ArcballControls extends Controls {
 		let state;
 		if ( this.object.isOrthographicCamera ) {
 
-			state = JSON.stringify( { arcballState: {
+			state = JSON.stringify( {
+				arcballState: {
 
-				cameraFar: this.object.far,
-				cameraMatrix: this.object.matrix,
-				cameraNear: this.object.near,
-				cameraUp: this.object.up,
-				cameraZoom: this.object.zoom,
-				gizmoMatrix: this._gizmos.matrix
+					cameraFar: this.object.far,
+					cameraMatrix: this.object.matrix,
+					cameraNear: this.object.near,
+					cameraUp: this.object.up,
+					cameraZoom: this.object.zoom,
+					gizmoMatrix: this._gizmos.matrix
 
-			} } );
+				}
+			} );
 
 		} else if ( this.object.isPerspectiveCamera ) {
 
-			state = JSON.stringify( { arcballState: {
-				cameraFar: this.object.far,
-				cameraFov: this.object.fov,
-				cameraMatrix: this.object.matrix,
-				cameraNear: this.object.near,
-				cameraUp: this.object.up,
-				cameraZoom: this.object.zoom,
-				gizmoMatrix: this._gizmos.matrix
+			state = JSON.stringify( {
+				arcballState: {
+					cameraFar: this.object.far,
+					cameraFov: this.object.fov,
+					cameraMatrix: this.object.matrix,
+					cameraNear: this.object.near,
+					cameraUp: this.object.up,
+					cameraZoom: this.object.zoom,
+					gizmoMatrix: this._gizmos.matrix
 
-			} } );
+				}
+			} );
 
 		}
 
@@ -2233,7 +2238,7 @@ class ArcballControls extends Controls {
 	 * @param {Matrix4} camera Transformation to be applied to the camera
 	 * @param {Matrix4} gizmos Transformation to be applied to gizmos
 	 */
-	 setTransformationMatrices( camera = null, gizmos = null ) {
+	setTransformationMatrices( camera = null, gizmos = null ) {
 
 		if ( camera != null ) {
 
@@ -2620,7 +2625,7 @@ class ArcballControls extends Controls {
 				this.applyTransformMatrix( this.scale( newDistance / distance, this._gizmos.position ) );
 				this.updateMatrixState();
 
-			 }
+			}
 
 			//check fov
 			if ( this.object.fov < this.minFov || this.object.fov > this.maxFov ) {

--- a/examples/misc_controls_arcball.html
+++ b/examples/misc_controls_arcball.html
@@ -63,6 +63,7 @@
 					folderOptions.add( controls, 'enableRotate' ).name( 'Enable rotate' );
 					folderOptions.add( controls, 'enablePan' ).name( 'Enable pan' );
 					folderOptions.add( controls, 'enableZoom' ).name( 'Enable zoom' );
+					folderOptions.add( controls, 'enableFocus' ).name( 'Enable focus' );
 					folderOptions.add( controls, 'cursorZoom' ).name( 'Cursor zoom' );
 					folderOptions.add( controls, 'adjustNearFar' ).name( 'adjust near/far' );
 					folderOptions.add( controls, 'scaleFactor', 1.1, 10, 0.1 ).name( 'Scale factor' );

--- a/examples/misc_controls_arcball.html
+++ b/examples/misc_controls_arcball.html
@@ -59,11 +59,11 @@
 				populateGui: function () {
 
 					folderOptions.add( controls, 'enabled' ).name( 'Enable controls' );
+					folderOptions.add( controls, 'enableFocus' ).name( 'Enable focus' );
 					folderOptions.add( controls, 'enableGrid' ).name( 'Enable Grid' );
 					folderOptions.add( controls, 'enableRotate' ).name( 'Enable rotate' );
 					folderOptions.add( controls, 'enablePan' ).name( 'Enable pan' );
 					folderOptions.add( controls, 'enableZoom' ).name( 'Enable zoom' );
-					folderOptions.add( controls, 'enableFocus' ).name( 'Enable focus' );
 					folderOptions.add( controls, 'cursorZoom' ).name( 'Cursor zoom' );
 					folderOptions.add( controls, 'adjustNearFar' ).name( 'adjust near/far' );
 					folderOptions.add( controls, 'scaleFactor', 1.1, 10, 0.1 ).name( 'Scale factor' );


### PR DESCRIPTION
**Description**
I’m developing a 3D Point Cloud editor using Three.js, and I’m using ArcballControls because it’s the best fit for this project. While editing (especially when removing noise points at specific click locations), unwanted focus events often get triggered by double-tap actions, which hurts the user experience.

To improve this, I’ve modified ArcballControls to prevent double-tap (or double-click) actions from triggering focus when it’s not wanted. I’ve added a new enableFocus property that allows users to disable the focus action, helping to avoid interruptions during editing.

Here's a GIF showing how it works:
![ArcballControls](https://github.com/user-attachments/assets/6f3d7435-c5a8-4f58-9991-6cfeebe22562)


