### PR TITLE
NodeBuilder: Cache node attributes for vertex stage only.

### DIFF
--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -1777,7 +1777,7 @@ class NodeBuilder {
 	 */
 	getBufferAttributeFromNode( node, type ) {
 
-		const nodeData = this.getDataFromNode( node );
+		const nodeData = this.getDataFromNode( node, 'vertex' );
 
 		let bufferAttribute = nodeData.bufferAttribute;
 


### PR DESCRIPTION
Related issue: #32179

**Description**

While investigating #32179, I have noticed the `NodeBuilder` creates duplicate `NodeAttribute` entries when the node from `bufferAttribute()` is used in the fragment shader as well (e.g. to modulate color).

Shader attributes do not exist in the fragment shader so it does not make sense to have separate caches per shader stage.
