### PR TITLE
TSL: Fix optional parameter in `Fn()` 

### DIFF
--- a/src/nodes/tsl/TSLCore.js
+++ b/src/nodes/tsl/TSLCore.js
@@ -305,7 +305,7 @@ class ShaderCallNodeInternal extends Node {
 		} else {
 
 			const jsFunc = shaderNode.jsFunc;
-			const outputNode = inputNodes !== null ? jsFunc( inputNodes, builder ) : jsFunc( builder );
+			const outputNode = inputNodes !== null || jsFunc.length > 1 ? jsFunc( inputNodes || [], builder ) : jsFunc( builder );
 
 			result = nodeObject( outputNode );
 


### PR DESCRIPTION
**Description**

Fix `Fn()` if used optional parameter and the call has no parameters. e.g:
```js
const fn = Fn( ( [ coord = uv() ], builder ) => ... );

fn();
```