### PR TITLE
Loader: Add `abort()`.

### DIFF
--- a/src/core/EventDispatcher.js
+++ b/src/core/EventDispatcher.js
@@ -94,21 +94,6 @@ class EventDispatcher {
 	}
 
 	/**
-	 * Removes all event listeners for the given event type.
-	 *
-	 * @param {string} type - The type of event.
-	 */
-	removeEventListeners( type ) {
-
-		const listeners = this._listeners;
-
-		if ( listeners === undefined ) return;
-
-		delete this._listeners[ type ];
-
-	}
-
-	/**
 	 * Dispatches an event object.
 	 *
 	 * @param {Object} event - The event that gets fired.

--- a/src/core/EventDispatcher.js
+++ b/src/core/EventDispatcher.js
@@ -94,6 +94,21 @@ class EventDispatcher {
 	}
 
 	/**
+	 * Removes all event listeners for the given event type.
+	 *
+	 * @param {string} type - The type of event.
+	 */
+	removeEventListeners( type ) {
+
+		const listeners = this._listeners;
+
+		if ( listeners === undefined ) return;
+
+		delete this._listeners[ type ];
+
+	}
+
+	/**
 	 * Dispatches an event object.
 	 *
 	 * @param {Object} event - The event that gets fired.

--- a/src/loaders/FileLoader.js
+++ b/src/loaders/FileLoader.js
@@ -129,7 +129,7 @@ class FileLoader extends Loader {
 		const req = new Request( url, {
 			headers: new Headers( this.requestHeader ),
 			credentials: this.withCredentials ? 'include' : 'same-origin',
-			signal: AbortSignal.any( [ this._abortController.signal, this.manager.abortController.signal ] )
+			signal: ( typeof AbortSignal.any === 'function' ) ? AbortSignal.any( [ this._abortController.signal, this.manager.abortController.signal ] ) : this._abortController.signal
 		} );
 
 		// record states ( avoid data race )

--- a/src/loaders/FileLoader.js
+++ b/src/loaders/FileLoader.js
@@ -55,6 +55,14 @@ class FileLoader extends Loader {
 		 */
 		this.responseType = '';
 
+		/**
+		 * Used for aborting requests.
+		 *
+		 * @private
+		 * @type {AbortController}
+		 */
+		this._abortController = new AbortController();
+
 	}
 
 	/**
@@ -121,7 +129,7 @@ class FileLoader extends Loader {
 		const req = new Request( url, {
 			headers: new Headers( this.requestHeader ),
 			credentials: this.withCredentials ? 'include' : 'same-origin',
-			// An abort controller could be added within a future PR
+			signal: this._abortController.signal
 		} );
 
 		// record states ( avoid data race )
@@ -334,6 +342,19 @@ class FileLoader extends Loader {
 	setMimeType( value ) {
 
 		this.mimeType = value;
+		return this;
+
+	}
+
+	/**
+	 * Aborts ongoing fetch requests.
+	 *
+	 * @return {FileLoader} A reference to this instance.
+	 */
+	abort() {
+
+		this._abortController.abort();
+
 		return this;
 
 	}

