### PR TITLE
WebGPUBackend: Fix `generateMipmaps` when used `copyFramebufferToTexture()`

### DIFF
--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -2394,6 +2394,12 @@ class WebGPUBackend extends Backend {
 
 		}
 
+		if ( texture.generateMipmaps ) {
+
+			this.textureUtils.generateMipmaps( texture );
+
+		}
+
 	}
 
 }


### PR DESCRIPTION
Fixes https://github.com/mrdoob/three.js/issues/31143

**Description**

`copyFramebufferToTexture()` is not generating mipmaps after copying even if the property `texture.generateMipmaps` is `true`.