### PR TITLE
Serialize and deserialize texture userData in glTF sampler.

### DIFF
--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -761,7 +761,7 @@ class GLTFWriter {
 	/**
 	 * Serializes a userData.
 	 *
-	 * @param {THREE.Object3D|THREE.Material|THREE.BufferGeometry|THREE.AnimationClip} object
+	 * @param {THREE.Object3D|THREE.Material|THREE.BufferGeometry|THREE.AnimationClip|THREE.Texture} object
 	 * @param {Object} objectDef
 	 */
 	serializeUserData( object, objectDef ) {
@@ -1505,6 +1505,8 @@ class GLTFWriter {
 			wrapS: THREE_TO_WEBGL[ map.wrapS ],
 			wrapT: THREE_TO_WEBGL[ map.wrapT ]
 		};
+
+		this.serializeUserData( map, samplerDef );
 
 		return json.samplers.push( samplerDef ) - 1;
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2376,7 +2376,7 @@ function addUnknownExtensionsToUserData( knownExtensions, object, objectDef ) {
 /**
  *
  * @private
- * @param {Object3D|Material|BufferGeometry|Object|AnimationClip} object
+ * @param {Object3D|Material|BufferGeometry|Object|AnimationClip|Texture} object
  * @param {GLTF.definition} gltfDef
  */
 function assignExtrasToUserData( object, gltfDef ) {
@@ -3336,13 +3336,15 @@ class GLTFParser {
 			}
 
 			const samplers = json.samplers || {};
-			const sampler = samplers[ textureDef.sampler ] || {};
+			const samplerDef = samplers[ textureDef.sampler ] || {};
 
-			texture.magFilter = WEBGL_FILTERS[ sampler.magFilter ] || LinearFilter;
-			texture.minFilter = WEBGL_FILTERS[ sampler.minFilter ] || LinearMipmapLinearFilter;
-			texture.wrapS = WEBGL_WRAPPINGS[ sampler.wrapS ] || RepeatWrapping;
-			texture.wrapT = WEBGL_WRAPPINGS[ sampler.wrapT ] || RepeatWrapping;
+			texture.magFilter = WEBGL_FILTERS[ samplerDef.magFilter ] || LinearFilter;
+			texture.minFilter = WEBGL_FILTERS[ samplerDef.minFilter ] || LinearMipmapLinearFilter;
+			texture.wrapS = WEBGL_WRAPPINGS[ samplerDef.wrapS ] || RepeatWrapping;
+			texture.wrapT = WEBGL_WRAPPINGS[ samplerDef.wrapT ] || RepeatWrapping;
 			texture.generateMipmaps = ! texture.isCompressedTexture && texture.minFilter !== NearestFilter && texture.minFilter !== LinearFilter;
+
+			assignExtrasToUserData( texture, samplerDef );
 
 			parser.associations.set( texture, { textures: textureIndex } );
 
@@ -3430,8 +3432,6 @@ class GLTFParser {
 				URL.revokeObjectURL( sourceURI );
 
 			}
-
-			assignExtrasToUserData( texture, sourceDef );
 
 			texture.userData.mimeType = sourceDef.mimeType || getImageURIMimeType( sourceDef.uri );
 


### PR DESCRIPTION
**Description**

Hello, 

The `userData` in three.js `Texture` is not serialized into glTF. This PR adds support for that.

It also changes GLTFLoader so that userData from the `Sampler` is copied to texture.userData, instead of `Image` (as introduced in #28226)

Some background - 
in glTF, textures are broken up into Texture, Sampler, TextureInfo and Image, all of which support storing extras. See - https://github.com/donmccurdy/glTF-Transform/issues/645#issuecomment-1212408241

For three.js, its ideal that any file that is imported and exported across three.js, gltf-transform etc, retain as many properties as possible without changing or transferring them across primitives. 
Based on how three.js objects are structured, and the above explanation by donmccurdy, it makes sense to map three.js `Source` to glTF `Image`, and three.js `Texture` to glTF `Sampler` or `Texture`. Since the threejs API does not prevent changing/sharing the Source instance attached to a Texture(which is the case in glTF I think), I think it makes sense to map it to `Sampler` instead of `Texture`.

Ofc, with this, the extras on source and texture def will never be read from glTF in three and lost when exported with GLTFExporter. This can be handled by reading them into something like `texture.userData.imageExtras` and `texture.userData.textureExtras` and used when exporting.

*This contribution is funded by [Threepipe](https://threepipe.org)*
