### PR TITLE
Examples: Cleanup `webgl_reverse_depth_buffer`.

### DIFF
--- a/examples/webgl_reverse_depth_buffer.html
+++ b/examples/webgl_reverse_depth_buffer.html
@@ -113,7 +113,6 @@
 			const meshes = [];
 
 			const renderTarget = new THREE.WebGLRenderTarget();
-			renderTarget.type = THREE.UnsignedByteType;
 			renderTarget.depthTexture = new THREE.DepthTexture();
 			renderTarget.depthTexture.type = THREE.FloatType;
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/30941#discussion_r2057124885

**Description**

Removes the extraneous line in the example.

The correct API would instead be `renderTarget.texture.type`, but it is `UnsignedByteType` by default.
