### PR TITLE
Editor: Fix material reference in `SetMaterialRangeCommand`.

### DIFF
--- a/editor/js/commands/SetMaterialRangeCommand.js
+++ b/editor/js/commands/SetMaterialRangeCommand.js
@@ -24,7 +24,7 @@ class SetMaterialRangeCommand extends Command {
 
 		const material = ( object !== null ) ? editor.getObjectMaterial( object, materialSlot ) : null;
 
-		this.oldRange = ( material !== null && material[ attributeName ] !== undefined ) ? [ ...this.material[ attributeName ] ] : null;
+		this.oldRange = ( material !== null && material[ attributeName ] !== undefined ) ? [ ... material[ attributeName ] ] : null;
 		this.newRange = [ newMinValue, newMaxValue ];
 
 		this.attributeName = attributeName;


### PR DESCRIPTION
Related issue: -

**Description**

This PR fixed the following issue:

1. add a sphere to scene
2. select the sphere, navigate to material tab
3. update property "thin-flim thickness" from 400nm to 401nm
4. now press f12, you should see an error raised
