### PR TITLE
Editor: Add Multiple Mesh Selection with Ctrl key and right click

### DIFF
--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -59,7 +59,10 @@ function Editor() {
 
 		geometryChanged: new Signal(),
 
+		readyForMultipleSelect: new Signal(),
+
 		objectSelected: new Signal(),
+		objectsMultipleSelected: new Signal(),
 		objectFocused: new Signal(),
 
 		objectAdded: new Signal(),
@@ -123,6 +126,7 @@ function Editor() {
 	this.mixer = new THREE.AnimationMixer( this.scene );
 
 	this.selected = null;
+	this.selectedObjects = [];
 	this.helpers = {};
 
 	this.cameras = {};


### PR DESCRIPTION
Related issue: #16276 

feature to add multiple select with Ctrl key

when user does not want to Group meshes and also does not want to rotate on center of group or wants to do the change action once but multiple objects receive  the change

note: I have further plans for this feature

works like this:

[Screencast from 2025-01-18 22-48-11.webm](https://github.com/user-attachments/assets/212e24a8-b234-4ee2-b251-c3e3ee804ec0)



