### PR TITLE
TSL: Fix `instance()` usage with `velocity`.

### DIFF
--- a/src/nodes/accessors/InstanceNode.js
+++ b/src/nodes/accessors/InstanceNode.js
@@ -2,7 +2,7 @@ import Node from '../core/Node.js';
 import { varyingProperty } from '../core/PropertyNode.js';
 import { instancedBufferAttribute, instancedDynamicBufferAttribute } from './BufferAttributeNode.js';
 import { normalLocal, transformNormal } from './Normal.js';
-import { positionLocal } from './Position.js';
+import { positionLocal, positionPrevious } from './Position.js';
 import { nodeProxy, vec3, mat4 } from '../tsl/TSLBase.js';
 import { NodeUpdateType } from '../core/constants.js';
 import { buffer } from '../accessors/BufferNode.js';
@@ -162,6 +162,9 @@ class InstanceNode extends Node {
 
 		const instancePosition = instanceMatrixNode.mul( positionLocal ).xyz;
 		positionLocal.assign( instancePosition );
+
+		const instancePositionPrevious = instanceMatrixNode.mul( positionPrevious ).xyz;
+		positionPrevious.assign( instancePositionPrevious );
 
 		// NORMAL
 


### PR DESCRIPTION
Related issue: -

**Description**

I'm currently doing some deeper testing with `VelocityNode`. Turns out the node does not work with instancing yet since `positionPrevious` has no valid value per instance so far. The PR fixes that by honoring the instance matrix in `positionPrevious`. 