### PR TITLE
Docs:Update TransformControls.html

### DIFF
--- a/docs/examples/zh/controls/TransformControls.html
+++ b/docs/examples/zh/controls/TransformControls.html
@@ -223,6 +223,16 @@
 			</p>
 		</p>
 
+		<h3>[method:undefined setScaleSnap] ( [param:Number scaleSnap] )</h3>
+		<p>
+			<p>
+				[page:Number scaleSnap]: 缩放捕捉步幅。
+			</p>
+			<p>
+				设置缩放捕捉。
+			</p>
+		</p>
+
 		<h2>源代码</h2>
 
 		<p>


### PR DESCRIPTION
Fill in the missing content for Chinese documents

**Description**

The method for setting a value for scaleSnap property is missing from the Chinese documentation, and has been added


