### PR TITLE
OrbitControls: Make `update()` respect `Controls.enabled`

### DIFF
--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -596,6 +596,8 @@ class OrbitControls extends Controls {
 
 	update( deltaTime = null ) {
 
+		if ( ! this.enabled ) return;
+
 		const position = this.object.position;
 
 		_v.copy( position ).sub( this.target );


### PR DESCRIPTION
Related issue: #32267


**Description**

This bails out of updating the controls when it is not enabled.
