### PR TITLE
WebXRManager: Do not try to init `WebXRDepthSensing` with cpu-optimized depth.

### DIFF
--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -784,8 +784,11 @@ class WebXRManager extends EventDispatcher {
 				//
 
 				const enabledFeatures = session.enabledFeatures;
+				const gpuDepthSensingEnabled = enabledFeatures &&
+					enabledFeatures.includes( 'depth-sensing' ) &&
+					session.depthUsage == 'gpu-optimized';
 
-				if ( enabledFeatures && enabledFeatures.includes( 'depth-sensing' ) ) {
+				if ( gpuDepthSensingEnabled && glBinding ) {
 
 					const depthData = glBinding.getDepthInformation( views[ 0 ] );
 


### PR DESCRIPTION
On Android with cpu-optimized, there is a crash on the line with glBinding.getDepthInformation because glBinding only gets initialized with WebXR layers. Additionally, WebXRDepthSensing.js is only compatible with gpu-optimized depth.
This change allows cpu-optimized depth to be used separately from WebXRDepthSensing.js.