### PR TITLE
ShadowMaskModel: Fix signatures.

### DIFF
--- a/src/materials/nodes/ShadowNodeMaterial.js
+++ b/src/materials/nodes/ShadowNodeMaterial.js
@@ -45,6 +45,15 @@ class ShadowNodeMaterial extends NodeMaterial {
 		 */
 		this.lights = true;
 
+		/**
+		 * Overwritten since shadow materials are transparent
+		 * by default.
+		 *
+		 * @type {boolean}
+		 * @default true
+		 */
+		this.transparent = true;
+
 		this.setDefaultValues( _defaultValues );
 
 		this.setValues( parameters );

--- a/src/nodes/functions/ShadowMaskModel.js
+++ b/src/nodes/functions/ShadowMaskModel.js
@@ -32,7 +32,7 @@ class ShadowMaskModel extends LightingModel {
 	 */
 	direct( { lightNode } ) {
 
-		this.shadowNode.assign( lightNode.shadowNode );
+		this.shadowNode.mulAssign( lightNode.shadowNode );
 
 	}
 

--- a/src/nodes/functions/ShadowMaskModel.js
+++ b/src/nodes/functions/ShadowMaskModel.js
@@ -30,18 +30,18 @@ class ShadowMaskModel extends LightingModel {
 	 *
 	 * @param {Object} input - The input data.
 	 */
-	direct( { shadowMask } ) {
+	direct( { lightNode } ) {
 
-		this.shadowNode.mulAssign( shadowMask );
+		this.shadowNode.assign( lightNode.shadowNode );
 
 	}
 
 	/**
 	 * Uses the shadow mask to produce the final color.
 	 *
-	 * @param {ContextNode} context - The current node context.
+	 * @param {NodeBuilder} builder - The current node builder.
 	 */
-	finish( context ) {
+	finish( { context } ) {
 
 		diffuseColor.a.mulAssign( this.shadowNode.oneMinus() );
 


### PR DESCRIPTION
Fixed #30762.

**Description**

The `direct()` and `finish()` methods of `ShadowMaskModel` have outdated signatures. It seems when refactoring shadow and lighting related code the interface of this class was overlooked.

The PR restores `ShadowMaterial` with `WebGPURenderer`. However, `ShadowNodeMaterial` does not show the shadow mask for some reason. The following fiddles is using `ShadowMaterial`  and fixed with the PR but when using `ShadowNodeMaterial`, the plane gets black. https://jsfiddle.net/tbmgkf4s/

@sunag Before I dive into this more deeply, do you have an idea what's going wrong?
