### PR TITLE
Jsdoc: Improve @see links

### DIFF
--- a/examples/jsm/loaders/MTLLoader.js
+++ b/examples/jsm/loaders/MTLLoader.js
@@ -33,7 +33,7 @@ class MTLLoader extends Loader {
 	 * @param {Function} [onProgress] - Callback for download progress.
 	 * @param {Function} [onError] - Callback for download errors.
 	 *
-	 * @see setPath setResourcePath
+	 * @see {@link FileLoader#setPath} {@link FileLoader#setResourcePath}
 	 *
 	 * @note In order for relative texture references to resolve correctly
 	 * you must call setResourcePath() explicitly prior to load.
@@ -88,7 +88,7 @@ class MTLLoader extends Loader {
 	 * @param {string} path
 	 * @return {MaterialCreator}
 	 *
-	 * @see setPath setResourcePath
+	 * @see {@link FileLoader#setPath} {@link FileLoader#setResourcePath}
 	 *
 	 * @note In order for relative texture references to resolve correctly
 	 * you must call setResourcePath() explicitly prior to parse.

--- a/examples/jsm/misc/Volume.js
+++ b/examples/jsm/misc/Volume.js
@@ -427,7 +427,7 @@ class Volume {
 	/**
 	 * Call repaint on all the slices extracted from this volume
 	 *
-	 * @see VolumeSlice.repaint
+	 * @see {@link VolumeSlice#repaint}
 	 * @memberof Volume
 	 * @returns {Volume} this
 	 */

--- a/examples/jsm/misc/VolumeSlice.js
+++ b/examples/jsm/misc/VolumeSlice.js
@@ -12,7 +12,7 @@ import {
 /**
  * This class has been made to hold a slice of a volume data
  * @class
- * @see Volume
+ * @see {@link Volume}
  */
 class VolumeSlice {
 
@@ -95,7 +95,7 @@ class VolumeSlice {
 
 		/**
 		 * @member {Function} sliceAccess Function that allow the slice to access right data
-		 * @see Volume.extractPerpendicularPlane
+		 * @see {@link Volume#extractPerpendicularPlane}
 		 * @param {number} i The first coordinate
 		 * @param {number} j The second coordinate
 		 * @returns {number} the index corresponding to the voxel in volume.data of the given position in the slice
@@ -192,7 +192,7 @@ class VolumeSlice {
 
 	/**
 	 * Refresh the geometry according to axis and index
-	 * @see Volume.extractPerpendicularPlane
+	 * @see {@link Volume#extractPerpendicularPlane}
 	 * @memberof VolumeSlice
 	 */
 	updateGeometry() {

--- a/src/renderers/common/extras/PMREMGenerator.js
+++ b/src/renderers/common/extras/PMREMGenerator.js
@@ -141,7 +141,7 @@ class PMREMGenerator {
 	 * @param {Vector3} [options.renderTarget=origin] - The position of the internal cube camera that renders the scene.
 	 * @param {?RenderTarget} [options.renderTarget=null] - The render target to use.
 	 * @return {RenderTarget} The resulting PMREM.
-	 * @see fromSceneAsync
+	 * @see {@link PMREMGenerator#fromSceneAsync}
 	 */
 	fromScene( scene, sigma = 0, near = 0.1, far = 100, options = {} ) {
 
@@ -206,7 +206,7 @@ class PMREMGenerator {
 	 * @param {Vector3} [options.renderTarget=origin] - The position of the internal cube camera that renders the scene.
 	 * @param {?RenderTarget} [options.renderTarget=null] - The render target to use.
 	 * @return {Promise<RenderTarget>} A Promise that resolve with the PMREM when the generation has been finished.
-	 * @see fromScene
+	 * @see {@link PMREMGenerator#fromScene}
 	 */
 	async fromSceneAsync( scene, sigma = 0, near = 0.1, far = 100, options = {} ) {
 
@@ -224,7 +224,7 @@ class PMREMGenerator {
 	 * @param {Texture} equirectangular - The equirectangular texture to be converted.
 	 * @param {?RenderTarget} [renderTarget=null] - The render target to use.
 	 * @return {RenderTarget} The resulting PMREM.
-	 * @see fromEquirectangularAsync
+	 * @see {@link PMREMGenerator#fromEquirectangularAsync}
 	 */
 	fromEquirectangular( equirectangular, renderTarget = null ) {
 
@@ -254,7 +254,7 @@ class PMREMGenerator {
 	 * @param {Texture} equirectangular - The equirectangular texture to be converted.
 	 * @param {?RenderTarget} [renderTarget=null] - The render target to use.
 	 * @return {Promise<RenderTarget>} The resulting PMREM.
-	 * @see fromEquirectangular
+	 * @see {@link PMREMGenerator#fromEquirectangular}
 	 */
 	async fromEquirectangularAsync( equirectangular, renderTarget = null ) {
 
@@ -272,7 +272,7 @@ class PMREMGenerator {
 	 * @param {Texture} cubemap - The cubemap texture to be converted.
 	 * @param {?RenderTarget} [renderTarget=null] - The render target to use.
 	 * @return {RenderTarget} The resulting PMREM.
-	 * @see fromCubemapAsync
+	 * @see {@link PMREMGenerator#fromCubemapAsync}
 	 */
 	fromCubemap( cubemap, renderTarget = null ) {
 
@@ -302,7 +302,7 @@ class PMREMGenerator {
 	 * @param {Texture} cubemap - The cubemap texture to be converted.
 	 * @param {?RenderTarget} [renderTarget=null] - The render target to use.
 	 * @return {Promise<RenderTarget>} The resulting PMREM.
-	 * @see fromCubemap
+	 * @see {@link PMREMGenerator#fromCubemap}
 	 */
 	async fromCubemapAsync( cubemap, renderTarget = null ) {
 


### PR DESCRIPTION
**Description**

Currently the PMREMGenerator `@see` tag only produce text in the new documentation, I updated the tag content so it links to the target method now.

I also update other `@see` examples in the code to stay coherent.

![image](https://github.com/user-attachments/assets/58feeb29-6534-49e3-bd71-615ec1d9f336)
