### PR TITLE
TSL: Auto-cache `atomic*` nodes

### DIFF
--- a/src/nodes/gpgpu/AtomicFunctionNode.js
+++ b/src/nodes/gpgpu/AtomicFunctionNode.js
@@ -1,4 +1,5 @@
 import Node from '../core/Node.js';
+import { expression } from '../code/ExpressionNode.js';
 import { nodeProxy } from '../tsl/TSLCore.js';
 
 /**
@@ -89,7 +90,8 @@ class AtomicFunctionNode extends Node {
 
 	generate( builder ) {
 
-		const parents = builder.getNodeProperties( this ).parents;
+		const properties = builder.getNodeProperties( this );
+		const parents = properties.parents;
 
 		const method = this.method;
 
@@ -119,12 +121,13 @@ class AtomicFunctionNode extends Node {
 
 		} else {
 
-			const nodeVar = builder.getVarFromNode( this, null, type );
-			const propertyName = builder.getPropertyName( nodeVar );
+			if ( properties.constNode === undefined ) {
 
-			builder.addLineFlowCode( `${ propertyName } = ${ methodSnippet }`, this );
+				properties.constNode = expression( methodSnippet, type ).toConst();
 
-			return propertyName;
+			}
+
+			return properties.constNode.build( builder );
 
 		}
 

--- a/src/nodes/gpgpu/AtomicFunctionNode.js
+++ b/src/nodes/gpgpu/AtomicFunctionNode.js
@@ -117,9 +117,16 @@ class AtomicFunctionNode extends Node {
 
 			builder.addLineFlowCode( methodSnippet, this );
 
-		}
+		} else {
 
-		return methodSnippet;
+			const nodeVar = builder.getVarFromNode( this, null, type );
+			const propertyName = builder.getPropertyName( nodeVar );
+
+			builder.addLineFlowCode( `${ propertyName } = ${ methodSnippet }`, this );
+
+			return propertyName;
+
+		}
 
 	}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/30971

**Description**

This avoids double-adding by adding `assign()` multiple times without using `.toConst()` or `.toVar()`. 
