### PR TITLE
Docs/Examples: Open panel on mobile when no page/example is selected

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1913,6 +1913,12 @@
 
 			const selectedPage = window.location.hash.substring( 1 );
 
+			if ( selectedPage === '' ) {
+
+				panel.classList.add( 'open' );
+
+			}
+
 			const links = navigation.querySelectorAll( 'a' );
 
 			links.forEach( link => {

--- a/examples/index.html
+++ b/examples/index.html
@@ -110,6 +110,12 @@
 
 			}
 
+			if ( selected === null ) {
+
+				panel.classList.add( 'open' );
+
+			}
+
 			if ( viewer.src === '' ) {
 
 				viewer.srcdoc = document.getElementById( 'PlaceholderHTML' ).innerHTML;

--- a/utils/docs/template/static/index.html
+++ b/utils/docs/template/static/index.html
@@ -188,6 +188,12 @@
 
 			const selectedPage = window.location.hash.substring( 1 );
 
+			if ( selectedPage === '' ) {
+
+				panel.classList.add( 'open' );
+
+			}
+
 			const links = navigation.querySelectorAll( 'a' );
 
 			links.forEach( link => {


### PR DESCRIPTION
Related: #31505

**Description**

Made de docs open the panel on mobile when no page is selected.

When visiting https://threejs.org/docs/?q=tsl

| Before | After |
| --- | --- |
| <img width="413" height="895" alt="Screenshot 2025-11-13 at 5 27 31 PM" src="https://github.com/user-attachments/assets/aced5495-92b4-4a12-86a4-455e33605cff" /> | <img width="413" height="895" alt="Screenshot 2025-11-13 at 5 27 49 PM" src="https://github.com/user-attachments/assets/08a61feb-c500-4788-a307-84946ab01831" /> | 

Made the examples page behave the same too.