### PR TITLE
WebGLRenderer: Use Vogel disk sampling for PCF shadows

### DIFF
--- a/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl.js
@@ -65,10 +65,9 @@ export default /* glsl */`
 
 	#endif
 
-	float interleavedGradientNoise( vec2 position_screen ) {
+	float interleavedGradientNoise( vec2 position ) {
 
-		vec3 magic = vec3( 0.06711056, 0.00583715, 52.9829189 );
-		return fract( magic.z * fract( dot( position_screen, magic.xy ) ) );
+		return fract( 52.9829189 * fract( dot( position, vec2( 0.06711056, 0.00583715 ) ) ) );
 
 	}
 

--- a/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl.js
@@ -154,19 +154,23 @@ export default /* glsl */`
 
 			float phi = interleavedGradientNoise( gl_FragCoord.xy ) * PI2;
 
+			vec2 offset = texelSize * shadowRadius;
+			vec2 uv = shadowCoord.xy;
+			float compare = shadowCoord.z;
+
 			shadow = (
-				texture2DCompare( shadowMap, shadowCoord.xy + vogelDiskSample( 0, 12, phi ) * texelSize * shadowRadius, shadowCoord.z ) +
-				texture2DCompare( shadowMap, shadowCoord.xy + vogelDiskSample( 1, 12, phi ) * texelSize * shadowRadius, shadowCoord.z ) +
-				texture2DCompare( shadowMap, shadowCoord.xy + vogelDiskSample( 2, 12, phi ) * texelSize * shadowRadius, shadowCoord.z ) +
-				texture2DCompare( shadowMap, shadowCoord.xy + vogelDiskSample( 3, 12, phi ) * texelSize * shadowRadius, shadowCoord.z ) +
-				texture2DCompare( shadowMap, shadowCoord.xy + vogelDiskSample( 4, 12, phi ) * texelSize * shadowRadius, shadowCoord.z ) +
-				texture2DCompare( shadowMap, shadowCoord.xy + vogelDiskSample( 5, 12, phi ) * texelSize * shadowRadius, shadowCoord.z ) +
-				texture2DCompare( shadowMap, shadowCoord.xy + vogelDiskSample( 6, 12, phi ) * texelSize * shadowRadius, shadowCoord.z ) +
-				texture2DCompare( shadowMap, shadowCoord.xy + vogelDiskSample( 7, 12, phi ) * texelSize * shadowRadius, shadowCoord.z ) +
-				texture2DCompare( shadowMap, shadowCoord.xy + vogelDiskSample( 8, 12, phi ) * texelSize * shadowRadius, shadowCoord.z ) +
-				texture2DCompare( shadowMap, shadowCoord.xy + vogelDiskSample( 9, 12, phi ) * texelSize * shadowRadius, shadowCoord.z ) +
-				texture2DCompare( shadowMap, shadowCoord.xy + vogelDiskSample( 10, 12, phi ) * texelSize * shadowRadius, shadowCoord.z ) +
-				texture2DCompare( shadowMap, shadowCoord.xy + vogelDiskSample( 11, 12, phi ) * texelSize * shadowRadius, shadowCoord.z )
+				texture2DCompare( shadowMap, uv + vogelDiskSample( 0, 12, phi ) * offset, compare ) +
+				texture2DCompare( shadowMap, uv + vogelDiskSample( 1, 12, phi ) * offset, compare ) +
+				texture2DCompare( shadowMap, uv + vogelDiskSample( 2, 12, phi ) * offset, compare ) +
+				texture2DCompare( shadowMap, uv + vogelDiskSample( 3, 12, phi ) * offset, compare ) +
+				texture2DCompare( shadowMap, uv + vogelDiskSample( 4, 12, phi ) * offset, compare ) +
+				texture2DCompare( shadowMap, uv + vogelDiskSample( 5, 12, phi ) * offset, compare ) +
+				texture2DCompare( shadowMap, uv + vogelDiskSample( 6, 12, phi ) * offset, compare ) +
+				texture2DCompare( shadowMap, uv + vogelDiskSample( 7, 12, phi ) * offset, compare ) +
+				texture2DCompare( shadowMap, uv + vogelDiskSample( 8, 12, phi ) * offset, compare ) +
+				texture2DCompare( shadowMap, uv + vogelDiskSample( 9, 12, phi ) * offset, compare ) +
+				texture2DCompare( shadowMap, uv + vogelDiskSample( 10, 12, phi ) * offset, compare ) +
+				texture2DCompare( shadowMap, uv + vogelDiskSample( 11, 12, phi ) * offset, compare )
 			) * ( 1.0 / 12.0 );
 
 		#elif defined( SHADOWMAP_TYPE_PCF_SOFT )
