### PR TITLE
WebGPURenderer: Fix VSM shadow artifacts.

### DIFF
--- a/src/nodes/lighting/ShadowNode.js
+++ b/src/nodes/lighting/ShadowNode.js
@@ -123,7 +123,7 @@ const VSMPassVertical = /*@__PURE__*/ Fn( ( { samples, radius, size, shadowPass,
 	mean.divAssign( samples );
 	squaredMean.divAssign( samples );
 
-	const std_dev = sqrt( squaredMean.sub( mean.mul( mean ) ) );
+	const std_dev = sqrt( squaredMean.sub( mean.mul( mean ) ).max( 0 ) );
 	return vec2( mean, std_dev );
 
 } );
@@ -168,7 +168,7 @@ const VSMPassHorizontal = /*@__PURE__*/ Fn( ( { samples, radius, size, shadowPas
 	mean.divAssign( samples );
 	squaredMean.divAssign( samples );
 
-	const std_dev = sqrt( squaredMean.sub( mean.mul( mean ) ) );
+	const std_dev = sqrt( squaredMean.sub( mean.mul( mean ) ).max( 0 ) );
 	return vec2( mean, std_dev );
 
 } );


### PR DESCRIPTION
Related issue: #31885

**Description**

This PR fixes visual artifacts (black/white noise) when using `VSMShadowMap` in `WebGPURenderer`.

| Before | After |
| - | - |
| <img width="897" height="750" alt="Screenshot 2025-11-21 at 6 27 57 PM" src="https://github.com/user-attachments/assets/cb8cc216-518d-410b-8cb5-e2d132d4880a" /> | <img width="897" height="750" alt="Screenshot 2025-11-21 at 6 26 08 PM" src="https://github.com/user-attachments/assets/6abf6928-0944-4352-b028-1b344143a942" /> |

The issue was caused by floating point precision errors in the variance calculation. Occasionally, `squaredMean - mean * mean` would result in a slightly negative value. When passed to `sqrt()`, this produced `NaN` values that propagated through the shadow calculation.

The fix clamps the variance value to `0` before the square root operation, ensuring valid results.

(Made using https://antigravity.google/ with Gemini 3.0)