### PR TITLE
WebGPURenderer: Make `material.transparent` behave as in WebGLRenderer

### DIFF
--- a/src/renderers/webgpu/utils/WebGPUPipelineUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUPipelineUtils.js
@@ -88,7 +88,7 @@ class WebGPUPipelineUtils {
 
 		let blending;
 
-		if ( material.blending !== NoBlending && (material.blending !== NormalBlending || material.transparent === true) ) {
+		if ( material.blending !== NoBlending && ( material.blending !== NormalBlending || material.transparent === true ) ) {
 
 			blending = this._getBlending( material );
 

--- a/src/renderers/webgpu/utils/WebGPUPipelineUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUPipelineUtils.js
@@ -88,7 +88,7 @@ class WebGPUPipelineUtils {
 
 		let blending;
 
-		if ( material.transparent === true && material.blending !== NoBlending ) {
+		if ( material.blending !== NoBlending && (material.blending !== NormalBlending || material.transparent === true) ) {
 
 			blending = this._getBlending( material );
 


### PR DESCRIPTION
Fixed #30861

**Description**

Make WebGPU backend apply `material.blending` even when `material.transparent` is false, just like WebGL backend.