### PR TITLE
USDZExporter: Improve material prop types and setup

### DIFF
--- a/examples/jsm/exporters/USDZExporter.js
+++ b/examples/jsm/exporters/USDZExporter.js
@@ -794,13 +794,13 @@ function buildMaterial( material, textures, quickLookCompatible = false ) {
 			'uniform token info:id = "UsdPrimvarReader_float2"'
 		);
 		primvarReaderNode.addProperty( 'float2 inputs:fallback = (0.0, 0.0)' );
-		primvarReaderNode.addProperty( `token inputs:varname = "${uv}"` );
+		primvarReaderNode.addProperty( `string inputs:varname = "${uv}"` );
 		primvarReaderNode.addProperty( 'float2 outputs:result' );
 
 		const transform2dNode = new USDNode( `Transform2d_${mapType}`, 'Shader' );
 		transform2dNode.addProperty( 'uniform token info:id = "UsdTransform2d"' );
 		transform2dNode.addProperty(
-			`token inputs:in.connect = </Materials/Material_${material.id}/PrimvarReader_${mapType}.outputs:result>`
+			`float2 inputs:in.connect = </Materials/Material_${material.id}/PrimvarReader_${mapType}.outputs:result>`
 		);
 		transform2dNode.addProperty(
 			`float inputs:rotation = ${( rotation * ( 180 / Math.PI ) ).toFixed(
@@ -828,6 +828,13 @@ function buildMaterial( material, textures, quickLookCompatible = false ) {
 		if ( color !== undefined ) {
 
 			textureNode.addProperty( `float4 inputs:scale = ${buildColor4( color )}` );
+
+		}
+
+		if ( mapType === 'normal' ) {
+
+			textureNode.addProperty( 'float4 inputs:scale = (2, 2, 2, 1)' );
+			textureNode.addProperty( 'float4 inputs:bias = (-1, -1, -1, 0)' );
 
 		}
 


### PR DESCRIPTION
Fix material property types that are flagged by standard USD validation tool (`usdchecker`).

Also fix another spec error on normal texture setup.
[spec text](https://openusd.org/release/spec_usdpreviewsurface.html#spec_usdpreviewsurface_NormalTextures:~:text=If%20the%20texture%20has%208%20bits%20per%20component%2C%20then%20scale%20and%20bias%20must%20be%20adjusted%20to%20be%20(2.0%2C%202.0%2C%202.0%2C%201.0)%20and%20(%2D1%2C%20%2D1%2C%20%2D1%2C%200)%20respectively%20in%20order%20to%20satisfy%20tangent%20space%20requirements.)

No output behavior change.

---
Before:
```
usdchecker DamagedHelmet.usdz

Validation Result with no explicit variants set

Error: (usdShadeValidators:NormalMapTextureValidator.NonCompliantBiasAndScale) UsdUVTexture prim </Materials/Material_109/Texture_12_normal> reads 8 bit Normal Map @textures/Texture_13_false.png@, which requires that inputs:scale be set to (2, 2, 2, 1) and inputs:bias be set to (-1, -1, -1, 0) for proper interpretation as per the UsdPreviewSurface and UsdUVTexture docs.

Error: (usdShadeValidators:ShaderSdrCompliance.MismatchedPropertyType) Incorrect type for /Materials/Material_109/PrimvarReader_roughness.inputs:varname. Expected 'string'; got 'token'.
Error: (usdShadeValidators:ShaderSdrCompliance.MismatchedPropertyType) Incorrect type for /Materials/Material_109/Transform2d_normal.inputs:in. Expected 'float2'; got 'token'.
Error: (usdShadeValidators:ShaderSdrCompliance.MismatchedPropertyType) Incorrect type for /Materials/Material_109/Transform2d_diffuse.inputs:in. Expected 'float2'; got 'token'.
Error: (usdShadeValidators:ShaderSdrCompliance.MismatchedPropertyType) Incorrect type for /Materials/Material_109/PrimvarReader_occlusion.inputs:varname. Expected 'string'; got 'token'.
Error: (usdShadeValidators:ShaderSdrCompliance.MismatchedPropertyType) Incorrect type for /Materials/Material_109/PrimvarReader_emissive.inputs:varname. Expected 'string'; got 'token'.
Error: (usdShadeValidators:ShaderSdrCompliance.MismatchedPropertyType) Incorrect type for /Materials/Material_109/Transform2d_roughness.inputs:in. Expected 'float2'; got 'token'.
Error: (usdShadeValidators:ShaderSdrCompliance.MismatchedPropertyType) Incorrect type for /Materials/Material_109/Transform2d_emissive.inputs:in. Expected 'float2'; got 'token'.
Error: (usdShadeValidators:ShaderSdrCompliance.MismatchedPropertyType) Incorrect type for /Materials/Material_109/PrimvarReader_normal.inputs:varname. Expected 'string'; got 'token'.
Error: (usdShadeValidators:ShaderSdrCompliance.MismatchedPropertyType) Incorrect type for /Materials/Material_109/Transform2d_occlusion.inputs:in. Expected 'float2'; got 'token'.
Error: (usdShadeValidators:ShaderSdrCompliance.MismatchedPropertyType) Incorrect type for /Materials/Material_109/PrimvarReader_diffuse.inputs:varname. Expected 'string'; got 'token'.
Error: (usdShadeValidators:ShaderSdrCompliance.MismatchedPropertyType) Incorrect type for /Materials/Material_109/PrimvarReader_metallic.inputs:varname. Expected 'string'; got 'token'.
Error: (usdShadeValidators:ShaderSdrCompliance.MismatchedPropertyType) Incorrect type for /Materials/Material_109/Transform2d_metallic.inputs:in. Expected 'float2'; got 'token'.

Failed!
```

After:
```
usdchecker DamagedHelmet-after.usdz 

Validation Result with no explicit variants set
Success!
```
