### PR TITLE
InstanceNode: Add support for StorageInstancedBufferAttribute

### DIFF
--- a/src/nodes/accessors/InstanceNode.js
+++ b/src/nodes/accessors/InstanceNode.js
@@ -62,20 +62,6 @@ class InstanceNode extends Node {
 		this.instanceColor = instanceColor;
 
 		/**
-		 * Tracks whether the matrix data is provided via a storage buffer.
-		 *
-		 * @type {boolean}
-		 */
-		this.isStorageMatrix = instanceMatrix && instanceMatrix.isStorageInstancedBufferAttribute === true;
-
-		/**
-		 * Tracks whether the color data is provided via a storage buffer.
-		 *
-		 * @type {boolean}
-		 */
-		this.isStorageColor = instanceColor && instanceColor.isStorageInstancedBufferAttribute === true;
-
-		/**
 		 * The node that represents the instance matrix data.
 		 *
 		 * @type {?Node}
@@ -112,6 +98,32 @@ class InstanceNode extends Node {
 		 * @type {?InstancedBufferAttribute}
 		 */
 		this.bufferColor = null;
+
+	}
+
+	/**
+	 * Tracks whether the matrix data is provided via a storage buffer.
+	 *
+	 * @type {boolean}
+	 */
+	get isStorageMatrix() {
+
+		const { instanceMatrix } = this;
+
+		return instanceMatrix && instanceMatrix.isStorageInstancedBufferAttribute === true;
+
+	}
+
+	/**
+	 * Tracks whether the color data is provided via a storage buffer.
+	 *
+	 * @type {boolean}
+	 */
+	get isStorageColor() {
+
+		const { instanceColor } = this;
+
+		return instanceColor && instanceColor.isStorageInstancedBufferAttribute === true;
 
 	}
 

--- a/src/nodes/accessors/InstanceNode.js
+++ b/src/nodes/accessors/InstanceNode.js
@@ -101,7 +101,6 @@ class InstanceNode extends Node {
 
 		/**
 		 * A reference to a buffer that is used by `instanceMatrixNode`
-		 * when CPU-side interleaved attributes are required.
 		 *
 		 * @type {?InstancedInterleavedBuffer}
 		 */
@@ -109,7 +108,6 @@ class InstanceNode extends Node {
 
 		/**
 		 * A reference to a buffer that is used by `instanceColorNode`
-		 * when CPU-side attributes are required.
 		 *
 		 * @type {?InstancedBufferAttribute}
 		 */

--- a/src/nodes/accessors/InstanceNode.js
+++ b/src/nodes/accessors/InstanceNode.js
@@ -100,14 +100,14 @@ class InstanceNode extends Node {
 		this.updateType = NodeUpdateType.FRAME;
 
 		/**
-		 * A reference to a buffer that is used by `instanceMatrixNode`
+		 * A reference to a buffer that is used by `instanceMatrixNode`.
 		 *
 		 * @type {?InstancedInterleavedBuffer}
 		 */
 		this.buffer = null;
 
 		/**
-		 * A reference to a buffer that is used by `instanceColorNode`
+		 * A reference to a buffer that is used by `instanceColorNode`.
 		 *
 		 * @type {?InstancedBufferAttribute}
 		 */


### PR DESCRIPTION
**Description**
Add support for direct usage of `StorageInstancedBufferAttribute` for `instanceMatrix` of `InstancedMesh` (or any type of Mesh tagged with `mesh.isInstancedMesh`.

For example:
```js
const instanceMatrixStorage = new THREE.StorageInstancedBufferAttribute()

const instancedMesh = new THREE.InstancedMesh(geometry, material, count)
instancedMesh.instanceMatrix = instanceMatrixStorage

// -> No need for any tricky patch in positionNode or vertexNode anymore nor buffer duplication and update in InstancedNode
```
Can be very useful for advanced usage without having to create complex nodes by naturally make use of the `InstancedNode` and NodeMaterial pipeline.

Alternative would be to expose InstanceNode and patch via prototype the old WebGLRenderer way which I don't recommend.

*This contribution is funded by [Utsubo](https://utsubo.com) & [Three.js Blocks](https://www.threejs-blocks.com/)*
