### PR TITLE
Types: fix missing properties

### DIFF
--- a/examples/jsm/loaders/lwo/IFFParser.js
+++ b/examples/jsm/loaders/lwo/IFFParser.js
@@ -1013,7 +1013,7 @@ class DataViewReader {
 
 	getFloat64() {
 
-		const value = this.dv.getFloat64( this.offset, this.littleEndian );
+		const value = this.dv.getFloat64( this.offset );
 		this.offset += 8;
 		return value;
 

--- a/examples/jsm/utils/SkeletonUtils.js
+++ b/examples/jsm/utils/SkeletonUtils.js
@@ -447,7 +447,10 @@ function getBones( skeleton ) {
 
 function getHelperFromSkeleton( skeleton ) {
 
-	return new SkeletonHelper( skeleton.bones[ 0 ] );
+	const source = new SkeletonHelper( skeleton.bones[ 0 ] );
+	source.skeleton = skeleton;
+
+	return source;
 
 }
 

--- a/examples/jsm/utils/SkeletonUtils.js
+++ b/examples/jsm/utils/SkeletonUtils.js
@@ -447,10 +447,7 @@ function getBones( skeleton ) {
 
 function getHelperFromSkeleton( skeleton ) {
 
-	const source = new SkeletonHelper( skeleton.bones[ 0 ] );
-	source.skeleton = skeleton;
-
-	return source;
+	return new SkeletonHelper( skeleton.bones[ 0 ] );
 
 }
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -1670,6 +1670,6 @@ export const InterpolationSamplingMode = {
  * @property {string} NORMAL - Normal sampling mode.
  * @property {string} CENTROID - Centroid sampling mode.
  * @property {string} SAMPLE - Sample-specific sampling mode.
- * @property {string} FLAT_FIRST - Flat interpolation using the first vertex.
- * @property {string} FLAT_EITHER - Flat interpolation using either vertex.
+ * @property {string} FIRST - Flat interpolation using the first vertex.
+ * @property {string} EITHER - Flat interpolation using either vertex.
  */


### PR DESCRIPTION
Fixing these errors:

ConstantsInterpolationSamplingMode - FIRST EITHER type ref
examples/jsm/utils/SkeletonUtils.js - error TS2339: Property 'skeleton' does not exist on type 'SkeletonHelper'.
examples/jsm/loaders/lwo/IFFParser.js - error TS2339: Property 'littleEndian' does not exist on type 'DataViewReader'.