### PR TITLE
TSL: Fix `onDispose` listener not being removed in `Sampler`

### DIFF
--- a/src/renderers/common/Sampler.js
+++ b/src/renderers/common/Sampler.js
@@ -53,6 +53,19 @@ class Sampler extends Binding {
 	}
 
 	/**
+	 * An event listener which is added to {@link texture}'s dispose event.
+	 *
+	 * @private
+	 */
+	_onDispose() {
+
+		this._texture = null;
+		this.generation = null;
+		this.version = 0;
+
+	}
+
+	/**
 	 * Sets the texture of this sampler.
 	 * @param {?Texture} value - The texture to set.
 	 */
@@ -60,17 +73,9 @@ class Sampler extends Binding {
 
 		if ( this._texture === value ) return;
 
-		const onDispose = () => {
-
-			this._texture = null;
-			this.generation = null;
-			this.version = 0;
-
-		};
-
 		if ( this._texture ) {
 
-			this._texture.removeEventListener( 'dispose', onDispose );
+			this._texture.removeEventListener( 'dispose', this._onDispose );
 
 		}
 
@@ -81,7 +86,7 @@ class Sampler extends Binding {
 
 		if ( this._texture ) {
 
-			this._texture.addEventListener( 'dispose', onDispose );
+			this._texture.addEventListener( 'dispose', this._onDispose );
 
 		}
 

--- a/src/renderers/common/Sampler.js
+++ b/src/renderers/common/Sampler.js
@@ -50,18 +50,19 @@ class Sampler extends Binding {
 		 */
 		this.isSampler = true;
 
-	}
+		/**
+		 * An event listener which is added to {@link texture}'s dispose event.
+		 *
+		 * @private
+		 * @type {Function}
+		 */
+		this._onTextureDispose = () => {
 
-	/**
-	 * An event listener which is added to {@link texture}'s dispose event.
-	 *
-	 * @private
-	 */
-	_onTextureDispose() {
+			this._texture = null;
+			this.generation = null;
+			this.version = 0;
 
-		this._texture = null;
-		this.generation = null;
-		this.version = 0;
+		};
 
 	}
 

--- a/src/renderers/common/Sampler.js
+++ b/src/renderers/common/Sampler.js
@@ -21,8 +21,24 @@ class Sampler extends Binding {
 		/**
 		 * The texture the sampler is referring to.
 		 *
+		 * @private
 		 * @type {?Texture}
 		 */
+		this._texture = null;
+
+		/**
+		 * An event listener which is added to {@link texture}'s dispose event.
+		 *
+		 * @private
+		 * @type {Function}
+		 */
+		this._onTextureDispose = () => {
+
+			this.texture = null;
+
+		};
+
+		// Assignment to the texture via a setter must occur after "_onTextureDispose" is initialized.
 		this.texture = texture;
 
 		/**
@@ -49,20 +65,6 @@ class Sampler extends Binding {
 		 * @default true
 		 */
 		this.isSampler = true;
-
-		/**
-		 * An event listener which is added to {@link texture}'s dispose event.
-		 *
-		 * @private
-		 * @type {Function}
-		 */
-		this._onTextureDispose = () => {
-
-			this._texture = null;
-			this.generation = null;
-			this.version = 0;
-
-		};
 
 	}
 
@@ -134,6 +136,13 @@ class Sampler extends Binding {
 		// TODO: Find better solution, see #31747
 
 		clonedSampler._texture = null;
+
+		clonedSampler._onTextureDispose = () => {
+
+			clonedSampler.texture = null;
+
+		};
+
 		clonedSampler.texture = this.texture;
 
 		return clonedSampler;

--- a/src/renderers/common/Sampler.js
+++ b/src/renderers/common/Sampler.js
@@ -57,7 +57,7 @@ class Sampler extends Binding {
 	 *
 	 * @private
 	 */
-	_onDispose() {
+	_onTextureDispose() {
 
 		this._texture = null;
 		this.generation = null;
@@ -75,7 +75,7 @@ class Sampler extends Binding {
 
 		if ( this._texture ) {
 
-			this._texture.removeEventListener( 'dispose', this._onDispose );
+			this._texture.removeEventListener( 'dispose', this._onTextureDispose );
 
 		}
 
@@ -86,7 +86,7 @@ class Sampler extends Binding {
 
 		if ( this._texture ) {
 
-			this._texture.addEventListener( 'dispose', this._onDispose );
+			this._texture.addEventListener( 'dispose', this._onTextureDispose );
 
 		}
 


### PR DESCRIPTION
Fixes: #31866

**Description**

This PR fixes that the event listeners on textures are not removed and grow indefinitely. Heap snapshots of `webgpu_cubemap_dynamic` no longer contain a large array of `onDispose` listeners.