### PR TITLE
Core: Remove Luminance and LuminanceAlpha format

### DIFF
--- a/docs/api/ar/constants/Textures.html
+++ b/docs/api/ar/constants/Textures.html
@@ -143,8 +143,6 @@
 		THREE.RGBFormat
 		THREE.RGBAFormat 
 		THREE.RGBAIntegerFormat
-		THREE.LuminanceFormat 
-		THREE.LuminanceAlphaFormat 
 		THREE.DepthFormat
 		THREE.DepthStencilFormat
 		</code>
@@ -180,16 +178,6 @@
 			الزرقاء والألفا. يتم قراءة `texels` كأعداد صحيحة بدلاً من
 			نقطة عائمة.
 			<br /> <br />
-		 
-			[page:constant LuminanceFormat] يقرأ كل عنصر كمكون إضاءة واحد
-			. يتم تحويله بعد ذلك إلى نقطة عائمة ، ويتم تثبيته في
- 			النطاق [0،1] ، ثم يتم تجميعه في عنصر RGBA عن طريق وضع
- 			قيمة الإضاءة في القنوات الحمراء والخضراء والزرقاء ، وإرفاق `1.0` بـ
- 			قناة الألفا. <br /> <br />
-
- 			[page:constant LuminanceAlphaFormat] يقرأ كل عنصر كـ
- 			مزدوج إضاءة / ألفا. يحدث نفس العملية كما هو الحال في [page:constant LuminanceFormat] ، باستثناء أن قناة الألفا قد تحتوي على قيم غير
- 			`1.0`. <br /> <br />
 
  			[page:constant DepthFormat] يقرأ كل عنصر كقيمة عمق واحدة ،
  			يتحول إلى نقطة عائمة ، ويتم تثبيته في النطاق [0،1]. هذا هو

--- a/docs/api/en/constants/Textures.html
+++ b/docs/api/en/constants/Textures.html
@@ -155,8 +155,6 @@
 		THREE.RGBFormat
 		THREE.RGBAFormat 
 		THREE.RGBAIntegerFormat
-		THREE.LuminanceFormat 
-		THREE.LuminanceAlphaFormat 
 		THREE.DepthFormat
 		THREE.DepthStencilFormat
 		</code>
@@ -192,16 +190,6 @@
 			blue and alpha components. The texels are read as integers instead of
 			floating point.
 			<br /><br />
-
-			[page:constant LuminanceFormat] reads each element as a single luminance
-			component. This is then converted to a floating point, clamped to the
-			range [0,1], and then assembled into an RGBA element by placing the
-			luminance value in the red, green and blue channels, and attaching 1.0 to
-			the alpha channel.<br /><br />
-
-			[page:constant LuminanceAlphaFormat] reads each element as a
-			luminance/alpha double. The same process occurs as for the [page:constant LuminanceFormat], except that the alpha channel may have values other than
-			`1.0`.<br /><br />
 
 			[page:constant DepthFormat] reads each element as a single depth value,
 			converts it to floating point, and clamps to the range [0,1]. This is the

--- a/docs/api/fr/constants/Textures.html
+++ b/docs/api/fr/constants/Textures.html
@@ -147,8 +147,6 @@
 		THREE.RGBFormat
 		THREE.RGBAFormat
 		THREE.RGBAIntegerFormat
-		THREE.LuminanceFormat
-		THREE.LuminanceAlphaFormat
 		THREE.DepthFormat
 		THREE.DepthStencilFormat
 		</code>
@@ -176,14 +174,6 @@
 		[page:constant RGBAIntegerFormat] est la valeur par défaut et lit les composants rouge, vert, bleu et alpha.
 		Les texels sont lus comme des entiers au lieu de points flottants.
 		<br /><br />
