### PR TITLE
Sort by updated time feature for examples page

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -25,9 +25,14 @@
 				<input placeholder="" type="text" id="filterInput" autocorrect="off" autocapitalize="off"
 					spellcheck="false" />
 				<div id="sortControls">
-					<span class="sort-label">Sort:</span>
-					<button id="sortAsc" title="Sort by oldest modified">▲</button>
-					<button id="sortDesc" title="Sort by newest modified">▼</button>
+					<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="currentColor">
+						<path d="M3 18h6v-2H3v2zM3 6v2h18V6H3zm0 7h12v-2H3v2z"/>
+					</svg>
+					<select id="sort-by">
+						<option value="added">date created</option>
+						<option value="name">alphabetical</option>
+					</select>
+					<button id="sort-order" title="Sort Descending">▼</button>
 				</div>
 				<div id="clearSearchButton"></div>
 			</div>
@@ -48,8 +53,8 @@
 		const viewSrcButton = document.getElementById( 'button' );
 		const panelScrim = document.getElementById( 'panelScrim' );
 		const previewsToggler = document.getElementById( 'previewsToggler' );
-		const sortAscButton = document.getElementById( 'sortAsc' );
-		const sortDescButton = document.getElementById( 'sortDesc' );
+		const sortBySelect = document.getElementById( 'sort-by' );
+		const sortOrderButton = document.getElementById( 'sort-order' );
 		const links = {};
 		const validRedirects = new Map();
 		const fragment = document.createDocumentFragment();
@@ -133,6 +138,8 @@
 
 			};
 
+
+
 			filterInput.addEventListener( 'input', function () {
 
 				updateFilter( files, tags );
@@ -158,8 +165,15 @@
 
 			};
 
-			sortAscButton.onclick = () => sortCards( 'asc' );
-			sortDescButton.onclick = () => sortCards( 'desc' );
+			sortBySelect.onchange = () => sortCards();
+			sortOrderButton.onclick = () => {
+
+				sortOrderButton.textContent = sortOrderButton.textContent === '▲' ? '▼' : '▲';
+				sortOrderButton.title = sortOrderButton.textContent === '▲' ? 'sort ascending' : 'sort descending';
+				sortCards();
+
+			};
+
 			if ( /(iPad|iPhone|iPod)/g.test( navigator.userAgent ) ) {
 
 				viewer.style.width = getComputedStyle( viewer ).width;
@@ -167,7 +181,9 @@
 				viewer.setAttribute( 'scrolling', 'no' );
 
 			}
-		
+
+			sortCards();
+
 		}
 
 		function timeAgo( date ) {
@@ -184,21 +200,21 @@
 			interval = seconds / 60;
 			if ( interval > 1 ) return Math.floor( interval ) + ( Math.floor( interval ) === 1 ? ' minute ago' : ' minutes ago' );
 			return 'just now';
-		
+
 		}
 
 		function createLink( file, tags, timestamp ) {
 
 			const external = Array.isArray( tags ) && tags.includes( 'external' ) ? ' <span class="tag">external</span>' : '';
-			const modified = timestamp ? timestamp.modified : 0;
-			const date = new Date( modified * 1000 );
+			const created = timestamp ? timestamp.created : 0;
+			const date = new Date( created * 1000 );
 			const template = `
-				<div class="card" data-modified="${modified}">
+				<div class="card" data-created="${created}" data-name="${file}">
 					<a href="${file}.html" target="viewer">
 						<div class="cover">
 							<img src="screenshots/${file}.jpg" loading="lazy" width="400" />
 						</div>
-						<div class="title">${getName( file )}${external}${modified ? ` / <span class="date-info"><i>${timeAgo( date )}</i></span>` : ''}</div>
+						<div class="title">${getName( file )}${external}${created ? ` <span class="date-info"><i>${timeAgo( date )}</i></span>` : ''}</div>
 					</a>
 				</div>
 			`;
@@ -210,7 +226,7 @@
 
 			} );
 			return link;
-		
+
 		}
 
 		function selectFile( file ) {
@@ -225,15 +241,17 @@
 			viewSrcButton.style.display = '';
 			viewSrcButton.href = 'https://github.com/mrdoob/three.js/blob/master/examples/' + selected + '.html';
 			viewSrcButton.title = 'View source code for ' + getName( selected ) + ' on GitHub';
-		
+
 		}
 
 		function escapeRegExp( string ) {
 
 			string = string.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' );
 			return '(?=.*' + string.split( ' ' ).join( ')(?=.*' ) + ')';
-		
+
 		}
+
+
 
 		function updateFilter( files, tags ) {
 
@@ -262,7 +280,8 @@
 			}
 
 			layoutList( files );
-		
+			sortCards();
+
 		}
 
 		function filterExample( file, exp, tags ) {
@@ -279,7 +298,7 @@
 				link.classList.add( 'hidden' );
 
 			}
-		
+
 		}
 
 		function getName( file ) {
@@ -287,7 +306,7 @@
 			const name = file.split( '_' );
 			name.shift();
 			return name.join( ' / ' );
-		
+
 		}
 
 		function layoutList( files ) {
@@ -324,11 +343,13 @@
 				}
 
 			}
-		
+
 		}
 
-		function sortCards( direction ) {
+		function sortCards() {
 
+			const sortBy = sortBySelect.value;
+			const direction = sortOrderButton.textContent === '▲' ? 'asc' : 'desc';
 			const headers = content.querySelectorAll( 'h2' );
 			headers.forEach( header => {
 
@@ -348,9 +369,22 @@
 
 				categoryCards.sort( ( a, b ) => {
 
-					const aDate = Number( a.dataset.modified );
-					const bDate = Number( b.dataset.modified );
-					return direction === 'asc' ? aDate - bDate : bDate - aDate;
+					const valA = ( sortBy === 'name' ) ? a.dataset.name : Number( a.dataset.created );
+					const valB = ( sortBy === 'name' ) ? b.dataset.name : Number( b.dataset.created );
+
+					if ( valA < valB ) {
+
+						return direction === 'asc' ? - 1 : 1;
+
+					}
+
+					if ( valA > valB ) {
+
+						return direction === 'asc' ? 1 : - 1;
+
+					}
+
+					return 0;
 
 				} );
 				const fragment = document.createDocumentFragment();
@@ -358,7 +392,7 @@
 				header.parentNode.insertBefore( fragment, header.nextSibling );
 
 			} );
-		
+
 		}
 
 		function extractQuery() {
@@ -371,7 +405,7 @@
 			}
 
 			return '';
-		
+
 		}
 
 		function createElementFromHTML( htmlString ) {
@@ -379,7 +413,7 @@
 			const div = document.createElement( 'div' );
 			div.innerHTML = htmlString.trim();
 			return div.firstChild;
-		
+
 		}
 	</script>
 	<template id="PlaceholderHTML">

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,49 +1,44 @@
 <!DOCTYPE html>
 <html lang="en">
-	<head>
-		<meta charset="utf-8">
-		<title>three.js examples</title>
-		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
-		<link rel="shortcut icon" href="../files/favicon_white.ico" media="(prefers-color-scheme: dark)"/>
-		<link rel="shortcut icon" href="../files/favicon.ico" media="(prefers-color-scheme: light)" />
-		<link rel="stylesheet" type="text/css" href="../files/main.css">
-	</head>
-	<body>
 
-		<div id="panel">
+<head>
+	<meta charset="utf-8">
+	<title>three.js examples</title>
+	<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+	<link rel="shortcut icon" href="../files/favicon_white.ico" media="(prefers-color-scheme: dark)" />
+	<link rel="shortcut icon" href="../files/favicon.ico" media="(prefers-color-scheme: light)" />
+	<link rel="stylesheet" type="text/css" href="../files/main.css">
+</head>
 
-			<div id="header">
-				<h1><a href="https://threejs.org">three.js</a></h1>
-
-				<div id="sections">
-					<span class="selected">examples</span>
-				</div>
-
-				<div id="expandButton"></div>
+<body>
+	<div id="panel">
+		<div id="header">
+			<h1><a href="https://threejs.org">three.js</a></h1>
+			<div id="sections">
+				<span class="selected">examples</span>
 			</div>
-
-			<div id="panelScrim"></div>
-
-			<div id="contentWrapper">
-
-				<div id="inputWrapper">
-					<input placeholder="" type="text" id="filterInput" autocorrect="off" autocapitalize="off" spellcheck="false" />
-					<div id="clearSearchButton"></div>
-				</div>
-
-				<div id="content">
-					<img id="previewsToggler" src="./files/thumbnails.svg" width="20" height="20" />
-				</div>
-			</div>
-
+			<div id="expandButton"></div>
 		</div>
-
-		<iframe id="viewer" name="viewer" allow="fullscreen; xr-spatial-tracking;"></iframe>
-
-		<a id="button" target="_blank"><img src="../files/ic_code_black_24dp.svg"></a>
-
-		<script>
-
+		<div id="panelScrim"></div>
+		<div id="contentWrapper">
+			<div id="inputWrapper">
+				<input placeholder="" type="text" id="filterInput" autocorrect="off" autocapitalize="off"
+					spellcheck="false" />
+				<div id="sortControls">
+					<span class="sort-label">Sort:</span>
+					<button id="sortAsc" title="Sort by oldest modified">▲</button>
+					<button id="sortDesc" title="Sort by newest modified">▼</button>
+				</div>
+				<div id="clearSearchButton"></div>
+			</div>
+			<div id="content">
+				<img id="previewsToggler" src="./files/thumbnails.svg" width="20" height="20" />
+			</div>
+		</div>
+	</div>
+	<iframe id="viewer" name="viewer" allow="fullscreen; xr-spatial-tracking;"></iframe>
+	<a id="button" target="_blank"><img src="../files/ic_code_black_24dp.svg"></a>
+	<script>
 		const panel = document.getElementById( 'panel' );
 		const content = document.getElementById( 'content' );
 		const viewer = document.getElementById( 'viewer' );
@@ -53,38 +48,31 @@
 		const viewSrcButton = document.getElementById( 'button' );
 		const panelScrim = document.getElementById( 'panelScrim' );
 		const previewsToggler = document.getElementById( 'previewsToggler' );
-
+		const sortAscButton = document.getElementById( 'sortAsc' );
+		const sortDescButton = document.getElementById( 'sortDesc' );
 		const links = {};
 		const validRedirects = new Map();
 		const fragment = document.createDocumentFragment();
-
 		let selected = null;
-
 		init();
