### PR TITLE
SpotLightNode: Add custom attenuation using `spotLight.attenuationNode`

### DIFF
--- a/examples/webgpu_lights_spotlight.html
+++ b/examples/webgpu_lights_spotlight.html
@@ -26,6 +26,7 @@
 		<script type="module">
 
 			import * as THREE from 'three';
+			import { Fn, vec2, length, abs, max, min, div, mul, clamp, acos } from 'three/tsl';
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 
@@ -86,13 +87,35 @@
 
 				}
 
+				const boxAttenuationFn = Fn( ( [ lightNode ], builder ) => {
+
+					const sdBox = Fn( ( [ p, b ] ) => {
+
+						const d = vec2( abs( p ).sub( b ) ).toVar();
+
+						return length( max( d, 0.0 ) ).add( min( max( d.x, d.y ), 0.0 ) );
+
+					} );
+
+					const penumbraCos = lightNode.penumbraCosNode;
+					const spotLightCoord = lightNode.getSpotLightCoord( builder );
+					const coord = spotLightCoord.xyz.div( spotLightCoord.w );
+
+					const boxDist = sdBox( coord.xy.sub( vec2( 0.5 ) ), vec2( 0.5 ) );
+					const angleFactor = div( 1.0, acos( penumbraCos ).sub( 1.0 ) );
+					const attenuation = clamp( mul( 2.0, boxDist ).mul( angleFactor ), 0.0, 1.0 );
+
+					return attenuation;
+
+				} );
+
 				spotLight = new THREE.SpotLight( 0xffffff, 100 );
+				spotLight.map = textures[ 'disturb.jpg' ];
 				spotLight.position.set( 2.5, 5, 2.5 );
 				spotLight.angle = Math.PI / 6;
 				spotLight.penumbra = 1;
 				spotLight.decay = 2;
 				spotLight.distance = 0;
-				spotLight.map = textures[ 'disturb.jpg' ];
 
 				spotLight.castShadow = true;
 				spotLight.shadow.mapSize.width = 1024;
@@ -150,7 +173,8 @@
 					penumbra: spotLight.penumbra,
 					decay: spotLight.decay,
 					focus: spotLight.shadow.focus,
-					shadows: true
+					shadows: true,
+					customAttenuation: false
 				};
 
 				gui.add( params, 'map', textures ).onChange( function ( val ) {
@@ -202,7 +226,6 @@
 
 				} );
 
-
 				gui.add( params, 'shadows' ).onChange( function ( val ) {
 
 					renderer.shadowMap.enabled = val;
@@ -216,6 +239,12 @@
 						}
 
 					} );
+
+				} );
+
+				gui.add( params, 'customAttenuation' ).name( 'custom attenuation' ).onChange( function ( val ) {
+
+					spotLight.attenuationNode = val ? boxAttenuationFn : null;
 
 				} );
 

--- a/src/nodes/lighting/LightsNode.js
+++ b/src/nodes/lighting/LightsNode.js
@@ -125,9 +125,10 @@ class LightsNode extends Node {
 
 			if ( light.isSpotLight === true ) {
 
-				const hashValue = ( light.map !== null ) ? light.map.id : - 1;
+				const hashMap = ( light.map !== null ) ? light.map.id : - 1;
+				const hashAttenuation = ( light.attenuationNode ) ? light.attenuationNode.id : - 1;
 
-				hashData.push( hashValue );
+				hashData.push( hashMap, hashAttenuation );
 
 			}
 

--- a/src/nodes/lighting/SpotLightNode.js
+++ b/src/nodes/lighting/SpotLightNode.js
@@ -5,7 +5,6 @@ import { smoothstep } from '../math/MathNode.js';
 import { renderGroup } from '../core/UniformGroupNode.js';
 import { lightTargetDirection, lightProjectionUV } from '../accessors/Lights.js';
 import { texture } from '../accessors/TextureNode.js';
-import { float } from '../tsl/TSLBase.js';
 
 /**
  * Module for representing spot lights as nodes.

--- a/src/nodes/tsl/TSLCore.js
+++ b/src/nodes/tsl/TSLCore.js
@@ -619,6 +619,7 @@ export const Fn = ( jsFunc, layout = null ) => {
 	};
 
 	fn.shaderNode = shaderNode;
+	fn.id = shaderNode.id;
 
 	fn.setLayout = ( layout ) => {
 


### PR DESCRIPTION
Closes https://github.com/mrdoob/three.js/issues/30993#issuecomment-2829669458

**Description**

Add custom attenuation using `spotLight.attenuationNode`.

![image](https://github.com/user-attachments/assets/cfdf1bb9-dc03-4905-aabe-a875a3feebd1)
