### PR TITLE
CCDIKSolver: Add `blendFactor` support.

### DIFF
--- a/examples/jsm/animation/CCDIKSolver.js
+++ b/examples/jsm/animation/CCDIKSolver.js
@@ -57,6 +57,22 @@ class CCDIKSolver {
 		this.mesh = mesh;
 		this.iks = iks;
 
+		this._initialQuaternions = [];
+		this._workingQuaternion = new Quaternion();
+
+		for ( const ik of iks ) {
+
+			const chainQuats = [];
+			for ( let i = 0; i < ik.links.length; i ++ ) {
+
+			  chainQuats.push( new Quaternion() );
+
+			}
+
+			this._initialQuaternions.push( chainQuats );
+
+		}
+
 		this._valid();
 
 	}
@@ -64,15 +80,16 @@ class CCDIKSolver {
 	/**
 	 * Update all IK bones.
 	 *
+	 * @param {number} [globalBlendFactor=1.0] - Blend factor applied if an IK chain doesn't have its own .blendFactor.
 	 * @return {CCDIKSolver}
 	 */
-	update() {
+	update( globalBlendFactor = 1.0 ) {
 
 		const iks = this.iks;
 
 		for ( let i = 0, il = iks.length; i < il; i ++ ) {
 
-			this.updateOne( iks[ i ] );
+			this.updateOne( iks[ i ], globalBlendFactor );
 
 		}
 
@@ -84,11 +101,15 @@ class CCDIKSolver {
 	 * Update one IK bone
 	 *
 	 * @param {Object} ik parameter
+	 * @param {number} [overrideBlend=1.0] - If the ik object does not define .blendFactor, this value is used.
 	 * @return {CCDIKSolver}
 	 */
-	updateOne( ik ) {
+	updateOne( ik, overrideBlend = 1.0 ) {
 
+		const chainBlend = ik.blendFactor !== undefined ? ik.blendFactor : overrideBlend;
 		const bones = this.mesh.skeleton.bones;
+		const chainIndex = this.iks.indexOf( ik );
+		const initialQuaternions = this._initialQuaternions[ chainIndex ];
 
 		// for reference overhead reduction in loop
 		const math = Math;
@@ -102,6 +123,17 @@ class CCDIKSolver {
 
 		const links = ik.links;
 		const iteration = ik.iteration !== undefined ? ik.iteration : 1;
+
+		if ( chainBlend < 1.0 ) {
+
+			for ( let j = 0; j < links.length; j ++ ) {
+
+			  const linkIndex = links[ j ].index;
+			  initialQuaternions[ j ].copy( bones[ linkIndex ].quaternion );
+
+			}
+
+		}
 
 		for ( let i = 0; i < iteration; i ++ ) {
 
@@ -205,7 +237,23 @@ class CCDIKSolver {
 
 		}
 
-		return this;
+		if ( chainBlend < 1.0 ) {
+
+			for ( let j = 0; j < links.length; j ++ ) {
+
+			  const linkIndex = links[ j ].index;
+			  const link = bones[ linkIndex ];
+
+			  this._workingQuaternion.copy( initialQuaternions[ j ] ).slerp( link.quaternion, chainBlend );
+
+			  link.quaternion.copy( this._workingQuaternion );
+			  link.updateMatrixWorld( true );
+
+			}
+
+		}
+
+		  return this;
 
 	}
 


### PR DESCRIPTION
**Description**

Added ability to control IK influence through blend factors:

- Global blendFactor in update() method
- Per-chain blendFactor in updateOne() method
- Default value of 1.0 maintains backward compatibility

**Use Case**
I was developing an animation + procedural animation system and needed smooth interpolation between animation clips and IK implementation. Since the overrides happen in the CCDIKSolver, modifying it to support blending was necessary.

**Usage Example**

```js
ikSolver.updateOne(indexFingerIk, indexBlend) // Control single IK chain
ikSolver.update(globalBlend) // Control all IK chains globally

```

https://github.com/user-attachments/assets/234d2b60-0b4a-4113-8136-234ee6e357eb

**Alternative Approaches Considered**

```js
ikSolver.blendOne(ik, factor)
ikSolver[0].setBlendFactor() // target specific link
// or

const iks = [{
   target: 4,
   effector: 3,
   links: [{...}]
   iterations: 10,
   blendFactor: 1 // default blend factor
}]

```

