### PR TITLE
WebGLBackend: Honor depth/stencil in `blitFramebuffer()`.

### DIFF
--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -543,18 +543,24 @@ class WebGLBackend extends Backend {
 		}
 
 		this._currentContext = previousContext;
+		const renderTarget = renderContext.renderTarget;
 
-		if ( renderContext.textures !== null && renderContext.renderTarget ) {
+		if ( renderContext.textures !== null && renderTarget ) {
 
-			const renderTargetContextData = this.get( renderContext.renderTarget );
+			const renderTargetContextData = this.get( renderTarget );
 
-			const { resolveDepthBuffer, samples } = renderContext.renderTarget;
-
-			if ( samples > 0 && this._useMultisampledExtension( renderContext.renderTarget ) === false ) {
+			if ( renderTarget.samples > 0 && this._useMultisampledExtension( renderTarget ) === false ) {
 
 				const fb = renderTargetContextData.framebuffers[ renderContext.getCacheKey() ];
 
-				const mask = gl.COLOR_BUFFER_BIT;
+				let mask = gl.COLOR_BUFFER_BIT;
+
+				if ( renderTarget.resolveDepthBuffer ) {
+
+					if ( renderTarget.depthBuffer ) mask |= gl.DEPTH_BUFFER_BIT;
+					if ( renderTarget.stencilBuffer && renderTarget.resolveStencilBuffer ) mask |= gl.STENCIL_BUFFER_BIT;
+
+				}
 
 				const msaaFrameBuffer = renderTargetContextData.msaaFrameBuffer;
 
@@ -595,7 +601,7 @@ class WebGLBackend extends Backend {
 
 				}
 
-			} else if ( resolveDepthBuffer === false && renderTargetContextData.framebuffers ) {
+			} else if ( renderTarget.resolveDepthBuffer === false && renderTargetContextData.framebuffers ) {
 
 				const fb = renderTargetContextData.framebuffers[ renderContext.getCacheKey() ];
 				state.bindFramebuffer( gl.DRAW_FRAMEBUFFER, fb );


### PR DESCRIPTION
Related issue: #30995

**Description**

This PR is one step towards full MSAA support for RTT with the WebGL backend of `WebGPURenderer`. 

The depth and stencil data were never honored during the blit operation so far. That explains why examples like `webgpu_custom_fog_background` failed with `PassNode` using MSAA since `getViewZNode()` or `getLinearDepthNode()` returned nodes operating on empty buffers.

The WebGL backend uses the same approach like in `WebGLRenderer` to avoid this issue:

https://github.com/mrdoob/three.js/blob/c0854e60011c3af69488a84a95d59b2353691435/src/renderers/webgl/WebGLTextures.js#L2137-L2145

/cc @cabanier 