### PR TITLE
Examples: Clean up XR examples browser notices

### DIFF
--- a/examples/webxr_ar_cones.html
+++ b/examples/webxr_ar_cones.html
@@ -9,7 +9,7 @@
 	<body>
 
 		<div id="info">
-			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> ar - cones<br/>(Chrome Android 81+)
+			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> ar - cones<br/>
 		</div>
 
 		<script type="importmap">

--- a/examples/webxr_ar_lighting.html
+++ b/examples/webxr_ar_lighting.html
@@ -9,8 +9,7 @@
 	<body>
 
 		<div id="info">
-			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> ar - Lighting Estimation<br/>
-			(Chrome Android 90+)
+			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> ar - lighting estimation<br/>
 		</div>
 
 		<script type="importmap">

--- a/examples/webxr_ar_plane_detection.html
+++ b/examples/webxr_ar_plane_detection.html
@@ -9,7 +9,7 @@
 	<body>
 
 		<div id="info">
-			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> ar - plane detection<br/>(Chrome Android 81+)
+			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> ar - plane detection<br/>
 		</div>
 
 		<script type="importmap">

--- a/examples/webxr_vr_handinput.html
+++ b/examples/webxr_vr_handinput.html
@@ -10,7 +10,6 @@
 
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> vr - handinput<br/>
-			(Oculus Browser 15.1+)
 		</div>
 
 		<script type="importmap">

--- a/examples/webxr_vr_handinput_cubes.html
+++ b/examples/webxr_vr_handinput_cubes.html
@@ -10,7 +10,6 @@
 
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> vr - handinput - cubes<br/>
-			(Oculus Browser 15.1+)
 		</div>
 
 		<script type="importmap">

--- a/examples/webxr_vr_handinput_pointerclick.html
+++ b/examples/webxr_vr_handinput_pointerclick.html
@@ -12,7 +12,6 @@
 
 	<div id="info">
 		<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a>	vr - handinput - point and click<br />
-		(Oculus Browser 15.1+)
 	</div>
 
 	<script type="importmap">

--- a/examples/webxr_vr_handinput_pointerdrag.html
+++ b/examples/webxr_vr_handinput_pointerdrag.html
@@ -12,7 +12,6 @@
 
 	<div id="info">
 		<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> vr - handinput - point and drag<br />
-		(Oculus Browser 15.1+)
 	</div>
 
 	<script type="importmap">

--- a/examples/webxr_vr_handinput_pressbutton.html
+++ b/examples/webxr_vr_handinput_pressbutton.html
@@ -12,7 +12,6 @@
 
 	<div id="info">
 		<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a>	vr - handinput - press button<br />
-		(Oculus Browser 15.1+)
 	</div>
 
 	<script type="importmap">

--- a/examples/webxr_vr_handinput_profiles.html
+++ b/examples/webxr_vr_handinput_profiles.html
@@ -10,7 +10,6 @@
 
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> vr - handinput - profiles<br/>
-			(Oculus Browser 15.1+)
 		</div>
 
 		<script type="importmap">

--- a/examples/webxr_vr_layers.html
+++ b/examples/webxr_vr_layers.html
@@ -10,7 +10,6 @@
 
 		<div id="info">
 			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> media and projection layers<br/>
-			(Oculus Browser 16.1+)
 
 			<p> This example demonstrates the use of <a href="https://www.w3.org/TR/webxrlayers-1/">WebXR Layers</a> to render high quality text and video.
 				  For static content such as text, using layers increases the usable resolution of the content by avoiding the extra resampling pass that occurs during normal VR rendering.


### PR DESCRIPTION
Related issue: -

**Description**

Remove browser notices as they are quite old. WebXR support now is broader across current (and upcoming) HW/SW.

*This contribution is funded by Samsung*
