### PR TITLE
WebGPU: Fix `navigator` usage.

### DIFF
--- a/examples/jsm/capabilities/WebGPU.js
+++ b/examples/jsm/capabilities/WebGPU.js
@@ -1,5 +1,4 @@
-let isAvailable = navigator.gpu !== undefined;
-
+let isAvailable = ( typeof navigator !== 'undefined'  && navigator.gpu !== undefined );
 
 if ( typeof window !== 'undefined' && isAvailable ) {
 


### PR DESCRIPTION
Related issue: see https://github.com/mrdoob/three.js/pull/29919#issuecomment-2498323719

**Description**

The PR fixes the top-level usage of `navigator` as suggested in #29919.