### PR TITLE
TSL: Forces assignment of a function call if a loop is detected (2)

### DIFF
--- a/src/nodes/core/ContextNode.js
+++ b/src/nodes/core/ContextNode.js
@@ -94,9 +94,7 @@ class ContextNode extends Node {
 
 	analyze( builder ) {
 
-		const previousContext = builder.getContext();
-
-		builder.setContext( { ...builder.context, ...this.value } );
+		const previousContext = builder.addContext( this.value );
 
 		this.node.build( builder );
 
@@ -106,9 +104,7 @@ class ContextNode extends Node {
 
 	setup( builder ) {
 
-		const previousContext = builder.getContext();
-
-		builder.setContext( { ...builder.context, ...this.value } );
+		const previousContext = builder.addContext( this.value );
 
 		this.node.build( builder );
 
@@ -118,9 +114,7 @@ class ContextNode extends Node {
 
 	generate( builder, output ) {
 
-		const previousContext = builder.getContext();
-
-		builder.setContext( { ...builder.context, ...this.value } );
+		const previousContext = builder.addContext( this.value );
 
 		const snippet = this.node.build( builder, output );
 

--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -451,14 +451,6 @@ class NodeBuilder {
 		 */
 		this.subBuildFn = null;
 
-		/**
-		 * The current TSL function(Fn) call node.
-		 *
-		 * @type {?Node}
-		 * @default null
-		 */
-		this.fnCall = null;
-
 	}
 
 	/**

--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -451,6 +451,14 @@ class NodeBuilder {
 		 */
 		this.subBuildFn = null;
 
+		/**
+		 * The current TSL function(Fn) call node.
+		 *
+		 * @type {?Node}
+		 * @default null
+		 */
+		this.fnCall = null;
+
 	}
 
 	/**

--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -900,6 +900,22 @@ class NodeBuilder {
 	}
 
 	/**
+	 * Adds context data to the builder's current context.
+	 *
+	 * @param {Object} context - The context to add.
+	 * @return {Object} The previous context.
+	 */
+	addContext( context ) {
+
+		const previousContext = this.getContext();
+
+		this.setContext( { ...this.context, ...context } );
+
+		return previousContext;
+
+	}
+
+	/**
 	 * Gets a context used in shader construction that can be shared across different materials.
 	 * This is necessary since the renderer cache can reuse shaders generated in one material and use them in another.
 	 *

--- a/src/nodes/core/StackNode.js
+++ b/src/nodes/core/StackNode.js
@@ -261,9 +261,15 @@ class StackNode extends Node {
 
 		for ( const childNode of this.getChildren() ) {
 
-			if ( childNode.isVarNode && childNode.isAssign( builder ) !== true ) {
+			if ( childNode.isVarNode && childNode.intent === true ) {
 
-				continue;
+				const properties = builder.getNodeProperties( childNode );
+
+				if ( properties.assign !== true ) {
+
+					continue;
+
+				}
 
 			}
 
@@ -296,9 +302,15 @@ class StackNode extends Node {
 
 		for ( const node of this.nodes ) {
 
-			if ( node.isVarNode && node.isAssign( builder ) !== true ) {
+			if ( node.isVarNode && node.intent === true ) {
 
-				continue;
+				const properties = builder.getNodeProperties( node );
+
+				if ( properties.assign !== true ) {
+
+					continue;
+
+				}
 
 			}
 

--- a/src/nodes/core/StackNode.js
+++ b/src/nodes/core/StackNode.js
@@ -263,7 +263,9 @@ class StackNode extends Node {
 
 			if ( childNode.isVarNode && childNode.intent === true ) {
 
-				if ( childNode.isAssign( builder ) !== true ) {
+				const properties = builder.getNodeProperties( childNode );
+
+				if ( properties.assign !== true ) {
 
 					continue;
 
@@ -302,7 +304,9 @@ class StackNode extends Node {
 
 			if ( node.isVarNode && node.intent === true ) {
 
-				if ( node.isAssign( builder ) !== true ) {
+				const properties = builder.getNodeProperties( node );
+
+				if ( properties.assign !== true ) {
 
 					continue;
 

--- a/src/nodes/core/StackNode.js
+++ b/src/nodes/core/StackNode.js
@@ -261,15 +261,9 @@ class StackNode extends Node {
 
 		for ( const childNode of this.getChildren() ) {
 
-			if ( childNode.isVarNode && childNode.intent === true ) {
+			if ( childNode.isVarNode && childNode.isAssign( builder ) !== true ) {
 
-				const properties = builder.getNodeProperties( childNode );
-
-				if ( properties.assign !== true ) {
-
-					continue;
-
-				}
+				continue;
 
 			}
 
@@ -302,15 +296,9 @@ class StackNode extends Node {
 
 		for ( const node of this.nodes ) {
 
-			if ( node.isVarNode && node.intent === true ) {
+			if ( node.isVarNode && node.isAssign( builder ) !== true ) {
 
-				const properties = builder.getNodeProperties( node );
-
-				if ( properties.assign !== true ) {
-
-					continue;
-
-				}
+				continue;
 
 			}
 

--- a/src/nodes/core/StackNode.js
+++ b/src/nodes/core/StackNode.js
@@ -263,9 +263,7 @@ class StackNode extends Node {
 
 			if ( childNode.isVarNode && childNode.intent === true ) {
 
-				const properties = builder.getNodeProperties( childNode );
-
-				if ( properties.assign !== true ) {
+				if ( childNode.isAssign( builder ) !== true ) {
 
 					continue;
 
@@ -304,9 +302,7 @@ class StackNode extends Node {
 
 			if ( node.isVarNode && node.intent === true ) {
 
-				const properties = builder.getNodeProperties( node );
-
-				if ( properties.assign !== true ) {
+				if ( node.isAssign( builder ) !== true ) {
 
 					continue;
 

--- a/src/nodes/core/VarNode.js
+++ b/src/nodes/core/VarNode.js
@@ -146,14 +146,53 @@ class VarNode extends Node {
 
 	}
 
+	isAssign( builder ) {
+
+		if ( this.intent !== true ) return true;
+
+		//
+
+		const properties = builder.getNodeProperties( this );
+
+		let assign = properties.assign;
+
+		if ( assign !== true ) {
+
+			if ( this.node.isShaderCallNodeInternal && this.node.shaderNode.getLayout() === null ) {
+
+				if ( builder.context.fnCall && builder.context.fnCall.shaderNode ) {
+
+					const nodeType = this.node.getNodeType( builder );
+
+					if ( nodeType !== 'void' ) {
+
+						const shaderNodeData = builder.getDataFromNode( this.node.shaderNode );
+
+						if ( shaderNodeData.hasLoop ) {
+
+							assign = true;
+
+						}
+
+					}
+
+				}
+
+			}
+
+		}
+
+		return assign;
+
+	}
+
 	build( ...params ) {
 
 		if ( this.intent === true ) {
 
 			const builder = params[ 0 ];
-			const properties = builder.getNodeProperties( this );
 
-			if ( properties.assign !== true ) {
+			if ( this.isAssign( builder ) !== true ) {
 
 				return this.node.build( ...params );
 

--- a/src/nodes/core/VarNode.js
+++ b/src/nodes/core/VarNode.js
@@ -148,6 +148,10 @@ class VarNode extends Node {
 
 	isAssign( builder ) {
 
+		if ( this.intent !== true ) return true;
+
+		//
+
 		const properties = builder.getNodeProperties( this );
 
 		let assign = properties.assign;

--- a/src/nodes/core/VarNode.js
+++ b/src/nodes/core/VarNode.js
@@ -148,10 +148,6 @@ class VarNode extends Node {
 
 	isAssign( builder ) {
 
-		if ( this.intent !== true ) return true;
-
-		//
-
 		const properties = builder.getNodeProperties( this );
 
 		let assign = properties.assign;

--- a/src/nodes/core/VarNode.js
+++ b/src/nodes/core/VarNode.js
@@ -154,7 +154,7 @@ class VarNode extends Node {
 
 		if ( assign !== true ) {
 
-			/*if ( this.node.isShaderCallNodeInternal && this.node.shaderNode.getLayout() === null ) {
+			if ( this.node.isShaderCallNodeInternal && this.node.shaderNode.getLayout() === null ) {
 
 				if ( builder.fnCall && builder.fnCall.shaderNode ) {
 
@@ -166,7 +166,7 @@ class VarNode extends Node {
 
 						if ( shaderNodeData.hasLoop ) {
 
-							assign = true;
+							//assign = true;
 
 						}
 
@@ -174,7 +174,7 @@ class VarNode extends Node {
 
 				}
 
-			}*/
+			}
 
 		}
 

--- a/src/nodes/core/VarNode.js
+++ b/src/nodes/core/VarNode.js
@@ -154,7 +154,7 @@ class VarNode extends Node {
 
 		if ( assign !== true ) {
 
-			if ( this.node.isShaderCallNodeInternal && this.node.shaderNode.getLayout() === null ) {
+			/*if ( this.node.isShaderCallNodeInternal && this.node.shaderNode.getLayout() === null ) {
 
 				if ( builder.fnCall && builder.fnCall.shaderNode ) {
 
@@ -174,7 +174,7 @@ class VarNode extends Node {
 
 				}
 
-			}
+			}*/
 
 		}
 

--- a/src/nodes/core/VarNode.js
+++ b/src/nodes/core/VarNode.js
@@ -158,17 +158,11 @@ class VarNode extends Node {
 
 				if ( builder.fnCall && builder.fnCall.shaderNode ) {
 
-					const nodeType = this.node.getNodeType( builder );
+					const shaderNodeData = builder.getDataFromNode( this.node.shaderNode );
 
-					if ( nodeType !== 'void' ) {
+					if ( shaderNodeData.hasLoop ) {
 
-						const shaderNodeData = builder.getDataFromNode( this.node.shaderNode );
-
-						if ( shaderNodeData.hasLoop ) {
-
-							//assign = true;
-
-						}
+						assign = true;
 
 					}
 

--- a/src/nodes/core/VarNode.js
+++ b/src/nodes/core/VarNode.js
@@ -160,7 +160,7 @@ class VarNode extends Node {
 
 			if ( this.node.isShaderCallNodeInternal && this.node.shaderNode.getLayout() === null ) {
 
-				if ( builder.fnCall && builder.fnCall.shaderNode ) {
+				if ( builder.context.fnCall && builder.context.fnCall.shaderNode ) {
 
 					const nodeType = this.node.getNodeType( builder );
 

--- a/src/nodes/core/VarNode.js
+++ b/src/nodes/core/VarNode.js
@@ -160,7 +160,7 @@ class VarNode extends Node {
 
 			if ( this.node.isShaderCallNodeInternal && this.node.shaderNode.getLayout() === null ) {
 
-				if ( builder.context.fnCall && builder.context.fnCall.shaderNode ) {
+				if ( builder.fnCall && builder.fnCall.shaderNode ) {
 
 					const nodeType = this.node.getNodeType( builder );
 

--- a/src/nodes/core/VarNode.js
+++ b/src/nodes/core/VarNode.js
@@ -1,5 +1,6 @@
 import Node from './Node.js';
 import { addMethodChaining, getCurrentStack, nodeProxy } from '../tsl/TSLCore.js';
+import { error } from '../../utils.js';
 
 /**
  * Class for representing shader variables as nodes. Variables are created from
@@ -212,7 +213,23 @@ class VarNode extends Node {
 
 		}
 
-		const vectorType = builder.getVectorType( this.getNodeType( builder ) );
+		const nodeType = this.getNodeType( builder );
+
+		if ( nodeType == 'void' ) {
+
+			if ( this.intent !== true ) {
+
+				error( 'TSL: ".toVar()" can not be used with void type.' );
+
+			}
+
+			const snippet = node.build( builder );
+
+			return snippet;
+
+		}
+
+		const vectorType = builder.getVectorType( nodeType );
 		const snippet = node.build( builder, vectorType );
 
 		const nodeVar = builder.getVarFromNode( this, name, vectorType, undefined, shouldTreatAsReadOnly );

--- a/src/nodes/tsl/TSLCore.js
+++ b/src/nodes/tsl/TSLCore.js
@@ -488,10 +488,9 @@ class ShaderCallNodeInternal extends Node {
 		//
 
 		const previousSubBuildFn = builder.subBuildFn;
-		const previousFnCall = builder.fnCall;
+		const previousContext = builder.addContext( { fnCall: this } );
 
 		builder.subBuildFn = subBuild;
-		builder.fnCall = this;
 
 		let result = null;
 
@@ -567,7 +566,7 @@ class ShaderCallNodeInternal extends Node {
 		}
 
 		builder.subBuildFn = previousSubBuildFn;
-		builder.fnCall = previousFnCall;
+		builder.setContext( previousContext );
 
 		if ( shaderNode.once ) {
 
@@ -611,9 +610,7 @@ class ShaderCallNodeInternal extends Node {
 		const subBuildOutput = builder.getSubBuildOutput( this );
 		const outputNode = this.getOutputNode( builder );
 
-		const previousFnCall = builder.fnCall;
-
-		builder.fnCall = this;
+		const previousContext = builder.addContext( { fnCall: this } );
 
 		if ( buildStage === 'setup' ) {
 
@@ -662,7 +659,7 @@ class ShaderCallNodeInternal extends Node {
 
 		}
 
-		builder.fnCall = previousFnCall;
+		builder.setContext( previousContext );
 
 		return result;
 

--- a/src/nodes/tsl/TSLCore.js
+++ b/src/nodes/tsl/TSLCore.js
@@ -488,9 +488,10 @@ class ShaderCallNodeInternal extends Node {
 		//
 
 		const previousSubBuildFn = builder.subBuildFn;
-		const previousContext = builder.addContext( { fnCall: this } );
+		const previousFnCall = builder.fnCall;
 
 		builder.subBuildFn = subBuild;
+		builder.fnCall = this;
 
 		let result = null;
 
@@ -566,7 +567,7 @@ class ShaderCallNodeInternal extends Node {
 		}
 
 		builder.subBuildFn = previousSubBuildFn;
-		builder.setContext( previousContext );
+		builder.fnCall = previousFnCall;
 
 		if ( shaderNode.once ) {
 
@@ -610,7 +611,9 @@ class ShaderCallNodeInternal extends Node {
 		const subBuildOutput = builder.getSubBuildOutput( this );
 		const outputNode = this.getOutputNode( builder );
 
-		const previousContext = builder.addContext( { fnCall: this } );
+		const previousFnCall = builder.fnCall;
+
+		builder.fnCall = this;
 
 		if ( buildStage === 'setup' ) {
 
@@ -659,7 +662,7 @@ class ShaderCallNodeInternal extends Node {
 
 		}
 
-		builder.setContext( previousContext );
+		builder.fnCall = previousFnCall;
 
 		return result;
 

--- a/src/nodes/tsl/TSLCore.js
+++ b/src/nodes/tsl/TSLCore.js
@@ -488,6 +488,7 @@ class ShaderCallNodeInternal extends Node {
 		//
 
 		const previousSubBuildFn = builder.subBuildFn;
+		const previousContext = builder.addContext( { fnCall: this } );
 
 		builder.subBuildFn = subBuild;
 
@@ -565,6 +566,7 @@ class ShaderCallNodeInternal extends Node {
 		}
 
 		builder.subBuildFn = previousSubBuildFn;
+		builder.setContext( previousContext );
 
 		if ( shaderNode.once ) {
 
@@ -607,6 +609,8 @@ class ShaderCallNodeInternal extends Node {
 
 		const subBuildOutput = builder.getSubBuildOutput( this );
 		const outputNode = this.getOutputNode( builder );
+
+		const previousContext = builder.addContext( { fnCall: this } );
 
 		if ( buildStage === 'setup' ) {
 
@@ -654,6 +658,8 @@ class ShaderCallNodeInternal extends Node {
 			result = outputNode.build( builder, output ) || '';
 
 		}
+
+		builder.setContext( previousContext );
 
 		return result;
 
@@ -788,9 +794,15 @@ class ShaderNodeInternal extends Node {
 
 	}
 
+	getLayout() {
+
+		return this.layout;
+
+	}
+
 	call( rawInputs = null ) {
 
-		return nodeObject( new ShaderCallNodeInternal( this, rawInputs ) );
+		return new ShaderCallNodeInternal( this, rawInputs );
 
 	}
 

--- a/src/nodes/utils/LoopNode.js
+++ b/src/nodes/utils/LoopNode.js
@@ -1,6 +1,6 @@
 import Node from '../core/Node.js';
 import { expression } from '../code/ExpressionNode.js';
-import { nodeObject, nodeArray, Fn } from '../tsl/TSLBase.js';
+import { nodeArray, Fn } from '../tsl/TSLBase.js';
 import { error } from '../../utils.js';
 
 /**
@@ -138,6 +138,13 @@ class LoopNode extends Node {
 		// setup properties
 
 		this.getProperties( builder );
+
+		if ( builder.context.fnCall ) {
+
+			const shaderNodeData = builder.getDataFromNode( builder.context.fnCall.shaderNode );
+			shaderNodeData.hasLoop = true;
+
+		}
 
 	}
 
@@ -333,7 +340,7 @@ export default LoopNode;
  * @param {...any} params - A list of parameters.
  * @returns {LoopNode}
  */
-export const Loop = ( ...params ) => nodeObject( new LoopNode( nodeArray( params, 'int' ) ) ).toStack();
+export const Loop = ( ...params ) => new LoopNode( nodeArray( params, 'int' ) ).toStack();
 
 /**
  * TSL function for creating a `Continue()` expression.

--- a/src/nodes/utils/LoopNode.js
+++ b/src/nodes/utils/LoopNode.js
@@ -139,9 +139,9 @@ class LoopNode extends Node {
 
 		this.getProperties( builder );
 
-		if ( builder.context.fnCall ) {
+		if ( builder.fnCall ) {
 
-			const shaderNodeData = builder.getDataFromNode( builder.context.fnCall.shaderNode );
+			const shaderNodeData = builder.getDataFromNode( builder.fnCall.shaderNode );
 			shaderNodeData.hasLoop = true;
 
 		}

--- a/src/nodes/utils/LoopNode.js
+++ b/src/nodes/utils/LoopNode.js
@@ -139,9 +139,9 @@ class LoopNode extends Node {
 
 		this.getProperties( builder );
 
-		if ( builder.fnCall ) {
+		if ( builder.context.fnCall ) {
 
-			const shaderNodeData = builder.getDataFromNode( builder.fnCall.shaderNode );
+			const shaderNodeData = builder.getDataFromNode( builder.context.fnCall.shaderNode );
 			shaderNodeData.hasLoop = true;
 
 		}


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/31961

**Description**

Forces assignment of a function call if a loop is detected inside the function.

This is equivalent to using `.toVar()` if calling a function without a layout without an inner loop, avoiding unwanted sub-loops.

- Move the `fnCall` property out of context to avoid context conflict.