### PR TITLE
FBXLoader: Add `webp` MIME type.

### DIFF
--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -348,6 +348,11 @@ class FBXTreeParser {
 				type = 'image/tga';
 				break;
 
+			case 'webp':
+
+				type = 'image/webp';
+				break;
+
 			default:
 
 				console.warn( 'FBXLoader: Image type "' + extension + '" is not supported.' );


### PR DESCRIPTION
**Description**

Webp images on materials wouldn't load with the FBXLoader.

Very simple change to add webp type to the parseImage function.

It's a fairly rare that webp is used within an FBX, but ran in to this today. Using webp was able to shave 100kb from a 512x512 png texture (reduced from >150kb to <50kb), while keeping transparency.