### PR TITLE
Examples: Use `onLoad()` in `webgpu_materials`.

### DIFF
--- a/examples/webgpu_materials.html
+++ b/examples/webgpu_materials.html
@@ -429,20 +429,22 @@
 
 				const json = mesh.toJSON();
 				const loader = new THREE.NodeObjectLoader().setNodes( moduleToLib( THREE ) ).setNodeMaterials( moduleToLib( THREE ) );
-				const serializedMesh = loader.parse( json );
+				const serializedMesh = loader.parse( json, () => {
 
-				serializedMesh.position.x = ( objects.length % 4 ) * 200 - 400;
-				serializedMesh.position.z = Math.floor( objects.length / 4 ) * 200 - 200;
+					serializedMesh.position.x = ( objects.length % 4 ) * 200 - 400;
+					serializedMesh.position.z = Math.floor( objects.length / 4 ) * 200 - 200;
 
-				const scriptableNode = serializedMesh.material.colorNode;
+					const scriptableNode = serializedMesh.material.colorNode;
 
-				// it's because local.get( 'material' ) is used in the example ( local/global is unserializable )
-				scriptableNode.setLocal( 'material', serializedMesh.material );
-				scriptableNode.setParameter( 'execFrom', 'serialized' );
+					// it's because local.get( 'material' ) is used in the example ( local/global is unserializable )
+					scriptableNode.setLocal( 'material', serializedMesh.material );
+					scriptableNode.setParameter( 'execFrom', 'serialized' );
 
-				objects.push( serializedMesh );
+					objects.push( serializedMesh );
 
-				scene.add( serializedMesh );
+					scene.add( serializedMesh );
+
+				} );
 
 			}
 


### PR DESCRIPTION
This fixes intermittent "Texture marked for update but image is incomplete" errors running the demo in Firefox, by waiting until the `onLoad` event has fired before adding the object to the scene.