### PR TITLE
WEBGPU: make batchMesh._matricesTexture optional

### DIFF
--- a/src/nodes/accessors/BatchNode.js
+++ b/src/nodes/accessors/BatchNode.js
@@ -107,7 +107,7 @@ class BatchNode extends Node {
 				textureLoad( matricesTexture, ivec2( x.add( 3 ), y ) )
 			);
 
-		}	 
+		}
 
 
 		const colorsTexture = this.batchMesh._colorsTexture;

--- a/src/nodes/accessors/BatchNode.js
+++ b/src/nodes/accessors/BatchNode.js
@@ -91,17 +91,23 @@ class BatchNode extends Node {
 
 		const matricesTexture = this.batchMesh._matricesTexture;
 
-		const size = int( textureSize( textureLoad( matricesTexture ), 0 ).x );
-		const j = float( indirectId ).mul( 4 ).toInt().toVar();
+		let batchingMatrix = mat4();
 
-		const x = j.mod( size );
-		const y = j.div( size );
-		const batchingMatrix = mat4(
-			textureLoad( matricesTexture, ivec2( x, y ) ),
-			textureLoad( matricesTexture, ivec2( x.add( 1 ), y ) ),
-			textureLoad( matricesTexture, ivec2( x.add( 2 ), y ) ),
-			textureLoad( matricesTexture, ivec2( x.add( 3 ), y ) )
-		);
+		if ( matricesTexture !== null ) {
+
+			const size = int( textureSize( textureLoad( matricesTexture ), 0 ).x );
+			const j = float( indirectId ).mul( 4 ).toInt().toVar();
+
+			const x = j.mod( size );
+			const y = j.div( size );
+			batchingMatrix = mat4(
+				textureLoad( matricesTexture, ivec2( x, y ) ),
+				textureLoad( matricesTexture, ivec2( x.add( 1 ), y ) ),
+				textureLoad( matricesTexture, ivec2( x.add( 2 ), y ) ),
+				textureLoad( matricesTexture, ivec2( x.add( 3 ), y ) )
+			);
+
+		}	 
 
 
 		const colorsTexture = this.batchMesh._colorsTexture;

--- a/src/renderers/common/RenderObject.js
+++ b/src/renderers/common/RenderObject.js
@@ -703,8 +703,12 @@ class RenderObject {
 		}
 
 		if ( object.isBatchedMesh ) {
+			
+			if ( object._matricesTexture !== null ) {
 
-			cacheKey += object._matricesTexture.uuid + ',';
+				cacheKey += object._matricesTexture.uuid + ',';
+
+			}
 
 			if ( object._colorsTexture !== null ) {
 

--- a/src/renderers/common/RenderObject.js
+++ b/src/renderers/common/RenderObject.js
@@ -703,7 +703,7 @@ class RenderObject {
 		}
 
 		if ( object.isBatchedMesh ) {
-			
+
 			if ( object._matricesTexture !== null ) {
 
 				cacheKey += object._matricesTexture.uuid + ',';


### PR DESCRIPTION
I dont use  `batchMesh._matricesTexture` and cant switch to webgpu without modifications
With these changes it works