### PR TITLE
TSL: Fix `equal()` inconsistent

### DIFF
--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -412,14 +412,6 @@ class NodeBuilder {
 		 */
 		this.buildStage = null;
 
-		/**
-		 * Whether comparison in shader code are generated with methods or not.
-		 *
-		 * @type {boolean}
-		 * @default false
-		 */
-		this.useComparisonMethod = false;
-
 	}
 
 	/**

--- a/src/nodes/math/MathNode.js
+++ b/src/nodes/math/MathNode.js
@@ -1,5 +1,5 @@
 import TempNode from '../core/TempNode.js';
-import { sub, mul, div } from './OperatorNode.js';
+import { sub, mul, div, equal } from './OperatorNode.js';
 import { addMethodChaining, nodeObject, nodeProxy, float, vec2, vec3, vec4, Fn } from '../tsl/TSLCore.js';
 import { WebGLCoordinateSystem, WebGPUCoordinateSystem } from '../../constants.js';
 
@@ -126,7 +126,7 @@ class MathNode extends TempNode {
 
 			return 'vec3';
 
-		} else if ( method === MathNode.ALL ) {
+		} else if ( method === MathNode.ALL || method === MathNode.ANY ) {
 
 			return 'bool';
 
@@ -714,9 +714,15 @@ export const bitcast = /*@__PURE__*/ nodeProxy( MathNode, MathNode.BITCAST );
  * @function
  * @param {Node | number} x - The first parameter.
  * @param {Node | number} y - The second parameter.
+ * @deprecated since r175. Use {@link equal} instead.
  * @returns {Node<bool>}
  */
