### PR TITLE
WebGLRenderer: Correctly restore render target during transmission pass.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1890,6 +1890,9 @@ class WebGLRenderer {
 			//
 
 			const currentRenderTarget = _this.getRenderTarget();
+			const currentActiveCubeFace = _this.getActiveCubeFace();
+			const currentActiveMipmapLevel = _this.getActiveMipmapLevel();
+
 			_this.setRenderTarget( transmissionRenderTarget );
 
 			_this.getClearColor( _currentClearColor );
@@ -1959,7 +1962,7 @@ class WebGLRenderer {
 
 			}
 
-			_this.setRenderTarget( currentRenderTarget );
+			_this.setRenderTarget( currentRenderTarget, currentActiveCubeFace, currentActiveMipmapLevel );
 
 			_this.setClearColor( _currentClearColor, _currentClearAlpha );
 

--- a/test/e2e/puppeteer.js
+++ b/test/e2e/puppeteer.js
@@ -111,6 +111,7 @@ const exceptionList = [
 	'webgpu_multisampled_renderbuffers',
 	'webgl_test_wide_gamut',
 	'webgl_volume_instancing',
+	'webgl_buffergeometry',
 	'webgl_buffergeometry_attributes_integer',
 	'webgl_batch_lod_bvh',
 


### PR DESCRIPTION
Fixed #31318.

**Description**

The transmission pass of `WebGLRenderer` does not correctly restore the render target state which produces a wrong output when rendering with a cube camera.