### PR TITLE
Node: fix small typos

### DIFF
--- a/src/nodes/core/Node.js
+++ b/src/nodes/core/Node.js
@@ -469,7 +469,7 @@ class Node extends EventDispatcher {
 
 	/**
 	 * Represents the analyze stage which is the second step of the build process, see {@link Node#build} method.
-	 * This stage anaylzes the node hierarchy and ensures descendent nodes are built.
+	 * This stage analyzes the node hierarchy and ensures descendent nodes are built.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
 	 */

--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -794,7 +794,7 @@ class NodeBuilder {
 	/**
 	 * Returns the native shader method name for a given generic name. E.g.
 	 * the method name `textureDimensions` matches the WGSL name but must be
-	 * resolved to `texureSize` in GLSL.
+	 * resolved to `textureSize` in GLSL.
 	 *
 	 * @abstract
 	 * @param {String} name - The method name to resolve.
@@ -972,7 +972,7 @@ class NodeBuilder {
 	}
 
 	/**
-	 * Returns thefragCoord input variable as a native shader string.
+	 * Returns the fragCoord input variable as a native shader string.
 	 *
 	 * @abstract
 	 * @return {String} The fragCoord shader string.
@@ -985,7 +985,7 @@ class NodeBuilder {
 
 	/**
 	 * Whether to flip texture data along its vertical axis or not. WebGL needs
-	 * this method evalaute to `true`, WebGPU to `false`.
+	 * this method evaluate to `true`, WebGPU to `false`.
 	 *
 	 * @abstract
 	 * @return {Boolean} Whether to flip texture data along its vertical axis or not.
@@ -997,7 +997,7 @@ class NodeBuilder {
 	}
 
 	/**
-	 * Calling this mehod increases the usage count for the given node by one.
+	 * Calling this method increases the usage count for the given node by one.
 	 *
 	 * @param {Node} Node - The node to increase the usage count for.
 	 * @return {Number} The updated usage count.
@@ -1223,7 +1223,7 @@ class NodeBuilder {
 	}
 
 	/**
-	 * Returns the component type of a given texutre.
+	 * Returns the component type of a given texture.
 	 *
 	 * @param {Texture} texture - The texture.
 	 * @return {String} The component type.

--- a/src/nodes/core/PropertyNode.js
+++ b/src/nodes/core/PropertyNode.js
@@ -3,7 +3,7 @@ import { nodeImmutable, nodeObject } from '../tsl/TSLCore.js';
 
 /**
  * This class represents a shader property. It can be used on
- * to explicitely define a property and assign a value to it.
+ * to explicitly define a property and assign a value to it.
  *
  * ```js
  * const threshold = property( 'float', 'threshold' ).assign( THRESHOLD );

--- a/src/nodes/core/VarNode.js
+++ b/src/nodes/core/VarNode.js
@@ -2,7 +2,7 @@ import Node from './Node.js';
 import { addMethodChaining, nodeProxy } from '../tsl/TSLCore.js';
 
 /**
- * Class for representing shader variables as nodes. Variables are create from
+ * Class for representing shader variables as nodes. Variables are created from
  * existing nodes like the following:
  *
  * ```js
@@ -46,7 +46,7 @@ class VarNode extends Node {
 		this.name = name;
 
 		/**
-		 * `VarNonde` sets this property to `true` by default.
+		 * `VarNode` sets this property to `true` by default.
 		 *
 		 * @type {Boolean}
 		 * @default true

--- a/src/nodes/display/PassNode.js
+++ b/src/nodes/display/PassNode.js
@@ -520,7 +520,7 @@ class PassNode extends TempNode {
 	 * Returns a linear depth node of this pass.
 	 *
 	 * @param {String} [name='depth'] - The output name to get the linear depth node for. In most cases the default `'depth'` can be used however the parameter exists for custom depth outputs.
-	 * @return {Node} The lienar depth node.
+	 * @return {Node} The linear depth node.
 	 */
 	getLinearDepthNode( name = 'depth' ) {
 

--- a/src/nodes/display/ScreenNode.js
+++ b/src/nodes/display/ScreenNode.js
@@ -36,7 +36,7 @@ class ScreenNode extends Node {
 		 * The node represents different metric depending on which scope is selected.
 		 *
 		 * - `ScreenNode.COORDINATE`: Window-relative coordinates of the current fragment according to WebGPU standards.
-		 * - `ScreenNode.VIEWPORT`: The current viewport defined as a four-dimnesional vector.
+		 * - `ScreenNode.VIEWPORT`: The current viewport defined as a four-dimensional vector.
 		 * - `ScreenNode.SIZE`: The dimensions of the current bound framebuffer.
 		 * - `ScreenNode.UV`: Normalized screen coordinates.
 		 *

--- a/src/nodes/display/ViewportDepthNode.js
+++ b/src/nodes/display/ViewportDepthNode.js
@@ -43,7 +43,7 @@ class ViewportDepthNode extends Node {
 
 		/**
 		 * Can be used to define a custom depth value.
-		 * The propety is ignored in the `ViewportDepthNode.DEPTH` scope.
+		 * The property is ignored in the `ViewportDepthNode.DEPTH` scope.
 		 *
 		 * @type {Node}
 		 * @default null

--- a/src/nodes/fog/FogExp2Node.js
+++ b/src/nodes/fog/FogExp2Node.js
@@ -20,7 +20,7 @@ class FogExp2Node extends FogNode {
 	 * Constructs a new exponential squared fog node.
 	 *
 	 * @param {Node} colorNode - Defines the color of the fog.
-	 * @param {Node} densityNode - Defines the fog densitiy.
+	 * @param {Node} densityNode - Defines the fog density.
 	 */
 	constructor( colorNode, densityNode ) {
 
@@ -36,7 +36,7 @@ class FogExp2Node extends FogNode {
 		this.isFogExp2Node = true;
 
 		/**
-		 * Defines the fog densitiy.
+		 * Defines the fog density.
 		 *
 		 * @type {Node}
 		 */

--- a/src/nodes/utils/ConvertNode.js
+++ b/src/nodes/utils/ConvertNode.js
@@ -42,7 +42,7 @@ class ConvertNode extends Node {
 	}
 
 	/**
-	 * This method is overwritten since the implementation tries to infere the best
+	 * This method is overwritten since the implementation tries to infer the best
 	 * matching type from the {@link ConvertNode#convertTo} property.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.

--- a/src/nodes/utils/CubeMapNode.js
+++ b/src/nodes/utils/CubeMapNode.js
@@ -61,7 +61,7 @@ class CubeMapNode extends TempNode {
 		/**
 		 * A default cube texture that acts as a placeholder.
 		 * It is used when the conversion from equirectangular to cube
-		 * map has not finished yet for a givent texture.
+		 * map has not finished yet for a given texture.
 		 *
 		 * @private
 		 * @type {CubeTexture}

--- a/src/nodes/utils/JoinNode.js
+++ b/src/nodes/utils/JoinNode.js
@@ -36,7 +36,7 @@ class JoinNode extends TempNode {
 
 	/**
 	 * This method is overwritten since the node type must be inferred from the
-	 * joined data length if not explicitely defined.
+	 * joined data length if not explicitly defined.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
 	 * @return {String} The node type.

--- a/src/nodes/utils/RotateNode.js
+++ b/src/nodes/utils/RotateNode.js
@@ -16,7 +16,7 @@ class RotateNode extends TempNode {
 	}
 
 	/**
-	 * Constructs a new rorate node.
+	 * Constructs a new rotate node.
 	 *
 	 * @param {Node} positionNode - The position node.
 	 * @param {Node} rotationNode - Represents the rotation that is applied to the position node. Depending

--- a/src/nodes/utils/UVUtils.js
+++ b/src/nodes/utils/UVUtils.js
@@ -19,11 +19,11 @@ export const rotateUV = /*@__PURE__*/ Fn( ( [ uv, rotation, center = vec2( 0.5 )
 } );
 
 /**
- * Applies a spherical warping effect to the given uv coordinats.
+ * Applies a spherical warping effect to the given uv coordinates.
  *
  * @method
  * @param {Node<vec2>} uv - The uv coordinates.
- * @param {Node<float>} strength - The stength of the effect.
+ * @param {Node<float>} strength - The strength of the effect.
  * @param {Node<vec2>} center - The center point
  * @return {Node<vec2>} The updated uv coordinates.
  */


### PR DESCRIPTION
**Description**

Fix small typos in `src/node` folder.