### PR TITLE
WebGPURenderer: Render bundle work with multiple render targets

### DIFF
--- a/src/renderers/webgpu/utils/WebGPUPipelineUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUPipelineUtils.js
@@ -267,12 +267,12 @@ class WebGPUPipelineUtils {
 		const { utils, device } = backend;
 
 		const depthStencilFormat = utils.getCurrentDepthStencilFormat( renderContext );
-		const colorFormat = utils.getCurrentColorFormat( renderContext );
+		const colorFormats = utils.getCurrentColorFormats( renderContext );
 		const sampleCount = this._getSampleCount( renderContext );
 
 		const descriptor = {
-			label: label,
-			colorFormats: [ colorFormat ],
+			label,
+			colorFormats,
 			depthStencilFormat,
 			sampleCount
 		};

--- a/src/renderers/webgpu/utils/WebGPUUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUUtils.js
@@ -125,6 +125,26 @@ class WebGPUUtils {
 	}
 
 	/**
+	 * Returns the GPU formats of all color attachments of the current render context.
+	 *
+	 * @param {RenderContext} renderContext - The render context.
+	 * @return {Array<string>} The GPU texture formats of all color attachments.
+	 */
+	getCurrentColorFormats( renderContext ) {
+
+		if ( renderContext.textures !== null ) {
+
+			return renderContext.textures.map( t => this.getTextureFormatGPU( t ) );
+
+		} else {
+
+			return [ this.getPreferredCanvasFormat() ]; // default context format
+
+		}
+
+	}
+
+	/**
 	 * Returns the output color space of the current render context.
 	 *
 	 * @param {RenderContext} renderContext - The render context.


### PR DESCRIPTION
Currently, Three.js supports the WebGPU Render Bundle API through its `BundleGroup `class. It also supports rendering to multiple render targets on WebGPU.

However, there seems to be no way to use both at the same time. We get a WebGPU error like `Attachment state of [RenderPipeline "renderPipeline_NodeMaterial_17"] is not compatible with [RenderBundleEncoder "renderBundleEncoder"].`, because the render bundle encoder only contains a single target.

In this pull request, I attempt to add support to multiple render targets when using render bundle, by including all targets in the render bundle encoder.

With this fix, it indeed becomes possible to use these features together. Still, I don't know if this is the best way to do it. I welcome feedback/discussion from someone more familiar with this part of the code.

*This contribution is funded by [Trimble](https://trimble.com)*
