### PR TITLE
SpriteNodeMaterial: Fix `scaleNode` type convertion

### DIFF
--- a/src/materials/nodes/SpriteNodeMaterial.js
+++ b/src/materials/nodes/SpriteNodeMaterial.js
@@ -121,7 +121,7 @@ class SpriteNodeMaterial extends NodeMaterial {
 
 		if ( scaleNode !== null ) {
 
-			scale = scale.mul( float( scaleNode ) );
+			scale = scale.mul( vec2( scaleNode ) );
 
 		}
 


### PR DESCRIPTION
Fixes: https://github.com/mrdoob/three.js/issues/30539

**Description**

Fix `scaleNode` type convertion of `SpriteNodeMaterial`.