### PR TITLE
TextureLoader inherits FbxLoader's credentials

### DIFF
--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -169,8 +169,8 @@ class FBXLoader extends Loader {
 		}
 
 		// console.log( fbxTree );
-
-		const textureLoader = new TextureLoader( this.manager ).setPath( this.resourcePath || path ).setCrossOrigin( this.crossOrigin );
+		const scope = this;
+		const textureLoader = new TextureLoader( this.manager ).setPath( this.resourcePath || path ).setCrossOrigin( this.crossOrigin ).setRequestHeader( scope.requestHeader ).setWithCredentials( scope.withCredentials );
 
 		return new FBXTreeParser( textureLoader, this.manager ).parse( fbxTree );
 


### PR DESCRIPTION
**Description**
I’d like to submit a PR to three.js because the TextureLoader inside FbxLoader isn’t receiving any credentials—this causes errors when loading textures.
so updated it to inherit FbxLoader’s credentials.

