### PR TITLE
OculusHandModel: fix reference to path attribute

### DIFF
--- a/examples/jsm/webxr/OculusHandModel.js
+++ b/examples/jsm/webxr/OculusHandModel.js
@@ -15,6 +15,7 @@ class OculusHandModel extends Object3D {
 		this.envMap = null;
 		this.loader = loader;
 		this.onLoad = onLoad;
+		this.path = null;
 
 		this.mesh = null;
 


### PR DESCRIPTION
**Description**

`this.path` is referenced but not initialized in `OculusHandModel` class.