### PR TITLE
Renderer - Properly Delete Bind Groups on Bindings in Dispose

### DIFF
--- a/src/renderers/common/Bindings.js
+++ b/src/renderers/common/Bindings.js
@@ -170,6 +170,22 @@ class Bindings extends DataMap {
 
 	}
 
+	/**
+	 * Deletes the bindings for the given renderObject node.
+	 *
+	 * @param {RenderObject} renderObject - The renderObject.
+	 */
+	deleteForRender( renderObject ) {
+
+		const bindings = renderObject.getBindings();
+
+		for ( const bindGroup of bindings ) {
+
+			this.delete( bindGroup );
+
+		}
+
+	}
 
 	/**
 	 * Updates the given array of bindings.

--- a/src/renderers/common/RenderObjects.js
+++ b/src/renderers/common/RenderObjects.js
@@ -185,7 +185,7 @@ class RenderObjects {
 		renderObject.onDispose = () => {
 
 			this.pipelines.delete( renderObject );
-			this.bindings.delete( renderObject );
+			this.bindings.deleteForRender( renderObject );
 			this.nodes.delete( renderObject );
 
 			chainMap.delete( renderObject.getChainArray() );


### PR DESCRIPTION
Related issue: #31832 

**Description**

Solves the same issue as #31832 but for RenderObject.
