### PR TITLE
PropertyBinding: Fix versioning scheme determination.

### DIFF
--- a/src/animation/PropertyBinding.js
+++ b/src/animation/PropertyBinding.js
@@ -569,11 +569,11 @@ class PropertyBinding {
 
 		this.targetObject = targetObject;
 
-		if ( targetObject.needsUpdate !== undefined ) { // material
+		if ( targetObject.isMaterial === true ) {
 
 			versioning = this.Versioning.NeedsUpdate;
 
-		} else if ( targetObject.matrixWorldNeedsUpdate !== undefined ) { // node transform
+		} else if ( targetObject.isObject3D === true ) {
 
 			versioning = this.Versioning.MatrixWorldNeedsUpdate;
 


### PR DESCRIPTION
Fixed #30035.

**Description**

The PR makes sure `PropertyBinding` uses the `is*` flags for type detection. The previous approach of using update flags is error prone since such property might only exist as a setter.
