### PR TITLE
USDZExporter: handling NaNs in buildVector3Array and buildVector2Array

### DIFF
--- a/examples/jsm/exporters/USDZExporter.js
+++ b/examples/jsm/exporters/USDZExporter.js
@@ -682,9 +682,19 @@ function buildVector3Array( attribute, count ) {
 
 	for ( let i = 0; i < attribute.count; i ++ ) {
 
-		const x = attribute.getX( i );
-		const y = attribute.getY( i );
-		const z = attribute.getZ( i );
+		let x = attribute.getX( i );
+		let y = attribute.getY( i );
+		let z = attribute.getZ( i );
+
+		if ( isNaN( x ) ) {
+			x = 0;
+		}
+		if ( isNaN( y ) ) {
+			y = 0;
+		}
+		if ( isNaN( z ) ) {
+			z = 0;
+		}
 
 		array.push(
 			`(${x.toPrecision( PRECISION )}, ${y.toPrecision(
@@ -704,8 +714,15 @@ function buildVector2Array( attribute ) {
 
 	for ( let i = 0; i < attribute.count; i ++ ) {
 
-		const x = attribute.getX( i );
-		const y = attribute.getY( i );
+		let x = attribute.getX( i );
+		let y = attribute.getY( i );
+
+		if ( isNaN( x ) ) {
+			x = 0;
+		}
+		if ( isNaN( y ) ) {
+			y = 0;
+		}
 
 		array.push(
 			`(${x.toPrecision( PRECISION )}, ${1 - y.toPrecision( PRECISION )})`


### PR DESCRIPTION
**Description**

While working with some highly detailed models, I found that some will fail to export to USDZ properly because they include NaNs in the geometry, so model viewers/editors will fail to parse NaN and refuse to render some geometry that include any. Replacing the NaNs with zeroes works well:

Left: Apple preview not rendering geometry containing NaNs.
Right: Geometry rendering properly after replacing NaNs.

<img width="1983" height="928" alt="image" src="https://github.com/user-attachments/assets/20ae5030-a70d-4546-bb20-47605a330249" />

Not sure if this is the best approach as the NaNs are converted to 0 rather than being removed, both approaches seem to work fine.