### PR TITLE
SSAOPass: Replace visibility cache Map with an array for improved performance

### DIFF
--- a/examples/jsm/postprocessing/SSAOPass.js
+++ b/examples/jsm/postprocessing/SSAOPass.js
@@ -487,8 +487,6 @@ class SSAOPass extends Pass {
 		const scene = this.scene;
 		const cache = this._visibilityCache;
 
-		cache.length = 0;
-
 		scene.traverse( function ( object ) {
 
 			if ( ( object.isPoints || object.isLine || object.isLine2 ) && object.visible ) {

--- a/examples/jsm/postprocessing/SSAOPass.js
+++ b/examples/jsm/postprocessing/SSAOPass.js
@@ -139,7 +139,7 @@ class SSAOPass extends Pass {
 		 */
 		this.maxDistance = 0.1;
 
-		this._visibilityCache = new Map();
+		this._visibilityCache = [];
 
 		//
 
@@ -487,11 +487,16 @@ class SSAOPass extends Pass {
 		const scene = this.scene;
 		const cache = this._visibilityCache;
 
+		cache.length = 0;
+
 		scene.traverse( function ( object ) {
 
-			cache.set( object, object.visible );
+			if ( ( object.isPoints || object.isLine || object.isPoints || object.isLine2 ) && object.visible ) {
 
-			if ( object.isPoints || object.isLine ) object.visible = false;
+				object.visible = false;
+				cache.push( object );
+
+			}
 
 		} );
 
@@ -499,17 +504,15 @@ class SSAOPass extends Pass {
 
 	_restoreVisibility() {
 
-		const scene = this.scene;
 		const cache = this._visibilityCache;
 
-		scene.traverse( function ( object ) {
+		for ( let i = 0; i < cache.length; i ++ ) {
 
-			const visible = cache.get( object );
-			object.visible = visible;
+			cache[ i ].visible = true;
 
-		} );
+		}
 
-		cache.clear();
+		cache.length = 0;
 
 	}
 

--- a/examples/jsm/postprocessing/SSAOPass.js
+++ b/examples/jsm/postprocessing/SSAOPass.js
@@ -491,7 +491,7 @@ class SSAOPass extends Pass {
 
 		scene.traverse( function ( object ) {
 
-			if ( ( object.isPoints || object.isLine || object.isPoints || object.isLine2 ) && object.visible ) {
+			if ( ( object.isPoints || object.isLine || object.isLine2 ) && object.visible ) {
 
 				object.visible = false;
 				cache.push( object );


### PR DESCRIPTION
This PR refactors the SSAOPass class in `examples/jsm/postprocessing/SSAOPass.js` to improve how object visibility is cached and restored during the SSAO pass. It improves performance and clarity by only tracking objects whose visibility is actually modified.

We can reduce the SSAO pass render time by nearly 40-50%.

| The dev branch | PR |
| --- | --- |
| <img width="492" height="148" alt="Screenshot 2025-07-20 at 17 00 50" src="https://github.com/user-attachments/assets/0e212d8f-7f8f-43aa-bbcd-aeed97ed9377" /> | <img width="283" height="178" alt="Screenshot 2025-07-20 at 17 07 46" src="https://github.com/user-attachments/assets/eb1d4446-744f-417a-a771-dcb2f8809821" /> |

