### PR TITLE
LightsNode: Honor map version in cache key.

### DIFF
--- a/src/nodes/lighting/LightsNode.js
+++ b/src/nodes/lighting/LightsNode.js
@@ -127,9 +127,10 @@ class LightsNode extends Node {
 			if ( light.isSpotLight === true ) {
 
 				const hashMap = ( light.map !== null ) ? light.map.id : - 1;
+				const hashMapVersion = ( light.map !== null ) ? light.map.version : - 1;
 				const hashColorNode = ( light.colorNode ) ? light.colorNode.getCacheKey() : - 1;
 
-				_hashData.push( hashMap, hashColorNode );
+				_hashData.push( hashMap, hashMapVersion, hashColorNode );
 
 			}
 


### PR DESCRIPTION
Related issue: #31330

**Description**

The custom cache key of `LightsNode` must honor the version of spot light maps otherwise a texture update is not correctly honored. `webgpu_lights_projector` only worked since the material observer forces a refresh for each new `renderId`. But if you add more than one objects that _share_ a node builder state (and thus material observer) and are affected by the spot light, textured lighting breaks for all objects except the first one. 

Note: The video texture also works now but there are still WebGPU warnings in the console:

> External texture [ExternalTexture (unlabeled)] used in a submit is not active.
> Destroyed texture [Texture "IOSurface(Gles2Read|RasterRead|DisplayRead|Scanout|WebgpuRead)"] used in a submit.

WebGL reports no warnings. Investigating this separately.