### PR TITLE
TSL: `viewportTexture()` cache `FramebufferTexture` according to `RenderTarget`

### DIFF
--- a/src/nodes/display/ViewportTextureNode.js
+++ b/src/nodes/display/ViewportTextureNode.js
@@ -8,7 +8,6 @@ import { FramebufferTexture } from '../../textures/FramebufferTexture.js';
 import { LinearMipmapLinearFilter } from '../../constants.js';
 
 const _size = /*@__PURE__*/ new Vector2();
-const _textures = /*@__PURE__*/ new WeakMap();
 
 /**
  * A special type of texture node which represents the data of the current viewport
@@ -89,6 +88,14 @@ class ViewportTextureNode extends TextureNode {
 		 */
 		this.updateBeforeType = NodeUpdateType.RENDER;
 
+		/**
+		 * The framebuffer texture for the current renderer context.
+		 *
+		 * @type {WeakMap}
+		 * @private
+		 */
+		this._textures = new WeakMap();
+
 	}
 
 	getFrameBufferTexture( reference = null ) {
@@ -101,22 +108,22 @@ class ViewportTextureNode extends TextureNode {
 
 		}
 
-		if ( _textures.has( reference ) === false ) {
+		if ( this._textures.has( reference ) === false ) {
 
 			const framebufferTexture = defaultFramebuffer.clone();
 
-			_textures.set( reference, framebufferTexture );
+			this._textures.set( reference, framebufferTexture );
 
 		}
 
-		return _textures.get( reference );
+		return this._textures.get( reference );
 
 	}
 
 	updateBefore( frame ) {
 
 		const renderer = frame.renderer;
-		const renderTarget = frame.renderer.getRenderTarget();
+		const renderTarget = renderer.getRenderTarget();
 
 		if ( renderTarget === null ) {
 

--- a/src/nodes/display/ViewportTextureNode.js
+++ b/src/nodes/display/ViewportTextureNode.js
@@ -70,7 +70,7 @@ class ViewportTextureNode extends TextureNode {
 		 * @default null
 		 */
 		this.defaultFramebuffer = defaultFramebuffer;
-		
+
 		/**
 		 * This flag can be used for type testing.
 		 *

--- a/src/nodes/display/ViewportTextureNode.js
+++ b/src/nodes/display/ViewportTextureNode.js
@@ -8,6 +8,7 @@ import { FramebufferTexture } from '../../textures/FramebufferTexture.js';
 import { LinearMipmapLinearFilter } from '../../constants.js';
 
 const _size = /*@__PURE__*/ new Vector2();
+const _textures = /*@__PURE__*/ new WeakMap();
 
 /**
  * A special type of texture node which represents the data of the current viewport
@@ -35,10 +36,18 @@ class ViewportTextureNode extends TextureNode {
 	 */
 	constructor( uvNode = screenUV, levelNode = null, framebufferTexture = null ) {
 
+		let defaultFramebuffer = null;
+
 		if ( framebufferTexture === null ) {
 
-			framebufferTexture = new FramebufferTexture();
-			framebufferTexture.minFilter = LinearMipmapLinearFilter;
+			defaultFramebuffer = new FramebufferTexture();
+			defaultFramebuffer.minFilter = LinearMipmapLinearFilter;
+
+			framebufferTexture = defaultFramebuffer;
+
+		} else {
+
+			defaultFramebuffer = framebufferTexture;
 
 		}
 
@@ -53,6 +62,16 @@ class ViewportTextureNode extends TextureNode {
 		this.generateMipmaps = false;
 
 		/**
+		 * The reference framebuffer texture. This is used to store the framebuffer texture
+		 * for the current render target. If the render target changes, a new framebuffer texture
+		 * is created automatically.
+		 *
+		 * @type {FramebufferTexture}
+		 * @default null
+		 */
+		this.defaultFramebuffer = defaultFramebuffer;
+		
+		/**
 		 * This flag can be used for type testing.
 		 *
 		 * @type {boolean}
@@ -62,24 +81,56 @@ class ViewportTextureNode extends TextureNode {
 		this.isOutputTextureNode = true;
 
 		/**
-		 * The `updateBeforeType` is set to `NodeUpdateType.FRAME` since the node renders the
-		 * scene once per frame in its {@link ViewportTextureNode#updateBefore} method.
+		 * The `updateBeforeType` is set to `NodeUpdateType.RENDER` since the node renders the
+		 * scene once per render in its {@link ViewportTextureNode#updateBefore} method.
 		 *
 		 * @type {string}
 		 * @default 'frame'
 		 */
-		this.updateBeforeType = NodeUpdateType.FRAME;
+		this.updateBeforeType = NodeUpdateType.RENDER;
+
+	}
+
+	getFrameBufferTexture( reference = null ) {
+
+		const defaultFramebuffer = this.referenceNode ? this.referenceNode.defaultFramebuffer : this.defaultFramebuffer;
+
+		if ( reference === null ) {
+
+			return defaultFramebuffer;
+
+		}
+
+		if ( _textures.has( reference ) === false ) {
+
+			const framebufferTexture = defaultFramebuffer.clone();
+
+			_textures.set( reference, framebufferTexture );
+
+		}
+
+		return _textures.get( reference );
 
 	}
 
 	updateBefore( frame ) {
 
 		const renderer = frame.renderer;
-		renderer.getDrawingBufferSize( _size );
+		const renderTarget = frame.renderer.getRenderTarget();
+
+		if ( renderTarget === null ) {
+
+			renderer.getDrawingBufferSize( _size );
+
+		} else {
+
+			_size.set( renderTarget.width, renderTarget.height );
+
+		}
 
 		//
 
-		const framebufferTexture = this.value;
+		const framebufferTexture = this.getFrameBufferTexture( renderTarget );
 
 		if ( framebufferTexture.image.width !== _size.width || framebufferTexture.image.height !== _size.height ) {
 
@@ -97,6 +148,8 @@ class ViewportTextureNode extends TextureNode {
 		renderer.copyFramebufferToTexture( framebufferTexture );
 
 		framebufferTexture.generateMipmaps = currentGenerateMipmaps;
+
+		this.value = framebufferTexture;
 
 	}
 


### PR DESCRIPTION
Fixes https://github.com/mrdoob/three.js/pull/31294#issuecomment-3018507294

**Description**

Cache `FramebufferTexture` according to `RenderTarget`, preventing the same framebuffer texture from being used in different rendering contexts.

![image](https://github.com/user-attachments/assets/0548e5cd-7283-4108-8899-68810ced1ab1)
