### PR TITLE
WebGPUAttributeUtils: Use correct buffer offset for `updateRanges`.

### DIFF
--- a/src/renderers/webgpu/utils/WebGPUAttributeUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUAttributeUtils.js
@@ -204,7 +204,7 @@ class WebGPUAttributeUtils {
 
 				device.queue.writeBuffer(
 					buffer,
-					0,
+					dataOffset * 4,
 					array,
 					dataOffset,
 					size

--- a/src/renderers/webgpu/utils/WebGPUAttributeUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUAttributeUtils.js
@@ -202,9 +202,11 @@ class WebGPUAttributeUtils {
 
 				}
 
+				const bufferOffset = dataOffset * ( isTypedArray ? array.BYTES_PER_ELEMENT : 1 ); // bufferOffset is always in bytes
+
 				device.queue.writeBuffer(
 					buffer,
-					dataOffset * ( isTypedArray ? array.BYTES_PER_ELEMENT : 1 ),
+					bufferOffset,
 					array,
 					dataOffset,
 					size

--- a/src/renderers/webgpu/utils/WebGPUAttributeUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUAttributeUtils.js
@@ -204,7 +204,7 @@ class WebGPUAttributeUtils {
 
 				device.queue.writeBuffer(
 					buffer,
-					dataOffset * 4,
+					dataOffset * ( isTypedArray ? array.BYTES_PER_ELEMENT : 1 ),
 					array,
 					dataOffset,
 					size


### PR DESCRIPTION
**Description**
Currently when using updateRanges with the WebGPU renderer, the updates are being copied to the start of the buffer. 

This PR sets the correct buffer destination offset for: [device.queue.writeBuffer](https://developer.mozilla.org/en-US/docs/Web/API/GPUQueue/writeBuffer), so updateRanges work the same as the WebGLRenderer.
