### PR TITLE
WebGPURenderer: Fix change the current canvas samples

### DIFF
--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -328,15 +328,16 @@ class WebGPUBackend extends Backend {
 		const renderer = this.renderer;
 		const canvasTarget = renderer.getCanvasTarget();
 		const canvasData = this.get( canvasTarget );
+		const samples = renderer.currentSamples;
 
 		let descriptor = canvasData.descriptor;
 
-		if ( descriptor === undefined ) {
+		if ( descriptor === undefined || canvasData.samples !== samples ) {
 
 			descriptor = {
 				colorAttachments: [ {
 					view: null
-				} ],
+				} ]
 			};
 
 			if ( renderer.depth === true || renderer.stencil === true ) {
@@ -349,7 +350,7 @@ class WebGPUBackend extends Backend {
 
 			const colorAttachment = descriptor.colorAttachments[ 0 ];
 
-			if ( renderer.currentSamples > 0 ) {
+			if ( samples > 0 ) {
 
 				colorAttachment.view = this.textureUtils.getColorBuffer().createView();
 
@@ -360,12 +361,13 @@ class WebGPUBackend extends Backend {
 			}
 
 			canvasData.descriptor = descriptor;
+			canvasData.samples = samples;
 
 		}
 
 		const colorAttachment = descriptor.colorAttachments[ 0 ];
 
-		if ( renderer.currentSamples > 0 ) {
+		if ( samples > 0 ) {
 
 			colorAttachment.resolveTarget = this.context.getCurrentTexture().createView();
 

--- a/src/renderers/webgpu/utils/WebGPUTextureUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUTextureUtils.js
@@ -470,7 +470,7 @@ class WebGPUTextureUtils {
 
 		if ( depthTextureGPU !== undefined ) {
 
-			if ( depthTexture.image.width === width && depthTexture.image.height === height && depthTexture.format === format && depthTexture.type === type ) {
+			if ( depthTexture.image.width === width && depthTexture.image.height === height && depthTexture.format === format && depthTexture.type === type && depthTexture.samples === samples ) {
 
 				return depthTextureGPU;
 
@@ -487,6 +487,7 @@ class WebGPUTextureUtils {
 		depthTexture.type = type;
 		depthTexture.image.width = width;
 		depthTexture.image.height = height;
+		depthTexture.samples = samples;
 
 		this.createTexture( depthTexture, { width, height } );
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/31743#issuecomment-3315058314

**Description**

Fix change the current canvas samples.