### PR TITLE
TSL: Avoid name collision

### DIFF
--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -1864,7 +1864,7 @@ class NodeBuilder {
 		let index = 1;
 		let name = property;
 
-		// Auto rename if the name is already in use
+		// Automatically renames the property if the name is already in use.
 
 		while ( declarations[ name ] !== undefined ) {
 

--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -1864,6 +1864,8 @@ class NodeBuilder {
 		let index = 1;
 		let name = property;
 
+		// Auto rename if the name is already in use
+
 		while ( declarations[ name ] !== undefined ) {
 
 			name = property + '_' + index ++;

--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -266,6 +266,14 @@ class NodeBuilder {
 		 */
 		this.bindings = { vertex: {}, fragment: {}, compute: {} };
 
+
+		/**
+		 * This dictionary holds the declarations for each shader stage.
+		 *
+		 * @type {Object}
+		 */
+		this.declarations = { vertex: {}, fragment: {}, compute: {} };
+
 		/**
 		 * This dictionary maintains the binding indices per bind group.
 		 *
@@ -1226,6 +1234,8 @@ class NodeBuilder {
 
 		const attribute = new NodeAttribute( name, type );
 
+		this.registerDeclaration( attribute );
+
 		attributes.push( attribute );
 
 		return attribute;
@@ -1676,6 +1686,8 @@ class NodeBuilder {
 
 			this.uniforms[ shaderStage ].push( nodeUniform );
 
+			this.registerDeclaration( nodeUniform );
+
 			nodeData.uniform = nodeUniform;
 
 		}
@@ -1744,6 +1756,8 @@ class NodeBuilder {
 				vars.push( nodeVar );
 
 			}
+
+			this.registerDeclaration( nodeVar );
 
 			nodeData.variable = nodeVar;
 
@@ -1825,11 +1839,46 @@ class NodeBuilder {
 
 			varyings.push( nodeVarying );
 
+			this.registerDeclaration( nodeVarying );
+
 			nodeData.varying = nodeVarying;
 
 		}
 
 		return nodeVarying;
+
+	}
+
+	/**
+	 * Registers a node declaration in the current shader stage.
+	 *
+	 * @param {Object} node - The node to be registered.
+	 */
+	registerDeclaration( node ) {
+
+		const shaderStage = this.shaderStage;
+		const declarations = this.declarations[ shaderStage ];
+
+		const property = this.getPropertyName( node );
+
+		let index = 1;
+		let name = property;
+
+		while ( declarations[ name ] !== undefined ) {
+
+			name = property + '_' + index ++;
+
+		}
+
+		declarations[ name ] = node;
+
+		if ( index > 1 ) {
+
+			node.name = name;
+
+			console.warn( `THREE.TSL: Declaration name '${ property }' of '${ node.type }' already in use. Renamed to '${ name }'.` );
+
+		}
 
 	}
 

--- a/src/nodes/core/VarNode.js
+++ b/src/nodes/core/VarNode.js
@@ -74,12 +74,6 @@ class VarNode extends Node {
 
 	}
 
-	getHash( builder ) {
-
-		return this.name || super.getHash( builder );
-
-	}
-
 	getMemberType( builder, name ) {
 
 		return this.node.getMemberType( builder, name );


### PR DESCRIPTION
Fixes: https://github.com/mrdoob/three.js/issues/29969

**Description**

Automatically renames the property if the name is already in use.

![image](https://github.com/user-attachments/assets/a3d4ef5f-d478-46b1-b32a-16bbd0635b80)

