### PR TITLE
JSDoc: More import sections.

### DIFF
--- a/examples/jsm/animation/AnimationClipCreator.js
+++ b/examples/jsm/animation/AnimationClipCreator.js
@@ -11,6 +11,7 @@ import {
  * A utility class with factory methods for creating basic animation clips.
  *
  * @hideconstructor
+ * @three_import import { AnimationClipCreator } from 'three/addons/animation/AnimationClipCreator.js';
  */
 class AnimationClipCreator {
 

--- a/examples/jsm/animation/CCDIKSolver.js
+++ b/examples/jsm/animation/CCDIKSolver.js
@@ -29,6 +29,8 @@ const _matrix = new Matrix4();
  * This class solves the Inverse Kinematics Problem with a [CCD Algorithm]{@link https://web.archive.org/web/20221206080850/https://sites.google.com/site/auraliusproject/ccd-algorithm}.
  *
  * `CCDIKSolver` is designed to work with instances of {@link SkinnedMesh}.
+ *
+ * @three_import import { CCDIKSolver } from 'three/addons/animation/CCDIKSolver.js';
  */
 class CCDIKSolver {
 
@@ -322,6 +324,7 @@ function setPositionOfBoneToAttributeArray( array, index, bone, matrixWorldInv )
  * Helper for visualizing IK bones.
  *
  * @augments Object3D
+ * @three_import import { CCDIKHelper } from 'three/addons/animation/CCDIKSolver.js';
  */
 class CCDIKHelper extends Object3D {
 

--- a/examples/jsm/capabilities/WebGL.js
+++ b/examples/jsm/capabilities/WebGL.js
@@ -2,6 +2,7 @@
  * A utility module with basic WebGL 2 capability testing.
  *
  * @hideconstructor
+ * @three_import import WebGL from 'three/addons/capabilities/WebGL.js';
  */
 class WebGL {
 

--- a/examples/jsm/capabilities/WebGPU.js
+++ b/examples/jsm/capabilities/WebGPU.js
@@ -10,6 +10,7 @@ if ( typeof window !== 'undefined' && isAvailable ) {
  * A utility module with basic WebGPU capability testing.
  *
  * @hideconstructor
+ * @three_import import WebGPU from 'three/addons/capabilities/WebGPU.js';
  */
 class WebGPU {
 

--- a/examples/jsm/controls/ArcballControls.js
+++ b/examples/jsm/controls/ArcballControls.js
@@ -107,6 +107,7 @@ const _EPS = 0.000001;
  * animation loop when animations are on.
  *
  * @augments Controls
+ * @three_import import { ArcballControls } from 'three/addons/controls/ArcballControls.js';
  */
 class ArcballControls extends Controls {
 

--- a/examples/jsm/controls/DragControls.js
+++ b/examples/jsm/controls/DragControls.js
@@ -52,6 +52,7 @@ const STATE = {
  * ```
  *
  * @augments Controls
+ * @three_import import { DragControls } from 'three/addons/controls/DragControls.js';
  */
 class DragControls extends Controls {
 

--- a/examples/jsm/controls/FirstPersonControls.js
+++ b/examples/jsm/controls/FirstPersonControls.js
@@ -14,6 +14,7 @@ const _targetPosition = new Vector3();
  * This class is an alternative implementation of {@link FlyControls}.
  *
  * @augments Controls
+ * @three_import import { FirstPersonControls } from 'three/addons/controls/FirstPersonControls.js';
  */
 class FirstPersonControls extends Controls {
 

--- a/examples/jsm/controls/FlyControls.js
+++ b/examples/jsm/controls/FlyControls.js
@@ -21,6 +21,7 @@ const _tmpQuaternion = new Quaternion();
  * (e.g. focus on a specific target).
  *
  * @augments Controls
+ * @three_import import { FlyControls } from 'three/addons/controls/FlyControls.js';
  */
 class FlyControls extends Controls {
 

--- a/examples/jsm/controls/MapControls.js
+++ b/examples/jsm/controls/MapControls.js
@@ -12,6 +12,7 @@ import { OrbitControls } from './OrbitControls.js';
  * - Pan: Left mouse, or arrow keys / touch: one-finger move.
  *
  * @augments OrbitControls
+ * @three_import import { MapControls } from 'three/addons/controls/MapControls.js';
  */
 class MapControls extends OrbitControls {
 

--- a/examples/jsm/controls/PointerLockControls.js
+++ b/examples/jsm/controls/PointerLockControls.js
@@ -55,6 +55,7 @@ const _PI_2 = Math.PI / 2;
  * ```
  *
  * @augments Controls
+ * @three_import import { PointerLockControls } from 'three/addons/controls/PointerLockControls.js';
  */
 class PointerLockControls extends Controls {
 
@@ -200,7 +201,7 @@ class PointerLockControls extends Controls {
 
 	/**
 	 * Activates the pointer lock.
-	 * 
+	 *
 	 * @param {boolean} [unadjustedMovement=false] - Disables OS-level adjustment for mouse acceleration, and accesses raw mouse input instead.
 	 * Setting it to true will disable mouse acceleration.
 	 */

--- a/examples/jsm/controls/TrackballControls.js
+++ b/examples/jsm/controls/TrackballControls.js
@@ -51,6 +51,7 @@ const _moveDirection = new Vector3();
  * to stay "right side up".
  *
  * @augments Controls
+ * @three_import import { TrackballControls } from 'three/addons/controls/TrackballControls.js';
  */
 class TrackballControls extends Controls {
 

--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -72,6 +72,7 @@ const _objectChangeEvent = { type: 'objectChange' };
  * `TransformControls` expects that its attached 3D object is part of the scene graph.
  *
  * @augments Controls
+ * @three_import import { TransformControls } from 'three/addons/controls/TransformControls.js';
  */
 class TransformControls extends Controls {
 

--- a/examples/jsm/csm/CSM.js
+++ b/examples/jsm/csm/CSM.js
@@ -25,6 +25,8 @@ const _up = new Vector3( 0, 1, 0 );
  *
  * This module can only be used with {@link WebGLRenderer}. When using {@link WebGPURenderer},
  * use {@link CSMShadowNode} instead.
+ *
+ * @three_import import { CSM } from 'three/addons/csm/CSM.js';
  */
 export class CSM {
 

--- a/examples/jsm/csm/CSMFrustum.js
+++ b/examples/jsm/csm/CSMFrustum.js
@@ -4,6 +4,8 @@ const inverseProjectionMatrix = new Matrix4();
 
 /**
  * Represents the frustum of a CSM instance.
+ *
+ * @three_import import { CSMFrustum } from 'three/addons/csm/CSMFrustum.js';
  */
 class CSMFrustum {
 

--- a/examples/jsm/csm/CSMHelper.js
+++ b/examples/jsm/csm/CSMHelper.js
@@ -16,6 +16,7 @@ import {
  * A helper for visualizing the cascades of a CSM instance.
  *
  * @augments Group
+ * @three_import import { CSMHelper } from 'three/addons/csm/CSMHelper.js';
  */
 class CSMHelper extends Group {
 

--- a/examples/jsm/csm/CSMShader.js
+++ b/examples/jsm/csm/CSMShader.js
@@ -1,6 +1,9 @@
 import { ShaderChunk } from 'three';
 
-/** @module CSMShader */
+/**
+ * @module CSMShader
+ * @three_import import { CSMShader } from 'three/addons/csm/CSMShader.js';
+ */
 
 /**
  * The object that holds the GLSL enhancements to enable CSM. This

--- a/examples/jsm/csm/CSMShadowNode.js
+++ b/examples/jsm/csm/CSMShadowNode.js
@@ -42,6 +42,7 @@ class LwLight extends Object3D {
  * use {@link CSM} instead.
  *
  * @augments ShadowBaseNode
+ * @three_import import { CSMShadowNode } from 'three/addons/csm/CSMShadowNode.js';
  */
 class CSMShadowNode extends ShadowBaseNode {
 

--- a/examples/jsm/curves/CurveExtras.js
+++ b/examples/jsm/curves/CurveExtras.js
@@ -17,6 +17,7 @@ import {
  * A Granny Knot curve.
  *
  * @augments Curve
+ * @three_import import { GrannyKnot } from 'three/addons/curves/CurveExtras.js';
  */
 class GrannyKnot extends Curve {
 
@@ -47,6 +48,7 @@ class GrannyKnot extends Curve {
  * A heart curve.
  *
  * @augments Curve
+ * @three_import import { HeartCurve } from 'three/addons/curves/CurveExtras.js';
  */
 class HeartCurve extends Curve {
 
@@ -96,6 +98,7 @@ class HeartCurve extends Curve {
  * A Viviani curve.
  *
  * @augments Curve
+ * @three_import import { VivianiCurve } from 'three/addons/curves/CurveExtras.js';
  */
 class VivianiCurve extends Curve {
 
@@ -146,6 +149,7 @@ class VivianiCurve extends Curve {
  * A knot curve.
  *
  * @augments Curve
+ * @three_import import { KnotCurve } from 'three/addons/curves/CurveExtras.js';
  */
 class KnotCurve extends Curve {
 
@@ -179,6 +183,7 @@ class KnotCurve extends Curve {
  * A helix curve.
  *
  * @augments Curve
+ * @three_import import { HelixCurve } from 'three/addons/curves/CurveExtras.js';
  */
 class HelixCurve extends Curve {
 
@@ -212,6 +217,7 @@ class HelixCurve extends Curve {
  * A Trefoil Knot.
  *
  * @augments Curve
+ * @three_import import { TrefoilKnot } from 'three/addons/curves/CurveExtras.js';
  */
 class TrefoilKnot extends Curve {
 
@@ -261,6 +267,7 @@ class TrefoilKnot extends Curve {
  * A torus knot.
  *
  * @augments Curve
+ * @three_import import { TorusKnot } from 'three/addons/curves/CurveExtras.js';
  */
 class TorusKnot extends Curve {
 
@@ -313,6 +320,7 @@ class TorusKnot extends Curve {
  * A Cinquefoil Knot.
  *
  * @augments Curve
+ * @three_import import { CinquefoilKnot } from 'three/addons/curves/CurveExtras.js';
  */
 class CinquefoilKnot extends Curve {
 
@@ -365,6 +373,7 @@ class CinquefoilKnot extends Curve {
  * A Trefoil Polynomial Knot.
  *
  * @augments Curve
+ * @three_import import { TrefoilPolynomialKnot } from 'three/addons/curves/CurveExtras.js';
  */
 class TrefoilPolynomialKnot extends Curve {
 
@@ -421,6 +430,7 @@ function scaleTo( x, y, t ) {
  * A Figure Eight Polynomial Knot.
  *
  * @augments Curve
+ * @three_import import { FigureEightPolynomialKnot } from 'three/addons/curves/CurveExtras.js';
  */
 class FigureEightPolynomialKnot extends Curve {
 
@@ -470,6 +480,7 @@ class FigureEightPolynomialKnot extends Curve {
  * A Decorated Torus Knot 4a.
  *
  * @augments Curve
+ * @three_import import { DecoratedTorusKnot4a } from 'three/addons/curves/CurveExtras.js';
  */
 class DecoratedTorusKnot4a extends Curve {
 
@@ -519,6 +530,7 @@ class DecoratedTorusKnot4a extends Curve {
  * A Decorated Torus Knot 4b.
  *
  * @augments Curve
+ * @three_import import { DecoratedTorusKnot4b } from 'three/addons/curves/CurveExtras.js';
  */
 class DecoratedTorusKnot4b extends Curve {
 
@@ -568,6 +580,7 @@ class DecoratedTorusKnot4b extends Curve {
  * A Decorated Torus Knot 5a.
  *
  * @augments Curve
+ * @three_import import { DecoratedTorusKnot5a } from 'three/addons/curves/CurveExtras.js';
  */
 class DecoratedTorusKnot5a extends Curve {
 
@@ -617,6 +630,7 @@ class DecoratedTorusKnot5a extends Curve {
  * A Decorated Torus Knot 5c.
  *
  * @augments Curve
+ * @three_import import { DecoratedTorusKnot5c } from 'three/addons/curves/CurveExtras.js';
  */
 class DecoratedTorusKnot5c extends Curve {
 

--- a/examples/jsm/curves/NURBSCurve.js
+++ b/examples/jsm/curves/NURBSCurve.js
@@ -11,6 +11,7 @@ import * as NURBSUtils from '../curves/NURBSUtils.js';
  * Implementation is based on `(x, y [, z=0 [, w=1]])` control points with `w=weight`.
  *
  * @augments Curve
+ * @three_import import { NURBSCurve } from 'three/addons/curves/NURBSCurve.js';
  */
 class NURBSCurve extends Curve {
 

--- a/examples/jsm/curves/NURBSSurface.js
+++ b/examples/jsm/curves/NURBSSurface.js
@@ -7,6 +7,8 @@ import * as NURBSUtils from '../curves/NURBSUtils.js';
  * This class represents a NURBS surface.
  *
  * Implementation is based on `(x, y [, z=0 [, w=1]])` control points with `w=weight`.
+ *
+ * @three_import import { NURBSSurface } from 'three/addons/curves/NURBSSurface.js';
  */
 class NURBSSurface {
 

--- a/examples/jsm/curves/NURBSUtils.js
+++ b/examples/jsm/curves/NURBSUtils.js
@@ -3,7 +3,10 @@ import {
 	Vector4
 } from 'three';
 
-/** @module NURBSUtils */
+/**
+ * @module NURBSUtils
+ * @three_import import * as NURBSUtils from 'three/addons/curves/NURBSUtils.js';
+ */
 
 /**
  * Finds knot vector span.

--- a/examples/jsm/curves/NURBSVolume.js
+++ b/examples/jsm/curves/NURBSVolume.js
@@ -7,6 +7,8 @@ import * as NURBSUtils from '../curves/NURBSUtils.js';
  * This class represents a NURBS volume.
  *
  * Implementation is based on `(x, y [, z=0 [, w=1]])` control points with `w=weight`.
+ *
+ * @three_import import { NURBSVolume } from 'three/addons/curves/NURBSVolume.js';
  */
 class NURBSVolume {
 

--- a/examples/jsm/effects/AnaglyphEffect.js
+++ b/examples/jsm/effects/AnaglyphEffect.js
@@ -14,6 +14,8 @@ import { FullScreenQuad } from '../postprocessing/Pass.js';
  *
  * Note that this class can only be used with {@link WebGLRenderer}.
  * When using {@link WebGPURenderer}, use {@link AnaglyphPassNode}.
+ *
+ * @three_import import { AnaglyphEffect } from 'three/addons/effects/AnaglyphEffect.js';
  */
 class AnaglyphEffect {
 

--- a/examples/jsm/effects/AsciiEffect.js
+++ b/examples/jsm/effects/AsciiEffect.js
@@ -2,6 +2,8 @@
  * A class that creates an ASCII effect.
  *
  * The ASCII generation is based on [jsascii]{@link https://github.com/hassadee/jsascii/blob/master/jsascii.js}.
+ *
+ * @three_import import { AsciiEffect } from 'three/addons/effects/AsciiEffect.js';
  */
 class AsciiEffect {
 

--- a/examples/jsm/effects/OutlineEffect.js
+++ b/examples/jsm/effects/OutlineEffect.js
@@ -21,6 +21,8 @@ import {
  *
  * }
  * ```
+ *
+ * @three_import import { OutlineEffect } from 'three/addons/effects/OutlineEffect.js';
  */
 class OutlineEffect {
 

--- a/examples/jsm/effects/ParallaxBarrierEffect.js
+++ b/examples/jsm/effects/ParallaxBarrierEffect.js
@@ -13,6 +13,8 @@ import { FullScreenQuad } from '../postprocessing/Pass.js';
  *
  * Note that this class can only be used with {@link WebGLRenderer}.
  * When using {@link WebGPURenderer}, use {@link ParallaxBarrierPassNode}.
+ *
+ * @three_import import { ParallaxBarrierEffect } from 'three/addons/effects/ParallaxBarrierEffect.js';
  */
 class ParallaxBarrierEffect {
 

--- a/examples/jsm/effects/PeppersGhostEffect.js
+++ b/examples/jsm/effects/PeppersGhostEffect.js
@@ -8,6 +8,8 @@ import {
  * A class that implements a peppers ghost effect.
  *
  * Reference: [Reflective Prism]{@link http://www.instructables.com/id/Reflective-Prism/?ALLSTEPS}
+ *
+ * @three_import import { PeppersGhostEffect } from 'three/addons/effects/PeppersGhostEffect.js';
  */
 class PeppersGhostEffect {
 

--- a/examples/jsm/effects/StereoEffect.js
+++ b/examples/jsm/effects/StereoEffect.js
@@ -8,6 +8,8 @@ import {
  *
  * Note that this class can only be used with {@link WebGLRenderer}.
  * When using {@link WebGPURenderer}, use {@link StereoPassNode}.
+ *
+ * @three_import import { StereoEffect } from 'three/addons/effects/StereoEffect.js';
  */
 class StereoEffect {
 

--- a/examples/jsm/environments/DebugEnvironment.js
+++ b/examples/jsm/environments/DebugEnvironment.js
@@ -26,6 +26,7 @@ import {
  * ```
  *
  * @augments Scene
+ * @three_import import { DebugEnvironment } from 'three/addons/environments/DebugEnvironment.js';
  */
 class DebugEnvironment extends Scene {
 

--- a/examples/jsm/environments/RoomEnvironment.js
+++ b/examples/jsm/environments/RoomEnvironment.js
@@ -26,6 +26,7 @@ import {
  * ```
  *
  * @augments Scene
+ * @three_import import { RoomEnvironment } from 'three/addons/environments/RoomEnvironment.js';
  */
 class RoomEnvironment extends Scene {
 

--- a/examples/jsm/exporters/DRACOExporter.js
+++ b/examples/jsm/exporters/DRACOExporter.js
@@ -19,6 +19,8 @@ import { Color, ColorManagement, SRGBColorSpace } from 'three';
  * const exporter = new DRACOExporter();
  * const data = exporter.parse( mesh, options );
  * ```
+ *
+ * @three_import import { DRACOExporter } from 'three/addons/exporters/DRACOExporter.js';
  */
 class DRACOExporter {
 

--- a/examples/jsm/exporters/EXRExporter.js
+++ b/examples/jsm/exporters/EXRExporter.js
@@ -26,6 +26,8 @@ const ZIP_COMPRESSION = 3;
  * const exporter = new EXRExporter();
  * const result = await exporter.parse( renderer, options );
  * ```
+ *
+ * @three_import import { EXRExporter } from 'three/addons/exporters/EXRExporter.js';
  */
 class EXRExporter {
 

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -97,6 +97,8 @@ const KHR_mesh_quantization_ExtraAttrTypes = {
  * const exporter = new GLTFExporter();
  * const data = await exporter.parseAsync( scene, options );
  * ```
+ *
+ * @three_import import { GLTFExporter } from 'three/addons/exporters/GLTFExporter.js';
  */
 class GLTFExporter {
 

--- a/examples/jsm/exporters/KTX2Exporter.js
+++ b/examples/jsm/exporters/KTX2Exporter.js
@@ -134,6 +134,8 @@ const ERROR_COLOR_SPACE = 'THREE.KTX2Exporter: Supported color spaces are SRGBCo
  * const exporter = new KTX2Exporter();
  * const result = await exporter.parse( dataTexture );
  * ```
+ *
+ * @three_import import { KTX2Exporter } from 'three/addons/exporters/KTX2Exporter.js';
  */
 export class KTX2Exporter {
 

--- a/examples/jsm/exporters/OBJExporter.js
+++ b/examples/jsm/exporters/OBJExporter.js
@@ -16,6 +16,8 @@ import {
  * const exporter = new OBJExporter();
  * const data = exporter.parse( scene );
  * ```
+ *
+ * @three_import import { OBJExporter } from 'three/addons/exporters/OBJExporter.js';
  */
 class OBJExporter {
 

--- a/examples/jsm/exporters/PLYExporter.js
+++ b/examples/jsm/exporters/PLYExporter.js
@@ -18,6 +18,8 @@ import {
  * const exporter = new PLYExporter();
  * const data = exporter.parse( scene, options );
  * ```
+ *
+ * @three_import import { PLYExporter } from 'three/addons/exporters/PLYExporter.js';
  */
 class PLYExporter {
 

--- a/examples/jsm/exporters/STLExporter.js
+++ b/examples/jsm/exporters/STLExporter.js
@@ -12,6 +12,8 @@ import { Vector3 } from 'three';
  * const exporter = new STLExporter();
  * const data = exporter.parse( mesh, { binary: true } );
  * ```
+ *
+ * @three_import import { STLExporter } from 'three/addons/exporters/STLExporter.js';
  */
 class STLExporter {
 

--- a/examples/jsm/exporters/USDZExporter.js
+++ b/examples/jsm/exporters/USDZExporter.js
@@ -16,6 +16,8 @@ import {
  * const exporter = new USDZExporter();
  * const arraybuffer = await exporter.parseAsync( scene );
  * ```
+ *
+ * @three_import import { USDZExporter } from 'three/addons/exporters/USDZExporter.js';
  */
 class USDZExporter {
 

--- a/examples/jsm/geometries/BoxLineGeometry.js
+++ b/examples/jsm/geometries/BoxLineGeometry.js
@@ -14,6 +14,7 @@ import {
  * ```
  *
  * @augments BufferGeometry
+ * @three_import import { BoxLineGeometry } from 'three/addons/geometries/BoxLineGeometry.js';
  */
 class BoxLineGeometry extends BufferGeometry {
 

--- a/examples/jsm/geometries/ConvexGeometry.js
+++ b/examples/jsm/geometries/ConvexGeometry.js
@@ -16,6 +16,7 @@ import { ConvexHull } from '../math/ConvexHull.js';
  * ```
  *
  * @augments BufferGeometry
+ * @three_import import { ConvexGeometry } from 'three/addons/geometries/ConvexGeometry.js';
  */
 class ConvexGeometry extends BufferGeometry {
 

--- a/examples/jsm/geometries/DecalGeometry.js
+++ b/examples/jsm/geometries/DecalGeometry.js
@@ -25,6 +25,7 @@ import {
  * ```
  *
  * @augments BufferGeometry
+ * @three_import import { DecalGeometry } from 'three/addons/geometries/DecalGeometry.js';
  */
 class DecalGeometry extends BufferGeometry {
 

--- a/examples/jsm/geometries/ParametricFunctions.js
+++ b/examples/jsm/geometries/ParametricFunctions.js
@@ -1,5 +1,8 @@
 
-/** @module ParametricFunctions */
+/**
+ * @module ParametricFunctions
+ * @three_import import * as ParametricFunctions from 'three/addons/geometries/ParametricFunctions.js';
+ */
 
 /**
  * A parametric function representing the Klein bottle.

--- a/examples/jsm/geometries/ParametricGeometry.js
+++ b/examples/jsm/geometries/ParametricGeometry.js
@@ -17,6 +17,7 @@ import {
  * ```
  *
  * @augments BufferGeometry
+ * @three_import import { ParametricGeometry } from 'three/addons/geometries/ParametricGeometry.js';
  */
 class ParametricGeometry extends BufferGeometry {
 

--- a/examples/jsm/geometries/RoundedBoxGeometry.js
+++ b/examples/jsm/geometries/RoundedBoxGeometry.js
@@ -49,6 +49,7 @@ function getUv( faceDirVector, normal, uvAxis, projectionAxis, radius, sideLengt
  * ```
  *
  * @augments BoxGeometry
+ * @three_import import { RoundedBoxGeometry } from 'three/addons/geometries/RoundedBoxGeometry.js';
  */
 class RoundedBoxGeometry extends BoxGeometry {
 

--- a/examples/jsm/geometries/TeapotGeometry.js
+++ b/examples/jsm/geometries/TeapotGeometry.js
@@ -26,6 +26,7 @@ import {
  * ```
  *
  * @augments BufferGeometry
+ * @three_import import { TeapotGeometry } from 'three/addons/geometries/TeapotGeometry.js';
  */
 class TeapotGeometry extends BufferGeometry {
 

--- a/examples/jsm/geometries/TextGeometry.js
+++ b/examples/jsm/geometries/TextGeometry.js
@@ -23,6 +23,7 @@ import {
  * ```
  *
  * @augments ExtrudeGeometry
+ * @three_import import { TextGeometry } from 'three/addons/geometries/TextGeometry.js';
  */
 class TextGeometry extends ExtrudeGeometry {
 

--- a/examples/jsm/helpers/LightProbeHelper.js
+++ b/examples/jsm/helpers/LightProbeHelper.js
@@ -16,6 +16,7 @@ import {
  * ```
  *
  * @augments Mesh
+ * @three_import import { LightProbeHelper } from 'three/addons/helpers/LightProbeHelper.js';
  */
 class LightProbeHelper extends Mesh {
 

--- a/examples/jsm/helpers/LightProbeHelperGPU.js
+++ b/examples/jsm/helpers/LightProbeHelperGPU.js
@@ -18,6 +18,7 @@ import { float, Fn, getShIrradianceAt, normalWorld, uniformArray, uniform, vec4 
  *
  * @private
  * @augments Mesh
+ * @three_import import { LightProbeHelper } from 'three/addons/helpers/LightProbeHelperGPU.js';
  */
 class LightProbeHelper extends Mesh {
 

--- a/examples/jsm/helpers/OctreeHelper.js
+++ b/examples/jsm/helpers/OctreeHelper.js
@@ -14,6 +14,7 @@ import {
  * ```
  *
  * @augments LineSegments
+ * @three_import import { OctreeHelper } from 'three/addons/helpers/OctreeHelper.js';
  */
 class OctreeHelper extends LineSegments {
 

--- a/examples/jsm/helpers/PositionalAudioHelper.js
+++ b/examples/jsm/helpers/PositionalAudioHelper.js
@@ -21,6 +21,7 @@ import {
  * ```
  *
  * @augments Line
+ * @three_import import { PositionalAudioHelper } from 'three/addons/helpers/PositionalAudioHelper.js';
  */
 class PositionalAudioHelper extends Line {
 

--- a/examples/jsm/helpers/RapierHelper.js
+++ b/examples/jsm/helpers/RapierHelper.js
@@ -3,6 +3,7 @@ import { LineSegments, LineBasicMaterial, BufferAttribute } from 'three';
  * This class displays all Rapier Colliders in outline.
  *
  * @augments LineSegments
+ * @three_import import { RapierHelper } from 'three/addons/helpers/RapierHelper.js';
  */
 class RapierHelper extends LineSegments {
 

--- a/examples/jsm/helpers/RectAreaLightHelper.js
+++ b/examples/jsm/helpers/RectAreaLightHelper.js
@@ -20,6 +20,7 @@ import {
  * ```
  *
  * @augments Line
+ * @three_import import { RectAreaLightHelper } from 'three/addons/helpers/RectAreaLightHelper.js';
  */
 class RectAreaLightHelper extends Line {
 

--- a/examples/jsm/helpers/TextureHelper.js
+++ b/examples/jsm/helpers/TextureHelper.js
@@ -18,6 +18,7 @@ import { mergeGeometries } from '../utils/BufferGeometryUtils.js';
  * When using {@link WebGPURenderer}, import from `TextureHelperGPU.js`.
  *
  * @augments Mesh
+ * @three_import import { TextureHelper } from 'three/addons/helpers/TextureHelper.js';
  */
 class TextureHelper extends Mesh {
 

--- a/examples/jsm/helpers/TextureHelperGPU.js
+++ b/examples/jsm/helpers/TextureHelperGPU.js
@@ -20,6 +20,7 @@ import { mergeGeometries } from '../utils/BufferGeometryUtils.js';
  *
  * @private
  * @augments Mesh
+ * @three_import import { TextureHelper } from 'three/addons/helpers/TextureHelperGPU.js';
  */
 class TextureHelper extends Mesh {
 

--- a/examples/jsm/helpers/VertexNormalsHelper.js
+++ b/examples/jsm/helpers/VertexNormalsHelper.js
@@ -27,6 +27,7 @@ const _normalMatrix = new Matrix3();
  * ```
  *
  * @augments LineSegments
+ * @three_import import { VertexNormalsHelper } from 'three/addons/helpers/VertexNormalsHelper.js';
  */
 class VertexNormalsHelper extends LineSegments {
 

--- a/examples/jsm/helpers/VertexTangentsHelper.js
+++ b/examples/jsm/helpers/VertexTangentsHelper.js
@@ -20,6 +20,7 @@ const _v2 = new Vector3();
  * ```
  *
  * @augments LineSegments
+ * @three_import import { VertexTangentsHelper } from 'three/addons/helpers/VertexTangentsHelper.js';
  */
 class VertexTangentsHelper extends LineSegments {
 

--- a/examples/jsm/helpers/ViewHelper.js
+++ b/examples/jsm/helpers/ViewHelper.js
@@ -26,6 +26,7 @@ import {
  * so it looks along the selected axis.
  *
  * @augments Object3D
+ * @three_import import { ViewHelper } from 'three/addons/helpers/ViewHelper.js';
  */
 class ViewHelper extends Object3D {
 

--- a/examples/jsm/interactive/HTMLMesh.js
+++ b/examples/jsm/interactive/HTMLMesh.js
@@ -23,6 +23,7 @@ import {
  * ```
  *
  * @augments Mesh
+ * @three_import import { HTMLMesh } from 'three/addons/interactive/HTMLMesh.js';
  */
 class HTMLMesh extends Mesh {
 

--- a/examples/jsm/interactive/InteractiveGroup.js
+++ b/examples/jsm/interactive/InteractiveGroup.js
@@ -34,6 +34,7 @@ const _raycaster = new Raycaster();
  * group.add( mesh1, mesh2, mesh3 );
  * ```
  * @augments Group
+ * @three_import import { InteractiveGroup } from 'three/addons/interactive/InteractiveGroup.js';
  */
 class InteractiveGroup extends Group {
 

--- a/examples/jsm/interactive/SelectionBox.js
+++ b/examples/jsm/interactive/SelectionBox.js
@@ -37,6 +37,8 @@ const _scale = new Vector3();
  * const selectionBox = new SelectionBox( camera, scene );
  * const selectedObjects = selectionBox.select( startPoint, endPoint );
  * ```
+ *
+ * @three_import import { SelectionBox } from 'three/addons/interactive/SelectionBox.js';
  */
 class SelectionBox {
 

--- a/examples/jsm/interactive/SelectionHelper.js
+++ b/examples/jsm/interactive/SelectionHelper.js
@@ -4,6 +4,8 @@ import { Vector2 } from 'three';
  * A helper for {@link SelectionBox}.
  *
  * It visualizes the current selection box with a `div` container element.
+ *
+ * @three_import import { SelectionHelper } from 'three/addons/interactive/SelectionHelper.js';
  */
 class SelectionHelper {
 

--- a/examples/jsm/lighting/TiledLighting.js
+++ b/examples/jsm/lighting/TiledLighting.js
@@ -11,6 +11,7 @@ import { tiledLights } from '../tsl/lighting/TiledLightsNode.js';
  * ```
  *
  * @augments Lighting
+ * @three_import import { TiledLighting } from 'three/addons/lighting/TiledLighting.js';
  */
 export class TiledLighting extends Lighting {
 

--- a/examples/jsm/lights/LightProbeGenerator.js
+++ b/examples/jsm/lights/LightProbeGenerator.js
@@ -15,6 +15,7 @@ import {
  * Utility class for creating instances of {@link LightProbe}.
  *
  * @hideconstructor
+ * @three_import import { LightProbeGenerator } from 'three/addons/lights/LightProbeGenerator.js';
  */
 class LightProbeGenerator {
 

--- a/examples/jsm/lights/RectAreaLightTexturesLib.js
+++ b/examples/jsm/lights/RectAreaLightTexturesLib.js
@@ -25,6 +25,7 @@ import {
  * in the main build files.
  *
  * @hideconstructor
+ * @three_import import { RectAreaLightTexturesLib } from 'three/addons/lights/RectAreaLightTexturesLib.js';
  */
 class RectAreaLightTexturesLib {
 

--- a/examples/jsm/lights/RectAreaLightUniformsLib.js
+++ b/examples/jsm/lights/RectAreaLightUniformsLib.js
@@ -12,6 +12,7 @@ import { RectAreaLightTexturesLib } from './RectAreaLightTexturesLib.js';
  * ```
  *
  * @hideconstructor
+ * @three_import import { RectAreaLightUniformsLib } from 'three/addons/lights/RectAreaLightUniformsLib.js';
  */
 class RectAreaLightUniformsLib {
 

--- a/examples/jsm/lines/Line2.js
+++ b/examples/jsm/lines/Line2.js
@@ -24,6 +24,7 @@ import { LineMaterial } from '../lines/LineMaterial.js';
  * ```
  *
  * @augments LineSegments2
+ * @three_import import { Line2 } from 'three/addons/lines/Line2.js';
  */
 class Line2 extends LineSegments2 {
 

--- a/examples/jsm/lines/LineGeometry.js
+++ b/examples/jsm/lines/LineGeometry.js
@@ -17,6 +17,7 @@ import { LineSegmentsGeometry } from '../lines/LineSegmentsGeometry.js';
  * ```
  *
  * @augments LineSegmentsGeometry
+ * @three_import import { LineLineGeometry2 } from 'three/addons/lines/LineGeometry.js';
  */
 class LineGeometry extends LineSegmentsGeometry {
 

--- a/examples/jsm/lines/LineMaterial.js
+++ b/examples/jsm/lines/LineMaterial.js
@@ -413,6 +413,7 @@ ShaderLib[ 'line' ] = {
  * use {@link Line2NodeMaterial}.
  *
  * @augments ShaderMaterial
+ * @three_import import { LineMaterial } from 'three/addons/lines/LineMaterial.js';
  */
 class LineMaterial extends ShaderMaterial {
 

--- a/examples/jsm/lines/LineSegments2.js
+++ b/examples/jsm/lines/LineSegments2.js
@@ -246,6 +246,7 @@ function raycastScreenSpace( lineSegments, camera, intersects ) {
  * ```
  *
  * @augments Mesh
+ * @three_import import { LineSegments2 } from 'three/addons/lines/LineSegments2.js';
  */
 class LineSegments2 extends Mesh {
 

--- a/examples/jsm/lines/LineSegmentsGeometry.js
+++ b/examples/jsm/lines/LineSegmentsGeometry.js
@@ -18,6 +18,7 @@ const _vector = new Vector3();
  * This is used in {@link LineSegments2} to describe the shape.
  *
  * @augments InstancedBufferGeometry
+ * @three_import import { LineSegmentsGeometry } from 'three/addons/lines/LineSegmentsGeometry.js';
  */
 class LineSegmentsGeometry extends InstancedBufferGeometry {
 

--- a/examples/jsm/lines/Wireframe.js
+++ b/examples/jsm/lines/Wireframe.js
@@ -27,6 +27,7 @@ const _viewport = new Vector4();
  * ```
  *
  * @augments Mesh
+ * @three_import import { Wireframe } from 'three/addons/lines/Wireframe.js';
  */
 class Wireframe extends Mesh {
 

--- a/examples/jsm/lines/WireframeGeometry2.js
+++ b/examples/jsm/lines/WireframeGeometry2.js
@@ -14,6 +14,7 @@ import { LineSegmentsGeometry } from '../lines/LineSegmentsGeometry.js';
  * ```
  *
  * @augments LineSegmentsGeometry
+ * @three_import import { WireframeGeometry2 } from 'three/addons/lines/WireframeGeometry2.js';
  */
 class WireframeGeometry2 extends LineSegmentsGeometry {
 

--- a/examples/jsm/lines/webgpu/Line2.js
+++ b/examples/jsm/lines/webgpu/Line2.js
@@ -14,6 +14,7 @@ import { LineGeometry } from '../LineGeometry.js';
  * import the class from `lines/Line2.js`.
  *
  * @augments LineSegments2
+ * @three_import import { Line2 } from 'three/addons/lines/webgpu/Line2.js';
  */
 class Line2 extends LineSegments2 {
 

--- a/examples/jsm/lines/webgpu/LineSegments2.js
+++ b/examples/jsm/lines/webgpu/LineSegments2.js
@@ -234,6 +234,7 @@ function raycastScreenSpace( lineSegments, camera, intersects ) {
  * import the class from `lines/LineSegments2.js`.
  *
  * @augments Mesh
+ * @three_import import { LineSegments2 } from 'three/addons/lines/webgpu/LineSegments2.js';
  */
 class LineSegments2 extends Mesh {
 

--- a/examples/jsm/lines/webgpu/Wireframe.js
+++ b/examples/jsm/lines/webgpu/Wireframe.js
@@ -18,6 +18,7 @@ const _end = new Vector3();
  * import the class from `lines/Wireframe.js`.
  *
  * @augments Mesh
+ * @three_import import { Wireframe } from 'three/addons/lines/webgpu/Wireframe.js';
  */
 class Wireframe extends Mesh {
 

--- a/examples/jsm/loaders/3DMLoader.js
+++ b/examples/jsm/loaders/3DMLoader.js
@@ -48,6 +48,7 @@ const _taskCache = new WeakMap();
  * ```
  *
  * @augments Loader
+ * @three_import import { Rhino3dmLoader } from 'three/addons/loaders/3DMLoader.js';
  */
 class Rhino3dmLoader extends Loader {
 

--- a/examples/jsm/loaders/3MFLoader.js
+++ b/examples/jsm/loaders/3MFLoader.js
@@ -48,6 +48,7 @@ const COLOR_SPACE_3MF = SRGBColorSpace;
  * ```
  *
  * @augments Loader
+ * @three_import import { ThreeMFLoader } from 'three/addons/loaders/3MFLoader.js';
  */
 class ThreeMFLoader extends Loader {
 

--- a/examples/jsm/loaders/AMFLoader.js
+++ b/examples/jsm/loaders/AMFLoader.js
@@ -24,6 +24,7 @@ import * as fflate from '../libs/fflate.module.js';
  * ```
  *
  * @augments Loader
+ * @three_import import { AMFLoader } from 'three/addons/loaders/AMFLoader.js';
  */
 class AMFLoader extends Loader {
 

--- a/examples/jsm/loaders/BVHLoader.js
+++ b/examples/jsm/loaders/BVHLoader.js
@@ -31,6 +31,7 @@ import {
  * ```
  *
  * @augments Loader
+ * @three_import import { BVHLoader } from 'three/addons/loaders/BVHLoader.js';
  */
 class BVHLoader extends Loader {
 

--- a/examples/jsm/loaders/ColladaLoader.js
+++ b/examples/jsm/loaders/ColladaLoader.js
@@ -58,6 +58,7 @@ import { TGALoader } from '../loaders/TGALoader.js';
  * ```
  *
  * @augments Loader
+ * @three_import import { ColladaLoader } from 'three/addons/loaders/ColladaLoader.js';
  */
 class ColladaLoader extends Loader {
 

--- a/examples/jsm/loaders/DDSLoader.js
+++ b/examples/jsm/loaders/DDSLoader.js
@@ -20,6 +20,7 @@ import {
  * ```
  *
  * @augments CompressedTextureLoader
+ * @three_import import { DDSLoader } from 'three/addons/loaders/DDSLoader.js';
  */
 class DDSLoader extends CompressedTextureLoader {
 

--- a/examples/jsm/loaders/DRACOLoader.js
+++ b/examples/jsm/loaders/DRACOLoader.js
@@ -41,6 +41,7 @@ const _taskCache = new WeakMap();
  * ```
  *
  * @augments Loader
+ * @three_import import { DRACOLoader } from 'three/addons/loaders/DRACOLoader.js';
  */
 class DRACOLoader extends Loader {
 

--- a/examples/jsm/loaders/EXRLoader.js
+++ b/examples/jsm/loaders/EXRLoader.js
@@ -92,6 +92,7 @@ import * as fflate from '../libs/fflate.module.js';
  * ```
  *
  * @augments DataTextureLoader
+ * @three_import import { EXRLoader } from 'three/addons/loaders/EXRLoader.js';
  */
 class EXRLoader extends DataTextureLoader {
 

--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -73,6 +73,7 @@ let sceneGraph;
  * ```
  *
  * @augments Loader
+ * @three_import import { FBXLoader } from 'three/addons/loaders/FBXLoader.js';
  */
 class FBXLoader extends Loader {
 

--- a/examples/jsm/loaders/FontLoader.js
+++ b/examples/jsm/loaders/FontLoader.js
@@ -15,6 +15,7 @@ import {
  * ```
  *
  * @augments Loader
+ * @three_import import { FontLoader } from 'three/addons/loaders/FontLoader.js';
  */
 class FontLoader extends Loader {
 

--- a/examples/jsm/loaders/GCodeLoader.js
+++ b/examples/jsm/loaders/GCodeLoader.js
@@ -20,6 +20,7 @@ import {
  * ```
  *
  * @augments Loader
+ * @three_import import { GCodeLoader } from 'three/addons/loaders/GCodeLoader.js';
  */
 class GCodeLoader extends Loader {
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -115,6 +115,7 @@ import { toTrianglesDrawMode } from '../utils/BufferGeometryUtils.js';
  * ```
  *
  * @augments Loader
+ * @three_import import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
  */
 class GLTFLoader extends Loader {
 

--- a/examples/jsm/loaders/HDRCubeTextureLoader.js
+++ b/examples/jsm/loaders/HDRCubeTextureLoader.js
@@ -23,6 +23,7 @@ import { RGBELoader } from '../loaders/RGBELoader.js';
  * ```
  *
  * @augments Loader
+ * @three_import import { HDRCubeTextureLoader } from 'three/addons/loaders/HDRCubeTextureLoader.js';
  */
 class HDRCubeTextureLoader extends Loader {
 

--- a/examples/jsm/loaders/IESLoader.js
+++ b/examples/jsm/loaders/IESLoader.js
@@ -25,6 +25,7 @@ import {
  * ```
  *
  * @augments Loader
+ * @three_import import { IESLoader } from 'three/addons/loaders/IESLoader.js';
  */
 class IESLoader extends Loader {
 

--- a/examples/jsm/loaders/KMZLoader.js
+++ b/examples/jsm/loaders/KMZLoader.js
@@ -18,6 +18,7 @@ import * as fflate from '../libs/fflate.module.js';
  * ```
  *
  * @augments Loader
+ * @three_import import { KMZLoader } from 'three/addons/loaders/KMZLoader.js';
  */
 class KMZLoader extends Loader {
 

--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -90,6 +90,7 @@ let _zstd;
  * ```
  *
  * @augments Loader
+ * @three_import import { KTX2Loader } from 'three/addons/loaders/KTX2Loader.js';
  */
 class KTX2Loader extends Loader {
 

--- a/examples/jsm/loaders/KTXLoader.js
+++ b/examples/jsm/loaders/KTXLoader.js
@@ -17,6 +17,7 @@ import {
  * ```
  *
  * @augments CompressedTextureLoader
+ * @three_import import { KTXLoader } from 'three/addons/loaders/KTXLoader.js';
  */
 class KTXLoader extends CompressedTextureLoader {
 

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -1776,6 +1776,7 @@ function createObject( loader, elements, elementSize, isConditionalSegments = fa
  * ```
  *
  * @augments Loader
+ * @three_import import { LDrawLoader } from 'three/addons/loaders/LDrawLoader.js';
  */
 class LDrawLoader extends Loader {
 

--- a/examples/jsm/loaders/LUT3dlLoader.js
+++ b/examples/jsm/loaders/LUT3dlLoader.js
@@ -21,6 +21,7 @@ import {
  * ```
  *
  * @augments Loader
+ * @three_import import { LUT3dlLoader } from 'three/addons/loaders/LUT3dlLoader.js';
  */
 export class LUT3dlLoader extends Loader {
 

--- a/examples/jsm/loaders/LUTCubeLoader.js
+++ b/examples/jsm/loaders/LUTCubeLoader.js
@@ -20,6 +20,7 @@ import {
  * ```
  *
  * @augments Loader
+ * @three_import import { LUTCubeLoader } from 'three/addons/loaders/LUTCubeLoader.js';
  */
 export class LUTCubeLoader extends Loader {
 

--- a/examples/jsm/loaders/LUTImageLoader.js
+++ b/examples/jsm/loaders/LUTImageLoader.js
@@ -17,6 +17,7 @@ import {
  * ```
  *
  * @augments Loader
+ * @three_import import { LUTImageLoader } from 'three/addons/loaders/LUTImageLoader.js';
  */
 export class LUTImageLoader extends Loader {
 

--- a/examples/jsm/loaders/LWOLoader.js
+++ b/examples/jsm/loaders/LWOLoader.js
@@ -1,16 +1,3 @@
-/**
- * @version 1.1.1
- *
- * @desc Load files in LWO3 and LWO2 format on Three.js
- *
- * LWO3 format specification:
- *  https://static.lightwave3d.com/sdk/2019/html/filefmts/lwo3.html
- *
- * LWO2 format specification:
- *  https://static.lightwave3d.com/sdk/2019/html/filefmts/lwo2.html
- *
- **/
-
 import {
 	AddOperation,
 	BackSide,
@@ -61,6 +48,7 @@ let _lwoTree;
  * ```
  *
  * @augments Loader
+ * @three_import import { LWOLoader } from 'three/addons/loaders/LWOLoader.js';
  */
 class LWOLoader extends Loader {
 

--- a/examples/jsm/loaders/LottieLoader.js
+++ b/examples/jsm/loaders/LottieLoader.js
@@ -29,6 +29,7 @@ import lottie from '../libs/lottie_canvas.module.js';
  * ```
  *
  * @augments Loader
+ * @three_import import { LottieLoader } from 'three/addons/loaders/LottieLoader.js';
  */
 class LottieLoader extends Loader {
 

--- a/examples/jsm/loaders/MD2Loader.js
+++ b/examples/jsm/loaders/MD2Loader.js
@@ -105,6 +105,7 @@ const _normalData = [
  * ```
  *
  * @augments Loader
+ * @three_import import { MD2Loader } from 'three/addons/loaders/MD2Loader.js';
  */
 class MD2Loader extends Loader {
 

--- a/examples/jsm/loaders/MDDLoader.js
+++ b/examples/jsm/loaders/MDDLoader.js
@@ -40,6 +40,7 @@ import {
  * ```
  *
  * @augments Loader
+ * @three_import import { MDDLoader } from 'three/addons/loaders/MDDLoader.js';
  */
 class MDDLoader extends Loader {
 

--- a/examples/jsm/loaders/MTLLoader.js
+++ b/examples/jsm/loaders/MTLLoader.js
@@ -29,6 +29,7 @@ import {
  * ```
  *
  * @augments Loader
+ * @three_import import { MTLLoader } from 'three/addons/loaders/MTLLoader.js';
  */
 class MTLLoader extends Loader {
 

--- a/examples/jsm/loaders/MaterialXLoader.js
+++ b/examples/jsm/loaders/MaterialXLoader.js
@@ -156,6 +156,7 @@ MXElements.forEach( element => MtlXLibrary[ element.name ] = element );
  * ```
  *
  * @augments Loader
+ * @three_import import { MaterialXLoader } from 'three/addons/loaders/MaterialXLoader.js';
  */
 class MaterialXLoader extends Loader {
 

--- a/examples/jsm/loaders/NRRDLoader.js
+++ b/examples/jsm/loaders/NRRDLoader.js
@@ -16,6 +16,7 @@ import { Volume } from '../misc/Volume.js';
  * ```
  *
  * @augments Loader
+ * @three_import import { NRRDLoader } from 'three/addons/loaders/NRRDLoader.js';
  */
 class NRRDLoader extends Loader {
 

--- a/examples/jsm/loaders/OBJLoader.js
+++ b/examples/jsm/loaders/OBJLoader.js
@@ -448,6 +448,7 @@ function ParserState() {
  * ```
  *
  * @augments Loader
+ * @three_import import { OBJLoader } from 'three/addons/loaders/OBJLoader.js';
  */
 class OBJLoader extends Loader {
 

--- a/examples/jsm/loaders/PCDLoader.js
+++ b/examples/jsm/loaders/PCDLoader.js
@@ -30,6 +30,7 @@ import {
  * ```
  *
  * @augments Loader
+ * @three_import import { PCDLoader } from 'three/addons/loaders/PCDLoader.js';
  */
 class PCDLoader extends Loader {
 

--- a/examples/jsm/loaders/PDBLoader.js
+++ b/examples/jsm/loaders/PDBLoader.js
@@ -23,6 +23,7 @@ import {
  * ```
  *
  * @augments Loader
+ * @three_import import { PDBLoader } from 'three/addons/loaders/PDBLoader.js';
  */
 class PDBLoader extends Loader {
 

--- a/examples/jsm/loaders/PLYLoader.js
+++ b/examples/jsm/loaders/PLYLoader.js
@@ -23,6 +23,7 @@ const _color = new Color();
  * ```
  *
  * @augments Loader
+ * @three_import import { PLYLoader } from 'three/addons/loaders/PLYLoader.js';
  */
 class PLYLoader extends Loader {
 

--- a/examples/jsm/loaders/PVRLoader.js
+++ b/examples/jsm/loaders/PVRLoader.js
@@ -17,6 +17,7 @@ import {
  * ```
  *
  * @augments CompressedTextureLoader
+ * @three_import import { PVRLoader } from 'three/addons/loaders/PVRLoader.js';
  */
 class PVRLoader extends CompressedTextureLoader {
 

--- a/examples/jsm/loaders/RGBELoader.js
+++ b/examples/jsm/loaders/RGBELoader.js
@@ -19,6 +19,7 @@ import {
  * ```
  *
  * @augments DataTextureLoader
+ * @three_import import { RGBELoader } from 'three/addons/loaders/RGBELoader.js';
  */
 class RGBELoader extends DataTextureLoader {
 

--- a/examples/jsm/loaders/RGBMLoader.js
+++ b/examples/jsm/loaders/RGBMLoader.js
@@ -18,6 +18,7 @@ import {
  * ```
  *
  * @augments DataTextureLoader
+ * @three_import import { RGBMLoader } from 'three/addons/loaders/RGBMLoader.js';
  */
 class RGBMLoader extends DataTextureLoader {
 

--- a/examples/jsm/loaders/STLLoader.js
+++ b/examples/jsm/loaders/STLLoader.js
@@ -49,6 +49,7 @@ import {
  * ```
  *
  * @augments Loader
+ * @three_import import { STLLoader } from 'three/addons/loaders/STLLoader.js';
  */
 class STLLoader extends Loader {
 

--- a/examples/jsm/loaders/SVGLoader.js
+++ b/examples/jsm/loaders/SVGLoader.js
@@ -55,6 +55,7 @@ const COLOR_SPACE_SVG = SRGBColorSpace;
  * ```
  *
  * @augments Loader
+ * @three_import import { SVGLoader } from 'three/addons/loaders/SVGLoader.js';
  */
 class SVGLoader extends Loader {
 

--- a/examples/jsm/loaders/TDSLoader.js
+++ b/examples/jsm/loaders/TDSLoader.js
@@ -26,6 +26,7 @@ import {
  * scene.add( object );
  *
  * @augments Loader
+ * @three_import import { TDSLoader } from 'three/addons/loaders/TDSLoader.js';
  */
 class TDSLoader extends Loader {
 

--- a/examples/jsm/loaders/TGALoader.js
+++ b/examples/jsm/loaders/TGALoader.js
@@ -13,6 +13,7 @@ import {
  * ```
  *
  * @augments DataTextureLoader
+ * @three_import import { TGALoader } from 'three/addons/loaders/TGALoader.js';
  */
 class TGALoader extends DataTextureLoader {
 

--- a/examples/jsm/loaders/TIFFLoader.js
+++ b/examples/jsm/loaders/TIFFLoader.js
@@ -16,6 +16,7 @@ import UTIF from '../libs/utif.module.js';
  * ```
  *
  * @augments DataTextureLoader
+ * @three_import import { TIFFLoader } from 'three/addons/loaders/TIFFLoader.js';
  */
 class TIFFLoader extends DataTextureLoader {
 

--- a/examples/jsm/loaders/TTFLoader.js
+++ b/examples/jsm/loaders/TTFLoader.js
@@ -17,6 +17,7 @@ import opentype from '../libs/opentype.module.js';
  * ```
  *
  * @augments Loader
+ * @three_import import { TTFLoader } from 'three/addons/loaders/TTFLoader.js';
  */
 class TTFLoader extends Loader {
 

--- a/examples/jsm/loaders/USDZLoader.js
+++ b/examples/jsm/loaders/USDZLoader.js
@@ -128,6 +128,7 @@ class USDAParser {
  * ```
  *
  * @augments Loader
+ * @three_import import { USDZLoader } from 'three/addons/loaders/USDZLoader.js';
  */
 class USDZLoader extends Loader {
 

--- a/examples/jsm/loaders/UltraHDRLoader.js
+++ b/examples/jsm/loaders/UltraHDRLoader.js
@@ -62,6 +62,7 @@ const SRGB_TO_LINEAR = Array( 1024 )
  * ```
  *
  * @augments Loader
+ * @three_import import { UltraHDRLoader } from 'three/addons/loaders/UltraHDRLoader.js';
  */
 class UltraHDRLoader extends Loader {
 

--- a/examples/jsm/loaders/VOXLoader.js
+++ b/examples/jsm/loaders/VOXLoader.js
@@ -30,6 +30,7 @@ import {
  * }
  * ```
  * @augments Loader
+ * @three_import import { VOXLoader } from 'three/addons/loaders/VOXLoader.js';
  */
 class VOXLoader extends Loader {
 

--- a/examples/jsm/loaders/VRMLLoader.js
+++ b/examples/jsm/loaders/VRMLLoader.js
@@ -46,6 +46,7 @@ import chevrotain from '../libs/chevrotain.module.min.js';
  * ```
  *
  * @augments Loader
+ * @three_import import { VRMLLoader } from 'three/addons/loaders/VRMLLoader.js';
  */
 class VRMLLoader extends Loader {
 

--- a/examples/jsm/loaders/VTKLoader.js
+++ b/examples/jsm/loaders/VTKLoader.js
@@ -26,6 +26,7 @@ import * as fflate from '../libs/fflate.module.js';
  * ```
  *
  * @augments Loader
+ * @three_import import { VTKLoader } from 'three/addons/loaders/VTKLoader.js';
  */
 class VTKLoader extends Loader {
 

--- a/examples/jsm/loaders/XYZLoader.js
+++ b/examples/jsm/loaders/XYZLoader.js
@@ -26,6 +26,7 @@ import {
  * ```
  *
  * @augments Loader
+ * @three_import import { XYZLoader } from 'three/addons/loaders/XYZLoader.js';
  */
 class XYZLoader extends Loader {
 

--- a/examples/jsm/materials/LDrawConditionalLineMaterial.js
+++ b/examples/jsm/materials/LDrawConditionalLineMaterial.js
@@ -12,6 +12,7 @@ import {
  * import the class from `LDrawConditionalLineNodeMaterial.js`.
  *
  * @augments ShaderMaterial
+ * @three_import import { LDrawConditionalLineMaterial } from 'three/addons/materials/LDrawConditionalLineMaterial.js';
  */
 class LDrawConditionalLineMaterial extends ShaderMaterial {
 

--- a/examples/jsm/materials/LDrawConditionalLineNodeMaterial.js
+++ b/examples/jsm/materials/LDrawConditionalLineNodeMaterial.js
@@ -8,6 +8,7 @@ import { attribute, cameraProjectionMatrix, dot, float, Fn, modelViewMatrix, mod
  * import the class from `LDrawConditionalLineMaterial.js`.
  *
  * @augments NodeMaterial
+ * @three_import import { LDrawConditionalLineMaterial } from 'three/addons/materials/LDrawConditionalLineMaterial.js';
  */
 class LDrawConditionalLineMaterial extends NodeMaterial {
 

--- a/examples/jsm/materials/MeshPostProcessingMaterial.js
+++ b/examples/jsm/materials/MeshPostProcessingMaterial.js
@@ -23,6 +23,7 @@ import { MeshPhysicalMaterial } from 'three';
  * This would then create the possibility of SSR and IR depending on material properties such as `roughness`, `metalness` and `reflectivity`.
  *
  * @augments MeshPhysicalMaterial
+ * @three_import import { MeshPostProcessingMaterial } from 'three/addons/materials/MeshPostProcessingMaterial.js';
  */
 class MeshPostProcessingMaterial extends MeshPhysicalMaterial {
 

--- a/examples/jsm/math/Capsule.js
+++ b/examples/jsm/math/Capsule.js
@@ -7,6 +7,8 @@ import {
  * It can be thought of as a swept sphere, where a sphere is moved along a line segment.
  *
  * Capsules are often used as bounding volumes (next to AABBs and bounding spheres).
+ *
+ * @three_import import { Capsule } from 'three/addons/math/Capsule.js';
  */
 class Capsule {
 

--- a/examples/jsm/math/ColorConverter.js
+++ b/examples/jsm/math/ColorConverter.js
@@ -6,6 +6,7 @@ const _hsl = {};
  * A utility class with helper functions for color conversion.
  *
  * @hideconstructor
+ * @three_import import { ColorConverter } from 'three/addons/math/ColorConverter.js';
  */
 class ColorConverter {
 

--- a/examples/jsm/math/ConvexHull.js
+++ b/examples/jsm/math/ConvexHull.js
@@ -20,6 +20,8 @@ const _triangle = new Triangle();
  *
  * This Quickhull 3D implementation is a port of [quickhull3d]{@link https://github.com/maurizzzio/quickhull3d/}
  * by Mauricio Poppe.
+ *
+ * @three_import import { ConvexHull } from 'three/addons/math/ConvexHull.js';
  */
 class ConvexHull {
 

--- a/examples/jsm/math/ImprovedNoise.js
+++ b/examples/jsm/math/ImprovedNoise.js
@@ -40,6 +40,8 @@ function grad( hash, x, y, z ) {
  *
  * The code is based on [IMPROVED NOISE]{@link https://cs.nyu.edu/~perlin/noise/}
  * by Ken Perlin, 2002.
+ *
+ * @three_import import { ImprovedNoise } from 'three/addons/math/ImprovedNoise.js';
  */
 class ImprovedNoise {
 

--- a/examples/jsm/math/Lut.js
+++ b/examples/jsm/math/Lut.js
@@ -12,6 +12,8 @@ import {
  * const lut = new Lut( 'rainbow', 512 );
  * const color = lut.getColor( 0.5 );
  * ```
+ *
+ * @three_import import { Lut } from 'three/addons/math/Lut.js';
  */
 class Lut {
 

--- a/examples/jsm/math/MeshSurfaceSampler.js
+++ b/examples/jsm/math/MeshSurfaceSampler.js
@@ -40,6 +40,8 @@ const _uva = new Vector2(), _uvb = new Vector2(), _uvc = new Vector2();
  *
  * scene.add( mesh );
  * ```
+ *
+ * @three_import import { MeshSurfaceSampler } from 'three/addons/math/MeshSurfaceSampler.js';
  */
 class MeshSurfaceSampler {
 

--- a/examples/jsm/math/OBB.js
+++ b/examples/jsm/math/OBB.js
@@ -39,6 +39,8 @@ const localRay = new Ray();
 
 /**
  * Represents an oriented bounding box (OBB) in 3D space.
+ *
+ * @three_import import { OBB } from 'three/addons/math/OBB.js';
  */
 class OBB {
 

--- a/examples/jsm/math/Octree.js
+++ b/examples/jsm/math/Octree.js
@@ -96,6 +96,8 @@ function lineToLineClosestPoints( line1, line2, target1 = null, target2 = null )
  * const octree = new Octree().fromGraphNode( scene );
  * const result = octree.capsuleIntersect( playerCollider ); // collision detection
  * ```
+ *
+ * @three_import import { Octree } from 'three/addons/math/Octree.js';
  */
 class Octree {
 

--- a/examples/jsm/math/SimplexNoise.js
+++ b/examples/jsm/math/SimplexNoise.js
@@ -3,6 +3,8 @@
  *
  * The code is based on [Simplex noise demystified]{@link https://web.archive.org/web/20210210162332/http://staffwww.itn.liu.se/~stegu/simplexnoise/simplexnoise.pdf}
  * by Stefan Gustavson, 2005.
+ *
+ * @three_import import { SimplexNoise } from 'three/addons/math/SimplexNoise.js';
  */
 class SimplexNoise {
 

--- a/examples/jsm/misc/ConvexObjectBreaker.js
+++ b/examples/jsm/misc/ConvexObjectBreaker.js
@@ -24,7 +24,9 @@ const _v1 = new Vector3();
  *
  * Note: This lib adds member variables to object's userData member (see prepareBreakableObject function)
  * Use with caution and read the code when using with other libs.
-*/
+ *
+ * @three_import import { ConvexObjectBreaker } from 'three/addons/misc/ConvexObjectBreaker.js';
+ */
 class ConvexObjectBreaker {
 
 	/**

--- a/examples/jsm/misc/GPUComputationRenderer.js
+++ b/examples/jsm/misc/GPUComputationRenderer.js
@@ -98,6 +98,8 @@ import { FullScreenQuad } from '../postprocessing/Pass.js';
  * gpuCompute.doRenderTarget( myFilter1, myRenderTarget );
  * gpuCompute.doRenderTarget( myFilter2, outputRenderTarget );
  * ```
+ *
+ * @three_import import { GPUComputationRenderer } from 'three/addons/misc/GPUComputationRenderer.js';
  */
 class GPUComputationRenderer {
 

--- a/examples/jsm/misc/Gyroscope.js
+++ b/examples/jsm/misc/Gyroscope.js
@@ -19,6 +19,7 @@ const _scaleWorld = new Vector3();
  * respect to the world.
  *
  * @augments Object3D
+ * @three_import import { Gyroscope } from 'three/addons/misc/Gyroscope.js';
  */
 class Gyroscope extends Object3D {
 

--- a/examples/jsm/misc/MD2Character.js
+++ b/examples/jsm/misc/MD2Character.js
@@ -13,6 +13,8 @@ import { MD2Loader } from '../loaders/MD2Loader.js';
 /**
  * This class represents a management component for animated MD2
  * character assets.
+ *
+ * @three_import import { MD2Character } from 'three/addons/misc/MD2Character.js';
  */
 class MD2Character {
 

--- a/examples/jsm/misc/MD2CharacterComplex.js
+++ b/examples/jsm/misc/MD2CharacterComplex.js
@@ -13,6 +13,8 @@ import { MorphBlendMesh } from '../misc/MorphBlendMesh.js';
 /**
  * This class represents a management component for animated MD2
  * character assets. It provides a larger API compared to {@link MD2Character}.
+ *
+ * @three_import import { MD2CharacterComplex } from 'three/addons/misc/MD2CharacterComplex.js';
  */
 class MD2CharacterComplex {
 

--- a/examples/jsm/misc/MorphAnimMesh.js
+++ b/examples/jsm/misc/MorphAnimMesh.js
@@ -10,6 +10,7 @@ import {
  * without any transitions or fading between animation changes.
  *
  * @augments Mesh
+ * @three_import import { MorphAnimMesh } from 'three/addons/misc/MorphAnimMesh.js';
  */
 class MorphAnimMesh extends Mesh {
 

--- a/examples/jsm/misc/MorphBlendMesh.js
+++ b/examples/jsm/misc/MorphBlendMesh.js
@@ -10,6 +10,7 @@ import {
  * fading options.
  *
  * @augments Mesh
+ * @three_import import { MorphBlendMesh } from 'three/addons/misc/MorphBlendMesh.js';
  */
 class MorphBlendMesh extends Mesh {
 

--- a/examples/jsm/misc/ProgressiveLightMap.js
+++ b/examples/jsm/misc/ProgressiveLightMap.js
@@ -16,6 +16,8 @@ import { potpack } from '../libs/potpack.module.js';
  *
  * This class can only be used with {@link WebGLRenderer}.
  * When using {@link WebGPURenderer}, import from `ProgressiveLightMapGPU.js`.
+ *
+ * @three_import import { ProgressiveLightMap } from 'three/addons/misc/ProgressiveLightMap.js';
  */
 class ProgressiveLightMap {
 

--- a/examples/jsm/misc/ProgressiveLightMapGPU.js
+++ b/examples/jsm/misc/ProgressiveLightMapGPU.js
@@ -18,6 +18,8 @@ import { potpack } from '../libs/potpack.module.js';
  *
  * This class can only be used with {@link WebGPURenderer}.
  * When using {@link WebGLRenderer}, import from `ProgressiveLightMap.js`.
+ *
+ * @three_import import { ProgressiveLightMap } from 'three/addons/misc/ProgressiveLightMapGPU.js';
  */
 class ProgressiveLightMap {
 

--- a/examples/jsm/misc/RollerCoaster.js
+++ b/examples/jsm/misc/RollerCoaster.js
@@ -12,6 +12,7 @@ import {
  * A procedural roller coaster geometry.
  *
  * @augments BufferGeometry
+ * @three_import import { RollerCoasterGeometry } from 'three/addons/misc/RollerCoaster.js';
  */
 class RollerCoasterGeometry extends BufferGeometry {
 
@@ -237,6 +238,7 @@ class RollerCoasterGeometry extends BufferGeometry {
  * A procedural roller coaster lifters geometry.
  *
  * @augments BufferGeometry
+ * @three_import import { RollerCoasterLiftersGeometry } from 'three/addons/misc/RollerCoaster.js';
  */
 class RollerCoasterLiftersGeometry extends BufferGeometry {
 
@@ -424,6 +426,7 @@ class RollerCoasterLiftersGeometry extends BufferGeometry {
  * A procedural roller coaster shadow geometry.
  *
  * @augments BufferGeometry
+ * @three_import import { RollerCoasterShadowGeometry } from 'three/addons/misc/RollerCoaster.js';
  */
 class RollerCoasterShadowGeometry extends BufferGeometry {
 
@@ -507,6 +510,7 @@ class RollerCoasterShadowGeometry extends BufferGeometry {
  * A procedural sky geometry.
  *
  * @augments BufferGeometry
+ * @three_import import { SkyGeometry } from 'three/addons/misc/RollerCoaster.js';
  */
 class SkyGeometry extends BufferGeometry {
 
@@ -548,6 +552,7 @@ class SkyGeometry extends BufferGeometry {
  * A procedural trees geometry.
  *
  * @augments BufferGeometry
+ * @three_import import { TreesGeometry } from 'three/addons/misc/RollerCoaster.js';
  */
 class TreesGeometry extends BufferGeometry {
 

--- a/examples/jsm/misc/Timer.js
+++ b/examples/jsm/misc/Timer.js
@@ -11,6 +11,8 @@
  * const timer = new Timer();
  * timer.connect( document ); // use Page Visibility API
  * ```
+ *
+ * @three_import import { Timer } from 'three/addons/misc/Timer.js';
  */
 class Timer {
 

--- a/examples/jsm/misc/TubePainter.js
+++ b/examples/jsm/misc/TubePainter.js
@@ -21,6 +21,7 @@ import {
  *
  * @name TubePainter
  * @class
+ * @three_import import { TubePainter } from 'three/addons/misc/TubePainter.js';
  */
 function TubePainter() {
 

--- a/examples/jsm/misc/Volume.js
+++ b/examples/jsm/misc/Volume.js
@@ -8,6 +8,8 @@ import { VolumeSlice } from '../misc/VolumeSlice.js';
 /**
  * This class had been written to handle the output of the {@link NRRDLoader}.
  * It contains a volume of data and information about it. For now it only handles 3 dimensional data.
+ *
+ * @three_import import { Volume } from 'three/addons/misc/Volume.js';
  */
 class Volume {
 

--- a/examples/jsm/misc/VolumeSlice.js
+++ b/examples/jsm/misc/VolumeSlice.js
@@ -13,6 +13,7 @@ import {
  * This class has been made to hold a slice of a volume data.
  *
  * @see {@link Volume}
+ * @three_import import { VolumeSlice } from 'three/addons/misc/VolumeSlice.js';
  */
 class VolumeSlice {
 

--- a/examples/jsm/modifiers/CurveModifier.js
+++ b/examples/jsm/modifiers/CurveModifier.js
@@ -203,6 +203,8 @@ vec3 transformedNormal = normalMatrix * (basis * objectNormal);
  *
  * This module can only be used with {@link WebGLRenderer}. When using {@link WebGPURenderer},
  * import the class from `CurveModifierGPU.js`.
+ *
+ * @three_import import { Flow } from 'three/addons/modifiers/CurveModifier.js';
  */
 export class Flow {
 
@@ -296,6 +298,7 @@ const _matrix = new Matrix4();
  * This module can only be used with {@link WebGLRenderer}.
  *
  * @augments Flow
+ * @three_import import { InstancedFlow } from 'three/addons/modifiers/CurveModifier.js';
  */
 export class InstancedFlow extends Flow {
 

--- a/examples/jsm/modifiers/CurveModifierGPU.js
+++ b/examples/jsm/modifiers/CurveModifierGPU.js
@@ -164,6 +164,8 @@ function modifyShader( material, uniforms, numberOfCurves ) {
  *
  * This module can only be used with {@link WebGPURenderer}. When using {@link WebGLRenderer},
  * import the class from `CurveModifier.js`.
+ *
+ * @three_import import { Flow } from 'three/addons/modifiers/CurveModifierGPU.js';
  */
 export class Flow {
 

--- a/examples/jsm/modifiers/EdgeSplitModifier.js
+++ b/examples/jsm/modifiers/EdgeSplitModifier.js
@@ -17,6 +17,8 @@ const _C = new Vector3();
  * const modifier = new EdgeSplitModifier();
  * geometry = modifier.modify( geometry, Math.PI * 0.4 );
  * ```
+ *
+ * @three_import import { EdgeSplitModifier } from 'three/addons/modifiers/EdgeSplitModifier.js';
  */
 class EdgeSplitModifier {
 

--- a/examples/jsm/modifiers/SimplifyModifier.js
+++ b/examples/jsm/modifiers/SimplifyModifier.js
@@ -21,6 +21,8 @@ const _cb = new Vector3(), _ab = new Vector3();
  * const modifier = new SimplifyModifier();
  * geometry = modifier.modify( geometry );
  * ```
+ *
+ * @three_import import { SimplifyModifier } from 'three/addons/modifiers/SimplifyModifier.js';
  */
 class SimplifyModifier {
 

--- a/examples/jsm/modifiers/TessellateModifier.js
+++ b/examples/jsm/modifiers/TessellateModifier.js
@@ -14,6 +14,8 @@ import {
  * const modifier = new TessellateModifier( 8, 6 );
  * geometry = modifier.modify( geometry );
  * ```
+ *
+ * @three_import import { TessellateModifier } from 'three/addons/modifiers/TessellateModifier.js';
  */
 class TessellateModifier {
 

--- a/examples/jsm/objects/GroundedSkybox.js
+++ b/examples/jsm/objects/GroundedSkybox.js
@@ -15,6 +15,7 @@ import { Mesh, MeshBasicMaterial, SphereGeometry, Vector3 } from 'three';
  * ```
  *
  * @augments Mesh
+ * @three_import import { GroundedSkybox } from 'three/addons/objects/GroundedSkybox.js';
  */
 class GroundedSkybox extends Mesh {
 

--- a/examples/jsm/objects/Lensflare.js
+++ b/examples/jsm/objects/Lensflare.js
@@ -33,6 +33,7 @@ import {
  * ```
  *
  * @augments Mesh
+ * @three_import import { Lensflare } from 'three/addons/objects/Lensflare.js';
  */
 class Lensflare extends Mesh {
 
@@ -338,6 +339,8 @@ class Lensflare extends Mesh {
 
 /**
  * Represents a single flare that can be added to a {@link Lensflare} container.
+ *
+ * @three_import import { LensflareElement } from 'three/addons/objects/Lensflare.js';
  */
 class LensflareElement {
 

--- a/examples/jsm/objects/LensflareMesh.js
+++ b/examples/jsm/objects/LensflareMesh.js
@@ -36,6 +36,7 @@ import { texture, textureLoad, uv, ivec2, vec2, vec4, positionGeometry, referenc
  * ```
  *
  * @augments Mesh
+ * @three_import import { LensflareMesh } from 'three/addons/objects/LensflareMesh.js';
  */
 class LensflareMesh extends Mesh {
 

--- a/examples/jsm/objects/MarchingCubes.js
+++ b/examples/jsm/objects/MarchingCubes.js
@@ -12,6 +12,8 @@ import {
  * A marching cubes implementation.
  *
  * Port of: {@link http://webglsamples.org/blob/blob.html}
+ *
+ * @three_import import { MarchingCubes } from 'three/addons/objects/MarchingCubes.js';
  */
 class MarchingCubes extends Mesh {
 

--- a/examples/jsm/objects/Reflector.js
+++ b/examples/jsm/objects/Reflector.js
@@ -32,6 +32,7 @@ import {
  * ```
  *
  * @augments Mesh
+ * @three_import import { Reflector } from 'three/addons/objects/Reflector.js';
  */
 class Reflector extends Mesh {
 

--- a/examples/jsm/objects/ReflectorForSSRPass.js
+++ b/examples/jsm/objects/ReflectorForSSRPass.js
@@ -19,6 +19,7 @@ import {
  * A special version of {@link Reflector} for usage with {@link SSRPass}.
  *
  * @augments Mesh
+ * @three_import import { ReflectorForSSRPass } from 'three/addons/objects/ReflectorForSSRPass.js';
  */
 class ReflectorForSSRPass extends Mesh {
 

--- a/examples/jsm/objects/Refractor.js
+++ b/examples/jsm/objects/Refractor.js
@@ -33,6 +33,7 @@ import {
  * ```
  *
  * @augments Mesh
+ * @three_import import { Refractor } from 'three/addons/objects/Refractor.js';
  */
 class Refractor extends Mesh {
 

--- a/examples/jsm/objects/ShadowMesh.js
+++ b/examples/jsm/objects/ShadowMesh.js
@@ -23,6 +23,7 @@ const _shadowMatrix = new Matrix4();
  * ```
  *
  * @augments Mesh
+ * @three_import import { ShadowMesh } from 'three/addons/objects/ShadowMesh.js';
  */
 class ShadowMesh extends Mesh {
 

--- a/examples/jsm/objects/Sky.js
+++ b/examples/jsm/objects/Sky.js
@@ -27,7 +27,8 @@ import {
  * ```
  *
  * @augments Mesh
-*/
+ * @three_import import { Sky } from 'three/addons/objects/Sky.js';
+ */
 class Sky extends Mesh {
 
 	/**

--- a/examples/jsm/objects/SkyMesh.js
+++ b/examples/jsm/objects/SkyMesh.js
@@ -27,7 +27,8 @@ import { Fn, float, vec3, acos, add, mul, clamp, cos, dot, exp, max, mix, modelV
  * ```
  *
  * @augments Mesh
-*/
+ * @three_import import { SkyMesh } from 'three/addons/objects/SkyMesh.js';
+ */
 class SkyMesh extends Mesh {
 
 	/**

--- a/examples/jsm/objects/Water.js
+++ b/examples/jsm/objects/Water.js
@@ -26,6 +26,7 @@ import {
  * - [Water shader explanations in WebGL]{@link http://29a.ch/slides/2012/webglwater/ }
  *
  * @augments Mesh
+ * @three_import import { Water } from 'three/addons/objects/Water.js';
  */
 class Water extends Mesh {
 

--- a/examples/jsm/objects/Water2.js
+++ b/examples/jsm/objects/Water2.js
@@ -28,6 +28,7 @@ import { Refractor } from '../objects/Refractor.js';
  * - {@link http://graphicsrunner.blogspot.de/2010/08/water-using-flow-maps.html}
  *
  * @augments Mesh
+ * @three_import import { Water } from 'three/addons/objects/Water2.js';
  */
 class Water extends Mesh {
 

--- a/examples/jsm/objects/Water2Mesh.js
+++ b/examples/jsm/objects/Water2Mesh.js
@@ -24,6 +24,7 @@ import { Fn, vec2, viewportSafeUV, viewportSharedTexture, reflector, pow, float,
  * - {@link http://graphicsrunner.blogspot.de/2010/08/water-using-flow-maps.html}
  *
  * @augments Mesh
+ * @three_import import { WaterMesh } from 'three/addons/objects/Water2Mesh.js';
  */
 class WaterMesh extends Mesh {
 

--- a/examples/jsm/objects/WaterMesh.js
+++ b/examples/jsm/objects/WaterMesh.js
@@ -20,6 +20,7 @@ import { Fn, add, cameraPosition, div, normalize, positionWorld, sub, time, text
  * - [Water shader explanations in WebGL]{@link http://29a.ch/slides/2012/webglwater/ }
  *
  * @augments Mesh
+ * @three_import import { WaterMesh } from 'three/addons/objects/WaterMesh.js';
  */
 class WaterMesh extends Mesh {
 

--- a/examples/jsm/physics/AmmoPhysics.js
+++ b/examples/jsm/physics/AmmoPhysics.js
@@ -12,6 +12,7 @@
  * @name AmmoPhysics
  * @class
  * @hideconstructor
+ * @three_import import { AmmoPhysics } from 'three/addons/physics/AmmoPhysics.js';
  */
 async function AmmoPhysics() {
 

--- a/examples/jsm/physics/JoltPhysics.js
+++ b/examples/jsm/physics/JoltPhysics.js
@@ -69,6 +69,7 @@ function setupCollisionFiltering( settings ) {
  * @name JoltPhysics
  * @class
  * @hideconstructor
+ * @three_import import { JoltPhysics } from 'three/addons/physics/JoltPhysics.js';
  */
 async function JoltPhysics() {
 

--- a/examples/jsm/physics/RapierPhysics.js
+++ b/examples/jsm/physics/RapierPhysics.js
@@ -80,6 +80,7 @@ function getShape( geometry ) {
  * @name RapierPhysics
  * @class
  * @hideconstructor
+ * @three_import import { RapierPhysics } from 'three/addons/physics/RapierPhysics.js';
  */
 async function RapierPhysics() {
 

--- a/examples/jsm/postprocessing/AfterimagePass.js
+++ b/examples/jsm/postprocessing/AfterimagePass.js
@@ -19,6 +19,7 @@ import { AfterimageShader } from '../shaders/AfterimageShader.js';
  * ```
  *
  * @augments Pass
+ * @three_import import { AfterimagePass } from 'three/addons/postprocessing/AfterimagePass.js';
  */
 class AfterimagePass extends Pass {
 

--- a/examples/jsm/postprocessing/BloomPass.js
+++ b/examples/jsm/postprocessing/BloomPass.js
@@ -21,6 +21,7 @@ import { ConvolutionShader } from '../shaders/ConvolutionShader.js';
  * ```
  *
  * @augments Pass
+ * @three_import import { BloomPass } from 'three/addons/postprocessing/BloomPass.js';
  */
 class BloomPass extends Pass {
 

--- a/examples/jsm/postprocessing/BokehPass.js
+++ b/examples/jsm/postprocessing/BokehPass.js
@@ -25,6 +25,7 @@ import { BokehShader } from '../shaders/BokehShader.js';
  * ```
  *
  * @augments Pass
+ * @three_import import { BokehPass } from 'three/addons/postprocessing/BokehPass.js';
  */
 class BokehPass extends Pass {
 

--- a/examples/jsm/postprocessing/ClearPass.js
+++ b/examples/jsm/postprocessing/ClearPass.js
@@ -13,6 +13,7 @@ import { Pass } from './Pass.js';
  * ```
  *
  * @augments Pass
+ * @three_import import { ClearPass } from 'three/addons/postprocessing/ClearPass.js';
  */
 class ClearPass extends Pass {
 

--- a/examples/jsm/postprocessing/CubeTexturePass.js
+++ b/examples/jsm/postprocessing/CubeTexturePass.js
@@ -21,6 +21,7 @@ import { Pass } from './Pass.js';
  * ```
  *
  * @augments Pass
+ * @three_import import { CubeTexturePass } from 'three/addons/postprocessing/CubeTexturePass.js';
  */
 class CubeTexturePass extends Pass {
 

--- a/examples/jsm/postprocessing/DotScreenPass.js
+++ b/examples/jsm/postprocessing/DotScreenPass.js
@@ -14,6 +14,7 @@ import { DotScreenShader } from '../shaders/DotScreenShader.js';
  * ```
  *
  * @augments Pass
+ * @three_import import { DotScreenPass } from 'three/addons/postprocessing/DotScreenPass.js';
  */
 class DotScreenPass extends Pass {
 

--- a/examples/jsm/postprocessing/EffectComposer.js
+++ b/examples/jsm/postprocessing/EffectComposer.js
@@ -36,6 +36,8 @@ import { ClearMaskPass, MaskPass } from './MaskPass.js';
  *
  * }
  * ```
+ *
+ * @three_import import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
  */
 class EffectComposer {
 

--- a/examples/jsm/postprocessing/FilmPass.js
+++ b/examples/jsm/postprocessing/FilmPass.js
@@ -14,6 +14,7 @@ import { FilmShader } from '../shaders/FilmShader.js';
  * ```
  *
  * @augments Pass
+ * @three_import import { FilmPass } from 'three/addons/postprocessing/FilmPass.js';
  */
 class FilmPass extends Pass {
 

--- a/examples/jsm/postprocessing/GTAOPass.js
+++ b/examples/jsm/postprocessing/GTAOPass.js
@@ -38,6 +38,7 @@ import { SimplexNoise } from '../math/SimplexNoise.js';
  * ```
  *
  * @augments Pass
+ * @three_import import { GTAOPass } from 'three/addons/postprocessing/GTAOPass.js';
  */
 class GTAOPass extends Pass {
 

--- a/examples/jsm/postprocessing/GlitchPass.js
+++ b/examples/jsm/postprocessing/GlitchPass.js
@@ -18,6 +18,7 @@ import { DigitalGlitch } from '../shaders/DigitalGlitch.js';
  * ```
  *
  * @augments Pass
+ * @three_import import { GlitchPass } from 'three/addons/postprocessing/GlitchPass.js';
  */
 class GlitchPass extends Pass {
 

--- a/examples/jsm/postprocessing/HalftonePass.js
+++ b/examples/jsm/postprocessing/HalftonePass.js
@@ -26,6 +26,7 @@ import { HalftoneShader } from '../shaders/HalftoneShader.js';
  * ```
  *
  * @augments Pass
+ * @three_import import { HalftonePass } from 'three/addons/postprocessing/HalftonePass.js';
  */
 class HalftonePass extends Pass {
 

--- a/examples/jsm/postprocessing/LUTPass.js
+++ b/examples/jsm/postprocessing/LUTPass.js
@@ -65,6 +65,7 @@ const LUTShader = {
  * ```
  *
  * @augments ShaderPass
+ * @three_import import { LUTPass } from 'three/addons/postprocessing/LUTPass.js';
  */
 class LUTPass extends ShaderPass {
 

--- a/examples/jsm/postprocessing/MaskPass.js
+++ b/examples/jsm/postprocessing/MaskPass.js
@@ -12,6 +12,7 @@ import { Pass } from './Pass.js';
  * ```
  *
  * @augments Pass
+ * @three_import import { MaskPass } from 'three/addons/postprocessing/MaskPass.js';
  */
 class MaskPass extends Pass {
 

--- a/examples/jsm/postprocessing/OutlinePass.js
+++ b/examples/jsm/postprocessing/OutlinePass.js
@@ -26,6 +26,7 @@ import { CopyShader } from '../shaders/CopyShader.js';
  * ```
  *
  * @augments Pass
+ * @three_import import { OutlinePass } from 'three/addons/postprocessing/OutlinePass.js';
  */
 class OutlinePass extends Pass {
 

--- a/examples/jsm/postprocessing/OutputPass.js
+++ b/examples/jsm/postprocessing/OutputPass.js
@@ -28,6 +28,7 @@ import { OutputShader } from '../shaders/OutputShader.js';
  * ```
  *
  * @augments Pass
+ * @three_import import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
  */
 class OutputPass extends Pass {
 

--- a/examples/jsm/postprocessing/Pass.js
+++ b/examples/jsm/postprocessing/Pass.js
@@ -11,6 +11,7 @@ import {
  * This module is only relevant for post processing with {@link WebGLRenderer}.
  *
  * @abstract
+ * @three_import import { Pass } from 'three/addons/postprocessing/Pass.js';
  */
 class Pass {
 
@@ -132,6 +133,7 @@ const _geometry = new FullscreenTriangleGeometry();
  * This module can only be used with {@link WebGLRenderer}.
  *
  * @augments Mesh
+ * @three_import import { FullScreenQuad } from 'three/addons/postprocessing/Pass.js';
  */
 class FullScreenQuad {
 

--- a/examples/jsm/postprocessing/RenderPass.js
+++ b/examples/jsm/postprocessing/RenderPass.js
@@ -13,6 +13,7 @@ import { Pass } from './Pass.js';
  * ```
  *
  * @augments Pass
+ * @three_import import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
  */
 class RenderPass extends Pass {
 

--- a/examples/jsm/postprocessing/RenderPixelatedPass.js
+++ b/examples/jsm/postprocessing/RenderPixelatedPass.js
@@ -19,6 +19,7 @@ import { Pass, FullScreenQuad } from './Pass.js';
  * ```
  *
  * @augments Pass
+ * @three_import import { RenderPixelatedPass } from 'three/addons/postprocessing/RenderPixelatedPass.js';
  */
 class RenderPixelatedPass extends Pass {
 

--- a/examples/jsm/postprocessing/RenderTransitionPass.js
+++ b/examples/jsm/postprocessing/RenderTransitionPass.js
@@ -16,6 +16,7 @@ import { FullScreenQuad, Pass } from './Pass.js';
  * ```
  *
  * @augments Pass
+ * @three_import import { RenderTransitionPass } from 'three/addons/postprocessing/RenderTransitionPass.js';
  */
 class RenderTransitionPass extends Pass {
 

--- a/examples/jsm/postprocessing/SAOPass.js
+++ b/examples/jsm/postprocessing/SAOPass.js
@@ -33,6 +33,7 @@ import { CopyShader } from '../shaders/CopyShader.js';
  * ```
  *
  * @augments Pass
+ * @three_import import { SAOPass } from 'three/addons/postprocessing/SAOPass.js';
  */
 class SAOPass extends Pass {
 

--- a/examples/jsm/postprocessing/SMAAPass.js
+++ b/examples/jsm/postprocessing/SMAAPass.js
@@ -20,6 +20,7 @@ import { SMAABlendShader, SMAAEdgesShader, SMAAWeightsShader } from '../shaders/
  * ```
  *
  * @augments Pass
+ * @three_import import { SMAAPass } from 'three/addons/postprocessing/SMAAPass.js';
  */
 class SMAAPass extends Pass {
 

--- a/examples/jsm/postprocessing/SSAARenderPass.js
+++ b/examples/jsm/postprocessing/SSAARenderPass.js
@@ -21,6 +21,7 @@ import { CopyShader } from '../shaders/CopyShader.js';
  * ```
  *
  * @augments Pass
+ * @three_import import { SSAARenderPass } from 'three/addons/postprocessing/SSAARenderPass.js';
  */
 class SSAARenderPass extends Pass {
 

--- a/examples/jsm/postprocessing/SSAOPass.js
+++ b/examples/jsm/postprocessing/SSAOPass.js
@@ -39,6 +39,7 @@ import { CopyShader } from '../shaders/CopyShader.js';
  * ```
  *
  * @augments Pass
+ * @three_import import { SSAOPass } from 'three/addons/postprocessing/SSAOPass.js';
  */
 class SSAOPass extends Pass {
 

--- a/examples/jsm/postprocessing/SSRPass.js
+++ b/examples/jsm/postprocessing/SSRPass.js
@@ -34,6 +34,7 @@ import { CopyShader } from '../shaders/CopyShader.js';
  * ```
  *
  * @augments Pass
+ * @three_import import { SSRPass } from 'three/addons/postprocessing/SSRPass.js';
  */
 class SSRPass extends Pass {
 

--- a/examples/jsm/postprocessing/SavePass.js
+++ b/examples/jsm/postprocessing/SavePass.js
@@ -17,6 +17,7 @@ import { CopyShader } from '../shaders/CopyShader.js';
  * ```
  *
  * @augments Pass
+ * @three_import import { SavePass } from 'three/addons/postprocessing/SavePass.js';
  */
 class SavePass extends Pass {
 

--- a/examples/jsm/postprocessing/ShaderPass.js
+++ b/examples/jsm/postprocessing/ShaderPass.js
@@ -15,6 +15,7 @@ import { Pass, FullScreenQuad } from './Pass.js';
  * ```
  *
  * @augments Pass
+ * @three_import import { ShaderPass } from 'three/addons/postprocessing/ShaderPass.js';
  */
 class ShaderPass extends Pass {
 

--- a/examples/jsm/postprocessing/TAARenderPass.js
+++ b/examples/jsm/postprocessing/TAARenderPass.js
@@ -20,6 +20,7 @@ import { SSAARenderPass } from './SSAARenderPass.js';
  * ```
  *
  * @augments SSAARenderPass
+ * @three_import import { TAARenderPass } from 'three/addons/postprocessing/TAARenderPass.js';
  */
 class TAARenderPass extends SSAARenderPass {
 

--- a/examples/jsm/postprocessing/TexturePass.js
+++ b/examples/jsm/postprocessing/TexturePass.js
@@ -17,6 +17,7 @@ import { CopyShader } from '../shaders/CopyShader.js';
  * ```
  *
  * @augments Pass
+ * @three_import import { TexturePass } from 'three/addons/postprocessing/TexturePass.js';
  */
 class TexturePass extends Pass {
 

--- a/examples/jsm/postprocessing/UnrealBloomPass.js
+++ b/examples/jsm/postprocessing/UnrealBloomPass.js
@@ -31,6 +31,7 @@ import { LuminosityHighPassShader } from '../shaders/LuminosityHighPassShader.js
  * ```
  *
  * @augments Pass
+ * @three_import import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
  */
 class UnrealBloomPass extends Pass {
 

--- a/examples/jsm/renderers/CSS2DRenderer.js
+++ b/examples/jsm/renderers/CSS2DRenderer.js
@@ -9,6 +9,7 @@ import {
  * The only type of 3D object that is supported by {@link CSS2DRenderer}.
  *
  * @augments Object3D
+ * @three_import import { CSS2DObject } from 'three/addons/renderers/CSS2DRenderer.js';
  */
 class CSS2DObject extends Object3D {
 
@@ -103,6 +104,8 @@ const _b = new Vector3();
  * scene graph. All other types of renderable 3D objects (like meshes or point clouds) are ignored.
  *
  * `CSS2DRenderer` only supports 100% browser and display zoom.
+ *
+ * @three_import import { CSS2DRenderer } from 'three/addons/renderers/CSS2DRenderer.js';
  */
 class CSS2DRenderer {
 

--- a/examples/jsm/renderers/CSS3DRenderer.js
+++ b/examples/jsm/renderers/CSS3DRenderer.js
@@ -15,6 +15,7 @@ const _scale = new Vector3();
  * The base 3D object that is supported by {@link CSS3DRenderer}.
  *
  * @augments Object3D
+ * @three_import import { CSS3DObject } from 'three/addons/renderers/CSS3DRenderer.js';
  */
 class CSS3DObject extends Object3D {
 
@@ -86,6 +87,7 @@ class CSS3DObject extends Object3D {
  * DOM elements as sprites.
  *
  * @augments CSS3DObject
+ * @three_import import { CSS3DSprite } from 'three/addons/renderers/CSS3DRenderer.js';
  */
 class CSS3DSprite extends CSS3DObject {
 
@@ -148,6 +150,8 @@ const _matrix2 = new Matrix4();
  *
  * So `CSS3DRenderer` is just focused on ordinary DOM elements. These elements are wrapped into special
  * 3D objects ({@link CSS3DObject} or {@link CSS3DSprite}) and then added to the scene graph.
+ *
+ * @three_import import { CSS3DRenderer } from 'three/addons/renderers/CSS3DRenderer.js';
  */
 class CSS3DRenderer {
 

--- a/examples/jsm/renderers/Projector.js
+++ b/examples/jsm/renderers/Projector.js
@@ -124,6 +124,8 @@ class RenderableSprite {
  * This class can project a given scene in 3D space into a 2D representation
  * used for rendering with a 2D API. `Projector` is currently used by {@link SVGRenderer}
  * and was previously used by the legacy `CanvasRenderer`.
+ *
+ * @three_import import { Projector } from 'three/addons/renderers/Projector.js';
  */
 class Projector {
 

--- a/examples/jsm/renderers/SVGRenderer.js
+++ b/examples/jsm/renderers/SVGRenderer.js
@@ -19,6 +19,7 @@ import {
  * Can be used to wrap SVG elements into a 3D object.
  *
  * @augments Object3D
+ * @three_import import { SVGObject } from 'three/addons/renderers/SVGRenderer.js';
  */
 class SVGObject extends Object3D {
 
@@ -69,6 +70,8 @@ class SVGObject extends Object3D {
  * - No advanced shading.
  * - No texture support.
  * - No shadow support.
+ *
+ * @three_import import { SVGRenderer } from 'three/addons/renderers/SVGRenderer.js';
  */
 class SVGRenderer {
 

--- a/examples/jsm/shaders/ACESFilmicToneMappingShader.js
+++ b/examples/jsm/shaders/ACESFilmicToneMappingShader.js
@@ -1,4 +1,7 @@
-/** @module ACESFilmicToneMappingShader */
+/**
+ * @module ACESFilmicToneMappingShader
+ * @three_import import { ACESFilmicToneMappingShader } from 'three/addons/shaders/ACESFilmicToneMappingShader.js';
+ */
 
 /**
  * ACES Filmic Tone Mapping Shader by Stephen Hill.

--- a/examples/jsm/shaders/AfterimageShader.js
+++ b/examples/jsm/shaders/AfterimageShader.js
@@ -1,4 +1,7 @@
-/** @module AfterimageShader */
+/**
+ * @module AfterimageShader
+ * @three_import import { AfterimageShader } from 'three/addons/shaders/AfterimageShader.js';
+ */
 
 /**
  * Inspired by [Three.js FBO motion trails]{@link https://codepen.io/brunoimbrizi/pen/MoRJaN?page=1&}.

--- a/examples/jsm/shaders/BasicShader.js
+++ b/examples/jsm/shaders/BasicShader.js
@@ -1,4 +1,7 @@
-/** @module BasicShader */
+/**
+ * @module BasicShader
+ * @three_import import { BasicShader } from 'three/addons/shaders/BasicShader.js';
+ */
 
 /**
  * Simple shader for testing.

--- a/examples/jsm/shaders/BleachBypassShader.js
+++ b/examples/jsm/shaders/BleachBypassShader.js
@@ -1,5 +1,8 @@
 
-/** @module BleachBypassShader */
+/**
+ * @module BleachBypassShader
+ * @three_import import { BleachBypassShader } from 'three/addons/shaders/BleachBypassShader.js';
+ */
 
 /**
  * Bleach bypass shader [http://en.wikipedia.org/wiki/Bleach_bypass] based on

--- a/examples/jsm/shaders/BlendShader.js
+++ b/examples/jsm/shaders/BlendShader.js
@@ -1,4 +1,7 @@
-/** @module BlendShader */
+/**
+ * @module BlendShader
+ * @three_import import { BlendShader } from 'three/addons/shaders/BlendShader.js';
+ */
 
 /**
  * Blends two textures.

--- a/examples/jsm/shaders/BokehShader.js
+++ b/examples/jsm/shaders/BokehShader.js
@@ -1,4 +1,7 @@
-/** @module BokehShader */
+/**
+ * @module BokehShader
+ * @three_import import { BokehShader } from 'three/addons/shaders/BokehShader.js';
+ */
 
 /**
  * Depth-of-field shader with bokeh ported from

--- a/examples/jsm/shaders/BokehShader2.js
+++ b/examples/jsm/shaders/BokehShader2.js
@@ -2,7 +2,10 @@ import {
 	Vector2
 } from 'three';
 
-/** @module BokehShader2 */
+/**
+ * @module BokehShader2
+ * @three_import import { BokehShader, BokehDepthShader } from 'three/addons/shaders/BokehShader2.js';
+ */
 
 /**
  * Depth-of-field shader with bokeh ported from

--- a/examples/jsm/shaders/BrightnessContrastShader.js
+++ b/examples/jsm/shaders/BrightnessContrastShader.js
@@ -1,4 +1,7 @@
-/** @module BrightnessContrastShader */
+/**
+ * @module BrightnessContrastShader
+ * @three_import import { BrightnessContrastShader } from 'three/addons/shaders/BrightnessContrastShader.js';
+ */
 
 /**
  * Brightness and contrast adjustment {@link https://github.com/evanw/glfx.js}.

--- a/examples/jsm/shaders/ColorCorrectionShader.js
+++ b/examples/jsm/shaders/ColorCorrectionShader.js
@@ -2,7 +2,10 @@ import {
 	Vector3
 } from 'three';
 
-/** @module ColorCorrectionShader */
+/**
+ * @module ColorCorrectionShader
+ * @three_import import { ColorCorrectionShader } from 'three/addons/shaders/ColorCorrectionShader.js';
+ */
 
 /**
  * Color correction shader.

--- a/examples/jsm/shaders/ColorifyShader.js
+++ b/examples/jsm/shaders/ColorifyShader.js
@@ -2,7 +2,10 @@ import {
 	Color
 } from 'three';
 
-/** @module ColorifyShader */
+/**
+ * @module ColorifyShader
+ * @three_import import { ColorifyShader } from 'three/addons/shaders/ColorifyShader.js';
+ */
 
 /**
  * Colorify shader.

--- a/examples/jsm/shaders/ConvolutionShader.js
+++ b/examples/jsm/shaders/ConvolutionShader.js
@@ -2,7 +2,10 @@ import {
 	Vector2
 } from 'three';
 
-/** @module ConvolutionShader */
+/**
+ * @module ConvolutionShader
+ * @three_import import { ConvolutionShader } from 'three/addons/shaders/ConvolutionShader.js';
+ */
 
 /**
  * Convolution shader ported from o3d sample to WebGL / GLSL.

--- a/examples/jsm/shaders/CopyShader.js
+++ b/examples/jsm/shaders/CopyShader.js
@@ -1,4 +1,7 @@
-/** @module CopyShader */
+/**
+ * @module CopyShader
+ * @three_import import { CopyShader } from 'three/addons/shaders/CopyShader.js';
+ */
 
 /**
  * Full-screen copy shader pass.

--- a/examples/jsm/shaders/DOFMipMapShader.js
+++ b/examples/jsm/shaders/DOFMipMapShader.js
@@ -1,4 +1,7 @@
-/** @module DOFMipMapShader */
+/**
+ * @module DOFMipMapShader
+ * @three_import import { DOFMipMapShader } from 'three/addons/shaders/DOFMipMapShader.js';
+ */
 
 /**
  * Depth-of-field shader using mipmaps from Matt Handley @applmak.

--- a/examples/jsm/shaders/DepthLimitedBlurShader.js
+++ b/examples/jsm/shaders/DepthLimitedBlurShader.js
@@ -2,7 +2,10 @@ import {
 	Vector2
 } from 'three';
 
-/** @module DepthLimitedBlurShader */
+/**
+ * @module DepthLimitedBlurShader
+ * @three_import import { DepthLimitedBlurShader, BlurShaderUtils } from 'three/addons/shaders/DepthLimitedBlurShader.js';
+ */
 
 /**
  * TODO

--- a/examples/jsm/shaders/DigitalGlitch.js
+++ b/examples/jsm/shaders/DigitalGlitch.js
@@ -1,4 +1,7 @@
-/** @module DigitalGlitch */
+/**
+ * @module DigitalGlitch
+ * @three_import import { DigitalGlitch } from 'three/addons/shaders/DigitalGlitch.js';
+ */
 
 /**
  * Digital glitch shader.

--- a/examples/jsm/shaders/DotScreenShader.js
+++ b/examples/jsm/shaders/DotScreenShader.js
@@ -2,7 +2,10 @@ import {
 	Vector2
 } from 'three';
 
-/** @module DotScreenShader */
+/**
+ * @module DotScreenShader
+ * @three_import import { DotScreenShader } from 'three/addons/shaders/DotScreenShader.js';
+ */
 
 /**
  * Dot screen shader based on [glfx.js sepia shader]{@link https://github.com/evanw/glfx.js}.

--- a/examples/jsm/shaders/ExposureShader.js
+++ b/examples/jsm/shaders/ExposureShader.js
@@ -1,4 +1,7 @@
-/** @module ExposureShader */
+/**
+ * @module ExposureShader
+ * @three_import import { ExposureShader } from 'three/addons/shaders/ExposureShader.js';
+ */
 
 /**
  * TODO

--- a/examples/jsm/shaders/FXAAShader.js
+++ b/examples/jsm/shaders/FXAAShader.js
@@ -2,7 +2,10 @@ import {
 	Vector2
 } from 'three';
 
-/** @module FXAAShader */
+/**
+ * @module FXAAShader
+ * @three_import import { FXAAShader } from 'three/addons/shaders/FXAAShader.js';
+ */
 
 /**
  * FXAA algorithm from NVIDIA, C# implementation by Jasper Flick, GLSL port by Dave Hoskins.

--- a/examples/jsm/shaders/FilmShader.js
+++ b/examples/jsm/shaders/FilmShader.js
@@ -1,4 +1,7 @@
-/** @module FilmShader */
+/**
+ * @module FilmShader
+ * @three_import import { FilmShader } from 'three/addons/shaders/FilmShader.js';
+ */
 
 /**
  * TODO

--- a/examples/jsm/shaders/FocusShader.js
+++ b/examples/jsm/shaders/FocusShader.js
@@ -1,4 +1,7 @@
-/** @module FocusShader */
+/**
+ * @module FocusShader
+ * @three_import import { FocusShader } from 'three/addons/shaders/FocusShader.js';
+ */
 
 /**
  * Focus shader based on [PaintEffect postprocess from ro.me]{@link http://code.google.com/p/3-dreams-of-black/source/browse/deploy/js/effects/PaintEffect.js}.

--- a/examples/jsm/shaders/FreiChenShader.js
+++ b/examples/jsm/shaders/FreiChenShader.js
@@ -2,7 +2,10 @@ import {
 	Vector2
 } from 'three';
 
-/** @module FreiChenShader */
+/**
+ * @module FreiChenShader
+ * @three_import import { FreiChenShader } from 'three/addons/shaders/FreiChenShader.js';
+ */
 
 /**
  * Edge Detection Shader using Frei-Chen filter.

--- a/examples/jsm/shaders/GTAOShader.js
+++ b/examples/jsm/shaders/GTAOShader.js
@@ -6,7 +6,10 @@ import {
 	Vector3,
 } from 'three';
 
-/** @module GTAOShader */
+/**
+ * @module GTAOShader
+ * @three_import import { GTAOShader } from 'three/addons/shaders/GTAOShader.js';
+ */
 
 /**
  * GTAO shader. Use by {@link GTAOPass}.

--- a/examples/jsm/shaders/GammaCorrectionShader.js
+++ b/examples/jsm/shaders/GammaCorrectionShader.js
@@ -1,4 +1,7 @@
-/** @module GammaCorrectionShader */
+/**
+ * @module GammaCorrectionShader
+ * @three_import import { GammaCorrectionShader } from 'three/addons/shaders/GammaCorrectionShader.js';
+ */
 
 /**
  * Gamma Correction Shader

--- a/examples/jsm/shaders/GodRaysShader.js
+++ b/examples/jsm/shaders/GodRaysShader.js
@@ -3,7 +3,10 @@ import {
 	Vector3
 } from 'three';
 
-/** @module GodRaysShader */
+/**
+ * @module GodRaysShader
+ * @three_import import * as GodRaysShader from 'three/addons/shaders/GodRaysShader.js';
+ */
 
 /**
  * God-rays (crepuscular rays)

--- a/examples/jsm/shaders/HalftoneShader.js
+++ b/examples/jsm/shaders/HalftoneShader.js
@@ -1,4 +1,7 @@
-/** @module HalftoneShader */
+/**
+ * @module HalftoneShader
+ * @three_import import { HalftoneShader } from 'three/addons/shaders/HalftoneShader.js';
+ */
 
 /**
  * RGB Halftone shader.

--- a/examples/jsm/shaders/HorizontalBlurShader.js
+++ b/examples/jsm/shaders/HorizontalBlurShader.js
@@ -1,4 +1,7 @@
-/** @module HorizontalBlurShader */
+/**
+ * @module HorizontalBlurShader
+ * @three_import import { HorizontalBlurShader } from 'three/addons/shaders/HorizontalBlurShader.js';
+ */
 
 /**
  * Two pass Gaussian blur filter (horizontal and vertical blur shaders).

--- a/examples/jsm/shaders/HorizontalTiltShiftShader.js
+++ b/examples/jsm/shaders/HorizontalTiltShiftShader.js
@@ -1,4 +1,7 @@
-/** @module HorizontalTiltShiftShader */
+/**
+ * @module HorizontalTiltShiftShader
+ * @three_import import { HorizontalTiltShiftShader } from 'three/addons/shaders/HorizontalTiltShiftShader.js';
+ */
 
 /**
  * Simple fake tilt-shift effect, modulating two pass Gaussian blur (see above) by vertical position.

--- a/examples/jsm/shaders/HueSaturationShader.js
+++ b/examples/jsm/shaders/HueSaturationShader.js
@@ -1,4 +1,7 @@
-/** @module HueSaturationShader */
+/**
+ * @module HueSaturationShader
+ * @three_import import { HueSaturationShader } from 'three/addons/shaders/HueSaturationShader.js';
+ */
 
 /**
  * Hue and saturation adjustment, {@link https://github.com/evanw/glfx.js}.

--- a/examples/jsm/shaders/KaleidoShader.js
+++ b/examples/jsm/shaders/KaleidoShader.js
@@ -1,4 +1,7 @@
-/** @module KaleidoShader */
+/**
+ * @module KaleidoShader
+ * @three_import import { KaleidoShader } from 'three/addons/shaders/KaleidoShader.js';
+ */
 
 /**
  * Kaleidoscope Shader.

--- a/examples/jsm/shaders/LuminosityHighPassShader.js
+++ b/examples/jsm/shaders/LuminosityHighPassShader.js
@@ -2,7 +2,10 @@ import {
 	Color
 } from 'three';
 
-/** @module LuminosityHighPassShader */
+/**
+ * @module LuminosityHighPassShader
+ * @three_import import { LuminosityHighPassShader } from 'three/addons/shaders/LuminosityHighPassShader.js';
+ */
 
 /**
  * Luminosity high pass shader.

--- a/examples/jsm/shaders/LuminosityShader.js
+++ b/examples/jsm/shaders/LuminosityShader.js
@@ -1,4 +1,7 @@
-/** @module LuminosityShader */
+/**
+ * @module LuminosityShader
+ * @three_import import { LuminosityShader } from 'three/addons/shaders/LuminosityShader.js';
+ */
 
 /**
  * Luminosity shader.

--- a/examples/jsm/shaders/MirrorShader.js
+++ b/examples/jsm/shaders/MirrorShader.js
@@ -1,4 +1,7 @@
-/** @module MirrorShader */
+/**
+ * @module MirrorShader
+ * @three_import import { MirrorShader } from 'three/addons/shaders/MirrorShader.js';
+ */
 
 /**
  * Copies half the input to the other half.

--- a/examples/jsm/shaders/NormalMapShader.js
+++ b/examples/jsm/shaders/NormalMapShader.js
@@ -2,7 +2,10 @@ import {
 	Vector2
 } from 'three';
 
-/** @module NormalMapShader */
+/**
+ * @module NormalMapShader
+ * @three_import import { NormalMapShader } from 'three/addons/shaders/NormalMapShader.js';
+ */
 
 /**
  * Normal map shader, compute normals from heightmap.

--- a/examples/jsm/shaders/OutputShader.js
+++ b/examples/jsm/shaders/OutputShader.js
@@ -1,4 +1,7 @@
-/** @module OutputShader */
+/**
+ * @module OutputShader
+ * @three_import import { OutputShader } from 'three/addons/shaders/OutputShader.js';
+ */
 
 /**
  * Performs tone mapping and color space conversion for

--- a/examples/jsm/shaders/PoissonDenoiseShader.js
+++ b/examples/jsm/shaders/PoissonDenoiseShader.js
@@ -4,7 +4,10 @@ import {
 	Vector3,
 } from 'three';
 
-/** @module PoissonDenoiseShader */
+/**
+ * @module PoissonDenoiseShader
+ * @three_import import { PoissonDenoiseShader } from 'three/addons/shaders/PoissonDenoiseShader.js';
+ */
 
 /**
  * Poisson Denoise Shader.

--- a/examples/jsm/shaders/RGBShiftShader.js
+++ b/examples/jsm/shaders/RGBShiftShader.js
@@ -1,4 +1,7 @@
-/** @module RGBShiftShader */
+/**
+ * @module RGBShiftShader
+ * @three_import import { RGBShiftShader } from 'three/addons/shaders/RGBShiftShader.js';
+ */
 
 /**
  * RGB Shift Shader

--- a/examples/jsm/shaders/SAOShader.js
+++ b/examples/jsm/shaders/SAOShader.js
@@ -3,7 +3,10 @@ import {
 	Vector2
 } from 'three';
 
-/** @module SAOShader */
+/**
+ * @module SAOShader
+ * @three_import import { SAOShader } from 'three/addons/shaders/SAOShader.js';
+ */
 
 /**
  * SAO shader.

--- a/examples/jsm/shaders/SMAAShader.js
+++ b/examples/jsm/shaders/SMAAShader.js
@@ -10,6 +10,7 @@ import {
  * - {@link https://github.com/iryoku/smaa/releases/tag/v2.8}
  *
  * @module SMAAShader
+ * @three_import import { SMAAShader } from 'three/addons/shaders/SMAAShader.js';
  */
 
 /**

--- a/examples/jsm/shaders/SSAOShader.js
+++ b/examples/jsm/shaders/SSAOShader.js
@@ -3,7 +3,10 @@ import {
 	Vector2
 } from 'three';
 
-/** @module SSAOShader */
+/**
+ * @module SSAOShader
+ * @three_import import { SSAOShader } from 'three/addons/shaders/SSAOShader.js';
+ */
 
 /**
  * SSAO shader.

--- a/examples/jsm/shaders/SSRShader.js
+++ b/examples/jsm/shaders/SSRShader.js
@@ -11,6 +11,7 @@ import {
  * - [3D Game Shaders For Beginners, Screen Space Reflection (SSR)]{@link https://lettier.github.io/3d-game-shaders-for-beginners/screen-space-reflection.html}.
  *
  * @module SSRShader
+ * @three_import import * as SSRShader from 'three/addons/shaders/SSRShader.js';
  */
 
 /**

--- a/examples/jsm/shaders/SepiaShader.js
+++ b/examples/jsm/shaders/SepiaShader.js
@@ -1,4 +1,7 @@
-/** @module SepiaShader */
+/**
+ * @module SepiaShader
+ * @three_import import { SepiaShader } from 'three/addons/shaders/SepiaShader.js';
+ */
 
 /**
  * Sepia tone shader based on [glfx.js sepia shader]{@link https://github.com/evanw/glfx.js}.

--- a/examples/jsm/shaders/SobelOperatorShader.js
+++ b/examples/jsm/shaders/SobelOperatorShader.js
@@ -2,7 +2,10 @@ import {
 	Vector2
 } from 'three';
 
-/** @module SobelOperatorShader */
+/**
+ * @module SobelOperatorShader
+ * @three_import import { SobelOperatorShader } from 'three/addons/shaders/SobelOperatorShader.js';
+ */
 
 /**
  * Sobel Edge Detection (see {@link https://youtu.be/uihBwtPIBxM}).

--- a/examples/jsm/shaders/SubsurfaceScatteringShader.js
+++ b/examples/jsm/shaders/SubsurfaceScatteringShader.js
@@ -14,7 +14,10 @@ function replaceAll( string, find, replace ) {
 const meshphong_frag_head = ShaderChunk[ 'meshphong_frag' ].slice( 0, ShaderChunk[ 'meshphong_frag' ].indexOf( 'void main() {' ) );
 const meshphong_frag_body = ShaderChunk[ 'meshphong_frag' ].slice( ShaderChunk[ 'meshphong_frag' ].indexOf( 'void main() {' ) );
 
-/** @module SubsurfaceScatteringShader */
+/**
+ * @module SubsurfaceScatteringShader
+ * @three_import import { SubsurfaceScatteringShader } from 'three/addons/shaders/SubsurfaceScatteringShader.js';
+ */
 
 /**
  * Subsurface Scattering shader.

--- a/examples/jsm/shaders/TechnicolorShader.js
+++ b/examples/jsm/shaders/TechnicolorShader.js
@@ -1,4 +1,7 @@
-/** @module TriangleBlurShader */
+/**
+ * @module TriangleBlurShader
+ * @three_import import { TriangleBlurShader } from 'three/addons/shaders/TriangleBlurShader.js';
+ */
 
 /**
  * Simulates the look of the two-strip technicolor process popular in early 20th century films.

--- a/examples/jsm/shaders/ToonShader.js
+++ b/examples/jsm/shaders/ToonShader.js
@@ -7,7 +7,8 @@ import {
  * Collection of toon shaders.
  *
  * @module TriangleBlurShader
- * */
+ * @three_import import * as ToonShader from 'three/addons/shaders/ToonShader.js';
+ */
 
 /**
  * Toon1 shader.

--- a/examples/jsm/shaders/TriangleBlurShader.js
+++ b/examples/jsm/shaders/TriangleBlurShader.js
@@ -2,7 +2,10 @@ import {
 	Vector2
 } from 'three';
 
-/** @module TriangleBlurShader */
+/**
+ * @module TriangleBlurShader
+ * @three_import import { TriangleBlurShader } from 'three/addons/shaders/TriangleBlurShader.js';
+ */
 
 /**
  * Triangle blur shader based on [glfx.js triangle blur shader]{@link https://github.com/evanw/glfx.js}.

--- a/examples/jsm/shaders/UnpackDepthRGBAShader.js
+++ b/examples/jsm/shaders/UnpackDepthRGBAShader.js
@@ -1,4 +1,7 @@
-/** @module UnpackDepthRGBAShader */
+/**
+ * @module UnpackDepthRGBAShader
+ * @three_import import { UnpackDepthRGBAShader } from 'three/addons/shaders/UnpackDepthRGBAShader.js';
+ */
 
 /**
  * Unpack RGBA depth shader that shows RGBA encoded depth as monochrome color.

--- a/examples/jsm/shaders/VelocityShader.js
+++ b/examples/jsm/shaders/VelocityShader.js
@@ -4,7 +4,10 @@ import {
 	Matrix4
 } from 'three';
 
-/** @module VelocityShader */
+/**
+ * @module VelocityShader
+ * @three_import import { VelocityShader } from 'three/addons/shaders/VelocityShader.js';
+ */
 
 /**
  * Mesh velocity shader by @bhouston.

--- a/examples/jsm/shaders/VerticalBlurShader.js
+++ b/examples/jsm/shaders/VerticalBlurShader.js
@@ -1,4 +1,7 @@
-/** @module VerticalBlurShader */
+/**
+ * @module VerticalBlurShader
+ * @three_import import { VerticalBlurShader } from 'three/addons/shaders/VerticalBlurShader.js';
+ */
 
 /**
  * Two pass Gaussian blur filter (horizontal and vertical blur shaders)

--- a/examples/jsm/shaders/VerticalTiltShiftShader.js
+++ b/examples/jsm/shaders/VerticalTiltShiftShader.js
@@ -1,4 +1,7 @@
-/** @module VerticalTiltShiftShader */
+/**
+ * @module VerticalTiltShiftShader
+ * @three_import import { VerticalTiltShiftShader } from 'three/addons/shaders/VerticalTiltShiftShader.js';
+ */
 
 /**
  * Simple fake tilt-shift effect, modulating two pass Gaussian blur (see above) by vertical position

--- a/examples/jsm/shaders/VignetteShader.js
+++ b/examples/jsm/shaders/VignetteShader.js
@@ -1,4 +1,7 @@
-/** @module VignetteShader */
+/**
+ * @module VignetteShader
+ * @three_import import { VignetteShader } from 'three/addons/shaders/VignetteShader.js';
+ */
 
 /**
  * Based on [PaintEffect postprocess from ro.me]{@link http://code.google.com/p/3-dreams-of-black/source/browse/deploy/js/effects/PaintEffect.js}.

--- a/examples/jsm/shaders/VolumeShader.js
+++ b/examples/jsm/shaders/VolumeShader.js
@@ -3,7 +3,10 @@ import {
 	Vector3
 } from 'three';
 
-/** @module VolumeShader */
+/**
+ * @module VolumeShader
+ * @three_import import { VolumeRenderShader1 } from 'three/addons/shaders/VolumeShader.js';
+ */
 
 /**
  * Shaders to render 3D volumes using raycasting.

--- a/examples/jsm/shaders/WaterRefractionShader.js
+++ b/examples/jsm/shaders/WaterRefractionShader.js
@@ -1,4 +1,7 @@
-/** @module WaterRefractionShader */
+/**
+ * @module WaterRefractionShader
+ * @three_import import { WaterRefractionShader } from 'three/addons/shaders/WaterRefractionShader.js';
+ */
 
 /**
  * Basic water refraction shader.

--- a/examples/jsm/textures/FlakesTexture.js
+++ b/examples/jsm/textures/FlakesTexture.js
@@ -1,6 +1,8 @@
 /**
  * Utility class for generating a flakes texture image. This image might be used
  * as a normal map to produce a car paint like effect.
+ *
+ * @three_import import { FlakesTexture } from 'three/addons/textures/FlakesTexture.js';
  */
 class FlakesTexture {
 

--- a/examples/jsm/transpiler/Transpiler.js
+++ b/examples/jsm/transpiler/Transpiler.js
@@ -4,6 +4,8 @@
  * `Transpiler` can only be used to convert GLSL into TSL right now. It is intended
  * to support developers when they want to migrate their custom materials from the
  * current to the new node-based material system.
+ *
+ * @three_import import Transpiler from 'three/addons/transpiler/Transpiler.js';
  */
 class Transpiler {
 

--- a/examples/jsm/tsl/display/AfterImageNode.js
+++ b/examples/jsm/tsl/display/AfterImageNode.js
@@ -10,6 +10,7 @@ let _rendererState;
  * Post processing node for creating an after image effect.
  *
  * @augments TempNode
+ * @three_import import { afterImage } from 'three/addons/tsl/display/AfterImageNode.js';
  */
 class AfterImageNode extends TempNode {
 

--- a/examples/jsm/tsl/display/AnaglyphPassNode.js
+++ b/examples/jsm/tsl/display/AnaglyphPassNode.js
@@ -6,6 +6,7 @@ import StereoCompositePassNode from './StereoCompositePassNode.js';
  * A render pass node that creates an anaglyph effect.
  *
  * @augments StereoCompositePassNode
+ * @three_import import { anaglyphPass } from 'three/addons/tsl/display/AnaglyphPassNode.js';
  */
 class AnaglyphPassNode extends StereoCompositePassNode {
 

--- a/examples/jsm/tsl/display/AnamorphicNode.js
+++ b/examples/jsm/tsl/display/AnamorphicNode.js
@@ -9,6 +9,7 @@ let _rendererState;
  * Post processing node for adding an anamorphic flare effect.
  *
  * @augments TempNode
+ * @three_import import { anamorphic } from 'three/addons/tsl/display/AnamorphicNode.js';
  */
 class AnamorphicNode extends TempNode {
 

--- a/examples/jsm/tsl/display/BloomNode.js
+++ b/examples/jsm/tsl/display/BloomNode.js
@@ -40,6 +40,7 @@ let _rendererState;
  * postProcessing.outputNode = scenePassColor.add( bloomPass );
  * ```
  * @augments TempNode
+ * @three_import import { bloom } from 'three/addons/tsl/display/BloomNode.js';
  */
 class BloomNode extends TempNode {
 

--- a/examples/jsm/tsl/display/DenoiseNode.js
+++ b/examples/jsm/tsl/display/DenoiseNode.js
@@ -11,6 +11,7 @@ import { SimplexNoise } from '../../math/SimplexNoise.js';
  * Reference: {@link https://openaccess.thecvf.com/content/WACV2021/papers/Khademi_Self-Supervised_Poisson-Gaussian_Denoising_WACV_2021_paper.pdf}.
  *
  * @augments TempNode
+ * @three_import import { denoise } from 'three/addons/tsl/display/DenoiseNode.js';
  */
 class DenoiseNode extends TempNode {
 

--- a/examples/jsm/tsl/display/DepthOfFieldNode.js
+++ b/examples/jsm/tsl/display/DepthOfFieldNode.js
@@ -5,6 +5,7 @@ import { convertToTexture, nodeObject, Fn, uv, uniform, vec2, vec4, clamp } from
  * Post processing node for creating depth of field (DOF) effect.
  *
  * @augments TempNode
+ * @three_import import { dof } from 'three/addons/tsl/display/DepthOfFieldNode.js';
  */
 class DepthOfFieldNode extends TempNode {
 

--- a/examples/jsm/tsl/display/DotScreenNode.js
+++ b/examples/jsm/tsl/display/DotScreenNode.js
@@ -5,6 +5,7 @@ import { nodeObject, Fn, uv, uniform, vec2, vec3, sin, cos, add, vec4, screenSiz
  * Post processing node for creating dot-screen effect.
  *
  * @augments TempNode
+ * @three_import import { dotScreen } from 'three/addons/tsl/display/DotScreenNode.js';
  */
 class DotScreenNode extends TempNode {
 

--- a/examples/jsm/tsl/display/FXAANode.js
+++ b/examples/jsm/tsl/display/FXAANode.js
@@ -6,6 +6,7 @@ import { nodeObject, Fn, uniformArray, select, float, NodeUpdateType, uv, dot, c
  * so tone mapping and color space conversion must happen before the anti-aliasing.
  *
  * @augments TempNode
+ * @three_import import { fxaa } from 'three/addons/tsl/display/FXAANode.js';
  */
 class FXAANode extends TempNode {
 

--- a/examples/jsm/tsl/display/FilmNode.js
+++ b/examples/jsm/tsl/display/FilmNode.js
@@ -5,6 +5,7 @@ import { rand, Fn, fract, time, uv, clamp, mix, vec4, nodeProxy } from 'three/ts
  * Post processing node for creating a film grain effect.
  *
  * @augments TempNode
+ * @three_import import { film } from 'three/addons/tsl/display/FilmNode.js';
  */
 class FilmNode extends TempNode {
 

--- a/examples/jsm/tsl/display/GTAONode.js
+++ b/examples/jsm/tsl/display/GTAONode.js
@@ -29,6 +29,7 @@ let _rendererState;
  * Reference: {@link https://www.activision.com/cdn/research/Practical_Real_Time_Strategies_for_Accurate_Indirect_Occlusion_NEW%20VERSION_COLOR.pdf}.
  *
  * @augments TempNode
+ * @three_import import { ao } from 'three/addons/tsl/display/GTAONode.js';
  */
 class GTAONode extends TempNode {
 

--- a/examples/jsm/tsl/display/GaussianBlurNode.js
+++ b/examples/jsm/tsl/display/GaussianBlurNode.js
@@ -35,6 +35,7 @@ const unpremult = /*@__PURE__*/ Fn( ( [ color ] ) => {
  * Post processing node for creating a gaussian blur effect.
  *
  * @augments TempNode
+ * @three_import import { gaussianBlur, premultipliedGaussianBlur } from 'three/addons/tsl/display/GaussianBlurNode.js';
  */
 class GaussianBlurNode extends TempNode {
 

--- a/examples/jsm/tsl/display/LensflareNode.js
+++ b/examples/jsm/tsl/display/LensflareNode.js
@@ -14,6 +14,7 @@ let _rendererState;
  * - {@link https://john-chapman.github.io/2017/11/05/pseudo-lens-flare.html}.
  *
  * @augments TempNode
+ * @three_import import { lensflare } from 'three/addons/tsl/display/LensflareNode.js';
  */
 class LensflareNode extends TempNode {
 

--- a/examples/jsm/tsl/display/Lut3DNode.js
+++ b/examples/jsm/tsl/display/Lut3DNode.js
@@ -5,6 +5,7 @@ import { nodeObject, Fn, float, uniform, vec3, vec4, mix } from 'three/tsl';
  * A post processing node for color grading via lookup tables.
  *
  * @augments TempNode
+ * @three_import import { lut3D } from 'three/addons/tsl/display/Lut3DNode.js';
  */
 class Lut3DNode extends TempNode {
 

--- a/examples/jsm/tsl/display/OutlineNode.js
+++ b/examples/jsm/tsl/display/OutlineNode.js
@@ -40,6 +40,7 @@ let _rendererState;
  * ```
  *
  * @augments TempNode
+ * @three_import import { outline } from 'three/addons/tsl/display/OutlineNode.js';
  */
 class OutlineNode extends TempNode {
 

--- a/examples/jsm/tsl/display/ParallaxBarrierPassNode.js
+++ b/examples/jsm/tsl/display/ParallaxBarrierPassNode.js
@@ -6,6 +6,7 @@ import StereoCompositePassNode from './StereoCompositePassNode.js';
  * A render pass node that creates a parallax barrier effect.
  *
  * @augments StereoCompositePassNode
+ * @three_import import { parallaxBarrierPass } from 'three/addons/tsl/display/ParallaxBarrierPassNode.js';
  */
 class ParallaxBarrierPassNode extends StereoCompositePassNode {
 

--- a/examples/jsm/tsl/display/PixelationPassNode.js
+++ b/examples/jsm/tsl/display/PixelationPassNode.js
@@ -219,6 +219,7 @@ const pixelation = ( node, depthNode, normalNode, pixelSize = 6, normalEdgeStren
  * A special render pass node that renders the scene with a pixelation effect.
  *
  * @augments PassNode
+ * @three_import import { pixelationPass } from 'three/addons/tsl/display/PixelationPassNode.js';
  */
 class PixelationPassNode extends PassNode {
 

--- a/examples/jsm/tsl/display/RGBShiftNode.js
+++ b/examples/jsm/tsl/display/RGBShiftNode.js
@@ -6,6 +6,7 @@ import { nodeObject, Fn, uv, uniform, vec2, sin, cos, vec4, convertToTexture } f
  * separates color channels and offsets them from each other.
  *
  * @augments TempNode
+ * @three_import import { rgbShift } from 'three/addons/tsl/display/RGBShiftNode.js';
  */
 class RGBShiftNode extends TempNode {
 

--- a/examples/jsm/tsl/display/SMAANode.js
+++ b/examples/jsm/tsl/display/SMAANode.js
@@ -15,6 +15,7 @@ let _rendererState;
  * Reference: {@link https://github.com/iryoku/smaa/releases/tag/v2.8}.
  *
  * @augments TempNode
+ * @three_import import { smaa } from 'three/addons/tsl/display/SMAANode.js';
  */
 class SMAANode extends TempNode {
 

--- a/examples/jsm/tsl/display/SSAAPassNode.js
+++ b/examples/jsm/tsl/display/SSAAPassNode.js
@@ -15,6 +15,7 @@ let _rendererState;
  * Reference: {@link https://en.wikipedia.org/wiki/Supersampling}
  *
  * @augments PassNode
+ * @three_import import { ssaaPass } from 'three/addons/tsl/display/SSAAPassNode.js';
  */
 class SSAAPassNode extends PassNode {
 

--- a/examples/jsm/tsl/display/SSRNode.js
+++ b/examples/jsm/tsl/display/SSRNode.js
@@ -11,6 +11,7 @@ let _rendererState;
  * Reference: {@link https://lettier.github.io/3d-game-shaders-for-beginners/screen-space-reflection.html}
  *
  * @augments TempNode
+ * @three_import import { ssr } from 'three/addons/tsl/display/SSRNode.js';
  */
 class SSRNode extends TempNode {
 

--- a/examples/jsm/tsl/display/SobelOperatorNode.js
+++ b/examples/jsm/tsl/display/SobelOperatorNode.js
@@ -7,6 +7,7 @@ import { nodeObject, Fn, uv, uniform, convertToTexture, vec2, vec3, vec4, mat3, 
  * space conversion.
  *
  * @augments TempNode
+ * @three_import import { sobel } from 'three/addons/tsl/display/SobelOperatorNode.js';
  */
 class SobelOperatorNode extends TempNode {
 

--- a/examples/jsm/tsl/display/StereoCompositePassNode.js
+++ b/examples/jsm/tsl/display/StereoCompositePassNode.js
@@ -15,6 +15,7 @@ let _rendererState;
  *
  * @abstract
  * @augments PassNode
+ * @three_import import { StereoCompositePassNode } from 'three/addons/tsl/display/StereoCompositePassNode.js';
  */
 class StereoCompositePassNode extends PassNode {
 

--- a/examples/jsm/tsl/display/StereoPassNode.js
+++ b/examples/jsm/tsl/display/StereoPassNode.js
@@ -9,6 +9,7 @@ let _rendererState;
  * A special render pass node that renders the scene as a stereoscopic image.
  *
  * @augments PassNode
+ * @three_import import { stereoPass } from 'three/addons/tsl/display/StereoPassNode.js';
  */
 class StereoPassNode extends PassNode {
 

--- a/examples/jsm/tsl/display/TRAAPassNode.js
+++ b/examples/jsm/tsl/display/TRAAPassNode.js
@@ -17,6 +17,7 @@ let _rendererState;
  * - {@link https://www.elopezr.com/temporal-aa-and-the-quest-for-the-holy-trail/}
  *
  * @augments PassNode
+ * @three_import import { traaPass } from 'three/addons/tsl/display/TRAAPassNode.js';
  */
 class TRAAPassNode extends PassNode {
 

--- a/examples/jsm/tsl/display/TransitionNode.js
+++ b/examples/jsm/tsl/display/TransitionNode.js
@@ -5,6 +5,7 @@ import { nodeObject, Fn, float, uv, convertToTexture, vec4, If, int, clamp, sub,
  * Post processing node for creating a transition effect between scenes.
  *
  * @augments TempNode
+ * @three_import import { transition } from 'three/addons/tsl/display/TransitionNode.js';
  */
 class TransitionNode extends TempNode {
 

--- a/examples/jsm/tsl/display/hashBlur.js
+++ b/examples/jsm/tsl/display/hashBlur.js
@@ -5,7 +5,6 @@ import { float, Fn, vec2, uv, sin, rand, degrees, cos, Loop, vec4 } from 'three/
  *
  * Reference: {@link https://www.shadertoy.com/view/4lXXWn}.
  *
- * @tsl
  * @function
  * @param {Node<vec4>} textureNode - The texture node that should be blurred.
  * @param {Node<float>} [bluramount=float(0.1)] - This node determines the amount of blur.

--- a/examples/jsm/tsl/lighting/TiledLightsNode.js
+++ b/examples/jsm/tsl/lighting/TiledLightsNode.js
@@ -40,6 +40,7 @@ const _size = /*@__PURE__*/ new Vector2();
  * a custom implementation.
  *
  * @augments LightsNode
+ * @three_import import { tiledLights } from 'three/addons/tsl/lighting/TiledLightsNode.js';
  */
 class TiledLightsNode extends LightsNode {
 

--- a/examples/jsm/tsl/math/Bayer.js
+++ b/examples/jsm/tsl/math/Bayer.js
@@ -1,7 +1,10 @@
 import { TextureLoader } from 'three';
 import { Fn, int, ivec2, textureLoad } from 'three/tsl';
 
-/** @module Bayer */
+/**
+ * @module Bayer
+ * @three_import import { bayer16 } from 'three/addons/tsl/math/Bayer.js';
+ */
 
 let bayer16Texture = null;
 

--- a/examples/jsm/tsl/shadows/TileShadowNode.js
+++ b/examples/jsm/tsl/shadows/TileShadowNode.js
@@ -43,7 +43,8 @@ class LwLight extends Object3D {
  * **Note:** This class does not support `VSMShadowMap` at the moment.
  *
  * @class
- * @extends ShadowBaseNode
+ * @augments ShadowBaseNode
+ * @three_import import { TileShadowNode } from 'three/addons/tsl/shadows/TileShadowNode.js';
  */
 class TileShadowNode extends ShadowBaseNode {
 

--- a/examples/jsm/tsl/shadows/TileShadowNodeHelper.js
+++ b/examples/jsm/tsl/shadows/TileShadowNodeHelper.js
@@ -3,6 +3,9 @@ import { Fn, vec4, vec3, texture, uv, positionLocal, vec2, float, screenSize } f
 
 /**
  * Helper class to manage and display debug visuals for TileShadowNode.
+ *
+ * @augments Group
+ * @three_import import { TileShadowNodeHelper } from 'three/addons/tsl/shadows/TileShadowNodeHelper.js';
  */
 class TileShadowNodeHelper extends Group {
 
@@ -173,7 +176,7 @@ class TileShadowNodeHelper extends Group {
 	}
 
 	/**
-     * Removes all debug objects (planes and helpers) from the scene.
+	 * Removes all debug objects (planes and helpers) from the scene.
 	 */
 	dispose() {
 

--- a/examples/jsm/tsl/utils/Raymarching.js
+++ b/examples/jsm/tsl/utils/Raymarching.js
@@ -1,6 +1,9 @@
 import { varying, vec4, modelWorldMatrixInverse, cameraPosition, positionGeometry, float, Fn, Loop, max, min, vec2, vec3 } from 'three/tsl';
 
-/** @module Raymarching */
+/**
+ * @module Raymarching
+ * @three_import import { RaymarchingBox } from 'three/addons/tsl/utils/Raymarching.js';
+ */
 
 const hitBox = /*@__PURE__*/ Fn( ( { orig, dir } ) => {
 

--- a/examples/jsm/utils/CameraUtils.js
+++ b/examples/jsm/utils/CameraUtils.js
@@ -4,7 +4,10 @@ import {
 	Vector3
 } from 'three';
 
-/** @module CameraUtils */
+/**
+ * @module CameraUtils
+ * @three_import import * as CameraUtils from 'three/addons/utils/CameraUtils.js';
+ */
 
 const _va = /*@__PURE__*/ new Vector3(), // from pe to pa
 	_vb = /*@__PURE__*/ new Vector3(), // from pe to pb

--- a/examples/jsm/utils/GeometryCompressionUtils.js
+++ b/examples/jsm/utils/GeometryCompressionUtils.js
@@ -5,7 +5,10 @@ import {
 	Vector3
 } from 'three';
 
-/** @module GeometryCompressionUtils */
+/**
+ * @module GeometryCompressionUtils
+ * @three_import import * as GeometryCompressionUtils from 'three/addons/utils/GeometryCompressionUtils.js';
+ */
 
 // Octahedron and Quantization encodings based on work by: https://github.com/tsherif/mesh-quantization-example
 

--- a/examples/jsm/utils/GeometryUtils.js
+++ b/examples/jsm/utils/GeometryUtils.js
@@ -1,6 +1,9 @@
 import { Vector3 } from 'three';
 
-/** @module GeometryUtils */
+/**
+ * @module GeometryUtils
+ * @three_import import * as GeometryUtils from 'three/addons/utils/GeometryUtils.js';
+ */
 
 /**
  * Generates 2D-Coordinates along a Hilbert curve.

--- a/examples/jsm/utils/LDrawUtils.js
+++ b/examples/jsm/utils/LDrawUtils.js
@@ -11,6 +11,8 @@ import { mergeGeometries } from './BufferGeometryUtils.js';
 
 /**
  * Utility class for LDraw models.
+ *
+ * @three_import import { LDrawUtils } from 'three/addons/utils/LDrawUtils.js';
  */
 class LDrawUtils {
 

--- a/examples/jsm/utils/SceneOptimizer.js
+++ b/examples/jsm/utils/SceneOptimizer.js
@@ -4,6 +4,8 @@ import * as THREE from 'three';
  * This class can be used to optimized scenes by converting
  * individual meshes into {@link BatchedMesh}. This component
  * is an experimental attempt to implement auto-batching in three.js.
+ *
+ * @three_import import { SceneOptimizer } from 'three/addons/utils/SceneOptimizer.js';
  */
 class SceneOptimizer {
 

--- a/examples/jsm/utils/SceneUtils.js
+++ b/examples/jsm/utils/SceneUtils.js
@@ -10,7 +10,10 @@ import {
 
 import { mergeGroups, deepCloneAttribute } from './BufferGeometryUtils.js';
 
-/** @module SceneUtils */
+/**
+ * @module SceneUtils
+ * @three_import import * as SceneUtils from 'three/addons/utils/SceneUtils.js';
+ */
 
 const _color = /*@__PURE__*/new Color();
 const _matrix = /*@__PURE__*/new Matrix4();

--- a/examples/jsm/utils/ShadowMapViewer.js
+++ b/examples/jsm/utils/ShadowMapViewer.js
@@ -27,6 +27,8 @@ import { UnpackDepthRGBAShader } from '../shaders/UnpackDepthRGBAShader.js';
  * lightShadowMapViewer.size.height = SHADOW_MAP_HEIGHT / 4;
  * lightShadowMapViewer.update();
  * ```
+ *
+ * @three_import import { ShadowMapViewer } from 'three/addons/utils/ShadowMapViewer.js';
  */
 class ShadowMapViewer {
 

--- a/examples/jsm/utils/ShadowMapViewerGPU.js
+++ b/examples/jsm/utils/ShadowMapViewerGPU.js
@@ -27,6 +27,8 @@ import { texture } from 'three/tsl';
  * lightShadowMapViewer.size.height = SHADOW_MAP_HEIGHT / 4;
  * lightShadowMapViewer.update();
  * ```
+ *
+ * @three_import import { ShadowMapViewer } from 'three/addons/utils/ShadowMapViewerGPU.js';
  */
 class ShadowMapViewer {
 

--- a/examples/jsm/utils/SkeletonUtils.js
+++ b/examples/jsm/utils/SkeletonUtils.js
@@ -9,7 +9,10 @@ import {
 	VectorKeyframeTrack
 } from 'three';
 
-/** @module SkeletonUtils */
+/**
+ * @module SkeletonUtils
+ * @three_import import * as SkeletonUtils from 'three/addons/utils/SkeletonUtils.js';
+ */
 
 function getBoneName( bone, options ) {
 

--- a/examples/jsm/utils/SortUtils.js
+++ b/examples/jsm/utils/SortUtils.js
@@ -1,5 +1,8 @@
 
-/** @module SortUtils */
+/**
+ * @module SortUtils
+ * @three_import import * as SortUtils from 'three/addons/utils/SortUtils.js';
+ */
 
 const POWER = 3;
 const BIT_MAX = 32;

--- a/examples/jsm/utils/UVsDebug.js
+++ b/examples/jsm/utils/UVsDebug.js
@@ -2,7 +2,10 @@ import {
 	Vector2
 } from 'three';
 
-/** @module UVsDebug */
+/**
+ * @module UVsDebug
+ * @three_import import { UVsDebug } from 'three/addons/utils/UVsDebug.js';
+ */
 
 /**
  * Function for "unwrapping" and debugging three.js geometries UV mapping.

--- a/examples/jsm/utils/WebGLTextureUtils.js
+++ b/examples/jsm/utils/WebGLTextureUtils.js
@@ -10,7 +10,10 @@ import {
 	SRGBColorSpace
 } from 'three';
 
-/** @module WebGLTextureUtils */
+/**
+ * @module WebGLTextureUtils
+ * @three_import import * as WebGLTextureUtils from 'three/addons/utils/WebGLTextureUtils.js';
+ */
 
 let _renderer;
 let fullscreenQuadGeometry;

--- a/examples/jsm/utils/WebGPUTextureUtils.js
+++ b/examples/jsm/utils/WebGPUTextureUtils.js
@@ -6,7 +6,10 @@ import {
 } from 'three';
 import { texture, uv } from 'three/tsl';
 
-/** @module WebGPUTextureUtils */
+/**
+ * @module WebGPUTextureUtils
+ * @three_import import * as WebGPUTextureUtils from 'three/addons/utils/WebGPUTextureUtils.js';
+ */
 
 let _renderer;
 const _quadMesh = /*@__PURE__*/ new QuadMesh();

--- a/examples/jsm/utils/WorkerPool.js
+++ b/examples/jsm/utils/WorkerPool.js
@@ -1,5 +1,7 @@
 /**
  * A simple pool for managing Web Workers.
+ *
+ * @three_import import { WorkerPool } from 'three/addons/utils/WorkerPool.js';
  */
 export class WorkerPool {
 

--- a/examples/jsm/webxr/ARButton.js
+++ b/examples/jsm/webxr/ARButton.js
@@ -8,6 +8,7 @@
  * ```
  *
  * @hideconstructor
+ * @three_import import { ARButton } from 'three/addons/webxr/ARButton.js';
  */
 class ARButton {
 

--- a/examples/jsm/webxr/OculusHandModel.js
+++ b/examples/jsm/webxr/OculusHandModel.js
@@ -8,6 +8,7 @@ const POINTING_JOINT = 'index-finger-tip';
  * Represents an Oculus hand model.
  *
  * @augments Object3D
+ * @three_import import { OculusHandModel } from 'three/addons/webxr/OculusHandModel.js';
  */
 class OculusHandModel extends Object3D {
 

--- a/examples/jsm/webxr/OculusHandPointerModel.js
+++ b/examples/jsm/webxr/OculusHandPointerModel.js
@@ -23,6 +23,7 @@ const CURSOR_MAX_DISTANCE = 1.5;
  * Represents an Oculus hand pointer model.
  *
  * @augments Object3D
+ * @three_import import { OculusHandPointerModel } from 'three/addons/webxr/OculusHandPointerModel.js';
  */
 class OculusHandPointerModel extends Object3D {
 

--- a/examples/jsm/webxr/Text2D.js
+++ b/examples/jsm/webxr/Text2D.js
@@ -1,6 +1,9 @@
 import { DoubleSide, Mesh, MeshBasicMaterial, PlaneGeometry, Texture } from 'three';
 
-/** @module Text2D */
+/**
+ * @module Text2D
+ * @three_import import * as Text2D from 'three/addons/webxr/Text2D.js';
+ */
 
 /**
  * A helper function for creating a simple plane mesh

--- a/examples/jsm/webxr/VRButton.js
+++ b/examples/jsm/webxr/VRButton.js
@@ -8,6 +8,7 @@
  * ```
  *
  * @hideconstructor
+ * @three_import import { VRButton } from 'three/addons/webxr/VRButton.js';
  */
 class VRButton {
 

--- a/examples/jsm/webxr/XRButton.js
+++ b/examples/jsm/webxr/XRButton.js
@@ -12,6 +12,7 @@
  * support this type of session, it uses an immersive VR session.
  *
  * @hideconstructor
+ * @three_import import { XRButton } from 'three/addons/webxr/XRButton.js';
  */
 class XRButton {
 

--- a/examples/jsm/webxr/XRControllerModelFactory.js
+++ b/examples/jsm/webxr/XRControllerModelFactory.js
@@ -255,6 +255,8 @@ function addAssetSceneToControllerModel( controllerModel, scene ) {
  * controllerGrip.add( controllerModelFactory.createControllerModel( controllerGrip ) );
  * scene.add( controllerGrip );
  * ```
+ *
+ * @three_import import { XRControllerModelFactory } from 'three/addons/webxr/XRControllerModelFactory.js';
  */
 class XRControllerModelFactory {
 

--- a/examples/jsm/webxr/XREstimatedLight.js
+++ b/examples/jsm/webxr/XREstimatedLight.js
@@ -138,6 +138,7 @@ class SessionLightProbe {
  * a XR session. It relies on the WebXR Lighting Estimation API.
  *
  * @augments Group
+ * @three_import import { XREstimatedLight } from 'three/addons/webxr/XREstimatedLight.js';
  */
 export class XREstimatedLight extends Group {
 

--- a/examples/jsm/webxr/XRHandMeshModel.js
+++ b/examples/jsm/webxr/XRHandMeshModel.js
@@ -6,6 +6,8 @@ const DEFAULT_HAND_PROFILE_PATH = 'https://cdn.jsdelivr.net/npm/@webxr-input-pro
  * Represents one of the hand model types {@link XRHandModelFactory} might produce
  * depending on the selected profile. `XRHandMeshModel` represents a hand with a
  * custom asset.
+ *
+ * @three_import import { XRHandMeshModel } from 'three/addons/webxr/XRHandMeshModel.js';
  */
 class XRHandMeshModel {
 

--- a/examples/jsm/webxr/XRHandModelFactory.js
+++ b/examples/jsm/webxr/XRHandModelFactory.js
@@ -90,6 +90,8 @@ class XRHandModel extends Object3D {
  * hand.add( handModelFactory.createHandModel( hand ) );
  * scene.add( hand );
  * ```
+ *
+ * @three_import import { XRHandModelFactory } from 'three/addons/webxr/XRHandModelFactory.js';
  */
 class XRHandModelFactory {
 

--- a/examples/jsm/webxr/XRHandPrimitiveModel.js
+++ b/examples/jsm/webxr/XRHandPrimitiveModel.js
@@ -15,6 +15,8 @@ const _vector = new Vector3();
  * Represents one of the hand model types {@link XRHandModelFactory} might produce
  * depending on the selected profile. `XRHandPrimitiveModel` represents a hand
  * with sphere or box primitives according to the selected `primitive` option.
+ *
+ * @three_import import { XRHandPrimitiveModel } from 'three/addons/webxr/XRHandPrimitiveModel.js';
  */
 class XRHandPrimitiveModel {
 

--- a/examples/jsm/webxr/XRPlanes.js
+++ b/examples/jsm/webxr/XRPlanes.js
@@ -17,6 +17,7 @@ import {
  * ```
  *
  * @augments Object3D
+ * @three_import import { XRPlanes } from 'three/addons/webxr/XRPlanes.js';
  */
 class XRPlanes extends Object3D {
 


### PR DESCRIPTION
Related issue: #30853

**Description**

As described in #30853, this PR ensures the JSDoc documentation pages for addons have "Import" sections that demonstrate the ES6 import statement for easier use.