### PR TITLE
WebGLRenderer - Assign CurrentRenderState in renderer.compile()

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1028,8 +1028,7 @@ class WebGLRenderer {
 
 			} );
 
-			renderStateStack.pop();
-			currentRenderState = null;
+			currentRenderState = renderStateStack.pop();
 
 			return materials;
 


### PR DESCRIPTION
Related issues: ##22217, #22220

**Description**

Assign currentRenderState to renderStateStack.pop() to more closely align renderer.compile()'s behavior with its pre r131.1 behavior.