### PR TITLE
WebGPUTextureUtils: Fix `dispose()` of `VideoTexture`.

### DIFF
--- a/src/renderers/webgpu/utils/WebGPUTextureUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUTextureUtils.js
@@ -230,7 +230,7 @@ class WebGPUTextureUtils {
 		const backend = this.backend;
 		const textureData = backend.get( texture );
 
-		textureData.texture.destroy();
+		if ( textureData.texture !== undefined ) textureData.texture.destroy();
 
 		if ( textureData.msaaTexture !== undefined ) textureData.msaaTexture.destroy();
 


### PR DESCRIPTION
Fixed #29925.

**Description**

`Texture.dispose()` currently produces a runtime error with `VideoTexture` and `WebGPURenderer` since video textures are treated as external textures and thus don't have an instance of `GPUTexture`.