### PR TITLE
FBXLoader: Loading FBX files with out-of-bounds material assignments lead to incorrect geometry groups and subsequent errors

### DIFF
--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -22,6 +22,7 @@ import {
 	Mesh,
 	MeshLambertMaterial,
 	MeshPhongMaterial,
+	MeshStandardMaterial,
 	NumberKeyframeTrack,
 	Object3D,
 	PerspectiveCamera,
@@ -1295,6 +1296,35 @@ class FBXTreeParser {
 				material.vertexColors = true;
 
 			} );
+
+		}
+
+		// Sanitization: If geometry has groups, then it must match the provided material array.
+		// If not, we need to clean up the `group.materialIndex` properties inside the groups and point at a (new) default material.
+		// This isn't well defined; Unity creates default material, while Blender implicitly uses the previous material in the list.
+		if ( geometry.groups.length > 0 ) {
+
+			let needsDefaultMaterial = false;
+
+			for ( let i = 0, il = geometry.groups.length; i < il; i ++ ) {
+
+				const group = geometry.groups[ i ];
+
+				if ( group.materialIndex < 0 || group.materialIndex >= materials.length ) {
+
+					group.materialIndex = materials.length;
+					needsDefaultMaterial = true;
+
+				}
+
+			}
+
+			if ( needsDefaultMaterial ) {
+
+				const defaultMaterial = new MeshStandardMaterial();
+				materials.push( defaultMaterial );
+
+			}
 
 		}
 


### PR DESCRIPTION
**Description**

The previous behaviour was a visual hole (invalid material) and hard-to-catch errors e.g. when using `Mesh._computeIntersections` or `SkinnedMesh._computeIntersections`.

In line with other FBX loaders (tested in Unity/Blender/F3D), a default material is now created. Note that "default material" is to be taken literal; the material looks different in all implementations I tested because their defaults differ, so I decided that's the most reasonable approach here as well.

Reproduction file: 
[response.fbx.zip](https://github.com/user-attachments/files/18908519/response.fbx.zip)

**Screenshots**

The hot pink parts have an invalid materialIndex already in the underlying FBX data (there's 6 materials in the file, the index here is "8"):
![image](https://github.com/user-attachments/assets/02c7774a-3124-456b-97c5-5108181a5d8f)

Unity just uses an existing default material for that problematic slot:
<img width="800" alt="image" src="https://github.com/user-attachments/assets/b5e3a468-420a-4576-9863-effabe6476d4" />

Blender just kicks out the wrong group and thus uses whatever the "last valid" material was, which is super confusing (e.g. if the last valid material was textured, that texture is now on random geometry).

*This contribution is funded by [Needle](https://needle.tools)*