### PR TITLE
WebGPURenderer: Honor `polygonOffset` with WebGPU backend.

### DIFF
--- a/src/renderers/webgpu/utils/WebGPUPipelineUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUPipelineUtils.js
@@ -188,6 +188,14 @@ class WebGPUPipelineUtils {
 
 			}
 
+			if ( material.polygonOffset === true ) {
+
+				depthStencil.depthBias = material.polygonOffsetUnits;
+				depthStencil.depthBiasSlopeScale = material.polygonOffsetFactor;
+				depthStencil.depthBiasClamp = 0; // three.js does not provide an API to configure this value
+
+			}
+
 			pipelineDescriptor.depthStencil = depthStencil;
 
 		}


### PR DESCRIPTION
Fixed #30494.

**Description**

The PR adds `Material.polygonOffset` support to the WebGPU backend. The WebGL backend already supports it.

Note: The semantics of `polygonOffset` in WebGPU are different than in WebGL. When understanding the specs correctly, `polygonOffsetUnits` should be mapped to `depthBias` and `polygonOffsetFactor` to `depthBiasSlopeScale`. It seems that makes the most sense.

WebGPU: https://www.w3.org/TR/webgpu/#dom-gpudepthstencilstate-depthbias
WebGL: https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/polygonOffset

@AndrewChan2022 Would this work for you?