### PR TITLE
WebGPURenderer: Persistent video texture approach

### DIFF
--- a/src/renderers/common/SampledTexture.js
+++ b/src/renderers/common/SampledTexture.js
@@ -78,8 +78,6 @@ class SampledTexture extends Binding {
 	 */
 	needsBindingsUpdate( generation ) {
 
-		const { texture } = this;
-
 		if ( generation !== this.generation ) {
 
 			this.generation = generation;
@@ -88,7 +86,7 @@ class SampledTexture extends Binding {
 
 		}
 
-		return texture.isVideoTexture;
+		return false;
 
 	}
 

--- a/src/renderers/common/Textures.js
+++ b/src/renderers/common/Textures.js
@@ -366,9 +366,19 @@ class Textures extends DataMap {
 
 			if ( image.image !== undefined ) image = image.image;
 
-			target.width = image.width || 1;
-			target.height = image.height || 1;
-			target.depth = texture.isCubeTexture ? 6 : ( image.depth || 1 );
+			if ( image instanceof HTMLVideoElement ) {
+
+				target.width = image.videoWidth || 1;
+				target.height = image.videoHeight || 1;
+				target.depth = 1;
+
+			} else {
+
+				target.width = image.width || 1;
+				target.height = image.height || 1;
+				target.depth = texture.isCubeTexture ? 6 : ( image.depth || 1 );
+
+			}
 
 		} else {
 

--- a/src/renderers/webgpu/utils/WebGPUBindingUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUBindingUtils.js
@@ -113,10 +113,6 @@ class WebGPUBindingUtils {
 
 				bindingGPU.sampler = sampler;
 
-			} else if ( binding.isSampledTexture && binding.texture.isVideoTexture ) {
-
-				bindingGPU.externalTexture = {}; // GPUExternalTextureBindingLayout
-
 			} else if ( binding.isSampledTexture && binding.store ) {
 
 				const storageTexture = {}; // GPUStorageTextureBindingLayout


### PR DESCRIPTION
Closes https://github.com/mrdoob/three.js/issues/31330, https://github.com/mrdoob/three.js/pull/31397

**Description**

Replaces `texture_external` with a persistent texture using `copyExternalImageToTexture()` updating by `requestVideoFrameCallback` of `VideoTexture`, reusing all of the core's texture management, including sharing between materials, and adds support for vertex stage usage too.

@Mugen87 I think this is the best way, in addition to the benefits, it reduces the total code.