### PR TITLE
RenderContexts: Introduce `getForClear()`.

### DIFF
--- a/src/renderers/common/RenderContexts.js
+++ b/src/renderers/common/RenderContexts.js
@@ -1,7 +1,11 @@
 import ChainMap from './ChainMap.js';
 import RenderContext from './RenderContext.js';
+import { Scene } from '../../scenes/Scene.js';
+import { Camera } from '../../cameras/Camera.js';
 
 const _chainKeys = [];
+const _defaultScene = /*@__PURE__*/ new Scene();
+const _defaultCamera = /*@__PURE__*/ new Camera();
 
 /**
  * This module manages the render contexts of the renderer.
@@ -28,22 +32,15 @@ class RenderContexts {
 	/**
 	 * Returns a render context for the given scene, camera and render target.
 	 *
-	 * @param {Scene?} [scene=null] - The scene. The parameter can become `null` e.g. when the renderer clears a render target.
-	 * @param {Camera?} [camera=null] - The camera that is used to render the scene. The parameter can become `null` e.g. when the renderer clears a render target.
+	 * @param {Scene} scene - The scene.
+	 * @param {Camera} camera - The camera that is used to render the scene.
 	 * @param {RenderTarget?} [renderTarget=null] - The active render target.
 	 * @return {RenderContext} The render context.
 	 */
-	get( scene = null, camera = null, renderTarget = null ) {
+	get( scene, camera, renderTarget = null ) {
 
-		if ( scene !== null ) _chainKeys.push( scene );
-		if ( camera !== null ) _chainKeys.push( camera );
-
-		if ( _chainKeys.length === 0 ) {
-
-			_chainKeys.push( { id: 'default' } );
-
-		}
-
+		_chainKeys[ 0 ] = scene;
+		_chainKeys[ 1 ] = camera;
 
 		let attachmentState;
 
@@ -60,7 +57,7 @@ class RenderContexts {
 
 		}
 
-		const chainMap = this.getChainMap( attachmentState );
+		const chainMap = this._getChainMap( attachmentState );
 
 		let renderState = chainMap.get( _chainKeys );
 
@@ -81,12 +78,25 @@ class RenderContexts {
 	}
 
 	/**
+	 * Returns a render context intended for clear operations.
+	 *
+	 * @param {RenderTarget?} [renderTarget=null] - The active render target.
+	 * @return {RenderContext} The render context.
+	 */
+	getForClear( renderTarget = null ) {
+
+		return this.get( _defaultScene, _defaultCamera, renderTarget );
+
+	}
+
+	/**
 	 * Returns a chain map for the given attachment state.
 	 *
+	 * @private
 	 * @param {String} attachmentState - The attachment state.
 	 * @return {ChainMap} The chain map.
 	 */
-	getChainMap( attachmentState ) {
+	_getChainMap( attachmentState ) {
 
 		return this.chainMaps[ attachmentState ] || ( this.chainMaps[ attachmentState ] = new ChainMap() );
 

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -1844,7 +1844,7 @@ class Renderer {
 
 			const renderTargetData = this._textures.get( renderTarget );
 
-			renderContext = this._renderContexts.get( null, null, renderTarget );
+			renderContext = this._renderContexts.getForClear( renderTarget );
 			renderContext.textures = renderTargetData.textures;
 			renderContext.depthTexture = renderTargetData.depthTexture;
 			renderContext.width = renderTargetData.width;


### PR DESCRIPTION
Related issue: -

**Description**

A render context is normally requested for a given scene and camera (and optionally a render target). There is currently one exception for clear operations which require a render context as well. The PR introduces a dedicated method `RenderContexts.getForClear()` for this edge case to simplify the implementation in `RenderContexts.get()`. 
