### PR TITLE
Examples: Fix Uint32Array initialization

### DIFF
--- a/examples/webgpu_compute_sort_bitonic.html
+++ b/examples/webgpu_compute_sort_bitonic.html
@@ -396,7 +396,7 @@
 
 				const scene = new THREE.Scene();
 
-				const infoArray = new Uint32Array( 3, 2, 2 );
+				const infoArray = new Uint32Array( [ 3, 2, 2 ] );
 				const infoBuffer = new THREE.StorageInstancedBufferAttribute( infoArray, 1 );
 				const infoStorage = storage( infoBuffer, 'uint', infoBuffer.count ).setPBO( true ).setName( 'TheInfo' );
 


### PR DESCRIPTION
Related issue: #31852

**Description**

Fixes the initialization of the `Uint32Array` discussed [here](https://github.com/mrdoob/three.js/pull/31852#discussion_r2404220676)
