### PR TITLE
Examples: Clean up.

### DIFF
--- a/examples/webgpu_compute_sort_bitonic.html
+++ b/examples/webgpu_compute_sort_bitonic.html
@@ -122,6 +122,14 @@
 			
 			} );
 
+			if ( WebGPU.isAvailable() === false ) {
+
+				document.body.appendChild( WebGPU.getErrorMessage() );
+
+				throw new Error( 'No WebGPU support' );
+
+			}
+
 			// Allow Workgroup Array Swaps
 			init();
 
@@ -131,15 +139,6 @@
 
 			// When forceGlobalSwap is true, force all valid local swaps to be global swaps.
 			async function init( forceGlobalSwap = false ) {
-
-
-				if ( WebGPU.isAvailable() === false ) {
-
-					document.body.appendChild( WebGPU.getErrorMessage() );
-
-					throw new Error( 'No WebGPU support' );
-
-				}
 
 				let currentStep = 0;
 				let nextStepGlobal = false;

--- a/examples/webgpu_materials.html
+++ b/examples/webgpu_materials.html
@@ -31,6 +31,7 @@
 			import { Fn, wgslFn, positionLocal, scriptable, positionWorld, normalLocal, normalWorld, normalView, color, texture, uv, float, vec2, vec3, vec4, oscSine, triplanarTexture, screenUV, js, string, Loop, cameraProjectionMatrix, ScriptableNodeResources } from 'three/tsl';
 
 			import { TeapotGeometry } from 'three/addons/geometries/TeapotGeometry.js';
+			import WebGPU from 'three/addons/capabilities/WebGPU.js';
 
 			import Stats from 'three/addons/libs/stats.module.js';
 
@@ -43,6 +44,14 @@
 			init();
 
 			function init() {
+
+				if ( WebGPU.isAvailable() === false ) {
+
+					document.body.appendChild( WebGPU.getErrorMessage() );
+
+					throw new Error( 'No WebGPU support' );
+
+				}
 
 				const container = document.createElement( 'div' );
 				document.body.appendChild( container );

--- a/examples/webgpu_particles.html
+++ b/examples/webgpu_particles.html
@@ -28,6 +28,7 @@
 			import { range, texture, mix, uv, color, rotateUV, positionLocal, time, uniform } from 'three/tsl';
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
+			import WebGPU from 'three/addons/capabilities/WebGPU.js';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 
@@ -37,6 +38,14 @@
 			init();
 
 			function init() {
+
+				if ( WebGPU.isAvailable() === false ) {
+
+					document.body.appendChild( WebGPU.getErrorMessage() );
+
+					throw new Error( 'No WebGPU support' );
+
+				}
 
 				const { innerWidth, innerHeight } = window;
 

--- a/examples/webgpu_struct_drawindirect.html
+++ b/examples/webgpu_struct_drawindirect.html
@@ -29,6 +29,16 @@
 			import { struct, storage, wgslFn, instanceIndex, time, varyingProperty, attribute } from 'three/tsl';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import WebGPU from 'three/addons/capabilities/WebGPU.js';
+
+			if ( WebGPU.isAvailable() === false ) {
+
+				document.body.appendChild( WebGPU.getErrorMessage() );
+
+				throw new Error( 'No WebGPU support' );
+
+			}
+
 
 			const renderer = new THREE.WebGPURenderer( { antialias: true } );
 			renderer.outputColorSpace = THREE.SRGBColorSpace;

--- a/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
+++ b/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
@@ -1256,7 +1256,6 @@ void main() {
 
 			this.vertexShader = this._getGLSLVertexCode( shadersData.vertex );
 			this.fragmentShader = this._getGLSLFragmentCode( shadersData.fragment );
-			console.log( this.fragmentShader );
 
 		} else {
 


### PR DESCRIPTION
Related issue: -

**Description**

The PR makes sure that `webgpu_*` examples that only support WebGPU use `WebGPU.isAvailable()` to report a controlled error on WebGL 2 only browsers. 

The PR also removes a debug log from `GLSLNodeBuilder`.