### PR TITLE
WebGPURenderer: Add warning when video textures with invalid color spaces are used.

### DIFF
--- a/src/renderers/common/Textures.js
+++ b/src/renderers/common/Textures.js
@@ -2,7 +2,8 @@ import DataMap from './DataMap.js';
 
 import { Vector3 } from '../../math/Vector3.js';
 import { DepthTexture } from '../../textures/DepthTexture.js';
-import { DepthStencilFormat, DepthFormat, UnsignedIntType, UnsignedInt248Type, UnsignedByteType, SRGBColorSpace } from '../../constants.js';
+import { DepthStencilFormat, DepthFormat, UnsignedIntType, UnsignedInt248Type, UnsignedByteType, SRGBTransfer } from '../../constants.js';
+import { ColorManagement } from '../../math/ColorManagement.js';
 
 const _size = /*@__PURE__*/ new Vector3();
 
@@ -328,9 +329,9 @@ class Textures extends DataMap {
 
 			//
 
-			if ( texture.isVideoTexture && texture.colorSpace !== SRGBColorSpace ) {
+			if ( texture.isVideoTexture && ColorManagement.getTransfer( texture.colorSpace ) !== SRGBTransfer ) {
 
-				console.warn( 'Textures: VideoTexture is rarely used with non-SRGB color space.' );
+				console.warn( 'Textures: VideoTexture only supports SRGBColorSpace.' );
 
 			}
 

--- a/src/renderers/common/Textures.js
+++ b/src/renderers/common/Textures.js
@@ -331,7 +331,7 @@ class Textures extends DataMap {
 
 			if ( texture.isVideoTexture && ColorManagement.getTransfer( texture.colorSpace ) !== SRGBTransfer ) {
 
-				console.warn( 'Textures: VideoTexture only supports SRGBColorSpace.' );
+				console.warn( 'WebGPURenderer: Video textures must use a color space with a sRGB transfer function, e.g. SRGBColorSpace.' );
 
 			}
 

--- a/src/renderers/common/Textures.js
+++ b/src/renderers/common/Textures.js
@@ -2,7 +2,7 @@ import DataMap from './DataMap.js';
 
 import { Vector3 } from '../../math/Vector3.js';
 import { DepthTexture } from '../../textures/DepthTexture.js';
-import { DepthStencilFormat, DepthFormat, UnsignedIntType, UnsignedInt248Type, UnsignedByteType } from '../../constants.js';
+import { DepthStencilFormat, DepthFormat, UnsignedIntType, UnsignedInt248Type, UnsignedByteType, SRGBColorSpace } from '../../constants.js';
 
 const _size = /*@__PURE__*/ new Vector3();
 
@@ -325,6 +325,14 @@ class Textures extends DataMap {
 			//
 
 			this.info.memory.textures ++;
+
+			//
+
+			if ( texture.isVideoTexture && texture.colorSpace !== SRGBColorSpace ) {
+
+				console.warn( 'Textures: VideoTexture is rarely used with non-SRGB color space.' );
+
+			}
 
 			// dispose
 


### PR DESCRIPTION
This PR continues the work from #31534