### PR TITLE
Remove ambient occlusion from webgpu_compute_particles_fluid example

### DIFF
--- a/examples/webgpu_compute_particles_fluid.html
+++ b/examples/webgpu_compute_particles_fluid.html
@@ -28,9 +28,8 @@
 
 			import * as THREE from 'three';
 
-			import { Fn, If, Return, instancedArray, instanceIndex, uniform, attribute, uint, float, clamp, struct, atomicStore, int, ivec3, array, vec3, atomicAdd, Loop, atomicLoad, max, pow, mat3, vec4, cross, step, pass, mrt, output, normalView } from 'three/tsl';
+			import { Fn, If, Return, instancedArray, instanceIndex, uniform, attribute, uint, float, clamp, struct, atomicStore, int, ivec3, array, vec3, atomicAdd, Loop, atomicLoad, max, pow, mat3, vec4, cross, step } from 'three/tsl';
 
-			import { ao } from 'three/addons/tsl/display/GTAONode.js';
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { RGBELoader } from 'three/addons/loaders/RGBELoader.js';
@@ -53,7 +52,6 @@
 			const mouseCoord = new THREE.Vector3();
 			const prevMouseCoord = new THREE.Vector3();
 			let mouseRayOriginUniform, mouseRayDirectionUniform, mouseForceUniform;
-			let postProcessing, aoPass, blendPassAO, scenePassColor;
 
 			if ( WebGPU.isAvailable() === false ) {
 
@@ -66,7 +64,6 @@
 
 			const params = {
 				particleCount: 8192 * 4,
-				ambientOcclusion: true,
 			};
 
 			init();
@@ -114,23 +111,6 @@
 					particleCountUniform.value = value;
 
 				} );
-
-				gui.add( params, 'ambientOcclusion' );
-
-				// setting up post processing for ambient occlusion
-				postProcessing = new THREE.PostProcessing( renderer );
-				const scenePass = pass( scene, camera );
-				scenePass.setMRT( mrt( {
-					output: output,
-					normal: normalView
-				} ) );
-				scenePassColor = scenePass.getTextureNode( 'output' );
-				const scenePassNormal = scenePass.getTextureNode( 'normal' );
-				const scenePassDepth = scenePass.getTextureNode( 'depth' );
-				aoPass = ao( scenePassDepth, scenePassNormal, camera );
-				aoPass.resolutionScale = 0.5;
-				blendPassAO = aoPass.getTextureNode().mul( scenePassColor );
-				postProcessing.outputNode = blendPassAO;
 
 				window.addEventListener( 'resize', onWindowResize );
 				controls.update();
@@ -579,15 +559,7 @@
 
 				await renderer.computeAsync( [ clearGridKernel, p2g1Kernel, p2g2Kernel, updateGridKernel, g2pKernel ] );
 
-				if ( params.ambientOcclusion ) {
-
-					await postProcessing.renderAsync();
-			
-				} else {
-
-					await renderer.renderAsync( scene, camera );
-			
-				}
+				await renderer.renderAsync( scene, camera );
 
 			}
 


### PR DESCRIPTION
**Description**

As per comments in #31148, remove ambient occlusion post processing from webgpu_compute_particles_fluid example for performance reasons