### PR TITLE
Docs: Post-processing - Missing FR translation

### DIFF
--- a/docs/manual/fr/introduction/How-to-use-post-processing.html
+++ b/docs/manual/fr/introduction/How-to-use-post-processing.html
@@ -59,8 +59,7 @@
 
 		<p>
 			Notre composer est maintenant prêt, il est donc possible de configurer la chaîne d'effets de post-processing. Ces effets (passes) sont chargés de la création
-			de l'apparence visuelle finale de l'application. Ils sont traités dans l'ordre de leur ajout/insertion. In our example, the instance of `RenderPass`
-			is executed first, then the instance of `GlitchPass` and finally `OutputPass`. Le dernier effet activé de la chaîne est automatiquement rendu dans la scène. Le setup
+			de l'apparence visuelle finale de l'application. Ils sont traités dans l'ordre de leur ajout/insertion. Dans notre exemple, l'instance de `RenderPass` est exécutée en premier, puis l'instance de `GlitchPass` et enfin `OutputPass`. Le dernier effet activé de la chaîne est automatiquement rendu dans la scène. Le setup
 			des effets ressemble à ça:
 		</p>
 


### PR DESCRIPTION
**Description**

Translation is missing for this sentence:

```
In our example, the instance of `RenderPass` is executed first, then the instance of `GlitchPass` and finally `OutputPass`
```