### PR TITLE
WebGLShadowMap: Support `alphaToCoverage` with shadows.

### DIFF
--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -257,7 +257,8 @@ function WebGLShadowMap( renderer, objects, capabilities ) {
 			if ( ( renderer.localClippingEnabled && material.clipShadows === true && Array.isArray( material.clippingPlanes ) && material.clippingPlanes.length !== 0 ) ||
 				( material.displacementMap && material.displacementScale !== 0 ) ||
 				( material.alphaMap && material.alphaTest > 0 ) ||
-				( material.map && material.alphaTest > 0 ) ) {
+				( material.map && material.alphaTest > 0 ) ||
+				( material.alphaToCoverage === true ) ) {
 
 				// in this case we need a unique material instance reflecting the
 				// appropriate state
@@ -303,7 +304,7 @@ function WebGLShadowMap( renderer, objects, capabilities ) {
 		}
 
 		result.alphaMap = material.alphaMap;
-		result.alphaTest = material.alphaTest;
+		result.alphaTest = ( material.alphaToCoverage === true ) ? 0.5 : material.alphaTest; // approximate alphaToCoverage by using a fixed alphaTest value
 		result.map = material.map;
 
 		result.clipShadows = material.clipShadows;


### PR DESCRIPTION
Fixed #30462.

**Description**

Materials might use `alphaToCoverage` to implement grass sprites/billboards like mentioned in #30462. `WebGLRenderer` is currently not able to provide proper shadows with such a setup. `alphaToCoverage` can only be used in a multisampled context which is not true for shadow map generation. So the idea is to approximate shadows like suggested by #30760. This PR implements a different approach with less changes in `WebGLShadowMap`. The shared codesandbox in https://github.com/mrdoob/three.js/pull/30760#issuecomment-2746380392 is fixed with this change.