### PR TITLE
SSGINode: Fix Sampling Asymmetry

### DIFF
--- a/examples/jsm/tsl/display/SSGINode.js
+++ b/examples/jsm/tsl/display/SSGINode.js
@@ -1,5 +1,6 @@
 import { RenderTarget, Vector2, TempNode, QuadMesh, NodeMaterial, RendererUtils, MathUtils } from 'three/webgpu';
 import { clamp, normalize, reference, nodeObject, Fn, NodeUpdateType, uniform, vec4, passTexture, uv, logarithmicDepthToViewZ, viewZToPerspectiveDepth, getViewPosition, screenCoordinate, float, sub, fract, dot, vec2, rand, vec3, Loop, mul, PI, cos, sin, uint, cross, acos, sign, pow, luminance, If, max, abs, Break, sqrt, HALF_PI, div, ceil, shiftRight, uvec2, convertToTexture, bool, getNormalFromDepth } from 'three/tsl';
+import { clamp, normalize, reference, nodeObject, Fn, NodeUpdateType, uniform, vec4, passTexture, uv, logarithmicDepthToViewZ, viewZToPerspectiveDepth, getViewPosition, screenCoordinate, float, sub, fract, dot, vec2, rand, vec3, Loop, mul, PI, cos, sin, uint, cross, acos, sign, pow, luminance, If, max, abs, Break, sqrt, HALF_PI, PI2, div, ceil, shiftRight, uvec2, convertToTexture, bool, getNormalFromDepth } from 'three/tsl';
 
 const _quadMesh = /*@__PURE__*/ new QuadMesh();
 const _size = /*@__PURE__*/ new Vector2();
@@ -567,7 +568,7 @@ class SSGINode extends TempNode {
 
 			Loop( { start: uint( 0 ), end: ROTATION_COUNT, type: 'uint', condition: '<' }, ( { i } ) => {
 
-				const rotationAngle = mul( float( i ).add( noiseDirection ).add( this._temporalDirection ), PI.div( float( ROTATION_COUNT ) ) ).toConst();
+				const rotationAngle = mul( float( i ).add( noiseDirection ).add( this._temporalDirection ), PI2.div( float( ROTATION_COUNT ) ) ).toConst(); // Port note: PI was changed to PI2 to fix a sampling asymmetry issue
 				const sliceDir = vec3( vec2( cos( rotationAngle ), sin( rotationAngle ) ), 0 ).toConst();
 				const slideDirTexelSize = sliceDir.xy.mul( float( 1 ).div( this._resolution ) ).toConst();
 

--- a/examples/jsm/tsl/display/SSGINode.js
+++ b/examples/jsm/tsl/display/SSGINode.js
@@ -1,5 +1,4 @@
 import { RenderTarget, Vector2, TempNode, QuadMesh, NodeMaterial, RendererUtils, MathUtils } from 'three/webgpu';
-import { clamp, normalize, reference, nodeObject, Fn, NodeUpdateType, uniform, vec4, passTexture, uv, logarithmicDepthToViewZ, viewZToPerspectiveDepth, getViewPosition, screenCoordinate, float, sub, fract, dot, vec2, rand, vec3, Loop, mul, PI, cos, sin, uint, cross, acos, sign, pow, luminance, If, max, abs, Break, sqrt, HALF_PI, div, ceil, shiftRight, uvec2, convertToTexture, bool, getNormalFromDepth } from 'three/tsl';
 import { clamp, normalize, reference, nodeObject, Fn, NodeUpdateType, uniform, vec4, passTexture, uv, logarithmicDepthToViewZ, viewZToPerspectiveDepth, getViewPosition, screenCoordinate, float, sub, fract, dot, vec2, rand, vec3, Loop, mul, PI, cos, sin, uint, cross, acos, sign, pow, luminance, If, max, abs, Break, sqrt, HALF_PI, PI2, div, ceil, shiftRight, uvec2, convertToTexture, bool, getNormalFromDepth } from 'three/tsl';
 
 const _quadMesh = /*@__PURE__*/ new QuadMesh();

--- a/examples/webgpu_postprocessing_ssgi.html
+++ b/examples/webgpu_postprocessing_ssgi.html
@@ -65,7 +65,7 @@
 
 				controls = new OrbitControls( camera, renderer.domElement );
 				controls.target.set( 0, 1, 0 );
-				controls.enablePan = false;
+				controls.enablePan = true;
 				controls.minDistance = 1;
 				controls.maxDistance = 6;
 				controls.update();
@@ -89,8 +89,8 @@
 				// gi
 
 				const giPass = ssgi( scenePassColor, scenePassDepth, scenePassNormal, camera );
-				//giPass.sliceCount.value = 2;
-				//giPass.stepCount.value = 8;
+				giPass.sliceCount.value = 2;
+				giPass.stepCount.value = 8;
 
 				// composite
 

--- a/examples/webgpu_postprocessing_ssgi.html
+++ b/examples/webgpu_postprocessing_ssgi.html
@@ -89,8 +89,8 @@
 				// gi
 
 				const giPass = ssgi( scenePassColor, scenePassDepth, scenePassNormal, camera );
-				giPass.sliceCount.value = 2;
-				giPass.stepCount.value = 8;
+				//giPass.sliceCount.value = 2;
+				//giPass.stepCount.value = 8;
 
 				// composite
 


### PR DESCRIPTION
**Description**

Live Demo: https://rawcdn.githack.com/zalo/three.js/fix-ssgi-rotations/examples/webgpu_postprocessing_ssgi.html

Make the SSGI pass work closer to the way it was intended to... Also enables panning in the demo scene (to better examine the GI). @Mugen87 @cdrintherrieno

Related issue: [#31839](https://github.com/mrdoob/three.js/pull/31839#issuecomment-3272044728)

https://github.com/user-attachments/assets/638ca21b-99df-464b-b8e7-e2ba89af684c

We should switch to a better target model (like the LittleTokyo model), but I won't porkbarrel this fix any more than this 😅 
