### PR TITLE
NodeUtils: Ignore private sub properties in `getNodeChildren()`.

### DIFF
--- a/src/nodes/core/NodeUtils.js
+++ b/src/nodes/core/NodeUtils.js
@@ -142,6 +142,9 @@ export function* getNodeChildren( node, toJSON = false ) {
 
 			for ( const subProperty in object ) {
 
+				// Ignore private properties.
+				if ( subProperty.startsWith( '_' ) === true ) continue;
+
 				const child = object[ subProperty ];
 
 				if ( child && ( child.isNode === true || toJSON && typeof child.toJSON === 'function' ) ) {

--- a/src/nodes/core/NodeUtils.js
+++ b/src/nodes/core/NodeUtils.js
@@ -138,7 +138,7 @@ export function* getNodeChildren( node, toJSON = false ) {
 
 			yield { property, childNode: object };
 
-		} else if ( typeof object === 'object' ) {
+		} else if ( object && Object.getPrototypeOf( object ) === Object.prototype ) {
 
 			for ( const subProperty in object ) {
 


### PR DESCRIPTION
Fixes #31522

**Description**

`getNodeChildren()` ignores private properties on object level but not on the level below. For consistency reasons, private sub properties should also be ignored.

Note: The PR does not fix #31522. However, consistently ignoring private properties makes it possible to workaround the issue, see https://github.com/mrdoob/three.js/issues/31522#issuecomment-3128254173.