### PR TITLE
Examples: Clean up.

### DIFF
--- a/examples/webgpu_centroid_sampling.html
+++ b/examples/webgpu_centroid_sampling.html
@@ -158,8 +158,8 @@
 
 				};
 
-				const withFlatFirstShader = createShader( 'flat', 'first' );
-				const withFlatEitherShader = createShader( 'flat', 'either' );
+				const withFlatFirstShader = createShader( THREE.InterpolationSamplingType.FLAT, THREE.InterpolationSamplingMode.FLAT_FIRST );
+				const withFlatEitherShader = createShader( THREE.InterpolationSamplingType.FLAT, THREE.InterpolationSamplingMode.FLAT_EITHER );
 
 				const withSampleShader = Fn( () => {
 


### PR DESCRIPTION
Related issue: N/A

**Description**

Seems like the sampling modes should be 'flat first' and 'flat either' instead of 'first' and 'either'. I went ahead and used the constants to avoid further issues.
