### PR TITLE
Remove useless vars from FlyControls.js

### DIFF
--- a/examples/jsm/controls/FlyControls.js
+++ b/examples/jsm/controls/FlyControls.js
@@ -167,9 +167,6 @@ function onKeyDown( event ) {
 
 	switch ( event.code ) {
 
-		case 'ShiftLeft':
-		case 'ShiftRight': this.movementSpeedMultiplier = .1; break;
-
 		case 'KeyW': this._moveState.forward = 1; break;
 		case 'KeyS': this._moveState.back = 1; break;
 
@@ -200,9 +197,6 @@ function onKeyUp( event ) {
 	if ( this.enabled === false ) return;
 
 	switch ( event.code ) {
-
-		case 'ShiftLeft':
-		case 'ShiftRight': this.movementSpeedMultiplier = 1; break;
 
 		case 'KeyW': this._moveState.forward = 0; break;
 		case 'KeyS': this._moveState.back = 0; break;


### PR DESCRIPTION
While browsing through the camera controls, I stumbled upon this dynamically created var. It seems like it's not used anywhere in the repo.