### PR TITLE
TSL: `convertToTexture()` - return `pass()` texture if available

### DIFF
--- a/src/nodes/utils/RTTNode.js
+++ b/src/nodes/utils/RTTNode.js
@@ -130,4 +130,12 @@ class RTTNode extends TextureNode {
 export default RTTNode;
 
 export const rtt = ( node, ...params ) => nodeObject( new RTTNode( nodeObject( node ), ...params ) );
-export const convertToTexture = ( node, ...params ) => node.isTextureNode ? node : rtt( node, ...params );
+
+export const convertToTexture = ( node, ...params ) => {
+
+	if ( node.isTextureNode ) return node;
+	if ( node.isPassNode ) return node.getTextureNode();
+
+	return rtt( node, ...params );
+
+};


### PR DESCRIPTION
Related issue: Closes https://github.com/mrdoob/three.js/issues/29851

**Description**

Returns the texture automatically if the input is a `pass()`.