### PR TITLE
Examples: Fix memory leak in FBX demo.

### DIFF
--- a/examples/webgl_loader_fbx.html
+++ b/examples/webgl_loader_fbx.html
@@ -128,6 +128,12 @@
 
 						object.traverse( function ( child ) {
 
+							if ( child.isSkinnedMesh ) {
+
+								child.skeleton.dispose();
+
+							}
+
 							if ( child.material ) {
 
 								const materials = Array.isArray( child.material ) ? child.material : [ child.material ];


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/31057#issuecomment-2864351013

**Description**

The example did not call `dispose()` on skeletons which lead to a memory leak.