### PR TITLE
Renderer - Properly Delete ComputeNode Bindings in Dispose

### DIFF
--- a/src/renderers/common/Bindings.js
+++ b/src/renderers/common/Bindings.js
@@ -164,7 +164,7 @@ class Bindings extends DataMap {
 
 		for ( const bindGroup of bindings ) {
 
-			super.delete( bindGroup );
+			this.delete( bindGroup );
 
 		}
 

--- a/src/renderers/common/Bindings.js
+++ b/src/renderers/common/Bindings.js
@@ -154,6 +154,24 @@ class Bindings extends DataMap {
 	}
 
 	/**
+	 * Deletes the bindings for the given compute node.
+	 *
+	 * @param {Node} computeNode - The compute node.
+	 */
+	deleteForCompute( computeNode ) {
+
+		const bindings = this.nodes.getForCompute( computeNode ).bindings;
+
+		for ( const bindGroup of bindings ) {
+
+			super.delete( bindGroup );
+
+		}
+
+	}
+
+
+	/**
 	 * Updates the given array of bindings.
 	 *
 	 * @param {Array<BindGroup>} bindings - The bind groups.

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -2389,7 +2389,7 @@ class Renderer {
 					computeNode.removeEventListener( 'dispose', dispose );
 
 					pipelines.delete( computeNode );
-					bindings.delete( computeNode );
+					bindings.deleteForCompute( computeNode );
 					nodes.delete( computeNode );
 
 				};


### PR DESCRIPTION
**Description**

The original dispose function wasn't doing anything on the bindings object because the Bindings.getForCompute DataMap only sets BindGroup objects on its map and not ComputeNode objects. Aligning the delete functionality with the get functionality will actually delete the Bind Group.
