### PR TITLE
Manual: Fix missed href parameters for manual/#xx/lights

### DIFF
--- a/manual/en/lights.html
+++ b/manual/en/lights.html
@@ -42,14 +42,14 @@ const near = 0.1;
 const camera = new THREE.PerspectiveCamera(fov, aspect, near, far);
 +camera.position.set(0, 10, 20);
 </pre>
-<p>Next let's add <a href="/docs/#examples/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a>. <a href="/docs/#examples/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a> let the user spin
-or <em>orbit</em> the camera around some point. The <a href="/docs/#examples/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a> are
+<p>Next let's add <a href="/docs/#examples/en/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a>. <a href="/docs/#examples/en/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a> let the user spin
+or <em>orbit</em> the camera around some point. The <a href="/docs/#examples/en/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a> are
 an optional feature of three.js so first we need to include them
 in our page</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">import * as THREE from 'three';
 +import {OrbitControls} from 'three/addons/controls/OrbitControls.js';
 </pre>
-<p>Then we can use them. We pass the <a href="/docs/#examples/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a> a camera to
+<p>Then we can use them. We pass the <a href="/docs/#examples/en/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a> a camera to
 control and the DOM element to use to get input events</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">const controls = new OrbitControls(camera, canvas);
 controls.target.set(0, 5, 0);

--- a/manual/fr/lights.html
+++ b/manual/fr/lights.html
@@ -42,14 +42,14 @@ const near = 0.1;
 const camera = new THREE.PerspectiveCamera(fov, aspect, near, far);
 +camera.position.set(0, 10, 20);
 </pre>
-<p>Ajoutons ensuite <a href="/docs/#examples/fr/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a>. Les <a href="/docs/#examples/fr/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a>
-permettent à l'utilisateur de faire tourner ou d'<em>orbiter</em> la caméra autour d'un point. Les <a href="/docs/#examples/fr/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a>
+<p>Ajoutons ensuite <a href="/docs/#examples/en/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a>. Les <a href="/docs/#examples/en/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a>
+permettent à l'utilisateur de faire tourner ou d'<em>orbiter</em> la caméra autour d'un point. Les <a href="/docs/#examples/en/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a>
 sont une fonctionnalité optionnelle de three.js, nous devons donc d'abord les inclure
 dans notre page</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">import * as THREE from 'three';
 +import {OrbitControls} from 'three/addons/controls/OrbitControls.js';
 </pre>
-<p>Ensuite, nous pouvons les utiliser. Nous passons aux <a href="/docs/#examples/fr/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a> une caméra à
+<p>Ensuite, nous pouvons les utiliser. Nous passons aux <a href="/docs/#examples/en/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a> une caméra à
 contrôler et l'élément DOM à utiliser pour obtenir les événements d'entrée</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">const controls = new OrbitControls(camera, canvas);
 controls.target.set(0, 5, 0);

--- a/manual/fr/lights.html
+++ b/manual/fr/lights.html
@@ -42,14 +42,14 @@ const near = 0.1;
 const camera = new THREE.PerspectiveCamera(fov, aspect, near, far);
 +camera.position.set(0, 10, 20);
 </pre>
-<p>Ajoutons ensuite <a href="/docs/#examples/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a>. Les <a href="/docs/#examples/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a>
-permettent à l'utilisateur de faire tourner ou d'<em>orbiter</em> la caméra autour d'un point. Les <a href="/docs/#examples/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a>
+<p>Ajoutons ensuite <a href="/docs/#examples/fr/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a>. Les <a href="/docs/#examples/fr/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a>
+permettent à l'utilisateur de faire tourner ou d'<em>orbiter</em> la caméra autour d'un point. Les <a href="/docs/#examples/fr/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a>
 sont une fonctionnalité optionnelle de three.js, nous devons donc d'abord les inclure
 dans notre page</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">import * as THREE from 'three';
 +import {OrbitControls} from 'three/addons/controls/OrbitControls.js';
 </pre>
