### PR TITLE
SceneOptimizer: Fix toBatchedMesh() Materials

### DIFF
--- a/examples/jsm/utils/SceneOptimizer.js
+++ b/examples/jsm/utils/SceneOptimizer.js
@@ -46,6 +46,7 @@ class SceneOptimizer {
 	getMaterialPropertiesHash( material ) {
 
 		const mapProps = [
+			'map',
 			'alphaMap',
 			'aoMap',
 			'bumpMap',
@@ -237,7 +238,15 @@ class SceneOptimizer {
 				0
 			);
 
-			const batchedMaterial = new THREE.MeshPhysicalMaterial( group.materialProps );
+			const batchedMaterial = new group.materialProps.constructor( group.materialProps );
+
+			if ( batchedMaterial.color !== undefined ) {
+
+				// Reset color to white, color will be set per instance
+				batchedMaterial.color.set( 1, 1, 1 );
+
+			}
+
 			const batchedMesh = new THREE.BatchedMesh(
 				maxGeometries,
 				maxVertices,


### PR DESCRIPTION
**Description**

While playing with the sceneOptimizer I noticed that it didn't check for the map property when generating the mapHash, which would cause some incompatible mesh to be batched together.

Regarding the material, they were all converted to physicalMaterial, now they use the same constructor as the original material.

And lastly, regarding the color, it was both on the initial material and per instance resulting in different color than the originals. 

*This contribution is funded by [Alaric Baraou](https://alaricbaraou.com/)💶*