### PR TITLE
WebGPUAttributeUtils: fix updateAttribute() when using range (#29966)

### DIFF
--- a/src/renderers/webgpu/utils/WebGPUAttributeUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUAttributeUtils.js
@@ -130,8 +130,8 @@ class WebGPUAttributeUtils {
 					buffer,
 					0,
 					array,
-					range.start * array.BYTES_PER_ELEMENT,
-					range.count * array.BYTES_PER_ELEMENT
+					range.start,
+					range.count
 				);
 
 			}

--- a/src/renderers/webgpu/utils/WebGPUAttributeUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUAttributeUtils.js
@@ -108,6 +108,7 @@ class WebGPUAttributeUtils {
 		const buffer = backend.get( bufferAttribute ).buffer;
 
 		const array = bufferAttribute.array;
+		const isTypedArray = this._isTypedArray( array );
 		const updateRanges = bufferAttribute.updateRanges;
 
 		if ( updateRanges.length === 0 ) {
@@ -123,15 +124,21 @@ class WebGPUAttributeUtils {
 
 		} else {
 
+			const byteOffsetFactor = isTypedArray ? 1 : array.BYTES_PER_ELEMENT;
+
 			for ( let i = 0, l = updateRanges.length; i < l; i ++ ) {
 
 				const range = updateRanges[ i ];
+
+				const dataOffset = range.start * byteOffsetFactor;
+				const size = range.count * byteOffsetFactor;
+
 				device.queue.writeBuffer(
 					buffer,
 					0,
 					array,
-					range.start,
-					range.count
+					dataOffset,
+					size
 				);
 
 			}
@@ -296,6 +303,12 @@ class WebGPUAttributeUtils {
 		}
 
 		return format;
+
+	}
+
+	_isTypedArray( array ) {
+
+		return ArrayBuffer.isView( array ) && ! ( array instanceof DataView );
 
 	}
 


### PR DESCRIPTION
Related issue: #29966

**Description**

When using updateAttribute() with a range, the range start and count were wrongfully multiplied by array.BYTES_PER_ELEMENT before calling writeBuffer(), even though the writeBuffer() function expects the range start and count as number of typed array elements, not as bytes.