### PR TITLE
NodeBuilder - Add Hints in Comments

### DIFF
--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -1674,6 +1674,11 @@ class NodeBuilder {
 	/**
 	 * Returns the properties for the given node and shader stage.
 	 *
+	 * Properties are typically used within a build stage to reference nodes or parameters
+	 * created in a separate build stage. A typical usage pattern would be
+	 * assigning dependency nodes to the current node's properties in the setup stage
+	 * and building those properties in the generate stage.
+	 *
 	 * @param {Node} node - The node to get the properties for.
 	 * @param {('vertex'|'fragment'|'compute'|'any')} [shaderStage='any'] - The shader stage.
 	 * @return {Object} The node properties.

--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -1674,10 +1674,10 @@ class NodeBuilder {
 	/**
 	 * Returns the properties for the given node and shader stage.
 	 *
-	 * Properties are typically used within a build stage to reference nodes or parameters
-	 * created in a separate build stage. A typical usage pattern would be
-	 * assigning dependency nodes to the current node's properties in the setup stage
-	 * and building those properties in the generate stage.
+	 * Properties are typically used within a build stage to reference a node's
+	 * child nodes or nodes manually assigned to the properties in a separate build stage.
+	 * A typical usage pattern for defining nodes manually would be assigning dependency nodes
+	 * to the current node's properties in the setup stage and building those properties in the generate stage.
 	 *
 	 * @param {Node} node - The node to get the properties for.
 	 * @param {('vertex'|'fragment'|'compute'|'any')} [shaderStage='any'] - The shader stage.
@@ -2291,7 +2291,7 @@ class NodeBuilder {
 	 *
 	 * This function can be used to arbitrarily execute the specified build stage
 	 * outside of the standard build process. For instance, if a node's type depends
-	 * on properties created by the 'setup' stage, then flowBuidStage('setup')
+	 * on properties created by the 'setup' stage, then flowBuildStage('setup')
 	 * can be used to execute the setup build stage and access its generated nodes
 	 * before the standard build process begins.
 	 *

--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -1675,7 +1675,7 @@ class NodeBuilder {
 	 * Returns the properties for the given node and shader stage.
 	 *
 	 * Properties are typically used within a build stage to reference a node's
-	 * child nodes or nodes manually assigned to the properties in a separate build stage.
+	 * child node or nodes manually assigned to the properties in a separate build stage.
 	 * A typical usage pattern for defining nodes manually would be assigning dependency nodes
 	 * to the current node's properties in the setup stage and building those properties in the generate stage.
 	 *
@@ -2291,7 +2291,7 @@ class NodeBuilder {
 	 *
 	 * This function can be used to arbitrarily execute the specified build stage
 	 * outside of the standard build process. For instance, if a node's type depends
-	 * on properties created by the 'setup' stage, then flowBuildStage('setup')
+	 * on properties created by the 'setup' stage, then flowBuildStage(node, 'setup')
 	 * can be used to execute the setup build stage and access its generated nodes
 	 * before the standard build process begins.
 	 *

--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -2289,6 +2289,12 @@ class NodeBuilder {
 	/**
 	 * Executes the node in a specific build stage.
 	 *
+	 * This function can be used to arbitrarily execute the specified build stage
+	 * outside of the standard build process. For instance, if a node's type depends
+	 * on properties created by the 'setup' stage, then flowBuidStage('setup')
+	 * can be used to execute the setup build stage and access its generated nodes
+	 * before the standard build process begins.
+	 *
 	 * @param {Node} node - The node to execute.
 	 * @param {string} buildStage - The build stage to execute the node in.
 	 * @param {?(Node|string)} [output=null] - Expected output type. For example 'vec3'.


### PR DESCRIPTION
**Description**

Adds comments that help specify how NodeBuilder functions should be used within the build stages. 