-
 		async function init() {
 
 			viewSrcButton.style.display = 'none';
-
 			const files = await ( await fetch( 'files.json' ) ).json();
 			const tags = await ( await fetch( 'tags.json' ) ).json();
-
+			const timestamps = await ( await fetch( 'timestamps.json' ) ).json();
 			for ( const key in files ) {
 
 				const category = files[ key ];
-
 				const header = document.createElement( 'h2' );
 				header.textContent = key;
 				header.setAttribute( 'data-category', key );
 				fragment.appendChild( header );
-
 				for ( let i = 0; i < category.length; i ++ ) {
 
 					const file = category[ i ];
-
-					const link = createLink( file, tags[ file ] );
+					const link = createLink( file, tags[ file ], timestamps[ file ] );
 					fragment.appendChild( link );
-
 					links[ file ] = link;
 					validRedirects.set( file, file + '.html' );
 
@@ -93,13 +81,9 @@
 			}
 
 			content.appendChild( fragment );
-
 			if ( window.location.hash !== '' ) {
 
 				const file = window.location.hash.substring( 1 );
-
-				// use a predefined map of redirects to avoid untrusted URL redirection due to user-provided value
-
 				if ( validRedirects.has( file ) === true ) {
 
 					selectFile( file );
@@ -118,24 +102,20 @@
 			}
 
 			filterInput.value = extractQuery();
-
 			if ( filterInput.value !== '' ) {
 
 				panel.classList.add( 'searchFocused' );
-
 				updateFilter( files, tags );
 
 			}
 
-			// Events
-
-			filterInput.onfocus = function ( ) {
+			filterInput.onfocus = function () {
 
 				panel.classList.add( 'searchFocused' );
 
 			};
 
-			filterInput.onblur = function ( ) {
+			filterInput.onblur = function () {
 
 				if ( filterInput.value === '' ) {
 
@@ -145,7 +125,7 @@
 
 			};
 
-			clearSearchButton.onclick = function ( ) {
+			clearSearchButton.onclick = function () {
 
 				filterInput.value = '';
 				updateFilter( files, tags );
@@ -158,15 +138,12 @@
 				updateFilter( files, tags );
 
 			} );
-
-
 			expandButton.addEventListener( 'click', function ( event ) {
 
 				event.preventDefault();
 				panel.classList.toggle( 'open' );
 
 			} );
-
 			panelScrim.onclick = function ( event ) {
 
 				event.preventDefault();
@@ -181,8 +158,8 @@
 
 			};
 
-			// iOS iframe auto-resize workaround
-
+			sortAscButton.onclick = () => sortCards( 'asc' );
+			sortDescButton.onclick = () => sortCards( 'desc' );
 			if ( /(iPad|iPhone|iPod)/g.test( navigator.userAgent ) ) {
 
 				viewer.style.width = getComputedStyle( viewer ).width;
@@ -190,72 +167,78 @@
 				viewer.setAttribute( 'scrolling', 'no' );
 
 			}
-
+		
 		}
 
-		function createLink( file, tags ) {
+		function timeAgo( date ) {
+
+			const seconds = Math.floor( ( new Date() - date ) / 1000 );
+			let interval = seconds / 31536000;
+			if ( interval > 1 ) return Math.floor( interval ) + ( Math.floor( interval ) === 1 ? ' year ago' : ' years ago' );
+			interval = seconds / 2592000;
+			if ( interval > 1 ) return Math.floor( interval ) + ( Math.floor( interval ) === 1 ? ' month ago' : ' months ago' );
+			interval = seconds / 86400;
+			if ( interval > 1 ) return Math.floor( interval ) + ( Math.floor( interval ) === 1 ? ' day ago' : ' days ago' );
+			interval = seconds / 3600;
+			if ( interval > 1 ) return Math.floor( interval ) + ( Math.floor( interval ) === 1 ? ' hour ago' : ' hours ago' );
+			interval = seconds / 60;
+			if ( interval > 1 ) return Math.floor( interval ) + ( Math.floor( interval ) === 1 ? ' minute ago' : ' minutes ago' );
+			return 'just now';
+		
+		}
+
+		function createLink( file, tags, timestamp ) {
 
 			const external = Array.isArray( tags ) && tags.includes( 'external' ) ? ' <span class="tag">external</span>' : '';
-
+			const modified = timestamp ? timestamp.modified : 0;
+			const date = new Date( modified * 1000 );
 			const template = `
-				<div class="card">
-					<a href="${ file }.html" target="viewer">
+				<div class="card" data-modified="${modified}">
+					<a href="${file}.html" target="viewer">
 						<div class="cover">
-							<img src="screenshots/${ file }.jpg" loading="lazy" width="400" />
+							<img src="screenshots/${file}.jpg" loading="lazy" width="400" />
 						</div>
-						<div class="title">${ getName( file ) }${ external }</div>
+						<div class="title">${getName( file )}${external}${modified ? ` / <span class="date-info"><i>${timeAgo( date )}</i></span>` : ''}</div>
 					</a>
 				</div>
 			`;
-
 			const link = createElementFromHTML( template );
-
 			link.querySelector( 'a[target="viewer"]' ).addEventListener( 'click', function ( event ) {
 
 				if ( event.button !== 0 || event.ctrlKey || event.altKey || event.metaKey ) return;
-
 				selectFile( file );
 
 			} );
-
 			return link;
-
+		
 		}
 
 		function selectFile( file ) {
 
 			if ( selected !== null ) links[ selected ].classList.remove( 'selected' );
-
 			links[ file ].classList.add( 'selected' );
-
 			window.location.hash = file;
 			viewer.focus();
 			viewer.style.display = 'unset';
-
 			panel.classList.remove( 'open' );
-
 			selected = file;
-
-			// Reveal "View source" button and set attributes to this example
 			viewSrcButton.style.display = '';
 			viewSrcButton.href = 'https://github.com/mrdoob/three.js/blob/master/examples/' + selected + '.html';
 			viewSrcButton.title = 'View source code for ' + getName( selected ) + ' on GitHub';
-
+		
 		}
 
 		function escapeRegExp( string ) {
 
-			string = string.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' ); // https://stackoverflow.com/a/6969486/5250847
-
-			return '(?=.*' + string.split( ' ' ).join( ')(?=.*' ) + ')'; // match all words, in any order
-
+			string = string.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' );
+			return '(?=.*' + string.split( ' ' ).join( ')(?=.*' ) + ')';
+		
 		}
 
 		function updateFilter( files, tags ) {
 
 			let v = filterInput.value.trim();
-			v = v.replace( /\s+/gi, ' ' ); // replace multiple whitespaces with a single one
-
+			v = v.replace( /\s+/gi, ' ' );
 			if ( v !== '' ) {
 
 				window.history.replaceState( {}, '', '?q=' + v + window.location.hash );
@@ -267,11 +250,9 @@
 			}
 
 			const exp = new RegExp( escapeRegExp( v ), 'gi' );
-
 			for ( const key in files ) {
 
 				const section = files[ key ];
-
 				for ( let i = 0; i < section.length; i ++ ) {
 
 					filterExample( section[ i ], exp, tags );
@@ -281,7 +262,7 @@
 			}
 
 			layoutList( files );
-
+		
 		}
 
 		function filterExample( file, exp, tags ) {
@@ -289,7 +270,6 @@
 			const link = links[ file ];
 			if ( file in tags ) file += ' ' + tags[ file ].join( ' ' );
 			const res = file.replace( /_+/g, ' ' ).match( exp );
-
 			if ( res && res.length > 0 ) {
 
 				link.classList.remove( 'hidden' );
@@ -299,7 +279,7 @@
 				link.classList.add( 'hidden' );
 
 			}
-
+		
 		}
 
 		function getName( file ) {
@@ -307,7 +287,7 @@
 			const name = file.split( '_' );
 			name.shift();
 			return name.join( ' / ' );
-
+		
 		}
 
 		function layoutList( files ) {
@@ -315,13 +295,10 @@
 			for ( const key in files ) {
 
 				let collapsed = true;
-
 				const section = files[ key ];
-
 				for ( let i = 0; i < section.length; i ++ ) {
 
 					const file = section[ i ];
-
 					if ( links[ file ].classList.contains( 'hidden' ) === false ) {
 
 						collapsed = false;
@@ -332,25 +309,61 @@
 				}
 
 				const element = document.querySelector( 'h2[data-category="' + key + '"]' );
+				if ( element ) {
 
-				if ( collapsed ) {
+					if ( collapsed ) {
 
-					element.classList.add( 'hidden' );
+						element.classList.add( 'hidden' );
 
-				} else {
+					} else {
 
-					element.classList.remove( 'hidden' );
+						element.classList.remove( 'hidden' );
+
+					}
 
 				}
 
 			}
+		
+		}
 
+		function sortCards( direction ) {
+
+			const headers = content.querySelectorAll( 'h2' );
+			headers.forEach( header => {
+
+				const categoryCards = [];
+				let sibling = header.nextElementSibling;
+				while ( sibling && ! sibling.matches( 'h2' ) ) {
+
+					if ( sibling.classList.contains( 'card' ) && ! sibling.classList.contains( 'hidden' ) ) {
+
+						categoryCards.push( sibling );
+
+					}
+
+					sibling = sibling.nextElementSibling;
+
+				}
+
+				categoryCards.sort( ( a, b ) => {
+
+					const aDate = Number( a.dataset.modified );
+					const bDate = Number( b.dataset.modified );
+					return direction === 'asc' ? aDate - bDate : bDate - aDate;
+
+				} );
+				const fragment = document.createDocumentFragment();
+				categoryCards.forEach( card => fragment.appendChild( card ) );
+				header.parentNode.insertBefore( fragment, header.nextSibling );
+
+			} );
+		
 		}
 
 		function extractQuery() {
 
 			const search = window.location.search;
-
 			if ( search.indexOf( '?q=' ) !== - 1 ) {
 
 				return decodeURI( search.slice( 3 ) );
@@ -358,7 +371,7 @@
 			}
 
 			return '';
-
+		
 		}
 
 		function createElementFromHTML( htmlString ) {
@@ -366,35 +379,40 @@
 			const div = document.createElement( 'div' );
 			div.innerHTML = htmlString.trim();
 			return div.firstChild;
-
+		
 		}
+	</script>
+	<template id="PlaceholderHTML">
+		<!DOCTYPE html>
+		<html lang="en">
 
-		</script>
-		<template id="PlaceholderHTML">
-			<!DOCTYPE html>
-				<html lang="en">
-					<head>
-						<meta charset="utf-8">
-						<title>three.js examples</title>
-						<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
-						<link rel="stylesheet" type="text/css" href="../files/main.css">
-						<style>
-						html, body {
-							height: 100%;
-						}
-						body {
-							height: 100%;
-							display: flex;
-							align-items: center;
-							justify-content: center;
-							user-select: none;
-						}
-						</style>
-					</head>
-					<body>
-						Select an example from the sidebar
-					</body>
-				</html>
-		</template>
-	</body>
+		<head>
+			<meta charset="utf-8">
+			<title>three.js examples</title>
+			<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+			<link rel="stylesheet" type="text/css" href="../files/main.css">
+			<style>
+				html,
+				body {
+					height: 100%;
+				}
+
+				body {
+					height: 100%;
+					display: flex;
+					align-items: center;
+					justify-content: center;
+					user-select: none;
+				}
+			</style>
+		</head>
+
+		<body>
+			Select an example from the sidebar
+		</body>
+
+		</html>
+	</template>
+</body>
+
 </html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -25,14 +25,11 @@
 				<input placeholder="" type="text" id="filterInput" autocorrect="off" autocapitalize="off"
 					spellcheck="false" />
 				<div id="sortControls">
-					<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="currentColor">
-						<path d="M3 18h6v-2H3v2zM3 6v2h18V6H3zm0 7h12v-2H3v2z"/>
-					</svg>
 					<select id="sort-by">
 						<option value="added">date created</option>
 						<option value="name">alphabetical</option>
 					</select>
-					<button id="sort-order" title="Sort Descending">▼</button>
+					<button id="sort-order" data-order="desc" title="Sort Descending"></button>
 				</div>
 				<div id="clearSearchButton"></div>
 			</div>
@@ -55,6 +52,8 @@
 		const previewsToggler = document.getElementById( 'previewsToggler' );
 		const sortBySelect = document.getElementById( 'sort-by' );
 		const sortOrderButton = document.getElementById( 'sort-order' );
+		const sortAscSVG = '<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 26 26" width="24px" fill="currentColor"><path d="M3 18h6v-2H3v2zM3 6v2h18V6H3zm0 7h12v-2H3v2z"/></svg>';
+		const sortDescSVG = '<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 26 26" width="24px" fill="currentColor"><path d="M3 6v2h6V6H3zm0 5v2h12v-2H3zm0 5v2h18v-2H3z"/></svg>';
 		const links = {};
 		const validRedirects = new Map();
 		const fragment = document.createDocumentFragment();
@@ -63,6 +62,7 @@
 		async function init() {
 
 			viewSrcButton.style.display = 'none';
+			sortOrderButton.innerHTML = sortDescSVG;
 			const files = await ( await fetch( 'files.json' ) ).json();
 			const tags = await ( await fetch( 'tags.json' ) ).json();
 			const timestamps = await ( await fetch( 'timestamps.json' ) ).json();
@@ -168,8 +168,21 @@
 			sortBySelect.onchange = () => sortCards();
 			sortOrderButton.onclick = () => {
 
-				sortOrderButton.textContent = sortOrderButton.textContent === '▲' ? '▼' : '▲';
-				sortOrderButton.title = sortOrderButton.textContent === '▲' ? 'sort ascending' : 'sort descending';
+				const currentOrder = sortOrderButton.dataset.order;
+				if ( currentOrder === 'desc' ) {
+
+					sortOrderButton.dataset.order = 'asc';
+					sortOrderButton.innerHTML = sortAscSVG;
+					sortOrderButton.title = 'Sort Ascending';
+
+				} else {
+
+					sortOrderButton.dataset.order = 'desc';
+					sortOrderButton.innerHTML = sortDescSVG;
+					sortOrderButton.title = 'Sort Descending';
+
+				}
+
 				sortCards();
 
 			};
@@ -349,7 +362,7 @@
 		function sortCards() {
 
 			const sortBy = sortBySelect.value;
-			const direction = sortOrderButton.textContent === '▲' ? 'asc' : 'desc';
+			const direction = sortOrderButton.dataset.order;
 			const headers = content.querySelectorAll( 'h2' );
 			headers.forEach( header => {
 

--- a/examples/timestamps.json
+++ b/examples/timestamps.json
@@ -2105,7 +2105,7 @@
   },
   "index": {
     "created": 1376605063,
-    "modified": 1743140653
+    "modified": 1751301392
   },
   "games_fps": {
     "created": 1607163868,

--- a/examples/timestamps.json
+++ b/examples/timestamps.json
@@ -1,0 +1,2142 @@
+{
+  "webxr_xr_sculpt": {
+    "created": 1472231248,
+    "modified": 1714645250
+  },
+  "webxr_xr_paint": {
+    "created": 1472231248,
+    "modified": 1714645250
+  },
+  "webxr_xr_haptics": {
+    "created": 1288901497,
+    "modified": 1748618570
+  },
+  "webxr_xr_dragging_custom_depth": {
+    "created": 1717232934,
+    "modified": 1717406353
+  },
+  "webxr_xr_dragging": {
+    "created": 1288901497,
+    "modified": 1717097977
+  },
+  "webxr_xr_cubes": {
+    "created": 1288901497,
+    "modified": 1717097977
+  },
+  "webxr_xr_controls_transform": {
+    "created": 1288901497,
+    "modified": 1734365075
+  },
+  "webxr_xr_ballshooter": {
+    "created": 1288901497,
+    "modified": 1717097977
+  },
+  "webxr_vr_video": {
+    "created": 1426471746,
+    "modified": 1714645250
+  },
+  "webxr_vr_teleport": {
+    "created": 1288901497,
+    "modified": 1714645250
+  },
+  "webxr_vr_sandbox": {
+    "created": 1450563020,
+    "modified": 1714645250
+  },
+  "webxr_vr_rollercoaster": {
+    "created": 1457120262,
+    "modified": 1714645250
+  },
+  "webxr_vr_panorama_depth": {
+    "created": 1574635279,
+    "modified": 1733159184
+  },
+  "webxr_vr_panorama": {
+    "created": 1454345256,
+    "modified": 1714645250
+  },
+  "webxr_vr_layers": {
+    "created": 1288901497,
+    "modified": 1746517988
+  },
+  "webxr_vr_handinput_profiles": {
+    "created": 1288901497,
+    "modified": 1746517988
+  },
+  "webxr_vr_handinput_pressbutton": {
+    "created": 1620281099,
+    "modified": 1746517988
+  },
+  "webxr_vr_handinput_pointerdrag": {
+    "created": 1620281099,
+    "modified": 1746517988
+  },
+  "webxr_vr_handinput_pointerclick": {
+    "created": 1620281099,
+    "modified": 1746517988
+  },
+  "webxr_vr_handinput_cubes": {
+    "created": 1288901497,
+    "modified": 1746517988
+  },
+  "webxr_vr_handinput": {
+    "created": 1288901497,
+    "modified": 1746517988
+  },
+  "webxr_ar_plane_detection": {
+    "created": 1577214878,
+    "modified": 1746517988
+  },
+  "webxr_ar_lighting": {
+    "created": 1614103786,
+    "modified": 1746517988
+  },
+  "webxr_ar_hittest": {
+    "created": 1577214878,
+    "modified": 1743803516
+  },
+  "webxr_ar_cones": {
+    "created": 1574880780,
+    "modified": 1746517988
+  },
+  "webgpu_xr_rollercoaster": {
+    "created": 1457120262,
+    "modified": 1748385358
+  },
+  "webgpu_xr_native_layers": {
+    "created": 1741902324,
+    "modified": 1748385358
+  },
+  "webgpu_xr_cubes": {
+    "created": 1288901497,
+    "modified": 1744664677
+  },
+  "webgpu_water": {
+    "created": 1507023088,
+    "modified": 1751286906
+  },
+  "webgpu_volume_perlin": {
+    "created": 1716307059,
+    "modified": 1739663467
+  },
+  "webgpu_volume_lighting_rectarea": {
+    "created": 1739931854,
+    "modified": 1741236022
+  },
+  "webgpu_volume_lighting": {
+    "created": 1739931854,
+    "modified": 1741236022
+  },
+  "webgpu_volume_cloud": {
+    "created": 1716307059,
+    "modified": 1739663467
+  },
+  "webgpu_volume_caustics": {
+    "created": 1745292894,
+    "modified": 1745292894
+  },
+  "webgpu_video_panorama": {
+    "created": 1275883404,
+    "modified": 1732477266
+  },
+  "webgpu_video_frame": {
+    "created": 1633371335,
+    "modified": 1737584759
+  },
+  "webgpu_tsl_vfx_tornado": {
+    "created": 1722366483,
+    "modified": 1749524576
+  },
+  "webgpu_tsl_vfx_linkedparticles": {
+    "created": 1725832461,
+    "modified": 1749524576
+  },
+  "webgpu_tsl_vfx_flames": {
+    "created": 1721923080,
+    "modified": 1749524576
+  },
+  "webgpu_tsl_transpiler": {
+    "created": 1697864833,
+    "modified": 1751165912
+  },
+  "webgpu_tsl_raging_sea": {
+    "created": 1722135631,
+    "modified": 1732477266
+  },
+  "webgpu_tsl_procedural_terrain": {
+    "created": 1722211900,
+    "modified": 1732477266
+  },
+  "webgpu_tsl_interoperability": {
+    "created": 1718070326,
+    "modified": 1734365075
+  },
+  "webgpu_tsl_halftone": {
+    "created": 1722099330,
+    "modified": 1749524576
+  },
+  "webgpu_tsl_galaxy": {
+    "created": 1721848786,
+    "modified": 1738340548
+  },
+  "webgpu_tsl_editor": {
+    "created": 1687023952,
+    "modified": 1750579204
+  },
+  "webgpu_tsl_earth": {
+    "created": 1722183404,
+    "modified": 1750102862
+  },
+  "webgpu_tsl_compute_attractors_particles": {
+    "created": 1722026303,
+    "modified": 1738340548
+  },
+  "webgpu_tsl_angular_slicing": {
+    "created": 1722289278,
+    "modified": 1734375347
+  },
+  "webgpu_tonemapping": {
+    "created": 1455303963,
+    "modified": 1746517926
+  },
+  "webgpu_textures_partialupdate": {
+    "created": 1520412259,
+    "modified": 1732477266
+  },
+  "webgpu_textures_anisotropy": {
+    "created": 1343308413,
+    "modified": 1732477266
+  },
+  "webgpu_textures_2d-array_compressed": {
+    "created": 1537556999,
+    "modified": 1732477266
+  },
+  "webgpu_textures_2d-array": {
+    "created": 1537556999,
+    "modified": 1732477266
+  },
+  "webgpu_texturegrad": {
+    "created": 1712069844,
+    "modified": 1737784706
+  },
+  "webgpu_struct_drawindirect": {
+    "created": 1738086290,
+    "modified": 1739381597
+  },
+  "webgpu_storage_buffer": {
+    "created": 1707199013,
+    "modified": 1737784706
+  },
+  "webgpu_sprites": {
+    "created": 1653538351,
+    "modified": 1738340548
+  },
+  "webgpu_sky": {
+    "created": 1398536447,
+    "modified": 1732477266
+  },
+  "webgpu_skinning_points": {
+    "created": 1633371335,
+    "modified": 1749227243
+  },
+  "webgpu_skinning_instancing": {
+    "created": 1633371335,
+    "modified": 1732477266
+  },
+  "webgpu_skinning": {
+    "created": 1633371335,
+    "modified": 1732477266
+  },
+  "webgpu_shadowmap_vsm": {
+    "created": 1421879195,
+    "modified": 1732477266
+  },
+  "webgpu_shadowmap_progressive": {
+    "created": 1615590365,
+    "modified": 1732477266
+  },
+  "webgpu_shadowmap_opacity": {
+    "created": 1721962003,
+    "modified": 1745426540
+  },
+  "webgpu_shadowmap_csm": {
+    "created": 1579964020,
+    "modified": 1748420339
+  },
+  "webgpu_shadowmap_array": {
+    "created": 1743695476,
+    "modified": 1745981056
+  },
+  "webgpu_shadowmap": {
+    "created": 1421879195,
+    "modified": 1745292894
+  },
+  "webgpu_shadertoy": {
+    "created": 1697864833,
+    "modified": 1750551041
+  },
+  "webgpu_sandbox": {
+    "created": 1599071235,
+    "modified": 1748936843
+  },
+  "webgpu_rtt": {
+    "created": 1599071235,
+    "modified": 1732477266
+  },
+  "webgpu_rendertarget_2d-array_3d": {
+    "created": 1734961887,
+    "modified": 1745981056
+  },
+  "webgpu_refraction": {
+    "created": 1506794047,
+    "modified": 1732477266
+  },
+  "webgpu_reflection_roughness": {
+    "created": 1750518992,
+    "modified": 1751275258
+  },
+  "webgpu_reflection_blurred": {
+    "created": 1747296602,
+    "modified": 1747322795
+  },
+  "webgpu_reflection": {
+    "created": 1706048445,
+    "modified": 1750102862
+  },
+  "webgpu_procedural_texture": {
+    "created": 1693047447,
+    "modified": 1732477266
+  },
+  "webgpu_postprocessing_transition": {
+    "created": 1385928542,
+    "modified": 1732477266
+  },
+  "webgpu_postprocessing_traa": {
+    "created": 1454945263,
+    "modified": 1736939466
+  },
+  "webgpu_postprocessing_ssr": {
+    "created": 1728489261,
+    "modified": 1750444759
+  },
+  "webgpu_postprocessing_ssaa": {
+    "created": 1723448592,
+    "modified": 1740042044
+  },
+  "webgpu_postprocessing_sobel": {
+    "created": 1295054447,
+    "modified": 1732477266
+  },
+  "webgpu_postprocessing_smaa": {
+    "created": 1454945263,
+    "modified": 1732477266
+  },
+  "webgpu_postprocessing_pixel": {
+    "created": 1513810962,
+    "modified": 1732477266
+  },
+  "webgpu_postprocessing_outline": {
+    "created": 1469565272,
+    "modified": 1732477266
+  },
+  "webgpu_postprocessing_motion_blur": {
+    "created": 1706048445,
+    "modified": 1734472337
+  },
+  "webgpu_postprocessing_masking": {
+    "created": 1449268433,
+    "modified": 1732477266
+  },
+  "webgpu_postprocessing_lensflare": {
+    "created": 1729526009,
+    "modified": 1732477266
+  },
+  "webgpu_postprocessing_fxaa": {
+    "created": 1720824357,
+    "modified": 1732477266
+  },
+  "webgpu_postprocessing_dof": {
+    "created": 1719303065,
+    "modified": 1732477266
+  },
+  "webgpu_postprocessing_difference": {
+    "created": 1722920165,
+    "modified": 1740042044
+  },
+  "webgpu_postprocessing_ca": {
+    "created": 1749355764,
+    "modified": 1751276990
+  },
+  "webgpu_postprocessing_bloom_selective": {
+    "created": 1721342202,
+    "modified": 1732477266
+  },
+  "webgpu_postprocessing_bloom_emissive": {
+    "created": 1392158538,
+    "modified": 1732477266
+  },
+  "webgpu_postprocessing_bloom": {
+    "created": 1455303963,
+    "modified": 1732477266
+  },
+  "webgpu_postprocessing_ao": {
+    "created": 1720717078,
+    "modified": 1748424749
+  },
+  "webgpu_postprocessing_anamorphic": {
+    "created": 1392158538,
+    "modified": 1732477266
+  },
+  "webgpu_postprocessing_afterimage": {
+    "created": 1295054447,
+    "modified": 1738340548
+  },
+  "webgpu_postprocessing_3dlut": {
+    "created": 1392158538,
+    "modified": 1737728583
+  },
+  "webgpu_postprocessing": {
+    "created": 1295054447,
+    "modified": 1732477266
+  },
+  "webgpu_portal": {
+    "created": 1702613366,
+    "modified": 1732477266
+  },
+  "webgpu_pmrem_scene": {
+    "created": 1709240453,
+    "modified": 1734116203
+  },
+  "webgpu_pmrem_equirectangular": {
+    "created": 1392158538,
+    "modified": 1750102862
+  },
+  "webgpu_pmrem_cubemap": {
+    "created": 1392158538,
+    "modified": 1750102862
+  },
+  "webgpu_performance_renderbundle": {
+    "created": 1716507158,
+    "modified": 1737479954
+  },
+  "webgpu_performance": {
+    "created": 1392158538,
+    "modified": 1737601400
+  },
+  "webgpu_particles": {
+    "created": 1656040212,
+    "modified": 1738340548
+  },
+  "webgpu_parallax_uv": {
+    "created": 1707863035,
+    "modified": 1734365075
+  },
+  "webgpu_ocean": {
+    "created": 1388561366,
+    "modified": 1732477266
+  },
+  "webgpu_occlusion": {
+    "created": 1691972336,
+    "modified": 1736389902
+  },
+  "webgpu_multisampled_renderbuffers": {
+    "created": 1599071235,
+    "modified": 1735786887
+  },
+  "webgpu_multiple_rendertargets_readback": {
+    "created": 1693426644,
+    "modified": 1750102862
+  },
+  "webgpu_multiple_rendertargets": {
+    "created": 1693426644,
+    "modified": 1732477266
+  },
+  "webgpu_mrt_mask": {
+    "created": 1633371335,
+    "modified": 1732477266
+  },
+  "webgpu_mrt": {
+    "created": 1392158538,
+    "modified": 1750102862
+  },
+  "webgpu_morphtargets_face": {
+    "created": 1631562234,
+    "modified": 1732477266
+  },
+  "webgpu_morphtargets": {
+    "created": 1299862318,
+    "modified": 1732477266
+  },
+  "webgpu_modifier_curve": {
+    "created": 1603205802,
+    "modified": 1732477266
+  },
+  "webgpu_mirror": {
+    "created": 1379293254,
+    "modified": 1732477266
+  },
+  "webgpu_mesh_batch": {
+    "created": 1697641879,
+    "modified": 1750102862
+  },
+  "webgpu_materialx_noise": {
+    "created": 1562879741,
+    "modified": 1732477266
+  },
+  "webgpu_materials_video": {
+    "created": 1298128883,
+    "modified": 1732477266
+  },
+  "webgpu_materials_transmission": {
+    "created": 1455303963,
+    "modified": 1732477266
+  },
+  "webgpu_materials_toon": {
+    "created": 1445439521,
+    "modified": 1734472337
+  },
+  "webgpu_materials_sss": {
+    "created": 1704266584,
+    "modified": 1732477266
+  },
+  "webgpu_materials_matcap": {
+    "created": 1535942782,
+    "modified": 1732477266
+  },
+  "webgpu_materials_lightmap": {
+    "created": 1346470359,
+    "modified": 1747428795
+  },
+  "webgpu_materials_envmaps_bpcem": {
+    "created": 1730301130,
+    "modified": 1732477266
+  },
+  "webgpu_materials_envmaps": {
+    "created": 1415905012,
+    "modified": 1739658627
+  },
+  "webgpu_materials_displacementmap": {
+    "created": 1441479759,
+    "modified": 1732477266
+  },
+  "webgpu_materials_basic": {
+    "created": 1290138560,
+    "modified": 1732477266
+  },
+  "webgpu_materials_arrays": {
+    "created": 1725115469,
+    "modified": 1732477266
+  },
+  "webgpu_materials_alphahash": {
+    "created": 1574087990,
+    "modified": 1732477266
+  },
+  "webgpu_materials": {
+    "created": 1289919426,
+    "modified": 1738097901
+  },
+  "webgpu_loader_materialx": {
+    "created": 1666850664,
+    "modified": 1732477266
+  },
+  "webgpu_loader_gltf_transmission": {
+    "created": 1392158538,
+    "modified": 1732477266
+  },
+  "webgpu_loader_gltf_sheen": {
+    "created": 1392158538,
+    "modified": 1732477266
+  },
+  "webgpu_loader_gltf_iridescence": {
+    "created": 1392158538,
+    "modified": 1732477266
+  },
+  "webgpu_loader_gltf_dispersion": {
+    "created": 1392158538,
+    "modified": 1732477266
+  },
+  "webgpu_loader_gltf_compressed": {
+    "created": 1633371335,
+    "modified": 1732477266
+  },
+  "webgpu_loader_gltf_anisotropy": {
+    "created": 1392158538,
+    "modified": 1732477266
+  },
+  "webgpu_loader_gltf": {
+    "created": 1392158538,
+    "modified": 1743702524
+  },
+  "webgpu_lines_fat_wireframe": {
+    "created": 1494970694,
+    "modified": 1745769388
+  },
+  "webgpu_lines_fat_raycasting": {
+    "created": 1646792084,
+    "modified": 1748026399
+  },
+  "webgpu_lines_fat": {
+    "created": 1494970694,
+    "modified": 1732477266
+  },
+  "webgpu_lights_tiled": {
+    "created": 1728949112,
+    "modified": 1734375525
+  },
+  "webgpu_lights_spotlight": {
+    "created": 1459333027,
+    "modified": 1746029568
+  },
+  "webgpu_lights_selective": {
+    "created": 1619158503,
+    "modified": 1733802787
+  },
+  "webgpu_lights_rectarealight": {
+    "created": 1478653275,
+    "modified": 1732477266
+  },
+  "webgpu_lights_projector": {
+    "created": 1459333027,
+    "modified": 1746029568
+  },
+  "webgpu_lights_pointlights": {
+    "created": 1746388491,
+    "modified": 1746388491
+  },
+  "webgpu_lights_physical": {
+    "created": 1456852829,
+    "modified": 1732477266
+  },
+  "webgpu_lights_phong": {
+    "created": 1619158503,
+    "modified": 1733802787
+  },
+  "webgpu_lights_ies_spotlight": {
+    "created": 1673015307,
+    "modified": 1735763889
+  },
+  "webgpu_lights_custom": {
+    "created": 1619724337,
+    "modified": 1732477266
+  },
+  "webgpu_lightprobe_cubecamera": {
+    "created": 1555030484,
+    "modified": 1732477266
+  },
+  "webgpu_lightprobe": {
+    "created": 1555030484,
+    "modified": 1732477266
+  },
+  "webgpu_lensflares": {
+    "created": 1321586652,
+    "modified": 1732477266
+  },
+  "webgpu_layers": {
+    "created": 1746257423,
+    "modified": 1747137737
+  },
+  "webgpu_instancing_morph": {
+    "created": 1707125631,
+    "modified": 1732477266
+  },
+  "webgpu_instance_uniform": {
+    "created": 1289919426,
+    "modified": 1732477266
+  },
+  "webgpu_instance_sprites": {
+    "created": 1272110983,
+    "modified": 1738340548
+  },
+  "webgpu_instance_points": {
+    "created": 1494970694,
+    "modified": 1736518159
+  },
+  "webgpu_instance_path": {
+    "created": 1748815843,
+    "modified": 1748815843
+  },
+  "webgpu_instance_mesh": {
+    "created": 1292188945,
+    "modified": 1732477266
+  },
+  "webgpu_equirectangular": {
+    "created": 1334680014,
+    "modified": 1732477266
+  },
+  "webgpu_display_stereo": {
+    "created": 1290138560,
+    "modified": 1740042044
+  },
+  "webgpu_depth_texture": {
+    "created": 1599071235,
+    "modified": 1732477266
+  },
+  "webgpu_custom_fog_background": {
+    "created": 1392158538,
+    "modified": 1733802787
+  },
+  "webgpu_custom_fog": {
+    "created": 1705850753,
+    "modified": 1732477266
+  },
+  "webgpu_cubemap_mix": {
+    "created": 1392158538,
+    "modified": 1732477266
+  },
+  "webgpu_cubemap_dynamic": {
+    "created": 1317554455,
+    "modified": 1732477266
+  },
+  "webgpu_cubemap_adjustments": {
+    "created": 1654729337,
+    "modified": 1732477266
+  },
+  "webgpu_compute_water": {
+    "created": 1725832366,
+    "modified": 1750708359
+  },
+  "webgpu_compute_texture_pingpong": {
+    "created": 1693047447,
+    "modified": 1732477266
+  },
+  "webgpu_compute_texture": {
+    "created": 1693047447,
+    "modified": 1742970181
+  },
+  "webgpu_compute_sort_bitonic": {
+    "created": 1725992988,
+    "modified": 1743116769
+  },
+  "webgpu_compute_points": {
+    "created": 1600749505,
+    "modified": 1737601400
+  },
+  "webgpu_compute_particles_snow": {
+    "created": 1702998509,
+    "modified": 1738315688
+  },
+  "webgpu_compute_particles_rain": {
+    "created": 1698280252,
+    "modified": 1732477266
+  },
+  "webgpu_compute_particles_fluid": {
+    "created": 1748026498,
+    "modified": 1748249828
+  },
+  "webgpu_compute_particles": {
+    "created": 1693275030,
+    "modified": 1747627813
+  },
+  "webgpu_compute_geometry": {
+    "created": 1712321915,
+    "modified": 1741630617
+  },
+  "webgpu_compute_cloth": {
+    "created": 1747582724,
+    "modified": 1749198513
+  },
+  "webgpu_compute_birds": {
+    "created": 1723561462,
+    "modified": 1749186166
+  },
+  "webgpu_compute_audio": {
+    "created": 1668416869,
+    "modified": 1734375556
+  },
+  "webgpu_clipping": {
+    "created": 1459987817,
+    "modified": 1732477266
+  },
+  "webgpu_clearcoat": {
+    "created": 1562879741,
+    "modified": 1732477266
+  },
+  "webgpu_centroid_sampling": {
+    "created": 1743753030,
+    "modified": 1749026613
+  },
+  "webgpu_caustics": {
+    "created": 1745292894,
+    "modified": 1745292894
+  },
+  "webgpu_camera_logarithmicdepthbuffer": {
+    "created": 1379145116,
+    "modified": 1732477266
+  },
+  "webgpu_camera_array": {
+    "created": 1496462396,
+    "modified": 1737029674
+  },
+  "webgpu_camera": {
+    "created": 1325635632,
+    "modified": 1734365720
+  },
+  "webgpu_backdrop_water": {
+    "created": 1702997772,
+    "modified": 1735233725
+  },
+  "webgpu_backdrop_area": {
+    "created": 1686155671,
+    "modified": 1732477266
+  },
+  "webgpu_backdrop": {
+    "created": 1633371335,
+    "modified": 1732477266
+  },
+  "webgpu_animation_retargeting_readyplayer": {
+    "created": 1726530466,
+    "modified": 1737567783
+  },
+  "webgpu_animation_retargeting": {
+    "created": 1725655635,
+    "modified": 1750102862
+  },
+  "webgl_worker_offscreencanvas": {
+    "created": 1517828942,
+    "modified": 1701341611
+  },
+  "webgl_watch": {
+    "created": 1743124051,
+    "modified": 1743611865
+  },
+  "webgl_volume_perlin": {
+    "created": 1596033535,
+    "modified": 1717150487
+  },
+  "webgl_volume_instancing": {
+    "created": 1596033535,
+    "modified": 1738834087
+  },
+  "webgl_volume_cloud": {
+    "created": 1596033535,
+    "modified": 1717150487
+  },
+  "webgl_video_panorama_equirectangular": {
+    "created": 1275883404,
+    "modified": 1714645250
+  },
+  "webgl_video_kinect": {
+    "created": 1319992509,
+    "modified": 1729331421
+  },
+  "webgl_ubo_arrays": {
+    "created": 1701694211,
+    "modified": 1717150487
+  },
+  "webgl_ubo": {
+    "created": 1657169615,
+    "modified": 1717150487
+  },
+  "webgl_tonemapping": {
+    "created": 1455303963,
+    "modified": 1746517926
+  },
+  "webgl_texture3d_partialupdate": {
+    "created": 1596033535,
+    "modified": 1729731209
+  },
+  "webgl_texture3d": {
+    "created": 1537556999,
+    "modified": 1717150487
+  },
+  "webgl_texture2darray_layerupdate": {
+    "created": 1718918018,
+    "modified": 1732918796
+  },
+  "webgl_texture2darray_compressed": {
+    "created": 1537556999,
+    "modified": 1717150487
+  },
+  "webgl_texture2darray": {
+    "created": 1537556999,
+    "modified": 1717150487
+  },
+  "webgl_test_wide_gamut": {
+    "created": 1539437668,
+    "modified": 1727444593
+  },
+  "webgl_test_memory2": {
+    "created": 1335474488,
+    "modified": 1695689493
+  },
+  "webgl_test_memory": {
+    "created": 1314890282,
+    "modified": 1714645250
+  },
+  "webgl_sprites": {
+    "created": 1302189054,
+    "modified": 1714645250
+  },
+  "webgl_simple_gi": {
+    "created": 1486251942,
+    "modified": 1714645250
+  },
+  "webgl_shadow_contact": {
+    "created": 1583025451,
+    "modified": 1733159184
+  },
+  "webgl_shadowmesh": {
+    "created": 1424326876,
+    "modified": 1714645250
+  },
+  "webgl_shadowmap_vsm": {
+    "created": 1421879195,
+    "modified": 1714645250
+  },
+  "webgl_shadowmap_viewer": {
+    "created": 1421879195,
+    "modified": 1714645250
+  },
+  "webgl_shadowmap_progressive": {
+    "created": 1615590365,
+    "modified": 1729782641
+  },
+  "webgl_shadowmap_pointlight": {
+    "created": 1441997443,
+    "modified": 1714645250
+  },
+  "webgl_shadowmap_performance": {
+    "created": 1311860630,
+    "modified": 1714645250
+  },
+  "webgl_shadowmap_pcss": {
+    "created": 1502847346,
+    "modified": 1714645250
+  },
+  "webgl_shadowmap_csm": {
+    "created": 1579964020,
+    "modified": 1714645250
+  },
+  "webgl_shadowmap": {
+    "created": 1311860630,
+    "modified": 1714645250
+  },
+  "webgl_shader_lava": {
+    "created": 1298128883,
+    "modified": 1714645250
+  },
+  "webgl_shaders_sky": {
+    "created": 1398536447,
+    "modified": 1695689493
+  },
+  "webgl_shaders_ocean": {
+    "created": 1388561366,
+    "modified": 1714645250
+  },
+  "webgl_shader": {
+    "created": 1293664199,
+    "modified": 1714645250
+  },
+  "webgl_rtt": {
+    "created": 1294602836,
+    "modified": 1714645250
+  },
+  "webgl_reverse_depth_buffer": {
+    "created": 1743116889,
+    "modified": 1745503505
+  },
+  "webgl_rendertarget_texture2darray": {
+    "created": 1597744369,
+    "modified": 1717150487
+  },
+  "webgl_renderer_pathtracer": {
+    "created": 1666030847,
+    "modified": 1742977841
+  },
+  "webgl_refraction": {
+    "created": 1506794047,
+    "modified": 1714645250
+  },
+  "webgl_read_float_buffer": {
+    "created": 1294602836,
+    "modified": 1714645250
+  },
+  "webgl_raycaster_texture": {
+    "created": 1440196704,
+    "modified": 1714645250
+  },
+  "webgl_raycaster_sprite": {
+    "created": 1531813063,
+    "modified": 1714645250
+  },
+  "webgl_raycaster_bvh": {
+    "created": 1656403070,
+    "modified": 1714645250
+  },
+  "webgl_random_uv": {
+    "created": 1743124051,
+    "modified": 1743611865
+  },
+  "webgl_postprocessing_unreal_bloom_selective": {
+    "created": 1554100159,
+    "modified": 1695689493
+  },
+  "webgl_postprocessing_unreal_bloom": {
+    "created": 1455303963,
+    "modified": 1714645250
+  },
+  "webgl_postprocessing_transition": {
+    "created": 1385928542,
+    "modified": 1717578377
+  },
+  "webgl_postprocessing_taa": {
+    "created": 1454945263,
+    "modified": 1733159184
+  },
+  "webgl_postprocessing_ssr": {
+    "created": 1614098989,
+    "modified": 1714645250
+  },
+  "webgl_postprocessing_ssao": {
+    "created": 1436090192,
+    "modified": 1714645250
+  },
+  "webgl_postprocessing_ssaa": {
+    "created": 1454945263,
+    "modified": 1727262486
+  },
+  "webgl_postprocessing_sobel": {
+    "created": 1502543804,
+    "modified": 1714645250
+  },
+  "webgl_postprocessing_smaa": {
+    "created": 1454945263,
+    "modified": 1741785979
+  },
+  "webgl_postprocessing_sao": {
+    "created": 1496841288,
+    "modified": 1714645250
+  },
+  "webgl_postprocessing_rgb_halftone": {
+    "created": 1523605343,
+    "modified": 1741785979
+  },
+  "webgl_postprocessing_procedural": {
+    "created": 1460488603,
+    "modified": 1714645250
+  },
+  "webgl_postprocessing_pixel": {
+    "created": 1513810962,
+    "modified": 1714645250
+  },
+  "webgl_postprocessing_outline": {
+    "created": 1469565272,
+    "modified": 1728207096
+  },
+  "webgl_postprocessing_material_ao": {
+    "created": 1704204467,
+    "modified": 1714645250
+  },
+  "webgl_postprocessing_masking": {
+    "created": 1449268433,
+    "modified": 1729331421
+  },
+  "webgl_postprocessing_gtao": {
+    "created": 1699233904,
+    "modified": 1722524016
+  },
+  "webgl_postprocessing_godrays": {
+    "created": 1333987594,
+    "modified": 1744718049
+  },
+  "webgl_postprocessing_glitch": {
+    "created": 1295054447,
+    "modified": 1714645250
+  },
+  "webgl_postprocessing_fxaa": {
+    "created": 1503583256,
+    "modified": 1746431275
+  },
+  "webgl_postprocessing_dof2": {
+    "created": 1364232748,
+    "modified": 1714645250
+  },
+  "webgl_postprocessing_dof": {
+    "created": 1298352307,
+    "modified": 1714645250
+  },
+  "webgl_postprocessing_backgrounds": {
+    "created": 1454945263,
+    "modified": 1714645250
+  },
+  "webgl_postprocessing_afterimage": {
+    "created": 1295054447,
+    "modified": 1746348904
+  },
+  "webgl_postprocessing_advanced": {
+    "created": 1295054447,
+    "modified": 1726590552
+  },
+  "webgl_postprocessing_3dlut": {
+    "created": 1392158538,
+    "modified": 1743116769
+  },
+  "webgl_postprocessing": {
+    "created": 1295054447,
+    "modified": 1714645250
+  },
+  "webgl_portal": {
+    "created": 1622105638,
+    "modified": 1714581551
+  },
+  "webgl_points_waves": {
+    "created": 1272110983,
+    "modified": 1714581551
+  },
+  "webgl_points_sprites": {
+    "created": 1272110983,
+    "modified": 1714581551
+  },
+  "webgl_points_dynamic": {
+    "created": 1306975307,
+    "modified": 1714581551
+  },
+  "webgl_points_billboards": {
+    "created": 1272110983,
+    "modified": 1714581551
+  },
+  "webgl_pmrem_test": {
+    "created": 1576194596,
+    "modified": 1695689493
+  },
+  "webgl_performance": {
+    "created": 1392158538,
+    "modified": 1723047588
+  },
+  "webgl_panorama_equirectangular": {
+    "created": 1275883404,
+    "modified": 1742894850
+  },
+  "webgl_panorama_cube": {
+    "created": 1454345256,
+    "modified": 1714581551
+  },
+  "webgl_multisampled_renderbuffers": {
+    "created": 1546889398,
+    "modified": 1717150487
+  },
+  "webgl_multiple_views": {
+    "created": 1297470401,
+    "modified": 1743116769
+  },
+  "webgl_multiple_scenes_comparison": {
+    "created": 1539437668,
+    "modified": 1714581551
+  },
+  "webgl_multiple_rendertargets": {
+    "created": 1620273838,
+    "modified": 1717150487
+  },
+  "webgl_multiple_elements_text": {
+    "created": 1452549552,
+    "modified": 1714581551
+  },
+  "webgl_multiple_elements": {
+    "created": 1433384257,
+    "modified": 1714581551
+  },
+  "webgl_morphtargets_webcam": {
+    "created": 1684402774,
+    "modified": 1722524016
+  },
+  "webgl_morphtargets_sphere": {
+    "created": 1510362809,
+    "modified": 1740042044
+  },
+  "webgl_morphtargets_horse": {
+    "created": 1306732319,
+    "modified": 1714581551
+  },
+  "webgl_morphtargets_face": {
+    "created": 1631562234,
+    "modified": 1722524016
+  },
+  "webgl_morphtargets": {
+    "created": 1299862318,
+    "modified": 1695689493
+  },
+  "webgl_modifier_tessellation": {
+    "created": 1308235588,
+    "modified": 1714581551
+  },
+  "webgl_modifier_subdivision": {
+    "created": 1317792389,
+    "modified": 1711453246
+  },
+  "webgl_modifier_simplifier": {
+    "created": 1466179910,
+    "modified": 1695689493
+  },
+  "webgl_modifier_edgesplit": {
+    "created": 1603193742,
+    "modified": 1698222575
+  },
+  "webgl_modifier_curve_instanced": {
+    "created": 1603205802,
+    "modified": 1726153182
+  },
+  "webgl_modifier_curve": {
+    "created": 1603205802,
+    "modified": 1726153182
+  },
+  "webgl_mirror": {
+    "created": 1379293254,
+    "modified": 1714581551
+  },
+  "webgl_mesh_batch": {
+    "created": 1697641879,
+    "modified": 1718734736
+  },
+  "webgl_math_orientation_transform": {
+    "created": 1531299420,
+    "modified": 1746777661
+  },
+  "webgl_math_obb": {
+    "created": 1578511370,
+    "modified": 1714581551
+  },
+  "webgl_materials_wireframe": {
+    "created": 1343952785,
+    "modified": 1711144832
+  },
+  "webgl_materials_video_webcam": {
+    "created": 1514230951,
+    "modified": 1714581551
+  },
+  "webgl_materials_video": {
+    "created": 1298128883,
+    "modified": 1714581551
+  },
+  "webgl_materials_toon": {
+    "created": 1445439521,
+    "modified": 1734472337
+  },
+  "webgl_materials_texture_rotation": {
+    "created": 1501468218,
+    "modified": 1745981871
+  },
+  "webgl_materials_texture_partialupdate": {
+    "created": 1520412259,
+    "modified": 1715077042
+  },
+  "webgl_materials_texture_manualmipmap": {
+    "created": 1353826436,
+    "modified": 1714581551
+  },
+  "webgl_materials_texture_filters": {
+    "created": 1299387700,
+    "modified": 1729331421
+  },
+  "webgl_materials_texture_canvas": {
+    "created": 1489659263,
+    "modified": 1714581551
+  },
+  "webgl_materials_texture_anisotropy": {
+    "created": 1343308413,
+    "modified": 1714581551
+  },
+  "webgl_materials_subsurface_scattering": {
+    "created": 1520870347,
+    "modified": 1714581551
+  },
+  "webgl_materials_physical_transmission_alpha": {
+    "created": 1455303963,
+    "modified": 1698137798
+  },
+  "webgl_materials_physical_transmission": {
+    "created": 1455303963,
+    "modified": 1733733176
+  },
+  "webgl_materials_physical_clearcoat": {
+    "created": 1562879741,
+    "modified": 1714581551
+  },
+  "webgl_materials_normalmap_object_space": {
+    "created": 1532990329,
+    "modified": 1695689493
+  },
+  "webgl_materials_normalmap": {
+    "created": 1291894069,
+    "modified": 1746891177
+  },
+  "webgl_materials_modified": {
+    "created": 1291894069,
+    "modified": 1734365075
+  },
+  "webgl_materials_matcap": {
+    "created": 1535942782,
+    "modified": 1720412266
+  },
+  "webgl_materials_envmaps_hdr": {
+    "created": 1455303963,
+    "modified": 1714581551
+  },
+  "webgl_materials_envmaps_groundprojected": {
+    "created": 1658224254,
+    "modified": 1749568552
+  },
+  "webgl_materials_envmaps_exr": {
+    "created": 1522023789,
+    "modified": 1714581551
+  },
+  "webgl_materials_envmaps": {
+    "created": 1415905012,
+    "modified": 1714581551
+  },
+  "webgl_materials_displacementmap": {
+    "created": 1441479759,
+    "modified": 1714581551
+  },
+  "webgl_materials_cubemap_render_to_mipmaps": {
+    "created": 1689668946,
+    "modified": 1714581551
+  },
+  "webgl_materials_cubemap_refraction": {
+    "created": 1290042011,
+    "modified": 1714581551
+  },
+  "webgl_materials_cubemap_mipmaps": {
+    "created": 1564135254,
+    "modified": 1714581551
+  },
+  "webgl_materials_cubemap_dynamic": {
+    "created": 1317554455,
+    "modified": 1714581551
+  },
+  "webgl_materials_cubemap": {
+    "created": 1290042011,
+    "modified": 1714581551
+  },
+  "webgl_materials_channels": {
+    "created": 1441479759,
+    "modified": 1720028353
+  },
+  "webgl_materials_car": {
+    "created": 1290636383,
+    "modified": 1749568552
+  },
+  "webgl_materials_bumpmap": {
+    "created": 1344632300,
+    "modified": 1746891177
+  },
+  "webgl_materials_blending_custom": {
+    "created": 1333537523,
+    "modified": 1714581551
+  },
+  "webgl_materials_blending": {
+    "created": 1333537523,
+    "modified": 1749568552
+  },
+  "webgl_materials_alphahash": {
+    "created": 1574087990,
+    "modified": 1722524016
+  },
+  "webgl_marchingcubes": {
+    "created": 1333392315,
+    "modified": 1714581551
+  },
+  "webgl_lod": {
+    "created": 1298991014,
+    "modified": 1714469534
+  },
+  "webgl_loader_xyz": {
+    "created": 1584272378,
+    "modified": 1714469534
+  },
+  "webgl_loader_vtk": {
+    "created": 1334680014,
+    "modified": 1714469534
+  },
+  "webgl_loader_vrml": {
+    "created": 1334680014,
+    "modified": 1714469534
+  },
+  "webgl_loader_vox": {
+    "created": 1595968788,
+    "modified": 1714469534
+  },
+  "webgl_loader_usdz": {
+    "created": 1466644585,
+    "modified": 1714469534
+  },
+  "webgl_loader_ttf": {
+    "created": 1307312978,
+    "modified": 1742894850
+  },
+  "webgl_loader_texture_ultrahdr": {
+    "created": 1720593547,
+    "modified": 1720593547
+  },
+  "webgl_loader_texture_tiff": {
+    "created": 1584272378,
+    "modified": 1695689493
+  },
+  "webgl_loader_texture_tga": {
+    "created": 1399563591,
+    "modified": 1714469534
+  },
+  "webgl_loader_texture_rgbm": {
+    "created": 1295804354,
+    "modified": 1695689493
+  },
+  "webgl_loader_texture_pvrtc": {
+    "created": 1411124513,
+    "modified": 1742977841
+  },
+  "webgl_loader_texture_lottie": {
+    "created": 1604004318,
+    "modified": 1751032773
+  },
+  "webgl_loader_texture_ktx2": {
+    "created": 1580095624,
+    "modified": 1748385481
+  },
+  "webgl_loader_texture_ktx": {
+    "created": 1513953126,
+    "modified": 1714469534
+  },
+  "webgl_loader_texture_hdr": {
+    "created": 1295804354,
+    "modified": 1695689493
+  },
+  "webgl_loader_texture_exr": {
+    "created": 1295804354,
+    "modified": 1695689493
+  },
+  "webgl_loader_texture_dds": {
+    "created": 1346202517,
+    "modified": 1740348604
+  },
+  "webgl_loader_svg": {
+    "created": 1521281075,
+    "modified": 1748250317
+  },
+  "webgl_loader_stl": {
+    "created": 1289919426,
+    "modified": 1714469534
+  },
+  "webgl_loader_ply": {
+    "created": 1289919426,
+    "modified": 1714469534
+  },
+  "webgl_loader_pdb": {
+    "created": 1397514588,
+    "modified": 1714469534
+  },
+  "webgl_loader_pcd": {
+    "created": 1454296117,
+    "modified": 1746712800
+  },
+  "webgl_loader_obj": {
+    "created": 1334599188,
+    "modified": 1748936946
+  },
+  "webgl_loader_nrrd": {
+    "created": 1457989089,
+    "modified": 1714469534
+  },
+  "webgl_loader_mdd": {
+    "created": 1584272378,
+    "modified": 1714469534
+  },
+  "webgl_loader_md2_control": {
+    "created": 1331048144,
+    "modified": 1714469534
+  },
+  "webgl_loader_md2": {
+    "created": 1328533535,
+    "modified": 1714469534
+  },
+  "webgl_loader_lwo": {
+    "created": 1334680014,
+    "modified": 1714469534
+  },
+  "webgl_loader_ldraw": {
+    "created": 1545287720,
+    "modified": 1742977841
+  },
+  "webgl_loader_kmz": {
+    "created": 1443048817,
+    "modified": 1695689493
+  },
+  "webgl_loader_imagebitmap": {
+    "created": 1497450963,
+    "modified": 1745323006
+  },
+  "webgl_loader_ifc": {
+    "created": 1617105427,
+    "modified": 1718969065
+  },
+  "webgl_loader_gltf_variants": {
+    "created": 1392158538,
+    "modified": 1695689493
+  },
+  "webgl_loader_gltf_transmission": {
+    "created": 1392158538,
+    "modified": 1714469534
+  },
+  "webgl_loader_gltf_sheen": {
+    "created": 1392158538,
+    "modified": 1722524016
+  },
+  "webgl_loader_gltf_iridescence": {
+    "created": 1392158538,
+    "modified": 1714469534
+  },
+  "webgl_loader_gltf_instancing": {
+    "created": 1392158538,
+    "modified": 1695689493
+  },
+  "webgl_loader_gltf_dispersion": {
+    "created": 1392158538,
+    "modified": 1722524016
+  },
+  "webgl_loader_gltf_compressed": {
+    "created": 1392158538,
+    "modified": 1722524016
+  },
+  "webgl_loader_gltf_avif": {
+    "created": 1392158538,
+    "modified": 1695689493
+  },
+  "webgl_loader_gltf_anisotropy": {
+    "created": 1392158538,
+    "modified": 1695689493
+  },
+  "webgl_loader_gltf": {
+    "created": 1392158538,
+    "modified": 1697358301
+  },
+  "webgl_loader_gcode": {
+    "created": 1334599188,
+    "modified": 1695689493
+  },
+  "webgl_loader_fbx_nurbs": {
+    "created": 1334680014,
+    "modified": 1714469534
+  },
+  "webgl_loader_fbx": {
+    "created": 1451280395,
+    "modified": 1747299884
+  },
+  "webgl_loader_draco": {
+    "created": 1489450225,
+    "modified": 1714469534
+  },
+  "webgl_loader_collada_skinning": {
+    "created": 1313356783,
+    "modified": 1714469534
+  },
+  "webgl_loader_collada_kinematics": {
+    "created": 1289919426,
+    "modified": 1714469534
+  },
+  "webgl_loader_collada": {
+    "created": 1289919426,
+    "modified": 1714469534
+  },
+  "webgl_loader_bvh": {
+    "created": 1466644585,
+    "modified": 1714469534
+  },
+  "webgl_loader_amf": {
+    "created": 1443048817,
+    "modified": 1695689493
+  },
+  "webgl_loader_3mf_materials": {
+    "created": 1443048817,
+    "modified": 1695689493
+  },
+  "webgl_loader_3mf": {
+    "created": 1443048817,
+    "modified": 1729187861
+  },
+  "webgl_loader_3dtiles": {
+    "created": 1744084592,
+    "modified": 1744360017
+  },
+  "webgl_loader_3ds": {
+    "created": 1334599188,
+    "modified": 1714469534
+  },
+  "webgl_loader_3dm": {
+    "created": 1334599188,
+    "modified": 1714469534
+  },
+  "webgl_lines_fat_wireframe": {
+    "created": 1494970694,
+    "modified": 1715721075
+  },
+  "webgl_lines_fat_raycasting": {
+    "created": 1646792084,
+    "modified": 1733317104
+  },
+  "webgl_lines_fat": {
+    "created": 1494970694,
+    "modified": 1733317104
+  },
+  "webgl_lines_dashed": {
+    "created": 1352161986,
+    "modified": 1714469534
+  },
+  "webgl_lines_colors": {
+    "created": 1294112305,
+    "modified": 1714469534
+  },
+  "webgl_lights_spotlights": {
+    "created": 1459333179,
+    "modified": 1714469534
+  },
+  "webgl_lights_spotlight": {
+    "created": 1459333027,
+    "modified": 1729331421
+  },
+  "webgl_lights_rectarealight": {
+    "created": 1478653275,
+    "modified": 1695689493
+  },
+  "webgl_lights_physical": {
+    "created": 1456852829,
+    "modified": 1714469534
+  },
+  "webgl_lights_hemisphere": {
+    "created": 1345757256,
+    "modified": 1717924196
+  },
+  "webgl_lightprobe_cubecamera": {
+    "created": 1555030484,
+    "modified": 1725892239
+  },
+  "webgl_lightprobe": {
+    "created": 1555030484,
+    "modified": 1725472921
+  },
+  "webgl_lensflares": {
+    "created": 1321586652,
+    "modified": 1714469534
+  },
+  "webgl_interactive_voxelpainter": {
+    "created": 1288936809,
+    "modified": 1695689493
+  },
+  "webgl_interactive_raycasting_points": {
+    "created": 1399580756,
+    "modified": 1714469534
+  },
+  "webgl_interactive_points": {
+    "created": 1398965563,
+    "modified": 1733159184
+  },
+  "webgl_interactive_lines": {
+    "created": 1288901497,
+    "modified": 1714469534
+  },
+  "webgl_interactive_cubes_ortho": {
+    "created": 1288901497,
+    "modified": 1714469534
+  },
+  "webgl_interactive_cubes_gpu": {
+    "created": 1342813387,
+    "modified": 1741338020
+  },
+  "webgl_interactive_cubes": {
+    "created": 1288901497,
+    "modified": 1714469534
+  },
+  "webgl_interactive_buffergeometry": {
+    "created": 1345037326,
+    "modified": 1714469534
+  },
+  "webgl_instancing_scatter": {
+    "created": 1575171186,
+    "modified": 1714469534
+  },
+  "webgl_instancing_raycast": {
+    "created": 1574087990,
+    "modified": 1714469534
+  },
+  "webgl_instancing_performance": {
+    "created": 1444163500,
+    "modified": 1714469534
+  },
+  "webgl_instancing_morph": {
+    "created": 1707125631,
+    "modified": 1714469534
+  },
+  "webgl_instancing_dynamic": {
+    "created": 1292188945,
+    "modified": 1746608606
+  },
+  "webgl_helpers": {
+    "created": 1331787163,
+    "modified": 1714469534
+  },
+  "webgl_gpgpu_water": {
+    "created": 1464716249,
+    "modified": 1743611865
+  },
+  "webgl_gpgpu_protoplanet": {
+    "created": 1464716249,
+    "modified": 1714469534
+  },
+  "webgl_gpgpu_birds_gltf": {
+    "created": 1385313069,
+    "modified": 1714469534
+  },
+  "webgl_gpgpu_birds": {
+    "created": 1385313069,
+    "modified": 1714469534
+  },
+  "webgl_geometry_text_stroke": {
+    "created": 1487441943,
+    "modified": 1739612691
+  },
+  "webgl_geometry_text_shapes": {
+    "created": 1487441943,
+    "modified": 1739612691
+  },
+  "webgl_geometry_text": {
+    "created": 1307312978,
+    "modified": 1742894850
+  },
+  "webgl_geometry_terrain_raycast": {
+    "created": 1291713212,
+    "modified": 1714469534
+  },
+  "webgl_geometry_terrain": {
+    "created": 1291713212,
+    "modified": 1714469534
+  },
+  "webgl_geometry_teapot": {
+    "created": 1440508447,
+    "modified": 1735900404
+  },
+  "webgl_geometry_spline_editor": {
+    "created": 1426350093,
+    "modified": 1726153182
+  },
+  "webgl_geometry_shapes": {
+    "created": 1310385602,
+    "modified": 1742894850
+  },
+  "webgl_geometry_nurbs": {
+    "created": 1272140721,
+    "modified": 1742894850
+  },
+  "webgl_geometry_minecraft": {
+    "created": 1291638094,
+    "modified": 1714469534
+  },
+  "webgl_geometry_extrude_splines": {
+    "created": 1331886183,
+    "modified": 1734365075
+  },
+  "webgl_geometry_extrude_shapes": {
+    "created": 1333311100,
+    "modified": 1751122361
+  },
+  "webgl_geometry_cube": {
+    "created": 1331787163,
+    "modified": 1714469534
+  },
+  "webgl_geometry_csg": {
+    "created": 1674043727,
+    "modified": 1714469534
+  },
+  "webgl_geometry_convex": {
+    "created": 1300247507,
+    "modified": 1733159184
+  },
+  "webgl_geometry_colors_lookuptable": {
+    "created": 1395141334,
+    "modified": 1695689493
+  },
+  "webgl_geometry_colors": {
+    "created": 1297470401,
+    "modified": 1750750702
+  },
+  "webgl_geometries": {
+    "created": 1300247507,
+    "modified": 1749670224
+  },
+  "webgl_furnace_test": {
+    "created": 1548303873,
+    "modified": 1695689493
+  },
+  "webgl_framebuffer_texture": {
+    "created": 1515180033,
+    "modified": 1715331391
+  },
+  "webgl_effects_stereo": {
+    "created": 1290138560,
+    "modified": 1714469534
+  },
+  "webgl_effects_parallaxbarrier": {
+    "created": 1290636383,
+    "modified": 1714469534
+  },
+  "webgl_effects_ascii": {
+    "created": 1540372895,
+    "modified": 1714469534
+  },
+  "webgl_effects_anaglyph": {
+    "created": 1290138560,
+    "modified": 1714469534
+  },
+  "webgl_depth_texture": {
+    "created": 1460230252,
+    "modified": 1729331421
+  },
+  "webgl_decals": {
+    "created": 1405932394,
+    "modified": 1727252727
+  },
+  "webgl_custom_attributes_points3": {
+    "created": 1308235588,
+    "modified": 1733159184
+  },
+  "webgl_custom_attributes_points2": {
+    "created": 1308235588,
+    "modified": 1714469534
+  },
+  "webgl_custom_attributes_points": {
+    "created": 1308235588,
+    "modified": 1714469534
+  },
+  "webgl_custom_attributes_lines": {
+    "created": 1308235588,
+    "modified": 1714469534
+  },
+  "webgl_custom_attributes": {
+    "created": 1308235588,
+    "modified": 1714469534
+  },
+  "webgl_clipping_stencil": {
+    "created": 1459987817,
+    "modified": 1714469534
+  },
+  "webgl_clipping_intersection": {
+    "created": 1476487950,
+    "modified": 1705657131
+  },
+  "webgl_clipping_advanced": {
+    "created": 1459987817,
+    "modified": 1743865875
+  },
+  "webgl_clipping": {
+    "created": 1459987817,
+    "modified": 1714469534
+  },
+  "webgl_clipculldistance": {
+    "created": 1293664199,
+    "modified": 1717150487
+  },
+  "webgl_camera_logarithmicdepthbuffer": {
+    "created": 1379145116,
+    "modified": 1710926530
+  },
+  "webgl_camera_array": {
+    "created": 1496462396,
+    "modified": 1714469534
+  },
+  "webgl_camera": {
+    "created": 1325635632,
+    "modified": 1714469534
+  },
+  "webgl_buffergeometry_uint": {
+    "created": 1345037326,
+    "modified": 1714428350
+  },
+  "webgl_buffergeometry_selective_draw": {
+    "created": 1444971874,
+    "modified": 1714428350
+  },
+  "webgl_buffergeometry_rawshader": {
+    "created": 1293664199,
+    "modified": 1714428350
+  },
+  "webgl_buffergeometry_points_interleaved": {
+    "created": 1346171687,
+    "modified": 1714428350
+  },
+  "webgl_buffergeometry_points": {
+    "created": 1346171687,
+    "modified": 1714428350
+  },
+  "webgl_buffergeometry_lines_indexed": {
+    "created": 1390627434,
+    "modified": 1714428350
+  },
+  "webgl_buffergeometry_lines": {
+    "created": 1346171687,
+    "modified": 1740042044
+  },
+  "webgl_buffergeometry_instancing_interleaved": {
+    "created": 1426695943,
+    "modified": 1714428350
+  },
+  "webgl_buffergeometry_instancing_billboards": {
+    "created": 1430317923,
+    "modified": 1734365075
+  },
+  "webgl_buffergeometry_instancing": {
+    "created": 1426564933,
+    "modified": 1733159184
+  },
+  "webgl_buffergeometry_indexed": {
+    "created": 1345037326,
+    "modified": 1714428350
+  },
+  "webgl_buffergeometry_glbufferattribute": {
+    "created": 1346171687,
+    "modified": 1750063076
+  },
+  "webgl_buffergeometry_drawrange": {
+    "created": 1419635932,
+    "modified": 1714428350
+  },
+  "webgl_buffergeometry_custom_attributes_particles": {
+    "created": 1308235588,
+    "modified": 1714428350
+  },
+  "webgl_buffergeometry_attributes_none": {
+    "created": 1667029554,
+    "modified": 1717150487
+  },
+  "webgl_buffergeometry_attributes_integer": {
+    "created": 1585914534,
+    "modified": 1732093277
+  },
+  "webgl_buffergeometry": {
+    "created": 1345037326,
+    "modified": 1714428350
+  },
+  "webgl_batch_lod_bvh": {
+    "created": 1749888369,
+    "modified": 1751276998
+  },
+  "webgl_animation_walk": {
+    "created": 1743124051,
+    "modified": 1743611865
+  },
+  "webgl_animation_skinning_morph": {
+    "created": 1345254299,
+    "modified": 1714428350
+  },
+  "webgl_animation_skinning_ik": {
+    "created": 1663919003,
+    "modified": 1726153182
+  },
+  "webgl_animation_skinning_blending": {
+    "created": 1396992914,
+    "modified": 1714428350
+  },
+  "webgl_animation_skinning_additive_blending": {
+    "created": 1583461152,
+    "modified": 1714428350
+  },
+  "webgl_animation_multiple": {
+    "created": 1552861676,
+    "modified": 1714428350
+  },
+  "webgl_animation_keyframes": {
+    "created": 1533274753,
+    "modified": 1722524016
+  },
+  "webaudio_visualizer": {
+    "created": 1502455327,
+    "modified": 1714428350
+  },
+  "webaudio_timing": {
+    "created": 1507893651,
+    "modified": 1714428350
+  },
+  "webaudio_sandbox": {
+    "created": 1298128883,
+    "modified": 1714428350
+  },
+  "webaudio_orientation": {
+    "created": 1507893651,
+    "modified": 1714428350
+  },
+  "svg_sandbox": {
+    "created": 1279322750,
+    "modified": 1695689493
+  },
+  "svg_lines": {
+    "created": 1496190313,
+    "modified": 1695689493
+  },
+  "physics_rapier_vehicle_controller": {
+    "created": 1743528013,
+    "modified": 1743528013
+  },
+  "physics_rapier_terrain": {
+    "created": 1466102119,
+    "modified": 1744452764
+  },
+  "physics_rapier_joints": {
+    "created": 1743528013,
+    "modified": 1743528013
+  },
+  "physics_rapier_instancing": {
+    "created": 1583008038,
+    "modified": 1745811089
+  },
+  "physics_rapier_character_controller": {
+    "created": 1743528013,
+    "modified": 1743528013
+  },
+  "physics_rapier_basic": {
+    "created": 1743528013,
+    "modified": 1750494176
+  },
+  "physics_jolt_instancing": {
+    "created": 1583008038,
+    "modified": 1746887075
+  },
+  "physics_ammo_volume": {
+    "created": 1466102119,
+    "modified": 1714428350
+  },
+  "physics_ammo_terrain": {
+    "created": 1466102119,
+    "modified": 1714428350
+  },
+  "physics_ammo_rope": {
+    "created": 1466102119,
+    "modified": 1714428350
+  },
+  "physics_ammo_instancing": {
+    "created": 1583008038,
+    "modified": 1745514687
+  },
+  "physics_ammo_cloth": {
+    "created": 1466102119,
+    "modified": 1714428350
+  },
+  "physics_ammo_break": {
+    "created": 1470959934,
+    "modified": 1714428350
+  },
+  "misc_uv_tests": {
+    "created": 1335498265,
+    "modified": 1695689493
+  },
+  "misc_raycaster_helper": {
+    "created": 1735984621,
+    "modified": 1739201770
+  },
+  "misc_exporter_usdz": {
+    "created": 1612978130,
+    "modified": 1749568552
+  },
+  "misc_exporter_stl": {
+    "created": 1527672828,
+    "modified": 1714428350
+  },
+  "misc_exporter_ply": {
+    "created": 1527672828,
+    "modified": 1714428350
+  },
+  "misc_exporter_obj": {
+    "created": 1431362161,
+    "modified": 1714428350
+  },
+  "misc_exporter_ktx2": {
+    "created": 1695547328,
+    "modified": 1727991818
+  },
+  "misc_exporter_gltf": {
+    "created": 1300247507,
+    "modified": 1729157518
+  },
+  "misc_exporter_exr": {
+    "created": 1695547328,
+    "modified": 1725391365
+  },
+  "misc_exporter_draco": {
+    "created": 1527672828,
+    "modified": 1714428350
+  },
+  "misc_controls_transform": {
+    "created": 1366567426,
+    "modified": 1726153182
+  },
+  "misc_controls_trackball": {
+    "created": 1302612585,
+    "modified": 1714428350
+  },
+  "misc_controls_pointerlock": {
+    "created": 1348696718,
+    "modified": 1723139134
+  },
+  "misc_controls_orbit": {
+    "created": 1302612585,
+    "modified": 1714428350
+  },
+  "misc_controls_map": {
+    "created": 1302612585,
+    "modified": 1714428350
+  },
+  "misc_controls_fly": {
+    "created": 1302469985,
+    "modified": 1732477266
+  },
+  "misc_controls_drag": {
+    "created": 1288901497,
+    "modified": 1723109125
+  },
+  "misc_controls_arcball": {
+    "created": 1631205155,
+    "modified": 1731923888
+  },
+  "misc_boxselection": {
+    "created": 1288901497,
+    "modified": 1714428350
+  },
+  "misc_animation_keys": {
+    "created": 1390910289,
+    "modified": 1714428350
+  },
+  "misc_animation_groups": {
+    "created": 1390910289,
+    "modified": 1714428350
+  },
+  "index": {
+    "created": 1376605063,
+    "modified": 1743140653
+  },
+  "games_fps": {
+    "created": 1607163868,
+    "modified": 1718450525
+  },
+  "css3d_youtube": {
+    "created": 1352993910,
+    "modified": 1695689493
+  },
+  "css3d_sprites": {
+    "created": 1369605851,
+    "modified": 1695689493
+  },
+  "css3d_sandbox": {
+    "created": 1347383421,
+    "modified": 1695689493
+  },
+  "css3d_periodictable": {
+    "created": 1351453094,
+    "modified": 1695689493
+  },
+  "css3d_orthographic": {
+    "created": 1347383421,
+    "modified": 1695689493
+  },
+  "css3d_molecules": {
+    "created": 1351477597,
+    "modified": 1695689493
+  },
+  "css2d_label": {
+    "created": 1525063515,
+    "modified": 1695689493
+  }
+}

--- a/files/main.css
+++ b/files/main.css
@@ -466,12 +466,6 @@ iframe#viewer {
 	margin-right: 10px;
 }
 
-#sortControls .sort-label {
-	color: var(--secondary-text-color);
-	white-space: nowrap;
-	font-size: calc(var(--font-size) - 2px);
-}
-
 #sort-by,
 #sort-order {
 	font-family: 'Roboto Mono', monospace;
@@ -505,16 +499,14 @@ iframe#viewer {
 #sort-order {
 	width: 24px;
 	padding: 0;
-	text-align: center;
-	font-size: 0.8em;
-	line-height: 22px;
 }
 
-.sort-icon {
-	color: var(--secondary-text-color);
+#sort-order svg {
+	display: block;
+	margin: auto;
 	width: var(--icon-size);
 	height: var(--icon-size);
-  }
+}
 
 .card .date-info {
 	color: #808080;

--- a/files/main.css
+++ b/files/main.css
@@ -459,24 +459,63 @@ iframe#viewer {
 }
 
 #sortControls {
-	display: inline-block;
+	display: flex;
+	align-items: center;
+	gap: 8px;
 	margin-left: 10px;
-	color: #888;
 	margin-right: 10px;
 }
-#sortControls button {
-	background: none;
-	border: 1px solid #ccc;
-	color: #888;
-	cursor: pointer;
-	margin-left: 5px;
+
+#sortControls .sort-label {
+	color: var(--secondary-text-color);
+	white-space: nowrap;
+	font-size: calc(var(--font-size) - 2px);
+}
+
+#sort-by,
+#sort-order {
+	font-family: 'Roboto Mono', monospace;
+	font-size: calc(var(--font-size) - 4px);
+	color: var(--text-color);
+	background-color: var(--secondary-background-color);
+	border: var(--border-style);
 	border-radius: 3px;
-	padding: 2px 6px;
+	height: 24px;
+	padding: 0 8px;
+	cursor: pointer;
 }
-#sortControls button:hover {
-	background-color: #f0f0f0;
-	border-color: #999;
+
+#sort-by:hover,
+#sort-order:hover {
+	border-color: var(--color-blue);
 }
+
+#sort-by {
+	-webkit-appearance: none;
+	-moz-appearance: none;
+	appearance: none;
+	background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%23888888%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.5-3.5%205.4-7.8%205.4-12.8%200-5-1.9-9.4-5.4-13z%22/%3E%3C/svg%3E');
+	background-repeat: no-repeat;
+	background-position: right 8px center;
+	background-size: .6em auto;
+	padding-right: 24px;
+
+}
+
+#sort-order {
+	width: 24px;
+	padding: 0;
+	text-align: center;
+	font-size: 0.8em;
+	line-height: 22px;
+}
+
+.sort-icon {
+	color: var(--secondary-text-color);
+	width: var(--icon-size);
+	height: var(--icon-size);
+  }
+
 .card .date-info {
 	color: #808080;
 	margin-top: 4px;

--- a/files/main.css
+++ b/files/main.css
@@ -458,6 +458,30 @@ iframe#viewer {
 	transform: scale(1.08);
 }
 
+#sortControls {
+	display: inline-block;
+	margin-left: 10px;
+	color: #888;
+	margin-right: 10px;
+}
+#sortControls button {
+	background: none;
+	border: 1px solid #ccc;
+	color: #888;
+	cursor: pointer;
+	margin-left: 5px;
+	border-radius: 3px;
+	padding: 2px 6px;
+}
+#sortControls button:hover {
+	background-color: #f0f0f0;
+	border-color: #999;
+}
+.card .date-info {
+	color: #808080;
+	margin-top: 4px;
+	font-style: italic;
+}
 
 
 @media all and ( min-width: 1500px ) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "three",
