### PR TITLE
Examples: Clean up.

### DIFF
--- a/examples/webgpu_compute_water.html
+++ b/examples/webgpu_compute_water.html
@@ -277,8 +277,8 @@
  				borderGeom.rotateY( Math.PI * 0.25 );
  				poolBorder = new THREE.Mesh( borderGeom, new THREE.MeshStandardMaterial( { color: 0x908877, roughness: 0.2 } ) );
  				scene.add( poolBorder );
- 				borderGeom.receiveShadow = true;
- 				borderGeom.castShadow = true;
+ 				poolBorder.receiveShadow = true;
+ 				poolBorder.castShadow = true;
 
 				// THREE.Mesh just for mouse raycasting
 				const geometryRay = new THREE.PlaneGeometry( BOUNDS, BOUNDS, 1, 1 );


### PR DESCRIPTION
Related issue: N/A

**Description**

Presumably the `receiveShadow` and `castShadow` properties were meant to be set on the mesh and not the geometry.