### PR TITLE
TSL: Rename `.varying` -> `.toVarying` and `.vertexStage` -> `.toVertexStage`

### DIFF
--- a/src/nodes/accessors/Camera.js
+++ b/src/nodes/accessors/Camera.js
@@ -11,7 +11,7 @@ import { uniformArray } from './UniformArrayNode.js';
  *
  * @type {UniformNode<uint>}
  */
-export const cameraIndex = /*@__PURE__*/ uniform( 'uint' ).setGroup( sharedUniformGroup( 'cameraIndex' ) ).vertexStage();
+export const cameraIndex = /*@__PURE__*/ uniform( 0, 'uint' ).setGroup( sharedUniformGroup( 'cameraIndex' ) ).toVarying( 'v_cameraIndex' );
 
 /**
  * TSL object that represents the `near` value of the camera used for the current render.

--- a/src/nodes/accessors/ModelViewProjectionNode.js
+++ b/src/nodes/accessors/ModelViewProjectionNode.js
@@ -11,4 +11,4 @@ export const modelViewProjection = /*@__PURE__*/ ( Fn( ( builder ) => {
 
 	return builder.context.setupModelViewProjection();
 
-}, 'vec4' ).once() )().varying( 'v_modelViewProjection' );
+}, 'vec4' ).once() )().toVarying( 'v_modelViewProjection' );

--- a/src/nodes/accessors/Position.js
+++ b/src/nodes/accessors/Position.js
@@ -16,7 +16,7 @@ export const positionGeometry = /*@__PURE__*/ attribute( 'position', 'vec3' );
  *
  * @type {AttributeNode<vec3>}
  */
-export const positionLocal = /*@__PURE__*/ positionGeometry.varying( 'positionLocal' );
+export const positionLocal = /*@__PURE__*/ positionGeometry.toVarying( 'positionLocal' );
 
 /**
  * TSL object that represents the previous vertex position in local space of the current rendered object.
@@ -24,21 +24,21 @@ export const positionLocal = /*@__PURE__*/ positionGeometry.varying( 'positionLo
  *
  * @type {AttributeNode<vec3>}
  */
-export const positionPrevious = /*@__PURE__*/ positionGeometry.varying( 'positionPrevious' );
+export const positionPrevious = /*@__PURE__*/ positionGeometry.toVarying( 'positionPrevious' );
 
 /**
  * TSL object that represents the vertex position in world space of the current rendered object.
  *
  * @type {VaryingNode<vec3>}
  */
-export const positionWorld = /*@__PURE__*/ modelWorldMatrix.mul( positionLocal ).xyz.varying( 'v_positionWorld' ).context( { needsPositionReassign: true } );
+export const positionWorld = /*@__PURE__*/ modelWorldMatrix.mul( positionLocal ).xyz.toVarying( 'v_positionWorld' ).context( { needsPositionReassign: true } );
 
 /**
  * TSL object that represents the position world direction of the current rendered object.
  *
  * @type {Node<vec3>}
  */
-export const positionWorldDirection = /*@__PURE__*/ positionLocal.transformDirection( modelWorldMatrix ).varying( 'v_positionWorldDirection' ).normalize().toVar( 'positionWorldDirection' ).context( { needsPositionReassign: true } );
+export const positionWorldDirection = /*@__PURE__*/ positionLocal.transformDirection( modelWorldMatrix ).toVarying( 'v_positionWorldDirection' ).normalize().toVar( 'positionWorldDirection' ).context( { needsPositionReassign: true } );
 
 /**
  * TSL object that represents the vertex position in view space of the current rendered object.
@@ -49,11 +49,11 @@ export const positionView = /*@__PURE__*/ ( Fn( ( builder ) => {
 
 	return builder.context.setupPositionView();
 
-}, 'vec3' ).once() )().varying( 'v_positionView' ).context( { needsPositionReassign: true } );
+}, 'vec3' ).once() )().toVarying( 'v_positionView' ).context( { needsPositionReassign: true } );
 
 /**
  * TSL object that represents the position view direction of the current rendered object.
  *
  * @type {VaryingNode<vec3>}
  */
-export const positionViewDirection = /*@__PURE__*/ positionView.negate().varying( 'v_positionViewDirection' ).normalize().toVar( 'positionViewDirection' );
+export const positionViewDirection = /*@__PURE__*/ positionView.negate().toVarying( 'v_positionViewDirection' ).normalize().toVar( 'positionViewDirection' );

