### PR TITLE
TiledLightsNode: Fix `reflectedLight` declaration sequence

### DIFF
--- a/examples/jsm/tsl/lighting/TiledLightsNode.js
+++ b/examples/jsm/tsl/lighting/TiledLightsNode.js
@@ -204,6 +204,8 @@ class TiledLightsNode extends LightsNode {
 		lightingModel.directDiffuse.append();
 		lightingModel.directSpecular.append();
 
+		super.setupLights( builder, lightNodes );
+
 		Fn( () => {
 
 			Loop( this.tileLightCount, ( { i } ) => {
@@ -228,10 +230,6 @@ class TiledLightsNode extends LightsNode {
 			} );
 
 		} )().append();
-
-		// others lights
-
-		super.setupLights( builder, lightNodes );
 
 	}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/29642#issuecomment-2472847711

**Description**

Fix `reflectedLight` declaration sequence.