-<p>Ensuite, nous pouvons les utiliser. Nous passons aux <a href="/docs/#examples/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a> une caméra à
+<p>Ensuite, nous pouvons les utiliser. Nous passons aux <a href="/docs/#examples/fr/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a> une caméra à
 contrôler et l'élément DOM à utiliser pour obtenir les événements d'entrée</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">const controls = new OrbitControls(camera, canvas);
 controls.target.set(0, 5, 0);

--- a/manual/ja/lights.html
+++ b/manual/ja/lights.html
@@ -40,14 +40,14 @@ const near = 0.1;
 const camera = new THREE.PerspectiveCamera(fov, aspect, near, far);
 +camera.position.set(0, 10, 20);
 </pre>
-<p>次に <a href="/docs/#examples/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a> を追加します。
-<a href="/docs/#examples/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a> は、カメラをある点を中心に<em>軌道</em>を回転できます。
-<a href="/docs/#examples/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a> はthree.jsのオプション機能なので、importする必要があります。</p>
+<p>次に <a href="/docs/#examples/ja/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a> を追加します。
+<a href="/docs/#examples/ja/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a> は、カメラをある点を中心に<em>軌道</em>を回転できます。
+<a href="/docs/#examples/ja/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a> はthree.jsのオプション機能なので、importする必要があります。</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">import * as THREE from 'three';
 +import {OrbitControls} from 'three/addons/controls/OrbitControls.js';
 </pre>
 <p>これでOrbitControlsを利用できます。
-<a href="/docs/#examples/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a> にカメラと入力イベントを取得するDOM要素を渡します。</p>
+<a href="/docs/#examples/ja/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a> にカメラと入力イベントを取得するDOM要素を渡します。</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">const controls = new OrbitControls(camera, canvas);
 controls.target.set(0, 5, 0);
 controls.update();

--- a/manual/ko/lights.html
+++ b/manual/ko/lights.html
@@ -41,20 +41,20 @@ const near = 0.1;
 const camera = new THREE.PerspectiveCamera(fov, aspect, near, far);
 +camera.position.set(0, 10, 20);
 </pre>
-<p>다음으로 <a href="/docs/#examples/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a>를 추가합니다. <a href="/docs/#examples/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a>는 특정 좌표를
-중심으로 카메라를 자전 또는 <em>공전(orbit)</em>하도록 해줍니다. <a href="/docs/#examples/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a>는
+<p>다음으로 <a href="/docs/#examples/ko/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a>를 추가합니다. <a href="/docs/#examples/ko/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a>는 특정 좌표를
+중심으로 카메라를 자전 또는 <em>공전(orbit)</em>하도록 해줍니다. <a href="/docs/#examples/ko/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a>는
 별도 모듈이므로, 먼저 페이지에 로드해야 합니다.</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">import * as THREE from 'three';
 +import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 </pre>
-<p>이제 <a href="/docs/#examples/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a>에 카메라와, DOM 이벤트를 감지할 수 있도록
+<p>이제 <a href="/docs/#examples/ko/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a>에 카메라와, DOM 이벤트를 감지할 수 있도록
 canvas 요소를 넘겨줍니다.</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">const controls = new OrbitControls(camera, canvas);
 controls.target.set(0, 5, 0);
 controls.update();
 </pre>
 <p>또한 시점을 중점에서 위로 5칸 올린 후 <code class="notranslate" translate="no">controls.update</code> 메서드를
-호출해 <a href="/docs/#examples/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a>가 새로운 시점을 바라보게 합니다.</p>
+호출해 <a href="/docs/#examples/ko/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a>가 새로운 시점을 바라보게 합니다.</p>
 <p>다음으로 빛을 받을 무언가를 만들어보겠습니다. 먼저 땅의 역할을 할
 평면을 만들고, 평면에 2x2 픽셀의 체크판 텍스처를 씌우겠습니다.</p>
 <div class="threejs_center">

