### PR TITLE
Manual: Fix links to homepage.

### DIFF
--- a/manual/examples/resources/editor.html
+++ b/manual/examples/resources/editor.html
@@ -242,7 +242,7 @@ button:focus {
             <button class="button-fullscreen">&nbsp;</button>
         </div>
         <div class="panelogo">
-          <div><a href="/"><span data-subst="textContent|name"></span>&nbsp;</a><a href="/"><img data-subst="src|icon" width="32" height="32"/></a></div>
+          <div><a href="/" target="_blank"><span data-subst="textContent|name"></span>&nbsp;</a><a href="/" target="_blank"><img data-subst="src|icon" width="32" height="32"/></a></div>
         </div>
     </div>
     <div class="panes">


### PR DESCRIPTION
Related issue: -

**Description**

While verifying #31300, I have noticed that the top-right links from the code editor open the homepage inside the iFrame. I'm referring to the "three.js" title and logo from below screenshot:

<img width="861" alt="image" src="https://github.com/user-attachments/assets/21ef9cf7-b51f-4e0a-8580-6a71ced60b55" />

The PR makes sure to open the links in a new tab.