### PR TITLE
WebGLRenderer: Fix WebXR Depth Sensing.

### DIFF
--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -554,6 +554,10 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 			uploadTexture( textureProperties, texture, slot );
 			return;
 
+		} else if ( texture.isExternalTexture ) {
+
+			textureProperties.__webglTexture = texture.sourceTexture ? texture.sourceTexture : null;
+
 		}
 
 		state.bindTexture( _gl.TEXTURE_2D_ARRAY, textureProperties.__webglTexture, _gl.TEXTURE0 + slot );


### PR DESCRIPTION
The introduction of `ExternalTexture` broke support for WebXR Depth Sensing because the depth texture was never bound to the sampler.
Fixed by doing the same thing in `setTexture2DArray` as we do for `setTexture2D`.

cc @Mugen87 

*This contribution is funded by [Meta](https://meta.com)*
