### PR TITLE
Docs: Do not capitalize primitive types.

### DIFF
--- a/examples/jsm/animation/CCDIKSolver.js
+++ b/examples/jsm/animation/CCDIKSolver.js
@@ -380,7 +380,7 @@ class CCDIKHelper extends Object3D {
 	/**
 	 * Updates IK bones visualization.
 	 *
-	 * @param {Boolean} force
+	 * @param {boolean} force
 	 */
 	updateMatrixWorld( force ) {
 

--- a/examples/jsm/controls/ArcballControls.js
+++ b/examples/jsm/controls/ArcballControls.js
@@ -1045,8 +1045,8 @@ class ArcballControls extends Controls {
 
 	/**
 	 * Set _center's x/y coordinates
-	 * @param {Number} clientX
-	 * @param {Number} clientY
+	 * @param {number} clientX
+	 * @param {number} clientY
 	 */
 	setCenter( clientX, clientY ) {
 
@@ -1078,7 +1078,7 @@ class ArcballControls extends Controls {
 	 * Compare two mouse actions
 	 * @param {Object} action1
 	 * @param {Object} action2
-	 * @returns {Boolean} True if action1 and action 2 are the same mouse action, false otherwise
+	 * @returns {boolean} True if action1 and action 2 are the same mouse action, false otherwise
 	 */
 	compareMouseAction( action1, action2 ) {
 
@@ -1107,7 +1107,7 @@ class ArcballControls extends Controls {
 	 * @param {'PAN'|'ROTATE'|'ZOOM'|'FOV'} operation The operation to be performed ('PAN', 'ROTATE', 'ZOOM', 'FOV')
 	 * @param {0|1|2|'WHEEL'} mouse A mouse button (0, 1, 2) or 'WHEEL' for wheel notches
 	 * @param {'CTRL'|'SHIFT'|null} [key=null] The keyboard modifier ('CTRL', 'SHIFT') or null if key is not needed
-	 * @returns {Boolean} True if the mouse action has been successfully added, false otherwise
+	 * @returns {boolean} True if the mouse action has been successfully added, false otherwise
 	 */
 	setMouseAction( operation, mouse, key = null ) {
 
@@ -1187,7 +1187,7 @@ class ArcballControls extends Controls {
 	 * Remove a mouse action by specifying its mouse/key combination
 	 * @param {0|1|2|'WHEEL'} mouse A mouse button (0, 1, 2) or 'WHEEL' for wheel notches
 	 * @param {'CTRL'|'SHIFT'|null} key The keyboard modifier ('CTRL', 'SHIFT') or null if key is not needed
-	 * @returns {Boolean} True if the operation has been successfully removed, false otherwise
+	 * @returns {boolean} True if the operation has been successfully removed, false otherwise
 	 */
 	unsetMouseAction( mouse, key = null ) {
 
@@ -1290,7 +1290,7 @@ class ArcballControls extends Controls {
 	 * Calculate the angle between two pointers
 	 * @param {PointerEvent} p1
 	 * @param {PointerEvent} p2
-	 * @returns {Number} The angle between two pointers in degrees
+	 * @returns {number} The angle between two pointers in degrees
 	 */
 	getAngle( p1, p2 ) {
 
@@ -1407,11 +1407,11 @@ class ArcballControls extends Controls {
 	/**
 	 * Calculate the angular speed
 	 *
-	 * @param {Number} p0 Position at t0
-	 * @param {Number} p1 Position at t1
-	 * @param {Number} t0 Initial time in milliseconds
-	 * @param {Number} t1 Ending time in milliseconds
-	 * @returns {Number}
+	 * @param {number} p0 Position at t0
+	 * @param {number} p1 Position at t1
+	 * @param {number} t0 Initial time in milliseconds
+	 * @param {number} t1 Ending time in milliseconds
+	 * @returns {number}
 	 */
 	calculateAngularSpeed( p0, p1, t0, t1 ) {
 
@@ -1458,7 +1458,7 @@ class ArcballControls extends Controls {
 	/**
 	 * Calculate the trackball radius so that gizmo's diameter will be 2/3 of the minimum side of the camera frustum
 	 * @param {Camera} camera
-	 * @returns {Number} The trackball radius
+	 * @returns {number} The trackball radius
 	 */
 	calculateTbRadius( camera ) {
 
@@ -1481,8 +1481,8 @@ class ArcballControls extends Controls {
 	/**
 	 * Focus operation consist of positioning the point of interest in front of the camera and a slightly zoom in
 	 * @param {Vector3} point The point of interest
-	 * @param {Number} size Scale factor
-	 * @param {Number} [amount=1] Amount of operation to be completed (used for focus animations, default is complete full operation)
+	 * @param {number} size Scale factor
+	 * @param {number} [amount=1] Amount of operation to be completed (used for focus animations, default is complete full operation)
 	 */
 	focus( point, size, amount = 1 ) {
 
@@ -1596,8 +1596,8 @@ class ArcballControls extends Controls {
 
 	/**
 	 * Compute the easing out cubic function for ease out effect in animation
-	 * @param {Number} t The absolute progress of the animation in the bound of 0 (beginning of the) and 1 (ending of animation)
-	 * @returns {Number} Result of easing out cubic at time t
+	 * @param {number} t The absolute progress of the animation in the bound of 0 (beginning of the) and 1 (ending of animation)
+	 * @returns {number} Result of easing out cubic at time t
 	 */
 	easeOutCubic( t ) {
 
@@ -1607,7 +1607,7 @@ class ArcballControls extends Controls {
 
 	/**
 	 * Make rotation gizmos more or less visible
-	 * @param {Boolean} isActive If true, make gizmos more visible
+	 * @param {boolean} isActive If true, make gizmos more visible
 	 */
 	activateGizmos( isActive ) {
 
@@ -1651,8 +1651,8 @@ class ArcballControls extends Controls {
 	/**
 	 * Calculate the cursor position inside the canvas x/y coordinates with the origin being in the center of the canvas
 	 *
-	 * @param {Number} cursorX Cursor horizontal coordinate within the canvas
-	 * @param {Number} cursorY Cursor vertical coordinate within the canvas
+	 * @param {number} cursorX Cursor horizontal coordinate within the canvas
+	 * @param {number} cursorY Cursor vertical coordinate within the canvas
 	 * @param {HTMLElement} canvas The canvas where the renderer draws its output
 	 * @returns {Vector2} Cursor position inside the canvas
 	 */
@@ -1710,7 +1710,7 @@ class ArcballControls extends Controls {
 
 	/**
 	 * Set gizmos visibility
-	 * @param {Boolean} value Value of gizmos visibility
+	 * @param {boolean} value Value of gizmos visibility
 	 */
 	setGizmosVisible( value ) {
 
@@ -1721,7 +1721,7 @@ class ArcballControls extends Controls {
 
 	/**
 	 * Set gizmos radius factor and redraws gizmos
-	 * @param {Number} value Value of radius factor
+	 * @param {number} value Value of radius factor
 	 */
 	setTbRadius( value ) {
 
@@ -1815,7 +1815,7 @@ class ArcballControls extends Controls {
 
 	/**
 	 * Perform animation for focus operation
-	 * @param {Number} time Instant in which this function is called as performance.now()
+	 * @param {number} time Instant in which this function is called as performance.now()
 	 * @param {Vector3} point Point of interest for focus operation
 	 * @param {Matrix4} cameraMatrix Camera matrix
 	 * @param {Matrix4} gizmoMatrix Gizmos matrix
@@ -1881,7 +1881,7 @@ class ArcballControls extends Controls {
 
 	/**
 	 * Perform animation for rotation operation
-	 * @param {Number} time Instant in which this function is called as performance.now()
+	 * @param {number} time Instant in which this function is called as performance.now()
 	 * @param {Vector3} rotationAxis Rotation axis
 	 * @param {number} w0 Initial angular velocity
 	 */
@@ -1951,7 +1951,7 @@ class ArcballControls extends Controls {
 	 *
 	 * @param {Vector3} p0 Initial point
 	 * @param {Vector3} p1 Ending point
-	 * @param {Boolean} [adjust=false] If movement should be adjusted considering camera distance (Perspective only)
+	 * @param {boolean} [adjust=false] If movement should be adjusted considering camera distance (Perspective only)
 	 * @returns {Object}
 	 */
 	pan( p0, p1, adjust = false ) {
@@ -2113,9 +2113,9 @@ class ArcballControls extends Controls {
 
 	/**
 	 * Perform uniform scale operation around a given point
-	 * @param {Number} size Scale factor
+	 * @param {number} size Scale factor
 	 * @param {Vector3} point Point around which scale
-	 * @param {Boolean} scaleGizmos If gizmos should be scaled (Perspective only)
+	 * @param {boolean} scaleGizmos If gizmos should be scaled (Perspective only)
 	 * @returns {Object} Object with 'camera' and 'gizmo' fields containing transformation matrices resulting from the operation to be applied to the camera and gizmos
 	 */
 	scale( size, point, scaleGizmos = true ) {
@@ -2229,7 +2229,7 @@ class ArcballControls extends Controls {
 
 	/**
 	 * Set camera fov
-	 * @param {Number} value fov to be set
+	 * @param {number} value fov to be set
 	 */
 	setFov( value ) {
 
@@ -2292,7 +2292,7 @@ class ArcballControls extends Controls {
 	 * Rotate camera around its direction axis passing by a given point by a given angle
 	 *
 	 * @param {Vector3} point The point where the rotation axis is passing trough
-	 * @param {Number} angle Angle in radians
+	 * @param {number} angle Angle in radians
 	 * @returns {Object} The computed transformation matrix
 	 */
 	zRotate( point, angle ) {
@@ -2356,8 +2356,8 @@ class ArcballControls extends Controls {
 	/**
 	 * Unproject the cursor on the trackball surface
 	 * @param {Camera} camera The virtual camera
-	 * @param {Number} cursorX Cursor horizontal coordinate on screen
-	 * @param {Number} cursorY Cursor vertical coordinate on screen
+	 * @param {number} cursorX Cursor horizontal coordinate on screen
+	 * @param {number} cursorY Cursor vertical coordinate on screen
 	 * @param {HTMLElement} canvas The canvas where the renderer draws its output
 	 * @param {number} tbRadius The trackball radius
 	 * @returns {Vector3} The unprojected point on the trackball surface
@@ -2486,10 +2486,10 @@ class ArcballControls extends Controls {
 	/**
 	 * Unproject the cursor on the plane passing through the center of the trackball orthogonal to the camera
 	 * @param {Camera} camera The virtual camera
-	 * @param {Number} cursorX Cursor horizontal coordinate on screen
-	 * @param {Number} cursorY Cursor vertical coordinate on screen
+	 * @param {number} cursorX Cursor horizontal coordinate on screen
+	 * @param {number} cursorY Cursor vertical coordinate on screen
 	 * @param {HTMLElement} canvas The canvas where the renderer draws its output
-	 * @param {Boolean} [initialDistance=false] If initial distance between camera and gizmos should be used for calculations instead of current (Perspective only)
+	 * @param {boolean} [initialDistance=false] If initial distance between camera and gizmos should be used for calculations instead of current (Perspective only)
 	 * @returns {Vector3} The unprojected point on the trackball plane
 	 */
 	unprojectOnTbPlane( camera, cursorX, cursorY, canvas, initialDistance = false ) {
@@ -2589,7 +2589,7 @@ class ArcballControls extends Controls {
 	/**
 	 * Update the trackball FSA
 	 * @param {STATE} newState New state of the FSA
-	 * @param {Boolean} updateMatrices If matrices state should be updated
+	 * @param {boolean} updateMatrices If matrices state should be updated
 	 */
 	updateTbState( newState, updateMatrices ) {
 

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -306,7 +306,7 @@ const GLB_CHUNK_TYPE_BIN = 0x004E4942;
  * Compare two arrays
  * @param  {Array} array1 Array 1 to compare
  * @param  {Array} array2 Array 2 to compare
- * @return {Boolean}        Returns true if both arrays are equal
+ * @return {boolean}        Returns true if both arrays are equal
  */
 function equalArray( array1, array2 ) {
 
@@ -333,7 +333,7 @@ function stringToArrayBuffer( text ) {
  * Is identity matrix
  *
  * @param {Matrix4} matrix
- * @returns {Boolean} Returns true, if parameter is identity matrix
+ * @returns {boolean} Returns true, if parameter is identity matrix
  */
 function isIdentityMatrix( matrix ) {
 
@@ -345,8 +345,8 @@ function isIdentityMatrix( matrix ) {
  * Get the min and max vectors from the given attribute
  *
  * @param  {BufferAttribute} attribute Attribute to find the min/max in range from start to start + count
- * @param  {Number} start Start index
- * @param  {Number} count Range to cover
+ * @param  {number} start Start index
+ * @param  {number} count Range to cover
  * @return {Object} Object containing the `min` and `max` values (As an array of attribute.itemSize components)
  */
 function getMinMax( attribute, start, count ) {
@@ -400,8 +400,8 @@ function getMinMax( attribute, start, count ) {
  * Get the required size + padding for a buffer, rounded to the next 4-byte boundary.
  * https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#data-alignment
  *
- * @param {Number} bufferSize The size the original buffer. Should be an integer.
- * @returns {Number} new buffer size with required padding as an integer.
+ * @param {number} bufferSize The size the original buffer. Should be an integer.
+ * @returns {number} new buffer size with required padding as an integer.
  *
  */
 function getPaddedBufferSize( bufferSize ) {
@@ -414,7 +414,7 @@ function getPaddedBufferSize( bufferSize ) {
  * Returns a buffer aligned to 4-byte boundary.
  *
  * @param {ArrayBuffer} arrayBuffer Buffer to pad
- * @param {Number} [paddingByte=0] Should be an integer
+ * @param {number} [paddingByte=0] Should be an integer
  * @returns {ArrayBuffer} The same buffer if it's already aligned to 4-byte boundary or a new buffer
  */
 function getPaddedArrayBuffer( arrayBuffer, paddingByte = 0 ) {
@@ -715,7 +715,7 @@ class GLTFWriter {
 	 *
 	 * @param  {Object} attribute
 	 * @param {boolean} [isRelativeCopy=false]
-	 * @return {Number} An integer
+	 * @return {number} An integer
 	 */
 	getUID( attribute, isRelativeCopy = false ) {
 
@@ -740,7 +740,7 @@ class GLTFWriter {
 	 * Checks if normal attribute values are normalized.
 	 *
 	 * @param {BufferAttribute} normal
-	 * @returns {Boolean}
+	 * @returns {boolean}
 	 */
 	isNormalizedNormalAttribute( normal ) {
 
@@ -1145,7 +1145,7 @@ class GLTFWriter {
 	/**
 	 * Process and generate a BufferView from an image Blob.
 	 * @param {Blob} blob
-	 * @return {Promise<Number>} An integer
+	 * @return {Promise<number>} An integer
 	 */
 	processBufferViewImage( blob ) {
 
@@ -1181,9 +1181,9 @@ class GLTFWriter {
 	 * Process attribute to generate an accessor
 	 * @param  {BufferAttribute} attribute Attribute to process
 	 * @param  {THREE.BufferGeometry?} geometry Geometry used for truncated draw range
-	 * @param  {Number} [start=0]
-	 * @param  {Number} [count=Infinity]
-	 * @return {Number?} Index of the processed accessor on the "accessors" array
+	 * @param  {number} [start=0]
+	 * @param  {number} [count=Infinity]
+	 * @return {number?} Index of the processed accessor on the "accessors" array
 	 */
 	processAccessor( attribute, geometry, start, count ) {
 
@@ -1278,10 +1278,10 @@ class GLTFWriter {
 	/**
 	 * Process image
 	 * @param  {Image} image to process
-	 * @param  {Number} format Identifier of the format (RGBAFormat)
-	 * @param  {Boolean} flipY before writing out the image
-	 * @param  {String} mimeType export format
-	 * @return {Number}     Index of the processed texture in the "images" array
+	 * @param  {number} format Identifier of the format (RGBAFormat)
+	 * @param  {boolean} flipY before writing out the image
+	 * @param  {string} mimeType export format
+	 * @return {number}     Index of the processed texture in the "images" array
 	 */
 	processImage( image, format, flipY, mimeType = 'image/png' ) {
 
@@ -1418,7 +1418,7 @@ class GLTFWriter {
 	/**
 	 * Process sampler
 	 * @param  {Texture} map Texture to process
-	 * @return {Number}      Index of the processed texture in the "samplers" array
+	 * @return {number}      Index of the processed texture in the "samplers" array
 	 */
 	processSampler( map ) {
 
@@ -1440,7 +1440,7 @@ class GLTFWriter {
 	/**
 	 * Process texture
 	 * @param  {Texture} map Map to process
-	 * @return {Promise<Number>} Index of the processed texture in the "textures" array
+	 * @return {Promise<number>} Index of the processed texture in the "textures" array
 	 */
 	async processTextureAsync( map ) {
 
@@ -2067,7 +2067,7 @@ class GLTFWriter {
 	/**
 	 * Process camera
 	 * @param  {THREE.Camera} camera Camera to process
-	 * @return {Number} Index of the processed mesh in the "camera" array
+	 * @return {number} Index of the processed mesh in the "camera" array
 	 */
 	processCamera( camera ) {
 
@@ -2268,7 +2268,7 @@ class GLTFWriter {
 	/**
 	 * Process Object3D node
 	 * @param  {THREE.Object3D} object Object3D to processNodeAsync
-	 * @return {Promise<Number>} Index of the node in the nodes list
+	 * @return {Promise<number>} Index of the node in the nodes list
 	 */
 	async processNodeAsync( object ) {
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2776,7 +2776,7 @@ class GLTFParser {
 	 * Returns a reference to a shared resource, cloning it if necessary.
 	 *
 	 * @param {Object} cache
-	 * @param {Number} index
+	 * @param {number} index
 	 * @param {Object} object
 	 * @return {Object}
 	 */
@@ -3667,8 +3667,8 @@ class GLTFParser {
 	/**
 	 * When Object3D instances are targeted by animation, they need unique names.
 	 *
-	 * @param {String} originalName
-	 * @return {String}
+	 * @param {string} originalName
+	 * @return {string}
 	 */
 	createUniqueName( originalName ) {
 

--- a/examples/jsm/loaders/MTLLoader.js
+++ b/examples/jsm/loaders/MTLLoader.js
@@ -28,7 +28,7 @@ class MTLLoader extends Loader {
 	/**
 	 * Loads and parses a MTL asset from a URL.
 	 *
-	 * @param {String} url - URL to the MTL file.
+	 * @param {string} url - URL to the MTL file.
 	 * @param {Function} [onLoad] - Callback invoked with the loaded object.
 	 * @param {Function} [onProgress] - Callback for download progress.
 	 * @param {Function} [onError] - Callback for download errors.
@@ -84,8 +84,8 @@ class MTLLoader extends Loader {
 	/**
 	 * Parses a MTL file.
 	 *
-	 * @param {String} text - Content of MTL file
-	 * @param {String} path
+	 * @param {string} text - Content of MTL file
+	 * @param {string} path
 	 * @return {MaterialCreator}
 	 *
 	 * @see setPath setResourcePath

--- a/examples/jsm/loaders/TDSLoader.js
+++ b/examples/jsm/loaders/TDSLoader.js
@@ -89,7 +89,7 @@ class TDSLoader extends Loader {
 	 *
 	 * @method parse
 	 * @param {ArrayBuffer} arraybuffer Arraybuffer data to be loaded.
-	 * @param {String} path Path for external resources.
+	 * @param {string} path Path for external resources.
 	 * @return {Group} Group loaded from 3ds file.
 	 */
 	parse( arraybuffer, path ) {
@@ -115,7 +115,7 @@ class TDSLoader extends Loader {
 	 *
 	 * @method readFile
 	 * @param {ArrayBuffer} arraybuffer Arraybuffer data to be loaded.
-	 * @param {String} path Path for external resources.
+	 * @param {string} path Path for external resources.
 	 */
 	readFile( arraybuffer, path ) {
 
@@ -158,7 +158,7 @@ class TDSLoader extends Loader {
 	 *
 	 * @method readMeshData
 	 * @param {Chunk} chunk to read mesh from
-	 * @param {String} path Path for external resources.
+	 * @param {string} path Path for external resources.
 	 */
 	readMeshData( chunk, path ) {
 
@@ -235,7 +235,7 @@ class TDSLoader extends Loader {
 	 *
 	 * @method readMaterialEntry
 	 * @param {Chunk} chunk Chunk in use.
-	 * @param {String} path Path for external resources.
+	 * @param {string} path Path for external resources.
 	 */
 	readMaterialEntry( chunk, path ) {
 
@@ -529,7 +529,7 @@ class TDSLoader extends Loader {
 	 *
 	 * @method readMap
 	 * @param {Chunk} chunk Chunk in use.
-	 * @param {String} path Path for external resources.
+	 * @param {string} path Path for external resources.
 	 * @return {Texture} Texture read from this data chunk.
 	 */
 	readMap( chunk, path ) {
@@ -656,7 +656,7 @@ class TDSLoader extends Loader {
 	 *
 	 * @method readPercentage
 	 * @param {Chunk} chunk Chunk to read data from.
-	 * @return {Number} Data read from the dataview.
+	 * @return {number} Data read from the dataview.
 	 */
 	readPercentage( chunk ) {
 
@@ -709,7 +709,7 @@ class Chunk {
 	 *
 	 * @class Chunk
 	 * @param {DataView} data DataView to read from.
-	 * @param {Number} position in data.
+	 * @param {number} position in data.
 	 * @param {Function} debugMessage logging callback.
 	 */
 	constructor( data, position, debugMessage ) {
@@ -772,7 +772,7 @@ class Chunk {
 	 * return the ID of this chunk as Hex
 	 *
 	 * @method idToString
-	 * @return {String} hex-string of id
+	 * @return {string} hex-string of id
 	 */
 	get hexId() {
 
@@ -790,7 +790,7 @@ class Chunk {
 	 * Read byte value.
 	 *
 	 * @method readByte
-	 * @return {Number} Data read from the dataview.
+	 * @return {number} Data read from the dataview.
 	 */
 	readByte() {
 
@@ -804,7 +804,7 @@ class Chunk {
 	 * Read 32 bit float value.
 	 *
 	 * @method readFloat
-	 * @return {Number} Data read from the dataview.
+	 * @return {number} Data read from the dataview.
 	 */
 	readFloat() {
 
@@ -827,7 +827,7 @@ class Chunk {
 	 * Read 32 bit signed integer value.
 	 *
 	 * @method readInt
-	 * @return {Number} Data read from the dataview.
+	 * @return {number} Data read from the dataview.
 	 */
 	readInt() {
 
@@ -841,7 +841,7 @@ class Chunk {
 	 * Read 16 bit signed integer value.
 	 *
 	 * @method readShort
-	 * @return {Number} Data read from the dataview.
+	 * @return {number} Data read from the dataview.
 	 */
 	readShort() {
 
@@ -855,7 +855,7 @@ class Chunk {
 	 * Read 64 bit unsigned integer value.
 	 *
 	 * @method readDWord
-	 * @return {Number} Data read from the dataview.
+	 * @return {number} Data read from the dataview.
 	 */
 	readDWord() {
 
@@ -869,7 +869,7 @@ class Chunk {
 	 * Read 32 bit unsigned integer value.
 	 *
 	 * @method readWord
-	 * @return {Number} Data read from the dataview.
+	 * @return {number} Data read from the dataview.
 	 */
 	readWord() {
 
@@ -883,7 +883,7 @@ class Chunk {
 	 * Read NULL terminated ASCII string value from chunk-pos.
 	 *
 	 * @method readString
-	 * @return {String} Data read from the dataview.
+	 * @return {string} Data read from the dataview.
 	 */
 	readString() {
 

--- a/examples/jsm/math/OBB.js
+++ b/examples/jsm/math/OBB.js
@@ -151,8 +151,8 @@ class OBB {
 	* by Christer Ericson (chapter 4.4.1)
 	*
 	* @param {OBB} obb
-	* @param {Number} [epsilon=Number.EPSILON] - A small value to prevent arithmetic errors
-	* @returns {Boolean}
+	* @param {number} [epsilon=Number.EPSILON] - A small value to prevent arithmetic errors
+	* @returns {boolean}
 	*/
 	intersectsOBB( obb, epsilon = Number.EPSILON ) {
 
@@ -294,7 +294,7 @@ class OBB {
 	* by Christer Ericson (chapter 5.2.3)
 	*
 	* @param {Plane} plane
-	* @returns {Boolean}
+	* @returns {boolean}
 	*/
 	intersectsPlane( plane ) {
 
@@ -363,7 +363,7 @@ class OBB {
 	* there is a intersection or not.
 	*
 	* @param {Ray} ray
-	* @returns {Boolean}
+	* @returns {boolean}
 	*/
 	intersectsRay( ray ) {
 

--- a/examples/jsm/misc/GPUComputationRenderer.js
+++ b/examples/jsm/misc/GPUComputationRenderer.js
@@ -104,8 +104,8 @@ import { FullScreenQuad } from '../postprocessing/Pass.js';
 class GPUComputationRenderer {
 
 	/**
-	 * @param {Number} sizeX Computation problem size is always 2d: sizeX * sizeY elements.
- 	 * @param {Number} sizeY Computation problem size is always 2d: sizeX * sizeY elements.
+	 * @param {number} sizeX Computation problem size is always 2d: sizeX * sizeY elements.
+ 	 * @param {number} sizeY Computation problem size is always 2d: sizeX * sizeY elements.
  	 * @param {WebGLRenderer} renderer The renderer
 	 */
 	constructor( sizeX, sizeY, renderer ) {

--- a/examples/jsm/misc/VolumeSlice.js
+++ b/examples/jsm/misc/VolumeSlice.js
@@ -29,7 +29,7 @@ class VolumeSlice {
 		 */
 		this.volume = volume;
 		/**
-		 * @member {Number} index The index of the slice, if changed, will automatically call updateGeometry at the next repaint
+		 * @member {number} index The index of the slice, if changed, will automatically call updateGeometry at the next repaint
 		 */
 		index = index || 0;
 		Object.defineProperty( this, 'index', {
@@ -47,7 +47,7 @@ class VolumeSlice {
 			}
 		} );
 		/**
-		 * @member {String} axis The normal axis
+		 * @member {string} axis The normal axis
 		 */
 		this.axis = axis || 'z';
 
@@ -80,25 +80,25 @@ class VolumeSlice {
 		this.mesh = new Mesh( this.geometry, material );
 		this.mesh.matrixAutoUpdate = false;
 		/**
-		 * @member {Boolean} geometryNeedsUpdate If set to true, updateGeometry will be triggered at the next repaint
+		 * @member {boolean} geometryNeedsUpdate If set to true, updateGeometry will be triggered at the next repaint
 		 */
 		this.geometryNeedsUpdate = true;
 		this.repaint();
 
 		/**
-		 * @member {Number} iLength Width of slice in the original coordinate system, corresponds to the width of the buffer canvas
+		 * @member {number} iLength Width of slice in the original coordinate system, corresponds to the width of the buffer canvas
 		 */
 
 		/**
-		 * @member {Number} jLength Height of slice in the original coordinate system, corresponds to the height of the buffer canvas
+		 * @member {number} jLength Height of slice in the original coordinate system, corresponds to the height of the buffer canvas
 		 */
 
 		/**
 		 * @member {Function} sliceAccess Function that allow the slice to access right data
 		 * @see Volume.extractPerpendicularPlane
-		 * @param {Number} i The first coordinate
-		 * @param {Number} j The second coordinate
-		 * @returns {Number} the index corresponding to the voxel in volume.data of the given position in the slice
+		 * @param {number} i The first coordinate
+		 * @param {number} j The second coordinate
+		 * @returns {number} the index corresponding to the voxel in volume.data of the given position in the slice
 		 */
 
 

--- a/examples/jsm/tsl/display/AfterImageNode.js
+++ b/examples/jsm/tsl/display/AfterImageNode.js
@@ -23,7 +23,7 @@ class AfterImageNode extends TempNode {
 	 * Constructs a new after image node.
 	 *
 	 * @param {TextureNode} textureNode - The texture node that represents the input of the effect.
-	 * @param {Number} [damp=0.96] - The damping intensity. A higher value means a stronger after image effect.
+	 * @param {number} [damp=0.96] - The damping intensity. A higher value means a stronger after image effect.
 	 */
 	constructor( textureNode, damp = 0.96 ) {
 
@@ -82,7 +82,7 @@ class AfterImageNode extends TempNode {
 		 * The `updateBeforeType` is set to `NodeUpdateType.FRAME` since the node renders
 		 * its effect once per frame in `updateBefore()`.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default 'frame'
 		 */
 		this.updateBeforeType = NodeUpdateType.FRAME;
@@ -103,8 +103,8 @@ class AfterImageNode extends TempNode {
 	/**
 	 * Sets the size of the effect.
 	 *
-	 * @param {Number} width - The width of the effect.
-	 * @param {Number} height - The height of the effect.
+	 * @param {number} width - The width of the effect.
+	 * @param {number} height - The height of the effect.
 	 */
 	setSize( width, height ) {
 
@@ -235,7 +235,7 @@ class AfterImageNode extends TempNode {
  * @tsl
  * @function
  * @param {Node<vec4>} node - The node that represents the input of the effect.
- * @param {Number} [damp=0.96] - The damping intensity. A higher value means a stronger after image effect.
+ * @param {number} [damp=0.96] - The damping intensity. A higher value means a stronger after image effect.
  * @returns {AfterImageNode}
  */
 export const afterImage = ( node, damp ) => nodeObject( new AfterImageNode( convertToTexture( node ), damp ) );

--- a/examples/jsm/tsl/display/AnaglyphPassNode.js
+++ b/examples/jsm/tsl/display/AnaglyphPassNode.js
@@ -28,7 +28,7 @@ class AnaglyphPassNode extends StereoCompositePassNode {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */

--- a/examples/jsm/tsl/display/AnamorphicNode.js
+++ b/examples/jsm/tsl/display/AnamorphicNode.js
@@ -24,7 +24,7 @@ class AnamorphicNode extends TempNode {
 	 * @param {TextureNode} textureNode - The texture node that represents the input of the effect.
 	 * @param {Node<float>} tresholdNode - The threshold is one option to control the intensity and size of the effect.
 	 * @param {Node<float>} scaleNode - Defines the vertical scale of the flares.
-	 * @param {Number} samples - More samples result in larger flares and a more expensive runtime behavior.
+	 * @param {number} samples - More samples result in larger flares and a more expensive runtime behavior.
 	 */
 	constructor( textureNode, tresholdNode, scaleNode, samples ) {
 
@@ -101,7 +101,7 @@ class AnamorphicNode extends TempNode {
 		 * The `updateBeforeType` is set to `NodeUpdateType.FRAME` since the node renders
 		 * its effect once per frame in `updateBefore()`.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default 'frame'
 		 */
 		this.updateBeforeType = NodeUpdateType.FRAME;
@@ -122,8 +122,8 @@ class AnamorphicNode extends TempNode {
 	/**
 	 * Sets the size of the effect.
 	 *
-	 * @param {Number} width - The width of the effect.
-	 * @param {Number} height - The height of the effect.
+	 * @param {number} width - The width of the effect.
+	 * @param {number} height - The height of the effect.
 	 */
 	setSize( width, height ) {
 
@@ -247,9 +247,9 @@ class AnamorphicNode extends TempNode {
  * @tsl
  * @function
  * @param {TextureNode} node - The node that represents the input of the effect.
- * @param {Node<float> | Number} [threshold=0.9] - The threshold is one option to control the intensity and size of the effect.
- * @param {Node<float> | Number} [scale=3] - Defines the vertical scale of the flares.
- * @param {Number} [samples=32] - More samples result in larger flares and a more expensive runtime behavior.
+ * @param {Node<float> | number} [threshold=0.9] - The threshold is one option to control the intensity and size of the effect.
+ * @param {Node<float> | number} [scale=3] - Defines the vertical scale of the flares.
+ * @param {number} [samples=32] - More samples result in larger flares and a more expensive runtime behavior.
  * @returns {AnamorphicNode}
  */
 export const anamorphic = ( node, threshold = .9, scale = 3, samples = 32 ) => nodeObject( new AnamorphicNode( convertToTexture( node ), nodeObject( threshold ), nodeObject( scale ), samples ) );

--- a/examples/jsm/tsl/display/BloomNode.js
+++ b/examples/jsm/tsl/display/BloomNode.js
@@ -53,9 +53,9 @@ class BloomNode extends TempNode {
 	 * Constructs a new bloom node.
 	 *
 	 * @param {Node<vec4>} inputNode - The node that represents the input of the effect.
-	 * @param {Number} [strength=1] - The strength of the bloom.
-	 * @param {Number} [radius=0] - The radius of the bloom.
-	 * @param {Number} [threshold=0] - The luminance threshold limits which bright areas contribute to the bloom effect.
+	 * @param {number} [strength=1] - The strength of the bloom.
+	 * @param {number} [radius=0] - The radius of the bloom.
+	 * @param {number} [threshold=0] - The luminance threshold limits which bright areas contribute to the bloom effect.
 	 */
 	constructor( inputNode, strength = 1, radius = 0, threshold = 0 ) {
 
@@ -116,7 +116,7 @@ class BloomNode extends TempNode {
 		 * The number if blur mips.
 		 *
 		 * @private
-		 * @type {Number}
+		 * @type {number}
 		 */
 		this._nMips = 5;
 
@@ -234,7 +234,7 @@ class BloomNode extends TempNode {
 		 * The `updateBeforeType` is set to `NodeUpdateType.FRAME` since the node renders
 		 * its effect once per frame in `updateBefore()`.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default 'frame'
 		 */
 		this.updateBeforeType = NodeUpdateType.FRAME;
@@ -255,8 +255,8 @@ class BloomNode extends TempNode {
 	/**
 	 * Sets the size of the effect.
 	 *
-	 * @param {Number} width - The width of the effect.
-	 * @param {Number} height - The height of the effect.
+	 * @param {number} width - The width of the effect.
+	 * @param {number} height - The height of the effect.
 	 */
 	setSize( width, height ) {
 
@@ -442,7 +442,7 @@ class BloomNode extends TempNode {
 	 * Create a separable blur material for the given kernel radius.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @param {Number} kernelRadius - The kernel radius.
+	 * @param {number} kernelRadius - The kernel radius.
 	 * @return {NodeMaterial}
 	 */
 	_getSeparableBlurMaterial( builder, kernelRadius ) {
@@ -508,9 +508,9 @@ class BloomNode extends TempNode {
  * @tsl
  * @function
  * @param {Node<vec4>} node - The node that represents the input of the effect.
- * @param {Number} [strength=1] - The strength of the bloom.
- * @param {Number} [radius=0] - The radius of the bloom.
- * @param {Number} [threshold=0] - The luminance threshold limits which bright areas contribute to the bloom effect.
+ * @param {number} [strength=1] - The strength of the bloom.
+ * @param {number} [radius=0] - The radius of the bloom.
+ * @param {number} [threshold=0] - The luminance threshold limits which bright areas contribute to the bloom effect.
  * @returns {BloomNode}
  */
 export const bloom = ( node, strength, radius, threshold ) => nodeObject( new BloomNode( nodeObject( node ), strength, radius, threshold ) );

--- a/examples/jsm/tsl/display/DenoiseNode.js
+++ b/examples/jsm/tsl/display/DenoiseNode.js
@@ -101,7 +101,7 @@ class DenoiseNode extends TempNode {
 		 * The `updateBeforeType` is set to `NodeUpdateType.FRAME` since the node updates
 		 * its internal uniforms once per frame in `updateBefore()`.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default 'frame'
 		 */
 		this.updateBeforeType = NodeUpdateType.FRAME;
@@ -259,9 +259,9 @@ export default DenoiseNode;
 /**
  * Generates denoise samples based on the given parameters.
  *
- * @param {Number} numSamples - The number of samples.
- * @param {Number} numRings - The number of rings.
- * @param {Number} radiusExponent - The radius exponent.
+ * @param {number} numSamples - The number of samples.
+ * @param {number} numRings - The number of rings.
+ * @param {number} radiusExponent - The radius exponent.
  * @return {Array<Vector3>} The denoise samples.
  */
 function generateDenoiseSamples( numSamples, numRings, radiusExponent ) {
@@ -283,7 +283,7 @@ function generateDenoiseSamples( numSamples, numRings, radiusExponent ) {
 /**
  * Generates a default noise texture for the given size.
  *
- * @param {Number} [size=64] - The texture size.
+ * @param {number} [size=64] - The texture size.
  * @return {DataTexture} The generated noise texture.
  */
 function generateDefaultNoise( size = 64 ) {

--- a/examples/jsm/tsl/display/DepthOfFieldNode.js
+++ b/examples/jsm/tsl/display/DepthOfFieldNode.js
@@ -74,7 +74,7 @@ class DepthOfFieldNode extends TempNode {
 		 * The `updateBeforeType` is set to `NodeUpdateType.FRAME` since the node updates
 		 * its internal uniforms once per frame in `updateBefore()`.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default 'frame'
 		 */
 		this.updateBeforeType = NodeUpdateType.FRAME;
@@ -189,9 +189,9 @@ export default DepthOfFieldNode;
  * @function
  * @param {Node<vec4>} node - The node that represents the input of the effect.
  * @param {Node<float>} viewZNode - Represents the viewZ depth values of the scene.
- * @param {Node<float> | Number} focus - Defines the effect's focus which is the distance along the camera's look direction in world units.
- * @param {Node<float> | Number} aperture - Defines the effect's aperture.
- * @param {Node<float> | Number} maxblur - Defines the effect's maximum blur.
+ * @param {Node<float> | number} focus - Defines the effect's focus which is the distance along the camera's look direction in world units.
+ * @param {Node<float> | number} aperture - Defines the effect's aperture.
+ * @param {Node<float> | number} maxblur - Defines the effect's maximum blur.
  * @returns {DepthOfFieldNode}
  */
 export const dof = ( node, viewZNode, focus = 1, aperture = 0.025, maxblur = 1 ) => nodeObject( new DepthOfFieldNode( convertToTexture( node ), nodeObject( viewZNode ), nodeObject( focus ), nodeObject( aperture ), nodeObject( maxblur ) ) );

--- a/examples/jsm/tsl/display/DotScreenNode.js
+++ b/examples/jsm/tsl/display/DotScreenNode.js
@@ -18,8 +18,8 @@ class DotScreenNode extends TempNode {
 	 * Constructs a new dot screen node.
 	 *
 	 * @param {Node} inputNode - The node that represents the input of the effect.
-	 * @param {Number} [angle=1.57] - The rotation of the effect in radians.
-	 * @param {Number} [scale=1] - The scale of the effect. A higher value means smaller dots.
+	 * @param {number} [angle=1.57] - The rotation of the effect in radians.
+	 * @param {number} [scale=1] - The scale of the effect. A higher value means smaller dots.
 	 */
 	constructor( inputNode, angle = 1.57, scale = 1 ) {
 
@@ -96,8 +96,8 @@ export default DotScreenNode;
  * @tsl
  * @function
  * @param {Node<vec4>} node - The node that represents the input of the effect.
- * @param {Number} [angle=1.57] - The rotation of the effect in radians.
- * @param {Number} [scale=1] - The scale of the effect. A higher value means smaller dots.
+ * @param {number} [angle=1.57] - The rotation of the effect in radians.
+ * @param {number} [scale=1] - The scale of the effect. A higher value means smaller dots.
  * @returns {DotScreenNode}
  */
 export const dotScreen = ( node, angle, scale ) => nodeObject( new DotScreenNode( nodeObject( node ), angle, scale ) );

--- a/examples/jsm/tsl/display/FXAANode.js
+++ b/examples/jsm/tsl/display/FXAANode.js
@@ -35,7 +35,7 @@ class FXAANode extends TempNode {
 		 * The `updateBeforeType` is set to `NodeUpdateType.FRAME` since the node updates
 		 * its internal uniforms once per frame in `updateBefore()`.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default 'frame'
 		 */
 		this.updateBeforeType = NodeUpdateType.FRAME;

--- a/examples/jsm/tsl/display/GTAONode.js
+++ b/examples/jsm/tsl/display/GTAONode.js
@@ -69,7 +69,7 @@ class GTAONode extends TempNode {
 		 * The resolution scale. By default the effect is rendered in full resolution
 		 * for best quality but a value of `0.5` should be sufficient for most scenes.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @default 1
 		 */
 		this.resolutionScale = 1;
@@ -78,7 +78,7 @@ class GTAONode extends TempNode {
 		 * The `updateBeforeType` is set to `NodeUpdateType.FRAME` since the node renders
 		 * its effect once per frame in `updateBefore()`.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default 'frame'
 		 */
 		this.updateBeforeType = NodeUpdateType.FRAME;
@@ -222,8 +222,8 @@ class GTAONode extends TempNode {
 	/**
 	 * Sets the size of the effect.
 	 *
-	 * @param {Number} width - The width of the effect.
-	 * @param {Number} height - The height of the effect.
+	 * @param {number} width - The width of the effect.
+	 * @param {number} height - The height of the effect.
 	 */
 	setSize( width, height ) {
 
@@ -415,7 +415,7 @@ export default GTAONode;
 /**
  * Generates the AO's noise texture for the given size.
  *
- * @param {Number} [size=5] - The noise size.
+ * @param {number} [size=5] - The noise size.
  * @return {DataTexture} The generated noise texture.
  */
 function generateMagicSquareNoise( size = 5 ) {
@@ -453,8 +453,8 @@ function generateMagicSquareNoise( size = 5 ) {
 /**
  * Computes an array of magic square values required to generate the noise texture.
  *
- * @param {Number} size - The noise size.
- * @return {Array<Number>} The magic square values.
+ * @param {number} size - The noise size.
+ * @return {Array<number>} The magic square values.
  */
 function generateMagicSquare( size ) {
 

--- a/examples/jsm/tsl/display/GaussianBlurNode.js
+++ b/examples/jsm/tsl/display/GaussianBlurNode.js
@@ -49,7 +49,7 @@ class GaussianBlurNode extends TempNode {
 	 *
 	 * @param {TextureNode} textureNode - The texture node that represents the input of the effect.
 	 * @param {Node<vec2|float>} directionNode - Defines the direction and radius of the blur.
-	 * @param {Number} sigma - Controls the kernel of the blur filter. Higher values mean a wider blur radius.
+	 * @param {number} sigma - Controls the kernel of the blur filter. Higher values mean a wider blur radius.
 	 */
 	constructor( textureNode, directionNode = null, sigma = 2 ) {
 
@@ -72,7 +72,7 @@ class GaussianBlurNode extends TempNode {
 		/**
 		 * Controls the kernel of the blur filter. Higher values mean a wider blur radius.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 */
 		this.sigma = sigma;
 
@@ -124,7 +124,7 @@ class GaussianBlurNode extends TempNode {
 		 * The `updateBeforeType` is set to `NodeUpdateType.FRAME` since the node renders
 		 * its effect once per frame in `updateBefore()`.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default 'frame'
 		 */
 		this.updateBeforeType = NodeUpdateType.FRAME;
@@ -141,7 +141,7 @@ class GaussianBlurNode extends TempNode {
 		 * Whether the effect should use premultiplied alpha or not. Set this to `true`
 		 * if you are going to blur texture input with transparency.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default false
 		 */
 		this.premultipliedAlpha = false;
@@ -151,7 +151,7 @@ class GaussianBlurNode extends TempNode {
 	/**
 	 * Sets the given premultiplied alpha value.
 	 *
-	 * @param {Boolean} value - Whether the effect should use premultiplied alpha or not.
+	 * @param {boolean} value - Whether the effect should use premultiplied alpha or not.
 	 * @return {GaussianBlurNode} height - A reference to this node.
 	 */
 	setPremultipliedAlpha( value ) {
@@ -165,7 +165,7 @@ class GaussianBlurNode extends TempNode {
 	/**
 	 * Returns the premultiplied alpha value.
 	 *
-	 * @return {Boolean} Whether the effect should use premultiplied alpha or not.
+	 * @return {boolean} Whether the effect should use premultiplied alpha or not.
 	 */
 	getPremultipliedAlpha() {
 
@@ -176,8 +176,8 @@ class GaussianBlurNode extends TempNode {
 	/**
 	 * Sets the size of the effect.
 	 *
-	 * @param {Number} width - The width of the effect.
-	 * @param {Number} height - The height of the effect.
+	 * @param {number} width - The width of the effect.
+	 * @param {number} height - The height of the effect.
 	 */
 	setSize( width, height ) {
 
@@ -347,8 +347,8 @@ class GaussianBlurNode extends TempNode {
 	 * Computes gaussian coefficients depending on the given kernel radius.
 	 *
 	 * @private
-	 * @param {Number} kernelRadius - The kernel radius.
-	 * @return {Array<Number>}
+	 * @param {number} kernelRadius - The kernel radius.
+	 * @return {Array<number>}
 	 */
 	_getCoefficients( kernelRadius ) {
 
@@ -375,7 +375,7 @@ export default GaussianBlurNode;
  * @function
  * @param {Node<vec4>} node - The node that represents the input of the effect.
  * @param {Node<vec2|float>} directionNode - Defines the direction and radius of the blur.
- * @param {Number} sigma - Controls the kernel of the blur filter. Higher values mean a wider blur radius.
+ * @param {number} sigma - Controls the kernel of the blur filter. Higher values mean a wider blur radius.
  * @returns {GaussianBlurNode}
  */
 export const gaussianBlur = ( node, directionNode, sigma ) => nodeObject( new GaussianBlurNode( convertToTexture( node ), directionNode, sigma ) );
@@ -387,7 +387,7 @@ export const gaussianBlur = ( node, directionNode, sigma ) => nodeObject( new Ga
  * @function
  * @param {Node<vec4>} node - The node that represents the input of the effect.
  * @param {Node<vec2|float>} directionNode - Defines the direction and radius of the blur.
- * @param {Number} sigma - Controls the kernel of the blur filter. Higher values mean a wider blur radius.
+ * @param {number} sigma - Controls the kernel of the blur filter. Higher values mean a wider blur radius.
  * @returns {GaussianBlurNode}
  */
 export const premultipliedGaussianBlur = ( node, directionNode, sigma ) => nodeObject( new GaussianBlurNode( convertToTexture( node ), directionNode, sigma ).setPremultipliedAlpha( true ) );

--- a/examples/jsm/tsl/display/LensflareNode.js
+++ b/examples/jsm/tsl/display/LensflareNode.js
@@ -29,11 +29,11 @@ class LensflareNode extends TempNode {
 	 * @param {TextureNode} textureNode - The texture node that represents the scene's bloom.
 	 * @param {Object} params - The parameter object for configuring the effect.
 	 * @param {Node<vec3> | Color} [params.ghostTint=vec3(1, 1, 1)] - Defines the tint of the flare/ghosts.
-	 * @param {Node<float> | Number} [params.threshold=float(0.5)] - Controls the size and strength of the effect. A higher threshold results in smaller flares.
-	 * @param {Node<float> | Number} [params.ghostSamples=float(4)] - Represents the number of flares/ghosts per bright spot which pivot around the center.
-	 * @param {Node<float> | Number} [params.ghostSpacing=float(0.25)] - Defines the spacing of the flares/ghosts.
-	 * @param {Node<float> | Number} [params.ghostAttenuationFactor=float(25)] - Defines the attenuation factor of flares/ghosts.
-	 * @param {Number} [params.downSampleRatio=4] - Defines how downsampling since the effect is usually not rendered at full resolution.
+	 * @param {Node<float> | number} [params.threshold=float(0.5)] - Controls the size and strength of the effect. A higher threshold results in smaller flares.
+	 * @param {Node<float> | number} [params.ghostSamples=float(4)] - Represents the number of flares/ghosts per bright spot which pivot around the center.
+	 * @param {Node<float> | number} [params.ghostSpacing=float(0.25)] - Defines the spacing of the flares/ghosts.
+	 * @param {Node<float> | number} [params.ghostAttenuationFactor=float(25)] - Defines the attenuation factor of flares/ghosts.
+	 * @param {number} [params.downSampleRatio=4] - Defines how downsampling since the effect is usually not rendered at full resolution.
 	 */
 	constructor( textureNode, params = {} ) {
 
@@ -93,7 +93,7 @@ class LensflareNode extends TempNode {
 		/**
 		 * Defines how downsampling since the effect is usually not rendered at full resolution.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 */
 		this.downSampleRatio = downSampleRatio;
 
@@ -101,7 +101,7 @@ class LensflareNode extends TempNode {
 		 * The `updateBeforeType` is set to `NodeUpdateType.FRAME` since the node renders
 		 * its effect once per frame in `updateBefore()`.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default 'frame'
 		 */
 		this.updateBeforeType = NodeUpdateType.FRAME;
@@ -148,8 +148,8 @@ class LensflareNode extends TempNode {
 	/**
 	 * Sets the size of the effect.
 	 *
-	 * @param {Number} width - The width of the effect.
-	 * @param {Number} height - The height of the effect.
+	 * @param {number} width - The width of the effect.
+	 * @param {number} height - The height of the effect.
 	 */
 	setSize( width, height ) {
 
@@ -268,11 +268,11 @@ export default LensflareNode;
  * @param {TextureNode} node - The node that represents the scene's bloom.
  * @param {Object} params - The parameter object for configuring the effect.
  * @param {Node<vec3> | Color} [params.ghostTint=vec3(1, 1, 1)] - Defines the tint of the flare/ghosts.
- * @param {Node<float> | Number} [params.threshold=float(0.5)] - Controls the size and strength of the effect. A higher threshold results in smaller flares.
- * @param {Node<float> | Number} [params.ghostSamples=float(4)] - Represents the number of flares/ghosts per bright spot which pivot around the center.
- * @param {Node<float> | Number} [params.ghostSpacing=float(0.25)] - Defines the spacing of the flares/ghosts.
- * @param {Node<float> | Number} [params.ghostAttenuationFactor=float(25)] - Defines the attenuation factor of flares/ghosts.
- * @param {Number} [params.downSampleRatio=4] - Defines how downsampling since the effect is usually not rendered at full resolution.
+ * @param {Node<float> | number} [params.threshold=float(0.5)] - Controls the size and strength of the effect. A higher threshold results in smaller flares.
+ * @param {Node<float> | number} [params.ghostSamples=float(4)] - Represents the number of flares/ghosts per bright spot which pivot around the center.
+ * @param {Node<float> | number} [params.ghostSpacing=float(0.25)] - Defines the spacing of the flares/ghosts.
+ * @param {Node<float> | number} [params.ghostAttenuationFactor=float(25)] - Defines the attenuation factor of flares/ghosts.
+ * @param {number} [params.downSampleRatio=4] - Defines how downsampling since the effect is usually not rendered at full resolution.
  * @returns {LensflareNode}
  */
 export const lensflare = ( node, params ) => nodeObject( new LensflareNode( convertToTexture( node ), params ) );

--- a/examples/jsm/tsl/display/Lut3DNode.js
+++ b/examples/jsm/tsl/display/Lut3DNode.js
@@ -19,7 +19,7 @@ class Lut3DNode extends TempNode {
 	 *
 	 * @param {Node} inputNode - The node that represents the input of the effect.
 	 * @param {TextureNode} lutNode - A texture node that represents the lookup table.
-	 * @param {Number} size - The size of the lookup table.
+	 * @param {number} size - The size of the lookup table.
 	 * @param {Node<float>} intensityNode - Controls the intensity of the effect.
 	 */
 	constructor( inputNode, lutNode, size, intensityNode ) {
@@ -101,8 +101,8 @@ export default Lut3DNode;
  * @function
  * @param {Node} node - The node that represents the input of the effect.
  * @param {TextureNode} lut - A texture node that represents the lookup table.
- * @param {Number} size - The size of the lookup table.
- * @param {Node<float> | Number} intensity - Controls the intensity of the effect.
+ * @param {number} size - The size of the lookup table.
+ * @param {Node<float> | number} intensity - Controls the intensity of the effect.
  * @returns {Lut3DNode}
  */
 export const lut3D = ( node, lut, size, intensity ) => nodeObject( new Lut3DNode( nodeObject( node ), nodeObject( lut ), size, nodeObject( intensity ) ) );

--- a/examples/jsm/tsl/display/OutlineNode.js
+++ b/examples/jsm/tsl/display/OutlineNode.js
@@ -58,7 +58,7 @@ class OutlineNode extends TempNode {
 	 * @param {Array<Object3D>} params.selectedObjects - An array of selected objects.
 	 * @param {Node<float>} [params.edgeThickness=float(1)] - The thickness of the edges.
 	 * @param {Node<float>} [params.edgeGlow=float(0)] - Can be used for an animated glow/pulse effects.
-	 * @param {Number} [params.downSampleRatio=2] - The downsample ratio.
+	 * @param {number} [params.downSampleRatio=2] - The downsample ratio.
 	 */
 	constructor( scene, camera, params = {} ) {
 
@@ -109,7 +109,7 @@ class OutlineNode extends TempNode {
 		/**
 		 * The downsample ratio.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @default 2
 		 */
 		this.downSampleRatio = downSampleRatio;
@@ -118,7 +118,7 @@ class OutlineNode extends TempNode {
 		 * The `updateBeforeType` is set to `NodeUpdateType.FRAME` since the node renders
 		 * its effect once per frame in `updateBefore()`.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default 'frame'
 		 */
 		this.updateBeforeType = NodeUpdateType.FRAME;
@@ -403,8 +403,8 @@ class OutlineNode extends TempNode {
 	/**
 	 * Sets the size of the effect.
 	 *
-	 * @param {Number} width - The width of the effect.
-	 * @param {Number} height - The height of the effect.
+	 * @param {number} width - The width of the effect.
+	 * @param {number} height - The height of the effect.
 	 */
 	setSize( width, height ) {
 
@@ -744,7 +744,7 @@ export default OutlineNode;
  * @param {Array<Object3D>} params.selectedObjects - An array of selected objects.
  * @param {Node<float>} [params.edgeThickness=float(1)] - The thickness of the edges.
  * @param {Node<float>} [params.edgeGlow=float(0)] - Can be used for animated glow/pulse effects.
- * @param {Number} [params.downSampleRatio=2] - The downsample ratio.
+ * @param {number} [params.downSampleRatio=2] - The downsample ratio.
  * @returns {OutlineNode}
  */
 export const outline = ( scene, camera, params ) => nodeObject( new OutlineNode( scene, camera, params ) );

--- a/examples/jsm/tsl/display/ParallaxBarrierPassNode.js
+++ b/examples/jsm/tsl/display/ParallaxBarrierPassNode.js
@@ -28,7 +28,7 @@ class ParallaxBarrierPassNode extends StereoCompositePassNode {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */

--- a/examples/jsm/tsl/display/PixelationPassNode.js
+++ b/examples/jsm/tsl/display/PixelationPassNode.js
@@ -82,7 +82,7 @@ class PixelationNode extends TempNode {
 		 * The `updateBeforeType` is set to `NodeUpdateType.FRAME` since the node updates
 		 * its internal uniforms once per frame in `updateBefore()`.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default 'frame'
 		 */
 		this.updateBeforeType = NodeUpdateType.FRAME;
@@ -233,9 +233,9 @@ class PixelationPassNode extends PassNode {
 	 *
 	 * @param {Scene} scene - The scene to render.
 	 * @param {Camera} camera - The camera to render the scene with.
-	 * @param {Node<float> | Number} [pixelSize=6] - The pixel size.
-	 * @param {Node<float> | Number} [normalEdgeStrength=03] - The normal edge strength.
-	 * @param {Node<float> | Number} [depthEdgeStrength=03] - The depth edge strength.
+	 * @param {Node<float> | number} [pixelSize=6] - The pixel size.
+	 * @param {Node<float> | number} [normalEdgeStrength=03] - The normal edge strength.
+	 * @param {Node<float> | number} [depthEdgeStrength=03] - The depth edge strength.
 	 */
 	constructor( scene, camera, pixelSize = 6, normalEdgeStrength = 0.3, depthEdgeStrength = 0.4 ) {
 
@@ -244,7 +244,7 @@ class PixelationPassNode extends PassNode {
 		/**
 		 * The pixel size.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @default 6
 		 */
 		this.pixelSize = pixelSize;
@@ -252,7 +252,7 @@ class PixelationPassNode extends PassNode {
 		/**
 		 * The normal edge strength.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @default 0.3
 		 */
 		this.normalEdgeStrength = normalEdgeStrength;
@@ -260,7 +260,7 @@ class PixelationPassNode extends PassNode {
 		/**
 		 * The depth edge strength.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @default 0.4
 		 */
 		this.depthEdgeStrength = depthEdgeStrength;
@@ -268,7 +268,7 @@ class PixelationPassNode extends PassNode {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -284,8 +284,8 @@ class PixelationPassNode extends PassNode {
 	/**
 	 * Sets the size of the pass.
 	 *
-	 * @param {Number} width - The width of the pass.
-	 * @param {Number} height - The height of the pass.
+	 * @param {number} width - The width of the pass.
+	 * @param {number} height - The height of the pass.
 	 */
 	setSize( width, height ) {
 
@@ -323,9 +323,9 @@ class PixelationPassNode extends PassNode {
  * @function
  * @param {Scene} scene - The scene to render.
  * @param {Camera} camera - The camera to render the scene with.
- * @param {Node<float> | Number} [pixelSize=6] - The pixel size.
- * @param {Node<float> | Number} [normalEdgeStrength=03] - The normal edge strength.
- * @param {Node<float> | Number} [depthEdgeStrength=03] - The depth edge strength.
+ * @param {Node<float> | number} [pixelSize=6] - The pixel size.
+ * @param {Node<float> | number} [normalEdgeStrength=03] - The normal edge strength.
+ * @param {Node<float> | number} [depthEdgeStrength=03] - The depth edge strength.
  * @returns {PixelationPassNode}
  */
 export const pixelationPass = ( scene, camera, pixelSize, normalEdgeStrength, depthEdgeStrength ) => nodeObject( new PixelationPassNode( scene, camera, pixelSize, normalEdgeStrength, depthEdgeStrength ) );

--- a/examples/jsm/tsl/display/RGBShiftNode.js
+++ b/examples/jsm/tsl/display/RGBShiftNode.js
@@ -19,8 +19,8 @@ class RGBShiftNode extends TempNode {
 	 * Constructs a new RGB shift node.
 	 *
 	 * @param {TextureNode} textureNode - The texture node that represents the input of the effect.
-	 * @param {Number} [amount=0.005] - The amount of the RGB shift.
-	 * @param {Number} [angle=0] - Defines the orientation in which colors are shifted.
+	 * @param {number} [amount=0.005] - The amount of the RGB shift.
+	 * @param {number} [angle=0] - Defines the orientation in which colors are shifted.
 	 */
 	constructor( textureNode, amount = 0.005, angle = 0 ) {
 
@@ -88,8 +88,8 @@ export default RGBShiftNode;
  * @tsl
  * @function
  * @param {Node<vec4>} node - The node that represents the input of the effect.
- * @param {Number} [amount=0.005] - The amount of the RGB shift.
- * @param {Number} [angle=0] - Defines in which direction colors are shifted.
+ * @param {number} [amount=0.005] - The amount of the RGB shift.
+ * @param {number} [angle=0] - Defines in which direction colors are shifted.
  * @returns {RGBShiftNode}
  */
 export const rgbShift = ( node, amount, angle ) => nodeObject( new RGBShiftNode( convertToTexture( node ), amount, angle ) );

--- a/examples/jsm/tsl/display/SMAANode.js
+++ b/examples/jsm/tsl/display/SMAANode.js
@@ -44,7 +44,7 @@ class SMAANode extends TempNode {
 		 * The `updateBeforeType` is set to `NodeUpdateType.FRAME` since the node renders
 		 * its effect once per frame in `updateBefore()`.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default 'frame'
 		 */
 		this.updateBeforeType = NodeUpdateType.FRAME;
@@ -216,8 +216,8 @@ class SMAANode extends TempNode {
 	/**
 	 * Sets the size of the effect.
 	 *
-	 * @param {Number} width - The width of the effect.
-	 * @param {Number} height - The height of the effect.
+	 * @param {number} width - The width of the effect.
+	 * @param {number} height - The height of the effect.
 	 */
 	setSize( width, height ) {
 
@@ -732,7 +732,7 @@ class SMAANode extends TempNode {
 	 * Returns the area texture as a Base64 string.
 	 *
 	 * @private
-	 * @return {String} The area texture.
+	 * @return {string} The area texture.
 	 */
 	_getAreaTexture() {
 
@@ -744,7 +744,7 @@ class SMAANode extends TempNode {
 	 * Returns the search texture as a Base64 string..
 	 *
 	 * @private
-	 * @return {String} The search texture.
+	 * @return {string} The search texture.
 	 */
 	_getSearchTexture() {
 

--- a/examples/jsm/tsl/display/SSAAPassNode.js
+++ b/examples/jsm/tsl/display/SSAAPassNode.js
@@ -37,7 +37,7 @@ class SSAAPassNode extends PassNode {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -47,7 +47,7 @@ class SSAAPassNode extends PassNode {
 		 * The sample level specified  as n, where the number of samples is 2^n,
 		 * so sampleLevel = 4, is 2^4 samples, 16.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @default 4
 		 */
 		this.sampleLevel = 4;
@@ -55,7 +55,7 @@ class SSAAPassNode extends PassNode {
 		/**
 		 * Whether rounding errors should be mitigated or not.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default true
 		 */
 		this.unbiased = true;
@@ -71,7 +71,7 @@ class SSAAPassNode extends PassNode {
 		/**
 		 * The clear alpha of the pass.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @default 0
 		 */
 		this.clearAlpha = 0;

--- a/examples/jsm/tsl/display/SSRNode.js
+++ b/examples/jsm/tsl/display/SSRNode.js
@@ -74,7 +74,7 @@ class SSRNode extends TempNode {
 		 * to `1` improves quality but also results in more
 		 * computational overhead.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @default 0.5
 		 */
 		this.resolutionScale = 0.5;
@@ -83,7 +83,7 @@ class SSRNode extends TempNode {
 		 * The `updateBeforeType` is set to `NodeUpdateType.FRAME` since the node renders
 		 * its effect once per frame in `updateBefore()`.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default 'frame'
 		 */
 		this.updateBeforeType = NodeUpdateType.FRAME;
@@ -209,8 +209,8 @@ class SSRNode extends TempNode {
 	/**
 	 * Sets the size of the effect.
 	 *
-	 * @param {Number} width - The width of the effect.
-	 * @param {Number} height - The height of the effect.
+	 * @param {number} width - The width of the effect.
+	 * @param {number} height - The height of the effect.
 	 */
 	setSize( width, height ) {
 

--- a/examples/jsm/tsl/display/SobelOperatorNode.js
+++ b/examples/jsm/tsl/display/SobelOperatorNode.js
@@ -36,7 +36,7 @@ class SobelOperatorNode extends TempNode {
 		 * The `updateBeforeType` is set to `NodeUpdateType.FRAME` since the node updates
 		 * its internal uniforms once per frame in `updateBefore()`.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default 'frame'
 		 */
 		this.updateBeforeType = NodeUpdateType.FRAME;

--- a/examples/jsm/tsl/display/StereoCompositePassNode.js
+++ b/examples/jsm/tsl/display/StereoCompositePassNode.js
@@ -37,7 +37,7 @@ class StereoCompositePassNode extends PassNode {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -92,7 +92,7 @@ class StereoCompositePassNode extends PassNode {
 	/**
 	 * Updates the internal stereo camera.
 	 *
-	 * @param {Number} coordinateSystem - The current coordinate system.
+	 * @param {number} coordinateSystem - The current coordinate system.
 	 */
 	updateStereoCamera( coordinateSystem ) {
 
@@ -105,8 +105,8 @@ class StereoCompositePassNode extends PassNode {
 	/**
 	 * Sets the size of the pass.
 	 *
-	 * @param {Number} width - The width of the pass.
-	 * @param {Number} height - The height of the pass.
+	 * @param {number} width - The width of the pass.
+	 * @param {number} height - The height of the pass.
 	 */
 	setSize( width, height ) {
 

--- a/examples/jsm/tsl/display/StereoPassNode.js
+++ b/examples/jsm/tsl/display/StereoPassNode.js
@@ -31,7 +31,7 @@ class StereoPassNode extends PassNode {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */

--- a/examples/jsm/tsl/display/TRAAPassNode.js
+++ b/examples/jsm/tsl/display/TRAAPassNode.js
@@ -39,7 +39,7 @@ class TRAAPassNode extends PassNode {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -56,7 +56,7 @@ class TRAAPassNode extends PassNode {
 		/**
 		 * The clear alpha of the pass.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @default 0
 		 */
 		this.clearAlpha = 0;
@@ -65,7 +65,7 @@ class TRAAPassNode extends PassNode {
 		 * The jitter index selects the current camera offset value.
 		 *
 		 * @private
-		 * @type {Number}
+		 * @type {number}
 		 * @default 0
 		 */
 		this._jitterIndex = 0;
@@ -116,9 +116,9 @@ class TRAAPassNode extends PassNode {
 	/**
 	 * Sets the size of the effect.
 	 *
-	 * @param {Number} width - The width of the effect.
-	 * @param {Number} height - The height of the effect.
-	 * @return {Boolean} Whether the TRAA needs a restart or not. That is required after a resize since buffer data with different sizes can't be resolved.
+	 * @param {number} width - The width of the effect.
+	 * @param {number} height - The height of the effect.
+	 * @return {boolean} Whether the TRAA needs a restart or not. That is required after a resize since buffer data with different sizes can't be resolved.
 	 */
 	setSize( width, height ) {
 

--- a/examples/jsm/tsl/display/TransitionNode.js
+++ b/examples/jsm/tsl/display/TransitionNode.js
@@ -132,9 +132,9 @@ export default TransitionNode;
  * @param {Node<vec4>} nodeA - A texture node that represents the beauty pass of the first scene.
  * @param {Node<vec4>} nodeB - A texture node that represents the beauty pass of the second scene.
  * @param {Node<vec4>} mixTextureNode - A texture that defines how the transition effect should look like.
- * @param {Node<float> | Number} mixRatio - The interpolation factor that controls the mix.
- * @param {Node<float> | Number} threshold - Can be used to tweak the linear interpolation.
- * @param {Node<float> | Number} useTexture - Whether `mixTextureNode` should influence the transition or not.
+ * @param {Node<float> | number} mixRatio - The interpolation factor that controls the mix.
+ * @param {Node<float> | number} threshold - Can be used to tweak the linear interpolation.
+ * @param {Node<float> | number} useTexture - Whether `mixTextureNode` should influence the transition or not.
  * @returns {TransitionNode}
  */
 export const transition = ( nodeA, nodeB, mixTextureNode, mixRatio, threshold, useTexture ) => nodeObject( new TransitionNode( convertToTexture( nodeA ), convertToTexture( nodeB ), convertToTexture( mixTextureNode ), nodeObject( mixRatio ), nodeObject( threshold ), nodeObject( useTexture ) ) );

--- a/examples/jsm/utils/BufferGeometryUtils.js
+++ b/examples/jsm/utils/BufferGeometryUtils.js
@@ -101,7 +101,7 @@ function computeMikkTSpaceTangents( geometry, MikkTSpace, negateSign = true ) {
 
 /**
  * @param  {Array<BufferGeometry>} geometries
- * @param  {Boolean} useGroups
+ * @param  {boolean} useGroups
  * @return {BufferGeometry}
  */
 function mergeGeometries( geometries, useGroups = false ) {

--- a/examples/jsm/utils/GeometryCompressionUtils.js
+++ b/examples/jsm/utils/GeometryCompressionUtils.js
@@ -18,7 +18,7 @@ import {
  * Make the input geometry's normal attribute encoded and compressed by 3 different methods.
  *
  * @param {THREE.BufferGeometry} geometry
- * @param {String} encodeMethod		"DEFAULT" || "OCT1Byte" || "OCT2Byte" || "ANGLES"
+ * @param {string} encodeMethod		"DEFAULT" || "OCT1Byte" || "OCT2Byte" || "ANGLES"
  *
  */
 function compressNormals( geometry, encodeMethod ) {

--- a/examples/jsm/webxr/XRControllerModelFactory.js
+++ b/examples/jsm/webxr/XRControllerModelFactory.js
@@ -55,7 +55,7 @@ class XRControllerModel extends Object3D {
 	 * Polls data from the XRInputSource and updates the model's components to match
 	 * the real world data
 	 *
-	 * @param {Boolean} force
+	 * @param {boolean} force
 	 */
 	updateMatrixWorld( force ) {
 

--- a/src/extras/TextureUtils.js
+++ b/src/extras/TextureUtils.js
@@ -70,11 +70,11 @@ function fill( texture ) {
  * Given the width, height, format, and type of a texture. Determines how many
  * bytes must be used to represent the texture.
  *
- * @param {Number} width
- * @param {Number} height
- * @param {Number} format
- * @param {Number} type
- * @return {Number} The number of bytes required to represent the texture.
+ * @param {number} width
+ * @param {number} height
+ * @param {number} format
+ * @param {number} type
+ * @return {number} The number of bytes required to represent the texture.
  */
 function getByteLength( width, height, format, type ) {
 

--- a/src/loaders/nodes/NodeLoader.js
+++ b/src/loaders/nodes/NodeLoader.js
@@ -22,14 +22,14 @@ class NodeLoader extends Loader {
 		/**
 		 * Represents a dictionary of textures.
 		 *
-		 * @type {Object<String,Texture>}
+		 * @type {Object<string,Texture>}
 		 */
 		this.textures = {};
 
 		/**
 		 * Represents a dictionary of node types.
 		 *
-		 * @type {Object<String,Node.constructor>}
+		 * @type {Object<string,Node.constructor>}
 		 */
 		this.nodes = {};
 
@@ -38,7 +38,7 @@ class NodeLoader extends Loader {
 	/**
 	 * Loads the node definitions from the given URL.
 	 *
-	 * @param {String} url - The path/URL of the file to be loaded.
+	 * @param {string} url - The path/URL of the file to be loaded.
 	 * @param {Function} onLoad - Will be called when load completes.
 	 * @param {Function} onProgress - Will be called while load progresses.
 	 * @param {Function} onError - Will be called when errors are thrown during the loading process.
@@ -79,7 +79,7 @@ class NodeLoader extends Loader {
 	 * Parse the node dependencies for the loaded node.
 	 *
 	 * @param {Object} json - The JSON definition
-	 * @return {Object<String,Node>} A dictionary with node dependencies.
+	 * @return {Object<string,Node>} A dictionary with node dependencies.
 	 */
 	parseNodes( json ) {
 
@@ -142,7 +142,7 @@ class NodeLoader extends Loader {
 	/**
 	 * Defines the dictionary of textures.
 	 *
-	 * @param {Object<String,Texture>} value - The texture library defines as `<uuid,texture>`.
+	 * @param {Object<string,Texture>} value - The texture library defines as `<uuid,texture>`.
 	 * @return {NodeLoader} A reference to this loader.
 	 */
 	setTextures( value ) {
@@ -155,7 +155,7 @@ class NodeLoader extends Loader {
 	/**
 	 * Defines the dictionary of node types.
 	 *
-	 * @param {Object<String,Node.constructor>} value - The node library defined as `<classname,class>`.
+	 * @param {Object<string,Node.constructor>} value - The node library defined as `<classname,class>`.
 	 * @return {NodeLoader} A reference to this loader.
 	 */
 	setNodes( value ) {
@@ -168,7 +168,7 @@ class NodeLoader extends Loader {
 	/**
 	 * Creates a node object from the given type.
 	 *
-	 * @param {String} type - The node type.
+	 * @param {string} type - The node type.
 	 * @return {Node} The created node instance.
 	 */
 	createNodeFromType( type ) {

--- a/src/loaders/nodes/NodeMaterialLoader.js
+++ b/src/loaders/nodes/NodeMaterialLoader.js
@@ -19,14 +19,14 @@ class NodeMaterialLoader extends MaterialLoader {
 		/**
 		 * Represents a dictionary of node types.
 		 *
-		 * @type {Object<String,Node.constructor>}
+		 * @type {Object<string,Node.constructor>}
 		 */
 		this.nodes = {};
 
 		/**
 		 * Represents a dictionary of node material types.
 		 *
-		 * @type {Object<String,NodeMaterial.constructor>}
+		 * @type {Object<string,NodeMaterial.constructor>}
 		 */
 		this.nodeMaterials = {};
 
@@ -60,7 +60,7 @@ class NodeMaterialLoader extends MaterialLoader {
 	/**
 	 * Defines the dictionary of node types.
 	 *
-	 * @param {Object<String,Node.constructor>} value - The node library defined as `<classname,class>`.
+	 * @param {Object<string,Node.constructor>} value - The node library defined as `<classname,class>`.
 	 * @return {NodeLoader} A reference to this loader.
 	 */
 	setNodes( value ) {
@@ -73,7 +73,7 @@ class NodeMaterialLoader extends MaterialLoader {
 	/**
 	 * Defines the dictionary of node material types.
 	 *
-	 * @param {Object<String,NodeMaterial.constructor>} value - The node material library defined as `<classname,class>`.
+	 * @param {Object<string,NodeMaterial.constructor>} value - The node material library defined as `<classname,class>`.
 	 * @return {NodeLoader} A reference to this loader.
 	 */
 	setNodeMaterials( value ) {
@@ -86,7 +86,7 @@ class NodeMaterialLoader extends MaterialLoader {
 	/**
 	 * Creates a node material from the given type.
 	 *
-	 * @param {String} type - The node material type.
+	 * @param {string} type - The node material type.
 	 * @return {Node} The created node material instance.
 	 */
 	createMaterialFromType( type ) {

--- a/src/loaders/nodes/NodeObjectLoader.js
+++ b/src/loaders/nodes/NodeObjectLoader.js
@@ -23,14 +23,14 @@ class NodeObjectLoader extends ObjectLoader {
 		/**
 		 * Represents a dictionary of node types.
 		 *
-		 * @type {Object<String,Node.constructor>}
+		 * @type {Object<string,Node.constructor>}
 		 */
 		this.nodes = {};
 
 		/**
 		 * Represents a dictionary of node material types.
 		 *
-		 * @type {Object<String,NodeMaterial.constructor>}
+		 * @type {Object<string,NodeMaterial.constructor>}
 		 */
 		this.nodeMaterials = {};
 
@@ -47,7 +47,7 @@ class NodeObjectLoader extends ObjectLoader {
 	/**
 	 * Defines the dictionary of node types.
 	 *
-	 * @param {Object<String,Node.constructor>} value - The node library defined as `<classname,class>`.
+	 * @param {Object<string,Node.constructor>} value - The node library defined as `<classname,class>`.
 	 * @return {NodeLoader} A reference to this loader.
 	 */
 	setNodes( value ) {
@@ -60,7 +60,7 @@ class NodeObjectLoader extends ObjectLoader {
 	/**
 	 * Defines the dictionary of node material types.
 	 *
-	 * @param {Object<String,NodeMaterial.constructor>} value - The node material library defined as `<classname,class>`.
+	 * @param {Object<string,NodeMaterial.constructor>} value - The node material library defined as `<classname,class>`.
 	 * @return {NodeLoader} A reference to this loader.
 	 */
 	setNodeMaterials( value ) {
@@ -93,8 +93,8 @@ class NodeObjectLoader extends ObjectLoader {
 	 * Parses the node objects from the given JSON and textures.
 	 *
 	 * @param {Object} json - The JSON definition
-	 * @param {Object<String,Texture>} textures - The texture library.
-	 * @return {Object<String,Node>}. The parsed nodes.
+	 * @param {Object<string,Texture>} textures - The texture library.
+	 * @return {Object<string,Node>}. The parsed nodes.
 	 */
 	parseNodes( json, textures ) {
 
@@ -116,8 +116,8 @@ class NodeObjectLoader extends ObjectLoader {
 	 * Parses the node objects from the given JSON and textures.
 	 *
 	 * @param {Object} json - The JSON definition
-	 * @param {Object<String,Texture>} textures - The texture library.
-	 * @return {Object<String,NodeMaterial>}. The parsed materials.
+	 * @param {Object<string,Texture>} textures - The texture library.
+	 * @return {Object<string,NodeMaterial>}. The parsed materials.
 	 */
 	parseMaterials( json, textures ) {
 

--- a/src/materials/nodes/Line2NodeMaterial.js
+++ b/src/materials/nodes/Line2NodeMaterial.js
@@ -42,7 +42,7 @@ class Line2NodeMaterial extends NodeMaterial {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -53,7 +53,7 @@ class Line2NodeMaterial extends NodeMaterial {
 		/**
 		 * Whether vertex colors should be used or not.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default false
 		 */
 		this.useColor = parameters.vertexColors;
@@ -61,7 +61,7 @@ class Line2NodeMaterial extends NodeMaterial {
 		/**
 		 * The dash offset.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @default 0
 		 */
 		this.dashOffset = 0;
@@ -69,7 +69,7 @@ class Line2NodeMaterial extends NodeMaterial {
 		/**
 		 * The line width.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @default 0
 		 */
 		this.lineWidth = 1;
@@ -118,7 +118,7 @@ class Line2NodeMaterial extends NodeMaterial {
 		 * Blending is set to `NoBlending` since transparency
 		 * is not supported, yet.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @default 0
 		 */
 		this.blending = NoBlending;
@@ -479,7 +479,7 @@ class Line2NodeMaterial extends NodeMaterial {
 	 * Whether the lines should sized in world units or not.
 	 * When set to `false` the unit is pixel.
 	 *
-	 * @type {Boolean}
+	 * @type {boolean}
 	 * @default false
 	 */
 	get worldUnits() {
@@ -502,7 +502,7 @@ class Line2NodeMaterial extends NodeMaterial {
 	/**
 	 * Whether the lines should be dashed or not.
 	 *
-	 * @type {Boolean}
+	 * @type {boolean}
 	 * @default false
 	 */
 	get dashed() {
@@ -525,7 +525,7 @@ class Line2NodeMaterial extends NodeMaterial {
 	/**
 	 * Whether alpha to coverage should be used or not.
 	 *
-	 * @type {Boolean}
+	 * @type {boolean}
 	 * @default true
 	 */
 	get alphaToCoverage() {

--- a/src/materials/nodes/LineBasicNodeMaterial.js
+++ b/src/materials/nodes/LineBasicNodeMaterial.js
@@ -29,7 +29,7 @@ class LineBasicNodeMaterial extends NodeMaterial {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */

--- a/src/materials/nodes/LineDashedNodeMaterial.js
+++ b/src/materials/nodes/LineDashedNodeMaterial.js
@@ -33,7 +33,7 @@ class LineDashedNodeMaterial extends NodeMaterial {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -44,7 +44,7 @@ class LineDashedNodeMaterial extends NodeMaterial {
 		/**
 		 * The dash offset.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @default 0
 		 */
 		this.dashOffset = 0;

--- a/src/materials/nodes/MeshBasicNodeMaterial.js
+++ b/src/materials/nodes/MeshBasicNodeMaterial.js
@@ -35,7 +35,7 @@ class MeshBasicNodeMaterial extends NodeMaterial {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -46,7 +46,7 @@ class MeshBasicNodeMaterial extends NodeMaterial {
 		 * this property to `true` since we use a lighting model to compute
 		 * the outgoing light of the fragment shader.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default true
 		 */
 		this.lights = true;

--- a/src/materials/nodes/MeshLambertNodeMaterial.js
+++ b/src/materials/nodes/MeshLambertNodeMaterial.js
@@ -31,7 +31,7 @@ class MeshLambertNodeMaterial extends NodeMaterial {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -40,7 +40,7 @@ class MeshLambertNodeMaterial extends NodeMaterial {
 		/**
 		 * Set to `true` because lambert materials react on lights.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default true
 		 */
 		this.lights = true;

--- a/src/materials/nodes/MeshMatcapNodeMaterial.js
+++ b/src/materials/nodes/MeshMatcapNodeMaterial.js
@@ -34,7 +34,7 @@ class MeshMatcapNodeMaterial extends NodeMaterial {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */

--- a/src/materials/nodes/MeshNormalNodeMaterial.js
+++ b/src/materials/nodes/MeshNormalNodeMaterial.js
@@ -34,7 +34,7 @@ class MeshNormalNodeMaterial extends NodeMaterial {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */

--- a/src/materials/nodes/MeshPhongNodeMaterial.js
+++ b/src/materials/nodes/MeshPhongNodeMaterial.js
@@ -34,7 +34,7 @@ class MeshPhongNodeMaterial extends NodeMaterial {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -43,7 +43,7 @@ class MeshPhongNodeMaterial extends NodeMaterial {
 		/**
 		 * Set to `true` because phong materials react on lights.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default true
 		 */
 		this.lights = true;

--- a/src/materials/nodes/MeshPhysicalNodeMaterial.js
+++ b/src/materials/nodes/MeshPhysicalNodeMaterial.js
@@ -36,7 +36,7 @@ class MeshPhysicalNodeMaterial extends MeshStandardNodeMaterial {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -272,7 +272,7 @@ class MeshPhysicalNodeMaterial extends MeshStandardNodeMaterial {
 	/**
 	 * Whether the lighting model should use clearcoat or not.
 	 *
-	 * @type {Boolean}
+	 * @type {boolean}
 	 * @default true
 	 */
 	get useClearcoat() {
@@ -284,7 +284,7 @@ class MeshPhysicalNodeMaterial extends MeshStandardNodeMaterial {
 	/**
 	 * Whether the lighting model should use iridescence or not.
 	 *
-	 * @type {Boolean}
+	 * @type {boolean}
 	 * @default true
 	 */
 	get useIridescence() {
@@ -296,7 +296,7 @@ class MeshPhysicalNodeMaterial extends MeshStandardNodeMaterial {
 	/**
 	 * Whether the lighting model should use sheen or not.
 	 *
-	 * @type {Boolean}
+	 * @type {boolean}
 	 * @default true
 	 */
 	get useSheen() {
@@ -308,7 +308,7 @@ class MeshPhysicalNodeMaterial extends MeshStandardNodeMaterial {
 	/**
 	 * Whether the lighting model should use anisotropy or not.
 	 *
-	 * @type {Boolean}
+	 * @type {boolean}
 	 * @default true
 	 */
 	get useAnisotropy() {
@@ -320,7 +320,7 @@ class MeshPhysicalNodeMaterial extends MeshStandardNodeMaterial {
 	/**
 	 * Whether the lighting model should use transmission or not.
 	 *
-	 * @type {Boolean}
+	 * @type {boolean}
 	 * @default true
 	 */
 	get useTransmission() {
@@ -332,7 +332,7 @@ class MeshPhysicalNodeMaterial extends MeshStandardNodeMaterial {
 	/**
 	 * Whether the lighting model should use dispersion or not.
 	 *
-	 * @type {Boolean}
+	 * @type {boolean}
 	 * @default true
 	 */
 	get useDispersion() {

--- a/src/materials/nodes/MeshSSSNodeMaterial.js
+++ b/src/materials/nodes/MeshSSSNodeMaterial.js
@@ -14,13 +14,13 @@ class SSSLightingModel extends PhysicalLightingModel {
 	/**
 	 * Constructs a new physical lighting model.
 	 *
-	 * @param {Boolean} [clearcoat=false] - Whether clearcoat is supported or not.
-	 * @param {Boolean} [sheen=false] - Whether sheen is supported or not.
-	 * @param {Boolean} [iridescence=false] - Whether iridescence is supported or not.
-	 * @param {Boolean} [anisotropy=false] - Whether anisotropy is supported or not.
-	 * @param {Boolean} [transmission=false] - Whether transmission is supported or not.
-	 * @param {Boolean} [dispersion=false] - Whether dispersion is supported or not.
-	 * @param {Boolean} [sss=false] - Whether SSS is supported or not.
+	 * @param {boolean} [clearcoat=false] - Whether clearcoat is supported or not.
+	 * @param {boolean} [sheen=false] - Whether sheen is supported or not.
+	 * @param {boolean} [iridescence=false] - Whether iridescence is supported or not.
+	 * @param {boolean} [anisotropy=false] - Whether anisotropy is supported or not.
+	 * @param {boolean} [transmission=false] - Whether transmission is supported or not.
+	 * @param {boolean} [dispersion=false] - Whether dispersion is supported or not.
+	 * @param {boolean} [sss=false] - Whether SSS is supported or not.
 	 */
 	constructor( clearcoat = false, sheen = false, iridescence = false, anisotropy = false, transmission = false, dispersion = false, sss = false ) {
 
@@ -29,7 +29,7 @@ class SSSLightingModel extends PhysicalLightingModel {
 		/**
 		 * Whether the lighting model should use SSS or not.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default false
 		 */
 		this.useSSS = sss;
@@ -138,7 +138,7 @@ class MeshSSSNodeMaterial extends MeshPhysicalNodeMaterial {
 	/**
 	 * Whether the lighting model should use SSS or not.
 	 *
-	 * @type {Boolean}
+	 * @type {boolean}
 	 * @default true
 	 */
 	get useSSS() {

--- a/src/materials/nodes/MeshStandardNodeMaterial.js
+++ b/src/materials/nodes/MeshStandardNodeMaterial.js
@@ -36,7 +36,7 @@ class MeshStandardNodeMaterial extends NodeMaterial {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -45,7 +45,7 @@ class MeshStandardNodeMaterial extends NodeMaterial {
 		/**
 		 * Set to `true` because standard materials react on lights.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default true
 		 */
 		this.lights = true;

--- a/src/materials/nodes/MeshToonNodeMaterial.js
+++ b/src/materials/nodes/MeshToonNodeMaterial.js
@@ -30,7 +30,7 @@ class MeshToonNodeMaterial extends NodeMaterial {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -39,7 +39,7 @@ class MeshToonNodeMaterial extends NodeMaterial {
 		/**
 		 * Set to `true` because toon materials react on lights.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default true
 		 */
 		this.lights = true;

--- a/src/materials/nodes/NodeMaterial.js
+++ b/src/materials/nodes/NodeMaterial.js
@@ -41,7 +41,7 @@ class NodeMaterial extends Material {
 	/**
 	 * Represents the type of the node material.
 	 *
-	 * @type {String}
+	 * @type {string}
 	 */
 	get type() {
 
@@ -61,7 +61,7 @@ class NodeMaterial extends Material {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -70,7 +70,7 @@ class NodeMaterial extends Material {
 		/**
 		 * Whether this material is affected by fog or not.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default true
 		 */
 		this.fog = true;
@@ -78,7 +78,7 @@ class NodeMaterial extends Material {
 		/**
 		 * Whether this material is affected by lights or not.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default false
 		 */
 		this.lights = false;
@@ -88,7 +88,7 @@ class NodeMaterial extends Material {
 		 * This property is managed by the engine and should not be
 		 * modified by apps.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default false
 		 */
 		this.hardwareClipping = false;
@@ -368,7 +368,7 @@ class NodeMaterial extends Material {
 	 * Allows to define a custom cache key that influence the material key computation
 	 * for render objects.
 	 *
-	 * @return {String} The custom cache key.
+	 * @return {string} The custom cache key.
 	 */
 	customProgramCacheKey() {
 
@@ -1062,7 +1062,7 @@ class NodeMaterial extends Material {
 	/**
 	 * Serializes this material to JSON.
 	 *
-	 * @param {(Object|String)?} meta - The meta information for serialization.
+	 * @param {(Object|string)?} meta - The meta information for serialization.
 	 * @return {Object} The serialized node.
 	 */
 	toJSON( meta ) {

--- a/src/materials/nodes/PointsNodeMaterial.js
+++ b/src/materials/nodes/PointsNodeMaterial.js
@@ -43,7 +43,7 @@ class PointsNodeMaterial extends SpriteNodeMaterial {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -128,7 +128,7 @@ class PointsNodeMaterial extends SpriteNodeMaterial {
 	/**
 	 * Whether alpha to coverage should be used or not.
 	 *
-	 * @type {Boolean}
+	 * @type {boolean}
 	 * @default true
 	 */
 	get alphaToCoverage() {

--- a/src/materials/nodes/ShadowNodeMaterial.js
+++ b/src/materials/nodes/ShadowNodeMaterial.js
@@ -30,7 +30,7 @@ class ShadowNodeMaterial extends NodeMaterial {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -40,7 +40,7 @@ class ShadowNodeMaterial extends NodeMaterial {
 		 * Set to `true` because so it's possible to implement
 		 * the shadow mask effect.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default true
 		 */
 		this.lights = true;

--- a/src/materials/nodes/SpriteNodeMaterial.js
+++ b/src/materials/nodes/SpriteNodeMaterial.js
@@ -36,7 +36,7 @@ class SpriteNodeMaterial extends NodeMaterial {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -89,7 +89,7 @@ class SpriteNodeMaterial extends NodeMaterial {
 		/**
 		 * In Sprites, the transparent property is enabled by default.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default true
 		 */
 		this.transparent = true;
@@ -173,7 +173,7 @@ class SpriteNodeMaterial extends NodeMaterial {
 	/**
 	 * Whether to use size attenuation or not.
 	 *
-	 * @type {Boolean}
+	 * @type {boolean}
 	 * @default true
 	 */
 	get sizeAttenuation() {

--- a/src/materials/nodes/VolumeNodeMaterial.js
+++ b/src/materials/nodes/VolumeNodeMaterial.js
@@ -36,7 +36,7 @@ class VolumeNodeMaterial extends NodeMaterial {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -62,7 +62,7 @@ class VolumeNodeMaterial extends NodeMaterial {
 		 * This number of samples for each ray that hits the mesh's surface
 		 * and travels through the volume.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @default 100
 		 */
 		this.steps = 100;

--- a/src/materials/nodes/manager/NodeMaterialObserver.js
+++ b/src/materials/nodes/manager/NodeMaterialObserver.js
@@ -76,28 +76,28 @@ class NodeMaterialObserver {
 		/**
 		 * Whether the material uses node objects or not.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 */
 		this.hasNode = this.containsNode( builder );
 
 		/**
 		 * Whether the node builder's 3D object is animated or not.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 */
 		this.hasAnimation = builder.object.isSkinnedMesh === true;
 
 		/**
 		 * A list of all possible material uniforms
 		 *
-		 * @type {Array<String>}
+		 * @type {Array<string>}
 		 */
 		this.refreshUniforms = refreshUniforms;
 
 		/**
 		 * Holds the current render ID from the node frame.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @default 0
 		 */
 		this.renderId = 0;
@@ -108,7 +108,7 @@ class NodeMaterialObserver {
 	 * Returns `true` if the given render object is verified for the first time of this observer.
 	 *
 	 * @param {RenderObject} renderObject - The render object.
-	 * @return {Boolean} Whether the given render object is verified for the first time of this observer.
+	 * @return {boolean} Whether the given render object is verified for the first time of this observer.
 	 */
 	firstInitialization( renderObject ) {
 
@@ -216,7 +216,7 @@ class NodeMaterialObserver {
 	 * node properties.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {Boolean} Whether the node builder's material uses node properties or not.
+	 * @return {boolean} Whether the node builder's material uses node properties or not.
 	 */
 	containsNode( builder ) {
 
@@ -281,7 +281,7 @@ class NodeMaterialObserver {
 	 * Returns `true` if the given render object has not changed its state.
 	 *
 	 * @param {RenderObject} renderObject - The render object.
-	 * @return {Boolean} Whether the given render object has changed its state or not.
+	 * @return {boolean} Whether the given render object has changed its state or not.
 	 */
 	equals( renderObject ) {
 
@@ -475,7 +475,7 @@ class NodeMaterialObserver {
 	 *
 	 * @param {RenderObject} renderObject - The render object.
 	 * @param {NodeFrame} nodeFrame - The current node frame.
-	 * @return {Boolean} Whether the given render object requires a refresh or not.
+	 * @return {boolean} Whether the given render object requires a refresh or not.
 	 */
 	needsRefresh( renderObject, nodeFrame ) {
 

--- a/src/nodes/accessors/Arrays.js
+++ b/src/nodes/accessors/Arrays.js
@@ -8,8 +8,8 @@ import { getLengthFromType, getTypedArrayFromType } from '../core/NodeUtils.js';
  *
  * @tsl
  * @function
- * @param {Number|TypedArray} count - The data count. It is also valid to pass a typed array as an argument.
- * @param {String|Struct} [type='float'] - The data type.
+ * @param {number|TypedArray} count - The data count. It is also valid to pass a typed array as an argument.
+ * @param {string|Struct} [type='float'] - The data type.
  * @returns {StorageBufferNode}
  */
 export const attributeArray = ( count, type = 'float' ) => {
@@ -40,8 +40,8 @@ export const attributeArray = ( count, type = 'float' ) => {
  *
  * @tsl
  * @function
- * @param {Number|TypedArray} count - The data count. It is also valid to pass a typed array as an argument.
- * @param {String|Struct} [type='float'] - The data type.
+ * @param {number|TypedArray} count - The data count. It is also valid to pass a typed array as an argument.
+ * @param {string|Struct} [type='float'] - The data type.
  * @returns {StorageBufferNode}
  */
 export const instancedArray = ( count, type = 'float' ) => {

--- a/src/nodes/accessors/BufferAttributeNode.js
+++ b/src/nodes/accessors/BufferAttributeNode.js
@@ -40,9 +40,9 @@ class BufferAttributeNode extends InputNode {
 	 * Constructs a new buffer attribute node.
 	 *
 	 * @param {BufferAttribute|InterleavedBuffer|TypedArray} value - The attribute data.
-	 * @param {String?} [bufferType=null] - The buffer type (e.g. `'vec3'`).
-	 * @param {Number} [bufferStride=0] - The buffer stride.
-	 * @param {Number} [bufferOffset=0] - The buffer offset.
+	 * @param {string?} [bufferType=null] - The buffer type (e.g. `'vec3'`).
+	 * @param {number} [bufferStride=0] - The buffer stride.
+	 * @param {number} [bufferOffset=0] - The buffer offset.
 	 */
 	constructor( value, bufferType = null, bufferStride = 0, bufferOffset = 0 ) {
 
@@ -51,7 +51,7 @@ class BufferAttributeNode extends InputNode {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -60,7 +60,7 @@ class BufferAttributeNode extends InputNode {
 		/**
 		 * The buffer type (e.g. `'vec3'`).
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default null
 		 */
 		this.bufferType = bufferType;
@@ -68,7 +68,7 @@ class BufferAttributeNode extends InputNode {
 		/**
 		 * The buffer stride.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @default 0
 		 */
 		this.bufferStride = bufferStride;
@@ -76,7 +76,7 @@ class BufferAttributeNode extends InputNode {
 		/**
 		 * The buffer offset.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @default 0
 		 */
 		this.bufferOffset = bufferOffset;
@@ -85,7 +85,7 @@ class BufferAttributeNode extends InputNode {
 		 * The usage property. Set this to `THREE.DynamicDrawUsage` via `.setUsage()`,
 		 * if you are planning to update the attribute data per frame.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @default StaticDrawUsage
 		 */
 		this.usage = StaticDrawUsage;
@@ -93,7 +93,7 @@ class BufferAttributeNode extends InputNode {
 		/**
 		 * Whether the attribute is instanced or not.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default false
 		 */
 		this.instanced = false;
@@ -109,7 +109,7 @@ class BufferAttributeNode extends InputNode {
 		/**
 		 * `BufferAttributeNode` sets this property to `true` by default.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default true
 		 */
 		this.global = true;
@@ -129,7 +129,7 @@ class BufferAttributeNode extends InputNode {
 	 * and thus the hash should be shared as well.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The hash.
+	 * @return {string} The hash.
 	 */
 	getHash( builder ) {
 
@@ -160,7 +160,7 @@ class BufferAttributeNode extends InputNode {
 	 * the buffer attribute.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The node type.
+	 * @return {string} The node type.
 	 */
 	getNodeType( builder ) {
 
@@ -205,7 +205,7 @@ class BufferAttributeNode extends InputNode {
 	 * Generates the code snippet of the buffer attribute node.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The generated code snippet.
+	 * @return {string} The generated code snippet.
 	 */
 	generate( builder ) {
 
@@ -238,7 +238,7 @@ class BufferAttributeNode extends InputNode {
 	 * Overwrites the default implementation to return a fixed value `'bufferAttribute'`.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The input type.
+	 * @return {string} The input type.
 	 */
 	getInputType( /*builder*/ ) {
 
@@ -249,7 +249,7 @@ class BufferAttributeNode extends InputNode {
 	/**
 	 * Sets the `usage` property to the given value.
 	 *
-	 * @param {Number} value - The usage to set.
+	 * @param {number} value - The usage to set.
 	 * @return {BufferAttributeNode} A reference to this node.
 	 */
 	setUsage( value ) {
@@ -269,7 +269,7 @@ class BufferAttributeNode extends InputNode {
 	/**
 	 * Sets the `instanced` property to the given value.
 	 *
-	 * @param {Boolean} value - The value to set.
+	 * @param {boolean} value - The value to set.
 	 * @return {BufferAttributeNode} A reference to this node.
 	 */
 	setInstanced( value ) {
@@ -290,9 +290,9 @@ export default BufferAttributeNode;
  * @tsl
  * @function
  * @param {BufferAttribute|InterleavedBuffer|TypedArray} array - The attribute data.
- * @param {String?} [type=null] - The buffer type (e.g. `'vec3'`).
- * @param {Number} [stride=0] - The buffer stride.
- * @param {Number} [offset=0] - The buffer offset.
+ * @param {string?} [type=null] - The buffer type (e.g. `'vec3'`).
+ * @param {number} [stride=0] - The buffer stride.
+ * @param {number} [offset=0] - The buffer offset.
  * @returns {BufferAttributeNode}
  */
 export const bufferAttribute = ( array, type = null, stride = 0, offset = 0 ) => nodeObject( new BufferAttributeNode( array, type, stride, offset ) );
@@ -304,9 +304,9 @@ export const bufferAttribute = ( array, type = null, stride = 0, offset = 0 ) =>
  * @tsl
  * @function
  * @param {BufferAttribute|InterleavedBuffer|TypedArray} array - The attribute data.
- * @param {String?} [type=null] - The buffer type (e.g. `'vec3'`).
- * @param {Number} [stride=0] - The buffer stride.
- * @param {Number} [offset=0] - The buffer offset.
+ * @param {string?} [type=null] - The buffer type (e.g. `'vec3'`).
+ * @param {number} [stride=0] - The buffer stride.
+ * @param {number} [offset=0] - The buffer offset.
  * @returns {BufferAttributeNode}
  */
 export const dynamicBufferAttribute = ( array, type = null, stride = 0, offset = 0 ) => bufferAttribute( array, type, stride, offset ).setUsage( DynamicDrawUsage );
@@ -317,9 +317,9 @@ export const dynamicBufferAttribute = ( array, type = null, stride = 0, offset =
  * @tsl
  * @function
  * @param {BufferAttribute|InterleavedBuffer|TypedArray} array - The attribute data.
- * @param {String?} [type=null] - The buffer type (e.g. `'vec3'`).
- * @param {Number} [stride=0] - The buffer stride.
- * @param {Number} [offset=0] - The buffer offset.
+ * @param {string?} [type=null] - The buffer type (e.g. `'vec3'`).
+ * @param {number} [stride=0] - The buffer stride.
+ * @param {number} [offset=0] - The buffer offset.
  * @returns {BufferAttributeNode}
  */
 export const instancedBufferAttribute = ( array, type = null, stride = 0, offset = 0 ) => bufferAttribute( array, type, stride, offset ).setInstanced( true );
@@ -330,9 +330,9 @@ export const instancedBufferAttribute = ( array, type = null, stride = 0, offset
  * @tsl
  * @function
  * @param {BufferAttribute|InterleavedBuffer|TypedArray} array - The attribute data.
- * @param {String?} [type=null] - The buffer type (e.g. `'vec3'`).
- * @param {Number} [stride=0] - The buffer stride.
- * @param {Number} [offset=0] - The buffer offset.
+ * @param {string?} [type=null] - The buffer type (e.g. `'vec3'`).
+ * @param {number} [stride=0] - The buffer stride.
+ * @param {number} [offset=0] - The buffer offset.
  * @returns {BufferAttributeNode}
  */
 export const instancedDynamicBufferAttribute = ( array, type = null, stride = 0, offset = 0 ) => dynamicBufferAttribute( array, type, stride, offset ).setInstanced( true );

--- a/src/nodes/accessors/BufferNode.js
+++ b/src/nodes/accessors/BufferNode.js
@@ -26,9 +26,9 @@ class BufferNode extends UniformNode {
 	/**
 	 * Constructs a new buffer node.
 	 *
-	 * @param {Array<Number>} value - Array-like buffer data.
-	 * @param {String} bufferType - The data type of the buffer.
-	 * @param {Number} [bufferCount=0] - The count of buffer elements.
+	 * @param {Array<number>} value - Array-like buffer data.
+	 * @param {string} bufferType - The data type of the buffer.
+	 * @param {number} [bufferCount=0] - The count of buffer elements.
 	 */
 	constructor( value, bufferType, bufferCount = 0 ) {
 
@@ -37,7 +37,7 @@ class BufferNode extends UniformNode {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -46,14 +46,14 @@ class BufferNode extends UniformNode {
 		/**
 		 * The data type of the buffer.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.bufferType = bufferType;
 
 		/**
 		 * The uniform node that holds the value of the reference node.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @default 0
 		 */
 		this.bufferCount = bufferCount;
@@ -64,7 +64,7 @@ class BufferNode extends UniformNode {
 	 * The data type of the buffer elements.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The element type.
+	 * @return {string} The element type.
 	 */
 	getElementType( builder ) {
 
@@ -76,7 +76,7 @@ class BufferNode extends UniformNode {
 	 * Overwrites the default implementation to return a fixed value `'buffer'`.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The input type.
+	 * @return {string} The input type.
 	 */
 	getInputType( /*builder*/ ) {
 
@@ -94,8 +94,8 @@ export default BufferNode;
  * @tsl
  * @function
  * @param {Array} value - Array-like buffer data.
- * @param {String} type - The data type of a buffer element.
- * @param {Number} count - The count of buffer elements.
+ * @param {string} type - The data type of a buffer element.
+ * @param {number} count - The count of buffer elements.
  * @returns {BufferNode}
  */
 export const buffer = ( value, type, count ) => nodeObject( new BufferNode( value, type, count ) );

--- a/src/nodes/accessors/BuiltinNode.js
+++ b/src/nodes/accessors/BuiltinNode.js
@@ -12,7 +12,7 @@ class BuiltinNode extends Node {
 	/**
 	 * Constructs a new builtin node.
 	 *
-	 * @param {String} name - The name of the built-in shader variable.
+	 * @param {string} name - The name of the built-in shader variable.
 	 */
 	constructor( name ) {
 
@@ -21,14 +21,14 @@ class BuiltinNode extends Node {
 		/**
 		 * The name of the built-in shader variable.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.name = name;
 
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -40,7 +40,7 @@ class BuiltinNode extends Node {
 	 * Generates the code snippet of the builtin node.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The generated code snippet.
+	 * @return {string} The generated code snippet.
 	 */
 	generate( /* builder */ ) {
 
@@ -57,7 +57,7 @@ export default BuiltinNode;
  *
  * @tsl
  * @function
- * @param {String} name - The name of the built-in shader variable.
+ * @param {string} name - The name of the built-in shader variable.
  * @returns {BuiltinNode}
  */
 export const builtin = nodeProxy( BuiltinNode );

--- a/src/nodes/accessors/CubeTextureNode.js
+++ b/src/nodes/accessors/CubeTextureNode.js
@@ -32,7 +32,7 @@ class CubeTextureNode extends TextureNode {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -44,7 +44,7 @@ class CubeTextureNode extends TextureNode {
 	 * Overwrites the default implementation to return a fixed value `'cubeTexture'`.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The input type.
+	 * @return {string} The input type.
 	 */
 	getInputType( /*builder*/ ) {
 
@@ -83,7 +83,7 @@ class CubeTextureNode extends TextureNode {
 	 * Overwritten with an empty implementation since the `updateMatrix` flag is ignored
 	 * for cube textures. The uv transformation matrix is not applied to cube textures.
 	 *
-	 * @param {Boolean} value - The update toggle.
+	 * @param {boolean} value - The update toggle.
 	 */
 	setUpdateMatrix( /*updateMatrix*/ ) { } // Ignore .updateMatrix for CubeTextureNode
 
@@ -116,7 +116,7 @@ class CubeTextureNode extends TextureNode {
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
 	 * @param {Node} cubeUV - The uv node to generate code for.
-	 * @return {String} The generated code snippet.
+	 * @return {string} The generated code snippet.
 	 */
 	generateUV( builder, cubeUV ) {
 

--- a/src/nodes/accessors/InstanceNode.js
+++ b/src/nodes/accessors/InstanceNode.js
@@ -31,7 +31,7 @@ class InstanceNode extends Node {
 	/**
 	 * Constructs a new instance node.
 	 *
-	 * @param {Number} count - The number of instances.
+	 * @param {number} count - The number of instances.
 	 * @param {InstancedBufferAttribute} instanceMatrix - Instanced buffer attribute representing the instance transformations.
 	 * @param {InstancedBufferAttribute} instanceColor - Instanced buffer attribute representing the instance colors.
 	 */
@@ -42,7 +42,7 @@ class InstanceNode extends Node {
 		/**
 		 * The number of instances.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 */
 		this.count = count;
 
@@ -78,7 +78,7 @@ class InstanceNode extends Node {
 		 * The update type is set to `frame` since an update
 		 * of instanced buffer data must be checked per frame.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default 'frame'
 		 */
 		this.updateType = NodeUpdateType.FRAME;
@@ -215,7 +215,7 @@ export default InstanceNode;
  *
  * @tsl
  * @function
- * @param {Number} count - The number of instances.
+ * @param {number} count - The number of instances.
  * @param {InstancedBufferAttribute} instanceMatrix - Instanced buffer attribute representing the instance transformations.
  * @param {InstancedBufferAttribute} instanceColor - Instanced buffer attribute representing the instance colors.
  * @returns {InstanceNode}

--- a/src/nodes/accessors/MaterialNode.js
+++ b/src/nodes/accessors/MaterialNode.js
@@ -29,7 +29,7 @@ class MaterialNode extends Node {
 	/**
 	 * Constructs a new material node.
 	 *
-	 * @param {String} scope - The scope defines what kind of material property is referred by the node.
+	 * @param {string} scope - The scope defines what kind of material property is referred by the node.
 	 */
 	constructor( scope ) {
 
@@ -38,7 +38,7 @@ class MaterialNode extends Node {
 		/**
 		 * The scope defines what material property is referred by the node.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.scope = scope;
 
@@ -47,8 +47,8 @@ class MaterialNode extends Node {
 	/**
 	 * Returns a cached reference node for the given property and type.
 	 *
-	 * @param {String} property - The name of the material property.
-	 * @param {String} type - The uniform type of the property.
+	 * @param {string} property - The name of the material property.
+	 * @param {string} type - The uniform type of the property.
 	 * @return {MaterialReferenceNode} A material reference node representing the property access.
 	 */
 	getCache( property, type ) {
@@ -70,7 +70,7 @@ class MaterialNode extends Node {
 	/**
 	 * Returns a float-typed material reference node for the given property name.
 	 *
-	 * @param {String} property - The name of the material property.
+	 * @param {string} property - The name of the material property.
 	 * @return {MaterialReferenceNode<float>} A material reference node representing the property access.
 	 */
 	getFloat( property ) {
@@ -82,7 +82,7 @@ class MaterialNode extends Node {
 	/**
 	 * Returns a color-typed material reference node for the given property name.
 	 *
-	 * @param {String} property - The name of the material property.
+	 * @param {string} property - The name of the material property.
 	 * @return {MaterialReferenceNode<color>} A material reference node representing the property access.
 	 */
 	getColor( property ) {
@@ -94,7 +94,7 @@ class MaterialNode extends Node {
 	/**
 	 * Returns a texture-typed material reference node for the given property name.
 	 *
-	 * @param {String} property - The name of the material property.
+	 * @param {string} property - The name of the material property.
 	 * @return {MaterialReferenceNode} A material reference node representing the property access.
 	 */
 	getTexture( property ) {

--- a/src/nodes/accessors/MaterialReferenceNode.js
+++ b/src/nodes/accessors/MaterialReferenceNode.js
@@ -23,8 +23,8 @@ class MaterialReferenceNode extends ReferenceNode {
 	/**
 	 * Constructs a new material reference node.
 	 *
-	 * @param {String} property - The name of the property the node refers to.
-	 * @param {String} inputType - The uniform type that should be used to represent the property value.
+	 * @param {string} property - The name of the property the node refers to.
+	 * @param {string} inputType - The uniform type that should be used to represent the property value.
 	 * @param {Material?} [material=null] - The material the property belongs to. When no material is set,
 	 * the node refers to the material of the current rendered object.
 	 */
@@ -44,7 +44,7 @@ class MaterialReferenceNode extends ReferenceNode {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -76,8 +76,8 @@ export default MaterialReferenceNode;
  *
  * @tsl
  * @function
- * @param {String} name - The name of the property the node refers to.
- * @param {String} type - The uniform type that should be used to represent the property value.
+ * @param {string} name - The name of the property the node refers to.
+ * @param {string} type - The uniform type that should be used to represent the property value.
  * @param {Material?} [material=null] - The material the property belongs to.
  * When no material is set, the node refers to the material of the current rendered object.
  * @returns {MaterialReferenceNode}

--- a/src/nodes/accessors/MorphNode.js
+++ b/src/nodes/accessors/MorphNode.js
@@ -196,7 +196,7 @@ class MorphNode extends Node {
 		/**
 		 * The update type overwritten since morph nodes are updated per object.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.updateType = NodeUpdateType.OBJECT;
 

--- a/src/nodes/accessors/Object3DNode.js
+++ b/src/nodes/accessors/Object3DNode.js
@@ -53,7 +53,7 @@ class Object3DNode extends Node {
 		/**
 		 * Overwritten since this type of node is updated per object.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default 'object'
 		 */
 		this.updateType = NodeUpdateType.OBJECT;
@@ -71,7 +71,7 @@ class Object3DNode extends Node {
 	/**
 	 * Overwritten since the node type is inferred from the scope.
 	 *
-	 * @return {String} The node type.
+	 * @return {string} The node type.
 	 */
 	getNodeType() {
 
@@ -140,7 +140,7 @@ class Object3DNode extends Node {
 	 * node also depends on the selected scope.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The generated code snippet.
+	 * @return {string} The generated code snippet.
 	 */
 	generate( builder ) {
 

--- a/src/nodes/accessors/PointUVNode.js
+++ b/src/nodes/accessors/PointUVNode.js
@@ -28,7 +28,7 @@ class PointUVNode extends Node {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */

--- a/src/nodes/accessors/ReferenceBaseNode.js
+++ b/src/nodes/accessors/ReferenceBaseNode.js
@@ -43,7 +43,7 @@ class ReferenceElementNode extends ArrayElementNode {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -55,7 +55,7 @@ class ReferenceElementNode extends ArrayElementNode {
 	 * This method is overwritten since the node type is inferred from
 	 * the uniform type of the reference node.
 	 *
-	 * @return {String} The node type.
+	 * @return {string} The node type.
 	 */
 	getNodeType() {
 
@@ -94,10 +94,10 @@ class ReferenceBaseNode extends Node {
 	/**
 	 * Constructs a new reference base node.
 	 *
-	 * @param {String} property - The name of the property the node refers to.
-	 * @param {String} uniformType - The uniform type that should be used to represent the property value.
+	 * @param {string} property - The name of the property the node refers to.
+	 * @param {string} uniformType - The uniform type that should be used to represent the property value.
 	 * @param {Object?} [object=null] - The object the property belongs to.
-	 * @param {Number?} [count=null] - When the linked property is an array-like, this parameter defines its length.
+	 * @param {number?} [count=null] - When the linked property is an array-like, this parameter defines its length.
 	 */
 	constructor( property, uniformType, object = null, count = null ) {
 
@@ -106,14 +106,14 @@ class ReferenceBaseNode extends Node {
 		/**
 		 * The name of the property the node refers to.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.property = property;
 
 		/**
 		 * The uniform type that should be used to represent the property value.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.uniformType = uniformType;
 
@@ -128,7 +128,7 @@ class ReferenceBaseNode extends Node {
 		/**
 		 * When the linked property is an array, this parameter defines its length.
 		 *
-		 * @type {Number?}
+		 * @type {number?}
 		 * @default null
 		 */
 		this.count = count;
@@ -137,7 +137,7 @@ class ReferenceBaseNode extends Node {
 		 * The property name might have dots so nested properties can be referred.
 		 * The hierarchy of the names is stored inside this array.
 		 *
-		 * @type {Array<String>}
+		 * @type {Array<string>}
 		 */
 		this.properties = property.split( '.' );
 
@@ -169,7 +169,7 @@ class ReferenceBaseNode extends Node {
 		/**
 		 * Overwritten since reference nodes are updated per object.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default 'object'
 		 */
 		this.updateType = NodeUpdateType.OBJECT;
@@ -207,7 +207,7 @@ class ReferenceBaseNode extends Node {
 	 * Sets the node type which automatically defines the internal
 	 * uniform type.
 	 *
-	 * @param {String} uniformType - The type to set.
+	 * @param {string} uniformType - The type to set.
 	 */
 	setNodeType( uniformType ) {
 
@@ -228,7 +228,7 @@ class ReferenceBaseNode extends Node {
 	 * the type of the reference node.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The node type.
+	 * @return {string} The node type.
 	 */
 	getNodeType( builder ) {
 
@@ -247,7 +247,7 @@ class ReferenceBaseNode extends Node {
 	 * Returns the property value from the given referred object.
 	 *
 	 * @param {Object} [object=this.reference] - The object to retrieve the property value from.
-	 * @return {Any} The value.
+	 * @return {any} The value.
 	 */
 	getValueFromReference( object = this.reference ) {
 
@@ -335,8 +335,8 @@ export default ReferenceBaseNode;
  *
  * @tsl
  * @function
- * @param {String} name - The name of the property the node refers to.
- * @param {String} type - The uniform type that should be used to represent the property value.
+ * @param {string} name - The name of the property the node refers to.
+ * @param {string} type - The uniform type that should be used to represent the property value.
  * @param {Object} object - The object the property belongs to.
  * @returns {ReferenceBaseNode}
  */
@@ -348,9 +348,9 @@ export const reference = ( name, type, object ) => nodeObject( new ReferenceBase
  *
  * @tsl
  * @function
- * @param {String} name - The name of the property the node refers to.
- * @param {String} type - The uniform type that should be used to represent the property value.
- * @param {Number} count - The number of value inside the array-like object.
+ * @param {string} name - The name of the property the node refers to.
+ * @param {string} type - The uniform type that should be used to represent the property value.
+ * @param {number} count - The number of value inside the array-like object.
  * @param {Object} object - An array-like object the property belongs to.
  * @returns {ReferenceBaseNode}
  */

--- a/src/nodes/accessors/ReferenceNode.js
+++ b/src/nodes/accessors/ReferenceNode.js
@@ -47,7 +47,7 @@ class ReferenceElementNode extends ArrayElementNode {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -59,7 +59,7 @@ class ReferenceElementNode extends ArrayElementNode {
 	 * This method is overwritten since the node type is inferred from
 	 * the uniform type of the reference node.
 	 *
-	 * @return {String} The node type.
+	 * @return {string} The node type.
 	 */
 	getNodeType() {
 
@@ -98,10 +98,10 @@ class ReferenceNode extends Node {
 	/**
 	 * Constructs a new reference node.
 	 *
-	 * @param {String} property - The name of the property the node refers to.
-	 * @param {String} uniformType - The uniform type that should be used to represent the property value.
+	 * @param {string} property - The name of the property the node refers to.
+	 * @param {string} uniformType - The uniform type that should be used to represent the property value.
 	 * @param {Object?} [object=null] - The object the property belongs to.
-	 * @param {Number?} [count=null] - When the linked property is an array-like, this parameter defines its length.
+	 * @param {number?} [count=null] - When the linked property is an array-like, this parameter defines its length.
 	 */
 	constructor( property, uniformType, object = null, count = null ) {
 
@@ -110,14 +110,14 @@ class ReferenceNode extends Node {
 		/**
 		 * The name of the property the node refers to.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.property = property;
 
 		/**
 		 * The uniform type that should be used to represent the property value.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.uniformType = uniformType;
 
@@ -132,7 +132,7 @@ class ReferenceNode extends Node {
 		/**
 		 * When the linked property is an array, this parameter defines its length.
 		 *
-		 * @type {Number?}
+		 * @type {number?}
 		 * @default null
 		 */
 		this.count = count;
@@ -141,7 +141,7 @@ class ReferenceNode extends Node {
 		 * The property name might have dots so nested properties can be referred.
 		 * The hierarchy of the names is stored inside this array.
 		 *
-		 * @type {Array<String>}
+		 * @type {Array<string>}
 		 */
 		this.properties = property.split( '.' );
 
@@ -173,7 +173,7 @@ class ReferenceNode extends Node {
 		/**
 		 * An optional label of the internal uniform node.
 		 *
-		 * @type {String?}
+		 * @type {string?}
 		 * @default null
 		 */
 		this.name = null;
@@ -181,7 +181,7 @@ class ReferenceNode extends Node {
 		/**
 		 * Overwritten since reference nodes are updated per object.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default 'object'
 		 */
 		this.updateType = NodeUpdateType.OBJECT;
@@ -218,7 +218,7 @@ class ReferenceNode extends Node {
 	/**
 	 * Sets the label for the internal uniform.
 	 *
-	 * @param {String} name - The label to set.
+	 * @param {string} name - The label to set.
 	 * @return {ReferenceNode} A reference to this node.
 	 */
 	label( name ) {
@@ -233,7 +233,7 @@ class ReferenceNode extends Node {
 	 * Sets the node type which automatically defines the internal
 	 * uniform type.
 	 *
-	 * @param {String} uniformType - The type to set.
+	 * @param {string} uniformType - The type to set.
 	 */
 	setNodeType( uniformType ) {
 
@@ -278,7 +278,7 @@ class ReferenceNode extends Node {
 	 * the type of the reference node.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The node type.
+	 * @return {string} The node type.
 	 */
 	getNodeType( builder ) {
 
@@ -297,7 +297,7 @@ class ReferenceNode extends Node {
 	 * Returns the property value from the given referred object.
 	 *
 	 * @param {Object} [object=this.reference] - The object to retrieve the property value from.
-	 * @return {Any} The value.
+	 * @return {any} The value.
 	 */
 	getValueFromReference( object = this.reference ) {
 
@@ -386,8 +386,8 @@ export default ReferenceNode;
  *
  * @tsl
  * @function
- * @param {String} name - The name of the property the node refers to.
- * @param {String} type - The uniform type that should be used to represent the property value.
+ * @param {string} name - The name of the property the node refers to.
+ * @param {string} type - The uniform type that should be used to represent the property value.
  * @param {Object} object - The object the property belongs to.
  * @returns {ReferenceNode}
  */
@@ -399,9 +399,9 @@ export const reference = ( name, type, object ) => nodeObject( new ReferenceNode
  *
  * @tsl
  * @function
- * @param {String} name - The name of the property the node refers to.
- * @param {String} type - The uniform type that should be used to represent the property value.
- * @param {Number} count - The number of value inside the array-like object.
+ * @param {string} name - The name of the property the node refers to.
+ * @param {string} type - The uniform type that should be used to represent the property value.
+ * @param {number} count - The number of value inside the array-like object.
  * @param {Object} object - An array-like object the property belongs to.
  * @returns {ReferenceNode}
  */

--- a/src/nodes/accessors/RendererReferenceNode.js
+++ b/src/nodes/accessors/RendererReferenceNode.js
@@ -24,8 +24,8 @@ class RendererReferenceNode extends ReferenceBaseNode {
 	/**
 	 * Constructs a new renderer reference node.
 	 *
-	 * @param {String} property - The name of the property the node refers to.
-	 * @param {String} inputType - The uniform type that should be used to represent the property value.
+	 * @param {string} property - The name of the property the node refers to.
+	 * @param {string} inputType - The uniform type that should be used to represent the property value.
 	 * @param {Renderer?} [renderer=null] - The renderer the property belongs to. When no renderer is set,
 	 * the node refers to the renderer of the current state.
 	 */
@@ -70,8 +70,8 @@ export default RendererReferenceNode;
  *
  * @tsl
  * @function
- * @param {String} name - The name of the property the node refers to.
- * @param {String} type - The uniform type that should be used to represent the property value.
+ * @param {string} name - The name of the property the node refers to.
+ * @param {string} type - The uniform type that should be used to represent the property value.
  * @param {Renderer?} [renderer=null] - The renderer the property belongs to. When no renderer is set,
  * the node refers to the renderer of the current state.
  * @returns {RendererReferenceNode}

--- a/src/nodes/accessors/SkinningNode.js
+++ b/src/nodes/accessors/SkinningNode.js
@@ -31,7 +31,7 @@ class SkinningNode extends Node {
 	 * Constructs a new skinning node.
 	 *
 	 * @param {SkinnedMesh} skinnedMesh - The skinned mesh.
-	 * @param {Boolean} [useReference=false] - Whether to use reference nodes for internal skinned mesh related data or not.
+	 * @param {boolean} [useReference=false] - Whether to use reference nodes for internal skinned mesh related data or not.
 	 */
 	constructor( skinnedMesh, useReference = false ) {
 
@@ -48,14 +48,14 @@ class SkinningNode extends Node {
 		 * Whether to use reference nodes for internal skinned mesh related data or not.
 		 * TODO: Explain the purpose of the property.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 */
 		this.useReference = useReference;
 
 		/**
 		 * The update type overwritten since skinning nodes are updated per object.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.updateType = NodeUpdateType.OBJECT;
 
@@ -211,7 +211,7 @@ class SkinningNode extends Node {
 	 * Returns `true` if bone matrices from the previous frame are required.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {Boolean} Whether bone matrices from the previous frame are required or not.
+	 * @return {boolean} Whether bone matrices from the previous frame are required or not.
 	 */
 	needsPreviousBoneMatrices( builder ) {
 
@@ -259,8 +259,8 @@ class SkinningNode extends Node {
 	 * Generates the code snippet of the skinning node.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @param {String} output - The current output.
-	 * @return {String} The generated code snippet.
+	 * @param {string} output - The current output.
+	 * @return {string} The generated code snippet.
 	 */
 	generate( builder, output ) {
 

--- a/src/nodes/accessors/StorageBufferNode.js
+++ b/src/nodes/accessors/StorageBufferNode.js
@@ -48,8 +48,8 @@ class StorageBufferNode extends BufferNode {
 	 * Constructs a new storage buffer node.
 	 *
 	 * @param {StorageBufferAttribute|StorageInstancedBufferAttribute|BufferAttribute} value - The buffer data.
-	 * @param {(String|Struct)?} [bufferType=null] - The buffer type (e.g. `'vec3'`).
-	 * @param {Number} [bufferCount=0] - The buffer count.
+	 * @param {(string|Struct)?} [bufferType=null] - The buffer type (e.g. `'vec3'`).
+	 * @param {number} [bufferCount=0] - The buffer count.
 	 */
 	constructor( value, bufferType = null, bufferCount = 0 ) {
 
@@ -76,7 +76,7 @@ class StorageBufferNode extends BufferNode {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -94,7 +94,7 @@ class StorageBufferNode extends BufferNode {
 		/**
 		 * The access type of the texture node.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default 'readWrite'
 		 */
 		this.access = NodeAccess.READ_WRITE;
@@ -102,7 +102,7 @@ class StorageBufferNode extends BufferNode {
 		/**
 		 * Whether the node is atomic or not.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default false
 		 */
 		this.isAtomic = false;
@@ -111,7 +111,7 @@ class StorageBufferNode extends BufferNode {
 		 * Whether the node represents a PBO or not.
 		 * Only relevant for WebGL.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default false
 		 */
 		this.isPBO = false;
@@ -135,7 +135,7 @@ class StorageBufferNode extends BufferNode {
 		/**
 		 * `StorageBufferNode` sets this property to `true` by default.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default true
 		 */
 		this.global = true;
@@ -156,7 +156,7 @@ class StorageBufferNode extends BufferNode {
 	 * and thus the hash should be shared as well.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The hash.
+	 * @return {string} The hash.
 	 */
 	getHash( builder ) {
 
@@ -186,7 +186,7 @@ class StorageBufferNode extends BufferNode {
 	 * Overwrites the default implementation to return a fixed value `'indirectStorageBuffer'` or `'storageBuffer'`.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The input type.
+	 * @return {string} The input type.
 	 */
 	getInputType( /*builder*/ ) {
 
@@ -209,7 +209,7 @@ class StorageBufferNode extends BufferNode {
 	/**
 	 * Defines whether this node is a PBO or not. Only relevant for WebGL.
 	 *
-	 * @param {Boolean} value - The value so set.
+	 * @param {boolean} value - The value so set.
 	 * @return {StorageBufferNode} A reference to this node.
 	 */
 	setPBO( value ) {
@@ -223,7 +223,7 @@ class StorageBufferNode extends BufferNode {
 	/**
 	 * Returns the `isPBO` value.
 	 *
-	 * @return {Boolean} Whether the node represents a PBO or not.
+	 * @return {boolean} Whether the node represents a PBO or not.
 	 */
 	getPBO() {
 
@@ -234,7 +234,7 @@ class StorageBufferNode extends BufferNode {
 	/**
 	 * Defines the node access.
 	 *
-	 * @param {String} value - The node access.
+	 * @param {string} value - The node access.
 	 * @return {StorageBufferNode} A reference to this node.
 	 */
 	setAccess( value ) {
@@ -259,7 +259,7 @@ class StorageBufferNode extends BufferNode {
 	/**
 	 * Defines whether the node is atomic or not.
 	 *
-	 * @param {Boolean} value - The atomic flag.
+	 * @param {boolean} value - The atomic flag.
 	 * @return {StorageBufferNode} A reference to this node.
 	 */
 	setAtomic( value ) {
@@ -307,7 +307,7 @@ class StorageBufferNode extends BufferNode {
 	 * and the attribute data.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The node type.
+	 * @return {string} The node type.
 	 */
 	getNodeType( builder ) {
 
@@ -333,7 +333,7 @@ class StorageBufferNode extends BufferNode {
 	 * Generates the code snippet of the storage buffer node.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The generated code snippet.
+	 * @return {string} The generated code snippet.
 	 */
 	generate( builder ) {
 
@@ -365,8 +365,8 @@ export default StorageBufferNode;
  * @tsl
  * @function
  * @param {StorageBufferAttribute|StorageInstancedBufferAttribute|BufferAttribute} value - The buffer data.
- * @param {(String|Struct)?} [type=null] - The buffer type (e.g. `'vec3'`).
- * @param {Number} [count=0] - The buffer count.
+ * @param {(string|Struct)?} [type=null] - The buffer type (e.g. `'vec3'`).
+ * @param {number} [count=0] - The buffer count.
  * @returns {StorageBufferNode}
  */
 export const storage = ( value, type = null, count = 0 ) => nodeObject( new StorageBufferNode( value, type, count ) );
@@ -377,8 +377,8 @@ export const storage = ( value, type = null, count = 0 ) => nodeObject( new Stor
  * @deprecated since r171. Use `storage().setPBO( true )` instead.
  *
  * @param {StorageBufferAttribute|StorageInstancedBufferAttribute|BufferAttribute} value - The buffer data.
- * @param {String?} type - The buffer type (e.g. `'vec3'`).
- * @param {Number} count - The buffer count.
+ * @param {string?} type - The buffer type (e.g. `'vec3'`).
+ * @param {number} count - The buffer count.
  * @returns {StorageBufferNode}
  */
 export const storageObject = ( value, type, count ) => { // @deprecated, r171

--- a/src/nodes/accessors/StorageTextureNode.js
+++ b/src/nodes/accessors/StorageTextureNode.js
@@ -63,7 +63,7 @@ class StorageTextureNode extends TextureNode {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -72,7 +72,7 @@ class StorageTextureNode extends TextureNode {
 		/**
 		 * The access type of the texture node.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default 'writeOnly'
 		 */
 		this.access = NodeAccess.WRITE_ONLY;
@@ -83,7 +83,7 @@ class StorageTextureNode extends TextureNode {
 	 * Overwrites the default implementation to return a fixed value `'storageTexture'`.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The input type.
+	 * @return {string} The input type.
 	 */
 	getInputType( /*builder*/ ) {
 
@@ -103,7 +103,7 @@ class StorageTextureNode extends TextureNode {
 	/**
 	 * Defines the node access.
 	 *
-	 * @param {String} value - The node access.
+	 * @param {string} value - The node access.
 	 * @return {StorageTextureNode} A reference to this node.
 	 */
 	setAccess( value ) {
@@ -118,8 +118,8 @@ class StorageTextureNode extends TextureNode {
 	 * is defined, the texture node is generated as normal texture.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @param {String} output - The current output.
-	 * @return {String} The generated code snippet.
+	 * @param {string} output - The current output.
+	 * @return {string} The generated code snippet.
 	 */
 	generate( builder, output ) {
 

--- a/src/nodes/accessors/Texture3DNode.js
+++ b/src/nodes/accessors/Texture3DNode.js
@@ -75,7 +75,7 @@ class Texture3DNode extends TextureNode {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -87,7 +87,7 @@ class Texture3DNode extends TextureNode {
 	 * Overwrites the default implementation to return a fixed value `'texture3D'`.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The input type.
+	 * @return {string} The input type.
 	 */
 	getInputType( /*builder*/ ) {
 
@@ -111,7 +111,7 @@ class Texture3DNode extends TextureNode {
 	 * Overwritten with an empty implementation since the `updateMatrix` flag is ignored
 	 * for 3D textures. The uv transformation matrix is not applied to 3D textures.
 	 *
-	 * @param {Boolean} value - The update toggle.
+	 * @param {boolean} value - The update toggle.
 	 */
 	setUpdateMatrix( /*value*/ ) { } // Ignore .updateMatrix for 3d TextureNode
 
@@ -149,7 +149,7 @@ class Texture3DNode extends TextureNode {
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
 	 * @param {Node} uvNode - The uv node to generate code for.
-	 * @return {String} The generated code snippet.
+	 * @return {string} The generated code snippet.
 	 */
 	generateUV( builder, uvNode ) {
 

--- a/src/nodes/accessors/TextureNode.js
+++ b/src/nodes/accessors/TextureNode.js
@@ -37,7 +37,7 @@ class TextureNode extends UniformNode {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -94,7 +94,7 @@ class TextureNode extends UniformNode {
 		/**
 		 * Whether texture values should be sampled or fetched.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default true
 		 */
 		this.sampler = true;
@@ -104,7 +104,7 @@ class TextureNode extends UniformNode {
 		 * automatically updated or not. Use `setUpdateMatrix()`
 		 * if you want to change the value of the property.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default false
 		 */
 		this.updateMatrix = false;
@@ -114,7 +114,7 @@ class TextureNode extends UniformNode {
 		 * sets the value to `frame` when the uv transformation matrix should
 		 * automatically be updated.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default 'none'
 		 */
 		this.updateType = NodeUpdateType.NONE;
@@ -176,7 +176,7 @@ class TextureNode extends UniformNode {
 	 * Overwritten since the uniform hash is defined by the texture's UUID.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The uniform hash.
+	 * @return {string} The uniform hash.
 	 */
 	getUniformHash( /*builder*/ ) {
 
@@ -188,7 +188,7 @@ class TextureNode extends UniformNode {
 	 * Overwritten since the node type is inferred from the texture type.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The node type.
+	 * @return {string} The node type.
 	 */
 	getNodeType( /*builder*/ ) {
 
@@ -212,7 +212,7 @@ class TextureNode extends UniformNode {
 	 * Overwrites the default implementation to return a fixed value `'texture'`.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The input type.
+	 * @return {string} The input type.
 	 */
 	getInputType( /*builder*/ ) {
 
@@ -234,7 +234,7 @@ class TextureNode extends UniformNode {
 	/**
 	 * Overwritten to always return the texture reference of the node.
 	 *
-	 * @param {Any} state - This method can be invocated in different contexts so `state` can refer to any object type.
+	 * @param {any} state - This method can be invocated in different contexts so `state` can refer to any object type.
 	 * @return {Texture} The texture reference.
 	 */
 	updateReference( /*state*/ ) {
@@ -260,7 +260,7 @@ class TextureNode extends UniformNode {
 	/**
 	 * Defines whether the uv transformation matrix should automatically be updated or not.
 	 *
-	 * @param {Boolean} value - The update toggle.
+	 * @param {boolean} value - The update toggle.
 	 * @return {TextureNode} A reference to this node.
 	 */
 	setUpdateMatrix( value ) {
@@ -368,7 +368,7 @@ class TextureNode extends UniformNode {
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
 	 * @param {Node} uvNode - The uv node to generate code for.
-	 * @return {String} The generated code snippet.
+	 * @return {string} The generated code snippet.
 	 */
 	generateUV( builder, uvNode ) {
 
@@ -380,14 +380,14 @@ class TextureNode extends UniformNode {
 	 * Generates the snippet for the texture sampling.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @param {String} textureProperty - The texture property.
-	 * @param {String} uvSnippet - The uv snippet.
-	 * @param {String?} levelSnippet - The level snippet.
-	 * @param {String?} biasSnippet - The bias snippet.
-	 * @param {String?} depthSnippet - The depth snippet.
-	 * @param {String?} compareSnippet - The compare snippet.
-	 * @param {Array<String>?} gradSnippet - The grad snippet.
-	 * @return {String} The generated code snippet.
+	 * @param {string} textureProperty - The texture property.
+	 * @param {string} uvSnippet - The uv snippet.
+	 * @param {string?} levelSnippet - The level snippet.
+	 * @param {string?} biasSnippet - The bias snippet.
+	 * @param {string?} depthSnippet - The depth snippet.
+	 * @param {string?} compareSnippet - The compare snippet.
+	 * @param {Array<string>?} gradSnippet - The grad snippet.
+	 * @return {string} The generated code snippet.
 	 */
 	generateSnippet( builder, textureProperty, uvSnippet, levelSnippet, biasSnippet, depthSnippet, compareSnippet, gradSnippet ) {
 
@@ -429,8 +429,8 @@ class TextureNode extends UniformNode {
 	 * Generates the code snippet of the texture node.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @param {String} output - The current output.
-	 * @return {String} The generated code snippet.
+	 * @param {string} output - The current output.
+	 * @return {string} The generated code snippet.
 	 */
 	generate( builder, output ) {
 
@@ -495,7 +495,7 @@ class TextureNode extends UniformNode {
 	/**
 	 * Sets the sampler value.
 	 *
-	 * @param {Boolean} value - The sampler value to set.
+	 * @param {boolean} value - The sampler value to set.
 	 * @return {TextureNode} A reference to this texture node.
 	 */
 	setSampler( value ) {
@@ -509,7 +509,7 @@ class TextureNode extends UniformNode {
 	/**
 	 * Returns the sampler value.
 	 *
-	 * @return {Boolean} The sampler value.
+	 * @return {boolean} The sampler value.
 	 */
 	getSampler() {
 

--- a/src/nodes/accessors/TextureSizeNode.js
+++ b/src/nodes/accessors/TextureSizeNode.js
@@ -29,7 +29,7 @@ class TextureSizeNode extends Node {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */

--- a/src/nodes/accessors/UV.js
+++ b/src/nodes/accessors/UV.js
@@ -5,7 +5,7 @@ import { attribute } from '../core/AttributeNode.js';
  *
  * @tsl
  * @function
- * @param {Number} [index=0] - The uv index.
+ * @param {number} [index=0] - The uv index.
  * @return {AttributeNode<vec2>} The uv attribute node.
  */
 export const uv = ( index = 0 ) => attribute( 'uv' + ( index > 0 ? index : '' ), 'vec2' );

--- a/src/nodes/accessors/UniformArrayNode.js
+++ b/src/nodes/accessors/UniformArrayNode.js
@@ -30,7 +30,7 @@ class UniformArrayElementNode extends ArrayElementNode {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -78,8 +78,8 @@ class UniformArrayNode extends BufferNode {
 	/**
 	 * Constructs a new uniform array node.
 	 *
-	 * @param {Array<Any>} value - Array holding the buffer data.
-	 * @param {String?} [elementType=null] - The data type of a buffer element.
+	 * @param {Array<any>} value - Array holding the buffer data.
+	 * @param {string?} [elementType=null] - The data type of a buffer element.
 	 */
 	constructor( value, elementType = null ) {
 
@@ -90,14 +90,14 @@ class UniformArrayNode extends BufferNode {
 		 * hold number primitives as well as three.js objects like vectors, matrices
 		 * or colors.
 		 *
-		 * @type {Array<Any>}
+		 * @type {Array<any>}
 		 */
 		this.array = value;
 
 		/**
 		 * The data type of an array element.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.elementType = elementType === null ? getValueType( value[ 0 ] ) : elementType;
 
@@ -105,14 +105,14 @@ class UniformArrayNode extends BufferNode {
 		 * The padded type. Uniform buffers must conform to a certain buffer layout
 		 * so a separate type is computed to ensure correct buffer size.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.paddedType = this.getPaddedType();
 
 		/**
 		 * Overwritten since uniform array nodes are updated per render.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default 'render'
 		 */
 		this.updateType = NodeUpdateType.RENDER;
@@ -120,7 +120,7 @@ class UniformArrayNode extends BufferNode {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -133,7 +133,7 @@ class UniformArrayNode extends BufferNode {
 	 * {@link UniformArrayNode#paddedType}.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The node type.
+	 * @return {string} The node type.
 	 */
 	getNodeType( /*builder*/ ) {
 
@@ -145,7 +145,7 @@ class UniformArrayNode extends BufferNode {
 	 * The data type of the array elements.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The element type.
+	 * @return {string} The element type.
 	 */
 	getElementType() {
 
@@ -156,7 +156,7 @@ class UniformArrayNode extends BufferNode {
 	/**
 	 * Returns the padded type based on the element type.
 	 *
-	 * @return {String} The padded type.
+	 * @return {string} The padded type.
 	 */
 	getPaddedType() {
 
@@ -341,8 +341,8 @@ export default UniformArrayNode;
  *
  * @tsl
  * @function
- * @param {Array<Any>} values - Array-like data.
- * @param {String?} nodeType - The data type of the array elements.
+ * @param {Array<any>} values - Array-like data.
+ * @param {string?} nodeType - The data type of the array elements.
  * @returns {UniformArrayNode}
  */
 export const uniformArray = ( values, nodeType ) => nodeObject( new UniformArrayNode( values, nodeType ) );
@@ -352,8 +352,8 @@ export const uniformArray = ( values, nodeType ) => nodeObject( new UniformArray
  * @function
  * @deprecated since r168. Use {@link uniformArray} instead.
  *
- * @param {Array<Any>} values - Array-like data.
- * @param {String} nodeType - The data type of the array elements.
+ * @param {Array<any>} values - Array-like data.
+ * @param {string} nodeType - The data type of the array elements.
  * @returns {UniformArrayNode}
  */
 export const uniforms = ( values, nodeType ) => { // @deprecated, r168

--- a/src/nodes/accessors/UserDataNode.js
+++ b/src/nodes/accessors/UserDataNode.js
@@ -26,8 +26,8 @@ class UserDataNode extends ReferenceNode {
 	/**
 	 * Constructs a new user data node.
 	 *
-	 * @param {String} property - The property name that should be referenced by the node.
-	 * @param {String} inputType - The node data type of the reference.
+	 * @param {string} property - The property name that should be referenced by the node.
+	 * @param {string} inputType - The node data type of the reference.
 	 * @param {Object?} [userData=null] - A reference to the `userData` object. If not provided, the `userData` property of the 3D object that uses the node material is evaluated.
 	 */
 	constructor( property, inputType, userData = null ) {
@@ -69,8 +69,8 @@ export default UserDataNode;
  *
  * @tsl
  * @function
- * @param {String} name - The property name that should be referenced by the node.
- * @param {String} inputType - The node data type of the reference.
+ * @param {string} name - The property name that should be referenced by the node.
+ * @param {string} inputType - The node data type of the reference.
  * @param {Object?} userData - A reference to the `userData` object. If not provided, the `userData` property of the 3D object that uses the node material is evaluated.
  * @returns {UserDataNode}
  */

--- a/src/nodes/accessors/VelocityNode.js
+++ b/src/nodes/accessors/VelocityNode.js
@@ -47,7 +47,7 @@ class VelocityNode extends TempNode {
 		/**
 		 * Overwritten since velocity nodes are updated per object.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default 'object'
 		 */
 		this.updateType = NodeUpdateType.OBJECT;
@@ -55,7 +55,7 @@ class VelocityNode extends TempNode {
 		/**
 		 * Overwritten since velocity nodes save data after the update.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default 'object'
 		 */
 		this.updateAfterType = NodeUpdateType.OBJECT;

--- a/src/nodes/accessors/VertexColorNode.js
+++ b/src/nodes/accessors/VertexColorNode.js
@@ -18,7 +18,7 @@ class VertexColorNode extends AttributeNode {
 	/**
 	 * Constructs a new vertex color node.
 	 *
-	 * @param {Number} [index=0] - The attribute index.
+	 * @param {number} [index=0] - The attribute index.
 	 */
 	constructor( index = 0 ) {
 
@@ -27,7 +27,7 @@ class VertexColorNode extends AttributeNode {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -36,7 +36,7 @@ class VertexColorNode extends AttributeNode {
 		/**
 		 * The attribute index to enable more than one sets of vertex colors.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @default 0
 		 */
 		this.index = index;
@@ -47,7 +47,7 @@ class VertexColorNode extends AttributeNode {
 	 * Overwrites the default implementation by honoring the attribute index.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The attribute name.
+	 * @return {string} The attribute name.
 	 */
 	getAttributeName( /*builder*/ ) {
 
@@ -104,7 +104,7 @@ export default VertexColorNode;
  *
  * @tsl
  * @function
- * @param {Number} index - The attribute index.
+ * @param {number} index - The attribute index.
  * @returns {VertexColorNode}
  */
 export const vertexColor = ( index ) => nodeObject( new VertexColorNode( index ) );

--- a/src/nodes/code/CodeNode.js
+++ b/src/nodes/code/CodeNode.js
@@ -19,7 +19,7 @@ class CodeNode extends Node {
 	/**
 	 * Constructs a new code node.
 	 *
-	 * @param {String} [code=''] - The native code.
+	 * @param {string} [code=''] - The native code.
 	 * @param {Array<Node>} [includes=[]] - An array of includes.
 	 * @param {('js'|'wgsl'|'glsl')} [language=''] - The used language.
 	 */
@@ -30,7 +30,7 @@ class CodeNode extends Node {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -39,7 +39,7 @@ class CodeNode extends Node {
 		/**
 		 * The native code.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default ''
 		 */
 		this.code = code;
@@ -65,7 +65,7 @@ class CodeNode extends Node {
 	/**
 	 * The method is overwritten so it always returns `true`.
 	 *
-	 * @return {Boolean} Whether this node is global or not.
+	 * @return {boolean} Whether this node is global or not.
 	 */
 	isGlobal() {
 
@@ -143,7 +143,7 @@ export default CodeNode;
  *
  * @tsl
  * @function
- * @param {String} [code=''] - The native code.
+ * @param {string} [code=''] - The native code.
  * @param {Array<Node>} [includes=[]] - An array of includes.
  * @param {('js'|'wgsl'|'glsl')} [language=''] - The used language.
  * @returns {CodeNode}
@@ -155,7 +155,7 @@ export const code = /*@__PURE__*/ nodeProxy( CodeNode );
  *
  * @tsl
  * @function
- * @param {String} src - The native code.
+ * @param {string} src - The native code.
  * @param {Array<Node>} includes - An array of includes.
  * @returns {CodeNode}
  */
@@ -166,7 +166,7 @@ export const js = ( src, includes ) => code( src, includes, 'js' );
  *
  * @tsl
  * @function
- * @param {String} src - The native code.
+ * @param {string} src - The native code.
  * @param {Array<Node>} includes - An array of includes.
  * @returns {CodeNode}
  */
@@ -177,7 +177,7 @@ export const wgsl = ( src, includes ) => code( src, includes, 'wgsl' );
  *
  * @tsl
  * @function
- * @param {String} src - The native code.
+ * @param {string} src - The native code.
  * @param {Array<Node>} includes - An array of includes.
  * @returns {CodeNode}
  */

--- a/src/nodes/code/ExpressionNode.js
+++ b/src/nodes/code/ExpressionNode.js
@@ -18,8 +18,8 @@ class ExpressionNode extends Node {
 	/**
 	 * Constructs a new expression node.
 	 *
-	 * @param {String} [snippet=''] - The native code snippet.
-	 * @param {String} [nodeType='void'] - The node type.
+	 * @param {string} [snippet=''] - The native code snippet.
+	 * @param {string} [nodeType='void'] - The node type.
 	 */
 	constructor( snippet = '', nodeType = 'void' ) {
 
@@ -28,7 +28,7 @@ class ExpressionNode extends Node {
 		/**
 		 * The native code snippet.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default ''
 		 */
 		this.snippet = snippet;
@@ -61,8 +61,8 @@ export default ExpressionNode;
  *
  * @tsl
  * @function
- * @param {String} [snippet=''] - The native code snippet.
- * @param {String} [nodeType='void'] - The node type.
+ * @param {string} [snippet=''] - The native code snippet.
+ * @param {string} [nodeType='void'] - The node type.
  * @returns {ExpressionNode}
  */
 export const expression = /*@__PURE__*/ nodeProxy( ExpressionNode );

--- a/src/nodes/code/FunctionCallNode.js
+++ b/src/nodes/code/FunctionCallNode.js
@@ -20,7 +20,7 @@ class FunctionCallNode extends TempNode {
 	 * Constructs a new function call node.
 	 *
 	 * @param {FunctionNode?} functionNode - The function node.
-	 * @param {Object<String, Node>} [parameters={}] - The parameters for the function call.
+	 * @param {Object<string, Node>} [parameters={}] - The parameters for the function call.
 	 */
 	constructor( functionNode = null, parameters = {} ) {
 
@@ -37,7 +37,7 @@ class FunctionCallNode extends TempNode {
 		/**
 		 * The parameters of the function call.
 		 *
-		 * @type {Object<String, Node>}
+		 * @type {Object<string, Node>}
 		 * @default {}
 		 */
 		this.parameters = parameters;
@@ -47,7 +47,7 @@ class FunctionCallNode extends TempNode {
 	/**
 	 * Sets the parameters of the function call node.
 	 *
-	 * @param {Object<String, Node>} parameters - The parameters to set.
+	 * @param {Object<string, Node>} parameters - The parameters to set.
 	 * @return {FunctionCallNode} A reference to this node.
 	 */
 	setParameters( parameters ) {
@@ -61,7 +61,7 @@ class FunctionCallNode extends TempNode {
 	/**
 	 * Returns the parameters of the function call node.
 	 *
-	 * @return {Object<String, Node>} The parameters of this node.
+	 * @return {Object<string, Node>} The parameters of this node.
 	 */
 	getParameters() {
 

--- a/src/nodes/code/FunctionNode.js
+++ b/src/nodes/code/FunctionNode.js
@@ -38,7 +38,7 @@ class FunctionNode extends CodeNode {
 	/**
 	 * Constructs a new function node.
 	 *
-	 * @param {String} [code=''] - The native code.
+	 * @param {string} [code=''] - The native code.
 	 * @param {Array<Node>} [includes=[]] - An array of includes.
 	 * @param {('js'|'wgsl'|'glsl')} [language=''] - The used language.
 	 */

--- a/src/nodes/code/ScriptableNode.js
+++ b/src/nodes/code/ScriptableNode.js
@@ -154,7 +154,7 @@ class ScriptableNode extends Node {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -165,7 +165,7 @@ class ScriptableNode extends Node {
 	/**
 	 * The source code of the scriptable node.
 	 *
-	 * @type {String}
+	 * @type {string}
 	 */
 	get source() {
 
@@ -176,7 +176,7 @@ class ScriptableNode extends Node {
 	/**
 	 * Sets the reference of a local script variable.
 	 *
-	 * @param {String} name - The variable name.
+	 * @param {string} name - The variable name.
 	 * @param {Object} value - The reference to set.
 	 * @return {Resources} The resource map
 	 */
@@ -189,7 +189,7 @@ class ScriptableNode extends Node {
 	/**
 	 * Gets the value of a local script variable.
 	 *
-	 * @param {String} name - The variable name.
+	 * @param {string} name - The variable name.
 	 * @return {Object} The value.
 	 */
 	getLocal( name ) {
@@ -210,7 +210,7 @@ class ScriptableNode extends Node {
 	/**
 	 * Returns an input from the layout with the given id/name.
 	 *
-	 * @param {String} id - The id/name of the input.
+	 * @param {string} id - The id/name of the input.
 	 * @return {Object} The element entry.
 	 */
 	getInputLayout( id ) {
@@ -230,7 +230,7 @@ class ScriptableNode extends Node {
 	/**
 	 * Returns an output from the layout with the given id/name.
 	 *
-	 * @param {String} id - The id/name of the output.
+	 * @param {string} id - The id/name of the output.
 	 * @return {Object} The element entry.
 	 */
 	getOutputLayout( id ) {
@@ -250,7 +250,7 @@ class ScriptableNode extends Node {
 	/**
 	 * Defines a script output for the given name and value.
 	 *
-	 * @param {String} name - The name of the output.
+	 * @param {string} name - The name of the output.
 	 * @param {Node} value - The node value.
 	 * @return {ScriptableNode} A reference to this node.
 	 */
@@ -275,7 +275,7 @@ class ScriptableNode extends Node {
 	/**
 	 * Returns a script output for the given name.
 	 *
-	 * @param {String} name - The name of the output.
+	 * @param {string} name - The name of the output.
 	 * @return {ScriptableValueNode} The node value.
 	 */
 	getOutput( name ) {
@@ -287,7 +287,7 @@ class ScriptableNode extends Node {
 	/**
 	 * Returns a parameter for the given name
 	 *
-	 * @param {String} name - The name of the parameter.
+	 * @param {string} name - The name of the parameter.
 	 * @return {ScriptableValueNode} The node value.
 	 */
 	getParameter( name ) {
@@ -299,8 +299,8 @@ class ScriptableNode extends Node {
 	/**
 	 * Sets a value for the given parameter name.
 	 *
-	 * @param {String} name - The parameter name.
-	 * @param {Any} value - The parameter value.
+	 * @param {string} name - The parameter name.
+	 * @param {any} value - The parameter value.
 	 * @return {ScriptableNode} A reference to this node.
 	 */
 	setParameter( name, value ) {
@@ -351,7 +351,7 @@ class ScriptableNode extends Node {
 	/**
 	 * Deletes a parameter from the script.
 	 *
-	 * @param {String} name - The parameter to remove.
+	 * @param {string} name - The parameter to remove.
 	 * @return {ScriptableNode} A reference to this node.
 	 */
 	deleteParameter( name ) {
@@ -392,9 +392,9 @@ class ScriptableNode extends Node {
 	/**
 	 * Calls a function from the script.
 	 *
-	 * @param {String} name - The function name.
-	 * @param {...Any} params - A list of parameters.
-	 * @return {Any} The result of the function call.
+	 * @param {string} name - The function name.
+	 * @param {...any} params - A list of parameters.
+	 * @return {any} The result of the function call.
 	 */
 	call( name, ...params ) {
 
@@ -412,9 +412,9 @@ class ScriptableNode extends Node {
 	/**
 	 * Asynchronously calls a function from the script.
 	 *
-	 * @param {String} name - The function name.
-	 * @param {...Any} params - A list of parameters.
-	 * @return {Promise<Any>} The result of the function call.
+	 * @param {string} name - The function name.
+	 * @param {...any} params - A list of parameters.
+	 * @return {Promise<any>} The result of the function call.
 	 */
 	async callAsync( name, ...params ) {
 
@@ -433,7 +433,7 @@ class ScriptableNode extends Node {
 	 * Overwritten since the node types is inferred from the script's output.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder
-	 * @return {String} The node type.
+	 * @return {string} The node type.
 	 */
 	getNodeType( builder ) {
 
@@ -444,7 +444,7 @@ class ScriptableNode extends Node {
 	/**
 	 * Refreshes the script node.
 	 *
-	 * @param {String?} [output=null] - An optional output.
+	 * @param {string?} [output=null] - An optional output.
 	 */
 	refresh( output = null ) {
 

--- a/src/nodes/code/ScriptableValueNode.js
+++ b/src/nodes/code/ScriptableValueNode.js
@@ -20,7 +20,7 @@ class ScriptableValueNode extends Node {
 	/**
 	 * Constructs a new scriptable node.
 	 *
-	 * @param {Any} [value=null] - The value.
+	 * @param {any} [value=null] - The value.
 	 */
 	constructor( value = null ) {
 
@@ -45,7 +45,7 @@ class ScriptableValueNode extends Node {
 		/**
 		 * If this node represents an input, this property represents the input type.
 		 *
-		 * @type {String?}
+		 * @type {string?}
 		 * @default null
 		 */
 		this.inputType = null;
@@ -53,7 +53,7 @@ class ScriptableValueNode extends Node {
 		/**
 		 * If this node represents an output, this property represents the output type.
 		 *
-		 * @type {String?}
+		 * @type {string?}
 		 * @default null
 		 */
 		this.outputType = null;
@@ -68,7 +68,7 @@ class ScriptableValueNode extends Node {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -79,7 +79,7 @@ class ScriptableValueNode extends Node {
 	/**
 	 * Whether this node represents an output or not.
 	 *
-	 * @type {Boolean}
+	 * @type {boolean}
 	 * @readonly
 	 * @default true
 	 */
@@ -112,7 +112,7 @@ class ScriptableValueNode extends Node {
 	/**
 	 * The node's value.
 	 *
-	 * @type {Any}
+	 * @type {any}
 	 */
 	get value() {
 
@@ -133,7 +133,7 @@ class ScriptableValueNode extends Node {
 	 * The `value` property usually represents a node or even binary data in form of array buffers.
 	 * In this case, this method tries to return the actual value behind the complex type.
 	 *
-	 * @return {Any} The value.
+	 * @return {any} The value.
 	 */
 	getValue() {
 
@@ -166,7 +166,7 @@ class ScriptableValueNode extends Node {
 	 * Overwritten since the node type is inferred from the value.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The node type.
+	 * @return {string} The node type.
 	 */
 	getNodeType( builder ) {
 
@@ -247,7 +247,7 @@ export default ScriptableValueNode;
  *
  * @tsl
  * @function
- * @param {Any} [value=null] - The value.
+ * @param {any} [value=null] - The value.
  * @returns {ScriptableValueNode}
  */
 export const scriptableValue = /*@__PURE__*/ nodeProxy( ScriptableValueNode );

--- a/src/nodes/core/ArrayNode.js
+++ b/src/nodes/core/ArrayNode.js
@@ -25,8 +25,8 @@ class ArrayNode extends TempNode {
 	/**
 	 * Constructs a new array node.
 	 *
-	 * @param {String} [nodeType] - The data type of the elements.
-	 * @param {Number} [count] - Size of the array.
+	 * @param {string} [nodeType] - The data type of the elements.
+	 * @param {number} [count] - Size of the array.
 	 * @param {Array<Node>?} [values=null] - Array default values.
 	 */
 	constructor( nodeType, count, values = null ) {
@@ -50,7 +50,7 @@ class ArrayNode extends TempNode {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -93,9 +93,9 @@ export default ArrayNode;
  *
  * @tsl
  * @function
- * @param {String|Array<Node>} nodeTypeOrValues - A string representing the element type (e.g., 'vec3')
+ * @param {string|Array<Node>} nodeTypeOrValues - A string representing the element type (e.g., 'vec3')
  * or an array containing the default values (e.g., [ vec3() ]).
- * @param {Number?} [count] - Size of the array.
+ * @param {number?} [count] - Size of the array.
  * @returns {ArrayNode}
  */
 export const array = ( ...params ) => {

--- a/src/nodes/core/AssignNode.js
+++ b/src/nodes/core/AssignNode.js
@@ -46,7 +46,7 @@ class AssignNode extends TempNode {
 	 * Whether this node is used more than once in context of other nodes. This method
 	 * is overwritten since it always returns `false` (assigns are unique).
 	 *
-	 * @return {Boolean} A flag that indicates if there is more than one dependency to other nodes. Always `false`.
+	 * @return {boolean} A flag that indicates if there is more than one dependency to other nodes. Always `false`.
 	 */
 	hasDependencies() {
 
@@ -65,7 +65,7 @@ class AssignNode extends TempNode {
 	 * target and source data type does not match.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {Boolean} Whether a split is required when assigning source to target.
+	 * @return {boolean} Whether a split is required when assigning source to target.
 	 */
 	needsSplitAssign( builder ) {
 

--- a/src/nodes/core/AttributeNode.js
+++ b/src/nodes/core/AttributeNode.js
@@ -17,8 +17,8 @@ class AttributeNode extends Node {
 	/**
 	 * Constructs a new attribute node.
 	 *
-	 * @param {String} attributeName - The name of the attribute.
-	 * @param {String?} nodeType - The node type.
+	 * @param {string} attributeName - The name of the attribute.
+	 * @param {string?} nodeType - The node type.
 	 */
 	constructor( attributeName, nodeType = null ) {
 
@@ -27,7 +27,7 @@ class AttributeNode extends Node {
 		/**
 		 * `AttributeNode` sets this property to `true` by default.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default true
 		 */
 		this.global = true;
@@ -73,7 +73,7 @@ class AttributeNode extends Node {
 	 * overwritten in derived classes if the final name must be computed
 	 * analytically.
 	 *
-	 * @param {String} attributeName - The name of the attribute.
+	 * @param {string} attributeName - The name of the attribute.
 	 * @return {AttributeNode} A reference to this node.
 	 */
 	setAttributeName( attributeName ) {
@@ -90,7 +90,7 @@ class AttributeNode extends Node {
 	 * analytically.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The attribute name.
+	 * @return {string} The attribute name.
 	 */
 	getAttributeName( /*builder*/ ) {
 
@@ -160,8 +160,8 @@ export default AttributeNode;
  *
  * @tsl
  * @function
- * @param {String} name - The name of the attribute.
- * @param {String?} nodeType - The node type.
+ * @param {string} name - The name of the attribute.
+ * @param {string?} nodeType - The node type.
  * @returns {AttributeNode}
  */
 export const attribute = ( name, nodeType ) => nodeObject( new AttributeNode( name, nodeType ) );

--- a/src/nodes/core/BypassNode.js
+++ b/src/nodes/core/BypassNode.js
@@ -33,7 +33,7 @@ class BypassNode extends Node {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */

--- a/src/nodes/core/CacheNode.js
+++ b/src/nodes/core/CacheNode.js
@@ -20,7 +20,7 @@ class CacheNode extends Node {
 	 * Constructs a new cache node.
 	 *
 	 * @param {Node} node - The node that should be cached.
-	 * @param {Boolean} [parent=true] - Whether this node refers to a shared parent cache or not.
+	 * @param {boolean} [parent=true] - Whether this node refers to a shared parent cache or not.
 	 */
 	constructor( node, parent = true ) {
 
@@ -36,7 +36,7 @@ class CacheNode extends Node {
 		/**
 		 * Whether this node refers to a shared parent cache or not.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default true
 		 */
 		this.parent = parent;
@@ -44,7 +44,7 @@ class CacheNode extends Node {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -92,7 +92,7 @@ export default CacheNode;
  * @tsl
  * @function
  * @param {Node} node - The node that should be cached.
- * @param {Boolean} parent - Whether this node refers to a shared parent cache or not.
+ * @param {boolean} parent - Whether this node refers to a shared parent cache or not.
  * @returns {CacheNode}
  */
 export const cache = ( node, parent ) => nodeObject( new CacheNode( nodeObject( node ), parent ) );

--- a/src/nodes/core/ConstNode.js
+++ b/src/nodes/core/ConstNode.js
@@ -18,8 +18,8 @@ class ConstNode extends InputNode {
 	/**
 	 * Constructs a new input node.
 	 *
-	 * @param {Any} value - The value of this node. Usually a JS primitive or three.js object (vector, matrix, color).
-	 * @param {String?} nodeType - The node type. If no explicit type is defined, the node tries to derive the type from its value.
+	 * @param {any} value - The value of this node. Usually a JS primitive or three.js object (vector, matrix, color).
+	 * @param {string?} nodeType - The node type. If no explicit type is defined, the node tries to derive the type from its value.
 	 */
 	constructor( value, nodeType = null ) {
 
@@ -28,7 +28,7 @@ class ConstNode extends InputNode {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -40,7 +40,7 @@ class ConstNode extends InputNode {
 	 * Generates the shader string of the value with the current node builder.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The generated value as a shader string.
+	 * @return {string} The generated value as a shader string.
 	 */
 	generateConst( builder ) {
 

--- a/src/nodes/core/ContextNode.js
+++ b/src/nodes/core/ContextNode.js
@@ -32,7 +32,7 @@ class ContextNode extends Node {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -70,7 +70,7 @@ class ContextNode extends Node {
 	 * This method is overwritten to ensure it returns the type of {@link ContextNode#node}.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The node type.
+	 * @return {string} The node type.
 	 */
 	getNodeType( builder ) {
 
@@ -133,7 +133,7 @@ export const context = /*@__PURE__*/ nodeProxy( ContextNode );
  * @tsl
  * @function
  * @param {Node} node - The node whose context should be modified.
- * @param {String} name - The name/label to set.
+ * @param {string} name - The name/label to set.
  * @returns {ContextNode}
  */
 export const label = ( node, name ) => context( node, { label: name } );

--- a/src/nodes/core/IndexNode.js
+++ b/src/nodes/core/IndexNode.js
@@ -34,14 +34,14 @@ class IndexNode extends Node {
 		/**
 		 * The scope of the index node.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.scope = scope;
 
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */

--- a/src/nodes/core/InputNode.js
+++ b/src/nodes/core/InputNode.js
@@ -17,8 +17,8 @@ class InputNode extends Node {
 	/**
 	 * Constructs a new input node.
 	 *
-	 * @param {Any} value - The value of this node. This can be a any JS primitive, functions, array buffers or even three.js objects (vector, matrices, colors).
-	 * @param {String?} nodeType - The node type. If no explicit type is defined, the node tries to derive the type from its value.
+	 * @param {any} value - The value of this node. This can be a any JS primitive, functions, array buffers or even three.js objects (vector, matrices, colors).
+	 * @param {string?} nodeType - The node type. If no explicit type is defined, the node tries to derive the type from its value.
 	 */
 	constructor( value, nodeType = null ) {
 
@@ -27,7 +27,7 @@ class InputNode extends Node {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -36,7 +36,7 @@ class InputNode extends Node {
 		/**
 		 * The value of this node. This can be a any JS primitive, functions, array buffers or even three.js objects (vector, matrices, colors).
 		 *
-		 * @type {Any}
+		 * @type {any}
 		 */
 		this.value = value;
 
@@ -70,7 +70,7 @@ class InputNode extends Node {
 	 * normal RGBA texture is `texture` whereas its node type is `vec4`.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The input type.
+	 * @return {string} The input type.
 	 */
 	getInputType( builder ) {
 

--- a/src/nodes/core/MRTNode.js
+++ b/src/nodes/core/MRTNode.js
@@ -5,8 +5,8 @@ import { nodeProxy, vec4 } from '../tsl/TSLBase.js';
  * Returns the MRT texture index for the given name.
  *
  * @param {Array<Texture>} textures - The textures of a MRT-configured render target.
- * @param {String} name - The name of the MRT texture which index is requested.
- * @return {Number} The texture index.
+ * @param {string} name - The name of the MRT texture which index is requested.
+ * @return {number} The texture index.
  */
 export function getTextureIndex( textures, name ) {
 
@@ -48,7 +48,7 @@ class MRTNode extends OutputStructNode {
 	/**
 	 * Constructs a new output struct node.
 	 *
-	 * @param {Object<String, Node>} outputNodes - The MRT outputs.
+	 * @param {Object<string, Node>} outputNodes - The MRT outputs.
 	 */
 	constructor( outputNodes ) {
 
@@ -59,14 +59,14 @@ class MRTNode extends OutputStructNode {
 		 * is the name of the output, the value the node which produces
 		 * the output result.
 		 *
-		 * @type {Object<String, Node>}
+		 * @type {Object<string, Node>}
 		 */
 		this.outputNodes = outputNodes;
 
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -77,7 +77,7 @@ class MRTNode extends OutputStructNode {
 	/**
 	 * Returns `true` if the MRT node has an output with the given name.
 	 *
-	 * @param {String} name - The name of the output.
+	 * @param {string} name - The name of the output.
 	 * @return {NodeBuilder} Whether the MRT node has an output for the given name or not.
 	 */
 	has( name ) {
@@ -89,7 +89,7 @@ class MRTNode extends OutputStructNode {
 	/**
 	 * Returns the output node for the given name.
 	 *
-	 * @param {String} name - The name of the output.
+	 * @param {string} name - The name of the output.
 	 * @return {Node} The output node.
 	 */
 	get( name ) {
@@ -144,7 +144,7 @@ export default MRTNode;
  *
  * @tsl
  * @function
- * @param {Object<String, Node>} outputNodes - The MRT outputs.
+ * @param {Object<string, Node>} outputNodes - The MRT outputs.
  * @returns {MRTNode}
  */
 export const mrt = /*@__PURE__*/ nodeProxy( MRTNode );

--- a/src/nodes/core/Node.js
+++ b/src/nodes/core/Node.js
@@ -22,7 +22,7 @@ class Node extends EventDispatcher {
 	/**
 	 * Constructs a new node.
 	 *
-	 * @param {String?} nodeType - The node type.
+	 * @param {string?} nodeType - The node type.
 	 */
 	constructor( nodeType = null ) {
 
@@ -31,7 +31,7 @@ class Node extends EventDispatcher {
 		/**
 		 * The node type. This represents the result type of the node (e.g. `float` or `vec3`).
 		 *
-		 * @type {String?}
+		 * @type {string?}
 		 * @default null
 		 */
 		this.nodeType = nodeType;
@@ -39,7 +39,7 @@ class Node extends EventDispatcher {
 		/**
 		 * The update type of the node's {@link Node#update} method. Possible values are listed in {@link NodeUpdateType}.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default 'none'
 		 */
 		this.updateType = NodeUpdateType.NONE;
@@ -47,7 +47,7 @@ class Node extends EventDispatcher {
 		/**
 		 * The update type of the node's {@link Node#updateBefore} method. Possible values are listed in {@link NodeUpdateType}.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default 'none'
 		 */
 		this.updateBeforeType = NodeUpdateType.NONE;
@@ -55,7 +55,7 @@ class Node extends EventDispatcher {
 		/**
 		 * The update type of the node's {@link Node#updateAfter} method. Possible values are listed in {@link NodeUpdateType}.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default 'none'
 		 */
 		this.updateAfterType = NodeUpdateType.NONE;
@@ -63,7 +63,7 @@ class Node extends EventDispatcher {
 		/**
 		 * The UUID of the node.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @readonly
 		 */
 		this.uuid = MathUtils.generateUUID();
@@ -71,7 +71,7 @@ class Node extends EventDispatcher {
 		/**
 		 * The version of the node. The version automatically is increased when {@link Node#needsUpdate} is set to `true`.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @readonly
 		 * @default 0
 		 */
@@ -82,7 +82,7 @@ class Node extends EventDispatcher {
 		 * node caching system. All nodes which should be declared just once should
 		 * set this flag to `true` (a typical example is {@link AttributeNode}).
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default false
 		 */
 		this.global = false;
@@ -90,7 +90,7 @@ class Node extends EventDispatcher {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -102,7 +102,7 @@ class Node extends EventDispatcher {
 		 * The cache key of this node.
 		 *
 		 * @private
-		 * @type {Number?}
+		 * @type {number?}
 		 * @default null
 		 */
 		this._cacheKey = null;
@@ -111,7 +111,7 @@ class Node extends EventDispatcher {
 		 * The cache key 's version.
 		 *
 		 * @private
-		 * @type {Number}
+		 * @type {number}
 		 * @default 0
 		 */
 		this._cacheKeyVersion = 0;
@@ -123,7 +123,7 @@ class Node extends EventDispatcher {
 	/**
 	 * Set this property to `true` when the node should be regenerated.
 	 *
-	 * @type {Boolean}
+	 * @type {boolean}
 	 * @default false
 	 * @param {boolean} value
 	 */
@@ -140,7 +140,7 @@ class Node extends EventDispatcher {
 	/**
 	 * The type of the class. The value is usually the constructor name.
 	 *
-	 * @type {String}
+	 * @type {string}
  	 * @readonly
 	 */
 	get type() {
@@ -153,7 +153,7 @@ class Node extends EventDispatcher {
 	 * Convenient method for defining {@link Node#update}.
 	 *
 	 * @param {Function} callback - The update method.
-	 * @param {String} updateType - The update type.
+	 * @param {string} updateType - The update type.
 	 * @return {Node} A reference to this node.
 	 */
 	onUpdate( callback, updateType ) {
@@ -236,8 +236,8 @@ class Node extends EventDispatcher {
 	 * Nodes might refer to other objects like materials. This method allows to dynamically update the reference
 	 * to such objects based on a given state (e.g. the current node frame or builder).
 	 *
-	 * @param {Any} state - This method can be invocated in different contexts so `state` can refer to any object type.
-	 * @return {Any} The updated reference.
+	 * @param {any} state - This method can be invocated in different contexts so `state` can refer to any object type.
+	 * @return {any} The updated reference.
 	 */
 	updateReference( /*state*/ ) {
 
@@ -251,7 +251,7 @@ class Node extends EventDispatcher {
 	 * global status.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {Boolean} Whether this node is global or not.
+	 * @return {boolean} Whether this node is global or not.
 	 */
 	isGlobal( /*builder*/ ) {
 
@@ -312,8 +312,8 @@ class Node extends EventDispatcher {
 	/**
 	 * Returns the cache key for this node.
 	 *
-	 * @param {Boolean} [force=false] - When set to `true`, a recomputation of the cache key is forced.
-	 * @return {Number} The cache key of the node.
+	 * @param {boolean} [force=false] - When set to `true`, a recomputation of the cache key is forced.
+	 * @return {number} The cache key of the node.
 	 */
 	getCacheKey( force = false ) {
 
@@ -333,7 +333,7 @@ class Node extends EventDispatcher {
 	/**
 	 * Generate a custom cache key for this node.
 	 *
-	 * @return {Number} The cache key of the node.
+	 * @return {number} The cache key of the node.
 	 */
 	customCacheKey() {
 
@@ -358,7 +358,7 @@ class Node extends EventDispatcher {
 	 * depending on their implementation.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The hash.
+	 * @return {string} The hash.
 	 */
 	getHash( /*builder*/ ) {
 
@@ -405,7 +405,7 @@ class Node extends EventDispatcher {
 	 * these elements.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The type of the node.
+	 * @return {string} The type of the node.
 	 */
 	getElementType( builder ) {
 
@@ -420,8 +420,8 @@ class Node extends EventDispatcher {
 	 * Returns the node member type for the given name.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @param {String} name - The name of the member.
-	 * @return {String} The type of the node.
+	 * @param {string} name - The name of the member.
+	 * @return {string} The type of the node.
 	 */
 	getMemberType( /*uilder, name*/ ) {
 
@@ -433,7 +433,7 @@ class Node extends EventDispatcher {
 	 * Returns the node's type.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The type of the node.
+	 * @return {string} The type of the node.
 	 */
 	getNodeType( builder ) {
 
@@ -528,8 +528,8 @@ class Node extends EventDispatcher {
 	 * This state builds the output node and returns the resulting shader string.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @param {String?} output - Can be used to define the output type.
-	 * @return {String?} The generated shader string.
+	 * @param {string?} output - Can be used to define the output type.
+	 * @return {string?} The generated shader string.
 	 */
 	generate( builder, output ) {
 
@@ -549,7 +549,7 @@ class Node extends EventDispatcher {
 	 *
 	 * @abstract
 	 * @param {NodeFrame} frame - A reference to the current node frame.
-	 * @return {Boolean?} An optional bool that indicates whether the implementation actually performed an update or not (e.g. due to caching).
+	 * @return {boolean?} An optional bool that indicates whether the implementation actually performed an update or not (e.g. due to caching).
 	 */
 	updateBefore( /*frame*/ ) {
 
@@ -563,7 +563,7 @@ class Node extends EventDispatcher {
 	 *
 	 * @abstract
 	 * @param {NodeFrame} frame - A reference to the current node frame.
-	 * @return {Boolean?} An optional bool that indicates whether the implementation actually performed an update or not (e.g. due to caching).
+	 * @return {boolean?} An optional bool that indicates whether the implementation actually performed an update or not (e.g. due to caching).
 	 */
 	updateAfter( /*frame*/ ) {
 
@@ -577,7 +577,7 @@ class Node extends EventDispatcher {
 	 *
 	 * @abstract
 	 * @param {NodeFrame} frame - A reference to the current node frame.
-	 * @return {Boolean?} An optional bool that indicates whether the implementation actually performed an update or not (e.g. due to caching).
+	 * @return {boolean?} An optional bool that indicates whether the implementation actually performed an update or not (e.g. due to caching).
 	 */
 	update( /*frame*/ ) {
 
@@ -590,8 +590,8 @@ class Node extends EventDispatcher {
 	 * on the current build stage (setup, analyze or generate).
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @param {String?} output - Can be used to define the output type.
-	 * @return {String?} When this method is executed in the setup or analyze stage, `null` is returned. In the generate stage, the generated shader string.
+	 * @param {string?} output - Can be used to define the output type.
+	 * @return {string?} When this method is executed in the setup or analyze stage, `null` is returned. In the generate stage, the generated shader string.
 	 */
 	build( builder, output = null ) {
 

--- a/src/nodes/core/NodeAttribute.js
+++ b/src/nodes/core/NodeAttribute.js
@@ -9,8 +9,8 @@ class NodeAttribute {
 	/**
 	 * Constructs a new node attribute.
 	 *
-	 * @param {String} name - The name of the attribute.
-	 * @param {String} type - The type of the attribute.
+	 * @param {string} name - The name of the attribute.
+	 * @param {string} type - The type of the attribute.
 	 * @param {Node?} node - An optional reference to the node.
 	 */
 	constructor( name, type, node = null ) {
@@ -18,7 +18,7 @@ class NodeAttribute {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -27,14 +27,14 @@ class NodeAttribute {
 		/**
 		 * The name of the attribute.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.name = name;
 
 		/**
 		 * The type of the attribute.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.type = type;
 

--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -167,7 +167,7 @@ class NodeBuilder {
 		/**
 		 * A dictionary that assigns each node to a unique hash.
 		 *
-		 * @type {Object<Number,Node>}
+		 * @type {Object<number,Node>}
 		 */
 		this.hashNodes = {};
 
@@ -213,35 +213,35 @@ class NodeBuilder {
 		/**
 		 * The generated vertex shader.
 		 *
-		 * @type {String?}
+		 * @type {string?}
 		 */
 		this.vertexShader = null;
 
 		/**
 		 * The generated fragment shader.
 		 *
-		 * @type {String?}
+		 * @type {string?}
 		 */
 		this.fragmentShader = null;
 
 		/**
 		 * The generated compute shader.
 		 *
-		 * @type {String?}
+		 * @type {string?}
 		 */
 		this.computeShader = null;
 
 		/**
 		 * Nodes used in the primary flow of code generation.
 		 *
-		 * @type {Object<String,Array<Node>>}
+		 * @type {Object<string,Array<Node>>}
 		 */
 		this.flowNodes = { vertex: [], fragment: [], compute: [] };
 
 		/**
 		 * Nodes code from `.flowNodes`.
 		 *
-		 * @type {Object<String,String>}
+		 * @type {Object<string,string>}
 		 */
 		this.flowCode = { vertex: '', fragment: '', compute: '' };
 
@@ -309,7 +309,7 @@ class NodeBuilder {
 		 * This dictionary holds the (native) node codes of this builder.
 		 * The codes are maintained in an array for each shader stage.
 		 *
-		 * @type {Object<String,Array<NodeCode>>}
+		 * @type {Object<string,Array<NodeCode>>}
 		 */
 		this.codes = {};
 
@@ -317,7 +317,7 @@ class NodeBuilder {
 		 * This dictionary holds the node variables of this builder.
 		 * The variables are maintained in an array for each shader stage.
 		 *
-		 * @type {Object<String,Array<NodeVar>>}
+		 * @type {Object<string,Array<NodeVar>>}
 		 */
 		this.vars = {};
 
@@ -325,7 +325,7 @@ class NodeBuilder {
 		 * Current code flow.
 		 * All code generated in this stack will be stored in `.flow`.
 		 *
-		 * @type {{code: String}}
+		 * @type {{code: string}}
 		 */
 		this.flow = { code: '' };
 
@@ -357,7 +357,7 @@ class NodeBuilder {
 		/**
 		 * A tab value. Used for shader string generation.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default '\t'
 		 */
 		this.tab = '\t';
@@ -415,7 +415,7 @@ class NodeBuilder {
 		/**
 		 * Whether comparison in shader code are generated with methods or not.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default false
 		 */
 		this.useComparisonMethod = false;
@@ -447,8 +447,8 @@ class NodeBuilder {
 	 * Factory method for creating an instance of {@link RenderTarget} with the given
 	 * dimensions and options.
 	 *
-	 * @param {Number} width - The width of the render target.
-	 * @param {Number} height - The height of the render target.
+	 * @param {number} width - The width of the render target.
+	 * @param {number} height - The height of the render target.
 	 * @param {Object} options - The options of the render target.
 	 * @return {RenderTarget} The render target.
 	 */
@@ -462,7 +462,7 @@ class NodeBuilder {
 	 * Factory method for creating an instance of {@link CubeRenderTarget} with the given
 	 * dimensions and options.
 	 *
-	 * @param {Number} size - The size of the cube render target.
+	 * @param {number} size - The size of the cube render target.
 	 * @param {Object} options - The options of the cube render target.
 	 * @return {CubeRenderTarget} The cube render target.
 	 */
@@ -489,7 +489,7 @@ class NodeBuilder {
 	 * Whether the given node is included in the internal array of nodes or not.
 	 *
 	 * @param {Node} node - The node to test.
-	 * @return {Boolean} Whether the given node is included in the internal array of nodes or not.
+	 * @return {boolean} Whether the given node is included in the internal array of nodes or not.
 	 */
 	includes( node ) {
 
@@ -502,7 +502,7 @@ class NodeBuilder {
 	 * {@link OutputStructNode}.
 	 *
 	 * @abstract
-	 * @return {String} The name of the output struct.
+	 * @return {string} The name of the output struct.
 	 */
 	getOutputStructName() {}
 
@@ -510,7 +510,7 @@ class NodeBuilder {
 	 * Returns a bind group for the given group name and binding.
 	 *
 	 * @private
-	 * @param {String} groupName - The group name.
+	 * @param {string} groupName - The group name.
 	 * @param {Array<NodeUniformsGroup>} bindings - List of bindings.
 	 * @return {BindGroup} The bind group
 	 */
@@ -561,7 +561,7 @@ class NodeBuilder {
 	/**
 	 * Returns an array of node uniform groups for the given group name and shader stage.
 	 *
-	 * @param {String} groupName - The group name.
+	 * @param {string} groupName - The group name.
 	 * @param {('vertex'|'fragment'|'compute'|'any')} shaderStage - The shader stage.
 	 * @return {Array<NodeUniformsGroup>} The array of node uniform groups.
 	 */
@@ -659,7 +659,7 @@ class NodeBuilder {
 	 * This method sets the given node (value) with the given hash (key) into this dictionary.
 	 *
 	 * @param {Node} node - The node to add.
-	 * @param {Number} hash - The hash of the node.
+	 * @param {number} hash - The hash of the node.
 	 */
 	setHashNode( node, hash ) {
 
@@ -755,7 +755,7 @@ class NodeBuilder {
 	 * Whether the given texture is filtered or not.
 	 *
 	 * @param {Texture} texture - The texture to check.
-	 * @return {Boolean} Whether the given texture is filtered or not.
+	 * @return {boolean} Whether the given texture is filtered or not.
 	 */
 	isFilteredTexture( texture ) {
 
@@ -807,8 +807,8 @@ class NodeBuilder {
 	 * resolved to `textureSize` in GLSL.
 	 *
 	 * @abstract
-	 * @param {String} method - The method name to resolve.
-	 * @return {String} The resolved method name.
+	 * @param {string} method - The method name to resolve.
+	 * @return {string} The resolved method name.
 	 */
 	getMethod( method ) {
 
@@ -819,7 +819,7 @@ class NodeBuilder {
 	/**
 	 * Returns a node for the given hash, see {@link NodeBuilder#setHashNode}.
 	 *
-	 * @param {Number} hash - The hash of the node.
+	 * @param {number} hash - The hash of the node.
 	 * @return {Node} The found node.
 	 */
 	getNodeFromHash( hash ) {
@@ -907,7 +907,7 @@ class NodeBuilder {
 	 * Returns a cache for the given node.
 	 *
 	 * @param {Node} node - The node.
-	 * @param {Boolean} [parent=true] - Whether this node refers to a shared parent cache or not.
+	 * @param {boolean} [parent=true] - Whether this node refers to a shared parent cache or not.
 	 * @return {NodeCache} The cache.
 	 */
 	getCacheFromNode( node, parent = true ) {
@@ -923,8 +923,8 @@ class NodeBuilder {
 	 * Whether the requested feature is available or not.
 	 *
 	 * @abstract
-	 * @param {String} name - The requested feature.
-	 * @return {Boolean} Whether the requested feature is supported or not.
+	 * @param {string} name - The requested feature.
+	 * @return {boolean} Whether the requested feature is supported or not.
 	 */
 	isAvailable( /*name*/ ) {
 
@@ -936,7 +936,7 @@ class NodeBuilder {
 	 * Returns the vertexIndex input variable as a native shader string.
 	 *
 	 * @abstract
-	 * @return {String} The instanceIndex shader string.
+	 * @return {string} The instanceIndex shader string.
 	 */
 	getVertexIndex() {
 
@@ -948,7 +948,7 @@ class NodeBuilder {
 	 * Returns the instanceIndex input variable as a native shader string.
 	 *
 	 * @abstract
-	 * @return {String} The instanceIndex shader string.
+	 * @return {string} The instanceIndex shader string.
 	 */
 	getInstanceIndex() {
 
@@ -961,7 +961,7 @@ class NodeBuilder {
 	 * Only relevant for WebGL and its `WEBGL_multi_draw` extension.
 	 *
 	 * @abstract
-	 * @return {String} The drawIndex shader string.
+	 * @return {string} The drawIndex shader string.
 	 */
 	getDrawIndex() {
 
@@ -973,7 +973,7 @@ class NodeBuilder {
 	 * Returns the frontFacing input variable as a native shader string.
 	 *
 	 * @abstract
-	 * @return {String} The frontFacing shader string.
+	 * @return {string} The frontFacing shader string.
 	 */
 	getFrontFacing() {
 
@@ -985,7 +985,7 @@ class NodeBuilder {
 	 * Returns the fragCoord input variable as a native shader string.
 	 *
 	 * @abstract
-	 * @return {String} The fragCoord shader string.
+	 * @return {string} The fragCoord shader string.
 	 */
 	getFragCoord() {
 
@@ -998,7 +998,7 @@ class NodeBuilder {
 	 * this method evaluate to `true`, WebGPU to `false`.
 	 *
 	 * @abstract
-	 * @return {Boolean} Whether to flip texture data along its vertical axis or not.
+	 * @return {boolean} Whether to flip texture data along its vertical axis or not.
 	 */
 	isFlipY() {
 
@@ -1010,7 +1010,7 @@ class NodeBuilder {
 	 * Calling this method increases the usage count for the given node by one.
 	 *
 	 * @param {Node} node - The node to increase the usage count for.
-	 * @return {Number} The updated usage count.
+	 * @return {number} The updated usage count.
 	 */
 	increaseUsage( node ) {
 
@@ -1026,9 +1026,9 @@ class NodeBuilder {
 	 *
 	 * @abstract
 	 * @param {Texture} texture - The texture.
-	 * @param {String} textureProperty - The texture property name.
-	 * @param {String} uvSnippet - Snippet defining the texture coordinates.
-	 * @return {String} The generated shader string.
+	 * @param {string} textureProperty - The texture property name.
+	 * @param {string} uvSnippet - Snippet defining the texture coordinates.
+	 * @return {string} The generated shader string.
 	 */
 	generateTexture( /* texture, textureProperty, uvSnippet */ ) {
 
@@ -1041,11 +1041,11 @@ class NodeBuilder {
 	 *
 	 * @abstract
 	 * @param {Texture} texture - The texture.
-	 * @param {String} textureProperty - The texture property name.
-	 * @param {String} uvSnippet - Snippet defining the texture coordinates.
-	 * @param {String?} depthSnippet - Snippet defining the 0-based texture array index to sample.
-	 * @param {String} levelSnippet - Snippet defining the mip level.
-	 * @return {String} The generated shader string.
+	 * @param {string} textureProperty - The texture property name.
+	 * @param {string} uvSnippet - Snippet defining the texture coordinates.
+	 * @param {string?} depthSnippet - Snippet defining the 0-based texture array index to sample.
+	 * @param {string} levelSnippet - Snippet defining the mip level.
+	 * @return {string} The generated shader string.
 	 */
 	generateTextureLod( /* texture, textureProperty, uvSnippet, depthSnippet, levelSnippet */ ) {
 
@@ -1056,9 +1056,9 @@ class NodeBuilder {
 	/**
 	 * Generates the array declaration string.
 	 *
-	 * @param {String} type - The type.
-	 * @param {Number?} [count] - The count.
-	 * @return {String} The generated value as a shader string.
+	 * @param {string} type - The type.
+	 * @param {number?} [count] - The count.
+	 * @return {string} The generated value as a shader string.
 	 */
 	generateArrayDeclaration( type, count ) {
 
@@ -1069,10 +1069,10 @@ class NodeBuilder {
 	/**
 	 * Generates the array shader string for the given type and value.
 	 *
-	 * @param {String} type - The type.
-	 * @param {Number?} [count] - The count.
+	 * @param {string} type - The type.
+	 * @param {number?} [count] - The count.
 	 * @param {Array<Node>?} [values=null] - The default values.
-	 * @return {String} The generated value as a shader string.
+	 * @return {string} The generated value as a shader string.
 	 */
 	generateArray( type, count, values = null ) {
 
@@ -1105,10 +1105,10 @@ class NodeBuilder {
 	/**
 	 * Generates the struct shader string.
 	 *
-	 * @param {String} type - The type.
+	 * @param {string} type - The type.
 	 * @param {Array<Object>} [membersLayout] - The count.
 	 * @param {Array<Node>?} [values=null] - The default values.
-	 * @return {String} The generated value as a shader string.
+	 * @return {string} The generated value as a shader string.
 	 */
 	generateStruct( type, membersLayout, values = null ) {
 
@@ -1138,9 +1138,9 @@ class NodeBuilder {
 	/**
 	 * Generates the shader string for the given type and value.
 	 *
-	 * @param {String} type - The type.
-	 * @param {Any?} [value=null] - The value.
-	 * @return {String} The generated value as a shader string.
+	 * @param {string} type - The type.
+	 * @param {any?} [value=null] - The value.
+	 * @return {string} The generated value as a shader string.
 	 */
 	generateConst( type, value = null ) {
 
@@ -1197,8 +1197,8 @@ class NodeBuilder {
 	 * It might be necessary to convert certain data types to different ones
 	 * so this method can be used to hide the conversion.
 	 *
-	 * @param {String} type - The type.
-	 * @return {String} The updated type.
+	 * @param {string} type - The type.
+	 * @return {string} The updated type.
 	 */
 	getType( type ) {
 
@@ -1211,8 +1211,8 @@ class NodeBuilder {
 	/**
 	 * Whether the given attribute name is defined in the geometry or not.
 	 *
-	 * @param {String} name - The attribute name.
-	 * @return {Boolean} Whether the given attribute name is defined in the geometry.
+	 * @param {string} name - The attribute name.
+	 * @return {boolean} Whether the given attribute name is defined in the geometry.
 	 */
 	hasGeometryAttribute( name ) {
 
@@ -1223,8 +1223,8 @@ class NodeBuilder {
 	/**
 	 * Returns a node attribute for the given name and type.
 	 *
-	 * @param {String} name - The attribute's name.
-	 * @param {String} type - The attribute's type.
+	 * @param {string} name - The attribute's name.
+	 * @param {string} type - The attribute's type.
 	 * @return {NodeAttribute} The node attribute.
 	 */
 	getAttribute( name, type ) {
@@ -1258,7 +1258,7 @@ class NodeBuilder {
 	 *
 	 * @param {Node} node - The node.
 	 * @param {('vertex'|'fragment'|'compute'|'any')} shaderStage - The shader stage.
-	 * @return {String} The property name.
+	 * @return {string} The property name.
 	 */
 	getPropertyName( node/*, shaderStage*/ ) {
 
@@ -1269,8 +1269,8 @@ class NodeBuilder {
 	/**
 	 * Whether the given type is a vector type or not.
 	 *
-	 * @param {String} type - The type to check.
-	 * @return {Boolean} Whether the given type is a vector type or not.
+	 * @param {string} type - The type to check.
+	 * @return {boolean} Whether the given type is a vector type or not.
 	 */
 	isVector( type ) {
 
@@ -1281,8 +1281,8 @@ class NodeBuilder {
 	/**
 	 * Whether the given type is a matrix type or not.
 	 *
-	 * @param {String} type - The type to check.
-	 * @return {Boolean} Whether the given type is a matrix type or not.
+	 * @param {string} type - The type to check.
+	 * @return {boolean} Whether the given type is a matrix type or not.
 	 */
 	isMatrix( type ) {
 
@@ -1293,8 +1293,8 @@ class NodeBuilder {
 	/**
 	 * Whether the given type is a reference type or not.
 	 *
-	 * @param {String} type - The type to check.
-	 * @return {Boolean} Whether the given type is a reference type or not.
+	 * @param {string} type - The type to check.
+	 * @return {boolean} Whether the given type is a reference type or not.
 	 */
 	isReference( type ) {
 
@@ -1307,7 +1307,7 @@ class NodeBuilder {
 	 *
 	 * @abstract
 	 * @param {Texture} texture - The texture to check.
-	 * @return {Boolean} Whether the given texture requires a conversion to working color space or not.
+	 * @return {boolean} Whether the given texture requires a conversion to working color space or not.
 	 */
 	needsToWorkingColorSpace( /*texture*/ ) {
 
@@ -1319,7 +1319,7 @@ class NodeBuilder {
 	 * Returns the component type of a given texture.
 	 *
 	 * @param {Texture} texture - The texture.
-	 * @return {String} The component type.
+	 * @return {string} The component type.
 	 */
 	getComponentTypeFromTexture( texture ) {
 
@@ -1339,8 +1339,8 @@ class NodeBuilder {
 	/**
 	 * Returns the element type for a given type.
 	 *
-	 * @param {String} type - The type.
-	 * @return {String} The element type.
+	 * @param {string} type - The type.
+	 * @return {string} The element type.
 	 */
 	getElementType( type ) {
 
@@ -1355,8 +1355,8 @@ class NodeBuilder {
 	/**
 	 * Returns the component type for a given type.
 	 *
-	 * @param {String} type - The type.
-	 * @return {String} The component type.
+	 * @param {string} type - The type.
+	 * @return {string} The component type.
 	 */
 	getComponentType( type ) {
 
@@ -1379,8 +1379,8 @@ class NodeBuilder {
 	/**
 	 * Returns the vector type for a given type.
 	 *
-	 * @param {String} type - The type.
-	 * @return {String} The vector type.
+	 * @param {string} type - The type.
+	 * @return {string} The vector type.
 	 */
 	getVectorType( type ) {
 
@@ -1394,9 +1394,9 @@ class NodeBuilder {
 	/**
 	 * Returns the data type for the given the length and component type.
 	 *
-	 * @param {Number} length - The length.
-	 * @param {String} [componentType='float'] - The component type.
-	 * @return {String} The type.
+	 * @param {number} length - The length.
+	 * @param {string} [componentType='float'] - The component type.
+	 * @return {string} The type.
 	 */
 	getTypeFromLength( length, componentType = 'float' ) {
 
@@ -1420,7 +1420,7 @@ class NodeBuilder {
 	 * Returns the type for a given typed array.
 	 *
 	 * @param {TypedArray} array - The typed array.
-	 * @return {String} The type.
+	 * @return {string} The type.
 	 */
 	getTypeFromArray( array ) {
 
@@ -1432,7 +1432,7 @@ class NodeBuilder {
 	 * Returns the type for a given buffer attribute.
 	 *
 	 * @param {BufferAttribute} attribute - The buffer attribute.
-	 * @return {String} The type.
+	 * @return {string} The type.
 	 */
 	getTypeFromAttribute( attribute ) {
 
@@ -1459,8 +1459,8 @@ class NodeBuilder {
 	/**
 	 * Returns the length for the given data type.
 	 *
-	 * @param {String} type - The data type.
-	 * @return {Number} The length.
+	 * @param {string} type - The data type.
+	 * @return {number} The length.
 	 */
 	getTypeLength( type ) {
 
@@ -1480,8 +1480,8 @@ class NodeBuilder {
 	/**
 	 * Returns the vector type for a given matrix type.
 	 *
-	 * @param {String} type - The matrix type.
-	 * @return {String} The vector type.
+	 * @param {string} type - The matrix type.
+	 * @return {string} The vector type.
 	 */
 	getVectorFromMatrix( type ) {
 
@@ -1494,9 +1494,9 @@ class NodeBuilder {
 	 * given value. E.g. `vec4` should be changed to the new component type
 	 * `uint` which results in `uvec4`.
 	 *
-	 * @param {String} type - The type.
-	 * @param {String} newComponentType - The new component type.
-	 * @return {String} The new type.
+	 * @param {string} type - The type.
+	 * @param {string} newComponentType - The new component type.
+	 * @return {string} The new type.
 	 */
 	changeComponentType( type, newComponentType ) {
 
@@ -1507,8 +1507,8 @@ class NodeBuilder {
 	/**
 	 * Returns the integer type pendant for the given type.
 	 *
-	 * @param {String} type - The type.
-	 * @return {String} The integer type.
+	 * @param {string} type - The type.
+	 * @return {string} The integer type.
 	 */
 	getIntegerType( type ) {
 
@@ -1600,7 +1600,7 @@ class NodeBuilder {
 	 * Returns an instance of {@link NodeAttribute} for the given buffer attribute node.
 	 *
 	 * @param {BufferAttributeNode} node - The buffer attribute node.
-	 * @param {String} type - The node type.
+	 * @param {string} type - The node type.
 	 * @return {NodeAttribute} The node attribute.
 	 */
 	getBufferAttributeFromNode( node, type ) {
@@ -1630,7 +1630,7 @@ class NodeBuilder {
 	 *
 	 * @param {OutputStructNode} node - The output struct node.
 	 * @param {Array<Object>} membersLayout - The output struct types.
-	 * @param {String?} [name=null] - The name of the struct.
+	 * @param {string?} [name=null] - The name of the struct.
 	 * @param {('vertex'|'fragment'|'compute'|'any')} [shaderStage=this.shaderStage] - The shader stage.
 	 * @return {StructType} The struct type attribute.
 	 */
@@ -1678,9 +1678,9 @@ class NodeBuilder {
 	 * Returns an instance of {@link NodeUniform} for the given uniform node.
 	 *
 	 * @param {UniformNode} node - The uniform node.
-	 * @param {String} type - The uniform type.
+	 * @param {string} type - The uniform type.
 	 * @param {('vertex'|'fragment'|'compute'|'any')} [shaderStage=this.shaderStage] - The shader stage.
-	 * @param {String?} name - The name of the uniform.
+	 * @param {string?} name - The name of the uniform.
 	 * @return {NodeUniform} The node uniform.
 	 */
 	getUniformFromNode( node, type, shaderStage = this.shaderStage, name = null ) {
@@ -1709,7 +1709,7 @@ class NodeBuilder {
 	 * Returns the array length.
 	 *
 	 * @param {Node} node - The node.
-	 * @return {Number?} The array length.
+	 * @return {number?} The array length.
 	 */
 	getArrayCount( node ) {
 
@@ -1726,10 +1726,10 @@ class NodeBuilder {
 	 * Returns an instance of {@link NodeVar} for the given variable node.
 	 *
 	 * @param {VarNode} node - The variable node.
-	 * @param {String?} name - The variable's name.
-	 * @param {String} [type=node.getNodeType( this )] - The variable's type.
+	 * @param {string?} name - The variable's name.
+	 * @param {string} [type=node.getNodeType( this )] - The variable's type.
 	 * @param {('vertex'|'fragment'|'compute'|'any')} [shaderStage=this.shaderStage] - The shader stage.
-	 * @param {Boolean} [readOnly=false] - Whether the variable is read-only or not.
+	 * @param {boolean} [readOnly=false] - Whether the variable is read-only or not.
 	 *
 	 * @return {NodeVar} The node variable.
 	 */
@@ -1778,7 +1778,7 @@ class NodeBuilder {
 	 * Returns whether a Node or its flow is deterministic, useful for use in `const`.
 	 *
 	 * @param {Node} node - The varying node.
-	 * @return {Boolean} Returns true if deterministic.
+	 * @return {boolean} Returns true if deterministic.
 	 */
 	isDeterministic( node ) {
 
@@ -1825,8 +1825,8 @@ class NodeBuilder {
 	 * Returns an instance of {@link NodeVarying} for the given varying node.
 	 *
 	 * @param {(VaryingNode|PropertyNode)} node - The varying node.
-	 * @param {String?} name - The varying's name.
-	 * @param {String} [type=node.getNodeType( this )] - The varying's type.
+	 * @param {string?} name - The varying's name.
+	 * @param {string} [type=node.getNodeType( this )] - The varying's type.
 	 * @return {NodeVar} The node varying.
 	 */
 	getVaryingFromNode( node, name = null, type = node.getNodeType( this ) ) {
@@ -1858,7 +1858,7 @@ class NodeBuilder {
 	 * Returns an instance of {@link NodeCode} for the given code node.
 	 *
 	 * @param {CodeNode} node - The code node.
-	 * @param {String} type - The node type.
+	 * @param {string} type - The node type.
 	 * @param {('vertex'|'fragment'|'compute'|'any')} [shaderStage=this.shaderStage] - The shader stage.
 	 * @return {NodeCode} The node code.
 	 */
@@ -1930,7 +1930,7 @@ class NodeBuilder {
 	 * Add a inline-code to the current flow code-block.
 	 *
 	 * @param {Node} node - The node to add.
-	 * @param {String} code - The code to add.
+	 * @param {string} code - The code to add.
 	 * @param {Node} nodeBlock - Current ConditionalNode
 	 */
 	addLineFlowCodeBlock( node, code, nodeBlock ) {
@@ -1947,7 +1947,7 @@ class NodeBuilder {
 	/**
 	 * Add a inline-code to the current flow.
 	 *
-	 * @param {String} code - The code to add.
+	 * @param {string} code - The code to add.
 	 * @param {Node?} [node= null] - Optional Node, can help the system understand if the Node is part of a code-block.
 	 * @return {NodeBuilder} A reference to this node builder.
 	 */
@@ -1978,7 +1978,7 @@ class NodeBuilder {
 	/**
 	 * Adds a code to the current code flow.
 	 *
-	 * @param {String} code - Shader code.
+	 * @param {string} code - Shader code.
 	 * @return {NodeBuilder} A reference to this node builder.
 	 */
 	addFlowCode( code ) {
@@ -2134,7 +2134,7 @@ class NodeBuilder {
 	 * Runs the node flow through all the steps of creation, 'setup', 'analyze', 'generate'.
 	 *
 	 * @param {Node} node - The node to execute.
-	 * @param {String?} output - Expected output type. For example 'vec3'.
+	 * @param {string?} output - Expected output type. For example 'vec3'.
 	 * @return {Object}
 	 */
 	flowStagesNode( node, output = null ) {
@@ -2180,8 +2180,8 @@ class NodeBuilder {
 	 * It is a similar type of method like {@link NodeBuilder#getMethod}.
 	 *
 	 * @abstract
-	 * @param {String} op - The operator name to resolve.
-	 * @return {String} The resolved operator name.
+	 * @param {string} op - The operator name to resolve.
+	 * @return {string} The resolved operator name.
 	 */
 	getFunctionOperator( /* op */ ) {
 
@@ -2193,7 +2193,7 @@ class NodeBuilder {
 	 * Generates a code flow based on a child Node.
 	 *
 	 * @param {Node} node - The node to execute.
-	 * @param {String?} output - Expected output type. For example 'vec3'.
+	 * @param {string?} output - Expected output type. For example 'vec3'.
 	 * @return {Object} The code flow.
 	 */
 	flowChildNode( node, output = null ) {
@@ -2222,8 +2222,8 @@ class NodeBuilder {
 	 *
 	 * @param {('vertex'|'fragment'|'compute'|'any')} shaderStage - The shader stage.
 	 * @param {Node} node - The node to execute.
-	 * @param {String?} output - Expected output type. For example 'vec3'.
-	 * @param {String?} propertyName - The property name to assign the result.
+	 * @param {string?} output - Expected output type. For example 'vec3'.
+	 * @param {string?} propertyName - The property name to assign the result.
 	 * @return {Object}
 	 */
 	flowNodeFromShaderStage( shaderStage, node, output = null, propertyName = null ) {
@@ -2264,7 +2264,7 @@ class NodeBuilder {
 	 *
 	 * @abstract
 	 * @param {('vertex'|'fragment'|'compute'|'any')} shaderStage - The shader stage.
-	 * @return {String} The attribute code section.
+	 * @return {string} The attribute code section.
 	 */
 	getAttributes( /*shaderStage*/ ) {
 
@@ -2277,7 +2277,7 @@ class NodeBuilder {
 	 *
 	 * @abstract
 	 * @param {('vertex'|'fragment'|'compute'|'any')} shaderStage - The shader stage.
-	 * @return {String} The varying code section.
+	 * @return {string} The varying code section.
 	 */
 	getVaryings( /*shaderStage*/ ) {
 
@@ -2288,10 +2288,10 @@ class NodeBuilder {
 	/**
 	 * Returns a single variable definition as a shader string for the given variable type and name.
 	 *
-	 * @param {String} type - The variable's type.
-	 * @param {String} name - The variable's name.
-	 * @param {Number?} [count=null] - The array length.
-	 * @return {String} The shader string.
+	 * @param {string} type - The variable's type.
+	 * @param {string} name - The variable's name.
+	 * @param {number?} [count=null] - The array length.
+	 * @return {string} The shader string.
 	 */
 	getVar( type, name, count = null ) {
 
@@ -2303,7 +2303,7 @@ class NodeBuilder {
 	 * Returns the variable definitions as a shader string for the given shader stage.
 	 *
 	 * @param {('vertex'|'fragment'|'compute'|'any')} shaderStage - The shader stage.
-	 * @return {String} The variable code section.
+	 * @return {string} The variable code section.
 	 */
 	getVars( shaderStage ) {
 
@@ -2330,7 +2330,7 @@ class NodeBuilder {
 	 *
 	 * @abstract
 	 * @param {('vertex'|'fragment'|'compute'|'any')} shaderStage - The shader stage.
-	 * @return {String} The uniform code section.
+	 * @return {string} The uniform code section.
 	 */
 	getUniforms( /*shaderStage*/ ) {
 
@@ -2342,7 +2342,7 @@ class NodeBuilder {
 	 * Returns the native code definitions as a shader string for the given shader stage.
 	 *
 	 * @param {('vertex'|'fragment'|'compute'|'any')} shaderStage - The shader stage.
-	 * @return {String} The native code section.
+	 * @return {string} The native code section.
 	 */
 	getCodes( shaderStage ) {
 
@@ -2367,7 +2367,7 @@ class NodeBuilder {
 	/**
 	 * Returns the hash of this node builder.
 	 *
-	 * @return {String} The hash.
+	 * @return {string} The hash.
 	 */
 	getHash() {
 
@@ -2513,7 +2513,7 @@ class NodeBuilder {
 	 * Returns a uniform representation which is later used for UBO generation and rendering.
 	 *
 	 * @param {NodeUniform} uniformNode - The uniform node.
-	 * @param {String} type - The requested type.
+	 * @param {string} type - The requested type.
 	 * @return {Uniform} The uniform.
 	 */
 	getNodeUniform( uniformNode, type ) {
@@ -2536,10 +2536,10 @@ class NodeBuilder {
 	 * this method might be used to convert a simple float string `"1.0"` into a
 	 * `vec3` representation: `"vec3<f32>( 1.0 )"`.
 	 *
-	 * @param {String} snippet - The shader snippet.
-	 * @param {String} fromType - The source type.
-	 * @param {String} toType - The target type.
-	 * @return {String} The updated shader string.
+	 * @param {string} snippet - The shader snippet.
+	 * @param {string} fromType - The source type.
+	 * @param {string} toType - The target type.
+	 * @return {string} The updated shader string.
 	 */
 	format( snippet, fromType, toType ) {
 
@@ -2624,7 +2624,7 @@ class NodeBuilder {
 	/**
 	 * Returns a signature with the engine's current revision.
 	 *
-	 * @return {String} The signature.
+	 * @return {string} The signature.
 	 */
 	getSignature() {
 
@@ -2638,7 +2638,7 @@ class NodeBuilder {
 	 * @function
 	 * @deprecated since r168. Use `new NodeMaterial()` instead, with targeted node material name.
 	 *
-	 * @param {String} [type='NodeMaterial'] - The node material type.
+	 * @param {string} [type='NodeMaterial'] - The node material type.
 	 * @throws {Error}
 	 */
 	createNodeMaterial( type = 'NodeMaterial' ) { // @deprecated, r168

--- a/src/nodes/core/NodeCache.js
+++ b/src/nodes/core/NodeCache.js
@@ -16,7 +16,7 @@ class NodeCache {
 		/**
 		 * The id of the cache.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @readonly
 		 */
 		this.id = _id ++;

--- a/src/nodes/core/NodeCode.js
+++ b/src/nodes/core/NodeCode.js
@@ -9,30 +9,30 @@ class NodeCode {
 	/**
 	 * Constructs a new code node.
 	 *
-	 * @param {String} name - The name of the code.
-	 * @param {String} type - The node type.
-	 * @param {String} [code=''] - The native shader code.
+	 * @param {string} name - The name of the code.
+	 * @param {string} type - The node type.
+	 * @param {string} [code=''] - The native shader code.
 	 */
 	constructor( name, type, code = '' ) {
 
 		/**
 		 * The name of the code.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.name = name;
 
 		/**
 		 * The node type.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.type = type;
 
 		/**
 		 * The native shader code.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default ''
 		 */
 		this.code = code;

--- a/src/nodes/core/NodeFrame.js
+++ b/src/nodes/core/NodeFrame.js
@@ -16,7 +16,7 @@ class NodeFrame {
 		/**
 		 * The elapsed time in seconds.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @default 0
 		 */
 		this.time = 0;
@@ -24,7 +24,7 @@ class NodeFrame {
 		/**
 		 * The delta time in seconds.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @default 0
 		 */
 		this.deltaTime = 0;
@@ -32,7 +32,7 @@ class NodeFrame {
 		/**
 		 * The frame ID.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @default 0
 		 */
 		this.frameId = 0;
@@ -40,7 +40,7 @@ class NodeFrame {
 		/**
 		 * The render ID.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @default 0
 		 */
 		this.renderId = 0;
@@ -115,7 +115,7 @@ class NodeFrame {
 	 * @private
 	 * @param {WeakMap<Node, Object>} referenceMap - The reference weak map.
 	 * @param {Node} nodeRef - The reference to the current node.
-	 * @return {Object<String,WeakMap>} The dictionary.
+	 * @return {Object<string,WeakMap>} The dictionary.
 	 */
 	_getMaps( referenceMap, nodeRef ) {
 

--- a/src/nodes/core/NodeFunction.js
+++ b/src/nodes/core/NodeFunction.js
@@ -9,17 +9,17 @@ class NodeFunction {
 	/**
 	 * Constructs a new node function.
 	 *
-	 * @param {String} type - The node type. This type is the return type of the node function.
+	 * @param {string} type - The node type. This type is the return type of the node function.
 	 * @param {Array<NodeFunctionInput>} inputs - The function's inputs.
-	 * @param {String} [name=''] - The function's name.
-	 * @param {String} [precision=''] - The precision qualifier.
+	 * @param {string} [name=''] - The function's name.
+	 * @param {string} [precision=''] - The precision qualifier.
 	 */
 	constructor( type, inputs, name = '', precision = '' ) {
 
 		/**
 		 * The node type. This type is the return type of the node function.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.type = type;
 
@@ -33,7 +33,7 @@ class NodeFunction {
 		/**
 		 * The name of the uniform.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default ''
 		 */
 		this.name = name;
@@ -41,7 +41,7 @@ class NodeFunction {
 		/**
 		 * The precision qualifier.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default ''
 		 */
 		this.precision = precision;
@@ -52,8 +52,8 @@ class NodeFunction {
 	 * This method returns the native code of the node function.
 	 *
 	 * @abstract
-	 * @param {String} name - The function's name.
-	 * @return {String} A shader code.
+	 * @param {string} name - The function's name.
+	 * @return {string} A shader code.
 	 */
 	getCode( /*name = this.name*/ ) {
 

--- a/src/nodes/core/NodeFunctionInput.js
+++ b/src/nodes/core/NodeFunctionInput.js
@@ -6,32 +6,32 @@ class NodeFunctionInput {
 	/**
 	 * Constructs a new node function input.
 	 *
-	 * @param {String} type - The input type.
-	 * @param {String} name - The input name.
-	 * @param {Number?} [count=null] - If the input is an Array, count will be the length.
+	 * @param {string} type - The input type.
+	 * @param {string} name - The input name.
+	 * @param {number?} [count=null] - If the input is an Array, count will be the length.
 	 * @param {('in'|'out'|'inout')} [qualifier=''] - The parameter qualifier (only relevant for GLSL).
-	 * @param {Boolean} [isConst=false] - Whether the input uses a const qualifier or not (only relevant for GLSL).
+	 * @param {boolean} [isConst=false] - Whether the input uses a const qualifier or not (only relevant for GLSL).
 	 */
 	constructor( type, name, count = null, qualifier = '', isConst = false ) {
 
 		/**
 		 *  The input type.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.type = type;
 
 		/**
 		 * The input name.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.name = name;
 
 		/**
 		 * If the input is an Array, count will be the length.
 		 *
-		 * @type {Number?}
+		 * @type {number?}
 		 * @default null
 		 */
 		this.count = count;
@@ -47,7 +47,7 @@ class NodeFunctionInput {
 		/**
 		 * Whether the input uses a const qualifier or not (only relevant for GLSL).
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default false
 		 */
 		this.isConst = isConst;

--- a/src/nodes/core/NodeParser.js
+++ b/src/nodes/core/NodeParser.js
@@ -8,7 +8,7 @@ class NodeParser {
 	 * The method parses the given native code an returns a node function.
 	 *
 	 * @abstract
-	 * @param {String} source - The native shader code.
+	 * @param {string} source - The native shader code.
 	 * @return {NodeFunction} A node function.
 	 */
 	parseFunction( /*source*/ ) {

--- a/src/nodes/core/NodeUniform.js
+++ b/src/nodes/core/NodeUniform.js
@@ -9,8 +9,8 @@ class NodeUniform {
 	/**
 	 * Constructs a new node uniform.
 	 *
-	 * @param {String} name - The name of the uniform.
-	 * @param {String} type - The type of the uniform.
+	 * @param {string} name - The name of the uniform.
+	 * @param {string} type - The type of the uniform.
 	 * @param {UniformNode} node - An reference to the node.
 	 */
 	constructor( name, type, node ) {
@@ -18,7 +18,7 @@ class NodeUniform {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -27,14 +27,14 @@ class NodeUniform {
 		/**
 		 * The name of the uniform.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.name = name;
 
 		/**
 		 * The type of the uniform.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.type = type;
 
@@ -50,7 +50,7 @@ class NodeUniform {
 	/**
 	 * The value of the uniform node.
 	 *
-	 * @type {Any}
+	 * @type {any}
 	 */
 	get value() {
 
@@ -67,7 +67,7 @@ class NodeUniform {
 	/**
 	 * The id of the uniform node.
 	 *
-	 * @type {Number}
+	 * @type {number}
 	 */
 	get id() {
 

--- a/src/nodes/core/NodeUtils.js
+++ b/src/nodes/core/NodeUtils.js
@@ -50,8 +50,8 @@ function cyrb53( value, seed = 0 ) {
  * Computes a hash for the given string.
  *
  * @method
- * @param {String} str - The string to be hashed.
- * @return {Number} The hash.
+ * @param {string} str - The string to be hashed.
+ * @return {number} The hash.
  */
 export const hashString = ( str ) => cyrb53( str );
 
@@ -59,8 +59,8 @@ export const hashString = ( str ) => cyrb53( str );
  * Computes a hash for the given array.
  *
  * @method
- * @param {Array<Number>} array - The array to be hashed.
- * @return {Number} The hash.
+ * @param {Array<number>} array - The array to be hashed.
+ * @return {number} The hash.
  */
 export const hashArray = ( array ) => cyrb53( array );
 
@@ -68,8 +68,8 @@ export const hashArray = ( array ) => cyrb53( array );
  * Computes a hash for the given list of parameters.
  *
  * @method
- * @param {...Number} params - A list of parameters.
- * @return {Number} The hash.
+ * @param {...number} params - A list of parameters.
+ * @return {number} The hash.
  */
 export const hash = ( ...params ) => cyrb53( params );
 
@@ -78,8 +78,8 @@ export const hash = ( ...params ) => cyrb53( params );
  *
  * @method
  * @param {Object} object - The object to be hashed.
- * @param {Boolean} [force=false] - Whether to force a cache key computation or not.
- * @return {Number} The hash.
+ * @param {boolean} [force=false] - Whether to force a cache key computation or not.
+ * @return {number} The hash.
  */
 export function getCacheKey( object, force = false ) {
 
@@ -108,7 +108,7 @@ export function getCacheKey( object, force = false ) {
  *
  * @generator
  * @param {Object} node - The object to be hashed.
- * @param {Boolean} [toJSON=false] - Whether to return JSON or not.
+ * @param {boolean} [toJSON=false] - Whether to return JSON or not.
  * @yields {Object} A result node holding the property, index (if available) and the child node.
  */
 export function* getNodeChildren( node, toJSON = false ) {
@@ -173,8 +173,8 @@ const dataFromObject = /*@__PURE__*/ new WeakMap();
  * Returns the data type for the given the length.
  *
  * @method
- * @param {Number} length - The length.
- * @return {String} The data type.
+ * @param {number} length - The length.
+ * @return {string} The data type.
  */
 export function getTypeFromLength( length ) {
 
@@ -186,7 +186,7 @@ export function getTypeFromLength( length ) {
  * Returns the typed array for the given data type.
  *
  * @method
- * @param {String} type - The data type.
+ * @param {string} type - The data type.
  * @return {TypedArray} The typed array.
  */
 export function getTypedArrayFromType( type ) {
@@ -219,8 +219,8 @@ export function getTypedArrayFromType( type ) {
  * Returns the length for the given data type.
  *
  * @method
- * @param {String} type - The data type.
- * @return {Number} The length.
+ * @param {string} type - The data type.
+ * @return {number} The length.
  */
 export function getLengthFromType( type ) {
 
@@ -240,8 +240,8 @@ export function getLengthFromType( type ) {
  * Returns the data type for the given value.
  *
  * @method
- * @param {Any} value - The value.
- * @return {String?} The data type.
+ * @param {any} value - The value.
+ * @return {string?} The data type.
  */
 export function getValueType( value ) {
 
@@ -311,9 +311,9 @@ export function getValueType( value ) {
  * Returns the value/object for the given data type and parameters.
  *
  * @method
- * @param {String} type - The given type.
- * @param {...Any} params - A parameter list.
- * @return {Any} The value/object.
+ * @param {string} type - The given type.
+ * @param {...any} params - A parameter list.
+ * @return {any} The value/object.
  */
 export function getValueFromType( type, ...params ) {
 
@@ -403,7 +403,7 @@ export function getDataFromObject( object ) {
  *
  * @method
  * @param {ArrayBuffer} arrayBuffer - The array buffer.
- * @return {String} The Base64 string.
+ * @return {string} The Base64 string.
  */
 export function arrayBufferToBase64( arrayBuffer ) {
 
@@ -425,7 +425,7 @@ export function arrayBufferToBase64( arrayBuffer ) {
  * Converts the given Base64 string to an array buffer.
  *
  * @method
- * @param {String} base64 - The Base64 string.
+ * @param {string} base64 - The Base64 string.
  * @return {ArrayBuffer} The array buffer.
  */
 export function base64ToArrayBuffer( base64 ) {

--- a/src/nodes/core/NodeVar.js
+++ b/src/nodes/core/NodeVar.js
@@ -9,17 +9,17 @@ class NodeVar {
 	/**
 	 * Constructs a new node variable.
 	 *
-	 * @param {String} name - The name of the variable.
-	 * @param {String} type - The type of the variable.
-	 * @param {Boolean} [readOnly=false] - The read-only flag.
-	 * @param {Number?} [count=null] - The size.
+	 * @param {string} name - The name of the variable.
+	 * @param {string} type - The type of the variable.
+	 * @param {boolean} [readOnly=false] - The read-only flag.
+	 * @param {number?} [count=null] - The size.
 	 */
 	constructor( name, type, readOnly = false, count = null ) {
 
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -28,28 +28,28 @@ class NodeVar {
 		/**
 		 * The name of the variable.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.name = name;
 
 		/**
 		 * The type of the variable.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.type = type;
 
 		/**
 		 *  The read-only flag.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 */
 		this.readOnly = readOnly;
 
 		/**
 		 * The size.
 		 *
-		 * @type {Number?}
+		 * @type {number?}
 		 */
 		this.count = count;
 

--- a/src/nodes/core/NodeVarying.js
+++ b/src/nodes/core/NodeVarying.js
@@ -13,8 +13,8 @@ class NodeVarying extends NodeVar {
 	/**
 	 * Constructs a new node varying.
 	 *
-	 * @param {String} name - The name of the varying.
-	 * @param {String} type - The type of the varying.
+	 * @param {string} name - The name of the varying.
+	 * @param {string} type - The type of the varying.
 	 */
 	constructor( name, type ) {
 
@@ -24,7 +24,7 @@ class NodeVarying extends NodeVar {
 		 * Whether this varying requires interpolation or not. This property can be used
 		 * to check if the varying can be optimized for a variable.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default false
 		 */
 		this.needsInterpolation = false;
@@ -32,7 +32,7 @@ class NodeVarying extends NodeVar {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */

--- a/src/nodes/core/OutputStructNode.js
+++ b/src/nodes/core/OutputStructNode.js
@@ -34,7 +34,7 @@ class OutputStructNode extends Node {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */

--- a/src/nodes/core/ParameterNode.js
+++ b/src/nodes/core/ParameterNode.js
@@ -17,8 +17,8 @@ class ParameterNode extends PropertyNode {
 	/**
 	 * Constructs a new parameter node.
 	 *
-	 * @param {String} nodeType - The type of the node.
-	 * @param {String?} [name=null] - The name of the parameter in the shader.
+	 * @param {string} nodeType - The type of the node.
+	 * @param {string?} [name=null] - The name of the parameter in the shader.
 	 */
 	constructor( nodeType, name = null ) {
 
@@ -27,7 +27,7 @@ class ParameterNode extends PropertyNode {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -56,8 +56,8 @@ export default ParameterNode;
  *
  * @tsl
  * @function
- * @param {String} type - The type of the node.
- * @param {String?} name - The name of the parameter in the shader.
+ * @param {string} type - The type of the node.
+ * @param {string?} name - The name of the parameter in the shader.
  * @returns {ParameterNode}
  */
 export const parameter = ( type, name ) => nodeObject( new ParameterNode( type, name ) );

--- a/src/nodes/core/PropertyNode.js
+++ b/src/nodes/core/PropertyNode.js
@@ -24,9 +24,9 @@ class PropertyNode extends Node {
 	/**
 	 * Constructs a new property node.
 	 *
-	 * @param {String} nodeType - The type of the node.
-	 * @param {String?} [name=null] - The name of the property in the shader.
-	 * @param {Boolean} [varying=false] - Whether this property is a varying or not.
+	 * @param {string} nodeType - The type of the node.
+	 * @param {string?} [name=null] - The name of the property in the shader.
+	 * @param {boolean} [varying=false] - Whether this property is a varying or not.
 	 */
 	constructor( nodeType, name = null, varying = false ) {
 
@@ -36,7 +36,7 @@ class PropertyNode extends Node {
 		 * The name of the property in the shader. If no name is defined,
 		 * the node system auto-generates one.
 		 *
-		 * @type {String?}
+		 * @type {string?}
 		 * @default null
 		 */
 		this.name = name;
@@ -44,7 +44,7 @@ class PropertyNode extends Node {
 		/**
 		 * Whether this property is a varying or not.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default false
 		 */
 		this.varying = varying;
@@ -52,7 +52,7 @@ class PropertyNode extends Node {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -70,7 +70,7 @@ class PropertyNode extends Node {
 	 * The method is overwritten so it always returns `true`.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {Boolean} Whether this node is global or not.
+	 * @return {boolean} Whether this node is global or not.
 	 */
 	isGlobal( /*builder*/ ) {
 
@@ -106,8 +106,8 @@ export default PropertyNode;
  *
  * @tsl
  * @function
- * @param {String} type - The type of the node.
- * @param {String?} [name=null] - The name of the property in the shader.
+ * @param {string} type - The type of the node.
+ * @param {string?} [name=null] - The name of the property in the shader.
  * @returns {PropertyNode}
  */
 export const property = ( type, name ) => nodeObject( new PropertyNode( type, name ) );
@@ -117,8 +117,8 @@ export const property = ( type, name ) => nodeObject( new PropertyNode( type, na
  *
  * @tsl
  * @function
- * @param {String} type - The type of the node.
- * @param {String?} [name=null] - The name of the varying in the shader.
+ * @param {string} type - The type of the node.
+ * @param {string?} [name=null] - The name of the varying in the shader.
  * @returns {PropertyNode}
  */
 export const varyingProperty = ( type, name ) => nodeObject( new PropertyNode( type, name, true ) );

--- a/src/nodes/core/StackNode.js
+++ b/src/nodes/core/StackNode.js
@@ -60,7 +60,7 @@ class StackNode extends Node {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */

--- a/src/nodes/core/StructTypeNode.js
+++ b/src/nodes/core/StructTypeNode.js
@@ -62,7 +62,7 @@ class StructTypeNode extends Node {
 		/**
 		 * The name of the struct.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default null
 		 */
 		this.name = name;
@@ -70,7 +70,7 @@ class StructTypeNode extends Node {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -82,7 +82,7 @@ class StructTypeNode extends Node {
 	 * Returns the length of the struct.
 	 * The length is calculated by summing the lengths of the struct's members.
 	 *
-	 * @returns {Number} The length of the struct.
+	 * @returns {number} The length of the struct.
 	 */
 	getLength() {
 

--- a/src/nodes/core/TempNode.js
+++ b/src/nodes/core/TempNode.js
@@ -19,7 +19,7 @@ class TempNode extends Node {
 	/**
 	 * Constructs a temp node.
 	 *
-	 * @param {String?} nodeType - The node type.
+	 * @param {string?} nodeType - The node type.
 	 */
 	constructor( nodeType = null ) {
 
@@ -28,7 +28,7 @@ class TempNode extends Node {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -40,7 +40,7 @@ class TempNode extends Node {
 	 * Whether this node is used more than once in context of other nodes.
 	 *
 	 * @param {NodeBuilder} builder - The node builder.
-	 * @return {Boolean} A flag that indicates if there is more than one dependency to other nodes.
+	 * @return {boolean} A flag that indicates if there is more than one dependency to other nodes.
 	 */
 	hasDependencies( builder ) {
 

--- a/src/nodes/core/UniformGroupNode.js
+++ b/src/nodes/core/UniformGroupNode.js
@@ -24,9 +24,9 @@ class UniformGroupNode extends Node {
 	/**
 	 * Constructs a new uniform group node.
 	 *
-	 * @param {String} name - The name of the uniform group node.
-	 * @param {Boolean} [shared=false] - Whether this uniform group node is shared or not.
-	 * @param {Number} [order=1] - Influences the internal sorting.
+	 * @param {string} name - The name of the uniform group node.
+	 * @param {boolean} [shared=false] - Whether this uniform group node is shared or not.
+	 * @param {number} [order=1] - Influences the internal sorting.
 	 */
 	constructor( name, shared = false, order = 1 ) {
 
@@ -35,14 +35,14 @@ class UniformGroupNode extends Node {
 		/**
 		 * The name of the uniform group node.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.name = name;
 
 		/**
 		 * Whether this uniform group node is shared or not.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default false
 		 */
 		this.shared = shared;
@@ -51,7 +51,7 @@ class UniformGroupNode extends Node {
 		 * Influences the internal sorting.
 		 * TODO: Add details when this property should be changed.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @default 1
 		 */
 		this.order = order;
@@ -59,7 +59,7 @@ class UniformGroupNode extends Node {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -96,7 +96,7 @@ export default UniformGroupNode;
  *
  * @tsl
  * @function
- * @param {String} name - The name of the uniform group node.
+ * @param {string} name - The name of the uniform group node.
  * @returns {UniformGroupNode}
  */
 export const uniformGroup = ( name ) => new UniformGroupNode( name );
@@ -106,8 +106,8 @@ export const uniformGroup = ( name ) => new UniformGroupNode( name );
  *
  * @tsl
  * @function
- * @param {String} name - The name of the uniform group node.
- * @param {Number} [order=0] - Influences the internal sorting.
+ * @param {string} name - The name of the uniform group node.
+ * @param {number} [order=0] - Influences the internal sorting.
  * @returns {UniformGroupNode}
  */
 export const sharedUniformGroup = ( name, order = 0 ) => new UniformGroupNode( name, true, order );

--- a/src/nodes/core/UniformNode.js
+++ b/src/nodes/core/UniformNode.js
@@ -18,8 +18,8 @@ class UniformNode extends InputNode {
 	/**
 	 * Constructs a new uniform node.
 	 *
-	 * @param {Any} value - The value of this node. Usually a JS primitive or three.js object (vector, matrix, color, texture).
-	 * @param {String?} nodeType - The node type. If no explicit type is defined, the node tries to derive the type from its value.
+	 * @param {any} value - The value of this node. Usually a JS primitive or three.js object (vector, matrix, color, texture).
+	 * @param {string?} nodeType - The node type. If no explicit type is defined, the node tries to derive the type from its value.
 	 */
 	constructor( value, nodeType = null ) {
 
@@ -28,7 +28,7 @@ class UniformNode extends InputNode {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -37,7 +37,7 @@ class UniformNode extends InputNode {
 		/**
 		 * The name or label of the uniform.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default ''
 		 */
 		this.name = '';
@@ -56,7 +56,7 @@ class UniformNode extends InputNode {
 	/**
 	 * Sets the {@link UniformNode#name} property.
 	 *
-	 * @param {String} name - The name of the uniform.
+	 * @param {string} name - The name of the uniform.
 	 * @return {UniformNode} A reference to this node.
 	 */
 	label( name ) {
@@ -97,7 +97,7 @@ class UniformNode extends InputNode {
 	 * classes might overwrite this method with a different implementation.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The uniform hash.
+	 * @return {string} The uniform hash.
 	 */
 	getUniformHash( builder ) {
 
@@ -161,8 +161,8 @@ export default UniformNode;
  *
  * @tsl
  * @function
- * @param {Any} arg1 - The value of this node. Usually a JS primitive or three.js object (vector, matrix, color, texture).
- * @param {String?} arg2 - The node type. If no explicit type is defined, the node tries to derive the type from its value.
+ * @param {any} arg1 - The value of this node. Usually a JS primitive or three.js object (vector, matrix, color, texture).
+ * @param {string?} arg2 - The node type. If no explicit type is defined, the node tries to derive the type from its value.
  * @returns {UniformNode}
  */
 export const uniform = ( arg1, arg2 ) => {

--- a/src/nodes/core/VarNode.js
+++ b/src/nodes/core/VarNode.js
@@ -23,8 +23,8 @@ class VarNode extends Node {
 	 * Constructs a new variable node.
 	 *
 	 * @param {Node} node - The node for which a variable should be created.
-	 * @param {String?} name - The name of the variable in the shader.
-	 * @param {Boolean?} readOnly - The read-only flag.
+	 * @param {string?} name - The name of the variable in the shader.
+	 * @param {boolean?} readOnly - The read-only flag.
 	 */
 	constructor( node, name = null, readOnly = false ) {
 
@@ -41,7 +41,7 @@ class VarNode extends Node {
 		 * The name of the variable in the shader. If no name is defined,
 		 * the node system auto-generates one.
 		 *
-		 * @type {String?}
+		 * @type {string?}
 		 * @default null
 		 */
 		this.name = name;
@@ -49,7 +49,7 @@ class VarNode extends Node {
 		/**
 		 * `VarNode` sets this property to `true` by default.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default true
 		 */
 		this.global = true;
@@ -57,7 +57,7 @@ class VarNode extends Node {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -67,7 +67,7 @@ class VarNode extends Node {
 		 *
 		 * The read-only flag.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default false
 		 */
 		this.readOnly = readOnly;
@@ -159,7 +159,7 @@ export default VarNode;
  * @tsl
  * @function
  * @param {Node} node - The node for which a variable should be created.
- * @param {String?} name - The name of the variable in the shader.
+ * @param {string?} name - The name of the variable in the shader.
  * @returns {VarNode}
  */
 const createVar = /*@__PURE__*/ nodeProxy( VarNode );
@@ -170,7 +170,7 @@ const createVar = /*@__PURE__*/ nodeProxy( VarNode );
  * @tsl
  * @function
  * @param {Node} node - The node for which a variable should be created.
- * @param {String?} name - The name of the variable in the shader.
+ * @param {string?} name - The name of the variable in the shader.
  * @returns {VarNode}
  */
 export const Var = ( node, name = null ) => createVar( node, name ).append();
@@ -181,7 +181,7 @@ export const Var = ( node, name = null ) => createVar( node, name ).append();
  * @tsl
  * @function
  * @param {Node} node - The node for which a constant should be created.
- * @param {String?} name - The name of the constant in the shader.
+ * @param {string?} name - The name of the constant in the shader.
  * @returns {VarNode}
  */
 export const Const = ( node, name = null ) => createVar( node, name, true ).append();
@@ -198,7 +198,7 @@ addMethodChaining( 'toConst', Const );
  * @function
  * @deprecated since r170. Use `Var( node )` or `node.toVar()` instead.
  *
- * @param {Any} node
+ * @param {any} node
  * @returns {VarNode}
  */
 export const temp = ( node ) => { // @deprecated, r170

--- a/src/nodes/core/VaryingNode.js
+++ b/src/nodes/core/VaryingNode.js
@@ -24,7 +24,7 @@ class VaryingNode extends Node {
 	 * Constructs a new varying node.
 	 *
 	 * @param {Node} node - The node for which a varying should be created.
-	 * @param {String?} name - The name of the varying in the shader.
+	 * @param {string?} name - The name of the varying in the shader.
 	 */
 	constructor( node, name = null ) {
 
@@ -41,7 +41,7 @@ class VaryingNode extends Node {
 		 * The name of the varying in the shader. If no name is defined,
 		 * the node system auto-generates one.
 		 *
-		 * @type {String?}
+		 * @type {string?}
 		 * @default null
 		 */
 		this.name = name;
@@ -49,7 +49,7 @@ class VaryingNode extends Node {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -61,7 +61,7 @@ class VaryingNode extends Node {
 	 * The method is overwritten so it always returns `true`.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {Boolean} Whether this node is global or not.
+	 * @return {boolean} Whether this node is global or not.
 	 */
 	isGlobal( /*builder*/ ) {
 
@@ -170,7 +170,7 @@ export default VaryingNode;
  * @tsl
  * @function
  * @param {Node} node - The node for which a varying should be created.
- * @param {String?} name - The name of the varying in the shader.
+ * @param {string?} name - The name of the varying in the shader.
  * @returns {VaryingNode}
  */
 export const varying = /*@__PURE__*/ nodeProxy( VaryingNode );

--- a/src/nodes/display/ColorSpaceNode.js
+++ b/src/nodes/display/ColorSpaceNode.js
@@ -27,8 +27,8 @@ class ColorSpaceNode extends TempNode {
 	 * Constructs a new color space node.
 	 *
 	 * @param {Node} colorNode - Represents the color to convert.
-	 * @param {String} source - The source color space.
-	 * @param {String} target - The target color space.
+	 * @param {string} source - The source color space.
+	 * @param {string} target - The target color space.
 	 */
 	constructor( colorNode, source, target ) {
 
@@ -44,14 +44,14 @@ class ColorSpaceNode extends TempNode {
 		/**
 		 * The source color space.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.source = source;
 
 		/**
 		 * The target color space.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.target = target;
 
@@ -63,8 +63,8 @@ class ColorSpaceNode extends TempNode {
 	 * color management and renderer.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @param {String} colorSpace - The color space to resolve.
-	 * @return {String} The resolved color space.
+	 * @param {string} colorSpace - The color space to resolve.
+	 * @return {string} The resolved color space.
 	 */
 	resolveColorSpace( builder, colorSpace ) {
 
@@ -152,7 +152,7 @@ export const toWorkingColorSpace = ( node ) => nodeObject( new ColorSpaceNode( n
  * @tsl
  * @function
  * @param {Node} node - Represents the node to convert.
- * @param {String} colorSpace - The target color space.
+ * @param {string} colorSpace - The target color space.
  * @returns {ColorSpaceNode}
  */
 export const workingToColorSpace = ( node, colorSpace ) => nodeObject( new ColorSpaceNode( nodeObject( node ), WORKING_COLOR_SPACE, colorSpace ) );
@@ -163,7 +163,7 @@ export const workingToColorSpace = ( node, colorSpace ) => nodeObject( new Color
  * @tsl
  * @function
  * @param {Node} node - Represents the node to convert.
- * @param {String} colorSpace - The source color space.
+ * @param {string} colorSpace - The source color space.
  * @returns {ColorSpaceNode}
  */
 export const colorSpaceToWorking = ( node, colorSpace ) => nodeObject( new ColorSpaceNode( nodeObject( node ), colorSpace, WORKING_COLOR_SPACE ) );
@@ -174,8 +174,8 @@ export const colorSpaceToWorking = ( node, colorSpace ) => nodeObject( new Color
  * @tsl
  * @function
  * @param {Node} node - Represents the node to convert.
- * @param {String} sourceColorSpace - The source color space.
- * @param {String} targetColorSpace - The target color space.
+ * @param {string} sourceColorSpace - The source color space.
+ * @param {string} targetColorSpace - The target color space.
  * @returns {ColorSpaceNode}
  */
 export const convertColorSpace = ( node, sourceColorSpace, targetColorSpace ) => nodeObject( new ColorSpaceNode( nodeObject( node ), sourceColorSpace, targetColorSpace ) );

--- a/src/nodes/display/FrontFacingNode.js
+++ b/src/nodes/display/FrontFacingNode.js
@@ -26,7 +26,7 @@ class FrontFacingNode extends Node {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */

--- a/src/nodes/display/PassNode.js
+++ b/src/nodes/display/PassNode.js
@@ -80,8 +80,8 @@ class PassMultipleTextureNode extends PassTextureNode {
 	 * Constructs a new pass texture node.
 	 *
 	 * @param {PassNode} passNode - The pass node.
-	 * @param {String} textureName - The output texture name.
-	 * @param {Boolean} [previousTexture=false] - Whether previous frame data should be used or not.
+	 * @param {string} textureName - The output texture name.
+	 * @param {boolean} [previousTexture=false] - Whether previous frame data should be used or not.
 	 */
 	constructor( passNode, textureName, previousTexture = false ) {
 
@@ -94,14 +94,14 @@ class PassMultipleTextureNode extends PassTextureNode {
 		/**
 		 * The output texture name.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.textureName = textureName;
 
 		/**
 		 * Whether previous frame data should be used or not.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 */
 		this.previousTexture = previousTexture;
 
@@ -199,7 +199,7 @@ class PassNode extends TempNode {
 		 * The pass's pixel ratio. Will be kept automatically kept in sync with the renderer's pixel ratio.
 		 *
 		 * @private
-		 * @type {Number}
+		 * @type {number}
 		 * @default 1
 		 */
 		this._pixelRatio = 1;
@@ -207,7 +207,7 @@ class PassNode extends TempNode {
 		/**
 		 * The pass's pixel width. Will be kept automatically kept in sync with the renderer's width.
 		 * @private
-		 * @type {Number}
+		 * @type {number}
 		 * @default 1
 		 */
 		this._width = 1;
@@ -215,7 +215,7 @@ class PassNode extends TempNode {
 		/**
 		 * The pass's pixel height. Will be kept automatically kept in sync with the renderer's height.
 		 * @private
-		 * @type {Number}
+		 * @type {number}
 		 * @default 1
 		 */
 		this._height = 1;
@@ -240,7 +240,7 @@ class PassNode extends TempNode {
 		 * A dictionary holding the internal result textures.
 		 *
 		 * @private
-		 * @type {Object<String, Texture>}
+		 * @type {Object<string, Texture>}
 		 */
 		this._textures = {
 			output: renderTarget.texture,
@@ -251,7 +251,7 @@ class PassNode extends TempNode {
 		 * A dictionary holding the internal texture nodes.
 		 *
 		 * @private
-		 * @type {Object<String, TextureNode>}
+		 * @type {Object<string, TextureNode>}
 		 */
 		this._textureNodes = {};
 
@@ -276,7 +276,7 @@ class PassNode extends TempNode {
 		 * Used for computing velocity/motion vectors.
 		 *
 		 * @private
-		 * @type {Object<String, Texture>}
+		 * @type {Object<string, Texture>}
 		 */
 		this._previousTextures = {};
 
@@ -285,7 +285,7 @@ class PassNode extends TempNode {
 		 * Used for computing velocity/motion vectors.
 		 *
 		 * @private
-		 * @type {Object<String, TextureNode>}
+		 * @type {Object<string, TextureNode>}
 		 */
 		this._previousTextureNodes = {};
 
@@ -317,7 +317,7 @@ class PassNode extends TempNode {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -327,7 +327,7 @@ class PassNode extends TempNode {
 		 * The `updateBeforeType` is set to `NodeUpdateType.FRAME` since the node renders the
 		 * scene once per frame in its {@link PassNode#updateBefore} method.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default 'frame'
 		 */
 		this.updateBeforeType = NodeUpdateType.FRAME;
@@ -362,7 +362,7 @@ class PassNode extends TempNode {
 	/**
 	 * The method is overwritten so it always returns `true`.
 	 *
-	 * @return {Boolean} Whether this node is global or not.
+	 * @return {boolean} Whether this node is global or not.
 	 */
 	isGlobal() {
 
@@ -373,7 +373,7 @@ class PassNode extends TempNode {
 	/**
 	 * Returns the texture for the given output name.
 	 *
-	 * @param {String} name - The output name to get the texture for.
+	 * @param {string} name - The output name to get the texture for.
 	 * @return {Texture} The texture.
 	 */
 	getTexture( name ) {
@@ -400,7 +400,7 @@ class PassNode extends TempNode {
 	/**
 	 * Returns the texture holding the data of the previous frame for the given output name.
 	 *
-	 * @param {String} name - The output name to get the texture for.
+	 * @param {string} name - The output name to get the texture for.
 	 * @return {Texture} The texture holding the data of the previous frame.
 	 */
 	getPreviousTexture( name ) {
@@ -422,7 +422,7 @@ class PassNode extends TempNode {
 	/**
 	 * Switches current and previous textures for the given output name.
 	 *
-	 * @param {String} name - The output name.
+	 * @param {string} name - The output name.
 	 */
 	toggleTexture( name ) {
 
@@ -448,7 +448,7 @@ class PassNode extends TempNode {
 	/**
 	 * Returns the texture node for the given output name.
 	 *
-	 * @param {String} [name='output'] - The output name to get the texture node for.
+	 * @param {string} [name='output'] - The output name to get the texture node for.
 	 * @return {TextureNode} The texture node.
 	 */
 	getTextureNode( name = 'output' ) {
@@ -470,7 +470,7 @@ class PassNode extends TempNode {
 	/**
 	 * Returns the previous texture node for the given output name.
 	 *
-	 * @param {String} [name='output'] - The output name to get the previous texture node for.
+	 * @param {string} [name='output'] - The output name to get the previous texture node for.
 	 * @return {TextureNode} The previous texture node.
 	 */
 	getPreviousTextureNode( name = 'output' ) {
@@ -494,7 +494,7 @@ class PassNode extends TempNode {
 	/**
 	 * Returns a viewZ node of this pass.
 	 *
-	 * @param {String} [name='depth'] - The output name to get the viewZ node for. In most cases the default `'depth'` can be used however the parameter exists for custom depth outputs.
+	 * @param {string} [name='depth'] - The output name to get the viewZ node for. In most cases the default `'depth'` can be used however the parameter exists for custom depth outputs.
 	 * @return {Node} The viewZ node.
 	 */
 	getViewZNode( name = 'depth' ) {
@@ -517,7 +517,7 @@ class PassNode extends TempNode {
 	/**
 	 * Returns a linear depth node of this pass.
 	 *
-	 * @param {String} [name='depth'] - The output name to get the linear depth node for. In most cases the default `'depth'` can be used however the parameter exists for custom depth outputs.
+	 * @param {string} [name='depth'] - The output name to get the linear depth node for. In most cases the default `'depth'` can be used however the parameter exists for custom depth outputs.
 	 * @return {Node} The linear depth node.
 	 */
 	getLinearDepthNode( name = 'depth' ) {
@@ -593,8 +593,8 @@ class PassNode extends TempNode {
 	/**
 	 * Sets the size of the pass's render target. Honors the pixel ratio.
 	 *
-	 * @param {Number} width - The width to set.
-	 * @param {Number} height - The height to set.
+	 * @param {number} width - The width to set.
+	 * @param {number} height - The height to set.
 	 */
 	setSize( width, height ) {
 
@@ -611,7 +611,7 @@ class PassNode extends TempNode {
 	/**
 	 * Sets the pixel ratio the pass's render target and updates the size.
 	 *
-	 * @param {Number} pixelRatio - The pixel ratio to set.
+	 * @param {number} pixelRatio - The pixel ratio to set.
 	 */
 	setPixelRatio( pixelRatio ) {
 

--- a/src/nodes/display/RenderOutputNode.js
+++ b/src/nodes/display/RenderOutputNode.js
@@ -39,8 +39,8 @@ class RenderOutputNode extends TempNode {
 	 * Constructs a new render output node.
 	 *
 	 * @param {Node} colorNode - The color node to process.
-	 * @param {Number} toneMapping - The tone mapping type.
-	 * @param {String} outputColorSpace - The output color space.
+	 * @param {number} toneMapping - The tone mapping type.
+	 * @param {string} outputColorSpace - The output color space.
 	 */
 	constructor( colorNode, toneMapping, outputColorSpace ) {
 
@@ -56,21 +56,21 @@ class RenderOutputNode extends TempNode {
 		/**
 		 * The tone mapping type.
 		 *
-		 * @type {Number?}
+		 * @type {number?}
 		 */
 		this.toneMapping = toneMapping;
 
 		/**
 		 * The output color space.
 		 *
-		 * @type {String?}
+		 * @type {string?}
 		 */
 		this.outputColorSpace = outputColorSpace;
 
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -115,8 +115,8 @@ export default RenderOutputNode;
  * @tsl
  * @function
  * @param {Node} color - The color node to process.
- * @param {Number?} [toneMapping=null] - The tone mapping type.
- * @param {String?} [outputColorSpace=null] - The output color space.
+ * @param {number?} [toneMapping=null] - The tone mapping type.
+ * @param {string?} [outputColorSpace=null] - The output color space.
  * @returns {RenderOutputNode}
  */
 export const renderOutput = ( color, toneMapping = null, outputColorSpace = null ) => nodeObject( new RenderOutputNode( nodeObject( color ), toneMapping, outputColorSpace ) );

--- a/src/nodes/display/ScreenNode.js
+++ b/src/nodes/display/ScreenNode.js
@@ -47,7 +47,7 @@ class ScreenNode extends Node {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */

--- a/src/nodes/display/ToneMappingNode.js
+++ b/src/nodes/display/ToneMappingNode.js
@@ -21,7 +21,7 @@ class ToneMappingNode extends TempNode {
 	/**
 	 * Constructs a new tone mapping node.
 	 *
-	 * @param {Number} toneMapping - The tone mapping type.
+	 * @param {number} toneMapping - The tone mapping type.
 	 * @param {Node} exposureNode - The tone mapping exposure.
 	 * @param {Node} [colorNode=null] - The color node to process.
 	 */
@@ -32,7 +32,7 @@ class ToneMappingNode extends TempNode {
 		/**
 		 * The tone mapping type.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 */
 		this.toneMapping = toneMapping;
 
@@ -58,7 +58,7 @@ class ToneMappingNode extends TempNode {
 	 * Overwrites the default `customCacheKey()` implementation by including the tone
 	 * mapping type into the cache key.
 	 *
-	 * @return {Number} The hash.
+	 * @return {number} The hash.
 	 */
 	customCacheKey() {
 
@@ -102,8 +102,8 @@ export default ToneMappingNode;
  *
  * @tsl
  * @function
- * @param {Number} mapping - The tone mapping type.
- * @param {Node<float> | Number} exposure - The tone mapping exposure.
+ * @param {number} mapping - The tone mapping type.
+ * @param {Node<float> | number} exposure - The tone mapping exposure.
  * @param {Node<vec3> | Color} color - The color node to process.
  * @returns {ToneMappingNode<vec3>}
  */

--- a/src/nodes/display/ToonOutlinePassNode.js
+++ b/src/nodes/display/ToonOutlinePassNode.js
@@ -176,8 +176,8 @@ export default ToonOutlinePassNode;
  * @param {Scene} scene - A reference to the scene.
  * @param {Camera} camera - A reference to the camera.
  * @param {Color} color - Defines the outline's color.
- * @param {Number} [thickness=0.003] - Defines the outline's thickness.
- * @param {Number} [alpha=1] - Defines the outline's alpha.
+ * @param {number} [thickness=0.003] - Defines the outline's thickness.
+ * @param {number} [alpha=1] - Defines the outline's alpha.
  * @returns {ToonOutlinePassNode}
  */
 export const toonOutlinePass = ( scene, camera, color = new Color( 0, 0, 0 ), thickness = 0.003, alpha = 1 ) => nodeObject( new ToonOutlinePassNode( scene, camera, nodeObject( color ), nodeObject( thickness ), nodeObject( alpha ) ) );

--- a/src/nodes/display/ViewportDepthNode.js
+++ b/src/nodes/display/ViewportDepthNode.js
@@ -53,7 +53,7 @@ class ViewportDepthNode extends Node {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */

--- a/src/nodes/display/ViewportTextureNode.js
+++ b/src/nodes/display/ViewportTextureNode.js
@@ -47,7 +47,7 @@ class ViewportTextureNode extends TextureNode {
 		/**
 		 * Whether to generate mipmaps or not.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default false
 		 */
 		this.generateMipmaps = false;
@@ -55,7 +55,7 @@ class ViewportTextureNode extends TextureNode {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -65,7 +65,7 @@ class ViewportTextureNode extends TextureNode {
 		 * The `updateBeforeType` is set to `NodeUpdateType.FRAME` since the node renders the
 		 * scene once per frame in its {@link ViewportTextureNode#updateBefore} method.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default 'frame'
 		 */
 		this.updateBeforeType = NodeUpdateType.FRAME;

--- a/src/nodes/functions/PhongLightingModel.js
+++ b/src/nodes/functions/PhongLightingModel.js
@@ -40,7 +40,7 @@ class PhongLightingModel extends BasicLightingModel {
 	/**
 	 * Constructs a new phong lighting model.
 	 *
-	 * @param {Boolean} [specular=true] - Whether specular is supported or not.
+	 * @param {boolean} [specular=true] - Whether specular is supported or not.
 	 */
 	constructor( specular = true ) {
 
@@ -51,7 +51,7 @@ class PhongLightingModel extends BasicLightingModel {
 		 * looking for a Lambert-like material meaning a material for non-shiny
 		 * surfaces, without specular highlights.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default true
 		 */
 		this.specular = specular;

--- a/src/nodes/functions/PhysicalLightingModel.js
+++ b/src/nodes/functions/PhysicalLightingModel.js
@@ -352,12 +352,12 @@ class PhysicalLightingModel extends LightingModel {
 	/**
 	 * Constructs a new physical lighting model.
 	 *
-	 * @param {Boolean} [clearcoat=false] - Whether clearcoat is supported or not.
-	 * @param {Boolean} [sheen=false] - Whether sheen is supported or not.
-	 * @param {Boolean} [iridescence=false] - Whether iridescence is supported or not.
-	 * @param {Boolean} [anisotropy=false] - Whether anisotropy is supported or not.
-	 * @param {Boolean} [transmission=false] - Whether transmission is supported or not.
-	 * @param {Boolean} [dispersion=false] - Whether dispersion is supported or not.
+	 * @param {boolean} [clearcoat=false] - Whether clearcoat is supported or not.
+	 * @param {boolean} [sheen=false] - Whether sheen is supported or not.
+	 * @param {boolean} [iridescence=false] - Whether iridescence is supported or not.
+	 * @param {boolean} [anisotropy=false] - Whether anisotropy is supported or not.
+	 * @param {boolean} [transmission=false] - Whether transmission is supported or not.
+	 * @param {boolean} [dispersion=false] - Whether dispersion is supported or not.
 	 */
 	constructor( clearcoat = false, sheen = false, iridescence = false, anisotropy = false, transmission = false, dispersion = false ) {
 
@@ -366,7 +366,7 @@ class PhysicalLightingModel extends LightingModel {
 		/**
 		 * Whether clearcoat is supported or not.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default false
 		 */
 		this.clearcoat = clearcoat;
@@ -374,7 +374,7 @@ class PhysicalLightingModel extends LightingModel {
 		/**
 		 * Whether sheen is supported or not.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default false
 		 */
 		this.sheen = sheen;
@@ -382,7 +382,7 @@ class PhysicalLightingModel extends LightingModel {
 		/**
 		 * Whether iridescence is supported or not.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default false
 		 */
 		this.iridescence = iridescence;
@@ -390,7 +390,7 @@ class PhysicalLightingModel extends LightingModel {
 		/**
 		 * Whether anisotropy is supported or not.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default false
 		 */
 		this.anisotropy = anisotropy;
@@ -398,7 +398,7 @@ class PhysicalLightingModel extends LightingModel {
 		/**
 		 * Whether transmission is supported or not.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default false
 		 */
 		this.transmission = transmission;
@@ -406,7 +406,7 @@ class PhysicalLightingModel extends LightingModel {
 		/**
 		 * Whether dispersion is supported or not.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default false
 		 */
 		this.dispersion = dispersion;

--- a/src/nodes/geometry/RangeNode.js
+++ b/src/nodes/geometry/RangeNode.js
@@ -63,7 +63,7 @@ class RangeNode extends Node {
 	 * Returns the vector length which is computed based on the range definition.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {Number} The vector length.
+	 * @return {number} The vector length.
 	 */
 	getVectorLength( builder ) {
 
@@ -78,7 +78,7 @@ class RangeNode extends Node {
 	 * This method is overwritten since the node type is inferred from range definition.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The node type.
+	 * @return {string} The node type.
 	 */
 	getNodeType( builder ) {
 

--- a/src/nodes/gpgpu/AtomicFunctionNode.js
+++ b/src/nodes/gpgpu/AtomicFunctionNode.js
@@ -23,7 +23,7 @@ class AtomicFunctionNode extends TempNode {
 	/**
 	 * Constructs a new atomic function node.
 	 *
-	 * @param {String} method - The signature of the atomic function to construct.
+	 * @param {string} method - The signature of the atomic function to construct.
 	 * @param {Node} pointerNode - An atomic variable or element of an atomic buffer.
 	 * @param {Node} valueNode - The value that mutates the atomic variable.
 	 * @param {Node?} [storeNode=null] - A variable storing the return value of an atomic operation, typically the value of the atomic variable before the operation.
@@ -35,7 +35,7 @@ class AtomicFunctionNode extends TempNode {
 		/**
 		 * The signature of the atomic function to construct.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.method = method;
 
@@ -68,7 +68,7 @@ class AtomicFunctionNode extends TempNode {
 	 * the pointer node.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The input type.
+	 * @return {string} The input type.
 	 */
 	getInputType( builder ) {
 
@@ -80,7 +80,7 @@ class AtomicFunctionNode extends TempNode {
 	 * Overwritten since the node type is inferred from the input type.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The node type.
+	 * @return {string} The node type.
 	 */
 	getNodeType( builder ) {
 
@@ -144,7 +144,7 @@ export default AtomicFunctionNode;
  *
  * @tsl
  * @function
- * @param {String} method - The signature of the atomic function to construct.
+ * @param {string} method - The signature of the atomic function to construct.
  * @param {Node} pointerNode - An atomic variable or element of an atomic buffer.
  * @param {Node} valueNode - The value that mutates the atomic variable.
  * @param {Node?} [storeNode=null] - A variable storing the return value of an atomic operation, typically the value of the atomic variable before the operation.
@@ -157,7 +157,7 @@ const atomicNode = nodeProxy( AtomicFunctionNode );
  *
  * @tsl
  * @function
- * @param {String} method - The signature of the atomic function to construct.
+ * @param {string} method - The signature of the atomic function to construct.
  * @param {Node} pointerNode - An atomic variable or element of an atomic buffer.
  * @param {Node} valueNode - The value that mutates the atomic variable.
  * @param {Node?} [storeNode=null] - A variable storing the return value of an atomic operation, typically the value of the atomic variable before the operation.

--- a/src/nodes/gpgpu/BarrierNode.js
+++ b/src/nodes/gpgpu/BarrierNode.js
@@ -13,7 +13,7 @@ class BarrierNode extends Node {
 	/**
 	 * Constructs a new barrier node.
 	 *
-	 * @param {String} scope - The scope defines the behavior of the node.
+	 * @param {string} scope - The scope defines the behavior of the node.
 	 */
 	constructor( scope ) {
 
@@ -49,7 +49,7 @@ export default BarrierNode;
  *
  * @tsl
  * @function
- * @param {String} scope - The scope defines the behavior of the node..
+ * @param {string} scope - The scope defines the behavior of the node..
  * @returns {BarrierNode}
  */
 const barrier = nodeProxy( BarrierNode );

--- a/src/nodes/gpgpu/ComputeBuiltinNode.js
+++ b/src/nodes/gpgpu/ComputeBuiltinNode.js
@@ -20,8 +20,8 @@ class ComputeBuiltinNode extends Node {
 	/**
 	 * Constructs a new compute builtin node.
 	 *
-	 * @param {String} builtinName - The built-in name.
-	 * @param {String} nodeType - The node type.
+	 * @param {string} builtinName - The built-in name.
+	 * @param {string} nodeType - The node type.
 	 */
 	constructor( builtinName, nodeType ) {
 
@@ -31,7 +31,7 @@ class ComputeBuiltinNode extends Node {
 		 * The built-in name.
 		 *
 		 * @private
-		 * @type {String}
+		 * @type {string}
 		 */
 		this._builtinName = builtinName;
 
@@ -41,7 +41,7 @@ class ComputeBuiltinNode extends Node {
 	 * This method is overwritten since hash is derived from the built-in name.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The hash.
+	 * @return {string} The hash.
 	 */
 	getHash( builder ) {
 
@@ -53,7 +53,7 @@ class ComputeBuiltinNode extends Node {
 	 * This method is overwritten since the node type is simply derived from `nodeType`..
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The node type.
+	 * @return {string} The node type.
 	 */
 	getNodeType( /*builder*/ ) {
 
@@ -64,7 +64,7 @@ class ComputeBuiltinNode extends Node {
 	/**
 	 * Sets the builtin name.
 	 *
-	 * @param {String} builtinName - The built-in name.
+	 * @param {string} builtinName - The built-in name.
 	 * @return {ComputeBuiltinNode} A reference to this node.
 	 */
 	setBuiltinName( builtinName ) {
@@ -79,7 +79,7 @@ class ComputeBuiltinNode extends Node {
 	 * Returns the builtin name.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The builtin name.
+	 * @return {string} The builtin name.
 	 */
 	getBuiltinName( /*builder*/ ) {
 
@@ -143,8 +143,8 @@ export default ComputeBuiltinNode;
  *
  * @tsl
  * @function
- * @param {String} name - The built-in name.
- * @param {String} nodeType - The node type.
+ * @param {string} name - The built-in name.
+ * @param {string} nodeType - The node type.
  * @returns {ComputeBuiltinNode}
  */
 const computeBuiltin = ( name, nodeType ) => nodeObject( new ComputeBuiltinNode( name, nodeType ) );

--- a/src/nodes/gpgpu/ComputeNode.js
+++ b/src/nodes/gpgpu/ComputeNode.js
@@ -19,8 +19,8 @@ class ComputeNode extends Node {
 	 * Constructs a new compute node.
 	 *
 	 * @param {Node} computeNode - TODO
-	 * @param {Number} count - TODO.
-	 * @param {Array<Number>} [workgroupSize=[64]] - TODO.
+	 * @param {number} count - TODO.
+	 * @param {Array<number>} [workgroupSize=[64]] - TODO.
 	 */
 	constructor( computeNode, count, workgroupSize = [ 64 ] ) {
 
@@ -29,7 +29,7 @@ class ComputeNode extends Node {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -45,14 +45,14 @@ class ComputeNode extends Node {
 		/**
 		 * TODO
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 */
 		this.count = count;
 
 		/**
 		 * TODO
 		 *
-		 * @type {Array<Number>}
+		 * @type {Array<number>}
 		 * @default [64]
 		 */
 		this.workgroupSize = workgroupSize;
@@ -60,21 +60,21 @@ class ComputeNode extends Node {
 		/**
 		 * TODO
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 */
 		this.dispatchCount = 0;
 
 		/**
 		 * TODO
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 */
 		this.version = 1;
 
 		/**
 		 * The name or label of the uniform.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default ''
 		 */
 		this.name = '';
@@ -83,7 +83,7 @@ class ComputeNode extends Node {
 		 * The `updateBeforeType` is set to `NodeUpdateType.OBJECT` since {@link ComputeNode#updateBefore}
 		 * is executed once per object by default.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default 'object'
 		 */
 		this.updateBeforeType = NodeUpdateType.OBJECT;
@@ -111,7 +111,7 @@ class ComputeNode extends Node {
 	/**
 	 * Sets the {@link ComputeNode#name} property.
 	 *
-	 * @param {String} name - The name of the uniform.
+	 * @param {string} name - The name of the uniform.
 	 * @return {ComputeNode} A reference to this node.
 	 */
 	label( name ) {
@@ -191,8 +191,8 @@ export default ComputeNode;
  * @tsl
  * @function
  * @param {Node} node - TODO
- * @param {Number} count - TODO.
- * @param {Array<Number>} [workgroupSize=[64]] - TODO.
+ * @param {number} count - TODO.
+ * @param {Array<number>} [workgroupSize=[64]] - TODO.
  * @returns {AtomicFunctionNode}
  */
 export const compute = ( node, count, workgroupSize ) => nodeObject( new ComputeNode( nodeObject( node ), count, workgroupSize ) );

--- a/src/nodes/gpgpu/WorkgroupInfoNode.js
+++ b/src/nodes/gpgpu/WorkgroupInfoNode.js
@@ -22,7 +22,7 @@ class WorkgroupInfoElementNode extends ArrayElementNode {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -70,9 +70,9 @@ class WorkgroupInfoNode extends Node {
 	/**
 	 * Constructs a new buffer scoped to type scope.
 	 *
-	 * @param {String} scope - TODO.
-	 * @param {String} bufferType - The data type of a 'workgroup' scoped buffer element.
-	 * @param {Number} [bufferCount=0] - The number of elements in the buffer.
+	 * @param {string} scope - TODO.
+	 * @param {string} bufferType - The data type of a 'workgroup' scoped buffer element.
+	 * @param {number} [bufferCount=0] - The number of elements in the buffer.
 	 */
 	constructor( scope, bufferType, bufferCount = 0 ) {
 
@@ -81,14 +81,14 @@ class WorkgroupInfoNode extends Node {
 		/**
 		 * The buffer type.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.bufferType = bufferType;
 
 		/**
 		 * The buffer count.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @default 0
 		 */
 		this.bufferCount = bufferCount;
@@ -96,7 +96,7 @@ class WorkgroupInfoNode extends Node {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -105,14 +105,14 @@ class WorkgroupInfoNode extends Node {
 		/**
 		 * The data type of the array buffer.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.elementType = bufferType;
 
 		/**
 		 * TODO.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.scope = scope;
 
@@ -121,7 +121,7 @@ class WorkgroupInfoNode extends Node {
 	/**
 	 * Sets the name/label of this node.
 	 *
-	 * @param {String} name - The name to set.
+	 * @param {string} name - The name to set.
 	 * @return {WorkgroupInfoNode} A reference to this node.
 	 */
 	label( name ) {
@@ -135,7 +135,7 @@ class WorkgroupInfoNode extends Node {
 	/**
 	 * Sets the scope of this node.
 	 *
-	 * @param {String} scope - The scope to set.
+	 * @param {string} scope - The scope to set.
 	 * @return {WorkgroupInfoNode} A reference to this node.
 	 */
 	setScope( scope ) {
@@ -150,7 +150,7 @@ class WorkgroupInfoNode extends Node {
 	/**
 	 * The data type of the array buffer.
 	 *
-	 * @return {String} The element type.
+	 * @return {string} The element type.
 	 */
 	getElementType() {
 
@@ -163,7 +163,7 @@ class WorkgroupInfoNode extends Node {
 	 * is inferred from the scope.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The input type.
+	 * @return {string} The input type.
 	 */
 	getInputType( /*builder*/ ) {
 
@@ -199,8 +199,8 @@ export default WorkgroupInfoNode;
  *
  * @tsl
  * @function
- * @param {String} type - The data type of a 'workgroup' scoped buffer element.
- * @param {Number} [count=0] - The number of elements in the buffer.
+ * @param {string} type - The data type of a 'workgroup' scoped buffer element.
+ * @param {number} [count=0] - The number of elements in the buffer.
  * @returns {WorkgroupInfoNode}
  */
 export const workgroupArray = ( type, count ) => nodeObject( new WorkgroupInfoNode( 'Workgroup', type, count ) );

--- a/src/nodes/lighting/AnalyticLightNode.js
+++ b/src/nodes/lighting/AnalyticLightNode.js
@@ -80,7 +80,7 @@ class AnalyticLightNode extends LightingNode {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -90,7 +90,7 @@ class AnalyticLightNode extends LightingNode {
 		 * Overwritten since analytic light nodes are updated
 		 * once per frame.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default 'frame'
 		 */
 		this.updateType = NodeUpdateType.FRAME;
@@ -101,7 +101,7 @@ class AnalyticLightNode extends LightingNode {
 	 * Overwrites the default {@link Node#customCacheKey} implementation by including the
 	 * `light.id` and `light.castShadow` into the cache key.
 	 *
-	 * @return {Number} The custom cache key.
+	 * @return {number} The custom cache key.
 	 */
 	customCacheKey() {
 

--- a/src/nodes/lighting/LightingNode.js
+++ b/src/nodes/lighting/LightingNode.js
@@ -23,7 +23,7 @@ class LightingNode extends Node {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */

--- a/src/nodes/lighting/LightsNode.js
+++ b/src/nodes/lighting/LightsNode.js
@@ -91,7 +91,7 @@ class LightsNode extends Node {
 		 * A hash for identifying the current light nodes setup.
 		 *
 		 * @private
-		 * @type {String?}
+		 * @type {string?}
 		 * @default null
 		 */
 		this._lightNodesHash = null;
@@ -99,7 +99,7 @@ class LightsNode extends Node {
 		/**
 		 * `LightsNode` sets this property to `true` by default.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default true
 		 */
 		this.global = true;
@@ -110,7 +110,7 @@ class LightsNode extends Node {
 	 * Overwrites the default {@link Node#customCacheKey} implementation by including the
 	 * light IDs into the cache key.
 	 *
-	 * @return {Number} The custom cache key.
+	 * @return {number} The custom cache key.
 	 */
 	customCacheKey() {
 
@@ -131,7 +131,7 @@ class LightsNode extends Node {
 	 * Computes a hash value for identifying the current light nodes setup.
 	 *
 	 * @param {NodeBuilder} builder - A reference to the current node builder.
-	 * @return {String} The computed hash.
+	 * @return {string} The computed hash.
 	 */
 	getHash( builder ) {
 
@@ -368,7 +368,7 @@ class LightsNode extends Node {
 	/**
 	 * Whether the scene has lights or not.
 	 *
-	 * @type {Boolean}
+	 * @type {boolean}
 	 */
 	get hasLights() {
 

--- a/src/nodes/lighting/PointShadowNode.js
+++ b/src/nodes/lighting/PointShadowNode.js
@@ -187,7 +187,7 @@ class PointShadowNode extends ShadowNode {
 	 * Overwrites the default implementation to return point light shadow specific
 	 * filtering functions.
 	 *
-	 * @param {Number} type - The shadow type.
+	 * @param {number} type - The shadow type.
 	 * @return {Function} The filtering function.
 	 */
 	getShadowFilterFn( type ) {

--- a/src/nodes/lighting/RectAreaLightNode.js
+++ b/src/nodes/lighting/RectAreaLightNode.js
@@ -53,7 +53,7 @@ class RectAreaLightNode extends AnalyticLightNode {
 		 * The `updateType` is set to `NodeUpdateType.RENDER` since the light
 		 * relies on `viewMatrix` which might vary per render call.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default 'render'
 		 */
 		this.updateType = NodeUpdateType.RENDER;

--- a/src/nodes/lighting/ShadowBaseNode.js
+++ b/src/nodes/lighting/ShadowBaseNode.js
@@ -39,7 +39,7 @@ class ShadowBaseNode extends Node {
 		/**
 		 * Overwritten since shadows are updated by default per render.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default 'render'
 		 */
 		this.updateBeforeType = NodeUpdateType.RENDER;
@@ -47,7 +47,7 @@ class ShadowBaseNode extends Node {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */

--- a/src/nodes/lighting/ShadowNode.js
+++ b/src/nodes/lighting/ShadowNode.js
@@ -398,7 +398,7 @@ class ShadowNode extends ShadowBaseNode {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -488,7 +488,7 @@ class ShadowNode extends ShadowBaseNode {
 	/**
 	 * Returns the shadow filtering function for the given shadow type.
 	 *
-	 * @param {Number} type - The shadow type.
+	 * @param {number} type - The shadow type.
 	 * @return {Function} The filtering function.
 	 */
 	getShadowFilterFn( type ) {

--- a/src/nodes/math/ConditionalNode.js
+++ b/src/nodes/math/ConditionalNode.js
@@ -63,7 +63,7 @@ class ConditionalNode extends Node {
 	 * nodes.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The node type.
+	 * @return {string} The node type.
 	 */
 	getNodeType( builder ) {
 

--- a/src/nodes/math/MathNode.js
+++ b/src/nodes/math/MathNode.js
@@ -24,7 +24,7 @@ class MathNode extends TempNode {
 	/**
 	 * Constructs a new math node.
 	 *
-	 * @param {String} method - The method name.
+	 * @param {string} method - The method name.
 	 * @param {Node} aNode - The first input.
 	 * @param {Node?} [bNode=null] - The second input.
 	 * @param {Node?} [cNode=null] - The third input.
@@ -36,7 +36,7 @@ class MathNode extends TempNode {
 		/**
 		 * The method name.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.method = method;
 
@@ -66,7 +66,7 @@ class MathNode extends TempNode {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -78,7 +78,7 @@ class MathNode extends TempNode {
 	 * The input type is inferred from the node types of the input nodes.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The input type.
+	 * @return {string} The input type.
 	 */
 	getInputType( builder ) {
 
@@ -112,7 +112,7 @@ class MathNode extends TempNode {
 	 * The selected method as well as the input type determine the node type of this node.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The node type.
+	 * @return {string} The node type.
 	 */
 	getNodeType( builder ) {
 
@@ -377,7 +377,7 @@ export const PI2 = /*@__PURE__*/ float( Math.PI * 2 );
  *
  * @tsl
  * @function
- * @param {Node | Number} x - The parameter.
+ * @param {Node | number} x - The parameter.
  * @returns {Node<bool>}
  */
 export const all = /*@__PURE__*/ nodeProxy( MathNode, MathNode.ALL );
@@ -387,7 +387,7 @@ export const all = /*@__PURE__*/ nodeProxy( MathNode, MathNode.ALL );
  *
  * @tsl
  * @function
- * @param {Node | Number} x - The parameter.
+ * @param {Node | number} x - The parameter.
  * @returns {Node<bool>}
  */
 export const any = /*@__PURE__*/ nodeProxy( MathNode, MathNode.ANY );
@@ -397,7 +397,7 @@ export const any = /*@__PURE__*/ nodeProxy( MathNode, MathNode.ANY );
  *
  * @tsl
  * @function
- * @param {Node | Number} x - The input in degrees.
+ * @param {Node | number} x - The input in degrees.
  * @returns {Node}
  */
 export const radians = /*@__PURE__*/ nodeProxy( MathNode, MathNode.RADIANS );
@@ -407,7 +407,7 @@ export const radians = /*@__PURE__*/ nodeProxy( MathNode, MathNode.RADIANS );
  *
  * @tsl
  * @function
- * @param {Node | Number} x - The input in radians.
+ * @param {Node | number} x - The input in radians.
  * @returns {Node}
  */
 export const degrees = /*@__PURE__*/ nodeProxy( MathNode, MathNode.DEGREES );
@@ -417,7 +417,7 @@ export const degrees = /*@__PURE__*/ nodeProxy( MathNode, MathNode.DEGREES );
  *
  * @tsl
  * @function
- * @param {Node | Number} x - The parameter.
+ * @param {Node | number} x - The parameter.
  * @returns {Node}
  */
 export const exp = /*@__PURE__*/ nodeProxy( MathNode, MathNode.EXP );
@@ -427,7 +427,7 @@ export const exp = /*@__PURE__*/ nodeProxy( MathNode, MathNode.EXP );
  *
  * @tsl
  * @function
- * @param {Node | Number} x - The parameter.
+ * @param {Node | number} x - The parameter.
  * @returns {Node}
  */
 export const exp2 = /*@__PURE__*/ nodeProxy( MathNode, MathNode.EXP2 );
@@ -437,7 +437,7 @@ export const exp2 = /*@__PURE__*/ nodeProxy( MathNode, MathNode.EXP2 );
  *
  * @tsl
  * @function
- * @param {Node | Number} x - The parameter.
+ * @param {Node | number} x - The parameter.
  * @returns {Node}
  */
 export const log = /*@__PURE__*/ nodeProxy( MathNode, MathNode.LOG );
@@ -447,7 +447,7 @@ export const log = /*@__PURE__*/ nodeProxy( MathNode, MathNode.LOG );
  *
  * @tsl
  * @function
- * @param {Node | Number} x - The parameter.
+ * @param {Node | number} x - The parameter.
  * @returns {Node}
  */
 export const log2 = /*@__PURE__*/ nodeProxy( MathNode, MathNode.LOG2 );
@@ -457,7 +457,7 @@ export const log2 = /*@__PURE__*/ nodeProxy( MathNode, MathNode.LOG2 );
  *
  * @tsl
  * @function
- * @param {Node | Number} x - The parameter.
+ * @param {Node | number} x - The parameter.
  * @returns {Node}
  */
 export const sqrt = /*@__PURE__*/ nodeProxy( MathNode, MathNode.SQRT );
@@ -467,7 +467,7 @@ export const sqrt = /*@__PURE__*/ nodeProxy( MathNode, MathNode.SQRT );
  *
  * @tsl
  * @function
- * @param {Node | Number} x - The parameter.
+ * @param {Node | number} x - The parameter.
  * @returns {Node}
  */
 export const inverseSqrt = /*@__PURE__*/ nodeProxy( MathNode, MathNode.INVERSE_SQRT );
@@ -477,7 +477,7 @@ export const inverseSqrt = /*@__PURE__*/ nodeProxy( MathNode, MathNode.INVERSE_S
  *
  * @tsl
  * @function
- * @param {Node | Number} x - The parameter.
+ * @param {Node | number} x - The parameter.
  * @returns {Node}
  */
 export const floor = /*@__PURE__*/ nodeProxy( MathNode, MathNode.FLOOR );
@@ -487,7 +487,7 @@ export const floor = /*@__PURE__*/ nodeProxy( MathNode, MathNode.FLOOR );
  *
  * @tsl
  * @function
- * @param {Node | Number} x - The parameter.
+ * @param {Node | number} x - The parameter.
  * @returns {Node}
  */
 export const ceil = /*@__PURE__*/ nodeProxy( MathNode, MathNode.CEIL );
@@ -507,7 +507,7 @@ export const normalize = /*@__PURE__*/ nodeProxy( MathNode, MathNode.NORMALIZE )
  *
  * @tsl
  * @function
- * @param {Node | Number} x - The parameter.
+ * @param {Node | number} x - The parameter.
  * @returns {Node}
  */
 export const fract = /*@__PURE__*/ nodeProxy( MathNode, MathNode.FRACT );
@@ -517,7 +517,7 @@ export const fract = /*@__PURE__*/ nodeProxy( MathNode, MathNode.FRACT );
  *
  * @tsl
  * @function
- * @param {Node | Number} x - The parameter.
+ * @param {Node | number} x - The parameter.
  * @returns {Node}
  */
 export const sin = /*@__PURE__*/ nodeProxy( MathNode, MathNode.SIN );
@@ -527,7 +527,7 @@ export const sin = /*@__PURE__*/ nodeProxy( MathNode, MathNode.SIN );
  *
  * @tsl
  * @function
- * @param {Node | Number} x - The parameter.
+ * @param {Node | number} x - The parameter.
  * @returns {Node}
  */
 export const cos = /*@__PURE__*/ nodeProxy( MathNode, MathNode.COS );
@@ -537,7 +537,7 @@ export const cos = /*@__PURE__*/ nodeProxy( MathNode, MathNode.COS );
  *
  * @tsl
  * @function
- * @param {Node | Number} x - The parameter.
+ * @param {Node | number} x - The parameter.
  * @returns {Node}
  */
 export const tan = /*@__PURE__*/ nodeProxy( MathNode, MathNode.TAN );
@@ -547,7 +547,7 @@ export const tan = /*@__PURE__*/ nodeProxy( MathNode, MathNode.TAN );
  *
  * @tsl
  * @function
- * @param {Node | Number} x - The parameter.
+ * @param {Node | number} x - The parameter.
  * @returns {Node}
  */
 export const asin = /*@__PURE__*/ nodeProxy( MathNode, MathNode.ASIN );
@@ -557,7 +557,7 @@ export const asin = /*@__PURE__*/ nodeProxy( MathNode, MathNode.ASIN );
  *
  * @tsl
  * @function
- * @param {Node | Number} x - The parameter.
+ * @param {Node | number} x - The parameter.
  * @returns {Node}
  */
 export const acos = /*@__PURE__*/ nodeProxy( MathNode, MathNode.ACOS );
@@ -568,8 +568,8 @@ export const acos = /*@__PURE__*/ nodeProxy( MathNode, MathNode.ACOS );
  *
  * @tsl
  * @function
- * @param {Node | Number} y - The y parameter.
- * @param {(Node | Number)?} x - The x parameter.
+ * @param {Node | number} y - The y parameter.
+ * @param {(Node | number)?} x - The x parameter.
  * @returns {Node}
  */
 export const atan = /*@__PURE__*/ nodeProxy( MathNode, MathNode.ATAN );
@@ -579,7 +579,7 @@ export const atan = /*@__PURE__*/ nodeProxy( MathNode, MathNode.ATAN );
  *
  * @tsl
  * @function
- * @param {Node | Number} x - The parameter.
+ * @param {Node | number} x - The parameter.
  * @returns {Node}
  */
 export const abs = /*@__PURE__*/ nodeProxy( MathNode, MathNode.ABS );
@@ -589,7 +589,7 @@ export const abs = /*@__PURE__*/ nodeProxy( MathNode, MathNode.ABS );
  *
  * @tsl
  * @function
- * @param {Node | Number} x - The parameter.
+ * @param {Node | number} x - The parameter.
  * @returns {Node}
  */
 export const sign = /*@__PURE__*/ nodeProxy( MathNode, MathNode.SIGN );
@@ -609,7 +609,7 @@ export const length = /*@__PURE__*/ nodeProxy( MathNode, MathNode.LENGTH );
  *
  * @tsl
  * @function
- * @param {Node | Number} x - The parameter.
+ * @param {Node | number} x - The parameter.
  * @returns {Node}
  */
 export const negate = /*@__PURE__*/ nodeProxy( MathNode, MathNode.NEGATE );
@@ -619,7 +619,7 @@ export const negate = /*@__PURE__*/ nodeProxy( MathNode, MathNode.NEGATE );
  *
  * @tsl
  * @function
- * @param {Node | Number} x - The parameter.
+ * @param {Node | number} x - The parameter.
  * @returns {Node}
  */
 export const oneMinus = /*@__PURE__*/ nodeProxy( MathNode, MathNode.ONE_MINUS );
@@ -629,7 +629,7 @@ export const oneMinus = /*@__PURE__*/ nodeProxy( MathNode, MathNode.ONE_MINUS );
  *
  * @tsl
  * @function
- * @param {Node | Number} x - The parameter.
+ * @param {Node | number} x - The parameter.
  * @returns {Node}
  */
 export const dFdx = /*@__PURE__*/ nodeProxy( MathNode, MathNode.DFDX );
@@ -639,7 +639,7 @@ export const dFdx = /*@__PURE__*/ nodeProxy( MathNode, MathNode.DFDX );
  *
  * @tsl
  * @function
- * @param {Node | Number} x - The parameter.
+ * @param {Node | number} x - The parameter.
  * @returns {Node}
  */
 export const dFdy = /*@__PURE__*/ nodeProxy( MathNode, MathNode.DFDY );
@@ -649,7 +649,7 @@ export const dFdy = /*@__PURE__*/ nodeProxy( MathNode, MathNode.DFDY );
  *
  * @tsl
  * @function
- * @param {Node | Number} x - The parameter.
+ * @param {Node | number} x - The parameter.
  * @returns {Node}
  */
 export const round = /*@__PURE__*/ nodeProxy( MathNode, MathNode.ROUND );
@@ -659,7 +659,7 @@ export const round = /*@__PURE__*/ nodeProxy( MathNode, MathNode.ROUND );
  *
  * @tsl
  * @function
- * @param {Node | Number} x - The parameter.
+ * @param {Node | number} x - The parameter.
  * @returns {Node}
  */
 export const reciprocal = /*@__PURE__*/ nodeProxy( MathNode, MathNode.RECIPROCAL );
@@ -669,7 +669,7 @@ export const reciprocal = /*@__PURE__*/ nodeProxy( MathNode, MathNode.RECIPROCAL
  *
  * @tsl
  * @function
- * @param {Node | Number} x - The parameter.
+ * @param {Node | number} x - The parameter.
  * @returns {Node}
  */
 export const trunc = /*@__PURE__*/ nodeProxy( MathNode, MathNode.TRUNC );
@@ -679,7 +679,7 @@ export const trunc = /*@__PURE__*/ nodeProxy( MathNode, MathNode.TRUNC );
  *
  * @tsl
  * @function
- * @param {Node | Number} x - The parameter.
+ * @param {Node | number} x - The parameter.
  * @returns {Node}
  */
 export const fwidth = /*@__PURE__*/ nodeProxy( MathNode, MathNode.FWIDTH );
@@ -701,8 +701,8 @@ export const transpose = /*@__PURE__*/ nodeProxy( MathNode, MathNode.TRANSPOSE )
  *
  * @tsl
  * @function
- * @param {Node | Number} x - The parameter.
- * @param {String} y - The new type.
+ * @param {Node | number} x - The parameter.
+ * @param {string} y - The new type.
  * @returns {Node}
  */
 export const bitcast = /*@__PURE__*/ nodeProxy( MathNode, MathNode.BITCAST );
@@ -712,8 +712,8 @@ export const bitcast = /*@__PURE__*/ nodeProxy( MathNode, MathNode.BITCAST );
  *
  * @tsl
  * @function
- * @param {Node | Number} x - The first parameter.
- * @param {Node | Number} y - The second parameter.
+ * @param {Node | number} x - The first parameter.
+ * @param {Node | number} y - The second parameter.
  * @returns {Node<bool>}
  */
 export const equals = /*@__PURE__*/ nodeProxy( MathNode, MathNode.EQUALS );
@@ -723,8 +723,8 @@ export const equals = /*@__PURE__*/ nodeProxy( MathNode, MathNode.EQUALS );
  *
  * @tsl
  * @function
- * @param {Node | Number} x - The y parameter.
- * @param {Node | Number} y - The x parameter.
+ * @param {Node | number} x - The y parameter.
+ * @param {Node | number} y - The x parameter.
  * @returns {Node}
  */
 export const min = /*@__PURE__*/ nodeProxy( MathNode, MathNode.MIN );
@@ -734,8 +734,8 @@ export const min = /*@__PURE__*/ nodeProxy( MathNode, MathNode.MIN );
  *
  * @tsl
  * @function
- * @param {Node | Number} x - The y parameter.
- * @param {Node | Number} y - The x parameter.
+ * @param {Node | number} x - The y parameter.
+ * @param {Node | number} y - The x parameter.
  * @returns {Node}
  */
 export const max = /*@__PURE__*/ nodeProxy( MathNode, MathNode.MAX );
@@ -745,8 +745,8 @@ export const max = /*@__PURE__*/ nodeProxy( MathNode, MathNode.MAX );
  *
  * @tsl
  * @function
- * @param {Node | Number} x - The y parameter.
- * @param {Node | Number} y - The x parameter.
+ * @param {Node | number} x - The y parameter.
+ * @param {Node | number} y - The x parameter.
  * @returns {Node}
  */
 export const mod = /*@__PURE__*/ nodeProxy( MathNode, MathNode.MOD );
@@ -756,8 +756,8 @@ export const mod = /*@__PURE__*/ nodeProxy( MathNode, MathNode.MOD );
  *
  * @tsl
  * @function
- * @param {Node | Number} x - The y parameter.
- * @param {Node | Number} y - The x parameter.
+ * @param {Node | number} x - The y parameter.
+ * @param {Node | number} y - The x parameter.
  * @returns {Node}
  */
 export const step = /*@__PURE__*/ nodeProxy( MathNode, MathNode.STEP );
@@ -789,8 +789,8 @@ export const distance = /*@__PURE__*/ nodeProxy( MathNode, MathNode.DISTANCE );
  *
  * @tsl
  * @function
- * @param {Node | Number} x - The first parameter.
- * @param {Node | Number} y - The second parameter.
+ * @param {Node | number} x - The first parameter.
+ * @param {Node | number} y - The second parameter.
  * @returns {Node}
  */
 export const difference = /*@__PURE__*/ nodeProxy( MathNode, MathNode.DIFFERENCE );
@@ -822,8 +822,8 @@ export const cross = /*@__PURE__*/ nodeProxy( MathNode, MathNode.CROSS );
  *
  * @tsl
  * @function
- * @param {Node | Number} x - The first parameter.
- * @param {Node | Number} y - The second parameter.
+ * @param {Node | number} x - The first parameter.
+ * @param {Node | number} y - The second parameter.
  * @returns {Node}
  */
 export const pow = /*@__PURE__*/ nodeProxy( MathNode, MathNode.POW );
@@ -833,7 +833,7 @@ export const pow = /*@__PURE__*/ nodeProxy( MathNode, MathNode.POW );
  *
  * @tsl
  * @function
- * @param {Node | Number} x - The first parameter.
+ * @param {Node | number} x - The first parameter.
  * @returns {Node}
  */
 export const pow2 = /*@__PURE__*/ nodeProxy( MathNode, MathNode.POW, 2 );
@@ -843,7 +843,7 @@ export const pow2 = /*@__PURE__*/ nodeProxy( MathNode, MathNode.POW, 2 );
  *
  * @tsl
  * @function
- * @param {Node | Number} x - The first parameter.
+ * @param {Node | number} x - The first parameter.
  * @returns {Node}
  */
 export const pow3 = /*@__PURE__*/ nodeProxy( MathNode, MathNode.POW, 3 );
@@ -853,7 +853,7 @@ export const pow3 = /*@__PURE__*/ nodeProxy( MathNode, MathNode.POW, 3 );
  *
  * @tsl
  * @function
- * @param {Node | Number} x - The first parameter.
+ * @param {Node | number} x - The first parameter.
  * @returns {Node}
  */
 export const pow4 = /*@__PURE__*/ nodeProxy( MathNode, MathNode.POW, 4 );
@@ -874,7 +874,7 @@ export const transformDirection = /*@__PURE__*/ nodeProxy( MathNode, MathNode.TR
  *
  * @tsl
  * @function
- * @param {Node | Number} a - The first parameter.
+ * @param {Node | number} a - The first parameter.
  * @returns {Node}
  */
 export const cbrt = ( a ) => mul( sign( a ), pow( abs( a ), 1.0 / 3.0 ) );
@@ -894,9 +894,9 @@ export const lengthSq = ( a ) => dot( a, a );
  *
  * @tsl
  * @function
- * @param {Node | Number} a - The first parameter.
- * @param {Node | Number} b - The second parameter.
- * @param {Node | Number} t - The interpolation value.
+ * @param {Node | number} a - The first parameter.
+ * @param {Node | number} b - The second parameter.
+ * @param {Node | number} t - The interpolation value.
  * @returns {Node}
  */
 export const mix = /*@__PURE__*/ nodeProxy( MathNode, MathNode.MIX );
@@ -906,9 +906,9 @@ export const mix = /*@__PURE__*/ nodeProxy( MathNode, MathNode.MIX );
  *
  * @tsl
  * @function
- * @param {Node | Number} value - The value to constrain.
- * @param {Node | Number} [low=0] - The lower bound.
- * @param {Node | Number} [high=1] - The upper bound.
+ * @param {Node | number} value - The value to constrain.
+ * @param {Node | number} [low=0] - The lower bound.
+ * @param {Node | number} [high=1] - The upper bound.
  * @returns {Node}
  */
 export const clamp = ( value, low = 0, high = 1 ) => nodeObject( new MathNode( MathNode.CLAMP, nodeObject( value ), nodeObject( low ), nodeObject( high ) ) );
@@ -918,7 +918,7 @@ export const clamp = ( value, low = 0, high = 1 ) => nodeObject( new MathNode( M
  *
  * @tsl
  * @function
- * @param {Node | Number} value - The value to constrain.
+ * @param {Node | number} value - The value to constrain.
  * @returns {Node}
  */
 export const saturate = ( value ) => clamp( value );
@@ -940,9 +940,9 @@ export const refract = /*@__PURE__*/ nodeProxy( MathNode, MathNode.REFRACT );
  *
  * @tsl
  * @function
- * @param {Node | Number} low - The value of the lower edge of the Hermite function.
- * @param {Node | Number} high - The value of the upper edge of the Hermite function.
- * @param {Node | Number} x - The source value for interpolation.
+ * @param {Node | number} low - The value of the lower edge of the Hermite function.
+ * @param {Node | number} high - The value of the upper edge of the Hermite function.
+ * @param {Node | number} x - The source value for interpolation.
  * @returns {Node}
  */
 export const smoothstep = /*@__PURE__*/ nodeProxy( MathNode, MathNode.SMOOTHSTEP );
@@ -981,9 +981,9 @@ export const rand = /*@__PURE__*/ Fn( ( [ uv ] ) => {
  *
  * @tsl
  * @function
- * @param {Node | Number} t - The interpolation value.
- * @param {Node | Number} e1 - The first parameter.
- * @param {Node | Number} e2 - The second parameter.
+ * @param {Node | number} t - The interpolation value.
+ * @param {Node | number} e1 - The first parameter.
+ * @param {Node | number} e2 - The second parameter.
  * @returns {Node}
  */
 export const mixElement = ( t, e1, e2 ) => mix( e1, e2, t );
@@ -993,9 +993,9 @@ export const mixElement = ( t, e1, e2 ) => mix( e1, e2, t );
  *
  * @tsl
  * @function
- * @param {Node | Number} x - The source value for interpolation.
- * @param {Node | Number} low - The value of the lower edge of the Hermite function.
- * @param {Node | Number} high - The value of the upper edge of the Hermite function.
+ * @param {Node | number} x - The source value for interpolation.
+ * @param {Node | number} low - The value of the lower edge of the Hermite function.
+ * @param {Node | number} high - The value of the upper edge of the Hermite function.
  * @returns {Node}
  */
 export const smoothstepElement = ( x, low, high ) => smoothstep( low, high, x );
@@ -1007,8 +1007,8 @@ export const smoothstepElement = ( x, low, high ) => smoothstep( low, high, x );
  * @function
  * @deprecated since r172. Use {@link atan} instead.
  *
- * @param {Node | Number} y - The y parameter.
- * @param {Node | Number} x - The x parameter.
+ * @param {Node | number} y - The y parameter.
+ * @param {Node | number} x - The x parameter.
  * @returns {Node}
  */
 export const atan2 = ( y, x ) => { // @deprecated, r172

--- a/src/nodes/math/OperatorNode.js
+++ b/src/nodes/math/OperatorNode.js
@@ -18,7 +18,7 @@ class OperatorNode extends TempNode {
 	/**
 	 * Constructs a new operator node.
 	 *
-	 * @param {String} op - The operator.
+	 * @param {string} op - The operator.
 	 * @param {Node} aNode - The first input.
 	 * @param {Node} bNode - The second input.
 	 * @param {...Node} params - Additional input parameters.
@@ -45,7 +45,7 @@ class OperatorNode extends TempNode {
 		/**
 		 * The operator.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.op = op;
 
@@ -66,7 +66,7 @@ class OperatorNode extends TempNode {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -79,8 +79,8 @@ class OperatorNode extends TempNode {
 	 * and the input node types.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @param {String} output - The current output string.
-	 * @return {String} The node type.
+	 * @param {string} output - The current output string.
+	 * @return {string} The node type.
 	 */
 	getNodeType( builder, output ) {
 

--- a/src/nodes/parsers/GLSLNodeFunction.js
+++ b/src/nodes/parsers/GLSLNodeFunction.js
@@ -111,7 +111,7 @@ class GLSLNodeFunction extends NodeFunction {
 	/**
 	 * Constructs a new GLSL node function.
 	 *
-	 * @param {String} source - The GLSL source.
+	 * @param {string} source - The GLSL source.
 	 */
 	constructor( source ) {
 
@@ -128,8 +128,8 @@ class GLSLNodeFunction extends NodeFunction {
 	/**
 	 * This method returns the GLSL code of the node function.
 	 *
-	 * @param {String} [name=this.name] - The function's name.
-	 * @return {String} The shader code.
+	 * @param {string} [name=this.name] - The function's name.
+	 * @return {string} The shader code.
 	 */
 	getCode( name = this.name ) {
 

--- a/src/nodes/parsers/GLSLNodeParser.js
+++ b/src/nodes/parsers/GLSLNodeParser.js
@@ -11,7 +11,7 @@ class GLSLNodeParser extends NodeParser {
 	/**
 	 * The method parses the given GLSL code an returns a node function.
 	 *
-	 * @param {String} source - The GLSL code.
+	 * @param {string} source - The GLSL code.
 	 * @return {GLSLNodeFunction} A node function.
 	 */
 	parseFunction( source ) {

--- a/src/nodes/pmrem/PMREMNode.js
+++ b/src/nodes/pmrem/PMREMNode.js
@@ -16,8 +16,8 @@ const _cache = new WeakMap();
  * Generates the cubeUV size based on the given image height.
  *
  * @private
- * @param {Number} imageHeight - The image height.
- * @return {{texelWidth: Number,texelHeight: Number, maxMip: Number}} The result object.
+ * @param {number} imageHeight - The image height.
+ * @return {{texelWidth: number,texelHeight: number, maxMip: number}} The result object.
  */
 function _generateCubeUVSize( imageHeight ) {
 
@@ -193,7 +193,7 @@ class PMREMNode extends TempNode {
 		/**
 		 * The `updateBeforeType` is set to `NodeUpdateType.RENDER`.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default 'render'
 		 */
 		this.updateBeforeType = NodeUpdateType.RENDER;
@@ -324,7 +324,7 @@ export default PMREMNode;
  *
  * @private
  * @param {Array<(Image|Object)>} image - The cube map image.
- * @return {Boolean} Whether the given cube map is ready or not.
+ * @return {boolean} Whether the given cube map is ready or not.
  */
 function isCubeMapReady( image ) {
 
@@ -349,7 +349,7 @@ function isCubeMapReady( image ) {
  *
  * @private
  * @param {(Image|Object)} image - The equirectangular image.
- * @return {Boolean} Whether the given cube map is ready or not.
+ * @return {boolean} Whether the given cube map is ready or not.
  */
 function isEquirectangularMapReady( image ) {
 

--- a/src/nodes/utils/ArrayElementNode.js
+++ b/src/nodes/utils/ArrayElementNode.js
@@ -41,7 +41,7 @@ class ArrayElementNode extends Node { // @TODO: If extending from TempNode it br
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -53,7 +53,7 @@ class ArrayElementNode extends Node { // @TODO: If extending from TempNode it br
 	 * This method is overwritten since the node type is inferred from the array-like node.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The node type.
+	 * @return {string} The node type.
 	 */
 	getNodeType( builder ) {
 

--- a/src/nodes/utils/ConvertNode.js
+++ b/src/nodes/utils/ConvertNode.js
@@ -19,7 +19,7 @@ class ConvertNode extends Node {
 	 * Constructs a new convert node.
 	 *
 	 * @param {Node} node - The node which type should be converted.
-	 * @param {String} convertTo - The target node type. Multiple types can be defined by separating them with a `|` sign.
+	 * @param {string} convertTo - The target node type. Multiple types can be defined by separating them with a `|` sign.
 	 */
 	constructor( node, convertTo ) {
 
@@ -35,7 +35,7 @@ class ConvertNode extends Node {
 		/**
 		 * The target node type. Multiple types can be defined by separating them with a `|` sign.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.convertTo = convertTo;
 
@@ -46,7 +46,7 @@ class ConvertNode extends Node {
 	 * matching type from the {@link ConvertNode#convertTo} property.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The node type.
+	 * @return {string} The node type.
 	 */
 	getNodeType( builder ) {
 

--- a/src/nodes/utils/CubeMapNode.js
+++ b/src/nodes/utils/CubeMapNode.js
@@ -72,7 +72,7 @@ class CubeMapNode extends TempNode {
 		 * The `updateBeforeType` is set to `NodeUpdateType.RENDER` since the node updates
 		 * the texture once per render in its {@link CubeMapNode#updateBefore} method.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default 'render'
 		 */
 		this.updateBeforeType = NodeUpdateType.RENDER;
@@ -168,7 +168,7 @@ export default CubeMapNode;
  *
  * @private
  * @param {Image} image - The equirectangular image to check.
- * @return {Boolean} Whether the image is ready or not.
+ * @return {boolean} Whether the image is ready or not.
  */
 function isEquirectangularMapReady( image ) {
 
@@ -210,7 +210,7 @@ function onTextureDispose( event ) {
  *
  * @private
  * @param {Texture} texture - The cube texture.
- * @param {Number} mapping - The original texture mapping.
+ * @param {number} mapping - The original texture mapping.
  */
 function mapTextureMapping( texture, mapping ) {
 

--- a/src/nodes/utils/FlipNode.js
+++ b/src/nodes/utils/FlipNode.js
@@ -28,7 +28,7 @@ class FlipNode extends TempNode {
 	 * Constructs a new flip node.
 	 *
 	 * @param {Node} sourceNode - The node which component(s) should be flipped.
-	 * @param {String} components - The components that should be flipped e.g. `'x'` or `'xy'`.
+	 * @param {string} components - The components that should be flipped e.g. `'x'` or `'xy'`.
 	 */
 	constructor( sourceNode, components ) {
 
@@ -44,7 +44,7 @@ class FlipNode extends TempNode {
 		/**
 		 * The components that should be flipped e.g. `'x'` or `'xy'`.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.components = components;
 
@@ -54,7 +54,7 @@ class FlipNode extends TempNode {
 	 * This method is overwritten since the node type is inferred from the source node.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The node type.
+	 * @return {string} The node type.
 	 */
 	getNodeType( builder ) {
 

--- a/src/nodes/utils/FunctionOverloadingNode.js
+++ b/src/nodes/utils/FunctionOverloadingNode.js
@@ -51,7 +51,7 @@ class FunctionOverloadingNode extends Node {
 		/**
 		 * This node is marked as global.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default true
 		 */
 		this.global = true;
@@ -63,7 +63,7 @@ class FunctionOverloadingNode extends Node {
 	 * the function's return type.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The node type.
+	 * @return {string} The node type.
 	 */
 	getNodeType() {
 

--- a/src/nodes/utils/JoinNode.js
+++ b/src/nodes/utils/JoinNode.js
@@ -19,7 +19,7 @@ class JoinNode extends TempNode {
 	 * Constructs a new join node.
 	 *
 	 * @param {Array<Node>} nodes - An array of nodes that should be joined.
-	 * @param {String?} [nodeType=null] - The node type.
+	 * @param {string?} [nodeType=null] - The node type.
 	 */
 	constructor( nodes = [], nodeType = null ) {
 
@@ -39,7 +39,7 @@ class JoinNode extends TempNode {
 	 * joined data length if not explicitly defined.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The node type.
+	 * @return {string} The node type.
 	 */
 	getNodeType( builder ) {
 

--- a/src/nodes/utils/LoopNode.js
+++ b/src/nodes/utils/LoopNode.js
@@ -39,7 +39,7 @@ class LoopNode extends Node {
 	/**
 	 * Constructs a new loop node.
 	 *
-	 * @param {Array<Any>} params - Depending on the loop type, array holds different parameterization values for the loop.
+	 * @param {Array<any>} params - Depending on the loop type, array holds different parameterization values for the loop.
 	 */
 	constructor( params = [] ) {
 
@@ -53,8 +53,8 @@ class LoopNode extends Node {
 	 * Returns a loop variable name based on an index. The pattern is
 	 * `0` = `i`, `1`= `j`, `2`= `k` and so on.
 	 *
-	 * @param {Number} index - The index.
-	 * @return {String} The loop variable name.
+	 * @param {number} index - The index.
+	 * @return {string} The loop variable name.
 	 */
 	getVarName( index ) {
 
@@ -104,7 +104,7 @@ class LoopNode extends Node {
 	 * This method is overwritten since the node type is inferred based on the loop configuration.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The node type.
+	 * @return {string} The node type.
 	 */
 	getNodeType( builder ) {
 
@@ -252,7 +252,7 @@ export default LoopNode;
  *
  * @tsl
  * @function
- * @param {...Any} params - A list of parameters.
+ * @param {...any} params - A list of parameters.
  * @returns {LoopNode}
  */
 export const Loop = ( ...params ) => nodeObject( new LoopNode( nodeArray( params, 'int' ) ) ).append();

--- a/src/nodes/utils/MaxMipLevelNode.js
+++ b/src/nodes/utils/MaxMipLevelNode.js
@@ -41,7 +41,7 @@ class MaxMipLevelNode extends UniformNode {
 		 * The `updateType` is set to `NodeUpdateType.FRAME` since the node updates
 		 * the texture once per frame in its {@link MaxMipLevelNode#update} method.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default 'frame'
 		 */
 		this.updateType = NodeUpdateType.FRAME;

--- a/src/nodes/utils/MemberNode.js
+++ b/src/nodes/utils/MemberNode.js
@@ -18,7 +18,7 @@ class MemberNode extends Node {
 	 * Constructs an array element node.
 	 *
 	 * @param {Node} node - The array-like node.
-	 * @param {String} property - The property name.
+	 * @param {string} property - The property name.
 	 */
 	constructor( node, property ) {
 
@@ -41,7 +41,7 @@ class MemberNode extends Node {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */

--- a/src/nodes/utils/RTTNode.js
+++ b/src/nodes/utils/RTTNode.js
@@ -31,8 +31,8 @@ class RTTNode extends TextureNode {
 	 * Constructs a new RTT node.
 	 *
 	 * @param {Node} node - The node to render a texture with.
-	 * @param {Number?} [width=null] - The width of the internal render target. If not width is applied, the render target is automatically resized.
-	 * @param {Number?} [height=null] - The height of the internal render target.
+	 * @param {number?} [width=null] - The width of the internal render target. If not width is applied, the render target is automatically resized.
+	 * @param {number?} [height=null] - The height of the internal render target.
 	 * @param {Object} [options={type:HalfFloatType}] - The options for the internal render target.
 	 */
 	constructor( node, width = null, height = null, options = { type: HalfFloatType } ) {
@@ -52,7 +52,7 @@ class RTTNode extends TextureNode {
 		 * The width of the internal render target.
 		 * If not width is applied, the render target is automatically resized.
 		 *
-		 * @type {Number?}
+		 * @type {number?}
 		 * @default null
 		 */
 		this.width = width;
@@ -60,7 +60,7 @@ class RTTNode extends TextureNode {
 		/**
 		 * The height of the internal render target.
 		 *
-		 * @type {Number?}
+		 * @type {number?}
 		 * @default null
 		 */
 		this.height = height;
@@ -68,7 +68,7 @@ class RTTNode extends TextureNode {
 		/**
 		 * The pixel ratio
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @default 1
 		 */
 		this.pixelRatio = 1;
@@ -83,7 +83,7 @@ class RTTNode extends TextureNode {
 		/**
 		 * Whether the texture requires an update or not.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default true
 		 */
 		this.textureNeedsUpdate = true;
@@ -91,7 +91,7 @@ class RTTNode extends TextureNode {
 		/**
 		 * Whether the texture should automatically be updated or not.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default true
 		 */
 		this.autoUpdate = true;
@@ -117,7 +117,7 @@ class RTTNode extends TextureNode {
 		 * The `updateBeforeType` is set to `NodeUpdateType.RENDER` since the node updates
 		 * the texture once per render in its {@link RTTNode#updateBefore} method.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default 'render'
 		 */
 		this.updateBeforeType = NodeUpdateType.RENDER;
@@ -127,7 +127,7 @@ class RTTNode extends TextureNode {
 	/**
 	 * Whether the internal render target should automatically be resized or not.
 	 *
-	 * @type {Boolean}
+	 * @type {boolean}
 	 * @readonly
 	 * @default true
 	 */
@@ -150,8 +150,8 @@ class RTTNode extends TextureNode {
 	/**
 	 * Sets the size of the internal render target
 	 *
-	 * @param {Number} width - The width to set.
-	 * @param {Number} height - The width to set.
+	 * @param {number} width - The width to set.
+	 * @param {number} height - The width to set.
 	 */
 	setSize( width, height ) {
 
@@ -170,7 +170,7 @@ class RTTNode extends TextureNode {
 	/**
 	 * Sets the pixel ratio. This will also resize the render target.
 	 *
-	 * @param {Number} pixelRatio - The pixel ratio to set.
+	 * @param {number} pixelRatio - The pixel ratio to set.
 	 */
 	setPixelRatio( pixelRatio ) {
 
@@ -234,8 +234,8 @@ export default RTTNode;
  * @tsl
  * @function
  * @param {Node} node - The node to render a texture with.
- * @param {Number?} [width=null] - The width of the internal render target. If not width is applied, the render target is automatically resized.
- * @param {Number?} [height=null] - The height of the internal render target.
+ * @param {number?} [width=null] - The width of the internal render target. If not width is applied, the render target is automatically resized.
+ * @param {number?} [height=null] - The height of the internal render target.
  * @param {Object} [options={type:HalfFloatType}] - The options for the internal render target.
  * @returns {RTTNode}
  */
@@ -247,8 +247,8 @@ export const rtt = ( node, ...params ) => nodeObject( new RTTNode( nodeObject( n
  * @tsl
  * @function
  * @param {Node} node - The node to render a texture with.
- * @param {Number?} [width=null] - The width of the internal render target. If not width is applied, the render target is automatically resized.
- * @param {Number?} [height=null] - The height of the internal render target.
+ * @param {number?} [width=null] - The width of the internal render target. If not width is applied, the render target is automatically resized.
+ * @param {number?} [height=null] - The height of the internal render target.
  * @param {Object} [options={type:HalfFloatType}] - The options for the internal render target.
  * @returns {RTTNode}
  */

--- a/src/nodes/utils/ReflectorNode.js
+++ b/src/nodes/utils/ReflectorNode.js
@@ -61,10 +61,10 @@ class ReflectorNode extends TextureNode {
 	 *
 	 * @param {Object} [parameters={}] - An object holding configuration parameters.
 	 * @param {Object3D} [parameters.target=new Object3D()] - The 3D object the reflector is linked to.
-	 * @param {Number} [parameters.resolution=1] - The resolution scale.
-	 * @param {Boolean} [parameters.generateMipmaps=false] - Whether mipmaps should be generated or not.
-	 * @param {Boolean} [parameters.bounces=true] - Whether reflectors can render other reflector nodes or not.
-	 * @param {Boolean} [parameters.depth=false] - Whether depth data should be generated or not.
+	 * @param {number} [parameters.resolution=1] - The resolution scale.
+	 * @param {boolean} [parameters.generateMipmaps=false] - Whether mipmaps should be generated or not.
+	 * @param {boolean} [parameters.bounces=true] - Whether reflectors can render other reflector nodes or not.
+	 * @param {boolean} [parameters.depth=false] - Whether depth data should be generated or not.
 	 * @param {TextureNode} [parameters.defaultTexture] - The default texture node.
 	 * @param {ReflectorBaseNode} [parameters.reflector] - The reflector base node.
 	 */
@@ -186,10 +186,10 @@ class ReflectorBaseNode extends Node {
 	 * @param {TextureNode} textureNode - Represents the rendered reflections as a texture node.
 	 * @param {Object} [parameters={}] - An object holding configuration parameters.
 	 * @param {Object3D} [parameters.target=new Object3D()] - The 3D object the reflector is linked to.
-	 * @param {Number} [parameters.resolution=1] - The resolution scale.
-	 * @param {Boolean} [parameters.generateMipmaps=false] - Whether mipmaps should be generated or not.
-	 * @param {Boolean} [parameters.bounces=true] - Whether reflectors can render other reflector nodes or not.
-	 * @param {Boolean} [parameters.depth=false] - Whether depth data should be generated or not.
+	 * @param {number} [parameters.resolution=1] - The resolution scale.
+	 * @param {boolean} [parameters.generateMipmaps=false] - Whether mipmaps should be generated or not.
+	 * @param {boolean} [parameters.bounces=true] - Whether reflectors can render other reflector nodes or not.
+	 * @param {boolean} [parameters.depth=false] - Whether depth data should be generated or not.
 	 */
 	constructor( textureNode, parameters = {} ) {
 
@@ -221,7 +221,7 @@ class ReflectorBaseNode extends Node {
 		/**
 		 * The resolution scale.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @default {1}
 		 */
 		this.resolution = resolution;
@@ -229,7 +229,7 @@ class ReflectorBaseNode extends Node {
 		/**
 		 * Whether mipmaps should be generated or not.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default {false}
 		 */
 		this.generateMipmaps = generateMipmaps;
@@ -237,7 +237,7 @@ class ReflectorBaseNode extends Node {
 		/**
 		 * Whether reflectors can render other reflector nodes or not.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default {true}
 		 */
 		this.bounces = bounces;
@@ -245,7 +245,7 @@ class ReflectorBaseNode extends Node {
 		/**
 		 * Whether depth data should be generated or not.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default {false}
 		 */
 		this.depth = depth;
@@ -254,7 +254,7 @@ class ReflectorBaseNode extends Node {
 		 * The `updateBeforeType` is set to `NodeUpdateType.RENDER` when {@link ReflectorBaseNode#bounces}
 		 * is `true`. Otherwise it's `NodeUpdateType.FRAME`.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default 'render'
 		 */
 		this.updateBeforeType = bounces ? NodeUpdateType.RENDER : NodeUpdateType.FRAME;
@@ -485,10 +485,10 @@ class ReflectorBaseNode extends Node {
  * @function
  * @param {Object} [parameters={}] - An object holding configuration parameters.
  * @param {Object3D} [parameters.target=new Object3D()] - The 3D object the reflector is linked to.
- * @param {Number} [parameters.resolution=1] - The resolution scale.
- * @param {Boolean} [parameters.generateMipmaps=false] - Whether mipmaps should be generated or not.
- * @param {Boolean} [parameters.bounces=true] - Whether reflectors can render other reflector nodes or not.
- * @param {Boolean} [parameters.depth=false] - Whether depth data should be generated or not.
+ * @param {number} [parameters.resolution=1] - The resolution scale.
+ * @param {boolean} [parameters.generateMipmaps=false] - Whether mipmaps should be generated or not.
+ * @param {boolean} [parameters.bounces=true] - Whether reflectors can render other reflector nodes or not.
+ * @param {boolean} [parameters.depth=false] - Whether depth data should be generated or not.
  * @param {TextureNode} [parameters.defaultTexture] - The default texture node.
  * @param {ReflectorBaseNode} [parameters.reflector] - The reflector base node.
  * @returns {ReflectorNode}

--- a/src/nodes/utils/RemapNode.js
+++ b/src/nodes/utils/RemapNode.js
@@ -70,7 +70,7 @@ class RemapNode extends Node {
 		 * Whether the node value should be clamped before
 		 * remapping it to the target range.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default true
 		 */
 		this.doClamp = true;

--- a/src/nodes/utils/RotateNode.js
+++ b/src/nodes/utils/RotateNode.js
@@ -47,7 +47,7 @@ class RotateNode extends TempNode {
 	 * The type of the {@link RotateNode#positionNode} defines the node's type.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The node's type.
+	 * @return {string} The node's type.
 	 */
 	getNodeType( builder ) {
 

--- a/src/nodes/utils/SetNode.js
+++ b/src/nodes/utils/SetNode.js
@@ -24,7 +24,7 @@ class SetNode extends TempNode {
 	 * Constructs a new set node.
 	 *
 	 * @param {Node} sourceNode - The node that should be updated.
-	 * @param {String} components - The components that should be updated.
+	 * @param {string} components - The components that should be updated.
 	 * @param {Node} targetNode - The value node.
 	 */
 	constructor( sourceNode, components, targetNode ) {
@@ -41,7 +41,7 @@ class SetNode extends TempNode {
 		/**
 		 * The components that should be updated.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.components = components;
 
@@ -58,7 +58,7 @@ class SetNode extends TempNode {
 	 * This method is overwritten since the node type is inferred from {@link SetNode#sourceNode}.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The node type.
+	 * @return {string} The node type.
 	 */
 	getNodeType( builder ) {
 

--- a/src/nodes/utils/SplitNode.js
+++ b/src/nodes/utils/SplitNode.js
@@ -26,7 +26,7 @@ class SplitNode extends Node {
 	 * Constructs a new split node.
 	 *
 	 * @param {Node} node - The node that should be accessed.
-	 * @param {String} [components='x'] - The components that should be accessed.
+	 * @param {string} [components='x'] - The components that should be accessed.
 	 */
 	constructor( node, components = 'x' ) {
 
@@ -49,7 +49,7 @@ class SplitNode extends Node {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -60,7 +60,7 @@ class SplitNode extends Node {
 	/**
 	 * Returns the vector length which is computed based on the requested components.
 	 *
-	 * @return {Number} The vector length.
+	 * @return {number} The vector length.
 	 */
 	getVectorLength() {
 
@@ -80,7 +80,7 @@ class SplitNode extends Node {
 	 * Returns the component type of the node's type.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The component type.
+	 * @return {string} The component type.
 	 */
 	getComponentType( builder ) {
 
@@ -92,7 +92,7 @@ class SplitNode extends Node {
 	 * This method is overwritten since the node type is inferred from requested components.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {String} The node type.
+	 * @return {string} The node type.
 	 */
 	getNodeType( builder ) {
 

--- a/src/nodes/utils/SpriteUtils.js
+++ b/src/nodes/utils/SpriteUtils.js
@@ -15,8 +15,8 @@ import { Fn, defined } from '../tsl/TSLBase.js';
  * @function
  * @param {Object} config - The configuration object.
  * @param {Node<vec3>?} [config.position=null] - Can be used to define the vertex positions in world space.
- * @param {Boolean} [config.horizontal=true] - Whether to follow the camera rotation horizontally or not.
- * @param {Boolean} [config.vertical=false] - Whether to follow the camera rotation vertically or not.
+ * @param {boolean} [config.horizontal=true] - Whether to follow the camera rotation horizontally or not.
+ * @param {boolean} [config.vertical=false] - Whether to follow the camera rotation vertically or not.
  * @return {Node<vec3>} The updated vertex position in clip space.
  */
 export const billboarding = /*@__PURE__*/ Fn( ( { position = null, horizontal = true, vertical = false } ) => {

--- a/src/nodes/utils/StorageArrayElementNode.js
+++ b/src/nodes/utils/StorageArrayElementNode.js
@@ -33,7 +33,7 @@ class StorageArrayElementNode extends ArrayElementNode {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */

--- a/src/nodes/utils/Timer.js
+++ b/src/nodes/utils/Timer.js
@@ -32,7 +32,7 @@ export const frameId = /*@__PURE__*/ uniform( 0, 'uint' ).setGroup( renderGroup 
  * @function
  * @deprecated since r170. Use {@link time} instead.
  *
- * @param {Number} [timeScale=1] - The time scale.
+ * @param {number} [timeScale=1] - The time scale.
  * @returns {UniformNode<float>}
  */
 export const timerLocal = ( timeScale = 1 ) => { // @deprecated, r170
@@ -47,7 +47,7 @@ export const timerLocal = ( timeScale = 1 ) => { // @deprecated, r170
  * @function
  * @deprecated since r170. Use {@link time} instead.
  *
- * @param {Number} [timeScale=1] - The time scale.
+ * @param {number} [timeScale=1] - The time scale.
  * @returns {UniformNode<float>}
  */
 export const timerGlobal = ( timeScale = 1 ) => { // @deprecated, r170
@@ -62,7 +62,7 @@ export const timerGlobal = ( timeScale = 1 ) => { // @deprecated, r170
  * @function
  * @deprecated since r170. Use {@link deltaTime} instead.
  *
- * @param {Number} [timeScale=1] - The time scale.
+ * @param {number} [timeScale=1] - The time scale.
  * @returns {UniformNode<float>}
  */
 export const timerDelta = ( timeScale = 1 ) => { // @deprecated, r170

--- a/src/objects/ClippingGroup.js
+++ b/src/objects/ClippingGroup.js
@@ -24,7 +24,7 @@ class ClippingGroup extends Group {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -40,7 +40,7 @@ class ClippingGroup extends Group {
 		/**
 		 * Whether clipping should be enabled or not.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default true
 		 */
 		this.enabled = true;
@@ -48,7 +48,7 @@ class ClippingGroup extends Group {
 		/**
 		 * Whether the intersection of the clipping planes is used to clip objects, rather than their union.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default false
 		 */
 		this.clipIntersection = false;
@@ -56,7 +56,7 @@ class ClippingGroup extends Group {
 		/**
 		 * Whether shadows should be clipped or not.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default false
 		 */
 		this.clipShadows = false;

--- a/src/renderers/common/Animation.js
+++ b/src/renderers/common/Animation.js
@@ -48,7 +48,7 @@ class Animation {
 		 * The requestId which is returned from the `requestAnimationFrame()` call.
 		 * Can be used to cancel the stop the animation loop.
 		 *
-		 * @type {Number?}
+		 * @type {number?}
 		 * @default null
 		 */
 		this._requestId = null;

--- a/src/renderers/common/Attributes.js
+++ b/src/renderers/common/Attributes.js
@@ -54,7 +54,7 @@ class Attributes extends DataMap {
 	 * for new attributes and updates data for existing ones.
 	 *
 	 * @param {BufferAttribute} attribute - The attribute to update.
-	 * @param {Number} type - The attribute type.
+	 * @param {number} type - The attribute type.
 	 */
 	update( attribute, type ) {
 

--- a/src/renderers/common/Backend.js
+++ b/src/renderers/common/Backend.js
@@ -89,7 +89,7 @@ class Backend {
 	 * The coordinate system of the backend.
 	 *
 	 * @abstract
-	 * @type {Number}
+	 * @type {number}
 	 * @readonly
 	 */
 	get coordinateSystem() {}
@@ -186,8 +186,8 @@ class Backend {
 	 * @abstract
 	 * @param {BindGroup} bindGroup - The bind group.
 	 * @param {Array<BindGroup>} bindings - Array of bind groups.
-	 * @param {Number} cacheIndex - The cache index.
-	 * @param {Number} version - The version.
+	 * @param {number} cacheIndex - The cache index.
+	 * @param {number} version - The version.
 	 */
 	createBindings( /*bindGroup, bindings, cacheIndex, version*/ ) { }
 
@@ -197,8 +197,8 @@ class Backend {
 	 * @abstract
 	 * @param {BindGroup} bindGroup - The bind group.
 	 * @param {Array<BindGroup>} bindings - Array of bind groups.
-	 * @param {Number} cacheIndex - The cache index.
-	 * @param {Number} version - The version.
+	 * @param {number} cacheIndex - The cache index.
+	 * @param {number} version - The version.
 	 */
 	updateBindings( /*bindGroup, bindings, cacheIndex, version*/ ) { }
 
@@ -237,7 +237,7 @@ class Backend {
 	 *
 	 * @abstract
 	 * @param {RenderObject} renderObject - The render object.
-	 * @return {Boolean} Whether the render pipeline requires an update or not.
+	 * @return {boolean} Whether the render pipeline requires an update or not.
 	 */
 	needsRenderUpdate( /*renderObject*/ ) { }
 
@@ -246,7 +246,7 @@ class Backend {
 	 *
 	 * @abstract
 	 * @param {RenderObject} renderObject - The render object.
-	 * @return {String} The cache key.
+	 * @return {string} The cache key.
 	 */
 	getRenderCacheKey( /*renderObject*/ ) { }
 
@@ -329,11 +329,11 @@ class Backend {
 	 * @abstract
 	 * @async
 	 * @param {Texture} texture - The texture to copy.
-	 * @param {Number} x - The x coordinate of the copy origin.
-	 * @param {Number} y - The y coordinate of the copy origin.
-	 * @param {Number} width - The width of the copy.
-	 * @param {Number} height - The height of the copy.
-	 * @param {Number} faceIndex - The face index.
+	 * @param {number} x - The x coordinate of the copy origin.
+	 * @param {number} y - The y coordinate of the copy origin.
+	 * @param {number} width - The width of the copy.
+	 * @param {number} height - The height of the copy.
+	 * @param {number} faceIndex - The face index.
 	 * @return {Promise<TypedArray>} A Promise that resolves with a typed array when the copy operation has finished.
 	 */
 	async copyTextureToBuffer( /*texture, x, y, width, height, faceIndex*/ ) {}
@@ -346,7 +346,7 @@ class Backend {
 	 * @param {Texture} dstTexture - The destination texture.
 	 * @param {Vector4?} [srcRegion=null] - The region of the source texture to copy.
 	 * @param {(Vector2|Vector3)?} [dstPosition=null] - The destination position of the copy.
-	 * @param {Number} [level=0] - The mip level to copy.
+	 * @param {number} [level=0] - The mip level to copy.
 	 */
 	copyTextureToTexture( /*srcTexture, dstTexture, srcRegion = null, dstPosition = null, level = 0*/ ) {}
 
@@ -438,7 +438,7 @@ class Backend {
 	 * @abstract
 	 * @param {RenderContext} renderContext - The render context.
 	 * @param {Object3D} object - The 3D object to test.
-	 * @return {Boolean} Whether the 3D object is fully occluded or not.
+	 * @return {boolean} Whether the 3D object is fully occluded or not.
 	 */
 	isOccluded( /*renderContext, object*/ ) {}
 
@@ -447,8 +447,8 @@ class Backend {
 	 *
 	 * @async
 	 * @abstract
-	 * @param {String} [type='render'] - The type of the time stamp.
-	 * @return {Promise<Number>} A Promise that resolves with the time stamp.
+	 * @param {string} [type='render'] - The type of the time stamp.
+	 * @return {Promise<number>} A Promise that resolves with the time stamp.
 	 */
 	async resolveTimestampsAsync( type = 'render' ) {
 
@@ -500,8 +500,8 @@ class Backend {
 	 *
 	 * @async
 	 * @abstract
-	 * @param {String} name - The feature's name.
-	 * @return {Promise<Boolean>} A Promise that resolves with a bool that indicates whether the feature is supported or not.
+	 * @param {string} name - The feature's name.
+	 * @return {Promise<boolean>} A Promise that resolves with a bool that indicates whether the feature is supported or not.
 	 */
 	async hasFeatureAsync( /*name*/ ) { }
 
@@ -509,8 +509,8 @@ class Backend {
 	 * Checks if the given feature is supported  by the backend.
 	 *
 	 * @abstract
-	 * @param {String} name - The feature's name.
-	 * @return {Boolean} Whether the feature is supported or not.
+	 * @param {string} name - The feature's name.
+	 * @return {boolean} Whether the feature is supported or not.
 	 */
 	hasFeature( /*name*/ ) {}
 
@@ -518,7 +518,7 @@ class Backend {
 	 * Returns the maximum anisotropy texture filtering value.
 	 *
 	 * @abstract
-	 * @return {Number} The maximum anisotropy texture filtering value.
+	 * @return {number} The maximum anisotropy texture filtering value.
 	 */
 	getMaxAnisotropy() {}
 
@@ -539,7 +539,7 @@ class Backend {
 	 * Defines the scissor test.
 	 *
 	 * @abstract
-	 * @param {Boolean} boolean - Whether the scissor test should be enabled or not.
+	 * @param {boolean} boolean - Whether the scissor test should be enabled or not.
 	 */
 	setScissorTest( /*boolean*/ ) { }
 
@@ -627,7 +627,7 @@ class Backend {
 	 * with data defined.
 	 *
 	 * @param {Object} object - The object.
-	 * @return {Boolean} Whether a dictionary for the given object as been defined or not.
+	 * @return {boolean} Whether a dictionary for the given object as been defined or not.
 	 */
 	has( object ) {
 

--- a/src/renderers/common/BindGroup.js
+++ b/src/renderers/common/BindGroup.js
@@ -12,9 +12,9 @@ class BindGroup {
 	/**
 	 * Constructs a new bind group.
 	 *
-	 * @param {String} name - The bind group's name.
+	 * @param {string} name - The bind group's name.
 	 * @param {Array<Binding>} bindings - An array of bindings.
-	 * @param {Number} index - The group index.
+	 * @param {number} index - The group index.
 	 * @param {Array<Binding>} bindingsReference - An array of reference bindings.
 	 */
 	constructor( name = '', bindings = [], index = 0, bindingsReference = [] ) {
@@ -22,7 +22,7 @@ class BindGroup {
 		/**
 		 * The bind group's name.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.name = name;
 
@@ -36,7 +36,7 @@ class BindGroup {
 		/**
 		 * The group index.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 */
 		this.index = index;
 
@@ -50,7 +50,7 @@ class BindGroup {
 		/**
 		 * The group's ID.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 */
 		this.id = _id ++;
 

--- a/src/renderers/common/Binding.js
+++ b/src/renderers/common/Binding.js
@@ -12,14 +12,14 @@ class Binding {
 	/**
 	 * Constructs a new binding.
 	 *
-	 * @param {String} [name=''] - The binding's name.
+	 * @param {string} [name=''] - The binding's name.
 	 */
 	constructor( name = '' ) {
 
 		/**
 		 * The binding's name.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.name = name;
 
@@ -27,7 +27,7 @@ class Binding {
 		 * A bitmask that defines in what shader stages the
 		 * binding's resource is accessible.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 */
 		this.visibility = 0;
 
@@ -36,7 +36,7 @@ class Binding {
 	/**
 	 * Makes sure binding's resource is visible for the given shader stage.
 	 *
-	 * @param {Number} visibility - The shader stage.
+	 * @param {number} visibility - The shader stage.
 	 */
 	setVisibility( visibility ) {
 

--- a/src/renderers/common/Buffer.js
+++ b/src/renderers/common/Buffer.js
@@ -13,7 +13,7 @@ class Buffer extends Binding {
 	/**
 	 * Constructs a new buffer.
 	 *
-	 * @param {String} name - The buffer's name.
+	 * @param {string} name - The buffer's name.
 	 * @param {TypedArray} [buffer=null] - The buffer.
 	 */
 	constructor( name, buffer = null ) {
@@ -23,7 +23,7 @@ class Buffer extends Binding {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -32,7 +32,7 @@ class Buffer extends Binding {
 		/**
 		 * The bytes per element.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 */
 		this.bytesPerElement = Float32Array.BYTES_PER_ELEMENT;
 
@@ -49,7 +49,7 @@ class Buffer extends Binding {
 	/**
 	 * The buffer's byte length.
 	 *
-	 * @type {Number}
+	 * @type {number}
 	 * @readonly
 	 */
 	get byteLength() {
@@ -73,7 +73,7 @@ class Buffer extends Binding {
 	/**
 	 * Updates the binding.
 	 *
-	 * @return {Boolean} Whether the buffer has been updated and must be
+	 * @return {boolean} Whether the buffer has been updated and must be
 	 * uploaded to the GPU.
 	 */
 	update() {

--- a/src/renderers/common/BufferUtils.js
+++ b/src/renderers/common/BufferUtils.js
@@ -5,8 +5,8 @@ import { GPU_CHUNK_BYTES } from './Constants.js';
  * It returns an padded value which ensure chunk size alignment according to STD140 layout.
  *
  * @function
- * @param {Number} floatLength - The buffer length.
- * @return {Number} The padded length.
+ * @param {number} floatLength - The buffer length.
+ * @return {number} The padded length.
  */
 function getFloatLength( floatLength ) {
 
@@ -21,9 +21,9 @@ function getFloatLength( floatLength ) {
  * a total length in bytes with buffer alignment according to STD140 layout.
  *
  * @function
- * @param {Number} count - The number of vectors.
- * @param {Number} [vectorLength=4] - The vector length.
- * @return {Number} The padded length.
+ * @param {number} count - The number of vectors.
+ * @param {number} [vectorLength=4] - The vector length.
+ * @return {number} The padded length.
  */
 function getVectorLength( count, vectorLength = 4 ) {
 
@@ -40,8 +40,8 @@ function getVectorLength( count, vectorLength = 4 ) {
  * matches a predefined stride (in this case `4`).
  *
  * @function
- * @param {Number} vectorLength - The vector length.
- * @return {Number} The padded length.
+ * @param {number} vectorLength - The vector length.
+ * @return {number} The padded length.
  */
 function getStrideLength( vectorLength ) {
 

--- a/src/renderers/common/BundleGroup.js
+++ b/src/renderers/common/BundleGroup.js
@@ -24,7 +24,7 @@ class BundleGroup extends Group {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -35,7 +35,7 @@ class BundleGroup extends Group {
 		 * during serialization/deserialization. It should always
 		 * match the class name.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @readonly
 		 * @default 'BundleGroup'
 		 */
@@ -49,7 +49,7 @@ class BundleGroup extends Group {
 		 * If a change is required, an update can still be forced by setting the
 		 * `needsUpdate` flag to `true`.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default true
 		 */
 		this.static = true;
@@ -57,7 +57,7 @@ class BundleGroup extends Group {
 		/**
 		 * The bundle group's version.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @readonly
 		 * @default 0
 		 */
@@ -68,9 +68,9 @@ class BundleGroup extends Group {
 	/**
 	 * Set this property to `true` when the bundle group has changed.
 	 *
-	 * @type {Boolean}
+	 * @type {boolean}
 	 * @default false
-	 * @param {Boolean} value
+	 * @param {boolean} value
 	 */
 	set needsUpdate( value ) {
 

--- a/src/renderers/common/ChainMap.js
+++ b/src/renderers/common/ChainMap.js
@@ -26,7 +26,7 @@ class ChainMap {
 	 * Returns the value for the given array of keys.
 	 *
 	 * @param {Array<Object>} keys - List of keys.
-	 * @return {Any} The value. Returns `undefined` if no value was found.
+	 * @return {any} The value. Returns `undefined` if no value was found.
 	 */
 	get( keys ) {
 
@@ -48,7 +48,7 @@ class ChainMap {
 	 * Sets the value for the given keys.
 	 *
 	 * @param {Array<Object>} keys - List of keys.
-	 * @param {Any} value - The value to set.
+	 * @param {any} value - The value to set.
 	 * @return {ChainMap} A reference to this Chain Map.
 	 */
 	set( keys, value ) {
@@ -75,7 +75,7 @@ class ChainMap {
 	 * Deletes a value for the given keys.
 	 *
 	 * @param {Array<Object>} keys - The keys.
-	 * @return {Boolean} Returns `true` if the value has been removed successfully and `false` if the value has not be found.
+	 * @return {boolean} Returns `true` if the value has been removed successfully and `false` if the value has not be found.
 	 */
 	delete( keys ) {
 

--- a/src/renderers/common/ClippingContext.js
+++ b/src/renderers/common/ClippingContext.js
@@ -24,7 +24,7 @@ class ClippingContext {
 		/**
 		 * The clipping context's version.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @readonly
 		 */
 		this.version = 0;
@@ -32,7 +32,7 @@ class ClippingContext {
 		/**
 		 * Whether the intersection of the clipping planes is used to clip objects, rather than their union.
 		 *
-		 * @type {Boolean?}
+		 * @type {boolean?}
 		 * @default null
 		 */
 		this.clipIntersection = null;
@@ -40,14 +40,14 @@ class ClippingContext {
 		/**
 		 * The clipping context's cache key.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.cacheKey = '';
 
 		/**
 		 * Whether the shadow pass is active or not.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default false
 		 */
 		this.shadowPass = false;
@@ -83,7 +83,7 @@ class ClippingContext {
 		/**
 		 * The version of the clipping context's parent context.
 		 *
-		 * @type {Number?}
+		 * @type {number?}
 		 * @readonly
 		 */
 		this.parentVersion = null;
@@ -106,7 +106,7 @@ class ClippingContext {
 	 *
 	 * @param {Array<Plane>} source - The source clipping planes.
 	 * @param {Array<Vector4>} destination - The destination.
-	 * @param {Number} offset - The offset.
+	 * @param {number} offset - The offset.
 	 */
 	projectPlanes( source, destination, offset ) {
 
@@ -248,7 +248,7 @@ class ClippingContext {
 	/**
 	 * The count of union clipping planes.
 	 *
-	 * @type {Number}
+	 * @type {number}
 	 * @readonly
 	 */
 	get unionClippingCount() {

--- a/src/renderers/common/Color4.js
+++ b/src/renderers/common/Color4.js
@@ -15,10 +15,10 @@ class Color4 extends Color {
 	 * You can also pass a single THREE.Color, hex or
 	 * string argument to this constructor.
 	 *
-	 * @param {Number|String} [r=1] - The red value.
-	 * @param {Number} [g=1] - The green value.
-	 * @param {Number} [b=1] - The blue value.
-	 * @param {Number} [a=1] - The alpha value.
+	 * @param {number|string} [r=1] - The red value.
+	 * @param {number} [g=1] - The green value.
+	 * @param {number} [b=1] - The blue value.
+	 * @param {number} [a=1] - The alpha value.
 	 */
 	constructor( r, g, b, a = 1 ) {
 
@@ -33,10 +33,10 @@ class Color4 extends Color {
 	 * You can also pass a single THREE.Color, hex or
 	 * string argument to this method.
 	 *
-	 * @param {Number|String} r - The red value.
-	 * @param {Number} g - The green value.
-	 * @param {Number} b - The blue value.
-	 * @param {Number} [a=1] - The alpha value.
+	 * @param {number|string} r - The red value.
+	 * @param {number} g - The green value.
+	 * @param {number} b - The blue value.
+	 * @param {number} [a=1] - The alpha value.
 	 * @return {Color4} A reference to this object.
 	 */
 	set( r, g, b, a = 1 ) {

--- a/src/renderers/common/ComputePipeline.js
+++ b/src/renderers/common/ComputePipeline.js
@@ -11,7 +11,7 @@ class ComputePipeline extends Pipeline {
 	/**
 	 * Constructs a new render pipeline.
 	 *
-	 * @param {String} cacheKey - The pipeline's cache key.
+	 * @param {string} cacheKey - The pipeline's cache key.
 	 * @param {ProgrammableStage} computeProgram - The pipeline's compute shader.
 	 */
 	constructor( cacheKey, computeProgram ) {
@@ -28,7 +28,7 @@ class ComputePipeline extends Pipeline {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */

--- a/src/renderers/common/DataMap.js
+++ b/src/renderers/common/DataMap.js
@@ -68,7 +68,7 @@ class DataMap {
 	 * Returns `true` if the given object has a dictionary defined.
 	 *
 	 * @param {Object} object - The object to test.
-	 * @return {Boolean} Whether a dictionary is defined or not.
+	 * @return {boolean} Whether a dictionary is defined or not.
 	 */
 	has( object ) {
 

--- a/src/renderers/common/Geometries.js
+++ b/src/renderers/common/Geometries.js
@@ -10,7 +10,7 @@ import { Uint16BufferAttribute, Uint32BufferAttribute } from '../../core/BufferA
  * @private
  * @function
  * @param {BufferGeometry} geometry - The geometry.
- * @return {Number} The version.
+ * @return {number} The version.
  */
 function getWireframeVersion( geometry ) {
 
@@ -113,7 +113,7 @@ class Geometries extends DataMap {
 		 * This Weak Map is used to make sure buffer attributes are
 		 * updated only once per render call.
 		 *
-		 * @type {WeakMap<BufferAttribute,Number>}
+		 * @type {WeakMap<BufferAttribute,number>}
 		 */
 		this.attributeCall = new WeakMap();
 
@@ -123,7 +123,7 @@ class Geometries extends DataMap {
 	 * Returns `true` if the given render object has an initialized geometry.
 	 *
 	 * @param {RenderObject} renderObject - The render object.
-	 * @return {Boolean} Whether if the given render object has an initialized geometry or not.
+	 * @return {boolean} Whether if the given render object has an initialized geometry or not.
 	 */
 	has( renderObject ) {
 
@@ -246,7 +246,7 @@ class Geometries extends DataMap {
 	 * Updates the given attribute.
 	 *
 	 * @param {BufferAttribute} attribute - The attribute to update.
-	 * @param {Number} type - The attribute type.
+	 * @param {number} type - The attribute type.
 	 */
 	updateAttribute( attribute, type ) {
 

--- a/src/renderers/common/IndirectStorageBufferAttribute.js
+++ b/src/renderers/common/IndirectStorageBufferAttribute.js
@@ -14,9 +14,9 @@ class IndirectStorageBufferAttribute extends StorageBufferAttribute {
 	/**
 	 * Constructs a new storage buffer attribute.
 	 *
-	 * @param {Number|Uint32Array} count - The item count. It is also valid to pass a `Uint32Array` as an argument.
+	 * @param {number|Uint32Array} count - The item count. It is also valid to pass a `Uint32Array` as an argument.
 	 * The subsequent parameter is then obsolete.
-	 * @param {Number} itemSize - The item size.
+	 * @param {number} itemSize - The item size.
 	 */
 	constructor( count, itemSize ) {
 
@@ -25,7 +25,7 @@ class IndirectStorageBufferAttribute extends StorageBufferAttribute {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */

--- a/src/renderers/common/Info.js
+++ b/src/renderers/common/Info.js
@@ -16,7 +16,7 @@ class Info {
 		 * by apps which manage their own animation loop. They must
 		 * then call `renderer.info.reset()` once per frame manually.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default true
 		 */
 		this.autoReset = true;
@@ -25,7 +25,7 @@ class Info {
 		 * The current frame ID. This ID is managed
 		 * by `NodeFrame`.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @readonly
 		 * @default 0
 		 */
@@ -35,7 +35,7 @@ class Info {
 		 * The number of render calls since the
 		 * app has been started.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @readonly
 		 * @default 0
 		 */
@@ -46,13 +46,13 @@ class Info {
 		 *
 		 * @type {Object}
 		 * @readonly
-		 * @property {Number} calls - The number of render calls since the app has been started.
-		 * @property {Number} frameCalls - The number of render calls of the current frame.
-		 * @property {Number} drawCalls - The number of draw calls of the current frame.
-		 * @property {Number} triangles - The number of rendered triangle primitives of the current frame.
-		 * @property {Number} points - The number of rendered point primitives of the current frame.
-		 * @property {Number} lines - The number of rendered line primitives of the current frame.
-		 * @property {Number} timestamp - The timestamp of the frame when using `renderer.renderAsync()`.
+		 * @property {number} calls - The number of render calls since the app has been started.
+		 * @property {number} frameCalls - The number of render calls of the current frame.
+		 * @property {number} drawCalls - The number of draw calls of the current frame.
+		 * @property {number} triangles - The number of rendered triangle primitives of the current frame.
+		 * @property {number} points - The number of rendered point primitives of the current frame.
+		 * @property {number} lines - The number of rendered line primitives of the current frame.
+		 * @property {number} timestamp - The timestamp of the frame when using `renderer.renderAsync()`.
 		 */
 		this.render = {
 			calls: 0,
@@ -69,9 +69,9 @@ class Info {
 		 *
 		 * @type {Object}
 		 * @readonly
-		 * @property {Number} calls - The number of compute calls since the app has been started.
-		 * @property {Number} frameCalls - The number of compute calls of the current frame.
-		 * @property {Number} timestamp - The timestamp of the frame when using `renderer.computeAsync()`.
+		 * @property {number} calls - The number of compute calls since the app has been started.
+		 * @property {number} frameCalls - The number of compute calls of the current frame.
+		 * @property {number} timestamp - The timestamp of the frame when using `renderer.computeAsync()`.
 		 */
 		this.compute = {
 			calls: 0,
@@ -84,8 +84,8 @@ class Info {
 		 *
 		 * @type {Object}
 		 * @readonly
-		 * @property {Number} geometries - The number of active geometries.
-		 * @property {Number} frameCalls - The number of active textures.
+		 * @property {number} geometries - The number of active geometries.
+		 * @property {number} frameCalls - The number of active textures.
 		 */
 		this.memory = {
 			geometries: 0,
@@ -98,8 +98,8 @@ class Info {
 	 * This method should be executed per draw call and updates the corresponding metrics.
 	 *
 	 * @param {Object3D} object - The 3D object that is going to be rendered.
-	 * @param {Number} count - The vertex or index count.
-	 * @param {Number} instanceCount - The instance count.
+	 * @param {number} count - The vertex or index count.
+	 * @param {number} instanceCount - The instance count.
 	 */
 	update( object, count, instanceCount ) {
 

--- a/src/renderers/common/Pipeline.js
+++ b/src/renderers/common/Pipeline.js
@@ -9,21 +9,21 @@ class Pipeline {
 	/**
 	 * Constructs a new pipeline.
 	 *
-	 * @param {String} cacheKey - The pipeline's cache key.
+	 * @param {string} cacheKey - The pipeline's cache key.
 	 */
 	constructor( cacheKey ) {
 
 		/**
 		 * The pipeline's cache key.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.cacheKey = cacheKey;
 
 		/**
 		 * How often the pipeline is currently in use.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @default 0
 		 */
 		this.usedTimes = 0;

--- a/src/renderers/common/Pipelines.js
+++ b/src/renderers/common/Pipelines.js
@@ -49,7 +49,7 @@ class Pipelines extends DataMap {
 		 * Internal cache for maintaining pipelines.
 		 * The key of the map is a cache key, the value the pipeline.
 		 *
-		 * @type {Map<String,Pipeline>}
+		 * @type {Map<string,Pipeline>}
 		 */
 		this.caches = new Map();
 
@@ -58,7 +58,7 @@ class Pipelines extends DataMap {
 		 * fragment and compute) the programmable stage objects which
 		 * represent the actual shader code.
 		 *
-		 * @type {Object<String,Map>}
+		 * @type {Object<string,Map>}
 		 */
 		this.programs = {
 			vertex: new Map(),
@@ -309,7 +309,7 @@ class Pipelines extends DataMap {
 	 * @private
 	 * @param {Node} computeNode - The compute node.
 	 * @param {ProgrammableStage} stageCompute - The programmable stage representing the compute shader.
-	 * @param {String} cacheKey - The cache key.
+	 * @param {string} cacheKey - The cache key.
 	 * @param {Array<BindGroup>} bindings - The bindings.
 	 * @return {ComputePipeline} The compute pipeline.
 	 */
@@ -342,7 +342,7 @@ class Pipelines extends DataMap {
 	 * @param {RenderObject} renderObject - The render object.
 	 * @param {ProgrammableStage} stageVertex - The programmable stage representing the vertex shader.
 	 * @param {ProgrammableStage} stageFragment - The programmable stage representing the fragment shader.
-	 * @param {String} cacheKey - The cache key.
+	 * @param {string} cacheKey - The cache key.
 	 * @param {Array<Promise>?} promises - An array of compilation promises which is only relevant in context of `Renderer.compileAsync()`.
 	 * @return {ComputePipeline} The compute pipeline.
 	 */
@@ -380,7 +380,7 @@ class Pipelines extends DataMap {
 	 * @private
 	 * @param {Node} computeNode - The compute node.
 	 * @param {ProgrammableStage} stageCompute - The programmable stage representing the compute shader.
-	 * @return {String} The cache key.
+	 * @return {string} The cache key.
 	 */
 	_getComputeCacheKey( computeNode, stageCompute ) {
 
@@ -395,7 +395,7 @@ class Pipelines extends DataMap {
 	 * @param {RenderObject} renderObject - The render object.
 	 * @param {ProgrammableStage} stageVertex - The programmable stage representing the vertex shader.
 	 * @param {ProgrammableStage} stageFragment - The programmable stage representing the fragment shader.
-	 * @return {String} The cache key.
+	 * @return {string} The cache key.
 	 */
 	_getRenderCacheKey( renderObject, stageVertex, stageFragment ) {
 
@@ -435,7 +435,7 @@ class Pipelines extends DataMap {
 	 *
 	 * @private
 	 * @param {Node} computeNode - The compute node.
-	 * @return {Boolean} Whether the compute pipeline for the given compute node requires an update or not.
+	 * @return {boolean} Whether the compute pipeline for the given compute node requires an update or not.
 	 */
 	_needsComputeUpdate( computeNode ) {
 
@@ -450,7 +450,7 @@ class Pipelines extends DataMap {
 	 *
 	 * @private
 	 * @param {RenderObject} renderObject - The render object.
-	 * @return {Boolean} Whether the render object for the given render object requires an update or not.
+	 * @return {boolean} Whether the render object for the given render object requires an update or not.
 	 */
 	_needsRenderUpdate( renderObject ) {
 

--- a/src/renderers/common/PostProcessing.js
+++ b/src/renderers/common/PostProcessing.js
@@ -57,7 +57,7 @@ class PostProcessing {
 		 * const outputPass = renderOutput( scenePass );
 		 * ```
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 */
 		this.outputColorTransform = true;
 

--- a/src/renderers/common/ProgrammableStage.js
+++ b/src/renderers/common/ProgrammableStage.js
@@ -12,9 +12,9 @@ class ProgrammableStage {
 	/**
 	 * Constructs a new programmable stage.
 	 *
-	 * @param {String} code - The shader code.
+	 * @param {string} code - The shader code.
 	 * @param {('vertex'|'fragment'|'compute')} stage - The type of stage.
-	 * @param {String} name - The name of the shader.
+	 * @param {string} name - The name of the shader.
 	 * @param {Array<Object>?} [transforms=null] - The transforms (only relevant for compute stages with WebGL 2 which uses Transform Feedback).
 	 * @param {Array<Object>?} [attributes=null] - The attributes (only relevant for compute stages with WebGL 2 which uses Transform Feedback).
 	 */
@@ -23,21 +23,21 @@ class ProgrammableStage {
 		/**
 		 * The id of the programmable stage.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 */
 		this.id = _id ++;
 
 		/**
 		 * The shader code.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.code = code;
 
 		/**
 		 * The type of stage.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.stage = stage;
 
@@ -45,7 +45,7 @@ class ProgrammableStage {
 		 * The name of the stage.
 		 * This is used for debugging purposes.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.name = name;
 
@@ -66,7 +66,7 @@ class ProgrammableStage {
 		/**
 		 * How often the programmable stage is currently in use.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @default 0
 		 */
 		this.usedTimes = 0;

--- a/src/renderers/common/QuadMesh.js
+++ b/src/renderers/common/QuadMesh.js
@@ -18,7 +18,7 @@ class QuadGeometry extends BufferGeometry {
 	/**
 	 * Constructs a new quad geometry.
 	 *
-	 * @param {Boolean} [flipY=false] - Whether the uv coordinates should be flipped along the vertical axis or not.
+	 * @param {boolean} [flipY=false] - Whether the uv coordinates should be flipped along the vertical axis or not.
 	 */
 	constructor( flipY = false ) {
 
@@ -67,7 +67,7 @@ class QuadMesh extends Mesh {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */

--- a/src/renderers/common/RenderContext.js
+++ b/src/renderers/common/RenderContext.js
@@ -21,14 +21,14 @@ class RenderContext {
 		/**
 		 * The context's ID.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 */
 		this.id = _id ++;
 
 		/**
 		 * Whether the current active framebuffer has a color attachment.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default true
 		 */
 		this.color = true;
@@ -36,7 +36,7 @@ class RenderContext {
 		/**
 		 * Whether the color attachment should be cleared or not.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default true
 		 */
 		this.clearColor = true;
@@ -52,7 +52,7 @@ class RenderContext {
 		/**
 		 * Whether the current active framebuffer has a depth attachment.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default true
 		 */
 		this.depth = true;
@@ -60,7 +60,7 @@ class RenderContext {
 		/**
 		 * Whether the depth attachment should be cleared or not.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default true
 		 */
 		this.clearDepth = true;
@@ -68,7 +68,7 @@ class RenderContext {
 		/**
 		 * The clear depth value.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @default 1
 		 */
 		this.clearDepthValue = 1;
@@ -76,7 +76,7 @@ class RenderContext {
 		/**
 		 * Whether the current active framebuffer has a stencil attachment.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default false
 		 */
 		this.stencil = false;
@@ -84,7 +84,7 @@ class RenderContext {
 		/**
 		 * Whether the stencil attachment should be cleared or not.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default true
 		 */
 		this.clearStencil = true;
@@ -92,7 +92,7 @@ class RenderContext {
 		/**
 		 * The clear stencil value.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @default 1
 		 */
 		this.clearStencilValue = 1;
@@ -101,7 +101,7 @@ class RenderContext {
 		 * By default the viewport encloses the entire framebuffer If a smaller
 		 * viewport is manually defined, this property is to `true` by the renderer.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default false
 		 */
 		this.viewport = false;
@@ -119,7 +119,7 @@ class RenderContext {
 		 * When the scissor test is active and scissor rectangle smaller than the
 		 * framebuffers dimensions, this property is to `true` by the renderer.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default false
 		 */
 		this.scissor = false;
@@ -160,7 +160,7 @@ class RenderContext {
 		/**
 		 * The active cube face.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @default 0
 		 */
 		this.activeCubeFace = 0;
@@ -168,7 +168,7 @@ class RenderContext {
 		/**
 		 * The active mipmap level.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @default 0
 		 */
 		this.activeMipmapLevel = 0;
@@ -177,7 +177,7 @@ class RenderContext {
 		 * The number of MSAA samples. This value is always `1` when
 		 * MSAA isn't used.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @default 1
 		 */
 		this.sampleCount = 1;
@@ -185,7 +185,7 @@ class RenderContext {
 		/**
 		 * The active render target's width in physical pixels.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @default 0
 		 */
 		this.width = 0;
@@ -193,7 +193,7 @@ class RenderContext {
 		/**
 		 * The active render target's height in physical pixels.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @default 0
 		 */
 		this.height = 0;
@@ -201,7 +201,7 @@ class RenderContext {
 		/**
 		 * The occlusion query count.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @default 0
 		 */
 		this.occlusionQueryCount = 0;
@@ -217,7 +217,7 @@ class RenderContext {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -228,7 +228,7 @@ class RenderContext {
 	/**
 	 * Returns the cache key of this render context.
 	 *
-	 * @return {Number} The cache key.
+	 * @return {number} The cache key.
 	 */
 	getCacheKey() {
 
@@ -244,7 +244,7 @@ class RenderContext {
  * configure the correct attachments in the respective backend.
  *
  * @param {RenderContext} renderContext - The render context.
- * @return {Number} The cache key.
+ * @return {number} The cache key.
  */
 export function getCacheKey( renderContext ) {
 

--- a/src/renderers/common/RenderContexts.js
+++ b/src/renderers/common/RenderContexts.js
@@ -23,7 +23,7 @@ class RenderContexts {
 		 * A dictionary that manages render contexts in chain maps
 		 * for each attachment state.
 		 *
-		 * @type {Object<String,ChainMap>}
+		 * @type {Object<string,ChainMap>}
 		 */
 		this.chainMaps = {};
 
@@ -93,7 +93,7 @@ class RenderContexts {
 	 * Returns a chain map for the given attachment state.
 	 *
 	 * @private
-	 * @param {String} attachmentState - The attachment state.
+	 * @param {string} attachmentState - The attachment state.
 	 * @return {ChainMap} The chain map.
 	 */
 	_getChainMap( attachmentState ) {

--- a/src/renderers/common/RenderList.js
+++ b/src/renderers/common/RenderList.js
@@ -7,7 +7,7 @@ import { DoubleSide } from '../../constants.js';
  * @function
  * @param {Object} a - The first render item.
  * @param {Object} b - The second render item.
- * @return {Number} A numeric value which defines the sort order.
+ * @return {number} A numeric value which defines the sort order.
  */
 function painterSortStable( a, b ) {
 
@@ -42,7 +42,7 @@ function painterSortStable( a, b ) {
  * @function
  * @param {Object} a - The first render item.
  * @param {Object} b - The second render item.
- * @return {Number} A numeric value which defines the sort order.
+ * @return {number} A numeric value which defines the sort order.
  */
 function reversePainterSortStable( a, b ) {
 
@@ -72,7 +72,7 @@ function reversePainterSortStable( a, b ) {
  * @private
  * @function
  * @param {Material} material - The transparent material.
- * @return {Boolean} Whether the given material requires a double pass or not.
+ * @return {boolean} Whether the given material requires a double pass or not.
  */
 function needsDoublePass( material ) {
 
@@ -114,7 +114,7 @@ class RenderList {
 		/**
 		 * The current render items index.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @default 0
 		 */
 		this.renderItemsIndex = 0;
@@ -182,7 +182,7 @@ class RenderList {
 		/**
 		 * How many objects perform occlusion query tests.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @default 0
 		 */
 		this.occlusionQueryCount = 0;
@@ -223,9 +223,9 @@ class RenderList {
 	 * @param {Object3D} object - The 3D object.
 	 * @param {BufferGeometry} geometry - The 3D object's geometry.
 	 * @param {Material} material - The 3D object's material.
-	 * @param {Number} groupOrder - The current group order.
-	 * @param {Number} z - Th 3D object's depth value (z value in clip space).
-	 * @param {Number?} group - {Object?} group - Only relevant for objects using multiple materials. This represents a group entry from the respective `BufferGeometry`.
+	 * @param {number} groupOrder - The current group order.
+	 * @param {number} z - Th 3D object's depth value (z value in clip space).
+	 * @param {number?} group - {Object?} group - Only relevant for objects using multiple materials. This represents a group entry from the respective `BufferGeometry`.
 	 * @param {ClippingContext} clippingContext - The current clipping context.
 	 * @return {Object} The render item.
 	 */
@@ -276,9 +276,9 @@ class RenderList {
 	 * @param {Object3D} object - The 3D object.
 	 * @param {BufferGeometry} geometry - The 3D object's geometry.
 	 * @param {Material} material - The 3D object's material.
-	 * @param {Number} groupOrder - The current group order.
-	 * @param {Number} z - Th 3D object's depth value (z value in clip space).
-	 * @param {Number?} group - {Object?} group - Only relevant for objects using multiple materials. This represents a group entry from the respective `BufferGeometry`.
+	 * @param {number} groupOrder - The current group order.
+	 * @param {number} z - Th 3D object's depth value (z value in clip space).
+	 * @param {number?} group - {Object?} group - Only relevant for objects using multiple materials. This represents a group entry from the respective `BufferGeometry`.
 	 * @param {ClippingContext} clippingContext - The current clipping context.
 	 */
 	push( object, geometry, material, groupOrder, z, group, clippingContext ) {
@@ -308,9 +308,9 @@ class RenderList {
 	 * @param {Object3D} object - The 3D object.
 	 * @param {BufferGeometry} geometry - The 3D object's geometry.
 	 * @param {Material} material - The 3D object's material.
-	 * @param {Number} groupOrder - The current group order.
-	 * @param {Number} z - Th 3D object's depth value (z value in clip space).
-	 * @param {Number?} group - {Object?} group - Only relevant for objects using multiple materials. This represents a group entry from the respective `BufferGeometry`.
+	 * @param {number} groupOrder - The current group order.
+	 * @param {number} z - Th 3D object's depth value (z value in clip space).
+	 * @param {number?} group - {Object?} group - Only relevant for objects using multiple materials. This represents a group entry from the respective `BufferGeometry`.
 	 * @param {ClippingContext} clippingContext - The current clipping context.
 	 */
 	unshift( object, geometry, material, groupOrder, z, group, clippingContext ) {
@@ -356,8 +356,8 @@ class RenderList {
 	/**
 	 * Sorts the internal render lists.
 	 *
-	 * @param {function(Any, Any): Number} customOpaqueSort - A custom sort function for opaque objects.
-	 * @param {function(Any, Any): Number} customTransparentSort -  A custom sort function for transparent objects.
+	 * @param {function(any, any): number} customOpaqueSort - A custom sort function for opaque objects.
+	 * @param {function(any, any): number} customTransparentSort -  A custom sort function for transparent objects.
 	 */
 	sort( customOpaqueSort, customTransparentSort ) {
 

--- a/src/renderers/common/RenderObject.js
+++ b/src/renderers/common/RenderObject.js
@@ -149,7 +149,7 @@ class RenderObject {
 		/**
 		 * The render object's version.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 */
 		this.version = material.version;
 
@@ -185,7 +185,7 @@ class RenderObject {
 		 * multiple materials. This represents a group entry
 		 * from the respective `BufferGeometry`.
 		 *
-		 * @type {{start: Number, count: Number}?}
+		 * @type {{start: number, count: number}?}
 		 * @default null
 		 */
 		this.group = null;
@@ -226,21 +226,21 @@ class RenderObject {
 		/**
 		 * The clipping context's cache key.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.clippingContextCacheKey = clippingContext !== null ? clippingContext.cacheKey : '';
 
 		/**
 		 * The initial node cache key.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 */
 		this.initialNodesCacheKey = this.getDynamicCacheKey();
 
 		/**
 		 * The initial cache key.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 */
 		this.initialCacheKey = this.getCacheKey();
 
@@ -282,7 +282,7 @@ class RenderObject {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -318,7 +318,7 @@ class RenderObject {
 	/**
 	 * Whether the clipping requires an update or not.
 	 *
-	 * @type {Boolean}
+	 * @type {boolean}
 	 * @readonly
 	 */
 	get clippingNeedsUpdate() {
@@ -334,7 +334,7 @@ class RenderObject {
 	/**
 	 * The number of clipping planes defined in context of hardware clipping.
 	 *
-	 * @type {Number}
+	 * @type {number}
 	 * @readonly
 	 */
 	get hardwareClippingPlanes() {
@@ -379,7 +379,7 @@ class RenderObject {
 	/**
 	 * Returns a binding group by group name of this render object.
 	 *
-	 * @param {String} name - The name of the binding group.
+	 * @param {string} name - The name of the binding group.
 	 * @return {BindGroup?} The bindings.
 	 */
 	getBindingGroup( name ) {
@@ -494,7 +494,7 @@ class RenderObject {
 	/**
 	 * Returns the draw parameters for the render object.
 	 *
-	 * @return {{vertexCount: Number, firstVertex: Number, instanceCount: Number, firstInstance: Number}} The draw parameters.
+	 * @return {{vertexCount: number, firstVertex: number, instanceCount: number, firstInstance: number}} The draw parameters.
 	 */
 	getDrawParameters() {
 
@@ -567,7 +567,7 @@ class RenderObject {
 	 *
 	 * The geometry cache key is part of the material cache key.
 	 *
-	 * @return {String} The geometry cache key.
+	 * @return {string} The geometry cache key.
 	 */
 	getGeometryCacheKey() {
 
@@ -623,7 +623,7 @@ class RenderObject {
 	 *
 	 * The material cache key is part of the render object cache key.
 	 *
-	 * @return {Number} The material cache key.
+	 * @return {number} The material cache key.
 	 */
 	getMaterialCacheKey() {
 
@@ -720,7 +720,7 @@ class RenderObject {
 	/**
 	 * Whether the geometry requires an update or not.
 	 *
-	 * @type {Boolean}
+	 * @type {boolean}
 	 * @readonly
 	 */
 	get needsGeometryUpdate() {
@@ -743,7 +743,7 @@ class RenderObject {
 	 * TODO: Investigate if it's possible to merge both steps so there is only a single place
 	 * that performs the 'needsUpdate' check.
 	 *
-	 * @type {Boolean}
+	 * @type {boolean}
 	 * @readonly
 	 */
 	get needsUpdate() {
@@ -755,7 +755,7 @@ class RenderObject {
 	/**
 	 * Returns the dynamic cache key which represents a key that is computed per draw command.
 	 *
-	 * @return {Number} The cache key.
+	 * @return {number} The cache key.
 	 */
 	getDynamicCacheKey() {
 
@@ -789,7 +789,7 @@ class RenderObject {
 	/**
 	 * Returns the render object's cache key.
 	 *
-	 * @return {Number} The cache key.
+	 * @return {number} The cache key.
 	 */
 	getCacheKey() {
 

--- a/src/renderers/common/RenderObjects.js
+++ b/src/renderers/common/RenderObjects.js
@@ -68,7 +68,7 @@ class RenderObjects {
 		 * A dictionary that manages render contexts in chain maps
 		 * for each pass ID.
 		 *
-		 * @type {Object<String,ChainMap>}
+		 * @type {Object<string,ChainMap>}
 		 */
 		this.chainMaps = {};
 
@@ -84,7 +84,7 @@ class RenderObjects {
 	 * @param {LightsNode} lightsNode - The lights node.
 	 * @param {RenderContext} renderContext - The render context.
 	 * @param {ClippingContext} clippingContext - The clipping context.
-	 * @param {String?} passId - An optional ID for identifying the pass.
+	 * @param {string?} passId - An optional ID for identifying the pass.
 	 * @return {RenderObject} The render object.
 	 */
 	get( object, material, scene, camera, lightsNode, renderContext, clippingContext, passId ) {
@@ -142,7 +142,7 @@ class RenderObjects {
 	/**
 	 * Returns a chain map for the given pass ID.
 	 *
-	 * @param {String} [passId='default'] - The pass ID.
+	 * @param {string} [passId='default'] - The pass ID.
 	 * @return {ChainMap} The chain map.
 	 */
 	getChainMap( passId = 'default' ) {
@@ -173,7 +173,7 @@ class RenderObjects {
 	 * @param {LightsNode} lightsNode - The lights node.
 	 * @param {RenderContext} renderContext - The render context.
 	 * @param {ClippingContext} clippingContext - The clipping context.
-	 * @param {String?} passId - An optional ID for identifying the pass.
+	 * @param {string?} passId - An optional ID for identifying the pass.
 	 * @return {RenderObject} The render object.
 	 */
 	createRenderObject( nodes, geometries, renderer, object, material, scene, camera, lightsNode, renderContext, clippingContext, passId ) {

--- a/src/renderers/common/RenderPipeline.js
+++ b/src/renderers/common/RenderPipeline.js
@@ -11,7 +11,7 @@ class RenderPipeline extends Pipeline {
 	/**
 	 * Constructs a new render pipeline.
 	 *
-	 * @param {String} cacheKey - The pipeline's cache key.
+	 * @param {string} cacheKey - The pipeline's cache key.
 	 * @param {ProgrammableStage} vertexProgram - The pipeline's vertex shader.
 	 * @param {ProgrammableStage} fragmentProgram - The pipeline's fragment shader.
 	 */

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -45,15 +45,15 @@ class Renderer {
 	 *
 	 * @param {Backend} backend - The backend the renderer is targeting (e.g. WebGPU or WebGL 2).
 	 * @param {Object} parameters - The configuration parameter.
-	 * @param {Boolean} [parameters.logarithmicDepthBuffer=false] - Whether logarithmic depth buffer is enabled or not.
-	 * @param {Boolean} [parameters.alpha=true] - Whether the default framebuffer (which represents the final contents of the canvas) should be transparent or opaque.
-	 * @param {Boolean} [parameters.depth=true] - Whether the default framebuffer should have a depth buffer or not.
-	 * @param {Boolean} [parameters.stencil=false] - Whether the default framebuffer should have a stencil buffer or not.
-	 * @param {Boolean} [parameters.antialias=false] - Whether MSAA as the default anti-aliasing should be enabled or not.
-	 * @param {Number} [parameters.samples=0] - When `antialias` is `true`, `4` samples are used by default. This parameter can set to any other integer value than 0
+	 * @param {boolean} [parameters.logarithmicDepthBuffer=false] - Whether logarithmic depth buffer is enabled or not.
+	 * @param {boolean} [parameters.alpha=true] - Whether the default framebuffer (which represents the final contents of the canvas) should be transparent or opaque.
+	 * @param {boolean} [parameters.depth=true] - Whether the default framebuffer should have a depth buffer or not.
+	 * @param {boolean} [parameters.stencil=false] - Whether the default framebuffer should have a stencil buffer or not.
+	 * @param {boolean} [parameters.antialias=false] - Whether MSAA as the default anti-aliasing should be enabled or not.
+	 * @param {number} [parameters.samples=0] - When `antialias` is `true`, `4` samples are used by default. This parameter can set to any other integer value than 0
 	 * to overwrite the default.
 	 * @param {Function?} [parameters.getFallback=null] - This callback function can be used to provide a fallback backend, if the primary backend can't be targeted.
-	 * @param {Number} [parameters.colorBufferType=HalfFloatType] - Defines the type of color buffers. The default `HalfFloatType` is recommend for best
+	 * @param {number} [parameters.colorBufferType=HalfFloatType] - Defines the type of color buffers. The default `HalfFloatType` is recommend for best
 	 * quality. To save memory and bandwidth, `UnsignedByteType` might be used. This will reduce rendering quality though.
 	 */
 	constructor( backend, parameters = {} ) {
@@ -61,7 +61,7 @@ class Renderer {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -99,7 +99,7 @@ class Renderer {
 		/**
 		 * The number of MSAA samples.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @default 0
 		 */
 		this.samples = samples || ( antialias === true ) ? 4 : 0;
@@ -109,7 +109,7 @@ class Renderer {
 		 * before execute a `render()` call. The target can be the canvas (default framebuffer)
 		 * or the current bound render target (custom framebuffer).
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default true
 		 */
 		this.autoClear = true;
@@ -118,7 +118,7 @@ class Renderer {
 		 * When `autoClear` is set to `true`, this property defines whether the renderer
 		 * should clear the color buffer.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default true
 		 */
 		this.autoClearColor = true;
@@ -127,7 +127,7 @@ class Renderer {
 		 * When `autoClear` is set to `true`, this property defines whether the renderer
 		 * should clear the depth buffer.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default true
 		 */
 		this.autoClearDepth = true;
@@ -136,7 +136,7 @@ class Renderer {
 		 * When `autoClear` is set to `true`, this property defines whether the renderer
 		 * should clear the stencil buffer.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default true
 		 */
 		this.autoClearStencil = true;
@@ -144,7 +144,7 @@ class Renderer {
 		/**
 		 * Whether the default framebuffer should be transparent or opaque.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default true
 		 */
 		this.alpha = alpha;
@@ -152,7 +152,7 @@ class Renderer {
 		/**
 		 * Whether logarithmic depth buffer is enabled or not.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default false
 		 */
 		this.logarithmicDepthBuffer = logarithmicDepthBuffer;
@@ -160,7 +160,7 @@ class Renderer {
 		/**
 		 * Defines the output color space of the renderer.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 * @default SRGBColorSpace
 		 */
 		this.outputColorSpace = SRGBColorSpace;
@@ -168,7 +168,7 @@ class Renderer {
 		/**
 		 * Defines the tone mapping of the renderer.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @default NoToneMapping
 		 */
 		this.toneMapping = NoToneMapping;
@@ -176,7 +176,7 @@ class Renderer {
 		/**
 		 * Defines the tone mapping exposure.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @default 1
 		 */
 		this.toneMappingExposure = 1.0;
@@ -189,7 +189,7 @@ class Renderer {
 		 * it may be necessary to turn off sorting and use other methods to deal with transparency rendering
 		 * e.g. manually determining each object's rendering order.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default true
 		 */
 		this.sortObjects = true;
@@ -197,7 +197,7 @@ class Renderer {
 		/**
 		 * Whether the default framebuffer should have a depth buffer or not.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default true
 		 */
 		this.depth = depth;
@@ -205,7 +205,7 @@ class Renderer {
 		/**
 		 * Whether the default framebuffer should have a stencil buffer or not.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default false
 		 */
 		this.stencil = stencil;
@@ -255,7 +255,7 @@ class Renderer {
 		 * The renderer's pixel ration.
 		 *
 		 * @private
-		 * @type {Number}
+		 * @type {number}
 		 * @default 1
 		 */
 		this._pixelRatio = 1;
@@ -264,7 +264,7 @@ class Renderer {
 		 * The width of the renderer's default framebuffer in logical pixel unit.
 		 *
 		 * @private
-		 * @type {Number}
+		 * @type {number}
 		 */
 		this._width = this.domElement.width;
 
@@ -272,7 +272,7 @@ class Renderer {
 		 * The height of the renderer's default framebuffer in logical pixel unit.
 		 *
 		 * @private
-		 * @type {Number}
+		 * @type {number}
 		 */
 		this._height = this.domElement.height;
 
@@ -296,7 +296,7 @@ class Renderer {
 		 * Whether the scissor test should be enabled or not.
 		 *
 		 * @private
-		 * @type {Boolean}
+		 * @type {boolean}
 		 */
 		this._scissorTest = false;
 
@@ -468,7 +468,7 @@ class Renderer {
 		 * The clear depth value.
 		 *
 		 * @private
-		 * @type {Number}
+		 * @type {number}
 		 * @default 1
 		 */
 		this._clearDepth = 1;
@@ -477,7 +477,7 @@ class Renderer {
 		 * The clear stencil value.
 		 *
 		 * @private
-		 * @type {Number}
+		 * @type {number}
 		 * @default 0
 		 */
 		this._clearStencil = 0;
@@ -495,7 +495,7 @@ class Renderer {
 		 * The active cube face.
 		 *
 		 * @private
-		 * @type {Number}
+		 * @type {number}
 		 * @default 0
 		 */
 		this._activeCubeFace = 0;
@@ -504,7 +504,7 @@ class Renderer {
 		 * The active mipmap level.
 		 *
 		 * @private
-		 * @type {Number}
+		 * @type {number}
 		 * @default 0
 		 */
 		this._activeMipmapLevel = 0;
@@ -566,7 +566,7 @@ class Renderer {
 		 * isn't possible anymore.
 		 *
 		 * @private
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default false
 		 */
 		this._isDeviceLost = false;
@@ -584,7 +584,7 @@ class Renderer {
 		 * This will reduce rendering quality though.
 		 *
 		 * @private
-		 * @type {Number}
+		 * @type {number}
 		 * @default HalfFloatType
 		 */
 		this._colorBufferType = colorBufferType;
@@ -593,7 +593,7 @@ class Renderer {
 		 * Whether the renderer has been initialized or not.
 		 *
 		 * @private
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default false
 		 */
 		this._initialized = false;
@@ -619,7 +619,7 @@ class Renderer {
 		/**
 		 * Whether the renderer should render transparent render objects or not.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default true
 		 */
 		this.transparent = true;
@@ -627,7 +627,7 @@ class Renderer {
 		/**
 		 * Whether the renderer should render opaque render objects or not.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default true
 		 */
 		this.opaque = true;
@@ -635,8 +635,8 @@ class Renderer {
 		/**
 		 * Shadow map configuration
 		 * @typedef {Object} ShadowMapConfig
-		 * @property {Boolean} enabled - Whether to globally enable shadows or not.
-		 * @property {Number} type - The shadow map type.
+		 * @property {boolean} enabled - Whether to globally enable shadows or not.
+		 * @property {number} type - The shadow map type.
 		 */
 
 		/**
@@ -652,7 +652,7 @@ class Renderer {
 		/**
 		 * XR configuration.
 		 * @typedef {Object} XRConfig
-		 * @property {Boolean} enabled - Whether to globally enable XR or not.
+		 * @property {boolean} enabled - Whether to globally enable XR or not.
 		 */
 
 		/**
@@ -665,7 +665,7 @@ class Renderer {
 		/**
 		 * Debug configuration.
 		 * @typedef {Object} DebugConfig
-		 * @property {Boolean} checkShaderErrors - Whether shader errors should be checked or not.
+		 * @property {boolean} checkShaderErrors - Whether shader errors should be checked or not.
 		 * @property {Function} onShaderError - A callback function that is executed when a shader error happens. Only supported with WebGL 2 right now.
 		 * @property {Function} getShaderAsync - Allows the get the raw shader code for the given scene, camera and 3D object.
 		 */
@@ -785,7 +785,7 @@ class Renderer {
 	 * `THREE.WebGPUCoordinateSystem`.
 	 *
 	 * @readonly
-	 * @type {Number}
+	 * @type {number}
 	 */
 	get coordinateSystem() {
 
@@ -989,7 +989,7 @@ class Renderer {
 	/**
 	 * Returns the color buffer type.
 	 *
-	 * @return {Number} The color buffer type.
+	 * @return {number} The color buffer type.
 	 */
 	getColorBufferType() {
 
@@ -1185,7 +1185,7 @@ class Renderer {
 	 * @private
 	 * @param {Object3D} scene - The scene or 3D object to render.
 	 * @param {Camera} camera - The camera to render the scene with.
-	 * @param {Boolean} [useFrameBufferTarget=true] - Whether to use a framebuffer target or not.
+	 * @param {boolean} [useFrameBufferTarget=true] - Whether to use a framebuffer target or not.
 	 * @return {RenderContext} The current render context.
 	 */
 	_renderScene( scene, camera, useFrameBufferTarget = true ) {
@@ -1451,7 +1451,7 @@ class Renderer {
 	/**
 	 * Returns the maximum available anisotropy for texture filtering.
 	 *
-	 * @return {Number} The maximum available anisotropy.
+	 * @return {number} The maximum available anisotropy.
 	 */
 	getMaxAnisotropy() {
 
@@ -1462,7 +1462,7 @@ class Renderer {
 	/**
 	 * Returns the active cube face.
 	 *
-	 * @return {Number} The active cube face.
+	 * @return {number} The active cube face.
 	 */
 	getActiveCubeFace() {
 
@@ -1473,7 +1473,7 @@ class Renderer {
 	/**
 	 * Returns the active mipmap level.
 	 *
-	 * @return {Number} The active mipmap level.
+	 * @return {number} The active mipmap level.
 	 */
 	getActiveMipmapLevel() {
 
@@ -1526,7 +1526,7 @@ class Renderer {
 	/**
 	 * Returns the pixel ratio.
 	 *
-	 * @return {Number} The pixel ratio.
+	 * @return {number} The pixel ratio.
 	 */
 	getPixelRatio() {
 
@@ -1561,7 +1561,7 @@ class Renderer {
 	/**
 	 * Sets the given pixel ration and resizes the canvas if necessary.
 	 *
-	 * @param {Number} [value=1] - The pixel ratio.
+	 * @param {number} [value=1] - The pixel ratio.
 	 */
 	setPixelRatio( value = 1 ) {
 
@@ -1582,9 +1582,9 @@ class Renderer {
 	 * size.y = height * pixelRatio;
 	 *```
 	 *
-	 * @param {Number} width - The width in logical pixels.
-	 * @param {Number} height - The height in logical pixels.
-	 * @param {Number} pixelRatio - The pixel ratio.
+	 * @param {number} width - The width in logical pixels.
+	 * @param {number} height - The height in logical pixels.
+	 * @param {number} pixelRatio - The pixel ratio.
 	 */
 	setDrawingBufferSize( width, height, pixelRatio ) {
 
@@ -1605,9 +1605,9 @@ class Renderer {
 	/**
 	 * Sets the size of the renderer.
 	 *
-	 * @param {Number} width - The width in logical pixels.
-	 * @param {Number} height - The height in logical pixels.
-	 * @param {Boolean} [updateStyle=true] - Whether to update the `style` attribute of the canvas or not.
+	 * @param {number} width - The width in logical pixels.
+	 * @param {number} height - The height in logical pixels.
+	 * @param {boolean} [updateStyle=true] - Whether to update the `style` attribute of the canvas or not.
 	 */
 	setSize( width, height, updateStyle = true ) {
 
@@ -1676,11 +1676,11 @@ class Renderer {
 	/**
 	 * Defines the scissor rectangle.
 	 *
-	 * @param {Number | Vector4} x - The horizontal coordinate for the lower left corner of the box in logical pixel unit.
+	 * @param {number | Vector4} x - The horizontal coordinate for the lower left corner of the box in logical pixel unit.
 	 * Instead of passing four arguments, the method also works with a single four-dimensional vector.
-	 * @param {Number} y - The vertical coordinate for the lower left corner of the box in logical pixel unit.
-	 * @param {Number} width - The width of the scissor box in logical pixel unit.
-	 * @param {Number} height - The height of the scissor box in logical pixel unit.
+	 * @param {number} y - The vertical coordinate for the lower left corner of the box in logical pixel unit.
+	 * @param {number} width - The width of the scissor box in logical pixel unit.
+	 * @param {number} height - The height of the scissor box in logical pixel unit.
 	 */
 	setScissor( x, y, width, height ) {
 
@@ -1701,7 +1701,7 @@ class Renderer {
 	/**
 	 * Returns the scissor test value.
 	 *
-	 * @return {Boolean} Whether the scissor test should be enabled or not.
+	 * @return {boolean} Whether the scissor test should be enabled or not.
 	 */
 	getScissorTest() {
 
@@ -1712,7 +1712,7 @@ class Renderer {
 	/**
 	 * Defines the scissor test.
 	 *
-	 * @param {Boolean} boolean - Whether the scissor test should be enabled or not.
+	 * @param {boolean} boolean - Whether the scissor test should be enabled or not.
 	 */
 	setScissorTest( boolean ) {
 
@@ -1737,12 +1737,12 @@ class Renderer {
 	/**
 	 * Defines the viewport.
 	 *
-	 * @param {Number | Vector4} x - The horizontal coordinate for the lower left corner of the viewport origin in logical pixel unit.
-	 * @param {Number} y - The vertical coordinate for the lower left corner of the viewport origin  in logical pixel unit.
-	 * @param {Number} width - The width of the viewport in logical pixel unit.
-	 * @param {Number} height - The height of the viewport in logical pixel unit.
-	 * @param {Number} minDepth - The minimum depth value of the viewport. WebGPU only.
-	 * @param {Number} maxDepth - The maximum depth value of the viewport. WebGPU only.
+	 * @param {number | Vector4} x - The horizontal coordinate for the lower left corner of the viewport origin in logical pixel unit.
+	 * @param {number} y - The vertical coordinate for the lower left corner of the viewport origin  in logical pixel unit.
+	 * @param {number} width - The width of the viewport in logical pixel unit.
+	 * @param {number} height - The height of the viewport in logical pixel unit.
+	 * @param {number} minDepth - The minimum depth value of the viewport. WebGPU only.
+	 * @param {number} maxDepth - The maximum depth value of the viewport. WebGPU only.
 	 */
 	setViewport( x, y, width, height, minDepth = 0, maxDepth = 1 ) {
 
@@ -1779,7 +1779,7 @@ class Renderer {
 	 * Defines the clear color and optionally the clear alpha.
 	 *
 	 * @param {Color} color - The clear color.
-	 * @param {Number} [alpha=1] - The clear alpha.
+	 * @param {number} [alpha=1] - The clear alpha.
 	 */
 	setClearColor( color, alpha = 1 ) {
 
@@ -1791,7 +1791,7 @@ class Renderer {
 	/**
 	 * Returns the clear alpha.
 	 *
-	 * @return {Number} The clear alpha.
+	 * @return {number} The clear alpha.
 	 */
 	getClearAlpha() {
 
@@ -1802,7 +1802,7 @@ class Renderer {
 	/**
 	 * Defines the clear alpha.
 	 *
-	 * @param {Number} alpha - The clear alpha.
+	 * @param {number} alpha - The clear alpha.
 	 */
 	setClearAlpha( alpha ) {
 
@@ -1813,7 +1813,7 @@ class Renderer {
 	/**
 	 * Returns the clear depth.
 	 *
-	 * @return {Number} The clear depth.
+	 * @return {number} The clear depth.
 	 */
 	getClearDepth() {
 
@@ -1824,7 +1824,7 @@ class Renderer {
 	/**
 	 * Defines the clear depth.
 	 *
-	 * @param {Number} depth - The clear depth.
+	 * @param {number} depth - The clear depth.
 	 */
 	setClearDepth( depth ) {
 
@@ -1835,7 +1835,7 @@ class Renderer {
 	/**
 	 * Returns the clear stencil.
 	 *
-	 * @return {Number} The clear stencil.
+	 * @return {number} The clear stencil.
 	 */
 	getClearStencil() {
 
@@ -1846,7 +1846,7 @@ class Renderer {
 	/**
 	 * Defines the clear stencil.
 	 *
-	 * @param {Number} stencil - The clear stencil.
+	 * @param {number} stencil - The clear stencil.
 	 */
 	setClearStencil( stencil ) {
 
@@ -1860,7 +1860,7 @@ class Renderer {
 	 * 3D objects in the scene.
 	 *
 	 * @param {Object3D} object - The 3D object to test.
-	 * @return {Boolean} Whether the 3D object is fully occluded or not.
+	 * @return {boolean} Whether the 3D object is fully occluded or not.
 	 */
 	isOccluded( object ) {
 
@@ -1873,9 +1873,9 @@ class Renderer {
 	/**
 	 * Performs a manual clear operation. This method ignores `autoClear` properties.
 	 *
-	 * @param {Boolean} [color=true] - Whether the color buffer should be cleared or not.
-	 * @param {Boolean} [depth=true] - Whether the depth buffer should be cleared or not.
-	 * @param {Boolean} [stencil=true] - Whether the stencil buffer should be cleared or not.
+	 * @param {boolean} [color=true] - Whether the color buffer should be cleared or not.
+	 * @param {boolean} [depth=true] - Whether the depth buffer should be cleared or not.
+	 * @param {boolean} [stencil=true] - Whether the stencil buffer should be cleared or not.
 	 * @return {Promise} A Promise that resolves when the clear operation has been executed.
 	 * Only returned when the renderer has not been initialized.
 	 */
@@ -1962,9 +1962,9 @@ class Renderer {
 	 * Async version of {@link Renderer#clear}.
 	 *
 	 * @async
-	 * @param {Boolean} [color=true] - Whether the color buffer should be cleared or not.
-	 * @param {Boolean} [depth=true] - Whether the depth buffer should be cleared or not.
-	 * @param {Boolean} [stencil=true] - Whether the stencil buffer should be cleared or not.
+	 * @param {boolean} [color=true] - Whether the color buffer should be cleared or not.
+	 * @param {boolean} [depth=true] - Whether the depth buffer should be cleared or not.
+	 * @param {boolean} [stencil=true] - Whether the stencil buffer should be cleared or not.
 	 * @return {Promise} A Promise that resolves when the clear operation has been executed.
 	 */
 	async clearAsync( color = true, depth = true, stencil = true ) {
@@ -2015,7 +2015,7 @@ class Renderer {
 	 * The current output tone mapping of the renderer. When a render target is set,
 	 * the output tone mapping is always `NoToneMapping`.
 	 *
-	 * @type {Number}
+	 * @type {number}
 	 */
 	get currentToneMapping() {
 
@@ -2027,7 +2027,7 @@ class Renderer {
 	 * The current output color space of the renderer. When a render target is set,
 	 * the output color space is always `LinearSRGBColorSpace`.
 	 *
-	 * @type {String}
+	 * @type {string}
 	 */
 	get currentColorSpace() {
 
@@ -2072,8 +2072,8 @@ class Renderer {
 	 * Use `null` as the first argument to reset the state.
 	 *
 	 * @param {RenderTarget?} renderTarget - The render target to set.
-	 * @param {Number} [activeCubeFace=0] - The active cube face.
-	 * @param {Number} [activeMipmapLevel=0] - The active mipmap level.
+	 * @param {number} [activeCubeFace=0] - The active cube face.
+	 * @param {number} [activeMipmapLevel=0] - The active mipmap level.
 	 */
 	setRenderTarget( renderTarget, activeCubeFace = 0, activeMipmapLevel = 0 ) {
 
@@ -2106,7 +2106,7 @@ class Renderer {
 	 * @param {Object?} group - Only relevant for objects using multiple materials. This represents a group entry from the respective `BufferGeometry`.
 	 * @param {LightsNode} lightsNode - The current lights node.
 	 * @param {ClippingContext} clippingContext - The clipping context.
-	 * @param {String?} [passId=null] - An optional ID for identifying the pass.
+	 * @param {string?} [passId=null] - An optional ID for identifying the pass.
 	 */
 
 	/**
@@ -2254,8 +2254,8 @@ class Renderer {
 	 * Checks if the given feature is supported by the selected backend.
 	 *
 	 * @async
-	 * @param {String} name - The feature's name.
-	 * @return {Promise<Boolean>} A Promise that resolves with a bool that indicates whether the feature is supported or not.
+	 * @param {string} name - The feature's name.
+	 * @return {Promise<boolean>} A Promise that resolves with a bool that indicates whether the feature is supported or not.
 	 */
 	async hasFeatureAsync( name ) {
 
@@ -2277,8 +2277,8 @@ class Renderer {
 	 * Checks if the given feature is supported by the selected backend. If the
 	 * renderer has not been initialized, this method always returns `false`.
 	 *
-	 * @param {String} name - The feature's name.
-	 * @return {Boolean} Whether the feature is supported or not.
+	 * @param {string} name - The feature's name.
+	 * @return {boolean} Whether the feature is supported or not.
 	 */
 	hasFeature( name ) {
 
@@ -2297,7 +2297,7 @@ class Renderer {
 	/**
 	 * Returns `true` when the renderer has been initialized.
 	 *
-	 * @return {Boolean} Whether the renderer has been initialized or not.
+	 * @return {boolean} Whether the renderer has been initialized or not.
 	 */
 	hasInitialized() {
 
@@ -2411,7 +2411,7 @@ class Renderer {
 	 * @param {Texture} dstTexture - The destination texture.
 	 * @param {Box2|Box3} [srcRegion=null] - A bounding box which describes the source region. Can be two or three-dimensional.
 	 * @param {Vector2|Vector3} [dstPosition=null] - A vector that represents the origin of the destination region. Can be two or three-dimensional.
-	 * @param {Number} level - The mipmap level to copy.
+	 * @param {number} level - The mipmap level to copy.
 	 */
 	copyTextureToTexture( srcTexture, dstTexture, srcRegion = null, dstPosition = null, level = 0 ) {
 
@@ -2427,12 +2427,12 @@ class Renderer {
 	 *
 	 * @async
 	 * @param {RenderTarget} renderTarget - The render target to read from.
-	 * @param {Number} x - The `x` coordinate of the copy region's origin.
-	 * @param {Number} y - The `y` coordinate of the copy region's origin.
-	 * @param {Number} width - The width of the copy region.
-	 * @param {Number} height - The height of the copy region.
-	 * @param {Number} [textureIndex=0] - The texture index of a MRT render target.
-	 * @param {Number} [faceIndex=0] - The active cube face index.
+	 * @param {number} x - The `x` coordinate of the copy region's origin.
+	 * @param {number} y - The `y` coordinate of the copy region's origin.
+	 * @param {number} width - The width of the copy region.
+	 * @param {number} height - The height of the copy region.
+	 * @param {number} [textureIndex=0] - The texture index of a MRT render target.
+	 * @param {number} [faceIndex=0] - The active cube face index.
 	 * @return {Promise<TypedArray>} A Promise that resolves when the read has been finished. The resolve provides the read data as a typed array.
 	 */
 	async readRenderTargetPixelsAsync( renderTarget, x, y, width, height, textureIndex = 0, faceIndex = 0 ) {
@@ -2447,7 +2447,7 @@ class Renderer {
 	 *
 	 * @param {Object3D} object - The 3D object to process (usually a scene).
 	 * @param {Camera} camera - The camera the object is rendered with.
-	 * @param {Number} groupOrder - The group order is derived from the `renderOrder` of groups and is used to group 3D objects within groups.
+	 * @param {number} groupOrder - The group order is derived from the `renderOrder` of groups and is used to group 3D objects within groups.
 	 * @param {RenderList} renderList - The current render list.
 	 * @param {ClippingContext} clippingContext - The current clipping context.
 	 */
@@ -2648,7 +2648,7 @@ class Renderer {
 	 * @param {Camera} camera - The camera the render list should be rendered with.
 	 * @param {Scene} scene - The scene the render list belongs to.
 	 * @param {LightsNode} lightsNode - The current lights node.
-	 * @param {String?} [passId=null] - An optional ID for identifying the pass.
+	 * @param {string?} [passId=null] - An optional ID for identifying the pass.
 	 */
 	_renderObjects( renderList, camera, scene, lightsNode, passId = null ) {
 
@@ -2674,7 +2674,7 @@ class Renderer {
 	 * @param {Object?} group - Only relevant for objects using multiple materials. This represents a group entry from the respective `BufferGeometry`.
 	 * @param {LightsNode} lightsNode - The current lights node.
 	 * @param {ClippingContext} clippingContext - The clipping context.
-	 * @param {String?} [passId=null] - An optional ID for identifying the pass.
+	 * @param {string?} [passId=null] - An optional ID for identifying the pass.
 	 */
 	renderObject( object, scene, camera, geometry, material, group, lightsNode, clippingContext = null, passId = null ) {
 
@@ -2781,9 +2781,9 @@ class Renderer {
 	 * @param {Scene} scene - The scene the 3D object belongs to.
 	 * @param {Camera} camera - The camera the object should be rendered with.
 	 * @param {LightsNode} lightsNode - The current lights node.
-	 * @param {{start: Number, count: Number}?} group - Only relevant for objects using multiple materials. This represents a group entry from the respective `BufferGeometry`.
+	 * @param {{start: number, count: number}?} group - Only relevant for objects using multiple materials. This represents a group entry from the respective `BufferGeometry`.
 	 * @param {ClippingContext} clippingContext - The clipping context.
-	 * @param {String?} [passId=null] - An optional ID for identifying the pass.
+	 * @param {string?} [passId=null] - An optional ID for identifying the pass.
 	 */
 	_renderObjectDirect( object, material, scene, camera, lightsNode, group, clippingContext, passId ) {
 
@@ -2836,9 +2836,9 @@ class Renderer {
 	 * @param {Scene} scene - The scene the 3D object belongs to.
 	 * @param {Camera} camera - The camera the object should be rendered with.
 	 * @param {LightsNode} lightsNode - The current lights node.
-	 * @param {{start: Number, count: Number}?} group - Only relevant for objects using multiple materials. This represents a group entry from the respective `BufferGeometry`.
+	 * @param {{start: number, count: number}?} group - Only relevant for objects using multiple materials. This represents a group entry from the respective `BufferGeometry`.
 	 * @param {ClippingContext} clippingContext - The clipping context.
-	 * @param {String?} [passId=null] - An optional ID for identifying the pass.
+	 * @param {string?} [passId=null] - An optional ID for identifying the pass.
 	 */
 	_createObjectPipeline( object, material, scene, camera, lightsNode, group, clippingContext, passId ) {
 

--- a/src/renderers/common/SampledTexture.js
+++ b/src/renderers/common/SampledTexture.js
@@ -13,7 +13,7 @@ class SampledTexture extends Binding {
 	/**
 	 * Constructs a new sampled texture.
 	 *
-	 * @param {String} name - The sampled texture's name.
+	 * @param {string} name - The sampled texture's name.
 	 * @param {Texture?} texture - The texture this binding is referring to.
 	 */
 	constructor( name, texture ) {
@@ -23,7 +23,7 @@ class SampledTexture extends Binding {
 		/**
 		 * This identifier.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 */
 		this.id = _id ++;
 
@@ -37,14 +37,14 @@ class SampledTexture extends Binding {
 		/**
 		 * The binding's version.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 */
 		this.version = texture ? texture.version : 0;
 
 		/**
 		 * Whether the texture is a storage texture or not.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default false
 		 */
 		this.store = false;
@@ -53,7 +53,7 @@ class SampledTexture extends Binding {
 		 * The binding's generation which is an additional version
 		 * qualifier.
 		 *
-		 * @type {Number?}
+		 * @type {number?}
 		 * @default null
 		 */
 		this.generation = null;
@@ -61,7 +61,7 @@ class SampledTexture extends Binding {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -73,8 +73,8 @@ class SampledTexture extends Binding {
 	 * Returns `true` whether this binding requires an update for the
 	 * given generation.
 	 *
-	 * @param {Number} generation - The generation.
-	 * @return {Boolean} Whether an update is required or not.
+	 * @param {number} generation - The generation.
+	 * @return {boolean} Whether an update is required or not.
 	 */
 	needsBindingsUpdate( generation ) {
 
@@ -95,7 +95,7 @@ class SampledTexture extends Binding {
 	/**
 	 * Updates the binding.
 	 *
-	 * @return {Boolean} Whether the texture has been updated and must be
+	 * @return {boolean} Whether the texture has been updated and must be
 	 * uploaded to the GPU.
 	 */
 	update() {
@@ -127,7 +127,7 @@ class SampledArrayTexture extends SampledTexture {
 	/**
 	 * Constructs a new sampled array texture.
 	 *
-	 * @param {String} name - The sampled array texture's name.
+	 * @param {string} name - The sampled array texture's name.
 	 * @param {(DataArrayTexture|CompressedArrayTexture)?} texture - The texture this binding is referring to.
 	 */
 	constructor( name, texture ) {
@@ -137,7 +137,7 @@ class SampledArrayTexture extends SampledTexture {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -158,7 +158,7 @@ class Sampled3DTexture extends SampledTexture {
 	/**
 	 * Constructs a new sampled 3D texture.
 	 *
-	 * @param {String} name - The sampled 3D texture's name.
+	 * @param {string} name - The sampled 3D texture's name.
 	 * @param {Data3DTexture?} texture - The texture this binding is referring to.
 	 */
 	constructor( name, texture ) {
@@ -168,7 +168,7 @@ class Sampled3DTexture extends SampledTexture {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -189,7 +189,7 @@ class SampledCubeTexture extends SampledTexture {
 	/**
 	 * Constructs a new sampled cube texture.
 	 *
-	 * @param {String} name - The sampled cube texture's name.
+	 * @param {string} name - The sampled cube texture's name.
 	 * @param {(CubeTexture|CompressedCubeTexture)?} texture - The texture this binding is referring to.
 	 */
 	constructor( name, texture ) {
@@ -199,7 +199,7 @@ class SampledCubeTexture extends SampledTexture {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */

--- a/src/renderers/common/Sampler.js
+++ b/src/renderers/common/Sampler.js
@@ -11,7 +11,7 @@ class Sampler extends Binding {
 	/**
 	 * Constructs a new sampler.
 	 *
-	 * @param {String} name - The samplers's name.
+	 * @param {string} name - The samplers's name.
 	 * @param {Texture?} texture - The texture this binding is referring to.
 	 */
 	constructor( name, texture ) {
@@ -28,14 +28,14 @@ class Sampler extends Binding {
 		/**
 		 * The binding's version.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 */
 		this.version = texture ? texture.version : 0;
 
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */

--- a/src/renderers/common/StorageBuffer.js
+++ b/src/renderers/common/StorageBuffer.js
@@ -11,7 +11,7 @@ class StorageBuffer extends Buffer {
 	/**
 	 * Constructs a new uniform buffer.
 	 *
-	 * @param {String} name - The buffer's name.
+	 * @param {string} name - The buffer's name.
 	 * @param {BufferAttribute} attribute - The buffer attribute.
 	 */
 	constructor( name, attribute ) {
@@ -28,7 +28,7 @@ class StorageBuffer extends Buffer {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */

--- a/src/renderers/common/StorageBufferAttribute.js
+++ b/src/renderers/common/StorageBufferAttribute.js
@@ -19,9 +19,9 @@ class StorageBufferAttribute extends BufferAttribute {
 	/**
 	 * Constructs a new storage buffer attribute.
 	 *
-	 * @param {Number|TypedArray} count - The item count. It is also valid to pass a typed array as an argument.
+	 * @param {number|TypedArray} count - The item count. It is also valid to pass a typed array as an argument.
 	 * The subsequent parameters are then obsolete.
-	 * @param {Number} itemSize - The item size.
+	 * @param {number} itemSize - The item size.
 	 * @param {TypedArray.constructor} [typeClass=Float32Array] - A typed array constructor.
 	 */
 	constructor( count, itemSize, typeClass = Float32Array ) {
@@ -33,7 +33,7 @@ class StorageBufferAttribute extends BufferAttribute {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */

--- a/src/renderers/common/StorageInstancedBufferAttribute.js
+++ b/src/renderers/common/StorageInstancedBufferAttribute.js
@@ -19,9 +19,9 @@ class StorageInstancedBufferAttribute extends InstancedBufferAttribute {
 	/**
 	 * Constructs a new storage instanced buffer attribute.
 	 *
-	 * @param {Number|TypedArray} count - The item count. It is also valid to pass a typed array as an argument.
+	 * @param {number|TypedArray} count - The item count. It is also valid to pass a typed array as an argument.
 	 * The subsequent parameters are then obsolete.
-	 * @param {Number} itemSize - The item size.
+	 * @param {number} itemSize - The item size.
 	 * @param {TypedArray.constructor} [typeClass=Float32Array] - A typed array constructor.
 	 */
 	constructor( count, itemSize, typeClass = Float32Array ) {
@@ -33,7 +33,7 @@ class StorageInstancedBufferAttribute extends InstancedBufferAttribute {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */

--- a/src/renderers/common/StorageTexture.js
+++ b/src/renderers/common/StorageTexture.js
@@ -15,8 +15,8 @@ class StorageTexture extends Texture {
 	/**
 	 * Constructs a new storage texture.
 	 *
-	 * @param {Number} [width=1] - The storage texture's width.
-	 * @param {Number} [height=1] - The storage texture's height.
+	 * @param {number} [width=1] - The storage texture's width.
+	 * @param {number} [height=1] - The storage texture's height.
 	 */
 	constructor( width = 1, height = 1 ) {
 
@@ -25,28 +25,28 @@ class StorageTexture extends Texture {
 		/**
 		 * The image object which just represents the texture's dimension.
 		 *
-		 * @type {{width: Number, height: Number}}
+		 * @type {{width: number, height: number}}
 		 */
 		this.image = { width, height };
 
 		/**
 		 * The default `magFilter` for storage textures is `THREE.LinearFilter`.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 */
 		this.magFilter = LinearFilter;
 
 		/**
 		 * The default `minFilter` for storage textures is `THREE.LinearFilter`.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 */
 		this.minFilter = LinearFilter;
 
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */

--- a/src/renderers/common/Textures.js
+++ b/src/renderers/common/Textures.js
@@ -53,7 +53,7 @@ class Textures extends DataMap {
 	 * it updates the texture states representing the attachments of the framebuffer.
 	 *
 	 * @param {RenderTarget} renderTarget - The render target to update.
-	 * @param {Number} [activeMipmapLevel=0] - The active mipmap level.
+	 * @param {number} [activeMipmapLevel=0] - The active mipmap level.
 	 */
 	updateRenderTarget( renderTarget, activeMipmapLevel = 0 ) {
 
@@ -382,9 +382,9 @@ class Textures extends DataMap {
 	 * Computes the number of mipmap levels for the given texture.
 	 *
 	 * @param {Texture} texture - The texture.
-	 * @param {Number} width - The texture's width.
-	 * @param {Number} height - The texture's height.
-	 * @return {Number} The number of mipmap levels.
+	 * @param {number} width - The texture's width.
+	 * @param {number} height - The texture's height.
+	 * @return {number} The number of mipmap levels.
 	 */
 	getMipLevels( texture, width, height ) {
 
@@ -416,7 +416,7 @@ class Textures extends DataMap {
 	 * Returns `true` if the given texture requires mipmaps.
 	 *
 	 * @param {Texture} texture - The texture.
-	 * @return {Boolean} Whether mipmaps are required or not.
+	 * @return {boolean} Whether mipmaps are required or not.
 	 */
 	needsMipmaps( texture ) {
 
@@ -428,7 +428,7 @@ class Textures extends DataMap {
 	 * Returns `true` if the given texture is an environment map.
 	 *
 	 * @param {Texture} texture - The texture.
-	 * @return {Boolean} Whether the given texture is an environment map or not.
+	 * @return {boolean} Whether the given texture is an environment map or not.
 	 */
 	isEnvironmentTexture( texture ) {
 

--- a/src/renderers/common/TimestampQueryPool.js
+++ b/src/renderers/common/TimestampQueryPool.js
@@ -8,14 +8,14 @@ class TimestampQueryPool {
 	/**
 	 * Creates a new timestamp query pool.
 	 *
-	 * @param {Number} [maxQueries=256] - Maximum number of queries this pool can hold.
+	 * @param {number} [maxQueries=256] - Maximum number of queries this pool can hold.
 	 */
 	constructor( maxQueries = 256 ) {
 
 		/**
 		 * Whether to track timestamps or not.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default true
 		 */
 		this.trackTimestamp = true;
@@ -23,7 +23,7 @@ class TimestampQueryPool {
 		/**
 		 * Maximum number of queries this pool can hold.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @default 256
 		 */
 		this.maxQueries = maxQueries;
@@ -31,7 +31,7 @@ class TimestampQueryPool {
 		/**
 		 * How many queries allocated so far.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @default 0
 		 */
 		this.currentQueryIndex = 0;
@@ -46,7 +46,7 @@ class TimestampQueryPool {
 		/**
 		 * Whether the pool has been disposed or not.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default false
 		 */
 		this.isDisposed = false;
@@ -54,7 +54,7 @@ class TimestampQueryPool {
 		/**
 		 * TODO
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 * @default 0
 		 */
 		this.lastValue = 0;
@@ -62,7 +62,7 @@ class TimestampQueryPool {
 		/**
 		 * TODO
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default false
 		 */
 		this.pendingResolve = false;
@@ -82,7 +82,7 @@ class TimestampQueryPool {
 	 *
 	 * @abstract
 	 * @async
-	 * @returns {Promise<Number>|Number} The resolved timestamp value.
+	 * @returns {Promise<number>|number} The resolved timestamp value.
 	 */
 	async resolveQueriesAsync() {}
 

--- a/src/renderers/common/Uniform.js
+++ b/src/renderers/common/Uniform.js
@@ -17,22 +17,22 @@ class Uniform {
 	/**
 	 * Constructs a new uniform.
 	 *
-	 * @param {String} name - The uniform's name.
-	 * @param {Any} value - The uniform's value.
+	 * @param {string} name - The uniform's name.
+	 * @param {any} value - The uniform's value.
 	 */
 	constructor( name, value ) {
 
 		/**
 		 * The uniform's name.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.name = name;
 
 		/**
 		 * The uniform's value.
 		 *
-		 * @type {Any}
+		 * @type {any}
 		 */
 		this.value = value;
 
@@ -41,7 +41,7 @@ class Uniform {
 		 * Derived uniforms will set this property to a data type specific
 		 * value.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 */
 		this.boundary = 0;
 
@@ -49,7 +49,7 @@ class Uniform {
 		 * The item size. Derived uniforms will set this property to a data
 		 * type specific value.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 */
 		this.itemSize = 0;
 
@@ -57,7 +57,7 @@ class Uniform {
 		 * This property is set by {@link UniformsGroup} and marks
 		 * the start position in the uniform buffer.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 */
 		this.offset = 0;
 
@@ -66,7 +66,7 @@ class Uniform {
 	/**
 	 * Sets the uniform's value.
 	 *
-	 * @param {Any} value - The value to set.
+	 * @param {any} value - The value to set.
 	 */
 	setValue( value ) {
 
@@ -77,7 +77,7 @@ class Uniform {
 	/**
 	 * Returns the uniform's value.
 	 *
-	 * @return {Any} The value.
+	 * @return {any} The value.
 	 */
 	getValue() {
 
@@ -98,8 +98,8 @@ class NumberUniform extends Uniform {
 	/**
 	 * Constructs a new Number uniform.
 	 *
-	 * @param {String} name - The uniform's name.
-	 * @param {Number} value - The uniform's value.
+	 * @param {string} name - The uniform's name.
+	 * @param {number} value - The uniform's value.
 	 */
 	constructor( name, value = 0 ) {
 
@@ -108,7 +108,7 @@ class NumberUniform extends Uniform {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -132,7 +132,7 @@ class Vector2Uniform extends Uniform {
 	/**
 	 * Constructs a new Number uniform.
 	 *
-	 * @param {String} name - The uniform's name.
+	 * @param {string} name - The uniform's name.
 	 * @param {Vector2} value - The uniform's value.
 	 */
 	constructor( name, value = new Vector2() ) {
@@ -142,7 +142,7 @@ class Vector2Uniform extends Uniform {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -166,7 +166,7 @@ class Vector3Uniform extends Uniform {
 	/**
 	 * Constructs a new Number uniform.
 	 *
-	 * @param {String} name - The uniform's name.
+	 * @param {string} name - The uniform's name.
 	 * @param {Vector3} value - The uniform's value.
 	 */
 	constructor( name, value = new Vector3() ) {
@@ -176,7 +176,7 @@ class Vector3Uniform extends Uniform {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -200,7 +200,7 @@ class Vector4Uniform extends Uniform {
 	/**
 	 * Constructs a new Number uniform.
 	 *
-	 * @param {String} name - The uniform's name.
+	 * @param {string} name - The uniform's name.
 	 * @param {Vector4} value - The uniform's value.
 	 */
 	constructor( name, value = new Vector4() ) {
@@ -210,7 +210,7 @@ class Vector4Uniform extends Uniform {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -234,7 +234,7 @@ class ColorUniform extends Uniform {
 	/**
 	 * Constructs a new Number uniform.
 	 *
-	 * @param {String} name - The uniform's name.
+	 * @param {string} name - The uniform's name.
 	 * @param {Color} value - The uniform's value.
 	 */
 	constructor( name, value = new Color() ) {
@@ -244,7 +244,7 @@ class ColorUniform extends Uniform {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -268,7 +268,7 @@ class Matrix2Uniform extends Uniform {
 	/**
 	 * Constructs a new Number uniform.
 	 *
-	 * @param {String} name - The uniform's name.
+	 * @param {string} name - The uniform's name.
 	 * @param {Matrix2} value - The uniform's value.
 	 */
 	constructor( name, value = new Matrix2() ) {
@@ -278,7 +278,7 @@ class Matrix2Uniform extends Uniform {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -303,7 +303,7 @@ class Matrix3Uniform extends Uniform {
 	/**
 	 * Constructs a new Number uniform.
 	 *
-	 * @param {String} name - The uniform's name.
+	 * @param {string} name - The uniform's name.
 	 * @param {Matrix3} value - The uniform's value.
 	 */
 	constructor( name, value = new Matrix3() ) {
@@ -313,7 +313,7 @@ class Matrix3Uniform extends Uniform {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -337,7 +337,7 @@ class Matrix4Uniform extends Uniform {
 	/**
 	 * Constructs a new Number uniform.
 	 *
-	 * @param {String} name - The uniform's name.
+	 * @param {string} name - The uniform's name.
 	 * @param {Matrix4} value - The uniform's value.
 	 */
 	constructor( name, value = new Matrix4() ) {
@@ -347,7 +347,7 @@ class Matrix4Uniform extends Uniform {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */

--- a/src/renderers/common/UniformBuffer.js
+++ b/src/renderers/common/UniformBuffer.js
@@ -11,7 +11,7 @@ class UniformBuffer extends Buffer {
 	/**
 	 * Constructs a new uniform buffer.
 	 *
-	 * @param {String} name - The buffer's name.
+	 * @param {string} name - The buffer's name.
 	 * @param {TypedArray} [buffer=null] - The buffer.
 	 */
 	constructor( name, buffer = null ) {
@@ -21,7 +21,7 @@ class UniformBuffer extends Buffer {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */

--- a/src/renderers/common/UniformsGroup.js
+++ b/src/renderers/common/UniformsGroup.js
@@ -13,7 +13,7 @@ class UniformsGroup extends UniformBuffer {
 	/**
 	 * Constructs a new uniforms group.
 	 *
-	 * @param {String} name - The group's name.
+	 * @param {string} name - The group's name.
 	 */
 	constructor( name ) {
 
@@ -22,7 +22,7 @@ class UniformsGroup extends UniformBuffer {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -32,7 +32,7 @@ class UniformsGroup extends UniformBuffer {
 		 * An array with the raw uniform values.
 		 *
 		 * @private
-		 * @type {Array<Number>?}
+		 * @type {Array<number>?}
 		 * @default null
 		 */
 		this._values = null;
@@ -85,7 +85,7 @@ class UniformsGroup extends UniformBuffer {
 	/**
 	 * An array with the raw uniform values.
 	 *
-	 * @type {Array<Number>}
+	 * @type {Array<number>}
 	 */
 	get values() {
 
@@ -125,7 +125,7 @@ class UniformsGroup extends UniformBuffer {
 	/**
 	 * The byte length of the buffer with correct buffer alignment.
 	 *
-	 * @type {Number}
+	 * @type {number}
 	 */
 	get byteLength() {
 
@@ -174,7 +174,7 @@ class UniformsGroup extends UniformBuffer {
 	 * values has actually changed so this method only returns
 	 * `true` if there is a real value change.
 	 *
-	 * @return {Boolean} Whether the uniforms have been updated and
+	 * @return {boolean} Whether the uniforms have been updated and
 	 * must be uploaded to the GPU.
 	 */
 	update() {
@@ -200,7 +200,7 @@ class UniformsGroup extends UniformBuffer {
 	 * the uniforms type.
 	 *
 	 * @param {Uniform} uniform - The uniform to update.
-	 * @return {Boolean} Whether the uniform has been updated or not.
+	 * @return {boolean} Whether the uniform has been updated or not.
 	 */
 	updateByType( uniform ) {
 
@@ -220,7 +220,7 @@ class UniformsGroup extends UniformBuffer {
 	 * Updates a given Number uniform.
 	 *
 	 * @param {NumberUniform} uniform - The Number uniform.
-	 * @return {Boolean} Whether the uniform has been updated or not.
+	 * @return {boolean} Whether the uniform has been updated or not.
 	 */
 	updateNumber( uniform ) {
 
@@ -248,7 +248,7 @@ class UniformsGroup extends UniformBuffer {
 	 * Updates a given Vector2 uniform.
 	 *
 	 * @param {Vector2Uniform} uniform - The Vector2 uniform.
-	 * @return {Boolean} Whether the uniform has been updated or not.
+	 * @return {boolean} Whether the uniform has been updated or not.
 	 */
 	updateVector2( uniform ) {
 
@@ -278,7 +278,7 @@ class UniformsGroup extends UniformBuffer {
 	 * Updates a given Vector3 uniform.
 	 *
 	 * @param {Vector3Uniform} uniform - The Vector3 uniform.
-	 * @return {Boolean} Whether the uniform has been updated or not.
+	 * @return {boolean} Whether the uniform has been updated or not.
 	 */
 	updateVector3( uniform ) {
 
@@ -309,7 +309,7 @@ class UniformsGroup extends UniformBuffer {
 	 * Updates a given Vector4 uniform.
 	 *
 	 * @param {Vector4Uniform} uniform - The Vector4 uniform.
-	 * @return {Boolean} Whether the uniform has been updated or not.
+	 * @return {boolean} Whether the uniform has been updated or not.
 	 */
 	updateVector4( uniform ) {
 
@@ -341,7 +341,7 @@ class UniformsGroup extends UniformBuffer {
 	 * Updates a given Color uniform.
 	 *
 	 * @param {ColorUniform} uniform - The Color uniform.
-	 * @return {Boolean} Whether the uniform has been updated or not.
+	 * @return {boolean} Whether the uniform has been updated or not.
 	 */
 	updateColor( uniform ) {
 
@@ -371,7 +371,7 @@ class UniformsGroup extends UniformBuffer {
 	 * Updates a given Matrix3 uniform.
 	 *
 	 * @param {Matrix3Uniform} uniform - The Matrix3 uniform.
-	 * @return {Boolean} Whether the uniform has been updated or not.
+	 * @return {boolean} Whether the uniform has been updated or not.
 	 */
 	updateMatrix3( uniform ) {
 
@@ -409,7 +409,7 @@ class UniformsGroup extends UniformBuffer {
 	 * Updates a given Matrix4 uniform.
 	 *
 	 * @param {Matrix4Uniform} uniform - The Matrix4 uniform.
-	 * @return {Boolean} Whether the uniform has been updated or not.
+	 * @return {boolean} Whether the uniform has been updated or not.
 	 */
 	updateMatrix4( uniform ) {
 
@@ -435,7 +435,7 @@ class UniformsGroup extends UniformBuffer {
 	/**
 	 * Returns a typed array that matches the given data type.
 	 *
-	 * @param {String} type - The data type.
+	 * @param {string} type - The data type.
 	 * @return {TypedArray} The typed array.
 	 */
 	_getBufferForType( type ) {
@@ -454,7 +454,7 @@ class UniformsGroup extends UniformBuffer {
  * @private
  * @param {TypedArray} a - The first array.
  * @param {TypedArray} b - The second array.
- * @param {Number} offset - An index offset for the first array.
+ * @param {number} offset - An index offset for the first array.
  */
 function setArray( a, b, offset ) {
 
@@ -472,8 +472,8 @@ function setArray( a, b, offset ) {
  * @private
  * @param {TypedArray} a - The first array.
  * @param {TypedArray} b - The second array.
- * @param {Number} offset - An index offset for the first array.
- * @return {Boolean} Whether the given arrays are equal or not.
+ * @param {number} offset - An index offset for the first array.
+ * @return {boolean} Whether the given arrays are equal or not.
  */
 function arraysEqual( a, b, offset ) {
 

--- a/src/renderers/common/XRManager.js
+++ b/src/renderers/common/XRManager.js
@@ -35,7 +35,7 @@ class XRManager extends EventDispatcher {
 		/**
 		 * This flag globally enables XR rendering.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default false
 		 */
 		this.enabled = false;
@@ -43,7 +43,7 @@ class XRManager extends EventDispatcher {
 		/**
 		 * Whether the XR device is currently presenting or not.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default false
 		 * @readonly
 		 */
@@ -52,7 +52,7 @@ class XRManager extends EventDispatcher {
 		/**
 		 * Whether the XR camera should automatically be updated or not.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default true
 		 */
 		this.cameraAutoUpdate = true;
@@ -105,7 +105,7 @@ class XRManager extends EventDispatcher {
 		 * The current near value of the XR camera.
 		 *
 		 * @private
-		 * @type {Number?}
+		 * @type {number?}
 		 * @default null
 		 */
 		this._currentDepthNear = null;
@@ -114,7 +114,7 @@ class XRManager extends EventDispatcher {
 		 * The current far value of the XR camera.
 		 *
 		 * @private
-		 * @type {Number?}
+		 * @type {number?}
 		 * @default null
 		 */
 		this._currentDepthFar = null;
@@ -177,7 +177,7 @@ class XRManager extends EventDispatcher {
 		 * The current pixel ratio.
 		 *
 		 * @private
-		 * @type {Number?}
+		 * @type {number?}
 		 * @default null
 		 */
 		this._currentPixelRatio = null;
@@ -238,7 +238,7 @@ class XRManager extends EventDispatcher {
 		 * The current XR reference space type.
 		 *
 		 * @private
-		 * @type {String}
+		 * @type {string}
 		 * @default 'local-floor'
 		 */
 		this._referenceSpaceType = 'local-floor';
@@ -256,7 +256,7 @@ class XRManager extends EventDispatcher {
 		 * The framebuffer scale factor.
 		 *
 		 * @private
-		 * @type {Number}
+		 * @type {number}
 		 * @default 1
 		 */
 		this._framebufferScaleFactor = 1;
@@ -265,7 +265,7 @@ class XRManager extends EventDispatcher {
 		 * The foveation factor.
 		 *
 		 * @private
-		 * @type {Number}
+		 * @type {number}
 		 * @default 1
 		 */
 		this._foveation = 1.0;
@@ -319,7 +319,7 @@ class XRManager extends EventDispatcher {
 		 * Whether to use the WebXR Layers API or not.
 		 *
 		 * @private
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 */
 		this._useLayers = ( typeof XRWebGLBinding !== 'undefined' && 'createProjectionLayer' in XRWebGLBinding.prototype ); // eslint-disable-line compat/compat
@@ -331,7 +331,7 @@ class XRManager extends EventDispatcher {
 	 * of a XR controller in target ray space. The requested controller is defined
 	 * by the given index.
 	 *
-	 * @param {Number} index - The index of the XR controller.
+	 * @param {number} index - The index of the XR controller.
 	 * @return {Group} A group that represents the controller's transformation.
 	 */
 	getController( index ) {
@@ -347,7 +347,7 @@ class XRManager extends EventDispatcher {
 	 * of a XR controller in grip space. The requested controller is defined
 	 * by the given index.
 	 *
-	 * @param {Number} index - The index of the XR controller.
+	 * @param {number} index - The index of the XR controller.
 	 * @return {Group} A group that represents the controller's transformation.
 	 */
 	getControllerGrip( index ) {
@@ -363,7 +363,7 @@ class XRManager extends EventDispatcher {
 	 * of a XR controller in hand space. The requested controller is defined
 	 * by the given index.
 	 *
-	 * @param {Number} index - The index of the XR controller.
+	 * @param {number} index - The index of the XR controller.
 	 * @return {Group} A group that represents the controller's transformation.
 	 */
 	getHand( index ) {
@@ -377,7 +377,7 @@ class XRManager extends EventDispatcher {
 	/**
 	 * Returns the foveation value.
 	 *
-	 * @return {Number|undefined} The foveation value. Returns `undefined` if no base or projection layer is defined.
+	 * @return {number|undefined} The foveation value. Returns `undefined` if no base or projection layer is defined.
 	 */
 	getFoveation() {
 
@@ -394,7 +394,7 @@ class XRManager extends EventDispatcher {
 	/**
 	 * Sets the foveation value.
 	 *
-	 * @param {Number} foveation - A number in the range `[0,1]` where `0` means no foveation (full resolution)
+	 * @param {number} foveation - A number in the range `[0,1]` where `0` means no foveation (full resolution)
 	 * and `1` means maximum foveation (the edges render at lower resolution).
 	 */
 	setFoveation( foveation ) {
@@ -418,7 +418,7 @@ class XRManager extends EventDispatcher {
 	/**
 	 * Returns the framebuffer scale factor.
 	 *
-	 * @return {Number} The framebuffer scale factor.
+	 * @return {number} The framebuffer scale factor.
 	 */
 	getFramebufferScaleFactor() {
 
@@ -431,7 +431,7 @@ class XRManager extends EventDispatcher {
 	 *
 	 * This method can not be used during a XR session.
 	 *
-	 * @param {Number} factor - The framebuffer scale factor.
+	 * @param {number} factor - The framebuffer scale factor.
 	 */
 	setFramebufferScaleFactor( factor ) {
 
@@ -448,7 +448,7 @@ class XRManager extends EventDispatcher {
 	/**
 	 * Returns the reference space type.
 	 *
-	 * @return {String} The reference space type.
+	 * @return {string} The reference space type.
 	 */
 	getReferenceSpaceType() {
 
@@ -461,7 +461,7 @@ class XRManager extends EventDispatcher {
 	 *
 	 * This method can not be used during a XR session.
 	 *
-	 * @param {String} type - The reference space type.
+	 * @param {string} type - The reference space type.
 	 */
 	setReferenceSpaceType( type ) {
 
@@ -764,7 +764,7 @@ class XRManager extends EventDispatcher {
 	 * Returns a WebXR controller for the given controller index.
 	 *
 	 * @private
-	 * @param {Number} index - The controller index.
+	 * @param {number} index - The controller index.
 	 * @return {WebXRController} The XR controller.
 	 */
 	_getController( index ) {

--- a/src/renderers/common/XRRenderTarget.js
+++ b/src/renderers/common/XRRenderTarget.js
@@ -12,8 +12,8 @@ class XRRenderTarget extends RenderTarget {
 	/**
 	 * Constructs a new XR render target.
 	 *
-	 * @param {Number} [width=1] - The width of the render target.
-	 * @param {Number} [height=1] - The height of the render target.
+	 * @param {number} [width=1] - The width of the render target.
+	 * @param {number} [height=1] - The height of the render target.
 	 * @param {Object} [options={}] - The configuration options.
 	 */
 	constructor( width = 1, height = 1, options = {} ) {
@@ -23,7 +23,7 @@ class XRRenderTarget extends RenderTarget {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -34,7 +34,7 @@ class XRRenderTarget extends RenderTarget {
 		 * are defined by external textures. This flag is
 		 * set to `true` when using the WebXR Layers API.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default false
 		 */
 		this.hasExternalTextures = false;
@@ -50,7 +50,7 @@ class XRRenderTarget extends RenderTarget {
 		 *
 		 * Reference: {@link https://www.w3.org/TR/webxrlayers-1/#dom-xrprojectionlayer-ignoredepthvalues}.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default true
 		 */
 		this.autoAllocateDepthBuffer = true;

--- a/src/renderers/common/extras/PMREMGenerator.js
+++ b/src/renderers/common/extras/PMREMGenerator.js
@@ -132,9 +132,9 @@ class PMREMGenerator {
 	 * is placed at the origin).
 	 *
 	 * @param {Scene} scene - The scene to be captured.
-	 * @param {Number} [sigma=0] - The blur radius in radians.
-	 * @param {Number} [near=0.1] - The near plane distance.
-	 * @param {Number} [far=100] - The far plane distance.
+	 * @param {number} [sigma=0] - The blur radius in radians.
+	 * @param {number} [near=0.1] - The near plane distance.
+	 * @param {number} [far=100] - The far plane distance.
 	 * @param {RenderTarget?} [renderTarget=null] - The render target to use.
 	 * @return {RenderTarget} The resulting PMREM.
 	 * @see fromSceneAsync
@@ -186,9 +186,9 @@ class PMREMGenerator {
 	 * is placed at the origin).
 	 *
 	 * @param {Scene} scene - The scene to be captured.
-	 * @param {Number} [sigma=0] - The blur radius in radians.
-	 * @param {Number} [near=0.1] - The near plane distance.
-	 * @param {Number} [far=100] - The far plane distance.
+	 * @param {number} [sigma=0] - The blur radius in radians.
+	 * @param {number} [near=0.1] - The near plane distance.
+	 * @param {number} [far=100] - The far plane distance.
 	 * @param {RenderTarget?} [renderTarget=null] - The render target to use.
 	 * @return {Promise<RenderTarget>} The resulting PMREM.
 	 * @see fromScene
@@ -623,9 +623,9 @@ class PMREMGenerator {
 	 * accurate at the poles, but still does a decent job.
 	 *
 	 * @param {RenderTarget} cubeUVRenderTarget - The cubemap render target.
-	 * @param {Number} lodIn - The input level-of-detail.
-	 * @param {Number} lodOut - The output level-of-detail.
-	 * @param {Number} sigma - The blur radius in radians.
+	 * @param {number} lodIn - The input level-of-detail.
+	 * @param {number} lodOut - The output level-of-detail.
+	 * @param {number} sigma - The blur radius in radians.
 	 * @param {Vector3} [poleAxis] - The pole axis.
 	 */
 	_blur( cubeUVRenderTarget, lodIn, lodOut, sigma, poleAxis ) {

--- a/src/renderers/common/nodes/NodeBuilderState.js
+++ b/src/renderers/common/nodes/NodeBuilderState.js
@@ -14,9 +14,9 @@ class NodeBuilderState {
 	/**
 	 * Constructs a new node builder state.
 	 *
-	 * @param {String?} vertexShader - The native vertex shader code.
-	 * @param {String?} fragmentShader - The native fragment shader code.
-	 * @param {String?} computeShader - The native compute shader code.
+	 * @param {string?} vertexShader - The native vertex shader code.
+	 * @param {string?} fragmentShader - The native fragment shader code.
+	 * @param {string?} computeShader - The native compute shader code.
 	 * @param {Array<NodeAttribute>} nodeAttributes - An array of node attributes.
 	 * @param {Array<BindGroup>} bindings - An array of bind groups.
 	 * @param {Array<Node>} updateNodes - An array of nodes that implement their `update()` method.
@@ -30,21 +30,21 @@ class NodeBuilderState {
 		/**
 		 * The native vertex shader code.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.vertexShader = vertexShader;
 
 		/**
 		 * The native fragment shader code.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.fragmentShader = fragmentShader;
 
 		/**
 		 * The native compute shader code.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.computeShader = computeShader;
 
@@ -103,7 +103,7 @@ class NodeBuilderState {
 		/**
 		 * How often this state is used by render objects.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 */
 		this.usedTimes = 0;
 

--- a/src/renderers/common/nodes/NodeLibrary.js
+++ b/src/renderers/common/nodes/NodeLibrary.js
@@ -23,7 +23,7 @@ class NodeLibrary {
 		/**
 		 * A map that maps materials to node materials.
 		 *
-		 * @type {Map<String,NodeMaterial.constructor>}
+		 * @type {Map<string,NodeMaterial.constructor>}
 		 */
 		this.materialNodes = new Map();
 
@@ -31,7 +31,7 @@ class NodeLibrary {
 		 * A map that maps tone mapping techniques (constants)
 		 * to tone mapping node functions.
 		 *
-		 * @type {Map<Number,Function>}
+		 * @type {Map<number,Function>}
 		 */
 		this.toneMappingNodes = new Map();
 
@@ -75,7 +75,7 @@ class NodeLibrary {
 	 * Adds a tone mapping node function for a tone mapping technique (constant).
 	 *
 	 * @param {Function} toneMappingNode - The tone mapping node function.
-	 * @param {Number} toneMapping - The tone mapping.
+	 * @param {number} toneMapping - The tone mapping.
 	 */
 	addToneMapping( toneMappingNode, toneMapping ) {
 
@@ -86,7 +86,7 @@ class NodeLibrary {
 	/**
 	 * Returns a tone mapping node function for a tone mapping technique (constant).
 	 *
-	 * @param {Number} toneMapping - The tone mapping.
+	 * @param {number} toneMapping - The tone mapping.
 	 * @return {Function?} The tone mapping node function. Returns `null` if no node function is found.
 	 */
 	getToneMappingFunction( toneMapping ) {
@@ -98,7 +98,7 @@ class NodeLibrary {
 	/**
 	 * Returns a node material class definition for a material type.
 	 *
-	 * @param {String} materialType - The material type.
+	 * @param {string} materialType - The material type.
 	 * @return {NodeMaterial.constructor?} The node material class definition. Returns `null` if no node material is found.
 	 */
 	getMaterialNodeClass( materialType ) {
@@ -111,7 +111,7 @@ class NodeLibrary {
 	 * Adds a node material class definition for a given material type.
 	 *
 	 * @param {NodeMaterial.constructor} materialNodeClass - The node material class definition.
-	 * @param {String} materialClassType - The material type.
+	 * @param {string} materialClassType - The material type.
 	 */
 	addMaterial( materialNodeClass, materialClassType ) {
 
@@ -146,8 +146,8 @@ class NodeLibrary {
 	/**
 	 * Adds a node class definition for the given type to the provided type library.
 	 *
-	 * @param {Any} nodeClass - The node class definition.
-	 * @param {Number|String} type - The object type.
+	 * @param {any} nodeClass - The node class definition.
+	 * @param {number|string} type - The object type.
 	 * @param {Map} library - The type library.
 	 */
 	addType( nodeClass, type, library ) {
@@ -169,8 +169,8 @@ class NodeLibrary {
 	/**
 	 * Adds a node class definition for the given class definition to the provided type library.
 	 *
-	 * @param {Any} nodeClass - The node class definition.
-	 * @param {Any} baseClass - The class definition.
+	 * @param {any} nodeClass - The node class definition.
+	 * @param {any} baseClass - The class definition.
 	 * @param {WeakMap} library - The type library.
 	 */
 	addClass( nodeClass, baseClass, library ) {

--- a/src/renderers/common/nodes/NodeSampledTexture.js
+++ b/src/renderers/common/nodes/NodeSampledTexture.js
@@ -12,10 +12,10 @@ class NodeSampledTexture extends SampledTexture {
 	/**
 	 * Constructs a new node-based sampled texture.
 	 *
-	 * @param {String} name - The textures's name.
+	 * @param {string} name - The textures's name.
 	 * @param {TextureNode} textureNode - The texture node.
 	 * @param {UniformGroupNode} groupNode - The uniform group node.
-	 * @param {String?} [access=null] - The access type.
+	 * @param {string?} [access=null] - The access type.
 	 */
 	constructor( name, textureNode, groupNode, access = null ) {
 
@@ -38,7 +38,7 @@ class NodeSampledTexture extends SampledTexture {
 		/**
 		 * The access type.
 		 *
-		 * @type {String?}
+		 * @type {string?}
 		 * @default null
 		 */
 		this.access = access;
@@ -48,8 +48,8 @@ class NodeSampledTexture extends SampledTexture {
 	/**
 	 * Overwrites the default to additionally check if the node value has changed.
 	 *
-	 * @param {Number} generation - The generation.
-	 * @return {Boolean} Whether an update is required or not.
+	 * @param {number} generation - The generation.
+	 * @return {boolean} Whether an update is required or not.
 	 */
 	needsBindingsUpdate( generation ) {
 
@@ -60,7 +60,7 @@ class NodeSampledTexture extends SampledTexture {
 	/**
 	 * Updates the binding.
 	 *
-	 * @return {Boolean} Whether the texture has been updated and must be
+	 * @return {boolean} Whether the texture has been updated and must be
 	 * uploaded to the GPU.
 	 */
 	update() {
@@ -93,10 +93,10 @@ class NodeSampledCubeTexture extends NodeSampledTexture {
 	/**
 	 * Constructs a new node-based sampled cube texture.
 	 *
-	 * @param {String} name - The textures's name.
+	 * @param {string} name - The textures's name.
 	 * @param {TextureNode} textureNode - The texture node.
 	 * @param {UniformGroupNode} groupNode - The uniform group node.
-	 * @param {String?} [access=null] - The access type.
+	 * @param {string?} [access=null] - The access type.
 	 */
 	constructor( name, textureNode, groupNode, access = null ) {
 
@@ -105,7 +105,7 @@ class NodeSampledCubeTexture extends NodeSampledTexture {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -127,10 +127,10 @@ class NodeSampledTexture3D extends NodeSampledTexture {
 	/**
 	 * Constructs a new node-based sampled 3D texture.
 	 *
-	 * @param {String} name - The textures's name.
+	 * @param {string} name - The textures's name.
 	 * @param {TextureNode} textureNode - The texture node.
 	 * @param {UniformGroupNode} groupNode - The uniform group node.
-	 * @param {String?} [access=null] - The access type.
+	 * @param {string?} [access=null] - The access type.
 	 */
 	constructor( name, textureNode, groupNode, access = null ) {
 
@@ -139,7 +139,7 @@ class NodeSampledTexture3D extends NodeSampledTexture {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */

--- a/src/renderers/common/nodes/NodeSampler.js
+++ b/src/renderers/common/nodes/NodeSampler.js
@@ -12,7 +12,7 @@ class NodeSampler extends Sampler {
 	/**
 	 * Constructs a new node-based sampler.
 	 *
-	 * @param {String} name - The samplers's name.
+	 * @param {string} name - The samplers's name.
 	 * @param {TextureNode} textureNode - The texture node.
 	 * @param {UniformGroupNode} groupNode - The uniform group node.
 	 */

--- a/src/renderers/common/nodes/NodeStorageBuffer.js
+++ b/src/renderers/common/nodes/NodeStorageBuffer.js
@@ -32,7 +32,7 @@ class NodeStorageBuffer extends StorageBuffer {
 		/**
 		 * The access type.
 		 *
-		 * @type {String}
+		 * @type {string}
 		 */
 		this.access = nodeUniform ? nodeUniform.access : NodeAccess.READ_WRITE;
 

--- a/src/renderers/common/nodes/NodeUniform.js
+++ b/src/renderers/common/nodes/NodeUniform.js
@@ -33,7 +33,7 @@ class NumberNodeUniform extends NumberUniform {
 	/**
 	 * Overwritten to return the value of the node uniform.
 	 *
-	 * @return {Number} The value.
+	 * @return {number} The value.
 	 */
 	getValue() {
 
@@ -44,7 +44,7 @@ class NumberNodeUniform extends NumberUniform {
 	/**
 	 * Returns the node uniform data type.
 	 *
-	 * @return {String} The data type.
+	 * @return {string} The data type.
 	 */
 	getType() {
 
@@ -95,7 +95,7 @@ class Vector2NodeUniform extends Vector2Uniform {
 	/**
 	 * Returns the node uniform data type.
 	 *
-	 * @return {String} The data type.
+	 * @return {string} The data type.
 	 */
 	getType() {
 
@@ -146,7 +146,7 @@ class Vector3NodeUniform extends Vector3Uniform {
 	/**
 	 * Returns the node uniform data type.
 	 *
-	 * @return {String} The data type.
+	 * @return {string} The data type.
 	 */
 	getType() {
 
@@ -197,7 +197,7 @@ class Vector4NodeUniform extends Vector4Uniform {
 	/**
 	 * Returns the node uniform data type.
 	 *
-	 * @return {String} The data type.
+	 * @return {string} The data type.
 	 */
 	getType() {
 
@@ -248,7 +248,7 @@ class ColorNodeUniform extends ColorUniform {
 	/**
 	 * Returns the node uniform data type.
 	 *
-	 * @return {String} The data type.
+	 * @return {string} The data type.
 	 */
 	getType() {
 
@@ -300,7 +300,7 @@ class Matrix2NodeUniform extends Matrix2Uniform {
 	/**
 	 * Returns the node uniform data type.
 	 *
-	 * @return {String} The data type.
+	 * @return {string} The data type.
 	 */
 	getType() {
 
@@ -351,7 +351,7 @@ class Matrix3NodeUniform extends Matrix3Uniform {
 	/**
 	 * Returns the node uniform data type.
 	 *
-	 * @return {String} The data type.
+	 * @return {string} The data type.
 	 */
 	getType() {
 
@@ -402,7 +402,7 @@ class Matrix4NodeUniform extends Matrix4Uniform {
 	/**
 	 * Returns the node uniform data type.
 	 *
-	 * @return {String} The data type.
+	 * @return {string} The data type.
 	 */
 	getType() {
 

--- a/src/renderers/common/nodes/NodeUniformsGroup.js
+++ b/src/renderers/common/nodes/NodeUniformsGroup.js
@@ -14,7 +14,7 @@ class NodeUniformsGroup extends UniformsGroup {
 	/**
 	 * Constructs a new node-based uniforms group.
 	 *
-	 * @param {String} name - The group's name.
+	 * @param {string} name - The group's name.
 	 * @param {UniformGroupNode} groupNode - The uniform group node.
 	 */
 	constructor( name, groupNode ) {
@@ -24,7 +24,7 @@ class NodeUniformsGroup extends UniformsGroup {
 		/**
 		 * The group's ID.
 		 *
-		 * @type {Number}
+		 * @type {number}
 		 */
 		this.id = _id ++;
 
@@ -38,7 +38,7 @@ class NodeUniformsGroup extends UniformsGroup {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */

--- a/src/renderers/common/nodes/Nodes.js
+++ b/src/renderers/common/nodes/Nodes.js
@@ -55,7 +55,7 @@ class Nodes extends DataMap {
 		/**
 		 * A cache for managing node builder states.
 		 *
-		 * @type {Map<Number,NodeBuilderState>}
+		 * @type {Map<number,NodeBuilderState>}
 		 */
 		this.nodeBuilderCache = new Map();
 
@@ -77,7 +77,7 @@ class Nodes extends DataMap {
 		 * A cache for managing node objects of
 		 * scene properties like fog or environments.
 		 *
-		 * @type {Object<String,WeakMap>}
+		 * @type {Object<string,WeakMap>}
 		 */
 		this.cacheLib = {};
 
@@ -87,7 +87,7 @@ class Nodes extends DataMap {
 	 * Returns `true` if the given node uniforms group must be updated or not.
 	 *
 	 * @param {NodeUniformsGroup} nodeUniformsGroup - The node uniforms group.
-	 * @return {Boolean} Whether the node uniforms group requires an update or not.
+	 * @return {boolean} Whether the node uniforms group requires an update or not.
 	 */
 	updateGroup( nodeUniformsGroup ) {
 
@@ -162,7 +162,7 @@ class Nodes extends DataMap {
 	 * Returns the cache key for the given render object.
 	 *
 	 * @param {RenderObject} renderObject - The render object.
-	 * @return {Number} The cache key.
+	 * @return {number} The cache key.
 	 */
 	getForRenderCacheKey( renderObject ) {
 
@@ -222,7 +222,7 @@ class Nodes extends DataMap {
 	/**
 	 * Deletes the given object from the internal data map
 	 *
-	 * @param {Any} object - The object to delete.
+	 * @param {any} object - The object to delete.
 	 * @return {Object?} The deleted dictionary.
 	 */
 	delete( object ) {
@@ -383,7 +383,7 @@ class Nodes extends DataMap {
 	 *
 	 * @param {Scene} scene - The scene.
 	 * @param {LightsNode} lightsNode - The lights node.
-	 * @return {Number} The cache key.
+	 * @return {number} The cache key.
 	 */
 	getCacheKey( scene, lightsNode ) {
 
@@ -424,7 +424,7 @@ class Nodes extends DataMap {
 	 * A boolean that indicates whether tone mapping should be enabled
 	 * or not.
 	 *
-	 * @type {Boolean}
+	 * @type {boolean}
 	 */
 	get isToneMappingState() {
 
@@ -506,10 +506,10 @@ class Nodes extends DataMap {
 	 * This method is part of the caching of nodes which are used to represents the
 	 * scene's background, fog or environment.
 	 *
-	 * @param {String} type - The type of object to cache.
+	 * @param {string} type - The type of object to cache.
 	 * @param {Object} object - The object.
 	 * @param {Function} callback - A callback that produces a node representation for the given object.
-	 * @param {Boolean} [forceUpdate=false] - Whether an update should be enforced or not.
+	 * @param {boolean} [forceUpdate=false] - Whether an update should be enforced or not.
 	 * @return {Node} The node representation.
 	 */
 	getCacheNode( type, object, callback, forceUpdate = false ) {
@@ -652,7 +652,7 @@ class Nodes extends DataMap {
 	/**
 	 * Returns the current output cache key.
 	 *
-	 * @return {String} The output cache key.
+	 * @return {string} The output cache key.
 	 */
 	getOutputCacheKey() {
 
@@ -667,7 +667,7 @@ class Nodes extends DataMap {
 	 * the given target has changed.
 	 *
 	 * @param {Texture} outputTarget - The output target.
-	 * @return {Boolean} Whether the output configuration has changed or not.
+	 * @return {boolean} Whether the output configuration has changed or not.
 	 */
 	hasOutputChange( outputTarget ) {
 
@@ -779,7 +779,7 @@ class Nodes extends DataMap {
 	 * Returns `true` if the given render object requires a refresh.
 	 *
 	 * @param {RenderObject} renderObject - The render object.
-	 * @return {Boolean} Whether the given render object requires a refresh or not.
+	 * @return {boolean} Whether the given render object requires a refresh or not.
 	 */
 	needsRefresh( renderObject ) {
 

--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -27,13 +27,13 @@ class WebGLBackend extends Backend {
 	 * Constructs a new WebGPU backend.
 	 *
 	 * @param {Object} parameters - The configuration parameter.
-	 * @param {Boolean} [parameters.logarithmicDepthBuffer=false] - Whether logarithmic depth buffer is enabled or not.
-	 * @param {Boolean} [parameters.alpha=true] - Whether the default framebuffer (which represents the final contents of the canvas) should be transparent or opaque.
-	 * @param {Boolean} [parameters.depth=true] - Whether the default framebuffer should have a depth buffer or not.
-	 * @param {Boolean} [parameters.stencil=false] - Whether the default framebuffer should have a stencil buffer or not.
-	 * @param {Boolean} [parameters.antialias=false] - Whether MSAA as the default anti-aliasing should be enabled or not.
-	 * @param {Number} [parameters.samples=0] - When `antialias` is `true`, `4` samples are used by default. Set this parameter to any other integer value than 0 to overwrite the default.
-	 * @param {Boolean} [parameters.forceWebGL=false] - If set to `true`, the renderer uses a WebGL 2 backend no matter if WebGPU is supported or not.
+	 * @param {boolean} [parameters.logarithmicDepthBuffer=false] - Whether logarithmic depth buffer is enabled or not.
+	 * @param {boolean} [parameters.alpha=true] - Whether the default framebuffer (which represents the final contents of the canvas) should be transparent or opaque.
+	 * @param {boolean} [parameters.depth=true] - Whether the default framebuffer should have a depth buffer or not.
+	 * @param {boolean} [parameters.stencil=false] - Whether the default framebuffer should have a stencil buffer or not.
+	 * @param {boolean} [parameters.antialias=false] - Whether MSAA as the default anti-aliasing should be enabled or not.
+	 * @param {number} [parameters.samples=0] - When `antialias` is `true`, `4` samples are used by default. Set this parameter to any other integer value than 0 to overwrite the default.
+	 * @param {boolean} [parameters.forceWebGL=false] - If set to `true`, the renderer uses a WebGL 2 backend no matter if WebGPU is supported or not.
 	 * @param {WebGL2RenderingContext} [parameters.context=undefined] - A WebGL 2 rendering context.
 	 */
 	constructor( parameters = {} ) {
@@ -43,7 +43,7 @@ class WebGLBackend extends Backend {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -123,14 +123,14 @@ class WebGLBackend extends Backend {
 		/**
 		 * Dictionary for caching VAOs.
 		 *
-		 * @type {Object<String,WebGLVertexArrayObject>}
+		 * @type {Object<string,WebGLVertexArrayObject>}
 		 */
 		this.vaoCache = {};
 
 		/**
 		 * Dictionary for caching transform feedback objects.
 		 *
-		 * @type {Object<String,WebGLTransformFeedback>}
+		 * @type {Object<string,WebGLTransformFeedback>}
 		 */
 		this.transformFeedbackCache = {};
 
@@ -138,7 +138,7 @@ class WebGLBackend extends Backend {
 		 * Controls if `gl.RASTERIZER_DISCARD` should be enabled or not.
 		 * Only relevant when using compute shaders.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default false
 		 */
 		this.discard = false;
@@ -164,7 +164,7 @@ class WebGLBackend extends Backend {
 		/**
 		 * Whether to track timestamps with a Timestamp Query API or not.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default false
 		 */
 		this.trackTimestamp = ( parameters.trackTimestamp === true );
@@ -266,7 +266,7 @@ class WebGLBackend extends Backend {
 	/**
 	 * The coordinate system of the backend.
 	 *
-	 * @type {Number}
+	 * @type {number}
 	 * @readonly
 	 */
 	get coordinateSystem() {
@@ -669,7 +669,7 @@ class WebGLBackend extends Backend {
 	 *
 	 * @param {RenderContext} renderContext - The render context.
 	 * @param {Object3D} object - The 3D object to test.
-	 * @return {Boolean} Whether the 3D object is fully occluded or not.
+	 * @return {boolean} Whether the 3D object is fully occluded or not.
 	 */
 	isOccluded( renderContext, object ) {
 
@@ -696,7 +696,7 @@ class WebGLBackend extends Backend {
 	/**
 	 * Defines the scissor test.
 	 *
-	 * @param {Boolean} boolean - Whether the scissor test should be enabled or not.
+	 * @param {boolean} boolean - Whether the scissor test should be enabled or not.
 	 */
 	setScissorTest( boolean ) {
 
@@ -709,11 +709,11 @@ class WebGLBackend extends Backend {
 	/**
 	 * Performs a clear operation.
 	 *
-	 * @param {Boolean} color - Whether the color buffer should be cleared or not.
-	 * @param {Boolean} depth - Whether the depth buffer should be cleared or not.
-	 * @param {Boolean} stencil - Whether the stencil buffer should be cleared or not.
+	 * @param {boolean} color - Whether the color buffer should be cleared or not.
+	 * @param {boolean} depth - Whether the depth buffer should be cleared or not.
+	 * @param {boolean} stencil - Whether the stencil buffer should be cleared or not.
 	 * @param {Object?} [descriptor=null] - The render context of the current set render target.
-	 * @param {Boolean} [setFrameBuffer=true] - TODO.
+	 * @param {boolean} [setFrameBuffer=true] - TODO.
 	 */
 	clear( color, depth, stencil, descriptor = null, setFrameBuffer = true ) {
 
@@ -1163,7 +1163,7 @@ class WebGLBackend extends Backend {
 	 * Explain why always null is returned.
 	 *
 	 * @param {RenderObject} renderObject - The render object.
-	 * @return {Boolean} Whether the render pipeline requires an update or not.
+	 * @return {boolean} Whether the render pipeline requires an update or not.
 	 */
 	needsRenderUpdate( /*renderObject*/ ) {
 
@@ -1175,7 +1175,7 @@ class WebGLBackend extends Backend {
 	 * Explain why no cache key is computed.
 	 *
 	 * @param {RenderObject} renderObject - The render object.
-	 * @return {String} The cache key.
+	 * @return {string} The cache key.
 	 */
 	getRenderCacheKey( /*renderObject*/ ) {
 
@@ -1248,11 +1248,11 @@ class WebGLBackend extends Backend {
 	 *
 	 * @async
 	 * @param {Texture} texture - The texture to copy.
-	 * @param {Number} x - The x coordinate of the copy origin.
-	 * @param {Number} y - The y coordinate of the copy origin.
-	 * @param {Number} width - The width of the copy.
-	 * @param {Number} height - The height of the copy.
-	 * @param {Number} faceIndex - The face index.
+	 * @param {number} x - The x coordinate of the copy origin.
+	 * @param {number} y - The y coordinate of the copy origin.
+	 * @param {number} width - The width of the copy.
+	 * @param {number} height - The height of the copy.
+	 * @param {number} faceIndex - The face index.
 	 * @return {Promise<TypedArray>} A Promise that resolves with a typed array when the copy operation has finished.
 	 */
 	async copyTextureToBuffer( texture, x, y, width, height, faceIndex ) {
@@ -1396,9 +1396,9 @@ class WebGLBackend extends Backend {
 	 * Formats the source code of error messages.
 	 *
 	 * @private
-	 * @param {String} string - The code.
-	 * @param {Number} errorLine - The error line.
-	 * @return {String} The formatted code.
+	 * @param {string} string - The code.
+	 * @param {number} errorLine - The error line.
+	 * @return {string} The formatted code.
 	 */
 	_handleSource( string, errorLine ) {
 
@@ -1425,8 +1425,8 @@ class WebGLBackend extends Backend {
 	 * @private
 	 * @param {WebGL2RenderingContext} gl - The rendering context.
 	 * @param {WebGLShader} shader - The WebGL shader object.
-	 * @param {String} type - The shader type.
-	 * @return {String} The shader errors.
+	 * @param {string} type - The shader type.
+	 * @return {string} The shader errors.
 	 */
 	_getShaderErrors( gl, shader, type ) {
 
@@ -1639,8 +1639,8 @@ class WebGLBackend extends Backend {
 	 *
 	 * @param {BindGroup} bindGroup - The bind group.
 	 * @param {Array<BindGroup>} bindings - Array of bind groups.
-	 * @param {Number} cacheIndex - The cache index.
-	 * @param {Number} version - The version.
+	 * @param {number} cacheIndex - The cache index.
+	 * @param {number} version - The version.
 	 */
 	createBindings( bindGroup, bindings /*, cacheIndex, version*/ ) {
 
@@ -1678,8 +1678,8 @@ class WebGLBackend extends Backend {
 	 *
 	 * @param {BindGroup} bindGroup - The bind group.
 	 * @param {Array<BindGroup>} bindings - Array of bind groups.
-	 * @param {Number} cacheIndex - The cache index.
-	 * @param {Number} version - The version.
+	 * @param {number} cacheIndex - The cache index.
+	 * @param {number} version - The version.
 	 */
 	updateBindings( bindGroup /*, bindings, cacheIndex, version*/ ) {
 
@@ -1813,8 +1813,8 @@ class WebGLBackend extends Backend {
 	/**
 	 * Checks if the given feature is supported  by the backend.
 	 *
-	 * @param {String} name - The feature's name.
-	 * @return {Boolean} Whether the feature is supported or not.
+	 * @param {string} name - The feature's name.
+	 * @return {boolean} Whether the feature is supported or not.
 	 */
 	hasFeature( name ) {
 
@@ -1835,7 +1835,7 @@ class WebGLBackend extends Backend {
 	/**
 	 * Returns the maximum anisotropy texture filtering value.
 	 *
-	 * @return {Number} The maximum anisotropy texture filtering value.
+	 * @return {number} The maximum anisotropy texture filtering value.
 	 */
 	getMaxAnisotropy() {
 
@@ -1850,7 +1850,7 @@ class WebGLBackend extends Backend {
 	 * @param {Texture} dstTexture - The destination texture.
 	 * @param {Vector4?} [srcRegion=null] - The region of the source texture to copy.
 	 * @param {(Vector2|Vector3)?} [dstPosition=null] - The destination position of the copy.
-	 * @param {Number} [level=0] - The mip level to copy.
+	 * @param {number} [level=0] - The mip level to copy.
 	 */
 	copyTextureToTexture( srcTexture, dstTexture, srcRegion = null, dstPosition = null, level = 0 ) {
 
@@ -2137,7 +2137,7 @@ class WebGLBackend extends Backend {
 	 * @private
 	 * @param {BufferAttribute?} index - The index. `null` for non-indexed geometries.
 	 * @param {Array<BufferAttribute>} attributes - An array of buffer attributes.
-	 * @return {String} The VAO key.
+	 * @return {string} The VAO key.
 	 */
 	_getVaoKey( index, attributes ) {
 
@@ -2371,7 +2371,7 @@ class WebGLBackend extends Backend {
 	 *
 	 * @private
 	 * @param {RenderTarget} renderTarget - The render target that should be multisampled.
-	 * @return {Boolean} Whether to use the `WEBGL_multisampled_render_to_texture` extension for MSAA or not.
+	 * @return {boolean} Whether to use the `WEBGL_multisampled_render_to_texture` extension for MSAA or not.
 	 */
 	_useMultisampledRTT( renderTarget ) {
 

--- a/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
+++ b/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
@@ -71,7 +71,7 @@ class GLSLNodeBuilder extends NodeBuilder {
 		 * A dictionary holds for each shader stage ('vertex', 'fragment', 'compute')
 		 * another dictionary which manages UBOs per group ('render','frame','object').
 		 *
-		 * @type {Object<String,Object<String,NodeUniformsGroup>>}
+		 * @type {Object<string,Object<string,NodeUniformsGroup>>}
 		 */
 		this.uniformGroups = {};
 
@@ -79,28 +79,28 @@ class GLSLNodeBuilder extends NodeBuilder {
 		 * An array that holds objects defining the varying and attribute data in
 		 * context of Transform Feedback.
 		 *
-		 * @type {Object<String,Map<String,Object>>}
+		 * @type {Object<string,Map<string,Object>>}
 		 */
 		this.transforms = [];
 
 		/**
 		 * A dictionary that holds for each shader stage a Map of used extensions.
 		 *
-		 * @type {Object<String,Map<String,Object>>}
+		 * @type {Object<string,Map<string,Object>>}
 		 */
 		this.extensions = {};
 
 		/**
 		 * A dictionary that holds for each shader stage an Array of used builtins.
 		 *
-		 * @type {Object<String,Array<String>>}
+		 * @type {Object<string,Array<string>>}
 		 */
 		this.builtins = { vertex: [], fragment: [], compute: [] };
 
 		/**
 		 * Whether comparison in shader code are generated with methods or not.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default true
 		 */
 		this.useComparisonMethod = true;
@@ -111,7 +111,7 @@ class GLSLNodeBuilder extends NodeBuilder {
 	 * Checks if the given texture requires a manual conversion to the working color space.
 	 *
 	 * @param {Texture} texture - The texture to check.
-	 * @return {Boolean} Whether the given texture requires a conversion to working color space or not.
+	 * @return {boolean} Whether the given texture requires a conversion to working color space or not.
 	 */
 	needsToWorkingColorSpace( texture ) {
 
@@ -122,8 +122,8 @@ class GLSLNodeBuilder extends NodeBuilder {
 	/**
 	 * Returns the native shader method name for a given generic name.
 	 *
-	 * @param {String} method - The method name to resolve.
-	 * @return {String} The resolved GLSL method name.
+	 * @param {string} method - The method name to resolve.
+	 * @return {string} The resolved GLSL method name.
 	 */
 	getMethod( method ) {
 
@@ -134,7 +134,7 @@ class GLSLNodeBuilder extends NodeBuilder {
 	/**
 	 * Returns the output struct name. Not relevant for GLSL.
 	 *
-	 * @return {String}
+	 * @return {string}
 	 */
 	getOutputStructName() {
 
@@ -146,7 +146,7 @@ class GLSLNodeBuilder extends NodeBuilder {
 	 * Builds the given shader node.
 	 *
 	 * @param {ShaderNodeInternal} shaderNode - The shader node.
-	 * @return {String} The GLSL function code.
+	 * @return {string} The GLSL function code.
 	 */
 	buildFunctionCode( shaderNode ) {
 
@@ -256,8 +256,8 @@ ${ flowData.code }
 	 * Returns a GLSL snippet that represents the property name of the given node.
 	 *
 	 * @param {Node} node - The node.
-	 * @param {String} [shaderStage=this.shaderStage] - The shader stage this code snippet is generated for.
-	 * @return {String} The property name.
+	 * @param {string} [shaderStage=this.shaderStage] - The shader stage this code snippet is generated for.
+	 * @return {string} The property name.
 	 */
 	getPropertyName( node, shaderStage = this.shaderStage ) {
 
@@ -276,7 +276,7 @@ ${ flowData.code }
 	 * buffer node.
 	 *
 	 * @param {StorageArrayElementNode} storageArrayElementNode - The storage array element node.
-	 * @return {String} The property name.
+	 * @return {string} The property name.
 	 */
 	generatePBO( storageArrayElementNode ) {
 
@@ -364,11 +364,11 @@ ${ flowData.code }
 	 * Generates the GLSL snippet that reads a single texel from a texture without sampling or filtering.
 	 *
 	 * @param {Texture} texture - The texture.
-	 * @param {String} textureProperty - The name of the texture uniform in the shader.
-	 * @param {String} uvIndexSnippet - A GLSL snippet that represents texture coordinates used for sampling.
-	 * @param {String?} depthSnippet - A GLSL snippet that represents the 0-based texture array index to sample.
-	 * @param {String} [levelSnippet='0u'] - A GLSL snippet that represents the mip level, with level 0 containing a full size version of the texture.
-	 * @return {String} The GLSL snippet.
+	 * @param {string} textureProperty - The name of the texture uniform in the shader.
+	 * @param {string} uvIndexSnippet - A GLSL snippet that represents texture coordinates used for sampling.
+	 * @param {string?} depthSnippet - A GLSL snippet that represents the 0-based texture array index to sample.
+	 * @param {string} [levelSnippet='0u'] - A GLSL snippet that represents the mip level, with level 0 containing a full size version of the texture.
+	 * @return {string} The GLSL snippet.
 	 */
 	generateTextureLoad( texture, textureProperty, uvIndexSnippet, depthSnippet, levelSnippet = '0' ) {
 
@@ -388,10 +388,10 @@ ${ flowData.code }
 	 * Generates the GLSL snippet for sampling/loading the given texture.
 	 *
 	 * @param {Texture} texture - The texture.
-	 * @param {String} textureProperty - The name of the texture uniform in the shader.
-	 * @param {String} uvSnippet - A GLSL snippet that represents texture coordinates used for sampling.
-	 * @param {String?} depthSnippet -  A GLSL snippet that represents the 0-based texture array index to sample.
-	 * @return {String} The GLSL snippet.
+	 * @param {string} textureProperty - The name of the texture uniform in the shader.
+	 * @param {string} uvSnippet - A GLSL snippet that represents texture coordinates used for sampling.
+	 * @param {string?} depthSnippet -  A GLSL snippet that represents the 0-based texture array index to sample.
+	 * @return {string} The GLSL snippet.
 	 */
 	generateTexture( texture, textureProperty, uvSnippet, depthSnippet ) {
 
@@ -413,10 +413,10 @@ ${ flowData.code }
 	 * Generates the GLSL snippet when sampling textures with explicit mip level.
 	 *
 	 * @param {Texture} texture - The texture.
-	 * @param {String} textureProperty - The name of the texture uniform in the shader.
-	 * @param {String} uvSnippet - A GLSL snippet that represents texture coordinates used for sampling.
-	 * @param {String} levelSnippet - A GLSL snippet that represents the mip level, with level 0 containing a full size version of the texture.
-	 * @return {String} The GLSL snippet.
+	 * @param {string} textureProperty - The name of the texture uniform in the shader.
+	 * @param {string} uvSnippet - A GLSL snippet that represents texture coordinates used for sampling.
+	 * @param {string} levelSnippet - A GLSL snippet that represents the mip level, with level 0 containing a full size version of the texture.
+	 * @return {string} The GLSL snippet.
 	 */
 	generateTextureLevel( texture, textureProperty, uvSnippet, levelSnippet ) {
 
@@ -428,10 +428,10 @@ ${ flowData.code }
 	 * Generates the GLSL snippet when sampling textures with a bias to the mip level.
 	 *
 	 * @param {Texture} texture - The texture.
-	 * @param {String} textureProperty - The name of the texture uniform in the shader.
-	 * @param {String} uvSnippet - A GLSL snippet that represents texture coordinates used for sampling.
-	 * @param {String} biasSnippet - A GLSL snippet that represents the bias to apply to the mip level before sampling.
-	 * @return {String} The GLSL snippet.
+	 * @param {string} textureProperty - The name of the texture uniform in the shader.
+	 * @param {string} uvSnippet - A GLSL snippet that represents texture coordinates used for sampling.
+	 * @param {string} biasSnippet - A GLSL snippet that represents the bias to apply to the mip level before sampling.
+	 * @return {string} The GLSL snippet.
 	 */
 	generateTextureBias( texture, textureProperty, uvSnippet, biasSnippet ) {
 
@@ -443,10 +443,10 @@ ${ flowData.code }
 	 * Generates the GLSL snippet for sampling/loading the given texture using explicit gradients.
 	 *
 	 * @param {Texture} texture - The texture.
-	 * @param {String} textureProperty - The name of the texture uniform in the shader.
-	 * @param {String} uvSnippet - A GLSL snippet that represents texture coordinates used for sampling.
-	 * @param {Array<String>} gradSnippet - An array holding both gradient GLSL snippets.
-	 * @return {String} The GLSL snippet.
+	 * @param {string} textureProperty - The name of the texture uniform in the shader.
+	 * @param {string} uvSnippet - A GLSL snippet that represents texture coordinates used for sampling.
+	 * @param {Array<string>} gradSnippet - An array holding both gradient GLSL snippets.
+	 * @return {string} The GLSL snippet.
 	 */
 	generateTextureGrad( texture, textureProperty, uvSnippet, gradSnippet ) {
 
@@ -459,12 +459,12 @@ ${ flowData.code }
 	 * against a reference value.
 	 *
 	 * @param {Texture} texture - The texture.
-	 * @param {String} textureProperty - The name of the texture uniform in the shader.
-	 * @param {String} uvSnippet - A GLSL snippet that represents texture coordinates used for sampling.
-	 * @param {String} compareSnippet -  A GLSL snippet that represents the reference value.
-	 * @param {String?} depthSnippet - A GLSL snippet that represents 0-based texture array index to sample.
-	 * @param {String} [shaderStage=this.shaderStage] - The shader stage this code snippet is generated for.
-	 * @return {String} The GLSL snippet.
+	 * @param {string} textureProperty - The name of the texture uniform in the shader.
+	 * @param {string} uvSnippet - A GLSL snippet that represents texture coordinates used for sampling.
+	 * @param {string} compareSnippet -  A GLSL snippet that represents the reference value.
+	 * @param {string?} depthSnippet - A GLSL snippet that represents 0-based texture array index to sample.
+	 * @param {string} [shaderStage=this.shaderStage] - The shader stage this code snippet is generated for.
+	 * @return {string} The GLSL snippet.
 	 */
 	generateTextureCompare( texture, textureProperty, uvSnippet, compareSnippet, depthSnippet, shaderStage = this.shaderStage ) {
 
@@ -483,8 +483,8 @@ ${ flowData.code }
 	/**
 	 * Returns the variables of the given shader stage as a GLSL string.
 	 *
-	 * @param {String} shaderStage - The shader stage.
-	 * @return {String} The GLSL snippet that defines the variables.
+	 * @param {string} shaderStage - The shader stage.
+	 * @return {string} The GLSL snippet that defines the variables.
 	 */
 	getVars( shaderStage ) {
 
@@ -509,8 +509,8 @@ ${ flowData.code }
 	/**
 	 * Returns the uniforms of the given shader stage as a GLSL string.
 	 *
-	 * @param {String} shaderStage - The shader stage.
-	 * @return {String} The GLSL snippet that defines the uniforms.
+	 * @param {string} shaderStage - The shader stage.
+	 * @return {string} The GLSL snippet that defines the uniforms.
 	 */
 	getUniforms( shaderStage ) {
 
@@ -633,7 +633,7 @@ ${ flowData.code }
 	 * Returns the type for a given buffer attribute.
 	 *
 	 * @param {BufferAttribute} attribute - The buffer attribute.
-	 * @return {String} The type.
+	 * @return {string} The type.
 	 */
 	getTypeFromAttribute( attribute ) {
 
@@ -662,8 +662,8 @@ ${ flowData.code }
 	/**
 	 * Returns the shader attributes of the given shader stage as a GLSL string.
 	 *
-	 * @param {String} shaderStage - The shader stage.
-	 * @return {String} The GLSL snippet that defines the shader attributes.
+	 * @param {string} shaderStage - The shader stage.
+	 * @return {string} The GLSL snippet that defines the shader attributes.
 	 */
 	getAttributes( shaderStage ) {
 
@@ -691,7 +691,7 @@ ${ flowData.code }
 	 * Returns the members of the given struct type node as a GLSL string.
 	 *
 	 * @param {StructTypeNode} struct - The struct type node.
-	 * @return {String} The GLSL snippet that defines the struct members.
+	 * @return {string} The GLSL snippet that defines the struct members.
 	 */
 	getStructMembers( struct ) {
 
@@ -710,8 +710,8 @@ ${ flowData.code }
 	/**
 	 * Returns the structs of the given shader stage as a GLSL string.
 	 *
-	 * @param {String} shaderStage - The shader stage.
-	 * @return {String} The GLSL snippet that defines the structs.
+	 * @param {string} shaderStage - The shader stage.
+	 * @return {string} The GLSL snippet that defines the structs.
 	 */
 	getStructs( shaderStage ) {
 
@@ -755,8 +755,8 @@ ${ flowData.code }
 	/**
 	 * Returns the varyings of the given shader stage as a GLSL string.
 	 *
-	 * @param {String} shaderStage - The shader stage.
-	 * @return {String} The GLSL snippet that defines the varyings.
+	 * @param {string} shaderStage - The shader stage.
+	 * @return {string} The GLSL snippet that defines the varyings.
 	 */
 	getVaryings( shaderStage ) {
 
@@ -816,7 +816,7 @@ ${ flowData.code }
 	/**
 	 * Returns the vertex index builtin.
 	 *
-	 * @return {String} The vertex index.
+	 * @return {string} The vertex index.
 	 */
 	getVertexIndex() {
 
@@ -827,7 +827,7 @@ ${ flowData.code }
 	/**
 	 * Returns the instance index builtin.
 	 *
-	 * @return {String} The instance index.
+	 * @return {string} The instance index.
 	 */
 	getInstanceIndex() {
 
@@ -838,7 +838,7 @@ ${ flowData.code }
 	/**
 	 * Returns the invocation local index builtin.
 	 *
-	 * @return {String} The invocation local index.
+	 * @return {string} The invocation local index.
 	 */
 	getInvocationLocalIndex() {
 
@@ -853,7 +853,7 @@ ${ flowData.code }
 	/**
 	 * Returns the draw index builtin.
 	 *
-	 * @return {String?} The drawIndex shader string. Returns `null` if `WEBGL_multi_draw` isn't supported by the device.
+	 * @return {string?} The drawIndex shader string. Returns `null` if `WEBGL_multi_draw` isn't supported by the device.
 	 */
 	getDrawIndex() {
 
@@ -872,7 +872,7 @@ ${ flowData.code }
 	/**
 	 * Returns the front facing builtin.
 	 *
-	 * @return {String} The front facing builtin.
+	 * @return {string} The front facing builtin.
 	 */
 	getFrontFacing() {
 
@@ -883,7 +883,7 @@ ${ flowData.code }
 	/**
 	 * Returns the frag coord builtin.
 	 *
-	 * @return {String} The frag coord builtin.
+	 * @return {string} The frag coord builtin.
 	 */
 	getFragCoord() {
 
@@ -894,7 +894,7 @@ ${ flowData.code }
 	/**
 	 * Returns the frag depth builtin.
 	 *
-	 * @return {String} The frag depth builtin.
+	 * @return {string} The frag depth builtin.
 	 */
 	getFragDepth() {
 
@@ -905,9 +905,9 @@ ${ flowData.code }
 	/**
 	 * Enables the given extension.
 	 *
-	 * @param {String} name - The extension name.
-	 * @param {String} behavior - The extension behavior.
-	 * @param {String} [shaderStage=this.shaderStage] - The shader stage.
+	 * @param {string} name - The extension name.
+	 * @param {string} behavior - The extension behavior.
+	 * @param {string} [shaderStage=this.shaderStage] - The shader stage.
 	 */
 	enableExtension( name, behavior, shaderStage = this.shaderStage ) {
 
@@ -927,8 +927,8 @@ ${ flowData.code }
 	/**
 	 * Returns the enabled extensions of the given shader stage as a GLSL string.
 	 *
-	 * @param {String} shaderStage - The shader stage.
-	 * @return {String} The GLSL snippet that defines the enabled extensions.
+	 * @param {string} shaderStage - The shader stage.
+	 * @return {string} The GLSL snippet that defines the enabled extensions.
 	 */
 	getExtensions( shaderStage ) {
 
@@ -966,7 +966,7 @@ ${ flowData.code }
 	/**
 	 * Returns the clip distances builtin.
 	 *
-	 * @return {String} The clip distances builtin.
+	 * @return {string} The clip distances builtin.
 	 */
 	getClipDistance() {
 
@@ -977,8 +977,8 @@ ${ flowData.code }
 	/**
 	 * Whether the requested feature is available or not.
 	 *
-	 * @param {String} name - The requested feature.
-	 * @return {Boolean} Whether the requested feature is supported or not.
+	 * @param {string} name - The requested feature.
+	 * @return {boolean} Whether the requested feature is supported or not.
 	 */
 	isAvailable( name ) {
 
@@ -1026,7 +1026,7 @@ ${ flowData.code }
 	/**
 	 * Whether to flip texture data along its vertical axis or not.
 	 *
-	 * @return {Boolean} Returns always `true` in context of GLSL.
+	 * @return {boolean} Returns always `true` in context of GLSL.
 	 */
 	isFlipY() {
 
@@ -1037,7 +1037,7 @@ ${ flowData.code }
 	/**
 	 * Enables hardware clipping.
 	 *
-	 * @param {String} planeCount - The clipping plane count.
+	 * @param {string} planeCount - The clipping plane count.
 	 */
 	enableHardwareClipping( planeCount ) {
 
@@ -1050,7 +1050,7 @@ ${ flowData.code }
 	/**
 	 * Registers a transform in context of Transform Feedback.
 	 *
-	 * @param {String} varyingName - The varying name.
+	 * @param {string} varyingName - The varying name.
 	 * @param {AttributeNode} attributeNode - The attribute node.
 	 */
 	registerTransform( varyingName, attributeNode ) {
@@ -1062,8 +1062,8 @@ ${ flowData.code }
 	/**
 	 * Returns the transforms of the given shader stage as a GLSL string.
 	 *
-	 * @param {String} shaderStage - The shader stage.
-	 * @return {String} The GLSL snippet that defines the transforms.
+	 * @param {string} shaderStage - The shader stage.
+	 * @return {string} The GLSL snippet that defines the transforms.
 	 */
 	getTransforms( /* shaderStage  */ ) {
 
@@ -1089,9 +1089,9 @@ ${ flowData.code }
 	 * Returns a GLSL struct based on the given name and variables.
 	 *
 	 * @private
-	 * @param {String} name - The struct name.
-	 * @param {String} vars - The struct variables.
-	 * @return {String} The GLSL snippet representing a struct.
+	 * @param {string} name - The struct name.
+	 * @param {string} vars - The struct variables.
+	 * @return {string} The GLSL snippet representing a struct.
 	 */
 	_getGLSLUniformStruct( name, vars ) {
 
@@ -1107,7 +1107,7 @@ ${vars}
 	 *
 	 * @private
 	 * @param {Object} shaderData - The shader data.
-	 * @return {String} The vertex shader.
+	 * @return {string} The vertex shader.
 	 */
 	_getGLSLVertexCode( shaderData ) {
 
@@ -1156,7 +1156,7 @@ void main() {
 	 *
 	 * @private
 	 * @param {Object} shaderData - The shader data.
-	 * @return {String} The vertex shader.
+	 * @return {string} The vertex shader.
 	 */
 	_getGLSLFragmentCode( shaderData ) {
 
@@ -1283,9 +1283,9 @@ void main() {
 	 * and layouts.
 	 *
 	 * @param {UniformNode} node - The uniform node.
-	 * @param {String} type - The node data type.
-	 * @param {String} shaderStage - The shader stage.
-	 * @param {String?} [name=null] - An optional uniform name.
+	 * @param {string} type - The node data type.
+	 * @param {string} shaderStage - The shader stage.
+	 * @param {string?} [name=null] - An optional uniform name.
 	 * @return {NodeUniform} The node uniform object.
 	 */
 	getUniformFromNode( node, type, shaderStage, name = null ) {

--- a/src/renderers/webgl-fallback/utils/WebGLCapabilities.js
+++ b/src/renderers/webgl-fallback/utils/WebGLCapabilities.js
@@ -22,7 +22,7 @@ class WebGLCapabilities {
 		/**
 		 * This value holds the cached max anisotropy value.
 		 *
-		 * @type {Number?}
+		 * @type {number?}
 		 * @default null
 		 */
 		this.maxAnisotropy = null;
@@ -34,7 +34,7 @@ class WebGLCapabilities {
 	 * depends on the device and is reported by the `EXT_texture_filter_anisotropic`
 	 * WebGL extension.
 	 *
-	 * @return {Number} The maximum anisotropy texture filtering value.
+	 * @return {number} The maximum anisotropy texture filtering value.
 	 */
 	getMaxAnisotropy() {
 

--- a/src/renderers/webgl-fallback/utils/WebGLExtensions.js
+++ b/src/renderers/webgl-fallback/utils/WebGLExtensions.js
@@ -29,7 +29,7 @@ class WebGLExtensions {
 		/**
 		 * A list with all the supported WebGL extensions.
 		 *
-		 * @type {Array<String>}
+		 * @type {Array<string>}
 		 */
 		this.availableExtensions = this.gl.getSupportedExtensions();
 
@@ -38,7 +38,7 @@ class WebGLExtensions {
 		 * The key is the name of the extension, the value
 		 * the requested extension object.
 		 *
-		 * @type {Object<String,Object>}
+		 * @type {Object<string,Object>}
 		 */
 		this.extensions = {};
 
@@ -47,7 +47,7 @@ class WebGLExtensions {
 	/**
 	 * Returns the extension object for the given extension name.
 	 *
-	 * @param {String} name - The extension name.
+	 * @param {string} name - The extension name.
 	 * @return {Object} The extension object.
 	 */
 	get( name ) {
@@ -69,8 +69,8 @@ class WebGLExtensions {
 	/**
 	 * Returns `true` if the requested extension is available.
 	 *
-	 * @param {String} name - The extension name.
-	 * @return {Boolean} Whether the given extension is available or not.
+	 * @param {string} name - The extension name.
+	 * @return {boolean} Whether the given extension is available or not.
 	 */
 	has( name ) {
 

--- a/src/renderers/webgl-fallback/utils/WebGLState.js
+++ b/src/renderers/webgl-fallback/utils/WebGLState.js
@@ -176,7 +176,7 @@ class WebGLState {
 	 * This method caches the state so `gl.frontFace()` is only
 	 * called when necessary.
 	 *
-	 * @param {Boolean} flipSided - Whether triangles flipped their sides or not.
+	 * @param {boolean} flipSided - Whether triangles flipped their sides or not.
 	 */
 	setFlipSided( flipSided ) {
 
@@ -207,7 +207,7 @@ class WebGLState {
 	 * This method caches the state so `gl.cullFace()` is only
 	 * called when necessary.
 	 *
-	 * @param {Number} cullFace - Defines which polygons are candidates for culling.
+	 * @param {number} cullFace - Defines which polygons are candidates for culling.
 	 */
 	setCullFace( cullFace ) {
 
@@ -251,7 +251,7 @@ class WebGLState {
 	 * This method caches the state so `gl.lineWidth()` is only
 	 * called when necessary.
 	 *
-	 * @param {Number} width - The line width.
+	 * @param {number} width - The line width.
 	 */
 	setLineWidth( width ) {
 
@@ -273,14 +273,14 @@ class WebGLState {
 	 * This method caches the state so `gl.blendEquation()`, `gl.blendEquationSeparate()`,
 	 * `gl.blendFunc()` and  `gl.blendFuncSeparate()` are only called when necessary.
 	 *
-	 * @param {Number} blending - The blending type.
-	 * @param {Number} blendEquation - The blending equation.
-	 * @param {Number} blendSrc - Only relevant for custom blending. The RGB source blending factor.
-	 * @param {Number} blendDst - Only relevant for custom blending. The RGB destination blending factor.
-	 * @param {Number} blendEquationAlpha - Only relevant for custom blending. The blending equation for alpha.
-	 * @param {Number} blendSrcAlpha - Only relevant for custom blending. The alpha source blending factor.
-	 * @param {Number} blendDstAlpha - Only relevant for custom blending. The alpha destination blending factor.
-	 * @param {Boolean} premultipliedAlpha - Whether premultiplied alpha is enabled or not.
+	 * @param {number} blending - The blending type.
+	 * @param {number} blendEquation - The blending equation.
+	 * @param {number} blendSrc - Only relevant for custom blending. The RGB source blending factor.
+	 * @param {number} blendDst - Only relevant for custom blending. The RGB destination blending factor.
+	 * @param {number} blendEquationAlpha - Only relevant for custom blending. The blending equation for alpha.
+	 * @param {number} blendSrcAlpha - Only relevant for custom blending. The alpha source blending factor.
+	 * @param {number} blendDstAlpha - Only relevant for custom blending. The alpha destination blending factor.
+	 * @param {boolean} premultipliedAlpha - Whether premultiplied alpha is enabled or not.
 	 */
 	setBlending( blending, blendEquation, blendSrc, blendDst, blendEquationAlpha, blendSrcAlpha, blendDstAlpha, premultipliedAlpha ) {
 
@@ -425,7 +425,7 @@ class WebGLState {
 	 * This method caches the state so `gl.colorMask()` is only
 	 * called when necessary.
 	 *
-	 * @param {Boolean} colorMask - The color mask.
+	 * @param {boolean} colorMask - The color mask.
 	 */
 	setColorMask( colorMask ) {
 
@@ -441,7 +441,7 @@ class WebGLState {
 	/**
 	 * Specifies whether the depth test is enabled or not.
 	 *
-	 * @param {Boolean} depthTest - Whether the depth test is enabled or not.
+	 * @param {boolean} depthTest - Whether the depth test is enabled or not.
 	 */
 	setDepthTest( depthTest ) {
 
@@ -466,7 +466,7 @@ class WebGLState {
 	 * This method caches the state so `gl.depthMask()` is only
 	 * called when necessary.
 	 *
-	 * @param {Boolean} depthMask - The depth mask.
+	 * @param {boolean} depthMask - The depth mask.
 	 */
 	setDepthMask( depthMask ) {
 
@@ -485,7 +485,7 @@ class WebGLState {
 	 * This method caches the state so `gl.depthFunc()` is only
 	 * called when necessary.
 	 *
-	 * @param {Number} depthFunc - The depth compare function.
+	 * @param {number} depthFunc - The depth compare function.
 	 */
 	setDepthFunc( depthFunc ) {
 
@@ -550,10 +550,10 @@ class WebGLState {
 	/**
 	 * Specifies the scissor box.
 	 *
-	 * @param {Number} x - The x-coordinate of the lower left corner of the viewport.
-	 * @param {Number} y - The y-coordinate of the lower left corner of the viewport.
-	 * @param {Number} width - The width of the viewport.
-	 * @param {Number} height - The height of the viewport.
+	 * @param {number} x - The x-coordinate of the lower left corner of the viewport.
+	 * @param {number} y - The y-coordinate of the lower left corner of the viewport.
+	 * @param {number} width - The width of the viewport.
+	 * @param {number} height - The height of the viewport.
 	 *
 	 */
 	scissor( x, y, width, height ) {
@@ -574,10 +574,10 @@ class WebGLState {
 	/**
 	 * Specifies the viewport.
 	 *
-	 * @param {Number} x - The x-coordinate of the lower left corner of the viewport.
-	 * @param {Number} y - The y-coordinate of the lower left corner of the viewport.
-	 * @param {Number} width - The width of the viewport.
-	 * @param {Number} height - The height of the viewport.
+	 * @param {number} x - The x-coordinate of the lower left corner of the viewport.
+	 * @param {number} y - The y-coordinate of the lower left corner of the viewport.
+	 * @param {number} width - The width of the viewport.
+	 * @param {number} height - The height of the viewport.
 	 *
 	 */
 	viewport( x, y, width, height ) {
@@ -598,7 +598,7 @@ class WebGLState {
 	/**
 	 * Defines the scissor test.
 	 *
-	 * @param {Boolean} boolean - Whether the scissor test should be enabled or not.
+	 * @param {boolean} boolean - Whether the scissor test should be enabled or not.
 	 */
 	setScissorTest( boolean ) {
 
@@ -619,7 +619,7 @@ class WebGLState {
 	/**
 	 * Specifies whether the stencil test is enabled or not.
 	 *
-	 * @param {Boolean} stencilTest - Whether the stencil test is enabled or not.
+	 * @param {boolean} stencilTest - Whether the stencil test is enabled or not.
 	 */
 	setStencilTest( stencilTest ) {
 
@@ -644,7 +644,7 @@ class WebGLState {
 	 * This method caches the state so `gl.stencilMask()` is only
 	 * called when necessary.
 	 *
-	 * @param {Boolean} stencilMask - The stencil mask.
+	 * @param {boolean} stencilMask - The stencil mask.
 	 */
 	setStencilMask( stencilMask ) {
 
@@ -663,9 +663,9 @@ class WebGLState {
 	 * This method caches the state so `gl.stencilFunc()` is only
 	 * called when necessary.
 	 *
-	 * @param {Number} stencilFunc - The stencil compare function.
-	 * @param {Number} stencilRef - The reference value for the stencil test.
-	 * @param {Number} stencilMask - A bit-wise mask that is used to AND the reference value and the stored stencil value when the test is done.
+	 * @param {number} stencilFunc - The stencil compare function.
+	 * @param {number} stencilRef - The reference value for the stencil test.
+	 * @param {number} stencilMask - A bit-wise mask that is used to AND the reference value and the stored stencil value when the test is done.
 	 */
 	setStencilFunc( stencilFunc, stencilRef, stencilMask ) {
 
@@ -689,9 +689,9 @@ class WebGLState {
 	 * This method caches the state so `gl.stencilOp()` is only
 	 * called when necessary.
 	 *
-	 * @param {Number} stencilFail - The function to use when the stencil test fails.
-	 * @param {Number} stencilZFail - The function to use when the stencil test passes, but the depth test fail.
-	 * @param {Number} stencilZPass - The function to use when both the stencil test and the depth test pass,
+	 * @param {number} stencilFail - The function to use when the stencil test fails.
+	 * @param {number} stencilZFail - The function to use when the stencil test passes, but the depth test fail.
+	 * @param {number} stencilZPass - The function to use when both the stencil test and the depth test pass,
 	 * or when the stencil test passes and there is no depth buffer or depth testing is disabled.
 	 */
 	setStencilOp( stencilFail, stencilZFail, stencilZPass ) {
@@ -714,8 +714,8 @@ class WebGLState {
 	 * Configures the WebGL state for the given material.
 	 *
 	 * @param {Material} material - The material to configure the state for.
-	 * @param {Number} frontFaceCW - Whether the front faces are counter-clockwise or not.
-	 * @param {Number} hardwareClippingPlanes - The number of hardware clipping planes.
+	 * @param {number} frontFaceCW - Whether the front faces are counter-clockwise or not.
+	 * @param {number} hardwareClippingPlanes - The number of hardware clipping planes.
 	 */
 	setMaterial( material, frontFaceCW, hardwareClippingPlanes ) {
 
@@ -787,9 +787,9 @@ class WebGLState {
 	 * This method caches the state so `gl.polygonOffset()` is only
 	 * called when necessary.
 	 *
-	 * @param {Boolean} polygonOffset - Whether polygon offset is enabled or not.
-	 * @param {Number} factor - The scale factor for the variable depth offset for each polygon.
-	 * @param {Number} units - The multiplier by which an implementation-specific value is multiplied with to create a constant depth offset.
+	 * @param {boolean} polygonOffset - Whether polygon offset is enabled or not.
+	 * @param {number} factor - The scale factor for the variable depth offset for each polygon.
+	 * @param {number} units - The multiplier by which an implementation-specific value is multiplied with to create a constant depth offset.
 	 */
 	setPolygonOffset( polygonOffset, factor, units ) {
 
@@ -823,7 +823,7 @@ class WebGLState {
 	 * called when necessary.
 	 *
 	 * @param {WebGLProgram} program - The WebGL program to use.
-	 * @return {Boolean} Whether a program change has been executed or not.
+	 * @return {boolean} Whether a program change has been executed or not.
 	 */
 	useProgram( program ) {
 
@@ -850,9 +850,9 @@ class WebGLState {
 	 * This method caches the state so `gl.bindFramebuffer()` is only
 	 * called when necessary.
 	 *
-	 * @param {Number} target - The binding point (target).
+	 * @param {number} target - The binding point (target).
 	 * @param {WebGLFramebuffer} framebuffer - The WebGL framebuffer to bind.
-	 * @return {Boolean} Whether a bind has been executed or not.
+	 * @return {boolean} Whether a bind has been executed or not.
 	 */
 	bindFramebuffer( target, framebuffer ) {
 
@@ -962,7 +962,7 @@ class WebGLState {
 	 * This method caches the state so `gl.activeTexture()` is only
 	 * called when necessary.
 	 *
-	 * @param {Number} webglSlot - The texture unit to make active.
+	 * @param {number} webglSlot - The texture unit to make active.
 	 */
 	activeTexture( webglSlot ) {
 
@@ -985,9 +985,9 @@ class WebGLState {
 	 * This method caches the state so `gl.bindTexture()` is only
 	 * called when necessary.
 	 *
-	 * @param {Number} webglType - The binding point (target).
+	 * @param {number} webglType - The binding point (target).
 	 * @param {WebGLTexture} webglTexture - The WebGL texture to bind.
-	 * @param {Number} webglSlot - The texture.
+	 * @param {number} webglSlot - The texture.
 	 */
 	bindTexture( webglType, webglTexture, webglSlot ) {
 
@@ -1040,10 +1040,10 @@ class WebGLState {
 	 * This method caches the state so `gl.bindBufferBase()` is only
 	 * called when necessary.
 	 *
-	 * @param {Number} target - The target for the bind operation.
-	 * @param {Number} index - The index of the target.
+	 * @param {number} target - The target for the bind operation.
+	 * @param {number} index - The index of the target.
 	 * @param {WebGLBuffer} buffer - The WebGL buffer.
-	 * @return {Boolean} Whether a bind has been executed or not.
+	 * @return {boolean} Whether a bind has been executed or not.
 	 */
 	bindBufferBase( target, index, buffer ) {
 

--- a/src/renderers/webgl-fallback/utils/WebGLTextureUtils.js
+++ b/src/renderers/webgl-fallback/utils/WebGLTextureUtils.js
@@ -134,11 +134,11 @@ class WebGLTextureUtils {
 	/**
 	 * Returns the native texture type for the given texture.
 	 *
-	 * @param {String?} internalFormatName - The internal format name. When `null`, the internal format is derived from the subsequent parameters.
+	 * @param {string?} internalFormatName - The internal format name. When `null`, the internal format is derived from the subsequent parameters.
 	 * @param {GLenum} glFormat - The WebGL format.
 	 * @param {GLenum} glType - The WebGL type.
-	 * @param {String} colorSpace - The texture's color space.
-	 * @param {Boolean} [forceLinearTransfer=false] - Whether to force a linear transfer or not.
+	 * @param {string} colorSpace - The texture's color space.
+	 * @param {boolean} [forceLinearTransfer=false] - Whether to force a linear transfer or not.
 	 * @return {GLenum} The internal format.
 	 */
 	getInternalFormat( internalFormatName, glFormat, glType, colorSpace, forceLinearTransfer = false ) {
@@ -699,7 +699,7 @@ class WebGLTextureUtils {
 	 * @param {Texture} dstTexture - The destination texture.
 	 * @param {Vector4?} [srcRegion=null] - The region of the source texture to copy.
 	 * @param {(Vector2|Vector3)?} [dstPosition=null] - The destination position of the copy.
-	 * @param {Number} [level=0] - The mip level to copy.
+	 * @param {number} [level=0] - The mip level to copy.
 	 */
 	copyTextureToTexture( srcTexture, dstTexture, srcRegion = null, dstPosition = null, level = 0 ) {
 
@@ -918,8 +918,8 @@ class WebGLTextureUtils {
 	 *
 	 * @param {WebGLRenderbuffer} renderbuffer - The render buffer.
 	 * @param {RenderContext} renderContext - The render context.
-	 * @param {Number} samples - The MSAA sample count.
-	 * @param {Boolean} [useMultisampledRTT=false] - Whether to use WEBGL_multisampled_render_to_texture or not.
+	 * @param {number} samples - The MSAA sample count.
+	 * @param {boolean} [useMultisampledRTT=false] - Whether to use WEBGL_multisampled_render_to_texture or not.
 	 */
 	setupRenderBufferStorage( renderbuffer, renderContext, samples, useMultisampledRTT = false ) {
 
@@ -986,11 +986,11 @@ class WebGLTextureUtils {
 	 *
 	 * @async
 	 * @param {Texture} texture - The texture to copy.
-	 * @param {Number} x - The x coordinate of the copy origin.
-	 * @param {Number} y - The y coordinate of the copy origin.
-	 * @param {Number} width - The width of the copy.
-	 * @param {Number} height - The height of the copy.
-	 * @param {Number} faceIndex - The face index.
+	 * @param {number} x - The x coordinate of the copy origin.
+	 * @param {number} y - The y coordinate of the copy origin.
+	 * @param {number} width - The width of the copy.
+	 * @param {number} height - The height of the copy.
+	 * @param {number} faceIndex - The face index.
 	 * @return {Promise<TypedArray>} A Promise that resolves with a typed array when the copy operation has finished.
 	 */
 	async copyTextureToBuffer( texture, x, y, width, height, faceIndex ) {
@@ -1066,7 +1066,7 @@ class WebGLTextureUtils {
 	 * @private
 	 * @param {GLenum} glType - The WebGL data type.
 	 * @param {GLenum} glFormat - The WebGL texture format.
-	 * @return {Number} The bytes-per-texel.
+	 * @return {number} The bytes-per-texel.
 	 */
 	_getBytesPerTexel( glType, glFormat ) {
 

--- a/src/renderers/webgl-fallback/utils/WebGLTimestampQueryPool.js
+++ b/src/renderers/webgl-fallback/utils/WebGLTimestampQueryPool.js
@@ -52,7 +52,7 @@ class WebGLTimestampQueryPool extends TimestampQueryPool {
 	 * Allocates a pair of queries for a given render context.
 	 *
 	 * @param {Object} renderContext - The render context to allocate queries for.
-	 * @returns {Number?} The base offset for the allocated queries, or null if allocation failed.
+	 * @returns {number?} The base offset for the allocated queries, or null if allocation failed.
 	 */
 	allocateQueriesForContext( renderContext ) {
 
@@ -136,7 +136,7 @@ class WebGLTimestampQueryPool extends TimestampQueryPool {
 	 * Ends the active timestamp query for the specified render context.
 	 *
 	 * @param {Object} renderContext - The render context to end timing for.
-	 * @param {String} renderContext.id - Unique identifier for the render context.
+	 * @param {string} renderContext.id - Unique identifier for the render context.
 	 */
 	endQuery( renderContext ) {
 
@@ -181,7 +181,7 @@ class WebGLTimestampQueryPool extends TimestampQueryPool {
 	 * Asynchronously resolves all completed queries and returns the total duration.
 	 *
 	 * @async
-	 * @returns {Promise<Number>} The total duration in milliseconds, or the last valid value if resolution fails.
+	 * @returns {Promise<number>} The total duration in milliseconds, or the last valid value if resolution fails.
 	 */
 	async resolveQueriesAsync() {
 
@@ -247,7 +247,7 @@ class WebGLTimestampQueryPool extends TimestampQueryPool {
 	 *
 	 * @async
 	 * @param {WebGLQuery} query - The query object to resolve.
-	 * @returns {Promise<Number>} The elapsed time in milliseconds.
+	 * @returns {Promise<number>} The elapsed time in milliseconds.
 	 */
 	async resolveQuery( query ) {
 

--- a/src/renderers/webgl-fallback/utils/WebGLUtils.js
+++ b/src/renderers/webgl-fallback/utils/WebGLUtils.js
@@ -43,9 +43,9 @@ class WebGLUtils {
 	 * The method currently supports the conversion of texture formats
 	 * and types.
 	 *
-	 * @param {Number} p - The three.js constant.
-	 * @param {String} [colorSpace=NoColorSpace] - The color space.
-	 * @return {Number} The corresponding WebGL constant.
+	 * @param {number} p - The three.js constant.
+	 * @param {string} [colorSpace=NoColorSpace] - The color space.
+	 * @return {number} The corresponding WebGL constant.
 	 */
 	convert( p, colorSpace = NoColorSpace ) {
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -28,18 +28,18 @@ class WebGPUBackend extends Backend {
 	 * Constructs a new WebGPU backend.
 	 *
 	 * @param {Object} parameters - The configuration parameter.
-	 * @param {Boolean} [parameters.logarithmicDepthBuffer=false] - Whether logarithmic depth buffer is enabled or not.
-	 * @param {Boolean} [parameters.alpha=true] - Whether the default framebuffer (which represents the final contents of the canvas) should be transparent or opaque.
-	 * @param {Boolean} [parameters.depth=true] - Whether the default framebuffer should have a depth buffer or not.
-	 * @param {Boolean} [parameters.stencil=false] - Whether the default framebuffer should have a stencil buffer or not.
-	 * @param {Boolean} [parameters.antialias=false] - Whether MSAA as the default anti-aliasing should be enabled or not.
-	 * @param {Number} [parameters.samples=0] - When `antialias` is `true`, `4` samples are used by default. Set this parameter to any other integer value than 0 to overwrite the default.
-	 * @param {Boolean} [parameters.forceWebGL=false] - If set to `true`, the renderer uses a WebGL 2 backend no matter if WebGPU is supported or not.
-	 * @param {Boolean} [parameters.trackTimestamp=false] - Whether to track timestamps with a Timestamp Query API or not.
-	 * @param {String} [parameters.powerPreference=undefined] - The power preference.
+	 * @param {boolean} [parameters.logarithmicDepthBuffer=false] - Whether logarithmic depth buffer is enabled or not.
+	 * @param {boolean} [parameters.alpha=true] - Whether the default framebuffer (which represents the final contents of the canvas) should be transparent or opaque.
+	 * @param {boolean} [parameters.depth=true] - Whether the default framebuffer should have a depth buffer or not.
+	 * @param {boolean} [parameters.stencil=false] - Whether the default framebuffer should have a stencil buffer or not.
+	 * @param {boolean} [parameters.antialias=false] - Whether MSAA as the default anti-aliasing should be enabled or not.
+	 * @param {number} [parameters.samples=0] - When `antialias` is `true`, `4` samples are used by default. Set this parameter to any other integer value than 0 to overwrite the default.
+	 * @param {boolean} [parameters.forceWebGL=false] - If set to `true`, the renderer uses a WebGL 2 backend no matter if WebGPU is supported or not.
+	 * @param {boolean} [parameters.trackTimestamp=false] - Whether to track timestamps with a Timestamp Query API or not.
+	 * @param {string} [parameters.powerPreference=undefined] - The power preference.
 	 * @param {Object} [parameters.requiredLimits=undefined] - Specifies the limits that are required by the device request. The request will fail if the adapter cannot provide these limits.
 	 * @param {GPUDevice} [parameters.device=undefined] - If there is an existing GPU device on app level, it can be passed to the renderer as a parameter.
-	 * @param {Number} [parameters.outputType=undefined] - Texture type for output to canvas. By default, device's preferred format is used; other formats may incur overhead.
+	 * @param {number} [parameters.outputType=undefined] - Texture type for output to canvas. By default, device's preferred format is used; other formats may incur overhead.
 	 */
 	constructor( parameters = {} ) {
 
@@ -48,7 +48,7 @@ class WebGPUBackend extends Backend {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */
@@ -62,7 +62,7 @@ class WebGPUBackend extends Backend {
 		/**
 		 * Whether to track timestamps with a Timestamp Query API or not.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @default false
 		 */
 		this.trackTimestamp = ( parameters.trackTimestamp === true );
@@ -141,7 +141,7 @@ class WebGPUBackend extends Backend {
 		/**
 		 * A map that manages the resolve buffers for occlusion queries.
 		 *
-		 * @type {Map<Number,GPUBuffer>}
+		 * @type {Map<number,GPUBuffer>}
 		 */
 		this.occludedResolveCache = new Map();
 
@@ -245,7 +245,7 @@ class WebGPUBackend extends Backend {
 	/**
 	 * The coordinate system of the backend.
 	 *
-	 * @type {Number}
+	 * @type {number}
 	 * @readonly
 	 */
 	get coordinateSystem() {
@@ -748,7 +748,7 @@ class WebGPUBackend extends Backend {
 	 *
 	 * @param {RenderContext} renderContext - The render context.
 	 * @param {Object3D} object - The 3D object to test.
-	 * @return {Boolean} Whether the 3D object is fully occluded or not.
+	 * @return {boolean} Whether the 3D object is fully occluded or not.
 	 */
 	isOccluded( renderContext, object ) {
 
@@ -821,9 +821,9 @@ class WebGPUBackend extends Backend {
 	/**
 	 * Performs a clear operation.
 	 *
-	 * @param {Boolean} color - Whether the color buffer should be cleared or not.
-	 * @param {Boolean} depth - Whether the depth buffer should be cleared or not.
-	 * @param {Boolean} stencil - Whether the stencil buffer should be cleared or not.
+	 * @param {boolean} color - Whether the color buffer should be cleared or not.
+	 * @param {boolean} depth - Whether the depth buffer should be cleared or not.
+	 * @param {boolean} stencil - Whether the stencil buffer should be cleared or not.
 	 * @param {RenderContext?} [renderTargetContext=null] - The render context of the current set render target.
 	 */
 	clear( color, depth, stencil, renderTargetContext = null ) {
@@ -1329,7 +1329,7 @@ class WebGPUBackend extends Backend {
 	 * Returns `true` if the render pipeline requires an update.
 	 *
 	 * @param {RenderObject} renderObject - The render object.
-	 * @return {Boolean} Whether the render pipeline requires an update or not.
+	 * @return {boolean} Whether the render pipeline requires an update or not.
 	 */
 	needsRenderUpdate( renderObject ) {
 
@@ -1391,7 +1391,7 @@ class WebGPUBackend extends Backend {
 	 * Returns a cache key that is used to identify render pipelines.
 	 *
 	 * @param {RenderObject} renderObject - The render object.
-	 * @return {String} The cache key.
+	 * @return {string} The cache key.
 	 */
 	getRenderCacheKey( renderObject ) {
 
@@ -1506,11 +1506,11 @@ class WebGPUBackend extends Backend {
 	 *
 	 * @async
 	 * @param {Texture} texture - The texture to copy.
-	 * @param {Number} x - The x coordinate of the copy origin.
-	 * @param {Number} y - The y coordinate of the copy origin.
-	 * @param {Number} width - The width of the copy.
-	 * @param {Number} height - The height of the copy.
-	 * @param {Number} faceIndex - The face index.
+	 * @param {number} x - The x coordinate of the copy origin.
+	 * @param {number} y - The y coordinate of the copy origin.
+	 * @param {number} width - The width of the copy.
+	 * @param {number} height - The height of the copy.
+	 * @param {number} faceIndex - The face index.
 	 * @return {Promise<TypedArray>} A Promise that resolves with a typed array when the copy operation has finished.
 	 */
 	async copyTextureToBuffer( texture, x, y, width, height, faceIndex ) {
@@ -1681,8 +1681,8 @@ class WebGPUBackend extends Backend {
 	 *
 	 * @param {BindGroup} bindGroup - The bind group.
 	 * @param {Array<BindGroup>} bindings - Array of bind groups.
-	 * @param {Number} cacheIndex - The cache index.
-	 * @param {Number} version - The version.
+	 * @param {number} cacheIndex - The cache index.
+	 * @param {number} version - The version.
 	 */
 	createBindings( bindGroup, bindings, cacheIndex, version ) {
 
@@ -1695,8 +1695,8 @@ class WebGPUBackend extends Backend {
 	 *
 	 * @param {BindGroup} bindGroup - The bind group.
 	 * @param {Array<BindGroup>} bindings - Array of bind groups.
-	 * @param {Number} cacheIndex - The cache index.
-	 * @param {Number} version - The version.
+	 * @param {number} cacheIndex - The cache index.
+	 * @param {number} version - The version.
 	 */
 	updateBindings( bindGroup, bindings, cacheIndex, version ) {
 
@@ -1800,7 +1800,7 @@ class WebGPUBackend extends Backend {
 	/**
 	 * Returns the maximum anisotropy texture filtering value.
 	 *
-	 * @return {Number} The maximum anisotropy texture filtering value.
+	 * @return {number} The maximum anisotropy texture filtering value.
 	 */
 	getMaxAnisotropy() {
 
@@ -1811,8 +1811,8 @@ class WebGPUBackend extends Backend {
 	/**
 	 * Checks if the given feature is supported  by the backend.
 	 *
-	 * @param {String} name - The feature's name.
-	 * @return {Boolean} Whether the feature is supported or not.
+	 * @param {string} name - The feature's name.
+	 * @return {boolean} Whether the feature is supported or not.
 	 */
 	hasFeature( name ) {
 
@@ -1827,7 +1827,7 @@ class WebGPUBackend extends Backend {
 	 * @param {Texture} dstTexture - The destination texture.
 	 * @param {Vector4?} [srcRegion=null] - The region of the source texture to copy.
 	 * @param {(Vector2|Vector3)?} [dstPosition=null] - The destination position of the copy.
-	 * @param {Number} [level=0] - The mip level to copy.
+	 * @param {number} [level=0] - The mip level to copy.
 	 */
 	copyTextureToTexture( srcTexture, dstTexture, srcRegion = null, dstPosition = null, level = 0 ) {
 

--- a/src/renderers/webgpu/WebGPURenderer.Nodes.js
+++ b/src/renderers/webgpu/WebGPURenderer.Nodes.js
@@ -16,15 +16,15 @@ class WebGPURenderer extends Renderer {
 	 * Constructs a new WebGPU renderer.
 	 *
 	 * @param {Object} parameters - The configuration parameter.
-	 * @param {Boolean} [parameters.logarithmicDepthBuffer=false] - Whether logarithmic depth buffer is enabled or not.
-	 * @param {Boolean} [parameters.alpha=true] - Whether the default framebuffer (which represents the final contents of the canvas) should be transparent or opaque.
-	 * @param {Boolean} [parameters.depth=true] - Whether the default framebuffer should have a depth buffer or not.
-	 * @param {Boolean} [parameters.stencil=false] - Whether the default framebuffer should have a stencil buffer or not.
-	 * @param {Boolean} [parameters.antialias=false] - Whether MSAA as the default anti-aliasing should be enabled or not.
-	 * @param {Number} [parameters.samples=0] - When `antialias` is `true`, `4` samples are used by default. Set this parameter to any other integer value than 0 to overwrite the default.
-	 * @param {Boolean} [parameters.forceWebGL=false] - If set to `true`, the renderer uses it WebGL 2 backend no matter if WebGPU is supported or not.
-	 * @param {Number} [parameters.outputType=undefined] - Texture type for output to canvas. By default, device's preferred format is used; other formats may incur overhead.
-	 * @param {Number} [parameters.colorBufferType=HalfFloatType] - Defines the type of color buffers. The default `HalfFloatType` is recommend for best
+	 * @param {boolean} [parameters.logarithmicDepthBuffer=false] - Whether logarithmic depth buffer is enabled or not.
+	 * @param {boolean} [parameters.alpha=true] - Whether the default framebuffer (which represents the final contents of the canvas) should be transparent or opaque.
+	 * @param {boolean} [parameters.depth=true] - Whether the default framebuffer should have a depth buffer or not.
+	 * @param {boolean} [parameters.stencil=false] - Whether the default framebuffer should have a stencil buffer or not.
+	 * @param {boolean} [parameters.antialias=false] - Whether MSAA as the default anti-aliasing should be enabled or not.
+	 * @param {number} [parameters.samples=0] - When `antialias` is `true`, `4` samples are used by default. Set this parameter to any other integer value than 0 to overwrite the default.
+	 * @param {boolean} [parameters.forceWebGL=false] - If set to `true`, the renderer uses it WebGL 2 backend no matter if WebGPU is supported or not.
+	 * @param {number} [parameters.outputType=undefined] - Texture type for output to canvas. By default, device's preferred format is used; other formats may incur overhead.
+	 * @param {number} [parameters.colorBufferType=HalfFloatType] - Defines the type of color buffers. The default `HalfFloatType` is recommend for best
 	 * quality. To save memory and bandwidth, `UnsignedByteType` might be used. This will reduce rendering quality though.
 	 */
 	constructor( parameters = {} ) {
@@ -65,7 +65,7 @@ class WebGPURenderer extends Renderer {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */

--- a/src/renderers/webgpu/WebGPURenderer.js
+++ b/src/renderers/webgpu/WebGPURenderer.js
@@ -30,15 +30,15 @@ class WebGPURenderer extends Renderer {
 	 * Constructs a new WebGPU renderer.
 	 *
 	 * @param {Object} parameters - The configuration parameter.
-	 * @param {Boolean} [parameters.logarithmicDepthBuffer=false] - Whether logarithmic depth buffer is enabled or not.
-	 * @param {Boolean} [parameters.alpha=true] - Whether the default framebuffer (which represents the final contents of the canvas) should be transparent or opaque.
-	 * @param {Boolean} [parameters.depth=true] - Whether the default framebuffer should have a depth buffer or not.
-	 * @param {Boolean} [parameters.stencil=false] - Whether the default framebuffer should have a stencil buffer or not.
-	 * @param {Boolean} [parameters.antialias=false] - Whether MSAA as the default anti-aliasing should be enabled or not.
-	 * @param {Number} [parameters.samples=0] - When `antialias` is `true`, `4` samples are used by default. Set this parameter to any other integer value than 0 to overwrite the default.
-	 * @param {Boolean} [parameters.forceWebGL=false] - If set to `true`, the renderer uses a WebGL 2 backend no matter if WebGPU is supported or not.
-	 * @param {Number} [parameters.outputType=undefined] - Texture type for output to canvas. By default, device's preferred format is used; other formats may incur overhead.
-	 * @param {Number} [parameters.colorBufferType=HalfFloatType] - Defines the type of color buffers. The default `HalfFloatType` is recommend for best
+	 * @param {boolean} [parameters.logarithmicDepthBuffer=false] - Whether logarithmic depth buffer is enabled or not.
+	 * @param {boolean} [parameters.alpha=true] - Whether the default framebuffer (which represents the final contents of the canvas) should be transparent or opaque.
+	 * @param {boolean} [parameters.depth=true] - Whether the default framebuffer should have a depth buffer or not.
+	 * @param {boolean} [parameters.stencil=false] - Whether the default framebuffer should have a stencil buffer or not.
+	 * @param {boolean} [parameters.antialias=false] - Whether MSAA as the default anti-aliasing should be enabled or not.
+	 * @param {number} [parameters.samples=0] - When `antialias` is `true`, `4` samples are used by default. Set this parameter to any other integer value than 0 to overwrite the default.
+	 * @param {boolean} [parameters.forceWebGL=false] - If set to `true`, the renderer uses a WebGL 2 backend no matter if WebGPU is supported or not.
+	 * @param {number} [parameters.outputType=undefined] - Texture type for output to canvas. By default, device's preferred format is used; other formats may incur overhead.
+	 * @param {number} [parameters.colorBufferType=HalfFloatType] - Defines the type of color buffers. The default `HalfFloatType` is recommend for best
 	 * quality. To save memory and bandwidth, `UnsignedByteType` might be used. This will reduce rendering quality though.
 	 */
 	constructor( parameters = {} ) {
@@ -79,7 +79,7 @@ class WebGPURenderer extends Renderer {
 		/**
 		 * This flag can be used for type testing.
 		 *
-		 * @type {Boolean}
+		 * @type {boolean}
 		 * @readonly
 		 * @default true
 		 */

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -183,21 +183,21 @@ class WGSLNodeBuilder extends NodeBuilder {
 		 * A dictionary that holds for each shader stage ('vertex', 'fragment', 'compute')
 		 * another dictionary which manages UBOs per group ('render','frame','object').
 		 *
-		 * @type {Object<String,Object<String,NodeUniformsGroup>>}
+		 * @type {Object<string,Object<string,NodeUniformsGroup>>}
 		 */
 		this.uniformGroups = {};
 
 		/**
 		 * A dictionary that holds for each shader stage a Map of builtins.
 		 *
-		 * @type {Object<String,Map<String,Object>>}
+		 * @type {Object<string,Map<string,Object>>}
 		 */
 		this.builtins = {};
 
 		/**
 		 * A dictionary that holds for each shader stage a Set of directives.
 		 *
-		 * @type {Object<String,Set<String>>}
+		 * @type {Object<string,Set<string>>}
 		 */
 		this.directives = {};
 
@@ -205,7 +205,7 @@ class WGSLNodeBuilder extends NodeBuilder {
 		 * A map for managing scope arrays. Only relevant for when using
 		 * {@link WorkgroupInfoNode} in context of compute shaders.
 		 *
-		 * @type {Map<String,Object>}
+		 * @type {Map<string,Object>}
 		 */
 		this.scopedArrays = new Map();
 
@@ -215,7 +215,7 @@ class WGSLNodeBuilder extends NodeBuilder {
 	 * Checks if the given texture requires a manual conversion to the working color space.
 	 *
 	 * @param {Texture} texture - The texture to check.
-	 * @return {Boolean} Whether the given texture requires a conversion to working color space or not.
+	 * @return {boolean} Whether the given texture requires a conversion to working color space or not.
 	 */
 	needsToWorkingColorSpace( texture ) {
 
@@ -228,11 +228,11 @@ class WGSLNodeBuilder extends NodeBuilder {
 	 *
 	 * @private
 	 * @param {Texture} texture - The texture.
-	 * @param {String} textureProperty - The name of the texture uniform in the shader.
-	 * @param {String} uvSnippet - A WGSL snippet that represents texture coordinates used for sampling.
-	 * @param {String?} depthSnippet - A WGSL snippet that represents 0-based texture array index to sample.
-	 * @param {String} [shaderStage=this.shaderStage] - The shader stage this code snippet is generated for.
-	 * @return {String} The WGSL snippet.
+	 * @param {string} textureProperty - The name of the texture uniform in the shader.
+	 * @param {string} uvSnippet - A WGSL snippet that represents texture coordinates used for sampling.
+	 * @param {string?} depthSnippet - A WGSL snippet that represents 0-based texture array index to sample.
+	 * @param {string} [shaderStage=this.shaderStage] - The shader stage this code snippet is generated for.
+	 * @return {string} The WGSL snippet.
 	 */
 	_generateTextureSample( texture, textureProperty, uvSnippet, depthSnippet, shaderStage = this.shaderStage ) {
 
@@ -264,10 +264,10 @@ class WGSLNodeBuilder extends NodeBuilder {
 	 * Generates the WGSL snippet when sampling video textures.
 	 *
 	 * @private
-	 * @param {String} textureProperty - The name of the video texture uniform in the shader.
-	 * @param {String} uvSnippet - A WGSL snippet that represents texture coordinates used for sampling.
-	 * @param {String} [shaderStage=this.shaderStage] - The shader stage this code snippet is generated for.
-	 * @return {String} The WGSL snippet.
+	 * @param {string} textureProperty - The name of the video texture uniform in the shader.
+	 * @param {string} uvSnippet - A WGSL snippet that represents texture coordinates used for sampling.
+	 * @param {string} [shaderStage=this.shaderStage] - The shader stage this code snippet is generated for.
+	 * @return {string} The WGSL snippet.
 	 */
 	_generateVideoSample( textureProperty, uvSnippet, shaderStage = this.shaderStage ) {
 
@@ -288,12 +288,12 @@ class WGSLNodeBuilder extends NodeBuilder {
 	 *
 	 * @private
 	 * @param {Texture} texture - The texture.
-	 * @param {String} textureProperty - The name of the texture uniform in the shader.
-	 * @param {String} uvSnippet - A WGSL snippet that represents texture coordinates used for sampling.
-	 * @param {String} levelSnippet - A WGSL snippet that represents the mip level, with level 0 containing a full size version of the texture.
-	 * @param {String?} depthSnippet - A WGSL snippet that represents 0-based texture array index to sample.
-	 * @param {String} [shaderStage=this.shaderStage] - The shader stage this code snippet is generated for.
-	 * @return {String} The WGSL snippet.
+	 * @param {string} textureProperty - The name of the texture uniform in the shader.
+	 * @param {string} uvSnippet - A WGSL snippet that represents texture coordinates used for sampling.
+	 * @param {string} levelSnippet - A WGSL snippet that represents the mip level, with level 0 containing a full size version of the texture.
+	 * @param {string?} depthSnippet - A WGSL snippet that represents 0-based texture array index to sample.
+	 * @param {string} [shaderStage=this.shaderStage] - The shader stage this code snippet is generated for.
+	 * @return {string} The WGSL snippet.
 	 */
 	_generateTextureSampleLevel( texture, textureProperty, uvSnippet, levelSnippet, depthSnippet, shaderStage = this.shaderStage ) {
 
@@ -317,7 +317,7 @@ class WGSLNodeBuilder extends NodeBuilder {
 	 * Generates a wrap function used in context of textures.
 	 *
 	 * @param {Texture} texture - The texture to generate the function for.
-	 * @return {String} The name of the generated function.
+	 * @return {string} The name of the generated function.
 	 */
 	generateWrapFunction( texture ) {
 
@@ -391,9 +391,9 @@ class WGSLNodeBuilder extends NodeBuilder {
 	/**
 	 * Generates the array declaration string.
 	 *
-	 * @param {String} type - The type.
-	 * @param {Number?} [count] - The count.
-	 * @return {String} The generated value as a shader string.
+	 * @param {string} type - The type.
+	 * @param {number?} [count] - The count.
+	 * @return {string} The generated value as a shader string.
 	 */
 	generateArrayDeclaration( type, count ) {
 
@@ -407,9 +407,9 @@ class WGSLNodeBuilder extends NodeBuilder {
 	 * texture as well as the cube face count of cube textures.
 	 *
 	 * @param {Texture} texture - The texture to generate the function for.
-	 * @param {String} textureProperty - The name of the video texture uniform in the shader.
-	 * @param {String} levelSnippet - A WGSL snippet that represents the mip level, with level 0 containing a full size version of the texture.
-	 * @return {String} The name of the dimension variable.
+	 * @param {string} textureProperty - The name of the video texture uniform in the shader.
+	 * @param {string} levelSnippet - A WGSL snippet that represents the mip level, with level 0 containing a full size version of the texture.
+	 * @return {string} The name of the dimension variable.
 	 */
 	generateTextureDimension( texture, textureProperty, levelSnippet ) {
 
@@ -483,10 +483,10 @@ class WGSLNodeBuilder extends NodeBuilder {
 	 * Generates the WGSL snippet for a manual filtered texture.
 	 *
 	 * @param {Texture} texture - The texture.
-	 * @param {String} textureProperty - The name of the texture uniform in the shader.
-	 * @param {String} uvSnippet - A WGSL snippet that represents texture coordinates used for sampling.
-	 * @param {String} levelSnippet - A WGSL snippet that represents the mip level, with level 0 containing a full size version of the texture.
-	 * @return {String} The WGSL snippet.
+	 * @param {string} textureProperty - The name of the texture uniform in the shader.
+	 * @param {string} uvSnippet - A WGSL snippet that represents texture coordinates used for sampling.
+	 * @param {string} levelSnippet - A WGSL snippet that represents the mip level, with level 0 containing a full size version of the texture.
+	 * @return {string} The WGSL snippet.
 	 */
 	generateFilteredTexture( texture, textureProperty, uvSnippet, levelSnippet = '0u' ) {
 
@@ -504,11 +504,11 @@ class WGSLNodeBuilder extends NodeBuilder {
 	 * Since it's a lookup, no sampling or filtering is applied.
 	 *
 	 * @param {Texture} texture - The texture.
-	 * @param {String} textureProperty - The name of the texture uniform in the shader.
-	 * @param {String} uvSnippet - A WGSL snippet that represents texture coordinates used for sampling.
-	 * @param {String?} depthSnippet - A WGSL snippet that represents 0-based texture array index to sample.
-	 * @param {String} [levelSnippet='0u'] - A WGSL snippet that represents the mip level, with level 0 containing a full size version of the texture.
-	 * @return {String} The WGSL snippet.
+	 * @param {string} textureProperty - The name of the texture uniform in the shader.
+	 * @param {string} uvSnippet - A WGSL snippet that represents texture coordinates used for sampling.
+	 * @param {string?} depthSnippet - A WGSL snippet that represents 0-based texture array index to sample.
+	 * @param {string} [levelSnippet='0u'] - A WGSL snippet that represents the mip level, with level 0 containing a full size version of the texture.
+	 * @return {string} The WGSL snippet.
 	 */
 	generateTextureLod( texture, textureProperty, uvSnippet, depthSnippet, levelSnippet = '0u' ) {
 
@@ -526,11 +526,11 @@ class WGSLNodeBuilder extends NodeBuilder {
 	 * Generates the WGSL snippet that reads a single texel from a texture without sampling or filtering.
 	 *
 	 * @param {Texture} texture - The texture.
-	 * @param {String} textureProperty - The name of the texture uniform in the shader.
-	 * @param {String} uvIndexSnippet - A WGSL snippet that represents texture coordinates used for sampling.
-	 * @param {String?} depthSnippet - A WGSL snippet that represents 0-based texture array index to sample.
-	 * @param {String} [levelSnippet='0u'] - A WGSL snippet that represents the mip level, with level 0 containing a full size version of the texture.
-	 * @return {String} The WGSL snippet.
+	 * @param {string} textureProperty - The name of the texture uniform in the shader.
+	 * @param {string} uvIndexSnippet - A WGSL snippet that represents texture coordinates used for sampling.
+	 * @param {string?} depthSnippet - A WGSL snippet that represents 0-based texture array index to sample.
+	 * @param {string} [levelSnippet='0u'] - A WGSL snippet that represents the mip level, with level 0 containing a full size version of the texture.
+	 * @return {string} The WGSL snippet.
 	 */
 	generateTextureLoad( texture, textureProperty, uvIndexSnippet, depthSnippet, levelSnippet = '0u' ) {
 
@@ -554,10 +554,10 @@ class WGSLNodeBuilder extends NodeBuilder {
 	 * Generates the WGSL snippet that writes a single texel to a texture.
 	 *
 	 * @param {Texture} texture - The texture.
-	 * @param {String} textureProperty - The name of the texture uniform in the shader.
-	 * @param {String} uvIndexSnippet - A WGSL snippet that represents texture coordinates used for sampling.
-	 * @param {String} valueSnippet - A WGSL snippet that represent the new texel value.
-	 * @return {String} The WGSL snippet.
+	 * @param {string} textureProperty - The name of the texture uniform in the shader.
+	 * @param {string} uvIndexSnippet - A WGSL snippet that represents texture coordinates used for sampling.
+	 * @param {string} valueSnippet - A WGSL snippet that represent the new texel value.
+	 * @return {string} The WGSL snippet.
 	 */
 	generateTextureStore( texture, textureProperty, uvIndexSnippet, valueSnippet ) {
 
@@ -569,7 +569,7 @@ class WGSLNodeBuilder extends NodeBuilder {
 	 * Returns `true` if the sampled values of the given texture should be compared against a reference value.
 	 *
 	 * @param {Texture} texture - The texture.
-	 * @return {Boolean} Whether the sampled values of the given texture should be compared against a reference value or not.
+	 * @return {boolean} Whether the sampled values of the given texture should be compared against a reference value or not.
 	 */
 	isSampleCompare( texture ) {
 
@@ -581,7 +581,7 @@ class WGSLNodeBuilder extends NodeBuilder {
 	 * Returns `true` if the given texture is unfilterable.
 	 *
 	 * @param {Texture} texture - The texture.
-	 * @return {Boolean} Whether the given texture is unfilterable or not.
+	 * @return {boolean} Whether the given texture is unfilterable or not.
 	 */
 	isUnfilterable( texture ) {
 
@@ -596,11 +596,11 @@ class WGSLNodeBuilder extends NodeBuilder {
 	 * Generates the WGSL snippet for sampling/loading the given texture.
 	 *
 	 * @param {Texture} texture - The texture.
-	 * @param {String} textureProperty - The name of the texture uniform in the shader.
-	 * @param {String} uvSnippet - A WGSL snippet that represents texture coordinates used for sampling.
-	 * @param {String?} depthSnippet - A WGSL snippet that represents 0-based texture array index to sample.
-	 * @param {String} [shaderStage=this.shaderStage] - The shader stage this code snippet is generated for.
-	 * @return {String} The WGSL snippet.
+	 * @param {string} textureProperty - The name of the texture uniform in the shader.
+	 * @param {string} uvSnippet - A WGSL snippet that represents texture coordinates used for sampling.
+	 * @param {string?} depthSnippet - A WGSL snippet that represents 0-based texture array index to sample.
+	 * @param {string} [shaderStage=this.shaderStage] - The shader stage this code snippet is generated for.
+	 * @return {string} The WGSL snippet.
 	 */
 	generateTexture( texture, textureProperty, uvSnippet, depthSnippet, shaderStage = this.shaderStage ) {
 
@@ -628,12 +628,12 @@ class WGSLNodeBuilder extends NodeBuilder {
 	 * Generates the WGSL snippet for sampling/loading the given texture using explicit gradients.
 	 *
 	 * @param {Texture} texture - The texture.
-	 * @param {String} textureProperty - The name of the texture uniform in the shader.
-	 * @param {String} uvSnippet - A WGSL snippet that represents texture coordinates used for sampling.
-	 * @param {Array<String>} gradSnippet - An array holding both gradient WGSL snippets.
-	 * @param {String?} depthSnippet - A WGSL snippet that represents 0-based texture array index to sample.
-	 * @param {String} [shaderStage=this.shaderStage] - The shader stage this code snippet is generated for.
-	 * @return {String} The WGSL snippet.
+	 * @param {string} textureProperty - The name of the texture uniform in the shader.
+	 * @param {string} uvSnippet - A WGSL snippet that represents texture coordinates used for sampling.
+	 * @param {Array<string>} gradSnippet - An array holding both gradient WGSL snippets.
+	 * @param {string?} depthSnippet - A WGSL snippet that represents 0-based texture array index to sample.
+	 * @param {string} [shaderStage=this.shaderStage] - The shader stage this code snippet is generated for.
+	 * @return {string} The WGSL snippet.
 	 */
 	generateTextureGrad( texture, textureProperty, uvSnippet, gradSnippet, depthSnippet, shaderStage = this.shaderStage ) {
 
@@ -655,12 +655,12 @@ class WGSLNodeBuilder extends NodeBuilder {
 	 * against a reference value.
 	 *
 	 * @param {Texture} texture - The texture.
-	 * @param {String} textureProperty - The name of the texture uniform in the shader.
-	 * @param {String} uvSnippet - A WGSL snippet that represents texture coordinates used for sampling.
-	 * @param {String} compareSnippet -  A WGSL snippet that represents the reference value.
-	 * @param {String?} depthSnippet - A WGSL snippet that represents 0-based texture array index to sample.
-	 * @param {String} [shaderStage=this.shaderStage] - The shader stage this code snippet is generated for.
-	 * @return {String} The WGSL snippet.
+	 * @param {string} textureProperty - The name of the texture uniform in the shader.
+	 * @param {string} uvSnippet - A WGSL snippet that represents texture coordinates used for sampling.
+	 * @param {string} compareSnippet -  A WGSL snippet that represents the reference value.
+	 * @param {string?} depthSnippet - A WGSL snippet that represents 0-based texture array index to sample.
+	 * @param {string} [shaderStage=this.shaderStage] - The shader stage this code snippet is generated for.
+	 * @return {string} The WGSL snippet.
 	 */
 	generateTextureCompare( texture, textureProperty, uvSnippet, compareSnippet, depthSnippet, shaderStage = this.shaderStage ) {
 
@@ -680,12 +680,12 @@ class WGSLNodeBuilder extends NodeBuilder {
 	 * Generates the WGSL snippet when sampling textures with explicit mip level.
 	 *
 	 * @param {Texture} texture - The texture.
-	 * @param {String} textureProperty - The name of the texture uniform in the shader.
-	 * @param {String} uvSnippet - A WGSL snippet that represents texture coordinates used for sampling.
-	 * @param {String} levelSnippet - A WGSL snippet that represents the mip level, with level 0 containing a full size version of the texture.
-	 * @param {String?} depthSnippet - A WGSL snippet that represents 0-based texture array index to sample.
-	 * @param {String} [shaderStage=this.shaderStage] - The shader stage this code snippet is generated for.
-	 * @return {String} The WGSL snippet.
+	 * @param {string} textureProperty - The name of the texture uniform in the shader.
+	 * @param {string} uvSnippet - A WGSL snippet that represents texture coordinates used for sampling.
+	 * @param {string} levelSnippet - A WGSL snippet that represents the mip level, with level 0 containing a full size version of the texture.
+	 * @param {string?} depthSnippet - A WGSL snippet that represents 0-based texture array index to sample.
+	 * @param {string} [shaderStage=this.shaderStage] - The shader stage this code snippet is generated for.
+	 * @return {string} The WGSL snippet.
 	 */
 	generateTextureLevel( texture, textureProperty, uvSnippet, levelSnippet, depthSnippet, shaderStage = this.shaderStage ) {
 
@@ -709,12 +709,12 @@ class WGSLNodeBuilder extends NodeBuilder {
 	 * Generates the WGSL snippet when sampling textures with a bias to the mip level.
 	 *
 	 * @param {Texture} texture - The texture.
-	 * @param {String} textureProperty - The name of the texture uniform in the shader.
-	 * @param {String} uvSnippet - A WGSL snippet that represents texture coordinates used for sampling.
-	 * @param {String} biasSnippet - A WGSL snippet that represents the bias to apply to the mip level before sampling.
-	 * @param {String?} depthSnippet - A WGSL snippet that represents 0-based texture array index to sample.
-	 * @param {String} [shaderStage=this.shaderStage] - The shader stage this code snippet is generated for.
-	 * @return {String} The WGSL snippet.
+	 * @param {string} textureProperty - The name of the texture uniform in the shader.
+	 * @param {string} uvSnippet - A WGSL snippet that represents texture coordinates used for sampling.
+	 * @param {string} biasSnippet - A WGSL snippet that represents the bias to apply to the mip level before sampling.
+	 * @param {string?} depthSnippet - A WGSL snippet that represents 0-based texture array index to sample.
+	 * @param {string} [shaderStage=this.shaderStage] - The shader stage this code snippet is generated for.
+	 * @return {string} The WGSL snippet.
 	 */
 	generateTextureBias( texture, textureProperty, uvSnippet, biasSnippet, depthSnippet, shaderStage = this.shaderStage ) {
 
@@ -734,8 +734,8 @@ class WGSLNodeBuilder extends NodeBuilder {
 	 * Returns a WGSL snippet that represents the property name of the given node.
 	 *
 	 * @param {Node} node - The node.
-	 * @param {String} [shaderStage=this.shaderStage] - The shader stage this code snippet is generated for.
-	 * @return {String} The property name.
+	 * @param {string} [shaderStage=this.shaderStage] - The shader stage this code snippet is generated for.
+	 * @return {string} The property name.
 	 */
 	getPropertyName( node, shaderStage = this.shaderStage ) {
 
@@ -781,7 +781,7 @@ class WGSLNodeBuilder extends NodeBuilder {
 	/**
 	 * Returns the output struct name.
 	 *
-	 * @return {String} The name of the output struct.
+	 * @return {string} The name of the output struct.
 	 */
 	getOutputStructName() {
 
@@ -793,8 +793,8 @@ class WGSLNodeBuilder extends NodeBuilder {
 	 * Returns uniforms group count for the given shader stage.
 	 *
 	 * @private
-	 * @param {String} shaderStage - The shader stage.
-	 * @return {Number} The uniforms group count for the given shader stage.
+	 * @param {string} shaderStage - The shader stage.
+	 * @return {number} The uniforms group count for the given shader stage.
 	 */
 	_getUniformGroupCount( shaderStage ) {
 
@@ -805,8 +805,8 @@ class WGSLNodeBuilder extends NodeBuilder {
 	/**
 	 * Returns the native shader operator name for a given generic name.
 	 *
-	 * @param {String} op - The operator name to resolve.
-	 * @return {String} The resolved operator name.
+	 * @param {string} op - The operator name to resolve.
+	 * @return {string} The resolved operator name.
 	 */
 	getFunctionOperator( op ) {
 
@@ -828,8 +828,8 @@ class WGSLNodeBuilder extends NodeBuilder {
 	 * Returns the node access for the given node and shader stage.
 	 *
 	 * @param {StorageTextureNode|StorageBufferNode} node - The storage node.
-	 * @param {String} shaderStage - The shader stage.
-	 * @return {String} The node access.
+	 * @param {string} shaderStage - The shader stage.
+	 * @return {string} The node access.
 	 */
 	getNodeAccess( node, shaderStage ) {
 
@@ -844,8 +844,8 @@ class WGSLNodeBuilder extends NodeBuilder {
 	 * Returns A WGSL snippet representing the storage access.
 	 *
 	 * @param {StorageTextureNode|StorageBufferNode} node - The storage node.
-	 * @param {String} shaderStage - The shader stage.
-	 * @return {String} The WGSL snippet representing the storage access.
+	 * @param {string} shaderStage - The shader stage.
+	 * @return {string} The WGSL snippet representing the storage access.
 	 */
 	getStorageAccess( node, shaderStage ) {
 
@@ -861,9 +861,9 @@ class WGSLNodeBuilder extends NodeBuilder {
 	 * and layouts.
 	 *
 	 * @param {UniformNode} node - The uniform node.
-	 * @param {String} type - The node data type.
-	 * @param {String} shaderStage - The shader stage.
-	 * @param {String?} [name=null] - An optional uniform name.
+	 * @param {string} type - The node data type.
+	 * @param {string} shaderStage - The shader stage.
+	 * @param {string?} [name=null] - An optional uniform name.
 	 * @return {NodeUniform} The node uniform object.
 	 */
 	getUniformFromNode( node, type, shaderStage, name = null ) {
@@ -969,11 +969,11 @@ class WGSLNodeBuilder extends NodeBuilder {
 	 * The internal builtins data structure will make sure builtins are
 	 * defined in the WGSL source.
 	 *
-	 * @param {String} name - The builtin name.
-	 * @param {String} property - The property name.
-	 * @param {String} type - The node data type.
-	 * @param {String} [shaderStage=this.shaderStage] - The shader stage this code snippet is generated for.
-	 * @return {String} The property name.
+	 * @param {string} name - The builtin name.
+	 * @param {string} property - The property name.
+	 * @param {string} type - The node data type.
+	 * @param {string} [shaderStage=this.shaderStage] - The shader stage this code snippet is generated for.
+	 * @return {string} The property name.
 	 */
 	getBuiltin( name, property, type, shaderStage = this.shaderStage ) {
 
@@ -996,9 +996,9 @@ class WGSLNodeBuilder extends NodeBuilder {
 	/**
 	 * Returns `true` if the given builtin is defined in the given shader stage.
 	 *
-	 * @param {String} name - The builtin name.
-	 * @param {String} [shaderStage=this.shaderStage] - The shader stage this code snippet is generated for.
-	 * @return {String} Whether the given builtin is defined in the given shader stage or not.
+	 * @param {string} name - The builtin name.
+	 * @param {string} [shaderStage=this.shaderStage] - The shader stage this code snippet is generated for.
+	 * @return {string} Whether the given builtin is defined in the given shader stage or not.
 	 */
 	hasBuiltin( name, shaderStage = this.shaderStage ) {
 
@@ -1009,7 +1009,7 @@ class WGSLNodeBuilder extends NodeBuilder {
 	/**
 	 * Returns the vertex index builtin.
 	 *
-	 * @return {String} The vertex index.
+	 * @return {string} The vertex index.
 	 */
 	getVertexIndex() {
 
@@ -1027,7 +1027,7 @@ class WGSLNodeBuilder extends NodeBuilder {
 	 * Builds the given shader node.
 	 *
 	 * @param {ShaderNodeInternal} shaderNode - The shader node.
-	 * @return {String} The WGSL function code.
+	 * @return {string} The WGSL function code.
 	 */
 	buildFunctionCode( shaderNode ) {
 
@@ -1066,7 +1066,7 @@ ${ flowData.code }
 	/**
 	 * Returns the instance index builtin.
 	 *
-	 * @return {String} The instance index.
+	 * @return {string} The instance index.
 	 */
 	getInstanceIndex() {
 
@@ -1083,7 +1083,7 @@ ${ flowData.code }
 	/**
 	 * Returns the invocation local index builtin.
 	 *
-	 * @return {String} The invocation local index.
+	 * @return {string} The invocation local index.
 	 */
 	getInvocationLocalIndex() {
 
@@ -1094,7 +1094,7 @@ ${ flowData.code }
 	/**
 	 * Returns the subgroup size builtin.
 	 *
-	 * @return {String} The subgroup size.
+	 * @return {string} The subgroup size.
 	 */
 	getSubgroupSize() {
 
@@ -1107,7 +1107,7 @@ ${ flowData.code }
 	/**
 	 * Returns the invocation subgroup index builtin.
 	 *
-	 * @return {String} The invocation subgroup index.
+	 * @return {string} The invocation subgroup index.
 	 */
 	getInvocationSubgroupIndex() {
 
@@ -1120,7 +1120,7 @@ ${ flowData.code }
 	/**
 	 * Returns the subgroup index builtin.
 	 *
-	 * @return {String} The subgroup index.
+	 * @return {string} The subgroup index.
 	 */
 	getSubgroupIndex() {
 
@@ -1144,7 +1144,7 @@ ${ flowData.code }
 	/**
 	 * Returns the front facing builtin.
 	 *
-	 * @return {String} The front facing builtin.
+	 * @return {string} The front facing builtin.
 	 */
 	getFrontFacing() {
 
@@ -1155,7 +1155,7 @@ ${ flowData.code }
 	/**
 	 * Returns the frag coord builtin.
 	 *
-	 * @return {String} The frag coord builtin.
+	 * @return {string} The frag coord builtin.
 	 */
 	getFragCoord() {
 
@@ -1166,7 +1166,7 @@ ${ flowData.code }
 	/**
 	 * Returns the frag depth builtin.
 	 *
-	 * @return {String} The frag depth builtin.
+	 * @return {string} The frag depth builtin.
 	 */
 	getFragDepth() {
 
@@ -1177,7 +1177,7 @@ ${ flowData.code }
 	/**
 	 * Returns the clip distances builtin.
 	 *
-	 * @return {String} The clip distances builtin.
+	 * @return {string} The clip distances builtin.
 	 */
 	getClipDistance() {
 
@@ -1188,7 +1188,7 @@ ${ flowData.code }
 	/**
 	 * Whether to flip texture data along its vertical axis or not.
 	 *
-	 * @return {Boolean} Returns always `false` in context of WGSL.
+	 * @return {boolean} Returns always `false` in context of WGSL.
 	 */
 	isFlipY() {
 
@@ -1199,8 +1199,8 @@ ${ flowData.code }
 	/**
 	 * Enables the given directive for the given shader stage.
 	 *
-	 * @param {String} name - The directive name.
-	 * @param {String} [shaderStage=this.shaderStage] - The shader stage to enable the directive for.
+	 * @param {string} name - The directive name.
+	 * @param {string} [shaderStage=this.shaderStage] - The shader stage to enable the directive for.
 	 */
 	enableDirective( name, shaderStage = this.shaderStage ) {
 
@@ -1212,8 +1212,8 @@ ${ flowData.code }
 	/**
 	 * Returns the directives of the given shader stage as a WGSL string.
 	 *
-	 * @param {String} shaderStage - The shader stage.
-	 * @return {String} A WGSL snippet that enables the directives of the given stage.
+	 * @param {string} shaderStage - The shader stage.
+	 * @return {string} A WGSL snippet that enables the directives of the given stage.
 	 */
 	getDirectives( shaderStage ) {
 
@@ -1282,7 +1282,7 @@ ${ flowData.code }
 	/**
 	 * Enables hardware clipping.
 	 *
-	 * @param {String} planeCount - The clipping plane count.
+	 * @param {string} planeCount - The clipping plane count.
 	 */
 	enableHardwareClipping( planeCount ) {
 
@@ -1294,8 +1294,8 @@ ${ flowData.code }
 	/**
 	 * Returns the builtins of the given shader stage as a WGSL string.
 	 *
-	 * @param {String} shaderStage - The shader stage.
-	 * @return {String} A WGSL snippet that represents the builtins of the given stage.
+	 * @param {string} shaderStage - The shader stage.
+	 * @return {string} A WGSL snippet that represents the builtins of the given stage.
 	 */
 	getBuiltins( shaderStage ) {
 
@@ -1321,11 +1321,11 @@ ${ flowData.code }
 	 * compute shaders. It adds the array to the internal data structure which is
 	 * later used to generate the respective WGSL.
 	 *
-	 * @param {String} name - The array name.
-	 * @param {String} scope - The scope.
-	 * @param {String} bufferType - The buffer type.
-	 * @param {String} bufferCount - The buffer count.
-	 * @return {String} The array name.
+	 * @param {string} name - The array name.
+	 * @param {string} scope - The scope.
+	 * @param {string} bufferType - The buffer type.
+	 * @param {string} bufferCount - The buffer count.
+	 * @return {string} The array name.
 	 */
 	getScopedArray( name, scope, bufferType, bufferCount ) {
 
@@ -1347,8 +1347,8 @@ ${ flowData.code }
 	/**
 	 * Returns the scoped arrays of the given shader stage as a WGSL string.
 	 *
-	 * @param {String} shaderStage - The shader stage.
-	 * @return {String|undefined} The WGSL snippet that defines the scoped arrays.
+	 * @param {string} shaderStage - The shader stage.
+	 * @return {string|undefined} The WGSL snippet that defines the scoped arrays.
 	 * Returns `undefined` when used in the vertex or fragment stage.
 	 */
 	getScopedArrays( shaderStage ) {
@@ -1376,8 +1376,8 @@ ${ flowData.code }
 	/**
 	 * Returns the shader attributes of the given shader stage as a WGSL string.
 	 *
-	 * @param {String} shaderStage - The shader stage.
-	 * @return {String} The WGSL snippet that defines the shader attributes.
+	 * @param {string} shaderStage - The shader stage.
+	 * @return {string} The WGSL snippet that defines the shader attributes.
 	 */
 	getAttributes( shaderStage ) {
 
@@ -1427,7 +1427,7 @@ ${ flowData.code }
 	 * Returns the members of the given struct type node as a WGSL string.
 	 *
 	 * @param {StructTypeNode} struct - The struct type node.
-	 * @return {String} The WGSL snippet that defines the struct members.
+	 * @return {string} The WGSL snippet that defines the struct members.
 	 */
 	getStructMembers( struct ) {
 
@@ -1456,8 +1456,8 @@ ${ flowData.code }
 	/**
 	 * Returns the structs of the given shader stage as a WGSL string.
 	 *
-	 * @param {String} shaderStage - The shader stage.
-	 * @return {String} The WGSL snippet that defines the structs.
+	 * @param {string} shaderStage - The shader stage.
+	 * @return {string} The WGSL snippet that defines the structs.
 	 */
 	getStructs( shaderStage ) {
 
@@ -1490,10 +1490,10 @@ ${ flowData.code }
 	/**
 	 * Returns a WGSL string representing a variable.
 	 *
-	 * @param {String} type - The variable's type.
-	 * @param {String} name - The variable's name.
-	 * @param {Number?} [count=null] - The array length.
-	 * @return {String} The WGSL snippet that defines a variable.
+	 * @param {string} type - The variable's type.
+	 * @param {string} name - The variable's name.
+	 * @param {number?} [count=null] - The array length.
+	 * @return {string} The WGSL snippet that defines a variable.
 	 */
 	getVar( type, name, count = null ) {
 
@@ -1516,8 +1516,8 @@ ${ flowData.code }
 	/**
 	 * Returns the variables of the given shader stage as a WGSL string.
 	 *
-	 * @param {String} shaderStage - The shader stage.
-	 * @return {String} The WGSL snippet that defines the variables.
+	 * @param {string} shaderStage - The shader stage.
+	 * @return {string} The WGSL snippet that defines the variables.
 	 */
 	getVars( shaderStage ) {
 
@@ -1541,8 +1541,8 @@ ${ flowData.code }
 	/**
 	 * Returns the varyings of the given shader stage as a WGSL string.
 	 *
-	 * @param {String} shaderStage - The shader stage.
-	 * @return {String} The WGSL snippet that defines the varyings.
+	 * @param {string} shaderStage - The shader stage.
+	 * @return {string} The WGSL snippet that defines the varyings.
 	 */
 	getVaryings( shaderStage ) {
 
@@ -1605,8 +1605,8 @@ ${ flowData.code }
 	/**
 	 * Returns the uniforms of the given shader stage as a WGSL string.
 	 *
-	 * @param {String} shaderStage - The shader stage.
-	 * @return {String} The WGSL snippet that defines the uniforms.
+	 * @param {string} shaderStage - The shader stage.
+	 * @return {string} The WGSL snippet that defines the uniforms.
 	 */
 	getUniforms( shaderStage ) {
 
@@ -1853,9 +1853,9 @@ ${ flowData.code }
 	/**
 	 * Returns the native shader method name for a given generic name.
 	 *
-	 * @param {String} method - The method name to resolve.
-	 * @param {String} [output=null] - An optional output.
-	 * @return {String} The resolved WGSL method name.
+	 * @param {string} method - The method name to resolve.
+	 * @param {string} [output=null] - An optional output.
+	 * @return {string} The resolved WGSL method name.
 	 */
 	getMethod( method, output = null ) {
 
@@ -1880,8 +1880,8 @@ ${ flowData.code }
 	/**
 	 * Returns the WGSL type of the given node data type.
 	 *
-	 * @param {String} type - The node data type.
-	 * @return {String} The WGSL type.
+	 * @param {string} type - The node data type.
+	 * @return {string} The WGSL type.
 	 */
 	getType( type ) {
 
@@ -1892,8 +1892,8 @@ ${ flowData.code }
 	/**
 	 * Whether the requested feature is available or not.
 	 *
-	 * @param {String} name - The requested feature.
-	 * @return {Boolean} Whether the requested feature is supported or not.
+	 * @param {string} name - The requested feature.
+	 * @return {boolean} Whether the requested feature is supported or not.
 	 */
 	isAvailable( name ) {
 
@@ -1923,8 +1923,8 @@ ${ flowData.code }
 	 * Returns the native shader method name for a given generic name.
 	 *
 	 * @private
-	 * @param {String} method - The method name to resolve.
-	 * @return {String} The resolved WGSL method name.
+	 * @param {string} method - The method name to resolve.
+	 * @return {string} The resolved WGSL method name.
 	 */
 	_getWGSLMethod( method ) {
 
@@ -1943,7 +1943,7 @@ ${ flowData.code }
 	 * function node.
 	 *
 	 * @private
-	 * @param {String} name - The method name to include.
+	 * @param {string} name - The method name to include.
 	 * @return {CodeNode} The respective code node.
 	 */
 	_include( name ) {
@@ -1966,7 +1966,7 @@ ${ flowData.code }
 	 *
 	 * @private
 	 * @param {Object} shaderData - The shader data.
-	 * @return {String} The vertex shader.
+	 * @return {string} The vertex shader.
 	 */
 	_getWGSLVertexCode( shaderData ) {
 
@@ -2008,7 +2008,7 @@ fn main( ${shaderData.attributes} ) -> VaryingsStruct {
 	 *
 	 * @private
 	 * @param {Object} shaderData - The shader data.
-	 * @return {String} The vertex shader.
+	 * @return {string} The vertex shader.
 	 */
 	_getWGSLFragmentCode( shaderData ) {
 
@@ -2044,8 +2044,8 @@ fn main( ${shaderData.varyings} ) -> ${shaderData.returnType} {
 	 *
 	 * @private
 	 * @param {Object} shaderData - The shader data.
-	 * @param {String} workgroupSize - The workgroup size.
-	 * @return {String} The vertex shader.
+	 * @param {string} workgroupSize - The workgroup size.
+	 * @return {string} The vertex shader.
 	 */
 	_getWGSLComputeCode( shaderData, workgroupSize ) {
 
@@ -2089,9 +2089,9 @@ fn main( ${shaderData.attributes} ) {
 	 * Returns a WGSL struct based on the given name and variables.
 	 *
 	 * @private
-	 * @param {String} name - The struct name.
-	 * @param {String} vars - The struct variables.
-	 * @return {String} The WGSL snippet representing a struct.
+	 * @param {string} name - The struct name.
+	 * @param {string} vars - The struct variables.
+	 * @return {string} The WGSL snippet representing a struct.
 	 */
 	_getWGSLStruct( name, vars ) {
 
@@ -2106,12 +2106,12 @@ ${vars}
 	 * Returns a WGSL struct binding.
 	 *
 	 * @private
-	 * @param {String} name - The struct name.
-	 * @param {String} vars - The struct variables.
-	 * @param {String} access - The access.
-	 * @param {Number} [binding=0] - The binding index.
-	 * @param {Number} [group=0] - The group index.
-	 * @return {String} The WGSL snippet representing a struct binding.
+	 * @param {string} name - The struct name.
+	 * @param {string} vars - The struct variables.
+	 * @param {string} access - The access.
+	 * @param {number} [binding=0] - The binding index.
+	 * @param {number} [group=0] - The group index.
+	 * @return {string} The WGSL snippet representing a struct binding.
 	 */
 	_getWGSLStructBinding( name, vars, access, binding = 0, group = 0 ) {
 

--- a/src/renderers/webgpu/nodes/WGSLNodeFunction.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeFunction.js
@@ -151,7 +151,7 @@ class WGSLNodeFunction extends NodeFunction {
 	/**
 	 * Constructs a new WGSL node function.
 	 *
-	 * @param {String} source - The WGSL source.
+	 * @param {string} source - The WGSL source.
 	 */
 	constructor( source ) {
 
@@ -168,8 +168,8 @@ class WGSLNodeFunction extends NodeFunction {
 	/**
 	 * This method returns the WGSL code of the node function.
 	 *
-	 * @param {String} [name=this.name] - The function's name.
-	 * @return {String} The shader code.
+	 * @param {string} [name=this.name] - The function's name.
+	 * @return {string} The shader code.
 	 */
 	getCode( name = this.name ) {
 

--- a/src/renderers/webgpu/nodes/WGSLNodeParser.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeParser.js
@@ -11,7 +11,7 @@ class WGSLNodeParser extends NodeParser {
 	/**
 	 * The method parses the given WGSL code an returns a node function.
 	 *
-	 * @param {String} source - The WGSL code.
+	 * @param {string} source - The WGSL code.
 	 * @return {WGSLNodeFunction} A node function.
 	 */
 	parseFunction( source ) {

--- a/src/renderers/webgpu/utils/WebGPUAttributeUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUAttributeUtils.js
@@ -325,7 +325,7 @@ class WebGPUAttributeUtils {
 	 *
 	 * @private
 	 * @param {BufferAttribute} geometryAttribute - The buffer attribute.
-	 * @return {String} The vertex format (e.g. 'float32x3').
+	 * @return {string} The vertex format (e.g. 'float32x3').
 	 */
 	_getVertexFormat( geometryAttribute ) {
 
@@ -376,8 +376,8 @@ class WebGPUAttributeUtils {
 	 * Returns `true` if the given array is a typed array.
 	 *
 	 * @private
-	 * @param {Any} array - The array.
-	 * @return {Boolean} Whether the given array is a typed array or not.
+	 * @param {any} array - The array.
+	 * @return {boolean} Whether the given array is a typed array or not.
 	 */
 	_isTypedArray( array ) {
 

--- a/src/renderers/webgpu/utils/WebGPUBindingUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUBindingUtils.js
@@ -220,8 +220,8 @@ class WebGPUBindingUtils {
 	 *
 	 * @param {BindGroup} bindGroup - The bind group.
 	 * @param {Array<BindGroup>} bindings - Array of bind groups.
-	 * @param {Number} cacheIndex - The cache index.
-	 * @param {Number} version - The version.
+	 * @param {number} cacheIndex - The cache index.
+	 * @param {number} version - The version.
 	 */
 	createBindings( bindGroup, bindings, cacheIndex, version = 0 ) {
 

--- a/src/renderers/webgpu/utils/WebGPUPipelineUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUPipelineUtils.js
@@ -43,7 +43,7 @@ class WebGPUPipelineUtils {
 	 *
 	 * @private
 	 * @param {RenderContext} renderContext - The render context.
-	 * @return {Number} The sample count.
+	 * @return {number} The sample count.
 	 */
 	_getSampleCount( renderContext ) {
 
@@ -397,8 +397,8 @@ class WebGPUPipelineUtils {
 	 * Returns the GPU blend factor which is required for the pipeline creation.
 	 *
 	 * @private
-	 * @param {Number} blend - The blend factor as a three.js constant.
-	 * @return {String} The GPU blend factor.
+	 * @param {number} blend - The blend factor as a three.js constant.
+	 * @return {string} The GPU blend factor.
 	 */
 	_getBlendFactor( blend ) {
 
@@ -472,7 +472,7 @@ class WebGPUPipelineUtils {
 	 *
 	 * @private
 	 * @param {Material} material - The material.
-	 * @return {String} The GPU stencil compare function.
+	 * @return {string} The GPU stencil compare function.
 	 */
 	_getStencilCompare( material ) {
 
@@ -527,8 +527,8 @@ class WebGPUPipelineUtils {
 	 * Returns the GPU stencil operation which is required for the pipeline creation.
 	 *
 	 * @private
-	 * @param {Number} op - A three.js constant defining the stencil operation.
-	 * @return {String} The GPU stencil operation.
+	 * @param {number} op - A three.js constant defining the stencil operation.
+	 * @return {string} The GPU stencil operation.
 	 */
 	_getStencilOperation( op ) {
 
@@ -581,8 +581,8 @@ class WebGPUPipelineUtils {
 	 * Returns the GPU blend operation which is required for the pipeline creation.
 	 *
 	 * @private
-	 * @param {Number} blendEquation - A three.js constant defining the blend equation.
-	 * @return {String} The GPU blend operation.
+	 * @param {number} blendEquation - A three.js constant defining the blend equation.
+	 * @return {string} The GPU blend operation.
 	 */
 	_getBlendOperation( blendEquation ) {
 
@@ -674,7 +674,7 @@ class WebGPUPipelineUtils {
 	 *
 	 * @private
 	 * @param {Material} material - The material.
-	 * @return {String} The GPU color write mask.
+	 * @return {string} The GPU color write mask.
 	 */
 	_getColorWriteMask( material ) {
 
@@ -687,7 +687,7 @@ class WebGPUPipelineUtils {
 	 *
 	 * @private
 	 * @param {Material} material - The material.
-	 * @return {String} The GPU depth compare function.
+	 * @return {string} The GPU depth compare function.
 	 */
 	_getDepthCompare( material ) {
 

--- a/src/renderers/webgpu/utils/WebGPUTexturePassUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUTexturePassUtils.js
@@ -105,7 +105,7 @@ fn main( @location( 0 ) vTex : vec2<f32> ) -> @location( 0 ) vec4<f32> {
 		 * A cache for GPU render pipelines used for copy/transfer passes.
 		 * Every texture format requires a unique pipeline.
 		 *
-		 * @type {Object<String,GPURenderPipeline>}
+		 * @type {Object<string,GPURenderPipeline>}
 		 */
 		this.transferPipelines = {};
 
@@ -113,7 +113,7 @@ fn main( @location( 0 ) vTex : vec2<f32> ) -> @location( 0 ) vec4<f32> {
 		 * A cache for GPU render pipelines used for flipY passes.
 		 * Every texture format requires a unique pipeline.
 		 *
-		 * @type {Object<String,GPURenderPipeline>}
+		 * @type {Object<string,GPURenderPipeline>}
 		 */
 		this.flipYPipelines = {};
 
@@ -153,7 +153,7 @@ fn main( @location( 0 ) vTex : vec2<f32> ) -> @location( 0 ) vec4<f32> {
 	 * Returns a render pipeline for the internal copy render pass. The pass
 	 * requires a unique render pipeline for each texture format.
 	 *
-	 * @param {String} format - The GPU texture format
+	 * @param {string} format - The GPU texture format
 	 * @return {GPURenderPipeline} The GPU render pipeline.
 	 */
 	getTransferPipeline( format ) {
@@ -192,7 +192,7 @@ fn main( @location( 0 ) vTex : vec2<f32> ) -> @location( 0 ) vec4<f32> {
 	 * Returns a render pipeline for the flipY render pass. The pass
 	 * requires a unique render pipeline for each texture format.
 	 *
-	 * @param {String} format - The GPU texture format
+	 * @param {string} format - The GPU texture format
 	 * @return {GPURenderPipeline} The GPU render pipeline.
 	 */
 	getFlipYPipeline( format ) {
@@ -232,7 +232,7 @@ fn main( @location( 0 ) vTex : vec2<f32> ) -> @location( 0 ) vec4<f32> {
 	 *
 	 * @param {GPUTexture} textureGPU - The GPU texture object.
 	 * @param {Object} textureGPUDescriptor - The texture descriptor.
-	 * @param {Number} [baseArrayLayer=0] - The index of the first array layer accessible to the texture view.
+	 * @param {number} [baseArrayLayer=0] - The index of the first array layer accessible to the texture view.
 	 */
 	flipY( textureGPU, textureGPUDescriptor, baseArrayLayer = 0 ) {
 
@@ -309,7 +309,7 @@ fn main( @location( 0 ) vTex : vec2<f32> ) -> @location( 0 ) vec4<f32> {
 	 *
 	 * @param {GPUTexture} textureGPU - The GPU texture object.
 	 * @param {Object} textureGPUDescriptor - The texture descriptor.
-	 * @param {Number} [baseArrayLayer=0] - The index of the first array layer accessible to the texture view.
+	 * @param {number} [baseArrayLayer=0] - The index of the first array layer accessible to the texture view.
 	 */
 	generateMipmaps( textureGPU, textureGPUDescriptor, baseArrayLayer = 0 ) {
 
@@ -342,7 +342,7 @@ fn main( @location( 0 ) vTex : vec2<f32> ) -> @location( 0 ) vec4<f32> {
 	 *
 	 * @param {GPUTexture} textureGPU - The GPU texture object.
 	 * @param {Object} textureGPUDescriptor - The texture descriptor.
-	 * @param {Number} baseArrayLayer - The index of the first array layer accessible to the texture view.
+	 * @param {number} baseArrayLayer - The index of the first array layer accessible to the texture view.
 	 * @return {Array} An array of render bundles.
 	 */
 	_mipmapCreateBundles( textureGPU, textureGPUDescriptor, baseArrayLayer ) {

--- a/src/renderers/webgpu/utils/WebGPUTextureUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUTextureUtils.js
@@ -65,7 +65,7 @@ class WebGPUTextureUtils {
 		 * A dictionary for managing default textures. The key
 		 * is the texture format, the value the texture object.
 		 *
-		 * @type {Object<String,Texture>}
+		 * @type {Object<string,Texture>}
 		 */
 		this.defaultTexture = {};
 
@@ -73,7 +73,7 @@ class WebGPUTextureUtils {
 		 * A dictionary for managing default cube textures. The key
 		 * is the texture format, the value the texture object.
 		 *
-		 * @type {Object<String,CubeTexture>}
+		 * @type {Object<string,CubeTexture>}
 		 */
 		this.defaultCubeTexture = {};
 
@@ -387,8 +387,8 @@ class WebGPUTextureUtils {
 	 * Returns the depth buffer representing the depth
 	 * attachment of the default framebuffer.
 	 *
-	 * @param {Boolean} [depth=true] - Whether depth is enabled or not.
-	 * @param {Boolean} [stencil=false] -  Whether stencil is enabled or not.
+	 * @param {boolean} [depth=true] - Whether depth is enabled or not.
+	 * @param {boolean} [stencil=false] -  Whether stencil is enabled or not.
 	 * @return {GPUTexture} The depth buffer.
 	 */
 	getDepthBuffer( depth = true, stencil = false ) {
@@ -499,11 +499,11 @@ class WebGPUTextureUtils {
 	 *
 	 * @async
 	 * @param {Texture} texture - The texture to copy.
-	 * @param {Number} x - The x coordinate of the copy origin.
-	 * @param {Number} y - The y coordinate of the copy origin.
-	 * @param {Number} width - The width of the copy.
-	 * @param {Number} height - The height of the copy.
-	 * @param {Number} faceIndex - The face index.
+	 * @param {number} x - The x coordinate of the copy origin.
+	 * @param {number} y - The y coordinate of the copy origin.
+	 * @param {number} width - The width of the copy.
+	 * @param {number} height - The height of the copy.
+	 * @param {number} faceIndex - The face index.
 	 * @return {Promise<TypedArray>} A Promise that resolves with a typed array when the copy operation has finished.
 	 */
 	async copyTextureToBuffer( texture, x, y, width, height, faceIndex ) {
@@ -560,7 +560,7 @@ class WebGPUTextureUtils {
 	 *
 	 * @private
 	 * @param {Texture} texture - The texture.
-	 * @return {Boolean} Whether the given texture is an environment map or not.
+	 * @return {boolean} Whether the given texture is an environment map or not.
 	 */
 	_isEnvironmentTexture( texture ) {
 
@@ -574,7 +574,7 @@ class WebGPUTextureUtils {
 	 * Returns the default GPU texture for the given format.
 	 *
 	 * @private
-	 * @param {String} format - The GPU format.
+	 * @param {string} format - The GPU format.
 	 * @return {GPUTexture} The GPU texture.
 	 */
 	_getDefaultTextureGPU( format ) {
@@ -601,7 +601,7 @@ class WebGPUTextureUtils {
 	 * Returns the default GPU cube texture for the given format.
 	 *
 	 * @private
-	 * @param {String} format - The GPU format.
+	 * @param {string} format - The GPU format.
 	 * @return {GPUTexture} The GPU texture.
 	 */
 	_getDefaultCubeTextureGPU( format ) {
@@ -658,7 +658,7 @@ class WebGPUTextureUtils {
 	 * @param {Array} images - The cube image data.
 	 * @param {GPUTexture} textureGPU - The GPU texture.
 	 * @param {Object} textureDescriptorGPU - The GPU texture descriptor.
-	 * @param {Boolean} flipY - Whether to flip texture data along their vertical axis or not.
+	 * @param {boolean} flipY - Whether to flip texture data along their vertical axis or not.
 	 */
 	_copyCubeMapToTexture( images, textureGPU, textureDescriptorGPU, flipY ) {
 
@@ -689,8 +689,8 @@ class WebGPUTextureUtils {
 	 * @param {HTMLImageElement|ImageBitmap|HTMLCanvasElement} image - The image data.
 	 * @param {GPUTexture} textureGPU - The GPU texture.
 	 * @param {Object} textureDescriptorGPU - The GPU texture descriptor.
-	 * @param {Number} originDepth - The origin depth.
-	 * @param {Boolean} flipY - Whether to flip texture data along their vertical axis or not.
+	 * @param {number} originDepth - The origin depth.
+	 * @param {boolean} flipY - Whether to flip texture data along their vertical axis or not.
 	 */
 	_copyImageToTexture( image, textureGPU, textureDescriptorGPU, originDepth, flipY ) {
 
@@ -739,7 +739,7 @@ class WebGPUTextureUtils {
 	 * @private
 	 * @param {GPUTexture} textureGPU - The GPU texture object.
 	 * @param {Object} textureDescriptorGPU - The texture descriptor.
-	 * @param {Number} [baseArrayLayer=0] - The index of the first array layer accessible to the texture view.
+	 * @param {number} [baseArrayLayer=0] - The index of the first array layer accessible to the texture view.
 	 */
 	_generateMipmaps( textureGPU, textureDescriptorGPU, baseArrayLayer = 0 ) {
 
@@ -753,7 +753,7 @@ class WebGPUTextureUtils {
 	 * @private
 	 * @param {GPUTexture} textureGPU - The GPU texture object.
 	 * @param {Object} textureDescriptorGPU - The texture descriptor.
-	 * @param {Number} [originDepth=0] - The origin depth.
+	 * @param {number} [originDepth=0] - The origin depth.
 	 */
 	_flipY( textureGPU, textureDescriptorGPU, originDepth = 0 ) {
 
@@ -768,9 +768,9 @@ class WebGPUTextureUtils {
 	 * @param {Object} image - An object defining the image buffer data.
 	 * @param {GPUTexture} textureGPU - The GPU texture.
 	 * @param {Object} textureDescriptorGPU - The GPU texture descriptor.
-	 * @param {Number} originDepth - The origin depth.
-	 * @param {Boolean} flipY - Whether to flip texture data along their vertical axis or not.
-	 * @param {Number} [depth=0] - TODO.
+	 * @param {number} originDepth - The origin depth.
+	 * @param {boolean} flipY - Whether to flip texture data along their vertical axis or not.
+	 * @param {number} [depth=0] - TODO.
 	 */
 	_copyBufferToTexture( image, textureGPU, textureDescriptorGPU, originDepth, flipY, depth = 0 ) {
 
@@ -869,7 +869,7 @@ class WebGPUTextureUtils {
 	 * data descriptor for the given GPU compressed texture format.
 	 *
 	 * @private
-	 * @param {String} format - The GPU compressed texture format.
+	 * @param {string} format - The GPU compressed texture format.
 	 * @return {Object} The block data descriptor.
 	 */
 	_getBlockData( format ) {
@@ -911,8 +911,8 @@ class WebGPUTextureUtils {
 	 * Converts the three.js uv wrapping constants to GPU address mode constants.
 	 *
 	 * @private
-	 * @param {Number} value - The three.js constant defining a uv wrapping mode.
-	 * @return {String} The GPU address mode.
+	 * @param {number} value - The three.js constant defining a uv wrapping mode.
+	 * @return {string} The GPU address mode.
 	 */
 	_convertAddressMode( value ) {
 
@@ -936,8 +936,8 @@ class WebGPUTextureUtils {
 	 * Converts the three.js filter constants to GPU filter constants.
 	 *
 	 * @private
-	 * @param {Number} value - The three.js constant defining a filter mode.
-	 * @return {String} The GPU filter mode.
+	 * @param {number} value - The three.js constant defining a filter mode.
+	 * @return {string} The GPU filter mode.
 	 */
 	_convertFilterMode( value ) {
 
@@ -957,8 +957,8 @@ class WebGPUTextureUtils {
 	 * Returns the bytes-per-texel value for the given GPU texture format.
 	 *
 	 * @private
-	 * @param {String} format - The GPU texture format.
-	 * @return {Number} The bytes-per-texel.
+	 * @param {string} format - The GPU texture format.
+	 * @return {number} The bytes-per-texel.
 	 */
 	_getBytesPerTexel( format ) {
 
@@ -1020,7 +1020,7 @@ class WebGPUTextureUtils {
 	 * Returns the corresponding typed array type for the given GPU texture format.
 	 *
 	 * @private
-	 * @param {String} format - The GPU texture format.
+	 * @param {string} format - The GPU texture format.
 	 * @return {TypedArray.constructor} The typed array type.
 	 */
 	_getTypedArrayType( format ) {
@@ -1078,7 +1078,7 @@ class WebGPUTextureUtils {
 	 *
 	 * @private
 	 * @param {Texture} texture - The texture.
-	 * @return {String} The GPU dimension.
+	 * @return {string} The GPU dimension.
 	 */
 	_getDimension( texture ) {
 
@@ -1106,7 +1106,7 @@ class WebGPUTextureUtils {
  * @param {Texture} texture - The texture.
  * @param {GPUDevice?} [device=null] - The GPU device which is used for feature detection.
  * It is not necessary to apply the device for most formats.
- * @return {String} The GPU format.
+ * @return {string} The GPU format.
  */
 export function getFormat( texture, device = null ) {
 

--- a/src/renderers/webgpu/utils/WebGPUTimestampQueryPool.js
+++ b/src/renderers/webgpu/utils/WebGPUTimestampQueryPool.js
@@ -13,8 +13,8 @@ class WebGPUTimestampQueryPool extends TimestampQueryPool {
 	 * Creates a new WebGPU timestamp query pool.
 	 *
 	 * @param {GPUDevice} device - The WebGPU device to create queries on.
-	 * @param {String} type - The type identifier for this query pool.
-	 * @param {Number} [maxQueries=2048] - Maximum number of queries this pool can hold.
+	 * @param {string} type - The type identifier for this query pool.
+	 * @param {number} [maxQueries=2048] - Maximum number of queries this pool can hold.
 	 */
 	constructor( device, type, maxQueries = 2048 ) {
 
@@ -47,7 +47,7 @@ class WebGPUTimestampQueryPool extends TimestampQueryPool {
 	 * Allocates a pair of queries for a given render context.
 	 *
 	 * @param {Object} renderContext - The render context to allocate queries for.
-	 * @returns {Number?} The base offset for the allocated queries, or null if allocation failed.
+	 * @returns {number?} The base offset for the allocated queries, or null if allocation failed.
 	 */
 	allocateQueriesForContext( renderContext ) {
 
@@ -73,7 +73,7 @@ class WebGPUTimestampQueryPool extends TimestampQueryPool {
 	 * If there's already a pending resolve operation, returns that promise instead.
 	 *
 	 * @async
-	 * @returns {Promise<Number>} The total duration in milliseconds, or the last valid value if resolution fails.
+	 * @returns {Promise<number>} The total duration in milliseconds, or the last valid value if resolution fails.
 	 */
 	async resolveQueriesAsync() {
 
@@ -109,7 +109,7 @@ class WebGPUTimestampQueryPool extends TimestampQueryPool {
 	 *
 	 * @async
 	 * @private
-	 * @returns {Promise<Number>} The total duration in milliseconds.
+	 * @returns {Promise<number>} The total duration in milliseconds.
 	 */
 	async _resolveQueries() {
 

--- a/src/renderers/webgpu/utils/WebGPUUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUUtils.js
@@ -28,7 +28,7 @@ class WebGPUUtils {
 	 * Returns the depth/stencil GPU format for the given render context.
 	 *
 	 * @param {RenderContext} renderContext - The render context.
-	 * @return {String} The depth/stencil GPU texture format.
+	 * @return {string} The depth/stencil GPU texture format.
 	 */
 	getCurrentDepthStencilFormat( renderContext ) {
 
@@ -56,7 +56,7 @@ class WebGPUUtils {
 	 * Returns the GPU format for the given texture.
 	 *
 	 * @param {Texture} texture - The texture.
-	 * @return {String} The GPU texture format.
+	 * @return {string} The GPU texture format.
 	 */
 	getTextureFormatGPU( texture ) {
 
@@ -104,7 +104,7 @@ class WebGPUUtils {
 	 * Returns the default color attachment's GPU format of the current render context.
 	 *
 	 * @param {RenderContext} renderContext - The render context.
-	 * @return {String} The GPU texture format of the default color attachment.
+	 * @return {string} The GPU texture format of the default color attachment.
 	 */
 	getCurrentColorFormat( renderContext ) {
 
@@ -128,7 +128,7 @@ class WebGPUUtils {
 	 * Returns the output color space of the current render context.
 	 *
 	 * @param {RenderContext} renderContext - The render context.
-	 * @return {String} The output color space.
+	 * @return {string} The output color space.
 	 */
 	getCurrentColorSpace( renderContext ) {
 
@@ -147,7 +147,7 @@ class WebGPUUtils {
 	 *
 	 * @param {Object3D} object - The 3D object.
 	 * @param {Material} material - The material.
-	 * @return {String} The GPU primitive topology.
+	 * @return {string} The GPU primitive topology.
 	 */
 	getPrimitiveTopology( object, material ) {
 
@@ -163,8 +163,8 @@ class WebGPUUtils {
 	 *
 	 * That is required since WebGPU does not support arbitrary sample counts.
 	 *
-	 * @param {Number} sampleCount - The input sample count.
-	 * @return {Number} The (potentially updated) output sample count.
+	 * @param {number} sampleCount - The input sample count.
+	 * @return {number} The (potentially updated) output sample count.
 	 */
 	getSampleCount( sampleCount ) {
 
@@ -191,7 +191,7 @@ class WebGPUUtils {
 	 * Returns the sample count of the given render context.
 	 *
 	 * @param {RenderContext} renderContext - The render context.
-	 * @return {Number} The sample count.
+	 * @return {number} The sample count.
 	 */
 	getSampleCountRenderContext( renderContext ) {
 
@@ -211,7 +211,7 @@ class WebGPUUtils {
 	 * There is a separate method for this so it's possible to
 	 * honor edge cases for specific devices.
 	 *
-	 * @return {String} The GPU texture format of the canvas.
+	 * @return {string} The GPU texture format of the canvas.
 	 */
 	getPreferredCanvasFormat() {
 


### PR DESCRIPTION
Related issue: #30445

**Description**

This PR ensures `string`, `number`, `boolean` and `any` are not capitalized in JSDoc anymore.
