### PR TITLE
Material: Add `allowOverride`.

### DIFF
--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -428,6 +428,14 @@ class Material extends EventDispatcher {
 		this.forceSinglePass = false;
 
 		/**
+		 * Whether it's possible to override the material with {@link Scene#overrideMaterial} or not.
+		 *
+		 * @type {boolean}
+		 * @default true
+		 */
+		this.allowOverride = true;
+
+		/**
 		 * Defines whether 3D objects using this material are visible.
 		 *
 		 * @type {boolean}

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1979,8 +1979,14 @@ class WebGLRenderer {
 
 				const object = renderItem.object;
 				const geometry = renderItem.geometry;
-				const material = overrideMaterial === null ? renderItem.material : overrideMaterial;
 				const group = renderItem.group;
+				let material = renderItem.material;
+
+				if ( material.allowOverride === true && overrideMaterial !== null ) {
+
+					material = overrideMaterial;
+
+				}
 
 				if ( object.layers.test( camera.layers ) ) {
 

--- a/src/renderers/common/Background.js
+++ b/src/renderers/common/Background.js
@@ -101,6 +101,7 @@ class Background extends DataMap {
 				nodeMaterial.side = BackSide;
 				nodeMaterial.depthTest = false;
 				nodeMaterial.depthWrite = false;
+				nodeMaterial.allowOverride = false;
 				nodeMaterial.fog = false;
 				nodeMaterial.lights = false;
 				nodeMaterial.vertexNode = viewProj;

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -2758,7 +2758,7 @@ class Renderer {
 
 		//
 
-		if ( scene.overrideMaterial !== null ) {
+		if ( material.allowOverride === true && scene.overrideMaterial !== null ) {
 
 			const overrideMaterial = scene.overrideMaterial;
 

--- a/src/renderers/webgl/WebGLBackground.js
+++ b/src/renderers/webgl/WebGLBackground.js
@@ -101,7 +101,8 @@ function WebGLBackground( renderer, cubemaps, cubeuvmaps, state, objects, alpha,
 						side: BackSide,
 						depthTest: false,
 						depthWrite: false,
-						fog: false
+						fog: false,
+						allowOverride: false
 					} )
 				);
 
@@ -180,7 +181,8 @@ function WebGLBackground( renderer, cubemaps, cubeuvmaps, state, objects, alpha,
 						side: FrontSide,
 						depthTest: false,
 						depthWrite: false,
-						fog: false
+						fog: false,
+						allowOverride: false
 					} )
 				);
 

--- a/src/scenes/Scene.js
+++ b/src/scenes/Scene.js
@@ -105,7 +105,7 @@ class Scene extends Object3D {
 
 		/**
 		 * Forces everything in the scene to be rendered with the defined material. It is possible
-		 * to exclude materials from override by settings {@link Material#allowOverride} to `false`.
+		 * to exclude materials from override by setting {@link Material#allowOverride} to `false`.
 		 *
 		 * @type {?Material}
 		 * @default null

--- a/src/scenes/Scene.js
+++ b/src/scenes/Scene.js
@@ -104,7 +104,8 @@ class Scene extends Object3D {
 		this.environmentRotation = new Euler();
 
 		/**
-		 * Forces everything in the scene to be rendered with the defined material.
+		 * Forces everything in the scene to be rendered with the defined material. It is possible
+		 * to exclude materials from override by settings {@link Material#allowOverride} to `false`.
 		 *
 		 * @type {?Material}
 		 * @default null


### PR DESCRIPTION
Fixed #30726.

**Description**

The PR introduces `Material.allowOverride` which controls whether the material can be overwritten by `Scene.overrideMaterial` or not. It is `true` by default.

With this new flag, the background textures and skyboxes are not affected by `Scene.overrideMaterial`, see #30726. If users render a scene with `Scene.overrideMaterial` e.g. to produce a normal pass, they must set the background to `null`. For a correct result, this was mandatory even before this PR but now the overall engine behavior is more consistent.
