### PR TITLE
Examples: Clean up.

### DIFF
--- a/examples/webgpu_tsl_vfx_linkedparticles.html
+++ b/examples/webgpu_tsl_vfx_linkedparticles.html
@@ -35,10 +35,6 @@
 			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 			import WebGPU from 'three/addons/capabilities/WebGPU.js';
 
-			import { ExtendedSRGBColorSpace, ExtendedSRGBColorSpaceImpl } from 'three/addons/math/ColorSpaces.js';
-
-			THREE.ColorManagement.define( { [ ExtendedSRGBColorSpace ]: ExtendedSRGBColorSpaceImpl } );
-
 			let camera, scene, renderer, postProcessing, controls, timer, light;
 
 			let updateParticles, spawnParticles; // TSL compute nodes
@@ -94,15 +90,12 @@
 
 				// renderer
 
-				renderer = new THREE.WebGPURenderer( { antialias: true, outputType: THREE.HalfFloatType } );
+				renderer = new THREE.WebGPURenderer( { antialias: true } );
 				renderer.setClearColor( 0x14171a );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setAnimationLoop( animate );
-
-				renderer.outputColorSpace = ExtendedSRGBColorSpace;
-				// TODO: Add support for tone mapping #29573
-				// renderer.toneMapping = THREE.ACESFilmicToneMapping;
+				renderer.toneMapping = THREE.ACESFilmicToneMapping;
 				document.body.appendChild( renderer.domElement );
 
 				// TSL function


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/31893#issuecomment-3284620394

**Description**

Now that there is a dedicated WebGPU HDR example, `webgpu_tsl_vfx_linkedparticles` can be restored to its original version. Modifying this example was not meant to be a permanent solution.
