### PR TITLE
Audio: Ensure progress is reset in `onEnded()`.

### DIFF
--- a/src/audio/Audio.js
+++ b/src/audio/Audio.js
@@ -327,7 +327,8 @@ class Audio extends Object3D {
 
 	onEnded() {
 
-		this.stop();
+		this.isPlaying = false;
+		this._progress = 0;
 
 	}
 

--- a/src/audio/Audio.js
+++ b/src/audio/Audio.js
@@ -327,7 +327,7 @@ class Audio extends Object3D {
 
 	onEnded() {
 
-		this.isPlaying = false;
+		this.stop();
 
 	}
 


### PR DESCRIPTION
## Issue Description:
The `play` method of the audio object in Three.js sets the starting point based on the current `progress`. The `progress` is updated only when the `pause` or `stop` methods are called.

Currently, when `pause` is executed during playback, the `progress` is set to the pause point. If the audio is played to the end from that point, the `onEnded` event is triggered, and the audio stops. However, if playback is restarted after this, the `onEnded` event does not update the `progress`. As a result, the audio restarts from the previous `pause` point rather than the actual start of the audio.

## Proposed Solution:
This behavior is unintuitive and can lead to unexpected behavior. To resolve this issue, I modified the `onEnded` method to execute the `stop` method, which ensures that `progress` is updated correctly.

## ScreenShot
before

https://github.com/user-attachments/assets/676cb00d-f3b0-49c6-bf2f-e8145c0f88a0

after

https://github.com/user-attachments/assets/d22f169f-995b-4b06-bdf0-64bae2a08646





