### PR TITLE
Sprite: Improve JSDoc.

### DIFF
--- a/src/objects/Sprite.js
+++ b/src/objects/Sprite.js
@@ -48,7 +48,7 @@ class Sprite extends Object3D {
 	/**
 	 * Constructs a new sprite.
 	 *
-	 * @param {SpriteMaterial | SpriteNodeMaterial} [material] - The sprite material.
+	 * @param {(SpriteMaterial|SpriteNodeMaterial)} [material] - The sprite material.
 	 */
 	constructor( material = new SpriteMaterial() ) {
 
@@ -94,7 +94,7 @@ class Sprite extends Object3D {
 		/**
 		 * The sprite material.
 		 *
-		 * @type {SpriteMaterial | SpriteNodeMaterial}
+		 * @type {(SpriteMaterial|SpriteNodeMaterial)}
 		 */
 		this.material = material;
 

--- a/src/objects/Sprite.js
+++ b/src/objects/Sprite.js
@@ -48,7 +48,7 @@ class Sprite extends Object3D {
 	/**
 	 * Constructs a new sprite.
 	 *
-	 * @param {SpriteMaterial} [material] - The sprite material.
+	 * @param {SpriteMaterial | SpriteNodeMaterial} [material] - The sprite material.
 	 */
 	constructor( material = new SpriteMaterial() ) {
 
@@ -94,7 +94,7 @@ class Sprite extends Object3D {
 		/**
 		 * The sprite material.
 		 *
-		 * @type {SpriteMaterial}
+		 * @type {SpriteMaterial | SpriteNodeMaterial}
 		 */
 		this.material = material;
 


### PR DESCRIPTION
Related issue: https://github.com/three-types/three-ts-types/pull/1716

**Description**

Updates the JSDoc for Sprite to account for situations where THREE.Sprite will take classes derived from SpriteNodeMaterial, such as PointsNodeMaterial in webgpu_skinning_points. 