### PR TITLE
Change npm install to npm ci in contributing guide

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -18,7 +18,7 @@ It is assumed that you know a little about Node.js and Git. If not, [here's some
 
 * Install the dependencies
 
-      npm install
+      npm ci
 
 ## Next Steps
 


### PR DESCRIPTION
**Description**

`ci` installs exactly what's in `package-lock.json` where as `install` installs compatible versions.

Given today's [issue](https://www.aikido.dev/blog/npm-debug-and-chalk-packages-compromised) it's probably best to tell users to use `ci` and not `install`
