### PR TITLE
OrbitControls: Add `panLimits`

### DIFF
--- a/docs/examples/en/controls/OrbitControls.html
+++ b/docs/examples/en/controls/OrbitControls.html
@@ -244,6 +244,19 @@ controls.mouseButtons = {
 		Default is `true`.
 		</p>
 
+		<h3>[property:Object panLimits]</h3>
+		<p>
+			Defines 'invisible walls' camera will bump onto when panning, preventing it from leaving area designated for viewing.
+			Can be defined partially, to restrict movement on specific axes, or block one side only.
+			<code>
+				controls.panLimits = {
+					x: { min: Float, max: Float },
+					y: { min: Float, max: Float },
+					z: { min: Float, max: Float }
+				}
+			</code>
+		</p>
+
 		<h3>[property:Vector3 target0]</h3>
 		<p>
 			Used internally by the [page:.saveState] and [page:.reset] methods.

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -372,23 +372,9 @@ class OrbitControls extends Controls {
 
 		// restrict panning to set limits
 		if ( this.enablePan ) {
-			if ( this.panLimits.x?.min != null && this.target.x < this.panLimits.x.min )
-				this.target.setX( this.panLimits.x.min );
 
-			if ( this.panLimits.x?.max != null && this.target.x > this.panLimits.x.max )
-				this.target.setX( this.panLimits.x.max );
+			this._ensurePanWithinLimits();
 
-			if ( this.panLimits.y?.min != null && this.target.y < this.panLimits.y.min )
-				this.target.setY( this.panLimits.y.min );
-
-			if ( this.panLimits.y?.max != null && this.target.y > this.panLimits.y.max )
-				this.target.setY( this.panLimits.y.max );
-
-			if ( this.panLimits.z?.min != null && this.target.z < this.panLimits.z.min )
-				this.target.setZ( this.panLimits.z.min );
-
-			if ( this.panLimits.z?.max != null && this.target.z > this.panLimits.z.max )
-				this.target.setZ( this.panLimits.z.max );
 		}
 
 		// Limit the target distance from the cursor to create a sphere around the center of interest
@@ -644,6 +630,40 @@ class OrbitControls extends Controls {
 			// camera neither orthographic nor perspective
 			console.warn( 'WARNING: OrbitControls.js encountered an unknown camera type - pan disabled.' );
 			this.enablePan = false;
+
+		}
+
+	}
+
+	_ensurePanWithinLimits() {
+
+		if ( this.panLimits.x != null ) {
+
+			if ( this.panLimits.x.min != null && this.target.x < this.panLimits.x.min )
+				this.target.setX( this.panLimits.x.min );
+
+			if ( this.panLimits.x.max != null && this.target.x > this.panLimits.x.max )
+				this.target.setX( this.panLimits.x.max );
+
+		}
+
+		if ( this.panLimits.y != null ) {
+
+			if ( this.panLimits.y.min != null && this.target.y < this.panLimits.y.min )
+				this.target.setY( this.panLimits.y.min );
+
+			if ( this.panLimits.y.max != null && this.target.y > this.panLimits.y.max )
+				this.target.setY( this.panLimits.y.max );
+
+		}
+
+		if ( this.panLimits.z != null ) {
+
+			if ( this.panLimits.z.min != null && this.target.z < this.panLimits.z.min )
+				this.target.setZ( this.panLimits.z.min );
+
+			if ( this.panLimits.z.max != null && this.target.z > this.panLimits.z.max )
+				this.target.setZ( this.panLimits.z.max );
 
 		}
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -101,6 +101,13 @@ class OrbitControls extends Controls {
 		this.keyPanSpeed = 7.0;	// pixels moved per arrow key push
 		this.zoomToCursor = false;
 
+		// Set constraints to how far you can pan
+		this.panLimits = {
+			x: { min: null, max: null },
+			y: { min: null, max: null },
+			z: { min: null, max: null },
+		};
+
 		// Set to true to automatically rotate around the target
 		// If auto-rotate is enabled, you must call controls.update() in your animation loop
 		this.autoRotate = false;
@@ -361,6 +368,27 @@ class OrbitControls extends Controls {
 
 			this.target.add( this._panOffset );
 
+		}
+
+		// restrict panning to set limits
+		if ( this.enablePan ) {
+			if ( this.panLimits.x?.min != null && this.target.x < this.panLimits.x.min )
+				this.target.setX( this.panLimits.x.min );
+
+			if ( this.panLimits.x?.max != null && this.target.x > this.panLimits.x.max )
+				this.target.setX( this.panLimits.x.max );
+
+			if ( this.panLimits.y?.min != null && this.target.y < this.panLimits.y.min )
+				this.target.setY( this.panLimits.y.min );
+
+			if ( this.panLimits.y?.max != null && this.target.y > this.panLimits.y.max )
+				this.target.setY( this.panLimits.y.max );
+
+			if ( this.panLimits.z?.min != null && this.target.z < this.panLimits.z.min )
+				this.target.setZ( this.panLimits.z.min );
+
+			if ( this.panLimits.z?.max != null && this.target.z > this.panLimits.z.max )
+				this.target.setZ( this.panLimits.z.max );
 		}
 
 		// Limit the target distance from the cursor to create a sphere around the center of interest


### PR DESCRIPTION
**Description**

This PR adds simple x, y, z constraints to panning.

Use case below:
before:
<video src='https://github.com/user-attachments/assets/91fb18f6-4b0b-4934-90af-73cbf38e11c6'>

after:
<video src='https://github.com/user-attachments/assets/e4f840ca-f475-44e7-be3a-e1e62ad0411c'>

When I tried to add this one outside of `OrbitControls` I wasn't able to get result like here, and as I'm probably not the only one with such use case, so here goes PR. And if I got this totally wrong, and there is a way to do it without this modification, let me know ;)

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [41set](https://41set.com)*
