### PR TITLE
Avoid unnecessary console warning

### DIFF
--- a/src/nodes/core/AttributeNode.js
+++ b/src/nodes/core/AttributeNode.js
@@ -125,8 +125,6 @@ class AttributeNode extends Node {
 
 		} else {
 
-			console.warn( `AttributeNode: Vertex attribute "${ attributeName }" not found on geometry.` );
-
 			return builder.generateConst( nodeType );
 
 		}


### PR DESCRIPTION
This PR is only intended to disable the console warning when no attributes are used.

With SBOs + structs / structArrays + drawIndirect / drawIndexedIndirect, there are no longer any attributes. You can precisely control which vertices the vertex shader should be executed for, instead of simply looping through all attribute entries like the classic approach.
Attribute-based geometry is fine, but it's no longer the only way and for highend not the best. The modern approach works without attributes, so missing a position, normal, or uv attribute isn't an error. And I admit that over time, when I'm developing, it bothers me to get a warning in the console that draws attention to something that isn't an error.
