### PR TITLE
RoomEnvironment: Set emissiveIntensity instead

### DIFF
--- a/examples/jsm/environments/RoomEnvironment.js
+++ b/examples/jsm/environments/RoomEnvironment.js
@@ -168,6 +168,7 @@ class RoomEnvironment extends Scene {
 
 function createAreaLightMaterial( intensity ) {
 
+	// create an emissive-only material. see #31348
 	const material = new MeshLambertMaterial( {
 		color: 0x000000,
 		emissive: 0xffffff,

--- a/examples/jsm/environments/RoomEnvironment.js
+++ b/examples/jsm/environments/RoomEnvironment.js
@@ -3,7 +3,7 @@ import {
  	BoxGeometry,
  	InstancedMesh,
  	Mesh,
-	MeshBasicMaterial,
+	MeshLambertMaterial,
  	MeshStandardMaterial,
  	PointLight,
  	Scene,
@@ -168,8 +168,12 @@ class RoomEnvironment extends Scene {
 
 function createAreaLightMaterial( intensity ) {
 
-	const material = new MeshBasicMaterial();
-	material.color.setScalar( intensity );
+	const material = new MeshLambertMaterial( {
+		color: 0x000000,
+		emissive: 0xffffff,
+		emissiveIntensity: intensity
+	} );
+
 	return material;
 
 }

--- a/src/materials/MeshBasicMaterial.js
+++ b/src/materials/MeshBasicMaterial.js
@@ -42,7 +42,7 @@ class MeshBasicMaterial extends Material {
 		 * @type {Color}
 		 * @default (1,1,1)
 		 */
-		this.color = new Color( 0xffffff ); // emissive
+		this.color = new Color( 0xffffff ); // diffuse
 
 		/**
 		 * The color map. May optionally include an alpha channel, typically combined


### PR DESCRIPTION
`material.color` represents the diffuse reflectance of the material. It is a dimensionless quantity in [ 0, 1 $]^3$.

It does not make sense to set `material.color` to a value outside that range.

This is particularly true when mapping between sRGB and linear-sRGB color space, as the transfer function is only defined on [ 0, 1 ].

Instead, set the `emissive` property of `MeshLambertMaterial`, and assign the desired intensity to `material.emissiveIntensity`.

`emissive` is dimensionless; `emissiveIntensity` represents luminance.

By luck, as used in `RoomEnvironment`, the result is the same, but the current implementation is improper.
