### PR TITLE
Add export for BuiltinNode in TSL.js

### DIFF
--- a/src/nodes/TSL.js
+++ b/src/nodes/TSL.js
@@ -55,6 +55,7 @@ export * from './accessors/UniformArrayNode.js';
 export * from './accessors/Bitangent.js';
 export * from './accessors/BufferAttributeNode.js';
 export * from './accessors/BufferNode.js';
+export * from './accessors/BuiltinNode.js';
 export * from './accessors/Camera.js';
 export * from './accessors/VertexColorNode.js';
 export * from './accessors/CubeTextureNode.js';


### PR DESCRIPTION
Related issue: N/A

**Description**

Fixes https://github.com/mrdoob/three.js/pull/31615#discussion_r2296273225. `TSL.builtin` wasn't being exported from  `Three.TSL.js`, and therefore wasn't defined on `TSL`.