### PR TITLE
Renderer: Remove outdated comment.

### DIFF
--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -2599,9 +2599,6 @@ class Renderer {
 
 			const renderItem = renderList[ i ];
 
-			// @TODO: Add support for multiple materials per object. This will require to extract
-			// the material from the renderItem object and pass it with its group data to renderObject().
-
 			const { object, geometry, material, group, clippingContext } = renderItem;
 
 			if ( camera.isArrayCamera ) {


### PR DESCRIPTION
Related issue: -

**Description**

In the meanwhile, multi materials are supported in `Renderer` so respective TODO comment in `_renderObjects()` can be removed.
