### PR TITLE
Tests: add qunit failonlyreporter - to allow testing locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,6 +154,8 @@
     "eslint-plugin-compat": "^4.0.2",
     "eslint-plugin-html": "^7.1.0",
     "eslint-plugin-import": "^2.26.0",
+    "failonlyreporter": "^1.0.0",
+    "qunit": "^2.23.1",
     "rollup": "^2.77.2",
     "rollup-plugin-filesize": "^9.1.2",
     "rollup-plugin-terser": "^7.0.2",


### PR DESCRIPTION
**Description**

Tests could not be done on a local clone.

Running local tests on  a clean repo:
```
npm install --include=dev && npm run test
```
Linting is done well, but right after it shows:
```
> npm run unit --prefix test
> test-deps-intaller@1.0.0 unit
> qunit -r failonlyreporter -f !-webonly unit/three.source.unit.js
sh: 1: qunit: not found
```
to fix this i installed `qunit`, and since it still didn't work i installed `failonlyreporter`, both in `devDependencies`.

and now the clone can test locally.