### PR TITLE
TSL: Ensure 4 byte alignment for `instancedArray()` and `attributeArray()`

### DIFF
--- a/src/extras/DataUtils.js
+++ b/src/extras/DataUtils.js
@@ -207,6 +207,23 @@ class DataUtils {
 
 	}
 
+	/**
+	 * Aligns a given byte length to the nearest 4-byte boundary.
+	 *
+	 * This function ensures that the returned byte length is a multiple of 4,
+	 * which is often required for memory alignment in certain systems or formats.
+	 *
+	 * @param {number} byteLength - The original byte length to align.
+	 * @returns {number} The aligned byte length, which is a multiple of 4.
+	 */
+	static alignTo4ByteBoundary( byteLength ) {
+
+		// ensure 4 byte alignment, see #20441
+
+		return byteLength + ( ( 4 - ( byteLength % 4 ) ) % 4 );
+
+	}
+
 }
 
 export {

--- a/src/nodes/accessors/Arrays.js
+++ b/src/nodes/accessors/Arrays.js
@@ -19,7 +19,7 @@ export const attributeArray = ( count, type = 'float' ) => {
 
 	if ( type.isStruct === true ) {
 
-		itemSize = type.layout.getLength();
+		itemSize = DataUtils.alignTo4ByteBoundary( type.layout.getLength() );
 		typedArray = getTypedArrayFromType( 'float' );
 
 	} else {
@@ -29,9 +29,7 @@ export const attributeArray = ( count, type = 'float' ) => {
 
 	}
 
-	const alignmentItemSize = DataUtils.alignTo4ByteBoundary( itemSize );
-
-	const buffer = new StorageBufferAttribute( count, alignmentItemSize, typedArray );
+	const buffer = new StorageBufferAttribute( count, itemSize, typedArray );
 	const node = storage( buffer, type, count );
 
 	return node;
@@ -53,7 +51,7 @@ export const instancedArray = ( count, type = 'float' ) => {
 
 	if ( type.isStruct === true ) {
 
-		itemSize = type.layout.getLength();
+		itemSize = DataUtils.alignTo4ByteBoundary( type.layout.getLength() );
 		typedArray = getTypedArrayFromType( 'float' );
 
 	} else {
@@ -63,9 +61,7 @@ export const instancedArray = ( count, type = 'float' ) => {
 
 	}
 
-	const alignmentItemSize = DataUtils.alignTo4ByteBoundary( itemSize );
-
-	const buffer = new StorageInstancedBufferAttribute( count, alignmentItemSize, typedArray );
+	const buffer = new StorageInstancedBufferAttribute( count, itemSize, typedArray );
 	const node = storage( buffer, type, count );
 
 	return node;

--- a/src/nodes/accessors/Arrays.js
+++ b/src/nodes/accessors/Arrays.js
@@ -2,6 +2,7 @@ import StorageInstancedBufferAttribute from '../../renderers/common/StorageInsta
 import StorageBufferAttribute from '../../renderers/common/StorageBufferAttribute.js';
 import { storage } from './StorageBufferNode.js';
 import { getLengthFromType, getTypedArrayFromType } from '../core/NodeUtils.js';
+import { DataUtils } from '../../extras/DataUtils.js';
 
 /**
  * TSL function for creating a storage buffer node with a configured `StorageBufferAttribute`.
@@ -28,7 +29,9 @@ export const attributeArray = ( count, type = 'float' ) => {
 
 	}
 
-	const buffer = new StorageBufferAttribute( count, itemSize, typedArray );
+	const alignmentItemSize = DataUtils.alignTo4ByteBoundary( itemSize );
+
+	const buffer = new StorageBufferAttribute( count, alignmentItemSize, typedArray );
 	const node = storage( buffer, type, count );
 
 	return node;
@@ -60,7 +63,9 @@ export const instancedArray = ( count, type = 'float' ) => {
 
 	}
 
-	const buffer = new StorageInstancedBufferAttribute( count, itemSize, typedArray );
+	const alignmentItemSize = DataUtils.alignTo4ByteBoundary( itemSize );
+
+	const buffer = new StorageInstancedBufferAttribute( count, alignmentItemSize, typedArray );
 	const node = storage( buffer, type, count );
 
 	return node;

--- a/src/renderers/webgpu/utils/WebGPUAttributeUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUAttributeUtils.js
@@ -1,6 +1,7 @@
 import { GPUInputStepMode } from './WebGPUConstants.js';
 
 import { Float16BufferAttribute } from '../../../core/BufferAttribute.js';
+import { DataUtils } from '../../../extras/DataUtils.js';
 
 const typedArraysToVertexFormatPrefix = new Map( [
 	[ Int8Array, [ 'sint8', 'snorm8' ]],
@@ -113,7 +114,7 @@ class WebGPUAttributeUtils {
 
 			}
 
-			const size = array.byteLength + ( ( 4 - ( array.byteLength % 4 ) ) % 4 ); // ensure 4 byte alignment, see #20441
+			const size = DataUtils.alignTo4ByteBoundary( array.byteLength );
 
 			buffer = device.createBuffer( {
 				label: bufferAttribute.name,


### PR DESCRIPTION
Fixes https://github.com/mrdoob/three.js/issues/30983

**Description**

Ensure 4 byte alignment for `instancedArray()` and `attributeArray()`.

Example:

```js
const testStruct = struct( {
	a: 'vec3',
	b: 'vec3'
} );

const outputBuffer = instancedArray( 2, testStruct ); // return 8 lengths instead of 6
```