### PR TITLE
Selective Bloom Example: Add bloomStrength uniform to enhance bloom effect control

### DIFF
--- a/examples/webgl_postprocessing_unreal_bloom_selective.html
+++ b/examples/webgl_postprocessing_unreal_bloom_selective.html
@@ -30,12 +30,13 @@
 
 			uniform sampler2D baseTexture;
 			uniform sampler2D bloomTexture;
+			uniform float bloomStrength;
 
 			varying vec2 vUv;
 
 			void main() {
 
-				gl_FragColor = ( texture2D( baseTexture, vUv ) + vec4( 1.0 ) * texture2D( bloomTexture, vUv ) );
+				gl_FragColor = ( texture2D( baseTexture, vUv ) + vec4( 1.0 ) * texture2D( bloomTexture, vUv ) * bloomStrength );
 
 			}
 
@@ -116,7 +117,8 @@
 				new THREE.ShaderMaterial( {
 					uniforms: {
 						baseTexture: { value: null },
-						bloomTexture: { value: bloomComposer.renderTarget2.texture }
+						bloomTexture: { value: bloomComposer.renderTarget2.texture },
+						bloomStrength: { value: params.strength }
 					},
 					vertexShader: document.getElementById( 'vertexshader' ).textContent,
 					fragmentShader: document.getElementById( 'fragmentshader' ).textContent,
@@ -153,6 +155,9 @@
 			bloomFolder.add( params, 'strength', 0.0, 3 ).onChange( function ( value ) {
 
 				bloomPass.strength = Number( value );
+				// Pass strength also to the mix shader so the final composite intensity matches
+				mixPass && mixPass.material && mixPass.material.uniforms && mixPass.material.uniforms.bloomStrength && ( mixPass.material.uniforms.bloomStrength.value = Number( value ) );
+
 				render();
 
 			} );

--- a/examples/webgl_postprocessing_unreal_bloom_selective.html
+++ b/examples/webgl_postprocessing_unreal_bloom_selective.html
@@ -155,8 +155,7 @@
 			bloomFolder.add( params, 'strength', 0.0, 3 ).onChange( function ( value ) {
 
 				bloomPass.strength = Number( value );
-				// Pass strength also to the mix shader so the final composite intensity matches
-				mixPass && mixPass.material && mixPass.material.uniforms && mixPass.material.uniforms.bloomStrength && ( mixPass.material.uniforms.bloomStrength.value = Number( value ) );
+				mixPass.material.uniforms.bloomStrength.value = bloomPass.strength;
 
 				render();
 

--- a/examples/webgl_postprocessing_unreal_bloom_selective.html
+++ b/examples/webgl_postprocessing_unreal_bloom_selective.html
@@ -36,7 +36,7 @@
 
 			void main() {
 
-				gl_FragColor = ( texture2D( baseTexture, vUv ) + vec4( 1.0 ) * texture2D( bloomTexture, vUv ) * bloomStrength );
+				gl_FragColor = ( texture2D( baseTexture, vUv ) + texture2D( bloomTexture, vUv ) * bloomStrength );
 
 			}
 


### PR DESCRIPTION
Adds a bloomStrength uniform to the mix shader in `webgl_postprocessing_unreal_bloom_selective.html` and wires the GUI strength slider to it so the final composite matches the bloom pass intensity.

[Notes and ensures parity with BloomNode which already exposes a strength uniform.](https://github.com/mrdoob/three.js/blob/b24a79100fba0ddc6d3e284f0cb3c99888c6e143/examples/jsm/tsl/display/BloomNode.js#L411)
