### PR TITLE
WebGLBackend: Fix `ArrayCamera` pixel ratio

### DIFF
--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -1104,11 +1104,16 @@ class WebGLBackend extends Backend {
 
 					const vp = subCamera.viewport;
 
+					const x = vp.x * pixelRatio;
+					const y = vp.y * pixelRatio;
+					const width = vp.width * pixelRatio;
+					const height = vp.height * pixelRatio;
+
 					state.viewport(
-						Math.floor( vp.x * pixelRatio ),
-						Math.floor( ( renderObject.context.height - vp.height - vp.y ) * pixelRatio ),
-						Math.floor( vp.width * pixelRatio ),
-						Math.floor( vp.height * pixelRatio )
+						Math.floor( x ),
+						Math.floor( renderObject.context.height - height - y ),
+						Math.floor( width ),
+						Math.floor( height )
 					);
 
 					state.bindBufferBase( gl.UNIFORM_BUFFER, cameraIndexData.index, cameraData.indexesGPU[ i ] );


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/30337#issuecomment-2596180127

**Description**

Fix `ArrayCamera` pixel ratio on WebGLBackend.
