### PR TITLE
TSL: Fix primitive vector conversion, `vec*` with `ivec*`

### DIFF
--- a/src/nodes/utils/JoinNode.js
+++ b/src/nodes/utils/JoinNode.js
@@ -95,7 +95,9 @@ class JoinNode extends TempNode {
 
 			if ( inputPrimitiveType !== primitiveType ) {
 
-				inputSnippet = builder.format( inputSnippet, inputPrimitiveType, primitiveType );
+				const targetType = builder.getTypeFromLength( inputTypeLength, primitiveType );
+
+				inputSnippet = builder.format( inputSnippet, inputType, targetType );
 
 			}
 


### PR DESCRIPTION
Fixes https://github.com/mrdoob/three.js/issues/31791

**Description**

The primitive types of vectors were not being properly converted when used together, as shown in the example in the issue.
