### PR TITLE
Examples: Simplify UnpackDepthRGBAShader

### DIFF
--- a/examples/jsm/shaders/UnpackDepthRGBAShader.js
+++ b/examples/jsm/shaders/UnpackDepthRGBAShader.js
@@ -47,17 +47,13 @@ const UnpackDepthRGBAShader = {
 
 			#ifdef USE_REVERSEDEPTHBUF
 
-				if ( depth == 1.0 ) depth = 0.0; // wrong clear value?
+				gl_FragColor = vec4( vec3( depth ), opacity );
 
-				// [0, 1] -> [-1, 1]
-				depth = depth * 2.0 - 1.0;
+			#else
 
-				// Reverse to forward depth (precision is already destroyed at this point)
-				depth = 1.0 - depth;
+				gl_FragColor = vec4( vec3( 1.0 - depth ), opacity );
 
 			#endif
-
-			gl_FragColor = vec4( vec3( 1.0 - depth ), opacity );
 
 		}`
 


### PR DESCRIPTION
This PR simplifies `UnpackDepthRGBAShader`.

The previous transforms to `depth` when using a reversed depth buffer are no longer necessary.