### PR TITLE
Examples: Call `ImageBitmap.close()` in `webgl_loader_imagebitmap`.

### DIFF
--- a/examples/webgl_loader_imagebitmap.html
+++ b/examples/webgl_loader_imagebitmap.html
@@ -38,10 +38,9 @@
 						texture.colorSpace = THREE.SRGBColorSpace;
 						const material = new THREE.MeshBasicMaterial( { map: texture } );
 
-						/* ImageBitmap should be disposed when done with it
-						   Can't be done until it's actually uploaded to WebGLTexture */
+						// ImageBitmap should be disposed when done with it.
 
-						// imageBitmap.close();
+						texture.onUpdate = disposeImageBitmap;
 
 						addCube( material );
 
@@ -145,6 +144,13 @@
 				group.rotation.y = performance.now() / 3000;
 
 				renderer.render( scene, camera );
+
+			}
+
+			function disposeImageBitmap( texture ) {
+
+				texture.source.data.close();
+				texture.onUpdate = null; // make sure this callback is executed only once per texture
 
 			}
 


### PR DESCRIPTION
Related issue: #30416

**Description**

The PR resolves a comment in `webgl_loader_imagebitmap` which suggested the usage of `ImageBitmap.close()` to force a dispose after the texture upload. At that time when `ImageBitmapLoader` was added, the original author probably overlooked that this can be done with `Texture.onUpdate()`.