### PR TITLE
TSL: Add `roughness` as an independent parameter for `ssr()` and move camera to optional.

### DIFF
--- a/examples/jsm/tsl/display/SSRNode.js
+++ b/examples/jsm/tsl/display/SSRNode.js
@@ -147,7 +147,7 @@ class SSRNode extends TempNode {
 
 			} else {
 
-				throw Error( 'THREE.TSL: No camera found. ssr() requires a camera.' );
+				throw new Error( 'THREE.TSL: No camera found. ssr() requires a camera.' );
 
 			}
 

--- a/examples/jsm/tsl/display/SSRNode.js
+++ b/examples/jsm/tsl/display/SSRNode.js
@@ -147,7 +147,7 @@ class SSRNode extends TempNode {
 
 			} else {
 
-				console.error( 'THREE.TSL: No camera found. ssr() requires a camera.' );
+				throw Error( 'THREE.TSL: No camera found. ssr() requires a camera.' );
 
 			}
 

--- a/examples/jsm/tsl/display/SSRNode.js
+++ b/examples/jsm/tsl/display/SSRNode.js
@@ -190,7 +190,7 @@ class SSRNode extends TempNode {
 		 * @private
 		 * @type {UniformNode<bool>}
 		 */
-		this._isPerspectiveCamera = uniform( camera.isPerspectiveCamera ? 1 : 0 );
+		this._isPerspectiveCamera = uniform( camera.isPerspectiveCamera );
 
 		/**
 		 * The resolution of the pass.
@@ -448,7 +448,7 @@ class SSRNode extends TempNode {
 			const d1viewPosition = viewPosition.add( viewReflectDir.mul( maxReflectRayLen ) ).toVar();
 
 			// check if d1viewPosition lies behind the camera near plane
-			If( this._isPerspectiveCamera.equal( float( 1 ) ).and( d1viewPosition.z.greaterThan( this._cameraNear.negate() ) ), () => {
+			If( this._isPerspectiveCamera.and( d1viewPosition.z.greaterThan( this._cameraNear.negate() ) ), () => {
 
 				// if so, ensure d1viewPosition is clamped on the near plane.
 				// this prevents artifacts during the ray marching process
@@ -507,7 +507,7 @@ class SSRNode extends TempNode {
 				const s = xy.sub( d0 ).length().div( totalLen );
 
 				// depending on the camera type, we now compute the z-coordinate of the reflected ray at the current step in view space
-				If( this._isPerspectiveCamera.equal( float( 1 ) ), () => {
+				If( this._isPerspectiveCamera, () => {
 
 					const recipVPZ = float( 1 ).div( viewPosition.z ).toVar();
 					viewReflectRayZ.assign( float( 1 ).div( recipVPZ.add( s.mul( float( 1 ).div( d1viewPosition.z ).sub( recipVPZ ) ) ) ) );

--- a/examples/jsm/tsl/display/SSRNode.js
+++ b/examples/jsm/tsl/display/SSRNode.js
@@ -29,10 +29,10 @@ class SSRNode extends TempNode {
 	 * @param {Node<float>} depthNode - A node that represents the beauty pass's depth.
 	 * @param {Node<vec3>} normalNode - A node that represents the beauty pass's normals.
 	 * @param {Node<float>} metalnessNode - A node that represents the beauty pass's metalness.
-	 * @param {Camera} camera - The camera the scene is rendered with.
 	 * @param {?Node<float>} [roughnessNode=null] - A node that represents the beauty pass's roughness.
+	 * @param {?Camera} [camera=null] - The camera the scene is rendered with.
 	 */
-	constructor( colorNode, depthNode, normalNode, metalnessNode, camera, roughnessNode = null ) {
+	constructor( colorNode, depthNode, normalNode, metalnessNode, roughnessNode = null, camera = null ) {
 
 		super( 'vec4' );
 
@@ -63,13 +63,6 @@ class SSRNode extends TempNode {
 		 * @type {Node<float>}
 		 */
 		this.metalnessNode = metalnessNode;
-
-		/**
-		 * The camera the scene is rendered with.
-		 *
-		 * @type {Camera}
-		 */
-		this.camera = camera;
 
 		/**
 		 * Whether the SSR reflections should be blurred or not. Blurring is a costly
@@ -143,6 +136,29 @@ class SSRNode extends TempNode {
 		 * @type {UniformNode<int>}
 		 */
 		this.blurQuality = uniform( 2 );
+
+		//
+
+		if ( camera === null ) {
+
+			if ( this.colorNode.passNode && this.colorNode.passNode.isPassNode === true ) {
+
+				camera = this.colorNode.passNode.camera;
+
+			} else {
+
+				console.error( 'THREE.TSL: No camera found. ssr() requires a camera.' );
+
+			}
+
+		}
+
+		/**
+		 * The camera the scene is rendered with.
+		 *
+		 * @type {Camera}
+		 */
+		this.camera = camera;
 
 		/**
 		 * The spread of the blur. Automatically set when generating mips.
@@ -631,8 +647,8 @@ export default SSRNode;
  * @param {Node<float>} depthNode - A node that represents the beauty pass's depth.
  * @param {Node<vec3>} normalNode - A node that represents the beauty pass's normals.
  * @param {Node<float>} metalnessNode - A node that represents the beauty pass's metalness.
- * @param {Camera} camera - The camera the scene is rendered with.
- * @param {Node<float>} roughnessNode - A node that represents the beauty pass's roughness.
+ * @param {?Node<float>} [roughnessNode=null] - A node that represents the beauty pass's roughness.
+ * @param {?Camera} [camera=null] - The camera the scene is rendered with.
  * @returns {SSRNode}
  */
-export const ssr = ( colorNode, depthNode, normalNode, metalnessNode, camera, roughnessNode ) => nodeObject( new SSRNode( nodeObject( colorNode ), nodeObject( depthNode ), nodeObject( normalNode ), nodeObject( metalnessNode ), camera, nodeObject( roughnessNode ) ) );
+export const ssr = ( colorNode, depthNode, normalNode, metalnessNode, roughnessNode = null, camera = null ) => nodeObject( new SSRNode( nodeObject( colorNode ), nodeObject( depthNode ), nodeObject( normalNode ), nodeObject( metalnessNode ), nodeObject( roughnessNode ), camera ) );

--- a/examples/jsm/tsl/display/SSRNode.js
+++ b/examples/jsm/tsl/display/SSRNode.js
@@ -425,7 +425,6 @@ class SSRNode extends TempNode {
 
 		const ssr = Fn( () => {
 
-			const metalness = this.metalnessNode.sample( uvNode ).r;
 
 			// fragments with no metalness do not reflect their environment
 			metalness.equal( 0.0 ).discard();

--- a/examples/jsm/tsl/display/SSRNode.js
+++ b/examples/jsm/tsl/display/SSRNode.js
@@ -259,7 +259,7 @@ class SSRNode extends TempNode {
 		if ( this.roughnessNode !== null ) {
 
 			const mips = this._blurRenderTarget.texture.mipmaps.length - 1;
-			const lod = this.roughnessNode.mul( mips ).clamp( 0, mips );
+			const lod = float( this.roughnessNode ).mul( mips ).clamp( 0, mips );
 
 			blurredTextureNode = passTexture( this, this._blurRenderTarget.texture ).level( lod );
 
@@ -425,7 +425,7 @@ class SSRNode extends TempNode {
 
 		const ssr = Fn( () => {
 
-			const metalness = this.metalnessNode;
+			const metalness = float( this.metalnessNode );
 
 			// fragments with no metalness do not reflect their environment
 			metalness.equal( 0.0 ).discard();

--- a/examples/jsm/tsl/display/SSRNode.js
+++ b/examples/jsm/tsl/display/SSRNode.js
@@ -425,6 +425,7 @@ class SSRNode extends TempNode {
 
 		const ssr = Fn( () => {
 
+			const metalness = this.metalnessNode;
 
 			// fragments with no metalness do not reflect their environment
 			metalness.equal( 0.0 ).discard();

--- a/examples/webgpu_postprocessing_ssr.html
+++ b/examples/webgpu_postprocessing_ssr.html
@@ -148,7 +148,7 @@
 
 			//
 
-			ssrPass = ssr( scenePassColor, scenePassDepth, sceneNormal, scenePassMetalRough.r, camera, scenePassMetalRough.g );
+			ssrPass = ssr( scenePassColor, scenePassDepth, sceneNormal, scenePassMetalRough.r, scenePassMetalRough.g );
 
 			// blend SSR over beauty
 

--- a/examples/webgpu_postprocessing_ssr.html
+++ b/examples/webgpu_postprocessing_ssr.html
@@ -146,15 +146,15 @@
 
 			} );
 
-			const sceneMetalness = sample( ( uv ) => {
+			const sceneMetalness = sample( () => {
 
-				return scenePassMetalRough.sample( uv ).r;
+				return scenePassMetalRough.r;
 
 			} );
 
-			const sceneRoughness = sample( ( uv ) => {
+			const sceneRoughness = sample( () => {
 
-				return scenePassMetalRough.sample( uv ).g;
+				return scenePassMetalRough.g;
 
 			} );
 

--- a/examples/webgpu_postprocessing_ssr.html
+++ b/examples/webgpu_postprocessing_ssr.html
@@ -140,15 +140,27 @@
 			const metalRoughTexture = scenePass.getTexture( 'metalrough' );
 			metalRoughTexture.type = THREE.UnsignedByteType;
 
-			const customNormal = sample( ( uv ) => {
+			const sceneNormal = sample( ( uv ) => {
 
 				return colorToDirection( scenePassNormal.sample( uv ) );
 
 			} );
 
+			const sceneMetalness = sample( ( uv ) => {
+
+				return scenePassMetalRough.sample( uv ).r;
+
+			} );
+
+			const sceneRoughness = sample( ( uv ) => {
+
+				return scenePassMetalRough.sample( uv ).g;
+
+			} );
+
 			//
 
-			ssrPass = ssr( scenePassColor, scenePassDepth, customNormal, scenePassMetalRough, camera, true );
+			ssrPass = ssr( scenePassColor, scenePassDepth, sceneNormal, sceneMetalness, camera, sceneRoughness );
 
 			// blend SSR over beauty
 

--- a/examples/webgpu_postprocessing_ssr.html
+++ b/examples/webgpu_postprocessing_ssr.html
@@ -146,21 +146,9 @@
 
 			} );
 
-			const sceneMetalness = sample( () => {
-
-				return scenePassMetalRough.r;
-
-			} );
-
-			const sceneRoughness = sample( () => {
-
-				return scenePassMetalRough.g;
-
-			} );
-
 			//
 
-			ssrPass = ssr( scenePassColor, scenePassDepth, sceneNormal, sceneMetalness, camera, sceneRoughness );
+			ssrPass = ssr( scenePassColor, scenePassDepth, sceneNormal, scenePassMetalRough.r, camera, scenePassMetalRough.g );
 
 			// blend SSR over beauty
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/31649

**Description**

By adding the `roughness` parameter, which defaults to `null`, blur will be enabled.
This gives more individuality to the inputs, making them improve to modify.
