### PR TITLE
WebGPUBackend: Simplify Timestamp Queries and Ensure Work Done

### DIFF
--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -1239,12 +1239,9 @@ class WebGPUBackend extends Backend {
 
 		const renderContextData = this.get( renderContext );
 
-
 		if ( renderContextData.currentTimestampQueryBuffers === undefined ) return;
 
 		const { resultBuffer } = renderContextData.currentTimestampQueryBuffers;
-
-
 
 		await this.device.queue.onSubmittedWorkDone();
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/29857 #29940

**Description**

This PR removes the patch introduced in [#29857](https://github.com/mrdoob/three.js/pull/29857), as the underlying issue is specific to WebGPU and will be resolved through [gpuweb/gpuweb#4941](https://github.com/gpuweb/gpuweb/pull/4941).

The logic has been streamlined by leveraging mapState and ensuring all pending work is completed using `await this.device.queue.onSubmittedWorkDone(); `(seems to be necessary as compute shading resolves too quickly).

*This contribution is funded by [Utsubo](https://utsubo.com)*