### PR TITLE
Core: Increase version of Object/Scene format.

### DIFF
--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -1201,7 +1201,7 @@ class BufferGeometry extends EventDispatcher {
 
 		const data = {
 			metadata: {
-				version: 4.6,
+				version: 4.7,
 				type: 'BufferGeometry',
 				generator: 'BufferGeometry.toJSON'
 			}

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -1246,7 +1246,7 @@ class Object3D extends EventDispatcher {
 			};
 
 			output.metadata = {
-				version: 4.6,
+				version: 4.7,
 				type: 'Object',
 				generator: 'Object3D.toJSON'
 			};

--- a/src/extras/core/Curve.js
+++ b/src/extras/core/Curve.js
@@ -483,7 +483,7 @@ class Curve {
 
 		const data = {
 			metadata: {
-				version: 4.6,
+				version: 4.7,
 				type: 'Curve',
 				generator: 'Curve.toJSON'
 			}

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -615,7 +615,7 @@ class Material extends EventDispatcher {
 
 		const data = {
 			metadata: {
-				version: 4.6,
+				version: 4.7,
 				type: 'Material',
 				generator: 'Material.toJSON'
 			}

--- a/src/nodes/core/Node.js
+++ b/src/nodes/core/Node.js
@@ -858,7 +858,7 @@ class Node extends EventDispatcher {
 				type,
 				meta,
 				metadata: {
-					version: 4.6,
+					version: 4.7,
 					type: 'Node',
 					generator: 'Node.toJSON'
 				}

--- a/src/objects/Skeleton.js
+++ b/src/objects/Skeleton.js
@@ -350,7 +350,7 @@ class Skeleton {
 
 		const data = {
 			metadata: {
-				version: 4.6,
+				version: 4.7,
 				type: 'Skeleton',
 				generator: 'Skeleton.toJSON'
 			},

--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -529,7 +529,7 @@ class Texture extends EventDispatcher {
 		const output = {
 
 			metadata: {
-				version: 4.6,
+				version: 4.7,
 				type: 'Texture',
 				generator: 'Texture.toJSON'
 			},

--- a/test/unit/src/core/BufferGeometry.tests.js
+++ b/test/unit/src/core/BufferGeometry.tests.js
@@ -654,7 +654,7 @@ export default QUnit.module( 'Core', () => {
 			let j = a.toJSON();
 			const gold = {
 				'metadata': {
-					'version': 4.6,
+					'version': 4.7,
 					'type': 'BufferGeometry',
 					'generator': 'BufferGeometry.toJSON'
 				},

--- a/test/unit/src/core/Object3D.tests.js
+++ b/test/unit/src/core/Object3D.tests.js
@@ -1271,7 +1271,7 @@ export default QUnit.module( 'Core', () => {
 
 			const gold = {
 				'metadata': {
-					'version': 4.6,
+					'version': 4.7,
 					'type': 'Object',
 					'generator': 'Object3D.toJSON'
 				},

--- a/test/unit/utils/qunit-utils.js
+++ b/test/unit/utils/qunit-utils.js
@@ -121,7 +121,7 @@ function getDifferingProp( geometryA, geometryB ) {
 // Compare json file with its source geometry.
 function checkGeometryJsonWriting( geom, json ) {
 
-	QUnit.assert.equal( json.metadata.version, '4.6', 'check metadata version' );
+	QUnit.assert.equal( json.metadata.version, '4.7', 'check metadata version' );
 	QUnit.assert.equalKey( geom, json, 'type' );
 	QUnit.assert.equalKey( geom, json, 'uuid' );
 	QUnit.assert.equal( json.id, undefined, 'should not persist id' );
@@ -270,7 +270,7 @@ function checkLightCopyClone( assert, light ) {
 // Compare json file with its source Light.
 function checkLightJsonWriting( assert, light, json ) {
 
-	assert.equal( json.metadata.version, '4.6', 'check metadata version' );
+	assert.equal( json.metadata.version, '4.7', 'check metadata version' );
 
 	const object = json.object;
 	assert.equalKey( light, object, 'type' );


### PR DESCRIPTION
Fixes: #31095

**Description**

Updated the version to `4.7` in `Material.toJSON`, can do the same for other classes - Object3D, BufferGeometry etc if you want to keep it consistent.

The handling of bumpScale was changed in https://github.com/mrdoob/three.js/pull/26899, which is saved in Material.toJSON.

To distinguish between old and new files metadata.version is checked while loading, so that either a warning can be shown to the user or some heuristic can be used to automatically adjust the value.

*This contribution is funded by [ThreePipe](https://threepipe.org/)*
