### PR TITLE
TSL: Fix instance buffer size in `instance()`.

### DIFF
--- a/src/nodes/accessors/InstanceNode.js
+++ b/src/nodes/accessors/InstanceNode.js
@@ -109,7 +109,9 @@ class InstanceNode extends Node {
 	 */
 	setup( builder ) {
 
-		const { count, instanceMatrix, instanceColor } = this;
+		const { instanceMatrix, instanceColor } = this;
+
+		const { count } = instanceMatrix;
 
 		let { instanceMatrixNode, instanceColorNode } = this;
 


### PR DESCRIPTION
**Bug Description**

Setting `mesh.count` is currently broken in the webgl fallback. Instance matrices are not added properly.

**Explanation**
I started with one instance, built the material and wanted to add more. They won't show up.

`InstancedMesh` defines two counts.
* `this.instanceMatrix.count`: max instance count.
* `this.count` current instance count, may be lower than max.

The attached PR defines a buffer big enough for all instances.