### PR TITLE
FBXLoader: Gracefully handle missing color data.

### DIFF
--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -445,7 +445,7 @@ class FBXTreeParser {
 		const extension = textureNode.FileName.split( '.' ).pop().toLowerCase();
 
 		let loader = this.manager.getHandler( `.${extension}` );
-		if ( loader === null) loader = this.textureLoader;
+		if ( loader === null ) loader = this.textureLoader;
 
 		const loaderPath = loader.path;
 
@@ -1784,7 +1784,7 @@ class GeometryParser {
 		geoInfo.vertexPositions = ( geoNode.Vertices !== undefined ) ? geoNode.Vertices.a : [];
 		geoInfo.vertexIndices = ( geoNode.PolygonVertexIndex !== undefined ) ? geoNode.PolygonVertexIndex.a : [];
 
-		if ( geoNode.LayerElementColor ) {
+		if ( geoNode.LayerElementColor && geoNode.LayerElementColor.Color ) {
 
 			geoInfo.color = this.parseVertexColors( geoNode.LayerElementColor[ 0 ] );
 


### PR DESCRIPTION
Fixed #31247.

**Description**

The asset of #31247 has a `LayerElementColor` definition in the FBX asset but without providing the actual color data. According to [Blender's FBX importer](https://github.com/sobotka/blender-addons/blob/7d80f2f97161fc8e353a657b179b9aa1f8e5280b/io_scene_fbx/import_fbx.py#L1092-L1095), there are valid FBX files where this is the case. `FBXLoader` simply ignores now the incomplete definition without throwing a runtime error.

@trusktr Do you mind testing with below URL if the asset is now displayed as expected?

https://rawcdn.githack.com/mrdoob/three.js/80389de0d4be9c37f4093e1e6e9724577942ef55/editor/index.html
