### PR TITLE
VideoTexture: Cancel rVFC on Dispose

### DIFF
--- a/src/textures/VideoTexture.js
+++ b/src/textures/VideoTexture.js
@@ -55,7 +55,7 @@ class VideoTexture extends Texture {
 
 		/**
 		 * The video frame request callback identifier, which is initially zero.
-		 * 
+		 *
 		 * @private
 		 * @type {number}
 		 */

--- a/src/textures/VideoTexture.js
+++ b/src/textures/VideoTexture.js
@@ -54,12 +54,14 @@ class VideoTexture extends Texture {
 		this.generateMipmaps = false;
 
 		/**
-		 * The video frame request callback identifier, which is initially zero.
+		 * The video frame request callback identifier, which is a positive integer.
+		 * 
+		 * Value of 0 represents no scheduled rVFC.
 		 *
 		 * @private
 		 * @type {number}
 		 */
-		this._requestVideoFrameCallbackId = - 1;
+		this._requestVideoFrameCallbackId = 0;
 
 		const scope = this;
 
@@ -108,7 +110,7 @@ class VideoTexture extends Texture {
 	 */
 	dispose() {
 
-		if ( this._requestVideoFrameCallbackId !== - 1 ) {
+		if ( this._requestVideoFrameCallbackId !== 0 ) {
 
 			this.source.data.cancelVideoFrameCallback( this._requestVideoFrameCallbackId );
 

--- a/src/textures/VideoTexture.js
+++ b/src/textures/VideoTexture.js
@@ -55,7 +55,7 @@ class VideoTexture extends Texture {
 
 		/**
 		 * The video frame request callback identifier, which is a positive integer.
-		 * 
+		 *
 		 * Value of 0 represents no scheduled rVFC.
 		 *
 		 * @private

--- a/src/textures/VideoTexture.js
+++ b/src/textures/VideoTexture.js
@@ -53,18 +53,26 @@ class VideoTexture extends Texture {
 		 */
 		this.generateMipmaps = false;
 
+		/**
+		 * The video frame request callback identifier, which is initially zero.
+		 * 
+		 * @private
+		 * @type {number}
+		 */
+		this._requestVideoFrameCallbackId = - 1;
+
 		const scope = this;
 
 		function updateVideo() {
 
 			scope.needsUpdate = true;
-			video.requestVideoFrameCallback( updateVideo );
+			scope._requestVideoFrameCallbackId = video.requestVideoFrameCallback( updateVideo );
 
 		}
 
 		if ( 'requestVideoFrameCallback' in video ) {
 
-			video.requestVideoFrameCallback( updateVideo );
+			this._requestVideoFrameCallbackId = video.requestVideoFrameCallback( updateVideo );
 
 		}
 
@@ -92,6 +100,21 @@ class VideoTexture extends Texture {
 			this.needsUpdate = true;
 
 		}
+
+	}
+
+	/**
+	 * @override
+	 */
+	dispose() {
+
+		if ( this._requestVideoFrameCallbackId !== - 1 ) {
+
+			this.source.data.cancelVideoFrameCallback( this._requestVideoFrameCallbackId );
+
+		}
+
+		super.dispose();
 
 	}
 


### PR DESCRIPTION
**Description**

This PR ensures that `onUpdate` wouldn't be called after `dispose()`. 