### PR TITLE
PMREMGenerator: Add optional `renderTarget` in `fromScene()`

### DIFF
--- a/src/renderers/common/extras/PMREMGenerator.js
+++ b/src/renderers/common/extras/PMREMGenerator.js
@@ -187,6 +187,8 @@ class PMREMGenerator {
 
 			console.warn( 'THREE.PMREMGenerator: .fromEquirectangular() called before the backend is initialized. Try using .fromEquirectangularAsync() instead.' );
 
+			this._setSizeFromTexture( equirectangular );
+
 			const cubeUVRenderTarget = renderTarget || this._allocateTargets();
 
 			this.fromEquirectangularAsync( equirectangular, cubeUVRenderTarget );
@@ -217,6 +219,8 @@ class PMREMGenerator {
 		if ( this._hasInitialized === false ) {
 
 			console.warn( 'THREE.PMREMGenerator: .fromCubemap() called before the backend is initialized. Try using .fromCubemapAsync() instead.' );
+
+			this._setSizeFromTexture( cubemap );
 
 			const cubeUVRenderTarget = renderTarget || this._allocateTargets();
 
@@ -289,6 +293,20 @@ class PMREMGenerator {
 	}
 
 	// private interface
+
+	_setSizeFromTexture( texture ) {
+
+		if ( texture.mapping === CubeReflectionMapping || texture.mapping === CubeRefractionMapping ) {
+
+			this._setSize( texture.image.length === 0 ? 16 : ( texture.image[ 0 ].width || texture.image[ 0 ].image.width ) );
+
+		} else { // Equirectangular
+
+			this._setSize( texture.image.width / 4 );
+
+		}
+
+	}
 
 	_setSize( cubeSize ) {
 

--- a/src/renderers/common/extras/PMREMGenerator.js
+++ b/src/renderers/common/extras/PMREMGenerator.js
@@ -339,15 +339,7 @@ class PMREMGenerator {
 
 	_fromTexture( texture, renderTarget ) {
 
-		if ( texture.mapping === CubeReflectionMapping || texture.mapping === CubeRefractionMapping ) {
-
-			this._setSize( texture.image.length === 0 ? 16 : ( texture.image[ 0 ].width || texture.image[ 0 ].image.width ) );
-
-		} else { // Equirectangular
-
-			this._setSize( texture.image.width / 4 );
-
-		}
+		this._setSizeFromTexture( texture );
 
 		_oldTarget = this._renderer.getRenderTarget();
 		_oldActiveCubeFace = this._renderer.getActiveCubeFace();

--- a/src/renderers/common/extras/PMREMGenerator.js
+++ b/src/renderers/common/extras/PMREMGenerator.js
@@ -131,7 +131,7 @@ class PMREMGenerator {
 	 */
 	fromScene( scene, sigma = 0, near = 0.1, far = 100, renderTarget = null ) {
 
-		this._setSize( 256 ); // @TODO: calculate the cube size from optional renderTarget
+		this._setSize( 256 );
 
 		if ( this._hasInitialized === false ) {
 

--- a/src/renderers/common/extras/PMREMGenerator.js
+++ b/src/renderers/common/extras/PMREMGenerator.js
@@ -129,13 +129,19 @@ class PMREMGenerator {
 	 * and far planes ensure the scene is rendered in its entirety (the cubeCamera
 	 * is placed at the origin).
 	 */
-	fromScene( scene, sigma = 0, near = 0.1, far = 100 ) {
+	fromScene( scene, sigma = 0, near = 0.1, far = 100, renderTarget = null ) {
+
+		this._setSize( 256 ); // @TODO: calculate the cube size from optional renderTarget
 
 		if ( this._hasInitialized === false ) {
 
 			console.warn( 'THREE.PMREMGenerator: .fromScene() called before the backend is initialized. Try using .fromSceneAsync() instead.' );
 
-			return this.fromSceneAsync( scene, sigma, near, far );
+			const cubeUVRenderTarget = renderTarget || this._allocateTargets();
+
+			this.fromSceneAsync( scene, sigma, near, far, cubeUVRenderTarget );
+
+			return cubeUVRenderTarget;
 
 		}
 
@@ -143,9 +149,7 @@ class PMREMGenerator {
 		_oldActiveCubeFace = this._renderer.getActiveCubeFace();
 		_oldActiveMipmapLevel = this._renderer.getActiveMipmapLevel();
 
-		this._setSize( 256 );
-
-		const cubeUVRenderTarget = this._allocateTargets();
+		const cubeUVRenderTarget = renderTarget || this._allocateTargets();
 		cubeUVRenderTarget.depthBuffer = true;
 
 		this._sceneToCubeUV( scene, near, far, cubeUVRenderTarget );
@@ -164,11 +168,11 @@ class PMREMGenerator {
 
 	}
 
-	async fromSceneAsync( scene, sigma = 0, near = 0.1, far = 100 ) {
+	async fromSceneAsync( scene, sigma = 0, near = 0.1, far = 100, renderTarget = null ) {
 
 		if ( this._hasInitialized === false ) await this._renderer.init();
 
-		return this.fromScene( scene, sigma, near, far );
+		return this.fromScene( scene, sigma, near, far, renderTarget );
 
 	}
 
@@ -183,7 +187,11 @@ class PMREMGenerator {
 
 			console.warn( 'THREE.PMREMGenerator: .fromEquirectangular() called before the backend is initialized. Try using .fromEquirectangularAsync() instead.' );
 
-			return this.fromEquirectangularAsync( equirectangular, renderTarget );
+			const cubeUVRenderTarget = renderTarget || this._allocateTargets();
+
+			this.fromEquirectangularAsync( equirectangular, cubeUVRenderTarget );
+
+			return cubeUVRenderTarget;
 
 		}
 
@@ -210,7 +218,11 @@ class PMREMGenerator {
 
 			console.warn( 'THREE.PMREMGenerator: .fromCubemap() called before the backend is initialized. Try using .fromCubemapAsync() instead.' );
 
-			return this.fromCubemapAsync( cubemap, renderTarget );
+			const cubeUVRenderTarget = renderTarget || this._allocateTargets();
+
+			this.fromCubemapAsync( cubemap, renderTarget );
+
+			return cubeUVRenderTarget;
 
 		}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/29951, https://github.com/mrdoob/three.js/pull/29942

**Description**

This PR improves backwards compatibility, even if the device is not initialized it returns the texture it will later use to generate the PMREM but keep the warnings.

- [x] Add optional `renderTarget` in `fromScene()`
- [x] Return the `RenderTarget` if asynchronous calls necessary instead of `Promise`.

![image](https://github.com/user-attachments/assets/28dfbdb4-9145-4659-9796-e571beed7c7a)