### PR TITLE
WebGPURenderer: Increase GGX_SAMPLES from 1024 to 2048

### DIFF
--- a/src/renderers/common/extras/PMREMGenerator.js
+++ b/src/renderers/common/extras/PMREMGenerator.js
@@ -44,7 +44,7 @@ const EXTRA_LOD_SIGMA = [ 0.125, 0.215, 0.35, 0.446, 0.526, 0.582 ];
 const MAX_SAMPLES = 20;
 
 // GGX VNDF importance sampling configuration
-const GGX_SAMPLES = 1024;
+const GGX_SAMPLES = 2048;
 
 const _flatCamera = /*@__PURE__*/ new OrthographicCamera( - 1, 1, 1, - 1, 0, 1 );
 const _cubeCamera = /*@__PURE__*/ new PerspectiveCamera( 90, 1 );


### PR DESCRIPTION
Related issue: #32134 https://github.com/mrdoob/three.js/commit/ec097899e338da8c1c3341a35080b6af62715a7a
