### PR TITLE
KTX2Loader: Add setTranscoderUrls() for custom transcoder URLs

### DIFF
--- a/docs/examples/en/loaders/KTX2Loader.html
+++ b/docs/examples/en/loaders/KTX2Loader.html
@@ -42,7 +42,10 @@
 
 		<code>
 		var ktx2Loader = new KTX2Loader();
-		ktx2Loader.setTranscoderPath( 'examples/jsm/libs/basis/' );
+		ktx2Loader.setTranscoderPath( {
+			js: 'jsm/libs/basis/basis_transcoder.js',
+			wasm: 'jsm/libs/basis/basis_transcoder.wasm'
+		} )
 		ktx2Loader.detectSupport( renderer );
 		ktx2Loader.load( 'diffuse.ktx2', function ( texture ) {
 

--- a/docs/examples/zh/loaders/KTX2Loader.html
+++ b/docs/examples/zh/loaders/KTX2Loader.html
@@ -39,7 +39,10 @@
 
 	<code>
 		var ktx2Loader = new KTX2Loader();
-		ktx2Loader.setTranscoderPath( 'examples/jsm/libs/basis/' );
+		ktx2Loader.setTranscoderPath( {
+			js: 'jsm/libs/basis/basis_transcoder.js',
+			wasm: 'jsm/libs/basis/basis_transcoder.wasm'
+		} )
 		ktx2Loader.detectSupport( renderer );
 		ktx2Loader.load( 'diffuse.ktx2', function ( texture ) {
 

--- a/editor/js/Loader.js
+++ b/editor/js/Loader.js
@@ -992,7 +992,10 @@ function Loader( editor ) {
 		dracoLoader.setDecoderPath( '../examples/jsm/libs/draco/gltf/' );
 
 		const ktx2Loader = new KTX2Loader( manager );
-		ktx2Loader.setTranscoderPath( '../examples/jsm/libs/basis/' );
+		ktx2Loader.setTranscoderPath( {
+			js: 'jsm/libs/basis/basis_transcoder.js',
+			wasm: 'jsm/libs/basis/basis_transcoder.wasm'
+		} );
 
 		editor.signals.rendererDetectKTX2Support.dispatch( ktx2Loader );
 

--- a/editor/js/libs/ui.three.js
+++ b/editor/js/libs/ui.three.js
@@ -117,7 +117,10 @@ class UITexture extends UISpan {
 					const arrayBuffer = event.target.result;
 					const blobURL = URL.createObjectURL( new Blob( [ arrayBuffer ] ) );
 					const ktx2Loader = new KTX2Loader();
-					ktx2Loader.setTranscoderPath( '../../examples/jsm/libs/basis/' );
+					ktx2Loader.setTranscoderPath( {
+						js: 'jsm/libs/basis/basis_transcoder.js',
+						wasm: 'jsm/libs/basis/basis_transcoder.wasm'
+					} );
 					editor.signals.rendererDetectKTX2Support.dispatch( ktx2Loader );
 
 					ktx2Loader.load( blobURL, function ( texture ) {

--- a/examples/jsm/libs/basis/README.md
+++ b/examples/jsm/libs/basis/README.md
@@ -24,7 +24,10 @@ Both are dependencies of `KTX2Loader`:
 
 ```js
 const ktx2Loader = new KTX2Loader();
-ktx2Loader.setTranscoderPath( 'examples/jsm/libs/basis/' );
+ktx2Loader.setTranscoderPath( {
+	js: 'jsm/libs/basis/basis_transcoder.js',
+	wasm: 'jsm/libs/basis/basis_transcoder.wasm'
+} )
 ktx2Loader.detectSupport( renderer );
 ktx2Loader.load( 'diffuse.ktx2', function ( texture ) {
 

--- a/examples/misc_exporter_gltf.html
+++ b/examples/misc_exporter_gltf.html
@@ -484,7 +484,10 @@
 				// Exporting compressed textures and meshes (KTX2 / Draco / Meshopt)
 				// ---------------------------------------------------------------------
 				const ktx2Loader = new KTX2Loader()
-					.setTranscoderPath( 'jsm/libs/basis/' )
+					.setTranscoderPath( {
+						js: 'jsm/libs/basis/basis_transcoder.js',
+						wasm: 'jsm/libs/basis/basis_transcoder.wasm'
+					} )
 					.detectSupport( renderer );
 
 				const gltfLoader = new GLTFLoader().setPath( 'models/gltf/' );

--- a/examples/webgl_loader_gltf_compressed.html
+++ b/examples/webgl_loader_gltf_compressed.html
@@ -69,7 +69,10 @@
 				scene.add( grid );
 
 				const ktx2Loader = new KTX2Loader()
-					.setTranscoderPath( 'jsm/libs/basis/' )
+					.setTranscoderPath( {
+						js: 'jsm/libs/basis/basis_transcoder.js',
+						wasm: 'jsm/libs/basis/basis_transcoder.wasm'
+					} )
 					.detectSupport( renderer );
 
 				const loader = new GLTFLoader().setPath( 'models/gltf/' );

--- a/examples/webgl_loader_texture_ktx2.html
+++ b/examples/webgl_loader_texture_ktx2.html
@@ -141,7 +141,10 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 
 				const loader = new KTX2Loader()
-					.setTranscoderPath( 'jsm/libs/basis/' )
+					.setTranscoderPath( {
+						js: 'jsm/libs/basis/basis_transcoder.js',
+						wasm: 'jsm/libs/basis/basis_transcoder.wasm'
+					} )
 					.setPath( 'textures/ktx2/' )
 					.detectSupport( renderer );
 

--- a/examples/webgl_morphtargets_face.html
+++ b/examples/webgl_morphtargets_face.html
@@ -68,7 +68,10 @@
 				container.appendChild( renderer.domElement );
 
 				const ktx2Loader = new KTX2Loader()
-					.setTranscoderPath( 'jsm/libs/basis/' )
+					.setTranscoderPath( {
+						js: 'jsm/libs/basis/basis_transcoder.js',
+						wasm: 'jsm/libs/basis/basis_transcoder.wasm'
+					} )
 					.detectSupport( renderer );
 
 				new GLTFLoader()

--- a/examples/webgl_morphtargets_webcam.html
+++ b/examples/webgl_morphtargets_webcam.html
@@ -130,7 +130,10 @@
 			const eyeRotationLimit = THREE.MathUtils.degToRad( 30 );
 
 			const ktx2Loader = new KTX2Loader()
-				.setTranscoderPath( 'jsm/libs/basis/' )
+				.setTranscoderPath( {
+					js: 'jsm/libs/basis/basis_transcoder.js',
+					wasm: 'jsm/libs/basis/basis_transcoder.wasm'
+				} )
 				.detectSupport( renderer );
 
 			new GLTFLoader()

--- a/examples/webgl_texture2darray_compressed.html
+++ b/examples/webgl_texture2darray_compressed.html
@@ -96,7 +96,10 @@
 				//
 
 				const ktx2Loader = new KTX2Loader();
-				ktx2Loader.setTranscoderPath( 'jsm/libs/basis/' );
+				ktx2Loader.setTranscoderPath( {
+					js: 'jsm/libs/basis/basis_transcoder.js',
+					wasm: 'jsm/libs/basis/basis_transcoder.wasm'
+				} );
 				ktx2Loader.detectSupport( renderer );
 
 				ktx2Loader.load( 'textures/spiritedaway.ktx2', function ( texturearray ) {

--- a/examples/webgl_texture2darray_layerupdate.html
+++ b/examples/webgl_texture2darray_layerupdate.html
@@ -94,7 +94,10 @@
 				// Configure the KTX2 loader.
 
 				const ktx2Loader = new KTX2Loader();
-				ktx2Loader.setTranscoderPath( 'jsm/libs/basis/' );
+				ktx2Loader.setTranscoderPath( {
+					js: 'jsm/libs/basis/basis_transcoder.js',
+					wasm: 'jsm/libs/basis/basis_transcoder.wasm'
+				} );
 				ktx2Loader.detectSupport( renderer );
 
 				// Load several KTX2 textures which will later be used to modify

--- a/examples/webgpu_loader_gltf_compressed.html
+++ b/examples/webgpu_loader_gltf_compressed.html
@@ -68,7 +68,10 @@
 				controls.update();
 
 				const ktx2Loader = await new KTX2Loader()
-					.setTranscoderPath( 'jsm/libs/basis/' )
+					.setTranscoderPath( {
+						js: 'jsm/libs/basis/basis_transcoder.js',
+						wasm: 'jsm/libs/basis/basis_transcoder.wasm'
+					} )
 					.detectSupportAsync( renderer );
 
 				const loader = new GLTFLoader();

--- a/examples/webgpu_morphtargets_face.html
+++ b/examples/webgpu_morphtargets_face.html
@@ -74,7 +74,10 @@
 				scene.environment = pmremGenerator.fromScene( environment ).texture;
 
 				const ktx2Loader = await new KTX2Loader()
-					.setTranscoderPath( 'jsm/libs/basis/' )
+					.setTranscoderPath( {
+						js: 'jsm/libs/basis/basis_transcoder.js',
+						wasm: 'jsm/libs/basis/basis_transcoder.wasm'
+					} )
 					.detectSupportAsync( renderer );
 
 				new GLTFLoader()

--- a/examples/webgpu_sandbox.html
+++ b/examples/webgpu_sandbox.html
@@ -64,7 +64,10 @@
 				textureDisplace.wrapT = THREE.RepeatWrapping;
 
 				const ktxLoader = await new KTX2Loader()
-					.setTranscoderPath( 'jsm/libs/basis/' )
+					.setTranscoderPath( {
+						js: 'jsm/libs/basis/basis_transcoder.js',
+						wasm: 'jsm/libs/basis/basis_transcoder.wasm'
+					} )
 					.detectSupportAsync( renderer );
 
 				const ktxTexture = await ktxLoader.loadAsync( './textures/ktx2/2d_uastc.ktx2' );

--- a/examples/webgpu_textures_2d-array_compressed.html
+++ b/examples/webgpu_textures_2d-array_compressed.html
@@ -67,7 +67,10 @@
 				//
 
 				const ktx2Loader = new KTX2Loader();
-				ktx2Loader.setTranscoderPath( 'jsm/libs/basis/' );
+				ktx2Loader.setTranscoderPath( {
+					js: 'jsm/libs/basis/basis_transcoder.js',
+					wasm: 'jsm/libs/basis/basis_transcoder.wasm'
+				} );
 				await ktx2Loader.detectSupportAsync( renderer );
 
 				ktx2Loader.load( 'textures/spiritedaway.ktx2', function ( texturearray ) {


### PR DESCRIPTION
### What

Adds a new method `setTranscoderUrls()` to `KTX2Loader`:

```js
ktx2Loader.setTranscoderUrls({
  jsUrl: 'path/to/basis_transcoder.js',
  wasmUrl: 'path/to/basis_transcoder.wasm',
});
```

This method allows to provide explicit URLs for the transcoder JS and WASM files, instead of relying on fixed filenames and directory paths.

## Why

The existing `setTranscoderPath()` method assumes that `basis_transcoder.js` and `.wasm` are located in the same directory and have fixed names. This is not always suitable for:

- Projects using bundlers like Vite, Webpack, or Rollup
- Single-file deployments (e.g., HTML5 playable ads)
- CDN-hosted or dynamically resolved asset setups

`setTranscoderUrls()` provides more control and flexibility while remaining fully backward-compatible.

## Implementation Notes

- If `setTranscoderUrls()` is used, it overrides `setTranscoderPath()`.
- If neither method is called, the default path-based behavior is preserved.
- No external dependencies added.
- The new method includes full JSDoc for in-editor discoverability.
