### PR TITLE
fix up AA for WebXR and use multisample extension only when needed

### DIFF
--- a/src/renderers/common/XRManager.js
+++ b/src/renderers/common/XRManager.js
@@ -551,6 +551,7 @@ class XRManager extends EventDispatcher {
 		const backend = renderer.backend;
 
 		const gl = renderer.getContext();
+		const attributes = gl.getContextAttributes();
 
 		this._session = session;
 
@@ -620,6 +621,7 @@ class XRManager extends EventDispatcher {
 						colorSpace: renderer.outputColorSpace,
 						depthTexture: new DepthTexture( glProjLayer.textureWidth, glProjLayer.textureHeight, depthType, undefined, undefined, undefined, undefined, undefined, undefined, depthFormat ),
 						stencilBuffer: renderer.stencil,
+						samples: attributes.antialias ? 4 : 0,
 						resolveDepthBuffer: ( glProjLayer.ignoreDepthValues === false ),
 						resolveStencilBuffer: ( glProjLayer.ignoreDepthValues === false ),
 					} );
@@ -965,6 +967,7 @@ function onSessionEnd() {
 
 	renderer.backend.setXRTarget( null );
 	renderer.setOutputRenderTarget( null );
+	renderer.setRenderTarget( null );
 
 	this._session = null;
 	this._xrRenderTarget = null;

--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -2006,7 +2006,7 @@ class WebGLBackend extends Backend {
 
 						} else {
 
-							if ( useMultisampledRTT ) {
+							if ( hasExternalTextures && useMultisampledRTT ) {
 
 								multisampledRTTExt.framebufferTexture2DMultisampleEXT( gl.FRAMEBUFFER, attachment, gl.TEXTURE_2D, textureData.textureGPU, 0, samples );
 
@@ -2039,7 +2039,7 @@ class WebGLBackend extends Backend {
 						textureData.renderTarget = descriptor.renderTarget;
 						textureData.cacheKey = cacheKey; // required for copyTextureToTexture()
 
-						if ( useMultisampledRTT ) {
+						if ( hasExternalTextures && useMultisampledRTT ) {
 
 							multisampledRTTExt.framebufferTexture2DMultisampleEXT( gl.FRAMEBUFFER, depthStyle, gl.TEXTURE_2D, textureData.textureGPU, 0, samples );
 


### PR DESCRIPTION
This diff brings back multisampling for WebXR when using projection layers.
It also disables multisampled_render_to_texture unless the rendertarget was set up with explicit textures.
It also clears the render target when exiting WebXR. Previously, the XR render target continued to be used which resulted in errors.

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Meta](https://meta.com)*

cc @Mugen87 
