### PR TITLE
Fix performance of BatchedMesh removals and insertions

### DIFF
--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -262,6 +262,8 @@ class BatchedMesh extends Mesh {
 		// flags
 		this._visibilityChanged = true;
 		this._geometryInitialized = false;
+		this._availableInstanceIdsSorted = true;
+		this._availableGeometryIdsSorted = true;
 
 		// cached user options
 		this._maxInstanceCount = maxInstanceCount;
@@ -580,7 +582,12 @@ class BatchedMesh extends Mesh {
 		// Prioritize using previously freed instance ids
 		if ( this._availableInstanceIds.length > 0 ) {
 
-			this._availableInstanceIds.sort( ascIdSort );
+			if ( ! this._availableInstanceIdsSorted ) {
+
+				this._availableInstanceIds.sort( ascIdSort );
+				this._availableInstanceIdsSorted = true;
+
+			}
 
 			drawId = this._availableInstanceIds.shift();
 			this._instanceInfo[ drawId ] = instanceInfo;
@@ -677,7 +684,12 @@ class BatchedMesh extends Mesh {
 		let geometryId;
 		if ( this._availableGeometryIds.length > 0 ) {
 
-			this._availableGeometryIds.sort( ascIdSort );
+			if ( ! this._availableGeometryIdsSorted ) {
+
+				this._availableGeometryIds.sort( ascIdSort );
+				this._availableGeometryIdsSorted = true;
+
+			}
 
 			geometryId = this._availableGeometryIds.shift();
 			geometryInfoList[ geometryId ] = geometryInfo;
@@ -846,6 +858,7 @@ class BatchedMesh extends Mesh {
 
 		geometryInfoList[ geometryId ].active = false;
 		this._availableGeometryIds.push( geometryId );
+		this._availableGeometryIdsSorted = false;
 		this._visibilityChanged = true;
 
 		return this;
@@ -864,6 +877,7 @@ class BatchedMesh extends Mesh {
 
 		this._instanceInfo[ instanceId ].active = false;
 		this._availableInstanceIds.push( instanceId );
+		this._availableInstanceIdsSorted = false;
 		this._visibilityChanged = true;
 
 		return this;
@@ -1250,7 +1264,13 @@ class BatchedMesh extends Mesh {
 		// shrink the available instances as much as possible
 		const availableInstanceIds = this._availableInstanceIds;
 		const instanceInfo = this._instanceInfo;
-		availableInstanceIds.sort( ascIdSort );
+		if ( ! this._availableInstanceIdsSorted ) {
+
+			availableInstanceIds.sort( ascIdSort );
+			this._availableInstanceIdsSorted = true;
+
+		}
+
 		while ( availableInstanceIds[ availableInstanceIds.length - 1 ] === instanceInfo.length - 1 ) {
 
 			instanceInfo.pop();
@@ -1445,6 +1465,8 @@ class BatchedMesh extends Mesh {
 
 		this._availableInstanceIds = source._availableInstanceIds.slice();
 		this._availableGeometryIds = source._availableGeometryIds.slice();
+		this._availableInstanceIdsSorted = source._availableInstanceIdsSorted;
+		this._availableGeometryIdsSorted = source._availableGeometryIdsSorted;
 
 		this._nextIndexStart = source._nextIndexStart;
 		this._nextVertexStart = source._nextVertexStart;


### PR DESCRIPTION
Related issue: #31465

**Description**

BatchedMesh keeps track of the deleted ids in _availableInstanceIds or _availableGeometryIds, respectively.
For every (!) call of addInstance/addGeometry these arrays are sorted.
This implies if you delete n entities, and add n entities again, you have at least a complexity of n^2 (even ignoring the log n for now).
As a user, I would rather expect a complexity of roughly n log n for this scenario.

To avoid this, two internal flags _availableInstanceIdsSorted and _availableGeometryIdsSorted are introduced, which keep track whether the sorting was already done and thus can be skipped.

For the two test cases described in the issue, this reduced the runtime from roughly 10s for each of them to 10 ms (test1) or 150ms (test2) on my laptop. 
This should reduce the complexity in the scenario described above to n log n (as you'll perform a single sort plus the actual removal and insertion).


