### PR TITLE
WebGPURenderer: Fix depthTest in logarithmicDepthBuffer

### DIFF
--- a/src/materials/nodes/NodeMaterial.js
+++ b/src/materials/nodes/NodeMaterial.js
@@ -438,9 +438,8 @@ class NodeMaterial extends Material {
 		let resultNode;
 
 		const clippingNode = this.setupClipping( builder );
-		const needsDepthWrite = this.depthWrite === true || ( this.depthTest === true && ( this.depthNode !== null || renderer.logarithmicDepthBuffer === true ) );
 
-		if ( needsDepthWrite ) {
+		if ( this.depthWrite === true || this.depthTest === true ) {
 
 			// only write depth if depth buffer is configured
 

--- a/src/materials/nodes/NodeMaterial.js
+++ b/src/materials/nodes/NodeMaterial.js
@@ -438,8 +438,9 @@ class NodeMaterial extends Material {
 		let resultNode;
 
 		const clippingNode = this.setupClipping( builder );
+		const needsDepthWrite = this.depthWrite === true || ( this.depthTest === true && ( this.depthNode !== null || renderer.logarithmicDepthBuffer === true ) );
 
-		if ( this.depthWrite === true ) {
+		if ( needsDepthWrite ) {
 
 			// only write depth if depth buffer is configured
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/30203, https://github.com/mrdoob/three.js/pull/29799

**Description**

Calculate the depth should be required for depth testing, but it won't necessarily write once it is disabled in the pipeline if `material.depthWrite` is `false`.