### PR TITLE
fix:openthe developer tools are opened, the rotation of TrackballControls becomes very sticky.

### DIFF
--- a/examples/jsm/controls/TrackballControls.js
+++ b/examples/jsm/controls/TrackballControls.js
@@ -232,7 +232,7 @@ class TrackballControls extends Controls {
 
 		// event listeners
 
-		this._onPointerMove = onPointerMove.bind( this );
+		this._onPointerMove = throttle(onPointerMove.bind( this ),16);
 		this._onPointerDown = onPointerDown.bind( this );
 		this._onPointerUp = onPointerUp.bind( this );
 		this._onPointerCancel = onPointerCancel.bind( this );
@@ -651,6 +651,22 @@ class TrackballControls extends Controls {
 	}
 
 }
+
+function throttle (fn, delay){
+	let curTime = Date.now();
+
+	return function(){
+		let context = this,
+		args = arguments,
+		nowTime = Date.now();
+
+		if (nowTime - curTime >= delay) {
+			curTime = Date.now();
+			return fn.apply(context, args);
+		}
+	}
+}
+
 
 function onPointerDown( event ) {
 


### PR DESCRIPTION
**Description**
Problem:
When the developer tools are opened, the rotation of TrackballControls becomes very sticky.
Slove:
When the developer tools are opened, the browser increases the frequency of event triggers. 
To solve this problem, a throttle function is added to reduce the number of times the move event is triggered, maintaining the same frequency as when the developer tools are not open.
Video:
https://github.com/user-attachments/assets/92047286-ce6d-402e-882c-a51e57208880



