### PR TITLE
Docs: Fixes missing material on the doc page about the LOD class

### DIFF
--- a/docs/api/en/objects/LOD.html
+++ b/docs/api/en/objects/LOD.html
@@ -25,11 +25,11 @@
 
 		<code>
 		const lod = new THREE.LOD();
+		const material = new THREE.MeshBasicMaterial( { color: 0xffff00 } );
 
 		//Create spheres with 3 levels of detail and create new LOD levels for them
 		for( let i = 0; i < 3; i++ ) {
 			const geometry = new THREE.IcosahedronGeometry( 10, 3 - i );
-			const material = new THREE.MeshBasicMaterial( { color: 0xffff00 } );
 			const mesh = new THREE.Mesh( geometry, material );
 			lod.addLevel( mesh, i * 75 );
 		}

--- a/docs/api/en/objects/LOD.html
+++ b/docs/api/en/objects/LOD.html
@@ -29,6 +29,7 @@
 		//Create spheres with 3 levels of detail and create new LOD levels for them
 		for( let i = 0; i < 3; i++ ) {
 			const geometry = new THREE.IcosahedronGeometry( 10, 3 - i );
+			const material = new THREE.MeshBasicMaterial( { color: 0xffff00 } );
 			const mesh = new THREE.Mesh( geometry, material );
 			lod.addLevel( mesh, i * 75 );
 		}


### PR DESCRIPTION
**Description**

fixes the documentation of the LOD class, missing the declaration of the material already in use in the Mesh
