### PR TITLE
AtomicFunctionNode: add inline support

### DIFF
--- a/src/nodes/gpgpu/AtomicFunctionNode.js
+++ b/src/nodes/gpgpu/AtomicFunctionNode.js
@@ -26,9 +26,8 @@ class AtomicFunctionNode extends TempNode {
 	 * @param {string} method - The signature of the atomic function to construct.
 	 * @param {Node} pointerNode - An atomic variable or element of an atomic buffer.
 	 * @param {Node} valueNode - The value that mutates the atomic variable.
-	 * @param {?Node} [storeNode=null] - A variable storing the return value of an atomic operation, typically the value of the atomic variable before the operation.
 	 */
-	constructor( method, pointerNode, valueNode, storeNode = null ) {
+	constructor( method, pointerNode, valueNode ) {
 
 		super( 'uint' );
 
@@ -52,14 +51,6 @@ class AtomicFunctionNode extends TempNode {
 		 * @type {Node}
 		 */
 		this.valueNode = valueNode;
-
-		/**
-		 * A variable storing the return value of an atomic operation, typically the value of the atomic variable before the operation.
-		 *
-		 * @type {?Node}
-		 * @default null
-		 */
-		this.storeNode = storeNode;
 
 	}
 
@@ -109,19 +100,15 @@ class AtomicFunctionNode extends TempNode {
 
 		}
 
-		const methodSnippet = `${ builder.getMethod( method, type ) }( ${params.join( ', ' )} )`;
+		const methodSnippet = `${ builder.getMethod( method, type ) }( ${ params.join( ', ' ) } )`;
 
-		if ( this.storeNode !== null ) {
-
-			const varSnippet = this.storeNode.build( builder, inputType );
-
-			builder.addLineFlowCode( `${varSnippet} = ${methodSnippet}`, this );
-
-		} else {
+		if ( b !== null ) {
 
 			builder.addLineFlowCode( methodSnippet, this );
 
 		}
+
+		return methodSnippet;
 
 	}
 
@@ -147,7 +134,6 @@ export default AtomicFunctionNode;
  * @param {string} method - The signature of the atomic function to construct.
  * @param {Node} pointerNode - An atomic variable or element of an atomic buffer.
  * @param {Node} valueNode - The value that mutates the atomic variable.
- * @param {?Node} [storeNode=null] - A variable storing the return value of an atomic operation, typically the value of the atomic variable before the operation.
  * @returns {AtomicFunctionNode}
  */
 const atomicNode = nodeProxy( AtomicFunctionNode );
@@ -160,12 +146,11 @@ const atomicNode = nodeProxy( AtomicFunctionNode );
  * @param {string} method - The signature of the atomic function to construct.
  * @param {Node} pointerNode - An atomic variable or element of an atomic buffer.
  * @param {Node} valueNode - The value that mutates the atomic variable.
- * @param {?Node} [storeNode=null] - A variable storing the return value of an atomic operation, typically the value of the atomic variable before the operation.
  * @returns {AtomicFunctionNode}
  */
-export const atomicFunc = ( method, pointerNode, valueNode, storeNode = null ) => {
+export const atomicFunc = ( method, pointerNode, valueNode ) => {
 
-	const node = atomicNode( method, pointerNode, valueNode, storeNode );
+	const node = atomicNode( method, pointerNode, valueNode );
 	node.append();
 
 	return node;
@@ -178,10 +163,9 @@ export const atomicFunc = ( method, pointerNode, valueNode, storeNode = null ) =
  * @tsl
  * @function
  * @param {Node} pointerNode - An atomic variable or element of an atomic buffer.
- * @param {?Node} [storeNode=null] - A variable storing the return value of an atomic operation, typically the value of the atomic variable before the operation.
  * @returns {AtomicFunctionNode}
  */
-export const atomicLoad = ( pointerNode, storeNode = null ) => atomicFunc( AtomicFunctionNode.ATOMIC_LOAD, pointerNode, null, storeNode );
+export const atomicLoad = ( pointerNode ) => atomicFunc( AtomicFunctionNode.ATOMIC_LOAD, pointerNode, null );
 
 /**
  * Stores a value in the atomic variable.
@@ -190,10 +174,9 @@ export const atomicLoad = ( pointerNode, storeNode = null ) => atomicFunc( Atomi
  * @function
  * @param {Node} pointerNode - An atomic variable or element of an atomic buffer.
  * @param {Node} valueNode - The value that mutates the atomic variable.
- * @param {?Node} [storeNode=null] - A variable storing the return value of an atomic operation, typically the value of the atomic variable before the operation.
  * @returns {AtomicFunctionNode}
  */
-export const atomicStore = ( pointerNode, valueNode, storeNode = null ) => atomicFunc( AtomicFunctionNode.ATOMIC_STORE, pointerNode, valueNode, storeNode );
+export const atomicStore = ( pointerNode, valueNode ) => atomicFunc( AtomicFunctionNode.ATOMIC_STORE, pointerNode, valueNode );
 
 /**
  * Increments the value stored in the atomic variable.
@@ -202,10 +185,9 @@ export const atomicStore = ( pointerNode, valueNode, storeNode = null ) => atomi
  * @function
  * @param {Node} pointerNode - An atomic variable or element of an atomic buffer.
  * @param {Node} valueNode - The value that mutates the atomic variable.
- * @param {?Node} [storeNode=null] - A variable storing the return value of an atomic operation, typically the value of the atomic variable before the operation.
  * @returns {AtomicFunctionNode}
  */
-export const atomicAdd = ( pointerNode, valueNode, storeNode = null ) => atomicFunc( AtomicFunctionNode.ATOMIC_ADD, pointerNode, valueNode, storeNode );
+export const atomicAdd = ( pointerNode, valueNode ) => atomicFunc( AtomicFunctionNode.ATOMIC_ADD, pointerNode, valueNode );
 
 /**
  * Decrements the value stored in the atomic variable.
@@ -214,10 +196,9 @@ export const atomicAdd = ( pointerNode, valueNode, storeNode = null ) => atomicF
  * @function
  * @param {Node} pointerNode - An atomic variable or element of an atomic buffer.
  * @param {Node} valueNode - The value that mutates the atomic variable.
- * @param {?Node} [storeNode=null] - A variable storing the return value of an atomic operation, typically the value of the atomic variable before the operation.
  * @returns {AtomicFunctionNode}
  */
-export const atomicSub = ( pointerNode, valueNode, storeNode = null ) => atomicFunc( AtomicFunctionNode.ATOMIC_SUB, pointerNode, valueNode, storeNode );
+export const atomicSub = ( pointerNode, valueNode ) => atomicFunc( AtomicFunctionNode.ATOMIC_SUB, pointerNode, valueNode );
 
 /**
  * Stores in an atomic variable the maximum between its current value and a parameter.
@@ -226,10 +207,9 @@ export const atomicSub = ( pointerNode, valueNode, storeNode = null ) => atomicF
  * @function
  * @param {Node} pointerNode - An atomic variable or element of an atomic buffer.
  * @param {Node} valueNode - The value that mutates the atomic variable.
- * @param {?Node} [storeNode=null] - A variable storing the return value of an atomic operation, typically the value of the atomic variable before the operation.
  * @returns {AtomicFunctionNode}
  */
-export const atomicMax = ( pointerNode, valueNode, storeNode = null ) => atomicFunc( AtomicFunctionNode.ATOMIC_MAX, pointerNode, valueNode, storeNode );
+export const atomicMax = ( pointerNode, valueNode ) => atomicFunc( AtomicFunctionNode.ATOMIC_MAX, pointerNode, valueNode );
 
 /**
  * Stores in an atomic variable the minimum between its current value and a parameter.
@@ -238,10 +218,9 @@ export const atomicMax = ( pointerNode, valueNode, storeNode = null ) => atomicF
  * @function
  * @param {Node} pointerNode - An atomic variable or element of an atomic buffer.
  * @param {Node} valueNode - The value that mutates the atomic variable.
- * @param {?Node} [storeNode=null] - A variable storing the return value of an atomic operation, typically the value of the atomic variable before the operation.
  * @returns {AtomicFunctionNode}
  */
-export const atomicMin = ( pointerNode, valueNode, storeNode = null ) => atomicFunc( AtomicFunctionNode.ATOMIC_MIN, pointerNode, valueNode, storeNode );
+export const atomicMin = ( pointerNode, valueNode ) => atomicFunc( AtomicFunctionNode.ATOMIC_MIN, pointerNode, valueNode );
 
 /**
  * Stores in an atomic variable the bitwise AND of its value with a parameter.
@@ -250,10 +229,9 @@ export const atomicMin = ( pointerNode, valueNode, storeNode = null ) => atomicF
  * @function
  * @param {Node} pointerNode - An atomic variable or element of an atomic buffer.
  * @param {Node} valueNode - The value that mutates the atomic variable.
- * @param {?Node} [storeNode=null] - A variable storing the return value of an atomic operation, typically the value of the atomic variable before the operation.
  * @returns {AtomicFunctionNode}
  */
-export const atomicAnd = ( pointerNode, valueNode, storeNode = null ) => atomicFunc( AtomicFunctionNode.ATOMIC_AND, pointerNode, valueNode, storeNode );
+export const atomicAnd = ( pointerNode, valueNode ) => atomicFunc( AtomicFunctionNode.ATOMIC_AND, pointerNode, valueNode );
 
 /**
  * Stores in an atomic variable the bitwise OR of its value with a parameter.
@@ -262,10 +240,9 @@ export const atomicAnd = ( pointerNode, valueNode, storeNode = null ) => atomicF
  * @function
  * @param {Node} pointerNode - An atomic variable or element of an atomic buffer.
  * @param {Node} valueNode - The value that mutates the atomic variable.
- * @param {?Node} [storeNode=null] - A variable storing the return value of an atomic operation, typically the value of the atomic variable before the operation.
  * @returns {AtomicFunctionNode}
  */
-export const atomicOr = ( pointerNode, valueNode, storeNode = null ) => atomicFunc( AtomicFunctionNode.ATOMIC_OR, pointerNode, valueNode, storeNode );
+export const atomicOr = ( pointerNode, valueNode ) => atomicFunc( AtomicFunctionNode.ATOMIC_OR, pointerNode, valueNode );
 
 /**
  * Stores in an atomic variable the bitwise XOR of its value with a parameter.
@@ -274,7 +251,6 @@ export const atomicOr = ( pointerNode, valueNode, storeNode = null ) => atomicFu
  * @function
  * @param {Node} pointerNode - An atomic variable or element of an atomic buffer.
  * @param {Node} valueNode - The value that mutates the atomic variable.
- * @param {?Node} [storeNode=null] - A variable storing the return value of an atomic operation, typically the value of the atomic variable before the operation.
  * @returns {AtomicFunctionNode}
  */
-export const atomicXor = ( pointerNode, valueNode, storeNode = null ) => atomicFunc( AtomicFunctionNode.ATOMIC_XOR, pointerNode, valueNode, storeNode );
+export const atomicXor = ( pointerNode, valueNode ) => atomicFunc( AtomicFunctionNode.ATOMIC_XOR, pointerNode, valueNode );


### PR DESCRIPTION
Fixes: https://github.com/mrdoob/three.js/issues/30634

**Description**

Add inline support for `a.assign(b)` and removed the redundant `.storeNode`.