### PR TITLE
TSL: Do not auto-generate tangent attribute.

### DIFF
--- a/src/nodes/accessors/Tangent.js
+++ b/src/nodes/accessors/Tangent.js
@@ -11,17 +11,7 @@ import { directionToFaceDirection } from '../display/FrontFacingNode.js';
  * @tsl
  * @type {Node<vec4>}
  */
-export const tangentGeometry = /*@__PURE__*/ Fn( ( builder ) => {
-
-	if ( builder.geometry.hasAttribute( 'tangent' ) === false ) {
-
-		builder.geometry.computeTangents();
-
-	}
-
-	return attribute( 'tangent', 'vec4' );
-
-} )();
+export const tangentGeometry = /*@__PURE__*/ attribute( 'tangent', 'vec4' );
 
 /**
  * TSL object that represents the vertex tangent in local space of the current rendered object.


### PR DESCRIPTION
Fixed #32198.

**Description**

Computing a tangent attribute when building nodes corrupts the cache key and leads to confusing behavior like described in #32198. For a more consistent behavior, it's better to let the application compute tangent vectors if they are missing in geometry data. Developers might prefer to use `BufferGeometryUtils.computeMikkTSpaceTangents()` anyway for tangent computation.

Removing the auto-generation triggers below warning if tangent are missing so users should be informed about what's going on: 

> THREE.AttributeNode: Vertex attribute "tangent" not found on geometry.