### PR TITLE
Add PointerControls

### DIFF
--- a/examples/jsm/Addons.js
+++ b/examples/jsm/Addons.js
@@ -12,6 +12,7 @@ export * from './controls/OrbitControls.js';
 export * from './controls/PointerLockControls.js';
 export * from './controls/TrackballControls.js';
 export * from './controls/TransformControls.js';
+export * from './controls/PointerControls.js';
 
 export * from './csm/CSM.js';
 export * from './csm/CSMFrustum.js';

--- a/examples/jsm/controls/PointerControls.js
+++ b/examples/jsm/controls/PointerControls.js
@@ -1,0 +1,126 @@
+import {
+    EventDispatcher,
+    Plane,
+    Raycaster,
+    Vector2,
+    Vector3
+} from 'three';
+class PointerControls extends EventDispatcher {
+    #__cache__
+    constructor(objects, camera, domElement) {
+        super();
+        this.#__cache__={
+            plane : new Plane(),
+            raycaster : new Raycaster(),
+            pointer : new Vector2(),
+            previousPointer : new Vector2(),
+            worldPosition : new Vector3(),
+            hovered : null,
+            selected : null,
+            intersections : []
+        }
+        this.objects = objects;
+        this.camera = camera;
+        this.domElement = domElement;
+        this.domElement.style.touchAction = 'none'; 
+        this.enabled = true;
+        this.recursive = true;
+        this.transformGroup = false;
+        this.activate();
+    }
+    activate() {
+        this.domElement.addEventListener('pointermove', this.#onPointerMove.bind(this));
+        this.domElement.addEventListener('pointerdown', this.#onPointerDown.bind(this));
+        this.domElement.addEventListener('pointerup', this.#onPointerCancel.bind(this));
+        this.domElement.addEventListener('pointerleave', this.#onPointerCancel.bind(this));
+    }
+    deactivate() {
+        this.domElement.removeEventListener('pointermove', this.#onPointerMove.bind(this));
+        this.domElement.removeEventListener('pointerdown', this.#onPointerDown.bind(this));
+        this.domElement.removeEventListener('pointerup', this.#onPointerCancel.bind(this));
+        this.domElement.removeEventListener('pointerleave', this.#onPointerCancel.bind(this));
+        this.domElement.style.cursor = '';
+    }
+    dispose() {
+        this.deactivate();
+    }
+    getObjects() {
+        return this.objects;
+    }
+    setObjects(objects) {
+        this.objects = objects;
+    }
+    #onPointerMove(event) {
+        if (this.enabled === false) return;
+        this.#updatePointer(event);
+        this.#__cache__.raycaster.setFromCamera(this.#__cache__.pointer, this.camera);
+        if(!this.#__cache__.selected) {
+            if (event.pointerType === 'mouse' || event.pointerType === 'pen') {
+                this.#__cache__.intersections.length = 0;
+                this.#__cache__.raycaster.setFromCamera(this.#__cache__.pointer, this.camera);
+                this.#__cache__.raycaster.intersectObjects(this.objects, this.recursive, this.#__cache__.intersections);
+                if (this.#__cache__.intersections.length > 0) {
+                    const object = this.#__cache__.intersections[0].object;
+                    this.#__cache__.plane.setFromNormalAndCoplanarPoint(
+                        this.camera.getWorldDirection(this.#__cache__.plane.normal),
+                        this.#__cache__.worldPosition.setFromMatrixPosition(object.matrixWorld)
+                    );
+                    if (this.#__cache__.hovered !== object && this.#__cache__.hovered !== null) {
+                        this.dispatchEvent({ type: 'hoveroff', object: this.#__cache__.hovered });
+                        this.domElement.style.cursor = 'auto';
+                        this.#__cache__.hovered = null;
+                    }
+                    if (this.#__cache__.hovered !== object) {
+                        this.dispatchEvent({ type: 'hoveron', object: object });
+                        this.domElement.style.cursor = 'pointer';
+                        this.#__cache__.hovered = object;
+                    }
+                } else {
+                    if (this.#__cache__.hovered !== null) {
+                        this.dispatchEvent({ type: 'hoveroff', object: this.#__cache__.hovered });
+                        this.domElement.style.cursor = 'auto';
+                        this.#__cache__.hovered = null;
+                    }
+                }
+            }
+        }
+        this.#__cache__.previousPointer.copy(this.#__cache__.pointer);
+    }
+    #onPointerDown(event) {
+        if (this.enabled === false) return;
+        this.#updatePointer(event);
+        this.#__cache__.intersections.length = 0;
+        this.#__cache__.raycaster.setFromCamera(this.#__cache__.pointer, this.camera);
+        this.#__cache__.raycaster.intersectObjects(this.objects, this.recursive, this.#__cache__.intersections);
+        if (this.#__cache__.intersections.length > 0) {
+            if (this.transformGroup === true) {
+                this.#__cache__.selected = this.#findGroup(this.#__cache__.intersections[0].object);
+            } else {
+                this.#__cache__.selected = this.#__cache__.intersections[0].object;
+            }
+            this.domElement.style.cursor = 'move';
+            this.dispatchEvent({ type: 'click', object: this.#__cache__.selected });
+        }
+        this.#__cache__.previousPointer.copy(this.#__cache__.pointer);
+    }
+    #onPointerCancel() {
+        if (this.enabled === false) return;
+        if (this.#__cache__.selected) {
+            this.dispatchEvent({ type: 'pointerup', object: this.#__cache__.selected });
+            this.#__cache__.selected = null;
+        }
+        this.domElement.style.cursor = this.#__cache__.hovered ? 'pointer' : 'auto';
+    }
+    #updatePointer(event) {
+        const rect = this.domElement.getBoundingClientRect();
+        this.#__cache__.pointer.x = (event.clientX - rect.left) / rect.width * 2 - 1;
+        this.#__cache__.pointer.y = - (event.clientY - rect.top) / rect.height * 2 + 1;
+    }
+    #findGroup(obj, group = null) {
+        if (obj.isGroup) group = obj;
+        if (obj.parent === null) return group;
+        return this.#findGroup(obj.parent, group);
+    }
+}
+
+export { PointerControls };

--- a/examples/misc_controls_pointer.html
+++ b/examples/misc_controls_pointer.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>three.js webgl - pointer controls</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<link type="text/css" rel="stylesheet" href="main.css">
+		<style>
+			body {
+				background-color: #ccc;
+				color: #000;
+			}
+
+			a {
+				color: #f00;
+			}
+		</style>
+	</head>
+
+	<body>
+		<div id="info">
+			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> - pointer controls
+		</div>
+
+		<script type="importmap">
+			{
+				"imports": {
+					"three": "../build/three.module.js",
+					"three/addons/": "./jsm/"
+				}
+			}
+		</script>
+
+		<script type="module">
+
+			import * as THREE from 'three';
+
+			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+            import { TransformControls } from 'three/addons/controls/TransformControls.js';
+            import { PointerControls } from 'three/addons/controls/PointerControls.js'
+
+			let camera, orbit, transform, pointer, scene, renderer;
+
+			init();
+			render();
+
+			function init() {
+
+				scene = new THREE.Scene();
+				scene.background = new THREE.Color( 0xcccccc );
+				scene.fog = new THREE.FogExp2( 0xcccccc, 0.002 );
+
+				renderer = new THREE.WebGLRenderer( { antialias: true } );
+				renderer.setPixelRatio( window.devicePixelRatio );
+				renderer.setSize( window.innerWidth, window.innerHeight );
+				document.body.appendChild( renderer.domElement );
+
+				camera = new THREE.PerspectiveCamera( 60, window.innerWidth / window.innerHeight, 1, 1000 );
+				camera.position.set( 400, 200, 0 );
+
+				// Orbit controls
+
+				orbit = new OrbitControls( camera, renderer.domElement );
+                orbit.update();
+				orbit.addEventListener( 'change', render );
+				// world
+                const objects = []
+				const geometry = new THREE.BoxGeometry( 20, 20, 20 );
+				const material = new THREE.MeshPhongMaterial( { color: 0x7777aa, flatShading: true } );
+				for ( let i = -10; i < 10; i ++ ) {
+                    for( let j = -10 ; j <10 ; j ++){
+                        const mesh = new THREE.Mesh( geometry, material );
+                        mesh.position.x = Math.random() * 1200 - 600;
+                        mesh.position.y = Math.random() * 1200 - 600;
+                        mesh.position.z = Math.random() * 1200 - 600;
+                        mesh.updateMatrix();
+                        mesh.matrixAutoUpdate = false;
+                        objects.push( mesh );
+                        scene.add( mesh );
+                    }
+
+				}
+
+                // Select Object to Translate  
+                transform = new TransformControls(camera, renderer.domElement);
+                transform.addEventListener( 'change', render );
+				transform.addEventListener( 'dragging-changed', function ( event ) {
+					orbit.enabled = ! event.value;
+				} );
+                scene.add( transform );
+                pointer = new PointerControls(objects, camera, renderer.domElement);
+                pointer.addEventListener("hoveron", e=> {
+                    e.object.matrixAutoUpdate = true;
+                    transform.attach(e.object);
+                })
+
+				// lights
+
+				const dirLight1 = new THREE.DirectionalLight( 0xffffff, 10 );
+				dirLight1.position.set( 1, 1, 1 );
+				scene.add( dirLight1 );
+
+				const dirLight2 = new THREE.DirectionalLight( 0x002288, 3 );
+				dirLight2.position.set( - 1, - 1, - 1 );
+				scene.add( dirLight2 );
+
+				const ambientLight = new THREE.AmbientLight( 0x555555 );
+				scene.add( ambientLight );
+
+				window.addEventListener( 'resize', onWindowResize );
+
+			}
+
+			function onWindowResize() {
+
+				camera.aspect = window.innerWidth / window.innerHeight;
+				camera.updateProjectionMatrix();
+
+				renderer.setSize( window.innerWidth, window.innerHeight );
+
+			}
+			function render() {
+				renderer.render( scene, camera );
+
+			}
+		</script>
+
+	</body>
+</html>


### PR DESCRIPTION
I’m currently working on [***Ziko-gl***](https://github.com/zakarialaoui10/ziko-gl), an addon for [***Ziko.js***](https://github.com/zakarialaoui10/ziko.js) built on top of [***Three.js***](https://threejs.org/), and I’ve added PointerControls to it. Now, I’m considering integrating it into the core library.

PointerControls is used to enable interaction with 3D objects in the scene by detecting pointer events such as hoveron, hoveroff, click, and pointerup. These events allow you to interact with objects by hovering over them, clicking on them, or releasing the pointer