-
-		[page:constant LuminanceFormat] lit chaque élément comme une seule composante de luminance.
-		Celui-ci est ensuite converti en point flottant, fixé dans l'intervalle [0,1], puis assemblé
-		dans un élément RGBA en plaçant la valeur de luminance dans les canaux rouge, vert et bleu,
-		et en assignant 1.0 au canal alpha.<br /><br />
-
-		[page:constant LuminanceAlphaFormat] lit chaque élément comme une composante de luminance/double alpha.
-		Il s'agit du même procédé que pour [page:constant LuminanceFormat], sauf que le canal alpha peut avoir une autre valeur que `1.0`.<br /><br />
 
 		[page:constant DepthFormat] lit chaque élément comme une seule valeur de profondeur, les converti en point flottant, fixé dans l'intervalle [0,1].
 		C'est la valeur par défaut pour [page:DepthTexture DepthTexture].<br /><br />

--- a/docs/api/it/constants/Textures.html
+++ b/docs/api/it/constants/Textures.html
@@ -143,8 +143,6 @@
 		THREE.RGBFormat
 		THREE.RGBAFormat
 		THREE.RGBAIntegerFormat
-		THREE.LuminanceFormat
-		THREE.LuminanceAlphaFormat
 		THREE.DepthFormat
 		THREE.DepthStencilFormat
 		</code>
@@ -168,14 +166,6 @@
 
       [page:constant RGBAIntegerFormat] è l'impostazione di default e legge i componenti rosso, verde, blu e alfa.
       I texel sono letti come numeri interi invece che come floating point.<br /><br />
-
-      [page:constant LuminanceFormat] legge ogni elemento come un singolo componente di luminanza.
-      Questo viene quindi convertito in floating point, fissato all'intervallo [0,1], e quindi assemblato
-      in un elemento RGBA posizionando il valore di luminanza nei canali rosso, verde e blu, e allegando
-      1.0 al canale alfa.<br /><br />
-
-      [page:constant LuminanceAlphaFormat] legge ogni elemento come un doppio luminanza/alfa. Lo stesso processo si verifica
-      come per [page:constant LuminanceFormat], tranne per il fatto che il canale alfa può avere valori diversi da `1.0`.<br /><br />
 
       [page:constant DepthFormat] legge ogni elemento come un singolo valore depth, lo converte in floating point e si blocca 
       nell'intervallo [0,1]. Questa è l'impostazione predefinita per [page:DepthTexture DepthTexture].<br /><br />

--- a/docs/api/ko/constants/Textures.html
+++ b/docs/api/ko/constants/Textures.html
@@ -144,8 +144,6 @@
 		THREE.RGBFormat
 		THREE.RGBAFormat
 		THREE.RGBAIntegerFormat
-		THREE.LuminanceFormat
-		THREE.LuminanceAlphaFormat
 		THREE.DepthFormat
 		THREE.DepthStencilFormat
 		</code>
@@ -172,14 +170,6 @@
 
 		[page:constant RGBAIntegerFormat]는 기본값이며 red, green, blue 및 alpha 요소를 읽어들입니다.
 		texel은 부동 소수점 대신 정수로 읽어들입니다.
-		<br /><br />
-
-		[page:constant LuminanceFormat]은 각 요소(element)를 단일 휘도 요소(component)로 읽어들입니다.
-		그 다음에 부동 소수점으로 변환되어 [0,1] 범위에 고정한 다음
-		휘도 값을 적색, 녹색 및 청색 채널에 배치하고 1.0을 알파 채널에 할당하여 RGBA 요소로 조립합니다.<br /><br />
-
-		[page:constant LuminanceAlphaFormat]은 각 요소(element)를 휘도/알파 소수로 읽어들입니다.
-		The same process occurs as for the [page:constant LuminanceFormat]와 같은 절차가 이루어지며, 알파 채널에 *1.0* 이외의 값이 들어갈 수 있다는 점만 다릅니다.
 		<br /><br />
 
 		[page:constant DepthFormat]은 각 요소를 단일 깊이 값으로 일거들이며 부동 소수점으로 변환하고, [0,1]범위에 고정합니다.

--- a/docs/api/pt-br/constants/Textures.html
+++ b/docs/api/pt-br/constants/Textures.html
@@ -147,8 +147,6 @@
 		THREE.RGBFormat
 		THREE.RGBAFormat
 		THREE.RGBAIntegerFormat
-		THREE.LuminanceFormat
-		THREE.LuminanceAlphaFormat
 		THREE.DepthFormat
 		THREE.DepthStencilFormat
 		</code>
