### PR TITLE
Fix: webgl_renderer_pathtracer requiring lines

### DIFF
--- a/examples/webgl_renderer_pathtracer.html
+++ b/examples/webgl_renderer_pathtracer.html
@@ -156,7 +156,7 @@
 				// only smooth when not rendering with flat colors to improve processing time
 				const ldrawPromise =
 					new LDrawLoader()
-						.setConditionalLineMaterial(LDrawConditionalLineMaterial)
+						.setConditionalLineMaterial( LDrawConditionalLineMaterial )
 						.setPath( 'models/ldraw/officialLibrary/' )
 						.loadAsync( 'models/7140-1-X-wingFighter.mpd_Packed.mpd', onProgress )
 						.then( function ( legoGroup ) {

--- a/examples/webgl_renderer_pathtracer.html
+++ b/examples/webgl_renderer_pathtracer.html
@@ -60,7 +60,7 @@
 			import { RGBELoader } from 'three/addons/loaders/RGBELoader.js';
 			import { LDrawLoader } from 'three/addons/loaders/LDrawLoader.js';
 			import { LDrawUtils } from 'three/addons/utils/LDrawUtils.js';
-
+			import { LDrawConditionalLineMaterial } from 'three/addons/materials/LDrawConditionalLineMaterial.js';
 			import { WebGLPathTracer, BlurredEnvMapGenerator, GradientEquirectTexture } from 'three-gpu-pathtracer';
 
 			let progressBarDiv, samplesEl;
@@ -156,6 +156,7 @@
 				// only smooth when not rendering with flat colors to improve processing time
 				const ldrawPromise =
 					new LDrawLoader()
+						.setConditionalLineMaterial(LDrawConditionalLineMaterial)
 						.setPath( 'models/ldraw/officialLibrary/' )
 						.loadAsync( 'models/7140-1-X-wingFighter.mpd_Packed.mpd', onProgress )
 						.then( function ( legoGroup ) {


### PR DESCRIPTION
Related issue: Didn't file an issue.

The example for path tracing errors out with the LDrawLoader requiring the conditional line material.

This just imports the material and adds it into the loader for use.
