### PR TITLE
FBXLoader: Improve error handling.

### DIFF
--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -477,6 +477,13 @@ class FBXTreeParser {
 
 		}
 
+		if ( fileName === undefined ) {
+
+			console.warn( 'FBXLoader: Undefined filename, creating placeholder texture.' );
+			return new Texture();
+
+		}
+
 		const texture = loader.load( fileName );
 
 		// revert to initial path


### PR DESCRIPTION
Fixed #31005.

**Description**

The PR improves the error handling of `FBXLoader`. The loader does not try to load an undefined filename anymore. Instead, it returns a placeholder texture and reports a warning. 
