### PR TITLE
BatchedMesh: Fix index and attribute updates in the optimize method

### DIFF
--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -926,6 +926,7 @@ class BatchedMesh extends Mesh {
 
 					index.array.copyWithin( nextIndexStart, indexStart, indexStart + reservedIndexCount );
 					index.addUpdateRange( nextIndexStart, reservedIndexCount );
+					index.needsUpdate = true;
 
 					geometryInfo.indexStart = nextIndexStart;
 
@@ -946,6 +947,7 @@ class BatchedMesh extends Mesh {
 					const { array, itemSize } = attribute;
 					array.copyWithin( nextVertexStart * itemSize, vertexStart * itemSize, ( vertexStart + reservedVertexCount ) * itemSize );
 					attribute.addUpdateRange( nextVertexStart * itemSize, reservedVertexCount * itemSize );
+					attribute.needsUpdate = true;
 
 				}
 
@@ -961,6 +963,8 @@ class BatchedMesh extends Mesh {
 			this._nextVertexStart = geometryInfo.vertexStart + geometryInfo.reservedVertexCount;
 
 		}
+
+		this._visibilityChanged = true;
 
 		return this;
 


### PR DESCRIPTION

### Description

Fix buffer sync issues in `BatchedMesh.prototype.optimize()` that caused incorrect rendering after repacking. The method now:

* Marks the index buffer as dirty after in-place reordering.
* Marks moved vertex attributes as dirty after in-place copies.
* Flags _visibilityChanged so draw ranges and visibility-dependent state get refreshed.

When `optimize()` compacts geometry ranges, it mutates the underlying typed arrays via `copyWithin`. However, without setting `needsUpdate = true`, WebGL/WebGPU buffers aren’t re-uploaded, resulting in stale GPU data and visible artifacts, especially after sequences like add/delete/optimize.

Also, `_visibilityChanged` must be set to ensure the next render pass rebuilds multi-draw ranges and respects updated starts/counts after repacking.