### PR TITLE
AMFLoader: fix materialId reference

### DIFF
--- a/examples/jsm/loaders/AMFLoader.js
+++ b/examples/jsm/loaders/AMFLoader.js
@@ -236,7 +236,7 @@ class AMFLoader extends Loader {
 
 		function loadMeshVolume( node ) {
 
-			const volume = { name: '', triangles: [], materialid: null };
+			const volume = { name: '', triangles: [], materialId: null };
 
 			let currVolumeNode = node.firstElementChild;
 


### PR DESCRIPTION
**Description**

Object was wrongly initialised with `materialid` key instead of `materialId`.