### PR TITLE
Matrix4: Optimize determinant() calculation

### DIFF
--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -614,9 +614,6 @@ class Matrix4 {
 		const n31 = te[ 2 ], n32 = te[ 6 ], n33 = te[ 10 ], n34 = te[ 14 ];
 		const n41 = te[ 3 ], n42 = te[ 7 ], n43 = te[ 11 ], n44 = te[ 15 ];
 
-		// Optimized calculation using pre-computed sub-expressions
-		// Based on cofactor expansion, but with common sub-expressions factored out
-
 		const t11 = n23 * n34 - n24 * n33;
 		const t12 = n22 * n34 - n24 * n32;
 		const t13 = n22 * n33 - n23 * n32;

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -614,43 +614,21 @@ class Matrix4 {
 		const n31 = te[ 2 ], n32 = te[ 6 ], n33 = te[ 10 ], n34 = te[ 14 ];
 		const n41 = te[ 3 ], n42 = te[ 7 ], n43 = te[ 11 ], n44 = te[ 15 ];
 
-		//TODO: make this more efficient
+		// Optimized calculation using pre-computed sub-expressions
+		// Based on cofactor expansion, but with common sub-expressions factored out
 
-		return (
-			n41 * (
-				+ n14 * n23 * n32
-				 - n13 * n24 * n32
-				 - n14 * n22 * n33
-				 + n12 * n24 * n33
-				 + n13 * n22 * n34
-				 - n12 * n23 * n34
-			) +
-			n42 * (
-				+ n11 * n23 * n34
-				 - n11 * n24 * n33
-				 + n14 * n21 * n33
-				 - n13 * n21 * n34
-				 + n13 * n24 * n31
-				 - n14 * n23 * n31
-			) +
-			n43 * (
-				+ n11 * n24 * n32
-				 - n11 * n22 * n34
-				 - n14 * n21 * n32
-				 + n12 * n21 * n34
-				 + n14 * n22 * n31
-				 - n12 * n24 * n31
-			) +
-			n44 * (
-				- n13 * n22 * n31
-				 - n11 * n23 * n32
-				 + n11 * n22 * n33
-				 + n13 * n21 * n32
-				 - n12 * n21 * n33
-				 + n12 * n23 * n31
-			)
+		const t11 = n23 * n34 - n24 * n33;
+		const t12 = n22 * n34 - n24 * n32;
+		const t13 = n22 * n33 - n23 * n32;
 
-		);
+		const t21 = n21 * n34 - n24 * n31;
+		const t22 = n21 * n33 - n23 * n31;
+		const t23 = n21 * n32 - n22 * n31;
+
+		return n11 * ( n42 * t11 - n43 * t12 + n44 * t13 ) -
+			n12 * ( n41 * t11 - n43 * t21 + n44 * t22 ) +
+			n13 * ( n41 * t12 - n42 * t21 + n44 * t23 ) -
+			n14 * ( n41 * t13 - n42 * t22 + n43 * t23 );
 
 	}
 


### PR DESCRIPTION
**Description**

This PR optimizes the `Matrix4.determinant()` method by factoring out common sub-expressions, reducing redundant calculations.

### Changes
- Refactored determinant calculation to pre-compute reusable sub-expressions (t11-t23)
- Reduced multiplication operations from ~48 to ~27
- Removed TODO comment as the method is now optimized
- Maintains exact same mathematical accuracy

### Performance Impact
The optimized implementation reduces computational overhead for determinant calculations, which are used in:
- Matrix decomposition (`decompose()` method)
- Matrix inversion validation
- General matrix operations requiring determinant checks

### Testing
All existing unit tests pass, including specific determinant test cases verifying correctness with various matrix configurations.