### PR TITLE
TiledLightsNode: Fix cache-key performance

### DIFF
--- a/examples/jsm/tsl/lighting/TiledLightsNode.js
+++ b/examples/jsm/tsl/lighting/TiledLightsNode.js
@@ -69,30 +69,6 @@ class TiledLightsNode extends LightsNode {
 	}
 
 	/**
-	 * Overwrites the default {@link Node#customCacheKey} implementation by including the
-	 * light IDs into the cache key.
-	 *
-	 * @return {Number} The custom cache key.
-	 */
-	customCacheKey() {
-
-		const lightIDs = [];
-		const lights = this._lights;
-
-		for ( let i = 0; i < lights.length; i ++ ) {
-
-			// There's no need to recreate the shader when adding or removing PointLights in Tiled Lights.
-			if ( lights[ i ].isPointLight === true ) continue;
-
-			lightIDs.push( lights[ i ].id );
-
-		}
-
-		return NodeUtils.hashArray( lightIDs );
-
-	}
-
-	/**
 	 * Optimized method for computing the cache key of the tiled lights.
 	 *
 	 * @param {Boolean} [force=false] - When set to `true`, a recomputation of the cache key is forced.

--- a/examples/jsm/tsl/lighting/TiledLightsNode.js
+++ b/examples/jsm/tsl/lighting/TiledLightsNode.js
@@ -1,4 +1,4 @@
-import { DataTexture, FloatType, RGBAFormat, Vector2, Vector3, LightsNode, NodeUpdateType, NodeUtils } from 'three/webgpu';
+import { DataTexture, FloatType, RGBAFormat, Vector2, Vector3, LightsNode, NodeUpdateType } from 'three/webgpu';
 
 import {
 	attributeArray, nodeProxy, int, float, vec2, ivec2, ivec4, uniform, Break, Loop,

--- a/examples/jsm/tsl/lighting/TiledLightsNode.js
+++ b/examples/jsm/tsl/lighting/TiledLightsNode.js
@@ -52,42 +52,30 @@ class TiledLightsNode extends LightsNode {
 		this.maxLights = maxLights;
 		this.tileSize = tileSize;
 
-		this.bufferSize = null;
-		this.lightIndexes = null;
-		this.screenTileIndex = null;
-		this.compute = null;
-		this.lightsTexture = null;
+		this._bufferSize = null;
+		this._lightIndexes = null;
+		this._screenTileIndex = null;
+		this._compute = null;
+		this._lightsTexture = null;
 
-		this.lightsCount = uniform( 0, 'int' );
-		this.tileLightCount = 8;
-		this.screenSize = uniform( new Vector2() );
-		this.cameraProjectionMatrix = uniform( 'mat4' );
-		this.cameraViewMatrix = uniform( 'mat4' );
+		this._lightsCount = uniform( 0, 'int' );
+		this._tileLightCount = 8;
+		this._screenSize = uniform( new Vector2() );
+		this._cameraProjectionMatrix = uniform( 'mat4' );
+		this._cameraViewMatrix = uniform( 'mat4' );
 
 		this.updateBeforeType = NodeUpdateType.RENDER;
 
 	}
 
-	/**
-	 * Optimized method for computing the cache key of the tiled lights.
-	 *
-	 * @param {Boolean} [force=false] - When set to `true`, a recomputation of the cache key is forced.
-	 * @return {Number} The cache key of the node.
-	 */
-	getCacheKey( force ) {
-
-		return this.customCacheKey() + this.compute.getCacheKey( force );
-
-	}
-
 	updateLightsTexture() {
 
-		const { lightsTexture, tiledLights } = this;
+		const { _lightsTexture: lightsTexture, tiledLights } = this;
 
 		const data = lightsTexture.image.data;
 		const lineSize = lightsTexture.image.width * 4;
 
-		this.lightsCount.value = tiledLights.length;
+		this._lightsCount.value = tiledLights.length;
 
 		for ( let i = 0; i < tiledLights.length; i ++ ) {
 
@@ -125,13 +113,13 @@ class TiledLightsNode extends LightsNode {
 
 		this.updateLightsTexture( camera );
 
-		this.cameraProjectionMatrix.value = camera.projectionMatrix;
-		this.cameraViewMatrix.value = camera.matrixWorldInverse;
+		this._cameraProjectionMatrix.value = camera.projectionMatrix;
+		this._cameraViewMatrix.value = camera.matrixWorldInverse;
 
 		renderer.getDrawingBufferSize( _size );
-		this.screenSize.value.copy( _size );
+		this._screenSize.value.copy( _size );
 
-		renderer.compute( this.compute );
+		renderer.compute( this._compute );
 
 	}
 
@@ -165,7 +153,7 @@ class TiledLightsNode extends LightsNode {
 
 	getBlock( block = 0 ) {
 
-		return this.lightIndexes.element( this.screenTileIndex.mul( int( 2 ).add( int( block ) ) ) );
+		return this._lightIndexes.element( this._screenTileIndex.mul( int( 2 ).add( int( block ) ) ) );
 
 	}
 
@@ -175,9 +163,9 @@ class TiledLightsNode extends LightsNode {
 
 		const stride = int( 4 );
 		const tileOffset = element.div( stride );
-		const tileIndex = this.screenTileIndex.mul( int( 2 ) ).add( tileOffset );
+		const tileIndex = this._screenTileIndex.mul( int( 2 ) ).add( tileOffset );
 
-		return this.lightIndexes.element( tileIndex ).element( element.modInt( stride ) );
+		return this._lightIndexes.element( tileIndex ).element( element.modInt( stride ) );
 
 	}
 
@@ -185,11 +173,11 @@ class TiledLightsNode extends LightsNode {
 
 		index = int( index );
 
-		const dataA = textureLoad( this.lightsTexture, ivec2( index, 0 ) );
-		const dataB = textureLoad( this.lightsTexture, ivec2( index, 1 ) );
+		const dataA = textureLoad( this._lightsTexture, ivec2( index, 0 ) );
+		const dataB = textureLoad( this._lightsTexture, ivec2( index, 1 ) );
 
 		const position = dataA.xyz;
-		const viewPosition = this.cameraViewMatrix.mul( position );
+		const viewPosition = this._cameraViewMatrix.mul( position );
 		const distance = dataA.w;
 		const color = dataB.rgb;
 		const decay = dataB.w;
@@ -220,7 +208,7 @@ class TiledLightsNode extends LightsNode {
 
 		Fn( () => {
 
-			Loop( this.tileLightCount, ( { i } ) => {
+			Loop( this._tileLightCount, ( { i } ) => {
 
 				const lightIndex = this.getTile( i );
 
@@ -258,7 +246,7 @@ class TiledLightsNode extends LightsNode {
 		width = this.getBufferFitSize( width );
 		height = this.getBufferFitSize( height );
 
-		if ( ! this.bufferSize || this.bufferSize.width !== width || this.bufferSize.height !== height ) {
+		if ( ! this._bufferSize || this._bufferSize.width !== width || this._bufferSize.height !== height ) {
 
 			this.create( width, height );
 
@@ -275,11 +263,11 @@ class TiledLightsNode extends LightsNode {
 		const width = this.getBufferFitSize( _size.width );
 		const height = this.getBufferFitSize( _size.height );
 
-		if ( this.bufferSize === null ) {
+		if ( this._bufferSize === null ) {
 
 			this.create( width, height );
 
-		} else if ( this.bufferSize.width !== width || this.bufferSize.height !== height ) {
+		} else if ( this._bufferSize.width !== width || this._bufferSize.height !== height ) {
 
 			this.create( width, height );
 
@@ -327,7 +315,7 @@ class TiledLightsNode extends LightsNode {
 
 		const compute = Fn( () => {
 
-			const { cameraProjectionMatrix, bufferSize, screenSize } = this;
+			const { _cameraProjectionMatrix: cameraProjectionMatrix, _bufferSize: bufferSize, _screenSize: screenSize } = this;
 
 			const tiledBufferSize = bufferSize.clone().divideScalar( tileSize ).floor();
 
@@ -347,7 +335,7 @@ class TiledLightsNode extends LightsNode {
 
 			Loop( this.maxLights, ( { i } ) => {
 
-				If( index.greaterThanEqual( this.tileLightCount ).or( int( i ).greaterThanEqual( int( this.lightsCount ) ) ), () => {
+				If( index.greaterThanEqual( this._tileLightCount ).or( int( i ).greaterThanEqual( int( this._lightsCount ) ) ), () => {
 
 					Return();
 
@@ -380,11 +368,11 @@ class TiledLightsNode extends LightsNode {
 
 		// assigns
 
-		this.bufferSize = bufferSize;
-		this.lightIndexes = lightIndexes;
-		this.screenTileIndex = screenTileIndex;
-		this.compute = compute;
-		this.lightsTexture = lightsTexture;
+		this._bufferSize = bufferSize;
+		this._lightIndexes = lightIndexes;
+		this._screenTileIndex = screenTileIndex;
+		this._compute = compute;
+		this._lightsTexture = lightsTexture;
 
 	}
 

--- a/examples/jsm/tsl/lighting/TiledLightsNode.js
+++ b/examples/jsm/tsl/lighting/TiledLightsNode.js
@@ -68,6 +68,12 @@ class TiledLightsNode extends LightsNode {
 
 	}
 
+	customCacheKey() {
+
+		return this._compute.getCacheKey() + super.customCacheKey();
+
+	}
+
 	updateLightsTexture() {
 
 		const { _lightsTexture: lightsTexture, tiledLights } = this;

--- a/examples/jsm/tsl/lighting/TiledLightsNode.js
+++ b/examples/jsm/tsl/lighting/TiledLightsNode.js
@@ -1,4 +1,4 @@
-import { DataTexture, FloatType, RGBAFormat, Vector2, Vector3, LightsNode, NodeUpdateType } from 'three/webgpu';
+import { DataTexture, FloatType, RGBAFormat, Vector2, Vector3, LightsNode, NodeUpdateType, NodeUtils } from 'three/webgpu';
 
 import {
 	attributeArray, nodeProxy, int, float, vec2, ivec2, ivec4, uniform, Break, Loop,
@@ -65,6 +65,42 @@ class TiledLightsNode extends LightsNode {
 		this.cameraViewMatrix = uniform( 'mat4' );
 
 		this.updateBeforeType = NodeUpdateType.RENDER;
+
+	}
+
+	/**
+	 * Overwrites the default {@link Node#customCacheKey} implementation by including the
+	 * light IDs into the cache key.
+	 *
+	 * @return {Number} The custom cache key.
+	 */
+	customCacheKey() {
+
+		const lightIDs = [];
+		const lights = this._lights;
+
+		for ( let i = 0; i < lights.length; i ++ ) {
+
+			// There's no need to recreate the shader when adding or removing PointLights in Tiled Lights.
+			if ( lights[ i ].isPointLight === true ) continue;
+
+			lightIDs.push( lights[ i ].id );
+
+		}
+
+		return NodeUtils.hashArray( lightIDs );
+
+	}
+
+	/**
+	 * Optimized method for computing the cache key of the tiled lights.
+	 *
+	 * @param {Boolean} [force=false] - When set to `true`, a recomputation of the cache key is forced.
+	 * @return {Number} The cache key of the node.
+	 */
+	getCacheKey( force ) {
+
+		return this.customCacheKey() + this.compute.getCacheKey( force );
 
 	}
 

--- a/examples/webgpu_lights_tiled.html
+++ b/examples/webgpu_lights_tiled.html
@@ -26,7 +26,7 @@
 		<script type="module">
 
 			import * as THREE from 'three';
-			import { texture, uv, pass, uniform } from 'three/tsl';
+			import { texture, uv, pass, normalMap, uniform } from 'three/tsl';
 			import { bloom } from 'three/addons/tsl/display/BloomNode.js';
 
 			import { TiledLighting } from 'three/addons/lighting/TiledLighting.js';
@@ -122,10 +122,12 @@
 				floorNormal.wrapS = THREE.RepeatWrapping;
 				floorNormal.wrapT = THREE.RepeatWrapping;
 
+				const uvTile = uv().mul( 50 );
+
 				const planeGeometry = new THREE.PlaneGeometry( 1000, 1000 );
 				const planeMaterial = new THREE.MeshPhongNodeMaterial( {
-					colorNode: texture( floorColor, uv().mul( 50 ) ),
-					normalMap: floorNormal
+					colorNode: texture( floorColor, uvTile ),
+					normalNode: normalMap( texture( floorNormal, uvTile ) ),
 				} );
 
 				const ground = new THREE.Mesh( planeGeometry, planeMaterial );

--- a/src/nodes/lighting/LightsNode.js
+++ b/src/nodes/lighting/LightsNode.js
@@ -117,6 +117,7 @@ class LightsNode extends Node {
 	customCacheKey() {
 
 		const lightIDs = [];
+		const lights = this._lights;
 
 		for ( let i = 0; i < lights.length; i ++ ) {
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/30062

**Description**

Improve cache-key performance by removing PointLights cache-key:
There's no need to recreate the shader when adding or removing PointLights in Tiled Lights.

- [x] [LightsNode: Fix lights property reference](https://github.com/mrdoob/three.js/commit/9b9fdad5be2f39aa8735f97aa3ced20b795edab9)
- [x] [`webgpu_lights_tiled`: Fix normal map tiles](https://github.com/mrdoob/three.js/commit/feb3ff6013e9e74d7398e0d16196242ac8730398)