### PR TITLE
Timer: Add `usePageVisibilityAPI` ctor parameter.

### DIFF
--- a/docs/examples/en/misc/Timer.html
+++ b/docs/examples/en/misc/Timer.html
@@ -60,7 +60,10 @@
 
 		<h2>Constructor</h2>
 
-		<h3>Timer()</h3>
+		<h3>Timer( [param:Boolean usePageVisibilityAPI] )</h3>
+		<p>
+			[page:Boolean usePageVisibilityAPI] - (optional) Whether to use the Page Visibility API to avoid large time delta values in inactive tabs or not. Default is `true`. 
+		</p>
 
 		<h2>Methods</h2>
 

--- a/examples/jsm/misc/Timer.js
+++ b/examples/jsm/misc/Timer.js
@@ -1,6 +1,6 @@
 class Timer {
 
-	constructor() {
+	constructor( usePageVisibilityAPI = true ) {
 
 		this._previousTime = 0;
 		this._currentTime = 0;
@@ -13,7 +13,7 @@ class Timer {
 
 		// use Page Visibility API to avoid large time delta values
 
-		this._usePageVisibilityAPI = ( typeof document !== 'undefined' && document.hidden !== undefined );
+		this._usePageVisibilityAPI = ( usePageVisibilityAPI === true ) && ( typeof document !== 'undefined' && document.hidden !== undefined );
 
 		if ( this._usePageVisibilityAPI === true ) {
 


### PR DESCRIPTION
Related issue: #30497

**Description**

As requested in #30497, the PR introduces an optional ctor parameter that controls the usage of the Page Visibility API to avoid large time delta values in inactive tabs. The default is `true` but it can be set to `false` if this mechanism isn't wanted. 
