### PR TITLE
Renderer: Fix viewport configuration of `ArrayCamera`.

### DIFF
--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -2622,6 +2622,7 @@ class Renderer {
 						viewportValue.copy( vp ).multiplyScalar( this._pixelRatio ).floor();
 						viewportValue.minDepth = minDepth;
 						viewportValue.maxDepth = maxDepth;
+						this._currentRenderContext.viewport = true;
 
 						this.backend.updateViewport( this._currentRenderContext );
 

--- a/test/e2e/puppeteer.js
+++ b/test/e2e/puppeteer.js
@@ -131,7 +131,6 @@ const exceptionList = [
 
 	// WebGPURenderer: Unknown problem
 	'webgpu_backdrop_water',
-	'webgpu_camera_array',
 	'webgpu_camera_logarithmicdepthbuffer',
 	'webgpu_clipping',
 	'webgpu_lightprobe_cubecamera',


### PR DESCRIPTION
Related issue: -

**Description**

Whenever a viewport value is configured, the `viewport` flag must be set to `true`. Normally the renderer takes automatically care of that but not in the `ArrayCamera` code path. This broke shadow rendering in the WebGL backend.
