### PR TITLE
BatchedMesh: Fix `setInstanceCount()`.

### DIFF
--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -1251,7 +1251,7 @@ class BatchedMesh extends Mesh {
 		const availableInstanceIds = this._availableInstanceIds;
 		const instanceInfo = this._instanceInfo;
 		availableInstanceIds.sort( ascIdSort );
-		while ( availableInstanceIds[ availableInstanceIds.length - 1 ] === instanceInfo.length ) {
+		while ( availableInstanceIds[ availableInstanceIds.length - 1 ] === instanceInfo.length - 1 ) {
 
 			instanceInfo.pop();
 			availableInstanceIds.pop();

--- a/test/unit/src/objects/BatchedMesh.tests.js
+++ b/test/unit/src/objects/BatchedMesh.tests.js
@@ -1,0 +1,40 @@
+/* global QUnit */
+
+import { BatchedMesh } from '../../../../src/objects/BatchedMesh.js';
+import { BoxGeometry } from '../../../../src/geometries/BoxGeometry.js';
+import { MeshBasicMaterial } from '../../../../src/materials/MeshBasicMaterial.js';
+
+export default QUnit.module( 'Objects', () => {
+
+	QUnit.module( 'BatchedMesh', () => {
+
+		// PUBLIC
+
+		QUnit.test( 'setInstanceCount', ( assert ) => {
+
+			const box = new BoxGeometry( 1, 1, 1 );
+			const material = new MeshBasicMaterial( { color: 0x00ff00 } );
+			
+			// initialize and add geometries into the batched mesh
+			const batchedMesh = new BatchedMesh( 4, 5000, 10000, material );
+			const boxGeometryId = batchedMesh.addGeometry( box );
+			
+			// create instances of those geometries
+			let boxInstanceIds = []
+			for (let i = 0; i < 4; i++){
+				boxInstanceIds.push( batchedMesh.addInstance( boxGeometryId ) );
+			}
+			
+			batchedMesh.deleteInstance( boxInstanceIds[2] );
+			batchedMesh.deleteInstance( boxInstanceIds[3] );
+
+			// shrink the instance count
+			batchedMesh.setInstanceCount(2);
+
+			assert.ok( batchedMesh.instanceCount === 2, 'instance count unequal 2' );
+
+		} );
+
+	} );
+
+} );

--- a/test/unit/src/objects/BatchedMesh.tests.js
+++ b/test/unit/src/objects/BatchedMesh.tests.js
@@ -15,12 +15,12 @@ export default QUnit.module( 'Objects', () => {
 			const box = new BoxGeometry( 1, 1, 1 );
 			const material = new MeshBasicMaterial( { color: 0x00ff00 } );
 			
-			// initialize and add geometries into the batched mesh
+			// initialize and add a geometry into the batched mesh
 			const batchedMesh = new BatchedMesh( 4, 5000, 10000, material );
 			const boxGeometryId = batchedMesh.addGeometry( box );
 			
-			// create instances of those geometries
-			let boxInstanceIds = []
+			// create instances of this geometry
+			let boxInstanceIds = [];
 			for (let i = 0; i < 4; i++){
 				boxInstanceIds.push( batchedMesh.addInstance( boxGeometryId ) );
 			}

--- a/test/unit/three.source.unit.js
+++ b/test/unit/three.source.unit.js
@@ -215,6 +215,7 @@ import './src/math/interpolants/QuaternionLinearInterpolant.tests.js';
 
 //src/objects
 import './src/objects/Bone.tests.js';
+import './src/objects/BatchedMesh.tests.js';
 import './src/objects/Group.tests.js';
 import './src/objects/InstancedMesh.tests.js';
 import './src/objects/Line.tests.js';


### PR DESCRIPTION
Fixed #31457

**Description**

setInstanceCount tries to shrink availableInstanceIds as much as it can, by trying to remove ids at the end.
However, the condition was wrong, given that the largest id is instanceInfo.length - 1, not instanceInfo.length.