### PR TITLE
WebGLRenderer: Add `ReversedCoordinateSystem`, fix shadows with `reverseDepthBuffer`.

### DIFF
--- a/examples/jsm/shaders/UnpackDepthRGBAShader.js
+++ b/examples/jsm/shaders/UnpackDepthRGBAShader.js
@@ -43,8 +43,21 @@ const UnpackDepthRGBAShader = {
 
 		void main() {
 
-			float depth = 1.0 - unpackRGBAToDepth( texture2D( tDiffuse, vUv ) );
-			gl_FragColor = vec4( vec3( depth ), opacity );
+			float depth = unpackRGBAToDepth( texture2D( tDiffuse, vUv ) );
+
+			#ifdef USE_REVERSEDEPTHBUF
+
+				if ( depth == 1.0 ) depth = 0.0; // wrong clear value?
+
+				// [0, 1] -> [-1, 1]
+				depth = depth * 2.0 - 1.0;
+
+				// Reverse to forward depth (precision is already destroyed at this point)
+				depth = 1.0 - depth;
+
+			#endif
+
+			gl_FragColor = vec4( vec3( 1.0 - depth ), opacity );
 
 		}`
 

--- a/examples/webgl_reverse_depth_buffer.html
+++ b/examples/webgl_reverse_depth_buffer.html
@@ -107,7 +107,7 @@
 			import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
 			import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
 
-			let stats, camera, scene;
+			let stats, camera, reversedCamera, scene;
 			let normalRenderer, logarithmicRenderer, reverseRenderer;
 			let normalComposer, logarithmicComposer, reverseComposer;
 			const meshes = [];
@@ -128,6 +128,9 @@
 
 				camera = new THREE.PerspectiveCamera( 72, 0.33 * window.innerWidth / window.innerHeight, 5, 9999 );
 				camera.position.z = 12;
+
+				reversedCamera = camera.clone();
+				reversedCamera.coordinateSystem = THREE.ReversedCoordinateSystem;
 
 				scene = new THREE.Scene();
 
@@ -236,7 +239,7 @@
 				reverseContainer.appendChild( reverseRenderer.domElement );
 
 				reverseComposer = new EffectComposer( reverseRenderer, renderTarget );
-				reverseComposer.addPass( new RenderPass( scene, camera ) );
+				reverseComposer.addPass( new RenderPass( scene, reversedCamera ) );
 				reverseComposer.addPass( new OutputPass() );
 
 				window.addEventListener( 'resize', onWindowResize );
@@ -288,6 +291,9 @@
 
 				camera.aspect = 0.33 * window.innerWidth / window.innerHeight;
 				camera.updateProjectionMatrix();
+
+				reversedCamera.aspect = 0.33 * window.innerWidth / window.innerHeight;
+				reversedCamera.updateProjectionMatrix();
 
 			}
 		</script>

--- a/examples/webgl_shadowmap.html
+++ b/examples/webgl_shadowmap.html
@@ -102,11 +102,18 @@
 
 				// RENDERER
 
-				renderer = new THREE.WebGLRenderer( { antialias: true } );
+				renderer = new THREE.WebGLRenderer( { antialias: true, reverseDepthBuffer: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( SCREEN_WIDTH, SCREEN_HEIGHT );
 				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
+
+				if ( renderer.capabilities.reverseDepthBuffer ) {
+
+					camera.coordinateSystem = THREE.ReversedCoordinateSystem;
+					camera.updateProjectionMatrix();
+
+				}
 
 				renderer.autoClear = false;
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -1564,7 +1564,7 @@ export const GLSL1 = '100';
 export const GLSL3 = '300 es';
 
 /**
- * WebGL coordinate system.
+ * WebGL coordinate system [-1, 1].
  *
  * @type {number}
  * @constant
@@ -1572,12 +1572,22 @@ export const GLSL3 = '300 es';
 export const WebGLCoordinateSystem = 2000;
 
 /**
- * WebGPU coordinate system.
+ * WebGPU coordinate system [0, 1].
  *
  * @type {number}
  * @constant
  */
 export const WebGPUCoordinateSystem = 2001;
+
+/**
+ * Reversed coordinate system [1, 0].
+ *
+ * Used for reverse depth buffer.
+ *
+ * @type {number}
+ * @constant
+ */
+export const ReversedCoordinateSystem = 2002;
 
 /**
  * Represents the different timestamp query types.

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -1,4 +1,4 @@
-import { WebGLCoordinateSystem, WebGPUCoordinateSystem } from '../constants.js';
+import { WebGLCoordinateSystem, WebGPUCoordinateSystem, ReversedCoordinateSystem } from '../constants.js';
 import { Vector3 } from './Vector3.js';
 
 /**
@@ -1126,6 +1126,11 @@ class Matrix4 {
 			c = - far / ( far - near );
 			d = ( - far * near ) / ( far - near );
 
+		} else if ( coordinateSystem === ReversedCoordinateSystem ) {
+
+			c = far / ( far - near ) - 1;
+			d = ( far * near ) / ( far - near );
+
 		} else {
 
 			throw new Error( 'THREE.Matrix4.makePerspective(): Invalid coordinate system: ' + coordinateSystem );
@@ -1175,6 +1180,11 @@ class Matrix4 {
 
 			z = near * p;
 			zInv = - 1 * p;
+
+		} else if ( coordinateSystem === ReversedCoordinateSystem ) {
+
+			z = - near * p - 1;
+			zInv = 1 * p;
 
 		} else {
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -17,7 +17,8 @@ import {
 	UnsignedInt248Type,
 	UnsignedShort4444Type,
 	UnsignedShort5551Type,
-	WebGLCoordinateSystem
+	WebGLCoordinateSystem,
+	ReversedCoordinateSystem
 } from '../constants.js';
 import { Color } from '../math/Color.js';
 import { Frustum } from '../math/Frustum.js';
@@ -2382,7 +2383,10 @@ class WebGLRenderer {
 
 				const reverseDepthBuffer = state.buffers.depth.getReversed();
 
-				if ( reverseDepthBuffer ) {
+				if ( reverseDepthBuffer && camera.coordinateSystem !== ReversedCoordinateSystem ) {
+
+					// @deprecated, r179
+					warnOnce( 'THREE.WebGLRenderer: reverseDepthBuffer must be used with camera.coordinateSystem = THREE.ReversedCoordinateSystem for correct results. Automatic conversion will be removed in r189.' );
 
 					_currentProjectionMatrix.copy( camera.projectionMatrix );
 

--- a/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl.js
@@ -75,7 +75,18 @@ export default /* glsl */`
 
 	float texture2DCompare( sampler2D depths, vec2 uv, float compare ) {
 
-		return step( compare, unpackRGBAToDepth( texture2D( depths, uv ) ) );
+		float depth = unpackRGBAToDepth( texture2D( depths, uv ) );
+
+		#ifdef USE_REVERSEDEPTHBUF
+
+			if ( depth == 1.0 ) depth = 0.0; // wrong clear value?
+			return step( depth, compare );
+
+		#else
+
+			return step( compare, depth );
+
+		#endif
 
 	}
 
@@ -91,7 +102,15 @@ export default /* glsl */`
 
 		vec2 distribution = texture2DDistribution( shadow, uv );
 
-		float hard_shadow = step( compare , distribution.x ); // Hard Shadow
+		#ifdef USE_REVERSEDEPTHBUF
+
+			float hard_shadow = step( distribution.x, compare ); // Hard Shadow
+
+		#else
+
+			float hard_shadow = step( compare , distribution.x ); // Hard Shadow
+
+		#endif
 
 		if (hard_shadow != 1.0 ) {
 

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -1,4 +1,4 @@
-import { FrontSide, BackSide, DoubleSide, NearestFilter, PCFShadowMap, VSMShadowMap, RGBADepthPacking, NoBlending } from '../../constants.js';
+import { FrontSide, BackSide, DoubleSide, NearestFilter, PCFShadowMap, VSMShadowMap, RGBADepthPacking, NoBlending, ReversedCoordinateSystem } from '../../constants.js';
 import { WebGLRenderTarget } from '../WebGLRenderTarget.js';
 import { MeshDepthMaterial } from '../../materials/MeshDepthMaterial.js';
 import { MeshDistanceMaterial } from '../../materials/MeshDistanceMaterial.js';
@@ -149,6 +149,17 @@ function WebGLShadowMap( renderer, objects, capabilities ) {
 
 				shadow.map = new WebGLRenderTarget( _shadowMapSize.x, _shadowMapSize.y, pars );
 				shadow.map.texture.name = light.name + '.shadowMap';
+
+				// @deprecated, r179
+				if ( capabilities.reverseDepthBuffer === true && camera.coordinateSystem !== ReversedCoordinateSystem ) {
+
+					shadow.camera.coordinateSystem = ReversedCoordinateSystem;
+
+				} else {
+
+					shadow.camera.coordinateSystem = camera.coordinateSystem;
+
+				}
 
 				shadow.camera.updateProjectionMatrix();
 


### PR DESCRIPTION
Fixed #29770

**Description**

Introduces `ReversedCoordinateSystem` to produce a [0, 1] reversed projection matrix. This was previously done internally on the GPU with #29445. For backwards compatibility purposes, I have deprecated this conversion, and it now emits a warning, encouraging cameras to be configured with `ReversedCoordinateSystem` when using reverse depth. As reverse depth in WebGL relies on `EXT_clip_control`, it is best to use feature detection:

```js
const renderer = new THREE.WebGLRenderer( { reverseDepthBuffer: true } );

const camera = new THREE.PerspectiveCamera();

if ( renderer.capabilities.reverseDepthBuffer ) { // Firefox, namely

	camera.coordinateSystem = THREE.ReversedCoordinateSystem;
	camera.updateProjectionMatrix();

}
```

Shadow maps are also fixed in this PR, which previously had misconfigured shadow cameras and the wrong comparison operator (as depth is now reversed). Shaders that rely on a specific NDC range or linearize depth still need to be updated.

I have not updated cascaded shadow maps (CSM) and other add-ons like GTAO with this PR.

| Before | After |
|--------|--------|
| ![Before](https://github.com/user-attachments/assets/465585c7-83ab-4468-b9f8-d9190195f3b5) | ![After](https://github.com/user-attachments/assets/52713a45-b7a5-4c22-999b-0a302b9250ca) |

All shadow map types were tested with this PR. Below is a quality comparison after changes with/without `reverseDepthBuffer`.

Note that an ideal setup for `reverseDepthBuffer` configures a floating-point depth buffer in post-processing https://github.com/mrdoob/three.js/pull/29445#issuecomment-2362709888.

| | Default | Reverse Depth |
|--------|--------|--------|
| `BasicShadowMap` | ![Default](https://github.com/user-attachments/assets/315cdba9-89ee-4c9e-928c-6d9a26d00e54) | ![Reverse Depth](https://github.com/user-attachments/assets/effd5d56-e1a0-4f69-bb14-6f67f2546f42) |
| `PCFShadowMap` | ![Default](https://github.com/user-attachments/assets/ae8da7a6-1245-40bd-a410-e7bb595d116f) | ![Reverse Depth](https://github.com/user-attachments/assets/ee38cf80-1563-411c-909d-499d95bd20ba) |
| `PCFSoftShadowMap` | ![Default](https://github.com/user-attachments/assets/c164b3eb-4c96-4bd8-b1c5-0198725fcdc9) | ![Reverse Depth](https://github.com/user-attachments/assets/498e31d4-b11b-4ec7-83de-a4dbba2440e2) |
| `VSMShadowMap` | ![Default](https://github.com/user-attachments/assets/09e9febb-1dcd-4aad-b099-2cce608779d6) | ![Reverse Depth](https://github.com/user-attachments/assets/521adc48-5f90-434c-8e9d-196f33fa03ca) |
