### PR TITLE
WebGPURenderer: Disable fog in shadow-material

### DIFF
--- a/src/nodes/lighting/ShadowNode.js
+++ b/src/nodes/lighting/ShadowNode.js
@@ -58,6 +58,7 @@ const getShadowMaterial = ( light ) => {
 		material.depthNode = depthNode;
 		material.isShadowNodeMaterial = true; // Use to avoid other overrideMaterial override material.colorNode unintentionally when using material.shadowNode
 		material.name = 'ShadowMaterial';
+		material.fog = false;
 
 		shadowMaterialLib.set( light, material );
 

--- a/src/renderers/common/RendererUtils.js
+++ b/src/renderers/common/RendererUtils.js
@@ -92,8 +92,6 @@ export function saveSceneState( scene, state = {} ) {
 
 	state.background = scene.background;
 	state.backgroundNode = scene.backgroundNode;
-	state.fog = scene.fog;
-	state.fogNode = scene.fogNode;
 	state.overrideMaterial = scene.overrideMaterial;
 
 	return state;
@@ -117,8 +115,6 @@ export function resetSceneState( scene, state ) {
 
 	scene.background = null;
 	scene.backgroundNode = null;
-	scene.fog = null;
-	scene.fogNode = null;
 	scene.overrideMaterial = null;
 
 	return state;
@@ -136,8 +132,6 @@ export function restoreSceneState( scene, state ) {
 
 	scene.background = state.background;
 	scene.backgroundNode = state.backgroundNode;
-	scene.fog = state.fog;
-	scene.fogNode = state.fogNode;
 	scene.overrideMaterial = state.overrideMaterial;
 
 }


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/30178

**Description**

I think it would be to disable the fog in the shadow-map, maybe preserve the fog make more sense for other nodes like `OutlineNode` or `SSAAPass` for example. @Mugen87 
