### PR TITLE
WebGPURenderer: Add Array Type Variable Declaration Support

### DIFF
--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -1612,11 +1612,11 @@ class NodeBuilder {
 	 * @param {String} [type=node.getNodeType( this )] - The variable's type.
 	 * @param {('vertex'|'fragment'|'compute'|'any')} [shaderStage=this.shaderStage] - The shader stage.
 	 * @param {Boolean} [readOnly=false] - Whether the variable is read-only or not.
-	 * @param {Number} [length=1] - The variable's length in case of an array type.
+	 * @param {Number} [arrayLength=1] - The variable's length in case of an array type.
 	 *
 	 * @return {NodeVar} The node variable.
 	 */
-	getVarFromNode( node, name = null, type = node.getNodeType( this ), shaderStage = this.shaderStage, readOnly = false, length = 1 ) {
+	getVarFromNode( node, name = null, type = node.getNodeType( this ), shaderStage = this.shaderStage, readOnly = false, arrayLength = 1 ) {
 
 		const nodeData = this.getDataFromNode( node, shaderStage );
 
@@ -1637,7 +1637,7 @@ class NodeBuilder {
 
 			}
 
-			nodeVar = new NodeVar( name, type, readOnly, length );
+			nodeVar = new NodeVar( name, type, readOnly, arrayLength );
 
 			if ( ! readOnly ) {
 
@@ -2135,14 +2135,14 @@ class NodeBuilder {
 	 *
 	 * @param {String} type - The variable's type.
 	 * @param {String} name - The variable's name.
-	 * @param {Number} [length=1] - The variable's length in case of an array type.
+	 * @param {Number} [arrayLength=1] - The variable's length in case of an array type.
 	 * @return {String} The shader string.
 	 */
-	getVar( type, name, length ) {
+	getVar( type, name, arrayLength ) {
 
-		const arrayLength = length > 1 ? `[ ${ length } ]` : '';
+		const length = arrayLength > 1 ? `[ ${ arrayLength } ]` : '';
 
-		return `${ this.getType( type ) }${ arrayLength } ${ name }`;
+		return `${ this.getType( type ) }${ length } ${ name }`;
 
 	}
 
@@ -2162,7 +2162,7 @@ class NodeBuilder {
 
 			for ( const variable of vars ) {
 
-				snippet += `${ this.getVar( variable.type, variable.name, variable.length ) }; `;
+				snippet += `${ this.getVar( variable.type, variable.name, variable.arrayLength ) }; `;
 
 			}
 

--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -1612,10 +1612,11 @@ class NodeBuilder {
 	 * @param {String} [type=node.getNodeType( this )] - The variable's type.
 	 * @param {('vertex'|'fragment'|'compute'|'any')} [shaderStage=this.shaderStage] - The shader stage.
 	 * @param {Boolean} [readOnly=false] - Whether the variable is read-only or not.
+	 * @param {Number} [length=1] - The variable's length in case of an array type.
 	 *
 	 * @return {NodeVar} The node variable.
 	 */
-	getVarFromNode( node, name = null, type = node.getNodeType( this ), shaderStage = this.shaderStage, readOnly = false ) {
+	getVarFromNode( node, name = null, type = node.getNodeType( this ), shaderStage = this.shaderStage, readOnly = false, length = 1 ) {
 
 		const nodeData = this.getDataFromNode( node, shaderStage );
 
@@ -1636,7 +1637,7 @@ class NodeBuilder {
 
 			}
 
-			nodeVar = new NodeVar( name, type, readOnly );
+			nodeVar = new NodeVar( name, type, readOnly, length );
 
 			if ( ! readOnly ) {
 
@@ -2134,11 +2135,14 @@ class NodeBuilder {
 	 *
 	 * @param {String} type - The variable's type.
 	 * @param {String} name - The variable's name.
+	 * @param {Number} [length=1] - The variable's length in case of an array type.
 	 * @return {String} The shader string.
 	 */
-	getVar( type, name ) {
+	getVar( type, name, length ) {
 
-		return `${ this.getType( type ) } ${ name }`;
+		const arrayLength = length > 1 ? `[ ${ length } ]` : '';
+
+		return `${ this.getType( type ) }${ arrayLength } ${ name }`;
 
 	}
 
@@ -2158,7 +2162,7 @@ class NodeBuilder {
 
 			for ( const variable of vars ) {
 
-				snippet += `${ this.getVar( variable.type, variable.name ) }; `;
+				snippet += `${ this.getVar( variable.type, variable.name, variable.length ) }; `;
 
 			}
 

--- a/src/nodes/core/NodeVar.js
+++ b/src/nodes/core/NodeVar.js
@@ -12,8 +12,9 @@ class NodeVar {
 	 * @param {String} name - The name of the variable.
 	 * @param {String} type - The type of the variable.
 	 * @param {Boolean} [readOnly=false] - The read-only flag.
+	 * @param {Number} [length=1] - The variable's length in case of an array type.
 	 */
-	constructor( name, type, readOnly = false ) {
+	constructor( name, type, readOnly = false, length = 1 ) {
 
 		/**
 		 * This flag can be used for type testing.
@@ -44,6 +45,13 @@ class NodeVar {
 		 * @type {boolean}
 		 */
 		this.readOnly = readOnly;
+
+		/**
+		 * The length of the variable.
+		 *
+		 * @type {Number}
+		 */
+		this.length = length;
 
 	}
 

--- a/src/nodes/core/NodeVar.js
+++ b/src/nodes/core/NodeVar.js
@@ -12,9 +12,9 @@ class NodeVar {
 	 * @param {String} name - The name of the variable.
 	 * @param {String} type - The type of the variable.
 	 * @param {Boolean} [readOnly=false] - The read-only flag.
-	 * @param {Number} [length=1] - The variable's length in case of an array type.
+	 * @param {Number} [arrayLength=1] - The variable's length in case of an array type.
 	 */
-	constructor( name, type, readOnly = false, length = 1 ) {
+	constructor( name, type, readOnly = false, arrayLength = 1 ) {
 
 		/**
 		 * This flag can be used for type testing.
@@ -47,11 +47,11 @@ class NodeVar {
 		this.readOnly = readOnly;
 
 		/**
-		 * The length of the variable.
+		 * The length of the variable in case of an array type.
 		 *
 		 * @type {Number}
 		 */
-		this.length = length;
+		this.arrayLength = arrayLength;
 
 	}
 

--- a/src/nodes/core/VarNode.js
+++ b/src/nodes/core/VarNode.js
@@ -81,7 +81,7 @@ class VarNode extends Node {
 		 * @type {Number}
 		 * @default 1
 		 */
-		this.length = 1;
+		this.arrayLength = 1;
 
 	}
 
@@ -106,7 +106,7 @@ class VarNode extends Node {
 	 */
 	toArray( length ) {
 
-		this.length = length;
+		this.arrayLength = length;
 
 		return this;
 
@@ -138,7 +138,7 @@ class VarNode extends Node {
 		const type = this.getNodeType( builder );
 		const elementType = builder.getElementType( type );
 
-		if ( this.length > 1 ) {
+		if ( this.arrayLength > 1 ) {
 
 			return this.getNodeType( builder );
 
@@ -170,7 +170,7 @@ class VarNode extends Node {
 		const vectorType = builder.getVectorType( this.getNodeType( builder ) );
 		const snippet = node.build( builder, vectorType );
 
-		const nodeVar = builder.getVarFromNode( this, name, vectorType, undefined, shouldTreatAsReadOnly, this.length );
+		const nodeVar = builder.getVarFromNode( this, name, vectorType, undefined, shouldTreatAsReadOnly, this.arrayLength );
 
 		const propertyName = builder.getPropertyName( nodeVar );
 
@@ -178,7 +178,7 @@ class VarNode extends Node {
 
 		if ( shouldTreatAsReadOnly ) {
 
-			const type = builder.getType( nodeVar.type, this.length );
+			const type = builder.getType( nodeVar.type, this.arrayLength );
 
 			if ( isWebGPUBackend ) {
 
@@ -194,7 +194,7 @@ class VarNode extends Node {
 
 		}
 
-		if ( this.length <= 1 ) {
+		if ( this.arrayLength <= 1 ) {
 
 			builder.addLineFlowCode( `${ declarationPrefix } = ${ snippet }`, this );
 

--- a/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
+++ b/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
@@ -496,7 +496,7 @@ ${ flowData.code }
 
 			for ( const variable of vars ) {
 
-				snippets.push( `${ this.getVar( variable.type, variable.name ) };` );
+				snippets.push( `${ this.getVar( variable.type, variable.name, variable.length ) };` );
 
 			}
 

--- a/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
+++ b/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
@@ -496,7 +496,7 @@ ${ flowData.code }
 
 			for ( const variable of vars ) {
 
-				snippets.push( `${ this.getVar( variable.type, variable.name, variable.length ) };` );
+				snippets.push( `${ this.getVar( variable.type, variable.name, variable.arrayLength ) };` );
 
 			}
 

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -1464,11 +1464,12 @@ ${ flowData.code }
 	 *
 	 * @param {String} type - The variable's type.
 	 * @param {String} name - The variable's name.
+	 * @param {Number} length - The variable's length.
 	 * @return {String} The WGSL snippet that defines a variable.
 	 */
-	getVar( type, name ) {
+	getVar( type, name, length ) {
 
-		return `var ${ name } : ${ this.getType( type ) }`;
+		return `var ${ name } : ${ this.getType( type, length ) }`;
 
 	}
 
@@ -1487,7 +1488,7 @@ ${ flowData.code }
 
 			for ( const variable of vars ) {
 
-				snippets.push( `\t${ this.getVar( variable.type, variable.name ) };` );
+				snippets.push( `\t${ this.getVar( variable.type, variable.name, variable.length ) };` );
 
 			}
 
@@ -1822,11 +1823,22 @@ ${ flowData.code }
 	 * Returns the WGSL type of the given node data type.
 	 *
 	 * @param {String} type - The node data type.
+	 * @param {Number} [length=1] - The length of the type.
 	 * @return {String} The WGSL type.
 	 */
-	getType( type ) {
+	getType( type, length = 1 ) {
 
-		return wgslTypeLib[ type ] || type;
+		const baseType = wgslTypeLib[ type ] || type;
+
+		// Return base type if length is 1 or not provided
+		if ( ! length || length <= 1 ) {
+
+			return baseType;
+
+		}
+
+		// Return array type with specified length for arrays
+		return `array<${baseType}, ${length}>`;
 
 	}
 

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -1488,7 +1488,7 @@ ${ flowData.code }
 
 			for ( const variable of vars ) {
 
-				snippets.push( `\t${ this.getVar( variable.type, variable.name, variable.length ) };` );
+				snippets.push( `\t${ this.getVar( variable.type, variable.name, variable.arrayLength ) };` );
 
 			}
 

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -1464,12 +1464,12 @@ ${ flowData.code }
 	 *
 	 * @param {String} type - The variable's type.
 	 * @param {String} name - The variable's name.
-	 * @param {Number} length - The variable's length.
+	 * @param {Number} arrayLength - The variable's length.
 	 * @return {String} The WGSL snippet that defines a variable.
 	 */
-	getVar( type, name, length ) {
+	getVar( type, name, arrayLength ) {
 
-		return `var ${ name } : ${ this.getType( type, length ) }`;
+		return `var ${ name } : ${ this.getType( type, arrayLength ) }`;
 
 	}
 
@@ -1823,22 +1823,22 @@ ${ flowData.code }
 	 * Returns the WGSL type of the given node data type.
 	 *
 	 * @param {String} type - The node data type.
-	 * @param {Number} [length=1] - The length of the type.
+	 * @param {Number} [arrayLength=1] - The length of the type.
 	 * @return {String} The WGSL type.
 	 */
-	getType( type, length = 1 ) {
+	getType( type, arrayLength = 1 ) {
 
 		const baseType = wgslTypeLib[ type ] || type;
 
 		// Return base type if length is 1 or not provided
-		if ( ! length || length <= 1 ) {
+		if ( ! arrayLength || arrayLength <= 1 ) {
 
 			return baseType;
 
 		}
 
 		// Return array type with specified length for arrays
-		return `array<${baseType}, ${length}>`;
+		return `array<${baseType}, ${arrayLength}>`;
 
 	}
 


### PR DESCRIPTION
Fixed: https://github.com/mrdoob/three.js/issues/30097

**Description**

This PR introduces the support of array type in variable declarations in both WGSL and GLSL backends.

Example usage:
```js
const a = vec2().toVar( 'a' ).toArray( 10 );

// assign first element of the array of vec2
a.element(0).assign(vec2(10, 10))

// access to the first element of the array of vec2
const b = a.element(0).add(1);
```

Related comment: https://github.com/mrdoob/three.js/issues/30097#issuecomment-2604872082


This PR cover array of `var` so far.
Next we could also support array of `Const` with a new syntax such as `Const([vec2(),vec2()])` by updating `NodeVar` to take an optional array as node argument and by updating the `generateConst` of the `NodeBuilder` to support assigning array types:
```js
generateConst(type, value = null, length = undefined) {
    // Handle array types
    if (length && length > 1) {
        if (value === null || !Array.isArray(value)) {
            // Create default array with the base type's default value
            const defaultValue = this.generateConst(type);
            return `array<${this.getType(type)}, ${length}>(${Array(length).fill(defaultValue).join(', ')})`;
        }

        // Generate array with provided values
        const arrayValues = value.map(v => this.generateConst(type, v)).join(', ');
        return `array<${this.getType(type)}, ${length}>(${arrayValues})`;
    }
    ....
```

*This contribution is funded by [Utsubo](https://utsubo.com)*
