### PR TITLE
TransformControls: introduce scaleFromEdge property

### DIFF
--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -1,5 +1,4 @@
 import {
-	Box3,
 	BoxGeometry,
 	BufferGeometry,
 	Controls,

--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -460,6 +460,10 @@ class TransformControls extends Controls {
 					this.object.geometry.computeBoundingBox();
 					this._bbox = this.object.geometry.boundingBox.clone();
 
+				} else {
+
+					this._bbox = null;
+
 				}
 
 			}

--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -460,10 +460,6 @@ class TransformControls extends Controls {
 					if (!this.object.geometry.boundingBox) this.object.geometry.computeBoundingBox();
 					this._bbox = this.object.geometry.boundingBox.clone();
 
-				} else {
-
-					this._bbox = null;
-
 				}
 
 			}

--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -361,13 +361,13 @@ class TransformControls extends Controls {
 		this._quaternionStart = new Quaternion();
 		this._scaleStart = new Vector3();
 
+		this._bbox = null;
+
 		this._getPointer = getPointer.bind( this );
 		this._onPointerDown = onPointerDown.bind( this );
 		this._onPointerHover = onPointerHover.bind( this );
 		this._onPointerMove = onPointerMove.bind( this );
 		this._onPointerUp = onPointerUp.bind( this );
-
-		this._bbox = null;
 
 		if ( domElement !== null ) {
 
@@ -455,12 +455,12 @@ class TransformControls extends Controls {
 
 				this.pointStart.copy( planeIntersect.point ).sub( this.worldPositionStart );
 
-                if ( this.object.geometry ) {
+				if ( this.object.geometry ) {
 
-				    this.object.geometry.computeBoundingBox();
-				    this._bbox = this.object.geometry.boundingBox.clone();
+					this.object.geometry.computeBoundingBox();
+					this._bbox = this.object.geometry.boundingBox.clone();
 
-                }
+				}
 
 			}
 
@@ -664,6 +664,7 @@ class TransformControls extends Controls {
 			}
 
 			// Scale from pulled side
+
 			if ( this.scaleFromEdge && this._bbox ) {
 
 				if ( this.pointStart.x > 0 ) {
@@ -686,13 +687,13 @@ class TransformControls extends Controls {
 
 				}
 
-				if (this.pointStart.z > 0) {
+				if ( this.pointStart.z > 0 ) {
 
-					this._offset.z = this._bbox.min.z * (this._scaleStart.z - object.scale.z);
+					this._offset.z = this._bbox.min.z * ( this._scaleStart.z - object.scale.z );
 
 				} else {
 
-					this._offset.z = this._bbox.max.z * (this._scaleStart.z - object.scale.z);
+					this._offset.z = this._bbox.max.z * ( this._scaleStart.z - object.scale.z );
 
 				}
 

--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -457,7 +457,8 @@ class TransformControls extends Controls {
 
 				if ( this.object.geometry ) {
 
-					if (!this.object.geometry.boundingBox) this.object.geometry.computeBoundingBox();
+					if ( ! this.object.geometry.boundingBox ) this.object.geometry.computeBoundingBox();
+
 					this._bbox = this.object.geometry.boundingBox.clone();
 
 				}

--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -457,7 +457,7 @@ class TransformControls extends Controls {
 
 				if ( this.object.geometry ) {
 
-					this.object.geometry.computeBoundingBox();
+					if (!this.object.geometry.boundingBox) this.object.geometry.computeBoundingBox();
 					this._bbox = this.object.geometry.boundingBox.clone();
 
 				} else {

--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -640,6 +640,11 @@ class TransformControls extends Controls {
 
 			// Apply scale
 
+			// Don't allow negative scales
+			if ( _tempVector2.x < 0 || _tempVector2.y < 0 || _tempVector2.z < 0 ) {
+				return;
+			}
+
 			object.scale.copy( this._scaleStart ).multiply( _tempVector2 );
 
 			if ( this.scaleSnap ) {


### PR DESCRIPTION
This PR proposes an option to the TransformControls to scale objects while keeping the opposite edge as the fixed anchor point, instead of scaling around the center. It currently only works for simple objects, not object groups.