### PR TITLE
NodeMaterial: Fix `getAlphaHashThreshold()` properties conflict

### DIFF
--- a/src/nodes/functions/material/getAlphaHashThreshold.js
+++ b/src/nodes/functions/material/getAlphaHashThreshold.js
@@ -24,7 +24,7 @@ const getAlphaHashThreshold = /*@__PURE__*/ Fn( ( [ position ] ) => {
 	const maxDeriv = max(
 		length( dFdx( position.xyz ) ),
 		length( dFdy( position.xyz ) )
-	).toVar( 'maxDeriv' );
+	);
 
 	const pixScale = float( 1 ).div( float( ALPHA_HASH_SCALE ).mul( maxDeriv ) ).toVar( 'pixScale' );
 
@@ -32,13 +32,13 @@ const getAlphaHashThreshold = /*@__PURE__*/ Fn( ( [ position ] ) => {
 	const pixScales = vec2(
 		exp2( floor( log2( pixScale ) ) ),
 		exp2( ceil( log2( pixScale ) ) )
-	).toVar( 'pixScales' );
+	);
 
 	// Compute alpha thresholds at our two noise scales
 	const alpha = vec2(
 		hash3D( floor( pixScales.x.mul( position.xyz ) ) ),
 		hash3D( floor( pixScales.y.mul( position.xyz ) ) ),
-	).toVar( 'alpha' );
+	);
 
 	// Factor to interpolate lerp with
 	const lerpFactor = fract( log2( pixScale ) ).toVar( 'lerpFactor' );
@@ -59,6 +59,12 @@ const getAlphaHashThreshold = /*@__PURE__*/ Fn( ( [ position ] ) => {
 	// Avoids ατ == 0. Could also do ατ =1-ατ
 	return clamp( threshold, 1.0e-6, 1.0 );
 
+} ).setLayout( {
+	name: 'getAlphaHashThreshold',
+	type: 'float',
+	inputs: [
+		{ name: 'position', type: 'vec3' }
+	]
 } );
 
 export default getAlphaHashThreshold;

--- a/src/nodes/functions/material/getAlphaHashThreshold.js
+++ b/src/nodes/functions/material/getAlphaHashThreshold.js
@@ -41,17 +41,17 @@ const getAlphaHashThreshold = /*@__PURE__*/ Fn( ( [ position ] ) => {
 	);
 
 	// Factor to interpolate lerp with
-	const lerpFactor = fract( log2( pixScale ) ).toVar( 'lerpFactor' );
+	const lerpFactor = fract( log2( pixScale ) );
 
 	// Interpolate alpha threshold from noise at two scales
-	const x = add( mul( lerpFactor.oneMinus(), alpha.x ), mul( lerpFactor, alpha.y ) ).toVar( 'x' );
+	const x = add( mul( lerpFactor.oneMinus(), alpha.x ), mul( lerpFactor, alpha.y ) );
 
 	// Pass into CDF to compute uniformly distrib threshold
-	const a = min( lerpFactor, lerpFactor.oneMinus() ).toVar( 'a' );
+	const a = min( lerpFactor, lerpFactor.oneMinus() );
 	const cases = vec3(
 		x.mul( x ).div( mul( 2.0, a ).mul( sub( 1.0, a ) ) ),
 		x.sub( mul( 0.5, a ) ).div( sub( 1.0, a ) ),
-		sub( 1.0, sub( 1.0, x ).mul( sub( 1.0, x ) ).div( mul( 2.0, a ).mul( sub( 1.0, a ) ) ) ) ).toVar( 'cases' );
+		sub( 1.0, sub( 1.0, x ).mul( sub( 1.0, x ) ).div( mul( 2.0, a ).mul( sub( 1.0, a ) ) ) ) );
 
 	// Find our final, uniformly distributed alpha threshold (ατ)
 	const threshold = x.lessThan( a.oneMinus() ).select( x.lessThan( a ).select( cases.x, cases.y ), cases.z );


### PR DESCRIPTION
**Description**

Remove variable conflicts for now until we create an auto-naming system.