### PR TITLE
docs: fix Safari hash (TSL.* → id) for TSL documentation

### DIFF
--- a/docs/pages/TSL.html
+++ b/docs/pages/TSL.html
@@ -12092,6 +12092,17 @@ complete before the barrier can be surpassed.</p>
 					</div>
 			</article>
 		</section>
+ <script>
+        (function() {
+            // Safari bug: hashes like "#TSL.Break" don't match element ids like "Break"
+            const rawHash = location.hash.slice(1);
+            if (rawHash.includes('.')) {
+                const id = rawHash.split('.').pop();
+                const el = document.getElementById(id);
+                if (el) el.scrollIntoView();
+            }
+        })();
+</script>
 <script src="../scripts/linenumber.js"></script>
 <script src="../scripts/page.js"></script>
 </body>


### PR DESCRIPTION
Related issue:  Docs: Links in navigation sidebar do not work for some sections #32302


I’m looking at the Three.js documentation here:
In the navigation sidebar, some sections — I specifically noticed TSL and Global — contain links that point to anchors which do not exist. This makes the navigation sidebar unusable in these sections.

For example, the first entry under the TSL section is rendered as:

```
<li>
  <a href="pages/TSL.html#Break" target="viewer" class="selected">Break</a>
</li>
```

However, when clicking this link in Safari, the browser rewrites the URL to:
https://threejs.org/docs/#TSL.Break

This is problematic because the actual method heading has the following markup:

```
<h3 class="name name-method" id="Break" translate="no">
  .<a href="#Break">Break</a>
  <span class="signature">()</span>
  <span class="type-signature"> : <a href="ExpressionNode.html">ExpressionNode</a></span>
</h3>

```

The element has id="Break", not id="TSL.Break", so Safari cannot jump to the correct section. As a result, all links in the TSL (and some other sections) fail to navigate properly.

Resolved this by fixing hasing in script tag 

This issue appears only in Safari — Chromium-based browsers do not rewrite the hash.