### PR TITLE
LoadingManager: Lazily instantiate abort controller.

### DIFF
--- a/src/loaders/LoadingManager.js
+++ b/src/loaders/LoadingManager.js
@@ -72,9 +72,9 @@ class LoadingManager {
 		/**
 		 * Used for aborting ongoing requests in loaders using this manager.
 		 *
-		 * @type {AbortController}
+		 * @type {AbortController | null}
 		 */
-		this.abortController = new AbortController();
+		this._abortController = null;
 
 		/**
 		 * This should be called by any loader using the manager when the loader
@@ -285,12 +285,34 @@ class LoadingManager {
 		 */
 		this.abort = function () {
 
-			this.abortController.abort();
-			this.abortController = new AbortController();
+
+			if ( this.abortController ) {
+
+				this.abortController.abort();
+				this._abortController = null;
+
+			}
 
 			return this;
 
 		};
+
+	}
+
+	/**
+	 * Used for aborting ongoing requests in loaders using this manager.
+	 *
+	 * @type {AbortController}
+	 */
+	get abortController() {
+
+		if ( ! this._abortController ) {
+
+			this._abortController = new AbortController();
+
+		}
+
+		return this._abortController;
 
 	}
 

--- a/src/loaders/LoadingManager.js
+++ b/src/loaders/LoadingManager.js
@@ -286,12 +286,8 @@ class LoadingManager {
 		this.abort = function () {
 
 
-			if ( this.abortController ) {
-
-				this.abortController.abort();
-				this._abortController = null;
-
-			}
+			this.abortController.abort();
+			this._abortController = null;
 
 			return this;
 

--- a/src/loaders/LoadingManager.js
+++ b/src/loaders/LoadingManager.js
@@ -72,6 +72,7 @@ class LoadingManager {
 		/**
 		 * Used for aborting ongoing requests in loaders using this manager.
 		 *
+		 * @private
 		 * @type {AbortController | null}
 		 */
 		this._abortController = null;

--- a/src/loaders/LoadingManager.js
+++ b/src/loaders/LoadingManager.js
@@ -295,6 +295,9 @@ class LoadingManager {
 
 	}
 
+	// TODO: Revert this back to a single member variable once this issue has been fixed
+	// https://github.com/cloudflare/workerd/issues/3657
+
 	/**
 	 * Used for aborting ongoing requests in loaders using this manager.
 	 *

--- a/test/unit/src/loaders/LoadingManager.tests.js
+++ b/test/unit/src/loaders/LoadingManager.tests.js
@@ -121,6 +121,56 @@ export default QUnit.module( 'Loaders', () => {
 
 		} );
 
+		QUnit.test( 'abortController - lazy instantiation', ( assert ) => {
+
+			const loadingManager = new LoadingManager();
+
+			assert.equal( loadingManager._abortController, null, '_abortController is initially null.' );
+
+			const controller = loadingManager.abortController;
+
+			assert.ok( controller instanceof AbortController, 'abortController returns an AbortController instance.' );
+			assert.equal( loadingManager._abortController, controller, '_abortController is set after first access.' );
+
+			const controller2 = loadingManager.abortController;
+			assert.equal( controller, controller2, 'Subsequent accesses return the same AbortController instance.' );
+
+		} );
+
+		QUnit.test( 'abort() - aborts controller and resets', ( assert ) => {
+
+			const loadingManager = new LoadingManager();
+
+			const controller = loadingManager.abortController;
+
+			assert.ok( ! controller.signal.aborted, 'Controller signal is not aborted initially.' );
+
+			loadingManager.abort();
+
+			assert.ok( controller.signal.aborted, 'Controller signal is aborted after calling abort().' );
+			assert.equal( loadingManager._abortController, null, '_abortController is reset to null after abort().' );
+
+		} );
+
+		QUnit.test( 'abortController - recreation after abort', ( assert ) => {
+
+			const loadingManager = new LoadingManager();
+
+			const controller1 = loadingManager.abortController;
+
+			loadingManager.abort();
+
+			assert.ok( controller1.signal.aborted, 'First controller is aborted.' );
+			assert.equal( loadingManager._abortController, null, '_abortController is null after abort.' );
+
+			const controller2 = loadingManager.abortController;
+
+			assert.ok( controller2 instanceof AbortController, 'New AbortController is created.' );
+			assert.notEqual( controller1, controller2, 'New controller is a different instance from the aborted one.' );
+			assert.ok( ! controller2.signal.aborted, 'New controller signal is not aborted.' );
+
+		} );
+
 	} );
 
 } );


### PR DESCRIPTION
**Description**

This is a fix for a very niche edge case, but wanted to at least propose a fix for it.

#### The problem

For context, I work for @ronin-co and we are building [`blade`](https://blade.im/), a React framework for building instant web apps. With this we have found when deploying to Cloudflare Workers, which is powered by [workerd](https://github.com/cloudflare/workerd), their API throws an error if a Blade project tries to use Three.js:
```log
Uncaught Error: Disallowed operation called within global scope. Asynchronous I/O (ex: fetch() or connect()), setting a timeout, and generating random values are not allowed within global scope. To fix this error, perform this operation within a handler. https://developers.cloudflare.com/workers/runtime-apis/handlers/
  at public/client/chunk.3154980606.js:37678:27 in LoadingManager
  at public/client/chunk.3154980606.js:37828:48 in cdn:https://unpkg.com/three
  at public/client/chunk.3154980606.js:10:51
  at public/client/chunk.3154980606.js:48683:46
```
After a bit of investigating I found [this issue](https://github.com/cloudflare/workerd/issues/3657) outlining that workerd does not currently support creating a new abort controller instance in global scope, which the`LoadingManager` loader seems to rely on to construct a new instance.

#### The solution

I found [this PR](https://github.com/mastra-ai/mastra/pull/6470/files) which defers calling `new AbortController()` on class construction, and instead uses a getter to manage it. Testing this on our Blade project that uses Three.js it seems to fix the issue.

With this I have added some basic unit tests to validate this logic, however I am not deeply familiar with this code base so there could be something I am missing here.