### PR TITLE
ShadowMapViewerGPU: Fix DepthTexture usage

### DIFF
--- a/examples/jsm/utils/ShadowMapViewerGPU.js
+++ b/examples/jsm/utils/ShadowMapViewerGPU.js
@@ -171,6 +171,12 @@ class ShadowMapViewer {
 
 			if ( this.enabled ) {
 
+				//Because a light's .shadowMap is only initialised after the first render pass
+				//we have to make sure the correct map is sent into the shader, otherwise we
+				//always end up with the scene's first added shadow casting light's shadowMap
+				//in the shader
+				//See: https://github.com/mrdoob/three.js/issues/5932
+
 				const depthTexture = light.shadow.map.depthTexture;
 
 				shadowMapUniform.value = depthTexture;

--- a/examples/jsm/utils/ShadowMapViewerGPU.js
+++ b/examples/jsm/utils/ShadowMapViewerGPU.js
@@ -7,9 +7,10 @@ import {
 	OrthographicCamera,
 	PlaneGeometry,
 	Scene,
-	Texture
+	DepthTexture,
+	Vector2
 } from 'three';
-import { texture } from 'three/tsl';
+import { uv, uniform, textureLoad } from 'three/tsl';
 
 /**
  * This is a helper for visualising a given light's shadow map.
@@ -60,8 +61,10 @@ class ShadowMapViewer {
 
 		const material = new NodeMaterial();
 
-		const shadowMapUniform = texture( new Texture() );
-		material.fragmentNode = shadowMapUniform;
+		const textureDimension = uniform( new Vector2() );
+
+		const shadowMapUniform = textureLoad( new DepthTexture(), uv().mul( textureDimension ) );
+		material.fragmentNode = shadowMapUniform.x;
 
 		const plane = new PlaneGeometry( frame.width, frame.height );
 		const mesh = new Mesh( plane, material );
@@ -168,12 +171,10 @@ class ShadowMapViewer {
 
 			if ( this.enabled ) {
 
-				//Because a light's .shadowMap is only initialised after the first render pass
-				//we have to make sure the correct map is sent into the shader, otherwise we
-				//always end up with the scene's first added shadow casting light's shadowMap
-				//in the shader
-				//See: https://github.com/mrdoob/three.js/issues/5932
-				shadowMapUniform.value = light.shadow.map.texture;
+				const depthTexture = light.shadow.map.depthTexture;
+
+				shadowMapUniform.value = depthTexture;
+				textureDimension.value.set( depthTexture.width, depthTexture.height );
 
 				currentAutoClear = renderer.autoClear;
 				renderer.autoClear = false; // To allow render overlay

--- a/examples/jsm/utils/ShadowMapViewerGPU.js
+++ b/examples/jsm/utils/ShadowMapViewerGPU.js
@@ -63,8 +63,8 @@ class ShadowMapViewer {
 
 		const textureDimension = uniform( new Vector2() );
 
-		const shadowMapUniform = textureLoad( new DepthTexture(), uv().mul( textureDimension ) );
-		material.fragmentNode = shadowMapUniform.x;
+		const shadowMapUniform = textureLoad( new DepthTexture(), uv().flipY().mul( textureDimension ) );
+		material.fragmentNode = shadowMapUniform.x.oneMinus();
 
 		const plane = new PlaneGeometry( frame.width, frame.height );
 		const mesh = new Mesh( plane, material );

--- a/examples/webgpu_shadowmap.html
+++ b/examples/webgpu_shadowmap.html
@@ -29,9 +29,12 @@
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 
+			import { ShadowMapViewer } from 'three/addons/utils/ShadowMapViewerGPU.js';
+
 			let camera, scene, renderer, clock;
 			let dirLight, spotLight;
 			let torusKnot, dirGroup;
+			let lightShadowMapViewer;
 
 			init();
 
@@ -75,6 +78,17 @@
 				dirLight.shadow.mapSize.height = 2048;
 				dirLight.shadow.radius = 4;
 				dirLight.shadow.bias = - 0.0005;
+
+				lightShadowMapViewer = new ShadowMapViewer( dirLight );
+				//lightShadowMapViewer.position.x = 10;
+				//lightShadowMapViewer.position.y = SCREEN_HEIGHT - ( SHADOW_MAP_HEIGHT / 4 ) - 10;
+				//lightShadowMapViewer.size.width = SHADOW_MAP_WIDTH / 4;
+				//lightShadowMapViewer.size.height = SHADOW_MAP_HEIGHT / 4;
+				lightShadowMapViewer.position.x = 10;
+				lightShadowMapViewer.position.y = 10;
+				lightShadowMapViewer.size.width = 256;
+				lightShadowMapViewer.size.height = 256;
+				lightShadowMapViewer.update();
 
 				dirGroup = new THREE.Group();
 				dirGroup.add( dirLight );
@@ -212,6 +226,8 @@
 				dirLight.position.z = 17 + Math.sin( time * 0.001 ) * 5;
 
 				renderer.render( scene, camera );
+
+				lightShadowMapViewer.render( renderer );
 
 			}
 

--- a/examples/webgpu_shadowmap.html
+++ b/examples/webgpu_shadowmap.html
@@ -29,12 +29,9 @@
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 
-			import { ShadowMapViewer } from 'three/addons/utils/ShadowMapViewerGPU.js';
-
 			let camera, scene, renderer, clock;
 			let dirLight, spotLight;
 			let torusKnot, dirGroup;
-			let lightShadowMapViewer;
 
 			init();
 
@@ -78,17 +75,6 @@
 				dirLight.shadow.mapSize.height = 2048;
 				dirLight.shadow.radius = 4;
 				dirLight.shadow.bias = - 0.0005;
-
-				lightShadowMapViewer = new ShadowMapViewer( dirLight );
-				//lightShadowMapViewer.position.x = 10;
-				//lightShadowMapViewer.position.y = SCREEN_HEIGHT - ( SHADOW_MAP_HEIGHT / 4 ) - 10;
-				//lightShadowMapViewer.size.width = SHADOW_MAP_WIDTH / 4;
-				//lightShadowMapViewer.size.height = SHADOW_MAP_HEIGHT / 4;
-				lightShadowMapViewer.position.x = 10;
-				lightShadowMapViewer.position.y = 10;
-				lightShadowMapViewer.size.width = 256;
-				lightShadowMapViewer.size.height = 256;
-				lightShadowMapViewer.update();
 
 				dirGroup = new THREE.Group();
 				dirGroup.add( dirLight );
@@ -226,8 +212,6 @@
 				dirLight.position.z = 17 + Math.sin( time * 0.001 ) * 5;
 
 				renderer.render( scene, camera );
-
-				lightShadowMapViewer.render( renderer );
 
 			}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/29331#discussion_r2280595871

**Description**

At the moment we need a base texture that is compatible for initialization. Since `DepthTexture` does not allow sampling, I used `textureLoad()`.

In `WebGPURenderer`, the **beauty pass** in the shadow map rendering process is used to color the shadow and individual opacity, as seen in `webgpu_shadowmap_opacity`.

For this reason, we need to use DepthTexture, which would be the better option anyway.

/cc @WestLangley 