### PR TITLE
Add support for array uniform variants in ShaderMaterial serialization

### DIFF
--- a/src/loaders/MaterialLoader.js
+++ b/src/loaders/MaterialLoader.js
@@ -265,6 +265,31 @@ class MaterialLoader extends Loader {
 						material.uniforms[ name ].value = new Matrix4().fromArray( uniform.value );
 						break;
 
+					case 'tv':
+						// Array of textures
+						material.uniforms[ name ].value = uniform.value.map( uuid => getTexture( uuid ) );
+						break;
+
+					case 'v2v':
+						// Array of Vector2
+						material.uniforms[ name ].value = uniform.value.map( arr => new Vector2().fromArray( arr ) );
+						break;
+
+					case 'v3v':
+						// Array of Vector3
+						material.uniforms[ name ].value = uniform.value.map( arr => new Vector3().fromArray( arr ) );
+						break;
+
+					case 'v4v':
+						// Array of Vector4
+						material.uniforms[ name ].value = uniform.value.map( arr => new Vector4().fromArray( arr ) );
+						break;
+
+					case 'm4v':
+						// Array of Matrix4
+						material.uniforms[ name ].value = uniform.value.map( arr => new Matrix4().fromArray( arr ) );
+						break;
+
 					default:
 						material.uniforms[ name ].value = uniform.value;
 

--- a/src/materials/ShaderMaterial.js
+++ b/src/materials/ShaderMaterial.js
@@ -314,7 +314,107 @@ class ShaderMaterial extends Material {
 			const uniform = this.uniforms[ name ];
 			const value = uniform.value;
 
-			if ( value && value.isTexture ) {
+			// Check for array variants first
+			if ( Array.isArray( value ) ) {
+
+				if ( value.length === 0 ) {
+
+					// Empty array, serialize as-is
+					data.uniforms[ name ] = {
+						value: value
+					};
+
+					continue;
+
+				}
+
+				const firstElement = value[ 0 ];
+
+				if ( firstElement && firstElement.isTexture ) {
+
+					// Array of textures (tv)
+					const uuids = [];
+					for ( let i = 0; i < value.length; i ++ ) {
+
+						uuids.push( value[ i ].toJSON( meta ).uuid );
+
+					}
+
+					data.uniforms[ name ] = {
+						type: 'tv',
+						value: uuids
+					};
+
+				} else if ( firstElement && firstElement.isVector2 ) {
+
+					// Array of Vector2 (v2v)
+					const arrays = [];
+					for ( let i = 0; i < value.length; i ++ ) {
+
+						arrays.push( value[ i ].toArray() );
+
+					}
+
+					data.uniforms[ name ] = {
+						type: 'v2v',
+						value: arrays
+					};
+
+				} else if ( firstElement && firstElement.isVector3 ) {
+
+					// Array of Vector3 (v3v)
+					const arrays = [];
+					for ( let i = 0; i < value.length; i ++ ) {
+
+						arrays.push( value[ i ].toArray() );
+
+					}
+
+					data.uniforms[ name ] = {
+						type: 'v3v',
+						value: arrays
+					};
+
+				} else if ( firstElement && firstElement.isVector4 ) {
+
+					// Array of Vector4 (v4v)
+					const arrays = [];
+					for ( let i = 0; i < value.length; i ++ ) {
+
+						arrays.push( value[ i ].toArray() );
+
+					}
+
+					data.uniforms[ name ] = {
+						type: 'v4v',
+						value: arrays
+					};
+
+				} else if ( firstElement && firstElement.isMatrix4 ) {
+
+					// Array of Matrix4 (m4v)
+					const arrays = [];
+					for ( let i = 0; i < value.length; i ++ ) {
+
+						arrays.push( value[ i ].toArray() );
+
+					}
+
+					data.uniforms[ name ] = {
+						type: 'm4v',
+						value: arrays
+					};
+
+				} else {
+
+					// Unknown array type, serialize as-is
+					data.uniforms[ name ] = {
+						value: value
+					};
+
+				}
+
+			} else if ( value && value.isTexture ) {
 
 				data.uniforms[ name ] = {
 					type: 't',
@@ -368,8 +468,6 @@ class ShaderMaterial extends Material {
 				data.uniforms[ name ] = {
 					value: value
 				};
-
-				// note: the array variants v2v, v3v, v4v, m4v and tv are not supported so far
 
 			}
 


### PR DESCRIPTION
Description

This PR adds support for saving and loading array uniforms in ShaderMaterial.

What’s added

Serialization + deserialization for array types (v2v, v3v, v4v, m4v, tv)

Works even when the array is empty

Why

Before this, ShaderMaterial couldn’t handle array uniforms, so materials using texture arrays, vector arrays, or matrix arrays couldn’t be serialized or loaded correctly.

Changes

Updated ShaderMaterial.js to detect and serialize array values

Updated MaterialLoader.js to rebuild these arrays

Removed the old “not supported” comment