### PR TITLE
ImageBitmapLoader: Make error handling more robust.

### DIFF
--- a/src/loaders/ImageBitmapLoader.js
+++ b/src/loaders/ImageBitmapLoader.js
@@ -118,7 +118,10 @@ class ImageBitmapLoader extends Loader {
 
 					if ( _errorMap.has( cached ) === true ) {
 
-						throw new Error();
+						if ( onError ) onError( _errorMap.get( cached ) );
+
+						scope.manager.itemError( url );
+						scope.manager.itemEnd( url );
 
 					} else {
 
@@ -126,16 +129,12 @@ class ImageBitmapLoader extends Loader {
 
 						scope.manager.itemEnd( url );
 
+						return imageBitmap;
+
 					}
 
-				} ).catch( () => {
-
-					if ( onError ) onError( _errorMap.get( cached ) );
-
-					scope.manager.itemError( url );
-					scope.manager.itemEnd( url );
-
 				} );
+
 				return;
 
 			}

--- a/src/loaders/ImageBitmapLoader.js
+++ b/src/loaders/ImageBitmapLoader.js
@@ -113,8 +113,7 @@ class ImageBitmapLoader extends Loader {
 
 				cached.then( imageBitmap => {
 
-					// The code checks if there is an error for the cached promise. If so, throw
-					// a new error to force the code flow into the catch() block.
+					// check if there is an error for the cached promise
 
 					if ( _errorMap.has( cached ) === true ) {
 

--- a/src/loaders/ImageBitmapLoader.js
+++ b/src/loaders/ImageBitmapLoader.js
@@ -13,7 +13,7 @@ const _errorMap = new WeakMap();
  *
  * You need to set the equivalent options via {@link ImageBitmapLoader#setOptions} instead.
  *
- * Also note that unlike {@link FileLoader}, this loader does not avoid multiple concurrent requests to the same URL.
+ * Also note that unlike {@link FileLoader}, this loader avoids multiple concurrent requests to the same URL only if `Cache` is enabled.
  *
  * ```js
  * const loader = new THREE.ImageBitmapLoader();


### PR DESCRIPTION
Fixed #31083.

**Description**

The PR fixes a bug in `ImageBitmapLoader` that can appear when more than one image loader try to load an erroneous URL with enabled caching. In that case, not all `onError()` callback were executed.

The idea of the PR is to keep track of the error object so it can be used to detect an error situation for duplicated requests. 