### PR TITLE
Texture: Introduce `width`, `height`, `depth`

### DIFF
--- a/src/textures/Source.js
+++ b/src/textures/Source.js
@@ -73,6 +73,28 @@ class Source {
 
 	}
 
+	getSize( target ) {
+
+		const data = this.data;
+
+		if ( data instanceof HTMLVideoElement ) {
+
+			target.set( data.videoWidth, data.videoHeight );
+
+		} else if ( data !== null ) {
+
+			target.set( data.width, data.height, data.depth || 0 );
+
+		} else {
+
+			target.set( 0, 0, 0 );
+
+		}
+
+		return target;
+
+	}
+
 	/**
 	 * When the property is set to `true`, the engine allocates the memory
 	 * for the texture (if necessary) and triggers the actual texture upload

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -12,10 +12,13 @@ import {
 } from '../constants.js';
 import { generateUUID } from '../math/MathUtils.js';
 import { Vector2 } from '../math/Vector2.js';
+import { Vector3 } from '../math/Vector3.js';
 import { Matrix3 } from '../math/Matrix3.js';
 import { Source } from './Source.js';
 
 let _textureId = 0;
+
+const _tempVec3 = /*@__PURE__*/ new Vector3();
 
 /**
  * Base class for all textures.
@@ -355,6 +358,33 @@ class Texture extends EventDispatcher {
 		 * @default 0
 		 */
 		this.pmremVersion = 0;
+
+	}
+
+	/**
+	 * The width of the texture in pixels.
+	 */
+	get width() {
+
+		return this.source.getSize( _tempVec3 ).x;
+
+	}
+
+	/**
+	 * The height of the texture in pixels.
+	 */
+	get height() {
+
+		return this.source.getSize( _tempVec3 ).y;
+
+	}
+
+	/**
+	 * The depth of the texture in pixels.
+	 */
+	get depth() {
+
+		return this.source.getSize( _tempVec3 ).z;
 
 	}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/31022

**Description**

Introduce partial support for `texture.width`, `texture.height` and `texture.depth`.