### PR TITLE
Unit Tests: Clean up Frustum Tests

### DIFF
--- a/test/unit/src/math/Frustum.tests.js
+++ b/test/unit/src/math/Frustum.tests.js
@@ -122,7 +122,7 @@ export default QUnit.module( 'Maths', () => {
 
 		QUnit.test( 'setFromProjectionMatrix/makeOrthographic/containsPoint', ( assert ) => {
 
-			const m = new Matrix4().makeOrthographic( - 1, 1, - 1, 1, 1, 100 );
+			const m = new Matrix4().makeOrthographic( - 1, 1, 1, - 1, 1, 100 );
 			const a = new Frustum().setFromProjectionMatrix( m );
 
 			assert.ok( ! a.containsPoint( new Vector3( 0, 0, 0 ) ), 'Passed!' );
@@ -132,10 +132,10 @@ export default QUnit.module( 'Maths', () => {
 			assert.ok( ! a.containsPoint( new Vector3( - 1.1, - 1.1, - 1.001 ) ), 'Passed!' );
 			assert.ok( a.containsPoint( new Vector3( 1, 1, - 1.001 ) ), 'Passed!' );
 			assert.ok( ! a.containsPoint( new Vector3( 1.1, 1.1, - 1.001 ) ), 'Passed!' );
-			assert.ok( a.containsPoint( new Vector3( 0, 0, - 100 ) ), 'Passed!' );
-			assert.ok( a.containsPoint( new Vector3( - 1, - 1, - 100 ) ), 'Passed!' );
+			assert.ok( a.containsPoint( new Vector3( 0, 0, - 99.999 ) ), 'Passed!' );
+			assert.ok( a.containsPoint( new Vector3( - 0.999, - 0.999, - 99.999 ) ), 'Passed!' );
 			assert.ok( ! a.containsPoint( new Vector3( - 1.1, - 1.1, - 100.1 ) ), 'Passed!' );
-			assert.ok( a.containsPoint( new Vector3( 1, 1, - 100 ) ), 'Passed!' );
+			assert.ok( a.containsPoint( new Vector3( 0.999, 0.999, - 99.999 ) ), 'Passed!' );
 			assert.ok( ! a.containsPoint( new Vector3( 1.1, 1.1, - 100.1 ) ), 'Passed!' );
 			assert.ok( ! a.containsPoint( new Vector3( 0, 0, - 101 ) ), 'Passed!' );
 


### PR DESCRIPTION
Avoid tests on the frustum boundary. Such tests are governed by round-off errors.
