### PR TITLE
WebGPUBindingUtils - Change bindGroupLayout cache system

### DIFF
--- a/examples/webgpu_bitcount_consecutive.html
+++ b/examples/webgpu_bitcount_consecutive.html
@@ -1,0 +1,292 @@
+<html lang="en">
+	<head>
+		<title>three.js webgpu - Bit counting shader validation</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<link type="text/css" rel="stylesheet" href="main.css">
+	</head>
+	<style>
+		body {
+			margin: 0;
+			overflow: hidden;
+			width: 100vw;
+			height: 100vh;
+		}
+
+		#demo {
+			display: flex;
+			flex-direction: row;
+			align-items: center;
+		}
+
+		.renderer-wrapper {
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+		}
+
+		#antialiasing-disabled {
+			border-right: 1px solid black;
+		}
+
+		canvas {
+			width: 100%;
+			height: 100%;
+		}
+	</style>
+	<body>
+		<div id="demo">
+			<div id="bitCountWebGPU" class="renderer-wrapper">
+				<div>bitCountWebGPU</div>
+			</div>
+			<div id="bitCountWebGL" class="renderer-wrapper">
+				<div>bitCountWebGL</div>
+			</div>
+
+		<script type="importmap">
+			{
+				"imports": {
+					"three": "../build/three.webgpu.js",
+					"three/webgpu": "../build/three.webgpu.js",
+					"three/tsl": "../build/three.tsl.js",
+					"three/addons/": "./jsm/"
+				}
+			}
+		</script>
+
+		<script type="module">
+
+			import * as THREE from 'three/webgpu';
+			import { Fn, instancedArray, countTrailingZeros, countLeadingZeros, countOneBits, instanceIndex, uint, uv, uvec2, vec2, floor, float, If, vec3 } from 'three/tsl';
+
+			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
+
+			function windowResizeCallback( renderer, camera ) {
+
+				const halfWidth = window.innerWidth / 2;
+				renderer.setSize( halfWidth, window.innerHeight );
+				const aspect = ( halfWidth ) / window.innerHeight;
+
+				camera.aspect = aspect;
+				camera.updateProjectionMatrix();
+
+			}
+
+
+			const test = [];
+			for ( let i = 0; i < 2000; i ++ ) {
+
+				const binaryString = i.toString( 2 );
+  			const matches = binaryString.match( /1/g );
+  			const numMatches = matches ? matches.length : 0;
+
+				test.push( i );
+
+			}
+
+			const testArray = new Uint32Array( test );
+
+			const gui = new GUI();
+			
+			async function init( isWebGL = false ) {
+
+				const camera = new THREE.PerspectiveCamera();
+				camera.fov = 60;
+				camera.near = 1;
+				camera.far = 2100;
+				camera.position.z = 3;
+
+				const scene = new THREE.Scene();
+				scene.background = new THREE.Color( 0x313131 );
+			
+				let testBuffer;
+			
+				let validationMethod = ( value, index, color ) => {
+			
+					return vec3( 0, 0, 0 );
+
+				};
+
+				let usedTSL;
+
+				if ( algoType === COUNT_TRAILING_ZEROS ) {
+
+					usedTSL = countTrailingZeros;
+					validationMethod = ( value, index, baseColor ) => {
+
+						const color = vec3( 0.0, 0.0, 0.0 );
+
+						If( value.equal( index ), () => {
+
+							color.assign( vec3( 0, baseColor, 0 ) );
+
+						} ).Else( () => {
+
+							color.assign( vec3( baseColor, 0, 0 ) );
+
+						} );
+
+						return color;
+
+					};
+
+				} else if ( algoType === COUNT_LEADING_ZEROS ) {
+
+					usedTSL = countLeadingZeros;
+
+					validationMethod = ( value, index, baseColor ) => {
+
+						const color = vec3( 0.0, 0.0, 0.0 );
+
+						If( value.equal( uint( 32 ).sub( 1 ).sub( index ) ), () => {
+
+							color.assign( vec3( 0, baseColor, 0 ) );
+
+						} ).Else( () => {
+
+							color.assign( vec3( baseColor, 0, 0 ) );
+
+						} );
+
+						return color;
+
+					};
+			
+
+				} else {
+
+					usedTSL = countOneBits;
+
+					validationMethod = ( value, index, baseColor ) => {
+
+						const color = vec3( 0.0, 0.0, 0.0 );
+
+						If( value.equal( index.add( 1 ) ), () => {
+
+							color.assign( vec3( 0, baseColor, 0 ) );
+
+						} ).Else( () => {
+
+							color.assign( vec3( baseColor, 0, 0 ) );
+
+						} );
+
+						return color;
+
+					};
+
+				}
+
+				const storageBuffer = instancedArray( 32, 'uint' ).setPBO( true );
+				const computeBuffer = Fn( () => {
+			
+					storageBuffer.element( instanceIndex ).assign( usedTSL( storageBuffer.element( instanceIndex ) ) );
+
+				} )().compute( 32 );
+
+				// Create computeInit function
+
+				if ( algoType !== BIT_COUNT ) {
+
+					testBuffer = instancedArray( zerosTestArray, 'uint' ).setPBO( true );
+
+				} else {
+
+					testBuffer = instancedArray( bitCountTestArray, 'uint' ).setPBO( true );
+
+				}
+
+				const computeInit = Fn( () => {
+
+					storageBuffer.element( instanceIndex ).assign( testBuffer.element( instanceIndex ) );
+
+				} )().compute( 32 );
+
+				const material = new THREE.MeshBasicNodeMaterial( { color: 0x00ff00 } );
+				material.colorNode = Fn( () => {
+
+					const newUV = uv().mul( vec2( 32.0, 1.0 ) );
+
+					const pixel = uvec2( uint( floor( newUV.x ) ), uint( floor( newUV.y ) ) );
+
+					const value = float( storageBuffer.element( pixel.x ) );
+
+					const color = value.div( 32 );
+
+					return validationMethod( value, pixel.x, color );
+
+				} )();
+
+				const geometry = new THREE.PlaneGeometry();
+				const mesh = new THREE.Mesh( geometry, material );
+				scene.add( mesh );
+
+				// Create Standard Renderer
+				const renderer = new THREE.WebGPURenderer( { antialias: false, forceWebGL: false } );
+				renderer.setPixelRatio( window.devicePixelRatio );
+				renderer.setSize( window.innerWidth / 3, window.innerHeight );
+
+				const functionObj = {};
+
+
+				functionObj.logBuffer = async () => {
+
+					console.log( new Uint32Array( await renderer.getArrayBufferAsync( storageBuffer.value ) ) );
+			
+				};
+
+				gui.add( functionObj, 'logBuffer' ).name( `Log ${algoType}` );
+			
+
+
+				const animate = () => {
+
+					renderer.render( scene, camera );
+
+				};
+
+				renderer.setAnimationLoop( animate );
+
+				let computeStep = true;
+
+				await renderer.computeAsync( computeInit );
+
+				 const stepAnimation = async function () {
+
+					if ( computeStep ) {
+
+						await renderer.computeAsync( computeBuffer );
+
+					} else {
+
+						renderer.computeAsync( computeInit );
+			
+					}
+
+					computeStep = ! computeStep;
+
+					setTimeout( stepAnimation, 1000 );
+
+				};
+
+				stepAnimation();
+
+				document.body.querySelector( `#${algoType}` ).appendChild( renderer.domElement );
+
+				window.addEventListener( 'resize', onWindowResize );
+
+				function onWindowResize() {
+
+					windowResizeCallback( renderer, camera );
+
+				}
+
+			}
+
+			init( COUNT_TRAILING_ZEROS );
+			init( COUNT_LEADING_ZEROS );
+			init( BIT_COUNT );
+
+		</script>
+	</body>
+</html>

