### PR TITLE
SelectionHelper: ensure DOM cleanup

### DIFF
--- a/examples/jsm/interactive/SelectionHelper.js
+++ b/examples/jsm/interactive/SelectionHelper.js
@@ -59,6 +59,8 @@ class SelectionHelper {
 		this.renderer.domElement.removeEventListener( 'pointermove', this.onPointerMove );
 		this.renderer.domElement.removeEventListener( 'pointerup', this.onPointerUp );
 
+		this.element.remove(); // in case disposal happens while dragging
+
 	}
 
 	onSelectStart( event ) {

--- a/examples/jsm/interactive/SelectionHelper.js
+++ b/examples/jsm/interactive/SelectionHelper.js
@@ -97,7 +97,7 @@ class SelectionHelper {
 
 	onSelectOver() {
 
-		this.element.parentElement.removeChild( this.element );
+		this.element.remove();
 
 	}
 


### PR DESCRIPTION


**Description**

Ensure DOM is cleaned up in case `SelectionHelper.dispose()` is called during an incomplete dragging operation.

Example scenario: if a view changes to another view and the selection should no longer apply, we don't want the selection rectangle to remain leaked on screen.

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Lume (3D HTML framework)](https://lume.io)*
