### PR TITLE
TSL: Use correct elementType with WorkgroupInfoNode

### DIFF
--- a/src/nodes/gpgpu/WorkgroupInfoNode.js
+++ b/src/nodes/gpgpu/WorkgroupInfoNode.js
@@ -105,6 +105,13 @@ class WorkgroupInfoNode extends Node {
 		this.isWorkgroupInfoNode = true;
 
 		/**
+		 * The data type of the array buffer.
+		 *
+		 * @type {String}
+		 */
+		this.elementType = bufferType;
+
+		/**
 		 * TODO.
 		 *
 		 * @type {String}
@@ -138,6 +145,18 @@ class WorkgroupInfoNode extends Node {
 		this.scope = scope;
 
 		return this;
+
+	}
+
+
+	/**
+	 * The data type of the array buffer.
+	 *
+	 * @return {String} The element type.
+	 */
+	getElementType() {
+
+		return this.elementType;
 
 	}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/29192

**Description**
```js
const localStorage = workgroupArray('uvec2', 64 * 2)

// before: (error)
localStorage.element(0) <-- WGSL will assign uint type

// after:
localStorage.element(0) <-- WGSL now assign correctly uvec2
```

*This contribution is funded by [Utsubo](https://Utsubo.com)*
