### PR TITLE
Source: Guard reference to `VideoFrame`.

### DIFF
--- a/src/textures/Source.js
+++ b/src/textures/Source.js
@@ -88,7 +88,7 @@ class Source {
 
 			target.set( data.videoWidth, data.videoHeight, 0 );
 
-		} else if ( data instanceof VideoFrame ) {
+		} else if ( ( typeof VideoFrame !== 'undefined' ) && ( data instanceof VideoFrame ) ) {
 
 			target.set( data.displayHeight, data.displayWidth, 0 );
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/31862#issuecomment-3546316373

**Description**

Applies the same fix from #31864 to the `Source` class.
