### PR TITLE
TSL: Export `shadowWorldPosition`

### DIFF
--- a/src/nodes/TSL.js
+++ b/src/nodes/TSL.js
@@ -131,6 +131,7 @@ export * from './gpgpu/AtomicFunctionNode.js';
 export * from './accessors/Lights.js';
 export * from './lighting/LightsNode.js';
 export * from './lighting/LightingContextNode.js';
+export * from "./lighting/ShadowBaseNode.js";
 export * from './lighting/ShadowNode.js';
 export * from './lighting/PointLightNode.js';
 

--- a/src/nodes/TSL.js
+++ b/src/nodes/TSL.js
@@ -131,7 +131,7 @@ export * from './gpgpu/AtomicFunctionNode.js';
 export * from './accessors/Lights.js';
 export * from './lighting/LightsNode.js';
 export * from './lighting/LightingContextNode.js';
-export * from "./lighting/ShadowBaseNode.js";
+export * from './lighting/ShadowBaseNode.js';
 export * from './lighting/ShadowNode.js';
 export * from './lighting/PointLightNode.js';
 


### PR DESCRIPTION
Related issue: N/A

**Description**

I think this is missing from https://github.com/mrdoob/three.js/pull/30060 in order to export `shadowWorldPosition` from `Three.TSL.js`?