### PR TITLE
rename 'docs' to 'api' in the docs menu

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -20,8 +20,8 @@
 				<h1><a href="https://threejs.org">three.js</a></h1>
 
 				<div id="sections">
-					<span class="selected">docs</span>
 					<a href="../manual/">manual</a>
+					<span class="selected">api</span>
 				</div>
 
 				<div id="expandButton"></div>
@@ -97,7 +97,7 @@
 
 					// Redirect to the manual
 
-					window.location.href = hash.replace(/^manual\/([^\/]+)\/([^\/]+)\/(.+)$/, '../manual/#$1/$3').toLowerCase();
+					window.location.href = hash.replace( /^manual\/([^\/]+)\/([^\/]+)\/(.+)$/, '../manual/#$1/$3' ).toLowerCase();
 
 				}
 

--- a/manual/index.html
+++ b/manual/index.html
@@ -20,8 +20,8 @@
 				<h1><a href="https://threejs.org">three.js</a></h1>
 
 				<div id="sections">
-					<a href="../docs/">docs</a>
 					<span class="selected">manual</span>
+					<a href="../docs/">api</a>
 				</div>
 
 				<div id="expandButton"></div>

--- a/utils/docs/template/tmpl/layout.tmpl
+++ b/utils/docs/template/tmpl/layout.tmpl
@@ -30,8 +30,8 @@
         <h1><a href="https://threejs.org">three.js</a></h1>
 
         <div id="sections">
-            <span class="selected">docs</span>
-            <a href="/examples/#webgl_animation_keyframes">examples</a>
+            <span class="selected">docs (is this used? it doesn't match the new menu)</span>
+            <a href="/examples/#webgl_animation_keyframes">examples (is this used? it doesn't match the new menu)</a>
         </div>
         <div id="expandButton"></div>
     </div>


### PR DESCRIPTION
## **Description**

Two minor changes:

- rename "docs" to "api" in the documentation menu
- swap the two menu items, so that when "documentation" on the home page is clicked, the first tab will be selected.

## **Reasoning**

Concepts like "guide" and "api reference" are both are part of overall "documentation". So it seemed fit to rename "docs" (which is the api reference) to "api".

Instead of "guide" I left "manual" alone, though personally I think "guide" is more common for this thing (guide vs api reference). I also tried the word "reference" but it was a bit long, taking up too much space in the menu alongside "manual".

"guide" + "api" is my fav, but "manual" + "api" is good too, both fit under the overall concept of "documentation" (the home page link is "documentation").

## **screenshots**

Start with the first tab after clicking "documentation" on home page:

<img width="387" alt="Screenshot 2025-03-30 at 1 15 33 PM" src="https://github.com/user-attachments/assets/03c8c44c-6f54-47e0-b0ae-1dc6f4ad293c" />

Then go to the API section if needed (order of tabs matches the navigation):

<img width="442" alt="Screenshot 2025-03-30 at 1 15 38 PM" src="https://github.com/user-attachments/assets/187b593a-7443-475c-bfdf-89fa1d3a0e71" />

## **alternative**

Here's what it looks like with "reference", which happens to match the "reference" in the sidebar (we could change that to "api" too though). Possibly we could adjust the spacing if you prefer "manual" + "reference" to make it fit better:

<img width="369" alt="Screenshot 2025-03-30 at 1 22 11 PM" src="https://github.com/user-attachments/assets/4fdafd8c-2821-4668-ace5-9149f12cbcd7" />

<img width="379" alt="Screenshot 2025-03-30 at 1 22 17 PM" src="https://github.com/user-attachments/assets/abb65e09-4d23-4e4c-bae4-b2107342ada0" />


---

I didn't change the folder name.

- [ ] Rename `/docs/` to `/api/` too (or `/reference/` if you like that more)? 
- [ ] match the sidebar title with the tab title (f.e. "api" instead of "reference" in the sidebar if the tab title is "api". but "api" and then "reference" might just make sense! read "api" "reference")

---

Where's the home page source? Some links are outdated on the home page (f.e. twitter -> x), and some links could be added (f.e. Bluesky, which is open source, and dev chatter is better and more active there).

*This contribution is funded by [Lume, 3D HTML framework](https://lume.io)*
