### PR TITLE
ImageLoader: Optimize caching.

### DIFF
--- a/src/loaders/ImageLoader.js
+++ b/src/loaders/ImageLoader.js
@@ -125,7 +125,7 @@ class ImageLoader extends Loader {
 			for ( let i = 0; i < callbacks.length; i ++ ) {
 
 				const callback = callbacks[ i ];
-				if ( callback.onError ) callback.onError( this );
+				if ( callback.onError ) callback.onError( event );
 
 			}
 

--- a/src/loaders/ImageLoader.js
+++ b/src/loaders/ImageLoader.js
@@ -72,8 +72,6 @@ class ImageLoader extends Loader {
 
 			removeEventListeners();
 
-			Cache.add( url, this );
-
 			if ( onLoad ) onLoad( this );
 
 			scope.manager.itemEnd( url );
@@ -85,6 +83,8 @@ class ImageLoader extends Loader {
 			removeEventListeners();
 
 			if ( onError ) onError( event );
+
+			Cache.remove( url );
 
 			scope.manager.itemError( url );
 			scope.manager.itemEnd( url );
@@ -107,6 +107,7 @@ class ImageLoader extends Loader {
 
 		}
 
+		Cache.add( url, image );
 		scope.manager.itemStart( url );
 
 		image.src = url;

--- a/src/loaders/ImageLoader.js
+++ b/src/loaders/ImageLoader.js
@@ -93,8 +93,6 @@ class ImageLoader extends Loader {
 
 			if ( onLoad ) onLoad( this );
 
-			scope.manager.itemEnd( url );
-
 			//
 
 			const callbacks = _loading.get( this ) || [];
@@ -108,6 +106,8 @@ class ImageLoader extends Loader {
 
 			_loading.delete( this );
 
+			scope.manager.itemEnd( url );
+
 		}
 
 		function onImageError( event ) {
@@ -117,9 +117,6 @@ class ImageLoader extends Loader {
 			if ( onError ) onError( event );
 
 			Cache.remove( url );
-
-			scope.manager.itemError( url );
-			scope.manager.itemEnd( url );
 
 			//
 
@@ -133,6 +130,10 @@ class ImageLoader extends Loader {
 			}
 
 			_loading.delete( this );
+
+
+			scope.manager.itemError( url );
+			scope.manager.itemEnd( url );
 
 		}
 


### PR DESCRIPTION
Fixed #31256.

**Description**

The idea of this PR is to cache the image object in `ImageLoader` a bit earlier. In this way, concurrent pending requests get the same cached image. 

If the request fails, the cache entry is removed so subsequent `load()` calls (like retries) perform a fresh request.