--- a/src/nodes/accessors/Tangent.js
+++ b/src/nodes/accessors/Tangent.js
@@ -34,14 +34,14 @@ export const tangentLocal = /*@__PURE__*/ tangentGeometry.xyz.toVar( 'tangentLoc
  *
  * @type {Node<vec3>}
  */
-export const tangentView = /*@__PURE__*/ modelViewMatrix.mul( vec4( tangentLocal, 0 ) ).xyz.varying( 'v_tangentView' ).normalize().toVar( 'tangentView' );
+export const tangentView = /*@__PURE__*/ modelViewMatrix.mul( vec4( tangentLocal, 0 ) ).xyz.toVarying( 'v_tangentView' ).normalize().toVar( 'tangentView' );
 
 /**
  * TSL object that represents the vertex tangent in world space of the current rendered object.
  *
  * @type {Node<vec3>}
  */
-export const tangentWorld = /*@__PURE__*/ tangentView.transformDirection( cameraViewMatrix ).varying( 'v_tangentWorld' ).normalize().toVar( 'tangentWorld' );
+export const tangentWorld = /*@__PURE__*/ tangentView.transformDirection( cameraViewMatrix ).toVarying( 'v_tangentWorld' ).normalize().toVar( 'tangentWorld' );
 
 /**
  * TSL object that represents the transformed vertex tangent in view space of the current rendered object.

--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -2467,7 +2467,7 @@ class NodeBuilder {
 
 	}
 
-	// deprecated
+	// Deprecated
 
 	/**
 	 * @function

--- a/src/nodes/core/StackNode.js
+++ b/src/nodes/core/StackNode.js
@@ -157,7 +157,7 @@ class StackNode extends Node {
 
 	}
 
-	// deprecated
+	// Deprecated
 
 	/**
 	 * @function

--- a/src/nodes/core/VaryingNode.js
+++ b/src/nodes/core/VaryingNode.js
@@ -9,7 +9,7 @@ import { addMethodChaining, nodeProxy } from '../tsl/TSLCore.js';
  * existing nodes like the following:
  *
  * ```js
- * const positionLocal = positionGeometry.varying( 'vPositionLocal' );
+ * const positionLocal = positionGeometry.toVarying( 'vPositionLocal' );
  * ```
  *
  * @augments Node
@@ -185,5 +185,21 @@ export const varying = /*@__PURE__*/ nodeProxy( VaryingNode );
  */
 export const vertexStage = ( node ) => varying( node );
 
-addMethodChaining( 'varying', varying );
-addMethodChaining( 'vertexStage', vertexStage );
+addMethodChaining( 'toVarying', varying );
+addMethodChaining( 'toVertexStage', vertexStage );
+
+// Deprecated
+
+addMethodChaining( 'varying', ( ...params ) => { // @deprecated, r173
+
+	console.warn( 'TSL.VaryingNode: .varying() has been renamed to .toVarying().' );
+	return varying( ...params );
+
+} );
+
+addMethodChaining( 'vertexStage', ( ...params ) => { // @deprecated, r173
+
+	console.warn( 'TSL.VaryingNode: .vertexStage() has been renamed to .toVertexStage().' );
+	return varying( ...params );
+
+} );

--- a/src/nodes/display/BlendModes.js
+++ b/src/nodes/display/BlendModes.js
@@ -127,7 +127,7 @@ export const blendColor = /*@__PURE__*/ Fn( ( [ base, blend ] ) => {
 	]
 } );
 
-// deprecated
+// Deprecated
 
 /**
  * @function

--- a/src/nodes/math/ConditionalNode.js
+++ b/src/nodes/math/ConditionalNode.js
@@ -211,7 +211,7 @@ export const select = /*@__PURE__*/ nodeProxy( ConditionalNode );
 
 addMethodChaining( 'select', select );
 
-// deprecated
+// Deprecated
 
 /**
  * @function

--- a/src/nodes/utils/LoopNode.js
+++ b/src/nodes/utils/LoopNode.js
@@ -274,7 +274,7 @@ export const Continue = () => expression( 'continue' ).append();
  */
 export const Break = () => expression( 'break' ).append();
 
-// deprecated
+// Deprecated
 
 /**
  * @function


### PR DESCRIPTION
**Description**

Maintains API consistency with other functions like `.toVar()` and `.toConst()`.