### PR TITLE
Manual: Fix formatting in `prerequisites.html`.

### DIFF
--- a/manual/resources/lesson.js
+++ b/manual/resources/lesson.js
@@ -51,7 +51,7 @@
 	const parts = window.location.href.split( '/' );
 	const filename = parts[ parts.length - 1 ];
 
-	if ( filename !== 'primitives.html' ) {
+	if ( filename !== 'primitives.html' && filename !== 'prerequisites.html' ) {
 
 		let text = document.body.innerHTML;
 


### PR DESCRIPTION
Fixed #32216.

**Description**

A few of manual pages use special formatting and are thus not compatible with the code replacements from the old doc's manual pages. The PR adds `prerequisites.html` to the exceptions.
