### PR TITLE
WebGPU: Remove `GPUShaderStage` hack.

### DIFF
--- a/examples/jsm/capabilities/WebGPU.js
+++ b/examples/jsm/capabilities/WebGPU.js
@@ -1,11 +1,3 @@
-if ( self.GPUShaderStage === undefined ) {
-
-	self.GPUShaderStage = { VERTEX: 1, FRAGMENT: 2, COMPUTE: 4 };
-
-}
-
-// statics
-
 let isAvailable = navigator.gpu !== undefined;
 
 


### PR DESCRIPTION
Related issue: -

**Description**

Since there is already a fallback in place for `GPUShaderStage` in `WGSLNodeBuilder`, it seems the fallback from `WebGPU.js` can be removed.

https://github.com/mrdoob/three.js/blob/d6c03fcec870f6c702a8b13e6d51a90b9f6d7384/src/renderers/webgpu/nodes/WGSLNodeBuilder.js#L21-L34