### PR TITLE
GLTFExporter rougness-metalness export cache fix

### DIFF
--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -935,6 +935,8 @@ class GLTFWriter {
 	async buildMetalRoughTextureAsync( metalnessMap, roughnessMap ) {
 
 		if ( metalnessMap === roughnessMap ) return metalnessMap;
+		if ( metalnessMap === null ) return roughnessMap;
+		if ( roughnessMap === null ) return metalnessMap;
 
 		function getEncodingConversion( map ) {
 


### PR DESCRIPTION
Related issue: #31364

**Description**

Early return if only one map is in the material. That way, this texture can be cached and we don't need to use canvas 2d to mix those textures.

