### PR TITLE
Docs: Improve `Object3DNode`.

### DIFF
--- a/src/nodes/accessors/Object3DNode.js
+++ b/src/nodes/accessors/Object3DNode.js
@@ -263,6 +263,6 @@ export const objectViewPosition = /*@__PURE__*/ nodeProxy( Object3DNode, Object3
  * @tsl
  * @function
  * @param {?Object3D} [object3d] - The 3D object.
- * @returns {Object3DNode<vec3>}
+ * @returns {Object3DNode<float>}
  */
 export const objectRadius = /*@__PURE__*/ nodeProxy( Object3DNode, Object3DNode.RADIUS ).setParameterLength( 1 );


### PR DESCRIPTION
Fix JSDoc for objectRadius to match implementation

**Description**

objectRadius returns a float, not vec3. A pure documentation fix - no impact on functionality.