### PR TITLE
New Docs: Improved generation speed by 7.5x

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "build": "rollup -c utils/build/rollup.config.js",
     "build-module": "rollup -c utils/build/rollup.config.js --configOnlyModule",
     "build-docs": "jsdoc -c utils/docs/jsdoc.config.json",
+    "postinstall": "node utils/docs/apply-patch.cjs",
     "dev": "node utils/build/dev.js && servez -p 8080",
     "dev-ssl": "node utils/build/dev.js && servez -p 8080 --ssl",
     "preview": "concurrently --names \"ROLLUP,HTTP\" -c \"bgBlue.bold,bgGreen.bold\" \"rollup -c utils/build/rollup.config.js -w -m inline\" \"servez -p 8080\"",

--- a/utils/docs/apply-patch.cjs
+++ b/utils/docs/apply-patch.cjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const patchFile = path.join(__dirname, 'templateHelper.patch');
+const targetFile = path.join(__dirname, '../../node_modules/jsdoc/lib/jsdoc/util/templateHelper.js');
+
+// Check if jsdoc is installed
+if (!fs.existsSync(targetFile)) {
+	console.log('jsdoc not found, skipping patch');
+	process.exit(0);
+}
+
+// Check if already patched
+const content = fs.readFileSync(targetFile, 'utf8');
+if (content.includes('buildMemberofIndex')) {
+	console.log('✓ jsdoc already patched');
+	process.exit(0);
+}
+
+// Apply the patch
+try {
+	execSync(`patch -p0 < "${patchFile}"`, {
+		cwd: path.join(__dirname, '../..'),
+		stdio: 'pipe'
+	});
+	console.log('✓ Applied JSDoc performance patch (7.5x faster docs build)');
+} catch (err) {
+	console.error('Failed to apply patch:', err.message);
+	process.exit(1);
+}

--- a/utils/docs/template/publish.js
+++ b/utils/docs/template/publish.js
@@ -268,8 +268,6 @@ function getPathFromDoclet( { meta } ) {
 
 function generate( title, docs, filename, resolveLinks ) {
 
-	let html;
-
 	resolveLinks = resolveLinks !== false;
 
 	const docData = {
@@ -280,7 +278,8 @@ function generate( title, docs, filename, resolveLinks ) {
 	};
 
 	const outpath = path.join( outdir, filename );
-	html = view.render( 'container.tmpl', docData );
+
+	let html = view.render( 'container.tmpl', docData );
 
 	if ( resolveLinks ) {
 

--- a/utils/docs/templateHelper.patch
+++ b/utils/docs/templateHelper.patch
@@ -1,0 +1,45 @@
+--- node_modules/jsdoc/lib/jsdoc/util/templateHelper.js.orig
++++ node_modules/jsdoc/lib/jsdoc/util/templateHelper.js
+@@ -804,7 +804,27 @@
+ 
+     return returnTypes;
+ };
++
++// Cache for memberof index to speed up ancestor lookups
++let memberofIndex = null;
++
++function buildMemberofIndex(data) {
++    if (memberofIndex) {
++        return memberofIndex;
++    }
++
++    memberofIndex = new Map();
++    const allDoclets = data().get();
++
++    for (const doclet of allDoclets) {
++        if (doclet.longname) {
++            memberofIndex.set(doclet.longname, doclet);
++        }
++    }
+ 
++    return memberofIndex;
++}
++
+ /**
+  * Retrieve an ordered list of doclets for a symbol's ancestors.
+  *
+@@ -818,9 +838,13 @@
+     let doc = doclet;
+     let previousDoc;
+ 
++    // Build index once for all lookups
++    const index = buildMemberofIndex(data);
++
+     while (doc) {
+         previousDoc = doc;
+-        doc = find(data, {longname: doc.memberof})[0];
++        // Use index instead of database query
++        doc = index.get(doc.memberof);
+ 
+         // prevent infinite loop that can be caused by duplicated module definitions
+         if (previousDoc === doc) {


### PR DESCRIPTION
Related issue: #30748

**Description**

`npm run build-docs` was taking ~2 minutes and it was making it hard to modify the templates to match the old docs.

I was curious to see what was it that was taking so long and was able to find [this jsdoc issue](https://github.com/jsdoc/jsdoc/pull/2150) with Claude.

Looks like [jsdoc may be unmaintained](https://github.com/jsdoc/jsdoc/issues/2129)... but, considering that there doesn't seem to be an alternative and the [Three.js contributors already decided on using jsdoc](https://github.com/mrdoob/three.js/issues/24984), I've added a `postinstall` script for now.
