### PR TITLE
Examples: Apply camera constraint immediately in WebGPU bloom demo.

### DIFF
--- a/examples/webgpu_postprocessing_bloom_emissive.html
+++ b/examples/webgpu_postprocessing_bloom_emissive.html
@@ -111,6 +111,7 @@
 				controls.minDistance = 2;
 				controls.maxDistance = 10;
 				controls.target.set( 0, 0, - 0.2 );
+				controls.update();
 
 				window.addEventListener( 'resize', onWindowResize );
 


### PR DESCRIPTION
Related issue: -

**Description**

This PR fixed the following issue:

1. open https://raw.githack.com/mrdoob/three.js/r180/examples/webgpu_postprocessing_bloom_emissive.html
2. await helmet model loaded
3. mouse click on screen, drag slowly to the right
4. you should see camera was shifted 
