### PR TITLE
Docs: Add TSL subcategory

### DIFF
--- a/utils/docs/template/static/index.html
+++ b/utils/docs/template/static/index.html
@@ -327,7 +327,14 @@
 					for ( const item of items ) {
 
 						// Match against combined category and title for multi-word searches
-						const searchText = category + ' ' + item.title;
+						// For TSL items, also include the sub-category in the search
+						let searchText = category + ' ' + item.title;
+						if ( item.subCategory ) {
+
+							searchText = category + ' ' + item.subCategory + ' ' + item.title;
+
+						}
+
 						if ( searchText.match( regExp ) ) {
 
 							results.push( { ...item, category } );
@@ -354,7 +361,8 @@
 							grouped[ className ] = {
 								class: null,
 								members: [],
-								category: item.category
+								category: item.category,
+								subCategory: item.subCategory
 							};
 
 						}
@@ -421,42 +429,119 @@
 						const highlightedCategory = highlightMatch( category, highlightRegExp );
 						html += `<h2>${highlightedCategory}</h2>`;
 
-						for ( const className in byCategory[ category ] ) {
+						// For TSL category, group by sub-category
+						if ( category === 'TSL' ) {
 
-							const group = byCategory[ category ][ className ];
+							const bySubCategory = {};
 
-							if ( group.class ) {
+							for ( const className in byCategory[ category ] ) {
 
-								html += '<div class="search-result-group">';
-								const selectedClass = group.class.hash === currentHash ? ' selected' : '';
-								const highlightedName = highlightMatch( group.class.name, highlightRegExp );
-								html += `<a href="#${group.class.hash}" class="search-result-class${selectedClass}">${highlightedName}</a>`;
+								const group = byCategory[ category ][ className ];
+								const subCat = group.subCategory || 'Other';
 
-							}
+								if ( ! bySubCategory[ subCat ] ) {
 
-							if ( group.members.length > 0 ) {
-
-								if ( ! group.class ) {
-
-									html += '<div class="search-result-group">';
-									html += `<a href="#${className}" class="search-result-class">${className}</a>`;
+									bySubCategory[ subCat ] = {};
 
 								}
 
-								group.members.forEach( member => {
-
-									const selectedClass = member.hash === currentHash ? ' selected' : '';
-									const highlightedName = highlightMatch( member.name, highlightRegExp );
-									const suffix = member.kind === 'function' ? '()' : '';
-									html += `<a href="#${member.hash}" class="search-result-member${selectedClass}">.${highlightedName}${suffix}</a>`;
-
-								} );
+								bySubCategory[ subCat ][ className ] = group;
 
 							}
 
-							if ( group.class || group.members.length > 0 ) {
+							// Sort sub-categories and render them
+							const sortedSubCategories = Object.keys( bySubCategory ).sort();
 
-								html += '</div>';
+							for ( const subCat of sortedSubCategories ) {
+
+								const highlightedSubCat = highlightMatch( subCat, highlightRegExp );
+								html += `<h3>${highlightedSubCat}</h3>`;
+
+								for ( const className in bySubCategory[ subCat ] ) {
+
+									const group = bySubCategory[ subCat ][ className ];
+
+									if ( group.class ) {
+
+										html += '<div class="search-result-group">';
+										const selectedClass = group.class.hash === currentHash ? ' selected' : '';
+										const highlightedName = highlightMatch( group.class.name, highlightRegExp );
+										html += `<a href="#${group.class.hash}" class="search-result-class${selectedClass}">${highlightedName}</a>`;
+
+									}
+
+									if ( group.members.length > 0 ) {
+
+										if ( ! group.class ) {
+
+											html += '<div class="search-result-group">';
+											html += `<a href="#${className}" class="search-result-class">${className}</a>`;
+
+										}
+
+										group.members.forEach( member => {
+
+											const selectedClass = member.hash === currentHash ? ' selected' : '';
+											const highlightedName = highlightMatch( member.name, highlightRegExp );
+											const suffix = member.kind === 'function' ? '()' : '';
+											html += `<a href="#${member.hash}" class="search-result-member${selectedClass}">.${highlightedName}${suffix}</a>`;
+
+										} );
+
+									}
+
+									if ( group.class || group.members.length > 0 ) {
+
+										html += '</div>';
+
+									}
+
+								}
+
+							}
+
+						} else {
+
+							// Regular category rendering (Core, Addons, Global)
+
+							for ( const className in byCategory[ category ] ) {
+
+								const group = byCategory[ category ][ className ];
+
+								if ( group.class ) {
+
+									html += '<div class="search-result-group">';
+									const selectedClass = group.class.hash === currentHash ? ' selected' : '';
+									const highlightedName = highlightMatch( group.class.name, highlightRegExp );
+									html += `<a href="#${group.class.hash}" class="search-result-class${selectedClass}">${highlightedName}</a>`;
+
+								}
+
+								if ( group.members.length > 0 ) {
+
+									if ( ! group.class ) {
+
+										html += '<div class="search-result-group">';
+										html += `<a href="#${className}" class="search-result-class">${className}</a>`;
+
+									}
+
+									group.members.forEach( member => {
+
+										const selectedClass = member.hash === currentHash ? ' selected' : '';
+										const highlightedName = highlightMatch( member.name, highlightRegExp );
+										const suffix = member.kind === 'function' ? '()' : '';
+										html += `<a href="#${member.hash}" class="search-result-member${selectedClass}">.${highlightedName}${suffix}</a>`;
+
+									} );
+
+								}
+
+								if ( group.class || group.members.length > 0 ) {
+
+									html += '</div>';
+
+								}
 
 							}
 

--- a/utils/docs/template/tmpl/container.tmpl
+++ b/utils/docs/template/tmpl/container.tmpl
@@ -95,9 +95,43 @@
 					if (members && members.length && members.forEach) {
 				?>
 				<h2 class="subsection-title">Properties</h2>
-				<?js members.forEach(function(p) { ?>
+				<?js 
+					if (isTSLPage) {
+						// Group TSL properties by sub-category
+						var membersBySubCategory = {};
+						members.forEach(function(m) {
+							var subCategory = 'Other';
+							if (m.meta && m.meta.filename) {
+								var filename = m.meta.filename.replace(/\.js$/, '');
+								subCategory = filename.replace(/Node$/, '');
+							}
+							if (!membersBySubCategory[subCategory]) {
+								membersBySubCategory[subCategory] = [];
+							}
+							membersBySubCategory[subCategory].push(m);
+						});
+						
+						// Sort sub-categories and render
+						var sortedSubCategories = Object.keys(membersBySubCategory).sort();
+						sortedSubCategories.forEach(function(subCategory) {
+				?>
+				<h3><?js= subCategory ?></h3>
+				<?js 
+							membersBySubCategory[subCategory].forEach(function(p) { 
+				?>
 					<?js= self.partial('members.tmpl', p) ?>
-				<?js }); ?>
+				<?js 
+							}); 
+						});
+					} else {
+						// Regular rendering for non-TSL pages
+						members.forEach(function(p) { 
+				?>
+					<?js= self.partial('members.tmpl', p) ?>
+				<?js 
+						}); 
+					}
+				?>
 				<?js } ?>
 				<?js
 					var methods = self.find({kind: 'function', memberof: isGlobalPage ? {isUndefined: true} : doc.longname, ...ignoreInheritedSymbols});
@@ -116,15 +150,83 @@
 					if (instanceMethods.length) {
 				?>
 				<h2 class="subsection-title">Methods</h2>
-				<?js instanceMethods.forEach(function(m) { ?>
+				<?js 
+					if (isTSLPage) {
+						// Group TSL methods by sub-category
+						var methodsBySubCategory = {};
+						instanceMethods.forEach(function(m) {
+							var subCategory = 'Other';
+							if (m.meta && m.meta.filename) {
+								var filename = m.meta.filename.replace(/\.js$/, '');
+								subCategory = filename.replace(/Node$/, '');
+							}
+							if (!methodsBySubCategory[subCategory]) {
+								methodsBySubCategory[subCategory] = [];
+							}
+							methodsBySubCategory[subCategory].push(m);
+						});
+						
+						// Sort sub-categories and render
+						var sortedSubCategories = Object.keys(methodsBySubCategory).sort();
+						sortedSubCategories.forEach(function(subCategory) {
+				?>
+				<h3><?js= subCategory ?></h3>
+				<?js 
+							methodsBySubCategory[subCategory].forEach(function(m) { 
+				?>
 					<?js= self.partial('method.tmpl', m) ?>
-				<?js }); ?>
+				<?js 
+							}); 
+						});
+					} else {
+						// Regular rendering for non-TSL pages
+						instanceMethods.forEach(function(m) { 
+				?>
+					<?js= self.partial('method.tmpl', m) ?>
+				<?js 
+						}); 
+					}
+				?>
 				<?js } ?>
 				<?js if (staticMethods.length) { ?>
 				<h2 class="subsection-title">Static Methods</h2>
-				<?js staticMethods.forEach(function(m) { ?>
+				<?js 
+					if (isTSLPage) {
+						// Group TSL static methods by sub-category
+						var staticMethodsBySubCategory = {};
+						staticMethods.forEach(function(m) {
+							var subCategory = 'Other';
+							if (m.meta && m.meta.filename) {
+								var filename = m.meta.filename.replace(/\.js$/, '');
+								subCategory = filename.replace(/Node$/, '');
+							}
+							if (!staticMethodsBySubCategory[subCategory]) {
+								staticMethodsBySubCategory[subCategory] = [];
+							}
+							staticMethodsBySubCategory[subCategory].push(m);
+						});
+						
+						// Sort sub-categories and render
+						var sortedSubCategories = Object.keys(staticMethodsBySubCategory).sort();
+						sortedSubCategories.forEach(function(subCategory) {
+				?>
+				<h3><?js= subCategory ?></h3>
+				<?js 
+							staticMethodsBySubCategory[subCategory].forEach(function(m) { 
+				?>
 					<?js= self.partial('method.tmpl', m) ?>
-				<?js }); ?>
+				<?js 
+							}); 
+						});
+					} else {
+						// Regular rendering for non-TSL pages
+						staticMethods.forEach(function(m) { 
+				?>
+					<?js= self.partial('method.tmpl', m) ?>
+				<?js 
+						}); 
+					}
+				?>
 				<?js } ?>
 				<?js
 					var typedefs = self.find({kind: 'typedef', memberof: isGlobalPage ? {isUndefined: true} : doc.longname, ...ignoreInheritedSymbols});

--- a/utils/docs/template/tmpl/container.tmpl
+++ b/utils/docs/template/tmpl/container.tmpl
@@ -92,49 +92,7 @@
 							return isTSLPage ? hasTslTag : !hasTslTag;
 						});
 					}
-					if (members && members.length && members.forEach) {
-				?>
-				<h2 class="subsection-title">Properties</h2>
-				<?js 
-					if (isTSLPage) {
-						// Group TSL properties by sub-category
-						var membersBySubCategory = {};
-						members.forEach(function(m) {
-							var subCategory = 'Other';
-							if (m.meta && m.meta.filename) {
-								var filename = m.meta.filename.replace(/\.js$/, '');
-								subCategory = filename.replace(/Node$/, '');
-							}
-							if (!membersBySubCategory[subCategory]) {
-								membersBySubCategory[subCategory] = [];
-							}
-							membersBySubCategory[subCategory].push(m);
-						});
-						
-						// Sort sub-categories and render
-						var sortedSubCategories = Object.keys(membersBySubCategory).sort();
-						sortedSubCategories.forEach(function(subCategory) {
-				?>
-				<h3><?js= subCategory ?></h3>
-				<?js 
-							membersBySubCategory[subCategory].forEach(function(p) {
-								p.isTSLItem = true;
-				?>
-					<?js= self.partial('members.tmpl', p) ?>
-				<?js 
-							}); 
-						});
-					} else {
-						// Regular rendering for non-TSL pages
-						members.forEach(function(p) { 
-				?>
-					<?js= self.partial('members.tmpl', p) ?>
-				<?js 
-						}); 
-					}
-				?>
-				<?js } ?>
-				<?js
+
 					var methods = self.find({kind: 'function', memberof: isGlobalPage ? {isUndefined: true} : doc.longname, ...ignoreInheritedSymbols});
 
 					// Filter methods for TSL vs Global
@@ -148,89 +106,101 @@
 					var staticMethods = methods.filter(function(m) { return m.scope === 'static'; });
 					var instanceMethods = methods.filter(function(m) { return m.scope !== 'static'; });
 
-					if (instanceMethods.length) {
+					// For TSL pages, group everything by sub-category
+					if (isTSLPage && ((members && members.length) || instanceMethods.length || staticMethods.length)) {
+						// Collect all items and group by sub-category
+						var allItemsBySubCategory = {};
+
+						function addToSubCategory(item, type) {
+							var subCategory = 'Other';
+							if (item.meta && item.meta.filename) {
+								var filename = item.meta.filename.replace(/\.js$/, '');
+								subCategory = filename.replace(/Node$/, '');
+							}
+							if (!allItemsBySubCategory[subCategory]) {
+								allItemsBySubCategory[subCategory] = {
+									properties: [],
+									methods: [],
+									staticMethods: []
+								};
+							}
+							item.isTSLItem = true;
+							allItemsBySubCategory[subCategory][type].push(item);
+						}
+
+						if (members && members.length) {
+							members.forEach(function(m) { addToSubCategory(m, 'properties'); });
+						}
+						if (instanceMethods.length) {
+							instanceMethods.forEach(function(m) { addToSubCategory(m, 'methods'); });
+						}
+						if (staticMethods.length) {
+							staticMethods.forEach(function(m) { addToSubCategory(m, 'staticMethods'); });
+						}
+
+						// Sort sub-categories and render
+						var sortedSubCategories = Object.keys(allItemsBySubCategory).sort();
+				?>
+				<h2 class="subsection-title">TSL Functions</h2>
+				<?js 
+						sortedSubCategories.forEach(function(subCategory) {
+							var items = allItemsBySubCategory[subCategory];
+				?>
+				<h3><?js= subCategory ?></h3>
+				<?js 
+							// Render properties first
+							items.properties.forEach(function(p) {
+				?>
+					<?js= self.partial('members.tmpl', p) ?>
+				<?js 
+							});
+							// Then methods
+							items.methods.forEach(function(m) {
+				?>
+					<?js= self.partial('method.tmpl', m) ?>
+				<?js 
+							});
+							// Then static methods
+							items.staticMethods.forEach(function(m) {
+				?>
+					<?js= self.partial('method.tmpl', m) ?>
+				<?js 
+							});
+						});
+					} else {
+						// Regular rendering for non-TSL pages
+						if (members && members.length && members.forEach) {
+				?>
+				<h2 class="subsection-title">Properties</h2>
+				<?js 
+							members.forEach(function(p) { 
+				?>
+					<?js= self.partial('members.tmpl', p) ?>
+				<?js 
+							}); 
+						}
+						if (instanceMethods.length) {
 				?>
 				<h2 class="subsection-title">Methods</h2>
 				<?js 
-					if (isTSLPage) {
-						// Group TSL methods by sub-category
-						var methodsBySubCategory = {};
-						instanceMethods.forEach(function(m) {
-							var subCategory = 'Other';
-							if (m.meta && m.meta.filename) {
-								var filename = m.meta.filename.replace(/\.js$/, '');
-								subCategory = filename.replace(/Node$/, '');
-							}
-							if (!methodsBySubCategory[subCategory]) {
-								methodsBySubCategory[subCategory] = [];
-							}
-							methodsBySubCategory[subCategory].push(m);
-						});
-						
-						// Sort sub-categories and render
-						var sortedSubCategories = Object.keys(methodsBySubCategory).sort();
-						sortedSubCategories.forEach(function(subCategory) {
-				?>
-				<h3><?js= subCategory ?></h3>
-				<?js 
-							methodsBySubCategory[subCategory].forEach(function(m) {
-								m.isTSLItem = true;
+							instanceMethods.forEach(function(m) { 
 				?>
 					<?js= self.partial('method.tmpl', m) ?>
 				<?js 
 							}); 
-						});
-					} else {
-						// Regular rendering for non-TSL pages
-						instanceMethods.forEach(function(m) { 
+						}
+						if (staticMethods.length) {
 				?>
-					<?js= self.partial('method.tmpl', m) ?>
-				<?js 
-						}); 
-					}
-				?>
-				<?js } ?>
-				<?js if (staticMethods.length) { ?>
 				<h2 class="subsection-title">Static Methods</h2>
 				<?js 
-					if (isTSLPage) {
-						// Group TSL static methods by sub-category
-						var staticMethodsBySubCategory = {};
-						staticMethods.forEach(function(m) {
-							var subCategory = 'Other';
-							if (m.meta && m.meta.filename) {
-								var filename = m.meta.filename.replace(/\.js$/, '');
-								subCategory = filename.replace(/Node$/, '');
-							}
-							if (!staticMethodsBySubCategory[subCategory]) {
-								staticMethodsBySubCategory[subCategory] = [];
-							}
-							staticMethodsBySubCategory[subCategory].push(m);
-						});
-						
-						// Sort sub-categories and render
-						var sortedSubCategories = Object.keys(staticMethodsBySubCategory).sort();
-						sortedSubCategories.forEach(function(subCategory) {
-				?>
-				<h3><?js= subCategory ?></h3>
-				<?js 
-							staticMethodsBySubCategory[subCategory].forEach(function(m) {
-								m.isTSLItem = true;
+							staticMethods.forEach(function(m) { 
 				?>
 					<?js= self.partial('method.tmpl', m) ?>
 				<?js 
 							}); 
-						});
-					} else {
-						// Regular rendering for non-TSL pages
-						staticMethods.forEach(function(m) { 
-				?>
-					<?js= self.partial('method.tmpl', m) ?>
-				<?js 
-						}); 
+						}
 					}
 				?>
-				<?js } ?>
 				<?js
 					var typedefs = self.find({kind: 'typedef', memberof: isGlobalPage ? {isUndefined: true} : doc.longname, ...ignoreInheritedSymbols});
 					if (typedefs && typedefs.length && typedefs.forEach) {

--- a/utils/docs/template/tmpl/container.tmpl
+++ b/utils/docs/template/tmpl/container.tmpl
@@ -117,7 +117,8 @@
 				?>
 				<h3><?js= subCategory ?></h3>
 				<?js 
-							membersBySubCategory[subCategory].forEach(function(p) { 
+							membersBySubCategory[subCategory].forEach(function(p) {
+								p.isTSLItem = true;
 				?>
 					<?js= self.partial('members.tmpl', p) ?>
 				<?js 
@@ -172,7 +173,8 @@
 				?>
 				<h3><?js= subCategory ?></h3>
 				<?js 
-							methodsBySubCategory[subCategory].forEach(function(m) { 
+							methodsBySubCategory[subCategory].forEach(function(m) {
+								m.isTSLItem = true;
 				?>
 					<?js= self.partial('method.tmpl', m) ?>
 				<?js 
@@ -212,7 +214,8 @@
 				?>
 				<h3><?js= subCategory ?></h3>
 				<?js 
-							staticMethodsBySubCategory[subCategory].forEach(function(m) { 
+							staticMethodsBySubCategory[subCategory].forEach(function(m) {
+								m.isTSLItem = true;
 				?>
 					<?js= self.partial('method.tmpl', m) ?>
 				<?js 

--- a/utils/docs/template/tmpl/members.tmpl
+++ b/utils/docs/template/tmpl/members.tmpl
@@ -1,9 +1,10 @@
 <?js
 	var data = obj;
 	var self = this;
+	var prefix = (data.isTSLItem === true) ? '' : '.';
 ?>
 				<div class="member">
-					<h3 class="name" id="<?js= id ?>" translate="no">.<a href="#<?js= id ?>"><?js= name ?></a><?js= (data.signature ? data.signature : '') ?> <?js= data.attribs ?></h3>
+					<h3 class="name" id="<?js= id ?>" translate="no"><?js= prefix ?><a href="#<?js= id ?>"><?js= name ?></a><?js= (data.signature ? data.signature : '') ?> <?js= data.attribs ?></h3>
 					<?js if (data.summary) { ?>
 					<p class="summary"><?js= summary ?></p>
 					<?js } ?>

--- a/utils/docs/template/tmpl/method.tmpl
+++ b/utils/docs/template/tmpl/method.tmpl
@@ -1,12 +1,13 @@
 <?js
 	var data = obj;
 	var self = this;
+	var prefix = (data.isTSLItem === true) ? '' : (kind === 'class' ? 'new ' : '.');
 ?>
 	<?js if (data.kind !== 'module' && !data.hideconstructor) { ?>
 		<?js if (data.kind === 'class' && data.classdesc) { ?>
 					<h2>Constructor</h2>
 		<?js } ?>
-					<h3 class="name name-method" id="<?js= id ?>" translate="no"><?js= (kind === 'class' ? 'new ' : '.') ?><a href="#<?js= id ?>"><?js= name ?></a><?js= (data.signature || '') ?> <?js= data.attribs ?></h3>
+					<h3 class="name name-method" id="<?js= id ?>" translate="no"><?js= prefix ?><a href="#<?js= id ?>"><?js= name ?></a><?js= (data.signature || '') ?> <?js= data.attribs ?></h3>
 		<?js if (data.summary) { ?>
 					<p class="summary"><?js= summary ?></p>
 		<?js } ?>


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/32118#issuecomment-3443523836

**Description**

I made an update using Vibe Code to allow TSL searches to have sub-categories based on the filename in which they were declared.

<img width="1904" height="790" alt="image" src="https://github.com/user-attachments/assets/703816f6-c425-4de6-9e91-7a4401e9aa77" />

----

<img width="1900" height="1742" alt="image" src="https://github.com/user-attachments/assets/d900386b-af8a-4c3d-8034-c6d5bc1d5b04" />
