### PR TITLE
SkinningNode: Fix `previousBoneMatrices`

### DIFF
--- a/src/nodes/accessors/SkinningNode.js
+++ b/src/nodes/accessors/SkinningNode.js
@@ -218,7 +218,7 @@ class SkinningNode extends Node {
 
 		const mrt = builder.renderer.getMRT();
 
-		return mrt && mrt.has( 'velocity' );
+		return ( mrt && mrt.has( 'velocity' ) ) || builder.object.userData.useVelocity === true;
 
 	}
 

--- a/src/nodes/lighting/ShadowNode.js
+++ b/src/nodes/lighting/ShadowNode.js
@@ -662,11 +662,20 @@ class ShadowNode extends ShadowBaseNode {
 		const currentRenderObjectFunction = renderer.getRenderObjectFunction();
 		const currentMRT = renderer.getMRT();
 
+		const useVelocity = currentMRT.has( 'velocity' );
+
 		renderer.setMRT( null );
 
 		renderer.setRenderObjectFunction( ( object, scene, _camera, geometry, material, group, ...params ) => {
 
 			if ( object.castShadow === true || ( object.receiveShadow && shadowType === VSMShadowMap ) ) {
+
+				if ( useVelocity ) {
+
+					object.userData = object.userData || {};
+					object.userData.useVelocity = true;
+
+				}
 
 				object.onBeforeShadow( renderer, object, camera, shadow.camera, geometry, scene.overrideMaterial, group );
 

--- a/src/nodes/lighting/ShadowNode.js
+++ b/src/nodes/lighting/ShadowNode.js
@@ -662,7 +662,7 @@ class ShadowNode extends ShadowBaseNode {
 		const currentRenderObjectFunction = renderer.getRenderObjectFunction();
 		const currentMRT = renderer.getMRT();
 
-		const useVelocity = currentMRT.has( 'velocity' );
+		const useVelocity = currentMRT ? currentMRT.has( 'velocity' ) : false;
 
 		renderer.setMRT( null );
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/29991

**Description**

Fix  `webgpu_postprocessing_motion_blur` after ignore MRT in shadow rendering.