### PR TITLE
ProgressiveLightMap: Make normals mandatory.

### DIFF
--- a/examples/jsm/misc/ProgressiveLightMap.js
+++ b/examples/jsm/misc/ProgressiveLightMap.js
@@ -123,6 +123,12 @@ class ProgressiveLightMap {
 
 			}
 
+			if ( object.geometry.hasAttribute( 'normal' ) === false ) {
+
+				console.warn( 'THREE.ProgressiveLightMap: All lightmap objects need normals.' ); continue;
+
+			}
+
 			if ( this.blurringPlane === null ) {
 
 				this._initializeBlurPlane( this.res, this.progressiveLightMap1 );

--- a/examples/jsm/misc/ProgressiveLightMapGPU.js
+++ b/examples/jsm/misc/ProgressiveLightMapGPU.js
@@ -101,6 +101,12 @@ class ProgressiveLightMap {
 
 			}
 
+			if ( object.geometry.hasAttribute( 'normal' ) === false ) {
+
+				console.warn( 'THREE.ProgressiveLightMap: All lightmap objects need normals.' ); continue;
+
+			}
+
 			if ( this._blurringPlane === null ) {
 
 				this._initializeBlurPlane();


### PR DESCRIPTION
Fixed #31799.

**Description**

The PR makes sure `ProgressiveLightMap` for both `WebGLRenderer` and `WebGPURenderer` inform the user when 3D objects with no normals should be rendered into the lightmap.
