### PR TITLE
Renderer: Disallow render target resizing while in XR.

### DIFF
--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -1616,6 +1616,9 @@ class Renderer {
 	 */
 	setDrawingBufferSize( width, height, pixelRatio ) {
 
+		// Renderer can't be resized while presenting in XR.
+		if ( this.xr && this.xr.isPresenting ) return;
+
 		this._width = width;
 		this._height = height;
 
@@ -1638,6 +1641,9 @@ class Renderer {
 	 * @param {boolean} [updateStyle=true] - Whether to update the `style` attribute of the canvas or not.
 	 */
 	setSize( width, height, updateStyle = true ) {
+
+		// Renderer can't be resized while presenting in XR.
+		if ( this.xr && this.xr.isPresenting ) return;
 
 		this._width = width;
 		this._height = height;


### PR DESCRIPTION
When you bring up the browser in overlay while in WebXR on the Quest browser, the example page tries to do a resize.
This messes up the rendertarget because it doesn't expect that its backing can be resized.

I added code to disallow resizing while in XR mode.

*This contribution is funded by [Meta](https://meta.com)*
