### PR TITLE
Editor: Fix typo in comment.

### DIFF
--- a/editor/js/libs/jsonlint.js
+++ b/editor/js/libs/jsonlint.js
@@ -122,7 +122,7 @@ parse: function parse(input) {
 
     var symbol, preErrorSymbol, state, action, r, yyval={},p,len,newState, expected;
     while (true) {
-        // retreive state number from top of stack
+        // retrieve state number from top of stack
         state = stack[stack.length-1];
 
         // use default actions if available


### PR DESCRIPTION


Description:  
This pull request corrects a typo in a comment within the editor/js/libs/jsonlint.js file. The word "retrive" has been changed to the correct spelling "retrieve" for improved code clarity and professionalism. No functional code changes were made.
