### PR TITLE
WebGPURenderer: Enable dynamic shadowMap type switching.

### DIFF
--- a/src/nodes/lighting/ShadowNode.js
+++ b/src/nodes/lighting/ShadowNode.js
@@ -567,7 +567,7 @@ class ShadowNode extends ShadowBaseNode {
 
 			const currentShadowType = builder.renderer.shadowMap.type;
 
-			if ( this._currentShadowType !== null && this._currentShadowType !== currentShadowType ) {
+			if ( this._currentShadowType !== currentShadowType ) {
 
 				this._reset();
 				this._node = null;

--- a/src/nodes/lighting/ShadowNode.js
+++ b/src/nodes/lighting/ShadowNode.js
@@ -273,8 +273,22 @@ class ShadowNode extends ShadowBaseNode {
 		 */
 		this._node = null;
 
-		this._builtShadowType = undefined;
+		/**
+		 * The current shadow map type of this shadow node.
+		 *
+		 * @type {?number}
+		 * @private
+		 * @default null
+		 */
+		this._currentShadowType = null;
 
+		/**
+		 * A Weak Map holding the current frame ID per camera. Used
+		 * to control the update of shadow maps.
+		 *
+		 * @type {WeakMap<Camera,number>}
+		 * @private
+		 */
 		this._cameraFrameId = new WeakMap();
 
 		/**
@@ -551,11 +565,11 @@ class ShadowNode extends ShadowBaseNode {
 
 		return Fn( () => {
 
-			const currentType = builder.renderer.shadowMap.type;
+			const currentShadowType = builder.renderer.shadowMap.type;
 
-			if ( this._builtShadowType !== undefined && this._builtShadowType !== currentType ) {
+			if ( this._currentShadowType !== null && this._currentShadowType !== currentShadowType ) {
 
-				this.disposeShadowResources();
+				this._reset();
 				this._node = null;
 
 			}
@@ -567,7 +581,7 @@ class ShadowNode extends ShadowBaseNode {
 			if ( node === null ) {
 
 				this._node = node = this.setupShadow( builder );
-				this._builtShadowType = currentType;
+				this._currentShadowType = currentShadowType;
 
 			}
 
@@ -700,16 +714,20 @@ class ShadowNode extends ShadowBaseNode {
 	 */
 	dispose() {
 
-		this.disposeShadowResources();
+		this._reset();
 
 		super.dispose();
 
 	}
 
 	/**
-	 * Frees the internal shadow map resources.
+	 * Resets the resouce state of this shadow node.
+	 *
+	 * @private
 	 */
-	disposeShadowResources() {
+	_reset() {
+
+		this._currentShadowType = null;
 
 		if ( this.shadowMap ) {
 

--- a/src/nodes/lighting/ShadowNode.js
+++ b/src/nodes/lighting/ShadowNode.js
@@ -273,6 +273,8 @@ class ShadowNode extends ShadowBaseNode {
 		 */
 		this._node = null;
 
+		this._builtShadowType = undefined;
+
 		this._cameraFrameId = new WeakMap();
 
 		/**
@@ -549,6 +551,15 @@ class ShadowNode extends ShadowBaseNode {
 
 		return Fn( () => {
 
+			const currentType = builder.renderer.shadowMap.type;
+
+			if ( this._builtShadowType !== undefined && this._builtShadowType !== currentType ) {
+
+				this.disposeShadowResources();
+				this._node = null;
+
+			}
+
 			let node = this._node;
 
 			this.setupShadowPosition( builder );
@@ -556,6 +567,7 @@ class ShadowNode extends ShadowBaseNode {
 			if ( node === null ) {
 
 				this._node = node = this.setupShadow( builder );
+				this._builtShadowType = currentType;
 
 			}
 
@@ -688,8 +700,23 @@ class ShadowNode extends ShadowBaseNode {
 	 */
 	dispose() {
 
-		this.shadowMap.dispose();
-		this.shadowMap = null;
+		this.disposeShadowResources();
+
+		super.dispose();
+
+	}
+
+	/**
+	 * Frees the internal shadow map resources.
+	 */
+	disposeShadowResources() {
+
+		if ( this.shadowMap ) {
+
+			this.shadowMap.dispose();
+			this.shadowMap = null;
+
+		}
 
 		if ( this.vsmShadowMapVertical !== null ) {
 
@@ -710,8 +737,6 @@ class ShadowNode extends ShadowBaseNode {
 			this.vsmMaterialHorizontal = null;
 
 		}
-
-		super.dispose();
 
 	}
 

--- a/src/renderers/common/nodes/Nodes.js
+++ b/src/renderers/common/nodes/Nodes.js
@@ -413,6 +413,7 @@ class Nodes extends DataMap {
 
 			_cacheKeyValues.push( this.renderer.getOutputRenderTarget() && this.renderer.getOutputRenderTarget().multiview ? 1 : 0 );
 			_cacheKeyValues.push( this.renderer.shadowMap.enabled ? 1 : 0 );
+			_cacheKeyValues.push( this.renderer.shadowMap.type );
 
 			cacheKeyData.callId = callId;
 			cacheKeyData.cacheKey = hashArray( _cacheKeyValues );


### PR DESCRIPTION
This PR makes two related fixes:

* Allow changing the shadow map type at runtime

* Prevent exceptions from incorrect shadow node state (for example, PCF -> VSM)

<img width="370" height="550" alt="Screenshot 2025-10-22 at 12 31 35" src="https://github.com/user-attachments/assets/0d9a0c21-579b-42c1-a4af-bcb68c762f52" />

