### PR TITLE
Examples: Rename import from `three` to `three/webgpu` of webgpu

### DIFF
--- a/examples/misc_raycaster_helper.html
+++ b/examples/misc_raycaster_helper.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { RaycasterHelper } from 'https://cdn.jsdelivr.net/npm/@gsimone/three-raycaster-helper@0.1.0/dist/gsimone-three-raycaster-helper.esm.js';
 
 			let scene, renderer;

--- a/examples/physics_jolt_instancing.html
+++ b/examples/physics_jolt_instancing.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { JoltPhysics } from 'three/addons/physics/JoltPhysics.js';
 			import Stats from 'three/addons/libs/stats.module.js';

--- a/examples/webgpu_animation_retargeting.html
+++ b/examples/webgpu_animation_retargeting.html
@@ -24,7 +24,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { color, screenUV, hue, reflector, time, Fn, vec2, length, atan, float, sin, cos, vec3, sub, mul, pow, blendDodge, normalWorldGeometry } from 'three/tsl';
 
 			import Stats from 'three/addons/libs/stats.module.js';

--- a/examples/webgpu_animation_retargeting_readyplayer.html
+++ b/examples/webgpu_animation_retargeting_readyplayer.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { screenUV, color, vec2, vec4, reflector, positionWorld } from 'three/tsl';
 
 			import Stats from 'three/addons/libs/stats.module.js';

--- a/examples/webgpu_backdrop.html
+++ b/examples/webgpu_backdrop.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { float, vec3, color, viewportSharedTexture, hue, blendOverlay, posterize, grayscale, saturation, viewportSafeUV, screenUV, checker, uv, time, oscSine, output } from 'three/tsl';
 
 			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';

--- a/examples/webgpu_backdrop_area.html
+++ b/examples/webgpu_backdrop_area.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { color, positionWorld, linearDepth, viewportLinearDepth, viewportSharedTexture, screenUV, hue, time, checker, uv, modelScale } from 'three/tsl';
 			import { hashBlur } from 'three/addons/tsl/display/hashBlur.js';
 

--- a/examples/webgpu_backdrop_water.html
+++ b/examples/webgpu_backdrop_water.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { color, vec2, pass, linearDepth, normalWorld, triplanarTexture, texture, objectPosition, screenUV, viewportLinearDepth, viewportDepthTexture, viewportSharedTexture, mx_worley_noise_float, positionWorld, time } from 'three/tsl';
 			import { gaussianBlur } from 'three/addons/tsl/display/GaussianBlurNode.js';
 

--- a/examples/webgpu_camera.html
+++ b/examples/webgpu_camera.html
@@ -29,7 +29,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { color } from 'three/tsl';
 
 			let SCREEN_WIDTH = window.innerWidth;

--- a/examples/webgpu_camera_array.html
+++ b/examples/webgpu_camera_array.html
@@ -21,7 +21,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import Stats from 'three/addons/libs/stats.module.js';
 

--- a/examples/webgpu_camera_logarithmicdepthbuffer.html
+++ b/examples/webgpu_camera_logarithmicdepthbuffer.html
@@ -75,7 +75,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import { FontLoader } from 'three/addons/loaders/FontLoader.js';
 			import { TextGeometry } from 'three/addons/geometries/TextGeometry.js';

--- a/examples/webgpu_caustics.html
+++ b/examples/webgpu_caustics.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import { uniform, refract, div, positionViewDirection, positionLocal, normalView, texture, Fn, vec2, vec3, vec4 } from 'three/tsl';
 

--- a/examples/webgpu_centroid_sampling.html
+++ b/examples/webgpu_centroid_sampling.html
@@ -57,7 +57,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { varying, uv, texture, Fn } from 'three/tsl';
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';

--- a/examples/webgpu_clearcoat.html
+++ b/examples/webgpu_clearcoat.html
@@ -24,7 +24,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import Stats from 'three/addons/libs/stats.module.js';
 

--- a/examples/webgpu_clipping.html
+++ b/examples/webgpu_clipping.html
@@ -23,7 +23,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import Stats from 'three/addons/libs/stats.module.js';
 

--- a/examples/webgpu_compute_audio.html
+++ b/examples/webgpu_compute_audio.html
@@ -29,7 +29,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { Fn, uniform, instanceIndex, instancedArray, float, texture, screenUV, color } from 'three/tsl';
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';

--- a/examples/webgpu_compute_birds.html
+++ b/examples/webgpu_compute_birds.html
@@ -36,7 +36,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { uniform, varying, vec4, add, sub, max, dot, sin, mat3, uint, negate, instancedArray, cameraProjectionMatrix, cameraViewMatrix, positionLocal, modelWorldMatrix, sqrt, attribute, property, float, Fn, If, cos, Loop, Continue, normalize, instanceIndex, length } from 'three/tsl';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';

--- a/examples/webgpu_compute_cloth.html
+++ b/examples/webgpu_compute_cloth.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import { Fn, If, Return, instancedArray, instanceIndex, uniform, select, attribute, uint, Loop, float, transformNormalToView, cross, triNoise3D, time } from 'three/tsl';
 

--- a/examples/webgpu_compute_geometry.html
+++ b/examples/webgpu_compute_geometry.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { vec4, storage, Fn, If, uniform, instanceIndex, objectWorldMatrix, color, screenUV, attribute } from 'three/tsl';
 
 			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';

--- a/examples/webgpu_compute_particles.html
+++ b/examples/webgpu_compute_particles.html
@@ -37,7 +37,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { Fn, If, uniform, float, uv, vec2, vec3, hash, shapeCircle,
 				instancedArray, instanceIndex } from 'three/tsl';
 

--- a/examples/webgpu_compute_particles_fluid.html
+++ b/examples/webgpu_compute_particles_fluid.html
@@ -26,7 +26,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import { Fn, If, Return, instancedArray, instanceIndex, uniform, attribute, uint, float, clamp, struct, atomicStore, int, ivec3, array, vec3, atomicAdd, Loop, atomicLoad, max, pow, mat3, vec4, cross, step } from 'three/tsl';
 

