### PR TITLE
Improve WebXR layers feature testing

### DIFF
--- a/examples/webxr_vr_layers.html
+++ b/examples/webxr_vr_layers.html
@@ -305,7 +305,9 @@
 				const gl = renderer.getContext();
 
 				// Init layers once in immersive mode and video is ready.
-				if ( session && session.renderState.layers === undefined ) {
+				const useLayers = session.enabledFeatures !== undefined && session.enabledFeatures.includes('layers');
+
+				if ( session && ! useLayers ) {
 
 					errorMesh.visible = true;
 
@@ -313,7 +315,7 @@
 
 				if (
 					session &&
-					session.renderState.layers !== undefined &&
+					useLayers &&
 					session.hasMediaLayer === undefined &&
 					video.readyState >= 2
 				) {

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -275,7 +275,9 @@ class WebXRManager extends EventDispatcher {
 				currentPixelRatio = renderer.getPixelRatio();
 				renderer.getSize( currentSize );
 
-				if ( session.renderState.layers === undefined ) {
+				const useLayers = session.enabledFeatures !== undefined && session.enabledFeatures.includes( 'layers' );
+
+				if ( ! useLayers ) {
 
 					const layerInit = {
 						antialias: attributes.antialias,


### PR DESCRIPTION
**Description**

Currently Three.js tests for WebXR layers support by checking to see if the `layers` attribute is present in the `session.renderState` object. This isn't ideal, however.

It's possible that the `layers` attribute may be present but not usable if the session did not request the `'layers'` feature, if they did request it but the browser denied it, or if the browser supports `layers` but the backend being used does not.

A more reliable way to check for `layers` support is to look at the `session.enabledFeatures` list and check to see if it contains the `'layers'` string. If so the the session is confirmed to have layers support and the rest of the code can be used as-is. This PR makes that change to both the layers sample and the WebXRManager.