--- a/src/loaders/FileLoader.js
+++ b/src/loaders/FileLoader.js
@@ -129,7 +129,7 @@ class FileLoader extends Loader {
 		const req = new Request( url, {
 			headers: new Headers( this.requestHeader ),
 			credentials: this.withCredentials ? 'include' : 'same-origin',
-			signal: this._abortController.signal
+			signal: AbortSignal.any( [ this._abortController.signal, this.manager.abortController.signal ] )
 		} );
 
 		// record states ( avoid data race )

--- a/src/loaders/FileLoader.js
+++ b/src/loaders/FileLoader.js
@@ -354,6 +354,7 @@ class FileLoader extends Loader {
 	abort() {
 
 		this._abortController.abort();
+		this._abortController = new AbortController();
 
 		return this;
 

--- a/src/loaders/ImageBitmapLoader.js
+++ b/src/loaders/ImageBitmapLoader.js
@@ -162,7 +162,7 @@ class ImageBitmapLoader extends Loader {
 		const fetchOptions = {};
 		fetchOptions.credentials = ( this.crossOrigin === 'anonymous' ) ? 'same-origin' : 'include';
 		fetchOptions.headers = this.requestHeader;
-		fetchOptions.signal = AbortSignal.any( [ this._abortController.signal, this.manager.abortController.signal ] );
+		fetchOptions.signal = ( typeof AbortSignal.any === 'function' ) ? AbortSignal.any( [ this._abortController.signal, this.manager.abortController.signal ] ) : this._abortController.signal;
 
 		const promise = fetch( url, fetchOptions ).then( function ( res ) {
 

--- a/src/loaders/ImageBitmapLoader.js
+++ b/src/loaders/ImageBitmapLoader.js
@@ -66,6 +66,14 @@ class ImageBitmapLoader extends Loader {
 		 */
 		this.options = { premultiplyAlpha: 'none' };
 
+		/**
+		 * Used for aborting requests.
+		 *
+		 * @private
+		 * @type {AbortController}
+		 */
+		this._abortController = new AbortController();
+
 	}
 
 	/**
@@ -154,6 +162,7 @@ class ImageBitmapLoader extends Loader {
 		const fetchOptions = {};
 		fetchOptions.credentials = ( this.crossOrigin === 'anonymous' ) ? 'same-origin' : 'include';
 		fetchOptions.headers = this.requestHeader;
+		fetchOptions.signal = this._abortController.signal;
 
 		const promise = fetch( url, fetchOptions ).then( function ( res ) {
 
@@ -188,6 +197,19 @@ class ImageBitmapLoader extends Loader {
 
 		Cache.add( url, promise );
 		scope.manager.itemStart( url );
+
+	}
+
+	/**
+	 * Aborts ongoing fetch requests.
+	 *
+	 * @return {ImageBitmapLoader} A reference to this instance.
+	 */
+	abort() {
+
+		this._abortController.abort();
+
+		return this;
 
 	}
 

--- a/src/loaders/ImageBitmapLoader.js
+++ b/src/loaders/ImageBitmapLoader.js
@@ -162,7 +162,7 @@ class ImageBitmapLoader extends Loader {
 		const fetchOptions = {};
 		fetchOptions.credentials = ( this.crossOrigin === 'anonymous' ) ? 'same-origin' : 'include';
 		fetchOptions.headers = this.requestHeader;
-		fetchOptions.signal = this._abortController.signal;
+		fetchOptions.signal = AbortSignal.any( [ this._abortController.signal, this.manager.abortController.signal ] );
 
 		const promise = fetch( url, fetchOptions ).then( function ( res ) {
 

--- a/src/loaders/ImageBitmapLoader.js
+++ b/src/loaders/ImageBitmapLoader.js
@@ -208,6 +208,7 @@ class ImageBitmapLoader extends Loader {
 	abort() {
 
 		this._abortController.abort();
+		this._abortController = new AbortController();
 
 		return this;
 

--- a/src/loaders/Loader.js
+++ b/src/loaders/Loader.js
@@ -61,12 +61,21 @@ class Loader {
 		 */
 		this.requestHeader = {};
 
+		//
+
+		if ( this.manager.enableAbortManagement === true ) {
+
+			this.manager.addEventListener( 'abort', () => this.abort() );
+
+		}
+
 	}
 
 	/**
 	 * This method needs to be implemented by all concrete loaders. It holds the
 	 * logic for loading assets from the backend.
 	 *
+	 * @abstract
 	 * @param {string} url - The path/URL of the file to be loaded.
 	 * @param {Function} onLoad - Executed when the loading process has been finished.
 	 * @param {onProgressCallback} [onProgress] - Executed while the loading is in progress.
@@ -97,6 +106,7 @@ class Loader {
 	 * This method needs to be implemented by all concrete loaders. It holds the
 	 * logic for parsing the asset into three.js entities.
 	 *
+	 * @abstract
 	 * @param {any} data - The data to parse.
 	 */
 	parse( /* data */ ) {}
@@ -167,6 +177,18 @@ class Loader {
 	setRequestHeader( requestHeader ) {
 
 		this.requestHeader = requestHeader;
+		return this;
+
+	}
+
+	/**
+	 * This method can be implemented in loaders for aborting ongoing requests.
+	 *
+	 * @abstract
+	 * @return {Loader} A reference to this instance.
+	 */
+	abort() {
+
 		return this;
 
 	}

--- a/src/loaders/Loader.js
+++ b/src/loaders/Loader.js
@@ -61,14 +61,6 @@ class Loader {
 		 */
 		this.requestHeader = {};
 
-		//
-
-		if ( this.manager.enableAbortManagement === true ) {
-
-			this.manager.addEventListener( 'abort', () => this.abort() );
-
-		}
-
 	}
 
 	/**

--- a/src/loaders/LoadingManager.js
+++ b/src/loaders/LoadingManager.js
@@ -280,7 +280,6 @@ class LoadingManager {
 		 * Can be used to abort ongoing loading requests in loaders using this manager.
 		 * The abort only works if the loaders implement {@link Loader#abort}.
 		 *
-		 * @fires LoadingManager#abort
 		 * @return {LoadingManager} A reference to this loading manager.
 		 */
 		this.abort = function () {

--- a/src/loaders/LoadingManager.js
+++ b/src/loaders/LoadingManager.js
@@ -313,7 +313,9 @@ class LoadingManager extends EventDispatcher {
 		 */
 		this.dispose = function () {
 
-			this._listeners = {}; // remove abort handler
+			handlers.length = 0;
+
+			this.removeEventListeners( 'abort' );
 
 			return this;
 

--- a/src/loaders/LoadingManager.js
+++ b/src/loaders/LoadingManager.js
@@ -1,3 +1,13 @@
+import { EventDispatcher } from '../core/EventDispatcher.js';
+
+/**
+ * Fires when {@link LoadingManager#abort} is called.
+ *
+ * @event LoadingManager#abort
+ * @type {Object}
+ */
+const _abort = { type: 'abort' };
+
 /**
  * Handles and keeps track of loaded and pending data. A default global
  * instance of this class is created and used by loaders if not supplied
@@ -15,7 +25,7 @@
  * const loader2 = new ColladaLoader( manager );
  * ```
  */
-class LoadingManager {
+class LoadingManager extends EventDispatcher {
 
 	/**
 	 * Constructs a new loading manager.
@@ -25,6 +35,8 @@ class LoadingManager {
 	 * @param {Function} [onError] - Executes when an error occurs.
 	 */
 	constructor( onLoad, onProgress, onError ) {
+
+		super();
 
 		const scope = this;
 
@@ -68,6 +80,14 @@ class LoadingManager {
 		 * @default undefined
 		 */
 		this.onError = onError;
+
+		/**
+		 * Whether loading requests can be aborted with {@link LoadingManager#abort} or not.
+		 *
+		 * @type {boolean}
+		 * @default false
+		 */
+		this.enableAbortManagement = false;
 
 		/**
 		 * This should be called by any loader using the manager when the loader
@@ -266,6 +286,36 @@ class LoadingManager {
 			}
 
 			return null;
+
+		};
+
+		/**
+		 * Can be used to abort ongoing loading requests in loaders using this manager.
+		 * The abort only works if {@link LoadingManager#enableAbortManagement} is set
+		 * to `true` and the loaders implement {@link Loader#abort}.
+		 *
+		 * @fires LoadingManager#abort
+		 * @return {LoadingManager} A reference to this loading manager.
+		 */
+		this.abort = function () {
+
+			this.dispatchEvent( _abort );
+
+			return this;
+
+		};
+
+		/**
+		 * Frees internal resources. Call this method whenever this instance is no
+		 * longer used in your app.
+		 *
+		 * @return {LoadingManager} A reference to this loading manager.
+		 */
+		this.dispose = function () {
+
+			this._listeners = {}; // remove abort handler
+
+			return this;
 
 		};
 

--- a/src/loaders/LoadingManager.js
+++ b/src/loaders/LoadingManager.js
@@ -278,7 +278,8 @@ class LoadingManager {
 
 		/**
 		 * Can be used to abort ongoing loading requests in loaders using this manager.
-		 * The abort only works if the loaders implement {@link Loader#abort}.
+		 * The abort only works if the loaders implement {@link Loader#abort} and `AbortSignal.any()`
+		 * is supported in the browser.
 		 *
 		 * @return {LoadingManager} A reference to this loading manager.
 		 */

--- a/src/loaders/LoadingManager.js
+++ b/src/loaders/LoadingManager.js
@@ -1,13 +1,3 @@
-import { EventDispatcher } from '../core/EventDispatcher.js';
-
-/**
- * Fires when {@link LoadingManager#abort} is called.
- *
- * @event LoadingManager#abort
- * @type {Object}
- */
-const _abort = { type: 'abort' };
-
 /**
  * Handles and keeps track of loaded and pending data. A default global
  * instance of this class is created and used by loaders if not supplied
@@ -25,7 +15,7 @@ const _abort = { type: 'abort' };
  * const loader2 = new ColladaLoader( manager );
  * ```
  */
-class LoadingManager extends EventDispatcher {
+class LoadingManager {
 
 	/**
 	 * Constructs a new loading manager.
@@ -35,8 +25,6 @@ class LoadingManager extends EventDispatcher {
 	 * @param {Function} [onError] - Executes when an error occurs.
 	 */
 	constructor( onLoad, onProgress, onError ) {
-
-		super();
 
 		const scope = this;
 
@@ -82,12 +70,11 @@ class LoadingManager extends EventDispatcher {
 		this.onError = onError;
 
 		/**
-		 * Whether loading requests can be aborted with {@link LoadingManager#abort} or not.
+		 * Used for aborting ongoing requests in loaders using this manager.
 		 *
-		 * @type {boolean}
-		 * @default false
+		 * @type {AbortController}
 		 */
-		this.enableAbortManagement = false;
+		this.abortController = new AbortController();
 
 		/**
 		 * This should be called by any loader using the manager when the loader
@@ -291,15 +278,15 @@ class LoadingManager extends EventDispatcher {
 
 		/**
 		 * Can be used to abort ongoing loading requests in loaders using this manager.
-		 * The abort only works if {@link LoadingManager#enableAbortManagement} is set
-		 * to `true` and the loaders implement {@link Loader#abort}.
+		 * The abort only works if the loaders implement {@link Loader#abort}.
 		 *
 		 * @fires LoadingManager#abort
 		 * @return {LoadingManager} A reference to this loading manager.
 		 */
 		this.abort = function () {
 
-			this.dispatchEvent( _abort );
+			this.abortController.abort();
+			this.abortController = new AbortController();
 
 			return this;
 

--- a/src/loaders/LoadingManager.js
+++ b/src/loaders/LoadingManager.js
@@ -305,22 +305,6 @@ class LoadingManager extends EventDispatcher {
 
 		};
 
-		/**
-		 * Frees internal resources. Call this method whenever this instance is no
-		 * longer used in your app.
-		 *
-		 * @return {LoadingManager} A reference to this loading manager.
-		 */
-		this.dispose = function () {
-
-			handlers.length = 0;
-
-			this.removeEventListeners( 'abort' );
-
-			return this;
-
-		};
-
 	}
 
 }


### PR DESCRIPTION
Fixed #20705.

Closes #23070, #29634.

**Description**

Aborting loading requests is a feature that has been requested more than once. Previous PRs weren't ideal though so this one is an attempt to find a good compromise.

The idea is to introduce `Loader.abort()` as an abstract method that can be implemented by concrete loaders. The loader implementation itself must decide how an abort operation is implemented. `FileLoader` and `ImageBitmapLoader` do this with `AbortController` but other loaders might use different strategies. 

The PR also introduces `LoadingManager.abort()` that makes it easier to abort the loading process of more complex loaders like `GLTFLoader`. If you create an instance of `LoadingManager`, you can now set `enableAbortManagement` to `true` which enables abort management on loading manager level. Loaders using this manager will listen to an `abort` event that will trigger their `abort()` implementation.