### PR TITLE
PointerLockControls: Add `unadjustedMovement`option to `lock()`.

### DIFF
--- a/examples/jsm/controls/PointerLockControls.js
+++ b/examples/jsm/controls/PointerLockControls.js
@@ -199,7 +199,7 @@ class PointerLockControls extends Controls {
 	/**
 	 * Activates the pointer lock.
 	 * 
-	 * @param {boolean} unadjustedMovement - Whether to disable OS-level adjustment for mouse acceleration and accesses raw mouse input instead or not.
+	 * @param {boolean} [unadjustedMovement=false] - Whether to disable OS-level adjustment for mouse acceleration and accesses raw mouse input instead or not.
 	 */
 	lock( unadjustedMovement = false ) {
 

--- a/examples/jsm/controls/PointerLockControls.js
+++ b/examples/jsm/controls/PointerLockControls.js
@@ -199,7 +199,8 @@ class PointerLockControls extends Controls {
 	/**
 	 * Activates the pointer lock.
 	 * 
-	 * @param {boolean} [unadjustedMovement=false] - Whether to disable OS-level adjustment for mouse acceleration and accesses raw mouse input instead or not.
+	 * @param {boolean} [unadjustedMovement=false] - Disables OS-level adjustment for mouse acceleration, and accesses raw mouse input instead.
+	 * Setting it to true will disable mouse acceleration.
 	 */
 	lock( unadjustedMovement = false ) {
 

--- a/examples/jsm/controls/PointerLockControls.js
+++ b/examples/jsm/controls/PointerLockControls.js
@@ -198,10 +198,14 @@ class PointerLockControls extends Controls {
 
 	/**
 	 * Activates the pointer lock.
+	 * 
+	 * @param {boolean} unadjustedMovement - Whether to access raw mouse input instead of OS level acceleration.
 	 */
-	lock() {
+	lock(unadjustedMovement = false) {
 
-		this.domElement.requestPointerLock();
+		this.domElement.requestPointerLock({
+			unadjustedMovement
+		});
 
 	}
 

--- a/examples/jsm/controls/PointerLockControls.js
+++ b/examples/jsm/controls/PointerLockControls.js
@@ -199,13 +199,13 @@ class PointerLockControls extends Controls {
 	/**
 	 * Activates the pointer lock.
 	 * 
-	 * @param {boolean} unadjustedMovement - Whether to access raw mouse input instead of OS level acceleration.
+	 * @param {boolean} unadjustedMovement - Whether to disable OS-level adjustment for mouse acceleration and accesses raw mouse input instead or not.
 	 */
-	lock(unadjustedMovement = false) {
+	lock( unadjustedMovement = false ) {
 
-		this.domElement.requestPointerLock({
+		this.domElement.requestPointerLock( {
 			unadjustedMovement
-		});
+		} );
 
 	}
 


### PR DESCRIPTION
Related issue: #27747
https://issues.chromium.org/issues/40662608

**Description**

This PR adds the option to use `unadjustedMovement` when Locking controls in PointerLockControls.js.
