### PR TITLE
Docs: Add missing `@private` annotation.

### DIFF
--- a/examples/jsm/loaders/PCDLoader.js
+++ b/examples/jsm/loaders/PCDLoader.js
@@ -100,6 +100,7 @@ class PCDLoader extends Loader {
 	/**
 	 * Get dataview value by field type and size.
 	 *
+	 * @private
 	 * @param {DataView} dataview - The DataView to read from.
 	 * @param {number} offset - The offset to start reading from.
 	 * @param {'F' | 'U' | 'I'} type - Field type.

--- a/examples/jsm/tsl/display/AnaglyphPassNode.js
+++ b/examples/jsm/tsl/display/AnaglyphPassNode.js
@@ -40,6 +40,7 @@ class AnaglyphPassNode extends StereoCompositePassNode {
 		/**
 		 * Color matrix node for the left eye.
 		 *
+		 * @private
 		 * @type {UniformNode<mat3>}
 		 */
 		this._colorMatrixLeft = uniform( new Matrix3().fromArray( [
@@ -51,6 +52,7 @@ class AnaglyphPassNode extends StereoCompositePassNode {
 		/**
 		 * Color matrix node for the right eye.
 		 *
+		 * @private
 		 * @type {UniformNode<mat3>}
 		 */
 		this._colorMatrixRight = uniform( new Matrix3().fromArray( [

--- a/examples/jsm/tsl/display/BloomNode.js
+++ b/examples/jsm/tsl/display/BloomNode.js
@@ -448,6 +448,7 @@ class BloomNode extends TempNode {
 	/**
 	 * Create a separable blur material for the given kernel radius.
 	 *
+	 * @private
 	 * @param {NodeBuilder} builder - The current node builder.
 	 * @param {number} kernelRadius - The kernel radius.
 	 * @return {NodeMaterial}

--- a/examples/jsm/tsl/display/PixelationPassNode.js
+++ b/examples/jsm/tsl/display/PixelationPassNode.js
@@ -74,6 +74,7 @@ class PixelationNode extends TempNode {
 		/**
 		 * Uniform node that represents the resolution.
 		 *
+		 * @private
 		 * @type {Node<vec4>}
 		 */
 		this._resolution = uniform( new Vector4() );

--- a/examples/jsm/tsl/display/SSGINode.js
+++ b/examples/jsm/tsl/display/SSGINode.js
@@ -197,6 +197,7 @@ class SSGINode extends TempNode {
 		/**
 		 * The resolution of the effect.
 		 *
+		 * @private
 		 * @type {UniformNode<vec2>}
 		 */
 		this._resolution = uniform( new Vector2() );
@@ -204,6 +205,7 @@ class SSGINode extends TempNode {
 		/**
 		 * Used to compute the effective step radius when viewSpaceSampling is `false`.
 		 *
+		 * @private
 		 * @type {UniformNode<vec2>}
 		 */
 		this._halfProjScale = uniform( 1 );
@@ -211,6 +213,7 @@ class SSGINode extends TempNode {
 		/**
 		 * Temporal direction that influences the rotation angle for each slice.
 		 *
+		 * @private
 		 * @type {UniformNode<float>}
 		 */
 		this._temporalDirection = uniform( 0 );
@@ -218,6 +221,7 @@ class SSGINode extends TempNode {
 		/**
 		 * Temporal offset added to the initial ray step.
 		 *
+		 * @private
 		 * @type {UniformNode<float>}
 		 */
 		this._temporalOffset = uniform( 0 );

--- a/examples/jsm/tsl/display/SSSNode.js
+++ b/examples/jsm/tsl/display/SSSNode.js
@@ -192,6 +192,7 @@ class SSSNode extends TempNode {
 		/**
 		 * Temporal offset added to the initial ray step.
 		 *
+		 * @private
 		 * @type {UniformNode<float>}
 		 */
 		this._temporalOffset = uniform( 0 );
@@ -199,6 +200,7 @@ class SSSNode extends TempNode {
 		/**
 		 * The frame ID use when temporal filtering is enabled.
 		 *
+		 * @private
 		 * @type {UniformNode<uint>}
 		 */
 		this._frameId = uniform( 0 );

--- a/examples/jsm/tsl/display/StereoCompositePassNode.js
+++ b/examples/jsm/tsl/display/StereoCompositePassNode.js
@@ -50,11 +50,13 @@ class StereoCompositePassNode extends PassNode {
 		 * @type {StereoCamera}
 		 */
 		this.stereo = new StereoCamera();
+
 		const _params = { minFilter: LinearFilter, magFilter: NearestFilter, type: HalfFloatType };
 
 		/**
 		 * The render target for rendering the left eye's view.
 		 *
+		 * @private
 		 * @type {RenderTarget}
 		 */
 		this._renderTargetL = new RenderTarget( 1, 1, _params );
@@ -62,6 +64,7 @@ class StereoCompositePassNode extends PassNode {
 		/**
 		 * The render target for rendering the right eye's view.
 		 *
+		 * @private
 		 * @type {RenderTarget}
 		 */
 		this._renderTargetR = new RenderTarget( 1, 1, _params );
@@ -69,6 +72,7 @@ class StereoCompositePassNode extends PassNode {
 		/**
 		 * A texture node representing the left's eye view.
 		 *
+		 * @private
 		 * @type {TextureNode}
 		 */
 		this._mapLeft = texture( this._renderTargetL.texture );
@@ -76,6 +80,7 @@ class StereoCompositePassNode extends PassNode {
 		/**
 		 * A texture node representing the right's eye view.
 		 *
+		 * @private
 		 * @type {TextureNode}
 		 */
 		this._mapRight = texture( this._renderTargetR.texture );
@@ -84,7 +89,9 @@ class StereoCompositePassNode extends PassNode {
 		 * The node material that implements the composite. All
 		 * derived effect passes must provide an instance for rendering.
 		 *
-		 * @type {NodeMaterial}
+		 * @private
+		 * @type {?NodeMaterial}
+		 * @default null
 		 */
 		this._material = null;
 

--- a/src/nodes/accessors/StorageBufferNode.js
+++ b/src/nodes/accessors/StorageBufferNode.js
@@ -126,6 +126,7 @@ class StorageBufferNode extends BufferNode {
 		/**
 		 * A reference to the internal buffer attribute node.
 		 *
+		 * @private
 		 * @type {?BufferAttributeNode}
 		 * @default null
 		 */
@@ -134,6 +135,7 @@ class StorageBufferNode extends BufferNode {
 		/**
 		 * A reference to the internal varying node.
 		 *
+		 * @private
 		 * @type {?VaryingNode}
 		 * @default null
 		 */

--- a/src/nodes/display/ScreenNode.js
+++ b/src/nodes/display/ScreenNode.js
@@ -49,6 +49,7 @@ class ScreenNode extends Node {
 		/**
 		 * This output node.
 		 *
+		 * @private
 		 * @type {?Node}
 		 * @default null
 		 */

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -2360,6 +2360,7 @@ class Renderer {
 	/**
 	 * Resets the renderer to the initial state before WebXR started.
 	 *
+	 * @private
 	 */
 	_resetXRState() {
 
@@ -2750,6 +2751,7 @@ class Renderer {
 	 * Analyzes the given 3D object's hierarchy and builds render lists from the
 	 * processed hierarchy.
 	 *
+	 * @private
 	 * @param {Object3D} object - The 3D object to process (usually a scene).
 	 * @param {Camera} camera - The camera the object is rendered with.
 	 * @param {number} groupOrder - The group order is derived from the `renderOrder` of groups and is used to group 3D objects within groups.
@@ -2975,6 +2977,7 @@ class Renderer {
 	 * Retrieves shadow nodes for the given material. This is used to setup shadow passes.
 	 * The result is cached per material and updated when the material's version changes.
 	 *
+	 * @private
 	 * @param {Material} material
 	 * @returns {Object} - The shadow nodes for the material.
 	 */

--- a/src/renderers/common/UniformsGroup.js
+++ b/src/renderers/common/UniformsGroup.js
@@ -432,6 +432,7 @@ class UniformsGroup extends UniformBuffer {
 	/**
 	 * Returns a typed array that matches the given data type.
 	 *
+	 * @private
 	 * @param {string} type - The data type.
 	 * @return {TypedArray} The typed array.
 	 */

--- a/src/renderers/common/XRManager.js
+++ b/src/renderers/common/XRManager.js
@@ -167,6 +167,7 @@ class XRManager extends EventDispatcher {
 		/**
 		 * Whether the XR session uses layers.
 		 *
+		 * @private
 		 * @type {boolean}
 		 * @default false
 		 */


### PR DESCRIPTION
Related issue: -

**Description**

Some private properties and methods were missing the `@private`annotation to make sure they are not documented as part of the public interface.