### PR TITLE
Line: Fix index on intersection.

### DIFF
--- a/src/objects/Line.js
+++ b/src/objects/Line.js
@@ -119,7 +119,7 @@ class Line extends Object3D {
 				const a = index.getX( i );
 				const b = index.getX( i + 1 );
 
-				const intersect = checkIntersection( this, raycaster, _ray, localThresholdSq, a, b );
+				const intersect = checkIntersection( this, raycaster, _ray, localThresholdSq, a, b, i );
 
 				if ( intersect ) {
 
@@ -134,7 +134,7 @@ class Line extends Object3D {
 				const a = index.getX( end - 1 );
 				const b = index.getX( start );
 
-				const intersect = checkIntersection( this, raycaster, _ray, localThresholdSq, a, b );
+				const intersect = checkIntersection( this, raycaster, _ray, localThresholdSq, a, b, end - 1 );
 
 				if ( intersect ) {
 
@@ -151,7 +151,7 @@ class Line extends Object3D {
 
 			for ( let i = start, l = end - 1; i < l; i += step ) {
 
-				const intersect = checkIntersection( this, raycaster, _ray, localThresholdSq, i, i + 1 );
+				const intersect = checkIntersection( this, raycaster, _ray, localThresholdSq, i, i + 1, i );
 
 				if ( intersect ) {
 
@@ -163,7 +163,7 @@ class Line extends Object3D {
 
 			if ( this.isLineLoop ) {
 
-				const intersect = checkIntersection( this, raycaster, _ray, localThresholdSq, end - 1, start );
+				const intersect = checkIntersection( this, raycaster, _ray, localThresholdSq, end - 1, start, end - 1 );
 
 				if ( intersect ) {
 
@@ -210,7 +210,7 @@ class Line extends Object3D {
 
 }
 
-function checkIntersection( object, raycaster, ray, thresholdSq, a, b ) {
+function checkIntersection( object, raycaster, ray, thresholdSq, a, b, i ) {
 
 	const positionAttribute = object.geometry.attributes.position;
 
@@ -233,7 +233,7 @@ function checkIntersection( object, raycaster, ray, thresholdSq, a, b ) {
 		// What do we want? intersection point on the ray or on the segment??
 		// point: raycaster.ray.at( distance ),
 		point: _intersectPointOnSegment.clone().applyMatrix4( object.matrixWorld ),
-		index: a,
+		index: i,
 		face: null,
 		faceIndex: null,
 		barycoord: null,


### PR DESCRIPTION
Fixed #30414.

**Description**

Revert to assign line segment index on intersection again. 

I'm not sure, if the line loop case is correctly handled.

