### PR TITLE
TRAANode: Reduce Ghosting/Smearing

### DIFF
--- a/examples/jsm/tsl/display/TRAANode.js
+++ b/examples/jsm/tsl/display/TRAANode.js
@@ -1,5 +1,5 @@
 import { HalfFloatType, Vector2, RenderTarget, RendererUtils, QuadMesh, NodeMaterial, TempNode, NodeUpdateType, Matrix4, DepthTexture } from 'three/webgpu';
-import { add, float, If, Loop, int, Fn, min, max, clamp, nodeObject, texture, uniform, uv, vec2, vec4, luminance, convertToTexture, passTexture, velocity, getViewPosition, length, vec3, mat4 } from 'three/tsl';
+import { add, float, If, Loop, int, Fn, min, max, clamp, nodeObject, texture, uniform, uv, vec2, vec4, luminance, convertToTexture, passTexture, velocity, getViewPosition, length, mat4 } from 'three/tsl';
 
 const _quadMesh = /*@__PURE__*/ new QuadMesh();
 const _size = /*@__PURE__*/ new Vector2();
@@ -358,7 +358,7 @@ class TRAANode extends TempNode {
 
 		// Copy current depth to previous depth buffer
 		const currentDepth = this.depthNode.value;
-		if (this._previousDepthTexture.image.width  !== currentDepth.width ||
+		if (this._previousDepthTexture.image.width !== currentDepth.width ||
 			this._previousDepthTexture.image.height !== currentDepth.height ) {
 			this._previousDepthTexture.dispose();
 			this._previousDepthTexture = currentDepth.clone();
@@ -506,10 +506,6 @@ class TRAANode extends TempNode {
 			historyWeight.mulAssign( float( 1.0 ).div( luminanceHistory.add( 1 ) ) );
 
 			const smoothedOutput = add( currentColor.mul( currentWeight ), clampedHistoryColor.mul( historyWeight ) ).div( max( currentWeight.add( historyWeight ), 0.00001 ) ).toVar();
-
-			// debug: visualize where unoccluded areas have appeared
-
-			//If( rejectPixel, () => { smoothedOutput.assign( vec3( 1.0, 0.0, 0.0 ) ); } );
 
 			return smoothedOutput;
 

--- a/examples/jsm/tsl/display/TRAANode.js
+++ b/examples/jsm/tsl/display/TRAANode.js
@@ -358,12 +358,15 @@ class TRAANode extends TempNode {
 
 		// Copy current depth to previous depth buffer
 		const currentDepth = this.depthNode.value;
-		if (this._previousDepthTexture.image.width !== currentDepth.width ||
+		if ( this._previousDepthTexture.image.width !== currentDepth.width ||
 			this._previousDepthTexture.image.height !== currentDepth.height ) {
+
 			this._previousDepthTexture.dispose();
 			this._previousDepthTexture = currentDepth.clone();
 			this._previousDepthNode.value = this._previousDepthTexture;
+
 		}
+
 		renderer.copyTextureToTexture( currentDepth, this._previousDepthTexture );
 
 		// restore
@@ -529,7 +532,9 @@ class TRAANode extends TempNode {
 		this._resolveRenderTarget.dispose();
 
 		if ( this._previousDepthTexture ) {
+
 			this._previousDepthTexture.dispose();
+
 		}
 
 		this._resolveMaterial.dispose();

--- a/examples/jsm/tsl/display/TRAANode.js
+++ b/examples/jsm/tsl/display/TRAANode.js
@@ -484,7 +484,7 @@ class TRAANode extends TempNode {
 			const historyWeight = currentWeight.oneMinus().toVar();
 
 			// Zero out history weight if world positions are different (indicating motion) except on edges
-			// TODO: Figure out more principled ways to set these values...
+			// TODO: Figure out if there is a scale independent unit for these values...
 			const rejectPixel = worldPositionDifference.greaterThan( 0.01 ).and( farthestDepth.sub( closestDepth ).lessThan( 0.0001 ) );
 			If( rejectPixel, () => {
 


### PR DESCRIPTION
Related issue: #31892 #31839

**Description**

This PR adjusts the TRAANode implementation to reset the accumulation for unoccluded regions of the scene.  This largely eliminates "smearing" (where the foreground gets written onto the background), but not "ghosting" (where the freshly unoccluded areas need to start temporal accumulation from scratch).

Debug View:

https://github.com/user-attachments/assets/78a95150-7733-456e-a4a6-08d0585a80c9

Live Demos
- Before: https://rawcdn.githack.com/mrdoob/three.js/ce783910bcf441be07b9d2949945f1ba6ed6c296/examples/webgpu_postprocessing_ssgi.html
- After: https://rawcdn.githack.com/mrdoob/three.js/3f16e3b4fcb1471fb73990605478a4671dbea540/examples/webgpu_postprocessing_ssgi.html

To totally eliminate ghosting, the unoccluded/dirty regions should be calculated _before_ SSGI is run, so it can be passed to both SSGI (to increase the number of samples for a smooth image in those regions) and TRAA (to suppress the history accumulation).  This would change the ergonomics/inputs to TRAA, so perhaps in a future PR?