### PR TITLE
TSL: Add switch/case.

### DIFF
--- a/src/Three.TSL.js
+++ b/src/Three.TSL.js
@@ -13,6 +13,7 @@ export const F_Schlick = TSL.F_Schlick;
 export const Fn = TSL.Fn;
 export const INFINITY = TSL.INFINITY;
 export const If = TSL.If;
+export const Switch = TSL.Switch;
 export const Loop = TSL.Loop;
 export const NodeShaderStage = TSL.NodeShaderStage;
 export const NodeType = TSL.NodeType;

--- a/src/nodes/tsl/TSLCore.js
+++ b/src/nodes/tsl/TSLCore.js
@@ -705,6 +705,7 @@ export const setCurrentStack = ( stack ) => {
 export const getCurrentStack = () => currentStack;
 
 export const If = ( ...params ) => currentStack.If( ...params );
+export const Switch = ( ...params ) => currentStack.Switch( ...params );
 
 export function append( node ) {
 


### PR DESCRIPTION
Related issue: #30900

**Description**

The PR adds switch/case syntax to TSL.

```js
material.colorNode = Fn( () => {

	const col = color().toVar();

	Switch( 0 ).Case( 0, () => {

		col.assign( color( 1, 0, 0 ) );

	} ).Case( 1, () => {

		col.assign( color( 0, 1, 0 ) );

	} ).Case( 2, () => {

		col.assign( color( 0, 0, 1 ) );

	} ).Default( () => {

		col.assign( color( 1, 1, 1 ) );

	} );

	return col;

} )();
```
The values of the switch and case statements can be primitives or node objects.