### PR TITLE
Docs: Fix Safari scrolling to anchors in iframes.

### DIFF
--- a/utils/docs/template/static/scripts/page.js
+++ b/utils/docs/template/static/scripts/page.js
@@ -43,7 +43,7 @@ if ( typeof hljs !== 'undefined' ) {
 
 					element.scrollIntoView();
 
-				}, 100 );
+				}, 250 );
 
 			} else {
 

--- a/utils/docs/template/static/scripts/page.js
+++ b/utils/docs/template/static/scripts/page.js
@@ -32,7 +32,26 @@ if ( typeof hljs !== 'undefined' ) {
 
 		const element = document.getElementById( hash );
 
-		if ( element ) element.scrollIntoView();
+		if ( element ) {
+
+			// Safari needs a small delay for iframe scrolling
+			const isSafari = /^((?!chrome|android).)*safari/i.test( navigator.userAgent );
+
+			if ( isSafari ) {
+
+				setTimeout( function () {
+
+					element.scrollIntoView();
+
+				}, 100 );
+
+			} else {
+
+				element.scrollIntoView();
+
+			}
+
+		}
 
 	}
 


### PR DESCRIPTION
Related issue: #32302

**Description**

Fixes an issue where clicking on navigation links in Safari would not scroll to the correct position within the documentation iframe.

The problem occurred because Safari needs additional time to complete iframe layout before scrollIntoView can accurately position the target element. This was only noticeable when navigating via clicks - direct page loads with hash fragments worked fine due to browser's native hash handling.

The fix adds Safari-specific detection and applies a 100ms delay before scrolling, giving Safari time to properly lay out the iframe content.