@@ -317,24 +321,27 @@ export default /* glsl */`
 
 				float phi = interleavedGradientNoise( gl_FragCoord.xy ) * PI2;
 
-				vec2 d0 = vogelDiskSample( 0, 8, phi ) * shadowRadius * texelSize.y;
-				vec2 d1 = vogelDiskSample( 1, 8, phi ) * shadowRadius * texelSize.y;
-				vec2 d2 = vogelDiskSample( 2, 8, phi ) * shadowRadius * texelSize.y;
-				vec2 d3 = vogelDiskSample( 3, 8, phi ) * shadowRadius * texelSize.y;
-				vec2 d4 = vogelDiskSample( 4, 8, phi ) * shadowRadius * texelSize.y;
-				vec2 d5 = vogelDiskSample( 5, 8, phi ) * shadowRadius * texelSize.y;
-				vec2 d6 = vogelDiskSample( 6, 8, phi ) * shadowRadius * texelSize.y;
-				vec2 d7 = vogelDiskSample( 7, 8, phi ) * shadowRadius * texelSize.y;
+				float offset = shadowRadius * texelSize.y;
+				float texelSizeY = texelSize.y;
+
+				vec2 d0 = vogelDiskSample( 0, 8, phi ) * offset;
+				vec2 d1 = vogelDiskSample( 1, 8, phi ) * offset;
+				vec2 d2 = vogelDiskSample( 2, 8, phi ) * offset;
+				vec2 d3 = vogelDiskSample( 3, 8, phi ) * offset;
+				vec2 d4 = vogelDiskSample( 4, 8, phi ) * offset;
+				vec2 d5 = vogelDiskSample( 5, 8, phi ) * offset;
+				vec2 d6 = vogelDiskSample( 6, 8, phi ) * offset;
+				vec2 d7 = vogelDiskSample( 7, 8, phi ) * offset;
 
 				shadow = (
-					texture2DCompare( shadowMap, cubeToUV( bd3D + vec3( d0.x, d0.y, d0.x ), texelSize.y ), dp ) +
-					texture2DCompare( shadowMap, cubeToUV( bd3D + vec3( d1.x, d1.y, d1.x ), texelSize.y ), dp ) +
-					texture2DCompare( shadowMap, cubeToUV( bd3D + vec3( d2.x, d2.y, d2.x ), texelSize.y ), dp ) +
-					texture2DCompare( shadowMap, cubeToUV( bd3D + vec3( d3.x, d3.y, d3.x ), texelSize.y ), dp ) +
-					texture2DCompare( shadowMap, cubeToUV( bd3D + vec3( d4.x, d4.y, d4.x ), texelSize.y ), dp ) +
-					texture2DCompare( shadowMap, cubeToUV( bd3D + vec3( d5.x, d5.y, d5.x ), texelSize.y ), dp ) +
-					texture2DCompare( shadowMap, cubeToUV( bd3D + vec3( d6.x, d6.y, d6.x ), texelSize.y ), dp ) +
-					texture2DCompare( shadowMap, cubeToUV( bd3D + vec3( d7.x, d7.y, d7.x ), texelSize.y ), dp )
+					texture2DCompare( shadowMap, cubeToUV( bd3D + d0.xyx, texelSizeY ), dp ) +
+					texture2DCompare( shadowMap, cubeToUV( bd3D + d1.xyx, texelSizeY ), dp ) +
+					texture2DCompare( shadowMap, cubeToUV( bd3D + d2.xyx, texelSizeY ), dp ) +
+					texture2DCompare( shadowMap, cubeToUV( bd3D + d3.xyx, texelSizeY ), dp ) +
+					texture2DCompare( shadowMap, cubeToUV( bd3D + d4.xyx, texelSizeY ), dp ) +
+					texture2DCompare( shadowMap, cubeToUV( bd3D + d5.xyx, texelSizeY ), dp ) +
+					texture2DCompare( shadowMap, cubeToUV( bd3D + d6.xyx, texelSizeY ), dp ) +
+					texture2DCompare( shadowMap, cubeToUV( bd3D + d7.xyx, texelSizeY ), dp )
 				) * ( 1.0 / 8.0 );
 
 			#else // no percentage-closer filtering


### PR DESCRIPTION
**Description**

This PR replaces the fixed grid PCF shadow sampling with Vogel disk sampling for improved shadow quality and performance.

### Changes
- Implements Vogel disk sampling using the golden angle for evenly distributed sample points
- Adds interleaved gradient noise for per-pixel rotation to eliminate banding artifacts
- Reduces sample counts while maintaining/improving quality:
  - Directional/SpotLights: 17 → 12 samples (~29% faster)
  - Point lights: 9 → 8 samples (~11% faster)

| Before (Shadow Radius: 1.0) | After (Shadow Radius: 1.0) |
| --- | --- |
| <img width="901" height="548" alt="Screenshot 2025-11-04 at 22 56 00" src="https://github.com/user-attachments/assets/ac3fea73-f6a7-47ec-ae6d-6869a73aab1a" /> | <img width="901" height="548" alt="Screenshot 2025-11-04 at 22 56 07" src="https://github.com/user-attachments/assets/887f7822-1a85-46d5-a8bc-b17d29f54dab" /> |

| Before (Shadow Radius: 10.0) | After (Shadow Radius: 10.0) |
| --- | --- |
| <img width="901" height="548" alt="Screenshot 2025-11-04 at 22 54 21" src="https://github.com/user-attachments/assets/9d3e199b-b2f3-4129-a4da-d57e712d35e8" /> | <img width="901" height="548" alt="Screenshot 2025-11-04 at 22 54 31" src="https://github.com/user-attachments/assets/ca3578d1-e407-4be0-a7e0-9e13beaac5b5" /> |

This improvement probably makes `SHADOWMAP_TYPE_PCF_SOFT` redundant.