### PR TITLE
Addons: Fix SSAA/TRAA state reset.

### DIFF
--- a/examples/jsm/tsl/display/SSAAPassNode.js
+++ b/examples/jsm/tsl/display/SSAAPassNode.js
@@ -113,7 +113,7 @@ class SSAAPassNode extends PassNode {
 		const { renderer } = frame;
 		const { scene, camera } = this;
 
-		_rendererState = RendererUtils.resetRendererAndSceneState( renderer, scene, _rendererState );
+		_rendererState = RendererUtils.resetRendererState( renderer, _rendererState );
 
 		//
 
@@ -229,7 +229,7 @@ class SSAAPassNode extends PassNode {
 
 		//
 
-		RendererUtils.restoreRendererAndSceneState( renderer, scene, _rendererState );
+		RendererUtils.restoreRendererState( renderer, _rendererState );
 
 	}
 

--- a/examples/jsm/tsl/display/TRAAPassNode.js
+++ b/examples/jsm/tsl/display/TRAAPassNode.js
@@ -153,7 +153,7 @@ class TRAAPassNode extends PassNode {
 		const { renderer } = frame;
 		const { scene, camera } = this;
 
-		_rendererState = RendererUtils.resetRendererAndSceneState( renderer, scene, _rendererState );
+		_rendererState = RendererUtils.resetRendererState( renderer, _rendererState );
 
 		//
 
@@ -291,7 +291,7 @@ class TRAAPassNode extends PassNode {
 
 		velocityOutput.setProjectionMatrix( null );
 
-		RendererUtils.restoreRendererAndSceneState( renderer, scene, _rendererState );
+		RendererUtils.restoreRendererState( renderer, _rendererState );
 
 	}
 


### PR DESCRIPTION
Related issue: -

**Description**

When using with `SSAANode`, I've realized `Scene.background` isn't honored. That's because `SSAANode` (and `TRAANode`) reset the scene state which is actually not required. Using `resetRendererState()` is sufficient.