### PR TITLE
VideoTexture: Reset internal state rVFCId on dispose.

### DIFF
--- a/src/textures/VideoTexture.js
+++ b/src/textures/VideoTexture.js
@@ -114,6 +114,8 @@ class VideoTexture extends Texture {
 
 			this.source.data.cancelVideoFrameCallback( this._requestVideoFrameCallbackId );
 
+			this._requestVideoFrameCallbackId = 0;
+
 		}
 
 		super.dispose();


### PR DESCRIPTION
Related issue: -

**Description**

Reset _requestVideoFrameCallbackId on dispose to satisfy:

https://github.com/mrdoob/three.js/blob/29ed210870e29cdf411de6bc674e8617cd432d9e/src/textures/VideoTexture.js#L59-L67

