### PR TITLE
TSL: Ensure memory alignment for `struct()`

### DIFF
--- a/src/extras/DataUtils.js
+++ b/src/extras/DataUtils.js
@@ -160,25 +160,6 @@ function toHalfFloat( val ) {
 }
 
 /**
- * Aligns a given byte length to the specified boundary alignment.
- *
- * Ensures that the resulting byte length is a multiple of the alignment value.
- * This is useful for maintaining proper memory alignment, which can be critical
- * for performance and compatibility in certain systems.
- *
- * @param {number} byteLength - The original byte length to align.
- * @param {number} [alignment=4] - The boundary alignment value.
- * @returns {number} The aligned byte length.
- */
-function alignToBoundary( byteLength, alignment ) {
-
-	// ensure byte alignment, see #20441
-
-	return byteLength + ( ( alignment - ( byteLength % alignment ) ) % alignment );
-
-}
-
-/**
  * Returns a single precision floating point value (FP32) from the given half
  * precision floating point value (FP16).
  *
@@ -226,28 +207,10 @@ class DataUtils {
 
 	}
 
-	/**
-	 * Aligns a given byte length to the specified boundary alignment.
-	 *
-	 * Ensures that the resulting byte length is a multiple of the alignment value.
-	 * This is useful for maintaining proper memory alignment, which can be critical
-	 * for performance and compatibility in certain systems.
-	 *
-	 * @param {number} byteLength - The original byte length to align.
-	 * @param {number} [alignment=4] - The boundary alignment value.
-	 * @returns {number} The aligned byte length.
-	 */
-	static alignToBoundary( byteLength, alignment ) {
-
-		return alignToBoundary( byteLength, alignment );
-
-	}
-
 }
 
 export {
 	toHalfFloat,
 	fromHalfFloat,
-	alignToBoundary,
 	DataUtils
 };

--- a/src/extras/DataUtils.js
+++ b/src/extras/DataUtils.js
@@ -160,6 +160,25 @@ function toHalfFloat( val ) {
 }
 
 /**
+ * Aligns a given byte length to the specified boundary alignment.
+ *
+ * Ensures that the resulting byte length is a multiple of the alignment value.
+ * This is useful for maintaining proper memory alignment, which can be critical
+ * for performance and compatibility in certain systems.
+ *
+ * @param {number} byteLength - The original byte length to align.
+ * @param {number} [alignment=4] - The boundary alignment value. Defaults to 4.
+ * @returns {number} The aligned byte length.
+ */
+function alignToBoundary( byteLength, alignment = 4 ) {
+
+	// ensure 4 byte alignment, see #20441
+
+	return byteLength + ( ( alignment - ( byteLength % alignment ) ) % alignment );
+
+}
+
+/**
  * Returns a single precision floating point value (FP32) from the given half
  * precision floating point value (FP16).
  *
@@ -208,19 +227,19 @@ class DataUtils {
 	}
 
 	/**
-	 * Aligns a given byte length to the nearest 4-byte boundary.
+	 * Aligns a given byte length to the specified boundary alignment.
 	 *
-	 * This function ensures that the returned byte length is a multiple of 4,
-	 * which is often required for memory alignment in certain systems or formats.
+	 * Ensures that the resulting byte length is a multiple of the alignment value.
+	 * This is useful for maintaining proper memory alignment, which can be critical
+	 * for performance and compatibility in certain systems.
 	 *
 	 * @param {number} byteLength - The original byte length to align.
-	 * @returns {number} The aligned byte length, which is a multiple of 4.
+	 * @param {number} [alignment=4] - The boundary alignment value. Defaults to 4.
+	 * @returns {number} The aligned byte length.
 	 */
