### PR TITLE
Examples: Clean up.

### DIFF
--- a/examples/webgpu_postprocessing_ao.html
+++ b/examples/webgpu_postprocessing_ao.html
@@ -45,17 +45,13 @@
 			let aoPass, traaPass, blendPassAO, scenePassColor;
 
 			const params = {
+				samples: 16,
 				distanceExponent: 1,
 				distanceFallOff: 1,
 				radius: 0.25,
 				scale: 1,
 				thickness: 1,
-				denoised: false,
-				enabled: true,
-				denoiseRadius: 5,
-				lumaPhi: 5,
-				depthPhi: 5,
-				normalPhi: 5
+				aoOnly: false
 			};
 
 			init();
@@ -121,7 +117,6 @@
 				// traa
 
 				traaPass = traa( blendPassAO, scenePassDepth, scenePassVelocity, camera );
-
 				postProcessing.outputNode = traaPass;
 
 				//
@@ -158,16 +153,34 @@
 
 				const gui = new GUI();
 				gui.title( 'AO settings' );
-				gui.add( params, 'distanceExponent' ).min( 1 ).max( 4 ).onChange( updateParameters );
+				gui.add( params, 'samples' ).min( 4 ).max( 32 ).step( 1 ).onChange( updateParameters );
+				gui.add( params, 'distanceExponent' ).min( 1 ).max( 2 ).onChange( updateParameters );
 				gui.add( params, 'distanceFallOff' ).min( 0.01 ).max( 1 ).onChange( updateParameters );
 				gui.add( params, 'radius' ).min( 0.1 ).max( 1 ).onChange( updateParameters );
 				gui.add( params, 'scale' ).min( 0.01 ).max( 2 ).onChange( updateParameters );
 				gui.add( params, 'thickness' ).min( 0.01 ).max( 2 ).onChange( updateParameters );
+				gui.add( params, 'aoOnly' ).onChange( ( value ) => {
+
+					if ( value === true ) {
+
+						postProcessing.outputNode = aoPass;
+
+					} else {
+
+
+						postProcessing.outputNode = traaPass;
+
+					}
+
+					postProcessing.needsUpdate = true;
+
+				} );
 
 			}
 
 			function updateParameters() {
 
+				aoPass.samples.value = params.samples;
 				aoPass.distanceExponent.value = params.distanceExponent;
 				aoPass.distanceFallOff.value = params.distanceFallOff;
 				aoPass.radius.value = params.radius;


### PR DESCRIPTION
Related issue: -

**Description**

The PR makes sure the `samples` parameter is configurable over the GUI in `webgpu_postprocessing_ao`. It also adds a toggle that allows to visualize just the AO which is useful for debugging and comparisons with other AO approaches.