--- a/examples/webgpu_compute_particles_rain.html
+++ b/examples/webgpu_compute_particles_rain.html
@@ -24,7 +24,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { Fn, texture, uv, uint, instancedArray, positionWorld, billboarding, time, hash, deltaTime, vec2, instanceIndex, positionGeometry, If } from 'three/tsl';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';

--- a/examples/webgpu_compute_particles_snow.html
+++ b/examples/webgpu_compute_particles_snow.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { Fn, texture, vec3, pass, color, uint, screenUV, instancedArray, positionWorld, positionLocal, time, vec2, hash, instanceIndex, If } from 'three/tsl';
 			import { gaussianBlur } from 'three/addons/tsl/display/GaussianBlurNode.js';
 

--- a/examples/webgpu_compute_points.html
+++ b/examples/webgpu_compute_points.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import Stats from 'stats-gl';
 

--- a/examples/webgpu_compute_sort_bitonic.html
+++ b/examples/webgpu_compute_sort_bitonic.html
@@ -54,7 +54,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { storage, If, vec3, not, uniform, uv, uint, float, Fn, vec2, abs, int, invocationLocalIndex, workgroupArray, uvec2, floor, instanceIndex, workgroupBarrier, atomicAdd, atomicStore, workgroupId } from 'three/tsl';
 
 			import WebGPU from 'three/addons/capabilities/WebGPU.js';

--- a/examples/webgpu_compute_texture.html
+++ b/examples/webgpu_compute_texture.html
@@ -24,7 +24,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { texture, textureStore, Fn, instanceIndex, float, uvec2, vec4 } from 'three/tsl';
 
 			import WebGPU from 'three/addons/capabilities/WebGPU.js';

--- a/examples/webgpu_compute_texture_3d.html
+++ b/examples/webgpu_compute_texture_3d.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { time, mx_noise_vec3, instanceIndex, textureStore, float, vec3, vec4, If, Break, Fn, smoothstep, texture3D, uniform } from 'three/tsl';
 
 			import { RaymarchingBox } from 'three/addons/tsl/utils/Raymarching.js';

--- a/examples/webgpu_compute_texture_pingpong.html
+++ b/examples/webgpu_compute_texture_pingpong.html
@@ -24,7 +24,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { storageTexture, wgslFn, code, instanceIndex, uniform, NodeAccess } from 'three/tsl';
 
 			import WebGPU from 'three/addons/capabilities/WebGPU.js';

--- a/examples/webgpu_compute_water.html
+++ b/examples/webgpu_compute_water.html
@@ -26,7 +26,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { instanceIndex, struct, If, uint, int, floor, float, length, clamp, vec2, cos, vec3, vertexIndex, Fn, uniform, instancedArray, min, max, positionLocal, transformNormalToView } from 'three/tsl';
 
 			import { SimplexNoise } from 'three/addons/math/SimplexNoise.js';

--- a/examples/webgpu_cubemap_adjustments.html
+++ b/examples/webgpu_cubemap_adjustments.html
@@ -27,7 +27,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { uniform, mix, pmremTexture, reference, positionLocal, hue, saturation, positionWorld, normalWorld, positionWorldDirection, reflectVector } from 'three/tsl';
 
 			import { RGBMLoader } from 'three/addons/loaders/RGBMLoader.js';

--- a/examples/webgpu_cubemap_dynamic.html
+++ b/examples/webgpu_cubemap_dynamic.html
@@ -28,7 +28,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { RGBMLoader } from 'three/addons/loaders/RGBMLoader.js';

--- a/examples/webgpu_cubemap_mix.html
+++ b/examples/webgpu_cubemap_mix.html
@@ -27,7 +27,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { mix, oscSine, time, pmremTexture, float } from 'three/tsl';
 
 			import { RGBMLoader } from 'three/addons/loaders/RGBMLoader.js';

--- a/examples/webgpu_custom_fog.html
+++ b/examples/webgpu_custom_fog.html
@@ -24,7 +24,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { color, fog, float, positionWorld, triNoise3D, positionView, normalWorld, uniform } from 'three/tsl';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';

--- a/examples/webgpu_custom_fog_background.html
+++ b/examples/webgpu_custom_fog_background.html
@@ -35,7 +35,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { pass, color, rangeFogFactor } from 'three/tsl';
 
 			import { RGBELoader } from 'three/addons/loaders/RGBELoader.js';

--- a/examples/webgpu_depth_texture.html
+++ b/examples/webgpu_depth_texture.html
@@ -24,7 +24,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { texture } from 'three/tsl';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';

--- a/examples/webgpu_display_stereo.html
+++ b/examples/webgpu_display_stereo.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import { stereoPass } from 'three/addons/tsl/display/StereoPassNode.js';
 			import { anaglyphPass } from 'three/addons/tsl/display/AnaglyphPassNode.js';

--- a/examples/webgpu_equirectangular.html
+++ b/examples/webgpu_equirectangular.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { texture, equirectUV } from 'three/tsl';
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';

--- a/examples/webgpu_instance_mesh.html
+++ b/examples/webgpu_instance_mesh.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { mix, range, normalWorld, oscSine, time } from 'three/tsl';
 
 			import Stats from 'three/addons/libs/stats.module.js';

--- a/examples/webgpu_instance_path.html
+++ b/examples/webgpu_instance_path.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { RoomEnvironment } from 'three/addons/environments/RoomEnvironment.js';

--- a/examples/webgpu_instance_points.html
+++ b/examples/webgpu_instance_points.html
@@ -26,7 +26,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { color, storage, Fn, instancedBufferAttribute, instanceIndex, sin, time, float, uniform, shapeCircle, mix, vec3 } from 'three/tsl';
 
 			import Stats from 'three/addons/libs/stats.module.js';

--- a/examples/webgpu_instance_sprites.html
+++ b/examples/webgpu_instance_sprites.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import Stats from 'three/addons/libs/stats.module.js';
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';

