### PR TITLE
XRManager: Reset XRWebGLBinding on session end

### DIFF
--- a/src/renderers/common/XRManager.js
+++ b/src/renderers/common/XRManager.js
@@ -1382,6 +1382,8 @@ function onSessionEnd() {
 	this._session = null;
 	this._xrRenderTarget = null;
 	this._glBinding = null;
+	this._glBaseLayer = null;
+	this._glProjLayer = null;
 
 	// switch layers back to emulated
 	if ( this._sessionUsesLayers === true ) {

--- a/src/renderers/common/XRManager.js
+++ b/src/renderers/common/XRManager.js
@@ -1381,6 +1381,7 @@ function onSessionEnd() {
 
 	this._session = null;
 	this._xrRenderTarget = null;
+	this._glBinding = null;
 
 	// switch layers back to emulated
 	if ( this._sessionUsesLayers === true ) {


### PR DESCRIPTION
Related issue: #31821

**Description**

`XRWebGLBinding` can't be cached between XR sessions. Fixes #31821.

