### PR TITLE
Ray: Handle empty spheres in `intersectsSphere()`.

### DIFF
--- a/src/math/Ray.js
+++ b/src/math/Ray.js
@@ -346,6 +346,8 @@ class Ray {
 	 */
 	intersectsSphere( sphere ) {
 
+		if ( sphere.radius < 0 ) return false; // handle empty spheres, see #31187
+
 		return this.distanceSqToPoint( sphere.center ) <= ( sphere.radius * sphere.radius );
 
 	}


### PR DESCRIPTION
Fixed #31187.

**Description**

The PR makes sure empty spheres are properly handled in `Ray.intersectsSphere()`.