### PR TITLE
Addons - Bitonic Sort

### DIFF
--- a/examples/jsm/gpgpu/BitonicSort.js
+++ b/examples/jsm/gpgpu/BitonicSort.js
@@ -242,34 +242,6 @@ export class BitonicSort {
 
 	}
 
-	async logBuffer( name ) {
-
-		switch(name) {
-
-			case 'info': {
-
-				console.log( new Uint32Array( await renderer.getArrayBufferAsync( this.infoStorage.value ) ) );
-
-			}
-
-			case 'temp': {
-
-				console.log( new Uint32Array( await renderer.getArrayBufferAsync( this.dataBuffer.value ) ) );
-
-			}
-
-			
-			case 'temp': {
-
-				console.log( new Uint32Array( await renderer.getArrayBufferAsync( this.tempBuffer.value ) ) );
-
-			}
-
-
-		}
-
-	}
-
 	_getSwapOpCount() {
 
 		const n = Math.log2( this.count );

--- a/examples/jsm/gpgpu/BitonicSort.js
+++ b/examples/jsm/gpgpu/BitonicSort.js
@@ -1,0 +1,589 @@
+import { Fn, uvec2, If, instancedArray, instanceIndex, invocationLocalIndex, Loop, workgroupArray, workgroupBarrier, workgroupId, uint, select, Switch, Return } from 'three/tsl';
+
+const StepType = {
+
+	NONE: 0,
+	// Swap all values within the local range of workgroupSize * 2
+	SWAP_LOCAL: 1,
+	DISPERSE_LOCAL: 2,
+	// Swap values within global data buffer.
+	FLIP_GLOBAL: 3,
+	DISPERSE_GLOBAL: 4,
+
+};
+
+
+/**
+ * Returns the indices that will be compared in a bitonic flip operation.
+ *
+ * @tsl
+ * @private
+ * @param {Node<uint>} index - The compute thread's invocation id.
+ * @param {Node<uint>} swapSpan - The maximum span over which elements are being swapped.
+ * @returns {Node<uvec2>} The indices of the elements in the data buffer being compared.
+ */
+export const getBitonicFlipIndices = /*@__PURE__*/ Fn( ( [ index, swapSpan ] ) => {
+
+	const blockOffset = ( index.mul( 2 ).div( swapSpan ) ).mul( swapSpan );
+	const halfHeight = swapSpan.div( 2 );
+	const idx = uvec2(
+		index.mod( halfHeight ),
+		swapSpan.sub( index.mod( halfHeight ) ).sub( 1 )
+	);
+	idx.x.addAssign( blockOffset );
+	idx.y.addAssign( blockOffset );
+
+	return idx;
+
+}, { index: 'uint', swapSpan: 'uint', return: 'uvec2' } );
+
+/**
+ * Returns the indices that will be compared in a bitonic sort's disperse operation.
+ *
+ * @tsl
+ * @private
+ * @param {Node<uint>} index - The compute thread's invocation id.
+ * @param {Node<uint>} swapSpan - The maximum span over which elements are being swapped.
+ * @returns {Node<uvec2>} The indices of the elements in the data buffer being compared.
+ */
+export const getBitonicDisperseIndices = /*@__PURE__*/ Fn( ( [ index, swapSpan ] ) => {
+
+	const blockOffset = ( ( index.mul( 2 ) ).div( swapSpan ) ).mul( swapSpan );
+	const halfHeight = swapSpan.div( 2 );
+	const idx = uvec2(
+		index.mod( halfHeight ),
+		( index.mod( halfHeight ) ).add( halfHeight )
+	);
+
+	idx.x.addAssign( blockOffset );
+	idx.y.addAssign( blockOffset );
+
+	return idx;
+
+}, { index: 'uint', swapSpan: 'uint', return: 'uvec2' } );
+
+// TODO: Add parameters for computing a buffer larger than vec4
+export class BitonicSort {
+
+	constructor( renderer, dataBuffer, options = {} ) {
+
+		/**
+		 * A reference to the renderer.
+		 *
+		 * @type {Renderer}
+		 */
+		this.renderer = renderer;
+
+		/**
+		 * A reference to the StorageBufferNode holding the data that will be sorted  .
+		 *
+		 * @type {StorageBufferNode}
+		 */
+		this.dataBuffer = dataBuffer;
+
+		/**
+		 * The size of the data.
+		 *
+		 * @type {StorageBufferNode}
+		 */
+		this.count = dataBuffer.value.count;
+
+		/**
+		 *
+		 * The dispatch size of a sort operation
+		 * @type {number}
+		 */
+
+		 this.dispatchSize = this.count / 2;
+
+		/**
+		 * The workgroup size of the compute shaders executed during the sort.
+		 *
+		 * @type {StorageBufferNode}
+		*/
+		this.workgroupSize = options.workgroupSize ? Math.min( this.dispatchSize, options.workgroupSize ) : Math.min( this.dispatchSize, 64 );
+		//this.sideEffectBuffers = options.sideEffectBuffers ? options.sideEffectBuffers : [];
+
+		// Helper buffers
+
+		/**
+		 * A node representing a workgroup scoped buffer that holds locally sorted elements.
+		 *
+		 * @type {WorkgroupInfoNode}
+		*/
+		this.localStorage = workgroupArray( 'uint', this.workgroupSize * 2 );
+
+		/**
+		 * A node representing a storage buffer used for transfering the result of the global sort back to the original data buffer.
+		 *
+		 * @type {StorageBufferNode}
+		*/
+		this.tempBuffer = instancedArray( dataBuffer.value.count, 'uint' ).setName( 'TempStorage' );
+
+		this.infoBuffer = new Uint32Array( 1, 2, 2 );
+
+		/**
+		 * TODO: Determine if needed.
+		 *
+		 * @type {StorageBufferNode}
+		*/
+		this.infoStorage = instancedArray( this.infoBuffer, 'uint' ).setName( 'BitonicSortInfo' );
+
+		this.infoStorageRead = instancedArray( this.infoBuffer, 'uint' ).setName( 'BitonicSortInfoRead' ).toReadOnly();
+
+
+		/**
+		 * The number of distinct swap operations ('flips' and 'disperses') executed in an in-place
+		 * bitonic sort of the current data buffer.
+		 *
+		 * @type {number}
+		*/
+		this.swapOpCount = this._getSwapOpCount();
+
+		/**
+		 * The number of steps (i.e prepping and/or executing a swap) needed to fully execute an in-place bitonic sort of the current data buffer.
+		 *
+		 * @type {number}
+		*/
+		this.stepCount = this._getStepCount();
+
+		// Have to create three separate shaders since we cannot switch between
+		// local and global sort in a single shader without breaking uniform control flow
+		// and thus workgroupBarrier() functionality
+
+		/**
+		 * A compute shader that executes a 'flip' swap within a global address space on elements in the data buffer.
+		 *
+		 * @type {ComputeNode}
+		*/
+		this.flipGlobalFn = this._getFlipGlobal();
+
+		/**
+		 * A compute shader that executes a 'disperse' swap within a global address space on elements in the data buffer.
+		 *
+		 * @type {ComputeNode}
+		*/
+		this.disperseGlobalFn = this._getDisperseGlobal();
+
+		/**
+		 * A compute shader that executes a sequence of flip and disperse swaps within a local address space on elements in the data buffer.
+		 *
+		 * @type {ComputeNode}
+		*/
+		this.swapLocalFn = this._getSwapLocal();
+
+		/**
+		 * A compute shader that executes a sequence of disperse swaps within a local address space on elements in the data buffer.
+		 *
+		 * @type {ComputeNode}
+		*/
+		this.disperseLocalFn = this._getDisperseLocal();
+
+		// Utility functions
+
+		/**
+		 * TODO.
+		 *
+		 * @type {ComputeNode}
+		*/
+		this.setAlgoFn = this._getSetAlgoFn();
+
+		/**
+		 * TODO
+		 *
+		 * @type {ComputeNode}
+		*/
+		this.alignFn = this._getAlignFn();
+
+
+		/**
+		 * TODO
+		 *
+		 * @type {ComputeNode}
+		*/
+		this.resetFn = this._getResetFn();
+
+		this.currentDispatch = 0;
+
+		/**
+		 * The number of global swap operations that must be executed before the sort
+		 * can swap in local address space.
+		 *
+		 * @type {number}
+		*/
+		this.globalOpsRemaining = 0;
+
+		/**
+		 * The total number of global operations needed to sort elements within the current swap span.
+		 *
+		 * @type {number}
+		*/
+		this.globalOpsInSpan = 0;
+
+
+	}
+
+	_getSwapOpCount() {
+
+		const n = Math.log2( this.count );
+		return ( n * ( n + 1 ) ) / 2;
+
+	}
+
+	_getStepCount() {
+
+		const logElements = Math.log2( this.count );
+		const logSwapSpan = Math.log2( this.workgroupSize * 2 );
+
+		const numGlobalFlips = logElements - logSwapSpan;
+
+		// Start with 1 for initial sort over all local elements
+		let numSteps = 1;
+		let numGlobalDisperses = 0;
+
+		for ( let i = 1; i <= numGlobalFlips; i ++ ) {
+
+			// Increment by the global flip that starts each global block
+			numSteps += 1;
+			// Increment by number of global disperses following the global flip
+			numSteps += numGlobalDisperses;
+			// Increment by local disperse that occurs after all global swaps are finished
+			numSteps += 1;
+
+			// Number of global disperse increases as swapSpan increases by factor of 2
+			numGlobalDisperses += 1;
+
+		}
+
+		return numSteps;
+
+	}
+
+	_globalCompareAndSwapTSL( idxBefore, idxAfter, dataBuffer, tempBuffer ) {
+
+		// If the later element is less than the current element
+		If( dataBuffer.element( idxAfter ).lessThan( dataBuffer.element( idxBefore ) ), () => {
+
+			tempBuffer.element( idxBefore ).assign( dataBuffer.element( idxAfter ) );
+			tempBuffer.element( idxAfter ).assign( dataBuffer.element( idxBefore ) );
+
+		} ).Else( () => {
+
+			// Otherwise apply the existing values to temporary storage.
+			tempBuffer.element( idxBefore ).assign( dataBuffer.element( idxBefore ) );
+			tempBuffer.element( idxAfter ).assign( dataBuffer.element( idxAfter ) );
+
+		} );
+
+	}
+
+
+	_getDisperseGlobal() {
+
+		const { infoStorage, tempBuffer, dataBuffer } = this;
+
+		const currentSwapSpan = infoStorage.element( 1 );
+
+		const fnDef = Fn( () => {
+
+			const idx = getBitonicDisperseIndices( instanceIndex, currentSwapSpan );
+			this._globalCompareAndSwapTSL( idx.x, idx.y, dataBuffer, tempBuffer );
+
+		} )().compute( this.dispatchSize, [ this.workgroupSize ] );
+
+		return fnDef;
+
+	}
+
+	_getFlipGlobal() {
+
+		const { infoStorage, tempBuffer, dataBuffer } = this;
+
+		const currentSwapSpan = infoStorage.element( 1 );
+
+		const fnDef = Fn( () => {
+
+			const idx = getBitonicFlipIndices( instanceIndex, currentSwapSpan );
+			this._globalCompareAndSwapTSL( idx.x, idx.y, dataBuffer, tempBuffer );
+
+		} )().compute( this.dispatchSize, [ this.workgroupSize ] );
+
+		return fnDef;
+
+	}
+
+	_getSwapLocal() {
+
+		const { localStorage, dataBuffer, workgroupSize } = this;
+
+		const localCompareAndSwap = ( idxBefore, idxAfter ) => {
+
+			If( localStorage.element( idxAfter ).lessThan( localStorage.element( idxBefore ) ), () => {
+
+				const temp = localStorage.element( idxBefore ).toVar();
+				localStorage.element( idxBefore ).assign( localStorage.element( idxAfter ) );
+				localStorage.element( idxAfter ).assign( temp );
+
+			} );
+
+		};
+
+		const fnDef = Fn( () => {
+
+			// Get ids of indices needed to populate workgroup local buffer.
+			// Use .toVar() to prevent these values from being recalculated multiple times.
+			const localOffset = uint( this.workgroupSize ).mul( 2 ).mul( workgroupId.x ).toVar();
+
+			const localID1 = invocationLocalIndex.mul( 2 );
+			const localID2 = invocationLocalIndex.mul( 2 ).add( 1 );
+
+			localStorage.element( localID1 ).assign( dataBuffer.element( localOffset.add( localID1 ) ) );
+			localStorage.element( localID2 ).assign( dataBuffer.element( localOffset.add( localID2 ) ) );
+
+			// Ensure that all local data has populated
+			workgroupBarrier();
+
+			// Perform a chunk of the sort in a single pass that operates entirely in workgroup local space
+			// SWAP_LOCAL will always be first pass, so we start with known block height of 2
+			const flipBlockHeight = uint( 2 );
+
+			Loop( { start: uint( 2 ), end: uint( workgroupSize * 2 ), type: 'uint', condition: '<=', update: '<<= 1' }, () => {
+
+				// Ensure that last dispatch block executed
+				workgroupBarrier();
+
+				const flipIdx = getBitonicFlipIndices( invocationLocalIndex, flipBlockHeight );
+				localCompareAndSwap( flipIdx.x, flipIdx.y );
+
+				const localBlockHeight = flipBlockHeight.toVar();
+
+				Loop( { start: localBlockHeight, end: uint( 1 ), type: 'uint', condition: '>', update: '>>= 1' }, () => {
+
+					// Ensure that last dispatch op executed
+					workgroupBarrier();
+
+					const disperseIdx = getBitonicFlipIndices( invocationLocalIndex, localBlockHeight );
+					localCompareAndSwap( disperseIdx.x, disperseIdx.y );
+
+					localBlockHeight.divAssign( 2 );
+
+				} );
+
+				// flipBlockHeight *= 2;
+				flipBlockHeight.shiftLeftAssign( 1 );
+
+			} );
+
+			// Ensure that all invocations have swapped their own regions of data
+			workgroupBarrier();
+
+			dataBuffer.element( localOffset.add( localID1 ) ).assign( localStorage.element( localID1 ) );
+			dataBuffer.element( localOffset.add( localID2 ) ).assign( localStorage.element( localID2 ) );
+
+
+		} )().compute( this.dispatchSize, [ this.workgroupSize ] );
+
+		return fnDef;
+
+	}
+
+	_getDisperseLocal() {
+
+		const { infoStorageRead, localStorage, dataBuffer } = this;
+
+		const localCompareAndSwap = ( idxBefore, idxAfter ) => {
+
+			If( localStorage.element( idxAfter ).lessThan( localStorage.element( idxBefore ) ), () => {
+
+				const temp = localStorage.element( idxBefore ).toVar();
+				localStorage.element( idxBefore ).assign( localStorage.element( idxAfter ) );
+				localStorage.element( idxAfter ).assign( temp );
+
+			} );
+
+		};
+
+		const currentSwapSpan = infoStorageRead.element( 1 ).toVar();
+
+		const fnDef = Fn( () => {
+
+			// Get ids of indices needed to populate workgroup local buffer.
+			// Use .toVar() to prevent these values from being recalculated multiple times.
+			const localOffset = uint( this.workgroupSize ).mul( 2 ).mul( workgroupId.x ).toVar();
+
+			const localID1 = invocationLocalIndex.mul( 2 );
+			const localID2 = invocationLocalIndex.mul( 2 ).add( 1 );
+
+			localStorage.element( localID1 ).assign( dataBuffer.element( localOffset.add( localID1 ) ) );
+			localStorage.element( localID2 ).assign( dataBuffer.element( localOffset.add( localID2 ) ) );
+
+			const localBlockHeight = currentSwapSpan.toVar();
+
+			Loop( { start: localBlockHeight, end: uint( 1 ), type: 'uint', condition: '>', update: '>>= 1' }, () => {
+
+				// Ensure that last dispatch op executed
+				workgroupBarrier();
+
+				const disperseIdx = getBitonicFlipIndices( invocationLocalIndex, localBlockHeight );
+				localCompareAndSwap( disperseIdx.x, disperseIdx.y );
+
+				localBlockHeight.divAssign( 2 );
+
+			} );
+
+
+			// Ensure that all invocations have swapped their own regions of data
+			workgroupBarrier();
+
+			// Populate output data with the results from our swaps
+
+			dataBuffer.element( localOffset.add( localID1 ) ).assign( localStorage.element( localID1 ) );
+			dataBuffer.element( localOffset.add( localID2 ) ).assign( localStorage.element( localID2 ) );
+
+
+		} )().compute( this.dispatchSize, [ this.workgroupSize ] );
+
+		return fnDef;
+
+	}
+
+	_getResetFn() {
+
+		const fnDef = Fn( () => {
+
+			const { infoStorage } = this;
+
+			const currentAlgo = infoStorage.element( 0 );
+			const currentSwapSpan = infoStorage.element( 1 );
+			const maxSwapSpan = infoStorage.element( 2 );
+
+			currentAlgo.assign( StepType.SWAP_LOCAL );
+			currentSwapSpan.assign( 2 );
+			maxSwapSpan.assign( 2 );
+
+		} )().compute( 1 );
+
+		return fnDef;
+
+	}
+
+	_getAlignFn() {
+
+		const { dataBuffer, tempBuffer } = this;
+
+		// TODO: Only do this in certain instances by ping-ponging which buffer gets sorted
+		// And only aligning if numDispatches % 2 === 1
+		const fnDef = Fn( () => {
+
+			dataBuffer.element( instanceIndex ).assign( tempBuffer.element( instanceIndex ) );
+
+		} )().compute( this.count, [ this.workgroupSize ] );
+
+		return fnDef;
+
+	}
+
+	_getSetAlgoFn() {
+
+		const fnDef = Fn( () => {
+
+			const { infoStorage, workgroupSize } = this;
+
+			const currentAlgo = infoStorage.element( 0 );
+			const currentSwapSpan = infoStorage.element( 1 );
+			const maxSwapSpan = infoStorage.element( 2 );
+
+			Switch( currentAlgo ).Case( StepType.SWAP_LOCAL, () => {
+
+				currentAlgo.assign( StepType.FLIP_GLOBAL );
+				currentSwapSpan.assign( workgroupSize * 4 );
+				maxSwapSpan.assign( workgroupSize * 4 );
+
+			} ).Case( StepType.DISPERSE_LOCAL, () => {
+
+				const nextHighestSwapSpan = maxSwapSpan.mul( 2 );
+
+				currentAlgo.assign( StepType.FLIP_GLOBAL );
+				currentSwapSpan.assign( nextHighestSwapSpan );
+				maxSwapSpan.assign( nextHighestSwapSpan );
+
+			} ).Default( () => {
+
+				const nextSwapSpan = currentSwapSpan.div( 2 );
+				currentAlgo.assign(
+					select(
+						nextSwapSpan.lessThanEqual( uint( workgroupSize ).mul( 2 ) ),
+						StepType.DISPERSE_LOCAL,
+						StepType.DISPERSE_GLOBAL
+					).uniformFlow()
+				);
+				currentSwapSpan.assign( nextSwapSpan );
+
+			} );
+
+		} )().compute( 1 );
+
+		return fnDef;
+
+	}
+
+	computeStep( renderer ) {
+
+		// Swap local only runs once
+		if ( this.currentDispatch === 0 ) {
+
+			renderer.compute( this.swapLocalFn );
+
+			this.globalOpsRemaining = 1;
+			this.globalOpsInSpan = 1;
+
+		} else if ( this.globalOpsRemaining > 0 ) {
+
+			renderer.compute( this.globalOpsRemaining === this.globalOpsInSpan ? this.flipGlobalFn : this.disperseGlobalFn );
+			renderer.compute( this.alignFn );
+
+			this.globalOpsRemaining -= 1;
+
+		} else {
+
+			// Then run local disperses when we've finished all global swaps
+			renderer.compute( this.disperseLocalFn );
+
+			const nextSpanGlobalOps = this.globalOpsInSpan + 1;
+			this.globalOpsInSpan = nextSpanGlobalOps;
+			this.globalOpsRemaining = nextSpanGlobalOps;
+
+
+		}
+
+		// Pass the next swap span to compute storage
+		renderer.compute( this.setAlgoFn );
+
+		this.currentDispatch += 1;
+
+		if ( this.currentDispatch === this.stepCount ) {
+
+			this.currentDispatch = 0;
+			this.globalOpsRemaining = 0;
+			this.globalOpsInSpan = 0;
+
+		}
+
+	}
+
+
+	compute( renderer ) {
+
+		this.globalOpsRemaining = 0;
+		this.globalOpsInSpan = 0;
+		this.currentDispatch = 0;
+
+		for ( let i = 0; i < this.stepCount; i ++ ) {
+
+			this.computeStep( renderer );
+
+		}
+
+	}
+
+}

--- a/examples/jsm/gpgpu/BitonicSort.js
+++ b/examples/jsm/gpgpu/BitonicSort.js
@@ -33,14 +33,14 @@ export const getBitonicFlipIndices = /*@__PURE__*/ Fn( ( [ index, blockHeight ] 
 
 	return idx;
 
-}).setLayout({ 
-	name: 'getBitonicFlipIndices', 
+} ).setLayout( {
+	name: 'getBitonicFlipIndices',
 	type: 'uvec2',
 	inputs: [
-		{name: 'index', type: 'uint'},
-		{name: 'blockHeight', type: 'uint'}
+		{ name: 'index', type: 'uint' },
+		{ name: 'blockHeight', type: 'uint' }
 	]
-});
+} );
 
 /**
  * Returns the indices that will be compared in a bitonic sort's disperse operation.
@@ -65,18 +65,25 @@ export const getBitonicDisperseIndices = /*@__PURE__*/ Fn( ( [ index, swapSpan ]
 
 	return idx;
 
-}).setLayout({
+} ).setLayout( {
 	name: 'getBitonicDisperseIndices',
-	type: 'uvec2', 
+	type: 'uvec2',
 	inputs: [
-		{name: 'index', type: 'uint'},
-		{name: 'blockHeight', type: 'uint'}
+		{ name: 'index', type: 'uint' },
+		{ name: 'blockHeight', type: 'uint' }
 	]
-});
+} );
 
 // TODO: Add parameters for computing a buffer larger than vec4
 export class BitonicSort {
 
+	/**
+	 * Constructs a new light probe helper.
+	 *
+	 * @param {Renderer} renderer - The current scene's renderer.
+	 * @param {StorageBufferNode} [size=1] - The size of the helper.
+	 * @param {Object} [options={}] - The size of the helper.
+	 */
 	constructor( renderer, dataBuffer, options = {} ) {
 
 		/**
@@ -122,10 +129,10 @@ export class BitonicSort {
 		*/
 		this.localStorage = workgroupArray( dataBuffer.nodeType, this.workgroupSize * 2 );
 
-		this._tempArray = new Uint32Array(this.count);
-		for (let i = 0; i < this.count; i++) {
+		this._tempArray = new Uint32Array( this.count );
+		for ( let i = 0; i < this.count; i ++ ) {
 
-			this._tempArray[i] = 0;
+			this._tempArray[ i ] = 0;
 
 		}
 
@@ -141,7 +148,7 @@ export class BitonicSort {
 		 *
 		 * @type {StorageBufferNode}
 		*/
-		this.infoStorage = instancedArray( new Uint32Array([1, 2, 2]), 'uint' ).setName( 'BitonicSortInfo' );
+		this.infoStorage = instancedArray( new Uint32Array( [ 1, 2, 2 ] ), 'uint' ).setName( 'BitonicSortInfo' );
 
 
 		/**
@@ -350,7 +357,7 @@ export class BitonicSort {
 
 	}
 
-	
+
 	/**
 	 * Create the compute shader that performs a complete local swap on the data buffer.
 	 *
@@ -399,7 +406,7 @@ export class BitonicSort {
 				const flipIdx = getBitonicFlipIndices( invocationLocalIndex, flipBlockHeight );
 				localCompareAndSwap( flipIdx.x, flipIdx.y );
 
-				const localBlockHeight = flipBlockHeight.div(2)
+				const localBlockHeight = flipBlockHeight.div( 2 );
 
 				Loop( { start: localBlockHeight, end: uint( 1 ), type: 'uint', condition: '>', update: '>>= 1' }, () => {
 
@@ -438,7 +445,7 @@ export class BitonicSort {
 	 */
 	_getDisperseLocal() {
 
-		const { localStorage, dataBuffer, workgroupSize, infoStorage } = this;
+		const { localStorage, dataBuffer, workgroupSize } = this;
 
 		const localCompareAndSwap = ( idxBefore, idxAfter ) => {
 
@@ -467,7 +474,7 @@ export class BitonicSort {
 			// Ensure that all local data has been populated
 			workgroupBarrier();
 
-			const localBlockHeight = uint(workgroupSize * 2);
+			const localBlockHeight = uint( workgroupSize * 2 );
 
 			Loop( { start: localBlockHeight, end: uint( 1 ), type: 'uint', condition: '>', update: '>>= 1' }, () => {
 
@@ -548,7 +555,7 @@ export class BitonicSort {
 
 		const fnDef = Fn( () => {
 
-			const { infoStorage, workgroupSize, count } = this;
+			const { infoStorage, workgroupSize } = this;
 
 			const currentAlgo = infoStorage.element( 0 );
 			const currentSwapSpan = infoStorage.element( 1 );
@@ -559,10 +566,10 @@ export class BitonicSort {
 				const nextHighestSwapSpan = uint( workgroupSize * 4 );
 
 				currentAlgo.assign( StepType.FLIP_GLOBAL );
-				currentSwapSpan.assign( nextHighestSwapSpan);
+				currentSwapSpan.assign( nextHighestSwapSpan );
 				maxSwapSpan.assign( nextHighestSwapSpan );
 
-			} ).ElseIf( currentAlgo.equal(StepType.DISPERSE_LOCAL), () => {
+			} ).ElseIf( currentAlgo.equal( StepType.DISPERSE_LOCAL ), () => {
 
 				currentAlgo.assign( StepType.FLIP_GLOBAL );
 
@@ -583,7 +590,7 @@ export class BitonicSort {
 				);
 				currentSwapSpan.assign( nextSwapSpan );
 
-			} )
+			} );
 
 		} )().compute( 1 );
 
@@ -629,11 +636,11 @@ export class BitonicSort {
 
 
 		this.currentDispatch += 1;
-		
+
 		if ( this.currentDispatch === this.stepCount ) {
 
 			// Just reset the algorithm information
-			await renderer.computeAsync( this.resetFn )
+			await renderer.computeAsync( this.resetFn );
 
 			this.currentDispatch = 0;
 			this.globalOpsRemaining = 0;

--- a/examples/webgpu_compute_sort_bitonic.html
+++ b/examples/webgpu_compute_sort_bitonic.html
@@ -55,7 +55,9 @@
 		<script type="module">
 
 			import * as THREE from 'three/webgpu';
-			import { storage, If, vec3, not, uniform, uv, uint, float, Fn, vec2, abs, int, invocationLocalIndex, workgroupArray, uvec2, floor, instanceIndex, workgroupBarrier, atomicAdd, atomicStore, workgroupId } from 'three/tsl';
+			import { storage, If, vec3, not, uniform, uv, uint, Fn, vec2, abs, int, invocationLocalIndex, workgroupArray, uvec2, floor, instanceIndex, workgroupBarrier, workgroupId } from 'three/tsl';
+
+			import { BitonicSort, getBitonicDisperseIndices, getBitonicFlipIndices } from 'three/addons/gpgpu/BitonicSort.js';
 
 			import WebGPU from 'three/addons/capabilities/WebGPU.js';
 
@@ -83,7 +85,7 @@
 			const globalColors = [ 'rgb(1, 150, 1)', 'red' ];
 
 			// Total number of elements and the dimensions of the display grid.
-			const size = 16384;
+			const size = 256;
 			const gridDim = Math.sqrt( size );
 
 			const getNumSteps = () => {
@@ -119,7 +121,6 @@
 
 				}
 
-
 			} );
 
 			if ( WebGPU.isAvailable() === false ) {
@@ -130,12 +131,250 @@
 
 			}
 
-			// Allow Workgroup Array Swaps
-			init();
+			// Display utilities
+
+			const getElementIndex = Fn( ( [ uvNode, gridWidth, gridHeight ] ) => {
+
+				const newUV = uvNode.mul( vec2( gridWidth, gridHeight ) );
+				const pixel = uvec2( uint( floor( newUV.x ) ), uint( floor( newUV.y ) ) );
+				const elementIndex = uint( gridWidth ).mul( pixel.y ).add( pixel.x );
+
+				return elementIndex;
+
+			}, {
+				uvNode: 'vec2',
+				gridWidth: 'uint',
+				gridHeight: 'uint',
+				return: 'uint'
+			} );
+
+			const getColor = Fn( ( [ colorChanger, gridWidth, gridHeight ] ) => {
+
+				const subtracter = colorChanger.div( gridWidth.mul( gridHeight ) );
+				return vec3( subtracter.oneMinus() ).toVar();
+
+			}, {
+				colorChanger: 'float',
+				gridWidth: 'float',
+				gridHeight: 'float',
+				return: 'vec3'
+			} );
+
+			const randomizeDataArray = ( array ) => {
+
+				let currentIndex = array.length;
+				while ( currentIndex !== 0 ) {
+
+					const randomIndex = Math.floor( Math.random() * currentIndex );
+					currentIndex -= 1;
+					[ array[ currentIndex ], array[ randomIndex ] ] = [
+						array[ randomIndex ],
+						array[ currentIndex ],
+					];
+
+				}
+
+			};
+
+			const windowResizeCallback = ( renderer, scene, camera ) => {
+
+				renderer.setSize( window.innerWidth / 2, window.innerHeight );
+				const aspect = ( window.innerWidth / 2 ) / window.innerHeight;
+				const frustumHeight = camera.top - camera.bottom;
+				camera.left = - frustumHeight * aspect / 2;
+				camera.right = frustumHeight * aspect / 2;
+				camera.updateProjectionMatrix();
+				renderer.render( scene, camera );
+
+			};
+
+			const constructInnerHTML = ( renderer, isGlobal, colorsArr ) => {
+
+				return `
+
+				Compute ${isGlobal ? 'Global' : 'Local'}: ${renderer.info.compute.frameCalls} pass in ${renderer.info.compute.timestamp.toFixed( 6 )}ms<br>
+				<div style="display: flex; flex-direction:row; justify-content: center; align-items: center;">
+					${isGlobal ? 'Global Swaps' : 'Local Swaps'} Compare Region&nbsp;
+					<div style="background-color: ${ colorsArr[ 0 ]}; width:12.5px; height: 1em; border-radius: 20%;"></div>
+					&nbsp;to Region&nbsp;
+					<div style="background-color: ${ colorsArr[ 1 ] }; width:12.5px; height: 1em; border-radius: 20%;"></div>
+				</div>`;
+
+			};
+
+			const createDisplayMesh = ( elementsStorage, algoStorage = null, blockHeightStorage = null ) => {
+
+				const material = new THREE.MeshBasicNodeMaterial( { color: 0x00ff00 } );
+
+				const display = Fn( () => {
+
+					const { gridWidth, gridHeight, highlight } = effectController;
+
+					const elementIndex = getElementIndex( uv(), gridWidth, gridHeight );
+					const color = getColor( elementsStorage.element( elementIndex ), gridWidth, gridHeight ).toVar();
+
+					if ( algoStorage !== null && blockHeightStorage !== null ) {
+
+						If( highlight.equal( 1 ).and( not( algoStorage.element( 0 ).equal( StepType.NONE ) ) ), () => {
+
+							const boolCheck = int( elementIndex.mod( blockHeightStorage.element( 0 ) ).lessThan( blockHeightStorage.element( 0 ).div( 2 ) ) );
+							color.z.assign( algoStorage.element( 0 ).lessThanEqual( StepType.DISPERSE_LOCAL ) );
+							color.x.mulAssign( boolCheck );
+							color.y.mulAssign( abs( boolCheck.sub( 1 ) ) );
+
+						} );
+
+					}
+
+					return color;
+
+				} );
+
+				material.colorNode = display();
+				const plane = new THREE.Mesh( new THREE.PlaneGeometry( 1, 1 ), material );
+				return plane;
+
+			};
+			
+			const setupDomElement = ( renderer ) => {
+
+				document.body.appendChild( renderer.domElement );
+				renderer.domElement.style.position = 'absolute';
+				renderer.domElement.style.top = '0';
+				renderer.domElement.style.left = '0';
+				renderer.domElement.style.width = '50%';
+				renderer.domElement.style.height = '100%';
+
+			};
+
+			async function initBitonicSort() {
+
+				let currentStep = 0;
+
+				const aspect = ( window.innerWidth / 2 ) / window.innerHeight;
+				const camera = new THREE.OrthographicCamera( - aspect, aspect, 1, - 1, 0, 2 );
+				camera.position.z = 1;
+
+				const scene = new THREE.Scene();
+
+				const array = new Uint32Array( Array.from( { length: size }, ( _, i ) => {
+
+					return i;
+
+				} ) );
+
+
+				randomizeDataArray( array );
+
+				const currentElementsBuffer = new THREE.StorageInstancedBufferAttribute( array, 1 );
+				const currentElementsStorage = storage( currentElementsBuffer, 'uint', size ).setPBO( true ).setName( 'Elements' );
+				const randomizedElementsBuffer = new THREE.StorageInstancedBufferAttribute( size, 1 );
+				const randomizedElementsStorage = storage( randomizedElementsBuffer, 'uint', size ).setPBO( true ).setName( 'RandomizedElements' );
+
+				const computeInitFn = Fn( () => {
+
+					randomizedElementsStorage.element( instanceIndex ).assign( currentElementsStorage.element( instanceIndex ) );
+
+				} );
+
+				const computeResetBuffersFn = Fn( () => {
+
+					currentElementsStorage.element( instanceIndex ).assign( randomizedElementsStorage.element( instanceIndex ) );
+
+				} );
+
+				scene.add( createDisplayMesh( currentElementsStorage ) );
+
+				const renderer = new THREE.WebGPURenderer( { antialias: false, trackTimestamp: true } );
+				renderer.setPixelRatio( window.devicePixelRatio );
+				renderer.setSize( window.innerWidth / 2, window.innerHeight );
+
+				const animate = () => {
+
+					renderer.render( scene, camera );
+
+				};
+
+				renderer.setAnimationLoop( animate );
+				setupDomElement( renderer );
+				scene.background = new THREE.Color( 0x313131 );
+
+				const bitonicSortModule = new BitonicSort(
+					renderer,
+					currentElementsStorage,
+					{
+						workgroupSize: 64,
+						sideEffectBuffers: [ 2, 3 ]
+					}
+				);
+
+				console.log( bitonicSortModule );
+
+				// Initialize each value in the elements buffer.
+				const computeInit = computeInitFn().compute( size );
+				const computeReset = computeResetBuffersFn().compute( size );
+
+				await renderer.computeAsync( computeInit );
+
+				renderer.info.autoReset = false;
+
+				 const stepAnimation = async function () {
+
+					renderer.info.reset();
+
+					if ( currentStep < bitonicSortModule.stepCount ) {
+
+						bitonicSortModule.computeStep( renderer );
+
+						currentStep ++;
+
+					} else {
+
+						renderer.compute( computeReset );
+
+						currentStep = 0;
+
+					}
+
+					renderer.resolveTimestampsAsync( THREE.TimestampQuery.COMPUTE );
+
+
+					//const algo = new Uint32Array( await renderer.getArrayBufferAsync( nextAlgoBuffer ) );
+					//nextStepGlobal = algo[ 0 ] > StepType.DISPERSE_LOCAL;
+
+					renderer.render( scene, camera );
+					renderer.resolveTimestampsAsync( THREE.TimestampQuery.RENDER );
+
+					timestamps[ 'local_swap' ].innerHTML = constructInnerHTML( renderer, false, localColors );
+
+					if ( currentStep === bitonicSortModule.stepCount ) {
+
+						setTimeout( stepAnimation, 5000 );
+
+					} else {
+
+						setTimeout( stepAnimation, 5000 );
+
+					}
+
+				};
+
+				stepAnimation();
+
+				window.addEventListener( 'resize', onWindowResize );
+
+				function onWindowResize() {
+
+					windowResizeCallback( renderer, scene, camera );
+
+				}
+
+			}
+
+			initBitonicSort();
 
 			// Global Swaps Only
 			init( true );
-
 
 			// When forceGlobalSwap is true, force all valid local swaps to be global swaps.
 			async function init( forceGlobalSwap = false ) {
@@ -160,33 +399,13 @@
 				const highestBlockHeightBuffer = new THREE.StorageInstancedBufferAttribute( new Uint32Array( 1 ).fill( 2 ), 1 );
 				const highestBlockHeightStorage = storage( highestBlockHeightBuffer, 'uint', highestBlockHeightBuffer.count ).setPBO( true ).setName( 'HighestBlockHeight' );
 
-				const counterBuffer = new THREE.StorageBufferAttribute( 1, 1 );
-				const counterStorage = storage( counterBuffer, 'uint', counterBuffer.count ).setPBO( true ).toAtomic().setName( 'Counter' );
-
 				const array = new Uint32Array( Array.from( { length: size }, ( _, i ) => {
 
 					return i;
 
 				} ) );
 
-
-				const randomizeDataArray = () => {
-
-					let currentIndex = array.length;
-					while ( currentIndex !== 0 ) {
-
-						const randomIndex = Math.floor( Math.random() * currentIndex );
-						currentIndex -= 1;
-						[ array[ currentIndex ], array[ randomIndex ] ] = [
-							array[ randomIndex ],
-							array[ currentIndex ],
-						];
-
-					}
-
-				};
-
-				randomizeDataArray();
+				randomizeDataArray( array );
 
 				const currentElementsBuffer = new THREE.StorageInstancedBufferAttribute( array, 1 );
 				const currentElementsStorage = storage( currentElementsBuffer, 'uint', size ).setPBO( true ).setName( 'Elements' );
@@ -195,37 +414,6 @@
 				const randomizedElementsBuffer = new THREE.StorageInstancedBufferAttribute( size, 1 );
 				const randomizedElementsStorage = storage( randomizedElementsBuffer, 'uint', size ).setPBO( true ).setName( 'RandomizedElements' );
 
-				const getFlipIndices = ( index, blockHeight ) => {
-
-					const blockOffset = ( index.mul( 2 ).div( blockHeight ) ).mul( blockHeight );
-					const halfHeight = blockHeight.div( 2 );
-					const idx = uvec2(
-						index.mod( halfHeight ),
-						blockHeight.sub( index.mod( halfHeight ) ).sub( 1 )
-					);
-					idx.x.addAssign( blockOffset );
-					idx.y.addAssign( blockOffset );
-
-					return idx;
-
-				};
-
-				const getDisperseIndices = ( index, blockHeight ) => {
-
-					const blockOffset = ( ( index.mul( 2 ) ).div( blockHeight ) ).mul( blockHeight );
-					const halfHeight = blockHeight.div( 2 );
-					const idx = uvec2(
-						index.mod( halfHeight ),
-						( index.mod( halfHeight ) ).add( halfHeight )
-					);
-
-					idx.x.addAssign( blockOffset );
-					idx.y.addAssign( blockOffset );
-
-					return idx;
-
-				};
-
 				const localStorage = workgroupArray( 'uint', 64 * 2 );
 
 				// Swap the elements in local storage
@@ -233,7 +421,6 @@
 
 					If( localStorage.element( idxAfter ).lessThan( localStorage.element( idxBefore ) ), () => {
 
-						atomicAdd( counterStorage.element( 0 ), 1 );
 						const temp = localStorage.element( idxBefore ).toVar();
 						localStorage.element( idxBefore ).assign( localStorage.element( idxAfter ) );
 						localStorage.element( idxAfter ).assign( temp );
@@ -248,7 +435,6 @@
 					If( currentElementsStorage.element( idxAfter ).lessThan( currentElementsStorage.element( idxBefore ) ), () => {
 
 						// Apply the swapped values to temporary storage.
-						atomicAdd( counterStorage.element( 0 ), 1 );
 						tempStorage.element( idxBefore ).assign( currentElementsStorage.element( idxAfter ) );
 						tempStorage.element( idxAfter ).assign( currentElementsStorage.element( idxBefore ) );
 
@@ -293,22 +479,22 @@
 					// TODO: Convert to switch block.
 					If( nextAlgo.equal( uint( StepType.FLIP_LOCAL ) ), () => {
 
-						const idx = getFlipIndices( invocationLocalIndex, nextBlockHeight );
+						const idx = getBitonicFlipIndices( invocationLocalIndex, nextBlockHeight );
 						localCompareAndSwap( idx.x, idx.y );
 
 					} ).ElseIf( nextAlgo.equal( uint( StepType.DISPERSE_LOCAL ) ), () => {
 
-						const idx = getDisperseIndices( invocationLocalIndex, nextBlockHeight );
+						const idx = getBitonicDisperseIndices( invocationLocalIndex, nextBlockHeight );
 						localCompareAndSwap( idx.x, idx.y );
 
 					} ).ElseIf( nextAlgo.equal( uint( StepType.FLIP_GLOBAL ) ), () => {
 
-						const idx = getFlipIndices( instanceIndex, nextBlockHeight );
+						const idx = getBitonicFlipIndices( instanceIndex, nextBlockHeight );
 						globalCompareAndSwap( idx.x, idx.y );
 
 					} ).ElseIf( nextAlgo.equal( uint( StepType.DISPERSE_GLOBAL ) ), () => {
 
-						const idx = getDisperseIndices( instanceIndex, nextBlockHeight );
+						const idx = getBitonicDisperseIndices( instanceIndex, nextBlockHeight );
 						globalCompareAndSwap( idx.x, idx.y );
 
 					} );
@@ -411,7 +597,6 @@
 					nextAlgoStorage.element( 0 ).assign( forceGlobalSwap ? StepType.FLIP_GLOBAL : StepType.FLIP_LOCAL );
 					nextBlockHeightStorage.element( 0 ).assign( 2 );
 					highestBlockHeightStorage.element( 0 ).assign( 2 );
-					atomicStore( counterStorage.element( 0 ), 0 );
 
 				} );
 
@@ -427,41 +612,7 @@
 				const computeResetBuffers = computeResetBuffersFn().compute( size );
 				const computeResetAlgo = computeResetAlgoFn().compute( 1 );
 
-				const material = new THREE.MeshBasicNodeMaterial( { color: 0x00ff00 } );
-
-				const display = Fn( () => {
-
-					const { gridWidth, gridHeight, highlight } = effectController;
-
-					const newUV = uv().mul( vec2( gridWidth, gridHeight ) );
-
-					const pixel = uvec2( uint( floor( newUV.x ) ), uint( floor( newUV.y ) ) );
-
-					const elementIndex = uint( gridWidth ).mul( pixel.y ).add( pixel.x );
-
-					const colorChanger = currentElementsStorage.element( elementIndex );
-
-					const subtracter = float( colorChanger ).div( gridWidth.mul( gridHeight ) );
-
-					const color = vec3( subtracter.oneMinus() ).toVar();
-
-					If( highlight.equal( 1 ).and( not( nextAlgoStorage.element( 0 ).equal( StepType.NONE ) ) ), () => {
-
-						const boolCheck = int( elementIndex.mod( nextBlockHeightRead.element( 0 ) ).lessThan( nextBlockHeightRead.element( 0 ).div( 2 ) ) );
-						color.z.assign( nextAlgoStorage.element( 0 ).lessThanEqual( StepType.DISPERSE_LOCAL ) );
-						color.x.mulAssign( boolCheck );
-						color.y.mulAssign( abs( boolCheck.sub( 1 ) ) );
-
-					} );
-
-					return color;
-
-				} );
-
-				material.colorNode = display();
-
-				const plane = new THREE.Mesh( new THREE.PlaneGeometry( 1, 1 ), material );
-				scene.add( plane );
+				scene.add( createDisplayMesh( currentElementsStorage, nextAlgoStorage, nextBlockHeightRead ) );
 
 				const renderer = new THREE.WebGPURenderer( { antialias: false, trackTimestamp: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
@@ -474,25 +625,9 @@
 				};
 
 				renderer.setAnimationLoop( animate );
-
-				document.body.appendChild( renderer.domElement );
-				renderer.domElement.style.position = 'absolute';
-				renderer.domElement.style.top = '0';
-				renderer.domElement.style.left = '0';
-				renderer.domElement.style.width = '50%';
-				renderer.domElement.style.height = '100%';
-
-				if ( forceGlobalSwap ) {
-
-					renderer.domElement.style.left = '50%';
-
-					scene.background = new THREE.Color( 0x212121 );
-
-				} else {
-
-					scene.background = new THREE.Color( 0x313131 );
-
-				}
+				setupDomElement( renderer );
+				renderer.domElement.style.left = '50%';
+				scene.background = new THREE.Color( 0x212121 );
 
 				await renderer.computeAsync( computeInit );
 
@@ -530,21 +665,11 @@
 
 					const algo = new Uint32Array( await renderer.getArrayBufferAsync( nextAlgoBuffer ) );
 					nextStepGlobal = algo[ 0 ] > StepType.DISPERSE_LOCAL;
-					const totalSwaps = new Uint32Array( await renderer.getArrayBufferAsync( counterBuffer ) );
 
 					renderer.render( scene, camera );
 					renderer.resolveTimestampsAsync( THREE.TimestampQuery.RENDER );
 
-					timestamps[ forceGlobalSwap ? 'global_swap' : 'local_swap' ].innerHTML = `
-
-							Compute ${forceGlobalSwap ? 'Global' : 'Local'}: ${renderer.info.compute.frameCalls} pass in ${renderer.info.compute.timestamp.toFixed( 6 )}ms<br>
-							Total Swaps: ${totalSwaps}<br>
-								<div style="display: flex; flex-direction:row; justify-content: center; align-items: center;">
-									${forceGlobalSwap ? 'Global Swaps' : 'Local Swaps'} Compare Region&nbsp;
-									<div style="background-color: ${ forceGlobalSwap ? globalColors[ 0 ] : localColors[ 0 ]}; width:12.5px; height: 1em; border-radius: 20%;"></div>
-									&nbsp;to Region&nbsp;
-									<div style="background-color: ${ forceGlobalSwap ? globalColors[ 1 ] : localColors[ 1 ]}; width:12.5px; height: 1em; border-radius: 20%;"></div>
-								</div>`;
+					timestamps[ 'global_swap' ].innerHTML = constructInnerHTML( renderer, true, globalColors );
 
 
 					if ( currentStep === MAX_STEPS ) {
@@ -566,18 +691,7 @@
 
 				function onWindowResize() {
 
-					renderer.setSize( window.innerWidth / 2, window.innerHeight );
-
-					const aspect = ( window.innerWidth / 2 ) / window.innerHeight;
-
-					const frustumHeight = camera.top - camera.bottom;
-
-					camera.left = - frustumHeight * aspect / 2;
-					camera.right = frustumHeight * aspect / 2;
-
-					camera.updateProjectionMatrix();
-
-					renderer.render( scene, camera );
+					windowResizeCallback( renderer, scene, camera );
 
 				}
 

--- a/examples/webgpu_compute_sort_bitonic.html
+++ b/examples/webgpu_compute_sort_bitonic.html
@@ -55,7 +55,7 @@
 		<script type="module">
 
 			import * as THREE from 'three/webgpu';
-			import { storage, If, vec3, not, uniform, uv, uint, Fn, vec2, abs, int, invocationLocalIndex, workgroupArray, uvec2, floor, instanceIndex, workgroupBarrier, workgroupId } from 'three/tsl';
+			import { storage, If, vec3, not, uniform, uv, uint, Fn, vec2, abs, int, uvec2, floor, instanceIndex } from 'three/tsl';
 
 			import { BitonicSort, getBitonicDisperseIndices, getBitonicFlipIndices } from 'three/addons/gpgpu/BitonicSort.js';
 
@@ -66,7 +66,7 @@
 			const StepType = {
 
 				NONE: 0,
-				// Swap values within workgroup local buffer.
+				// Swap values within workgroup local values
 				FLIP_LOCAL: 1,
 				DISPERSE_LOCAL: 2,
 				// Swap values within global data buffer.
@@ -80,12 +80,11 @@
 				global_swap: document.getElementById( 'global_swap' )
 			};
 
-
 			const localColors = [ 'rgb(203, 64, 203)', 'rgb(0, 215, 215)' ];
 			const globalColors = [ 'rgb(1, 150, 1)', 'red' ];
 
 			// Total number of elements and the dimensions of the display grid.
-			const size = 16;
+			const size = 1024;
 			const gridDim = Math.sqrt( size );
 
 			const getNumSteps = () => {
@@ -97,7 +96,6 @@
 
 			// Total number of steps in a bitonic sort with 'size' elements.
 			const MAX_STEPS = getNumSteps();
-			const WORKGROUP_SIZE = [ 64 ];
 
 			const effectController = {
 				// Sqr root of 16834
@@ -189,11 +187,11 @@
 
 			};
 
-			const constructInnerHTML = ( renderer, isGlobal, colorsArr ) => {
+			const constructInnerHTML = ( isGlobal, colorsArr ) => {
 
 				return `
 
-				Compute ${isGlobal ? 'Global' : 'Local'}: ${renderer.info.compute.frameCalls} pass in ${renderer.info.compute.timestamp.toFixed( 6 )}ms<br>
+				Compute ${isGlobal ? 'Global' : 'Local'}:
 				<div style="display: flex; flex-direction:row; justify-content: center; align-items: center;">
 					${isGlobal ? 'Global Swaps' : 'Local Swaps'} Compare Region&nbsp;
 					<div style="background-color: ${ colorsArr[ 0 ]}; width:12.5px; height: 1em; border-radius: 20%;"></div>
@@ -286,7 +284,7 @@
 
 				scene.add( createDisplayMesh( currentElementsStorage ) );
 
-				const renderer = new THREE.WebGPURenderer( { antialias: false, trackTimestamp: true } );
+				const renderer = new THREE.WebGPURenderer( { antialias: false } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth / 2, window.innerHeight );
 
@@ -317,11 +315,7 @@
 
 				await renderer.computeAsync( computeInit );
 
-				renderer.info.autoReset = false;
-
 				gui.add( effectController, 'stepBitonic' ).onChange( async () => {
-
-					renderer.info.reset();
 
 					if ( currentStep < bitonicSortModule.stepCount ) {
 
@@ -331,20 +325,13 @@
 
 					} else {
 
-						renderer.computeAsync( computeReset );
-
-						console.log( new Uint32Array( await renderer.getArrayBufferAsync( bitonicSortModule.dataBuffer.value ) ) );
+						await renderer.computeAsync( computeReset );
 
 						currentStep = 0;
 
 					}
 
-					renderer.resolveTimestampsAsync( THREE.TimestampQuery.COMPUTE );
-
-					renderer.render( scene, camera );
-					renderer.resolveTimestampsAsync( THREE.TimestampQuery.RENDER );
-
-					timestamps[ 'local_swap' ].innerHTML = constructInnerHTML( renderer, false, localColors );
+					timestamps[ 'local_swap' ].innerHTML = constructInnerHTML( false, localColors );
 
 				} );
 
@@ -368,16 +355,7 @@
 
 					}
 
-					renderer.resolveTimestampsAsync( THREE.TimestampQuery.COMPUTE );
-
-
-					//const algo = new Uint32Array( await renderer.getArrayBufferAsync( nextAlgoBuffer ) );
-					//nextStepGlobal = algo[ 0 ] > StepType.DISPERSE_LOCAL;
-
-					renderer.render( scene, camera );
-					renderer.resolveTimestampsAsync( THREE.TimestampQuery.RENDER );
-
-					timestamps[ 'local_swap' ].innerHTML = constructInnerHTML( renderer, false, localColors );
+					timestamps[ 'local_swap' ].innerHTML = constructInnerHTML(false, localColors );
 
 					if ( currentStep === bitonicSortModule.stepCount ) {
 
@@ -406,13 +384,12 @@
 			initBitonicSort();
 
 			// Global Swaps Only
-			init( true );
+			initGlobalSwapOnly();
 
 			// When forceGlobalSwap is true, force all valid local swaps to be global swaps.
-			async function init( forceGlobalSwap = false ) {
+			async function initGlobalSwapOnly() {
 
 				let currentStep = 0;
-				let nextStepGlobal = false;
 
 				const aspect = ( window.innerWidth / 2 ) / window.innerHeight;
 				const camera = new THREE.OrthographicCamera( - aspect, aspect, 1, - 1, 0, 2 );
@@ -420,16 +397,13 @@
 
 				const scene = new THREE.Scene();
 
-				const nextAlgoBuffer = new THREE.StorageInstancedBufferAttribute( new Uint32Array( 1 ).fill( forceGlobalSwap ? StepType.FLIP_GLOBAL : StepType.FLIP_LOCAL ), 1 );
-
-				const nextAlgoStorage = storage( nextAlgoBuffer, 'uint', nextAlgoBuffer.count ).setPBO( true ).setName( 'NextAlgo' );
+				const infoArray = new Uint32Array( 3, 2, 2 );
+				const infoBuffer = new THREE.StorageInstancedBufferAttribute( infoArray, 1 );
+				const infoStorage = storage( infoBuffer, 'uint', infoBuffer.count ).setPBO( true ).setName( 'TheInfo' );
 
 				const nextBlockHeightBuffer = new THREE.StorageInstancedBufferAttribute( new Uint32Array( 1 ).fill( 2 ), 1 );
 				const nextBlockHeightStorage = storage( nextBlockHeightBuffer, 'uint', nextBlockHeightBuffer.count ).setPBO( true ).setName( 'NextBlockHeight' );
 				const nextBlockHeightRead = storage( nextBlockHeightBuffer, 'uint', nextBlockHeightBuffer.count ).setPBO( true ).setName( 'NextBlockHeight' ).toReadOnly();
-
-				const highestBlockHeightBuffer = new THREE.StorageInstancedBufferAttribute( new Uint32Array( 1 ).fill( 2 ), 1 );
-				const highestBlockHeightStorage = storage( highestBlockHeightBuffer, 'uint', highestBlockHeightBuffer.count ).setPBO( true ).setName( 'HighestBlockHeight' );
 
 				const array = new Uint32Array( Array.from( { length: size }, ( _, i ) => {
 
@@ -446,21 +420,7 @@
 				const randomizedElementsBuffer = new THREE.StorageInstancedBufferAttribute( size, 1 );
 				const randomizedElementsStorage = storage( randomizedElementsBuffer, 'uint', size ).setPBO( true ).setName( 'RandomizedElements' );
 
-				const localStorage = workgroupArray( 'uint', 64 * 2 );
-
 				// Swap the elements in local storage
-				const localCompareAndSwap = ( idxBefore, idxAfter ) => {
-
-					If( localStorage.element( idxAfter ).lessThan( localStorage.element( idxBefore ) ), () => {
-
-						const temp = localStorage.element( idxBefore ).toVar();
-						localStorage.element( idxBefore ).assign( localStorage.element( idxAfter ) );
-						localStorage.element( idxAfter ).assign( temp );
-
-					} );
-
-				};
-
 				const globalCompareAndSwap = ( idxBefore, idxAfter ) => {
 
 					// If the later element is less than the current element
@@ -489,37 +449,10 @@
 				const computeBitonicStepFn = Fn( () => {
 
 					const nextBlockHeight = nextBlockHeightStorage.element( 0 ).toVar();
-					const nextAlgo = nextAlgoStorage.element( 0 ).toVar();
-
-					// Get ids of indices needed to populate workgroup local buffer.
-					// Use .toVar() to prevent these values from being recalculated multiple times.
-					const localOffset = uint( WORKGROUP_SIZE[ 0 ] ).mul( 2 ).mul( workgroupId.x ).toVar();
-
-					const localID1 = invocationLocalIndex.mul( 2 );
-					const localID2 = invocationLocalIndex.mul( 2 ).add( 1 );
-
-					// If we will perform a local swap, then populate the local data
-					If( nextAlgo.lessThanEqual( uint( StepType.DISPERSE_LOCAL ) ), () => {
-
-						localStorage.element( localID1 ).assign( currentElementsStorage.element( localOffset.add( localID1 ) ) );
-						localStorage.element( localID2 ).assign( currentElementsStorage.element( localOffset.add( localID2 ) ) );
-
-					} );
-
-					workgroupBarrier();
+					const nextAlgo = infoStorage.element( 0 ).toVar();
 
 					// TODO: Convert to switch block.
-					If( nextAlgo.equal( uint( StepType.FLIP_LOCAL ) ), () => {
-
-						const idx = getBitonicFlipIndices( invocationLocalIndex, nextBlockHeight );
-						localCompareAndSwap( idx.x, idx.y );
-
-					} ).ElseIf( nextAlgo.equal( uint( StepType.DISPERSE_LOCAL ) ), () => {
-
-						const idx = getBitonicDisperseIndices( invocationLocalIndex, nextBlockHeight );
-						localCompareAndSwap( idx.x, idx.y );
-
-					} ).ElseIf( nextAlgo.equal( uint( StepType.FLIP_GLOBAL ) ), () => {
+					If( nextAlgo.equal( uint( StepType.FLIP_GLOBAL ) ), () => {
 
 						const idx = getBitonicFlipIndices( instanceIndex, nextBlockHeight );
 						globalCompareAndSwap( idx.x, idx.y );
@@ -531,26 +464,15 @@
 
 					} );
 
-					// Ensure that all invocations have swapped their own regions of data
-					workgroupBarrier();
-
-					// Populate output data with the results from our swaps
-					If( nextAlgo.lessThanEqual( uint( StepType.DISPERSE_LOCAL ) ), () => {
-
-						currentElementsStorage.element( localOffset.add( localID1 ) ).assign( localStorage.element( localID1 ) );
-						currentElementsStorage.element( localOffset.add( localID2 ) ).assign( localStorage.element( localID2 ) );
-
-					} );
-
-					// If the previous algorithm was global, we execute an additional compute step to sync the current buffer with the output buffer.
+					// Since this algorithm is global only, we execute an additional compute step to sync the current buffer with the output buffer.
 
 				} );
 
 				const computeSetAlgoFn = Fn( () => {
 
 					const nextBlockHeight = nextBlockHeightStorage.element( 0 ).toVar();
-					const nextAlgo = nextAlgoStorage.element( 0 );
-					const highestBlockHeight = highestBlockHeightStorage.element( 0 ).toVar();
+					const nextAlgo = infoStorage.element( 0 );
+					const highestBlockHeight = infoStorage.element( 2 ).toVar();
 
 					nextBlockHeight.divAssign( 2 );
 
@@ -558,57 +480,27 @@
 
 						highestBlockHeight.mulAssign( 2 );
 
-						if ( forceGlobalSwap ) {
+						If( highestBlockHeight.equal( size * 2 ), () => {
 
-							If( highestBlockHeight.equal( size * 2 ), () => {
+							nextAlgo.assign( StepType.NONE );
+							nextBlockHeight.assign( 0 );
 
-								nextAlgo.assign( StepType.NONE );
-								nextBlockHeight.assign( 0 );
+						} ).Else( () => {
 
-							} ).Else( () => {
+							nextAlgo.assign( StepType.FLIP_GLOBAL );
+							nextBlockHeight.assign( highestBlockHeight );
 
-								nextAlgo.assign( StepType.FLIP_GLOBAL );
-								nextBlockHeight.assign( highestBlockHeight );
+						} );
 
-							} );
-
-						} else {
-
-							If( highestBlockHeight.equal( size * 2 ), () => {
-
-								nextAlgo.assign( StepType.NONE );
-								nextBlockHeight.assign( 0 );
-
-							} ).ElseIf( highestBlockHeight.greaterThan( WORKGROUP_SIZE[ 0 ] * 2 ), () => {
-
-								nextAlgo.assign( StepType.FLIP_GLOBAL );
-								nextBlockHeight.assign( highestBlockHeight );
-
-							} ).Else( () => {
-
-								nextAlgo.assign( forceGlobalSwap ? StepType.FLIP_GLOBAL : StepType.FLIP_LOCAL );
-								nextBlockHeight.assign( highestBlockHeight );
-
-							} );
-
-						}
 
 					} ).Else( () => {
 
-						if ( forceGlobalSwap ) {
-
-							nextAlgo.assign( StepType.DISPERSE_GLOBAL );
-
-						} else {
-
-							nextAlgo.assign( nextBlockHeight.greaterThan( WORKGROUP_SIZE[ 0 ] * 2 ).select( StepType.DISPERSE_GLOBAL, StepType.DISPERSE_LOCAL ).uniformFlow() );
-
-						}
+						nextAlgo.assign( StepType.DISPERSE_GLOBAL );
 
 					} );
 
 					nextBlockHeightStorage.element( 0 ).assign( nextBlockHeight );
-					highestBlockHeightStorage.element( 0 ).assign( highestBlockHeight );
+					infoStorage.element( 2 ).assign( highestBlockHeight );
 
 				} );
 
@@ -626,9 +518,9 @@
 
 				const computeResetAlgoFn = Fn( () => {
 
-					nextAlgoStorage.element( 0 ).assign( forceGlobalSwap ? StepType.FLIP_GLOBAL : StepType.FLIP_LOCAL );
+					infoStorage.element( 0 ).assign( StepType.FLIP_GLOBAL );
 					nextBlockHeightStorage.element( 0 ).assign( 2 );
-					highestBlockHeightStorage.element( 0 ).assign( 2 );
+					infoStorage.element( 2 ).assign( 2 );
 
 				} );
 
@@ -644,9 +536,9 @@
 				const computeResetBuffers = computeResetBuffersFn().compute( size );
 				const computeResetAlgo = computeResetAlgoFn().compute( 1 );
 
-				scene.add( createDisplayMesh( currentElementsStorage, nextAlgoStorage, nextBlockHeightRead ) );
+				scene.add( createDisplayMesh( currentElementsStorage, infoStorage, nextBlockHeightRead ) );
 
-				const renderer = new THREE.WebGPURenderer( { antialias: false, trackTimestamp: true } );
+				const renderer = new THREE.WebGPURenderer( { antialias: false } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth / 2, window.innerHeight );
 
@@ -663,21 +555,13 @@
 
 				await renderer.computeAsync( computeInit );
 
-				renderer.info.autoReset = false;
-
 				 const stepAnimation = async function () {
-
-					renderer.info.reset();
 
 					if ( currentStep !== MAX_STEPS ) {
 
 						renderer.compute( computeBitonicStep );
 
-						if ( nextStepGlobal ) {
-
-							renderer.compute( computeAlignCurrent );
-
-						}
+						renderer.compute( computeAlignCurrent );
 
 						renderer.compute( computeSetAlgo );
 
@@ -692,22 +576,11 @@
 
 					}
 
-					renderer.resolveTimestampsAsync( THREE.TimestampQuery.COMPUTE );
-
-
-					const algo = new Uint32Array( await renderer.getArrayBufferAsync( nextAlgoBuffer ) );
-					nextStepGlobal = algo[ 0 ] > StepType.DISPERSE_LOCAL;
-
-					renderer.render( scene, camera );
-					renderer.resolveTimestampsAsync( THREE.TimestampQuery.RENDER );
-
-					timestamps[ 'global_swap' ].innerHTML = constructInnerHTML( renderer, true, globalColors );
-
+					timestamps[ 'global_swap' ].innerHTML = constructInnerHTML( true, globalColors );
 
 					if ( currentStep === MAX_STEPS ) {
 
 						setTimeout( stepAnimation, 1000 );
-
 
 					} else {
 

--- a/examples/webgpu_compute_sort_bitonic.html
+++ b/examples/webgpu_compute_sort_bitonic.html
@@ -85,7 +85,7 @@
 			const globalColors = [ 'rgb(1, 150, 1)', 'red' ];
 
 			// Total number of elements and the dimensions of the display grid.
-			const size = 64;
+			const size = 16;
 			const gridDim = Math.sqrt( size );
 
 			const getNumSteps = () => {
@@ -332,6 +332,8 @@
 					} else {
 
 						renderer.computeAsync( computeReset );
+
+						console.log( new Uint32Array( await renderer.getArrayBufferAsync( bitonicSortModule.dataBuffer.value ) ) );
 
 						currentStep = 0;
 

--- a/examples/webgpu_compute_sort_bitonic.html
+++ b/examples/webgpu_compute_sort_bitonic.html
@@ -85,7 +85,7 @@
 			const globalColors = [ 'rgb(1, 150, 1)', 'red' ];
 
 			// Total number of elements and the dimensions of the display grid.
-			const size = 256;
+			const size = 64;
 			const gridDim = Math.sqrt( size );
 
 			const getNumSteps = () => {
@@ -104,6 +104,7 @@
 				gridWidth: uniform( gridDim ),
 				gridHeight: uniform( gridDim ),
 				highlight: uniform( 1 ),
+				stepBitonic: true,
 				'Display Mode': 'Swap Zone Highlight'
 			};
 
@@ -318,7 +319,36 @@
 
 				renderer.info.autoReset = false;
 
-				 const stepAnimation = async function () {
+				gui.add( effectController, 'stepBitonic' ).onChange( async () => {
+
+					renderer.info.reset();
+
+					if ( currentStep < bitonicSortModule.stepCount ) {
+
+						await bitonicSortModule.computeStep( renderer );
+
+						currentStep ++;
+
+					} else {
+
+						renderer.computeAsync( computeReset );
+
+						currentStep = 0;
+
+					}
+
+					renderer.resolveTimestampsAsync( THREE.TimestampQuery.COMPUTE );
+
+					renderer.render( scene, camera );
+					renderer.resolveTimestampsAsync( THREE.TimestampQuery.RENDER );
+
+					timestamps[ 'local_swap' ].innerHTML = constructInnerHTML( renderer, false, localColors );
+
+				} );
+
+
+
+				 /*const stepAnimation = async function () {
 
 					renderer.info.reset();
 
@@ -359,7 +389,7 @@
 
 				};
 
-				stepAnimation();
+				stepAnimation(); */
 
 				window.addEventListener( 'resize', onWindowResize );
 

--- a/examples/webgpu_compute_sort_bitonic.html
+++ b/examples/webgpu_compute_sort_bitonic.html
@@ -76,7 +76,7 @@
 			const globalColors = [ 'rgb(1, 150, 1)', 'red' ];
 
 			// Total number of elements and the dimensions of the display grid.
-			const size = 1024;
+			const size = 16384;
 			const gridDim = Math.sqrt( size );
 
 			const getNumSteps = () => {
@@ -606,7 +606,7 @@
 
 					} else {
 
-						setTimeout( stepAnimation, 50 );
+						setTimeout( stepAnimation, 100 );
 
 					}
 

--- a/examples/webgpu_compute_sort_bitonic.html
+++ b/examples/webgpu_compute_sort_bitonic.html
@@ -7,16 +7,10 @@
 	</head>
 	<body>
 
-		<div id="info">
-			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a>
-			<br /> This example demonstrates a bitonic sort running step by step in a compute shader.
-			<br /> The left canvas swaps values within workgroup local arrays. The right swaps values within storage buffers.
-			<br /> Reference implementation by <a href="https://poniesandlight.co.uk/reflect/bitonic_merge_sort/">Tim Gfrerer</a>
-			<br />
-			<div id="local_swap" style="
+		<style>
+			.swap_area {
 				position: absolute;
 				top: 150px;
-				left: 0;
 				padding: 10px;
 				background: rgba( 0, 0, 0, 0.5 );
 				color: #fff;
@@ -25,20 +19,18 @@
 				line-height: 1.5;
 				pointer-events: none;
 				text-align: left;
-			"></div>
-			<div id="global_swap" style="
-			position: absolute;
-			top: 150px;
-			right: 0;
-			padding: 10px;
-			background: rgba( 0, 0, 0, 0.5 );
-			color: #fff;
-			font-family: monospace;
-			font-size: 12px;
-			line-height: 1.5;
-			pointer-events: none;
-			text-align: left;
-		"></div>
+			}
+		
+		</style>
+
+		<div id="info">
+			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a>
+			<br /> This example demonstrates a bitonic sort running step by step in a compute shader.
+			<br /> The left canvas swaps values within workgroup local arrays. The right swaps values within storage buffers.
+			<br /> Reference implementation by <a href="https://poniesandlight.co.uk/reflect/bitonic_merge_sort/">Tim Gfrerer</a>
+			<br />
+			<div id="local_swap" class="swap_area" style="left: 0;"></div>
+			<div id="global_swap" class="swap_area" style="right: 0;"></div>
 		</div>
 
 		<script type="importmap">
@@ -67,7 +59,7 @@
 
 				NONE: 0,
 				// Swap values within workgroup local values
-				FLIP_LOCAL: 1,
+				SWAP_LOCAL: 1,
 				DISPERSE_LOCAL: 2,
 				// Swap values within global data buffer.
 				FLIP_GLOBAL: 3,
@@ -234,6 +226,38 @@
 				return plane;
 
 			};
+
+			const createDisplayMesh2 = ( elementsStorage, infoStorage ) => {
+
+				const material = new THREE.MeshBasicNodeMaterial( { color: 0x00ff00 } );
+
+				const display = Fn( () => {
+
+					const { gridWidth, gridHeight, highlight } = effectController;
+
+					const elementIndex = getElementIndex( uv(), gridWidth, gridHeight );
+					const color = getColor( elementsStorage.element( elementIndex ), gridWidth, gridHeight ).toVar();
+
+
+					If( highlight.equal( 1 ).and( not( infoStorage.element( 0 ).equal( StepType.SWAP_LOCAL ) ) ), () => {
+
+						const boolCheck = int( elementIndex.mod( infoStorage.element( 1 ) ).lessThan( infoStorage.element( 1 ).div( 2 ) ) );
+						color.z.assign( infoStorage.element( 0 ).lessThanEqual( StepType.DISPERSE_LOCAL ) );
+						color.x.mulAssign( boolCheck );
+						color.y.mulAssign( abs( boolCheck.sub( 1 ) ) );
+
+					} );
+
+
+					return color;
+
+				} );
+
+				material.colorNode = display();
+				const plane = new THREE.Mesh( new THREE.PlaneGeometry( 1, 1 ), material );
+				return plane;
+
+			};
 			
 			const setupDomElement = ( renderer ) => {
 
@@ -282,8 +306,6 @@
 
 				} );
 
-				scene.add( createDisplayMesh( currentElementsStorage ) );
-
 				const renderer = new THREE.WebGPURenderer( { antialias: false } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth / 2, window.innerHeight );
@@ -307,7 +329,7 @@
 					}
 				);
 
-				console.log( bitonicSortModule );
+				scene.add( createDisplayMesh2( currentElementsStorage, bitonicSortModule.infoStorage ) );
 
 				// Initialize each value in the elements buffer.
 				const computeInit = computeInitFn().compute( size );
@@ -337,7 +359,7 @@
 
 
 
-				 /*const stepAnimation = async function () {
+				 const stepAnimation = async function () {
 
 					renderer.info.reset();
 
@@ -355,21 +377,21 @@
 
 					}
 
-					timestamps[ 'local_swap' ].innerHTML = constructInnerHTML(false, localColors );
+					timestamps[ 'local_swap' ].innerHTML = constructInnerHTML( false, localColors );
 
 					if ( currentStep === bitonicSortModule.stepCount ) {
 
-						setTimeout( stepAnimation, 5000 );
+						setTimeout( stepAnimation, 1000 );
 
 					} else {
 
-						setTimeout( stepAnimation, 5000 );
+						setTimeout( stepAnimation, 100 );
 
 					}
 
 				};
 
-				stepAnimation(); */
+				stepAnimation();
 
 				window.addEventListener( 'resize', onWindowResize );
 


### PR DESCRIPTION
**Description**

Creates an add-on that encapsulates the bitonic sort functionality present in the webgpu_compute_sort_bitonic example. Currently only handles scalar inputs because I'm uncertain whether TSL currently emulates the boolean vector functionality of GLSL. I've also removed the timestamps from the bitonic sort example since they aren't really informative when presented at such high speed, and one can already perceive that the new encapsulated bitonic sort takes less dispatches than the previous local sort and the global sort only example.
