### PR TITLE
TSL: Fix `convertToTexture()` auto resize

### DIFF
--- a/src/nodes/utils/RTTNode.js
+++ b/src/nodes/utils/RTTNode.js
@@ -131,7 +131,7 @@ class RTTNode extends TextureNode {
 	 * @readonly
 	 * @default true
 	 */
-	get autoSize() {
+	get autoResize() {
 
 		return this.width === null;
 
@@ -188,7 +188,7 @@ class RTTNode extends TextureNode {
 
 		//
 
-		if ( this.autoSize === true ) {
+		if ( this.autoResize === true ) {
 
 			const pixelRatio = renderer.getPixelRatio();
 			const size = renderer.getSize( _size );

--- a/src/nodes/utils/RTTNode.js
+++ b/src/nodes/utils/RTTNode.js
@@ -190,11 +190,19 @@ class RTTNode extends TextureNode {
 
 		if ( this.autoSize === true ) {
 
-			this.pixelRatio = renderer.getPixelRatio();
-
+			const pixelRatio = renderer.getPixelRatio();
 			const size = renderer.getSize( _size );
 
-			this.setSize( size.width, size.height );
+			const effectiveWidth = size.width * pixelRatio;
+			const effectiveHeight = size.height * pixelRatio;
+
+			if ( effectiveWidth !== this.renderTarget.width || effectiveHeight !== this.renderTarget.height ) {
+
+				this.renderTarget.setSize( effectiveWidth, effectiveHeight );
+
+				this.textureNeedsUpdate = true;
+
+			}
 
 		}
 


### PR DESCRIPTION
Fixes https://github.com/mrdoob/three.js/issues/31275

**Description**

Fix `RTTNode` auto resize.