### PR TITLE
USDZExporter: Fix Object indentation level

### DIFF
--- a/examples/jsm/exporters/USDZExporter.js
+++ b/examples/jsm/exporters/USDZExporter.js
@@ -315,16 +315,16 @@ function buildXform( object, geometry, material ) {
 
 	}
 
-	return `def Xform "${ name }" (
-	prepend references = @./geometries/Geometry_${ geometry.id }.usda@</Geometry>
-	prepend apiSchemas = ["MaterialBindingAPI"]
-)
-{
-	matrix4d xformOp:transform = ${ transform }
-	uniform token[] xformOpOrder = ["xformOp:transform"]
+	return `			def Xform "${ name }" (
+				prepend references = @./geometries/Geometry_${ geometry.id }.usda@</Geometry>
+				prepend apiSchemas = ["MaterialBindingAPI"]
+			)
+			{
+				matrix4d xformOp:transform = ${ transform }
+				uniform token[] xformOpOrder = ["xformOp:transform"]
 
-	rel material:binding = </Materials/Material_${ material.id }>
-}
+				rel material:binding = </Materials/Material_${ material.id }>
+			}
 
 `;
 


### PR DESCRIPTION
**Description**

Add 3 tabs for `Object_x`'s as they should always be placed at 3 levels in with the current exporter fixed output structure.

Before:
```
def Xform "Root"
{
	def Scope "Scenes" (
		kind = "sceneLibrary"
	)
	{
		def Xform "Scene" (
			customData = {
				bool preliminary_collidesWithEnvironment = 0
				string sceneName = "Scene"
			}
			sceneName = "Scene"
		)
		{
def Xform "Object_15" (
	prepend references = @./geometries/Geometry_3.usda@</Geometry>
	prepend apiSchemas = ["MaterialBindingAPI"]
)
{
	matrix4d xformOp:transform = ( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 0, 0, 1) )
	uniform token[] xformOpOrder = ["xformOp:transform"]

	rel material:binding = </Materials/Material_6>
}
...
```

After:
```
def Xform "Root"
{
	def Scope "Scenes" (
		kind = "sceneLibrary"
	)
	{
		def Xform "Scene" (
			customData = {
				bool preliminary_collidesWithEnvironment = 0
				string sceneName = "Scene"
			}
			sceneName = "Scene"
		)
		{
			def Xform "Object_15" (
				prepend references = @./geometries/Geometry_3.usda@</Geometry>
				prepend apiSchemas = ["MaterialBindingAPI"]
			)
			{
				matrix4d xformOp:transform = ( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 0, 0, 1) )
				uniform token[] xformOpOrder = ["xformOp:transform"]

				rel material:binding = </Materials/Material_6>
			}
...
```
