### PR TITLE
SSGINode: Improve Temporal Noise.

### DIFF
--- a/examples/jsm/tsl/display/SSGINode.js
+++ b/examples/jsm/tsl/display/SSGINode.js
@@ -576,7 +576,8 @@ class SSGINode extends TempNode {
 
 			const noiseOffset = spatialOffsets( screenCoordinate );
 			const noiseDirection = gradientNoise( screenCoordinate );
-			const initialRayStep = fract( noiseOffset.add( this._temporalOffset ) ).add( rand( uvNode.add( this._temporalDirection )  ).mul( 2 ).sub( 1 ) ); // Port: Add _temporalDirection here for slightly better noise convergence with TRAA
+			const noiseJitterIdx = this._temporalDirection.mul( 0.02 ); // Port: Add noiseJitterIdx here for slightly better noise convergence with TRAA
+			const initialRayStep = fract( noiseOffset.add( this._temporalOffset ) ).add( rand( uvNode.add( noiseJitterIdx ).mul( 2 ).sub( 1 ) ) );
 
 			const ao = float( 0 );
 			const color = vec3( 0 );

--- a/examples/jsm/tsl/display/SSGINode.js
+++ b/examples/jsm/tsl/display/SSGINode.js
@@ -576,7 +576,7 @@ class SSGINode extends TempNode {
 
 			const noiseOffset = spatialOffsets( screenCoordinate );
 			const noiseDirection = gradientNoise( screenCoordinate );
-			const initialRayStep = fract( noiseOffset.add( this._temporalOffset ) ).add( rand( uvNode.add( this._temporalDirection )  ).mul( 2 ).sub( 1 ) );
+			const initialRayStep = fract( noiseOffset.add( this._temporalOffset ) ).add( rand( uvNode.add( this._temporalDirection )  ).mul( 2 ).sub( 1 ) ); // Port: Add _temporalDirection here for slightly better noise convergence with TRAA
 
 			const ao = float( 0 );
 			const color = vec3( 0 );

--- a/examples/jsm/tsl/display/SSGINode.js
+++ b/examples/jsm/tsl/display/SSGINode.js
@@ -576,7 +576,7 @@ class SSGINode extends TempNode {
 
 			const noiseOffset = spatialOffsets( screenCoordinate );
 			const noiseDirection = gradientNoise( screenCoordinate );
-			const noiseJitterIdx = this._temporalDirection.mul( 0.02 ); // Port: Add noiseJitterIdx here for slightly better noise convergence with TRAA
+			const noiseJitterIdx = this._temporalDirection.mul( 0.02 ); // Port: Add noiseJitterIdx here for slightly better noise convergence with TRAA (see #31890 for more details)
 			const initialRayStep = fract( noiseOffset.add( this._temporalOffset ) ).add( rand( uvNode.add( noiseJitterIdx ).mul( 2 ).sub( 1 ) ) );
 
 			const ao = float( 0 );

--- a/examples/jsm/tsl/display/SSGINode.js
+++ b/examples/jsm/tsl/display/SSGINode.js
@@ -576,7 +576,7 @@ class SSGINode extends TempNode {
 
 			const noiseOffset = spatialOffsets( screenCoordinate );
 			const noiseDirection = gradientNoise( screenCoordinate );
-			const initialRayStep = fract( noiseOffset.add( this._temporalOffset ) ).add( rand( uvNode ).mul( 2 ).sub( 1 ) );
+			const initialRayStep = fract( noiseOffset.add( this._temporalOffset ) ).add( rand( uvNode.add( this._temporalDirection )  ).mul( 2 ).sub( 1 ) );
 
 			const ao = float( 0 );
 			const color = vec3( 0 );

--- a/examples/webgpu_postprocessing_ssgi.html
+++ b/examples/webgpu_postprocessing_ssgi.html
@@ -160,7 +160,9 @@
 				gui.add( giPass.useScreenSpaceSampling, 'value' ).name( 'screen-space sampling' );
 				gui.add( giPass, 'useTemporalFiltering' ).name( 'temporal filtering' ).onChange( updatePostprocessing );
 
-				function updatePostprocessing( value ) {
+				function updatePostprocessing() {
+
+					const value = params.output;
 
 					if ( value === 1 ) {
 


### PR DESCRIPTION
Related issue: #31839

**Description**

Current Noise Behavior: https://rawcdn.githack.com/mrdoob/three.js/e33c7162cc881ae2301e067d71076e0ef6137029/examples/webgpu_postprocessing_ssgi.html

New Noise Behavior: https://rawcdn.githack.com/mrdoob/three.js/ce783910bcf441be07b9d2949945f1ba6ed6c296/examples/webgpu_postprocessing_ssgi.html

The SSGI Noise wasn't getting temporally jittered everywhere, this adds some jitter an additional UV node, allowing the noise to converge a little more smoothly.

Before/After of the TRAA Converged Noise Values:
![NoiseComparison](https://github.com/user-attachments/assets/db97e423-4992-48f6-b3d4-2800ca54ecd0)

The use of `rand()` here is a little suspicious; I wonder if it should be the InterleavedGradientNoise or something else to converge even better.   You can see there is a persistent screen-space noise pattern that overlays everything...