### PR TITLE
Docs: Fix external links.

### DIFF
--- a/utils/docs/template/static/scripts/page.js
+++ b/utils/docs/template/static/scripts/page.js
@@ -20,6 +20,23 @@ if ( typeof hljs !== 'undefined' ) {
 
 } )();
 
+// Open external URLs in new tabs
+( function () {
+
+	const links = document.querySelectorAll( 'a' );
+
+	for ( const link of links ) {
+
+		if ( link.href.match( /^https?:\/\//i ) ) {
+
+			link.setAttribute( 'target', '_blank' );
+
+		}
+
+	}
+
+} )();
+
 // Update URL hash when clicking on method/property links
 ( function () {
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/32036#issuecomment-3473523333

**Description**

External links currently open inside the iFrame. The PR fixes this by scanning links and add `target="_blank"` to links which start with http or https. Compared to https://github.com/mrdoob/three.js/pull/32036#issuecomment-3473957649, the code of this PR uses a regex to cover some edge cases.
