### PR TITLE
WebGPURenderer: Add cache for shadow nodes

### DIFF
--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -2939,11 +2939,8 @@ class Renderer {
 
 			}
 
-			const side = material.shadowSide === null ? material.side : material.shadowSide;
-
 			cache = {
 				version,
-				side,
 				colorNode,
 				depthNode,
 				positionNode
@@ -3009,9 +3006,9 @@ class Renderer {
 
 			if ( overrideMaterial.isShadowPassMaterial ) {
 
-				const { side, colorNode, depthNode, positionNode } = this._getShadowNodes( material );
+				const { colorNode, depthNode, positionNode } = this._getShadowNodes( material );
 
-				overrideMaterial.side = side;
+				overrideMaterial.side = material.shadowSide === null ? material.side : material.shadowSide;
 				overrideMaterial.colorNode = colorNode;
 				overrideMaterial.depthNode = depthNode;
 				overrideMaterial.positionNode = positionNode;

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -3009,9 +3009,9 @@ class Renderer {
 				const { colorNode, depthNode, positionNode } = this._getShadowNodes( material );
 
 				overrideMaterial.side = material.shadowSide === null ? material.side : material.shadowSide;
-				overrideMaterial.colorNode = colorNode;
-				overrideMaterial.depthNode = depthNode;
-				overrideMaterial.positionNode = positionNode;
+				if ( colorNode !== null ) overrideMaterial.colorNode = colorNode;
+				if ( depthNode !== null ) overrideMaterial.depthNode = depthNode;
+				if ( positionNode !== null ) overrideMaterial.positionNode = positionNode;
 
 			}
 

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -3009,6 +3009,7 @@ class Renderer {
 				const { colorNode, depthNode, positionNode } = this._getShadowNodes( material );
 
 				overrideMaterial.side = material.shadowSide === null ? material.side : material.shadowSide;
+
 				if ( colorNode !== null ) overrideMaterial.colorNode = colorNode;
 				if ( depthNode !== null ) overrideMaterial.depthNode = depthNode;
 				if ( positionNode !== null ) overrideMaterial.positionNode = positionNode;

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -2933,7 +2933,7 @@ class Renderer {
 
 				positionNode = material.castShadowPositionNode;
 
-			} else {
+			} else if ( material.positionNode && material.positionNode.isNode ) {
 
 				positionNode = material.positionNode;
 

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -2933,6 +2933,10 @@ class Renderer {
 
 				positionNode = material.castShadowPositionNode;
 
+			} else {
+
+				positionNode = material.positionNode;
+
 			}
 
 			const side = material.shadowSide === null ? material.side : material.shadowSide;


### PR DESCRIPTION
Fixes https://github.com/mrdoob/three.js/issues/31872

**Description**

Add a cache to reuse the shadow nodes created from the material and update it if the material version is updated.
