### PR TITLE
fix: handle alphaToCoverage in shadow map generation

### DIFF
--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -310,7 +310,7 @@ function WebGLShadowMap( renderer, objects, capabilities ) {
 			// Check if the original material uses alphaToCoverage
 			if ( material.alphaToCoverage ) {
 
-				result.alphaTest = 0.1;
+				result.alphaTest = 0.5;
 
 			} else {
 

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -302,17 +302,31 @@ function WebGLShadowMap( renderer, objects, capabilities ) {
 
 		}
 
-		result.alphaMap = material.alphaMap;
-		result.alphaTest = material.alphaTest;
-		result.map = material.map;
+		if ( customMaterial === undefined ) {
 
-		result.clipShadows = material.clipShadows;
-		result.clippingPlanes = material.clippingPlanes;
-		result.clipIntersection = material.clipIntersection;
+			result.alphaMap = material.alphaMap;
+			result.map = material.map;
 
-		result.displacementMap = material.displacementMap;
-		result.displacementScale = material.displacementScale;
-		result.displacementBias = material.displacementBias;
+			// Check if the original material uses alphaToCoverage
+			if ( material.alphaToCoverage ) {
+
+				result.alphaTest = 0.1;
+
+			} else {
+
+				result.alphaTest = material.alphaTest;
+
+			}
+
+			result.clipShadows = material.clipShadows;
+			result.clippingPlanes = material.clippingPlanes;
+			result.clipIntersection = material.clipIntersection;
+
+			result.displacementMap = material.displacementMap;
+			result.displacementScale = material.displacementScale;
+			result.displacementBias = material.displacementBias;
+
+		}
 
 		result.wireframeLinewidth = material.wireframeLinewidth;
 		result.linewidth = material.linewidth;


### PR DESCRIPTION
Related issue: #[30462](https://github.com/mrdoob/three.js/issues/30462)

**Description**
When materials use `alphaToCoverage` shadow map used to fail to respect the transparency. This occurs because shadow generation relies on alphaTest to discard fragments, but alphaToCoverage bypasses alphaTest and uses multisampling instead. As a result, shadows render opaque even when the material appears transparent.

This PR fixes this by adding a check if original material uses `alphaToCoverage` then setting the shadow material's alphatest manually. 


<!-- Remove the line below if is not relevant -->
Before:
<img width="1264" alt="Screenshot 2025-03-20 at 12 14 15 AM" src="https://github.com/user-attachments/assets/64c80575-8654-45d5-9b04-8107044f41c2" />

After this change has been applied: 
<img width="1272" alt="Screenshot 2025-03-20 at 12 09 47 AM" src="https://github.com/user-attachments/assets/fa9993f5-a347-44e2-a191-02a955ccd9c6" />