--- a/examples/webgpu_instance_uniform.html
+++ b/examples/webgpu_instance_uniform.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { nodeObject, uniform, cubeTexture } from 'three/tsl';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';

--- a/examples/webgpu_instancing_morph.html
+++ b/examples/webgpu_instancing_morph.html
@@ -20,7 +20,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 

--- a/examples/webgpu_layers.html
+++ b/examples/webgpu_layers.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 

--- a/examples/webgpu_lensflares.html
+++ b/examples/webgpu_lensflares.html
@@ -27,7 +27,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import Stats from 'three/addons/libs/stats.module.js';
 

--- a/examples/webgpu_lightprobe.html
+++ b/examples/webgpu_lightprobe.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 

--- a/examples/webgpu_lightprobe_cubecamera.html
+++ b/examples/webgpu_lightprobe_cubecamera.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { LightProbeHelper } from 'three/addons/helpers/LightProbeHelperGPU.js';

--- a/examples/webgpu_lights_custom.html
+++ b/examples/webgpu_lights_custom.html
@@ -24,7 +24,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { color, lights } from 'three/tsl';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';

--- a/examples/webgpu_lights_ies_spotlight.html
+++ b/examples/webgpu_lights_ies_spotlight.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import { OrbitControls } from './jsm/controls/OrbitControls.js';
 

--- a/examples/webgpu_lights_phong.html
+++ b/examples/webgpu_lights_phong.html
@@ -26,7 +26,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { color, fog, rangeFogFactor, checker, uv, mix, texture, lights, normalMap } from 'three/tsl';
 
 			import Stats from 'three/addons/libs/stats.module.js';

--- a/examples/webgpu_lights_physical.html
+++ b/examples/webgpu_lights_physical.html
@@ -27,7 +27,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import Stats from 'three/addons/libs/stats.module.js';
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';

--- a/examples/webgpu_lights_pointlights.html
+++ b/examples/webgpu_lights_pointlights.html
@@ -27,7 +27,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import { OBJLoader } from 'three/addons/loaders/OBJLoader.js';
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';

--- a/examples/webgpu_lights_projector.html
+++ b/examples/webgpu_lights_projector.html
@@ -30,7 +30,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { Fn, color, mx_worley_noise_float, time } from 'three/tsl';
 
 			import Stats from 'three/addons/libs/stats.module.js';

--- a/examples/webgpu_lights_rectarealight.html
+++ b/examples/webgpu_lights_rectarealight.html
@@ -26,7 +26,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import Stats from 'three/addons/libs/stats.module.js';
 

--- a/examples/webgpu_lights_selective.html
+++ b/examples/webgpu_lights_selective.html
@@ -26,7 +26,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { fog, rangeFogFactor, color, lights, texture, normalMap } from 'three/tsl';
 
 			import Stats from 'three/addons/libs/stats.module.js';

--- a/examples/webgpu_lights_spotlight.html
+++ b/examples/webgpu_lights_spotlight.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 

--- a/examples/webgpu_lights_tiled.html
+++ b/examples/webgpu_lights_tiled.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { texture, uv, pass, normalMap, uniform } from 'three/tsl';
 			import { bloom } from 'three/addons/tsl/display/BloomNode.js';
 

--- a/examples/webgpu_lines_fat.html
+++ b/examples/webgpu_lines_fat.html
@@ -26,7 +26,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { color } from 'three/tsl';
 
 			import Stats from 'three/addons/libs/stats.module.js';

--- a/examples/webgpu_lines_fat_raycasting.html
+++ b/examples/webgpu_lines_fat_raycasting.html
@@ -26,7 +26,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import Stats from 'stats-gl';
 

--- a/examples/webgpu_lines_fat_wireframe.html
+++ b/examples/webgpu_lines_fat_wireframe.html
@@ -26,7 +26,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { color } from 'three/tsl';
 
 			import Stats from 'three/addons/libs/stats.module.js';

--- a/examples/webgpu_loader_gltf.html
+++ b/examples/webgpu_loader_gltf.html
@@ -28,7 +28,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import { RGBELoader } from 'three/addons/loaders/RGBELoader.js';
 

--- a/examples/webgpu_loader_gltf_anisotropy.html
+++ b/examples/webgpu_loader_gltf_anisotropy.html
@@ -27,7 +27,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';

--- a/examples/webgpu_loader_gltf_compressed.html
+++ b/examples/webgpu_loader_gltf_compressed.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 			import { KTX2Loader } from 'three/addons/loaders/KTX2Loader.js';

--- a/examples/webgpu_loader_gltf_dispersion.html
+++ b/examples/webgpu_loader_gltf_dispersion.html
@@ -26,7 +26,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';

--- a/examples/webgpu_loader_gltf_iridescence.html
+++ b/examples/webgpu_loader_gltf_iridescence.html
@@ -27,7 +27,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';

--- a/examples/webgpu_loader_gltf_sheen.html
+++ b/examples/webgpu_loader_gltf_sheen.html
@@ -31,7 +31,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';

--- a/examples/webgpu_loader_gltf_transmission.html
+++ b/examples/webgpu_loader_gltf_transmission.html
@@ -27,7 +27,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';

--- a/examples/webgpu_loader_materialx.html
+++ b/examples/webgpu_loader_materialx.html
@@ -30,7 +30,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import { OrbitControls } from './jsm/controls/OrbitControls.js';
 

--- a/examples/webgpu_materials.html
+++ b/examples/webgpu_materials.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import * as TSL from 'three/tsl';
 
 			import { Fn, wgslFn, positionLocal, scriptable, positionWorld, normalLocal, normalWorld, normalView, color, texture, uv, float, vec2, vec3, vec4, oscSine, triplanarTexture, screenUV, js, string, Loop, cameraProjectionMatrix, ScriptableNodeResources } from 'three/tsl';

--- a/examples/webgpu_materials_alphahash.html
+++ b/examples/webgpu_materials_alphahash.html
@@ -20,7 +20,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import Stats from 'three/addons/libs/stats.module.js';
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';

