### PR TITLE
WebGPUBackend: Fix manual `clear()` regression.

### DIFF
--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -1236,7 +1236,7 @@ class WebGPUBackend extends Backend {
 
 		}
 
-		if ( supportsDepth && depthStencilAttachment && depthStencilAttachment.depthLoadOp === undefined ) {
+		if ( supportsDepth && depthStencilAttachment ) {
 
 			if ( depth ) {
 
@@ -1255,7 +1255,7 @@ class WebGPUBackend extends Backend {
 
 		//
 
-		if ( supportsStencil && depthStencilAttachment && depthStencilAttachment.stencilLoadOp === undefined ) {
+		if ( supportsStencil && depthStencilAttachment ) {
 
 			if ( stencil ) {
 


### PR DESCRIPTION
Related issue: #30647

**Description**

While investigating #31387, I've noticed that #30647 has introduced a minor regression in `WebGPUBackend.clear()` when rendering directly to the default framebuffer (e.g. when using `THREE.LinearSRGBColorSpace` as the output color space). Below fiddles demonstrates the glitch:

https://jsfiddle.net/5k3xga61/

The default render pass descriptor is _shared_ so it is not possible to rely on cached depth and stencil clear values in `clear()`. They must be configured on every clear invocation or the configuration values in the depth stencil attachment are incorrect.