### PR TITLE
NodeMaterial: Execute `setupVertex()` if `vertexNode` is defined

### DIFF
--- a/src/materials/nodes/NodeMaterial.js
+++ b/src/materials/nodes/NodeMaterial.js
@@ -455,7 +455,9 @@ class NodeMaterial extends Material {
 
 		builder.addStack();
 
-		const vertexNode = this.vertexNode || this.setupVertex( builder );
+		const mvp = this.setupVertex( builder );
+
+		const vertexNode = this.vertexNode || mvp;
 
 		builder.stack.outputNode = vertexNode;
 


### PR DESCRIPTION
Fixes https://github.com/mrdoob/three.js/issues/31131

**Description**

Execute `setupVertex()` if `vertexNode` is defined which can be useful to reuse the vertex transformation by modifying the MVP.