### PR TITLE
TSL: Fix `Fn` as parameter

### DIFF
--- a/src/nodes/tsl/TSLCore.js
+++ b/src/nodes/tsl/TSLCore.js
@@ -175,7 +175,7 @@ const ShaderNodeObject = function ( obj, altType = null ) {
 
 	} else if ( type === 'shader' ) {
 
-		return Fn( obj );
+		return obj.isFn ? obj : Fn( obj );
 
 	}
 
@@ -651,6 +651,8 @@ export const Fn = ( jsFunc, layout = null ) => {
 
 	fn.shaderNode = shaderNode;
 	fn.id = shaderNode.id;
+
+	fn.isFn = true;
 
 	fn.getNodeType = ( ...params ) => shaderNode.getNodeType( ...params );
 	fn.getCacheKey = ( ...params ) => shaderNode.getCacheKey( ...params );


### PR DESCRIPTION
Fixes https://github.com/mrdoob/three.js/issues/31212

**Description**

Fix `Fn` as parameter. e.g:

```js
const bar = Fn(([r, g, b]) => {
    return vec3(r, g, b)
})

const foo = Fn(([baz]) => {
    return baz(0.1, 0.2, 0.3)
})

const material = new THREE.NodeMaterial()
material.fragmentNode = foo(bar)
```