### PR TITLE
TSL Transpiler: Fix operator precedence of `GLSLDecoder`

### DIFF
--- a/examples/jsm/transpiler/GLSLDecoder.js
+++ b/examples/jsm/transpiler/GLSLDecoder.js
@@ -11,7 +11,7 @@ const arithmeticOperators = [
 ];
 
 const precedenceOperators = [
-	'*', '/', '%',
+	'/', '*', '%',
 	'-', '+',
 	'<<', '>>',
 	'<', '>', '<=', '>=',


### PR DESCRIPTION
Fixes https://github.com/mrdoob/three.js/issues/31513

**Description**

Fix operator precedence level of `/` and `*` :

Input expression to TSL transpiler:

```glsl
float r = a / b * ( c / d );
```

```js
const r = a.div( b ).mul( c.div( d ) );
// old: = a.div( b.mul( c.div( d ) ) );
```

```wgsl
let r: f32 = ( a / b ) * ( c / d );
// old:    = a / ( b * ( c / d ) );
```