### PR TITLE
PhysicalLightingModel: Fix `Favg` assignment

### DIFF
--- a/src/nodes/functions/PhysicalLightingModel.js
+++ b/src/nodes/functions/PhysicalLightingModel.js
@@ -561,7 +561,7 @@ class PhysicalLightingModel extends LightingModel {
 		const Ess = fab.x.add( fab.y );
 		const Ems = Ess.oneMinus();
 
-		const Favg = specularColor.add( specularColor.oneMinus().mul( 0.047619 ) ); // 1/21
+		const Favg = Fr.add( Fr.oneMinus().mul( 0.047619 ) ); // 1/21
 		const Fms = FssEss.mul( Favg ).div( Ems.mul( Favg ).oneMinus() );
 
 		singleScatter.addAssign( FssEss );


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/26489#discussion_r2445348676

**Description**

Follow the WebGLRenderer `computeMultiscattering`
https://github.com/mrdoob/three.js/blob/dev/src/renderers/shaders/ShaderChunk/lights_physical_pars_fragment.glsl.js#L421
