### PR TITLE
TSL: Introduce `boolean` for `uniform()`

### DIFF
--- a/src/nodes/core/UniformNode.js
+++ b/src/nodes/core/UniformNode.js
@@ -140,6 +140,20 @@ class UniformNode extends InputNode {
 
 	}
 
+	getInputType( builder ) {
+
+		let type = super.getInputType( builder );
+
+		if ( type === 'bool' ) {
+
+			type = 'uint';
+
+		}
+
+		return type;
+
+	}
+
 	generate( builder, output ) {
 
 		const type = this.getNodeType( builder );
@@ -159,11 +173,40 @@ class UniformNode extends InputNode {
 		const sharedNodeType = sharedNode.getInputType( builder );
 
 		const nodeUniform = builder.getUniformFromNode( sharedNode, sharedNodeType, builder.shaderStage, this.name || builder.context.label );
-		const propertyName = builder.getPropertyName( nodeUniform );
+		const uniformName = builder.getPropertyName( nodeUniform );
 
 		if ( builder.context.label !== undefined ) delete builder.context.label;
 
-		return builder.format( propertyName, type, output );
+		//
+
+		let snippet = uniformName;
+
+		if ( type === 'bool' ) {
+
+			// cache to variable
+
+			const nodeData = builder.getDataFromNode( this );
+
+			let propertyName = nodeData.propertyName;
+
+			if ( propertyName === undefined ) {
+
+				const nodeVar = builder.getVarFromNode( this, null, 'bool' );
+				propertyName = builder.getPropertyName( nodeVar );
+
+				nodeData.propertyName = propertyName;
+
+				snippet = builder.format( uniformName, sharedNodeType, output );
+
+				builder.addLineFlowCode( `${ propertyName } = ${ snippet }`, this );
+
+			}
+
+			snippet = propertyName;
+
+		}
+
+		return builder.format( snippet, type, output );
 
 	}
 

--- a/src/nodes/core/UniformNode.js
+++ b/src/nodes/core/UniformNode.js
@@ -196,7 +196,7 @@ class UniformNode extends InputNode {
 
 				nodeData.propertyName = propertyName;
 
-				snippet = builder.format( uniformName, sharedNodeType, output );
+				snippet = builder.format( uniformName, sharedNodeType, type );
 
 				builder.addLineFlowCode( `${ propertyName } = ${ snippet }`, this );
 


### PR DESCRIPTION
Fixes https://github.com/mrdoob/three.js/issues/31479

**Description**

If a boolean uniform is declared, TSL will convert the uniform input to a `uint` and create a `bool` variable as a cache, which will be used as a reference for the uniform node throughout the rest of the code. This works around the non-host-shareable limitation. 