### PR TITLE
Inspector: Reuse the last frame if there is desynchronization.

### DIFF
--- a/examples/jsm/inspector/RendererInspector.js
+++ b/examples/jsm/inspector/RendererInspector.js
@@ -74,6 +74,7 @@ export class RendererInspector extends InspectorBase {
 		this.currentFrame = null;
 		this.currentRender = null;
 		this.currentNodes = null;
+		this.lastFrame = null;
 
 		this.frames = [];
 		this.framesLib = {};
@@ -104,6 +105,8 @@ export class RendererInspector extends InspectorBase {
 
 		this.addFrame( frame );
 
+		this.lastFrame = frame;
+
 		this.currentFrame = null;
 		this.currentRender = null;
 		this.currentNodes = null;
@@ -131,7 +134,7 @@ export class RendererInspector extends InspectorBase {
 
 	getFrame() {
 
-		return this.currentFrame;
+		return this.currentFrame || this.lastFrame;
 
 	}
 
@@ -327,6 +330,8 @@ export class RendererInspector extends InspectorBase {
 
 		const frame = this.getFrame();
 
+		if ( ! frame ) return;
+
 		const currentRender = new RenderStats( uid, scene, camera, renderTarget );
 		currentRender.timestamp = performance.now();
 		currentRender.parent = this.currentRender;
@@ -348,6 +353,10 @@ export class RendererInspector extends InspectorBase {
 	}
 
 	finishRender() {
+
+		const frame = this.getFrame();
+
+		if ( ! frame ) return;
 
 		const currentRender = this.currentRender;
 		currentRender.cpu = performance.now() - currentRender.timestamp;


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/31954#issuecomment-3341455970

**Description**

Reuse the last frame if there is desynchronization and ignore the check if no frame is started.
This can happen if calls are made outside of `renderer.setAnimationLoop()`.
