### PR TITLE
TSL Transpiler: Fix addition of `Before` for non `++` or `--`

### DIFF
--- a/examples/jsm/transpiler/TSLEncoder.js
+++ b/examples/jsm/transpiler/TSLEncoder.js
@@ -340,7 +340,7 @@ class TSLEncoder {
 
 			if ( node.hasAssignment ) {
 
-				if ( node.after === false ) {
+				if ( node.after === false && ( node.type === '++' || node.type === '--' ) ) {
 
 					type += 'Before';
 


### PR DESCRIPTION
Fixes https://github.com/mrdoob/three.js/issues/31567

**Description**

Fix incorrect addition of `Before` for operations other than `++` or `--`.
