### PR TITLE
WebGPURenderer: Fix types for indirect compute and modify example to show usage

### DIFF
--- a/examples/webgpu_compute_particles.html
+++ b/examples/webgpu_compute_particles.html
@@ -31,15 +31,14 @@
 		<script type="module">
 
 			import * as THREE from 'three/webgpu';
-			import { Fn, If, Switch, uniform, float, uv, vec2, vec3, hash, shapeCircle, storage,
+			import { Fn, If, uniform, float, uv, vec3, hash, shapeCircle,
 				instancedArray, instanceIndex } from 'three/tsl';
 
 			import { Inspector } from 'three/addons/inspector/Inspector.js';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 
-			const particleCount = 200_000;
-			const movableParticleCount = particleCount / 2;
+			const particleCount = 200000;
 
 			const gravity = uniform( - .00098 );
 			const bounce = uniform( .8 );
@@ -187,24 +186,6 @@
 
 				//
 
-				const movableParticleIndirectBuffer = new THREE.IndirectStorageBufferAttribute(new Uint32Array(3));
-				const movableParticleBufferNode = storage( movableParticleIndirectBuffer, 'uint' );
-
-				const computeMovableCount = Fn( () => {
-
-					If( instanceIndex.lessThan( 3 ), () => {
-						const count = movableParticleBufferNode.element(instanceIndex);
-
-						Switch(instanceIndex)
-							.Case(0, () => count.assign(Math.ceil(movableParticleCount / 64)))
-							.Case(1, () => count.assign(1))
-							.Case(2, () => count.assign(1));
-					})
-
-				} )().compute( 3 );
-
-				renderer.computeAsync( computeMovableCount );
-
 				function onMove( event ) {
 
 					if ( isOrbitControlsActive ) return;
@@ -226,7 +207,7 @@
 
 						// compute
 
-						renderer.compute( computeHit, movableParticleIndirectBuffer );
+						renderer.compute( computeHit );
 
 					}
 

--- a/examples/webgpu_compute_particles.html
+++ b/examples/webgpu_compute_particles.html
@@ -31,14 +31,15 @@
 		<script type="module">
 
 			import * as THREE from 'three/webgpu';
-			import { Fn, If, uniform, float, uv, vec3, hash, shapeCircle,
+			import { Fn, If, Switch, uniform, float, uv, vec2, vec3, hash, shapeCircle, storage,
 				instancedArray, instanceIndex } from 'three/tsl';
 
 			import { Inspector } from 'three/addons/inspector/Inspector.js';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 
-			const particleCount = 200000;
+			const particleCount = 200_000;
+			const movableParticleCount = particleCount / 2;
 
 			const gravity = uniform( - .00098 );
 			const bounce = uniform( .8 );
@@ -186,6 +187,24 @@
 
 				//
 
+				const movableParticleIndirectBuffer = new THREE.IndirectStorageBufferAttribute(new Uint32Array(3));
+				const movableParticleBufferNode = storage( movableParticleIndirectBuffer, 'uint' );
+
+				const computeMovableCount = Fn( () => {
+
+					If( instanceIndex.lessThan( 3 ), () => {
+						const count = movableParticleBufferNode.element(instanceIndex);
+
+						Switch(instanceIndex)
+							.Case(0, () => count.assign(Math.ceil(movableParticleCount / 64)))
+							.Case(1, () => count.assign(1))
+							.Case(2, () => count.assign(1));
+					})
+
+				} )().compute( 3 );
+
+				renderer.computeAsync( computeMovableCount );
+
 				function onMove( event ) {
 
 					if ( isOrbitControlsActive ) return;
@@ -207,7 +226,7 @@
 
 						// compute
 
-						renderer.compute( computeHit );
+						renderer.compute( computeHit, movableParticleIndirectBuffer );
 
 					}
 

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -2434,7 +2434,7 @@ class Renderer {
 
 			warn( 'Renderer: .compute() called before the backend is initialized. Try using .computeAsync() instead.' );
 
-			return this.computeAsync( computeNodes );
+			return this.computeAsync( computeNodes, dispatchSize );
 
 		}
 

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -2420,10 +2420,10 @@ class Renderer {
 	 * if the renderer has been initialized.
 	 *
 	 * @param {Node|Array<Node>} computeNodes - The compute node(s).
-	 * @param {number|Array<number>|GPUBuffer} [dispatchSize=null]
+	 * @param {number|Array<number>|IndirectStorageBufferAttribute} [dispatchSize=null]
 	 * - A single number representing count, or
 	 * - An array [x, y, z] representing dispatch size, or
-	 * - A GPUBuffer for indirect dispatch size.
+	 * - A IndirectStorageBufferAttribute for indirect dispatch size.
 	 * @return {Promise|undefined} A Promise that resolve when the compute has finished. Only returned when the renderer has not been initialized.
 	 */
 	compute( computeNodes, dispatchSize = null ) {
@@ -2532,10 +2532,10 @@ class Renderer {
 	 *
 	 * @async
 	 * @param {Node|Array<Node>} computeNodes - The compute node(s).
-	 * @param {number|Array<number>|GPUBuffer} [dispatchSize=null]
+	 * @param {number|Array<number>|IndirectStorageBufferAttribute} [dispatchSize=null]
 	 * - A single number representing count, or
 	 * - An array [x, y, z] representing dispatch size, or
-	 * - A GPUBuffer for indirect dispatch size.
+	 * - A IndirectStorageBufferAttribute for indirect dispatch size.
 	 * @return {Promise} A Promise that resolve when the compute has finished.
 	 */
 	async computeAsync( computeNodes, dispatchSize = null ) {

--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -852,6 +852,12 @@ class WebGLBackend extends Backend {
 
 			count = count[ 0 ];
 
+		} else if ( count && typeof count === 'object' && count.isIndirectStorageBufferAttribute ) {
+
+			warnOnce( 'WebGLBackend.compute(): The count parameter must be a single number, not IndirectStorageBufferAttribute' );
+
+			count = computeNode.count;
+
 		}
 
 		if ( attributes[ 0 ].isStorageInstancedBufferAttribute ) {

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -1343,10 +1343,10 @@ class WebGPUBackend extends Backend {
 	 * @param {Node} computeNode - The compute node.
 	 * @param {Array<BindGroup>} bindings - The bindings.
 	 * @param {ComputePipeline} pipeline - The compute pipeline.
-	 * @param {number|Array<number>|GPUBuffer} [dispatchSize=null]
+	 * @param {number|Array<number>|IndirectStorageBufferAttribute} [dispatchSize=null]
 	 * - A single number representing count, or
 	 * - An array [x, y, z] representing dispatch size, or
-	 * - A GPUBuffer for indirect dispatch size.
+	 * - A IndirectStorageBufferAttribute for indirect dispatch size.
 	 */
 	compute( computeGroup, computeNode, bindings, pipeline, dispatchSize = null ) {
 

--- a/test/e2e/puppeteer.js
+++ b/test/e2e/puppeteer.js
@@ -22,6 +22,7 @@ const exceptionList = [
 	'webgpu_postprocessing_traa',
 	'webgpu_reflection',
 	'webgpu_texturegrad',
+	'webgpu_tsl_vfx_flames',
 
 	// Need more time
 	'css3d_mixed',


### PR DESCRIPTION
Related issue: #30982

**Description**

This is a follow-up PR for https://github.com/mrdoob/three.js/pull/31488
- Fix types for compute and computeAsync functions
- Handle indirect buffer in webgl backend gracefully
- In webgpu_compute_particles example make only half of the balls move based on an indirect buffer
- Respect dispatchSize when running computeAsync from compute on uninitialized renderer

cc: @sunag 