### PR TITLE
ArrayElementNode: Optimize indexes

### DIFF
--- a/src/nodes/utils/ArrayElementNode.js
+++ b/src/nodes/utils/ArrayElementNode.js
@@ -63,8 +63,10 @@ class ArrayElementNode extends Node { // @TODO: If extending from TempNode it br
 
 	generate( builder ) {
 
+		const indexType = this.indexNode.getNodeType( builder );
+
 		const nodeSnippet = this.node.build( builder );
-		const indexSnippet = this.indexNode.build( builder, 'uint' );
+		const indexSnippet = this.indexNode.build( builder, indexType === 'int' ? indexType : 'uint' );
 
 		return `${ nodeSnippet }[ ${ indexSnippet } ]`;
 


### PR DESCRIPTION
**Description**

Ignore redundant `int` -> `uint` conversion for indexes.