### PR TITLE
Audio: Override copy and clone methods to include missing properties

### DIFF
--- a/src/audio/Audio.js
+++ b/src/audio/Audio.js
@@ -412,6 +412,8 @@ class Audio extends Object3D {
 		this.playbackRate = source.playbackRate;
 		this.hasPlaybackControl = source.hasPlaybackControl;
 
+		this.filters = source.filters.slice();
+
 		if ( source.sourceType !== 'buffer' ) {
 
 			console.warn( 'THREE.Audio: Audio source type cannot be copied.' );

--- a/src/audio/Audio.js
+++ b/src/audio/Audio.js
@@ -396,6 +396,42 @@ class Audio extends Object3D {
 
 	}
 
+	copy( source, recursive ) {
+
+		super.copy( source, recursive );
+
+		this.autoplay = source.autoplay;
+
+		this.buffer = source.buffer;
+		this.detune = source.detune;
+		this.loop = source.loop;
+		this.loopStart = source.loopStart;
+		this.loopEnd = source.loopEnd;
+		this.offset = source.offset;
+		this.duration = source.duration;
+		this.playbackRate = source.playbackRate;
+		this.hasPlaybackControl = source.hasPlaybackControl;
+
+		if ( source.sourceType !== 'buffer' ) {
+
+			console.warn( 'THREE.Audio: Audio source type cannot be copied.' );
+
+			return this;
+
+		}
+
+		this.sourceType = source.sourceType;
+
+		return this;
+
+	}
+
+	clone( recursive ) {
+
+		return new this.constructor( this.listener ).copy( this, recursive );
+
+	}
+
 }
 
 export { Audio };


### PR DESCRIPTION
This PR addresses issues with the `Audio` class's `clone` and `copy` methods.

**Description**

The `Object3D`'s `clone` method, inherited by `Audio`, creates a new instance without passing additional parameters. This causes errors when cloning an `Audio` object, as the `listener` is mandatory for its creation.

**Proposed Solution**
The `clone` method has been overridden to align with the expected behavior: reusing the existing `listener` when creating a new `Audio` instance.

The `copy` method has been overridden to correctly handle properties specific to the `Audio` class, ensuring all relevant data is properly transferred.

**Exception Handling for `sourceType`**
* `'buffer'`:  
  The `play` method regenerates the `source` internally using `context.createBufferSource`.
*  `'audioNode'`, `'mediaNode'`, or `'mediaStreamNode'`:    
  These source types are single-use and cannot be reused across multiple connections. A warning is logged, and these sources are excluded from the copy process to prevent misuse.

**Demo of the feature with buffer souce**  
before  
<video src="https://github.com/user-attachments/assets/6328f09f-92ec-48d9-a8a1-cee83549b2c9" />

after  
<video src="https://github.com/user-attachments/assets/415f841d-4bcb-414c-bcfd-541d6c55ccc9" />




