### PR TITLE
NodeMaterialObserver: Accounts for lightsNode

### DIFF
--- a/examples/webgpu_lights_projector.html
+++ b/examples/webgpu_lights_projector.html
@@ -136,10 +136,15 @@
 
 					const mesh = new THREE.Mesh( geometry, material );
 					mesh.rotation.y = - Math.PI / 2;
+					mesh.position.x = - 1;
 					mesh.position.y = 0.8;
 					mesh.castShadow = true;
 					mesh.receiveShadow = true;
 					scene.add( mesh );
+
+					const mesh2 = mesh.clone();
+					mesh2.position.x = 1;
+					scene.add( mesh2 );
 
 				} );
 

--- a/src/materials/nodes/manager/NodeMaterialObserver.js
+++ b/src/materials/nodes/manager/NodeMaterialObserver.js
@@ -497,6 +497,9 @@ class NodeMaterialObserver {
 	 */
 	needsRefresh( renderObject, nodeFrame ) {
 
+		if ( renderObject.lightsNode.getLights().some( light => light.map ) )
+			return true;
+
 		if ( this.hasNode || this.hasAnimation || this.firstInitialization( renderObject ) || this.needsVelocity( nodeFrame.renderer ) )
 			return true;
 


### PR DESCRIPTION
Fix: #31330

**Description**

This PR ensures NodeMaterialObserver observes renderObject associated `lightsNode`,

and updates webgpu_lights_projector.html to have multi models, for test.