### PR TITLE
RenderTarget: Fix depth texture assignment regression.

### DIFF
--- a/src/core/RenderTarget.js
+++ b/src/core/RenderTarget.js
@@ -177,7 +177,8 @@ class RenderTarget extends EventDispatcher {
 		 */
 		this.resolveStencilBuffer = options.resolveStencilBuffer;
 
-		this._depthTexture = options.depthTexture;
+		this._depthTexture = null;
+		this.depthTexture = options.depthTexture;
 
 		/**
 		 * The number of MSAA samples.


### PR DESCRIPTION
I fixed a small bug in RenderTarget.js. I corrected the usage of depthTexture assignment in the RenderTarget constructor. Now using the setter function again like in r174 and before. The setter ensure the correct _depthTexture assignment and proper renderTarget linkage.

Fixed #30895

A lot of changes were made in #30633, and this may have gotten lost

