### PR TITLE
[Proposal] add gitmcp badge for LLM-accessible documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 [![Discord][discord]][discord-url]
 [![GitMCP][gitmcp]][gitmcp-url]
 
-
 #### JavaScript 3D library
 
 The aim of the project is to create an easy-to-use, lightweight, cross-browser, general-purpose 3D library. The current builds only include WebGL and WebGPU renderers but SVG and CSS3D renderers are also available as addons.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 [![NPM Downloads][npm-downloads]][npmtrends-url]
 [![DeepScan][deepscan]][deepscan-url]
 [![Discord][discord]][discord-url]
+[![GitMCP][gitmcp]][gitmcp-url]
+
 
 #### JavaScript 3D library
 
@@ -83,4 +85,6 @@ git clone --depth=1 https://github.com/mrdoob/three.js.git
 [deepscan-url]: https://deepscan.io/dashboard#view=project&tid=16600&pid=19901&bid=525701
 [discord]: https://img.shields.io/discord/685241246557667386
 [discord-url]: https://discord.gg/56GBJwAnUS
+[gitmcp]: https://img.shields.io/endpoint?url=https://gitmcp.io/badge/mrdoob/three.js
+[gitmcp-url]: https://gitmcp.io/mrdoob/three.js "Documentation compatible with GitMCP"
 


### PR DESCRIPTION
**Description**

[gitmcp.io](https://gitmcp.io/) provides easy access to the latest three.js docs through a remote, free, open-source MCP. It enables two access points -
- Empower AI agents (e.g., Cursor) with live documentation context to prevent hallucinations
- Chat with the documentation in the browser via the embedded chat

This PR proposes adding a new badge to help users make the most of three.js's documentation with GitMCP. The badge is [customizable](https://github.com/idosal/git-mcp?tab=readme-ov-file#-gitmcp-badge).

[![GitMCP](https://img.shields.io/endpoint?url=https://gitmcp.io/badge/mrdoob/three.js)](https://gitmcp.io/mrdoob/three.js)

We look forward to hearing your thoughts!
