### PR TITLE
Docs: Fix incorrect note on color management in post-processing

### DIFF
--- a/docs/manual/en/introduction/Color-management.html
+++ b/docs/manual/en/introduction/Color-management.html
@@ -214,8 +214,8 @@ THREE.ColorManagement.enabled = true;
 
 	<p>
 		Output to a display device, image, or video may involve conversion from the open domain
-		Linear-sRGB working color space to another color space. This conversion may be performed in
-		the main render pass ([page:WebGLRenderer.outputColorSpace]), or in post-processing (OutputPass).
+		Linear-sRGB working color space to another color space. The conversion is defined by
+		([page:WebGLRenderer.outputColorSpace]). When using post-processing, this requires OutputPass.
 	</p>
 
 	<ul>

--- a/docs/manual/en/introduction/Color-management.html
+++ b/docs/manual/en/introduction/Color-management.html
@@ -215,12 +215,8 @@ THREE.ColorManagement.enabled = true;
 	<p>
 		Output to a display device, image, or video may involve conversion from the open domain
 		Linear-sRGB working color space to another color space. This conversion may be performed in
-		the main render pass ([page:WebGLRenderer.outputColorSpace]), or during post-processing.
+		the main render pass ([page:WebGLRenderer.outputColorSpace]), or in post-processing (OutputPass).
 	</p>
-
-	<code>
-renderer.outputColorSpace = THREE.SRGBColorSpace; // optional with post-processing
-	</code>
 
 	<ul>
 		<li>


### PR DESCRIPTION
Small fix in color management guide. The `renderer.outputColorSpace` setting is no longer "optional" in post-processing workflows – it manages OutputPass. The default (sRGB) is the recommended choice.