### PR TITLE
ShadowNode: Fix VSM with point lights.

### DIFF
--- a/src/nodes/lighting/ShadowNode.js
+++ b/src/nodes/lighting/ShadowNode.js
@@ -417,7 +417,7 @@ class ShadowNode extends ShadowBaseNode {
 
 		// VSM
 
-		if ( shadowMapType === VSMShadowMap ) {
+		if ( shadowMapType === VSMShadowMap && light.isPointLight !== true ) {
 
 			depthTexture.compareFunction = null; // VSM does not use textureSampleCompare()/texture2DCompare()
 
@@ -497,7 +497,7 @@ class ShadowNode extends ShadowBaseNode {
 
 		}
 
-		const shadowDepthTexture = ( shadowMapType === VSMShadowMap ) ? this.vsmShadowMapHorizontal.texture : depthTexture;
+		const shadowDepthTexture = ( shadowMapType === VSMShadowMap && light.isPointLight !== true ) ? this.vsmShadowMapHorizontal.texture : depthTexture;
 
 		const shadowNode = this.setupShadowFilter( builder, { filterFn, shadowTexture: shadowMap.texture, depthTexture: shadowDepthTexture, shadowCoord, shadow, depthLayer: this.depthLayer } );
 


### PR DESCRIPTION
Related issue: https://discourse.threejs.org/t/webgpu-shadow-tests-and-findings/82561

**Description**

A user in the forum reported an error that the combination of VSM and point lights is currently not supported with `WebGPURenderer`. The PR fixes that by making sure point light shadows use their default point shadow filter and not VSM similar to `WebGLRenderer`.