### PR TITLE
Background: Make sure background nodes can be disposed of.

### DIFF
--- a/src/renderers/common/Background.js
+++ b/src/renderers/common/Background.js
@@ -118,6 +118,17 @@ class Background extends DataMap {
 
 				};
 
+				function onBackgroundDispose() {
+
+					background.removeEventListener( 'dispose', onBackgroundDispose );
+
+					backgroundMesh.material.dispose();
+					backgroundMesh.geometry.dispose();
+
+				}
+
+				background.addEventListener( 'dispose', onBackgroundDispose );
+
 			}
 
 			const backgroundCacheKey = backgroundNode.getCacheKey();


### PR DESCRIPTION
Fixed #30937.

**Description**

The PR makes sure that calling `dispose()` on a background node triggers a dispose of the background material and geometry.