### PR TITLE
TRAANode: Improve motion factor and disocclusion

### DIFF
--- a/examples/jsm/tsl/display/TRAANode.js
+++ b/examples/jsm/tsl/display/TRAANode.js
@@ -452,8 +452,8 @@ class TRAANode extends TempNode {
 			// higher velocity = more weight on current frame
 			// zero out history weight where disocclusion
 
-			const motionFactor = uvNode.sub( historyUV ).length().mul( 10 ).saturate();
-			const currentWeight = isDisocclusion.select( 1, float( 0.05 ).add( motionFactor ) ).toVar();
+			const motionFactor = uvNode.sub( historyUV ).length().mul( 10 );
+			const currentWeight = isDisocclusion.select( 1, float( 0.05 ).add( motionFactor ).saturate() ).toVar();
 			const historyWeight = currentWeight.oneMinus().toVar();
 
 			// flicker reduction based on luminance weighing

--- a/examples/jsm/tsl/display/TRAANode.js
+++ b/examples/jsm/tsl/display/TRAANode.js
@@ -92,7 +92,7 @@ class TRAANode extends TempNode {
 		this.depthThreshold = 0.0001;
 
 		/**
-		 * The difference between current and previous depth to consider a pixel as an edge.
+		 * The depth difference within the 3×3 neighborhood to consider a pixel as an edge.
 		 *
 		 * @type {number}
 		 */

--- a/examples/jsm/tsl/display/TRAANode.js
+++ b/examples/jsm/tsl/display/TRAANode.js
@@ -452,7 +452,7 @@ class TRAANode extends TempNode {
 			// higher velocity = more weight on current frame
 			// zero out history weight where disocclusion
 
-			const motionFactor = uvNode.sub( historyUV ).length().mul( 10 );
+			const motionFactor = uvNode.sub( historyUV ).length().mul( 10 ).saturate();
 			const currentWeight = isDisocclusion.select( 1, float( 0.05 ).add( motionFactor ) ).toVar();
 			const historyWeight = currentWeight.oneMinus().toVar();
 

--- a/examples/jsm/tsl/display/TRAANode.js
+++ b/examples/jsm/tsl/display/TRAANode.js
@@ -116,22 +116,6 @@ class TRAANode extends TempNode {
 		this._invSize = uniform( new Vector2() );
 
 		/**
-		 * A uniform node holding the previous frame's view matrix.
-		 *
-		 * @private
-		 * @type {UniformNode<mat4>}
-		 */
-		this._previousCameraWorldMatrix = uniform( new Matrix4() );
-
-		/**
-		 * A uniform node holding the previous frame's projection matrix inverse.
-		 *
-		 * @private
-		 * @type {UniformNode<mat4>}
-		 */
-		this._previousCameraProjectionMatrixInverse = uniform( new Matrix4() );
-
-		/**
 		 * The render target that represents the history of frame data.
 		 *
 		 * @private


### PR DESCRIPTION
Related: #31892

**Description**

This PR changes the motion factor and disocclusion to use UV and depth, so that the parameters can be adjusted more easily to the scene's scale. It also adds `depthThreshold` and `edgeDepthDiff` parameters.

Previously they are compared in world space, which is highly scene-dependent and makes it difficult to adjust parameters (and they are not exposed as parameters). Since the camera frustum is expected to cover the entire region of interest in the scene, we can just compare depths for more consistent results.

This is part of my attempt to improve the quality of TRAANode, and this PR alone doesn't improve the quality much.

I'll add comparison later.