### PR TITLE
SkyMesh: Add isSkyMesh flag and deprecate isSky

### DIFF
--- a/examples/jsm/objects/SkyMesh.js
+++ b/examples/jsm/objects/SkyMesh.js
@@ -90,7 +90,7 @@ class SkyMesh extends Mesh {
 		 * @default true
 		 * @deprecated Use isSkyMesh instead.
 		 */
-		this.isSky = true;
+		this.isSky = true; // @deprecated, r182
 
 		/**
 		 * This flag can be used for type testing.

--- a/examples/jsm/objects/SkyMesh.js
+++ b/examples/jsm/objects/SkyMesh.js
@@ -88,8 +88,18 @@ class SkyMesh extends Mesh {
 		 * @type {boolean}
 		 * @readonly
 		 * @default true
+		 * @deprecated Use isSkyMesh instead.
 		 */
 		this.isSky = true;
+
+		/**
+		 * This flag can be used for type testing.
+		 *
+		 * @type {boolean}
+		 * @readonly
+		 * @default true
+		 */
+		this.isSkyMesh = true;
 
 		// Varyings
 


### PR DESCRIPTION
Added new isSkyMesh property for type testing and marked isSky as deprecated.
Looking at the SkyMesh class, here's why we added the `isSkyMesh` flag and deprecated `isSky`:

The class is called `SkyMesh`, so `isSkyMesh` provides a more precise type check than the generic `isSky`. This follows the naming convention where the flag matches the class name (Three.js commonly uses `is[ClassName]` flags for type checking).

```javascript
// Before (deprecated)
if (object.isSky) { /* ... */ }

// After (recommended)
if (object.isSkyMesh) { /* ... */ }