### PR TITLE
GLTFLoader: Clone node associations.

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -4451,6 +4451,11 @@ class GLTFParser {
 
 				parser.associations.set( node, {} );
 
+			} else if ( nodeDef.mesh !== undefined && parser.meshCache.refs[ nodeDef.mesh ] > 1 ) {
+
+				const mapping = parser.associations.get( node );
+				parser.associations.set( node, { ...mapping } );
+
 			}
 
 			parser.associations.get( node ).nodes = nodeIndex;


### PR DESCRIPTION
**Description**

GLTFLoader doesn't correctly assign the `nodes` association when multiple
nodes reference the same mesh. The problem occurs in `_loadNodeShallow`
where `nodes` property is added to the shared object describing the node/mesh
association.

For example, in the CesiumMilkTruck model nodes 0 (Wheels) and 2 (Wheels.001)
reference the same mesh 0, but resulting associations for both three.js meshes are 
`{meshes: 0, primitives: 0, nodes: 2}`.

A simple solution is to clone the association object if there are multiple references to
the same mesh.