### PR TITLE
WebGLRenderer: Fixed readRenderTargetPixelsAsync checking readability against incorrect render target

### DIFF
--- a/examples/webgl_interactive_cubes_gpu.html
+++ b/examples/webgl_interactive_cubes_gpu.html
@@ -254,6 +254,9 @@
 				renderer.setClearColor( clearColor );
 				renderer.render( pickingScene, camera );
 
+				// Restore active render target to canvas
+				renderer.setRenderTarget( null );
+
 				// clear the view offset so rendering returns to normal
 				camera.clearViewOffset();
 

--- a/examples/webgl_interactive_cubes_gpu.html
+++ b/examples/webgl_interactive_cubes_gpu.html
@@ -294,7 +294,6 @@
 
 				pick();
 
-				renderer.setRenderTarget( null );
 				renderer.render( scene, camera );
 
 			}

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2944,13 +2944,13 @@ class WebGLRenderer {
 					if ( ! capabilities.textureFormatReadable( textureFormat ) ) {
 
 						throw new Error( 'THREE.WebGLRenderer.readRenderTargetPixelsAsync: renderTarget is not in RGBA or implementation defined format.' );
-	
+
 					}
-	
+
 					if ( ! capabilities.textureTypeReadable( textureType ) ) {
-	
+
 						throw new Error( 'THREE.WebGLRenderer.readRenderTargetPixelsAsync: renderTarget is not in UnsignedByteType or implementation defined type.' );
-	
+
 					}
 
 					const glBuffer = _gl.createBuffer();

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2931,27 +2931,27 @@ class WebGLRenderer {
 
 			if ( framebuffer ) {
 
-				const texture = renderTarget.texture;
-				const textureFormat = texture.format;
-				const textureType = texture.type;
-
-				if ( ! capabilities.textureFormatReadable( textureFormat ) ) {
-
-					throw new Error( 'THREE.WebGLRenderer.readRenderTargetPixelsAsync: renderTarget is not in RGBA or implementation defined format.' );
-
-				}
-
-				if ( ! capabilities.textureTypeReadable( textureType ) ) {
-
-					throw new Error( 'THREE.WebGLRenderer.readRenderTargetPixelsAsync: renderTarget is not in UnsignedByteType or implementation defined type.' );
-
-				}
-
 				// the following if statement ensures valid read requests (no out-of-bounds pixels, see #8604)
 				if ( ( x >= 0 && x <= ( renderTarget.width - width ) ) && ( y >= 0 && y <= ( renderTarget.height - height ) ) ) {
 
 					// set the active frame buffer to the one we want to read
 					state.bindFramebuffer( _gl.FRAMEBUFFER, framebuffer );
+
+					const texture = renderTarget.texture;
+					const textureFormat = texture.format;
+					const textureType = texture.type;
+
+					if ( ! capabilities.textureFormatReadable( textureFormat ) ) {
+
+						throw new Error( 'THREE.WebGLRenderer.readRenderTargetPixelsAsync: renderTarget is not in RGBA or implementation defined format.' );
+	
+					}
+	
+					if ( ! capabilities.textureTypeReadable( textureType ) ) {
+	
+						throw new Error( 'THREE.WebGLRenderer.readRenderTargetPixelsAsync: renderTarget is not in UnsignedByteType or implementation defined type.' );
+	
+					}
 
 					const glBuffer = _gl.createBuffer();
 					_gl.bindBuffer( _gl.PIXEL_PACK_BUFFER, glBuffer );


### PR DESCRIPTION
**Description**

readRenderTargetPixelsAsync was checking if the render target was readable before binding the render target to active framebuffer.

This resulted in the texture readability check occurring on the previously set framebuffer and not the render target we are reading pixels from.

I modified the webgl_interactive_cubes_gpu example to restore the render target to the default before we call readRenderTargetPixelsAsync as that reproduces the issue without the fix.

EDIT: For some reason the file diff looks disgusting, please refer to the "Commits" tab instead of "Files changed" for better clarity on what changed.