### PR TITLE
BatchedMesh: Fix bug in `deleteGeometry()`.

### DIFF
--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -656,7 +656,7 @@ class BatchedMesh extends Mesh {
 		const instanceInfo = this._instanceInfo;
 		for ( let i = 0, l = instanceInfo.length; i < l; i ++ ) {
 
-			if ( instanceInfo[ i ].geometryIndex === geometryId ) {
+			if ( instanceInfo[ i ].active && instanceInfo[ i ].geometryIndex === geometryId ) {
 
 				this.deleteInstance( i );
 


### PR DESCRIPTION
Related forum discussion thread: https://discourse.threejs.org/t/batchedmesh-deleting-instances-and-geometry/76193/1

**Description**

Verify if instances are still active, before deleting them within deleteGeometry.

CC @gkjohnson 

