### PR TITLE
LightsNode: Fix `castShadow` regression.

### DIFF
--- a/src/nodes/lighting/AnalyticLightNode.js
+++ b/src/nodes/lighting/AnalyticLightNode.js
@@ -3,7 +3,6 @@ import { NodeUpdateType } from '../core/constants.js';
 import { uniform } from '../core/UniformNode.js';
 import { Color } from '../../math/Color.js';
 import { renderGroup } from '../core/UniformGroupNode.js';
-import { hash } from '../core/NodeUtils.js';
 import { shadow } from './ShadowNode.js';
 import { nodeObject } from '../tsl/TSLCore.js';
 import { lightViewPosition } from '../accessors/Lights.js';
@@ -99,24 +98,20 @@ class AnalyticLightNode extends LightingNode {
 
 	}
 
-	/**
-	 * Overwrites the default {@link Node#customCacheKey} implementation by including the
-	 * `light.id` and `light.castShadow` into the cache key.
-	 *
-	 * @return {number} The custom cache key.
-	 */
-	customCacheKey() {
-
-		return hash( this.light.id, this.light.castShadow ? 1 : 0 );
-
-	}
-
 	getHash() {
 
 		return this.light.uuid;
 
 	}
 
+	/**
+	 * Returns a node representing a direction vector which points from the current
+	 * position in view space to the light's position in view space.
+	 *
+	 * @abstract
+	 * @param {NodeBuilder} builder - The builder object used for setting up the light.
+	 * @return {Node<vec3>} The light vector node.
+	 */
 	getLightVector( builder ) {
 
 		return lightViewPosition( this.light ).sub( builder.context.positionView || positionView );

--- a/src/nodes/lighting/AnalyticLightNode.js
+++ b/src/nodes/lighting/AnalyticLightNode.js
@@ -108,7 +108,6 @@ class AnalyticLightNode extends LightingNode {
 	 * Returns a node representing a direction vector which points from the current
 	 * position in view space to the light's position in view space.
 	 *
-	 * @abstract
 	 * @param {NodeBuilder} builder - The builder object used for setting up the light.
 	 * @return {Node<vec3>} The light vector node.
 	 */

--- a/src/nodes/lighting/LightsNode.js
+++ b/src/nodes/lighting/LightsNode.js
@@ -25,6 +25,7 @@ const getLightNodeById = ( id, lightNodes ) => {
 };
 
 const _lightsNodeRef = /*@__PURE__*/ new WeakMap();
+const _hashData = [];
 
 /**
  * This node represents the scene's lighting and manages the lighting model's life cycle
@@ -114,27 +115,31 @@ class LightsNode extends Node {
 	 */
 	customCacheKey() {
 
-		const hashData = [];
 		const lights = this._lights;
 
 		for ( let i = 0; i < lights.length; i ++ ) {
 
 			const light = lights[ i ];
 
-			hashData.push( light.id );
+			_hashData.push( light.id );
+			_hashData.push( light.castShadow ? 1 : 0 );
 
 			if ( light.isSpotLight === true ) {
 
 				const hashMap = ( light.map !== null ) ? light.map.id : - 1;
 				const hashColorNode = ( light.colorNode ) ? light.colorNode.getCacheKey() : - 1;
 
-				hashData.push( hashMap, hashColorNode );
+				_hashData.push( hashMap, hashColorNode );
 
 			}
 
 		}
 
-		return hashArray( hashData );
+		const cacheKey = hashArray( _hashData );
+
+		_hashData.length = 0;
+
+		return cacheKey;
 
 	}
 


### PR DESCRIPTION
Related issue: https://discourse.threejs.org/t/webgpu-shadow-tests-and-findings/82561

**Description**

Toggling `light.castShadow` with `WebGPURenderer` has currently no effect.

The bit that checks the light state per frame is `LightsNode.customCacheKey()`. In this method we have to implement all checks that detect state changes of lights. 
