### PR TITLE
Camera: Remove `reversedDepth` from user level code.

### DIFF
--- a/examples/webgl_reverse_depth_buffer.html
+++ b/examples/webgl_reverse_depth_buffer.html
@@ -130,7 +130,6 @@
 				camera.position.z = 12;
 
 				reversedCamera = camera.clone();
-				reversedCamera.reversedDepth = true;
 
 				scene = new THREE.Scene();
 

--- a/examples/webgl_shadowmap.html
+++ b/examples/webgl_shadowmap.html
@@ -107,13 +107,6 @@
 				renderer.setAnimationLoop( animate );
 				container.appendChild( renderer.domElement );
 
-				if ( renderer.capabilities.reversedDepthBuffer ) {
-
-					camera.reversedDepth = true;
-					camera.updateProjectionMatrix();
-
-				}
-
 				renderer.autoClear = false;
 
 				//

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -150,17 +150,6 @@ function WebGLShadowMap( renderer, objects, capabilities ) {
 				shadow.map = new WebGLRenderTarget( _shadowMapSize.x, _shadowMapSize.y, pars );
 				shadow.map.texture.name = light.name + '.shadowMap';
 
-				// @deprecated, r179
-				if ( capabilities.reversedDepthBuffer === true && camera.reversedDepth === false ) {
-
-					shadow.camera.reversedDepth = true;
-
-				} else {
-
-					shadow.camera.reversedDepth = camera.reversedDepth;
-
-				}
-
 				shadow.camera.updateProjectionMatrix();
 
 			}


### PR DESCRIPTION
Users should not be expected to set `camera.reversedDepth` on every camera. It should only be necessary to set `reversedDepthBuffer: true` in the renderer's constructor.

These code blocks should not be necessary, if everything goes to plan...