### PR TITLE
Fix: ShaderMaterial.copy() missing linewidth property

### DIFF
--- a/src/materials/ShaderMaterial.js
+++ b/src/materials/ShaderMaterial.js
@@ -283,6 +283,7 @@ class ShaderMaterial extends Material {
 
 		this.wireframe = source.wireframe;
 		this.wireframeLinewidth = source.wireframeLinewidth;
+		this.linewidth = source.linewidth;
 
 		this.fog = source.fog;
 		this.lights = source.lights;


### PR DESCRIPTION
## Description

The `copy` method in `ShaderMaterial` was missing the `linewidth` property that is defined in the constructor. When cloning a `ShaderMaterial` instance, this property was not copied to the new material, causing incorrect behavior when `linewidth` is set to a value other than the default.

## Changes

Fixed by ensuring `linewidth` is properly copied in the `copy` method of `ShaderMaterial`.

- Added `this.linewidth = source.linewidth;` to the `copy()` method in `src/materials/ShaderMaterial.js`

## Related

This follows the same pattern as the `allowOverride` fix in `Material.copy()` (see similar PRs). The `linewidth` property is already properly handled in `Material.toJSON()` for serialization, but was missing from the copy operation.

## Testing

When cloning a `ShaderMaterial` with a custom `linewidth` value, the cloned material now correctly preserves the `linewidth` property instead of reverting to the default value of `1`.