### PR TITLE
TSL: Introduce `computeKernel()`

### DIFF
--- a/src/Three.TSL.js
+++ b/src/Three.TSL.js
@@ -118,6 +118,7 @@ export const color = TSL.color;
 export const colorSpaceToWorking = TSL.colorSpaceToWorking;
 export const colorToDirection = TSL.colorToDirection;
 export const compute = TSL.compute;
+export const computeKernel = TSL.computeKernel;
 export const computeSkinning = TSL.computeSkinning;
 export const cond = TSL.cond;
 export const Const = TSL.Const;

--- a/src/nodes/gpgpu/ComputeNode.js
+++ b/src/nodes/gpgpu/ComputeNode.js
@@ -219,18 +219,42 @@ export default ComputeNode;
  * @tsl
  * @function
  * @param {Node} node - TODO
- * @param {number} countOrWorkgroupSize - TODO.
- * @param {Array<number>} [workgroupSize=[ 64, 1, 1 ]]
+ * @param {number} countOrWorkgroupSize - TODO, depends on the future of count
  * @returns {AtomicFunctionNode}
  */
-export const compute = ( node, countOrWorkgroupSize, workgroupSize ) => {
+export const compute = ( node, countOrWorkgroupSize ) => {
 
-	let count = countOrWorkgroupSize;
+	let count = null;
+	let workgroupSize = [ 64, 1, 1 ];	//default
 
 	if ( Array.isArray( countOrWorkgroupSize ) ) {
 
 		workgroupSize = countOrWorkgroupSize;
-		count = null;
+
+		if ( workgroupSize.length === 0 || workgroupSize.length > 3 ) {
+
+			throw new Error( 'workgroupSize must have 1, 2, or 3 elements' );
+
+		}
+
+		for ( let i = 0; i < workgroupSize.length; i ++ ) {
+
+			const val = workgroupSize[ i ];
+
+			if ( typeof val !== 'number' || val <= 0 || ! Number.isInteger( val ) ) {
+
+				throw new Error( `workgroupSize element at index ${i} must be a positive integer` );
+
+			}
+
+		}
+
+		// Implicit fill-up to [ x, y, z ] with 1s, just like WGSL treats @workgroup_size when fewer dimensions are specified
+		while ( workgroupSize.length < 3 ) workgroupSize.push( 1 );
+
+	} else {
+
+		count = countOrWorkgroupSize;
 
 	}
 

--- a/src/nodes/gpgpu/ComputeNode.js
+++ b/src/nodes/gpgpu/ComputeNode.js
@@ -20,9 +20,9 @@ class ComputeNode extends Node {
 	 *
 	 * @param {Node} computeNode - TODO
 	 * @param {number} count - TODO.
-	 * @param {Array<number>} [workgroupSize=[64]] - TODO.
+	 * @param {Array<number>} [workgroupSize = [ 64, 1, 1 ]]
 	 */
-	constructor( computeNode, count, workgroupSize = [ 64 ] ) {
+	constructor( computeNode, count, workgroupSize = [ 64, 1, 1 ] ) {
 
 		super( 'void' );
 
@@ -53,7 +53,7 @@ class ComputeNode extends Node {
 		 * TODO
 		 *
 		 * @type {Array<number>}
-		 * @default [64]
+		 * @default [ 64, 1, 1 ]
 		 */
 		this.workgroupSize = workgroupSize;
 
@@ -220,9 +220,22 @@ export default ComputeNode;
  * @function
  * @param {Node} node - TODO
  * @param {number} count - TODO.
- * @param {Array<number>} [workgroupSize=[64]] - TODO.
+ * @param {Array<number>} [workgroupSize=[ 64, 1, 1 ]]
  * @returns {AtomicFunctionNode}
  */
-export const compute = ( node, count, workgroupSize ) => nodeObject( new ComputeNode( nodeObject( node ), count, workgroupSize ) );
+export const compute = ( node, countOrWorkgroupSize, workgroupSize ) => {
+
+	let count = countOrWorkgroupSize;
+
+	if ( Array.isArray( countOrWorkgroupSize ) ) {
+
+		workgroupSize = countOrWorkgroupSize;
+		count = null;
+
+	}
+
+	return nodeObject( new ComputeNode( nodeObject( node ), count, workgroupSize ) );
+
+};
 
 addMethodChaining( 'compute', compute );

--- a/src/nodes/gpgpu/ComputeNode.js
+++ b/src/nodes/gpgpu/ComputeNode.js
@@ -219,7 +219,7 @@ export default ComputeNode;
  * @tsl
  * @function
  * @param {Node} node - TODO
- * @param {number} count - TODO.
+ * @param {number} countOrWorkgroupSize - TODO.
  * @param {Array<number>} [workgroupSize=[ 64, 1, 1 ]]
  * @returns {AtomicFunctionNode}
  */

--- a/src/nodes/gpgpu/ComputeNode.js
+++ b/src/nodes/gpgpu/ComputeNode.js
@@ -19,10 +19,9 @@ class ComputeNode extends Node {
 	 * Constructs a new compute node.
 	 *
 	 * @param {Node} computeNode - TODO
-	 * @param {number} count - TODO.
-	 * @param {Array<number>} [workgroupSize = [ 64, 1, 1 ]]
+	 * @param {Array<number>} workgroupSize - TODO.
 	 */
-	constructor( computeNode, count, workgroupSize = [ 64, 1, 1 ] ) {
+	constructor( computeNode, workgroupSize ) {
 
 		super( 'void' );
 
@@ -42,18 +41,12 @@ class ComputeNode extends Node {
 		 */
 		this.computeNode = computeNode;
 
-		/**
-		 * TODO
-		 *
-		 * @type {number}
-		 */
-		this.count = count;
 
 		/**
 		 * TODO
 		 *
 		 * @type {Array<number>}
-		 * @default [ 64, 1, 1 ]
+		 * @default [ 64 ]
 		 */
 		this.workgroupSize = workgroupSize;
 
@@ -62,7 +55,7 @@ class ComputeNode extends Node {
 		 *
 		 * @type {number}
 		 */
-		this.dispatchCount = 0;
+		this.count = null;
 
 		/**
 		 * TODO
@@ -95,7 +88,19 @@ class ComputeNode extends Node {
 		 */
 		this.onInitFunction = null;
 
-		this.updateDispatchCount();
+	}
+
+	setCount( count ) {
+
+		this.count = count;
+
+		return this;
+
+	}
+
+	getCount() {
+
+		return this.count;
 
 	}
 
@@ -119,22 +124,6 @@ class ComputeNode extends Node {
 		this.name = name;
 
 		return this;
-
-	}
-
-	/**
-	 * TODO
-	 */
-	updateDispatchCount() {
-
-		const { count, workgroupSize } = this;
-
-		let size = workgroupSize[ 0 ];
-
-		for ( let i = 1; i < workgroupSize.length; i ++ )
-			size *= workgroupSize[ i ];
-
-		this.dispatchCount = Math.ceil( count / size );
 
 	}
 
@@ -214,52 +203,55 @@ class ComputeNode extends Node {
 export default ComputeNode;
 
 /**
+ * TSL function for creating a compute kernel node.
+ *
+ * @tsl
+ * @function
+ * @param {Node} node - TODO
+ * @param {Array<number>} [workgroupSize=[64]] - TODO.
+ * @returns {AtomicFunctionNode}
+ */
+export const computeKernel = ( node, workgroupSize = [ 64 ] ) => {
+
+	if ( workgroupSize.length === 0 || workgroupSize.length > 3 ) {
+
+		console.error( 'THREE.TSL: compute() workgroupSize must have 1, 2, or 3 elements' );
+
+	}
+
+	for ( let i = 0; i < workgroupSize.length; i ++ ) {
+
+		const val = workgroupSize[ i ];
+
+		if ( typeof val !== 'number' || val <= 0 || ! Number.isInteger( val ) ) {
+
+			console.error( `THREE.TSL: compute() workgroupSize element at index [ ${ i } ] must be a positive integer` );
+
+		}
+
+	}
+
+	// Implicit fill-up to [ x, y, z ] with 1s, just like WGSL treats @workgroup_size when fewer dimensions are specified
+
+	while ( workgroupSize.length < 3 ) workgroupSize.push( 1 );
+
+	//
+
+	return nodeObject( new ComputeNode( nodeObject( node ), workgroupSize ) );
+
+};
+
+/**
  * TSL function for creating a compute node.
  *
  * @tsl
  * @function
  * @param {Node} node - TODO
- * @param {number} countOrWorkgroupSize - TODO, depends on the future of count
+ * @param {number} count - TODO.
+ * @param {Array<number>} [workgroupSize=[64]] - TODO.
  * @returns {AtomicFunctionNode}
  */
-export const compute = ( node, countOrWorkgroupSize ) => {
-
-	let count = null;
-	let workgroupSize = [ 64, 1, 1 ];	//default
-
-	if ( Array.isArray( countOrWorkgroupSize ) ) {
-
-		workgroupSize = countOrWorkgroupSize;
-
-		if ( workgroupSize.length === 0 || workgroupSize.length > 3 ) {
-
-			throw new Error( 'workgroupSize must have 1, 2, or 3 elements' );
-
-		}
-
-		for ( let i = 0; i < workgroupSize.length; i ++ ) {
-
-			const val = workgroupSize[ i ];
-
-			if ( typeof val !== 'number' || val <= 0 || ! Number.isInteger( val ) ) {
-
-				throw new Error( `workgroupSize element at index ${i} must be a positive integer` );
-
-			}
-
-		}
-
-		// Implicit fill-up to [ x, y, z ] with 1s, just like WGSL treats @workgroup_size when fewer dimensions are specified
-		while ( workgroupSize.length < 3 ) workgroupSize.push( 1 );
-
-	} else {
-
-		count = countOrWorkgroupSize;
-
-	}
-
-	return nodeObject( new ComputeNode( nodeObject( node ), count, workgroupSize ) );
-
-};
+export const compute = ( node, count, workgroupSize ) => computeKernel( node, workgroupSize ).setCount( count );
 
 addMethodChaining( 'compute', compute );
+addMethodChaining( 'computeKernel', computeKernel );

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -2308,7 +2308,7 @@ class Renderer {
 	 * if the renderer has been initialized.
 	 *
 	 * @param {Node|Array<Node>} computeNodes - The compute node(s).
-	 * @param {Array<number>} dispatchSize - Array with [ x,y,z ] values for dispatch.
+	 * @param {Array<number>} dispatchSize - Array with [ x,y,z ] values for dispatch. Default = null
 	 * @return {Promise|undefined} A Promise that resolve when the compute has finished. Only returned when the renderer has not been initialized.
 	 */
 	compute( computeNodes, dispatchSize = null ) {

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -2308,10 +2308,10 @@ class Renderer {
 	 * if the renderer has been initialized.
 	 *
 	 * @param {Node|Array<Node>} computeNodes - The compute node(s).
-	 * @param {Array<number>} dispatchSize - Array with [ x,y,z ] values for dispatch. Default = null
+	 * @param {Array<number>|number} [dispatchSizeOrCount=null] - Array with [ x, y, z ] values for dispatch or a single number for the count.
 	 * @return {Promise|undefined} A Promise that resolve when the compute has finished. Only returned when the renderer has not been initialized.
 	 */
-	compute( computeNodes, dispatchSize = null ) {
+	compute( computeNodes, dispatchSizeOrCount = null ) {
 
 		if ( this._isDeviceLost === true ) return;
 
@@ -2390,7 +2390,7 @@ class Renderer {
 			const computeBindings = bindings.getForCompute( computeNode );
 			const computePipeline = pipelines.getForCompute( computeNode, computeBindings );
 
-			backend.compute( computeNodes, computeNode, computeBindings, computePipeline, dispatchSize );
+			backend.compute( computeNodes, computeNode, computeBindings, computePipeline, dispatchSizeOrCount );
 
 		}
 

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -2311,7 +2311,7 @@ class Renderer {
 	 * @param {Array<number>} dispatchSize - Array with [ x,y,z ] values for dispatch.
 	 * @return {Promise|undefined} A Promise that resolve when the compute has finished. Only returned when the renderer has not been initialized.
 	 */
-	compute( computeNodes, dispatchSize = [ 0, 0, 0 ] ) {
+	compute( computeNodes, dispatchSize = null ) {
 
 		if ( this._isDeviceLost === true ) return;
 
@@ -2349,6 +2349,38 @@ class Renderer {
 		if ( computeList[ 0 ] === undefined || computeList[ 0 ].isComputeNode !== true ) {
 
 			throw new Error( 'THREE.Renderer: .compute() expects a ComputeNode.' );
+
+		}
+
+		if ( dispatchSize !== null ) {
+
+			if ( ! Array.isArray( dispatchSize ) ) {
+
+				throw new Error( 'dispatchSize must be an array' );
+
+			}
+
+			if ( dispatchSize.length === 0 || dispatchSize.length > 3 ) {
+
+				throw new Error( 'dispatchSize must have 1, 2, or 3 elements' );
+
+			}
+
+			// Check each element for positive integer
+			for ( let i = 0; i < dispatchSize.length; i ++ ) {
+
+				const val = dispatchSize[ i ];
+
+				if ( typeof val !== 'number' || val <= 0 || ! Number.isInteger( val ) ) {
+
+					throw new Error( `dispatchSize element at index ${i} must be a positive integer` );
+
+				}
+
+			}
+
+			// Implicit fill-up
+			while ( dispatchSize.length < 3 ) dispatchSize.push( 1 );
 
 		}
 

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -2352,38 +2352,6 @@ class Renderer {
 
 		}
 
-		if ( dispatchSize !== null ) {
-
-			if ( ! Array.isArray( dispatchSize ) ) {
-
-				throw new Error( 'dispatchSize must be an array' );
-
-			}
-
-			if ( dispatchSize.length === 0 || dispatchSize.length > 3 ) {
-
-				throw new Error( 'dispatchSize must have 1, 2, or 3 elements' );
-
-			}
-
-			// Check each element for positive integer
-			for ( let i = 0; i < dispatchSize.length; i ++ ) {
-
-				const val = dispatchSize[ i ];
-
-				if ( typeof val !== 'number' || val <= 0 || ! Number.isInteger( val ) ) {
-
-					throw new Error( `dispatchSize element at index ${i} must be a positive integer` );
-
-				}
-
-			}
-
-			// Implicit fill-up
-			while ( dispatchSize.length < 3 ) dispatchSize.push( 1 );
-
-		}
-
 		backend.beginCompute( computeNodes );
 
 		for ( const computeNode of computeList ) {

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -1243,13 +1243,24 @@ class Renderer {
 
 		frameBufferTarget.depthBuffer = depth;
 		frameBufferTarget.stencilBuffer = stencil;
-		frameBufferTarget.setSize( width, height, outputRenderTarget !== null ? outputRenderTarget.depth : 1 );
+		if ( outputRenderTarget !== null ) {
+
+			frameBufferTarget.setSize( outputRenderTarget.width, outputRenderTarget.height, outputRenderTarget.depth );
+
+		} else {
+
+			frameBufferTarget.setSize( width, height, 1 );
+
+		}
+
 		frameBufferTarget.viewport.copy( this._viewport );
 		frameBufferTarget.scissor.copy( this._scissor );
 		frameBufferTarget.viewport.multiplyScalar( this._pixelRatio );
 		frameBufferTarget.scissor.multiplyScalar( this._pixelRatio );
 		frameBufferTarget.scissorTest = this._scissorTest;
 		frameBufferTarget.multiview = outputRenderTarget !== null ? outputRenderTarget.multiview : false;
+		frameBufferTarget.resolveDepthBuffer = outputRenderTarget !== null ? outputRenderTarget.resolveDepthBuffer : true;
+		frameBufferTarget._autoAllocateDepthBuffer = outputRenderTarget !== null ? outputRenderTarget._autoAllocateDepthBuffer : false;
 
 		return frameBufferTarget;
 
@@ -1502,6 +1513,15 @@ class Renderer {
 		//
 
 		return renderContext;
+
+	}
+
+	_setXRLayerSize( width, height ) {
+
+		this._width = width;
+		this._height = height;
+
+		this.setViewport( 0, 0, width, height );
 
 	}
 

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -2308,7 +2308,7 @@ class Renderer {
 	 * if the renderer has been initialized.
 	 *
 	 * @param {Node|Array<Node>} computeNodes - The compute node(s).
-	 * @param {Array<number>} dispatchSize - Array with [x,y,z] values for dispatch.
+	 * @param {Array<number>} dispatchSize - Array with [ x,y,z ] values for dispatch.
 	 * @return {Promise|undefined} A Promise that resolve when the compute has finished. Only returned when the renderer has not been initialized.
 	 */
 	compute( computeNodes, dispatchSize = [ 0, 0, 0 ] ) {

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -1241,7 +1241,6 @@ class Renderer {
 
 		const outputRenderTarget = this.getOutputRenderTarget();
 
-
 		frameBufferTarget.depthBuffer = depth;
 		frameBufferTarget.stencilBuffer = stencil;
 		frameBufferTarget.setSize( width, height, outputRenderTarget !== null ? outputRenderTarget.depth : 1 );

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -1241,6 +1241,7 @@ class Renderer {
 
 		const outputRenderTarget = this.getOutputRenderTarget();
 
+
 		frameBufferTarget.depthBuffer = depth;
 		frameBufferTarget.stencilBuffer = stencil;
 		frameBufferTarget.setSize( width, height, outputRenderTarget !== null ? outputRenderTarget.depth : 1 );

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -2407,13 +2407,14 @@ class Renderer {
 	 *
 	 * @async
 	 * @param {Node|Array<Node>} computeNodes - The compute node(s).
+	 * @param {Array<number>|number} [dispatchSizeOrCount=null] - Array with [ x, y, z ] values for dispatch or a single number for the count.
 	 * @return {Promise} A Promise that resolve when the compute has finished.
 	 */
-	async computeAsync( computeNodes ) {
+	async computeAsync( computeNodes, dispatchSizeOrCount = null ) {
 
 		if ( this._initialized === false ) await this.init();
 
-		this.compute( computeNodes );
+		this.compute( computeNodes, dispatchSizeOrCount );
 
 	}
 

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -1243,24 +1243,13 @@ class Renderer {
 
 		frameBufferTarget.depthBuffer = depth;
 		frameBufferTarget.stencilBuffer = stencil;
-		if ( outputRenderTarget !== null ) {
-
-			frameBufferTarget.setSize( outputRenderTarget.width, outputRenderTarget.height, outputRenderTarget.depth );
-
-		} else {
-
-			frameBufferTarget.setSize( width, height, 1 );
-
-		}
-
+		frameBufferTarget.setSize( width, height, outputRenderTarget !== null ? outputRenderTarget.depth : 1 );
 		frameBufferTarget.viewport.copy( this._viewport );
 		frameBufferTarget.scissor.copy( this._scissor );
 		frameBufferTarget.viewport.multiplyScalar( this._pixelRatio );
 		frameBufferTarget.scissor.multiplyScalar( this._pixelRatio );
 		frameBufferTarget.scissorTest = this._scissorTest;
 		frameBufferTarget.multiview = outputRenderTarget !== null ? outputRenderTarget.multiview : false;
-		frameBufferTarget.resolveDepthBuffer = outputRenderTarget !== null ? outputRenderTarget.resolveDepthBuffer : true;
-		frameBufferTarget._autoAllocateDepthBuffer = outputRenderTarget !== null ? outputRenderTarget._autoAllocateDepthBuffer : false;
 
 		return frameBufferTarget;
 
@@ -1513,15 +1502,6 @@ class Renderer {
 		//
 
 		return renderContext;
-
-	}
-
-	_setXRLayerSize( width, height ) {
-
-		this._width = width;
-		this._height = height;
-
-		this.setViewport( 0, 0, width, height );
 
 	}
 
@@ -2310,7 +2290,7 @@ class Renderer {
 	 * @param {Node|Array<Node>} computeNodes - The compute node(s).
 	 * @return {Promise|undefined} A Promise that resolve when the compute has finished. Only returned when the renderer has not been initialized.
 	 */
-	compute( computeNodes ) {
+	compute( computeNodes, dispatchSize = [ 0, 0, 0 ] ) {
 
 		if ( this._isDeviceLost === true ) return;
 
@@ -2389,7 +2369,7 @@ class Renderer {
 			const computeBindings = bindings.getForCompute( computeNode );
 			const computePipeline = pipelines.getForCompute( computeNode, computeBindings );
 
-			backend.compute( computeNodes, computeNode, computeBindings, computePipeline );
+			backend.compute( computeNodes, computeNode, computeBindings, computePipeline, dispatchSize );
 
 		}
 

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -2288,6 +2288,7 @@ class Renderer {
 	 * if the renderer has been initialized.
 	 *
 	 * @param {Node|Array<Node>} computeNodes - The compute node(s).
+	 * @param {Array<number>} dispatchSize - Array with [x,y,z] values for dispatch.
 	 * @return {Promise|undefined} A Promise that resolve when the compute has finished. Only returned when the renderer has not been initialized.
 	 */
 	compute( computeNodes, dispatchSize = [ 0, 0, 0 ] ) {

--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -915,8 +915,9 @@ class WebGLBackend extends Backend {
 	 * @param {Node} computeNode - The compute node.
 	 * @param {Array<BindGroup>} bindings - The bindings.
 	 * @param {ComputePipeline} pipeline - The compute pipeline.
+	 * @param {number|null} [count=null] - The count of compute invocations. If `null`, the count is determined by the compute node.
 	 */
-	compute( computeGroup, computeNode, bindings, pipeline ) {
+	compute( computeGroup, computeNode, bindings, pipeline, count = null ) {
 
 		const { state, gl } = this;
 
@@ -953,13 +954,23 @@ class WebGLBackend extends Backend {
 		gl.bindTransformFeedback( gl.TRANSFORM_FEEDBACK, transformFeedbackGPU );
 		gl.beginTransformFeedback( gl.POINTS );
 
+		count = ( count !== null ) ? count : computeNode.count;
+
+		if ( Array.isArray( count ) ) {
+
+			warnOnce( 'WebGLBackend.compute(): The count parameter must be a single number, not an array.' );
+
+			count = count[ 0 ];
+
+		}
+
 		if ( attributes[ 0 ].isStorageInstancedBufferAttribute ) {
 
-			gl.drawArraysInstanced( gl.POINTS, 0, 1, computeNode.count );
+			gl.drawArraysInstanced( gl.POINTS, 0, 1, count );
 
 		} else {
 
-			gl.drawArrays( gl.POINTS, 0, computeNode.count );
+			gl.drawArrays( gl.POINTS, 0, count );
 
 		}
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -1397,8 +1397,8 @@ class WebGPUBackend extends Backend {
 
 		passEncoderGPU.dispatchWorkgroups(
 			dispatchSize[ 0 ],
-			dispatchSize[ 1 ],
-			dispatchSize[ 2 ]
+			dispatchSize[ 1 ] || 1,
+			dispatchSize[ 2 ] || 1
 		);
 
 	}

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -1324,9 +1324,6 @@ class WebGPUBackend extends Backend {
 
 		const computeNodeData = this.get( computeNode );
 		const { passEncoderGPU } = this.get( computeGroup );
-		const isValid = Array.isArray( dispatchSize );
-
-		dispatchSize = isValid ? dispatchSize : computeNodeData;	//Or at some point an initial value if condition is not met and count should be depracticed
 
 		// pipeline
 
@@ -1345,7 +1342,33 @@ class WebGPUBackend extends Backend {
 
 		}
 
-		if ( isValid ) {
+		if ( dispatchSize !== null ) {
+
+			if ( ! Array.isArray( dispatchSize ) ) {
+
+				throw new Error( 'dispatchSize must be an array' );
+
+			}
+
+			if ( dispatchSize.length === 0 || dispatchSize.length > 3 ) {
+
+				throw new Error( 'dispatchSize must have 1, 2, or 3 elements' );
+
+			}
+
+			for ( let i = 0; i < dispatchSize.length; i ++ ) {
+
+				const value = dispatchSize[ i ];
+
+				if ( typeof value !== 'number' || value <= 0 || ! Number.isInteger( value ) ) {
+
+					throw new Error( `dispatchSize element at index ${i} must be a positive integer` );
+
+				}
+
+			}
+
+	 		while ( dispatchSize.length < 3 ) dispatchSize.push( 1 );
 
 			passEncoderGPU.dispatchWorkgroups(
 				dispatchSize[ 0 ],
@@ -1354,6 +1377,8 @@ class WebGPUBackend extends Backend {
 			);
 
 		} else {
+
+			dispatchSize = computeNodeData;
 
 			const maxComputeWorkgroupsPerDimension = this.device.limits.maxComputeWorkgroupsPerDimension;
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -1318,6 +1318,7 @@ class WebGPUBackend extends Backend {
 	 * @param {Node} computeNode - The compute node.
 	 * @param {Array<BindGroup>} bindings - The bindings.
 	 * @param {ComputePipeline} pipeline - The compute pipeline.
+	 * @param {Array<number>} dispatchSize - Array with [x,y,z] values for dispatch.
 	 */
 	compute( computeGroup, computeNode, bindings, pipeline, dispatchSize ) {
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -1357,6 +1357,8 @@ class WebGPUBackend extends Backend {
 
 			if ( computeNodeData.dispatchSize === undefined || computeNodeData.count !== count ) {
 
+				// cache dispatch size to avoid recalculating it every time
+
 				computeNodeData.dispatchSize = [ 0, 1, 1 ];
 				computeNodeData.count = count;
 
@@ -1394,6 +1396,7 @@ class WebGPUBackend extends Backend {
 
 		}
 
+		//
 
 		passEncoderGPU.dispatchWorkgroups(
 			dispatchSize[ 0 ],

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -1324,9 +1324,9 @@ class WebGPUBackend extends Backend {
 
 		const computeNodeData = this.get( computeNode );
 		const { passEncoderGPU } = this.get( computeGroup );
-		const isValid = dispatchSize[ 0 ] > 0 && dispatchSize[ 1 ] > 0 && dispatchSize[ 2 ] > 0;
+		const isValid = Array.isArray( dispatchSize );
 
-		dispatchSize = isValid ? dispatchSize : computeNodeData;
+		dispatchSize = isValid ? dispatchSize : computeNodeData;	//Or at some point an initial value if condition is not met and count should be depracticed
 
 		// pipeline
 

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -1898,9 +1898,7 @@ ${ flowData.code }
 
 		} else {
 
-			const workgroupSize = this.object.workgroupSize || [ 64, 1, 1 ];
-
-			if ( workgroupSize.length !== 3 ) throw new Error( 'workgroupSize must have 3 elements' );
+			const workgroupSize = this.object.workgroupSize;	//early strictly validated in computeNode
 
 			this.computeShader = this._getWGSLComputeCode( shadersData.compute, workgroupSize );
 

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -1902,7 +1902,7 @@ ${ flowData.code }
 
 			const workgroupSize = this.object.workgroupSize || [ 8, 8, 1 ];
 
-			if ( workgroupSize.length !== 3 ) throw new Error( "workgroupSize must have 3 elements" );
+			if ( workgroupSize.length !== 3 ) throw new Error( 'workgroupSize must have 3 elements' );
 
 			this.computeShader = this._getWGSLComputeCode( shadersData.compute, workgroupSize );
 

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -1898,9 +1898,7 @@ ${ flowData.code }
 
 		} else {
 
-			//this.computeShader = this._getWGSLComputeCode( shadersData.compute, ( this.object.workgroupSize || [ 64 ] ).join( ', ' ) );
-
-			const workgroupSize = this.object.workgroupSize || [ 8, 8, 1 ];
+			const workgroupSize = this.object.workgroupSize || [ 64, 1, 1 ];
 
 			if ( workgroupSize.length !== 3 ) throw new Error( 'workgroupSize must have 3 elements' );
 

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -1898,7 +1898,9 @@ ${ flowData.code }
 
 		} else {
 
-			const workgroupSize = this.object.workgroupSize;	//early strictly validated in computeNode
+			// Early strictly validated in computeNode
+
+			const workgroupSize = this.object.workgroupSize;
 
 			this.computeShader = this._getWGSLComputeCode( shadersData.compute, workgroupSize );
 
@@ -2109,36 +2111,36 @@ fn main( ${shaderData.varyings} ) -> ${shaderData.returnType} {
 
 		return `${ this.getSignature() }
 // directives
-${shaderData.directives}
+${ shaderData.directives }
 
 // system
 var<private> instanceIndex : u32;
 
 // locals
-${shaderData.scopedArrays}
+${ shaderData.scopedArrays }
 
 // structs
-${shaderData.structs}
+${ shaderData.structs }
 
 // uniforms
-${shaderData.uniforms}
+${ shaderData.uniforms }
 
 // codes
-${shaderData.codes}
+${ shaderData.codes }
 
-@compute @workgroup_size( ${workgroupSizeX}, ${workgroupSizeY}, ${workgroupSizeZ} )
-fn main( ${shaderData.attributes} ) {
+@compute @workgroup_size( ${ workgroupSizeX }, ${ workgroupSizeY }, ${ workgroupSizeZ } )
+fn main( ${ shaderData.attributes } ) {
 
 	// system
 	instanceIndex = globalId.x
-    + globalId.y * (${workgroupSizeX} * numWorkgroups.x)
-    + globalId.z * (${workgroupSizeX} * numWorkgroups.x) * (${workgroupSizeY} * numWorkgroups.y);
+    	+ globalId.y * ( ${ workgroupSizeX } * numWorkgroups.x )
+    	+ globalId.z * ( ${ workgroupSizeX } * numWorkgroups.x ) * ( ${ workgroupSizeY } * numWorkgroups.y );
 
 	// vars
-	${shaderData.vars}
+	${ shaderData.vars }
 
 	// flow
-	${shaderData.flow}
+	${ shaderData.flow }
 
 }
 `;


### PR DESCRIPTION
Related issue: #31393

So far, the workgroup for the compute shader consists of a scalar and the dispatchSize always uses dispatch.x up to ```device.limits.maxComputeWorkgroupsPerDimension``` before dispatch.y is used. The default workgroup is now [ 64, 1, 1 ] instead of [ 64 ]. This ensures that all previous examples are treated as before.

Example on webgpu_compute_particles_rain, usual usage:
```
computeParticles = computeUpdate().compute( maxParticleCount );
renderer.compute( computeParticles );
```

Use with workgroup and dispatchSize
```
computeParticles = computeUpdate().computeKernel( [ 16, 16, 1 ] );
renderer.compute( computeParticles, [ 10, 10, 1 ] );
```

Since the instanceCount in the example is 25,000, workgroup = [ 16, 16, 1 ] and dispatchSize = [ 10, 10, 1 ] = 16 * 10 * 16 * 10 * 1 = 25,600 threads, enough to cover everything. If you choose smaller values for dispatchSize, e.g., [ 9, 9, 1 ], you would see that not all raindrops are computed.

You now have full control over the thread distribution for the GPU, which was not possible.
I'm setting the PR to draft for now, even though it works, because I might think of a few more things I'd like to add. Maybe warnings if you enter something incorrectly.
