### PR TITLE
ImageUtils: Add optional `type` parameter to `getDataURL()`.

### DIFF
--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -24,7 +24,8 @@ import {
 	CompressedTexture,
 	Vector3,
 	Quaternion,
-	REVISION
+	REVISION,
+	ImageUtils
 } from 'three';
 
 /**
@@ -1465,7 +1466,7 @@ class GLTFWriter {
 
 			} else {
 
-				imageDef.uri = canvas.toDataURL( mimeType );
+				imageDef.uri = ImageUtils.getDataURL( canvas, mimeType );
 
 			}
 

--- a/src/extras/ImageUtils.js
+++ b/src/extras/ImageUtils.js
@@ -14,9 +14,10 @@ class ImageUtils {
 	 * Returns a data URI containing a representation of the given image.
 	 *
 	 * @param {(HTMLImageElement|HTMLCanvasElement)} image - The image object.
+	 * @param {string} [type='image/png'] - Indicates the image format.
 	 * @return {string} The data URI.
 	 */
-	static getDataURL( image ) {
+	static getDataURL( image, type = 'image/png' ) {
 
 		if ( /^data:/i.test( image.src ) ) {
 
@@ -59,7 +60,7 @@ class ImageUtils {
 
 		}
 
-		return canvas.toDataURL( 'image/png' );
+		return canvas.toDataURL( type );
 
 	}
 


### PR DESCRIPTION
Related issue: -

**Description**

The PR adds an optional `type` parameter to `ImageUtils.getDataURL()` so it's possible to request other image formats than `image/png`. 

Also uses `ImageUtils.getDataURL()` in `GLTFExporter` now.