### PR TITLE
Fix video decoder stalls issue in webgpu_video_frame.html

### DIFF
--- a/examples/webgpu_video_frame.html
+++ b/examples/webgpu_video_frame.html
@@ -87,6 +87,8 @@
 								// In case our VideoFrameTexture is no longer needed, we should close its backed VideoFrame, see issue #30379:
 								if ( videoTexture.image instanceof VideoFrame ) videoTexture.image.close();
 
+								videoTexture.image = null;
+
 							} );
 
 						}

--- a/examples/webgpu_video_frame.html
+++ b/examples/webgpu_video_frame.html
@@ -88,8 +88,6 @@
 								if ( videoTexture.image instanceof VideoFrame ) videoTexture.image.close();
 								videoTexture.image = null;
 
-								scene.remove( mesh );
-
 							} );
 
 						}

--- a/examples/webgpu_video_frame.html
+++ b/examples/webgpu_video_frame.html
@@ -50,6 +50,9 @@
 				const decoder = new VideoDecoder( {
 					output( frame ) {
 
+						// To avoid video decoder stalls, we should close the VideoFrame which is no longer needed. https://w3c.github.io/webcodecs/#dom-videodecoder-decode
+						if ( videoTexture.image instanceof VideoFrame ) videoTexture.image.close();
+
 						videoTexture.setFrame( frame );
 			
 					},
@@ -71,9 +74,25 @@
 						decoder.decode( chunk );
 
 					},
-					setStatus( s ) {
+					setStatus( kind, status ) {
 
-						console.info( 'MP4Demuxer:', s );
+						console.info( 'MP4Demuxer:', kind );
+
+						if ( kind === 'fetch' && status === 'Done' ) {
+
+							decoder.flush().then( () => {
+
+								decoder.close();
+
+								// In case our VideoFrameTexture is no longer needed, we should close its backed VideoFrame, see issue #30379:
+								if ( videoTexture.image instanceof VideoFrame ) videoTexture.image.close();
+								videoTexture.image = null;
+
+								scene.remove( mesh );
+
+							} );
+
+						}
 
 					}
 				} );

--- a/examples/webgpu_video_frame.html
+++ b/examples/webgpu_video_frame.html
@@ -86,7 +86,6 @@
 
 								// In case our VideoFrameTexture is no longer needed, we should close its backed VideoFrame, see issue #30379:
 								if ( videoTexture.image instanceof VideoFrame ) videoTexture.image.close();
-								videoTexture.image = null;
 
 							} );
 


### PR DESCRIPTION
**Description**

This PR closes video frames no longer needed to avoid video decode stalls, and adds a path to show proper destruction of VideoDecoder and VideoFrameTexture