### PR TITLE
Example.css: Add invert class

### DIFF
--- a/examples/example.css
+++ b/examples/example.css
@@ -88,3 +88,7 @@ a {
 	background: #c3c3c3;
 	opacity: .5;
 }
+
+#info.invert {
+	filter: invert(1);
+}

--- a/examples/webgpu_depth_texture.html
+++ b/examples/webgpu_depth_texture.html
@@ -3,12 +3,18 @@
 		<title>three.js webgpu - depth texture</title>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
-		<link type="text/css" rel="stylesheet" href="main.css">
+		<link type="text/css" rel="stylesheet" href="example.css">
 	</head>
 	<body>
 
-		<div id="info">
-			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> webgpu - depth texture
+		<div id="info" class="invert">
+			<a href="https://threejs.org/" target="_blank" rel="noopener" class="logo-link"></a>
+
+			<div class="title-wrapper">
+				<a href="https://threejs.org/" target="_blank" rel="noopener">three.js</a><span>Depth Texture</span>
+			</div>
+
+			<small>Rendering the scene's depth into a texture for later use</small>
 		</div>
 
 		<script type="importmap">


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/31954#issuecomment-3341455970

**Description**

Add invert class for use info over a white background.

<img width="410" height="87" alt="image" src="https://github.com/user-attachments/assets/fbebf34e-b5fc-4502-a744-98ab8f345770" />

