### PR TITLE
WebGPUBackend - Update Compute Pass Labels

### DIFF
--- a/examples/webgpu_compute_birds.html
+++ b/examples/webgpu_compute_birds.html
@@ -412,8 +412,6 @@
 
 				} )().compute( BIRDS ).setName( 'Birds Velocity' );
 
-				console.log( computeVelocity );
-
 				computePosition = Fn( () => {
 
 					const { deltaTime } = effectController;

--- a/examples/webgpu_compute_birds.html
+++ b/examples/webgpu_compute_birds.html
@@ -412,6 +412,8 @@
 
 				} )().compute( BIRDS ).setName( 'Birds Velocity' );
 
+				console.log( computeVelocity );
+
 				computePosition = Fn( () => {
 
 					const { deltaTime } = effectController;
@@ -472,8 +474,8 @@
 				effectController.rayOrigin.value.copy( raycaster.ray.origin );
 				effectController.rayDirection.value.copy( raycaster.ray.direction );
 
-				renderer.compute( computeVelocity );
-				renderer.compute( computePosition );
+				renderer.compute( [ computeVelocity, computePosition ] );
+				//renderer.compute( computePosition );
 
 				renderer.render( scene, camera );
 

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -2419,7 +2419,7 @@ class Renderer {
 	 * Execute a single or an array of compute nodes. This method can only be called
 	 * if the renderer has been initialized.
 	 *
-	 * @param {ComputeNode|Array<ComputeNode>} computeNodes - The compute node(s).
+	 * @param {ComputeNode|Array<ComputeNode>} computeNodes - The compute node(s) to be executed.
 	 * @param {?(Array<number>|number)} [dispatchSizeOrCount=null] - Array with [ x, y, z ] values for dispatch or a single number for the count.
 	 * @return {Promise|undefined} A Promise that resolve when the compute has finished. Only returned when the renderer has not been initialized.
 	 */

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -2419,7 +2419,7 @@ class Renderer {
 	 * Execute a single or an array of compute nodes. This method can only be called
 	 * if the renderer has been initialized.
 	 *
-	 * @param {Node|Array<Node>} computeNodes - The compute node(s).
+	 * @param {ComputeNode|Array<ComputeNode>} computeNodes - The compute node(s).
 	 * @param {?(Array<number>|number)} [dispatchSizeOrCount=null] - Array with [ x, y, z ] values for dispatch or a single number for the count.
 	 * @return {Promise|undefined} A Promise that resolve when the compute has finished. Only returned when the renderer has not been initialized.
 	 */

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -1310,7 +1310,7 @@ class WebGPUBackend extends Backend {
 
 	}
 
-
+	// compute
 
 	/**
 	 * This method is executed at the beginning of a compute call and

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -1310,7 +1310,7 @@ class WebGPUBackend extends Backend {
 
 	}
 
-	// compute
+
 
 	/**
 	 * This method is executed at the beginning of a compute call and
@@ -1322,17 +1322,39 @@ class WebGPUBackend extends Backend {
 
 		const groupGPU = this.get( computeGroup );
 
+		if ( groupGPU.computePassDescriptor === undefined ) {
+
+			let computePassLabel = 'computeGroup[';
+
+			if ( Array.isArray( computeGroup ) ) {
+
+				for ( let i = 0; i < computeGroup.length; i ++ ) {
+
+					const group = computeGroup[ i ];
+					computePassLabel += `${group.name}_${group.id}${i !== computeGroup.length - 1 ? ',' : ''}`;
+
+				}
+
+			} else {
+
+				computePassLabel += `${computeGroup.name}_${computeGroup.id}`;
+
+			}
+
+			computePassLabel += ']';
+
+			const descriptor = { label: computePassLabel };
+
+			groupGPU.computePassDescriptor = descriptor;
+
+		}
 		//
 
-		const descriptor = {
-			label: 'computeGroup_' + computeGroup.id
-		};
+		this.initTimestampQuery( TimestampQuery.COMPUTE, this.getTimestampUID( computeGroup ), groupGPU.computePassDescriptor );
 
-		this.initTimestampQuery( TimestampQuery.COMPUTE, this.getTimestampUID( computeGroup ), descriptor );
+		groupGPU.cmdEncoderGPU = this.device.createCommandEncoder( groupGPU.computePassDescriptor );
 
-		groupGPU.cmdEncoderGPU = this.device.createCommandEncoder( { label: 'computeGroup_' + computeGroup.id } );
-
-		groupGPU.passEncoderGPU = groupGPU.cmdEncoderGPU.beginComputePass( descriptor );
+		groupGPU.passEncoderGPU = groupGPU.cmdEncoderGPU.beginComputePass( groupGPU.computePassDescriptor );
 
 	}
 


### PR DESCRIPTION
Related issue: #32037 

**Description**

Updates compute cache labels and caches them on the passed in computeGroup so they are not recreated each frame.
