### PR TITLE
Run addons unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   test:
-    name: Lint, Unit, Circular dependencies & Examples testing
+    name: Lint, Unit, Unit addons, Circular dependencies & Examples testing
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
@@ -30,6 +30,9 @@ jobs:
 
       - name: === Unit testing ===
         run: npm run test-unit
+
+      - name: === Unit addons testing ===
+        run: npm run test-unit-addons
 
       - name: === Circular dependencies testing ===
         run: npm run test-circular-deps


### PR DESCRIPTION
Run the addons test for CI so that all tests are run. 

This aligns with the current local test command:
```
npm run test => 
    "test": "npm run lint && npm run test-unit && npm run test-unit-addons"
```

This does not appreciably add to overall tests execution time. `test-unit-addons` takes <0.2s on my machine.