### PR TITLE
LightProbeGenerator: Support `FloatType` in `fromCubeRenderTarget()`.

### DIFF
--- a/examples/jsm/lights/LightProbeGenerator.js
+++ b/examples/jsm/lights/LightProbeGenerator.js
@@ -8,7 +8,8 @@ import {
 	NoColorSpace,
 	HalfFloatType,
 	DataUtils,
-	WebGLCoordinateSystem
+	WebGLCoordinateSystem,
+	FloatType
 } from 'three';
 
 /**
@@ -178,7 +179,11 @@ class LightProbeGenerator {
 
 		if ( renderer.isWebGLRenderer ) {
 
-			if ( dataType === HalfFloatType ) {
+			if ( dataType === FloatType ) {
+
+				data = new Float32Array( imageWidth * imageWidth * 4 );
+
+			} else if ( dataType === HalfFloatType ) {
 
 				data = new Uint16Array( imageWidth * imageWidth * 4 );
 
@@ -210,7 +215,13 @@ class LightProbeGenerator {
 
 				let r, g, b;
 
-				if ( dataType === HalfFloatType ) {
+				if ( dataType === FloatType ) {
+
+					r = data[ i ];
+					g = data[ i + 1 ];
+					b = data[ i + 2 ];
+
+				} else if ( dataType === HalfFloatType ) {
 
 					r = DataUtils.fromHalfFloat( data[ i ] );
 					g = DataUtils.fromHalfFloat( data[ i + 1 ] );

--- a/test/e2e/puppeteer.js
+++ b/test/e2e/puppeteer.js
@@ -113,6 +113,8 @@ const exceptionList = [
 	'webgl_volume_instancing',
 	'webgl_buffergeometry',
 	'webgl_buffergeometry_attributes_integer',
+	'webgl_buffergeometry_attributes_none',
+	'webgl_buffergeometry_custom_attributes_particles',
 	'webgl_batch_lod_bvh',
 
 	// Intentional z-fighting in this demo makes it non-deterministic


### PR DESCRIPTION
Fixed #31347.

**Description**

`LightProbeGenerator.fromCubeRenderTarget()` now supports `FloatType` as the data type of the input cube texture.
