### PR TITLE
Eslint: Implement no-var

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -65,6 +65,9 @@
     "no-duplicate-imports": [
       "error"
     ],
+    "no-var": [
+      "error"
+    ],
     "prefer-spread": "error",
     "valid-jsdoc": [
       "error",

--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -7,7 +7,7 @@ import { Strings } from './Strings.js';
 import { Storage as _Storage } from './Storage.js';
 import { Selector } from './Selector.js';
 
-var _DEFAULT_CAMERA = new THREE.PerspectiveCamera( 50, 1, 0.01, 1000 );
+const _DEFAULT_CAMERA = new THREE.PerspectiveCamera( 50, 1, 0.01, 1000 );
 _DEFAULT_CAMERA.name = 'Camera';
 _DEFAULT_CAMERA.position.set( 0, 5, 10 );
 _DEFAULT_CAMERA.lookAt( new THREE.Vector3() );
@@ -168,7 +168,7 @@ Editor.prototype = {
 
 	addObject: function ( object, parent, index ) {
 
-		var scope = this;
+		const scope = this;
 
 		object.traverse( function ( child ) {
 
@@ -207,7 +207,7 @@ Editor.prototype = {
 
 		if ( object.parent === null ) return; // avoid deleting the camera or scene
 
-		var scope = this;
+		const scope = this;
 
 		object.traverse( function ( child ) {
 
@@ -242,7 +242,7 @@ Editor.prototype = {
 
 		if ( Array.isArray( material ) ) {
 
-			for ( var i = 0, l = material.length; i < l; i ++ ) {
+			for ( let i = 0, l = material.length; i < l; i ++ ) {
 
 				this.addMaterialToRefCounter( material[ i ] );
 
@@ -260,9 +260,9 @@ Editor.prototype = {
 
 	addMaterialToRefCounter: function ( material ) {
 
-		var materialsRefCounter = this.materialsRefCounter;
+		const materialsRefCounter = this.materialsRefCounter;
 
-		var count = materialsRefCounter.get( material );
+		let count = materialsRefCounter.get( material );
 
 		if ( count === undefined ) {
 
@@ -282,7 +282,7 @@ Editor.prototype = {
 
 		if ( Array.isArray( material ) ) {
 
-			for ( var i = 0, l = material.length; i < l; i ++ ) {
+			for ( let i = 0, l = material.length; i < l; i ++ ) {
 
 				this.removeMaterialFromRefCounter( material[ i ] );
 
@@ -300,9 +300,9 @@ Editor.prototype = {
 
 	removeMaterialFromRefCounter: function ( material ) {
 
-		var materialsRefCounter = this.materialsRefCounter;
+		const materialsRefCounter = this.materialsRefCounter;
 
-		var count = materialsRefCounter.get( material );
+		let count = materialsRefCounter.get( material );
 		count --;
 
 		if ( count === 0 ) {
@@ -320,10 +320,10 @@ Editor.prototype = {
 
 	getMaterialById: function ( id ) {
 
-		var material;
-		var materials = Object.values( this.materials );
+		let material;
+		const materials = Object.values( this.materials );
 
-		for ( var i = 0; i < materials.length; i ++ ) {
+		for ( let i = 0; i < materials.length; i ++ ) {
 
 			if ( materials[ i ].id === id ) {
 
@@ -381,8 +381,8 @@ Editor.prototype = {
 
 	addHelper: function () {
 
-		var geometry = new THREE.SphereGeometry( 2, 4, 2 );
-		var material = new THREE.MeshBasicMaterial( { color: 0xff0000, visible: false } );
+		const geometry = new THREE.SphereGeometry( 2, 4, 2 );
+		const material = new THREE.MeshBasicMaterial( { color: 0xff0000, visible: false } );
 
 		return function ( object, helper ) {
 
@@ -443,7 +443,7 @@ Editor.prototype = {
 
 		if ( this.helpers[ object.id ] !== undefined ) {
 
-			var helper = this.helpers[ object.id ];
+			const helper = this.helpers[ object.id ];
 			helper.parent.remove( helper );
 			helper.dispose();
 
@@ -475,7 +475,7 @@ Editor.prototype = {
 
 		if ( this.scripts[ object.uuid ] === undefined ) return;
 
-		var index = this.scripts[ object.uuid ].indexOf( script );
+		const index = this.scripts[ object.uuid ].indexOf( script );
 
 		if ( index !== - 1 ) {
 
@@ -489,7 +489,7 @@ Editor.prototype = {
 
 	getObjectMaterial: function ( object, slot ) {
 
-		var material = object.material;
+		let material = object.material;
 
 		if ( Array.isArray( material ) && slot !== undefined ) {
 
@@ -552,7 +552,7 @@ Editor.prototype = {
 
 	selectByUuid: function ( uuid ) {
 
-		var scope = this;
+		const scope = this;
 
 		this.scene.traverse( function ( child ) {
 
@@ -602,7 +602,7 @@ Editor.prototype = {
 		this.scene.environment = null;
 		this.scene.fog = null;
 
-		var objects = this.scene.children;
+		const objects = this.scene.children;
 
 		this.signals.sceneGraphChanged.active = false;
 
@@ -634,8 +634,8 @@ Editor.prototype = {
 
 	fromJSON: async function ( json ) {
 
-		var loader = new THREE.ObjectLoader();
-		var camera = await loader.parseAsync( json.camera );
+		const loader = new THREE.ObjectLoader();
+		const camera = await loader.parseAsync( json.camera );
 
 		const existingUuid = this.camera.uuid;
 		const incomingUuid = camera.uuid;
@@ -667,12 +667,12 @@ Editor.prototype = {
 
 		// scripts clean up
 
-		var scene = this.scene;
-		var scripts = this.scripts;
+		const scene = this.scene;
+		const scripts = this.scripts;
 
-		for ( var key in scripts ) {
+		for ( const key in scripts ) {
 
-			var script = scripts[ key ];
+			const script = scripts[ key ];
 
 			if ( script.length === 0 || scene.getObjectByProperty( 'uuid', key ) === undefined ) {
 

--- a/editor/js/EditorControls.js
+++ b/editor/js/EditorControls.js
@@ -16,31 +16,31 @@ class EditorControls extends THREE.EventDispatcher {
 
 		// internals
 
-		var scope = this;
-		var vector = new THREE.Vector3();
-		var delta = new THREE.Vector3();
-		var box = new THREE.Box3();
+		const scope = this;
+		const vector = new THREE.Vector3();
+		const delta = new THREE.Vector3();
+		const box = new THREE.Box3();
 
-		var STATE = { NONE: - 1, ROTATE: 0, ZOOM: 1, PAN: 2 };
-		var state = STATE.NONE;
+		const STATE = { NONE: - 1, ROTATE: 0, ZOOM: 1, PAN: 2 };
+		let state = STATE.NONE;
 
-		var center = this.center;
-		var normalMatrix = new THREE.Matrix3();
-		var pointer = new THREE.Vector2();
-		var pointerOld = new THREE.Vector2();
-		var spherical = new THREE.Spherical();
-		var sphere = new THREE.Sphere();
+		const center = this.center;
+		const normalMatrix = new THREE.Matrix3();
+		const pointer = new THREE.Vector2();
+		const pointerOld = new THREE.Vector2();
+		const spherical = new THREE.Spherical();
+		const sphere = new THREE.Sphere();
 
-		var pointers = [];
-		var pointerPositions = {};
+		const pointers = [];
+		const pointerPositions = {};
 
 		// events
 
-		var changeEvent = { type: 'change' };
+		const changeEvent = { type: 'change' };
 
 		this.focus = function ( target ) {
 
-			var distance;
+			let distance;
 
 			box.setFromObject( target );
 
@@ -70,7 +70,7 @@ class EditorControls extends THREE.EventDispatcher {
 
 		this.pan = function ( delta ) {
 
-			var distance = object.position.distanceTo( center );
+			const distance = object.position.distanceTo( center );
 
 			delta.multiplyScalar( distance * scope.panSpeed );
 			delta.applyMatrix3( normalMatrix.getNormalMatrix( object.matrix ) );
@@ -84,7 +84,7 @@ class EditorControls extends THREE.EventDispatcher {
 
 		this.zoom = function ( delta ) {
 
-			var distance = object.position.distanceTo( center );
+			const distance = object.position.distanceTo( center );
 
 			delta.multiplyScalar( distance * scope.zoomSpeed );
 
@@ -187,8 +187,8 @@ class EditorControls extends THREE.EventDispatcher {
 
 				case 1:
 
-					var pointerId = pointers[ 0 ];
-					var position = pointerPositions[ pointerId ];
+					const pointerId = pointers[ 0 ];
+					const position = pointerPositions[ pointerId ];
 
 					// minimal placeholder event - allows state correction on pointer-up
 					onTouchStart( { pointerId: pointerId, pageX: position.x, pageY: position.y } );
@@ -225,8 +225,8 @@ class EditorControls extends THREE.EventDispatcher {
 
 			pointer.set( event.clientX, event.clientY );
 
-			var movementX = pointer.x - pointerOld.x;
-			var movementY = pointer.y - pointerOld.y;
+			const movementX = pointer.x - pointerOld.x;
+			const movementY = pointer.y - pointerOld.y;
 
 			if ( state === STATE.ROTATE ) {
 
@@ -287,10 +287,10 @@ class EditorControls extends THREE.EventDispatcher {
 
 		// touch
 
-		var touches = [ new THREE.Vector3(), new THREE.Vector3(), new THREE.Vector3() ];
-		var prevTouches = [ new THREE.Vector3(), new THREE.Vector3(), new THREE.Vector3() ];
+		const touches = [ new THREE.Vector3(), new THREE.Vector3(), new THREE.Vector3() ];
+		const prevTouches = [ new THREE.Vector3(), new THREE.Vector3(), new THREE.Vector3() ];
 
-		var prevDistance = null;
+		let prevDistance = null;
 
 		function onTouchStart( event ) {
 
@@ -305,7 +305,7 @@ class EditorControls extends THREE.EventDispatcher {
 
 				case 2:
 
-					var position = getSecondPointerPosition( event );
+					const position = getSecondPointerPosition( event );
 
 					touches[ 0 ].set( event.pageX, event.pageY, 0 ).divideScalar( window.devicePixelRatio );
 					touches[ 1 ].set( position.x, position.y, 0 ).divideScalar( window.devicePixelRatio );
@@ -326,9 +326,9 @@ class EditorControls extends THREE.EventDispatcher {
 
 			function getClosest( touch, touches ) {
 
-				var closest = touches[ 0 ];
+				let closest = touches[ 0 ];
 
-				for ( var touch2 of touches ) {
+				for ( const touch2 of touches ) {
 
 					if ( closest.distanceTo( touch ) > touch2.distanceTo( touch ) ) closest = touch2;
 
@@ -348,17 +348,17 @@ class EditorControls extends THREE.EventDispatcher {
 
 				case 2:
 
-					var position = getSecondPointerPosition( event );
+					const position = getSecondPointerPosition( event );
 
 					touches[ 0 ].set( event.pageX, event.pageY, 0 ).divideScalar( window.devicePixelRatio );
 					touches[ 1 ].set( position.x, position.y, 0 ).divideScalar( window.devicePixelRatio );
-					var distance = touches[ 0 ].distanceTo( touches[ 1 ] );
+					const distance = touches[ 0 ].distanceTo( touches[ 1 ] );
 					scope.zoom( delta.set( 0, 0, prevDistance - distance ) );
 					prevDistance = distance;
 
 
-					var offset0 = touches[ 0 ].clone().sub( getClosest( touches[ 0 ], prevTouches ) );
-					var offset1 = touches[ 1 ].clone().sub( getClosest( touches[ 1 ], prevTouches ) );
+					const offset0 = touches[ 0 ].clone().sub( getClosest( touches[ 0 ], prevTouches ) );
+					const offset1 = touches[ 1 ].clone().sub( getClosest( touches[ 1 ], prevTouches ) );
 					offset0.x = - offset0.x;
 					offset1.x = - offset1.x;
 
@@ -383,7 +383,7 @@ class EditorControls extends THREE.EventDispatcher {
 
 			delete pointerPositions[ event.pointerId ];
 
-			for ( var i = 0; i < pointers.length; i ++ ) {
+			for ( let i = 0; i < pointers.length; i ++ ) {
 
 				if ( pointers[ i ] == event.pointerId ) {
 
@@ -398,7 +398,7 @@ class EditorControls extends THREE.EventDispatcher {
 
 		function isTrackingPointer( event ) {
 
-			for ( var i = 0; i < pointers.length; i ++ ) {
+			for ( let i = 0; i < pointers.length; i ++ ) {
 
 				if ( pointers[ i ] == event.pointerId ) return true;
 
@@ -410,7 +410,7 @@ class EditorControls extends THREE.EventDispatcher {
 
 		function trackPointer( event ) {
 
-			var position = pointerPositions[ event.pointerId ];
+			let position = pointerPositions[ event.pointerId ];
 
 			if ( position === undefined ) {
 
@@ -425,7 +425,7 @@ class EditorControls extends THREE.EventDispatcher {
 
 		function getSecondPointerPosition( event ) {
 
-			var pointerId = ( event.pointerId === pointers[ 0 ] ) ? pointers[ 1 ] : pointers[ 0 ];
+			const pointerId = ( event.pointerId === pointers[ 0 ] ) ? pointers[ 1 ] : pointers[ 0 ];
 
 			return pointerPositions[ pointerId ];
 

--- a/examples/jsm/loaders/RGBMLoader.js
+++ b/examples/jsm/loaders/RGBMLoader.js
@@ -147,18 +147,18 @@ var UPNG = {};
 
 UPNG.toRGBA8 = function ( out ) {
 
-	var w = out.width, h = out.height;
+	const w = out.width, h = out.height;
 	if ( out.tabs.acTL == null ) return [ UPNG.toRGBA8.decodeImage( out.data, w, h, out ).buffer ];
 
-	var frms = [];
+	const frms = [];
 	if ( out.frames[ 0 ].data == null ) out.frames[ 0 ].data = out.data;
 
-	var len = w * h * 4, img = new Uint8Array( len ), empty = new Uint8Array( len ), prev = new Uint8Array( len );
-	for ( var i = 0; i < out.frames.length; i ++ ) {
+	const len = w * h * 4, img = new Uint8Array( len ), empty = new Uint8Array( len ), prev = new Uint8Array( len );
+	for ( let i = 0; i < out.frames.length; i ++ ) {
 
-		var frm = out.frames[ i ];
-		var fx = frm.rect.x, fy = frm.rect.y, fw = frm.rect.width, fh = frm.rect.height;
-		var fdata = UPNG.toRGBA8.decodeImage( frm.data, fw, fh, out );
+		const frm = out.frames[ i ];
+		const fx = frm.rect.x, fy = frm.rect.y, fw = frm.rect.width, fh = frm.rect.height;
+		const fdata = UPNG.toRGBA8.decodeImage( frm.data, fw, fh, out );
 
 		if ( i != 0 ) for ( var j = 0; j < len; j ++ ) prev[ j ] = img[ j ];
 
@@ -178,16 +178,16 @@ UPNG.toRGBA8 = function ( out ) {
 
 UPNG.toRGBA8.decodeImage = function ( data, w, h, out ) {
 
-	var area = w * h, bpp = UPNG.decode._getBPP( out );
-	var bpl = Math.ceil( w * bpp / 8 );	// bytes per line
+	const area = w * h, bpp = UPNG.decode._getBPP( out );
+	const bpl = Math.ceil( w * bpp / 8 );	// bytes per line
 
-	var bf = new Uint8Array( area * 4 ), bf32 = new Uint32Array( bf.buffer );
-	var ctype = out.ctype, depth = out.depth;
-	var rs = UPNG._bin.readUshort;
+	const bf = new Uint8Array( area * 4 ), bf32 = new Uint32Array( bf.buffer );
+	const ctype = out.ctype, depth = out.depth;
+	const rs = UPNG._bin.readUshort;
 
 	if ( ctype == 6 ) { // RGB + alpha
 
-		var qarea = area << 2;
+		const qarea = area << 2;
 		if ( depth == 8 ) for ( var i = 0; i < qarea; i += 4 ) {
 
 			bf[ i ] = data[ i ]; bf[ i + 1 ] = data[ i + 1 ]; bf[ i + 2 ] = data[ i + 2 ]; bf[ i + 3 ] = data[ i + 3 ];
@@ -202,7 +202,7 @@ UPNG.toRGBA8.decodeImage = function ( data, w, h, out ) {
 
 	} else if ( ctype == 2 ) {	// RGB
 
-		var ts = out.tabs[ 'tRNS' ];
+		const ts = out.tabs[ 'tRNS' ];
 		if ( ts == null ) {
 
 			if ( depth == 8 ) for ( var i = 0; i < area; i ++ ) {
@@ -238,7 +238,7 @@ UPNG.toRGBA8.decodeImage = function ( data, w, h, out ) {
 
 	} else if ( ctype == 3 ) {	// palette
 
-		var p = out.tabs[ 'PLTE' ], ap = out.tabs[ 'tRNS' ], tl = ap ? ap.length : 0;
+		const p = out.tabs[ 'PLTE' ], ap = out.tabs[ 'tRNS' ], tl = ap ? ap.length : 0;
 		//console.log(p, ap);
 		if ( depth == 1 ) for ( var y = 0; y < h; y ++ ) {
 
@@ -298,7 +298,7 @@ UPNG.toRGBA8.decodeImage = function ( data, w, h, out ) {
 		var tr = out.tabs[ 'tRNS' ] ? out.tabs[ 'tRNS' ] : - 1;
 		for ( var y = 0; y < h; y ++ ) {
 
-			var off = y * bpl, to = y * w;
+			const off = y * bpl, to = y * w;
 			if ( depth == 1 ) for ( var x = 0; x < w; x ++ ) {
 
 				var gr = 255 * ( ( data[ off + ( x >>> 3 ) ] >>> ( 7 - ( x & 7 ) ) ) & 1 ), al = ( gr == tr * 255 ) ? 0 : 255; bf32[ to + x ] = ( al << 24 ) | ( gr << 16 ) | ( gr << 8 ) | gr;
@@ -338,19 +338,19 @@ UPNG.toRGBA8.decodeImage = function ( data, w, h, out ) {
 
 UPNG.decode = function ( buff ) {
 
-	var data = new Uint8Array( buff ), offset = 8, bin = UPNG._bin, rUs = bin.readUshort, rUi = bin.readUint;
-	var out = { tabs: {}, frames: [] };
-	var dd = new Uint8Array( data.length ), doff = 0;	 // put all IDAT data into it
-	var fd, foff = 0;	// frames
-	var text, keyw, bfr;
+	let data = new Uint8Array( buff ), offset = 8, bin = UPNG._bin, rUs = bin.readUshort, rUi = bin.readUint;
+	const out = { tabs: {}, frames: [] };
+	let dd = new Uint8Array( data.length ), doff = 0;	 // put all IDAT data into it
+	let fd, foff = 0;	// frames
+	let text, keyw, bfr;
 
-	var mgck = [ 0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a ];
+	const mgck = [ 0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a ];
 	for ( var i = 0; i < 8; i ++ ) if ( data[ i ] != mgck[ i ] ) throw new Error( 'The input is not a PNG file!' );
 
 	while ( offset < data.length ) {
 
-		var len = bin.readUint( data, offset ); offset += 4;
-		var type = bin.readASCII( data, offset, 4 ); offset += 4;
+		const len = bin.readUint( data, offset ); offset += 4;
+		const type = bin.readASCII( data, offset, 4 ); offset += 4;
 		//console.log(type,len);
 
 		if ( type == 'IHDR' ) {
@@ -380,9 +380,9 @@ UPNG.decode = function ( buff ) {
 
 			}
 
-			var rct = { x: rUi( data, offset + 12 ), y: rUi( data, offset + 16 ), width: rUi( data, offset + 4 ), height: rUi( data, offset + 8 ) };
-			var del = rUs( data, offset + 22 ); del = rUs( data, offset + 20 ) / ( del == 0 ? 100 : del );
-			var frm = { rect: rct, delay: Math.round( del * 1000 ), dispose: data[ offset + 24 ], blend: data[ offset + 25 ] };
+			const rct = { x: rUi( data, offset + 12 ), y: rUi( data, offset + 16 ), width: rUi( data, offset + 4 ), height: rUi( data, offset + 8 ) };
+			let del = rUs( data, offset + 22 ); del = rUs( data, offset + 20 ) / ( del == 0 ? 100 : del );
+			const frm = { rect: rct, delay: Math.round( del * 1000 ), dispose: data[ offset + 24 ], blend: data[ offset + 25 ] };
 			//console.log(frm);
 			out.frames.push( frm );
 
@@ -422,7 +422,7 @@ UPNG.decode = function ( buff ) {
 			var nz = 0, off = offset;
 			nz = bin.nextZero( data, off );
 			keyw = bin.readASCII( data, off, nz - off ); off = nz + 1;
-			var cflag = data[ off ]; off += 2;
+			const cflag = data[ off ]; off += 2;
 			nz = bin.nextZero( data, off );
 			bin.readASCII( data, off, nz - off ); off = nz + 1;
 			nz = bin.nextZero( data, off );
@@ -444,7 +444,7 @@ UPNG.decode = function ( buff ) {
 
 		} else if ( type == 'hIST' ) {
 
-			var pl = out.tabs[ 'PLTE' ].length / 3;
+			const pl = out.tabs[ 'PLTE' ].length / 3;
 			out.tabs[ type ] = []; for ( var i = 0; i < pl; i ++ ) out.tabs[ type ].push( rUs( data, offset + i * 2 ) );
 
 		} else if ( type == 'tRNS' ) {
@@ -490,7 +490,7 @@ UPNG.decode = function ( buff ) {
 
 UPNG.decode._decompress = function ( out, dd, w, h ) {
 
-	var bpp = UPNG.decode._getBPP( out ), bpl = Math.ceil( w * bpp / 8 ), buff = new Uint8Array( ( bpl + 1 + out.interlace ) * h );
+	const bpp = UPNG.decode._getBPP( out ), bpl = Math.ceil( w * bpp / 8 ), buff = new Uint8Array( ( bpl + 1 + out.interlace ) * h );
 	if ( out.tabs[ 'CgBI' ] ) dd = UPNG.inflateRaw( dd, buff );
 	else dd = UPNG.decode._inflate( dd, buff );
 
@@ -503,22 +503,22 @@ UPNG.decode._decompress = function ( out, dd, w, h ) {
 
 UPNG.decode._inflate = function ( data, buff ) {
 
-	var out = UPNG[ 'inflateRaw' ]( new Uint8Array( data.buffer, 2, data.length - 6 ), buff ); return out;
+	const out = UPNG[ 'inflateRaw' ]( new Uint8Array( data.buffer, 2, data.length - 6 ), buff ); return out;
 
 };
 
 UPNG.inflateRaw = function () {
 
-	var H = {}; H.H = {}; H.H.N = function ( N, W ) {
+	const H = {}; H.H = {}; H.H.N = function ( N, W ) {
 
-		var R = Uint8Array, i = 0, m = 0, J = 0, h = 0, Q = 0, X = 0, u = 0, w = 0, d = 0, v, C;
-		if ( N[ 0 ] == 3 && N[ 1 ] == 0 ) return W ? W : new R( 0 ); var V = H.H, n = V.b, A = V.e, l = V.R, M = V.n, I = V.A, e = V.Z, b = V.m, Z = W == null;
+		let R = Uint8Array, i = 0, m = 0, J = 0, h = 0, Q = 0, X = 0, u = 0, w = 0, d = 0, v, C;
+		if ( N[ 0 ] == 3 && N[ 1 ] == 0 ) return W ? W : new R( 0 ); const V = H.H, n = V.b, A = V.e, l = V.R, M = V.n, I = V.A, e = V.Z, b = V.m, Z = W == null;
 		if ( Z )W = new R( N.length >>> 2 << 5 ); while ( i == 0 ) {
 
 			i = n( N, d, 1 ); m = n( N, d + 1, 2 ); d += 3; if ( m == 0 ) {
 
 				if ( ( d & 7 ) != 0 )d += 8 - ( d & 7 );
-				var D = ( d >>> 3 ) + 4, q = N[ D - 4 ] | N[ D - 3 ] << 8; if ( Z )W = H.H.W( W, w + q ); W.set( new R( N.buffer, N.byteOffset + D, q ), w ); d = D + q << 3;
+				const D = ( d >>> 3 ) + 4, q = N[ D - 4 ] | N[ D - 3 ] << 8; if ( Z )W = H.H.W( W, w + q ); W.set( new R( N.buffer, N.byteOffset + D, q ), w ); d = D + q << 3;
 				w += q; continue
 				;
 
@@ -533,7 +533,7 @@ UPNG.inflateRaw = function () {
 			if ( m == 2 ) {
 
 				J = A( N, d, 5 ) + 257;
-				h = A( N, d + 5, 5 ) + 1; Q = A( N, d + 10, 4 ) + 4; d += 14; var j = 1; for ( var c = 0; c < 38; c += 2 ) {
+				h = A( N, d + 5, 5 ) + 1; Q = A( N, d + 10, 4 ) + 4; d += 14; let j = 1; for ( var c = 0; c < 38; c += 2 ) {
 
 					b.Q[ c ] = 0; b.Q[ c + 1 ] = 0;
 
@@ -542,13 +542,13 @@ UPNG.inflateRaw = function () {
 				for ( var c = 0;
 					c < Q; c ++ ) {
 
-					var K = A( N, d + c * 3, 3 ); b.Q[ ( b.X[ c ] << 1 ) + 1 ] = K; if ( K > j )j = K
+					const K = A( N, d + c * 3, 3 ); b.Q[ ( b.X[ c ] << 1 ) + 1 ] = K; if ( K > j )j = K
 					;
 
 				}
 
 				d += 3 * Q; M( b.Q, j ); I( b.Q, j, b.u ); v = b.w; C = b.d;
-				d = l( b.u, ( 1 << j ) - 1, J + h, N, d, b.v ); var r = V.V( b.v, 0, J, b.C ); X = ( 1 << r ) - 1; var S = V.V( b.v, J, h, b.D ); u = ( 1 << S ) - 1; M( b.C, r );
+				d = l( b.u, ( 1 << j ) - 1, J + h, N, d, b.v ); const r = V.V( b.v, 0, J, b.C ); X = ( 1 << r ) - 1; const S = V.V( b.v, J, h, b.D ); u = ( 1 << S ) - 1; M( b.C, r );
 				I( b.C, r, v ); M( b.D, S ); I( b.D, S, C )
 				;
 
@@ -556,7 +556,7 @@ UPNG.inflateRaw = function () {
 
 			while ( ! 0 ) {
 
-				var T = v[ e( N, d ) & X ]; d += T & 15; var p = T >>> 4; if ( p >>> 8 == 0 ) {
+				const T = v[ e( N, d ) & X ]; d += T & 15; const p = T >>> 4; if ( p >>> 8 == 0 ) {
 
 					W[ w ++ ] = p;
 
@@ -566,14 +566,14 @@ UPNG.inflateRaw = function () {
 
 				} else {
 
-					var z = w + p - 254;
+					let z = w + p - 254;
 					if ( p > 264 ) {
 
-						var _ = b.q[ p - 257 ]; z = w + ( _ >>> 3 ) + A( N, d, _ & 7 ); d += _ & 7;
+						const _ = b.q[ p - 257 ]; z = w + ( _ >>> 3 ) + A( N, d, _ & 7 ); d += _ & 7;
 
 					}
 
-					var $ = C[ e( N, d ) & u ]; d += $ & 15; var s = $ >>> 4, Y = b.c[ s ], a = ( Y >>> 4 ) + n( N, d, Y & 15 );
+					const $ = C[ e( N, d ) & u ]; d += $ & 15; const s = $ >>> 4, Y = b.c[ s ], a = ( Y >>> 4 ) + n( N, d, Y & 15 );
 					d += Y & 15; while ( w < z ) {
 
 						W[ w ] = W[ w ++ - a ]; W[ w ] = W[ w ++ - a ]; W[ w ] = W[ w ++ - a ]; W[ w ] = W[ w ++ - a ];
@@ -596,22 +596,22 @@ UPNG.inflateRaw = function () {
 
 	H.H.W = function ( N, W ) {
 
-		var R = N.length; if ( W <= R ) return N; var V = new Uint8Array( R << 1 ); V.set( N, 0 ); return V;
+		const R = N.length; if ( W <= R ) return N; const V = new Uint8Array( R << 1 ); V.set( N, 0 ); return V;
 
 	};
 
 	H.H.R = function ( N, W, R, V, n, A ) {
 
-		var l = H.H.e, M = H.H.Z, I = 0; while ( I < R ) {
+		let l = H.H.e, M = H.H.Z, I = 0; while ( I < R ) {
 
-			var e = N[ M( V, n ) & W ]; n += e & 15; var b = e >>> 4;
+			const e = N[ M( V, n ) & W ]; n += e & 15; const b = e >>> 4;
 			if ( b <= 15 ) {
 
 				A[ I ] = b; I ++;
 
 			} else {
 
-				var Z = 0, m = 0; if ( b == 16 ) {
+				let Z = 0, m = 0; if ( b == 16 ) {
 
 					m = 3 + l( V, n, 2 ); n += 2; Z = A[ I - 1 ];
 
@@ -627,7 +627,7 @@ UPNG.inflateRaw = function () {
 
 				}
 
-				var J = I + m; while ( I < J ) {
+				const J = I + m; while ( I < J ) {
 
 					A[ I ] = Z; I ++;
 
@@ -644,10 +644,10 @@ UPNG.inflateRaw = function () {
 
 	H.H.V = function ( N, W, R, V ) {
 
-		var n = 0, A = 0, l = V.length >>> 1;
+		let n = 0, A = 0, l = V.length >>> 1;
 		while ( A < R ) {
 
-			var M = N[ A + W ]; V[ A << 1 ] = 0; V[ ( A << 1 ) + 1 ] = M; if ( M > n )n = M; A ++;
+			const M = N[ A + W ]; V[ A << 1 ] = 0; V[ ( A << 1 ) + 1 ] = M; if ( M > n )n = M; A ++;
 
 		}
 
@@ -665,7 +665,7 @@ UPNG.inflateRaw = function () {
 	H.H.n = function ( N, W ) {
 
 		var R = H.H.m, V = N.length, n, A, l, M, I, e = R.j; for ( var M = 0; M <= W; M ++ )e[ M ] = 0; for ( M = 1; M < V; M += 2 )e[ N[ M ] ] ++;
-		var b = R.K; n = 0; e[ 0 ] = 0; for ( A = 1; A <= W; A ++ ) {
+		const b = R.K; n = 0; e[ 0 ] = 0; for ( A = 1; A <= W; A ++ ) {
 
 			n = n + e[ A - 1 ] << 1; b[ A ] = n;
 
@@ -687,12 +687,12 @@ UPNG.inflateRaw = function () {
 
 	H.H.A = function ( N, W, R ) {
 
-		var V = N.length, n = H.H.m, A = n.r; for ( var l = 0; l < V; l += 2 ) if ( N[ l + 1 ] != 0 ) {
+		const V = N.length, n = H.H.m, A = n.r; for ( let l = 0; l < V; l += 2 ) if ( N[ l + 1 ] != 0 ) {
 
-			var M = l >> 1, I = N[ l + 1 ], e = M << 4 | I, b = W - I, Z = N[ l ] << b, m = Z + ( 1 << b );
+			let M = l >> 1, I = N[ l + 1 ], e = M << 4 | I, b = W - I, Z = N[ l ] << b, m = Z + ( 1 << b );
 			while ( Z != m ) {
 
-				var J = A[ Z ] >>> 15 - W; R[ J ] = e; Z ++;
+				const J = A[ Z ] >>> 15 - W; R[ J ] = e; Z ++;
 
 			}
 
@@ -702,10 +702,10 @@ UPNG.inflateRaw = function () {
 
 	H.H.l = function ( N, W ) {
 
-		var R = H.H.m.r, V = 15 - W; for ( var n = 0; n < N.length;
+		const R = H.H.m.r, V = 15 - W; for ( let n = 0; n < N.length;
 			n += 2 ) {
 
-			var A = N[ n ] << W - N[ n + 1 ]; N[ n ] = R[ A ] >>> V;
+			const A = N[ n ] << W - N[ n + 1 ]; N[ n ] = R[ A ] >>> V;
 
 		}
 
@@ -713,13 +713,13 @@ UPNG.inflateRaw = function () {
 
 	H.H.M = function ( N, W, R ) {
 
-		R = R << ( W & 7 ); var V = W >>> 3; N[ V ] |= R; N[ V + 1 ] |= R >>> 8;
+		R = R << ( W & 7 ); const V = W >>> 3; N[ V ] |= R; N[ V + 1 ] |= R >>> 8;
 
 	};
 
 	H.H.I = function ( N, W, R ) {
 
-		R = R << ( W & 7 ); var V = W >>> 3; N[ V ] |= R; N[ V + 1 ] |= R >>> 8; N[ V + 2 ] |= R >>> 16;
+		R = R << ( W & 7 ); const V = W >>> 3; N[ V ] |= R; N[ V + 1 ] |= R >>> 8; N[ V + 2 ] |= R >>> 16;
 
 	};
 
@@ -749,16 +749,16 @@ UPNG.inflateRaw = function () {
 
 	H.H.m = function () {
 
-		var N = Uint16Array, W = Uint32Array;
+		const N = Uint16Array, W = Uint32Array;
 		return { K: new N( 16 ), j: new N( 16 ), X: [ 16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15 ], S: [ 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 15, 17, 19, 23, 27, 31, 35, 43, 51, 59, 67, 83, 99, 115, 131, 163, 195, 227, 258, 999, 999, 999 ], T: [ 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 0, 0, 0, 0 ], q: new N( 32 ), p: [ 1, 2, 3, 4, 5, 7, 9, 13, 17, 25, 33, 49, 65, 97, 129, 193, 257, 385, 513, 769, 1025, 1537, 2049, 3073, 4097, 6145, 8193, 12289, 16385, 24577, 65535, 65535 ], z: [ 0, 0, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13, 0, 0 ], c: new W( 32 ), J: new N( 512 ), _: [], h: new N( 32 ), $: [], w: new N( 32768 ), C: [], v: [], d: new N( 32768 ), D: [], u: new N( 512 ), Q: [], r: new N( 1 << 15 ), s: new W( 286 ), Y: new W( 30 ), a: new W( 19 ), t: new W( 15e3 ), k: new N( 1 << 16 ), g: new N( 1 << 15 ) }
 		;
 
 	}();
 	( function () {
 
-		var N = H.H.m, W = 1 << 15; for ( var R = 0; R < W; R ++ ) {
+		const N = H.H.m, W = 1 << 15; for ( var R = 0; R < W; R ++ ) {
 
-			var V = R; V = ( V & 2863311530 ) >>> 1 | ( V & 1431655765 ) << 1;
+			let V = R; V = ( V & 2863311530 ) >>> 1 | ( V & 1431655765 ) << 1;
 			V = ( V & 3435973836 ) >>> 2 | ( V & 858993459 ) << 2; V = ( V & 4042322160 ) >>> 4 | ( V & 252645135 ) << 4; V = ( V & 4278255360 ) >>> 8 | ( V & 16711935 ) << 8;
 			N.r[ R ] = ( V >>> 16 | V << 16 ) >>> 17
 			;
@@ -795,43 +795,43 @@ UPNG.inflateRaw = function () {
 
 UPNG.decode._readInterlace = function ( data, out ) {
 
-	var w = out.width, h = out.height;
-	var bpp = UPNG.decode._getBPP( out ), cbpp = bpp >> 3, bpl = Math.ceil( w * bpp / 8 );
-	var img = new Uint8Array( h * bpl );
-	var di = 0;
+	const w = out.width, h = out.height;
+	const bpp = UPNG.decode._getBPP( out ), cbpp = bpp >> 3, bpl = Math.ceil( w * bpp / 8 );
+	const img = new Uint8Array( h * bpl );
+	let di = 0;
 
-	var starting_row = [ 0, 0, 4, 0, 2, 0, 1 ];
-	var starting_col = [ 0, 4, 0, 2, 0, 1, 0 ];
-	var row_increment = [ 8, 8, 8, 4, 4, 2, 2 ];
-	var col_increment = [ 8, 8, 4, 4, 2, 2, 1 ];
+	const starting_row = [ 0, 0, 4, 0, 2, 0, 1 ];
+	const starting_col = [ 0, 4, 0, 2, 0, 1, 0 ];
+	const row_increment = [ 8, 8, 8, 4, 4, 2, 2 ];
+	const col_increment = [ 8, 8, 4, 4, 2, 2, 1 ];
 
-	var pass = 0;
+	let pass = 0;
 	while ( pass < 7 ) {
 
-		var ri = row_increment[ pass ], ci = col_increment[ pass ];
-		var sw = 0, sh = 0;
-		var cr = starting_row[ pass ]; while ( cr < h ) {
+		const ri = row_increment[ pass ], ci = col_increment[ pass ];
+		let sw = 0, sh = 0;
+		let cr = starting_row[ pass ]; while ( cr < h ) {
 
 			cr += ri; sh ++;
 
 		}
 
-		var cc = starting_col[ pass ]; while ( cc < w ) {
+		let cc = starting_col[ pass ]; while ( cc < w ) {
 
 			cc += ci; sw ++;
 
 		}
 
-		var bpll = Math.ceil( sw * bpp / 8 );
+		const bpll = Math.ceil( sw * bpp / 8 );
 		UPNG.decode._filterZero( data, out, di, sw, sh );
 
-		var y = 0, row = starting_row[ pass ];
+		let y = 0, row = starting_row[ pass ];
 		var val;
 
 		while ( row < h ) {
 
-			var col = starting_col[ pass ];
-			var cdi = ( di + y * bpll ) << 3;
+			let col = starting_col[ pass ];
+			let cdi = ( di + y * bpll ) << 3;
 
 			while ( col < w ) {
 
@@ -858,8 +858,8 @@ UPNG.decode._readInterlace = function ( data, out ) {
 
 				if ( bpp >= 8 ) {
 
-					var ii = row * bpl + col * cbpp;
-					for ( var j = 0; j < cbpp; j ++ ) img[ ii + j ] = data[ ( cdi >> 3 ) + j ];
+					const ii = row * bpl + col * cbpp;
+					for ( let j = 0; j < cbpp; j ++ ) img[ ii + j ] = data[ ( cdi >> 3 ) + j ];
 
 				}
 
@@ -882,22 +882,22 @@ UPNG.decode._readInterlace = function ( data, out ) {
 
 UPNG.decode._getBPP = function ( out ) {
 
-	var noc = [ 1, null, 3, 1, 2, null, 4 ][ out.ctype ];
+	const noc = [ 1, null, 3, 1, 2, null, 4 ][ out.ctype ];
 	return noc * out.depth;
 
 };
 
 UPNG.decode._filterZero = function ( data, out, off, w, h ) {
 
-	var bpp = UPNG.decode._getBPP( out ), bpl = Math.ceil( w * bpp / 8 ), paeth = UPNG.decode._paeth;
+	let bpp = UPNG.decode._getBPP( out ), bpl = Math.ceil( w * bpp / 8 ), paeth = UPNG.decode._paeth;
 	bpp = Math.ceil( bpp / 8 );
 
-	var i, di, type = data[ off ], x = 0;
+	let i, di, type = data[ off ], x = 0;
 
 	if ( type > 1 ) data[ off ] = [ 0, 0, 1 ][ type - 2 ];
 	if ( type == 3 ) for ( x = bpp; x < bpl; x ++ ) data[ x + 1 ] = ( data[ x + 1 ] + ( data[ x + 1 - bpp ] >>> 1 ) ) & 255;
 
-	for ( var y = 0; y < h; y ++ ) {
+	for ( let y = 0; y < h; y ++ ) {
 
 		i = off + y * bpl; di = i + y + 1;
 		type = data[ di - 1 ]; x = 0;
@@ -932,7 +932,7 @@ UPNG.decode._filterZero = function ( data, out, off, w, h ) {
 
 UPNG.decode._paeth = function ( a, b, c ) {
 
-	var p = a + b - c, pa = ( p - a ), pb = ( p - b ), pc = ( p - c );
+	const p = a + b - c, pa = ( p - a ), pb = ( p - b ), pc = ( p - c );
 	if ( pa * pa <= pb * pb && pa * pa <= pc * pc ) return a;
 	else if ( pb * pb <= pc * pc ) return b;
 	return c;
@@ -941,7 +941,7 @@ UPNG.decode._paeth = function ( a, b, c ) {
 
 UPNG.decode._IHDR = function ( data, offset, out ) {
 
-	var bin = UPNG._bin;
+	const bin = UPNG._bin;
 	out.width = bin.readUint( data, offset ); offset += 4;
 	out.height = bin.readUint( data, offset ); offset += 4;
 	out.depth = data[ offset ]; offset ++;
@@ -980,17 +980,17 @@ UPNG._bin = {
 	},
 	readASCII: function ( buff, p, l ) {
 
-		var s = ''; for ( var i = 0; i < l; i ++ ) s += String.fromCharCode( buff[ p + i ] ); return s;
+		let s = ''; for ( let i = 0; i < l; i ++ ) s += String.fromCharCode( buff[ p + i ] ); return s;
 
 	},
 	writeASCII: function ( data, p, s ) {
 
-		for ( var i = 0; i < s.length; i ++ ) data[ p + i ] = s.charCodeAt( i );
+		for ( let i = 0; i < s.length; i ++ ) data[ p + i ] = s.charCodeAt( i );
 
 	},
 	readBytes: function ( buff, p, l ) {
 
-		var arr = []; for ( var i = 0; i < l; i ++ ) arr.push( buff[ p + i ] ); return arr;
+		const arr = []; for ( let i = 0; i < l; i ++ ) arr.push( buff[ p + i ] ); return arr;
 
 	},
 	pad: function ( n ) {
@@ -1000,8 +1000,8 @@ UPNG._bin = {
 	},
 	readUTF8: function ( buff, p, l ) {
 
-		var s = '', ns;
-		for ( var i = 0; i < l; i ++ ) s += '%' + UPNG._bin.pad( buff[ p + i ].toString( 16 ) );
+		let s = '', ns;
+		for ( let i = 0; i < l; i ++ ) s += '%' + UPNG._bin.pad( buff[ p + i ].toString( 16 ) );
 		try {
 
 			ns = decodeURIComponent( s );
@@ -1018,10 +1018,10 @@ UPNG._bin = {
 };
 UPNG._copyTile = function ( sb, sw, sh, tb, tw, th, xoff, yoff, mode ) {
 
-	var w = Math.min( sw, tw ), h = Math.min( sh, th );
-	var si = 0, ti = 0;
-	for ( var y = 0; y < h; y ++ )
-		for ( var x = 0; x < w; x ++ ) {
+	const w = Math.min( sw, tw ), h = Math.min( sh, th );
+	let si = 0, ti = 0;
+	for ( let y = 0; y < h; y ++ )
+		for ( let x = 0; x < w; x ++ ) {
 
 			if ( xoff >= 0 && yoff >= 0 ) {
 
@@ -1042,7 +1042,7 @@ UPNG._copyTile = function ( sb, sw, sh, tb, tw, th, xoff, yoff, mode ) {
 				var fa = sb[ si + 3 ] * ( 1 / 255 ), fr = sb[ si ] * fa, fg = sb[ si + 1 ] * fa, fb = sb[ si + 2 ] * fa;
 				var ba = tb[ ti + 3 ] * ( 1 / 255 ), br = tb[ ti ] * ba, bg = tb[ ti + 1 ] * ba, bb = tb[ ti + 2 ] * ba;
 
-				var ifa = 1 - fa, oa = fa + ba * ifa, ioa = ( oa == 0 ? 0 : 1 / oa );
+				const ifa = 1 - fa, oa = fa + ba * ifa, ioa = ( oa == 0 ? 0 : 1 / oa );
 				tb[ ti + 3 ] = 255 * oa;
 				tb[ ti + 0 ] = ( fr + br * ifa ) * ioa;
 				tb[ ti + 1 ] = ( fg + bg * ifa ) * ioa;

--- a/examples/jsm/loaders/lwo/IFFParser.js
+++ b/examples/jsm/loaders/lwo/IFFParser.js
@@ -86,7 +86,7 @@ class IFFParser {
 
 		this.debugger.offset = this.reader.offset;
 
-		var topForm = this.reader.getIDTag();
+		const topForm = this.reader.getIDTag();
 
 		if ( topForm !== 'FORM' ) {
 
@@ -95,12 +95,12 @@ class IFFParser {
 
 		}
 
-		var length = this.reader.getUint32();
+		const length = this.reader.getUint32();
 
 		this.debugger.dataOffset = this.reader.offset;
 		this.debugger.length = length;
 
-		var type = this.reader.getIDTag();
+		const type = this.reader.getIDTag();
 
 		if ( type === 'LWO2' ) {
 
@@ -129,7 +129,7 @@ class IFFParser {
 	// FORM ::= 'FORM'[ID4], length[U4], type[ID4], ( chunk[CHUNK] | form[FORM] ) * }
 	parseForm( length ) {
 
-		var type = this.reader.getIDTag();
+		const type = this.reader.getIDTag();
 
 		switch ( type ) {
 
@@ -350,9 +350,9 @@ class IFFParser {
 
 		this.reader.skip( 8 ); // unknown Uint32 x2
 
-		var name = this.reader.getString();
+		const name = this.reader.getString();
 
-		var surface = {
+		const surface = {
 			attributes: {}, // LWO2 style non-node attributes will go here
 			connections: {},
 			name: name,
@@ -372,9 +372,9 @@ class IFFParser {
 
 	parseSurfaceLwo2( length ) {
 
-		var name = this.reader.getString();
+		const name = this.reader.getString();
 
-		var surface = {
+		const surface = {
 			attributes: {}, // LWO2 style non-node attributes will go here
 			connections: {},
 			name: name,
@@ -398,9 +398,9 @@ class IFFParser {
 		// some subnodes can be renamed, but Input and Surface cannot
 
 		this.reader.skip( 8 ); // NRNM + length
-		var name = this.reader.getString();
+		const name = this.reader.getString();
 
-		var node = {
+		const node = {
 			name: name
 		};
 		this.currentForm = node;
@@ -425,7 +425,7 @@ class IFFParser {
 	parseEntryForm( length ) {
 
 		this.reader.skip( 8 ); // NAME + length
-		var name = this.reader.getString();
+		const name = this.reader.getString();
 		this.currentForm = this.currentNode.attributes;
 
 		this.setupForm( name, length );
@@ -438,7 +438,7 @@ class IFFParser {
 
 		this.reader.skip( 8 ); // unknown + length
 
-		var valueType = this.reader.getString();
+		const valueType = this.reader.getString();
 
 		if ( valueType === 'double' ) {
 
@@ -480,7 +480,7 @@ class IFFParser {
 
 		if ( ! this.currentForm.maps ) this.currentForm.maps = [];
 
-		var map = {};
+		const map = {};
 		this.currentForm.maps.push( map );
 		this.currentForm = map;
 
@@ -541,7 +541,7 @@ class IFFParser {
 	// level and they have a different format in each case
 	parseClip( length ) {
 
-		var tag = this.reader.getIDTag();
+		const tag = this.reader.getIDTag();
 
 		// inside surface node
 		if ( tag === 'FORM' ) {
@@ -562,7 +562,7 @@ class IFFParser {
 
 		this.reader.skip( 8 ); // unknown
 
-		var texture = {
+		const texture = {
 			index: this.reader.getUint32()
 		};
 		this.tree.textures.push( texture );
@@ -572,7 +572,7 @@ class IFFParser {
 
 	parseClipLwo2( length ) {
 
-		var texture = {
+		const texture = {
 			index: this.reader.getUint32(),
 			fileName: ''
 		};
@@ -580,8 +580,8 @@ class IFFParser {
 		// search STIL block
 		while ( true ) {
 
-			var tag = this.reader.getIDTag();
-			var n_length = this.reader.getUint16();
+			const tag = this.reader.getIDTag();
+			const n_length = this.reader.getUint16();
 			if ( tag === 'STIL' ) {
 
 				texture.fileName = this.reader.getString();
@@ -611,7 +611,7 @@ class IFFParser {
 
 	parseXVAL( type, length ) {
 
-		var endOffset = this.reader.offset + length - 4;
+		const endOffset = this.reader.offset + length - 4;
 		this.reader.skip( 8 );
 
 		this.currentForm[ type ] = this.reader.getFloat32();
@@ -622,7 +622,7 @@ class IFFParser {
 
 	parseXVAL3( type, length ) {
 
-		var endOffset = this.reader.offset + length - 4;
+		const endOffset = this.reader.offset + length - 4;
 		this.reader.skip( 8 );
 
 		this.currentForm[ type ] = {
@@ -651,10 +651,10 @@ class IFFParser {
 	// LAYR: number[U2], flags[U2], pivot[VEC12], name[S0], parent[U2]
 	parseLayer( length ) {
 
-		var number = this.reader.getUint16();
-		var flags = this.reader.getUint16(); // If the least significant bit of flags is set, the layer is hidden.
-		var pivot = this.reader.getFloat32Array( 3 ); // Note: this seems to be superfluous, as the geometry is translated when pivot is present
-		var layer = {
+		const number = this.reader.getUint16();
+		const flags = this.reader.getUint16(); // If the least significant bit of flags is set, the layer is hidden.
+		const pivot = this.reader.getFloat32Array( 3 ); // Note: this seems to be superfluous, as the geometry is translated when pivot is present
+		const layer = {
 			number: number,
 			flags: flags, // If the least significant bit of flags is set, the layer is hidden.
 			pivot: [ - pivot[ 0 ], pivot[ 1 ], pivot[ 2 ] ], // Note: this seems to be superfluous, as the geometry is translated when pivot is present
@@ -664,7 +664,7 @@ class IFFParser {
 		this.tree.layers.push( layer );
 		this.currentLayer = layer;
 
-		var parsedLength = 16 + stringOffset( this.currentLayer.name ); // index ( 2 ) + flags( 2 ) + pivot( 12 ) + stringlength
+		const parsedLength = 16 + stringOffset( this.currentLayer.name ); // index ( 2 ) + flags( 2 ) + pivot( 12 ) + stringlength
 
 		// if we have not reached then end of the layer block, there must be a parent defined
 		this.currentLayer.parent = ( parsedLength < length ) ? this.reader.getUint16() : - 1; // omitted or -1 for no parent
@@ -677,7 +677,7 @@ class IFFParser {
 	parsePoints( length ) {
 
 		this.currentPoints = [];
-		for ( var i = 0; i < length / 4; i += 3 ) {
+		for ( let i = 0; i < length / 4; i += 3 ) {
 
 			// x -> -x to match three.js right handed coords
 			this.currentPoints.push( - this.reader.getFloat32(), this.reader.getFloat32(), this.reader.getFloat32() );
@@ -698,9 +698,9 @@ class IFFParser {
 	// VMAD { type[ID4], dimension[U2], name[S0], ( vert[VX], poly[VX], value[F4] # dimension ) * }
 	parseVertexMapping( length, discontinuous ) {
 
-		var finalOffset = this.reader.offset + length;
+		const finalOffset = this.reader.offset + length;
 
-		var channelName = this.reader.getString();
+		const channelName = this.reader.getString();
 
 		if ( this.reader.offset === finalOffset ) {
 
@@ -713,12 +713,12 @@ class IFFParser {
 		// otherwise reset to initial length and parse normal VMAP CHUNK
 		this.reader.setOffset( this.reader.offset - stringOffset( channelName ) );
 
-		var type = this.reader.getIDTag();
+		const type = this.reader.getIDTag();
 
 		this.reader.getUint16(); // dimension
-		var name = this.reader.getString();
+		const name = this.reader.getString();
 
-		var remainingLength = length - 6 - stringOffset( name );
+		const remainingLength = length - 6 - stringOffset( name );
 
 		switch ( type ) {
 
@@ -749,9 +749,9 @@ class IFFParser {
 
 	parseUVMapping( name, finalOffset, discontinuous ) {
 
-		var uvIndices = [];
-		var polyIndices = [];
-		var uvs = [];
+		const uvIndices = [];
+		const polyIndices = [];
+		const uvs = [];
 
 		while ( this.reader.offset < finalOffset ) {
 
@@ -788,8 +788,8 @@ class IFFParser {
 
 	parseMorphTargets( name, finalOffset, type ) {
 
-		var indices = [];
-		var points = [];
+		const indices = [];
+		const points = [];
 
 		type = ( type === 'MORF' ) ? 'relative' : 'absolute';
 
@@ -815,27 +815,27 @@ class IFFParser {
 	// POLS { type[ID4], ( numvert+flags[U2], vert[VX] # numvert ) * }
 	parsePolygonList( length ) {
 
-		var finalOffset = this.reader.offset + length;
-		var type = this.reader.getIDTag();
+		const finalOffset = this.reader.offset + length;
+		const type = this.reader.getIDTag();
 
-		var indices = [];
+		const indices = [];
 
 		// hold a list of polygon sizes, to be split up later
-		var polygonDimensions = [];
+		const polygonDimensions = [];
 
 		while ( this.reader.offset < finalOffset ) {
 
-			var numverts = this.reader.getUint16();
+			let numverts = this.reader.getUint16();
 
 			//var flags = numverts & 64512; // 6 high order bits are flags - ignoring for now
 			numverts = numverts & 1023; // remaining ten low order bits are vertex num
 			polygonDimensions.push( numverts );
 
-			for ( var j = 0; j < numverts; j ++ ) indices.push( this.reader.getVariableLengthIndex() );
+			for ( let j = 0; j < numverts; j ++ ) indices.push( this.reader.getVariableLengthIndex() );
 
 		}
 
-		var geometryData = {
+		const geometryData = {
 			type: type,
 			vertexIndices: indices,
 			polygonDimensions: polygonDimensions,
@@ -862,8 +862,8 @@ class IFFParser {
 	// PTAG { type[ID4], ( poly[VX], tag[U2] ) * }
 	parsePolygonTagMapping( length ) {
 
-		var finalOffset = this.reader.offset + length;
-		var type = this.reader.getIDTag();
+		const finalOffset = this.reader.offset + length;
+		const type = this.reader.getIDTag();
 		if ( type === 'SURF' ) this.parseMaterialIndices( finalOffset );
 		else { //PART, SMGP, COLR not supported
 
@@ -880,8 +880,8 @@ class IFFParser {
 
 		while ( this.reader.offset < finalOffset ) {
 
-			var polygonIndex = this.reader.getVariableLengthIndex();
-			var materialIndex = this.reader.getUint16();
+			const polygonIndex = this.reader.getVariableLengthIndex();
+			const materialIndex = this.reader.getUint16();
 
 			this.currentLayer.geometry.materialIndices.push( polygonIndex, materialIndex );
 
@@ -896,7 +896,7 @@ class IFFParser {
 		// print the chunk plus some bytes padding either side
 		// printBuffer( this.reader.dv.buffer, this.reader.offset - 20, length + 40 );
 
-		var data = this.reader.getString( length );
+		const data = this.reader.getString( length );
 
 		this.currentForm[ blockID ] = data;
 
@@ -951,7 +951,7 @@ class DataViewReader {
 
 	getUint8() {
 
-		var value = this.dv.getUint8( this.offset );
+		const value = this.dv.getUint8( this.offset );
 		this.offset += 1;
 		return value;
 
@@ -959,7 +959,7 @@ class DataViewReader {
 
 	getUint16() {
 
-		var value = this.dv.getUint16( this.offset );
+		const value = this.dv.getUint16( this.offset );
 		this.offset += 2;
 		return value;
 
@@ -967,7 +967,7 @@ class DataViewReader {
 
 	getInt32() {
 
-		var value = this.dv.getInt32( this.offset, false );
+		const value = this.dv.getInt32( this.offset, false );
 		this.offset += 4;
 		return value;
 
@@ -975,7 +975,7 @@ class DataViewReader {
 
 	getUint32() {
 
-		var value = this.dv.getUint32( this.offset, false );
+		const value = this.dv.getUint32( this.offset, false );
 		this.offset += 4;
 		return value;
 
@@ -983,17 +983,15 @@ class DataViewReader {
 
 	getUint64() {
 
-		var low, high;
-
-		high = this.getUint32();
-		low = this.getUint32();
+		const low = this.getUint32();
+		const high = this.getUint32();
 		return high * 0x100000000 + low;
 
 	}
 
 	getFloat32() {
 
-		var value = this.dv.getFloat32( this.offset, false );
+		const value = this.dv.getFloat32( this.offset, false );
 		this.offset += 4;
 		return value;
 
@@ -1001,9 +999,9 @@ class DataViewReader {
 
 	getFloat32Array( size ) {
 
-		var a = [];
+		const a = [];
 
-		for ( var i = 0; i < size; i ++ ) {
+		for ( let i = 0; i < size; i ++ ) {
 
 			a.push( this.getFloat32() );
 
@@ -1015,7 +1013,7 @@ class DataViewReader {
 
 	getFloat64() {
 
-		var value = this.dv.getFloat64( this.offset, this.littleEndian );
+		const value = this.dv.getFloat64( this.offset, this.littleEndian );
 		this.offset += 8;
 		return value;
 
@@ -1023,9 +1021,9 @@ class DataViewReader {
 
 	getFloat64Array( size ) {
 
-		var a = [];
+		const a = [];
 
-		for ( var i = 0; i < size; i ++ ) {
+		for ( let i = 0; i < size; i ++ ) {
 
 			a.push( this.getFloat64() );
 
@@ -1043,7 +1041,7 @@ class DataViewReader {
 	// the four-byte form is being used and the first byte should be discarded or masked out.
 	getVariableLengthIndex() {
 
-		var firstByte = this.getUint8();
+		const firstByte = this.getUint8();
 
 		if ( firstByte === 255 ) {
 
@@ -1099,7 +1097,7 @@ class DataViewReader {
 
 	getStringArray( size ) {
 
-		var a = this.getString( size );
+		let a = this.getString( size );
 		a = a.split( '\0' );
 
 		return a.filter( Boolean ); // return array with any empty strings removed
@@ -1131,7 +1129,7 @@ class Debugger {
 
 		if ( ! this.active ) return;
 
-		var nodeType;
+		let nodeType;
 
 		switch ( this.node ) {
 
@@ -1174,7 +1172,7 @@ class Debugger {
 
 		if ( ! this.active ) return;
 
-		for ( var i = this.formList.length - 1; i >= 0; i -- ) {
+		for ( let i = this.formList.length - 1; i >= 0; i -- ) {
 
 			if ( this.offset >= this.formList[ i ] ) {
 

--- a/examples/jsm/transpiler/GLSLDecoder.js
+++ b/examples/jsm/transpiler/GLSLDecoder.js
@@ -193,7 +193,7 @@ class Tokenizer {
 
 		const remainingCode = this.skip( spaceRegExp );
 
-		for ( var i = 0; i < TokenParserList.length; i ++ ) {
+		for ( let i = 0; i < TokenParserList.length; i ++ ) {
 
 			const parser = TokenParserList[ i ];
 			const result = parser.regexp.exec( remainingCode );

--- a/examples/webgl_worker_offscreencanvas.html
+++ b/examples/webgl_worker_offscreencanvas.html
@@ -77,7 +77,7 @@
 
 			import initJank from 'three/addons/offscreen/jank.js';
 			import init from 'three/addons/offscreen/scene.js';
-			
+
 			// onscreen
 
 			const canvas1 = document.getElementById( 'canvas1' );
@@ -98,8 +98,8 @@
 			// If it's Safari, then check the version because Safari < 17 doesn't support OffscreenCanvas with a WebGL context.
 			if ( isSafari ) {
 
-				var versionMatch = navigator.userAgent.match( /version\/(\d+)/i );
-				var safariVersion = versionMatch ? parseInt( versionMatch[ 1 ] ) : 0;
+				const versionMatch = navigator.userAgent.match( /version\/(\d+)/i );
+				const safariVersion = versionMatch ? parseInt( versionMatch[ 1 ] ) : 0;
 
 				supportOffScreenWebGL = safariVersion >= 17;
 

--- a/examples/webgpu_postprocessing_afterimage.html
+++ b/examples/webgpu_postprocessing_afterimage.html
@@ -72,7 +72,7 @@
 				const vertices = [];
 				const timeOffsets = [];
 
-				for ( var i = 0; i < count; i ++ ) {
+				for ( let i = 0; i < count; i ++ ) {
 
 					getRandomPointOnSphere( radius, vertex );
 					vertices.push( vertex.x, vertex.y, vertex.z );
@@ -81,7 +81,7 @@
 					colors.push( color.r, color.g, color.b );
 
 					timeOffsets.push( i / count );
-			
+
 				}
 
 				const positionAttribute = new THREE.InstancedBufferAttribute( new Float32Array( vertices ), 3 );
@@ -158,13 +158,13 @@
 
 				const angle = Math.random() * Math.PI * 2;
 				const u = Math.random() * 2 - 1;
-			
+
 				v.set(
 					Math.cos( angle ) * Math.sqrt( 1 - Math.pow( u, 2 ) ) * r,
 					Math.sin( angle ) * Math.sqrt( 1 - Math.pow( u, 2 ) ) * r,
 					u * r
 				);
-			
+
 				return v;
 
 			}

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "lint-playground": "eslint playground --ignore-pattern libs",
     "lint-manual": "eslint manual --ignore-pattern 3rdparty --ignore-pattern prettify.js --ignore-pattern shapefile.js",
     "lint-test": "eslint test --ignore-pattern vendor",
-    "lint-utils": "eslint utils",
+    "lint-utils": "eslint utils --ignore-pattern prettify --ignore-pattern fuse",
     "lint": "npm run lint-core",
     "lint-fix": "npm run lint-core -- --fix && npm run lint-addons -- --fix && npm run lint-examples -- --fix && npm run lint-docs -- --fix && npm run lint-editor -- --fix && npm run lint-playground -- --fix && npm run lint-manual -- --fix && npm run lint-test -- --fix && npm run lint-utils -- --fix",
     "test-unit": "qunit -r failonlyreporter -f !-webonly test/unit/three.source.unit.js",

--- a/test/unit/src/animation/AnimationObjectGroup.tests.js
+++ b/test/unit/src/animation/AnimationObjectGroup.tests.js
@@ -77,18 +77,20 @@ export default QUnit.module( 'Animation', () => {
 		// OTHERS
 		QUnit.test( 'smoke test', ( assert ) => {
 
-			var expect = function expect( testIndex, group, bindings, path, cached, roots ) {
+			const expect = function expect( testIndex, group, bindings, path, cached, roots ) {
 
-				var rootNodes = [], pathsOk = true, nodesOk = true;
+				const rootNodes = [];
+				let pathsOk = true;
+				let nodesOk = true;
 
-				for ( var i = group.nCachedObjects_, n = bindings.length; i !== n; ++ i ) {
+				for ( let i = group.nCachedObjects_, n = bindings.length; i !== n; ++ i ) {
 
 					if ( bindings[ i ].path !== path ) pathsOk = false;
 					rootNodes.push( bindings[ i ].rootNode );
 
 				}
 
-				for ( var i = 0, n = roots.length; i !== n; ++ i ) {
+				for ( let i = 0, n = roots.length; i !== n; ++ i ) {
 
 					if ( rootNodes.indexOf( roots[ i ] ) === - 1 ) nodesOk = false;
 


### PR DESCRIPTION
**Description**

Added the `no-var` eslint rule. The result in this PR is just the output of running lint --fix on the whole project. The rule is safe as it only tries to infer the variable declaration when it is sure about the side effects.

Some `var` are still present in RGBMLoader.js, but I prefer doing the changes manually to get rid of all the vars in another PR as it will be much easier to test.

tested the changes locally with editor, webgl_loader_lwo example and webgl_loader_texture_rgbm example just in case