### PR TITLE
OutlinePass: Exclude Line2 objects from outline computation.

### DIFF
--- a/examples/jsm/postprocessing/OutlinePass.js
+++ b/examples/jsm/postprocessing/OutlinePass.js
@@ -494,7 +494,23 @@ class OutlinePass extends Pass {
 
 		function VisibilityChangeCallBack( object ) {
 
-			if ( object.isMesh || object.isSprite ) {
+			if ( object.isPoints || object.isLine || object.isLine2 ) {
+
+				// the visibility of points and lines is always set to false in order to
+				// not affect the outline computation
+
+				if ( bVisible === true ) {
+
+					object.visible = visibilityCache.get( object ); // restore
+
+				} else {
+
+					visibilityCache.set( object, object.visible );
+					object.visible = bVisible;
+
+				}
+
+			} else if ( object.isMesh || object.isSprite) {
 
 				// only meshes and sprites are supported by OutlinePass
 
@@ -509,22 +525,6 @@ class OutlinePass extends Pass {
 					}
 
 					visibilityCache.set( object, visibility );
-
-				}
-
-			} else if ( object.isPoints || object.isLine ) {
-
-				// the visibility of points and lines is always set to false in order to
-				// not affect the outline computation
-
-				if ( bVisible === true ) {
-
-					object.visible = visibilityCache.get( object ); // restore
-
-				} else {
-
-					visibilityCache.set( object, object.visible );
-					object.visible = bVisible;
 
 				}
 


### PR DESCRIPTION


**Description**

This PR fixes an issue where an outlined square appears at the world center when selecting Line2 objects with OutlinePass

**Cause**

The OutlinePass's _changeVisibilityOfNonSelectedObjects() method was not excluding Line2 objects from outline computation. 

**Solution**

-  Added || object.isLine2 condition  in OutlinePass._changeVisibilityOfNonSelectedObjects() 
- Change the order to ensure Line2 objects are excluded from outline computation

**Changes in `OutlinePass.js`**

- Modified _changeVisibilityOfNonSelectedObjects() method  
- Added || object.isLine2 condition 
- Process meshes and sprites after points and lines in this method

