### PR TITLE
TSL: Add expression support for `Loop( { update: ... } )`

### DIFF
--- a/examples/jsm/transpiler/TSLEncoder.js
+++ b/examples/jsm/transpiler/TSLEncoder.js
@@ -466,12 +466,34 @@ ${ this.tab }} )`;
 		const name = node.initialization.name;
 		const type = node.initialization.type;
 		const condition = node.condition.type;
-		const update = node.afterthought.type;
 
 		const nameParam = name !== 'i' ? `, name: '${ name }'` : '';
 		const typeParam = type !== 'int' ? `, type: '${ type }'` : '';
 		const conditionParam = condition !== '<' ? `, condition: '${ condition }'` : '';
-		const updateParam = update !== '++' ? `, update: '${ update }'` : '';
+
+		let updateParam = '';
+
+		if ( node.afterthought.isUnary ) {
+
+			if ( node.afterthought.type !== '++' ) {
+
+				updateParam = `, update: '${ node.afterthought.type }'`;
+
+			}
+
+		} else if ( node.afterthought.isOperator ) {
+
+			if ( node.afterthought.right.isAccessor || node.afterthought.right.isNumber ) {
+
+				updateParam = `, update: ${ this.emitExpression( node.afterthought.right ) }`;
+
+			} else {
+
+				updateParam = `, update: ( { i } ) => ${ this.emitExpression( node.afterthought ) }`;
+
+			}
+
+		}
 
 		let loopStr = `Loop( { start: ${ start }, end: ${ end + nameParam + typeParam + conditionParam + updateParam } }, ( { ${ name } } ) => {\n\n`;
 

--- a/examples/jsm/tsl/utils/Raymarching.js
+++ b/examples/jsm/tsl/utils/Raymarching.js
@@ -53,13 +53,13 @@ export const RaymarchingBox = ( steps, callback ) => {
 	bounds.assign( vec2( max( bounds.x, 0.0 ), bounds.y ) );
 
 	const inc = vec3( rayDir.abs().reciprocal() ).toVar();
-	const delta = float( min( inc.x, min( inc.y, inc.z ) ) ).toVar( 'rayDelta' ); // used 'rayDelta' name in loop
+	const delta = float( min( inc.x, min( inc.y, inc.z ) ) ).toVar();
 
 	delta.divAssign( float( steps ) );
 
 	const positionRay = vec3( vOrigin.add( bounds.x.mul( rayDir ) ) ).toVar();
 
-	Loop( { type: 'float', start: bounds.x, end: bounds.y, update: '+= rayDelta' }, () => {
+	Loop( { type: 'float', start: bounds.x, end: bounds.y, update: delta }, () => {
 
 		callback( { positionRay } );
 

--- a/src/nodes/utils/LoopNode.js
+++ b/src/nodes/utils/LoopNode.js
@@ -1,6 +1,6 @@
 import Node from '../core/Node.js';
 import { expression } from '../code/ExpressionNode.js';
-import { nodeObject, nodeArray } from '../tsl/TSLBase.js';
+import { nodeObject, nodeArray, Fn } from '../tsl/TSLBase.js';
 
 /**
  * This module offers a variety of ways to implement loops in TSL. In it's basic form it's:
@@ -101,8 +101,14 @@ class LoopNode extends Node {
 
 		const stack = builder.addStack(); // TODO: cache() it
 
-		properties.returnsNode = this.params[ this.params.length - 1 ]( inputs, stack, builder );
+		properties.returnsNode = this.params[ this.params.length - 1 ]( inputs, builder );
 		properties.stackNode = stack;
+
+		if ( typeof this.params[ 0 ].update === 'function' ) {
+
+			properties.updateNode = Fn( this.params[ 0 ].update )( inputs );
+
+		}
 
 		builder.removeStack();
 
@@ -222,30 +228,67 @@ class LoopNode extends Node {
 				const startSnippet = internalParam.start;
 				const endSnippet = internalParam.end;
 
-				let declarationSnippet = '';
-				let conditionalSnippet = '';
-				let updateSnippet = '';
+				let updateSnippet;
 
-				if ( ! update ) {
+				const deltaOperator = () => condition.includes( '<' ) ? '+=' : '-=';
 
-					if ( type === 'int' || type === 'uint' ) {
+				switch ( typeof update ) {
 
-						if ( condition.includes( '<' ) ) update = '++';
-						else update = '--';
+					case 'undefined':
 
-					} else {
+						if ( type === 'int' || type === 'uint' ) {
 
-						if ( condition.includes( '<' ) ) update = '+= 1.';
-						else update = '-= 1.';
+							update = condition.includes( '<' ) ? '++' : '--';
 
-					}
+						} else {
+
+							update = deltaOperator() + ' 1.';
+
+						}
+
+						updateSnippet = name + ' ' + update;
+
+						break;
+
+					case 'function':
+
+						const flow = builder.flowStagesNode( properties.updateNode, 'void' );
+						const snippet = flow.code.replace( /\t|;/g, '' );
+
+						updateSnippet = snippet;
+
+						break;
+
+					case 'number':
+
+						updateSnippet = name + ' ' + deltaOperator() + ' ' + builder.generateConst( type, update );
+
+						break;
+
+					case 'string':
+
+						updateSnippet = name + ' ' + update;
+
+						break;
+
+					default:
+
+						if ( update && update.isNode ) {
+
+							updateSnippet = name + ' ' + deltaOperator() + ' ' + update.build( builder );
+
+						} else {
+
+							console.error( 'THREE.TSL: \'Loop( { update: ... } )\' is not a function, string or number.' );
+
+							updateSnippet = 'break /* invalid update */';
+
+						}
 
 				}
 
-				declarationSnippet += builder.getVar( type, name ) + ' = ' + startSnippet;
-
-				conditionalSnippet += name + ' ' + condition + ' ' + endSnippet;
-				updateSnippet += name + ' ' + update;
+				const declarationSnippet = builder.getVar( type, name ) + ' = ' + startSnippet;
+				const conditionalSnippet = name + ' ' + condition + ' ' + endSnippet;
 
 				loopSnippet = `for ( ${ declarationSnippet }; ${ conditionalSnippet }; ${ updateSnippet } )`;
 

--- a/src/nodes/utils/LoopNode.js
+++ b/src/nodes/utils/LoopNode.js
@@ -104,7 +104,9 @@ class LoopNode extends Node {
 		properties.returnsNode = this.params[ this.params.length - 1 ]( inputs, builder );
 		properties.stackNode = stack;
 
-		if ( typeof this.params[ 0 ].update === 'function' ) {
+		const baseParam = this.params[ 0 ];
+
+		if ( baseParam.isNode !== true && typeof baseParam.update === 'function' ) {
 
 			properties.updateNode = Fn( this.params[ 0 ].update )( inputs );
 

--- a/src/nodes/utils/LoopNode.js
+++ b/src/nodes/utils/LoopNode.js
@@ -232,58 +232,60 @@ class LoopNode extends Node {
 
 				const deltaOperator = () => condition.includes( '<' ) ? '+=' : '-=';
 
-				switch ( typeof update ) {
+				if ( update !== undefined && update !== null ) {
 
-					case 'undefined':
+					switch ( typeof update ) {
 
-						if ( type === 'int' || type === 'uint' ) {
+						case 'function':
 
-							update = condition.includes( '<' ) ? '++' : '--';
+							const flow = builder.flowStagesNode( properties.updateNode, 'void' );
+							const snippet = flow.code.replace( /\t|;/g, '' );
 
-						} else {
+							updateSnippet = snippet;
 
-							update = deltaOperator() + ' 1.';
+							break;
 
-						}
+						case 'number':
 
-						updateSnippet = name + ' ' + update;
+							updateSnippet = name + ' ' + deltaOperator() + ' ' + builder.generateConst( type, update );
 
-						break;
+							break;
 
-					case 'function':
+						case 'string':
 
-						const flow = builder.flowStagesNode( properties.updateNode, 'void' );
-						const snippet = flow.code.replace( /\t|;/g, '' );
+							updateSnippet = name + ' ' + update;
 
-						updateSnippet = snippet;
+							break;
 
-						break;
+						default:
 
-					case 'number':
+							if ( update.isNode ) {
 
-						updateSnippet = name + ' ' + deltaOperator() + ' ' + builder.generateConst( type, update );
+								updateSnippet = name + ' ' + deltaOperator() + ' ' + update.build( builder );
 
-						break;
+							} else {
 
-					case 'string':
+								console.error( 'THREE.TSL: \'Loop( { update: ... } )\' is not a function, string or number.' );
 
-						updateSnippet = name + ' ' + update;
+								updateSnippet = 'break /* invalid update */';
 
-						break;
+							}
 
-					default:
+					}
 
-						if ( update && update.isNode ) {
+				} else {
 
-							updateSnippet = name + ' ' + deltaOperator() + ' ' + update.build( builder );
+					if ( type === 'int' || type === 'uint' ) {
 
-						} else {
+						update = condition.includes( '<' ) ? '++' : '--';
 
-							console.error( 'THREE.TSL: \'Loop( { update: ... } )\' is not a function, string or number.' );
+					} else {
 
-							updateSnippet = 'break /* invalid update */';
+						update = deltaOperator() + ' 1.';
 
-						}
+					}
+
+					updateSnippet = name + ' ' + update;
 
 				}
 


### PR DESCRIPTION
Fixes https://github.com/mrdoob/three.js/issues/30945

**Description**

Add expression support for `loop( { update: ... } )`

```js
// GLSL
for ( int i = 0; i < 10; i += 2 ) { }

// TSL
Loop( { start: 0, end: 10, update: 2 }, () => {} );


// GLSL
for ( int i = 0; i < 10; i += j + 2 ) { }

// TSL
Loop( { start: 0, end: 10, update: ( { i } ) => i.addAssign( j.add( 2 ) ) }, () => {} );
```

- [LoopNode: Add expression support for loop() update](https://github.com/mrdoob/three.js/commit/3b07268218e7a9133d5be46d5d7868d8134b2b44)
- [Raymarching: update with new approach](https://github.com/mrdoob/three.js/commit/0ddbd7e668f16d0a1dfaeeb6f88cf9844d1525d4)
- [TSLEncoder: update with new approach](https://github.com/mrdoob/three.js/commit/934fc0bebd6aa83ac6ff0b493e3c91b26a68960c)
