### PR TITLE
ImageUtils: Always use `image/png` in `getDataURL()`.

### DIFF
--- a/src/extras/ImageUtils.js
+++ b/src/extras/ImageUtils.js
@@ -48,17 +48,7 @@ class ImageUtils {
 
 		}
 
-		if ( canvas.width > 2048 || canvas.height > 2048 ) {
-
-			console.warn( 'THREE.ImageUtils.getDataURL: Image converted to jpg for performance reasons', image );
-
-			return canvas.toDataURL( 'image/jpeg', 0.6 );
-
-		} else {
-
-			return canvas.toDataURL( 'image/png' );
-
-		}
+		return canvas.toDataURL( 'image/png' );
 
 	}
 


### PR DESCRIPTION
Fixes #30326.

**Description**

This PR makes sure `image/png` is always used in `getDataURL()` to avoid quality and transparency issues when serializing large images.

As mentioned in https://github.com/mrdoob/three.js/issues/30326#issuecomment-2592116257, the JPG fallback was implemented when texture serialization was initially developed ten years ago. In the meanwhile, hardware should be capable to handle images uniformly as `image/png`.