### PR TITLE
WaterMesh: Fix incorrect resolution scale assignment.

### DIFF
--- a/examples/jsm/objects/WaterMesh.js
+++ b/examples/jsm/objects/WaterMesh.js
@@ -51,7 +51,7 @@ class WaterMesh extends Mesh {
 		 * @type {number}
 		 * @default 0.5
 		 */
-		this.resolution = options.resolution !== undefined ? options.resolution : 0.5;
+		this.resolutionScale = options.resolutionScale !== undefined ? options.resolutionScale : undefined;
 
 		// Uniforms
 
@@ -161,7 +161,7 @@ class WaterMesh extends Mesh {
 
 			const mirrorSampler = reflector();
 			mirrorSampler.uvNode = mirrorSampler.uvNode.add( distortion );
-			mirrorSampler.reflector.resolutionScale = this.resolution;
+			mirrorSampler.reflector.resolutionScale = this.resolutionScale;
 
 			this.add( mirrorSampler.target );
 
@@ -183,7 +183,7 @@ class WaterMesh extends Mesh {
  * Constructor options of `WaterMesh`.
  *
  * @typedef {Object} WaterMesh~Options
- * @property {number} [resolution=0.5] - The resolution scale.
+ * @property {number} [resolutionScale=0.5] - The resolution scale.
  * @property {?Texture} [waterNormals=null] - The water's normal map.
  * @property {number} [alpha=1] - The alpha value.
  * @property {number} [size=1] - The size value.

--- a/examples/jsm/objects/WaterMesh.js
+++ b/examples/jsm/objects/WaterMesh.js
@@ -51,7 +51,7 @@ class WaterMesh extends Mesh {
 		 * @type {number}
 		 * @default 0.5
 		 */
-		this.resolutionScale = options.resolutionScale !== undefined ? options.resolutionScale : undefined;
+		this.resolutionScale = options.resolutionScale !== undefined ? options.resolutionScale : 0.5;
 
 		// Uniforms
 

--- a/examples/jsm/objects/WaterMesh.js
+++ b/examples/jsm/objects/WaterMesh.js
@@ -161,7 +161,7 @@ class WaterMesh extends Mesh {
 
 			const mirrorSampler = reflector();
 			mirrorSampler.uvNode = mirrorSampler.uvNode.add( distortion );
-			mirrorSampler.resolution = this.resolution;
+			mirrorSampler.reflector.resolutionScale = this.resolution;
 
 			this.add( mirrorSampler.target );
 


### PR DESCRIPTION
**Description**

The `resolution` option in `WaterMesh` does nothing. If you convert WaterMesh to typescript, it has an error on this field assignment. With this change, `resolution` option is respected.