### PR TITLE
PixelationPassNode: Fix zero normal processing.

### DIFF
--- a/examples/jsm/tsl/display/PixelationPassNode.js
+++ b/examples/jsm/tsl/display/PixelationPassNode.js
@@ -193,7 +193,7 @@ class PixelationNode extends TempNode {
 
 			const nei = property( 'float', 'nei' );
 
-			If( this.normalEdgeStrength.greaterThan( 0.0 ), () => {
+			If( this.normalEdgeStrength.greaterThan( 0.0 ).and( normal.length().greaterThan( 0 ) ), () => {
 
 				nei.assign( normalEdgeIndicator( depth, normal ) );
 


### PR DESCRIPTION
Closes #32113.

**Description**

The PR makes sure that `PixelationPassNode` does not process normals with a zero length. Such normals can appear for background pixels which just have clear values like `(0,0,0)`.

When normals have 0 length, they can not be used to compute a normal edge indicator since this computation relies on the dot product. A dot product with a zero vector always produces 0 so this results in a normal edge indicator of 1. That is wrong since pixel with a (0,0,0) normals should not be affected by the pixelation pass.

@cmhhelgeson The PR fixes the issue for me on Windows and Android. Can you please make a test on your devices?

https://rawcdn.githack.com/Mugen87/three.js/c406652ebdc0e33d091582847df9dfd95e350215/examples/webgpu_postprocessing_pixel.html
