### PR TITLE
SSRNode: Ensure boolean value for isPerspectiveCamera uniform.

### DIFF
--- a/examples/jsm/tsl/display/SSRNode.js
+++ b/examples/jsm/tsl/display/SSRNode.js
@@ -206,7 +206,7 @@ class SSRNode extends TempNode {
 		 * @private
 		 * @type {UniformNode<bool>}
 		 */
-		this._isPerspectiveCamera = uniform( !!camera.isPerspectiveCamera );
+		this._isPerspectiveCamera = uniform( camera.isPerspectiveCamera === true );
 
 		/**
 		 * The resolution of the pass.

--- a/examples/jsm/tsl/display/SSRNode.js
+++ b/examples/jsm/tsl/display/SSRNode.js
@@ -206,7 +206,7 @@ class SSRNode extends TempNode {
 		 * @private
 		 * @type {UniformNode<bool>}
 		 */
-		this._isPerspectiveCamera = uniform( camera.isPerspectiveCamera );
+		this._isPerspectiveCamera = uniform( !!camera.isPerspectiveCamera );
 
 		/**
 		 * The resolution of the pass.


### PR DESCRIPTION
Related issue: N/A

**Description**

The SSR node breaks with the following error when used with `OrthographicCamera`. This is because the current code resolves to `this._isPerspectiveCamera = uniform( undefined );` as `isPerspectiveCamera` is undefined on `OrthographicCamera`.

Error
```
THREE.TSL: Error: Uniform "null" not declared.
```

Fixed by ensuring the `_isPerspectiveCamera` uniform is a boolean.

Broken example on r181: 

https://codesandbox.io/p/devbox/cranky-framework-zrtfz3?workspaceId=ws_5NvLnrKyk5Nd2YftNHw3Fy