### PR TITLE
Examples: Visualize normal as color in inspector `webgpu_postprocessing_ao`

### DIFF
--- a/examples/webgpu_postprocessing_ao.html
+++ b/examples/webgpu_postprocessing_ao.html
@@ -36,7 +36,7 @@
 		<script type="module">
 
 			import * as THREE from 'three/webgpu';
-			import { pass, mrt, output, normalView, velocity, vec3, vec4 } from 'three/tsl';
+			import { pass, mrt, output, normalView, velocity, vec3, vec4, directionToColor } from 'three/tsl';
 			import { ao } from 'three/addons/tsl/display/GTAONode.js';
 			import { traa } from 'three/addons/tsl/display/TRAANode.js';
 
@@ -114,7 +114,11 @@
 					return scenePass.getLinearDepthNode();
 
 				} );
-				const scenePassNormal = scenePass.getTextureNode( 'normal' ).toInspector( 'Normal' );
+				const scenePassNormal = scenePass.getTextureNode( 'normal' ).toInspector( 'Normal', () => {
+
+					return directionToColor( scenePassNormal.sample() );
+
+				} );
 				const scenePassVelocity = scenePass.getTextureNode( 'velocity' ).toInspector( 'Velocity' );
 
 				// ao

--- a/examples/webgpu_postprocessing_ao.html
+++ b/examples/webgpu_postprocessing_ao.html
@@ -123,10 +123,10 @@
 
 				// ao
 
-				aoPass = ao( scenePassDepth, scenePassNormal, camera ).toInspector( 'AO' );
+				aoPass = ao( scenePassDepth, scenePassNormal, camera );
 				aoPass.resolutionScale = 0.5; // running AO in half resolution is often sufficient
 				aoPass.useTemporalFiltering = true;
-				blendPassAO = vec4( scenePassColor.rgb.mul( aoPass.r ), scenePassColor.a ); // the AO is stored only in the red channel
+				blendPassAO = vec4( scenePassColor.rgb.mul( aoPass.r.toInspector( 'AO' ) ), scenePassColor.a ); // the AO is stored only in the red channel
 
 				// traa
 


### PR DESCRIPTION
Related: -

**Description**

It's more intuitive if *inspector::viewer* is visualized normal attachment(currently storing direction) as color

L: Dev branch https://raw.githack.com/mrdoob/three.js/dev/examples/webgpu_postprocessing_ao.html
R: This PR https://raw.githack.com/ycw/three.js/d/examples/webgpu_postprocessing_ao.html

<img width="1318" height="426" alt="image" src="https://github.com/user-attachments/assets/0b496094-83a1-4adb-8f03-df6fb4f2b0be" />