### PR TITLE
fix(GTAOPass): exclude Line2 objects from AO calculation

### DIFF
--- a/examples/jsm/postprocessing/GTAOPass.js
+++ b/examples/jsm/postprocessing/GTAOPass.js
@@ -657,7 +657,7 @@ class GTAOPass extends Pass {
 
 			cache.set( object, object.visible );
 
-			if ( object.isPoints || object.isLine ) object.visible = false;
+			if ( object.isPoints || object.isLine || object.isLine2) object.visible = false;
 
 		} );
 


### PR DESCRIPTION
**Description**

This PR fixes a rendering issue where black squares appear at the world center when using Line2 objects with GTAOPass.

**Problem:**
When Line2 objects are present in a scene that uses GTAOPass for ambient occlusion, black artifacts (squares) appear at the world center during rendering.

**Root Cause:**
The GTAOPass's `_overrideVisibility()` method was not excluding Line2 objects from AO calculation. While Points and Line objects were already properly excluded, Line2 objects were inadvertently included in the ambient occlusion rendering pass, causing rendering artifacts.

**Solution:**
Added `|| object.isLine2` condition to the visibility override check in `GTAOPass._overrideVisibility()`. This ensures Line2 objects are treated consistently with other line-based objects (Points and Line) and are excluded from AO calculations.

**Changes:**
- Modified `examples/jsm/postprocessing/GTAOPass.js` line 660 to include Line2 objects in the visibility override condition
- Line2 objects now follow the same rendering behavior as Points and Line objects in GTAO passes
