### PR TITLE
AfterImageNode: Fix swap.

### DIFF
--- a/examples/jsm/tsl/display/AfterImageNode.js
+++ b/examples/jsm/tsl/display/AfterImageNode.js
@@ -38,13 +38,6 @@ class AfterImageNode extends TempNode {
 		this.textureNode = textureNode;
 
 		/**
-		 * The texture represents the pervious frame.
-		 *
-		 * @type {TextureNode}
-		 */
-		this.textureNodeOld = texture( null );
-
-		/**
 		 * How quickly the after-image fades. A higher value means the after-image
 		 * persists longer, while a lower value means it fades faster. Should be in
 		 * the range `[0, 1]`.
@@ -78,6 +71,14 @@ class AfterImageNode extends TempNode {
 		 * @type {PassTextureNode}
 		 */
 		this._textureNode = passTexture( this, this._compRT.texture );
+
+		/**
+		 * The texture represents the pervious frame.
+		 *
+		 * @private
+		 * @type {TextureNode}
+		 */
+		this._textureNodeOld = texture( this._oldRT.texture );
 
 		/**
 		 * The `updateBeforeType` is set to `NodeUpdateType.FRAME` since the node renders
@@ -139,26 +140,26 @@ class AfterImageNode extends TempNode {
 
 		this.setSize( _size.x, _size.y );
 
-		const currentTexture = textureNode.value;
+		// make sure texture nodes point to correct render targets
 
-		this.textureNodeOld.value = this._oldRT.texture;
+		this._textureNode.value = this._compRT.texture;
+		this._textureNodeOld.value = this._oldRT.texture;
 
-		// comp
+		// composite
+
 		_quadMesh.material = this._materialComposed;
 		_quadMesh.name = 'AfterImage';
 
 		renderer.setRenderTarget( this._compRT );
 		_quadMesh.render( renderer );
 
-		// Swap the textures
+		// swap
 
 		const temp = this._oldRT;
 		this._oldRT = this._compRT;
 		this._compRT = temp;
 
 		//
-
-		textureNode.value = currentTexture;
 
 		RendererUtils.restoreRendererState( renderer, _rendererState );
 
@@ -173,7 +174,7 @@ class AfterImageNode extends TempNode {
 	setup( builder ) {
 
 		const textureNode = this.textureNode;
-		const textureNodeOld = this.textureNodeOld;
+		const textureNodeOld = this._textureNodeOld;
 
 		//
 


### PR DESCRIPTION
Related issue: -

**Description**

The PR fixes below warning when a scene with `AfterImageNode` is resized.

<img width="616" height="37" alt="image" src="https://github.com/user-attachments/assets/41a0f285-dede-4ab6-99d1-6afd9ebd85a6" />

That happened because the texture node references did not always point to the correct render target textures due to the swap operation.

Prod: https://threejs.org/examples/webgpu_postprocessing_afterimage
PR: https://rawcdn.githack.com/Mugen87/three.js/9721868dddbffbc40598c692c99e889f4d497d71/examples/webgpu_postprocessing_afterimage.html
