### PR TITLE
InstancedMesh: add option to opt out of InstanceMesh.instanceMatrix default

### DIFF
--- a/src/objects/InstancedMesh.js
+++ b/src/objects/InstancedMesh.js
@@ -33,8 +33,9 @@ class InstancedMesh extends Mesh {
 	 * @param {BufferGeometry} [geometry] - The mesh geometry.
 	 * @param {Material|Array<Material>} [material] - The mesh material.
 	 * @param {number} count - The number of instances.
+	 * @param {boolean} prepopulateInstanceMatrix - The number of instances.
 	 */
-	constructor( geometry, material, count ) {
+	constructor( geometry, material, count, prepopulateInstanceMatrix = true ) {
 
 		super( geometry, material );
 
@@ -99,9 +100,13 @@ class InstancedMesh extends Mesh {
 		 */
 		this.boundingSphere = null;
 
-		for ( let i = 0; i < count; i ++ ) {
+		if ( prepopulateInstanceMatrix ) {
 
-			this.setMatrixAt( i, _identity );
+			for ( let i = 0; i < count; i ++ ) {
+
+				this.setMatrixAt( i, _identity );
+
+			}
 
 		}
 

--- a/src/objects/InstancedMesh.js
+++ b/src/objects/InstancedMesh.js
@@ -33,7 +33,7 @@ class InstancedMesh extends Mesh {
 	 * @param {BufferGeometry} [geometry] - The mesh geometry.
 	 * @param {Material|Array<Material>} [material] - The mesh material.
 	 * @param {number} count - The number of instances.
-	 * @param {boolean} prepopulateInstanceMatrix - The number of instances.
+	 * @param {boolean} [prepopulateInstanceMatrix=true] - Dictates whether the instanceMatrix should be prepopulated or not.
 	 */
 	constructor( geometry, material, count, prepopulateInstanceMatrix = true ) {
 


### PR DESCRIPTION
**Description**

In r146, there was a change made to populate instanceMatrix on InstancedMesh creation. I would like more control over this and would like an option to disable this pre population.

r146 change: 
https://github.com/mrdoob/three.js/pull/24749

I have a scenario where I'm creating many instancedMeshes in a loop, and this change makes my laptop come to a halt. 
