### PR TITLE
Backend: Move trackTimestamp to parent class

### DIFF
--- a/src/renderers/common/Backend.js
+++ b/src/renderers/common/Backend.js
@@ -68,6 +68,14 @@ class Backend {
 			'compute': null
 		};
 
+		/**
+		 * Whether to track timestamps with a Timestamp Query API or not.
+		 *
+		 * @type {boolean}
+		 * @default false
+		 */
+		this.trackTimestamp = ( parameters.trackTimestamp === true );
+
 	}
 
 	/**

--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -168,14 +168,6 @@ class WebGLBackend extends Backend {
 		this.parallel = null;
 
 		/**
-		 * Whether to track timestamps with a Timestamp Query API or not.
-		 *
-		 * @type {boolean}
-		 * @default false
-		 */
-		this.trackTimestamp = ( parameters.trackTimestamp === true );
-
-		/**
 		 * A reference to the current render context.
 		 *
 		 * @private

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -67,14 +67,6 @@ class WebGPUBackend extends Backend {
 		this.parameters.requiredLimits = ( parameters.requiredLimits === undefined ) ? {} : parameters.requiredLimits;
 
 		/**
-		 * Whether to track timestamps with a Timestamp Query API or not.
-		 *
-		 * @type {boolean}
-		 * @default false
-		 */
-		this.trackTimestamp = ( parameters.trackTimestamp === true );
-
-		/**
 		 * A reference to the device.
 		 *
 		 * @type {?GPUDevice}


### PR DESCRIPTION
**Description**

`trackTimestamp` is used for both backends and referenced inside `Backend.resolveTimestampsAsync()`.