### PR TITLE
TSL: Show shader stage in `debug()` message

### DIFF
--- a/src/nodes/utils/DebugNode.js
+++ b/src/nodes/utils/DebugNode.js
@@ -41,11 +41,14 @@ class DebugNode extends TempNode {
 		const callback = this.callback;
 		const snippet = this.node.build( builder );
 
+		const title = '--- TSL debug - ' + builder.shaderStage + ' shader ---';
+		const border = '-'.repeat( title.length );
+
 		let code = '';
-		code += '// #--- TSL Debug ---#\n';
+		code += '// #' + title + '#\n';
 		code += builder.flow.code.replace( /^\t/mg, '' ) + '\n';
 		code += '/* ... */ ' + snippet + ' /* ... */\n';
-		code += '// #-----------------#\n';
+		code += '// #' + border + '#\n';
 
 		if ( callback !== null ) {
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/30797

**Description**

Show shader stage in `debug()` message.