### PR TITLE
WebGPURenderer: Support ExternalTexture with GPUTexture

### DIFF
--- a/src/Three.Core.js
+++ b/src/Three.Core.js
@@ -34,6 +34,7 @@ export { CompressedCubeTexture } from './textures/CompressedCubeTexture.js';
 export { CubeTexture } from './textures/CubeTexture.js';
 export { CanvasTexture } from './textures/CanvasTexture.js';
 export { DepthTexture } from './textures/DepthTexture.js';
+export { ExternalTexture } from './textures/ExternalTexture.js';
 export { Texture } from './textures/Texture.js';
 export * from './geometries/Geometries.js';
 export * from './materials/Materials.js';

--- a/src/renderers/common/Textures.js
+++ b/src/renderers/common/Textures.js
@@ -250,7 +250,7 @@ class Textures extends DataMap {
 
 		//
 
-		if ( isRenderTarget || texture.isStorageTexture === true ) {
+		if ( isRenderTarget || texture.isStorageTexture === true || texture.isExternalTexture === true ) {
 
 			backend.createSampler( texture );
 			backend.createTexture( texture, options );

--- a/src/renderers/webgpu/utils/WebGPUTextureUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUTextureUtils.js
@@ -187,6 +187,15 @@ class WebGPUTextureUtils {
 
 		}
 
+		if ( texture.isExternalTexture ) {
+
+			textureData.texture = texture.sourceTexture;
+			textureData.initialized = true;
+
+			return;
+
+		}
+
 		if ( options.needsMipmaps === undefined ) options.needsMipmaps = false;
 		if ( options.levels === undefined ) options.levels = 1;
 		if ( options.depth === undefined ) options.depth = 1;

--- a/src/textures/ExternalTexture.js
+++ b/src/textures/ExternalTexture.js
@@ -1,12 +1,13 @@
 import { Texture } from './Texture.js';
 
 /**
- * Represents a texture created externally from the renderer context.
+ * Represents a texture created externally with the same renderer context.
  *
  * This may be a texture from a protected media stream, device camera feed,
  * or other data feeds like a depth sensor.
  *
- * Note that this class is only supported in {@link WebGLRenderer} right now.
+ * Note that this class is only supported in {@link WebGLRenderer}, and in
+ * the {@link WebGPURenderer} WebGPU backend.
  *
  * @augments Texture
  */

--- a/src/textures/ExternalTexture.js
+++ b/src/textures/ExternalTexture.js
@@ -15,7 +15,7 @@ class ExternalTexture extends Texture {
 	/**
 	 * Creates a new raw texture.
 	 *
-	 * @param {?WebGLTexture} [sourceTexture=null] - The external texture.
+	 * @param {?(WebGLTexture|GPUTexture)} [sourceTexture=null] - The external texture.
 	 */
 	constructor( sourceTexture = null ) {
 
@@ -24,7 +24,7 @@ class ExternalTexture extends Texture {
 		/**
 		 * The external source texture.
 		 *
-		 * @type {?WebGLTexture}
+		 * @type {?(WebGLTexture|GPUTexture)}
 		 * @default null
 		 */
 		this.sourceTexture = sourceTexture;


### PR DESCRIPTION
Related issue: 

- https://github.com/mrdoob/three.js/issues/31595

Adds support for initializing a THREE.ExternalTexture instance with a GPUTexture created by the WebGPU renderer's own device. Provides a fast path for using textures created by other libraries (example: https://ludicon.com/sparkjs/) without extra copies.

Example:

```javascript
import { Spark } from '@ludicon/spark.js';

const gpuTexture = await spark.encodeTexture( texturePath, { mips: true, srgb: true, flipY: true } );

const texture = new THREE.ExternalTexture( gpuTexture );
```

On local testing, our `textures/uv_grid_opengl.jpg` is compressed to BC7 in 0.1 ms (!) on an M1 device.

~~The code changes required are trivial, but I'm not sure if using THREE.ExternalTexture as proposed in #31595 is semantically right — this is the opposite of a "texture created externally from the renderer context" as the JSDoc suggests... Would it make more sense to use THREE.CompressedTexture? A new THREE.InternalTexture or THREE.GPUTexture class? My (slight) preference would be to keep using THREE.ExternalTexture, but to update the documentation to say "externally from three.js" instead.~~