### PR TITLE
XRManager: More fixes.

### DIFF
--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -1260,6 +1260,7 @@ class Renderer {
 		frameBufferTarget.scissorTest = this._scissorTest;
 		frameBufferTarget.multiview = outputRenderTarget !== null ? outputRenderTarget.multiview : false;
 		frameBufferTarget.resolveDepthBuffer = outputRenderTarget !== null ? outputRenderTarget.resolveDepthBuffer : true;
+		frameBufferTarget.autoAllocateDepthBuffer = outputRenderTarget !== null ? outputRenderTarget.autoAllocateDepthBuffer : false;
 
 		return frameBufferTarget;
 

--- a/src/renderers/common/XRManager.js
+++ b/src/renderers/common/XRManager.js
@@ -1021,7 +1021,7 @@ class XRManager extends EventDispatcher {
 				session.updateRenderState( { baseLayer: glBaseLayer } );
 
 				renderer.setPixelRatio( 1 );
-				renderer.setSize( glBaseLayer.framebufferWidth, glBaseLayer.framebufferHeight, false );
+				renderer._setXRLayerSize( glBaseLayer.framebufferWidth, glBaseLayer.framebufferHeight );
 
 				this._xrRenderTarget = new XRRenderTarget(
 					glBaseLayer.framebufferWidth,


### PR DESCRIPTION
Fixed #31193.

This fixes a couple of issues in the XR rendering:
- non-multiview rendering will now use multisampling
- webxr will render correctly in browsers that don't support layers (ie apple vision pro)
- resolve js error at end of the render pass for browsers that don't support layers