### PR TITLE
SVGLoader: Make node transform parsing more robust.

### DIFF
--- a/examples/jsm/loaders/SVGLoader.js
+++ b/examples/jsm/loaders/SVGLoader.js
@@ -1502,8 +1502,8 @@ class SVGLoader extends Loader {
 
 			if ( node.nodeName === 'use' && ( node.hasAttribute( 'x' ) || node.hasAttribute( 'y' ) ) ) {
 
-				const tx = parseFloatWithUnits( node.getAttribute( 'x' ) );
-				const ty = parseFloatWithUnits( node.getAttribute( 'y' ) );
+				const tx = parseFloatWithUnits( node.getAttribute( 'x' ) || 0 );
+				const ty = parseFloatWithUnits( node.getAttribute( 'y' ) || 0 );
 
 				transform.translate( tx, ty );
 


### PR DESCRIPTION
Fixed #31981.

**Description**

Make sure the `use` attribute is parsed in a way such that single `x` and `y` attributes are supported.

@nkallen Are we allowed to use the SVG from the issue as a test asset in this repository?
