### PR TITLE
WebGLBackend: Configure scissor/viewport before clear.

### DIFF
--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -438,18 +438,6 @@ class WebGLBackend extends Backend {
 
 		//
 
-		//
-
-		this.initTimestampQuery( renderContext );
-
-		renderContextData.previousContext = this._currentContext;
-		this._currentContext = renderContext;
-
-		this._setFramebuffer( renderContext );
-
-		this.clear( renderContext.clearColor, renderContext.clearDepth, renderContext.clearStencil, renderContext, false );
-
-		//
 		if ( renderContext.viewport ) {
 
 			this.updateViewport( renderContext );
@@ -467,6 +455,18 @@ class WebGLBackend extends Backend {
 			state.scissor( x, renderContext.height - height - y, width, height );
 
 		}
+
+		//
+
+		this.initTimestampQuery( renderContext );
+
+		renderContextData.previousContext = this._currentContext;
+		this._currentContext = renderContext;
+
+		this._setFramebuffer( renderContext );
+
+		this.clear( renderContext.clearColor, renderContext.clearDepth, renderContext.clearStencil, renderContext, false );
+
 
 		const occlusionQueryCount = renderContext.occlusionQueryCount;
 

--- a/src/renderers/webgl-fallback/utils/WebGLState.js
+++ b/src/renderers/webgl-fallback/utils/WebGLState.js
@@ -548,7 +548,7 @@ class WebGLState {
 	}
 
 	/**
-	 * Specifies the viewport.
+	 * Specifies the scissor box.
 	 *
 	 * @param {Number} x - The x-coordinate of the lower left corner of the viewport.
 	 * @param {Number} y - The y-coordinate of the lower left corner of the viewport.


### PR DESCRIPTION
Fixed #30450.

**Description**

The WebGL backend of `WebGPURenderer` must configure scissor and viewport before a clear operation. Otherwise it uses outdated values from the previous render.