### PR TITLE
TSL: Vertex shader revision 2

### DIFF
--- a/src/materials/nodes/NodeMaterial.js
+++ b/src/materials/nodes/NodeMaterial.js
@@ -19,7 +19,7 @@ import AONode from '../../nodes/lighting/AONode.js';
 import { lightingContext } from '../../nodes/lighting/LightingContextNode.js';
 import IrradianceNode from '../../nodes/lighting/IrradianceNode.js';
 import { depth, viewZToLogarithmicDepth, viewZToOrthographicDepth } from '../../nodes/display/ViewportDepthNode.js';
-import { cameraFar, cameraNear } from '../../nodes/accessors/Camera.js';
+import { cameraFar, cameraNear, cameraProjectionMatrix } from '../../nodes/accessors/Camera.js';
 import { clipping, clippingAlpha, hardwareClipping } from '../../nodes/accessors/ClippingNode.js';
 import NodeMaterialObserver from './manager/NodeMaterialObserver.js';
 import getAlphaHashThreshold from '../../nodes/functions/material/getAlphaHashThreshold.js';
@@ -102,6 +102,7 @@ class NodeMaterial extends Material {
 
 		builder.context.setupNormal = () => this.setupNormal( builder );
 		builder.context.setupPositionView = () => this.setupPositionView( builder );
+		builder.context.setupModelViewProjection = () => this.setupModelViewProjection( builder );
 
 		const renderer = builder.renderer;
 		const renderTarget = renderer.getRenderTarget();
@@ -314,6 +315,12 @@ class NodeMaterial extends Material {
 	setupPositionView() {
 
 		return modelViewMatrix.mul( positionLocal ).xyz;
+
+	}
+
+	setupModelViewProjection() {
+
+		return cameraProjectionMatrix.mul( positionView );
 
 	}
 

--- a/src/materials/nodes/SpriteNodeMaterial.js
+++ b/src/materials/nodes/SpriteNodeMaterial.js
@@ -2,7 +2,7 @@ import NodeMaterial from './NodeMaterial.js';
 import { cameraProjectionMatrix } from '../../nodes/accessors/Camera.js';
 import { materialRotation } from '../../nodes/accessors/MaterialNode.js';
 import { modelViewMatrix, modelWorldMatrix } from '../../nodes/accessors/ModelNode.js';
-import { positionGeometry, positionLocal } from '../../nodes/accessors/Position.js';
+import { positionGeometry } from '../../nodes/accessors/Position.js';
 import { rotate } from '../../nodes/utils/RotateNode.js';
 import { float, vec2, vec3, vec4 } from '../../nodes/tsl/TSLBase.js';
 

--- a/src/materials/nodes/SpriteNodeMaterial.js
+++ b/src/materials/nodes/SpriteNodeMaterial.js
@@ -4,7 +4,7 @@ import { materialRotation } from '../../nodes/accessors/MaterialNode.js';
 import { modelViewMatrix, modelWorldMatrix } from '../../nodes/accessors/ModelNode.js';
 import { positionGeometry, positionLocal } from '../../nodes/accessors/Position.js';
 import { rotate } from '../../nodes/utils/RotateNode.js';
-import { float, vec2, vec4 } from '../../nodes/tsl/TSLBase.js';
+import { float, vec2, vec3, vec4 } from '../../nodes/tsl/TSLBase.js';
 
 import { SpriteMaterial } from '../SpriteMaterial.js';
 import { reference } from '../../nodes/accessors/ReferenceBaseNode.js';
@@ -46,9 +46,9 @@ class SpriteNodeMaterial extends NodeMaterial {
 
 		// < VERTEX STAGE >
 
-		const { rotationNode, scaleNode } = this;
+		const { positionNode, rotationNode, scaleNode } = this;
 
-		const mvPosition = modelViewMatrix.mul( positionLocal );
+		const mvPosition = modelViewMatrix.mul( vec3( positionNode || 0 ) );
 
 		let scale = vec2( modelWorldMatrix[ 0 ].xyz.length(), modelWorldMatrix[ 1 ].xyz.length() );
 
@@ -57,7 +57,6 @@ class SpriteNodeMaterial extends NodeMaterial {
 			scale = scale.mul( scaleNode );
 
 		}
-
 
 		if ( ! sizeAttenuation ) {
 

--- a/src/nodes/accessors/ModelViewProjectionNode.js
+++ b/src/nodes/accessors/ModelViewProjectionNode.js
@@ -1,11 +1,14 @@
-import { cameraProjectionMatrix } from './Camera.js';
-import { positionView } from './Position.js';
+import { Fn } from '../tsl/TSLCore.js';
 
 /** @module ModelViewProjectionNode **/
 
 /**
  * TSL object that represents the position in clip space after the model-view-projection transform of the current rendered object.
  *
- * @type {VaryingNode<vec3>}
+ * @type {VaryingNode<vec4>}
  */
-export const modelViewProjection = /*@__PURE__*/ cameraProjectionMatrix.mul( positionView ).varying( 'v_modelViewProjection' );
+export const modelViewProjection = /*@__PURE__*/ ( Fn( ( builder ) => {
+
+	return builder.context.setupModelViewProjection();
+
+}, 'vec4' ).once() )().varying( 'v_modelViewProjection' );


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/30108

**Description**

Add a `setupModelViewProjection()` interface to allow extended materials to manipulate the MVP if needed.