### PR TITLE
Sampler: Don't set `_texture` to `null`.

### DIFF
--- a/src/renderers/common/Sampler.js
+++ b/src/renderers/common/Sampler.js
@@ -34,7 +34,8 @@ class Sampler extends Binding {
 		 */
 		this._onTextureDispose = () => {
 
-			this.texture = null;
+			this.generation = null;
+			this.version = 0;
 
 		};
 
@@ -70,7 +71,8 @@ class Sampler extends Binding {
 
 	/**
 	 * Sets the texture of this sampler.
-	 * @param {?Texture} value - The texture to set.
+	 *
+	 * @param {Texture} value - The texture to set.
 	 */
 	set texture( value ) {
 
@@ -139,7 +141,8 @@ class Sampler extends Binding {
 
 		clonedSampler._onTextureDispose = () => {
 
-			clonedSampler.texture = null;
+			clonedSampler.generation = null;
+			clonedSampler.version = 0;
 
 		};
 


### PR DESCRIPTION
Fixed #31747.

**Description**

#31497 introduced the private `_texture`  property in `Sampler` to fix #31480. This property is set to `null` if a texture dispose happens.

However, a lot of code in context of bind groups breaks if the `texture` property of a sampler binding is `null`. #31747 is one example how runtime errors occur, in this instance during the init of a bind group. However, the same error occurs when the WebGPU backend tries to create bind group layouts. All this code assumes `binding.texture` never points to `null`. Even if a texture is disposed, the  (cached) binding must point to it for the case the texture is reused again.

The cached bindings I'm talking about are the bindings from the render object:

https://github.com/mrdoob/three.js/blob/47c6359dcf6a4dbe0d9f9f4fff71090ad15d32b2/src/renderers/common/Bindings.js#L80