### PR TITLE
TSLCore: Use `node.nodeType` instead of `safeGetNodeType()`

### DIFF
--- a/src/nodes/tsl/TSLCore.js
+++ b/src/nodes/tsl/TSLCore.js
@@ -554,20 +554,6 @@ const getConstNode = ( value, type ) => {
 
 };
 
-const safeGetNodeType = ( node ) => {
-
-	try {
-
-		return node.getNodeType();
-
-	} catch ( _ ) {
-
-		return undefined;
-
-	}
-
-};
-
 const ConvertType = function ( type, cacheMap = null ) {
 
 	return ( ...params ) => {
@@ -587,7 +573,7 @@ const ConvertType = function ( type, cacheMap = null ) {
 		if ( params.length === 1 ) {
 
 			const node = getConstNode( params[ 0 ], type );
-			if ( safeGetNodeType( node ) === type ) return nodeObject( node );
+			if ( node.nodeType === type ) return nodeObject( node );
 			return nodeObject( new ConvertNode( node, type ) );
 
 		}


### PR DESCRIPTION
Fixes https://github.com/mrdoob/three.js/issues/31306

**Description**

The method was more necessary when we didn't have a more robust flow control like we have in `NodeBuilder`, we can replace it with fixed typing, as used in `node.nodeType`.
