### PR TITLE
PMREMGenerator: Add `fromSceneAsync()`

### DIFF
--- a/src/renderers/common/extras/PMREMGenerator.js
+++ b/src/renderers/common/extras/PMREMGenerator.js
@@ -116,6 +116,12 @@ class PMREMGenerator {
 
 	}
 
+	get hasInitialized() {
+
+		return this._renderer.hasInitialized();
+
+	}
+
 	/**
 	 * Generates a PMREM from a supplied Scene, which can be faster than using an
 	 * image if networking bandwidth is low. Optional sigma specifies a blur radius
@@ -124,6 +130,14 @@ class PMREMGenerator {
 	 * is placed at the origin).
 	 */
 	fromScene( scene, sigma = 0, near = 0.1, far = 100 ) {
+
+		if ( this.hasInitialized === false ) {
+
+			console.warn( 'THREE.PMREMGenerator: .fromScene() called before the backend is initialized. Try using .fromSceneAsync() instead.' );
+
+			return this.fromSceneAsync( scene, sigma, near, far );
+
+		}
 
 		_oldTarget = this._renderer.getRenderTarget();
 		_oldActiveCubeFace = this._renderer.getActiveCubeFace();
@@ -150,12 +164,36 @@ class PMREMGenerator {
 
 	}
 
+	async fromSceneAsync( scene, sigma = 0, near = 0.1, far = 100 ) {
+
+		if ( this.hasInitialized === false ) await this._renderer.init();
+
+		return this.fromScene( scene, sigma, near, far );
+
+	}
+
 	/**
 	 * Generates a PMREM from an equirectangular texture, which can be either LDR
 	 * or HDR. The ideal input image size is 1k (1024 x 512),
 	 * as this matches best with the 256 x 256 cubemap output.
 	 */
 	fromEquirectangular( equirectangular, renderTarget = null ) {
+
+		if ( this.hasInitialized === false ) {
+
+			console.warn( 'THREE.PMREMGenerator: .fromEquirectangular() called before the backend is initialized. Try using .fromEquirectangularAsync() instead.' );
+
+			return this.fromEquirectangularAsync( equirectangular, renderTarget );
+
+		}
+
+		return this._fromTexture( equirectangular, renderTarget );
+
+	}
+
+	async fromEquirectangularAsync( equirectangular, renderTarget = null ) {
+
+		if ( this.hasInitialized === false ) await this._renderer.init();
 
 		return this._fromTexture( equirectangular, renderTarget );
 
@@ -167,6 +205,22 @@ class PMREMGenerator {
 	 * as this matches best with the 256 x 256 cubemap output.
 	 */
 	fromCubemap( cubemap, renderTarget = null ) {
+
+		if ( this.hasInitialized === false ) {
+
+			console.warn( 'THREE.PMREMGenerator: .fromCubemap() called before the backend is initialized. Try using .fromCubemapAsync() instead.' );
+
+			return this.fromCubemapAsync( cubemap, renderTarget );
+
+		}
+
+		return this._fromTexture( cubemap, renderTarget );
+
+	}
+
+	async fromCubemapAsync( cubemap, renderTarget = null ) {
+
+		if ( this.hasInitialized === false ) await this._renderer.init();
 
 		return this._fromTexture( cubemap, renderTarget );
 

--- a/src/renderers/common/extras/PMREMGenerator.js
+++ b/src/renderers/common/extras/PMREMGenerator.js
@@ -116,7 +116,7 @@ class PMREMGenerator {
 
 	}
 
-	get hasInitialized() {
+	get _hasInitialized() {
 
 		return this._renderer.hasInitialized();
 
@@ -131,7 +131,7 @@ class PMREMGenerator {
 	 */
 	fromScene( scene, sigma = 0, near = 0.1, far = 100 ) {
 
-		if ( this.hasInitialized === false ) {
+		if ( this._hasInitialized === false ) {
 
 			console.warn( 'THREE.PMREMGenerator: .fromScene() called before the backend is initialized. Try using .fromSceneAsync() instead.' );
 
@@ -166,7 +166,7 @@ class PMREMGenerator {
 
 	async fromSceneAsync( scene, sigma = 0, near = 0.1, far = 100 ) {
 
-		if ( this.hasInitialized === false ) await this._renderer.init();
+		if ( this._hasInitialized === false ) await this._renderer.init();
 
 		return this.fromScene( scene, sigma, near, far );
 
@@ -179,7 +179,7 @@ class PMREMGenerator {
 	 */
 	fromEquirectangular( equirectangular, renderTarget = null ) {
 
-		if ( this.hasInitialized === false ) {
+		if ( this._hasInitialized === false ) {
 
 			console.warn( 'THREE.PMREMGenerator: .fromEquirectangular() called before the backend is initialized. Try using .fromEquirectangularAsync() instead.' );
 
@@ -193,7 +193,7 @@ class PMREMGenerator {
 
 	async fromEquirectangularAsync( equirectangular, renderTarget = null ) {
 
-		if ( this.hasInitialized === false ) await this._renderer.init();
+		if ( this._hasInitialized === false ) await this._renderer.init();
 
 		return this._fromTexture( equirectangular, renderTarget );
 
@@ -206,7 +206,7 @@ class PMREMGenerator {
 	 */
 	fromCubemap( cubemap, renderTarget = null ) {
 
-		if ( this.hasInitialized === false ) {
+		if ( this._hasInitialized === false ) {
 
 			console.warn( 'THREE.PMREMGenerator: .fromCubemap() called before the backend is initialized. Try using .fromCubemapAsync() instead.' );
 
@@ -220,7 +220,7 @@ class PMREMGenerator {
 
 	async fromCubemapAsync( cubemap, renderTarget = null ) {
 
-		if ( this.hasInitialized === false ) await this._renderer.init();
+		if ( this._hasInitialized === false ) await this._renderer.init();
 
 		return this._fromTexture( cubemap, renderTarget );
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/29942

**Description**

Based on the [PR](https://github.com/mrdoob/three.js/pull/29942) we can see that the `webgl_animation_keyframes` example emits a lot of error messages that may not make much sense to the user and it doesn't load the IBL properly.

![image](https://github.com/user-attachments/assets/501f2253-c506-4271-979b-dd0483dc5b5a)

This is because `PMREMGenerator` is being used without the WebGPU Backend being initialized. This PR aims to improve the error messages by guiding the user to replace functions like `pmremGenerator.fromScene()` with `pmremGenerator.fromSceneAsync()`.

After this PR.

![image](https://github.com/user-attachments/assets/726e9593-a592-43c4-a8dd-cdc8f8f4ba35)

The user can fix it using:

```js
scene.environment = ( await pmremGenerator.fromSceneAsync( new RoomEnvironment(), 0.04 ) ).texture;
```

![image](https://github.com/user-attachments/assets/082c4a6e-9fc1-4902-af82-115f201c5eba)
