### PR TITLE
TSL: Fixed persistent reference of the first stack

### DIFF
--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -1575,7 +1575,9 @@ class NodeBuilder {
 
 		this.stack = stack( this.stack );
 
-		this.stacks.push( getCurrentStack() || this.stack );
+		const previousStack = getCurrentStack();
+
+		this.stacks.push( previousStack );
 		setCurrentStack( this.stack );
 
 		return this.stack;


### PR DESCRIPTION
Fixes https://github.com/mrdoob/three.js/issues/31644

**Description**

It's a simple fix, but it should fix the memory leak issue regarding the first stack.

| Before | Now |
| ------------- | ------------- |
| <img width="970" height="634" alt="image" src="https://github.com/user-attachments/assets/b6fe22ae-1d1d-4b24-95ea-2a0bc4ffeeee" /> | <img width="980" height="644" alt="image" src="https://github.com/user-attachments/assets/a3f7ab14-5016-45fc-acde-1df35368d193" /> |


