### PR TITLE
WebGLBackground: Reset meshes in `dispose()`.

### DIFF
--- a/src/renderers/webgl/WebGLBackground.js
+++ b/src/renderers/webgl/WebGLBackground.js
@@ -249,12 +249,16 @@ function WebGLBackground( renderer, cubemaps, cubeuvmaps, state, objects, alpha,
 			boxMesh.geometry.dispose();
 			boxMesh.material.dispose();
 
+			boxMesh = undefined;
+
 		}
 
 		if ( planeMesh !== undefined ) {
 
 			planeMesh.geometry.dispose();
 			planeMesh.material.dispose();
+
+			planeMesh = undefined;
 
 		}
 


### PR DESCRIPTION
Fixed #30230.

**Description**

When `renderer.dispose()` is called, the background's `dispose()` method is called as well since `r171`. If a renderer is used after `renderer.dispose()` which is true for the editor, the background wasn't functional anymore. To force a call of `WebGLObjects.update()`, `WebGLBackground.dispose()` simplify removes the references to its internal meshes which is also the more correct implementation.

It is open for debate if using a renderer after `dispose()` is valid but this PR restores the behavior before `r171`. 