### PR TITLE
TSL Transpiler: Support more matrix types, bool vectors.

### DIFF
--- a/examples/jsm/transpiler/GLSLDecoder.js
+++ b/examples/jsm/transpiler/GLSLDecoder.js
@@ -224,7 +224,7 @@ class Tokenizer {
 
 }
 
-const isType = ( str ) => /void|bool|float|u?int|mat[234]|(u|i)?vec[234]/.test( str );
+const isType = ( str ) => /void|bool|float|u?int|mat[234]|mat[234]x[234]|(u|i|b)?vec[234]/.test( str );
 
 class GLSLDecoder {
 


### PR DESCRIPTION
Related issue: #27538

**Description**

The fix in #30501 is incomplete and does not account for `mat[234]x[234]` types. Additionally, I added `bvec[234]` type specifiers. `hvec[234]`, `dvec[234]`, and `fvec[234]` are reserved in the language but not used. This is still far from complete, and both storage qualifiers and storage type specifiers (e.g. `sampler2D`) are not supported. Further, suffixes and octal/hex representations are not tokenized correctly, if at all. I assume this is functionally only for porting ShaderToy shaders (unminified; no preprocessor) in examples, so this is best effort for that purpose. I maintain my own compiler aimed at robustness, but there is no clear way to have that serve as a front-end to node materials and have to maintain an IR over TSL.

See "3.8 Keywords" of https://registry.khronos.org/OpenGL/specs/es/3.0/GLSL_ES_Specification_3.00.pdf.