--- a/src/renderers/webgpu/utils/WebGPUBindingUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUBindingUtils.js
@@ -42,6 +42,184 @@ class WebGPUBindingUtils {
 
 	}
 
+	createBindingsLayoutEntry( binding, index = 0 ) {
+
+		const backend = this.backend;
+		const device = backend.device;
+
+		const bindingGPU = {
+			binding: index,
+			visibility: binding.visibility
+		};
+
+		if ( binding.isUniformBuffer || binding.isStorageBuffer ) {
+
+			const buffer = {}; // GPUBufferBindingLayout
+
+			if ( binding.isStorageBuffer ) {
+
+				if ( binding.visibility & 4 ) {
+
+					// compute
+
+					if ( binding.access === NodeAccess.READ_WRITE || binding.access === NodeAccess.WRITE_ONLY ) {
+
+						buffer.type = GPUBufferBindingType.Storage;
+
+					} else {
+
+						buffer.type = GPUBufferBindingType.ReadOnlyStorage;
+
+					}
+
+				} else {
+
+					buffer.type = GPUBufferBindingType.ReadOnlyStorage;
+
+				}
+
+			}
+
+			bindingGPU.buffer = buffer;
+
+		} else if ( binding.isSampledTexture && binding.store ) {
+
+			const storageTexture = {}; // GPUStorageTextureBindingLayout
+			storageTexture.format = this.backend.get( binding.texture ).texture.format;
+
+			const access = binding.access;
+
+			if ( access === NodeAccess.READ_WRITE ) {
+
+				storageTexture.access = GPUStorageTextureAccess.ReadWrite;
+
+			} else if ( access === NodeAccess.WRITE_ONLY ) {
+
+				storageTexture.access = GPUStorageTextureAccess.WriteOnly;
+
+			} else {
+
+				storageTexture.access = GPUStorageTextureAccess.ReadOnly;
+
+			}
+
+			if ( binding.texture.isArrayTexture ) {
+
+				storageTexture.viewDimension = GPUTextureViewDimension.TwoDArray;
+
+			} else if ( binding.texture.is3DTexture ) {
+
+				storageTexture.viewDimension = GPUTextureViewDimension.ThreeD;
+
+			}
+
+			bindingGPU.storageTexture = storageTexture;
+
+		} else if ( binding.isSampledTexture ) {
+
+			const texture = {}; // GPUTextureBindingLayout
+
+			const { primarySamples } = backend.utils.getTextureSampleData( binding.texture );
+
+			if ( primarySamples > 1 ) {
+
+				texture.multisampled = true;
+
+				if ( ! binding.texture.isDepthTexture ) {
+
+					texture.sampleType = GPUTextureSampleType.UnfilterableFloat;
+
+				}
+
+			}
+
+			if ( binding.texture.isDepthTexture ) {
+
+				if ( backend.compatibilityMode && binding.texture.compareFunction === null ) {
+
+					texture.sampleType = GPUTextureSampleType.UnfilterableFloat;
+
+				} else {
+
+					texture.sampleType = GPUTextureSampleType.Depth;
+
+				}
+
+			} else if ( binding.texture.isDataTexture || binding.texture.isDataArrayTexture || binding.texture.isData3DTexture ) {
+
+				const type = binding.texture.type;
+
+				if ( type === IntType ) {
+
+					texture.sampleType = GPUTextureSampleType.SInt;
+
+				} else if ( type === UnsignedIntType ) {
+
+					texture.sampleType = GPUTextureSampleType.UInt;
+
+				} else if ( type === FloatType ) {
+
+					if ( this.backend.hasFeature( 'float32-filterable' ) ) {
+
+						texture.sampleType = GPUTextureSampleType.Float;
+
+					} else {
+
+						texture.sampleType = GPUTextureSampleType.UnfilterableFloat;
+
+					}
+
+				}
+
+			}
+
+			if ( binding.isSampledCubeTexture ) {
+
+				texture.viewDimension = GPUTextureViewDimension.Cube;
+
+			} else if ( binding.texture.isArrayTexture || binding.texture.isDataArrayTexture || binding.texture.isCompressedArrayTexture ) {
+
+				texture.viewDimension = GPUTextureViewDimension.TwoDArray;
+
+			} else if ( binding.isSampledTexture3D ) {
+
+				texture.viewDimension = GPUTextureViewDimension.ThreeD;
+
+			}
+
+			bindingGPU.texture = texture;
+
+		} else if ( binding.isSampler ) {
+
+			const sampler = {}; // GPUSamplerBindingLayout
+
+			if ( binding.texture.isDepthTexture ) {
+
+				if ( binding.texture.compareFunction !== null ) {
+
+					sampler.type = GPUSamplerBindingType.Comparison;
+
+				} else if ( backend.compatibilityMode ) {
+
+					sampler.type = GPUSamplerBindingType.NonFiltering;
+
+				}
+
+			}
+
+			bindingGPU.sampler = sampler;
+
+		} else {
+
+			console.error( `WebGPUBindingUtils: Unsupported binding "${ binding }".` );
+
+		}
+
+		return bindingGPU;
+
+
+	}
+
 	/**
 	 * Creates a GPU bind group layout for the given bind group.
 	 *
@@ -59,6 +237,7 @@ class WebGPUBindingUtils {
 
 		for ( const binding of bindGroup.bindings ) {
 
+<<<<<<< HEAD
 			const bindingGPU = {
 				binding: index ++,
 				visibility: binding.visibility
@@ -227,7 +406,11 @@ class WebGPUBindingUtils {
 
 			}
 
+=======
+			const bindingGPU = this.createBindingsLayoutEntry( binding, index );
+>>>>>>> a3263a10eb (create bindingsLayoutEntry function)
 			entries.push( bindingGPU );
+			index ++;
 
 		}
 


### PR DESCRIPTION
**Description**

Testing alternate caching system for bindGroupLayouts.

webgpu_materials_toon only creates 4 bind group layouts. 

Problem with the PR thus far is that entries still has to be created for each bindGroup even though many of the bindings and bindGroups are nearly identical. 
