### PR TITLE
Docs: Simplify JSDoc.

### DIFF
--- a/examples/jsm/tsl/display/AfterImageNode.js
+++ b/examples/jsm/tsl/display/AfterImageNode.js
@@ -1,8 +1,6 @@
 import { RenderTarget, Vector2, QuadMesh, NodeMaterial, RendererUtils, TempNode, NodeUpdateType } from 'three/webgpu';
 import { nodeObject, Fn, float, uv, texture, passTexture, uniform, sign, max, convertToTexture } from 'three/tsl';
 
-/** @module AfterImageNode **/
-
 const _size = /*@__PURE__*/ new Vector2();
 const _quadMeshComp = /*@__PURE__*/ new QuadMesh();
 

--- a/examples/jsm/tsl/display/AnaglyphPassNode.js
+++ b/examples/jsm/tsl/display/AnaglyphPassNode.js
@@ -2,8 +2,6 @@ import { Matrix3, NodeMaterial } from 'three/webgpu';
 import { clamp, nodeObject, Fn, vec4, uv, uniform, max } from 'three/tsl';
 import StereoCompositePassNode from './StereoCompositePassNode.js';
 
-/** @module AnaglyphPassNode **/
-
 /**
  * A render pass node that creates an anaglyph effect.
  *

--- a/examples/jsm/tsl/display/AnamorphicNode.js
+++ b/examples/jsm/tsl/display/AnamorphicNode.js
@@ -1,8 +1,6 @@
 import { RenderTarget, Vector2, TempNode, QuadMesh, NodeMaterial, RendererUtils } from 'three/webgpu';
 import { nodeObject, Fn, float, NodeUpdateType, uv, passTexture, uniform, convertToTexture, vec2, vec3, Loop, mix, luminance } from 'three/tsl';
 
-/** @module AnamorphicNode **/
-
 const _quadMesh = /*@__PURE__*/ new QuadMesh();
 
 let _rendererState;

--- a/examples/jsm/tsl/display/BleachBypass.js
+++ b/examples/jsm/tsl/display/BleachBypass.js
@@ -1,7 +1,5 @@
 import { float, Fn, vec3, vec4, min, max, mix, luminance } from 'three/tsl';
 
-/** @module BleachBypass **/
-
 /**
  * Applies a bleach bypass effect to the given color node.
  *

--- a/examples/jsm/tsl/display/BloomNode.js
+++ b/examples/jsm/tsl/display/BloomNode.js
@@ -1,8 +1,6 @@
 import { HalfFloatType, RenderTarget, Vector2, Vector3, TempNode, QuadMesh, NodeMaterial, RendererUtils, NodeUpdateType } from 'three/webgpu';
 import { nodeObject, Fn, float, uv, passTexture, uniform, Loop, texture, luminance, smoothstep, mix, vec4, uniformArray, add, int } from 'three/tsl';
 
-/** @module BloomNode **/
-
 const _quadMesh = /*@__PURE__*/ new QuadMesh();
 const _size = /*@__PURE__*/ new Vector2();
 

--- a/examples/jsm/tsl/display/DenoiseNode.js
+++ b/examples/jsm/tsl/display/DenoiseNode.js
@@ -2,8 +2,6 @@ import { DataTexture, RepeatWrapping, Vector2, Vector3, TempNode } from 'three/w
 import { texture, getNormalFromDepth, getViewPosition, convertToTexture, nodeObject, Fn, float, NodeUpdateType, uv, uniform, Loop, luminance, vec2, vec3, vec4, uniformArray, int, dot, max, pow, abs, If, textureSize, sin, cos, mat2, PI } from 'three/tsl';
 import { SimplexNoise } from '../../math/SimplexNoise.js';
 
-/** @module DenoiseNode **/
-
 /**
  * Post processing node for denoising data like raw screen-space ambient occlusion output.
  * Denoise can noticeably improve the quality of ambient occlusion but also add quite some

--- a/examples/jsm/tsl/display/DepthOfFieldNode.js
+++ b/examples/jsm/tsl/display/DepthOfFieldNode.js
@@ -1,8 +1,6 @@
 import { TempNode, NodeUpdateType } from 'three/webgpu';
 import { convertToTexture, nodeObject, Fn, uv, uniform, vec2, vec4, clamp } from 'three/tsl';
 
-/** @module DepthOfFieldNode **/
-
 /**
  * Post processing node for creating depth of field (DOF) effect.
  *

--- a/examples/jsm/tsl/display/DotScreenNode.js
+++ b/examples/jsm/tsl/display/DotScreenNode.js
@@ -1,8 +1,6 @@
 import { TempNode } from 'three/webgpu';
 import { nodeObject, Fn, uv, uniform, vec2, vec3, sin, cos, add, vec4, screenSize } from 'three/tsl';
 
-/** @module DotScreenNode **/
-
 /**
  * Post processing node for creating dot-screen effect.
  *

--- a/examples/jsm/tsl/display/FXAANode.js
+++ b/examples/jsm/tsl/display/FXAANode.js
@@ -1,8 +1,6 @@
 import { Vector2, TempNode } from 'three/webgpu';
 import { nodeObject, Fn, uniformArray, select, float, NodeUpdateType, uv, dot, clamp, uniform, convertToTexture, smoothstep, bool, vec2, vec3, If, Loop, max, min, Break, abs } from 'three/tsl';
 
-/** @module FXAANode **/
-
 /**
  * Post processing node for applying FXAA. This node requires sRGB input
  * so tone mapping and color space conversion must happen before the anti-aliasing.

--- a/examples/jsm/tsl/display/FilmNode.js
+++ b/examples/jsm/tsl/display/FilmNode.js
@@ -1,8 +1,6 @@
 import { TempNode } from 'three/webgpu';
 import { rand, Fn, fract, time, uv, clamp, mix, vec4, nodeProxy } from 'three/tsl';
 
-/** @module FilmNode **/
-
 /**
  * Post processing node for creating a film grain effect.
  *

--- a/examples/jsm/tsl/display/GTAONode.js
+++ b/examples/jsm/tsl/display/GTAONode.js
@@ -1,8 +1,6 @@
 import { DataTexture, RenderTarget, RepeatWrapping, Vector2, Vector3, TempNode, QuadMesh, NodeMaterial, RendererUtils } from 'three/webgpu';
 import { reference, logarithmicDepthToViewZ, viewZToPerspectiveDepth, getNormalFromDepth, getScreenPosition, getViewPosition, nodeObject, Fn, float, NodeUpdateType, uv, uniform, Loop, vec2, vec3, vec4, int, dot, max, pow, abs, If, textureSize, sin, cos, PI, texture, passTexture, mat3, add, normalize, mul, cross, div, mix, sqrt, sub, acos, clamp } from 'three/tsl';
 
-/** @module GTAONode **/
-
 const _quadMesh = /*@__PURE__*/ new QuadMesh();
 const _size = /*@__PURE__*/ new Vector2();
 

--- a/examples/jsm/tsl/display/GaussianBlurNode.js
+++ b/examples/jsm/tsl/display/GaussianBlurNode.js
@@ -1,8 +1,6 @@
 import { RenderTarget, Vector2, NodeMaterial, RendererUtils, QuadMesh, TempNode, NodeUpdateType } from 'three/webgpu';
 import { nodeObject, Fn, If, float, uv, uniform, convertToTexture, vec2, vec4, passTexture, mul } from 'three/tsl';
 
-/** @module GaussianBlurNode **/
-
 const _quadMesh = /*@__PURE__*/ new QuadMesh();
 
 let _rendererState;

--- a/examples/jsm/tsl/display/LensflareNode.js
+++ b/examples/jsm/tsl/display/LensflareNode.js
@@ -1,8 +1,6 @@
 import { RenderTarget, Vector2, TempNode, NodeUpdateType, QuadMesh, RendererUtils, NodeMaterial } from 'three/webgpu';
 import { convertToTexture, nodeObject, Fn, passTexture, uv, vec2, vec3, vec4, max, float, sub, int, Loop, fract, pow, distance } from 'three/tsl';
 
-/** @module LensflareNode **/
-
 const _quadMesh = /*@__PURE__*/ new QuadMesh();
 const _size = /*@__PURE__*/ new Vector2();
 let _rendererState;

--- a/examples/jsm/tsl/display/Lut3DNode.js
+++ b/examples/jsm/tsl/display/Lut3DNode.js
@@ -1,8 +1,6 @@
 import { TempNode } from 'three/webgpu';
 import { nodeObject, Fn, float, uniform, vec3, vec4, mix } from 'three/tsl';
 
-/** @module Lut3DNode **/
-
 /**
  * A post processing node for color grading via lookup tables.
  *

--- a/examples/jsm/tsl/display/MotionBlur.js
+++ b/examples/jsm/tsl/display/MotionBlur.js
@@ -1,7 +1,5 @@
 import { Fn, float, uv, Loop, int } from 'three/tsl';
 
-/** @module MotionBlur **/
-
 /**
  * Applies a motion blur effect to the given input node.
  *

--- a/examples/jsm/tsl/display/OutlineNode.js
+++ b/examples/jsm/tsl/display/OutlineNode.js
@@ -1,8 +1,6 @@
 import { DepthTexture, FloatType, RenderTarget, Vector2, TempNode, QuadMesh, NodeMaterial, RendererUtils, NodeUpdateType } from 'three/webgpu';
 import { Loop, int, exp, min, float, mul, uv, vec2, vec3, Fn, textureSize, orthographicDepthToViewZ, screenUV, nodeObject, uniform, vec4, passTexture, texture, perspectiveDepthToViewZ, positionView, reference } from 'three/tsl';
 
-/** @module OutlineNode **/
-
 const _quadMesh = /*@__PURE__*/ new QuadMesh();
 const _size = /*@__PURE__*/ new Vector2();
 const _BLUR_DIRECTION_X = /*@__PURE__*/ new Vector2( 1.0, 0.0 );

--- a/examples/jsm/tsl/display/ParallaxBarrierPassNode.js
+++ b/examples/jsm/tsl/display/ParallaxBarrierPassNode.js
@@ -2,8 +2,6 @@ import { NodeMaterial } from 'three/webgpu';
 import { nodeObject, Fn, vec4, uv, If, mod, screenCoordinate } from 'three/tsl';
 import StereoCompositePassNode from './StereoCompositePassNode.js';
 
-/** @module ParallaxBarrierPassNode **/
-
 /**
  * A render pass node that creates a parallax barrier effect.
  *

--- a/examples/jsm/tsl/display/PixelationPassNode.js
+++ b/examples/jsm/tsl/display/PixelationPassNode.js
@@ -1,8 +1,6 @@
 import { NearestFilter, Vector4, TempNode, NodeUpdateType, PassNode } from 'three/webgpu';
 import { nodeObject, Fn, float, uv, uniform, convertToTexture, vec2, vec3, clamp, floor, dot, smoothstep, If, sign, step, mrt, output, normalView, property } from 'three/tsl';
 
-/** @module PixelationPassNode **/
-
 /**
  * A inner node definition that implements the actual pixelation TSL code.
  *

--- a/examples/jsm/tsl/display/RGBShiftNode.js
+++ b/examples/jsm/tsl/display/RGBShiftNode.js
@@ -1,8 +1,6 @@
 import { TempNode } from 'three/webgpu';
 import { nodeObject, Fn, uv, uniform, vec2, sin, cos, vec4, convertToTexture } from 'three/tsl';
 
-/** @module RGBShiftNode **/
-
 /**
  * Post processing node for shifting/splitting RGB color channels. The effect
  * separates color channels and offsets them from each other.

--- a/examples/jsm/tsl/display/SMAANode.js
+++ b/examples/jsm/tsl/display/SMAANode.js
@@ -1,8 +1,6 @@
 import { HalfFloatType, LinearFilter, NearestFilter, RenderTarget, Texture, Vector2, QuadMesh, NodeMaterial, TempNode, RendererUtils } from 'three/webgpu';
 import { abs, nodeObject, Fn, NodeUpdateType, uv, uniform, convertToTexture, varyingProperty, vec2, vec4, modelViewProjection, passTexture, max, step, dot, float, texture, If, Loop, int, Break, sqrt, sign, mix } from 'three/tsl';
 
-/** @module SMAANode **/
-
 const _quadMesh = /*@__PURE__*/ new QuadMesh();
 const _size = /*@__PURE__*/ new Vector2();
 

--- a/examples/jsm/tsl/display/SSAAPassNode.js
+++ b/examples/jsm/tsl/display/SSAAPassNode.js
@@ -1,8 +1,6 @@
 import { AdditiveBlending, Color, Vector2, RendererUtils, PassNode, QuadMesh, NodeMaterial } from 'three/webgpu';
 import { nodeObject, uniform, mrt, texture, getTextureIndex } from 'three/tsl';
 
-/** @module SSAAPassNode **/
-
 const _size = /*@__PURE__*/ new Vector2();
 
 let _rendererState;
