### PR TITLE
ShaderMaterial: Fix copy method to include missing properties

### DIFF
--- a/src/materials/ShaderMaterial.js
+++ b/src/materials/ShaderMaterial.js
@@ -270,7 +270,6 @@ class ShaderMaterial extends Material {
 
 		this.wireframe = source.wireframe;
 		this.wireframeLinewidth = source.wireframeLinewidth;
-		this.linewidth = source.linewidth;
 
 		this.fog = source.fog;
 		this.lights = source.lights;
@@ -279,8 +278,6 @@ class ShaderMaterial extends Material {
 		this.extensions = Object.assign( {}, source.extensions );
 
 		this.glslVersion = source.glslVersion;
-
-		this.forceSinglePass = source.forceSinglePass;
 
 		this.defaultAttributeValues = Object.assign( {}, source.defaultAttributeValues );
 

--- a/src/materials/ShaderMaterial.js
+++ b/src/materials/ShaderMaterial.js
@@ -270,6 +270,7 @@ class ShaderMaterial extends Material {
 
 		this.wireframe = source.wireframe;
 		this.wireframeLinewidth = source.wireframeLinewidth;
+		this.linewidth = source.linewidth;
 
 		this.fog = source.fog;
 		this.lights = source.lights;
@@ -278,6 +279,14 @@ class ShaderMaterial extends Material {
 		this.extensions = Object.assign( {}, source.extensions );
 
 		this.glslVersion = source.glslVersion;
+
+		this.forceSinglePass = source.forceSinglePass;
+
+		this.defaultAttributeValues = Object.assign( {}, source.defaultAttributeValues );
+
+		this.index0AttributeName = source.index0AttributeName;
+
+		this.uniformsNeedUpdate = source.uniformsNeedUpdate;
 
 		return this;
 


### PR DESCRIPTION
Related issue: N/A

Description

The `copy` method in `ShaderMaterial` was missing several properties that are defined in the constructor. When cloning a `ShaderMaterial` instance, these properties were not copied to the new material, causing incorrect behavior.

The missing properties are:
-  ~~`linewidth`~~
-  ~~`forceSinglePass`~~
- `defaultAttributeValues`
- `index0AttributeName`
- `uniformsNeedUpdate`

Fixed by ensuring all `ShaderMaterial` properties are properly copied in the `copy` method.