### PR TITLE
WebGLState: Initialize the depth func to the default value

### DIFF
--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -1203,7 +1203,7 @@ function WebGLState( gl, extensions ) {
 		gl.clearColor( 0, 0, 0, 0 );
 
 		gl.depthMask( true );
-		gl.depthFunc( gl.LESS );
+		gl.depthFunc( gl.LEQUAL );
 
 		depthBuffer.setReversed( false );
 


### PR DESCRIPTION
Initialize the depth func to the default value used in the library.

Granted, it may not matter in this case.