### PR TITLE
Animation: Rename `frame` parameter to `xrFrame`.

### DIFF
--- a/src/renderers/common/Animation.js
+++ b/src/renderers/common/Animation.js
@@ -60,7 +60,7 @@ class Animation {
 	 */
 	start() {
 
-		const update = ( time, frame ) => {
+		const update = ( time ) => {
 
 			this._requestId = this._context.requestAnimationFrame( update );
 
@@ -70,7 +70,7 @@ class Animation {
 
 			this.info.frame = this.nodes.nodeFrame.frameId;
 
-			if ( this._animationLoop !== null ) this._animationLoop( time, frame );
+			if ( this._animationLoop !== null ) this._animationLoop( time );
 
 		};
 

--- a/src/renderers/common/Animation.js
+++ b/src/renderers/common/Animation.js
@@ -60,7 +60,7 @@ class Animation {
 	 */
 	start() {
 
-		const update = ( time ) => {
+		const update = ( time, xrFrame ) => {
 
 			this._requestId = this._context.requestAnimationFrame( update );
 
@@ -70,7 +70,7 @@ class Animation {
 
 			this.info.frame = this.nodes.nodeFrame.frameId;
 
-			if ( this._animationLoop !== null ) this._animationLoop( time );
+			if ( this._animationLoop !== null ) this._animationLoop( time, xrFrame );
 
 		};
 


### PR DESCRIPTION
Related issue: -

**Description**

~~The PR removes the `frame` parameter from the renderer's internal animation loop since it is always `undefined`. `requestAnimationFrame()` only has a single parameter.~~

The PR renames `frame` to `xrFrame` for better clarity.