-export const equals = /*@__PURE__*/ nodeProxy( MathNode, MathNode.EQUALS );
+export const equals = ( x, y ) => { // @deprecated, r172
+
+	console.warn( 'THREE.TSL: "equals" is deprecated. Use "equal" inside a vector instead, like: "bvec*( equal( ... ) )"' );
+	return equal( x, y );
+
+};
 
 /**
  * Returns the lesser of two values.

--- a/src/nodes/math/OperatorNode.js
+++ b/src/nodes/math/OperatorNode.js
@@ -1,3 +1,4 @@
+import { WebGLCoordinateSystem } from '../../constants.js';
 import TempNode from '../core/TempNode.js';
 import { addMethodChaining, nodeProxy } from '../tsl/TSLCore.js';
 
@@ -117,6 +118,7 @@ class OperatorNode extends TempNode {
 		} else {
 
 			// Handle matrix operations
+
 			if ( builder.isMatrix( typeA ) ) {
 
 				if ( typeB === 'float' ) {
@@ -148,6 +150,7 @@ class OperatorNode extends TempNode {
 			}
 
 			// Handle non-matrix cases
+
 			if ( builder.getTypeLength( typeB ) > builder.getTypeLength( typeA ) ) {
 
 				// anytype x anytype: use the greater length vector
@@ -201,6 +204,7 @@ class OperatorNode extends TempNode {
 				if ( typeB === 'float' ) {
 
 					// Keep matrix type for typeA, but ensure typeB stays float
+
 					typeB = 'float';
 
 				} else if ( builder.isVector( typeB ) ) {
@@ -209,7 +213,9 @@ class OperatorNode extends TempNode {
 					typeB = builder.getVectorFromMatrix( typeA );
 
 				} else if ( builder.isMatrix( typeB ) ) {
+
 					// matrix x matrix - keep both types
+
 				} else {
 
 					typeA = typeB = type;
@@ -221,11 +227,13 @@ class OperatorNode extends TempNode {
 				if ( typeA === 'float' ) {
 
 					// Keep matrix type for typeB, but ensure typeA stays float
+
 					typeA = 'float';
 
 				} else if ( builder.isVector( typeA ) ) {
 
 					// vector x matrix
+
 					typeA = builder.getVectorFromMatrix( typeB );
 
 				} else {
@@ -256,13 +264,47 @@ class OperatorNode extends TempNode {
 
 		if ( output !== 'void' ) {
 
-			if ( op === '<' && outputLength > 1 ) {
+			const isGLSL = builder.renderer.coordinateSystem === WebGLCoordinateSystem;
 
-				if ( builder.useComparisonMethod ) {
+			if ( op === '==' ) {
+
+				if ( isGLSL ) {
+
+					if ( outputLength > 1 ) {
+
+						return builder.format( `${ builder.getMethod( 'equal', output ) }( ${ a }, ${ b } )`, type, output );
+
+					} else {
+
+						return builder.format( `( ${ a } ${ op } ${ b } )`, type, output );
+
+					}
+
+				} else {
+
+					// WGSL
+
+					if ( outputLength > 1 || ! builder.isVector( typeA ) ) {
+
+						return builder.format( `( ${ a } == ${ b } )`, type, output );
+
+					} else {
+
+						return builder.format( `all( ${ a } == ${ b } )`, type, output );
+
+					}
+
+				}
+
+			} else if ( op === '<' && outputLength > 1 ) {
+
+				if ( isGLSL ) {
 
 					return builder.format( `${ builder.getMethod( 'lessThan', output ) }( ${ a }, ${ b } )`, type, output );
 
 				} else {
+
+					// WGSL
 
 					return builder.format( `( ${ a } < ${ b } )`, type, output );
 
@@ -270,11 +312,13 @@ class OperatorNode extends TempNode {
 
 			} else if ( op === '<=' && outputLength > 1 ) {
 
-				if ( builder.useComparisonMethod ) {
+				if ( isGLSL ) {
 
 					return builder.format( `${ builder.getMethod( 'lessThanEqual', output ) }( ${ a }, ${ b } )`, type, output );
 
 				} else {
+
+					// WGSL
 
 					return builder.format( `( ${ a } <= ${ b } )`, type, output );
 
@@ -282,11 +326,13 @@ class OperatorNode extends TempNode {
 
 			} else if ( op === '>' && outputLength > 1 ) {
 
-				if ( builder.useComparisonMethod ) {
+				if ( isGLSL ) {
 
 					return builder.format( `${ builder.getMethod( 'greaterThan', output ) }( ${ a }, ${ b } )`, type, output );
 
 				} else {
+
+					// WGSL
 
 					return builder.format( `( ${ a } > ${ b } )`, type, output );
 
@@ -294,11 +340,13 @@ class OperatorNode extends TempNode {
 
 			} else if ( op === '>=' && outputLength > 1 ) {
 
-				if ( builder.useComparisonMethod ) {
+				if ( isGLSL ) {
 
 					return builder.format( `${ builder.getMethod( 'greaterThanEqual', output ) }( ${ a }, ${ b } )`, type, output );
 
 				} else {
+
+					// WGSL
 
 					return builder.format( `( ${ a } >= ${ b } )`, type, output );
 
@@ -315,6 +363,7 @@ class OperatorNode extends TempNode {
 			} else {
 
 				// Handle matrix operations
+
 				if ( builder.isMatrix( typeA ) && typeB === 'float' ) {
 
 					return builder.format( `( ${ b } ${ op } ${ a } )`, type, output );

--- a/src/nodes/pmrem/PMREMUtils.js
+++ b/src/nodes/pmrem/PMREMUtils.js
@@ -1,5 +1,5 @@
 import { Fn, int, float, vec2, vec3, vec4, If } from '../tsl/TSLBase.js';
-import { cos, sin, abs, max, exp2, log2, clamp, fract, mix, floor, normalize, cross, all } from '../math/MathNode.js';
+import { cos, sin, abs, max, exp2, log2, clamp, fract, mix, floor, normalize, cross } from '../math/MathNode.js';
 import { mul } from '../math/OperatorNode.js';
 import { select } from '../math/ConditionalNode.js';
 import { Loop, Break } from '../utils/LoopNode.js';

--- a/src/nodes/pmrem/PMREMUtils.js
+++ b/src/nodes/pmrem/PMREMUtils.js
@@ -258,7 +258,7 @@ export const blur = /*@__PURE__*/ Fn( ( { n, latitudinal, poleAxis, outputDirect
 
 	const axis = vec3( select( latitudinal, poleAxis, cross( poleAxis, outputDirection ) ) ).toVar();
 
-	If( all( axis.equals( vec3( 0.0 ) ) ), () => {
+	If( axis.equal( vec3( 0.0 ) ), () => {
 
 		axis.assign( vec3( outputDirection.z, 0.0, outputDirection.x.negate() ) );
 

--- a/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
+++ b/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
@@ -97,14 +97,6 @@ class GLSLNodeBuilder extends NodeBuilder {
 		 */
 		this.builtins = { vertex: [], fragment: [], compute: [] };
 
-		/**
-		 * Whether comparison in shader code are generated with methods or not.
-		 *
-		 * @type {boolean}
-		 * @default true
-		 */
-		this.useComparisonMethod = true;
-
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/mrdoob/three.js/issues/30755

**Description**

Fix `equality operator` consistency since in WGSL it returns a vector and in GLSL a boolean thus deprecating `equals()` making it simpler and similar to GLSL.
