### PR TITLE
WebGPURenderer: Fix binding sampler update

### DIFF
--- a/src/renderers/common/nodes/NodeSampler.js
+++ b/src/renderers/common/nodes/NodeSampler.js
@@ -43,7 +43,15 @@ class NodeSampler extends Sampler {
 	 */
 	update() {
 
-		this.texture = this.textureNode.value;
+		const { textureNode } = this;
+
+		if ( this.texture !== textureNode.value ) {
+
+			this.texture = textureNode.value;
+
+			return true;
+
+		}
 
 		return super.update();
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/31899

**Description**

Fix the binding texture reference if it is changed in the node.
Example related: `webgpu_compute_texture_pingpong`
