### PR TITLE
AsciiEffect: avoid useless split operations

### DIFF
--- a/examples/jsm/effects/AsciiEffect.js
+++ b/examples/jsm/effects/AsciiEffect.js
@@ -118,8 +118,6 @@ class AsciiEffect {
 		}
 
 
-		const aDefaultCharList = ( ' .,:;i1tfLCG08@' ).split( '' );
-		const aDefaultColorCharList = ( ' CGO08@' ).split( '' );
 		const strFont = 'courier new, monospace';
 
 		const oCanvasImg = renderer.domElement;
@@ -138,9 +136,19 @@ class AsciiEffect {
 
 		}
 
-		let aCharList = ( bColor ? aDefaultColorCharList : aDefaultCharList );
+		let aCharList;
+		if ( charSet ) {
 
-		if ( charSet ) aCharList = charSet;
+			aCharList = ( charSet ).split( '' );
+
+		} else {
+
+			const aDefaultCharList = ( ' .,:;i1tfLCG08@' ).split( '' );
+			const aDefaultColorCharList = ( ' CGO08@' ).split( '' );
+			aCharList = ( bColor ? aDefaultColorCharList : aDefaultCharList );
+
+		}
+
 
 		// Setup dom
 


### PR DESCRIPTION
**Description**

There was a small type inconsistency before as `aDefaultColorCharList` and `aDefaultCharList` where `string[]` but `charSet` was only a `string`. Without the split everything is a normal string and the code works exactly like before.