### PR TITLE
WebGPURenderer: Add mat2 uniform support

### DIFF
--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -13,7 +13,7 @@ import { NodeUpdateType, defaultBuildStages, shaderStages } from './constants.js
 
 import {
 	NumberNodeUniform, Vector2NodeUniform, Vector3NodeUniform, Vector4NodeUniform,
-	ColorNodeUniform, Matrix3NodeUniform, Matrix4NodeUniform
+	ColorNodeUniform, Matrix2NodeUniform, Matrix3NodeUniform, Matrix4NodeUniform
 } from '../../renderers/common/nodes/NodeUniform.js';
 
 import { stack } from './StackNode.js';
@@ -2366,6 +2366,7 @@ class NodeBuilder {
 		if ( type === 'vec3' || type === 'ivec3' || type === 'uvec3' ) return new Vector3NodeUniform( uniformNode );
 		if ( type === 'vec4' || type === 'ivec4' || type === 'uvec4' ) return new Vector4NodeUniform( uniformNode );
 		if ( type === 'color' ) return new ColorNodeUniform( uniformNode );
+		if ( type === 'mat2' ) return new Matrix2NodeUniform( uniformNode );
 		if ( type === 'mat3' ) return new Matrix3NodeUniform( uniformNode );
 		if ( type === 'mat4' ) return new Matrix4NodeUniform( uniformNode );
 

--- a/src/renderers/common/Uniform.js
+++ b/src/renderers/common/Uniform.js
@@ -1,4 +1,5 @@
 import { Color } from '../../math/Color.js';
+import { Matrix2 } from '../../math/Matrix2.js';
 import { Matrix3 } from '../../math/Matrix3.js';
 import { Matrix4 } from '../../math/Matrix4.js';
 import { Vector2 } from '../../math/Vector2.js';
@@ -262,6 +263,41 @@ class ColorUniform extends Uniform {
  * @private
  * @augments Uniform
  */
+class Matrix2Uniform extends Uniform {
+
+	/**
+	 * Constructs a new Number uniform.
+	 *
+	 * @param {String} name - The uniform's name.
+	 * @param {Matrix3} value - The uniform's value.
+	 */
+	constructor( name, value = new Matrix2() ) {
+
+		super( name, value );
+
+		/**
+		 * This flag can be used for type testing.
+		 *
+		 * @type {Boolean}
+		 * @readonly
+		 * @default true
+		 */
+		this.isMatrix2Uniform = true;
+
+		this.boundary = 16;
+		this.itemSize = 4;
+
+	}
+
+}
+
+
+/**
+ * Represents a Matrix3 uniform.
+ *
+ * @private
+ * @augments Uniform
+ */
 class Matrix3Uniform extends Uniform {
 
 	/**
@@ -327,5 +363,5 @@ class Matrix4Uniform extends Uniform {
 export {
 	NumberUniform,
 	Vector2Uniform, Vector3Uniform, Vector4Uniform, ColorUniform,
-	Matrix3Uniform, Matrix4Uniform
+	Matrix2Uniform, Matrix3Uniform, Matrix4Uniform
 };

--- a/src/renderers/common/Uniform.js
+++ b/src/renderers/common/Uniform.js
@@ -258,7 +258,7 @@ class ColorUniform extends Uniform {
 }
 
 /**
- * Represents a Matrix3 uniform.
+ * Represents a Matrix2 uniform.
  *
  * @private
  * @augments Uniform
@@ -269,7 +269,7 @@ class Matrix2Uniform extends Uniform {
 	 * Constructs a new Number uniform.
 	 *
 	 * @param {String} name - The uniform's name.
-	 * @param {Matrix3} value - The uniform's value.
+	 * @param {Matrix2} value - The uniform's value.
 	 */
 	constructor( name, value = new Matrix2() ) {
 

--- a/src/renderers/common/nodes/NodeUniform.js
+++ b/src/renderers/common/nodes/NodeUniform.js
@@ -269,7 +269,7 @@ class ColorNodeUniform extends ColorUniform {
 class Matrix2NodeUniform extends Matrix2Uniform {
 
 	/**
-	 * Constructs a new node-based Matrix3 uniform.
+	 * Constructs a new node-based Matrix2 uniform.
 	 *
 	 * @param {NodeUniform} nodeUniform - The node uniform.
 	 */
@@ -289,7 +289,7 @@ class Matrix2NodeUniform extends Matrix2Uniform {
 	/**
 	 * Overwritten to return the value of the node uniform.
 	 *
-	 * @return {Matrix3} The value.
+	 * @return {Matrix2} The value.
 	 */
 	getValue() {
 

--- a/src/renderers/common/nodes/NodeUniform.js
+++ b/src/renderers/common/nodes/NodeUniform.js
@@ -1,6 +1,6 @@
 import {
 	NumberUniform, Vector2Uniform, Vector3Uniform, Vector4Uniform,
-	ColorUniform, Matrix3Uniform, Matrix4Uniform
+	ColorUniform, Matrix2Uniform, Matrix3Uniform, Matrix4Uniform
 } from '../Uniform.js';
 
 /**
@@ -258,6 +258,58 @@ class ColorNodeUniform extends ColorUniform {
 
 }
 
+
+/**
+ * A special form of Matrix2 uniform binding type.
+ * It's value is managed by a node object.
+ *
+ * @private
+ * @augments Matrix2Uniform
+ */
+class Matrix2NodeUniform extends Matrix2Uniform {
+
+	/**
+	 * Constructs a new node-based Matrix3 uniform.
+	 *
+	 * @param {NodeUniform} nodeUniform - The node uniform.
+	 */
+	constructor( nodeUniform ) {
+
+		super( nodeUniform.name, nodeUniform.value );
+
+		/**
+		 * The node uniform.
+		 *
+		 * @type {NodeUniform}
+		 */
+		this.nodeUniform = nodeUniform;
+
+	}
+
+	/**
+	 * Overwritten to return the value of the node uniform.
+	 *
+	 * @return {Matrix3} The value.
+	 */
+	getValue() {
+
+		return this.nodeUniform.value;
+
+	}
+
+	/**
+	 * Returns the node uniform data type.
+	 *
+	 * @return {String} The data type.
+	 */
+	getType() {
+
+		return this.nodeUniform.type;
+
+	}
+
+}
+
 /**
  * A special form of Matrix3 uniform binding type.
  * It's value is managed by a node object.
@@ -362,5 +414,5 @@ class Matrix4NodeUniform extends Matrix4Uniform {
 
 export {
 	NumberNodeUniform, Vector2NodeUniform, Vector3NodeUniform, Vector4NodeUniform,
-	ColorNodeUniform, Matrix3NodeUniform, Matrix4NodeUniform
+	ColorNodeUniform, Matrix2NodeUniform, Matrix3NodeUniform, Matrix4NodeUniform
 };


### PR DESCRIPTION
Related: https://github.com/mrdoob/three.js/pull/30364

**Description**

Following https://github.com/mrdoob/three.js/pull/30364, after adding mat2 support in TSL, this PR adds support for mat2 uniforms in the WebGPURenderer.

*This contribution is funded by [Utsubo](https://utsubo.com)*
