### PR TITLE
Add reflector resolutionScale factor to webgl mirror example

### DIFF
--- a/examples/webgl_mirror.html
+++ b/examples/webgl_mirror.html
@@ -44,6 +44,8 @@
 
 			let groundMirror, verticalMirror;
 
+			const resolution = 1; // render target scale factor
+
 			init();
 
 			function init() {
@@ -81,8 +83,8 @@
 				geometry = new THREE.CircleGeometry( 40, 64 );
 				groundMirror = new Reflector( geometry, {
 					clipBias: 0.003,
-					textureWidth: window.innerWidth * window.devicePixelRatio,
-					textureHeight: window.innerHeight * window.devicePixelRatio,
+					textureWidth: window.innerWidth * resolution,
+					textureHeight: window.innerHeight * resolution,
 					color: 0xb5b5b5
 				} );
 				groundMirror.position.y = 0.5;
@@ -92,8 +94,8 @@
 				geometry = new THREE.PlaneGeometry( 100, 100 );
 				verticalMirror = new Reflector( geometry, {
 					clipBias: 0.003,
-					textureWidth: window.innerWidth * window.devicePixelRatio,
-					textureHeight: window.innerHeight * window.devicePixelRatio,
+					textureWidth: window.innerWidth * resolution,
+					textureHeight: window.innerHeight * resolution,
 					color: 0xc1cbcb
 				} );
 				verticalMirror.position.y = 50;
@@ -181,12 +183,12 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 
 				groundMirror.getRenderTarget().setSize(
-					window.innerWidth * window.devicePixelRatio,
-					window.innerHeight * window.devicePixelRatio
+					window.innerWidth * resolution,
+					window.innerHeight * resolution
 				);
 				verticalMirror.getRenderTarget().setSize(
-					window.innerWidth * window.devicePixelRatio,
-					window.innerHeight * window.devicePixelRatio
+					window.innerWidth * resolution,
+					window.innerHeight * resolution
 				);
 
 			}

--- a/examples/webgl_mirror.html
+++ b/examples/webgl_mirror.html
@@ -33,6 +33,8 @@
 
 			import * as THREE from 'three';
 
+			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
+
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { Reflector } from 'three/addons/objects/Reflector.js';
 
@@ -44,9 +46,9 @@
 
 			let groundMirror, verticalMirror;
 
-			const size = new THREE.Vector2();
+			let resolutionScale = 1; // render target scale factor in [ 0, 1 ]
 
-			const resolutionScale = 0.5; // render target scale factor in [ 0, 1 ]
+			const size = new THREE.Vector2();
 
 			init();
 
@@ -83,7 +85,7 @@
 				let geometry, material;
 
 				renderer.getDrawingBufferSize( size );
-				size.multiplyScalar( resolutionScale );
+				size.multiplyScalar( resolutionScale ).round();
 
 				geometry = new THREE.CircleGeometry( 40, 64 );
 				groundMirror = new Reflector( geometry, {
@@ -176,6 +178,26 @@
 				blueLight.position.set( 0, 50, 550 );
 				scene.add( blueLight );
 
+				// GUI
+
+				const params = {
+					resolution: resolutionScale,
+				};
+
+				const gui = new GUI();
+
+				const folder = gui.addFolder( 'Mirrors' );
+
+				folder.add( params, 'resolution', 0.2, 1, 0.1 )
+					.onChange( function ( val ) {
+
+						resolutionScale = val;
+						onWindowResize();
+
+					} );
+
+				folder.open();
+
 				window.addEventListener( 'resize', onWindowResize );
 
 			}
@@ -188,7 +210,7 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 
 				renderer.getDrawingBufferSize( size );
-				size.multiplyScalar( resolutionScale );
+				size.multiplyScalar( resolutionScale ).round();
 
 				groundMirror.getRenderTarget().setSize( size.width, size.height );
 				verticalMirror.getRenderTarget().setSize( size.width, size.height );

--- a/examples/webgl_mirror.html
+++ b/examples/webgl_mirror.html
@@ -44,7 +44,9 @@
 
 			let groundMirror, verticalMirror;
 
-			const resolution = 1; // render target scale factor
+			const size = new THREE.Vector2();
+
+			const resolutionScale = 0.5; // render target scale factor in [ 0, 1 ]
 
 			init();
 
@@ -80,11 +82,14 @@
 
 				let geometry, material;
 
+				renderer.getDrawingBufferSize( size );
+				size.multiplyScalar( resolutionScale );
+
 				geometry = new THREE.CircleGeometry( 40, 64 );
 				groundMirror = new Reflector( geometry, {
 					clipBias: 0.003,
-					textureWidth: window.innerWidth * resolution,
-					textureHeight: window.innerHeight * resolution,
+					textureWidth: size.width,
+					textureHeight: size.heignt,
 					color: 0xb5b5b5
 				} );
 				groundMirror.position.y = 0.5;
@@ -94,8 +99,8 @@
 				geometry = new THREE.PlaneGeometry( 100, 100 );
 				verticalMirror = new Reflector( geometry, {
 					clipBias: 0.003,
-					textureWidth: window.innerWidth * resolution,
-					textureHeight: window.innerHeight * resolution,
+					textureWidth: size.width,
+					textureHeight: size.heignt,
 					color: 0xc1cbcb
 				} );
 				verticalMirror.position.y = 50;
@@ -182,14 +187,11 @@
 
 				renderer.setSize( window.innerWidth, window.innerHeight );
 
-				groundMirror.getRenderTarget().setSize(
-					window.innerWidth * resolution,
-					window.innerHeight * resolution
-				);
-				verticalMirror.getRenderTarget().setSize(
-					window.innerWidth * resolution,
-					window.innerHeight * resolution
-				);
+				renderer.getDrawingBufferSize( size );
+				size.multiplyScalar( resolutionScale );
+
+				groundMirror.getRenderTarget().setSize( size.width, size.height );
+				verticalMirror.getRenderTarget().setSize( size.width, size.height );
 
 			}
 


### PR DESCRIPTION
I noticed that scaling by DPR was perhaps overkill in this example, and it seemed a bit jittery when resizing the window.

Also, I see `ReflectorNode` has a `resolutionScale` property.

The change in this PR seems like a reasonable first step. It may even be sufficient.