### PR TITLE
ExtrudeGeometry: Deprecated options.UVGenerator

### DIFF
--- a/src/geometries/ExtrudeGeometry.js
+++ b/src/geometries/ExtrudeGeometry.js
@@ -5,6 +5,7 @@ import { Vector2 } from '../math/Vector2.js';
 import { Vector3 } from '../math/Vector3.js';
 import { Shape } from '../extras/core/Shape.js';
 import { ShapeUtils } from '../extras/ShapeUtils.js';
+import { warnOnce } from '../utils.js';
 
 /**
  * Creates extruded geometry from a path shape.
@@ -95,6 +96,13 @@ class ExtrudeGeometry extends BufferGeometry {
 			const extrudePath = options.extrudePath;
 
 			const uvgen = options.UVGenerator !== undefined ? options.UVGenerator : WorldUVGenerator;
+
+			if ( options.UVGenerator !== undefined ) {
+
+				// @deprecated, r178
+				warnOnce( 'THREE.ExtrudeGeometry: The UVGenerator option is deprecated.' );
+
+			}
 
 			//
 

--- a/src/geometries/ExtrudeGeometry.js
+++ b/src/geometries/ExtrudeGeometry.js
@@ -97,8 +97,8 @@ class ExtrudeGeometry extends BufferGeometry {
 
 			if ( options.UVGenerator !== undefined ) {
 
-				// @deprecated, r178
-				warnOnce( 'THREE.ExtrudeGeometry: The UVGenerator option has been deprecated and will be removed in r188.' );
+				// @deprecated, r179
+				warnOnce( 'THREE.ExtrudeGeometry: The UVGenerator option has been deprecated and will be removed in r189.' );
 
 			}
 

--- a/src/geometries/ExtrudeGeometry.js
+++ b/src/geometries/ExtrudeGeometry.js
@@ -95,14 +95,14 @@ class ExtrudeGeometry extends BufferGeometry {
 
 			const extrudePath = options.extrudePath;
 
-			const uvgen = options.UVGenerator !== undefined ? options.UVGenerator : WorldUVGenerator;
-
 			if ( options.UVGenerator !== undefined ) {
 
 				// @deprecated, r178
-				warnOnce( 'THREE.ExtrudeGeometry: The UVGenerator option is deprecated.' );
+				warnOnce( 'THREE.ExtrudeGeometry: The UVGenerator option has been deprecated and will be removed in r188.' );
 
 			}
+
+			const uvgen = options.UVGenerator !== undefined ? options.UVGenerator : WorldUVGenerator;
 
 			//
 

--- a/src/geometries/ExtrudeGeometry.js
+++ b/src/geometries/ExtrudeGeometry.js
@@ -97,8 +97,8 @@ class ExtrudeGeometry extends BufferGeometry {
 
 			if ( options.UVGenerator !== undefined ) {
 
-				// @deprecated, r179
-				warnOnce( 'THREE.ExtrudeGeometry: The UVGenerator option has been deprecated and will be removed in r189.' );
+				// @deprecated, r178
+				warnOnce( 'THREE.ExtrudeGeometry: The UVGenerator option has been deprecated and will be removed in r188.' );
 
 			}
 


### PR DESCRIPTION
Related issuecomment: https://github.com/mrdoob/three.js/issues/31312#issuecomment-3007673211

**Description**

As the title says.
