### PR TITLE
SkeletonHelper: Add `setColors()`

### DIFF
--- a/docs/api/en/helpers/SkeletonHelper.html
+++ b/docs/api/en/helpers/SkeletonHelper.html
@@ -58,6 +58,10 @@
 			Frees the GPU-related resources allocated by this instance. Call this
 			method whenever this instance is no longer used in your app.
 		</p>
+
+		<h3>[method:this setColors]( [param:Color color1], [param:Color color2] )</h3>
+		<p>Defines the colors of the helper.</p>
+
 		<h2>Source</h2>
 
 		<p>

--- a/examples/webgl_animation_walk.html
+++ b/examples/webgl_animation_walk.html
@@ -229,6 +229,7 @@
 					//
 
 					skeleton = new THREE.SkeletonHelper( model );
+					skeleton.setColors( new THREE.Color( 0xe000ff ), new THREE.Color( 0x00e0ff ) );
 					skeleton.visible = false;
 					scene.add( skeleton );
 

--- a/src/helpers/CameraHelper.js
+++ b/src/helpers/CameraHelper.js
@@ -159,6 +159,7 @@ class CameraHelper extends LineSegments {
 	 * @param {Color} up - The up line color.
 	 * @param {Color} target - The target line color.
 	 * @param {Color} cross - The cross line color.
+	 * @return {CameraHelper} A reference to this helper.
 	 */
 	setColors( frustum, cone, up, target, cross ) {
 
@@ -214,6 +215,8 @@ class CameraHelper extends LineSegments {
 		colorAttribute.setXYZ( 48, cross.r, cross.g, cross.b ); colorAttribute.setXYZ( 49, cross.r, cross.g, cross.b ); // cf3, cf4
 
 		colorAttribute.needsUpdate = true;
+
+		return this;
 
 	}
 

--- a/src/helpers/SkeletonHelper.js
+++ b/src/helpers/SkeletonHelper.js
@@ -23,7 +23,7 @@ const _matrixWorldInv = /*@__PURE__*/ new Matrix4();
 class SkeletonHelper extends LineSegments {
 
 	/**
-	 * Constructs a new hemisphere light helper.
+	 * Constructs a new skeleton helper.
 	 *
 	 * @param {Object3D} object -  Usually an instance of {@link SkinnedMesh}. However, any 3D object
 	 * can be used if it represents a hierarchy of bones (see {@link Bone}).
@@ -37,9 +37,6 @@ class SkeletonHelper extends LineSegments {
 		const vertices = [];
 		const colors = [];
 
-		const color1 = new Color( 0, 0, 1 );
-		const color2 = new Color( 0, 1, 0 );
-
 		for ( let i = 0; i < bones.length; i ++ ) {
 
 			const bone = bones[ i ];
@@ -48,8 +45,8 @@ class SkeletonHelper extends LineSegments {
 
 				vertices.push( 0, 0, 0 );
 				vertices.push( 0, 0, 0 );
-				colors.push( color1.r, color1.g, color1.b );
-				colors.push( color2.r, color2.g, color2.b );
+				colors.push( 0, 0, 0 );
+				colors.push( 0, 0, 0 );
 
 			}
 
@@ -90,6 +87,13 @@ class SkeletonHelper extends LineSegments {
 		this.matrix = object.matrixWorld;
 		this.matrixAutoUpdate = false;
 
+		// colors
+
+		const color1 = new Color( 0x0000ff );
+		const color2 = new Color( 0x00ff00 );
+
+		this.setColors( color1, color2 );
+
 	}
 
 	updateMatrixWorld( force ) {
@@ -124,6 +128,31 @@ class SkeletonHelper extends LineSegments {
 		geometry.getAttribute( 'position' ).needsUpdate = true;
 
 		super.updateMatrixWorld( force );
+
+	}
+
+	/**
+	 * Defines the colors of the helper.
+	 *
+	 * @param {Color} color1 - The first line color for each bone.
+	 * @param {Color} color2 - The second line color for each bone.
+	 * @return {SkeletonHelper} A reference to this helper.
+	 */
+	setColors( color1, color2 ) {
+
+		const geometry = this.geometry;
+		const colorAttribute = geometry.getAttribute( 'color' );
+
+		for ( let i = 0; i < colorAttribute.count; i += 2 ) {
+
+			colorAttribute.setXYZ( i, color1.r, color1.g, color1.b );
+			colorAttribute.setXYZ( i + 1, color2.r, color2.g, color2.b );
+
+		}
+
+		colorAttribute.needsUpdate = true;
+
+		return this;
 
 	}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/23829#issuecomment-1087263257

**Description**

`SkeletonHelper` always defaults to green and blue line colors for each bone. These colors might be hard to see on some meshes, so it would be nice to have the option of setting custom colors.

I added a `setColors( color1, color2 )` method for this purpose, modeled on the existing `setColors` methods of `CameraHelper` and `AxesHelper`.

<img width="402" src="https://github.com/user-attachments/assets/7b5563c0-1b72-4735-a26b-75933eb3df03" />

