### PR TITLE
WebGPURenderer: Only use `HalfFloatType` for the framebuffer target if necessary.

### DIFF
--- a/examples/webgpu_lights_custom.html
+++ b/examples/webgpu_lights_custom.html
@@ -113,6 +113,7 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setAnimationLoop( animate );
+				renderer.toneMapping = THREE.LinearToneMapping;
 				document.body.appendChild( renderer.domElement );
 
 				// controls

--- a/src/renderers/common/Backend.js
+++ b/src/renderers/common/Backend.js
@@ -4,7 +4,7 @@ let _color4 = null;
 import Color4 from './Color4.js';
 import { Vector2 } from '../../math/Vector2.js';
 import { createCanvasElement, warnOnce } from '../../utils.js';
-import { REVISION } from '../../constants.js';
+import { HalfFloatType, REVISION } from '../../constants.js';
 
 /**
  * Most of the rendering related logic is implemented in the
@@ -595,7 +595,7 @@ class Backend {
 	 */
 	needsHalfFloatFrameBufferTarget() {
 
-		return false;
+		return ( this.parameters.outputType === HalfFloatType );
 
 	}
 

--- a/src/renderers/common/Backend.js
+++ b/src/renderers/common/Backend.js
@@ -589,6 +589,17 @@ class Backend {
 	}
 
 	/**
+	 * Returns `true` if the backend requires a framebuffer target with type `HalfFloat`.
+	 *
+	 * @return {Boolean} Whether the backend requires a framebuffer target with type `HalfFloat` or not.
+	 */
+	needsHalfFloatFrameBufferTarget() {
+
+		return false;
+
+	}
+
+	/**
 	 * Sets a dictionary for the given object into the
 	 * internal data structure.
 	 *

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -450,7 +450,6 @@ class Renderer {
 		 *
 		 * @private
 		 * @type {Map<Number,RenderTarget>}
-		 * @default null
 		 */
 		this._frameBufferTargetMap = new Map();
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -13,7 +13,7 @@ import WebGPUBindingUtils from './utils/WebGPUBindingUtils.js';
 import WebGPUPipelineUtils from './utils/WebGPUPipelineUtils.js';
 import WebGPUTextureUtils from './utils/WebGPUTextureUtils.js';
 
-import { HalfFloatType, WebGPUCoordinateSystem } from '../../constants.js';
+import { WebGPUCoordinateSystem } from '../../constants.js';
 import WebGPUTimestampQueryPool from './utils/WebGPUTimestampQueryPool.js';
 
 /**
@@ -276,17 +276,6 @@ class WebGPUBackend extends Backend {
 	getContext() {
 
 		return this.context;
-
-	}
-
-	/**
-	 * Returns `true` if the backend requires a framebuffer target with type `HalfFloat`.
-	 *
-	 * @return {Boolean} Whether the backend requires a framebuffer target with type `HalfFloat` or not.
-	 */
-	needsHalfFloatFrameBufferTarget() {
-
-		return ( this.parameters.outputType === HalfFloatType );
 
 	}
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -13,7 +13,7 @@ import WebGPUBindingUtils from './utils/WebGPUBindingUtils.js';
 import WebGPUPipelineUtils from './utils/WebGPUPipelineUtils.js';
 import WebGPUTextureUtils from './utils/WebGPUTextureUtils.js';
 
-import { WebGPUCoordinateSystem } from '../../constants.js';
+import { HalfFloatType, WebGPUCoordinateSystem } from '../../constants.js';
 import WebGPUTimestampQueryPool from './utils/WebGPUTimestampQueryPool.js';
 
 /**
@@ -276,6 +276,17 @@ class WebGPUBackend extends Backend {
 	getContext() {
 
 		return this.context;
+
+	}
+
+	/**
+	 * Returns `true` if the backend requires a framebuffer target with type `HalfFloat`.
+	 *
+	 * @return {Boolean} Whether the backend requires a framebuffer target with type `HalfFloat` or not.
+	 */
+	needsHalfFloatFrameBufferTarget() {
+
+		return ( this.parameters.outputType === HalfFloatType );
 
 	}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/30387#issuecomment-2613211405

**Description**

This was found during investigating performance behavior in WebXR.

Right now, `WebGPURenderer` always creates a RGBA16F framebuffer for the beauty pass. Using `HalfFloatType` is not always required though. If we switch to `UnsignedByteType` whenever possible, we can improve renderer performance especially on mobile GPUs.

The idea is to identify HDR workflows by checking `toneMapping` and introduce a new method that allows backends to force `HalfFloatType` if they require it (e.g. when `outputType` is set to `HalfFloatType`).

As a reminder: The internal framebuffer target is only relevant when rendering directly to screen since it is the input for the internal tone mapping and output color space conversion pass. It is not used when rendering into a render target e.g. when doing post processing.
