### PR TITLE
Docs: Remove `decodeText`

### DIFF
--- a/docs/api/ar/loaders/LoaderUtils.html
+++ b/docs/api/ar/loaders/LoaderUtils.html
@@ -12,13 +12,7 @@
 		<p class="desc">كائن يحتوي على العديد من وظائف المحمل المساعدة.</p>
 
 		<h2>الطرق (Methods)</h2>
-	 
-		<h3>[method:String decodeText]( [param:TypedArray array] )</h3>
-		<p>[page:TypedArray array] — تدفق بايتات كمصفوفة مكتوبة.</p>
-		<p>
-		تأخذ الوظيفة تدفق بايتات كمدخل وتعيد تمثيلًا للسلسلة
-		</p>
-	 
+	 	 
 		<h3>[method:String extractUrlBase]( [param:String url] )</h3>
 		<p>[page:String url] — عنوان url الذي سيتم استخراج العنوان الأساسي منه.</p>
 		<p>استخراج الأساس من عنوان URL.</p>

--- a/docs/api/en/loaders/LoaderUtils.html
+++ b/docs/api/en/loaders/LoaderUtils.html
@@ -13,13 +13,6 @@
 
 		<h2>Functions</h2>
 
-		<h3>[method:String decodeText]( [param:TypedArray array] )</h3>
-		<p>[page:TypedArray array] — A stream of bytes as a typed array.</p>
-		<p>
-			The function takes a stream of bytes as input and returns a string
-			representation.
-		</p>
-
 		<h3>[method:String extractUrlBase]( [param:String url] )</h3>
 		<p>[page:String url] — The url to extract the base url from.</p>
 		<p>Extract the base from the URL.</p>

--- a/docs/api/it/loaders/LoaderUtils.html
+++ b/docs/api/it/loaders/LoaderUtils.html
@@ -13,14 +13,6 @@
 
 		<h2>Funzioni</h2>
 
-		<h3>[method:String decodeText]( [param:TypedArray array] )</h3>
-		<p>
-		[page:TypedArray array] —  Uno stream di byte come array tipizzato.
-		</p>
-		<p>
-      La funzione prende uno stream di byte in input e restituisce una rappresentazione di stringa.
-		</p>
-
 		<h3>[method:String extractUrlBase]( [param:String url] )</h3>
 		<p>
 		[page:String url] —  La url da cui estrarre la url di base.

--- a/docs/api/zh/loaders/LoaderUtils.html
+++ b/docs/api/zh/loaders/LoaderUtils.html
@@ -13,14 +13,6 @@
 
 		<h2>函数</h2>
 
-		<h3>[method:String decodeText]( [param:TypedArray array] )</h3>
-		<p>
-		[page:TypedArray array] — 作为类型化数组的字节流
-		</p>
-		<p>
-			该函数将字节流作为输入并返回字符串作为表示。
-		</p>
-
 		<h3>[method:String extractUrlBase]( [param:String url] )</h3>
 		<p>
 		[page:String url] — 从基本URL中，进行提取的URL。


### PR DESCRIPTION
Related issue: #30621

**Description**

Removes its docs as well
