### PR TITLE
OutputPass: Support `THREE.CustomToneMapping`.

### DIFF
--- a/examples/jsm/postprocessing/OutputPass.js
+++ b/examples/jsm/postprocessing/OutputPass.js
@@ -8,6 +8,7 @@ import {
 	AgXToneMapping,
 	ACESFilmicToneMapping,
 	NeutralToneMapping,
+	CustomToneMapping,
 	SRGBTransfer
 } from 'three';
 import { Pass, FullScreenQuad } from './Pass.js';
@@ -63,6 +64,7 @@ class OutputPass extends Pass {
 			else if ( this._toneMapping === ACESFilmicToneMapping ) this.material.defines.ACES_FILMIC_TONE_MAPPING = '';
 			else if ( this._toneMapping === AgXToneMapping ) this.material.defines.AGX_TONE_MAPPING = '';
 			else if ( this._toneMapping === NeutralToneMapping ) this.material.defines.NEUTRAL_TONE_MAPPING = '';
+			else if ( this._toneMapping === CustomToneMapping ) this.material.defines.CUSTOM_TONE_MAPPING = '';
 
 			this.material.needsUpdate = true;
 

--- a/examples/jsm/shaders/OutputShader.js
+++ b/examples/jsm/shaders/OutputShader.js
@@ -28,7 +28,7 @@ const OutputShader = {
 		}`,
 
 	fragmentShader: /* glsl */`
-	
+
 		precision highp float;
 
 		uniform sampler2D tDiffuse;
@@ -67,6 +67,10 @@ const OutputShader = {
 			#elif defined( NEUTRAL_TONE_MAPPING )
 
 				gl_FragColor.rgb = NeutralToneMapping( gl_FragColor.rgb );
+
+			#elif defined( CUSTOM_TONE_MAPPING )
+
+				gl_FragColor.rgb = CustomToneMapping( gl_FragColor.rgb );
 
 			#endif
 


### PR DESCRIPTION

**Description**

Custom ToneMapping is ignored in post-processing effects
