### PR TITLE
WebGPURenderer: Fix mat2() arguments

### DIFF
--- a/src/math/Matrix2.js
+++ b/src/math/Matrix2.js
@@ -28,17 +28,6 @@ export class Matrix2 {
 
 	}
 
-	multiplyScalar( scalar ) {
-
-		const te = this.elements;
-
-		te[ 0 ] *= scalar; te[ 2 ] *= scalar;
-		te[ 1 ] *= scalar; te[ 3 ] *= scalar;
-
-		return this;
-
-	}
-
 	fromArray( array, offset = 0 ) {
 
 		for ( let i = 0; i < 4; i ++ ) {

--- a/src/math/Matrix2.js
+++ b/src/math/Matrix2.js
@@ -28,6 +28,17 @@ export class Matrix2 {
 
 	}
 
+	multiplyScalar( scalar ) {
+
+		const te = this.elements;
+
+		te[ 0 ] *= scalar; te[ 2 ] *= scalar;
+		te[ 1 ] *= scalar; te[ 3 ] *= scalar;
+
+		return this;
+
+	}
+
 	fromArray( array, offset = 0 ) {
 
 		for ( let i = 0; i < 4; i ++ ) {

--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -1176,9 +1176,9 @@ class NodeBuilder {
 
 					value.elements.fill( 0 );
 
-				} else if ( value.elements[ 0 ] === 1 ) {
+				} else {
 
-					value.identity();
+					value.identity().multiplyScalar( value.elements[ 0 ] );
 
 				}
 

--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -1168,14 +1168,9 @@ class NodeBuilder {
 
 			// in WGSL matN() -> zero matrix and matN( 1.0 ) -> identity matrix
 			// in GLSL matN() -> identity matrix and matN( 0.0 ) -> zero matrix
-			const argumentsLength = value.elements.filter( e => e !== undefined ).length;
+			// undefined values fallback to 0 in the NodeBuilder setting both backends matN() to zero matrix
 
-			// aligns GLSL with WGSL to matN() -> zero matri
-			if ( argumentsLength === 0 && this.isFlipY() ) {
-
-				value.elements.fill( 0 );
-
-			} else if ( argumentsLength === 1 ) {
+			if ( value.elements.filter( e => e !== undefined ).length === 1 ) {
 
 				if ( value.elements[ 0 ] === 0 ) {
 

--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -1166,21 +1166,9 @@ class NodeBuilder {
 
 		} else if ( typeLength >= 4 && value && ( value.isMatrix2 || value.isMatrix3 || value.isMatrix4 ) ) {
 
-			// in WGSL matN() -> zero matrix and matN( 1.0 ) -> identity matrix
-			// in GLSL matN() -> identity matrix and matN( 0.0 ) -> zero matrix
-			// undefined values fallback to 0 in the NodeBuilder setting both backends matN() to zero matrix
-
 			if ( value.elements.filter( e => e !== undefined ).length === 1 ) {
 
-				if ( value.elements[ 0 ] === 0 ) {
-
-					value.elements.fill( 0 );
-
-				} else {
-
-					value.identity().multiplyScalar( value.elements[ 0 ] );
-
-				}
+				value.identity().multiplyScalar( value.elements[ 0 ] );
 
 			}
 

--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -1160,11 +1160,34 @@ class NodeBuilder {
 
 			return `${ this.getType( type ) }( ${ generateConst( value.x ) }, ${ generateConst( value.y ) }, ${ generateConst( value.z ) } )`;
 
-		} else if ( typeLength === 4 ) {
+		} else if ( typeLength === 4 && type !== 'mat2' ) {
 
 			return `${ this.getType( type ) }( ${ generateConst( value.x ) }, ${ generateConst( value.y ) }, ${ generateConst( value.z ) }, ${ generateConst( value.w ) } )`;
 
-		} else if ( typeLength > 4 && value && ( value.isMatrix3 || value.isMatrix4 ) ) {
+		} else if ( typeLength >= 4 && value && ( value.isMatrix2 || value.isMatrix3 || value.isMatrix4 ) ) {
+
+			// in WGSL matN() -> zero matrix and matN( 1.0 ) -> identity matrix
+			// in GLSL matN() -> identity matrix and matN( 0.0 ) -> zero matrix
+			const argumentsLength = value.elements.filter( e => e !== undefined ).length;
+
+			// aligns GLSL with WGSL to matN() -> zero matri
+			if ( argumentsLength === 0 && this.isFlipY() ) {
+
+				value.elements.fill( 0 );
+
+			} else if ( argumentsLength === 1 ) {
+
+				if ( value.elements[ 0 ] === 0 ) {
+
+					value.elements.fill( 0 );
+
+				} else if ( value.elements[ 0 ] === 1 ) {
+
+					value.identity();
+
+				}
+
+			}
 
 			return `${ this.getType( type ) }( ${ value.elements.map( generateConst ).join( ', ' ) } )`;
 

--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -1166,12 +1166,6 @@ class NodeBuilder {
 
 		} else if ( typeLength >= 4 && value && ( value.isMatrix2 || value.isMatrix3 || value.isMatrix4 ) ) {
 
-			if ( value.elements.filter( e => e !== undefined ).length === 1 ) {
-
-				value.identity().multiplyScalar( value.elements[ 0 ] );
-
-			}
-
 			return `${ this.getType( type ) }( ${ value.elements.map( generateConst ).join( ', ' ) } )`;
 
 		} else if ( typeLength > 4 ) {


### PR DESCRIPTION
**Description**
This PR fixes `mat2()` incorrectly interpreted as vec4 in the Node Builder. This fix ensures correct type handling.


*This contribution is funded by [Utsubo](https://utsubo.com)*
