### PR TITLE
TSL: Fix `bitcast` type resolver

### DIFF
--- a/src/nodes/Nodes.js
+++ b/src/nodes/Nodes.js
@@ -57,6 +57,9 @@ export { default as MemberNode } from './utils/MemberNode.js';
 export { default as DebugNode } from './utils/DebugNode.js';
 export { default as EventNode } from './utils/EventNode.js';
 
+// math
+export { default as BitcastNode } from './math/BitcastNode.js';
+
 // accessors
 export { default as UniformArrayNode } from './accessors/UniformArrayNode.js';
 export { default as BufferAttributeNode } from './accessors/BufferAttributeNode.js';

--- a/src/nodes/TSL.js
+++ b/src/nodes/TSL.js
@@ -19,6 +19,7 @@ export * from './core/OutputStructNode.js';
 export * from './core/MRTNode.js';
 
 // math
+export * from './math/BitcastNode.js';
 export * from './math/Hash.js';
 export * from './math/MathUtils.js';
 export * from './math/TriNoise3D.js';

--- a/src/nodes/math/BitcastNode.js
+++ b/src/nodes/math/BitcastNode.js
@@ -1,0 +1,131 @@
+import TempNode from '../core/TempNode.js';
+import { nodeProxyIntent } from '../tsl/TSLCore.js';
+/**
+ * This node represents an operation that reinterprets the bit representation of a value
+ * in one type as a value in another type.
+ *
+ * @augments TempNode
+ */
+class BitcastNode extends TempNode {
+
+	static get type() {
+
+		return 'BitcastNode';
+
+	}
+
+	/**
+	 * Constructs a new bitcast node.
+	 *
+	 * @param {Node} valueNode - The value to convert.
+	 * @param {string} conversionType - The type to convert to.
+	 */
+	constructor( valueNode, conversionType ) {
+
+		super();
+
+		/**
+		 * The data to bitcast to a new type.
+		 *
+		 * @type {Node}
+		 */
+		this.valueNode = valueNode;
+
+		/**
+		 * The type the value will be converted to.
+		 *
+		 * @type {string}
+		 * @default null
+		 */
+		this.conversionType = conversionType;
+
+		/**
+		 * This flag can be used for type testing.
+		 *
+		 * @type {boolean}
+		 * @readonly
+		 * @default true
+		 */
+		this.isBitcastNode = true;
+
+	}
+
+	/**
+	 * The input type is inferred from the node types of the input node.
+	 *
+	 * @param {NodeBuilder} builder - The current node builder.
+	 * @return {string} The input type.
+	 */
+	getInputType( builder ) {
+
+		return this.aNode.getNodeType( builder );
+
+	}
+
+	/**
+	 * The node's type is defined by the conversion type.
+	 *
+	 * @return {string} The node type.
+	 */
+	getNodeType() {
+
+		return this.conversionType;
+
+	}
+
+
+	generate( builder, output ) {
+
+		const properties = builder.getNodeProperties( this );
+
+		if ( properties.outputNode ) {
+
+			return super.generate( builder, output );
+
+		}
+
+		const type = this.getNodeType( builder );
+		const inputType = this.getInputType( builder );
+
+		const params = [];
+
+		params.push(
+			this.aNode.build( builder, inputType ),
+		);
+
+		return builder.format( `bitcast<${ builder.getType( type ) }>( ${ params.join( ', ' ) } )`, inputType, output );
+
+
+
+	}
+
+	serialize( data ) {
+
+		super.serialize( data );
+
+		data.method = this.method;
+
+	}
+
+	deserialize( data ) {
+
+		super.deserialize( data );
+
+		this.method = data.method;
+
+	}
+
+}
+
+export default BitcastNode;
+
+/**
+ * Reinterpret the bit representation of a value in one type as a value in another type.
+ *
+ * @tsl
+ * @function
+ * @param {Node | number} x - The parameter.
+ * @param {string} y - The new type.
+ * @returns {Node}
+ */
+export const bitcast = /*@__PURE__*/ nodeProxyIntent( BitcastNode ).setParameterLength( 2 );

