### PR TITLE
MaterialNode: Fix `dashOffset` with LineDashedMaterial.

### DIFF
--- a/examples/webgpu_lines_fat_wireframe.html
+++ b/examples/webgpu_lines_fat_wireframe.html
@@ -220,7 +220,7 @@
 
 				gui.add( param, 'dash scale', 0.5, 1, 0.1 ).onChange( function ( val ) {
 
-					matLine.dashScale = val;
+					matLine.scale = val;
 					matLineDashed.scale = val;
 
 				} );

--- a/src/nodes/accessors/MaterialNode.js
+++ b/src/nodes/accessors/MaterialNode.js
@@ -386,6 +386,10 @@ class MaterialNode extends Node {
 
 			node = this.getTexture( scope ).r.sub( 1.0 ).mul( this.getFloat( 'aoMapIntensity' ) ).add( 1.0 );
 
+		} else if ( scope === MaterialNode.LINE_DASH_OFFSET ) {
+
+			node = ( material.dashOffset ) ? this.getFloat( scope ) : float( 0 );
+
 		} else {
 
 			const outputType = this.getNodeType( builder );


### PR DESCRIPTION
Fixed #31006.

**Description**

`LineDashedNodeMaterial` is the node variant of `LineDashedMaterial`. The node version supports a property `dashOffset` which does exist for `LineDashedMaterial`. To make the TSL material property `materialLineDashOffset` compatible with `LineDashedMaterial`, `MaterialNode` must check for the existence of `dashOffset` before creating a uniform node. Otherwise a constant is used.

The PR also applies a minor fix to `webgpu_lines_fat_wireframe` which ensures the right dash `scale` property name is used.