### PR TITLE
CSMShader: Add missing `getPointShadow()` argument.

### DIFF
--- a/examples/jsm/csm/CSMShader.js
+++ b/examples/jsm/csm/CSMShader.js
@@ -54,7 +54,8 @@ IncidentLight directLight;
 
 		#if defined( USE_SHADOWMAP ) && ( UNROLLED_LOOP_INDEX < NUM_POINT_LIGHT_SHADOWS )
 		pointLightShadow = pointLightShadows[ i ];
-		directLight.color *= ( directLight.visible && receiveShadow ) ? getPointShadow( pointShadowMap[ i ], pointLightShadow.shadowMapSize, pointLightShadow.shadowBias, pointLightShadow.shadowRadius, vPointShadowCoord[ i ], pointLightShadow.shadowCameraNear, pointLightShadow.shadowCameraFar ) : 1.0;
+		directLight.color *= ( directLight.visible && receiveShadow ) ? getPointShadow( pointShadowMap[ i ], pointLightShadow.shadowMapSize, pointLightShadow.shadowIntensity, pointLightShadow.shadowBias, pointLightShadow.shadowRadius, vPointShadowCoord[ i ], pointLightShadow.shadowCameraNear, pointLightShadow.shadowCameraFar ) : 1.0;
+
 		#endif
 
 		RE_Direct( directLight, geometryPosition, geometryNormal, geometryViewDir, geometryClearcoatNormal, material, reflectedLight );


### PR DESCRIPTION
#28588 adds an intensity argument to the `getPointShadow()` function, but this wasn't updated in the CSM add-on.

If we add a point light into the CSM example:

```diff
diff --git a/examples/webgl_shadowmap_csm.html b/examples/webgl_shadowmap_csm.html
index 41bb816..7d00a08 100644
--- a/examples/webgl_shadowmap_csm.html
+++ b/examples/webgl_shadowmap_csm.html
@@ -95,6 +95,11 @@
                                const ambientLight = new THREE.AmbientLight( 0xffffff, 1.5 );
                                scene.add( ambientLight );

+                               const pointLight = new THREE.PointLight( 0xffffff, 5, 500, 0 );
+                               pointLight.castShadow = true;
+                               pointLight.position.set(-200, 150, 100);
+                               scene.add( pointLight );
+
                                const additionalDirectionalLight = new THREE.DirectionalLight( 0x000020, 1.5 );
                                additionalDirectionalLight.position.set( params.lightX, params.lightY, params.lightZ ).normalize().multiplyScalar( - 200 );
                                scene.add( additionalDirectionalLight );
```

Previously, we'd get a blank viewport:

<img width="1074" alt="image" src="https://github.com/user-attachments/assets/eafb60c9-9b62-4e6e-aae4-34fa67592ec3" />

And this error:
```
ERROR: 0:968: 'getPointShadow' : no matching overloaded function found
```


After this change, we can render all lights/shadows:

<img width="1074" alt="image" src="https://github.com/user-attachments/assets/25c3374a-5299-43d0-8c97-0248e96dc1c6" />
