### PR TITLE
Added in BufferGeometry documentation the referential of Rotation

### DIFF
--- a/docs/api/en/core/BufferGeometry.html
+++ b/docs/api/en/core/BufferGeometry.html
@@ -297,6 +297,8 @@
 			Rotate the geometry about the X axis. This is typically done as a one time
 			operation, and not during a loop. Use [page:Object3D.rotation] for typical
 			real-time mesh rotation.
+
+			Rotates the object around x axis in world space.
 		</p>
 
 		<h3>[method:this rotateY] ( [param:Float radians] )</h3>
@@ -304,6 +306,8 @@
 			Rotate the geometry about the Y axis. This is typically done as a one time
 			operation, and not during a loop. Use [page:Object3D.rotation] for typical
 			real-time mesh rotation.
+
+			Rotates the object around y axis in world space.
 		</p>
 
 		<h3>[method:this rotateZ] ( [param:Float radians] )</h3>
@@ -311,6 +315,8 @@
 			Rotate the geometry about the Z axis. This is typically done as a one time
 			operation, and not during a loop. Use [page:Object3D.rotation] for typical
 			real-time mesh rotation.
+
+			Rotates the object around z axis in world space.
 		</p>
 
 		<h3>[method:this scale] ( [param:Float x], [param:Float y], [param:Float z] )</h3>


### PR DESCRIPTION
**Description**

So there was a inconsistency between the BufferGeometry and Object3D documentation in the rotation part.
In the Object3D it said the referential that the rotation was being made.
In the BufferGeometry didn't say the referential and it redirected to Object3D.rotation that was being made in a different referential and that could induce someone in error.
So I added in the BufferGeometry a line to say the referential that the rotation was being made.
