### PR TITLE
TSL: Fix missing `getMemberType()` in `context()`

### DIFF
--- a/src/nodes/core/ContextNode.js
+++ b/src/nodes/core/ContextNode.js
@@ -78,6 +78,19 @@ class ContextNode extends Node {
 
 	}
 
+	/**
+	 * This method is overwritten to ensure it returns the member type of {@link ContextNode#node}.
+	 *
+	 * @param {NodeBuilder} builder - The current node builder.
+	 * @param {string} name - The member name.
+	 * @returns {string} The member type.
+	 */
+	getMemberType( builder, name ) {
+
+		return this.node.getMemberType( builder, name );
+
+	}
+
 	analyze( builder ) {
 
 		const previousContext = builder.getContext();


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/31596

**Description**

Fix missing `getMemberType()` in `context()`, it's not fix the issue totaly.