### PR TITLE
E2E: Simplify logging.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^16.0.0",
         "@rollup/plugin-terser": "^0.4.0",
-        "chalk": "^5.2.0",
         "concurrently": "^9.0.0",
         "dpdm": "^3.14.0",
         "eslint": "^8.37.0",
@@ -2738,19 +2737,6 @@
       },
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/chalk": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.0.tgz",
-      "integrity": "sha512-46QrSQFyVSEyYAgQ22hQ+zDa60YHA4fBstHmtSApj1Y5vKtG27fWowW03jCk5KcbXEWPZUIR894aARCA/G1kfQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/chownr": {

--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^16.0.0",
     "@rollup/plugin-terser": "^0.4.0",
-    "chalk": "^5.2.0",
     "concurrently": "^9.0.0",
     "dpdm": "^3.14.0",
     "eslint": "^8.37.0",

--- a/test/e2e/check-coverage.js
+++ b/test/e2e/check-coverage.js
@@ -1,8 +1,7 @@
-import chalk from 'chalk';
 import * as fs from 'fs/promises';
 
-console.red = msg => console.log( chalk.red( msg ) );
-console.green = msg => console.log( chalk.green( msg ) );
+console.red = msg => console.log( `\x1b[31m${msg}\x1b[39m` );
+console.green = msg => console.log( `\x1b[32m${msg}\x1b[39m` );
 
 main();
 

--- a/test/e2e/puppeteer.js
+++ b/test/e2e/puppeteer.js
@@ -1,4 +1,3 @@
-import chalk from 'chalk';
 import puppeteer from 'puppeteer';
 import express from 'express';
 import path from 'path';
@@ -215,9 +214,9 @@ const height = 250;
 const viewScale = 2;
 const jpgQuality = 95;
 
-console.red = msg => console.log( chalk.red( msg ) );
-console.yellow = msg => console.log( chalk.yellow( msg ) );
-console.green = msg => console.log( chalk.green( msg ) );
+console.red = msg => console.log( `\x1b[31m${msg}\x1b[39m` );
+console.green = msg => console.log( `\x1b[32m${msg}\x1b[39m` );
+console.yellow = msg => console.log( `\x1b[33m${msg}\x1b[39m` );
 
 let browser;
 

--- a/test/rollup.treeshake.config.js
+++ b/test/rollup.treeshake.config.js
@@ -4,7 +4,6 @@ import filesize from 'rollup-plugin-filesize';
 import terser from '@rollup/plugin-terser';
 import { visualizer } from 'rollup-plugin-visualizer';
 import { glsl } from '../utils/build/rollup.config.js';
-import chalk from 'chalk';
 
 const statsFile = path.resolve( 'test/treeshake/stats.html' );
 
@@ -15,7 +14,7 @@ function logStatsFile() {
 
 			console.log();
 			console.log( 'Open the following url in a browser to analyze the tree-shaken bundle.' );
-			console.log( chalk.blue.bold.underline( statsFile ) );
+			console.log( statsFile );
 			console.log();
 
 		}


### PR DESCRIPTION
Related issue: #31859

**Description**

We can simplify the logging in the E2E code so we don't need `chalk ` as a dev dependency.
