### PR TITLE
New Docs: Reduce folder size

### DIFF
--- a/utils/docs/jsdoc.config.json
+++ b/utils/docs/jsdoc.config.json
@@ -9,6 +9,11 @@
                 "ignoreInheritedSymbols": true
             }
     },
+    "templates": {
+        "default": {
+            "outputSourceFiles": false
+        }
+    },
     "plugins": [ "plugins/markdown" ],
     "source": {
         "include": [

--- a/utils/docs/template/publish.js
+++ b/utils/docs/template/publish.js
@@ -299,6 +299,9 @@ function generate( title, docs, filename, resolveLinks ) {
 
 	}
 
+	// Remove lines that only contain whitespace
+	html = html.replace( /^\s*\n/gm, '' );
+
 	fs.writeFileSync( outpath, html, 'utf8' );
 
 }

--- a/utils/docs/template/publish.js
+++ b/utils/docs/template/publish.js
@@ -366,7 +366,7 @@ function buildMainNav( items, itemsSeen, linktoFn ) {
 
 				}
 
-				itemNav += `<li data-name="${item.name}">${linktoFn( item.longname, displayName.replace( /\b(module|event):/g, '' ) )}</li>`;
+				itemNav += `<li>${linktoFn( item.longname, displayName.replace( /\b(module|event):/g, '' ) )}</li>`;
 
 				itemsSeen[ item.longname ] = true;
 
@@ -392,13 +392,13 @@ function buildMainNav( items, itemsSeen, linktoFn ) {
 
 		for ( const [ mainCategory, map ] of hierarchy ) {
 
-			nav += `<h2>${mainCategory}</h2>`;
+			nav += `<h2>${mainCategory}</h2>\n`;
 
 			const sortedMap = new Map( [ ...map.entries() ].sort() ); // sort sub categories
 
 			for ( const [ subCategory, links ] of sortedMap ) {
 
-				nav += `<h3>${subCategory}</h3>`;
+				nav += `<h3>${subCategory}</h3>\n`;
 
 				let navItems = '';
 
@@ -406,11 +406,11 @@ function buildMainNav( items, itemsSeen, linktoFn ) {
 
 				for ( const link of links ) {
 
-					navItems += link;
+					navItems += link + '\n';
 
 				}
 
-				nav += `<ul>${navItems}</ul>`;
+				nav += `<ul>\n${navItems}</ul>\n`;
 
 			}
 
@@ -441,7 +441,7 @@ function buildGlobalsNav( globals, seen ) {
 
 				if ( tslTag !== undefined ) {
 
-					tslNav += `<li data-name="${longname}">${linkto( longname, name )}</li>`;
+					tslNav += `<li>${linkto( longname, name )}</li>\n`;
 
 					seen[ longname ] = true;
 
@@ -451,7 +451,7 @@ function buildGlobalsNav( globals, seen ) {
 
 		} );
 
-		nav += `<h2>TSL</h2><ul>${tslNav}</ul>`;
+		nav += `<h2>TSL</h2>\n<ul>\n${tslNav}</ul>\n`;
 
 		// Globals
 
@@ -461,7 +461,7 @@ function buildGlobalsNav( globals, seen ) {
 
 			if ( kind !== 'typedef' && ! hasOwnProp.call( seen, longname ) ) {
 
-				globalNav += `<li data-name="${longname}">${linkto( longname, name )}</li>`;
+				globalNav += `<li>${linkto( longname, name )}</li>\n`;
 
 			}
 
@@ -472,11 +472,11 @@ function buildGlobalsNav( globals, seen ) {
 		if ( ! globalNav ) {
 
 			// turn the heading into a link so you can actually get to the global page
-			nav += `<h3>${linkto( 'global', 'Global' )}</h3>`;
+			nav += `<h3>${linkto( 'global', 'Global' )}</h3>\n`;
 
 		} else {
 
-			nav += `<h2>Global</h2><ul>${globalNav}</ul>`;
+			nav += `<h2>Global</h2>\n<ul>\n${globalNav}</ul>\n`;
 
 		}
 

--- a/utils/docs/template/publish.js
+++ b/utils/docs/template/publish.js
@@ -743,8 +743,8 @@ exports.publish = ( taffyData, opts, tutorials ) => {
 	view.outputSourceFiles = outputSourceFiles;
 	view.ignoreInheritedSymbols = themeOpts.ignoreInheritedSymbols;
 
-	// once for all
-	view.nav = buildNav( members );
+	// Empty nav in templates - will be loaded from nav.html client-side
+	view.nav = '';
 
 	// generate the pretty-printed source files first so other pages can link to them
 	if ( outputSourceFiles ) {
@@ -794,6 +794,13 @@ exports.publish = ( taffyData, opts, tutorials ) => {
 		}
 
 	} );
+
+	// Write navigation to separate file
+	fs.writeFileSync(
+		path.join( outdir, 'nav.html' ),
+		buildNav( members ),
+		'utf8'
+	);
 
 	// search
 

--- a/utils/docs/template/static/scripts/page.js
+++ b/utils/docs/template/static/scripts/page.js
@@ -40,6 +40,26 @@
 
 } )();
 
+// Load navigation from separate file
+( function loadNavigation() {
+
+	const navContainer = document.querySelector( '#content nav' );
+
+	if ( navContainer ) {
+
+		fetch( 'nav.html' )
+			.then( response => response.text() )
+			.then( html => {
+
+				navContainer.innerHTML = html;
+
+			} )
+			.catch( err => console.error( 'Failed to load navigation:', err ) );
+
+	}
+
+} )();
+
 const panel = document.getElementById( 'panel' );
 const panelScrim = document.getElementById( 'panelScrim' );
 const expandButton = document.getElementById( 'expandButton' );

--- a/utils/docs/template/static/scripts/page.js
+++ b/utils/docs/template/static/scripts/page.js
@@ -60,6 +60,8 @@
 
 } )();
 
+//
+
 const panel = document.getElementById( 'panel' );
 const panelScrim = document.getElementById( 'panelScrim' );
 const expandButton = document.getElementById( 'expandButton' );
@@ -215,3 +217,11 @@ console.log( [
 	'                                         / __/  /  \\__  \\',
 	'                                         \\/____/\\/_____/'
 ].join( '\n' ) );
+
+// console sandbox
+
+import( '/build/three.module.js' ).then( THREE => {
+
+	window.THREE = THREE;
+
+} );

--- a/utils/docs/template/static/scripts/page.js
+++ b/utils/docs/template/static/scripts/page.js
@@ -40,7 +40,6 @@
 
 } )();
 
-// Load navigation from separate file
 ( function loadNavigation() {
 
 	const navContainer = document.querySelector( '#content nav' );
@@ -191,11 +190,9 @@ function updateNavigation() {
 
 	// select target and move into view
 
-	const liElement = document.querySelector( `li[data-name="${target}"]` );
+	const aElement = document.querySelector( `nav a[href="${filename}"], nav a[href="${filename}#${target}"]` );
 
-	if ( liElement !== null ) {
-
-		const aElement = liElement.firstChild;
+	if ( aElement !== null ) {
 
 		aElement.scrollIntoView( { block: 'center' } );
 		aElement.classList.add( 'selected' );

--- a/utils/docs/template/tmpl/augments.tmpl
+++ b/utils/docs/template/tmpl/augments.tmpl
@@ -1,10 +1,10 @@
 <?js
-    var data = obj;
-    var self = this;
+	var data = obj;
+	var self = this;
 ?>
 
 <?js if (data.augments && data.augments.length) { ?>
-    <ul><?js data.augments.forEach(function(a) { ?>
-        <li><?js= self.linkto(a, a) ?></li>
-    <?js }) ?></ul>
+	<ul><?js data.augments.forEach(function(a) { ?>
+		<li><?js= self.linkto(a, a) ?></li>
+	<?js }) ?></ul>
 <?js } ?>

--- a/utils/docs/template/tmpl/container.tmpl
+++ b/utils/docs/template/tmpl/container.tmpl
@@ -187,6 +187,11 @@
 			<?js= self.partial('method.tmpl', e) ?>
 		<?js }); ?>
 	<?js } ?>
+
+	<?js if (doc.meta && doc.meta.shortpath) { ?>
+		<h3 class="subsection-title">Source</h3>
+		<a href="https://github.com/mrdoob/three.js/blob/master/<?js= doc.meta.shortpath ?>" target="_blank" rel="noopener"><?js= doc.meta.shortpath ?></a>
+	<?js } ?>
 </article>
 
 </section>

--- a/utils/docs/template/tmpl/container.tmpl
+++ b/utils/docs/template/tmpl/container.tmpl
@@ -1,192 +1,192 @@
 <?js
-    var self = this;
-    var isGlobalPage;
+	var self = this;
+	var isGlobalPage;
 
-    docs.forEach(function(doc, i) {
+	docs.forEach(function(doc, i) {
 ?>
 
 <?js
-    // we only need to check this once
-    if (typeof isGlobalPage === 'undefined') {
-        isGlobalPage = (doc.kind === 'globalobj');
-    }
+	// we only need to check this once
+	if (typeof isGlobalPage === 'undefined') {
+		isGlobalPage = (doc.kind === 'globalobj');
+	}
 ?>
 <?js if (doc.kind === 'mainpage' || (doc.kind === 'package')) { ?>
-    <?js= self.partial('mainpage.tmpl', doc) ?>
+	<?js= self.partial('mainpage.tmpl', doc) ?>
 <?js } else if (doc.kind === 'source') { ?>
-    <?js= self.partial('source.tmpl', doc) ?>
+	<?js= self.partial('source.tmpl', doc) ?>
 <?js } else { ?>
 
 <section>
 
 <header>
-    <?js if (!doc.longname || doc.kind !== 'module') { ?>
-        <?js if (doc.classdesc) { ?>
-            <div class="class-description"><?js= doc.classdesc ?></div>
-        <?js } ?>
-    <?js } else if (doc.kind === 'module' && doc.modules) { ?>
-        <?js doc.modules.forEach(function(module) { ?>
-            <?js if (module.classdesc) { ?>
-                <div class="class-description"><?js= module.classdesc ?></div>
-            <?js } ?>
-        <?js }) ?>
-    <?js } ?>
+	<?js if (!doc.longname || doc.kind !== 'module') { ?>
+		<?js if (doc.classdesc) { ?>
+			<div class="class-description"><?js= doc.classdesc ?></div>
+		<?js } ?>
+	<?js } else if (doc.kind === 'module' && doc.modules) { ?>
+		<?js doc.modules.forEach(function(module) { ?>
+			<?js if (module.classdesc) { ?>
+				<div class="class-description"><?js= module.classdesc ?></div>
+			<?js } ?>
+		<?js }) ?>
+	<?js } ?>
 </header>
 
 <article>
-    <div class="container-overview">
-    <?js if (doc.kind === 'module' && doc.modules) { ?>
-        <?js if (doc.description) { ?>
-            <div class="description"><?js= doc.description ?></div>
-        <?js } ?>
+	<div class="container-overview">
+	<?js if (doc.kind === 'module' && doc.modules) { ?>
+		<?js if (doc.description) { ?>
+			<div class="description"><?js= doc.description ?></div>
+		<?js } ?>
 
-        <?js doc.modules.forEach(function(module) { ?>
-            <?js= self.partial('method.tmpl', module) ?>
-        <?js }) ?>
-    <?js } else if (doc.kind === 'class' || (doc.kind === 'namespace' && doc.signature)) { ?>
-        <?js= self.partial('method.tmpl', doc) ?>
-    <?js } else { ?>
-        <?js if (doc.description) { ?>
-            <div class="description"><?js= doc.description ?></div>
-        <?js } ?>
+		<?js doc.modules.forEach(function(module) { ?>
+			<?js= self.partial('method.tmpl', module) ?>
+		<?js }) ?>
+	<?js } else if (doc.kind === 'class' || (doc.kind === 'namespace' && doc.signature)) { ?>
+		<?js= self.partial('method.tmpl', doc) ?>
+	<?js } else { ?>
+		<?js if (doc.description) { ?>
+			<div class="description"><?js= doc.description ?></div>
+		<?js } ?>
 
-        <?js= self.partial('details.tmpl', doc) ?>
+		<?js= self.partial('details.tmpl', doc) ?>
 
-        <?js if (doc.examples && doc.examples.length) { ?>
-            <h3>Example<?js= doc.examples.length > 1? 's':'' ?></h3>
-            <?js= self.partial('examples.tmpl', doc.examples) ?>
-        <?js } ?>
-    <?js } ?>
-    </div>
+		<?js if (doc.examples && doc.examples.length) { ?>
+			<h3>Example<?js= doc.examples.length > 1? 's':'' ?></h3>
+			<?js= self.partial('examples.tmpl', doc.examples) ?>
+		<?js } ?>
+	<?js } ?>
+	</div>
 
-    <?js if (doc.augments && doc.augments.length) { ?>
-        <h3 class="subsection-title">Extends</h3>
+	<?js if (doc.augments && doc.augments.length) { ?>
+		<h3 class="subsection-title">Extends</h3>
 
-        <?js= self.partial('augments.tmpl', doc) ?>
-    <?js } ?>
+		<?js= self.partial('augments.tmpl', doc) ?>
+	<?js } ?>
 
-    <?js if (doc.import) { ?>
-        <h3 class="subsection-title">Import</h3>
-        <?js= doc.name ?> is an addon, and must be imported explicitly, see <a href="https://threejs.org/manual/#en/installation" target="_blank">Installation#Addons</a>.
-        <pre class="prettyprint source lang-js"><code><?js= doc.import ?></code></pre>
-    <?js } ?>
+	<?js if (doc.import) { ?>
+		<h3 class="subsection-title">Import</h3>
+		<?js= doc.name ?> is an addon, and must be imported explicitly, see <a href="https://threejs.org/manual/#en/installation" target="_blank">Installation#Addons</a>.
+		<pre class="prettyprint source lang-js"><code><?js= doc.import ?></code></pre>
+	<?js } ?>
 
-    <?js if (doc.requires && doc.requires.length) { ?>
-        <h3 class="subsection-title">Requires</h3>
+	<?js if (doc.requires && doc.requires.length) { ?>
+		<h3 class="subsection-title">Requires</h3>
 
-        <ul><?js doc.requires.forEach(function(r) { ?>
-            <li><?js= self.linkto(r, r) ?></li>
-        <?js }); ?></ul>
-    <?js } ?>
+		<ul><?js doc.requires.forEach(function(r) { ?>
+			<li><?js= self.linkto(r, r) ?></li>
+		<?js }); ?></ul>
+	<?js } ?>
 
-    <?js
-        var ignoreInheritedSymbols = { ...(self.ignoreInheritedSymbols ? { inherited: {isUndefined: true} } : {}) };
-        var classes = self.find({kind: 'class', memberof: doc.longname});
-        if (!isGlobalPage && classes && classes.length) {
-    ?>
-        <h3 class="subsection-title">Classes</h3>
+	<?js
+		var ignoreInheritedSymbols = { ...(self.ignoreInheritedSymbols ? { inherited: {isUndefined: true} } : {}) };
+		var classes = self.find({kind: 'class', memberof: doc.longname});
+		if (!isGlobalPage && classes && classes.length) {
+	?>
+		<h3 class="subsection-title">Classes</h3>
 
-        <dl><?js classes.forEach(function(c) { ?>
-            <dt><?js= self.linkto(c.longname, c.name) ?></dt>
-            <dd><?js if (c.summary) { ?><?js= c.summary ?><?js } ?></dd>
-        <?js }); ?></dl>
-    <?js } ?>
+		<dl><?js classes.forEach(function(c) { ?>
+			<dt><?js= self.linkto(c.longname, c.name) ?></dt>
+			<dd><?js if (c.summary) { ?><?js= c.summary ?><?js } ?></dd>
+		<?js }); ?></dl>
+	<?js } ?>
 
-    <?js
-        var interfaces = self.find({kind: 'interface', memberof: doc.longname, ...ignoreInheritedSymbols});
-        if (!isGlobalPage && interfaces && interfaces.length) {
-    ?>
-        <h3 class="subsection-title">Interfaces</h3>
+	<?js
+		var interfaces = self.find({kind: 'interface', memberof: doc.longname, ...ignoreInheritedSymbols});
+		if (!isGlobalPage && interfaces && interfaces.length) {
+	?>
+		<h3 class="subsection-title">Interfaces</h3>
 
-        <dl><?js interfaces.forEach(function(i) { ?>
-            <dt><?js= self.linkto(i.longname, i.name) ?></dt>
-            <dd><?js if (i.summary) { ?><?js= i.summary ?><?js } ?></dd>
-        <?js }); ?></dl>
-    <?js } ?>
+		<dl><?js interfaces.forEach(function(i) { ?>
+			<dt><?js= self.linkto(i.longname, i.name) ?></dt>
+			<dd><?js if (i.summary) { ?><?js= i.summary ?><?js } ?></dd>
+		<?js }); ?></dl>
+	<?js } ?>
 
-    <?js
-        var mixins = self.find({kind: 'mixin', memberof: doc.longname, ...ignoreInheritedSymbols});
-        if (!isGlobalPage && mixins && mixins.length) {
-    ?>
-        <h3 class="subsection-title">Mixins</h3>
+	<?js
+		var mixins = self.find({kind: 'mixin', memberof: doc.longname, ...ignoreInheritedSymbols});
+		if (!isGlobalPage && mixins && mixins.length) {
+	?>
+		<h3 class="subsection-title">Mixins</h3>
 
-        <dl><?js mixins.forEach(function(m) { ?>
-            <dt><?js= self.linkto(m.longname, m.name) ?></dt>
-            <dd><?js if (m.summary) { ?><?js= m.summary ?><?js } ?></dd>
-        <?js }); ?></dl>
-    <?js } ?>
+		<dl><?js mixins.forEach(function(m) { ?>
+			<dt><?js= self.linkto(m.longname, m.name) ?></dt>
+			<dd><?js if (m.summary) { ?><?js= m.summary ?><?js } ?></dd>
+		<?js }); ?></dl>
+	<?js } ?>
 
-    <?js
-        var namespaces = self.find({kind: 'namespace', memberof: doc.longname, ...ignoreInheritedSymbols});
-        if (!isGlobalPage && namespaces && namespaces.length) {
-    ?>
-        <h3 class="subsection-title">Namespaces</h3>
+	<?js
+		var namespaces = self.find({kind: 'namespace', memberof: doc.longname, ...ignoreInheritedSymbols});
+		if (!isGlobalPage && namespaces && namespaces.length) {
+	?>
+		<h3 class="subsection-title">Namespaces</h3>
 
-        <dl><?js namespaces.forEach(function(n) { ?>
-            <dt><?js= self.linkto(n.longname, n.name) ?></dt>
-            <dd><?js if (n.summary) { ?><?js= n.summary ?><?js } ?></dd>
-        <?js }); ?></dl>
-    <?js } ?>
+		<dl><?js namespaces.forEach(function(n) { ?>
+			<dt><?js= self.linkto(n.longname, n.name) ?></dt>
+			<dd><?js if (n.summary) { ?><?js= n.summary ?><?js } ?></dd>
+		<?js }); ?></dl>
+	<?js } ?>
 
-    <?js
-        var members = self.find({kind: 'member', memberof: isGlobalPage ? {isUndefined: true} : doc.longname, ...ignoreInheritedSymbols});
+	<?js
+		var members = self.find({kind: 'member', memberof: isGlobalPage ? {isUndefined: true} : doc.longname, ...ignoreInheritedSymbols});
 
-        // symbols that are assigned to module.exports are not globals, even though they're not a memberof anything
-        if (isGlobalPage && members && members.length && members.forEach) {
-            members = members.filter(function(m) {
-                return m.longname && m.longname.indexOf('module:') !== 0;
-            });
-        }
-        if (members && members.length && members.forEach) {
-    ?>
-        <h3 class="subsection-title">Members</h3>
+		// symbols that are assigned to module.exports are not globals, even though they're not a memberof anything
+		if (isGlobalPage && members && members.length && members.forEach) {
+			members = members.filter(function(m) {
+				return m.longname && m.longname.indexOf('module:') !== 0;
+			});
+		}
+		if (members && members.length && members.forEach) {
+	?>
+		<h3 class="subsection-title">Members</h3>
 
-        <?js members.forEach(function(p) { ?>
-            <?js= self.partial('members.tmpl', p) ?>
-        <?js }); ?>
-    <?js } ?>
+		<?js members.forEach(function(p) { ?>
+			<?js= self.partial('members.tmpl', p) ?>
+		<?js }); ?>
+	<?js } ?>
 
-    <?js
-        var methods = self.find({kind: 'function', memberof: isGlobalPage ? {isUndefined: true} : doc.longname, ...ignoreInheritedSymbols});
-        if (methods && methods.length && methods.forEach) {
-    ?>
-        <h3 class="subsection-title">Methods</h3>
+	<?js
+		var methods = self.find({kind: 'function', memberof: isGlobalPage ? {isUndefined: true} : doc.longname, ...ignoreInheritedSymbols});
+		if (methods && methods.length && methods.forEach) {
+	?>
+		<h3 class="subsection-title">Methods</h3>
 
-        <?js methods.forEach(function(m) { ?>
-            <?js= self.partial('method.tmpl', m) ?>
-        <?js }); ?>
-    <?js } ?>
+		<?js methods.forEach(function(m) { ?>
+			<?js= self.partial('method.tmpl', m) ?>
+		<?js }); ?>
+	<?js } ?>
 
-    <?js
-        var typedefs = self.find({kind: 'typedef', memberof: isGlobalPage ? {isUndefined: true} : doc.longname, ...ignoreInheritedSymbols});
-        if (typedefs && typedefs.length && typedefs.forEach) {
-    ?>
-        <h3 class="subsection-title">Type Definitions</h3>
+	<?js
+		var typedefs = self.find({kind: 'typedef', memberof: isGlobalPage ? {isUndefined: true} : doc.longname, ...ignoreInheritedSymbols});
+		if (typedefs && typedefs.length && typedefs.forEach) {
+	?>
+		<h3 class="subsection-title">Type Definitions</h3>
 
-        <?js typedefs.forEach(function(e) {
-                if (e.signature) {
-            ?>
-                <?js= self.partial('method.tmpl', e) ?>
-            <?js
-                }
-                else {
-            ?>
-                <?js= self.partial('members.tmpl', e) ?>
-            <?js
-                }
-            }); ?>
-    <?js } ?>
+		<?js typedefs.forEach(function(e) {
+				if (e.signature) {
+			?>
+				<?js= self.partial('method.tmpl', e) ?>
+			<?js
+				}
+				else {
+			?>
+				<?js= self.partial('members.tmpl', e) ?>
+			<?js
+				}
+			}); ?>
+	<?js } ?>
 
-    <?js
-        var events = self.find({kind: 'event', memberof: isGlobalPage ? {isUndefined: true} : doc.longname, ...ignoreInheritedSymbols});
-        if (events && events.length && events.forEach) {
-    ?>
-        <h3 class="subsection-title">Events</h3>
+	<?js
+		var events = self.find({kind: 'event', memberof: isGlobalPage ? {isUndefined: true} : doc.longname, ...ignoreInheritedSymbols});
+		if (events && events.length && events.forEach) {
+	?>
+		<h3 class="subsection-title">Events</h3>
 
-        <?js events.forEach(function(e) { ?>
-            <?js= self.partial('method.tmpl', e) ?>
-        <?js }); ?>
-    <?js } ?>
+		<?js events.forEach(function(e) { ?>
+			<?js= self.partial('method.tmpl', e) ?>
+		<?js }); ?>
+	<?js } ?>
 </article>
 
 </section>

--- a/utils/docs/template/tmpl/details.tmpl
+++ b/utils/docs/template/tmpl/details.tmpl
@@ -5,139 +5,139 @@ var defaultObjectClass = '';
 
 // Check if the default value is an object or array; if so, apply code highlighting
 if (data.defaultvalue && (data.defaultvaluetype === 'object' || data.defaultvaluetype === 'array')) {
-    data.defaultvalue = "<pre class=\"prettyprint\"><code>" + data.defaultvalue + "</code></pre>";
-    defaultObjectClass = ' class="object-value"';
+	data.defaultvalue = "<pre class=\"prettyprint\"><code>" + data.defaultvalue + "</code></pre>";
+	defaultObjectClass = ' class="object-value"';
 }
 ?>
 <?js
-    var properties = data.properties;
-    if (properties && properties.length && properties.forEach && !data.hideconstructor) {
+	var properties = data.properties;
+	if (properties && properties.length && properties.forEach && !data.hideconstructor) {
 ?>
 
-    <h5 class="subsection-title">Properties:</h5>
+	<h5 class="subsection-title">Properties:</h5>
 
-    <?js= this.partial('properties.tmpl', data) ?>
+	<?js= this.partial('properties.tmpl', data) ?>
 
 <?js } ?>
 
 <dl class="details">
 
-    <?js if (data.version) {?>
-    <dt class="tag-version">Version:</dt>
-    <dd class="tag-version"><ul class="dummy"><li><?js= version ?></li></ul></dd>
-    <?js } ?>
+	<?js if (data.version) {?>
+	<dt class="tag-version">Version:</dt>
+	<dd class="tag-version"><ul class="dummy"><li><?js= version ?></li></ul></dd>
+	<?js } ?>
 
-    <?js if (data.since) {?>
-    <dt class="tag-since">Since:</dt>
-    <dd class="tag-since"><ul class="dummy"><li><?js= since ?></li></ul></dd>
-    <?js } ?>
+	<?js if (data.since) {?>
+	<dt class="tag-since">Since:</dt>
+	<dd class="tag-since"><ul class="dummy"><li><?js= since ?></li></ul></dd>
+	<?js } ?>
 
-    <?js if (data.inherited && data.inherits && !data.overrides) { ?>
-    <dt class="inherited-from">Inherited From:</dt>
-    <dd class="inherited-from"><ul class="dummy"><li>
-        <?js= this.linkto(data.inherits, this.htmlsafe(data.inherits)) ?>
-    </li></ul></dd>
-    <?js } ?>
+	<?js if (data.inherited && data.inherits && !data.overrides) { ?>
+	<dt class="inherited-from">Inherited From:</dt>
+	<dd class="inherited-from"><ul class="dummy"><li>
+		<?js= this.linkto(data.inherits, this.htmlsafe(data.inherits)) ?>
+	</li></ul></dd>
+	<?js } ?>
 
-    <?js if (data.overrides) { ?>
-    <dt class="tag-overrides">Overrides:</dt>
-    <dd class="tag-overrides"><ul class="dummy"><li>
-        <?js= this.linkto(data.overrides, this.htmlsafe(data.overrides)) ?>
-    </li></ul></dd>
-    <?js } ?>
+	<?js if (data.overrides) { ?>
+	<dt class="tag-overrides">Overrides:</dt>
+	<dd class="tag-overrides"><ul class="dummy"><li>
+		<?js= this.linkto(data.overrides, this.htmlsafe(data.overrides)) ?>
+	</li></ul></dd>
+	<?js } ?>
 
-    <?js if (data.implementations && data.implementations.length) { ?>
-    <dt class="implementations">Implementations:</dt>
-    <dd class="implementations"><ul>
-        <?js data.implementations.forEach(function(impl) { ?>
-            <li><?js= self.linkto(impl, self.htmlsafe(impl)) ?></li>
-        <?js }); ?>
-    </ul></dd>
-    <?js } ?>
+	<?js if (data.implementations && data.implementations.length) { ?>
+	<dt class="implementations">Implementations:</dt>
+	<dd class="implementations"><ul>
+		<?js data.implementations.forEach(function(impl) { ?>
+			<li><?js= self.linkto(impl, self.htmlsafe(impl)) ?></li>
+		<?js }); ?>
+	</ul></dd>
+	<?js } ?>
 
-    <?js if (data.implements && data.implements.length) { ?>
-    <dt class="implements">Implements:</dt>
-    <dd class="implements"><ul>
-        <?js data.implements.forEach(function(impl) { ?>
-            <li><?js= self.linkto(impl, self.htmlsafe(impl)) ?></li>
-        <?js }); ?>
-    </ul></dd>
-    <?js } ?>
+	<?js if (data.implements && data.implements.length) { ?>
+	<dt class="implements">Implements:</dt>
+	<dd class="implements"><ul>
+		<?js data.implements.forEach(function(impl) { ?>
+			<li><?js= self.linkto(impl, self.htmlsafe(impl)) ?></li>
+		<?js }); ?>
+	</ul></dd>
+	<?js } ?>
 
-    <?js if (data.mixes && data.mixes.length) { ?>
-        <dt class="mixes">Mixes In:</dt>
+	<?js if (data.mixes && data.mixes.length) { ?>
+		<dt class="mixes">Mixes In:</dt>
 
-        <dd class="mixes"><ul>
-        <?js data.mixes.forEach(function(a) { ?>
-            <li><?js= self.linkto(a, a) ?></li>
-        <?js }); ?>
-        </ul></dd>
-    <?js } ?>
+		<dd class="mixes"><ul>
+		<?js data.mixes.forEach(function(a) { ?>
+			<li><?js= self.linkto(a, a) ?></li>
+		<?js }); ?>
+		</ul></dd>
+	<?js } ?>
 
-    <?js if (data.deprecated) { ?>
-        <dt class="important tag-deprecated">Deprecated:</dt><?js
-            if (data.deprecated === true) { ?><dd class="yes-def tag-deprecated"><ul class="dummy"><li>Yes</li></ul></dd><?js }
-            else { ?><dd><ul class="dummy"><li><?js= data.deprecated ?></li></ul></dd><?js }
-        ?>
-    <?js } ?>
+	<?js if (data.deprecated) { ?>
+		<dt class="important tag-deprecated">Deprecated:</dt><?js
+			if (data.deprecated === true) { ?><dd class="yes-def tag-deprecated"><ul class="dummy"><li>Yes</li></ul></dd><?js }
+			else { ?><dd><ul class="dummy"><li><?js= data.deprecated ?></li></ul></dd><?js }
+		?>
+	<?js } ?>
 
-    <?js if (data.author && author.length) {?>
-    <dt class="tag-author">Author:</dt>
-    <dd class="tag-author">
-        <ul><?js author.forEach(function(a) { ?>
-            <li><?js= self.resolveAuthorLinks(a) ?></li>
-        <?js }); ?></ul>
-    </dd>
-    <?js } ?>
+	<?js if (data.author && author.length) {?>
+	<dt class="tag-author">Author:</dt>
+	<dd class="tag-author">
+		<ul><?js author.forEach(function(a) { ?>
+			<li><?js= self.resolveAuthorLinks(a) ?></li>
+		<?js }); ?></ul>
+	</dd>
+	<?js } ?>
 
-    <?js if (data.copyright) {?>
-    <dt class="tag-copyright">Copyright:</dt>
-    <dd class="tag-copyright"><ul class="dummy"><li><?js= copyright ?></li></ul></dd>
-    <?js } ?>
+	<?js if (data.copyright) {?>
+	<dt class="tag-copyright">Copyright:</dt>
+	<dd class="tag-copyright"><ul class="dummy"><li><?js= copyright ?></li></ul></dd>
+	<?js } ?>
 
-    <?js if (data.license) {?>
-    <dt class="tag-license">License:</dt>
-    <dd class="tag-license"><ul class="dummy"><li><?js= license ?></li></ul></dd>
-    <?js } ?>
+	<?js if (data.license) {?>
+	<dt class="tag-license">License:</dt>
+	<dd class="tag-license"><ul class="dummy"><li><?js= license ?></li></ul></dd>
+	<?js } ?>
 
-    <?js if (data.defaultvalue) {?>
-    <dt class="tag-default">Default Value:</dt>
-    <dd class="tag-default"><ul class="dummy">
-            <li<?js= defaultObjectClass ?>><?js= data.defaultvalue ?></li>
-        </ul></dd>
-    <?js } ?>
+	<?js if (data.defaultvalue) {?>
+	<dt class="tag-default">Default Value:</dt>
+	<dd class="tag-default"><ul class="dummy">
+			<li<?js= defaultObjectClass ?>><?js= data.defaultvalue ?></li>
+		</ul></dd>
+	<?js } ?>
 
-    <?js if (data.meta) {?>
-    <dt class="tag-source">Source:</dt>
-    <dd class="tag-source"><ul class="dummy"><li>
-        <a href="https://github.com/mrdoob/three.js/blob/master/<?js= meta.shortpath ?>#L<?js= meta.lineno ?>" target="_blank" rel="noopener"><?js= meta.shortpath ?>, line <?js= meta.lineno ?></a>
-    </li></ul></dd>
-    <?js } ?>
+	<?js if (data.meta) {?>
+	<dt class="tag-source">Source:</dt>
+	<dd class="tag-source"><ul class="dummy"><li>
+		<a href="https://github.com/mrdoob/three.js/blob/master/<?js= meta.shortpath ?>#L<?js= meta.lineno ?>" target="_blank" rel="noopener"><?js= meta.shortpath ?>, line <?js= meta.lineno ?></a>
+	</li></ul></dd>
+	<?js } ?>
 
-    <?js if (data.tutorials && tutorials.length) {?>
-    <dt class="tag-tutorial">Tutorials:</dt>
-    <dd class="tag-tutorial">
-        <ul><?js tutorials.forEach(function(t) { ?>
-            <li><?js= self.tutoriallink(t) ?></li>
-        <?js }); ?></ul>
-    </dd>
-    <?js } ?>
+	<?js if (data.tutorials && tutorials.length) {?>
+	<dt class="tag-tutorial">Tutorials:</dt>
+	<dd class="tag-tutorial">
+		<ul><?js tutorials.forEach(function(t) { ?>
+			<li><?js= self.tutoriallink(t) ?></li>
+		<?js }); ?></ul>
+	</dd>
+	<?js } ?>
 
-    <?js if (data.see && see.length) {?>
-    <dt class="tag-see">See:</dt>
-    <dd class="tag-see">
-        <ul><?js see.forEach(function(s) { ?>
-            <li><?js= self.linkto(s) ?></li>
-        <?js }); ?></ul>
-    </dd>
-    <?js } ?>
+	<?js if (data.see && see.length) {?>
+	<dt class="tag-see">See:</dt>
+	<dd class="tag-see">
+		<ul><?js see.forEach(function(s) { ?>
+			<li><?js= self.linkto(s) ?></li>
+		<?js }); ?></ul>
+	</dd>
+	<?js } ?>
 
-    <?js if (data.todo && todo.length) {?>
-    <dt class="tag-todo">To Do:</dt>
-    <dd class="tag-todo">
-        <ul><?js todo.forEach(function(t) { ?>
-            <li><?js= t ?></li>
-        <?js }); ?></ul>
-    </dd>
-    <?js } ?>
+	<?js if (data.todo && todo.length) {?>
+	<dt class="tag-todo">To Do:</dt>
+	<dd class="tag-todo">
+		<ul><?js todo.forEach(function(t) { ?>
+			<li><?js= t ?></li>
+		<?js }); ?></ul>
+	</dd>
+	<?js } ?>
 </dl>

--- a/utils/docs/template/tmpl/details.tmpl
+++ b/utils/docs/template/tmpl/details.tmpl
@@ -107,10 +107,10 @@ if (data.defaultvalue && (data.defaultvaluetype === 'object' || data.defaultvalu
         </ul></dd>
     <?js } ?>
 
-    <?js if (data.meta && self.outputSourceFiles) {?>
+    <?js if (data.meta) {?>
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <?js= self.linkto(meta.shortpath) ?>, <?js= self.linkto(meta.shortpath, 'line ' + meta.lineno, null, 'line' + meta.lineno) ?>
+        <a href="https://github.com/mrdoob/three.js/blob/master/<?js= meta.shortpath ?>#L<?js= meta.lineno ?>" target="_blank" rel="noopener"><?js= meta.shortpath ?>, line <?js= meta.lineno ?></a>
     </li></ul></dd>
     <?js } ?>
 

--- a/utils/docs/template/tmpl/details.tmpl
+++ b/utils/docs/template/tmpl/details.tmpl
@@ -101,12 +101,6 @@ if (data.defaultvalue && (data.defaultvaluetype === 'object' || data.defaultvalu
 	<dd class="tag-default"<?js= defaultObjectClass ?>><?js= data.defaultvalue ?></dd>
 	<?js } ?>
 
-	<?js if (data.meta) {?>
-	<dt class="tag-source">Source:</dt>
-	<dd class="tag-source">
-		<a href="https://github.com/mrdoob/three.js/blob/master/<?js= meta.shortpath ?>#L<?js= meta.lineno ?>" target="_blank" rel="noopener"><?js= meta.shortpath ?>, line <?js= meta.lineno ?></a>
-	</dd>
-	<?js } ?>
 
 	<?js if (data.tutorials && tutorials.length) {?>
 	<dt class="tag-tutorial">Tutorials:</dt>

--- a/utils/docs/template/tmpl/details.tmpl
+++ b/utils/docs/template/tmpl/details.tmpl
@@ -24,26 +24,22 @@ if (data.defaultvalue && (data.defaultvaluetype === 'object' || data.defaultvalu
 
 	<?js if (data.version) {?>
 	<dt class="tag-version">Version:</dt>
-	<dd class="tag-version"><ul class="dummy"><li><?js= version ?></li></ul></dd>
+	<dd class="tag-version"><?js= version ?></dd>
 	<?js } ?>
 
 	<?js if (data.since) {?>
 	<dt class="tag-since">Since:</dt>
-	<dd class="tag-since"><ul class="dummy"><li><?js= since ?></li></ul></dd>
+	<dd class="tag-since"><?js= since ?></dd>
 	<?js } ?>
 
 	<?js if (data.inherited && data.inherits && !data.overrides) { ?>
 	<dt class="inherited-from">Inherited From:</dt>
-	<dd class="inherited-from"><ul class="dummy"><li>
-		<?js= this.linkto(data.inherits, this.htmlsafe(data.inherits)) ?>
-	</li></ul></dd>
+	<dd class="inherited-from"><?js= this.linkto(data.inherits, this.htmlsafe(data.inherits)) ?></dd>
 	<?js } ?>
 
 	<?js if (data.overrides) { ?>
 	<dt class="tag-overrides">Overrides:</dt>
-	<dd class="tag-overrides"><ul class="dummy"><li>
-		<?js= this.linkto(data.overrides, this.htmlsafe(data.overrides)) ?>
-	</li></ul></dd>
+	<dd class="tag-overrides"><?js= this.linkto(data.overrides, this.htmlsafe(data.overrides)) ?></dd>
 	<?js } ?>
 
 	<?js if (data.implementations && data.implementations.length) { ?>
@@ -76,8 +72,8 @@ if (data.defaultvalue && (data.defaultvaluetype === 'object' || data.defaultvalu
 
 	<?js if (data.deprecated) { ?>
 		<dt class="important tag-deprecated">Deprecated:</dt><?js
-			if (data.deprecated === true) { ?><dd class="yes-def tag-deprecated"><ul class="dummy"><li>Yes</li></ul></dd><?js }
-			else { ?><dd><ul class="dummy"><li><?js= data.deprecated ?></li></ul></dd><?js }
+			if (data.deprecated === true) { ?><dd class="yes-def tag-deprecated">Yes</dd><?js }
+			else { ?><dd><?js= data.deprecated ?></dd><?js }
 		?>
 	<?js } ?>
 
@@ -92,26 +88,24 @@ if (data.defaultvalue && (data.defaultvaluetype === 'object' || data.defaultvalu
 
 	<?js if (data.copyright) {?>
 	<dt class="tag-copyright">Copyright:</dt>
-	<dd class="tag-copyright"><ul class="dummy"><li><?js= copyright ?></li></ul></dd>
+	<dd class="tag-copyright"><?js= copyright ?></dd>
 	<?js } ?>
 
 	<?js if (data.license) {?>
 	<dt class="tag-license">License:</dt>
-	<dd class="tag-license"><ul class="dummy"><li><?js= license ?></li></ul></dd>
+	<dd class="tag-license"><?js= license ?></dd>
 	<?js } ?>
 
 	<?js if (data.defaultvalue) {?>
-	<dt class="tag-default">Default Value:</dt>
-	<dd class="tag-default"><ul class="dummy">
-			<li<?js= defaultObjectClass ?>><?js= data.defaultvalue ?></li>
-		</ul></dd>
+	<dt class="tag-default">Default:</dt>
+	<dd class="tag-default"<?js= defaultObjectClass ?>><?js= data.defaultvalue ?></dd>
 	<?js } ?>
 
 	<?js if (data.meta) {?>
 	<dt class="tag-source">Source:</dt>
-	<dd class="tag-source"><ul class="dummy"><li>
+	<dd class="tag-source">
 		<a href="https://github.com/mrdoob/three.js/blob/master/<?js= meta.shortpath ?>#L<?js= meta.lineno ?>" target="_blank" rel="noopener"><?js= meta.shortpath ?>, line <?js= meta.lineno ?></a>
-	</li></ul></dd>
+	</dd>
 	<?js } ?>
 
 	<?js if (data.tutorials && tutorials.length) {?>

--- a/utils/docs/template/tmpl/exceptions.tmpl
+++ b/utils/docs/template/tmpl/exceptions.tmpl
@@ -1,32 +1,32 @@
 <?js
-    var data = obj;
+	var data = obj;
 ?>
 <?js if (data.description && data.type && data.type.names) { ?>
 <dl>
-    <dt>
-        <div class="param-desc">
-        <?js= data.description ?>
-        </div>
-    </dt>
-    <dd></dd>
-    <dt>
-        <dl>
-            <dt>
-                Type
-            </dt>
-            <dd>
-                <?js= this.partial('type.tmpl', data.type.names) ?>
-            </dd>
-        </dl>
-    </dt>
-    <dd></dd>
+	<dt>
+		<div class="param-desc">
+		<?js= data.description ?>
+		</div>
+	</dt>
+	<dd></dd>
+	<dt>
+		<dl>
+			<dt>
+				Type
+			</dt>
+			<dd>
+				<?js= this.partial('type.tmpl', data.type.names) ?>
+			</dd>
+		</dl>
+	</dt>
+	<dd></dd>
 </dl>
 <?js } else { ?>
-    <div class="param-desc">
-    <?js if (data.description) { ?>
-        <?js= data.description ?>
-    <?js } else if (data.type && data.type.names) { ?>
-        <?js= this.partial('type.tmpl', data.type.names) ?>
-    <?js } ?>
-    </div>
+	<div class="param-desc">
+	<?js if (data.description) { ?>
+		<?js= data.description ?>
+	<?js } else if (data.type && data.type.names) { ?>
+		<?js= this.partial('type.tmpl', data.type.names) ?>
+	<?js } ?>
+	</div>
 <?js } ?>

--- a/utils/docs/template/tmpl/layout.tmpl
+++ b/utils/docs/template/tmpl/layout.tmpl
@@ -1,64 +1,64 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="utf-8">
-    <title><?js= title || 'Home' ?> - three.js docs</title>
-    <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
-    <link rel="shortcut icon" href="/files/favicon_white.ico" media="(prefers-color-scheme: dark)"/>
-    <link rel="shortcut icon" href="/files/favicon.ico" media="(prefers-color-scheme: light)" />
-    <link rel="stylesheet" type="text/css" href="/files/main.css">
+	<meta charset="utf-8">
+	<title><?js= title || 'Home' ?> - Three.js Docs</title>
+	<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+	<link rel="shortcut icon" href="/files/favicon_white.ico" media="(prefers-color-scheme: dark)"/>
+	<link rel="shortcut icon" href="/files/favicon.ico" media="(prefers-color-scheme: light)" />
+	<link rel="stylesheet" type="text/css" href="/files/main.css">
 
-    <script src="scripts/fuse/fuse.js"></script>
-    <script src="scripts/prettify/prettify.js"></script>
-    <script src="scripts/prettify/lang-css.js"></script>
+	<script src="scripts/fuse/fuse.js"></script>
+	<script src="scripts/prettify/prettify.js"></script>
+	<script src="scripts/prettify/lang-css.js"></script>
 
-    <link type="text/css" rel="stylesheet" href="styles/prettify-three.css">
-    <link type="text/css" rel="stylesheet" href="styles/page.css">
+	<link type="text/css" rel="stylesheet" href="styles/prettify-three.css">
+	<link type="text/css" rel="stylesheet" href="styles/page.css">
 
-    <!-- console sandbox -->
-    <script type="module">
-        import * as THREE from '/build/three.module.js';
-        window.THREE = THREE;
-    </script>
+	<!-- console sandbox -->
+	<script type="module">
+		import * as THREE from '/build/three.module.js';
+		window.THREE = THREE;
+	</script>
 </head>
 
 <body>
 
 <div id="panel">
 
-    <div id="header">
-        <h1><a href="https://threejs.org">three.js</a></h1>
+	<div id="header">
+		<h1><a href="https://threejs.org">three.js</a></h1>
 
-        <div id="sections">
-            <span class="selected">docs</span>
-            <a href="/examples/#webgl_animation_keyframes">examples</a>
-        </div>
-        <div id="expandButton"></div>
-    </div>
+		<div id="sections">
+			<span class="selected">docs</span>
+			<a href="/examples/#webgl_animation_keyframes">examples</a>
+		</div>
+		<div id="expandButton"></div>
+	</div>
 
-    <div id="panelScrim"></div>
+	<div id="panelScrim"></div>
 
-    <div id="contentWrapper">
-        <div id="inputWrapper">
-            <input placeholder="" type="text" id="filterInput" autocorrect="off" autocapitalize="off" spellcheck="false" />
-            <div id="clearSearchButton"></div>
-        </div>
-        <div id="content">
-            <nav>
-                <?js= this.nav ?>
-            </nav>
-        </div>
-    </div>
+	<div id="contentWrapper">
+		<div id="inputWrapper">
+			<input placeholder="" type="text" id="filterInput" autocorrect="off" autocapitalize="off" spellcheck="false" />
+			<div id="clearSearchButton"></div>
+		</div>
+		<div id="content">
+			<nav>
+				<?js= this.nav ?>
+			</nav>
+		</div>
+	</div>
 </div>
 
 <div id="viewer">
-    <div id="page">
-        <div id="page-content">
-            <h1><?js= title ?></h1>
-            <?js= content ?>
-        </div>
-        <?js= this.partial('search.tmpl')?>
-    </div>
+	<div id="page">
+		<div id="page-content">
+			<h1><?js= title ?></h1>
+			<?js= content ?>
+		</div>
+		<?js= this.partial('search.tmpl')?>
+	</div>
 </div>
 
 <script src="scripts/page.js"></script>

--- a/utils/docs/template/tmpl/layout.tmpl
+++ b/utils/docs/template/tmpl/layout.tmpl
@@ -14,12 +14,6 @@
 
 	<link type="text/css" rel="stylesheet" href="styles/prettify-three.css">
 	<link type="text/css" rel="stylesheet" href="styles/page.css">
-
-	<!-- console sandbox -->
-	<script type="module">
-		import * as THREE from '/build/three.module.js';
-		window.THREE = THREE;
-	</script>
 </head>
 
 <body>

--- a/utils/docs/template/tmpl/members.tmpl
+++ b/utils/docs/template/tmpl/members.tmpl
@@ -3,31 +3,31 @@ var data = obj;
 var self = this;
 ?>
 <div class="member">
-    <h4 class="name" id="<?js= id ?>"><?js= data.attribs + name + (data.signature ? data.signature : '') ?>
-    <a href="#<?js= id ?>" class="link-anchor">#</a>
-    </h4>
+	<h4 class="name" id="<?js= id ?>"><?js= data.attribs + name + (data.signature ? data.signature : '') ?>
+	<a href="#<?js= id ?>" class="link-anchor">#</a>
+	</h4>
 
-    <?js if (data.summary) { ?>
-    <p class="summary"><?js= summary ?></p>
-    <?js } ?>
+	<?js if (data.summary) { ?>
+	<p class="summary"><?js= summary ?></p>
+	<?js } ?>
 
-    <?js if (data.description) { ?>
-    <div class="description">
-        <?js= data.description ?>
-    </div>
-    <?js } ?>
+	<?js if (data.description) { ?>
+	<div class="description">
+		<?js= data.description ?>
+	</div>
+	<?js } ?>
 
-    <?js= this.partial('details.tmpl', data) ?>
+	<?js= this.partial('details.tmpl', data) ?>
 
-    <?js if (data.fires && fires.length) { ?>
-        <h5>Fires:</h5>
-        <ul><?js fires.forEach(function(f) { ?>
-            <li><?js= self.linkto(f) ?></li>
-        <?js }); ?></ul>
-    <?js } ?>
+	<?js if (data.fires && fires.length) { ?>
+		<h5>Fires:</h5>
+		<ul><?js fires.forEach(function(f) { ?>
+			<li><?js= self.linkto(f) ?></li>
+		<?js }); ?></ul>
+	<?js } ?>
 
-    <?js if (data.examples && examples.length) { ?>
-        <h5>Example<?js= examples.length > 1? 's':'' ?></h5>
-        <?js= this.partial('examples.tmpl', examples) ?>
-    <?js } ?>
+	<?js if (data.examples && examples.length) { ?>
+		<h5>Example<?js= examples.length > 1? 's':'' ?></h5>
+		<?js= this.partial('examples.tmpl', examples) ?>
+	<?js } ?>
 </div>

--- a/utils/docs/template/tmpl/method.tmpl
+++ b/utils/docs/template/tmpl/method.tmpl
@@ -3,129 +3,129 @@ var data = obj;
 var self = this;
 ?>
 <?js if (data.kind !== 'module' && !data.hideconstructor) { ?>
-    <?js if (data.kind === 'class' && data.classdesc) { ?>
-    <h2>Constructor</h2>
-    <?js } ?>
+	<?js if (data.kind === 'class' && data.classdesc) { ?>
+	<h2>Constructor</h2>
+	<?js } ?>
 
-    <?js if (data.kind !== 'namespace') { ?>
-    <h4 class="name name-method" id="<?js= id ?>"><?js= data.attribs + (kind === 'class' ? 'new ' : '') +
-    name + (data.signature || '') ?>
-    <a href="#<?js= id ?>" class="link-anchor">#</a>
-    </h4>
-    <?js } ?>
+	<?js if (data.kind !== 'namespace') { ?>
+	<h4 class="name name-method" id="<?js= id ?>"><?js= data.attribs + (kind === 'class' ? 'new ' : '') +
+	name + (data.signature || '') ?>
+	<a href="#<?js= id ?>" class="link-anchor">#</a>
+	</h4>
+	<?js } ?>
 
-    <?js if (data.summary) { ?>
-    <p class="summary"><?js= summary ?></p>
-    <?js } ?>
+	<?js if (data.summary) { ?>
+	<p class="summary"><?js= summary ?></p>
+	<?js } ?>
 <?js } ?>
 
 <div class="method">
-    <?js if (data.kind !== 'module' && data.description && !data.hideconstructor) { ?>
-    <div class="description">
-        <?js= data.description ?>
-    </div>
-    <?js } ?>
+	<?js if (data.kind !== 'module' && data.description && !data.hideconstructor) { ?>
+	<div class="description">
+		<?js= data.description ?>
+	</div>
+	<?js } ?>
 
-    <?js if (data.augments && data.alias && data.alias.indexOf('module:') === 0) { ?>
-        <h5>Extends:</h5>
-        <?js= self.partial('augments.tmpl', data) ?>
-    <?js } ?>
+	<?js if (data.augments && data.alias && data.alias.indexOf('module:') === 0) { ?>
+		<h5>Extends:</h5>
+		<?js= self.partial('augments.tmpl', data) ?>
+	<?js } ?>
 
-    <?js if (kind === 'event' && data.type && data.type.names) {?>
-        <h5>Type:</h5>
-        <ul>
-            <li>
-                <?js= self.partial('type.tmpl', data.type.names) ?>
-            </li>
-        </ul>
-    <?js } ?>
+	<?js if (kind === 'event' && data.type && data.type.names) {?>
+		<h5>Type:</h5>
+		<ul>
+			<li>
+				<?js= self.partial('type.tmpl', data.type.names) ?>
+			</li>
+		</ul>
+	<?js } ?>
 
-    <?js if (data['this']) { ?>
-        <h5>This:</h5>
-        <ul><li><?js= this.linkto(data['this'], data['this']) ?></li></ul>
-    <?js } ?>
+	<?js if (data['this']) { ?>
+		<h5>This:</h5>
+		<ul><li><?js= this.linkto(data['this'], data['this']) ?></li></ul>
+	<?js } ?>
 
-    <?js if (data.params && params.length && !data.hideconstructor) { ?>
-        <h5>Parameters:</h5>
-        <?js= this.partial('params.tmpl', params) ?>
-    <?js } ?>
+	<?js if (data.params && params.length && !data.hideconstructor) { ?>
+		<h5>Parameters:</h5>
+		<?js= this.partial('params.tmpl', params) ?>
+	<?js } ?>
 
-    <?js= this.partial('details.tmpl', data) ?>
+	<?js= this.partial('details.tmpl', data) ?>
 
-    <?js if (data.kind !== 'module' && data.requires && data.requires.length) { ?>
-    <h5>Requires:</h5>
-    <ul><?js data.requires.forEach(function(r) { ?>
-        <li><?js= self.linkto(r) ?></li>
-    <?js }); ?></ul>
-    <?js } ?>
+	<?js if (data.kind !== 'module' && data.requires && data.requires.length) { ?>
+	<h5>Requires:</h5>
+	<ul><?js data.requires.forEach(function(r) { ?>
+		<li><?js= self.linkto(r) ?></li>
+	<?js }); ?></ul>
+	<?js } ?>
 
-    <?js if (data.fires && fires.length) { ?>
-    <h5>Fires:</h5>
-    <ul><?js fires.forEach(function(f) { ?>
-        <li><?js= self.linkto(f) ?></li>
-    <?js }); ?></ul>
-    <?js } ?>
+	<?js if (data.fires && fires.length) { ?>
+	<h5>Fires:</h5>
+	<ul><?js fires.forEach(function(f) { ?>
+		<li><?js= self.linkto(f) ?></li>
+	<?js }); ?></ul>
+	<?js } ?>
 
-    <?js if (data.listens && listens.length) { ?>
-    <h5>Listens to Events:</h5>
-    <ul><?js listens.forEach(function(f) { ?>
-        <li><?js= self.linkto(f) ?></li>
-    <?js }); ?></ul>
-    <?js } ?>
+	<?js if (data.listens && listens.length) { ?>
+	<h5>Listens to Events:</h5>
+	<ul><?js listens.forEach(function(f) { ?>
+		<li><?js= self.linkto(f) ?></li>
+	<?js }); ?></ul>
+	<?js } ?>
 
-    <?js if (data.listeners && listeners.length) { ?>
-    <h5>Listeners of This Event:</h5>
-    <ul><?js listeners.forEach(function(f) { ?>
-        <li><?js= self.linkto(f) ?></li>
-    <?js }); ?></ul>
-    <?js } ?>
+	<?js if (data.listeners && listeners.length) { ?>
+	<h5>Listeners of This Event:</h5>
+	<ul><?js listeners.forEach(function(f) { ?>
+		<li><?js= self.linkto(f) ?></li>
+	<?js }); ?></ul>
+	<?js } ?>
 
-    <?js if (data.modifies && modifies.length) {?>
-    <h5>Modifies:</h5>
-    <?js if (modifies.length > 1) { ?><ul><?js
-        modifies.forEach(function(m) { ?>
-            <li><?js= self.partial('modifies.tmpl', m) ?></li>
-        <?js });
-    ?></ul><?js } else {
-        modifies.forEach(function(m) { ?>
-            <?js= self.partial('modifies.tmpl', m) ?>
-        <?js });
-    } } ?>
+	<?js if (data.modifies && modifies.length) {?>
+	<h5>Modifies:</h5>
+	<?js if (modifies.length > 1) { ?><ul><?js
+		modifies.forEach(function(m) { ?>
+			<li><?js= self.partial('modifies.tmpl', m) ?></li>
+		<?js });
+	?></ul><?js } else {
+		modifies.forEach(function(m) { ?>
+			<?js= self.partial('modifies.tmpl', m) ?>
+		<?js });
+	} } ?>
 
-    <?js if (data.exceptions && exceptions.length) { ?>
-    <h5>Throws:</h5>
-    <?js if (exceptions.length > 1) { ?><ul><?js
-        exceptions.forEach(function(r) { ?>
-            <li><?js= self.partial('exceptions.tmpl', r) ?></li>
-        <?js });
-    ?></ul><?js } else {
-        exceptions.forEach(function(r) { ?>
-            <?js= self.partial('exceptions.tmpl', r) ?>
-        <?js });
-    } } ?>
+	<?js if (data.exceptions && exceptions.length) { ?>
+	<h5>Throws:</h5>
+	<?js if (exceptions.length > 1) { ?><ul><?js
+		exceptions.forEach(function(r) { ?>
+			<li><?js= self.partial('exceptions.tmpl', r) ?></li>
+		<?js });
+	?></ul><?js } else {
+		exceptions.forEach(function(r) { ?>
+			<?js= self.partial('exceptions.tmpl', r) ?>
+		<?js });
+	} } ?>
 
-    <?js if (data.returns && returns.length) { ?>
-    <h5>Returns:</h5>
-    <?js if (returns.length > 1) { ?><ul><?js
-        returns.forEach(function(r) { ?>
-            <li><?js= self.partial('returns.tmpl', r) ?></li>
-        <?js });
-    ?></ul><?js } else {
-        returns.forEach(function(r) { ?>
-            <?js= self.partial('returns.tmpl', r) ?>
-        <?js });
-    } } ?>
+	<?js if (data.returns && returns.length) { ?>
+	<h5>Returns:</h5>
+	<?js if (returns.length > 1) { ?><ul><?js
+		returns.forEach(function(r) { ?>
+			<li><?js= self.partial('returns.tmpl', r) ?></li>
+		<?js });
+	?></ul><?js } else {
+		returns.forEach(function(r) { ?>
+			<?js= self.partial('returns.tmpl', r) ?>
+		<?js });
+	} } ?>
 
-    <?js if (data.yields && yields.length) { ?>
-    <h5>Yields:</h5>
-    <?js if (yields.length > 1) { ?><ul><?js
-        yields.forEach(function(r) { ?>
-            <li><?js= self.partial('returns.tmpl', r) ?></li>
-        <?js });
-    ?></ul><?js } else {
-        yields.forEach(function(r) { ?>
-            <?js= self.partial('returns.tmpl', r) ?>
-        <?js });
-    } } ?>
+	<?js if (data.yields && yields.length) { ?>
+	<h5>Yields:</h5>
+	<?js if (yields.length > 1) { ?><ul><?js
+		yields.forEach(function(r) { ?>
+			<li><?js= self.partial('returns.tmpl', r) ?></li>
+		<?js });
+	?></ul><?js } else {
+		yields.forEach(function(r) { ?>
+			<?js= self.partial('returns.tmpl', r) ?>
+		<?js });
+	} } ?>
 
 </div>

--- a/utils/docs/template/tmpl/modifies.tmpl
+++ b/utils/docs/template/tmpl/modifies.tmpl
@@ -4,11 +4,11 @@ var data = obj || {};
 
 <?js if (data.type && data.type.names) {?>
 <dl>
-    <dt>
-        Type
-    </dt>
-    <dd>
-        <?js= this.partial('type.tmpl', data.type.names) ?>
-    </dd>
+	<dt>
+		Type
+	</dt>
+	<dd>
+		<?js= this.partial('type.tmpl', data.type.names) ?>
+	</dd>
 </dl>
 <?js } ?>

--- a/utils/docs/template/tmpl/params.tmpl
+++ b/utils/docs/template/tmpl/params.tmpl
@@ -1,131 +1,131 @@
 <?js
-    var params = obj;
+	var params = obj;
 
-    /* sort subparams under their parent params (like opts.classname) */
-    var parentParam = null;
-    params.forEach(function(param, i) {
-        var paramRegExp;
+	/* sort subparams under their parent params (like opts.classname) */
+	var parentParam = null;
+	params.forEach(function(param, i) {
+		var paramRegExp;
 
-        if (!param) {
-            return;
-        }
+		if (!param) {
+			return;
+		}
 
-        if (parentParam && parentParam.name && param.name) {
-            try {
-                paramRegExp = new RegExp('^(?:' + parentParam.name + '(?:\\[\\])*)\\.(.+)$');
-            }
-            catch (e) {
-                // there's probably a typo in the JSDoc comment that resulted in a weird
-                // parameter name
-                return;
-            }
+		if (parentParam && parentParam.name && param.name) {
+			try {
+				paramRegExp = new RegExp('^(?:' + parentParam.name + '(?:\\[\\])*)\\.(.+)$');
+			}
+			catch (e) {
+				// there's probably a typo in the JSDoc comment that resulted in a weird
+				// parameter name
+				return;
+			}
 
-            if ( paramRegExp.test(param.name) ) {
-                param.name = RegExp.$1;
-                parentParam.subparams = parentParam.subparams || [];
-                parentParam.subparams.push(param);
-                params[i] = null;
-            }
-            else {
-                parentParam = param;
-            }
-        }
-        else {
-            parentParam = param;
-        }
-    });
+			if ( paramRegExp.test(param.name) ) {
+				param.name = RegExp.$1;
+				parentParam.subparams = parentParam.subparams || [];
+				parentParam.subparams.push(param);
+				params[i] = null;
+			}
+			else {
+				parentParam = param;
+			}
+		}
+		else {
+			parentParam = param;
+		}
+	});
 
-    /* determine if we need extra columns, "attributes" and "default" */
-    params.hasAttributes = false;
-    params.hasDefault = false;
-    params.hasName = false;
+	/* determine if we need extra columns, "attributes" and "default" */
+	params.hasAttributes = false;
+	params.hasDefault = false;
+	params.hasName = false;
 
-    params.forEach(function(param) {
-        if (!param) { return; }
+	params.forEach(function(param) {
+		if (!param) { return; }
 
-        if (param.optional || param.nullable || param.variable) {
-            params.hasAttributes = true;
-        }
+		if (param.optional || param.nullable || param.variable) {
+			params.hasAttributes = true;
+		}
 
-        if (param.name) {
-            params.hasName = true;
-        }
+		if (param.name) {
+			params.hasName = true;
+		}
 
-        if (typeof param.defaultvalue !== 'undefined') {
-            params.hasDefault = true;
-        }
-    });
+		if (typeof param.defaultvalue !== 'undefined') {
+			params.hasDefault = true;
+		}
+	});
 ?>
 
 <table class="params">
-    <thead>
-    <tr>
-        <?js if (params.hasName) {?>
-        <th>Name</th>
-        <?js } ?>
+	<thead>
+	<tr>
+		<?js if (params.hasName) {?>
+		<th>Name</th>
+		<?js } ?>
 
-        <th>Type</th>
+		<th>Type</th>
 
-        <?js if (params.hasAttributes) {?>
-        <th>Attributes</th>
-        <?js } ?>
+		<?js if (params.hasAttributes) {?>
+		<th>Attributes</th>
+		<?js } ?>
 
-        <?js if (params.hasDefault) {?>
-        <th>Default</th>
-        <?js } ?>
+		<?js if (params.hasDefault) {?>
+		<th>Default</th>
+		<?js } ?>
 
-        <th class="last">Description</th>
-    </tr>
-    </thead>
+		<th class="last">Description</th>
+	</tr>
+	</thead>
 
-    <tbody>
-    <?js
-        var self = this;
-        params.forEach(function(param) {
-            if (!param) { return; }
-    ?>
+	<tbody>
+	<?js
+		var self = this;
+		params.forEach(function(param) {
+			if (!param) { return; }
+	?>
 
-        <tr>
-            <?js if (params.hasName) {?>
-                <td class="name"><code><?js= param.name ?></code></td>
-            <?js } ?>
+		<tr>
+			<?js if (params.hasName) {?>
+				<td class="name"><code><?js= param.name ?></code></td>
+			<?js } ?>
 
-            <td class="type">
-            <?js if (param.type && param.type.names) {?>
-                <?js= self.partial('type.tmpl', param.type.names) ?>
-            <?js } ?>
-            </td>
+			<td class="type">
+			<?js if (param.type && param.type.names) {?>
+				<?js= self.partial('type.tmpl', param.type.names) ?>
+			<?js } ?>
+			</td>
 
-            <?js if (params.hasAttributes) {?>
-                <td class="attributes">
-                <?js if (param.optional) { ?>
-                    &lt;optional><br>
-                <?js } ?>
+			<?js if (params.hasAttributes) {?>
+				<td class="attributes">
+				<?js if (param.optional) { ?>
+					&lt;optional><br>
+				<?js } ?>
 
-                <?js if (param.nullable) { ?>
-                    &lt;nullable><br>
-                <?js } ?>
+				<?js if (param.nullable) { ?>
+					&lt;nullable><br>
+				<?js } ?>
 
-                <?js if (param.variable) { ?>
-                    &lt;repeatable><br>
-                <?js } ?>
-                </td>
-            <?js } ?>
+				<?js if (param.variable) { ?>
+					&lt;repeatable><br>
+				<?js } ?>
+				</td>
+			<?js } ?>
 
-            <?js if (params.hasDefault) {?>
-                <td class="default">
-                <?js if (typeof param.defaultvalue !== 'undefined') { ?>
-                    <?js= self.htmlsafe(param.defaultvalue) ?>
-                <?js } ?>
-                </td>
-            <?js } ?>
+			<?js if (params.hasDefault) {?>
+				<td class="default">
+				<?js if (typeof param.defaultvalue !== 'undefined') { ?>
+					<?js= self.htmlsafe(param.defaultvalue) ?>
+				<?js } ?>
+				</td>
+			<?js } ?>
 
-            <td class="description last"><?js= param.description ?><?js if (param.subparams) { ?>
-                <h6>Properties</h6>
-                <?js= self.partial('params.tmpl', param.subparams) ?>
-            <?js } ?></td>
-        </tr>
+			<td class="description last"><?js= param.description ?><?js if (param.subparams) { ?>
+				<h6>Properties</h6>
+				<?js= self.partial('params.tmpl', param.subparams) ?>
+			<?js } ?></td>
+		</tr>
 
-    <?js }); ?>
-    </tbody>
+	<?js }); ?>
+	</tbody>
 </table>

--- a/utils/docs/template/tmpl/properties.tmpl
+++ b/utils/docs/template/tmpl/properties.tmpl
@@ -1,108 +1,108 @@
 <?js
-    var data = obj;
-    var props = data.subprops || data.properties;
+	var data = obj;
+	var props = data.subprops || data.properties;
 
-    /* sort subprops under their parent props (like opts.classname) */
-    var parentProp = null;
-    props.forEach(function(prop, i) {
-        if (!prop) { return; }
-        if ( parentProp && prop.name && prop.name.indexOf(parentProp.name + '.') === 0 ) {
-            prop.name = prop.name.substr(parentProp.name.length+1);
-            parentProp.subprops = parentProp.subprops || [];
-            parentProp.subprops.push(prop);
-            props[i] = null;
-        }
-        else {
-            parentProp = prop;
-        }
-    });
+	/* sort subprops under their parent props (like opts.classname) */
+	var parentProp = null;
+	props.forEach(function(prop, i) {
+		if (!prop) { return; }
+		if ( parentProp && prop.name && prop.name.indexOf(parentProp.name + '.') === 0 ) {
+			prop.name = prop.name.substr(parentProp.name.length+1);
+			parentProp.subprops = parentProp.subprops || [];
+			parentProp.subprops.push(prop);
+			props[i] = null;
+		}
+		else {
+			parentProp = prop;
+		}
+	});
 
-    /* determine if we need extra columns, "attributes" and "default" */
-    props.hasAttributes = false;
-    props.hasDefault = false;
-    props.hasName = false;
+	/* determine if we need extra columns, "attributes" and "default" */
+	props.hasAttributes = false;
+	props.hasDefault = false;
+	props.hasName = false;
 
-    props.forEach(function(prop) {
-        if (!prop) { return; }
+	props.forEach(function(prop) {
+		if (!prop) { return; }
 
-        if (prop.optional || prop.nullable) {
-            props.hasAttributes = true;
-        }
+		if (prop.optional || prop.nullable) {
+			props.hasAttributes = true;
+		}
 
-        if (prop.name) {
-            props.hasName = true;
-        }
+		if (prop.name) {
+			props.hasName = true;
+		}
 
-        if (typeof prop.defaultvalue !== 'undefined' && !data.isEnum) {
-            props.hasDefault = true;
-        }
-    });
+		if (typeof prop.defaultvalue !== 'undefined' && !data.isEnum) {
+			props.hasDefault = true;
+		}
+	});
 ?>
 
 <table class="props">
-    <thead>
-    <tr>
-        <?js if (props.hasName) {?>
-        <th>Name</th>
-        <?js } ?>
+	<thead>
+	<tr>
+		<?js if (props.hasName) {?>
+		<th>Name</th>
+		<?js } ?>
 
-        <th>Type</th>
+		<th>Type</th>
 
-        <?js if (props.hasAttributes) {?>
-        <th>Attributes</th>
-        <?js } ?>
+		<?js if (props.hasAttributes) {?>
+		<th>Attributes</th>
+		<?js } ?>
 
-        <?js if (props.hasDefault) {?>
-        <th>Default</th>
-        <?js } ?>
+		<?js if (props.hasDefault) {?>
+		<th>Default</th>
+		<?js } ?>
 
-        <th class="last">Description</th>
-    </tr>
-    </thead>
+		<th class="last">Description</th>
+	</tr>
+	</thead>
 
-    <tbody>
-    <?js
-        var self = this;
-        props.forEach(function(prop) {
-            if (!prop) { return; }
-    ?>
+	<tbody>
+	<?js
+		var self = this;
+		props.forEach(function(prop) {
+			if (!prop) { return; }
+	?>
 
-        <tr>
-            <?js if (props.hasName) {?>
-                <td class="name"><code><?js= prop.name ?></code></td>
-            <?js } ?>
+		<tr>
+			<?js if (props.hasName) {?>
+				<td class="name"><code><?js= prop.name ?></code></td>
+			<?js } ?>
 
-            <td class="type">
-            <?js if (prop.type && prop.type.names) {?>
-                <?js= self.partial('type.tmpl', prop.type.names) ?>
-            <?js } ?>
-            </td>
+			<td class="type">
+			<?js if (prop.type && prop.type.names) {?>
+				<?js= self.partial('type.tmpl', prop.type.names) ?>
+			<?js } ?>
+			</td>
 
-            <?js if (props.hasAttributes) {?>
-                <td class="attributes">
-                <?js if (prop.optional) { ?>
-                    &lt;optional><br>
-                <?js } ?>
+			<?js if (props.hasAttributes) {?>
+				<td class="attributes">
+				<?js if (prop.optional) { ?>
+					&lt;optional><br>
+				<?js } ?>
 
-                <?js if (prop.nullable) { ?>
-                    &lt;nullable><br>
-                <?js } ?>
-                </td>
-            <?js } ?>
+				<?js if (prop.nullable) { ?>
+					&lt;nullable><br>
+				<?js } ?>
+				</td>
+			<?js } ?>
 
-            <?js if (props.hasDefault) {?>
-                <td class="default">
-                <?js if (typeof prop.defaultvalue !== 'undefined') { ?>
-                    <?js= self.htmlsafe(prop.defaultvalue) ?>
-                <?js } ?>
-                </td>
-            <?js } ?>
+			<?js if (props.hasDefault) {?>
+				<td class="default">
+				<?js if (typeof prop.defaultvalue !== 'undefined') { ?>
+					<?js= self.htmlsafe(prop.defaultvalue) ?>
+				<?js } ?>
+				</td>
+			<?js } ?>
 
-            <td class="description last"><?js= prop.description ?><?js if (prop.subprops) { ?>
-                <h6>Properties</h6><?js= self.partial('properties.tmpl', prop) ?>
-            <?js } ?></td>
-        </tr>
+			<td class="description last"><?js= prop.description ?><?js if (prop.subprops) { ?>
+				<h6>Properties</h6><?js= self.partial('properties.tmpl', prop) ?>
+			<?js } ?></td>
+		</tr>
 
-    <?js }); ?>
-    </tbody>
+	<?js }); ?>
+	</tbody>
 </table>

--- a/utils/docs/template/tmpl/returns.tmpl
+++ b/utils/docs/template/tmpl/returns.tmpl
@@ -3,6 +3,6 @@ var data = obj || {};
 if (data.description) {
 ?>
 <div class="param-desc">
-    <?js= description ?>
+	<?js= description ?>
 </div>
 <?js } ?>

--- a/utils/docs/template/tmpl/source.tmpl
+++ b/utils/docs/template/tmpl/source.tmpl
@@ -1,8 +1,8 @@
 <?js
-    var data = obj;
+	var data = obj;
 ?>
-    <section>
-        <article>
-            <pre class="prettyprint source linenums"><code><?js= data.code ?></code></pre>
-        </article>
-    </section>
+	<section>
+		<article>
+			<pre class="prettyprint source linenums"><code><?js= data.code ?></code></pre>
+		</article>
+	</section>

--- a/utils/docs/template/tmpl/type.tmpl
+++ b/utils/docs/template/tmpl/type.tmpl
@@ -1,7 +1,7 @@
 <?js
-    var data = obj;
-    var self = this;
-    data.forEach(function(name, i) { ?>
+	var data = obj;
+	var self = this;
+	data.forEach(function(name, i) { ?>
 <span class="param-type"><?js= self.linkto(name, self.htmlsafe(name)) ?></span>
 <?js if (i < data.length-1) { ?>|<?js } ?>
 <?js }); ?>


### PR DESCRIPTION
Related issue: #30748

**Description**

The `/docs` folder is 7MB in total, including multiple languages.

<img width="991" height="713" alt="Screenshot 2025-10-01 at 11 44 08 AM" src="https://github.com/user-attachments/assets/4a53593d-32d9-4954-abfb-20d2d1285939" />

This is how `/docs_new` looked like:

<img width="991" height="713" alt="Screenshot 2025-10-02 at 2 29 42 PM" src="https://github.com/user-attachments/assets/bc76a6f1-e11d-4067-8808-68bc7dd5bcaf" />

We can reduce 120MB by not generating docs for source files and linking to github directly as the old docs did.

Now `/docs_new` looks like this:

<img width="991" height="713" alt="Screenshot 2025-10-01 at 11 45 50 AM" src="https://github.com/user-attachments/assets/d7a93d72-1502-47cb-befa-9e7f34abcb5e" />

However, 120MB for a single language is... not the best.

I'll continue investigating ways to get closer to where we were.