### PR TITLE
Timer: Move into core.

### DIFF
--- a/docs/api/en/core/Timer.html
+++ b/docs/api/en/core/Timer.html
@@ -20,17 +20,6 @@
 			</ul>
 		</p>
 
-		<h2>Import</h2>
-
-		<p>
-			[name] is an add-on, and must be imported explicitly.
-			See [link:#manual/introduction/Installation Installation / Addons].
-		</p>
-
-		<code>
-			import { Timer } from 'three/addons/misc/Timer.js';
-		</code>
-
 		<h2>Code Example</h2>
 
 		<code>
@@ -114,7 +103,7 @@
 		<h2>Source</h2>
 
 		<p>
-			[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/misc/Timer.js examples/jsm/misc/Timer.js]
+			[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
 		</p>
 	</body>
 </html>

--- a/docs/api/zh/core/Timer.html
+++ b/docs/api/zh/core/Timer.html
@@ -22,16 +22,6 @@
 	</ul>
 	</p>
 
-	<h2>导入</h2>
-
-	<p>
-		[name] 是一个附加组件，必须显式导入。请参阅 [link:#manual/introduction/Installation Installation / Addons].
-	</p>
-
-	<code>
-			import { Timer } from 'three/addons/misc/Timer.js';
-		</code>
-
 	<h2>代码示例</h2>
 
 	<code>
@@ -103,7 +93,7 @@
 	<h2>源代码</h2>
 
 	<p>
-		[link:https://github.com/mrdoob/three.js/blob/master/examples/jsm/misc/Timer.js examples/jsm/misc/Timer.js]
+		[link:https://github.com/mrdoob/three.js/blob/master/src/[path].js src/[path].js]
 	</p>
 </body>
 

--- a/docs/list.json
+++ b/docs/list.json
@@ -65,6 +65,7 @@
 				"Layers": "api/en/core/Layers",
 				"Object3D": "api/en/core/Object3D",
 				"Raycaster": "api/en/core/Raycaster",
+				"Timer": "api/en/core/Timer",
 				"Uniform": "api/en/core/Uniform"
 			},
 
@@ -383,10 +384,6 @@
 				"LookupTable": "examples/en/math/Lut",
 				"MeshSurfaceSampler": "examples/en/math/MeshSurfaceSampler",
 				"OBB": "examples/en/math/OBB"
-			},
-
-			"Misc": {
-				"Timer": "examples/en/misc/Timer"
 			},
 
 			"Modifiers": {
@@ -775,6 +772,7 @@
 				"Layers": "api/zh/core/Layers",
 				"Object3D": "api/zh/core/Object3D",
 				"Raycaster": "api/zh/core/Raycaster",
+				"Timer": "api/zh/core/Timer",
 				"Uniform": "api/zh/core/Uniform"
 			},
 
@@ -1086,10 +1084,6 @@
 
 			"修改器":{
 				"EdgeSplitModifier": "examples/zh/modifiers/EdgeSplitModifier"
-			},
-
-			"杂项": {
-				"Timer": "examples/zh/misc/Timer"
 			},
 
 			"凸包": {

--- a/examples/jsm/Addons.js
+++ b/examples/jsm/Addons.js
@@ -146,7 +146,6 @@ export * from './misc/MorphAnimMesh.js';
 export * from './misc/MorphBlendMesh.js';
 export * from './misc/ProgressiveLightMap.js';
 export * from './misc/RollerCoaster.js';
-export * from './misc/Timer.js';
 export * from './misc/TubePainter.js';
 export * from './misc/Volume.js';
 export * from './misc/VolumeSlice.js';

--- a/examples/webgl_buffergeometry_lines.html
+++ b/examples/webgl_buffergeometry_lines.html
@@ -24,7 +24,6 @@
 
 			import * as THREE from 'three';
 
-			import { Timer } from 'three/addons/misc/Timer.js';
 			import Stats from 'three/addons/libs/stats.module.js';
 
 			let container, stats, timer;
@@ -50,7 +49,7 @@
 
 				scene = new THREE.Scene();
 
-				timer = new Timer();
+				timer = new THREE.Timer();
 				timer.connect( document );
 
 				const geometry = new THREE.BufferGeometry();

--- a/examples/webgl_instancing_dynamic.html
+++ b/examples/webgl_instancing_dynamic.html
@@ -26,7 +26,6 @@
 
 			import * as THREE from 'three';
 
-			import { Timer } from 'three/addons/misc/Timer.js';
 			import { RoomEnvironment } from 'three/addons/environments/RoomEnvironment.js';
 			import TWEEN from 'three/addons/libs/tween.module.js';
 
@@ -70,7 +69,7 @@
 				scene.background = new THREE.Color( 0xadd8e6 );
 				scene.environment = pmremGenerator.fromScene( new RoomEnvironment(), 0.04 ).texture;
 
-				timer = new Timer();
+				timer = new THREE.Timer();
 				timer.connect( document );
 
 				const loader = new THREE.TextureLoader();

--- a/examples/webgl_morphtargets_sphere.html
+++ b/examples/webgl_morphtargets_sphere.html
@@ -28,7 +28,6 @@
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
-			import { Timer } from 'three/addons/misc/Timer.js';
 
 			let camera, scene, renderer, timer;
 
@@ -48,7 +47,7 @@
 
 				scene = new THREE.Scene();
 
-				timer = new Timer();
+				timer = new THREE.Timer();
 				timer.connect( document );
 
 				const light1 = new THREE.PointLight( 0xff2200, 50000 );

--- a/examples/webgpu_display_stereo.html
+++ b/examples/webgpu_display_stereo.html
@@ -31,7 +31,6 @@
 			import { anaglyphPass } from 'three/addons/tsl/display/AnaglyphPassNode.js';
 			import { parallaxBarrierPass } from 'three/addons/tsl/display/ParallaxBarrierPassNode.js';
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
-			import { Timer } from 'three/addons/misc/Timer.js';
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 
 			let camera, scene, renderer, postProcessing;
@@ -61,7 +60,7 @@
 					.setPath( 'textures/cube/Park3Med/' )
 					.load( [ 'px.jpg', 'nx.jpg', 'py.jpg', 'ny.jpg', 'pz.jpg', 'nz.jpg' ] );
 
-				timer = new Timer();
+				timer = new THREE.Timer();
 				timer.connect( document );
 
 				const geometry = new THREE.SphereGeometry( 0.1, 32, 16 );

--- a/examples/webgpu_lights_pointlights.html
+++ b/examples/webgpu_lights_pointlights.html
@@ -31,7 +31,6 @@
 
 			import { OBJLoader } from 'three/addons/loaders/OBJLoader.js';
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
-			import { Timer } from 'three/addons/misc/Timer.js';
 
 			import { abs, attribute, distance, float, max, modelWorldMatrixInverse, positionLocal, sin, time, uniform } from 'three/tsl';
 
@@ -48,7 +47,7 @@
 
 				scene = new THREE.Scene();
 
-				timer = new Timer();
+				timer = new THREE.Timer();
 				timer.connect( document );
 
 				// model

--- a/examples/webgpu_postprocessing_difference.html
+++ b/examples/webgpu_postprocessing_difference.html
@@ -30,7 +30,6 @@
 			import { pass, luminance, saturation } from 'three/tsl';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
-			import { Timer } from 'three/addons/misc/Timer.js';
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 
@@ -61,7 +60,7 @@
 				scene.fog = new THREE.Fog( 0x0487e2, 7, 25 );
 				scene.background = new THREE.Color( 0x0487e2 );
 
-				timer = new Timer();
+				timer = new THREE.Timer();
 				timer.connect( document );
 
 				const texture = new THREE.TextureLoader().load( 'textures/crate.gif' );

--- a/examples/webgpu_postprocessing_ssaa.html
+++ b/examples/webgpu_postprocessing_ssaa.html
@@ -27,7 +27,6 @@
 			import * as THREE from 'three';
 			import { ssaaPass } from 'three/addons/tsl/display/SSAAPassNode.js';
 
-			import { Timer } from 'three/addons/misc/Timer.js';
 			import Stats from 'three/addons/libs/stats.module.js';
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 
@@ -86,7 +85,7 @@
 				stats = new Stats();
 				document.body.appendChild( stats.dom );
 
-				timer = new Timer();
+				timer = new THREE.Timer();
 				timer.connect( document );
 
 				camera = new THREE.PerspectiveCamera( 65, width / height, 3, 10 );

--- a/examples/webgpu_tsl_vfx_linkedparticles.html
+++ b/examples/webgpu_tsl_vfx_linkedparticles.html
@@ -32,7 +32,6 @@
 			import { bloom } from 'three/addons/tsl/display/BloomNode.js';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
-			import { Timer } from 'three/addons/misc/Timer.js';
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 			import WebGPU from 'three/addons/capabilities/WebGPU.js';
 
@@ -86,7 +85,7 @@
 
 				scene = new THREE.Scene();
 
-				timer = new Timer();
+				timer = new THREE.Timer();
 				timer.connect( document );
 
 				// renderer

--- a/src/Three.Core.js
+++ b/src/Three.Core.js
@@ -103,6 +103,7 @@ export { Raycaster } from './core/Raycaster.js';
 export { Layers } from './core/Layers.js';
 export { EventDispatcher } from './core/EventDispatcher.js';
 export { Clock } from './core/Clock.js';
+export { Timer } from './core/Timer.js';
 export { QuaternionLinearInterpolant } from './math/interpolants/QuaternionLinearInterpolant.js';
 export { LinearInterpolant } from './math/interpolants/LinearInterpolant.js';
 export { DiscreteInterpolant } from './math/interpolants/DiscreteInterpolant.js';

--- a/src/core/Timer.js
+++ b/src/core/Timer.js
@@ -11,8 +11,6 @@
  * const timer = new Timer();
  * timer.connect( document ); // use Page Visibility API
  * ```
- *
- * @three_import import { Timer } from 'three/addons/misc/Timer.js';
  */
 class Timer {
 
@@ -23,7 +21,7 @@ class Timer {
 
 		this._previousTime = 0;
 		this._currentTime = 0;
-		this._startTime = now();
+		this._startTime = performance.now();
 
 		this._delta = 0;
 		this._elapsed = 0;
@@ -129,7 +127,7 @@ class Timer {
 	 */
 	reset() {
 
-		this._currentTime = now() - this._startTime;
+		this._currentTime = performance.now() - this._startTime;
 
 		return this;
 
@@ -164,7 +162,7 @@ class Timer {
 		} else {
 
 			this._previousTime = this._currentTime;
-			this._currentTime = ( timestamp !== undefined ? timestamp : now() ) - this._startTime;
+			this._currentTime = ( timestamp !== undefined ? timestamp : performance.now() ) - this._startTime;
 
 			this._delta = ( this._currentTime - this._previousTime ) * this._timescale;
 			this._elapsed += this._delta; // _elapsed is the accumulation of all previous deltas
@@ -177,46 +175,10 @@ class Timer {
 
 }
 
-/**
- * A special version of a timer with a fixed time delta value.
- * Can be useful for testing and debugging purposes.
- *
- * @augments Timer
- */
-class FixedTimer extends Timer {
-
-	/**
-	 * Constructs a new timer.
-	 *
-	 * @param {number} [fps=60] - The fixed FPS of this timer.
-	 */
-	constructor( fps = 60 ) {
-
-		super();
-		this._delta = ( 1 / fps ) * 1000;
-
-	}
-
-	update() {
-
-		this._elapsed += ( this._delta * this._timescale ); // _elapsed is the accumulation of all previous deltas
-
-		return this;
-
-	}
-
-}
-
-function now() {
-
-	return performance.now();
-
-}
-
 function handleVisibilityChange() {
 
 	if ( this._document.hidden === false ) this.reset();
 
 }
 
-export { Timer, FixedTimer };
+export { Timer };


### PR DESCRIPTION
Related issue: #30497

**Description**

As suggested in https://github.com/mrdoob/three.js/issues/30497#issuecomment-3051971689, this PR moves `THREE.Timer` into the core as the successor for `THREE.Clock`.

Ideally, `THREE.Clock` with its conceptual flaws is deprecated in the future.