### PR TITLE
Nodes: Fix recursion with environment nodes.

### DIFF
--- a/src/nodes/accessors/MaterialNode.js
+++ b/src/nodes/accessors/MaterialNode.js
@@ -540,7 +540,7 @@ export const materialMetalness = /*@__PURE__*/ nodeImmutable( MaterialNode, Mate
  *
  * @type {Node<vec3>}
  */
-export const materialNormal = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.NORMAL ).context( { getUV: null } );
+export const materialNormal = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.NORMAL );
 
 /**
  * TSL object that represents the clearcoat of the current material.
@@ -564,7 +564,7 @@ export const materialClearcoatRoughness = /*@__PURE__*/ nodeImmutable( MaterialN
  *
  * @type {Node<vec3>}
  */
-export const materialClearcoatNormal = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.CLEARCOAT_NORMAL ).context( { getUV: null } );
+export const materialClearcoatNormal = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.CLEARCOAT_NORMAL );
 
 /**
  * TSL object that represents the rotation of the current sprite material.

--- a/src/nodes/accessors/Normal.js
+++ b/src/nodes/accessors/Normal.js
@@ -77,7 +77,9 @@ export const normalWorld = /*@__PURE__*/ varying( normalView.transformDirection(
  */
 export const transformedNormalView = /*@__PURE__*/ ( Fn( ( builder ) => {
 
-	return builder.context.setupNormal();
+	// Use getUV context to avoid side effects from nodes overwriting getUV in the context (e.g. EnvironmentNode)
+
+	return builder.context.setupNormal().context( { getUV: null } );
 
 }, 'vec3' ).once() )().mul( faceDirection ).toVar( 'transformedNormalView' );
 
@@ -95,7 +97,9 @@ export const transformedNormalWorld = /*@__PURE__*/ transformedNormalView.transf
  */
 export const transformedClearcoatNormalView = /*@__PURE__*/ ( Fn( ( builder ) => {
 
-	return builder.context.setupClearcoatNormal();
+	// Use getUV context to avoid side effects from nodes overwriting getUV in the context (e.g. EnvironmentNode)
+
+	return builder.context.setupClearcoatNormal().context( { getUV: null } );
 
 }, 'vec3' ).once() )().mul( faceDirection ).toVar( 'transformedClearcoatNormalView' );
 

--- a/src/nodes/display/NormalMapNode.js
+++ b/src/nodes/display/NormalMapNode.js
@@ -93,9 +93,11 @@ class NormalMapNode extends TempNode {
 
 	setup( builder ) {
 
-		const { normalMapType, scaleNode } = this;
+		const { normalMapType, node, scaleNode } = this;
 
-		let normalMap = this.node.mul( 2.0 ).sub( 1.0 );
+		const normalNode = node.context( { getUV: () => node.uvNode || uv() } ); // avoid side effects from nodes overwriting getUV in the context (e.g. EnvironmentNode)
+
+		let normalMap = normalNode.mul( 2.0 ).sub( 1.0 );
 
 		if ( scaleNode !== null ) {
 

--- a/src/nodes/display/NormalMapNode.js
+++ b/src/nodes/display/NormalMapNode.js
@@ -93,11 +93,9 @@ class NormalMapNode extends TempNode {
 
 	setup( builder ) {
 
-		const { normalMapType, node, scaleNode } = this;
+		const { normalMapType, scaleNode } = this;
 
-		const normalNode = node.context( { getUV: () => node.uvNode || uv() } ); // avoid side effects from nodes overwriting getUV in the context (e.g. EnvironmentNode)
-
-		let normalMap = normalNode.mul( 2.0 ).sub( 1.0 );
+		let normalMap = this.node.mul( 2.0 ).sub( 1.0 );
 
 		if ( scaleNode !== null ) {
 


### PR DESCRIPTION
Fixed #30255.

**Description**

This fixes the recursion issue when using `NormalMapNode` with `EnvironmentNode`.

The root cause is that `EnvironmentNode` modifies the builder's context with a custom  `getUV()` which relies on `transformedNormalView`. Using this TSL object triggers `setupNormal()` which consequently triggers the build of `NormalMapNode` which now uses an invalid  `getUV()` implementation.

@sunag Granted this is a bit of an edge case but this kind of context behavior might be unexpected in other scenarios as well. It would be great to limit the scope of `context()` somehow so code like in `NormalMapNode` wouldn't be necessary.