### PR TITLE
Docs: Improve dispose guide.

### DIFF
--- a/docs/manual/en/introduction/How-to-dispose-of-objects.html
+++ b/docs/manual/en/introduction/How-to-dispose-of-objects.html
@@ -57,6 +57,13 @@
 		for realizing custom rendering destinations. These objects are only deallocated by executing [page:WebGLRenderTarget.dispose]().
 	</p>
 
+	<h2>Skinned Mesh</h2>
+
+	<p>
+		Skinned meshes represent their bone hierarchy as skeletons. If you don't need a skinned mesh anymore, consider to call [page:Skeleton.dispose]() on the skeleton to free internal resources.
+		Keep in mind that skeletons can be shared across multiple skinned meshes, so only call `dispose()` if the skeleton is not used by other active skinned meshes.
+	</p>
+
 	<h2>Miscellaneous</h2>
 
 	<p>


### PR DESCRIPTION
Fixed #30438.

**Description**

Adds a section about skinned meshes in the dispose guide to clarify the usage of `object.skeleton.dispose()`.