### PR TITLE
LDrawLoader: Don't clear already-loaded materials onload.

### DIFF
--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -1907,7 +1907,7 @@ class LDrawLoader extends Loader {
 		fileLoader.load( url, text => {
 
 			// Initializes the materials library with default materials
-			this.addMaterials( [] );
+			this.addDefaultMaterials();
 
 			this.partsCache
 				.parseModel( text )
@@ -1973,6 +1973,12 @@ class LDrawLoader extends Loader {
 			this.addMaterial( materials[ i ] );
 
 		}
+
+		return this;
+
+	}
+
+	addDefaultMaterials() {
 
 		// Add default main triangle and line edge materials (used in pieces that can be colored with a main color)
 		this.addMaterial( this.parseColorMetaDirective( new LineParser( 'Main_Colour CODE 16 VALUE #FF8080 EDGE #333333' ) ) );

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -1885,7 +1885,7 @@ class LDrawLoader extends Loader {
 
 		}
 
-		this.setMaterials( materials );
+		this.addMaterials( materials );
 
 	}
 
@@ -1907,7 +1907,7 @@ class LDrawLoader extends Loader {
 		fileLoader.load( url, text => {
 
 			// Initializes the materials library with default materials
-			this.setMaterials( [] );
+			this.addMaterials( [] );
 
 			this.partsCache
 				.parseModel( text )
@@ -1950,8 +1950,24 @@ class LDrawLoader extends Loader {
 
 	setMaterials( materials ) {
 
+		this.clearMaterials();
+		this.addMaterials(materials);
+
+		return this;
+
+	}
+
+	clearMaterials() {
+
 		this.materialLibrary = {};
 		this.materials = [];
+
+		return this;
+
+	}
+
+	addMaterials( materials ) {
+
 		for ( let i = 0, l = materials.length; i < l; i ++ ) {
 
 			this.addMaterial( materials[ i ] );


### PR DESCRIPTION
Fixed #31149

LDraw materials that had been preloaded were being discarded by the load() method. Following suggestions by @Mugen87, this PR:

* renames `setMaterials` to `addMaterials`, and removes the reset of the material arrays.
* adds `clearMaterials` to explicitly clear the material arrays.
* re-adds `setMaterials` which calls clear then add, to reproduce the old behaviour and API.