### PR TITLE
Nodes: fix type errors

### DIFF
--- a/src/nodes/core/NodeCache.js
+++ b/src/nodes/core/NodeCache.js
@@ -24,7 +24,7 @@ class NodeCache {
 		/**
 		 * A weak map for managing node data.
 		 *
-		 * @type {WeakMap}
+		 * @type {WeakMap<Node, Object>}
 		 */
 		this.nodesData = new WeakMap();
 

--- a/src/nodes/core/NodeFrame.js
+++ b/src/nodes/core/NodeFrame.js
@@ -48,21 +48,21 @@ class NodeFrame {
 		/**
 		 * Used to control the {@link Node#update} call.
 		 *
-		 * @type {WeakMap}
+		 * @type {WeakMap<Node, Object>}
 		 */
 		this.updateMap = new WeakMap();
 
 		/**
 		 * Used to control the {@link Node#updateBefore} call.
 		 *
-		 * @type {WeakMap}
+		 * @type {WeakMap<Node, Object>}
 		 */
 		this.updateBeforeMap = new WeakMap();
 
 		/**
 		 * Used to control the {@link Node#updateAfter} call.
 		 *
-		 * @type {WeakMap}
+		 * @type {WeakMap<Node, Object>}
 		 */
 		this.updateAfterMap = new WeakMap();
 
@@ -113,7 +113,7 @@ class NodeFrame {
 	 * is used to correctly call node update methods per frame or render.
 	 *
 	 * @private
-	 * @param {WeakMap} referenceMap - The reference weak map.
+	 * @param {WeakMap<Node, Object>} referenceMap - The reference weak map.
 	 * @param {Node} nodeRef - The reference to the current node.
 	 * @return {Object<String,WeakMap>} The dictionary.
 	 */

--- a/src/nodes/core/ParameterNode.js
+++ b/src/nodes/core/ParameterNode.js
@@ -51,4 +51,10 @@ class ParameterNode extends PropertyNode {
 
 export default ParameterNode;
 
+/**
+ *
+ * @param {string} type
+ * @param {string?} [name=null]
+ * @returns {ShaderNodeObject}
+ */
 export const parameter = ( type, name ) => nodeObject( new ParameterNode( type, name ) );

--- a/src/nodes/core/TempNode.js
+++ b/src/nodes/core/TempNode.js
@@ -19,11 +19,11 @@ class TempNode extends Node {
 	/**
 	 * Constructs a temp node.
 	 *
-	 * @param {String} type - The node type.
+	 * @param {String?} nodeType - The node type.
 	 */
-	constructor( type ) {
+	constructor( nodeType = null ) {
 
-		super( type );
+		super( nodeType );
 
 		/**
 		 * This flag can be used for type testing.

--- a/src/nodes/display/ToonOutlinePassNode.js
+++ b/src/nodes/display/ToonOutlinePassNode.js
@@ -68,7 +68,7 @@ class ToonOutlinePassNode extends PassNode {
 		 * An internal material cache.
 		 *
 		 * @private
-		 * @type {WeakMap}
+		 * @type {WeakMap<Material, NodeMaterial>}
 		 */
 		this._materialCache = new WeakMap();
 

--- a/src/nodes/pmrem/PMREMNode.js
+++ b/src/nodes/pmrem/PMREMNode.js
@@ -127,7 +127,7 @@ class PMREMNode extends TempNode {
 		 * Reference to the generated PMREM.
 		 *
 		 * @private
-		 * @type {Texture}
+		 * @type {Texture | null}
 		 * @default null
 		 */
 		this._pmrem = null;

--- a/src/nodes/utils/LoopNode.js
+++ b/src/nodes/utils/LoopNode.js
@@ -58,7 +58,7 @@ class LoopNode extends Node {
 	 */
 	getVarName( index ) {
 
-		return String.fromCharCode( 'i'.charCodeAt() + index );
+		return String.fromCharCode( 'i'.charCodeAt( 0 ) + index );
 
 	}
 

--- a/src/nodes/utils/RTTNode.js
+++ b/src/nodes/utils/RTTNode.js
@@ -17,7 +17,7 @@ const _size = /*@__PURE__*/ new Vector2();
  * texture input for their effects. With the helper function `convertToTexture()` which is based
  * on this module, the node system can automatically ensure texture input if required.
  *
- * @augments Node
+ * @augments TextureNode
  */
 class RTTNode extends TextureNode {
 

--- a/src/nodes/utils/ReflectorNode.js
+++ b/src/nodes/utils/ReflectorNode.js
@@ -267,7 +267,7 @@ class ReflectorBaseNode extends Node {
 		/**
 		 * Weak map for managing render targets.
 		 *
-		 * @type {WeakMap}
+		 * @type {WeakMap<Camera, RenderTarget>}
 		 */
 		this.renderTargets = new WeakMap();
 
@@ -299,7 +299,7 @@ class ReflectorBaseNode extends Node {
 	}
 
 	/**
-	 * Returns a virtual camera for the given camera. The virutal camera is used to
+	 * Returns a virtual camera for the given camera. The virtual camera is used to
 	 * render the scene from the reflector's view so correct reflections can be produced.
 	 *
 	 * @param {Camera} camera - The scene's camera.


### PR DESCRIPTION
**Description**

I tried running Typescript to check the coherence of all the types inside the `nodes` folder. I found some updates to improve the existing code and fix some TS warning:

* Better typing for WeakMap
* TempNode constructor name is not set from existing children like `AssignNode` or `SetNode` so I set the name as optional
* String.charCodeAt requires an argument
* Other small fixes