### PR TITLE
RenderObject: Fix cache key for instanced meshes.

### DIFF
--- a/src/renderers/common/RenderObject.js
+++ b/src/renderers/common/RenderObject.js
@@ -770,7 +770,7 @@ class RenderObject {
 
 		}
 
-		if ( object.count > 1 ) {
+		if ( object.isInstancedMesh || object.count > 1 ) {
 
 			// TODO: https://github.com/mrdoob/three.js/pull/29066#issuecomment-2269400850
 


### PR DESCRIPTION
Fixed #31776.

**Description**

Render objects using instancing are not allowed to share the same node builder state. There is already code in `RenderObject` that ensures this for 3D objects using the `count` property but not for `InstancedMesh` with an instance count of `1`. Granted, this is an edge case but it still should be fixed.
