### PR TITLE
Water2Mesh: Fix missing `material.transparent=true`

### DIFF
--- a/examples/jsm/objects/Water2Mesh.js
+++ b/examples/jsm/objects/Water2Mesh.js
@@ -50,7 +50,7 @@ class WaterMesh extends Mesh {
 		 */
 		this.isWater = true;
 
-		material.fragmentNode = new WaterNode( options, this );
+		material.colorNode = new WaterNode( options, this );
 
 	}
 

--- a/examples/jsm/objects/Water2Mesh.js
+++ b/examples/jsm/objects/Water2Mesh.js
@@ -37,6 +37,7 @@ class WaterMesh extends Mesh {
 	constructor( geometry, options = {} ) {
 
 		const material = new NodeMaterial();
+		material.transparent = true;
 
 		super( geometry, material );
 


### PR DESCRIPTION
**Description**

Fix missing `material.transparent=true` and add MRT support moving `material.fragmentNode` to `material.colorNode`.