### PR TITLE
Docs: Clean up.

### DIFF
--- a/docs/api/en/materials/MeshDistanceMaterial.html
+++ b/docs/api/en/materials/MeshDistanceMaterial.html
@@ -18,7 +18,7 @@
 			Can also be used to customize the shadow casting of an object by assigning
 			an instance of [name] to [page:Object3D.customDistanceMaterial]. The
 			following examples demonstrates this approach in order to ensure
-			transparent parts of objects do no cast shadows.
+			transparent parts of objects do not cast shadows.
 		</p>
 
 		<h2>Examples</h2>

--- a/src/materials/MeshDistanceMaterial.js
+++ b/src/materials/MeshDistanceMaterial.js
@@ -7,7 +7,7 @@ import { Material } from './Material.js';
  * Can also be used to customize the shadow casting of an object by assigning
  * an instance of `MeshDistanceMaterial` to {@link Object3D#customDistanceMaterial}.
  * The following examples demonstrates this approach in order to ensure
- * transparent parts of objects do no cast shadows.
+ * transparent parts of objects do not cast shadows.
  *
  * @augments Material
  */


### PR DESCRIPTION
Fixed #31753.

**Description**

Fixed a typo in context of `MeshDistanceMaterial`.
