### PR TITLE
WebGLBackend: Fix depth formats.

### DIFF
--- a/src/renderers/webgl-fallback/utils/WebGLTextureUtils.js
+++ b/src/renderers/webgl-fallback/utils/WebGLTextureUtils.js
@@ -261,7 +261,8 @@ class WebGLTextureUtils {
 
 		if ( glFormat === gl.DEPTH_COMPONENT ) {
 
-			if ( glType === gl.UNSIGNED_INT ) internalFormat = gl.DEPTH24_STENCIL8;
+			if ( glType === gl.UNSIGNED_SHORT ) internalFormat = gl.DEPTH_COMPONENT16;
+			if ( glType === gl.UNSIGNED_INT ) internalFormat = gl.DEPTH_COMPONENT24;
 			if ( glType === gl.FLOAT ) internalFormat = gl.DEPTH_COMPONENT32F;
 
 		}


### PR DESCRIPTION
Related issue: #30387

**Description**

This was found by @cabanier in https://github.com/mrdoob/three.js/pull/30387#issuecomment-2620814987 🎉 . The WebGL 2 backend of `WebGPURenderer` did not use the correct internal format when using depth textures with `UnsignedIntType`. Instead of `gl.DEPTH24_STENCIL8`, it should be `gl.DEPTH_COMPONENT24`.

Besides, the PR adds the missing support for `THREE.UnsignedShortType`.