### PR TITLE
Eslint: remove old .apply syntax

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -65,6 +65,7 @@
     "no-duplicate-imports": [
       "error"
     ],
+    "prefer-spread": "error",
     "valid-jsdoc": [
       "error",
       {

--- a/examples/jsm/loaders/ColladaLoader.js
+++ b/examples/jsm/loaders/ColladaLoader.js
@@ -3971,7 +3971,7 @@ class ColladaLoader extends Loader {
 				} else {
 
 					result += '\n';
-					stack.push.apply( stack, node.childNodes );
+					stack.push( ...node.childNodes );
 
 				}
 

--- a/examples/webgl_geometry_text_shapes.html
+++ b/examples/webgl_geometry_text_shapes.html
@@ -104,7 +104,7 @@
 
 					}
 
-					shapes.push.apply( shapes, holeShapes );
+					shapes.push( ...holeShapes );
 
 					const lineText = new THREE.Object3D();
 

--- a/examples/webgl_geometry_text_stroke.html
+++ b/examples/webgl_geometry_text_stroke.html
@@ -105,7 +105,7 @@
 
 					}
 
-					shapes.push.apply( shapes, holeShapes );
+					shapes.push( ...holeShapes );
 
 					const style = SVGLoader.getStrokeStyle( 5, color.getStyle() );
 

--- a/src/animation/AnimationUtils.js
+++ b/src/animation/AnimationUtils.js
@@ -90,7 +90,7 @@ function flattenJSON( jsonKeys, times, values, valuePropertyName ) {
 			if ( value !== undefined ) {
 
 				times.push( key.time );
-				values.push.apply( values, value ); // push all elements
+				values.push( ...value ); // push all elements
 
 			}
 

--- a/src/helpers/SkeletonHelper.js
+++ b/src/helpers/SkeletonHelper.js
@@ -116,7 +116,7 @@ function getBoneList( object ) {
 
 	for ( let i = 0; i < object.children.length; i ++ ) {
 
-		boneList.push.apply( boneList, getBoneList( object.children[ i ] ) );
+		boneList.push( ...getBoneList( object.children[ i ] ) );
 
 	}
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -522,7 +522,7 @@ class WebGLRenderer {
 
 		this.setClearColor = function () {
 
-			background.setClearColor.apply( background, arguments );
+			background.setClearColor( ...arguments );
 
 		};
 
@@ -534,7 +534,7 @@ class WebGLRenderer {
 
 		this.setClearAlpha = function () {
 
-			background.setClearAlpha.apply( background, arguments );
+			background.setClearAlpha( ...arguments );
 
 		};
 

--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -980,7 +980,7 @@ function WebGLState( gl, extensions ) {
 
 		try {
 
-			gl.compressedTexImage2D.apply( gl, arguments );
+			gl.compressedTexImage2D( ...arguments );
 
 		} catch ( error ) {
 
@@ -994,7 +994,7 @@ function WebGLState( gl, extensions ) {
 
 		try {
 
-			gl.compressedTexImage3D.apply( gl, arguments );
+			gl.compressedTexImage3D( ...arguments );
 
 		} catch ( error ) {
 
@@ -1008,7 +1008,7 @@ function WebGLState( gl, extensions ) {
 
 		try {
 
-			gl.texSubImage2D.apply( gl, arguments );
+			gl.texSubImage2D( ...arguments );
 
 		} catch ( error ) {
 
@@ -1022,7 +1022,7 @@ function WebGLState( gl, extensions ) {
 
 		try {
 
-			gl.texSubImage3D.apply( gl, arguments );
+			gl.texSubImage3D( ...arguments );
 
 		} catch ( error ) {
 
@@ -1036,7 +1036,7 @@ function WebGLState( gl, extensions ) {
 
 		try {
 
-			gl.compressedTexSubImage2D.apply( gl, arguments );
+			gl.compressedTexSubImage2D( ...arguments );
 
 		} catch ( error ) {
 
@@ -1050,7 +1050,7 @@ function WebGLState( gl, extensions ) {
 
 		try {
 
-			gl.compressedTexSubImage3D.apply( gl, arguments );
+			gl.compressedTexSubImage3D( ...arguments );
 
 		} catch ( error ) {
 
@@ -1064,7 +1064,7 @@ function WebGLState( gl, extensions ) {
 
 		try {
 
-			gl.texStorage2D.apply( gl, arguments );
+			gl.texStorage2D( ...arguments );
 
 		} catch ( error ) {
 
@@ -1078,7 +1078,7 @@ function WebGLState( gl, extensions ) {
 
 		try {
 
-			gl.texStorage3D.apply( gl, arguments );
+			gl.texStorage3D( ...arguments );
 
 		} catch ( error ) {
 
@@ -1092,7 +1092,7 @@ function WebGLState( gl, extensions ) {
 
 		try {
 
-			gl.texImage2D.apply( gl, arguments );
+			gl.texImage2D( ...arguments );
 
 		} catch ( error ) {
 
@@ -1106,7 +1106,7 @@ function WebGLState( gl, extensions ) {
 
 		try {
 
-			gl.texImage3D.apply( gl, arguments );
+			gl.texImage3D( ...arguments );
 
 		} catch ( error ) {
 

--- a/test/unit/utils/console-wrapper.js
+++ b/test/unit/utils/console-wrapper.js
@@ -33,30 +33,30 @@ console._debug = console.debug;
 // Wrap console methods
 console.error = function () {
 
-	if ( this.level >= CONSOLE_LEVEL.ERROR ) this._error.apply( this, arguments );
+	if ( this.level >= CONSOLE_LEVEL.ERROR ) this._error( ...arguments );
 
 };
 
 console.warn = function () {
 
-	if ( this.level >= CONSOLE_LEVEL.WARN ) this._warn.apply( this, arguments );
+	if ( this.level >= CONSOLE_LEVEL.WARN ) this._warn( ...arguments );
 
 };
 
 console.log = function () {
 
-	if ( this.level >= CONSOLE_LEVEL.LOG ) this._log.apply( this, arguments );
+	if ( this.level >= CONSOLE_LEVEL.LOG ) this._log( ...arguments );
 
 };
 
 console.info = function () {
 
-	if ( this.level >= CONSOLE_LEVEL.INFO ) this._info.apply( this, arguments );
+	if ( this.level >= CONSOLE_LEVEL.INFO ) this._info( ...arguments );
 
 };
 
 console.debug = function () {
 
-	if ( this.level >= CONSOLE_LEVEL.DEBUG ) this._debug.apply( this, arguments );
+	if ( this.level >= CONSOLE_LEVEL.DEBUG ) this._debug( ...arguments );
 
 };


### PR DESCRIPTION
**Description**

Add eslint rule to remove old `object.function.apply( object, values )` in favor of `object.function( ...values )`