### PR TITLE
WebGPUBackend: Revert onSubmittedWorkDone usage in timestamp queries

### DIFF
--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -1243,8 +1243,6 @@ class WebGPUBackend extends Backend {
 
 		const { resultBuffer } = renderContextData.currentTimestampQueryBuffers;
 
-		await this.device.queue.onSubmittedWorkDone();
-
 		if ( resultBuffer.mapState === 'unmapped' ) {
 
 			resultBuffer.mapAsync( GPUMapMode.READ ).then( () => {


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/29970

**Description**

Partially revert https://github.com/mrdoob/three.js/pull/29970 as the usage of `await this.device.queue.onSubmittedWorkDone();` seems too heavy on the CPU (add an average of 3ms) and should be manually handled by the developer using `renderer.waitForGPU()` if needed instead.


*This contribution is funded by [Utsubo](https://utsubo.com)*
