### PR TITLE
SVGLoader: Add stylesheet jsName vs svgName fix.

### DIFF
--- a/examples/jsm/loaders/SVGLoader.js
+++ b/examples/jsm/loaders/SVGLoader.js
@@ -1082,7 +1082,7 @@ class SVGLoader extends Loader {
 				};
 
 				if ( node.hasAttribute( svgName ) ) style[ jsName ] = adjustFunction( node.getAttribute( svgName ) );
-				if ( stylesheetStyles[ svgName ] ) style[ jsName ] = adjustFunction( stylesheetStyles[ svgName ] );
+				if ( stylesheetStyles[ jsName ] ) style[ jsName ] = adjustFunction( stylesheetStyles[ jsName ] );
 				if ( node.style && node.style[ svgName ] !== '' ) style[ jsName ] = adjustFunction( node.style[ svgName ] );
 
 			}


### PR DESCRIPTION
Related issue: #XXXX

**Description**

In the SVG Loader, there's some code to read styles from embedded style sheets, which are held in a collection called stylesheetStyles.  This collection was being indexed into using svgName, but the styles in an embedded style sheet are actually identified by the slightly different jsName so, where these two differed, the styles were not being picked up.

The fix is a one-line change, in which stylesheetStyles[ svgName ] is replaced with stylesheetStyles[ jsName ] (two occurrences).

For example, here is a style node from an SVG file:

<style>.highlightBox {
	fill: #ffa500;
	fill-opacity: .2;
}
.highlightBoxReferent {
	fill: #9ff3db;
	fill-opacity: .3;
}</style>

Elsewhere in the file, there are elements with this attribute
class="highlightBox"

With the old code, these elements were rendered as fully opaque but, with this fix, they are now rendered with the specified opacity of .2.  

The likely reason this wasn't noticed before is that not all styles are affected.  In the example above, the fill colour was not affected because, for fill colour, the svgName and the jsName are the same (namely, "fill").

SVG file referenced in this example:
[LogicEssence1_TimesNewRomanPSMT_TimesNewRomanPSMT.xml](https://github.com/user-attachments/files/23115574/LogicEssence1_TimesNewRomanPSMT_TimesNewRomanPSMT.xml)

screenshot with old code:
<img width="960" height="520" alt="opaque" src="https://github.com/user-attachments/assets/fe7f1b85-c833-4491-8287-3c9f2bc3b818" />

screenshot with fixed code:
<img width="960" height="520" alt="transparent" src="https://github.com/user-attachments/assets/e472b359-2d01-45c5-96d9-26f1c37e0a1d" />
