### PR TITLE
MeshGouraudMaterial: Deprecate module.

### DIFF
--- a/examples/jsm/materials/MeshGouraudMaterial.js
+++ b/examples/jsm/materials/MeshGouraudMaterial.js
@@ -319,6 +319,8 @@ class MeshGouraudMaterial extends ShaderMaterial {
 
 		super();
 
+		console.warn( 'THREE.MeshGouraudMaterial: MeshGouraudMaterial has been deprecated and will be removed with r183. Use THREE.MeshLambertMaterial instead.' ); // @deprecated r173
+
 		this.isMeshGouraudMaterial = true;
 
 		this.type = 'MeshGouraudMaterial';


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/30220#issuecomment-2567054445

**Description**

As previously discussed this PR deprecates `MeshGouraudMaterial`. The motivation behind this change is that all lit materials in the engine use Phong shading to produce more consistent lighting/shadows.