### PR TITLE
Texture: Add updateRanges.

### DIFF
--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -594,14 +594,12 @@ class BatchedMesh extends Mesh {
 
 		const matricesTexture = this._matricesTexture;
 		_matrix.identity().toArray( matricesTexture.image.data, drawId * 16 );
-		matricesTexture.addUpdateRange( drawId * 16, 16 );
 		matricesTexture.needsUpdate = true;
 
 		const colorsTexture = this._colorsTexture;
 		if ( colorsTexture ) {
 
 			_whiteColor.toArray( colorsTexture.image.data, drawId * 4 );
-			colorsTexture.addUpdateRange( drawId * 4, 4 );
 			colorsTexture.needsUpdate = true;
 
 		}
@@ -1080,7 +1078,6 @@ class BatchedMesh extends Mesh {
 		const matricesTexture = this._matricesTexture;
 		const matricesArray = this._matricesTexture.image.data;
 		matrix.toArray( matricesArray, instanceId * 16 );
-		matricesTexture.addUpdateRange( instanceId * 16, 16 );
 		matricesTexture.needsUpdate = true;
 
 		return this;
@@ -1119,7 +1116,6 @@ class BatchedMesh extends Mesh {
 		}
 
 		color.toArray( this._colorsTexture.image.data, instanceId * 4 );
-		this._colorsTexture.addUpdateRange( instanceId * 4, 4 );
 		this._colorsTexture.needsUpdate = true;
 
 		return this;

--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -594,12 +594,14 @@ class BatchedMesh extends Mesh {
 
 		const matricesTexture = this._matricesTexture;
 		_matrix.identity().toArray( matricesTexture.image.data, drawId * 16 );
+		matricesTexture.addUpdateRange( drawId * 16, 16 );
 		matricesTexture.needsUpdate = true;
 
 		const colorsTexture = this._colorsTexture;
 		if ( colorsTexture ) {
 
 			_whiteColor.toArray( colorsTexture.image.data, drawId * 4 );
+			colorsTexture.addUpdateRange( drawId * 4, 4 );
 			colorsTexture.needsUpdate = true;
 
 		}
@@ -1078,6 +1080,7 @@ class BatchedMesh extends Mesh {
 		const matricesTexture = this._matricesTexture;
 		const matricesArray = this._matricesTexture.image.data;
 		matrix.toArray( matricesArray, instanceId * 16 );
+		matricesTexture.addUpdateRange( instanceId * 16, 16 );
 		matricesTexture.needsUpdate = true;
 
 		return this;
@@ -1116,6 +1119,7 @@ class BatchedMesh extends Mesh {
 		}
 
 		color.toArray( this._colorsTexture.image.data, instanceId * 4 );
+		this._colorsTexture.addUpdateRange( instanceId * 4, 4 );
 		this._colorsTexture.needsUpdate = true;
 
 		return this;

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -889,6 +889,8 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 								}
 
+								texture.clearUpdateRanges();
+
 								_gl.pixelStorei( _gl.UNPACK_ROW_LENGTH, currentUnpackRowLen );
 								_gl.pixelStorei( _gl.UNPACK_SKIP_PIXELS, currentUnpackSkipPixels );
 								_gl.pixelStorei( _gl.UNPACK_SKIP_ROWS, currentUnpackSkipRows );

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -828,7 +828,6 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 				const y = Math.floor( pixelStart / image.width );
 
 				// Assumes update ranges refer to contiguous memory
-				// TODO: split multi-row updates into multiple calls?
 				const width = pixelCount;
 				const height = 1;
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -739,6 +739,116 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 	}
 
+	function getRow( index, rowLength, componentStride ) {
+
+		return Math.floor( Math.floor( index / componentStride ) / rowLength );
+
+	}
+
+	function updateTexture( texture, image, glFormat, glType ) {
+
+		const componentStride = 4; // only RGBA supported
+
+		const updateRanges = texture.updateRanges;
+
+		if ( updateRanges.length === 0 ) {
+
+			state.texSubImage2D( _gl.TEXTURE_2D, 0, 0, 0, image.width, image.height, glFormat, glType, image.data );
+
+		} else {
+
+			// Before applying update ranges, we merge any adjacent / overlapping
+			// ranges to reduce load on `gl.bufferSubData`. Empirically, this has led
+			// to performance improvements for applications which make heavy use of
+			// update ranges. Likely due to GPU command overhead.
+			//
+			// Note that to reduce garbage collection between frames, we merge the
+			// update ranges in-place. This is safe because this method will clear the
+			// update ranges once updated.
+
+			updateRanges.sort( ( a, b ) => a.start - b.start );
+
+			// To merge the update ranges in-place, we work from left to right in the
+			// existing updateRanges array, merging ranges. This may result in a final
+			// array which is smaller than the original. This index tracks the last
+			// index representing a merged range, any data after this index can be
+			// trimmed once the merge algorithm is completed.
+			let mergeIndex = 0;
+
+			for ( let i = 1; i < updateRanges.length; i ++ ) {
+
+				const previousRange = updateRanges[ mergeIndex ];
+				const range = updateRanges[ i ];
+
+				// We add one here to merge adjacent ranges. This is safe because ranges
+				// operate over positive integers.
+				const previousEnd = previousRange.start + previousRange.count;
+				const currentRow = getRow( range.start, image.width, componentStride );
+				const previousRow = getRow( previousRange.start, image.width, componentStride );
+
+				// Only merge if in the same row and overlapping/adjacent
+				if (
+					range.start <= previousEnd + 1 &&
+					currentRow === previousRow &&
+					getRow( range.start + range.count - 1, image.width, componentStride ) === currentRow // ensure range doesn't spill
+				) {
+
+					previousRange.count = Math.max(
+						previousRange.count,
+						range.start + range.count - previousRange.start
+					);
+
+				} else {
+
+					++ mergeIndex;
+					updateRanges[ mergeIndex ] = range;
+
+				}
+
+
+			}
+
+			// Trim the array to only contain the merged ranges.
+			updateRanges.length = mergeIndex + 1;
+
+			const currentUnpackRowLen = _gl.getParameter( _gl.UNPACK_ROW_LENGTH );
+			const currentUnpackSkipPixels = _gl.getParameter( _gl.UNPACK_SKIP_PIXELS );
+			const currentUnpackSkipRows = _gl.getParameter( _gl.UNPACK_SKIP_ROWS );
+
+			_gl.pixelStorei( _gl.UNPACK_ROW_LENGTH, image.width );
+
+			for ( let i = 0, l = updateRanges.length; i < l; i ++ ) {
+
+				const range = updateRanges[ i ];
+
+				const pixelStart = Math.floor( range.start / componentStride );
+				const pixelCount = Math.ceil( range.count / componentStride );
+
+				const x = pixelStart % image.width;
+				const y = Math.floor( pixelStart / image.width );
+
+				// Assumes update ranges refer to contiguous memory
+				// TODO: split multi-row updates into multiple calls?
+				const width = pixelCount;
+				const height = 1;
+
+				_gl.pixelStorei( _gl.UNPACK_SKIP_PIXELS, x );
+				_gl.pixelStorei( _gl.UNPACK_SKIP_ROWS, y );
+
+				state.texSubImage2D( _gl.TEXTURE_2D, 0, x, y, width, height, glFormat, glType, image.data );
+
+			}
+
+			texture.clearUpdateRanges();
+
+			_gl.pixelStorei( _gl.UNPACK_ROW_LENGTH, currentUnpackRowLen );
+			_gl.pixelStorei( _gl.UNPACK_SKIP_PIXELS, currentUnpackSkipPixels );
+			_gl.pixelStorei( _gl.UNPACK_SKIP_ROWS, currentUnpackSkipRows );
+
+		}
+
+	}
+
 	function uploadTexture( textureProperties, texture, slot ) {
 
 		let textureType = _gl.TEXTURE_2D;
@@ -778,7 +888,6 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 			let mipmap;
 			const mipmaps = texture.mipmaps;
-			const updateRanges = texture.updateRanges;
 
 			const useTexStorage = ( texture.isVideoTexture !== true );
 			const allocateMemory = ( sourceProperties.__version === undefined ) || ( forceUpload === true );
@@ -853,49 +962,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 						if ( dataReady ) {
 
-							if ( updateRanges.length === 0 ) {
-
-								state.texSubImage2D( _gl.TEXTURE_2D, 0, 0, 0, image.width, image.height, glFormat, glType, image.data );
-
-							} else {
-
-								const currentUnpackRowLen = _gl.getParameter( _gl.UNPACK_ROW_LENGTH );
-								const currentUnpackSkipPixels = _gl.getParameter( _gl.UNPACK_SKIP_PIXELS );
-								const currentUnpackSkipRows = _gl.getParameter( _gl.UNPACK_SKIP_ROWS );
-
-								_gl.pixelStorei( _gl.UNPACK_ROW_LENGTH, image.width );
-
-								const componentStride = 4; // only RGBA supported
-
-								for ( let i = 0, l = updateRanges.length; i < l; i ++ ) {
-
-									const range = updateRanges[ i ];
-
-									const pixelStart = Math.floor( range.start / componentStride );
-									const pixelCount = Math.ceil( range.count / componentStride );
-
-									const x = pixelStart % image.width;
-									const y = Math.floor( pixelStart / image.width );
-
-									// Assumes update ranges refer to contiguous memory
-									// TODO: split multi-row updates into multiple calls?
-									const width = pixelCount;
-									const height = 1;
-
-									_gl.pixelStorei( _gl.UNPACK_SKIP_PIXELS, x );
-									_gl.pixelStorei( _gl.UNPACK_SKIP_ROWS, y );
-
-									state.texSubImage2D( _gl.TEXTURE_2D, 0, x, y, width, height, glFormat, glType, image.data );
-
-								}
-
-								texture.clearUpdateRanges();
-
-								_gl.pixelStorei( _gl.UNPACK_ROW_LENGTH, currentUnpackRowLen );
-								_gl.pixelStorei( _gl.UNPACK_SKIP_PIXELS, currentUnpackSkipPixels );
-								_gl.pixelStorei( _gl.UNPACK_SKIP_ROWS, currentUnpackSkipRows );
-
-							}
+							updateTexture( texture, image, glFormat, glType );
 
 						}
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -758,7 +758,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 		} else {
 
 			// Before applying update ranges, we merge any adjacent / overlapping
-			// ranges to reduce load on `gl.bufferSubData`. Empirically, this has led
+			// ranges to reduce load on `gl.texSubImage2D`. Empirically, this has led
 			// to performance improvements for applications which make heavy use of
 			// update ranges. Likely due to GPU command overhead.
 			//
@@ -780,13 +780,13 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 				const previousRange = updateRanges[ mergeIndex ];
 				const range = updateRanges[ i ];
 
-				// We add one here to merge adjacent ranges. This is safe because ranges
-				// operate over positive integers.
+				// Only merge if in the same row and overlapping/adjacent
 				const previousEnd = previousRange.start + previousRange.count;
 				const currentRow = getRow( range.start, image.width, componentStride );
 				const previousRow = getRow( previousRange.start, image.width, componentStride );
 
-				// Only merge if in the same row and overlapping/adjacent
+				// We add one here to merge adjacent ranges. This is safe because ranges
+				// operate over positive integers.
 				if (
 					range.start <= previousEnd + 1 &&
 					currentRow === previousRow &&

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -859,8 +859,11 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 							} else {
 
+								const currentUnpackRowLen = _gl.getParameter( _gl.UNPACK_ROW_LENGTH );
 								const currentUnpackSkipPixels = _gl.getParameter( _gl.UNPACK_SKIP_PIXELS );
 								const currentUnpackSkipRows = _gl.getParameter( _gl.UNPACK_SKIP_ROWS );
+
+								_gl.pixelStorei( _gl.UNPACK_ROW_LENGTH, image.width );
 
 								const componentStride = 4; // only RGBA supported
 
@@ -886,6 +889,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 								}
 
+								_gl.pixelStorei( _gl.UNPACK_ROW_LENGTH, currentUnpackRowLen );
 								_gl.pixelStorei( _gl.UNPACK_SKIP_PIXELS, currentUnpackSkipPixels );
 								_gl.pixelStorei( _gl.UNPACK_SKIP_ROWS, currentUnpackSkipRows );
 

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -303,6 +303,14 @@ class Texture extends EventDispatcher {
 		this.userData = {};
 
 		/**
+		 * This can be used to only update a subregion or specific rows of the texture (for example, just the
+		 * first 3 rows). Use the `addUpdateRange()` function to add ranges to this array.
+		 *
+		 * @type {Array<Object>}
+		 */
+		this.updateRanges = [];
+
+		/**
 		 * This starts at `0` and counts how many times {@link Texture#needsUpdate} is set to `true`.
 		 *
 		 * @type {number}
@@ -382,6 +390,27 @@ class Texture extends EventDispatcher {
 	updateMatrix() {
 
 		this.matrix.setUvTransform( this.offset.x, this.offset.y, this.repeat.x, this.repeat.y, this.rotation, this.center.x, this.center.y );
+
+	}
+
+	/**
+	 * Adds a range of data in the data texture to be updated on the GPU.
+	 *
+	 * @param {number} start - Position at which to start update.
+	 * @param {number} count - The number of components to update.
+	 */
+	addUpdateRange( start, count ) {
+
+		this.updateRanges.push( { start, count } );
+
+	}
+
+	/**
+	 * Clears the update ranges.
+	 */
+	clearUpdateRanges() {
+
+		this.updateRanges.length = 0;
 
 	}
 


### PR DESCRIPTION
Related issue: #30184

**Description**

Adds an update ranges API to textures, mirroring `BufferAttribute`. Note that the current implementation assumes update ranges refer to contiguous blocks or rows of memory; non-contiguous updates should be split into multiple update ranges. Adjacent update ranges are merged similarly to #29189 with additional checks according to the texture image layout.

A good application of partial updates to textures would be `BatchedMesh`, where updating a single object's matrix or visibility flushes the entire texture, which is very slow and can cause a memory management event (crash!). It should serve as a good testbed for usability/performance with the webgl_mesh_batch example.
