### PR TITLE
WebGPUConstants: Fix name of RG11B10UFloat

### DIFF
--- a/src/renderers/webgpu/utils/WebGPUConstants.js
+++ b/src/renderers/webgpu/utils/WebGPUConstants.js
@@ -113,7 +113,7 @@ export const GPUTextureFormat = {
 	// Packed 32-bit formats
 	RGB9E5UFloat: 'rgb9e5ufloat',
 	RGB10A2Unorm: 'rgb10a2unorm',
-	RG11B10uFloat: 'rgb10a2unorm',
+	RG11B10UFloat: 'rgb10a2unorm',
 
 	// 64-bit formats
 


### PR DESCRIPTION
**Description**

`WebGPUTextureUtils._getBytesPerTexel()` was referencing `RG11B10UFloat` but the key was misspelled