### PR TITLE
NodeMaterial: Introduce `.maskNode` and improve `shapeCircle()`

### DIFF
--- a/examples/webgpu_compute_particles.html
+++ b/examples/webgpu_compute_particles.html
@@ -38,7 +38,7 @@
 		<script type="module">
 
 			import * as THREE from 'three';
-			import { Fn, If, uniform, float, uv, vec2, vec3, hash,
+			import { Fn, If, uniform, float, uv, vec2, vec3, hash, shapeCircle,
 				instancedArray, instanceIndex } from 'three/tsl';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
@@ -133,13 +133,14 @@
 				computeParticles = computeUpdate().compute( particleCount );
 
 				// create particles
-				
+
 				const material = new THREE.SpriteNodeMaterial();
 				material.colorNode = uv().mul( colors.element( instanceIndex ) );
 				material.positionNode = positions.toAttribute();
 				material.scaleNode = size;
-				material.alphaTestNode = uv().mul( 2 ).distance( vec2( 1 ) );
-				material.transparent = false;
+				material.opacityNode = shapeCircle();
+				material.alphaToCoverage = true;
+				material.transparent = true;
 
 				const particles = new THREE.Sprite( material );
 				particles.count = particleCount;

--- a/src/materials/nodes/NodeMaterial.js
+++ b/src/materials/nodes/NodeMaterial.js
@@ -782,7 +782,7 @@ class NodeMaterial extends Material {
 
 		}
 
-		// Instanced colors
+		// INSTANCED COLORS
 
 		if ( object.instanceColor ) {
 
@@ -800,7 +800,6 @@ class NodeMaterial extends Material {
 
 		}
 
-
 		// COLOR
 
 		diffuseColor.assign( colorNode );
@@ -812,13 +811,19 @@ class NodeMaterial extends Material {
 
 		// ALPHA TEST
 
+		let alphaTestNode;
+
 		if ( this.alphaTestNode !== null || this.alphaTest > 0 ) {
 
-			const alphaTestNode = this.alphaTestNode !== null ? float( this.alphaTestNode ) : materialAlphaTest;
+			alphaTestNode = this.alphaTestNode !== null ? float( this.alphaTestNode ) : materialAlphaTest;
 
-			diffuseColor.a.lessThanEqual( alphaTestNode ).discard();
+		} else {
+
+			alphaTestNode = float( 0 );
 
 		}
+
+		diffuseColor.a.lessThanEqual( alphaTestNode ).discard();
 
 		// ALPHA HASH
 

--- a/src/materials/nodes/NodeMaterial.js
+++ b/src/materials/nodes/NodeMaterial.js
@@ -13,7 +13,7 @@ import { positionLocal, positionView } from '../../nodes/accessors/Position.js';
 import { skinning } from '../../nodes/accessors/SkinningNode.js';
 import { morphReference } from '../../nodes/accessors/MorphNode.js';
 import { mix } from '../../nodes/math/MathNode.js';
-import { float, vec3, vec4 } from '../../nodes/tsl/TSLBase.js';
+import { float, vec3, vec4, bool } from '../../nodes/tsl/TSLBase.js';
 import AONode from '../../nodes/lighting/AONode.js';
 import { lightingContext } from '../../nodes/lighting/LightingContextNode.js';
 import IrradianceNode from '../../nodes/lighting/IrradianceNode.js';
@@ -228,6 +228,15 @@ class NodeMaterial extends Material {
 		 * @default null
 		 */
 		this.alphaTestNode = null;
+
+
+		/**
+		 * Discards the fragment if the mask value is `false`.
+		 *
+		 * @type {?Node<bool>}
+		 * @default null
+		 */
+		this.maskNode = null;
 
 		/**
 		 * The local vertex positions are computed based on multiple factors like the
@@ -774,6 +783,14 @@ class NodeMaterial extends Material {
 
 		let colorNode = this.colorNode ? vec4( this.colorNode ) : materialColor;
 
+		// MASK
+
+		if ( this.maskNode !== null ) {
+
+			bool( this.maskNode ).discard();
+
+		}
+
 		// VERTEX COLORS
 
 		if ( this.vertexColors === true && geometry.hasAttribute( 'color' ) ) {
@@ -1194,6 +1211,7 @@ class NodeMaterial extends Material {
 		this.backdropNode = source.backdropNode;
 		this.backdropAlphaNode = source.backdropAlphaNode;
 		this.alphaTestNode = source.alphaTestNode;
+		this.maskNode = source.maskNode;
 
 		this.positionNode = source.positionNode;
 		this.geometryNode = source.geometryNode;

--- a/src/nodes/shapes/Shapes.js
+++ b/src/nodes/shapes/Shapes.js
@@ -1,4 +1,4 @@
-import { Fn, float } from '../tsl/TSLBase.js';
+import { Fn, float, select } from '../tsl/TSLBase.js';
 import { lengthSq, smoothstep } from '../math/MathNode.js';
 import { uv } from '../accessors/UV.js';
 
@@ -12,18 +12,19 @@ import { uv } from '../accessors/UV.js';
  */
 export const shapeCircle = Fn( ( [ coord = uv() ], { renderer, material } ) => {
 
-	const alpha = float( 1 ).toVar();
 	const len2 = lengthSq( coord.mul( 2 ).sub( 1 ) );
+
+	let alpha;
 
 	if ( material.alphaToCoverage && renderer.samples > 1 ) {
 
 		const dlen = float( len2.fwidth() ).toVar();
 
-		alpha.assign( smoothstep( dlen.oneMinus(), dlen.add( 1 ), len2 ).oneMinus() );
+		alpha = smoothstep( dlen.oneMinus(), dlen.add( 1 ), len2 ).oneMinus();
 
 	} else {
 
-		len2.greaterThan( 1.0 ).discard();
+		alpha = select( len2.greaterThan( 1.0 ), 0, 1 );
 
 	}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/31092

**Description**

Introduce `.maskNode` as was done in the old NodeMaterial, this simplifies the use of `alphaTest` for procedural purposes since `alphaTestNode` needs to deal with the current opacity.

- [Introduce `.maskNode`](https://github.com/mrdoob/three.js/commit/567e6de6b319a825dba47f3f4d8220c5dec34541)
- [always check `.alphaTest` but optimize uniform to constant if necessary](https://github.com/mrdoob/three.js/commit/b517b9ce13b07bde0485f0013209c95f854daa82)
- [improve `shapeCircle()`](https://github.com/mrdoob/three.js/commit/2054e99153547269c40453aab1e57054a8069c16)
- [webgpu_compute_particles: use shapeCirle()](https://github.com/mrdoob/three.js/commit/7d880b2874150f10f118f35344f523a4aa47b6c0)