### PR TITLE
NodeMaterialObserver: Force refresh when rendering velocity.

### DIFF
--- a/src/materials/nodes/manager/NodeMaterialObserver.js
+++ b/src/materials/nodes/manager/NodeMaterialObserver.js
@@ -127,6 +127,20 @@ class NodeMaterialObserver {
 	}
 
 	/**
+	 * Returns `true` if the current rendering produces motion vectors.
+	 *
+	 * @param {Renderer} renderer - The renderer.
+	 * @return {boolean} Whether the current rendering produces motion vectors or not.
+	 */
+	needsVelocity( renderer ) {
+
+		const mrt = renderer.getMRT();
+
+		return ( mrt !== null && mrt.has( 'velocity' ) );
+
+	}
+
+	/**
 	 * Returns monitoring data for the given render object.
 	 *
 	 * @param {RenderObject} renderObject - The render object.
@@ -479,7 +493,7 @@ class NodeMaterialObserver {
 	 */
 	needsRefresh( renderObject, nodeFrame ) {
 
-		if ( this.hasNode || this.hasAnimation || this.firstInitialization( renderObject ) )
+		if ( this.hasNode || this.hasAnimation || this.firstInitialization( renderObject ) || this.needsVelocity( nodeFrame.renderer ) )
 			return true;
 
 		const { renderId } = nodeFrame;


### PR DESCRIPTION
Related issue: -

**Description**

I've tried using TRAA in `webgpu_postprocessing_fxaa` and it turned out the AA did not work correctly. The problem is the update callbacks of `VelocityNode` don't get properly executed when render objects share the same node builder state. Hence, only one tetrahedron is properly anti-aliased, all others not because their motions vectors are not updated.

 A refresh must be forced in the material observer when velocity rendering is active.

