### PR TITLE
Remove setting backgroundBlurryness property

### DIFF
--- a/examples/webgl_materials_envmaps_fasthdr.html
+++ b/examples/webgl_materials_envmaps_fasthdr.html
@@ -56,7 +56,6 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setAnimationLoop( animate );
-				renderer.backgroundBlurryness = params.backgroundBlurryness;
 
 				container.appendChild( renderer.domElement );
 


### PR DESCRIPTION
Related issue: #31749

**Description**

Removes setting the `backgroundBlurryness` property on `WebGLRenderer`. I don't think it does anything?
