### PR TITLE
FatLine: Add Arrow Rendering Support to webgl and webgpu

### DIFF
--- a/examples/jsm/lines/LineSegments2.js
+++ b/examples/jsm/lines/LineSegments2.js
@@ -2,6 +2,8 @@ import {
 	Box3,
 	InstancedInterleavedBuffer,
 	InterleavedBufferAttribute,
+	Float32BufferAttribute,
+	Uint16BufferAttribute,
 	Line3,
 	MathUtils,
 	Matrix4,
@@ -260,6 +262,42 @@ class LineSegments2 extends Mesh {
 
 		geometry.setAttribute( 'instanceDistanceStart', new InterleavedBufferAttribute( instanceDistanceBuffer, 1, 0 ) ); // d0
 		geometry.setAttribute( 'instanceDistanceEnd', new InterleavedBufferAttribute( instanceDistanceBuffer, 1, 1 ) ); // d1
+
+		return this;
+
+	}
+
+	computeArrow( ) {
+
+		const geometry = this.geometry;
+		const material = this.material;
+
+		const positionArray = geometry.getAttribute( 'position' ).array;
+		const uvArray = geometry.getAttribute( 'uv' ).array;
+		const indexArray = geometry.getIndex().array;
+
+		const positionCount = positionArray.length / 3;
+
+		// arrow vertex coordinates
+		const newPositions = [ 0, 2.0, 0, - 0.1, 1.8, 0, 0, 1.9, 0, 0.1, 1.8, 0 ];
+
+		const newUvs = [ 0, 2.0, 0.1, 1.6, 0, 1.8, - 0.1, 1.6 ];
+
+		const newIndices = [
+			positionCount, positionCount + 1, positionCount + 2,
+			positionCount + 2, positionCount + 3, positionCount
+		];
+
+		const updatedPositions = new Float32Array( [ ...positionArray, ...newPositions ] );
+		const updatedUvs = new Float32Array( [ ...uvArray, ...newUvs ] );
+		const updatedIndices = new Uint16Array( [ ...indexArray, ...newIndices ] );
+
+		geometry.setIndex( new Uint16BufferAttribute( updatedIndices, 1 ) );
+		geometry.setAttribute( 'position', new Float32BufferAttribute( updatedPositions, 3 ) );
+		geometry.setAttribute( 'uv', new Float32BufferAttribute( updatedUvs, 2 ) );
+
+		// start and end of arrow vertex Id use in shader
+		material.arrowVertexId = [ positionCount, positionCount + 3 ];
 
 		return this;
 

--- a/examples/jsm/lines/webgpu/LineSegments2.js
+++ b/examples/jsm/lines/webgpu/LineSegments2.js
@@ -2,6 +2,8 @@ import {
 	Box3,
 	InstancedInterleavedBuffer,
 	InterleavedBufferAttribute,
+	Float32BufferAttribute,
+	Uint16BufferAttribute,
 	Line3,
 	MathUtils,
 	Matrix4,
@@ -261,6 +263,42 @@ class LineSegments2 extends Mesh {
 
 		geometry.setAttribute( 'instanceDistanceStart', new InterleavedBufferAttribute( instanceDistanceBuffer, 1, 0 ) ); // d0
 		geometry.setAttribute( 'instanceDistanceEnd', new InterleavedBufferAttribute( instanceDistanceBuffer, 1, 1 ) ); // d1
+
+		return this;
+
+	}
+
+	computeArrow( ) {
+
+		const geometry = this.geometry;
+		const material = this.material;
+
+		const positionArray = geometry.getAttribute( 'position' ).array;
+		const uvArray = geometry.getAttribute( 'uv' ).array;
+		const indexArray = geometry.getIndex().array;
+
+		const positionCount = positionArray.length / 3;
+
+		// arrow vertex coordinates
+		const newPositions = [ 0, 2.0, 0, - 0.1, 1.8, 0, 0, 1.9, 0, 0.1, 1.8, 0 ];
+
+		const newUvs = [ 0, 2.0, 0.1, 1.6, 0, 1.8, - 0.1, 1.6 ];
+
+		const newIndices = [
+			positionCount, positionCount + 1, positionCount + 2,
+			positionCount + 2, positionCount + 3, positionCount
+		];
+
+		const updatedPositions = new Float32Array( [ ...positionArray, ...newPositions ] );
+		const updatedUvs = new Float32Array( [ ...uvArray, ...newUvs ] );
+		const updatedIndices = new Uint16Array( [ ...indexArray, ...newIndices ] );
+
+		geometry.setIndex( new Uint16BufferAttribute( updatedIndices, 1 ) );
+		geometry.setAttribute( 'position', new Float32BufferAttribute( updatedPositions, 3 ) );
+		geometry.setAttribute( 'uv', new Float32BufferAttribute( updatedUvs, 2 ) );
+
+		// start and end of arrow vertex Id use in shader
+		material.arrowVertexId = [ positionCount, positionCount + 3 ];
 
 		return this;
 

--- a/examples/webgl_lines_fat.html
+++ b/examples/webgl_lines_fat.html
@@ -110,10 +110,16 @@
 
 					dashed: false,
 					alphaToCoverage: true,
+			
+					arrow: false,
+					arrowSize: 1,
+					arrowStep: 1,
+					arrowReverse: false,
 
 				} );
 
 				line = new Line2( geometry, matLine );
+				line.computeArrow(); // compute arrow positions index uvs etc
 				line.computeLineDistances();
 				line.scale.set( 1, 1, 1 );
 				scene.add( line );
@@ -209,7 +215,11 @@
 					'alphaToCoverage': true,
 					'dashed': false,
 					'dash scale': 1,
-					'dash / gap': 1
+					'dash / gap': 1,
+					'arrow': false,
+					'arrow step': 1,
+					'arrow size': 1,
+					'arrow reverse': false,
 				};
 
 				gui.add( param, 'line type', { 'LineGeometry': 0, 'gl.LINE': 1 } ).onChange( function ( val ) {
@@ -299,6 +309,34 @@
 							break;
 
 					}
+
+				} );
+
+				gui.add( param, 'arrow' ).onChange( function ( val ) {
+
+					matLine.arrow = val;
+					matLine.needsUpdate = true;
+
+				} );
+
+				gui.add( param, 'arrow step', 1, 10, 1 ).onChange( function ( val ) {
+
+					matLine.arrowStep = val;
+					matLine.needsUpdate = true;
+
+				} );
+
+				gui.add( param, 'arrow size', 0.5, 3, 0.1 ).onChange( function ( val ) {
+
+					matLine.arrowSize = val;
+					matLine.needsUpdate = true;
+
+				} );
+
+				gui.add( param, 'arrow reverse' ).onChange( function ( val ) {
+
+					matLine.arrowReverse = val;
+					matLine.needsUpdate = true;
 
 				} );
 

