### PR TITLE
FrontFacingNode: Fix `frontFacing` if used `material.flatShading`

### DIFF
--- a/src/nodes/display/FrontFacingNode.js
+++ b/src/nodes/display/FrontFacingNode.js
@@ -38,8 +38,6 @@ class FrontFacingNode extends Node {
 
 		const { renderer, material } = builder;
 
-		if ( material.flatShading === true ) return 'true';
-
 		if ( renderer.coordinateSystem === WebGLCoordinateSystem ) {
 
 			if ( material.side === BackSide ) {


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/30823#issuecomment-2764687149

**Description**

Fix `frontFacing` if used `material.flatShading`.