### PR TITLE
PointsNodeMaterial: Improve JSDoc.

### DIFF
--- a/src/materials/nodes/PointsNodeMaterial.js
+++ b/src/materials/nodes/PointsNodeMaterial.js
@@ -17,15 +17,15 @@ const _size = /*@__PURE__*/ new Vector2();
  *
  * This material can be used in two ways:
  *
- * - For rendering point primitives with {@link Points}. Since WebGPU only supports
- * point primitives with a pixel size of `1`, it's not possible to define a size.
+ * - By rendering point primitives with {@link Points}. Since WebGPU only supports point primitives
+ * with a pixel size of `1`, it's not possible to define a size.
  *
  * ```js
  * const pointCloud = new THREE.Points( geometry, new THREE.PointsNodeMaterial() );
  * ```
  *
- * - For rendering points with a size greater than `1` by combining it with instanced
- * sprites. In this case, size is honored, see {@link PointsNodeMaterial#sizeNode}.
+ * - By rendering point primitives with {@link Sprites}. In this case, size is honored,
+ * see {@link PointsNodeMaterial#sizeNode}.
  *
  * ```js
  * const instancedPoints = new THREE.Sprite( new THREE.PointsNodeMaterial( { positionNode: instancedBufferAttribute( positionAttribute ) } ) );

--- a/src/materials/nodes/PointsNodeMaterial.js
+++ b/src/materials/nodes/PointsNodeMaterial.js
@@ -15,6 +15,22 @@ const _size = /*@__PURE__*/ new Vector2();
 /**
  * Node material version of {@link PointsMaterial}.
  *
+ * This material can be used in two ways:
+ *
+ * - For rendering point primitives with {@link Points}. Since WebGPU only supports
+ * point primitives with a pixel size of `1`, it's not possible to define a size.
+ *
+ * ```js
+ * const pointCloud = new THREE.Points( geometry, new THREE.PointsNodeMaterial() );
+ * ```
+ *
+ * - For rendering points with a size greater than `1` by combining it with instanced
+ * sprites. In this case, size is honored, see {@link PointsNodeMaterial#sizeNode}.
+ *
+ * ```js
+ * const instancedPoints = new THREE.Sprite( new THREE.PointsNodeMaterial( { positionNode: instancedBufferAttribute( positionAttribute ) } ) );
+ * ```
+ *
  * @augments SpriteNodeMaterial
  */
 class PointsNodeMaterial extends SpriteNodeMaterial {


### PR DESCRIPTION
Related issue: #31627

**Description**

Try to clarify the docs of `PointsNodeMaterial` a bit.
