### PR TITLE
Docs: Fix code blocks occasionally lacking white-space in Firefox

### DIFF
--- a/docs/page.js
+++ b/docs/page.js
@@ -205,6 +205,7 @@ function onDocumentLoad() {
 		for ( let i = 0; i < elements.length; i ++ ) {
 
 			const e = elements[ i ];
+			e.currentStyle = { 'whiteSpace': 'pre-wrap' }; // Workaround for Firefox, see #30008
 			e.className += ' prettyprint';
 			e.setAttribute( 'translate', 'no' );
 


### PR DESCRIPTION
Related issue: #30008 

**Description**

Prettify strips white-space from code blocks unless they are preformatted. This is based on the element's computed style. While the page is loading, the iframe is hidden using `display: none`, which under Firefox means `getComputedStyle` returns empty results. Depending on load order and connection speed, this could cause prettify to incorrectly assume code blocks _aren't_ preformatted.

This PR sets the `currentStyle` property on the code block elements before loading `prettify.js`. This triggers a code path that avoids `getComputedStyle` working around the issue. The code path is originally for old versions of IE.

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Fern Solutions](https://fern.solutions/)*
