### PR TITLE
Explicitly set `VideoTexture#colorSpace` to `SRGBColorSpace`

### DIFF
--- a/examples/webgpu_lights_projector.html
+++ b/examples/webgpu_lights_projector.html
@@ -191,6 +191,7 @@
 							video.play();
 
 							videoTexture = new THREE.VideoTexture( video );
+							videoTexture.colorSpace = THREE.SRGBColorSpace;
 
 						}
 

--- a/examples/webgpu_materials_video.html
+++ b/examples/webgpu_materials_video.html
@@ -97,6 +97,7 @@
 				} );
 
 				texture = new THREE.VideoTexture( video );
+				texture.colorSpace = THREE.SRGBColorSpace;
 
 				//
 

--- a/src/textures/VideoTexture.js
+++ b/src/textures/VideoTexture.js
@@ -10,7 +10,7 @@ import { Texture } from './Texture.js';
  * const texture = new THREE.VideoTexture( video );
  * ```
  *
- * Note: When using video textures with {@link WebGPURenderer}, {@link Texture#colorSpace} must be 
+ * Note: When using video textures with {@link WebGPURenderer}, {@link Texture#colorSpace} must be
  * set to THREE.SRGBColorSpace.
  *
  * Note: After the initial use of a texture, its dimensions, format, and type

--- a/src/textures/VideoTexture.js
+++ b/src/textures/VideoTexture.js
@@ -10,6 +10,12 @@ import { Texture } from './Texture.js';
  * const texture = new THREE.VideoTexture( video );
  * ```
  *
+ * Note: Due to inherent design constraints in WebGPURenderer, .colorSpace must be explicitly set
+ * to SRGBColorSpace. Assigning alternative values may result in perceptible color inaccuracies,
+ * including luminance shifts and hue distortion. This outcome is a direct consequence of the
+ * renderer's internal texture handling mechanisms and is entirely independent of the color space
+ * employed by the browser during video decoding.
+ *
  * Note: After the initial use of a texture, its dimensions, format, and type
  * cannot be changed. Instead, call {@link Texture#dispose} on the texture and instantiate a new one.
  *

--- a/src/textures/VideoTexture.js
+++ b/src/textures/VideoTexture.js
@@ -10,11 +10,8 @@ import { Texture } from './Texture.js';
  * const texture = new THREE.VideoTexture( video );
  * ```
  *
- * Note: Due to inherent design constraints in WebGPURenderer, .colorSpace must be explicitly set
- * to SRGBColorSpace. Assigning alternative values may result in perceptible color inaccuracies,
- * including luminance shifts and hue distortion. This outcome is a direct consequence of the
- * renderer's internal texture handling mechanisms and is entirely independent of the color space
- * employed by the browser during video decoding.
+ * Note: When using video textures with {@link WebGPURenderer}, {@link Texture#colorSpace} must be 
+ * set to THREE.SRGBColorSpace.
  *
  * Note: After the initial use of a texture, its dimensions, format, and type
  * cannot be changed. Instead, call {@link Texture#dispose} on the texture and instantiate a new one.


### PR DESCRIPTION
Related: https://github.com/mrdoob/three.js/pull/31416, Discussion: https://github.com/mrdoob/three.js/issues/31533

Due to inherent design constraints in WebGPURenderer, `VideoTexture#colorSpace` must be explicitly set to SRGBColorSpace. Assigning alternative values may result in perceptible color inaccuracies, including luminance shifts and hue distortion. This outcome is a direct consequence of the renderer's internal texture handling mechanisms (i.e. copyExternalImageToTexture with destination.colorSpace:'srgb') and is entirely independent of the color space employed by the browser during video decoding.