### PR TITLE
WebGPURenderer: Fix and improve the dynamic updating of the scene nodes cache

### DIFF
--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -361,10 +361,6 @@ class Renderer {
 
 		//
 
-		this._nodes.updateScene( sceneRef );
-
-		//
-
 		this._background.update( sceneRef, renderList, renderContext );
 
 		// process render lists
@@ -734,10 +730,6 @@ class Renderer {
 		renderContext.activeCubeFace = activeCubeFace;
 		renderContext.activeMipmapLevel = activeMipmapLevel;
 		renderContext.occlusionQueryCount = renderList.occlusionQueryCount;
-
-		//
-
-		this._nodes.updateScene( sceneRef );
 
 		//
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/30178

**Description**

The PR fixes changing of shader-related scene properties like `scene.fog`, `scene.environment` when changed during the rendering pass using `Node.updateBefore()`, and also creates a cache layer for the related classes.