--- a/examples/webgpu_materials_arrays.html
+++ b/examples/webgpu_materials_arrays.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';

--- a/examples/webgpu_materials_basic.html
+++ b/examples/webgpu_materials_basic.html
@@ -20,7 +20,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 

--- a/examples/webgpu_materials_displacementmap.html
+++ b/examples/webgpu_materials_displacementmap.html
@@ -27,7 +27,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import Stats from 'three/addons/libs/stats.module.js';
 

--- a/examples/webgpu_materials_envmaps.html
+++ b/examples/webgpu_materials_envmaps.html
@@ -27,7 +27,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';

--- a/examples/webgpu_materials_envmaps_bpcem.html
+++ b/examples/webgpu_materials_envmaps_bpcem.html
@@ -26,7 +26,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { bumpMap, float, getParallaxCorrectNormal, pmremTexture, reflectVector, texture, uniform, vec3 } from 'three/tsl';
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';

--- a/examples/webgpu_materials_lightmap.html
+++ b/examples/webgpu_materials_lightmap.html
@@ -21,7 +21,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { vec4, color, positionLocal, mix } from 'three/tsl';
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';

--- a/examples/webgpu_materials_matcap.html
+++ b/examples/webgpu_materials_matcap.html
@@ -26,7 +26,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';

--- a/examples/webgpu_materials_toon.html
+++ b/examples/webgpu_materials_toon.html
@@ -24,7 +24,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { toonOutlinePass } from 'three/tsl';
 
 			import Stats from 'three/addons/libs/stats.module.js';

--- a/examples/webgpu_materials_transmission.html
+++ b/examples/webgpu_materials_transmission.html
@@ -24,7 +24,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';

--- a/examples/webgpu_materials_video.html
+++ b/examples/webgpu_materials_video.html
@@ -36,7 +36,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			let container;
 

--- a/examples/webgpu_materialx_noise.html
+++ b/examples/webgpu_materialx_noise.html
@@ -24,7 +24,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { normalWorld, time, mx_noise_vec3, mx_worley_noise_vec3, mx_cell_noise_float, mx_fractal_noise_vec3 } from 'three/tsl';
 
 			import Stats from 'three/addons/libs/stats.module.js';

--- a/examples/webgpu_mesh_batch.html
+++ b/examples/webgpu_mesh_batch.html
@@ -30,7 +30,7 @@
 
 	<script type="module">
 
-		import * as THREE from 'three';
+		import * as THREE from 'three/webgpu';
 
 		import Stats from 'three/addons/libs/stats.module.js';
 

--- a/examples/webgpu_mirror.html
+++ b/examples/webgpu_mirror.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { reflector, uv, texture, color } from 'three/tsl';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';

--- a/examples/webgpu_modifier_curve.html
+++ b/examples/webgpu_modifier_curve.html
@@ -26,7 +26,7 @@
 		</script>
 
 		<script type="module">
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { TransformControls } from 'three/addons/controls/TransformControls.js';
 			import Stats from 'three/addons/libs/stats.module.js';
 			import { Flow } from 'three/addons/modifiers/CurveModifierGPU.js';

--- a/examples/webgpu_morphtargets.html
+++ b/examples/webgpu_morphtargets.html
@@ -27,7 +27,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 

--- a/examples/webgpu_morphtargets_face.html
+++ b/examples/webgpu_morphtargets_face.html
@@ -31,7 +31,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import Stats from 'three/addons/libs/stats.module.js';
 

--- a/examples/webgpu_mrt.html
+++ b/examples/webgpu_mrt.html
@@ -26,7 +26,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { output, normalView, pass, step, diffuseColor, emissive, directionToColor, screenUV, mix, mrt, Fn } from 'three/tsl';
 
 			import { RGBELoader } from 'three/addons/loaders/RGBELoader.js';

--- a/examples/webgpu_mrt_mask.html
+++ b/examples/webgpu_mrt_mask.html
@@ -26,7 +26,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { color, screenUV, mrt, output, pass, vec4 } from 'three/tsl';
 			import { gaussianBlur } from 'three/addons/tsl/display/GaussianBlurNode.js';
 

--- a/examples/webgpu_multiple_rendertargets.html
+++ b/examples/webgpu_multiple_rendertargets.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { mix, vec2, step, texture, uv, screenUV, normalWorld, output, mrt } from 'three/tsl';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';

--- a/examples/webgpu_multiple_rendertargets_readback.html
+++ b/examples/webgpu_multiple_rendertargets_readback.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { mix, step, texture, screenUV, mrt, output, normalWorld, uv, vec2 } from 'three/tsl';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';

--- a/examples/webgpu_multisampled_renderbuffers.html
+++ b/examples/webgpu_multisampled_renderbuffers.html
@@ -24,7 +24,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { texture } from 'three/tsl';
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';

--- a/examples/webgpu_occlusion.html
+++ b/examples/webgpu_occlusion.html
@@ -26,7 +26,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { nodeObject, uniform } from 'three/tsl';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';

--- a/examples/webgpu_ocean.html
+++ b/examples/webgpu_ocean.html
@@ -26,7 +26,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import Stats from 'three/addons/libs/stats.module.js';
 

--- a/examples/webgpu_parallax_uv.html
+++ b/examples/webgpu_parallax_uv.html
@@ -27,7 +27,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { texture, parallaxUV, blendOverlay, uv } from 'three/tsl';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';

--- a/examples/webgpu_particles.html
+++ b/examples/webgpu_particles.html
@@ -24,7 +24,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { range, texture, mix, uv, color, rotateUV, positionLocal, time, uniform } from 'three/tsl';
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';

--- a/examples/webgpu_performance.html
+++ b/examples/webgpu_performance.html
@@ -29,7 +29,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import Stats from 'stats-gl';
 

--- a/examples/webgpu_performance_renderbundle.html
+++ b/examples/webgpu_performance_renderbundle.html
@@ -39,7 +39,7 @@
 
 	<script type="module">
 
