### PR TITLE
PMREMGenerator: Fix black HDRIs when processing textures of different sizes

### DIFF
--- a/src/extras/PMREMGenerator.js
+++ b/src/extras/PMREMGenerator.js
@@ -314,6 +314,7 @@ class PMREMGenerator {
 			( { lodMeshes: this._lodMeshes, sizeLods: this._sizeLods, sigmas: this._sigmas } = _createPlanes( _lodMax ) );
 
 			this._blurMaterial = _getBlurShader( _lodMax, width, height );
+			this._ggxMaterial = _getGGXShader( _lodMax, width, height );
 
 		}
 
@@ -518,14 +519,6 @@ class PMREMGenerator {
 
 		const renderer = this._renderer;
 		const pingPongRenderTarget = this._pingPongRenderTarget;
-
-		if ( this._ggxMaterial === null ) {
-
-			const width = 3 * Math.max( this._cubeSize, 16 );
-			const height = 4 * this._cubeSize;
-			this._ggxMaterial = _getGGXShader( this._lodMax, width, height );
-
-		}
 
 		const ggxMaterial = this._ggxMaterial;
 		const ggxMesh = this._lodMeshes[ lodOut ];

--- a/src/renderers/common/extras/PMREMGenerator.js
+++ b/src/renderers/common/extras/PMREMGenerator.js
@@ -459,6 +459,7 @@ class PMREMGenerator {
 			( { lodMeshes: this._lodMeshes, sizeLods: this._sizeLods, sigmas: this._sigmas } = _createPlanes( _lodMax ) );
 
 			this._blurMaterial = _getBlurShader( _lodMax, renderTarget.width, renderTarget.height );
+			this._ggxMaterial = _getGGXShader( _lodMax, renderTarget.width, renderTarget.height );
 
 		}
 
@@ -649,13 +650,6 @@ class PMREMGenerator {
 
 		const renderer = this._renderer;
 		const pingPongRenderTarget = this._pingPongRenderTarget;
-
-		// Lazy create GGX material only when first used
-		if ( this._ggxMaterial === null ) {
-
-			this._ggxMaterial = _getGGXShader( this._lodMax, this._pingPongRenderTarget.width, this._pingPongRenderTarget.height );
-
-		}
 
 		const ggxMaterial = this._ggxMaterial;
 		const ggxMesh = this._lodMeshes[ lodOut ];


### PR DESCRIPTION
Related issue: #32304

**Description** 

Fixes black HDRIs when processing multiple environment maps of different dimensions. The `_ggxMaterial` shader was created once with hardcoded defines based on the first HDRI's size, causing incorrect sampling for subsequent HDRIs.

**Solution**

Recreate `_ggxMaterial` when texture dimensions change (matching how `_blurMaterial` is already handled) to ensure shader defines always match the current HDRI size.

**Changes**

* Move `_ggxMaterial` initialization from lazy creation to proper allocation (WebGL & WebGPU)
* Ensures correct `CUBEUV_TEXEL_WIDTH/HEIGHT` and `CUBEUV_MAX_MIP` defines for each HDRI

(Made using https://antigravity.google/ with Claude Sonnet 4.5)