--- a/examples/webgpu_lines_fat.html
+++ b/examples/webgpu_lines_fat.html
@@ -112,9 +112,15 @@
 					dashed: false,
 					alphaToCoverage: true,
 
+					arrow: false,
+					arrowSize: 1,
+					arrowStep: 1,
+					arrowReverse: false,
+
 				} );
 
 				line = new Line2( geometry, matLine );
+				line.computeArrow();
 				line.computeLineDistances();
 				line.scale.set( 1, 1, 1 );
 				scene.add( line );
@@ -213,7 +219,11 @@
 					'dashed': false,
 					'dash offset': 0,
 					'dash scale': 1,
-					'dash / gap': 1
+					'dash / gap': 1,
+					'arrow': false,
+					'arrow step': 1,
+					'arrow size': 1,
+					'arrow reverse': false,
 				};
 
 				gui.add( param, 'line type', { 'LineGeometry': 0, '"line-strip"': 1 } ).onChange( function ( val ) {
@@ -310,6 +320,34 @@
 							break;
 
 					}
+
+				} );
+
+				gui.add( param, 'arrow' ).onChange( function ( val ) {
+
+					matLine.arrow = val;
+					matLine.needsUpdate = true;
+
+				} );
+
+				gui.add( param, 'arrow step', 1, 10, 1 ).onChange( function ( val ) {
+
+					matLine.arrowStep = val;
+					matLine.needsUpdate = true;
+
+				} );
+
+				gui.add( param, 'arrow size', 0.5, 3, 0.1 ).onChange( function ( val ) {
+
+					matLine.arrowSize = val;
+					matLine.needsUpdate = true;
+
+				} );
+
+				gui.add( param, 'arrow reverse' ).onChange( function ( val ) {
+
+					matLine.arrowReverse = val;
+					matLine.needsUpdate = true;
 
 				} );
 


### PR DESCRIPTION
## Summary
This PR extends the functionality of `LineSegmentGeometry` and `LineMaterial` in Three.js to support arrow rendering directly on fat lines. By adding customizable options to `LineMaterial`, users can now configure arrow properties for lines without needing additional geometries or meshes.

## New Options in `LineMaterial`
- **`arrow` (boolean)**: Enables or disables arrow rendering on lines. Default: `false`.
- **`arrowSize` (number)**: Defines the size of the arrows. Default: `1`.
- **`arrowStep` (number)**: Sets the interval between arrows along the line. Default: `1`.
- **`arrowReverse` (boolean)**: Reverses the direction of the arrows. Default: `false`.

The arrows are positioned between consecutive vertices along the line and are rendered using the existing line geometry and material properties.

## Motivation
Rendering arrows for large datasets using `InstancedMesh` or separate arrow geometries often leads to performance and memory issues. By integrating arrow rendering into `LineSegmentGeometry` and `LineMaterial`, we solve the following problems:

1. **Performance Optimization**: Reduces the need to render a separate arrow mesh for each line, which can be computationally expensive for large datasets.
2. **Memory Efficiency**: Avoids the memory overhead of managing additional arrow meshes for every line segment.
3. **Simplified Codebase**: Eliminates the need to synchronize arrow meshes with their corresponding lines, especially during visibility or state changes.
4. **Consistent Styling**: Arrows inherit line attributes such as width, color, and opacity, ensuring a unified appearance without extra effort.

## Arrow Rendering Demonstration on Fat Lines
<img width="1350" alt="Clipboard_Screenshot_1734423122" src="https://github.com/user-attachments/assets/d67c322b-f70a-484d-9060-6f789d6b3df1" />

## Example Usage
```javascript
const lineMaterial = new LineMaterial({
    color: 0xff0000,
    linewidth: 5,
    arrow: true,
    arrowSize: 2,
    arrowStep: 10,
    arrowReverse: false,
});
line = new Line2( geometry, matLine );
line.computeArrow();  
```
## world units
Since I am not very experienced with vertex shaders, I utilized a simple approach to implement arrows in world units. The arrow size is scaled by a factor of `20` to achieve consistent visual proportions.

