### PR TITLE
Docs: Improve `Scene` page.

### DIFF
--- a/docs/api/en/scenes/Scene.html
+++ b/docs/api/en/scenes/Scene.html
@@ -11,7 +11,7 @@
 		<h1>[name]</h1>
 
 		<p class="desc">
-			Scenes allow you to set up what and where is to be rendered by three.js.
+			Scenes allow you to set up what is to be rendered and where by three.js.
 			This is where you place objects, lights and cameras.
 		</p>
 


### PR DESCRIPTION
**Description**

"Scenes allow you to set up what and where is to be rendered by three.js" is gramatically incorrect and can be reworded as "Scenes allow you to set up what is to be rendered and where by three.js."