### PR TITLE
Examples: Cleanup.

### DIFF
--- a/examples/webgpu_multiple_canvas.html
+++ b/examples/webgpu_multiple_canvas.html
@@ -121,7 +121,7 @@
 					descriptionElement.innerText = 'Scene ' + ( i + 1 );
 					element.appendChild( descriptionElement );
 
-					const canvasTarget = new THREE.CanvasTarget( sceneCanvas, { antialias: true } );
+					const canvasTarget = new THREE.CanvasTarget( sceneCanvas );
 					canvasTarget.setPixelRatio( window.devicePixelRatio );
 					canvasTarget.setSize( 200, 200 );
 


### PR DESCRIPTION
Related issue: #31928

**Description**

Looks like the `antialias` parameter was removed in https://github.com/mrdoob/three.js/pull/31928. Not sure if it's fine to just remove it?
