### PR TITLE
Docs: Improve `Texture` page.

### DIFF
--- a/docs/api/en/textures/Texture.html
+++ b/docs/api/en/textures/Texture.html
@@ -309,10 +309,7 @@
 		<h3>[method:Texture clone]()</h3>
 		<p>
 			Make copy of the texture. Note this is not a "deep copy", the image is
-			shared. Besides, cloning a texture does not automatically mark it for a
-			texture upload. You have to set [page:Texture.needsUpdate .needsUpdate] to
-			true as soon as its image property (the data source) is fully loaded or
-			ready.
+			shared. Cloning the texture automatically mark it for texture upload.
 		</p>
 
 		<h3>[method:Object toJSON]( [param:Object meta] )</h3>

--- a/docs/api/en/textures/Texture.html
+++ b/docs/api/en/textures/Texture.html
@@ -309,7 +309,7 @@
 		<h3>[method:Texture clone]()</h3>
 		<p>
 			Make copy of the texture. Note this is not a "deep copy", the image is
-			shared. Cloning the texture automatically mark it for texture upload.
+			shared. Cloning the texture automatically marks it for texture upload.
 		</p>
 
 		<h3>[method:Object toJSON]( [param:Object meta] )</h3>


### PR DESCRIPTION
Fixes `Texture.copy()` description to reflect the behavior introduced in https://github.com/mrdoob/three.js/pull/23637

The incorrect description really confused me until I looked directly at the code and found out it was the other way around.