@@ -176,15 +174,6 @@
 		[page:constant RGBAIntegerFormat] é o padrão e lê os componentes vermelho, verde, azul e alfa.
 		Os texels são lidos como inteiros em vez de ponto flutuante.
 		<br /><br />
-
-		[page:constant LuminanceFormat] lê cada elemento como um único componente de luminância.
-		Este é então convertido em um ponto flutuante, fixado no intervalo [0,1], e então montado
-		em um elemento RGBA, colocando o valor de luminância nos canais vermelho, verde e azul,
-		e anexando 1.0 ao canal alfa.<br /><br />
-
-		[page:constant LuminanceAlphaFormat] lê cada elemento como um duplo de luminância/alfa.
-		O mesmo processo ocorre para o [page:constant LuminanceFormat], exceto que o
-		o canal alfa pode ter valores diferentes de `1.0`.<br /><br />
 
 		[page:constant DepthFormat] lê cada elemento como um único valor de profundidade, converte-o em ponto flutuante e fixa no intervalo [0,1].
 		Este é o padrão para [page:DepthTexture DepthTexture].<br /><br />

--- a/docs/api/zh/constants/Textures.html
+++ b/docs/api/zh/constants/Textures.html
@@ -137,8 +137,6 @@
 		THREE.RGBFormat
 		THREE.RGBAFormat
 		THREE.RGBAIntegerFormat
-		THREE.LuminanceFormat
-		THREE.LuminanceAlphaFormat
 		THREE.DepthFormat
 		THREE.DepthStencilFormat
 	</code>
@@ -165,12 +163,6 @@
 		[page:constant RGBAIntegerFormat] is the default and reads the red, green, blue and alpha components.
 		The texels are read as integers instead of floating point.
 		<br /><br />
-
-		[page:constant LuminanceFormat] 将每个元素作为单独的亮度分量来读取。
-		将其转换为范围限制在[0,1]区间的浮点数，然后通过将亮度值放入红、绿、蓝通道，并将1.0赋给Alpha通道，来组装成一个RGBA元素。<br /><br />
-
-		[page:constant LuminanceAlphaFormat] 将每个元素同时作为亮度分量和Alpha分量来读取。
-		和上面[page:constant LuminanceFormat]的处理过程是一致的，除了Alpha分量具有除了*1.0*以外的值。<br /><br />
 
 		[page:constant DepthFormat]将每个元素作为单独的深度值来读取，将其转换为范围限制在[0,1]区间的浮点数。
 		它是[page:DepthTexture DepthTexture]的默认值。<br /><br />

