### PR TITLE
JSDoc: Add `@tsl` tag.

### DIFF
--- a/examples/jsm/tsl/display/AfterImageNode.js
+++ b/examples/jsm/tsl/display/AfterImageNode.js
@@ -232,6 +232,7 @@ class AfterImageNode extends TempNode {
 /**
  * TSL function for creating an after image node for post processing.
  *
+ * @tsl
  * @function
  * @param {Node<vec4>} node - The node that represents the input of the effect.
  * @param {Number} [damp=0.96] - The damping intensity. A higher value means a stronger after image effect.

--- a/examples/jsm/tsl/display/AnaglyphPassNode.js
+++ b/examples/jsm/tsl/display/AnaglyphPassNode.js
@@ -97,6 +97,7 @@ export default AnaglyphPassNode;
 /**
  * TSL function for creating an anaglyph pass node.
  *
+ * @tsl
  * @function
  * @param {Scene} scene - The scene to render.
  * @param {Camera} camera - The camera to render the scene with.

--- a/examples/jsm/tsl/display/AnamorphicNode.js
+++ b/examples/jsm/tsl/display/AnamorphicNode.js
@@ -244,6 +244,7 @@ class AnamorphicNode extends TempNode {
 /**
  * TSL function for creating an anamorphic flare effect.
  *
+ * @tsl
  * @function
  * @param {TextureNode} node - The node that represents the input of the effect.
  * @param {Node<float> | Number} [threshold=0.9] - The threshold is one option to control the intensity and size of the effect.

--- a/examples/jsm/tsl/display/BleachBypass.js
+++ b/examples/jsm/tsl/display/BleachBypass.js
@@ -3,6 +3,7 @@ import { float, Fn, vec3, vec4, min, max, mix, luminance } from 'three/tsl';
 /**
  * Applies a bleach bypass effect to the given color node.
  *
+ * @tsl
  * @function
  * @param {Node<vec4>} color - The color node to apply the sepia for.
  * @param {Node<float>} [opacity=1] - Influences how strong the effect is blended with the original color.

--- a/examples/jsm/tsl/display/BloomNode.js
+++ b/examples/jsm/tsl/display/BloomNode.js
@@ -505,6 +505,7 @@ class BloomNode extends TempNode {
 /**
  * TSL function for creating a bloom effect.
  *
+ * @tsl
  * @function
  * @param {Node<vec4>} node - The node that represents the input of the effect.
  * @param {Number} [strength=1] - The strength of the bloom.

--- a/examples/jsm/tsl/display/DenoiseNode.js
+++ b/examples/jsm/tsl/display/DenoiseNode.js
@@ -321,6 +321,7 @@ function generateDefaultNoise( size = 64 ) {
 /**
  * TSL function for creating a denoise effect.
  *
+ * @tsl
  * @function
  * @param {Node} node - The node that represents the input of the effect (e.g. AO).
  * @param {Node<float>} depthNode - A node that represents the scene's depth.

--- a/examples/jsm/tsl/display/DepthOfFieldNode.js
+++ b/examples/jsm/tsl/display/DepthOfFieldNode.js
@@ -185,6 +185,7 @@ export default DepthOfFieldNode;
 /**
  * TSL function for creating a depth-of-field effect (DOF) for post processing.
  *
+ * @tsl
  * @function
  * @param {Node<vec4>} node - The node that represents the input of the effect.
  * @param {Node<float>} viewZNode - Represents the viewZ depth values of the scene.

--- a/examples/jsm/tsl/display/DotScreenNode.js
+++ b/examples/jsm/tsl/display/DotScreenNode.js
@@ -93,6 +93,7 @@ export default DotScreenNode;
 /**
  * TSL function for creating a dot-screen node for post processing.
  *
+ * @tsl
  * @function
  * @param {Node<vec4>} node - The node that represents the input of the effect.
  * @param {Number} [angle=1.57] - The rotation of the effect in radians.

--- a/examples/jsm/tsl/display/FXAANode.js
+++ b/examples/jsm/tsl/display/FXAANode.js
@@ -356,6 +356,7 @@ export default FXAANode;
 /**
  * TSL function for creating a FXAA node for anti-aliasing via post processing.
  *
+ * @tsl
  * @function
  * @param {Node<vec4>} node - The node that represents the input of the effect.
  * @returns {FXAANode}

--- a/examples/jsm/tsl/display/FilmNode.js
+++ b/examples/jsm/tsl/display/FilmNode.js
@@ -88,6 +88,7 @@ export default FilmNode;
 /**
  * TSL function for creating a film node for post processing.
  *
+ * @tsl
  * @function
  * @param {Node<vec4>} inputNode - The node that represents the input of the effect.
  * @param {Node<float>?} [intensityNode=null] - A node that represents the effect's intensity.

--- a/examples/jsm/tsl/display/GTAONode.js
+++ b/examples/jsm/tsl/display/GTAONode.js
@@ -511,6 +511,7 @@ function generateMagicSquare( size ) {
 /**
  * TSL function for creating a Ground Truth Ambient Occlusion (GTAO) effect.
  *
+ * @tsl
  * @function
  * @param {Node<float>} depthNode - A node that represents the scene's depth.
  * @param {Node<vec3>?} normalNode - A node that represents the scene's normals.

--- a/examples/jsm/tsl/display/GaussianBlurNode.js
+++ b/examples/jsm/tsl/display/GaussianBlurNode.js
@@ -371,6 +371,7 @@ export default GaussianBlurNode;
 /**
  * TSL function for creating a gaussian blur node for post processing.
  *
+ * @tsl
  * @function
  * @param {Node<vec4>} node - The node that represents the input of the effect.
  * @param {Node<vec2|float>} directionNode - Defines the direction and radius of the blur.
@@ -382,6 +383,7 @@ export const gaussianBlur = ( node, directionNode, sigma ) => nodeObject( new Ga
 /**
  * TSL function for creating a gaussian blur node for post processing with enabled premultiplied alpha.
  *
+ * @tsl
  * @function
  * @param {Node<vec4>} node - The node that represents the input of the effect.
  * @param {Node<vec2|float>} directionNode - Defines the direction and radius of the blur.

--- a/examples/jsm/tsl/display/LensflareNode.js
+++ b/examples/jsm/tsl/display/LensflareNode.js
@@ -263,6 +263,7 @@ export default LensflareNode;
 /**
  * TSL function for creating a bloom-based lens flare effect.
  *
+ * @tsl
  * @function
  * @param {TextureNode} node - The node that represents the scene's bloom.
  * @param {Object} params - The parameter object for configuring the effect.

--- a/examples/jsm/tsl/display/Lut3DNode.js
+++ b/examples/jsm/tsl/display/Lut3DNode.js
@@ -97,6 +97,7 @@ export default Lut3DNode;
 /**
  * TSL function for creating a LUT node for color grading via post processing.
  *
+ * @tsl
  * @function
  * @param {Node} node - The node that represents the input of the effect.
  * @param {TextureNode} lut - A texture node that represents the lookup table.

--- a/examples/jsm/tsl/display/MotionBlur.js
+++ b/examples/jsm/tsl/display/MotionBlur.js
@@ -3,6 +3,7 @@ import { Fn, float, uv, Loop, int } from 'three/tsl';
 /**
  * Applies a motion blur effect to the given input node.
  *
+ * @tsl
  * @function
  * @param {Node<vec4>} inputNode - The input node to apply the motion blur for.
  * @param {Node<vec2>} velocity - The motion vectors of the beauty pass.

--- a/examples/jsm/tsl/display/OutlineNode.js
+++ b/examples/jsm/tsl/display/OutlineNode.js
@@ -736,6 +736,7 @@ export default OutlineNode;
 /**
  * TSL function for creating an outline effect around selected objects.
  *
+ * @tsl
  * @function
  * @param {Scene} scene - A reference to the scene.
  * @param {Camera} camera - The camera the scene is rendered with.

--- a/examples/jsm/tsl/display/ParallaxBarrierPassNode.js
+++ b/examples/jsm/tsl/display/ParallaxBarrierPassNode.js
@@ -79,6 +79,7 @@ export default ParallaxBarrierPassNode;
 /**
  * TSL function for creating an parallax barrier pass node.
  *
+ * @tsl
  * @function
  * @param {Scene} scene - The scene to render.
  * @param {Camera} camera - The camera to render the scene with.

--- a/examples/jsm/tsl/display/PixelationPassNode.js
+++ b/examples/jsm/tsl/display/PixelationPassNode.js
@@ -319,6 +319,7 @@ class PixelationPassNode extends PassNode {
 /**
  * TSL function for creating a pixelation render pass node for post processing.
  *
+ * @tsl
  * @function
  * @param {Scene} scene - The scene to render.
  * @param {Camera} camera - The camera to render the scene with.

--- a/examples/jsm/tsl/display/RGBShiftNode.js
+++ b/examples/jsm/tsl/display/RGBShiftNode.js
@@ -85,6 +85,7 @@ export default RGBShiftNode;
 /**
  * TSL function for creating a RGB shift or split effect for post processing.
  *
+ * @tsl
  * @function
  * @param {Node<vec4>} node - The node that represents the input of the effect.
  * @param {Number} [amount=0.005] - The amount of the RGB shift.

--- a/examples/jsm/tsl/display/SMAANode.js
+++ b/examples/jsm/tsl/display/SMAANode.js
@@ -756,4 +756,12 @@ class SMAANode extends TempNode {
 
 export default SMAANode;
 
+/**
+ * TSL function for creating a SMAA node for anti-aliasing via post processing.
+ *
+ * @tsl
+ * @function
+ * @param {Node<vec4>} node - The node that represents the input of the effect.
+ * @returns {SMAANode}
+ */
 export const smaa = ( node ) => nodeObject( new SMAANode( convertToTexture( node ) ) );

--- a/examples/jsm/tsl/display/SSAAPassNode.js
+++ b/examples/jsm/tsl/display/SSAAPassNode.js
@@ -347,6 +347,7 @@ const _JitterVectors = [
 /**
  * TSL function for creating a SSAA pass node for Supersampling Anti-Aliasing.
  *
+ * @tsl
  * @function
  * @param {Scene} scene - The scene to render.
  * @param {Camera} camera - The camera to render the scene with.

--- a/examples/jsm/tsl/display/SSRNode.js
+++ b/examples/jsm/tsl/display/SSRNode.js
@@ -526,6 +526,7 @@ export default SSRNode;
 /**
  * TSL function for creating screen space reflections (SSR).
  *
+ * @tsl
  * @function
  * @param {Node<vec4>} colorNode - The node that represents the beauty pass.
  * @param {Node<float>} depthNode - A node that represents the beauty pass's depth.

--- a/examples/jsm/tsl/display/Sepia.js
+++ b/examples/jsm/tsl/display/Sepia.js
@@ -3,6 +3,7 @@ import { dot, Fn, vec3, vec4 } from 'three/tsl';
 /**
  * Applies a sepia effect to the given color node.
  *
+ * @tsl
  * @function
  * @param {Node<vec4>} color - The color node to apply the sepia for.
  * @return {Node<vec4>} The updated color node.

--- a/examples/jsm/tsl/display/SobelOperatorNode.js
+++ b/examples/jsm/tsl/display/SobelOperatorNode.js
@@ -159,6 +159,7 @@ export default SobelOperatorNode;
 /**
  * TSL function for creating a sobel operator node which performs edge detection with a sobel filter.
  *
+ * @tsl
  * @function
  * @param {Node<vec4>} node - The node that represents the input of the effect.
  * @returns {SobelOperatorNode}

--- a/examples/jsm/tsl/display/StereoPassNode.js
+++ b/examples/jsm/tsl/display/StereoPassNode.js
@@ -110,6 +110,7 @@ export default StereoPassNode;
 /**
  * TSL function for creating a stereo pass node for stereoscopic rendering.
  *
+ * @tsl
  * @function
  * @param {Scene} scene - The scene to render.
  * @param {Camera} camera - The camera to render the scene with.

--- a/examples/jsm/tsl/display/TRAAPassNode.js
+++ b/examples/jsm/tsl/display/TRAAPassNode.js
@@ -440,6 +440,7 @@ const _JitterVectors = [
 /**
  * TSL function for creating a TRAA pass node for Temporal Reprojection Anti-Aliasing.
  *
+ * @tsl
  * @function
  * @param {Scene} scene - The scene to render.
  * @param {Camera} camera - The camera to render the scene with.

--- a/examples/jsm/tsl/display/TransitionNode.js
+++ b/examples/jsm/tsl/display/TransitionNode.js
@@ -127,6 +127,7 @@ export default TransitionNode;
 /**
  * TSL function for creating a transition node for post processing.
  *
+ * @tsl
  * @function
  * @param {Node<vec4>} nodeA - A texture node that represents the beauty pass of the first scene.
  * @param {Node<vec4>} nodeB - A texture node that represents the beauty pass of the second scene.

--- a/examples/jsm/tsl/display/hashBlur.js
+++ b/examples/jsm/tsl/display/hashBlur.js
@@ -5,6 +5,7 @@ import { float, Fn, vec2, uv, sin, rand, degrees, cos, Loop, vec4 } from 'three/
  *
  * Reference: {@link https://www.shadertoy.com/view/4lXXWn}.
  *
+ * @tsl
  * @function
  * @param {Node<vec4>} textureNode - The texture node that should be blurred.
  * @param {Node<float>} [bluramount=float(0.1)] - This node determines the amount of blur.

--- a/src/nodes/accessors/AccessorsUtils.js
+++ b/src/nodes/accessors/AccessorsUtils.js
@@ -9,6 +9,7 @@ import { positionViewDirection } from './Position.js';
 /**
  * TSL object that represents the TBN matrix in view space.
  *
+ * @tsl
  * @type {Node<mat3>}
  */
 export const TBNViewMatrix = /*@__PURE__*/ mat3( tangentView, bitangentView, normalView );
@@ -16,6 +17,7 @@ export const TBNViewMatrix = /*@__PURE__*/ mat3( tangentView, bitangentView, nor
 /**
  * TSL object that represents the parallax direction.
  *
+ * @tsl
  * @type {Node<mat3>}
  */
 export const parallaxDirection = /*@__PURE__*/ positionViewDirection.mul( TBNViewMatrix )/*.normalize()*/;
@@ -23,6 +25,7 @@ export const parallaxDirection = /*@__PURE__*/ positionViewDirection.mul( TBNVie
 /**
  * TSL function for computing parallax uv coordinates.
  *
+ * @tsl
  * @function
  * @param {Node<vec2>} uv - A uv node.
  * @param {Node<vec2>} scale - A scale node.
@@ -33,6 +36,7 @@ export const parallaxUV = ( uv, scale ) => uv.sub( parallaxDirection.mul( scale 
 /**
  * TSL function for computing bent normals.
  *
+ * @tsl
  * @function
  * @returns {Node<vec3>} Bent normals.
  */

--- a/src/nodes/accessors/Arrays.js
+++ b/src/nodes/accessors/Arrays.js
@@ -6,6 +6,7 @@ import { getLengthFromType, getTypedArrayFromType } from '../core/NodeUtils.js';
 /**
  * TSL function for creating a storage buffer node with a configured `StorageBufferAttribute`.
  *
+ * @tsl
  * @function
  * @param {Number|TypedArray} count - The data count. It is also valid to pass a typed array as an argument.
  * @param {String|Struct} [type='float'] - The data type.
@@ -37,6 +38,7 @@ export const attributeArray = ( count, type = 'float' ) => {
 /**
  * TSL function for creating a storage buffer node with a configured `StorageInstancedBufferAttribute`.
  *
+ * @tsl
  * @function
  * @param {Number|TypedArray} count - The data count. It is also valid to pass a typed array as an argument.
  * @param {String|Struct} [type='float'] - The data type.

--- a/src/nodes/accessors/BatchNode.js
+++ b/src/nodes/accessors/BatchNode.js
@@ -155,6 +155,7 @@ export default BatchNode;
 /**
  * TSL function for creating a batch node.
  *
+ * @tsl
  * @function
  * @param {BatchedMesh} batchMesh - A reference to batched mesh.
  * @returns {BatchNode}

--- a/src/nodes/accessors/Bitangent.js
+++ b/src/nodes/accessors/Bitangent.js
@@ -8,6 +8,7 @@ const getBitangent = ( crossNormalTangent ) => crossNormalTangent.mul( tangentGe
 /**
  * TSL object that represents the bitangent attribute of the current rendered object.
  *
+ * @tsl
  * @type {Node<vec3>}
  */
 export const bitangentGeometry = /*@__PURE__*/ varying( getBitangent( normalGeometry.cross( tangentGeometry ) ), 'v_bitangentGeometry' ).normalize().toVar( 'bitangentGeometry' );
@@ -15,6 +16,7 @@ export const bitangentGeometry = /*@__PURE__*/ varying( getBitangent( normalGeom
 /**
  * TSL object that represents the vertex bitangent in local space of the current rendered object.
  *
+ * @tsl
  * @type {Node<vec3>}
  */
 export const bitangentLocal = /*@__PURE__*/ varying( getBitangent( normalLocal.cross( tangentLocal ) ), 'v_bitangentLocal' ).normalize().toVar( 'bitangentLocal' );
@@ -22,6 +24,7 @@ export const bitangentLocal = /*@__PURE__*/ varying( getBitangent( normalLocal.c
 /**
  * TSL object that represents the vertex bitangent in view space of the current rendered object.
  *
+ * @tsl
  * @type {Node<vec4>}
  */
 export const bitangentView = /*@__PURE__*/ varying( getBitangent( normalView.cross( tangentView ) ), 'v_bitangentView' ).normalize().toVar( 'bitangentView' );
@@ -29,6 +32,7 @@ export const bitangentView = /*@__PURE__*/ varying( getBitangent( normalView.cro
 /**
  * TSL object that represents the vertex bitangent in world space of the current rendered object.
  *
+ * @tsl
  * @type {Node<vec4>}
  */
 export const bitangentWorld = /*@__PURE__*/ varying( getBitangent( normalWorld.cross( tangentWorld ) ), 'v_bitangentWorld' ).normalize().toVar( 'bitangentWorld' );
@@ -36,6 +40,7 @@ export const bitangentWorld = /*@__PURE__*/ varying( getBitangent( normalWorld.c
 /**
  * TSL object that represents the transformed vertex bitangent in view space of the current rendered object.
  *
+ * @tsl
  * @type {Node<vec4>}
  */
 export const transformedBitangentView = /*@__PURE__*/ getBitangent( transformedNormalView.cross( transformedTangentView ) ).normalize().toVar( 'transformedBitangentView' );
@@ -43,6 +48,7 @@ export const transformedBitangentView = /*@__PURE__*/ getBitangent( transformedN
 /**
  * TSL object that represents the transformed vertex bitangent in world space of the current rendered object.
  *
+ * @tsl
  * @type {Node<vec4>}
  */
 export const transformedBitangentWorld = /*@__PURE__*/ transformedBitangentView.transformDirection( cameraViewMatrix ).normalize().toVar( 'transformedBitangentWorld' );

--- a/src/nodes/accessors/BufferAttributeNode.js
+++ b/src/nodes/accessors/BufferAttributeNode.js
@@ -287,6 +287,7 @@ export default BufferAttributeNode;
 /**
  * TSL function for creating a buffer attribute node.
  *
+ * @tsl
  * @function
  * @param {BufferAttribute|InterleavedBuffer|TypedArray} array - The attribute data.
  * @param {String?} [type=null] - The buffer type (e.g. `'vec3'`).
@@ -300,6 +301,7 @@ export const bufferAttribute = ( array, type = null, stride = 0, offset = 0 ) =>
  * TSL function for creating a buffer attribute node but with dynamic draw usage.
  * Use this function if attribute data are updated per frame.
  *
+ * @tsl
  * @function
  * @param {BufferAttribute|InterleavedBuffer|TypedArray} array - The attribute data.
  * @param {String?} [type=null] - The buffer type (e.g. `'vec3'`).
@@ -312,6 +314,7 @@ export const dynamicBufferAttribute = ( array, type = null, stride = 0, offset =
 /**
  * TSL function for creating a buffer attribute node but with enabled instancing
  *
+ * @tsl
  * @function
  * @param {BufferAttribute|InterleavedBuffer|TypedArray} array - The attribute data.
  * @param {String?} [type=null] - The buffer type (e.g. `'vec3'`).
@@ -324,6 +327,7 @@ export const instancedBufferAttribute = ( array, type = null, stride = 0, offset
 /**
  * TSL function for creating a buffer attribute node but with dynamic draw usage and enabled instancing
  *
+ * @tsl
  * @function
  * @param {BufferAttribute|InterleavedBuffer|TypedArray} array - The attribute data.
  * @param {String?} [type=null] - The buffer type (e.g. `'vec3'`).

--- a/src/nodes/accessors/BufferNode.js
+++ b/src/nodes/accessors/BufferNode.js
@@ -91,6 +91,7 @@ export default BufferNode;
 /**
  * TSL function for creating a buffer node.
  *
+ * @tsl
  * @function
  * @param {Array} value - Array-like buffer data.
  * @param {String} type - The data type of a buffer element.

--- a/src/nodes/accessors/BuiltinNode.js
+++ b/src/nodes/accessors/BuiltinNode.js
@@ -55,6 +55,7 @@ export default BuiltinNode;
 /**
  * TSL function for creating a builtin node.
  *
+ * @tsl
  * @function
  * @param {String} name - The name of the built-in shader variable.
  * @returns {BuiltinNode}

--- a/src/nodes/accessors/Camera.js
+++ b/src/nodes/accessors/Camera.js
@@ -7,6 +7,7 @@ import { uniformArray } from './UniformArrayNode.js';
 /**
  * TSL object that represents the current `index` value of the camera if used ArrayCamera.
  *
+ * @tsl
  * @type {UniformNode<uint>}
  */
 export const cameraIndex = /*@__PURE__*/ uniform( 0, 'uint' ).setGroup( sharedUniformGroup( 'cameraIndex' ) ).toVarying( 'v_cameraIndex' );
@@ -14,6 +15,7 @@ export const cameraIndex = /*@__PURE__*/ uniform( 0, 'uint' ).setGroup( sharedUn
 /**
  * TSL object that represents the `near` value of the camera used for the current render.
  *
+ * @tsl
  * @type {UniformNode<float>}
  */
 export const cameraNear = /*@__PURE__*/ uniform( 'float' ).label( 'cameraNear' ).setGroup( renderGroup ).onRenderUpdate( ( { camera } ) => camera.near );
@@ -21,6 +23,7 @@ export const cameraNear = /*@__PURE__*/ uniform( 'float' ).label( 'cameraNear' )
 /**
  * TSL object that represents the `far` value of the camera used for the current render.
  *
+ * @tsl
  * @type {UniformNode<float>}
  */
 export const cameraFar = /*@__PURE__*/ uniform( 'float' ).label( 'cameraFar' ).setGroup( renderGroup ).onRenderUpdate( ( { camera } ) => camera.far );
@@ -28,6 +31,7 @@ export const cameraFar = /*@__PURE__*/ uniform( 'float' ).label( 'cameraFar' ).s
 /**
  * TSL object that represents the projection matrix of the camera used for the current render.
  *
+ * @tsl
  * @type {UniformNode<mat4>}
  */
 export const cameraProjectionMatrix = /*@__PURE__*/ ( Fn( ( { camera } ) => {
@@ -61,6 +65,7 @@ export const cameraProjectionMatrix = /*@__PURE__*/ ( Fn( ( { camera } ) => {
 /**
  * TSL object that represents the inverse projection matrix of the camera used for the current render.
  *
+ * @tsl
  * @type {UniformNode<mat4>}
  */
 export const cameraProjectionMatrixInverse = /*@__PURE__*/ uniform( 'mat4' ).label( 'cameraProjectionMatrixInverse' ).setGroup( renderGroup ).onRenderUpdate( ( { camera } ) => camera.projectionMatrixInverse );
@@ -68,6 +73,7 @@ export const cameraProjectionMatrixInverse = /*@__PURE__*/ uniform( 'mat4' ).lab
 /**
  * TSL object that represents the view matrix of the camera used for the current render.
  *
+ * @tsl
  * @type {UniformNode<mat4>}
  */
 export const cameraViewMatrix = /*@__PURE__*/ ( Fn( ( { camera } ) => {
@@ -101,6 +107,7 @@ export const cameraViewMatrix = /*@__PURE__*/ ( Fn( ( { camera } ) => {
 /**
  * TSL object that represents the world matrix of the camera used for the current render.
  *
+ * @tsl
  * @type {UniformNode<mat4>}
  */
 export const cameraWorldMatrix = /*@__PURE__*/ uniform( 'mat4' ).label( 'cameraWorldMatrix' ).setGroup( renderGroup ).onRenderUpdate( ( { camera } ) => camera.matrixWorld );
@@ -108,6 +115,7 @@ export const cameraWorldMatrix = /*@__PURE__*/ uniform( 'mat4' ).label( 'cameraW
 /**
  * TSL object that represents the normal matrix of the camera used for the current render.
  *
+ * @tsl
  * @type {UniformNode<mat3>}
  */
 export const cameraNormalMatrix = /*@__PURE__*/ uniform( 'mat3' ).label( 'cameraNormalMatrix' ).setGroup( renderGroup ).onRenderUpdate( ( { camera } ) => camera.normalMatrix );
@@ -115,6 +123,7 @@ export const cameraNormalMatrix = /*@__PURE__*/ uniform( 'mat3' ).label( 'camera
 /**
  * TSL object that represents the position in world space of the camera used for the current render.
  *
+ * @tsl
  * @type {UniformNode<vec3>}
  */
 export const cameraPosition = /*@__PURE__*/ uniform( new Vector3() ).label( 'cameraPosition' ).setGroup( renderGroup ).onRenderUpdate( ( { camera }, self ) => self.value.setFromMatrixPosition( camera.matrixWorld ) );

--- a/src/nodes/accessors/ClippingNode.js
+++ b/src/nodes/accessors/ClippingNode.js
@@ -229,6 +229,7 @@ export default ClippingNode;
 /**
  * TSL function for setting up the default clipping logic.
  *
+ * @tsl
  * @function
  * @returns {ClippingNode}
  */
@@ -237,6 +238,7 @@ export const clipping = () => nodeObject( new ClippingNode() );
 /**
  * TSL function for setting up alpha to coverage.
  *
+ * @tsl
  * @function
  * @returns {ClippingNode}
  */
@@ -245,6 +247,7 @@ export const clippingAlpha = () => nodeObject( new ClippingNode( ClippingNode.AL
 /**
  * TSL function for setting up hardware-based clipping.
  *
+ * @tsl
  * @function
  * @returns {ClippingNode}
  */

--- a/src/nodes/accessors/CubeTextureNode.js
+++ b/src/nodes/accessors/CubeTextureNode.js
@@ -131,6 +131,7 @@ export default CubeTextureNode;
 /**
  * TSL function for creating a cube texture node.
  *
+ * @tsl
  * @function
  * @param {CubeTexture} value - The cube texture.
  * @param {Node<vec3>?} [uvNode=null] - The uv node.

--- a/src/nodes/accessors/InstanceNode.js
+++ b/src/nodes/accessors/InstanceNode.js
@@ -213,6 +213,7 @@ export default InstanceNode;
 /**
  * TSL function for creating an instance node.
  *
+ * @tsl
  * @function
  * @param {Number} count - The number of instances.
  * @param {InstancedBufferAttribute} instanceMatrix - Instanced buffer attribute representing the instance transformations.

--- a/src/nodes/accessors/InstancedMeshNode.js
+++ b/src/nodes/accessors/InstancedMeshNode.js
@@ -42,6 +42,7 @@ export default InstancedMeshNode;
 /**
  * TSL function for creating an instanced mesh node.
  *
+ * @tsl
  * @function
  * @param {InstancedMesh} instancedMesh - The instancedMesh.
  * @returns {InstancedMeshNode}

--- a/src/nodes/accessors/Lights.js
+++ b/src/nodes/accessors/Lights.js
@@ -21,6 +21,7 @@ function getLightData( light ) {
 /**
  * TSL function for getting a shadow matrix uniform node for the given light.
  *
+ * @tsl
  * @function
  * @param {Light} light -The light source.
  * @returns {UniformNode<mat4>} The shadow matrix uniform node.
@@ -47,6 +48,7 @@ export function lightShadowMatrix( light ) {
  * TSL function for getting projected uv coordinates for the given light.
  * Relevant when using maps with spot lights.
  *
+ * @tsl
  * @function
  * @param {Light} light -The light source.
  * @returns {Node<vec3>} The projected uvs.
@@ -71,6 +73,7 @@ export function lightProjectionUV( light ) {
 /**
  * TSL function for getting the position in world space for the given light.
  *
+ * @tsl
  * @function
  * @param {Light} light -The light source.
  * @returns {UniformNode<vec3>} The light's position in world space.
@@ -86,6 +89,7 @@ export function lightPosition( light ) {
 /**
  * TSL function for getting the light target position in world space for the given light.
  *
+ * @tsl
  * @function
  * @param {Light} light -The light source.
  * @returns {UniformNode<vec3>} The light target position in world space.
@@ -101,6 +105,7 @@ export function lightTargetPosition( light ) {
 /**
  * TSL function for getting the position in view space for the given light.
  *
+ * @tsl
  * @function
  * @param {Light} light -The light source.
  * @returns {UniformNode<vec3>} The light's position in view space.
@@ -123,6 +128,7 @@ export function lightViewPosition( light ) {
 /**
  * TSL function for getting the light target direction for the given light.
  *
+ * @tsl
  * @function
  * @param {Light} light -The light source.
  * @returns {Node<vec3>} The light's target direction.

--- a/src/nodes/accessors/MaterialNode.js
+++ b/src/nodes/accessors/MaterialNode.js
@@ -443,6 +443,7 @@ export default MaterialNode;
 /**
  * TSL object that represents alpha test of the current material.
  *
+ * @tsl
  * @type {Node<float>}
  */
 export const materialAlphaTest = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.ALPHA_TEST );
@@ -451,6 +452,7 @@ export const materialAlphaTest = /*@__PURE__*/ nodeImmutable( MaterialNode, Mate
  * TSL object that represents the diffuse color of the current material.
  * The value is composed via `color` * `map`.
  *
+ * @tsl
  * @type {Node<vec3>}
  */
 export const materialColor = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.COLOR );
@@ -458,6 +460,7 @@ export const materialColor = /*@__PURE__*/ nodeImmutable( MaterialNode, Material
 /**
  * TSL object that represents the shininess of the current material.
  *
+ * @tsl
  * @type {Node<float>}
  */
 export const materialShininess = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.SHININESS );
@@ -466,6 +469,7 @@ export const materialShininess = /*@__PURE__*/ nodeImmutable( MaterialNode, Mate
  * TSL object that represents the emissive color of the current material.
  * The value is composed via `emissive` * `emissiveIntensity` * `emissiveMap`.
  *
+ * @tsl
  * @type {Node<vec3>}
  */
 export const materialEmissive = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.EMISSIVE );
@@ -474,6 +478,7 @@ export const materialEmissive = /*@__PURE__*/ nodeImmutable( MaterialNode, Mater
  * TSL object that represents the opacity of the current material.
  * The value is composed via `opacity` * `alphaMap`.
  *
+ * @tsl
  * @type {Node<float>}
  */
 export const materialOpacity = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.OPACITY );
@@ -481,6 +486,7 @@ export const materialOpacity = /*@__PURE__*/ nodeImmutable( MaterialNode, Materi
 /**
  * TSL object that represents the specular of the current material.
  *
+ * @tsl
  * @type {Node<vec3>}
  */
 export const materialSpecular = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.SPECULAR );
@@ -489,6 +495,7 @@ export const materialSpecular = /*@__PURE__*/ nodeImmutable( MaterialNode, Mater
  * TSL object that represents the specular intensity of the current material.
  * The value is composed via `specularIntensity` * `specularMap.a`.
  *
+ * @tsl
  * @type {Node<float>}
  */
 export const materialSpecularIntensity = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.SPECULAR_INTENSITY );
@@ -497,6 +504,7 @@ export const materialSpecularIntensity = /*@__PURE__*/ nodeImmutable( MaterialNo
  * TSL object that represents the specular color of the current material.
  * The value is composed via `specularColor` * `specularMap.rgb`.
  *
+ * @tsl
  * @type {Node<vec3>}
  */
 export const materialSpecularColor = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.SPECULAR_COLOR );
@@ -505,6 +513,7 @@ export const materialSpecularColor = /*@__PURE__*/ nodeImmutable( MaterialNode, 
  * TSL object that represents the specular strength of the current material.
  * The value is composed via `specularMap.r`.
  *
+ * @tsl
  * @type {Node<float>}
  */
 export const materialSpecularStrength = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.SPECULAR_STRENGTH );
@@ -512,6 +521,7 @@ export const materialSpecularStrength = /*@__PURE__*/ nodeImmutable( MaterialNod
 /**
  * TSL object that represents the reflectivity of the current material.
  *
+ * @tsl
  * @type {Node<float>}
  */
 export const materialReflectivity = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.REFLECTIVITY );
@@ -520,6 +530,7 @@ export const materialReflectivity = /*@__PURE__*/ nodeImmutable( MaterialNode, M
  * TSL object that represents the roughness of the current material.
  * The value is composed via `roughness` * `roughnessMap.g`.
  *
+ * @tsl
  * @type {Node<float>}
  */
 export const materialRoughness = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.ROUGHNESS );
@@ -528,6 +539,7 @@ export const materialRoughness = /*@__PURE__*/ nodeImmutable( MaterialNode, Mate
  * TSL object that represents the metalness of the current material.
  * The value is composed via `metalness` * `metalnessMap.b`.
  *
+ * @tsl
  * @type {Node<float>}
  */
 export const materialMetalness = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.METALNESS );
@@ -536,6 +548,7 @@ export const materialMetalness = /*@__PURE__*/ nodeImmutable( MaterialNode, Mate
  * TSL object that represents the normal of the current material.
  * The value will be either `normalMap` * `normalScale`, `bumpMap` * `bumpScale` or `normalView`.
  *
+ * @tsl
  * @type {Node<vec3>}
  */
 export const materialNormal = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.NORMAL );
@@ -544,6 +557,7 @@ export const materialNormal = /*@__PURE__*/ nodeImmutable( MaterialNode, Materia
  * TSL object that represents the clearcoat of the current material.
  * The value is composed via `clearcoat` * `clearcoatMap.r`
  *
+ * @tsl
  * @type {Node<float>}
  */
 export const materialClearcoat = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.CLEARCOAT );
@@ -552,6 +566,7 @@ export const materialClearcoat = /*@__PURE__*/ nodeImmutable( MaterialNode, Mate
  * TSL object that represents the clearcoat roughness of the current material.
  * The value is composed via `clearcoatRoughness` * `clearcoatRoughnessMap.r`.
  *
+ * @tsl
  * @type {Node<float>}
  */
 export const materialClearcoatRoughness = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.CLEARCOAT_ROUGHNESS );
@@ -560,6 +575,7 @@ export const materialClearcoatRoughness = /*@__PURE__*/ nodeImmutable( MaterialN
  * TSL object that represents the clearcoat normal of the current material.
  * The value will be either `clearcoatNormalMap` or `normalView`.
  *
+ * @tsl
  * @type {Node<vec3>}
  */
 export const materialClearcoatNormal = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.CLEARCOAT_NORMAL );
@@ -567,6 +583,7 @@ export const materialClearcoatNormal = /*@__PURE__*/ nodeImmutable( MaterialNode
 /**
  * TSL object that represents the rotation of the current sprite material.
  *
+ * @tsl
  * @type {Node<float>}
  */
 export const materialRotation = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.ROTATION );
@@ -575,6 +592,7 @@ export const materialRotation = /*@__PURE__*/ nodeImmutable( MaterialNode, Mater
  * TSL object that represents the sheen color of the current material.
  * The value is composed via `sheen` * `sheenColor` * `sheenColorMap`.
  *
+ * @tsl
  * @type {Node<vec3>}
  */
 export const materialSheen = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.SHEEN );
@@ -583,6 +601,7 @@ export const materialSheen = /*@__PURE__*/ nodeImmutable( MaterialNode, Material
  * TSL object that represents the sheen roughness of the current material.
  * The value is composed via `sheenRoughness` * `sheenRoughnessMap.a`.
  *
+ * @tsl
  * @type {Node<float>}
  */
 export const materialSheenRoughness = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.SHEEN_ROUGHNESS );
@@ -590,6 +609,7 @@ export const materialSheenRoughness = /*@__PURE__*/ nodeImmutable( MaterialNode,
 /**
  * TSL object that represents the anisotropy of the current material.
  *
+ * @tsl
  * @type {Node<vec2>}
  */
 export const materialAnisotropy = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.ANISOTROPY );
@@ -597,6 +617,7 @@ export const materialAnisotropy = /*@__PURE__*/ nodeImmutable( MaterialNode, Mat
 /**
  * TSL object that represents the iridescence of the current material.
  *
+ * @tsl
  * @type {Node<float>}
  */
 export const materialIridescence = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.IRIDESCENCE );
@@ -604,6 +625,7 @@ export const materialIridescence = /*@__PURE__*/ nodeImmutable( MaterialNode, Ma
 /**
  * TSL object that represents the iridescence IOR of the current material.
  *
+ * @tsl
  * @type {Node<float>}
  */
 export const materialIridescenceIOR = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.IRIDESCENCE_IOR );
@@ -611,6 +633,7 @@ export const materialIridescenceIOR = /*@__PURE__*/ nodeImmutable( MaterialNode,
 /**
  * TSL object that represents the iridescence thickness of the current material.
  *
+ * @tsl
  * @type {Node<float>}
  */
 export const materialIridescenceThickness = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.IRIDESCENCE_THICKNESS );
@@ -619,6 +642,7 @@ export const materialIridescenceThickness = /*@__PURE__*/ nodeImmutable( Materia
  * TSL object that represents the transmission of the current material.
  * The value is composed via `transmission` * `transmissionMap.r`.
  *
+ * @tsl
  * @type {Node<float>}
  */
 export const materialTransmission = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.TRANSMISSION );
@@ -627,6 +651,7 @@ export const materialTransmission = /*@__PURE__*/ nodeImmutable( MaterialNode, M
  * TSL object that represents the thickness of the current material.
  * The value is composed via `thickness` * `thicknessMap.g`.
  *
+ * @tsl
  * @type {Node<float>}
  */
 export const materialThickness = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.THICKNESS );
@@ -634,6 +659,7 @@ export const materialThickness = /*@__PURE__*/ nodeImmutable( MaterialNode, Mate
 /**
  * TSL object that represents the IOR of the current material.
  *
+ * @tsl
  * @type {Node<float>}
  */
 export const materialIOR = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.IOR );
@@ -641,6 +667,7 @@ export const materialIOR = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNo
 /**
  * TSL object that represents the attenuation distance of the current material.
  *
+ * @tsl
  * @type {Node<float>}
  */
 export const materialAttenuationDistance = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.ATTENUATION_DISTANCE );
@@ -648,6 +675,7 @@ export const materialAttenuationDistance = /*@__PURE__*/ nodeImmutable( Material
 /**
  * TSL object that represents the attenuation color of the current material.
  *
+ * @tsl
  * @type {Node<vec3>}
  */
 export const materialAttenuationColor = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.ATTENUATION_COLOR );
@@ -655,6 +683,7 @@ export const materialAttenuationColor = /*@__PURE__*/ nodeImmutable( MaterialNod
 /**
  * TSL object that represents the scale of the current dashed line material.
  *
+ * @tsl
  * @type {Node<float>}
  */
 export const materialLineScale = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.LINE_SCALE );
@@ -662,6 +691,7 @@ export const materialLineScale = /*@__PURE__*/ nodeImmutable( MaterialNode, Mate
 /**
  * TSL object that represents the dash size of the current dashed line material.
  *
+ * @tsl
  * @type {Node<float>}
  */
 export const materialLineDashSize = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.LINE_DASH_SIZE );
@@ -669,6 +699,7 @@ export const materialLineDashSize = /*@__PURE__*/ nodeImmutable( MaterialNode, M
 /**
  * TSL object that represents the gap size of the current dashed line material.
  *
+ * @tsl
  * @type {Node<float>}
  */
 export const materialLineGapSize = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.LINE_GAP_SIZE );
@@ -676,6 +707,7 @@ export const materialLineGapSize = /*@__PURE__*/ nodeImmutable( MaterialNode, Ma
 /**
  * TSL object that represents the line width of the current line material.
  *
+ * @tsl
  * @type {Node<float>}
  */
 export const materialLineWidth = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.LINE_WIDTH );
@@ -683,6 +715,7 @@ export const materialLineWidth = /*@__PURE__*/ nodeImmutable( MaterialNode, Mate
 /**
  * TSL object that represents the dash offset of the current line material.
  *
+ * @tsl
  * @type {Node<float>}
  */
 export const materialLineDashOffset = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.LINE_DASH_OFFSET );
@@ -690,6 +723,7 @@ export const materialLineDashOffset = /*@__PURE__*/ nodeImmutable( MaterialNode,
 /**
  * TSL object that represents the point size of the current points material.
  *
+ * @tsl
  * @type {Node<float>}
  */
 export const materialPointSize = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.POINT_SIZE );
@@ -697,6 +731,7 @@ export const materialPointSize = /*@__PURE__*/ nodeImmutable( MaterialNode, Mate
 /**
  * TSL object that represents the dispersion of the current material.
  *
+ * @tsl
  * @type {Node<float>}
  */
 export const materialDispersion = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.DISPERSION );
@@ -705,6 +740,7 @@ export const materialDispersion = /*@__PURE__*/ nodeImmutable( MaterialNode, Mat
  * TSL object that represents the light map of the current material.
  * The value is composed via `lightMapIntensity` * `lightMap.rgb`.
  *
+ * @tsl
  * @type {Node<vec3>}
  */
 export const materialLightMap = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.LIGHT_MAP );
@@ -713,6 +749,7 @@ export const materialLightMap = /*@__PURE__*/ nodeImmutable( MaterialNode, Mater
  * TSL object that represents the ambient occlusion map of the current material.
  * The value is composed via `aoMap.r` - 1 * `aoMapIntensity` + 1.
  *
+ * @tsl
  * @type {Node<float>}
  */
 export const materialAO = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNode.AO );
@@ -720,6 +757,7 @@ export const materialAO = /*@__PURE__*/ nodeImmutable( MaterialNode, MaterialNod
 /**
  * TSL object that represents the anisotropy vector of the current material.
  *
+ * @tsl
  * @type {Node<vec2>}
  */
 export const materialAnisotropyVector = /*@__PURE__*/ uniform( new Vector2() ).onReference( function ( frame ) {

--- a/src/nodes/accessors/MaterialProperties.js
+++ b/src/nodes/accessors/MaterialProperties.js
@@ -3,6 +3,7 @@ import { uniform } from '../core/UniformNode.js';
 /**
  * TSL object that represents the refraction ratio of the material used for rendering the current object.
  *
+ * @tsl
  * @type {UniformNode<float>}
  */
 export const materialRefractionRatio = /*@__PURE__*/ uniform( 0 ).onReference( ( { material } ) => material ).onRenderUpdate( ( { material } ) => material.refractionRatio );

--- a/src/nodes/accessors/MaterialReferenceNode.js
+++ b/src/nodes/accessors/MaterialReferenceNode.js
@@ -74,6 +74,7 @@ export default MaterialReferenceNode;
 /**
  * TSL function for creating a material reference node.
  *
+ * @tsl
  * @function
  * @param {String} name - The name of the property the node refers to.
  * @param {String} type - The uniform type that should be used to represent the property value.

--- a/src/nodes/accessors/ModelNode.js
+++ b/src/nodes/accessors/ModelNode.js
@@ -54,6 +54,7 @@ export default ModelNode;
 /**
  * TSL object that represents the object's direction in world space.
  *
+ * @tsl
  * @type {ModelNode<vec3>}
  */
 export const modelDirection = /*@__PURE__*/ nodeImmutable( ModelNode, ModelNode.DIRECTION );
@@ -61,6 +62,7 @@ export const modelDirection = /*@__PURE__*/ nodeImmutable( ModelNode, ModelNode.
 /**
  * TSL object that represents the object's world matrix.
  *
+ * @tsl
  * @type {ModelNode<mat4>}
  */
 export const modelWorldMatrix = /*@__PURE__*/ nodeImmutable( ModelNode, ModelNode.WORLD_MATRIX );
@@ -68,6 +70,7 @@ export const modelWorldMatrix = /*@__PURE__*/ nodeImmutable( ModelNode, ModelNod
 /**
  * TSL object that represents the object's position in world space.
  *
+ * @tsl
  * @type {ModelNode<vec3>}
  */
 export const modelPosition = /*@__PURE__*/ nodeImmutable( ModelNode, ModelNode.POSITION );
@@ -75,6 +78,7 @@ export const modelPosition = /*@__PURE__*/ nodeImmutable( ModelNode, ModelNode.P
 /**
  * TSL object that represents the object's scale in world space.
  *
+ * @tsl
  * @type {ModelNode<vec3>}
  */
 export const modelScale = /*@__PURE__*/ nodeImmutable( ModelNode, ModelNode.SCALE );
@@ -82,6 +86,7 @@ export const modelScale = /*@__PURE__*/ nodeImmutable( ModelNode, ModelNode.SCAL
 /**
  * TSL object that represents the object's position in view/camera space.
  *
+ * @tsl
  * @type {ModelNode<vec3>}
  */
 export const modelViewPosition = /*@__PURE__*/ nodeImmutable( ModelNode, ModelNode.VIEW_POSITION );
@@ -89,6 +94,7 @@ export const modelViewPosition = /*@__PURE__*/ nodeImmutable( ModelNode, ModelNo
 /**
  * TSL object that represents the object's normal matrix.
  *
+ * @tsl
  * @type {UniformNode<mat3>}
  */
 export const modelNormalMatrix = /*@__PURE__*/ uniform( new Matrix3() ).onObjectUpdate( ( { object }, self ) => self.value.getNormalMatrix( object.matrixWorld ) );
@@ -96,6 +102,7 @@ export const modelNormalMatrix = /*@__PURE__*/ uniform( new Matrix3() ).onObject
 /**
  * TSL object that represents the object's inverse world matrix.
  *
+ * @tsl
  * @type {UniformNode<mat4>}
  */
 export const modelWorldMatrixInverse = /*@__PURE__*/ uniform( new Matrix4() ).onObjectUpdate( ( { object }, self ) => self.value.copy( object.matrixWorld ).invert() );
@@ -103,6 +110,7 @@ export const modelWorldMatrixInverse = /*@__PURE__*/ uniform( new Matrix4() ).on
 /**
  * TSL object that represents the object's model view matrix.
  *
+ * @tsl
  * @type {Node<mat4>}
  */
 export const modelViewMatrix = /*@__PURE__*/ ( Fn( ( builder ) => {
@@ -116,6 +124,7 @@ export const modelViewMatrix = /*@__PURE__*/ ( Fn( ( builder ) => {
 /**
  * TSL object that represents the object's model view in `mediump` precision.
  *
+ * @tsl
  * @type {Node<mat4>}
  */
 export const mediumpModelViewMatrix = /*@__PURE__*/ cameraViewMatrix.mul( modelWorldMatrix );
@@ -126,6 +135,7 @@ export const mediumpModelViewMatrix = /*@__PURE__*/ cameraViewMatrix.mul( modelW
  * TSL object that represents the object's model view in `highp` precision
  * which is achieved by computing the matrix in JS and not in the shader.
  *
+ * @tsl
  * @type {Node<mat4>}
  */
 export const highpModelViewMatrix = /*@__PURE__*/ ( Fn( ( builder ) => {
@@ -144,6 +154,7 @@ export const highpModelViewMatrix = /*@__PURE__*/ ( Fn( ( builder ) => {
  * TSL object that represents the object's model normal view in `highp` precision
  * which is achieved by computing the matrix in JS and not in the shader.
  *
+ * @tsl
  * @type {Node<mat3>}
  */
 export const highpModelNormalViewMatrix = /*@__PURE__*/ ( Fn( ( builder ) => {

--- a/src/nodes/accessors/ModelViewProjectionNode.js
+++ b/src/nodes/accessors/ModelViewProjectionNode.js
@@ -3,6 +3,7 @@ import { Fn } from '../tsl/TSLCore.js';
 /**
  * TSL object that represents the position in clip space after the model-view-projection transform of the current rendered object.
  *
+ * @tsl
  * @type {VaryingNode<vec4>}
  */
 export const modelViewProjection = /*@__PURE__*/ ( Fn( ( builder ) => {

--- a/src/nodes/accessors/MorphNode.js
+++ b/src/nodes/accessors/MorphNode.js
@@ -298,6 +298,7 @@ export default MorphNode;
 /**
  * TSL function for creating a morph node.
  *
+ * @tsl
  * @function
  * @param {Mesh} mesh - The mesh holding the morph targets.
  * @returns {MorphNode}

--- a/src/nodes/accessors/Normal.js
+++ b/src/nodes/accessors/Normal.js
@@ -8,6 +8,7 @@ import { faceDirection } from '../display/FrontFacingNode.js';
 /**
  * TSL object that represents the normal attribute of the current rendered object.
  *
+ * @tsl
  * @type {Node<vec3>}
  */
 export const normalGeometry = /*@__PURE__*/ attribute( 'normal', 'vec3' );
@@ -15,6 +16,7 @@ export const normalGeometry = /*@__PURE__*/ attribute( 'normal', 'vec3' );
 /**
  * TSL object that represents the vertex normal in local space of the current rendered object.
  *
+ * @tsl
  * @type {Node<vec3>}
  */
 export const normalLocal = /*@__PURE__*/ ( Fn( ( builder ) => {
@@ -34,6 +36,7 @@ export const normalLocal = /*@__PURE__*/ ( Fn( ( builder ) => {
 /**
  * TSL object that represents the flat vertex normal in view space of the current rendered object.
  *
+ * @tsl
  * @type {Node<vec3>}
  */
 export const normalFlat = /*@__PURE__*/ positionView.dFdx().cross( positionView.dFdy() ).normalize().toVar( 'normalFlat' );
@@ -41,6 +44,7 @@ export const normalFlat = /*@__PURE__*/ positionView.dFdx().cross( positionView.
 /**
  * TSL object that represents the vertex normal in view space of the current rendered object.
  *
+ * @tsl
  * @type {Node<vec3>}
  */
 export const normalView = /*@__PURE__*/ ( Fn( ( builder ) => {
@@ -64,6 +68,7 @@ export const normalView = /*@__PURE__*/ ( Fn( ( builder ) => {
 /**
  * TSL object that represents the vertex normal in world space of the current rendered object.
  *
+ * @tsl
  * @type {Node<vec3>}
  */
 export const normalWorld = /*@__PURE__*/ varying( normalView.transformDirection( cameraViewMatrix ), 'v_normalWorld' ).normalize().toVar( 'normalWorld' );
@@ -71,6 +76,7 @@ export const normalWorld = /*@__PURE__*/ varying( normalView.transformDirection(
 /**
  * TSL object that represents the transformed vertex normal in view space of the current rendered object.
  *
+ * @tsl
  * @type {Node<vec3>}
  */
 export const transformedNormalView = /*@__PURE__*/ ( Fn( ( builder ) => {
@@ -84,6 +90,7 @@ export const transformedNormalView = /*@__PURE__*/ ( Fn( ( builder ) => {
 /**
  * TSL object that represents the transformed vertex normal in world space of the current rendered object.
  *
+ * @tsl
  * @type {Node<vec3>}
  */
 export const transformedNormalWorld = /*@__PURE__*/ transformedNormalView.transformDirection( cameraViewMatrix ).toVar( 'transformedNormalWorld' );
@@ -91,6 +98,7 @@ export const transformedNormalWorld = /*@__PURE__*/ transformedNormalView.transf
 /**
  * TSL object that represents the transformed clearcoat vertex normal in view space of the current rendered object.
  *
+ * @tsl
  * @type {Node<vec3>}
  */
 export const transformedClearcoatNormalView = /*@__PURE__*/ ( Fn( ( builder ) => {
@@ -104,6 +112,7 @@ export const transformedClearcoatNormalView = /*@__PURE__*/ ( Fn( ( builder ) =>
 /**
  * Transforms the normal with the given matrix.
  *
+ * @tsl
  * @function
  * @param {Node<vec3>} normal - The normal.
  * @param {Node<mat3>} [matrix=modelWorldMatrix] - The matrix.
@@ -122,6 +131,7 @@ export const transformNormal = /*@__PURE__*/ Fn( ( [ normal, matrix = modelWorld
 /**
  * Transforms the given normal from local to view space.
  *
+ * @tsl
  * @function
  * @param {Node<vec3>} normal - The normal.
  * @param {NodeBuilder} builder - The current node builder.

--- a/src/nodes/accessors/Object3DNode.js
+++ b/src/nodes/accessors/Object3DNode.js
@@ -189,6 +189,7 @@ export default Object3DNode;
 /**
  * TSL function for creating an object 3D node that represents the object's direction in world space.
  *
+ * @tsl
  * @function
  * @param {Object3D?} [object3d=null] - The 3D object.
  * @returns {Object3DNode<vec3>}
@@ -198,6 +199,7 @@ export const objectDirection = /*@__PURE__*/ nodeProxy( Object3DNode, Object3DNo
 /**
  * TSL function for creating an object 3D node that represents the object's world matrix.
  *
+ * @tsl
  * @function
  * @param {Object3D?} [object3d=null] - The 3D object.
  * @returns {Object3DNode<mat4>}
@@ -207,6 +209,7 @@ export const objectWorldMatrix = /*@__PURE__*/ nodeProxy( Object3DNode, Object3D
 /**
  * TSL function for creating an object 3D node that represents the object's position in world space.
  *
+ * @tsl
  * @function
  * @param {Object3D?} [object3d=null] - The 3D object.
  * @returns {Object3DNode<vec3>}
@@ -216,6 +219,7 @@ export const objectPosition = /*@__PURE__*/ nodeProxy( Object3DNode, Object3DNod
 /**
  * TSL function for creating an object 3D node that represents the object's scale in world space.
  *
+ * @tsl
  * @function
  * @param {Object3D?} [object3d=null] - The 3D object.
  * @returns {Object3DNode<vec3>}
@@ -225,6 +229,7 @@ export const objectScale = /*@__PURE__*/ nodeProxy( Object3DNode, Object3DNode.S
 /**
  * TSL function for creating an object 3D node that represents the object's position in view/camera space.
  *
+ * @tsl
  * @function
  * @param {Object3D?} [object3d=null] - The 3D object.
  * @returns {Object3DNode<vec3>}

--- a/src/nodes/accessors/PointUVNode.js
+++ b/src/nodes/accessors/PointUVNode.js
@@ -49,6 +49,7 @@ export default PointUVNode;
 /**
  * TSL object that represents the uv coordinates of points.
  *
+ * @tsl
  * @type {PointUVNode}
  */
 export const pointUV = /*@__PURE__*/ nodeImmutable( PointUVNode );

--- a/src/nodes/accessors/Position.js
+++ b/src/nodes/accessors/Position.js
@@ -5,6 +5,7 @@ import { modelWorldMatrix } from './ModelNode.js';
 /**
  * TSL object that represents the position attribute of the current rendered object.
  *
+ * @tsl
  * @type {AttributeNode<vec3>}
  */
 export const positionGeometry = /*@__PURE__*/ attribute( 'position', 'vec3' );
@@ -12,6 +13,7 @@ export const positionGeometry = /*@__PURE__*/ attribute( 'position', 'vec3' );
 /**
  * TSL object that represents the vertex position in local space of the current rendered object.
  *
+ * @tsl
  * @type {AttributeNode<vec3>}
  */
 export const positionLocal = /*@__PURE__*/ positionGeometry.toVarying( 'positionLocal' );
@@ -20,6 +22,7 @@ export const positionLocal = /*@__PURE__*/ positionGeometry.toVarying( 'position
  * TSL object that represents the previous vertex position in local space of the current rendered object.
  * Used in context of {@link VelocityNode} for rendering motion vectors.
  *
+ * @tsl
  * @type {AttributeNode<vec3>}
  */
 export const positionPrevious = /*@__PURE__*/ positionGeometry.toVarying( 'positionPrevious' );
@@ -27,6 +30,7 @@ export const positionPrevious = /*@__PURE__*/ positionGeometry.toVarying( 'posit
 /**
  * TSL object that represents the vertex position in world space of the current rendered object.
  *
+ * @tsl
  * @type {VaryingNode<vec3>}
  */
 export const positionWorld = /*@__PURE__*/ modelWorldMatrix.mul( positionLocal ).xyz.toVarying( 'v_positionWorld' ).context( { needsPositionReassign: true } );
@@ -34,6 +38,7 @@ export const positionWorld = /*@__PURE__*/ modelWorldMatrix.mul( positionLocal )
 /**
  * TSL object that represents the position world direction of the current rendered object.
  *
+ * @tsl
  * @type {Node<vec3>}
  */
 export const positionWorldDirection = /*@__PURE__*/ positionLocal.transformDirection( modelWorldMatrix ).toVarying( 'v_positionWorldDirection' ).normalize().toVar( 'positionWorldDirection' ).context( { needsPositionReassign: true } );
@@ -41,6 +46,7 @@ export const positionWorldDirection = /*@__PURE__*/ positionLocal.transformDirec
 /**
  * TSL object that represents the vertex position in view space of the current rendered object.
  *
+ * @tsl
  * @type {VaryingNode<vec3>}
  */
 export const positionView = /*@__PURE__*/ ( Fn( ( builder ) => {
@@ -52,6 +58,7 @@ export const positionView = /*@__PURE__*/ ( Fn( ( builder ) => {
 /**
  * TSL object that represents the position view direction of the current rendered object.
  *
+ * @tsl
  * @type {VaryingNode<vec3>}
  */
 export const positionViewDirection = /*@__PURE__*/ positionView.negate().toVarying( 'v_positionViewDirection' ).normalize().toVar( 'positionViewDirection' );

--- a/src/nodes/accessors/ReferenceBaseNode.js
+++ b/src/nodes/accessors/ReferenceBaseNode.js
@@ -333,6 +333,7 @@ export default ReferenceBaseNode;
 /**
  * TSL function for creating a reference base node.
  *
+ * @tsl
  * @function
  * @param {String} name - The name of the property the node refers to.
  * @param {String} type - The uniform type that should be used to represent the property value.
@@ -345,6 +346,7 @@ export const reference = ( name, type, object ) => nodeObject( new ReferenceBase
  * TSL function for creating a reference base node. Use this function if you want need a reference
  * to an array-like property that should be represented as a uniform buffer.
  *
+ * @tsl
  * @function
  * @param {String} name - The name of the property the node refers to.
  * @param {String} type - The uniform type that should be used to represent the property value.

--- a/src/nodes/accessors/ReferenceNode.js
+++ b/src/nodes/accessors/ReferenceNode.js
@@ -384,6 +384,7 @@ export default ReferenceNode;
 /**
  * TSL function for creating a reference node.
  *
+ * @tsl
  * @function
  * @param {String} name - The name of the property the node refers to.
  * @param {String} type - The uniform type that should be used to represent the property value.
@@ -396,6 +397,7 @@ export const reference = ( name, type, object ) => nodeObject( new ReferenceNode
  * TSL function for creating a reference node. Use this function if you want need a reference
  * to an array-like property that should be represented as a uniform buffer.
  *
+ * @tsl
  * @function
  * @param {String} name - The name of the property the node refers to.
  * @param {String} type - The uniform type that should be used to represent the property value.

--- a/src/nodes/accessors/ReflectVector.js
+++ b/src/nodes/accessors/ReflectVector.js
@@ -6,6 +6,7 @@ import { materialRefractionRatio } from './MaterialProperties.js';
 /**
  * The reflect vector in view space.
  *
+ * @tsl
  * @type {Node<vec3>}
  */
 export const reflectView = /*@__PURE__*/ positionViewDirection.negate().reflect( transformedNormalView );
@@ -13,6 +14,7 @@ export const reflectView = /*@__PURE__*/ positionViewDirection.negate().reflect(
 /**
  * The refract vector in view space.
  *
+ * @tsl
  * @type {Node<vec3>}
  */
 export const refractView = /*@__PURE__*/ positionViewDirection.negate().refract( transformedNormalView, materialRefractionRatio );
@@ -20,6 +22,7 @@ export const refractView = /*@__PURE__*/ positionViewDirection.negate().refract(
 /**
  * Used for sampling cube maps when using cube reflection mapping.
  *
+ * @tsl
  * @type {Node<vec3>}
  */
 export const reflectVector = /*@__PURE__*/ reflectView.transformDirection( cameraViewMatrix ).toVar( 'reflectVector' );
@@ -27,6 +30,7 @@ export const reflectVector = /*@__PURE__*/ reflectView.transformDirection( camer
 /**
  * Used for sampling cube maps when using cube refraction mapping.
  *
+ * @tsl
  * @type {Node<vec3>}
  */
 export const refractVector = /*@__PURE__*/ refractView.transformDirection( cameraViewMatrix ).toVar( 'reflectVector' );

--- a/src/nodes/accessors/RendererReferenceNode.js
+++ b/src/nodes/accessors/RendererReferenceNode.js
@@ -68,6 +68,7 @@ export default RendererReferenceNode;
 /**
  * TSL function for creating a renderer reference node.
  *
+ * @tsl
  * @function
  * @param {String} name - The name of the property the node refers to.
  * @param {String} type - The uniform type that should be used to represent the property value.

--- a/src/nodes/accessors/SceneNode.js
+++ b/src/nodes/accessors/SceneNode.js
@@ -122,6 +122,7 @@ export default SceneNode;
 /**
  * TSL object that represents the scene's background blurriness.
  *
+ * @tsl
  * @type {SceneNode}
  */
 export const backgroundBlurriness = /*@__PURE__*/ nodeImmutable( SceneNode, SceneNode.BACKGROUND_BLURRINESS );
@@ -129,6 +130,7 @@ export const backgroundBlurriness = /*@__PURE__*/ nodeImmutable( SceneNode, Scen
 /**
  * TSL object that represents the scene's background intensity.
  *
+ * @tsl
  * @type {SceneNode}
  */
 export const backgroundIntensity = /*@__PURE__*/ nodeImmutable( SceneNode, SceneNode.BACKGROUND_INTENSITY );
@@ -136,6 +138,7 @@ export const backgroundIntensity = /*@__PURE__*/ nodeImmutable( SceneNode, Scene
 /**
  * TSL object that represents the scene's background rotation.
  *
+ * @tsl
  * @type {SceneNode}
  */
 export const backgroundRotation = /*@__PURE__*/ nodeImmutable( SceneNode, SceneNode.BACKGROUND_ROTATION );

--- a/src/nodes/accessors/SkinningNode.js
+++ b/src/nodes/accessors/SkinningNode.js
@@ -299,6 +299,7 @@ export default SkinningNode;
 /**
  * TSL function for creating a skinning node.
  *
+ * @tsl
  * @function
  * @param {SkinnedMesh} skinnedMesh - The skinned mesh.
  * @returns {SkinningNode}
@@ -308,6 +309,7 @@ export const skinning = ( skinnedMesh ) => nodeObject( new SkinningNode( skinned
 /**
  * TSL function for creating a skinning node with reference usage.
  *
+ * @tsl
  * @function
  * @param {SkinnedMesh} skinnedMesh - The skinned mesh.
  * @returns {SkinningNode}

--- a/src/nodes/accessors/StorageBufferNode.js
+++ b/src/nodes/accessors/StorageBufferNode.js
@@ -362,6 +362,7 @@ export default StorageBufferNode;
 /**
  * TSL function for creating a storage buffer node.
  *
+ * @tsl
  * @function
  * @param {StorageBufferAttribute|StorageInstancedBufferAttribute|BufferAttribute} value - The buffer data.
  * @param {(String|Struct)?} [type=null] - The buffer type (e.g. `'vec3'`).
@@ -371,6 +372,7 @@ export default StorageBufferNode;
 export const storage = ( value, type = null, count = 0 ) => nodeObject( new StorageBufferNode( value, type, count ) );
 
 /**
+ * @tsl
  * @function
  * @deprecated since r171. Use `storage().setPBO( true )` instead.
  *

--- a/src/nodes/accessors/StorageTextureNode.js
+++ b/src/nodes/accessors/StorageTextureNode.js
@@ -200,6 +200,7 @@ export default StorageTextureNode;
 /**
  * TSL function for creating a storage texture node.
  *
+ * @tsl
  * @function
  * @param {StorageTexture} value - The storage texture.
  * @param {Node<vec2|vec3>} uvNode - The uv node.
@@ -212,6 +213,7 @@ export const storageTexture = /*@__PURE__*/ nodeProxy( StorageTextureNode );
 /**
  * TODO: Explain difference to `storageTexture()`.
  *
+ * @tsl
  * @function
  * @param {StorageTexture} value - The storage texture.
  * @param {Node<vec2|vec3>} uvNode - The uv node.

--- a/src/nodes/accessors/Tangent.js
+++ b/src/nodes/accessors/Tangent.js
@@ -6,6 +6,7 @@ import { Fn, vec4 } from '../tsl/TSLBase.js';
 /**
  * TSL object that represents the tangent attribute of the current rendered object.
  *
+ * @tsl
  * @type {Node<vec4>}
  */
 export const tangentGeometry = /*@__PURE__*/ Fn( ( builder ) => {
@@ -23,6 +24,7 @@ export const tangentGeometry = /*@__PURE__*/ Fn( ( builder ) => {
 /**
  * TSL object that represents the vertex tangent in local space of the current rendered object.
  *
+ * @tsl
  * @type {Node<vec3>}
  */
 export const tangentLocal = /*@__PURE__*/ tangentGeometry.xyz.toVar( 'tangentLocal' );
@@ -30,6 +32,7 @@ export const tangentLocal = /*@__PURE__*/ tangentGeometry.xyz.toVar( 'tangentLoc
 /**
  * TSL object that represents the vertex tangent in view space of the current rendered object.
  *
+ * @tsl
  * @type {Node<vec3>}
  */
 export const tangentView = /*@__PURE__*/ modelViewMatrix.mul( vec4( tangentLocal, 0 ) ).xyz.toVarying( 'v_tangentView' ).normalize().toVar( 'tangentView' );
@@ -37,6 +40,7 @@ export const tangentView = /*@__PURE__*/ modelViewMatrix.mul( vec4( tangentLocal
 /**
  * TSL object that represents the vertex tangent in world space of the current rendered object.
  *
+ * @tsl
  * @type {Node<vec3>}
  */
 export const tangentWorld = /*@__PURE__*/ tangentView.transformDirection( cameraViewMatrix ).toVarying( 'v_tangentWorld' ).normalize().toVar( 'tangentWorld' );
@@ -44,6 +48,7 @@ export const tangentWorld = /*@__PURE__*/ tangentView.transformDirection( camera
 /**
  * TSL object that represents the transformed vertex tangent in view space of the current rendered object.
  *
+ * @tsl
  * @type {Node<vec3>}
  */
 export const transformedTangentView = /*@__PURE__*/ tangentView.toVar( 'transformedTangentView' );
@@ -51,6 +56,7 @@ export const transformedTangentView = /*@__PURE__*/ tangentView.toVar( 'transfor
 /**
  * TSL object that represents the transformed vertex tangent in world space of the current rendered object.
  *
+ * @tsl
  * @type {Node<vec3>}
  */
 export const transformedTangentWorld = /*@__PURE__*/ transformedTangentView.transformDirection( cameraViewMatrix ).normalize().toVar( 'transformedTangentWorld' );

--- a/src/nodes/accessors/Texture3DNode.js
+++ b/src/nodes/accessors/Texture3DNode.js
@@ -176,6 +176,7 @@ export default Texture3DNode;
 /**
  * TSL function for creating a 3D texture node.
  *
+ * @tsl
  * @function
  * @param {Data3DTexture} value - The 3D texture.
  * @param {Node<vec2|vec3>?} [uvNode=null] - The uv node.

--- a/src/nodes/accessors/TextureBicubic.js
+++ b/src/nodes/accessors/TextureBicubic.js
@@ -54,7 +54,8 @@ const bicubic = ( textureNode, texelSize, lod ) => {
 /**
  * Applies mipped bicubic texture filtering to the given texture node.
  *
- * @method
+ * @tsl
+ * @function
  * @param {TextureNode} textureNode - The texture node that should be filtered.
  * @param {Node<float>} [lodNode=float(3)] - Defines the LOD to sample from.
  * @return {Node} The filtered texture sample.

--- a/src/nodes/accessors/TextureNode.js
+++ b/src/nodes/accessors/TextureNode.js
@@ -722,6 +722,7 @@ export default TextureNode;
 /**
  * TSL function for creating a texture node.
  *
+ * @tsl
  * @function
  * @param {Texture} value - The texture.
  * @param {Node<vec2|vec3>?} [uvNode=null] - The uv node.
@@ -734,6 +735,7 @@ export const texture = /*@__PURE__*/ nodeProxy( TextureNode );
 /**
  * TSL function for creating a texture node that fetches/loads texels without interpolation.
  *
+ * @tsl
  * @function
  * @param {Texture} value - The texture.
  * @param {Node<vec2|vec3>?} [uvNode=null] - The uv node.
@@ -748,6 +750,7 @@ export const textureLoad = ( ...params ) => texture( ...params ).setSampler( fal
 /**
  * Converts a texture or texture node to a sampler.
  *
+ * @tsl
  * @function
  * @param {TextureNode|Texture} aTexture - The texture or texture node to convert.
  * @returns {Node}

--- a/src/nodes/accessors/TextureSizeNode.js
+++ b/src/nodes/accessors/TextureSizeNode.js
@@ -68,6 +68,7 @@ export default TextureSizeNode;
 /**
  * TSL function for creating a texture size node.
  *
+ * @tsl
  * @function
  * @param {TextureNode} textureNode - A texture node which size should be retrieved.
  * @param {Node<int>?} [levelNode=null] - A level node which defines the requested mip.

--- a/src/nodes/accessors/UV.js
+++ b/src/nodes/accessors/UV.js
@@ -3,6 +3,7 @@ import { attribute } from '../core/AttributeNode.js';
 /**
  * TSL function for creating an uv attribute node with the given index.
  *
+ * @tsl
  * @function
  * @param {Number} [index=0] - The uv index.
  * @return {AttributeNode<vec2>} The uv attribute node.

--- a/src/nodes/accessors/UniformArrayNode.js
+++ b/src/nodes/accessors/UniformArrayNode.js
@@ -339,6 +339,7 @@ export default UniformArrayNode;
 /**
  * TSL function for creating an uniform array node.
  *
+ * @tsl
  * @function
  * @param {Array<Any>} values - Array-like data.
  * @param {String?} nodeType - The data type of the array elements.
@@ -347,6 +348,7 @@ export default UniformArrayNode;
 export const uniformArray = ( values, nodeType ) => nodeObject( new UniformArrayNode( values, nodeType ) );
 
 /**
+ * @tsl
  * @function
  * @deprecated since r168. Use {@link uniformArray} instead.
  *

--- a/src/nodes/accessors/UserDataNode.js
+++ b/src/nodes/accessors/UserDataNode.js
@@ -67,6 +67,7 @@ export default UserDataNode;
 /**
  * TSL function for creating a user data node.
  *
+ * @tsl
  * @function
  * @param {String} name - The property name that should be referenced by the node.
  * @param {String} inputType - The node data type of the reference.

--- a/src/nodes/accessors/VelocityNode.js
+++ b/src/nodes/accessors/VelocityNode.js
@@ -217,6 +217,7 @@ export default VelocityNode;
 /**
  * TSL object that represents the velocity of a render pass.
  *
+ * @tsl
  * @type {VelocityNode}
  */
 export const velocity = /*@__PURE__*/ nodeImmutable( VelocityNode );

--- a/src/nodes/accessors/VertexColorNode.js
+++ b/src/nodes/accessors/VertexColorNode.js
@@ -102,6 +102,7 @@ export default VertexColorNode;
 /**
  * TSL function for creating a reference node.
  *
+ * @tsl
  * @function
  * @param {Number} index - The attribute index.
  * @returns {VertexColorNode}

--- a/src/nodes/code/CodeNode.js
+++ b/src/nodes/code/CodeNode.js
@@ -141,6 +141,7 @@ export default CodeNode;
 /**
  * TSL function for creating a code node.
  *
+ * @tsl
  * @function
  * @param {String} [code=''] - The native code.
  * @param {Array<Node>} [includes=[]] - An array of includes.
@@ -152,6 +153,7 @@ export const code = /*@__PURE__*/ nodeProxy( CodeNode );
 /**
  * TSL function for creating a JS code node.
  *
+ * @tsl
  * @function
  * @param {String} src - The native code.
  * @param {Array<Node>} includes - An array of includes.
@@ -162,6 +164,7 @@ export const js = ( src, includes ) => code( src, includes, 'js' );
 /**
  * TSL function for creating a WGSL code node.
  *
+ * @tsl
  * @function
  * @param {String} src - The native code.
  * @param {Array<Node>} includes - An array of includes.
@@ -172,6 +175,7 @@ export const wgsl = ( src, includes ) => code( src, includes, 'wgsl' );
 /**
  * TSL function for creating a GLSL code node.
  *
+ * @tsl
  * @function
  * @param {String} src - The native code.
  * @param {Array<Node>} includes - An array of includes.

--- a/src/nodes/code/ExpressionNode.js
+++ b/src/nodes/code/ExpressionNode.js
@@ -59,6 +59,7 @@ export default ExpressionNode;
 /**
  * TSL function for creating an expression node.
  *
+ * @tsl
  * @function
  * @param {String} [snippet=''] - The native code snippet.
  * @param {String} [nodeType='void'] - The node type.

--- a/src/nodes/code/ScriptableNode.js
+++ b/src/nodes/code/ScriptableNode.js
@@ -717,6 +717,7 @@ export default ScriptableNode;
 /**
  * TSL function for creating a scriptable node.
  *
+ * @tsl
  * @function
  * @param {CodeNode?} [codeNode=null] - The code node.
  * @param {Object} [parameters={}] - The parameters definition.

--- a/src/nodes/code/ScriptableValueNode.js
+++ b/src/nodes/code/ScriptableValueNode.js
@@ -245,6 +245,7 @@ export default ScriptableValueNode;
 /**
  * TSL function for creating a scriptable value node.
  *
+ * @tsl
  * @function
  * @param {Any} [value=null] - The value.
  * @returns {ScriptableValueNode}

--- a/src/nodes/core/ArrayNode.js
+++ b/src/nodes/core/ArrayNode.js
@@ -91,6 +91,7 @@ export default ArrayNode;
 /**
  * TSL function for creating an array node.
  *
+ * @tsl
  * @function
  * @param {String|Array<Node>} nodeTypeOrValues - A string representing the element type (e.g., 'vec3')
  * or an array containing the default values (e.g., [ vec3() ]).

--- a/src/nodes/core/AssignNode.js
+++ b/src/nodes/core/AssignNode.js
@@ -165,6 +165,7 @@ export default AssignNode;
 /**
  * TSL function for creating an assign node.
  *
+ * @tsl
  * @function
  * @param {Node} targetNode - The target node.
  * @param {Node} sourceNode - The source type.

--- a/src/nodes/core/AttributeNode.js
+++ b/src/nodes/core/AttributeNode.js
@@ -158,6 +158,7 @@ export default AttributeNode;
 /**
  * TSL function for creating an attribute node.
  *
+ * @tsl
  * @function
  * @param {String} name - The name of the attribute.
  * @param {String?} nodeType - The node type.

--- a/src/nodes/core/BypassNode.js
+++ b/src/nodes/core/BypassNode.js
@@ -82,6 +82,7 @@ export default BypassNode;
 /**
  * TSL function for creating a bypass node.
  *
+ * @tsl
  * @function
  * @param {Node} outputNode - The output node.
  * @param {Node} callNode - The call node.

--- a/src/nodes/core/CacheNode.js
+++ b/src/nodes/core/CacheNode.js
@@ -89,6 +89,7 @@ export default CacheNode;
 /**
  * TSL function for creating a cache node.
  *
+ * @tsl
  * @function
  * @param {Node} node - The node that should be cached.
  * @param {Boolean} parent - Whether this node refers to a shared parent cache or not.

--- a/src/nodes/core/ContextNode.js
+++ b/src/nodes/core/ContextNode.js
@@ -119,6 +119,7 @@ export default ContextNode;
 /**
  * TSL function for creating a context node.
  *
+ * @tsl
  * @function
  * @param {Node} node - The node whose context should be modified.
  * @param {Object} [value={}] - The modified context data.
@@ -129,6 +130,7 @@ export const context = /*@__PURE__*/ nodeProxy( ContextNode );
 /**
  * TSL function for defining a label context value for a given node.
  *
+ * @tsl
  * @function
  * @param {Node} node - The node whose context should be modified.
  * @param {String} name - The name/label to set.

--- a/src/nodes/core/IndexNode.js
+++ b/src/nodes/core/IndexNode.js
@@ -118,6 +118,7 @@ export default IndexNode;
 /**
  * TSL object that represents the index of a vertex within a mesh.
  *
+ * @tsl
  * @type {IndexNode}
  */
 export const vertexIndex = /*@__PURE__*/ nodeImmutable( IndexNode, IndexNode.VERTEX );
@@ -125,6 +126,7 @@ export const vertexIndex = /*@__PURE__*/ nodeImmutable( IndexNode, IndexNode.VER
 /**
  * TSL object that represents the index of either a mesh instance or an invocation of a compute shader.
  *
+ * @tsl
  * @type {IndexNode}
  */
 export const instanceIndex = /*@__PURE__*/ nodeImmutable( IndexNode, IndexNode.INSTANCE );
@@ -132,6 +134,7 @@ export const instanceIndex = /*@__PURE__*/ nodeImmutable( IndexNode, IndexNode.I
 /**
  * TSL object that represents the index of the subgroup the current compute invocation belongs to.
  *
+ * @tsl
  * @type {IndexNode}
  */
 export const subgroupIndex = /*@__PURE__*/ nodeImmutable( IndexNode, IndexNode.SUBGROUP );
@@ -139,6 +142,7 @@ export const subgroupIndex = /*@__PURE__*/ nodeImmutable( IndexNode, IndexNode.S
 /**
  * TSL object that represents the index of a compute invocation within the scope of a subgroup.
  *
+ * @tsl
  * @type {IndexNode}
  */
 export const invocationSubgroupIndex = /*@__PURE__*/ nodeImmutable( IndexNode, IndexNode.INVOCATION_SUBGROUP );
@@ -146,6 +150,7 @@ export const invocationSubgroupIndex = /*@__PURE__*/ nodeImmutable( IndexNode, I
 /**
  * TSL object that represents the index of a compute invocation within the scope of a workgroup load.
  *
+ * @tsl
  * @type {IndexNode}
  */
 export const invocationLocalIndex = /*@__PURE__*/ nodeImmutable( IndexNode, IndexNode.INVOCATION_LOCAL );
@@ -153,6 +158,7 @@ export const invocationLocalIndex = /*@__PURE__*/ nodeImmutable( IndexNode, Inde
 /**
  * TSL object that represents the index of a draw call.
  *
+ * @tsl
  * @type {IndexNode}
  */
 export const drawIndex = /*@__PURE__*/ nodeImmutable( IndexNode, IndexNode.DRAW );

--- a/src/nodes/core/MRTNode.js
+++ b/src/nodes/core/MRTNode.js
@@ -142,6 +142,7 @@ export default MRTNode;
 /**
  * TSL function for creating a MRT node.
  *
+ * @tsl
  * @function
  * @param {Object<String, Node>} outputNodes - The MRT outputs.
  * @returns {MRTNode}

--- a/src/nodes/core/OutputStructNode.js
+++ b/src/nodes/core/OutputStructNode.js
@@ -95,6 +95,7 @@ export default OutputStructNode;
 /**
  * TSL function for creating an output struct node.
  *
+ * @tsl
  * @function
  * @param {...Node} members - A parameter list of nodes.
  * @returns {OutputStructNode}

--- a/src/nodes/core/ParameterNode.js
+++ b/src/nodes/core/ParameterNode.js
@@ -54,6 +54,7 @@ export default ParameterNode;
 /**
  * TSL function for creating a parameter node.
  *
+ * @tsl
  * @function
  * @param {String} type - The type of the node.
  * @param {String?} name - The name of the parameter in the shader.

--- a/src/nodes/core/PropertyNode.js
+++ b/src/nodes/core/PropertyNode.js
@@ -104,6 +104,7 @@ export default PropertyNode;
 /**
  * TSL function for creating a property node.
  *
+ * @tsl
  * @function
  * @param {String} type - The type of the node.
  * @param {String?} [name=null] - The name of the property in the shader.
@@ -114,6 +115,7 @@ export const property = ( type, name ) => nodeObject( new PropertyNode( type, na
 /**
  * TSL function for creating a varying property node.
  *
+ * @tsl
  * @function
  * @param {String} type - The type of the node.
  * @param {String?} [name=null] - The name of the varying in the shader.
@@ -124,6 +126,7 @@ export const varyingProperty = ( type, name ) => nodeObject( new PropertyNode( t
 /**
  * TSL object that represents the shader variable `DiffuseColor`.
  *
+ * @tsl
  * @type {PropertyNode<vec4>}
  */
 export const diffuseColor = /*@__PURE__*/ nodeImmutable( PropertyNode, 'vec4', 'DiffuseColor' );
@@ -131,6 +134,7 @@ export const diffuseColor = /*@__PURE__*/ nodeImmutable( PropertyNode, 'vec4', '
 /**
  * TSL object that represents the shader variable `EmissiveColor`.
  *
+ * @tsl
  * @type {PropertyNode<vec3>}
  */
 export const emissive = /*@__PURE__*/ nodeImmutable( PropertyNode, 'vec3', 'EmissiveColor' );
@@ -138,6 +142,7 @@ export const emissive = /*@__PURE__*/ nodeImmutable( PropertyNode, 'vec3', 'Emis
 /**
  * TSL object that represents the shader variable `Roughness`.
  *
+ * @tsl
  * @type {PropertyNode<float>}
  */
 export const roughness = /*@__PURE__*/ nodeImmutable( PropertyNode, 'float', 'Roughness' );
@@ -145,6 +150,7 @@ export const roughness = /*@__PURE__*/ nodeImmutable( PropertyNode, 'float', 'Ro
 /**
  * TSL object that represents the shader variable `Metalness`.
  *
+ * @tsl
  * @type {PropertyNode<float>}
  */
 export const metalness = /*@__PURE__*/ nodeImmutable( PropertyNode, 'float', 'Metalness' );
@@ -152,6 +158,7 @@ export const metalness = /*@__PURE__*/ nodeImmutable( PropertyNode, 'float', 'Me
 /**
  * TSL object that represents the shader variable `Clearcoat`.
  *
+ * @tsl
  * @type {PropertyNode<float>}
  */
 export const clearcoat = /*@__PURE__*/ nodeImmutable( PropertyNode, 'float', 'Clearcoat' );
@@ -159,6 +166,7 @@ export const clearcoat = /*@__PURE__*/ nodeImmutable( PropertyNode, 'float', 'Cl
 /**
  * TSL object that represents the shader variable `ClearcoatRoughness`.
  *
+ * @tsl
  * @type {PropertyNode<float>}
  */
 export const clearcoatRoughness = /*@__PURE__*/ nodeImmutable( PropertyNode, 'float', 'ClearcoatRoughness' );
@@ -166,6 +174,7 @@ export const clearcoatRoughness = /*@__PURE__*/ nodeImmutable( PropertyNode, 'fl
 /**
  * TSL object that represents the shader variable `Sheen`.
  *
+ * @tsl
  * @type {PropertyNode<vec3>}
  */
 export const sheen = /*@__PURE__*/ nodeImmutable( PropertyNode, 'vec3', 'Sheen' );
@@ -173,6 +182,7 @@ export const sheen = /*@__PURE__*/ nodeImmutable( PropertyNode, 'vec3', 'Sheen' 
 /**
  * TSL object that represents the shader variable `SheenRoughness`.
  *
+ * @tsl
  * @type {PropertyNode<float>}
  */
 export const sheenRoughness = /*@__PURE__*/ nodeImmutable( PropertyNode, 'float', 'SheenRoughness' );
@@ -180,6 +190,7 @@ export const sheenRoughness = /*@__PURE__*/ nodeImmutable( PropertyNode, 'float'
 /**
  * TSL object that represents the shader variable `Iridescence`.
  *
+ * @tsl
  * @type {PropertyNode<float>}
  */
 export const iridescence = /*@__PURE__*/ nodeImmutable( PropertyNode, 'float', 'Iridescence' );
@@ -187,6 +198,7 @@ export const iridescence = /*@__PURE__*/ nodeImmutable( PropertyNode, 'float', '
 /**
  * TSL object that represents the shader variable `IridescenceIOR`.
  *
+ * @tsl
  * @type {PropertyNode<float>}
  */
 export const iridescenceIOR = /*@__PURE__*/ nodeImmutable( PropertyNode, 'float', 'IridescenceIOR' );
@@ -194,6 +206,7 @@ export const iridescenceIOR = /*@__PURE__*/ nodeImmutable( PropertyNode, 'float'
 /**
  * TSL object that represents the shader variable `IridescenceThickness`.
  *
+ * @tsl
  * @type {PropertyNode<float>}
  */
 export const iridescenceThickness = /*@__PURE__*/ nodeImmutable( PropertyNode, 'float', 'IridescenceThickness' );
@@ -201,6 +214,7 @@ export const iridescenceThickness = /*@__PURE__*/ nodeImmutable( PropertyNode, '
 /**
  * TSL object that represents the shader variable `AlphaT`.
  *
+ * @tsl
  * @type {PropertyNode<float>}
  */
 export const alphaT = /*@__PURE__*/ nodeImmutable( PropertyNode, 'float', 'AlphaT' );
@@ -208,6 +222,7 @@ export const alphaT = /*@__PURE__*/ nodeImmutable( PropertyNode, 'float', 'Alpha
 /**
  * TSL object that represents the shader variable `Anisotropy`.
  *
+ * @tsl
  * @type {PropertyNode<float>}
  */
 export const anisotropy = /*@__PURE__*/ nodeImmutable( PropertyNode, 'float', 'Anisotropy' );
@@ -215,6 +230,7 @@ export const anisotropy = /*@__PURE__*/ nodeImmutable( PropertyNode, 'float', 'A
 /**
  * TSL object that represents the shader variable `AnisotropyT`.
  *
+ * @tsl
  * @type {PropertyNode<vec3>}
  */
 export const anisotropyT = /*@__PURE__*/ nodeImmutable( PropertyNode, 'vec3', 'AnisotropyT' );
@@ -222,6 +238,7 @@ export const anisotropyT = /*@__PURE__*/ nodeImmutable( PropertyNode, 'vec3', 'A
 /**
  * TSL object that represents the shader variable `AnisotropyB`.
  *
+ * @tsl
  * @type {PropertyNode<vec3>}
  */
 export const anisotropyB = /*@__PURE__*/ nodeImmutable( PropertyNode, 'vec3', 'AnisotropyB' );
@@ -229,6 +246,7 @@ export const anisotropyB = /*@__PURE__*/ nodeImmutable( PropertyNode, 'vec3', 'A
 /**
  * TSL object that represents the shader variable `SpecularColor`.
  *
+ * @tsl
  * @type {PropertyNode<color>}
  */
 export const specularColor = /*@__PURE__*/ nodeImmutable( PropertyNode, 'color', 'SpecularColor' );
@@ -236,6 +254,7 @@ export const specularColor = /*@__PURE__*/ nodeImmutable( PropertyNode, 'color',
 /**
  * TSL object that represents the shader variable `SpecularF90`.
  *
+ * @tsl
  * @type {PropertyNode<float>}
  */
 export const specularF90 = /*@__PURE__*/ nodeImmutable( PropertyNode, 'float', 'SpecularF90' );
@@ -243,6 +262,7 @@ export const specularF90 = /*@__PURE__*/ nodeImmutable( PropertyNode, 'float', '
 /**
  * TSL object that represents the shader variable `Shininess`.
  *
+ * @tsl
  * @type {PropertyNode<float>}
  */
 export const shininess = /*@__PURE__*/ nodeImmutable( PropertyNode, 'float', 'Shininess' );
@@ -250,6 +270,7 @@ export const shininess = /*@__PURE__*/ nodeImmutable( PropertyNode, 'float', 'Sh
 /**
  * TSL object that represents the shader variable `Output`.
  *
+ * @tsl
  * @type {PropertyNode<vec4>}
  */
 export const output = /*@__PURE__*/ nodeImmutable( PropertyNode, 'vec4', 'Output' );
@@ -257,6 +278,7 @@ export const output = /*@__PURE__*/ nodeImmutable( PropertyNode, 'vec4', 'Output
 /**
  * TSL object that represents the shader variable `dashSize`.
  *
+ * @tsl
  * @type {PropertyNode<float>}
  */
 export const dashSize = /*@__PURE__*/ nodeImmutable( PropertyNode, 'float', 'dashSize' );
@@ -264,6 +286,7 @@ export const dashSize = /*@__PURE__*/ nodeImmutable( PropertyNode, 'float', 'das
 /**
  * TSL object that represents the shader variable `gapSize`.
  *
+ * @tsl
  * @type {PropertyNode<float>}
  */
 export const gapSize = /*@__PURE__*/ nodeImmutable( PropertyNode, 'float', 'gapSize' );
@@ -271,6 +294,7 @@ export const gapSize = /*@__PURE__*/ nodeImmutable( PropertyNode, 'float', 'gapS
 /**
  * TSL object that represents the shader variable `pointWidth`.
  *
+ * @tsl
  * @type {PropertyNode<float>}
  */
 export const pointWidth = /*@__PURE__*/ nodeImmutable( PropertyNode, 'float', 'pointWidth' );
@@ -278,6 +302,7 @@ export const pointWidth = /*@__PURE__*/ nodeImmutable( PropertyNode, 'float', 'p
 /**
  * TSL object that represents the shader variable `IOR`.
  *
+ * @tsl
  * @type {PropertyNode<float>}
  */
 export const ior = /*@__PURE__*/ nodeImmutable( PropertyNode, 'float', 'IOR' );
@@ -285,6 +310,7 @@ export const ior = /*@__PURE__*/ nodeImmutable( PropertyNode, 'float', 'IOR' );
 /**
  * TSL object that represents the shader variable `Transmission`.
  *
+ * @tsl
  * @type {PropertyNode<float>}
  */
 export const transmission = /*@__PURE__*/ nodeImmutable( PropertyNode, 'float', 'Transmission' );
@@ -292,6 +318,7 @@ export const transmission = /*@__PURE__*/ nodeImmutable( PropertyNode, 'float', 
 /**
  * TSL object that represents the shader variable `Thickness`.
  *
+ * @tsl
  * @type {PropertyNode<float>}
  */
 export const thickness = /*@__PURE__*/ nodeImmutable( PropertyNode, 'float', 'Thickness' );
@@ -299,6 +326,7 @@ export const thickness = /*@__PURE__*/ nodeImmutable( PropertyNode, 'float', 'Th
 /**
  * TSL object that represents the shader variable `AttenuationDistance`.
  *
+ * @tsl
  * @type {PropertyNode<float>}
  */
 export const attenuationDistance = /*@__PURE__*/ nodeImmutable( PropertyNode, 'float', 'AttenuationDistance' );
@@ -306,6 +334,7 @@ export const attenuationDistance = /*@__PURE__*/ nodeImmutable( PropertyNode, 'f
 /**
  * TSL object that represents the shader variable `AttenuationColor`.
  *
+ * @tsl
  * @type {PropertyNode<color>}
  */
 export const attenuationColor = /*@__PURE__*/ nodeImmutable( PropertyNode, 'color', 'AttenuationColor' );
@@ -313,6 +342,7 @@ export const attenuationColor = /*@__PURE__*/ nodeImmutable( PropertyNode, 'colo
 /**
  * TSL object that represents the shader variable `Dispersion`.
  *
+ * @tsl
  * @type {PropertyNode<float>}
  */
 export const dispersion = /*@__PURE__*/ nodeImmutable( PropertyNode, 'float', 'Dispersion' );

--- a/src/nodes/core/StackNode.js
+++ b/src/nodes/core/StackNode.js
@@ -197,6 +197,7 @@ export default StackNode;
 /**
  * TSL function for creating a stack node.
  *
+ * @tsl
  * @function
  * @param {StackNode?} [parent=null] - The parent stack node.
  * @returns {StackNode}

--- a/src/nodes/core/StructNode.js
+++ b/src/nodes/core/StructNode.js
@@ -72,6 +72,7 @@ export default StructNode;
 /**
  * TSL function for creating a struct node.
  *
+ * @tsl
  * @function
  * @param {Object} membersLayout - The layout of the struct members.
  * @param {string} [name=null] - The name of the struct.

--- a/src/nodes/core/UniformGroupNode.js
+++ b/src/nodes/core/UniformGroupNode.js
@@ -94,6 +94,7 @@ export default UniformGroupNode;
 /**
  * TSL function for creating a uniform group node with the given name.
  *
+ * @tsl
  * @function
  * @param {String} name - The name of the uniform group node.
  * @returns {UniformGroupNode}
@@ -103,6 +104,7 @@ export const uniformGroup = ( name ) => new UniformGroupNode( name );
 /**
  * TSL function for creating a shared uniform group node with the given name and order.
  *
+ * @tsl
  * @function
  * @param {String} name - The name of the uniform group node.
  * @param {Number} [order=0] - Influences the internal sorting.
@@ -113,6 +115,7 @@ export const sharedUniformGroup = ( name, order = 0 ) => new UniformGroupNode( n
 /**
  * TSL object that represents a shared uniform group node which is updated once per frame.
  *
+ * @tsl
  * @type {UniformGroupNode}
  */
 export const frameGroup = /*@__PURE__*/ sharedUniformGroup( 'frame' );
@@ -120,6 +123,7 @@ export const frameGroup = /*@__PURE__*/ sharedUniformGroup( 'frame' );
 /**
  * TSL object that represents a shared uniform group node which is updated once per render.
  *
+ * @tsl
  * @type {UniformGroupNode}
  */
 export const renderGroup = /*@__PURE__*/ sharedUniformGroup( 'render' );
@@ -127,6 +131,7 @@ export const renderGroup = /*@__PURE__*/ sharedUniformGroup( 'render' );
 /**
  * TSL object that represents a uniform group node which is updated once per object.
  *
+ * @tsl
  * @type {UniformGroupNode}
  */
 export const objectGroup = /*@__PURE__*/ uniformGroup( 'object' );

--- a/src/nodes/core/UniformNode.js
+++ b/src/nodes/core/UniformNode.js
@@ -159,6 +159,7 @@ export default UniformNode;
 /**
  * TSL function for creating a uniform node.
  *
+ * @tsl
  * @function
  * @param {Any} arg1 - The value of this node. Usually a JS primitive or three.js object (vector, matrix, color, texture).
  * @param {String?} arg2 - The node type. If no explicit type is defined, the node tries to derive the type from its value.

--- a/src/nodes/core/VarNode.js
+++ b/src/nodes/core/VarNode.js
@@ -156,6 +156,7 @@ export default VarNode;
 /**
  * TSL function for creating a var node.
  *
+ * @tsl
  * @function
  * @param {Node} node - The node for which a variable should be created.
  * @param {String?} name - The name of the variable in the shader.
@@ -166,6 +167,7 @@ const createVar = /*@__PURE__*/ nodeProxy( VarNode );
 /**
  * TSL function for creating a var node.
  *
+ * @tsl
  * @function
  * @param {Node} node - The node for which a variable should be created.
  * @param {String?} name - The name of the variable in the shader.
@@ -176,6 +178,7 @@ export const Var = ( node, name = null ) => createVar( node, name ).append();
 /**
  * TSL function for creating a const node.
  *
+ * @tsl
  * @function
  * @param {Node} node - The node for which a constant should be created.
  * @param {String?} name - The name of the constant in the shader.
@@ -191,6 +194,7 @@ addMethodChaining( 'toConst', Const );
 // Deprecated
 
 /**
+ * @tsl
  * @function
  * @deprecated since r170. Use `Var( node )` or `node.toVar()` instead.
  *

--- a/src/nodes/core/VaryingNode.js
+++ b/src/nodes/core/VaryingNode.js
@@ -167,6 +167,7 @@ export default VaryingNode;
 /**
  * TSL function for creating a varying node.
  *
+ * @tsl
  * @function
  * @param {Node} node - The node for which a varying should be created.
  * @param {String?} name - The name of the varying in the shader.
@@ -177,6 +178,7 @@ export const varying = /*@__PURE__*/ nodeProxy( VaryingNode );
 /**
  * Computes a node in the vertex stage.
  *
+ * @tsl
  * @function
  * @param {Node} node - The node which should be executed in the vertex stage.
  * @returns {VaryingNode}

--- a/src/nodes/display/BlendModes.js
+++ b/src/nodes/display/BlendModes.js
@@ -8,7 +8,8 @@ import { mix, min, step } from '../math/MathNode.js';
  * It significantly increases the contrast of the base layer, making the colors more vibrant and saturated.
  * The darker the color in the blend layer, the stronger the darkening and contrast effect on the base layer.
  *
- * @method
+ * @tsl
+ * @function
  * @param {Node<vec3>} base - The base color.
  * @param {Node<vec3>} blend - The blend color. A white (#ffffff) blend color does not alter the base color.
  * @return {Node<vec3>} The result.
@@ -33,7 +34,8 @@ export const blendBurn = /*@__PURE__*/ Fn( ( [ base, blend ] ) => {
  * It significantly increases the brightness of the base layer, making the colors lighter and more vibrant.
  * The brighter the color in the blend layer, the stronger the lightening and contrast effect on the base layer.
  *
- * @method
+ * @tsl
+ * @function
  * @param {Node<vec3>} base - The base color.
  * @param {Node<vec3>} blend - The blend color. A black (#000000) blend color does not alter the base color.
  * @return {Node<vec3>} The result.
@@ -58,7 +60,8 @@ export const blendDodge = /*@__PURE__*/ Fn( ( [ base, blend ] ) => {
  * The "Screen" blend mode is better for general brightening whereas the "Dodge" results in more subtle and nuanced
  * effects.
  *
- * @method
+ * @tsl
+ * @function
  * @param {Node<vec3>} base - The base color.
  * @param {Node<vec3>} blend - The blend color. A black (#000000) blend color does not alter the base color.
  * @return {Node<vec3>} The result.
@@ -83,7 +86,8 @@ export const blendScreen = /*@__PURE__*/ Fn( ( [ base, blend ] ) => {
  * It amplifies the existing colors and contrast in the base layer, making lighter areas lighter and darker areas darker.
  * The color of the blend layer significantly influences the resulting contrast and color shift in the base layer.
  *
- * @method
+ * @tsl
+ * @function
  * @param {Node<vec3>} base - The base color.
  * @param {Node<vec3>} blend - The blend color
  * @return {Node<vec3>} The result.
@@ -105,7 +109,8 @@ export const blendOverlay = /*@__PURE__*/ Fn( ( [ base, blend ] ) => {
  * This function blends two color based on their alpha values by replicating the behavior of `THREE.NormalBlending`.
  * It assumes both input colors have non-preumiltiplied alpha.
  *
- * @method
+ * @tsl
+ * @function
  * @param {Node<vec4>} base - The base color.
  * @param {Node<vec4>} blend - The blend color
  * @return {Node<vec4>} The result.
@@ -128,6 +133,7 @@ export const blendColor = /*@__PURE__*/ Fn( ( [ base, blend ] ) => {
 // Deprecated
 
 /**
+ * @tsl
  * @function
  * @deprecated since r171. Use {@link blendBurn} instead.
  *
@@ -142,6 +148,7 @@ export const burn = ( ...params ) => { // @deprecated, r171
 };
 
 /**
+ * @tsl
  * @function
  * @deprecated since r171. Use {@link blendDodge} instead.
  *
@@ -156,7 +163,8 @@ export const dodge = ( ...params ) => { // @deprecated, r171
 };
 
 /**
- * @method
+ * @tsl
+ * @function
  * @deprecated since r171. Use {@link blendScreen} instead.
  *
  * @param  {...any} params
@@ -170,7 +178,8 @@ export const screen = ( ...params ) => { // @deprecated, r171
 };
 
 /**
- * @method
+ * @tsl
+ * @function
  * @deprecated since r171. Use {@link blendOverlay} instead.
  *
  * @param  {...any} params

--- a/src/nodes/display/BumpMapNode.js
+++ b/src/nodes/display/BumpMapNode.js
@@ -108,6 +108,7 @@ export default BumpMapNode;
 /**
  * TSL function for creating a bump map node.
  *
+ * @tsl
  * @function
  * @param {Node<float>} textureNode - Represents the bump map data.
  * @param {Node<float>?} [scaleNode=null] - Controls the intensity of the bump effect.

--- a/src/nodes/display/ColorAdjustment.js
+++ b/src/nodes/display/ColorAdjustment.js
@@ -8,7 +8,8 @@ import { LinearSRGBColorSpace } from '../../constants.js';
 /**
  * Computes a grayscale value for the given RGB color value.
  *
- * @method
+ * @tsl
+ * @function
  * @param {Node<vec3>} color - The color value to compute the grayscale for.
  * @return {Node<vec3>} The grayscale color.
  */
@@ -21,7 +22,8 @@ export const grayscale = /*@__PURE__*/ Fn( ( [ color ] ) => {
 /**
  * Super-saturates or desaturates the given RGB color.
  *
- * @method
+ * @tsl
+ * @function
  * @param {Node<vec3>} color - The input color.
  * @param {Node<float>} [adjustment=1] - Specifies the amount of the conversion. A value under `1` desaturates the color, a value over `1` super-saturates it.
  * @return {Node<vec3>} The saturated color.
@@ -37,7 +39,8 @@ export const saturation = /*@__PURE__*/ Fn( ( [ color, adjustment = float( 1 ) ]
  * in a more natural and visually appealing image with enhanced color depth
  * compared to {@link ColorAdjustment#saturation}.
  *
- * @method
+ * @tsl
+ * @function
  * @param {Node<vec3>} color - The input color.
  * @param {Node<float>} [adjustment=1] - Controls the intensity of the vibrance effect.
  * @return {Node<vec3>} The updated color.
@@ -56,7 +59,8 @@ export const vibrance = /*@__PURE__*/ Fn( ( [ color, adjustment = float( 1 ) ] )
 /**
  * Updates the hue component of the given RGB color while preserving its luminance and saturation.
  *
- * @method
+ * @tsl
+ * @function
  * @param {Node<vec3>} color - The input color.
  * @param {Node<float>} [adjustment=1] - Defines the degree of hue rotation in radians. A positive value rotates the hue clockwise, while a negative value rotates it counterclockwise.
  * @return {Node<vec3>} The updated color.
@@ -74,7 +78,8 @@ export const hue = /*@__PURE__*/ Fn( ( [ color, adjustment = float( 1 ) ] ) => {
 /**
  * Computes the luminance for the given RGB color value.
  *
- * @method
+ * @tsl
+ * @function
  * @param {Node<vec3>} color - The color value to compute the luminance for.
  * @param {Node<vec3>?} luminanceCoefficients - The luminance coefficients. By default predefined values of the current working color space are used.
  * @return {Node<vec3>} The luminance.
@@ -91,7 +96,8 @@ export const luminance = (
  * saturation. The CDL should be typically be given input in a log space (such as LogC, ACEScc,
  * or AgX Log), and will return output in the same space. Output may require clamping >=0.
  *
- * @method
+ * @tsl
+ * @function
  * @param {Node<vec4>} color Input (-Infinity < input < +Infinity)
  * @param {Node<vec3>} slope Slope (0 ≤ slope < +Infinity)
  * @param {Node<vec3>} offset Offset (-Infinity < offset < +Infinity; typically -1 < offset < 1)

--- a/src/nodes/display/ColorSpaceFunctions.js
+++ b/src/nodes/display/ColorSpaceFunctions.js
@@ -4,7 +4,8 @@ import { Fn } from '../tsl/TSLCore.js';
 /**
  * Converts the given color value from sRGB to linear-sRGB color space.
  *
- * @method
+ * @tsl
+ * @function
  * @param {Node<vec3>} color - The sRGB color.
  * @return {Node<vec3>} The linear-sRGB color.
  */
@@ -29,7 +30,8 @@ export const sRGBTransferEOTF = /*@__PURE__*/ Fn( ( [ color ] ) => {
 /**
  * Converts the given color value from linear-sRGB to sRGB color space.
  *
- * @method
+ * @tsl
+ * @function
  * @param {Node<vec3>} color - The linear-sRGB color.
  * @return {Node<vec3>} The sRGB color.
  */

--- a/src/nodes/display/ColorSpaceNode.js
+++ b/src/nodes/display/ColorSpaceNode.js
@@ -129,6 +129,7 @@ export default ColorSpaceNode;
 /**
  * TSL function for converting a given color node to the current output color space.
  *
+ * @tsl
  * @function
  * @param {Node} node - Represents the node to convert.
  * @returns {ColorSpaceNode}
@@ -138,6 +139,7 @@ export const toOutputColorSpace = ( node ) => nodeObject( new ColorSpaceNode( no
 /**
  * TSL function for converting a given color node to the current working color space.
  *
+ * @tsl
  * @function
  * @param {Node} node - Represents the node to convert.
  * @returns {ColorSpaceNode}
@@ -147,6 +149,7 @@ export const toWorkingColorSpace = ( node ) => nodeObject( new ColorSpaceNode( n
 /**
  * TSL function for converting a given color node from the current working color space to the given color space.
  *
+ * @tsl
  * @function
  * @param {Node} node - Represents the node to convert.
  * @param {String} colorSpace - The target color space.
@@ -157,6 +160,7 @@ export const workingToColorSpace = ( node, colorSpace ) => nodeObject( new Color
 /**
  * TSL function for converting a given color node from the given color space to the current working color space.
  *
+ * @tsl
  * @function
  * @param {Node} node - Represents the node to convert.
  * @param {String} colorSpace - The source color space.
@@ -167,6 +171,7 @@ export const colorSpaceToWorking = ( node, colorSpace ) => nodeObject( new Color
 /**
  * TSL function for converting a given color node from one color space to another one.
  *
+ * @tsl
  * @function
  * @param {Node} node - Represents the node to convert.
  * @param {String} sourceColorSpace - The source color space.

--- a/src/nodes/display/FrontFacingNode.js
+++ b/src/nodes/display/FrontFacingNode.js
@@ -59,6 +59,7 @@ export default FrontFacingNode;
 /**
  * TSL object that represents whether a primitive is front or back facing
  *
+ * @tsl
  * @type {FrontFacingNode<bool>}
  */
 export const frontFacing = /*@__PURE__*/ nodeImmutable( FrontFacingNode );
@@ -67,6 +68,7 @@ export const frontFacing = /*@__PURE__*/ nodeImmutable( FrontFacingNode );
  * TSL object that represents the front facing status as a number instead of a bool.
  * `1` means front facing, `-1` means back facing.
  *
+ * @tsl
  * @type {Node<float>}
  */
 export const faceDirection = /*@__PURE__*/ float( frontFacing ).mul( 2.0 ).sub( 1.0 );

--- a/src/nodes/display/NormalMapNode.js
+++ b/src/nodes/display/NormalMapNode.js
@@ -139,6 +139,7 @@ export default NormalMapNode;
 /**
  * TSL function for creating a normal map node.
  *
+ * @tsl
  * @function
  * @param {Node<vec3>} node - Represents the normal map data.
  * @param {Node<vec2>?} [scaleNode=null] - Controls the intensity of the effect.

--- a/src/nodes/display/PassNode.js
+++ b/src/nodes/display/PassNode.js
@@ -641,6 +641,7 @@ export default PassNode;
 /**
  * TSL function for creating a pass node.
  *
+ * @tsl
  * @function
  * @param {Scene} scene - A reference to the scene.
  * @param {Camera} camera - A reference to the camera.
@@ -652,6 +653,7 @@ export const pass = ( scene, camera, options ) => nodeObject( new PassNode( Pass
 /**
  * TSL function for creating a pass texture node.
  *
+ * @tsl
  * @function
  * @param {PassNode} pass - The pass node.
  * @param {Texture} texture - The output texture.
@@ -662,6 +664,7 @@ export const passTexture = ( pass, texture ) => nodeObject( new PassTextureNode(
 /**
  * TSL function for creating a depth pass node.
  *
+ * @tsl
  * @function
  * @param {Scene} scene - A reference to the scene.
  * @param {Camera} camera - A reference to the camera.

--- a/src/nodes/display/PosterizeNode.js
+++ b/src/nodes/display/PosterizeNode.js
@@ -56,6 +56,7 @@ export default PosterizeNode;
 /**
  * TSL function for creating a posterize node.
  *
+ * @tsl
  * @function
  * @param {Node} sourceNode - The input color.
  * @param {Node} stepsNode - Controls the intensity of the posterization effect. A lower number results in a more blocky appearance.

--- a/src/nodes/display/RenderOutputNode.js
+++ b/src/nodes/display/RenderOutputNode.js
@@ -112,6 +112,7 @@ export default RenderOutputNode;
 /**
  * TSL function for creating a posterize node.
  *
+ * @tsl
  * @function
  * @param {Node} color - The color node to process.
  * @param {Number?} [toneMapping=null] - The tone mapping type.

--- a/src/nodes/display/ScreenNode.js
+++ b/src/nodes/display/ScreenNode.js
@@ -191,6 +191,7 @@ export default ScreenNode;
 /**
  * TSL object that represents normalized screen coordinates, unitless in `[0, 1]`.
  *
+ * @tsl
  * @type {ScreenNode<vec2>}
  */
 export const screenUV = /*@__PURE__*/ nodeImmutable( ScreenNode, ScreenNode.UV );
@@ -198,6 +199,7 @@ export const screenUV = /*@__PURE__*/ nodeImmutable( ScreenNode, ScreenNode.UV )
 /**
  * TSL object that represents the screen resolution in physical pixel units.
  *
+ * @tsl
  * @type {ScreenNode<vec2>}
  */
 export const screenSize = /*@__PURE__*/ nodeImmutable( ScreenNode, ScreenNode.SIZE );
@@ -205,6 +207,7 @@ export const screenSize = /*@__PURE__*/ nodeImmutable( ScreenNode, ScreenNode.SI
 /**
  * TSL object that represents the current `x`/`y` pixel position on the screen in physical pixel units.
  *
+ * @tsl
  * @type {ScreenNode<vec2>}
  */
 export const screenCoordinate = /*@__PURE__*/ nodeImmutable( ScreenNode, ScreenNode.COORDINATE );
@@ -214,6 +217,7 @@ export const screenCoordinate = /*@__PURE__*/ nodeImmutable( ScreenNode, ScreenN
 /**
  * TSL object that represents the viewport rectangle as `x`, `y`, `width` and `height` in physical pixel units.
  *
+ * @tsl
  * @type {ScreenNode<vec4>}
  */
 export const viewport = /*@__PURE__*/ nodeImmutable( ScreenNode, ScreenNode.VIEWPORT );
@@ -221,6 +225,7 @@ export const viewport = /*@__PURE__*/ nodeImmutable( ScreenNode, ScreenNode.VIEW
 /**
  * TSL object that represents the viewport resolution in physical pixel units.
  *
+ * @tsl
  * @type {ScreenNode<vec2>}
  */
 export const viewportSize = viewport.zw;
@@ -228,6 +233,7 @@ export const viewportSize = viewport.zw;
 /**
  * TSL object that represents the current `x`/`y` pixel position on the viewport in physical pixel units.
  *
+ * @tsl
  * @type {ScreenNode<vec2>}
  */
 export const viewportCoordinate = /*@__PURE__*/ screenCoordinate.sub( viewport.xy );
@@ -235,6 +241,7 @@ export const viewportCoordinate = /*@__PURE__*/ screenCoordinate.sub( viewport.x
 /**
  * TSL object that represents normalized viewport coordinates, unitless in `[0, 1]`.
  *
+ * @tsl
  * @type {ScreenNode<vec2>}
  */
 export const viewportUV = /*@__PURE__*/ viewportCoordinate.div( viewportSize );
@@ -253,7 +260,9 @@ export const viewportResolution = /*@__PURE__*/ ( Fn( () => { // @deprecated, r1
 }, 'vec2' ).once() )();
 
 /**
+ * @tsl
  * @deprecated since r168. Use {@link screenUV} instead.
+ * @type {Node<vec2>}
  */
 export const viewportTopLeft = /*@__PURE__*/ ( Fn( () => { // @deprecated, r168
 
@@ -264,7 +273,9 @@ export const viewportTopLeft = /*@__PURE__*/ ( Fn( () => { // @deprecated, r168
 }, 'vec2' ).once() )();
 
 /**
+ * @tsl
  * @deprecated since r168. Use `screenUV.flipY()` instead.
+ * @type {Node<vec2>}
  */
 export const viewportBottomLeft = /*@__PURE__*/ ( Fn( () => { // @deprecated, r168
 

--- a/src/nodes/display/ToneMappingFunctions.js
+++ b/src/nodes/display/ToneMappingFunctions.js
@@ -6,7 +6,8 @@ import { mul, sub, div } from '../math/OperatorNode.js';
 /**
  * Linear tone mapping, exposure only.
  *
- * @method
+ * @tsl
+ * @function
  * @param {Node<vec3>} color - The color that should be tone mapped.
  * @param {Node<float>} exposure - The exposure.
  * @return {Node<vec3>} The tone mapped color.
@@ -29,7 +30,8 @@ export const linearToneMapping = /*@__PURE__*/ Fn( ( [ color, exposure ] ) => {
  *
  * Reference: {@link https://www.cs.utah.edu/docs/techreports/2002/pdf/UUCS-02-001.pdf}
  *
- * @method
+ * @tsl
+ * @function
  * @param {Node<vec3>} color - The color that should be tone mapped.
  * @param {Node<float>} exposure - The exposure.
  * @return {Node<vec3>} The tone mapped color.
@@ -54,7 +56,8 @@ export const reinhardToneMapping = /*@__PURE__*/ Fn( ( [ color, exposure ] ) => 
  *
  * Reference: {@link http://filmicworlds.com/blog/filmic-tonemapping-operators/}
  *
- * @method
+ * @tsl
+ * @function
  * @param {Node<vec3>} color - The color that should be tone mapped.
  * @param {Node<float>} exposure - The exposure.
  * @return {Node<vec3>} The tone mapped color.
@@ -95,7 +98,8 @@ const RRTAndODTFit = /*@__PURE__*/ Fn( ( [ color ] ) => {
  *
  * Reference: {@link https://github.com/selfshadow/ltc_code/blob/master/webgl/shaders/ltc/ltc_blit.fs}
  *
- * @method
+ * @tsl
+ * @function
  * @param {Node<vec3>} color - The color that should be tone mapped.
  * @param {Node<float>} exposure - The exposure.
  * @return {Node<vec3>} The tone mapped color.
@@ -153,7 +157,8 @@ const agxDefaultContrastApprox = /*@__PURE__*/ Fn( ( [ x_immutable ] ) => {
 /**
  * AgX tone mapping.
  *
- * @method
+ * @tsl
+ * @function
  * @param {Node<vec3>} color - The color that should be tone mapped.
  * @param {Node<float>} exposure - The exposure.
  * @return {Node<vec3>} The tone mapped color.
@@ -194,7 +199,8 @@ export const agxToneMapping = /*@__PURE__*/ Fn( ( [ color, exposure ] ) => {
  *
  * Reference: {@link https://modelviewer.dev/examples/tone-mapping}
  *
- * @method
+ * @tsl
+ * @function
  * @param {Node<vec3>} color - The color that should be tone mapped.
  * @param {Node<float>} exposure - The exposure.
  * @return {Node<vec3>} The tone mapped color.

--- a/src/nodes/display/ToneMappingNode.js
+++ b/src/nodes/display/ToneMappingNode.js
@@ -100,6 +100,7 @@ export default ToneMappingNode;
 /**
  * TSL function for creating a tone mapping node.
  *
+ * @tsl
  * @function
  * @param {Number} mapping - The tone mapping type.
  * @param {Node<float> | Number} exposure - The tone mapping exposure.
@@ -111,6 +112,7 @@ export const toneMapping = ( mapping, exposure, color ) => nodeObject( new ToneM
 /**
  * TSL object that represents the global tone mapping exposure of the renderer.
  *
+ * @tsl
  * @type {RendererReferenceNode<vec3>}
  */
 export const toneMappingExposure = /*@__PURE__*/ rendererReference( 'toneMappingExposure', 'float' );

--- a/src/nodes/display/ToonOutlinePassNode.js
+++ b/src/nodes/display/ToonOutlinePassNode.js
@@ -171,6 +171,7 @@ export default ToonOutlinePassNode;
 /**
  * TSL function for creating a toon outline pass node.
  *
+ * @tsl
  * @function
  * @param {Scene} scene - A reference to the scene.
  * @param {Camera} camera - A reference to the camera.

--- a/src/nodes/display/ViewportDepthNode.js
+++ b/src/nodes/display/ViewportDepthNode.js
@@ -143,6 +143,7 @@ export default ViewportDepthNode;
 /**
  * TSL function for converting a viewZ value to an orthographic depth value.
  *
+ * @tsl
  * @function
  * @param {Node<float>} viewZ - The viewZ node.
  * @param {Node<float>} near - The camera's near value.
@@ -154,6 +155,7 @@ export const viewZToOrthographicDepth = ( viewZ, near, far ) => viewZ.add( near 
 /**
  * TSL function for converting an orthographic depth value to a viewZ value.
  *
+ * @tsl
  * @function
  * @param {Node<float>} depth - The orthographic depth.
  * @param {Node<float>} near - The camera's near value.
@@ -167,6 +169,7 @@ export const orthographicDepthToViewZ = ( depth, near, far ) => near.sub( far ).
  *
  * Note: {link https://twitter.com/gonnavis/status/1377183786949959682}.
  *
+ * @tsl
  * @function
  * @param {Node<float>} viewZ - The viewZ node.
  * @param {Node<float>} near - The camera's near value.
@@ -178,6 +181,7 @@ export const viewZToPerspectiveDepth = ( viewZ, near, far ) => near.add( viewZ )
 /**
  * TSL function for converting a perspective depth value to a viewZ value.
  *
+ * @tsl
  * @function
  * @param {Node<float>} depth - The perspective depth.
  * @param {Node<float>} near - The camera's near value.
@@ -189,6 +193,7 @@ export const perspectiveDepthToViewZ = ( depth, near, far ) => near.mul( far ).d
 /**
  * TSL function for converting a viewZ value to a logarithmic depth value.
  *
+ * @tsl
  * @function
  * @param {Node<float>} viewZ - The viewZ node.
  * @param {Node<float>} near - The camera's near value.
@@ -233,6 +238,7 @@ export const viewZToLogarithmicDepth = ( viewZ, near, far ) => {
 /**
  * TSL function for converting a logarithmic depth value to a viewZ value.
  *
+ * @tsl
  * @function
  * @param {Node<float>} depth - The logarithmic depth.
  * @param {Node<float>} near - The camera's near value.
@@ -252,6 +258,7 @@ export const logarithmicDepthToViewZ = ( depth, near, far ) => {
 /**
  * TSL function for defining a value for the current fragment's depth.
  *
+ * @tsl
  * @function
  * @param {Node<float>} value - The depth value to set.
  * @returns {ViewportDepthNode<float>}
@@ -261,6 +268,7 @@ const depthBase = /*@__PURE__*/ nodeProxy( ViewportDepthNode, ViewportDepthNode.
 /**
  * TSL object that represents the depth value for the current fragment.
  *
+ * @tsl
  * @type {ViewportDepthNode}
  */
 export const depth = /*@__PURE__*/ nodeImmutable( ViewportDepthNode, ViewportDepthNode.DEPTH );
@@ -268,6 +276,7 @@ export const depth = /*@__PURE__*/ nodeImmutable( ViewportDepthNode, ViewportDep
 /**
  * TSL function for converting a perspective depth value to linear depth.
  *
+ * @tsl
  * @function
  * @param {Node<float>} value - The perspective depth.
  * @returns {ViewportDepthNode<float>}
@@ -277,6 +286,7 @@ export const linearDepth = /*@__PURE__*/ nodeProxy( ViewportDepthNode, ViewportD
 /**
  * TSL object that represents the linear (orthographic) depth value of the current fragment
  *
+ * @tsl
  * @type {ViewportDepthNode}
  */
 export const viewportLinearDepth = /*@__PURE__*/ linearDepth( viewportDepthTexture() );

--- a/src/nodes/display/ViewportDepthTextureNode.js
+++ b/src/nodes/display/ViewportDepthTextureNode.js
@@ -46,6 +46,7 @@ export default ViewportDepthTextureNode;
 /**
  * TSL function for a viewport depth texture node.
  *
+ * @tsl
  * @function
  * @param {Node} [uvNode=screenUV] - The uv node.
  * @param {Node?} [levelNode=null] - The level node.

--- a/src/nodes/display/ViewportSharedTextureNode.js
+++ b/src/nodes/display/ViewportSharedTextureNode.js
@@ -52,6 +52,7 @@ export default ViewportSharedTextureNode;
 /**
  * TSL function for creating a shared viewport texture node.
  *
+ * @tsl
  * @function
  * @param {Node} [uvNode=screenUV] - The uv node.
  * @param {Node?} [levelNode=null] - The level node.

--- a/src/nodes/display/ViewportTextureNode.js
+++ b/src/nodes/display/ViewportTextureNode.js
@@ -116,6 +116,7 @@ export default ViewportTextureNode;
 /**
  * TSL function for creating a viewport texture node.
  *
+ * @tsl
  * @function
  * @param {Node} [uvNode=screenUV] - The uv node.
  * @param {Node?} [levelNode=null] - The level node.
@@ -127,6 +128,7 @@ export const viewportTexture = /*@__PURE__*/ nodeProxy( ViewportTextureNode );
 /**
  * TSL function for creating a viewport texture node with enabled mipmap generation.
  *
+ * @tsl
  * @function
  * @param {Node} [uvNode=screenUV] - The uv node.
  * @param {Node?} [levelNode=null] - The level node.

--- a/src/nodes/fog/Fog.js
+++ b/src/nodes/fog/Fog.js
@@ -32,6 +32,7 @@ function getViewZNode( builder ) {
 /**
  * Constructs a new range factor node.
  *
+ * @tsl
  * @function
  * @param {Node} near - Defines the near value.
  * @param {Node} far - Defines the far value.
@@ -49,6 +50,7 @@ export const rangeFogFactor = Fn( ( [ near, far ], builder ) => {
  * a clear view near the camera and a faster than exponentially
  * densening fog farther from the camera.
  *
+ * @tsl
  * @function
  * @param {Node} density - Defines the fog density.
  */
@@ -64,6 +66,7 @@ export const densityFogFactor = Fn( ( [ density ], builder ) => {
  * This class can be used to configure a fog for the scene.
  * Nodes of this type are assigned to `Scene.fogNode`.
  *
+ * @tsl
  * @function
  * @param {Node} color - Defines the color of the fog.
  * @param {Node} factor - Defines how the fog is factored in the scene.
@@ -77,6 +80,7 @@ export const fog = Fn( ( [ color, factor ] ) => {
 // Deprecated
 
 /**
+ * @tsl
  * @function
  * @deprecated since r171. Use `fog( color, rangeFogFactor( near, far ) )` instead.
  *
@@ -93,6 +97,7 @@ export function rangeFog( color, near, far ) { // @deprecated, r171
 }
 
 /**
+ * @tsl
  * @function
  * @deprecated since r171. Use `fog( color, densityFogFactor( density ) )` instead.
  *

--- a/src/nodes/functions/material/getParallaxCorrectNormal.js
+++ b/src/nodes/functions/material/getParallaxCorrectNormal.js
@@ -10,6 +10,8 @@ import { float, Fn, min, normalize, sub, vec3 } from '../../tsl/TSLBase.js';
  * const uvNode = getParallaxCorrectNormal( reflectVector, vec3( 200, 100, 100 ), vec3( 0, - 50, 0 ) );
  * material.envNode = pmremTexture( renderTarget.texture, uvNode );
  * ```
+ *
+ * @tsl
  * @function
  * @param {Node<vec3>} normal - The normal to correct.
  * @param {Node<vec3>} cubeSize - The cube size should reflect the size of the environment (BPCEM is usually applied in closed environments like rooms).

--- a/src/nodes/geometry/RangeNode.js
+++ b/src/nodes/geometry/RangeNode.js
@@ -163,6 +163,7 @@ export default RangeNode;
 /**
  * TSL function for creating a range node.
  *
+ * @tsl
  * @function
  * @param {Node<any>} [minNode=float()] - A node defining the lower bound of the range.
  * @param {Node<any>} [maxNode=float()] - A node defining the upper bound of the range.

--- a/src/nodes/gpgpu/AtomicFunctionNode.js
+++ b/src/nodes/gpgpu/AtomicFunctionNode.js
@@ -142,6 +142,7 @@ export default AtomicFunctionNode;
 /**
  * TSL function for creating an atomic function node.
  *
+ * @tsl
  * @function
  * @param {String} method - The signature of the atomic function to construct.
  * @param {Node} pointerNode - An atomic variable or element of an atomic buffer.
@@ -154,6 +155,7 @@ const atomicNode = nodeProxy( AtomicFunctionNode );
 /**
  * TSL function for appending an atomic function call into the programmatic flow of a compute shader.
  *
+ * @tsl
  * @function
  * @param {String} method - The signature of the atomic function to construct.
  * @param {Node} pointerNode - An atomic variable or element of an atomic buffer.
@@ -173,6 +175,7 @@ export const atomicFunc = ( method, pointerNode, valueNode, storeNode = null ) =
 /**
  * Loads the value stored in the atomic variable.
  *
+ * @tsl
  * @function
  * @param {Node} pointerNode - An atomic variable or element of an atomic buffer.
  * @param {Node?} [storeNode=null] - A variable storing the return value of an atomic operation, typically the value of the atomic variable before the operation.
@@ -183,6 +186,7 @@ export const atomicLoad = ( pointerNode, storeNode = null ) => atomicFunc( Atomi
 /**
  * Stores a value in the atomic variable.
  *
+ * @tsl
  * @function
  * @param {Node} pointerNode - An atomic variable or element of an atomic buffer.
  * @param {Node} valueNode - The value that mutates the atomic variable.
@@ -194,6 +198,7 @@ export const atomicStore = ( pointerNode, valueNode, storeNode = null ) => atomi
 /**
  * Increments the value stored in the atomic variable.
  *
+ * @tsl
  * @function
  * @param {Node} pointerNode - An atomic variable or element of an atomic buffer.
  * @param {Node} valueNode - The value that mutates the atomic variable.
@@ -205,6 +210,7 @@ export const atomicAdd = ( pointerNode, valueNode, storeNode = null ) => atomicF
 /**
  * Decrements the value stored in the atomic variable.
  *
+ * @tsl
  * @function
  * @param {Node} pointerNode - An atomic variable or element of an atomic buffer.
  * @param {Node} valueNode - The value that mutates the atomic variable.
@@ -216,6 +222,7 @@ export const atomicSub = ( pointerNode, valueNode, storeNode = null ) => atomicF
 /**
  * Stores in an atomic variable the maximum between its current value and a parameter.
  *
+ * @tsl
  * @function
  * @param {Node} pointerNode - An atomic variable or element of an atomic buffer.
  * @param {Node} valueNode - The value that mutates the atomic variable.
@@ -227,6 +234,7 @@ export const atomicMax = ( pointerNode, valueNode, storeNode = null ) => atomicF
 /**
  * Stores in an atomic variable the minimum between its current value and a parameter.
  *
+ * @tsl
  * @function
  * @param {Node} pointerNode - An atomic variable or element of an atomic buffer.
  * @param {Node} valueNode - The value that mutates the atomic variable.
@@ -238,6 +246,7 @@ export const atomicMin = ( pointerNode, valueNode, storeNode = null ) => atomicF
 /**
  * Stores in an atomic variable the bitwise AND of its value with a parameter.
  *
+ * @tsl
  * @function
  * @param {Node} pointerNode - An atomic variable or element of an atomic buffer.
  * @param {Node} valueNode - The value that mutates the atomic variable.
@@ -249,6 +258,7 @@ export const atomicAnd = ( pointerNode, valueNode, storeNode = null ) => atomicF
 /**
  * Stores in an atomic variable the bitwise OR of its value with a parameter.
  *
+ * @tsl
  * @function
  * @param {Node} pointerNode - An atomic variable or element of an atomic buffer.
  * @param {Node} valueNode - The value that mutates the atomic variable.
@@ -260,6 +270,7 @@ export const atomicOr = ( pointerNode, valueNode, storeNode = null ) => atomicFu
 /**
  * Stores in an atomic variable the bitwise XOR of its value with a parameter.
  *
+ * @tsl
  * @function
  * @param {Node} pointerNode - An atomic variable or element of an atomic buffer.
  * @param {Node} valueNode - The value that mutates the atomic variable.

--- a/src/nodes/gpgpu/BarrierNode.js
+++ b/src/nodes/gpgpu/BarrierNode.js
@@ -47,6 +47,7 @@ export default BarrierNode;
 /**
  * TSL function for creating a barrier node.
  *
+ * @tsl
  * @function
  * @param {String} scope - The scope defines the behavior of the node..
  * @returns {BarrierNode}
@@ -58,6 +59,7 @@ const barrier = nodeProxy( BarrierNode );
  * invocations must wait for each invocation within a workgroup to
  * complete before the barrier can be surpassed.
  *
+ * @tsl
  * @function
  * @returns {BarrierNode}
  */
@@ -68,6 +70,7 @@ export const workgroupBarrier = () => barrier( 'workgroup' ).append();
  * wait for each access to variables within the 'storage' address space
  * to complete before the barrier can be passed.
  *
+ * @tsl
  * @function
  * @returns {BarrierNode}
  */
@@ -78,6 +81,7 @@ export const storageBarrier = () => barrier( 'storage' ).append();
  * wait for each access to variables within the 'texture' address space
  * to complete before the barrier can be passed.
  *
+ * @tsl
  * @function
  * @returns {BarrierNode}
  */

--- a/src/nodes/gpgpu/ComputeBuiltinNode.js
+++ b/src/nodes/gpgpu/ComputeBuiltinNode.js
@@ -141,6 +141,7 @@ export default ComputeBuiltinNode;
 /**
  * TSL function for creating a compute builtin node.
  *
+ * @tsl
  * @function
  * @param {String} name - The built-in name.
  * @param {String} nodeType - The node type.
@@ -149,7 +150,6 @@ export default ComputeBuiltinNode;
 const computeBuiltin = ( name, nodeType ) => nodeObject( new ComputeBuiltinNode( name, nodeType ) );
 
 /**
- * TSL function for creating a `numWorkgroups` builtin node.
  * Represents the number of workgroups dispatched by the compute shader.
  * ```js
  * // Run 512 invocations/threads with a workgroup size of 128.
@@ -169,13 +169,12 @@ const computeBuiltin = ( name, nodeType ) => nodeObject( new ComputeBuiltinNode(
  * })().compute(512);
  * ```
  *
- * @function
- * @returns {ComputeBuiltinNode<uvec3>}
+ * @tsl
+ * @type {ComputeBuiltinNode<uvec3>}
  */
 export const numWorkgroups = /*@__PURE__*/ computeBuiltin( 'numWorkgroups', 'uvec3' );
 
 /**
- * TSL function for creating a `workgroupId` builtin node.
  * Represents the 3-dimensional index of the workgroup the current compute invocation belongs to.
  * ```js
  * // Execute 12 compute threads with a workgroup size of 3.
@@ -197,34 +196,31 @@ export const numWorkgroups = /*@__PURE__*/ computeBuiltin( 'numWorkgroups', 'uve
  * // Buffer Output =  [0, 1, 2, 0, 0, 0, 6, 7, 8, 0, 0, 0];
  * ```
  *
- * @function
- * @returns {ComputeBuiltinNode<uvec3>}
+ * @tsl
+ * @type {ComputeBuiltinNode<uvec3>}
  */
 export const workgroupId = /*@__PURE__*/ computeBuiltin( 'workgroupId', 'uvec3' );
 
 /**
- * TSL function for creating a `globalId` builtin node. A non-linearized 3-dimensional
- * representation of the current invocation's position within a 3D global grid.
+ * A non-linearized 3-dimensional representation of the current invocation's position within a 3D global grid.
  *
- * @function
- * @returns {ComputeBuiltinNode<uvec3>}
+ * @tsl
+ * @type {ComputeBuiltinNode<uvec3>}
  */
 export const globalId = /*@__PURE__*/ computeBuiltin( 'globalId', 'uvec3' );
 /**
- * TSL function for creating a `localId` builtin node. A non-linearized 3-dimensional
- * representation of the current invocation's position within a 3D workgroup grid.
+ * A non-linearized 3-dimensional representation of the current invocation's position within a 3D workgroup grid.
  *
- * @function
- * @returns {ComputeBuiltinNode<uvec3>}
+ * @tsl
+ * @type {ComputeBuiltinNode<uvec3>}
  */
 export const localId = /*@__PURE__*/ computeBuiltin( 'localId', 'uvec3' );
 
 /**
- * TSL function for creating a `subgroupSize` builtin node. A device dependent variable
- * that exposes the size of the current invocation's subgroup.
+ * A device dependent variable that exposes the size of the current invocation's subgroup.
  *
- * @function
- * @returns {ComputeBuiltinNode<uint>}
+ * @tsl
+ * @type {ComputeBuiltinNode<uint>}
  */
 export const subgroupSize = /*@__PURE__*/ computeBuiltin( 'subgroupSize', 'uint' );
 

--- a/src/nodes/gpgpu/ComputeNode.js
+++ b/src/nodes/gpgpu/ComputeNode.js
@@ -188,6 +188,7 @@ export default ComputeNode;
 /**
  * TSL function for creating a compute node.
  *
+ * @tsl
  * @function
  * @param {Node} node - TODO
  * @param {Number} count - TODO.

--- a/src/nodes/gpgpu/WorkgroupInfoNode.js
+++ b/src/nodes/gpgpu/WorkgroupInfoNode.js
@@ -197,6 +197,7 @@ export default WorkgroupInfoNode;
  * TSL function for creating a workgroup info node.
  * Creates a new 'workgroup' scoped array buffer.
  *
+ * @tsl
  * @function
  * @param {String} type - The data type of a 'workgroup' scoped buffer element.
  * @param {Number} [count=0] - The number of elements in the buffer.

--- a/src/nodes/lighting/LightsNode.js
+++ b/src/nodes/lighting/LightsNode.js
@@ -384,6 +384,7 @@ export default LightsNode;
  * TSL function for creating an instance of `LightsNode` and configuring
  * it with the given array of lights.
  *
+ * @tsl
  * @function
  * @param {Array<Light>} lights - An array of lights.
  * @return {LightsNode} The created lights node.

--- a/src/nodes/lighting/PointShadowNode.js
+++ b/src/nodes/lighting/PointShadowNode.js
@@ -297,6 +297,7 @@ export default PointShadowNode;
 /**
  * TSL function for creating an instance of `PointShadowNode`.
  *
+ * @tsl
  * @function
  * @param {PointLight} light - The shadow casting point light.
  * @param {PointLightShadow?} [shadow=null] - An optional point light shadow.

--- a/src/nodes/lighting/ShadowBaseNode.js
+++ b/src/nodes/lighting/ShadowBaseNode.js
@@ -84,6 +84,7 @@ class ShadowBaseNode extends Node {
 /**
  * TSL object that represents the vertex position in world space during the shadow pass.
  *
+ * @tsl
  * @type {Node<vec3>}
  */
 export const shadowPositionWorld = /*@__PURE__*/ vec3().toVar( 'shadowPositionWorld' );

--- a/src/nodes/lighting/ShadowNode.js
+++ b/src/nodes/lighting/ShadowNode.js
@@ -789,6 +789,7 @@ export default ShadowNode;
 /**
  * TSL function for creating an instance of `ShadowNode`.
  *
+ * @tsl
  * @function
  * @param {Light} light - The shadow casting light.
  * @param {LightShadow} shadow - The light shadow.

--- a/src/nodes/math/ConditionalNode.js
+++ b/src/nodes/math/ConditionalNode.js
@@ -199,6 +199,7 @@ export default ConditionalNode;
 /**
  * TSL function for creating a conditional node.
  *
+ * @tsl
  * @function
  * @param {Node} condNode - The node that defines the condition.
  * @param {Node} ifNode - The node that is evaluate when the condition ends up `true`.
@@ -212,6 +213,7 @@ addMethodChaining( 'select', select );
 // Deprecated
 
 /**
+ * @tsl
  * @function
  * @deprecated since r168. Use {@link select} instead.
  *

--- a/src/nodes/math/Hash.js
+++ b/src/nodes/math/Hash.js
@@ -3,7 +3,8 @@ import { Fn } from '../tsl/TSLBase.js';
 /**
  * Generates a hash value in the range `[0, 1]` from the given seed.
  *
- * @method
+ * @tsl
+ * @function
  * @param {Node<float>} seed - The seed.
  * @return {Node<float>} The hash value.
  */

--- a/src/nodes/math/MathNode.js
+++ b/src/nodes/math/MathNode.js
@@ -343,6 +343,7 @@ export default MathNode;
 /**
  * A small value used to handle floating-point precision errors.
  *
+ * @tsl
  * @type {Node<float>}
  */
 export const EPSILON = /*@__PURE__*/ float( 1e-6 );
@@ -350,6 +351,7 @@ export const EPSILON = /*@__PURE__*/ float( 1e-6 );
 /**
  * Represents infinity.
  *
+ * @tsl
  * @type {Node<float>}
  */
 export const INFINITY = /*@__PURE__*/ float( 1e6 );
@@ -357,6 +359,7 @@ export const INFINITY = /*@__PURE__*/ float( 1e6 );
 /**
  * Represents PI.
  *
+ * @tsl
  * @type {Node<float>}
  */
 export const PI = /*@__PURE__*/ float( Math.PI );
@@ -364,6 +367,7 @@ export const PI = /*@__PURE__*/ float( Math.PI );
 /**
  * Represents PI * 2.
  *
+ * @tsl
  * @type {Node<float>}
  */
 export const PI2 = /*@__PURE__*/ float( Math.PI * 2 );
@@ -371,6 +375,7 @@ export const PI2 = /*@__PURE__*/ float( Math.PI * 2 );
 /**
  * Returns `true` if all components of `x` are `true`.
  *
+ * @tsl
  * @function
  * @param {Node | Number} x - The parameter.
  * @returns {Node<bool>}
@@ -380,6 +385,7 @@ export const all = /*@__PURE__*/ nodeProxy( MathNode, MathNode.ALL );
 /**
  * Returns `true` if any components of `x` are `true`.
  *
+ * @tsl
  * @function
  * @param {Node | Number} x - The parameter.
  * @returns {Node<bool>}
@@ -389,6 +395,7 @@ export const any = /*@__PURE__*/ nodeProxy( MathNode, MathNode.ANY );
 /**
  * Converts a quantity in degrees to radians.
  *
+ * @tsl
  * @function
  * @param {Node | Number} x - The input in degrees.
  * @returns {Node}
@@ -398,6 +405,7 @@ export const radians = /*@__PURE__*/ nodeProxy( MathNode, MathNode.RADIANS );
 /**
  * Convert a quantity in radians to degrees.
  *
+ * @tsl
  * @function
  * @param {Node | Number} x - The input in radians.
  * @returns {Node}
@@ -407,6 +415,7 @@ export const degrees = /*@__PURE__*/ nodeProxy( MathNode, MathNode.DEGREES );
 /**
  * Returns the natural exponentiation of the parameter.
  *
+ * @tsl
  * @function
  * @param {Node | Number} x - The parameter.
  * @returns {Node}
@@ -416,6 +425,7 @@ export const exp = /*@__PURE__*/ nodeProxy( MathNode, MathNode.EXP );
 /**
  * Returns 2 raised to the power of the parameter.
  *
+ * @tsl
  * @function
  * @param {Node | Number} x - The parameter.
  * @returns {Node}
@@ -425,6 +435,7 @@ export const exp2 = /*@__PURE__*/ nodeProxy( MathNode, MathNode.EXP2 );
 /**
  * Returns the natural logarithm of the parameter.
  *
+ * @tsl
  * @function
  * @param {Node | Number} x - The parameter.
  * @returns {Node}
@@ -434,6 +445,7 @@ export const log = /*@__PURE__*/ nodeProxy( MathNode, MathNode.LOG );
 /**
  * Returns the base 2 logarithm of the parameter.
  *
+ * @tsl
  * @function
  * @param {Node | Number} x - The parameter.
  * @returns {Node}
@@ -443,6 +455,7 @@ export const log2 = /*@__PURE__*/ nodeProxy( MathNode, MathNode.LOG2 );
 /**
  * Returns the square root of the parameter.
  *
+ * @tsl
  * @function
  * @param {Node | Number} x - The parameter.
  * @returns {Node}
@@ -452,6 +465,7 @@ export const sqrt = /*@__PURE__*/ nodeProxy( MathNode, MathNode.SQRT );
 /**
  * Returns the inverse of the square root of the parameter.
  *
+ * @tsl
  * @function
  * @param {Node | Number} x - The parameter.
  * @returns {Node}
@@ -461,6 +475,7 @@ export const inverseSqrt = /*@__PURE__*/ nodeProxy( MathNode, MathNode.INVERSE_S
 /**
  * Finds the nearest integer less than or equal to the parameter.
  *
+ * @tsl
  * @function
  * @param {Node | Number} x - The parameter.
  * @returns {Node}
@@ -470,6 +485,7 @@ export const floor = /*@__PURE__*/ nodeProxy( MathNode, MathNode.FLOOR );
 /**
  * Finds the nearest integer that is greater than or equal to the parameter.
  *
+ * @tsl
  * @function
  * @param {Node | Number} x - The parameter.
  * @returns {Node}
@@ -479,6 +495,7 @@ export const ceil = /*@__PURE__*/ nodeProxy( MathNode, MathNode.CEIL );
 /**
  * Calculates the unit vector in the same direction as the original vector.
  *
+ * @tsl
  * @function
  * @param {Node} x - The input vector.
  * @returns {Node}
@@ -488,6 +505,7 @@ export const normalize = /*@__PURE__*/ nodeProxy( MathNode, MathNode.NORMALIZE )
 /**
  * Computes the fractional part of the parameter.
  *
+ * @tsl
  * @function
  * @param {Node | Number} x - The parameter.
  * @returns {Node}
@@ -497,6 +515,7 @@ export const fract = /*@__PURE__*/ nodeProxy( MathNode, MathNode.FRACT );
 /**
  * Returns the sine of the parameter.
  *
+ * @tsl
  * @function
  * @param {Node | Number} x - The parameter.
  * @returns {Node}
@@ -506,6 +525,7 @@ export const sin = /*@__PURE__*/ nodeProxy( MathNode, MathNode.SIN );
 /**
  * Returns the cosine of the parameter.
  *
+ * @tsl
  * @function
  * @param {Node | Number} x - The parameter.
  * @returns {Node}
@@ -515,6 +535,7 @@ export const cos = /*@__PURE__*/ nodeProxy( MathNode, MathNode.COS );
 /**
  * Returns the tangent of the parameter.
  *
+ * @tsl
  * @function
  * @param {Node | Number} x - The parameter.
  * @returns {Node}
@@ -524,6 +545,7 @@ export const tan = /*@__PURE__*/ nodeProxy( MathNode, MathNode.TAN );
 /**
  * Returns the arcsine of the parameter.
  *
+ * @tsl
  * @function
  * @param {Node | Number} x - The parameter.
  * @returns {Node}
@@ -533,6 +555,7 @@ export const asin = /*@__PURE__*/ nodeProxy( MathNode, MathNode.ASIN );
 /**
  * Returns the arccosine of the parameter.
  *
+ * @tsl
  * @function
  * @param {Node | Number} x - The parameter.
  * @returns {Node}
@@ -543,6 +566,7 @@ export const acos = /*@__PURE__*/ nodeProxy( MathNode, MathNode.ACOS );
  * Returns the arc-tangent of the parameter.
  * If two parameters are provided, the result is `atan2(y/x)`.
  *
+ * @tsl
  * @function
  * @param {Node | Number} y - The y parameter.
  * @param {(Node | Number)?} x - The x parameter.
@@ -553,6 +577,7 @@ export const atan = /*@__PURE__*/ nodeProxy( MathNode, MathNode.ATAN );
 /**
  * Returns the absolute value of the parameter.
  *
+ * @tsl
  * @function
  * @param {Node | Number} x - The parameter.
  * @returns {Node}
@@ -562,6 +587,7 @@ export const abs = /*@__PURE__*/ nodeProxy( MathNode, MathNode.ABS );
 /**
  * Extracts the sign of the parameter.
  *
+ * @tsl
  * @function
  * @param {Node | Number} x - The parameter.
  * @returns {Node}
@@ -571,6 +597,7 @@ export const sign = /*@__PURE__*/ nodeProxy( MathNode, MathNode.SIGN );
 /**
  * Calculates the length of a vector.
  *
+ * @tsl
  * @function
  * @param {Node} x - The parameter.
  * @returns {Node<float>}
@@ -580,6 +607,7 @@ export const length = /*@__PURE__*/ nodeProxy( MathNode, MathNode.LENGTH );
 /**
  * Negates the value of the parameter (-x).
  *
+ * @tsl
  * @function
  * @param {Node | Number} x - The parameter.
  * @returns {Node}
@@ -589,6 +617,7 @@ export const negate = /*@__PURE__*/ nodeProxy( MathNode, MathNode.NEGATE );
 /**
  * Return `1` minus the parameter.
  *
+ * @tsl
  * @function
  * @param {Node | Number} x - The parameter.
  * @returns {Node}
@@ -598,6 +627,7 @@ export const oneMinus = /*@__PURE__*/ nodeProxy( MathNode, MathNode.ONE_MINUS );
 /**
  * Returns the partial derivative of the parameter with respect to x.
  *
+ * @tsl
  * @function
  * @param {Node | Number} x - The parameter.
  * @returns {Node}
@@ -607,6 +637,7 @@ export const dFdx = /*@__PURE__*/ nodeProxy( MathNode, MathNode.DFDX );
 /**
  * Returns the partial derivative of the parameter with respect to y.
  *
+ * @tsl
  * @function
  * @param {Node | Number} x - The parameter.
  * @returns {Node}
@@ -616,6 +647,7 @@ export const dFdy = /*@__PURE__*/ nodeProxy( MathNode, MathNode.DFDY );
 /**
  * Rounds the parameter to the nearest integer.
  *
+ * @tsl
  * @function
  * @param {Node | Number} x - The parameter.
  * @returns {Node}
@@ -625,6 +657,7 @@ export const round = /*@__PURE__*/ nodeProxy( MathNode, MathNode.ROUND );
 /**
  * Returns the reciprocal of the parameter `(1/x)`.
  *
+ * @tsl
  * @function
  * @param {Node | Number} x - The parameter.
  * @returns {Node}
@@ -634,6 +667,7 @@ export const reciprocal = /*@__PURE__*/ nodeProxy( MathNode, MathNode.RECIPROCAL
 /**
  * Truncates the parameter, removing the fractional part.
  *
+ * @tsl
  * @function
  * @param {Node | Number} x - The parameter.
  * @returns {Node}
@@ -643,6 +677,7 @@ export const trunc = /*@__PURE__*/ nodeProxy( MathNode, MathNode.TRUNC );
 /**
  * Returns the sum of the absolute derivatives in x and y.
  *
+ * @tsl
  * @function
  * @param {Node | Number} x - The parameter.
  * @returns {Node}
@@ -652,6 +687,7 @@ export const fwidth = /*@__PURE__*/ nodeProxy( MathNode, MathNode.FWIDTH );
 /**
  * Returns the transpose of a matrix.
  *
+ * @tsl
  * @function
  * @param {Node<mat2|mat3|mat4>} x - The parameter.
  * @returns {Node}
@@ -663,6 +699,7 @@ export const transpose = /*@__PURE__*/ nodeProxy( MathNode, MathNode.TRANSPOSE )
 /**
  * Reinterpret the bit representation of a value in one type as a value in another type.
  *
+ * @tsl
  * @function
  * @param {Node | Number} x - The parameter.
  * @param {String} y - The new type.
@@ -673,6 +710,7 @@ export const bitcast = /*@__PURE__*/ nodeProxy( MathNode, MathNode.BITCAST );
 /**
  * Returns `true` if `x` equals `y`.
  *
+ * @tsl
  * @function
  * @param {Node | Number} x - The first parameter.
  * @param {Node | Number} y - The second parameter.
@@ -683,6 +721,7 @@ export const equals = /*@__PURE__*/ nodeProxy( MathNode, MathNode.EQUALS );
 /**
  * Returns the lesser of two values.
  *
+ * @tsl
  * @function
  * @param {Node | Number} x - The y parameter.
  * @param {Node | Number} y - The x parameter.
@@ -693,6 +732,7 @@ export const min = /*@__PURE__*/ nodeProxy( MathNode, MathNode.MIN );
 /**
  * Returns the greater of two values.
  *
+ * @tsl
  * @function
  * @param {Node | Number} x - The y parameter.
  * @param {Node | Number} y - The x parameter.
@@ -703,6 +743,7 @@ export const max = /*@__PURE__*/ nodeProxy( MathNode, MathNode.MAX );
 /**
  * Computes the remainder of dividing the first node by the second one.
  *
+ * @tsl
  * @function
  * @param {Node | Number} x - The y parameter.
  * @param {Node | Number} y - The x parameter.
@@ -713,6 +754,7 @@ export const mod = /*@__PURE__*/ nodeProxy( MathNode, MathNode.MOD );
 /**
  * Generate a step function by comparing two values.
  *
+ * @tsl
  * @function
  * @param {Node | Number} x - The y parameter.
  * @param {Node | Number} y - The x parameter.
@@ -723,6 +765,7 @@ export const step = /*@__PURE__*/ nodeProxy( MathNode, MathNode.STEP );
 /**
  * Calculates the reflection direction for an incident vector.
  *
+ * @tsl
  * @function
  * @param {Node<vec2|vec3|vec4>} I - The incident vector.
  * @param {Node<vec2|vec3|vec4>} N - The normal vector.
@@ -733,6 +776,7 @@ export const reflect = /*@__PURE__*/ nodeProxy( MathNode, MathNode.REFLECT );
 /**
  * Calculates the distance between two points.
  *
+ * @tsl
  * @function
  * @param {Node<vec2|vec3|vec4>} x - The first point.
  * @param {Node<vec2|vec3|vec4>} y - The second point.
@@ -743,6 +787,7 @@ export const distance = /*@__PURE__*/ nodeProxy( MathNode, MathNode.DISTANCE );
 /**
  * Calculates the absolute difference between two values.
  *
+ * @tsl
  * @function
  * @param {Node | Number} x - The first parameter.
  * @param {Node | Number} y - The second parameter.
@@ -753,6 +798,7 @@ export const difference = /*@__PURE__*/ nodeProxy( MathNode, MathNode.DIFFERENCE
 /**
  * Calculates the dot product of two vectors.
  *
+ * @tsl
  * @function
  * @param {Node<vec2|vec3|vec4>} x - The first vector.
  * @param {Node<vec2|vec3|vec4>} y - The second vector.
@@ -763,6 +809,7 @@ export const dot = /*@__PURE__*/ nodeProxy( MathNode, MathNode.DOT );
 /**
  * Calculates the cross product of two vectors.
  *
+ * @tsl
  * @function
  * @param {Node<vec2|vec3|vec4>} x - The first vector.
  * @param {Node<vec2|vec3|vec4>} y - The second vector.
@@ -773,6 +820,7 @@ export const cross = /*@__PURE__*/ nodeProxy( MathNode, MathNode.CROSS );
 /**
  * Return the value of the first parameter raised to the power of the second one.
  *
+ * @tsl
  * @function
  * @param {Node | Number} x - The first parameter.
  * @param {Node | Number} y - The second parameter.
@@ -783,6 +831,7 @@ export const pow = /*@__PURE__*/ nodeProxy( MathNode, MathNode.POW );
 /**
  * Returns the square of the parameter.
  *
+ * @tsl
  * @function
  * @param {Node | Number} x - The first parameter.
  * @returns {Node}
@@ -792,6 +841,7 @@ export const pow2 = /*@__PURE__*/ nodeProxy( MathNode, MathNode.POW, 2 );
 /**
  * Returns the cube of the parameter.
  *
+ * @tsl
  * @function
  * @param {Node | Number} x - The first parameter.
  * @returns {Node}
@@ -801,6 +851,7 @@ export const pow3 = /*@__PURE__*/ nodeProxy( MathNode, MathNode.POW, 3 );
 /**
  * Returns the fourth power of the parameter.
  *
+ * @tsl
  * @function
  * @param {Node | Number} x - The first parameter.
  * @returns {Node}
@@ -810,6 +861,7 @@ export const pow4 = /*@__PURE__*/ nodeProxy( MathNode, MathNode.POW, 4 );
 /**
  * Transforms the direction of a vector by a matrix and then normalizes the result.
  *
+ * @tsl
  * @function
  * @param {Node<vec2|vec3|vec4>} direction - The direction vector.
  * @param {Node<mat2|mat3|mat4>} matrix - The transformation matrix.
@@ -820,6 +872,7 @@ export const transformDirection = /*@__PURE__*/ nodeProxy( MathNode, MathNode.TR
 /**
  * Returns the cube root of a number.
  *
+ * @tsl
  * @function
  * @param {Node | Number} a - The first parameter.
  * @returns {Node}
@@ -829,6 +882,7 @@ export const cbrt = ( a ) => mul( sign( a ), pow( abs( a ), 1.0 / 3.0 ) );
 /**
  * Calculate the squared length of a vector.
  *
+ * @tsl
  * @function
  * @param {Node<vec2|vec3|vec4>} a - The vector.
  * @returns {Node<float>}
@@ -838,6 +892,7 @@ export const lengthSq = ( a ) => dot( a, a );
 /**
  * Linearly interpolates between two values.
  *
+ * @tsl
  * @function
  * @param {Node | Number} a - The first parameter.
  * @param {Node | Number} b - The second parameter.
@@ -849,6 +904,7 @@ export const mix = /*@__PURE__*/ nodeProxy( MathNode, MathNode.MIX );
 /**
  * Constrains a value to lie between two further values.
  *
+ * @tsl
  * @function
  * @param {Node | Number} value - The value to constrain.
  * @param {Node | Number} [low=0] - The lower bound.
@@ -860,6 +916,7 @@ export const clamp = ( value, low = 0, high = 1 ) => nodeObject( new MathNode( M
 /**
  * Constrains a value between `0` and `1`.
  *
+ * @tsl
  * @function
  * @param {Node | Number} value - The value to constrain.
  * @returns {Node}
@@ -869,6 +926,7 @@ export const saturate = ( value ) => clamp( value );
 /**
  * Calculates the refraction direction for an incident vector.
  *
+ * @tsl
  * @function
  * @param {Node<vec2|vec3|vec4>} I - The incident vector.
  * @param {Node<vec2|vec3|vec4>} N - The normal vector.
@@ -880,6 +938,7 @@ export const refract = /*@__PURE__*/ nodeProxy( MathNode, MathNode.REFRACT );
 /**
  * Performs a Hermite interpolation between two values.
  *
+ * @tsl
  * @function
  * @param {Node | Number} low - The value of the lower edge of the Hermite function.
  * @param {Node | Number} high - The value of the upper edge of the Hermite function.
@@ -891,6 +950,7 @@ export const smoothstep = /*@__PURE__*/ nodeProxy( MathNode, MathNode.SMOOTHSTEP
 /**
  * Returns a vector pointing in the same direction as another.
  *
+ * @tsl
  * @function
  * @param {Node<vec2|vec3|vec4>} N - The vector to orient.
  * @param {Node<vec2|vec3|vec4>} I - The incident vector.
@@ -902,6 +962,7 @@ export const faceForward = /*@__PURE__*/ nodeProxy( MathNode, MathNode.FACEFORWA
 /**
  * Returns a random value for the given uv.
  *
+ * @tsl
  * @function
  * @param {Node<vec2>} uv - The uv node.
  * @returns {Node<float>}
@@ -918,6 +979,7 @@ export const rand = /*@__PURE__*/ Fn( ( [ uv ] ) => {
 /**
  * Alias for `mix()` with a different parameter order.
  *
+ * @tsl
  * @function
  * @param {Node | Number} t - The interpolation value.
  * @param {Node | Number} e1 - The first parameter.
@@ -929,6 +991,7 @@ export const mixElement = ( t, e1, e2 ) => mix( e1, e2, t );
 /**
  * Alias for `smoothstep()` with a different parameter order.
  *
+ * @tsl
  * @function
  * @param {Node | Number} x - The source value for interpolation.
  * @param {Node | Number} low - The value of the lower edge of the Hermite function.
@@ -940,6 +1003,7 @@ export const smoothstepElement = ( x, low, high ) => smoothstep( low, high, x );
 /**
  * Returns the arc-tangent of the quotient of its parameters.
  *
+ * @tsl
  * @function
  * @deprecated since r172. Use {@link atan} instead.
  *

--- a/src/nodes/math/MathUtils.js
+++ b/src/nodes/math/MathUtils.js
@@ -6,7 +6,8 @@ import { PI, pow, sin } from './MathNode.js';
  * The corners are mapped to `0` and the center to `1`.
  * Reference: {@link https://iquilezles.org/articles/functions/}.
  *
- * @method
+ * @tsl
+ * @function
  * @param {Node<float>} x - The value to remap.
  * @param {Node<float>} k - Allows to control the remapping functions shape by rising the parabola to a power `k`.
  * @return {Node<float>} The remapped value.
@@ -18,7 +19,8 @@ export const parabola = ( x, k ) => pow( mul( 4.0, x.mul( sub( 1.0, x ) ) ), k )
  * Expands the sides and compresses the center, and keeps `0.5` mapped to `0.5`.
  * Reference: {@link https://iquilezles.org/articles/functions/}.
  *
- * @method
+ * @tsl
+ * @function
  * @param {Node<float>} x - The value to remap.
  * @param {Node<float>} k - `k=1` is the identity curve,`k<1` produces the classic `gain()` shape, and `k>1` produces "s" shaped curves.
  * @return {Node<float>} The remapped value.
@@ -30,7 +32,8 @@ export const gain = ( x, k ) => x.lessThan( 0.5 ) ? parabola( x.mul( 2.0 ), k ).
  * A generalization of the `parabola()`. Keeps the corners mapped to 0 but allows the control of the shape one either side of the curve.
  * Reference: {@link https://iquilezles.org/articles/functions/}.
  *
- * @method
+ * @tsl
+ * @function
  * @param {Node<float>} x - The value to remap.
  * @param {Node<float>} a - First control parameter.
  * @param {Node<float>} b - Second control parameter.
@@ -42,7 +45,8 @@ export const pcurve = ( x, a, b ) => pow( div( pow( x, a ), add( pow( x, a ), po
  * A phase shifted sinus curve that starts at zero and ends at zero, with bouncing behavior.
  * Reference: {@link https://iquilezles.org/articles/functions/}.
  *
- * @method
+ * @tsl
+ * @function
  * @param {Node<float>} x - The value to compute the sin for.
  * @param {Node<float>} k - Controls the amount of bounces.
  * @return {Node<float>} The result value.

--- a/src/nodes/math/OperatorNode.js
+++ b/src/nodes/math/OperatorNode.js
@@ -378,6 +378,7 @@ export default OperatorNode;
 /**
  * Returns the addition of two or more value.
  *
+ * @tsl
  * @function
  * @param {Node} aNode - The first input.
  * @param {Node} bNode - The second input.
@@ -389,6 +390,7 @@ export const add = /*@__PURE__*/ nodeProxy( OperatorNode, '+' );
 /**
  * Returns the subtraction of two or more value.
  *
+ * @tsl
  * @function
  * @param {Node} aNode - The first input.
  * @param {Node} bNode - The second input.
@@ -400,6 +402,7 @@ export const sub = /*@__PURE__*/ nodeProxy( OperatorNode, '-' );
 /**
  * Returns the multiplication of two or more value.
  *
+ * @tsl
  * @function
  * @param {Node} aNode - The first input.
  * @param {Node} bNode - The second input.
@@ -411,6 +414,7 @@ export const mul = /*@__PURE__*/ nodeProxy( OperatorNode, '*' );
 /**
  * Returns the division of two or more value.
  *
+ * @tsl
  * @function
  * @param {Node} aNode - The first input.
  * @param {Node} bNode - The second input.
@@ -422,6 +426,7 @@ export const div = /*@__PURE__*/ nodeProxy( OperatorNode, '/' );
 /**
  * Computes the remainder of dividing the first node by the second, for integer values.
  *
+ * @tsl
  * @function
  * @param {Node} aNode - The first input.
  * @param {Node} bNode - The second input.
@@ -432,6 +437,7 @@ export const modInt = /*@__PURE__*/ nodeProxy( OperatorNode, '%' );
 /**
  * Checks if two nodes are equal.
  *
+ * @tsl
  * @function
  * @param {Node} aNode - The first input.
  * @param {Node} bNode - The second input.
@@ -442,6 +448,7 @@ export const equal = /*@__PURE__*/ nodeProxy( OperatorNode, '==' );
 /**
  * Checks if two nodes are not equal.
  *
+ * @tsl
  * @function
  * @param {Node} aNode - The first input.
  * @param {Node} bNode - The second input.
@@ -452,6 +459,7 @@ export const notEqual = /*@__PURE__*/ nodeProxy( OperatorNode, '!=' );
 /**
  * Checks if the first node is less than the second.
  *
+ * @tsl
  * @function
  * @param {Node} aNode - The first input.
  * @param {Node} bNode - The second input.
@@ -462,6 +470,7 @@ export const lessThan = /*@__PURE__*/ nodeProxy( OperatorNode, '<' );
 /**
  * Checks if the first node is greater than the second.
  *
+ * @tsl
  * @function
  * @param {Node} aNode - The first input.
  * @param {Node} bNode - The second input.
@@ -472,6 +481,7 @@ export const greaterThan = /*@__PURE__*/ nodeProxy( OperatorNode, '>' );
 /**
  * Checks if the first node is less than or equal to the second.
  *
+ * @tsl
  * @function
  * @param {Node} aNode - The first input.
  * @param {Node} bNode - The second input.
@@ -482,6 +492,7 @@ export const lessThanEqual = /*@__PURE__*/ nodeProxy( OperatorNode, '<=' );
 /**
  * Checks if the first node is greater than or equal to the second.
  *
+ * @tsl
  * @function
  * @param {Node} aNode - The first input.
  * @param {Node} bNode - The second input.
@@ -492,6 +503,7 @@ export const greaterThanEqual = /*@__PURE__*/ nodeProxy( OperatorNode, '>=' );
 /**
  * Performs logical AND on two nodes.
  *
+ * @tsl
  * @function
  * @param {Node} aNode - The first input.
  * @param {Node} bNode - The second input.
@@ -502,6 +514,7 @@ export const and = /*@__PURE__*/ nodeProxy( OperatorNode, '&&' );
 /**
  * Performs logical OR on two nodes.
  *
+ * @tsl
  * @function
  * @param {Node} aNode - The first input.
  * @param {Node} bNode - The second input.
@@ -512,6 +525,7 @@ export const or = /*@__PURE__*/ nodeProxy( OperatorNode, '||' );
 /**
  * Performs logical NOT on a node.
  *
+ * @tsl
  * @function
  * @param {Node} aNode - The first input.
  * @param {Node} bNode - The second input.
@@ -522,6 +536,7 @@ export const not = /*@__PURE__*/ nodeProxy( OperatorNode, '!' );
 /**
  * Performs logical XOR on two nodes.
  *
+ * @tsl
  * @function
  * @param {Node} aNode - The first input.
  * @param {Node} bNode - The second input.
@@ -532,6 +547,7 @@ export const xor = /*@__PURE__*/ nodeProxy( OperatorNode, '^^' );
 /**
  * Performs bitwise AND on two nodes.
  *
+ * @tsl
  * @function
  * @param {Node} aNode - The first input.
  * @param {Node} bNode - The second input.
@@ -542,6 +558,7 @@ export const bitAnd = /*@__PURE__*/ nodeProxy( OperatorNode, '&' );
 /**
  * Performs bitwise NOT on a node.
  *
+ * @tsl
  * @function
  * @param {Node} aNode - The first input.
  * @param {Node} bNode - The second input.
@@ -552,6 +569,7 @@ export const bitNot = /*@__PURE__*/ nodeProxy( OperatorNode, '~' );
 /**
  * Performs bitwise OR on two nodes.
  *
+ * @tsl
  * @function
  * @param {Node} aNode - The first input.
  * @param {Node} bNode - The second input.
@@ -562,6 +580,7 @@ export const bitOr = /*@__PURE__*/ nodeProxy( OperatorNode, '|' );
 /**
  * Performs bitwise XOR on two nodes.
  *
+ * @tsl
  * @function
  * @param {Node} aNode - The first input.
  * @param {Node} bNode - The second input.
@@ -572,6 +591,7 @@ export const bitXor = /*@__PURE__*/ nodeProxy( OperatorNode, '^' );
 /**
  * Shifts a node to the left.
  *
+ * @tsl
  * @function
  * @param {Node} aNode - The node to shift.
  * @param {Node} bNode - The value to shift.
@@ -582,6 +602,7 @@ export const shiftLeft = /*@__PURE__*/ nodeProxy( OperatorNode, '<<' );
 /**
  * Shifts a node to the right.
  *
+ * @tsl
  * @function
  * @param {Node} aNode - The node to shift.
  * @param {Node} bNode - The value to shift.
@@ -612,6 +633,7 @@ addMethodChaining( 'shiftLeft', shiftLeft );
 addMethodChaining( 'shiftRight', shiftRight );
 
 /**
+ * @tsl
  * @function
  * @deprecated since r168. Use {@link modInt} instead.
  *

--- a/src/nodes/math/TriNoise3D.js
+++ b/src/nodes/math/TriNoise3D.js
@@ -30,7 +30,8 @@ const tri3 = /*@__PURE__*/ Fn( ( [ p ] ) => {
 /**
  * Generates a noise value from the given position, speed and time parameters.
  *
- * @method
+ * @tsl
+ * @function
  * @param {Node<vec3>} position - The position.
  * @param {Node<float>} speed - The speed.
  * @param {Node<float>} time - The time.

--- a/src/nodes/pmrem/PMREMNode.js
+++ b/src/nodes/pmrem/PMREMNode.js
@@ -362,6 +362,7 @@ function isEquirectangularMapReady( image ) {
 /**
  * TSL function for creating a PMREM node.
  *
+ * @tsl
  * @function
  * @param {Texture} value - The input texture.
  * @param {Node<vec2>} [uvNode=null] - The uv node.

--- a/src/nodes/procedural/Checker.js
+++ b/src/nodes/procedural/Checker.js
@@ -4,7 +4,8 @@ import { Fn } from '../tsl/TSLBase.js';
 /**
  * Creates a 2x2 checkerboard pattern that can be used as procedural texture data.
  *
- * @method
+ * @tsl
+ * @function
  * @param {Node<vec2>} coord - The uv coordinates.
  * @return {Node<float>} The result data.
  */

--- a/src/nodes/shapes/Shapes.js
+++ b/src/nodes/shapes/Shapes.js
@@ -5,7 +5,8 @@ import { uv } from '../accessors/UV.js';
 /**
  * Generates a circle based on the uv coordinates.
  *
- * @method
+ * @tsl
+ * @function
  * @param {Node<vec2>} coord - The uv to generate the circle.
  * @return {Node<float>} The circle shape.
  */

--- a/src/nodes/tsl/TSLCore.js
+++ b/src/nodes/tsl/TSLCore.js
@@ -561,6 +561,7 @@ export const Fn = ( jsFunc, nodeType ) => {
 };
 
 /**
+ * @tsl
  * @function
  * @deprecated since r168. Use {@link Fn} instead.
  *

--- a/src/nodes/utils/CubeMapNode.js
+++ b/src/nodes/utils/CubeMapNode.js
@@ -229,6 +229,7 @@ function mapTextureMapping( texture, mapping ) {
 /**
  * TSL function for creating a cube map node.
  *
+ * @tsl
  * @function
  * @param {Node} envNode - The node representing the environment map.
  * @returns {CubeMapNode}

--- a/src/nodes/utils/Discard.js
+++ b/src/nodes/utils/Discard.js
@@ -5,7 +5,8 @@ import { addMethodChaining } from '../tsl/TSLCore.js';
 /**
  * Represents a `discard` shader operation in TSL.
  *
- * @method
+ * @tsl
+ * @function
  * @param {ConditionalNode?} conditional - An optional conditional node. It allows to decide whether the discard should be executed or not.
  * @return {Node} The `discard` expression.
  */
@@ -14,7 +15,8 @@ export const Discard = ( conditional ) => ( conditional ? select( conditional, e
 /**
  * Represents a `return` shader operation in TSL.
  *
- * @method
+ * @tsl
+ * @function
  * @return {ExpressionNode} The `return` expression.
  */
 export const Return = () => expression( 'return' ).append();

--- a/src/nodes/utils/EquirectUVNode.js
+++ b/src/nodes/utils/EquirectUVNode.js
@@ -57,6 +57,7 @@ export default EquirectUVNode;
 /**
  * TSL function for creating an equirect uv node.
  *
+ * @tsl
  * @function
  * @param {Node<vec3>} [dirNode=positionWorldDirection] - A direction vector for sampling which is by default `positionWorldDirection`.
  * @returns {EquirectUVNode}

--- a/src/nodes/utils/FunctionOverloadingNode.js
+++ b/src/nodes/utils/FunctionOverloadingNode.js
@@ -144,6 +144,7 @@ const overloadingBaseFn = /*@__PURE__*/ nodeProxy( FunctionOverloadingNode );
 /**
  * TSL function for creating a function overloading node.
  *
+ * @tsl
  * @function
  * @param {Array<Function>} functionNodes - Array of `Fn` function definitions.
  * @returns {FunctionOverloadingNode}

--- a/src/nodes/utils/LoopNode.js
+++ b/src/nodes/utils/LoopNode.js
@@ -250,6 +250,7 @@ export default LoopNode;
 /**
  * TSL function for creating a loop node.
  *
+ * @tsl
  * @function
  * @param {...Any} params - A list of parameters.
  * @returns {LoopNode}
@@ -259,6 +260,7 @@ export const Loop = ( ...params ) => nodeObject( new LoopNode( nodeArray( params
 /**
  * TSL function for creating a `Continue()` expression.
  *
+ * @tsl
  * @function
  * @returns {ExpressionNode}
  */
@@ -267,6 +269,7 @@ export const Continue = () => expression( 'continue' ).append();
 /**
  * TSL function for creating a `Break()` expression.
  *
+ * @tsl
  * @function
  * @returns {ExpressionNode}
  */
@@ -275,6 +278,7 @@ export const Break = () => expression( 'break' ).append();
 // Deprecated
 
 /**
+ * @tsl
  * @function
  * @deprecated since r168. Use {@link Loop} instead.
  *

--- a/src/nodes/utils/MatcapUVNode.js
+++ b/src/nodes/utils/MatcapUVNode.js
@@ -42,6 +42,7 @@ export default MatcapUVNode;
 /**
  * TSL function for creating a matcap uv node.
  *
+ * @tsl
  * @function
  * @returns {MatcapUVNode}
  */

--- a/src/nodes/utils/MaxMipLevelNode.js
+++ b/src/nodes/utils/MaxMipLevelNode.js
@@ -95,6 +95,7 @@ export default MaxMipLevelNode;
 /**
  * TSL function for creating a max mip level node.
  *
+ * @tsl
  * @function
  * @param {TextureNode} textureNode - The texture node to compute the max mip level for.
  * @returns {MaxMipLevelNode}

--- a/src/nodes/utils/Oscillators.js
+++ b/src/nodes/utils/Oscillators.js
@@ -3,7 +3,8 @@ import { time } from './Timer.js';
 /**
  * Generates a sine wave oscillation based on a timer.
  *
- * @method
+ * @tsl
+ * @function
  * @param {Node<float>} t - The timer to generate the oscillation with.
  * @return {Node<float>} The oscillation node.
  */
@@ -12,7 +13,8 @@ export const oscSine = ( t = time ) => t.add( 0.75 ).mul( Math.PI * 2 ).sin().mu
 /**
  * Generates a square wave oscillation based on a timer.
  *
- * @method
+ * @tsl
+ * @function
  * @param {Node<float>} t - The timer to generate the oscillation with.
  * @return {Node<float>} The oscillation node.
  */
@@ -21,7 +23,8 @@ export const oscSquare = ( t = time ) => t.fract().round();
 /**
  * Generates a triangle wave oscillation based on a timer.
  *
- * @method
+ * @tsl
+ * @function
  * @param {Node<float>} t - The timer to generate the oscillation with.
  * @return {Node<float>} The oscillation node.
  */
@@ -30,7 +33,8 @@ export const oscTriangle = ( t = time ) => t.add( 0.5 ).fract().mul( 2 ).sub( 1 
 /**
  * Generates a sawtooth wave oscillation based on a timer.
  *
- * @method
+ * @tsl
+ * @function
  * @param {Node<float>} t - The timer to generate the oscillation with.
  * @return {Node<float>} The oscillation node.
  */

--- a/src/nodes/utils/Packing.js
+++ b/src/nodes/utils/Packing.js
@@ -3,7 +3,8 @@ import { nodeObject } from '../tsl/TSLBase.js';
 /**
  * Packs a direction vector into a color value.
  *
- * @method
+ * @tsl
+ * @function
  * @param {Node<vec3>} node - The direction to pack.
  * @return {Node<vec3>} The color.
  */
@@ -12,7 +13,8 @@ export const directionToColor = ( node ) => nodeObject( node ).mul( 0.5 ).add( 0
 /**
  * Unpacks a color value into a direction vector.
  *
- * @method
+ * @tsl
+ * @function
  * @param {Node<vec3>} node - The color to unpack.
  * @return {Node<vec3>} The direction.
  */

--- a/src/nodes/utils/PostProcessingUtils.js
+++ b/src/nodes/utils/PostProcessingUtils.js
@@ -7,7 +7,8 @@ import { WebGPUCoordinateSystem } from '../../constants.js';
  * Computes a position in view space based on a fragment's screen position expressed as uv coordinates, the fragments
  * depth value and the camera's inverse projection matrix.
  *
- * @method
+ * @tsl
+ * @function
  * @param {Node<vec2>} screenPosition - The fragment's screen position expressed as uv coordinates.
  * @param {Node<float>} depth - The fragment's depth value.
  * @param {Node<mat4>} projectionMatrixInverse - The camera's inverse projection matrix.
@@ -38,7 +39,8 @@ export const getViewPosition = /*@__PURE__*/ Fn( ( [ screenPosition, depth, proj
  * Computes a screen position expressed as uv coordinates based on a fragment's position in view space
  * and the camera's projection matrix
  *
- * @method
+ * @tsl
+ * @function
  * @param {Node<vec3>} viewPosition - The fragments position in view space.
  * @param {Node<mat4>} projectionMatrix - The camera's projection matrix.
  * @return {Node<vec2>} The fragment's screen position expressed as uv coordinates.
@@ -55,7 +57,8 @@ export const getScreenPosition = /*@__PURE__*/ Fn( ( [ viewPosition, projectionM
  * Computes a normal vector based on depth data. Can be used as a fallback when no normal render
  * target is available or if flat surface normals are required.
  *
- * @method
+ * @tsl
+ * @function
  * @param {Node<vec2>} uv - The texture coordinate.
  * @param {DepthTexture} depthTexture - The depth texture.
  * @param {Node<mat4>} projectionMatrixInverse - The camera's inverse projection matrix.

--- a/src/nodes/utils/RTTNode.js
+++ b/src/nodes/utils/RTTNode.js
@@ -231,6 +231,7 @@ export default RTTNode;
 /**
  * TSL function for creating a RTT node.
  *
+ * @tsl
  * @function
  * @param {Node} node - The node to render a texture with.
  * @param {Number?} [width=null] - The width of the internal render target. If not width is applied, the render target is automatically resized.
@@ -243,6 +244,7 @@ export const rtt = ( node, ...params ) => nodeObject( new RTTNode( nodeObject( n
 /**
  * TSL function for converting nodes to textures nodes.
  *
+ * @tsl
  * @function
  * @param {Node} node - The node to render a texture with.
  * @param {Number?} [width=null] - The width of the internal render target. If not width is applied, the render target is automatically resized.

--- a/src/nodes/utils/ReflectorNode.js
+++ b/src/nodes/utils/ReflectorNode.js
@@ -481,6 +481,7 @@ class ReflectorBaseNode extends Node {
 /**
  * TSL function for creating a reflector node.
  *
+ * @tsl
  * @function
  * @param {Object} [parameters={}] - An object holding configuration parameters.
  * @param {Object3D} [parameters.target=new Object3D()] - The 3D object the reflector is linked to.

--- a/src/nodes/utils/RemapNode.js
+++ b/src/nodes/utils/RemapNode.js
@@ -96,6 +96,7 @@ export default RemapNode;
 /**
  * TSL function for creating a remap node.
  *
+ * @tsl
  * @function
  * @param {Node} node - The node that should be remapped.
  * @param {Node} inLowNode - The source or current lower bound of the range.
@@ -109,6 +110,7 @@ export const remap = /*@__PURE__*/ nodeProxy( RemapNode, null, null, { doClamp: 
 /**
  * TSL function for creating a remap node, but with enabled clamping.
  *
+ * @tsl
  * @function
  * @param {Node} node - The node that should be remapped.
  * @param {Node} inLowNode - The source or current lower bound of the range.

--- a/src/nodes/utils/RotateNode.js
+++ b/src/nodes/utils/RotateNode.js
@@ -93,6 +93,7 @@ export default RotateNode;
 /**
  * TSL function for creating a rotate node.
  *
+ * @tsl
  * @function
  * @param {Node} positionNode - The position node.
  * @param {Node} rotationNode - Represents the rotation that is applied to the position node. Depending

--- a/src/nodes/utils/SpriteSheetUVNode.js
+++ b/src/nodes/utils/SpriteSheetUVNode.js
@@ -80,6 +80,7 @@ export default SpriteSheetUVNode;
 /**
  * TSL function for creating a sprite sheet uv node.
  *
+ * @tsl
  * @function
  * @param {Node<vec2>} countNode - The node that defines the number of sprites in the x and y direction (e.g 6x6).
  * @param {Node<vec2>} [uvNode=uv()] - The uv node.

--- a/src/nodes/utils/SpriteUtils.js
+++ b/src/nodes/utils/SpriteUtils.js
@@ -11,7 +11,8 @@ import { Fn, defined } from '../tsl/TSLBase.js';
  * material.vertexNode = billboarding();
  * ```
  *
- * @method
+ * @tsl
+ * @function
  * @param {Object} config - The configuration object.
  * @param {Node<vec3>?} [config.position=null] - Can be used to define the vertex positions in world space.
  * @param {Boolean} [config.horizontal=true] - Whether to follow the camera rotation horizontally or not.

--- a/src/nodes/utils/StorageArrayElementNode.js
+++ b/src/nodes/utils/StorageArrayElementNode.js
@@ -134,6 +134,7 @@ export default StorageArrayElementNode;
 /**
  * TSL function for creating a storage element node.
  *
+ * @tsl
  * @function
  * @param {StorageBufferNode} storageBufferNode - The storage buffer node.
  * @param {Node} indexNode - The index node that defines the element access.

--- a/src/nodes/utils/Timer.js
+++ b/src/nodes/utils/Timer.js
@@ -4,6 +4,7 @@ import { uniform } from '../core/UniformNode.js';
 /**
  * Represents the elapsed time in seconds.
  *
+ * @tsl
  * @type {UniformNode<float>}
  */
 export const time = /*@__PURE__*/ uniform( 0 ).setGroup( renderGroup ).onRenderUpdate( ( frame ) => frame.time );
@@ -11,6 +12,7 @@ export const time = /*@__PURE__*/ uniform( 0 ).setGroup( renderGroup ).onRenderU
 /**
  * Represents the delta time in seconds.
  *
+ * @tsl
  * @type {UniformNode<float>}
  */
 export const deltaTime = /*@__PURE__*/ uniform( 0 ).setGroup( renderGroup ).onRenderUpdate( ( frame ) => frame.deltaTime );
@@ -18,6 +20,7 @@ export const deltaTime = /*@__PURE__*/ uniform( 0 ).setGroup( renderGroup ).onRe
 /**
  * Represents the current frame ID.
  *
+ * @tsl
  * @type {UniformNode<uint>}
  */
 export const frameId = /*@__PURE__*/ uniform( 0, 'uint' ).setGroup( renderGroup ).onRenderUpdate( ( frame ) => frame.frameId );
@@ -25,6 +28,7 @@ export const frameId = /*@__PURE__*/ uniform( 0, 'uint' ).setGroup( renderGroup 
 // Deprecated
 
 /**
+ * @tsl
  * @function
  * @deprecated since r170. Use {@link time} instead.
  *
@@ -39,6 +43,7 @@ export const timerLocal = ( timeScale = 1 ) => { // @deprecated, r170
 };
 
 /**
+ * @tsl
  * @function
  * @deprecated since r170. Use {@link time} instead.
  *
@@ -53,6 +58,7 @@ export const timerGlobal = ( timeScale = 1 ) => { // @deprecated, r170
 };
 
 /**
+ * @tsl
  * @function
  * @deprecated since r170. Use {@link deltaTime} instead.
  *

--- a/src/nodes/utils/TriplanarTexturesNode.js
+++ b/src/nodes/utils/TriplanarTexturesNode.js
@@ -120,6 +120,7 @@ export default TriplanarTexturesNode;
 /**
  * TSL function for creating a triplanar textures node.
  *
+ * @tsl
  * @function
  * @param {Node} textureXNode - First texture node.
  * @param {Node?} [textureYNode=null] - Second texture node. When not set, the shader will sample from `textureXNode` instead.
@@ -134,6 +135,7 @@ export const triplanarTextures = /*@__PURE__*/ nodeProxy( TriplanarTexturesNode 
 /**
  * TSL function for creating a triplanar textures node.
  *
+ * @tsl
  * @function
  * @param {Node} textureXNode - First texture node.
  * @param {Node?} [textureYNode=null] - Second texture node. When not set, the shader will sample from `textureXNode` instead.

--- a/src/nodes/utils/UVUtils.js
+++ b/src/nodes/utils/UVUtils.js
@@ -4,7 +4,8 @@ import { rotate } from './RotateNode.js';
 /**
  * Rotates the given uv coordinates around a center point
  *
- * @method
+ * @tsl
+ * @function
  * @param {Node<vec2>} uv - The uv coordinates.
  * @param {Node<float>} rotation - The rotation defined in radians.
  * @param {Node<vec2>} center - The center of rotation
@@ -19,7 +20,8 @@ export const rotateUV = /*@__PURE__*/ Fn( ( [ uv, rotation, center = vec2( 0.5 )
 /**
  * Applies a spherical warping effect to the given uv coordinates.
  *
- * @method
+ * @tsl
+ * @function
  * @param {Node<vec2>} uv - The uv coordinates.
  * @param {Node<float>} strength - The strength of the effect.
  * @param {Node<vec2>} center - The center point

--- a/src/nodes/utils/ViewportUtils.js
+++ b/src/nodes/utils/ViewportUtils.js
@@ -10,7 +10,8 @@ import { linearDepth } from '../display/ViewportDepthNode.js';
  * objects in front of a refractive surface might appear on the refractive surface
  * which is incorrect.
  *
- * @method
+ * @tsl
+ * @function
  * @param {Node<vec2>?} uv - Optional uv coordinates. By default `screenUV` is used.
  * @return {Node<vec2>} The update uv coordinates.
  */


### PR DESCRIPTION
Related issue: -

**Description**

The PR introduces a custom `@tsl` tag that allows the documentation template to list all TSL objects and functions in a separate nav list.