### PR TITLE
ImprovedNoise: Use MathUtils.lerp

### DIFF
--- a/examples/jsm/math/ImprovedNoise.js
+++ b/examples/jsm/math/ImprovedNoise.js
@@ -1,3 +1,7 @@
+import { MathUtils } from 'three';
+
+const { lerp } = MathUtils;
+
 const _p = [ 151, 160, 137, 91, 90, 15, 131, 13, 201, 95, 96, 53, 194, 233, 7, 225, 140, 36, 103, 30, 69, 142, 8, 99, 37, 240, 21, 10,
 	 23, 190, 6, 148, 247, 120, 234, 75, 0, 26, 197, 62, 94, 252, 219, 203, 117, 35, 11, 32, 57, 177, 33, 88, 237, 149, 56, 87,
 	 174, 20, 125, 136, 171, 168, 68, 175, 74, 165, 71, 134, 139, 48, 27, 166, 77, 146, 158, 231, 83, 111, 229, 122, 60, 211,
@@ -18,12 +22,6 @@ for ( let i = 0; i < 256; i ++ ) {
 function fade( t ) {
 
 	return t * t * t * ( t * ( t * 6 - 15 ) + 10 );
-
-}
-
-function lerp( t, a, b ) {
-
-	return a + t * ( b - a );
 
 }
 
@@ -69,14 +67,19 @@ class ImprovedNoise {
 
 		const A = _p[ X ] + Y, AA = _p[ A ] + Z, AB = _p[ A + 1 ] + Z, B = _p[ X + 1 ] + Y, BA = _p[ B ] + Z, BB = _p[ B + 1 ] + Z;
 
-		return lerp( w, lerp( v, lerp( u, grad( _p[ AA ], x, y, z ),
-			grad( _p[ BA ], xMinus1, y, z ) ),
-		lerp( u, grad( _p[ AB ], x, yMinus1, z ),
-			grad( _p[ BB ], xMinus1, yMinus1, z ) ) ),
-		lerp( v, lerp( u, grad( _p[ AA + 1 ], x, y, zMinus1 ),
-			grad( _p[ BA + 1 ], xMinus1, y, zMinus1 ) ),
-		lerp( u, grad( _p[ AB + 1 ], x, yMinus1, zMinus1 ),
-			grad( _p[ BB + 1 ], xMinus1, yMinus1, zMinus1 ) ) ) );
+		return lerp(
+			lerp(
+				lerp( grad( _p[ AA ], x, y, z ), grad( _p[ BA ], xMinus1, y, z ), u ),
+				lerp( grad( _p[ AB ], x, yMinus1, z ), grad( _p[ BB ], xMinus1, yMinus1, z ), u ),
+				v
+			),
+			lerp(
+				lerp( grad( _p[ AA + 1 ], x, y, zMinus1 ), grad( _p[ BA + 1 ], xMinus1, y, zMinus1 ), u ),
+				lerp( grad( _p[ AB + 1 ], x, yMinus1, zMinus1 ), grad( _p[ BB + 1 ], xMinus1, yMinus1, zMinus1 ), u ),
+				v
+			),
+			w
+		);
 
 	}
 


### PR DESCRIPTION
**Description**

Consuming `lerp` from `MathUtils` instead of creating another copy of it. 

The order of arguments is different, which makes it a bit off the [original algorithm](https://cs.nyu.edu/~perlin/noise/) when reading code, but I don't think it's an issue.