### PR TITLE
ProjectorLightNode: Fix back-projection.

### DIFF
--- a/src/nodes/lighting/ProjectorLightNode.js
+++ b/src/nodes/lighting/ProjectorLightNode.js
@@ -63,12 +63,14 @@ class ProjectorLightNode extends SpotLightNode {
 	 */
 	getSpotAttenuation( builder ) {
 
+		const attenuation = float( 0 ).toVar();
 		const penumbraCos = this.penumbraCosNode;
+
+		// compute the fragment's position in the light's clip space
+
 		const spotLightCoord = lightShadowMatrix( this.light ).mul( builder.context.positionWorld || positionWorld );
 
-		const attenuation = float( 0 ).toVar( 'attenuation' );
-
-		// the sign of w determines whether the current fragment is in front or behind the light
+		// the sign of w determines whether the current fragment is in front or behind the light.
 		// to avoid a back-projection, it's important to only compute an attenuation if w is positive
 
 		If( spotLightCoord.w.greaterThan( 0 ), () => {


### PR DESCRIPTION
Fixed #31461.

**Description**

The PR prevents  back-projection when using `ProjectorLight`. This bug was present in the initial code from #24589 and unfortunately ported to the node system.

The idea is to the check the `w` coordinate of `spotLightCoord` since this variable represents the fragment's position in the light's clip space. The sign of w  determines whether a fragment is in front or behind the light.