### PR TITLE
LightsNode: Honor spotlight maps in cache key.

### DIFF
--- a/src/nodes/lighting/LightsNode.js
+++ b/src/nodes/lighting/LightsNode.js
@@ -125,7 +125,9 @@ class LightsNode extends Node {
 
 			if ( light.isSpotLight === true ) {
 
-				hashData.push( Number( light.map !== null ) );
+				const hashValue = ( light.map !== null ) ? light.map.id : - 1;
+
+				hashData.push( hashValue );
 
 			}
 

--- a/src/nodes/lighting/LightsNode.js
+++ b/src/nodes/lighting/LightsNode.js
@@ -107,23 +107,31 @@ class LightsNode extends Node {
 	}
 
 	/**
-	 * Overwrites the default {@link Node#customCacheKey} implementation by including the
-	 * light IDs into the cache key.
+	 * Overwrites the default {@link Node#customCacheKey} implementation by including
+	 * light data into the cache key.
 	 *
 	 * @return {number} The custom cache key.
 	 */
 	customCacheKey() {
 
-		const lightIDs = [];
+		const hashData = [];
 		const lights = this._lights;
 
 		for ( let i = 0; i < lights.length; i ++ ) {
 
-			lightIDs.push( lights[ i ].id );
+			const light = lights[ i ];
+
+			hashData.push( light.id );
+
+			if ( light.isSpotLight === true ) {
+
+				hashData.push( Number( light.map !== null ) );
+
+			}
 
 		}
 
-		return hashArray( lightIDs );
+		return hashArray( hashData );
 
 	}
 


### PR DESCRIPTION
Fixed #30930.

**Description**

The existence of a spot light map must be honored in the dynamic light cache key which is computed per frame. Otherwise dynamic changes to a spot light like described in #30930 produce runtime errors. 
