### PR TITLE
ProjectorLightNode: Remove obsolete `toVar()`.

### DIFF
--- a/src/nodes/lighting/ProjectorLightNode.js
+++ b/src/nodes/lighting/ProjectorLightNode.js
@@ -63,7 +63,7 @@ class ProjectorLightNode extends SpotLightNode {
 	 */
 	getSpotAttenuation( builder ) {
 
-		const attenuation = float( 0 ).toVar();
+		const attenuation = float( 0 );
 		const penumbraCos = this.penumbraCosNode;
 
 		// compute the fragment's position in the light's clip space


### PR DESCRIPTION
Related issue: #31459

**Description**

Thanks to #31459, the code in `ProjectorLightNode.getSpotAttenuation()` can be simplified.
