### PR TITLE
PMREMGenerator: Fix `fromScene()` back-side materials

### DIFF
--- a/src/nodes/pmrem/PMREMNode.js
+++ b/src/nodes/pmrem/PMREMNode.js
@@ -191,6 +191,8 @@ class PMREMNode extends TempNode {
 
 		}
 
+		uvNode = vec3( uvNode.x, uvNode.y.negate(), uvNode.z );
+
 		//
 
 		let levelNode = this.levelNode;

--- a/src/renderers/common/extras/PMREMGenerator.js
+++ b/src/renderers/common/extras/PMREMGenerator.js
@@ -406,6 +406,7 @@ class PMREMGenerator {
 		cubeCamera.far = far;
 
 		// px, py, pz, nx, ny, nz
+		const upSign = [ 1, 1, 1, 1, - 1, 1 ];
 		const forwardSign = [ 1, - 1, 1, - 1, 1, - 1 ];
 
 		const renderer = this._renderer;
@@ -467,17 +468,17 @@ class PMREMGenerator {
 
 			if ( col === 0 ) {
 
-				cubeCamera.up.set( 0, 1, 0 );
+				cubeCamera.up.set( 0, upSign[ i ], 0 );
 				cubeCamera.lookAt( forwardSign[ i ], 0, 0 );
 
 			} else if ( col === 1 ) {
 
-				cubeCamera.up.set( 0, - 1, 0 );
+				cubeCamera.up.set( 0, 0, upSign[ i ] );
 				cubeCamera.lookAt( 0, forwardSign[ i ], 0 );
 
 			} else {
 
-				cubeCamera.up.set( 0, 1, 0 );
+				cubeCamera.up.set( 0, upSign[ i ], 0 );
 				cubeCamera.lookAt( 0, 0, forwardSign[ i ] );
 
 			}

--- a/src/renderers/common/extras/PMREMGenerator.js
+++ b/src/renderers/common/extras/PMREMGenerator.js
@@ -406,8 +406,7 @@ class PMREMGenerator {
 		cubeCamera.far = far;
 
 		// px, py, pz, nx, ny, nz
-		const upSign = [ - 1, 1, - 1, - 1, - 1, - 1 ];
-		const forwardSign = [ 1, 1, 1, - 1, - 1, - 1 ];
+		const forwardSign = [ 1, - 1, 1, - 1, 1, - 1 ];
 
 		const renderer = this._renderer;
 
@@ -468,17 +467,17 @@ class PMREMGenerator {
 
 			if ( col === 0 ) {
 
-				cubeCamera.up.set( 0, upSign[ i ], 0 );
+				cubeCamera.up.set( 0, 1, 0 );
 				cubeCamera.lookAt( forwardSign[ i ], 0, 0 );
 
 			} else if ( col === 1 ) {
 
-				cubeCamera.up.set( 0, 0, upSign[ i ] );
+				cubeCamera.up.set( 0, - 1, 0 );
 				cubeCamera.lookAt( 0, forwardSign[ i ], 0 );
 
 			} else {
 
-				cubeCamera.up.set( 0, upSign[ i ], 0 );
+				cubeCamera.up.set( 0, 1, 0 );
 				cubeCamera.lookAt( 0, 0, forwardSign[ i ] );
 
 			}

--- a/src/renderers/common/extras/PMREMGenerator.js
+++ b/src/renderers/common/extras/PMREMGenerator.js
@@ -78,7 +78,7 @@ const _faceLib = [
 ];
 
 const direction = getDirection( uv(), attribute( 'faceIndex' ) ).normalize();
-const outputDirection = vec3( direction.x, direction.y.negate(), direction.z );
+const outputDirection = vec3( direction.x, direction.y, direction.z );
 
 /**
  * This class generates a Prefiltered, Mipmapped Radiance Environment Map


### PR DESCRIPTION
Related issue: Fixes https://github.com/mrdoob/three.js/issues/30048

**Description**

Apparently the problem was with the back of the materials, I changed the approach a bit to do the flip-y on the sampler instead of the generator and it worked. The cause of the problem is still a bit unclear for me.