-		import * as THREE from 'three';
+		import * as THREE from 'three/webgpu';
 
 		import Stats from 'stats-gl';
 

--- a/examples/webgpu_pmrem_cubemap.html
+++ b/examples/webgpu_pmrem_cubemap.html
@@ -21,7 +21,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { normalWorldGeometry, uniform, normalView, positionViewDirection, cameraViewMatrix, pmremTexture } from 'three/tsl';
 
 			import { RGBMLoader } from 'three/addons/loaders/RGBMLoader.js';

--- a/examples/webgpu_pmrem_equirectangular.html
+++ b/examples/webgpu_pmrem_equirectangular.html
@@ -21,7 +21,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { normalWorldGeometry, uniform, normalView, positionViewDirection, cameraViewMatrix, pmremTexture } from 'three/tsl';
 
 			import { RGBELoader } from 'three/addons/loaders/RGBELoader.js';

--- a/examples/webgpu_pmrem_scene.html
+++ b/examples/webgpu_pmrem_scene.html
@@ -21,7 +21,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { normalWorld, uniform, pmremTexture } from 'three/tsl';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';

--- a/examples/webgpu_portal.html
+++ b/examples/webgpu_portal.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { pass, color, mx_worley_noise_float, time, screenUV, vec2, uv, normalWorld, mx_fractal_noise_vec3 } from 'three/tsl';
 
 			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';

--- a/examples/webgpu_postprocessing.html
+++ b/examples/webgpu_postprocessing.html
@@ -20,7 +20,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { pass } from 'three/tsl';
 			import { dotScreen } from 'three/addons/tsl/display/DotScreenNode.js';
 			import { rgbShift } from 'three/addons/tsl/display/RGBShiftNode.js';

--- a/examples/webgpu_postprocessing_3dlut.html
+++ b/examples/webgpu_postprocessing_3dlut.html
@@ -28,7 +28,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { mix, mul, oneMinus, positionLocal, smoothstep, texture, time, rotateUV, Fn, uv, vec2, vec3, vec4, pass, texture3D, uniform, renderOutput } from 'three/tsl';
 			import { lut3D } from 'three/addons/tsl/display/Lut3DNode.js';
 

--- a/examples/webgpu_postprocessing_afterimage.html
+++ b/examples/webgpu_postprocessing_afterimage.html
@@ -26,7 +26,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { instancedBufferAttribute, mod, pass, texture, float, time, vec2, vec3, vec4, sin, cos } from 'three/tsl';
 			import { afterImage } from 'three/addons/tsl/display/AfterImageNode.js';
 

--- a/examples/webgpu_postprocessing_anamorphic.html
+++ b/examples/webgpu_postprocessing_anamorphic.html
@@ -27,7 +27,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { pass, cubeTexture, screenUV, grayscale, uniform } from 'three/tsl';
 			import { anamorphic } from 'three/addons/tsl/display/AnamorphicNode.js';
 

--- a/examples/webgpu_postprocessing_ao.html
+++ b/examples/webgpu_postprocessing_ao.html
@@ -27,7 +27,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { pass, mrt, output, normalView, velocity } from 'three/tsl';
 			import { ao } from 'three/addons/tsl/display/GTAONode.js';
 			import { traa } from 'three/addons/tsl/display/TRAANode.js';

--- a/examples/webgpu_postprocessing_bloom.html
+++ b/examples/webgpu_postprocessing_bloom.html
@@ -37,7 +37,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { pass } from 'three/tsl';
 			import { bloom } from 'three/addons/tsl/display/BloomNode.js';
 

--- a/examples/webgpu_postprocessing_bloom_emissive.html
+++ b/examples/webgpu_postprocessing_bloom_emissive.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { pass, mrt, output, emissive } from 'three/tsl';
 			import { bloom } from 'three/addons/tsl/display/BloomNode.js';
 

--- a/examples/webgpu_postprocessing_bloom_selective.html
+++ b/examples/webgpu_postprocessing_bloom_selective.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { pass, mrt, output, float, uniform } from 'three/tsl';
 			import { bloom } from 'three/addons/tsl/display/BloomNode.js';
 

--- a/examples/webgpu_postprocessing_ca.html
+++ b/examples/webgpu_postprocessing_ca.html
@@ -26,7 +26,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { pass, renderOutput, uniform } from 'three/tsl';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';

--- a/examples/webgpu_postprocessing_difference.html
+++ b/examples/webgpu_postprocessing_difference.html
@@ -26,7 +26,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { pass, luminance, saturation } from 'three/tsl';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';

--- a/examples/webgpu_postprocessing_dof.html
+++ b/examples/webgpu_postprocessing_dof.html
@@ -20,7 +20,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { cubeTexture, positionWorld, oscSine, time, pass, uniform } from 'three/tsl';
 			import { dof } from 'three/addons/tsl/display/DepthOfFieldNode.js';
 

--- a/examples/webgpu_postprocessing_dof_basic.html
+++ b/examples/webgpu_postprocessing_dof_basic.html
@@ -37,7 +37,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { mix, pass, renderOutput, smoothstep, uniform, vec3 } from 'three/tsl';
 			import { gaussianBlur } from 'three/addons/tsl/display/GaussianBlurNode.js';
 			import { fxaa } from 'three/addons/tsl/display/FXAANode.js';

--- a/examples/webgpu_postprocessing_fxaa.html
+++ b/examples/webgpu_postprocessing_fxaa.html
@@ -22,7 +22,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { pass, renderOutput } from 'three/tsl';
 			import { fxaa } from 'three/addons/tsl/display/FXAANode.js';
 

--- a/examples/webgpu_postprocessing_lensflare.html
+++ b/examples/webgpu_postprocessing_lensflare.html
@@ -28,7 +28,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { pass, mrt, output, emissive, uniform } from 'three/tsl';
 			import { bloom } from 'three/addons/tsl/display/BloomNode.js';
 			import { lensflare } from 'three/addons/tsl/display/LensflareNode.js';