--- a/editor/js/libs/tern-threejs/threejs.js
+++ b/editor/js/libs/tern-threejs/threejs.js
@@ -4556,7 +4556,7 @@
         },
         "format": {
           "!type": "number",
-          "!doc": "The default is THREE.RGBAFormat for the texture. Other formats are: THREE.AlphaFormat, THREE.RGBFormat, THREE.LuminanceFormat, and THREE.LuminanceAlphaFormat. There are also compressed texture formats, if the S3TC extension is supported: THREE.RGB_S3TC_DXT1_Format, THREE.RGBA_S3TC_DXT1_Format, THREE.RGBA_S3TC_DXT3_Format, and THREE.RGBA_S3TC_DXT5_Format."
+          "!doc": "The default is THREE.RGBAFormat for the texture. Other formats are: THREE.AlphaFormat, THREE.RGBFormat. There are also compressed texture formats, if the S3TC extension is supported: THREE.RGB_S3TC_DXT1_Format, THREE.RGBA_S3TC_DXT1_Format, THREE.RGBA_S3TC_DXT3_Format, and THREE.RGBA_S3TC_DXT5_Format."
         },
         "type": {
           "!type": "number",
@@ -4970,7 +4970,7 @@
         },
         "format": {
           "!type": "number",
-          "!doc": "The default is THREE.RGBAFormat for the texture. Other formats are: THREE.AlphaFormat, THREE.RGBFormat, THREE.LuminanceFormat, and THREE.LuminanceAlphaFormat. There are also compressed texture formats, if the S3TC extension is supported: THREE.RGB_S3TC_DXT1_Format, THREE.RGBA_S3TC_DXT1_Format, THREE.RGBA_S3TC_DXT3_Format, and THREE.RGBA_S3TC_DXT5_Format."
+          "!doc": "The default is THREE.RGBAFormat for the texture. Other formats are: THREE.AlphaFormat, THREE.RGBFormat. There are also compressed texture formats, if the S3TC extension is supported: THREE.RGB_S3TC_DXT1_Format, THREE.RGBA_S3TC_DXT1_Format, THREE.RGBA_S3TC_DXT3_Format, and THREE.RGBA_S3TC_DXT5_Format."
         },
         "type": {
           "!type": "number",

--- a/src/constants.js
+++ b/src/constants.js
@@ -746,25 +746,6 @@ export const RGBFormat = 1022;
 export const RGBAFormat = 1023;
 
 /**
- * reads each element as a single luminance component. This is then converted to a floating point,
- * clamped to the range `[0,1]`, and then assembled into an RGBA element by placing the luminance value
- * in the red, green and blue channels, and attaching 1.0 to the alpha channel.
- *
- * @type {number}
- * @constant
- */
-export const LuminanceFormat = 1024;
-
-/**
- * Reads each element as a luminance/alpha double. The same process occurs as for the `LuminanceFormat`,
- * except that the alpha channel may have values other than `1.0`.
- *
- * @type {number}
- * @constant
- */
-export const LuminanceAlphaFormat = 1025;
-
-/**
  * Reads each element as a single depth value, converts it to floating point, and clamps to the range `[0,1]`.
  *
  * @type {number}

--- a/src/extras/TextureUtils.js
+++ b/src/extras/TextureUtils.js
@@ -1,4 +1,4 @@
-import { AlphaFormat, LuminanceFormat, LuminanceAlphaFormat, RedFormat, RedIntegerFormat, RGFormat, RGIntegerFormat, RGBFormat, RGBAFormat, RGBAIntegerFormat, RGB_S3TC_DXT1_Format, RGBA_S3TC_DXT1_Format, RGBA_S3TC_DXT3_Format, RGBA_S3TC_DXT5_Format, RGB_PVRTC_2BPPV1_Format, RGBA_PVRTC_2BPPV1_Format, RGB_PVRTC_4BPPV1_Format, RGBA_PVRTC_4BPPV1_Format, RGB_ETC1_Format, RGB_ETC2_Format, RGBA_ETC2_EAC_Format, RGBA_ASTC_4x4_Format, RGBA_ASTC_5x4_Format, RGBA_ASTC_5x5_Format, RGBA_ASTC_6x5_Format, RGBA_ASTC_6x6_Format, RGBA_ASTC_8x5_Format, RGBA_ASTC_8x6_Format, RGBA_ASTC_8x8_Format, RGBA_ASTC_10x5_Format, RGBA_ASTC_10x6_Format, RGBA_ASTC_10x8_Format, RGBA_ASTC_10x10_Format, RGBA_ASTC_12x10_Format, RGBA_ASTC_12x12_Format, RGBA_BPTC_Format, RGB_BPTC_SIGNED_Format, RGB_BPTC_UNSIGNED_Format, RED_RGTC1_Format, SIGNED_RED_RGTC1_Format, RED_GREEN_RGTC2_Format, SIGNED_RED_GREEN_RGTC2_Format, UnsignedByteType, ByteType, UnsignedShortType, ShortType, HalfFloatType, UnsignedShort4444Type, UnsignedShort5551Type, UnsignedIntType, IntType, FloatType, UnsignedInt5999Type } from '../constants.js';
+import { AlphaFormat, RedFormat, RedIntegerFormat, RGFormat, RGIntegerFormat, RGBFormat, RGBAFormat, RGBAIntegerFormat, RGB_S3TC_DXT1_Format, RGBA_S3TC_DXT1_Format, RGBA_S3TC_DXT3_Format, RGBA_S3TC_DXT5_Format, RGB_PVRTC_2BPPV1_Format, RGBA_PVRTC_2BPPV1_Format, RGB_PVRTC_4BPPV1_Format, RGBA_PVRTC_4BPPV1_Format, RGB_ETC1_Format, RGB_ETC2_Format, RGBA_ETC2_EAC_Format, RGBA_ASTC_4x4_Format, RGBA_ASTC_5x4_Format, RGBA_ASTC_5x5_Format, RGBA_ASTC_6x5_Format, RGBA_ASTC_6x6_Format, RGBA_ASTC_8x5_Format, RGBA_ASTC_8x6_Format, RGBA_ASTC_8x8_Format, RGBA_ASTC_10x5_Format, RGBA_ASTC_10x6_Format, RGBA_ASTC_10x8_Format, RGBA_ASTC_10x10_Format, RGBA_ASTC_12x10_Format, RGBA_ASTC_12x12_Format, RGBA_BPTC_Format, RGB_BPTC_SIGNED_Format, RGB_BPTC_UNSIGNED_Format, RED_RGTC1_Format, SIGNED_RED_RGTC1_Format, RED_GREEN_RGTC2_Format, SIGNED_RED_GREEN_RGTC2_Format, UnsignedByteType, ByteType, UnsignedShortType, ShortType, HalfFloatType, UnsignedShort4444Type, UnsignedShort5551Type, UnsignedIntType, IntType, FloatType, UnsignedInt5999Type } from '../constants.js';
 
 /**
  * Scales the texture as large as possible within its surface without cropping
@@ -106,10 +106,6 @@ function getByteLength( width, height, format, type ) {
 		// https://registry.khronos.org/OpenGL-Refpages/es3.0/html/glTexImage2D.xhtml
 		case AlphaFormat:
 			return width * height;
-		case LuminanceFormat:
-			return width * height;
-		case LuminanceAlphaFormat:
-			return width * height * 2;
 		case RedFormat:
 			return ( ( width * height ) / typeByteLength.components ) * typeByteLength.byteLength;
 		case RedIntegerFormat:

--- a/src/renderers/webgl-fallback/utils/WebGLUtils.js
+++ b/src/renderers/webgl-fallback/utils/WebGLUtils.js
@@ -1,4 +1,4 @@
-import { RGBA_ASTC_4x4_Format, RGBA_ASTC_5x4_Format, RGBA_ASTC_5x5_Format, RGBA_ASTC_6x5_Format, RGBA_ASTC_6x6_Format, RGBA_ASTC_8x5_Format, RGBA_ASTC_8x6_Format, RGBA_ASTC_8x8_Format, RGBA_ASTC_10x5_Format, RGBA_ASTC_10x6_Format, RGBA_ASTC_10x8_Format, RGBA_ASTC_10x10_Format, RGBA_ASTC_12x10_Format, RGBA_ASTC_12x12_Format, RGB_ETC1_Format, RGB_ETC2_Format, RGBA_ETC2_EAC_Format, RGBA_PVRTC_2BPPV1_Format, RGBA_PVRTC_4BPPV1_Format, RGB_PVRTC_2BPPV1_Format, RGB_PVRTC_4BPPV1_Format, RGBA_S3TC_DXT5_Format, RGBA_S3TC_DXT3_Format, RGBA_S3TC_DXT1_Format, RGB_S3TC_DXT1_Format, DepthFormat, DepthStencilFormat, LuminanceAlphaFormat, LuminanceFormat, RedFormat, RGBFormat, RGBAFormat, AlphaFormat, RedIntegerFormat, RGFormat, RGIntegerFormat, RGBAIntegerFormat, HalfFloatType, FloatType, UnsignedIntType, IntType, UnsignedShortType, ShortType, ByteType, UnsignedInt248Type, UnsignedInt5999Type, UnsignedShort5551Type, UnsignedShort4444Type, UnsignedByteType, RGBA_BPTC_Format, RED_RGTC1_Format, SIGNED_RED_RGTC1_Format, RED_GREEN_RGTC2_Format, SIGNED_RED_GREEN_RGTC2_Format, SRGBColorSpace, NoColorSpace } from '../../../constants.js';
+import { RGBA_ASTC_4x4_Format, RGBA_ASTC_5x4_Format, RGBA_ASTC_5x5_Format, RGBA_ASTC_6x5_Format, RGBA_ASTC_6x6_Format, RGBA_ASTC_8x5_Format, RGBA_ASTC_8x6_Format, RGBA_ASTC_8x8_Format, RGBA_ASTC_10x5_Format, RGBA_ASTC_10x6_Format, RGBA_ASTC_10x8_Format, RGBA_ASTC_10x10_Format, RGBA_ASTC_12x10_Format, RGBA_ASTC_12x12_Format, RGB_ETC1_Format, RGB_ETC2_Format, RGBA_ETC2_EAC_Format, RGBA_PVRTC_2BPPV1_Format, RGBA_PVRTC_4BPPV1_Format, RGB_PVRTC_2BPPV1_Format, RGB_PVRTC_4BPPV1_Format, RGBA_S3TC_DXT5_Format, RGBA_S3TC_DXT3_Format, RGBA_S3TC_DXT1_Format, RGB_S3TC_DXT1_Format, DepthFormat, DepthStencilFormat, RedFormat, RGBFormat, RGBAFormat, AlphaFormat, RedIntegerFormat, RGFormat, RGIntegerFormat, RGBAIntegerFormat, HalfFloatType, FloatType, UnsignedIntType, IntType, UnsignedShortType, ShortType, ByteType, UnsignedInt248Type, UnsignedInt5999Type, UnsignedShort5551Type, UnsignedShort4444Type, UnsignedByteType, RGBA_BPTC_Format, RED_RGTC1_Format, SIGNED_RED_RGTC1_Format, RED_GREEN_RGTC2_Format, SIGNED_RED_GREEN_RGTC2_Format, SRGBColorSpace, NoColorSpace } from '../../../constants.js';
 
 /**
  * A WebGL 2 backend utility module with common helpers.
@@ -74,8 +74,6 @@ class WebGLUtils {
 		if ( p === AlphaFormat ) return gl.ALPHA;
 		if ( p === RGBFormat ) return gl.RGB;
 		if ( p === RGBAFormat ) return gl.RGBA;
-		if ( p === LuminanceFormat ) return gl.LUMINANCE;
-		if ( p === LuminanceAlphaFormat ) return gl.LUMINANCE_ALPHA;
 		if ( p === DepthFormat ) return gl.DEPTH_COMPONENT;
 		if ( p === DepthStencilFormat ) return gl.DEPTH_STENCIL;
 

--- a/src/renderers/webgl/WebGLUtils.js
+++ b/src/renderers/webgl/WebGLUtils.js
@@ -1,4 +1,4 @@
-import { RGBA_ASTC_4x4_Format, RGBA_ASTC_5x4_Format, RGBA_ASTC_5x5_Format, RGBA_ASTC_6x5_Format, RGBA_ASTC_6x6_Format, RGBA_ASTC_8x5_Format, RGBA_ASTC_8x6_Format, RGBA_ASTC_8x8_Format, RGBA_ASTC_10x5_Format, RGBA_ASTC_10x6_Format, RGBA_ASTC_10x8_Format, RGBA_ASTC_10x10_Format, RGBA_ASTC_12x10_Format, RGBA_ASTC_12x12_Format, RGB_ETC1_Format, RGB_ETC2_Format, RGBA_ETC2_EAC_Format, RGBA_PVRTC_2BPPV1_Format, RGBA_PVRTC_4BPPV1_Format, RGB_PVRTC_2BPPV1_Format, RGB_PVRTC_4BPPV1_Format, RGBA_S3TC_DXT5_Format, RGBA_S3TC_DXT3_Format, RGBA_S3TC_DXT1_Format, RGB_S3TC_DXT1_Format, DepthFormat, DepthStencilFormat, LuminanceAlphaFormat, LuminanceFormat, RedFormat, RGBAFormat, AlphaFormat, RedIntegerFormat, RGFormat, RGIntegerFormat, RGBAIntegerFormat, HalfFloatType, FloatType, UnsignedIntType, IntType, UnsignedShortType, ShortType, ByteType, UnsignedInt248Type, UnsignedShort5551Type, UnsignedShort4444Type, UnsignedByteType, RGBA_BPTC_Format, RGB_BPTC_SIGNED_Format, RGB_BPTC_UNSIGNED_Format, RED_RGTC1_Format, SIGNED_RED_RGTC1_Format, RED_GREEN_RGTC2_Format, SIGNED_RED_GREEN_RGTC2_Format, NoColorSpace, SRGBTransfer, UnsignedInt5999Type, RGBFormat } from '../../constants.js';
+import { RGBA_ASTC_4x4_Format, RGBA_ASTC_5x4_Format, RGBA_ASTC_5x5_Format, RGBA_ASTC_6x5_Format, RGBA_ASTC_6x6_Format, RGBA_ASTC_8x5_Format, RGBA_ASTC_8x6_Format, RGBA_ASTC_8x8_Format, RGBA_ASTC_10x5_Format, RGBA_ASTC_10x6_Format, RGBA_ASTC_10x8_Format, RGBA_ASTC_10x10_Format, RGBA_ASTC_12x10_Format, RGBA_ASTC_12x12_Format, RGB_ETC1_Format, RGB_ETC2_Format, RGBA_ETC2_EAC_Format, RGBA_PVRTC_2BPPV1_Format, RGBA_PVRTC_4BPPV1_Format, RGB_PVRTC_2BPPV1_Format, RGB_PVRTC_4BPPV1_Format, RGBA_S3TC_DXT5_Format, RGBA_S3TC_DXT3_Format, RGBA_S3TC_DXT1_Format, RGB_S3TC_DXT1_Format, DepthFormat, DepthStencilFormat, RedFormat, RGBAFormat, AlphaFormat, RedIntegerFormat, RGFormat, RGIntegerFormat, RGBAIntegerFormat, HalfFloatType, FloatType, UnsignedIntType, IntType, UnsignedShortType, ShortType, ByteType, UnsignedInt248Type, UnsignedShort5551Type, UnsignedShort4444Type, UnsignedByteType, RGBA_BPTC_Format, RGB_BPTC_SIGNED_Format, RGB_BPTC_UNSIGNED_Format, RED_RGTC1_Format, SIGNED_RED_RGTC1_Format, RED_GREEN_RGTC2_Format, SIGNED_RED_GREEN_RGTC2_Format, NoColorSpace, SRGBTransfer, UnsignedInt5999Type, RGBFormat } from '../../constants.js';
 import { ColorManagement } from '../../math/ColorManagement.js';
 
 function WebGLUtils( gl, extensions ) {
@@ -25,8 +25,6 @@ function WebGLUtils( gl, extensions ) {
 		if ( p === AlphaFormat ) return gl.ALPHA;
 		if ( p === RGBFormat ) return gl.RGB;
 		if ( p === RGBAFormat ) return gl.RGBA;
-		if ( p === LuminanceFormat ) return gl.LUMINANCE;
-		if ( p === LuminanceAlphaFormat ) return gl.LUMINANCE_ALPHA;
 		if ( p === DepthFormat ) return gl.DEPTH_COMPONENT;
 		if ( p === DepthStencilFormat ) return gl.DEPTH_STENCIL;
 

--- a/test/unit/src/constants.tests.js
+++ b/test/unit/src/constants.tests.js
@@ -109,8 +109,6 @@ export default QUnit.module( 'Constants', () => {
 
 		assert.equal( Constants.AlphaFormat, 1021, 'AlphaFormat is equal to 1021' );
 		assert.equal( Constants.RGBAFormat, 1023, 'RGBAFormat is equal to 1023' );
-		assert.equal( Constants.LuminanceFormat, 1024, 'LuminanceFormat is equal to 1024' );
-		assert.equal( Constants.LuminanceAlphaFormat, 1025, 'LuminanceAlphaFormat is equal to 1025' );
 		assert.equal( Constants.DepthFormat, 1026, 'DepthFormat is equal to 1026' );
 		assert.equal( Constants.DepthStencilFormat, 1027, 'DepthStencilFormat is equal to 1027' );
 		assert.equal( Constants.RedFormat, 1028, 'RedFormat is equal to 1028' );


### PR DESCRIPTION
Fixed #30928

**Description**

Removes all references to Luminance and LuminanceAlpha format which have apparently not worked for over 3 years 😅 