### PR TITLE
Bindings: Fix caching of texture bindings.

### DIFF
--- a/src/renderers/common/Bindings.js
+++ b/src/renderers/common/Bindings.js
@@ -267,6 +267,8 @@ class Bindings extends DataMap {
 
 						needsBindingsUpdate = true;
 
+						cacheBindings = false;
+
 					}
 
 				}


### PR DESCRIPTION
Related issue: #31751

**Description**

I was still experiencing warnings with the WebGPU backend in _some_ occasions. After more debugging, I found out that caching bind groups (which is only done for WebGPU) must not be allowed if `binding.generation` was set to `true`. In this case a new GPU texture has been created which must be reflected in the bind group.