### PR TITLE
AsciiEffect: fix types

### DIFF
--- a/examples/jsm/effects/AsciiEffect.js
+++ b/examples/jsm/effects/AsciiEffect.js
@@ -101,8 +101,8 @@ class AsciiEffect {
 
 			}
 
-			oAscii.cellSpacing = 0;
-			oAscii.cellPadding = 0;
+			oAscii.cellSpacing = '0';
+			oAscii.cellPadding = '0';
 
 			const oStyle = oAscii.style;
 			oStyle.whiteSpace = 'pre';


### PR DESCRIPTION
**Description**

Event though the props are deprecated, the value is expected to be a string.

https://developer.mozilla.org/en-US/docs/Web/API/HTMLTableElement/cellSpacing
https://developer.mozilla.org/en-US/docs/Web/API/HTMLTableElement/cellPadding
