### PR TITLE
TextureNode: Manage y-flip as a uniform.

### DIFF
--- a/src/materials/nodes/MeshMatcapNodeMaterial.js
+++ b/src/materials/nodes/MeshMatcapNodeMaterial.js
@@ -53,7 +53,7 @@ class MeshMatcapNodeMaterial extends NodeMaterial {
 	 */
 	setupVariants( builder ) {
 
-		const uv = matcapUV;
+		const uv = matcapUV.toVar();
 
 		let matcapColor;
 

--- a/src/materials/nodes/MeshMatcapNodeMaterial.js
+++ b/src/materials/nodes/MeshMatcapNodeMaterial.js
@@ -53,7 +53,7 @@ class MeshMatcapNodeMaterial extends NodeMaterial {
 	 */
 	setupVariants( builder ) {
 
-		const uv = matcapUV.toVar();
+		const uv = matcapUV.toVar(); // #31929
 
 		let matcapColor;
 

--- a/src/materials/nodes/MeshMatcapNodeMaterial.js
+++ b/src/materials/nodes/MeshMatcapNodeMaterial.js
@@ -53,7 +53,7 @@ class MeshMatcapNodeMaterial extends NodeMaterial {
 	 */
 	setupVariants( builder ) {
 
-		const uv = matcapUV.toVar(); // #31929
+		const uv = matcapUV;
 
 		let matcapColor;
 

--- a/src/nodes/accessors/TextureNode.js
+++ b/src/nodes/accessors/TextureNode.js
@@ -309,6 +309,8 @@ class TextureNode extends UniformNode {
 
 			if ( this._flipYUniform === null ) this._flipYUniform = uniform( false );
 
+			uvNode = uvNode.toVar(); // #31929
+
 			if ( this.sampler ) {
 
 				uvNode = this._flipYUniform.equal( true ).select( uvNode.flipY(), uvNode );

--- a/src/nodes/accessors/TextureNode.js
+++ b/src/nodes/accessors/TextureNode.js
@@ -350,7 +350,7 @@ class TextureNode extends UniformNode {
 		//
 
 		let uvNode = Fn( () => {
-			
+
 			uvNode = this.uvNode;
 
 			if ( ( uvNode === null || builder.context.forceUVContext === true ) && builder.context.getUV ) {


### PR DESCRIPTION
Fixed #31750.

**Description**

The PR makes sure `TextureNode` manages the y-flip as a uniform which allows to reuse a texture node with textures with different flip-y requirements.

WebGPU is not affected by this change. The new uniform value is only created when the builder requests it which is only true for WebGL.