### PR TITLE
RenderObjects: Force `material.needsUpdate=true` to update the material if geometry is changed.

### DIFF
--- a/src/renderers/common/RenderObjects.js
+++ b/src/renderers/common/RenderObjects.js
@@ -40,9 +40,13 @@ class RenderObjects {
 
 			renderObject.updateClipping( clippingContext );
 
-			const needsGeometryUpdate = renderObject.needsGeometryUpdate;
+			if ( renderObject.needsGeometryUpdate ) {
 
-			if ( renderObject.version !== material.version || renderObject.needsUpdate || needsGeometryUpdate ) {
+				renderObject.setGeometry( object.geometry );
+
+			}
+
+			if ( renderObject.version !== material.version || renderObject.needsUpdate ) {
 
 				if ( renderObject.initialCacheKey !== renderObject.getCacheKey() ) {
 
@@ -53,12 +57,6 @@ class RenderObjects {
 				} else {
 
 					renderObject.version = material.version;
-
-					if ( needsGeometryUpdate ) {
-
-						renderObject.setGeometry( object.geometry );
-
-					}
 
 				}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/29836

**Description**

Force `material.needsUpdate=true` to update the material if geometry is changed.