### PR TITLE
WebGPURenderer: Add .outputType backend parameter

### DIFF
--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -38,6 +38,7 @@ class WebGPUBackend extends Backend {
 	 * @param {String} [parameters.powerPreference=undefined] - The power preference.
 	 * @param {Object} [parameters.requiredLimits=undefined] - Specifies the limits that are required by the device request. The request will fail if the adapter cannot provide these limits.
 	 * @param {GPUDevice} [parameters.device=undefined] - If there is an existing GPU device on app level, it can be passed to the renderer as a parameter.
+	 * @param {Number} [parameters.outputType=undefined] - Texture type for output to canvas. By default, device's preferred format is used; other formats may incur overhead.
 	 */
 	constructor( parameters = {} ) {
 

--- a/src/renderers/webgpu/WebGPURenderer.js
+++ b/src/renderers/webgpu/WebGPURenderer.js
@@ -37,6 +37,7 @@ class WebGPURenderer extends Renderer {
 	 * @param {Boolean} [parameters.antialias=false] - Whether MSAA as the default anti-aliasing should be enabled or not.
 	 * @param {Number} [parameters.samples=0] - When `antialias` is `true`, `4` samples are used by default. Set this parameter to any other integer value than 0 to overwrite the default.
 	 * @param {Boolean} [parameters.forceWebGL=false] - If set to `true`, the renderer uses a WebGL 2 backend no matter if WebGPU is supported or not.
+	 * @param {Number} [parameters.outputType=undefined] - Texture type for output to canvas. By default, device's preferred format is used; other formats may incur overhead.
 	 */
 	constructor( parameters = {} ) {
 

--- a/src/renderers/webgpu/utils/WebGPUUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUUtils.js
@@ -1,3 +1,4 @@
+import { HalfFloatType, UnsignedByteType } from '../../../constants.js';
 import { GPUPrimitiveTopology, GPUTextureFormat } from './WebGPUConstants.js';
 
 /**
@@ -214,16 +215,23 @@ class WebGPUUtils {
 	 */
 	getPreferredCanvasFormat() {
 
-		// TODO: Remove this check when Quest 34.5 is out
-		// https://github.com/mrdoob/three.js/pull/29221/files#r1731833949
+		const outputType = this.backend.parameters.outputType;
 
-		if ( navigator.userAgent.includes( 'Quest' ) ) {
+		if ( outputType === undefined ) {
+
+			return navigator.gpu.getPreferredCanvasFormat();
+
+		} else if ( outputType === UnsignedByteType ) {
 
 			return GPUTextureFormat.BGRA8Unorm;
 
+		} else if ( outputType === HalfFloatType ) {
+
+			return GPUTextureFormat.RGBA16Float;
+
 		} else {
 
-			return navigator.gpu.getPreferredCanvasFormat();
+			throw new Error( 'Unsupported outputType' );
 
 		}
 


### PR DESCRIPTION
Step toward #29573. Adds an independent parameter allowing the user to configure a float16 drawing buffer on a WebGPU canvas. For WebGL backends this does nothing, but my understanding is that WebGL will eventually support higher bit depth output as well.

Example:

```javascript
// default to device preference
const renderer = new WebGPURenderer();

// uint8
const renderer = new WebGPURenderer( { outputType: THREE.UnsignedByteType } );

// float16
const renderer = new WebGPURenderer( { outputType: THREE.HalfFloatType } );
```

A quick way to test the result is to modify the [TSL editor example](https://threejs.org/examples/?q=tsl%20editor#webgpu_tsl_editor), widen the preview renderer to at least 800px x 200px, and draw a dark gradient:

```javascript
const { uniform, vec3, vec4, uv } = await import( 'three/tsl' );

const l = uv().mul( 0.01 ).r;

output = vec4( l, l, l, 1.0 );
```


On a good monitor (for some unspecified definition of "good"; a modern Macbook Pro display will certainly do) you will see banding with `outputType: UnsignedByteType`, and the banding disappears with `outputType: HalfFloatType`.

_EDIT: I removed the screenshot, as it's difficult to get a reliable capture of the difference. I thought I had one taken correctly, but the bands seem to have disappeared (under compression on upload to Github?)._