### PR TITLE
Box3: Add toJSON, fromJSON

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -1296,10 +1296,7 @@ class Object3D extends EventDispatcher {
 
 			object.geometryInfo = this._geometryInfo.map( info => ( {
 				...info,
-				boundingBox: info.boundingBox ? {
-					min: info.boundingBox.min.toArray(),
-					max: info.boundingBox.max.toArray()
-				} : undefined,
+				boundingBox: info.boundingBox ? info.boundingBox.toJSON() : undefined,
 				boundingSphere: info.boundingSphere ? {
 					radius: info.boundingSphere.radius,
 					center: info.boundingSphere.center.toArray()
@@ -1341,10 +1338,7 @@ class Object3D extends EventDispatcher {
 
 			if ( this.boundingBox !== null ) {
 
-				object.boundingBox = {
-					min: this.boundingBox.min.toArray(),
-					max: this.boundingBox.max.toArray()
-				};
+				object.boundingBox = this.boundingBox.toJSON();
 
 			}
 

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -979,9 +979,7 @@ class ObjectLoader extends Loader {
 					let sphere = null;
 					if ( info.boundingBox !== undefined ) {
 
-						box = new Box3();
-						box.min.fromArray( info.boundingBox.min );
-						box.max.fromArray( info.boundingBox.max );
+						box = new Box3().fromJSON( info.boundingBox );
 
 					}
 
@@ -1035,9 +1033,7 @@ class ObjectLoader extends Loader {
 
 				if ( data.boundingBox !== undefined ) {
 
-					object.boundingBox = new Box3();
-					object.boundingBox.min.fromArray( data.boundingBox.min );
-					object.boundingBox.max.fromArray( data.boundingBox.max );
+					object.boundingBox = new Box3().fromJSON( data.boundingBox );
 
 				}
 

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -732,11 +732,13 @@ class Box3 {
 	 * Returns a serialized structure of the bounding box.
 	 *
 	 * @param {Object} json - The serialized json to set the box from.
+	 * @return {Box3} A reference to this bounding box.
 	 */
 	fromJSON( json ) {
 
 		this.min.fromArray( json.min );
 		this.max.fromArray( json.max );
+		return this;
 
 	}
 

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -714,6 +714,32 @@ class Box3 {
 
 	}
 
+	/**
+	 * Returns a serialized structure of the bounding box.
+	 *
+	 * @return {Object} Serialized structure with fields representing the object state.
+	 */
+	toJSON() {
+
+		return {
+			min: this.min.toArray(),
+			max: this.max.toArray()
+		};
+
+	}
+
+	/**
+	 * Returns a serialized structure of the bounding box.
+	 *
+	 * @param {Object} json - The serialized json to set the box from.
+	 */
+	fromJSON( json ) {
+
+		this.min.fromArray( json.min );
+		this.max.fromArray( json.max );
+
+	}
+
 }
 
 const _points = [


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/30965#issuecomment-2817053680

**Description**

A small prototype to add `fromJSON` and `toJSON` to `Box3` to normalize the serialization process of these shapes.

Note that `fromJSON` is currently a member function that modifies the already-created Box3 and returns itself, similar to `copy`. This could instead be a static member function that returns a new Box3 instance.

If this looks good I'll do the same thing for `Sphere` in a subsequent PR.