### PR TITLE
HTMLMesh: Fix dimensions of canvas drawing.

### DIFF
--- a/examples/jsm/interactive/HTMLMesh.js
+++ b/examples/jsm/interactive/HTMLMesh.js
@@ -295,17 +295,12 @@ function html2canvas( element ) {
 		} else if ( element instanceof HTMLCanvasElement ) {
 
 			// Canvas element
-
 			const rect = element.getBoundingClientRect();
-
 			x = rect.left - offset.left - 0.5;
 			y = rect.top - offset.top - 0.5;
-
-		        context.save();
-			const dpr = window.devicePixelRatio;
-			context.scale( 1 / dpr, 1 / dpr );
-			context.drawImage( element, x, y );
-			context.restore();
+			const width = rect.width;
+			const height = rect.height;
+			context.drawImage( element, x, y, width, height );
 
 		} else if ( element instanceof HTMLImageElement ) {
 
@@ -521,11 +516,12 @@ function html2canvas( element ) {
 	if ( canvas === undefined ) {
 
 		canvas = document.createElement( 'canvas' );
-		canvas.width = offset.width;
-		canvas.height = offset.height;
 		canvases.set( element, canvas );
 
 	}
+
+	canvas.width = offset.width;
+	canvas.height = offset.height;
 
 	const context = canvas.getContext( '2d'/*, { alpha: false }*/ );
 


### PR DESCRIPTION
examples/jsm/interactive/HTMLMesh.js

Related issue: #none-found

On Safari Version 18.6 (20621.3.11.11.3) (Mac OS Sequoia 15.6) when rendering complex canvas objects, objects that are further from the origin get scaled off canvas and do not show on the HTMLMesh.

Specifically when rendering trading view-lightweight charts objects using HTMLMesh.

This fix cleans up the HTMLCanvasElement  image drawing and aligns it with the HTMLImageElement drawing.

Submitted to three.js As per Vincent from frame-htmlmesh. @vincentfretin, @zz85 , @Elettrotecnica 