-  "version": "0.177.0",
+  "version": "0.178.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "three",
-      "version": "0.177.0",
+      "version": "0.178.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^16.0.0",
@@ -20,6 +20,8 @@
         "eslint-plugin-html": "^8.0.0",
         "eslint-plugin-import": "^2.27.5",
         "failonlyreporter": "^1.0.0",
+        "git-date-extractor": "^4.0.1",
+        "glob": "^11.0.3",
         "jimp": "^1.6.0",
         "jsdoc": "^4.0.4",
         "magic-string": "^0.30.0",
@@ -214,6 +216,29 @@
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@isaacs/balanced-match": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@isaacs/brace-expansion": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
+      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@isaacs/balanced-match": "^4.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -1685,6 +1710,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "16.9.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
@@ -1701,6 +1733,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/normalize-package-data": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+      "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
@@ -2076,6 +2115,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ast-metadata-inferer": {
@@ -2609,6 +2658,53 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/cacache/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/cacache/node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/cacache/node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "node_modules/cacache/node_modules/lru-cache": {
       "version": "7.18.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
@@ -2618,6 +2714,46 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/cacache/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/cacache/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/cacache/node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/call-bind": {
       "version": "1.0.8",
@@ -2690,6 +2826,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/camelcase-keys": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "map-obj": "^4.0.0",
+        "quick-lru": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/camelcase-keys/node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/caniuse-lite": {
@@ -3218,6 +3382,43 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/decamelize-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
+      "integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decamelize-keys/node_modules/map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -3464,6 +3665,16 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/dpdm/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/dpdm/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3479,6 +3690,83 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/dpdm/node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/dpdm/node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/dpdm/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/dpdm/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/dpdm/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/dpdm/node_modules/supports-color": {
@@ -4889,22 +5177,79 @@
         "omggif": "^1.0.10"
       }
     },
