### PR TITLE
Update default texture anisotropy value from 0 to 1

### DIFF
--- a/docs/pages/Texture.html
+++ b/docs/pages/Texture.html
@@ -129,7 +129,7 @@ cannot be changed. Instead, call <a href="Texture.html#dispose">Texture#dispose<
 highest density of texels. By default, this value is <code>1</code>. A higher value
 gives a less blurry result than a basic mipmap, at the cost of more
 texture samples being used.</p>
-						<p>Default is <code>0</code>.</p>
+						<p>Default is <code>1</code>.</p>
 					</div>
 				</div>
 				<div class="member">


### PR DESCRIPTION
Fix a small typo in the documentation. The default value for anisotropy is 1, not 0.