### PR TITLE
TSL: Fix get element through an output `Fn` value

### DIFF
--- a/src/nodes/core/StackNode.js
+++ b/src/nodes/core/StackNode.js
@@ -79,6 +79,12 @@ class StackNode extends Node {
 
 	}
 
+	getElementType( builder ) {
+
+		return this.hasOutput ? this.outputNode.getElementType( builder ) : 'void';
+
+	}
+
 	getNodeType( builder ) {
 
 		return this.hasOutput ? this.outputNode.getNodeType( builder ) : 'void';

--- a/src/nodes/tsl/TSLCore.js
+++ b/src/nodes/tsl/TSLCore.js
@@ -464,6 +464,12 @@ class ShaderCallNodeInternal extends Node {
 
 	}
 
+	getElementType( builder ) {
+
+		return this.getOutputNode( builder ).getElementType( builder );
+
+	}
+
 	getMemberType( builder, name ) {
 
 		return this.getOutputNode( builder ).getMemberType( builder, name );

--- a/test/e2e/puppeteer.js
+++ b/test/e2e/puppeteer.js
@@ -11,6 +11,7 @@ const exceptionList = [
 	'physics_rapier_instancing',
 	'webgl_shadowmap',
 	'webgl_postprocessing_dof2',
+	'webgl_video_kinect',
 	'webgl_worker_offscreencanvas',
 	'webgpu_backdrop_water',
 	'webgpu_lightprobe_cubecamera',


### PR DESCRIPTION
**Description**

Fix the type of node if used Fn's output to get some element. E.g: `someFn().element()` .