### PR TITLE
fix: enable default expand state in outliner sidebar

### DIFF
--- a/editor/js/Sidebar.Scene.js
+++ b/editor/js/Sidebar.Scene.js
@@ -390,7 +390,7 @@ function SidebarScene( editor ) {
 
 				if ( nodeStates.has( object ) === false ) {
 
-					nodeStates.set( object, false );
+					nodeStates.set( object, true );
 
 				}
 

--- a/examples/jsm/loaders/DRACOLoader.js
+++ b/examples/jsm/loaders/DRACOLoader.js
@@ -667,7 +667,7 @@ function DRACOWorker() {
 		const srcByteStride = itemSize * TypedArray.BYTES_PER_ELEMENT;
 		const dstByteStride = Math.ceil( srcByteStride / 4 ) * 4;
 
-		const dstStride = dstByteStride / TypedArray.BYTES_PER_ELEMENT
+		const dstStride = dstByteStride / TypedArray.BYTES_PER_ELEMENT;
 
 		const srcByteLength = count * srcByteStride;
 		const dstByteLength = count * dstByteStride;
@@ -690,13 +690,13 @@ function DRACOWorker() {
 
 			dstArray = new TypedArray( dstByteLength / TypedArray.BYTES_PER_ELEMENT );
 
-			let dstOffset = 0
+			let dstOffset = 0;
 
-			for ( let i = 0, il = srcArray.length; i < il; i++ ) {
+			for ( let i = 0, il = srcArray.length; i < il; i ++ ) {
 
-				for ( let j = 0; j < itemSize; j++ ) {
+				for ( let j = 0; j < itemSize; j ++ ) {
 
-					dstArray[ dstOffset + j ] = srcArray[ i * itemSize + j ]
+					dstArray[ dstOffset + j ] = srcArray[ i * itemSize + j ];
 
 				}
 

--- a/examples/jsm/materials/WoodNodeMaterial.js
+++ b/examples/jsm/materials/WoodNodeMaterial.js
@@ -297,7 +297,7 @@ const woodParams = {
 	teak: {
 		transformationMatrix: new THREE.Matrix4().identity(),
 		centerSize: 1.11, largeWarpScale: 0.32, largeGrainStretch: 0.24, smallWarpStrength: 0.059,
-		smallWarpScale: 2, fineWarpStrength: 0.006, fineWarpScale: 32.8, ringThickness: 1/34,
+		smallWarpScale: 2, fineWarpStrength: 0.006, fineWarpScale: 32.8, ringThickness: 1 / 34,
 		ringBias: 0.03, ringSizeVariance: 0.03, ringVarianceScale: 4.4, barkThickness: 0.3,
 		splotchScale: 0.2, splotchIntensity: 0.541, cellScale: 910, cellSize: 0.1,
 		darkGrainColor: '#0c0504', lightGrainColor: '#926c50'
@@ -305,7 +305,7 @@ const woodParams = {
 	walnut: {
 		transformationMatrix: new THREE.Matrix4().identity(),
 		centerSize: 1.07, largeWarpScale: 0.42, largeGrainStretch: 0.34, smallWarpStrength: 0.016,
-		smallWarpScale: 10.3, fineWarpStrength: 0.028, fineWarpScale: 12.7, ringThickness: 1/32,
+		smallWarpScale: 10.3, fineWarpStrength: 0.028, fineWarpScale: 12.7, ringThickness: 1 / 32,
 		ringBias: 0.08, ringSizeVariance: 0.03, ringVarianceScale: 5.5, barkThickness: 0.98,
 		splotchScale: 1.84, splotchIntensity: 0.97, cellScale: 710, cellSize: 0.31,
 		darkGrainColor: '#311e13', lightGrainColor: '#523424'
@@ -313,7 +313,7 @@ const woodParams = {
 	white_oak: {
 		transformationMatrix: new THREE.Matrix4().identity(),
 		centerSize: 1.23, largeWarpScale: 0.21, largeGrainStretch: 0.21, smallWarpStrength: 0.034,
-		smallWarpScale: 2.44, fineWarpStrength: 0.01, fineWarpScale: 14.3, ringThickness: 1/34,
+		smallWarpScale: 2.44, fineWarpStrength: 0.01, fineWarpScale: 14.3, ringThickness: 1 / 34,
 		ringBias: 0.82, ringSizeVariance: 0.16, ringVarianceScale: 1.4, barkThickness: 0.7,
 		splotchScale: 0.2, splotchIntensity: 0.541, cellScale: 800, cellSize: 0.28,
 		darkGrainColor: '#8b4c21', lightGrainColor: '#c57e43'
@@ -321,7 +321,7 @@ const woodParams = {
 	pine: {
 		transformationMatrix: new THREE.Matrix4().identity(),
 		centerSize: 1.23, largeWarpScale: 0.21, largeGrainStretch: 0.18, smallWarpStrength: 0.041,
-		smallWarpScale: 2.44, fineWarpStrength: 0.006, fineWarpScale: 23.2, ringThickness: 1/24,
+		smallWarpScale: 2.44, fineWarpStrength: 0.006, fineWarpScale: 23.2, ringThickness: 1 / 24,
 		ringBias: 0.1, ringSizeVariance: 0.07, ringVarianceScale: 5, barkThickness: 0.35,
 		splotchScale: 0.51, splotchIntensity: 3.32, cellScale: 1480, cellSize: 0.07,
 		darkGrainColor: '#c58355', lightGrainColor: '#d19d61'
@@ -329,7 +329,7 @@ const woodParams = {
 	poplar: {
 		transformationMatrix: new THREE.Matrix4().identity(),
 		centerSize: 1.43, largeWarpScale: 0.33, largeGrainStretch: 0.18, smallWarpStrength: 0.04,
-		smallWarpScale: 4.3, fineWarpStrength: 0.004, fineWarpScale: 33.6, ringThickness: 1/37,
+		smallWarpScale: 4.3, fineWarpStrength: 0.004, fineWarpScale: 33.6, ringThickness: 1 / 37,
 		ringBias: 0.07, ringSizeVariance: 0.03, ringVarianceScale: 3.8, barkThickness: 0.3,
 		splotchScale: 1.92, splotchIntensity: 0.71, cellScale: 830, cellSize: 0.04,
 		darkGrainColor: '#716347', lightGrainColor: '#998966'
@@ -337,7 +337,7 @@ const woodParams = {
 	maple: {
 		transformationMatrix: new THREE.Matrix4().identity(),
 		centerSize: 1.4, largeWarpScale: 0.38, largeGrainStretch: 0.25, smallWarpStrength: 0.067,
-		smallWarpScale: 2.5, fineWarpStrength: 0.005, fineWarpScale: 33.6, ringThickness: 1/35,
+		smallWarpScale: 2.5, fineWarpStrength: 0.005, fineWarpScale: 33.6, ringThickness: 1 / 35,
 		ringBias: 0.1, ringSizeVariance: 0.07, ringVarianceScale: 4.6, barkThickness: 0.61,
 		splotchScale: 0.46, splotchIntensity: 1.49, cellScale: 800, cellSize: 0.03,
 		darkGrainColor: '#b08969', lightGrainColor: '#bc9d7d'
@@ -345,7 +345,7 @@ const woodParams = {
 	red_oak: {
 		transformationMatrix: new THREE.Matrix4().identity(),
 		centerSize: 1.21, largeWarpScale: 0.24, largeGrainStretch: 0.25, smallWarpStrength: 0.044,
-		smallWarpScale: 2.54, fineWarpStrength: 0.01, fineWarpScale: 14.5, ringThickness: 1/34,
+		smallWarpScale: 2.54, fineWarpStrength: 0.01, fineWarpScale: 14.5, ringThickness: 1 / 34,
 		ringBias: 0.92, ringSizeVariance: 0.03, ringVarianceScale: 5.6, barkThickness: 1.01,
 		splotchScale: 0.28, splotchIntensity: 3.48, cellScale: 800, cellSize: 0.25,
 		darkGrainColor: '#af613b', lightGrainColor: '#e0a27a'
@@ -353,7 +353,7 @@ const woodParams = {
 	cherry: {
 		transformationMatrix: new THREE.Matrix4().identity(),
 		centerSize: 1.33, largeWarpScale: 0.11, largeGrainStretch: 0.33, smallWarpStrength: 0.024,
-		smallWarpScale: 2.48, fineWarpStrength: 0.01, fineWarpScale: 15.3, ringThickness: 1/36,
+		smallWarpScale: 2.48, fineWarpStrength: 0.01, fineWarpScale: 15.3, ringThickness: 1 / 36,
 		ringBias: 0.02, ringSizeVariance: 0.04, ringVarianceScale: 6.5, barkThickness: 0.09,
 		splotchScale: 1.27, splotchIntensity: 1.24, cellScale: 1530, cellSize: 0.15,
 		darkGrainColor: '#913f27', lightGrainColor: '#b45837'
@@ -361,7 +361,7 @@ const woodParams = {
 	cedar: {
 		transformationMatrix: new THREE.Matrix4().identity(),
 		centerSize: 1.11, largeWarpScale: 0.39, largeGrainStretch: 0.12, smallWarpStrength: 0.061,
-		smallWarpScale: 1.9, fineWarpStrength: 0.006, fineWarpScale: 4.8, ringThickness: 1/25,
+		smallWarpScale: 1.9, fineWarpStrength: 0.006, fineWarpScale: 4.8, ringThickness: 1 / 25,
 		ringBias: 0.01, ringSizeVariance: 0.07, ringVarianceScale: 6.7, barkThickness: 0.1,
 		splotchScale: 0.61, splotchIntensity: 2.54, cellScale: 630, cellSize: 0.19,
 		darkGrainColor: '#9a5b49', lightGrainColor: '#ae745e'
@@ -369,7 +369,7 @@ const woodParams = {
 	mahogany: {
 		transformationMatrix: new THREE.Matrix4().identity(),
 		centerSize: 1.25, largeWarpScale: 0.26, largeGrainStretch: 0.29, smallWarpStrength: 0.044,
-		smallWarpScale: 2.54, fineWarpStrength: 0.01, fineWarpScale: 15.3, ringThickness: 1/38,
+		smallWarpScale: 2.54, fineWarpStrength: 0.01, fineWarpScale: 15.3, ringThickness: 1 / 38,
 		ringBias: 0.01, ringSizeVariance: 0.33, ringVarianceScale: 1.2, barkThickness: 0.07,
 		splotchScale: 0.77, splotchIntensity: 1.39, cellScale: 1400, cellSize: 0.23,
 		darkGrainColor: '#501d12', lightGrainColor: '#6d3722'
@@ -433,7 +433,7 @@ uniforms.lightGrainColor = TSL.uniform( new THREE.Color( params.lightGrainColor 
 uniforms.transformationMatrix = TSL.uniform( new THREE.Matrix4().copy( params.transformationMatrix ) ).onObjectUpdate( ( { material } ) => material.transformationMatrix );
 
 const colorNode = wood(
-	uniforms.transformationMatrix.mul( TSL.vec4(TSL.positionLocal, 1) ).xyz,
+	uniforms.transformationMatrix.mul( TSL.vec4( TSL.positionLocal, 1 ) ).xyz,
 	uniforms.centerSize,
 	uniforms.largeWarpScale,
 	uniforms.largeGrainStretch,

--- a/examples/jsm/renderers/Projector.js
+++ b/examples/jsm/renderers/Projector.js
@@ -172,7 +172,7 @@ class Projector {
 				{ sign: + 1 },
 				{ sign: - 1 }
 			];
-		
+
 		//
 
 		function RenderList() {
@@ -348,7 +348,7 @@ class Projector {
 						_face.v3.copy( v3 );
 						_face.z = ( v1.positionScreen.z + v2.positionScreen.z + v3.positionScreen.z ) / 3;
 						_face.renderOrder = object.renderOrder;
-						
+
 						// face normal
 						_vector3.subVectors( v3.position, v2.position );
 						_vector4.subVectors( v1.position, v2.position );
@@ -397,7 +397,7 @@ class Projector {
 				for ( let i = 0; i < clippedCount; i ++ ) {
 
 					const cv = _clipInput[ i ];
-					
+
 					// Get or create renderable vertex from pool
 					let sv = _screenVertexPool[ i ];
 					if ( ! sv ) {
@@ -1095,7 +1095,7 @@ class Projector {
 			return inputCount;
 
 		}
-	
+
 		function clipLine( s1, s2 ) {
 
 			let alpha1 = 0, alpha2 = 1;


### PR DESCRIPTION
Related issue: #31923

**Description**
The Three.js Editor Outliner already had the logic for collapsible scene hierarchies, 
but it was not functioning correctly because new nodes were initialized in a collapsed 
state (`nodeStates = false`). This caused unexpected behavior when interacting with 
the sidebar.

This pull request fixes the issue by setting the default state of new nodes to `true`, 
so they appear expanded initially. The collapse/expand logic was already implemented; 
this change simply corrects the default state. Users can now manually collapse or expand 
scene hierarchy nodes as intended.

