### PR TITLE
WebGPURenderer: Fix getArrayBufferAsync in WebGPUBackend

### DIFF
--- a/examples/webgpu_compute_audio.html
+++ b/examples/webgpu_compute_audio.html
@@ -35,7 +35,7 @@
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 
 			let camera, scene, renderer;
-			let computeNode, computeShaderFn;
+			let computeNode, computeResetNode;
 			let waveBuffer, sampleRate;
 			let waveArray, originalWaveBuffer;
 			let currentAudio, currentAnalyser;
@@ -49,14 +49,7 @@
 
 				if ( currentAudio ) currentAudio.stop();
 
-				// Reset the wave buffer to original state before computing
-				waveBuffer.set( originalWaveBuffer );
-				waveArray = instancedArray( waveBuffer );
-				waveArray.setPBO( true );
-
-				// Recreate compute node with reset buffer
-				computeNode = computeShaderFn().compute( waveBuffer.length );
-
+				await renderer.computeAsync( computeResetNode );
 				// compute audio
 				await renderer.computeAsync( computeNode );
 				const wave = new Float32Array( await renderer.getArrayBufferAsync( waveArray.value ) );
@@ -107,6 +100,7 @@
 				// create webgpu buffers
 
 				waveArray = instancedArray( waveBuffer );
+				const originalWave = instancedArray( originalWaveBuffer ).toReadOnly();
 
 				// The Pixel Buffer Object (PBO) is required to get the GPU computed data to the CPU in the WebGL2 fallback.
 				// As used in `renderer.getArrayBufferAsync( waveArray.value )`.
@@ -120,10 +114,13 @@
 				const delayOffset = uniform( .55 );
 
 
-				// compute (shader-node)
+				// compute
 
-				computeShaderFn = Fn( () => {
+				computeNode = Fn( () => {
 
+					//  reset wave buffer
+
+			
 					const index = float( instanceIndex );
 
 					// pitch
@@ -151,12 +148,18 @@
 
 					waveStorageElementNode.assign( wave );
 
-				} );
+				} )().compute( waveBuffer.length );
 
+				computeResetNode = Fn( () => {
 
-				// compute
+					const index = float( instanceIndex );
 
-				computeNode = computeShaderFn().compute( waveBuffer.length );
+					const waveStorageElementNode = waveArray.element( index );
+
+					waveStorageElementNode.assign( originalWave.element( index ) );
+
+				} )().compute( waveBuffer.length );
+
 
 
 				// gui

--- a/examples/webgpu_compute_audio.html
+++ b/examples/webgpu_compute_audio.html
@@ -35,9 +35,9 @@
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 
 			let camera, scene, renderer;
-			let computeNode;
+			let computeNode, computeShaderFn;
 			let waveBuffer, sampleRate;
-			let waveArray;
+			let waveArray, originalWaveBuffer;
 			let currentAudio, currentAnalyser;
 			const analyserBuffer = new Uint8Array( 1024 );
 			let analyserTexture;
@@ -49,10 +49,16 @@
 
 				if ( currentAudio ) currentAudio.stop();
 
+				// Reset the wave buffer to original state before computing
+				waveBuffer.set( originalWaveBuffer );
+				waveArray = instancedArray( waveBuffer );
+				waveArray.setPBO( true );
+
+				// Recreate compute node with reset buffer
+				computeNode = computeShaderFn().compute( waveBuffer.length );
+
 				// compute audio
-
 				await renderer.computeAsync( computeNode );
-
 				const wave = new Float32Array( await renderer.getArrayBufferAsync( waveArray.value ) );
 
 				// play result
@@ -94,7 +100,8 @@
 
 				// adding extra silence to delay and pitch
 				waveBuffer = new Float32Array( [ ...waveBuffer, ...new Float32Array( 200000 ) ] );
-
+				originalWaveBuffer = waveBuffer.slice();
+			
 				sampleRate = audioBuffer.sampleRate / audioBuffer.numberOfChannels;
 
 				// create webgpu buffers
@@ -115,7 +122,7 @@
 
 				// compute (shader-node)
 
-				const computeShaderFn = Fn( () => {
+				computeShaderFn = Fn( () => {
 
 					const index = float( instanceIndex );
 
@@ -194,6 +201,9 @@
 
 				playAudioBuffer();
 
+				// on click replay
+				renderer.domElement.addEventListener( 'click', playAudioBuffer );
+			
 			}
 
 			function onWindowResize() {

--- a/examples/webgpu_compute_audio.html
+++ b/examples/webgpu_compute_audio.html
@@ -118,9 +118,6 @@
 
 				computeNode = Fn( () => {
 
-					//  reset wave buffer
-
-			
 					const index = float( instanceIndex );
 
 					// pitch
@@ -152,11 +149,7 @@
 
 				computeResetNode = Fn( () => {
 
-					const index = float( instanceIndex );
-
-					const waveStorageElementNode = waveArray.element( index );
-
-					waveStorageElementNode.assign( originalWave.element( index ) );
+					waveArray.element( instanceIndex ).assign( originalWave.element( instanceIndex ) );
 
 				} )().compute( waveBuffer.length );
 

--- a/src/renderers/webgpu/utils/WebGPUAttributeUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUAttributeUtils.js
@@ -261,7 +261,6 @@ class WebGPUAttributeUtils {
 
 		return dstBuffer.buffer;
 
-
 	}
 
 	_getVertexFormat( geometryAttribute ) {


### PR DESCRIPTION
**Description**

Fix GPU buffer readback by correctly sequencing map/unmap operations. It was necessary to create a detached copy of mapped data before unmapping to ensure buffer data remains accessible after the GPU operation completes.
There is no need to update the WebGLBackend as it was already properly returning a detached typed array.

I also noticed the audio example wasn't working anymore in production (related https://github.com/mrdoob/three.js/pull/29972), so I fixed it.

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Utsubo](https://utsubo.com)*
