### PR TITLE
Editor: Fix vertex normals helper regression.

### DIFF
--- a/editor/js/Sidebar.Geometry.js
+++ b/editor/js/Sidebar.Geometry.js
@@ -300,7 +300,7 @@ function SidebarGeometry( editor ) {
 
 			const helper = editor.helpers[ object.id ];
 
-			if ( helper !== undefined ) {
+			if ( helper !== undefined && helper.isVertexNormalsHelper === true ) {
 
 				editor.removeHelper( object );
 				editor.addHelper( object, new VertexNormalsHelper( object ) );

--- a/examples/jsm/helpers/VertexNormalsHelper.js
+++ b/examples/jsm/helpers/VertexNormalsHelper.js
@@ -32,6 +32,8 @@ class VertexNormalsHelper extends LineSegments {
 
 		this.matrixAutoUpdate = false;
 
+		this.isVertexNormalsHelper = true;
+
 		this.update();
 
 	}


### PR DESCRIPTION
Related issue: https://discourse.threejs.org/t/bug-in-editor-auto-activate-show-normals/74903

**Description**

Unfortunately, #28613 introduced a regression with skinned meshes. With this fix, the editor now only recreates the vertex normals helper if the active helper is of type `VertexNormalsHelper`.