### PR TITLE
RenderObject: Fix geometry key for morph targets.

### DIFF
--- a/docs/api/en/core/BufferAttribute.html
+++ b/docs/api/en/core/BufferAttribute.html
@@ -70,6 +70,9 @@
 		<h3>[property:Boolean isBufferAttribute]</h3>
 		<p>Read-only flag to check if a given object is of type [name].</p>
 
+		<h3>[property:Integer id]</h3>
+		<p>Unique number for this attribute instance.</p>
+
 		<h3>[property:Integer itemSize]</h3>
 		<p>
 			The length of vectors that are being stored in the

--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -7,6 +7,8 @@ import { fromHalfFloat, toHalfFloat } from '../extras/DataUtils.js';
 const _vector = /*@__PURE__*/ new Vector3();
 const _vector2 = /*@__PURE__*/ new Vector2();
 
+let _id = 0;
+
 class BufferAttribute {
 
 	constructor( array, itemSize, normalized = false ) {
@@ -18,6 +20,8 @@ class BufferAttribute {
 		}
 
 		this.isBufferAttribute = true;
+
+		Object.defineProperty( this, 'id', { value: _id ++ } );
 
 		this.name = '';
 

--- a/src/renderers/common/RenderObject.js
+++ b/src/renderers/common/RenderObject.js
@@ -558,6 +558,24 @@ class RenderObject {
 
 		}
 
+		// structural equality isn't sufficient for morph targets since the
+		// data are maintained in textures. only if the targets are all equal
+		// the texture and thus the instance of `MorphNode` can be shared.
+
+		for ( const name of Object.keys( geometry.morphAttributes ).sort() ) {
+
+			const targets = geometry.morphAttributes[ name ];
+
+			for ( let i = 0, l = targets.length; i < l; i ++ ) {
+
+				const attribute = targets[ i ];
+
+				cacheKey += attribute.id + ',';
+
+			}
+
+		}
+
 		if ( geometry.index ) {
 
 			cacheKey += 'index,';

--- a/src/renderers/common/RenderObject.js
+++ b/src/renderers/common/RenderObject.js
@@ -566,6 +566,8 @@ class RenderObject {
 
 			const targets = geometry.morphAttributes[ name ];
 
+			cacheKey += name + ',';
+
 			for ( let i = 0, l = targets.length; i < l; i ++ ) {
 
 				const attribute = targets[ i ];
@@ -656,12 +658,6 @@ class RenderObject {
 		if ( object.skeleton ) {
 
 			cacheKey += object.skeleton.bones.length + ',';
-
-		}
-
-		if ( object.morphTargetInfluences ) {
-
-			cacheKey += object.morphTargetInfluences.length + ',';
 
 		}
 

--- a/src/renderers/common/RenderObject.js
+++ b/src/renderers/common/RenderObject.js
@@ -566,7 +566,7 @@ class RenderObject {
 
 			const targets = geometry.morphAttributes[ name ];
 
-			cacheKey += name + ',';
+			cacheKey += 'morph-' + name + ',';
 
 			for ( let i = 0, l = targets.length; i < l; i ++ ) {
 


### PR DESCRIPTION
Fixed #30192

**Description**

`RenderObject.getGeometryCacheKey()` must honor morph target attributes. However, a simple structural comparison like with normal buffer attributes isn't sufficient. Since the vertex data are maintained in a texture via `MorphNode`, render objects can only share a common node builder state if morph target data are equal. That is verified with a new `id` attribute on `BufferAttribute` level.


