### PR TITLE
TSL Transpiler: Remove the need for `.toVar()`

### DIFF
--- a/examples/jsm/transpiler/TSLEncoder.js
+++ b/examples/jsm/transpiler/TSLEncoder.js
@@ -665,15 +665,7 @@ ${ this.tab }} )`;
 
 			}
 
-			if ( node.linker.assignments.length > 0 ) {
-
-				varStr += ' = ' + valueStr + '.toVar()';
-
-			} else {
-
-				varStr += ' = ' + valueStr;
-
-			}
+			varStr += ' = ' + valueStr;
 
 		} else {
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/31459

**Description**

The need for `.toVar()` became obsolete after PR https://github.com/mrdoob/three.js/pull/31459.
