### PR TITLE
WebGLPrograms: Fix cache key with gradient maps.

### DIFF
--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -515,6 +515,8 @@ function WebGLPrograms( renderer, cubemaps, cubeuvmaps, extensions, capabilities
 			_programLayers.enable( 20 );
 		if ( parameters.batchingColor )
 			_programLayers.enable( 21 );
+		if ( parameters.gradientMap )
+			_programLayers.enable( 22 );
 
 		array.push( _programLayers.mask );
 		_programLayers.disableAll();


### PR DESCRIPTION
Fixed #31290.

**Description**

`MeshToonMaterial.gradientMap` was not honored when computing the program cache key.