-	static alignTo4ByteBoundary( byteLength ) {
+	static alignToBoundary( byteLength, alignment = 4 ) {
 
-		// ensure 4 byte alignment, see #20441
-
-		return byteLength + ( ( 4 - ( byteLength % 4 ) ) % 4 );
+		return alignToBoundary( byteLength, alignment );
 
 	}
 
@@ -229,5 +248,6 @@ class DataUtils {
 export {
 	toHalfFloat,
 	fromHalfFloat,
+	alignToBoundary,
 	DataUtils
 };

--- a/src/extras/DataUtils.js
+++ b/src/extras/DataUtils.js
@@ -167,12 +167,12 @@ function toHalfFloat( val ) {
  * for performance and compatibility in certain systems.
  *
  * @param {number} byteLength - The original byte length to align.
- * @param {number} [alignment=4] - The boundary alignment value. Defaults to 4.
+ * @param {number} [alignment=4] - The boundary alignment value.
  * @returns {number} The aligned byte length.
  */
-function alignToBoundary( byteLength, alignment = 4 ) {
+function alignToBoundary( byteLength, alignment ) {
 
-	// ensure 4 byte alignment, see #20441
+	// ensure byte alignment, see #20441
 
 	return byteLength + ( ( alignment - ( byteLength % alignment ) ) % alignment );
 
@@ -234,10 +234,10 @@ class DataUtils {
 	 * for performance and compatibility in certain systems.
 	 *
 	 * @param {number} byteLength - The original byte length to align.
-	 * @param {number} [alignment=4] - The boundary alignment value. Defaults to 4.
+	 * @param {number} [alignment=4] - The boundary alignment value.
 	 * @returns {number} The aligned byte length.
 	 */
-	static alignToBoundary( byteLength, alignment = 4 ) {
+	static alignToBoundary( byteLength, alignment ) {
 
 		return alignToBoundary( byteLength, alignment );
 

--- a/src/nodes/accessors/Arrays.js
+++ b/src/nodes/accessors/Arrays.js
@@ -2,7 +2,6 @@ import StorageInstancedBufferAttribute from '../../renderers/common/StorageInsta
 import StorageBufferAttribute from '../../renderers/common/StorageBufferAttribute.js';
 import { storage } from './StorageBufferNode.js';
 import { getLengthFromType, getTypedArrayFromType } from '../core/NodeUtils.js';
-import { DataUtils } from '../../extras/DataUtils.js';
 
 /**
  * TSL function for creating a storage buffer node with a configured `StorageBufferAttribute`.
@@ -19,7 +18,7 @@ export const attributeArray = ( count, type = 'float' ) => {
 
 	if ( type.isStruct === true ) {
 
-		itemSize = DataUtils.alignTo4ByteBoundary( type.layout.getLength() );
+		itemSize = type.layout.getLength()
 		typedArray = getTypedArrayFromType( 'float' );
 
 	} else {
@@ -51,7 +50,7 @@ export const instancedArray = ( count, type = 'float' ) => {
 
 	if ( type.isStruct === true ) {
 
-		itemSize = DataUtils.alignTo4ByteBoundary( type.layout.getLength() );
+		itemSize = type.layout.getLength();
 		typedArray = getTypedArrayFromType( 'float' );
 
 	} else {

--- a/src/nodes/accessors/Arrays.js
+++ b/src/nodes/accessors/Arrays.js
@@ -18,7 +18,7 @@ export const attributeArray = ( count, type = 'float' ) => {
 
 	if ( type.isStruct === true ) {
 
-		itemSize = type.layout.getLength()
+		itemSize = type.layout.getLength();
 		typedArray = getTypedArrayFromType( 'float' );
 
 	} else {

--- a/src/nodes/core/NodeUtils.js
+++ b/src/nodes/core/NodeUtils.js
@@ -237,6 +237,27 @@ export function getLengthFromType( type ) {
 }
 
 /**
+ * Returns the gpu memory length for the given data type.
+ *
+ * @method
+ * @param {string} type - The data type.
+ * @return {number} The length.
+ */
+export function getMemoryLengthFromType( type ) {
+
+	if ( /float|int|uint/.test( type ) ) return 1;
+	if ( /vec2/.test( type ) ) return 2;
+	if ( /vec3/.test( type ) ) return 3;
+	if ( /vec4/.test( type ) ) return 4;
+	if ( /mat2/.test( type ) ) return 4;
+	if ( /mat3/.test( type ) ) return 12;
+	if ( /mat4/.test( type ) ) return 16;
+
+	console.error( 'THREE.TSL: Unsupported type:', type );
+
+}
+
+/**
  * Returns the byte boundary for the given data type.
  *
  * @method

--- a/src/nodes/core/NodeUtils.js
+++ b/src/nodes/core/NodeUtils.js
@@ -237,6 +237,27 @@ export function getLengthFromType( type ) {
 }
 
 /**
+ * Returns the byte boundary for the given data type.
+ *
+ * @method
+ * @param {string} type - The data type.
+ * @return {number} The byte boundary.
+ */
+export function getByteBoundaryFromType( type ) {
+
+	if ( /float|int|uint/.test( type ) ) return 4;
+	if ( /vec2/.test( type ) ) return 8;
+	if ( /vec3/.test( type ) ) return 16;
+	if ( /vec4/.test( type ) ) return 16;
+	if ( /mat2/.test( type ) ) return 16;
+	if ( /mat3/.test( type ) ) return 48;
+	if ( /mat4/.test( type ) ) return 64;
+
+	console.error( 'THREE.TSL: Unsupported type:', type );
+
+}
+
+/**
  * Returns the data type for the given value.
  *
  * @method

--- a/src/nodes/core/StructTypeNode.js
+++ b/src/nodes/core/StructTypeNode.js
@@ -96,9 +96,9 @@ class StructTypeNode extends Node {
 			const type = member.type;
 
 			const itemSize = getMemoryLengthFromType( type ) * Float32Array.BYTES_PER_ELEMENT;
-			const alignment = getByteBoundaryFromType( type );
+			const boundary = getByteBoundaryFromType( type );
 
-			offset = alignTo( offset, alignment ) + itemSize;
+			offset = alignTo( offset, boundary ) + itemSize;
 
 		}
 

--- a/src/nodes/core/StructTypeNode.js
+++ b/src/nodes/core/StructTypeNode.js
@@ -1,7 +1,7 @@
 
-import { alignToBoundary } from '../../extras/DataUtils.js';
 import Node from './Node.js';
 import { getLengthFromType } from './NodeUtils.js';
+import { alignToBoundary } from '../../extras/DataUtils.js';
 
 /**
  * Generates a layout for struct members.

--- a/src/nodes/core/StructTypeNode.js
+++ b/src/nodes/core/StructTypeNode.js
@@ -1,4 +1,5 @@
 
+import { alignToBoundary } from '../../extras/DataUtils.js';
 import Node from './Node.js';
 import { getLengthFromType } from './NodeUtils.js';
 
@@ -90,7 +91,9 @@ class StructTypeNode extends Node {
 
 		for ( const member of this.membersLayout ) {
 
-			length += getLengthFromType( member.type );
+			// Align to byte boundary for struct types to ensure proper memory alignment.
+
+			length += alignToBoundary( getLengthFromType( member.type ) );
 
 		}
 

--- a/src/nodes/core/StructTypeNode.js
+++ b/src/nodes/core/StructTypeNode.js
@@ -1,6 +1,6 @@
 
 import Node from './Node.js';
-import { getByteBoundaryFromType, getLengthFromType } from './NodeUtils.js';
+import { getByteBoundaryFromType, getMemoryLengthFromType } from './NodeUtils.js';
 import { GPU_CHUNK_BYTES } from '../../renderers/common/Constants.js';
 
 /**
@@ -93,7 +93,7 @@ class StructTypeNode extends Node {
 
 			const type = member.type;
 
-			const itemSize = getLengthFromType( type );
+			const itemSize = getMemoryLengthFromType( type );
 			const boundary = getByteBoundaryFromType( type );
 
 			// offset within a single chunk in bytes

--- a/src/renderers/webgpu/utils/WebGPUAttributeUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUAttributeUtils.js
@@ -1,7 +1,7 @@
 import { GPUInputStepMode } from './WebGPUConstants.js';
 
 import { Float16BufferAttribute } from '../../../core/BufferAttribute.js';
-import { DataUtils } from '../../../extras/DataUtils.js';
+import { alignToBoundary } from '../../../extras/DataUtils.js';
 
 const typedArraysToVertexFormatPrefix = new Map( [
 	[ Int8Array, [ 'sint8', 'snorm8' ]],
@@ -114,7 +114,8 @@ class WebGPUAttributeUtils {
 
 			}
 
-			const size = DataUtils.alignTo4ByteBoundary( array.byteLength );
+			// ensure 4 byte alignment
+			const size = alignToBoundary( array.byteLength );
 
 			buffer = device.createBuffer( {
 				label: bufferAttribute.name,

--- a/src/renderers/webgpu/utils/WebGPUAttributeUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUAttributeUtils.js
@@ -115,7 +115,7 @@ class WebGPUAttributeUtils {
 			}
 
 			// ensure 4 byte alignment
-			const size = alignToBoundary( array.byteLength );
+			const size = alignToBoundary( array.byteLength, 4 );
 
 			buffer = device.createBuffer( {
 				label: bufferAttribute.name,

--- a/src/renderers/webgpu/utils/WebGPUAttributeUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUAttributeUtils.js
@@ -1,7 +1,6 @@
 import { GPUInputStepMode } from './WebGPUConstants.js';
 
 import { Float16BufferAttribute } from '../../../core/BufferAttribute.js';
-import { alignToBoundary } from '../../../extras/DataUtils.js';
 
 const typedArraysToVertexFormatPrefix = new Map( [
 	[ Int8Array, [ 'sint8', 'snorm8' ]],
@@ -115,7 +114,8 @@ class WebGPUAttributeUtils {
 			}
 
 			// ensure 4 byte alignment
-			const size = alignToBoundary( array.byteLength, 4 );
+			const byteLength = array.byteLength;
+			const size = byteLength + ( ( 4 - ( byteLength % 4 ) ) % 4 );
 
 			buffer = device.createBuffer( {
 				label: bufferAttribute.name,


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/31146, https://github.com/mrdoob/three.js/issues/30983#issuecomment-2902351331

**Description**

Ensure memory alignment for `struct()`. adds more robust verification.

/cc @holtsetio 