--- a/manual/ru/lights.html
+++ b/manual/ru/lights.html
@@ -42,14 +42,14 @@ const near = 0.1;
 const camera = new THREE.PerspectiveCamera(fov, aspect, near, far);
 +camera.position.set(0, 10, 20);
 </pre>
-<p>Далее давайте добавим <a href="/docs/#examples/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a>. <a href="/docs/#examples/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a> позволить пользователю вращать
-или <em>поворачивать</em> камеру вокруг некоторой точки. <a href="/docs/#examples/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a> - это
+<p>Далее давайте добавим <a href="/docs/#examples/ru/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a>. <a href="/docs/#examples/ru/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a> позволить пользователю вращать
+или <em>поворачивать</em> камеру вокруг некоторой точки. <a href="/docs/#examples/ru/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a> - это
 дополнительные функции three.js, поэтому сначала нам нужно
 включить их в нашу страницу.</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">import * as THREE from 'three';
 +import {OrbitControls} from 'three/addons/controls/OrbitControls.js';
 </pre>
-<p>Теперь мы можем использовать их. Мы передаем в <a href="/docs/#examples/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a> камеру для
+<p>Теперь мы можем использовать их. Мы передаем в <a href="/docs/#examples/ru/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a> камеру для
 управления и элемент DOM для получения входных событий</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">const controls = new OrbitControls(camera, canvas);
 controls.target.set(0, 5, 0);

--- a/manual/zh/lights.html
+++ b/manual/zh/lights.html
@@ -37,16 +37,16 @@ const near = 0.1;
 const camera = new THREE.PerspectiveCamera(fov, aspect, near, far);
 +camera.position.set(0, 10, 20);
 </pre>
-<p>然后我们添加一个 <a href="/docs/#examples/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a>。<a href="/docs/#examples/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a> 让我们可以围绕某一个点旋转控制相机。<a href="/docs/#examples/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a> 是 three.js 的可选模块，所以我们首先需要引入这个模块。</p>
+<p>然后我们添加一个 <a href="/docs/#examples/zh/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a>。<a href="/docs/#examples/zh/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a> 让我们可以围绕某一个点旋转控制相机。<a href="/docs/#examples/zh/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a> 是 three.js 的可选模块，所以我们首先需要引入这个模块。</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">import * as THREE from 'three';
 +import {OrbitControls} from 'three/addons/controls/OrbitControls.js';
 </pre>
-<p>然后我们就可以使用了。创建 <a href="/docs/#examples/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a> 时传入两个参数，一个是要控制的相机对象，第二个是检测事件的 DOM 元素。</p>
+<p>然后我们就可以使用了。创建 <a href="/docs/#examples/zh/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a> 时传入两个参数，一个是要控制的相机对象，第二个是检测事件的 DOM 元素。</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">const controls = new OrbitControls(camera, canvas);
 controls.target.set(0, 5, 0);
 controls.update();
 </pre>
-<p>我们还将 <a href="/docs/#examples/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a> 的观察点设置为 (0, 5, 0) 的位置，设置完需要调用一下 <code class="notranslate" translate="no">controls.update</code>，这样才真正更新观察点位置。</p>
+<p>我们还将 <a href="/docs/#examples/zh/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a> 的观察点设置为 (0, 5, 0) 的位置，设置完需要调用一下 <code class="notranslate" translate="no">controls.update</code>，这样才真正更新观察点位置。</p>
 <p>下面我们创建一些东西来打光。首先，创建一个地平面，并用下方展示的 2x2 像素的黑白格图片来作为纹理。</p>
 <div class="threejs_center">
   <img src="../examples/resources/images/checker.png" class="border" style="


### PR DESCRIPTION
**Description**

Looks like the href parameter of language is missing in manual/#xx/lights: `OrbitControls`

Error occurred after clicked `OrbitControls` in manual page.

Target URL: https://threejs.org/manual/#en/lights

