### PR TITLE
GLSLNodeBuilder: Fix color space regression.

### DIFF
--- a/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
+++ b/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
@@ -61,7 +61,7 @@ class GLSLNodeBuilder extends NodeBuilder {
 
 	}
 
-	needsColorSpaceToLinearSRGB( texture ) {
+	needsToWorkingColorSpace( texture ) {
 
 		return texture.isVideoTexture === true && texture.colorSpace !== NoColorSpace;
 


### PR DESCRIPTION
Related issue: #29925

**Description**

When investigating #29925, I've noticed the color space of video textures is broken with the `WebGLBackend`. Turns out #29259 introduces a minor regression by not renaming `needsColorSpaceToLinearSRGB()` to `needsToWorkingColorSpace()` in `GLSLNodeBuilder`.
