### PR TITLE
Editor: Add color space options for background textures.

### DIFF
--- a/editor/js/Sidebar.Scene.js
+++ b/editor/js/Sidebar.Scene.js
@@ -187,9 +187,9 @@ function SidebarScene( editor ) {
 
 	const backgroundColorSpace = new UISelect().setOptions( {
 
-		'': 'No Color Space',
-		'srgb-linear': 'sRGB (linear)',
-		'srgb': 'sRGB',
+		[ THREE.NoColorSpace ]: 'No Color Space',
+		[ THREE.LinearSRGBColorSpace ]: 'srgb-linear',
+		[ THREE.SRGBColorSpace ]: 'srgb',
 
 	} ).setWidth( '150px' );
 	backgroundColorSpace.setValue( THREE.NoColorSpace );

--- a/editor/js/Sidebar.Scene.js
+++ b/editor/js/Sidebar.Scene.js
@@ -181,7 +181,23 @@ function SidebarScene( editor ) {
 	backgroundEquirectangularTexture.setDisplay( 'none' );
 	backgroundRow.add( backgroundEquirectangularTexture );
 
+	const backgroundColorSpaceRow = new UIRow();
+	backgroundColorSpaceRow.setDisplay( 'none' );
+	backgroundColorSpaceRow.setMarginLeft( '120px' );
+
+	const backgroundColorSpace = new UISelect().setOptions( {
+
+		'': 'No Color Space',
+		'srgb-linear': 'sRGB (linear)',
+		'srgb': 'sRGB',
+
+	} ).setWidth( '150px' );
+	backgroundColorSpace.setValue( THREE.NoColorSpace );
+	backgroundColorSpace.onChange( onBackgroundChanged );
+	backgroundColorSpaceRow.add( backgroundColorSpace );
+
 	container.add( backgroundRow );
+	container.add( backgroundColorSpaceRow );
 
 	const backgroundEquirectRow = new UIRow();
 	backgroundEquirectRow.setDisplay( 'none' );
@@ -205,6 +221,7 @@ function SidebarScene( editor ) {
 			backgroundColor.getHexValue(),
 			backgroundTexture.getValue(),
 			backgroundEquirectangularTexture.getValue(),
+			backgroundColorSpace.getValue(),
 			backgroundBlurriness.getValue(),
 			backgroundIntensity.getValue(),
 			backgroundRotation.getValue()
@@ -221,6 +238,16 @@ function SidebarScene( editor ) {
 		backgroundTexture.setDisplay( type === 'Texture' ? '' : 'none' );
 		backgroundEquirectangularTexture.setDisplay( type === 'Equirectangular' ? '' : 'none' );
 		backgroundEquirectRow.setDisplay( type === 'Equirectangular' ? '' : 'none' );
+
+		if ( type === 'Texture' || type === 'Equirectangular' ) {
+
+			backgroundColorSpaceRow.setDisplay( '' );
+
+		} else {
+
+			backgroundColorSpaceRow.setDisplay( 'none' );
+
+		}
 
 	}
 
@@ -412,6 +439,8 @@ function SidebarScene( editor ) {
 
 				}
 
+				backgroundColorSpace.setValue( scene.background.colorSpace );
+
 			}
 
 		} else {
@@ -419,6 +448,7 @@ function SidebarScene( editor ) {
 			backgroundType.setValue( 'None' );
 			backgroundTexture.setValue( null );
 			backgroundEquirectangularTexture.setValue( null );
+			backgroundColorSpace.setValue( THREE.NoColorSpace );
 
 		}
 

--- a/editor/js/Viewport.js
+++ b/editor/js/Viewport.js
@@ -495,7 +495,7 @@ function Viewport( editor ) {
 
 	// background
 
-	signals.sceneBackgroundChanged.add( function ( backgroundType, backgroundColor, backgroundTexture, backgroundEquirectangularTexture, backgroundBlurriness, backgroundIntensity, backgroundRotation ) {
+	signals.sceneBackgroundChanged.add( function ( backgroundType, backgroundColor, backgroundTexture, backgroundEquirectangularTexture, backgroundColorSpace, backgroundBlurriness, backgroundIntensity, backgroundRotation ) {
 
 		scene.background = null;
 
@@ -511,6 +511,9 @@ function Viewport( editor ) {
 
 				if ( backgroundTexture ) {
 
+					backgroundTexture.colorSpace = backgroundColorSpace;
+					backgroundTexture.needsUpdate = true;
+
 					scene.background = backgroundTexture;
 
 				}
@@ -522,6 +525,8 @@ function Viewport( editor ) {
 				if ( backgroundEquirectangularTexture ) {
 
 					backgroundEquirectangularTexture.mapping = THREE.EquirectangularReflectionMapping;
+					backgroundEquirectangularTexture.colorSpace = backgroundColorSpace;
+					backgroundEquirectangularTexture.needsUpdate = true;
 
 					scene.background = backgroundEquirectangularTexture;
 					scene.backgroundBlurriness = backgroundBlurriness;


### PR DESCRIPTION
Fixed #30788.

**Description**

The PR adds a color space options for background textures in the editor.

The default is `NoColorSpace`. Users must assign the correct color space for their texture similar to when loading textures via `TextureLoader`.