### PR TITLE
WebGPURenderer: Fix info metrics.

### DIFF
--- a/src/renderers/webgl-fallback/WebGLBufferRenderer.js
+++ b/src/renderers/webgl-fallback/WebGLBufferRenderer.js
@@ -26,7 +26,7 @@ class WebGLBufferRenderer {
 
 		}
 
-		info.update( object, count, mode, 1 );
+		info.update( object, count, 1 );
 
 	}
 
@@ -46,7 +46,7 @@ class WebGLBufferRenderer {
 
 		}
 
-		info.update( object, count, mode, primcount );
+		info.update( object, count, primcount );
 
 	}
 
@@ -85,7 +85,7 @@ class WebGLBufferRenderer {
 
 			}
 
-			info.update( object, elementCount, mode, 1 );
+			info.update( object, elementCount, 1 );
 
 		}
 
@@ -126,7 +126,7 @@ class WebGLBufferRenderer {
 
 			}
 
-			info.update( object, elementCount, mode, 1 );
+			info.update( object, elementCount, 1 );
 
 		}
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -1224,6 +1224,8 @@ class WebGPUBackend extends Backend {
 
 					}
 
+					info.update( object, counts[ i ], count );
+
 				}
 
 			} else if ( hasIndex === true ) {


### PR DESCRIPTION
Fixed #29488.

**Description**

The triangles rendered by `BatchedMesh` are now correctly reported for both the WebGPU and WebGL backend.

`WebGLBufferRenderer` used the `Info.update()` in the wrong way by default. The method has three parameters, not four.