+    "node_modules/git-date-extractor": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/git-date-extractor/-/git-date-extractor-4.0.1.tgz",
+      "integrity": "sha512-CzFWqqxhYHWjRL1iUwreduLmTlvVw5xYvpTTBaDZ2+n+cwYDASmFJY3qqVOLEzq6YEt1VJnq0umipEGya6QdKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fs-extra": "^8.1.0",
+        "meow": "^7.0.1",
+        "walkdir": "^0.4.1"
+      },
+      "bin": {
+        "git-date-extractor": "dist/cli.js",
+        "git-dates": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/git-date-extractor/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/git-date-extractor/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/git-date-extractor/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
+      "integrity": "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.0.3",
         "minipass": "^7.1.2",
         "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
+        "path-scurry": "^2.0.0"
       },
       "bin": {
         "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -4923,27 +5268,17 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
+      "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "@isaacs/brace-expansion": "^5.0.0"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -5045,6 +5380,16 @@
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/hard-rejection": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
+      "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -5751,6 +6096,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -5937,19 +6292,19 @@
       "license": "ISC"
     },
     "node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
+      "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
+      "engines": {
+        "node": "20 || >=22"
+      },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/jimp": {
@@ -6149,6 +6504,16 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/klaw": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
@@ -6291,11 +6656,14 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.1.0.tgz",
+      "integrity": "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.30.17",
@@ -6555,6 +6923,19 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/map-obj": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/markdown-it": {
       "version": "14.1.0",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
@@ -6637,6 +7018,99 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/meow": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-7.1.1.tgz",
+      "integrity": "sha512-GWHvA5QOcS412WCo8vwKDlTelGLsCGBVevQB5Kva961rmNfun0PCbv5+xta2kUMFJyR8/oWnn7ddeKdosbAPbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/minimist": "^1.2.0",
+        "camelcase-keys": "^6.2.2",
+        "decamelize-keys": "^1.1.0",
+        "hard-rejection": "^2.1.0",
+        "minimist-options": "4.1.0",
+        "normalize-package-data": "^2.5.0",
+        "read-pkg-up": "^7.0.1",
+        "redent": "^3.0.0",
+        "trim-newlines": "^3.0.0",
+        "type-fest": "^0.13.1",
+        "yargs-parser": "^18.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/meow/node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/meow/node_modules/hosted-git-info": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/meow/node_modules/normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/meow/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/meow/node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/meow/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/merge-descriptors": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
@@ -6703,6 +7177,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -6724,6 +7208,21 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minimist-options": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
+      "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0",
+        "kind-of": "^6.0.3"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/minipass": {
@@ -7657,6 +8156,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/pac-proxy-agent": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
@@ -7853,17 +8362,17 @@
       "license": "MIT"
     },
     "node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
