### PR TITLE
Renderers: Initial support for `Float16Array`.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -42,7 +42,8 @@
     "esprima": "readonly",
     "jsonlint": "readonly",
     "VideoFrame": "readonly",
-    "VideoDecoder": "readonly"
+    "VideoDecoder": "readonly",
+    "Float16Array": "readonly"
   },
   "rules": {
     "no-throw-literal": [

--- a/examples/webgl_geometry_colors.html
+++ b/examples/webgl_geometry_colors.html
@@ -103,7 +103,8 @@
 				const geometry1 = new THREE.IcosahedronGeometry( radius, 1 );
 
 				const count = geometry1.attributes.position.count;
-				geometry1.setAttribute( 'color', new THREE.BufferAttribute( new Float32Array( count * 3 ), 3 ) );
+				const arrayType = ( typeof Float16Array !== 'undefined' ) ? Float16Array : Float32Array;
+				geometry1.setAttribute( 'color', new THREE.BufferAttribute( new arrayType( count * 3 ), 3 ) );
 
 				const geometry2 = geometry1.clone();
 				const geometry3 = geometry1.clone();

--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -841,8 +841,8 @@ class Uint32BufferAttribute extends BufferAttribute {
  * Convenient class that can be used when creating a `Float16` buffer attribute with
  * a plain `Array` instance.
  *
- * This class automatically converts to and from FP16 since `Float16Array` is not
- * natively supported in JavaScript.
+ * This class automatically converts to and from FP16 via `Uint16Array` since `Float16Array`
+ * browser support is still problematic.
  *
  * @augments BufferAttribute
  */

--- a/src/renderers/webgl-fallback/utils/WebGLAttributeUtils.js
+++ b/src/renderers/webgl-fallback/utils/WebGLAttributeUtils.js
@@ -114,6 +114,10 @@ class WebGLAttributeUtils {
 
 			type = gl.FLOAT;
 
+		} else if ( typeof Float16Array !== 'undefined' && array instanceof Float16Array ) {
+
+			type = gl.HALF_FLOAT;
+
 		} else if ( array instanceof Uint16Array ) {
 
 			if ( attribute.isFloat16BufferAttribute ) {

--- a/src/renderers/webgl/WebGLAttributes.js
+++ b/src/renderers/webgl/WebGLAttributes.js
@@ -21,6 +21,10 @@ function WebGLAttributes( gl ) {
 
 			type = gl.FLOAT;
 
+		} else if ( typeof Float16Array !== 'undefined' && array instanceof Float16Array ) {
+
+			type = gl.HALF_FLOAT;
+
 		} else if ( array instanceof Uint16Array ) {
 
 			if ( attribute.isFloat16BufferAttribute ) {

--- a/src/renderers/webgpu/utils/WebGPUAttributeUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUAttributeUtils.js
@@ -12,6 +12,12 @@ const typedArraysToVertexFormatPrefix = new Map( [
 	[ Float32Array, [ 'float32', ]],
 ] );
 
+if ( typeof Float16Array !== 'undefined' ) {
+
+	typedArraysToVertexFormatPrefix.set( Float16Array, [ 'float16' ] );
+
+}
+
 const typedAttributeToVertexFormatPrefix = new Map( [
 	[ Float16BufferAttribute, [ 'float16', ]],
 ] );


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/20587#issuecomment-2907693780

**Description**

The PR introduces initial support for `Float16Array` as an attribute data type in both renderers.

Since the support for `Float16Array` is still a bit of a problem, we need to guard every usage to avoid runtime errors.

https://caniuse.com/?search=Float16Array

I did not update `Float16BufferAttribute` yet which is still a safe pick for all platforms. Developers who want to use `Float16Array` now should create the array on app level and pass it to `BufferAttribute` ctor like shown in the updated example.