### PR TITLE
WebGPURenderer: Fix storage buffer binding update and 4 bytes alignment

### DIFF
--- a/src/renderers/common/Bindings.js
+++ b/src/renderers/common/Bindings.js
@@ -1,6 +1,5 @@
 import DataMap from './DataMap.js';
 import { AttributeType } from './Constants.js';
-import { DynamicDrawUsage } from '../../constants.js';
 
 /**
  * This renderer module manages the bindings of the renderer.

--- a/src/renderers/common/Bindings.js
+++ b/src/renderers/common/Bindings.js
@@ -1,5 +1,6 @@
 import DataMap from './DataMap.js';
 import { AttributeType } from './Constants.js';
+import { DynamicDrawUsage } from '../../constants.js';
 
 /**
  * This renderer module manages the bindings of the renderer.
@@ -221,6 +222,16 @@ class Bindings extends DataMap {
 				// we move one with the next binding. Otherwise the next if block will update the group.
 
 				if ( updated === false ) continue;
+
+			}
+
+			if ( binding.isStorageBuffer ) {
+
+				const attribute = binding.attribute;
+				const attributeType = attribute.isIndirectStorageBufferAttribute ? AttributeType.INDIRECT : AttributeType.STORAGE;
+
+				this.attributes.update( attribute, attributeType );
+
 
 			}
 

--- a/src/renderers/webgpu/utils/WebGPUAttributeUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUAttributeUtils.js
@@ -109,6 +109,8 @@ class WebGPUAttributeUtils {
 				bufferAttribute.itemSize = 4;
 				bufferAttribute.array = array;
 
+				bufferData._force3to4BytesAlignment = true;
+
 			}
 
 			const size = array.byteLength + ( ( 4 - ( array.byteLength % 4 ) ) % 4 ); // ensure 4 byte alignment, see #20441
@@ -142,9 +144,27 @@ class WebGPUAttributeUtils {
 		const backend = this.backend;
 		const device = backend.device;
 
+		const bufferData = backend.get( bufferAttribute );
 		const buffer = backend.get( bufferAttribute ).buffer;
 
-		const array = bufferAttribute.array;
+		let array = bufferAttribute.array;
+
+		//  if storage buffer ensure 4 byte alignment
+		if ( bufferData._force3to4BytesAlignment === true ) {
+
+			array = new array.constructor( bufferAttribute.count * 4 );
+
+			for ( let i = 0; i < bufferAttribute.count; i ++ ) {
+
+				array.set( bufferAttribute.array.subarray( i * 3, i * 3 + 3 ), i * 4 );
+
+			}
+
+			bufferAttribute.array = array;
+
+		}
+
+
 		const isTypedArray = this._isTypedArray( array );
 		const updateRanges = bufferAttribute.updateRanges;
 


### PR DESCRIPTION
**Description**

Currently, updating the value of a storage buffer does not reflect the changes in the compute program.

Additionally, if the storage buffer is of size 3, the 4-byte alignment applied during attribute initialization is not accounted for in the update method, resulting in corrupted values.

*This contribution is funded by [Utsubo](https://utsubo.com)*
