### PR TITLE
Update default anisotropy value in Texture.js

### DIFF
--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -158,7 +158,7 @@ class Texture extends EventDispatcher {
 		 * texture samples being used.
 		 *
 		 * @type {number}
-		 * @default 0
+		 * @default Texture.DEFAULT_ANISOTROPY
 		 */
 		this.anisotropy = anisotropy;
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/32321

**Description**

Updates the Texture.anisotropy documentation to reference the correct default value (`Texture.DEFAULT_ANISOTROPY` instead of `0`)

