### PR TITLE
GaussianBlurNode: Fix custom uv

### DIFF
--- a/examples/jsm/tsl/display/GaussianBlurNode.js
+++ b/examples/jsm/tsl/display/GaussianBlurNode.js
@@ -267,7 +267,7 @@ class GaussianBlurNode extends TempNode {
 
 		//
 
-		const uvNode = textureNode.uvNode || uv();
+		const uvNode = uv();
 		const directionNode = vec2( this.directionNode || 1 );
 
 		let sampleTexture, output;


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/30211

**Description**

The PR fixed the use of GaussianBlur with custom UV. 

With these fixes https://github.com/mrdoob/three.js/pull/30228, https://github.com/mrdoob/three.js/pull/30231, and this, it is possible to run the reflector with blur if `bounce=false`. The approach with bounce should be revisited because the render tree is more complex than it appears and at the very least needs to be optimized.

![image](https://github.com/user-attachments/assets/de80cdc3-a94a-4ddb-9683-5df992c52d54)
