### PR TITLE
Update Loading-3D-models.html

### DIFF
--- a/docs/manual/en/introduction/Loading-3D-models.html
+++ b/docs/manual/en/introduction/Loading-3D-models.html
@@ -84,7 +84,7 @@
 	</p>
 
 	<code>
-		import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+		import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 	</code>
 
 	<p>


### PR DESCRIPTION
**Description**

Following the tutorial on the documentation, I couldn't import the GLTF loader. By looking up on the internet I found out the module has been moved elsewhere.
