### PR TITLE
GLTFLoader: add KHR_animation_pointer and NEEDLE_progressive

### DIFF
--- a/docs/examples/en/loaders/GLTFLoader.html
+++ b/docs/examples/en/loaders/GLTFLoader.html
@@ -69,6 +69,8 @@
 		<ul>
 			<li>[link:https://github.com/takahirox/three-gltf-extensions KHR_materials_variants]<sup>1</sup></li>
 			<li>[link:https://github.com/takahirox/three-gltf-extensions MSFT_texture_dds]</li>
+			<li>[link:https://github.com/needle-tools/three-animation-pointer KHR_animation_pointer]</li>
+			<li>[link:https://github.com/needle-tools/gltf-progressive NEEDLE_progressive]</li>
 		</ul>
 
 		<p><i>

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -101,6 +101,8 @@ import { toTrianglesDrawMode } from '../utils/BufferGeometryUtils.js';
  * The following glTF 2.0 extension is supported by an external user plugin:
  * - [KHR_materials_variants]{@link https://github.com/takahirox/three-gltf-extensions}
  * - [MSFT_texture_dds]{@link https://github.com/takahirox/three-gltf-extensions}
+ * - [KHR_animation_pointer]{@link https://github.com/needle-tools/three-animation-pointer}
+ * - [NEEDLE_progressive]{@link https://github.com/needle-tools/gltf-progressive}
  *
  * ```js
  * const loader = new GLTFLoader();


### PR DESCRIPTION
**Description**

This PR adds a link to the [GLTFLoader documentation](https://threejs.org/docs/#examples/en/loaders/GLTFLoader) for external extensions support for [KHR_animation_pointer](https://github.com/needle-tools/three-animation-pointer) and [NEEDLE_progressive](https://github.com/needle-tools/gltf-progressive)

Both extensions have three.js examples here: [animation-pointer](https://threejs.org/examples/?q=animation%20pointer#webgl_loader_gltf_animation_pointer). [progressive](https://threejs.org/examples/?q=prog#webgl_loader_gltf_progressive_lod)