@@ -16,7 +14,7 @@ let _rendererState;
  *
  * Reference: {@link https://en.wikipedia.org/wiki/Supersampling}
  *
- * @augments module:PassNode~PassNode
+ * @augments PassNode
  */
 class SSAAPassNode extends PassNode {
 

--- a/examples/jsm/tsl/display/SSRNode.js
+++ b/examples/jsm/tsl/display/SSRNode.js
@@ -1,8 +1,6 @@
 import { NearestFilter, RenderTarget, Vector2, RendererUtils, QuadMesh, TempNode, NodeMaterial, NodeUpdateType } from 'three/webgpu';
 import { reference, viewZToPerspectiveDepth, logarithmicDepthToViewZ, getScreenPosition, getViewPosition, sqrt, mul, div, cross, float, Continue, Break, Loop, int, max, abs, sub, If, dot, reflect, normalize, screenCoordinate, nodeObject, Fn, passTexture, uv, uniform, perspectiveDepthToViewZ, orthographicDepthToViewZ, vec2, vec3, vec4 } from 'three/tsl';
 
-/** @module SSRNode **/
-
 const _quadMesh = /*@__PURE__*/ new QuadMesh();
 const _size = /*@__PURE__*/ new Vector2();
 let _rendererState;

--- a/examples/jsm/tsl/display/Sepia.js
+++ b/examples/jsm/tsl/display/Sepia.js
@@ -1,7 +1,5 @@
 import { dot, Fn, vec3, vec4 } from 'three/tsl';
 
-/** @module Sepia **/
-
 /**
  * Applies a sepia effect to the given color node.
  *

--- a/examples/jsm/tsl/display/SobelOperatorNode.js
+++ b/examples/jsm/tsl/display/SobelOperatorNode.js
@@ -1,8 +1,6 @@
 import { Vector2, TempNode, NodeUpdateType } from 'three/webgpu';
 import { nodeObject, Fn, uv, uniform, convertToTexture, vec2, vec3, vec4, mat3, luminance, add } from 'three/tsl';
 
-/** @module SobelOperatorNode **/
-
 /**
  * Post processing node for detecting edges with a sobel filter.
  * A sobel filter should be applied after tone mapping and output color

--- a/examples/jsm/tsl/display/StereoCompositePassNode.js
+++ b/examples/jsm/tsl/display/StereoCompositePassNode.js
@@ -14,7 +14,7 @@ let _rendererState;
  * anaglyph or parallax barrier.
  *
  * @abstract
- * @augments module:PassNode~PassNode
+ * @augments PassNode
  */
 class StereoCompositePassNode extends PassNode {
 

--- a/examples/jsm/tsl/display/StereoPassNode.js
+++ b/examples/jsm/tsl/display/StereoPassNode.js
@@ -1,8 +1,6 @@
 import { StereoCamera, Vector2, PassNode, RendererUtils } from 'three/webgpu';
 import { nodeObject } from 'three/tsl';
 
-/** @module StereoPassNode **/
-
 const _size = /*@__PURE__*/ new Vector2();
 
 let _rendererState;
@@ -10,7 +8,7 @@ let _rendererState;
 /**
  * A special render pass node that renders the scene as a stereoscopic image.
  *
- * @augments module:PassNode~PassNode
+ * @augments PassNode
  */
 class StereoPassNode extends PassNode {
 

--- a/examples/jsm/tsl/display/TRAAPassNode.js
+++ b/examples/jsm/tsl/display/TRAAPassNode.js
@@ -1,8 +1,6 @@
 import { Color, Vector2, NearestFilter, Matrix4, RendererUtils, PassNode, QuadMesh, NodeMaterial } from 'three/webgpu';
 import { add, float, If, Loop, int, Fn, min, max, clamp, nodeObject, texture, uniform, uv, vec2, vec4, luminance } from 'three/tsl';
 
-/** @module TRAAPassNode **/
-
 const _quadMesh = /*@__PURE__*/ new QuadMesh();
 const _size = /*@__PURE__*/ new Vector2();
 
@@ -18,7 +16,7 @@ let _rendererState;
  * - {@link https://alextardif.com/TAA.html}
  * - {@link https://www.elopezr.com/temporal-aa-and-the-quest-for-the-holy-trail/}
  *
- * @augments module:PassNode~PassNode
+ * @augments PassNode
  */
 class TRAAPassNode extends PassNode {
 

--- a/examples/jsm/tsl/display/TransitionNode.js
+++ b/examples/jsm/tsl/display/TransitionNode.js
@@ -1,8 +1,6 @@
 import { TempNode } from 'three/webgpu';
 import { nodeObject, Fn, float, uv, convertToTexture, vec4, If, int, clamp, sub, mix } from 'three/tsl';
 
-/** @module TransitionNode **/
-
 /**
  * Post processing node for creating a transition effect between scenes.
  *

--- a/examples/jsm/tsl/display/hashBlur.js
+++ b/examples/jsm/tsl/display/hashBlur.js
@@ -1,7 +1,5 @@
 import { float, Fn, vec2, uv, sin, rand, degrees, cos, Loop, vec4 } from 'three/tsl';
 
-/** @module HashBlur **/
-
 /**
  * Applies a hash blur effect to the given texture node.
  *

--- a/src/materials/nodes/LineDashedNodeMaterial.js
+++ b/src/materials/nodes/LineDashedNodeMaterial.js
@@ -55,7 +55,7 @@ class LineDashedNodeMaterial extends NodeMaterial {
 		 * and define the offset with a node instead.
 		 *
 		 * If you don't want to overwrite the offset but modify the existing
-		 * value instead, use {@link module:MaterialNode.materialLineDashOffset}.
+		 * value instead, use {@link materialLineDashOffset}.
 		 *
 		 * @type {Node<float>?}
 		 * @default null
@@ -68,7 +68,7 @@ class LineDashedNodeMaterial extends NodeMaterial {
 		 * and define the scale with a node instead.
 		 *
 		 * If you don't want to overwrite the scale but modify the existing
-		 * value instead, use {@link module:MaterialNode.materialLineScale}.
+		 * value instead, use {@link materialLineScale}.
 		 *
 		 * @type {Node<float>?}
 		 * @default null
@@ -81,7 +81,7 @@ class LineDashedNodeMaterial extends NodeMaterial {
 		 * and define the dash size with a node instead.
 		 *
 		 * If you don't want to overwrite the dash size but modify the existing
-		 * value instead, use {@link module:MaterialNode.materialLineDashSize}.
+		 * value instead, use {@link materialLineDashSize}.
 		 *
 		 * @type {Node<float>?}
 		 * @default null
@@ -94,7 +94,7 @@ class LineDashedNodeMaterial extends NodeMaterial {
 		 * and define the gap size with a node instead.
 		 *
 		 * If you don't want to overwrite the gap size but modify the existing
-		 * value instead, use {@link module:MaterialNode.materialLineGapSize}.
+		 * value instead, use {@link materialLineGapSize}.
 		 *
 		 * @type {Node<float>?}
 		 * @default null

--- a/src/materials/nodes/MeshBasicNodeMaterial.js
+++ b/src/materials/nodes/MeshBasicNodeMaterial.js
@@ -59,7 +59,7 @@ class MeshBasicNodeMaterial extends NodeMaterial {
 
 	/**
 	 * Basic materials are not affected by normal and bump maps so we
-	 * return by default {@link module:Normal.normalView}.
+	 * return by default {@link normalView}.
 	 *
 	 * @return {Node<vec3>} The normal node.
 	 */

--- a/src/materials/nodes/MeshPhongNodeMaterial.js
+++ b/src/materials/nodes/MeshPhongNodeMaterial.js
@@ -54,7 +54,7 @@ class MeshPhongNodeMaterial extends NodeMaterial {
 		 * and define the shininess with a node instead.
 		 *
 		 * If you don't want to overwrite the shininess but modify the existing
-		 * value instead, use {@link module:MaterialNode.materialShininess}.
+		 * value instead, use {@link materialShininess}.
 		 *
 		 * @type {Node<float>?}
 		 * @default null
@@ -67,7 +67,7 @@ class MeshPhongNodeMaterial extends NodeMaterial {
 		 * and define the specular color with a node instead.
 		 *
 		 * If you don't want to overwrite the specular color but modify the existing
-		 * value instead, use {@link module:MaterialNode.materialSpecular}.
+		 * value instead, use {@link materialSpecular}.
 		 *
 		 * @type {Node<vec3>?}
 		 * @default null

--- a/src/materials/nodes/MeshPhysicalNodeMaterial.js
+++ b/src/materials/nodes/MeshPhysicalNodeMaterial.js
@@ -48,7 +48,7 @@ class MeshPhysicalNodeMaterial extends MeshStandardNodeMaterial {
 		 * and define the clearcoat with a node instead.
 		 *
 		 * If you don't want to overwrite the clearcoat but modify the existing
-		 * value instead, use {@link module:MaterialNode.materialClearcoat}.
+		 * value instead, use {@link materialClearcoat}.
 		 *
 		 * @type {Node<float>?}
 		 * @default null
@@ -61,7 +61,7 @@ class MeshPhysicalNodeMaterial extends MeshStandardNodeMaterial {
 		 * and define the clearcoat roughness with a node instead.
 		 *
 		 * If you don't want to overwrite the clearcoat roughness but modify the existing
-		 * value instead, use {@link module:MaterialNode.materialClearcoatRoughness}.
+		 * value instead, use {@link materialClearcoatRoughness}.
 		 *
 		 * @type {Node<float>?}
 		 * @default null
@@ -74,7 +74,7 @@ class MeshPhysicalNodeMaterial extends MeshStandardNodeMaterial {
 		 * and define the clearcoat normal with a node instead.
 		 *
 		 * If you don't want to overwrite the clearcoat normal but modify the existing
-		 * value instead, use {@link module:MaterialNode.materialClearcoatNormal}.
+		 * value instead, use {@link materialClearcoatNormal}.
 		 *
 		 * @type {Node<vec3>?}
 		 * @default null
@@ -87,7 +87,7 @@ class MeshPhysicalNodeMaterial extends MeshStandardNodeMaterial {
 		 * and define the sheen with a node instead.
 		 *
 		 * If you don't want to overwrite the sheen but modify the existing
-		 * value instead, use {@link module:MaterialNode.materialSheen}.
+		 * value instead, use {@link materialSheen}.
 		 *
 		 * @type {Node<vec3>?}
 		 * @default null
@@ -100,7 +100,7 @@ class MeshPhysicalNodeMaterial extends MeshStandardNodeMaterial {
 		 * and define the sheen roughness with a node instead.
 		 *
 		 * If you don't want to overwrite the sheen roughness but modify the existing
-		 * value instead, use {@link module:MaterialNode.materialSheenRoughness}.
+		 * value instead, use {@link materialSheenRoughness}.
 		 *
 		 * @type {Node<float>?}
 		 * @default null
@@ -113,7 +113,7 @@ class MeshPhysicalNodeMaterial extends MeshStandardNodeMaterial {
 		 * and define the iridescence with a node instead.
 		 *
 		 * If you don't want to overwrite the iridescence but modify the existing
-		 * value instead, use {@link module:MaterialNode.materialIridescence}.
+		 * value instead, use {@link materialIridescence}.
 		 *
 		 * @type {Node<float>?}
 		 * @default null
@@ -126,7 +126,7 @@ class MeshPhysicalNodeMaterial extends MeshStandardNodeMaterial {
 		 * and define the iridescence IOR with a node instead.
 		 *
 		 * If you don't want to overwrite the iridescence IOR but modify the existing
-		 * value instead, use {@link module:MaterialNode.materialIridescenceIOR}.
+		 * value instead, use {@link materialIridescenceIOR}.
 		 *
 		 * @type {Node<float>?}
 		 * @default null
@@ -139,7 +139,7 @@ class MeshPhysicalNodeMaterial extends MeshStandardNodeMaterial {
 		 * and define the iridescence thickness with a node instead.
 		 *
 		 * If you don't want to overwrite the iridescence thickness but modify the existing
-		 * value instead, use {@link module:MaterialNode.materialIridescenceThickness}.
+		 * value instead, use {@link materialIridescenceThickness}.
 		 *
 		 * @type {Node<float>?}
 		 * @default null
@@ -152,7 +152,7 @@ class MeshPhysicalNodeMaterial extends MeshStandardNodeMaterial {
 		 * and define the specular intensity with a node instead.
 		 *
 		 * If you don't want to overwrite the specular intensity but modify the existing
-		 * value instead, use {@link module:MaterialNode.materialSpecularIntensity}.
+		 * value instead, use {@link materialSpecularIntensity}.
 		 *
 		 * @type {Node<float>?}
 		 * @default null
@@ -165,7 +165,7 @@ class MeshPhysicalNodeMaterial extends MeshStandardNodeMaterial {
 		 * and define the specular color with a node instead.
 		 *
 		 * If you don't want to overwrite the specular color but modify the existing
-		 * value instead, use {@link module:MaterialNode.materialSpecularColor}.
+		 * value instead, use {@link materialSpecularColor}.
 		 *
 		 * @type {Node<vec3>?}
 		 * @default null
@@ -178,7 +178,7 @@ class MeshPhysicalNodeMaterial extends MeshStandardNodeMaterial {
 		 * and define the ior with a node instead.
 		 *
 		 * If you don't want to overwrite the ior but modify the existing
-		 * value instead, use {@link module:MaterialNode.materialIOR}.
+		 * value instead, use {@link materialIOR}.
 		 *
 		 * @type {Node<float>?}
 		 * @default null
@@ -191,7 +191,7 @@ class MeshPhysicalNodeMaterial extends MeshStandardNodeMaterial {
 		 * and define the transmission with a node instead.
 		 *
 		 * If you don't want to overwrite the transmission but modify the existing
-		 * value instead, use {@link module:MaterialNode.materialTransmission}.
+		 * value instead, use {@link materialTransmission}.
 		 *
 		 * @type {Node<float>?}
 		 * @default null
@@ -204,7 +204,7 @@ class MeshPhysicalNodeMaterial extends MeshStandardNodeMaterial {
 		 * and define the thickness with a node instead.
 		 *
 		 * If you don't want to overwrite the thickness but modify the existing
-		 * value instead, use {@link module:MaterialNode.materialThickness}.
+		 * value instead, use {@link materialThickness}.
 		 *
 		 * @type {Node<float>?}
 		 * @default null
@@ -217,7 +217,7 @@ class MeshPhysicalNodeMaterial extends MeshStandardNodeMaterial {
 		 * and define the attenuation distance with a node instead.
 		 *
 		 * If you don't want to overwrite the attenuation distance but modify the existing
-		 * value instead, use {@link module:MaterialNode.materialAttenuationDistance}.
+		 * value instead, use {@link materialAttenuationDistance}.
 		 *
 		 * @type {Node<float>?}
 		 * @default null
@@ -230,7 +230,7 @@ class MeshPhysicalNodeMaterial extends MeshStandardNodeMaterial {
 		 * and define the attenuation color with a node instead.
 		 *
 		 * If you don't want to overwrite the attenuation color but modify the existing
-		 * value instead, use {@link module:MaterialNode.materialAttenuationColor}.
+		 * value instead, use {@link materialAttenuationColor}.
 		 *
 		 * @type {Node<vec3>?}
 		 * @default null
@@ -243,7 +243,7 @@ class MeshPhysicalNodeMaterial extends MeshStandardNodeMaterial {
 		 * and define the dispersion with a node instead.
 		 *
 		 * If you don't want to overwrite the dispersion but modify the existing
-		 * value instead, use {@link module:MaterialNode.materialDispersion}.
+		 * value instead, use {@link materialDispersion}.
 		 *
 		 * @type {Node<float>?}
 		 * @default null
@@ -256,7 +256,7 @@ class MeshPhysicalNodeMaterial extends MeshStandardNodeMaterial {
 		 * and define the anisotropy with a node instead.
 		 *
 		 * If you don't want to overwrite the anisotropy but modify the existing
-		 * value instead, use {@link module:MaterialNode.materialAnisotropy}.
+		 * value instead, use {@link materialAnisotropy}.
 		 *
 		 * @type {Node<float>?}
 		 * @default null

--- a/src/materials/nodes/MeshSSSNodeMaterial.js
+++ b/src/materials/nodes/MeshSSSNodeMaterial.js
@@ -4,8 +4,6 @@ import { transformedNormalView } from '../../nodes/accessors/Normal.js';
 import { positionViewDirection } from '../../nodes/accessors/Position.js';
 import { float, vec3 } from '../../nodes/tsl/TSLBase.js';
 
-/** @module MeshSSSNodeMaterial **/
-
 /**
  * Represents the lighting model for {@link MeshSSSNodeMaterial}.
  *

--- a/src/materials/nodes/MeshStandardNodeMaterial.js
+++ b/src/materials/nodes/MeshStandardNodeMaterial.js
@@ -56,7 +56,7 @@ class MeshStandardNodeMaterial extends NodeMaterial {
 		 * overwrite the default and define the emissive color with a node instead.
 		 *
 		 * If you don't want to overwrite the emissive color but modify the existing
-		 * value instead, use {@link module:MaterialNode.materialEmissive}.
+		 * value instead, use {@link materialEmissive}.
 		 *
 		 * @type {Node<vec3>?}
 		 * @default null
@@ -69,7 +69,7 @@ class MeshStandardNodeMaterial extends NodeMaterial {
 		 * overwrite the default and define the metalness with a node instead.
 		 *
 		 * If you don't want to overwrite the metalness but modify the existing
-		 * value instead, use {@link module:MaterialNode.materialMetalness}.
+		 * value instead, use {@link materialMetalness}.
 		 *
 		 * @type {Node<float>?}
 		 * @default null
@@ -82,7 +82,7 @@ class MeshStandardNodeMaterial extends NodeMaterial {
 		 * overwrite the default and define the roughness with a node instead.
 		 *
 		 * If you don't want to overwrite the roughness but modify the existing
-		 * value instead, use {@link module:MaterialNode.materialRoughness}.
+		 * value instead, use {@link materialRoughness}.
 		 *
 		 * @type {Node<float>?}
 		 * @default null

--- a/src/materials/nodes/NodeMaterial.js
+++ b/src/materials/nodes/NodeMaterial.js
@@ -98,7 +98,7 @@ class NodeMaterial extends Material {
 		 * are affected by all lights of the scene. Sometimes selective
 		 * lighting is wanted which means only _some_ lights in the scene
 		 * affect a material. This can be achieved by creating an instance
-		 * of {@link module:LightsNode~LightsNode} with a list of selective
+		 * of {@link LightsNode} with a list of selective
 		 * lights and assign the node to this property.
 		 *
 		 * ```js
@@ -133,7 +133,7 @@ class NodeMaterial extends Material {
 		 * the default and define the ambient occlusion with a custom node instead.
 		 *
 		 * If you don't want to overwrite the diffuse color but modify the existing
-		 * values instead, use {@link module:MaterialNode.materialAO}.
+		 * values instead, use {@link materialAO}.
 		 *
 		 * @type {Node<float>?}
 		 * @default null
@@ -150,7 +150,7 @@ class NodeMaterial extends Material {
 		 * ```
 		 *
 		 * If you don't want to overwrite the diffuse color but modify the existing
-		 * values instead, use {@link module:MaterialNode.materialColor}.
+		 * values instead, use {@link materialColor}.
 		 *
 		 * ```js
 		 * material.colorNode = materialColor.mul( color( 0xff0000 ) ); // give diffuse colors a red tint
@@ -167,7 +167,7 @@ class NodeMaterial extends Material {
 		 * and define the normals with a node instead.
 		 *
 		 * If you don't want to overwrite the normals but modify the existing values instead,
-		 * use {@link module:MaterialNode.materialNormal}.
+		 * use {@link materialNormal}.
 		 *
 		 * @type {Node<vec3>?}
 		 * @default null
@@ -180,7 +180,7 @@ class NodeMaterial extends Material {
 		 * and define the opacity with a node instead.
 		 *
 		 * If you don't want to overwrite the normals but modify the existing
-		 * value instead, use {@link module:MaterialNode.materialOpacity}.
+		 * value instead, use {@link materialOpacity}.
 		 *
 		 * @type {Node<float>?}
 		 * @default null
@@ -222,7 +222,7 @@ class NodeMaterial extends Material {
 		 * alpha test with a node instead.
 		 *
 		 * If you don't want to overwrite the alpha test but modify the existing
-		 * value instead, use {@link module:MaterialNode.materialAlphaTest}.
+		 * value instead, use {@link materialAlphaTest}.
 		 *
 		 * @type {Node<float>?}
 		 * @default null
@@ -235,7 +235,7 @@ class NodeMaterial extends Material {
 		 * the default and define local vertex positions with nodes instead.
 		 *
 		 * If you don't want to overwrite the vertex positions but modify the existing
-		 * values instead, use {@link module:Position.positionLocal}.
+		 * values instead, use {@link positionLocal}.
 		 *
 		 *```js
 		 * material.positionNode = positionLocal.add( displace );
@@ -272,7 +272,7 @@ class NodeMaterial extends Material {
 
 		/**
 		 * Allows to overwrite the position used for shadow map rendering which
-		 * is by default {@link module:Position.positionWorld}, the vertex position
+		 * is by default {@link positionWorld}, the vertex position
 		 * in world space.
 		 *
 		 * @type {Node<float>?}

--- a/src/materials/nodes/SpriteNodeMaterial.js
+++ b/src/materials/nodes/SpriteNodeMaterial.js
@@ -69,7 +69,7 @@ class SpriteNodeMaterial extends NodeMaterial {
 		 * the rotation with a node instead.
 		 *
 		 * If you don't want to overwrite the rotation but modify the existing
-		 * value instead, use {@link module:MaterialNode.materialRotation}.
+		 * value instead, use {@link materialRotation}.
 		 *
 		 * @type {Node<float>?}
 		 * @default null

--- a/src/materials/nodes/VolumeNodeMaterial.js
+++ b/src/materials/nodes/VolumeNodeMaterial.js
@@ -10,8 +10,6 @@ import { Loop, Break } from '../../nodes/utils/LoopNode.js';
 import { texture3D } from '../../nodes/accessors/Texture3DNode.js';
 import { Color } from '../../math/Color.js';
 
-/** @module VolumeNodeMaterial **/
-
 /**
  * Node material intended for volume rendering. The volumetric data are
  * defined with an instance of {@link Data3DTexture}.

--- a/src/nodes/accessors/AccessorsUtils.js
+++ b/src/nodes/accessors/AccessorsUtils.js
@@ -6,8 +6,6 @@ import { mix } from '../math/MathNode.js';
 import { anisotropy, anisotropyB, roughness } from '../core/PropertyNode.js';
 import { positionViewDirection } from './Position.js';
 
-/** @module AccessorsUtils **/
-
 /**
  * TSL object that represents the TBN matrix in view space.
  *

--- a/src/nodes/accessors/Arrays.js
+++ b/src/nodes/accessors/Arrays.js
@@ -3,8 +3,6 @@ import StorageBufferAttribute from '../../renderers/common/StorageBufferAttribut
 import { storage } from './StorageBufferNode.js';
 import { getLengthFromType, getTypedArrayFromType } from '../core/NodeUtils.js';
 
-/** @module Arrays **/
-
 /**
  * TSL function for creating a storage buffer node with a configured `StorageBufferAttribute`.
  *

--- a/src/nodes/accessors/BatchNode.js
+++ b/src/nodes/accessors/BatchNode.js
@@ -8,8 +8,6 @@ import { tangentLocal } from './Tangent.js';
 import { instanceIndex, drawIndex } from '../core/IndexNode.js';
 import { varyingProperty } from '../core/PropertyNode.js';
 
-/** @module BatchNode **/
-
 /**
  * This node implements the vertex shader logic which is required
  * when rendering 3D objects via batching. `BatchNode` must be used

--- a/src/nodes/accessors/Bitangent.js
+++ b/src/nodes/accessors/Bitangent.js
@@ -3,8 +3,6 @@ import { cameraViewMatrix } from './Camera.js';
 import { normalGeometry, normalLocal, normalView, normalWorld, transformedNormalView } from './Normal.js';
 import { tangentGeometry, tangentLocal, tangentView, tangentWorld, transformedTangentView } from './Tangent.js';
 
-/** @module Bitangent **/
-
 const getBitangent = ( crossNormalTangent ) => crossNormalTangent.mul( tangentGeometry.w ).xyz;
 
 /**

--- a/src/nodes/accessors/BufferAttributeNode.js
+++ b/src/nodes/accessors/BufferAttributeNode.js
@@ -6,8 +6,6 @@ import { InterleavedBufferAttribute } from '../../core/InterleavedBufferAttribut
 import { InterleavedBuffer } from '../../core/InterleavedBuffer.js';
 import { StaticDrawUsage, DynamicDrawUsage } from '../../constants.js';
 
-/** @module BufferAttributeNode **/
-
 /**
  * In earlier `three.js` versions it was only possible to define attribute data
  * on geometry level. With `BufferAttributeNode`, it is also possible to do this

--- a/src/nodes/accessors/BufferNode.js
+++ b/src/nodes/accessors/BufferNode.js
@@ -1,8 +1,6 @@
 import UniformNode from '../core/UniformNode.js';
 import { nodeObject } from '../tsl/TSLBase.js';
 
-/** @module BufferNode **/
-
 /**
  * A special type of uniform node which represents array-like data
  * as uniform buffers. The access usually happens via `element()`
@@ -15,7 +13,7 @@ import { nodeObject } from '../tsl/TSLBase.js';
  * In general, it is recommended to use the more managed {@link UniformArrayNode}
  * since it handles more input types and automatically cares about buffer paddings.
  *
- * @augments module:UniformNode~UniformNode
+ * @augments UniformNode
  */
 class BufferNode extends UniformNode {
 

--- a/src/nodes/accessors/BuiltinNode.js
+++ b/src/nodes/accessors/BuiltinNode.js
@@ -1,8 +1,6 @@
 import Node from '../core/Node.js';
 import { nodeProxy } from '../tsl/TSLBase.js';
 
-/** @module BuiltinNode **/
-
 /**
  * The node allows to set values for built-in shader variables. That is
  * required for features like hardware-accelerated vertex clipping.

--- a/src/nodes/accessors/Camera.js
+++ b/src/nodes/accessors/Camera.js
@@ -4,8 +4,6 @@ import { Vector3 } from '../../math/Vector3.js';
 import { Fn } from '../tsl/TSLBase.js';
 import { uniformArray } from './UniformArrayNode.js';
 
-/** @module Camera **/
-
 /**
  * TSL object that represents the current `index` value of the camera if used ArrayCamera.
  *

--- a/src/nodes/accessors/ClippingNode.js
+++ b/src/nodes/accessors/ClippingNode.js
@@ -8,8 +8,6 @@ import { smoothstep } from '../math/MathNode.js';
 import { uniformArray } from './UniformArrayNode.js';
 import { builtin } from './BuiltinNode.js';
 
-/** @module ClippingNode **/
-
 /**
  * ```
  * This node is used in {@link NodeMaterial} to setup the clipping

--- a/src/nodes/accessors/CubeTextureNode.js
+++ b/src/nodes/accessors/CubeTextureNode.js
@@ -4,12 +4,10 @@ import { nodeProxy, vec3 } from '../tsl/TSLBase.js';
 
 import { CubeReflectionMapping, CubeRefractionMapping, WebGPUCoordinateSystem } from '../../constants.js';
 
-/** @module CubeTextureNode **/
-
 /**
  * This type of uniform node represents a cube texture.
  *
- * @augments module:TextureNode~TextureNode
+ * @augments TextureNode
  */
 class CubeTextureNode extends TextureNode {
 

--- a/src/nodes/accessors/InstanceNode.js
+++ b/src/nodes/accessors/InstanceNode.js
@@ -12,8 +12,6 @@ import { InstancedInterleavedBuffer } from '../../core/InstancedInterleavedBuffe
 import { InstancedBufferAttribute } from '../../core/InstancedBufferAttribute.js';
 import { DynamicDrawUsage } from '../../constants.js';
 
-/** @module InstanceNode **/
-
 /**
  * This node implements the vertex shader logic which is required
  * when rendering 3D objects via instancing. The code makes sure

--- a/src/nodes/accessors/InstancedMeshNode.js
+++ b/src/nodes/accessors/InstancedMeshNode.js
@@ -1,13 +1,11 @@
 import InstanceNode from './InstanceNode.js';
 import { nodeProxy } from '../tsl/TSLBase.js';
 
-/** @module InstancedMeshNode **/
-
 /**
  * This is a special version of `InstanceNode` which requires the usage of {@link InstancedMesh}.
  * It allows an easier setup of the instance node.
  *
- * @augments module:InstanceNode~InstanceNode
+ * @augments InstanceNode
  */
 class InstancedMeshNode extends InstanceNode {
 

--- a/src/nodes/accessors/Lights.js
+++ b/src/nodes/accessors/Lights.js
@@ -4,8 +4,6 @@ import { Vector3 } from '../../math/Vector3.js';
 import { cameraViewMatrix } from './Camera.js';
 import { positionWorld } from './Position.js';
 
-/** @module Lights **/
-
 let uniformsLib;
 
 function getLightData( light ) {

--- a/src/nodes/accessors/MaterialNode.js
+++ b/src/nodes/accessors/MaterialNode.js
@@ -8,8 +8,6 @@ import { normalMap } from '../display/NormalMapNode.js';
 import { bumpMap } from '../display/BumpMapNode.js';
 import { Vector2 } from '../../math/Vector2.js';
 
-/** @module MaterialNode **/
-
 const _propertyCache = new Map();
 
 /**

--- a/src/nodes/accessors/MaterialProperties.js
+++ b/src/nodes/accessors/MaterialProperties.js
@@ -1,7 +1,5 @@
 import { uniform } from '../core/UniformNode.js';
 
-/** @module MaterialProperties **/
-
 /**
  * TSL object that represents the refraction ratio of the material used for rendering the current object.
  *

--- a/src/nodes/accessors/MaterialReferenceNode.js
+++ b/src/nodes/accessors/MaterialReferenceNode.js
@@ -1,8 +1,6 @@
 import ReferenceNode from './ReferenceNode.js';
 import { nodeObject } from '../tsl/TSLBase.js';
 
-/** @module MaterialReferenceNode **/
-
 /**
  * This node is a special type of reference node which is intended
  * for linking material properties with node values.
@@ -12,7 +10,7 @@ import { nodeObject } from '../tsl/TSLBase.js';
  * When changing `material.opacity`, the node value of `opacityNode` will
  * automatically be updated.
  *
- * @augments module:ReferenceNode~ReferenceNode
+ * @augments ReferenceNode
  */
 class MaterialReferenceNode extends ReferenceNode {
 
@@ -56,7 +54,7 @@ class MaterialReferenceNode extends ReferenceNode {
 
 	/**
 	 * Updates the reference based on the given state. The state is only evaluated
-	 * {@link module:MaterialReferenceNode~MaterialReferenceNode#material} is not set.
+	 * {@link MaterialReferenceNode#material} is not set.
 	 *
 	 * @param {(NodeFrame|NodeBuilder)} state - The current state.
 	 * @return {Object} The updated reference.

--- a/src/nodes/accessors/ModelNode.js
+++ b/src/nodes/accessors/ModelNode.js
@@ -6,15 +6,13 @@ import { Matrix4 } from '../../math/Matrix4.js';
 import { cameraViewMatrix } from './Camera.js';
 import { Matrix3 } from '../../math/Matrix3.js';
 
-/** @module ModelNode **/
-
 /**
  * This type of node is a specialized version of `Object3DNode`
  * with larger set of model related metrics. Unlike `Object3DNode`,
  * `ModelNode` extracts the reference to the 3D object from the
  * current node frame state.
  *
- * @augments module:Object3DNode~Object3DNode
+ * @augments Object3DNode
  */
 class ModelNode extends Object3DNode {
 

--- a/src/nodes/accessors/ModelViewProjectionNode.js
+++ b/src/nodes/accessors/ModelViewProjectionNode.js
@@ -1,7 +1,5 @@
 import { Fn } from '../tsl/TSLCore.js';
 
-/** @module ModelViewProjectionNode **/
-
 /**
  * TSL object that represents the position in clip space after the model-view-projection transform of the current rendered object.
  *

--- a/src/nodes/accessors/MorphNode.js
+++ b/src/nodes/accessors/MorphNode.js
@@ -14,8 +14,6 @@ import { Vector2 } from '../../math/Vector2.js';
 import { Vector4 } from '../../math/Vector4.js';
 import { FloatType } from '../../constants.js';
 
-/** @module MorphNode **/
-
 const _morphTextures = /*@__PURE__*/ new WeakMap();
 const _morphVec4 = /*@__PURE__*/ new Vector4();
 

--- a/src/nodes/accessors/Normal.js
+++ b/src/nodes/accessors/Normal.js
@@ -5,8 +5,6 @@ import { mat3, vec3, Fn, varying } from '../tsl/TSLBase.js';
 import { positionView } from './Position.js';
 import { faceDirection } from '../display/FrontFacingNode.js';
 
-/** @module Normal **/
-
 /**
  * TSL object that represents the normal attribute of the current rendered object.
  *

--- a/src/nodes/accessors/Object3DNode.js
+++ b/src/nodes/accessors/Object3DNode.js
@@ -4,8 +4,6 @@ import UniformNode from '../core/UniformNode.js';
 import { nodeProxy } from '../tsl/TSLBase.js';
 import { Vector3 } from '../../math/Vector3.js';
 
-/** @module Object3DNode **/
-
 /**
  * This node can be used to access transformation related metrics of 3D objects.
  * Depending on the selected scope, a different metric is represented as a uniform

--- a/src/nodes/accessors/PointUVNode.js
+++ b/src/nodes/accessors/PointUVNode.js
@@ -1,8 +1,6 @@
 import Node from '../core/Node.js';
 import { nodeImmutable } from '../tsl/TSLBase.js';
 
-/** @module PointUVNode **/
-
 /**
  * A node for representing the uv coordinates of points.
  *

--- a/src/nodes/accessors/Position.js
+++ b/src/nodes/accessors/Position.js
@@ -2,8 +2,6 @@ import { attribute } from '../core/AttributeNode.js';
 import { Fn } from '../tsl/TSLCore.js';
 import { modelWorldMatrix } from './ModelNode.js';
 
-/** @module Position **/
-
 /**
  * TSL object that represents the position attribute of the current rendered object.
  *
@@ -20,7 +18,7 @@ export const positionLocal = /*@__PURE__*/ positionGeometry.toVarying( 'position
 
 /**
  * TSL object that represents the previous vertex position in local space of the current rendered object.
- * Used in context of {@link module:VelocityNode~VelocityNode} for rendering motion vectors.
+ * Used in context of {@link VelocityNode} for rendering motion vectors.
  *
  * @type {AttributeNode<vec3>}
  */

--- a/src/nodes/accessors/ReferenceBaseNode.js
+++ b/src/nodes/accessors/ReferenceBaseNode.js
@@ -6,8 +6,6 @@ import ArrayElementNode from '../utils/ArrayElementNode.js';
 
 // TODO: Avoid duplicated code and ues only ReferenceBaseNode or ReferenceNode
 
-/** @module ReferenceBaseNode **/
-
 /**
  * This class is only relevant if the referenced property is array-like.
  * In this case, `ReferenceElementNode` allows to refer to a specific
@@ -34,7 +32,7 @@ class ReferenceElementNode extends ArrayElementNode {
 		super( referenceNode, indexNode );
 
 		/**
-		 * Similar to {@link module:ReferenceBaseNode~ReferenceBaseNode#reference}, an additional
+		 * Similar to {@link ReferenceBaseNode#reference}, an additional
 		 * property references to the current node.
 		 *
 		 * @type {ReferenceBaseNode?}
@@ -144,7 +142,7 @@ class ReferenceBaseNode extends Node {
 		this.properties = property.split( '.' );
 
 		/**
-		 * Points to the current referred object. This property exists next to {@link module:ReferenceNode~ReferenceNode#object}
+		 * Points to the current referred object. This property exists next to {@link ReferenceNode#object}
 		 * since the final reference might be updated from calling code.
 		 *
 		 * @type {Object?}
@@ -269,7 +267,7 @@ class ReferenceBaseNode extends Node {
 
 	/**
 	 * Allows to update the reference based on the given state. The state is only
-	 * evaluated {@link module:ReferenceBaseNode~ReferenceBaseNode#object} is not set.
+	 * evaluated {@link ReferenceBaseNode#object} is not set.
 	 *
 	 * @param {(NodeFrame|NodeBuilder)} state - The current state.
 	 * @return {Object} The updated reference.

--- a/src/nodes/accessors/ReferenceNode.js
+++ b/src/nodes/accessors/ReferenceNode.js
@@ -10,8 +10,6 @@ import ArrayElementNode from '../utils/ArrayElementNode.js';
 
 // TODO: Avoid duplicated code and ues only ReferenceBaseNode or ReferenceNode
 
-/** @module ReferenceNode **/
-
 /**
  * This class is only relevant if the referenced property is array-like.
  * In this case, `ReferenceElementNode` allows to refer to a specific
@@ -38,7 +36,7 @@ class ReferenceElementNode extends ArrayElementNode {
 		super( referenceNode, indexNode );
 
 		/**
-		 * Similar to {@link module:ReferenceNode~ReferenceNode#reference}, an additional
+		 * Similar to {@link ReferenceNode#reference}, an additional
 		 * property references to the current node.
 		 *
 		 * @type {ReferenceNode?}
@@ -148,7 +146,7 @@ class ReferenceNode extends Node {
 		this.properties = property.split( '.' );
 
 		/**
-		 * Points to the current referred object. This property exists next to {@link module:ReferenceNode~ReferenceNode#object}
+		 * Points to the current referred object. This property exists next to {@link ReferenceNode#object}
 		 * since the final reference might be updated from calling code.
 		 *
 		 * @type {Object?}
@@ -319,7 +317,7 @@ class ReferenceNode extends Node {
 
 	/**
 	 * Allows to update the reference based on the given state. The state is only
-	 * evaluated {@link module:ReferenceNode~ReferenceNode#object} is not set.
+	 * evaluated {@link ReferenceNode#object} is not set.
 	 *
 	 * @param {(NodeFrame|NodeBuilder)} state - The current state.
 	 * @return {Object} The updated reference.

--- a/src/nodes/accessors/ReflectVector.js
+++ b/src/nodes/accessors/ReflectVector.js
@@ -3,8 +3,6 @@ import { transformedNormalView } from './Normal.js';
 import { positionViewDirection } from './Position.js';
 import { materialRefractionRatio } from './MaterialProperties.js';
 
-/** @module ReflectVector **/
-
 /**
  * The reflect vector in view space.
  *

--- a/src/nodes/accessors/RendererReferenceNode.js
+++ b/src/nodes/accessors/RendererReferenceNode.js
@@ -2,8 +2,6 @@ import ReferenceBaseNode from './ReferenceBaseNode.js';
 import { nodeObject } from '../tsl/TSLCore.js';
 import { renderGroup } from '../core/UniformGroupNode.js';
 
-/** @module RendererReferenceNode **/
-
 /**
  * This node is a special type of reference node which is intended
  * for linking renderer properties with node values.
@@ -50,7 +48,7 @@ class RendererReferenceNode extends ReferenceBaseNode {
 
 	/**
 	 * Updates the reference based on the given state. The state is only evaluated
-	 * {@link module:RendererReferenceNode~RendererReferenceNode#renderer} is not set.
+	 * {@link RendererReferenceNode#renderer} is not set.
 	 *
 	 * @param {(NodeFrame|NodeBuilder)} state - The current state.
 	 * @return {Object} The updated reference.

--- a/src/nodes/accessors/SceneNode.js
+++ b/src/nodes/accessors/SceneNode.js
@@ -9,8 +9,6 @@ import { reference } from './ReferenceNode.js';
 const _e1 = /*@__PURE__*/ new Euler();
 const _m1 = /*@__PURE__*/ new Matrix4();
 
-/** @module SceneNode **/
-
 /**
  * This module allows access to a collection of scene properties. The following predefined TSL objects
  * are available for easier use:

--- a/src/nodes/accessors/SkinningNode.js
+++ b/src/nodes/accessors/SkinningNode.js
@@ -11,8 +11,6 @@ import { uniform } from '../core/UniformNode.js';
 import { buffer } from './BufferNode.js';
 import { getDataFromObject } from '../core/NodeUtils.js';
 
-/** @module SkinningNode **/
-
 const _frameId = new WeakMap();
 
 /**

--- a/src/nodes/accessors/StorageBufferNode.js
+++ b/src/nodes/accessors/StorageBufferNode.js
@@ -5,8 +5,6 @@ import { storageElement } from '../utils/StorageArrayElementNode.js';
 import { NodeAccess } from '../core/constants.js';
 import { getTypeFromLength } from '../core/NodeUtils.js';
 
-/** @module StorageBufferNode **/
-
 /**
  * This node is used in context of compute shaders and allows to define a
  * storage buffer for data. A typical workflow is to create instances of

--- a/src/nodes/accessors/StorageTextureNode.js
+++ b/src/nodes/accessors/StorageTextureNode.js
@@ -2,8 +2,6 @@ import TextureNode from './TextureNode.js';
 import { nodeProxy } from '../tsl/TSLBase.js';
 import { NodeAccess } from '../core/constants.js';
 
-/** @module StorageTextureNode **/
-
 /**
  * This special version of a texture node can be used to
  * write data into a storage texture with a compute shader.
@@ -33,7 +31,7 @@ import { NodeAccess } from '../core/constants.js';
  *
  * This node can only be used with a WebGPU backend.
  *
- * @augments module:TextureNode~TextureNode
+ * @augments TextureNode
  */
 class StorageTextureNode extends TextureNode {
 

--- a/src/nodes/accessors/Tangent.js
+++ b/src/nodes/accessors/Tangent.js
@@ -3,8 +3,6 @@ import { cameraViewMatrix } from './Camera.js';
 import { modelViewMatrix } from './ModelNode.js';
 import { Fn, vec4 } from '../tsl/TSLBase.js';
 
-/** @module Tangent **/
-
 /**
  * TSL object that represents the tangent attribute of the current rendered object.
  *

--- a/src/nodes/accessors/Texture3DNode.js
+++ b/src/nodes/accessors/Texture3DNode.js
@@ -2,8 +2,6 @@ import TextureNode from './TextureNode.js';
 import { nodeProxy, vec3, Fn, If, int } from '../tsl/TSLBase.js';
 import { textureSize } from './TextureSizeNode.js';
 
-/** @module Texture3DNode **/
-
 const normal = Fn( ( { texture, uv } ) => {
 
 	const epsilon = 0.0001;
@@ -53,7 +51,7 @@ const normal = Fn( ( { texture, uv } ) => {
 /**
  * This type of uniform node represents a 3D texture.
  *
- * @augments module:TextureNode~TextureNode
+ * @augments TextureNode
  */
 class Texture3DNode extends TextureNode {
 

--- a/src/nodes/accessors/TextureBicubic.js
+++ b/src/nodes/accessors/TextureBicubic.js
@@ -2,8 +2,6 @@ import { add, mul, div } from '../math/OperatorNode.js';
 import { floor, ceil, fract, pow } from '../math/MathNode.js';
 import { Fn, float, vec2, vec4, int } from '../tsl/TSLBase.js';
 
-/** @module TextureBicubic **/
-
 // Mipped Bicubic Texture Filtering by N8
 // https://www.shadertoy.com/view/Dl2SDW
 

--- a/src/nodes/accessors/TextureNode.js
+++ b/src/nodes/accessors/TextureNode.js
@@ -9,12 +9,10 @@ import { NodeUpdateType } from '../core/constants.js';
 
 import { IntType, UnsignedIntType } from '../../constants.js';
 
-/** @module TextureNode **/
-
 /**
  * This type of uniform node represents a 2D texture.
  *
- * @augments module:UniformNode~UniformNode
+ * @augments UniformNode
  */
 class TextureNode extends UniformNode {
 

--- a/src/nodes/accessors/TextureSizeNode.js
+++ b/src/nodes/accessors/TextureSizeNode.js
@@ -1,8 +1,6 @@
 import Node from '../core/Node.js';
 import { nodeProxy } from '../tsl/TSLBase.js';
 
-/** @module TextureSizeNode **/
-
 /**
  * A node that represents the dimensions of a texture. The texture size is
  * retrieved in the shader via built-in shader functions like `textureDimensions()`

--- a/src/nodes/accessors/UV.js
+++ b/src/nodes/accessors/UV.js
@@ -1,7 +1,5 @@
 import { attribute } from '../core/AttributeNode.js';
 
-/** @module UV **/
-
 /**
  * TSL function for creating an uv attribute node with the given index.
  *

--- a/src/nodes/accessors/UniformArrayNode.js
+++ b/src/nodes/accessors/UniformArrayNode.js
@@ -4,8 +4,6 @@ import { getValueType } from '../core/NodeUtils.js';
 import ArrayElementNode from '../utils/ArrayElementNode.js';
 import BufferNode from './BufferNode.js';
 
-/** @module UniformArrayNode **/
-
 /**
  * Represents the element access on uniform array nodes.
  *
@@ -53,8 +51,8 @@ class UniformArrayElementNode extends ArrayElementNode {
 }
 
 /**
- * Similar to {@link module:BufferNode~BufferNode} this module represents array-like data as
- * uniform buffers. Unlike {@link module:BufferNode~BufferNode}, it can handle more common
+ * Similar to {@link BufferNode} this module represents array-like data as
+ * uniform buffers. Unlike {@link BufferNode}, it can handle more common
  * data types in the array (e.g `three.js` primitives) and automatically
  * manage buffer padding. It should be the first choice when working with
  * uniforms buffers.
@@ -67,7 +65,7 @@ class UniformArrayElementNode extends ArrayElementNode {
  *
  * const redColor = tintColors.element( 0 );
  *
- * @augments module:BufferNode~BufferNode
+ * @augments BufferNode
  */
 class UniformArrayNode extends BufferNode {
 
@@ -88,7 +86,7 @@ class UniformArrayNode extends BufferNode {
 		super( null );
 
 		/**
-		 * Array holding the buffer data. Unlike {@link module:BufferNode~BufferNode}, the array can
+		 * Array holding the buffer data. Unlike {@link BufferNode}, the array can
 		 * hold number primitives as well as three.js objects like vectors, matrices
 		 * or colors.
 		 *
@@ -132,7 +130,7 @@ class UniformArrayNode extends BufferNode {
 
 	/**
 	 * This method is overwritten since the node type is inferred from the
-	 * {@link module:UniformArrayNode~UniformArrayNode#paddedType}.
+	 * {@link UniformArrayNode#paddedType}.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
 	 * @return {String} The node type.
@@ -323,7 +321,7 @@ class UniformArrayNode extends BufferNode {
 
 	/**
 	 * Overwrites the default `element()` method to provide element access
-	 * based on {@link module:UniformArrayNode~UniformArrayNode}.
+	 * based on {@link UniformArrayNode}.
 	 *
 	 * @param {IndexNode} indexNode - The index node.
 	 * @return {UniformArrayElementNode}

--- a/src/nodes/accessors/UserDataNode.js
+++ b/src/nodes/accessors/UserDataNode.js
@@ -1,8 +1,6 @@
 import ReferenceNode from './ReferenceNode.js';
 import { nodeObject } from '../tsl/TSLBase.js';
 
-/** @module UserDataNode **/
-
 /**
  * A special type of reference node that allows to link values in
  * `userData` fields to node objects.
@@ -12,10 +10,10 @@ import { nodeObject } from '../tsl/TSLBase.js';
  * const material = new THREE.SpriteNodeMaterial();
  * material.rotationNode = userData( 'rotation', 'float' );
  * ```
- * Since `UserDataNode` is extended from {@link module:ReferenceNode~ReferenceNode}, the node value
+ * Since `UserDataNode` is extended from {@link ReferenceNode}, the node value
  * will automatically be updated when the `rotation` user data field changes.
  *
- * @augments module:ReferenceNode~ReferenceNode
+ * @augments ReferenceNode
  */
 class UserDataNode extends ReferenceNode {
 
@@ -48,7 +46,7 @@ class UserDataNode extends ReferenceNode {
 	}
 
 	/**
-	 * Overwritten to make sure {@link module:ReferenceNode~ReferenceNode#reference} points to the correct
+	 * Overwritten to make sure {@link ReferenceNode#reference} points to the correct
 	 * `userData` field.
 	 *
 	 * @param {(NodeFrame|NodeBuilder)} state - The current state to evaluate.

--- a/src/nodes/accessors/VelocityNode.js
+++ b/src/nodes/accessors/VelocityNode.js
@@ -11,8 +11,6 @@ import { renderGroup } from '../core/UniformGroupNode.js';
 
 const _objectData = new WeakMap();
 
-/** @module VelocityNode **/
-
 /**
  * A node for representing motion or velocity vectors. Foundation
  * for advanced post processing effects like motion blur or TRAA.

--- a/src/nodes/accessors/VertexColorNode.js
+++ b/src/nodes/accessors/VertexColorNode.js
@@ -2,12 +2,10 @@ import AttributeNode from '../core/AttributeNode.js';
 import { nodeObject } from '../tsl/TSLBase.js';
 import { Vector4 } from '../../math/Vector4.js';
 
-/** @module VertexColorNode **/
-
 /**
  * An attribute node for representing vertex colors.
  *
- * @augments module:AttributeNode~AttributeNode
+ * @augments AttributeNode
  */
 class VertexColorNode extends AttributeNode {
 

--- a/src/nodes/code/CodeNode.js
+++ b/src/nodes/code/CodeNode.js
@@ -1,8 +1,6 @@
 import Node from '../core/Node.js';
 import { nodeProxy } from '../tsl/TSLBase.js';
 
-/** @module CodeNode **/
-
 /**
  * This class represents native code sections. It is the base
  * class for modules like {@link FunctionNode} which allows to implement

--- a/src/nodes/code/ExpressionNode.js
+++ b/src/nodes/code/ExpressionNode.js
@@ -1,8 +1,6 @@
 import Node from '../core/Node.js';
 import { nodeProxy } from '../tsl/TSLCore.js';
 
-/** @module ExpressionNode **/
-
 /**
  * This class can be used to implement basic expressions in shader code.
  * Basic examples for that are `return`, `continue` or `discard` statements.

--- a/src/nodes/code/ScriptableNode.js
+++ b/src/nodes/code/ScriptableNode.js
@@ -3,8 +3,6 @@ import { scriptableValue } from './ScriptableValueNode.js';
 import { nodeProxy, float } from '../tsl/TSLBase.js';
 import { hashArray, hashString } from '../core/NodeUtils.js';
 
-/** @module ScriptableNode **/
-
 /**
  * A Map-like data structure for managing resources of scriptable nodes.
  *

--- a/src/nodes/code/ScriptableValueNode.js
+++ b/src/nodes/code/ScriptableValueNode.js
@@ -4,8 +4,6 @@ import { nodeProxy, float } from '../tsl/TSLBase.js';
 
 import { EventDispatcher } from '../../core/EventDispatcher.js';
 
-/** @module ScriptableValueNode **/
-
 /**
  * `ScriptableNode` uses this class to manage script inputs and outputs.
  *

--- a/src/nodes/core/ArrayNode.js
+++ b/src/nodes/core/ArrayNode.js
@@ -1,10 +1,8 @@
 import TempNode from './TempNode.js';
 import { addMethodChaining, nodeObject } from '../tsl/TSLCore.js';
 
-/** @module ArrayNode **/
-
 /**
- * ArrayNode represents a collection of nodes, typically created using the {@link module:TSL~array} function.
+ * ArrayNode represents a collection of nodes, typically created using the {@link marray} function.
  * ```js
  * const colors = array( [
  * 	vec3( 1, 0, 0 ),

--- a/src/nodes/core/AssignNode.js
+++ b/src/nodes/core/AssignNode.js
@@ -2,8 +2,6 @@ import TempNode from '../core/TempNode.js';
 import { addMethodChaining, nodeProxy } from '../tsl/TSLCore.js';
 import { vectorComponents } from '../core/constants.js';
 
-/** @module AssignNode **/
-
 /**
  * These node represents an assign operation. Meaning a node is assigned
  * to another node.

--- a/src/nodes/core/AttributeNode.js
+++ b/src/nodes/core/AttributeNode.js
@@ -1,8 +1,6 @@
 import Node from './Node.js';
 import { nodeObject, varying } from '../tsl/TSLBase.js';
 
-/** @module AttributeNode **/
-
 /**
  * Base class for representing shader attributes as nodes.
  *

--- a/src/nodes/core/BypassNode.js
+++ b/src/nodes/core/BypassNode.js
@@ -1,8 +1,6 @@
 import Node from './Node.js';
 import { addMethodChaining, nodeProxy } from '../tsl/TSLCore.js';
 
-/** @module BypassNode **/
-
 /**
  * The class generates the code of a given node but returns another node in the output.
  * This can be used to call a method or node that does not return a value, i.e.

--- a/src/nodes/core/CacheNode.js
+++ b/src/nodes/core/CacheNode.js
@@ -1,8 +1,6 @@
 import Node from './Node.js';
 import { addMethodChaining, nodeObject } from '../tsl/TSLCore.js';
 
-/** @module CacheNode **/
-
 /**
  * This node can be used as a cache management component for another node.
  * Caching is in general used by default in {@link NodeBuilder} but this node

--- a/src/nodes/core/ContextNode.js
+++ b/src/nodes/core/ContextNode.js
@@ -1,8 +1,6 @@
 import Node from './Node.js';
 import { addMethodChaining, nodeProxy } from '../tsl/TSLCore.js';
 
-/** @module ContextNode **/
-
 /**
  * This node can be used as a context management component for another node.
  * {@link NodeBuilder} performs its node building process in a specific context and
@@ -58,9 +56,9 @@ class ContextNode extends Node {
 	}
 
 	/**
-	 * This method is overwritten to ensure it returns the reference to {@link module:ContextNode~ContextNode#node}.
+	 * This method is overwritten to ensure it returns the reference to {@link ContextNode#node}.
 	 *
-	 * @return {Node} A reference to {@link module:ContextNode~ContextNode#node}.
+	 * @return {Node} A reference to {@link ContextNode#node}.
 	 */
 	getScope() {
 
@@ -69,7 +67,7 @@ class ContextNode extends Node {
 	}
 
 	/**
-	 * This method is overwritten to ensure it returns the type of {@link module:ContextNode~ContextNode#node}.
+	 * This method is overwritten to ensure it returns the type of {@link ContextNode#node}.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
 	 * @return {String} The node type.

--- a/src/nodes/core/IndexNode.js
+++ b/src/nodes/core/IndexNode.js
@@ -1,8 +1,6 @@
 import Node from './Node.js';
 import { nodeImmutable, varying } from '../tsl/TSLBase.js';
 
-/** @module IndexNode **/
-
 /**
  * This class represents shader indices of different types. The following predefined node
  * objects cover frequent use cases:

--- a/src/nodes/core/MRTNode.js
+++ b/src/nodes/core/MRTNode.js
@@ -1,8 +1,6 @@
 import OutputStructNode from './OutputStructNode.js';
 import { nodeProxy, vec4 } from '../tsl/TSLBase.js';
 
-/** @module MRTNode **/
-
 /**
  * Returns the MRT texture index for the given name.
  *

--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -499,7 +499,7 @@ class NodeBuilder {
 
 	/**
 	 * Returns the output struct name which is required by
-	 * {@link module:OutputStructNode}.
+	 * {@link OutputStructNode}.
 	 *
 	 * @abstract
 	 * @return {String} The name of the output struct.

--- a/src/nodes/core/NodeUtils.js
+++ b/src/nodes/core/NodeUtils.js
@@ -6,8 +6,6 @@ import { Vector2 } from '../../math/Vector2.js';
 import { Vector3 } from '../../math/Vector3.js';
 import { Vector4 } from '../../math/Vector4.js';
 
-/** @module NodeUtils **/
-
 // cyrb53 (c) 2018 bryc (github.com/bryc). License: Public domain. Attribution appreciated.
 // A fast and simple 64-bit (or 53-bit) string hash function with decent collision resistance.
 // Largely inspired by MurmurHash2/3, but with a focus on speed/simplicity.

--- a/src/nodes/core/OutputStructNode.js
+++ b/src/nodes/core/OutputStructNode.js
@@ -1,8 +1,6 @@
 import Node from './Node.js';
 import { nodeProxy } from '../tsl/TSLBase.js';
 
-/** @module OutputStructNode **/
-
 /**
  * This node can be used to define multiple outputs in a shader programs.
  *

--- a/src/nodes/core/ParameterNode.js
+++ b/src/nodes/core/ParameterNode.js
@@ -1,8 +1,6 @@
 import { nodeObject } from '../tsl/TSLBase.js';
 import PropertyNode from './PropertyNode.js';
 
-/** @module ParameterNode **/
-
 /**
  * Special version of {@link PropertyNode} which is used for parameters.
  *

--- a/src/nodes/core/PropertyNode.js
+++ b/src/nodes/core/PropertyNode.js
@@ -1,8 +1,6 @@
 import Node from './Node.js';
 import { nodeImmutable, nodeObject } from '../tsl/TSLCore.js';
 
-/** @module PropertyNode **/
-
 /**
  * This class represents a shader property. It can be used
  * to explicitly define a property and assign a value to it.

--- a/src/nodes/core/StackNode.js
+++ b/src/nodes/core/StackNode.js
@@ -2,8 +2,6 @@ import Node from './Node.js';
 import { select } from '../math/ConditionalNode.js';
 import { ShaderNode, nodeProxy, getCurrentStack, setCurrentStack } from '../tsl/TSLBase.js';
 
-/** @module StackNode **/
-
 /**
  * Stack is a helper for Nodes that need to produce stack-based code instead of continuous flow.
  * They are usually needed in cases like `If`, `Else`.

--- a/src/nodes/core/StructNode.js
+++ b/src/nodes/core/StructNode.js
@@ -2,8 +2,6 @@ import Node from './Node.js';
 import StructTypeNode from './StructTypeNode.js';
 import { nodeObject } from '../tsl/TSLCore.js';
 
-/** @module StructNode **/
-
 /**
  * StructNode allows to create custom structures with multiple members.
  * This can also be used to define structures in attribute and uniform data.

--- a/src/nodes/core/StructTypeNode.js
+++ b/src/nodes/core/StructTypeNode.js
@@ -2,8 +2,6 @@
 import Node from './Node.js';
 import { getLengthFromType } from './NodeUtils.js';
 
-/** @module StructTypeNode **/
-
 /**
  * Generates a layout for struct members.
  * This function takes an object representing struct members and returns an array of member layouts.

--- a/src/nodes/core/UniformGroupNode.js
+++ b/src/nodes/core/UniformGroupNode.js
@@ -1,7 +1,5 @@
 import Node from './Node.js';
 
-/** @module UniformGroupNode **/
-
 /**
  * This node can be used to group single instances of {@link UniformNode}
  * and manage them as a uniform buffer.

--- a/src/nodes/core/UniformNode.js
+++ b/src/nodes/core/UniformNode.js
@@ -2,8 +2,6 @@ import InputNode from './InputNode.js';
 import { objectGroup } from './UniformGroupNode.js';
 import { nodeObject, getConstNodeType } from '../tsl/TSLCore.js';
 
-/** @module UniformNode **/
-
 /**
  * Class for representing a uniform.
  *

--- a/src/nodes/core/VarNode.js
+++ b/src/nodes/core/VarNode.js
@@ -1,8 +1,6 @@
 import Node from './Node.js';
 import { addMethodChaining, nodeProxy } from '../tsl/TSLCore.js';
 
-/** @module VarNode **/
-
 /**
  * Class for representing shader variables as nodes. Variables are created from
  * existing nodes like the following:

--- a/src/nodes/core/VaryingNode.js
+++ b/src/nodes/core/VaryingNode.js
@@ -2,8 +2,6 @@ import Node from './Node.js';
 import { NodeShaderStage } from './constants.js';
 import { addMethodChaining, nodeProxy } from '../tsl/TSLCore.js';
 
-/** @module VaryingNode **/
-
 /**
  * Class for representing shader varyings as nodes. Varyings are create from
  * existing nodes like the following:

--- a/src/nodes/core/constants.js
+++ b/src/nodes/core/constants.js
@@ -1,5 +1,3 @@
-/** @module NodeConstants **/
-
 /**
  * Possible shader stages.
  *

--- a/src/nodes/display/BlendModes.js
+++ b/src/nodes/display/BlendModes.js
@@ -1,8 +1,6 @@
 import { Fn, vec4 } from '../tsl/TSLBase.js';
 import { mix, min, step } from '../math/MathNode.js';
 
-/** @module BlendModes **/
-
 /**
  * Represents a "Color Burn" blend mode.
  *

--- a/src/nodes/display/BumpMapNode.js
+++ b/src/nodes/display/BumpMapNode.js
@@ -5,8 +5,6 @@ import { positionView } from '../accessors/Position.js';
 import { faceDirection } from './FrontFacingNode.js';
 import { Fn, nodeProxy, float, vec2 } from '../tsl/TSLBase.js';
 
-/** @module BumpMapNode **/
-
 // Bump Mapping Unparametrized Surfaces on the GPU by Morten S. Mikkelsen
 // https://mmikk.github.io/papers3d/mm_sfgrad_bump.pdf
 

--- a/src/nodes/display/ColorAdjustment.js
+++ b/src/nodes/display/ColorAdjustment.js
@@ -5,8 +5,6 @@ import { ColorManagement } from '../../math/ColorManagement.js';
 import { Vector3 } from '../../math/Vector3.js';
 import { LinearSRGBColorSpace } from '../../constants.js';
 
-/** @module ColorAdjustment **/
-
 /**
  * Computes a grayscale value for the given RGB color value.
  *

--- a/src/nodes/display/ColorSpaceFunctions.js
+++ b/src/nodes/display/ColorSpaceFunctions.js
@@ -1,8 +1,6 @@
 import { mix } from '../math/MathNode.js';
 import { Fn } from '../tsl/TSLCore.js';
 
-/** @module ColorSpaceFunctions **/
-
 /**
  * Converts the given color value from sRGB to linear-sRGB color space.
  *

--- a/src/nodes/display/ColorSpaceNode.js
+++ b/src/nodes/display/ColorSpaceNode.js
@@ -6,8 +6,6 @@ import { ColorManagement } from '../../math/ColorManagement.js';
 import { sRGBTransferEOTF, sRGBTransferOETF } from './ColorSpaceFunctions.js';
 import { Matrix3 } from '../../math/Matrix3.js';
 
-/** @module ColorSpaceNode **/
-
 const WORKING_COLOR_SPACE = 'WorkingColorSpace';
 const OUTPUT_COLOR_SPACE = 'OutputColorSpace';
 

--- a/src/nodes/display/FrontFacingNode.js
+++ b/src/nodes/display/FrontFacingNode.js
@@ -3,8 +3,6 @@ import { nodeImmutable, float } from '../tsl/TSLBase.js';
 
 import { BackSide, WebGLCoordinateSystem } from '../../constants.js';
 
-/** @module FrontFacingNode **/
-
 /**
  * This node can be used to evaluate whether a primitive is front or back facing.
  *

--- a/src/nodes/display/NormalMapNode.js
+++ b/src/nodes/display/NormalMapNode.js
@@ -10,8 +10,6 @@ import { Fn, nodeProxy, vec3 } from '../tsl/TSLBase.js';
 
 import { TangentSpaceNormalMap, ObjectSpaceNormalMap } from '../../constants.js';
 
-/** @module NormalMapNode **/
-
 // Normal Mapping Without Precomputed Tangents
 // http://www.thetenthplanet.de/archives/1180
 

--- a/src/nodes/display/PassNode.js
+++ b/src/nodes/display/PassNode.js
@@ -10,14 +10,12 @@ import { Vector2 } from '../../math/Vector2.js';
 import { DepthTexture } from '../../textures/DepthTexture.js';
 import { RenderTarget } from '../../core/RenderTarget.js';
 
-/** @module PassNode **/
-
 const _size = /*@__PURE__*/ new Vector2();
 
 /**
  * Represents the texture of a pass node.
  *
- * @augments module:TextureNode~TextureNode
+ * @augments TextureNode
  */
 class PassTextureNode extends TextureNode {
 
@@ -68,7 +66,7 @@ class PassTextureNode extends TextureNode {
  * An extension of `PassTextureNode` which allows to manage more than one
  * internal texture. Relevant for the `getPreviousTexture()` related API.
  *
- * @augments module:PassTextureNode~PassTextureNode
+ * @augments PassTextureNode
  */
 class PassMultipleTextureNode extends PassTextureNode {
 

--- a/src/nodes/display/PosterizeNode.js
+++ b/src/nodes/display/PosterizeNode.js
@@ -1,8 +1,6 @@
 import TempNode from '../core/TempNode.js';
 import { nodeProxy } from '../tsl/TSLBase.js';
 
-/** @module PosterizeNode **/
-
 /**
  * Represents a posterize effect which reduces the number of colors
  * in an image, resulting in a more blocky and stylized appearance.

--- a/src/nodes/display/RenderOutputNode.js
+++ b/src/nodes/display/RenderOutputNode.js
@@ -4,8 +4,6 @@ import { addMethodChaining, nodeObject } from '../tsl/TSLCore.js';
 import { NoColorSpace, NoToneMapping } from '../../constants.js';
 import { ColorManagement } from '../../math/ColorManagement.js';
 
-/** @module RenderOutputNode **/
-
 /**
  * Normally, tone mapping and color conversion happens automatically
  * before outputting pixel too the default (screen) framebuffer. In certain

--- a/src/nodes/display/ScreenNode.js
+++ b/src/nodes/display/ScreenNode.js
@@ -6,13 +6,11 @@ import { Fn, nodeImmutable, vec2 } from '../tsl/TSLBase.js';
 import { Vector2 } from '../../math/Vector2.js';
 import { Vector4 } from '../../math/Vector4.js';
 
-/** @module ScreenNode **/
-
 let screenSizeVec, viewportVec;
 
 /**
  * This node provides a collection of screen related metrics.
- * Depending on {@link module:ScreenNode~ScreenNode#scope}, the nodes can represent
+ * Depending on {@link ScreenNode#scope}, the nodes can represent
  * resolution or viewport data as well as fragment or uv coordinates.
  *
  * @augments Node

--- a/src/nodes/display/ToneMappingFunctions.js
+++ b/src/nodes/display/ToneMappingFunctions.js
@@ -3,8 +3,6 @@ import { select } from '../math/ConditionalNode.js';
 import { clamp, log2, max, min, pow, mix } from '../math/MathNode.js';
 import { mul, sub, div } from '../math/OperatorNode.js';
 
-/** @module ToneMappingFunctions **/
-
 /**
  * Linear tone mapping, exposure only.
  *

--- a/src/nodes/display/ToneMappingNode.js
+++ b/src/nodes/display/ToneMappingNode.js
@@ -5,8 +5,6 @@ import { rendererReference } from '../accessors/RendererReferenceNode.js';
 import { NoToneMapping } from '../../constants.js';
 import { hash } from '../core/NodeUtils.js';
 
-/** @module ToneMappingNode **/
-
 /**
  * This node represents a tone mapping operation.
  *

--- a/src/nodes/display/ToonOutlinePassNode.js
+++ b/src/nodes/display/ToonOutlinePassNode.js
@@ -8,8 +8,6 @@ import { normalLocal } from '../../nodes/accessors/Normal.js';
 import { BackSide } from '../../constants.js';
 import PassNode from './PassNode.js';
 
-/** @module ToonOutlinePassNode **/
-
 /**
  * Represents a render pass for producing a toon outline effect on compatible objects.
  * Only 3D objects with materials of type `MeshToonMaterial` and `MeshToonNodeMaterial`

--- a/src/nodes/display/ViewportDepthNode.js
+++ b/src/nodes/display/ViewportDepthNode.js
@@ -4,8 +4,6 @@ import { cameraNear, cameraFar } from '../accessors/Camera.js';
 import { positionView } from '../accessors/Position.js';
 import { viewportDepthTexture } from './ViewportDepthTextureNode.js';
 
-/** @module ViewportDepthNode **/
-
 /**
  * This node offers a collection of features in context of the depth logic in the fragment shader.
  * Depending on {@link ViewportDepthNode#scope}, it can be used to define a depth value for the current

--- a/src/nodes/display/ViewportDepthTextureNode.js
+++ b/src/nodes/display/ViewportDepthTextureNode.js
@@ -4,8 +4,6 @@ import { screenUV } from './ScreenNode.js';
 
 import { DepthTexture } from '../../textures/DepthTexture.js';
 
-/** @module ViewportDepthTextureNode **/
-
 let sharedDepthbuffer = null;
 
 /**
@@ -13,7 +11,7 @@ let sharedDepthbuffer = null;
  * can be used in combination with viewport texture to achieve effects
  * that require depth evaluation.
  *
- * @augments module:ViewportTextureNode~ViewportTextureNode
+ * @augments ViewportTextureNode
  */
 class ViewportDepthTextureNode extends ViewportTextureNode {
 

--- a/src/nodes/display/ViewportSharedTextureNode.js
+++ b/src/nodes/display/ViewportSharedTextureNode.js
@@ -4,8 +4,6 @@ import { screenUV } from './ScreenNode.js';
 
 import { FramebufferTexture } from '../../textures/FramebufferTexture.js';
 
-/** @module ViewportSharedTextureNode **/
-
 let _sharedFramebuffer = null;
 
 /**
@@ -13,7 +11,7 @@ let _sharedFramebuffer = null;
  * shares a texture across all instances of `ViewportSharedTextureNode`. It should
  * be the first choice when using data of the default/screen framebuffer for performance reasons.
  *
- * @augments module:ViewportTextureNode~ViewportTextureNode
+ * @augments ViewportTextureNode
  */
 class ViewportSharedTextureNode extends ViewportTextureNode {
 

--- a/src/nodes/display/ViewportTextureNode.js
+++ b/src/nodes/display/ViewportTextureNode.js
@@ -7,8 +7,6 @@ import { Vector2 } from '../../math/Vector2.js';
 import { FramebufferTexture } from '../../textures/FramebufferTexture.js';
 import { LinearMipmapLinearFilter } from '../../constants.js';
 
-/** @module ViewportTextureNode **/
-
 const _size = /*@__PURE__*/ new Vector2();
 
 /**
@@ -18,7 +16,7 @@ const _size = /*@__PURE__*/ new Vector2();
  * (which is good for performance). `ViewportTextureNode` can be used as an input for a
  * variety of effects like refractive or transmissive materials.
  *
- * @augments module:TextureNode~TextureNode
+ * @augments TextureNode
  */
 class ViewportTextureNode extends TextureNode {
 

--- a/src/nodes/fog/Fog.js
+++ b/src/nodes/fog/Fog.js
@@ -2,8 +2,6 @@ import { positionView } from '../accessors/Position.js';
 import { smoothstep } from '../math/MathNode.js';
 import { Fn, output, vec4 } from '../tsl/TSLBase.js';
 
-/** @module Fog **/
-
 /**
  * Returns a node that represents the `z` coordinate in view space
  * for the current fragment. It's a different representation of the

--- a/src/nodes/functions/material/getParallaxCorrectNormal.js
+++ b/src/nodes/functions/material/getParallaxCorrectNormal.js
@@ -1,8 +1,6 @@
 import { positionWorld } from '../../accessors/Position.js';
 import { float, Fn, min, normalize, sub, vec3 } from '../../tsl/TSLBase.js';
 
-/** @module getParallaxCorrectNormal **/
-
 /**
  * This computes a parallax corrected normal which is used for box-projected cube mapping (BPCEM).
  *

--- a/src/nodes/geometry/RangeNode.js
+++ b/src/nodes/geometry/RangeNode.js
@@ -9,8 +9,6 @@ import { Vector4 } from '../../math/Vector4.js';
 import { MathUtils } from '../../math/MathUtils.js';
 import { InstancedBufferAttribute } from '../../core/InstancedBufferAttribute.js';
 
-/** @module RangeNode **/
-
 let min = null;
 let max = null;
 

--- a/src/nodes/gpgpu/AtomicFunctionNode.js
+++ b/src/nodes/gpgpu/AtomicFunctionNode.js
@@ -1,8 +1,6 @@
 import TempNode from '../core/TempNode.js';
 import { nodeProxy } from '../tsl/TSLCore.js';
 
-/** @module AtomicFunctionNode **/
-
 /**
  * `AtomicFunctionNode` represents any function that can operate on atomic variable types
  * within a shader. In an atomic function, any modification to an atomic variable will

--- a/src/nodes/gpgpu/BarrierNode.js
+++ b/src/nodes/gpgpu/BarrierNode.js
@@ -1,8 +1,6 @@
 import Node from '../core/Node.js';
 import { nodeProxy } from '../tsl/TSLCore.js';
 
-/** @module BarrierNode **/
-
 /**
  * Represents a GPU control barrier that synchronizes compute operations within a given scope.
  *

--- a/src/nodes/gpgpu/ComputeBuiltinNode.js
+++ b/src/nodes/gpgpu/ComputeBuiltinNode.js
@@ -1,8 +1,6 @@
 import Node from '../core/Node.js';
 import { nodeObject } from '../tsl/TSLBase.js';
 
-/** @module ComputeBuiltinNode **/
-
 /**
  * `ComputeBuiltinNode` represents a compute-scope builtin value that expose information
  * about the currently running dispatch and/or the device it is running on.

--- a/src/nodes/gpgpu/ComputeNode.js
+++ b/src/nodes/gpgpu/ComputeNode.js
@@ -2,8 +2,6 @@ import Node from '../core/Node.js';
 import { NodeUpdateType } from '../core/constants.js';
 import { addMethodChaining, nodeObject } from '../tsl/TSLCore.js';
 
-/** @module ComputeNode **/
-
 /**
  * TODO
  *

--- a/src/nodes/gpgpu/WorkgroupInfoNode.js
+++ b/src/nodes/gpgpu/WorkgroupInfoNode.js
@@ -2,8 +2,6 @@ import ArrayElementNode from '../utils/ArrayElementNode.js';
 import { nodeObject } from '../tsl/TSLCore.js';
 import Node from '../core/Node.js';
 
-/** @module WorkgroupInfoNode **/
-
 /**
  * Represents an element of a 'workgroup' scoped buffer.
  *

--- a/src/nodes/lighting/LightUtils.js
+++ b/src/nodes/lighting/LightUtils.js
@@ -1,7 +1,5 @@
 import { Fn } from '../tsl/TSLBase.js';
 
-/** @module LightUtils **/
-
 /**
  * Represents a `discard` shader operation in TSL.
  *

--- a/src/nodes/lighting/LightingContextNode.js
+++ b/src/nodes/lighting/LightingContextNode.js
@@ -2,7 +2,7 @@ import ContextNode from '../core/ContextNode.js';
 import { nodeProxy, float, vec3 } from '../tsl/TSLBase.js';
 
 /**
- * `LightingContextNode` represents an extension of the {@link module:ContextNode~ContextNode} module
+ * `LightingContextNode` represents an extension of the {@link ContextNode} module
  * by adding lighting specific context data. It represents the runtime context of
  * {@link LightsNode}.
  *

--- a/src/nodes/lighting/LightsNode.js
+++ b/src/nodes/lighting/LightsNode.js
@@ -2,8 +2,6 @@ import Node from '../core/Node.js';
 import { nodeObject, vec3 } from '../tsl/TSLBase.js';
 import { hashArray } from '../core/NodeUtils.js';
 
-/** @module LightsNode **/
-
 const sortLights = ( lights ) => {
 
 	return lights.sort( ( a, b ) => a.id - b.id );

--- a/src/nodes/lighting/PointShadowNode.js
+++ b/src/nodes/lighting/PointShadowNode.js
@@ -11,8 +11,6 @@ import { Vector4 } from '../../math/Vector4.js';
 import { Color } from '../../math/Color.js';
 import { BasicShadowMap } from '../../constants.js';
 
-/** @module PointShadowNode **/
-
 const _clearColor = /*@__PURE__*/ new Color();
 
 // cubeToUV() maps a 3D direction vector suitable for cube texture mapping to a 2D
@@ -163,7 +161,7 @@ const _shadowMapSize = /*@__PURE__*/ new Vector2();
 /**
  * Represents the shadow implementation for point light nodes.
  *
- * @augments module:ShadowNode~ShadowNode
+ * @augments ShadowNode
  */
 class PointShadowNode extends ShadowNode {
 

--- a/src/nodes/lighting/ShadowBaseNode.js
+++ b/src/nodes/lighting/ShadowBaseNode.js
@@ -3,8 +3,6 @@ import { NodeUpdateType } from '../core/constants.js';
 import { vec3 } from '../tsl/TSLBase.js';
 import { positionWorld } from '../accessors/Position.js';
 
-/** @module ShadowBaseNode **/
-
 /**
  * Base class for all shadow nodes.
  *

--- a/src/nodes/lighting/ShadowNode.js
+++ b/src/nodes/lighting/ShadowNode.js
@@ -19,8 +19,6 @@ import { lightShadowMatrix } from '../accessors/Lights.js';
 import { resetRendererAndSceneState, restoreRendererAndSceneState } from '../../renderers/common/RendererUtils.js';
 import { getDataFromObject } from '../core/NodeUtils.js';
 
-/** @module ShadowNode **/
-
 const shadowMaterialLib = /*@__PURE__*/ new WeakMap();
 const linearDistance = /*@__PURE__*/ Fn( ( [ position, cameraNear, cameraFar ] ) => {
 
@@ -314,7 +312,7 @@ const _quadMesh = /*@__PURE__*/ new QuadMesh();
 /**
  * Represents the default shadow implementation for lighting nodes.
  *
- * @augments module:ShadowBaseNode~ShadowBaseNode
+ * @augments ShadowBaseNode
  */
 class ShadowNode extends ShadowBaseNode {
 

--- a/src/nodes/math/ConditionalNode.js
+++ b/src/nodes/math/ConditionalNode.js
@@ -2,8 +2,6 @@ import Node from '../core/Node.js';
 import { property } from '../core/PropertyNode.js';
 import { addMethodChaining, nodeProxy } from '../tsl/TSLCore.js';
 
-/** @module ConditionalNode **/
-
 /**
  * Represents a logical `if/else` statement. Can be used as an alternative
  * to the `If()`/`Else()` syntax.

--- a/src/nodes/math/Hash.js
+++ b/src/nodes/math/Hash.js
@@ -1,7 +1,5 @@
 import { Fn } from '../tsl/TSLBase.js';
 
-/** @module Hash **/
-
 /**
  * Generates a hash value in the range `[0, 1]` from the given seed.
  *

--- a/src/nodes/math/MathNode.js
+++ b/src/nodes/math/MathNode.js
@@ -3,8 +3,6 @@ import { sub, mul, div } from './OperatorNode.js';
 import { addMethodChaining, nodeObject, nodeProxy, float, vec2, vec3, vec4, Fn } from '../tsl/TSLCore.js';
 import { WebGLCoordinateSystem, WebGPUCoordinateSystem } from '../../constants.js';
 
-/** @module MathNode **/
-
 /**
  * This node represents a variety of mathematical methods available in shaders.
  * They are divided into three categories:

--- a/src/nodes/math/MathUtils.js
+++ b/src/nodes/math/MathUtils.js
@@ -1,8 +1,6 @@
 import { sub, mul, div, add } from './OperatorNode.js';
 import { PI, pow, sin } from './MathNode.js';
 
-/** @module MathUtils **/
-
 /**
  * A function that remaps the `[0,1]` interval into the `[0,1]` interval.
  * The corners are mapped to `0` and the center to `1`.

--- a/src/nodes/math/OperatorNode.js
+++ b/src/nodes/math/OperatorNode.js
@@ -1,8 +1,6 @@
 import TempNode from '../core/TempNode.js';
 import { addMethodChaining, nodeProxy } from '../tsl/TSLCore.js';
 
-/** @module OperatorNode **/
-
 /**
  * This node represents basic mathematical and logical operations like addition,
  * subtraction or comparisons (e.g. `equal()`).

--- a/src/nodes/math/TriNoise3D.js
+++ b/src/nodes/math/TriNoise3D.js
@@ -3,8 +3,6 @@
 import { Loop } from '../utils/LoopNode.js';
 import { float, vec3, Fn } from '../tsl/TSLBase.js';
 
-/** @module TriNoise3D **/
-
 const tri = /*@__PURE__*/ Fn( ( [ x ] ) => {
 
 	return x.fract().sub( .5 ).abs();

--- a/src/nodes/pmrem/PMREMNode.js
+++ b/src/nodes/pmrem/PMREMNode.js
@@ -8,8 +8,6 @@ import { nodeProxy, vec3 } from '../tsl/TSLBase.js';
 import { WebGLCoordinateSystem } from '../../constants.js';
 import { Texture } from '../../textures/Texture.js';
 
-/** @module PMREMNode **/
-
 let _generator = null;
 
 const _cache = new WeakMap();

--- a/src/nodes/procedural/Checker.js
+++ b/src/nodes/procedural/Checker.js
@@ -1,8 +1,6 @@
 import { uv } from '../accessors/UV.js';
 import { Fn } from '../tsl/TSLBase.js';
 
-/** @module Procedural **/
-
 /**
  * Creates a 2x2 checkerboard pattern that can be used as procedural texture data.
  *

--- a/src/nodes/shapes/Shapes.js
+++ b/src/nodes/shapes/Shapes.js
@@ -2,8 +2,6 @@ import { Fn, float } from '../tsl/TSLBase.js';
 import { lengthSq, smoothstep } from '../math/MathNode.js';
 import { uv } from '../accessors/UV.js';
 
-/** @module Shapes **/
-
 /**
  * Generates a circle based on the uv coordinates.
  *

--- a/src/nodes/tsl/TSLCore.js
+++ b/src/nodes/tsl/TSLCore.js
@@ -9,8 +9,6 @@ import ConstNode from '../core/ConstNode.js';
 import MemberNode from '../utils/MemberNode.js';
 import { getValueFromType, getValueType } from '../core/NodeUtils.js';
 
-/** @module TSLCore **/
-
 let currentStack = null;
 
 const NodeElements = new Map();

--- a/src/nodes/utils/CubeMapNode.js
+++ b/src/nodes/utils/CubeMapNode.js
@@ -6,8 +6,6 @@ import { cubeTexture } from '../accessors/CubeTextureNode.js';
 import CubeRenderTarget from '../../renderers/common/CubeRenderTarget.js';
 import { CubeReflectionMapping, CubeRefractionMapping, EquirectangularReflectionMapping, EquirectangularRefractionMapping } from '../../constants.js';
 
-/** @module CubeMapNode **/
-
 const _cache = new WeakMap();
 
 /**

--- a/src/nodes/utils/Discard.js
+++ b/src/nodes/utils/Discard.js
@@ -2,8 +2,6 @@ import { select } from '../math/ConditionalNode.js';
 import { expression } from '../code/ExpressionNode.js';
 import { addMethodChaining } from '../tsl/TSLCore.js';
 
-/** @module Discard **/
-
 /**
  * Represents a `discard` shader operation in TSL.
  *

--- a/src/nodes/utils/EquirectUVNode.js
+++ b/src/nodes/utils/EquirectUVNode.js
@@ -2,8 +2,6 @@ import TempNode from '../core/TempNode.js';
 import { positionWorldDirection } from '../accessors/Position.js';
 import { nodeProxy, vec2 } from '../tsl/TSLBase.js';
 
-/** @module EquirectUVNode **/
-
 /**
  * Can be used to compute texture coordinates for projecting an
  * equirectangular texture onto a mesh for using it as the scene's

--- a/src/nodes/utils/FunctionOverloadingNode.js
+++ b/src/nodes/utils/FunctionOverloadingNode.js
@@ -1,8 +1,6 @@
 import Node from '../core/Node.js';
 import { nodeProxy } from '../tsl/TSLCore.js';
 
-/** @module FunctionOverloadingNode **/
-
 /**
  * This class allows to define multiple overloaded versions
  * of the same function. Depending on the parameters of the function

--- a/src/nodes/utils/LoopNode.js
+++ b/src/nodes/utils/LoopNode.js
@@ -2,8 +2,6 @@ import Node from '../core/Node.js';
 import { expression } from '../code/ExpressionNode.js';
 import { nodeObject, nodeArray } from '../tsl/TSLBase.js';
 
-/** @module LoopNode **/
-
 /**
  * This module offers a variety of ways to implement loops in TSL. In it's basic form it's:
  * ```js

--- a/src/nodes/utils/MatcapUVNode.js
+++ b/src/nodes/utils/MatcapUVNode.js
@@ -3,8 +3,6 @@ import { transformedNormalView } from '../accessors/Normal.js';
 import { positionViewDirection } from '../accessors/Position.js';
 import { nodeImmutable, vec2, vec3 } from '../tsl/TSLBase.js';
 
-/** @module MatcapUVNode **/
-
 /**
  * Can be used to compute texture coordinates for projecting a
  * matcap onto a mesh. Used by {@link MeshMatcapNodeMaterial}.

--- a/src/nodes/utils/MaxMipLevelNode.js
+++ b/src/nodes/utils/MaxMipLevelNode.js
@@ -2,8 +2,6 @@ import UniformNode from '../core/UniformNode.js';
 import { NodeUpdateType } from '../core/constants.js';
 import { nodeProxy } from '../tsl/TSLBase.js';
 
-/** @module MaxMipLevelNode **/
-
 /**
  * A special type of uniform node that computes the
  * maximum mipmap level for a given texture node.
@@ -12,7 +10,7 @@ import { nodeProxy } from '../tsl/TSLBase.js';
  * const level = maxMipLevel( textureNode );
  * ```
  *
- * @augments module:UniformNode~UniformNode
+ * @augments UniformNode
  */
 class MaxMipLevelNode extends UniformNode {
 

--- a/src/nodes/utils/Oscillators.js
+++ b/src/nodes/utils/Oscillators.js
@@ -1,7 +1,5 @@
 import { time } from './Timer.js';
 
-/** @module Oscillators **/
-
 /**
  * Generates a sine wave oscillation based on a timer.
  *

--- a/src/nodes/utils/Packing.js
+++ b/src/nodes/utils/Packing.js
@@ -1,7 +1,5 @@
 import { nodeObject } from '../tsl/TSLBase.js';
 
-/** @module Packing **/
-
 /**
  * Packs a direction vector into a color value.
  *

--- a/src/nodes/utils/PostProcessingUtils.js
+++ b/src/nodes/utils/PostProcessingUtils.js
@@ -3,8 +3,6 @@ import { textureSize } from '../accessors/TextureSizeNode.js';
 import { textureLoad } from '../accessors/TextureNode.js';
 import { WebGPUCoordinateSystem } from '../../constants.js';
 
-/** @module PostProcessingUtils **/
-
 /**
  * Computes a position in view space based on a fragment's screen position expressed as uv coordinates, the fragments
  * depth value and the camera's inverse projection matrix.

--- a/src/nodes/utils/RTTNode.js
+++ b/src/nodes/utils/RTTNode.js
@@ -9,8 +9,6 @@ import { RenderTarget } from '../../core/RenderTarget.js';
 import { Vector2 } from '../../math/Vector2.js';
 import { HalfFloatType } from '../../constants.js';
 
-/** @module RTTNode **/
-
 const _size = /*@__PURE__*/ new Vector2();
 
 /**
@@ -19,7 +17,7 @@ const _size = /*@__PURE__*/ new Vector2();
  * texture input for their effects. With the helper function `convertToTexture()` which is based
  * on this module, the node system can automatically ensure texture input if required.
  *
- * @augments module:TextureNode~TextureNode
+ * @augments TextureNode
  */
 class RTTNode extends TextureNode {
 

--- a/src/nodes/utils/ReflectorNode.js
+++ b/src/nodes/utils/ReflectorNode.js
@@ -14,8 +14,6 @@ import { Matrix4 } from '../../math/Matrix4.js';
 import { RenderTarget } from '../../core/RenderTarget.js';
 import { DepthTexture } from '../../textures/DepthTexture.js';
 
-/** @module ReflectorNode **/
-
 const _reflectorPlane = new Plane();
 const _normal = new Vector3();
 const _reflectorWorldPosition = new Vector3();
@@ -48,7 +46,7 @@ let _inReflector = false;
  * plane.add( groundReflector.target );
  * ```
  *
- * @augments module:TextureNode~TextureNode
+ * @augments TextureNode
  */
 class ReflectorNode extends TextureNode {
 

--- a/src/nodes/utils/RemapNode.js
+++ b/src/nodes/utils/RemapNode.js
@@ -1,8 +1,6 @@
 import Node from '../core/Node.js';
 import { float, addMethodChaining, nodeProxy } from '../tsl/TSLCore.js';
 
-/** @module RemapNode **/
-
 /**
  * This node allows to remap a node value from one range into another. E.g a value of
  * `0.4` in the range `[ 0.3, 0.5 ]` should be remapped into the normalized range `[ 0, 1 ]`.

--- a/src/nodes/utils/RotateNode.js
+++ b/src/nodes/utils/RotateNode.js
@@ -2,8 +2,6 @@ import TempNode from '../core/TempNode.js';
 import { nodeProxy, vec4, mat2, mat4 } from '../tsl/TSLBase.js';
 import { cos, sin } from '../math/MathNode.js';
 
-/** @module RotateNode **/
-
 /**
  * Applies a rotation to the given position node.
  *

--- a/src/nodes/utils/SpriteSheetUVNode.js
+++ b/src/nodes/utils/SpriteSheetUVNode.js
@@ -2,8 +2,6 @@ import Node from '../core/Node.js';
 import { uv } from '../accessors/UV.js';
 import { nodeProxy, float, vec2 } from '../tsl/TSLBase.js';
 
-/** @module SpriteSheetUVNode **/
-
 /**
  * Can be used to compute texture coordinates for animated sprite sheets.
  *

--- a/src/nodes/utils/SpriteUtils.js
+++ b/src/nodes/utils/SpriteUtils.js
@@ -3,8 +3,6 @@ import { cameraViewMatrix, cameraProjectionMatrix } from '../accessors/Camera.js
 import { positionLocal } from '../accessors/Position.js';
 import { Fn, defined } from '../tsl/TSLBase.js';
 
-/** @module SpriteUtils **/
-
 /**
  * This can be used to achieve a billboarding behavior for flat meshes. That means they are
  * oriented always towards the camera.

--- a/src/nodes/utils/StorageArrayElementNode.js
+++ b/src/nodes/utils/StorageArrayElementNode.js
@@ -1,8 +1,6 @@
 import { nodeProxy } from '../tsl/TSLBase.js';
 import ArrayElementNode from './ArrayElementNode.js';
 
-/** @module StorageArrayElementNode **/
-
 /**
  * This class enables element access on instances of {@link StorageBufferNode}.
  * In most cases, it is indirectly used when accessing elements with the

--- a/src/nodes/utils/Timer.js
+++ b/src/nodes/utils/Timer.js
@@ -1,8 +1,6 @@
 import { renderGroup } from '../core/UniformGroupNode.js';
 import { uniform } from '../core/UniformNode.js';
 
-/** @module Timer **/
-
 /**
  * Represents the elapsed time in seconds.
  *

--- a/src/nodes/utils/TriplanarTexturesNode.js
+++ b/src/nodes/utils/TriplanarTexturesNode.js
@@ -5,8 +5,6 @@ import { positionLocal } from '../accessors/Position.js';
 import { texture } from '../accessors/TextureNode.js';
 import { nodeProxy, float, vec3 } from '../tsl/TSLBase.js';
 
-/** @module TriplanarTexturesNode **/
-
 /**
  * Can be used for triplanar texture mapping.
  *

--- a/src/nodes/utils/UVUtils.js
+++ b/src/nodes/utils/UVUtils.js
@@ -1,8 +1,6 @@
 import { Fn, vec2 } from '../tsl/TSLBase.js';
 import { rotate } from './RotateNode.js';
 
-/** @module UVUtils **/
-
 /**
  * Rotates the given uv coordinates around a center point
  *

--- a/src/nodes/utils/ViewportUtils.js
+++ b/src/nodes/utils/ViewportUtils.js
@@ -3,8 +3,6 @@ import { screenUV } from '../display/ScreenNode.js';
 import { viewportDepthTexture } from '../display/ViewportDepthTextureNode.js';
 import { linearDepth } from '../display/ViewportDepthNode.js';
 
-/** @module ViewportUtils **/
-
 /**
  * A special version of a screen uv function that involves a depth comparison
  * when computing the final uvs. The function mitigates visual errors when

--- a/src/renderers/common/Backend.js
+++ b/src/renderers/common/Backend.js
@@ -8,7 +8,7 @@ import { REVISION } from '../../constants.js';
 
 /**
  * Most of the rendering related logic is implemented in the
- * {@link module:Renderer} module and related management components.
+ * {@link Renderer} module and related management components.
  * Sometimes it is required though to execute commands which are
  * specific to the current 3D backend (which is WebGPU or WebGL 2).
  * This abstract base class defines an interface that encapsulates

--- a/src/renderers/common/BufferUtils.js
+++ b/src/renderers/common/BufferUtils.js
@@ -1,7 +1,5 @@
 import { GPU_CHUNK_BYTES } from './Constants.js';
 
-/** @module BufferUtils **/
-
 /**
  * This function is usually called with the length in bytes of an array buffer.
  * It returns an padded value which ensure chunk size alignment according to STD140 layout.

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -28,8 +28,6 @@ import { Vector4 } from '../../math/Vector4.js';
 import { RenderTarget } from '../../core/RenderTarget.js';
 import { DoubleSide, BackSide, FrontSide, SRGBColorSpace, NoToneMapping, LinearFilter, LinearSRGBColorSpace, HalfFloatType, RGBAFormat, PCFShadowMap } from '../../constants.js';
 
-/** @module Renderer **/
-
 const _scene = /*@__PURE__*/ new Scene();
 const _drawingBufferSize = /*@__PURE__*/ new Vector2();
 const _screen = /*@__PURE__*/ new Vector4();
@@ -644,7 +642,7 @@ class Renderer {
 		/**
 		 * The renderer's shadow configuration.
 		 *
-		 * @type {module:Renderer~ShadowMapConfig}
+		 * @type {ShadowMapConfig}
 		 */
 		this.shadowMap = {
 			enabled: false,
@@ -675,7 +673,7 @@ class Renderer {
 		/**
 		 * The renderer's debug configuration.
 		 *
-		 * @type {module:Renderer~DebugConfig}
+		 * @type {DebugConfig}
 		 */
 		this.debug = {
 			checkShaderErrors: true,
@@ -1957,7 +1955,7 @@ class Renderer {
 	}
 
 	/**
-	 * Async version of {@link module:Renderer~Renderer#clear}.
+	 * Async version of {@link Renderer#clear}.
 	 *
 	 * @async
 	 * @param {Boolean} [color=true] - Whether the color buffer should be cleared or not.
@@ -1974,7 +1972,7 @@ class Renderer {
 	}
 
 	/**
-	 * Async version of {@link module:Renderer~Renderer#clearColor}.
+	 * Async version of {@link Renderer#clearColor}.
 	 *
 	 * @async
 	 * @return {Promise} A Promise that resolves when the clear operation has been executed.
@@ -1986,7 +1984,7 @@ class Renderer {
 	}
 
 	/**
-	 * Async version of {@link module:Renderer~Renderer#clearDepth}.
+	 * Async version of {@link Renderer#clearDepth}.
 	 *
 	 * @async
 	 * @return {Promise} A Promise that resolves when the clear operation has been executed.
@@ -1998,7 +1996,7 @@ class Renderer {
 	}
 
 	/**
-	 * Async version of {@link module:Renderer~Renderer#clearStencil}.
+	 * Async version of {@link Renderer#clearStencil}.
 	 *
 	 * @async
 	 * @return {Promise} A Promise that resolves when the clear operation has been executed.
@@ -2093,7 +2091,7 @@ class Renderer {
 	}
 
 	/**
-	 * Callback for {@link module:Renderer~Renderer#setRenderObjectFunction}.
+	 * Callback for {@link Renderer#setRenderObjectFunction}.
 	 *
 	 * @callback renderObjectFunction
 	 * @param {Object3D} object - The 3D object.
@@ -2109,14 +2107,14 @@ class Renderer {
 
 	/**
 	 * Sets the given render object function. Calling this method overwrites the default implementation
-	 * which is {@link module:Renderer~Renderer#renderObject}. Defining a custom function can be useful
+	 * which is {@link Renderer#renderObject}. Defining a custom function can be useful
 	 * if you want to modify the way objects are rendered. For example you can define things like "every
 	 * object that has material of a certain type should perform a pre-pass with a special overwrite material".
 	 * The custom function must always call `renderObject()` in its implementation.
 	 *
 	 * Use `null` as the first argument to reset the state.
 	 *
-	 * @param {module:Renderer~renderObjectFunction?} renderObjectFunction - The render object function.
+	 * @param {renderObjectFunction?} renderObjectFunction - The render object function.
 	 */
 	setRenderObjectFunction( renderObjectFunction ) {
 

--- a/src/renderers/common/RendererUtils.js
+++ b/src/renderers/common/RendererUtils.js
@@ -1,7 +1,5 @@
 import { Color } from '../../math/Color.js';
 
-/** @module RendererUtils **/
-
 /**
  * Saves the state of the given renderer and stores it into the given state object.
  *

--- a/src/renderers/common/StorageBufferAttribute.js
+++ b/src/renderers/common/StorageBufferAttribute.js
@@ -8,7 +8,7 @@ import { BufferAttribute } from '../../core/BufferAttribute.js';
  * to compute the data for an attribute more efficiently on the GPU.
  *
  * The idea is to create an instance of this class and provide it as an input
- * to {@link module:StorageBufferNode}.
+ * to {@link StorageBufferNode}.
  *
  * Note: This type of buffer attribute can only be used with `WebGPURenderer`.
  *

--- a/src/renderers/common/StorageInstancedBufferAttribute.js
+++ b/src/renderers/common/StorageInstancedBufferAttribute.js
@@ -8,7 +8,7 @@ import { InstancedBufferAttribute } from '../../core/InstancedBufferAttribute.js
  * to compute the data for an attribute more efficiently on the GPU.
  *
  * The idea is to create an instance of this class and provide it as an input
- * to {@link module:StorageBufferNode}.
+ * to {@link StorageBufferNode}.
  *
  * Note: This type of buffer attribute can only be used with `WebGPURenderer`.
  *

--- a/src/renderers/webgpu/WebGPURenderer.Nodes.js
+++ b/src/renderers/webgpu/WebGPURenderer.Nodes.js
@@ -8,7 +8,7 @@ import BasicNodeLibrary from './nodes/BasicNodeLibrary.js';
  * So classes like `MeshBasicMaterial` are not compatible.
  *
  * @private
- * @augments module:Renderer~Renderer
+ * @augments Renderer
  */
 class WebGPURenderer extends Renderer {
 

--- a/src/renderers/webgpu/WebGPURenderer.js
+++ b/src/renderers/webgpu/WebGPURenderer.js
@@ -22,7 +22,7 @@ const debugHandler = {
  * to target different backends. By default, the renderer tries to use a WebGPU backend if the
  * browser supports WebGPU. If not, `WebGPURenderer` falls backs to a WebGL 2 backend.
  *
- * @augments module:Renderer~Renderer
+ * @augments Renderer
  */
 class WebGPURenderer extends Renderer {
 

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -203,7 +203,7 @@ class WGSLNodeBuilder extends NodeBuilder {
 
 		/**
 		 * A map for managing scope arrays. Only relevant for when using
-		 * {@link module:WorkgroupInfoNode} in context of compute shaders.
+		 * {@link WorkgroupInfoNode} in context of compute shaders.
 		 *
 		 * @type {Map<String,Object>}
 		 */

--- a/utils/docs/jsdoc.config.json
+++ b/utils/docs/jsdoc.config.json
@@ -7,7 +7,7 @@
             "template": "node_modules/clean-jsdoc-theme",
             "theme_opts": {
                 "homepageTitle": "three.js docs",
-                "sections": ["Classes", "Modules"],
+                "sections": ["Classes"],
                 "include_css": ["utils/docs/custom/three.css"]
            }
     },


### PR DESCRIPTION
Related issue: -

**Description**

The usage of `@module` complicates linking and searching so this PR removes the tag from all modules.

I'm thinking about introducing a custom `@tsl` tag that allows us to identify TSL functions and objects so they can be listed separately. That would require a custom template though.
