### PR TITLE
WebXR: Fix inverted hand models 

### DIFF
--- a/examples/jsm/webxr/XRHandModelFactory.js
+++ b/examples/jsm/webxr/XRHandModelFactory.js
@@ -179,16 +179,12 @@ class XRHandModelFactory {
 
 			}
 
-			controller.visible = true;
-
 		} );
 
 		controller.addEventListener( 'disconnected', () => {
 
-			controller.visible = false;
-			// handModel.motionController = null;
-			// handModel.remove( scene );
-			// scene = null;
+			handModel.clear();
+			handModel.motionController = null;
 
 		} );
 


### PR DESCRIPTION
**Description**

`XRHandMeshModel` sometimes becomes inverted when the hand models are created using `XRHandModelFactory`.  

This doesn't happen when using `OculusHandModel`, so its method used in `controller.addEventListener('disconnected')` is used in `XRHandModelFactory`.

**Reproduction**

Device: Meta Quest 2, 3, 3s

Go to [webxr_vr_handinput_profiles.html](https://threejs.org/examples/?q=xr#webxr_vr_handinput_profiles) and select the mesh model.  Then place both of your hands behind your head.  Now move only one hand into view in front of your face.  It should look inverted. 

Note: 
Try your left hand first to see if it gets inverted. If not, repeat by placing both hands behind your head and try your right. It seems the hand that gets inverted depends on the order of initialization.     