### PR TITLE
Eslint: preferType limitation

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -1194,7 +1194,7 @@ class Object3D extends EventDispatcher {
 	/**
 	 * Serializes the 3D object into JSON.
 	 *
-	 * @param {?(Object|String)} meta - An optional value holding meta information about the serialization.
+	 * @param {?(Object|string)} meta - An optional value holding meta information about the serialization.
 	 * @return {Object} A JSON object representing the serialized 3D object.
 	 * @see {@link ObjectLoader#parse}
 	 */

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -581,7 +581,7 @@ class Material extends EventDispatcher {
 	/**
 	 * Serializes the material into JSON.
 	 *
-	 * @param {?(Object|String)} meta - An optional value holding meta information about the serialization.
+	 * @param {?(Object|string)} meta - An optional value holding meta information about the serialization.
 	 * @return {Object} A JSON object representing the serialized material.
 	 * @see {@link ObjectLoader#parse}
 	 */

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -443,7 +443,7 @@ class Texture extends EventDispatcher {
 	/**
 	 * Serializes the texture into JSON.
 	 *
-	 * @param {?(Object|String)} meta - An optional value holding meta information about the serialization.
+	 * @param {?(Object|string)} meta - An optional value holding meta information about the serialization.
 	 * @return {Object} A JSON object representing the serialized texture.
 	 * @see {@link ObjectLoader#parse}
 	 */
@@ -666,7 +666,7 @@ Texture.DEFAULT_IMAGE = null;
  * The default mapping for all textures.
  *
  * @static
- * @type {Number}
+ * @type {number}
  * @default UVMapping
  */
 Texture.DEFAULT_MAPPING = UVMapping;
@@ -675,7 +675,7 @@ Texture.DEFAULT_MAPPING = UVMapping;
  * The default anisotropy value for all textures.
  *
  * @static
- * @type {Number}
+ * @type {number}
  * @default 1
  */
 Texture.DEFAULT_ANISOTROPY = 1;


### PR DESCRIPTION
**Description**

Seems like the rule `valid-jsdoc:preferType` has some sever limitations:

* It only works with @params and not with @type
* It does not handled union type and only search for exact string

We could had some union types in the config to handle more cases but there is no real limit to what union can be used and the gain is really  small as this rule is only here to keep some typing concistency internally.

If this become really a concern a custom eslint can be made to handle this.