### PR TITLE
Renderer: Deprecate `computeAsync()`

### DIFF
--- a/examples/jsm/gpgpu/BitonicSort.js
+++ b/examples/jsm/gpgpu/BitonicSort.js
@@ -624,12 +624,12 @@ export class BitonicSort {
 	 *
 	 * @param {Renderer} renderer - The current scene's renderer.
 	 */
-	async computeStep( renderer ) {
+	computeStep( renderer ) {
 
 		// Swap local only runs once
 		if ( this.currentDispatch === 0 ) {
 
-			await renderer.computeAsync( this.swapLocalFn );
+			renderer.compute( this.swapLocalFn );
 
 			this.globalOpsRemaining = 1;
 			this.globalOpsInSpan = 1;
@@ -638,7 +638,7 @@ export class BitonicSort {
 
 			const swapType = this.globalOpsRemaining === this.globalOpsInSpan ? 'Flip' : 'Disperse';
 
-			await renderer.computeAsync( swapType === 'Flip' ? this.flipGlobalNodes[ this.readBufferName ] : this.disperseGlobalNodes[ this.readBufferName ] );
+			renderer.compute( swapType === 'Flip' ? this.flipGlobalNodes[ this.readBufferName ] : this.disperseGlobalNodes[ this.readBufferName ] );
 
 			if ( this.readBufferName === 'Data' ) {
 
@@ -655,7 +655,7 @@ export class BitonicSort {
 		} else {
 
 			// Then run local disperses when we've finished all global swaps
-			await renderer.computeAsync( this.disperseLocalNodes[ this.readBufferName ] );
+			renderer.compute( this.disperseLocalNodes[ this.readBufferName ] );
 
 			const nextSpanGlobalOps = this.globalOpsInSpan + 1;
 			this.globalOpsInSpan = nextSpanGlobalOps;
@@ -672,13 +672,13 @@ export class BitonicSort {
 			// to fulfill the requirement of an in-place sort.
 			if ( this.readBufferName === 'Temp' ) {
 
-				await renderer.computeAsync( this.alignFn );
+				renderer.compute( this.alignFn );
 				this.readBufferName = 'Data';
 
 			}
 
 			// Just reset the algorithm information
-			await renderer.computeAsync( this.resetFn );
+			renderer.compute( this.resetFn );
 
 			this.currentDispatch = 0;
 			this.globalOpsRemaining = 0;
@@ -687,7 +687,7 @@ export class BitonicSort {
 		} else {
 
 			// Otherwise, determine what next swap span is
-			await renderer.computeAsync( this.setAlgoFn );
+			renderer.compute( this.setAlgoFn );
 
 		}
 
@@ -698,7 +698,7 @@ export class BitonicSort {
 	 *
 	 * @param {Renderer} renderer - The current scene's renderer.
 	 */
-	async compute( renderer ) {
+	compute( renderer ) {
 
 		this.globalOpsRemaining = 0;
 		this.globalOpsInSpan = 0;
@@ -706,7 +706,7 @@ export class BitonicSort {
 
 		for ( let i = 0; i < this.stepCount; i ++ ) {
 
-			await this.computeStep( renderer );
+			this.computeStep( renderer );
 
 		}
 

--- a/examples/jsm/inspector/Inspector.js
+++ b/examples/jsm/inspector/Inspector.js
@@ -68,19 +68,6 @@ class Inspector extends RendererInspector {
 
 	}
 
-	computeAsync() {
-
-		const renderer = this.getRenderer();
-		const animationLoop = renderer.getAnimationLoop();
-
-		if ( renderer.info.frame > 1 && animationLoop !== null ) {
-
-			this.resolveConsoleOnce( 'log', 'TIP: "computeAsync()" was called while a "setAnimationLoop()" is active. This is probably not necessary, use "compute()" instead.' );
-
-		}
-
-	}
-
 	resolveConsoleOnce( type, message ) {
 
 		const key = type + message;

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -2534,9 +2534,9 @@ class Renderer {
 	 */
 	async computeAsync( computeNodes, dispatchSizeOrCount = null ) {
 
-		if ( this._initialized === false ) await this.init();
+		warnOnce( 'Renderer: "computeAsync()" has been deprecated. Use "compute()" and "await renderer.init();" when creating the renderer.' ); // @deprecated r181
 
-		this._inspector.computeAsync( computeNodes, dispatchSizeOrCount );
+		await this.init();
 
 		this.compute( computeNodes, dispatchSizeOrCount );
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/32022, https://github.com/mrdoob/three.js/pull/32033

**Description**

As the title.
