### PR TITLE
HTMLMesh: Add support for input of type text and number in VR

### DIFF
--- a/examples/jsm/interactive/HTMLMesh.js
+++ b/examples/jsm/interactive/HTMLMesh.js
@@ -578,6 +578,12 @@ function htmlevent( element, event, x, y ) {
 
 				}
 
+				if ( element instanceof HTMLInputElement && ( element.type === 'text' || element.type === 'number' ) && ( event === 'mousedown' || event === 'click' ) ) {
+
+					element.focus();
+
+				}
+
 			}
 
 			for ( let i = 0; i < element.childNodes.length; i ++ ) {


### PR DESCRIPTION
**Description**

Add support for input of type text and number, calling `input.focus()` to bring the system keyboard in VR.
See https://latest.developers.meta.com/horizon/documentation/web/webxr-keyboard/
Note that on Meta browser 38.4 for input of type number it brings the wrong keyboard in an immersive session, while it brings the correct numeric keyboard when you're not in a immersive session. I reported it pressing 5 times the meta button.

I did the PR initially in https://github.com/AdaRoseCannon/aframe-htmlmesh/pull/25 that also includes an example.

