### PR TITLE
Eslint: fix more JSDocs

### DIFF
--- a/editor/js/commands/AddObjectCommand.js
+++ b/editor/js/commands/AddObjectCommand.js
@@ -1,13 +1,13 @@
 import { Command } from '../Command.js';
 import { ObjectLoader } from 'three';
 
-/**
- * @param editor Editor
- * @param object THREE.Object3D
- * @constructor
- */
 class AddObjectCommand extends Command {
 
+	/**
+	 * @param {Editor} editor
+	 * @param {THREE.Object3D|null} [object=null]
+	 * @constructor
+	 */
 	constructor( editor, object = null ) {
 
 		super( editor );

--- a/editor/js/commands/AddScriptCommand.js
+++ b/editor/js/commands/AddScriptCommand.js
@@ -1,13 +1,13 @@
 import { Command } from '../Command.js';
 
-/**
- * @param editor Editor
- * @param object THREE.Object3D
- * @param script javascript object
- * @constructor
- */
 class AddScriptCommand extends Command {
 
+	/**
+	 * @param {Editor} editor
+	 * @param {THREE.Object3D|null} [object=null]
+	 * @param {String} [script='']
+	 * @constructor
+	 */
 	constructor( editor, object = null, script = '' ) {
 
 		super( editor );

--- a/editor/js/commands/MoveObjectCommand.js
+++ b/editor/js/commands/MoveObjectCommand.js
@@ -1,14 +1,14 @@
 import { Command } from '../Command.js';
 
-/**
- * @param editor Editor
- * @param object THREE.Object3D
- * @param newParent THREE.Object3D
- * @param newBefore THREE.Object3D
- * @constructor
- */
 class MoveObjectCommand extends Command {
 
+	/**
+	 * @param {Editor} editor
+	 * @param {THREE.Object3D|null} [object=null]
+	 * @param {THREE.Object3D|null} [newParent=null]
+	 * @param {THREE.Object3D|null} [newBefore=null]
+	 * @constructor
+	 */
 	constructor( editor, object = null, newParent = null, newBefore = null ) {
 
 		super( editor );

--- a/editor/js/commands/MultiCmdsCommand.js
+++ b/editor/js/commands/MultiCmdsCommand.js
@@ -1,12 +1,12 @@
 import { Command } from '../Command.js';
 
-/**
- * @param editor Editor
- * @param cmdArray array containing command objects
- * @constructor
- */
 class MultiCmdsCommand extends Command {
 
+	/**
+	 * @param {Editor} editor
+	 * @param {Array<Command>} [cmdArray=[]]
+	 * @constructor
+	 */
 	constructor( editor, cmdArray = [] ) {
 
 		super( editor );

--- a/editor/js/commands/RemoveObjectCommand.js
+++ b/editor/js/commands/RemoveObjectCommand.js
@@ -2,13 +2,13 @@ import { Command } from '../Command.js';
 
 import { ObjectLoader } from 'three';
 
-/**
- * @param editor Editor
- * @param object THREE.Object3D
- * @constructor
- */
 class RemoveObjectCommand extends Command {
 
+	/**
+	 * @param {Editor} editor
+	 * @param {THREE.Object3D|null} [object=null]
+	 * @constructor
+	 */
 	constructor( editor, object = null ) {
 
 		super( editor );

--- a/editor/js/commands/RemoveScriptCommand.js
+++ b/editor/js/commands/RemoveScriptCommand.js
@@ -1,13 +1,13 @@
 import { Command } from '../Command.js';
 
-/**
- * @param editor Editor
- * @param object THREE.Object3D
- * @param script javascript object
- * @constructor
- */
 class RemoveScriptCommand extends Command {
 
+	/**
+	 * @param {Editor} editor
+	 * @param {THREE.Object3D|null} [object=null]
+	 * @param {String} [script='']
+	 * @constructor
+	 */
 	constructor( editor, object = null, script = '' ) {
 
 		super( editor );

--- a/editor/js/commands/SetColorCommand.js
+++ b/editor/js/commands/SetColorCommand.js
@@ -1,14 +1,14 @@
 import { Command } from '../Command.js';
 
-/**
- * @param editor Editor
- * @param object THREE.Object3D
- * @param attributeName string
- * @param newValue integer representing a hex color value
- * @constructor
- */
 class SetColorCommand extends Command {
 
+	/**
+	 * @param {Editor} editor
+	 * @param {THREE.Object3D|null} [object=null]
+	 * @param {String} attributeName
+	 * @param {Number|null} [newValue=null] Integer representing a hex color value
+	 * @constructor
+	 */
 	constructor( editor, object = null, attributeName = '', newValue = null ) {
 
 		super( editor );

--- a/editor/js/commands/SetGeometryCommand.js
+++ b/editor/js/commands/SetGeometryCommand.js
@@ -1,15 +1,14 @@
 import { Command } from '../Command.js';
 import { ObjectLoader } from 'three';
 
-/**
- * @param editor Editor
- * @param object THREE.Object3D
- * @param newGeometry THREE.Geometry
- * @constructor
- */
-
 class SetGeometryCommand extends Command {
 
+	/**
+	 * @param {Editor} editor
+	 * @param {THREE.Object3D|null} [object=null]
+	 * @param {THREE.Geometry|null} [newGeometry=null]
+	 * @constructor
+	 */
 	constructor( editor, object = null, newGeometry = null ) {
 
 		super( editor );

--- a/editor/js/commands/SetGeometryValueCommand.js
+++ b/editor/js/commands/SetGeometryValueCommand.js
@@ -1,14 +1,14 @@
 import { Command } from '../Command.js';
 
-/**
- * @param editor Editor
- * @param object THREE.Object3D
- * @param attributeName string
- * @param newValue number, string, boolean or object
- * @constructor
- */
 class SetGeometryValueCommand extends Command {
 
+	/**
+	 * @param {Editor} editor
+	 * @param {THREE.Object3D|null} [object=null]
+	 * @param {String} [attributeName='']
+	 * @param {Number|String|Boolean|Object|null} [newValue=null]
+	 * @constructor
+	 */
 	constructor( editor, object = null, attributeName = '', newValue = null ) {
 
 		super( editor );

--- a/editor/js/commands/SetMaterialColorCommand.js
+++ b/editor/js/commands/SetMaterialColorCommand.js
@@ -1,14 +1,15 @@
 import { Command } from '../Command.js';
 
-/**
- * @param editor Editor
- * @param object THREE.Object3D
- * @param attributeName string
- * @param newValue integer representing a hex color value
- * @constructor
- */
 class SetMaterialColorCommand extends Command {
 
+	/**
+	 * @param {Editor} editor
+	 * @param {THREE.Object3D|null} [object=null]
+	 * @param {String} attributeName
+	 * @param {Number|null} [newValue=null] Integer representing a hex color value
+	 * @param {Number} [materialSlot=-1]
+	 * @constructor
+	 */
 	constructor( editor, object = null, attributeName = '', newValue = null, materialSlot = - 1 ) {
 
 		super( editor );

--- a/editor/js/commands/SetMaterialCommand.js
+++ b/editor/js/commands/SetMaterialCommand.js
@@ -1,14 +1,15 @@
 import { Command } from '../Command.js';
 import { ObjectLoader } from 'three';
 
-/**
- * @param editor Editor
- * @param object THREE.Object3D
- * @param newMaterial THREE.Material
- * @constructor
- */
 class SetMaterialCommand extends Command {
 
+	/**
+	 * @param {Editor} editor
+	 * @param {THREE.Object3D|null} object
+	 * @param {THREE.Material|null} newMaterial
+	 * @param {Number} [materialSlot=-1]
+	 * @constructor
+	 */
 	constructor( editor, object = null, newMaterial = null, materialSlot = - 1 ) {
 
 		super( editor );

--- a/editor/js/commands/SetMaterialMapCommand.js
+++ b/editor/js/commands/SetMaterialMapCommand.js
@@ -1,15 +1,16 @@
 import { Command } from '../Command.js';
 import { ObjectLoader } from 'three';
 
-/**
- * @param editor Editor
- * @param object THREE.Object3D
- * @param mapName string
- * @param newMap THREE.Texture
- * @constructor
- */
 class SetMaterialMapCommand extends Command {
 
+	/**
+	 * @param {Editor} editor
+	 * @param {THREE.Object3D|null} [object=null]
+	 * @param {String} [mapName='']
+	 * @param {THREE.Texture|null} [newMap=null]
+	 * @param {Number} [materialSlot=-1]
+	 * @constructor
+	 */
 	constructor( editor, object = null, mapName = '', newMap = null, materialSlot = - 1 ) {
 
 		super( editor );

--- a/editor/js/commands/SetMaterialRangeCommand.js
+++ b/editor/js/commands/SetMaterialRangeCommand.js
@@ -1,15 +1,16 @@
 import { Command } from '../Command.js';
 
-/**
- * @param editor Editor
- * @param object THREE.Object3D
- * @param attributeName string
- * @param newMinValue number
- * @param newMaxValue number
- * @constructor
- */
 class SetMaterialRangeCommand extends Command {
 
+	/**
+	 * @param {Editor} editor
+	 * @param {THREE.Object3D|null} [object=null]
+	 * @param {String} [attributeName='']
+	 * @param {Number} [newMinValue=-Infinity]
+	 * @param {Number} [newMaxValue=Infinity]
+	 * @param {Number} [materialSlot=-1]
+	 * @constructor
+	 */
 	constructor( editor, object = null, attributeName = '', newMinValue = - Infinity, newMaxValue = Infinity, materialSlot = - 1 ) {
 
 		super( editor );

--- a/editor/js/commands/SetMaterialValueCommand.js
+++ b/editor/js/commands/SetMaterialValueCommand.js
@@ -1,14 +1,15 @@
 import { Command } from '../Command.js';
 
-/**
- * @param editor Editor
- * @param object THREE.Object3D
- * @param attributeName string
- * @param newValue number, string, boolean or object
- * @constructor
- */
 class SetMaterialValueCommand extends Command {
 
+	/**
+	 * @param {Editor} editor
+	 * @param {THREE.Object3D|null} [object=null]
+	 * @param {String} [attributeName='']
+	 * @param {Number|String|Boolean|Object|null} [newValue=null]
+	 * @param {Number} [materialSlot=-1]
+	 * @constructor
+	 */
 	constructor( editor, object = null, attributeName = '', newValue = null, materialSlot = - 1 ) {
 
 		super( editor );

--- a/editor/js/commands/SetMaterialVectorCommand.js
+++ b/editor/js/commands/SetMaterialVectorCommand.js
@@ -2,6 +2,15 @@ import { Command } from '../Command.js';
 
 class SetMaterialVectorCommand extends Command {
 
+	/**
+	 *
+	 * @param {Editor} editor
+	 * @param {THREE.Object3D|null} [object=null]
+	 * @param {String} [attributeName='']
+	 * @param {THREE.Vector2|THREE.Vector3|THREE.Vector4|null} [newValue=null]
+	 * @param {Number} [materialSlot=-1]
+	 * @constructor
+	 */
 	constructor( editor, object = null, attributeName = '', newValue = null, materialSlot = - 1 ) {
 
 		super( editor );

--- a/editor/js/commands/SetPositionCommand.js
+++ b/editor/js/commands/SetPositionCommand.js
@@ -1,15 +1,15 @@
 import { Command } from '../Command.js';
 import { Vector3 } from 'three';
 
-/**
- * @param editor Editor
- * @param object THREE.Object3D
- * @param newPosition THREE.Vector3
- * @param optionalOldPosition THREE.Vector3
- * @constructor
- */
 class SetPositionCommand extends Command {
 
+	/**
+	 * @param {Editor} editor
+	 * @param {THREE.Object3D|null} object
+	 * @param {THREE.Vector3|null} newPosition
+	 * @param {THREE.Vector3|null} optionalOldPosition
+	 * @constructor
+	 */
 	constructor( editor, object = null, newPosition = null, optionalOldPosition = null ) {
 
 		super( editor );

--- a/editor/js/commands/SetRotationCommand.js
+++ b/editor/js/commands/SetRotationCommand.js
@@ -1,15 +1,15 @@
 import { Command } from '../Command.js';
 import { Euler } from 'three';
 
-/**
- * @param editor Editor
- * @param object THREE.Object3D
- * @param newRotation THREE.Euler
- * @param optionalOldRotation THREE.Euler
- * @constructor
- */
 class SetRotationCommand extends Command {
 
+	/**
+	 * @param {Editor} editor
+	 * @param {THREE.Object3D|null} object
+	 * @param {THREE.Euler|null} newRotation
+	 * @param {THREE.Euler|null} optionalOldRotation
+	 * @constructor
+	 */
 	constructor( editor, object = null, newRotation = null, optionalOldRotation = null ) {
 
 		super( editor );

--- a/editor/js/commands/SetScaleCommand.js
+++ b/editor/js/commands/SetScaleCommand.js
@@ -1,15 +1,15 @@
 import { Command } from '../Command.js';
 import { Vector3 } from 'three';
 
-/**
- * @param editor Editor
- * @param object THREE.Object3D
- * @param newScale THREE.Vector3
- * @param optionalOldScale THREE.Vector3
- * @constructor
- */
 class SetScaleCommand extends Command {
 
+	/**
+	 * @param {Editor} editor
+	 * @param {THREE.Object3D|null} object
+	 * @param {THREE.Vector3|null} newScale
+	 * @param {THREE.Vector3|null} optionalOldScale
+	 * @constructor
+	 */
 	constructor( editor, object = null, newScale = null, optionalOldScale = null ) {
 
 		super( editor );

--- a/editor/js/commands/SetSceneCommand.js
+++ b/editor/js/commands/SetSceneCommand.js
@@ -3,13 +3,13 @@ import { SetUuidCommand } from './SetUuidCommand.js';
 import { SetValueCommand } from './SetValueCommand.js';
 import { AddObjectCommand } from './AddObjectCommand.js';
 
-/**
- * @param editor Editor
- * @param scene containing children to import
- * @constructor
- */
 class SetSceneCommand extends Command {
 
+	/**
+	 * @param {Editor} editor
+	 * @param {THREE.Scene|null} [scene=null]
+	 * @constructor
+	 */
 	constructor( editor, scene = null ) {
 
 		super( editor );

--- a/editor/js/commands/SetScriptValueCommand.js
+++ b/editor/js/commands/SetScriptValueCommand.js
@@ -1,15 +1,15 @@
 import { Command } from '../Command.js';
 
-/**
- * @param editor Editor
- * @param object THREE.Object3D
- * @param script javascript object
- * @param attributeName string
- * @param newValue string, object
- * @constructor
- */
 class SetScriptValueCommand extends Command {
 
+	/**
+	 * @param {Editor} editor
+	 * @param {THREE.Object3D|null} object
+	 * @param {String} script
+	 * @param {String} attributeName
+	 * @param {String} newValue
+	 * @constructor
+	 */
 	constructor( editor, object = null, script = '', attributeName = '', newValue = null ) {
 
 		super( editor );

--- a/editor/js/commands/SetShadowValueCommand.js
+++ b/editor/js/commands/SetShadowValueCommand.js
@@ -1,14 +1,14 @@
 import { Command } from '../Command.js';
 
-/**
- * @param editor Editor
- * @param object THREE.Object3D
- * @param attributeName string
- * @param newValue number, string, boolean or object
- * @constructor
- */
 class SetShadowValueCommand extends Command {
 
+	/**
+	 * @param {Editor} editor
+	 * @param {THREE.Object3D|null} object
+	 * @param {String} attributeName
+	 * @param {Number|String|Boolean|Object|null} newValue
+	 * @constructor
+	 */
 	constructor( editor, object = null, attributeName = '', newValue = null ) {
 
 		super( editor );

--- a/editor/js/commands/SetUuidCommand.js
+++ b/editor/js/commands/SetUuidCommand.js
@@ -1,13 +1,13 @@
 import { Command } from '../Command.js';
 
-/**
- * @param editor Editor
- * @param object THREE.Object3D
- * @param newUuid string
- * @constructor
- */
 class SetUuidCommand extends Command {
 
+	/**
+	 * @param {Editor} editor
+	 * @param {THREE.Object3D|null} object
+	 * @param {string|null} newUuid
+	 * @constructor
+	 */
 	constructor( editor, object = null, newUuid = null ) {
 
 		super( editor );

--- a/editor/js/commands/SetValueCommand.js
+++ b/editor/js/commands/SetValueCommand.js
@@ -1,14 +1,14 @@
 import { Command } from '../Command.js';
 
-/**
- * @param editor Editor
- * @param object THREE.Object3D
- * @param attributeName string
- * @param newValue number, string, boolean or object
- * @constructor
- */
 class SetValueCommand extends Command {
 
+	/**
+	 * @param {Editor} editor
+	 * @param {THREE.Object3D|null} object
+	 * @param {string} attributeName
+	 * @param {Number|String|Boolean|Object|null} newValue
+	 * @constructor
+	 */
 	constructor( editor, object = null, attributeName = '', newValue = null ) {
 
 		super( editor );

--- a/examples/jsm/controls/ArcballControls.js
+++ b/examples/jsm/controls/ArcballControls.js
@@ -1204,9 +1204,9 @@ class ArcballControls extends Controls {
 
 	/**
 	 * Return the operation associated to a mouse/keyboard combination
-	 * @param {*} mouse A mouse button (0, 1, 2) or 'WHEEL' for wheel notches
-	 * @param {*} key The keyboard modifier ('CTRL', 'SHIFT') or null if key is not needed
-	 * @returns The operation if it has been found, null otherwise
+	 * @param {0|1|2|'WHEEL'} mouse Mouse button index (0, 1, 2) or 'WHEEL' for wheel notches
+	 * @param {'CTRL'|'SHIFT'|null} key Keyboard modifier
+	 * @returns {string|null} The operation if it has been found, null otherwise
 	 */
 	getOpFromAction( mouse, key ) {
 
@@ -1244,9 +1244,9 @@ class ArcballControls extends Controls {
 
 	/**
 	 * Get the operation associated to mouse and key combination and returns the corresponding FSA state
-	 * @param {Number} mouse Mouse button
-	 * @param {String} key Keyboard modifier
-	 * @returns The FSA state obtained from the operation associated to mouse/keyboard combination
+	 * @param {0|1|2} mouse Mouse button index (0, 1, 2)
+	 * @param {'CTRL'|'SHIFT'|null} key Keyboard modifier
+	 * @returns {STATE|null} The FSA state obtained from the operation associated to mouse/keyboard combination
 	 */
 	getOpStateFromAction( mouse, key ) {
 
@@ -1402,10 +1402,12 @@ class ArcballControls extends Controls {
 
 	/**
 	 * Calculate the angular speed
+	 *
 	 * @param {Number} p0 Position at t0
 	 * @param {Number} p1 Position at t1
 	 * @param {Number} t0 Initial time in milliseconds
 	 * @param {Number} t1 Ending time in milliseconds
+	 * @returns {Number}
 	 */
 	calculateAngularSpeed( p0, p1, t0, t1 ) {
 
@@ -1627,8 +1629,9 @@ class ArcballControls extends Controls {
 
 	/**
 	 * Calculate the cursor position in NDC
-	 * @param {number} x Cursor horizontal coordinate within the canvas
-	 * @param {number} y Cursor vertical coordinate within the canvas
+	 *
+	 * @param {number} cursorX Cursor horizontal coordinate within the canvas
+	 * @param {number} cursorY Cursor vertical coordinate within the canvas
 	 * @param {HTMLElement} canvas The canvas where the renderer draws its output
 	 * @returns {Vector2} Cursor normalized position inside the canvas
 	 */
@@ -1643,8 +1646,9 @@ class ArcballControls extends Controls {
 
 	/**
 	 * Calculate the cursor position inside the canvas x/y coordinates with the origin being in the center of the canvas
-	 * @param {Number} x Cursor horizontal coordinate within the canvas
-	 * @param {Number} y Cursor vertical coordinate within the canvas
+	 *
+	 * @param {Number} cursorX Cursor horizontal coordinate within the canvas
+	 * @param {Number} cursorY Cursor vertical coordinate within the canvas
 	 * @param {HTMLElement} canvas The canvas where the renderer draws its output
 	 * @returns {Vector2} Cursor position inside the canvas
 	 */
@@ -1940,9 +1944,11 @@ class ArcballControls extends Controls {
 
 	/**
 	 * Perform pan operation moving camera between two points
+	 *
 	 * @param {Vector3} p0 Initial point
 	 * @param {Vector3} p1 Ending point
-	 * @param {Boolean} adjust If movement should be adjusted considering camera distance (Perspective only)
+	 * @param {Boolean} [adjust=false] If movement should be adjusted considering camera distance (Perspective only)
+	 * @returns {Object}
 	 */
 	pan( p0, p1, adjust = false ) {
 
@@ -2234,8 +2240,9 @@ class ArcballControls extends Controls {
 
 	/**
 	 * Set values in transformation object
-	 * @param {Matrix4} camera Transformation to be applied to the camera
-	 * @param {Matrix4} gizmos Transformation to be applied to gizmos
+	 *
+	 * @param {Matrix4} [camera=null] Transformation to be applied to the camera
+	 * @param {Matrix4} [gizmos=null] Transformation to be applied to gizmos
 	 */
 	setTransformationMatrices( camera = null, gizmos = null ) {
 
@@ -2279,9 +2286,10 @@ class ArcballControls extends Controls {
 
 	/**
 	 * Rotate camera around its direction axis passing by a given point by a given angle
+	 *
 	 * @param {Vector3} point The point where the rotation axis is passing trough
 	 * @param {Number} angle Angle in radians
-	 * @returns The computed transormation matix
+	 * @returns {Object} The computed transformation matrix
 	 */
 	zRotate( point, angle ) {
 
@@ -2313,9 +2321,10 @@ class ArcballControls extends Controls {
 
 	/**
 	 * Unproject the cursor on the 3D object surface
+	 *
 	 * @param {Vector2} cursor Cursor coordinates in NDC
 	 * @param {Camera} camera Virtual camera
-	 * @returns {Vector3} The point of intersection with the model, if exist, null otherwise
+	 * @returns {Vector3|null} The point of intersection with the model, if exist, null otherwise
 	 */
 	unprojectOnObj( cursor, camera ) {
 

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -190,7 +190,8 @@ class GLTFExporter {
 
 	/**
 	 * Parse scenes and generate GLTF output
-	 * @param  {Scene or [THREE.Scenes]} input   Scene or Array of THREE.Scenes
+	 *
+	 * @param  {Scene|THREE.Scenes} input   Scene or Array of THREE.Scenes
 	 * @param  {Function} onDone  Callback on completed
 	 * @param  {Function} onError  Callback on errors
 	 * @param  {Object} options options
@@ -543,9 +544,10 @@ class GLTFWriter {
 
 	/**
 	 * Parse scenes and generate GLTF output
-	 * @param  {Scene or [THREE.Scenes]} input   Scene or Array of THREE.Scenes
-	 * @param  {Function} onDone  Callback on completed
-	 * @param  {Object} options options
+	 *
+	 * @param {Scene|THREE.Scenes} input   Scene or Array of THREE.Scenes
+	 * @param {Function} onDone  Callback on completed
+	 * @param {Object} options options
 	 */
 	async writeAsync( input, onDone, options = {} ) {
 
@@ -709,7 +711,9 @@ class GLTFWriter {
 
 	/**
 	 * Returns ids for buffer attributes.
-	 * @param  {Object} object
+	 *
+	 * @param  {Object} attribute
+	 * @param {boolean} [isRelativeCopy=false]
 	 * @return {Integer}
 	 */
 	getUID( attribute, isRelativeCopy = false ) {
@@ -2262,7 +2266,7 @@ class GLTFWriter {
 
 	/**
 	 * Process Object3D node
-	 * @param  {THREE.Object3D} node Object3D to processNodeAsync
+	 * @param  {THREE.Object3D} object Object3D to processNodeAsync
 	 * @return {Integer} Index of the node in the nodes list
 	 */
 	async processNodeAsync( object ) {
@@ -2370,7 +2374,7 @@ class GLTFWriter {
 
 	/**
 	 * Process Scene
-	 * @param  {Scene} node Scene to process
+	 * @param  {Scene} scene Scene to process
 	 */
 	async processSceneAsync( scene ) {
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -3340,9 +3340,11 @@ class GLTFParser {
 
 	/**
 	 * Asynchronously assigns a texture to the given material parameters.
+	 *
 	 * @param {Object} materialParams
 	 * @param {string} mapName
 	 * @param {Object} mapDef
+	 * @param {string} colorSpace
 	 * @return {Promise<Texture>}
 	 */
 	assignTexture( materialParams, mapName, mapDef, colorSpace ) {

--- a/examples/jsm/loaders/KTXLoader.js
+++ b/examples/jsm/loaders/KTXLoader.js
@@ -46,10 +46,10 @@ const COMPRESSED_2D = 0; // uses a gl.compressedTexImage2D()
 class KhronosTextureContainer {
 
 	/**
-	 * @param {ArrayBuffer} arrayBuffer- contents of the KTX container file
-	 * @param {number} facesExpected- should be either 1 or 6, based whether a cube texture or or
-	 * @param {boolean} threeDExpected- provision for indicating that data should be a 3D texture, not implemented
-	 * @param {boolean} textureArrayExpected- provision for indicating that data should be a texture array, not implemented
+	 * @param {ArrayBuffer} arrayBuffer - contents of the KTX container file
+	 * @param {number} facesExpected - should be either 1 or 6, based whether a cube texture or or
+	 * @param {boolean} threeDExpected - provision for indicating that data should be a 3D texture, not implemented
+	 * @param {boolean} textureArrayExpected - provision for indicating that data should be a texture array, not implemented
 	 */
 	constructor( arrayBuffer, facesExpected /*, threeDExpected, textureArrayExpected */ ) {
 

--- a/examples/jsm/loaders/MTLLoader.js
+++ b/examples/jsm/loaders/MTLLoader.js
@@ -85,6 +85,7 @@ class MTLLoader extends Loader {
 	 * Parses a MTL file.
 	 *
 	 * @param {String} text - Content of MTL file
+	 * @param {String} path
 	 * @return {MaterialCreator}
 	 *
 	 * @see setPath setResourcePath

--- a/examples/jsm/misc/Volume.js
+++ b/examples/jsm/misc/Volume.js
@@ -209,7 +209,8 @@ class Volume {
 	}
 
 	/**
-	 * @member {Function} getData Shortcut for data[access(i,j,k)]
+	 * Shortcut for data[access(i,j,k)]
+	 *
 	 * @memberof Volume
 	 * @param {number} i    First coordinate
 	 * @param {number} j    Second coordinate
@@ -223,7 +224,8 @@ class Volume {
 	}
 
 	/**
-	 * @member {Function} access compute the index in the data array corresponding to the given coordinates in IJK system
+	 * Compute the index in the data array corresponding to the given coordinates in IJK system
+	 *
 	 * @memberof Volume
 	 * @param {number} i    First coordinate
 	 * @param {number} j    Second coordinate
@@ -237,7 +239,8 @@ class Volume {
 	}
 
 	/**
-	 * @member {Function} reverseAccess Retrieve the IJK coordinates of the voxel corresponding of the given index in the data
+	 * Retrieve the IJK coordinates of the voxel corresponding of the given index in the data
+	 *
 	 * @memberof Volume
 	 * @param {number} index index of the voxel
 	 * @returns {Array}  [x,y,z]
@@ -252,7 +255,8 @@ class Volume {
 	}
 
 	/**
-	 * @member {Function} map Apply a function to all the voxels, be careful, the value will be replaced
+	 * Apply a function to all the voxels, be careful, the value will be replaced
+	 *
 	 * @memberof Volume
 	 * @param {Function} functionToMap A function to apply to every voxel, will be called with the following parameters :
 	 *                                 value of the voxel
@@ -277,11 +281,12 @@ class Volume {
 	}
 
 	/**
-	 * @member {Function} extractPerpendicularPlane Compute the orientation of the slice and returns all the information relative to the geometry such as sliceAccess, the plane matrix (orientation and position in RAS coordinate) and the dimensions of the plane in both coordinate system.
+	 * Compute the orientation of the slice and returns all the information relative to the geometry such as sliceAccess, the plane matrix (orientation and position in RAS coordinate) and the dimensions of the plane in both coordinate system.
+	 *
 	 * @memberof Volume
 	 * @param {string}            axis  the normal axis to the slice 'x' 'y' or 'z'
-	 * @param {number}            index the index of the slice
-	 * @returns {Object} an object containing all the usefull information on the geometry of the slice
+	 * @param {number}            RASIndex the index of the slice
+	 * @returns {Object} an object containing all the useful information on the geometry of the slice
 	 */
 	extractPerpendicularPlane( axis, RASIndex ) {
 
@@ -401,8 +406,9 @@ class Volume {
 	}
 
 	/**
-	 * @member {Function} extractSlice Returns a slice corresponding to the given axis and index
-	 *                        The coordinate are given in the Right Anterior Superior coordinate format
+	 * Returns a slice corresponding to the given axis and index.
+	 * The coordinate are given in the Right Anterior Superior coordinate format.
+	 *
 	 * @memberof Volume
 	 * @param {string}            axis  the normal axis to the slice 'x' 'y' or 'z'
 	 * @param {number}            index the index of the slice
@@ -417,7 +423,8 @@ class Volume {
 	}
 
 	/**
-	 * @member {Function} repaintAllSlices Call repaint on all the slices extracted from this volume
+	 * Call repaint on all the slices extracted from this volume
+	 *
 	 * @see VolumeSlice.repaint
 	 * @memberof Volume
 	 * @returns {Volume} this
@@ -435,7 +442,8 @@ class Volume {
 	}
 
 	/**
-	 * @member {Function} computeMinMax Compute the minimum and the maximum of the data in the volume
+	 * Compute the minimum and the maximum of the data in the volume
+	 *
 	 * @memberof Volume
 	 * @returns {Array} [min,max]
 	 */

--- a/examples/jsm/misc/VolumeSlice.js
+++ b/examples/jsm/misc/VolumeSlice.js
@@ -103,7 +103,7 @@ class VolumeSlice {
 	}
 
 	/**
-	 * @member {Function} repaint Refresh the texture and the geometry if geometryNeedsUpdate is set to true
+	 * Refresh the texture and the geometry if geometryNeedsUpdate is set to true
 	 * @memberof VolumeSlice
 	 */
 	repaint() {
@@ -189,7 +189,7 @@ class VolumeSlice {
 	}
 
 	/**
-	 * @member {Function} Refresh the geometry according to axis and index
+	 * Refresh the geometry according to axis and index
 	 * @see Volume.extractPerpendicularPlane
 	 * @memberof VolumeSlice
 	 */

--- a/examples/jsm/modifiers/CurveModifier.js
+++ b/examples/jsm/modifiers/CurveModifier.js
@@ -20,6 +20,7 @@ import {
  * Make a new DataTexture to store the descriptions of the curves.
  *
  * @param { number } numberOfCurves the number of curves needed to be described by this texture.
+ * @returns { DataTexture }
  */
 export function initSplineTexture( numberOfCurves = 1 ) {
 
@@ -93,7 +94,8 @@ function setTextureValue( texture, index, x, y, z, o ) {
 /**
  * Create a new set of uniforms for describing the curve modifier
  *
- * @param { DataTexture } Texture which holds the curve description
+ * @param { DataTexture } splineTexture which holds the curve description
+ * @returns { Object } The uniforms object to be used in the shader
  */
 export function getUniforms( splineTexture ) {
 

--- a/examples/jsm/modifiers/CurveModifierGPU.js
+++ b/examples/jsm/modifiers/CurveModifierGPU.js
@@ -19,7 +19,8 @@ import { modelWorldMatrix, normalLocal, vec2, vec3, vec4, mat3, varyingProperty,
 /**
  * Make a new DataTexture to store the descriptions of the curves.
  *
- * @param { number } numberOfCurves the number of curves needed to be described by this texture.
+ * @param { number } [numberOfCurves=1] the number of curves needed to be described by this texture.
+ * @returns { DataTexture } The new DataTexture
  */
 export function initSplineTexture( numberOfCurves = 1 ) {
 
@@ -94,7 +95,8 @@ function setTextureValue( texture, index, x, y, z, o ) {
 /**
  * Create a new set of uniforms for describing the curve modifier
  *
- * @param { DataTexture } Texture which holds the curve description
+ * @param { DataTexture } splineTexture which holds the curve description
+ * @returns { Object } The uniforms object
  */
 export function getUniforms( splineTexture ) {
 

--- a/examples/jsm/utils/BufferGeometryUtils.js
+++ b/examples/jsm/utils/BufferGeometryUtils.js
@@ -389,7 +389,7 @@ function mergeAttributes( attributes ) {
 }
 
 /**
- * @param {BufferAttribute}
+ * @param {BufferAttribute} attribute
  * @return {BufferAttribute}
  */
 export function deepCloneAttribute( attribute ) {

--- a/examples/jsm/utils/CameraUtils.js
+++ b/examples/jsm/utils/CameraUtils.js
@@ -18,10 +18,13 @@ const _va = /*@__PURE__*/ new Vector3(), // from pe to pa
  * to exactly frame the corners of an arbitrary rectangle.
  * NOTE: This function ignores the standard parameters;
  * do not call updateProjectionMatrix() after this!
+ *
+ * @param {PerspectiveCamera} camera
  * @param {Vector3} bottomLeftCorner
  * @param {Vector3} bottomRightCorner
  * @param {Vector3} topLeftCorner
- * @param {boolean} estimateViewFrustum */
+ * @param {boolean} [estimateViewFrustum=false]
+ */
 function frameCorners( camera, bottomLeftCorner, bottomRightCorner, topLeftCorner, estimateViewFrustum = false ) {
 
 	const pa = bottomLeftCorner, pb = bottomRightCorner, pc = topLeftCorner;

--- a/examples/jsm/utils/GeometryUtils.js
+++ b/examples/jsm/utils/GeometryUtils.js
@@ -7,13 +7,14 @@ import { Vector3 } from 'three';
  * Based on work by:
  * @link http://www.openprocessing.org/sketch/15493
  *
- * @param center     Center of Hilbert curve.
- * @param size       Total width of Hilbert curve.
- * @param iterations Number of subdivisions.
- * @param v0         Corner index -X, -Z.
- * @param v1         Corner index -X, +Z.
- * @param v2         Corner index +X, +Z.
- * @param v3         Corner index +X, -Z.
+ * @param {Vector3} center - Center of Hilbert curve.
+ * @param {number} [size=10] - Total width of Hilbert curve.
+ * @param {number} [iterations=10] - Number of subdivisions.
+ * @param {number} [v0=0] - Corner index -X, -Z.
+ * @param {number} [v1=1] - Corner index -X, +Z.
+ * @param {number} [v2=2] - Corner index +X, +Z.
+ * @param {number} [v3=3] - Corner index +X, -Z.
+ * @returns {Array<Array<number>>} The Hilbert curve points.
  */
 function hilbert2D( center = new Vector3( 0, 0, 0 ), size = 10, iterations = 1, v0 = 0, v1 = 1, v2 = 2, v3 = 3 ) {
 
@@ -56,17 +57,18 @@ function hilbert2D( center = new Vector3( 0, 0, 0 ), size = 10, iterations = 1, 
  * Based on work by:
  * @link https://openprocessing.org/user/5654
  *
- * @param center     Center of Hilbert curve.
- * @param size       Total width of Hilbert curve.
- * @param iterations Number of subdivisions.
- * @param v0         Corner index -X, +Y, -Z.
- * @param v1         Corner index -X, +Y, +Z.
- * @param v2         Corner index -X, -Y, +Z.
- * @param v3         Corner index -X, -Y, -Z.
- * @param v4         Corner index +X, -Y, -Z.
- * @param v5         Corner index +X, -Y, +Z.
- * @param v6         Corner index +X, +Y, +Z.
- * @param v7         Corner index +X, +Y, -Z.
+ * @param {Vector3} [center=new Vector3( 0, 0, 0 )] - Center of Hilbert curve.
+ * @param {number} [size=10] - Total width of Hilbert curve.
+ * @param {number} [iterations=1] - Number of subdivisions.
+ * @param {number} [v0=0] - Corner index -X, +Y, -Z.
+ * @param {number} [v1=1] - Corner index -X, +Y, +Z.
+ * @param {number} [v2=2] - Corner index -X, -Y, +Z.
+ * @param {number} [v3=3] - Corner index -X, -Y, -Z.
+ * @param {number} [v4=4] - Corner index +X, -Y, -Z.
+ * @param {number} [v5=5] - Corner index +X, -Y, +Z.
+ * @param {number} [v6=6] - Corner index +X, +Y, +Z.
+ * @param {number} [v7=7] - Corner index +X, +Y, -Z.
+ * @returns {Array<Array<number>>}  - The Hilbert curve points.
  */
 function hilbert3D( center = new Vector3( 0, 0, 0 ), size = 10, iterations = 1, v0 = 0, v1 = 1, v2 = 2, v3 = 3, v4 = 4, v5 = 5, v6 = 6, v7 = 7 ) {
 
@@ -121,7 +123,8 @@ function hilbert3D( center = new Vector3( 0, 0, 0 ), size = 10, iterations = 1, 
  *
  * https://gist.github.com/nitaku/6521802
  *
- * @param size The size of a single gosper island.
+ * @param {number} [size=1] - The size of a single gosper island.
+ * @return {Array<[number, number, number]>} The gosper island points.
  */
 function gosper( size = 1 ) {
 

--- a/examples/jsm/utils/SceneUtils.js
+++ b/examples/jsm/utils/SceneUtils.js
@@ -174,8 +174,8 @@ function reduceVertices( object, func, initialValue ) {
 }
 
 /**
- * @param {InstancedMesh}
- * @param {function(int, int):int}
+ * @param {InstancedMesh} mesh
+ * @param {function(int, int):int} compareFn
  */
 function sortInstancedMesh( mesh, compareFn ) {
 

--- a/examples/jsm/webxr/XRControllerModelFactory.js
+++ b/examples/jsm/webxr/XRControllerModelFactory.js
@@ -107,7 +107,7 @@ class XRControllerModel extends Object3D {
 
 /**
  * Walks the model's tree to find the nodes needed to animate the components and
- * saves them to the motionContoller components for use in the frame loop. When
+ * saves them to the motionController components for use in the frame loop. When
  * touchpads are found, attaches a touch dot to them.
  */
 function findNodes( motionController, scene ) {

--- a/examples/webgl_loader_texture_dds.html
+++ b/examples/webgl_loader_texture_dds.html
@@ -36,7 +36,7 @@
 			function init() {
 
 				camera = new THREE.PerspectiveCamera( 50, window.innerWidth / window.innerHeight, 1, 100 );
-				camera.position.y = -2;
+				camera.position.y = - 2;
 				camera.position.z = 16;
 
 				scene = new THREE.Scene();
@@ -211,8 +211,8 @@
 				meshes.push( mesh );
 
 				mesh = new THREE.Mesh( geometry, material13 );
-				mesh.position.x = -10;
-				mesh.position.y = -6;
+				mesh.position.x = - 10;
+				mesh.position.y = - 6;
 				scene.add( mesh );
 				meshes.push( mesh );
 


### PR DESCRIPTION
**Description**

As JSdoc syntax is now inspected by eslint, I just fixed some warnings in `addons` and move the doc closer to the constructor in the `editor` having the benefit of type hinting the constructor params and the class attributes at the same time.