### PR TITLE
SkyMesh: Use `colorNode` instead of `fragmentNode`.

### DIFF
--- a/examples/jsm/objects/SkyMesh.js
+++ b/examples/jsm/objects/SkyMesh.js
@@ -165,7 +165,7 @@ class SkyMesh extends Mesh {
 
 		} )();
 
-		const fragmentNode = /*@__PURE__*/ Fn( () => {
+		const colorNode = /*@__PURE__*/ Fn( () => {
 
 			// constants for atmospheric scattering
 			const pi = float( 3.141592653589793238462643383279502884197169 );
@@ -234,7 +234,7 @@ class SkyMesh extends Mesh {
 		material.depthWrite = false;
 
 		material.vertexNode = vertexNode;
-		material.fragmentNode = fragmentNode;
+		material.colorNode = colorNode;
 
 	}
 


### PR DESCRIPTION
Fixed #31367.

**Description**

The PR makes sure `SkyMesh` works with a MRT setup.

@sunag I don't find the discussion anymore but when I remember correctly using `colorNode` instead of `fragmentNode` whenever possible is preferable otherwise we miss out certain automatism like MRT configuration, right?