### PR TITLE
TSL: display atan second argument in the docs

### DIFF
--- a/src/nodes/math/MathNode.js
+++ b/src/nodes/math/MathNode.js
@@ -543,9 +543,11 @@ export const acos = /*@__PURE__*/ nodeProxy( MathNode, MathNode.ACOS );
 
 /**
  * Returns the arc-tangent of the parameter.
+ * If two parameters are provided, the result is `atan2(y/x)`.
  *
  * @function
- * @param {Node | Number} x - The parameter.
+ * @param {Node | Number} y - The y parameter.
+ * @param {(Node | Number)?} x - The x parameter.
  * @returns {Node}
  */
 export const atan = /*@__PURE__*/ nodeProxy( MathNode, MathNode.ATAN );


### PR DESCRIPTION
Related issue: #30131

**Description**

With the new code, atan can be called with two arguments. If so, it is translated to `atan` for GLSL  and `atan2` for WGSL https://github.com/sunag/three.js/blob/18046a6e4f79fb38bb98f14e12fa0e0268023c05/src/nodes/math/MathNode.js#L236
