### PR TITLE
ExternalTexture: Support .copy(), .clone()

### DIFF
--- a/src/textures/ExternalTexture.js
+++ b/src/textures/ExternalTexture.js
@@ -41,6 +41,16 @@ class ExternalTexture extends Texture {
 
 	}
 
+	copy( source ) {
+
+		super.copy( source );
+
+		this.sourceTexture = source.sourceTexture;
+
+		return this;
+
+	}
+
 }
 
 export { ExternalTexture };


### PR DESCRIPTION
Allows the same ExternalTexture to be used with different configurations of UV transforms or channels.

Related:

- #31653