### PR TITLE
Nodes: Ensure `getBackgroundNode()` and `getEnvironmentNode()` only return nodes.

### DIFF
--- a/src/renderers/common/nodes/Nodes.js
+++ b/src/renderers/common/nodes/Nodes.js
@@ -199,13 +199,49 @@ class Nodes extends DataMap {
 
 	getEnvironmentNode( scene ) {
 
-		return scene.environmentNode || this.get( scene ).environmentNode || null;
+		let environmentNode = null;
+
+		if ( scene.environmentNode && scene.environmentNode.isNode ) {
+
+			environmentNode = scene.environmentNode;
+
+		} else {
+
+			const sceneData = this.get( scene );
+
+			if ( sceneData.environmentNode ) {
+
+				environmentNode = sceneData.environmentNode;
+
+			}
+
+		}
+
+		return environmentNode;
 
 	}
 
 	getBackgroundNode( scene ) {
 
-		return scene.backgroundNode || this.get( scene ).backgroundNode || null;
+		let backgroundNode = null;
+
+		if ( scene.backgroundNode && scene.backgroundNode.isNode ) {
+
+			backgroundNode = scene.backgroundNode;
+
+		} else {
+
+			const sceneData = this.get( scene );
+
+			if ( sceneData.backgroundNode ) {
+
+				backgroundNode = sceneData.backgroundNode;
+
+			}
+
+		}
+
+		return backgroundNode;
 
 	}
 


### PR DESCRIPTION
Related issue: #30111

**Description**

This makes sure the `backgroundNode` and  `environmentNode` are treated a bit more strictly than before since they only allow node input now. So something like below has no effect anymore:
```js
scene.backgroundNode = new THREE.Color( 0x222222 );
```
It must be:
```js
scene.backgroundNode = color( 0x222222 );
```
or 
```js
scene.background = new THREE.Color( 0x222222 );
```