### PR TITLE
PointsNodeMaterial: Correct `size` calculation

### DIFF
--- a/src/materials/nodes/PointsNodeMaterial.js
+++ b/src/materials/nodes/PointsNodeMaterial.js
@@ -202,10 +202,9 @@ class PointsNodeMaterial extends SpriteNodeMaterial {
 
 const scale = /*@__PURE__*/ uniform( 1 ).onFrameUpdate( function ( { renderer } ) {
 
-	const dpr = renderer.getPixelRatio();
-	const size = renderer.getSize( _size );
+	const size = renderer.getSize( _size ); // logical units
 
-	this.value = 0.5 * size.y * dpr;
+	this.value = 0.5 * size.y;
 
 } );
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/31702#discussion_r2291560408.

The `scale` factor should be half the canvas height in logical units.
