### PR TITLE
TSL: Introduce `tangentViewFrame` and `bitangentViewFrame`

### DIFF
--- a/src/nodes/accessors/Bitangent.js
+++ b/src/nodes/accessors/Bitangent.js
@@ -1,7 +1,7 @@
 import { Fn } from '../tsl/TSLCore.js';
 import { normalGeometry, normalLocal, normalView, normalWorld } from './Normal.js';
 import { tangentGeometry, tangentLocal, tangentView, tangentWorld } from './Tangent.js';
-import { tangentFrame } from './TangentUtils.js';
+import { bitangentViewFrame } from './TangentUtils.js';
 import { directionToFaceDirection } from '../display/FrontFacingNode.js';
 
 /**
@@ -59,7 +59,7 @@ export const bitangentView = /*@__PURE__*/ ( Fn( ( { subBuildFn, geometry, mater
 
 	} else {
 
-		node = tangentFrame.bitangentView;
+		node = bitangentViewFrame;
 
 	}
 

--- a/src/nodes/accessors/Bitangent.js
+++ b/src/nodes/accessors/Bitangent.js
@@ -1,6 +1,8 @@
 import { Fn } from '../tsl/TSLCore.js';
 import { normalGeometry, normalLocal, normalView, normalWorld } from './Normal.js';
 import { tangentGeometry, tangentLocal, tangentView, tangentWorld } from './Tangent.js';
+import { tangentFrame } from './TangentUtils.js';
+import { directionToFaceDirection } from '../display/FrontFacingNode.js';
 
 /**
  * Returns the bitangent node and assigns it to a varying if the material is not flat shaded.
@@ -47,7 +49,29 @@ export const bitangentLocal = /*@__PURE__*/ getBitangent( normalLocal.cross( tan
  * @tsl
  * @type {Node<vec3>}
  */
-export const bitangentView = getBitangent( normalView.cross( tangentView ), 'v_bitangentView' ).normalize().toVar( 'bitangentView' );
+export const bitangentView = /*@__PURE__*/ ( Fn( ( { subBuildFn, geometry, material } ) => {
+
+	let node;
+
+	if ( subBuildFn === 'VERTEX' || geometry.hasAttribute( 'tangent' ) ) {
+
+		node = getBitangent( normalView.cross( tangentView ), 'v_bitangentView' ).normalize();
+
+	} else {
+
+		node = tangentFrame.bitangentView;
+
+	}
+
+	if ( material.flatShading !== true ) {
+
+		node = directionToFaceDirection( node );
+
+	}
+
+	return node;
+
+}, 'vec3' ).once( [ 'NORMAL', 'VERTEX' ] ) )().toVar( 'bitangentView' );
 
 /**
  * TSL object that represents the vertex bitangent in world space of the current rendered object.

--- a/src/nodes/accessors/Tangent.js
+++ b/src/nodes/accessors/Tangent.js
@@ -2,7 +2,7 @@ import { attribute } from '../core/AttributeNode.js';
 import { cameraViewMatrix } from './Camera.js';
 import { modelViewMatrix } from './ModelNode.js';
 import { Fn, vec4 } from '../tsl/TSLBase.js';
-import { tangentFrame } from './TangentUtils.js';
+import { tangentViewFrame } from './TangentUtils.js';
 import { directionToFaceDirection } from '../display/FrontFacingNode.js';
 
 /**
@@ -47,7 +47,7 @@ export const tangentView = /*@__PURE__*/ ( Fn( ( { subBuildFn, geometry, materia
 
 	} else {
 
-		node = tangentFrame.tangentView;
+		node = tangentViewFrame;
 
 	}
 

--- a/src/nodes/accessors/TangentUtils.js
+++ b/src/nodes/accessors/TangentUtils.js
@@ -2,45 +2,45 @@ import { uv as getUV } from './UV.js';
 import { positionView } from './Position.js';
 import { normalView } from './Normal.js';
 
+// Normal Mapping Without Precomputed Tangents
+// http://www.thetenthplanet.de/archives/1180
+
+const uv = getUV();
+
+const q0 = positionView.dFdx();
+const q1 = positionView.dFdy();
+const st0 = uv.dFdx();
+const st1 = uv.dFdy();
+
+const N = normalView;
+
+const q1perp = q1.cross( N );
+const q0perp = N.cross( q0 );
+
+const T = q1perp.mul( st0.x ).add( q0perp.mul( st1.x ) );
+const B = q1perp.mul( st0.y ).add( q0perp.mul( st1.y ) );
+
+const det = T.dot( T ).max( B.dot( B ) );
+const scale = det.equal( 0.0 ).select( 0.0, det.inverseSqrt() );
+
 /**
- * Computes the tangent and bitangent vectors in view space for normal mapping without precomputed tangents.
+ * Tangent vector in view space, computed dynamically from geometry and UV derivatives.
+ * Useful for normal mapping without precomputed tangents.
  *
- * This utility constructs a tangent frame using the derivatives of the position and UV coordinates,
- * following the method described at http://www.thetenthplanet.de/archives/1180.
+ * Reference: http://www.thetenthplanet.de/archives/1180
  *
- * @constant
- * @type {{ tangentView: Node<vec3>, bitangentView: Node<vec3>, normalView: Node<vec3> }}
- * @property {Node<vec3>} tangentView - The computed tangent vector in view space.
- * @property {Node<vec3>} bitangentView - The computed bitangent vector in view space.
- * @property {Node<vec3>} normalView - The normal vector in view space.
+ * @tsl
+ * @type {Node<vec3>}
  */
-export const tangentFrame = /*#__PURE__*/ ( () => {
+export const tangentViewFrame = /*@__PURE__*/ T.mul( scale ).toVar( 'tangentViewFrame' );
 
-	const uv = getUV();
-
-	const q0 = positionView.dFdx();
-	const q1 = positionView.dFdy();
-	const st0 = uv.dFdx();
-	const st1 = uv.dFdy();
-
-	const N = normalView;
-
-	const q1perp = q1.cross( N );
-	const q0perp = N.cross( q0 );
-
-	const T = q1perp.mul( st0.x ).add( q0perp.mul( st1.x ) );
-	const B = q1perp.mul( st0.y ).add( q0perp.mul( st1.y ) );
-
-	const det = T.dot( T ).max( B.dot( B ) );
-	const scale = det.equal( 0.0 ).select( 0.0, det.inverseSqrt() );
-
-	const tangentView = T.mul( scale ).toVar( 'tangentViewFrame' );
- 	const bitangentView = B.mul( scale ).toVar( 'bitangentViewFrame' );
-
-	return {
-		tangentView,
-		bitangentView,
-		normalView
-	};
-
-} )();
+/**
+ * Bitangent vector in view space, computed dynamically from geometry and UV derivatives.
+ * Complements the tangentViewFrame for constructing the tangent space basis.
+ *
+ * Reference: http://www.thetenthplanet.de/archives/1180
+ *
+ * @tsl
+ * @type {Node<vec3>}
+ */
+export const bitangentViewFrame = /*@__PURE__*/ B.mul( scale ).toVar( 'bitangentViewFrame' );

--- a/src/nodes/accessors/TangentUtils.js
+++ b/src/nodes/accessors/TangentUtils.js
@@ -1,0 +1,46 @@
+import { uv as getUV } from './UV.js';
+import { positionView } from './Position.js';
+import { normalView } from './Normal.js';
+
+/**
+ * Computes the tangent and bitangent vectors in view space for normal mapping without precomputed tangents.
+ *
+ * This utility constructs a tangent frame using the derivatives of the position and UV coordinates,
+ * following the method described at http://www.thetenthplanet.de/archives/1180.
+ *
+ * @constant
+ * @type {{ tangentView: Node<vec3>, bitangentView: Node<vec3>, normalView: Node<vec3> }}
+ * @property {Node<vec3>} tangentView - The computed tangent vector in view space.
+ * @property {Node<vec3>} bitangentView - The computed bitangent vector in view space.
+ * @property {Node<vec3>} normalView - The normal vector in view space.
+ */
+export const tangentFrame = /*#__PURE__*/ ( () => {
+
+	const uv = getUV();
+
+	const q0 = positionView.dFdx();
+	const q1 = positionView.dFdy();
+	const st0 = uv.dFdx();
+	const st1 = uv.dFdy();
+
+	const N = normalView;
+
+	const q1perp = q1.cross( N );
+	const q0perp = N.cross( q0 );
+
+	const T = q1perp.mul( st0.x ).add( q0perp.mul( st1.x ) );
+	const B = q1perp.mul( st0.y ).add( q0perp.mul( st1.y ) );
+
+	const det = T.dot( T ).max( B.dot( B ) );
+	const scale = det.equal( 0.0 ).select( 0.0, det.inverseSqrt() );
+
+	const tangentView = T.mul( scale ).toVar( 'tangentViewFrame' );
+ 	const bitangentView = B.mul( scale ).toVar( 'bitangentViewFrame' );
+
+	return {
+		tangentView,
+		bitangentView,
+		normalView
+	};
+
+} )();

--- a/src/nodes/display/NormalMapNode.js
+++ b/src/nodes/display/NormalMapNode.js
@@ -1,41 +1,11 @@
 import TempNode from '../core/TempNode.js';
-import { add } from '../math/OperatorNode.js';
 
 import { normalView, transformNormalToView } from '../accessors/Normal.js';
-import { positionView } from '../accessors/Position.js';
 import { TBNViewMatrix } from '../accessors/AccessorsUtils.js';
-import { uv } from '../accessors/UV.js';
-import { faceDirection } from './FrontFacingNode.js';
-import { Fn, nodeProxy, vec3 } from '../tsl/TSLBase.js';
+import { nodeProxy, vec3 } from '../tsl/TSLBase.js';
 
 import { TangentSpaceNormalMap, ObjectSpaceNormalMap } from '../../constants.js';
-
-// Normal Mapping Without Precomputed Tangents
-// http://www.thetenthplanet.de/archives/1180
-
-const perturbNormal2Arb = /*@__PURE__*/ Fn( ( inputs ) => {
-
-	const { eye_pos, surf_norm, mapN, uv } = inputs;
-
-	const q0 = eye_pos.dFdx();
-	const q1 = eye_pos.dFdy();
-	const st0 = uv.dFdx();
-	const st1 = uv.dFdy();
-
-	const N = surf_norm; // normalized
-
-	const q1perp = q1.cross( N );
-	const q0perp = N.cross( q0 );
-
-	const T = q1perp.mul( st0.x ).add( q0perp.mul( st1.x ) );
-	const B = q1perp.mul( st0.y ).add( q0perp.mul( st1.y ) );
-
-	const det = T.dot( T ).max( B.dot( B ) );
-	const scale = faceDirection.mul( det.inverseSqrt() );
-
-	return add( T.mul( mapN.x, scale ), B.mul( mapN.y, scale ), N.mul( mapN.z ) ).normalize();
-
-} );
+import { directionToFaceDirection } from './FrontFacingNode.js';
 
 /**
  * This class can be used for applying normals maps to materials.
@@ -89,7 +59,7 @@ class NormalMapNode extends TempNode {
 
 	}
 
-	setup( builder ) {
+	setup( { material } ) {
 
 		const { normalMapType, scaleNode } = this;
 
@@ -97,44 +67,37 @@ class NormalMapNode extends TempNode {
 
 		if ( scaleNode !== null ) {
 
-			normalMap = vec3( normalMap.xy.mul( scaleNode ), normalMap.z );
+			let scale = scaleNode;
+
+			if ( material.flatShading === true ) {
+
+				scale = directionToFaceDirection( scale );
+
+			}
+
+			normalMap = vec3( normalMap.xy.mul( scale ), normalMap.z );
 
 		}
 
-		let outputNode = null;
+		let output = null;
 
 		if ( normalMapType === ObjectSpaceNormalMap ) {
 
-			outputNode = transformNormalToView( normalMap );
+			output = transformNormalToView( normalMap );
 
 		} else if ( normalMapType === TangentSpaceNormalMap ) {
 
-			const tangent = builder.hasGeometryAttribute( 'tangent' );
-
-			if ( tangent === true ) {
-
-				outputNode = TBNViewMatrix.mul( normalMap ).normalize();
-
-			} else {
-
-				outputNode = perturbNormal2Arb( {
-					eye_pos: positionView,
-					surf_norm: normalView,
-					mapN: normalMap,
-					uv: uv()
-				} );
-
-			}
+			output = TBNViewMatrix.mul( normalMap ).normalize();
 
 		} else {
 
 			console.error( `THREE.NodeMaterial: Unsupported normal map type: ${ normalMapType }` );
 
-			outputNode = normalView; // Fallback to default normal view
+			output = normalView; // Fallback to default normal view
 
 		}
 
-		return outputNode;
+		return output;
 
 	}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/31059#issuecomment-2860882752, https://github.com/mrdoob/three.js/pull/30837#issuecomment-2986381881, https://github.com/mrdoob/three.js/pull/31271

**Description**

Introduce `tangentViewFrame`, `bitangentViewFrame` and fixed the incompatibilities between using `material.flatShading=true`  or `geometry.computeTangents()`.