### PR TITLE
JsDoc: improve type hinting for constructors

### DIFF
--- a/editor/js/Command.js
+++ b/editor/js/Command.js
@@ -1,11 +1,10 @@
-/**
- * @param editor pointer to main editor object used to initialize
- *        each command object with a reference to the editor
- * @constructor
- */
-
 class Command {
 
+	/**
+	 * @param {Editor} editor pointer to main editor object used to initialize
+	 *        each command object with a reference to the editor
+	 * @constructor
+	 */
 	constructor( editor ) {
 
 		this.id = - 1;

--- a/examples/jsm/animation/CCDIKSolver.js
+++ b/examples/jsm/animation/CCDIKSolver.js
@@ -277,13 +277,14 @@ function setPositionOfBoneToAttributeArray( array, index, bone, matrixWorldInv )
 
 /**
  * Visualize IK bones
- *
- * @param {SkinnedMesh} mesh
- * @param {Array<Object>} iks
- * @param {number} sphereSize
  */
 class CCDIKHelper extends Object3D {
 
+	/**
+	 * @param {SkinnedMesh} mesh
+ 	 * @param {Array<Object>} [iks=[]]
+ 	 * @param {number} [sphereSize=0.25]
+	 */
 	constructor( mesh, iks = [], sphereSize = 0.25 ) {
 
 		super();

--- a/examples/jsm/loaders/GCodeLoader.js
+++ b/examples/jsm/loaders/GCodeLoader.js
@@ -14,11 +14,13 @@ import {
  * Gcode files are composed by commands used by machines to create objects.
  *
  * @class GCodeLoader
- * @param {Manager} manager Loading manager.
  */
 
 class GCodeLoader extends Loader {
 
+	/**
+	 * @param {Manager} manager Loading manager.
+	 */
 	constructor( manager ) {
 
 		super( manager );

--- a/examples/jsm/loaders/TDSLoader.js
+++ b/examples/jsm/loaders/TDSLoader.js
@@ -20,7 +20,6 @@ import {
  * Loads geometry with uv and materials basic properties with texture support.
  *
  * @class TDSLoader
- * @constructor
  */
 
 class TDSLoader extends Loader {

--- a/examples/jsm/misc/GPUComputationRenderer.js
+++ b/examples/jsm/misc/GPUComputationRenderer.js
@@ -99,16 +99,15 @@ import { FullScreenQuad } from '../postprocessing/Pass.js';
  * // And compute each frame, before rendering to screen:
  * gpuCompute.doRenderTarget( myFilter1, myRenderTarget );
  * gpuCompute.doRenderTarget( myFilter2, outputRenderTarget );
- *
- *
- *
- * @param {int} sizeX Computation problem size is always 2d: sizeX * sizeY elements.
- * @param {int} sizeY Computation problem size is always 2d: sizeX * sizeY elements.
- * @param {WebGLRenderer} renderer The renderer
-  */
+ */
 
 class GPUComputationRenderer {
 
+	/**
+	 * @param {Number} sizeX Computation problem size is always 2d: sizeX * sizeY elements.
+ 	 * @param {Number} sizeY Computation problem size is always 2d: sizeX * sizeY elements.
+ 	 * @param {WebGLRenderer} renderer The renderer
+	 */
 	constructor( sizeX, sizeY, renderer ) {
 
 		this.variables = [];

--- a/examples/jsm/misc/ProgressiveLightMap.js
+++ b/examples/jsm/misc/ProgressiveLightMap.js
@@ -13,12 +13,13 @@ import { potpack } from '../libs/potpack.module.js';
  * This should begin accumulating lightmaps which apply to
  * your objects, so you can start jittering lighting to achieve
  * the texture-space effect you're looking for.
- *
- * @param {WebGLRenderer} renderer An instance of WebGLRenderer.
- * @param {number} res The side-long dimension of you total lightmap.
  */
 class ProgressiveLightMap {
 
+	/**
+	 * @param {WebGLRenderer} renderer An instance of WebGLRenderer.
+ 	 * @param {number} [res=1024] The side-long dimension of you total lightmap.
+	 */
 	constructor( renderer, res = 1024 ) {
 
 		this.renderer = renderer;

--- a/examples/jsm/misc/ProgressiveLightMapGPU.js
+++ b/examples/jsm/misc/ProgressiveLightMapGPU.js
@@ -15,12 +15,13 @@ import { potpack } from '../libs/potpack.module.js';
  * This should begin accumulating lightmaps which apply to
  * your objects, so you can start jittering lighting to achieve
  * the texture-space effect you're looking for.
- *
- * @param {WebGPURenderer} renderer An instance of WebGPURenderer.
- * @param {number} resolution The side-long dimension of you total lightmap.
  */
 class ProgressiveLightMap {
 
+	/**
+	 * @param {WebGPURenderer} renderer An instance of WebGPURenderer.
+	 * @param {number} [resolution=1024] The side-long dimension of you total lightmap.
+	 */
 	constructor( renderer, resolution = 1024 ) {
 
 		this.renderer = renderer;

--- a/examples/jsm/misc/Volume.js
+++ b/examples/jsm/misc/Volume.js
@@ -11,14 +11,16 @@ import { VolumeSlice } from '../misc/VolumeSlice.js';
  * For now it only handles 3 dimensional data.
  * See the webgl_loader_nrrd.html example and the loaderNRRD.js file to see how to use this class.
  * @class
- * @param   {number}        xLength         Width of the volume
- * @param   {number}        yLength         Length of the volume
- * @param   {number}        zLength         Depth of the volume
- * @param   {string}        type            The type of data (uint8, uint16, ...)
- * @param   {ArrayBuffer}   arrayBuffer     The buffer with volume data
  */
 class Volume {
 
+	/**
+	 * @param   {number}        xLength         Width of the volume
+	 * @param   {number}        yLength         Length of the volume
+	 * @param   {number}        zLength         Depth of the volume
+	 * @param   {string}        type            The type of data (uint8, uint16, ...)
+	 * @param   {ArrayBuffer}   arrayBuffer     The buffer with volume data
+	 */
 	constructor( xLength, yLength, zLength, type, arrayBuffer ) {
 
 		if ( xLength !== undefined ) {

--- a/examples/jsm/misc/VolumeSlice.js
+++ b/examples/jsm/misc/VolumeSlice.js
@@ -12,13 +12,15 @@ import {
 /**
  * This class has been made to hold a slice of a volume data
  * @class
- * @param   {Volume} volume    The associated volume
- * @param   {number}       [index=0] The index of the slice
- * @param   {string}       [axis='z']      For now only 'x', 'y' or 'z' but later it will change to a normal vector
  * @see Volume
  */
 class VolumeSlice {
 
+	/**
+ 	 * @param {Volume} volume     The associated volume
+ 	 * @param {number} [index=0]  The index of the slice
+ 	 * @param {string} [axis='z'] For now only 'x', 'y' or 'z' but later it will change to a normal vector
+	 */
 	constructor( volume, index, axis ) {
 
 		const slice = this;


### PR DESCRIPTION
**Description**

By moving JSDoc definition next to the constructor we actually get some type hinting working for linter and IDEs.

Before:

![image](https://github.com/user-attachments/assets/257da84e-4816-45f5-bd29-af03fa46f382)

After:

![image](https://github.com/user-attachments/assets/48dfcc89-4ad1-4eaa-9bfb-610ec940f5ff)