### PR TITLE
WebGPURenderer: Restore `isSampledTexture3D` binding check

### DIFF
--- a/src/renderers/common/nodes/NodeSampledTexture.js
+++ b/src/renderers/common/nodes/NodeSampledTexture.js
@@ -143,7 +143,7 @@ class NodeSampledTexture3D extends NodeSampledTexture {
 		 * @readonly
 		 * @default true
 		 */
-		this.is3DTexture = true;
+		this.isSampledTexture3D = true;
 
 	}
 

--- a/src/renderers/webgpu/utils/WebGPUBindingUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUBindingUtils.js
@@ -216,7 +216,7 @@ class WebGPUBindingUtils {
 
 					texture.viewDimension = GPUTextureViewDimension.TwoDArray;
 
-				} else if ( binding.texture.is3DTexture ) {
+				} else if ( binding.isSampledTexture3D ) {
 
 					texture.viewDimension = GPUTextureViewDimension.ThreeD;
 
@@ -438,7 +438,7 @@ class WebGPUBindingUtils {
 
 							dimensionViewGPU = GPUTextureViewDimension.Cube;
 
-						} else if ( binding.texture.is3DTexture ) {
+						} else if ( binding.isSampledTexture3D ) {
 
 							dimensionViewGPU = GPUTextureViewDimension.ThreeD;
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/31175

**Description**

Restore `isSampledTexture3D` binding check and fix `webgpu_postprocessing_3dlut` example and `Data3DTexture`.