### PR TITLE
TSL: Simplify expression output

### DIFF
--- a/src/nodes/code/ExpressionNode.js
+++ b/src/nodes/code/ExpressionNode.js
@@ -46,7 +46,7 @@ class ExpressionNode extends Node {
 
 		} else {
 
-			return builder.format( `( ${ snippet } )`, type, output );
+			return builder.format( snippet, type, output );
 
 		}
 


### PR DESCRIPTION
**Description**
We don't need the extra `()` in `ExpressionNode`.

With this PR: `array[ u32( ( i ) ) ]` -> `array[ u32( i ) ]`.

Before:
![Screenshot 2025-03-09 at 18 27 22](https://github.com/user-attachments/assets/c0be5bb8-aab1-415b-98bf-077d1e82eafc)
After:
![Screenshot 2025-03-09 at 18 28 09](https://github.com/user-attachments/assets/97a44646-a349-474a-8b72-4441da662cda)


*This contribution is funded by [Utsubo](https://utsubo.com)*
