### PR TITLE
TSL Transpiler: Add support for `discard`.

### DIFF
--- a/examples/jsm/transpiler/AST.js
+++ b/examples/jsm/transpiler/AST.js
@@ -204,6 +204,16 @@ export class Return {
 
 }
 
+export class Discard {
+
+	constructor() {
+
+		this.isDiscard = true;
+
+	}
+
+}
+
 export class Accessor {
 
 	constructor( property ) {

--- a/examples/jsm/transpiler/GLSLDecoder.js
+++ b/examples/jsm/transpiler/GLSLDecoder.js
@@ -1,4 +1,4 @@
-import { Program, FunctionDeclaration, For, AccessorElements, Ternary, Varying, DynamicElement, StaticElement, FunctionParameter, Unary, Conditional, VariableDeclaration, Operator, Number, String, FunctionCall, Return, Accessor, Uniform } from './AST.js';
+import { Program, FunctionDeclaration, For, AccessorElements, Ternary, Varying, DynamicElement, StaticElement, FunctionParameter, Unary, Conditional, VariableDeclaration, Operator, Number, String, FunctionCall, Return, Accessor, Uniform, Discard } from './AST.js';
 
 const unaryOperators = [
 	'+', '-', '~', '!', '++', '--'
@@ -488,6 +488,10 @@ class GLSLDecoder {
 			if ( firstToken.str === 'return' ) {
 
 				return new Return( this.parseExpressionFromTokens( tokens.slice( 1 ) ) );
+
+			} else if ( firstToken.str === 'discard' ) {
+
+				return new Discard();
 
 			}
 

--- a/examples/jsm/transpiler/TSLEncoder.js
+++ b/examples/jsm/transpiler/TSLEncoder.js
@@ -244,6 +244,12 @@ class TSLEncoder {
 
 			}
 
+		} else if ( node.isDiscard ) {
+
+			this.addImport( 'Discard' );
+
+			code = 'Discard()';
+
 		} else if ( node.isAccessorElements ) {
 
 			code = this.emitExpression( node.object );


### PR DESCRIPTION
Related issue: https://discourse.threejs.org/t/how-to-use-discard-in-tsl/78217/2

**Description**

The TSL Transpiler can now transpile the `discard` syntax in GLSL to TSL:
```
if ( finalColor.a <= 0.0 ) discard;
````
is converted to:
```js
import { Discard, If } from 'three/tsl';

If( finalColor.a.lessThanEqual( 0.0 ), () => {

	Discard();

} );

```
That said, there is a more compact way in writing the above statement in TSL without the `If`:
```js
 finalColor.a.lessThanEqual( 0.0 ).discard();
```
But I think the above should be okay for transpiled code.