### PR TITLE
NodeBuilderState: Fix type of bindingsReference in `createBindings()`.

### DIFF
--- a/src/renderers/common/nodes/NodeBuilderState.js
+++ b/src/renderers/common/nodes/NodeBuilderState.js
@@ -126,7 +126,7 @@ class NodeBuilderState {
 
 			if ( shared !== true ) {
 
-				const bindingsGroup = new BindGroup( instanceGroup.name, [], instanceGroup.index, instanceGroup );
+				const bindingsGroup = new BindGroup( instanceGroup.name, [], instanceGroup.index, instanceGroup.bindingsReference );
 				bindings.push( bindingsGroup );
 
 				for ( const instanceBinding of instanceGroup.bindings ) {


### PR DESCRIPTION
Related issue: #31674 

**Description**

Fixes an instance where bindGroup's bindingReference was being passed a bindGroup rather than an array of Bindings[]. 

Currently using this as a test PR to see if this change might have any downstream effects, which I don't anticipate since bindingsReference only appears to be relevant to bindGroupLayout caching. This PR does not have any effect on performance in webgpu_tsl_wood.html, which suggests that the way Bindings are parsed may be more relevant to the caching issue than the bindingsReference containing a valid Bindings array. However, optimizing GPU resource caching will presumably still depend on the cache's keys containing consistently structured data.