### PR TITLE
RenderTarget: Fix copy of images.

### DIFF
--- a/src/core/RenderTarget.js
+++ b/src/core/RenderTarget.js
@@ -148,12 +148,12 @@ class RenderTarget extends EventDispatcher {
 			this.textures[ i ].isRenderTargetTexture = true;
 			this.textures[ i ].renderTarget = this;
 
+			// ensure image object is not shared, see #20328
+
+			const image = Object.assign( {}, source.textures[ i ].image );
+			this.textures[ i ].source = new Source( image );
+
 		}
-
-		// ensure image object is not shared, see #20328
-
-		const image = Object.assign( {}, source.texture.image );
-		this.texture.source = new Source( image );
 
 		this.depthBuffer = source.depthBuffer;
 		this.stencilBuffer = source.stencilBuffer;

--- a/src/textures/DepthTexture.js
+++ b/src/textures/DepthTexture.js
@@ -1,5 +1,6 @@
 import { Texture } from './Texture.js';
 import { NearestFilter, UnsignedIntType, UnsignedInt248Type, DepthFormat, DepthStencilFormat } from '../constants.js';
+import { Source } from './Source.js';
 
 class DepthTexture extends Texture {
 
@@ -30,11 +31,11 @@ class DepthTexture extends Texture {
 
 	}
 
-
 	copy( source ) {
 
 		super.copy( source );
 
+		this.source = new Source( Object.assign( {}, source.image ) ); // see #30540
 		this.compareFunction = source.compareFunction;
 
 		return this;


### PR DESCRIPTION
Fixed #30540.

**Description**

Makes sure render targets do not copy the source/image references of their textures but clone them. This makes sure the renderer detects the correct texture that should be attached to framebuffers. 