### PR TITLE
TTFLoader: Fix when TTF has different unicode assign to same glyph index

### DIFF
--- a/examples/jsm/loaders/TTFLoader.js
+++ b/examples/jsm/loaders/TTFLoader.js
@@ -152,7 +152,7 @@ class TTFLoader extends Loader {
 
 					} );
 
-					if ( glyph.unicodes !== undefined && glyph.unicodes.length > 0 ) {
+					if ( Array.isArray( glyph.unicodes ) && glyph.unicodes.length > 0 ) {
 						
 						glyph.unicodes.forEach( function ( unicode ) {
 							

--- a/examples/jsm/loaders/TTFLoader.js
+++ b/examples/jsm/loaders/TTFLoader.js
@@ -152,13 +152,13 @@ class TTFLoader extends Loader {
 
 					} );
 
-					if( glyph.unicodes !== undefined && glyph.unicodes.length > 0 ) {
+					if ( glyph.unicodes !== undefined && glyph.unicodes.length > 0 ) {
 						
-						glyph.unicodes.forEach( function (unicode) {
+						glyph.unicodes.forEach( function ( unicode ) {
 							
 							glyphs[ String.fromCodePoint( unicode ) ] = token;
 							
-						});
+						} );
 						
 					} else {
 

--- a/examples/jsm/loaders/TTFLoader.js
+++ b/examples/jsm/loaders/TTFLoader.js
@@ -152,7 +152,19 @@ class TTFLoader extends Loader {
 
 					} );
 
-					glyphs[ String.fromCodePoint( glyph.unicode ) ] = token;
+					if( glyph.unicodes !== undefined && glyph.unicodes.length > 0 ) {
+						
+						glyph.unicodes.forEach( function (unicode) {
+							
+							glyphs[ String.fromCodePoint( unicode ) ] = token;
+							
+						});
+						
+					} else {
+
+						glyphs[ String.fromCodePoint( glyph.unicode ) ] = token;
+
+					}
 
 				}
 


### PR DESCRIPTION
**Description**

Some font has more than one unicode assigned to same glyph index.

**Issue**

For example [DotGothic16](https://fonts.google.com/specimen/DotGothic16?lang=ja_Jpan)

There are `⼈` very similar but actually are two different characters with different unicodes.
But **DotGothic16** is set to same characters and assigned same glyph index.

- `⼈`, ID: `12040`, HEXD: `2F08`, glyph index : `2531`
- `人`, ID: `20154`, HEXD: `4EBA`, glyph index : `2531`

Error occurred when I loaded `人, ID: 20154` since the TTFLoader load [by glyph index](https://github.com/mrdoob/three.js/blob/bc575041618f7750d66c9808e3c3bf1924c4ca91/examples/jsm/loaders/TTFLoader.js#L108) for now, the glyph object key has set `⼈, ID: 12040` only. 

As the image below, the characters `人, ID: 20154` cannot be found and show `?`.

<img width="335" alt="Screenshot 2025-07-10 at 1 53 57" src="https://github.com/user-attachments/assets/27950544-8647-4903-9210-6c207de8389f" />

**Solution**

To handle this issue, The TTFLoader has to set both of the `⼈` with different unicodes and same glyph index. With the code i changed, characters can be loaded by TTFLoader as the image below.

<img width="388" alt="Screenshot 2025-07-10 at 1 52 51" src="https://github.com/user-attachments/assets/58e81450-a185-455c-90e0-93d5e6f2c566" />

The issue with character `一` also fixed.
