### PR TITLE
Editor: Fix crash when geometry lacks position attribute.

### DIFF
--- a/editor/js/Viewport.Info.js
+++ b/editor/js/Viewport.Info.js
@@ -60,8 +60,14 @@ function ViewportInfo( editor ) {
 				if ( object.isMesh || object.isPoints ) {
 
 					const geometry = object.geometry;
+					const positionAttr = geometry.attributes.position;
 
-					vertices += geometry.attributes.position.count;
+					// Safely accumulate vertices only if a position attribute exists
+					if ( positionAttr !== undefined ) {
+
+						vertices += positionAttr.count;
+
+					}
 
 					if ( object.isMesh ) {
 
@@ -69,9 +75,9 @@ function ViewportInfo( editor ) {
 
 							triangles += geometry.index.count / 3;
 
-						} else {
+						} else if ( positionAttr !== undefined ) {
 
-							triangles += geometry.attributes.position.count / 3;
+							triangles += positionAttr.count / 3;
 
 						}
 

--- a/editor/js/Viewport.Info.js
+++ b/editor/js/Viewport.Info.js
@@ -60,12 +60,13 @@ function ViewportInfo( editor ) {
 				if ( object.isMesh || object.isPoints ) {
 
 					const geometry = object.geometry;
-					const positionAttr = geometry.attributes.position;
+					const positionAttribute = geometry.attributes.position;
 
-					// Safely accumulate vertices only if a position attribute exists
-					if ( positionAttr !== undefined ) {
+					// update counts only if vertex data are defined
 
-						vertices += positionAttr.count;
+					if ( positionAttribute !== undefined && positionAttribute !== null ) {
+
+						vertices += positionAttribute.count;
 
 					}
 
@@ -75,9 +76,9 @@ function ViewportInfo( editor ) {
 
 							triangles += geometry.index.count / 3;
 
-						} else if ( positionAttr !== undefined ) {
+						} else if ( positionAttribute !== undefined && positionAttribute !== null ) {
 
-							triangles += positionAttr.count / 3;
+							triangles += positionAttribute.count / 3;
 
 						}
 


### PR DESCRIPTION
This patch prevents a runtime error in Viewport.Info.js that occurs when importing a GLB file containing geometries without a position attribute. Previously, the code assumed all geometries had a position, leading to:

Viewport.Info.js:64 Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'count')
    at Viewport.Info.js:64:47
    at Mesh.traverseVisible (three.core.js:14211:3)
    at Object3D.traverseVisible (three.core.js:14217:18)
    at Group.traverseVisible (three.core.js:14217:18)
    at update (Viewport.Info.js:56:11)
    at h.execute (signals.min.js:9:20)
    at e.dispatch (signals.min.js:13:106)
    at e.dispatch (signals.min.js:8:368)
    at Editor.addObject (Editor.js:194:28)
    at AddObjectCommand.execute (AddObjectCommand.js:29:15)

Such cases are valid in glTF and occur with point clouds, line geometries, or custom data-only meshes.

Fixes included:

Introduced a null check before accessing geometry.attributes.position.

Ensured vertex and triangle counts are calculated only if position is defined.

Used a local positionAttr variable consistently to avoid repeated access.

This change improves Editor robustness by allowing valid, non-standard GLB files to load without crashing, and maintains accurate scene statistics when available.
