### PR TITLE
BufferGeometry: fix clone index data copy

### DIFF
--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -1352,7 +1352,7 @@ class BufferGeometry extends EventDispatcher {
 
 		if ( index !== null ) {
 
-			this.setIndex( index.clone( data ) );
+			this.setIndex( index.clone() );
 
 		}
 


### PR DESCRIPTION
**Description**

Not sure about what was the expected behavior and how data should store the index but the `clone` method inside `BufferAttribute` does not take any argument (same for subtypes of BufferAttribute).