### PR TITLE
MD2Loader: clip creation requires additional argument

### DIFF
--- a/examples/jsm/loaders/MD2Loader.js
+++ b/examples/jsm/loaders/MD2Loader.js
@@ -388,7 +388,7 @@ class MD2Loader extends Loader {
 		geometry.morphAttributes.normal = morphNormals;
 		geometry.morphTargetsRelative = false;
 
-		geometry.animations = AnimationClip.CreateClipsFromMorphTargetSequences( frames, 10 );
+		geometry.animations = AnimationClip.CreateClipsFromMorphTargetSequences( frames, 10, false );
 
 		return geometry;
 


### PR DESCRIPTION
**Description**

Value for `noLoop` argument inside `CreateClipsFromMorphTargetSequences` function is missing.

It was undefined before and the boolean value to keep the same behavior is false. 