### PR TITLE
Mesh,Sprite: Add `count` property

### DIFF
--- a/src/objects/Mesh.js
+++ b/src/objects/Mesh.js
@@ -94,6 +94,15 @@ class Mesh extends Object3D {
 		 */
 		this.morphTargetInfluences = undefined;
 
+		/**
+		 * The number of instances of this mesh.
+		 * Can only be used with {@link WebGPURenderer}.
+		 *
+		 * @type {number}
+		 * @default 1
+		 */
+		this.count = 1;
+
 		this.updateMorphTargets();
 
 	}

--- a/src/objects/Sprite.js
+++ b/src/objects/Sprite.js
@@ -108,6 +108,15 @@ class Sprite extends Object3D {
 		 */
 		this.center = new Vector2( 0.5, 0.5 );
 
+		/**
+		 * The number of instances of this sprite.
+		 * Can only be used with {@link WebGPURenderer}.
+		 *
+		 * @type {number}
+		 * @default 1
+		 */
+		this.count = 1;
+
 	}
 
 	/**


### PR DESCRIPTION
**Description**

In `WebGPURenderer` instances are created through TSL functions, this allows for easier skinning and sprite instancing which is very useful for particles. Practically all webgpu examples of instances already use it, the property is just not declared.