### PR TITLE
DepthOfFieldNode: Restore near-field blur strength.

### DIFF
--- a/examples/jsm/tsl/display/DepthOfFieldNode.js
+++ b/examples/jsm/tsl/display/DepthOfFieldNode.js
@@ -371,7 +371,7 @@ class DepthOfFieldNode extends TempNode {
 
 		// blurred CoC for near field
 
-		this._CoCBlurredMaterial.colorNode = gaussianBlur( this._CoCTextureNode, 1, 1 );
+		this._CoCBlurredMaterial.colorNode = gaussianBlur( this._CoCTextureNode, 1, 2 );
 		this._CoCBlurredMaterial.needsUpdate = true;
 
 		// bokeh 64 blur pass


### PR DESCRIPTION
Related issue: #31528

**Description**

Because of the changes in #31528, `DepthOfFieldNode` requires a small update to restore the original near-field blur.
