### PR TITLE
GLTFExporter: Make `getToBlobPromise()` more robust.

### DIFF
--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -543,7 +543,8 @@ function getCanvas() {
 
 function getToBlobPromise( canvas, mimeType ) {
 
-	if ( canvas.toBlob !== undefined ) {
+	// fix for Firefox 141.0.2+ not executing resolve function within the toBlob method of OffscreenCanvas
+	if ( canvas.toBlob !== undefined && !(canvas instanceof OffscreenCanvas)) {
 
 		return new Promise( ( resolve ) => canvas.toBlob( resolve, mimeType ) );
 

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -544,7 +544,7 @@ function getCanvas() {
 function getToBlobPromise( canvas, mimeType ) {
 
 	// fix for Firefox 141.0.2+ not executing resolve function within the toBlob method of OffscreenCanvas
-	if ( canvas.toBlob !== undefined && !(canvas instanceof OffscreenCanvas)) {
+	if ( ( canvas instanceof OffscreenCanvas ) === false )
 
 		return new Promise( ( resolve ) => canvas.toBlob( resolve, mimeType ) );
 

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -543,8 +543,7 @@ function getCanvas() {
 
 function getToBlobPromise( canvas, mimeType ) {
 
-	// fix for Firefox 141.0.2+ not executing resolve function within the toBlob method of OffscreenCanvas
-	if ( ( canvas instanceof OffscreenCanvas ) === false )
+	if ( ( canvas instanceof OffscreenCanvas ) === false ) {
 
 		return new Promise( ( resolve ) => canvas.toBlob( resolve, mimeType ) );
 

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -543,32 +543,36 @@ function getCanvas() {
 
 function getToBlobPromise( canvas, mimeType ) {
 
-	if ( ( canvas instanceof OffscreenCanvas ) === false ) {
+	if ( typeof OffscreenCanvas !== 'undefined' && canvas instanceof OffscreenCanvas ) {
+
+		let quality;
+
+		// Blink's implementation of convertToBlob seems to default to a quality level of 100%
+		// Use the Blink default quality levels of toBlob instead so that file sizes are comparable.
+		if ( mimeType === 'image/jpeg' ) {
+
+			quality = 0.92;
+
+		} else if ( mimeType === 'image/webp' ) {
+
+			quality = 0.8;
+
+		}
+
+		return canvas.convertToBlob( {
+
+			type: mimeType,
+			quality: quality
+
+		} );
+
+	} else {
+
+		// HTMLCanvasElement code path
 
 		return new Promise( ( resolve ) => canvas.toBlob( resolve, mimeType ) );
 
 	}
-
-	let quality;
-
-	// Blink's implementation of convertToBlob seems to default to a quality level of 100%
-	// Use the Blink default quality levels of toBlob instead so that file sizes are comparable.
-	if ( mimeType === 'image/jpeg' ) {
-
-		quality = 0.92;
-
-	} else if ( mimeType === 'image/webp' ) {
-
-		quality = 0.8;
-
-	}
-
-	return canvas.convertToBlob( {
-
-		type: mimeType,
-		quality: quality
-
-	} );
 
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "three",
-  "version": "0.179.2",
+  "version": "0.179.1",
   "description": "JavaScript 3D library",
   "type": "module",
   "main": "./build/three.cjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "three",
-  "version": "0.179.1",
+  "version": "0.179.2",
   "description": "JavaScript 3D library",
   "type": "module",
   "main": "./build/three.cjs",


### PR DESCRIPTION
fix for Firefox 141.0.2+ not resolving promise with Offscreencanvas when exporting GLTF/GLB images

Fixed #31588 

**Description**

- modified code not to use ```toBlob``` (deprecated) when canvas is an instance of Offscreencanvas to prevent returned promise from never resolving.