### PR TITLE
GTAONode: Add basic support for temporal filtering.

### DIFF
--- a/examples/webgpu_postprocessing_ao.html
+++ b/examples/webgpu_postprocessing_ao.html
@@ -121,6 +121,7 @@
 
 				aoPass = ao( scenePassDepth, scenePassNormal, camera ).toInspector( 'AO' );
 				aoPass.resolutionScale = 0.5; // running AO in half resolution is often sufficient
+				aoPass.useTemporalFiltering = true;
 				blendPassAO = vec4( scenePassColor.rgb.mul( aoPass.r ), scenePassColor.a ); // the AO is stored only in the red channel
 
 				// traa
@@ -167,6 +168,7 @@
 				gui.add( params, 'radius', 0.1, 1 ).onChange( updateParameters );
 				gui.add( params, 'scale', 0.01, 2 ).onChange( updateParameters );
 				gui.add( params, 'thickness', 0.01, 2 ).onChange( updateParameters );
+				gui.add( aoPass, 'useTemporalFiltering' ).name( 'temporal filtering' );
 				gui.add( params, 'aoOnly' ).onChange( ( value ) => {
 
 					if ( value === true ) {


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/31839#issuecomment-3341583019

**Description**

The PR adds basic support for temporal filtering to `GTAONode` by introducing the temporal rotations constants from the Activision GTAO paper that we already used in `SSGINode`. The idea is to use these values to modulate the sampling direction over time. With this approach, you get more effective samplings accumulated by the TAA.

So in the example instead of:

<img width="189" height="75" alt="image" src="https://github.com/user-attachments/assets/3f029296-684f-4450-9ca9-e934682879e6" />

You get:

<img width="222" height="66" alt="image" src="https://github.com/user-attachments/assets/3a6572f9-13d0-4674-be79-dc5285649db8" />
 
A noticeable quality improvement with basically no additional costs. However, depending on the scene, you might see more temporal instabilities and ghosting similar to SSGI. These can be mitigate in the future by improving the temporal filtering in `GTAONode` and the TAA itself.

Temporal filtering is optional and by default set to `false` so this is no breaking change.