--- a/src/nodes/math/BitcastNode.js
+++ b/src/nodes/math/BitcastNode.js
@@ -1,5 +1,5 @@
 import TempNode from '../core/TempNode.js';
-import { nodeProxy, nodeProxyIntent } from '../tsl/TSLCore.js';
+import { nodeProxyIntent } from '../tsl/TSLCore.js';
 /**
  * This node represents an operation that reinterprets the bit representation of a value
  * in one type as a value in another type.
@@ -51,18 +51,6 @@ class BitcastNode extends TempNode {
 	}
 
 	/**
-	 * The input type is inferred from the node types of the input node.
-	 *
-	 * @param {NodeBuilder} builder - The current node builder.
-	 * @return {string} The input type.
-	 */
-	getInputType( builder ) {
-
-		return this.valueNode.getNodeType( builder );
-
-	}
-
-	/**
 	 * The node's type is defined by the conversion type.
 	 *
 	 * @return {string} The node type.
@@ -74,25 +62,10 @@ class BitcastNode extends TempNode {
 	}
 
 
-	setup( builder ) {
-
-		return super.setup( builder );
-
-	}
-
-
-	generate( builder, output ) {
-
-		const properties = builder.getNodeProperties( this );
-
-		if ( properties.outputNode ) {
-
-			return super.generate( builder, output );
-
-		}
+	generate( builder ) {
 
 		const type = this.getNodeType( builder );
-		const inputType = this.getInputType( builder );
+		const inputType = this.valueNode.getNodeType( builder );
 
 		const params = [];
 
@@ -100,25 +73,8 @@ class BitcastNode extends TempNode {
 			this.valueNode.build( builder, inputType ),
 		);
 
-		return builder.format( `bitcast<${ builder.getType( type ) }>( ${ params.join( ', ' ) } )`, inputType, output );
+		return `bitcast<${ builder.getType( type ) }>( ${ params.join( ', ' ) } )`;
 
-
-
-	}
-
-	serialize( data ) {
-
-		super.serialize( data );
-
-		data.method = this.method;
-
-	}
-
-	deserialize( data ) {
-
-		super.deserialize( data );
-
-		this.method = data.method;
 
 	}
 

--- a/src/nodes/math/BitcastNode.js
+++ b/src/nodes/math/BitcastNode.js
@@ -1,5 +1,5 @@
 import TempNode from '../core/TempNode.js';
-import { nodeProxyIntent } from '../tsl/TSLCore.js';
+import { nodeProxy } from '../tsl/TSLCore.js';
 /**
  * This node represents an operation that reinterprets the bit representation of a value
  * in one type as a value in another type.
@@ -58,7 +58,7 @@ class BitcastNode extends TempNode {
 	 */
 	getInputType( builder ) {
 
-		return this.aNode.getNodeType( builder );
+		return this.valueNode.getNodeType( builder );
 
 	}
 
