### PR TITLE
SelectionBox: Add support for batchedMesh

### DIFF
--- a/examples/jsm/interactive/SelectionBox.js
+++ b/examples/jsm/interactive/SelectionBox.js
@@ -269,10 +269,10 @@ class SelectionBox {
 
 				this.batches[ object.uuid ] = [];
 
-
 				for ( let instanceId = 0, count = 0; count < object.instanceCount; instanceId ++ ) {
 
 					// skip invalid instances in the batchedMesh
+
 					if ( object.validateInstanceId( instanceId ) === false ) continue;
 
 					count ++;
@@ -280,6 +280,7 @@ class SelectionBox {
 					object.getMatrixAt( instanceId, _matrix );
 					_matrix.decompose( _center, _quaternion, _scale );
 					_center.applyMatrix4( object.matrixWorld );
+
 					if ( frustum.containsPoint( _center ) ) {
 
 						this.batches[ object.uuid ].push( instanceId );

--- a/examples/jsm/interactive/SelectionBox.js
+++ b/examples/jsm/interactive/SelectionBox.js
@@ -92,6 +92,12 @@ class SelectionBox {
 		 * @type {Object}
 		 */
 		this.instances = {};
+		/**
+		 * The selected batches of batched meshes.
+		 *
+		 * @type {Object}
+		 */
+		this.batches = {};
 
 		/**
 		 * How deep the selection frustum of perspective cameras should extend.
@@ -254,6 +260,29 @@ class SelectionBox {
 					if ( frustum.containsPoint( _center ) ) {
 
 						this.instances[ object.uuid ].push( instanceId );
+
+					}
+
+				}
+
+			} else if ( object.isBatchedMesh ) {
+
+				this.batches[ object.uuid ] = [];
+
+
+				for ( let instanceId = 0, count = 0; count < object.instanceCount; instanceId ++ ) {
+
+					// skip invalid instances in the batchedMesh
+					if ( object.validateInstanceId( instanceId ) === false ) continue;
+
+					count ++;
+
+					object.getMatrixAt( instanceId, _matrix );
+					_matrix.decompose( _center, _quaternion, _scale );
+					_center.applyMatrix4( object.matrixWorld );
+					if ( frustum.containsPoint( _center ) ) {
+
+						this.batches[ object.uuid ].push( instanceId );
 
 					}
 


### PR DESCRIPTION
**Description**

This pull request adds support for selecting instances within batched meshes in the `SelectionBox` class. The main changes introduce a new `batches` property to track selected batches and update the selection logic to handle objects of type `isBatchedMesh`.

**Batched mesh selection support:**

* Added a `batches` property to the `SelectionBox` class to store selected batches of batched meshes.
* Updated the selection logic to check for `isBatchedMesh` objects, validate instance IDs, and collect selected instance IDs for each batched mesh.