### PR TITLE
WebGPURenderer: Add Video and Storage 2D Texture textureLoad Support

### DIFF
--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -355,7 +355,11 @@ class WGSLNodeBuilder extends NodeBuilder {
 
 	generateTextureLoad( texture, textureProperty, uvIndexSnippet, depthSnippet, levelSnippet = '0u' ) {
 
-		if ( depthSnippet ) {
+		if ( texture.isVideoTexture === true || texture.isStorageTexture === true ) {
+
+			return `textureLoad( ${ textureProperty }, ${ uvIndexSnippet } )`;
+
+		} else if ( depthSnippet ) {
 
 			return `textureLoad( ${ textureProperty }, ${ uvIndexSnippet }, ${ depthSnippet }, u32( ${ levelSnippet } ) )`;
 


### PR DESCRIPTION
**Description**
https://www.w3.org/TR/webgpu/#external-texture-sampling
> External textures are represented in WGSL with texture_external and may be read using textureLoad and textureSampleBaseClampToEdge.

https://www.w3.org/TR/WGSL/#textureload
<img width="810" alt="image" src="https://github.com/user-attachments/assets/647f6c41-015f-4bb0-a035-0174806d08f6">

This PR adds support to read a single texel from a video or storage texture in the vertex and compute shading.


*This contribution is funded by [Utsubo](https://utsubo.com)*