--- a/examples/webgpu_postprocessing_masking.html
+++ b/examples/webgpu_postprocessing_masking.html
@@ -23,7 +23,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { pass, texture } from 'three/tsl';
 
 			let camera, postProcessing, renderer;

--- a/examples/webgpu_postprocessing_motion_blur.html
+++ b/examples/webgpu_postprocessing_motion_blur.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { pass, texture, uniform, output, mrt, mix, velocity, uv, screenUV } from 'three/tsl';
 			import { motionBlur } from 'three/addons/tsl/display/MotionBlur.js';
 

--- a/examples/webgpu_postprocessing_outline.html
+++ b/examples/webgpu_postprocessing_outline.html
@@ -24,7 +24,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { pass, uniform, time, oscSine } from 'three/tsl';
 			import { outline } from 'three/addons/tsl/display/OutlineNode.js';
 

--- a/examples/webgpu_postprocessing_pixel.html
+++ b/examples/webgpu_postprocessing_pixel.html
@@ -29,7 +29,7 @@
 
 	<script type="module">
 
-		import * as THREE from 'three';
+		import * as THREE from 'three/webgpu';
 
 		import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 		import { GUI } from 'three/addons/libs/lil-gui.module.min.js';

--- a/examples/webgpu_postprocessing_smaa.html
+++ b/examples/webgpu_postprocessing_smaa.html
@@ -24,7 +24,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { pass } from 'three/tsl';
 			import { smaa } from 'three/addons/tsl/display/SMAANode.js';
 

--- a/examples/webgpu_postprocessing_sobel.html
+++ b/examples/webgpu_postprocessing_sobel.html
@@ -24,7 +24,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { pass, renderOutput } from 'three/tsl';
 			import { sobel } from 'three/addons/tsl/display/SobelOperatorNode.js';
 

--- a/examples/webgpu_postprocessing_ssaa.html
+++ b/examples/webgpu_postprocessing_ssaa.html
@@ -24,7 +24,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { ssaaPass } from 'three/addons/tsl/display/SSAAPassNode.js';
 
 			import Stats from 'three/addons/libs/stats.module.js';

--- a/examples/webgpu_postprocessing_ssr.html
+++ b/examples/webgpu_postprocessing_ssr.html
@@ -31,7 +31,7 @@
 
 	<script type="module">
 
-		import * as THREE from 'three';
+		import * as THREE from 'three/webgpu';
 		import { pass, mrt, output, normalView, metalness, blendColor, screenUV, color, sample, directionToColor, colorToDirection } from 'three/tsl';
 		import { ssr } from 'three/addons/tsl/display/SSRNode.js';
 		import { smaa } from 'three/addons/tsl/display/SMAANode.js';

--- a/examples/webgpu_postprocessing_traa.html
+++ b/examples/webgpu_postprocessing_traa.html
@@ -24,7 +24,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { mrt, output, pass, velocity } from 'three/tsl';
 			import { traa } from 'three/addons/tsl/display/TRAANode.js';
 

--- a/examples/webgpu_postprocessing_transition.html
+++ b/examples/webgpu_postprocessing_transition.html
@@ -26,7 +26,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 			import TWEEN from 'three/addons/libs/tween.module.js';

--- a/examples/webgpu_procedural_texture.html
+++ b/examples/webgpu_procedural_texture.html
@@ -24,7 +24,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { checker, uv, uniform, convertToTexture } from 'three/tsl';
 			import { gaussianBlur } from 'three/addons/tsl/display/GaussianBlurNode.js';
 

--- a/examples/webgpu_reflection.html
+++ b/examples/webgpu_reflection.html
@@ -27,7 +27,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import { abs, blendOverlay, color, float, Fn, instancedBufferAttribute, materialColor, normalWorldGeometry, pass, positionGeometry, positionLocal, reflector, screenUV, sin, sub, texture, time, uniform, uv, vec3 } from 'three/tsl';
 			import { gaussianBlur } from 'three/addons/tsl/display/GaussianBlurNode.js';

--- a/examples/webgpu_reflection_blurred.html
+++ b/examples/webgpu_reflection_blurred.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { Fn, vec4, fract, abs, uniform, pow, color, max, length, rangeFogFactor, sub, reflector, normalWorld, hue, time, mix, positionWorld } from 'three/tsl';
 
 			import { hashBlur } from 'three/addons/tsl/display/hashBlur.js';

--- a/examples/webgpu_reflection_roughness.html
+++ b/examples/webgpu_reflection_roughness.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { Fn, vec2, vec4, texture, uv, textureBicubic, rangeFogFactor, reflector, time } from 'three/tsl';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';

--- a/examples/webgpu_refraction.html
+++ b/examples/webgpu_refraction.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { viewportSafeUV, viewportSharedTexture, screenUV, texture, uv } from 'three/tsl';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';

--- a/examples/webgpu_rendertarget_2d-array_3d.html
+++ b/examples/webgpu_rendertarget_2d-array_3d.html
@@ -42,7 +42,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { vec2, uniform, screenUV, color, texture, diffuseColor, attribute, vec3, vec4 } from 'three/tsl';
 			import Stats from 'three/addons/libs/stats.module.js';
 			import { TextureHelper } from 'three/addons/helpers/TextureHelperGPU.js';

--- a/examples/webgpu_rtt.html
+++ b/examples/webgpu_rtt.html
@@ -24,7 +24,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { texture, uniform, saturation, hue } from 'three/tsl';
 
 			let camera, scene, renderer;

--- a/examples/webgpu_sandbox.html
+++ b/examples/webgpu_sandbox.html
@@ -24,7 +24,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { time, vec2, uv, texture, mix, checker, normalLocal, positionLocal, color, oscSine, attribute } from 'three/tsl';
 
 			import { KTX2Loader } from 'three/addons/loaders/KTX2Loader.js';

--- a/examples/webgpu_shadowmap.html
+++ b/examples/webgpu_shadowmap.html
@@ -24,7 +24,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { mx_fractal_noise_vec3, positionWorld, vec4, Fn, color, vertexIndex, hash } from 'three/tsl';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';

