### PR TITLE
Texture: Add setValues.

### DIFF
--- a/src/core/RenderTarget.js
+++ b/src/core/RenderTarget.js
@@ -214,6 +214,7 @@ class RenderTarget extends EventDispatcher {
 		if ( options.mapping !== undefined ) values.mapping = options.mapping;
 		if ( options.wrapS !== undefined ) values.wrapS = options.wrapS;
 		if ( options.wrapT !== undefined ) values.wrapT = options.wrapT;
+		if ( options.wrapR !== undefined ) values.wrapR = options.wrapR;
 		if ( options.magFilter !== undefined ) values.magFilter = options.magFilter;
 		if ( options.minFilter !== undefined ) values.minFilter = options.minFilter;
 		if ( options.format !== undefined ) values.format = options.format;

--- a/src/core/RenderTarget.js
+++ b/src/core/RenderTarget.js
@@ -126,11 +126,7 @@ class RenderTarget extends EventDispatcher {
 
 		const image = { width: width, height: height, depth: options.depth };
 
-		const texture = new Texture( image, options.mapping, options.wrapS, options.wrapT, options.magFilter, options.minFilter, options.format, options.type, options.anisotropy, options.colorSpace );
-
-		texture.flipY = false;
-		texture.generateMipmaps = options.generateMipmaps;
-		texture.internalFormat = options.internalFormat;
+		const texture = new Texture( image );
 
 		/**
 		 * An array of textures. Each color attachment is represented as a separate texture.
@@ -148,6 +144,8 @@ class RenderTarget extends EventDispatcher {
 			this.textures[ i ].renderTarget = this;
 
 		}
+
+		this._setTextureOptions( options );
 
 		/**
 		 * Whether to allocate a depth buffer or not.
@@ -201,6 +199,37 @@ class RenderTarget extends EventDispatcher {
 		 * @default false
 		 */
 		this.multiview = options.multiview;
+
+	}
+
+	_setTextureOptions( options = {} ) {
+
+		const values = {
+			minFilter: LinearFilter,
+			generateMipmaps: false,
+			flipY: false,
+			internalFormat: null
+		};
+
+		if ( options.mapping !== undefined ) values.mapping = options.mapping;
+		if ( options.wrapS !== undefined ) values.wrapS = options.wrapS;
+		if ( options.wrapT !== undefined ) values.wrapT = options.wrapT;
+		if ( options.magFilter !== undefined ) values.magFilter = options.magFilter;
+		if ( options.minFilter !== undefined ) values.minFilter = options.minFilter;
+		if ( options.format !== undefined ) values.format = options.format;
+		if ( options.type !== undefined ) values.type = options.type;
+		if ( options.anisotropy !== undefined ) values.anisotropy = options.anisotropy;
+		if ( options.colorSpace !== undefined ) values.colorSpace = options.colorSpace;
+		if ( options.flipY !== undefined ) values.flipY = options.flipY;
+		if ( options.generateMipmaps !== undefined ) values.generateMipmaps = options.generateMipmaps;
+		if ( options.internalFormat !== undefined ) values.internalFormat = options.internalFormat;
+
+		for ( let i = 0; i < this.textures.length; i ++ ) {
+
+			const texture = this.textures[ i ];
+			texture.setValues( values );
+
+		}
 
 	}
 

--- a/src/core/RenderTarget3D.js
+++ b/src/core/RenderTarget3D.js
@@ -37,6 +37,7 @@ class RenderTarget3D extends RenderTarget {
 		 * @type {Data3DTexture}
 		 */
 		this.texture = new Data3DTexture( null, width, height, depth );
+		this._setTextureOptions( options );
 
 		this.texture.isRenderTargetTexture = true;
 

--- a/src/renderers/WebGL3DRenderTarget.js
+++ b/src/renderers/WebGL3DRenderTarget.js
@@ -37,6 +37,7 @@ class WebGL3DRenderTarget extends WebGLRenderTarget {
 		 * @type {Data3DTexture}
 		 */
 		this.texture = new Data3DTexture( null, width, height, depth );
+		this._setTextureOptions( options );
 
 		this.texture.isRenderTargetTexture = true;
 

--- a/src/renderers/WebGLArrayRenderTarget.js
+++ b/src/renderers/WebGLArrayRenderTarget.js
@@ -37,6 +37,7 @@ class WebGLArrayRenderTarget extends WebGLRenderTarget {
 		 * @type {DataArrayTexture}
 		 */
 		this.texture = new DataArrayTexture( null, width, height, depth );
+		this._setTextureOptions( options );
 
 		this.texture.isRenderTargetTexture = true;
 

--- a/src/renderers/WebGLCubeRenderTarget.js
+++ b/src/renderers/WebGLCubeRenderTarget.js
@@ -41,7 +41,8 @@ class WebGLCubeRenderTarget extends WebGLRenderTarget {
 		 *
 		 * @type {DataArrayTexture}
 		 */
-		this.texture = new CubeTexture( images, options.mapping, options.wrapS, options.wrapT, options.magFilter, options.minFilter, options.format, options.type, options.anisotropy, options.colorSpace );
+		this.texture = new CubeTexture( images );
+		this._setTextureOptions( options );
 
 		// By convention -- likely based on the RenderMan spec from the 1990's -- cube maps are specified by WebGL (and three.js)
 		// in a coordinate system in which positive-x is to the right when looking up the positive-z axis -- in other words,
@@ -52,9 +53,6 @@ class WebGLCubeRenderTarget extends WebGLRenderTarget {
 		// as a cube texture (this is detected when isRenderTargetTexture is set to true for cube textures).
 
 		this.texture.isRenderTargetTexture = true;
-
-		this.texture.generateMipmaps = options.generateMipmaps !== undefined ? options.generateMipmaps : false;
-		this.texture.minFilter = options.minFilter !== undefined ? options.minFilter : LinearFilter;
 
 	}
 

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -510,6 +510,54 @@ class Texture extends EventDispatcher {
 	}
 
 	/**
+	 * Sets this texture's properties based on `values`.
+	 * @param {Object} values - A container with texture parameters.
+	 */
+	setValues( values ) {
+
+		for ( const key in values ) {
+
+			const newValue = values[ key ];
+
+			if ( newValue === undefined ) {
+
+				console.warn( `THREE.Texture.setValues(): parameter '${ key }' has value of undefined.` );
+				continue;
+
+			}
+
+			const currentValue = this[ key ];
+
+			if ( currentValue === undefined ) {
+
+				console.warn( `THREE.Texture.setValues(): property '${ key }' does not exist.` );
+				continue;
+
+			}
+
+			if ( ( currentValue && newValue ) && ( currentValue.isVector2 && newValue.isVector2 ) ) {
+
+				currentValue.copy( newValue );
+
+			} else if ( ( currentValue && newValue ) && ( currentValue.isVector3 && newValue.isVector3 ) ) {
+
+				currentValue.copy( newValue );
+
+			} else if ( ( currentValue && newValue ) && ( currentValue.isMatrix3 && newValue.isMatrix3 ) ) {
+
+				currentValue.copy( newValue );
+
+			} else {
+
+				this[ key ] = newValue;
+
+			}
+
+		}
+
+	}
+
+	/**
 	 * Serializes the texture into JSON.
 	 *
 	 * @param {?(Object|string)} meta - An optional value holding meta information about the serialization.

--- a/test/unit/src/core/RenderTarget.tests.js
+++ b/test/unit/src/core/RenderTarget.tests.js
@@ -1,0 +1,68 @@
+/* global QUnit */
+
+import { NearestFilter } from '../../../../src/constants.js';
+import { RenderTarget } from '../../../../src/core/RenderTarget.js';
+
+export default QUnit.module( 'Core', () => {
+
+	QUnit.module( 'RenderTarget', () => {
+
+		// Constructor options
+		QUnit.test( 'Constructor', ( assert ) => {
+
+			const empty = new RenderTarget();
+			assert.ok( empty.width != null && empty.height != null && empty.textures.length === 1, 'Can instantiate a RenderTarget with no arguments.' );
+
+			const sized = new RenderTarget( 1, 1 );
+			assert.ok( sized.width === 1 && sized.height === 1 && sized.textures.length === 1, 'Can instantiate a RenderTarget with custom size.' );
+
+			const mrt = new RenderTarget( 1, 1, { count: 2 } );
+			assert.ok( mrt.width === 1 && mrt.height === 1 && mrt.textures.length === 2, 'Can instantiate a RenderTarget with custom count (MRT).' );
+
+			const options = new RenderTarget( 1, 1, { magFilter: NearestFilter } );
+			assert.ok( options.width === 1 && options.height === 1 && options.texture.magFilter === NearestFilter, 'Can instantiate a RenderTarget with texture options.' );
+
+		} );
+
+		// PROPERTIES
+		QUnit.todo( 'texture', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		QUnit.todo( 'depthTexture', ( assert ) => {
+
+			assert.ok( false, 'everything\'s gonna be alright' );
+
+		} );
+
+		// PUBLIC
+		QUnit.test( 'setSize', ( assert ) => {
+
+			const renderTarget = new RenderTarget();
+			renderTarget.setSize( 128, 128 );
+			assert.ok( renderTarget.width === 128 && renderTarget.height === 128, 'Sets a size with width and height' );
+			assert.ok( renderTarget.texture.image.width === 128 && renderTarget.texture.image.height === 128, 'Texture image is updated on resize' );
+			assert.ok( renderTarget.viewport.width === 128 && renderTarget.viewport.height === 128, 'Viewport is updated on resize' );
+			assert.ok( renderTarget.scissor.width === 128 && renderTarget.scissor.height === 128, 'Scissor is updated on resize' );
+
+			const mrt = new RenderTarget( 0, 0, { count: 2 } );
+			mrt.setSize( 128, 128 );
+			assert.ok( mrt.width === 128 && mrt.height === 128, 'Sets a size with width and height' );
+			assert.ok( mrt.textures[ 0 ].image.width === 128 && mrt.textures[ 0 ].image.height === 128 && mrt.textures[ 1 ].image.width === 128 && mrt.textures[ 1 ].image.height === 128, 'Texture images are updated on resize' );
+			assert.ok( mrt.viewport.width === 128 && mrt.viewport.height === 128, 'Viewport is updated on resize' );
+			assert.ok( mrt.scissor.width === 128 && mrt.scissor.height === 128, 'Scissor is updated on resize' );
+
+			const renderTarget3D = new RenderTarget();
+			renderTarget3D.setSize( 128, 128, 16 );
+			assert.ok( renderTarget3D.width === 128 && renderTarget3D.height === 128 && renderTarget3D.depth === 16, 'Sets a size with width, height, and depth' );
+			assert.ok( renderTarget3D.texture.image.width === 128 && renderTarget3D.texture.image.height === 128 && renderTarget3D.texture.image.depth === 16, 'Texture image is updated on resize' );
+			assert.ok( renderTarget3D.viewport.width === 128 && renderTarget3D.viewport.height === 128, 'Viewport is updated on resize' );
+			assert.ok( renderTarget3D.scissor.width === 128 && renderTarget3D.scissor.height === 128, 'Scissor is updated on resize' );
+
+		} );
+
+	} );
+
+} );

--- a/test/unit/src/core/RenderTarget3D.tests.js
+++ b/test/unit/src/core/RenderTarget3D.tests.js
@@ -1,0 +1,28 @@
+/* global QUnit */
+
+import { RenderTarget3D } from '../../../../src/core/RenderTarget3D.js';
+
+import { EventDispatcher } from '../../../../src/core/EventDispatcher.js';
+import { NearestFilter } from '../../../../src/constants.js';
+
+export default QUnit.module( 'Core', () => {
+
+	QUnit.module( 'RenderTarget3D', () => {
+
+		// INHERITANCE
+		QUnit.test( 'Extending', ( assert ) => {
+
+			const object = new RenderTarget3D();
+			assert.strictEqual(
+				object instanceof EventDispatcher, true,
+				'RenderTarget3D extends from EventDispatcher'
+			);
+
+			const options = new RenderTarget3D( 1, 1, 1, { magFilter: NearestFilter } );
+			assert.ok( options.width === 1 && options.height === 1 && options.depth === 1 && options.texture.magFilter === NearestFilter, 'Can instantiate a RenderTarget3D with texture options.' );
+
+		} );
+
+	} );
+
+} );

--- a/test/unit/src/core/RenderTarget3D.tests.js
+++ b/test/unit/src/core/RenderTarget3D.tests.js
@@ -3,7 +3,7 @@
 import { RenderTarget3D } from '../../../../src/core/RenderTarget3D.js';
 
 import { EventDispatcher } from '../../../../src/core/EventDispatcher.js';
-import { NearestFilter } from '../../../../src/constants.js';
+import { NearestFilter, RepeatWrapping } from '../../../../src/constants.js';
 
 export default QUnit.module( 'Core', () => {
 
@@ -18,8 +18,8 @@ export default QUnit.module( 'Core', () => {
 				'RenderTarget3D extends from EventDispatcher'
 			);
 
-			const options = new RenderTarget3D( 1, 1, 1, { magFilter: NearestFilter } );
-			assert.ok( options.width === 1 && options.height === 1 && options.depth === 1 && options.texture.magFilter === NearestFilter, 'Can instantiate a RenderTarget3D with texture options.' );
+			const options = new RenderTarget3D( 1, 1, 1, { magFilter: NearestFilter, wrapR: RepeatWrapping } );
+			assert.ok( options.width === 1 && options.height === 1 && options.depth === 1 && options.texture.magFilter === NearestFilter && options.texture.wrapR === RepeatWrapping, 'Can instantiate a RenderTarget3D with texture options.' );
 
 		} );
 

--- a/test/unit/src/renderers/WebGL3DRenderTarget.tests.js
+++ b/test/unit/src/renderers/WebGL3DRenderTarget.tests.js
@@ -1,5 +1,6 @@
 /* global QUnit */
 
+import { NearestFilter } from '../../../../src/constants.js';
 import { WebGL3DRenderTarget } from '../../../../src/renderers/WebGL3DRenderTarget.js';
 
 import { WebGLRenderTarget } from '../../../../src/renderers/WebGLRenderTarget.js';
@@ -16,6 +17,9 @@ export default QUnit.module( 'Renderers', () => {
 				object instanceof WebGLRenderTarget, true,
 				'WebGL3DRenderTarget extends from WebGLRenderTarget'
 			);
+
+			const options = new WebGL3DRenderTarget( 1, 1, 1, { magFilter: NearestFilter } );
+			assert.ok( options.width === 1 && options.height === 1 && options.depth === 1 && options.texture.magFilter === NearestFilter, 'Can instantiate a WebGL3DRenderTarget with texture options.' );
 
 		} );
 

--- a/test/unit/src/renderers/WebGLArrayRenderTarget.tests.js
+++ b/test/unit/src/renderers/WebGLArrayRenderTarget.tests.js
@@ -1,5 +1,6 @@
 /* global QUnit */
 
+import { NearestFilter } from '../../../../src/constants.js';
 import { WebGLArrayRenderTarget } from '../../../../src/renderers/WebGLArrayRenderTarget.js';
 
 import { WebGLRenderTarget } from '../../../../src/renderers/WebGLRenderTarget.js';
@@ -16,6 +17,9 @@ export default QUnit.module( 'Renderers', () => {
 				object instanceof WebGLRenderTarget, true,
 				'WebGLArrayRenderTarget extends from WebGLRenderTarget'
 			);
+
+			const options = new WebGLArrayRenderTarget( 1, 1, 1, { magFilter: NearestFilter } );
+			assert.ok( options.width === 1 && options.height === 1 && options.depth === 1 && options.texture.magFilter === NearestFilter, 'Can instantiate a WebGLArrayRenderTarget with texture options.' );
 
 		} );
 

--- a/test/unit/src/renderers/WebGLCubeRenderTarget.tests.js
+++ b/test/unit/src/renderers/WebGLCubeRenderTarget.tests.js
@@ -1,5 +1,6 @@
 /* global QUnit */
 
+import { NearestFilter } from '../../../../src/constants.js';
 import { WebGLCubeRenderTarget } from '../../../../src/renderers/WebGLCubeRenderTarget.js';
 
 import { WebGLRenderTarget } from '../../../../src/renderers/WebGLRenderTarget.js';
@@ -16,6 +17,9 @@ export default QUnit.module( 'Renderers', () => {
 				object instanceof WebGLRenderTarget, true,
 				'WebGLCubeRenderTarget extends from WebGLRenderTarget'
 			);
+
+			const options = new WebGLCubeRenderTarget( 1, { magFilter: NearestFilter } );
+			assert.ok( options.width === 1 && options.height === 1 && options.texture.magFilter === NearestFilter, 'Can instantiate a WebGLCubeRenderTarget with texture options.' );
 
 		} );
 

--- a/test/unit/src/renderers/WebGLRenderTarget.tests.js
+++ b/test/unit/src/renderers/WebGLRenderTarget.tests.js
@@ -3,6 +3,7 @@
 import { WebGLRenderTarget } from '../../../../src/renderers/WebGLRenderTarget.js';
 
 import { EventDispatcher } from '../../../../src/core/EventDispatcher.js';
+import { NearestFilter } from '../../../../src/constants.js';
 
 export default QUnit.module( 'Renderers', () => {
 
@@ -16,6 +17,9 @@ export default QUnit.module( 'Renderers', () => {
 				object instanceof EventDispatcher, true,
 				'WebGLRenderTarget extends from EventDispatcher'
 			);
+
+			const options = new WebGLRenderTarget( 1, 1, { magFilter: NearestFilter } );
+			assert.ok( options.width === 1 && options.height === 1 && options.texture.magFilter === NearestFilter, 'Can instantiate a WebGLRenderTarget with texture options.' );
 
 		} );
 


### PR DESCRIPTION
Fixed #28100

**Description**

Implements `setValues` in `Texture`. Since every render target class would need to filter options into texture parameters, I implement an internal `_setTextureOptions` method. It is recommended to use public API to enjoy validation.