### PR TITLE
Add support for foveation during additional render passes

### DIFF
--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -1419,7 +1419,11 @@ class Renderer {
 
 			}
 
+			const currentXREnabled = this.xr.enabled;
+
+			this.xr.enabled = false;
 			this._renderScene( quad, quad.camera, false );
+			this.xr.enabled = currentXREnabled;
 
 		}
 
@@ -2017,7 +2021,7 @@ class Renderer {
 	 */
 	get currentToneMapping() {
 
-		return this._renderTarget !== null ? NoToneMapping : this.toneMapping;
+		return ( this._renderTarget !== null && this._renderTarget.isXRRenderTarget !== true ) ? NoToneMapping : this.toneMapping;
 
 	}
 
@@ -2029,7 +2033,7 @@ class Renderer {
 	 */
 	get currentColorSpace() {
 
-		return this._renderTarget !== null ? LinearSRGBColorSpace : this.outputColorSpace;
+		return ( this._renderTarget !== null && this._renderTarget.isXRRenderTarget !== true ) ? LinearSRGBColorSpace : this.outputColorSpace;
 
 	}
 

--- a/src/renderers/common/XRManager.js
+++ b/src/renderers/common/XRManager.js
@@ -545,6 +545,11 @@ class XRManager extends EventDispatcher {
 
 	}
 
+	foveateBoundTexture( ) {
+
+		if ( this._glBinding && this._glBinding.foveateBoundTexture ) this._glBinding.foveateBoundTexture( this._renderer.getContext().TEXTURE_2D, this.getFoveation() );
+
+	}
 	/**
 	 * After a XR session has been requested usually with one of the `*Button` modules, it
 	 * is injected into the renderer with this method. This method triggers the start of

--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -1963,6 +1963,9 @@ class WebGLBackend extends Backend {
 
 							if ( useMultisampledRTT ) {
 
+								state.bindTexture( gl.TEXTURE_2D, textureData.textureGPU );
+								this.renderer.xr.foveateBoundTexture();
+
 								multisampledRTTExt.framebufferTexture2DMultisampleEXT( gl.FRAMEBUFFER, attachment, gl.TEXTURE_2D, textureData.textureGPU, 0, samples );
 
 							} else {
@@ -2034,7 +2037,7 @@ class WebGLBackend extends Backend {
 
 					const depthStyle = stencilBuffer ? gl.DEPTH_STENCIL_ATTACHMENT : gl.DEPTH_ATTACHMENT;
 
-					if ( renderTarget.autoAllocateDepthBuffer === true ) {
+					if ( ( renderTarget.autoAllocateDepthBuffer === true ) && !useMultisampledRTT ) {
 
 						const renderbuffer = renderTargetContextData.xrDepthRenderbuffer;
 						gl.bindRenderbuffer( gl.RENDERBUFFER, renderbuffer );


### PR DESCRIPTION
Proposal to foveate a user provided texture. I need to talk to the immersive group about adding this new API.

Without this feature:
`Surface 2    | 3360x1760 | color 32bit, depth 24bit, stencil 0 bit, MSAA 4, Mode: 1 (HwBinning) | 63  384x256 bins ( 63  rendered) |  1.38 ms | 128 stages : Binning : 0.194ms Render : 0.727ms StoreColor : 0.133ms Blit : 0.004ms`

With this feature:
`Surface 8    | 3360x1760 | color 32bit, depth 24bit, stencil 0 bit, MSAA 4, Mode: 1 (HwBinning) | 72  288x320 bins ( 38  rendered) |  1.26 ms | 78  stages : Binning : 0.161ms Render : 0.514ms StoreColor : 0.31ms Blit : 0.004ms`

Don't pay too much attention to the timings as they depend on the content that is on the screen. The important part is that there are fewer rendered "bins" since they're bigger in the foveated areas.