### PR TITLE
WebGPU: Fix `Renderer` not being garbage collected

### DIFF
--- a/src/renderers/common/Geometries.js
+++ b/src/renderers/common/Geometries.js
@@ -123,7 +123,7 @@ class Geometries extends DataMap {
 		 * @private
 		 * @type {Map<BufferGeometry,Function>}
 		 */
-		this._removeListeners = new Map();
+		this._geometryDisposeListeners = new Map();
 
 	}
 
@@ -197,7 +197,7 @@ class Geometries extends DataMap {
 
 			geometry.removeEventListener( 'dispose', onDispose );
 
-			this._removeListeners.delete( geometry );
+			this._geometryDisposeListeners.delete( geometry );
 
 		};
 
@@ -205,7 +205,7 @@ class Geometries extends DataMap {
 
 		// see #31798 why tracking separate remove listeners is required right now
 		// TODO: Re-evaluate how onDispose() is managed in this component
-		this._removeListeners.set( geometry, onDispose );
+		this._geometryDisposeListeners.set( geometry, onDispose );
 
 	}
 
@@ -355,13 +355,13 @@ class Geometries extends DataMap {
 
 	dispose() {
 
-		for ( const [ geometry, onDispose ] of this._removeListeners.entries() ) {
+		for ( const [ geometry, onDispose ] of this._geometryDisposeListeners.entries() ) {
 
 			geometry.removeEventListener( 'dispose', onDispose );
 
 		}
 
-		this._removeListeners.clear();
+		this._geometryDisposeListeners.clear();
 
 	}
 

--- a/src/renderers/common/Geometries.js
+++ b/src/renderers/common/Geometries.js
@@ -117,6 +117,14 @@ class Geometries extends DataMap {
 		 */
 		this.attributeCall = new WeakMap();
 
+		/**
+		 * Stores functions to remove dispose event listeners from geometries.
+		 *
+		 * @private
+		 * @type {Object}
+		 */
+		this._removeListeners = {};
+
 	}
 
 	/**
@@ -154,6 +162,13 @@ class Geometries extends DataMap {
 	initGeometry( renderObject ) {
 
 		const geometry = renderObject.geometry;
+
+		if ( this._removeListeners[ geometry.id ] !== undefined ) {
+
+			return;
+
+		}
+
 		const geometryData = this.get( geometry );
 
 		geometryData.initialized = true;
@@ -189,9 +204,17 @@ class Geometries extends DataMap {
 
 			geometry.removeEventListener( 'dispose', onDispose );
 
+			delete this._removeListeners[ geometry.id ];
+
 		};
 
 		geometry.addEventListener( 'dispose', onDispose );
+
+		this._removeListeners[ geometry.id ] = () => {
+
+			geometry.removeEventListener( 'dispose', onDispose );
+
+		};
 
 	}
 
@@ -336,6 +359,18 @@ class Geometries extends DataMap {
 		}
 
 		return index;
+
+	}
+
+	dispose() {
+
+		for ( const key in this._removeListeners ) {
+
+			this._removeListeners[ key ]();
+
+		}
+
+		this._removeListeners = {};
 
 	}
 

--- a/src/renderers/common/QuadMesh.js
+++ b/src/renderers/common/QuadMesh.js
@@ -33,9 +33,6 @@ class QuadGeometry extends BufferGeometry {
 
 }
 
-const _geometry = /*@__PURE__*/ new QuadGeometry();
-
-
 /**
  * This module is a helper for passes which need to render a full
  * screen effect which is quite common in context of post processing.
@@ -56,7 +53,7 @@ class QuadMesh extends Mesh {
 	 */
 	constructor( material = null ) {
 
-		super( _geometry, material );
+		super( new QuadGeometry(), material );
 
 		/**
 		 * The camera to render the quad mesh with.

--- a/src/renderers/common/QuadMesh.js
+++ b/src/renderers/common/QuadMesh.js
@@ -33,6 +33,9 @@ class QuadGeometry extends BufferGeometry {
 
 }
 
+const _geometry = /*@__PURE__*/ new QuadGeometry();
+
+
 /**
  * This module is a helper for passes which need to render a full
  * screen effect which is quite common in context of post processing.
@@ -53,7 +56,7 @@ class QuadMesh extends Mesh {
 	 */
 	constructor( material = null ) {
 
-		super( new QuadGeometry(), material );
+		super( _geometry, material );
 
 		/**
 		 * The camera to render the quad mesh with.

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -2194,6 +2194,7 @@ class Renderer {
 
 			this._animation.dispose();
 			this._objects.dispose();
+			this._geometries.dispose();
 			this._pipelines.dispose();
 			this._nodes.dispose();
 			this._bindings.dispose();


### PR DESCRIPTION
**Description**

This PR potentially fixes an issue that `Renderer` and all associated memory are not garbage collected (I say "potentially" because there may be other leak sources). 

The geometry used in `QuadMesh` is [instantiated in a global variable](https://github.com/mrdoob/three.js/blob/r179/src/renderers/common/QuadMesh.js#L36), and `Geometries` [adds a dispose event listener](https://github.com/mrdoob/three.js/blob/r179/src/renderers/common/Geometries.js#L194) that captures `this` in a closure and is never removed because the geometry is never disposed. `Geometries` [holds a reference to `Attributes`](https://github.com/mrdoob/three.js/blob/r179/src/renderers/common/Geometries.js#L96), which [holds a reference to a `Backend`](https://github.com/mrdoob/three.js/blob/r179/src/renderers/common/Attributes.js#L28), which [holds a reference to `Renderer`](https://github.com/mrdoob/three.js/blob/r179/src/renderers/common/Backend.js#L51), thus the GC cannot collect the entire renderer-related CPU memory.

I initially attempted to move `QuadGeometry` inside `QuadMesh`, but many `QuadMesh` instances are also instantiated in global variables. If we keep using it that way, we need to address it in `Geometries`.