### PR TITLE
RenderTarget: Fix copy of images.

### DIFF
--- a/docs/api/en/renderers/WebGLRenderTarget.html
+++ b/docs/api/en/renderers/WebGLRenderTarget.html
@@ -133,7 +133,11 @@
 		<p>Creates a copy of this render target.</p>
 
 		<h3>[method:this copy]( [param:WebGLRenderTarget source] )</h3>
-		<p>Adopts the settings of the given render target.</p>
+		<p>
+			Adopts the settings of the given render target. This is a structural copy so 
+			no resources are shared between render targets after the copy. That includes
+			all MRT textures and the depth texture.
+		</p>
 
 		<h3>[method:undefined dispose]()</h3>
 		<p>

--- a/src/core/RenderTarget.js
+++ b/src/core/RenderTarget.js
@@ -148,12 +148,12 @@ class RenderTarget extends EventDispatcher {
 			this.textures[ i ].isRenderTargetTexture = true;
 			this.textures[ i ].renderTarget = this;
 
+			// ensure image object is not shared, see #20328
+
+			const image = Object.assign( {}, source.textures[ i ].image );
+			this.textures[ i ].source = new Source( image );
+
 		}
-
-		// ensure image object is not shared, see #20328
-
-		const image = Object.assign( {}, source.texture.image );
-		this.texture.source = new Source( image );
 
 		this.depthBuffer = source.depthBuffer;
 		this.stencilBuffer = source.stencilBuffer;

--- a/src/textures/DepthTexture.js
+++ b/src/textures/DepthTexture.js
@@ -1,3 +1,4 @@
+import { Source } from './Source.js';
 import { Texture } from './Texture.js';
 import { NearestFilter, UnsignedIntType, UnsignedInt248Type, DepthFormat, DepthStencilFormat } from '../constants.js';
 
@@ -35,6 +36,7 @@ class DepthTexture extends Texture {
 
 		super.copy( source );
 
+		this.source = new Source( Object.assign( {}, source.image ) ); // see #30540
 		this.compareFunction = source.compareFunction;
 
 		return this;


### PR DESCRIPTION
Fixed https://github.com/mrdoob/three.js/issues/30540.

**Description**

Second attempt of #30570, now with a note in the documentation.