### PR TITLE
WebGPUTextureUtils: Fix `rgb9e5ufloat ` usage and `rg11b10ufloat` constant value.

### DIFF
--- a/src/renderers/webgpu/utils/WebGPUConstants.js
+++ b/src/renderers/webgpu/utils/WebGPUConstants.js
@@ -113,7 +113,7 @@ export const GPUTextureFormat = {
 	// Packed 32-bit formats
 	RGB9E5UFloat: 'rgb9e5ufloat',
 	RGB10A2Unorm: 'rgb10a2unorm',
-	RG11B10UFloat: 'rgb10a2unorm',
+	RG11B10UFloat: 'rg11b10ufloat',
 
 	// 64-bit formats
 

--- a/src/renderers/webgpu/utils/WebGPUTextureUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUTextureUtils.js
@@ -231,7 +231,7 @@ class WebGPUTextureUtils {
 
 		}
 
-		if ( texture.isCompressedTexture !== true && texture.isCompressedArrayTexture !== true ) {
+		if ( texture.isCompressedTexture !== true && texture.isCompressedArrayTexture !== true && format !== GPUTextureFormat.RGB9E5UFloat ) {
 
 			usage |= GPUTextureUsage.RENDER_ATTACHMENT;
 


### PR DESCRIPTION
Related issue: #31690

**Description**

According to https://www.w3.org/TR/webgpu/#packed-formats, `rgb9e5ufloat` is not renderable so `RENDER_ATTACHMENT` must not be set in the texture descriptor when using `rgb9e5ufloat`.

The PR also fixes a wrong constant value for `rg11b10ufloat`.