### PR TITLE
SSRNode: Improve performance and add quality setting.

### DIFF
--- a/examples/jsm/tsl/display/SSRNode.js
+++ b/examples/jsm/tsl/display/SSRNode.js
@@ -389,7 +389,7 @@ class SSRNode extends TempNode {
 			// it does not exceed d1 (the maximum ray extend)
 			Loop( totalStep, ( { i } ) => {
 
-				// advance on the ray by computing a new position in screen space
+				// advance on the ray by computing a new position in screen coordinates
 				const xy = vec2( d0.x.add( xSpan.mul( float( i ) ) ), d0.y.add( ySpan.mul( float( i ) ) ) ).toVar();
 
 				// stop processing if the new position lies outside of the screen
@@ -399,11 +399,10 @@ class SSRNode extends TempNode {
 
 				} );
 
-				// compute new uv, depth, viewZ and viewPosition for the new location on the ray
+				// compute new uv, depth, viewZ and viewPosition for the next fragment
 				const uvNode = xy.div( this._resolution );
 				const d = sampleDepth( uvNode ).toVar();
 				const vZ = getViewZ( d ).toVar();
-				const vP = getViewPosition( uvNode, d, this._cameraProjectionMatrixInverse ).toVar();
 
 				const viewReflectRayZ = float( 0 ).toVar();
 
@@ -427,6 +426,7 @@ class SSRNode extends TempNode {
 
 					// compute the distance of the new location to the ray in view space
 					// to clarify vP is the fragment's view position which is not an exact point on the ray
+					const vP = getViewPosition( uvNode, d, this._cameraProjectionMatrixInverse ).toVar();
 					const away = pointToLineDistance( vP, viewPosition, d1viewPosition ).toVar();
 
 					// compute the minimum thickness between the current fragment and its neighbor in the x-direction.

--- a/examples/jsm/tsl/display/SSRNode.js
+++ b/examples/jsm/tsl/display/SSRNode.js
@@ -399,7 +399,7 @@ class SSRNode extends TempNode {
 
 				} );
 
-				// compute new uv, depth, viewZ and viewPosition for the next fragment
+				// compute new uv, depth and viewZ for the next fragment
 				const uvNode = xy.div( this._resolution );
 				const d = sampleDepth( uvNode ).toVar();
 				const vZ = getViewZ( d ).toVar();

--- a/examples/webgpu_postprocessing_ssr.html
+++ b/examples/webgpu_postprocessing_ssr.html
@@ -44,6 +44,7 @@
 		import Stats from 'three/addons/libs/stats.module.js';
 
 		const params = {
+			quality: 0.5,
 			maxDistance: 0.5,
 			opacity: 1,
 			thickness: 0.015,
@@ -150,12 +151,11 @@
 			//
 
 			ssrPass = ssr( scenePassColor, scenePassDepth, customNormal, customMetalness, camera );
-			ssrPass.resolutionScale = 1.0;
 
 			// blend SSR over beauty
 
 			const outputNode = smaa( blendColor( scenePassColor, ssrPass.mul( scenePassMetalRough.g.oneMinus() ) ) );
-
+		
 			postProcessing.outputNode = outputNode;
 
 			//
@@ -174,6 +174,7 @@
 			// GUI
 
 			gui = new GUI();
+			gui.add( params, 'quality' ).min( 0 ).max( 1 ).onChange( updateParameters );
 			gui.add( params, 'maxDistance' ).min( 0 ).max( 1 ).onChange( updateParameters );
 			gui.add( params, 'opacity' ).min( 0 ).max( 1 ).onChange( updateParameters );
 			gui.add( params, 'thickness' ).min( 0 ).max( 0.05 ).onChange( updateParameters );
@@ -199,6 +200,7 @@
 
 		function updateParameters() {
 
+			ssrPass.quality.value = params.quality;
 			ssrPass.maxDistance.value = params.maxDistance;
 			ssrPass.opacity.value = params.opacity;
 			ssrPass.thickness.value = params.thickness;


### PR DESCRIPTION
Related issue: -

**Description**

The PR improves the performance of `SSRNode` by removing an outdated check inside the raymarching loop which was necessary for a Chromium bug. Since this bug is fixed since 133 (see [here](https://issues.chromium.org/issues/372714384#comment29)), I think it's safe to remove it. Another `if` can be removed by simplifying how the raymarching loop is configured. Removing both `if` statements produce some extra frames so this is a nice performance plus.

While reviewing other SSR implementations I have realized that `SSRNode` has a very high sampling rate inside the raymarching loop. Meaning it checks _every_ pixel that lies on a ray's path which is the maximum possible quality. No SRR implementation I have checked so far uses such a setting by default. An implementation for [Unity](https://github.com/Xerxes1138/UnitySSR/blob/14a711199eb68a08c120dbd76975f4b6759ca403/UnitySSR/Scripts/unitySSR.cs#L39-L41) uses `80` samples and a value range of `[20,80]` and [Lettier's](https://lettier.github.io/3d-game-shaders-for-beginners/screen-space-reflection.html) approach uses a scaling factor in the range `[0,1]`. I have adapted this approach to `SSRNode` with the same default value of `0.5`. That means only half of the pixels on the ray are processed. That setting is a uniform so it is configurable on app level. Even with `0.5`, you barely see a quality difference. However, in a performance restricted test with a 5K resolution, performance went up from 29 to 52 FPS. 

You can explore the new `quality` parameter in the updated example. Below is the one in production for comparison:

https://rawcdn.githack.com/mrdoob/three.js/75456f3498d9e213fbfe282d2cafda5cb4035cf8/examples/webgpu_postprocessing_ssr.html
https://threejs.org/examples/webgpu_postprocessing_ssr

I'm going to invest more time in `SSRNode` since there is still a lot of room for improvements. I'd like to test the raymarching loop from the Unity effect which works a bit different than ours. Besides, I've seen it supports mipmaps which means you can create blurred samples of the SSR reflections and then pick a mip based on the fragment's roughness. That is a similar approach like PMREM. Since this is quite heavy, it's an optional feature but of course worth checking out. Another thing is that some SSR implementations also have a temporal component which means they use a jitter in their ray marching process to produce different SSR reflections over time. The results are then accumulate similar to TRAA. There are different strategies of implementing such a feature and some of them are quite complex (e.g. "Stochastic Screen-Space Reflections") but it is definitely worth investigating.