### PR TITLE
ExtrudeGeometry: Fix regression introduced by #30750.

### DIFF
--- a/src/geometries/ExtrudeGeometry.js
+++ b/src/geometries/ExtrudeGeometry.js
@@ -443,7 +443,7 @@ class ExtrudeGeometry extends BufferGeometry {
 
 			if ( contractedContourVertices.length == 0 ) {
 
-				contractedContourVertices.push( ...vertices );
+				contractedContourVertices.push( ...contour );
 
 			}
 

--- a/src/geometries/ExtrudeGeometry.js
+++ b/src/geometries/ExtrudeGeometry.js
@@ -440,21 +440,18 @@ class ExtrudeGeometry extends BufferGeometry {
 			}
 
 			//When bevelSegments == 0, the modified vert arrays will not have been populated. We do this here.
-			{
 
-				if ( contractedContourVertices.length == 0 ) {
+			if ( contractedContourVertices.length == 0 ) {
 
-					contractedContourVertices.push( ...vertices );
+				contractedContourVertices.push( ...vertices );
 
-				}
+			}
 
-				if ( expandedHoleVertices.length == 0 ) {
+			if ( expandedHoleVertices.length == 0 ) {
 
-					for ( let h = 0, hl = numHoles; h < hl; h ++ ) {
+				for ( let h = 0, hl = numHoles; h < hl; h ++ ) {
 
-						expandedHoleVertices.push( holes[ h ] ); //triangulateShape expects a Vec2[][], ie. an array of holes, with each hole being a Vec2[]
-
-					}
+					expandedHoleVertices.push( holes[ h ] ); //triangulateShape expects a Vec2[][], ie. an array of holes, with each hole being a Vec2[]
 
 				}
 

--- a/src/geometries/ExtrudeGeometry.js
+++ b/src/geometries/ExtrudeGeometry.js
@@ -439,6 +439,27 @@ class ExtrudeGeometry extends BufferGeometry {
 
 			}
 
+			//When bevelSegments == 0, the modified vert arrays will not have been populated. We do this here.
+			{
+
+				if ( contractedContourVertices.length == 0 ) {
+
+					contractedContourVertices.push( ...vertices );
+
+				}
+
+				if ( expandedHoleVertices.length == 0 ) {
+
+					for ( let h = 0, hl = numHoles; h < hl; h ++ ) {
+
+						expandedHoleVertices.push( holes[ h ] ); //triangulateShape expects a Vec2[][], ie. an array of holes, with each hole being a Vec2[]
+
+					}
+
+				}
+
+			}
+
 			const faces = ShapeUtils.triangulateShape( contractedContourVertices, expandedHoleVertices );
 
 			const flen = faces.length;

--- a/src/geometries/ExtrudeGeometry.js
+++ b/src/geometries/ExtrudeGeometry.js
@@ -394,7 +394,8 @@ class ExtrudeGeometry extends BufferGeometry {
 			}
 
 			let faces;
-			if ( bevelSegments == 0 ) {
+
+			if ( bevelSegments === 0 ) {
 
 				faces = ShapeUtils.triangulateShape( contour, holes );
 

--- a/src/geometries/ExtrudeGeometry.js
+++ b/src/geometries/ExtrudeGeometry.js
@@ -421,7 +421,7 @@ class ExtrudeGeometry extends BufferGeometry {
 						const vert = scalePt2( contour[ i ], contourMovements[ i ], bs );
 
 						v( vert.x, vert.y, - z );
-						if ( t == 0 ) contractedContourVertices.push( vert );
+						if ( t === 0 ) contractedContourVertices.push( vert );
 
 					}
 
@@ -437,11 +437,11 @@ class ExtrudeGeometry extends BufferGeometry {
 							const vert = scalePt2( ahole[ i ], oneHoleMovements[ i ], bs );
 
 							v( vert.x, vert.y, - z );
-							if ( t == 0 ) oneHoleVertices.push( vert );
+							if ( t === 0 ) oneHoleVertices.push( vert );
 
 						}
 
-						if ( t == 0 ) expandedHoleVertices.push( oneHoleVertices );
+						if ( t === 0 ) expandedHoleVertices.push( oneHoleVertices );
 
 					}
 

--- a/src/geometries/ExtrudeGeometry.js
+++ b/src/geometries/ExtrudeGeometry.js
@@ -393,71 +393,62 @@ class ExtrudeGeometry extends BufferGeometry {
 
 			}
 
-			const contractedContourVertices = [];
-			const expandedHoleVertices = [];
+			let faces;
+			if ( bevelSegments == 0 ) {
 
-			// Loop bevelSegments, 1 for the front, 1 for the back
+				faces = ShapeUtils.triangulateShape( contour, holes );
 
-			for ( let b = 0; b < bevelSegments; b ++ ) {
+			} else {
 
-				//for ( b = bevelSegments; b > 0; b -- ) {
+				const contractedContourVertices = [];
+				const expandedHoleVertices = [];
 
-				const t = b / bevelSegments;
-				const z = bevelThickness * Math.cos( t * Math.PI / 2 );
-				const bs = bevelSize * Math.sin( t * Math.PI / 2 ) + bevelOffset;
+				// Loop bevelSegments, 1 for the front, 1 for the back
 
-				// contract shape
+				for ( let b = 0; b < bevelSegments; b ++ ) {
 
-				for ( let i = 0, il = contour.length; i < il; i ++ ) {
+					//for ( b = bevelSegments; b > 0; b -- ) {
 
-					const vert = scalePt2( contour[ i ], contourMovements[ i ], bs );
+					const t = b / bevelSegments;
+					const z = bevelThickness * Math.cos( t * Math.PI / 2 );
+					const bs = bevelSize * Math.sin( t * Math.PI / 2 ) + bevelOffset;
 
-					v( vert.x, vert.y, - z );
-					if ( t == 0 ) contractedContourVertices.push( vert );
+					// contract shape
 
-				}
+					for ( let i = 0, il = contour.length; i < il; i ++ ) {
 
-				// expand holes
-
-				for ( let h = 0, hl = numHoles; h < hl; h ++ ) {
-
-					const ahole = holes[ h ];
-					oneHoleMovements = holesMovements[ h ];
-					const oneHoleVertices = [];
-					for ( let i = 0, il = ahole.length; i < il; i ++ ) {
-
-						const vert = scalePt2( ahole[ i ], oneHoleMovements[ i ], bs );
+						const vert = scalePt2( contour[ i ], contourMovements[ i ], bs );
 
 						v( vert.x, vert.y, - z );
-						if ( t == 0 ) oneHoleVertices.push( vert );
+						if ( t == 0 ) contractedContourVertices.push( vert );
 
 					}
 
-					if ( t == 0 ) expandedHoleVertices.push( oneHoleVertices );
+					// expand holes
+
+					for ( let h = 0, hl = numHoles; h < hl; h ++ ) {
+
+						const ahole = holes[ h ];
+						oneHoleMovements = holesMovements[ h ];
+						const oneHoleVertices = [];
+						for ( let i = 0, il = ahole.length; i < il; i ++ ) {
+
+							const vert = scalePt2( ahole[ i ], oneHoleMovements[ i ], bs );
+
+							v( vert.x, vert.y, - z );
+							if ( t == 0 ) oneHoleVertices.push( vert );
+
+						}
+
+						if ( t == 0 ) expandedHoleVertices.push( oneHoleVertices );
+
+					}
 
 				}
 
-			}
-
-			//When bevelSegments == 0, the modified vert arrays will not have been populated. We do this here.
-
-			if ( contractedContourVertices.length == 0 ) {
-
-				contractedContourVertices.push( ...contour );
+				faces = ShapeUtils.triangulateShape( contractedContourVertices, expandedHoleVertices );
 
 			}
-
-			if ( expandedHoleVertices.length == 0 ) {
-
-				for ( let h = 0, hl = numHoles; h < hl; h ++ ) {
-
-					expandedHoleVertices.push( holes[ h ] ); //triangulateShape expects a Vec2[][], ie. an array of holes, with each hole being a Vec2[]
-
-				}
-
-			}
-
-			const faces = ShapeUtils.triangulateShape( contractedContourVertices, expandedHoleVertices );
 
 			const flen = faces.length;
 


### PR DESCRIPTION
Fixed #30819

**Description**

Changes introduced by #30750 resulted in the inputs to ShapeUtils.triangulateGeometry not being initialized when bevelSegments == 0 (which happens when bevelEnabled == false), causing triangulation to fail. This PR adds code to manually populate those lists if they are empty before triangulation, fixing the issue. See related issue for examples.