### PR TITLE
WebGPURenderer: Improve cache key verification

### DIFF
--- a/src/nodes/core/Node.js
+++ b/src/nodes/core/Node.js
@@ -402,7 +402,7 @@ class Node extends EventDispatcher {
 
 			//
 
-			const values = [ this.id ];
+			const values = [];
 
 			for ( const { property, childNode } of this._getChildren( ignores ) ) {
 
@@ -428,7 +428,7 @@ class Node extends EventDispatcher {
 	 */
 	customCacheKey() {
 
-		return 0;
+		return this.id;
 
 	}
 

--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -33,6 +33,8 @@ import { Vector4 } from '../../math/Vector4.js';
 import { Float16BufferAttribute } from '../../core/BufferAttribute.js';
 import { warn, error } from '../../utils.js';
 
+let _id = 0;
+
 const rendererCache = new WeakMap();
 
 const typeFromArray = new Map( [
@@ -458,6 +460,8 @@ class NodeBuilder {
 		 * @default null
 		 */
 		this.fnCall = null;
+
+		Object.defineProperty( this, 'id', { value: _id ++ } );
 
 	}
 

--- a/src/nodes/core/PropertyNode.js
+++ b/src/nodes/core/PropertyNode.js
@@ -1,5 +1,6 @@
 import Node from './Node.js';
 import { nodeImmutable, nodeObject } from '../tsl/TSLCore.js';
+import { hashString } from './NodeUtils.js';
 
 /**
  * This class represents a shader property. It can be used
@@ -65,6 +66,12 @@ class PropertyNode extends Node {
 		 * @default true
 		 */
 		this.global = true;
+
+	}
+
+	customCacheKey() {
+
+		return hashString( this.type + ':' + ( this.name || '' ) + ':' + ( this.varying ? '1' : '0' ) );
 
 	}
 

--- a/src/renderers/common/RenderObject.js
+++ b/src/renderers/common/RenderObject.js
@@ -869,6 +869,8 @@ class RenderObject {
 
 		}
 
+		cacheKey = hash( cacheKey, this.camera.id );
+
 		return cacheKey;
 
 	}


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/32134

**Description**

This makes `LightsNode`, even though the file is unchanged in this PR, the same cache key for other passes, reusing the same TSL code generated when using different scenes, especially if `.render(mesh, camera)` is used.