### PR TITLE
consider renaming any to anyof (or something) to avoid Flow syntax error

### DIFF
--- a/src/nodes/math/MathNode.js
+++ b/src/nodes/math/MathNode.js
@@ -2,7 +2,7 @@ import TempNode from '../core/TempNode.js';
 import { sub, mul, div } from './OperatorNode.js';
 import { addMethodChaining, nodeObject, nodeProxy, float, vec2, vec3, vec4, Fn } from '../tsl/TSLCore.js';
 import { WebGLCoordinateSystem, WebGPUCoordinateSystem } from '../../constants.js';
-
+asdfasdf
 /** @module MathNode **/
 
 /**
@@ -386,7 +386,7 @@ export const all = /*@__PURE__*/ nodeProxy( MathNode, MathNode.ALL );
  * @param {Node | Number} x - The parameter.
  * @returns {Node<bool>}
  */
-export const any = /*@__PURE__*/ nodeProxy( MathNode, MathNode.ANY );
+export const anyof = /*@__PURE__*/ nodeProxy( MathNode, MathNode.ANY );
 
 /**
  * Converts a quantity in degrees to radians.


### PR DESCRIPTION

**Description**

When trying to use some [Flow](https://flow.org/) [tooling](https://github.com/joarwilk/flowgen) to generate Flow type definitions for Three.js, I get an error like this:

```
SyntaxError: Unexpected reserved type any.
```

Looks like it gets confused with the `any` type or something.

`anyof` was the first name that popped into mind.

this would be a small but breaking change.

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Lume](https://lume.io)*
