### PR TITLE
EXRLoader: Added lossyDctChannelDecode

### DIFF
--- a/examples/jsm/loaders/EXRLoader.js
+++ b/examples/jsm/loaders/EXRLoader.js
@@ -1709,7 +1709,7 @@ class EXRLoader extends DataTextureLoader {
 
 			}
 
-			// Handle multi-channel RGB sets
+			// Decode lossy DCT data if we have a valid color space conversion set with the first RGB channel present
 			if ( cscSet.idx[ 0 ] !== undefined && channelData[ cscSet.idx[ 0 ] ] ) {
 
 				lossyDctDecode( cscSet, rowOffsets, channelData, acBuffer, dcBuffer, outBuffer );

--- a/examples/jsm/loaders/EXRLoader.js
+++ b/examples/jsm/loaders/EXRLoader.js
@@ -1044,6 +1044,7 @@ class EXRLoader extends DataTextureLoader {
 			for ( let blocky = 0; blocky < numBlocksY; ++ blocky ) {
 
 				let maxY = 8;
+
 				if ( blocky == numBlocksY - 1 ) maxY = leftoverY;
 
 				for ( let blockx = 0; blockx < numBlocksX; ++ blockx ) {
@@ -1065,11 +1066,13 @@ class EXRLoader extends DataTextureLoader {
 					for ( let blockx = 0; blockx < numFullBlocksX; ++ blockx ) {
 
 						const src = blockx * 64 + ( ( y & 0x7 ) * 8 );
+
 						for ( let x = 0; x < 8; ++ x ) {
 
 							dataView.setUint16( offset + x * INT16_SIZE * cd.type, rowBlock[ src + x ], true );
 
 						}
+
 						offset += 8 * INT16_SIZE * cd.type;
 
 					}
@@ -1077,6 +1080,7 @@ class EXRLoader extends DataTextureLoader {
 					if ( numBlocksX != numFullBlocksX ) {
 
 						const src = numFullBlocksX * 64 + ( ( y & 0x7 ) * 8 );
+
 						for ( let x = 0; x < leftoverX; ++ x ) {
 
 							dataView.setUint16( offset + x * INT16_SIZE * cd.type, rowBlock[ src + x ], true );

--- a/examples/jsm/loaders/EXRLoader.js
+++ b/examples/jsm/loaders/EXRLoader.js
@@ -1048,9 +1048,6 @@ class EXRLoader extends DataTextureLoader {
 
 				for ( let blockx = 0; blockx < numBlocksX; ++ blockx ) {
 
-					let maxX = 8;
-					if ( blockx == numBlocksX - 1 ) maxX = leftoverX;
-
 					halfZigBlock.fill( 0 );
 					halfZigBlock[ 0 ] = dcBuffer[ currDcComp ++ ];
 					unRleAC( currAcComp, acBuffer, halfZigBlock );

--- a/examples/jsm/loaders/EXRLoader.js
+++ b/examples/jsm/loaders/EXRLoader.js
@@ -863,7 +863,7 @@ class EXRLoader extends DataTextureLoader {
 
 		function lossyDctDecode( cscSet, rowPtrs, channelData, acBuffer, dcBuffer, outBuffer ) {
 
-			const dataView = new DataView( outBuffer.buffer );
+			let dataView = new DataView( outBuffer.buffer );
 
 			const width = channelData[ cscSet.idx[ 0 ] ].width;
 			const height = channelData[ cscSet.idx[ 0 ] ].height;


### PR DESCRIPTION
Related issue: #31429

**Description**

@sciecode Was curious if [Claude Code](https://www.anthropic.com/claude-code) could implement [your comment](https://github.com/mrdoob/three.js/issues/31429#issuecomment-3094680090). What do you think?

It creates a texture using `THREE.RedFormat` as `texture.format` and loads this:

<img width="565" height="565" alt="Screenshot 2025-07-24 at 08 45 06" src="https://github.com/user-attachments/assets/b4ff5dce-2eb2-4a67-b2d5-33b631461f98" />

With a custom shader that map the other channels it looks as it does in GIMP:

```glsl
float luminance = texture2D( map, vUv ).r;
gl_FragColor = vec4( luminance, luminance, luminance, 1.0 );
```

<img width="564" height="566" alt="Screenshot 2025-07-23 at 19 17 27" src="https://github.com/user-attachments/assets/cb4bf84f-0a51-4091-a20d-346c61892552" />

Should `EXRLoader` return a `RedFormat` texture?
Or should it duplicate the values and alwasys return a `RGBAFormat` texture?

/cc @drone1 @WestLangley 