### PR TITLE
LineSegments2: Fix `raycast()` .

### DIFF
--- a/examples/jsm/lines/webgpu/LineSegments2.js
+++ b/examples/jsm/lines/webgpu/LineSegments2.js
@@ -93,7 +93,6 @@ function raycastWorldUnits( lineSegments, intersects ) {
 function raycastScreenSpace( lineSegments, camera, intersects ) {
 
 	const projectionMatrix = camera.projectionMatrix;
-	const material = lineSegments.material;
 	const resolution = lineSegments.resolution;
 	const matrixWorld = lineSegments.matrixWorld;
 

--- a/examples/jsm/lines/webgpu/LineSegments2.js
+++ b/examples/jsm/lines/webgpu/LineSegments2.js
@@ -29,6 +29,7 @@ const _closestPoint = new Vector3();
 const _box = new Box3();
 const _sphere = new Sphere();
 const _clipToWorldVector = new Vector4();
+const _viewport = new Vector4();
 
 let _ray, _lineWidth;
 
@@ -232,7 +233,7 @@ class LineSegments2 extends Mesh {
 
 		this.type = 'LineSegments2';
 
-		this.resolution = new Vector2()
+		this.resolution = new Vector2();
 
 	}
 
@@ -267,7 +268,9 @@ class LineSegments2 extends Mesh {
 
 	onBeforeRender( renderer ) {
 
-		renderer.getViewport( this.resolution );
+		renderer.getViewport( _viewport );
+		this.resolution.set( _viewport.z, _viewport.w );
+
 	}
 
 	raycast( raycaster, intersects ) {

--- a/examples/jsm/lines/webgpu/LineSegments2.js
+++ b/examples/jsm/lines/webgpu/LineSegments2.js
@@ -9,9 +9,9 @@ import {
 	Sphere,
 	Vector3,
 	Vector4,
-	Line2NodeMaterial
+	Line2NodeMaterial,
+	Vector2
 } from 'three/webgpu';
-
 import { LineSegmentsGeometry } from '../../lines/LineSegmentsGeometry.js';
 
 const _start = new Vector3();
@@ -94,7 +94,7 @@ function raycastScreenSpace( lineSegments, camera, intersects ) {
 
 	const projectionMatrix = camera.projectionMatrix;
 	const material = lineSegments.material;
-	const resolution = material.resolution;
+	const resolution = lineSegments.resolution;
 	const matrixWorld = lineSegments.matrixWorld;
 
 	const geometry = lineSegments.geometry;
@@ -233,6 +233,8 @@ class LineSegments2 extends Mesh {
 
 		this.type = 'LineSegments2';
 
+		this.resolution = new Vector2()
+
 	}
 
 	// for backwards-compatibility, but could be a method of LineSegmentsGeometry...
@@ -262,6 +264,11 @@ class LineSegments2 extends Mesh {
 
 		return this;
 
+	}
+
+	onBeforeRender( renderer ) {
+
+		renderer.getViewport( this.resolution );
 	}
 
 	raycast( raycaster, intersects ) {
@@ -303,7 +310,7 @@ class LineSegments2 extends Mesh {
 		} else {
 
 			const distanceToSphere = Math.max( camera.near, _sphere.distanceToPoint( _ray.origin ) );
-			sphereMargin = getWorldSpaceHalfWidth( camera, distanceToSphere, material.resolution );
+			sphereMargin = getWorldSpaceHalfWidth( camera, distanceToSphere, this.resolution );
 
 		}
 
@@ -333,7 +340,7 @@ class LineSegments2 extends Mesh {
 		} else {
 
 			const distanceToBox = Math.max( camera.near, _box.distanceToPoint( _ray.origin ) );
-			boxMargin = getWorldSpaceHalfWidth( camera, distanceToBox, material.resolution );
+			boxMargin = getWorldSpaceHalfWidth( camera, distanceToBox, this.resolution );
 
 		}
 


### PR DESCRIPTION
Fixed https://github.com/mrdoob/three.js/issues/29986


**Description**

Fixed raycasting for the LineSegments2 for WebGPU

