### PR TITLE
NodeUtils: Simplify `getCacheKey()`.

### DIFF
--- a/src/nodes/core/NodeUtils.js
+++ b/src/nodes/core/NodeUtils.js
@@ -95,7 +95,7 @@ export function getCacheKey( object, force = false ) {
 
 	for ( const { property, childNode } of getNodeChildren( object ) ) {
 
-		values.push( values, cyrb53( property.slice( 0, - 4 ) ), childNode.getCacheKey( force ) );
+		values.push( cyrb53( property.slice( 0, - 4 ) ), childNode.getCacheKey( force ) );
 
 	}
 


### PR DESCRIPTION
Related issue: -

**Description**

This PR removes an entry from the `values` array that holds the values for computing a cache key.

I'm not sure there is a reason for the existing code but to me it seems this kind of nesting is not necessary to compute a key that reflects the state of a node.
