### PR TITLE
WebGPURenderer: Check if `OffscreenCanvas` is in window before accessing.

### DIFF
--- a/src/renderers/webgl-fallback/utils/WebGLTextureUtils.js
+++ b/src/renderers/webgl-fallback/utils/WebGLTextureUtils.js
@@ -506,7 +506,7 @@ class WebGLTextureUtils {
 			} else if ( ( typeof HTMLImageElement !== 'undefined' && source instanceof HTMLImageElement ) ||
 				( typeof HTMLCanvasElement !== 'undefined' && source instanceof HTMLCanvasElement ) ||
 				( typeof ImageBitmap !== 'undefined' && source instanceof ImageBitmap ) ||
-				source instanceof OffscreenCanvas ) {
+				( typeof OffscreenCanvas !== 'undefined' && source instanceof OffscreenCanvas ) ) {
 
 				return source;
 


### PR DESCRIPTION
**Description**

Three.js fails to run on some devices that don't have OffscreenCanvas support. This PR ensures that 'OffscreenCanvas' is always safely accessed.