### PR TITLE
Add FXAAPass class

### DIFF
--- a/examples/jsm/postprocessing/FXAAPass.js
+++ b/examples/jsm/postprocessing/FXAAPass.js
@@ -29,7 +29,7 @@ class FXAAPass extends ShaderPass {
 	 * @param {number} width - The width to set.
 	 * @param {number} height - The height to set.
 	 */
-	setSize(width, height) {
+	setSize( width, height ) {
 
 		this.material.uniforms[ 'resolution' ].value.set( 1 / width, 1 / height );
 

--- a/examples/jsm/postprocessing/FXAAPass.js
+++ b/examples/jsm/postprocessing/FXAAPass.js
@@ -14,11 +14,14 @@ import { ShaderPass } from './ShaderPass.js';
  */
 class FXAAPass extends ShaderPass {
 
-  constructor() {
+	/**
+	 * Constructs a new FXAA pass.
+	 */
+	constructor() {
 
-    super( FXAAShader );
+		super( FXAAShader );
 
-  }
+	}
 
 	/**
 	 * Sets the size of the pass.
@@ -26,11 +29,11 @@ class FXAAPass extends ShaderPass {
 	 * @param {number} width - The width to set.
 	 * @param {number} height - The width to set.
 	 */
-  setSize(width, height) {
+	setSize(width, height) {
 
-    this.material.uniforms[ 'resolution' ].value.set( 1 / width, 1 / height );
+		this.material.uniforms[ 'resolution' ].value.set( 1 / width, 1 / height );
 
-  }
+	}
 
 }
 

--- a/examples/jsm/postprocessing/FXAAPass.js
+++ b/examples/jsm/postprocessing/FXAAPass.js
@@ -6,7 +6,7 @@ import { ShaderPass } from './ShaderPass.js';
  *
  * ```js
  * const fxaaPass = new FXAAPass();
- * composer.addPass( smaaPass );
+ * composer.addPass( fxaaPass );
  * ```
  *
  * @augments ShaderPass

--- a/examples/jsm/postprocessing/FXAAPass.js
+++ b/examples/jsm/postprocessing/FXAAPass.js
@@ -27,7 +27,7 @@ class FXAAPass extends ShaderPass {
 	 * Sets the size of the pass.
 	 *
 	 * @param {number} width - The width to set.
-	 * @param {number} height - The width to set.
+	 * @param {number} height - The height to set.
 	 */
 	setSize(width, height) {
 

--- a/examples/jsm/postprocessing/FXAAPass.js
+++ b/examples/jsm/postprocessing/FXAAPass.js
@@ -1,0 +1,37 @@
+import { FXAAShader } from '../shaders/FXAAShader.js';
+import { ShaderPass } from './ShaderPass.js';
+
+/**
+ * A pass for applying FXAA.
+ *
+ * ```js
+ * const fxaaPass = new FXAAPass();
+ * composer.addPass( smaaPass );
+ * ```
+ *
+ * @augments ShaderPass
+ * @three_import import { FXAAPass } from 'three/addons/postprocessing/FXAAPass.js';
+ */
+class FXAAPass extends ShaderPass {
+
+  constructor() {
+
+    super( FXAAShader );
+
+  }
+
+	/**
+	 * Sets the size of the pass.
+	 *
+	 * @param {number} width - The width to set.
+	 * @param {number} height - The width to set.
+	 */
+  setSize(width, height) {
+
+    this.material.uniforms[ 'resolution' ].value.set( 1 / width, 1 / height );
+
+  }
+
+}
+
+export { FXAAPass };

--- a/examples/webgl_postprocessing_fxaa.html
+++ b/examples/webgl_postprocessing_fxaa.html
@@ -50,7 +50,7 @@
 			import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
 			import { ShaderPass } from 'three/addons/postprocessing/ShaderPass.js';
 			import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
-			import { FXAAShader } from 'three/addons/shaders/FXAAShader.js';
+			import { FXAAPass } from 'three/addons/postprocessing/FXAAPass.js';
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 
 			let camera, scene, renderer, controls, container;
@@ -119,7 +119,7 @@
 
 				//
 
-				fxaaPass = new ShaderPass( FXAAShader );
+				fxaaPass = new FXAAPass();
 
 				const outputPass = new OutputPass();
 
@@ -128,11 +128,6 @@
 				composer1.addPass( outputPass );
 
 				//
-
-				const pixelRatio = renderer.getPixelRatio();
-
-				fxaaPass.material.uniforms[ 'resolution' ].value.x = 1 / ( container.offsetWidth * pixelRatio );
-				fxaaPass.material.uniforms[ 'resolution' ].value.y = 1 / ( container.offsetHeight * pixelRatio );
 
 				composer2 = new EffectComposer( renderer );
 				composer2.addPass( renderPass );
@@ -156,11 +151,6 @@
 				renderer.setSize( container.offsetWidth, container.offsetHeight );
 				composer1.setSize( container.offsetWidth, container.offsetHeight );
 				composer2.setSize( container.offsetWidth, container.offsetHeight );
-
-				const pixelRatio = renderer.getPixelRatio();
-
-				fxaaPass.material.uniforms[ 'resolution' ].value.x = 1 / ( container.offsetWidth * pixelRatio );
-				fxaaPass.material.uniforms[ 'resolution' ].value.y = 1 / ( container.offsetHeight * pixelRatio );
 
 			}
 


### PR DESCRIPTION
The Three.js FXAA implementation is fantastic, but the WebGL pass has always felt unnecessarily cumbersome and more complicated to use than it needs to be.

This pull request simplifies the creation and use of an FXAA pass by creating a new `FXAAPass` class that works in the same way as `SMAAPass`: rather than having to pass `FXAAShader` as a parameter of the `ShaderPass` class and manually manage the size of the pass, you simply create a single class instance which is automatically updated by the `EffectComposer` calling its `setSize` method.