### PR TITLE
SpotLightShadow: Introduce `aspect` property

### DIFF
--- a/examples/webgpu_lights_spotlight.html
+++ b/examples/webgpu_lights_spotlight.html
@@ -107,7 +107,7 @@
 
 					} );
 
-					const penumbraCos = uniform( 'float' ).onRenderUpdate( () => Math.cos( light.angle * ( 1 - Math.min( light.penumbra, .999 ) ) ) );
+					const penumbraCos = uniform( 'float' ).onRenderUpdate( () => Math.min( Math.cos( light.angle * ( 1 - light.penumbra ) ), .99999 ) );
 					const spotLightCoord = lightNode.getSpotLightCoord( builder );
 					const coord = spotLightCoord.xyz.div( spotLightCoord.w );
 

--- a/examples/webgpu_lights_spotlight.html
+++ b/examples/webgpu_lights_spotlight.html
@@ -26,7 +26,7 @@
 		<script type="module">
 
 			import * as THREE from 'three';
-			import { Fn, float, vec2, vec3, length, uniform, abs, max, min, sub, div, mul, saturate, acos } from 'three/tsl';
+			import { Fn, vec2, length, uniform, abs, max, min, sub, div, saturate, acos } from 'three/tsl';
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 

--- a/examples/webgpu_lights_spotlight.html
+++ b/examples/webgpu_lights_spotlight.html
@@ -26,7 +26,7 @@
 		<script type="module">
 
 			import * as THREE from 'three';
-			import { Fn, vec2, length, abs, max, min, div, mul, clamp, acos } from 'three/tsl';
+			import { Fn, float, vec2, vec3, length, uniform, abs, max, min, sub, div, mul, saturate, acos } from 'three/tsl';
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 
@@ -40,6 +40,8 @@
 			init();
 
 			function init() {
+
+				// Renderer
 
 				renderer = new THREE.WebGPURenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
@@ -58,6 +60,8 @@
 				camera = new THREE.PerspectiveCamera( 40, window.innerWidth / window.innerHeight, 0.1, 100 );
 				camera.position.set( 7, 4, 1 );
 
+				// Controls
+
 				const controls = new OrbitControls( camera, renderer.domElement );
 				controls.minDistance = 2;
 				controls.maxDistance = 10;
@@ -65,8 +69,7 @@
 				controls.target.set( 0, 1, 0 );
 				controls.update();
 
-				const ambient = new THREE.HemisphereLight( 0xffffff, 0x8d8d8d, 0.15 );
-				scene.add( ambient );
+				// Textures
 
 				const loader = new THREE.TextureLoader().setPath( 'textures/' );
 				const filenames = [ 'disturb.jpg', 'colors.png', 'uv_grid_opengl.jpg' ];
@@ -87,7 +90,14 @@
 
 				}
 
+				// Lights
+
+				const ambient = new THREE.HemisphereLight( 0xffffff, 0x8d8d8d, 0.15 );
+				scene.add( ambient );
+
 				const boxAttenuationFn = Fn( ( [ lightNode ], builder ) => {
+
+					const light = lightNode.light;
 
 					const sdBox = Fn( ( [ p, b ] ) => {
 
@@ -97,13 +107,13 @@
 
 					} );
 
-					const penumbraCos = lightNode.penumbraCosNode;
+					const penumbraCos = uniform( 'float' ).onRenderUpdate( () => Math.cos( light.angle * ( 1 - Math.min( light.penumbra, .999 ) ) ) );
 					const spotLightCoord = lightNode.getSpotLightCoord( builder );
 					const coord = spotLightCoord.xyz.div( spotLightCoord.w );
 
 					const boxDist = sdBox( coord.xy.sub( vec2( 0.5 ) ), vec2( 0.5 ) );
-					const angleFactor = div( 1.0, acos( penumbraCos ).sub( 1.0 ) );
-					const attenuation = clamp( mul( 2.0, boxDist ).mul( angleFactor ), 0.0, 1.0 );
+					const angleFactor = div( -1.0, sub( 1.0, acos( penumbraCos ) ).sub( 1.0 ) );
+					const attenuation = saturate( boxDist.mul( - 2.0 ).mul( angleFactor ) );
 
 					return attenuation;
 
@@ -140,7 +150,7 @@
 				mesh.receiveShadow = true;
 				scene.add( mesh );
 
-				//
+				// Models
 
 				new PLYLoader().load( 'models/ply/binary/Lucy100k.ply', function ( geometry ) {
 
@@ -246,7 +256,11 @@
 
 					spotLight.attenuationNode = val ? boxAttenuationFn : null;
 
+					aspectGUI.setValue( 1 ).enable( val );
+
 				} );
+
+				const aspectGUI = gui.add( spotLight.shadow, 'aspect', 0, 1 ).enable( false );
 
 				gui.open();
 

--- a/examples/webgpu_lights_spotlight.html
+++ b/examples/webgpu_lights_spotlight.html
@@ -260,7 +260,7 @@
 
 				} );
 
-				const aspectGUI = gui.add( spotLight.shadow, 'aspect', 0, 1 ).enable( false );
+				const aspectGUI = gui.add( spotLight.shadow, 'aspect', 0, 2 ).enable( false );
 
 				gui.open();
 

--- a/src/lights/SpotLightShadow.js
+++ b/src/lights/SpotLightShadow.js
@@ -34,6 +34,14 @@ class SpotLightShadow extends LightShadow {
 		 */
 		this.focus = 1;
 
+		/**
+		 * Texture aspect ratio.
+		 *
+		 * @type {number}
+		 * @default 1
+		 */
+		this.aspect = 1;
+
 	}
 
 	updateMatrices( light ) {
@@ -41,7 +49,7 @@ class SpotLightShadow extends LightShadow {
 		const camera = this.camera;
 
 		const fov = RAD2DEG * 2 * light.angle * this.focus;
-		const aspect = this.mapSize.width / this.mapSize.height;
+		const aspect = ( this.mapSize.width / this.mapSize.height ) * this.aspect;
 		const far = light.distance || camera.far;
 
 		if ( fov !== camera.fov || aspect !== camera.aspect || far !== camera.far ) {

--- a/src/nodes/tsl/TSLCore.js
+++ b/src/nodes/tsl/TSLCore.js
@@ -85,7 +85,7 @@ const shaderNodeHandler = {
 
 				prop = parseSwizzleAndSort( prop.slice( 3 ).toLowerCase() );
 
-				return ( value ) => nodeObject( new SetNode( node, prop, value ) );
+				return ( value ) => nodeObject( new SetNode( node, prop, nodeObject( value ) ) );
 
 			} else if ( /^flip[XYZWRGBASTPQ]{1,4}$/.test( prop ) === true ) {
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/31013#issuecomment-2835329478

Summary

- [x] [SpotLightShadow: Introduce aspect](https://github.com/mrdoob/three.js/commit/95ff03dd76e6fd750a78a2442b3080906264ad4d)
- [x] [improve custom aspect example](https://github.com/mrdoob/three.js/commit/d57991bc68df321574b6620ab5258c212341d12f)
- [x] [TSL: Fix convert .set*() value to node-object](https://github.com/mrdoob/three.js/commit/fcd5629ec7be0fce3c455cf6ac81ed35cb7dd0cd)

Example 1
![image](https://github.com/user-attachments/assets/22d431c3-52e0-4fe0-96d0-f08e3a27f040)

Example 2
![image](https://github.com/user-attachments/assets/cd0725ec-6138-44ac-b2ef-d1e1f7932764)
