### PR TITLE
WebGPURenderer: Fix textured backgrounds with ortho cameras.

### DIFF
--- a/src/renderers/common/Background.js
+++ b/src/renderers/common/Background.js
@@ -1,12 +1,11 @@
 import DataMap from './DataMap.js';
 import Color4 from './Color4.js';
-import { vec4, context, normalWorldGeometry, backgroundBlurriness, backgroundIntensity, backgroundRotation, modelViewProjection, positionLocal, cameraProjectionMatrix, modelViewMatrix, div } from '../../nodes/TSL.js';
+import { vec4, context, normalWorldGeometry, backgroundBlurriness, backgroundIntensity, backgroundRotation, positionLocal, cameraProjectionMatrix, modelViewMatrix, div } from '../../nodes/TSL.js';
 import NodeMaterial from '../../materials/nodes/NodeMaterial.js';
 
 import { Mesh } from '../../objects/Mesh.js';
-import { PlaneGeometry } from '../../geometries/PlaneGeometry.js';
 import { SphereGeometry } from '../../geometries/SphereGeometry.js';
-import { BackSide, FrontSide } from '../../constants.js';
+import { BackSide } from '../../constants.js';
 import { error } from '../../utils.js';
 
 const _clearColor = /*@__PURE__*/ new Color4();
@@ -125,7 +124,6 @@ class Background extends DataMap {
 
 				sceneData.backgroundMeshNode = backgroundMeshNode;
 				sceneData.backgroundMesh = backgroundMesh = new Mesh( new SphereGeometry( 1, 32, 32 ), nodeMaterial );
-
 				backgroundMesh.frustumCulled = false;
 				backgroundMesh.name = 'Background.mesh';
 

--- a/src/renderers/common/Background.js
+++ b/src/renderers/common/Background.js
@@ -94,13 +94,13 @@ class Background extends DataMap {
 					getTextureLevel: () => backgroundBlurriness
 				} );
 
-				// when using orthographic cameras, we must scale the sphere
+				// when using orthographic cameras, we must scale the skybox sphere
 				// up to exceed the dimensions of the camera's viewing box.
 				const isOrtho = cameraProjectionMatrix.element( 3 ).element( 3 ).equal( 1.0 );
 
 				// calculate the orthographic scale
 				// projectionMatrix[1][1] is (1 / top). Invert it to get the height and multiply by 3.0
-				// (an arbitrary safety factor) to ensure the Sphere is large enough to cover the corners
+				// (an arbitrary safety factor) to ensure the skybox is large enough to cover the corners
 				// of the rectangular screen
 				const orthoScale = div( 1.0, cameraProjectionMatrix.element( 1 ).element( 1 ) ).mul( 3.0 );
 
@@ -108,7 +108,7 @@ class Background extends DataMap {
 				const modifiedPosition = isOrtho.select( positionLocal.mul( orthoScale ), positionLocal );
 				let viewProj = cameraProjectionMatrix.mul( modelViewMatrix.mul( vec4( modifiedPosition, 1.0 ) ) );
 
-				// forces background to far plane
+				// force background to far plane so it does not occlude objects
 				viewProj = viewProj.setZ( viewProj.w );
 
 				const nodeMaterial = new NodeMaterial();

--- a/src/renderers/common/Background.js
+++ b/src/renderers/common/Background.js
@@ -1,11 +1,12 @@
 import DataMap from './DataMap.js';
 import Color4 from './Color4.js';
-import { vec4, context, normalWorldGeometry, backgroundBlurriness, backgroundIntensity, backgroundRotation, modelViewProjection } from '../../nodes/TSL.js';
+import { vec4, context, normalWorldGeometry, backgroundBlurriness, backgroundIntensity, backgroundRotation, modelViewProjection, positionLocal } from '../../nodes/TSL.js';
 import NodeMaterial from '../../materials/nodes/NodeMaterial.js';
 
 import { Mesh } from '../../objects/Mesh.js';
+import { PlaneGeometry } from '../../geometries/PlaneGeometry.js';
 import { SphereGeometry } from '../../geometries/SphereGeometry.js';
-import { BackSide } from '../../constants.js';
+import { BackSide, FrontSide } from '../../constants.js';
 import { error } from '../../utils.js';
 
 const _clearColor = /*@__PURE__*/ new Color4();
@@ -94,22 +95,37 @@ class Background extends DataMap {
 					getTextureLevel: () => backgroundBlurriness
 				} );
 
