### PR TITLE
WebGLRenderer: Add transmission render target scale

### DIFF
--- a/docs/api/en/renderers/WebGLRenderer.html
+++ b/docs/api/en/renderers/WebGLRenderer.html
@@ -323,6 +323,9 @@ document.body.appendChild( renderer.domElement );
 		<h3>[property:Number toneMappingExposure]</h3>
 		<p>Exposure level of tone mapping. Default is `1`.</p>
 
+		<h3>[property:Number transmissionResolutionScale]</h3>
+		<p>The normalized resolution scale for the transmission render target, measured in percentage of viewport dimensions. Lowering this value can result in significant improvements to [page:MeshPhysicalMaterial MeshPhysicalMaterial] transmission performance. Default is `1`.</p>
+
 		<h3>[property:WebXRManager xr]</h3>
 		<p>
 			Provides access to the WebXR related [page:WebXRManager interface] of the

--- a/examples/webgl_materials_physical_transmission.html
+++ b/examples/webgl_materials_physical_transmission.html
@@ -40,7 +40,8 @@
 				specularColor: 0xffffff,
 				envMapIntensity: 1,
 				lightIntensity: 1,
-				exposure: 1
+				exposure: 1,
+				transmissionResolutionScale: 1
 			};
 
 			let camera, scene, renderer;
@@ -206,6 +207,15 @@
 					.onChange( function () {
 
 						renderer.toneMappingExposure = params.exposure;
+						render();
+
+					} );
+
+				gui.add( params, 'transmissionResolutionScale', 0.01, 1, 0.01 )
+					.name( 'transmission resolution' )
+					.onChange( function () {
+
+						renderer.transmissionResolutionScale = params.transmissionResolutionScale;
 						render();
 
 					} );

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -194,7 +194,7 @@ class WebGLRenderer {
 		let _localClippingEnabled = false;
 
 		// transmission render target scale
-		this.transmissionRenderTargetScale = 1.0;
+		this.transmissionResolutionScale = 1.0;
 
 		// camera matrices cache
 
@@ -1500,7 +1500,7 @@ class WebGLRenderer {
 			const transmissionRenderTarget = currentRenderState.state.transmissionRenderTarget[ camera.id ];
 
 			const activeViewport = camera.viewport || _currentViewport;
-			transmissionRenderTarget.setSize( activeViewport.z * _this.transmissionRenderTargetScale, activeViewport.w * _this.transmissionRenderTargetScale );
+			transmissionRenderTarget.setSize( activeViewport.z * _this.transmissionResolutionScale, activeViewport.w * _this.transmissionResolutionScale );
 
 			//
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -193,6 +193,9 @@ class WebGLRenderer {
 		let _clippingEnabled = false;
 		let _localClippingEnabled = false;
 
+		// transmission render target scale
+		this.transmissionRenderTargetScale = 1.0;
+
 		// camera matrices cache
 
 		const _currentProjectionMatrix = new Matrix4();
@@ -1497,7 +1500,7 @@ class WebGLRenderer {
 			const transmissionRenderTarget = currentRenderState.state.transmissionRenderTarget[ camera.id ];
 
 			const activeViewport = camera.viewport || _currentViewport;
-			transmissionRenderTarget.setSize( activeViewport.z, activeViewport.w );
+			transmissionRenderTarget.setSize( activeViewport.z * _this.transmissionRenderTargetScale, activeViewport.w * _this.transmissionRenderTargetScale );
 
 			//
 


### PR DESCRIPTION
Fixed #30017.

**Description**

By default, the transmission render target takes up the full viewport. Reducing this render target size is valuable due to the considerable performance impact of rendering at full resolution and minimal visual degradation by just scaling the transmission render target size.

Here is a quick side-by-side comparison of full scale versus 33% scale, respectively:

<img width="1225" alt="100-Screenshot 2024-12-02 at 20 20 59" src="https://github.com/user-attachments/assets/f11b8d7c-4158-4152-8a6f-6c3eb92dbfd5">


<img width="1226" alt="33-Screenshot 2024-12-02 at 20 20 38" src="https://github.com/user-attachments/assets/1eccc8f7-ba82-43e4-bdd5-6f623061ba14">