### PR TITLE
TSL: add `dFdx` and `dFdy` warnings

### DIFF
--- a/src/nodes/math/MathNode.js
+++ b/src/nodes/math/MathNode.js
@@ -260,6 +260,14 @@ class MathNode extends TempNode {
 
 				}
 
+				if ( builder.shaderStage !== 'fragment' && ( method === MathNode.DFDX || method === MathNode.DFDY ) ) {
+
+					console.warn( `THREE.TSL: '${ method }' is not supported in the ${ builder.shaderStage } stage.` );
+
+					method = '/*' + method + '*/';
+
+				}
+
 				params.push( a.build( builder, inputType ) );
 				if ( b !== null ) params.push( b.build( builder, inputType ) );
 				if ( c !== null ) params.push( c.build( builder, inputType ) );


### PR DESCRIPTION
**Description**

Improves warning and avoids crashing the renderer if  `dFdx` and `dFdy` are used in non-fragment shader stage.
