### PR TITLE
TSL: Improve `debug()` callback changing to `( builder, code )` function signature

### DIFF
--- a/src/nodes/utils/DebugNode.js
+++ b/src/nodes/utils/DebugNode.js
@@ -68,7 +68,7 @@ class DebugNode extends TempNode {
 
 export default DebugNode;
 
-/*
+/**
  * TSL function for creating a debug node.
  *
  * @tsl

--- a/src/nodes/utils/DebugNode.js
+++ b/src/nodes/utils/DebugNode.js
@@ -74,7 +74,7 @@ export default DebugNode;
  * @tsl
  * @function
  * @param {Node} node - The node to debug.
- * @param {?function} [callback=null] - Optional callback function to handle the debug output.
+ * @param {?Function} [callback=null] - Optional callback function to handle the debug output.
  * @returns {DebugNode}
  */
 export const debug = ( node, callback = null ) => nodeObject( new DebugNode( nodeObject( node ), callback ) );

--- a/src/nodes/utils/DebugNode.js
+++ b/src/nodes/utils/DebugNode.js
@@ -74,7 +74,7 @@ export default DebugNode;
  * @tsl
  * @function
  * @param {Node} node - The node to debug.
- * @param {function} [callback] - Optional callback function to handle the debug output.
+ * @param {?function} [callback=null] - Optional callback function to handle the debug output.
  * @returns {DebugNode}
  */
 export const debug = ( node, callback = null ) => nodeObject( new DebugNode( nodeObject( node ), callback ) );

--- a/src/nodes/utils/DebugNode.js
+++ b/src/nodes/utils/DebugNode.js
@@ -52,7 +52,7 @@ class DebugNode extends TempNode {
 
 		if ( callback !== null ) {
 
-			callback( code );
+			callback( builder, code );
 
 		} else {
 

--- a/src/nodes/utils/DebugNode.js
+++ b/src/nodes/utils/DebugNode.js
@@ -68,6 +68,15 @@ class DebugNode extends TempNode {
 
 export default DebugNode;
 
+/*
+ * TSL function for creating a debug node.
+ *
+ * @tsl
+ * @function
+ * @param {Node} node - The node to debug.
+ * @param {function} [callback] - Optional callback function to handle the debug output.
+ * @returns {DebugNode}
+ */
 export const debug = ( node, callback = null ) => nodeObject( new DebugNode( nodeObject( node ), callback ) );
 
 addMethodChaining( 'debug', debug );


### PR DESCRIPTION
Closes https://github.com/mrdoob/three.js/issues/30186

**Description**

Change the callback signature from debug to `callback( builder, code )`, thus giving the developer greater options.

```js
material.outputNode = output.debug( ( ( builder ) => {

	console.log( builder.uniforms );
	// console.log( builder.flow ); // for the current flow of code

} ) );
```
