### PR TITLE
Update JSDoc links for better readability

### DIFF
--- a/examples/jsm/animation/CCDIKSolver.js
+++ b/examples/jsm/animation/CCDIKSolver.js
@@ -26,7 +26,7 @@ const _vector = new Vector3();
 const _matrix = new Matrix4();
 
 /**
- * This class solves the Inverse Kinematics Problem with a [CCD Algorithm]{@link https://web.archive.org/web/20221206080850/https://sites.google.com/site/auraliusproject/ccd-algorithm}.
+ * This class solves the Inverse Kinematics Problem with a [CCD Algorithm](https://web.archive.org/web/20221206080850/https://sites.google.com/site/auraliusproject/ccd-algorithm).
  *
  * `CCDIKSolver` is designed to work with instances of {@link SkinnedMesh}.
  *

--- a/examples/jsm/controls/PointerLockControls.js
+++ b/examples/jsm/controls/PointerLockControls.js
@@ -35,7 +35,7 @@ const _MOUSE_SENSITIVITY = 0.002;
 const _PI_2 = Math.PI / 2;
 
 /**
- * The implementation of this class is based on the [Pointer Lock API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Pointer_Lock_API}.
+ * The implementation of this class is based on the [Pointer Lock API](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_Lock_API).
  * `PointerLockControls` is a perfect choice for first person 3D games.
  *
  * ```js

--- a/examples/jsm/effects/AsciiEffect.js
+++ b/examples/jsm/effects/AsciiEffect.js
@@ -1,7 +1,7 @@
 /**
  * A class that creates an ASCII effect.
  *
- * The ASCII generation is based on [jsascii]{@link https://github.com/hassadee/jsascii/blob/master/jsascii.js}.
+ * The ASCII generation is based on [jsascii](https://github.com/hassadee/jsascii/blob/master/jsascii.js).
  *
  * @three_import import { AsciiEffect } from 'three/addons/effects/AsciiEffect.js';
  */

