### PR TITLE
WebGPURenderer: Fix color space of clear colors.

### DIFF
--- a/src/renderers/common/Backend.js
+++ b/src/renderers/common/Backend.js
@@ -557,7 +557,7 @@ class Backend {
 
 		renderer.getClearColor( _color4 );
 
-		_color4.getRGB( _color4, this.renderer.currentColorSpace );
+		_color4.getRGB( _color4 );
 
 		return _color4;
 

--- a/src/renderers/common/Background.js
+++ b/src/renderers/common/Background.js
@@ -5,7 +5,7 @@ import NodeMaterial from '../../materials/nodes/NodeMaterial.js';
 
 import { Mesh } from '../../objects/Mesh.js';
 import { SphereGeometry } from '../../geometries/SphereGeometry.js';
-import { BackSide, LinearSRGBColorSpace } from '../../constants.js';
+import { BackSide } from '../../constants.js';
 
 const _clearColor = /*@__PURE__*/ new Color4();
 
@@ -64,14 +64,14 @@ class Background extends DataMap {
 
 			// no background settings, use clear color configuration from the renderer
 
-			renderer._clearColor.getRGB( _clearColor, LinearSRGBColorSpace );
+			renderer._clearColor.getRGB( _clearColor );
 			_clearColor.a = renderer._clearColor.a;
 
 		} else if ( background.isColor === true ) {
 
 			// background is an opaque color
 
-			background.getRGB( _clearColor, LinearSRGBColorSpace );
+			background.getRGB( _clearColor );
 			_clearColor.a = 1;
 
 			forceClear = true;


### PR DESCRIPTION
Follow-up of #30485.

**Description**

`Backend.getClearColor()` must return the color in working color space.
