### PR TITLE
TubePainter: Fixed end caps and removed object allocations

### DIFF
--- a/examples/jsm/misc/TubePainter.js
+++ b/examples/jsm/misc/TubePainter.js
@@ -83,25 +83,19 @@ function TubePainter() {
 	let size1 = 1;
 	let size2 = 1;
 
-	const capNormal = new Vector3();
-
 	function addCap( position, matrix, isEndCap, capSize ) {
 
 		let count = geometry.drawRange.count;
 
 		const points = getPoints( capSize );
 
-		capNormal.set(
-			matrix.elements[ 8 ],
-			matrix.elements[ 9 ],
-			matrix.elements[ 10 ]
+		const normalSign = isEndCap ? - 1 : 1;
+
+		normal.set(
+			matrix.elements[ 8 ] * normalSign,
+			matrix.elements[ 9 ] * normalSign,
+			matrix.elements[ 10 ] * normalSign
 		).normalize();
-
-		if ( isEndCap ) {
-
-			capNormal.negate();
-
-		}
 
 		for ( let i = 0, il = points.length; i < il; i ++ ) {
 
@@ -109,26 +103,16 @@ function TubePainter() {
 			const vertex2 = points[ ( i + 1 ) % il ];
 
 			vector1.copy( position );
-
-			if ( isEndCap ) {
-
-				vector2.copy( vertex1 ).applyMatrix4( matrix ).add( position );
-				vector3.copy( vertex2 ).applyMatrix4( matrix ).add( position );
-
-			} else {
-
-				vector2.copy( vertex2 ).applyMatrix4( matrix ).add( position );
-				vector3.copy( vertex1 ).applyMatrix4( matrix ).add( position );
-
-			}
+			vector2.copy( isEndCap ? vertex1 : vertex2 ).applyMatrix4( matrix ).add( position );
+			vector3.copy( isEndCap ? vertex2 : vertex1 ).applyMatrix4( matrix ).add( position );
 
 			vector1.toArray( positions.array, ( count + 0 ) * 3 );
 			vector2.toArray( positions.array, ( count + 1 ) * 3 );
 			vector3.toArray( positions.array, ( count + 2 ) * 3 );
 
-			capNormal.toArray( normals.array, ( count + 0 ) * 3 );
-			capNormal.toArray( normals.array, ( count + 1 ) * 3 );
-			capNormal.toArray( normals.array, ( count + 2 ) * 3 );
+			normal.toArray( normals.array, ( count + 0 ) * 3 );
+			normal.toArray( normals.array, ( count + 1 ) * 3 );
+			normal.toArray( normals.array, ( count + 2 ) * 3 );
 
 			color1.toArray( colors.array, ( count + 0 ) * 3 );
 			color1.toArray( colors.array, ( count + 1 ) * 3 );
@@ -148,7 +132,7 @@ function TubePainter() {
 
 		const points = getPoints( capSize );
 
-		capNormal.set(
+		normal.set(
 			- matrix.elements[ 8 ],
 			- matrix.elements[ 9 ],
 			- matrix.elements[ 10 ]
@@ -169,9 +153,9 @@ function TubePainter() {
 			vector2.toArray( positions.array, ( count + 1 ) * 3 );
 			vector3.toArray( positions.array, ( count + 2 ) * 3 );
 
-			capNormal.toArray( normals.array, ( count + 0 ) * 3 );
-			capNormal.toArray( normals.array, ( count + 1 ) * 3 );
-			capNormal.toArray( normals.array, ( count + 2 ) * 3 );
+			normal.toArray( normals.array, ( count + 0 ) * 3 );
+			normal.toArray( normals.array, ( count + 1 ) * 3 );
+			normal.toArray( normals.array, ( count + 2 ) * 3 );
 
 			color1.toArray( colors.array, ( count + 0 ) * 3 );
 			color1.toArray( colors.array, ( count + 1 ) * 3 );
@@ -261,14 +245,14 @@ function TubePainter() {
 	const prevDirection = new Vector3( 0, 0, 1 );
 	const rotationAxis = new Vector3();
 
-	let hasSegments = false;
+	let isPainting = false;
 
 	let endCapStartIndex = null;
 	let endCapVertexCount = 0;
 
 	function calculateRMF() {
 
-		if ( hasSegments === false ) {
+		if ( isPainting === false ) {
 
 			if ( Math.abs( direction.y ) < 0.99 ) {
 
@@ -307,7 +291,7 @@ function TubePainter() {
 		side.crossVectors( direction, normal ).normalize();
 		normal.crossVectors( side, direction ).normalize();
 
-		if ( hasSegments === true ) {
+		if ( isPainting === true ) {
 
 			const smoothFactor = 0.3;
 
@@ -330,7 +314,7 @@ function TubePainter() {
 
 		lastNormal.set( 0, 1, 0 );
 
-		hasSegments = false;
+		isPainting = false;
 
 		endCapStartIndex = null;
 		endCapVertexCount = 0;
@@ -351,7 +335,7 @@ function TubePainter() {
 
 		calculateRMF();
 
-		if ( hasSegments === false ) {
+		if ( isPainting === false ) {
 
 			color2.copy( color1 );
 			size2 = size1;
@@ -377,7 +361,7 @@ function TubePainter() {
 		color2.copy( color1 );
 		size2 = size1;
 
-		hasSegments = true;
+		isPainting = true;
 
 	}
 

--- a/examples/jsm/misc/TubePainter.js
+++ b/examples/jsm/misc/TubePainter.js
@@ -245,14 +245,14 @@ function TubePainter() {
 	const prevDirection = new Vector3( 0, 0, 1 );
 	const rotationAxis = new Vector3();
 
-	let isPainting = false;
+	let isFirstSegment = true;
 
 	let endCapStartIndex = null;
 	let endCapVertexCount = 0;
 
 	function calculateRMF() {
 
-		if ( isPainting === false ) {
+		if ( isFirstSegment === true ) {
 
 			if ( Math.abs( direction.y ) < 0.99 ) {
 
@@ -291,7 +291,7 @@ function TubePainter() {
 		side.crossVectors( direction, normal ).normalize();
 		normal.crossVectors( side, direction ).normalize();
 
-		if ( isPainting === true ) {
+		if ( isFirstSegment === false ) {
 
 			const smoothFactor = 0.3;
 
@@ -314,7 +314,7 @@ function TubePainter() {
 
 		lastNormal.set( 0, 1, 0 );
 
-		isPainting = false;
+		isFirstSegment = true;
 
 		endCapStartIndex = null;
 		endCapVertexCount = 0;
@@ -335,7 +335,7 @@ function TubePainter() {
 
 		calculateRMF();
 
-		if ( isPainting === false ) {
+		if ( isFirstSegment === true ) {
 
 			color2.copy( color1 );
 			size2 = size1;
@@ -361,7 +361,7 @@ function TubePainter() {
 		color2.copy( color1 );
 		size2 = size1;
 
-		isPainting = true;
+		isFirstSegment = false;
 
 	}
 

--- a/examples/jsm/misc/TubePainter.js
+++ b/examples/jsm/misc/TubePainter.js
@@ -241,8 +241,8 @@ function TubePainter() {
 	const matrix1 = new Matrix4();
 	const matrix2 = new Matrix4();
 
-	const lastNormal = new Vector3( 0, 1, 0 );
-	const prevDirection = new Vector3( 0, 0, 1 );
+	const lastNormal = new Vector3();
+	const prevDirection = new Vector3();
 	const rotationAxis = new Vector3();
 
 	let isFirstSegment = true;

--- a/examples/jsm/misc/TubePainter.js
+++ b/examples/jsm/misc/TubePainter.js
@@ -386,19 +386,18 @@ function TubePainter() {
 		const start = count;
 		const end = geometry.drawRange.count;
 
-		if ( start !== end ) {
+		if ( start === end ) return;
 
-			positions.addUpdateRange( start * 3, ( end - start ) * 3 );
-			normals.addUpdateRange( start * 3, ( end - start ) * 3 );
-			colors.addUpdateRange( start * 3, ( end - start ) * 3 );
+		positions.addUpdateRange( start * 3, ( end - start ) * 3 );
+		positions.needsUpdate = true;
 
-			count = end;
+		normals.addUpdateRange( start * 3, ( end - start ) * 3 );
+		normals.needsUpdate = true;
 
-		}
+		colors.addUpdateRange( start * 3, ( end - start ) * 3 );
+		colors.needsUpdate = true;
 
-		if ( positions.updateRanges.length > 0 ) positions.needsUpdate = true;
-		if ( normals.updateRanges.length > 0 ) normals.needsUpdate = true;
-		if ( colors.updateRanges.length > 0 ) colors.needsUpdate = true;
+		count = end;
 
 	}
 

--- a/examples/jsm/misc/TubePainter.js
+++ b/examples/jsm/misc/TubePainter.js
@@ -288,7 +288,7 @@ function TubePainter() {
 
 			} else {
 
-				vector.copy( direction ).multiplyScalar( direction.x )
+				vector.copy( direction ).multiplyScalar( direction.x );
 				normal.set( 1, 0, 0 ).sub( vector ).normalize();
 
 			}

--- a/examples/jsm/misc/TubePainter.js
+++ b/examples/jsm/misc/TubePainter.js
@@ -70,19 +70,20 @@ function TubePainter() {
 
 	//
 
+	const vector = new Vector3();
+
 	const vector1 = new Vector3();
 	const vector2 = new Vector3();
 	const vector3 = new Vector3();
 	const vector4 = new Vector3();
 
-	const vector = new Vector3();
-
-	const capNormal = new Vector3();
 	const color1 = new Color( 0xffffff );
 	const color2 = new Color( 0xffffff );
 
 	let size1 = 1;
 	let size2 = 1;
+
+	const capNormal = new Vector3();
 
 	function addCap( position, matrix, isEndCap, capSize ) {
 
@@ -180,6 +181,9 @@ function TubePainter() {
 
 		}
 
+		positions.addUpdateRange( endCapStartIndex * 3, endCapVertexCount * 3 );
+		normals.addUpdateRange( endCapStartIndex * 3, endCapVertexCount * 3 );
+		colors.addUpdateRange( endCapStartIndex * 3, endCapVertexCount * 3 );
 
 	}
 
@@ -391,11 +395,26 @@ function TubePainter() {
 
 	//
 
+	let count = 0;
+
 	function update() {
 
-		positions.needsUpdate = true;
-		normals.needsUpdate = true;
-		colors.needsUpdate = true;
+		const start = count;
+		const end = geometry.drawRange.count;
+
+		if ( start !== end ) {
+
+			positions.addUpdateRange( start * 3, ( end - start ) * 3 );
+			normals.addUpdateRange( start * 3, ( end - start ) * 3 );
+			colors.addUpdateRange( start * 3, ( end - start ) * 3 );
+
+			count = end;
+
+		}
+
+		if ( positions.updateRanges.length > 0 ) positions.needsUpdate = true;
+		if ( normals.updateRanges.length > 0 ) normals.needsUpdate = true;
+		if ( colors.updateRanges.length > 0 ) colors.needsUpdate = true;
 
 	}
 

--- a/examples/jsm/misc/TubePainter.js
+++ b/examples/jsm/misc/TubePainter.js
@@ -183,13 +183,8 @@ function TubePainter() {
 		}
 
 		positions.addUpdateRange( endCapStartIndex * 3, endCapVertexCount * 3 );
-		positions.needsUpdate = true;
-
 		normals.addUpdateRange( endCapStartIndex * 3, endCapVertexCount * 3 );
-		normals.needsUpdate = true;
-
 		colors.addUpdateRange( endCapStartIndex * 3, endCapVertexCount * 3 );
-		colors.needsUpdate = true;
 
 	}
 
@@ -404,6 +399,8 @@ function TubePainter() {
 
 			}
 
+			updateEndCap( point1, matrix1, size1 );
+
 		} else {
 
 			updateCurrentSegment( point1 );
@@ -471,7 +468,6 @@ function TubePainter() {
 
 		normals.addUpdateRange( prevSegmentIndex * 3, segmentVertexCount * 3 );
 		normals.addUpdateRange( segmentStartIndex * 3, segmentVertexCount * 3 );
-		normals.needsUpdate = true;
 
 	}
 
@@ -525,10 +521,7 @@ function TubePainter() {
 		}
 
 		positions.addUpdateRange( segmentStartIndex * 3, ( vertexIndex - segmentStartIndex ) * 3 );
-		positions.needsUpdate = true;
-
 		colors.addUpdateRange( segmentStartIndex * 3, ( vertexIndex - segmentStartIndex ) * 3 );
-		colors.needsUpdate = true;
 
 		updateEndCap( point1, matrix1, size1 );
 
@@ -555,18 +548,33 @@ function TubePainter() {
 		const start = count;
 		const end = geometry.drawRange.count;
 
-		if ( start === end ) return;
+		if ( start !== end ) {
 
-		positions.addUpdateRange( start * 3, ( end - start ) * 3 );
-		positions.needsUpdate = true;
+			positions.addUpdateRange( start * 3, ( end - start ) * 3 );
+			normals.addUpdateRange( start * 3, ( end - start ) * 3 );
+			colors.addUpdateRange( start * 3, ( end - start ) * 3 );
 
-		normals.addUpdateRange( start * 3, ( end - start ) * 3 );
-		normals.needsUpdate = true;
+			count = geometry.drawRange.count;
 
-		colors.addUpdateRange( start * 3, ( end - start ) * 3 );
-		colors.needsUpdate = true;
+		}
 
-		count = geometry.drawRange.count;
+		if ( positions.updateRanges.length > 0 ) {
+
+			positions.needsUpdate = true;
+
+		}
+
+		if ( normals.updateRanges.length > 0 ) {
+
+			normals.needsUpdate = true;
+
+		}
+
+		if ( colors.updateRanges.length > 0 ) {
+
+			colors.needsUpdate = true;
+
+		}
 
 	}
 

--- a/examples/jsm/misc/TubePainter.js
+++ b/examples/jsm/misc/TubePainter.js
@@ -372,7 +372,26 @@ function TubePainter() {
 			color2.copy( hasSegments ? lastSegmentColor : color1 );
 			size2 = hasSegments ? lastSegmentSize : size1;
 
-			_lineTo( point1 );
+			direction.subVectors( point1, point2 );
+			direction.normalize();
+
+			calculateRMF();
+
+			if ( hasSegments === false ) {
+
+				matrix2.copy( matrix1 );
+
+				addCap( point2, matrix2, false, size2 );
+
+				// End cap is added immediately after start cap and updated in-place
+				endCapStartIndex = geometry.drawRange.count;
+				addCap( point1, matrix1, true, size1 );
+				endCapVertexCount = geometry.drawRange.count - endCapStartIndex;
+
+			}
+
+			stroke( point1, point2, matrix1, matrix2, size1, size2 );
+
 			const afterCount = geometry.drawRange.count;
 
 			const points = getPoints( size1 );
@@ -512,36 +531,6 @@ function TubePainter() {
 		colors.needsUpdate = true;
 
 		updateEndCap( point1, matrix1, size1 );
-
-	}
-
-	function _lineTo( position ) {
-
-		point1.copy( position );
-
-		direction.subVectors( point1, point2 );
-		const length = direction.length();
-
-		if ( length === 0 ) return;
-
-		direction.divideScalar( length );
-
-		calculateRMF();
-
-		if ( hasSegments === false ) {
-
-			matrix2.copy( matrix1 );
-
-			addCap( point2, matrix2, false, size2 );
-
-			// End cap is added immediately after start cap and updated in-place
-			endCapStartIndex = geometry.drawRange.count;
-			addCap( point1, matrix1, true, size1 );
-			endCapVertexCount = geometry.drawRange.count - endCapStartIndex;
-
-		}
-
-		stroke( point1, point2, matrix1, matrix2, size1, size2 );
 
 	}
 

--- a/examples/webxr_xr_paint.html
+++ b/examples/webxr_xr_paint.html
@@ -32,6 +32,7 @@
 			let controller1, controller2;
 
 			const cursor = new THREE.Vector3();
+			const color = new THREE.Color();
 
 			let controls;
 
@@ -183,6 +184,10 @@
 				cursor.setFromMatrixPosition( pivot.matrixWorld );
 
 				if ( userData.isSelecting === true ) {
+
+					const hue = ( performance.now() * 0.001 ) % 1;
+					color.setHSL( hue, 1.0, 0.5 );
+					painter.setColor( color );
 
 					painter.lineTo( cursor );
 					painter.update();

--- a/examples/webxr_xr_paint.html
+++ b/examples/webxr_xr_paint.html
@@ -107,7 +107,9 @@
 
 					this.userData.isSqueezing = true;
 					this.userData.positionAtSqueezeStart = this.position.y;
-					this.userData.scaleAtSqueezeStart = this.scale.x;
+					
+					const pivot = this.getObjectByName( 'pivot' );
+					this.userData.scaleAtSqueezeStart = pivot.scale.x;
 
 				}
 


### PR DESCRIPTION
Related issue: #32025

**Description**

Wasn't happy with how end caps were being handled...

Now the end cap is being added right after the start cap and moved every time `lineTo()` is called.

Also...

* Fixed color handling
* Made the code more clear
* Removed on-the-fly allocations
* Removed minDistance code as it didn't look good in VR

https://github.com/user-attachments/assets/ec831791-c921-47f1-9fe4-1e38a748ecba

