### PR TITLE
KeyframeTrack: Correct typing of `values`.

### DIFF
--- a/src/animation/KeyframeTrack.js
+++ b/src/animation/KeyframeTrack.js
@@ -20,7 +20,7 @@ class KeyframeTrack {
 	 *
 	 * @param {string} name - The keyframe track's name.
 	 * @param {Array<number>} times - A list of keyframe times.
-	 * @param {Array<number>} values - A list of keyframe values.
+	 * @param {Array<number|string|boolean>} values - A list of keyframe values.
 	 * @param {(InterpolateLinear|InterpolateDiscrete|InterpolateSmooth)} [interpolation] - The interpolation type.
 	 */
 	constructor( name, times, values, interpolation ) {

--- a/src/animation/tracks/BooleanKeyframeTrack.js
+++ b/src/animation/tracks/BooleanKeyframeTrack.js
@@ -16,7 +16,7 @@ class BooleanKeyframeTrack extends KeyframeTrack {
 	 *
 	 * @param {string} name - The keyframe track's name.
 	 * @param {Array<number>} times - A list of keyframe times.
-	 * @param {Array<number>} values - A list of keyframe values.
+	 * @param {Array<boolean>} values - A list of keyframe values.
 	 */
 	constructor( name, times, values ) {
 

--- a/src/animation/tracks/StringKeyframeTrack.js
+++ b/src/animation/tracks/StringKeyframeTrack.js
@@ -16,7 +16,7 @@ class StringKeyframeTrack extends KeyframeTrack {
 	 *
 	 * @param {string} name - The keyframe track's name.
 	 * @param {Array<number>} times - A list of keyframe times.
-	 * @param {Array<number>} values - A list of keyframe values.
+	 * @param {Array<string>} values - A list of keyframe values.
 	 */
 	constructor( name, times, values ) {
 


### PR DESCRIPTION
Fixed #31374.

**Description**

Fixed the typings of the `values` property which is not always `number`.