### PR TITLE
Examples: avoid relying on implicit event parameter

### DIFF
--- a/examples/webgl_geometry_nurbs.html
+++ b/examples/webgl_geometry_nurbs.html
@@ -170,9 +170,9 @@
 					object.position.set( - 400, 100, 0 );
 					object.scale.multiplyScalar( 1 );
 					group.add( object );
-			
+
 				}
-			
+
 				// NURBS volume
 				{
 
@@ -313,9 +313,9 @@
 					objectSide.position.set( 400, 100, 0 );
 					objectSide.scale.multiplyScalar( 0.5 );
 					group.add( objectSide );
-			
+
 				}
-			
+
 				//
 
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
@@ -371,7 +371,7 @@
 
 			}
 
-			function onPointerUp() {
+			function onPointerUp( event ) {
 
 				if ( event.isPrimary === false ) return;
 

--- a/examples/webgl_geometry_shapes.html
+++ b/examples/webgl_geometry_shapes.html
@@ -406,7 +406,7 @@
 
 			}
 
-			function onPointerUp() {
+			function onPointerUp( event ) {
 
 				if ( event.isPrimary === false ) return;
 

--- a/examples/webgl_geometry_text.html
+++ b/examples/webgl_geometry_text.html
@@ -372,7 +372,7 @@
 
 			}
 
-			function onPointerUp() {
+			function onPointerUp( event ) {
 
 				if ( event.isPrimary === false ) return;
 

--- a/examples/webgl_loader_ttf.html
+++ b/examples/webgl_loader_ttf.html
@@ -268,7 +268,7 @@
 
 			}
 
-			function onPointerUp() {
+			function onPointerUp( event ) {
 
 				if ( event.isPrimary === false ) return;
 

--- a/examples/webgl_panorama_equirectangular.html
+++ b/examples/webgl_panorama_equirectangular.html
@@ -106,7 +106,7 @@
 
 			}
 
-			function onPointerUp() {
+			function onPointerUp( event ) {
 
 				if ( event.isPrimary === false ) return;
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/commit/0a1131fb92cf54c6ac05e1a39bd2c71efe07faeb

**Description**

While migrating the examples a long time ago, some event handler methods were missing an `event` parameters. Js is a bit junky and inject the `event` variable by default but having it as a parameter seems cleaner and it allows to be more consistent with other methods.