### PR TITLE
Line3: Add method for computing closest squared distance between line segments.

### DIFF
--- a/src/math/Line3.js
+++ b/src/math/Line3.js
@@ -186,9 +186,10 @@ class Line3 {
 	/**
 	 *
 	 * @param {Line3} line Line to find distance to
+	 * @param {boolean} clampToLine  - Whether to clamp the result to the range `[0,1]` or not.
 	 * @return {number} Closest distance between lines
 	 */
-	closestDistanceToLine( line ) {
+	closestDistanceToLine( line, clampToLine ) {
 
 		// algorithm thanks to Real-Time Collision Detection by Christer Ericson,
 		// published by Morgan Kaufmann Publishers, (c) 2005 Elsevier Inc.,
@@ -208,13 +209,13 @@ class Line3 {
 
 		if ( thisLengthSq < EPS_SQR ) {
 
-			return line.distanceToPoint( this.start );
+			return line.distanceToPoint( this.start, clampToLine );
 
 		}
 
 		if ( otherLengthSq < EPS_SQR ) {
 
-			return this.distanceToPoint( line.start );
+			return this.distanceToPoint( line.start, clampToLine );
 
 		}
 
@@ -232,8 +233,11 @@ class Line3 {
 		if ( denom != 0 ) {
 
 			s = ( b * f - c * otherLengthSq ) / denom;
-			// TODO: Clamp only if needed
-			s = Math.min( Math.max( s, 0 ), 1 );
+			if ( clampToLine ) {
+
+				s = clamp( s, 0, 1 );
+
+			}
 
 		}
 
@@ -241,19 +245,22 @@ class Line3 {
 		// t = Dot((P1 + D1*s) - P2,D2) / Dot(D2,D2) = (b*s + f) / otherLengthSq
 		let t = ( b * s + f ) / otherLengthSq;
 
-		// If t in [0,1] done. Else clamp t, recompute s for the new value
-		// of t using s = Dot((P2 + D2*t) - P1,D1) / Dot(D1,D1) = (t*b - c) / thisLengthSq
-		// and clamp s to [0, 1]
-		// TODO: clamp only if needed
-		if ( t < 0.0 ) {
+		if ( clampToLine ) {
 
-			t = 0.0;
-			s = Math.min( Math.max( - c / thisLengthSq, 0 ), 1 );
+			// If t in [0,1] done. Else clamp t, recompute s for the new value
+			// of t using s = Dot((P2 + D2*t) - P1,D1) / Dot(D1,D1) = (t*b - c) / thisLengthSq
+			// and clamp s to [0, 1]
+			if ( t < 0.0 ) {
 
-		} else if ( t > 1 ) {
+				t = 0.0;
+				s = clamp( - c / thisLengthSq, 0, 1 );
 
-			t = 1;
-			s = Math.min( Math.max( ( b - c ) / thisLengthSq, 0 ), 1 );
+			} else if ( t > 1 ) {
+
+				t = 1;
+				s = clamp( ( b - c ) / thisLengthSq, 0, 1 );
+
+			}
 
 		}
 

--- a/src/math/Line3.js
+++ b/src/math/Line3.js
@@ -173,21 +173,6 @@ class Line3 {
 	}
 
 	/**
-	 * Returns distance from a given point to the line.
-	 *
-	 * @param {Vector3} point - The point to compute the closest point on the line for.
-	 * @param {boolean} clampToLine - Whether to clamp the result to the range `[0,1]` or not.
-	 * @return {number} Distance from point to the line.
-	 */
-	distanceToPoint( point, clampToLine ) {
-
-		this.closestPointToPoint( point, clampToLine, _startP );
-
-		return point.distanceTo( _startP );
-
-	}
-
-	/**
 	 * Returns the closest squared distance between this line segment and the given one.
 	 *
 	 * @param {Line3} line - The line segment to compute the closest squared distance to.

--- a/src/math/Line3.js
+++ b/src/math/Line3.js
@@ -193,7 +193,7 @@ class Line3 {
 	 * @param {Vector2} target - The vector that is used to store the method's result. x is parameter for point on this, y is parameter for point on line.
 	 * @return {Vector2} - Point parameters of the shortest segment connecting two lines.
 	 */
-	closestSegmentToLineParameters( line, clampToLine, target ) {
+	shortestSegmentToLineParameters( line, clampToLine, target ) {
 
 		// algorithm thanks to Real-Time Collision Detection by Christer Ericson,
 		// published by Morgan Kaufmann Publishers, (c) 2005 Elsevier Inc.,
@@ -221,7 +221,7 @@ class Line3 {
 
 		if ( otherLengthSq < EPS_SQR ) {
 
-			target.set( this.closestPointToPoint( line.start, clampToLine ), 0 );
+			target.set( this.closestPointToPointParameter( line.start, clampToLine ), 0 );
 			return target;
 
 		}
@@ -285,9 +285,9 @@ class Line3 {
 	 * @param {Line3} target - The target segment that is used to store the method's result. Start point is on this, end is on line.
 	 * @return {Line3} - The shortest segment connecting two lines.
 	 */
-	closestSegmentToLine( line, clampToLine, target ) {
+	shortestSegmentToLine( line, clampToLine, target ) {
 
-		this.closestSegmentToLineParameters( line, clampToLine, _parameters );
+		this.shortestSegmentToLineParameters( line, clampToLine, _parameters );
 
 		this.delta( target.start ).multiplyScalar( _parameters.x ).add( this.start );
 		line.delta( target.end ).multiplyScalar( _parameters.y ).add( line.start );
@@ -305,7 +305,7 @@ class Line3 {
 	 */
 	closestDistanceToLine( line, clampToLine ) {
 
-		this.closestSegmentToLineParameters( line, clampToLine, _parameters );
+		this.shortestSegmentToLineParameters( line, clampToLine, _parameters );
 
 		const pointA = this.delta( _startEnd ).multiplyScalar( _parameters.x ).add( this.start );
 		const pointB = line.delta( _startEnd2 ).multiplyScalar( _parameters.y ).add( line.start );

--- a/test/unit/src/math/Line3.tests.js
+++ b/test/unit/src/math/Line3.tests.js
@@ -211,6 +211,53 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
+		QUnit.test( 'closestDistanceToLine', ( assert ) => {
+
+			const line1 = new Line3();
+			line1.start.set( 0, 0, 0 );
+			line1.end.set( 2, 0, 0 );
+
+			const line2 = new Line3();
+			line2.start.set( 1, 10, 0 );
+			line2.end.set( 1, - 2, 0 );
+
+			assert.numEqual( line1.closestDistanceToLine( line2 ), 0 );
+
+			// Parallel lines case
+			line2.start.set( - 2, 0, 2 );
+			line2.end.set( 20, 0, 2 );
+
+			assert.numEqual( line1.closestDistanceToLine( line2 ), 2 );
+
+			// Closest point on lines from one side is out of segment
+			line1.start.set( 0, 4, 0 );
+			line1.end.set( 2, 2, 0 );
+
+			line2.start.set( 0, 0, 0 );
+			line2.end.set( 4, 0, 0 );
+
+			assert.numEqual( line1.closestDistanceToLine( line2 ), 2 );
+
+			// Closest point on lines from anotehr side is out of segment
+			line1.start.set( 0, 4, 0 );
+			line1.end.set( 3, 1, 0 );
+
+			line2.start.set( 0, 0, 0 );
+			line2.end.set( 1, 0, 0 );
+
+			assert.numEqual( line1.closestDistanceToLine( line2 ), 1.5 * Math.sqrt( 2 ) );
+
+			// Closest point on lines from both sides is out of the segment
+			line1.start.set( 0, 4, 0 );
+			line1.end.set( 2, 2, 0 );
+
+			line2.start.set( 0, 0, 0 );
+			line2.end.set( 1, 0, 0 );
+
+			assert.numEqual( line1.closestDistanceToLine( line2 ), Math.sqrt( 5 ) );
+
+		} );
+
 	} );
 
 } );

--- a/test/unit/src/math/Line3.tests.js
+++ b/test/unit/src/math/Line3.tests.js
@@ -211,7 +211,7 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
-		QUnit.test( 'closestDistanceToLine', ( assert ) => {
+		QUnit.test( 'closestDistanceToLine; segment', ( assert ) => {
 
 			const line1 = new Line3();
 			line1.start.set( 0, 0, 0 );
@@ -221,13 +221,13 @@ export default QUnit.module( 'Maths', () => {
 			line2.start.set( 1, 10, 0 );
 			line2.end.set( 1, - 2, 0 );
 
-			assert.numEqual( line1.closestDistanceToLine( line2 ), 0 );
+			assert.numEqual( line1.closestDistanceToLine( line2, true ), 0 );
 
 			// Parallel lines case
 			line2.start.set( - 2, 0, 2 );
 			line2.end.set( 20, 0, 2 );
 
-			assert.numEqual( line1.closestDistanceToLine( line2 ), 2 );
+			assert.numEqual( line1.closestDistanceToLine( line2, true ), 2 );
 
 			// Closest point on lines from one side is out of segment
 			line1.start.set( 0, 4, 0 );
@@ -236,7 +236,7 @@ export default QUnit.module( 'Maths', () => {
 			line2.start.set( 0, 0, 0 );
 			line2.end.set( 4, 0, 0 );
 
-			assert.numEqual( line1.closestDistanceToLine( line2 ), 2 );
+			assert.numEqual( line1.closestDistanceToLine( line2, true ), 2 );
 
 			// Closest point on lines from anotehr side is out of segment
 			line1.start.set( 0, 4, 0 );
@@ -245,7 +245,7 @@ export default QUnit.module( 'Maths', () => {
 			line2.start.set( 0, 0, 0 );
 			line2.end.set( 1, 0, 0 );
 
-			assert.numEqual( line1.closestDistanceToLine( line2 ), 1.5 * Math.sqrt( 2 ) );
+			assert.numEqual( line1.closestDistanceToLine( line2, true ), 1.5 * Math.sqrt( 2 ) );
 
 			// Closest point on lines from both sides is out of the segment
 			line1.start.set( 0, 4, 0 );
@@ -254,7 +254,72 @@ export default QUnit.module( 'Maths', () => {
 			line2.start.set( 0, 0, 0 );
 			line2.end.set( 1, 0, 0 );
 
-			assert.numEqual( line1.closestDistanceToLine( line2 ), Math.sqrt( 5 ) );
+			assert.numEqual( line1.closestDistanceToLine( line2, true ), Math.sqrt( 5 ) );
+
+			// General case with skew lines
+			line1.start.set( 4, 0, 0 );
+			line1.end.set( - 4, 0, 0 );
+
+			line2.start.set( 0, 4, 0 );
+			line2.end.set( 0, 0, 4 );
+
+			assert.numEqual( line1.closestDistanceToLine( line2, true ), 2 * Math.sqrt( 2 ) );
+
+		} );
+
+		QUnit.test( 'closestDistanceToLine; line', ( assert ) => {
+
+			const line1 = new Line3();
+			line1.start.set( 0, 0, 0 );
+			line1.end.set( 2, 0, 0 );
+
+			const line2 = new Line3();
+			line2.start.set( 1, 10, 0 );
+			line2.end.set( 1, - 2, 0 );
+
+			assert.numEqual( line1.closestDistanceToLine( line2, false ), 0 );
+
+			// Parallel lines case
+			line2.start.set( - 2, 0, 2 );
+			line2.end.set( 20, 0, 2 );
+
+			assert.numEqual( line1.closestDistanceToLine( line2, false ), 2 );
+
+			// Closest point on lines from one side is out of segment
+			line1.start.set( 0, 4, 0 );
+			line1.end.set( 2, 2, 0 );
+
+			line2.start.set( 0, 0, 0 );
+			line2.end.set( 4, 0, 0 );
+
+			assert.numEqual( line1.closestDistanceToLine( line2, false ), 0 );
+
+			// Closest point on lines from anotehr side is out of segment
+			line1.start.set( 0, 4, 0 );
+			line1.end.set( 3, 1, 0 );
+
+			line2.start.set( 0, 0, 0 );
+			line2.end.set( 1, 0, 0 );
+
+			assert.numEqual( line1.closestDistanceToLine( line2, false ), 0 );
+
+			// Closest point on lines from both sides is out of the segment
+			line1.start.set( 0, 4, 0 );
+			line1.end.set( 2, 2, 0 );
+
+			line2.start.set( 0, 0, 0 );
+			line2.end.set( 1, 0, 0 );
+
+			assert.numEqual( line1.closestDistanceToLine( line2, false ), 0 );
+
+			// General case with skew lines
+			line1.start.set( 4, 0, 0 );
+			line1.end.set( - 4, 0, 0 );
+
+			line2.start.set( 0, 4, 0 );
+			line2.end.set( 0, 0, 4 );
+
+			assert.numEqual( line1.closestDistanceToLine( line2, false ), 2 * Math.sqrt( 2 ) );
 
 		} );
 

--- a/test/unit/src/math/Line3.tests.js
+++ b/test/unit/src/math/Line3.tests.js
@@ -211,7 +211,7 @@ export default QUnit.module( 'Maths', () => {
 
 		} );
 
-		QUnit.test( 'closestDistanceToLine; segment', ( assert ) => {
+		QUnit.test( 'distanceSqToLine3', ( assert ) => {
 
 			const line1 = new Line3();
 			line1.start.set( 0, 0, 0 );
@@ -221,13 +221,13 @@ export default QUnit.module( 'Maths', () => {
 			line2.start.set( 1, 10, 0 );
 			line2.end.set( 1, - 2, 0 );
 
-			assert.numEqual( line1.closestDistanceToLine( line2, true ), 0 );
+			assert.numEqual( line1.distanceSqToLine3( line2 ), 0 );
 
 			// Parallel lines case
 			line2.start.set( - 2, 0, 2 );
 			line2.end.set( 20, 0, 2 );
 
-			assert.numEqual( line1.closestDistanceToLine( line2, true ), 2 );
+			assert.numEqual( line1.distanceSqToLine3( line2 ), 4 );
 
 			// Closest point on lines from one side is out of segment
 			line1.start.set( 0, 4, 0 );
@@ -236,16 +236,16 @@ export default QUnit.module( 'Maths', () => {
 			line2.start.set( 0, 0, 0 );
 			line2.end.set( 4, 0, 0 );
 
-			assert.numEqual( line1.closestDistanceToLine( line2, true ), 2 );
+			assert.numEqual( line1.distanceSqToLine3( line2 ), 4 );
 
-			// Closest point on lines from anotehr side is out of segment
+			// Closest point on lines from another side is out of segment
 			line1.start.set( 0, 4, 0 );
 			line1.end.set( 3, 1, 0 );
 
 			line2.start.set( 0, 0, 0 );
 			line2.end.set( 1, 0, 0 );
 
-			assert.numEqual( line1.closestDistanceToLine( line2, true ), 1.5 * Math.sqrt( 2 ) );
+			assert.numEqual( line1.distanceSqToLine3( line2 ), 4.5 );
 
 			// Closest point on lines from both sides is out of the segment
 			line1.start.set( 0, 4, 0 );
@@ -254,7 +254,7 @@ export default QUnit.module( 'Maths', () => {
 			line2.start.set( 0, 0, 0 );
 			line2.end.set( 1, 0, 0 );
 
-			assert.numEqual( line1.closestDistanceToLine( line2, true ), Math.sqrt( 5 ) );
+			assert.numEqual( line1.distanceSqToLine3( line2 ), 5 );
 
 			// General case with skew lines
 			line1.start.set( 4, 0, 0 );
@@ -263,63 +263,7 @@ export default QUnit.module( 'Maths', () => {
 			line2.start.set( 0, 4, 0 );
 			line2.end.set( 0, 0, 4 );
 
-			assert.numEqual( line1.closestDistanceToLine( line2, true ), 2 * Math.sqrt( 2 ) );
-
-		} );
-
-		QUnit.test( 'closestDistanceToLine; line', ( assert ) => {
-
-			const line1 = new Line3();
-			line1.start.set( 0, 0, 0 );
-			line1.end.set( 2, 0, 0 );
-
-			const line2 = new Line3();
-			line2.start.set( 1, 10, 0 );
-			line2.end.set( 1, - 2, 0 );
-
-			assert.numEqual( line1.closestDistanceToLine( line2, false ), 0 );
-
-			// Parallel lines case
-			line2.start.set( - 2, 0, 2 );
-			line2.end.set( 20, 0, 2 );
-
-			assert.numEqual( line1.closestDistanceToLine( line2, false ), 2 );
-
-			// Closest point on lines from one side is out of segment
-			line1.start.set( 0, 4, 0 );
-			line1.end.set( 2, 2, 0 );
-
-			line2.start.set( 0, 0, 0 );
-			line2.end.set( 4, 0, 0 );
-
-			assert.numEqual( line1.closestDistanceToLine( line2, false ), 0 );
-
-			// Closest point on lines from anotehr side is out of segment
-			line1.start.set( 0, 4, 0 );
-			line1.end.set( 3, 1, 0 );
-
-			line2.start.set( 0, 0, 0 );
-			line2.end.set( 1, 0, 0 );
-
-			assert.numEqual( line1.closestDistanceToLine( line2, false ), 0 );
-
-			// Closest point on lines from both sides is out of the segment
-			line1.start.set( 0, 4, 0 );
-			line1.end.set( 2, 2, 0 );
-
-			line2.start.set( 0, 0, 0 );
-			line2.end.set( 1, 0, 0 );
-
-			assert.numEqual( line1.closestDistanceToLine( line2, false ), 0 );
-
-			// General case with skew lines
-			line1.start.set( 4, 0, 0 );
-			line1.end.set( - 4, 0, 0 );
-
-			line2.start.set( 0, 4, 0 );
-			line2.end.set( 0, 0, 4 );
-
-			assert.numEqual( line1.closestDistanceToLine( line2, false ), 2 * Math.sqrt( 2 ) );
+			assert.numEqual( line1.distanceSqToLine3( line2 ), 8 );
 
 		} );
 


### PR DESCRIPTION
Fixed #31368 

**Description**

Adds function to find distance between two Line3-s: `closestDistanceToLine`. I wanted to create granularity in the API as it is with distance to point. Hence `shortestSegmentToLine` and `shortestSegmentToLineParameters` which return shortest segment and shortest segment point's parameters.

Also adds helper function `distanceToPoint` on Line3 to more easily get distance to point.