### PR TITLE
Loaders: Use unique cache keys per loader type.

### DIFF
--- a/src/loaders/FileLoader.js
+++ b/src/loaders/FileLoader.js
@@ -74,7 +74,7 @@ class FileLoader extends Loader {
 
 		url = this.manager.resolveURL( url );
 
-		const cached = Cache.get( url );
+		const cached = Cache.get( `file:${url}` );
 
 		if ( cached !== undefined ) {
 
@@ -263,7 +263,7 @@ class FileLoader extends Loader {
 
 				// Add to cache only on HTTP success, so that we do not cache
 				// error response bodies as proper responses to requests.
-				Cache.add( url, data );
+				Cache.add( `file:${url}`, data );
 
 				const callbacks = loading[ url ];
 				delete loading[ url ];

--- a/src/loaders/ImageBitmapLoader.js
+++ b/src/loaders/ImageBitmapLoader.js
@@ -102,7 +102,7 @@ class ImageBitmapLoader extends Loader {
 
 		const scope = this;
 
-		const cached = Cache.get( url );
+		const cached = Cache.get( `imageBitmap:${url}` );
 
 		if ( cached !== undefined ) {
 
@@ -165,7 +165,7 @@ class ImageBitmapLoader extends Loader {
 
 		} ).then( function ( imageBitmap ) {
 
-			Cache.add( url, imageBitmap );
+			Cache.add( `imageBitmap:${url}`, imageBitmap );
 
 			if ( onLoad ) onLoad( imageBitmap );
 
@@ -179,14 +179,14 @@ class ImageBitmapLoader extends Loader {
 
 			_errorMap.set( promise, e );
 
-			Cache.remove( url );
+			Cache.remove( `imageBitmap:${url}` );
 
 			scope.manager.itemError( url );
 			scope.manager.itemEnd( url );
 
 		} );
 
-		Cache.add( url, promise );
+		Cache.add( `imageBitmap:${url}`, promise );
 		scope.manager.itemStart( url );
 
 	}

--- a/src/loaders/ImageLoader.js
+++ b/src/loaders/ImageLoader.js
@@ -50,7 +50,7 @@ class ImageLoader extends Loader {
 
 		const scope = this;
 
-		const cached = Cache.get( url );
+		const cached = Cache.get( `image:${url}` );
 
 		if ( cached !== undefined ) {
 
@@ -116,7 +116,7 @@ class ImageLoader extends Loader {
 
 			if ( onError ) onError( event );
 
-			Cache.remove( url );
+			Cache.remove( `image:${url}` );
 
 			//
 
@@ -153,7 +153,7 @@ class ImageLoader extends Loader {
 
 		}
 
-		Cache.add( url, image );
+		Cache.add( `image:${url}`, image );
 		scope.manager.itemStart( url );
 
 		image.src = url;

--- a/test/e2e/puppeteer.js
+++ b/test/e2e/puppeteer.js
@@ -111,6 +111,8 @@ const exceptionList = [
 	'webgpu_multisampled_renderbuffers',
 	'webgl_test_wide_gamut',
 	'webgl_volume_instancing',
+	'webgl_buffergeometry_attributes_integer',
+	'webgl_batch_lod_bvh',
 
 	// Intentional z-fighting in this demo makes it non-deterministic
 	'webgl_reverse_depth_buffer',


### PR DESCRIPTION
Fixed #27301.

**Description**

`THREE.Cache` is currently used by three core loaders: `FileLoader`, `ImageLoader` and `ImageBitmapLoader`.

Since the cache is global, loaders potentially share cache entries if the same URL is loaded by different loaders. Granted, that is an edge case but the OP of #27301 described a potential use case in https://github.com/mrdoob/three.js/issues/27301#issuecomment-1838326715.

And since the cached results are incompatible between loaders anyway, it makes sense like described in https://github.com/mrdoob/three.js/issues/27301#issuecomment-1838387554 to make the cache entries unique per loader. This is done by adding an additional loader-specific key part to the actual cache key.