### PR TITLE
Playground: Fix usage of `timerLocal`.

### DIFF
--- a/playground/editors/TimerEditor.js
+++ b/playground/editors/TimerEditor.js
@@ -1,12 +1,12 @@
 import { NumberInput, LabelElement, Element, ButtonInput } from 'flow';
 import { BaseNodeEditor } from '../BaseNodeEditor.js';
-import { timerLocal } from 'three/tsl';
+import { time } from 'three/tsl';
 
 export class TimerEditor extends BaseNodeEditor {
 
 	constructor() {
 
-		const node = timerLocal();
+		const node = time;
 
 		super( 'Timer', node, 200 );
 


### PR DESCRIPTION
Fixed #31888.

**Description**

Fixes the usage of the removed `timerLocal` API.