### PR TITLE
Examples: Use epsilon for zoomChanged comparison in OrbitControls

### DIFF
--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -683,7 +683,7 @@ class OrbitControls extends Controls {
 
 			const prevRadius = this._spherical.radius;
 			this._spherical.radius = this._clampDistance( this._spherical.radius * this._scale );
-			zoomChanged = Math.abs(prevRadius - this._spherical.radius) > _EPS;
+			zoomChanged = Math.abs( prevRadius - this._spherical.radius ) > _EPS;
 
 		}
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -683,7 +683,7 @@ class OrbitControls extends Controls {
 
 			const prevRadius = this._spherical.radius;
 			this._spherical.radius = this._clampDistance( this._spherical.radius * this._scale );
-			zoomChanged = prevRadius != this._spherical.radius;
+			zoomChanged = Math.abs(prevRadius - this._spherical.radius) > _EPS;
 
 		}
 


### PR DESCRIPTION
**Description**

zoomChanged was set using strict inequality, which could trigger unnecessary updates due to floating point precision errors. Instead, use an epsilon threshold to determine significant changes