### PR TITLE
Docs: Improved search with category matching

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2029,7 +2029,9 @@
 				}
 
 				const regExp = new RegExp( escapeRegExp( v ), 'gi' );
-				const highlightRegExp = new RegExp( v.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' ), 'gi' );
+				// Create highlight regex that matches any of the search words
+				const words = v.split( ' ' ).map( word => word.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' ) ).join( '|' );
+				const highlightRegExp = new RegExp( words, 'gi' );
 
 				// Search through all categories
 				const results = [];
@@ -2038,7 +2040,9 @@
 					const items = searchData[ category ];
 					for ( const item of items ) {
 
-						if ( item.title.match( regExp ) ) {
+						// Match against combined category and title for multi-word searches
+						const searchText = category + ' ' + item.title;
+						if ( searchText.match( regExp ) ) {
 
 							results.push( { ...item, category } );
 
@@ -2128,7 +2132,8 @@
 
 						if ( ! byCategory[ category ] ) continue;
 
-						html += `<h2>${category}</h2>`;
+						const highlightedCategory = highlightMatch( category, highlightRegExp );
+						html += `<h2>${highlightedCategory}</h2>`;
 
 						for ( const className in byCategory[ category ] ) {
 

--- a/utils/docs/template/static/index.html
+++ b/utils/docs/template/static/index.html
@@ -315,7 +315,9 @@
 				}
 
 				const regExp = new RegExp( escapeRegExp( v ), 'gi' );
-				const highlightRegExp = new RegExp( v.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' ), 'gi' );
+				// Create highlight regex that matches any of the search words
+				const words = v.split( ' ' ).map( word => word.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' ) ).join( '|' );
+				const highlightRegExp = new RegExp( words, 'gi' );
 
 				// Search through all categories
 				const results = [];
@@ -324,7 +326,9 @@
 					const items = searchData[ category ];
 					for ( const item of items ) {
 
-						if ( item.title.match( regExp ) ) {
+						// Match against combined category and title for multi-word searches
+						const searchText = category + ' ' + item.title;
+						if ( searchText.match( regExp ) ) {
 
 							results.push( { ...item, category } );
 
@@ -414,7 +418,8 @@
 
 						if ( ! byCategory[ category ] ) continue;
 
-						html += `<h2>${category}</h2>`;
+						const highlightedCategory = highlightMatch( category, highlightRegExp );
+						html += `<h2>${highlightedCategory}</h2>`;
 
 						for ( const className in byCategory[ category ] ) {
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/32036#issuecomment-3394005402

**Description**

Searching for "tsl" didn't return any meaningful result.

| Before | After |
| --- | --- |
| <img width="299" height="733" alt="Screenshot 2025-11-01 at 14 18 52" src="https://github.com/user-attachments/assets/47478616-0c9f-473c-a756-778b4a5a2f48" /> | <img width="299" height="733" alt="Screenshot 2025-11-01 at 14 23 55" src="https://github.com/user-attachments/assets/17b66521-e564-4634-afc8-6c087711001b" /> |

While I was at it, I also made it possible to search for multiple words and get useful results:

| | | |
| --- | --- | --- |
| <img width="299" height="733" alt="Screenshot 2025-11-01 at 14 23 46" src="https://github.com/user-attachments/assets/af4180a1-3543-4379-8ff2-6da1e1dbda7e" /> | <img width="299" height="733" alt="Screenshot 2025-11-01 at 14 36 18" src="https://github.com/user-attachments/assets/949f9da4-7f44-4483-bfa7-416090679960" /> | <img width="299" height="733" alt="Screenshot 2025-11-01 at 14 23 26" src="https://github.com/user-attachments/assets/8a9f6bde-3ff2-4ed7-a1e5-45ccf684465e" /> |

/fyi @sunag 

(Made using [Claude Code](https://code.claude.com/docs/en/vs-code) with Sonnet 4.5)