### PR TITLE
XRManager: Fix typo in getBinding jsdoc

### DIFF
--- a/src/renderers/common/XRManager.js
+++ b/src/renderers/common/XRManager.js
@@ -592,12 +592,12 @@ class XRManager extends EventDispatcher {
 
 
 	/**
-	 * Return the current XR binding.
+	 * Returns the current XR binding.
 	 *
 	 * Creates a new binding if needed and the browser is
 	 * capable of doing so.
 	 *
-	 * @return {?XRWebGLBinding} The XR binding. Returns `null` if a binding cannot be crated.
+	 * @return {?XRWebGLBinding} The XR binding. Returns `null` if one cannot be created.
 	 */
 	getBinding() {
 


### PR DESCRIPTION
Fix getBinding jsdoc in XRManager to be the same as the one in WebXRManager, that was missed in the review of #31648