### PR TITLE
Attributes: Fix `null` check.

### DIFF
--- a/src/renderers/common/Attributes.js
+++ b/src/renderers/common/Attributes.js
@@ -39,7 +39,7 @@ class Attributes extends DataMap {
 
 		const attributeData = super.delete( attribute );
 
-		if ( attributeData !== undefined ) {
+		if ( attributeData !== null ) {
 
 			this.backend.destroyAttribute( attribute );
 


### PR DESCRIPTION
Fixed #30693.

**Description**

The statement `const attributeData = super.delete( attribute );` does never return `undefined`. So checking for it has no effect. `null` must be used instead.

This is a regression which was unfortunately introduced in #30188 when the return type of `DataMap.delete()` was changed.

