### PR TITLE
TSL: use vec3 for DataArrayTexture UV coordinates

### DIFF
--- a/src/nodes/accessors/TextureNode.js
+++ b/src/nodes/accessors/TextureNode.js
@@ -372,7 +372,15 @@ class TextureNode extends UniformNode {
 	 */
 	generateUV( builder, uvNode ) {
 
-		return uvNode.build( builder, this.sampler === true ? 'vec2' : 'ivec2' );
+		let vecType = ( this.sampler === true ) ? 'vec2' : 'ivec2';
+
+		if ( this.value.isDataArrayTexture ) {
+
+			vecType = 'vec3';
+
+		}
+
+		return uvNode.build( builder, vecType );
 
 	}
 


### PR DESCRIPTION


**Description**

When using DataArrayTexture with the WebGLBackend, TSL's generateUV by default uses only the .xy for sampling textures, this causes shader compile errors when using a texture node with an DataArrayTexture. This is a simple fix which makes the uvSnippet use a vec3 instead when we have a DataArrayTexture.

