### PR TITLE
WebGPURenderer: Fix MSAA using mipmap levels

### DIFF
--- a/src/renderers/webgpu/utils/WebGPUTextureUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUTextureUtils.js
@@ -266,6 +266,7 @@ class WebGPUTextureUtils {
 
 			msaaTextureDescriptorGPU.label = msaaTextureDescriptorGPU.label + '-msaa';
 			msaaTextureDescriptorGPU.sampleCount = samples;
+			msaaTextureDescriptorGPU.mipLevelCount = 1; // See https://developer.mozilla.org/en-US/docs/Web/API/GPUDevice/createTexture
 
 			textureData.msaaTexture = backend.device.createTexture( msaaTextureDescriptorGPU );
 

--- a/src/renderers/webgpu/utils/WebGPUTextureUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUTextureUtils.js
@@ -266,7 +266,7 @@ class WebGPUTextureUtils {
 
 			msaaTextureDescriptorGPU.label = msaaTextureDescriptorGPU.label + '-msaa';
 			msaaTextureDescriptorGPU.sampleCount = samples;
-			msaaTextureDescriptorGPU.mipLevelCount = 1; // See https://developer.mozilla.org/en-US/docs/Web/API/GPUDevice/createTexture
+			msaaTextureDescriptorGPU.mipLevelCount = 1; // See https://www.w3.org/TR/webgpu/#texture-creation
 
 			textureData.msaaTexture = backend.device.createTexture( msaaTextureDescriptorGPU );
 


### PR DESCRIPTION
**Description**

According to the MDN-Documentation on [createTexture](https://developer.mozilla.org/en-US/docs/Web/API/GPUDevice/createTexture), textures cannot have mipmap levels if they also use MSAA/samples. This fix aims to prevent blank render-targets, which specify both mipmaps and MSAA, see https://github.com/mrdoob/three.js/pull/31542#discussion_r2246091433