### PR TITLE
WebGPURenderer: Removed console warnings about missing attributes.

### DIFF
--- a/src/nodes/accessors/Normal.js
+++ b/src/nodes/accessors/Normal.js
@@ -23,8 +23,6 @@ export const normalLocal = /*@__PURE__*/ ( Fn( ( builder ) => {
 
 	if ( builder.geometry.hasAttribute( 'normal' ) === false ) {
 
-		console.warn( 'THREE.TSL: Vertex attribute "normal" not found on geometry.' );
-
 		return vec3( 0, 1, 0 );
 
 	}

--- a/src/nodes/core/AttributeNode.js
+++ b/src/nodes/core/AttributeNode.js
@@ -125,8 +125,6 @@ class AttributeNode extends Node {
 
 		} else {
 
-			console.warn( `AttributeNode: Vertex attribute "${ attributeName }" not found on geometry.` );
-
 			return builder.generateConst( nodeType );
 
 		}


### PR DESCRIPTION
I have removed two console warnings because these warnings assume that you are only working with classic attribute based geometries.
My ocean geometry is a pure bufferGeometry and has no attributes. The geometry datas are calculated by a compute shader and stored in buffers. The vertex shader only receives these buffers. uv's and normals wouldn't make sense for a dynamic geometry like mine anyway.

<img width="400" alt="image" src="https://github.com/user-attachments/assets/6285b578-afe0-47d6-8906-e3c0544473d8" />

For dynamic procedural geometries like mine, this is the normal way.

compute -> vertex -> fragment

Since I also use drawIndexedIndirect here, attributes are obsolete in two respects.

This doesn't mean that attributes are obsolete or useless. It's just that attribute-based geometries in WebGPU are no longer the only way to generate geometries, and they're simply no longer the best choice for landscapes and dynamic geometries or virtual geometries. 