### PR TITLE
Docs: Improve `AnimationClip` page.

### DIFF
--- a/docs/api/ar/animation/AnimationClip.html
+++ b/docs/api/ar/animation/AnimationClip.html
@@ -91,7 +91,7 @@
 		<h2>الوظائف الساكنة (Static Methods)</h2>
 
 
-		<h3>[method:Array CreateClipsFromMorphTargetSequences]( [param:String name], [param:Array morphTargetSequence], [param:Number fps], [param:Boolean noLoop] )</h3>
+		<h3>[method:Array CreateClipsFromMorphTargetSequences]( [param:Array morphTargetSequence], [param:Number fps], [param:Boolean noLoop] )</h3>
 		<p>
 			تُرجع مصفوفة من AnimationClips الجديدة التي تم إنشاؤها من morph target sequences من الشكل الهندسي ، في محاولة لفرز أسماء الأهداف التحويلية إلى أنماط قائمة على مجموعة الرسوم المتحركة مثل "Walk_001 ، Walk_002 ، Run_001 ، Run_002 ...".
 		</p>

--- a/docs/api/en/animation/AnimationClip.html
+++ b/docs/api/en/animation/AnimationClip.html
@@ -105,7 +105,7 @@
 		<h2>Static Methods</h2>
 
 
-		<h3>[method:Array CreateClipsFromMorphTargetSequences]( [param:String name], [param:Array morphTargetSequence], [param:Number fps], [param:Boolean noLoop] )</h3>
+		<h3>[method:Array CreateClipsFromMorphTargetSequences]( [param:Array morphTargetSequence], [param:Number fps], [param:Boolean noLoop] )</h3>
 		<p>
 			Returns an array of new AnimationClips created from the morph target
 			sequences of a geometry, trying to sort morph target names into

--- a/docs/api/fr/animation/AnimationClip.html
+++ b/docs/api/fr/animation/AnimationClip.html
@@ -101,7 +101,7 @@
 		<h2>Méthodes Statiques</h2>
 
 
-		<h3>[method:Array CreateClipsFromMorphTargetSequences]( [param:String name], [param:Array morphTargetSequence], [param:Number fps], [param:Boolean noLoop] )</h3>
+		<h3>[method:Array CreateClipsFromMorphTargetSequences]( [param:Array morphTargetSequence], [param:Number fps], [param:Boolean noLoop] )</h3>
 		<p>
 			Renvoie un tableau de nouveaux AnimationClips créés depuis les séquences de morph
 			target d'une forme, essayant de trier les noms des morph targets en un pattern basé sur le groupe d'animation

--- a/docs/api/ko/animation/AnimationClip.html
+++ b/docs/api/ko/animation/AnimationClip.html
@@ -94,7 +94,7 @@
 		<h2>정적 메서드</h2>
 
 
-		<h3>[method:Array CreateClipsFromMorphTargetSequences]( [param:String name], [param:Array morphTargetSequence], [param:Number fps], [param:Boolean noLoop] )</h3>
+		<h3>[method:Array CreateClipsFromMorphTargetSequences]( [param:Array morphTargetSequence], [param:Number fps], [param:Boolean noLoop] )</h3>
 		<p>
 			geometry의 morphtarget sequences 를 통해 생성된 새 AnimationClips 배열을 리턴하고 ,
 			모프 타겟 이름을 애니메이션-그룹-기반의 "Walk_001, Walk_002, Run_001, Run_002 ..."와 같은 패턴으로 정리합니다.

--- a/docs/api/pt-br/animation/AnimationClip.html
+++ b/docs/api/pt-br/animation/AnimationClip.html
@@ -100,7 +100,7 @@
 		<h2>Métodos estáticos</h2>
 
 
-		<h3>[method:Array CreateClipsFromMorphTargetSequences]( [param:String name], [param:Array morphTargetSequence], [param:Number fps], [param:Boolean noLoop] )</h3>
+		<h3>[method:Array CreateClipsFromMorphTargetSequences]( [param:Array morphTargetSequence], [param:Number fps], [param:Boolean noLoop] )</h3>
 		<p>
 			Retorna um array de novos AnimationClips criados a partir
 			de sequências morph target de uma geometria, tentando classificar nomes de morph targets em grupos de animação

--- a/docs/api/zh/animation/AnimationClip.html
+++ b/docs/api/zh/animation/AnimationClip.html
@@ -93,7 +93,7 @@
 		<h2>静态方法</h2>
 
 
-		<h3>[method:Array CreateClipsFromMorphTargetSequences]( [param:String name], [param:Array morphTargetSequence], [param:Number fps], [param:Boolean noLoop] )</h3>
+		<h3>[method:Array CreateClipsFromMorphTargetSequences]( [param:Array morphTargetSequence], [param:Number fps], [param:Boolean noLoop] )</h3>
 		<p>
 			返回从几何体的变形目标序列(morph
 			target sequences)创建的新动画剪辑(AnimationClip)数组，并尝试将变形目标名称分类为基于动画组的模式，如“Walk_001、Walk_002、Run_001、Run_002……”。


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/31414#issuecomment-3071169016

**Description**

The PR fixes the wrongly documented signature of `AnimationClip.CreateClipsFromMorphTargetSequences()`.
