### PR TITLE
Docs: Improve `Material` page (en/fr)

### DIFF
--- a/docs/api/en/materials/Material.html
+++ b/docs/api/en/materials/Material.html
@@ -417,7 +417,9 @@
 		<p>
 			An optional callback that is executed immediately before the shader
 			program is compiled. This function is called with the shader source code
-			as a parameter. Useful for the modification of built-in materials.
+			as a parameter. Useful for the modification of built-in materials, but the recommended 
+      approach moving forward is to use [link:https://github.com/mrdoob/three.js/wiki/Three.js-Shading-Language TSL]. 
+      See the before/after example [link:https://github.com/mrdoob/three.js/wiki/Three.js-Shading-Language#example here].
 		</p>
 		<p>
 			Unlike properties, the callback is not supported by [page:Material.clone .clone](), 

--- a/docs/api/en/materials/Material.html
+++ b/docs/api/en/materials/Material.html
@@ -417,9 +417,9 @@
 		<p>
 			An optional callback that is executed immediately before the shader
 			program is compiled. This function is called with the shader source code
-			as a parameter. Useful for the modification of built-in materials, but the recommended 
-      approach moving forward is to use [link:https://github.com/mrdoob/three.js/wiki/Three.js-Shading-Language TSL]. 
-      See the before/after example [link:https://github.com/mrdoob/three.js/wiki/Three.js-Shading-Language#example here].
+			as a parameter. Useful for the modification of built-in materials, but the
+			recommended approach moving forward is to use `WebGPURenderer` with the new
+			Node Material system and [link:https://github.com/mrdoob/three.js/wiki/Three.js-Shading-Language TSL].
 		</p>
 		<p>
 			Unlike properties, the callback is not supported by [page:Material.clone .clone](), 

--- a/docs/api/fr/materials/Material.html
+++ b/docs/api/fr/materials/Material.html
@@ -350,7 +350,9 @@
 		<h3>[method:undefined onBeforeCompile]( [param:Shader shader], [param:WebGLRenderer renderer] )</h3>
 		<p>
 			Un callback facultatif qui est exécuté immédiatement avant la compilation du programme shader.
-			Cette fonction est appelée avec le code source du shader comme paramètre. Utile pour la modification des matériaux intégrés.
+			Cette fonction est appelée avec le code source du shader comme paramètre. Utile pour la modification des matériaux intégrés, 
+      bien que la nouvelle méthode recommandée soit d'utiliser [link:https://github.com/mrdoob/three.js/wiki/Three.js-Shading-Language TSL].
+      Voir l'exemple avant/après [link:https://github.com/mrdoob/three.js/wiki/Three.js-Shading-Language#example ici].
 		</p>
 		<p>
 			Contrairement aux propriétés, le callback n'est pas pris en charge par [page:Material.clone .clone](), [page:Material.copy .copy]() et [page:Material.toJSON .toJSON]().

--- a/docs/api/fr/materials/Material.html
+++ b/docs/api/fr/materials/Material.html
@@ -351,8 +351,8 @@
 		<p>
 			Un callback facultatif qui est exécuté immédiatement avant la compilation du programme shader.
 			Cette fonction est appelée avec le code source du shader comme paramètre. Utile pour la modification des matériaux intégrés, 
-      bien que la nouvelle méthode recommandée soit d'utiliser [link:https://github.com/mrdoob/three.js/wiki/Three.js-Shading-Language TSL].
-      Voir l'exemple avant/après [link:https://github.com/mrdoob/three.js/wiki/Three.js-Shading-Language#example ici].
+			bien que la nouvelle méthode recommandée soit d'utiliser `WebGPURenderer` avec le nouveau système de Node Material et
+			[link:https://github.com/mrdoob/three.js/wiki/Three.js-Shading-Language TSL].
 		</p>
 		<p>
 			Contrairement aux propriétés, le callback n'est pas pris en charge par [page:Material.clone .clone](), [page:Material.copy .copy]() et [page:Material.toJSON .toJSON]().


### PR DESCRIPTION
Related issue: #11475 

**Description**

Add TSL example for the onBeforeCompile method in the Material doc.

Note: `en` and `fr` doc only
