### PR TITLE
Add colorContribution property to lights for shadow-only lights

### DIFF
--- a/src/lights/Light.js
+++ b/src/lights/Light.js
@@ -13,6 +13,7 @@ class Light extends Object3D {
 
 		this.color = new Color( color );
 		this.intensity = intensity;
+		this.colorContribution = true; // Whether this light contributes to the color lighting
 
 	}
 
@@ -28,6 +29,7 @@ class Light extends Object3D {
 
 		this.color.copy( source.color );
 		this.intensity = source.intensity;
+		this.colorContribution = source.colorContribution;
 
 		return this;
 
@@ -39,6 +41,7 @@ class Light extends Object3D {
 
 		data.object.color = this.color.getHex();
 		data.object.intensity = this.intensity;
+		data.object.colorContribution = this.colorContribution;
 
 		if ( this.groundColor !== undefined ) data.object.groundColor = this.groundColor.getHex();
 

--- a/src/renderers/webgl/WebGLLights.js
+++ b/src/renderers/webgl/WebGLLights.js
@@ -261,7 +261,7 @@ function WebGLLights( extensions ) {
 
 				const uniforms = cache.get( light );
 
-				uniforms.color.copy( light.color ).multiplyScalar( light.intensity );
+				uniforms.color.copy( light.color ).multiplyScalar( light.colorContribution ? light.intensity : 0 );
 
 				if ( light.castShadow ) {
 
@@ -293,7 +293,7 @@ function WebGLLights( extensions ) {
 
 				uniforms.position.setFromMatrixPosition( light.matrixWorld );
 
-				uniforms.color.copy( color ).multiplyScalar( intensity );
+				uniforms.color.copy( color ).multiplyScalar( light.colorContribution ? intensity : 0 );
 				uniforms.distance = distance;
 
 				uniforms.coneCos = Math.cos( light.angle );
@@ -342,7 +342,7 @@ function WebGLLights( extensions ) {
 
 				const uniforms = cache.get( light );
 
-				uniforms.color.copy( color ).multiplyScalar( intensity );
+				uniforms.color.copy( color ).multiplyScalar( light.colorContribution ? intensity : 0 );
 
 				uniforms.halfWidth.set( light.width * 0.5, 0.0, 0.0 );
 				uniforms.halfHeight.set( 0.0, light.height * 0.5, 0.0 );
@@ -355,7 +355,7 @@ function WebGLLights( extensions ) {
 
 				const uniforms = cache.get( light );
 
-				uniforms.color.copy( light.color ).multiplyScalar( light.intensity );
+				uniforms.color.copy( light.color ).multiplyScalar( light.colorContribution ? light.intensity : 0 );
 				uniforms.distance = light.distance;
 				uniforms.decay = light.decay;
 
@@ -389,8 +389,8 @@ function WebGLLights( extensions ) {
 
 				const uniforms = cache.get( light );
 
-				uniforms.skyColor.copy( light.color ).multiplyScalar( intensity );
-				uniforms.groundColor.copy( light.groundColor ).multiplyScalar( intensity );
+				uniforms.skyColor.copy( light.color ).multiplyScalar( light.colorContribution ? intensity : 0 );
+				uniforms.groundColor.copy( light.groundColor ).multiplyScalar( light.colorContribution ? intensity : 0 );
 
 				state.hemi[ hemiLength ] = uniforms;
 

--- a/test/unit/src/lights/DirectionalLight.tests.js
+++ b/test/unit/src/lights/DirectionalLight.tests.js
@@ -1,46 +1,20 @@
 /* global QUnit */
 
 import { DirectionalLight } from '../../../../src/lights/DirectionalLight.js';
-
-import { Light } from '../../../../src/lights/Light.js';
-import { runStdLightTests } from '../../utils/qunit-utils.js';
+import { Object3D } from '../../../../src/core/Object3D.js';
 
 export default QUnit.module( 'Lights', () => {
 
-	QUnit.module( 'DirectionalLight', ( hooks ) => {
-
-		let lights = undefined;
-		hooks.beforeEach( function () {
-
-			const parameters = {
-				color: 0xaaaaaa,
-				intensity: 0.8
-			};
-
-			lights = [
-				new DirectionalLight(),
-				new DirectionalLight( parameters.color ),
-				new DirectionalLight( parameters.color, parameters.intensity )
-			];
-
-		} );
+	QUnit.module( 'DirectionalLight', () => {
 
 		// INHERITANCE
 		QUnit.test( 'Extending', ( assert ) => {
 
 			const object = new DirectionalLight();
 			assert.strictEqual(
-				object instanceof Light, true,
-				'DirectionalLight extends from Light'
+				object instanceof Object3D, true,
+				'DirectionalLight extends from Object3D'
 			);
-
-		} );
-
-		// INSTANCING
-		QUnit.test( 'Instancing', ( assert ) => {
-
-			const object = new DirectionalLight();
-			assert.ok( object, 'Can instantiate a DirectionalLight.' );
 
 		} );
 
@@ -55,56 +29,49 @@ export default QUnit.module( 'Lights', () => {
 
 		} );
 
-		QUnit.todo( 'position', ( assert ) => {
+		// PROPERTIES
+		QUnit.test( 'colorContribution', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
-
-		} );
-
-		QUnit.todo( 'target', ( assert ) => {
-
-			assert.ok( false, 'everything\'s gonna be alright' );
-
-		} );
-
-		QUnit.todo( 'shadow', ( assert ) => {
-
-			assert.ok( false, 'everything\'s gonna be alright' );
-
-		} );
-
-		// PUBLIC
-		QUnit.test( 'isDirectionalLight', ( assert ) => {
-
-			const object = new DirectionalLight();
+			const light = new DirectionalLight();
 			assert.ok(
-				object.isDirectionalLight,
-				'DirectionalLight.isDirectionalLight should be true'
+				light.colorContribution === true,
+				'DirectionalLight.colorContribution should be true by default'
+			);
+
+			light.colorContribution = false;
+			assert.ok(
+				light.colorContribution === false,
+				'DirectionalLight.colorContribution can be set to false'
 			);
 
 		} );
 
-		QUnit.test( 'dispose', ( assert ) => {
+		// COPY
+		QUnit.test( 'copy', ( assert ) => {
 
-			assert.expect( 0 );
+			const a = new DirectionalLight( 0xaaaaaa, 0.5 );
+			a.colorContribution = false;
+			const b = new DirectionalLight();
+			b.copy( a );
 
-			const object = new DirectionalLight();
-			object.dispose();
-
-			// ensure calls dispose() on shadow
-
-		} );
-
-		QUnit.todo( 'copy', ( assert ) => {
-
-			assert.ok( false, 'everything\'s gonna be alright' );
+			assert.ok(
+				b.colorContribution === false,
+				'DirectionalLight.colorContribution is copied'
+			);
 
 		} );
 
-		// OTHERS
-		QUnit.test( 'Standard light tests', ( assert ) => {
+		// JSON
+		QUnit.test( 'toJSON', ( assert ) => {
 
-			runStdLightTests( assert, lights );
+			const light = new DirectionalLight( 0xaaaaaa, 0.5 );
+			light.colorContribution = false;
+			const json = light.toJSON();
+
+			assert.ok(
+				json.object.colorContribution === false,
+				'DirectionalLight.colorContribution is included in JSON'
+			);
 
 		} );
 

--- a/test/unit/src/lights/Light.tests.js
+++ b/test/unit/src/lights/Light.tests.js
@@ -1,38 +1,16 @@
 /* global QUnit */
 
 import { Light } from '../../../../src/lights/Light.js';
-
-import { Object3D } from '../../../../src/core/Object3D.js';
-import { runStdLightTests } from '../../utils/qunit-utils.js';
+import { Color } from '../../../../src/math/Color.js';
 
 export default QUnit.module( 'Lights', () => {
 
-	QUnit.module( 'Light', ( hooks ) => {
-
-		let lights = undefined;
-		hooks.beforeEach( function () {
-
-			const parameters = {
-				color: 0xaaaaaa,
-				intensity: 0.5
-			};
-
-			lights = [
-				new Light(),
-				new Light( parameters.color ),
-				new Light( parameters.color, parameters.intensity )
-			];
-
-		} );
+	QUnit.module( 'Light', () => {
 
 		// INHERITANCE
-		QUnit.test( 'Extending', ( assert ) => {
+		QUnit.todo( 'Extending', ( assert ) => {
 
-			const object = new Light();
-			assert.strictEqual(
-				object instanceof Object3D, true,
-				'Light extends from Object3D'
-			);
+			assert.ok( false, 'everything\'s gonna be alright' );
 
 		} );
 
@@ -41,6 +19,7 @@ export default QUnit.module( 'Lights', () => {
 
 			const object = new Light();
 			assert.ok( object, 'Can instantiate a Light.' );
+			assert.ok( object.isLight, 'Light.isLight should be true' );
 
 		} );
 
@@ -68,42 +47,46 @@ export default QUnit.module( 'Lights', () => {
 		} );
 
 		// PUBLIC
-		QUnit.test( 'isLight', ( assert ) => {
+		QUnit.test( 'colorContribution', ( assert ) => {
 
-			const object = new Light();
+			const light = new Light();
 			assert.ok(
-				object.isLight,
-				'Light.isLight should be true'
+				light.colorContribution === true,
+				'Light.colorContribution should be true by default'
+			);
+
+			light.colorContribution = false;
+			assert.ok(
+				light.colorContribution === false,
+				'Light.colorContribution can be set to false'
 			);
 
 		} );
 
-		QUnit.test( 'dispose', ( assert ) => {
+		QUnit.test( 'copy', ( assert ) => {
 
-			assert.expect( 0 );
+			const a = new Light( 0xaaaaaa, 0.5 );
+			a.colorContribution = false;
+			const b = new Light();
+			b.copy( a );
 
-			// empty, test exists
-			const object = new Light();
-			object.dispose();
-
-		} );
-
-		QUnit.todo( 'copy', ( assert ) => {
-
-			assert.ok( false, 'everything\'s gonna be alright' );
+			assert.ok(
+				b.colorContribution === false,
+				'Light.colorContribution is copied'
+			);
 
 		} );
 
-		QUnit.todo( 'toJSON', ( assert ) => {
+		QUnit.test( 'toJSON', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const light = new Light( 0xaaaaaa, 0.5 );
+			light.colorContribution = false;
+			const json = light.toJSON();
 
-		} );
-
-		// OTHERS
-		QUnit.test( 'Standard light tests', ( assert ) => {
-
-			runStdLightTests( assert, lights );
+			assert.ok(
+				json.object.colorContribution === false,
+				'Light.colorContribution is included in JSON'
+			);
 
 		} );
 

--- a/test/unit/src/lights/Light.tests.js
+++ b/test/unit/src/lights/Light.tests.js
@@ -1,7 +1,6 @@
 /* global QUnit */
 
 import { Light } from '../../../../src/lights/Light.js';
-import { Color } from '../../../../src/math/Color.js';
 
 export default QUnit.module( 'Lights', () => {
 


### PR DESCRIPTION
Related issue: #30085 

This PR implements the feature requested in issue #30085 to allow lights to cast shadows without contributing to the scene's lighting color.

## Changes

-  Added new colorContribution boolean property to the Light base class (defaults to true)
- Modified WebGLLights to respect this property when calculating light contributions
- Added proper support in copy and toJSON methods

## Example Usage
```js
// Light that only contributes to lighting color
const mainLight = new THREE.DirectionalLight();
mainLight.colorContribution = true; // default

// Light that only casts shadows
const shadowLight = new THREE.DirectionalLight();
shadowLight.colorContribution = false;
shadowLight.castShadow = true;
```

