### PR TITLE
Shaders: Improve types.

### DIFF
--- a/examples/jsm/postprocessing/BloomPass.js
+++ b/examples/jsm/postprocessing/BloomPass.js
@@ -73,7 +73,7 @@ class BloomPass extends Pass {
 		this.convolutionUniforms = UniformsUtils.clone( convolutionShader.uniforms );
 
 		this.convolutionUniforms[ 'uImageIncrement' ].value = BloomPass.blurX;
-		this.convolutionUniforms[ 'cKernel' ].value = ConvolutionShader.buildKernel( sigma );
+		this.convolutionUniforms[ 'cKernel' ].value = buildKernel( sigma );
 
 		/**
 		 * The convolution pass material.
@@ -234,5 +234,40 @@ const CombineShader = {
 
 BloomPass.blurX = new Vector2( 0.001953125, 0.0 );
 BloomPass.blurY = new Vector2( 0.0, 0.001953125 );
+
+
+function gauss( x, sigma ) {
+
+	return Math.exp( - ( x * x ) / ( 2.0 * sigma * sigma ) );
+
+}
+
+function buildKernel( sigma ) {
+
+	// We loop off the sqrt(2 * pi) * sigma term, since we're going to normalize anyway.
+
+	const kMaxKernelSize = 25;
+	let kernelSize = 2 * Math.ceil( sigma * 3.0 ) + 1;
+
+	if ( kernelSize > kMaxKernelSize ) kernelSize = kMaxKernelSize;
+
+	const halfWidth = ( kernelSize - 1 ) * 0.5;
+
+	const values = new Array( kernelSize );
+	let sum = 0.0;
+	for ( let i = 0; i < kernelSize; ++ i ) {
+
+		values[ i ] = gauss( i - halfWidth, sigma );
+		sum += values[ i ];
+
+	}
+
+	// normalize the kernel
+
+	for ( let i = 0; i < kernelSize; ++ i ) values[ i ] /= sum;
+
+	return values;
+
+}
 
 export { BloomPass };

--- a/examples/jsm/shaders/ACESFilmicToneMappingShader.js
+++ b/examples/jsm/shaders/ACESFilmicToneMappingShader.js
@@ -8,7 +8,7 @@
  * The scale factor of 1/0.6 is subjective. See discussion in #19621.
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const ACESFilmicToneMappingShader = {
 

--- a/examples/jsm/shaders/AfterimageShader.js
+++ b/examples/jsm/shaders/AfterimageShader.js
@@ -4,7 +4,7 @@
  * Inspired by [Three.js FBO motion trails]{@link https://codepen.io/brunoimbrizi/pen/MoRJaN?page=1&}.
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const AfterimageShader = {
 

--- a/examples/jsm/shaders/BasicShader.js
+++ b/examples/jsm/shaders/BasicShader.js
@@ -4,7 +4,7 @@
  * Simple shader for testing.
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const BasicShader = {
 

--- a/examples/jsm/shaders/BleachBypassShader.js
+++ b/examples/jsm/shaders/BleachBypassShader.js
@@ -6,7 +6,7 @@
  * [Nvidia Shader library]{@link http://developer.download.nvidia.com/shaderlibrary/webpages/shader_library.html#post_bleach_bypass}.
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const BleachBypassShader = {
 

--- a/examples/jsm/shaders/BlendShader.js
+++ b/examples/jsm/shaders/BlendShader.js
@@ -4,7 +4,7 @@
  * Blends two textures.
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const BlendShader = {
 

--- a/examples/jsm/shaders/BokehShader.js
+++ b/examples/jsm/shaders/BokehShader.js
@@ -5,7 +5,7 @@
  * [GLSL shader by Martins Upitis]{@link http://artmartinsh.blogspot.com/2010/02/glsl-lens-blur-filter-with-bokeh.html}.
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const BokehShader = {
 

--- a/examples/jsm/shaders/BokehShader2.js
+++ b/examples/jsm/shaders/BokehShader2.js
@@ -11,7 +11,7 @@ import {
  * Requires #define RINGS and SAMPLES integers
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const BokehShader = {
 

--- a/examples/jsm/shaders/BrightnessContrastShader.js
+++ b/examples/jsm/shaders/BrightnessContrastShader.js
@@ -6,7 +6,7 @@
  * Contrast: -1 to 1 (-1 is solid gray, 0 is no change, and 1 is maximum contrast)
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const BrightnessContrastShader = {
 

--- a/examples/jsm/shaders/ColorCorrectionShader.js
+++ b/examples/jsm/shaders/ColorCorrectionShader.js
@@ -8,7 +8,7 @@ import {
  * Color correction shader.
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const ColorCorrectionShader = {
 

--- a/examples/jsm/shaders/ColorifyShader.js
+++ b/examples/jsm/shaders/ColorifyShader.js
@@ -8,7 +8,7 @@ import {
  * Colorify shader.
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const ColorifyShader = {
 

--- a/examples/jsm/shaders/ConvolutionShader.js
+++ b/examples/jsm/shaders/ConvolutionShader.js
@@ -8,7 +8,7 @@ import {
  * Convolution shader ported from o3d sample to WebGL / GLSL.
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const ConvolutionShader = {
 
@@ -65,42 +65,7 @@ const ConvolutionShader = {
 
 			gl_FragColor = sum;
 
-		}`,
-
-	buildKernel: function ( sigma ) {
-
-		// We lop off the sqrt(2 * pi) * sigma term, since we're going to normalize anyway.
-
-		const kMaxKernelSize = 25;
-		let kernelSize = 2 * Math.ceil( sigma * 3.0 ) + 1;
-
-		if ( kernelSize > kMaxKernelSize ) kernelSize = kMaxKernelSize;
-
-		const halfWidth = ( kernelSize - 1 ) * 0.5;
-
-		const values = new Array( kernelSize );
-		let sum = 0.0;
-		for ( let i = 0; i < kernelSize; ++ i ) {
-
-			values[ i ] = gauss( i - halfWidth, sigma );
-			sum += values[ i ];
-
-		}
-
-		// normalize the kernel
-
-		for ( let i = 0; i < kernelSize; ++ i ) values[ i ] /= sum;
-
-		return values;
-
-	}
-
+		}`
 };
-
-function gauss( x, sigma ) {
-
-	return Math.exp( - ( x * x ) / ( 2.0 * sigma * sigma ) );
-
-}
 
 export { ConvolutionShader };

--- a/examples/jsm/shaders/CopyShader.js
+++ b/examples/jsm/shaders/CopyShader.js
@@ -4,7 +4,7 @@
  * Full-screen copy shader pass.
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const CopyShader = {
 

--- a/examples/jsm/shaders/DOFMipMapShader.js
+++ b/examples/jsm/shaders/DOFMipMapShader.js
@@ -6,7 +6,7 @@
  * Requires power-of-2 sized render target with enabled mipmaps.
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const DOFMipMapShader = {
 

--- a/examples/jsm/shaders/DepthLimitedBlurShader.js
+++ b/examples/jsm/shaders/DepthLimitedBlurShader.js
@@ -10,7 +10,7 @@ import {
  * Used by {@link SAOPass}.
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const DepthLimitedBlurShader = {
 

--- a/examples/jsm/shaders/DigitalGlitch.js
+++ b/examples/jsm/shaders/DigitalGlitch.js
@@ -4,9 +4,11 @@
  * Digital glitch shader.
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const DigitalGlitch = {
+
+	name: 'DigitalGlitch',
 
 	uniforms: {
 

--- a/examples/jsm/shaders/DotScreenShader.js
+++ b/examples/jsm/shaders/DotScreenShader.js
@@ -8,7 +8,7 @@ import {
  * Dot screen shader based on [glfx.js sepia shader]{@link https://github.com/evanw/glfx.js}.
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const DotScreenShader = {
 

--- a/examples/jsm/shaders/ExposureShader.js
+++ b/examples/jsm/shaders/ExposureShader.js
@@ -4,7 +4,7 @@
  * TODO
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const ExposureShader = {
 

--- a/examples/jsm/shaders/FXAAShader.js
+++ b/examples/jsm/shaders/FXAAShader.js
@@ -12,7 +12,7 @@ import {
  * - {@link https://catlikecoding.com/unity/tutorials/advanced-rendering/fxaa/}.
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const FXAAShader = {
 
@@ -146,7 +146,7 @@ const FXAAShader = {
 			float nGradient = abs( nLuminance - l.m );
 
 			e.pixelStep = e.isHorizontal ? texSize.y : texSize.x;
-			
+
 			if (pGradient < nGradient) {
 
 				e.pixelStep = -e.pixelStep;
@@ -226,7 +226,7 @@ const FXAAShader = {
 				nDistance = uv.x - nuv.x;
 
 			} else {
-				
+
 				pDistance = puv.y - uv.y;
 				nDistance = uv.y - nuv.y;
 
@@ -287,7 +287,7 @@ const FXAAShader = {
 		void main() {
 
 			gl_FragColor = ApplyFXAA( tDiffuse, resolution.xy, vUv );
-			
+
 		}`
 
 };

--- a/examples/jsm/shaders/FilmShader.js
+++ b/examples/jsm/shaders/FilmShader.js
@@ -6,7 +6,7 @@
  * Used by {@link FilmPass}.
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const FilmShader = {
 

--- a/examples/jsm/shaders/FocusShader.js
+++ b/examples/jsm/shaders/FocusShader.js
@@ -4,7 +4,7 @@
  * Focus shader based on [PaintEffect postprocess from ro.me]{@link http://code.google.com/p/3-dreams-of-black/source/browse/deploy/js/effects/PaintEffect.js}.
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const FocusShader = {
 

--- a/examples/jsm/shaders/FreiChenShader.js
+++ b/examples/jsm/shaders/FreiChenShader.js
@@ -11,7 +11,7 @@ import {
  * aspect: vec2 of (1/width, 1/height)
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const FreiChenShader = {
 

--- a/examples/jsm/shaders/GTAOShader.js
+++ b/examples/jsm/shaders/GTAOShader.js
@@ -16,7 +16,7 @@ import {
  * - [Horizon-Based Indirect Lighting (HBIL)]{@link https://github.com/Patapom/GodComplex/blob/master/Tests/TestHBIL/2018%20Mayaux%20-%20Horizon-Based%20Indirect%20Lighting%20(HBIL).pdf}
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const GTAOShader = {
 
@@ -69,7 +69,7 @@ const GTAOShader = {
 		uniform float cameraNear;
 		uniform float cameraFar;
 		uniform mat4 cameraProjectionMatrix;
-		uniform mat4 cameraProjectionMatrixInverse;		
+		uniform mat4 cameraProjectionMatrixInverse;
 		uniform mat4 cameraWorldMatrix;
 		uniform float radius;
 		uniform float distanceExponent;
@@ -80,7 +80,7 @@ const GTAOShader = {
 			uniform vec3 sceneBoxMin;
 			uniform vec3 sceneBoxMax;
 		#endif
-		
+
 		#include <common>
 		#include <packing>
 
@@ -94,11 +94,11 @@ const GTAOShader = {
 			return viewSpacePosition.xyz / viewSpacePosition.w;
 		}
 
-		float getDepth(const vec2 uv) {  
+		float getDepth(const vec2 uv) {
 			return textureLod(tDepth, uv.xy, 0.0).DEPTH_SWIZZLING;
 		}
 
-		float fetchDepth(const ivec2 uv) {   
+		float fetchDepth(const ivec2 uv) {
 			return texelFetch(tDepth, uv.xy, 0).DEPTH_SWIZZLING;
 		}
 
@@ -148,7 +148,7 @@ const GTAOShader = {
 			float sampleSceneDepth = getDepth(sampleUv);
 			return vec3(sampleUv, sampleSceneDepth);
 		}
-		
+
 		void main() {
 			float depth = getDepth(vUv.xy);
 			if (depth >= 1.0) {
@@ -174,7 +174,7 @@ const GTAOShader = {
 					return;
 				}
 			#endif
-			
+
 			vec2 noiseResolution = vec2(textureSize(tNoise, 0));
 			vec2 noiseUv = vUv * resolution / noiseResolution;
 			vec4 noiseTexel = textureLod(tNoise, noiseUv, 0.0);
@@ -187,21 +187,21 @@ const GTAOShader = {
 			const int STEPS = (SAMPLES + DIRECTIONS - 1) / DIRECTIONS;
 			float ao = 0.0;
 			for (int i = 0; i < DIRECTIONS; ++i) {
-				
+
 				float angle = float(i) / float(DIRECTIONS) * PI;
-				vec4 sampleDir = vec4(cos(angle), sin(angle), 0., 0.5 + 0.5 * noiseTexel.w); 
+				vec4 sampleDir = vec4(cos(angle), sin(angle), 0., 0.5 + 0.5 * noiseTexel.w);
 				sampleDir.xyz = normalize(kernelMatrix * sampleDir.xyz);
 
 				vec3 viewDir = normalize(-viewPos.xyz);
 				vec3 sliceBitangent = normalize(cross(sampleDir.xyz, viewDir));
 				vec3 sliceTangent = cross(sliceBitangent, viewDir);
 				vec3 normalInSlice = normalize(viewNormal - sliceBitangent * dot(viewNormal, sliceBitangent));
-				
+
 				vec3 tangentToNormalInSlice = cross(normalInSlice, sliceBitangent);
 				vec2 cosHorizons = vec2(dot(viewDir, tangentToNormalInSlice), dot(viewDir, -tangentToNormalInSlice));
-				
+
 				for (int j = 0; j < STEPS; ++j) {
-					vec3 sampleViewOffset = sampleDir.xyz * radiusToUse * sampleDir.w * pow(float(j + 1) / float(STEPS), distanceExponent);	
+					vec3 sampleViewOffset = sampleDir.xyz * radiusToUse * sampleDir.w * pow(float(j + 1) / float(STEPS), distanceExponent);
 
 					vec3 sampleSceneUvDepth = getSceneUvAndDepth(viewPos + sampleViewOffset);
 					vec3 sampleSceneViewPos = getViewPosition(sampleSceneUvDepth.xy, sampleSceneUvDepth.z);
@@ -209,7 +209,7 @@ const GTAOShader = {
 					if (abs(viewDelta.z) < thickness) {
 						float sampleCosHorizon = dot(viewDir, normalize(viewDelta));
 						cosHorizons.x += max(0., (sampleCosHorizon - cosHorizons.x) * mix(1., 2. / float(j + 2), distanceFallOff));
-					}		
+					}
 
 					sampleSceneUvDepth = getSceneUvAndDepth(viewPos - sampleViewOffset);
 					sampleSceneViewPos = getViewPosition(sampleSceneUvDepth.xy, sampleSceneUvDepth.z);
@@ -229,7 +229,7 @@ const GTAOShader = {
 				ao += occlusion;
 			}
 
-			ao = clamp(ao / float(DIRECTIONS), 0., 1.);		
+			ao = clamp(ao / float(DIRECTIONS), 0., 1.);
 		#if SCENE_CLIP_BOX == 1
 			ao = mix(ao, 1., smoothstep(0., radiusToUse, boxDistance));
 		#endif

--- a/examples/jsm/shaders/GammaCorrectionShader.js
+++ b/examples/jsm/shaders/GammaCorrectionShader.js
@@ -7,7 +7,7 @@
  * - {@link http://en.wikipedia.org/wiki/gamma_correction}.
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const GammaCorrectionShader = {
 

--- a/examples/jsm/shaders/GodRaysShader.js
+++ b/examples/jsm/shaders/GodRaysShader.js
@@ -22,7 +22,7 @@ import {
  * - [Sousa2008, Crysis Next Gen Effects, GDC2008]{@link http://www.crytek.com/sites/default/files/GDC08_SousaT_CrysisEffects.ppt}.
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const GodRaysDepthMaskShader = {
 
@@ -77,7 +77,7 @@ const GodRaysDepthMaskShader = {
  * decreased distance between samples.
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const GodRaysGenerateShader = {
 
@@ -201,7 +201,7 @@ const GodRaysGenerateShader = {
  * fGodRayIntensity attenuates the god rays.
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const GodRaysCombineShader = {
 

--- a/examples/jsm/shaders/HalftoneShader.js
+++ b/examples/jsm/shaders/HalftoneShader.js
@@ -9,7 +9,7 @@
  * Blending Mode (1 = Linear, 2 = Multiply, 3 = Add, 4 = Lighter, 5 = Darker)
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const HalftoneShader = {
 

--- a/examples/jsm/shaders/HorizontalBlurShader.js
+++ b/examples/jsm/shaders/HorizontalBlurShader.js
@@ -11,7 +11,7 @@
  * - "h" and "v" parameters should be set to "1 / width" and "1 / height"
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const HorizontalBlurShader = {
 

--- a/examples/jsm/shaders/HorizontalTiltShiftShader.js
+++ b/examples/jsm/shaders/HorizontalTiltShiftShader.js
@@ -9,7 +9,7 @@
  * - "r" parameter control where "focused" horizontal line lies
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const HorizontalTiltShiftShader = {
 

--- a/examples/jsm/shaders/HueSaturationShader.js
+++ b/examples/jsm/shaders/HueSaturationShader.js
@@ -7,7 +7,7 @@
  * saturation: -1 to 1 (-1 is solid gray, 0 is no change, and 1 is maximum contrast)
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const HueSaturationShader = {
 

--- a/examples/jsm/shaders/KaleidoShader.js
+++ b/examples/jsm/shaders/KaleidoShader.js
@@ -10,7 +10,7 @@
  * angle: initial angle in radians
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const KaleidoShader = {
 

--- a/examples/jsm/shaders/LuminosityHighPassShader.js
+++ b/examples/jsm/shaders/LuminosityHighPassShader.js
@@ -8,13 +8,11 @@ import {
  * Luminosity high pass shader.
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const LuminosityHighPassShader = {
 
 	name: 'LuminosityHighPassShader',
-
-	shaderID: 'luminosityHighPass',
 
 	uniforms: {
 

--- a/examples/jsm/shaders/LuminosityShader.js
+++ b/examples/jsm/shaders/LuminosityShader.js
@@ -4,7 +4,7 @@
  * Luminosity shader.
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const LuminosityShader = {
 

--- a/examples/jsm/shaders/MirrorShader.js
+++ b/examples/jsm/shaders/MirrorShader.js
@@ -6,7 +6,7 @@
  * side: side of input to mirror (0 = left, 1 = right, 2 = top, 3 = bottom).
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const MirrorShader = {
 

--- a/examples/jsm/shaders/NormalMapShader.js
+++ b/examples/jsm/shaders/NormalMapShader.js
@@ -7,7 +7,7 @@ import {
 /**
  * Normal map shader, compute normals from heightmap.
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const NormalMapShader = {
 

--- a/examples/jsm/shaders/OutputShader.js
+++ b/examples/jsm/shaders/OutputShader.js
@@ -7,7 +7,7 @@
  * Used by {@link OutputPass}.
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const OutputShader = {
 

--- a/examples/jsm/shaders/PoissonDenoiseShader.js
+++ b/examples/jsm/shaders/PoissonDenoiseShader.js
@@ -14,7 +14,7 @@ import {
  * - [Poisson2Sparse: Self-Supervised Poisson Denoising From a Single Image]{@link https://arxiv.org/pdf/2206.01856.pdf}
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const PoissonDenoiseShader = {
 
@@ -65,7 +65,7 @@ const PoissonDenoiseShader = {
 		uniform float normalPhi;
 		uniform float radius;
 		uniform int index;
-		
+
 		#include <common>
 		#include <packing>
 
@@ -88,9 +88,9 @@ const PoissonDenoiseShader = {
 			vec4 viewSpacePosition = cameraProjectionMatrixInverse * clipSpacePosition;
 			return viewSpacePosition.xyz / viewSpacePosition.w;
 		}
-		
+
 		float getDepth(const vec2 uv) {
-		#if DEPTH_VALUE_SOURCE == 1    
+		#if DEPTH_VALUE_SOURCE == 1
 			return textureLod(tDepth, uv.xy, 0.0).a;
 		#else
 			return textureLod(tDepth, uv.xy, 0.0).r;
@@ -98,7 +98,7 @@ const PoissonDenoiseShader = {
 		}
 
 		float fetchDepth(const ivec2 uv) {
-			#if DEPTH_VALUE_SOURCE == 1    
+			#if DEPTH_VALUE_SOURCE == 1
 				return texelFetch(tDepth, uv.xy, 0).a;
 			#else
 				return texelFetch(tDepth, uv.xy, 0).r;
@@ -145,7 +145,7 @@ const PoissonDenoiseShader = {
 			vec3 sampleNormal = getViewNormal(sampleUv);
 			vec3 neighborColor = sampleTexel.rgb;
 			vec3 viewPosSample = getViewPosition(sampleUv, sampleDepth);
-			
+
 			float normalDiff = dot(viewNormal, sampleNormal);
 			float normalSimilarity = pow(max(normalDiff, 0.), normalPhi);
 			float lumaDiff = abs(getLuminance(neighborColor) - getLuminance(center));
@@ -153,14 +153,14 @@ const PoissonDenoiseShader = {
 			float depthDiff = abs(dot(viewPos - viewPosSample, viewNormal));
 			float depthSimilarity = max(1. - depthDiff / depthPhi, 0.);
 			float w = lumaSimilarity * depthSimilarity * normalSimilarity;
-		
+
 			denoised += w * neighborColor;
 			totalWeight += w;
 		}
-		
+
 		void main() {
-			float depth = getDepth(vUv.xy);	
-			vec3 viewNormal = getViewNormal(vUv);	
+			float depth = getDepth(vUv.xy);
+			vec3 viewNormal = getViewNormal(vUv);
 			if (depth == 1. || dot(viewNormal, viewNormal) == 0.) {
 				discard;
 				return;
@@ -174,7 +174,7 @@ const PoissonDenoiseShader = {
 			vec4 noiseTexel = textureLod(tNoise, noiseUv, 0.0);
       		vec2 noiseVec = vec2(sin(noiseTexel[index % 4] * 2. * PI), cos(noiseTexel[index % 4] * 2. * PI));
     		mat2 rotationMatrix = mat2(noiseVec.x, -noiseVec.y, noiseVec.x, noiseVec.y);
-		
+
 			float totalWeight = 1.0;
 			vec3 denoised = texel.rgb;
 			for (int i = 0; i < SAMPLES; i++) {
@@ -183,8 +183,8 @@ const PoissonDenoiseShader = {
 				vec2 sampleUv = vUv + offset;
 				denoiseSample(center, viewNormal, viewPos, sampleUv, denoised, totalWeight);
 			}
-		
-			if (totalWeight > 0.) { 
+
+			if (totalWeight > 0.) {
 				denoised /= totalWeight;
 			}
 			gl_FragColor = FRAGMENT_OUTPUT;

--- a/examples/jsm/shaders/RGBShiftShader.js
+++ b/examples/jsm/shaders/RGBShiftShader.js
@@ -10,7 +10,7 @@
  * angle: shift angle in radians
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const RGBShiftShader = {
 

--- a/examples/jsm/shaders/SAOShader.js
+++ b/examples/jsm/shaders/SAOShader.js
@@ -11,7 +11,7 @@ import {
  * Used by {@link SAOPass}.
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const SAOShader = {
 

--- a/examples/jsm/shaders/SMAAShader.js
+++ b/examples/jsm/shaders/SMAAShader.js
@@ -16,7 +16,7 @@ import {
  * SMAA Edges shader.
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const SMAAEdgesShader = {
 
@@ -129,7 +129,7 @@ const SMAAEdgesShader = {
  * SMAA Weights shader.
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const SMAAWeightsShader = {
 
@@ -391,7 +391,7 @@ const SMAAWeightsShader = {
  * SMAA Blend shader.
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const SMAABlendShader = {
 

--- a/examples/jsm/shaders/SSAOShader.js
+++ b/examples/jsm/shaders/SSAOShader.js
@@ -14,7 +14,7 @@ import {
  * - {@link https://github.com/McNopper/OpenGL/blob/master/Example28/shader/ssao.frag.glsl}
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const SSAOShader = {
 
@@ -137,7 +137,7 @@ const SSAOShader = {
 			if ( depth == 1.0 ) {
 
 				gl_FragColor = vec4( 1.0 ); // don't influence background
-				
+
 			} else {
 
 				float viewZ = getViewZ( depth );
@@ -192,7 +192,7 @@ const SSAOShader = {
  * SSAO depth shader.
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const SSAODepthShader = {
 

--- a/examples/jsm/shaders/SSRShader.js
+++ b/examples/jsm/shaders/SSRShader.js
@@ -17,7 +17,7 @@ import {
  * SSR shader.
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const SSRShader = {
 
@@ -249,7 +249,7 @@ const SSRShader = {
  * SSR Depth shader.
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const SSRDepthShader = {
 
@@ -324,7 +324,7 @@ const SSRDepthShader = {
  * SSR Blur shader.
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const SSRBlurShader = {
 

--- a/examples/jsm/shaders/SepiaShader.js
+++ b/examples/jsm/shaders/SepiaShader.js
@@ -4,7 +4,7 @@
  * Sepia tone shader based on [glfx.js sepia shader]{@link https://github.com/evanw/glfx.js}.
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const SepiaShader = {
 

--- a/examples/jsm/shaders/SobelOperatorShader.js
+++ b/examples/jsm/shaders/SobelOperatorShader.js
@@ -10,7 +10,7 @@ import {
  * As mentioned in the video the Sobel operator expects a grayscale image as input.
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const SobelOperatorShader = {
 

--- a/examples/jsm/shaders/SubsurfaceScatteringShader.js
+++ b/examples/jsm/shaders/SubsurfaceScatteringShader.js
@@ -22,7 +22,7 @@ const meshphong_frag_body = ShaderChunk[ 'meshphong_frag' ].slice( ShaderChunk[ 
  * Based on GDC 2011 – [Approximating Translucency for a Fast, Cheap and Convincing Subsurface Scattering Look]{@link https://colinbarrebrisebois.com/2011/03/07/gdc-2011-approximating-translucency-for-a-fast-cheap-and-convincing-subsurface-scattering-look/}
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const SubsurfaceScatteringShader = {
 

--- a/examples/jsm/shaders/TechnicolorShader.js
+++ b/examples/jsm/shaders/TechnicolorShader.js
@@ -6,7 +6,7 @@
  * Demo here: {@link http://charliehoey.com/technicolor_shader/shader_test.html}
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const TechnicolorShader = {
 

--- a/examples/jsm/shaders/ToonShader.js
+++ b/examples/jsm/shaders/ToonShader.js
@@ -13,9 +13,11 @@ import {
  * Toon1 shader.
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const ToonShader1 = {
+
+	name: 'ToonShader1',
 
 	uniforms: {
 

--- a/examples/jsm/shaders/TriangleBlurShader.js
+++ b/examples/jsm/shaders/TriangleBlurShader.js
@@ -12,7 +12,7 @@ import {
  * perpendicular triangle filters.
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const TriangleBlurShader = {
 

--- a/examples/jsm/shaders/UnpackDepthRGBAShader.js
+++ b/examples/jsm/shaders/UnpackDepthRGBAShader.js
@@ -4,7 +4,7 @@
  * Unpack RGBA depth shader that shows RGBA encoded depth as monochrome color.
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const UnpackDepthRGBAShader = {
 

--- a/examples/jsm/shaders/VelocityShader.js
+++ b/examples/jsm/shaders/VelocityShader.js
@@ -10,7 +10,7 @@ import {
  * Mesh velocity shader by @bhouston.
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const VelocityShader = {
 

--- a/examples/jsm/shaders/VerticalBlurShader.js
+++ b/examples/jsm/shaders/VerticalBlurShader.js
@@ -9,7 +9,7 @@
  * - "h" and "v" parameters should be set to "1 / width" and "1 / height"
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const VerticalBlurShader = {
 

--- a/examples/jsm/shaders/VerticalTiltShiftShader.js
+++ b/examples/jsm/shaders/VerticalTiltShiftShader.js
@@ -9,7 +9,7 @@
  * - "r" parameter control where "focused" horizontal line lies
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const VerticalTiltShiftShader = {
 

--- a/examples/jsm/shaders/VignetteShader.js
+++ b/examples/jsm/shaders/VignetteShader.js
@@ -4,7 +4,7 @@
  * Based on [PaintEffect postprocess from ro.me]{@link http://code.google.com/p/3-dreams-of-black/source/browse/deploy/js/effects/PaintEffect.js}.
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const VignetteShader = {
 

--- a/examples/jsm/shaders/VolumeShader.js
+++ b/examples/jsm/shaders/VolumeShader.js
@@ -11,9 +11,11 @@ import {
  * This is not the only approach, therefore it's marked 1.
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const VolumeRenderShader1 = {
+
+	name: 'VolumeRenderShader1',
 
 	uniforms: {
 		'u_size': { value: new Vector3( 1, 1, 1 ) },

--- a/examples/jsm/shaders/WaterRefractionShader.js
+++ b/examples/jsm/shaders/WaterRefractionShader.js
@@ -4,7 +4,7 @@
  * Basic water refraction shader.
  *
  * @constant
- * @type {Object}
+ * @type {Shader}
  */
 const WaterRefractionShader = {
 

--- a/src/materials/ShaderMaterial.js
+++ b/src/materials/ShaderMaterial.js
@@ -380,4 +380,16 @@ class ShaderMaterial extends Material {
 
 }
 
+/**
+ * This type represents the fields required to store and run the shader code.
+ *
+ * @typedef {Object} Shader
+ * @property {string} name - The name of the shader.
+ * @property {Object<string, {value: any}>} uniforms - The uniforms of the shader.
+ * @property {Object<string, any>} defines - The defines of the shader.
+ * @property {string} vertexShader - The vertex shader code.
+ * @property {string} fragmentShader - The fragment shader code.
+ **/
+
+
 export { ShaderMaterial };


### PR DESCRIPTION
**Description**

I am trying to improve the types for Shader passes. I try to make a single type that can be used and reference everywhere but I found some inconsistencies: 
* some passes are missing a name property
* `LuminosityHighPassShader` is using an old shaderID property (outdated I think)
*  `ConvolutionShader` is defining a `buildKernel` function that might just be passed as an utils like other shaders