### PR TITLE
Fix line raycast

### DIFF
--- a/examples/jsm/lines/LineSegments2.js
+++ b/examples/jsm/lines/LineSegments2.js
@@ -70,14 +70,15 @@ function raycastWorldUnits( lineSegments, intersects ) {
 		const point = new Vector3();
 
 		_ray.distanceSqToSegment( _line.start, _line.end, point, pointOnLine );
-		const isInside = point.distanceTo( pointOnLine ) < _lineWidth * 0.5;
+		const distance = point.distanceTo( pointOnLine );
+		const isInside = distance < _lineWidth * 0.5;
 
 		if ( isInside ) {
 
 			intersects.push( {
 				point,
 				pointOnLine,
-				distance: _ray.origin.distanceTo( point ),
+				distance: distance,
 				object: lineSegments,
 				face: null,
 				faceIndex: i,
@@ -205,12 +206,12 @@ function raycastScreenSpace( lineSegments, camera, intersects ) {
 			const pointOnLine = new Vector3();
 			const point = new Vector3();
 
-			_ray.distanceSqToSegment( _line.start, _line.end, point, pointOnLine );
+			const distSq = _ray.distanceSqToSegment( _line.start, _line.end, point, pointOnLine );
 
 			intersects.push( {
 				point: point,
 				pointOnLine: pointOnLine,
-				distance: _ray.origin.distanceTo( point ),
+				distance: Math.sqrt( distSq ),
 				object: lineSegments,
 				face: null,
 				faceIndex: i,

--- a/src/objects/Line.js
+++ b/src/objects/Line.js
@@ -303,9 +303,7 @@ function checkIntersection( object, raycaster, ray, thresholdSq, a, b, i ) {
 
 	if ( distSq > thresholdSq ) return;
 
-	_intersectPointOnRay.applyMatrix4( object.matrixWorld ); // Move back to world space for distance calculation
-
-	const distance = raycaster.ray.origin.distanceTo( _intersectPointOnRay );
+	const distance = Math.sqrt( distSq );
 
 	if ( distance < raycaster.near || distance > raycaster.far ) return;
 


### PR DESCRIPTION
**Description**

Raycast on line seems to have wrong distance calculation.
We expect to have the closest line to the ray at first intersect regardless of the threshold setting.

If we increse `threshold` parameter  in `webgl_interactive_lines` demo we can see some strange offset (wrong first line intersect detected).

```typescript
raycaster.params.Line.threshold = 20;
```

We can see same problem with Line2 in `webgl_lines_fat_raycasting` demo if the set threshold to `10`.

So I saw in the code of `Line` & `LineSegments2` that distance calculation is : 
```typescript
const distance = raycaster.ray.origin.distanceTo( _intersectPointOnRay );
```

Why not use the nearest distance to the segment instead ? It allows you to have the nearest line no matter what threshold parameter we have.

```typescript
const distSq = ray.distanceSqToSegment( _vStart, _vEnd, _intersectPointOnRay, _intersectPointOnSegment );
const distance = Math.sqrt(distSq);
```