### PR TITLE
Line2NodeMaterial: Remove unused `lineWidth` property.

### DIFF
--- a/src/materials/nodes/Line2NodeMaterial.js
+++ b/src/materials/nodes/Line2NodeMaterial.js
@@ -70,9 +70,9 @@ class Line2NodeMaterial extends NodeMaterial {
 		 * The line width.
 		 *
 		 * @type {number}
-		 * @default 0
+		 * @default 1
 		 */
-		this.lineWidth = 1;
+		this.linewidth = 1;
 
 		/**
 		 * Defines the lines color.

--- a/src/materials/nodes/Line2NodeMaterial.js
+++ b/src/materials/nodes/Line2NodeMaterial.js
@@ -67,14 +67,6 @@ class Line2NodeMaterial extends NodeMaterial {
 		this.dashOffset = 0;
 
 		/**
-		 * The line width.
-		 *
-		 * @type {number}
-		 * @default 1
-		 */
-		this.linewidth = 1;
-
-		/**
 		 * Defines the lines color.
 		 *
 		 * @type {?Node<vec3>}


### PR DESCRIPTION
Fixed #31398

**Description**

In the global environment of three.js, the `lineWidth` in `Line2NodeMaterial` does not take effect and is essentially ineffective. To modify the line width, it is necessary to use the `linewidth` setting. Additionally, neither `Material` nor `NodeMaterial` contains a `linewidth` property. Therefore, the `lineWidth` property in `Line2NodeMaterial` should be changed to `linewidth`, and its default value should be set to 1.