### PR TITLE
WebGPUBindingUtils - Buffer Labeling Adjustment

### DIFF
--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -19,8 +19,7 @@ import ExpressionNode from '../../../nodes/code/ExpressionNode.js';
 import { FloatType, RepeatWrapping, ClampToEdgeWrapping, MirroredRepeatWrapping, NearestFilter } from '../../../constants.js';
 import { warn, error } from '../../../utils.js';
 
-// GPUShaderStage is not defined in browsers not supporting WebGPU
-const GPUShaderStage = ( typeof self !== 'undefined' ) ? self.GPUShaderStage : { VERTEX: 1, FRAGMENT: 2, COMPUTE: 4 };
+import { GPUShaderStage } from '../utils/WebGPUConstants.js';
 
 const accessNames = {
 	[ NodeAccess.READ_ONLY ]: 'read',
@@ -35,9 +34,9 @@ const wrapNames = {
 };
 
 const gpuShaderStageLib = {
-	'vertex': GPUShaderStage ? GPUShaderStage.VERTEX : 1,
-	'fragment': GPUShaderStage ? GPUShaderStage.FRAGMENT : 2,
-	'compute': GPUShaderStage ? GPUShaderStage.COMPUTE : 4
+	'vertex': GPUShaderStage.VERTEX,
+	'fragment': GPUShaderStage.FRAGMENT,
+	'compute': GPUShaderStage.COMPUTE
 };
 
 const supports = {

--- a/src/renderers/webgpu/utils/WebGPUBindingUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUBindingUtils.js
@@ -6,7 +6,6 @@ import {
 import { FloatType, IntType, UnsignedIntType } from '../../../constants.js';
 import { NodeAccess } from '../../../nodes/core/constants.js';
 import { error } from '../../../utils.js';
-import { buffer } from '../../../nodes/TSL.js';
 
 /**
  * A WebGPU backend utility module for managing bindings.

--- a/src/renderers/webgpu/utils/WebGPUBindingUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUBindingUtils.js
@@ -6,6 +6,7 @@ import {
 import { FloatType, IntType, UnsignedIntType } from '../../../constants.js';
 import { NodeAccess } from '../../../nodes/core/constants.js';
 import { error } from '../../../utils.js';
+import { buffer } from '../../../nodes/TSL.js';
 
 /**
  * A WebGPU backend utility module for managing bindings.
@@ -373,8 +374,27 @@ class WebGPUBindingUtils {
 
 					const usage = GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST;
 
+					let bufferVisibility = '';
+					if ( binding.visibility & 1 ) {
+
+						bufferVisibility += 'vertex';
+
+					}
+
+					if ( binding.visibility & 2 ) {
+
+						bufferVisibility += 'fragment';
+
+					}
+
+					if ( binding.visibility & 4 ) {
+
+						bufferVisibility += 'compute';
+
+					}
+
 					const bufferGPU = device.createBuffer( {
-						label: 'bindingBuffer_' + binding.name,
+						label: `bufferBinding${binding.id}_${binding.name}_${bufferVisibility}`,
 						size: byteLength,
 						usage: usage
 					} );

--- a/src/renderers/webgpu/utils/WebGPUBindingUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUBindingUtils.js
@@ -374,27 +374,29 @@ class WebGPUBindingUtils {
 
 					const usage = GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST;
 
-					let bufferVisibility = '';
+					const visibilities = [];
 					if ( binding.visibility & 1 ) {
 
-						bufferVisibility += 'vertex';
+						visibilities.push( 'vertex' );
 
 					}
 
 					if ( binding.visibility & 2 ) {
 
-						bufferVisibility += 'fragment';
+						visibilities.push( 'fragment' );
 
 					}
 
 					if ( binding.visibility & 4 ) {
 
-						bufferVisibility += 'compute';
+						visibilities.push( 'compute' );
 
 					}
 
+					const bufferVisibility = `(${visibilities.join( ',' )})`;
+
 					const bufferGPU = device.createBuffer( {
-						label: `bufferBinding${binding.id}_${binding.name}_${bufferVisibility}`,
+						label: `bindingBuffer${binding.id}_${binding.name}_${bufferVisibility}`,
 						size: byteLength,
 						usage: usage
 					} );

--- a/src/renderers/webgpu/utils/WebGPUBindingUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUBindingUtils.js
@@ -1,6 +1,6 @@
 import {
 	GPUTextureAspect, GPUTextureViewDimension, GPUTextureSampleType, GPUBufferBindingType, GPUStorageTextureAccess,
-	GPUSamplerBindingType
+	GPUSamplerBindingType, GPUShaderStage
 } from './WebGPUConstants.js';
 
 import { FloatType, IntType, UnsignedIntType } from '../../../constants.js';
@@ -70,7 +70,7 @@ class WebGPUBindingUtils {
 
 				if ( binding.isStorageBuffer ) {
 
-					if ( binding.visibility & 4 ) {
+					if ( binding.visibility & GPUShaderStage.COMPUTE ) {
 
 						// compute
 
@@ -374,19 +374,19 @@ class WebGPUBindingUtils {
 					const usage = GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST;
 
 					const visibilities = [];
-					if ( binding.visibility & 1 ) {
+					if ( binding.visibility & GPUShaderStage.VERTEX ) {
 
 						visibilities.push( 'vertex' );
 
 					}
 
-					if ( binding.visibility & 2 ) {
+					if ( binding.visibility & GPUShaderStage.FRAGMENT ) {
 
 						visibilities.push( 'fragment' );
 
 					}
 
-					if ( binding.visibility & 4 ) {
+					if ( binding.visibility & GPUShaderStage.COMPUTE ) {
 
 						visibilities.push( 'compute' );
 

--- a/src/renderers/webgpu/utils/WebGPUConstants.js
+++ b/src/renderers/webgpu/utils/WebGPUConstants.js
@@ -6,6 +6,8 @@ export const GPUPrimitiveTopology = {
 	TriangleStrip: 'triangle-strip',
 };
 
+export const GPUShaderStage = ( typeof self !== 'undefined' ) ? self.GPUShaderStage : { VERTEX: 1, FRAGMENT: 2, COMPUTE: 4 };
+
 export const GPUCompareFunction = {
 	Never: 'never',
 	Less: 'less',


### PR DESCRIPTION
Related issue: #32037

**Description**

Add better labeling to the buffers generated from NodeUniformsGroup bindings, specifying the id of the binding the buffer was created from as well as the buffer's visibility.
