### PR TITLE
TSL: Fix `pass()` build during `sample()` call using `Mesh`

### DIFF
--- a/src/nodes/display/PassNode.js
+++ b/src/nodes/display/PassNode.js
@@ -49,7 +49,7 @@ class PassTextureNode extends TextureNode {
 
 	setup( builder ) {
 
-		if ( builder.object.isQuadMesh ) this.passNode.build( builder );
+		this.passNode.build( builder );
 
 		return super.setup( builder );
 


### PR DESCRIPTION
Related issue: https://discourse.threejs.org/t/tsl-using-the-output-of-pass-in-colornode-in-screen-space/85178/4

**Description**

Fix `pass()` build during `sample()` call using `Mesh`.

```js
// material
const material = new THREE.NodeMaterial();

const maskScenePass = pass( maskScene, camera );

material.colorNode = Fn( () => {

	const maskTexture = maskScenePass.getTextureNode();

	const maskVal = maskTexture.sample( screenUV ).r

	return mix( color( 1, 0, 0 ), color( 0, 1, 0 ), maskVal );

} )();

// mesh
mesh = new THREE.Mesh( geometry, material );
scene.add( mesh );
```