### PR TITLE
WebGPURenderer: Add Missing Export `NodeAccess`

### DIFF
--- a/examples/webgpu_compute_texture_pingpong.html
+++ b/examples/webgpu_compute_texture_pingpong.html
@@ -25,7 +25,7 @@
 		<script type="module">
 
 			import * as THREE from 'three';
-			import { storageTexture, wgslFn, code, instanceIndex, uniform, NodeAccess } from 'three/tsl';
+			import { storageTexture, wgslFn, code, instanceIndex, uniform } from 'three/tsl';
 
 			import WebGPU from 'three/addons/capabilities/WebGPU.js';
 
@@ -73,10 +73,10 @@
 
 				const wgslFormat = hdr ? 'rgba16float' : 'rgba8unorm';
 			
-				const readPing = storageTexture( pingTexture ).setAccess( NodeAccess.READ_ONLY );
-				const writePing = storageTexture( pingTexture ).setAccess( NodeAccess.WRITE_ONLY );
-				const readPong = storageTexture( pongTexture ).setAccess( NodeAccess.READ_ONLY );
-				const writePong = storageTexture( pongTexture ).setAccess( NodeAccess.WRITE_ONLY );
+				const readPing = storageTexture( pingTexture ).toReadOnly();
+				const writePing = storageTexture( pingTexture ).toWriteOnly();
+				const readPong = storageTexture( pongTexture ).toReadOnly();
+				const writePong = storageTexture( pongTexture ).toWriteOnly();
 
 				// compute init
 

--- a/examples/webgpu_compute_texture_pingpong.html
+++ b/examples/webgpu_compute_texture_pingpong.html
@@ -25,7 +25,7 @@
 		<script type="module">
 
 			import * as THREE from 'three';
-			import { storageTexture, wgslFn, code, instanceIndex, uniform } from 'three/tsl';
+			import { storageTexture, wgslFn, code, instanceIndex, uniform, NodeAccess } from 'three/tsl';
 
 			import WebGPU from 'three/addons/capabilities/WebGPU.js';
 
@@ -73,10 +73,10 @@
 
 				const wgslFormat = hdr ? 'rgba16float' : 'rgba8unorm';
 			
-				const readPing = storageTexture( pingTexture ).toReadOnly();
-				const writePing = storageTexture( pingTexture ).toWriteOnly();
-				const readPong = storageTexture( pongTexture ).toReadOnly();
-				const writePong = storageTexture( pongTexture ).toWriteOnly();
+				const readPing = storageTexture( pingTexture ).setAccess( NodeAccess.READ_ONLY );
+				const writePing = storageTexture( pingTexture ).setAccess( NodeAccess.WRITE_ONLY );
+				const readPong = storageTexture( pongTexture ).setAccess( NodeAccess.READ_ONLY );
+				const writePong = storageTexture( pongTexture ).setAccess( NodeAccess.WRITE_ONLY );
 
 				// compute init
 

--- a/src/Three.TSL.js
+++ b/src/Three.TSL.js
@@ -17,6 +17,7 @@ export const Loop = TSL.Loop;
 export const NodeShaderStage = TSL.NodeShaderStage;
 export const NodeType = TSL.NodeType;
 export const NodeUpdateType = TSL.NodeUpdateType;
+export const NodeAccess = TSL.NodeAccess;
 export const PCFShadowFilter = TSL.PCFShadowFilter;
 export const PCFSoftShadowFilter = TSL.PCFSoftShadowFilter;
 export const PI = TSL.PI;


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/29881

**Description**
Missing export was breaking the example `webgpu_compute_texture_pingpong.html`.

*This contribution is funded by [Utsubo](https://utsubo.com)*
