### PR TITLE
Types: use TS to fix issues

### DIFF
--- a/examples/jsm/loaders/TDSLoader.js
+++ b/examples/jsm/loaders/TDSLoader.js
@@ -41,7 +41,7 @@ class TDSLoader extends Loader {
 	 * Load 3ds file from url.
 	 *
 	 * @method load
-	 * @param {[type]} url URL for the file.
+	 * @param {string} url URL for the file.
 	 * @param {Function} onLoad onLoad callback, receives group Object3D as argument.
 	 * @param {Function} onProgress onProgress callback.
 	 * @param {Function} onError onError callback.

--- a/src/materials/nodes/PointsNodeMaterial.js
+++ b/src/materials/nodes/PointsNodeMaterial.js
@@ -13,7 +13,7 @@ const _defaultValues = /*@__PURE__*/ new PointsMaterial();
 /**
  * Node material version of `PointsMaterial`.
  *
- * @augments NodeMaterial
+ * @augments SpriteNodeMaterial
  */
 class PointsNodeMaterial extends SpriteNodeMaterial {
 
@@ -26,7 +26,7 @@ class PointsNodeMaterial extends SpriteNodeMaterial {
 	/**
 	 * Constructs a new points node material.
 	 *
-	 * @param {?Object} parameters - The configuration parameter.
+	 * @param {Object} [parameters] - The configuration parameter.
 	 */
 	constructor( parameters ) {
 

--- a/src/materials/nodes/SpriteNodeMaterial.js
+++ b/src/materials/nodes/SpriteNodeMaterial.js
@@ -27,7 +27,7 @@ class SpriteNodeMaterial extends NodeMaterial {
 	/**
 	 * Constructs a new sprite node material.
 	 *
-	 * @param {?Object} parameters - The configuration parameter.
+	 * @param {Object} [parameters] - The configuration parameter.
 	 */
 	constructor( parameters ) {
 

--- a/src/nodes/accessors/BufferAttributeNode.js
+++ b/src/nodes/accessors/BufferAttributeNode.js
@@ -60,7 +60,7 @@ class BufferAttributeNode extends InputNode {
 		/**
 		 * The buffer type (e.g. `'vec3'`).
 		 *
-		 * @type {string}
+		 * @type {?string}
 		 * @default null
 		 */
 		this.bufferType = bufferType;

--- a/src/nodes/accessors/ReferenceNode.js
+++ b/src/nodes/accessors/ReferenceNode.js
@@ -388,7 +388,7 @@ export default ReferenceNode;
  * @function
  * @param {string} name - The name of the property the node refers to.
  * @param {string} type - The uniform type that should be used to represent the property value.
- * @param {Object} object - The object the property belongs to.
+ * @param {?Object} object - The object the property belongs to.
  * @returns {ReferenceNode}
  */
 export const reference = ( name, type, object ) => nodeObject( new ReferenceNode( name, type, object ) );

--- a/src/nodes/accessors/StorageTextureNode.js
+++ b/src/nodes/accessors/StorageTextureNode.js
@@ -114,7 +114,7 @@ class StorageTextureNode extends TextureNode {
 	}
 
 	/**
-	 * Generates the code snippet of the stroge node. If no `storeNode`
+	 * Generates the code snippet of the storage node. If no `storeNode`
 	 * is defined, the texture node is generated as normal texture.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.

--- a/src/nodes/core/ArrayNode.js
+++ b/src/nodes/core/ArrayNode.js
@@ -12,7 +12,7 @@ import { addMethodChaining, nodeObject } from '../tsl/TSLCore.js';
  *
  * const redColor = tintColors.element( 0 );
  *
- * @augments Node
+ * @augments TempNode
  */
 class ArrayNode extends TempNode {
 
@@ -25,8 +25,8 @@ class ArrayNode extends TempNode {
 	/**
 	 * Constructs a new array node.
 	 *
-	 * @param {string} [nodeType] - The data type of the elements.
-	 * @param {number} [count] - Size of the array.
+	 * @param {?string} nodeType - The data type of the elements.
+	 * @param {number} count - Size of the array.
 	 * @param {?Array<Node>} [values=null] - Array default values.
 	 */
 	constructor( nodeType, count, values = null ) {

--- a/src/nodes/display/RenderOutputNode.js
+++ b/src/nodes/display/RenderOutputNode.js
@@ -39,8 +39,8 @@ class RenderOutputNode extends TempNode {
 	 * Constructs a new render output node.
 	 *
 	 * @param {Node} colorNode - The color node to process.
-	 * @param {number} toneMapping - The tone mapping type.
-	 * @param {string} outputColorSpace - The output color space.
+	 * @param {?number} toneMapping - The tone mapping type.
+	 * @param {?string} outputColorSpace - The output color space.
 	 */
 	constructor( colorNode, toneMapping, outputColorSpace ) {
 

--- a/src/renderers/common/TimestampQueryPool.js
+++ b/src/renderers/common/TimestampQueryPool.js
@@ -39,7 +39,7 @@ class TimestampQueryPool {
 		/**
 		 * Tracks offsets for different contexts.
 		 *
-		 * @type {Map}
+		 * @type {Map<string, number>}
 		 */
 		this.queryOffsets = new Map();
 


### PR DESCRIPTION
**Description**

I simply run TS on the project to detect typing issues. 

I also found two typing inconsistencies or weird behaviors: 

* [In this case]( https://github.com/mrdoob/three.js/blob/dev/src/nodes/accessors/StorageTextureNode.js#L130), the `generateStore` method does not return any value but the value is assigned to the snippet of type string. I'm not sure if nothing should be return in the function or a return is missing in the called method
* [In this case](https://github.com/mrdoob/three.js/blob/dev/src/nodes/accessors/UniformArrayNode.js#L86) a null value is passed instead of an array and no buffer type is provided so either `UniformArrayNode` should more parameters in the super constructor call or `BufferNode` constructor should be more permissive