### PR TITLE
USDZExporter: Reuse instantiated material for `buildXform()`.

### DIFF
--- a/examples/jsm/exporters/USDZExporter.js
+++ b/examples/jsm/exporters/USDZExporter.js
@@ -78,7 +78,7 @@ class USDZExporter {
 
 					}
 
-					output += buildXform( object, geometry, material );
+					output += buildXform( object, geometry, materials[ material.uuid ] );
 
 				} else {
 
@@ -755,7 +755,7 @@ function buildCamera( camera ) {
 			float verticalAperture = ${ ( ( Math.abs( camera.top ) + Math.abs( camera.bottom ) ) * 10 ).toPrecision( PRECISION ) }
 			token projection = "orthographic"
 		}
-	
+
 	`;
 
 	} else {
@@ -772,7 +772,7 @@ function buildCamera( camera ) {
 			token projection = "perspective"
 			float verticalAperture = ${ camera.getFilmHeight().toPrecision( PRECISION ) }
 		}
-	
+
 	`;
 
 	}


### PR DESCRIPTION

**Description**
- This PR solves that wrong references for instantiated materials are generated for an USDZ export. 
  The old code did not reuse the right instantiated material and then generated references with material ids that were not present in the material definitions.  

![[Screenshot from 2026-03-06 07-40-58](https://github.com/user-attachments/assets/051c7ffa-cb75-48d4-854b-9a136a7923fe)](https://github.com/user-attachments/assets/051c7ffa-cb75-48d4-854b-9a136a7923fe)

- Broken export (shortened):
  ```
  def Xform "Object_171" (
    prepend references = @./geometries/Geometry_42.usd@</Geometry>
  )
  {
    ...
    rel material:binding = </Materials/Material_58>
  }
  def Xform "Object_172" (
    prepend references = @./geometries/Geometry_44.usd@</Geometry>
  )
  {
    ...
    rel material:binding = </Materials/Material_59>
  }
  def Xform "Object_174" (
    prepend references = @./geometries/Geometry_46.usd@</Geometry>
  )
  {
    ...
    rel material:binding = </Materials/Material_60>
  }
  def "Materials"
  {
  - def Material "Material_58"
    {
      ...
    }
  }
  ```
- Fixed export (shortened):  
  ```
  def Xform "Object_170" (
  prepend references = @./geometries/Geometry_44.usda@</Geometry>
  )
  {
  ...
  rel material:binding = </Materials/Material_56>
  }
  def Xform "Object_172" (
  prepend references = @./geometries/Geometry_46.usda@</Geometry>
  )
  {
  ...
  rel material:binding = </Materials/Material_56>
  }
  def Xform "Object_177" (
  prepend references = @./geometries/Geometry_48.usda@</Geometry>
  )
  {
  ...
  rel material:binding = </Materials/Material_56>
  }
  - def "Materials"
  {
  - def Material "Material_56"
  {
  ...
  }
  }
  ```

*This contribution is funded by [ObjectCode](https://www.objectcode.de/)*
