### PR TITLE
TSL: Add `blendNormal()` to `BlendMode`.

### DIFF
--- a/examples/webgpu_postprocessing_ssr.html
+++ b/examples/webgpu_postprocessing_ssr.html
@@ -28,7 +28,7 @@
 
 	<script type="module">
 		import * as THREE from 'three';
-		import { pass, mrt, output, transformedNormalView, metalness, normalBlend, screenUV, color } from 'three/tsl';
+		import { pass, mrt, output, transformedNormalView, metalness, blendNormal, screenUV, color } from 'three/tsl';
 		import { ssr } from 'three/addons/tsl/display/SSRNode.js';
 
 		import { DRACOLoader } from 'three/addons/loaders/DRACOLoader.js';
@@ -107,7 +107,7 @@
 
 			// blend SSR over beauty
 		
-			const outputNode = normalBlend( scenePassColor, ssrPass );
+			const outputNode = blendNormal( scenePassColor, ssrPass );
 
 			postProcessing.outputNode = outputNode;
 

--- a/examples/webgpu_postprocessing_ssr.html
+++ b/examples/webgpu_postprocessing_ssr.html
@@ -28,7 +28,7 @@
 
 	<script type="module">
 		import * as THREE from 'three';
-		import { pass, mrt, output, transformedNormalView, metalness, vec4, screenUV, color } from 'three/tsl';
+		import { pass, mrt, output, transformedNormalView, metalness, normalBlend, screenUV, color } from 'three/tsl';
 		import { ssr } from 'three/addons/tsl/display/SSRNode.js';
 
 		import { DRACOLoader } from 'three/addons/loaders/DRACOLoader.js';
@@ -107,7 +107,7 @@
 
 			// blend SSR over beauty
 		
-			const outputNode = vec4( scenePass.rgb.mul( ssrPass.a.oneMinus() ).add( ssrPass.rgb.mul( ssrPass.a ) ), scenePass.a );
+			const outputNode = normalBlend( scenePassColor, ssrPass );
 
 			postProcessing.outputNode = outputNode;
 

--- a/src/nodes/display/BlendMode.js
+++ b/src/nodes/display/BlendMode.js
@@ -1,4 +1,4 @@
-import { Fn } from '../tsl/TSLBase.js';
+import { Fn, vec4 } from '../tsl/TSLBase.js';
 import { mix, min, step } from '../math/MathNode.js';
 
 export const burn = /*@__PURE__*/ Fn( ( [ base, blend ] ) => {
@@ -50,5 +50,18 @@ export const overlay = /*@__PURE__*/ Fn( ( [ base, blend ] ) => {
 	inputs: [
 		{ name: 'base', type: 'vec3' },
 		{ name: 'blend', type: 'vec3' }
+	]
+} );
+
+export const normalBlend = /*@__PURE__*/ Fn( ( [ base, blend ] ) => {
+
+	return vec4( base.rgb.mul( blend.a.oneMinus() ).add( blend.rgb.mul( blend.a ) ), base.a );
+
+} ).setLayout( {
+	name: 'normalBlend',
+	type: 'vec4',
+	inputs: [
+		{ name: 'base', type: 'vec4' },
+		{ name: 'blend', type: 'vec4' }
 	]
 } );

--- a/src/nodes/display/BlendMode.js
+++ b/src/nodes/display/BlendMode.js
@@ -53,12 +53,12 @@ export const overlay = /*@__PURE__*/ Fn( ( [ base, blend ] ) => {
 	]
 } );
 
-export const normalBlend = /*@__PURE__*/ Fn( ( [ base, blend ] ) => {
+export const blendNormal = /*@__PURE__*/ Fn( ( [ base, blend ] ) => {
 
 	return vec4( base.rgb.mul( blend.a.oneMinus() ).add( blend.rgb.mul( blend.a ) ), base.a );
 
 } ).setLayout( {
-	name: 'normalBlend',
+	name: 'blendNormal',
 	type: 'vec4',
 	inputs: [
 		{ name: 'base', type: 'vec4' },


### PR DESCRIPTION
Related issue:  https://github.com/mrdoob/three.js/pull/29597#discussion_r1793395359

**Description**

This PR adds a `blendNormal()` helper which simplifies the SSR blend on app level.

BTW: Is `BlendMode` a typo? Should it be `BlendNode`?