### PR TITLE
PointsNodeMaterial: Clarify docs for `sizeNode`.

### DIFF
--- a/src/materials/nodes/PointsNodeMaterial.js
+++ b/src/materials/nodes/PointsNodeMaterial.js
@@ -37,8 +37,8 @@ class PointsNodeMaterial extends SpriteNodeMaterial {
 		 *
 		 * Note that WebGPU only supports point primitives with 1 pixel size. Consequently,
 		 * this node has no effect when the material is used with {@link Points} and
-		 * a WebGPU backend. If want to render points with a size larger than 1 pixel,
-		 * use the material with {@link Sprite} and instancing.
+		 * a WebGPU backend. If an application wants to render points with a size larger than 1 pixel,
+		 * the material should be used with {@link Sprite} and instancing.
 		 *
 		 * @type {?Node<vec2>}
 		 * @default null

--- a/src/materials/nodes/PointsNodeMaterial.js
+++ b/src/materials/nodes/PointsNodeMaterial.js
@@ -35,6 +35,11 @@ class PointsNodeMaterial extends SpriteNodeMaterial {
 		/**
 		 * This node property provides an additional way to set the point size.
 		 *
+		 * Note that WebGPU only supports point primitives with 1 pixel size. Consequently,
+		 * this node has no effect when the material is used with {@link Points} and
+		 * a WebGPU backend. If want to render points with a size larger than 1 pixel,
+		 * use the material with {@link Sprite} and instancing.
+		 *
 		 * @type {?Node<vec2>}
 		 * @default null
 		 */

--- a/src/materials/nodes/PointsNodeMaterial.js
+++ b/src/materials/nodes/PointsNodeMaterial.js
@@ -36,8 +36,8 @@ class PointsNodeMaterial extends SpriteNodeMaterial {
 		 * This node property provides an additional way to set the point size.
 		 *
 		 * Note that WebGPU only supports point primitives with 1 pixel size. Consequently,
-		 * this node has no effect when the material is used with {@link Points} and
-		 * a WebGPU backend. If an application wants to render points with a size larger than 1 pixel,
+		 * this node has no effect when the material is used with {@link Points} and a WebGPU
+		 * backend. If an application wants to render points with a size larger than 1 pixel,
 		 * the material should be used with {@link Sprite} and instancing.
 		 *
 		 * @type {?Node<vec2>}


### PR DESCRIPTION
Fixed #31527.

**Description**

The PR improves the JSDoc for `sizeNode` by highlighting that the property has no effect when using with `THREE.Points` and a WebGPU backend.
