### PR TITLE
BufferAttributes and Materials are cloned by reference for Object3D instances, no matter what

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -1002,11 +1002,16 @@ class Object3D extends EventDispatcher {
 
 		if ( recursive === true ) {
 
-			if(typeof source.geometry.clone != 'undefined'){
+			if( typeof source.geometry.clone != 'undefined' ){
+				
 				this.geometry = source.geometry.clone( true );
+				
 			}
-			if(typeof source.material.clone != 'undefined'){
+			
+			if( typeof source.material.clone != 'undefined' ){
+				
 				this.material = source.material.clone( true );
+				
 			}
 
 			for ( let i = 0; i < source.children.length; i ++ ) {

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -6,7 +6,7 @@ import { Euler } from '../math/Euler.js';
 import { Layers } from './Layers.js';
 import { Matrix3 } from '../math/Matrix3.js';
 import { generateUUID } from '../math/MathUtils.js';
-import { BufferGeometry} from './BufferGeometry.js';
+import { BufferGeometry } from './BufferGeometry.js';
 
 let _object3DId = 0;
 
@@ -1003,10 +1003,9 @@ class Object3D extends EventDispatcher {
 
 		if ( recursive === true ) {
 
-      // de-reference (value-copy / deep clone) BufferAttributes & Material
 			source.geometry = source.geometry.clone();
 			source.material = source.material.clone();
-      
+
 			for ( let i = 0; i < source.children.length; i ++ ) {
 
 				const child = source.children[ i ];

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -1003,10 +1003,10 @@ class Object3D extends EventDispatcher {
 		if ( recursive === true ) {
 
 			if(typeof source?.geometry != 'undefined'){
-				source.geometry = source.geometry.clone();
+				this.geometry = source?.geometry?.clone( true );
 			}
 			if(typeof source?.material!= 'undefined'){
-				source.material = source.material.clone();
+				this.material = source?.material?.clone( true );
 			}
 
 			for ( let i = 0; i < source.children.length; i ++ ) {

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -6,6 +6,7 @@ import { Euler } from '../math/Euler.js';
 import { Layers } from './Layers.js';
 import { Matrix3 } from '../math/Matrix3.js';
 import { generateUUID } from '../math/MathUtils.js';
+import { BufferGeometry } from './BufferGeometry.js';
 
 let _object3DId = 0;
 
@@ -1002,12 +1003,37 @@ class Object3D extends EventDispatcher {
 
 		if ( recursive === true ) {
 
-			if(typeof source.geometry != 'undefined'){
-				this.geometry = source?.geometry?.clone( true );
-			}
-			if(typeof source.material!= 'undefined'){
-				this.material = source?.material?.clone( true );
-			}
+			//if(typeof source.geometry != 'undefined'){
+			//	this.geometry = source.geometry.clone( true );
+			//}
+			//if(typeof source.material!= 'undefined'){
+			//	this.material = source.material.clone( true );
+			//}
+
+
+
+			//  Copy VALUES, not just references to the source Attribute array
+			//  This fixes e.g. 'cumulative rotations' etc, for clones which would
+			//  apply transformations to their predecessors, otherwise
+			let originalGeometry = source.geometry;
+			let newGeometry = new BufferGeometry();
+			// create new containers for attributes
+			Object.keys(originalGeometry.attributes).forEach((key, idx) => {
+				
+				// get, use the correct 'typed array', dimension it
+				var arrayType = (''+originalGeometry.attributes[key].array.constructor).split(' ')[1].split('(')[0];
+				newGeometry.attributes[key] = new BufferAttribute(new window[arrayType](
+					originalGeometry.attributes[key].array.length),
+					originalGeometry.attributes[key].itemSize,
+					originalGeometry.attributes[key].normalized )
+					
+				// ...and copy values into them
+				originalGeometry.attributes[key].array.forEach((v, i) => {
+					newGeometry.attributes[key].array[i] = originalGeometry.attributes[key].array[i];
+				});
+			})
+			this.geometry = newGeometry;
+
 
 			for ( let i = 0; i < source.children.length; i ++ ) {
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -6,7 +6,6 @@ import { Euler } from '../math/Euler.js';
 import { Layers } from './Layers.js';
 import { Matrix3 } from '../math/Matrix3.js';
 import { generateUUID } from '../math/MathUtils.js';
-import { BufferAttribute } from './BufferAttribute.js';
 import { BufferGeometry} from './BufferGeometry.js';
 
 let _object3DId = 0;
@@ -964,7 +963,6 @@ class Object3D extends EventDispatcher {
 
 	}
 
-
 	clone( recursive ) {
 
 		return new this.constructor().copy( this, recursive );
@@ -972,36 +970,6 @@ class Object3D extends EventDispatcher {
 	}
 
 	copy( source, recursive = true ) {
-    
-    
-		if( recursivie ){
-
-			//  Copy VALUES, not just references to the source Attribute array
-			//  This fixes e.g. 'cumulative rotations' etc, for clones which would
-			//  apply transformations to their predecessors, otherwise
-
-			let originalGeometry = source.geometry;
-			let newGeometry = new BufferGeometry();
-
-			// create new containers for attributes
-			Object.keys(originalGeometry.attributes).forEach((key, idx) => {
-				
-				// get, use the correct 'typed array', dimension it
-				var arrayType = (''+originalGeometry.attributes[key].array.constructor).split(' ')[1].split('(')[0];
-				newGeometry.attributes[key] = new BufferAttribute(new window[arrayType](
-					originalGeometry.attributes[key].array.length),
-					originalGeometry.attributes[key].itemSize,
-					originalGeometry.attributes[key].normalized )
-					
-				// ...and copy values into them
-				originalGeometry.attributes[key].array.forEach((v, i) => {
-					newGeometry.attributes[key].array[i] = originalGeometry.attributes[key].array[i];
-				});
-			})
-
-			this.source.geometry = newGeometry;
-		}
-
 
 		this.name = source.name;
 
@@ -1035,6 +1003,10 @@ class Object3D extends EventDispatcher {
 
 		if ( recursive === true ) {
 
+      // de-reference (value-copy / deep clone) BufferAttributes & Material
+			source.geometry = source.geometry.clone();
+			source.material = source.material.clone();
+      
 			for ( let i = 0; i < source.children.length; i ++ ) {
 
 				const child = source.children[ i ];

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -6,6 +6,8 @@ import { Euler } from '../math/Euler.js';
 import { Layers } from './Layers.js';
 import { Matrix3 } from '../math/Matrix3.js';
 import { generateUUID } from '../math/MathUtils.js';
+import { BufferAttribute } from './BufferAttribute.js';
+import { BufferGeometry} from './BufferGeometry.js';
 
 let _object3DId = 0;
 
@@ -962,6 +964,7 @@ class Object3D extends EventDispatcher {
 
 	}
 
+
 	clone( recursive ) {
 
 		return new this.constructor().copy( this, recursive );
@@ -969,6 +972,34 @@ class Object3D extends EventDispatcher {
 	}
 
 	copy( source, recursive = true ) {
+    
+    
+    if( recursivie ){
+      
+      //  Copy VALUES, not just references to the source Attribute array
+      //  This fixes e.g. 'cumulative rotations' etc, for clones which would
+      //  apply transformations to their predecessors, otherwise
+      
+      let originalGeometry = source.geometry;
+      let newGeometry = new BufferGeometry();
+      
+      // create new containers for attributes
+      Object.keys(originalGeometry.attributes).forEach((key, idx) => {
+        // get, use the correct 'typed array', dimension it
+        var arrayType = (''+originalGeometry.attributes[key].array.constructor).split(' ')[1].split('(')[0];
+        newGeometry.attributes[key] = new BufferAttribute(new window[arrayType](
+                                             originalGeometry.attributes[key].array.length),
+                                             originalGeometry.attributes[key].itemSize,
+                                             originalGeometry.attributes[key].normalized )
+        // ...and copy values into them
+        originalGeometry.attributes[key].array.forEach((v, i) => {
+          newGeometry.attributes[key].array[i] = originalGeometry.attributes[key].array[i];
+        });
+      })
+
+      this.source.geometry = newGeometry;
+    }
+    
 
 		this.name = source.name;
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -6,7 +6,6 @@ import { Euler } from '../math/Euler.js';
 import { Layers } from './Layers.js';
 import { Matrix3 } from '../math/Matrix3.js';
 import { generateUUID } from '../math/MathUtils.js';
-import { BufferGeometry } from './BufferGeometry.js';
 
 let _object3DId = 0;
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -1002,16 +1002,16 @@ class Object3D extends EventDispatcher {
 
 		if ( recursive === true ) {
 
-			if( typeof source.geometry.clone != 'undefined' ){
-				
+			if ( typeof source.geometry.clone != 'undefined' ) {
+
 				this.geometry = source.geometry.clone( true );
-				
+
 			}
-			
-			if( typeof source.material.clone != 'undefined' ){
-				
+
+			if ( typeof source.material.clone != 'undefined' ) {
+
 				this.material = source.material.clone( true );
-				
+
 			}
 
 			for ( let i = 0; i < source.children.length; i ++ ) {

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -1002,10 +1002,10 @@ class Object3D extends EventDispatcher {
 
 		if ( recursive === true ) {
 
-			if(typeof source?.geometry != 'undefined'){
+			if(typeof source.geometry != 'undefined'){
 				this.geometry = source?.geometry?.clone( true );
 			}
-			if(typeof source?.material!= 'undefined'){
+			if(typeof source.material!= 'undefined'){
 				this.material = source?.material?.clone( true );
 			}
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -1002,8 +1002,12 @@ class Object3D extends EventDispatcher {
 
 		if ( recursive === true ) {
 
-			source.geometry = source.geometry.clone();
-			source.material = source.material.clone();
+			if(typeof source?.geometry != 'undefined'){
+				source.geometry = source.geometry.clone();
+			}
+			if(typeof source?.material!= 'undefined'){
+				source.material = source.material.clone();
+			}
 
 			for ( let i = 0; i < source.children.length; i ++ ) {
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -1002,15 +1002,15 @@ class Object3D extends EventDispatcher {
 
 		if ( recursive === true ) {
 
-			if ( typeof source.geometry.clone != 'undefined' ) {
+			if ( typeof source.geometry.copy != 'undefined' ) {
 
-				this.geometry = source.geometry.clone( true );
+				this.geometry = source.geometry.copy( true );
 
 			}
 
-			if ( typeof source.material.clone != 'undefined' ) {
+			if ( typeof source.material.copy != 'undefined' ) {
 
-				this.material = source.material.clone( true );
+				this.material = source.material.copy( true );
 
 			}
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -974,32 +974,34 @@ class Object3D extends EventDispatcher {
 	copy( source, recursive = true ) {
     
     
-    if( recursivie ){
-      
-      //  Copy VALUES, not just references to the source Attribute array
-      //  This fixes e.g. 'cumulative rotations' etc, for clones which would
-      //  apply transformations to their predecessors, otherwise
-      
-      let originalGeometry = source.geometry;
-      let newGeometry = new BufferGeometry();
-      
-      // create new containers for attributes
-      Object.keys(originalGeometry.attributes).forEach((key, idx) => {
-        // get, use the correct 'typed array', dimension it
-        var arrayType = (''+originalGeometry.attributes[key].array.constructor).split(' ')[1].split('(')[0];
-        newGeometry.attributes[key] = new BufferAttribute(new window[arrayType](
-                                             originalGeometry.attributes[key].array.length),
-                                             originalGeometry.attributes[key].itemSize,
-                                             originalGeometry.attributes[key].normalized )
-        // ...and copy values into them
-        originalGeometry.attributes[key].array.forEach((v, i) => {
-          newGeometry.attributes[key].array[i] = originalGeometry.attributes[key].array[i];
-        });
-      })
+		if( recursivie ){
 
-      this.source.geometry = newGeometry;
-    }
-    
+			//  Copy VALUES, not just references to the source Attribute array
+			//  This fixes e.g. 'cumulative rotations' etc, for clones which would
+			//  apply transformations to their predecessors, otherwise
+
+			let originalGeometry = source.geometry;
+			let newGeometry = new BufferGeometry();
+
+			// create new containers for attributes
+			Object.keys(originalGeometry.attributes).forEach((key, idx) => {
+				
+				// get, use the correct 'typed array', dimension it
+				var arrayType = (''+originalGeometry.attributes[key].array.constructor).split(' ')[1].split('(')[0];
+				newGeometry.attributes[key] = new BufferAttribute(new window[arrayType](
+					originalGeometry.attributes[key].array.length),
+					originalGeometry.attributes[key].itemSize,
+					originalGeometry.attributes[key].normalized )
+					
+				// ...and copy values into them
+				originalGeometry.attributes[key].array.forEach((v, i) => {
+					newGeometry.attributes[key].array[i] = originalGeometry.attributes[key].array[i];
+				});
+			})
+
+			this.source.geometry = newGeometry;
+		}
+
 
 		this.name = source.name;
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -6,7 +6,6 @@ import { Euler } from '../math/Euler.js';
 import { Layers } from './Layers.js';
 import { Matrix3 } from '../math/Matrix3.js';
 import { generateUUID } from '../math/MathUtils.js';
-import { BufferGeometry } from './BufferGeometry.js';
 
 let _object3DId = 0;
 
@@ -1003,37 +1002,12 @@ class Object3D extends EventDispatcher {
 
 		if ( recursive === true ) {
 
-			//if(typeof source.geometry != 'undefined'){
-			//	this.geometry = source.geometry.clone( true );
-			//}
-			//if(typeof source.material!= 'undefined'){
-			//	this.material = source.material.clone( true );
-			//}
-
-
-
-			//  Copy VALUES, not just references to the source Attribute array
-			//  This fixes e.g. 'cumulative rotations' etc, for clones which would
-			//  apply transformations to their predecessors, otherwise
-			let originalGeometry = source.geometry;
-			let newGeometry = new BufferGeometry();
-			// create new containers for attributes
-			Object.keys(originalGeometry.attributes).forEach((key, idx) => {
-				
-				// get, use the correct 'typed array', dimension it
-				var arrayType = (''+originalGeometry.attributes[key].array.constructor).split(' ')[1].split('(')[0];
-				newGeometry.attributes[key] = new BufferAttribute(new window[arrayType](
-					originalGeometry.attributes[key].array.length),
-					originalGeometry.attributes[key].itemSize,
-					originalGeometry.attributes[key].normalized )
-					
-				// ...and copy values into them
-				originalGeometry.attributes[key].array.forEach((v, i) => {
-					newGeometry.attributes[key].array[i] = originalGeometry.attributes[key].array[i];
-				});
-			})
-			this.geometry = newGeometry;
-
+			if(typeof source.geometry.clone != 'undefined'){
+				this.geometry = source.geometry.clone( true );
+			}
+			if(typeof source.material.clone != 'undefined'){
+				this.material = source.material.clone( true );
+			}
 
 			for ( let i = 0; i < source.children.length; i ++ ) {
 


### PR DESCRIPTION
Related issue: #30350

BufferAttribute arrays (for Object3D instances) are cloned / copied by reference.
this causes all predecessors of a clone to receive transformations such as rotations, which are meant to be applied only to clones.

The 'recursive' parameter for Object3D instances does not conform to new user expectations, making the method counterintuitive and user-unfriendly.

Users should expect any "recursive" clone to be a complete, new set. This update should be merged, or "recursive cloning" of Object3D instances should be removed.
