### PR TITLE
Tests: Remove obsolete material callbacks.

### DIFF
--- a/test/unit/src/materials/Material.tests.js
+++ b/test/unit/src/materials/Material.tests.js
@@ -309,12 +309,6 @@ export default QUnit.module( 'Materials', () => {
 
 		} );
 
-		QUnit.todo( 'onBuild', ( assert ) => {
-
-			assert.ok( false, 'everything\'s gonna be alright' );
-
-		} );
-
 		QUnit.todo( 'onBeforeRender', ( assert ) => {
 
 			assert.ok( false, 'everything\'s gonna be alright' );


### PR DESCRIPTION
Related issue: -

**Description**

Follow-up to #28702, where `onBuild` was removed (`onBeforeRender` was restored later in #29043).