### PR TITLE
fix(progressiveLightMap): add normal validation and preserve flatShading

### DIFF
--- a/examples/jsm/misc/ProgressiveLightMap.js
+++ b/examples/jsm/misc/ProgressiveLightMap.js
@@ -123,6 +123,12 @@ class ProgressiveLightMap {
 
 			}
 
+			if ( !object.material.flatShading && !object.geometry.hasAttribute( 'normal' ) ) {
+
+				console.warn( 'THREE.ProgressiveLightMap: All lightmap objects need vertex normals or flatShading.' ); continue;
+
+			}
+
 			if ( this.blurringPlane === null ) {
 
 				this._initializeBlurPlane( this.res, this.progressiveLightMap1 );
@@ -204,6 +210,10 @@ class ProgressiveLightMap {
 
 		// Set each object's material to the UV Unwrapped Surface Mapping Version
 		for ( let l = 0; l < this.lightMapContainers.length; l ++ ) {
+
+			// Ensure the object has correct flatShading
+			const flatShading = this.lightMapContainers[ l ].basicMat.flatShading;
+			this.uvMat.flatShading = flatShading;
 
 			this.uvMat.uniforms.averagingWindow = { value: blendWindow };
 			this.lightMapContainers[ l ].object.material = this.uvMat;

--- a/examples/jsm/misc/ProgressiveLightMapGPU.js
+++ b/examples/jsm/misc/ProgressiveLightMapGPU.js
@@ -101,6 +101,12 @@ class ProgressiveLightMap {
 
 			}
 
+			if ( !object.material.flatShading && !object.geometry.hasAttribute( 'normal' ) ) {
+
+				console.warn( 'THREE.ProgressiveLightMap: All lightmap objects need vertex normals or flatShading.' ); continue;
+
+			}
+
 			if ( this._blurringPlane === null ) {
 
 				this._initializeBlurPlane();
@@ -198,6 +204,10 @@ class ProgressiveLightMap {
 
 		// Set each object's material to the UV Unwrapped Surface Mapping Version
 		for ( let l = 0; l < this._lightMapContainers.length; l ++ ) {
+
+			// Ensure the object has correct flatShading
+			const flatShading = this._lightMapContainers[ l ].basicMat.flatShading;
+			this._uvMat.flatShading = flatShading;
 
 			this._averagingWindow.value = blendWindow;
 			this._lightMapContainers[ l ].object.material = this._uvMat;


### PR DESCRIPTION
- Added error checks to ensure all meshes have vertex normals or flat shading
- Fixed issue where flatShading setting from original material was lost
- New materials now correctly inherit flatShading from the original material

Related issue: (https://github.com/mrdoob/three.js/issues/31799)

**Description**

Some models use materials with flatShading = true while their geometries do not contain vertex normals.

In the main scene, these models render correctly because flatShading does not require vertex normals.
In ProgressiveLightMap, however, the material was replaced with an internal uvMat that had flatShading = false. This caused the affected objects to render completely black.
Additionally, when a material had flatShading = false and the geometry had no vertex normals, the code did not throw any warning or error, leading to silent failures.
This fix ensures:

The flatShading value is now correctly inherited from the original material.
If flatShading = false and the geometry has no vertex normals, an error is thrown to prevent silent rendering failures.