### PR TITLE
Node: Clarify Usage of Setup in Function Declaration

### DIFF
--- a/src/nodes/core/Node.js
+++ b/src/nodes/core/Node.js
@@ -494,8 +494,8 @@ class Node extends EventDispatcher {
 
 	/**
 	 * Represents the setup stage which is the first step of the build process, see {@link Node#build} method.
-	 * This method is often overwritten in derived modules to prepare the node which is used as the output/result.
-	 * The output node must be returned in the `return` statement.
+	 * This method is often overwritten in derived modules to prepare the node which is used as a node's output/result.
+	 * If an output node is prepared, then it must be returned in the `return` statement of the derived module's setup function.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
 	 * @return {?Node} The output node.

--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -2748,7 +2748,7 @@ class NodeBuilder {
 
 		}
 
-		// setup() -> stage 1: create possible new nodes and returns an output reference node
+		// setup() -> stage 1: create possible new nodes and/or return an output reference node
 		// analyze()   -> stage 2: analyze nodes to possible optimization and validation
 		// generate()  -> stage 3: generate shader
 


### PR DESCRIPTION
**Description**

The comment for the base Node setup class currently reads as follows:

```ts
/**
 * Represents the setup stage which is the first step of the build process, see {@link Node#build} me
 * This method is often overwritten in derived modules to prepare the node which is used as the output
 * The output node must be returned in the `return` statement.
 *
 * @param {NodeBuilder} builder - The current node builder.
 * @return {?Node} The output node.
 */
setup( builder ) {
```

For some, this can be misconstrued as all setup nodes requiring a returned outputNode. However, in many nodes, this is not the case. Examples include ConditionalNode, LoopNode, LightProbeNode, IrradianceNode, HemisphereLightNode, AONode, AnalyticLightNode, VaryingNode, ContextNode, and more. These nodes often perform actions that are not captured by the description in the setup function declaration, including modifying the context or creating new nodes. Additionally, many of these node are built under the assumption that setup() will not return and will fallback to properties.outputNode or null with Node.js

```ts
// Node.js

if ( buildStage === 'setup' ) {
	this.updateReference( builder );
	const properties = builder.getNodeProperties( this );
	if ( properties.initialized !== true ) {
		//const stackNodesBeforeSetup = builder.stack.nodes.length;
		properties.initialized = true;
		properties.outputNode = this.setup( builder ) || properties.outputNode || null;
```

Accordingly, I think the declaration for the setup function should more explicitly indicate that a returned outputNode is not necessary for every setup declaration.

