### PR TITLE
Renderer: Add `initTexture()`.

### DIFF
--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -1315,6 +1315,28 @@ class Renderer {
 
 	}
 
+	async initTextureAsync( texture ) {
+
+		if ( this._initialized === false ) await this.init();
+
+		this._textures.updateTexture( texture );
+
+	}
+
+	initTexture( texture ) {
+
+		if ( this._initialized === false ) {
+
+			console.warn( 'THREE.Renderer: .initTexture() called before the backend is initialized. Try using .initTextureAsync() instead.' );
+
+			return false;
+
+		}
+
+		this._textures.updateTexture( texture );
+
+	}
+
 	copyFramebufferToTexture( framebufferTexture, rectangle = null ) {
 
 		if ( rectangle !== null ) {


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/29898#issuecomment-2477948089

**Description**

The PR adds `initTexture()` in a snyc and async version so it is possible to avoid the texture decode overhead when textures are used in the first frame. 

I've verified the implementation with the WebGPU and WebGL backend by making sure the below texture decode metric does not appear in Chrome's performance analysis tool when rendering the first frame:

<img width="148" alt="image" src="https://github.com/user-attachments/assets/2c5a7d52-2b2d-45ce-b11f-4dbd2cbc7001">
 