### PR TITLE
Frustum: Honor sprite offset in `intersectsSprite()`.

### DIFF
--- a/src/math/Frustum.js
+++ b/src/math/Frustum.js
@@ -1,9 +1,11 @@
 import { WebGLCoordinateSystem, WebGPUCoordinateSystem } from '../constants.js';
+import { Vector2 } from './Vector2.js';
 import { Vector3 } from './Vector3.js';
 import { Sphere } from './Sphere.js';
 import { Plane } from './Plane.js';
 
 const _sphere = /*@__PURE__*/ new Sphere();
+const _center = /*@__PURE__*/ new Vector2( 0.5, 0.5 );
 const _vector = /*@__PURE__*/ new Vector3();
 
 /**
@@ -161,7 +163,10 @@ class Frustum {
 	intersectsSprite( sprite ) {
 
 		_sphere.center.set( 0, 0, 0 );
-		_sphere.radius = 0.7071067811865476;
+
+		const offset = _center.distanceTo( sprite.center );
+
+		_sphere.radius = 0.7071067811865476 + offset;
 		_sphere.applyMatrix4( sprite.matrixWorld );
 
 		return this.intersectsSphere( _sphere );

--- a/src/math/Frustum.js
+++ b/src/math/Frustum.js
@@ -5,7 +5,7 @@ import { Sphere } from './Sphere.js';
 import { Plane } from './Plane.js';
 
 const _sphere = /*@__PURE__*/ new Sphere();
-const _center = /*@__PURE__*/ new Vector2( 0.5, 0.5 );
+const _defaultSpriteCenter = /*@__PURE__*/ new Vector2( 0.5, 0.5 );
 const _vector = /*@__PURE__*/ new Vector3();
 
 /**
@@ -164,7 +164,7 @@ class Frustum {
 
 		_sphere.center.set( 0, 0, 0 );
 
-		const offset = _center.distanceTo( sprite.center );
+		const offset = _defaultSpriteCenter.distanceTo( sprite.center );
 
 		_sphere.radius = 0.7071067811865476 + offset;
 		_sphere.applyMatrix4( sprite.matrixWorld );


### PR DESCRIPTION
Fixed #24822.

**Description**

I've run into #24822 when changing the center properties of sprites. 

The PR fixes the issue by implementing the approach suggested by @WestLangley in #24828. So the idea is to increase the bounding sphere's radius by an offset derived from the sprite's center.

The implementation does not affect the intersection test for sprites with a default center value.

Below is a live example with the code from the original issue for reproducing the issue. The white quad prematurely disappears when moving it to the left.

https://jsfiddle.net/831pgxnv/
