### PR TITLE
fix interger types

### DIFF
--- a/src/renderers/webgl/WebGLBindingStates.js
+++ b/src/renderers/webgl/WebGLBindingStates.js
@@ -342,7 +342,7 @@ function WebGLBindingStates( gl, attributes ) {
 
 					// check for integer attributes
 
-					const integer = ( type === gl.INT || type === gl.UNSIGNED_INT || geometryAttribute.gpuType === IntType );
+					const integer = ( type === gl.INT || type === gl.UNSIGNED_INT || type === gl.SHORT || type === gl.BYTE || type === gl.UNSIGNED_BYTE || geometryAttribute.gpuType === IntType );
 
 					if ( geometryAttribute.isInterleavedBufferAttribute ) {
 


### PR DESCRIPTION
The main difference is that while values specified by vertexAttribPointer are always interpreted as floating-point values in the shader (even if they were originally specified as integers in the buffer), this method allows specifying values which are interpreted as integers in the shader.

ref: https://developer.mozilla.org/en-US/docs/Web/API/WebGL2RenderingContext/vertexAttribIPointer

