### PR TITLE
TSL Transpiler: Add valid !=

### DIFF
--- a/examples/jsm/transpiler/TSLEncoder.js
+++ b/examples/jsm/transpiler/TSLEncoder.js
@@ -15,6 +15,7 @@ const opLib = {
 	'<=': 'lessThanEqual',
 	'>=': 'greaterThanEqual',
 	'==': 'equal',
+	'!=': 'notEqual',
 	'&&': 'and',
 	'||': 'or',
 	'^^': 'xor',


### PR DESCRIPTION
Fixes #30889

**Description**

Map TSL `notEqual` function to GLSL `!=` operator.

![image](https://github.com/user-attachments/assets/d8167caf-fde0-4753-a4c6-d997e9cad6ea)