### PR TITLE
BatchedMesh: Fix toJSON, ObjectLoader integration

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -1296,26 +1296,39 @@ class Object3D extends EventDispatcher {
 
 			object.visibility = this._visibility;
 			object.active = this._active;
-			object.bounds = this._bounds.map( bound => ( {
-				boxInitialized: bound.boxInitialized,
-				boxMin: bound.box.min.toArray(),
-				boxMax: bound.box.max.toArray(),
+			object.geometryInfo = this._geometryInfo.map( info => ( {
+				boxInitialized: info.boxInitialized,
+				boxMin: info.boundingBox ? info.boundingBox.min.toArray() : null,
+				boxMax: info.boundingBox ? info.boundingBox.max.toArray() : null,
 
-				sphereInitialized: bound.sphereInitialized,
-				sphereRadius: bound.sphere.radius,
-				sphereCenter: bound.sphere.center.toArray()
+				sphereInitialized: info.sphereInitialized,
+				sphereRadius: info.boundingSphere ? info.boundingSphere.radius : null,
+				sphereCenter: info.boundingSphere ? info.boundingSphere.center.toArray() : null
 			} ) );
+			object.instanceInfo = this._instanceInfo.map( info => ( { ...info } ) );
+
+			object.availableInstanceIds = this._availableInstanceIds.slice();
+			object.availableGeometryIds = this._availableGeometryIds.slice();
+
+			object.nextIndexStart = this._nextIndexStart;
+			object.nextVertexStart = this._nextVertexStart;
+			object.geometryCount = this._geometryCount;
 
 			object.maxInstanceCount = this._maxInstanceCount;
 			object.maxVertexCount = this._maxVertexCount;
 			object.maxIndexCount = this._maxIndexCount;
 
 			object.geometryInitialized = this._geometryInitialized;
-			object.geometryCount = this._geometryCount;
 
 			object.matricesTexture = this._matricesTexture.toJSON( meta );
 
-			if ( this._colorsTexture !== null ) object.colorsTexture = this._colorsTexture.toJSON( meta );
+			object.indirectTexture = this._indirectTexture.toJSON( meta );
+
+			if ( this._colorsTexture !== null ) {
+
+				object.colorsTexture = this._colorsTexture.toJSON( meta );
+
+			}
 
 			if ( this.boundingSphere !== null ) {
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -1295,13 +1295,15 @@ class Object3D extends EventDispatcher {
 			object.reservedRanges = this._reservedRanges;
 
 			object.geometryInfo = this._geometryInfo.map( info => ( {
-				boxInitialized: info.boxInitialized,
-				boxMin: info.boundingBox ? info.boundingBox.min.toArray() : null,
-				boxMax: info.boundingBox ? info.boundingBox.max.toArray() : null,
-
-				sphereInitialized: info.sphereInitialized,
-				sphereRadius: info.boundingSphere ? info.boundingSphere.radius : null,
-				sphereCenter: info.boundingSphere ? info.boundingSphere.center.toArray() : null
+				...info,
+				boundingBox: info.boundingBox ? {
+					min: info.boundingBox.min.toArray(),
+					max: info.boundingBox.max.toArray()
+				} : undefined,
+				boundingSphere: info.boundingSphere ? {
+					radius: info.boundingSphere.radius,
+					center: info.boundingSphere.center.toArray()
+				} : undefined
 			} ) );
 			object.instanceInfo = this._instanceInfo.map( info => ( { ...info } ) );
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -1294,8 +1294,6 @@ class Object3D extends EventDispatcher {
 			object.drawRanges = this._drawRanges;
 			object.reservedRanges = this._reservedRanges;
 
-			object.visibility = this._visibility;
-			object.active = this._active;
 			object.geometryInfo = this._geometryInfo.map( info => ( {
 				boxInitialized: info.boxInitialized,
 				boxMin: info.boundingBox ? info.boundingBox.min.toArray() : null,
@@ -1333,8 +1331,8 @@ class Object3D extends EventDispatcher {
 			if ( this.boundingSphere !== null ) {
 
 				object.boundingSphere = {
-					center: object.boundingSphere.center.toArray(),
-					radius: object.boundingSphere.radius
+					center: this.boundingSphere.center.toArray(),
+					radius: this.boundingSphere.radius
 				};
 
 			}
@@ -1342,8 +1340,8 @@ class Object3D extends EventDispatcher {
 			if ( this.boundingBox !== null ) {
 
 				object.boundingBox = {
-					min: object.boundingBox.min.toArray(),
-					max: object.boundingBox.max.toArray()
+					min: this.boundingBox.min.toArray(),
+					max: this.boundingBox.max.toArray()
 				};
 
 			}

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -994,10 +994,8 @@ class ObjectLoader extends Loader {
 					}
 
 					return {
-						boxInitialized: info.boxInitialized,
+						...info,
 						boundingBox: box,
-
-						sphereInitialized: info.sphereInitialized,
 						boundingSphere: sphere
 					};
 

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -973,37 +973,65 @@ class ObjectLoader extends Loader {
 				object._drawRanges = data.drawRanges;
 				object._reservedRanges = data.reservedRanges;
 
-				object._visibility = data.visibility;
-				object._active = data.active;
-				object._bounds = data.bounds.map( bound => {
+				object._geometryInfo = data.geometryInfo.map( info => {
 
 					const box = new Box3();
-					box.min.fromArray( bound.boxMin );
-					box.max.fromArray( bound.boxMax );
+					box.min.fromArray( info.boxMin );
+					box.max.fromArray( info.boxMax );
 
 					const sphere = new Sphere();
-					sphere.radius = bound.sphereRadius;
-					sphere.center.fromArray( bound.sphereCenter );
+					sphere.radius = info.sphereRadius;
+					sphere.center.fromArray( info.sphereCenter );
 
 					return {
-						boxInitialized: bound.boxInitialized,
+						boxInitialized: info.boxInitialized,
 						box: box,
 
-						sphereInitialized: bound.sphereInitialized,
+						sphereInitialized: info.sphereInitialized,
 						sphere: sphere
 					};
 
 				} );
+				object._instanceInfo = data.instanceInfo;
+
+				object._availableInstanceIds = data._availableInstanceIds;
+				object._availableGeometryIds = data._availableGeometryIds;
+
+				object._nextIndexStart = data.nextIndexStart;
+				object._nextVertexStart = data.nextVertexStart;
+				object._geometryCount = data.geometryCount;
 
 				object._maxInstanceCount = data.maxInstanceCount;
 				object._maxVertexCount = data.maxVertexCount;
 				object._maxIndexCount = data.maxIndexCount;
 
 				object._geometryInitialized = data.geometryInitialized;
-				object._geometryCount = data.geometryCount;
 
 				object._matricesTexture = getTexture( data.matricesTexture.uuid );
-				if ( data.colorsTexture !== undefined ) object._colorsTexture = getTexture( data.colorsTexture.uuid );
+
+				object._indirectTexture = getTexture( data.indirectTexture.uuid );
+
+				if ( data.colorsTexture !== undefined ) {
+
+					object._colorsTexture = getTexture( data.colorsTexture.uuid );
+
+				}
+
+				if ( data.boundingSphere !== undefined ) {
+
+					object.boundingSphere = new Sphere();
+					object.boundingSphere.center.fromArray( data.boundingSphere.center );
+					object.boundingSphere.radius = data.boundingSphere.radius;
+
+				}
+
+				if ( data.boundingBox !== undefined ) {
+
+					object.boundingBox = new Box3();
+					object.boundingBox.min.fromArray( data.boundingBox.min );
+					object.boundingBox.max.fromArray( data.boundingBox.max );
+
+				}
 
 				break;
 

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -975,20 +975,30 @@ class ObjectLoader extends Loader {
 
 				object._geometryInfo = data.geometryInfo.map( info => {
 
-					const box = new Box3();
-					box.min.fromArray( info.boxMin );
-					box.max.fromArray( info.boxMax );
+					let box = null;
+					let sphere = null;
+					if ( info.boundingBox !== undefined ) {
 
-					const sphere = new Sphere();
-					sphere.radius = info.sphereRadius;
-					sphere.center.fromArray( info.sphereCenter );
+						box = new Box3();
+						box.min.fromArray( info.boundingBox.min );
+						box.max.fromArray( info.boundingBox.max );
+
+					}
+
+					if ( info.boundingSphere !== undefined ) {
+
+						sphere = new Sphere();
+						sphere.radius = info.boundingSphere.radius;
+						sphere.center.fromArray( info.boundingSphere.center );
+
+					}
 
 					return {
 						boxInitialized: info.boxInitialized,
-						box: box,
+						boundingBox: box,
 
 						sphereInitialized: info.sphereInitialized,
-						sphere: sphere
+						boundingSphere: sphere
 					};
 
 				} );

--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -1443,6 +1443,13 @@ class BatchedMesh extends Mesh {
 		} ) );
 		this._instanceInfo = source._instanceInfo.map( info => ( { ...info } ) );
 
+		this._availableInstanceIds = source._availableInstanceIds.slice();
+		this._availableGeometryIds = source._availableGeometryIds.slice();
+
+		this._nextIndexStart = source._nextIndexStart;
+		this._nextVertexStart = source._nextVertexStart;
+		this._geometryCount = source._geometryCount;
+
 		this._maxInstanceCount = source._maxInstanceCount;
 		this._maxVertexCount = source._maxVertexCount;
 		this._maxIndexCount = source._maxIndexCount;
@@ -1451,6 +1458,9 @@ class BatchedMesh extends Mesh {
 		this._geometryCount = source._geometryCount;
 		this._multiDrawCounts = source._multiDrawCounts.slice();
 		this._multiDrawStarts = source._multiDrawStarts.slice();
+
+		this._indirectTexture = source._indirectTexture.clone();
+		this._indirectTexture.image.data = this._indirectTexture.image.data.slice();
 
 		this._matricesTexture = source._matricesTexture.clone();
 		this._matricesTexture.image.data = this._matricesTexture.image.data.slice();

--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -1455,7 +1455,6 @@ class BatchedMesh extends Mesh {
 		this._maxIndexCount = source._maxIndexCount;
 
 		this._geometryInitialized = source._geometryInitialized;
-		this._geometryCount = source._geometryCount;
 		this._multiDrawCounts = source._multiDrawCounts.slice();
 		this._multiDrawStarts = source._multiDrawStarts.slice();
 


### PR DESCRIPTION
Fix #30960 
Fix #30961

**Description**

It seems BatchedMesh's toJSON and ObjectLoader integration had become out of date with some of the past changes. I tested by adding the following lines to the `webgl_mesh_batch` example to ensure the BatchedMesh could be cloned and serialized without error and render:

```js
// test clone
mesh = mesh.clone();

// test serialization
new THREE.ObjectLoader().parse( mesh.toJSON(), res => {

	mesh = res;
	scene.add( mesh );

} );
```

A couple questions (cc @mugen87):

- Have we considered adding `toJSON` and `fromJSON` functions to the Box3 or Sphere classes to make some of this kind of serialization more clean?
- Would we be open to adding some tests that serialize and deserialize different three.js Object3D classes and performs a diff between the source and clone to ensure the end-to-end serialization is working correctly?
- I'm sure I've asked it before but can your remind me why `Object3D.toJSON` handles serialization for all objects types rather than each child class implementing its own toJSON method? 