### PR TITLE
OutlinePass: Fix using with `BatchedMesh`.

### DIFF
--- a/examples/jsm/postprocessing/OutlinePass.js
+++ b/examples/jsm/postprocessing/OutlinePass.js
@@ -558,7 +558,8 @@ class OutlinePass extends Pass {
 			},
 
 			vertexShader:
-				`#include <morphtarget_pars_vertex>
+				`#include <batching_pars_vertex>
+				#include <morphtarget_pars_vertex>
 				#include <skinning_pars_vertex>
 
 				varying vec4 projTexCoord;
@@ -567,6 +568,7 @@ class OutlinePass extends Pass {
 
 				void main() {
 
+					#include <batching_vertex>
 					#include <skinbase_vertex>
 					#include <begin_vertex>
 					#include <morphtarget_vertex>


### PR DESCRIPTION
Fixed #30951 

**Description**

I added these imports in the shader to fix the error.

cc @gkjohnson 