### PR TITLE
Examples: Clean up.

### DIFF
--- a/examples/webgpu_compute_particles.html
+++ b/examples/webgpu_compute_particles.html
@@ -46,7 +46,7 @@
 
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 
-			const particleCount = 200_000;
+			const particleCount = 200000;
 
 			const gravity = uniform( - .00098 );
 			const bounce = uniform( .8 );
@@ -231,11 +231,19 @@
 				controls.enableDamping = true;
 				controls.minDistance = 5;
 				controls.maxDistance = 200;
-				controls.target.set( 0, -8, 0 );
+				controls.target.set( 0, - 8, 0 );
 				controls.update();
 
-				controls.addEventListener( 'start', () => { isOrbitControlsActive = true; } );
-				controls.addEventListener( 'end', () => { isOrbitControlsActive = false; } );
+				controls.addEventListener( 'start', () => {
+
+					isOrbitControlsActive = true;
+
+				} );
+				controls.addEventListener( 'end', () => {
+
+					isOrbitControlsActive = false;
+
+				} );
 
 				controls.touches = {
 					ONE: null,

--- a/examples/webgpu_lights_custom.html
+++ b/examples/webgpu_lights_custom.html
@@ -31,7 +31,7 @@
 
 			class CustomLightingModel extends THREE.LightingModel {
 
-				direct( { lightColor, reflectedLight }, stack ) {
+				direct( { lightColor, reflectedLight }/*, builder */ ) {
 
 					reflectedLight.directDiffuse.addAssign( lightColor );
 
@@ -85,7 +85,7 @@
 
 				const points = [];
 
-				for ( let i = 0; i < 500_000; i ++ ) {
+				for ( let i = 0; i < 500000; i ++ ) {
 
 					const point = new THREE.Vector3().random().subScalar( 0.5 ).multiplyScalar( 3 );
 					points.push( point );


### PR DESCRIPTION
Related issue: -

**Description**

Numbers like `200_000` break ESLint. For consistency reasons, better to use normal number notation.
