### PR TITLE
Tests: Use absolute delta value when comparing against tolerance

### DIFF
--- a/test/unit/src/cameras/PerspectiveCamera.tests.js
+++ b/test/unit/src/cameras/PerspectiveCamera.tests.js
@@ -21,7 +21,7 @@ export default QUnit.module( 'Cameras', () => {
 
 			for ( let i = 0, il = a.elements.length; i < il; i ++ ) {
 
-				const delta = a.elements[ i ] - b.elements[ i ];
+				const delta = Math.abs( a.elements[ i ] - b.elements[ i ] );
 				if ( delta > tolerance ) {
 
 					return false;

--- a/test/unit/src/core/BufferGeometry.tests.js
+++ b/test/unit/src/core/BufferGeometry.tests.js
@@ -30,7 +30,7 @@ function bufferAttributeEquals( a, b, tolerance ) {
 
 	for ( let i = 0, il = a.count * a.itemSize; i < il; i ++ ) {
 
-		const delta = a[ i ] - b[ i ];
+		const delta = Math.abs( a.array[ i ] - b.array[ i ] );
 		if ( delta > tolerance ) {
 
 			return false;
@@ -390,7 +390,7 @@ export default QUnit.module( 'Core', () => {
 			a.setAttribute( 'position', new BufferAttribute( vertices, 3 ) );
 
 			const sqrt = Math.sqrt( 2 );
-			const expected = new Float32Array( [
+			const expected = new BufferAttribute( new Float32Array( [
 				1, 0, - sqrt,
 				- 1, 0, - sqrt,
 				- 1, sqrt, 0,
@@ -398,11 +398,11 @@ export default QUnit.module( 'Core', () => {
 				- 1, sqrt, 0,
 				1, sqrt, 0,
 				1, 0, - sqrt
-			] );
+			] ), 3 );
 
 			a.lookAt( new Vector3( 0, 1, - 1 ) );
 
-			assert.ok( bufferAttributeEquals( a.attributes.position.array, expected ), 'Rotation is correct' );
+			assert.ok( bufferAttributeEquals( a.attributes.position, expected ), 'Rotation is correct' );
 
 		} );
 
@@ -568,16 +568,17 @@ export default QUnit.module( 'Core', () => {
 			const sqrt = 0.5 * Math.sqrt( 2 );
 			const normal = new BufferAttribute( new Float32Array( [
 				- 1, 0, 0, - 1, 0, 0, - 1, 0, 0,
-				sqrt, sqrt, 0, sqrt, sqrt, 0, sqrt, sqrt, 0,
-				- 1, 0, 0
+				sqrt, sqrt, 0, sqrt, sqrt, 0, sqrt, sqrt, 0
 			] ), 3 );
 			const position = new BufferAttribute( new Float32Array( [
 				0.5, 0.5, 0.5, 0.5, 0.5, - 0.5, 0.5, - 0.5, 0.5,
-				0.5, - 0.5, - 0.5, - 0.5, 0.5, - 0.5, - 0.5, 0.5, 0.5,
-				- 0.5, - 0.5, - 0.5
+				0.5, - 0.5, - 0.5, - 0.5, 0.5, - 0.5, - 0.5, 0.5, 0.5
 			] ), 3 );
+			// the index buffer defines the same two triangles but in counter-clockwise order,
+			// which should result in flipped normals.
+			const flippedNormals = normal.clone().applyMatrix4( new Matrix4().makeScale( - 1, - 1, - 1 ) );
 			const index = new BufferAttribute( new Uint16Array( [
-				0, 2, 1, 2, 3, 1, 4, 6, 5, 6, 7, 5
+				0, 2, 1, 3, 5, 4
 			] ), 1 );
 
 			let a = new BufferGeometry();
@@ -600,7 +601,7 @@ export default QUnit.module( 'Core', () => {
 			a.setAttribute( 'position', position );
 			a.setIndex( index );
 			a.computeVertexNormals();
-			assert.ok( bufferAttributeEquals( normal, a.getAttribute( 'normal' ) ), 'Indexed geometry: computed normals are correct' );
+			assert.ok( bufferAttributeEquals( flippedNormals, a.getAttribute( 'normal' ) ), 'Indexed geometry: computed normals are correct' );
 
 		} );
 

--- a/test/unit/src/math/Euler.tests.js
+++ b/test/unit/src/math/Euler.tests.js
@@ -21,7 +21,7 @@ function matrixEquals4( a, b, tolerance ) {
 
 	for ( let i = 0, il = a.elements.length; i < il; i ++ ) {
 
-		const delta = a.elements[ i ] - b.elements[ i ];
+		const delta = Math.abs( a.elements[ i ] - b.elements[ i ] );
 		if ( delta > tolerance ) {
 
 			return false;

--- a/test/unit/src/math/Matrix3.tests.js
+++ b/test/unit/src/math/Matrix3.tests.js
@@ -3,7 +3,7 @@
 import { Matrix3 } from '../../../../src/math/Matrix3.js';
 import { Matrix4 } from '../../../../src/math/Matrix4.js';
 
-function matrixEquals3( a, b, tolerance ) {
+function matrixEquals3( b, a, tolerance ) {
 
 	tolerance = tolerance || 0.0001;
 	if ( a.elements.length != b.elements.length ) {
@@ -14,7 +14,7 @@ function matrixEquals3( a, b, tolerance ) {
 
 	for ( let i = 0, il = a.elements.length; i < il; i ++ ) {
 
-		const delta = a.elements[ i ] - b.elements[ i ];
+		const delta = Math.abs( a.elements[ i ] - b.elements[ i ] );
 		if ( delta > tolerance ) {
 
 			return false;

--- a/test/unit/src/math/Matrix4.tests.js
+++ b/test/unit/src/math/Matrix4.tests.js
@@ -20,7 +20,7 @@ function matrixEquals4( a, b, tolerance ) {
 
 	for ( let i = 0, il = a.elements.length; i < il; i ++ ) {
 
-		const delta = a.elements[ i ] - b.elements[ i ];
+		const delta = Math.abs( a.elements[ i ] - b.elements[ i ] );
 		if ( delta > tolerance ) {
 
 			return false;


### PR DESCRIPTION
**Description**

Some of the equals functions in the unit tests (e.g. `matrixEquals4`) incorrectly compared signed delta values to the tolerance threshold, instead of absolute values. As a result differences where `b > a` would never "exceed" the tolerance and always pass.

Additionally the `bufferAttributeEquals` failed to actually compare the contents of the attributes. After resolving this issue, it became clear that the `computeVertexNormals (indexed)` test was broken. I tried to find out what the original intention of the test was but it seems it was introduced in a broken state in https://github.com/mrdoob/three.js/pull/12354. As such, I've taken the liberty to tweak it so that:

- There are only 6 vertices instead of 7 (ensuring non-indexed `computeVertexNormals` can actually compute all values)
- The index buffer uses the same two triangles as non-indexed, but in a counter-clockwise order, so that normals get flipped.

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Fern Solutions](https://fern.solutions/)*
