### PR TITLE
Fix: prevent crash when calling BufferGeometry.setFromPoints with too few points

### DIFF
--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -306,7 +306,7 @@ class BufferGeometry extends EventDispatcher {
 
 			const l = Math.min( points.length, positionAttribute.count ); // make sure data do not exceed buffer size
 
-			for ( let i = 0 ; i < l; i ++ ) {
+			for ( let i = 0; i < l; i ++ ) {
 
 				const point = points[ i ];
 				positionAttribute.setXYZ( i, point.x, point.y, point.z || 0 );

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -304,7 +304,7 @@ class BufferGeometry extends EventDispatcher {
 
 		} else {
 
-			for ( let i = 0, l = Math.min(positionAttribute.count, points.length); i < l; i ++ ) {
+			for ( let i = 0, l = Math.min( positionAttribute.count, points.length ); i < l; i ++ ) {
 
 				const point = points[ i ];
 				positionAttribute.setXYZ( i, point.x, point.y, point.z || 0 );

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -304,7 +304,7 @@ class BufferGeometry extends EventDispatcher {
 
 		} else {
 
-			for ( let i = 0, l = positionAttribute.count; i < l; i ++ ) {
+			for ( let i = 0, l = Math.min(positionAttribute.count, points.length); i < l; i ++ ) {
 
 				const point = points[ i ];
 				positionAttribute.setXYZ( i, point.x, point.y, point.z || 0 );

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -304,7 +304,9 @@ class BufferGeometry extends EventDispatcher {
 
 		} else {
 
-			for ( let i = 0, l = Math.min( positionAttribute.count, points.length ); i < l; i ++ ) {
+			const l = Math.min( points.length, positionAttribute.count ); // make sure data do not exceed buffer size
+
+			for ( let i = 0 ; i < l; i ++ ) {
 
 				const point = points[ i ];
 				positionAttribute.setXYZ( i, point.x, point.y, point.z || 0 );


### PR DESCRIPTION
**Description**

https://github.com/mrdoob/three.js/pull/29696 introduced a crash condition where calling `BufferGeometry.setFromPoints` would cause a crash like `three.module.js:10894 Uncaught TypeError: Cannot read properties of undefined (reading 'x')` if trying to set fewer points than is in the `position` attribute.