### PR TITLE
VarNode: Fix `getMemberType()` reference

### DIFF
--- a/src/nodes/core/VarNode.js
+++ b/src/nodes/core/VarNode.js
@@ -82,6 +82,12 @@ class VarNode extends Node {
 
 	}
 
+	getMemberType( builder, name ) {
+
+		return this.node.getMemberType( builder, name );
+
+	}
+
 	getElementType( builder ) {
 
 		return this.node.getElementType( builder );


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/30421

**Description**

This fixed the loss of member reference if using `toVar()`, however it should not be recommended for use in structures.
