### PR TITLE
Examples: removing antialias for `webgpu_backdrop_water`

### DIFF
--- a/examples/webgpu_backdrop_water.html
+++ b/examples/webgpu_backdrop_water.html
@@ -191,7 +191,7 @@
 
 				// renderer
 
-				renderer = new THREE.WebGPURenderer( { antialias: true } );
+				renderer = new THREE.WebGPURenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setAnimationLoop( animate );


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/30023#issuecomment-2558051040

**Description**

antialias for this example was more for testing for visual purposes since it didn't work without the PR Fix https://github.com/mrdoob/three.js/pull/30023