### PR TITLE
Fix: Copy array properties in Material.setValues() to prevent mutations

### DIFF
--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -584,6 +584,10 @@ class Material extends EventDispatcher {
 
 				currentValue.copy( newValue );
 
+			} else if ( Array.isArray( currentValue ) && Array.isArray( newValue ) ) {
+
+				this[ key ] = [ ...newValue ];
+
 			} else {
 
 				this[ key ] = newValue;


### PR DESCRIPTION
**Description**
Fixes array properties being assigned by reference in setValues(), now properly copying arrays to prevent mutations.

What was fixed:
- Fixed a bug where array properties in Material.setValues() were assigned by reference instead of being copied.

- This prevents unexpected mutations when arrays like iridescenceThicknessRange are passed to materials.

- The fix ensures array properties are properly cloned, consistent with how the copy() method handles arrays.