### PR TITLE
Docs: Add type annotations for dispatch size in `ComputeNode`

### DIFF
--- a/src/nodes/gpgpu/ComputeNode.js
+++ b/src/nodes/gpgpu/ComputeNode.js
@@ -54,7 +54,7 @@ class ComputeNode extends Node {
 		/**
 		 * TODO
 		 *
-		 * @type {number}
+		 * @type {number|Array<number>}
 		 */
 		this.count = null;
 
@@ -91,6 +91,12 @@ class ComputeNode extends Node {
 
 	}
 
+	/**
+	 * TODO
+	 *
+	 * @param {number|Array<number>} count - Array with [ x, y, z ] values for dispatch or a single number for the count
+	 * @return {ComputeNode}
+	 */
 	setCount( count ) {
 
 		this.count = count;
@@ -99,6 +105,11 @@ class ComputeNode extends Node {
 
 	}
 
+	/**
+	 * TODO
+	 *
+	 * @return {number|Array<number>}
+	 */
 	getCount() {
 
 		return this.count;
@@ -263,7 +274,7 @@ export const computeKernel = ( node, workgroupSize = [ 64 ] ) => {
  * @tsl
  * @function
  * @param {Node} node - TODO
- * @param {number} count - TODO.
+ * @param {number|Array<number>} count - TODO.
  * @param {Array<number>} [workgroupSize=[64]] - TODO.
  * @returns {AtomicFunctionNode}
  */


### PR DESCRIPTION
**Description**

This PR adds type annotations for the dispatch size in `ComputeNode`'s `count` parameter. It's [supported in WebGPUBackend](https://github.com/mrdoob/three.js/blob/r180/src/renderers/webgpu/WebGPUBackend.js#L1347). WebGLBackend doesn't support it, but the case is already handled and prints a warning.

While it made me consider renaming `setCount`, this PR focuses only on adding the type annotations in JSDoc to help clarify the supported usage.