### PR TITLE
Manual: Update `OffscreenCanvas` support details.

### DIFF
--- a/manual/en/multiple-scenes.html
+++ b/manual/en/multiple-scenes.html
@@ -622,8 +622,7 @@ render the scene for this area, then copy the result to the area's canvas.</p>
 <p></p>
 <p>One other advantage to this solution is you could potentially use
 <a href="https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas"><code class="notranslate" translate="no">OffscreenCanvas</code></a>
-to render from a web worker and still use this technique. Unfortunately as of July 2020
-<code class="notranslate" translate="no">OffscreenCanvas</code> is only supported by Chrome.</p>
+to render from a web worker and still use this technique.
 
         </div>
       </div>


### PR DESCRIPTION
Removed outdated information regarding `OffscreenCanvas` support.

**Description**

This is just a minor change to the docs on multiple scenes/canvases because `OffscreenCanvas` is now more widely supported.
