### PR TITLE
NodeBuilder - Fix Interpolation

### DIFF
--- a/examples/webgpu_centroid_sampling.html
+++ b/examples/webgpu_centroid_sampling.html
@@ -158,8 +158,8 @@
 
 				};
 
-				const withFlatFirstShader = createShader( THREE.InterpolationSamplingType.FLAT, THREE.InterpolationSamplingMode.FLAT_FIRST );
-				const withFlatEitherShader = createShader( THREE.InterpolationSamplingType.FLAT, THREE.InterpolationSamplingMode.FLAT_EITHER );
+				const withFlatFirstShader = createShader( THREE.InterpolationSamplingType.FLAT, THREE.InterpolationSamplingMode.FIRST );
+				const withFlatEitherShader = createShader( THREE.InterpolationSamplingType.FLAT, THREE.InterpolationSamplingMode.EITHER );
 
 				const withSampleShader = Fn( () => {
 
@@ -235,16 +235,16 @@
 					THREE.InterpolationSamplingMode.NORMAL,
 					THREE.InterpolationSamplingMode.CENTROID,
 					THREE.InterpolationSamplingMode.SAMPLE,
-					THREE.InterpolationSamplingMode.FLAT_FIRST,
-					THREE.InterpolationSamplingMode.FLAT_EITHER
+					'flat first',
+					'flat either'
 				] ).onChange( () => {
 
 					const interpolationShaderLib = {
 						[ THREE.InterpolationSamplingMode.NORMAL ]: withoutInterpolationShader,
 						[ THREE.InterpolationSamplingMode.CENTROID ]: withInterpolationShader,
 						[ THREE.InterpolationSamplingMode.SAMPLE ]: withSampleShader,
-						[ THREE.InterpolationSamplingMode.FLAT_FIRST ]: withFlatFirstShader,
-						[ THREE.InterpolationSamplingMode.FLAT_EITHER ]: withFlatEitherShader
+						[ 'flat first' ]: withFlatFirstShader,
+						[ 'flat either' ]: withFlatEitherShader
 					};
 
 					const shader = interpolationShaderLib[ effectController.sampling ];

--- a/src/constants.js
+++ b/src/constants.js
@@ -1612,8 +1612,8 @@ export const InterpolationSamplingMode = {
 	NORMAL: 'normal',
 	CENTROID: 'centroid',
 	SAMPLE: 'sample',
-	FLAT_FIRST: 'flat first',
-	FLAT_EITHER: 'flat either'
+	FIRST: 'first',
+	EITHER: 'either'
 };
 
 /**

--- a/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
+++ b/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
@@ -794,8 +794,6 @@ ${ flowData.code }
 
 					if ( varying.interpolationType ) {
 
-						console.log( varying.interpolationType	);
-
 						const interpolationType = interpolationTypeMap[ varying.interpolationType ] || varying.interpolationType;
 						const sampling = interpolationModeMap[ varying.interpolationSampling ] || '';
 

--- a/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
+++ b/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
@@ -26,11 +26,11 @@ const supports = {
 
 const interpolationTypeMap = {
 	perspective: 'smooth',
-	linear: 'noperspective',
+	linear: 'noperspective'
 };
 
 const interpolationModeMap = {
-	'centroid': 'centroid',
+	'centroid': 'centroid'
 };
 
 const defaultPrecisions = `

--- a/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
+++ b/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
@@ -26,13 +26,11 @@ const supports = {
 
 const interpolationTypeMap = {
 	perspective: 'smooth',
-	linear: 'noperspective'
+	linear: 'noperspective',
 };
 
 const interpolationModeMap = {
 	'centroid': 'centroid',
-	'first': 'flat',
-	'either': 'flat'
 };
 
 const defaultPrecisions = `
@@ -795,6 +793,8 @@ ${ flowData.code }
 				if ( varying.needsInterpolation ) {
 
 					if ( varying.interpolationType ) {
+
+						console.log( varying.interpolationType	);
 
 						const interpolationType = interpolationTypeMap[ varying.interpolationType ] || varying.interpolationType;
 						const sampling = interpolationModeMap[ varying.interpolationSampling ] || '';

--- a/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
+++ b/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
@@ -31,8 +31,8 @@ const interpolationTypeMap = {
 
 const interpolationModeMap = {
 	'centroid': 'centroid',
-	'flat first': 'flat',
-	'flat either': 'flat'
+	'first': 'flat',
+	'either': 'flat'
 };
 
 const defaultPrecisions = `


### PR DESCRIPTION
Related Issue: #30576
Related PR: #30582 

**Description**

As far as I'm aware, GLSL does not offer first and either forms of flat interpolation, so these shouldn't be mapped in GLSL.
