### PR TITLE
Preparation for dispatchWorkgroupsIndirect

### DIFF
--- a/src/nodes/gpgpu/ComputeNode.js
+++ b/src/nodes/gpgpu/ComputeNode.js
@@ -220,6 +220,7 @@ class ComputeNode extends Node {
 	/**
 	 * TODO
 	 *
+	 * @return {ComputeNode} A reference to this node.
 	 */
 	setIndirect( indirect ) {
 
@@ -232,6 +233,7 @@ class ComputeNode extends Node {
 	/**
 	 * TODO
 	 *
+	 * @return {?BufferAttribute} The indirect attribute. Returns `null` if no indirect attribute is defined.
 	 */
 	getIndirect() {
 

--- a/src/nodes/gpgpu/ComputeNode.js
+++ b/src/nodes/gpgpu/ComputeNode.js
@@ -220,6 +220,7 @@ class ComputeNode extends Node {
 	/**
 	 * TODO
 	 *
+	 * @param {BufferAttribute} indirect - The attribute holding indirect workgroup values.
 	 * @return {ComputeNode} A reference to this node.
 	 */
 	setIndirect( indirect ) {

--- a/src/nodes/gpgpu/ComputeNode.js
+++ b/src/nodes/gpgpu/ComputeNode.js
@@ -60,6 +60,14 @@ class ComputeNode extends Node {
 		/**
 		 * TODO
 		 *
+		 * @type {?BufferAttribute}
+		 * @default null
+		 */
+		this.indirect = null;
+
+		/**
+		 * TODO
+		 *
 		 * @type {number}
 		 */
 		this.dispatchCount = 0;
@@ -206,6 +214,28 @@ class ComputeNode extends Node {
 			}
 
 		}
+
+	}
+
+	/**
+	 * TODO
+	 *
+	 */
+	setIndirect( indirect ) {
+
+		this.indirect = indirect;
+
+		return this;
+
+	}
+
+	/**
+	 * TODO
+	 *
+	 */
+	getIndirect() {
+
+		return this.indirect;
 
 	}
 


### PR DESCRIPTION
Related issue: #30982

This is the preparation for ```dispatchWorkgroupsIndirect```

This allows an indirect buffer to be passed to the compute node, similar to the geometry. This indirect buffer has nothing to do with drawIndirect!
However, it is a very similar functionality to drawIndirect. This indirect buffer can be used to dynamically change the workgroup size with the GPU. This functionality can basically be used with any compute shader independent of drawIndirect.
In itself, the matter is quite simple, because the buffer simply needs to be passed to the passEncoderGPU, like this:

```
if ( indirect !== null ) {

	const buffer = this.get( indirect ).buffer;

	passEncoderGPU.dispatchWorkgroupsIndirect( buffer, 0 );

} else {

	passEncoderGPU.dispatchWorkgroups(
		dispatchSize.x,
		dispatchSize.y,
		dispatchSize.z
	);

}
```

However, I have not yet found the right place for the intermediate step in the compute routine that would actually retrieve the GPUBuffer with ```this.get( indirect )```
But that would be all there is to it. Fortunately, this functionality is much less complex, since the most important part is already present with the IndirectStorageBufferAttribute.

Here's a pure webgpu example. You can see the application in the line: 180

https://codepen.io/Spiri0/pen/zxxdgYZ

The triangle is normally RGB colored. The compute shader executed with dispatchWorkgroupsIndirect makes it green