-				let viewProj = modelViewProjection;
-				viewProj = viewProj.setZ( viewProj.w );
-
 				const nodeMaterial = new NodeMaterial();
 				nodeMaterial.name = 'Background.material';
-				nodeMaterial.side = BackSide;
 				nodeMaterial.depthTest = false;
 				nodeMaterial.depthWrite = false;
 				nodeMaterial.allowOverride = false;
 				nodeMaterial.fog = false;
 				nodeMaterial.lights = false;
-				nodeMaterial.vertexNode = viewProj;
 				nodeMaterial.colorNode = backgroundMeshNode;
 
+				if ( background.isEnvironmentMapNode === true ) {
+
+					let viewProj = modelViewProjection;
+					viewProj = viewProj.setZ( viewProj.w );
+
+					nodeMaterial.side = BackSide;
+					nodeMaterial.vertexNode = viewProj;
+
+					backgroundMesh = new Mesh( new SphereGeometry( 1, 32, 32 ), nodeMaterial );
+
+				} else {
+
+					nodeMaterial.side = FrontSide;
+					nodeMaterial.vertexNode = vec4( positionLocal.xy, 1, 1 );
+
+					backgroundMesh = new Mesh( new PlaneGeometry( 2, 2 ), nodeMaterial );
+
+				}
+
+				sceneData.backgroundMesh = backgroundMesh;
 				sceneData.backgroundMeshNode = backgroundMeshNode;
-				sceneData.backgroundMesh = backgroundMesh = new Mesh( new SphereGeometry( 1, 32, 32 ), nodeMaterial );
+
 				backgroundMesh.frustumCulled = false;
 				backgroundMesh.name = 'Background.mesh';
 

--- a/src/renderers/common/nodes/Nodes.js
+++ b/src/renderers/common/nodes/Nodes.js
@@ -483,11 +483,9 @@ class Nodes extends DataMap {
 
 					if ( background.isCubeTexture === true || ( background.mapping === EquirectangularReflectionMapping || background.mapping === EquirectangularRefractionMapping || background.mapping === CubeUVReflectionMapping ) ) {
 
-						let node;
-
 						if ( scene.backgroundBlurriness > 0 || background.mapping === CubeUVReflectionMapping ) {
 
-							node = pmremTexture( background );
+							return pmremTexture( background );
 
 						} else {
 
@@ -503,13 +501,9 @@ class Nodes extends DataMap {
 
 							}
 
-							node = cubeMapNode( envMap );
+							return cubeMapNode( envMap );
 
 						}
-
-						node.isEnvironmentMapNode = true;
-
-						return node;
 
 					} else if ( background.isTexture === true ) {
 

--- a/src/renderers/common/nodes/Nodes.js
+++ b/src/renderers/common/nodes/Nodes.js
@@ -483,9 +483,11 @@ class Nodes extends DataMap {
 
 					if ( background.isCubeTexture === true || ( background.mapping === EquirectangularReflectionMapping || background.mapping === EquirectangularRefractionMapping || background.mapping === CubeUVReflectionMapping ) ) {
 
+						let node;
+
 						if ( scene.backgroundBlurriness > 0 || background.mapping === CubeUVReflectionMapping ) {
 
-							return pmremTexture( background );
+							node = pmremTexture( background );
 
 						} else {
 
@@ -501,9 +503,13 @@ class Nodes extends DataMap {
 
 							}
 
-							return cubeMapNode( envMap );
+							node = cubeMapNode( envMap );
 
 						}
+
+						node.isEnvironmentMapNode = true;
+
+						return node;
 
 					} else if ( background.isTexture === true ) {
 


### PR DESCRIPTION
Related issue: https://discourse.threejs.org/t/issue-with-webgpu-orthographic-camera-scene-background-texture/88190

**Description**

A user in the forum reported an issue that (flat) textured backgrounds do not work with orthographic cameras.

For reproduction: https://jsfiddle.net/3Lwgv08s/1/

I have fixed the issue by setting up a different material and background mesh configuration for environment maps/skyboxes or flat textures. This is the same approach we use in `WebGLRenderer` as well.