### PR TITLE
WebGLBackend: Fix functions with struct layouts cannot resolve struct types

### DIFF
--- a/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
+++ b/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
@@ -1379,6 +1379,9 @@ ${shaderData.extensions}
 // precision
 ${ defaultPrecisions }
 
+// structs
+${shaderData.structs}
+
 // uniforms
 ${shaderData.uniforms}
 
@@ -1387,9 +1390,6 @@ ${shaderData.varyings}
 
 // codes
 ${shaderData.codes}
-
-// structs
-${shaderData.structs}
 
 void main() {
 


### PR DESCRIPTION
**Description**

This PR moves the structs section before uniforms and codes so that functions with struct layouts can resolve struct types.
