### PR TITLE
Editor Bug fix: Auto reload after language changing

### DIFF
--- a/editor/js/Sidebar.Settings.js
+++ b/editor/js/Sidebar.Settings.js
@@ -39,6 +39,8 @@ function SidebarSettings( editor ) {
 
 		editor.config.setKey( 'language', value );
 
+		window.location.reload();
+
 	} );
 
 	languageRow.add( new UIText( strings.getKey( 'sidebar/settings/language' ) ).setClass( 'Label' ) );


### PR DESCRIPTION
When language is changed user must reload the page manually.

I know this is not the best solution for this purpose but it fixes the bug for now.

I will work on a better solution later.

**Please consult me for the better solution (like should I add a new signal or etc...)**

[Screencast from 2025-01-20 12-00-34.webm](https://github.com/user-attachments/assets/ccb6df6a-a45c-4f23-9563-0d9a63810963)
