### PR TITLE
GLTFLoader: Add support for importing single root files

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -620,7 +620,7 @@ const EXTENSIONS = {
 	EXT_TEXTURE_AVIF: 'EXT_texture_avif',
 	EXT_MESHOPT_COMPRESSION: 'EXT_meshopt_compression',
 	EXT_MESH_GPU_INSTANCING: 'EXT_mesh_gpu_instancing',
-	GODOT_SINGLE_ROOT: 'GODOT_single_root',
+	GODOT_SINGLE_ROOT: 'GODOT_single_root'
 };
 
 /**

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -4489,10 +4489,13 @@ class GLTFParser {
 		if ( isSingleRoot ) {
 
 			if ( nodeIds.length !== 1 ) {
+
 				throw new Error( 'THREE.GLTFLoader: glTF file with the single root flag must have exactly one scene root node. File is invalid.' );
+
 			}
 
 		} else {
+
 			// Loader returns Group, not Scene.
 			// See: https://github.com/mrdoob/three.js/issues/18342#issuecomment-578981172
 			scene = new Group();
@@ -4501,6 +4504,7 @@ class GLTFParser {
 			assignExtrasToUserData( scene, sceneDef );
 
 			if ( sceneDef.extensions ) addUnknownExtensionsToUserData( extensions, scene, sceneDef );
+
 		}
 
 		const pending = [];

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -97,6 +97,7 @@ import { toTrianglesDrawMode } from '../utils/BufferGeometryUtils.js';
  * - EXT_texture_webp
  * - EXT_meshopt_compression
  * - EXT_mesh_gpu_instancing
+ * - GODOT_SINGLE_ROOT
  *
  * The following glTF 2.0 extension is supported by an external user plugin:
  * - [KHR_materials_variants]{@link https://github.com/takahirox/three-gltf-extensions}
@@ -4483,14 +4484,15 @@ class GLTFParser {
 		const nodeIds = sceneDef.nodes || [];
 		const parser = this;
 		const extensionsUsed = this.json.extensionsUsed;
-		const isSingleRoot = Array.isArray( extensionsUsed ) ? extensionsUsed.includes( EXTENSIONS.GODOT_SINGLE_ROOT ) : false;
+		const isGodotSingleRoot = Array.isArray( extensionsUsed ) ? extensionsUsed.includes( EXTENSIONS.GODOT_SINGLE_ROOT ) : false;
 
 		let scene;
-		if ( isSingleRoot ) {
+
+		if ( isGodotSingleRoot ) {
 
 			if ( nodeIds.length !== 1 ) {
 
-				throw new Error( 'THREE.GLTFLoader: glTF file with the single root flag must have exactly one scene root node. File is invalid.' );
+				throw new Error( 'THREE.GLTFLoader: glTF files using the GODOT_SINGLE_ROOT extension must have exactly one scene root node. File is invalid.' );
 
 			}
 
@@ -4517,7 +4519,7 @@ class GLTFParser {
 
 		return Promise.all( pending ).then( function ( nodes ) {
 
-			if ( isSingleRoot ) {
+			if ( isGodotSingleRoot ) {
 
 				scene = nodes[ 0 ];
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -4492,7 +4492,7 @@ class GLTFParser {
 
 			if ( nodeIds.length !== 1 ) {
 
-				throw new Error( 'THREE.GLTFLoader: glTF files using the GODOT_SINGLE_ROOT extension must have exactly one scene root node. File is invalid.' );
+				throw new Error( 'THREE.GLTFLoader: glTF files using the GODOT_single_root extension must have exactly one scene root node. File is invalid.' );
 
 			}
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -97,7 +97,7 @@ import { toTrianglesDrawMode } from '../utils/BufferGeometryUtils.js';
  * - EXT_texture_webp
  * - EXT_meshopt_compression
  * - EXT_mesh_gpu_instancing
- * - GODOT_SINGLE_ROOT
+ * - GODOT_single_root
  *
  * The following glTF 2.0 extension is supported by an external user plugin:
  * - [KHR_materials_variants]{@link https://github.com/takahirox/three-gltf-extensions}

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -405,7 +405,7 @@ class GLTFLoader extends Loader {
 	}
 
 	/**
-	 * Parses the given glTF data and returns the generated data to `onLoad`, with the root Object3D in the `.scene` property.
+	 * Parses the given glTF data and returns the generated data to `onLoad`.
 	 *
 	 * @param {string|ArrayBuffer} data - The raw glTF data.
 	 * @param {string} path - The URL base path.


### PR DESCRIPTION
**Description**

This PR adds support for importing files with the [`GODOT_single_root`](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Vendor/GODOT_single_root) extension to GLTFLoader. This vendor extension is recognized by Khronos in their repository's vendor extensions folder (but not developed by or officially endorsed by Khronos).

Old text collapsed, I removed the export code so this is no longer correct:

<details>

With this PR, if you round-trip a non-scene Three.JS object like this:

```js
const loader = new GLTFLoader();
const exporter = new GLTFExporter();

exporter.parse(myobject, function (gltfJson) {
	// We need to make a URL so that GLTFLoader can load the data.
	const blob = new Blob([JSON.stringify(gltfJson)], { type: "application/json" });
	const url = URL.createObjectURL(blob);
	loader.load(url, function (generated) {
		console.log(generated.scene);
	});
]);
```

... then the `generated.scene` object corresponds to the same object that was exported, with the same name, and with any data that can survive a round-trip through glTF node extensions. Without this PR, in the current dev branch, it will instead return a `Group` named `"AuxScene"`, and the exported node will be a child of that, needlessly creating an extra node.

Also with this PR, if you round-trip a glTF file with the GODOT_single_root flag:

```js
const loader = new GLTFLoader();
const exporter = new GLTFExporter();

loader.load("/path/to/my/file.gltf", function (generated) {
	exporter.parse(generated.scene, function (gltfJson) {
		console.log(gltfJson);
	});
]);
```

... then the exported glTF JSON data will have the `GODOT_single_root` flag set, because `generated.scene` is a single non-`Scene` object. This also applies to other objects regardless of if they came from a `GODOT_single_root` input file.

</details>

This improves interoperability with Godot Engine, including exporting files from Godot to Three.JS. I could imagine it being useful to use Godot as a visual tool to make objects for Three.JS. Other apps and engines may choose to support `GODOT_single_root` if they wish, such as a potential future Blender extension geared towards game development.

The code for this is heavily integrated into `loadScene()` so it can't be done with an extension to `GLTFLoader`, at most you could have code that wraps around `GLTFLoader`. Also, the code for this is quite minimal, most of the diffs are from indenting already existing code one scope further in.

Note: The "GODOT_single_root" extension name is prefixed with "GODOT_" because that is the context in which that extension was developed, however this does not mean it is only intended to be used for Godot. Quite the opposite actually, this is designed to improve interoperability between engines for glTF files containing "one object". The "EXT_" prefix is reserved for extensions developed by multiple vendors, it does not prescribe which apps can use it.

Also, I noticed the docs for `GLTFLoader.parse` said "Parses the given FBX data and returns the resulting group.". This is wrong in two ways: it's glTF not FBX, and it doesn't return the `Group`, it returns (in the callback) an object holding a bunch of generated data, which includes the single root node (which is `Group` without the single root flag, or another `Object3D` generated from the glTF root node with the single root flag). I've updated the description of this function.

This is my first contribution to Three.JS. I've tested this and I've done my best to follow the existing code style. If any changes are needed I will be happy to update the PR.