### PR TITLE
Renderer: Add `hasInitialized()`.

### DIFF
--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -1309,6 +1309,12 @@ class Renderer {
 
 	}
 
+	hasInitialized() {
+
+		return this._initialized;
+
+	}
+
 	copyFramebufferToTexture( framebufferTexture, rectangle = null ) {
 
 		if ( rectangle !== null ) {


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/29922#issuecomment-2488128904

**Description**

The PR adds `hasInitialized()` to `Renderer` so developers can check if the renderer is ready for usage.