### PR TITLE
NodeMaterialObserver: Detect geometry exchange.

### DIFF
--- a/src/materials/nodes/manager/NodeMaterialObserver.js
+++ b/src/materials/nodes/manager/NodeMaterialObserver.js
@@ -143,6 +143,7 @@ class NodeMaterialObserver {
 			data = {
 				material: this.getMaterialData( material ),
 				geometry: {
+					id: geometry.id,
 					attributes: this.getAttributesData( geometry.attributes ),
 					indexVersion: geometry.index ? geometry.index.version : null,
 					drawRange: { start: geometry.drawRange.start, count: geometry.drawRange.count }
@@ -361,6 +362,13 @@ class NodeMaterialObserver {
 
 		const storedAttributeNames = Object.keys( storedAttributes );
 		const currentAttributeNames = Object.keys( attributes );
+
+		if ( storedGeometryData.id !== geometry.id ) {
+
+			storedGeometryData.id = geometry.id;
+			return false;
+
+		}
 
 		if ( storedAttributeNames.length !== currentAttributeNames.length ) {
 


### PR DESCRIPTION
Fixed #30398.

**Description**

`NodeMaterialObserver` must detect a geometry exchange otherwise `Geometries.updateForRender()` is not correctly called which means attributes might not be in a valid state.

Below is the code block that must be executed in order to avoid the errors/warnings mentioned in #30398.

https://github.com/mrdoob/three.js/blob/d969abd832c1799fa7b3380701c05a42daa7e91e/src/renderers/common/Renderer.js#L2767-L2778