### PR TITLE
Examples: Cleanup.

### DIFF
--- a/examples/webgpu_tonemapping.html
+++ b/examples/webgpu_tonemapping.html
@@ -46,7 +46,7 @@
 			import { HDRLoader } from 'three/addons/loaders/HDRLoader.js';
 
 			let renderer, scene, camera, controls;
-			let gui = null;
+			let gui;
 
 			const params = {
 				exposure: 1.0,


### PR DESCRIPTION
Related issue: #32018

**Description**

The `null` initialization was mistakenly applied to `gui` in https://github.com/mrdoob/three.js/pull/32018