### PR TITLE
Renderer: Fix breakage in deprecated methods.

### DIFF
--- a/src/renderers/common/PostProcessing.js
+++ b/src/renderers/common/PostProcessing.js
@@ -215,6 +215,8 @@ class PostProcessing {
 
 		warnOnce( 'PostProcessing: "renderAsync()" has been deprecated. Use "render()" and "await renderer.init();" when creating the renderer.' ); // @deprecated r181
 
+		await this.renderer.init();
+
 		this.render();
 
 	}

--- a/src/renderers/common/QuadMesh.js
+++ b/src/renderers/common/QuadMesh.js
@@ -90,6 +90,8 @@ class QuadMesh extends Mesh {
 
 		warnOnce( 'QuadMesh: "renderAsync()" has been deprecated. Use "render()" and "await renderer.init();" when creating the renderer.' ); // @deprecated r181
 
+		await renderer.init();
+
 		renderer.render( this, _camera );
 
 	}

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -974,6 +974,8 @@ class Renderer {
 
 		warnOnce( 'Renderer: "renderAsync()" has been deprecated. Use "render()" and "await renderer.init();" when creating the renderer.' ); // @deprecated r181
 
+		await this.init();
+
 		this.render( scene, camera );
 
 	}
@@ -2104,6 +2106,8 @@ class Renderer {
 
 		warnOnce( 'Renderer: "clearAsync()" has been deprecated. Use "clear()" and "await renderer.init();" when creating the renderer.' ); // @deprecated r181
 
+		await this.init();
+
 		this.clear( color, depth, stencil );
 
 	}
@@ -2550,6 +2554,8 @@ class Renderer {
 
 		warnOnce( 'Renderer: "hasFeatureAsync()" has been deprecated. Use "hasFeature()" and "await renderer.init();" when creating the renderer.' ); // @deprecated r181
 
+		await this.init();
+
 		return this.hasFeature( name );
 
 	}
@@ -2604,6 +2610,8 @@ class Renderer {
 	async initTextureAsync( texture ) {
 
 		warnOnce( 'Renderer: "initTextureAsync()" has been deprecated. Use "initTexture()" and "await renderer.init();" when creating the renderer.' ); // @deprecated r181
+
+		await this.init();
 
 		this.initTexture( texture );
 


### PR DESCRIPTION
Related issue: #32022, #32026

**Description**

The PR makes sure the newly deprecated method are still functional which wasn't true after  #32022 and #32026.
