### PR TITLE
TSL: Add `debug()`

### DIFF
--- a/src/Three.TSL.js
+++ b/src/Three.TSL.js
@@ -129,6 +129,7 @@ export const cubeTexture = TSL.cubeTexture;
 export const dFdx = TSL.dFdx;
 export const dFdy = TSL.dFdy;
 export const dashSize = TSL.dashSize;
+export const debug = TSL.debug;
 export const defaultBuildStages = TSL.defaultBuildStages;
 export const defaultShaderStages = TSL.defaultShaderStages;
 export const defined = TSL.defined;

--- a/src/nodes/Nodes.js
+++ b/src/nodes/Nodes.js
@@ -56,6 +56,7 @@ export { default as TriplanarTexturesNode } from './utils/TriplanarTexturesNode.
 export { default as ReflectorNode } from './utils/ReflectorNode.js';
 export { default as RTTNode } from './utils/RTTNode.js';
 export { default as MemberNode } from './utils/MemberNode.js';
+export { default as DebugNode } from './utils/DebugNode.js';
 
 // accessors
 export { default as UniformArrayNode } from './accessors/UniformArrayNode.js';

--- a/src/nodes/tsl/TSLBase.js
+++ b/src/nodes/tsl/TSLBase.js
@@ -23,6 +23,7 @@ export * from '../utils/RemapNode.js'; // .remap(), .remapClamp()
 export * from '../code/ExpressionNode.js'; // expression()
 export * from '../utils/Discard.js'; // Discard(), Return()
 export * from '../display/RenderOutputNode.js'; // .renderOutput()
+export * from '../utils/DebugNode.js'; // debug()
 
 export function addNodeElement( name/*, nodeElement*/ ) {
 

--- a/src/nodes/utils/DebugNode.js
+++ b/src/nodes/utils/DebugNode.js
@@ -1,6 +1,5 @@
 import TempNode from '../core/TempNode.js';
 import { addMethodChaining, nodeObject } from '../tsl/TSLCore.js';
-import { REVISION } from '../../constants.js';
 
 class DebugNode extends TempNode {
 

--- a/src/nodes/utils/DebugNode.js
+++ b/src/nodes/utils/DebugNode.js
@@ -1,0 +1,71 @@
+import TempNode from '../core/TempNode.js';
+import { addMethodChaining, nodeObject } from '../tsl/TSLCore.js';
+import { REVISION } from '../../constants.js';
+
+class DebugNode extends TempNode {
+
+	static get type() {
+
+		return 'DebugNode';
+
+	}
+
+	constructor( node, callback = null ) {
+
+		super();
+
+		this.node = node;
+		this.callback = callback;
+
+	}
+
+	getNodeType( builder ) {
+
+		return this.node.getNodeType( builder );
+
+	}
+
+	setup( builder ) {
+
+		return this.node.build( builder );
+
+	}
+
+	analyze( builder ) {
+
+		return this.node.build( builder );
+
+	}
+
+	generate( builder ) {
+
+		const callback = this.callback;
+		const snippet = this.node.build( builder );
+
+		let code = '';
+		code += '// #--- TSL Debug ---#\n';
+		code += builder.flow.code.replace( /\t/g, '' ) + '\n';
+		code += '/* ... */ ' + snippet + ' /* ... */\n';
+		code += '// #-----------------#\n';
+
+		if ( callback !== null ) {
+
+			callback( code );
+
+		} else {
+
+			console.log( code );
+
+		}
+
+		return snippet;
+
+	}
+
+}
+
+export default DebugNode;
+
+export const debug = ( node, callback = null ) => nodeObject( new DebugNode( nodeObject( node ), callback ) );
+
+addMethodChaining( 'debug', debug );


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/30783#issuecomment-2750416368

**Description**

Add `debug()` method to facilitate inspection of the generated code.

```js
const timerScaleNode = time.mul( vec2( - 0.5, 0.1 ) );
const animateUV = uv().add( timerScaleNode );

materialBox.colorNode = checker( animateUV ).toVar().debug();
```

Alternative
```js
materialBox.colorNode = uv().debug( ( code ) => {

	console.log( code );

} )
```

WGSL Result
```js
// #--- TSL Debug ---#
nodeVar0 = ( ( nodeVarying3 + ( vec2<f32>( render.nodeUniform0 ) * vec2<f32>( -0.5, 0.1 ) ) ) * vec2<f32>( 2.0 ) );
nodeVar1 = sign( ( ( floor( nodeVar0.x ) + floor( nodeVar0.y ) ) % 2.0 ) );

/* ... */ nodeVar1 /* ... */
// #-----------------#
```

GLSL Result
```js
// #--- TSL Debug ---#
nodeVar0 = ( ( nodeVarying3 + ( vec2( f_nodeUniform0 ) * vec2( -0.5, 0.1 ) ) ) * vec2( 2.0 ) );
nodeVar1 = sign( mod( ( floor( nodeVar0.x ) + floor( nodeVar0.y ) ), 2.0 ) );

/* ... */ nodeVar1 /* ... */
// #-----------------#
```