### PR TITLE
CSMShadowNode: Fix toggle of `castShadow`.

### DIFF
--- a/examples/jsm/csm/CSMShadowNode.js
+++ b/examples/jsm/csm/CSMShadowNode.js
@@ -163,7 +163,6 @@ class CSMShadowNode extends ShadowBaseNode {
 		this.mainFrustum = new CSMFrustum( data );
 
 		const light = this.light;
-		const parent = light.parent;
 
 		for ( let i = 0; i < this.cascades; i ++ ) {
 
@@ -174,9 +173,6 @@ class CSMShadowNode extends ShadowBaseNode {
 			lShadow.bias = lShadow.bias * ( i + 1 );
 
 			this.lights.push( lwLight );
-
-			parent.add( lwLight );
-			parent.add( lwLight.target );
 
 			lwLight.shadow = lShadow;
 
@@ -503,8 +499,22 @@ class CSMShadowNode extends ShadowBaseNode {
 	updateBefore( /*builder*/ ) {
 
 		const light = this.light;
+		const parent = light.parent;
 		const camera = this.camera;
 		const frustums = this.frustums;
+
+		for ( let i = 0; i < this.lights.length; i ++ ) {
+
+			const lwLight = this.lights[ i ];
+
+			if ( lwLight.parent === null ) {
+
+				parent.add( lwLight.target );
+				parent.add( lwLight );
+
+			}
+
+		}
 
 		_lightDirection.subVectors( light.target.position, light.position ).normalize();
 

--- a/examples/jsm/csm/CSMShadowNode.js
+++ b/examples/jsm/csm/CSMShadowNode.js
@@ -503,6 +503,9 @@ class CSMShadowNode extends ShadowBaseNode {
 		const camera = this.camera;
 		const frustums = this.frustums;
 
+		// make sure the placeholder light objects which represent the
+		// multiple cascade shadow casters are part of the scene graph
+
 		for ( let i = 0; i < this.lights.length; i ++ ) {
 
 			const lwLight = this.lights[ i ];

--- a/examples/webgpu_shadowmap_csm.html
+++ b/examples/webgpu_shadowmap_csm.html
@@ -177,7 +177,7 @@
 
 				gui.add( params, 'shadows' ).onChange( function ( value ) {
 
-					renderer.shadowMap.enabled = value;
+					csmDirectionalLight.castShadow = value;
 
 				} );
 

--- a/src/nodes/lighting/ShadowBaseNode.js
+++ b/src/nodes/lighting/ShadowBaseNode.js
@@ -68,17 +68,6 @@ class ShadowBaseNode extends Node {
 
 	}
 
-	/**
-	 * Can be called when the shadow isn't required anymore. That can happen when
-	 * a lighting node stops casting shadows by setting {@link Object3D#castShadow}
-	 * to `false`.
-	 */
-	dispose() {
-
-		this.updateBeforeType = NodeUpdateType.NONE;
-
-	}
-
 }
 
 /**


### PR DESCRIPTION
Related issue: #31183

**Description**

It was not possible so far to toggle the `castShadow` property of directional lights using `CSMShadowNode`.

`AnalyticLightNode` calls `dispose()` on shadow nodes that are not used anymore. `CSMShadowNode` uses its `dispose()` method to remove additions to the scene graph to make cascading work. If the instance of `CSMShadowNode` is now used again (because `castShadow` is set back to `true`), the state must be restored. The PR is doing this in `updateBefore()`.

@sunag I have updated `ShadowBaseNode` by removing the `dispose()` method. Setting `updateBeforeType` to `NodeUpdateType.NONE` is an issue since when a shadow node is reused after a dispose, `updateBefore()` is never executed anymore. Because `updateBefore()` is not called when lights don't cast shadows, it seems better to not change `updateBeforeType` so shadow nodes don't have restore the update type on their own.