### PR TITLE
ShadowNode: Fix shadows in first frame.

### DIFF
--- a/src/nodes/accessors/Lights.js
+++ b/src/nodes/accessors/Lights.js
@@ -32,6 +32,9 @@ export function lightShadowMatrix( light ) {
 
 	return data.shadowMatrix || ( data.shadowMatrix = uniform( 'mat4' ).setGroup( renderGroup ).onRenderUpdate( ( frame ) => {
 
+		// normally, shadow matrices are updated in ShadowNode. However, if the shadow matrix is used outside
+		// of shadow rendering (like in ProjectorLightNode), the shadow matrix still requires an update.
+
 		if ( light.castShadow !== true || frame.renderer.shadowMap.enabled === false ) {
 
 			light.shadow.updateMatrices( light );

--- a/src/nodes/accessors/Lights.js
+++ b/src/nodes/accessors/Lights.js
@@ -33,9 +33,16 @@ export function lightShadowMatrix( light ) {
 	return data.shadowMatrix || ( data.shadowMatrix = uniform( 'mat4' ).setGroup( renderGroup ).onRenderUpdate( ( frame ) => {
 
 		// normally, shadow matrices are updated in ShadowNode. However, if the shadow matrix is used outside
-		// of shadow rendering (like in ProjectorLightNode), the shadow matrix still requires an update.
+		// of shadow rendering (like in ProjectorLightNode), the shadow matrix still requires an update
 
 		if ( light.castShadow !== true || frame.renderer.shadowMap.enabled === false ) {
+
+			if ( light.shadow.camera.coordinateSystem !== frame.camera.coordinateSystem ) {
+
+				light.shadow.camera.coordinateSystem = frame.camera.coordinateSystem;
+				light.shadow.camera.updateProjectionMatrix();
+
+			}
 
 			light.shadow.updateMatrices( light );
 

--- a/src/nodes/lighting/ShadowNode.js
+++ b/src/nodes/lighting/ShadowNode.js
@@ -408,7 +408,7 @@ class ShadowNode extends ShadowBaseNode {
 	 */
 	setupShadow( builder ) {
 
-		const { renderer } = builder;
+		const { renderer, camera } = builder;
 
 		const { light, shadow } = this;
 
@@ -416,6 +416,7 @@ class ShadowNode extends ShadowBaseNode {
 
 		const { depthTexture, shadowMap } = this.setupRenderTarget( shadow, builder );
 
+		shadow.camera.coordinateSystem = camera.coordinateSystem;
 		shadow.camera.updateProjectionMatrix();
 
 		// VSM


### PR DESCRIPTION
Fixed #31925.

**Description**

The PR makes sure shadows are rendered correctly in the first frame for the WebGPU backend.

The root cause was a wrong shadow matrix uniform that was always computed in the WebGL coordinate system. That's why the WebGL backend wasn't affected. In the second frame, the coordinate system was correctly set by the renderer. Too late for the initial uniform update though.

Many thanks to @greggman for the valuable help in #31925 🙌 . Besides, the results of [WebGPU Recorder](https://github.com/brendan-duncan/webgpu_recorder) made it much easier to pinpoint the root cause. Very useful tool!
