### PR TITLE
Jsodc: Improve Object3D

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -616,8 +616,8 @@ class Object3D extends EventDispatcher {
 	 * This method does not support objects having non-uniformly-scaled parent(s).
 	 *
 	 * @param {number|Vector3} x - The x coordinate in world space. Alternatively, a vector representing a position in world space
-	 * @param {number} y - The y coordinate in world space.
-	 * @param {number} z - The z coordinate in world space.
+	 * @param {number} [y] - The y coordinate in world space.
+	 * @param {number} [z] - The z coordinate in world space.
 	 */
 	lookAt( x, y, z ) {
 
@@ -1162,7 +1162,8 @@ class Object3D extends EventDispatcher {
 	 * Serializes the 3D object into JSON.
 	 *
 	 * @param {?(Object|String)} meta - An optional value holding meta information about the serialization.
-	 * @return {Object} The JSON.
+	 * @return {Object} A large Js object used to store all the important properties of this 3D object.
+	 * @see {@link ObjectLoader#parse}
 	 */
 	toJSON( meta ) {
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -1162,7 +1162,7 @@ class Object3D extends EventDispatcher {
 	 * Serializes the 3D object into JSON.
 	 *
 	 * @param {?(Object|String)} meta - An optional value holding meta information about the serialization.
-	 * @return {Object} A large Js object used to store all the important properties of this 3D object.
+	 * @return {Object} A JSON object representing the serialized 3D object.
 	 * @see {@link ObjectLoader#parse}
 	 */
 	toJSON( meta ) {


### PR DESCRIPTION
**Description**

Small improvements to the doc. 

Typing of `lookAt` is a bit hard as there is two ways of calling the method, I think this is a better way to signal that second and third parameters are not required in some cases.