### PR TITLE
PassNode: Ensure clear of internal render target.

### DIFF
--- a/examples/jsm/tsl/display/OutlineNode.js
+++ b/examples/jsm/tsl/display/OutlineNode.js
@@ -455,6 +455,8 @@ class OutlineNode extends TempNode {
 
 		this._updateSelectionCache();
 
+		const currentSceneName = scene.name;
+
 		// 1. Draw non-selected objects in the depth buffer
 
 		scene.overrideMaterial = this._depthMaterial;
@@ -470,6 +472,7 @@ class OutlineNode extends TempNode {
 
 		} );
 
+		scene.name = 'Outline [ Non-Selected Objects Pass ]';
 		renderer.render( scene, camera );
 
 		// 2. Draw only the selected objects by comparing the depth buffer of non-selected objects
@@ -487,6 +490,7 @@ class OutlineNode extends TempNode {
 
 		} );
 
+		scene.name = 'Outline [ Selected Objects Pass ]';
 		renderer.render( scene, camera );
 
 		//
@@ -495,15 +499,19 @@ class OutlineNode extends TempNode {
 
 		this._selectionCache.clear();
 
+		scene.name = currentSceneName;
+
 		// 3. Downsample to (at least) half resolution
 
 		_quadMesh.material = this._materialCopy;
+		_quadMesh.name = 'Outline [ Downsample ]';
 		renderer.setRenderTarget( this._renderTargetMaskDownSampleBuffer );
 		_quadMesh.render( renderer );
 
 		// 4. Perform edge detection (half resolution)
 
 		_quadMesh.material = this._edgeDetectionMaterial;
+		_quadMesh.name = 'Outline [ Edge Detection ]';
 		renderer.setRenderTarget( this._renderTargetEdgeBuffer1 );
 		_quadMesh.render( renderer );
 
@@ -513,6 +521,7 @@ class OutlineNode extends TempNode {
 		this._blurDirection.value.copy( _BLUR_DIRECTION_X );
 
 		_quadMesh.material = this._separableBlurMaterial;
+		_quadMesh.name = 'Outline [ Blur Half Resolution ]';
 		renderer.setRenderTarget( this._renderTargetBlurBuffer1 );
 		_quadMesh.render( renderer );
 
@@ -528,6 +537,7 @@ class OutlineNode extends TempNode {
 		this._blurDirection.value.copy( _BLUR_DIRECTION_X );
 
 		_quadMesh.material = this._separableBlurMaterial2;
+		_quadMesh.name = 'Outline [ Blur Quarter Resolution ]';
 		renderer.setRenderTarget( this._renderTargetBlurBuffer2 );
 		_quadMesh.render( renderer );
 
@@ -540,6 +550,7 @@ class OutlineNode extends TempNode {
 		// 7. Composite
 
 		_quadMesh.material = this._compositeMaterial;
+		_quadMesh.name = 'Outline [ Blur Quarter Resolution ]';
 		renderer.setRenderTarget( this._renderTargetComposite );
 		_quadMesh.render( renderer );
 

--- a/src/nodes/display/PassNode.js
+++ b/src/nodes/display/PassNode.js
@@ -737,6 +737,7 @@ class PassNode extends TempNode {
 
 		const currentRenderTarget = renderer.getRenderTarget();
 		const currentMRT = renderer.getMRT();
+		const currentAutoClear = renderer.autoClear;
 		const currentMask = camera.layers.mask;
 
 		this._cameraNear.value = camera.near;
@@ -756,6 +757,7 @@ class PassNode extends TempNode {
 
 		renderer.setRenderTarget( this.renderTarget );
 		renderer.setMRT( this._mrt );
+		renderer.autoClear = true;
 
 		const currentSceneName = scene.name;
 
@@ -767,6 +769,7 @@ class PassNode extends TempNode {
 
 		renderer.setRenderTarget( currentRenderTarget );
 		renderer.setMRT( currentMRT );
+		renderer.autoClear = currentAutoClear;
 
 		camera.layers.mask = currentMask;
 


### PR DESCRIPTION
Fixed #31966.

**Description**

#31966 exposed an issue in `PassNode`: If `autoClear` is set to `false`, the internal render target is never cleared which yields to different bugs in the backends. WebGL produces a persistent after image effect whereas WebGPU produces just a black texture.

The PR introduces the same behavior like in other FX passes by resetting the flag to its default value. We are not using `RendererUtils.resetRendererState()` though since most renderer settings should applied to `PassNode` as well. 

If we don't want to force a clear, we would have to expose a `PassNode.clear()` method which I'm not sure is necessary at the moment.