### PR TITLE
USDZExporter: Fix JSDoc to match default value

### DIFF
--- a/examples/jsm/exporters/USDZExporter.js
+++ b/examples/jsm/exporters/USDZExporter.js
@@ -827,7 +827,7 @@ function buildCamera( camera ) {
  *
  * @typedef {Object} USDZExporter~Options
  * @property {number} [maxTextureSize=1024] - The maximum texture size that is going to be exported.
- * @property {boolean} [includeAnchoringProperties=false] - Whether to include anchoring properties or not.
+ * @property {boolean} [includeAnchoringProperties=true] - Whether to include anchoring properties or not.
  * @property {Object} [ar] - If `includeAnchoringProperties` is set to `true`, the anchoring type and alignment
  * can be configured via `ar.anchoring.type` and `ar.planeAnchoring.alignment`.
  * @property {boolean} [quickLookCompatible=false] - Whether to make the exported USDZ compatible to QuickLook


### PR DESCRIPTION
**Description**

The JSDoc for `includeAnchoringProperties` default is `false`, while the [code](https://github.com/mrdoob/three.js/blob/r176/examples/jsm/exporters/USDZExporter.js#L82) uses `true`.
