### PR TITLE
Texture: add updateRanges documentation

### DIFF
--- a/docs/api/en/textures/Texture.html
+++ b/docs/api/en/textures/Texture.html
@@ -292,6 +292,12 @@
 			transformations.
 		</p>
 
+		<h3>[property:Array updateRanges]</h3>
+		<p>
+			This can be used to only update a subregion or specific rows of the texture (for example, just 
+			the first 3 rows). Use the [page:Texture.addUpdateRange .addUpdateRange] function to add ranges to this array.
+		</p>
+
 		<h2>Methods</h2>
 
 		<p>
@@ -330,6 +336,16 @@
 			Transform the uv based on the value of this texture's [page:Texture.offset .offset], 
 			[page:Texture.repeat .repeat], [page:Texture.wrapS .wrapS],
 			[page:Texture.wrapT .wrapT] and [page:Texture.flipY .flipY] properties.
+		</p>
+
+		<h3>[method:undefined addUpdateRange]( [param:number start], [param:number count] )</h3>
+		<p>
+			Adds a range of data in the data texture to be updated on the GPU.
+		</p>
+
+		<h3>[method:undefined clearUpdateRanges]()</h3>
+		<p>
+			Clears the update ranges.
 		</p>
 
 		<h2>Source</h2>


### PR DESCRIPTION
Related issue: #30184
Related PR: #30998

**Description**

Added documentation for `updateRanges` property and `addUpdateRange`, `clearUpdateRanges` methods.

I've used the same comments used for jsdoc.
