### PR TITLE
Examples: Fix shadows in physics instancing demos.

### DIFF
--- a/examples/physics_ammo_instancing.html
+++ b/examples/physics_ammo_instancing.html
@@ -60,14 +60,25 @@
 				dirLight.shadow.camera.zoom = 2;
 				scene.add( dirLight );
 
-				const floor = new THREE.Mesh(
-					new THREE.BoxGeometry( 10, 5, 10 ),
-					new THREE.ShadowMaterial( { color: 0x444444 } )
+				const shadowPlane = new THREE.Mesh(
+					new THREE.PlaneGeometry( 10, 10 ),
+					new THREE.ShadowMaterial( {
+						color: 0x444444,
+						polygonOffset: true,
+						polygonOffsetFactor: - 0.01
+					} ),
 				);
-				floor.position.y = - 2.5;
-				floor.receiveShadow = true;
-				floor.userData.physics = { mass: 0 };
-				scene.add( floor );
+				shadowPlane.rotation.x = - Math.PI / 2;
+				shadowPlane.receiveShadow = true;
+				scene.add( shadowPlane );
+
+				const floorCollider = new THREE.Mesh(
+					new THREE.BoxGeometry( 10, 5, 10 ),
+					new THREE.MeshBasicMaterial( { color: 0x666666 } )
+				);
+				floorCollider.position.y = - 2.5;
+				floorCollider.userData.physics = { mass: 0 };
+				scene.add( floorCollider );
 
 				//
 

--- a/examples/physics_ammo_instancing.html
+++ b/examples/physics_ammo_instancing.html
@@ -63,9 +63,7 @@
 				const shadowPlane = new THREE.Mesh(
 					new THREE.PlaneGeometry( 10, 10 ),
 					new THREE.ShadowMaterial( {
-						color: 0x444444,
-						polygonOffset: true,
-						polygonOffsetFactor: - 0.01
+						color: 0x444444
 					} ),
 				);
 				shadowPlane.rotation.x = - Math.PI / 2;
@@ -78,6 +76,7 @@
 				);
 				floorCollider.position.y = - 2.5;
 				floorCollider.userData.physics = { mass: 0 };
+				floorCollider.visible = false;
 				scene.add( floorCollider );
 
 				//

--- a/examples/physics_jolt_instancing.html
+++ b/examples/physics_jolt_instancing.html
@@ -61,9 +61,7 @@
 				const shadowPlane = new THREE.Mesh(
 					new THREE.PlaneGeometry( 10, 10 ),
 					new THREE.ShadowMaterial( {
-						color: 0x444444,
-						polygonOffset: true,
-						polygonOffsetFactor: - 0.01
+						color: 0x444444
 					} ),
 				);
 				shadowPlane.rotation.x = - Math.PI / 2;
@@ -76,6 +74,7 @@
 				);
 				floorCollider.position.y = - 2.5;
 				floorCollider.userData.physics = { mass: 0 };
+				floorCollider.visible = false;
 				scene.add( floorCollider );
 
 				//

--- a/examples/physics_jolt_instancing.html
+++ b/examples/physics_jolt_instancing.html
@@ -58,14 +58,25 @@
 				dirLight.shadow.camera.zoom = 2;
 				scene.add( dirLight );
 
-				const floor = new THREE.Mesh(
-					new THREE.BoxGeometry( 10, 5, 10 ),
-					new THREE.ShadowMaterial( { color: 0x444444 } )
+				const shadowPlane = new THREE.Mesh(
+					new THREE.PlaneGeometry( 10, 10 ),
+					new THREE.ShadowMaterial( {
+						color: 0x444444,
+						polygonOffset: true,
+						polygonOffsetFactor: - 0.01
+					} ),
 				);
-				floor.position.y = - 2.5;
-				floor.receiveShadow = true;
-				floor.userData.physics = { mass: 0 };
-				scene.add( floor );
+				shadowPlane.rotation.x = - Math.PI / 2;
+				shadowPlane.receiveShadow = true;
+				scene.add( shadowPlane );
+
+				const floorCollider = new THREE.Mesh(
+					new THREE.BoxGeometry( 10, 5, 10 ),
+					new THREE.MeshBasicMaterial( { color: 0x666666 } )
+				);
+				floorCollider.position.y = - 2.5;
+				floorCollider.userData.physics = { mass: 0 };
+				scene.add( floorCollider );
 
 				//
 

--- a/examples/physics_rapier_instancing.html
+++ b/examples/physics_rapier_instancing.html
@@ -61,9 +61,7 @@
 				const shadowPlane = new THREE.Mesh(
 					new THREE.PlaneGeometry( 10, 10 ),
 					new THREE.ShadowMaterial( {
-						color: 0x444444,
-						polygonOffset: true,
-						polygonOffsetFactor: - 0.01
+						color: 0x444444
 					} ),
 				);
 				shadowPlane.rotation.x = - Math.PI / 2;
@@ -76,6 +74,7 @@
 				);
 				floorCollider.position.y = - 2.5;
 				floorCollider.userData.physics = { mass: 0 };
+				floorCollider.visible = false;
 				scene.add( floorCollider );
 
 				//

--- a/examples/physics_rapier_instancing.html
+++ b/examples/physics_rapier_instancing.html
@@ -58,14 +58,25 @@
 				dirLight.shadow.camera.zoom = 2;
 				scene.add( dirLight );
 
-				const floor = new THREE.Mesh(
-					new THREE.BoxGeometry( 10, 5, 10 ),
-					new THREE.ShadowMaterial( { color: 0x444444 } )
+				const shadowPlane = new THREE.Mesh(
+					new THREE.PlaneGeometry( 10, 10 ),
+					new THREE.ShadowMaterial( {
+						color: 0x444444,
+						polygonOffset: true,
+						polygonOffsetFactor: - 0.01
+					} ),
 				);
-				floor.position.y = - 2.5;
-				floor.receiveShadow = true;
-				floor.userData.physics = { mass: 0 };
-				scene.add( floor );
+				shadowPlane.rotation.x = - Math.PI / 2;
+				shadowPlane.receiveShadow = true;
+				scene.add( shadowPlane );
+
+				const floorCollider = new THREE.Mesh(
+					new THREE.BoxGeometry( 10, 5, 10 ),
+					new THREE.MeshBasicMaterial( { color: 0x666666 } )
+				);
+				floorCollider.position.y = - 2.5;
+				floorCollider.userData.physics = { mass: 0 };
+				scene.add( floorCollider );
 
 				//
 


### PR DESCRIPTION
Fixed #30987.

**Description**

As explained in https://github.com/mrdoob/three.js/issues/30987#issuecomment-2826745563 the PR makes sure to use `ShadowMaterial` with plane geometries to avoid rendering issues.