### PR TITLE
RendererUtils: Honor fog.

### DIFF
--- a/src/renderers/common/RendererUtils.js
+++ b/src/renderers/common/RendererUtils.js
@@ -56,6 +56,8 @@ export function saveSceneState( scene, state = {} ) {
 
 	state.background = scene.background;
 	state.backgroundNode = scene.backgroundNode;
+	state.fog = scene.fog;
+	state.fogNode = scene.fogNode;
 	state.overrideMaterial = scene.overrideMaterial;
 
 	return state;
@@ -68,6 +70,8 @@ export function resetSceneState( scene, state ) {
 
 	scene.background = null;
 	scene.backgroundNode = null;
+	scene.fog = null;
+	scene.fogNode = null;
 	scene.overrideMaterial = null;
 
 	return state;
@@ -78,6 +82,8 @@ export function restoreSceneState( scene, state ) {
 
 	scene.background = state.background;
 	scene.backgroundNode = state.backgroundNode;
+	scene.fog = state.fog;
+	scene.fogNode = state.fogNode;
 	scene.overrideMaterial = state.overrideMaterial;
 
 }


### PR DESCRIPTION
Fixed #30177

**Description**

The PR makes sure `RendererUtils` honors fog definitions.
