### PR TITLE
WebGPURenderer: Respect TypedArray in StorageInstancedBufferAttribute

### DIFF
--- a/src/nodes/accessors/Arrays.js
+++ b/src/nodes/accessors/Arrays.js
@@ -1,7 +1,7 @@
 import StorageInstancedBufferAttribute from '../../renderers/common/StorageInstancedBufferAttribute.js';
 import StorageBufferAttribute from '../../renderers/common/StorageBufferAttribute.js';
 import { storage } from './StorageBufferNode.js';
-import { getLengthFromType } from '../core/NodeUtils.js';
+import { getLengthFromType, getTypedArrayFromType } from '../core/NodeUtils.js';
 
 /** @module Arrays **/
 
@@ -16,8 +16,9 @@ import { getLengthFromType } from '../core/NodeUtils.js';
 export const attributeArray = ( count, type = 'float' ) => {
 
 	const itemSize = getLengthFromType( type );
+	const typedArray = getTypedArrayFromType( type );
 
-	const buffer = new StorageBufferAttribute( count, itemSize );
+	const buffer = new StorageBufferAttribute( count, itemSize, typedArray );
 	const node = storage( buffer, type, count );
 
 	return node;
@@ -35,8 +36,9 @@ export const attributeArray = ( count, type = 'float' ) => {
 export const instancedArray = ( count, type = 'float' ) => {
 
 	const itemSize = getLengthFromType( type );
+	const typedArray = getTypedArrayFromType( type );
 
-	const buffer = new StorageInstancedBufferAttribute( count, itemSize );
+	const buffer = new StorageInstancedBufferAttribute( count, itemSize, typedArray );
 	const node = storage( buffer, type, count );
 
 	return node;

--- a/src/nodes/core/NodeUtils.js
+++ b/src/nodes/core/NodeUtils.js
@@ -190,7 +190,6 @@ export function getTypeFromLength( length ) {
  * @param {String} type - The data type.
  * @return {TypedArray} The typed array.
  */
-
 export function getTypedArrayFromType( type ) {
 
 	// Handle component type for vectors and matrices
@@ -213,7 +212,7 @@ export function getTypedArrayFromType( type ) {
 	if ( /uint/.test( type ) ) return Uint32Array;
 	if ( /int/.test( type ) ) return Int32Array;
 
-	throw new Error( `Unsupported type: ${type}` );
+	throw new Error( `THREE.NodeUtils: Unsupported type: ${type}` );
 
 }
 

--- a/src/nodes/core/NodeUtils.js
+++ b/src/nodes/core/NodeUtils.js
@@ -184,6 +184,40 @@ export function getTypeFromLength( length ) {
 }
 
 /**
+ * Returns the typed array for the given data type.
+ *
+ * @method
+ * @param {String} type - The data type.
+ * @return {TypedArray} The typed array.
+ */
+
+export function getTypedArrayFromType( type ) {
+
+	// Handle component type for vectors and matrices
+	if ( /[iu]?vec\d/.test( type ) ) {
+
+		// Handle int vectors
+		if ( type.startsWith( 'ivec' ) ) return Int32Array;
+		// Handle uint vectors
+		if ( type.startsWith( 'uvec' ) ) return Uint32Array;
+		// Default to float vectors
+		return Float32Array;
+
+	}
+
+	// Handle matrices (always float)
+	if ( /mat\d/.test( type ) ) return Float32Array;
+
+	// Basic types
+	if ( /float/.test( type ) ) return Float32Array;
+	if ( /uint/.test( type ) ) return Uint32Array;
+	if ( /int/.test( type ) ) return Int32Array;
+
+	throw new Error( `Unsupported type: ${type}` );
+
+}
+
+/**
  * Returns the length for the given data type.
  *
  * @method


### PR DESCRIPTION
**Description**

Currently using `instancedArray/attributeArray( data, 'uint')` will always generate a `float` buffer regardless of the type argument. this PR fixes the issue by correctly generating a `uint` typed array.
 

*This contribution is funded by [Utsubo](https://utsubo.com)*
