### PR TITLE
WebGLBackend: Fix context parameter.

### DIFF
--- a/src/renderers/common/XRManager.js
+++ b/src/renderers/common/XRManager.js
@@ -589,8 +589,6 @@ class XRManager extends EventDispatcher {
 
 			//
 
-			const attributes = gl.getContextAttributes();
-
 			if ( this._useLayers === true ) {
 
 				// default path using XRWebGLBinding/XRProjectionLayer
@@ -599,11 +597,11 @@ class XRManager extends EventDispatcher {
 				let depthType = null;
 				let glDepthFormat = null;
 
-				if ( attributes.depth ) {
+				if ( renderer.depth ) {
 
-					glDepthFormat = attributes.stencil ? gl.DEPTH24_STENCIL8 : gl.DEPTH_COMPONENT24;
-					depthFormat = attributes.stencil ? DepthStencilFormat : DepthFormat;
-					depthType = attributes.stencil ? UnsignedInt248Type : UnsignedIntType;
+					glDepthFormat = renderer.stencil ? gl.DEPTH24_STENCIL8 : gl.DEPTH_COMPONENT24;
+					depthFormat = renderer.stencil ? DepthStencilFormat : DepthFormat;
+					depthType = renderer.stencil ? UnsignedInt248Type : UnsignedIntType;
 
 				}
 
@@ -632,8 +630,8 @@ class XRManager extends EventDispatcher {
 						type: UnsignedByteType,
 						colorSpace: renderer.outputColorSpace,
 						depthTexture: new DepthTexture( glProjLayer.textureWidth, glProjLayer.textureHeight, depthType, undefined, undefined, undefined, undefined, undefined, undefined, depthFormat ),
-						stencilBuffer: attributes.stencil,
-						samples: attributes.antialias ? 4 : 0
+						stencilBuffer: renderer.stencil,
+						samples: renderer.samples
 					} );
 
 				this._xrRenderTarget.hasExternalTextures = true;
@@ -643,10 +641,10 @@ class XRManager extends EventDispatcher {
 				// fallback to XRWebGLLayer
 
 				const layerInit = {
-					antialias: attributes.antialias,
+					antialias: renderer.samples > 0,
 					alpha: true,
-					depth: attributes.depth,
-					stencil: attributes.stencil,
+					depth: renderer.depth,
+					stencil: renderer.stencil,
 					framebufferScaleFactor: this.getFramebufferScaleFactor()
 				};
 
@@ -665,7 +663,7 @@ class XRManager extends EventDispatcher {
 						format: RGBAFormat,
 						type: UnsignedByteType,
 						colorSpace: renderer.outputColorSpace,
-						stencilBuffer: attributes.stencil
+						stencilBuffer: renderer.stencil
 					}
 				);
 

--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -211,7 +211,12 @@ class WebGLBackend extends Backend {
 
 		const parameters = this.parameters;
 
-		const glContext = ( parameters.context !== undefined ) ? parameters.context : renderer.domElement.getContext( 'webgl2' );
+		const contextAttributes = {
+			antialias: false, // MSAA is applied via a custom renderbuffer
+			alpha: true // always true for performance reasons
+		};
+
+		const glContext = ( parameters.context !== undefined ) ? parameters.context : renderer.domElement.getContext( 'webgl2', contextAttributes );
 
 	 	function onContextLost( event ) {
 

--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -213,7 +213,9 @@ class WebGLBackend extends Backend {
 
 		const contextAttributes = {
 			antialias: false, // MSAA is applied via a custom renderbuffer
-			alpha: true // always true for performance reasons
+			alpha: true, // always true for performance reasons
+			depth: false, // depth and stencil are set to false since the engine always renders into a framebuffer target first
+			stencil: false
 		};
 
 		const glContext = ( parameters.context !== undefined ) ? parameters.context : renderer.domElement.getContext( 'webgl2', contextAttributes );


### PR DESCRIPTION
Related issue: -

**Description**

While trying to fix foveation with `XRManager`, I have noticed that the WebGL 2 rendering context is always created with `antialias` set to `true`. This has a side effect on `XRManager` as well as performance implications.

The `antialias` context parameter can always be set to `false` since the engine applies MSAA with custom renderbuffers.

With this change the framerate of the demanding SSAA demo improves from 45 to 53 FPS with a WebGL 2 backend (tested with Firefox). In fact, the overall performance of the WebGL backend has been improved since up to now the renderer applied MSAA on the fullscreen quad of the output pass.
