### PR TITLE
NodeMaterialObserver: Force refresh for video textures.

### DIFF
--- a/examples/webgpu_lights_projector.html
+++ b/examples/webgpu_lights_projector.html
@@ -23,11 +23,6 @@
 			}
 		</script>
 
-		<video id="video" loop muted crossOrigin="anonymous" playsinline style="display:none">
-			<source src="textures/sintel.ogv" type='video/ogg; codecs="theora, vorbis"'>
-			<source src="textures/sintel.mp4" type='video/mp4; codecs="avc1.42E01E, mp4a.40.2"'>
-		</video>
-
 		<script type="module">
 
 			import * as THREE from 'three';
@@ -161,9 +156,9 @@
 					shadows: true,
 				};
 
-				let videoTexture, mapTexture;
+				let mapTexture;
 
-				gui.add( params, 'type', [ 'procedural', 'video', 'texture' ] ).onChange( function ( val ) {
+				gui.add( params, 'type', [ 'procedural', 'texture' ] ).onChange( function ( val ) {
 
 					projectorLight.colorNode = null;
 					projectorLight.map = null;
@@ -173,21 +168,6 @@
 						projectorLight.colorNode = causticEffect;
 
 						focus.setValue( 1 );
-
-					} else if ( val === 'video' ) {
-
-						if ( videoTexture === undefined ) {
-
-							const video = document.getElementById( 'video' );
-							video.play();
-
-							videoTexture = new THREE.VideoTexture( video );
-
-						}
-
-						projectorLight.map = videoTexture;
-
-						focus.setValue( .46 );
 
 					} else if ( val === 'texture' ) {
 

--- a/src/lights/SpotLight.js
+++ b/src/lights/SpotLight.js
@@ -109,6 +109,7 @@ class SpotLight extends Light {
 		 * reproduced using pixel values (0, 0, 0, 1-cookie_value).
 		 *
 		 * *Warning*: This property is disabled if {@link Object3D#castShadow} is set to `false`.
+		 * Besides, instances of `VideoTexture` are not supported.
 		 *
 		 * @type {?Texture}
 		 * @default null

--- a/src/materials/nodes/manager/NodeMaterialObserver.js
+++ b/src/materials/nodes/manager/NodeMaterialObserver.js
@@ -299,9 +299,10 @@ class NodeMaterialObserver {
 	 * Returns `true` if the given render object has not changed its state.
 	 *
 	 * @param {RenderObject} renderObject - The render object.
+	 * @param {NodeFrame} nodeFrame - The current node frame.
 	 * @return {boolean} Whether the given render object has changed its state or not.
 	 */
-	equals( renderObject ) {
+	equals( renderObject, nodeFrame ) {
 
 		const { object, material, geometry } = renderObject;
 
@@ -338,9 +339,9 @@ class NodeMaterialObserver {
 
 			} else if ( mtlValue.isTexture === true ) {
 
-				if ( mtlValue.isVideoTexture ) {
+				if ( mtlValue.isVideoTexture && nodeFrame.renderer.backend.isWebGPUBackend === true ) {
 
-					return false;
+					return false; // video textures in WebGPU always require fresh bindings
 
 				} else if ( value.id !== mtlValue.id || value.version !== mtlValue.version ) {
 
@@ -520,7 +521,7 @@ class NodeMaterialObserver {
 		if ( isStatic || isBundle )
 			return false;
 
-		const notEqual = this.equals( renderObject ) !== true;
+		const notEqual = this.equals( renderObject, nodeFrame ) !== true;
 
 		return notEqual;
 

--- a/src/materials/nodes/manager/NodeMaterialObserver.js
+++ b/src/materials/nodes/manager/NodeMaterialObserver.js
@@ -338,7 +338,11 @@ class NodeMaterialObserver {
 
 			} else if ( mtlValue.isTexture === true ) {
 
-				if ( value.id !== mtlValue.id || value.version !== mtlValue.version ) {
+				if ( mtlValue.isVideoTexture ) {
+
+					return false;
+
+				} else if ( value.id !== mtlValue.id || value.version !== mtlValue.version ) {
 
 					value.id = mtlValue.id;
 					value.version = mtlValue.version;

--- a/src/renderers/webgpu/utils/WebGPUBindingUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUBindingUtils.js
@@ -432,17 +432,17 @@ class WebGPUBindingUtils {
 
 						// create initial cache object
 
-						cache = { renderId: - 1, resourceGPU: null };
+						cache = { frameId: - 1, resourceGPU: null };
 
 						this.externalTextureCache.set( binding.texture, cache );
 
 					}
 
-					const renderId = this.backend.renderer._nodes.nodeFrame.renderId;
+					const frameId = this.backend.renderer._nodes.nodeFrame.frameId;
 
-					if ( cache.renderId !== renderId ) {
+					if ( cache.frameId !== frameId ) {
 
-						cache.renderId = renderId;
+						cache.frameId = frameId;
 
 						cache.resourceGPU = device.importExternalTexture( { source: textureData.externalTexture } );
 

--- a/src/renderers/webgpu/utils/WebGPUBindingUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUBindingUtils.js
@@ -39,6 +39,13 @@ class WebGPUBindingUtils {
 		 */
 		this.bindGroupLayoutCache = new WeakMap();
 
+		/**
+		 * A cache for external textures.
+		 *
+		 * @type {WeakMap<VideoTexture,Object>}
+		 */
+		this.externalTextureCache = new WeakMap();
+
 	}
 
 	/**
@@ -419,7 +426,29 @@ class WebGPUBindingUtils {
 
 				if ( textureData.externalTexture !== undefined ) {
 
-					resourceGPU = device.importExternalTexture( { source: textureData.externalTexture } );
+					let cache = this.externalTextureCache.get( binding.texture );
+
+					if ( cache === undefined ) {
+
+						// create initial cache object
+
+						cache = { renderId: - 1, resourceGPU: null };
+
+						this.externalTextureCache.set( binding.texture, cache );
+
+					}
+
+					const renderId = this.backend.renderer._nodes.nodeFrame.renderId;
+
+					if ( cache.renderId !== renderId ) {
+
+						cache.renderId = renderId;
+
+						cache.resourceGPU = device.importExternalTexture( { source: textureData.externalTexture } );
+
+					}
+
+					resourceGPU = cache.resourceGPU;
 
 				} else {
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/31330#issuecomment-3064969284

**Description**

Using video textures in WebGPU seems more complicated than in WebGL since it is not possible to share an external texture. We have to recreate the bind group and the external texture for each render item. For material properties, we can enforce this in `NodeMaterialObserver`.

However, if video textures are used as spot light maps, there is no obvious way to enforce a refresh. Hence, I have removed the video texture from the `webgpu_lights_projector` demo. I think we can only properly support them on material level. And even then they are a bit problematic for performance in WebGPU since we can't share bindings in the same way like with normal textures.

I suggest to state in the documentation that video textures are not supported in `SpotLight.map`.