### PR TITLE
RenderTarget: Fix resize of 3D textures.

### DIFF
--- a/src/core/RenderTarget.js
+++ b/src/core/RenderTarget.js
@@ -294,7 +294,16 @@ class RenderTarget extends EventDispatcher {
 				this.textures[ i ].image.width = width;
 				this.textures[ i ].image.height = height;
 				this.textures[ i ].image.depth = depth;
-				this.textures[ i ].isArrayTexture = this.textures[ i ].image.depth > 1;
+
+				if ( this.textures[ i ].isData3DTexture !== true ) { // Fix for #31693
+
+					// TODO: Reconsider setting isArrayTexture flag here and in the ctor of Texture.
+					// Maybe a method `isArrayTexture()` or just a getter could replace a flag since
+					// both are evaluated on each call?
+
+					this.textures[ i ].isArrayTexture = this.textures[ i ].image.depth > 1;
+
+				}
 
 			}
 


### PR DESCRIPTION
Fixed #31693.

**Description**

Makes sure 3D textures don't get the `isArrayTexture` set to `true` during a resize. This currently happens and breaks the 3D texture in the backend. The texture is rendered black and the following WebGPU warning is logged:

> Dimension (TextureViewDimension::e3D) of [TextureView "colorAttachment_0"] doesn't match the expected dimension (TextureViewDimension::e2DArray).
While validating entries[1] as a Sampled Texture.
Expected entry layout: {sampleType: TextureSampleType::Float, viewDimension: TextureViewDimension::e2DArray, multisampled: 0}
While validating [BindGroupDescriptor ""bindGroup_object""] against [BindGroupLayout (unlabeled)]
While calling [Device].CreateBindGroup([BindGroupDescriptor ""bindGroup_object""]).

You can reproduce the issue by making a resize of the 3D render target in [webgpu_rendertarget_2d-array_3d](https://threejs.org/examples/webgpu_rendertarget_2d-array_3d.html).

I've added a TODO comment in the source since we maybe have to refactor the code from #30959 to avoid setting `isArrayTexture` in `RenderTarget.setSize()` and the ctor of `Texture`.