### PR TITLE
WebGPURenderer: Fix broken worker support.

### DIFF
--- a/src/renderers/common/Textures.js
+++ b/src/renderers/common/Textures.js
@@ -376,7 +376,7 @@ class Textures extends DataMap {
 
 			if ( image.image !== undefined ) image = image.image;
 
-			if ( image instanceof HTMLVideoElement ) {
+			if ( ( typeof HTMLVideoElement !== 'undefined' ) && ( image instanceof HTMLVideoElement ) ) {
 
 				target.width = image.videoWidth || 1;
 				target.height = image.videoHeight || 1;

--- a/src/textures/Source.js
+++ b/src/textures/Source.js
@@ -83,7 +83,7 @@ class Source {
 
 		const data = this.data;
 
-		if ( data instanceof HTMLVideoElement ) {
+		if ( ( typeof HTMLVideoElement !== 'undefined' ) && ( data instanceof HTMLVideoElement ) ) {
 
 			target.set( data.videoWidth, data.videoHeight, 0 );
 


### PR DESCRIPTION
Fixed #31605.

**Description**

We must guard all `HTMLVideoElement` instance checks with `typeof HTMLVideoElement !== 'undefined'` otherwise the renderer breaks in environments where `HTMLVideoElement` does not exist.
