### PR TITLE
TSL: Improve error message for operators with `void` values

### DIFF
--- a/src/nodes/math/OperatorNode.js
+++ b/src/nodes/math/OperatorNode.js
@@ -103,9 +103,10 @@ class OperatorNode extends TempNode {
 	 * and the input node types.
 	 *
 	 * @param {NodeBuilder} builder - The current node builder.
+	 * @param {?string} [output=null] - The output type.
 	 * @return {string} The node type.
 	 */
-	getNodeType( builder ) {
+	getNodeType( builder, output = null ) {
 
 		const op = this.op;
 
@@ -117,7 +118,7 @@ class OperatorNode extends TempNode {
 
 		if ( typeA === 'void' || typeB === 'void' ) {
 
-			return 'void';
+			return output || 'void';
 
 		} else if ( op === '%' ) {
 
@@ -193,7 +194,7 @@ class OperatorNode extends TempNode {
 
 		const { aNode, bNode } = this;
 
-		const type = this.getNodeType( builder );
+		const type = this.getNodeType( builder, output );
 
 		let typeA = null;
 		let typeB = null;


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/30849

**Description**

Improve error message for operators with `void` values.

```js
material.colorNode = add( 1, Fn( () => {} )() );
```

### New
<img width="535" height="25" alt="image" src="https://github.com/user-attachments/assets/e155dfe0-7399-4c73-afde-52cb33705830" />

### Old
<img width="746" height="112" alt="image" src="https://github.com/user-attachments/assets/2535ffc3-016a-4c2c-b9b2-9bcfd9249eb5" />

