### PR TITLE
Bugfix for WebGPU: Call Texture.onUpdate() after mipmap generation instead of before

### DIFF
--- a/src/renderers/common/Textures.js
+++ b/src/renderers/common/Textures.js
@@ -308,6 +308,8 @@ class Textures extends DataMap {
 
 					if ( options.needsMipmaps && texture.mipmaps.length === 0 ) backend.generateMipmaps( texture );
 
+					if ( texture.onUpdate ) texture.onUpdate( texture );
+
 				}
 
 			} else {

--- a/src/renderers/webgpu/utils/WebGPUTextureUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUTextureUtils.js
@@ -512,8 +512,6 @@ class WebGPUTextureUtils {
 
 		textureData.version = texture.version;
 
-		if ( texture.onUpdate ) texture.onUpdate( texture );
-
 	}
 
 	/**


### PR DESCRIPTION
There is an inconsistency between the WebGL and WebGPU implementations regarding the `Texture.onUpdate()` callback.

A common(?) use case for this callback is to dispose of the image from RAM once it has been uploaded to the GPU. Currently, in WebGL, one can do:

```
const texture = new Texture();
// ... set texture properties, source image etc.
texture.onUpdate = myDisposeFunction;
```

where `myDisposeFunction` does something like `delete texture.source.data;` or equivalent, thus allowing the image resource to be garbage collected.

With this, the texture can then be added to the scene at leisure, and one can be confident that whenever it get uploaded to the GPU, the dispose function will be called. Since the texture is already on the GPU, one might no longer need it in RAM, and this memory management is necessary for some projects. In WebGL mode, this code currently works fine.

However, in WebGPU mode, this same code causes an error, because Three.js will try to create mipmaps AFTER `texture.onUpdate()` has been called. The mipmaps will try to access the deleted image source, throwing an error. The mipmaps might also actually be needed for the texture, so they should probably be generated first.

Indeed, when comparing `WebGLTextures.js:uploadTexture()` with `Textures.js:updateTexture()`, we can see that in WebGL, mipmap generation happens before the `onUpdate()` callback is called. In WebGPU, it's done after.

In this pull request, I try to fix this issue, with the motivation of making it conform with how it works in WebGL. This fix definitely solves the issue at least for my project. I welcome feedback or discussion from those more familiar with this part of the code, as I am a new contributor.