### PR TITLE
Node Frame - Simplify Caching

### DIFF
--- a/src/nodes/core/NodeFrame.js
+++ b/src/nodes/core/NodeFrame.js
@@ -9,114 +9,114 @@ import { NodeUpdateType } from './constants.js';
 class NodeFrame {
 
 	/**
-     * Constructs a new node fame.
-     */
+	 * Constructs a new node fame.
+	 */
 	constructor() {
 
 		/**
-         * The elapsed time in seconds.
-         *
-         * @type {number}
-         * @default 0
-         */
+		 * The elapsed time in seconds.
+		 *
+		 * @type {number}
+		 * @default 0
+		 */
 		this.time = 0;
 
 		/**
-         * The delta time in seconds.
-         *
-         * @type {number}
-         * @default 0
-         */
+		 * The delta time in seconds.
+		 *
+		 * @type {number}
+		 * @default 0
+		 */
 		this.deltaTime = 0;
 
 		/**
-         * The frame ID.
-         *
-         * @type {number}
-         * @default 0
-         */
+		 * The frame ID.
+		 *
+		 * @type {number}
+		 * @default 0
+		 */
 		this.frameId = 0;
 
 		/**
-         * The render ID.
-         *
-         * @type {number}
-         * @default 0
-         */
+		 * The render ID.
+		 *
+		 * @type {number}
+		 * @default 0
+		 */
 		this.renderId = 0;
 
 		/**
-         * Used to control the {@link Node#update} call.
-         *
-         * @type {WeakMap<Node, Object>}
-         */
+		 * Used to control the {@link Node#update} call.
+		 *
+		 * @type {WeakMap<Node, Object>}
+		 */
 		this.updateMap = new WeakMap();
 
 		/**
-         * Used to control the {@link Node#updateBefore} call.
-         *
-         * @type {WeakMap<Node, Object>}
-         */
+		 * Used to control the {@link Node#updateBefore} call.
+		 *
+		 * @type {WeakMap<Node, Object>}
+		 */
 		this.updateBeforeMap = new WeakMap();
 
 		/**
-         * Used to control the {@link Node#updateAfter} call.
-         *
-         * @type {WeakMap<Node, Object>}
-         */
+		 * Used to control the {@link Node#updateAfter} call.
+		 *
+		 * @type {WeakMap<Node, Object>}
+		 */
 		this.updateAfterMap = new WeakMap();
 
 		/**
-         * A reference to the current renderer.
-         *
-         * @type {?Renderer}
-         * @default null
-         */
+		 * A reference to the current renderer.
+		 *
+		 * @type {?Renderer}
+		 * @default null
+		 */
 		this.renderer = null;
 
 		/**
-         * A reference to the current material.
-         *
-         * @type {?Material}
-         * @default null
-         */
+		 * A reference to the current material.
+		 *
+		 * @type {?Material}
+		 * @default null
+		 */
 		this.material = null;
 
 		/**
-         * A reference to the current camera.
-         *
-         * @type {?Camera}
-         * @default null
-         */
+		 * A reference to the current camera.
+		 *
+		 * @type {?Camera}
+		 * @default null
+		 */
 		this.camera = null;
 
 		/**
-         * A reference to the current 3D object.
-         *
-         * @type {?Object3D}
-         * @default null
-         */
+		 * A reference to the current 3D object.
+		 *
+		 * @type {?Object3D}
+		 * @default null
+		 */
 		this.object = null;
 
 		/**
-         * A reference to the current scene.
-         *
-         * @type {?Scene}
-         * @default null
-         */
+		 * A reference to the current scene.
+		 *
+		 * @type {?Scene}
+		 * @default null
+		 */
 		this.scene = null;
 
 	}
 
 	/**
-     * Returns a dictionary for a given node and update map which
-     * is used to correctly call node update methods per frame or render.
-     *
-     * @private
-     * @param {WeakMap<Node, Object>} referenceMap - The reference weak map.
-     * @param {Node} nodeRef - The reference to the current node.
-     * @return {Object<string,WeakMap<Object, number>>} The dictionary.
-     */
+	 * Returns a dictionary for a given node and update map which
+	 * is used to correctly call node update methods per frame or render.
+	 *
+	 * @private
+	 * @param {WeakMap<Node, Object>} referenceMap - The reference weak map.
+	 * @param {Node} nodeRef - The reference to the current node.
+	 * @return {Object<string,WeakMap<Object, number>>} The dictionary.
+	 */
 	_getMaps( referenceMap, nodeRef ) {
 
 		let maps = referenceMap.get( nodeRef );
@@ -137,13 +137,13 @@ class NodeFrame {
 	}
 
 	/**
-     * This method executes the {@link Node#updateBefore} for the given node.
-     * It makes sure {@link Node#updateBeforeType} is honored meaning the update
-     * is only executed once per frame, render or object depending on the update
-     * type.
-     *
-     * @param {Node} node - The node that should be updated.
-     */
+	 * This method executes the {@link Node#updateBefore} for the given node.
+	 * It makes sure {@link Node#updateBeforeType} is honored meaning the update
+	 * is only executed once per frame, render or object depending on the update
+	 * type.
+	 *
+	 * @param {Node} node - The node that should be updated.
+	 */
 	updateBeforeNode( node ) {
 
 		const updateType = node.getUpdateBeforeType();
@@ -186,13 +186,13 @@ class NodeFrame {
 	}
 
 	/**
-     * This method executes the {@link Node#updateAfter} for the given node.
-     * It makes sure {@link Node#updateAfterType} is honored meaning the update
-     * is only executed once per frame, render or object depending on the update
-     * type.
-     *
-     * @param {Node} node - The node that should be updated.
-     */
+	 * This method executes the {@link Node#updateAfter} for the given node.
+	 * It makes sure {@link Node#updateAfterType} is honored meaning the update
+	 * is only executed once per frame, render or object depending on the update
+	 * type.
+	 *
+	 * @param {Node} node - The node that should be updated.
+	 */
 	updateAfterNode( node ) {
 
 		const updateType = node.getUpdateAfterType();
@@ -235,13 +235,13 @@ class NodeFrame {
 	}
 
 	/**
-     * This method executes the {@link Node#update} for the given node.
-     * It makes sure {@link Node#updateType} is honored meaning the update
-     * is only executed once per frame, render or object depending on the update
-     * type.
-     *
-     * @param {Node} node - The node that should be updated.
-     */
+	 * This method executes the {@link Node#update} for the given node.
+	 * It makes sure {@link Node#updateType} is honored meaning the update
+	 * is only executed once per frame, render or object depending on the update
+	 * type.
+	 *
+	 * @param {Node} node - The node that should be updated.
+	 */
 	updateNode( node ) {
 
 		const updateType = node.getUpdateType();
@@ -284,9 +284,9 @@ class NodeFrame {
 	}
 
 	/**
-     * Updates the internal state of the node frame. This method is
-     * called by the renderer in its internal animation loop.
-     */
+	 * Updates the internal state of the node frame. This method is
+	 * called by the renderer in its internal animation loop.
+	 */
 	update() {
 
 		this.frameId ++;

--- a/src/nodes/core/NodeFrame.js
+++ b/src/nodes/core/NodeFrame.js
@@ -9,114 +9,114 @@ import { NodeUpdateType } from './constants.js';
 class NodeFrame {
 
 	/**
-	 * Constructs a new node fame.
-	 */
+     * Constructs a new node fame.
+     */
 	constructor() {
 
 		/**
-		 * The elapsed time in seconds.
-		 *
-		 * @type {number}
-		 * @default 0
-		 */
+         * The elapsed time in seconds.
+         *
+         * @type {number}
+         * @default 0
+         */
 		this.time = 0;
 
 		/**
-		 * The delta time in seconds.
-		 *
-		 * @type {number}
-		 * @default 0
-		 */
+         * The delta time in seconds.
+         *
+         * @type {number}
+         * @default 0
+         */
 		this.deltaTime = 0;
 
 		/**
-		 * The frame ID.
-		 *
-		 * @type {number}
-		 * @default 0
-		 */
+         * The frame ID.
+         *
+         * @type {number}
+         * @default 0
+         */
 		this.frameId = 0;
 
 		/**
-		 * The render ID.
-		 *
-		 * @type {number}
-		 * @default 0
-		 */
+         * The render ID.
+         *
+         * @type {number}
+         * @default 0
+         */
 		this.renderId = 0;
 
 		/**
-		 * Used to control the {@link Node#update} call.
-		 *
-		 * @type {WeakMap<Node, Object>}
-		 */
+         * Used to control the {@link Node#update} call.
+         *
+         * @type {WeakMap<Node, Object>}
+         */
 		this.updateMap = new WeakMap();
 
 		/**
-		 * Used to control the {@link Node#updateBefore} call.
-		 *
-		 * @type {WeakMap<Node, Object>}
-		 */
+         * Used to control the {@link Node#updateBefore} call.
+         *
+         * @type {WeakMap<Node, Object>}
+         */
 		this.updateBeforeMap = new WeakMap();
 
 		/**
-		 * Used to control the {@link Node#updateAfter} call.
-		 *
-		 * @type {WeakMap<Node, Object>}
-		 */
+         * Used to control the {@link Node#updateAfter} call.
+         *
+         * @type {WeakMap<Node, Object>}
+         */
 		this.updateAfterMap = new WeakMap();
 
 		/**
-		 * A reference to the current renderer.
-		 *
-		 * @type {?Renderer}
-		 * @default null
-		 */
+         * A reference to the current renderer.
+         *
+         * @type {?Renderer}
+         * @default null
+         */
 		this.renderer = null;
 
 		/**
-		 * A reference to the current material.
-		 *
-		 * @type {?Material}
-		 * @default null
-		 */
+         * A reference to the current material.
+         *
+         * @type {?Material}
+         * @default null
+         */
 		this.material = null;
 
 		/**
-		 * A reference to the current camera.
-		 *
-		 * @type {?Camera}
-		 * @default null
-		 */
+         * A reference to the current camera.
+         *
+         * @type {?Camera}
+         * @default null
+         */
 		this.camera = null;
 
 		/**
-		 * A reference to the current 3D object.
-		 *
-		 * @type {?Object3D}
-		 * @default null
-		 */
+         * A reference to the current 3D object.
+         *
+         * @type {?Object3D}
+         * @default null
+         */
 		this.object = null;
 
 		/**
-		 * A reference to the current scene.
-		 *
-		 * @type {?Scene}
-		 * @default null
-		 */
+         * A reference to the current scene.
+         *
+         * @type {?Scene}
+         * @default null
+         */
 		this.scene = null;
 
 	}
 
 	/**
-	 * Returns a dictionary for a given node and update map which
-	 * is used to correctly call node update methods per frame or render.
-	 *
-	 * @private
-	 * @param {WeakMap<Node, Object>} referenceMap - The reference weak map.
-	 * @param {Node} nodeRef - The reference to the current node.
-	 * @return {Object<string,WeakMap<Object, number>>} The dictionary.
-	 */
+     * Returns a dictionary for a given node and update map which
+     * is used to correctly call node update methods per frame or render.
+     *
+     * @private
+     * @param {WeakMap<Node, Object>} referenceMap - The reference weak map.
+     * @param {Node} nodeRef - The reference to the current node.
+     * @return {Object<string,WeakMap<Object, number>>} The dictionary.
+     */
 	_getMaps( referenceMap, nodeRef ) {
 
 		let maps = referenceMap.get( nodeRef );
@@ -124,8 +124,8 @@ class NodeFrame {
 		if ( maps === undefined ) {
 
 			maps = {
-				renderMap: new WeakMap(),
-				frameMap: new WeakMap()
+				renderId: 0,
+				frameId: 0,
 			};
 
 			referenceMap.set( nodeRef, maps );
@@ -137,13 +137,13 @@ class NodeFrame {
 	}
 
 	/**
-	 * This method executes the {@link Node#updateBefore} for the given node.
-	 * It makes sure {@link Node#updateBeforeType} is honored meaning the update
-	 * is only executed once per frame, render or object depending on the update
-	 * type.
-	 *
-	 * @param {Node} node - The node that should be updated.
-	 */
+     * This method executes the {@link Node#updateBefore} for the given node.
+     * It makes sure {@link Node#updateBeforeType} is honored meaning the update
+     * is only executed once per frame, render or object depending on the update
+     * type.
+     *
+     * @param {Node} node - The node that should be updated.
+     */
 	updateBeforeNode( node ) {
 
 		const updateType = node.getUpdateBeforeType();
@@ -151,13 +151,13 @@ class NodeFrame {
 
 		if ( updateType === NodeUpdateType.FRAME ) {
 
-			const { frameMap } = this._getMaps( this.updateBeforeMap, reference );
+			const nodeUpdateBeforeMap = this._getMaps( this.updateBeforeMap, reference );
 
-			if ( frameMap.get( reference ) !== this.frameId ) {
+			if ( nodeUpdateBeforeMap.frameId !== this.frameId ) {
 
 				if ( node.updateBefore( this ) !== false ) {
 
-					frameMap.set( reference, this.frameId );
+					nodeUpdateBeforeMap.frameId = this.frameId;
 
 				}
 
@@ -165,13 +165,13 @@ class NodeFrame {
 
 		} else if ( updateType === NodeUpdateType.RENDER ) {
 
-			const { renderMap } = this._getMaps( this.updateBeforeMap, reference );
+			const nodeUpdateBeforeMap = this._getMaps( this.updateBeforeMap, reference );
 
-			if ( renderMap.get( reference ) !== this.renderId ) {
+			if ( nodeUpdateBeforeMap.renderId !== this.renderId ) {
 
 				if ( node.updateBefore( this ) !== false ) {
 
-					renderMap.set( reference, this.renderId );
+					nodeUpdateBeforeMap.renderId = this.renderId;
 
 				}
 
@@ -186,13 +186,13 @@ class NodeFrame {
 	}
 
 	/**
-	 * This method executes the {@link Node#updateAfter} for the given node.
-	 * It makes sure {@link Node#updateAfterType} is honored meaning the update
-	 * is only executed once per frame, render or object depending on the update
-	 * type.
-	 *
-	 * @param {Node} node - The node that should be updated.
-	 */
+     * This method executes the {@link Node#updateAfter} for the given node.
+     * It makes sure {@link Node#updateAfterType} is honored meaning the update
+     * is only executed once per frame, render or object depending on the update
+     * type.
+     *
+     * @param {Node} node - The node that should be updated.
+     */
 	updateAfterNode( node ) {
 
 		const updateType = node.getUpdateAfterType();
@@ -200,13 +200,13 @@ class NodeFrame {
 
 		if ( updateType === NodeUpdateType.FRAME ) {
 
-			const { frameMap } = this._getMaps( this.updateAfterMap, reference );
+			const nodeUpdateAfterMap = this._getMaps( this.updateAfterMap, reference );
 
-			if ( frameMap.get( reference ) !== this.frameId ) {
+			if ( nodeUpdateAfterMap.frameId !== this.frameId ) {
 
 				if ( node.updateAfter( this ) !== false ) {
 
-					frameMap.set( reference, this.frameId );
+					nodeUpdateAfterMap.frameId = this.frameId;
 
 				}
 
@@ -214,13 +214,13 @@ class NodeFrame {
 
 		} else if ( updateType === NodeUpdateType.RENDER ) {
 
-			const { renderMap } = this._getMaps( this.updateAfterMap, reference );
+			const nodeUpdateAfterMap = this._getMaps( this.updateAfterMap, reference );
 
-			if ( renderMap.get( reference ) !== this.renderId ) {
+			if ( nodeUpdateAfterMap.renderId !== this.renderId ) {
 
 				if ( node.updateAfter( this ) !== false ) {
 
-					renderMap.set( reference, this.renderId );
+					nodeUpdateAfterMap.renderId = this.renderId;
 
 				}
 
@@ -235,13 +235,13 @@ class NodeFrame {
 	}
 
 	/**
-	 * This method executes the {@link Node#update} for the given node.
-	 * It makes sure {@link Node#updateType} is honored meaning the update
-	 * is only executed once per frame, render or object depending on the update
-	 * type.
-	 *
-	 * @param {Node} node - The node that should be updated.
-	 */
+     * This method executes the {@link Node#update} for the given node.
+     * It makes sure {@link Node#updateType} is honored meaning the update
+     * is only executed once per frame, render or object depending on the update
+     * type.
+     *
+     * @param {Node} node - The node that should be updated.
+     */
 	updateNode( node ) {
 
 		const updateType = node.getUpdateType();
@@ -249,13 +249,13 @@ class NodeFrame {
 
 		if ( updateType === NodeUpdateType.FRAME ) {
 
-			const { frameMap } = this._getMaps( this.updateMap, reference );
+			const nodeUpdateMap = this._getMaps( this.updateMap, reference );
 
-			if ( frameMap.get( reference ) !== this.frameId ) {
+			if ( nodeUpdateMap.frameId !== this.frameId ) {
 
 				if ( node.update( this ) !== false ) {
 
-					frameMap.set( reference, this.frameId );
+					nodeUpdateMap.frameId = this.frameId;
 
 				}
 
@@ -263,13 +263,13 @@ class NodeFrame {
 
 		} else if ( updateType === NodeUpdateType.RENDER ) {
 
-			const { renderMap } = this._getMaps( this.updateMap, reference );
+			const nodeUpdateMap = this._getMaps( this.updateMap, reference );
 
-			if ( renderMap.get( reference ) !== this.renderId ) {
+			if ( nodeUpdateMap.renderId !== this.renderId ) {
 
 				if ( node.update( this ) !== false ) {
 
-					renderMap.set( reference, this.renderId );
+					nodeUpdateMap.renderId = this.renderId;
 
 				}
 
@@ -284,9 +284,9 @@ class NodeFrame {
 	}
 
 	/**
-	 * Updates the internal state of the node frame. This method is
-	 * called by the renderer in its internal animation loop.
-	 */
+     * Updates the internal state of the node frame. This method is
+     * called by the renderer in its internal animation loop.
+     */
 	update() {
 
 		this.frameId ++;


### PR DESCRIPTION
Related issue: #XXXX

**Description**

Currently the Node Frame updateMap maps a node to a WeakMap, which itself is just a map of that same node to a render id. This can just be a map of the node to the ids themselves. 
