### PR TITLE
TSL Transpiler: Support struct definitions and declarations

### DIFF
--- a/examples/jsm/transpiler/AST.js
+++ b/examples/jsm/transpiler/AST.js
@@ -109,11 +109,12 @@ export class Comment extends ASTNode {
 
 export class Program extends ASTNode {
 
-	constructor( body = [] ) {
+	constructor( body = [], userDefinedStructTypes = new Set() ) {
 
 		super();
 
 		this.body = body;
+		this.userDefinedStructTypes = userDefinedStructTypes;
 
 		this.isProgram = true;
 
@@ -125,7 +126,7 @@ export class Program extends ASTNode {
 
 export class VariableDeclaration extends ASTNode {
 
-	constructor( type, name, value = null, next = null, immutable = false, isUserDefinedStructType = false ) {
+	constructor( type, name, value = null, next = null, immutable = false ) {
 
 		super();
 
@@ -135,8 +136,6 @@ export class VariableDeclaration extends ASTNode {
 		this.next = next;
 
 		this.immutable = immutable;
-
-		this.isUserDefinedStructType = isUserDefinedStructType;
 
 		this.isVariableDeclaration = true;
 

--- a/examples/jsm/transpiler/AST.js
+++ b/examples/jsm/transpiler/AST.js
@@ -629,3 +629,32 @@ export class SwitchCase extends ASTNode {
 	}
 
 }
+
+// helper class for StructDefinition
+export class StructMember {
+
+	constructor( type, name ) {
+
+		this.type = type;
+		this.name = name;
+		this.isStructMember = true;
+
+	}
+
+}
+
+export class StructDefinition extends ASTNode {
+
+	constructor( name, members = [] ) {
+
+		super();
+
+		this.name = name;
+		this.members = members;
+		this.isStructDefinition = true;
+
+		this.initialize();
+
+	}
+
+}

--- a/examples/jsm/transpiler/AST.js
+++ b/examples/jsm/transpiler/AST.js
@@ -46,6 +46,20 @@ export class ASTNode {
 
 	}
 
+	getProgram() {
+
+		let current = this;
+
+		while ( current.parent !== null ) {
+
+			current = current.parent;
+
+		}
+
+		return current;
+
+	}
+
 	getParent( parents = [] ) {
 
 		if ( this.parent === null ) {
@@ -109,12 +123,12 @@ export class Comment extends ASTNode {
 
 export class Program extends ASTNode {
 
-	constructor( body = [], userDefinedStructTypes = new Map() ) {
+	constructor( body = [] ) {
 
 		super();
 
 		this.body = body;
-		this.userDefinedStructTypes = userDefinedStructTypes;
+		this.structTypes = new Map();
 
 		this.isProgram = true;
 

--- a/examples/jsm/transpiler/AST.js
+++ b/examples/jsm/transpiler/AST.js
@@ -56,7 +56,7 @@ export class ASTNode {
 
 		}
 
-		return current && current.isProgram === true ? current : null;
+		return current.isProgram === true ? current : null;
 
 	}
 

--- a/examples/jsm/transpiler/AST.js
+++ b/examples/jsm/transpiler/AST.js
@@ -109,7 +109,7 @@ export class Comment extends ASTNode {
 
 export class Program extends ASTNode {
 
-	constructor( body = [], userDefinedStructTypes = new Set() ) {
+	constructor( body = [], userDefinedStructTypes = new Map() ) {
 
 		super();
 

--- a/examples/jsm/transpiler/AST.js
+++ b/examples/jsm/transpiler/AST.js
@@ -125,7 +125,7 @@ export class Program extends ASTNode {
 
 export class VariableDeclaration extends ASTNode {
 
-	constructor( type, name, value = null, next = null, immutable = false ) {
+	constructor( type, name, value = null, next = null, immutable = false, isUserDefinedStructType = false ) {
 
 		super();
 
@@ -135,6 +135,8 @@ export class VariableDeclaration extends ASTNode {
 		this.next = next;
 
 		this.immutable = immutable;
+
+		this.isUserDefinedStructType = isUserDefinedStructType;
 
 		this.isVariableDeclaration = true;
 

--- a/examples/jsm/transpiler/AST.js
+++ b/examples/jsm/transpiler/AST.js
@@ -56,7 +56,7 @@ export class ASTNode {
 
 		}
 
-		return current;
+		return current && current.isProgram === true ? current : null;
 
 	}
 

--- a/examples/jsm/transpiler/GLSLDecoder.js
+++ b/examples/jsm/transpiler/GLSLDecoder.js
@@ -255,7 +255,7 @@ class GLSLDecoder {
 		this.index = 0;
 		this.tokenizer = null;
 		this.keywords = [];
-		this.userDefinedStructTypes = new Map();
+		this.structTypes = new Map();
 
 		this.addPolyfill( 'gl_FragCoord', 'vec3 gl_FragCoord = vec3( screenCoordinate.x, screenCoordinate.y.oneMinus(), screenCoordinate.z );' );
 
@@ -823,7 +823,7 @@ class GLSLDecoder {
 		}
 
 		const definition = new StructDefinition( structName, structMembers );
-		this.userDefinedStructTypes.set( structName, definition );
+		this.structTypes.set( structName, definition );
 
 		return definition;
 
@@ -877,7 +877,8 @@ class GLSLDecoder {
 		let initialization;
 
 		const firstToken = initializationTokens[ 0 ];
-		if ( firstToken && ( isBuiltinType( firstToken.str ) || this.userDefinedStructTypes.has( firstToken.str ) ) ) {
+
+		if ( firstToken && ( isBuiltinType( firstToken.str ) || this.structTypes.has( firstToken.str ) ) ) {
 
 			initialization = this.parseVariablesFromToken( initializationTokens );
 
@@ -1133,7 +1134,7 @@ class GLSLDecoder {
 
 					statement = this.parseStructDefinition();
 
-				} else if ( isBuiltinType( token.str ) || this.userDefinedStructTypes.has( token.str ) ) {
+				} else if ( isBuiltinType( token.str ) || this.structTypes.has( token.str ) ) {
 
 					if ( this.getToken( 2 ).str === '(' ) {
 
@@ -1213,7 +1214,9 @@ class GLSLDecoder {
 		this.tokenizer = new Tokenizer( polyfill + source ).tokenize();
 
 		const body = this.parseBlock();
-		const program = new Program( body, this.userDefinedStructTypes );
+
+		const program = new Program( body );
+		program.structTypes = this.structTypes;
 
 		return program;
 

--- a/examples/jsm/transpiler/ShaderToyDecoder.js
+++ b/examples/jsm/transpiler/ShaderToyDecoder.js
@@ -38,6 +38,8 @@ class ShaderToyDecoder extends GLSLDecoder {
 			node.body.unshift( new VariableDeclaration( 'vec4', 'fragColor' ) );
 			node.body.push( new Return( fragColor ) );
 
+			node.initialize();
+
 		}
 
 		return node;

--- a/examples/jsm/transpiler/TSLEncoder.js
+++ b/examples/jsm/transpiler/TSLEncoder.js
@@ -56,6 +56,7 @@ class TSLEncoder {
 		this.imports = new Set();
 		this.global = new Set();
 		this.overloadings = new Map();
+		this.userDefinedStructTypes = new Map();
 		this.iife = false;
 		this.reference = false;
 
@@ -673,9 +674,9 @@ ${ this.tab }} )`;
 
 		} else {
 
-			if ( node.isUserDefinedStructType ) {
+			if ( this.userDefinedStructTypes.has( type ) ) {
 
-				varStr += ` = ${type}()`;
+				varStr += ` = ${ type }()`;
 
 			} else {
 
@@ -923,6 +924,8 @@ ${ this.tab }}`;
 			}
 
 		}
+
+		this.userDefinedStructTypes = ast.userDefinedStructTypes;
 
 		for ( const statement of ast.body ) {
 

--- a/examples/jsm/transpiler/TSLEncoder.js
+++ b/examples/jsm/transpiler/TSLEncoder.js
@@ -314,6 +314,10 @@ class TSLEncoder {
 
 			code = this.emitVarying( node );
 
+		} else if ( node.isStructDefinition ) {
+
+			code = this.emitStructDefinition( node );
+
 		} else if ( node.isTernary ) {
 
 			code = this.emitTernary( node );
@@ -699,6 +703,31 @@ ${ this.tab }} )`;
 		this.addImport( type );
 
 		return `const ${ name } = varying( ${ type }(), '${ name }' )`;
+
+	}
+
+	emitStructDefinition( node ) {
+
+		const { name, members } = node;
+
+		this.addImport( 'struct' );
+
+		let structString = `const ${ name } = struct({\n\n`;
+
+		for ( let i = 0; i < members.length; i += 1 ) {
+
+			const member = members[i];
+
+			structString += `${this.tab}\t${member.name}: '${member.type}'`;
+
+			const delimiter = (i != members.length - 1) ? ',\n' : '\n';
+			structString += delimiter;
+
+		}
+
+		structString += `\n${this.tab}}, \'${name}\' )`;
+
+		return structString;
 
 	}
 

--- a/examples/jsm/transpiler/TSLEncoder.js
+++ b/examples/jsm/transpiler/TSLEncoder.js
@@ -728,8 +728,11 @@ ${ this.tab }} )`;
 
 			structString += `${this.tab}\t${member.name}: '${member.type}'`;
 
-			const delimiter = ( i != members.length - 1 ) ? ',\n' : '';
-			structString += delimiter;
+			if ( i != members.length - 1 ) {
+
+				structString += ',\n';
+
+			}
 
 		}
 

--- a/examples/jsm/transpiler/TSLEncoder.js
+++ b/examples/jsm/transpiler/TSLEncoder.js
@@ -56,7 +56,6 @@ class TSLEncoder {
 		this.imports = new Set();
 		this.global = new Set();
 		this.overloadings = new Map();
-		this.userDefinedStructTypes = new Map();
 		this.iife = false;
 		this.reference = false;
 
@@ -674,7 +673,7 @@ ${ this.tab }} )`;
 
 		} else {
 
-			if ( this.userDefinedStructTypes.has( type ) ) {
+			if ( node.getProgram().structTypes.has( type ) ) {
 
 				varStr += ` = ${ type }()`;
 
@@ -721,7 +720,7 @@ ${ this.tab }} )`;
 
 		this.addImport( 'struct' );
 
-		let structString = `const ${ name } = struct({\n\n`;
+		let structString = `const ${ name } = struct( {\n`;
 
 		for ( let i = 0; i < members.length; i += 1 ) {
 
@@ -729,7 +728,7 @@ ${ this.tab }} )`;
 
 			structString += `${this.tab}\t${member.name}: '${member.type}'`;
 
-			const delimiter = ( i != members.length - 1 ) ? ',\n' : '\n';
+			const delimiter = ( i != members.length - 1 ) ? ',\n' : '';
 			structString += delimiter;
 
 		}
@@ -924,8 +923,6 @@ ${ this.tab }}`;
 			}
 
 		}
-
-		this.userDefinedStructTypes = ast.userDefinedStructTypes;
 
 		for ( const statement of ast.body ) {
 

--- a/examples/jsm/transpiler/TSLEncoder.js
+++ b/examples/jsm/transpiler/TSLEncoder.js
@@ -725,11 +725,11 @@ ${ this.tab }} )`;
 
 		for ( let i = 0; i < members.length; i += 1 ) {
 
-			const member = members[i];
+			const member = members[ i ];
 
 			structString += `${this.tab}\t${member.name}: '${member.type}'`;
 
-			const delimiter = (i != members.length - 1) ? ',\n' : '\n';
+			const delimiter = ( i != members.length - 1 ) ? ',\n' : '\n';
 			structString += delimiter;
 
 		}

--- a/examples/jsm/transpiler/TSLEncoder.js
+++ b/examples/jsm/transpiler/TSLEncoder.js
@@ -673,7 +673,9 @@ ${ this.tab }} )`;
 
 		} else {
 
-			if ( node.getProgram().structTypes.has( type ) ) {
+			const program = node.getProgram();
+
+			if ( program && program.structTypes.has( type ) ) {
 
 				varStr += ` = ${ type }()`;
 

--- a/examples/jsm/transpiler/TSLEncoder.js
+++ b/examples/jsm/transpiler/TSLEncoder.js
@@ -675,7 +675,7 @@ ${ this.tab }} )`;
 
 			const program = node.getProgram();
 
-			if ( program && program.structTypes.has( type ) ) {
+			if ( program.structTypes.has( type ) ) {
 
 				varStr += ` = ${ type }()`;
 

--- a/examples/jsm/transpiler/TSLEncoder.js
+++ b/examples/jsm/transpiler/TSLEncoder.js
@@ -673,9 +673,17 @@ ${ this.tab }} )`;
 
 		} else {
 
-			varStr += ` = property( '${ type }' )`;
+			if ( node.isUserDefinedStructType ) {
 
-			this.addImport( 'property' );
+				varStr += ` = ${type}()`;
+
+			} else {
+
+				varStr += ` = property( '${ type }' )`;
+
+				this.addImport( 'property' );
+
+			}
 
 		}
 

--- a/examples/jsm/transpiler/TranspilerUtils.js
+++ b/examples/jsm/transpiler/TranspilerUtils.js
@@ -10,9 +10,9 @@ export function isPrimitive( value ) {
 
 }
 
-export function isType( str ) {
+export function isBuiltinType( str ) {
 
-	return /void|bool|float|u?int|mat[234]|mat[234]x[234]|(u|i|b)?vec[234]/.test( str );
+	return /^(void|bool|float|u?int|mat[234]|mat[234]x[234]|(u|i|b)?vec[234])$/.test( str );
 
 }
 

--- a/examples/jsm/transpiler/TranspilerUtils.js
+++ b/examples/jsm/transpiler/TranspilerUtils.js
@@ -1,6 +1,6 @@
 export function isExpression( st ) {
 
-	return st.isFunctionDeclaration !== true && st.isFor !== true && st.isWhile !== true && st.isConditional !== true && st.isSwitch !== true;
+	return st.isFunctionDeclaration !== true && st.isFor !== true && st.isWhile !== true && st.isConditional !== true && st.isSwitch !== true && st.isStructDefinition !== true;
 
 }
 

--- a/examples/jsm/transpiler/WGSLEncoder.js
+++ b/examples/jsm/transpiler/WGSLEncoder.js
@@ -300,6 +300,10 @@ class WGSLEncoder {
 			this.varyings.push( node );
 			return ''; // Defer emission to the header
 
+		} else if ( node.isStructDefinition ) {
+
+			code = this.emitStructDefinition( node );
+
 		} else if ( node.isTernary ) {
 
 			const cond = this.emitExpression( node.cond );
@@ -581,6 +585,29 @@ class WGSLEncoder {
 
 		// In WGSL, multiple declarations in one line are not supported, so join with semicolons.
 		return declarations.join( ';\n' + this.tab );
+
+	}
+
+	emitStructDefinition( node ) {
+
+		const { name, members } = node;
+
+		let structString = `struct ${ name } {\n`;
+
+		for ( let i = 0; i < members.length; i += 1 ) {
+
+			const member = members[ i ];
+
+			structString += `${ this.tab }\t${ member.name }: ${ this.getWgslType( member.type ) }`;
+
+			const delimiter = ( i != members.length - 1 ) ? ',\n' : '\n';
+			structString += delimiter;
+
+		}
+
+		structString += this.tab + '}';
+
+		return structString;
 
 	}
 


### PR DESCRIPTION
Related issue: #30885

**Description**

This PR adds support for struct definitions/declarations to the TSL transpiler.

**Examples**

Struct definitions:
```glsl
struct Ray {
  vec3 origin;
  vec3 direction;
};
```
```js
const Ray = struct({

	origin: 'vec3',
	direction: 'vec3'

}, 'Ray' );
```
Struct Declarations:
```glsl
Ray r = Ray(vec3(0.0), vec3(0.0, 0.0, 1.0));
```
```javascript
const r = Ray( vec3( 0.0 ), vec3( 0.0, 0.0, 1.0 ) );
```
Return Values / Input parameters:
```glsl
// struct RaymarchResult { ... }

RaymarchResult raymarch(Ray r) {
	return RaymarchResult(vec3(0.0), 1.0);
}
```
```javascript
export const raymarch = /*@__PURE__*/ Fn( ( [ r ] ) => {

	return RaymarchResult( vec3( 0.0 ), 1.0 );

}, { r: 'Ray', return: 'RaymarchResult' } );
```

**Limitations**

1. Struct members can't be properly accessed. Currently, if a struct member is accessed, the transpiler will generate `.member` instead of `.get("member")`. In order to do this properly, the transpiler would need proper type resolution. Some type information is available in the linker, but this won't work in the general case.

2. As far as I can tell (and I'm okay being corrected on this), TSL doesn't support structs with array/struct members, so this PR doesn't add support for them.

Despite these limitations, this feature still helps with the discoverability of struct syntax in TSL