### PR TITLE
PMREMNode: Manage own generator, fix caching.

### DIFF
--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -22,8 +22,6 @@ import { getCurrentStack, setCurrentStack } from '../tsl/TSLBase.js';
 import CubeRenderTarget from '../../renderers/common/CubeRenderTarget.js';
 import ChainMap from '../../renderers/common/ChainMap.js';
 
-import PMREMGenerator from '../../renderers/common/extras/PMREMGenerator.js';
-
 import BindGroup from '../../renderers/common/BindGroup.js';
 
 import { REVISION, IntType, UnsignedIntType, LinearFilter, LinearMipmapNearestFilter, NearestMipmapLinearFilter, LinearMipmapLinearFilter } from '../../constants.js';
@@ -469,19 +467,6 @@ class NodeBuilder {
 	createCubeRenderTarget( size, options ) {
 
 		return new CubeRenderTarget( size, options );
-
-	}
-
-	/**
-	 * Factory method for creating an instance of {@link PMREMGenerator}.
-	 *
-	 * @return {PMREMGenerator} The PMREM generator.
-	 */
-	createPMREMGenerator() {
-
-		// TODO: Move Materials.js to outside of the Nodes.js in order to remove this function and improve tree-shaking support
-
-		return new PMREMGenerator( this.renderer );
 
 	}
 

--- a/src/nodes/pmrem/PMREMNode.js
+++ b/src/nodes/pmrem/PMREMNode.js
@@ -287,14 +287,6 @@ class PMREMNode extends TempNode {
 
 		//
 
-		const texture = this.value;
-
-		if ( builder.renderer.coordinateSystem === WebGLCoordinateSystem && texture.isPMREMTexture !== true && texture.isRenderTargetTexture === true ) {
-
-			uvNode = vec3( uvNode.x.negate(), uvNode.yz );
-
-		}
-
 		uvNode = vec3( uvNode.x, uvNode.y.negate(), uvNode.z );
 
 		//

--- a/src/nodes/pmrem/PMREMNode.js
+++ b/src/nodes/pmrem/PMREMNode.js
@@ -7,7 +7,7 @@ import { nodeProxy, vec3 } from '../tsl/TSLBase.js';
 
 import { WebGLCoordinateSystem } from '../../constants.js';
 import { Texture } from '../../textures/Texture.js';
-import { PMREMGenerator } from '../../renderers/common/extras/PMREMGenerator.js';
+import PMREMGenerator from '../../renderers/common/extras/PMREMGenerator.js';
 
 const _cache = new WeakMap();
 
@@ -191,14 +191,6 @@ class PMREMNode extends TempNode {
 		this._maxMip = uniform( 0 );
 
 		/**
-		 * A reference to a PMREM generator that can be globally used for generating PMREMs.
-		 *
-		 * @type {?PMREMGenerator}
-		 * @default null
-		 */
-		this._generator = null;
-
-		/**
 		 * The `updateBeforeType` is set to `NodeUpdateType.RENDER`.
 		 *
 		 * @type {string}
@@ -275,9 +267,9 @@ class PMREMNode extends TempNode {
 
 	setup( builder ) {
 
-		if ( this._pmremGenerator === null ) {
+		if ( this._generator === null ) {
 
-			this._pmremGenerator = new PMREMGenerator( builder.renderer );
+			this._generator = new PMREMGenerator( builder.renderer );
 
 		}
 

--- a/src/nodes/pmrem/PMREMNode.js
+++ b/src/nodes/pmrem/PMREMNode.js
@@ -5,7 +5,6 @@ import { uniform } from '../core/UniformNode.js';
 import { NodeUpdateType } from '../core/constants.js';
 import { nodeProxy, vec3 } from '../tsl/TSLBase.js';
 
-import { WebGLCoordinateSystem } from '../../constants.js';
 import { Texture } from '../../textures/Texture.js';
 import PMREMGenerator from '../../renderers/common/extras/PMREMGenerator.js';
 


### PR DESCRIPTION
Fixed #30503.

**Description**

~~Managing a global instance of `PMREMGenerator` in the renderer solves issues when more than one renderer is used in a multi-canvas setup.~~

I have updated the PR since integrating `PMREMGenerator` in the renderer is bad for tree-shaking. Since there are usually not many `PMREMNode` instances per scene it should be safe when each node manages its own generator.