### PR TITLE
Add damp accessor to WebGL AfterimagePass class

### DIFF
--- a/examples/jsm/postprocessing/AfterimagePass.js
+++ b/examples/jsm/postprocessing/AfterimagePass.js
@@ -4,7 +4,8 @@ import {
 	NoBlending,
 	ShaderMaterial,
 	UniformsUtils,
-	WebGLRenderTarget
+	WebGLRenderTarget,
+	MathUtils
 } from 'three';
 import { Pass, FullScreenQuad } from './Pass.js';
 import { CopyShader } from '../shaders/CopyShader.js';
@@ -43,7 +44,7 @@ class AfterimagePass extends Pass {
 		 */
 		this.uniforms = UniformsUtils.clone( AfterimageShader.uniforms );
 
-		this.uniforms[ 'damp' ].value = damp;
+		this.damp = damp;
 
 		/**
 		 * The composition material.
@@ -86,6 +87,28 @@ class AfterimagePass extends Pass {
 
 		this._compFsQuad = new FullScreenQuad( this.compFsMaterial );
 		this._copyFsQuad = new FullScreenQuad( this.copyFsMaterial );
+
+	}
+
+	/**
+	 * Get the damping intensity. A higher value means a stronger after image effect.
+	 * 
+	 * @type {number}
+	 */
+	get damp() {
+
+		return this.uniforms[ 'damp' ].value;
+
+	}
+
+	/**
+	 * Set the damping intensity. A higher value means a stronger after image effect.
+	 * 
+	 * @type {number}
+	 */
+	set damp( value ) {
+
+		this.uniforms[ 'damp' ].value = MathUtils.clamp(value, 0.0, 1.0);
 
 	}
 

--- a/examples/jsm/postprocessing/AfterimagePass.js
+++ b/examples/jsm/postprocessing/AfterimagePass.js
@@ -4,8 +4,7 @@ import {
 	NoBlending,
 	ShaderMaterial,
 	UniformsUtils,
-	WebGLRenderTarget,
-	MathUtils
+	WebGLRenderTarget
 } from 'three';
 import { Pass, FullScreenQuad } from './Pass.js';
 import { CopyShader } from '../shaders/CopyShader.js';
@@ -91,7 +90,7 @@ class AfterimagePass extends Pass {
 	}
 
 	/**
-	 * Get the damping intensity. A higher value means a stronger after image effect.
+	 * The damping intensity, from 0.0 to 1.0. A higher value means a stronger after image effect.
 	 * 
 	 * @type {number}
 	 */
@@ -101,14 +100,9 @@ class AfterimagePass extends Pass {
 
 	}
 
-	/**
-	 * Set the damping intensity. A higher value means a stronger after image effect.
-	 * 
-	 * @type {number}
-	 */
 	set damp( value ) {
 
-		this.uniforms[ 'damp' ].value = MathUtils.clamp(value, 0.0, 1.0);
+		this.uniforms[ 'damp' ].value = value;
 
 	}
 

--- a/examples/webgl_postprocessing_afterimage.html
+++ b/examples/webgl_postprocessing_afterimage.html
@@ -73,7 +73,7 @@
 				window.addEventListener( 'resize', onWindowResize );
 
 				const gui = new GUI( { title: 'Damp setting' } );
-				gui.add( afterimagePass.damp, 'value', 0, 1 ).step( 0.001 );
+				gui.add( afterimagePass, 'damp', 0, 1 ).step( 0.001 );
 				gui.add( params, 'enable' );
 
 			}

--- a/examples/webgl_postprocessing_afterimage.html
+++ b/examples/webgl_postprocessing_afterimage.html
@@ -73,7 +73,7 @@
 				window.addEventListener( 'resize', onWindowResize );
 
 				const gui = new GUI( { title: 'Damp setting' } );
-				gui.add( afterimagePass.uniforms[ 'damp' ], 'value', 0, 1 ).step( 0.001 );
+				gui.add( afterimagePass.damp, 'value', 0, 1 ).step( 0.001 );
 				gui.add( params, 'enable' );
 
 			}


### PR DESCRIPTION
**Description**

This pull request adds a `damp` property to the WebGL `AfterimagePass` class to ~add clamping,~ avoid the need to set uniforms directly and bring it into line with the TSL version.

Code style is consistent with the existing codebase and this change has been applied to the `webgl_postprocessing_afterimage` example, which has been tested as working.