### PR TITLE
TSL: Add error handling for invalid shader code in FunctionNode

### DIFF
--- a/src/nodes/code/CodeNode.js
+++ b/src/nodes/code/CodeNode.js
@@ -115,12 +115,12 @@ class CodeNode extends Node {
 
 	serialize( data ) {
 
-    super.serialize( data );
+		super.serialize( data );
 
-    data.code = this.code;
-	data.language = this.language;
+		data.code = this.code;
+		data.language = this.language;
 
-    return data;
+    	return data;
 
 	}
 
@@ -135,9 +135,6 @@ class CodeNode extends Node {
 		return this;
 
 	}
-
-
-
 }
 
 export default CodeNode;

--- a/src/nodes/code/CodeNode.js
+++ b/src/nodes/code/CodeNode.js
@@ -124,7 +124,6 @@ class CodeNode extends Node {
 
 	}
 
-
 	deserialize( data ) {
 
 		super.deserialize( data );

--- a/src/nodes/code/CodeNode.js
+++ b/src/nodes/code/CodeNode.js
@@ -135,6 +135,7 @@ class CodeNode extends Node {
 		return this;
 
 	}
+	
 }
 
 export default CodeNode;

--- a/src/nodes/code/CodeNode.js
+++ b/src/nodes/code/CodeNode.js
@@ -135,7 +135,7 @@ class CodeNode extends Node {
 		return this;
 
 	}
-	
+
 }
 
 export default CodeNode;

--- a/src/nodes/code/CodeNode.js
+++ b/src/nodes/code/CodeNode.js
@@ -115,12 +115,15 @@ class CodeNode extends Node {
 
 	serialize( data ) {
 
-		super.serialize( data );
+    super.serialize( data );
 
-		data.code = this.code;
-		data.language = this.language;
+    data.code = this.code;
+	data.language = this.language;
+
+    return data;
 
 	}
+
 
 	deserialize( data ) {
 
@@ -128,8 +131,13 @@ class CodeNode extends Node {
 
 		this.code = data.code;
 		this.language = data.language;
+		this.includes = data.includes || [];
+
+		return this;
 
 	}
+
+
 
 }
 

--- a/src/nodes/code/FunctionNode.js
+++ b/src/nodes/code/FunctionNode.js
@@ -105,6 +105,14 @@ class FunctionNode extends CodeNode {
 
 			nodeFunction = builder.parser.parseFunction( this.code );
 
+			if ( ! nodeFunction ) {
+
+				throw new Error(
+					'TSL: Failed to parse function in FunctionNode. Check the shader syntax:\n' + this.code
+				);
+
+			}
+
 			nodeData.nodeFunction = nodeFunction;
 
 		}
@@ -112,6 +120,7 @@ class FunctionNode extends CodeNode {
 		return nodeFunction;
 
 	}
+
 
 	generate( builder, output ) {
 


### PR DESCRIPTION
Related issue: None

**Description**

This PR adds a missing error check inside `FunctionNode.getNodeFunction()`.  
When `builder.parser.parseFunction()` fails to parse the WGSL/GLSL shader
function, it returns `undefined`. This leads to unclear runtime errors later
in the node-building pipeline (e.g., accessing `.inputs`, `.type`, `.name` on
an undefined object).

By validating the parser result immediately and throwing a clear error
message, developers receive instant feedback about invalid shader code, making
TSL debugging significantly easier.

**What this PR changes**

- Adds a guard check after parsing a function:
  ```js
  if ( ! nodeFunction ) {
      throw new Error(
          'TSL: Failed to parse function in FunctionNode. Check the shader syntax:\n' + this.code
      );
  }

