### PR TITLE
LineMaterial: Fix clipping planes.

### DIFF
--- a/examples/jsm/lines/LineMaterial.js
+++ b/examples/jsm/lines/LineMaterial.js
@@ -311,6 +311,9 @@ ShaderLib[ 'line' ] = {
 
 		void main() {
 
+			float alpha = opacity;
+			vec4 diffuseColor = vec4( diffuse, alpha );
+
 			#include <clipping_planes_fragment>
 
 			#ifdef USE_DASH
@@ -320,8 +323,6 @@ ShaderLib[ 'line' ] = {
 				if ( mod( vLineDistance + dashOffset, dashSize + gapSize ) > dashSize ) discard; // todo - FIX
 
 			#endif
-
-			float alpha = opacity;
 
 			#ifdef WORLD_UNITS
 
@@ -386,8 +387,6 @@ ShaderLib[ 'line' ] = {
 				#endif
 
 			#endif
-
-			vec4 diffuseColor = vec4( diffuse, alpha );
 
 			#include <logdepthbuf_fragment>
 			#include <color_fragment>


### PR DESCRIPTION
When using clippingPlanes over Line2 geometries, the shader does not compile since some variables are trying to be used before they are declared.

For other shaders, a similar change was made on https://github.com/mrdoob/three.js/pull/22172/files

