### PR TITLE
MeshDepthMaterial: Support Reversed Depth

### DIFF
--- a/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl.js
@@ -79,7 +79,6 @@ export default /* glsl */`
 
 		#ifdef USE_REVERSEDEPTHBUF
 
-			if ( depth == 1.0 ) depth = 0.0; // wrong clear value?
 			return step( depth, compare );
 
 		#else

--- a/src/renderers/shaders/ShaderLib/depth.glsl.js
+++ b/src/renderers/shaders/ShaderLib/depth.glsl.js
@@ -80,8 +80,17 @@ void main() {
 
 	#include <logdepthbuf_fragment>
 
-	// Higher precision equivalent of gl_FragCoord.z. This assumes depthRange has been left to its default values.
-	float fragCoordZ = 0.5 * vHighPrecisionZW[0] / vHighPrecisionZW[1] + 0.5;
+	// Higher precision equivalent of gl_FragCoord.z
+
+	#ifdef USE_REVERSEDEPTHBUF
+
+		float fragCoordZ = vHighPrecisionZW[ 0 ] / vHighPrecisionZW[ 1 ];
+
+	#else
+
+		float fragCoordZ = 0.5 * vHighPrecisionZW[ 0 ] / vHighPrecisionZW[ 1 ] + 0.5;
+
+	#endif
 
 	#if DEPTH_PACKING == 3200
 


### PR DESCRIPTION
The higher precision equivalent of `gl_FragCoord.z` assumes that the depth range is [ - 1, 1 ].

In the case of reversed depth, the depth range is [ 0, 1 ].
