### PR TITLE
TSL: Add `debug()` for the stack when running outside the code flow

### DIFF
--- a/src/nodes/utils/DebugNode.js
+++ b/src/nodes/utils/DebugNode.js
@@ -77,6 +77,6 @@ export default DebugNode;
  * @param {?Function} [callback=null] - Optional callback function to handle the debug output.
  * @returns {DebugNode}
  */
-export const debug = ( node, callback = null ) => nodeObject( new DebugNode( nodeObject( node ), callback ) );
+export const debug = ( node, callback = null ) => nodeObject( new DebugNode( nodeObject( node ), callback ) ).toStack();
 
 addMethodChaining( 'debug', debug );


### PR DESCRIPTION
Closes https://github.com/mrdoob/three.js/issues/31472

**Description**

Add `debug()` for the stack when running outside the code flow.

```js
Fn( ()=>{
// ...

	const animateUV = uv().add( timerScaleNode ).toVar()
	animateUV.debug() // add to stack, outside the normal code flow

	return animateUV.debug(); // return the value, inside the normal code flow

// ...
} )
```