### PR TITLE
Animation: Fix ReferenceError in non-broswer environment

### DIFF
--- a/src/renderers/common/Animation.js
+++ b/src/renderers/common/Animation.js
@@ -34,7 +34,7 @@ class Animation {
 		 *
 		 * @type {Window|XRSession}
 		 */
-		this._context = self;
+		this._context = typeof self !== 'undefined' ? self : null;
 
 		/**
 		 * The user-defined animation loop.

--- a/src/renderers/common/Animation.js
+++ b/src/renderers/common/Animation.js
@@ -32,7 +32,7 @@ class Animation {
 		 * A reference to the context from `requestAnimationFrame()` can
 		 * be called (usually `window`).
 		 *
-		 * @type {Window|XRSession}
+		 * @type {?(Window|XRSession)}
 		 */
 		this._context = typeof self !== 'undefined' ? self : null;
 


### PR DESCRIPTION
Node.js and Deno do not support `self`.
