### PR TITLE
Docs: Improve Chinese translation.

### DIFF
--- a/docs/examples/zh/loaders/FontLoader.html
+++ b/docs/examples/zh/loaders/FontLoader.html
@@ -34,7 +34,7 @@
 		<code>
 		const loader = new FontLoader();
 		const font = loader.load(
-			// 资源URL
+			// 资源URL，需在本地添加静态资源（根目录/public/fonts/helvetiker_bold.typeface.json）
 			'fonts/helvetiker_bold.typeface.json',
 
 			// onLoad回调


### PR DESCRIPTION
Add more detailed explanations to resolve some usage doubts.

Related issue: #XXXX

**Description**

I encountered confusion when importing fonts while learning about FontLoader. I directly copied the code, but it resulted in errors and failed to import the font. After checking, I found that if I don't import the font via import and instead use the method shown in the examples, I need to copy the corresponding font files from the official website to my project for a successful import. Therefore, I updated the instructions to prevent other learners from falling into the same confusion.
[两种导入方式，Two import methods.md](https://github.com/user-attachments/files/21705864/Two.import.methods.md)

<img width="944" height="85" alt="截屏2025-08-10 22 44 19" src="https://github.com/user-attachments/assets/8f639815-b453-4167-b5ef-b5158ff48b41" />
