### PR TITLE
GLTFLoader: assign unique names to children of cloned refs in _getNod…

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2796,7 +2796,15 @@ class GLTFParser {
 
 		updateMappings( object, ref );
 
-		ref.name += '_instance_' + ( cache.uses[ index ] ++ );
+		const instanceSuffix = '_instance_' + ( cache.uses[ index ] ++ );
+
+		ref.name += instanceSuffix;
+
+		for ( const child of ref.children ) {
+
+			child.name += instanceSuffix;
+
+		}
 
 		return ref;
 


### PR DESCRIPTION
…eRef() (fixes #30090)

Related issue: #30090 

**Description**

When cloning a reference the children of the cloned reference have the same names as the children of the original reference. This causes duplicate names for example when dealing with meshes that have multiple primitives and that are instantiated multiple times.

This pull request attempts to change this by applying the same `_instance_X` suffix applied to the reference name to its children. Another possible solution might be to apply createUniqueName() on the names of cloned children. Let me know if another solution than the current is preferred and I'd be happy to change it.