+      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.18"
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -8167,6 +8676,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/quick-lru": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/qunit": {
       "version": "2.24.1",
       "resolved": "https://registry.npmjs.org/qunit/-/qunit-2.24.1.tgz",
@@ -8275,6 +8794,53 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/read-package-json/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/read-package-json/node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/read-package-json/node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "node_modules/read-package-json/node_modules/json-parse-even-better-errors": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.2.tgz",
@@ -8283,6 +8849,186 @@
       "license": "MIT",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/read-package-json/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/read-package-json/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/read-package-json/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/read-pkg": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg-up": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.1.0",
+        "read-pkg": "^5.2.0",
+        "type-fest": "^0.8.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg/node_modules/hosted-git-info": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/read-pkg/node_modules/normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/read-pkg/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/read-pkg/node_modules/type-fest": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/readable-stream": {
@@ -8357,6 +9103,20 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -9710,6 +10470,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -9955,6 +10728,16 @@
       "license": "MIT",
       "bin": {
         "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/trim-newlines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/tsconfig-paths": {
@@ -10450,6 +11233,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/walkdir": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.4.1.tgz",
+      "integrity": "sha512-3eBwRyEln6E1MSzcxcVpQIhRG8Q1jLvEqRmCZqS3dsfXEDR/AhOF4d+jHg1qvDCpYaVRZjENPQyrVxAkQqxPgQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/wcwidth": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "test-e2e-webgpu": "node test/e2e/puppeteer.js --webgpu",
     "test-treeshake": "rollup -c test/rollup.treeshake.config.js",
     "test-circular-deps": "dpdm --no-warning --no-tree --exit-code circular:1 src/nodes/Nodes.js",
-    "make-screenshot": "node test/e2e/puppeteer.js --make"
+    "make-screenshot": "node test/e2e/puppeteer.js --make",
+    "generate-timestamps": "node utils/generate-timestamps.js"
   },
   "keywords": [
     "three",
@@ -106,6 +107,8 @@
     "eslint-plugin-html": "^8.0.0",
     "eslint-plugin-import": "^2.27.5",
     "failonlyreporter": "^1.0.0",
+    "git-date-extractor": "^4.0.1",
+    "glob": "^11.0.3",
     "jimp": "^1.6.0",
     "jsdoc": "^4.0.4",
     "magic-string": "^0.30.0",

--- a/utils/generate-timestamps.js
+++ b/utils/generate-timestamps.js
@@ -1,0 +1,62 @@
+import { getStamps } from 'git-date-extractor';
+import { glob } from 'glob';
+import fs from 'fs';
+
+( async () => {
+
+	const outputFile = 'examples/timestamps.json';
+	const filePattern = 'examples/*.html';
+
+	console.log( 'Starting timestamp generation...' );
+	console.log( `- Finding files with pattern: ${filePattern}` );
+
+	try {
+
+		const files = await glob( filePattern );
+
+		if ( files.length === 0 ) {
+
+			console.error( `Error: Glob pattern "${filePattern}" did not match any files. Please check the path.` );
+			process.exit( 1 );
+
+		}
+
+		console.log( `- Found ${files.length} files to process.` );
+
+		const stamps = await getStamps( {
+			projectRootPath: process.cwd(),
+			files: files, // Pass the explicit list of found files
+		} );
+
+		if ( Object.keys( stamps ).length === 0 ) {
+
+			console.error( 'Error: The script received no data from git-date-extractor, even though files were found.' );
+			console.error( 'This is unexpected. Please ensure your git history is not corrupt.' );
+			process.exit( 1 );
+
+		}
+
+		const cleaned = {};
+		for ( const key in stamps ) {
+
+			const newKey = key.replace( /^examples\//, '' ).replace( /\.html$/, '' );
+			cleaned[ newKey ] = stamps[ key ];
+
+		}
+
+		console.log( `- Successfully processed ${Object.keys( cleaned ).length} files.` );
+
+		fs.writeFileSync( outputFile, JSON.stringify( cleaned, null, 2 ) );
+
+		console.log( `\n✅ Successfully generated ${outputFile}` );
+
+	} catch ( error ) {
+
+		console.error( '\n--- SCRIPT FAILED ---' );
+		console.error( 'An error occurred during timestamp generation:', error );
+		console.error( '---------------------\n' );
+		process.exit( 1 );
+
+	}
+
+} )();


### PR DESCRIPTION
Attempted to add a simple **generate-timestamps** node script and a timestamp-based sort by update date feature to the examples page. I believe new features and updates are getting lost on newcomers who are not regularly following the project. I am not a developer, so please feel free to ignore if this is irrelevant. Cheers.
![image](https://github.com/user-attachments/assets/bf3bcc5a-4373-48e5-ac75-b38dc3b71ab8)
