### PR TITLE
ViewHelper: Adjust viewport position for WebGPU renderer

### DIFF
--- a/examples/jsm/helpers/ViewHelper.js
+++ b/examples/jsm/helpers/ViewHelper.js
@@ -157,11 +157,12 @@ class ViewHelper extends Object3D {
 			//
 
 			const x = domElement.offsetWidth - dim;
+			const y = renderer.isWebGPURenderer ? domElement.offsetHeight - dim : 0;
 
 			renderer.clearDepth();
 
 			renderer.getViewport( viewport );
-			renderer.setViewport( x, 0, dim, dim );
+			renderer.setViewport( x, y, dim, dim );
 
 			renderer.render( this, orthoCamera );
 


### PR DESCRIPTION
Closes: #30729 

**Description**
 set correct y-axis position when `renderer.isWebGPURenderer` is true

```js
const x = domElement.offsetWidth - dim;
const y = renderer.isWebGPURenderer ? domElement.offsetHeight - dim : 0;

renderer.clearDepth();

renderer.getViewport( viewport );
renderer.setViewport( x, y, dim, dim );
```
