### PR TITLE
Restore original camera FOV and Zoom after XR presentation ends

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1151,6 +1151,16 @@ class WebGLRenderer {
 
 			if ( scene.matrixWorldAutoUpdate === true ) scene.updateMatrixWorld();
 
+			// Restore original camera fov
+
+			if ( xr.enabled === true && xr.isPresenting === false && camera.userData.previousFov !== undefined ) {
+
+				camera.fov = camera.userData.previousFov;
+				delete camera.userData.previousFov;
+				camera.updateProjectionMatrix();
+
+			}
+
 			// update camera matrices and frustum
 
 			if ( camera.parent === null && camera.matrixWorldAutoUpdate === true ) camera.updateMatrixWorld();

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1151,16 +1151,6 @@ class WebGLRenderer {
 
 			if ( scene.matrixWorldAutoUpdate === true ) scene.updateMatrixWorld();
 
-			// Restore original camera fov
-
-			if ( xr.enabled === true && xr.isPresenting === false && camera.userData.previousFov !== undefined ) {
-
-				camera.fov = camera.userData.previousFov;
-				delete camera.userData.previousFov;
-				camera.updateProjectionMatrix();
-
-			}
-
 			// update camera matrices and frustum
 
 			if ( camera.parent === null && camera.matrixWorldAutoUpdate === true ) camera.updateMatrixWorld();

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -633,6 +633,12 @@ class WebXRManager extends EventDispatcher {
 
 			if ( camera.isPerspectiveCamera ) {
 
+				if ( camera.userData.previousFov === undefined ) {
+
+					camera.userData.previousFov = camera.fov;
+
+				}
+
 				camera.fov = RAD2DEG * 2 * Math.atan( 1 / camera.projectionMatrix.elements[ 5 ] );
 				camera.zoom = 1;
 

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -65,7 +65,7 @@ class WebXRManager extends EventDispatcher {
 
 		//
 
-		let updatedCameraProperties = null;
+		const updatedCameraProperties = new WeakMap();
 
 		this.cameraAutoUpdate = true;
 		this.enabled = false;
@@ -184,14 +184,16 @@ class WebXRManager extends EventDispatcher {
 
 			scope.isPresenting = false;
 
-			if ( updatedCameraProperties !== null ) {
+			if ( updatedCameraProperties.has( scope.getCamera() ) ) {
 
-				const camera = updatedCameraProperties.camera;
-				camera.fov = updatedCameraProperties.fov;
-				camera.zoom = updatedCameraProperties.zoom;
-				camera.updateProjectionMatrix();
+				const cameraAndProperties = updatedCameraProperties.get( scope.getCamera() );
 
-				updatedCameraProperties = null;
+				const userCamera = cameraAndProperties.userCamera;
+				userCamera.fov = cameraAndProperties.fov;
+				userCamera.zoom = cameraAndProperties.zoom;
+				userCamera.updateProjectionMatrix();
+
+				updatedCameraProperties.delete( scope.getCamera() );
 
 			}
 
@@ -376,7 +378,7 @@ class WebXRManager extends EventDispatcher {
 
 				scope.isPresenting = true;
 
-				updatedCameraProperties = null;
+				updatedCameraProperties.delete( scope.getCamera() );
 
 				scope.dispatchEvent( { type: 'sessionstart' } );
 
@@ -648,13 +650,13 @@ class WebXRManager extends EventDispatcher {
 
 			if ( camera.isPerspectiveCamera ) {
 
-				if ( updatedCameraProperties === null ) {
+				if ( ! updatedCameraProperties.has( scope.getCamera() ) ) {
 
-					updatedCameraProperties = {
-						camera: camera,
+					updatedCameraProperties.set( scope.getCamera(), {
+						userCamera: camera,
 						fov: camera.fov,
 						zoom: camera.zoom,
-					};
+					} );
 
 				}
 

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -65,6 +65,8 @@ class WebXRManager extends EventDispatcher {
 
 		//
 
+		let updatedCameraProperties = null;
+
 		this.cameraAutoUpdate = true;
 		this.enabled = false;
 
@@ -181,6 +183,17 @@ class WebXRManager extends EventDispatcher {
 			animation.stop();
 
 			scope.isPresenting = false;
+
+			if ( updatedCameraProperties !== null ) {
+
+				const camera = updatedCameraProperties.camera;
+				camera.fov = updatedCameraProperties.fov;
+				camera.zoom = updatedCameraProperties.zoom;
+				camera.updateProjectionMatrix();
+
+				updatedCameraProperties = null;
+
+			}
 
 			renderer.setPixelRatio( currentPixelRatio );
 			renderer.setSize( currentSize.width, currentSize.height, false );
@@ -362,6 +375,8 @@ class WebXRManager extends EventDispatcher {
 				animation.start();
 
 				scope.isPresenting = true;
+
+				updatedCameraProperties = null;
 
 				scope.dispatchEvent( { type: 'sessionstart' } );
 
@@ -633,9 +648,13 @@ class WebXRManager extends EventDispatcher {
 
 			if ( camera.isPerspectiveCamera ) {
 
-				if ( camera.userData.previousFov === undefined ) {
+				if ( updatedCameraProperties === null ) {
 
-					camera.userData.previousFov = camera.fov;
+					updatedCameraProperties = {
+						camera: camera,
+						fov: camera.fov,
+						zoom: camera.zoom,
+					};
 
 				}
 


### PR DESCRIPTION
Related issue: #XXXX

**Description**

This change restores the fov value of the camera before entering a WebXR session.