### PR TITLE
Examples: Set OrthographicCamera near plane >= 0

### DIFF
--- a/examples/webgl_postprocessing_dof2.html
+++ b/examples/webgl_postprocessing_dof2.html
@@ -322,8 +322,8 @@
 
 				postprocessing.scene = new THREE.Scene();
 
-				postprocessing.camera = new THREE.OrthographicCamera( window.innerWidth / - 2, window.innerWidth / 2, window.innerHeight / 2, window.innerHeight / - 2, - 10000, 10000 );
-				postprocessing.camera.position.z = 100;
+				postprocessing.camera = new THREE.OrthographicCamera( window.innerWidth / - 2, window.innerWidth / 2, window.innerHeight / 2, window.innerHeight / - 2, 1, 10 );
+				postprocessing.camera.position.z = 2;
 
 				postprocessing.scene.add( postprocessing.camera );
 
@@ -352,7 +352,6 @@
 				} );
 
 				postprocessing.quad = new THREE.Mesh( new THREE.PlaneGeometry( window.innerWidth, window.innerHeight ), postprocessing.materialBokeh );
-				postprocessing.quad.position.z = - 500;
 				postprocessing.scene.add( postprocessing.quad );
 
 			}

--- a/examples/webgl_read_float_buffer.html
+++ b/examples/webgl_read_float_buffer.html
@@ -94,8 +94,8 @@
 
 				container = document.getElementById( 'container' );
 
-				cameraRTT = new THREE.OrthographicCamera( window.innerWidth / - 2, window.innerWidth / 2, window.innerHeight / 2, window.innerHeight / - 2, - 10000, 10000 );
-				cameraRTT.position.z = 100;
+				cameraRTT = new THREE.OrthographicCamera( window.innerWidth / - 2, window.innerWidth / 2, window.innerHeight / 2, window.innerHeight / - 2, 1, 1000 );
+				cameraRTT.position.z = 500;
 
 				//
 

--- a/examples/webgl_rtt.html
+++ b/examples/webgl_rtt.html
@@ -93,8 +93,8 @@
 				camera = new THREE.PerspectiveCamera( 30, window.innerWidth / window.innerHeight, 1, 10000 );
 				camera.position.z = 100;
 
-				cameraRTT = new THREE.OrthographicCamera( window.innerWidth / - 2, window.innerWidth / 2, window.innerHeight / 2, window.innerHeight / - 2, - 10000, 10000 );
-				cameraRTT.position.z = 100;
+				cameraRTT = new THREE.OrthographicCamera( window.innerWidth / - 2, window.innerWidth / 2, window.innerHeight / 2, window.innerHeight / - 2, 1, 1000 );
+				cameraRTT.position.z = 500;
 
 				//
 


### PR DESCRIPTION
As per the docs, the valid range is between zero and the current value of the far plane.