### PR TITLE
Jsdoc: enable eslint rule valid-jsdoc.preferType

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -72,7 +72,14 @@
         "requireReturnType": true,
         "requireParamDescription": false,
         "requireReturnDescription": false,
-        "requireParamType": true
+        "requireParamType": true,
+        "preferType": {
+          "Any": "any",
+          "Boolean": "boolean",
+          "Number": "number",
+          "object": "Object",
+          "String": "string"
+        }
       }
     ]
   }

--- a/editor/js/commands/AddScriptCommand.js
+++ b/editor/js/commands/AddScriptCommand.js
@@ -5,7 +5,7 @@ class AddScriptCommand extends Command {
 	/**
 	 * @param {Editor} editor
 	 * @param {THREE.Object3D|null} [object=null]
-	 * @param {String} [script='']
+	 * @param {string} [script='']
 	 * @constructor
 	 */
 	constructor( editor, object = null, script = '' ) {

--- a/editor/js/commands/RemoveScriptCommand.js
+++ b/editor/js/commands/RemoveScriptCommand.js
@@ -5,7 +5,7 @@ class RemoveScriptCommand extends Command {
 	/**
 	 * @param {Editor} editor
 	 * @param {THREE.Object3D|null} [object=null]
-	 * @param {String} [script='']
+	 * @param {string} [script='']
 	 * @constructor
 	 */
 	constructor( editor, object = null, script = '' ) {

--- a/editor/js/commands/SetColorCommand.js
+++ b/editor/js/commands/SetColorCommand.js
@@ -5,8 +5,8 @@ class SetColorCommand extends Command {
 	/**
 	 * @param {Editor} editor
 	 * @param {THREE.Object3D|null} [object=null]
-	 * @param {String} attributeName
-	 * @param {Number|null} [newValue=null] Integer representing a hex color value
+	 * @param {string} attributeName
+	 * @param {?number} [newValue=null] Integer representing a hex color value
 	 * @constructor
 	 */
 	constructor( editor, object = null, attributeName = '', newValue = null ) {

--- a/editor/js/commands/SetGeometryValueCommand.js
+++ b/editor/js/commands/SetGeometryValueCommand.js
@@ -5,8 +5,8 @@ class SetGeometryValueCommand extends Command {
 	/**
 	 * @param {Editor} editor
 	 * @param {THREE.Object3D|null} [object=null]
-	 * @param {String} [attributeName='']
-	 * @param {Number|String|Boolean|Object|null} [newValue=null]
+	 * @param {string} [attributeName='']
+	 * @param {number|string|boolean|Object|null} [newValue=null]
 	 * @constructor
 	 */
 	constructor( editor, object = null, attributeName = '', newValue = null ) {

--- a/editor/js/commands/SetMaterialColorCommand.js
+++ b/editor/js/commands/SetMaterialColorCommand.js
@@ -5,9 +5,9 @@ class SetMaterialColorCommand extends Command {
 	/**
 	 * @param {Editor} editor
 	 * @param {THREE.Object3D|null} [object=null]
-	 * @param {String} attributeName
-	 * @param {Number|null} [newValue=null] Integer representing a hex color value
-	 * @param {Number} [materialSlot=-1]
+	 * @param {string} attributeName
+	 * @param {?number} [newValue=null] Integer representing a hex color value
+	 * @param {number} [materialSlot=-1]
 	 * @constructor
 	 */
 	constructor( editor, object = null, attributeName = '', newValue = null, materialSlot = - 1 ) {

--- a/editor/js/commands/SetMaterialCommand.js
+++ b/editor/js/commands/SetMaterialCommand.js
@@ -7,7 +7,7 @@ class SetMaterialCommand extends Command {
 	 * @param {Editor} editor
 	 * @param {THREE.Object3D|null} object
 	 * @param {THREE.Material|null} newMaterial
-	 * @param {Number} [materialSlot=-1]
+	 * @param {number} [materialSlot=-1]
 	 * @constructor
 	 */
 	constructor( editor, object = null, newMaterial = null, materialSlot = - 1 ) {

--- a/editor/js/commands/SetMaterialMapCommand.js
+++ b/editor/js/commands/SetMaterialMapCommand.js
@@ -6,9 +6,9 @@ class SetMaterialMapCommand extends Command {
 	/**
 	 * @param {Editor} editor
 	 * @param {THREE.Object3D|null} [object=null]
-	 * @param {String} [mapName='']
+	 * @param {string} [mapName='']
 	 * @param {THREE.Texture|null} [newMap=null]
-	 * @param {Number} [materialSlot=-1]
+	 * @param {number} [materialSlot=-1]
 	 * @constructor
 	 */
 	constructor( editor, object = null, mapName = '', newMap = null, materialSlot = - 1 ) {

--- a/editor/js/commands/SetMaterialRangeCommand.js
+++ b/editor/js/commands/SetMaterialRangeCommand.js
@@ -5,10 +5,10 @@ class SetMaterialRangeCommand extends Command {
 	/**
 	 * @param {Editor} editor
 	 * @param {THREE.Object3D|null} [object=null]
-	 * @param {String} [attributeName='']
-	 * @param {Number} [newMinValue=-Infinity]
-	 * @param {Number} [newMaxValue=Infinity]
-	 * @param {Number} [materialSlot=-1]
+	 * @param {string} [attributeName='']
+	 * @param {number} [newMinValue=-Infinity]
+	 * @param {number} [newMaxValue=Infinity]
+	 * @param {number} [materialSlot=-1]
 	 * @constructor
 	 */
 	constructor( editor, object = null, attributeName = '', newMinValue = - Infinity, newMaxValue = Infinity, materialSlot = - 1 ) {

--- a/editor/js/commands/SetMaterialValueCommand.js
+++ b/editor/js/commands/SetMaterialValueCommand.js
@@ -5,9 +5,9 @@ class SetMaterialValueCommand extends Command {
 	/**
 	 * @param {Editor} editor
 	 * @param {THREE.Object3D|null} [object=null]
-	 * @param {String} [attributeName='']
-	 * @param {Number|String|Boolean|Object|null} [newValue=null]
-	 * @param {Number} [materialSlot=-1]
+	 * @param {string} [attributeName='']
+	 * @param {number|string|boolean|Object|null} [newValue=null]
+	 * @param {number} [materialSlot=-1]
 	 * @constructor
 	 */
 	constructor( editor, object = null, attributeName = '', newValue = null, materialSlot = - 1 ) {

--- a/editor/js/commands/SetMaterialVectorCommand.js
+++ b/editor/js/commands/SetMaterialVectorCommand.js
@@ -6,9 +6,9 @@ class SetMaterialVectorCommand extends Command {
 	 *
 	 * @param {Editor} editor
 	 * @param {THREE.Object3D|null} [object=null]
-	 * @param {String} [attributeName='']
+	 * @param {string} [attributeName='']
 	 * @param {THREE.Vector2|THREE.Vector3|THREE.Vector4|null} [newValue=null]
-	 * @param {Number} [materialSlot=-1]
+	 * @param {number} [materialSlot=-1]
 	 * @constructor
 	 */
 	constructor( editor, object = null, attributeName = '', newValue = null, materialSlot = - 1 ) {

--- a/editor/js/commands/SetScriptValueCommand.js
+++ b/editor/js/commands/SetScriptValueCommand.js
@@ -5,9 +5,9 @@ class SetScriptValueCommand extends Command {
 	/**
 	 * @param {Editor} editor
 	 * @param {THREE.Object3D|null} object
-	 * @param {String} script
-	 * @param {String} attributeName
-	 * @param {String} newValue
+	 * @param {string} script
+	 * @param {string} attributeName
+	 * @param {string} newValue
 	 * @constructor
 	 */
 	constructor( editor, object = null, script = '', attributeName = '', newValue = null ) {

--- a/editor/js/commands/SetShadowValueCommand.js
+++ b/editor/js/commands/SetShadowValueCommand.js
@@ -5,8 +5,8 @@ class SetShadowValueCommand extends Command {
 	/**
 	 * @param {Editor} editor
 	 * @param {THREE.Object3D|null} object
-	 * @param {String} attributeName
-	 * @param {Number|String|Boolean|Object|null} newValue
+	 * @param {string} attributeName
+	 * @param {number|string|boolean|Object|null} newValue
 	 * @constructor
 	 */
 	constructor( editor, object = null, attributeName = '', newValue = null ) {

--- a/editor/js/commands/SetValueCommand.js
+++ b/editor/js/commands/SetValueCommand.js
@@ -6,7 +6,7 @@ class SetValueCommand extends Command {
 	 * @param {Editor} editor
 	 * @param {THREE.Object3D|null} object
 	 * @param {string} attributeName
-	 * @param {Number|String|Boolean|Object|null} newValue
+	 * @param {number|string|boolean|Object|null} newValue
 	 * @constructor
 	 */
 	constructor( editor, object = null, attributeName = '', newValue = null ) {

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -1486,7 +1486,7 @@ class GLTFWriter {
 	/**
 	 * Process material
 	 * @param  {THREE.Material} material Material to process
-	 * @return {Promise<Number|null>} Index of the processed material in the "materials" array
+	 * @return {Promise<number|null>} Index of the processed material in the "materials" array
 	 */
 	async processMaterialAsync( material ) {
 
@@ -1662,7 +1662,7 @@ class GLTFWriter {
 	/**
 	 * Process mesh
 	 * @param  {THREE.Mesh} mesh Mesh to process
-	 * @return {Promise<Number|null>} Index of the processed mesh in the "meshes" array
+	 * @return {Promise<number|null>} Index of the processed mesh in the "meshes" array
 	 */
 	async processMeshAsync( mesh ) {
 

--- a/examples/jsm/loaders/3MFLoader.js
+++ b/examples/jsm/loaders/3MFLoader.js
@@ -136,7 +136,7 @@ class ThreeMFLoader extends Loader {
 
 				} else if ( file.match( /^3D\/[^\/]*\.model$/ ) ) {
 
-					rootModelFile = file ;
+					rootModelFile = file;
 
 				} else if ( file.match( /^3D\/.*\/.*\.model$/ ) ) {
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2254,7 +2254,7 @@ const ALPHA_MODES = {
 /**
  * Specification: https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md#default-material
  *
- * @param {Object<String, Material>} cache
+ * @param {Object<string, Material>} cache
  * @return {Material}
  */
 function createDefaultMaterial( cache ) {

--- a/examples/jsm/tsl/utils/Raymarching.js
+++ b/examples/jsm/tsl/utils/Raymarching.js
@@ -31,7 +31,7 @@ const hitBox = /*@__PURE__*/ Fn( ( { orig, dir } ) => {
  *
  * @tsl
  * @function
- * @param {Number|Node} steps - The number of steps for raymarching.
+ * @param {number|Node} steps - The number of steps for raymarching.
  * @param {Function|FunctionNode} callback - The callback function to execute at each step.
  * @returns {void}
  */
@@ -71,10 +71,10 @@ export const RaymarchingBox = ( steps, callback ) => {
  * @function
  * @param {Object} params - The parameters for the function.
  * @param {Texture|Node} params.texture - The 3D texture to sample.
- * @param {Number|Node} [params.range=0.1] - The range for the smoothstep function.
- * @param {Number|Node} [params.threshold=0.25] - The threshold for the smoothstep function.
- * @param {Number|Node} [params.opacity=0.25] - The opacity value for the final color.
- * @param {Number|Node} [params.steps=100] - The number of steps for raymarching.
+ * @param {number|Node} [params.range=0.1] - The range for the smoothstep function.
+ * @param {number|Node} [params.threshold=0.25] - The threshold for the smoothstep function.
+ * @param {number|Node} [params.opacity=0.25] - The opacity value for the final color.
+ * @param {number|Node} [params.steps=100] - The number of steps for raymarching.
  * @returns {Function} The generated function that performs raymarching on the 3D texture.
  */
 export const raymarchingTexture3D = Fn( ( {


### PR DESCRIPTION
**Description**

In the same spirit as #30466 which tries to update code as close to Jsdoc official typing as possible, I added the eslint rule  [valid-jsdoc.preferType](https://eslint.org/docs/v8.x/rules/valid-jsdoc#prefertype) to enforce eslint to follow the official doc for future development.

I re-run all the linting commands, found nothing to update in the core folder as everything was nicely updated in the previous PR but I updated the files that needed changes in other folders to avoid adding additional linting errors.
