### PR TITLE
CSSRenderer: Ensure element exists when execute remove.

### DIFF
--- a/examples/jsm/renderers/CSS2DRenderer.js
+++ b/examples/jsm/renderers/CSS2DRenderer.js
@@ -59,6 +59,7 @@ class CSS2DObject extends Object3D {
 			this.traverse( function ( object ) {
 
 				if (
+					object.element &&
 					object.element instanceof object.element.ownerDocument.defaultView.Element &&
 					object.element.parentNode !== null
 				) {

--- a/examples/jsm/renderers/CSS3DRenderer.js
+++ b/examples/jsm/renderers/CSS3DRenderer.js
@@ -56,6 +56,7 @@ class CSS3DObject extends Object3D {
 			this.traverse( function ( object ) {
 
 				if (
+					object.element &&
 					object.element instanceof object.element.ownerDocument.defaultView.Element &&
 					object.element.parentNode !== null
 				) {


### PR DESCRIPTION
Related issue: #29660

I found that fixing this issue caused an edge issue where deleting a 2D object when its children contain non-2D objects would cause an error because its children did not have an element attribute, I think this should be added, although I'm not sure if this is the correct hierarchy.