### PR TITLE
WebGPURenderer: Relates `MRT` for `RenderContext` in obtaining a unique context.

### DIFF
--- a/src/renderers/common/RenderContexts.js
+++ b/src/renderers/common/RenderContexts.js
@@ -44,6 +44,9 @@ class RenderContexts {
 
 		if ( mrt !== null ) {
 
+			// TODO: Improve ChainMap so that it only matches submaps corresponding to the key lengths.
+			// For we use: if ( mrt !== null ) _chainKeys[ 2 ] = mrt;
+
 			_chainKeys[ index ++ ] = mrt;
 
 		}

--- a/src/renderers/common/RenderContexts.js
+++ b/src/renderers/common/RenderContexts.js
@@ -35,12 +35,21 @@ class RenderContexts {
 	 * @param {Scene} scene - The scene.
 	 * @param {Camera} camera - The camera that is used to render the scene.
 	 * @param {?RenderTarget} [renderTarget=null] - The active render target.
+	 * @param {?MRT} [mrt=null] - The active multiple render target.
 	 * @return {RenderContext} The render context.
 	 */
-	get( scene, camera, renderTarget = null ) {
+	get( scene, camera, renderTarget = null, mrt = null ) {
 
-		_chainKeys[ 0 ] = scene;
-		_chainKeys[ 1 ] = camera;
+		let index = 0;
+
+		if ( mrt !== null ) {
+
+			_chainKeys[ index ++ ] = mrt;
+
+		}
+
+		_chainKeys[ index ++ ] = scene;
+		_chainKeys[ index ++ ] = camera;
 
 		let attachmentState;
 

--- a/src/renderers/common/RenderObject.js
+++ b/src/renderers/common/RenderObject.js
@@ -778,6 +778,8 @@ class RenderObject {
 
 		}
 
+		cacheKey += this.context.id + ',';
+
 		cacheKey += object.receiveShadow + ',';
 
 		return hashString( cacheKey );

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -699,7 +699,7 @@ class Renderer {
 				await this.compileAsync( scene, camera );
 
 				const renderList = this._renderLists.get( scene, camera );
-				const renderContext = this._renderContexts.get( scene, camera, this._renderTarget );
+				const renderContext = this._renderContexts.get( scene, camera, this._renderTarget, this._mrt );
 
 				const material = scene.overrideMaterial || object.material;
 
@@ -859,7 +859,7 @@ class Renderer {
 		if ( targetScene === null ) targetScene = scene;
 
 		const renderTarget = this._renderTarget;
-		const renderContext = this._renderContexts.get( targetScene, camera, renderTarget );
+		const renderContext = this._renderContexts.get( targetScene, camera, renderTarget, this._mrt );
 		const activeMipmapLevel = this._activeMipmapLevel;
 
 		const compilationPromises = [];
@@ -1361,7 +1361,7 @@ class Renderer {
 
 		//
 
-		const renderContext = this._renderContexts.get( scene, camera, renderTarget );
+		const renderContext = this._renderContexts.get( scene, camera, renderTarget, this._mrt );
 
 		this._currentRenderContext = renderContext;
 		this._currentRenderObjectFunction = this._renderObjectFunction || this.renderObject;


### PR DESCRIPTION
Fixes https://github.com/mrdoob/three.js/issues/32253

**Description**

It relates `MRTNode` as a key to create or obtain a `RenderContext`, and relates `RenderContext` to `RenderObject` to generate the cache key.