### PR TITLE
Examples: Fix memory leak in SVG demo.

### DIFF
--- a/examples/webgl_loader_svg.html
+++ b/examples/webgl_loader_svg.html
@@ -142,6 +142,10 @@
 
 				//
 
+				if ( scene ) disposeScene( scene );
+
+				//
+
 				scene = new THREE.Scene();
 				scene.background = new THREE.Color( 0xb0b0b0 );
 
@@ -247,6 +251,21 @@
 			function render() {
 
 				renderer.render( scene, camera );
+
+			}
+
+			function disposeScene( scene ) {
+
+				scene.traverse( function ( object ) {
+			
+					if ( object.isMesh || object.isLine ) {
+
+						object.geometry.dispose();
+						object.material.dispose();
+
+					}
+
+				} );
 
 			}
 


### PR DESCRIPTION
Fixed #31161.

**Description**

The PR makes sure GPU resources are properly released. 

Although only the geometry memory grows over time, it seems more consistent with other examples to dispose of the entire scene that is created by `loadSVG()`.
