### PR TITLE
XRManager: Fix layer color correction.

### DIFF
--- a/src/renderers/common/XRManager.js
+++ b/src/renderers/common/XRManager.js
@@ -637,6 +637,8 @@ class XRManager extends EventDispatcher {
 				resolveStencilBuffer: false
 			} );
 
+		renderTarget.autoAllocateDepthBuffer = true;
+
 		const material = new MeshBasicMaterial( { color: 0xffffff, side: FrontSide } );
 		material.map = renderTarget.texture;
 		material.map.offset.y = 1;
@@ -726,6 +728,8 @@ class XRManager extends EventDispatcher {
 				resolveStencilBuffer: false
 			} );
 
+		renderTarget.autoAllocateDepthBuffer = true;
+
 		const material = new MeshBasicMaterial( { color: 0xffffff, side: BackSide } );
 		material.map = renderTarget.texture;
 		material.map.offset.y = 1;
@@ -794,7 +798,6 @@ class XRManager extends EventDispatcher {
 
 			layer.renderTarget.isXRRenderTarget = this._session !== null;
 			layer.renderTarget.hasExternalTextures = layer.renderTarget.isXRRenderTarget;
-			layer.renderTarget.autoAllocateDepthBuffer = ! layer.renderTarget.isXRRenderTarget;
 
 			if ( layer.renderTarget.isXRRenderTarget && this._supportsLayers ) {
 
@@ -804,13 +807,17 @@ class XRManager extends EventDispatcher {
 				this._renderer.backend.setXRRenderTargetTextures(
 					layer.renderTarget,
 					glSubImage.colorTexture,
-					glSubImage.depthStencilTexture );
+					undefined );
 
 				this._renderer.setOutputRenderTarget( layer.renderTarget );
+				this._renderer.setRenderTarget( null );
+
+			} else {
+
+				this._renderer.setRenderTarget( layer.renderTarget );
 
 			}
 
-			this._renderer.setRenderTarget( layer.renderTarget );
 			layer.rendercall();
 
 		}
@@ -1442,7 +1449,6 @@ function createXRLayer( layer ) {
 
 		return this._glBinding.createQuadLayer( {
 			transform: new XRRigidTransform( layer.translation, layer.quaternion ),
-			depthFormat: this._gl.DEPTH_COMPONENT,
 			width: layer.width / 2,
 			height: layer.height / 2,
 			space: this._referenceSpace,
@@ -1454,7 +1460,6 @@ function createXRLayer( layer ) {
 
 		return this._glBinding.createCylinderLayer( {
 			transform: new XRRigidTransform( layer.translation, layer.quaternion ),
-			depthFormat: this._gl.DEPTH_COMPONENT,
 			radius: layer.radius,
 			centralAngle: layer.centralAngle,
 			aspectRatio: layer.aspectRatio,


### PR DESCRIPTION
Addresses [comment](https://github.com/mrdoob/three.js/pull/30730#issuecomment-2876141898) from @mrdoob 

@Mugen87 , this "fixes" the problem but still has bad performance. The issue seems to be coming from the single _frameBufferTarget in the renderer, as well as its single _quad.
Because of the single target, textures and shaders get reallocated constantly. Because of the single fixed size quad, the layers get rendered to a texture that is too big in the first pass.
Maybe we can give each layer its own renderer or maybe we can fix the renderer so it correctly caches/reallocates the resources for the second pass.