### PR TITLE
WebGPURenderer: Compute DFG LUT

### DIFF
--- a/src/nodes/functions/BSDF/DFGApprox.js
+++ b/src/nodes/functions/BSDF/DFGApprox.js
@@ -91,9 +91,8 @@ const integrateBRDF = /*@__PURE__*/ Fn( ( [ NdotV, roughness, sampleCount ] ) =>
 		0.0
 	).xyz;
 
-	let A = float( 0.0 ).toVar();
-	let B = float( 0.0 ).toVar();
-	const N = vec4( 0.0, 0.0, 1.0, 0.0 ).xyz;
+	const A = float( 0.0 ).toVar();
+	const B = float( 0.0 ).toVar();
 
 	for ( let i = 0; i < sampleCount; i ++ ) {
 

--- a/src/nodes/functions/BSDF/DFGApprox.js
+++ b/src/nodes/functions/BSDF/DFGApprox.js
@@ -1,4 +1,6 @@
-import { Fn, vec2, vec4 } from '../../tsl/TSLBase.js';
+import { Fn, float, uvec2, vec2, vec4 } from '../../tsl/TSLBase.js';
+import { instanceIndex } from '../../core/IndexNode.js';
+import { textureStore } from '../../accessors/StorageTextureNode.js';
 
 // Analytical approximation of the DFG LUT, one half of the
 // split-sum approximation used in indirect specular lighting.
@@ -28,3 +30,120 @@ const DFGApprox = /*@__PURE__*/ Fn( ( { roughness, dotNV } ) => {
 } );
 
 export default DFGApprox;
+
+// Compute shader implementation for generating DFG LUT
+
+// Van der Corput radical inverse
+const radicalInverse_VdC = /*@__PURE__*/ Fn( ( [ bits ] ) => {
+
+	bits = bits.shiftLeft( 16 ).or( bits.shiftRight( 16 ) );
+	bits = bits.and( 0x55555555 ).shiftLeft( 1 ).or( bits.and( 0xAAAAAAAA ).shiftRight( 1 ) );
+	bits = bits.and( 0x33333333 ).shiftLeft( 2 ).or( bits.and( 0xCCCCCCCC ).shiftRight( 2 ) );
+	bits = bits.and( 0x0F0F0F0F ).shiftLeft( 4 ).or( bits.and( 0xF0F0F0F0 ).shiftRight( 4 ) );
+	bits = bits.and( 0x00FF00FF ).shiftLeft( 8 ).or( bits.and( 0xFF00FF00 ).shiftRight( 8 ) );
+
+	return bits.toFloat().mul( 2.3283064365386963e-10 );
+
+} );
+
+// Hammersley sequence
+const hammersley = /*@__PURE__*/ Fn( ( [ i, N ] ) => {
+
+	return vec2( i.toFloat().div( N.toFloat() ), radicalInverse_VdC( i ) );
+
+} );
+
+// Importance sampling GGX
+const importanceSampleGGX = /*@__PURE__*/ Fn( ( [ xi, roughness ] ) => {
+
+	const a = roughness.mul( roughness );
+	const phi = xi.x.mul( 2.0 * Math.PI );
+	const cosTheta = xi.y.oneMinus().div( xi.y.mul( a.mul( a ).sub( 1.0 ) ).add( 1.0 ) ).sqrt();
+	const sinTheta = cosTheta.mul( cosTheta ).oneMinus().sqrt();
+
+	return vec4(
+		phi.cos().mul( sinTheta ),
+		phi.sin().mul( sinTheta ),
+		cosTheta,
+		0.0
+	).xyz;
+
+} );
+
+// Smith GGX Correlated visibility function
+const V_SmithGGXCorrelated = /*@__PURE__*/ Fn( ( [ NdotV, NdotL, roughness ] ) => {
+
+	const a2 = roughness.pow( 4.0 );
+	const GGXV = NdotL.mul( NdotV.mul( NdotV ).mul( a2.oneMinus() ).add( a2 ).sqrt() );
+	const GGXL = NdotV.mul( NdotL.mul( NdotL ).mul( a2.oneMinus() ).add( a2 ).sqrt() );
+
+	return float( 0.5 ).div( GGXV.add( GGXL ) );
+
+} );
+
+// Integrate BRDF for a single roughness/NdotV pair
+const integrateBRDF = /*@__PURE__*/ Fn( ( [ NdotV, roughness, sampleCount ] ) => {
+
+	const V = vec4(
+		NdotV.mul( NdotV ).oneMinus().sqrt(),
+		0.0,
+		NdotV,
+		0.0
+	).xyz;
+
+	let A = float( 0.0 ).toVar();
+	let B = float( 0.0 ).toVar();
+	const N = vec4( 0.0, 0.0, 1.0, 0.0 ).xyz;
+
+	for ( let i = 0; i < sampleCount; i ++ ) {
+
+		const xi = hammersley( i, sampleCount );
+		const H = importanceSampleGGX( xi, roughness );
+
+		const VdotH = V.dot( H ).max( 0.0 );
+		const L = H.mul( 2.0 ).mul( VdotH ).sub( V ).normalize();
+
+		const NdotL = L.z.max( 0.0 );
+		const NdotH = H.z.max( 0.0 );
+
+		NdotL.greaterThan( 0.0 ).if( () => {
+
+			const V_pdf = V_SmithGGXCorrelated( NdotV, NdotL, roughness ).mul( VdotH ).mul( NdotL ).div( NdotH );
+			const Fc = VdotH.oneMinus().pow( 5.0 );
+
+			A.assign( A.add( Fc.oneMinus().mul( V_pdf ) ) );
+			B.assign( B.add( Fc.mul( V_pdf ) ) );
+
+		} );
+
+	}
+
+	return vec2( A, B ).mul( 4.0 ).div( sampleCount.toFloat() );
+
+} );
+
+/**
+ * Generates a DFG LUT (Directional-Fresnel-Geometry Look-Up Table) using a compute shader.
+ * This is used for Image-Based Lighting in PBR materials.
+ *
+ * @tsl
+ * @function
+ * @param {StorageTexture} storageTexture - The storage texture to write the LUT to.
+ * @param {number} lutSize - The size of the LUT (e.g., 32 for a 32x32 texture).
+ * @param {number} [sampleCount=1024] - The number of samples per texel.
+ * @returns {ComputeNode} The compute node that generates the LUT.
+ */
+export const generateDFGLUT = /*@__PURE__*/ Fn( ( { storageTexture, lutSize, sampleCount } ) => {
+
+	const posX = instanceIndex.mod( lutSize );
+	const posY = instanceIndex.div( lutSize );
+	const indexUV = uvec2( posX, posY );
+
+	const roughness = posX.add( 0.5 ).div( lutSize.toFloat() );
+	const NdotV = posY.add( 0.5 ).div( lutSize.toFloat() );
+
+	const result = integrateBRDF( NdotV, roughness, sampleCount );
+
+	textureStore( storageTexture, indexUV, vec4( result, 0.0, 0.0 ) ).toWriteOnly();
+
+} );

--- a/src/nodes/functions/BSDF/EnvironmentBRDF.js
+++ b/src/nodes/functions/BSDF/EnvironmentBRDF.js
@@ -1,11 +1,15 @@
-import DFGApprox from './DFGApprox.js';
-import { Fn } from '../../tsl/TSLBase.js';
+import { dfgLUT } from '../../lighting/DFGLUTNode.js';
+import { Fn, vec2 } from '../../tsl/TSLBase.js';
 
 const EnvironmentBRDF = /*@__PURE__*/ Fn( ( inputs ) => {
 
 	const { dotNV, specularColor, specularF90, roughness } = inputs;
 
-	const fab = DFGApprox( { dotNV, roughness } );
+	// Use DFG LUT for accurate BRDF integration
+	// LUT coordinates: x = roughness, y = NdotV
+	const uv = vec2( roughness, dotNV );
+	const fab = dfgLUT.sample( uv );
+
 	return specularColor.mul( fab.x ).add( specularF90.mul( fab.y ) );
 
 } );

--- a/src/nodes/lighting/DFGLUTNode.js
+++ b/src/nodes/lighting/DFGLUTNode.js
@@ -1,0 +1,114 @@
+import { texture } from '../accessors/TextureNode.js';
+import { generateDFGLUT } from '../functions/BSDF/DFGApprox.js';
+import { uint } from '../tsl/TSLBase.js';
+
+import StorageTexture from '../../renderers/common/StorageTexture.js';
+import { HalfFloatType } from '../../constants.js';
+
+const _cache = new WeakMap();
+
+/**
+ * Creates a DFG (Directional-Fresnel-Geometry) LUT texture for Image-Based Lighting.
+ * For WebGPU, it generates the LUT using a compute shader on first use.
+ * The LUT is cached per renderer to avoid regeneration.
+ *
+ * @param {Renderer} renderer - The WebGPU renderer.
+ * @param {number} [size=64] - The size of the LUT texture (e.g., 64 for 64x64).
+ * @param {number} [sampleCount=1024] - The number of samples per texel for compute generation.
+ * @returns {StorageTexture} The generated LUT texture.
+ */
+function getDFGLUTTexture( renderer, size = 64, sampleCount = 1024 ) {
+
+	let cache = _cache.get( renderer );
+
+	if ( cache === undefined ) {
+
+		cache = new Map();
+		_cache.set( renderer, cache );
+
+	}
+
+	// Check if we already have a LUT for this size
+	const cacheKey = `${size}_${sampleCount}`;
+	let cachedTexture = cache.get( cacheKey );
+
+	if ( cachedTexture === undefined ) {
+
+		// Create storage texture for the LUT
+		const storageTexture = new StorageTexture( size, size );
+		storageTexture.type = HalfFloatType;
+		storageTexture.generateMipmaps = false;
+
+		// Create compute node to generate the LUT
+		const computeNode = generateDFGLUT( {
+			storageTexture,
+			lutSize: uint( size ),
+			sampleCount: uint( sampleCount )
+		} ).compute( size * size );
+
+		// Generate the LUT
+		renderer.compute( computeNode );
+
+		// Cache it
+		cache.set( cacheKey, storageTexture );
+		cachedTexture = storageTexture;
+
+	}
+
+	return cachedTexture;
+
+}
+
+/**
+ * Singleton DFG LUT texture node (64x64, 1024 samples) that can be sampled in shaders.
+ * The texture is lazily generated on first use.
+ */
+class DFGLUTSingleton {
+
+	constructor() {
+
+		this._textureNode = null;
+		this._size = 64;
+		this._sampleCount = 1024;
+
+	}
+
+	sample( uv ) {
+
+		// Lazy initialization - the texture node will be created when first sampled
+		if ( this._textureNode === null ) {
+
+			// Create a placeholder texture node
+			const placeholderTexture = new StorageTexture( this._size, this._size );
+			placeholderTexture.type = HalfFloatType;
+			placeholderTexture.generateMipmaps = false;
+
+			this._textureNode = texture( placeholderTexture );
+
+			// Add a setup hook to update the texture value with the actual LUT
+			const originalSetup = this._textureNode.setup.bind( this._textureNode );
+			this._textureNode.setup = ( builder ) => {
+
+				// Get the actual LUT texture for this renderer
+				const lutTexture = getDFGLUTTexture( builder.renderer, this._size, this._sampleCount );
+				this._textureNode.value = lutTexture;
+
+				return originalSetup( builder );
+
+			};
+
+		}
+
+		return this._textureNode.sample( uv );
+
+	}
+
+}
+
+/**
+ * Singleton instance of the DFG LUT that can be sampled directly in shader code.
+ *
+ * @tsl
+ * @type {DFGLUTSingleton}
+ */
+export const dfgLUT = /*@__PURE__*/ new DFGLUTSingleton();


### PR DESCRIPTION
Related issue: #32054

**Description**

@sunag For yout amusement, this is Claude's attempt at writing a compute that generates the DFG LUT at init time.

Unfortunately this wouldn't work on the WebGL backend because it uses StorageTexture.