### PR TITLE
3MFLoader: Fix parsing of assets with sub models.

### DIFF
--- a/examples/jsm/loaders/3MFLoader.js
+++ b/examples/jsm/loaders/3MFLoader.js
@@ -135,12 +135,12 @@ class ThreeMFLoader extends Loader {
 					modelRelsName = file;
 
 				} else if ( file.match( /^3D\/[^\/]*\.model$/ ) ) {
-					// root model
+
 					rootModelFile = file ;
 
 				} else if ( file.match( /^3D\/.*\/.*\.model$/ ) ) {
-					// sub models
-					modelPartNames.push( file );
+
+					modelPartNames.push( file ); // sub models
 
 				} else if ( file.match( /^3D\/Textures?\/.*/ ) ) {
 
@@ -150,7 +150,7 @@ class ThreeMFLoader extends Loader {
 
 			}
 
-			modelPartNames.push(rootModelFile);
+			modelPartNames.push( rootModelFile ); // push root model at the end so it is processed after the sub models
 
 			if ( relsName === undefined ) throw new Error( 'THREE.ThreeMFLoader: Cannot find relationship file `rels` in 3MF archive.' );
 

--- a/examples/jsm/loaders/3MFLoader.js
+++ b/examples/jsm/loaders/3MFLoader.js
@@ -1468,7 +1468,7 @@ class ThreeMFLoader extends Loader {
 			const modelsData = data3mf.model;
 			const modelRels = data3mf.modelRels;
 			const objects = {};
-			const modelsKeys = Object.keys( modelsData );
+			const modelsKeys = Object.keys( modelsData ).reverse();
 			const textureData = {};
 
 			// evaluate model relationships to textures

--- a/examples/jsm/loaders/3MFLoader.js
+++ b/examples/jsm/loaders/3MFLoader.js
@@ -122,6 +122,8 @@ class ThreeMFLoader extends Loader {
 
 			}
 
+			let rootModelFile = null;
+
 			for ( file in zip ) {
 
 				if ( file.match( /\_rels\/.rels$/ ) ) {
@@ -132,8 +134,12 @@ class ThreeMFLoader extends Loader {
 
 					modelRelsName = file;
 
-				} else if ( file.match( /^3D\/.*\.model$/ ) ) {
+				} else if ( file.match( /^3D\/[^\/]*\.model$/ ) ) {
+					// root model
+					rootModelFile = file ;
 
+				} else if ( file.match( /^3D\/.*\/.*\.model$/ ) ) {
+					// sub models
 					modelPartNames.push( file );
 
 				} else if ( file.match( /^3D\/Textures?\/.*/ ) ) {
@@ -143,6 +149,8 @@ class ThreeMFLoader extends Loader {
 				}
 
 			}
+
+			modelPartNames.push(rootModelFile);
 
 			if ( relsName === undefined ) throw new Error( 'THREE.ThreeMFLoader: Cannot find relationship file `rels` in 3MF archive.' );
 
@@ -1468,7 +1476,7 @@ class ThreeMFLoader extends Loader {
 			const modelsData = data3mf.model;
 			const modelRels = data3mf.modelRels;
 			const objects = {};
-			const modelsKeys = Object.keys( modelsData ).reverse();
+			const modelsKeys = Object.keys( modelsData );
 			const textureData = {};
 
 			// evaluate model relationships to textures


### PR DESCRIPTION
Related issue: #30174

**Description**

Some 3MF files with with [production extension](https://github.com/3MFConsortium/spec_production/blob/master/3MF%20Production%20Extension.md) would not load as the root model can contain a path key used to reference a models outside the current file (still in the 3MF archive)

Only the root model can contain these references so reversing the build order is a simple fix for this.
Ref (Chapter 2): `Further, only a component element in the root model file MAY contain a path attribute. Non-root model file components MUST only reference objects in the same model file.`

There are models with the extension to test in the related issue, I also tested models without and they were unaffected.