### PR TITLE
WebGPUBackend: Add support for `setStencilReference()`.

### DIFF
--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -1080,7 +1080,7 @@ class WebGPUBackend extends Backend {
 	 */
 	draw( renderObject, info ) {
 
-		const { object, context, pipeline } = renderObject;
+		const { object, material, context, pipeline } = renderObject;
 		const bindings = renderObject.getBindings();
 		const renderContextData = this.get( context );
 		const pipelineGPU = this.get( pipeline ).pipeline;
@@ -1186,6 +1186,14 @@ class WebGPUBackend extends Backend {
 				renderContextData.lastOcclusionObject = object;
 
 			}
+
+		}
+
+		// stencil
+
+		if ( context.stencil === true && material.stencilWrite === true ) {
+
+			passEncoderGPU.setStencilReference( material.stencilRef );
 
 		}
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -1191,9 +1191,10 @@ class WebGPUBackend extends Backend {
 
 		// stencil
 
-		if ( context.stencil === true && material.stencilWrite === true ) {
+		if ( context.stencil === true && material.stencilWrite === true && renderContextData.currentStencilRef !== material.stencilRef ) {
 
 			passEncoderGPU.setStencilReference( material.stencilRef );
+			renderContextData.currentStencilRef = material.stencilRef;
 
 		}
 


### PR DESCRIPTION
Fixed #30469.

**Description**

The PR makes sure `WebGPUBackend` uses the `stencilRef` value of the current material to call [setStencilReference()](https://www.w3.org/TR/webgpu/#dom-gpurenderpassencoder-setstencilreference).
