### PR TITLE
Material: Add missing map properties to `toJSON()`.

### DIFF
--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -664,6 +664,18 @@ class Material extends EventDispatcher {
 
 		}
 
+		if ( this.sheenColorMap && this.sheenColorMap.isTexture ) {
+
+			data.sheenColorMap = this.sheenColorMap.toJSON( meta ).uuid;
+
+		}
+
+		if ( this.sheenRoughnessMap && this.sheenRoughnessMap.isTexture ) {
+
+			data.sheenRoughnessMap = this.sheenRoughnessMap.toJSON( meta ).uuid;
+
+		}
+
 		if ( this.dispersion !== undefined ) data.dispersion = this.dispersion;
 
 		if ( this.iridescence !== undefined ) data.iridescence = this.iridescence;


### PR DESCRIPTION
Fixed #31577.

**Description**

The PR adds the missing map properties `sheenColorMap` and `sheenRoughnessMap` to `toJSON()`.

Since both properties are already supported in `MaterialLoader`, serialization/deserialization should work now as expected.