--- a/examples/jsm/exporters/DRACOExporter.js
+++ b/examples/jsm/exporters/DRACOExporter.js
@@ -5,7 +5,7 @@ import { Color, ColorManagement, SRGBColorSpace } from 'three';
 /**
  * An exporter to compress geometry with the Draco library.
  *
- * [Draco]{@link https://google.github.io/draco/} is an open source library for compressing and
+ * [Draco](https://google.github.io/draco/) is an open source library for compressing and
  * decompressing 3D meshes and point clouds. Compressed geometry can be significantly smaller,
  * at the cost of additional decoding time on the client device.
  *
@@ -13,7 +13,7 @@ import { Color, ColorManagement, SRGBColorSpace } from 'three';
  * normals, colors, and other attributes. Draco files *do not* contain materials,
  * textures, animation, or node hierarchies – to use these features, embed Draco geometry
  * inside of a glTF file. A normal glTF file can be converted to a Draco-compressed glTF file
- * using [glTF-Pipeline]{@link https://github.com/AnalyticalGraphicsInc/gltf-pipeline}.
+ * using [glTF-Pipeline](https://github.com/AnalyticalGraphicsInc/gltf-pipeline).
  *
  * ```js
  * const exporter = new DRACOExporter();

--- a/examples/jsm/exporters/EXRExporter.js
+++ b/examples/jsm/exporters/EXRExporter.js
@@ -15,7 +15,7 @@ const ZIP_COMPRESSION = 3;
 /**
  * An exporter for EXR.
  *
- * EXR ( Extended Dynamic Range) is an [open format specification]{@link https://github.com/AcademySoftwareFoundation/openexr}
+ * EXR ( Extended Dynamic Range) is an [open format specification](https://github.com/AcademySoftwareFoundation/openexr)
  * for professional-grade image storage format of the motion picture industry. The purpose of
  * format is to accurately and efficiently represent high-dynamic-range scene-linear image data
  * and associated metadata. The library is widely used in host application software where accuracy

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -65,13 +65,13 @@ const KHR_mesh_quantization_ExtraAttrTypes = {
 /**
  * An exporter for `glTF` 2.0.
  *
- * glTF (GL Transmission Format) is an [open format specification]{@link https://github.com/KhronosGroup/glTF/tree/master/specification/2.0}
+ * glTF (GL Transmission Format) is an [open format specification](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0)
  * for efficient delivery and loading of 3D content. Assets may be provided either in JSON (.gltf)
  * or binary (.glb) format. External files store textures (.jpg, .png) and additional binary
  * data (.bin). A glTF asset may deliver one or more scenes, including meshes, materials,
  * textures, skins, skeletons, morph targets, animations, lights, and/or cameras.
  *
- * GLTFExporter supports the [glTF 2.0 extensions]{@link https://github.com/KhronosGroup/glTF/tree/master/extensions/}:
+ * GLTFExporter supports the [glTF 2.0 extensions](https://github.com/KhronosGroup/glTF/tree/master/extensions/):
  *
  * - KHR_lights_punctual
  * - KHR_materials_clearcoat
@@ -91,7 +91,7 @@ const KHR_mesh_quantization_ExtraAttrTypes = {
  *
  * The following glTF 2.0 extension is supported by an external user plugin:
  *
- * - [KHR_materials_variants]{@link https://github.com/takahirox/three-gltf-extensions}
+ * - [KHR_materials_variants](https://github.com/takahirox/three-gltf-extensions)
  *
  * ```js
  * const exporter = new GLTFExporter();

--- a/examples/jsm/geometries/DecalGeometry.js
+++ b/examples/jsm/geometries/DecalGeometry.js
@@ -13,9 +13,9 @@ import {
  * adding unique details to models, performing dynamic visual environmental changes or covering seams.
  *
  * Please not that decal projections can be distorted when used around corners. More information at
- * this GitHub issue: [Decal projections without distortions]{@link https://github.com/mrdoob/three.js/issues/21187}.
+ * this GitHub issue: [Decal projections without distortions](https://github.com/mrdoob/three.js/issues/21187).
  *
- * Reference: [How to project decals]{@link http://blog.wolfire.com/2009/06/how-to-project-decals/}
+ * Reference: [How to project decals](http://blog.wolfire.com/2009/06/how-to-project-decals/)
  *
  * ```js
  * const geometry = new DecalGeometry( mesh, position, orientation, size );

--- a/examples/jsm/geometries/ParametricGeometry.js
+++ b/examples/jsm/geometries/ParametricGeometry.js
@@ -7,7 +7,7 @@ import {
 /**
  * This class can be used to generate a geometry based on a parametric surface.
  *
- * Reference: [Mesh Generation with Python]{@link https://prideout.net/blog/old/blog/index.html@p=44.html}
+ * Reference: [Mesh Generation with Python](https://prideout.net/blog/old/blog/index.html@p=44.html)
  *
  * ```js
  * const geometry = new THREE.ParametricGeometry( klein, 25, 25 );

--- a/examples/jsm/geometries/TeapotGeometry.js
+++ b/examples/jsm/geometries/TeapotGeometry.js
@@ -15,8 +15,8 @@ import {
  * Segments 'n' determines the number of triangles output. Total triangles = 32*2*n*n - 8*n
  * (degenerates at the top and bottom cusps are deleted).
  *
- * Code based on [SPD software]{@link http://tog.acm.org/resources/SPD/}
- * Created for the Udacity course [Interactive Rendering]{@link http://bit.ly/ericity}
+ * Code based on [SPD software](http://tog.acm.org/resources/SPD/)
+ * Created for the Udacity course [Interactive Rendering](http://bit.ly/ericity)
  *
  * ```js
  * const geometry = new TeapotGeometry( 50, 18 );

--- a/examples/jsm/geometries/TextGeometry.js
+++ b/examples/jsm/geometries/TextGeometry.js
@@ -8,7 +8,7 @@ import {
  *
  * See the {@link FontLoader} page for additional details.
  *
- * `TextGeometry` uses [typeface.json]{@link http://gero3.github.io/facetype.js/} generated fonts.
+ * `TextGeometry` uses [typeface.json](http://gero3.github.io/facetype.js/) generated fonts.
  * Some existing fonts can be found located in `/examples/fonts`.
  *
  * ```js

--- a/examples/jsm/helpers/ViewHelper.js
+++ b/examples/jsm/helpers/ViewHelper.js
@@ -20,7 +20,7 @@ import {
 /**
  * A special type of helper that visualizes the camera's transformation
  * in a small viewport area as an axes helper. Such a helper is often wanted
- * in 3D modeling tools or scene editors like the [three.js editor]{@link https://threejs.org/editor}.
+ * in 3D modeling tools or scene editors like the [three.js editor](https://threejs.org/editor).
  *
  * The helper allows to click on the X, Y and Z axes which animates the camera
  * so it looks along the selected axis.

--- a/examples/jsm/lights/RectAreaLightTexturesLib.js
+++ b/examples/jsm/lights/RectAreaLightTexturesLib.js
@@ -15,7 +15,7 @@ import {
  * in data textures for further use in the renderer.
  *
  * Reference: Real-Time Polygonal-Light Shading with Linearly Transformed Cosines
- * by Eric Heitz, Jonathan Dupuy, Stephen Hill and David Neubelt. [Code]{@link https://github.com/selfshadow/ltc_code/}.
+ * by Eric Heitz, Jonathan Dupuy, Stephen Hill and David Neubelt. [Code](https://github.com/selfshadow/ltc_code/).
  *
  * NOTE: This is a temporary location for the BRDF approximation texture data
  * based off of Eric Heitz's work (see citation). BRDF data for

--- a/examples/jsm/loaders/3MFLoader.js
+++ b/examples/jsm/loaders/3MFLoader.js
@@ -24,7 +24,7 @@ import * as fflate from '../libs/fflate.module.js';
 const COLOR_SPACE_3MF = SRGBColorSpace;
 
 /**
- * A loader for the [3D Manufacturing Format (3MF)]{@link https://3mf.io/specification/} format.
+ * A loader for the [3D Manufacturing Format (3MF)](https://3mf.io/specification/) format.
  *
  * The following features from the core specification are supported:
  *

--- a/examples/jsm/loaders/ColladaLoader.js
+++ b/examples/jsm/loaders/ColladaLoader.js
@@ -45,7 +45,7 @@ import { TGALoader } from '../loaders/TGALoader.js';
  * A loader for the Collada format.
  *
  * The Collada format is very complex so this loader only supports a subset of what
- * is defined in the [official specification]{@link https://www.khronos.org/files/collada_spec_1_5.pdf}.
+ * is defined in the [official specification](https://www.khronos.org/files/collada_spec_1_5.pdf).
  *
  * Assets with a Z-UP coordinate system are transformed it into Y-UP by a simple rotation.
  * The vertex data are not converted.

--- a/examples/jsm/loaders/DRACOLoader.js
+++ b/examples/jsm/loaders/DRACOLoader.js
@@ -16,14 +16,14 @@ const _taskCache = new WeakMap();
 /**
  * A loader for the Draco format.
  *
- * [Draco]{@link https://google.github.io/draco/} is an open source library for compressing
+ * [Draco](https://google.github.io/draco/) is an open source library for compressing
  * and decompressing 3D meshes and point clouds. Compressed geometry can be significantly smaller,
  * at the cost of additional decoding time on the client device.
  *
  * Standalone Draco files have a `.drc` extension, and contain vertex positions, normals, colors,
  * and other attributes. Draco files do not contain materials, textures, animation, or node hierarchies –
  * to use these features, embed Draco geometry inside of a glTF file. A normal glTF file can be converted
- * to a Draco-compressed glTF file using [glTF-Pipeline]{@link https://github.com/CesiumGS/gltf-pipeline}.
+ * to a Draco-compressed glTF file using [glTF-Pipeline](https://github.com/CesiumGS/gltf-pipeline).
  * When using Draco with glTF, an instance of `DRACOLoader` will be used internally by {@link GLTFLoader}.
  *
  * It is recommended to create one DRACOLoader instance and reuse it to avoid loading and creating

--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -61,10 +61,10 @@ let sceneGraph;
  * - Morph normals / blend shape normals
  *
  * FBX format references:
- * - [C++ SDK reference]{@link https://help.autodesk.com/view/FBX/2017/ENU/?guid=__cpp_ref_index_html}
+ * - [C++ SDK reference](https://help.autodesk.com/view/FBX/2017/ENU/?guid=__cpp_ref_index_html)
  *
  * Binary format specification:
- * - [FBX binary file format specification]{@link https://code.blender.org/2013/08/fbx-binary-file-format-specification/}
+ * - [FBX binary file format specification](https://code.blender.org/2013/08/fbx-binary-file-format-specification/)
  *
  * ```js
  * const loader = new FBXLoader();

--- a/examples/jsm/loaders/FontLoader.js
+++ b/examples/jsm/loaders/FontLoader.js
@@ -7,7 +7,7 @@ import {
 /**
  * A loader for loading fonts.
  *
- * You can convert fonts online using [facetype.js]{@link https://gero3.github.io/facetype.js/}.
+ * You can convert fonts online using [facetype.js](https://gero3.github.io/facetype.js/).
  *
  * ```js
  * const loader = new FontLoader();

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -70,7 +70,7 @@ import { toTrianglesDrawMode } from '../utils/BufferGeometryUtils.js';
 /**
  * A loader for the glTF 2.0 format.
  *
- * [glTF]{@link https://www.khronos.org/gltf/} (GL Transmission Format) is an [open format specification]{@link https://github.com/KhronosGroup/glTF/tree/main/specification/2.0}
+ * [glTF](https://www.khronos.org/gltf/} (GL Transmission Format) is an [open format specification]{@link https://github.com/KhronosGroup/glTF/tree/main/specification/2.0)
  * for efficient delivery and loading of 3D content. Assets may be provided either in JSON (.gltf) or binary (.glb)
  * format. External files store textures (.jpg, .png) and additional binary data (.bin). A glTF asset may deliver
  * one or more scenes, including meshes, materials, textures, skins, skeletons, morph targets, animations, lights,
@@ -99,10 +99,10 @@ import { toTrianglesDrawMode } from '../utils/BufferGeometryUtils.js';
  * - EXT_mesh_gpu_instancing
  *
  * The following glTF 2.0 extension is supported by an external user plugin:
- * - [KHR_materials_variants]{@link https://github.com/takahirox/three-gltf-extensions}
- * - [MSFT_texture_dds]{@link https://github.com/takahirox/three-gltf-extensions}
- * - [KHR_animation_pointer]{@link https://github.com/needle-tools/three-animation-pointer}
- * - [NEEDLE_progressive]{@link https://github.com/needle-tools/gltf-progressive}
+ * - [KHR_materials_variants](https://github.com/takahirox/three-gltf-extensions)
+ * - [MSFT_texture_dds](https://github.com/takahirox/three-gltf-extensions)
+ * - [KHR_animation_pointer](https://github.com/needle-tools/three-animation-pointer)
+ * - [NEEDLE_progressive](https://github.com/needle-tools/gltf-progressive)
  *
  * ```js
  * const loader = new GLTFLoader();

--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -113,9 +113,9 @@ let _zstd;
  * This loader relies on Web Assembly which is not supported in older browsers.
  *
  * References:
- * - [KTX specification]{@link http://github.khronos.org/KTX-Specification/}
- * - [DFD]{@link https://www.khronos.org/registry/DataFormat/specs/1.3/dataformat.1.3.html#basicdescriptor}
- * - [BasisU HDR]{@link https://github.com/BinomialLLC/basis_universal/wiki/UASTC-HDR-Texture-Specification-v1.0}
+ * - [KTX specification](http://github.khronos.org/KTX-Specification/)
+ * - [DFD](https://www.khronos.org/registry/DataFormat/specs/1.3/dataformat.1.3.html#basicdescriptor)
+ * - [BasisU HDR](https://github.com/BinomialLLC/basis_universal/wiki/UASTC-HDR-Texture-Specification-v1.0)
  *
  * ```js
  * const loader = new KTX2Loader();

--- a/examples/jsm/loaders/KTXLoader.js
+++ b/examples/jsm/loaders/KTXLoader.js
@@ -6,8 +6,8 @@ import {
  * A loader for the KTX texture compression format.
  *
  * References:
- * - [The KTX File Format and Tools]{@link https://www.khronos.org/opengles/sdk/tools/KTX/}
- * - [Babylon.JS khronosTextureContainer.ts]{@link https://github.com/BabylonJS/Babylon.js/blob/master/src/Misc/khronosTextureContainer.ts}
+ * - [The KTX File Format and Tools](https://www.khronos.org/opengles/sdk/tools/KTX/)
+ * - [Babylon.JS khronosTextureContainer.ts](https://github.com/BabylonJS/Babylon.js/blob/master/src/Misc/khronosTextureContainer.ts)
  *
  * ```js
  * const loader = new KTXLoader();

--- a/examples/jsm/loaders/LDrawLoader.js
+++ b/examples/jsm/loaders/LDrawLoader.js
@@ -1749,7 +1749,7 @@ function createObject( loader, elements, elementSize, isConditionalSegments = fa
 /**
  * A loader for the LDraw format.
  *
- * [LDraw]{@link https://ldraw.org/} (LEGO Draw) is an [open format specification]{@link https://ldraw.org/article/218.html}
+ * [LDraw](https://ldraw.org/} (LEGO Draw) is an [open format specification]{@link https://ldraw.org/article/218.html)
  * for describing LEGO and other construction set 3D models.
  *
  * An LDraw asset (a text file usually with extension .ldr, .dat or .txt) can describe just a single construction

--- a/examples/jsm/loaders/LUT3dlLoader.js
+++ b/examples/jsm/loaders/LUT3dlLoader.js
@@ -12,8 +12,8 @@ import {
  * A loader for the 3DL LUT format.
  *
  * References:
- * - [3D LUTs]{@link http://download.autodesk.com/us/systemdocs/help/2011/lustre/index.html?url=./files/WSc4e151a45a3b785a24c3d9a411df9298473-7ffd.htm,topicNumber=d0e9492}
- * - [Format Spec for .3dl]{@link https://community.foundry.com/discuss/topic/103636/format-spec-for-3dl?mode=Post&postID=895258}
+ * - [3D LUTs](http://download.autodesk.com/us/systemdocs/help/2011/lustre/index.html?url=./files/WSc4e151a45a3b785a24c3d9a411df9298473-7ffd.htm,topicNumber=d0e9492)
+ * - [Format Spec for .3dl](https://community.foundry.com/discuss/topic/103636/format-spec-for-3dl?mode=Post&postID=895258)
  *
  * ```js
  * const loader = new LUT3dlLoader();

--- a/examples/jsm/loaders/LUTCubeLoader.js
+++ b/examples/jsm/loaders/LUTCubeLoader.js
@@ -12,7 +12,7 @@ import {
  * A loader for the Cube LUT format.
  *
  * References:
- * - [Cube LUT Specification]{@link https://web.archive.org/web/20220220033515/https://wwwimages2.adobe.com/content/dam/acom/en/products/speedgrade/cc/pdfs/cube-lut-specification-1.0.pdf}
+ * - [Cube LUT Specification](https://web.archive.org/web/20220220033515/https://wwwimages2.adobe.com/content/dam/acom/en/products/speedgrade/cc/pdfs/cube-lut-specification-1.0.pdf)
  *
  * ```js
  * const loader = new LUTCubeLoader();

--- a/examples/jsm/loaders/LWOLoader.js
+++ b/examples/jsm/loaders/LWOLoader.js
@@ -36,8 +36,8 @@ let _lwoTree;
  * LWO3 and LWO2 formats are supported.
  *
  * References:
- * - [LWO3 format specification]{@link https://static.lightwave3d.com/sdk/2019/html/filefmts/lwo3.html}
- * - [LWO2 format specification]{@link https://static.lightwave3d.com/sdk/2019/html/filefmts/lwo2.html}
+ * - [LWO3 format specification](https://static.lightwave3d.com/sdk/2019/html/filefmts/lwo3.html)
+ * - [LWO2 format specification](https://static.lightwave3d.com/sdk/2019/html/filefmts/lwo2.html)
  *
  * ```js
  * const loader = new LWOLoader();

--- a/examples/jsm/loaders/OBJLoader.js
+++ b/examples/jsm/loaders/OBJLoader.js
@@ -436,7 +436,7 @@ function ParserState() {
 /**
  * A loader for the OBJ format.
  *
- * The [OBJ format]{@link https://en.wikipedia.org/wiki/Wavefront_.obj_file} is a simple data-format that
+ * The [OBJ format](https://en.wikipedia.org/wiki/Wavefront_.obj_file) is a simple data-format that
  * represents 3D geometry in a human readable format as the position of each vertex, the UV position of
  * each texture coordinate vertex, vertex normals, and the faces that make each polygon defined as a list
  * of vertices, and texture vertices.

--- a/examples/jsm/loaders/PDBLoader.js
+++ b/examples/jsm/loaders/PDBLoader.js
@@ -10,7 +10,7 @@ import {
 /**
  * A loader for the PDB format.
  *
- * The [Protein Data Bank]{@link https://en.wikipedia.org/wiki/Protein_Data_Bank_(file_format)}
+ * The [Protein Data Bank](https://en.wikipedia.org/wiki/Protein_Data_Bank_(file_format))
  * file format is a textual file describing the three-dimensional structures of molecules.
  *
  * ```js

--- a/examples/jsm/loaders/UltraHDRLoader.js
+++ b/examples/jsm/loaders/UltraHDRLoader.js
@@ -39,7 +39,7 @@ const SRGB_TO_LINEAR = Array( 1024 )
 /**
  * A loader for the Ultra HDR Image Format.
  *
- * Existing HDR or EXR textures can be converted to Ultra HDR with this [tool]{@link https://gainmap-creator.monogrid.com/}.
+ * Existing HDR or EXR textures can be converted to Ultra HDR with this [tool](https://gainmap-creator.monogrid.com/).
  *
  * Current feature set:
  * - JPEG headers (required)

--- a/examples/jsm/math/ConvexHull.js
+++ b/examples/jsm/math/ConvexHull.js
@@ -18,7 +18,7 @@ const _triangle = new Triangle();
  * Can be used to compute the convex hull in 3D space for a given set of points. It
  * is primarily intended for {@link ConvexGeometry}.
  *
- * This Quickhull 3D implementation is a port of [quickhull3d]{@link https://github.com/maurizzzio/quickhull3d/}
+ * This Quickhull 3D implementation is a port of [quickhull3d](https://github.com/maurizzzio/quickhull3d/)
  * by Mauricio Poppe.
  *
  * @three_import import { ConvexHull } from 'three/addons/math/ConvexHull.js';

--- a/examples/jsm/math/ImprovedNoise.js
+++ b/examples/jsm/math/ImprovedNoise.js
@@ -36,7 +36,7 @@ function grad( hash, x, y, z ) {
 /**
  * A utility class providing a 3D noise function.
  *
- * The code is based on [IMPROVED NOISE]{@link https://cs.nyu.edu/~perlin/noise/}
+ * The code is based on [IMPROVED NOISE](https://cs.nyu.edu/~perlin/noise/)
  * by Ken Perlin, 2002.
  *
  * @three_import import { ImprovedNoise } from 'three/addons/math/ImprovedNoise.js';

--- a/examples/jsm/math/SimplexNoise.js
+++ b/examples/jsm/math/SimplexNoise.js
@@ -1,7 +1,7 @@
 /**
  * A utility class providing noise functions.
  *
- * The code is based on [Simplex noise demystified]{@link https://web.archive.org/web/20210210162332/http://staffwww.itn.liu.se/~stegu/simplexnoise/simplexnoise.pdf}
+ * The code is based on [Simplex noise demystified](https://web.archive.org/web/20210210162332/http://staffwww.itn.liu.se/~stegu/simplexnoise/simplexnoise.pdf)
  * by Stefan Gustavson, 2005.
  *
  * @three_import import { SimplexNoise } from 'three/addons/math/SimplexNoise.js';

--- a/examples/jsm/misc/ProgressiveLightMap.js
+++ b/examples/jsm/misc/ProgressiveLightMap.js
@@ -2,7 +2,7 @@ import { DoubleSide, FloatType, HalfFloatType, Mesh, MeshBasicMaterial, MeshPhon
 import { potpack } from '../libs/potpack.module.js';
 
 /**
- * Progressive Light Map Accumulator, by [zalo]{@link https://github.com/zalo/}.
+ * Progressive Light Map Accumulator, by [zalo](https://github.com/zalo/).
  *
  * To use, simply construct a `ProgressiveLightMap` object,
  * `plmap.addObjectsToLightMap(object)` an array of semi-static

--- a/examples/jsm/misc/ProgressiveLightMapGPU.js
+++ b/examples/jsm/misc/ProgressiveLightMapGPU.js
@@ -4,7 +4,7 @@ import { add, float, mix, output, sub, texture, uniform, uv, vec2, vec4 } from '
 import { potpack } from '../libs/potpack.module.js';
 
 /**
- * Progressive Light Map Accumulator, by [zalo]{@link https://github.com/zalo/}.
+ * Progressive Light Map Accumulator, by [zalo](https://github.com/zalo/).
  *
  * To use, simply construct a `ProgressiveLightMap` object,
  * `plmap.addObjectsToLightMap(object)` an array of semi-static

--- a/examples/jsm/modifiers/SimplifyModifier.js
+++ b/examples/jsm/modifiers/SimplifyModifier.js
@@ -14,7 +14,7 @@ const _cb = new Vector3(), _ab = new Vector3();
  * This class can be used to modify a geometry by simplifying it. A typical use
  * case for such a modifier is automatic LOD generation.
  *
- * The implementation is based on [Progressive Mesh type Polygon Reduction Algorithm]{@link https://web.archive.org/web/20230610044040/http://www.melax.com/polychop/}
+ * The implementation is based on [Progressive Mesh type Polygon Reduction Algorithm](https://web.archive.org/web/20230610044040/http://www.melax.com/polychop/)
  * by Stan Melax in 1998.
  *
  * ```js

--- a/examples/jsm/objects/Sky.js
+++ b/examples/jsm/objects/Sky.js
@@ -8,7 +8,7 @@ import {
 } from 'three';
 
 /**
- * Represents a skydome for scene backgrounds. Based on [A Practical Analytic Model for Daylight]{@link https://www.researchgate.net/publication/220720443_A_Practical_Analytic_Model_for_Daylight}
+ * Represents a skydome for scene backgrounds. Based on [A Practical Analytic Model for Daylight](https://www.researchgate.net/publication/220720443_A_Practical_Analytic_Model_for_Daylight)
  * aka The Preetham Model, the de facto standard for analytical skydomes.
  *
  * Note that this class can only be used with {@link WebGLRenderer}.

--- a/examples/jsm/objects/SkyMesh.js
+++ b/examples/jsm/objects/SkyMesh.js
@@ -9,7 +9,7 @@ import {
 import { Fn, float, vec3, acos, add, mul, clamp, cos, dot, exp, max, mix, modelViewProjection, normalize, positionWorld, pow, smoothstep, sub, varyingProperty, vec4, uniform, cameraPosition } from 'three/tsl';
 
 /**
- * Represents a skydome for scene backgrounds. Based on [A Practical Analytic Model for Daylight]{@link https://www.researchgate.net/publication/220720443_A_Practical_Analytic_Model_for_Daylight}
+ * Represents a skydome for scene backgrounds. Based on [A Practical Analytic Model for Daylight](https://www.researchgate.net/publication/220720443_A_Practical_Analytic_Model_for_Daylight)
  * aka The Preetham Model, the de facto standard for analytical skydomes.
  *
  * Note that this class can only be used with {@link WebGLRenderer}.

--- a/examples/jsm/objects/Water.js
+++ b/examples/jsm/objects/Water.js
@@ -21,9 +21,9 @@ import {
  *
  * References:
  *
- * - [Flat mirror for three.js]{@link https://github.com/Slayvin}
- * - [An implementation of water shader based on the flat mirror]{@link https://home.adelphi.edu/~stemkoski/}
- * - [Water shader explanations in WebGL]{@link http://29a.ch/slides/2012/webglwater/ }
+ * - [Flat mirror for three.js](https://github.com/Slayvin)
+ * - [An implementation of water shader based on the flat mirror](https://home.adelphi.edu/~stemkoski/)
+ * - [Water shader explanations in WebGL](http://29a.ch/slides/2012/webglwater/ )
  *
  * @augments Mesh
  * @three_import import { Water } from 'three/addons/objects/Water.js';

--- a/examples/jsm/objects/WaterMesh.js
+++ b/examples/jsm/objects/WaterMesh.js
@@ -15,9 +15,9 @@ import { Fn, add, cameraPosition, div, normalize, positionWorld, sub, time, text
  *
  * References:
  *
- * - [Flat mirror for three.js]{@link https://github.com/Slayvin}
- * - [An implementation of water shader based on the flat mirror]{@link https://home.adelphi.edu/~stemkoski/}
- * - [Water shader explanations in WebGL]{@link http://29a.ch/slides/2012/webglwater/ }
+ * - [Flat mirror for three.js](https://github.com/Slayvin)
+ * - [An implementation of water shader based on the flat mirror](https://home.adelphi.edu/~stemkoski/)
+ * - [Water shader explanations in WebGL](http://29a.ch/slides/2012/webglwater/ )
  *
  * @augments Mesh
  * @three_import import { WaterMesh } from 'three/addons/objects/WaterMesh.js';

--- a/examples/jsm/postprocessing/UnrealBloomPass.js
+++ b/examples/jsm/postprocessing/UnrealBloomPass.js
@@ -22,7 +22,7 @@ import { LuminosityHighPassShader } from '../shaders/LuminosityHighPassShader.js
  * When using this pass, tone mapping must be enabled in the renderer settings.
  *
  * Reference:
- * - [Bloom in Unreal Engine]{@link https://docs.unrealengine.com/latest/INT/Engine/Rendering/PostProcessEffects/Bloom/}
+ * - [Bloom in Unreal Engine](https://docs.unrealengine.com/latest/INT/Engine/Rendering/PostProcessEffects/Bloom/)
  *
  * ```js
  * const resolution = new THREE.Vector2( window.innerWidth, window.innerHeight );

--- a/examples/jsm/renderers/CSS3DRenderer.js
+++ b/examples/jsm/renderers/CSS3DRenderer.js
@@ -139,7 +139,7 @@ const _matrix2 = new Matrix4();
 
 /**
  * This renderer can be used to apply hierarchical 3D transformations to DOM elements
- * via the CSS3 [transform]{@link https://www.w3schools.com/cssref/css3_pr_transform.asp} property.
+ * via the CSS3 [transform](https://www.w3schools.com/cssref/css3_pr_transform.asp) property.
  * `CSS3DRenderer` is particularly interesting if you want to apply 3D effects to a website without
  * canvas based rendering. It can also be used in order to combine DOM elements with WebGLcontent.
  *

--- a/examples/jsm/shaders/ACESFilmicToneMappingShader.js
+++ b/examples/jsm/shaders/ACESFilmicToneMappingShader.js
@@ -5,7 +5,7 @@
 
 /**
  * ACES Filmic Tone Mapping Shader by Stephen Hill.
- * Reference: [ltc_blit.fs]{@link https://github.com/selfshadow/ltc_code/blob/master/webgl/shaders/ltc/ltc_blit.fs}
+ * Reference: [ltc_blit.fs](https://github.com/selfshadow/ltc_code/blob/master/webgl/shaders/ltc/ltc_blit.fs)
  *
  * This implementation of ACES is modified to accommodate a brighter viewing environment.
  * The scale factor of 1/0.6 is subjective. See discussion in #19621.

--- a/examples/jsm/shaders/AfterimageShader.js
+++ b/examples/jsm/shaders/AfterimageShader.js
@@ -4,7 +4,7 @@
  */
 
 /**
- * Inspired by [Three.js FBO motion trails]{@link https://codepen.io/brunoimbrizi/pen/MoRJaN?page=1&}.
+ * Inspired by [Three.js FBO motion trails](https://codepen.io/brunoimbrizi/pen/MoRJaN?page=1&).
  *
  * @constant
  * @type {ShaderMaterial~Shader}

--- a/examples/jsm/shaders/BleachBypassShader.js
+++ b/examples/jsm/shaders/BleachBypassShader.js
@@ -6,7 +6,7 @@
 
 /**
  * Bleach bypass shader [http://en.wikipedia.org/wiki/Bleach_bypass] based on
- * [Nvidia Shader library]{@link http://developer.download.nvidia.com/shaderlibrary/webpages/shader_library.html#post_bleach_bypass}.
+ * [Nvidia Shader library](http://developer.download.nvidia.com/shaderlibrary/webpages/shader_library.html#post_bleach_bypass).
  *
  * @constant
  * @type {ShaderMaterial~Shader}

--- a/examples/jsm/shaders/BokehShader.js
+++ b/examples/jsm/shaders/BokehShader.js
@@ -5,7 +5,7 @@
 
 /**
  * Depth-of-field shader with bokeh ported from
- * [GLSL shader by Martins Upitis]{@link http://artmartinsh.blogspot.com/2010/02/glsl-lens-blur-filter-with-bokeh.html}.
+ * [GLSL shader by Martins Upitis](http://artmartinsh.blogspot.com/2010/02/glsl-lens-blur-filter-with-bokeh.html).
  *
  * @constant
  * @type {ShaderMaterial~Shader}

--- a/examples/jsm/shaders/BokehShader2.js
+++ b/examples/jsm/shaders/BokehShader2.js
@@ -9,7 +9,7 @@ import {
 
 /**
  * Depth-of-field shader with bokeh ported from
- * [GLSL shader by Martins Upitis]{@link http://blenderartists.org/forum/showthread.php?237488-GLSL-depth-of-field-with-bokeh-v2-4-(update)}.
+ * [GLSL shader by Martins Upitis](http://blenderartists.org/forum/showthread.php?237488-GLSL-depth-of-field-with-bokeh-v2-4-(update)).
  *
  * Requires #define RINGS and SAMPLES integers
  *

--- a/examples/jsm/shaders/DotScreenShader.js
+++ b/examples/jsm/shaders/DotScreenShader.js
@@ -8,7 +8,7 @@ import {
  */
 
 /**
- * Dot screen shader based on [glfx.js sepia shader]{@link https://github.com/evanw/glfx.js}.
+ * Dot screen shader based on [glfx.js sepia shader](https://github.com/evanw/glfx.js).
  *
  * @constant
  * @type {ShaderMaterial~Shader}

--- a/examples/jsm/shaders/FocusShader.js
+++ b/examples/jsm/shaders/FocusShader.js
@@ -4,7 +4,7 @@
  */
 
 /**
- * Focus shader based on [PaintEffect postprocess from ro.me]{@link http://code.google.com/p/3-dreams-of-black/source/browse/deploy/js/effects/PaintEffect.js}.
+ * Focus shader based on [PaintEffect postprocess from ro.me](http://code.google.com/p/3-dreams-of-black/source/browse/deploy/js/effects/PaintEffect.js).
  *
  * @constant
  * @type {ShaderMaterial~Shader}

--- a/examples/jsm/shaders/GTAOShader.js
+++ b/examples/jsm/shaders/GTAOShader.js
@@ -15,8 +15,8 @@ import {
  * GTAO shader. Use by {@link GTAOPass}.
  *
  * References:
- * - [Practical Realtime Strategies for Accurate Indirect Occlusion]{@link https://iryoku.com/downloads/Practical-Realtime-Strategies-for-Accurate-Indirect-Occlusion.pdf}.
- * - [Horizon-Based Indirect Lighting (HBIL)]{@link https://github.com/Patapom/GodComplex/blob/master/Tests/TestHBIL/2018%20Mayaux%20-%20Horizon-Based%20Indirect%20Lighting%20(HBIL).pdf}
+ * - [Practical Realtime Strategies for Accurate Indirect Occlusion](https://iryoku.com/downloads/Practical-Realtime-Strategies-for-Accurate-Indirect-Occlusion.pdf).
+ * - [Horizon-Based Indirect Lighting (HBIL)](https://github.com/Patapom/GodComplex/blob/master/Tests/TestHBIL/2018%20Mayaux%20-%20Horizon-Based%20Indirect%20Lighting%20(HBIL).pdf)
  *
  * @constant
  * @type {ShaderMaterial~Shader}

--- a/examples/jsm/shaders/GodRaysShader.js
+++ b/examples/jsm/shaders/GodRaysShader.js
@@ -22,7 +22,7 @@ import {
  * 6*6*6 = 216 samples.
  *
  * References:
- * - [Sousa2008, Crysis Next Gen Effects, GDC2008]{@link http://www.crytek.com/sites/default/files/GDC08_SousaT_CrysisEffects.ppt}.
+ * - [Sousa2008, Crysis Next Gen Effects, GDC2008](http://www.crytek.com/sites/default/files/GDC08_SousaT_CrysisEffects.ppt).
  *
  * @constant
  * @type {ShaderMaterial~Shader}

--- a/examples/jsm/shaders/KaleidoShader.js
+++ b/examples/jsm/shaders/KaleidoShader.js
@@ -7,7 +7,7 @@
  * Kaleidoscope Shader.
  * Radial reflection around center point
  * Ported from: {@link http://pixelshaders.com/editor/}
- * by [Toby Schachman]{@link http://tobyschachman.com/}
+ * by [Toby Schachman](http://tobyschachman.com/)
  *
  * sides: number of reflections
  * angle: initial angle in radians

--- a/examples/jsm/shaders/PoissonDenoiseShader.js
+++ b/examples/jsm/shaders/PoissonDenoiseShader.js
@@ -13,8 +13,8 @@ import {
  * Poisson Denoise Shader.
  *
  * References:
- * - [Self-Supervised Poisson-Gaussian Denoising]{@link https://openaccess.thecvf.com/content/WACV2021/papers/Khademi_Self-Supervised_Poisson-Gaussian_Denoising_WACV_2021_paper.pdf}.
- * - [Poisson2Sparse: Self-Supervised Poisson Denoising From a Single Image]{@link https://arxiv.org/pdf/2206.01856.pdf}
+ * - [Self-Supervised Poisson-Gaussian Denoising](https://openaccess.thecvf.com/content/WACV2021/papers/Khademi_Self-Supervised_Poisson-Gaussian_Denoising_WACV_2021_paper.pdf).
+ * - [Poisson2Sparse: Self-Supervised Poisson Denoising From a Single Image](https://arxiv.org/pdf/2206.01856.pdf)
  *
  * @constant
  * @type {ShaderMaterial~Shader}

--- a/examples/jsm/shaders/SSRShader.js
+++ b/examples/jsm/shaders/SSRShader.js
@@ -8,7 +8,7 @@ import {
  * A collection of shaders used for SSR.
  *
  * References:
- * - [3D Game Shaders For Beginners, Screen Space Reflection (SSR)]{@link https://lettier.github.io/3d-game-shaders-for-beginners/screen-space-reflection.html}.
+ * - [3D Game Shaders For Beginners, Screen Space Reflection (SSR)](https://lettier.github.io/3d-game-shaders-for-beginners/screen-space-reflection.html).
  *
  * @module SSRShader
  * @three_import import * as SSRShader from 'three/addons/shaders/SSRShader.js';

--- a/examples/jsm/shaders/SepiaShader.js
+++ b/examples/jsm/shaders/SepiaShader.js
@@ -4,7 +4,7 @@
  */
 
 /**
- * Sepia tone shader based on [glfx.js sepia shader]{@link https://github.com/evanw/glfx.js}.
+ * Sepia tone shader based on [glfx.js sepia shader](https://github.com/evanw/glfx.js).
  *
  * @constant
  * @type {ShaderMaterial~Shader}

--- a/examples/jsm/shaders/SubsurfaceScatteringShader.js
+++ b/examples/jsm/shaders/SubsurfaceScatteringShader.js
@@ -22,7 +22,7 @@ const meshphong_frag_body = ShaderChunk[ 'meshphong_frag' ].slice( ShaderChunk[ 
 /**
  * Subsurface Scattering shader.
  *
- * Based on GDC 2011 – [Approximating Translucency for a Fast, Cheap and Convincing Subsurface Scattering Look]{@link https://colinbarrebrisebois.com/2011/03/07/gdc-2011-approximating-translucency-for-a-fast-cheap-and-convincing-subsurface-scattering-look/}
+ * Based on GDC 2011 – [Approximating Translucency for a Fast, Cheap and Convincing Subsurface Scattering Look](https://colinbarrebrisebois.com/2011/03/07/gdc-2011-approximating-translucency-for-a-fast-cheap-and-convincing-subsurface-scattering-look/)
  *
  * @constant
  * @type {ShaderMaterial~Shader}

--- a/examples/jsm/shaders/TriangleBlurShader.js
+++ b/examples/jsm/shaders/TriangleBlurShader.js
@@ -8,7 +8,7 @@ import {
  */
 
 /**
- * Triangle blur shader based on [glfx.js triangle blur shader]{@link https://github.com/evanw/glfx.js}.
+ * Triangle blur shader based on [glfx.js triangle blur shader](https://github.com/evanw/glfx.js).
  *
  * A basic blur filter, which convolves the image with a
  * pyramid filter. The pyramid filter is separable and is applied as two

--- a/examples/jsm/shaders/VignetteShader.js
+++ b/examples/jsm/shaders/VignetteShader.js
@@ -4,7 +4,7 @@
  */
 
 /**
- * Based on [PaintEffect postprocess from ro.me]{@link http://code.google.com/p/3-dreams-of-black/source/browse/deploy/js/effects/PaintEffect.js}.
+ * Based on [PaintEffect postprocess from ro.me](http://code.google.com/p/3-dreams-of-black/source/browse/deploy/js/effects/PaintEffect.js).
  *
  * @constant
  * @type {ShaderMaterial~Shader}

--- a/examples/jsm/webxr/XRControllerModelFactory.js
+++ b/examples/jsm/webxr/XRControllerModelFactory.js
@@ -245,7 +245,7 @@ function addAssetSceneToControllerModel( controllerModel, scene ) {
  * attached to the object returned from getControllerGrip in order to match the orientation of
  * the held device.
  *
- * This module depends on the [motion-controllers]{@link https://github.com/immersive-web/webxr-input-profiles/blob/main/packages/motion-controllers/README.md}
+ * This module depends on the [motion-controllers](https://github.com/immersive-web/webxr-input-profiles/blob/main/packages/motion-controllers/README.md)
  * third-part library.
  *
  * ```js

--- a/src/audio/Audio.js
+++ b/src/audio/Audio.js
@@ -4,7 +4,7 @@ import { warn } from '../utils.js';
 /**
  * Represents a non-positional ( global ) audio object.
  *
- * This and related audio modules make use of the [Web Audio API]{@link https://www.w3.org/TR/webaudio-1.1/}.
+ * This and related audio modules make use of the [Web Audio API](https://www.w3.org/TR/webaudio-1.1/).
  *
  * ```js
  * // create an AudioListener and add it to the camera

--- a/src/audio/PositionalAudio.js
+++ b/src/audio/PositionalAudio.js
@@ -154,7 +154,7 @@ class PositionalAudio extends Audio {
 	 * Defines which algorithm to use to reduce the volume of the audio source
 	 * as it moves away from the listener.
 	 *
-	 * Read [the spec]{@link https://www.w3.org/TR/webaudio-1.1/#enumdef-distancemodeltype}
+	 * Read [the spec](https://www.w3.org/TR/webaudio-1.1/#enumdef-distancemodeltype)
 	 * for more details.
 	 *
 	 * @param {('linear'|'inverse'|'exponential')} value - The distance model to set.

--- a/src/cameras/OrthographicCamera.js
+++ b/src/cameras/OrthographicCamera.js
@@ -1,7 +1,7 @@
 import { Camera } from './Camera.js';
 
 /**
- * Camera that uses [orthographic projection]{@link https://en.wikipedia.org/wiki/Orthographic_projection}.
+ * Camera that uses [orthographic projection](https://en.wikipedia.org/wiki/Orthographic_projection).
  *
  * In this projection mode, an object's size in the rendered image stays
  * constant regardless of its distance from the camera. This can be useful

--- a/src/cameras/PerspectiveCamera.js
+++ b/src/cameras/PerspectiveCamera.js
@@ -8,7 +8,7 @@ const _minTarget = /*@__PURE__*/ new Vector2();
 const _maxTarget = /*@__PURE__*/ new Vector2();
 
 /**
- * Camera that uses [perspective projection]{@link https://en.wikipedia.org/wiki/Perspective_(graphical)}.
+ * Camera that uses [perspective projection](https://en.wikipedia.org/wiki/Perspective_(graphical)).
  *
  * This projection mode is designed to mimic the way the human eye sees. It
  * is the most common projection mode used for rendering a 3D scene.

--- a/src/cameras/StereoCamera.js
+++ b/src/cameras/StereoCamera.js
@@ -9,8 +9,8 @@ const _projectionMatrix = /*@__PURE__*/ new Matrix4();
 /**
  * A special type of camera that uses two perspective cameras with
  * stereoscopic projection. Can be used for rendering stereo effects
- * like [3D Anaglyph]{@link https://en.wikipedia.org/wiki/Anaglyph_3D} or
- * [Parallax Barrier]{@link https://en.wikipedia.org/wiki/parallax_barrier}.
+ * like [3D Anaglyph](https://en.wikipedia.org/wiki/Anaglyph_3D) or
+ * [Parallax Barrier](https://en.wikipedia.org/wiki/parallax_barrier).
  */
 class StereoCamera {
 

--- a/src/core/EventDispatcher.js
+++ b/src/core/EventDispatcher.js
@@ -1,7 +1,7 @@
 /**
  * This modules allows to dispatch event objects on custom JavaScript objects.
  *
- * Main repository: [eventdispatcher.js]{@link https://github.com/mrdoob/eventdispatcher.js/}
+ * Main repository: [eventdispatcher.js](https://github.com/mrdoob/eventdispatcher.js/)
  *
  * Code Example:
  * ```js

--- a/src/core/InterleavedBuffer.js
+++ b/src/core/InterleavedBuffer.js
@@ -5,7 +5,7 @@ import { StaticDrawUsage } from '../constants.js';
  * "Interleaved" means that multiple attributes, possibly of different types,
  * (e.g., position, normal, uv, color) are packed into a single array buffer.
  *
- * An introduction into interleaved arrays can be found here: [Interleaved array basics]{@link https://blog.tojicode.com/2011/05/interleaved-array-basics.html}
+ * An introduction into interleaved arrays can be found here: [Interleaved array basics](https://blog.tojicode.com/2011/05/interleaved-array-basics.html)
  */
 class InterleavedBuffer {
 

--- a/src/helpers/CameraHelper.js
+++ b/src/helpers/CameraHelper.js
@@ -14,7 +14,7 @@ const _camera = /*@__PURE__*/ new Camera();
  * This helps with visualizing what a camera contains in its frustum. It
  * visualizes the frustum of a camera using a line segments.
  *
- * Based on frustum visualization in [lightgl.js shadowmap example]{@link https://github.com/evanw/lightgl.js/blob/master/tests/shadowmap.html}.
+ * Based on frustum visualization in [lightgl.js shadowmap example](https://github.com/evanw/lightgl.js/blob/master/tests/shadowmap.html).
  *
  * `CameraHelper` must be a child of the scene.
  *

--- a/src/loaders/FileLoader.js
+++ b/src/loaders/FileLoader.js
@@ -43,7 +43,7 @@ class FileLoader extends Loader {
 
 		/**
 		 * The expected mime type. Valid values can be found
-		 * [here]{@link hhttps://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString#mimetype}
+		 * [here](hhttps://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString#mimetype)
 		 *
 		 * @type {string}
 		 */

--- a/src/loaders/ImageBitmapLoader.js
+++ b/src/loaders/ImageBitmapLoader.js
@@ -5,7 +5,7 @@ import { warn } from '../utils.js';
 const _errorMap = new WeakMap();
 
 /**
- * A loader for loading images as an [ImageBitmap]{@link https://developer.mozilla.org/en-US/docs/Web/API/ImageBitmap}.
+ * A loader for loading images as an [ImageBitmap](https://developer.mozilla.org/en-US/docs/Web/API/ImageBitmap).
  * An `ImageBitmap` provides an asynchronous and resource efficient pathway to prepare
  * textures for rendering.
  *
@@ -79,7 +79,7 @@ class ImageBitmapLoader extends Loader {
 
 	/**
 	 * Sets the given loader options. The structure of the object must match the `options` parameter of
-	 * [createImageBitmap]{@link https://developer.mozilla.org/en-US/docs/Web/API/Window/createImageBitmap}.
+	 * [createImageBitmap](https://developer.mozilla.org/en-US/docs/Web/API/Window/createImageBitmap).
 	 *
 	 * @param {Object} options - The loader options to set.
 	 * @return {ImageBitmapLoader} A reference to this image bitmap loader.

--- a/src/loaders/ImageLoader.js
+++ b/src/loaders/ImageLoader.js
@@ -13,7 +13,7 @@ const _loading = new WeakMap();
  * ```
  * Please note that `ImageLoader` has dropped support for progress
  * events in `r84`. For an `ImageLoader` that supports progress events, see
- * [this thread]{@link https://github.com/mrdoob/three.js/issues/10439#issuecomment-275785639}.
+ * [this thread](https://github.com/mrdoob/three.js/issues/10439#issuecomment-275785639).
  *
  * @augments Loader
  */

--- a/src/loaders/Loader.js
+++ b/src/loaders/Loader.js
@@ -54,7 +54,7 @@ class Loader {
 		this.resourcePath = '';
 
 		/**
-		 * The [request header]{@link https://developer.mozilla.org/en-US/docs/Glossary/Request_header}
+		 * The [request header](https://developer.mozilla.org/en-US/docs/Glossary/Request_header)
 		 * used in HTTP request.
 		 *
 		 * @type {Object<string, any>}
@@ -119,7 +119,7 @@ class Loader {
 
 	/**
 	 * Whether the XMLHttpRequest uses credentials such as cookies, authorization
-	 * headers or TLS client certificates, see [XMLHttpRequest.withCredentials]{@link https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials}.
+	 * headers or TLS client certificates, see [XMLHttpRequest.withCredentials](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials).
 	 *
 	 * Note: This setting has no effect if you are loading files locally or from the same domain.
 	 *
@@ -162,7 +162,7 @@ class Loader {
 	/**
 	 * Sets the given request header.
 	 *
-	 * @param {Object} requestHeader - A [request header]{@link https://developer.mozilla.org/en-US/docs/Glossary/Request_header}
+	 * @param {Object} requestHeader - A [request header](https://developer.mozilla.org/en-US/docs/Glossary/Request_header)
 	 * for configuring the HTTP request.
 	 * @return {Loader} A reference to this instance.
 	 */

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -64,7 +64,7 @@ import { Box3 } from '../math/Box3.js';
 import { Sphere } from '../math/Sphere.js';
 
 /**
- * A loader for loading a JSON resource in the [JSON Object/Scene format]{@link https://github.com/mrdoob/three.js/wiki/JSON-Object-Scene-format-4}.
+ * A loader for loading a JSON resource in the [JSON Object/Scene format](https://github.com/mrdoob/three.js/wiki/JSON-Object-Scene-format-4).
  * The files are internally loaded via {@link FileLoader}.
  *
  * ```js

--- a/src/loaders/TextureLoader.js
+++ b/src/loaders/TextureLoader.js
@@ -14,7 +14,7 @@ import { Loader } from './Loader.js';
  * ```
  * Please note that `TextureLoader` has dropped support for progress
  * events in `r84`. For a `TextureLoader` that supports progress events, see
- * [this thread]{@link https://github.com/mrdoob/three.js/issues/10439#issuecomment-293260145}.
+ * [this thread](https://github.com/mrdoob/three.js/issues/10439#issuecomment-293260145).
  *
  * @augments Loader
  */

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -523,7 +523,7 @@ class Material extends EventDispatcher {
 	 *
 	 * This method can only be used when rendering with {@link WebGLRenderer}. The
 	 * recommended approach when customizing materials is to use `WebGPURenderer` with the new
-	 * Node Material system and [TSL]{@link https://github.com/mrdoob/three.js/wiki/Three.js-Shading-Language}.
+	 * Node Material system and [TSL](https://github.com/mrdoob/three.js/wiki/Three.js-Shading-Language).
 	 *
 	 * @param {{vertexShader:string,fragmentShader:string,uniforms:Object}} shaderobject - The object holds the uniforms and the vertex and fragment shader source.
 	 * @param {WebGLRenderer} renderer - A reference to the renderer.

--- a/src/materials/MeshLambertMaterial.js
+++ b/src/materials/MeshLambertMaterial.js
@@ -7,7 +7,7 @@ import { Euler } from '../math/Euler.js';
 /**
  * A material for non-shiny surfaces, without specular highlights.
  *
- * The material uses a non-physically based [Lambertian]{@link https://en.wikipedia.org/wiki/Lambertian_reflectance}
+ * The material uses a non-physically based [Lambertian](https://en.wikipedia.org/wiki/Lambertian_reflectance)
  * model for calculating reflectance. This can simulate some surfaces (such
  * as untreated wood or stone) well, but cannot simulate shiny surfaces with
  * specular highlights (such as varnished wood). `MeshLambertMaterial` uses per-fragment

--- a/src/materials/MeshPhongMaterial.js
+++ b/src/materials/MeshPhongMaterial.js
@@ -7,7 +7,7 @@ import { Euler } from '../math/Euler.js';
 /**
  * A material for shiny surfaces with specular highlights.
  *
- * The material uses a non-physically based [Blinn-Phong]{@link https://en.wikipedia.org/wiki/Blinn-Phong_shading_model}
+ * The material uses a non-physically based [Blinn-Phong](https://en.wikipedia.org/wiki/Blinn-Phong_shading_model)
  * model for calculating reflectance. Unlike the Lambertian model used in the
  * {@link MeshLambertMaterial} this can simulate shiny surfaces with specular
  * highlights (such as varnished wood). `MeshPhongMaterial` uses per-fragment shading.

--- a/src/materials/MeshStandardMaterial.js
+++ b/src/materials/MeshStandardMaterial.js
@@ -8,9 +8,9 @@ import { Euler } from '../math/Euler.js';
  * A standard physically based material, using Metallic-Roughness workflow.
  *
  * Physically based rendering (PBR) has recently become the standard in many
- * 3D applications, such as [Unity]{@link https://blogs.unity3d.com/2014/10/29/physically-based-shading-in-unity-5-a-primer/},
- * [Unreal]{@link https://docs.unrealengine.com/latest/INT/Engine/Rendering/Materials/PhysicallyBased/} and
- * [3D Studio Max]{@link http://area.autodesk.com/blogs/the-3ds-max-blog/what039s-new-for-rendering-in-3ds-max-2017}.
+ * 3D applications, such as [Unity](https://blogs.unity3d.com/2014/10/29/physically-based-shading-in-unity-5-a-primer/),
+ * [Unreal](https://docs.unrealengine.com/latest/INT/Engine/Rendering/Materials/PhysicallyBased/) and
+ * [3D Studio Max](http://area.autodesk.com/blogs/the-3ds-max-blog/what039s-new-for-rendering-in-3ds-max-2017).
  *
  * This approach differs from older approaches in that instead of using
  * approximations for the way in which light interacts with a surface, a
@@ -26,13 +26,13 @@ import { Euler } from '../math/Euler.js';
  * Note that for best results you should always specify an environment map when using this material.
  *
  * For a non-technical introduction to the concept of PBR and how to set up a
- * PBR material, check out these articles by the people at [marmoset]{@link https://www.marmoset.co}:
+ * PBR material, check out these articles by the people at [marmoset](https://www.marmoset.co):
  *
- * - [Basic Theory of Physically Based Rendering]{@link https://www.marmoset.co/posts/basic-theory-of-physically-based-rendering/}
- * - [Physically Based Rendering and You Can Too]{@link https://www.marmoset.co/posts/physically-based-rendering-and-you-can-too/}
+ * - [Basic Theory of Physically Based Rendering](https://www.marmoset.co/posts/basic-theory-of-physically-based-rendering/)
+ * - [Physically Based Rendering and You Can Too](https://www.marmoset.co/posts/physically-based-rendering-and-you-can-too/)
  *
  * Technical details of the approach used in three.js (and most other PBR systems) can be found is this
- * [paper from Disney]{@link https://media.disneyanimation.com/uploads/production/publication_asset/48/asset/s2012_pbs_disney_brdf_notes_v3.pdf}
+ * [paper from Disney](https://media.disneyanimation.com/uploads/production/publication_asset/48/asset/s2012_pbs_disney_brdf_notes_v3.pdf)
  * (pdf), by Brent Burley.
  *
  * @augments Material

--- a/src/materials/PointsMaterial.js
+++ b/src/materials/PointsMaterial.js
@@ -88,7 +88,7 @@ class PointsMaterial extends Material {
 		/**
 		 * Defines the size of the points in pixels.
 		 *
-		 * Might be capped if the value exceeds hardware dependent parameters like [gl.ALIASED_POINT_SIZE_RANGE]{@link https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/getParamete}.
+		 * Might be capped if the value exceeds hardware dependent parameters like [gl.ALIASED_POINT_SIZE_RANGE](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/getParamete).
 		 *
 		 * @type {number}
 		 * @default 1

--- a/src/materials/ShaderMaterial.js
+++ b/src/materials/ShaderMaterial.js
@@ -17,7 +17,7 @@ import default_fragment from '../renderers/shaders/ShaderChunk/default_fragment.
  * - You can use the directive `#pragma unroll_loop_start` and `#pragma unroll_loop_end`
  * in order to unroll a `for` loop in GLSL by the shader preprocessor. The directive has
  * to be placed right above the loop. The loop formatting has to correspond to a defined standard.
- *   - The loop has to be [normalized]{@link https://en.wikipedia.org/wiki/Normalized_loop}.
+ *   - The loop has to be [normalized](https://en.wikipedia.org/wiki/Normalized_loop).
  *   - The loop variable has to be *i*.
  *   - The value `UNROLLED_LOOP_INDEX` will be replaced with the explicitly
  * value of *i* for the given iteration and can be used in preprocessor
@@ -223,7 +223,7 @@ class ShaderMaterial extends Material {
 		};
 
 		/**
-		 * If set, this calls [gl.bindAttribLocation]{@link https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/bindAttribLocation}
+		 * If set, this calls [gl.bindAttribLocation](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/bindAttribLocation)
 		 * to bind a generic vertex index to an attribute variable.
 		 *
 		 * @type {string|undefined}

--- a/src/materials/nodes/MeshSSSNodeMaterial.js
+++ b/src/materials/nodes/MeshSSSNodeMaterial.js
@@ -39,7 +39,7 @@ class SSSLightingModel extends PhysicalLightingModel {
 	/**
 	 * Extends the default implementation with a SSS term.
 	 *
-	 * Reference: [Approximating Translucency for a Fast, Cheap and Convincing Subsurface Scattering Look]{@link https://colinbarrebrisebois.com/2011/03/07/gdc-2011-approximating-translucency-for-a-fast-cheap-and-convincing-subsurface-scattering-look/}
+	 * Reference: [Approximating Translucency for a Fast, Cheap and Convincing Subsurface Scattering Look](https://colinbarrebrisebois.com/2011/03/07/gdc-2011-approximating-translucency-for-a-fast-cheap-and-convincing-subsurface-scattering-look/)
 	 *
 	 * @param {Object} input - The input data.
 	 * @param {NodeBuilder} builder - The current node builder.

--- a/src/math/Color.js
+++ b/src/math/Color.js
@@ -276,7 +276,7 @@ class Color {
 	/**
 	 * Sets this color from a CSS-style string. For example, `rgb(250, 0,0)`,
 	 * `rgb(100%, 0%, 0%)`, `hsl(0, 100%, 50%)`, `#ff0000`, `#f00`, or `red` ( or
-	 * any [X11 color name]{@link https://en.wikipedia.org/wiki/X11_color_names#Color_name_chart} -
+	 * any [X11 color name](https://en.wikipedia.org/wiki/X11_color_names#Color_name_chart) -
 	 * all 140 color names are supported).
 	 *
 	 * @param {string} style - Color as a CSS-style string.

--- a/src/math/Cylindrical.js
+++ b/src/math/Cylindrical.js
@@ -1,6 +1,6 @@
 /**
  * This class can be used to represent points in 3D space as
- * [Cylindrical coordinates]{@link https://en.wikipedia.org/wiki/Cylindrical_coordinate_system}.
+ * [Cylindrical coordinates](https://en.wikipedia.org/wiki/Cylindrical_coordinate_system).
  */
 class Cylindrical {
 

--- a/src/math/MathUtils.js
+++ b/src/math/MathUtils.js
@@ -9,7 +9,7 @@ const DEG2RAD = Math.PI / 180;
 const RAD2DEG = 180 / Math.PI;
 
 /**
- * Generate a [UUID]{@link https://en.wikipedia.org/wiki/Universally_unique_identifier}
+ * Generate a [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier)
  * (universally unique identifier).
  *
  * @return {string} The UUID.
@@ -122,7 +122,7 @@ function lerp( x, y, t ) {
 /**
  * Smoothly interpolate a number from `x` to `y` in  a spring-like manner using a delta
  * time to maintain frame rate independent movement. For details, see
- * [Frame rate independent damping using lerp]{@link http://www.rorydriscoll.com/2016/03/07/frame-rate-independent-damping-using-lerp/}.
+ * [Frame rate independent damping using lerp](http://www.rorydriscoll.com/2016/03/07/frame-rate-independent-damping-using-lerp/).
  *
  * @param {number} x - The current point.
  * @param {number} y - The target point.
@@ -157,7 +157,7 @@ function pingpong( x, length = 1 ) {
  * moved between `min` and `max`, but smoothed or slowed down the closer `x` is to
  * the `min` and `max`.
  *
- * See [Smoothstep]{@link http://en.wikipedia.org/wiki/Smoothstep} for more details.
+ * See [Smoothstep](http://en.wikipedia.org/wiki/Smoothstep) for more details.
  *
  * @param {number} x - The value to evaluate based on its position between min and max.
  * @param {number} min - The min value. Any x value below min will be `0`.
@@ -176,7 +176,7 @@ function smoothstep( x, min, max ) {
 }
 
 /**
- * A [variation on smoothstep]{@link https://en.wikipedia.org/wiki/Smoothstep#Variations}
+ * A [variation on smoothstep](https://en.wikipedia.org/wiki/Smoothstep#Variations)
  * that has zero 1st and 2nd order derivatives at x=0 and x=1.
  *
  * @param {number} x - The value to evaluate based on its position between min and max.
@@ -316,7 +316,7 @@ function floorPowerOfTwo( value ) {
 }
 
 /**
- * Sets the given quaternion from the [Intrinsic Proper Euler Angles]{@link https://en.wikipedia.org/wiki/Euler_angles}
+ * Sets the given quaternion from the [Intrinsic Proper Euler Angles](https://en.wikipedia.org/wiki/Euler_angles)
  * defined by the given angles and order.
  *
  * Rotations are applied to the axes in the order specified by order:
@@ -481,7 +481,7 @@ const MathUtils = {
 	DEG2RAD: DEG2RAD,
 	RAD2DEG: RAD2DEG,
 	/**
-	 * Generate a [UUID]{@link https://en.wikipedia.org/wiki/Universally_unique_identifier}
+	 * Generate a [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier)
 	 * (universally unique identifier).
 	 *
 	 * @static
@@ -552,7 +552,7 @@ const MathUtils = {
 	/**
 	 * Smoothly interpolate a number from `x` to `y` in  a spring-like manner using a delta
 	 * time to maintain frame rate independent movement. For details, see
-	 * [Frame rate independent damping using lerp]{@link http://www.rorydriscoll.com/2016/03/07/frame-rate-independent-damping-using-lerp/}.
+	 * [Frame rate independent damping using lerp](http://www.rorydriscoll.com/2016/03/07/frame-rate-independent-damping-using-lerp/).
 	 *
 	 * @static
 	 * @method
@@ -579,7 +579,7 @@ const MathUtils = {
 	 * moved between `min` and `max`, but smoothed or slowed down the closer `x` is to
 	 * the `min` and `max`.
 	 *
-	 * See [Smoothstep]{@link http://en.wikipedia.org/wiki/Smoothstep} for more details.
+	 * See [Smoothstep](http://en.wikipedia.org/wiki/Smoothstep) for more details.
 	 *
 	 * @static
 	 * @method
@@ -590,7 +590,7 @@ const MathUtils = {
 	 */
 	smoothstep: smoothstep,
 	/**
-	 * A [variation on smoothstep]{@link https://en.wikipedia.org/wiki/Smoothstep#Variations}
+	 * A [variation on smoothstep](https://en.wikipedia.org/wiki/Smoothstep#Variations)
 	 * that has zero 1st and 2nd order derivatives at x=0 and x=1.
 	 *
 	 * @static
@@ -685,7 +685,7 @@ const MathUtils = {
 	 */
 	floorPowerOfTwo: floorPowerOfTwo,
 	/**
-	 * Sets the given quaternion from the [Intrinsic Proper Euler Angles]{@link https://en.wikipedia.org/wiki/Euler_angles}
+	 * Sets the given quaternion from the [Intrinsic Proper Euler Angles](https://en.wikipedia.org/wiki/Euler_angles)
 	 * defined by the given angles and order.
 	 *
 	 * Rotations are applied to the axes in the order specified by order:

--- a/src/math/Matrix2.js
+++ b/src/math/Matrix2.js
@@ -4,7 +4,7 @@
  * A Note on Row-Major and Column-Major Ordering:
  *
  * The constructor and {@link Matrix2#set} method take arguments in
- * [row-major]{@link https://en.wikipedia.org/wiki/Row-_and_column-major_order#Column-major_order}
+ * [row-major](https://en.wikipedia.org/wiki/Row-_and_column-major_order#Column-major_order)
  * order, while internally they are stored in the {@link Matrix2#elements} array in column-major order.
  * This means that calling:
  * ```js

--- a/src/math/Matrix3.js
+++ b/src/math/Matrix3.js
@@ -4,7 +4,7 @@
  * A Note on Row-Major and Column-Major Ordering:
  *
  * The constructor and {@link Matrix3#set} method take arguments in
- * [row-major]{@link https://en.wikipedia.org/wiki/Row-_and_column-major_order#Column-major_order}
+ * [row-major](https://en.wikipedia.org/wiki/Row-_and_column-major_order#Column-major_order)
  * order, while internally they are stored in the {@link Matrix3#elements} array in column-major order.
  * This means that calling:
  * ```js
@@ -278,7 +278,7 @@ class Matrix3 {
 	}
 
 	/**
-	 * Inverts this matrix, using the [analytic method]{@link https://en.wikipedia.org/wiki/Invertible_matrix#Analytic_solution}.
+	 * Inverts this matrix, using the [analytic method](https://en.wikipedia.org/wiki/Invertible_matrix#Analytic_solution).
 	 * You can not invert with a determinant of zero. If you attempt this, the method produces
 	 * a zero matrix instead.
 	 *

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -5,7 +5,7 @@ import { Vector3 } from './Vector3.js';
  * Represents a 4x4 matrix.
  *
  * The most common use of a 4x4 matrix in 3D computer graphics is as a transformation matrix.
- * For an introduction to transformation matrices as used in WebGL, check out [this tutorial]{@link https://www.opengl-tutorial.org/beginners-tutorials/tutorial-3-matrices}
+ * For an introduction to transformation matrices as used in WebGL, check out [this tutorial](https://www.opengl-tutorial.org/beginners-tutorials/tutorial-3-matrices)
  *
  * This allows a 3D vector representing a point in 3D space to undergo
  * transformations such as translation, rotation, shear, scale, reflection,
@@ -15,7 +15,7 @@ import { Vector3 } from './Vector3.js';
  * A Note on Row-Major and Column-Major Ordering:
  *
  * The constructor and {@link Matrix3#set} method take arguments in
- * [row-major]{@link https://en.wikipedia.org/wiki/Row-_and_column-major_order#Column-major_order}
+ * [row-major](https://en.wikipedia.org/wiki/Row-_and_column-major_order#Column-major_order)
  * order, while internally they are stored in the {@link Matrix3#elements} array in column-major order.
  * This means that calling:
  * ```js
@@ -309,7 +309,7 @@ class Matrix4 {
 	 * Sets the rotation component (the upper left 3x3 matrix) of this matrix to
 	 * the rotation specified by the given Euler angles. The rest of
 	 * the matrix is set to the identity. Depending on the {@link Euler#order},
-	 * there are six possible outcomes. See [this page]{@link https://en.wikipedia.org/wiki/Euler_angles#Rotation_matrix}
+	 * there are six possible outcomes. See [this page](https://en.wikipedia.org/wiki/Euler_angles#Rotation_matrix)
 	 * for a complete list.
 	 *
 	 * @param {Euler} euler - The Euler angles.
@@ -439,7 +439,7 @@ class Matrix4 {
 
 	/**
 	 * Sets the rotation component of this matrix to the rotation specified by
-	 * the given Quaternion as outlined [here]{@link https://en.wikipedia.org/wiki/Rotation_matrix#Quaternion}
+	 * the given Quaternion as outlined [here](https://en.wikipedia.org/wiki/Rotation_matrix#Quaternion)
 	 * The rest of the matrix is set to the identity.
 	 *
 	 * @param {Quaternion} q - The Quaternion.
@@ -601,7 +601,7 @@ class Matrix4 {
 	/**
 	 * Computes and returns the determinant of this matrix.
 	 *
-	 * Based on the method outlined [here]{@link http://www.euclideanspace.com/maths/algebra/matrix/functions/inverse/fourD/index.html}.
+	 * Based on the method outlined [here](http://www.euclideanspace.com/maths/algebra/matrix/functions/inverse/fourD/index.html).
 	 *
 	 * @return {number} The determinant.
 	 */
@@ -708,7 +708,7 @@ class Matrix4 {
 	}
 
 	/**
-	 * Inverts this matrix, using the [analytic method]{@link https://en.wikipedia.org/wiki/Invertible_matrix#Analytic_solution}.
+	 * Inverts this matrix, using the [analytic method](https://en.wikipedia.org/wiki/Invertible_matrix#Analytic_solution).
 	 * You can not invert with a determinant of zero. If you attempt this, the method produces
 	 * a zero matrix instead.
 	 *
@@ -911,7 +911,7 @@ class Matrix4 {
 	 * the given angle.
 	 *
 	 * This is a somewhat controversial but mathematically sound alternative to
-	 * rotating via Quaternions. See the discussion [here]{@link https://www.gamedev.net/articles/programming/math-and-physics/do-we-really-need-quaternions-r1199}.
+	 * rotating via Quaternions. See the discussion [here](https://www.gamedev.net/articles/programming/math-and-physics/do-we-really-need-quaternions-r1199).
 	 *
 	 * @param {Vector3} axis - The normalized rotation axis.
 	 * @param {number} angle - The rotation in radians.

--- a/src/math/Plane.js
+++ b/src/math/Plane.js
@@ -7,7 +7,7 @@ const _normalMatrix = /*@__PURE__*/ new Matrix3();
 
 /**
  * A two dimensional surface that extends infinitely in 3D space, represented
- * in [Hessian normal form]{@link http://mathworld.wolfram.com/HessianNormalForm.html}
+ * in [Hessian normal form](http://mathworld.wolfram.com/HessianNormalForm.html)
  * by a unit length normal vector and a constant.
  */
 class Plane {

--- a/src/math/Spherical.js
+++ b/src/math/Spherical.js
@@ -2,7 +2,7 @@ import { clamp } from './MathUtils.js';
 
 /**
  * This class can be used to represent points in 3D space as
- * [Spherical coordinates]{@link https://en.wikipedia.org/wiki/Spherical_coordinate_system}.
+ * [Spherical coordinates](https://en.wikipedia.org/wiki/Spherical_coordinate_system).
  */
 class Spherical {
 


### PR DESCRIPTION
Updated all JSDoc links for better readability:

Changed from 
`[CCD Algorithm]{@link https://web.archive.org/web/20221206080850/https://sites.google.com/site/auraliusproject/ccd-algorithm}`

to 
`[CCD Algorithm](https://web.archive.org/web/20221206080850/https://sites.google.com/site/auraliusproject/ccd-algorithm)`

## Before
<img width="635" height="236" alt="image" src="https://github.com/user-attachments/assets/5fe324ee-8d4e-42b6-97ee-95cd05df8f87" />

## After
<img width="421" height="151" alt="image" src="https://github.com/user-attachments/assets/7eabf213-6ec4-4201-95e6-6faf1d25c48f" />

### New Documentation rendering works fine too:
<img width="2366" height="790" alt="image" src="https://github.com/user-attachments/assets/7616cd7b-d33a-4123-9513-7f1c767032c9" />

---
Updated using VSCode ReplaceAll: `\]\{@link (.+)\}` -> `]($1)`

---

Related PR: https://github.com/mrdoob/three.js/pull/32096

*This contribution is funded by [Needle](https://needle.tools)*
