### PR TITLE
AnimationClip: Deprecate `parseAnimation()`.

### DIFF
--- a/src/animation/AnimationClip.js
+++ b/src/animation/AnimationClip.js
@@ -287,11 +287,14 @@ class AnimationClip {
 	 * Parses the `animation.hierarchy` format and returns a new animation clip.
 	 *
 	 * @static
+	 * @deprecated since r175.
 	 * @param {Object} animation - A serialized animation clip as JSON.
 	 * @param {Array<Bones>} bones - An array of bones.
 	 * @return {AnimationClip} The new animation clip.
 	 */
 	static parseAnimation( animation, bones ) {
+
+		console.warn( 'THREE.AnimationClip: parseAnimation() is deprecated and will be removed with r185' );
 
 		if ( ! animation ) {
 


### PR DESCRIPTION
Related issue: -

**Description**

The static method `AnimationClip.parseAnimation()` was intended to parse animations of the old JSON format used by `JSONLoader`. The method has no other use in the library, AFAICS. 

I vote to deprecate it now so we can safely remove it at the end of the year.
