### PR TITLE
JSDoc: Add import section for addons.

### DIFF
--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -83,6 +83,7 @@ const _EPS = 0.000001;
  * ```
  *
  * @augments Controls
+ * @three_import import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
  */
 class OrbitControls extends Controls {
 

--- a/examples/jsm/utils/BufferGeometryUtils.js
+++ b/examples/jsm/utils/BufferGeometryUtils.js
@@ -11,7 +11,10 @@ import {
 	Vector3,
 } from 'three';
 
-/** @module BufferGeometryUtils */
+/**
+ * @module BufferGeometryUtils
+ * @three_import import * as BufferGeometryUtils from 'three/addons/utils/BufferGeometryUtils.js';
+ */
 
 /**
  * Computes vertex tangents using the MikkTSpace algorithm. MikkTSpace generates the same tangents consistently,

--- a/utils/docs/template/publish.js
+++ b/utils/docs/template/publish.js
@@ -432,11 +432,17 @@ function buildGlobalsNav( globals, seen ) {
 
 		globals.forEach( ( { kind, longname, name, tags } ) => {
 
-			if ( kind !== 'typedef' && ! hasOwnProp.call( seen, longname ) && Array.isArray( tags ) && tags[ 0 ].title === 'tsl' ) {
+			if ( kind !== 'typedef' && ! hasOwnProp.call( seen, longname ) && Array.isArray( tags ) ) {
 
-				tslNav += `<li data-name="${longname}">${linkto( longname, name )}</li>`;
+				const tslTag = tags.find( tag => tag.title === 'tsl' );
 
-				seen[ longname ] = true;
+				if ( tslTag !== undefined ) {
+
+					tslNav += `<li data-name="${longname}">${linkto( longname, name )}</li>`;
+
+					seen[ longname ] = true;
+
+				}
 
 			}
 
@@ -700,6 +706,24 @@ exports.publish = ( taffyData, opts, tutorials ) => {
 			addSignatureTypes( doclet );
 			addAttribs( doclet );
 			doclet.kind = 'member';
+
+		}
+
+	} );
+
+	// prepare import statements
+	data().each( doclet => {
+
+		if ( doclet.kind === 'class' || doclet.kind === 'module' ) {
+
+			const tags = doclet.tags;
+
+			if ( Array.isArray( tags ) ) {
+
+				const importTag = tags.find( tag => tag.title === 'three_import' );
+				doclet.import = ( importTag !== undefined ) ? importTag.text : null;
+
+			}
 
 		}
 

--- a/utils/docs/template/tmpl/container.tmpl
+++ b/utils/docs/template/tmpl/container.tmpl
@@ -65,6 +65,12 @@
         <?js= self.partial('augments.tmpl', doc) ?>
     <?js } ?>
 
+    <?js if (doc.import) { ?>
+        <h3 class="subsection-title">Import</h3>
+        <?js= doc.name ?> is an addon, and must be imported explicitly, see <a href="https://threejs.org/manual/#en/installation" target="_blank">Installation#Addons</a>.
+        <pre class="prettyprint source lang-js"><code><?js= doc.import ?></code></pre>
+    <?js } ?>
+
     <?js if (doc.requires && doc.requires.length) { ?>
         <h3 class="subsection-title">Requires</h3>
 


### PR DESCRIPTION
Related issue: -

**Description**

The PR adds the following section to doc pages:

<img width="1075" alt="image" src="https://github.com/user-attachments/assets/427bd549-6ac3-4212-8e9c-5490ae30a018" />

We had this in place for the old docs and it seems it was a helpful feature for users. The only problem is we can't generate the section automatically since addons are not imported in a uniform fashion. E.g.
```js
import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
import GLSLDecoder from 'three/addons/transpiler/GLSLDecoder.js';
import * as BufferGeometryUtils from 'three/addons/utils/BufferGeometryUtils.js';
```

So the idea is to use a custom tag `@three_import` to classes and modules which documents the import. If we agree on that, I can file a follow-up PR updating all addons.