### PR TITLE
PassNode: Allow MSAA with WebGL 2 backend.

### DIFF
--- a/src/nodes/display/PassNode.js
+++ b/src/nodes/display/PassNode.js
@@ -544,13 +544,6 @@ class PassNode extends TempNode {
 
 		this.renderTarget.samples = this.options.samples === undefined ? renderer.samples : this.options.samples;
 
-		// TODO: Disable MSAA for WebGL backend for now
-		if ( renderer.backend.isWebGLBackend === true ) {
-
-			this.renderTarget.samples = 0;
-
-		}
-
 		this.renderTarget.texture.type = renderer.getColorBufferType();
 
 		return this.scope === PassNode.COLOR ? this.getTextureNode() : this.getLinearDepthNode();


### PR DESCRIPTION
Related issue: #28784

**Description**

Testing to see which examples fail when MSAA is used with `PassNode` and a WebGL 2 backend.