### PR TITLE
CSS2DRenderer: Add `sortObjects`.

### DIFF
--- a/examples/jsm/renderers/CSS2DRenderer.js
+++ b/examples/jsm/renderers/CSS2DRenderer.js
@@ -290,6 +290,7 @@ class CSS2DRenderer {
 
 				if ( a.renderOrder !== b.renderOrder ) {
 
+					// Sort by ascending renderOrder
 					return a.renderOrder - b.renderOrder;
 
 				}
@@ -299,7 +300,8 @@ class CSS2DRenderer {
 					const depthA = a.depthTest ? 1 : 0;
 					const depthB = b.depthTest ? 1 : 0;
 
-					return depthA - depthB;
+					// Put objects with depthTest=false in front of those with depthTest=true
+					return depthB - depthA;
 				}
 
 				const distanceA = cache.objects.get( a ).distanceToCameraSquared;

--- a/examples/jsm/renderers/CSS2DRenderer.js
+++ b/examples/jsm/renderers/CSS2DRenderer.js
@@ -30,6 +30,15 @@ class CSS2DObject extends Object3D {
 		 * @default true
 		 */
 		this.isCSS2DObject = true;
+		/**
+		 * If set to `true` (default), the renderer will automatically assign `z-index` css properties
+		 * according to the object's renderOrder and distance to the camera. If set to `false`, the `z-index`
+		 * of the object's element will not be changed by the renderer and can be controlled manually.
+		 *
+		 * @type {boolean}
+		 * @default true
+		 */
+		this.autoSortZ = true;
 
 		/**
 		 * The DOM element which defines the appearance of this 3D object.
@@ -268,7 +277,7 @@ class CSS2DRenderer {
 
 			scene.traverseVisible( function ( object ) {
 
-				if ( object.isCSS2DObject ) result.push( object );
+				if ( object.isCSS2DObject && object.autoSortZ ) result.push( object );
 
 			} );
 

--- a/examples/jsm/renderers/CSS2DRenderer.js
+++ b/examples/jsm/renderers/CSS2DRenderer.js
@@ -300,7 +300,8 @@ class CSS2DRenderer {
 					const depthA = a.depthTest ? 1 : 0;
 					const depthB = b.depthTest ? 1 : 0;
 
-					// Put objects with depthTest=false in front of those with depthTest=true
+					// Put objects with depthTest=false after objects with depthTest=true when
+					// they have the same renderOrder
 					return depthB - depthA;
 				}
 

--- a/examples/jsm/renderers/CSS2DRenderer.js
+++ b/examples/jsm/renderers/CSS2DRenderer.js
@@ -31,14 +31,13 @@ class CSS2DObject extends Object3D {
 		 */
 		this.isCSS2DObject = true;
 		/**
-		 * If set to `true` (default), the renderer will automatically assign `z-index` css properties
-		 * according to the object's renderOrder and distance to the camera. If set to `false`, the `z-index`
-		 * of the object's element will not be changed by the renderer and can be controlled manually.
+		 * If set to `true` (default), the renderer will assign different `z-index` css properties
+		 * to objects with the same `renderOrder` based on their distance to the camera.
 		 *
 		 * @type {boolean}
 		 * @default true
 		 */
-		this.autoSortZ = true;
+		this.depthTest = true;
 
 		/**
 		 * The DOM element which defines the appearance of this 3D object.
@@ -291,8 +290,16 @@ class CSS2DRenderer {
 
 				if ( a.renderOrder !== b.renderOrder ) {
 
-					return b.renderOrder - a.renderOrder;
+					return a.renderOrder - b.renderOrder;
 
+				}
+
+				if (a.depthTest !== b.depthTest){
+
+					const depthA = a.depthTest ? 1 : 0;
+					const depthB = b.depthTest ? 1 : 0;
+
+					return depthA - depthB;
 				}
 
 				const distanceA = cache.objects.get( a ).distanceToCameraSquared;
@@ -302,11 +309,20 @@ class CSS2DRenderer {
 
 			} );
 
-			const zMax = sorted.length;
+			let zIndex = 0;
+			let lastRenderOrder = null;
 
 			for ( let i = 0, l = sorted.length; i < l; i ++ ) {
+				const object = sorted[ i ];
 
-				sorted[ i ].element.style.zIndex = zMax - i;
+				if(object.renderOrder !== lastRenderOrder){
+					lastRenderOrder = object.renderOrder;
+					zIndex += 1;
+				} else if( object.depthTest ) {
+					zIndex += 1;
+				}
+
+				object.element.style.zIndex = zIndex;
 
 			}
 


### PR DESCRIPTION
Fixed #31945.

**Description**

Implemented a way of opting out from `CSS2DRenderer` automatic `z-index` assignment
