### PR TITLE
WebGPURenderer: Fix clear for default framebuffer

### DIFF
--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -1907,12 +1907,7 @@ class Renderer {
 			renderContext.renderTarget = renderTarget;
 			renderContext.depth = renderTarget.depthBuffer;
 			renderContext.stencil = renderTarget.stencilBuffer;
-
-		}
-
-		// #30329
-		if ( renderContext !== null ) {
-
+			// #30329
 			renderContext.clearColorValue = this._clearColor;
 
 		}

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -1911,7 +1911,11 @@ class Renderer {
 		}
 
 		// #30329
-		renderContext.clearColorValue = this._clearColor;
+		if ( renderContext !== null ) {
+
+			renderContext.clearColorValue = this._clearColor;
+
+		}
 
 		this.backend.clear( color, depth, stencil, renderContext );
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/30329#issuecomment-2633804481

**Description**

Fixes `clear` when rendering to default framebuffer as we don't need to forward the `clearColorValue` to any renderContext since it's directly accessible via `color`, `depth`, `stencil`.

*This contribution is funded by [Utsubo](https://utsubo.com)*