--- a/examples/webgpu_shadowmap_array.html
+++ b/examples/webgpu_shadowmap_array.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { mx_fractal_noise_vec3, positionWorld, Fn, color } from 'three/tsl';
 
 			import { TileShadowNode } from 'three/addons/tsl/shadows/TileShadowNode.js';

--- a/examples/webgpu_shadowmap_csm.html
+++ b/examples/webgpu_shadowmap_csm.html
@@ -27,7 +27,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';

--- a/examples/webgpu_shadowmap_opacity.html
+++ b/examples/webgpu_shadowmap_opacity.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { Fn, mix } from 'three/tsl';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';

--- a/examples/webgpu_shadowmap_progressive.html
+++ b/examples/webgpu_shadowmap_progressive.html
@@ -25,7 +25,7 @@
 		</script>
 
 		<script type="module">
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';

--- a/examples/webgpu_shadowmap_vsm.html
+++ b/examples/webgpu_shadowmap_vsm.html
@@ -24,7 +24,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import Stats from 'three/addons/libs/stats.module.js';
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';

--- a/examples/webgpu_skinning.html
+++ b/examples/webgpu_skinning.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { color, screenUV } from 'three/tsl';
 
 			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';

--- a/examples/webgpu_skinning_instancing.html
+++ b/examples/webgpu_skinning_instancing.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { pass, mix, range, color, oscSine, time } from 'three/tsl';
 			import { gaussianBlur } from 'three/addons/tsl/display/GaussianBlurNode.js';
 

--- a/examples/webgpu_skinning_points.html
+++ b/examples/webgpu_skinning_points.html
@@ -26,7 +26,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { color, computeSkinning, objectWorldMatrix, instancedArray, instanceIndex, Fn, shapeCircle } from 'three/tsl';
 
 			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';

--- a/examples/webgpu_sky.html
+++ b/examples/webgpu_sky.html
@@ -24,7 +24,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';

--- a/examples/webgpu_sprites.html
+++ b/examples/webgpu_sprites.html
@@ -24,7 +24,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { texture, uv, userData, fog, rangeFogFactor, color } from 'three/tsl';
 
 			let camera, scene, renderer;

