### PR TITLE
SampleNode: Remove `PURE` annotation.

### DIFF
--- a/src/nodes/utils/SampleNode.js
+++ b/src/nodes/utils/SampleNode.js
@@ -78,4 +78,4 @@ export default SampleNode;
  * @param {Function} callback - The function to be called when sampling. Should accept a UV node and return a value.
  * @returns {SampleNode} The created SampleNode instance wrapped as a node object.
  */
-export const sample = /*@__PURE__*/ ( callback ) => nodeObject( new SampleNode( callback ) );
+export const sample = ( callback ) => nodeObject( new SampleNode( callback ) );


### PR DESCRIPTION
Related issue: #31287

**Description**

@sunag Rollup complains about a `PURE` annotation in `SampleNode`. It seems putting the annotation right before an inline function has no effect.
```
[ROLLUP] (!) src/nodes/utils/SampleNode.js (81:22): A comment
[ROLLUP] 
[ROLLUP] "/*@__PURE__*/"
[ROLLUP] 
[ROLLUP] in "src/nodes/utils/SampleNode.js" contains an annotation that Rollup cannot interpret due to the position of the comment. The comment will be removed to avoid issues.
```