### PR TITLE
VelocityNode: Fix initial value of previous model matrix.

### DIFF
--- a/src/nodes/accessors/VelocityNode.js
+++ b/src/nodes/accessors/VelocityNode.js
@@ -205,6 +205,7 @@ function getPreviousMatrix( object, index = 0 ) {
 	if ( matrix === undefined ) {
 
 		objectData[ index ] = matrix = new Matrix4();
+		objectData[ index ].copy( object.matrixWorld );
 
 	}
 


### PR DESCRIPTION
Related issue: -

**Description**

I've noticed a strange bug in TRAA when testing static scenes. Turns out the initial value of `previousModelWorldMatrix` in `VelocityNode` is incorrect. When there is no motion in the scene, the velocity should be 0. Before this PR, motion was computed since the previous and current world matrix values didn't match.