@@ -70,6 +70,13 @@ class BitcastNode extends TempNode {
 	getNodeType() {
 
 		return this.conversionType;
+
+	}
+
+
+	setup( builder ) {
+
+		return super.setup( builder );
 
 	}
 
@@ -90,7 +97,7 @@ class BitcastNode extends TempNode {
 		const params = [];
 
 		params.push(
-			this.aNode.build( builder, inputType ),
+			this.valueNode.build( builder, inputType ),
 		);
 
 		return builder.format( `bitcast<${ builder.getType( type ) }>( ${ params.join( ', ' ) } )`, inputType, output );
@@ -128,4 +135,4 @@ export default BitcastNode;
  * @param {string} y - The new type.
  * @returns {Node}
  */
-export const bitcast = /*@__PURE__*/ nodeProxyIntent( BitcastNode ).setParameterLength( 2 );
+export const bitcast = /*@__PURE__*/ nodeProxy( BitcastNode ).setParameterLength( 2 );

--- a/src/nodes/math/BitcastNode.js
+++ b/src/nodes/math/BitcastNode.js
@@ -1,5 +1,5 @@
 import TempNode from '../core/TempNode.js';
-import { nodeProxy } from '../tsl/TSLCore.js';
+import { nodeProxy, nodeProxyIntent } from '../tsl/TSLCore.js';
 /**
  * This node represents an operation that reinterprets the bit representation of a value
  * in one type as a value in another type.
@@ -135,4 +135,4 @@ export default BitcastNode;
  * @param {string} y - The new type.
  * @returns {Node}
  */
-export const bitcast = /*@__PURE__*/ nodeProxy( BitcastNode ).setParameterLength( 2 );
+export const bitcast = /*@__PURE__*/ nodeProxyIntent( BitcastNode ).setParameterLength( 2 );

--- a/src/nodes/math/BitcastNode.js
+++ b/src/nodes/math/BitcastNode.js
@@ -67,13 +67,7 @@ class BitcastNode extends TempNode {
 		const type = this.getNodeType( builder );
 		const inputType = this.valueNode.getNodeType( builder );
 
-		const params = [];
-
-		params.push(
-			this.valueNode.build( builder, inputType ),
-		);
-
-		return `bitcast<${ builder.getType( type ) }>( ${ params.join( ', ' ) } )`;
+		return `${builder.getBitcastMethod( type, inputType )}( ${ this.valueNode.build( builder, inputType ) } )`;
 
 
 	}

--- a/src/nodes/math/MathNode.js
+++ b/src/nodes/math/MathNode.js
@@ -264,13 +264,7 @@ class MathNode extends TempNode {
 				a.build( builder, inputType ),
 			);
 
-			console.log( type );
-			console.log( inputType );
-
-			const text = builder.format( `${ builder.getMethod( method, type ) }( ${params.join( ', ' )} )`, inputType, output );
-			console.log( text );
-
-			return text;
+			return builder.format( `${ builder.getMethod( method, type ) }( ${params.join( ', ' )} )`, inputType, output );
 
 		} else {
 

--- a/src/nodes/math/MathNode.js
+++ b/src/nodes/math/MathNode.js
@@ -264,7 +264,7 @@ class MathNode extends TempNode {
 				a.build( builder, inputType ),
 			);
 
-			return builder.format( `${ builder.getMethod( method, type ) }( ${params.join( ', ' )} )`, inputType, output );
+			return builder.format( `${ builder.getMethod( method ) }<${builder.getType( type )}>( ${params.join( ', ' )} )`, inputType, output );
 
 		} else {
 

--- a/src/nodes/math/MathNode.js
+++ b/src/nodes/math/MathNode.js
@@ -366,7 +366,6 @@ MathNode.INVERSE = 'inverse';
 
 // 2 inputs
 
-MathNode.BITCAST = 'bitcast';
 MathNode.EQUALS = 'equals';
 MathNode.MIN = 'min';
 MathNode.MAX = 'max';
@@ -766,17 +765,6 @@ export const determinant = /*@__PURE__*/ nodeProxyIntent( MathNode, MathNode.DET
 export const inverse = /*@__PURE__*/ nodeProxyIntent( MathNode, MathNode.INVERSE ).setParameterLength( 1 );
 
 // 2 inputs
-
-/**
- * Reinterpret the bit representation of a value in one type as a value in another type.
- *
- * @tsl
- * @function
- * @param {Node | number} x - The parameter.
- * @param {string} y - The new type.
- * @returns {Node}
- */
-export const bitcast = /*@__PURE__*/ nodeProxyIntent( MathNode, MathNode.BITCAST ).setParameterLength( 2 );
 
 /**
  * Returns `true` if `x` equals `y`.

--- a/src/nodes/math/MathNode.js
+++ b/src/nodes/math/MathNode.js
@@ -101,8 +101,8 @@ class MathNode extends TempNode {
 	getInputType( builder ) {
 
 		const aType = this.aNode.getNodeType( builder );
-		const bType = ( this.bNode && this.bNode.isNode ) ? this.bNode.getNodeType( builder ) : null;
-		const cType = ( this.cNode && this.cNode.isNode ) ? this.cNode.getNodeType( builder ) : null;
+		const bType = this.bNode ? this.bNode.getNodeType( builder ) : null;
+		const cType = this.cNode ? this.cNode.getNodeType( builder ) : null;
 
 		const aLen = builder.isMatrix( aType ) ? 0 : builder.getTypeLength( aType );
 		const bLen = builder.isMatrix( bType ) ? 0 : builder.getTypeLength( bType );
@@ -151,10 +151,6 @@ class MathNode extends TempNode {
 		} else if ( method === MathNode.EQUALS ) {
 
 			return builder.changeComponentType( this.aNode.getNodeType( builder ), 'bool' );
-
-		} else if ( method === MathNode.BITCAST ) {
-
-			return this.bNode;
 
 		} else {
 
@@ -243,17 +239,6 @@ class MathNode extends TempNode {
 
 			return builder.format( '( - ' + a.build( builder, inputType ) + ' )', type, output );
 
-
-		} else if ( method === MathNode.BITCAST ) {
-
-			const params = [];
-
-			params.push(
-				a.build( builder, inputType ),
-			);
-
-			return builder.format( `${ builder.getMethod( method ) }<${ builder.getType( type ) }>( ${ params.join( ', ' ) } )`, inputType, output );
-
 		} else {
 
 			const params = [];
@@ -317,7 +302,7 @@ class MathNode extends TempNode {
 
 			}
 
-			return builder.format( `${ builder.getMethod( method, type ) }( ${ params.join( ', ' ) } )`, type, output );
+			return builder.format( `${ builder.getMethod( method, type ) }( ${params.join( ', ' )} )`, type, output );
 
 		}
 

--- a/src/nodes/math/MathNode.js
+++ b/src/nodes/math/MathNode.js
@@ -101,7 +101,19 @@ class MathNode extends TempNode {
 	getInputType( builder ) {
 
 		const aType = this.aNode.getNodeType( builder );
-		const bType = this.bNode ? this.bNode.getNodeType( builder ) : null;
+		let bType;
+
+		// bType is the node itself for bitcast
+		if ( this.method === MathNode.BITCAST ) {
+
+			bType = null;
+
+		} else {
+
+			bType = this.bNode ? this.bNode.getNodeType( builder ) : null;
+
+		}
+
 		const cType = this.cNode ? this.cNode.getNodeType( builder ) : null;
 
 		const aLen = builder.isMatrix( aType ) ? 0 : builder.getTypeLength( aType );
@@ -151,6 +163,10 @@ class MathNode extends TempNode {
 		} else if ( method === MathNode.EQUALS ) {
 
 			return builder.changeComponentType( this.aNode.getNodeType( builder ), 'bool' );
+
+		} else if ( method === MathNode.BITCAST ) {
+
+			return this.bNode;
 
 		} else {
 
@@ -239,6 +255,23 @@ class MathNode extends TempNode {
 
 			return builder.format( '( - ' + a.build( builder, inputType ) + ' )', type, output );
 
+
+		} else if ( method === MathNode.BITCAST ) {
+
+			const params = [];
+
+			params.push(
+				a.build( builder, inputType ),
+			);
+
+			console.log( type );
+			console.log( inputType );
+
+			const text = builder.format( `${ builder.getMethod( method, type ) }( ${params.join( ', ' )} )`, inputType, output );
+			console.log( text );
+
+			return text;
+
 		} else {
 
 			const params = [];
@@ -248,6 +281,12 @@ class MathNode extends TempNode {
 				params.push(
 					a.build( builder, type ),
 					b.build( builder, type )
+				);
+
+			} else if ( method === MathNode.BITCAST ) {
+
+				params.push(
+					a.build( builder, inputType ),
 				);
 
 			} else if ( coordinateSystem === WebGLCoordinateSystem && method === MathNode.STEP ) {

--- a/src/nodes/math/MathNode.js
+++ b/src/nodes/math/MathNode.js
@@ -277,12 +277,6 @@ class MathNode extends TempNode {
 					b.build( builder, type )
 				);
 
-			} else if ( method === MathNode.BITCAST ) {
-
-				params.push(
-					a.build( builder, inputType ),
-				);
-
 			} else if ( coordinateSystem === WebGLCoordinateSystem && method === MathNode.STEP ) {
 
 				params.push(

--- a/src/nodes/math/MathNode.js
+++ b/src/nodes/math/MathNode.js
@@ -101,20 +101,8 @@ class MathNode extends TempNode {
 	getInputType( builder ) {
 
 		const aType = this.aNode.getNodeType( builder );
-		let bType;
-
-		// bType is the node itself for bitcast
-		if ( this.method === MathNode.BITCAST ) {
-
-			bType = null;
-
-		} else {
-
-			bType = this.bNode ? this.bNode.getNodeType( builder ) : null;
-
-		}
-
-		const cType = this.cNode ? this.cNode.getNodeType( builder ) : null;
+		const bType = ( this.bNode && this.bNode.isNode ) ? this.bNode.getNodeType( builder ) : null;
+		const cType = ( this.cNode && this.cNode.isNode ) ? this.cNode.getNodeType( builder ) : null;
 
 		const aLen = builder.isMatrix( aType ) ? 0 : builder.getTypeLength( aType );
 		const bLen = builder.isMatrix( bType ) ? 0 : builder.getTypeLength( bType );

--- a/src/nodes/math/MathNode.js
+++ b/src/nodes/math/MathNode.js
@@ -252,7 +252,7 @@ class MathNode extends TempNode {
 				a.build( builder, inputType ),
 			);
 
-			return builder.format( `${ builder.getMethod( method ) }<${builder.getType( type )}>( ${params.join( ', ' )} )`, inputType, output );
+			return builder.format( `${ builder.getMethod( method ) }<${ builder.getType( type ) }>( ${ params.join( ', ' ) } )`, inputType, output );
 
 		} else {
 
@@ -317,7 +317,7 @@ class MathNode extends TempNode {
 
 			}
 
-			return builder.format( `${ builder.getMethod( method, type ) }( ${params.join( ', ' )} )`, type, output );
+			return builder.format( `${ builder.getMethod( method, type ) }( ${ params.join( ', ' ) } )`, type, output );
 
 		}
 

--- a/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
+++ b/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
@@ -137,6 +137,7 @@ class GLSLNodeBuilder extends NodeBuilder {
 		return glslMethods[ method ] || method;
 
 	}
+
 	/**
 	 * Returns the bitcast method name for a given input and outputType.
 	 *

--- a/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
+++ b/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
@@ -10,7 +10,11 @@ import { DataTexture } from '../../../textures/DataTexture.js';
 
 const glslMethods = {
 	textureDimensions: 'textureSize',
-	equals: 'equal'
+	equals: 'equal',
+	bitcast_float_int: 'floatBitsToInt',
+	bitcast_int_float: 'intBitsToFloat',
+	bitcast_uint_float: 'uintBitsToFloat',
+	bitcast_float_uint: 'floatBitsToUint',
 };
 
 const precisionLib = {
@@ -131,6 +135,18 @@ class GLSLNodeBuilder extends NodeBuilder {
 	getMethod( method ) {
 
 		return glslMethods[ method ] || method;
+
+	}
+	/**
+	 * Returns the bitcast method name for a given input and outputType.
+	 *
+	 * @param {string} type - The output type to bitcast to.
+	 * @param {string} inputType - The input type of the.
+	 * @return {string} The resolved WGSL bitcast invocation.
+	 */
+	getBitcastMethod( type, inputType ) {
+
+		return glslMethods[ `bitcast_${ inputType }_${ type }` ];
 
 	}
 

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -127,7 +127,8 @@ const wgslMethods = {
 	equals_bvec2: 'tsl_equals_bvec2',
 	equals_bvec3: 'tsl_equals_bvec3',
 	equals_bvec4: 'tsl_equals_bvec4',
-	inversesqrt: 'inverseSqrt'
+	inversesqrt: 'inverseSqrt',
+	bitcast: 'bitcast<f32>'
 };
 
 // WebGPU issue: does not support pow() with negative base on Windows

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -128,7 +128,18 @@ const wgslMethods = {
 	equals_bvec3: 'tsl_equals_bvec3',
 	equals_bvec4: 'tsl_equals_bvec4',
 	inversesqrt: 'inverseSqrt',
-	bitcast: 'bitcast<f32>'
+	bitcast_float: 'bitcast<f32>',
+	bitcast_uint: 'bitcast<u32>',
+	bitcast_int: 'bitcast<i32>',
+	bitcast_vec2: 'bitcast<vec2<f32>>',
+	bitcast_ivec2: 'bitcast<vec2<i32>>',
+	bitcast_uvec2: 'bitcast<vec2<u32>>',
+	bitcast_vec3: 'bitcast<vec3<f32>>',
+	bitcast_ivec3: 'bitcast<vec3<i32>>',
+	bitcast_uvec3: 'bitcast<vec3<u32>>',
+	bitcast_vec4: 'bitcast<vec4<f32>>',
+	bitcast_ivec4: 'bitcast<vec4<i32>>',
+	bitcast_uvec4: 'bitcast<vec4<u32>>'
 };
 
 // WebGPU issue: does not support pow() with negative base on Windows
@@ -1867,6 +1878,8 @@ ${ flowData.code }
 			const workgroupSize = this.object.workgroupSize;
 
 			this.computeShader = this._getWGSLComputeCode( shadersData.compute, workgroupSize );
+
+			console.log( this.computeShader );
 
 		}
 

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -127,19 +127,7 @@ const wgslMethods = {
 	equals_bvec2: 'tsl_equals_bvec2',
 	equals_bvec3: 'tsl_equals_bvec3',
 	equals_bvec4: 'tsl_equals_bvec4',
-	inversesqrt: 'inverseSqrt',
-	bitcast_float: 'bitcast<f32>',
-	bitcast_uint: 'bitcast<u32>',
-	bitcast_int: 'bitcast<i32>',
-	bitcast_vec2: 'bitcast<vec2<f32>>',
-	bitcast_ivec2: 'bitcast<vec2<i32>>',
-	bitcast_uvec2: 'bitcast<vec2<u32>>',
-	bitcast_vec3: 'bitcast<vec3<f32>>',
-	bitcast_ivec3: 'bitcast<vec3<i32>>',
-	bitcast_uvec3: 'bitcast<vec3<u32>>',
-	bitcast_vec4: 'bitcast<vec4<f32>>',
-	bitcast_ivec4: 'bitcast<vec4<i32>>',
-	bitcast_uvec4: 'bitcast<vec4<u32>>'
+	inversesqrt: 'inverseSqrt'
 };
 
 // WebGPU issue: does not support pow() with negative base on Windows
@@ -1878,8 +1866,6 @@ ${ flowData.code }
 			const workgroupSize = this.object.workgroupSize;
 
 			this.computeShader = this._getWGSLComputeCode( shadersData.compute, workgroupSize );
-
-			console.log( this.computeShader );
 
 		}
 

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -1900,6 +1900,20 @@ ${ flowData.code }
 	}
 
 	/**
+	 * Returns the bitcast method name for a given input and outputType.
+	 *
+	 * @param {string} type - The output type to bitcast to.
+	 * @return {string} The resolved WGSL bitcast invocation.
+	 */
+	getBitcastMethod( type ) {
+
+		const dataType = this.getType( type );
+
+		return `bitcast<${ dataType }>`;
+
+	}
+
+	/**
 	 * Returns the native snippet for a ternary operation.
 	 *
 	 * @param {string} condSnippet - The condition determining which expression gets resolved.


### PR DESCRIPTION
Related issue: #31735 

**Description**

Fixes bitcast functionality on WebGPU backend. Bitcast functionality was previously not working since the MathNode could not resolve getNodeType from the type string passed to bitcast. 
