### PR TITLE
EXRLoader: Fix string comparison

### DIFF
--- a/examples/jsm/loaders/EXRLoader.js
+++ b/examples/jsm/loaders/EXRLoader.js
@@ -2229,7 +2229,7 @@ class EXRLoader extends DataTextureLoader {
 
 				const attributeName = parseNullTerminatedString( buffer, offset );
 
-				if ( attributeName == 0 ) {
+				if ( attributeName === '' ) {
 
 					keepReading = false;
 


### PR DESCRIPTION
**Description**

`parseNullTerminatedString` always returns a string.