### PR TITLE
Examples: Fix webgl_effects_stereo having no visible stereo effect

### DIFF
--- a/examples/webgl_effects_stereo.html
+++ b/examples/webgl_effects_stereo.html
@@ -47,6 +47,7 @@
 
 				camera = new THREE.PerspectiveCamera( 60, window.innerWidth / window.innerHeight, 1, 100000 );
 				camera.position.z = 3200;
+				camera.focus = 3200;
 
 				scene = new THREE.Scene();
 				scene.background = new THREE.CubeTextureLoader()
@@ -83,6 +84,7 @@
 				container.appendChild( renderer.domElement );
 
 				effect = new StereoEffect( renderer );
+				effect.setEyeSeparation( 100 );
 				effect.setSize( window.innerWidth, window.innerHeight );
 
 				//


### PR DESCRIPTION
Related issue: #32317

**Description**

The `webgl_effects_stereo` example uses a scene with a very large scale (objects distributed within a range of 10,000 units, camera at z=3200). The default `StereoCamera` parameters (`eyeSep = 0.064, focus = 10`) were too small relative to this scale, resulting in a negligible parallax that made the stereo effect invisible.

This PR adjusts the parameters to match the scene scale:

* Sets `camera.focus = 3200` to match the distance to the center of the scene.
* Sets `effect.setEyeSeparation( 100 )` to provide a visible stereo baseline.

For testing:
https://raw.githack.com/mrdoob/three.js/effects-stereo/examples/webgl_effects_stereo.html

(Made using https://antigravity.google/ with Gemini 3.0)