### PR TITLE
Fix code typo in SceneGraph manual page

### DIFF
--- a/manual/en/scenegraph.html
+++ b/manual/en/scenegraph.html
@@ -91,7 +91,7 @@ details about point lights later but for now the simple version is a point light
 represents light that emanates from a single point.</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">{
   const color = 0xFFFFFF;
-  const intensity = 3;
+  const intensity = 500;
   const light = new THREE.PointLight(color, intensity);
   scene.add(light);
 }

--- a/manual/examples/scenegraph-sun-earth-moon-axes-grids.html
+++ b/manual/examples/scenegraph-sun-earth-moon-axes-grids.html
@@ -79,7 +79,7 @@ function main() {
 	{
 
 		const color = 0xFFFFFF;
-		const intensity = 3;
+		const intensity = 500;
 		const light = new THREE.PointLight( color, intensity );
 		scene.add( light );
 

--- a/manual/fr/scenegraph.html
+++ b/manual/fr/scenegraph.html
@@ -89,7 +89,7 @@ les détails des lumières ponctuelles, mais pour l'instant, la version simple e
 représente la lumière qui émane d'un point unique.</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">{
   const color = 0xFFFFFF;
-  const intensity = 3;
+  const intensity = 500;
   const light = new THREE.PointLight(color, intensity);
   scene.add(light);
 }

--- a/manual/ja/scenegraph.html
+++ b/manual/ja/scenegraph.html
@@ -80,7 +80,7 @@ phong materialのemissive属性は、基本的に、光が当たっていない�
 一点から発せられる明かりというのが、とりあえずの簡単な説明です。</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">{
   const color = 0xFFFFFF;
-  const intensity = 3;
+  const intensity = 500;
   const light = new THREE.PointLight(color, intensity);
   scene.add(light);
 }

--- a/manual/ko/scenegraph.html
+++ b/manual/ko/scenegraph.html
@@ -89,7 +89,7 @@ objects.push(sunMesh);
 정도로 알아둡시다.</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">{
   const color = 0xFFFFFF;
-  const intensity = 3;
+  const intensity = 500;
   const light = new THREE.PointLight(color, intensity);
   scene.add(light);
 }

--- a/manual/ru/scenegraph.html
+++ b/manual/ru/scenegraph.html
@@ -89,7 +89,7 @@ objects.push(sunMesh);
 представляет собой точечный источник света.</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">{
   const color = 0xFFFFFF;
-  const intensity = 3;
+  const intensity = 500;
   const light = new THREE.PointLight(color, intensity);
   scene.add(light);
 }

--- a/manual/zh/scenegraph.html
+++ b/manual/zh/scenegraph.html
@@ -66,7 +66,7 @@ objects.push(sunMesh);
 <p>我们也在场景的中心放置了一个点光源（point light）。稍后我们会介绍更多关于点光源的细节，但现在简单地说，点光源代表从一个点向各个方向发射的光源。</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">{
   const color = 0xffffff;
-  const intensity = 3;
+  const intensity = 500;
   const light = new THREE.PointLight(color, intensity);
   scene.add(light);
 }


### PR DESCRIPTION
**Description**

The sample code in the manual for the [Scene Graph fundamentals](https://threejs.org/manual/#en/scenegraph) has a code typo that was causing me some grief. Particularly this chunk of code:

```
{
  const color = 0xFFFFFF;
  const intensity = 3;
  const light = new THREE.PointLight(color, intensity);
  scene.add(light);
}
```

had the wrong intensity value (should be `500`, not `3`). It took me some time to realize why I couldn't get my example matching up with the docs.

I updated the docs to match the correct value in all the areas I could spot the issue.