### PR TITLE
WebGLRenderer: Fix binding __webglFramebuffer when mipmaps are used.

### DIFF
--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -2011,8 +2011,9 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 				state.bindFramebuffer( _gl.READ_FRAMEBUFFER, renderTargetProperties.__webglMultisampledFramebuffer );
 
-				// Handle mipmaps
-				if ( renderTarget.texture.mipmaps && renderTarget.texture.mipmaps.length > 0 ) {
+				const mipmaps = renderTarget.texture.mipmaps;
+
+				if ( mipmaps && mipmaps.length > 0 ) {
 
 					state.bindFramebuffer( _gl.DRAW_FRAMEBUFFER, renderTargetProperties.__webglFramebuffer[ 0 ] );
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -1629,7 +1629,17 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 			if ( isCube ) throw new Error( 'target.depthTexture not supported in Cube render targets' );
 
-			setupDepthTexture( renderTargetProperties.__webglFramebuffer, renderTarget );
+			const mipmaps = renderTarget.texture.mipmaps;
+
+			if (mipmaps && mipmaps.length > 0) {
+
+				setupDepthTexture( renderTargetProperties.__webglFramebuffer[0], renderTarget );
+
+			} else {
+
+				setupDepthTexture( renderTargetProperties.__webglFramebuffer, renderTarget );
+
+			}
 
 		} else {
 
@@ -1660,7 +1670,17 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 			} else {
 
-				state.bindFramebuffer( _gl.FRAMEBUFFER, renderTargetProperties.__webglFramebuffer );
+				const mipmaps = renderTarget.texture.mipmaps;
+
+				if (mipmaps && mipmaps.length > 0) {
+
+					state.bindFramebuffer( _gl.FRAMEBUFFER, renderTargetProperties.__webglFramebuffer[0] );
+
+				} else {
+
+					state.bindFramebuffer( _gl.FRAMEBUFFER, renderTargetProperties.__webglFramebuffer );
+
+				}
 
 				if ( renderTargetProperties.__webglDepthbuffer === undefined ) {
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -1631,7 +1631,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 			const mipmaps = renderTarget.texture.mipmaps;
 
-			if (mipmaps && mipmaps.length > 0) {
+			if ( mipmaps && mipmaps.length > 0 ) {
 
 				setupDepthTexture( renderTargetProperties.__webglFramebuffer[ 0 ], renderTarget );
 
@@ -1672,7 +1672,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 				const mipmaps = renderTarget.texture.mipmaps;
 
-				if (mipmaps && mipmaps.length > 0) {
+				if ( mipmaps && mipmaps.length > 0 ) {
 
 					state.bindFramebuffer( _gl.FRAMEBUFFER, renderTargetProperties.__webglFramebuffer[ 0 ] );
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -1633,7 +1633,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 			if (mipmaps && mipmaps.length > 0) {
 
-				setupDepthTexture( renderTargetProperties.__webglFramebuffer[0], renderTarget );
+				setupDepthTexture( renderTargetProperties.__webglFramebuffer[ 0 ], renderTarget );
 
 			} else {
 
@@ -1674,7 +1674,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 				if (mipmaps && mipmaps.length > 0) {
 
-					state.bindFramebuffer( _gl.FRAMEBUFFER, renderTargetProperties.__webglFramebuffer[0] );
+					state.bindFramebuffer( _gl.FRAMEBUFFER, renderTargetProperties.__webglFramebuffer[ 0 ] );
 
 				} else {
 
@@ -2010,7 +2010,17 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 				}
 
 				state.bindFramebuffer( _gl.READ_FRAMEBUFFER, renderTargetProperties.__webglMultisampledFramebuffer );
-				state.bindFramebuffer( _gl.DRAW_FRAMEBUFFER, renderTargetProperties.__webglFramebuffer );
+
+				// Handle mipmaps
+				if ( renderTarget.texture.mipmaps && renderTarget.texture.mipmaps.length > 0 ) {
+
+					state.bindFramebuffer( _gl.DRAW_FRAMEBUFFER, renderTargetProperties.__webglFramebuffer[ 0 ] );
+
+				} else {
+
+					state.bindFramebuffer( _gl.DRAW_FRAMEBUFFER, renderTargetProperties.__webglFramebuffer );
+
+				}
 
 				for ( let i = 0; i < textures.length; i ++ ) {
 


### PR DESCRIPTION
Closes https://github.com/mrdoob/three.js/issues/30745

Related issue:  https://github.com/mrdoob/three.js/issues/29779

**Description**

It's possible render into specific mipmap levels when we set the target.texture.mipmaps array. This works great for color-only render targets, however if we give this target a depth buffer (either through depthBuffer: true or an explicit depthTexture), rendering will fail with a crash when rendering

The crash is caused by three.js assuming .__webglFramebuffer is a single framebuffer, however, when .mipmaps is set it becomes an array:
```glsl
if (texture.mipmaps && texture.mipmaps.length > 0) {
  for (let level = 0; level < texture.mipmaps.length; level++) {
    setupFrameBufferTexture(renderTargetProperties.__webglFramebuffer[level], renderTarget, texture, _gl.COLOR_ATTACHMENT0, glTextureType, level);
  }
} else {
  setupFrameBufferTexture(renderTargetProperties.__webglFramebuffer, renderTarget, texture, _gl.COLOR_ATTACHMENT0, glTextureType, 0);
}
```

This causes a crash on this line
https://github.com/mrdoob/three.js/blob/fc4ef555314ef1838e48bd7b60d9ae4c1adbc7ba/src/renderers/webgl/WebGLTextures.js#L1663

And
https://github.com/mrdoob/three.js/blob/fc4ef555314ef1838e48bd7b60d9ae4c1adbc7ba/src/renderers/webgl/WebGLTextures.js#L1532

Maybe other places too

This PR resolves this by instead setting the depth attachment for *only* mipmap 0.

I will also think about setting a depth attachment for each mip level 

I've tried to use idomatic three.js style which comes out quite verbose but let me know if we want something tidier!