--- a/examples/webgpu_storage_buffer.html
+++ b/examples/webgpu_storage_buffer.html
@@ -52,7 +52,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { storage, If, vec3, uv, uint, float, Fn, instanceIndex, workgroupBarrier } from 'three/tsl';
 
 			const timestamps = {

--- a/examples/webgpu_struct_drawindirect.html
+++ b/examples/webgpu_struct_drawindirect.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { struct, storage, wgslFn, instanceIndex, time, varyingProperty, attribute } from 'three/tsl';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';

--- a/examples/webgpu_texturegrad.html
+++ b/examples/webgpu_texturegrad.html
@@ -27,7 +27,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { If, vec4, float, time, cos, pow, vec2, uv, texture, Fn } from 'three/tsl';
 
 			// WebGPU Backend

--- a/examples/webgpu_textures_2d-array.html
+++ b/examples/webgpu_textures_2d-array.html
@@ -28,7 +28,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { texture, uv, time, oscTriangle } from 'three/tsl';
 
 			import Stats from 'three/addons/libs/stats.module.js';

--- a/examples/webgpu_textures_2d-array_compressed.html
+++ b/examples/webgpu_textures_2d-array_compressed.html
@@ -27,7 +27,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import { texture, uniform, uv } from 'three/tsl';
 

--- a/examples/webgpu_textures_anisotropy.html
+++ b/examples/webgpu_textures_anisotropy.html
@@ -67,7 +67,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import Stats from 'three/addons/libs/stats.module.js';
 

--- a/examples/webgpu_textures_partialupdate.html
+++ b/examples/webgpu_textures_partialupdate.html
@@ -26,7 +26,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			let camera, scene, renderer, clock, dataTexture, diffuseMap;
 

--- a/examples/webgpu_tonemapping.html
+++ b/examples/webgpu_tonemapping.html
@@ -28,7 +28,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';

--- a/examples/webgpu_tsl_angular_slicing.html
+++ b/examples/webgpu_tsl_angular_slicing.html
@@ -27,7 +27,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { If, PI2, atan, color, frontFacing, output, positionLocal, Fn, uniform, vec4 } from 'three/tsl';
 
 			import { DRACOLoader } from 'three/addons/loaders/DRACOLoader.js';

--- a/examples/webgpu_tsl_compute_attractors_particles.html
+++ b/examples/webgpu_tsl_compute_attractors_particles.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { float, If, PI, color, cos, instanceIndex, Loop, mix, mod, sin, instancedArray, Fn, uint, uniform, uniformArray, hash, vec3, vec4 } from 'three/tsl';
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';

--- a/examples/webgpu_tsl_earth.html
+++ b/examples/webgpu_tsl_earth.html
@@ -29,7 +29,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { step, normalWorldGeometry, output, texture, vec3, vec4, normalize, positionWorld, bumpMap, cameraPosition, color, uniform, mix, uv, max } from 'three/tsl';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';

--- a/examples/webgpu_tsl_editor.html
+++ b/examples/webgpu_tsl_editor.html
@@ -173,7 +173,7 @@ output = vec4( finalColor, opacity );
 							const AsyncFunction = async function () {}.constructor;
 
 							const tslCode = `let output = null;\n${ editor.getValue() }\nreturn { output };`;
-							const nodes = await ( new AsyncFunction( 'THREE', tslCode )( THREE ) );
+							const nodes = await ( new AsyncFunction( 'three/webgpu', tslCode )( THREE ) );
 
 							mesh.material.fragmentNode = nodes.output;
 							mesh.material.needsUpdate = true;

--- a/examples/webgpu_tsl_galaxy.html
+++ b/examples/webgpu_tsl_galaxy.html
@@ -27,7 +27,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { color, cos, float, mix, range, sin, time, uniform, uv, vec3, vec4, PI2 } from 'three/tsl';
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';

--- a/examples/webgpu_tsl_halftone.html
+++ b/examples/webgpu_tsl_halftone.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { color, mix, normalWorld, output, Fn, uniform, vec4, rotate, screenCoordinate, screenSize } from 'three/tsl';
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';

--- a/examples/webgpu_tsl_interoperability.html
+++ b/examples/webgpu_tsl_interoperability.html
@@ -28,7 +28,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { Fn, attribute, varyingProperty, time, uniform, wgslFn, texture, sampler, uv, clamp, float, vec2, vec3, fract, floor, positionGeometry, sin } from 'three/tsl';
 
 			import WebGPU from 'three/addons/capabilities/WebGPU.js';

--- a/examples/webgpu_tsl_procedural_terrain.html
+++ b/examples/webgpu_tsl_procedural_terrain.html
@@ -27,7 +27,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { mx_noise_float, color, cross, dot, float, transformNormalToView, positionLocal, sign, step, Fn, uniform, varying, vec2, vec3, Loop } from 'three/tsl';
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';

--- a/examples/webgpu_tsl_raging_sea.html
+++ b/examples/webgpu_tsl_raging_sea.html
@@ -27,7 +27,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { float, mx_noise_float, Loop, color, positionLocal, sin, vec2, vec3, mul, time, uniform, Fn, transformNormalToView } from 'three/tsl';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';

--- a/examples/webgpu_tsl_vfx_flames.html
+++ b/examples/webgpu_tsl_vfx_flames.html
@@ -27,7 +27,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { PI2, oneMinus, spherizeUV, sin, step, texture, time, Fn, uv, vec2, vec3, vec4, mix, billboarding } from 'three/tsl';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';

--- a/examples/webgpu_tsl_vfx_linkedparticles.html
+++ b/examples/webgpu_tsl_vfx_linkedparticles.html
@@ -27,7 +27,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { atan, cos, float, max, min, mix, PI, PI2, sin, vec2, vec3, color, Fn, hash, hue, If, instanceIndex, Loop, mx_fractal_noise_float, mx_fractal_noise_vec3, pass, pcurve, storage, deltaTime, time, uv, uniform, step } from 'three/tsl';
 			import { bloom } from 'three/addons/tsl/display/BloomNode.js';
 

--- a/examples/webgpu_tsl_vfx_tornado.html
+++ b/examples/webgpu_tsl_vfx_tornado.html
@@ -27,7 +27,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { luminance, cos, min, time, atan, uniform, pass, PI, PI2, color, positionLocal, sin, texture, Fn, uv, vec2, vec3, vec4 } from 'three/tsl';
 			import { bloom } from 'three/addons/tsl/display/BloomNode.js';
 

--- a/examples/webgpu_video_frame.html
+++ b/examples/webgpu_video_frame.html
@@ -26,7 +26,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import { MP4Demuxer } from 'three/addons/libs/demuxer_mp4.js';
 

--- a/examples/webgpu_video_panorama.html
+++ b/examples/webgpu_video_panorama.html
@@ -36,7 +36,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			let camera, scene, renderer;
 

--- a/examples/webgpu_volume_caustics.html
+++ b/examples/webgpu_volume_caustics.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import { uniform, refract, div, frameId, lightViewPosition, float, positionView, positionViewDirection, screenUV, pass, texture3D, time, screenCoordinate, normalView, texture, Fn, vec2, vec3 } from 'three/tsl';
 

--- a/examples/webgpu_volume_cloud.html
+++ b/examples/webgpu_volume_cloud.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { float, vec3, vec4, If, Break, Fn, smoothstep, texture3D, uniform } from 'three/tsl';
 
 			import { RaymarchingBox } from 'three/addons/tsl/utils/Raymarching.js';

--- a/examples/webgpu_volume_lighting.html
+++ b/examples/webgpu_volume_lighting.html
@@ -27,7 +27,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { vec3, Fn, time, texture3D, screenUV, uniform, screenCoordinate, pass } from 'three/tsl';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';

--- a/examples/webgpu_volume_lighting_rectarea.html
+++ b/examples/webgpu_volume_lighting_rectarea.html
@@ -27,7 +27,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { vec3, Fn, time, texture3D, screenUV, uniform, screenCoordinate, pass } from 'three/tsl';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';

--- a/examples/webgpu_volume_perlin.html
+++ b/examples/webgpu_volume_perlin.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 			import { Break, If, vec3, vec4, texture3D, uniform, Fn } from 'three/tsl';
 
 			import { RaymarchingBox } from 'three/addons/tsl/utils/Raymarching.js';

--- a/examples/webgpu_water.html
+++ b/examples/webgpu_water.html
@@ -28,7 +28,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import { pass, mrt, output, emissive, renderOutput } from 'three/tsl';
 			import { bloom } from 'three/addons/tsl/display/BloomNode.js';

--- a/examples/webgpu_xr_cubes.html
+++ b/examples/webgpu_xr_cubes.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import { BoxLineGeometry } from 'three/addons/geometries/BoxLineGeometry.js';
 			import { XRButton } from 'three/addons/webxr/XRButton.js';

--- a/examples/webgpu_xr_native_layers.html
+++ b/examples/webgpu_xr_native_layers.html
@@ -25,7 +25,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import { BoxLineGeometry } from 'three/addons/geometries/BoxLineGeometry.js';
 			import { VRButton } from 'three/addons/webxr/VRButton.js';

--- a/examples/webgpu_xr_rollercoaster.html
+++ b/examples/webgpu_xr_rollercoaster.html
@@ -19,7 +19,7 @@
 
 		<script type="module">
 
-			import * as THREE from 'three';
+			import * as THREE from 'three/webgpu';
 
 			import {
 				RollerCoasterGeometry,


### PR DESCRIPTION
**Description**

This especially helps beginners who create their projects using NPM and Vite and had problems to replicate their examples because they are importing from 'three' instead of 'three/webgpu'.
