### PR TITLE
KTX2Loader: Honor `setRequestHeader()`.

### DIFF
--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -359,7 +359,7 @@ class KTX2Loader extends Loader {
 		loader.setPath( this.path );
 		loader.setCrossOrigin( this.crossOrigin );
 		loader.setWithCredentials( this.withCredentials );
-		loader.setRequestHeader(this.requestHeader);
+		loader.setRequestHeader( this.requestHeader );
 		loader.setResponseType( 'arraybuffer' );
 
 		loader.load( url, ( buffer ) => {

--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -359,6 +359,7 @@ class KTX2Loader extends Loader {
 		loader.setPath( this.path );
 		loader.setCrossOrigin( this.crossOrigin );
 		loader.setWithCredentials( this.withCredentials );
+		loader.setRequestHeader(this.requestHeader);
 		loader.setResponseType( 'arraybuffer' );
 
 		loader.load( url, ( buffer ) => {


### PR DESCRIPTION
Configure the internal loader to use the same request header of its owner
