### PR TITLE
RenderObject: Improve cache key computation when rendering shadows.

### DIFF
--- a/src/nodes/lighting/ShadowNode.js
+++ b/src/nodes/lighting/ShadowNode.js
@@ -56,7 +56,7 @@ const getShadowMaterial = ( light ) => {
 		material = new NodeMaterial();
 		material.colorNode = vec4( 0, 0, 0, 1 );
 		material.depthNode = depthNode;
-		material.isShadowNodeMaterial = true; // Use to avoid other overrideMaterial override material.colorNode unintentionally when using material.shadowNode
+		material.isShadowPassMaterial = true; // Use to avoid other overrideMaterial override material.colorNode unintentionally when using material.shadowNode
 		material.name = 'ShadowMaterial';
 		material.fog = false;
 

--- a/src/renderers/common/ClippingContext.js
+++ b/src/renderers/common/ClippingContext.js
@@ -136,7 +136,7 @@ class ClippingContext {
 	 */
 	updateGlobal( scene, camera ) {
 
-		this.shadowPass = ( scene.overrideMaterial !== null && scene.overrideMaterial.isShadowNodeMaterial );
+		this.shadowPass = ( scene.overrideMaterial !== null && scene.overrideMaterial.isShadowPassMaterial );
 		this.viewMatrix = camera.matrixWorldInverse;
 
 		this.viewNormalMatrix.getNormalMatrix( this.viewMatrix );

--- a/src/renderers/common/RenderObject.js
+++ b/src/renderers/common/RenderObject.js
@@ -734,7 +734,7 @@ class RenderObject {
 		// `Nodes.getCacheKey()` returns an environment cache key which is not relevant when
 		// the renderer is inside a shadow pass.
 
-		if ( this.material.isShadowNodeMaterial !== true ) {
+		if ( this.material.isShadowPassMaterial !== true ) {
 
 			cacheKey = this._nodes.getCacheKey( this.scene, this.lightsNode );
 

--- a/src/renderers/common/RenderObject.js
+++ b/src/renderers/common/RenderObject.js
@@ -729,9 +729,16 @@ class RenderObject {
 	 */
 	getDynamicCacheKey() {
 
-		// Environment Nodes Cache Key
+		let cacheKey = 0;
 
-		let cacheKey = this._nodes.getCacheKey( this.scene, this.lightsNode );
+		// `Nodes.getCacheKey()` returns an environment cache key which is not relevant when
+		// the renderer is inside a shadow pass.
+
+		if ( this.material.isShadowNodeMaterial !== true ) {
+
+			cacheKey = this._nodes.getCacheKey( this.scene, this.lightsNode );
+
+		}
 
 		if ( this.object.receiveShadow ) {
 

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -2680,7 +2680,7 @@ class Renderer {
 			overrideMaterial.alphaMap = material.alphaMap;
 			overrideMaterial.transparent = material.transparent || material.transmission > 0;
 
-			if ( overrideMaterial.isShadowNodeMaterial ) {
+			if ( overrideMaterial.isShadowPassMaterial ) {
 
 				overrideMaterial.side = material.shadowSide === null ? material.side : material.shadowSide;
 


### PR DESCRIPTION
Fixed #30065.

**Description**

When `WebGPURenderer` is inside a shadow pass, the dynamic cache key computation in `RenderObject` can be drastically simplified. The "expensive" part `Nodes.getCacheKey()` can be completely skipped since this key represents the environment of the scene (lighting, environment map, fog and background) which is irrelevant when rendering shadow maps.