### PR TITLE
TSL: Improve warnings (2)

### DIFF
--- a/src/nodes/core/AssignNode.js
+++ b/src/nodes/core/AssignNode.js
@@ -112,19 +112,10 @@ class AssignNode extends TempNode {
 
 		const needsSplitAssign = this.needsSplitAssign( builder );
 
-		const targetType = targetNode.getNodeType( builder );
 		const target = targetNode.build( builder );
+		const targetType = targetNode.getNodeType( builder );
 
-		let source = sourceNode.build( builder, targetType );
-
-		if ( source === '' ) {
-
-			console.error( `THREE.TSL: Invalid node using in "${ target }" assignment.` );
-
-			source = builder.generateConst( targetType );
-
-		}
-
+		const source = sourceNode.build( builder, targetType );
 		const sourceType = sourceNode.getNodeType( builder );
 
 		const nodeData = builder.getDataFromNode( this );

--- a/src/nodes/core/AssignNode.js
+++ b/src/nodes/core/AssignNode.js
@@ -113,9 +113,17 @@ class AssignNode extends TempNode {
 		const needsSplitAssign = this.needsSplitAssign( builder );
 
 		const targetType = targetNode.getNodeType( builder );
-
 		const target = targetNode.build( builder );
-		const source = sourceNode.build( builder, targetType );
+
+		let source = sourceNode.build( builder, targetType );
+
+		if ( source === '' ) {
+
+			console.error( `THREE.TSL: Invalid node using in "${ target }" assignment.` );
+
+			source = builder.generateConst( targetType );
+
+		}
 
 		const sourceType = sourceNode.getNodeType( builder );
 

--- a/src/nodes/core/Node.js
+++ b/src/nodes/core/Node.js
@@ -765,6 +765,16 @@ class Node extends EventDispatcher {
 
 			}
 
+			if ( result === '' && output !== null && output !== 'void' ) {
+
+				// if no snippet is generated, return a default value
+
+				console.error( `THREE.TSL: Invalid generated code, expected a "${ output }".` );
+
+				result = builder.generateConst( output );
+
+			}
+
 		}
 
 		builder.removeChain( this );

--- a/src/nodes/core/Node.js
+++ b/src/nodes/core/Node.js
@@ -765,7 +765,7 @@ class Node extends EventDispatcher {
 
 			}
 
-			if ( result === '' && output !== null && output !== 'void' ) {
+			if ( result === '' && output !== null && output !== 'void' && output !== 'OutputType' ) {
 
 				// if no snippet is generated, return a default value
 

--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -1144,7 +1144,6 @@ class NodeBuilder {
 
 	}
 
-
 	/**
 	 * Generates the shader string for the given type and value.
 	 *
@@ -2922,11 +2921,6 @@ class NodeBuilder {
 		return `// Three.js r${ REVISION } - Node System\n`;
 
 	}
-
-	/**
-	 * Prevents the node builder from being used as an iterable in TSL.Fn(), avoiding potential runtime errors.
-	 */
-	*[ Symbol.iterator ]() { }
 
 }
 

--- a/src/nodes/core/StackNode.js
+++ b/src/nodes/core/StackNode.js
@@ -80,13 +80,13 @@ class StackNode extends Node {
 
 	getNodeType( builder ) {
 
-		return this.outputNode ? this.outputNode.getNodeType( builder ) : 'void';
+		return this.hasOutput ? this.outputNode.getNodeType( builder ) : 'void';
 
 	}
 
 	getMemberType( builder, name ) {
 
-		return this.outputNode ? this.outputNode.getMemberType( builder, name ) : 'void';
+		return this.hasOutput ? this.outputNode.getMemberType( builder, name ) : 'void';
 
 	}
 
@@ -97,6 +97,13 @@ class StackNode extends Node {
 	 * @return {StackNode} A reference to this stack node.
 	 */
 	add( node ) {
+
+		if ( node.isNode !== true ) {
+
+			console.error( 'THREE.TSL: Invalid node added to stack.' );
+			return this;
+
+		}
 
 		this.nodes.push( node );
 
@@ -191,7 +198,7 @@ class StackNode extends Node {
 
 		} else {
 
-			throw new Error( 'TSL: Invalid parameter length. Case() requires at least two parameters.' );
+			console.error( 'THREE.TSL: Invalid parameter length. Case() requires at least two parameters.' );
 
 		}
 
@@ -275,6 +282,12 @@ class StackNode extends Node {
 
 	}
 
+	get hasOutput() {
+
+		return this.outputNode && this.outputNode.isNode;
+
+	}
+
 	build( builder, ...params ) {
 
 		const previousBuildStack = builder.currentStack;
@@ -325,7 +338,19 @@ class StackNode extends Node {
 
 		}
 
-		const result = this.outputNode ? this.outputNode.build( builder, ...params ) : super.build( builder, ...params );
+		//
+
+		let result;
+
+		if ( this.hasOutput ) {
+
+			result = this.outputNode.build( builder, ...params );
+
+		} else {
+
+			result = super.build( builder, ...params );
+
+		}
 
 		setCurrentStack( previousStack );
 

--- a/src/nodes/core/UniformNode.js
+++ b/src/nodes/core/UniformNode.js
@@ -1,6 +1,7 @@
 import InputNode from './InputNode.js';
 import { objectGroup } from './UniformGroupNode.js';
 import { nodeObject, getConstNodeType } from '../tsl/TSLCore.js';
+import { getValueFromType } from './NodeUtils.js';
 
 /**
  * Class for representing a uniform.
@@ -219,16 +220,24 @@ export default UniformNode;
  *
  * @tsl
  * @function
- * @param {any} arg1 - The value of this node. Usually a JS primitive or three.js object (vector, matrix, color, texture).
- * @param {string} [arg2] - The node type. If no explicit type is defined, the node tries to derive the type from its value.
+ * @param {any|string} value - The value of this uniform or your type. Usually a JS primitive or three.js object (vector, matrix, color, texture).
+ * @param {string} [type] - The node type. If no explicit type is defined, the node tries to derive the type from its value.
  * @returns {UniformNode}
  */
-export const uniform = ( arg1, arg2 ) => {
+export const uniform = ( value, type ) => {
 
-	const nodeType = getConstNodeType( arg2 || arg1 );
+	const nodeType = getConstNodeType( type || value );
+
+	if ( nodeType === value ) {
+
+		// if the value is a type but no having a value
+
+		value = getValueFromType( nodeType );
+
+	}
 
 	// @TODO: get ConstNode from .traverse() in the future
-	const value = ( arg1 && arg1.isNode === true ) ? ( arg1.node && arg1.node.value ) || arg1.value : arg1;
+	value = ( value && value.isNode === true ) ? ( value.node && value.node.value ) || value.value : value;
 
 	return nodeObject( new UniformNode( value, nodeType ) );
 

--- a/src/nodes/tsl/TSLCore.js
+++ b/src/nodes/tsl/TSLCore.js
@@ -647,7 +647,7 @@ const ConvertType = function ( type, cacheMap = null ) {
 
 			if ( param === undefined ) {
 
-				console.error( `THREE.TSL: Invalid parameter "${ param }" for type "${ type }".` );
+				console.error( `THREE.TSL: Invalid parameter for the type "${ type }".` );
 
 				return nodeObject( new ConstNode( 0, type ) );
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/30849

**Description**

Improves checks to prevent the renderer from freezing if the code has issues.
TSL normally replaces the faulty node with an "identity" value, regardless of the expected type.



#### Returning null value from a Fn()
```js
material.colorNode = Fn( () => { } )();
```
Now
<img width="530" height="30" alt="image" src="https://github.com/user-attachments/assets/62ed5a9f-8594-4d56-ad9c-590706618ba6" />

Old
<img width="726" height="116" alt="image" src="https://github.com/user-attachments/assets/9c17510e-f7a1-417c-a899-a7362168e82f" />

#### Return snippet verification for all nodes

```js
material.colorNode = vec3( Fn( () => { } )() );
```

Now
<img width="507" height="24" alt="image" src="https://github.com/user-attachments/assets/fb6b47a6-542e-41df-8ad3-15c31a0e50d5" />

Old
<img width="658" height="40" alt="image" src="https://github.com/user-attachments/assets/37941090-d698-4eaa-bb11-5d5b4b22afe2" />



