### PR TITLE
Manual: Fix `OrbitControls` usage in Offscreen Canvas demo.

### DIFF
--- a/manual/en/offscreencanvas.html
+++ b/manual/en/offscreencanvas.html
@@ -815,6 +815,7 @@ they make. That function will add the correct id and send it to the worker.</p>
   'pointerType',
   'clientX',
   'clientY',
+  'pointerId',
   'pageX',
   'pageY',
 ]);
@@ -853,6 +854,10 @@ function makeSendPropertiesHandler(properties) {
 }
 
 function touchEventHandler(event, sendFn) {
+  // preventDefault() fixes mousemove, mouseup and mousedown 
+  // firing when doing a simple touchup touchdown
+  // Happens only at offscreen canvas
+  event.preventDefault(); 
   const touches = [];
   const data = {type: event.type, touches};
   for (let i = 0; i &lt; event.touches.length; ++i) {
@@ -860,6 +865,8 @@ function touchEventHandler(event, sendFn) {
     touches.push({
       pageX: touch.pageX,
       pageY: touch.pageY,
+      clientX: touch.clientX,
+      clientY: touch.clientY,
     });
   }
   sendFn(data);

--- a/manual/examples/offscreencanvas-w-orbitcontrols.html
+++ b/manual/examples/offscreencanvas-w-orbitcontrols.html
@@ -87,7 +87,7 @@ function makeSendPropertiesHandler( properties ) {
 function touchEventHandler( event, sendFn ) {
 	
 	// preventDefault() fixes mousemove, mouseup and mousedown 
-	//	firing at touch events when doing a simple touchup touchdown
+	// firing at touch events when doing a simple touchup touchdown
 	// Happens only at offscreen canvas
 	event.preventDefault(); 
 	const touches = [];

--- a/manual/examples/offscreencanvas-w-orbitcontrols.html
+++ b/manual/examples/offscreencanvas-w-orbitcontrols.html
@@ -34,6 +34,7 @@ const mouseEventHandler = makeSendPropertiesHandler( [
 	'pointerType',
 	'clientX',
 	'clientY',
+	'pointerId',
 	'pageX',
 	'pageY',
 ] );
@@ -84,7 +85,11 @@ function makeSendPropertiesHandler( properties ) {
 }
 
 function touchEventHandler( event, sendFn ) {
-
+	
+	// preventDefault() fixes mousemove, mouseup and mousedown 
+	//	firing at touch events when doing a simple touchup touchdown
+	// Happens only at offscreen canvas
+	event.preventDefault(); 
 	const touches = [];
 	const data = { type: event.type, touches };
 	for ( let i = 0; i < event.touches.length; ++ i ) {
@@ -93,6 +98,8 @@ function touchEventHandler( event, sendFn ) {
 		touches.push( {
 			pageX: touch.pageX,
 			pageY: touch.pageY,
+			clientX: touch.clientX,
+			clientY: touch.clientY,
 		} );
 
 	}

--- a/manual/ja/offscreencanvas.html
+++ b/manual/ja/offscreencanvas.html
@@ -767,6 +767,7 @@ Worker„ÅØ <code class="notranslate" translate="no">ElementProxyReceiver</code> „
   'pointerType',
   'clientX',
   'clientY',
+  'pointerId',
   'pageX',
   'pageY',
 ]);
@@ -805,6 +806,10 @@ function makeSendPropertiesHandler(properties) {
 }
 
 function touchEventHandler(event, sendFn) {
+  // preventDefault() fixes mousemove, mouseup and mousedown 
+  // firing when doing a simple touchup touchdown
+  // Happens only at offscreen canvas
+  event.preventDefault(); 
   const touches = [];
   const data = {type: event.type, touches};
   for (let i = 0; i &lt; event.touches.length; ++i) {
@@ -812,6 +817,8 @@ function touchEventHandler(event, sendFn) {
     touches.push({
       pageX: touch.pageX,
       pageY: touch.pageY,
+      clientX: touch.clientX,
+      clientY: touch.clientY,
     });
   }
   sendFn(data);

--- a/manual/ko/offscreencanvas.html
+++ b/manual/ko/offscreencanvas.html
@@ -717,6 +717,7 @@ class ElementProxy {
   'pointerType',
   'clientX',
   'clientY',
+  'pointerId',
   'pageX',
   'pageY',
 ]);
@@ -755,6 +756,10 @@ function makeSendPropertiesHandler(properties) {
 }
 
 function touchEventHandler(event, sendFn) {
+  // preventDefault() fixes mousemove, mouseup and mousedown 
+  // firing when doing a simple touchup touchdown
+  // Happens only at offscreen canvas
+  event.preventDefault(); 
   const touches = [];
   const data = { type: event.type, touches };
   for (let i = 0; i &lt; event.touches.length; ++i) {
@@ -762,6 +767,8 @@ function touchEventHandler(event, sendFn) {
     touches.push({
       pageX: touch.pageX,
       pageY: touch.pageY,
+      clientX: touch.clientX,
+      clientY: touch.clientY,
     });
   }
   sendFn(data);

--- a/manual/ru/offscreencanvas.html
+++ b/manual/ru/offscreencanvas.html
@@ -748,6 +748,7 @@ class ElementProxy {
   'pointerType',
   'clientX',
   'clientY',
+  'pointerId',
   'pageX',
   'pageY',
 ]);
@@ -786,6 +787,10 @@ function makeSendPropertiesHandler(properties) {
 }
 
 function touchEventHandler(event, sendFn) {
+  // preventDefault() fixes mousemove, mouseup and mousedown 
+  // firing when doing a simple touchup touchdown
+  // Happens only at offscreen canvas
+  event.preventDefault(); 
   const touches = [];
   const data = {type: event.type, touches};
   for (let i = 0; i &lt; event.touches.length; ++i) {
@@ -793,6 +798,8 @@ function touchEventHandler(event, sendFn) {
     touches.push({
       pageX: touch.pageX,
       pageY: touch.pageY,
+      clientX: touch.clientX,
+      clientY: touch.clientY,
     });
   }
   sendFn(data);


### PR DESCRIPTION
- Picking doesn't work properly (sometimes at all) in touchscreens due to the lack of `clientX` and `clientY` values in the proxy event. Added those.

- Added a `event.preventDefault()` in `touchEventHandler()` because, for some unknown reason, mouse events get fired in touchscreens when doing a simple tap. Happens only at Offscreen Canvas. Tested on Chrome for Android and Firefox for Android. Same behavior both. Might be intended per specification? This is the best fix I found to handle it.

- 2 or more fingers don't get fully handled in OrbitControls, resulting in a black screen when trying to pinch-to-zoom, among other scenarios. It expects a `pointerId` with our custom Pointer Event proxy. To be specific, it gets called here: 

https://github.com/mrdoob/three.js/blob/beab9e845f9e5ae11d648f55b24a0e910b56a85a/examples/jsm/controls/OrbitControls.js#L1069-L1077

Fixed that as well :)

Also, wanted to express how good it is to have a fully working example of Offscreen Canvas + OrbitControls. I've learned so much about workers and code structuring with it. Offscreen Canvas are desperately needed in a website I maintain to keep a javascript horizontal slider to move smoothly while loading and presenting a 3D object. Without this example, I don't think I would have been able to do it.

Thank you so much!

