### PR TITLE
Material: Fix copy method to include allowOverride property

### DIFF
--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -968,6 +968,8 @@ class Material extends EventDispatcher {
 		this.premultipliedAlpha = source.premultipliedAlpha;
 		this.forceSinglePass = source.forceSinglePass;
 
+		this.allowOverride = source.allowOverride;
+
 		this.visible = source.visible;
 
 		this.toneMapped = source.toneMapped;

--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -832,6 +832,7 @@ class Material extends EventDispatcher {
 		if ( this.alphaToCoverage === true ) data.alphaToCoverage = true;
 		if ( this.premultipliedAlpha === true ) data.premultipliedAlpha = true;
 		if ( this.forceSinglePass === true ) data.forceSinglePass = true;
+		if ( this.allowOverride === false ) data.allowOverride = false;
 
 		if ( this.wireframe === true ) data.wireframe = true;
 		if ( this.wireframeLinewidth > 1 ) data.wireframeLinewidth = this.wireframeLinewidth;
@@ -967,7 +968,6 @@ class Material extends EventDispatcher {
 		this.alphaToCoverage = source.alphaToCoverage;
 		this.premultipliedAlpha = source.premultipliedAlpha;
 		this.forceSinglePass = source.forceSinglePass;
-
 		this.allowOverride = source.allowOverride;
 
 		this.visible = source.visible;


### PR DESCRIPTION
The copy method in Material was missing the allowOverride property that is defined in the constructor. When cloning a Material instance, this property was not copied to the new material, causing incorrect behavior when allowOverride was set to false.

Fixed by ensuring allowOverride is properly copied in the copy method.

Related issue: N/A

**Description**

The copy method in Material was missing the allowOverride property that is defined in the constructor. When cloning a Material instance, this property was not copied to the new material, causing incorrect behavior when allowOverride was set to false.
