### PR TITLE
Imporve performance to get trackType by value type in AnimationClip.js

### DIFF
--- a/src/animation/AnimationClip.js
+++ b/src/animation/AnimationClip.js
@@ -569,9 +569,7 @@ function getTrackTypeForValueTypeName( typeName ) {
 
 	var trackType = trackTypeMapper[ typeName.toLowerCase() ];
 
-	if ( ! trackType ) {
-		throw new Error( 'THREE.KeyframeTrack: Unsupported typeName: ' + typeName );
-	}
+	if ( ! trackType ) throw new Error( 'THREE.KeyframeTrack: Unsupported typeName: ' + typeName );
 
 	return trackType;
 }

--- a/src/animation/AnimationClip.js
+++ b/src/animation/AnimationClip.js
@@ -550,44 +550,38 @@ class AnimationClip {
 
 function getTrackTypeForValueTypeName( typeName ) {
 
-	switch ( typeName.toLowerCase() ) {
+	var trackTypeMapper = {
+		
+		'scalar': NumberKeyframeTrack,
+		'double': NumberKeyframeTrack,
+		'float': NumberKeyframeTrack,
+		'number': NumberKeyframeTrack,
+		'integer': NumberKeyframeTrack,
+		
+		'vector': VectorKeyframeTrack,
+		'vector2': VectorKeyframeTrack,
+		'vector3': VectorKeyframeTrack,
+		'vector4': VectorKeyframeTrack,
 
-		case 'scalar':
-		case 'double':
-		case 'float':
-		case 'number':
-		case 'integer':
+		'color': ColorKeyframeTrack,
 
-			return NumberKeyframeTrack;
+		'quaternion': QuaternionKeyframeTrack,
 
-		case 'vector':
-		case 'vector2':
-		case 'vector3':
-		case 'vector4':
+		'bool': BooleanKeyframeTrack,
+		'boolean': BooleanKeyframeTrack,
 
-			return VectorKeyframeTrack;
+		'string': StringKeyframeTrack
+		
+	};
 
-		case 'color':
+	var trackType = trackTypeMapper[ typeName.toLowerCase() ];
 
-			return ColorKeyframeTrack;
-
-		case 'quaternion':
-
-			return QuaternionKeyframeTrack;
-
-		case 'bool':
-		case 'boolean':
-
-			return BooleanKeyframeTrack;
-
-		case 'string':
-
-			return StringKeyframeTrack;
-
+	if ( !trackType ) {
+		
+		throw new Error( 'THREE.KeyframeTrack: Unsupported typeName: ' + typeName );
 	}
 
-	throw new Error( 'THREE.KeyframeTrack: Unsupported typeName: ' + typeName );
-
+	return trackType;
 }
 
 function parseKeyframeTrack( json ) {

--- a/src/animation/AnimationClip.js
+++ b/src/animation/AnimationClip.js
@@ -572,6 +572,7 @@ function getTrackTypeForValueTypeName( typeName ) {
 	if ( ! trackType ) {
 		
 		throw new Error( 'THREE.KeyframeTrack: Unsupported typeName: ' + typeName );
+	
 	}
 
 	return trackType;

--- a/src/animation/AnimationClip.js
+++ b/src/animation/AnimationClip.js
@@ -570,9 +570,7 @@ function getTrackTypeForValueTypeName( typeName ) {
 	var trackType = trackTypeMapper[ typeName.toLowerCase() ];
 
 	if ( ! trackType ) {
-		
 		throw new Error( 'THREE.KeyframeTrack: Unsupported typeName: ' + typeName );
-	
 	}
 
 	return trackType;

--- a/src/animation/AnimationClip.js
+++ b/src/animation/AnimationClip.js
@@ -570,9 +570,7 @@ function getTrackTypeForValueTypeName( typeName ) {
 	var trackType = trackTypeMapper[ typeName.toLowerCase() ];
 
 	if ( ! trackType ) throw new Error( 'THREE.KeyframeTrack: Unsupported typeName: ' + typeName );
-
 	return trackType;
-	
 }
 
 function parseKeyframeTrack( json ) {

--- a/src/animation/AnimationClip.js
+++ b/src/animation/AnimationClip.js
@@ -572,6 +572,7 @@ function getTrackTypeForValueTypeName( typeName ) {
 	if ( ! trackType ) throw new Error( 'THREE.KeyframeTrack: Unsupported typeName: ' + typeName );
 
 	return trackType;
+	
 }
 
 function parseKeyframeTrack( json ) {

--- a/src/animation/AnimationClip.js
+++ b/src/animation/AnimationClip.js
@@ -576,7 +576,7 @@ function getTrackTypeForValueTypeName( typeName ) {
 
 	var trackType = trackTypeMapper[ typeName.toLowerCase() ];
 
-	if ( !trackType ) {
+	if ( ! trackType ) {
 		
 		throw new Error( 'THREE.KeyframeTrack: Unsupported typeName: ' + typeName );
 	}

--- a/src/animation/AnimationClip.js
+++ b/src/animation/AnimationClip.js
@@ -551,27 +551,20 @@ class AnimationClip {
 function getTrackTypeForValueTypeName( typeName ) {
 
 	var trackTypeMapper = {
-		
 		'scalar': NumberKeyframeTrack,
 		'double': NumberKeyframeTrack,
 		'float': NumberKeyframeTrack,
 		'number': NumberKeyframeTrack,
 		'integer': NumberKeyframeTrack,
-		
 		'vector': VectorKeyframeTrack,
 		'vector2': VectorKeyframeTrack,
 		'vector3': VectorKeyframeTrack,
 		'vector4': VectorKeyframeTrack,
-
 		'color': ColorKeyframeTrack,
-
 		'quaternion': QuaternionKeyframeTrack,
-
 		'bool': BooleanKeyframeTrack,
 		'boolean': BooleanKeyframeTrack,
-
 		'string': StringKeyframeTrack
-		
 	};
 
 	var trackType = trackTypeMapper[ typeName.toLowerCase() ];

--- a/src/animation/AnimationClip.js
+++ b/src/animation/AnimationClip.js
@@ -570,7 +570,9 @@ function getTrackTypeForValueTypeName( typeName ) {
 	var trackType = trackTypeMapper[ typeName.toLowerCase() ];
 
 	if ( ! trackType ) throw new Error( 'THREE.KeyframeTrack: Unsupported typeName: ' + typeName );
+
 	return trackType;
+
 }
 
 function parseKeyframeTrack( json ) {


### PR DESCRIPTION
Related issue: #XXXX

**Description**

changed switch to mapper to decrease ByteCode size and improved performance to get tracker.

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Example](https://example.com)*
