### PR TITLE
GLSLNodeBuilder: Fix usage of `flat` qualifier.

### DIFF
--- a/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
+++ b/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
@@ -769,10 +769,20 @@ ${ flowData.code }
 			for ( const varying of varyings ) {
 
 				if ( shaderStage === 'compute' ) varying.needsInterpolation = true;
-				const type = this.getType( varying.type );
-				const flat = type.includes( 'int' ) || type.includes( 'uv' ) || type.includes( 'iv' ) ? 'flat ' : '';
 
-				snippet += `${flat}${varying.needsInterpolation ? 'out' : '/*out*/'} ${type} ${varying.name};\n`;
+				const type = this.getType( varying.type );
+
+				if ( varying.needsInterpolation ) {
+
+					const flat = type.includes( 'int' ) || type.includes( 'uv' ) || type.includes( 'iv' ) ? 'flat ' : '';
+
+					snippet += `${flat} out ${type} ${varying.name};\n`;
+
+				} else {
+
+					snippet += `${type} ${varying.name};\n`; // generate variable (no varying required)
+
+				}
 
 			}
 


### PR DESCRIPTION
Related issue: -

**Description**

When testing `webgpu_xr_cubes` on an Android device with Chrome, I have noticed a runtime error in the browser console. A vertex shader does not compile correctly since the `flat` interpolation qualifier is used without a varying which is not valid. Meaning:
```
flat /*out*/ uint cameraIndex;
```
To fix the issue, `GLSLNodeBuilder` now only uses `flat` in combination with `out`.