### PR TITLE
Sampler: Fix dispose.

### DIFF
--- a/src/renderers/common/Sampler.js
+++ b/src/renderers/common/Sampler.js
@@ -19,17 +19,6 @@ class Sampler extends Binding {
 		super( name );
 
 		/**
-		 * This function is called when the texture is disposed.
-		 * @type {function}
-		 * @private
-		 */
-		this._onDisposeTexture = () => {
-
-			this.texture = null;
-
-		};
-
-		/**
 		 * The texture the sampler is referring to.
 		 *
 		 * @type {?Texture}
@@ -71,9 +60,17 @@ class Sampler extends Binding {
 
 		if ( this._texture === value ) return;
 
+		const onDispose = () => {
+
+			this._texture = null;
+			this.generation = null;
+			this.version = 0;
+
+		};
+
 		if ( this._texture ) {
 
-			this._texture.removeEventListener( 'dispose', this._onDisposeTexture );
+			this._texture.removeEventListener( 'dispose', onDispose );
 
 		}
 
@@ -84,7 +81,7 @@ class Sampler extends Binding {
 
 		if ( this._texture ) {
 
-			this._texture.addEventListener( 'dispose', this._onDisposeTexture );
+			this._texture.addEventListener( 'dispose', onDispose );
 
 		}
 
@@ -119,6 +116,21 @@ class Sampler extends Binding {
 		}
 
 		return false;
+
+	}
+
+
+	clone() {
+
+		const clonedSampler = super.clone();
+
+		// fix dispose handler for cloned instances
+		// TODO: Find better solution, see #31747
+
+		clonedSampler._texture = null;
+		clonedSampler.texture = this.texture;
+
+		return clonedSampler;
 
 	}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/31747#issuecomment-3223453560

**Description**

Fixes the dispose logic in the `Sampler` binding class.
