### PR TITLE
Docs: Improve search in new doc

### DIFF
--- a/utils/docs/template/static/scripts/search.js
+++ b/utils/docs/template/static/scripts/search.js
@@ -2,12 +2,10 @@ const contentContainer = document.querySelector( '#page-content' );
 const searchContainer = document.querySelector( '#search-content' );
 const resultBox = document.querySelector( '#search-result' );
 
-// eslint-disable-next-line no-unused-vars
 function hideSearch() {
 
 	searchContainer.style.display = 'none';
 	contentContainer.style.display = 'block';
-
 
 }
 
@@ -99,13 +97,7 @@ function getSearchResult( list, keys, searchKey ) {
 
 	const result = fuse.search( searchKey );
 
-	if ( result.length > 20 ) {
-
-		return result.slice( 0, 20 );
-
-	}
-
-	return result;
+	return result.slice( 0, 20 );
 
 }
 
@@ -122,8 +114,6 @@ async function search( value ) {
 	}
 
 	showSearch();
-
-	const keys = [ 'title', 'description' ];
 
 	if ( searchData === undefined ) {
 
@@ -144,6 +134,7 @@ async function search( value ) {
 
 	}
 
+	const keys = [ 'title' ];
 	const result = getSearchResult( searchData, keys, value );
 
 	if ( ! result.length ) {
@@ -154,6 +145,6 @@ async function search( value ) {
 
 	}
 
-	resultBox.innerHTML = buildSearchResult( result );
+	showResultText( buildSearchResult( result ) );
 
 }


### PR DESCRIPTION
**Description**

Previous search only allowed to search on page/component name. If we try to allow to search by description we end up with a lot of results not close to what we can expect. 

For example, while searching for basic `Object3D` and just typing "object" we have those results

![image](https://github.com/user-attachments/assets/dc6f87ed-ed3f-47f7-93fc-997071ac67b8)

While in most cases we will want something like that

![image](https://github.com/user-attachments/assets/50bc0c0d-6ed6-4f16-8fef-92ae25c84821)

or maybe results without object methods or atributes ?
 