### PR TITLE
WGSLNodeBuilder: Improve `isCustomStruct()` checking

### DIFF
--- a/src/nodes/core/StructNode.js
+++ b/src/nodes/core/StructNode.js
@@ -115,6 +115,16 @@ export const struct = ( membersLayout, name = null ) => {
 	struct.layout = structLayout;
 	struct.isStruct = true;
 
+	Object.defineProperty( struct, 'length', {
+
+		get() {
+
+		  	return Object.keys( membersLayout ).length;
+
+		}
+
+	} );
+
 	return struct;
 
 };

--- a/src/nodes/core/StructNode.js
+++ b/src/nodes/core/StructNode.js
@@ -115,16 +115,6 @@ export const struct = ( membersLayout, name = null ) => {
 	struct.layout = structLayout;
 	struct.isStruct = true;
 
-	Object.defineProperty( struct, 'length', {
-
-		get() {
-
-		  	return Object.keys( membersLayout ).length;
-
-		}
-
-	} );
-
 	return struct;
 
 };

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -1692,7 +1692,12 @@ ${ flowData.code }
 
 				if ( this.isCustomStruct( uniform ) ) {
 
-					bufferSnippets.push( `@binding( ${ uniformIndexes.binding ++ } ) @group( ${ uniformIndexes.group } ) var<${ bufferAccessMode }> ${ uniform.name } : ${ bufferType };` );
+					const isStructArray = bufferNode.value &&
+					bufferNode.value.array &&
+					typeof bufferNode.value.itemSize === 'number' &&
+					bufferNode.value.array.length > bufferNode.value.itemSize;
+
+					bufferSnippets.push( `@binding( ${ uniformIndexes.binding ++ } ) @group( ${ uniformIndexes.group } ) var<${ bufferAccessMode }> ${ uniform.name } : ${ isStructArray ? `array<${ bufferType }>` : bufferType };` );
 
 				} else {
 

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -1692,12 +1692,7 @@ ${ flowData.code }
 
 				if ( this.isCustomStruct( uniform ) ) {
 
-					const isStructArray = bufferNode.value &&
-					bufferNode.value.array &&
-					typeof bufferNode.value.itemSize === 'number' &&
-					bufferNode.value.array.length > bufferNode.value.itemSize;
-
-					bufferSnippets.push( `@binding( ${ uniformIndexes.binding ++ } ) @group( ${ uniformIndexes.group } ) var<${ bufferAccessMode }> ${ uniform.name } : ${ isStructArray ? `array<${ bufferType }>` : bufferType };` );
+					bufferSnippets.push( `@binding( ${ uniformIndexes.binding ++ } ) @group( ${ uniformIndexes.group } ) var<${ bufferAccessMode }> ${ uniform.name } : ${ bufferType };` );
 
 				} else {
 

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -1591,7 +1591,16 @@ ${ flowData.code }
 
 	isCustomStruct( nodeUniform ) {
 
-		return nodeUniform.value.isStorageBufferAttribute && nodeUniform.node.structTypeNode !== null;
+		const attribute = nodeUniform.value;
+		const bufferNode = nodeUniform.node;
+
+		const isAttributeStructType = ( attribute.isBufferAttribute || attribute.isInstancedBufferAttribute ) && bufferNode.structTypeNode !== null;
+
+		const isStructArray =
+			( bufferNode.value && bufferNode.value.array ) &&
+			( typeof bufferNode.value.itemSize === 'number' && bufferNode.value.array.length > bufferNode.value.itemSize );
+
+		return isAttributeStructType && ! isStructArray;
 
 	}
 


### PR DESCRIPTION
#30394 #30487

I recreated the PR because I had big problems with creating the screenshot and the branch was completely destroyed as a result. I was only able to create the screenshot with changes in puppeteer.js and the screenshot still doesn't fit.
The code itself works perfectly. @sunag you have a new node in mind for the structArray anyway. That's why I'm holding off on experimenting with screenshots for the moment