### PR TITLE
Manual: Fix primitives page.

### DIFF
--- a/manual/resources/lesson.js
+++ b/manual/resources/lesson.js
@@ -48,15 +48,22 @@
 
 	}
 
-	let text = document.body.innerHTML;
+	const parts = window.location.href.split( '/' );
+	const filename = parts[ parts.length - 1 ];
 
-	text = text.replace( /\[link:([\w\:\/\.\-\_\(\)\?\#\=\!\~]+)\]/gi, '<a href="$1" target="_blank">$1</a>' ); // [link:url]
-	text = text.replace( /\[link:([\w:/.\-_()?#=!~]+) ([\w\p{L}:/.\-_'\s]+)\]/giu, '<a href="$1" target="_blank">$2</a>' ); // [link:url title]
-	text = text.replace( /\[example:([\w\_]+)\]/gi, '[example:$1 $1]' ); // [example:name] to [example:name title]
-	text = text.replace( /\[example:([\w\_]+) ([\w\:\/\.\-\_ \s]+)\]/gi, '<a href="../../examples/#$1" target="_blank">$2</a>' ); // [example:name title]
-	text = text.replace( /\`(.*?)\`/gs, '<code class="notranslate" translate="no">$1</code>' ); // `code`
+	if ( filename !== 'primitives.html' ) {
 
-	document.body.innerHTML = text;
+		let text = document.body.innerHTML;
+
+		text = text.replace( /\[link:([\w\:\/\.\-\_\(\)\?\#\=\!\~]+)\]/gi, '<a href="$1" target="_blank">$1</a>' ); // [link:url]
+		text = text.replace( /\[link:([\w:/.\-_()?#=!~]+) ([\w\p{L}:/.\-_'\s]+)\]/giu, '<a href="$1" target="_blank">$2</a>' ); // [link:url title]
+		text = text.replace( /\[example:([\w\_]+)\]/gi, '[example:$1 $1]' ); // [example:name] to [example:name title]
+		text = text.replace( /\[example:([\w\_]+) ([\w\:\/\.\-\_ \s]+)\]/gi, '<a href="../../examples/#$1" target="_blank">$2</a>' ); // [example:name title]
+		text = text.replace( /\`(.*?)\`/gs, '<code class="notranslate" translate="no">$1</code>' ); // `code`
+
+		document.body.innerHTML = text;
+
+	}
 
 	if ( window.prettyPrint ) {
 

--- a/manual/resources/threejs-primitives.js
+++ b/manual/resources/threejs-primitives.js
@@ -830,7 +830,7 @@ const geometry = new THREE.WireframeGeometry(
 
 		const a = document.createElement( 'a' );
 		a.setAttribute( 'target', '_blank' );
-		a.href = href || `https://threejs.org/docs/#api/geometries/${name}`;
+		a.href = href || `https://threejs.org/docs/#api/en/geometries/${name}`;
 		const code = document.createElement( 'code' );
 		code.textContent = name;
 		a.appendChild( code );
@@ -842,7 +842,7 @@ const geometry = new THREE.WireframeGeometry(
 	function addDeepLink( parent, name, href ) {
 
 		const a = document.createElement( 'a' );
-		a.href = href || `https://threejs.org/docs/#api/geometries/${name}`;
+		a.href = href || `https://threejs.org/docs/#api/en/geometries/${name}`;
 		a.textContent = name;
 		a.className = 'deep-link';
 		parent.appendChild( a );


### PR DESCRIPTION
Fixed #30996.

**Description**

#30736 introduced a regression since it broken the intersection observer logic used in `primitives.html`. Unlike other manual pages it uses the `defer` keyword to include `prettify.js` and `lesson.js`. That requires an exception in `lesson.js` so  the DOM post processing does not break anything.

The PR also fixes some links to the documentation.