### PR TITLE
Normal: Don't flip normals when using flat shading.

### DIFF
--- a/src/nodes/accessors/Normal.js
+++ b/src/nodes/accessors/Normal.js
@@ -109,9 +109,13 @@ export const transformedClearcoatNormalView = /*@__PURE__*/ ( Fn( ( builder ) =>
 
 	// Use getUV context to avoid side effects from nodes overwriting getUV in the context (e.g. EnvironmentNode)
 
-	return builder.context.setupClearcoatNormal().context( { getUV: null } );
+	let node = builder.context.setupClearcoatNormal().context( { getUV: null } );
 
-}, 'vec3' ).once() )().mul( faceDirection ).toVar( 'transformedClearcoatNormalView' );
+	if ( builder.material.flatShading === false ) node = node.mul( faceDirection );
+
+	return node;
+
+}, 'vec3' ).once() )().toVar( 'transformedClearcoatNormalView' );
 
 /**
  * Transforms the normal with the given matrix.

--- a/src/nodes/accessors/Normal.js
+++ b/src/nodes/accessors/Normal.js
@@ -85,7 +85,7 @@ export const transformedNormalView = /*@__PURE__*/ ( Fn( ( builder ) => {
 
 	let node = builder.context.setupNormal().context( { getUV: null } );
 
-	if ( builder.material.flatShading === false ) node = node.mul( faceDirection );
+	if ( builder.material.flatShading !== true ) node = node.mul( faceDirection );
 
 	return node;
 
@@ -111,7 +111,7 @@ export const transformedClearcoatNormalView = /*@__PURE__*/ ( Fn( ( builder ) =>
 
 	let node = builder.context.setupClearcoatNormal().context( { getUV: null } );
 
-	if ( builder.material.flatShading === false ) node = node.mul( faceDirection );
+	if ( builder.material.flatShading !== true ) node = node.mul( faceDirection );
 
 	return node;
 

--- a/src/nodes/accessors/Normal.js
+++ b/src/nodes/accessors/Normal.js
@@ -83,9 +83,13 @@ export const transformedNormalView = /*@__PURE__*/ ( Fn( ( builder ) => {
 
 	// Use getUV context to avoid side effects from nodes overwriting getUV in the context (e.g. EnvironmentNode)
 
-	return builder.context.setupNormal().context( { getUV: null } );
+	let node = builder.context.setupNormal().context( { getUV: null } );
 
-}, 'vec3' ).once() )().mul( faceDirection ).toVar( 'transformedNormalView' );
+	if ( builder.material.flatShading === false ) node = node.mul( faceDirection );
+
+	return node;
+
+}, 'vec3' ).once() )().toVar( 'transformedNormalView' );
 
 /**
  * TSL object that represents the transformed vertex normal in world space of the current rendered object.

--- a/src/nodes/display/FrontFacingNode.js
+++ b/src/nodes/display/FrontFacingNode.js
@@ -38,7 +38,7 @@ class FrontFacingNode extends Node {
 
 		const { renderer, material } = builder;
 
-		if ( material.flatShading === true ) return true;
+		if ( material.flatShading === true ) return 'true';
 
 		if ( renderer.coordinateSystem === WebGLCoordinateSystem ) {
 

--- a/src/nodes/display/FrontFacingNode.js
+++ b/src/nodes/display/FrontFacingNode.js
@@ -38,6 +38,8 @@ class FrontFacingNode extends Node {
 
 		const { renderer, material } = builder;
 
+		if ( material.flatShading === true ) return true;
+
 		if ( renderer.coordinateSystem === WebGLCoordinateSystem ) {
 
 			if ( material.side === BackSide ) {


### PR DESCRIPTION
Related issue: https://discourse.threejs.org/t/webgpu-flatshading-doubleside-broken/80198

**Description**

The PR ensures normals are not flipped when using flat shading.
