### PR TITLE
WebGLTextureUtils: Fix typo.

### DIFF
--- a/src/renderers/webgl-fallback/utils/WebGLTextureUtils.js
+++ b/src/renderers/webgl-fallback/utils/WebGLTextureUtils.js
@@ -731,7 +731,7 @@ class WebGLTextureUtils {
 
 		const requireDrawFrameBuffer = texture.isDepthTexture === true || ( renderContext.renderTarget && renderContext.renderTarget.samples > 0 );
 
-		const srcHeight = renderContext.renderTarget ? renderContext.renderTarget.height : this.backend.gerDrawingBufferSize().y;
+		const srcHeight = renderContext.renderTarget ? renderContext.renderTarget.height : this.backend.getDrawingBufferSize().y;
 
 		if ( requireDrawFrameBuffer ) {
 


### PR DESCRIPTION
Fixed #30236

**Description**

The file `src/renderers/webgl-fallback/utils/WebGLTextureUtils.js` has a call to `gerDrawingBufferSize`. The name has a typo. This PR fixes this typo with `ger...`->`get...`. No other changes are made.
