### PR TITLE
Inspector: Add window/panel boundary constraints

### DIFF
--- a/examples/jsm/inspector/ui/Profiler.js
+++ b/examples/jsm/inspector/ui/Profiler.js
@@ -218,8 +218,9 @@ export class Profiler {
 
 			this.isResizing = true;
 			this.panel.classList.add( 'resizing' );
-			const startX = e.clientX || ( e.touches && e.touches[ 0 ] ? e.touches[ 0 ].clientX : 0 );
-			const startY = e.clientY || ( e.touches && e.touches[ 0 ] ? e.touches[ 0 ].clientY : 0 );
+			resizer.setPointerCapture( e.pointerId );
+			const startX = e.clientX;
+			const startY = e.clientY;
 			const startHeight = this.panel.offsetHeight;
 			const startWidth = this.panel.offsetWidth;
 
@@ -227,8 +228,8 @@ export class Profiler {
 
 				if ( ! this.isResizing ) return;
 				moveEvent.preventDefault();
-				const currentX = moveEvent.clientX || ( moveEvent.touches && moveEvent.touches[ 0 ] ? moveEvent.touches[ 0 ].clientX : 0 );
-				const currentY = moveEvent.clientY || ( moveEvent.touches && moveEvent.touches[ 0 ] ? moveEvent.touches[ 0 ].clientY : 0 );
+				const currentX = moveEvent.clientX;
+				const currentY = moveEvent.clientY;
 
 				if ( this.position === 'bottom' ) {
 
@@ -260,10 +261,9 @@ export class Profiler {
 
 				this.isResizing = false;
 				this.panel.classList.remove( 'resizing' );
-				document.removeEventListener( 'mousemove', onMove );
-				document.removeEventListener( 'mouseup', onEnd );
-				document.removeEventListener( 'touchmove', onMove );
-				document.removeEventListener( 'touchend', onEnd );
+				resizer.removeEventListener( 'pointermove', onMove );
+				resizer.removeEventListener( 'pointerup', onEnd );
+				resizer.removeEventListener( 'pointercancel', onEnd );
 				if ( ! this.panel.classList.contains( 'maximized' ) ) {
 
 					// Save dimensions based on current position
@@ -284,15 +284,13 @@ export class Profiler {
 
 			};
 
-			document.addEventListener( 'mousemove', onMove );
-			document.addEventListener( 'mouseup', onEnd );
-			document.addEventListener( 'touchmove', onMove, { passive: false } );
-			document.addEventListener( 'touchend', onEnd );
+			resizer.addEventListener( 'pointermove', onMove );
+			resizer.addEventListener( 'pointerup', onEnd );
+			resizer.addEventListener( 'pointercancel', onEnd );
 
 		};
 
-		resizer.addEventListener( 'mousedown', onStart );
-		resizer.addEventListener( 'touchstart', onStart );
+		resizer.addEventListener( 'pointerdown', onStart );
 
 	}
 
@@ -479,17 +477,18 @@ export class Profiler {
 
 		const onDragStart = ( e ) => {
 
-			startX = e.clientX || ( e.touches && e.touches[ 0 ] ? e.touches[ 0 ].clientX : 0 );
-			startY = e.clientY || ( e.touches && e.touches[ 0 ] ? e.touches[ 0 ].clientY : 0 );
+			startX = e.clientX;
+			startY = e.clientY;
 			isDragging = false;
 			hasMoved = false;
+			tab.button.setPointerCapture( e.pointerId );
 
 		};
 
 		const onDragMove = ( e ) => {
 
-			const currentX = e.clientX || ( e.touches && e.touches[ 0 ] ? e.touches[ 0 ].clientX : 0 );
-			const currentY = e.clientY || ( e.touches && e.touches[ 0 ] ? e.touches[ 0 ].clientY : 0 );
+			const currentX = e.clientX;
+			const currentY = e.clientY;
 
 			const deltaX = Math.abs( currentX - startX );
 			const deltaY = Math.abs( currentY - startY );
@@ -560,26 +559,18 @@ export class Profiler {
 			hasMoved = false;
 			previewWindow = null;
 
-			document.removeEventListener( 'mousemove', onDragMove );
-			document.removeEventListener( 'mouseup', onDragEnd );
-			document.removeEventListener( 'touchmove', onDragMove );
-			document.removeEventListener( 'touchend', onDragEnd );
+			tab.button.removeEventListener( 'pointermove', onDragMove );
+			tab.button.removeEventListener( 'pointerup', onDragEnd );
+			tab.button.removeEventListener( 'pointercancel', onDragEnd );
 
 		};
 
-		tab.button.addEventListener( 'mousedown', ( e ) => {
+		tab.button.addEventListener( 'pointerdown', ( e ) => {
 
 			onDragStart( e );
-			document.addEventListener( 'mousemove', onDragMove );
-			document.addEventListener( 'mouseup', onDragEnd );
-
-		} );
-
-		tab.button.addEventListener( 'touchstart', ( e ) => {
-
-			onDragStart( e );
-			document.addEventListener( 'touchmove', onDragMove, { passive: false } );
-			document.addEventListener( 'touchend', onDragEnd );
+			tab.button.addEventListener( 'pointermove', onDragMove );
+			tab.button.addEventListener( 'pointerup', onDragEnd );
+			tab.button.addEventListener( 'pointercancel', onDragEnd );
 
 		} );
 
@@ -869,13 +860,7 @@ export class Profiler {
 		let startX, startY, startLeft, startTop;
 
 		// Bring window to front when clicking anywhere on it
-		windowPanel.addEventListener( 'mousedown', () => {
-
-			this.bringWindowToFront( windowPanel );
-
-		} );
-
-		windowPanel.addEventListener( 'touchstart', () => {
+		windowPanel.addEventListener( 'pointerdown', () => {
 
 			this.bringWindowToFront( windowPanel );
 
@@ -894,9 +879,10 @@ export class Profiler {
 
 			isDragging = true;
 			header.style.cursor = 'grabbing';
+			header.setPointerCapture( e.pointerId );
 
-			startX = e.clientX || ( e.touches && e.touches[ 0 ] ? e.touches[ 0 ].clientX : 0 );
-			startY = e.clientY || ( e.touches && e.touches[ 0 ] ? e.touches[ 0 ].clientY : 0 );
+			startX = e.clientX;
+			startY = e.clientY;
 
 			const rect = windowPanel.getBoundingClientRect();
 			startLeft = rect.left;
@@ -910,8 +896,8 @@ export class Profiler {
 
 			e.preventDefault();
 
-			const currentX = e.clientX || ( e.touches && e.touches[ 0 ] ? e.touches[ 0 ].clientX : 0 );
-			const currentY = e.clientY || ( e.touches && e.touches[ 0 ] ? e.touches[ 0 ].clientY : 0 );
+			const currentX = e.clientX;
+			const currentY = e.clientY;
 
 			const deltaX = currentX - startX;
 			const deltaY = currentY - startY;
@@ -987,8 +973,8 @@ export class Profiler {
 			this.panel.style.outline = '';
 
 			// Check if dropped over the inspector panel
-			const currentX = e.clientX || ( e.changedTouches && e.changedTouches[ 0 ].clientX );
-			const currentY = e.clientY || ( e.changedTouches && e.changedTouches[ 0 ].clientY );
+			const currentX = e.clientX;
+			const currentY = e.clientY;
 
 			if ( currentX !== undefined && currentY !== undefined ) {
 
@@ -1010,26 +996,18 @@ export class Profiler {
 
 			}
 
-			document.removeEventListener( 'mousemove', onDragMove );
-			document.removeEventListener( 'mouseup', onDragEnd );
-			document.removeEventListener( 'touchmove', onDragMove );
-			document.removeEventListener( 'touchend', onDragEnd );
+			header.removeEventListener( 'pointermove', onDragMove );
+			header.removeEventListener( 'pointerup', onDragEnd );
+			header.removeEventListener( 'pointercancel', onDragEnd );
 
 		};
 
-		header.addEventListener( 'mousedown', ( e ) => {
+		header.addEventListener( 'pointerdown', ( e ) => {
 
 			onDragStart( e );
-			document.addEventListener( 'mousemove', onDragMove );
-			document.addEventListener( 'mouseup', onDragEnd );
-
-		} );
-
-		header.addEventListener( 'touchstart', ( e ) => {
-
-			onDragStart( e );
-			document.addEventListener( 'touchmove', onDragMove, { passive: false } );
-			document.addEventListener( 'touchend', onDragEnd );
+			header.addEventListener( 'pointermove', onDragMove );
+			header.addEventListener( 'pointerup', onDragEnd );
+			header.addEventListener( 'pointercancel', onDragEnd );
 
 		} );
 
@@ -1056,8 +1034,10 @@ export class Profiler {
 				// Bring window to front when resizing
 				this.bringWindowToFront( windowPanel );
 
-				startX = e.clientX || ( e.touches && e.touches[ 0 ] ? e.touches[ 0 ].clientX : 0 );
-				startY = e.clientY || ( e.touches && e.touches[ 0 ] ? e.touches[ 0 ].clientY : 0 );
+				resizer.setPointerCapture( e.pointerId );
+
+				startX = e.clientX;
+				startY = e.clientY;
 				startWidth = windowPanel.offsetWidth;
 				startHeight = windowPanel.offsetHeight;
 				startLeft = windowPanel.offsetLeft;
@@ -1071,8 +1051,8 @@ export class Profiler {
 
 				e.preventDefault();
 
-				const currentX = e.clientX || ( e.touches && e.touches[ 0 ] ? e.touches[ 0 ].clientX : 0 );
-				const currentY = e.clientY || ( e.touches && e.touches[ 0 ] ? e.touches[ 0 ].clientY : 0 );
+				const currentX = e.clientX;
+				const currentY = e.clientY;
 
 				const deltaX = currentX - startX;
 				const deltaY = currentY - startY;
@@ -1152,29 +1132,21 @@ export class Profiler {
 
 				isResizing = false;
 
-				document.removeEventListener( 'mousemove', onResizeMove );
-				document.removeEventListener( 'mouseup', onResizeEnd );
-				document.removeEventListener( 'touchmove', onResizeMove );
-				document.removeEventListener( 'touchend', onResizeEnd );
+				resizer.removeEventListener( 'pointermove', onResizeMove );
+				resizer.removeEventListener( 'pointerup', onResizeEnd );
+				resizer.removeEventListener( 'pointercancel', onResizeEnd );
 
 				// Save layout after resizing detached window
 				this.saveLayout();
 
 			};
 
-			resizer.addEventListener( 'mousedown', ( e ) => {
+			resizer.addEventListener( 'pointerdown', ( e ) => {
 
 				onResizeStart( e );
-				document.addEventListener( 'mousemove', onResizeMove );
-				document.addEventListener( 'mouseup', onResizeEnd );
-
-			} );
-
-			resizer.addEventListener( 'touchstart', ( e ) => {
-
-				onResizeStart( e );
-				document.addEventListener( 'touchmove', onResizeMove, { passive: false } );
-				document.addEventListener( 'touchend', onResizeEnd );
+				resizer.addEventListener( 'pointermove', onResizeMove );
+				resizer.addEventListener( 'pointerup', onResizeEnd );
+				resizer.addEventListener( 'pointercancel', onResizeEnd );
 
 			} );
 

--- a/examples/jsm/inspector/ui/Profiler.js
+++ b/examples/jsm/inspector/ui/Profiler.js
@@ -84,8 +84,49 @@ export class Profiler {
 
 		};
 
+		const constrainMainPanel = () => {
+
+			// Skip if panel is maximized (it should always fill the screen)
+			if ( this.panel.classList.contains( 'maximized' ) ) return;
+
+			const windowWidth = window.innerWidth;
+			const windowHeight = window.innerHeight;
+
+			if ( this.position === 'bottom' ) {
+
+				const currentHeight = this.panel.offsetHeight;
+				const maxHeight = windowHeight - 50; // Leave 50px margin
+
+				if ( currentHeight > maxHeight ) {
+
+					this.panel.style.height = `${ maxHeight }px`;
+					this.lastHeightBottom = maxHeight;
+
+				}
+
+			} else if ( this.position === 'right' ) {
+
+				const currentWidth = this.panel.offsetWidth;
+				const maxWidth = windowWidth - 50; // Leave 50px margin
+
+				if ( currentWidth > maxWidth ) {
+
+					this.panel.style.width = `${ maxWidth }px`;
+					this.lastWidthRight = maxWidth;
+
+				}
+
+			}
+
+		};
+
 		// Listen for window resize events
-		window.addEventListener( 'resize', constrainDetachedWindows );
+		window.addEventListener( 'resize', () => {
+
+			constrainDetachedWindows();
+			constrainMainPanel();
+
+		} );
 
 	}
 
@@ -1511,6 +1552,22 @@ export class Profiler {
 			if ( layout.lastWidthRight ) {
 
 				this.lastWidthRight = layout.lastWidthRight;
+
+			}
+
+			// Constrain saved dimensions to current screen bounds
+			const windowWidth = window.innerWidth;
+			const windowHeight = window.innerHeight;
+
+			if ( this.lastHeightBottom > windowHeight - 50 ) {
+
+				this.lastHeightBottom = windowHeight - 50;
+
+			}
+
+			if ( this.lastWidthRight > windowWidth - 50 ) {
+
+				this.lastWidthRight = windowWidth - 50;
 
 			}
 

--- a/examples/jsm/inspector/ui/Profiler.js
+++ b/examples/jsm/inspector/ui/Profiler.js
@@ -205,6 +205,9 @@ export class Profiler {
 
 		this.domElement.append( this.toggleButton, this.panel );
 
+		// Set initial position class
+		this.panel.classList.add( `position-${this.position}` );
+
 	}
 
 	setupResizing() {

--- a/examples/jsm/inspector/ui/Style.js
+++ b/examples/jsm/inspector/ui/Style.js
@@ -220,6 +220,7 @@ export class Style {
 	height: 5px;
 	cursor: ns-resize;
 	z-index: 1001;
+	touch-action: none;
 }
 
 #profiler-panel.position-top .panel-resizer {
@@ -457,6 +458,7 @@ export class Style {
 	font-size: 14px;
 	user-select: none;
 	transition: opacity 0.2s, transform 0.2s;
+	touch-action: none;
 }
 
 .tab-btn.active {
@@ -1016,6 +1018,7 @@ body:has(#profiler-panel:not(.visible)) .detached-tab-panel {
 	flex-shrink: 0;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
+	touch-action: none;
 }
 
 .detached-tab-header:active {
@@ -1101,6 +1104,7 @@ body:has(#profiler-panel:not(.visible)) .detached-tab-panel {
 	height: 20px;
 	cursor: nwse-resize;
 	z-index: 10;
+	touch-action: none;
 }
 
 .detached-tab-resizer::after {
@@ -1130,6 +1134,7 @@ body:has(#profiler-panel:not(.visible)) .detached-tab-panel {
 	height: 5px;
 	cursor: ns-resize;
 	z-index: 10;
+	touch-action: none;
 }
 
 .detached-tab-resizer-right {
@@ -1140,6 +1145,7 @@ body:has(#profiler-panel:not(.visible)) .detached-tab-panel {
 	width: 5px;
 	cursor: ew-resize;
 	z-index: 10;
+	touch-action: none;
 }
 
 .detached-tab-resizer-bottom {
@@ -1150,6 +1156,7 @@ body:has(#profiler-panel:not(.visible)) .detached-tab-panel {
 	height: 5px;
 	cursor: ns-resize;
 	z-index: 10;
+	touch-action: none;
 }
 
 .detached-tab-resizer-left {
@@ -1160,6 +1167,7 @@ body:has(#profiler-panel:not(.visible)) .detached-tab-panel {
 	width: 5px;
 	cursor: ew-resize;
 	z-index: 10;
+	touch-action: none;
 }
 
 /* Input number spin buttons - hide arrows */

--- a/examples/jsm/inspector/ui/Style.js
+++ b/examples/jsm/inspector/ui/Style.js
@@ -341,13 +341,6 @@ export class Style {
 	border-bottom: 1px solid var(--profiler-border);
 }
 
-#profiler-panel.position-right.no-tabs #maximize-btn,
-#profiler-panel.position-left.no-tabs #maximize-btn,
-#profiler-panel.position-bottom.no-tabs #maximize-btn,
-#profiler-panel.position-top.no-tabs #maximize-btn {
-	display: none;
-}
-
 #profiler-panel.position-right.no-tabs .profiler-content-wrapper,
 #profiler-panel.position-left.no-tabs .profiler-content-wrapper {
 	display: none;
@@ -519,6 +512,14 @@ export class Style {
 #hide-panel-btn:hover {
 	background-color: rgba(255, 255, 255, 0.1);
 	color: var(--text-primary);
+}
+
+/* Hide maximize button when there are no tabs */
+#profiler-panel.position-right.no-tabs #maximize-btn,
+#profiler-panel.position-left.no-tabs #maximize-btn,
+#profiler-panel.position-bottom.no-tabs #maximize-btn,
+#profiler-panel.position-top.no-tabs #maximize-btn {
+	display: none !important;
 }
 
 .profiler-content-wrapper {

--- a/examples/jsm/inspector/ui/Style.js
+++ b/examples/jsm/inspector/ui/Style.js
@@ -966,6 +966,44 @@ export class Style {
 
 }
 
+/* Touch device optimizations */
+@media (hover: none) and (pointer: coarse) {
+
+	.panel-resizer {
+		top: -10px !important;
+		height: 20px !important;
+	}
+
+	#profiler-panel.position-top .panel-resizer {
+		top: auto !important;
+		bottom: -10px !important;
+		height: 20px !important;
+	}
+
+	#profiler-panel.position-left .panel-resizer {
+		right: -10px !important;
+		width: 20px !important;
+		height: 100% !important;
+	}
+
+	#profiler-panel.position-right .panel-resizer {
+		left: -10px !important;
+		width: 20px !important;
+		height: 100% !important;
+	}
+
+	.detached-tab-resizer-top,
+	.detached-tab-resizer-bottom {
+		height: 10px !important;
+	}
+
+	.detached-tab-resizer-left,
+	.detached-tab-resizer-right {
+		width: 10px !important;
+	}
+
+}
+
 .drag-preview-indicator {
 	position: fixed;
 	background-color: rgba(0, 170, 255, 0.2);


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/32197

**Description**

When transitioning from a large screen to a small one, or when redirecting the browser, windows can get lost; this code ensures that the windows will always be visible on the screen.

<img width="768" height="744" alt="image" src="https://github.com/user-attachments/assets/cde59263-f404-4610-a06c-334bebb75724" />
