### PR TITLE
Derives timestamp buffer size from BigUint64Array instead of BigInt64Array

### DIFF
--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -1501,7 +1501,7 @@ class WebGPUBackend extends Backend {
 		const renderContextData = this.get( renderContext );
 
 
-		const size = 2 * BigInt64Array.BYTES_PER_ELEMENT;
+		const size = 2 * BigUint64Array.BYTES_PER_ELEMENT;
 
 		if ( renderContextData.currentTimestampQueryBuffers === undefined ) {
 


### PR DESCRIPTION
Timestamp query will resolve as **u64**, not i64,  so the code should **reflect this fact** even if the BYTE_PER_ELEMENT has no difference between them