### PR TITLE
InstancedMesh, BatchedMesh docs: clarify lack of negatively scaled matrix support

### DIFF
--- a/docs/api/en/objects/BatchedMesh.html
+++ b/docs/api/en/objects/BatchedMesh.html
@@ -214,6 +214,9 @@
 		<p>
 			Sets the given local transformation matrix to the defined instance.
 		</p>
+		<p>
+			Negatively scaled matrices are not supported.
+		</p>
 
 		<h3>
 			[method:this setVisibleAt]( [param:Integer instanceId], [param:Boolean visible] )

--- a/docs/api/en/objects/InstancedMesh.html
+++ b/docs/api/en/objects/InstancedMesh.html
@@ -180,6 +180,9 @@
 			sure you set [page:.instanceMatrix][page:BufferAttribute.needsUpdate .needsUpdate] 
 			to true after updating all the matrices.
 		</p>
+		<p>
+			Negatively scaled matrices are not supported.
+		</p>
 
 		<h3>
 			[method:undefined setMorphAt]( [param:Integer index], [param:Mesh mesh] )


### PR DESCRIPTION
Related issue: #30342, #30327

**Description**

Updates the docs to clarify lack of support for negative scaling.