### PR TITLE
TSL: Check for `undefined` in `uniform()`.

### DIFF
--- a/src/nodes/core/UniformNode.js
+++ b/src/nodes/core/UniformNode.js
@@ -235,8 +235,23 @@ export const uniform = ( value, type ) => {
 
 	}
 
-	// @TODO: get ConstNode from .traverse() in the future
-	value = ( value && value.isNode === true ) ? ( value.node && value.node.value ) || value.value : value;
+	if ( value && value.isNode === true ) {
+
+		let v = value.value;
+
+		value.traverse( n => {
+
+			if ( n.isConstNode === true ) {
+
+				v = n.value;
+
+			}
+
+		} );
+
+		value = v;
+
+	}
 
 	return nodeObject( new UniformNode( value, nodeType ) );
 


### PR DESCRIPTION
Fixed #32182.

**Description**

`uniform()` currently uses this check `( value.node && value.node.value )`. This check does not properly handle the case when `value.node.value` is `0` (a valid value). The PR changes the check by testing for `undefined`.

@sunag Do we also have to honor `null`?