### PR TITLE
StorageTexture: Add width and height getters

### DIFF
--- a/src/renderers/common/StorageTexture.js
+++ b/src/renderers/common/StorageTexture.js
@@ -13,6 +13,24 @@ import { LinearFilter } from '../../constants.js';
 class StorageTexture extends Texture {
 
 	/**
+	 * The width of the storage texture.
+	 */
+	get width() {
+
+		return this.image.width;
+
+	}
+
+	/**
+	 * The height of the storage texture.
+	 */
+	get height() {
+
+		return this.image.height;
+
+	}
+
+	/**
 	 * Constructs a new storage texture.
 	 *
 	 * @param {number} [width=1] - The storage texture's width.


### PR DESCRIPTION
Related issue: --

**Description**

Adds "width" and "height" convenience getters for Storage texture to map `Texture` and `RenderTarget`.