### PR TITLE
KTX2Loader: Fix .minFilter default for untranscoded compressed textures

### DIFF
--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -988,6 +988,9 @@ async function createRawTexture( container ) {
 
 		texture = new CompressedTexture( mipmaps, container.pixelWidth, container.pixelHeight );
 
+		texture.minFilter = mipmaps.length === 1 ? LinearFilter : LinearMipmapLinearFilter;
+		texture.magFilter = LinearFilter;
+
 	}
 
 	texture.mipmaps = mipmaps;


### PR DESCRIPTION
KTX2Loader implements three 'paths' for textures:

1. Uncompressed DataTexture (F16, F32, Uint8, ...)
2. Raw CompressedTexture (ETC1/2, ASTC, BCn, ...)
3. Universal/transcoded CompressedTexture (BasisLZ/ETC1S, UASTC)

Basis UASTC HDR textures may take path (2) or (3) depending on device support for ASTC HDR formats, since the pre-transcode data is also valid ASTC data. In case (2), we weren't correctly setting `.minFilter` defaults for textures without mipmaps.

- Fixes #29884 
