### PR TITLE
GLTFExporter: Push nodes parent-first instead of child-first

### DIFF
--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -2408,6 +2408,9 @@ class GLTFWriter {
 
 		if ( object.isSkinnedMesh ) this.skins.push( object );
 
+		const nodeIndex = json.nodes.push( nodeDef ) - 1;
+		nodeMap.set( object, nodeIndex );
+
 		if ( object.children.length > 0 ) {
 
 			const children = [];
@@ -2418,9 +2421,9 @@ class GLTFWriter {
 
 				if ( child.visible || options.onlyVisible === false ) {
 
-					const nodeIndex = await this.processNodeAsync( child );
+					const childNodeIndex = await this.processNodeAsync( child );
 
-					if ( nodeIndex !== null ) children.push( nodeIndex );
+					if ( childNodeIndex !== null ) children.push( childNodeIndex );
 
 				}
 
@@ -2436,8 +2439,6 @@ class GLTFWriter {
 
 		} );
 
-		const nodeIndex = json.nodes.push( nodeDef ) - 1;
-		nodeMap.set( object, nodeIndex );
 		return nodeIndex;
 
 	}


### PR DESCRIPTION
Related to #31112

**Description**

Currently, if you have a Three.js Object3D hierarchy like this:

```
A
  B
  C
```

Then it will get exported to glTF child-first: node A at index 2, node B at index 0, and node C at index 1. Node A will have the `"children"` array set to `[0, 1]` and the glTF scene will have its root nodes set to `[2]`.

With this PR, it will instead export to the glTF parent-first: node A at index 0, node B at index 1, and node C at index 2. Node A will have the `"children"` array set to `[1, 2]` and the glTF scene will have its root nodes set to `[0]`.

Any order is fine for the most part, since glTF itself does not explicitly require any order, and does not suggest a preferred order. glTF importers can import any order, and changing the order does not affect compatibility. Blender uses the same order, too. However, UnityGLTF and Godot both use parent-first order. I'd argue it's more human-readable this way, because the first node in the array tells you the start of the tree, and well, if you display it visually like I did above, you put the root at the top anyway. Most importantly, [`GODOT_single_root`](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Vendor/GODOT_single_root) has a requirement that the root node is at index 0, since the goal is to make the `"scene"` and `"scenes"` properties fully redundant, as they are usually not useful for glTF files representing "one object". Changing the order Three.js exports nodes in matches `GODOT_single_root` and other game engines, with no downsides, so it should be done regardless of whether or not the exported file has the `GODOT_single_root` flag in it.