### PR TITLE
Docs: Improve `Matrix4` page.

### DIFF
--- a/docs/api/en/math/Matrix4.html
+++ b/docs/api/en/math/Matrix4.html
@@ -315,8 +315,8 @@ m.elements = [ 11, 21, 31, 41,
 			[method:this lookAt]( [param:Vector3 eye], [param:Vector3 target], [param:Vector3 up] )
 		</h3>
 		<p>
-			Defines the rotation portion of a transformation matrix, looking from [page:Vector3 eye] towards
-			[page:Vector3 target] oriented by the [page:Vector3 up] vector.
+			Sets the rotation component of the transformation matrix, looking from [page:Vector3 eye] towards
+			[page:Vector3 target], and oriented by the up-direction [page:Vector3 up].
 		</p>
 
 		<h3>

--- a/docs/api/en/math/Matrix4.html
+++ b/docs/api/en/math/Matrix4.html
@@ -315,7 +315,7 @@ m.elements = [ 11, 21, 31, 41,
 			[method:this lookAt]( [param:Vector3 eye], [param:Vector3 target], [param:Vector3 up] )
 		</h3>
 		<p>
-			Constructs a rotation matrix, looking from [page:Vector3 eye] towards
+			Defines the rotation portion of a transformation matrix, looking from [page:Vector3 eye] towards
 			[page:Vector3 target] oriented by the [page:Vector3 up] vector.
 		</p>
 


### PR DESCRIPTION
Fixed #30274.

**Description**

Clarifies the description of `Matrix4.lookAt()`. The new text should prevent the confusion that not all elements of a 4x4 matrix are set when using `Matrix4.lookAt()`.
