### PR TITLE
TSLEncoder: Fix Fn layout generation when generating a function with no input parameters

### DIFF
--- a/examples/jsm/transpiler/TSLEncoder.js
+++ b/examples/jsm/transpiler/TSLEncoder.js
@@ -798,7 +798,8 @@ ${ this.tab }}`;
 
 		if ( node.layout !== false && hasPointer === false ) {
 
-			funcStr += ', { ' + inputs.join( ', ' ) + ', return: \'' + type + '\' }';
+			const inputsStr = inputs.length > 0 ? inputs.join( ', ' ) + ', ' : '';
+			funcStr += ', { ' + inputsStr + 'return: \'' + type + '\' }';
 
 		}
 


### PR DESCRIPTION
**Description**

When generating a function that doesn't have any input parameters, the TSLEncoder emits an extraneous comma, causing the generated JavaScript to be invalid.

This PR fixes that by only emitting a comma if there is at least one input parameter to the function.

**Example**
Creating a function with no input parameters like this:
```glsl
float example() {
	return 1.0;
}
```
Causes the TSLEncoder to emit the following:
```js
import { Fn } from 'three/tsl';

export const example = /*@__PURE__*/ Fn( () => {

	return 1.0;

}, { , return: 'float' } );
```

The second parameter to Fn (i.e, the function layout) has an invalidly placed comma before the `return` property.

