### PR TITLE
HemisphereLightNode: Changed `normalView` to `normalWorld`.

### DIFF
--- a/src/nodes/lighting/HemisphereLightNode.js
+++ b/src/nodes/lighting/HemisphereLightNode.js
@@ -1,7 +1,7 @@
 import AnalyticLightNode from './AnalyticLightNode.js';
 import { uniform } from '../core/UniformNode.js';
 import { mix } from '../math/MathNode.js';
-import { normalView } from '../accessors/Normal.js';
+import { normalWorld } from '../accessors/Normal.js';
 import { lightPosition } from '../accessors/Lights.js';
 import { renderGroup } from '../core/UniformGroupNode.js';
 
@@ -73,7 +73,7 @@ class HemisphereLightNode extends AnalyticLightNode {
 
 		const { colorNode, groundColorNode, lightDirectionNode } = this;
 
-		const dotNL = normalView.dot( lightDirectionNode );
+		const dotNL = normalWorld.dot( lightDirectionNode );
 		const hemiDiffuseWeight = dotNL.mul( 0.5 ).add( 0.5 );
 
 		const irradiance = mix( groundColorNode, colorNode, hemiDiffuseWeight );


### PR DESCRIPTION
Fixed #31073

**Description**

HemisphereLightNode uses `normalView` which causes unwanted color drift when camera angle changes.

This PR changes `normalView` to `normalWorld` in light calculation


