### PR TITLE
Examples: Clean up

### DIFF
--- a/examples/webgl_renderer_pathtracer.html
+++ b/examples/webgl_renderer_pathtracer.html
@@ -94,7 +94,7 @@
 				camera.position.set( 150, 200, 250 );
 
 				// initialize the renderer
-				renderer = new THREE.WebGLRenderer( { antialias: true, alpha: true, preserveDrawingBuffer: true, premultipliedAlpha: false } );
+				renderer = new THREE.WebGLRenderer( { antialias: true, alpha: true, preserveDrawingBuffer: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;


### PR DESCRIPTION
Users should not be setting `premultipliedAlpha` to `false` in the renderer's constructor, unless they really know what they are doing.

I assume this PR is OK, but @gkjohnson should confirm.