### PR TITLE
TSL: Fix `mat2` boundary size

### DIFF
--- a/src/nodes/core/NodeUtils.js
+++ b/src/nodes/core/NodeUtils.js
@@ -270,7 +270,7 @@ export function getByteBoundaryFromType( type ) {
 	if ( /vec2/.test( type ) ) return 8;
 	if ( /vec3/.test( type ) ) return 16;
 	if ( /vec4/.test( type ) ) return 16;
-	if ( /mat2/.test( type ) ) return 16;
+	if ( /mat2/.test( type ) ) return 8;
 	if ( /mat3/.test( type ) ) return 48;
 	if ( /mat4/.test( type ) ) return 64;
 

--- a/src/nodes/core/StructTypeNode.js
+++ b/src/nodes/core/StructTypeNode.js
@@ -1,7 +1,6 @@
 
 import Node from './Node.js';
 import { getByteBoundaryFromType, getMemoryLengthFromType } from './NodeUtils.js';
-import { GPU_CHUNK_BYTES } from '../../renderers/common/Constants.js';
 
 /**
  * Generates a layout for struct members.
@@ -87,13 +86,16 @@ class StructTypeNode extends Node {
 	 */
 	getLength() {
 
+		const GPU_CHUNK_BYTES = 8;
+		const BYTES_PER_ELEMENT = Float32Array.BYTES_PER_ELEMENT;
+
 		let offset = 0; // global buffer offset in bytes
 
 		for ( const member of this.membersLayout ) {
 
 			const type = member.type;
 
-			const itemSize = getMemoryLengthFromType( type ) * Float32Array.BYTES_PER_ELEMENT;
+			const itemSize = getMemoryLengthFromType( type ) * BYTES_PER_ELEMENT;
 			const boundary = getByteBoundaryFromType( type );
 
 			const chunkOffset = offset % GPU_CHUNK_BYTES; // offset in the current chunk
@@ -114,7 +116,7 @@ class StructTypeNode extends Node {
 
 		}
 
-		return ( Math.ceil( offset / GPU_CHUNK_BYTES ) * GPU_CHUNK_BYTES ) / Float32Array.BYTES_PER_ELEMENT;
+		return ( Math.ceil( offset / GPU_CHUNK_BYTES ) * GPU_CHUNK_BYTES ) / BYTES_PER_ELEMENT;
 
 	}
 

--- a/src/renderers/common/Uniform.js
+++ b/src/renderers/common/Uniform.js
@@ -284,7 +284,7 @@ class Matrix2Uniform extends Uniform {
 		 */
 		this.isMatrix2Uniform = true;
 
-		this.boundary = 16;
+		this.boundary = 8;
 		this.itemSize = 4;
 
 	}


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/31151#issuecomment-2906771123

**Description**

Fix `mat2` boundary size.