### PR TITLE
Enable calling Object.freeze() on materials

### DIFF
--- a/src/core/EventDispatcher.js
+++ b/src/core/EventDispatcher.js
@@ -22,12 +22,27 @@
  */
 class EventDispatcher {
 
+	/**
+	 * Constructs a new event dispatcher.
+	 */
 	constructor() {
 
-		// Use a Map here (not a plain object) because we
-		// need to query for its size in some places.
-		/** @type {Map<string,Function[]>} */
-		this._listeners = new Map();
+		/**
+		 * This property is for internal use only.
+		 * It serves as a container for properties
+		 * that must be mutable even if the
+		 * {@link EventDispatcher} has been
+		 * frozen via Object.freeze().
+		 *
+		 * @type {Record<string,any>}
+		 */
+		this._internal = {};
+
+	}
+
+	get _listeners() {
+
+		return this._internal.listeners;
 
 	}
 
@@ -39,25 +54,19 @@ class EventDispatcher {
 	 */
 	addEventListener( type, listener ) {
 
-		if ( typeof listener !== 'function' ) {
-
-			throw new Error( 'listener must be a function' );
-
-		}
+		if ( this._listeners === undefined ) this._internal.listeners = {};
 
 		const listeners = this._listeners;
 
-		let listenerArray = listeners.get( type );
+		if ( listeners[ type ] === undefined ) {
 
-		if ( listenerArray === undefined ) {
-
-			listeners.set( type, listenerArray = [] );
+			listeners[ type ] = [];
 
 		}
 
-		if ( listenerArray.indexOf( listener ) === - 1 ) {
+		if ( listeners[ type ].indexOf( listener ) === - 1 ) {
 
-			listenerArray.push( listener );
+			listeners[ type ].push( listener );
 
 		}
 
@@ -74,11 +83,9 @@ class EventDispatcher {
 
 		const listeners = this._listeners;
 
-		if ( listeners.size === 0 ) return false;
+		if ( listeners === undefined ) return false;
 
-		const listenerArray = listeners.get( type );
-
-		return listenerArray !== undefined && listenerArray.indexOf( listener ) !== - 1;
+		return listeners[ type ] !== undefined && listeners[ type ].indexOf( listener ) !== - 1;
 
 	}
 
@@ -92,9 +99,9 @@ class EventDispatcher {
 
 		const listeners = this._listeners;
 
-		if ( listeners.size === 0 ) return;
+		if ( listeners === undefined ) return;
 
-		const listenerArray = listeners.get( type );
+		const listenerArray = listeners[ type ];
 
 		if ( listenerArray !== undefined ) {
 
@@ -119,9 +126,9 @@ class EventDispatcher {
 
 		const listeners = this._listeners;
 
-		if ( listeners.size === 0 ) return;
+		if ( listeners === undefined ) return;
 
-		const listenerArray = listeners.get( event.type );
+		const listenerArray = listeners[ event.type ];
 
 		if ( listenerArray !== undefined ) {
 

--- a/src/core/EventDispatcher.js
+++ b/src/core/EventDispatcher.js
@@ -29,7 +29,7 @@ class EventDispatcher {
 
 		/**
 		 * This property is a container for
-		 * internal key/values.
+		 * internal key-value pairs.
 		 *
 		 * @type {Record<string,any>}
 		 */

--- a/src/core/EventDispatcher.js
+++ b/src/core/EventDispatcher.js
@@ -22,6 +22,15 @@
  */
 class EventDispatcher {
 
+	constructor() {
+
+		// Use a Map here (not a plain object) because we
+		// need to query for its size in some places.
+		/** @type {Map<string,Function[]>} */
+		this._listeners = new Map();
+
+	}
+
 	/**
 	 * Adds the given event listener to the given event type.
 	 *
@@ -30,19 +39,25 @@ class EventDispatcher {
 	 */
 	addEventListener( type, listener ) {
 
-		if ( this._listeners === undefined ) this._listeners = {};
+		if ( typeof listener !== 'function' ) {
 
-		const listeners = this._listeners;
-
-		if ( listeners[ type ] === undefined ) {
-
-			listeners[ type ] = [];
+			throw new Error( 'listener must be a function' );
 
 		}
 
-		if ( listeners[ type ].indexOf( listener ) === - 1 ) {
+		const listeners = this._listeners;
 
-			listeners[ type ].push( listener );
+		let listenerArray = listeners.get( type );
+
+		if ( listenerArray === undefined ) {
+
+			listeners.set( type, listenerArray = [] );
+
+		}
+
+		if ( listenerArray.indexOf( listener ) === - 1 ) {
+
+			listenerArray.push( listener );
 
 		}
 
@@ -59,9 +74,11 @@ class EventDispatcher {
 
 		const listeners = this._listeners;
 
-		if ( listeners === undefined ) return false;
+		if ( listeners.size === 0 ) return false;
 
-		return listeners[ type ] !== undefined && listeners[ type ].indexOf( listener ) !== - 1;
+		const listenerArray = listeners.get( type );
+
+		return listenerArray !== undefined && listenerArray.indexOf( listener ) !== - 1;
 
 	}
 
@@ -75,9 +92,9 @@ class EventDispatcher {
 
 		const listeners = this._listeners;
 
-		if ( listeners === undefined ) return;
+		if ( listeners.size === 0 ) return;
 
-		const listenerArray = listeners[ type ];
+		const listenerArray = listeners.get( type );
 
 		if ( listenerArray !== undefined ) {
 
@@ -102,9 +119,9 @@ class EventDispatcher {
 
 		const listeners = this._listeners;
 
-		if ( listeners === undefined ) return;
+		if ( listeners.size === 0 ) return;
 
-		const listenerArray = listeners[ event.type ];
+		const listenerArray = listeners.get( event.type );
 
 		if ( listenerArray !== undefined ) {
 

--- a/src/core/EventDispatcher.js
+++ b/src/core/EventDispatcher.js
@@ -28,10 +28,8 @@ class EventDispatcher {
 	constructor() {
 
 		/**
-		 * This property is for internal use only. It serves as
-		 * a container for properties that must be mutable even
-		 * if the {@link EventDispatcher} has been frozen via
-		 * Object.freeze().
+		 * This property is a container for
+		 * internal key/values.
 		 *
 		 * @type {Record<string,any>}
 		 */

--- a/src/core/EventDispatcher.js
+++ b/src/core/EventDispatcher.js
@@ -28,11 +28,10 @@ class EventDispatcher {
 	constructor() {
 
 		/**
-		 * This property is for internal use only.
-		 * It serves as a container for properties
-		 * that must be mutable even if the
-		 * {@link EventDispatcher} has been
-		 * frozen via Object.freeze().
+		 * This property is for internal use only. It serves as
+		 * a container for properties that must be mutable even
+		 * if the {@link EventDispatcher} has been frozen via
+		 * Object.freeze().
 		 *
 		 * @type {Record<string,any>}
 		 */

--- a/src/materials/nodes/NodeMaterial.js
+++ b/src/materials/nodes/NodeMaterial.js
@@ -418,15 +418,6 @@ class NodeMaterial extends Material {
 	}
 
 	/**
-	 * @param {boolean} enable
-	 */
-	_setHardwareClipping( enable ) {
-
-		this._internal.hardwareClipping = enable;
-
-	}
-
-	/**
 	 * Allows to define a custom cache key that influence the material key computation
 	 * for render objects.
 	 *
@@ -635,7 +626,9 @@ class NodeMaterial extends Material {
 	 */
 	setupHardwareClipping( builder ) {
 
-		this._setHardwareClipping( false );
+		const internal = this._internal;
+
+		internal.hardwareClipping = false;
 
 		if ( builder.clippingContext === null ) return;
 
@@ -647,7 +640,7 @@ class NodeMaterial extends Material {
 
 			builder.stack.add( hardwareClipping() );
 
-			this._setHardwareClipping( true );
+			internal.hardwareClipping = true;
 
 		}
 

--- a/src/materials/nodes/NodeMaterial.js
+++ b/src/materials/nodes/NodeMaterial.js
@@ -59,10 +59,8 @@ class NodeMaterial extends Material {
 		super();
 
 		/**
-		 * This property is for internal use only. It serves as
-		 * a container for properties that must be mutable even
-		 * if the {@link NodeMaterial} has been frozen via
-		 * Object.freeze().
+		 * This property is a container for
+		 * internal key/values.
 		 *
 		 * @type {Record<string,any>}
 		 */

--- a/src/materials/nodes/NodeMaterial.js
+++ b/src/materials/nodes/NodeMaterial.js
@@ -60,7 +60,7 @@ class NodeMaterial extends Material {
 
 		/**
 		 * This property is a container for
-		 * internal key/values.
+		 * internal key-value pairs.
 		 *
 		 * @type {Record<string,any>}
 		 */

--- a/src/materials/nodes/NodeMaterial.js
+++ b/src/materials/nodes/NodeMaterial.js
@@ -59,11 +59,10 @@ class NodeMaterial extends Material {
 		super();
 
 		/**
-		 * This property is for internal use only.
-		 * It serves as a container for properties
-		 * that must be mutable even if the
-		 * {@link NodeMaterial} has been
-		 * frozen via Object.freeze().
+		 * This property is for internal use only. It serves as
+		 * a container for properties that must be mutable even
+		 * if the {@link NodeMaterial} has been frozen via
+		 * Object.freeze().
 		 *
 		 * @type {Record<string,any>}
 		 */

--- a/src/materials/nodes/NodeMaterial.js
+++ b/src/materials/nodes/NodeMaterial.js
@@ -67,7 +67,9 @@ class NodeMaterial extends Material {
 		 *
 		 * @type {Record<string,any>}
 		 */
-		this._internal = [];
+		this._internal = {
+			hardwareClipping: false,
+		};
 
 		/**
 		 * This flag can be used for type testing.
@@ -405,15 +407,7 @@ class NodeMaterial extends Material {
 	 */
 	get hardwareClipping() {
 
-		const val = this._internal.hardwareClipping;
-
-		if ( val === undefined ) {
-
-			return false;
-
-		}
-
-		return val;
+		return this._internal.hardwareClipping;
 
 	}
 

--- a/src/materials/nodes/NodeMaterial.js
+++ b/src/materials/nodes/NodeMaterial.js
@@ -59,6 +59,17 @@ class NodeMaterial extends Material {
 		super();
 
 		/**
+		 * This property is for internal use only.
+		 * It serves as a container for properties
+		 * that must be mutable even if the
+		 * {@link NodeMaterial} has been
+		 * frozen via Object.freeze().
+		 *
+		 * @type {Record<string,any>}
+		 */
+		this._internal = [];
+
+		/**
 		 * This flag can be used for type testing.
 		 *
 		 * @type {boolean}
@@ -82,16 +93,6 @@ class NodeMaterial extends Material {
 		 * @default false
 		 */
 		this.lights = false;
-
-		/**
-		 * Whether this material uses hardware clipping or not.
-		 * This property is managed by the engine and should not be
-		 * modified by apps.
-		 *
-		 * @type {boolean}
-		 * @default false
-		 */
-		this.hardwareClipping = false;
 
 		/**
 		 * Node materials which set their `lights` property to `true`
@@ -394,6 +395,38 @@ class NodeMaterial extends Material {
 	}
 
 	/**
+	 * Whether this material uses hardware clipping or not.
+	 * This property is managed by the engine and should not be
+	 * modified by apps.
+	 *
+	 * @type {boolean}
+	 * @default false
+	 * @readonly
+	 */
+	get hardwareClipping() {
+
+		const val = this._internal.hardwareClipping;
+
+		if ( val === undefined ) {
+
+			return false;
+
+		}
+
+		return val;
+
+	}
+
+	/**
+	 * @param {boolean} enable
+	 */
+	_setHardwareClipping( enable ) {
+
+		this._internal.hardwareClipping = enable;
+
+	}
+
+	/**
 	 * Allows to define a custom cache key that influence the material key computation
 	 * for render objects.
 	 *
@@ -602,7 +635,7 @@ class NodeMaterial extends Material {
 	 */
 	setupHardwareClipping( builder ) {
 
-		this.hardwareClipping = false;
+		this._setHardwareClipping( false );
 
 		if ( builder.clippingContext === null ) return;
 
@@ -614,7 +647,7 @@ class NodeMaterial extends Material {
 
 			builder.stack.add( hardwareClipping() );
 
-			this.hardwareClipping = true;
+			this._setHardwareClipping( true );
 
 		}
 

--- a/src/materials/nodes/NodeMaterial.js
+++ b/src/materials/nodes/NodeMaterial.js
@@ -620,9 +620,7 @@ class NodeMaterial extends Material {
 	 */
 	setupHardwareClipping( builder ) {
 
-		const internal = this._internal;
-
-		internal.hardwareClipping = false;
+		this._internal.hardwareClipping = false;
 
 		if ( builder.clippingContext === null ) return;
 
@@ -634,7 +632,7 @@ class NodeMaterial extends Material {
 
 			builder.stack.add( hardwareClipping() );
 
-			internal.hardwareClipping = true;
+			this._internal.hardwareClipping = true;
 
 		}
 

--- a/test/unit/src/core/EventDispatcher.tests.js
+++ b/test/unit/src/core/EventDispatcher.tests.js
@@ -19,16 +19,16 @@ export default QUnit.module( 'Core', () => {
 
 			const eventDispatcher = new EventDispatcher();
 
-			const listener = {};
+			const listener = () => undefined;
 			eventDispatcher.addEventListener( 'anyType', listener );
 
-			assert.ok( eventDispatcher._listeners.anyType.length === 1, 'listener with unknown type was added' );
-			assert.ok( eventDispatcher._listeners.anyType[ 0 ] === listener, 'listener with unknown type was added' );
+			assert.ok( eventDispatcher._listeners.get( 'anyType' ).length === 1, 'listener with unknown type was added' );
+			assert.ok( eventDispatcher._listeners.get( 'anyType' )[ 0 ] === listener, 'listener with unknown type was added' );
 
 			eventDispatcher.addEventListener( 'anyType', listener );
 
-			assert.ok( eventDispatcher._listeners.anyType.length === 1, 'can\'t add one listener twice to same type' );
-			assert.ok( eventDispatcher._listeners.anyType[ 0 ] === listener, 'listener is still there' );
+			assert.ok( eventDispatcher._listeners.get( 'anyType' ).length === 1, 'can\'t add one listener twice to same type' );
+			assert.ok( eventDispatcher._listeners.get( 'anyType' )[ 0 ] === listener, 'listener is still there' );
 
 		} );
 
@@ -36,7 +36,7 @@ export default QUnit.module( 'Core', () => {
 
 			const eventDispatcher = new EventDispatcher();
 
-			const listener = {};
+			const listener = () => undefined;
 			eventDispatcher.addEventListener( 'anyType', listener );
 
 			assert.ok( eventDispatcher.hasEventListener( 'anyType', listener ), 'listener was found' );
@@ -48,22 +48,22 @@ export default QUnit.module( 'Core', () => {
 
 			const eventDispatcher = new EventDispatcher();
 
-			const listener = {};
+			const listener = () => undefined;
 
-			assert.ok( eventDispatcher._listeners === undefined, 'there are no listeners by default' );
+			assert.ok( eventDispatcher._listeners.size === 0, 'there are no listeners by default' );
 
 			eventDispatcher.addEventListener( 'anyType', listener );
-			assert.ok( Object.keys( eventDispatcher._listeners ).length === 1 &&
-				eventDispatcher._listeners.anyType.length === 1, 'if a listener was added, there is a new key' );
+			assert.ok( eventDispatcher._listeners.size === 1 &&
+				eventDispatcher._listeners.get( 'anyType' ).length === 1, 'if a listener was added, there is a new key' );
 
 			eventDispatcher.removeEventListener( 'anyType', listener );
-			assert.ok( eventDispatcher._listeners.anyType.length === 0, 'listener was deleted' );
+			assert.ok( eventDispatcher._listeners.get( 'anyType' ).length === 0, 'listener was deleted' );
 
 			eventDispatcher.removeEventListener( 'unknownType', listener );
-			assert.ok( eventDispatcher._listeners.unknownType === undefined, 'unknown types will be ignored' );
+			assert.ok( eventDispatcher._listeners.get( 'unknownType' ) === undefined, 'unknown types will be ignored' );
 
 			eventDispatcher.removeEventListener( 'anyType', undefined );
-			assert.ok( eventDispatcher._listeners.anyType.length === 0, 'undefined listeners are ignored' );
+			assert.ok( eventDispatcher._listeners.get( 'anyType' ).length === 0, 'undefined listeners are ignored' );
 
 		} );
 

--- a/test/unit/src/core/EventDispatcher.tests.js
+++ b/test/unit/src/core/EventDispatcher.tests.js
@@ -19,16 +19,16 @@ export default QUnit.module( 'Core', () => {
 
 			const eventDispatcher = new EventDispatcher();
 
-			const listener = () => undefined;
+			const listener = {};
 			eventDispatcher.addEventListener( 'anyType', listener );
 
-			assert.ok( eventDispatcher._listeners.get( 'anyType' ).length === 1, 'listener with unknown type was added' );
-			assert.ok( eventDispatcher._listeners.get( 'anyType' )[ 0 ] === listener, 'listener with unknown type was added' );
+			assert.ok( eventDispatcher._listeners.anyType.length === 1, 'listener with unknown type was added' );
+			assert.ok( eventDispatcher._listeners.anyType[ 0 ] === listener, 'listener with unknown type was added' );
 
 			eventDispatcher.addEventListener( 'anyType', listener );
 
-			assert.ok( eventDispatcher._listeners.get( 'anyType' ).length === 1, 'can\'t add one listener twice to same type' );
-			assert.ok( eventDispatcher._listeners.get( 'anyType' )[ 0 ] === listener, 'listener is still there' );
+			assert.ok( eventDispatcher._listeners.anyType.length === 1, 'can\'t add one listener twice to same type' );
+			assert.ok( eventDispatcher._listeners.anyType[ 0 ] === listener, 'listener is still there' );
 
 		} );
 
@@ -36,7 +36,7 @@ export default QUnit.module( 'Core', () => {
 
 			const eventDispatcher = new EventDispatcher();
 
-			const listener = () => undefined;
+			const listener = {};
 			eventDispatcher.addEventListener( 'anyType', listener );
 
 			assert.ok( eventDispatcher.hasEventListener( 'anyType', listener ), 'listener was found' );
@@ -48,22 +48,22 @@ export default QUnit.module( 'Core', () => {
 
 			const eventDispatcher = new EventDispatcher();
 
-			const listener = () => undefined;
+			const listener = {};
 
-			assert.ok( eventDispatcher._listeners.size === 0, 'there are no listeners by default' );
+			assert.ok( eventDispatcher._listeners === undefined, 'there are no listeners by default' );
 
 			eventDispatcher.addEventListener( 'anyType', listener );
-			assert.ok( eventDispatcher._listeners.size === 1 &&
-				eventDispatcher._listeners.get( 'anyType' ).length === 1, 'if a listener was added, there is a new key' );
+			assert.ok( Object.keys( eventDispatcher._listeners ).length === 1 &&
+				eventDispatcher._listeners.anyType.length === 1, 'if a listener was added, there is a new key' );
 
 			eventDispatcher.removeEventListener( 'anyType', listener );
-			assert.ok( eventDispatcher._listeners.get( 'anyType' ).length === 0, 'listener was deleted' );
+			assert.ok( eventDispatcher._listeners.anyType.length === 0, 'listener was deleted' );
 
 			eventDispatcher.removeEventListener( 'unknownType', listener );
-			assert.ok( eventDispatcher._listeners.get( 'unknownType' ) === undefined, 'unknown types will be ignored' );
+			assert.ok( eventDispatcher._listeners.unknownType === undefined, 'unknown types will be ignored' );
 
 			eventDispatcher.removeEventListener( 'anyType', undefined );
-			assert.ok( eventDispatcher._listeners.get( 'anyType' ).length === 0, 'undefined listeners are ignored' );
+			assert.ok( eventDispatcher._listeners.anyType.length === 0, 'undefined listeners are ignored' );
 
 		} );
 


### PR DESCRIPTION
Related issue: #31722 

**Description**

This PR enables "freezing" of `Material` objects via `Object.freeze(material)`. This is a useful feature for developers wanting to increase the reliability of their three.js scenes/game engines/material workflows. Read about `Object.freeze()` here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze

Previously, freezing a `Material` object via would throw an error when it was used on a mesh. With this PR, you will no longer get an error.

Example:

```javascript
const mat = new three.MeshLambertNodeMaterial();

Object.freeze(mat);
```
