### PR TITLE
ChainMap: Avoid a redundant internal weak map.

### DIFF
--- a/src/renderers/common/ChainMap.js
+++ b/src/renderers/common/ChainMap.js
@@ -32,7 +32,7 @@ export default class ChainMap {
 
 		let map = this.weakMap;
 
-		for ( let i = 0; i < keys.length; i ++ ) {
+		for ( let i = 0; i < keys.length - 1; i ++ ) {
 
 			map = map.get( keys[ i ] );
 
@@ -55,7 +55,7 @@ export default class ChainMap {
 
 		let map = this.weakMap;
 
-		for ( let i = 0; i < keys.length; i ++ ) {
+		for ( let i = 0; i < keys.length - 1; i ++ ) {
 
 			const key = keys[ i ];
 
@@ -81,7 +81,7 @@ export default class ChainMap {
 
 		let map = this.weakMap;
 
-		for ( let i = 0; i < keys.length; i ++ ) {
+		for ( let i = 0; i < keys.length - 1; i ++ ) {
 
 			map = map.get( keys[ i ] );
 


### PR DESCRIPTION
**Description**

Issue: `ChainMap` holds value in a redundant weakmap, see https://jsfiddle.net/rebw4hvn/:

```js
chainMap.set([key0, key1], value)

// expected
chainMap.weakMap.get(key0).get(key1) === value

// actual
chainMap.weakMap.get(key0).get(key1).get(key1) === value
```

This PR fixed that by using just enough weakmaps.


