### PR TITLE
TSL: Add `samplerComparison`

### DIFF
--- a/src/Three.TSL.js
+++ b/src/Three.TSL.js
@@ -407,6 +407,7 @@ export const rtt = TSL.rtt;
 export const sRGBTransferEOTF = TSL.sRGBTransferEOTF;
 export const sRGBTransferOETF = TSL.sRGBTransferOETF;
 export const sampler = TSL.sampler;
+export const samplerComparison = TSL.samplerComparison;
 export const saturate = TSL.saturate;
 export const saturation = TSL.saturation;
 export const screen = TSL.screen;

--- a/src/nodes/accessors/TextureNode.js
+++ b/src/nodes/accessors/TextureNode.js
@@ -439,7 +439,7 @@ class TextureNode extends UniformNode {
 		const properties = builder.getNodeProperties( this );
 		const textureProperty = super.generate( builder, 'property' );
 
-		if ( output === 'sampler' ) {
+		if ( /^sampler/.test( output ) ) {
 
 			return textureProperty + '_sampler';
 
@@ -762,7 +762,17 @@ export const textureLoad = ( ...params ) => texture( ...params ).setSampler( fal
  *
  * @tsl
  * @function
- * @param {TextureNode|Texture} aTexture - The texture or texture node to convert.
+ * @param {TextureNode|Texture} value - The texture or texture node to convert.
  * @returns {Node}
  */
-export const sampler = ( aTexture ) => ( aTexture.isNode === true ? aTexture : texture( aTexture ) ).convert( 'sampler' );
+export const sampler = ( value ) => ( value.isNode === true ? value : texture( value ) ).convert( 'sampler' );
+
+/**
+ * Converts a texture or texture node to a sampler comparison.
+ *
+ * @tsl
+ * @function
+ * @param {TextureNode|Texture} value - The texture or texture node to convert.
+ * @returns {Node}
+ */
+export const samplerComparison = ( value ) => ( value.isNode === true ? value : texture( value ) ).convert( 'samplerComparison' );

--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -1285,7 +1285,7 @@ class NodeBuilder {
 	 */
 	isReference( type ) {
 
-		return type === 'void' || type === 'property' || type === 'sampler' || type === 'texture' || type === 'cubeTexture' || type === 'storageTexture' || type === 'depthTexture' || type === 'texture3D';
+		return type === 'void' || type === 'property' || type === 'sampler' || type === 'samplerComparison' || type === 'texture' || type === 'cubeTexture' || type === 'storageTexture' || type === 'depthTexture' || type === 'texture3D';
 
 	}
 


### PR DESCRIPTION
Closes: https://github.com/mrdoob/three.js/issues/30685

**Description**

Add TSL `samplerComparison` function.

```js
const shaderParams = {
	shadowDepthTexture: texture( directionalLight.shadow.map.depthTexture ),
	shadowDepthSampler: samplerComparison( directionalLight.shadow.map.depthTexture )
};
    
const fragmentShader = wgslFn(`
	fn main_fragment(
		shadowDepthSampler: sampler_comparison,
		shadowDepthTexture: texture_depth_2d
	) -> vec4<f32> {

		return vec4f( textureSampleCompare( shadowDepthTexture, shadowDepthSampler, vec2<f32>( 0.0 ), 5. ) );

	}
`);

```