### PR TITLE
Examples: fix bugs

### DIFF
--- a/examples/physics_ammo_break.html
+++ b/examples/physics_ammo_break.html
@@ -538,7 +538,7 @@
 
 				if ( breakable0 && ! collided0 && maxImpulse > fractureImpulse ) {
 
-					const debris = convexBreaker.subdivideByImpact( threeObject0, impactPoint, impactNormal, 1, 2, 1.5 );
+					const debris = convexBreaker.subdivideByImpact( threeObject0, impactPoint, impactNormal, 1, 2 );
 
 					const numObjects = debris.length;
 					for ( let j = 0; j < numObjects; j ++ ) {
@@ -560,7 +560,7 @@
 
 				if ( breakable1 && ! collided1 && maxImpulse > fractureImpulse ) {
 
-					const debris = convexBreaker.subdivideByImpact( threeObject1, impactPoint, impactNormal, 1, 2, 1.5 );
+					const debris = convexBreaker.subdivideByImpact( threeObject1, impactPoint, impactNormal, 1, 2 );
 
 					const numObjects = debris.length;
 					for ( let j = 0; j < numObjects; j ++ ) {

--- a/examples/webgl_gpgpu_water.html
+++ b/examples/webgl_gpgpu_water.html
@@ -328,8 +328,8 @@
 				borderGeom.rotateY( Math.PI * 0.25 );
 				poolBorder = new THREE.Mesh( borderGeom, new THREE.MeshStandardMaterial( { color: 0x908877, roughness: 0.2 } ) );
 				scene.add( poolBorder );
-				borderGeom.receiveShadow = true;
-				borderGeom.castShadow = true;
+				poolBorder.receiveShadow = true;
+				poolBorder.castShadow = true;
 
 				// THREE.Mesh just for mouse raycasting
 				const geometryRay = new THREE.PlaneGeometry( BOUNDS, BOUNDS, 1, 1 );

--- a/examples/webgl_lines_fat_raycasting.html
+++ b/examples/webgl_lines_fat_raycasting.html
@@ -85,7 +85,7 @@
 				'width': matLine.linewidth,
 				'alphaToCoverage': matLine.alphaToCoverage,
 				'threshold': raycaster.params.Line2.threshold,
-				'translation': raycaster.params.Line2.threshold,
+				'translation': 0,
 				'animate': true
 
 			};
@@ -197,7 +197,7 @@
 				stats = new Stats( { horizontal: false, trackGPU: true } );
 				stats.init( renderer );
 				document.body.appendChild( stats.dom );
-			
+
 				initGui();
 
 			}

--- a/examples/webgl_loader_ldraw.html
+++ b/examples/webgl_loader_ldraw.html
@@ -368,7 +368,7 @@
 
 			function updateProgressBar( fraction ) {
 
-				progressBarDiv.innerText = 'Loading... ' + Math.round( fraction * 100, 2 ) + '%';
+				progressBarDiv.innerText = 'Loading... ' + Math.round( fraction * 100 ) + '%';
 
 			}
 

--- a/examples/webgpu_lines_fat_raycasting.html
+++ b/examples/webgpu_lines_fat_raycasting.html
@@ -86,7 +86,7 @@
 				'width': matLine.linewidth,
 				'alphaToCoverage': matLine.alphaToCoverage,
 				'threshold': raycaster.params.Line2.threshold,
-				'translation': raycaster.params.Line2.threshold,
+				'translation': 0,
 				'animate': true
 
 			};
@@ -198,7 +198,7 @@
 				stats = new Stats( { horizontal: false, trackGPU: true } );
 				stats.init( renderer );
 				document.body.appendChild( stats.dom );
-			
+
 				initGui();
 
 			}


### PR DESCRIPTION
**Description**

Fix a few mistakes in the examples:

* `subdivideByImpact` only takes 5 params (6 provided)
* `Mesh` has `receiveShadow` and `castShadow` but not geometry
* I simplified `examples/webgl_lines_fat_raycasting.html` `translation` default value (no reason to reference threshold)
* `Math.round()` only accepts one param (no float rounding in Js)