### PR TITLE
RawTexture: Rename to `ExternalTexture`.

### DIFF
--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -515,7 +515,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		if ( texture.isVideoTexture ) updateVideoTexture( texture );
 
-		if ( texture.isRenderTargetTexture === false && texture.isRawTexture !== true && texture.version > 0 && textureProperties.__version !== texture.version ) {
+		if ( texture.isRenderTargetTexture === false && texture.isExternalTexture !== true && texture.version > 0 && textureProperties.__version !== texture.version ) {
 
 			const image = texture.image;
 
@@ -534,7 +534,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 			}
 
-		} else if ( texture.isRawTexture ) {
+		} else if ( texture.isExternalTexture ) {
 
 			textureProperties.__webglTexture = texture.sourceTexture ? texture.sourceTexture : null;
 

--- a/src/renderers/webxr/WebXRDepthSensing.js
+++ b/src/renderers/webxr/WebXRDepthSensing.js
@@ -1,7 +1,7 @@
 import { PlaneGeometry } from '../../geometries/PlaneGeometry.js';
 import { ShaderMaterial } from '../../materials/ShaderMaterial.js';
 import { Mesh } from '../../objects/Mesh.js';
-import { RawTexture } from '../../textures/RawTexture.js';
+import { ExternalTexture } from '../../textures/ExternalTexture.js';
 
 const _occlusion_vertex = `
 void main() {
@@ -44,7 +44,7 @@ class WebXRDepthSensing {
 		/**
 		 * An opaque texture representing the depth of the user's environment.
 		 *
-		 * @type {?RawTexture}
+		 * @type {?ExternalTexture}
 		 */
 		this.texture = null;
 
@@ -81,7 +81,7 @@ class WebXRDepthSensing {
 
 		if ( this.texture === null ) {
 
-			const texture = new RawTexture( depthData.texture );
+			const texture = new ExternalTexture( depthData.texture );
 
 			if ( ( depthData.depthNear !== renderState.depthNear ) || ( depthData.depthFar !== renderState.depthFar ) ) {
 
@@ -142,7 +142,7 @@ class WebXRDepthSensing {
 	/**
 	 * Returns a texture representing the depth of the user's environment.
 	 *
-	 * @return {?RawTexture} The depth texture.
+	 * @return {?ExternalTexture} The depth texture.
 	 */
 	getDepthTexture() {
 

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -9,7 +9,7 @@ import { WebGLAnimation } from '../webgl/WebGLAnimation.js';
 import { WebGLRenderTarget } from '../WebGLRenderTarget.js';
 import { WebXRController } from './WebXRController.js';
 import { DepthTexture } from '../../textures/DepthTexture.js';
-import { RawTexture } from '../../textures/RawTexture.js';
+import { ExternalTexture } from '../../textures/ExternalTexture.js';
 import { DepthFormat, DepthStencilFormat, RGBAFormat, UnsignedByteType, UnsignedIntType, UnsignedInt248Type } from '../../constants.js';
 import { WebXRDepthSensing } from './WebXRDepthSensing.js';
 
@@ -1023,7 +1023,7 @@ class WebXRManager extends EventDispatcher {
 
 								if ( ! cameraTex ) {
 
-									cameraTex = new RawTexture();
+									cameraTex = new ExternalTexture();
 									cameraAccessTextures[ camera ] = cameraTex;
 
 								}

--- a/src/textures/ExternalTexture.js
+++ b/src/textures/ExternalTexture.js
@@ -10,7 +10,7 @@ import { Texture } from './Texture.js';
  *
  * @augments Texture
  */
-class RawTexture extends Texture {
+class ExternalTexture extends Texture {
 
 	/**
 	 * Creates a new raw texture.
@@ -36,10 +36,10 @@ class RawTexture extends Texture {
 		 * @readonly
 		 * @default true
 		 */
-		this.isRawTexture = true;
+		this.isExternalTexture = true;
 
 	}
 
 }
 
-export { RawTexture };
+export { ExternalTexture };


### PR DESCRIPTION
Related issue: #31487

**Description**

As suggested in https://github.com/mrdoob/three.js/pull/31487#discussion_r2245071929.
