### PR TITLE
WebGPUTextureUtils: Fix readback buffer size.

### DIFF
--- a/src/renderers/webgpu/utils/WebGPUTextureUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUTextureUtils.js
@@ -540,7 +540,7 @@ class WebGPUTextureUtils {
 
 		const readBuffer = device.createBuffer(
 			{
-				size: width * height * bytesPerTexel,
+				size: ( height - 1 ) * bytesPerRow + width * bytesPerTexel, // see https://github.com/mrdoob/three.js/issues/31658#issuecomment-3229442010
 				usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
 			}
 		);


### PR DESCRIPTION
Fixed #31658.

**Description**

Turns out we have a bug in our readback buffer size computation in the WebGPU backend. We must honor the row padding in the buffer computation except for the last row. Credits to @greggman who explained the fix at the Chromium bug tracker and here: https://github.com/mrdoob/three.js/issues/31658#issuecomment-3229414051 🙌 ! 


