### PR TITLE
NodeMaterial: Honor `material.premultipliedAlpha` in the shader

### DIFF
--- a/src/materials/nodes/NodeMaterial.js
+++ b/src/materials/nodes/NodeMaterial.js
@@ -1076,6 +1076,21 @@ class NodeMaterial extends Material {
 	}
 
 	/**
+	 * Setups premultiplied alpha.
+	 *
+	 * @param {NodeBuilder} builder - The current node builder.
+	 * @param {Node<vec4>} outputNode - The existing output node.
+	 * @return {Node<vec4>} The output node.
+	 */
+	setupPremultipliedAlpha( builder, outputNode ) {
+
+		outputNode = vec4( outputNode.rgb.mul( outputNode.a ), outputNode.a );
+
+		return outputNode;
+
+	}
+
+	/**
 	 * Setups the output node.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
@@ -1089,6 +1104,14 @@ class NodeMaterial extends Material {
 		if ( this.fog === true ) {
 
 			outputNode = this.setupFog( builder, outputNode );
+
+		}
+
+		// PREMULTIPLIED ALPHA
+
+		if ( this.premultipliedAlpha === true ) {
+
+			outputNode = this.setupPremultipliedAlpha( builder, outputNode );
 
 		}
 


### PR DESCRIPTION
As the title says.

The alternative is to only add this code block in the built-in (node) materials -- as we do with `WebGLRenderer's` built-in materials.