### PR TITLE
AnalyticLightNode: fix call to setupShadowNode

### DIFF
--- a/src/nodes/lighting/AnalyticLightNode.js
+++ b/src/nodes/lighting/AnalyticLightNode.js
@@ -180,7 +180,7 @@ class AnalyticLightNode extends LightingNode {
 
 			} else {
 
-				shadowNode = this.setupShadowNode( builder );
+				shadowNode = this.setupShadowNode();
 
 			}
 


### PR DESCRIPTION
**Description**

`AnalyticLightNode.setupShadowNode()` and all subclasses implementing `setupShadowNode` do not require the builder as a param.