### PR TITLE
TSL: Assign stack for nodes after remove stack

### DIFF
--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -1683,6 +1683,14 @@ class NodeBuilder {
 	removeStack() {
 
 		const lastStack = this.stack;
+
+		for ( const node of lastStack.nodes ) {
+
+			const nodeData = this.getDataFromNode( node );
+			nodeData.stack = lastStack;
+
+		}
+
 		this.stack = lastStack.parent;
 
 		setCurrentStack( this.stacks.pop() );

--- a/src/nodes/core/StackNode.js
+++ b/src/nodes/core/StackNode.js
@@ -311,9 +311,6 @@ class StackNode extends Node {
 
 			if ( buildStage === 'setup' ) {
 
-				const nodeData = builder.getDataFromNode( node );
-				nodeData.stack = this;
-
 				node.build( builder );
 
 			} else if ( buildStage === 'analyze' ) {


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/32109

**Description**

Some nodes weren't being defined in the stack through setup because they were running in different processes. The PR is an attempt to assign the node to a stack. We may need a static reference to NodeBuilder, but I'd like to avoid that.