### PR TITLE
ShadowNode: Introduce `onBeforeUpdate` and `onAfterUpdate`

### DIFF
--- a/examples/jsm/tsl/shadows/TileShadowNode.js
+++ b/examples/jsm/tsl/shadows/TileShadowNode.js
@@ -265,6 +265,8 @@ class TileShadowNode extends ShadowBaseNode {
      */
 	updateShadow( frame ) {
 
+		this.update();
+
 		const { shadowMap, light } = this;
 		const { renderer, scene, camera } = frame;
 		const shadowType = renderer.shadowMap.type;
@@ -329,8 +331,11 @@ class TileShadowNode extends ShadowBaseNode {
 
 		if ( needsUpdate ) {
 
-			this.update();
+			this.onBeforeUpdate();
+
 			this.updateShadow( frame );
+
+			this.onAfterUpdate();
 
 			if ( this.shadowMap.depthTexture.version === this._depthVersionCached ) {
 
@@ -341,6 +346,22 @@ class TileShadowNode extends ShadowBaseNode {
 		}
 
 	}
+
+	/**
+	 * Called before the shadow map is rendered.
+	 * This method can be overridden by subclasses to perform custom actions.
+	 *
+	 * @abstract
+	 */
+	onBeforeUpdate() {}
+
+	/**
+	 * Called after the shadow map is rendered.
+	 * This method can be overridden by subclasses to perform custom actions.
+	 *
+	 * @abstract
+	 */
+	onAfterUpdate() {}
 
 	/**
 	 * Synchronizes the transformation of a tile light with the source light.

--- a/src/nodes/lighting/ShadowNode.js
+++ b/src/nodes/lighting/ShadowNode.js
@@ -680,7 +680,11 @@ class ShadowNode extends ShadowBaseNode {
 
 		if ( needsUpdate ) {
 
+			this.onBeforeUpdate();
+
 			this.updateShadow( frame );
+
+			this.onAfterUpdate();
 
 			if ( this.shadowMap.depthTexture.version === this._depthVersionCached ) {
 
@@ -691,6 +695,23 @@ class ShadowNode extends ShadowBaseNode {
 		}
 
 	}
+
+
+	/**
+	 * Called before the shadow map is rendered.
+	 * This method can be overridden by subclasses to perform custom actions.
+	 *
+	 * @abstract
+	 */
+	onBeforeUpdate() {}
+
+	/**
+	 * Called after the shadow map is rendered.
+	 * This method can be overridden by subclasses to perform custom actions.
+	 *
+	 * @abstract
+	 */
+	onAfterUpdate() {}
 
 }
 


### PR DESCRIPTION
**Description**
This PR adds two new hooks to shadow nodes: `onBeforeUpdate` and `onAfterUpdate`. These can be very useful for applying specific behavior to individual shadows in the scene.

For example, in the case of a static shadow and a dynamic shadow, a mesh can be hidden for one and visible only to the other:
```js
const staticMeshes = [...]
const dynamicMeshes = [...]
const bakedShadow = new THREE.DirectionalLight(0xffffaa, 4.5);
bakedShadow.castShadow = true;
bakedShadow.shadow.needsUpdate = true;
bakedShadow.shadow.autoUpdate = false;

bakedShadow.shadow.onBeforeUpdate = () => {
   staticMesh.visible = true;
   dynamicMesh.visible = false;
};

bakedShadow.shadow.onAfterUpdate = () => {
   staticMesh.visible = false;
   dynamicMesh.visible = true;
};

const dynamicShadow = new THREE.DirectionalLight(0xffffaa, 4.5);
dynamicShadow.castShadow = true;

bakedShadow.shadow.onBeforeUpdate = () => {
   staticMesh.visible = false;
   dynamicMesh.visible = true;
};

bakedShadow.shadow.onAfterUpdate = () => {
   staticMesh.visible = true;
   dynamicMesh.visible = false;
};
```

*This contribution is funded by [Renaud Rohlinger](https://github.com/sponsors/RenaudRohlinger) @ [Utsubo](https://utsubo.com)*