### PR TITLE
DragControls: Fix firing events when actions are disabled.

### DIFF
--- a/examples/jsm/controls/DragControls.js
+++ b/examples/jsm/controls/DragControls.js
@@ -305,6 +305,7 @@ function onPointerMove( event ) {
 			if ( raycaster.ray.intersectPlane( _plane, _intersection ) ) {
 
 				_selected.position.copy( _intersection.sub( _offset ).applyMatrix4( _inverseMatrix ) );
+				this.dispatchEvent( { type: 'drag', object: _selected } );
 
 			}
 
@@ -313,10 +314,9 @@ function onPointerMove( event ) {
 			_diff.subVectors( _pointer, _previousPointer ).multiplyScalar( this.rotateSpeed );
 			_selected.rotateOnWorldAxis( _up, _diff.x );
 			_selected.rotateOnWorldAxis( _right.normalize(), - _diff.y );
+			this.dispatchEvent( { type: 'drag', object: _selected } );
 
 		}
-
-		this.dispatchEvent( { type: 'drag', object: _selected } );
 
 		_previousPointer.copy( _pointer );
 
@@ -414,20 +414,20 @@ function onPointerDown( event ) {
 
 				_inverseMatrix.copy( _selected.parent.matrixWorld ).invert();
 				_offset.copy( _intersection ).sub( _worldPosition.setFromMatrixPosition( _selected.matrixWorld ) );
+				domElement.style.cursor = 'move';
+				this.dispatchEvent( { type: 'dragstart', object: _selected } );
 
 			} else if ( this.state === STATE.ROTATE ) {
 
 				// the controls only support Y+ up
 				_up.set( 0, 1, 0 ).applyQuaternion( camera.quaternion ).normalize();
 				_right.set( 1, 0, 0 ).applyQuaternion( camera.quaternion ).normalize();
+				domElement.style.cursor = 'move';
+				this.dispatchEvent( { type: 'dragstart', object: _selected } );
 
 			}
 
 		}
-
-		domElement.style.cursor = 'move';
-
-		this.dispatchEvent( { type: 'dragstart', object: _selected } );
 
 	}
 


### PR DESCRIPTION
**Description**

I tried to disable the middle mouse button in DragControls.
```
dragControls.mouseButtons.MIDDLE = null;
```

While objects cannot be dragged as expected, the event `dragstart` is still fired and the mouse cursor changes as if dragging was enabled.

Try it in this fiddle
https://jsfiddle.net/qbsyrh1w/

The PR proposes a fix that doesn't emit events when the action is disabled.