### PR TITLE
XRManager: Simplify MSAA setup.

### DIFF
--- a/src/renderers/common/XRManager.js
+++ b/src/renderers/common/XRManager.js
@@ -619,8 +619,7 @@ class XRManager extends EventDispatcher {
 						type: UnsignedByteType,
 						colorSpace: renderer.outputColorSpace,
 						depthTexture: new DepthTexture( glProjLayer.textureWidth, glProjLayer.textureHeight, depthType, undefined, undefined, undefined, undefined, undefined, undefined, depthFormat ),
-						stencilBuffer: renderer.stencil,
-						samples: renderer.samples
+						stencilBuffer: renderer.stencil
 					} );
 
 				this._xrRenderTarget.hasExternalTextures = true;


### PR DESCRIPTION
Related issue: #30459

**Description**

Since #30459 XR uses an intermediate framebuffer target which means the XR render target (or the output target) does not require MSAA.