### PR TITLE
WebGLPrograms: Allow flat shading when material.wireframe == undefined

### DIFF
--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -303,7 +303,7 @@ function WebGLPrograms( renderer, cubemaps, cubeuvmaps, extensions, capabilities
 			useFog: material.fog === true,
 			fogExp2: ( !! fog && fog.isFogExp2 ),
 
-			flatShading: ( material.flatShading === true && material.wireframe === false ),
+			flatShading: ( material.flatShading === true && material.wireframe !== true ),
 
 			sizeAttenuation: material.sizeAttenuation === true,
 			logarithmicDepthBuffer: logarithmicDepthBuffer,


### PR DESCRIPTION
[PR  #31242](https://github.com/mrdoob/three.js/pull/31242) introduced an issue where flat shading would not work for a `MeshMatcapMaterial` without explicitly setting `material.wireframe = false`, because by default `material.wireframe` is `undefined` for `MeshMatcapMaterial` . This PR makes it so flat shading can be enabled when wireframe is undefined.