### PR TITLE
TRAANode: Replace MSAA sample pattern with Halton sequence

### DIFF
--- a/examples/jsm/tsl/display/TRAANode.js
+++ b/examples/jsm/tsl/display/TRAANode.js
@@ -247,13 +247,13 @@ class TRAANode extends TempNode {
 
 		};
 
-		const jitterOffset = _JitterVectors[ this._jitterIndex ];
+		const jitterOffset = _haltonOffsets[ this._jitterIndex ];
 
 		this.camera.setViewOffset(
 
 			viewOffset.fullWidth, viewOffset.fullHeight,
 
-			viewOffset.offsetX + jitterOffset[ 0 ] * 0.0625, viewOffset.offsetY + jitterOffset[ 1 ] * 0.0625, // 0.0625 = 1 / 16
+			viewOffset.offsetX + jitterOffset[ 0 ] - 0.5, viewOffset.offsetY + jitterOffset[ 1 ] - 0.5,
 
 			viewOffset.width, viewOffset.height
 
@@ -273,7 +273,7 @@ class TRAANode extends TempNode {
 		// update jitter index
 
 		this._jitterIndex ++;
-		this._jitterIndex = this._jitterIndex % ( _JitterVectors.length - 1 );
+		this._jitterIndex = this._jitterIndex % ( _haltonOffsets.length - 1 );
 
 	}
 
@@ -548,21 +548,26 @@ class TRAANode extends TempNode {
 
 export default TRAANode;
 
-// These jitter vectors are specified in integers because it is easier.
-// I am assuming a [-8,8) integer grid, but it needs to be mapped onto [-0.5,0.5)
-// before being used, thus these integers need to be scaled by 1/16.
-//
-// Sample patterns reference: https://msdn.microsoft.com/en-us/library/windows/desktop/ff476218%28v=vs.85%29.aspx?f=255&MSPPError=-2147217396
-const _JitterVectors = [
-	[ - 4, - 7 ], [ - 7, - 5 ], [ - 3, - 5 ], [ - 5, - 4 ],
-	[ - 1, - 4 ], [ - 2, - 2 ], [ - 6, - 1 ], [ - 4, 0 ],
-	[ - 7, 1 ], [ - 1, 2 ], [ - 6, 3 ], [ - 3, 3 ],
-	[ - 7, 6 ], [ - 3, 6 ], [ - 5, 7 ], [ - 1, 7 ],
-	[ 5, - 7 ], [ 1, - 6 ], [ 6, - 5 ], [ 4, - 4 ],
-	[ 2, - 3 ], [ 7, - 2 ], [ 1, - 1 ], [ 4, - 1 ],
-	[ 2, 1 ], [ 6, 2 ], [ 0, 4 ], [ 4, 4 ],
-	[ 2, 5 ], [ 7, 5 ], [ 5, 6 ], [ 3, 7 ]
-];
+function _halton( index, base ) {
+
+	let fraction = 1;
+	let result = 0;
+	while ( index > 0 ) {
+
+		fraction /= base;
+		result += fraction * ( index % base );
+		index = Math.floor( index / base );
+
+	}
+
+	return result;
+
+}
+
+const _haltonOffsets = /*@__PURE__*/ Array.from(
+	{ length: 32 },
+	( _, index ) => [ _halton( index + 1, 2 ), _halton( index + 1, 3 ) ]
+);
 
 /**
  * TSL function for creating a TRAA node for Temporal Reprojection Anti-Aliasing.


### PR DESCRIPTION
Related: https://github.com/mrdoob/three.js/issues/31892#issuecomment-3541047189

**Description**

This PR replaces MSAA sample pattern used in TRAANode with a Halton sequence.

MSAA sample pattern is carefully constructed to maximize spatial information, but it doesn't take temporal discrepancy into account. Drawing the sample positions from first (white) to last (black) shows a roughly diagonal (or N-shaped) correlation, which repeatedly shifts the whole image by 1px at a low frequency. This only happens within subpixel level, so it's not a big problem, but it becomes noticeable when zoomed in, and it can also make temporal filtering less effective.

| MSAA sample pattern used in r181 | Halton sequence (2, 3) |
|-|-|
| <img width="100%" alt="image" src="https://github.com/user-attachments/assets/3a021c5a-eaab-46e3-b289-ac918d576b7a" /> | <img width="100%" alt="image" src="https://github.com/user-attachments/assets/a84dd75d-982a-42ea-a9bb-69146e19f3cf" /> |

Below is a comparison. Note that the MSAA sample pattern renders smoother subpixel gradients because it's spatially well-distributed.

| r181 | PR |
|-|-|
|<video src="https://github.com/user-attachments/assets/7b7200b3-6cc4-4c75-9ee3-37c218bbe288" width="100%" />|<video src="https://github.com/user-attachments/assets/b72e39bc-ad15-4d2a-bab7-25a84e5022a6" width="100%" />|
|<video src="https://github.com/user-attachments/assets/7d54d44c-33ef-44ce-a62d-a23a66bd7bc5" width="100%" />|<video src="https://github.com/user-attachments/assets/8bf0bcf5-9004-4c11-be0b-b5cceb9902b9" width="100%" />|
