### PR TITLE
LightsNode: Fix cache key.

### DIFF
--- a/src/nodes/lighting/LightsNode.js
+++ b/src/nodes/lighting/LightsNode.js
@@ -1,6 +1,6 @@
 import Node from '../core/Node.js';
 import { nodeObject, vec3 } from '../tsl/TSLBase.js';
-import { hash } from '../core/NodeUtils.js';
+import { hashArray } from '../core/NodeUtils.js';
 
 const sortLights = ( lights ) => {
 
@@ -25,7 +25,6 @@ const getLightNodeById = ( id, lightNodes ) => {
 };
 
 const _lightsNodeRef = /*@__PURE__*/ new WeakMap();
-const _lightIDs = /*@__PURE__*/ new Set();
 
 class LightsNode extends Node {
 
@@ -55,15 +54,24 @@ class LightsNode extends Node {
 
 	getCacheKey( force ) {
 
-		_lightIDs.clear();
+		force = force || this.version !== this._cacheKeyVersion;
 
-		for ( let i = 0; i < this._lights.length; i ++ ) {
+		if ( force === true || this._cacheKey === null ) {
 
-			_lightIDs.add( this._lights[ i ].id );
+			const lightIDs = [];
+
+			for ( let i = 0; i < this._lights.length; i ++ ) {
+
+				lightIDs.push( this._lights[ i ].id );
+
+			}
+
+			this._cacheKey = hashArray( lightIDs );
+			this._cacheKeyVersion = this.version;
 
 		}
 
-		return hash( super.getCacheKey( force ), ... _lightIDs );
+		return this._cacheKey;
 
 	}
 

--- a/src/nodes/lighting/LightsNode.js
+++ b/src/nodes/lighting/LightsNode.js
@@ -1,5 +1,6 @@
 import Node from '../core/Node.js';
 import { nodeObject, vec3 } from '../tsl/TSLBase.js';
+import { hash } from '../core/NodeUtils.js';
 
 const sortLights = ( lights ) => {
 
@@ -24,6 +25,7 @@ const getLightNodeById = ( id, lightNodes ) => {
 };
 
 const _lightsNodeRef = /*@__PURE__*/ new WeakMap();
+const _lightIDs = /*@__PURE__*/ new Set();
 
 class LightsNode extends Node {
 
@@ -48,6 +50,20 @@ class LightsNode extends Node {
 		this._lightNodesHash = null;
 
 		this.global = true;
+
+	}
+
+	getCacheKey( force ) {
+
+		_lightIDs.clear();
+
+		for ( let i = 0; i < this._lights.length; i ++ ) {
+
+			_lightIDs.add( this._lights[ i ].id );
+
+		}
+
+		return hash( super.getCacheKey( force ), ... _lightIDs );
 
 	}
 


### PR DESCRIPTION
Related issue: Fixes #30044

**Description**

Fixes the cache key by including the IDs of the scene's lights into the key computation.