### PR TITLE
fix(loader): update GLTFLoader import path to examples/jsm , because …

### DIFF
--- a/manual/en/loading-3d-models.html
+++ b/manual/en/loading-3d-models.html
@@ -100,7 +100,7 @@
           </p>
         
 <pre class="prettyprint notranslate lang-js" translate="no">
-import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 </pre>
 
           <p>


### PR DESCRIPTION
…addons/loaders doesn't exist

Related issue: #XXXX

**Description**

A clear and concise description of what the problem was and how this pull request solves it.

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Example](https://example.com)*
