### PR TITLE
WebXRManager: Safely check for `XRWebGLBinding`.

### DIFF
--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -277,7 +277,7 @@ class WebXRManager extends EventDispatcher {
 
 				// Check that the browser implements the necessary APIs to use an
 				// XRProjectionLayer rather than an XRWebGLLayer
-				const useLayers = XRWebGLBinding !== undefined && 'createProjectionLayer' in XRWebGLBinding.prototype;
+				const useLayers = typeof XRWebGLBinding !== 'undefined' && 'createProjectionLayer' in XRWebGLBinding.prototype;
 
 				if ( ! useLayers ) {
 


### PR DESCRIPTION


**Description**

When using the [immersive-web-emulator](https://github.com/meta-quest/immersive-web-emulator)  XRWebGLBinding is undefined. The current code:
```js
const useLayers = XRWebGLBinding !== undefined && 'createProjectionLayer' in XRWebGLBinding.prototype;
```
throws an error because it directly references XRWebGLBinding without checking if it is defined. I'm unsure whether all WebXR devices use XRWebGLBinding or if a PR would be better suited for their repo. This is a simple fix which resolves the issue when testing any of the WebXR demos using popular emulators.