### PR TITLE
Manual: Fix hyperlink open inside iFrame viewer by default attribute

### DIFF
--- a/manual/index.html
+++ b/manual/index.html
@@ -528,6 +528,7 @@
 
 			}
 
+			autoDefaultLinkAttribute(iframe);
 			document.body.replaceChild( iframe, oldIframe );
 
 		}
@@ -556,6 +557,28 @@
 			}
 
 			return parts;
+
+		}
+
+		function autoDefaultLinkAttribute( iframe ) {
+
+			// To set default attribute _blank to prevent link open inside the iFrame viewer
+
+			iframe.addEventListener( 'load', function () {
+
+				const links = iframe.contentDocument.querySelectorAll( 'a' );
+
+				links.forEach( function ( link ) {
+
+					if ( link.target !== undefined && link.target.trim() === "" ) {
+
+						link.setAttribute( 'target', '_blank' );
+
+					}
+
+				} );
+
+			} );
 
 		}
 


### PR DESCRIPTION
Related issue: [PR discussion](https://github.com/mrdoob/three.js/pull/31763#issuecomment-3229312899)

**Description**

Add a default function to set all a tags `target` attribute in manual as `"_blank"`

To prevent link and doc open in iFrame viewer. Open in new tab instead. 

Issue example: 
[a tag: there's a good tutorial on MDN](https://threejs.org/manual/#en/canvas-textures)
[a tag: PerspectiveCamera](https://threejs.org/manual/#en/cameras)
