### PR TITLE
WebGPURenderer: Fix rendering morphed meshes.

### DIFF
--- a/src/materials/nodes/manager/NodeMaterialObserver.js
+++ b/src/materials/nodes/manager/NodeMaterialObserver.js
@@ -465,13 +465,14 @@ class NodeMaterialObserver {
 
 				if ( renderObjectData.morphTargetInfluences[ i ] !== object.morphTargetInfluences[ i ] ) {
 
+					renderObjectData.morphTargetInfluences[ i ] = object.morphTargetInfluences[ i ];
 					morphChanged = true;
 
 				}
 
 			}
 
-			if ( morphChanged ) return true;
+			if ( morphChanged ) return false;
 
 		}
 

--- a/src/renderers/common/RenderObject.js
+++ b/src/renderers/common/RenderObject.js
@@ -770,7 +770,7 @@ class RenderObject {
 
 		}
 
-		if ( object.isInstancedMesh || object.count > 1 ) {
+		if ( object.isInstancedMesh || object.count > 1 || Array.isArray( object.morphTargetInfluences ) ) {
 
 			// TODO: https://github.com/mrdoob/three.js/pull/29066#issuecomment-2269400850
 


### PR DESCRIPTION
Fixed #31903.

**Description**

When two meshes with shared geometry and material share the same node builder state, rendering ends up wrong because the second meshes uses the (referenced) morph target influence values from the first mesh.

Unless this is somehow fixed on the node side by not coupling the uniform buffers directly to a specific mesh, `RenderObject` must make sure to return different cache keys for such meshes.

There was also a bug in `NodeMaterialObserver` that did not update the cached morph target influence values to detect changes which is fixed with this PR as well.
