### PR TITLE
TSL: Fix `.blur()` on Framebuffer

### DIFF
--- a/src/nodes/accessors/TextureNode.js
+++ b/src/nodes/accessors/TextureNode.js
@@ -564,7 +564,7 @@ class TextureNode extends UniformNode {
 
 		const map = textureNode.value;
 
-		if ( map && map.generateMipmaps === false || map.minFilter === NearestFilter || map.magFilter === NearestFilter ) {
+		if ( textureNode.generateMipmaps === false && ( map && map.generateMipmaps === false || map.minFilter === NearestFilter || map.magFilter === NearestFilter ) ) {
 
 			console.warn( 'THREE.TSL: texture().blur() requires mipmaps and sampling. Use .generateMipmaps=true and .minFilter/.magFilter=THREE.LinearFilter in the Texture.' );
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/30722

**Description**
`blur()` was broken on `TextureNode` with `Framebuffer` value such as `ViewportSharedTextureNode`. This PR fixes the issue.

*This contribution is funded by [Renaud Rohlinger](https://github.com/sponsors/RenaudRohlinger) @ [Utsubo](https://utsubo.com)*
