### PR TITLE
Config: Fix eslint for test and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,11 +8,13 @@ npm-debug.log
 .vs/
 
 test/unit/build
+test/treeshake/index-src.bundle.min.js
 test/treeshake/index.bundle.js
 test/treeshake/index.bundle.min.js
 test/treeshake/index.webgpu.bundle.js
 test/treeshake/index.webgpu.bundle.min.js
-test/treeshake/index-src.bundle.min.js
+test/treeshake/index.webgpu.nodes.bundle.js
+test/treeshake/index.webgpu.nodes.bundle.min.js
 test/treeshake/stats.html
 test/e2e/chromium
 test/e2e/output-screenshots

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "lint-playground": "eslint playground --ignore-pattern libs",
     "lint-manual": "eslint manual --ignore-pattern 3rdparty --ignore-pattern prettify.js --ignore-pattern shapefile.js",
     "lint-test": "eslint test --ignore-pattern vendor",
-    "lint-utils": "eslint utils",
+    "lint-utils": "eslint utils --ignore-pattern prettify --ignore-pattern fuse",
     "lint": "npm run lint-core",
     "lint-fix": "npm run lint-core -- --fix && npm run lint-addons -- --fix && npm run lint-examples -- --fix && npm run lint-docs -- --fix && npm run lint-editor -- --fix && npm run lint-playground -- --fix && npm run lint-manual -- --fix && npm run lint-test -- --fix && npm run lint-utils -- --fix",
     "test-unit": "qunit -r failonlyreporter -f !-webonly test/unit/three.source.unit.js",


### PR DESCRIPTION
**Description**

Currently `npm run lint-utils` ends up parsing prettify and fuse library outputing 9456 errors.
While running `npm run test-threeshake` two bundle files are not properly ignored.