### PR TITLE
WebXRManager: Disable left eye layer for right eye camera and vice versa

### DIFF
--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -722,9 +722,10 @@ class WebXRManager extends EventDispatcher {
 
 			}
 
-			cameraL.layers.mask = camera.layers.mask | 0b010;
-			cameraR.layers.mask = camera.layers.mask | 0b100;
-			cameraXR.layers.mask = cameraL.layers.mask | cameraR.layers.mask;
+			// inherit camera layers and enable eye layers (1 = left, 2 = right)
+			cameraXR.layers.mask = camera.layers.mask | 0b110;
+			cameraL.layers.mask = cameraXR.layers.mask & 0b011;
+			cameraR.layers.mask = cameraXR.layers.mask & 0b101;
 
 			const parent = camera.parent;
 			const cameras = cameraXR.cameras;


### PR DESCRIPTION
Related issue: #31434

**Description**

Since #29742, layers enabled on the camera are inherited by the XR cameras. In addition, the special layers (1 and 2) are enabled for the left and right camera respectively. 

This PR changes the logic slightly so that it not only enables the eye layers, but explicitly disables the eye layer for the other eye. This way the left eye camera will never render with the right eye layer and vice versa. Before this change that could still happen when the camera had these layers enabled.

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Fern Solutions](https://fern.solutions/)*

