### PR TITLE
WebGLBackend: Cache WebGL buffer when updating UBOs.

### DIFF
--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -1845,28 +1845,37 @@ class WebGLBackend extends Backend {
 
 		for ( const binding of bindGroup.bindings ) {
 
+			const map = this.get( binding );
+
 			if ( binding.isUniformsGroup || binding.isUniformBuffer ) {
 
 				const data = binding.buffer;
-				const bufferGPU = gl.createBuffer();
+				let { bufferGPU } = this.get( data );
+
+				if ( bufferGPU === undefined ) {
+
+					bufferGPU = gl.createBuffer();
+					this.set( data, { bufferGPU } );
+
+				}
 
 				gl.bindBuffer( gl.UNIFORM_BUFFER, bufferGPU );
 				gl.bufferData( gl.UNIFORM_BUFFER, data, gl.DYNAMIC_DRAW );
 
-				this.set( binding, {
-					index: i ++,
-					bufferGPU
-				} );
+				map.index = i ++;
+				map.bufferGPU = bufferGPU;
+
+				this.set( binding, map );
 
 			} else if ( binding.isSampledTexture ) {
 
 				const { textureGPU, glTextureType } = this.get( binding.texture );
 
-				this.set( binding, {
-					index: t ++,
-					textureGPU,
-					glTextureType
-				} );
+				map.index = t ++;
+				map.textureGPU = textureGPU;
+				map.glTextureType = glTextureType;
+
+				this.set( binding, map );
 
 			}
 

--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -1854,13 +1854,22 @@ class WebGLBackend extends Backend {
 
 				if ( bufferGPU === undefined ) {
 
+					// create
+
 					bufferGPU = gl.createBuffer();
+					gl.bindBuffer( gl.UNIFORM_BUFFER, bufferGPU );
+					gl.bufferData( gl.UNIFORM_BUFFER, data, gl.DYNAMIC_DRAW );
+
 					this.set( data, { bufferGPU } );
 
-				}
+				} else {
 
-				gl.bindBuffer( gl.UNIFORM_BUFFER, bufferGPU );
-				gl.bufferData( gl.UNIFORM_BUFFER, data, gl.DYNAMIC_DRAW );
+					// update
+
+					gl.bindBuffer( gl.UNIFORM_BUFFER, bufferGPU );
+					gl.bufferSubData( gl.UNIFORM_BUFFER, 0, data );
+
+				}
 
 				map.index = i ++;
 				map.bufferGPU = bufferGPU;


### PR DESCRIPTION
Fixed #31679.

**Description**

The PR fixes an issue where WebGL buffers were created over and over again for UBO updates. 

The GL buffer is directly coupled to the buffer of `THREE.UniformBuffer` which is fixed sized. So creating the GL buffer for a UBO once and then caching it should be safe.
