### PR TITLE
Examples: Add WebGPU check to some compute demos.

### DIFF
--- a/examples/webgpu_compute_birds.html
+++ b/examples/webgpu_compute_birds.html
@@ -43,6 +43,7 @@
 
 			import Stats from 'stats-gl';
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
+			import WebGPU from 'three/addons/capabilities/WebGPU.js';
 
 			let container, stats;
 			let camera, scene, renderer;
@@ -127,6 +128,14 @@
 					this.scale( 0.2, 0.2, 0.2 );
 
 				}
+
+			}
+			
+			if ( WebGPU.isAvailable() === false ) {
+
+				document.body.appendChild( WebGPU.getErrorMessage() );
+
+				throw new Error( 'No WebGPU support' );
 
 			}
 

--- a/examples/webgpu_compute_cloth.html
+++ b/examples/webgpu_compute_cloth.html
@@ -117,17 +117,17 @@
 				const materialFolder = gui.addFolder( 'material' );
 				materialFolder.addColor( API, 'color' ).onChange( function ( color ) {
 
-		clothMaterial.color.setHex( color );
+					clothMaterial.color.setHex( color );
 
-	} );
+				} );
 				materialFolder.add( clothMaterial, 'roughness', 0.0, 1, 0.01 );
 				materialFolder.add( clothMaterial, 'sheen', 0.0, 1, 0.01 );
 				materialFolder.add( clothMaterial, 'sheenRoughness', 0.0, 1, 0.01 );
 				materialFolder.addColor( API, 'sheenColor' ).onChange( function ( color ) {
 
-		clothMaterial.sheenColor.setHex( color );
+					clothMaterial.sheenColor.setHex( color );
 
-	} );
+				} );
 
 				window.addEventListener( 'resize', onWindowResize );
 

--- a/examples/webgpu_compute_cloth.html
+++ b/examples/webgpu_compute_cloth.html
@@ -32,6 +32,7 @@
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { HDRLoader } from 'three/addons/loaders/HDRLoader.js';
+			import WebGPU from 'three/addons/capabilities/WebGPU.js';
 
 			let renderer, scene, camera, controls;
 
@@ -66,6 +67,14 @@
 				color: 0x204080, // sRGB
 				sheenColor: 0xffffff // sRGB
 			};
+
+			if ( WebGPU.isAvailable() === false ) {
+
+				document.body.appendChild( WebGPU.getErrorMessage() );
+
+				throw new Error( 'No WebGPU support' );
+
+			}
 
 			init();
 
@@ -106,11 +115,19 @@
 				gui.add( params, 'wind', 0, 5, 0.1 );
 
 				const materialFolder = gui.addFolder( 'material' );
-				materialFolder.addColor( API, 'color' ).onChange( function ( color ) { clothMaterial.color.setHex( color ); } );
+				materialFolder.addColor( API, 'color' ).onChange( function ( color ) {
+
+		clothMaterial.color.setHex( color );
+
+	} );
 				materialFolder.add( clothMaterial, 'roughness', 0.0, 1, 0.01 );
 				materialFolder.add( clothMaterial, 'sheen', 0.0, 1, 0.01 );
 				materialFolder.add( clothMaterial, 'sheenRoughness', 0.0, 1, 0.01 );
-				materialFolder.addColor( API, 'sheenColor' ).onChange( function ( color ) { clothMaterial.sheenColor.setHex( color ); } );
+				materialFolder.addColor( API, 'sheenColor' ).onChange( function ( color ) {
+
+		clothMaterial.sheenColor.setHex( color );
+
+	} );
 
 				window.addEventListener( 'resize', onWindowResize );
 

--- a/examples/webgpu_compute_texture_3d.html
+++ b/examples/webgpu_compute_texture_3d.html
@@ -33,10 +33,19 @@
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
+			import WebGPU from 'three/addons/capabilities/WebGPU.js';
 
 			let renderer, scene, camera;
 			let mesh;
 			let computeNode;
+
+			if ( WebGPU.isAvailable() === false ) {
+
+				document.body.appendChild( WebGPU.getErrorMessage() );
+
+				throw new Error( 'No WebGPU support' );
+
+			}
 
 			init();
 

--- a/test/e2e/puppeteer.js
+++ b/test/e2e/puppeteer.js
@@ -127,6 +127,7 @@ const exceptionList = [
 
 	// Awaiting for WebGL backend support
 	'webgpu_compute_audio',
+	'webgpu_compute_birds',
 	'webgpu_compute_texture',
 	'webgpu_compute_texture_3d',
 	'webgpu_compute_texture_pingpong',


### PR DESCRIPTION
Related issue: -

**Description**

The PR adds WebGPU compatibility checks to some compute demos that don't work properly with WebGL 2.

1. [webgpu_compute_birds](https://threejs.org/examples/webgpu_compute_birds) runs with 3-4 FPS in Firefox/macOS with M2 Pro and produces the following WebGL warnings:

> WebGL warning: texSubImage: Uploads from a buffer with a final row with a byte count smaller than the row stride can incur extra overhead. 27
WebGL warning: drawArraysInstanced: Drawing to a destination rect smaller than the viewport rect. (This warning will only be given once)

@cmhhelgeson Is this example supposed to run with WebGL 2? If so, do you know why Firefox complains?

2. [webgpu_compute_cloth](https://threejs.org/examples/webgpu_compute_cloth) shows a broken velvet mesh in the first frames and then the velvet disappears. The following warnings are logged.

> WebGL warning: texSubImage: Uploads from a buffer with a final row with a byte count smaller than the row stride can incur extra overhead.

<img width="5120" height="2427" alt="screenshot" src="https://github.com/user-attachments/assets/92bf3d2a-c466-4710-8cf0-48d91723bb07" />

@holtsetio Does the cloth simulation support WebGL 2? I suppose it's similar problem like `webgpu_compute_birds`.

3. [webgpu_compute_texture_3d](https://threejs.org/examples/webgpu_compute_texture_3d) fails with a runtime error:

> Uncaught (in promise) Error: Uniform "storageTexture" not declared.