### PR TITLE
WebGLBackend: Honor `layerUpdates` for array textures.

### DIFF
--- a/src/renderers/webgl-fallback/utils/WebGLTextureUtils.js
+++ b/src/renderers/webgl-fallback/utils/WebGLTextureUtils.js
@@ -570,16 +570,21 @@ class WebGLTextureUtils {
 				const layerByteLength = getByteLength( image.width, image.height, texture.format, texture.type );
 
 				for ( const layerIndex of texture.layerUpdates ) {
+
 					const layerData = image.data.subarray(
 						layerIndex * layerByteLength / image.data.BYTES_PER_ELEMENT,
 						( layerIndex + 1 ) * layerByteLength / image.data.BYTES_PER_ELEMENT
 					);
 					gl.texSubImage3D( gl.TEXTURE_2D_ARRAY, 0, 0, 0, layerIndex, image.width, image.height, 1, glFormat, glType, layerData );
+
 				}
 
 				texture.clearLayerUpdates();
+
 			} else {
+
 				gl.texSubImage3D( gl.TEXTURE_2D_ARRAY, 0, 0, 0, 0, image.width, image.height, image.depth, glFormat, glType, image.data );
+
 			}
 
 		} else if ( texture.isData3DTexture ) {

--- a/src/renderers/webgl-fallback/utils/WebGLTextureUtils.js
+++ b/src/renderers/webgl-fallback/utils/WebGLTextureUtils.js
@@ -1,5 +1,6 @@
 import { LinearFilter, LinearMipmapLinearFilter, LinearMipmapNearestFilter, NearestFilter, NearestMipmapLinearFilter, NearestMipmapNearestFilter, FloatType, MirroredRepeatWrapping, ClampToEdgeWrapping, RepeatWrapping, NeverCompare, AlwaysCompare, LessCompare, LessEqualCompare, EqualCompare, GreaterEqualCompare, GreaterCompare, NotEqualCompare, NoColorSpace, LinearTransfer, SRGBTransfer } from '../../../constants.js';
 import { ColorManagement } from '../../../math/ColorManagement.js';
+import { getByteLength } from '../../../extras/TextureUtils.js';
 
 let initialized = false, wrappingToGL, filterToGL, compareToGL;
 
@@ -564,7 +565,22 @@ class WebGLTextureUtils {
 
 			const image = options.image;
 
-			gl.texSubImage3D( gl.TEXTURE_2D_ARRAY, 0, 0, 0, 0, image.width, image.height, image.depth, glFormat, glType, image.data );
+			if ( texture.layerUpdates.size > 0 ) {
+
+				const layerByteLength = getByteLength( image.width, image.height, texture.format, texture.type );
+
+				for ( const layerIndex of texture.layerUpdates ) {
+					const layerData = image.data.subarray(
+						layerIndex * layerByteLength / image.data.BYTES_PER_ELEMENT,
+						( layerIndex + 1 ) * layerByteLength / image.data.BYTES_PER_ELEMENT
+					);
+					gl.texSubImage3D( gl.TEXTURE_2D_ARRAY, 0, 0, 0, layerIndex, image.width, image.height, 1, glFormat, glType, layerData );
+				}
+
+				texture.clearLayerUpdates();
+			} else {
+				gl.texSubImage3D( gl.TEXTURE_2D_ARRAY, 0, 0, 0, 0, image.width, image.height, image.depth, glFormat, glType, image.data );
+			}
 
 		} else if ( texture.isData3DTexture ) {
 


### PR DESCRIPTION
Related issue: none, see below

**Description**

The WebGL fallback always uploads the complete array texture. That's too slow when I only change some layers.

The PR enables partial uploads using `texture.layerUpdates`.