### PR TITLE
WebGPURenderer: Improve TimestampQueryPool logs

### DIFF
--- a/examples/webgpu_compute_particles.html
+++ b/examples/webgpu_compute_particles.html
@@ -266,8 +266,10 @@
 				stats.update();
 
 				await renderer.computeAsync( computeParticles );
+				renderer.resolveTimestampsAsync( THREE.TimestampQuery.COMPUTE );
 
 				await renderer.renderAsync( scene, camera );
+				renderer.resolveTimestampsAsync( THREE.TimestampQuery.RENDER );
 
 				// throttle the logging
 

--- a/examples/webgpu_compute_sort_bitonic.html
+++ b/examples/webgpu_compute_sort_bitonic.html
@@ -57,6 +57,8 @@
 			import * as THREE from 'three';
 			import { storage, If, vec3, not, uniform, uv, uint, float, Fn, vec2, abs, int, invocationLocalIndex, workgroupArray, uvec2, floor, instanceIndex, workgroupBarrier, atomicAdd, atomicStore, workgroupId } from 'three/tsl';
 
+			import WebGPU from 'three/addons/capabilities/WebGPU.js';
+
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 
 			const StepType = {
@@ -129,6 +131,15 @@
 
 			// When forceGlobalSwap is true, force all valid local swaps to be global swaps.
 			async function init( forceGlobalSwap = false ) {
+
+
+				if ( WebGPU.isAvailable() === false ) {
+
+					document.body.appendChild( WebGPU.getErrorMessage() );
+
+					throw new Error( 'No WebGPU support' );
+
+				}
 
 				let currentStep = 0;
 				let nextStepGlobal = false;
@@ -515,11 +526,15 @@
 			
 					}
 
+					renderer.resolveTimestampsAsync( THREE.TimestampQuery.COMPUTE );
+
+
 					const algo = new Uint32Array( await renderer.getArrayBufferAsync( nextAlgoBuffer ) );
 					algo > StepType.DISPERSE_LOCAL ? ( nextStepGlobal = true ) : ( nextStepGlobal = false );
 					const totalSwaps = new Uint32Array( await renderer.getArrayBufferAsync( counterBuffer ) );
 			
 					renderer.render( scene, camera );
+					renderer.resolveTimestampsAsync( THREE.TimestampQuery.RENDER );
 
 					timestamps[ forceGlobalSwap ? 'global_swap' : 'local_swap' ].innerHTML = `
 

--- a/examples/webgpu_storage_buffer.html
+++ b/examples/webgpu_storage_buffer.html
@@ -53,7 +53,7 @@
 		<script type="module">
 
 			import * as THREE from 'three';
-			import { storageObject, If, vec3, uv, uint, float, Fn, instanceIndex, workgroupBarrier } from 'three/tsl';
+			import { storage, If, vec3, uv, uint, float, Fn, instanceIndex, workgroupBarrier } from 'three/tsl';
 
 			const timestamps = {
 				webgpu: document.getElementById( 'timestamps' ),
@@ -90,7 +90,7 @@
 
 					const arrayBuffer = new THREE.StorageInstancedBufferAttribute( new Float32Array( array ), typeSize );
 
-					arrayBufferNodes.push( storageObject( arrayBuffer, type[ i ], size ) );
+					arrayBufferNodes.push( storage( arrayBuffer, type[ i ], size ).setPBO( true ) );
 
 				}
 
@@ -217,6 +217,9 @@
 
 					await renderer.computeAsync( compute );
 					await renderer.renderAsync( scene, camera );
+
+					renderer.resolveTimestampsAsync( THREE.TimestampQuery.COMPUTE );
+					renderer.resolveTimestampsAsync( THREE.TimestampQuery.RENDER );
 
 					timestamps[ forceWebGL ? 'webgl' : 'webgpu' ].innerHTML = `
 

--- a/examples/webgpu_texturegrad.html
+++ b/examples/webgpu_texturegrad.html
@@ -90,7 +90,7 @@
 				const box = new THREE.Mesh( new THREE.PlaneGeometry( 1, 1 ), material );
 				scene.add( box );
 
-				const renderer = new THREE.WebGPURenderer( { antialias: false, forceWebGL: forceWebGL, trackTimestamp: true } );
+				const renderer = new THREE.WebGPURenderer( { antialias: false, forceWebGL: forceWebGL } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth / 2, window.innerHeight );
 

--- a/src/renderers/webgl-fallback/utils/WebGLTimestampQueryPool.js
+++ b/src/renderers/webgl-fallback/utils/WebGLTimestampQueryPool.js
@@ -1,3 +1,4 @@
+import { warnOnce } from '../../../utils.js';
 import TimestampQueryPool from '../../common/TimestampQueryPool.js';
 
 /**
@@ -57,6 +58,7 @@ class WebGLTimestampQueryPool extends TimestampQueryPool {
 		// Check if we have enough space for a new query pair
 		if ( this.currentQueryIndex + 2 > this.maxQueries ) {
 
+			warnOnce( `WebGPUTimestampQueryPool [${ this.type }]: Maximum number of queries exceeded, when using trackTimestamp it is necessary to resolves the queries via renderer.resolveTimestampsAsync( THREE.TimestampQuery.${ this.type.toUpperCase() } ).` );
 			return null;
 
 		}

--- a/src/renderers/webgpu/utils/WebGPUTimestampQueryPool.js
+++ b/src/renderers/webgpu/utils/WebGPUTimestampQueryPool.js
@@ -52,7 +52,7 @@ class WebGPUTimestampQueryPool extends TimestampQueryPool {
 
 		if ( this.currentQueryIndex + 2 > this.maxQueries ) {
 
-			warnOnce( 'WebGPUTimestampQueryPool: Maximum number of queries exceeded.' );
+			warnOnce( `WebGPUTimestampQueryPool [${ this.type }]: Maximum number of queries exceeded, when using trackTimestamp it is necessary to resolves the queries via renderer.resolveTimestampsAsync( THREE.TimestampQuery.${ this.type.toUpperCase() } ).` );
 			return null;
 
 		}


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/30359#issuecomment-2611891335

**Description**

Improved TimestampQueryPool logs, it is now a lot more explicit:
<img width="438" alt="Screenshot 2025-01-25 at 13 53 03" src="https://github.com/user-attachments/assets/d856fa6e-115b-42e2-bbd4-638b539e9aec" />

Fixed several examples, notably `compute_sort_bitonic`, which was incompatible with `WebGL` due to the use of `workgroups`.

Also the comparison between `production` and `dev` (now using `TimestampQueryPool`) is promising. Accuracy has significantly improved, and responsiveness is impressive. A notable example is `compute_sort_bitonic`, which runs multiple compute programs per frame.

*This contribution is funded by [Utsubo](https://utsubo.com)*
