### PR TITLE
Fix WebXR Haptics example when entering VR from Oculus Browser button

### DIFF
--- a/examples/webxr_xr_haptics.html
+++ b/examples/webxr_xr_haptics.html
@@ -140,6 +140,7 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setAnimationLoop( animate );
+				renderer.xr.addEventListener( 'sessionstart', () => initAudio() );
 				renderer.shadowMap.enabled = true;
 				renderer.xr.enabled = true;
 				container.appendChild( renderer.domElement );

--- a/examples/webxr_xr_haptics.html
+++ b/examples/webxr_xr_haptics.html
@@ -147,8 +147,6 @@
 
 				document.body.appendChild( XRButton.createButton( renderer ) );
 
-				document.getElementById( 'XRButton' ).addEventListener( 'click', initAudio );
-
 				// controllers
 
 				controller1 = renderer.xr.getController( 0 );


### PR DESCRIPTION
Fixed #30857.

**Description**

Fixes a bug where the WebXR Haptics example fails if the user taps "Enter VR" directly from the Oculus Browser button, before interacting with the page. The update ensures proper initialization by explicitly calling initAudio() when entering VR.
