### PR TITLE
Timer: Add `connect()`/`disconnect()`.

### DIFF
--- a/docs/examples/en/misc/Timer.html
+++ b/docs/examples/en/misc/Timer.html
@@ -16,7 +16,7 @@
 
 			<ul>
 				<li>[name] has an [page:.update]() method that updates its internal state. That makes it possible to call [page:.getDelta]() and [page:.getElapsed]() multiple times per simulation step without getting different values.</li>
-				<li>The class uses the Page Visibility API to avoid large time delta values when the app is inactive (e.g. tab switched or browser hidden).</li>
+				<li>The class can make use of the Page Visibility API to avoid large time delta values when the app is inactive (e.g. tab switched or browser hidden).</li>
 			</ul>
 		</p>
 
@@ -60,12 +60,20 @@
 
 		<h2>Constructor</h2>
 
-		<h3>Timer( [param:Boolean usePageVisibilityAPI] )</h3>
-		<p>
-			[page:Boolean usePageVisibilityAPI] - (optional) Whether to use the Page Visibility API to avoid large time delta values in inactive tabs or not. Default is `true`. 
-		</p>
+		<h3>Timer()</h3>
 
 		<h2>Methods</h2>
+
+		<h3>[method:this connect]( [param:Document document] )</h3>
+		<p>
+			Connects the timer to the given document. Calling this method is not mandatory to use the timer
+			but enables the usage of the Page Visibility API to avoid large time delta values.
+		</p>
+
+		<h3>[method:this disconnect]()</h3>
+		<p>
+			Disconnects the timer from the DOM and also disables the usage of the Page Visibility API.
+		</p>
 
 		<h3>[method:Number getDelta]()</h3>
 		<p>

--- a/examples/jsm/misc/Timer.js
+++ b/examples/jsm/misc/Timer.js
@@ -1,6 +1,6 @@
 class Timer {
 
-	constructor( usePageVisibilityAPI = true ) {
+	constructor() {
 
 		this._previousTime = 0;
 		this._currentTime = 0;
@@ -11,17 +11,37 @@ class Timer {
 
 		this._timescale = 1;
 
+		this._document = null;
+		this._pageVisibilityHandler = null;
+
+	}
+
+	connect( document ) {
+
+		this._document = document;
+
 		// use Page Visibility API to avoid large time delta values
 
-		this._usePageVisibilityAPI = ( usePageVisibilityAPI === true ) && ( typeof document !== 'undefined' && document.hidden !== undefined );
-
-		if ( this._usePageVisibilityAPI === true ) {
+		if ( document.hidden !== undefined ) {
 
 			this._pageVisibilityHandler = handleVisibilityChange.bind( this );
 
 			document.addEventListener( 'visibilitychange', this._pageVisibilityHandler, false );
 
 		}
+
+	}
+
+	disconnect() {
+
+		if ( this._pageVisibilityHandler !== null ) {
+
+			this._document.removeEventListener( 'visibilitychange', this._pageVisibilityHandler );
+			this._pageVisibilityHandler = null;
+
+		}
+
+		this._document = null;
 
 	}
 
@@ -61,11 +81,7 @@ class Timer {
 
 	dispose() {
 
-		if ( this._usePageVisibilityAPI === true ) {
-
-			document.removeEventListener( 'visibilitychange', this._pageVisibilityHandler );
-
-		}
+		this.disconnect();
 
 		return this;
 
@@ -73,8 +89,7 @@ class Timer {
 
 	update( timestamp ) {
 
-
-		if ( this._usePageVisibilityAPI === true && document.hidden === true ) {
+		if ( this._pageVisibilityHandler !== null && this._document.hidden === true ) {
 
 			this._delta = 0;
 
@@ -121,7 +136,7 @@ function now() {
 
 function handleVisibilityChange() {
 
-	if ( document.hidden === false ) this.reset();
+	if ( this._document.hidden === false ) this.reset();
 
 }
 

--- a/examples/webgl_buffergeometry_lines.html
+++ b/examples/webgl_buffergeometry_lines.html
@@ -51,6 +51,7 @@
 				scene = new THREE.Scene();
 
 				timer = new Timer();
+				timer.connect( document );
 
 				const geometry = new THREE.BufferGeometry();
 				const material = new THREE.LineBasicMaterial( { vertexColors: true } );

--- a/examples/webgl_geometry_dynamic.html
+++ b/examples/webgl_geometry_dynamic.html
@@ -50,6 +50,7 @@
 				camera.position.y = 200;
 
 				timer = new Timer();
+				timer.connect( document );
 
 				scene = new THREE.Scene();
 				scene.background = new THREE.Color( 0xaaccff );

--- a/examples/webgl_morphtargets_sphere.html
+++ b/examples/webgl_morphtargets_sphere.html
@@ -49,6 +49,8 @@
 				scene = new THREE.Scene();
 
 				timer = new Timer();
+				timer.connect( document );
+				timer.disconnect();
 
 				const light1 = new THREE.PointLight( 0xff2200, 50000 );
 				light1.position.set( 100, 100, 100 );

--- a/examples/webgl_morphtargets_sphere.html
+++ b/examples/webgl_morphtargets_sphere.html
@@ -50,7 +50,6 @@
 
 				timer = new Timer();
 				timer.connect( document );
-				timer.disconnect();
 
 				const light1 = new THREE.PointLight( 0xff2200, 50000 );
 				light1.position.set( 100, 100, 100 );

--- a/examples/webgpu_display_stereo.html
+++ b/examples/webgpu_display_stereo.html
@@ -62,6 +62,7 @@
 					.load( [ 'px.jpg', 'nx.jpg', 'py.jpg', 'ny.jpg', 'pz.jpg', 'nz.jpg' ] );
 
 				timer = new Timer();
+				timer.connect( document );
 
 				const geometry = new THREE.SphereGeometry( 0.1, 32, 16 );
 

--- a/examples/webgpu_postprocessing_difference.html
+++ b/examples/webgpu_postprocessing_difference.html
@@ -62,6 +62,7 @@
 				scene.background = new THREE.Color( 0x0487e2 );
 
 				timer = new Timer();
+				timer.connect( document );
 
 				const texture = new THREE.TextureLoader().load( 'textures/crate.gif' );
 				texture.colorSpace = THREE.SRGBColorSpace;

--- a/examples/webgpu_postprocessing_ssaa.html
+++ b/examples/webgpu_postprocessing_ssaa.html
@@ -87,6 +87,7 @@
 				document.body.appendChild( stats.dom );
 
 				timer = new Timer();
+				timer.connect( document );
 
 				camera = new THREE.PerspectiveCamera( 65, width / height, 3, 10 );
 				camera.position.z = 7;

--- a/examples/webgpu_tsl_vfx_linkedparticles.html
+++ b/examples/webgpu_tsl_vfx_linkedparticles.html
@@ -87,6 +87,7 @@
 				scene = new THREE.Scene();
 
 				timer = new Timer();
+				timer.connect( document );
 
 				// renderer
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/30522#issuecomment-2664806006

**Description**

The PR implements `connect()`/`disconnect()` to make the ctor side-effect free.

This change must be noted in the migration guide since calling `timer.connect( document );` is now mandatory if the Page Visibility API should be used to avoid large time delta values.
