### PR TITLE
Examples: Cleanup `webgpu_postprocessing_ao`

### DIFF
--- a/examples/webgpu_postprocessing_ao.html
+++ b/examples/webgpu_postprocessing_ao.html
@@ -36,7 +36,7 @@
 		<script type="module">
 
 			import * as THREE from 'three/webgpu';
-			import { pass, mrt, output, normalView, velocity, vec3, vec4, directionToColor } from 'three/tsl';
+			import { pass, mrt, output, normalView, velocity, vec3, vec4, directionToColor, colorSpaceToWorking } from 'three/tsl';
 			import { ao } from 'three/addons/tsl/display/GTAONode.js';
 			import { traa } from 'three/addons/tsl/display/TRAANode.js';
 
@@ -116,7 +116,7 @@
 				} );
 				const scenePassNormal = scenePass.getTextureNode( 'normal' ).toInspector( 'Normal', () => {
 
-					return directionToColor( scenePassNormal.sample() );
+					return colorSpaceToWorking( directionToColor( scenePassNormal ), THREE.SRGBColorSpace );
 
 				} );
 				const scenePassVelocity = scenePass.getTextureNode( 'velocity' ).toInspector( 'Velocity' );


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/32141#issuecomment-3465739355

**Description**

The PR fix the application of color space conversion in the example.

For clarification purposes only regarding the process.

We are defining `LinearSRGBColorSpace` in `outputColorSpace` when rendered in the Viewer. Because we are applying the color space conversion directly to the shader, this avoids rendering a new `quad` to apply it, since in this case it is not necessary, and we can optimize the process.

https://github.com/mrdoob/three.js/blob/e04b9f7bd7f5b17103339d343168bfab2d6e0ace/examples/jsm/inspector/Inspector.js#L269-L274

https://github.com/mrdoob/three.js/blob/e04b9f7bd7f5b17103339d343168bfab2d6e0ace/examples/jsm/inspector/tabs/Viewer.js#L149-L154