### PR TITLE
WebGLBackend: Fix depth regression.

### DIFF
--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -212,10 +212,10 @@ class WebGLBackend extends Backend {
 		const parameters = this.parameters;
 
 		const contextAttributes = {
-			antialias: false, // MSAA is applied via a custom renderbuffer
+			antialias: renderer.samples > 0,
 			alpha: true, // always true for performance reasons
-			depth: false, // depth and stencil are set to false since the engine always renders into a framebuffer target first
-			stencil: false
+			depth: renderer.depth,
+			stencil: renderer.stencil
 		};
 
 		const glContext = ( parameters.context !== undefined ) ? parameters.context : renderer.domElement.getContext( 'webgl2', contextAttributes );


### PR DESCRIPTION
Fixed #30526.

**Description**

#30413 was intended as a performance optimization for the WebGL backend however there are scenarios where no intermediate framebuffer is used (e.g. when using `linear-srgb` as output color space). Because color space and tone mapping settings can change at any time, the context must honor the initial renderer attributes. 

Unfortunately, that means most apps will have a depth buffer attached to the default framebuffer although it isn't required. 
