### PR TITLE
Update link to packLDrawModel script extension

### DIFF
--- a/docs/examples/en/loaders/LDrawLoader.html
+++ b/docs/examples/en/loaders/LDrawLoader.html
@@ -104,7 +104,7 @@
 		<p>To pack a model with all its referenced files, download the
 		[link:https://www.ldraw.org/parts/latest-parts.html Official LDraw parts library]
 		and use the following Node script:
-		[link:https://github.com/mrdoob/three.js/blob/master/utils/packLDrawModel.js utils/packLDrawModel.js]
+		[link:https://github.com/mrdoob/three.js/blob/master/utils/packLDrawModel.mjs utils/packLDrawModel.mjs]
 		It contains instructions on how to setup the files and execute it.</p>
 
 		<h2>Metadata in .userData</h2>


### PR DESCRIPTION
**Description**

Link in documentation was broken for packLDrawModel script. Fixed it to use correct link.
