### PR TITLE
`StorageBufferNode`: Add `getMemberType`

### DIFF
--- a/src/nodes/accessors/StorageBufferNode.js
+++ b/src/nodes/accessors/StorageBufferNode.js
@@ -336,6 +336,25 @@ class StorageBufferNode extends BufferNode {
 	}
 
 	/**
+	 * Returns the type of a member of the struct.
+	 *
+	 * @param {NodeBuilder} builder - The current node builder.
+	 * @param {string} name - The name of the member.
+	 * @return {string} The type of the member.
+	 */
+	getMemberType( builder, name ) {
+
+		if ( this.structTypeNode !== null ) {
+
+			return this.structTypeNode.getMemberType( builder, name );
+
+		}
+
+		return 'void';
+
+	}
+
+	/**
 	 * Generates the code snippet of the storage buffer node.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.


### PR DESCRIPTION
Fixes: #31100

**Description**

Preiviously, trying to get the member type of a sturct `StorageBufferNode` will fallback to the dedault `void`.

This PR adds getMemberType method to `StorageBufferNode` to correctly retrieve member type.