### PR TITLE
TSL: Fixes the return value of `atomic*` nodes

### DIFF
--- a/src/nodes/core/Node.js
+++ b/src/nodes/core/Node.js
@@ -88,6 +88,14 @@ class Node extends EventDispatcher {
 		this.global = false;
 
 		/**
+		 * Create a list of parents for this node during the build process.
+		 *
+		 * @type {boolean}
+		 * @default false
+		 */
+		this.parents = false;
+
+		/**
 		 * This flag can be used for type testing.
 		 *
 		 * @type {boolean}
@@ -642,6 +650,14 @@ class Node extends EventDispatcher {
 				for ( const childNode of Object.values( properties ) ) {
 
 					if ( childNode && childNode.isNode === true ) {
+
+						if ( childNode.parents === true ) {
+
+							const childProperties = builder.getNodeProperties( childNode );
+							childProperties.parents = childProperties.parents || [];
+							childProperties.parents.push( this );
+
+						}
 
 						childNode.build( builder );
 

--- a/src/nodes/gpgpu/AtomicFunctionNode.js
+++ b/src/nodes/gpgpu/AtomicFunctionNode.js
@@ -1,4 +1,4 @@
-import TempNode from '../core/TempNode.js';
+import Node from '../core/Node.js';
 import { nodeProxy } from '../tsl/TSLCore.js';
 
 /**
@@ -10,9 +10,9 @@ import { nodeProxy } from '../tsl/TSLCore.js';
  *
  * This node can only be used with a WebGPU backend.
  *
- * @augments TempNode
+ * @augments Node
  */
-class AtomicFunctionNode extends TempNode {
+class AtomicFunctionNode extends Node {
 
 	static get type() {
 
@@ -52,6 +52,14 @@ class AtomicFunctionNode extends TempNode {
 		 */
 		this.valueNode = valueNode;
 
+		/**
+		 * Creates a list of the parents for this node for detecting if the node needs to return a value.
+		 *
+		 * @type {boolean}
+		 * @default true
+		 */
+		this.parents = true;
+
 	}
 
 	/**
@@ -81,6 +89,8 @@ class AtomicFunctionNode extends TempNode {
 
 	generate( builder ) {
 
+		const parents = builder.getNodeProperties( this ).parents;
+
 		const method = this.method;
 
 		const type = this.getNodeType( builder );
@@ -101,8 +111,9 @@ class AtomicFunctionNode extends TempNode {
 		}
 
 		const methodSnippet = `${ builder.getMethod( method, type ) }( ${ params.join( ', ' ) } )`;
+		const isVoid = parents.length === 1 && parents[ 0 ].isStackNode === true;
 
-		if ( b !== null ) {
+		if ( isVoid ) {
 
 			builder.addLineFlowCode( methodSnippet, this );
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/30732#issuecomment-2808111274

**Description**

Detects whether `atomic*` needs to return a value or can be added to the stack immediately, allowing it to be used inside or outside expressions.

Summary
- [x] [add parents properties](https://github.com/mrdoob/three.js/commit/1620328f3ee4e83e72801a34e925de4d34c28782)
- [x] [TSL: Fixes the return value of atomic* nodes](https://github.com/mrdoob/three.js/commit/eb84a0db9a2e70dec4e6ceb90cba99a937a5f443)