### PR TITLE
WebXR: Frustum culling consistency

### DIFF
--- a/src/cameras/ArrayCamera.js
+++ b/src/cameras/ArrayCamera.js
@@ -41,6 +41,15 @@ class ArrayCamera extends PerspectiveCamera {
 		this.isMultiViewCamera = false;
 
 		/**
+		 * Whether to perform view-frustum culling during rendering
+		 * on a per-camera basis, or to use the `ArrayCamera`'s own projection matrix.
+		 *
+		 * @type {boolean}
+		 * @default true
+		 */
+		this.perCameraCulling = true;
+
+		/**
 		 * An array of perspective sub cameras.
 		 *
 		 * @type {Array<PerspectiveCamera>}

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -1408,12 +1408,10 @@ class Renderer {
 
 		//
 
-		const frustum = camera.isArrayCamera ? _frustumArray : _frustum;
-
-		if ( ! camera.isArrayCamera ) {
+		if ( ! camera.perCameraCulling ) {
 
 			_projScreenMatrix.multiplyMatrices( camera.projectionMatrix, camera.matrixWorldInverse );
-			frustum.setFromProjectionMatrix( _projScreenMatrix, camera.coordinateSystem, camera.reversedDepth );
+			_frustum.setFromProjectionMatrix( _projScreenMatrix, camera.coordinateSystem, camera.reversedDepth );
 
 		}
 
@@ -2645,7 +2643,7 @@ class Renderer {
 
 			} else if ( object.isSprite ) {
 
-				const frustum = camera.isArrayCamera ? _frustumArray : _frustum;
+				const frustum = camera.perCameraCulling ? _frustumArray : _frustum;
 
 				if ( ! object.frustumCulled || frustum.intersectsSprite( object, camera ) ) {
 
@@ -2671,7 +2669,7 @@ class Renderer {
 
 			} else if ( object.isMesh || object.isLine || object.isPoints ) {
 
-				const frustum = camera.isArrayCamera ? _frustumArray : _frustum;
+				const frustum = camera.perCameraCulling ? _frustumArray : _frustum;
 
 				if ( ! object.frustumCulled || frustum.intersectsObject( object, camera ) ) {
 

--- a/src/renderers/common/XRManager.js
+++ b/src/renderers/common/XRManager.js
@@ -1152,7 +1152,7 @@ class XRManager extends EventDispatcher {
 
 		} else {
 
-			// assume single camera setup (AR)
+			// view frustum culling will be performed per camera, but assign this anyway
 
 			cameraXR.projectionMatrix.copy( cameraL.projectionMatrix );
 
@@ -1575,16 +1575,7 @@ function onAnimationFrame( time, frame ) {
 
 			cameraXR.cameras.length = 0;
 			cameraXRNeedsUpdate = true;
-
-			if ( views.length === 2 ) {
-
-				cameraXR.perCameraCulling = false;
-
-			} else {
-
-				cameraXR.perCameraCulling = true;
-
-			}
+			cameraXR.perCameraCulling = views.length !== 2;
 
 		}
 

--- a/src/renderers/common/XRManager.js
+++ b/src/renderers/common/XRManager.js
@@ -1576,6 +1576,16 @@ function onAnimationFrame( time, frame ) {
 			cameraXR.cameras.length = 0;
 			cameraXRNeedsUpdate = true;
 
+			if ( views.length === 2 ) {
+
+				cameraXR.perCameraCulling = false;
+
+			} else {
+
+				cameraXR.perCameraCulling = true;
+
+			}
+
 		}
 
 		for ( let i = 0; i < views.length; i ++ ) {

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -937,6 +937,16 @@ class WebXRManager extends EventDispatcher {
 					cameraXR.cameras.length = 0;
 					cameraXRNeedsUpdate = true;
 
+					if ( views.length === 2 ) {
+
+						cameraXR.perCameraCulling = false;
+
+					} else {
+
+						cameraXR.perCameraCulling = true;
+
+					}
+
 				}
 
 				for ( let i = 0; i < views.length; i ++ ) {

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -770,7 +770,7 @@ class WebXRManager extends EventDispatcher {
 
 			} else {
 
-				// assume single camera setup (AR)
+				// view frustum culling will be performed per camera, but assign this anyway
 
 				cameraXR.projectionMatrix.copy( cameraL.projectionMatrix );
 
@@ -936,16 +936,7 @@ class WebXRManager extends EventDispatcher {
 
 					cameraXR.cameras.length = 0;
 					cameraXRNeedsUpdate = true;
-
-					if ( views.length === 2 ) {
-
-						cameraXR.perCameraCulling = false;
-
-					} else {
-
-						cameraXR.perCameraCulling = true;
-
-					}
+					cameraXR.perCameraCulling = views.length !== 2;
 
 				}
 


### PR DESCRIPTION
Related issue: #31672

**Description**

Allow per-view culling for XR content on `WebGLRenderer` by backporting `Renderer` changes from #30830.

Allow `ArrayCamera` to dictate whether it should be frustum-culled per-camera, or based on its own projection matrix, with `perCameraCulling`. This allows XR devices with 2 views to continue using the combined projection matrix of those views for culling in a single pass in both renderers, as they did prior to #30830.

More discussion in #31672.