### PR TITLE
WebGPURenderer: Fix texture view caching and dispose event stacking

### DIFF
--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -1932,6 +1932,8 @@ class Renderer {
 			renderContext.stencil = renderTarget.stencilBuffer;
 			// #30329
 			renderContext.clearColorValue = this.backend.getClearColor();
+			renderContext.activeCubeFace = this.getActiveCubeFace();
+			renderContext.activeMipmapLevel = this.getActiveMipmapLevel();
 
 		}
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -375,7 +375,10 @@ class WebGPUBackend extends Backend {
 		) {
 
 			descriptors = {};
+
 			renderTargetData.descriptors = descriptors;
+
+			// dispose
 
 			const onDispose = () => {
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -474,7 +474,6 @@ class WebGPUBackend extends Backend {
 
 		}
 
-		// Apply dynamic properties to cached views
 		const descriptor = {
 			colorAttachments: []
 		};
@@ -484,7 +483,6 @@ class WebGPUBackend extends Backend {
 
 			const viewInfo = descriptorBase.textureViews[ i ];
 
-			// Only apply the user-defined clearValue to the first color attachment
 			let clearValue = { r: 0, g: 0, b: 0, a: 1 };
 			if ( i === 0 && colorAttachmentsConfig.clearValue ) {
 
@@ -929,13 +927,11 @@ class WebGPUBackend extends Backend {
 			supportsDepth = renderTargetContext.depth;
 			supportsStencil = renderTargetContext.stencil;
 
-			// Config object with all dynamic properties
 			const clearConfig = {
 				loadOp: color ? GPULoadOp.Clear : GPULoadOp.Load,
 				clearValue: color ? clearValue : undefined
 			};
 
-			// If depth or stencil operations are needed, add them to config
 			if ( supportsDepth ) {
 
 				clearConfig.depthLoadOp = depth ? GPULoadOp.Clear : GPULoadOp.Load;

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -369,38 +369,42 @@ class WebGPUBackend extends Backend {
 			renderTargetData.width !== renderTarget.width ||
 			renderTargetData.height !== renderTarget.height ||
 			renderTargetData.dimensions !== renderTarget.dimensions ||
-			renderTargetData.activeMipmapLevel !== renderTarget.activeMipmapLevel ||
+			renderTargetData.activeMipmapLevel !== renderContext.activeMipmapLevel ||
 			renderTargetData.activeCubeFace !== renderContext.activeCubeFace ||
-			renderTargetData.samples !== renderTarget.samples ||
-			renderTargetData.loadOp !== colorAttachmentsConfig.loadOp
+			renderTargetData.samples !== renderTarget.samples
 		) {
 
+			console.log(
+				'WebGPUBackend: Render target descriptor cache miss. Recreating render pass descriptor.',
+				renderTargetData.activeMipmapLevel !== renderContext.activeMipmapLevel,
+				renderTargetData.activeCubeFace !== renderContext.activeCubeFace,
+				renderTargetData.samples !== renderTarget.samples
+			);
 			descriptors = {};
-
 			renderTargetData.descriptors = descriptors;
-
-			// dispose
 
 			const onDispose = () => {
 
 				renderTarget.removeEventListener( 'dispose', onDispose );
-
 				this.delete( renderTarget );
 
 			};
 
-			renderTarget.addEventListener( 'dispose', onDispose );
+			if ( renderTarget.hasEventListener( 'dispose', onDispose ) === false ) {
+
+				renderTarget.addEventListener( 'dispose', onDispose );
+
+			}
 
 		}
 
 		const cacheKey = renderContext.getCacheKey();
+		let descriptorBase = descriptors[ cacheKey ];
 
-		let descriptor = descriptors[ cacheKey ];
-
-		if ( descriptor === undefined ) {
+		if ( descriptorBase === undefined ) {
 
 			const textures = renderContext.textures;
-			const colorAttachments = [];
+			const textureViews = [];
 
 			let sliceIndex;
 
@@ -448,44 +452,24 @@ class WebGPUBackend extends Backend {
 
 				}
 
-				// only apply the user-defined clearValue to the first color attachment like in beginRender()
-
-				let clearValue = { r: 0, g: 0, b: 0, a: 1 };
-
-				if ( i === 0 && colorAttachmentsConfig.clearValue ) {
-
-					clearValue = colorAttachmentsConfig.clearValue;
-
-				}
-
-				colorAttachments.push( {
+				textureViews.push( {
 					view,
-					depthSlice: sliceIndex,
 					resolveTarget,
-					loadOp: colorAttachmentsConfig.loadOP || GPULoadOp.Load,
-					storeOp: colorAttachmentsConfig.storeOP || GPUStoreOp.Store,
-					clearValue: clearValue
+					depthSlice: sliceIndex
 				} );
 
 			}
 
-
-			descriptor = {
-				colorAttachments,
-			};
+			descriptorBase = { textureViews };
 
 			if ( renderContext.depth ) {
 
 				const depthTextureData = this.get( renderContext.depthTexture );
-
-				const depthStencilAttachment = {
-					view: depthTextureData.texture.createView()
-				};
-				descriptor.depthStencilAttachment = depthStencilAttachment;
+				descriptorBase.depthStencilView = depthTextureData.texture.createView();
 
 			}
 
-			descriptors[ cacheKey ] = descriptor;
+			descriptors[ cacheKey ] = descriptorBase;
 
 			renderTargetData.width = renderTarget.width;
 			renderTargetData.height = renderTarget.height;
@@ -493,8 +477,43 @@ class WebGPUBackend extends Backend {
 			renderTargetData.activeMipmapLevel = renderContext.activeMipmapLevel;
 			renderTargetData.activeCubeFace = renderContext.activeCubeFace;
 			renderTargetData.dimensions = renderTarget.dimensions;
-			renderTargetData.depthSlice = sliceIndex;
-			renderTargetData.loadOp = colorAttachments[ 0 ].loadOp;
+
+		}
+
+		// Apply dynamic properties to cached views
+		const descriptor = {
+			colorAttachments: []
+		};
+
+		// Apply dynamic properties to cached views
+		for ( let i = 0; i < descriptorBase.textureViews.length; i ++ ) {
+
+			const viewInfo = descriptorBase.textureViews[ i ];
+
+			// Only apply the user-defined clearValue to the first color attachment
+			let clearValue = { r: 0, g: 0, b: 0, a: 1 };
+			if ( i === 0 && colorAttachmentsConfig.clearValue ) {
+
+				clearValue = colorAttachmentsConfig.clearValue;
+
+			}
+
+			descriptor.colorAttachments.push( {
+				view: viewInfo.view,
+				depthSlice: viewInfo.depthSlice,
+				resolveTarget: viewInfo.resolveTarget,
+				loadOp: colorAttachmentsConfig.loadOp || GPULoadOp.Load,
+				storeOp: colorAttachmentsConfig.storeOp || GPUStoreOp.Store,
+				clearValue: clearValue
+			} );
+
+		}
+
+		if ( descriptorBase.depthStencilView ) {
+
+			descriptor.depthStencilAttachment = {
+				view: descriptorBase.depthStencilView
+			};
 
 		}
 
@@ -873,7 +892,6 @@ class WebGPUBackend extends Backend {
 		const renderer = this.renderer;
 
 		let colorAttachments = [];
-
 		let depthStencilAttachment;
 		let clearValue;
 
@@ -917,29 +935,37 @@ class WebGPUBackend extends Backend {
 			supportsDepth = renderTargetContext.depth;
 			supportsStencil = renderTargetContext.stencil;
 
-			if ( color ) {
+			// Config object with all dynamic properties
+			const clearConfig = {
+				loadOp: color ? GPULoadOp.Clear : GPULoadOp.Load,
+				clearValue: color ? clearValue : undefined
+			};
 
-				const descriptor = this._getRenderPassDescriptor( renderTargetContext, { loadOp: GPULoadOp.Clear, clearValue } );
+			// If depth or stencil operations are needed, add them to config
+			if ( supportsDepth ) {
 
-				colorAttachments = descriptor.colorAttachments;
+				clearConfig.depthLoadOp = depth ? GPULoadOp.Clear : GPULoadOp.Load;
+				clearConfig.depthClearValue = depth ? renderer.getClearDepth() : undefined;
+				clearConfig.depthStoreOp = GPUStoreOp.Store;
+
+			}
+
+			if ( supportsStencil ) {
+
+				clearConfig.stencilLoadOp = stencil ? GPULoadOp.Clear : GPULoadOp.Load;
+				clearConfig.stencilClearValue = stencil ? renderer.getClearStencil() : undefined;
+				clearConfig.stencilStoreOp = GPUStoreOp.Store;
 
 			}
 
-			if ( supportsDepth || supportsStencil ) {
+			const descriptor = this._getRenderPassDescriptor( renderTargetContext, clearConfig );
 
-				const depthTextureData = this.get( renderTargetContext.depthTexture );
-
-				depthStencilAttachment = {
-					view: depthTextureData.texture.createView()
-				};
-
-			}
+			colorAttachments = descriptor.colorAttachments;
+			depthStencilAttachment = descriptor.depthStencilAttachment;
 
 		}
 
-		//
-
-		if ( supportsDepth ) {
+		if ( supportsDepth && depthStencilAttachment && depthStencilAttachment.depthLoadOp === undefined ) {
 
 			if ( depth ) {
 
@@ -958,7 +984,7 @@ class WebGPUBackend extends Backend {
 
 		//
 
-		if ( supportsStencil ) {
+		if ( supportsStencil && depthStencilAttachment && depthStencilAttachment.stencilLoadOp === undefined ) {
 
 			if ( stencil ) {
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -374,12 +374,6 @@ class WebGPUBackend extends Backend {
 			renderTargetData.samples !== renderTarget.samples
 		) {
 
-			console.log(
-				'WebGPUBackend: Render target descriptor cache miss. Recreating render pass descriptor.',
-				renderTargetData.activeMipmapLevel !== renderContext.activeMipmapLevel,
-				renderTargetData.activeCubeFace !== renderContext.activeCubeFace,
-				renderTargetData.samples !== renderTarget.samples
-			);
 			descriptors = {};
 			renderTargetData.descriptors = descriptors;
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/30560

**Description**

In the WebGPU backend before r172, there was a bug where `renderTarget.activeMipmapLevel` was incorrectly used instead of `renderContext.activeMipmapLevel`. This was partially fixed in PR #30155:
https://github.com/mrdoob/three.js/pull/30155/files#diff-dab3c57cef925d356099192da6cb6710336ac50052d2f6774897e1864d8c46a9L305-R331

However, my commit missed updating the cache invalidation condition:
- Current: `renderTargetData.activeMipmapLevel !== renderTarget.activeMipmapLevel`
- Should be: `renderTargetData.activeMipmapLevel !== renderContext.activeMipmapLevel`

This oversight exposed two critical memory leaks:

1. The dispose event listener was being added repeatedly without proper cleanup, as cache invalidation was triggered incorrectly.

2. The caching strategy for texture views in `_getRenderPassDescriptor` was inefficient. It should separate the caching into two steps:
   - Cache expensive texture views based on target dimensions and mipmap/face properties
   - Apply dynamic properties (loadOp, storeOp, clearValue) on demand without recreating views

Additionally, texture views in the `clear()` method were never cached at all, resulting in new views being created for every clear operation, accumulating indefinitely.

I investigated this issue following memory leaks on a Windows project that ultimately crashed the GPU after running for a few hours. This suggests different platforms may handle GPU resource accumulation and cleanup differently, with Windows potentially being less forgiving.


Before this PR: Texture views infinitely accumulating, consuming GPU memory that may not be promptly released even after JavaScript references are no longer used.
<img width="1721" alt="Screenshot 2025-03-04 at 23 51 24" src="https://github.com/user-attachments/assets/310a8b4c-9328-40e9-9154-e45eaf4122ff" />
(But you can test any WebGPU example and will see the texture views accumulating and `onDispose` event stacking.)

After (Texture Views reduced and cached to 79):
<img width="1721" alt="Screenshot 2025-03-04 at 23 51 05" src="https://github.com/user-attachments/assets/1bfd8155-3532-4d0f-8cb8-614b1098c228" />




*This contribution is funded by [Utsubo](https://utsubo.com)*