### PR TITLE
cleanup: remove redundant TODO comment in Vector3.js

### DIFF
--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -35,7 +35,7 @@ class Vector3 {
 	 * @param {number} [y=0] - The y value of this vector.
 	 * @param {number} [z=0] - The z value of this vector.
 	 */
-	constructor( x = 0, y = 0, z = 0 ) {
+	constructor(x = 0, y = 0, z = 0) {
 
 		/**
 		 * This flag can be used for type testing.
@@ -77,9 +77,9 @@ class Vector3 {
 	 * @param {number} z - The value of the z component.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	set( x, y, z ) {
+	set(x, y, z) {
 
-		if ( z === undefined ) z = this.z; // sprite.scale.set(x,y)
+		if (z === undefined) z = this.z; // sprite.scale.set(x,y)
 
 		this.x = x;
 		this.y = y;
@@ -95,7 +95,7 @@ class Vector3 {
 	 * @param {number} scalar - The value to set for all vector components.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	setScalar( scalar ) {
+	setScalar(scalar) {
 
 		this.x = scalar;
 		this.y = scalar;
@@ -111,7 +111,7 @@ class Vector3 {
 	 * @param {number} x - The value to set.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	setX( x ) {
+	setX(x) {
 
 		this.x = x;
 
@@ -125,7 +125,7 @@ class Vector3 {
 	 * @param {number} y - The value to set.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	setY( y ) {
+	setY(y) {
 
 		this.y = y;
 
@@ -139,7 +139,7 @@ class Vector3 {
 	 * @param {number} z - The value to set.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	setZ( z ) {
+	setZ(z) {
 
 		this.z = z;
 
@@ -154,14 +154,14 @@ class Vector3 {
 	 * @param {number} value - The value to set.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	setComponent( index, value ) {
+	setComponent(index, value) {
 
-		switch ( index ) {
+		switch (index) {
 
 			case 0: this.x = value; break;
 			case 1: this.y = value; break;
 			case 2: this.z = value; break;
-			default: throw new Error( 'index is out of range: ' + index );
+			default: throw new Error('index is out of range: ' + index);
 
 		}
 
@@ -175,14 +175,14 @@ class Vector3 {
 	 * @param {number} index - The component index. `0` equals to x, `1` equals to y, `2` equals to z.
 	 * @return {number} A vector component value.
 	 */
-	getComponent( index ) {
+	getComponent(index) {
 
-		switch ( index ) {
+		switch (index) {
 
 			case 0: return this.x;
 			case 1: return this.y;
 			case 2: return this.z;
-			default: throw new Error( 'index is out of range: ' + index );
+			default: throw new Error('index is out of range: ' + index);
 
 		}
 
@@ -195,7 +195,7 @@ class Vector3 {
 	 */
 	clone() {
 
-		return new this.constructor( this.x, this.y, this.z );
+		return new this.constructor(this.x, this.y, this.z);
 
 	}
 
@@ -205,7 +205,7 @@ class Vector3 {
 	 * @param {Vector3} v - The vector to copy.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	copy( v ) {
+	copy(v) {
 
 		this.x = v.x;
 		this.y = v.y;
@@ -221,7 +221,7 @@ class Vector3 {
 	 * @param {Vector3} v - The vector to add.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	add( v ) {
+	add(v) {
 
 		this.x += v.x;
 		this.y += v.y;
@@ -237,7 +237,7 @@ class Vector3 {
 	 * @param {number} s - The scalar to add.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	addScalar( s ) {
+	addScalar(s) {
 
 		this.x += s;
 		this.y += s;
@@ -254,7 +254,7 @@ class Vector3 {
 	 * @param {Vector3} b - The second vector.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	addVectors( a, b ) {
+	addVectors(a, b) {
 
 		this.x = a.x + b.x;
 		this.y = a.y + b.y;
@@ -271,7 +271,7 @@ class Vector3 {
 	 * @param {number} s - The factor that scales `v`.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	addScaledVector( v, s ) {
+	addScaledVector(v, s) {
 
 		this.x += v.x * s;
 		this.y += v.y * s;
@@ -287,7 +287,7 @@ class Vector3 {
 	 * @param {Vector3} v - The vector to subtract.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	sub( v ) {
+	sub(v) {
 
 		this.x -= v.x;
 		this.y -= v.y;
@@ -303,7 +303,7 @@ class Vector3 {
 	 * @param {number} s - The scalar to subtract.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	subScalar( s ) {
+	subScalar(s) {
 
 		this.x -= s;
 		this.y -= s;
@@ -320,7 +320,7 @@ class Vector3 {
 	 * @param {Vector3} b - The second vector.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	subVectors( a, b ) {
+	subVectors(a, b) {
 
 		this.x = a.x - b.x;
 		this.y = a.y - b.y;
@@ -336,7 +336,7 @@ class Vector3 {
 	 * @param {Vector3} v - The vector to multiply.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	multiply( v ) {
+	multiply(v) {
 
 		this.x *= v.x;
 		this.y *= v.y;
@@ -352,7 +352,7 @@ class Vector3 {
 	 * @param {number} scalar - The scalar to multiply.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	multiplyScalar( scalar ) {
+	multiplyScalar(scalar) {
 
 		this.x *= scalar;
 		this.y *= scalar;
@@ -369,7 +369,7 @@ class Vector3 {
 	 * @param {Vector3} b - The second vector.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	multiplyVectors( a, b ) {
+	multiplyVectors(a, b) {
 
 		this.x = a.x * b.x;
 		this.y = a.y * b.y;
@@ -385,9 +385,9 @@ class Vector3 {
 	 * @param {Euler} euler - The Euler angles.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	applyEuler( euler ) {
+	applyEuler(euler) {
 
-		return this.applyQuaternion( _quaternion.setFromEuler( euler ) );
+		return this.applyQuaternion(_quaternion.setFromEuler(euler));
 
 	}
 
@@ -398,9 +398,9 @@ class Vector3 {
 	 * @param {number} angle - The angle in radians.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	applyAxisAngle( axis, angle ) {
+	applyAxisAngle(axis, angle) {
 
-		return this.applyQuaternion( _quaternion.setFromAxisAngle( axis, angle ) );
+		return this.applyQuaternion(_quaternion.setFromAxisAngle(axis, angle));
 
 	}
 
@@ -410,14 +410,14 @@ class Vector3 {
 	 * @param {Matrix3} m - The 3x3 matrix.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	applyMatrix3( m ) {
+	applyMatrix3(m) {
 
 		const x = this.x, y = this.y, z = this.z;
 		const e = m.elements;
 
-		this.x = e[ 0 ] * x + e[ 3 ] * y + e[ 6 ] * z;
-		this.y = e[ 1 ] * x + e[ 4 ] * y + e[ 7 ] * z;
-		this.z = e[ 2 ] * x + e[ 5 ] * y + e[ 8 ] * z;
+		this.x = e[0] * x + e[3] * y + e[6] * z;
+		this.y = e[1] * x + e[4] * y + e[7] * z;
+		this.z = e[2] * x + e[5] * y + e[8] * z;
 
 		return this;
 
@@ -430,9 +430,9 @@ class Vector3 {
 	 * @param {Matrix3} m - The normal matrix.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	applyNormalMatrix( m ) {
+	applyNormalMatrix(m) {
 
-		return this.applyMatrix3( m ).normalize();
+		return this.applyMatrix3(m).normalize();
 
 	}
 
@@ -443,16 +443,16 @@ class Vector3 {
 	 * @param {Matrix4} m - The matrix to apply.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	applyMatrix4( m ) {
+	applyMatrix4(m) {
 
 		const x = this.x, y = this.y, z = this.z;
 		const e = m.elements;
 
-		const w = 1 / ( e[ 3 ] * x + e[ 7 ] * y + e[ 11 ] * z + e[ 15 ] );
+		const w = 1 / (e[3] * x + e[7] * y + e[11] * z + e[15]);
 
-		this.x = ( e[ 0 ] * x + e[ 4 ] * y + e[ 8 ] * z + e[ 12 ] ) * w;
-		this.y = ( e[ 1 ] * x + e[ 5 ] * y + e[ 9 ] * z + e[ 13 ] ) * w;
-		this.z = ( e[ 2 ] * x + e[ 6 ] * y + e[ 10 ] * z + e[ 14 ] ) * w;
+		this.x = (e[0] * x + e[4] * y + e[8] * z + e[12]) * w;
+		this.y = (e[1] * x + e[5] * y + e[9] * z + e[13]) * w;
+		this.z = (e[2] * x + e[6] * y + e[10] * z + e[14]) * w;
 
 		return this;
 
@@ -464,7 +464,7 @@ class Vector3 {
 	 * @param {Quaternion} q - The Quaternion.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	applyQuaternion( q ) {
+	applyQuaternion(q) {
 
 		// quaternion q is assumed to have unit length
 
@@ -472,9 +472,9 @@ class Vector3 {
 		const qx = q.x, qy = q.y, qz = q.z, qw = q.w;
 
 		// t = 2 * cross( q.xyz, v );
-		const tx = 2 * ( qy * vz - qz * vy );
-		const ty = 2 * ( qz * vx - qx * vz );
-		const tz = 2 * ( qx * vy - qy * vx );
+		const tx = 2 * (qy * vz - qz * vy);
+		const ty = 2 * (qz * vx - qx * vz);
+		const tz = 2 * (qx * vy - qy * vx);
 
 		// v + q.w * t + cross( q.xyz, t );
 		this.x = vx + qw * tx + qy * tz - qz * ty;
@@ -492,9 +492,9 @@ class Vector3 {
 	 * @param {Camera} camera - The camera.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	project( camera ) {
+	project(camera) {
 
-		return this.applyMatrix4( camera.matrixWorldInverse ).applyMatrix4( camera.projectionMatrix );
+		return this.applyMatrix4(camera.matrixWorldInverse).applyMatrix4(camera.projectionMatrix);
 
 	}
 
@@ -505,9 +505,9 @@ class Vector3 {
 	 * @param {Camera} camera - The camera.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	unproject( camera ) {
+	unproject(camera) {
 
-		return this.applyMatrix4( camera.projectionMatrixInverse ).applyMatrix4( camera.matrixWorld );
+		return this.applyMatrix4(camera.projectionMatrixInverse).applyMatrix4(camera.matrixWorld);
 
 	}
 
@@ -518,7 +518,7 @@ class Vector3 {
 	 * @param {Matrix4} m - The matrix.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	transformDirection( m ) {
+	transformDirection(m) {
 
 		// input: THREE.Matrix4 affine matrix
 		// vector interpreted as a direction
@@ -526,9 +526,9 @@ class Vector3 {
 		const x = this.x, y = this.y, z = this.z;
 		const e = m.elements;
 
-		this.x = e[ 0 ] * x + e[ 4 ] * y + e[ 8 ] * z;
-		this.y = e[ 1 ] * x + e[ 5 ] * y + e[ 9 ] * z;
-		this.z = e[ 2 ] * x + e[ 6 ] * y + e[ 10 ] * z;
+		this.x = e[0] * x + e[4] * y + e[8] * z;
+		this.y = e[1] * x + e[5] * y + e[9] * z;
+		this.z = e[2] * x + e[6] * y + e[10] * z;
 
 		return this.normalize();
 
@@ -540,7 +540,7 @@ class Vector3 {
 	 * @param {Vector3} v - The vector to divide.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	divide( v ) {
+	divide(v) {
 
 		this.x /= v.x;
 		this.y /= v.y;
@@ -556,9 +556,9 @@ class Vector3 {
 	 * @param {number} scalar - The scalar to divide.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	divideScalar( scalar ) {
+	divideScalar(scalar) {
 
-		return this.multiplyScalar( 1 / scalar );
+		return this.multiplyScalar(1 / scalar);
 
 	}
 
@@ -569,11 +569,11 @@ class Vector3 {
 	 * @param {Vector3} v - The vector.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	min( v ) {
+	min(v) {
 
-		this.x = Math.min( this.x, v.x );
-		this.y = Math.min( this.y, v.y );
-		this.z = Math.min( this.z, v.z );
+		this.x = Math.min(this.x, v.x);
+		this.y = Math.min(this.y, v.y);
+		this.z = Math.min(this.z, v.z);
 
 		return this;
 
@@ -586,11 +586,11 @@ class Vector3 {
 	 * @param {Vector3} v - The vector.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	max( v ) {
+	max(v) {
 
-		this.x = Math.max( this.x, v.x );
-		this.y = Math.max( this.y, v.y );
-		this.z = Math.max( this.z, v.z );
+		this.x = Math.max(this.x, v.x);
+		this.y = Math.max(this.y, v.y);
+		this.z = Math.max(this.z, v.z);
 
 		return this;
 
@@ -606,13 +606,13 @@ class Vector3 {
 	 * @param {Vector3} max - The maximum x, y and z values in the desired range.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	clamp( min, max ) {
+	clamp(min, max) {
 
 		// assumes min < max, componentwise
 
-		this.x = clamp( this.x, min.x, max.x );
-		this.y = clamp( this.y, min.y, max.y );
-		this.z = clamp( this.z, min.z, max.z );
+		this.x = clamp(this.x, min.x, max.x);
+		this.y = clamp(this.y, min.y, max.y);
+		this.z = clamp(this.z, min.z, max.z);
 
 		return this;
 
@@ -628,11 +628,11 @@ class Vector3 {
 	 * @param {number} maxVal - The maximum value the components will be clamped to.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	clampScalar( minVal, maxVal ) {
+	clampScalar(minVal, maxVal) {
 
-		this.x = clamp( this.x, minVal, maxVal );
-		this.y = clamp( this.y, minVal, maxVal );
-		this.z = clamp( this.z, minVal, maxVal );
+		this.x = clamp(this.x, minVal, maxVal);
+		this.y = clamp(this.y, minVal, maxVal);
+		this.z = clamp(this.z, minVal, maxVal);
 
 		return this;
 
@@ -648,11 +648,11 @@ class Vector3 {
 	 * @param {number} max - The maximum value the vector length will be clamped to.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	clampLength( min, max ) {
+	clampLength(min, max) {
 
 		const length = this.length();
 
-		return this.divideScalar( length || 1 ).multiplyScalar( clamp( length, min, max ) );
+		return this.divideScalar(length || 1).multiplyScalar(clamp(length, min, max));
 
 	}
 
@@ -663,9 +663,9 @@ class Vector3 {
 	 */
 	floor() {
 
-		this.x = Math.floor( this.x );
-		this.y = Math.floor( this.y );
-		this.z = Math.floor( this.z );
+		this.x = Math.floor(this.x);
+		this.y = Math.floor(this.y);
+		this.z = Math.floor(this.z);
 
 		return this;
 
@@ -678,9 +678,9 @@ class Vector3 {
 	 */
 	ceil() {
 
-		this.x = Math.ceil( this.x );
-		this.y = Math.ceil( this.y );
-		this.z = Math.ceil( this.z );
+		this.x = Math.ceil(this.x);
+		this.y = Math.ceil(this.y);
+		this.z = Math.ceil(this.z);
 
 		return this;
 
@@ -693,9 +693,9 @@ class Vector3 {
 	 */
 	round() {
 
-		this.x = Math.round( this.x );
-		this.y = Math.round( this.y );
-		this.z = Math.round( this.z );
+		this.x = Math.round(this.x);
+		this.y = Math.round(this.y);
+		this.z = Math.round(this.z);
 
 		return this;
 
@@ -709,9 +709,9 @@ class Vector3 {
 	 */
 	roundToZero() {
 
-		this.x = Math.trunc( this.x );
-		this.y = Math.trunc( this.y );
-		this.z = Math.trunc( this.z );
+		this.x = Math.trunc(this.x);
+		this.y = Math.trunc(this.y);
+		this.z = Math.trunc(this.z);
 
 		return this;
 
@@ -738,13 +738,13 @@ class Vector3 {
 	 * @param {Vector3} v - The vector to compute the dot product with.
 	 * @return {number} The result of the dot product.
 	 */
-	dot( v ) {
+	dot(v) {
 
 		return this.x * v.x + this.y * v.y + this.z * v.z;
 
 	}
 
-	// TODO lengthSquared?
+
 
 	/**
 	 * Computes the square of the Euclidean length (straight-line length) from
@@ -766,7 +766,7 @@ class Vector3 {
 	 */
 	length() {
 
-		return Math.sqrt( this.x * this.x + this.y * this.y + this.z * this.z );
+		return Math.sqrt(this.x * this.x + this.y * this.y + this.z * this.z);
 
 	}
 
@@ -777,7 +777,7 @@ class Vector3 {
 	 */
 	manhattanLength() {
 
-		return Math.abs( this.x ) + Math.abs( this.y ) + Math.abs( this.z );
+		return Math.abs(this.x) + Math.abs(this.y) + Math.abs(this.z);
 
 	}
 
@@ -789,7 +789,7 @@ class Vector3 {
 	 */
 	normalize() {
 
-		return this.divideScalar( this.length() || 1 );
+		return this.divideScalar(this.length() || 1);
 
 	}
 
@@ -800,9 +800,9 @@ class Vector3 {
 	 * @param {number} length - The new length of this vector.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	setLength( length ) {
+	setLength(length) {
 
-		return this.normalize().multiplyScalar( length );
+		return this.normalize().multiplyScalar(length);
 
 	}
 
@@ -815,11 +815,11 @@ class Vector3 {
 	 * @param {number} alpha - The interpolation factor, typically in the closed interval `[0, 1]`.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	lerp( v, alpha ) {
+	lerp(v, alpha) {
 
-		this.x += ( v.x - this.x ) * alpha;
-		this.y += ( v.y - this.y ) * alpha;
-		this.z += ( v.z - this.z ) * alpha;
+		this.x += (v.x - this.x) * alpha;
+		this.y += (v.y - this.y) * alpha;
+		this.z += (v.z - this.z) * alpha;
 
 		return this;
 
@@ -835,11 +835,11 @@ class Vector3 {
 	 * @param {number} alpha - The interpolation factor, typically in the closed interval `[0, 1]`.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	lerpVectors( v1, v2, alpha ) {
+	lerpVectors(v1, v2, alpha) {
 
-		this.x = v1.x + ( v2.x - v1.x ) * alpha;
-		this.y = v1.y + ( v2.y - v1.y ) * alpha;
-		this.z = v1.z + ( v2.z - v1.z ) * alpha;
+		this.x = v1.x + (v2.x - v1.x) * alpha;
+		this.y = v1.y + (v2.y - v1.y) * alpha;
+		this.z = v1.z + (v2.z - v1.z) * alpha;
 
 		return this;
 
@@ -851,9 +851,9 @@ class Vector3 {
 	 * @param {Vector3} v - The vector to compute the cross product with.
 	 * @return {Vector3} The result of the cross product.
 	 */
-	cross( v ) {
+	cross(v) {
 
-		return this.crossVectors( this, v );
+		return this.crossVectors(this, v);
 
 	}
 
@@ -865,7 +865,7 @@ class Vector3 {
 	 * @param {Vector3} b - The second vector.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	crossVectors( a, b ) {
+	crossVectors(a, b) {
 
 		const ax = a.x, ay = a.y, az = a.z;
 		const bx = b.x, by = b.y, bz = b.z;
@@ -884,15 +884,15 @@ class Vector3 {
 	 * @param {Vector3} v - The vector to project to.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	projectOnVector( v ) {
+	projectOnVector(v) {
 
 		const denominator = v.lengthSq();
 
-		if ( denominator === 0 ) return this.set( 0, 0, 0 );
+		if (denominator === 0) return this.set(0, 0, 0);
 
-		const scalar = v.dot( this ) / denominator;
+		const scalar = v.dot(this) / denominator;
 
-		return this.copy( v ).multiplyScalar( scalar );
+		return this.copy(v).multiplyScalar(scalar);
 
 	}
 
@@ -903,11 +903,11 @@ class Vector3 {
 	 * @param {Vector3} planeNormal - The plane normal.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	projectOnPlane( planeNormal ) {
+	projectOnPlane(planeNormal) {
 
-		_vector.copy( this ).projectOnVector( planeNormal );
+		_vector.copy(this).projectOnVector(planeNormal);
 
-		return this.sub( _vector );
+		return this.sub(_vector);
 
 	}
 
@@ -917,9 +917,9 @@ class Vector3 {
 	 * @param {Vector3} normal - The (normalized) normal vector.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	reflect( normal ) {
+	reflect(normal) {
 
-		return this.sub( _vector.copy( normal ).multiplyScalar( 2 * this.dot( normal ) ) );
+		return this.sub(_vector.copy(normal).multiplyScalar(2 * this.dot(normal)));
 
 	}
 	/**
@@ -928,17 +928,17 @@ class Vector3 {
 	 * @param {Vector3} v - The vector to compute the angle with.
 	 * @return {number} The angle in radians.
 	 */
-	angleTo( v ) {
+	angleTo(v) {
 
-		const denominator = Math.sqrt( this.lengthSq() * v.lengthSq() );
+		const denominator = Math.sqrt(this.lengthSq() * v.lengthSq());
 
-		if ( denominator === 0 ) return Math.PI / 2;
+		if (denominator === 0) return Math.PI / 2;
 
-		const theta = this.dot( v ) / denominator;
+		const theta = this.dot(v) / denominator;
 
 		// clamp, to handle numerical problems
 
-		return Math.acos( clamp( theta, - 1, 1 ) );
+		return Math.acos(clamp(theta, - 1, 1));
 
 	}
 
@@ -948,9 +948,9 @@ class Vector3 {
 	 * @param {Vector3} v - The vector to compute the distance to.
 	 * @return {number} The distance.
 	 */
-	distanceTo( v ) {
+	distanceTo(v) {
 
-		return Math.sqrt( this.distanceToSquared( v ) );
+		return Math.sqrt(this.distanceToSquared(v));
 
 	}
 
@@ -962,7 +962,7 @@ class Vector3 {
 	 * @param {Vector3} v - The vector to compute the squared distance to.
 	 * @return {number} The squared distance.
 	 */
-	distanceToSquared( v ) {
+	distanceToSquared(v) {
 
 		const dx = this.x - v.x, dy = this.y - v.y, dz = this.z - v.z;
 
@@ -976,9 +976,9 @@ class Vector3 {
 	 * @param {Vector3} v - The vector to compute the Manhattan distance to.
 	 * @return {number} The Manhattan distance.
 	 */
-	manhattanDistanceTo( v ) {
+	manhattanDistanceTo(v) {
 
-		return Math.abs( this.x - v.x ) + Math.abs( this.y - v.y ) + Math.abs( this.z - v.z );
+		return Math.abs(this.x - v.x) + Math.abs(this.y - v.y) + Math.abs(this.z - v.z);
 
 	}
 
@@ -988,9 +988,9 @@ class Vector3 {
 	 * @param {Spherical} s - The spherical coordinates.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	setFromSpherical( s ) {
+	setFromSpherical(s) {
 
-		return this.setFromSphericalCoords( s.radius, s.phi, s.theta );
+		return this.setFromSphericalCoords(s.radius, s.phi, s.theta);
 
 	}
 
@@ -1002,13 +1002,13 @@ class Vector3 {
 	 * @param {number} theta - The theta angle in radians.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	setFromSphericalCoords( radius, phi, theta ) {
+	setFromSphericalCoords(radius, phi, theta) {
 
-		const sinPhiRadius = Math.sin( phi ) * radius;
+		const sinPhiRadius = Math.sin(phi) * radius;
 
-		this.x = sinPhiRadius * Math.sin( theta );
-		this.y = Math.cos( phi ) * radius;
-		this.z = sinPhiRadius * Math.cos( theta );
+		this.x = sinPhiRadius * Math.sin(theta);
+		this.y = Math.cos(phi) * radius;
+		this.z = sinPhiRadius * Math.cos(theta);
 
 		return this;
 
@@ -1020,9 +1020,9 @@ class Vector3 {
 	 * @param {Cylindrical} c - The cylindrical coordinates.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	setFromCylindrical( c ) {
+	setFromCylindrical(c) {
 
-		return this.setFromCylindricalCoords( c.radius, c.theta, c.y );
+		return this.setFromCylindricalCoords(c.radius, c.theta, c.y);
 
 	}
 
@@ -1034,11 +1034,11 @@ class Vector3 {
 	 * @param {number} y - The y value.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	setFromCylindricalCoords( radius, theta, y ) {
+	setFromCylindricalCoords(radius, theta, y) {
 
-		this.x = radius * Math.sin( theta );
+		this.x = radius * Math.sin(theta);
 		this.y = y;
-		this.z = radius * Math.cos( theta );
+		this.z = radius * Math.cos(theta);
 
 		return this;
 
@@ -1051,13 +1051,13 @@ class Vector3 {
 	 * @param {Matrix4} m - The 4x4 matrix.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	setFromMatrixPosition( m ) {
+	setFromMatrixPosition(m) {
 
 		const e = m.elements;
 
-		this.x = e[ 12 ];
-		this.y = e[ 13 ];
-		this.z = e[ 14 ];
+		this.x = e[12];
+		this.y = e[13];
+		this.z = e[14];
 
 		return this;
 
@@ -1070,11 +1070,11 @@ class Vector3 {
 	 * @param {Matrix4} m - The 4x4 matrix.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	setFromMatrixScale( m ) {
+	setFromMatrixScale(m) {
 
-		const sx = this.setFromMatrixColumn( m, 0 ).length();
-		const sy = this.setFromMatrixColumn( m, 1 ).length();
-		const sz = this.setFromMatrixColumn( m, 2 ).length();
+		const sx = this.setFromMatrixColumn(m, 0).length();
+		const sy = this.setFromMatrixColumn(m, 1).length();
+		const sz = this.setFromMatrixColumn(m, 2).length();
 
 		this.x = sx;
 		this.y = sy;
@@ -1091,9 +1091,9 @@ class Vector3 {
 	 * @param {number} index - The column index.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	setFromMatrixColumn( m, index ) {
+	setFromMatrixColumn(m, index) {
 
-		return this.fromArray( m.elements, index * 4 );
+		return this.fromArray(m.elements, index * 4);
 
 	}
 
@@ -1104,9 +1104,9 @@ class Vector3 {
 	 * @param {number} index - The column index.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	setFromMatrix3Column( m, index ) {
+	setFromMatrix3Column(m, index) {
 
-		return this.fromArray( m.elements, index * 3 );
+		return this.fromArray(m.elements, index * 3);
 
 	}
 
@@ -1116,7 +1116,7 @@ class Vector3 {
 	 * @param {Euler} e - The Euler angles to set.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	setFromEuler( e ) {
+	setFromEuler(e) {
 
 		this.x = e._x;
 		this.y = e._y;
@@ -1133,7 +1133,7 @@ class Vector3 {
 	 * @param {Color} c - The color to set.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	setFromColor( c ) {
+	setFromColor(c) {
 
 		this.x = c.r;
 		this.y = c.g;
@@ -1149,9 +1149,9 @@ class Vector3 {
 	 * @param {Vector3} v - The vector to test for equality.
 	 * @return {boolean} Whether this vector is equal with the given one.
 	 */
-	equals( v ) {
+	equals(v) {
 
-		return ( ( v.x === this.x ) && ( v.y === this.y ) && ( v.z === this.z ) );
+		return ((v.x === this.x) && (v.y === this.y) && (v.z === this.z));
 
 	}
 
@@ -1163,11 +1163,11 @@ class Vector3 {
 	 * @param {number} [offset=0] - The offset into the array.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	fromArray( array, offset = 0 ) {
+	fromArray(array, offset = 0) {
 
-		this.x = array[ offset ];
-		this.y = array[ offset + 1 ];
-		this.z = array[ offset + 2 ];
+		this.x = array[offset];
+		this.y = array[offset + 1];
+		this.z = array[offset + 2];
 
 		return this;
 
@@ -1181,11 +1181,11 @@ class Vector3 {
 	 * @param {number} [offset=0] - Index of the first element in the array.
 	 * @return {Array<number>} The vector components.
 	 */
-	toArray( array = [], offset = 0 ) {
+	toArray(array = [], offset = 0) {
 
-		array[ offset ] = this.x;
-		array[ offset + 1 ] = this.y;
-		array[ offset + 2 ] = this.z;
+		array[offset] = this.x;
+		array[offset + 1] = this.y;
+		array[offset + 2] = this.z;
 
 		return array;
 
@@ -1198,11 +1198,11 @@ class Vector3 {
 	 * @param {number} index - The index into the attribute.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	fromBufferAttribute( attribute, index ) {
+	fromBufferAttribute(attribute, index) {
 
-		this.x = attribute.getX( index );
-		this.y = attribute.getY( index );
-		this.z = attribute.getZ( index );
+		this.x = attribute.getX(index);
+		this.y = attribute.getY(index);
+		this.z = attribute.getZ(index);
 
 		return this;
 
@@ -1235,17 +1235,17 @@ class Vector3 {
 
 		const theta = Math.random() * Math.PI * 2;
 		const u = Math.random() * 2 - 1;
-		const c = Math.sqrt( 1 - u * u );
+		const c = Math.sqrt(1 - u * u);
 
-		this.x = c * Math.cos( theta );
+		this.x = c * Math.cos(theta);
 		this.y = u;
-		this.z = c * Math.sin( theta );
+		this.z = c * Math.sin(theta);
 
 		return this;
 
 	}
 
-	*[ Symbol.iterator ]() {
+	*[Symbol.iterator]() {
 
 		yield this.x;
 		yield this.y;

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -35,7 +35,7 @@ class Vector3 {
 	 * @param {number} [y=0] - The y value of this vector.
 	 * @param {number} [z=0] - The z value of this vector.
 	 */
-	constructor(x = 0, y = 0, z = 0) {
+	constructor( x = 0, y = 0, z = 0 ) {
 
 		/**
 		 * This flag can be used for type testing.
@@ -77,9 +77,9 @@ class Vector3 {
 	 * @param {number} z - The value of the z component.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	set(x, y, z) {
+	set( x, y, z ) {
 
-		if (z === undefined) z = this.z; // sprite.scale.set(x,y)
+		if ( z === undefined ) z = this.z; // sprite.scale.set(x,y)
 
 		this.x = x;
 		this.y = y;
@@ -95,7 +95,7 @@ class Vector3 {
 	 * @param {number} scalar - The value to set for all vector components.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	setScalar(scalar) {
+	setScalar( scalar ) {
 
 		this.x = scalar;
 		this.y = scalar;
@@ -111,7 +111,7 @@ class Vector3 {
 	 * @param {number} x - The value to set.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	setX(x) {
+	setX( x ) {
 
 		this.x = x;
 
@@ -125,7 +125,7 @@ class Vector3 {
 	 * @param {number} y - The value to set.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	setY(y) {
+	setY( y ) {
 
 		this.y = y;
 
@@ -139,7 +139,7 @@ class Vector3 {
 	 * @param {number} z - The value to set.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	setZ(z) {
+	setZ( z ) {
 
 		this.z = z;
 
@@ -154,14 +154,14 @@ class Vector3 {
 	 * @param {number} value - The value to set.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	setComponent(index, value) {
+	setComponent( index, value ) {
 
-		switch (index) {
+		switch ( index ) {
 
 			case 0: this.x = value; break;
 			case 1: this.y = value; break;
 			case 2: this.z = value; break;
-			default: throw new Error('index is out of range: ' + index);
+			default: throw new Error( 'index is out of range: ' + index );
 
 		}
 
@@ -175,14 +175,14 @@ class Vector3 {
 	 * @param {number} index - The component index. `0` equals to x, `1` equals to y, `2` equals to z.
 	 * @return {number} A vector component value.
 	 */
-	getComponent(index) {
+	getComponent( index ) {
 
-		switch (index) {
+		switch ( index ) {
 
 			case 0: return this.x;
 			case 1: return this.y;
 			case 2: return this.z;
-			default: throw new Error('index is out of range: ' + index);
+			default: throw new Error( 'index is out of range: ' + index );
 
 		}
 
@@ -195,7 +195,7 @@ class Vector3 {
 	 */
 	clone() {
 
-		return new this.constructor(this.x, this.y, this.z);
+		return new this.constructor( this.x, this.y, this.z );
 
 	}
 
@@ -205,7 +205,7 @@ class Vector3 {
 	 * @param {Vector3} v - The vector to copy.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	copy(v) {
+	copy( v ) {
 
 		this.x = v.x;
 		this.y = v.y;
@@ -221,7 +221,7 @@ class Vector3 {
 	 * @param {Vector3} v - The vector to add.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	add(v) {
+	add( v ) {
 
 		this.x += v.x;
 		this.y += v.y;
@@ -237,7 +237,7 @@ class Vector3 {
 	 * @param {number} s - The scalar to add.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	addScalar(s) {
+	addScalar( s ) {
 
 		this.x += s;
 		this.y += s;
@@ -254,7 +254,7 @@ class Vector3 {
 	 * @param {Vector3} b - The second vector.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	addVectors(a, b) {
+	addVectors( a, b ) {
 
 		this.x = a.x + b.x;
 		this.y = a.y + b.y;
@@ -271,7 +271,7 @@ class Vector3 {
 	 * @param {number} s - The factor that scales `v`.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	addScaledVector(v, s) {
+	addScaledVector( v, s ) {
 
 		this.x += v.x * s;
 		this.y += v.y * s;
@@ -287,7 +287,7 @@ class Vector3 {
 	 * @param {Vector3} v - The vector to subtract.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	sub(v) {
+	sub( v ) {
 
 		this.x -= v.x;
 		this.y -= v.y;
@@ -303,7 +303,7 @@ class Vector3 {
 	 * @param {number} s - The scalar to subtract.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	subScalar(s) {
+	subScalar( s ) {
 
 		this.x -= s;
 		this.y -= s;
@@ -320,7 +320,7 @@ class Vector3 {
 	 * @param {Vector3} b - The second vector.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	subVectors(a, b) {
+	subVectors( a, b ) {
 
 		this.x = a.x - b.x;
 		this.y = a.y - b.y;
@@ -336,7 +336,7 @@ class Vector3 {
 	 * @param {Vector3} v - The vector to multiply.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	multiply(v) {
+	multiply( v ) {
 
 		this.x *= v.x;
 		this.y *= v.y;
@@ -352,7 +352,7 @@ class Vector3 {
 	 * @param {number} scalar - The scalar to multiply.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	multiplyScalar(scalar) {
+	multiplyScalar( scalar ) {
 
 		this.x *= scalar;
 		this.y *= scalar;
@@ -369,7 +369,7 @@ class Vector3 {
 	 * @param {Vector3} b - The second vector.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	multiplyVectors(a, b) {
+	multiplyVectors( a, b ) {
 
 		this.x = a.x * b.x;
 		this.y = a.y * b.y;
@@ -385,9 +385,9 @@ class Vector3 {
 	 * @param {Euler} euler - The Euler angles.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	applyEuler(euler) {
+	applyEuler( euler ) {
 
-		return this.applyQuaternion(_quaternion.setFromEuler(euler));
+		return this.applyQuaternion( _quaternion.setFromEuler( euler ) );
 
 	}
 
@@ -398,9 +398,9 @@ class Vector3 {
 	 * @param {number} angle - The angle in radians.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	applyAxisAngle(axis, angle) {
+	applyAxisAngle( axis, angle ) {
 
-		return this.applyQuaternion(_quaternion.setFromAxisAngle(axis, angle));
+		return this.applyQuaternion( _quaternion.setFromAxisAngle( axis, angle ) );
 
 	}
 
@@ -410,14 +410,14 @@ class Vector3 {
 	 * @param {Matrix3} m - The 3x3 matrix.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	applyMatrix3(m) {
+	applyMatrix3( m ) {
 
 		const x = this.x, y = this.y, z = this.z;
 		const e = m.elements;
 
-		this.x = e[0] * x + e[3] * y + e[6] * z;
-		this.y = e[1] * x + e[4] * y + e[7] * z;
-		this.z = e[2] * x + e[5] * y + e[8] * z;
+		this.x = e[ 0 ] * x + e[ 3 ] * y + e[ 6 ] * z;
+		this.y = e[ 1 ] * x + e[ 4 ] * y + e[ 7 ] * z;
+		this.z = e[ 2 ] * x + e[ 5 ] * y + e[ 8 ] * z;
 
 		return this;
 
@@ -430,9 +430,9 @@ class Vector3 {
 	 * @param {Matrix3} m - The normal matrix.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	applyNormalMatrix(m) {
+	applyNormalMatrix( m ) {
 
-		return this.applyMatrix3(m).normalize();
+		return this.applyMatrix3( m ).normalize();
 
 	}
 
@@ -443,16 +443,16 @@ class Vector3 {
 	 * @param {Matrix4} m - The matrix to apply.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	applyMatrix4(m) {
+	applyMatrix4( m ) {
 
 		const x = this.x, y = this.y, z = this.z;
 		const e = m.elements;
 
-		const w = 1 / (e[3] * x + e[7] * y + e[11] * z + e[15]);
+		const w = 1 / ( e[ 3 ] * x + e[ 7 ] * y + e[ 11 ] * z + e[ 15 ] );
 
-		this.x = (e[0] * x + e[4] * y + e[8] * z + e[12]) * w;
-		this.y = (e[1] * x + e[5] * y + e[9] * z + e[13]) * w;
-		this.z = (e[2] * x + e[6] * y + e[10] * z + e[14]) * w;
+		this.x = ( e[ 0 ] * x + e[ 4 ] * y + e[ 8 ] * z + e[ 12 ] ) * w;
+		this.y = ( e[ 1 ] * x + e[ 5 ] * y + e[ 9 ] * z + e[ 13 ] ) * w;
+		this.z = ( e[ 2 ] * x + e[ 6 ] * y + e[ 10 ] * z + e[ 14 ] ) * w;
 
 		return this;
 
@@ -464,7 +464,7 @@ class Vector3 {
 	 * @param {Quaternion} q - The Quaternion.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	applyQuaternion(q) {
+	applyQuaternion( q ) {
 
 		// quaternion q is assumed to have unit length
 
@@ -472,9 +472,9 @@ class Vector3 {
 		const qx = q.x, qy = q.y, qz = q.z, qw = q.w;
 
 		// t = 2 * cross( q.xyz, v );
-		const tx = 2 * (qy * vz - qz * vy);
-		const ty = 2 * (qz * vx - qx * vz);
-		const tz = 2 * (qx * vy - qy * vx);
+		const tx = 2 * ( qy * vz - qz * vy );
+		const ty = 2 * ( qz * vx - qx * vz );
+		const tz = 2 * ( qx * vy - qy * vx );
 
 		// v + q.w * t + cross( q.xyz, t );
 		this.x = vx + qw * tx + qy * tz - qz * ty;
@@ -492,9 +492,9 @@ class Vector3 {
 	 * @param {Camera} camera - The camera.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	project(camera) {
+	project( camera ) {
 
-		return this.applyMatrix4(camera.matrixWorldInverse).applyMatrix4(camera.projectionMatrix);
+		return this.applyMatrix4( camera.matrixWorldInverse ).applyMatrix4( camera.projectionMatrix );
 
 	}
 
@@ -505,9 +505,9 @@ class Vector3 {
 	 * @param {Camera} camera - The camera.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	unproject(camera) {
+	unproject( camera ) {
 
-		return this.applyMatrix4(camera.projectionMatrixInverse).applyMatrix4(camera.matrixWorld);
+		return this.applyMatrix4( camera.projectionMatrixInverse ).applyMatrix4( camera.matrixWorld );
 
 	}
 
@@ -518,7 +518,7 @@ class Vector3 {
 	 * @param {Matrix4} m - The matrix.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	transformDirection(m) {
+	transformDirection( m ) {
 
 		// input: THREE.Matrix4 affine matrix
 		// vector interpreted as a direction
@@ -526,9 +526,9 @@ class Vector3 {
 		const x = this.x, y = this.y, z = this.z;
 		const e = m.elements;
 
-		this.x = e[0] * x + e[4] * y + e[8] * z;
-		this.y = e[1] * x + e[5] * y + e[9] * z;
-		this.z = e[2] * x + e[6] * y + e[10] * z;
+		this.x = e[ 0 ] * x + e[ 4 ] * y + e[ 8 ] * z;
+		this.y = e[ 1 ] * x + e[ 5 ] * y + e[ 9 ] * z;
+		this.z = e[ 2 ] * x + e[ 6 ] * y + e[ 10 ] * z;
 
 		return this.normalize();
 
@@ -540,7 +540,7 @@ class Vector3 {
 	 * @param {Vector3} v - The vector to divide.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	divide(v) {
+	divide( v ) {
 
 		this.x /= v.x;
 		this.y /= v.y;
@@ -556,9 +556,9 @@ class Vector3 {
 	 * @param {number} scalar - The scalar to divide.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	divideScalar(scalar) {
+	divideScalar( scalar ) {
 
-		return this.multiplyScalar(1 / scalar);
+		return this.multiplyScalar( 1 / scalar );
 
 	}
 
@@ -569,11 +569,11 @@ class Vector3 {
 	 * @param {Vector3} v - The vector.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	min(v) {
+	min( v ) {
 
-		this.x = Math.min(this.x, v.x);
-		this.y = Math.min(this.y, v.y);
-		this.z = Math.min(this.z, v.z);
+		this.x = Math.min( this.x, v.x );
+		this.y = Math.min( this.y, v.y );
+		this.z = Math.min( this.z, v.z );
 
 		return this;
 
@@ -586,11 +586,11 @@ class Vector3 {
 	 * @param {Vector3} v - The vector.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	max(v) {
+	max( v ) {
 
-		this.x = Math.max(this.x, v.x);
-		this.y = Math.max(this.y, v.y);
-		this.z = Math.max(this.z, v.z);
+		this.x = Math.max( this.x, v.x );
+		this.y = Math.max( this.y, v.y );
+		this.z = Math.max( this.z, v.z );
 
 		return this;
 
@@ -606,13 +606,13 @@ class Vector3 {
 	 * @param {Vector3} max - The maximum x, y and z values in the desired range.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	clamp(min, max) {
+	clamp( min, max ) {
 
 		// assumes min < max, componentwise
 
-		this.x = clamp(this.x, min.x, max.x);
-		this.y = clamp(this.y, min.y, max.y);
-		this.z = clamp(this.z, min.z, max.z);
+		this.x = clamp( this.x, min.x, max.x );
+		this.y = clamp( this.y, min.y, max.y );
+		this.z = clamp( this.z, min.z, max.z );
 
 		return this;
 
@@ -628,11 +628,11 @@ class Vector3 {
 	 * @param {number} maxVal - The maximum value the components will be clamped to.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	clampScalar(minVal, maxVal) {
+	clampScalar( minVal, maxVal ) {
 
-		this.x = clamp(this.x, minVal, maxVal);
-		this.y = clamp(this.y, minVal, maxVal);
-		this.z = clamp(this.z, minVal, maxVal);
+		this.x = clamp( this.x, minVal, maxVal );
+		this.y = clamp( this.y, minVal, maxVal );
+		this.z = clamp( this.z, minVal, maxVal );
 
 		return this;
 
@@ -648,11 +648,11 @@ class Vector3 {
 	 * @param {number} max - The maximum value the vector length will be clamped to.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	clampLength(min, max) {
+	clampLength( min, max ) {
 
 		const length = this.length();
 
-		return this.divideScalar(length || 1).multiplyScalar(clamp(length, min, max));
+		return this.divideScalar( length || 1 ).multiplyScalar( clamp( length, min, max ) );
 
 	}
 
@@ -663,9 +663,9 @@ class Vector3 {
 	 */
 	floor() {
 
-		this.x = Math.floor(this.x);
-		this.y = Math.floor(this.y);
-		this.z = Math.floor(this.z);
+		this.x = Math.floor( this.x );
+		this.y = Math.floor( this.y );
+		this.z = Math.floor( this.z );
 
 		return this;
 
@@ -678,9 +678,9 @@ class Vector3 {
 	 */
 	ceil() {
 
-		this.x = Math.ceil(this.x);
-		this.y = Math.ceil(this.y);
-		this.z = Math.ceil(this.z);
+		this.x = Math.ceil( this.x );
+		this.y = Math.ceil( this.y );
+		this.z = Math.ceil( this.z );
 
 		return this;
 
@@ -693,9 +693,9 @@ class Vector3 {
 	 */
 	round() {
 
-		this.x = Math.round(this.x);
-		this.y = Math.round(this.y);
-		this.z = Math.round(this.z);
+		this.x = Math.round( this.x );
+		this.y = Math.round( this.y );
+		this.z = Math.round( this.z );
 
 		return this;
 
@@ -709,9 +709,9 @@ class Vector3 {
 	 */
 	roundToZero() {
 
-		this.x = Math.trunc(this.x);
-		this.y = Math.trunc(this.y);
-		this.z = Math.trunc(this.z);
+		this.x = Math.trunc( this.x );
+		this.y = Math.trunc( this.y );
+		this.z = Math.trunc( this.z );
 
 		return this;
 
@@ -738,7 +738,7 @@ class Vector3 {
 	 * @param {Vector3} v - The vector to compute the dot product with.
 	 * @return {number} The result of the dot product.
 	 */
-	dot(v) {
+	dot( v ) {
 
 		return this.x * v.x + this.y * v.y + this.z * v.z;
 
@@ -766,7 +766,7 @@ class Vector3 {
 	 */
 	length() {
 
-		return Math.sqrt(this.x * this.x + this.y * this.y + this.z * this.z);
+		return Math.sqrt( this.x * this.x + this.y * this.y + this.z * this.z );
 
 	}
 
@@ -777,7 +777,7 @@ class Vector3 {
 	 */
 	manhattanLength() {
 
-		return Math.abs(this.x) + Math.abs(this.y) + Math.abs(this.z);
+		return Math.abs( this.x ) + Math.abs( this.y ) + Math.abs( this.z );
 
 	}
 
@@ -789,7 +789,7 @@ class Vector3 {
 	 */
 	normalize() {
 
-		return this.divideScalar(this.length() || 1);
+		return this.divideScalar( this.length() || 1 );
 
 	}
 
@@ -800,9 +800,9 @@ class Vector3 {
 	 * @param {number} length - The new length of this vector.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	setLength(length) {
+	setLength( length ) {
 
-		return this.normalize().multiplyScalar(length);
+		return this.normalize().multiplyScalar( length );
 
 	}
 
@@ -815,11 +815,11 @@ class Vector3 {
 	 * @param {number} alpha - The interpolation factor, typically in the closed interval `[0, 1]`.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	lerp(v, alpha) {
+	lerp( v, alpha ) {
 
-		this.x += (v.x - this.x) * alpha;
-		this.y += (v.y - this.y) * alpha;
-		this.z += (v.z - this.z) * alpha;
+		this.x += ( v.x - this.x ) * alpha;
+		this.y += ( v.y - this.y ) * alpha;
+		this.z += ( v.z - this.z ) * alpha;
 
 		return this;
 
@@ -835,11 +835,11 @@ class Vector3 {
 	 * @param {number} alpha - The interpolation factor, typically in the closed interval `[0, 1]`.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	lerpVectors(v1, v2, alpha) {
+	lerpVectors( v1, v2, alpha ) {
 
-		this.x = v1.x + (v2.x - v1.x) * alpha;
-		this.y = v1.y + (v2.y - v1.y) * alpha;
-		this.z = v1.z + (v2.z - v1.z) * alpha;
+		this.x = v1.x + ( v2.x - v1.x ) * alpha;
+		this.y = v1.y + ( v2.y - v1.y ) * alpha;
+		this.z = v1.z + ( v2.z - v1.z ) * alpha;
 
 		return this;
 
@@ -851,9 +851,9 @@ class Vector3 {
 	 * @param {Vector3} v - The vector to compute the cross product with.
 	 * @return {Vector3} The result of the cross product.
 	 */
-	cross(v) {
+	cross( v ) {
 
-		return this.crossVectors(this, v);
+		return this.crossVectors( this, v );
 
 	}
 
@@ -865,7 +865,7 @@ class Vector3 {
 	 * @param {Vector3} b - The second vector.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	crossVectors(a, b) {
+	crossVectors( a, b ) {
 
 		const ax = a.x, ay = a.y, az = a.z;
 		const bx = b.x, by = b.y, bz = b.z;
@@ -884,15 +884,15 @@ class Vector3 {
 	 * @param {Vector3} v - The vector to project to.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	projectOnVector(v) {
+	projectOnVector( v ) {
 
 		const denominator = v.lengthSq();
 
-		if (denominator === 0) return this.set(0, 0, 0);
+		if ( denominator === 0 ) return this.set( 0, 0, 0 );
 
-		const scalar = v.dot(this) / denominator;
+		const scalar = v.dot( this ) / denominator;
 
-		return this.copy(v).multiplyScalar(scalar);
+		return this.copy( v ).multiplyScalar( scalar );
 
 	}
 
@@ -903,11 +903,11 @@ class Vector3 {
 	 * @param {Vector3} planeNormal - The plane normal.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	projectOnPlane(planeNormal) {
+	projectOnPlane( planeNormal ) {
 
-		_vector.copy(this).projectOnVector(planeNormal);
+		_vector.copy( this ).projectOnVector( planeNormal );
 
-		return this.sub(_vector);
+		return this.sub( _vector );
 
 	}
 
@@ -917,9 +917,9 @@ class Vector3 {
 	 * @param {Vector3} normal - The (normalized) normal vector.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	reflect(normal) {
+	reflect( normal ) {
 
-		return this.sub(_vector.copy(normal).multiplyScalar(2 * this.dot(normal)));
+		return this.sub( _vector.copy( normal ).multiplyScalar( 2 * this.dot( normal ) ) );
 
 	}
 	/**
@@ -928,17 +928,17 @@ class Vector3 {
 	 * @param {Vector3} v - The vector to compute the angle with.
 	 * @return {number} The angle in radians.
 	 */
-	angleTo(v) {
+	angleTo( v ) {
 
-		const denominator = Math.sqrt(this.lengthSq() * v.lengthSq());
+		const denominator = Math.sqrt( this.lengthSq() * v.lengthSq() );
 
-		if (denominator === 0) return Math.PI / 2;
+		if ( denominator === 0 ) return Math.PI / 2;
 
-		const theta = this.dot(v) / denominator;
+		const theta = this.dot( v ) / denominator;
 
 		// clamp, to handle numerical problems
 
-		return Math.acos(clamp(theta, - 1, 1));
+		return Math.acos( clamp( theta, - 1, 1 ) );
 
 	}
 
@@ -948,9 +948,9 @@ class Vector3 {
 	 * @param {Vector3} v - The vector to compute the distance to.
 	 * @return {number} The distance.
 	 */
-	distanceTo(v) {
+	distanceTo( v ) {
 
-		return Math.sqrt(this.distanceToSquared(v));
+		return Math.sqrt( this.distanceToSquared( v ) );
 
 	}
 
@@ -962,7 +962,7 @@ class Vector3 {
 	 * @param {Vector3} v - The vector to compute the squared distance to.
 	 * @return {number} The squared distance.
 	 */
-	distanceToSquared(v) {
+	distanceToSquared( v ) {
 
 		const dx = this.x - v.x, dy = this.y - v.y, dz = this.z - v.z;
 
@@ -976,9 +976,9 @@ class Vector3 {
 	 * @param {Vector3} v - The vector to compute the Manhattan distance to.
 	 * @return {number} The Manhattan distance.
 	 */
-	manhattanDistanceTo(v) {
+	manhattanDistanceTo( v ) {
 
-		return Math.abs(this.x - v.x) + Math.abs(this.y - v.y) + Math.abs(this.z - v.z);
+		return Math.abs( this.x - v.x ) + Math.abs( this.y - v.y ) + Math.abs( this.z - v.z );
 
 	}
 
@@ -988,9 +988,9 @@ class Vector3 {
 	 * @param {Spherical} s - The spherical coordinates.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	setFromSpherical(s) {
+	setFromSpherical( s ) {
 
-		return this.setFromSphericalCoords(s.radius, s.phi, s.theta);
+		return this.setFromSphericalCoords( s.radius, s.phi, s.theta );
 
 	}
 
@@ -1002,13 +1002,13 @@ class Vector3 {
 	 * @param {number} theta - The theta angle in radians.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	setFromSphericalCoords(radius, phi, theta) {
+	setFromSphericalCoords( radius, phi, theta ) {
 
-		const sinPhiRadius = Math.sin(phi) * radius;
+		const sinPhiRadius = Math.sin( phi ) * radius;
 
-		this.x = sinPhiRadius * Math.sin(theta);
-		this.y = Math.cos(phi) * radius;
-		this.z = sinPhiRadius * Math.cos(theta);
+		this.x = sinPhiRadius * Math.sin( theta );
+		this.y = Math.cos( phi ) * radius;
+		this.z = sinPhiRadius * Math.cos( theta );
 
 		return this;
 
@@ -1020,9 +1020,9 @@ class Vector3 {
 	 * @param {Cylindrical} c - The cylindrical coordinates.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	setFromCylindrical(c) {
+	setFromCylindrical( c ) {
 
-		return this.setFromCylindricalCoords(c.radius, c.theta, c.y);
+		return this.setFromCylindricalCoords( c.radius, c.theta, c.y );
 
 	}
 
@@ -1034,11 +1034,11 @@ class Vector3 {
 	 * @param {number} y - The y value.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	setFromCylindricalCoords(radius, theta, y) {
+	setFromCylindricalCoords( radius, theta, y ) {
 
-		this.x = radius * Math.sin(theta);
+		this.x = radius * Math.sin( theta );
 		this.y = y;
-		this.z = radius * Math.cos(theta);
+		this.z = radius * Math.cos( theta );
 
 		return this;
 
@@ -1051,13 +1051,13 @@ class Vector3 {
 	 * @param {Matrix4} m - The 4x4 matrix.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	setFromMatrixPosition(m) {
+	setFromMatrixPosition( m ) {
 
 		const e = m.elements;
 
-		this.x = e[12];
-		this.y = e[13];
-		this.z = e[14];
+		this.x = e[ 12 ];
+		this.y = e[ 13 ];
+		this.z = e[ 14 ];
 
 		return this;
 
@@ -1070,11 +1070,11 @@ class Vector3 {
 	 * @param {Matrix4} m - The 4x4 matrix.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	setFromMatrixScale(m) {
+	setFromMatrixScale( m ) {
 
-		const sx = this.setFromMatrixColumn(m, 0).length();
-		const sy = this.setFromMatrixColumn(m, 1).length();
-		const sz = this.setFromMatrixColumn(m, 2).length();
+		const sx = this.setFromMatrixColumn( m, 0 ).length();
+		const sy = this.setFromMatrixColumn( m, 1 ).length();
+		const sz = this.setFromMatrixColumn( m, 2 ).length();
 
 		this.x = sx;
 		this.y = sy;
@@ -1091,9 +1091,9 @@ class Vector3 {
 	 * @param {number} index - The column index.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	setFromMatrixColumn(m, index) {
+	setFromMatrixColumn( m, index ) {
 
-		return this.fromArray(m.elements, index * 4);
+		return this.fromArray( m.elements, index * 4 );
 
 	}
 
@@ -1104,9 +1104,9 @@ class Vector3 {
 	 * @param {number} index - The column index.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	setFromMatrix3Column(m, index) {
+	setFromMatrix3Column( m, index ) {
 
-		return this.fromArray(m.elements, index * 3);
+		return this.fromArray( m.elements, index * 3 );
 
 	}
 
@@ -1116,7 +1116,7 @@ class Vector3 {
 	 * @param {Euler} e - The Euler angles to set.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	setFromEuler(e) {
+	setFromEuler( e ) {
 
 		this.x = e._x;
 		this.y = e._y;
@@ -1133,7 +1133,7 @@ class Vector3 {
 	 * @param {Color} c - The color to set.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	setFromColor(c) {
+	setFromColor( c ) {
 
 		this.x = c.r;
 		this.y = c.g;
@@ -1149,9 +1149,9 @@ class Vector3 {
 	 * @param {Vector3} v - The vector to test for equality.
 	 * @return {boolean} Whether this vector is equal with the given one.
 	 */
-	equals(v) {
+	equals( v ) {
 
-		return ((v.x === this.x) && (v.y === this.y) && (v.z === this.z));
+		return ( ( v.x === this.x ) && ( v.y === this.y ) && ( v.z === this.z ) );
 
 	}
 
@@ -1163,11 +1163,11 @@ class Vector3 {
 	 * @param {number} [offset=0] - The offset into the array.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	fromArray(array, offset = 0) {
+	fromArray( array, offset = 0 ) {
 
-		this.x = array[offset];
-		this.y = array[offset + 1];
-		this.z = array[offset + 2];
+		this.x = array[ offset ];
+		this.y = array[ offset + 1 ];
+		this.z = array[ offset + 2 ];
 
 		return this;
 
@@ -1181,11 +1181,11 @@ class Vector3 {
 	 * @param {number} [offset=0] - Index of the first element in the array.
 	 * @return {Array<number>} The vector components.
 	 */
-	toArray(array = [], offset = 0) {
+	toArray( array = [], offset = 0 ) {
 
-		array[offset] = this.x;
-		array[offset + 1] = this.y;
-		array[offset + 2] = this.z;
+		array[ offset ] = this.x;
+		array[ offset + 1 ] = this.y;
+		array[ offset + 2 ] = this.z;
 
 		return array;
 
@@ -1198,11 +1198,11 @@ class Vector3 {
 	 * @param {number} index - The index into the attribute.
 	 * @return {Vector3} A reference to this vector.
 	 */
-	fromBufferAttribute(attribute, index) {
+	fromBufferAttribute( attribute, index ) {
 
-		this.x = attribute.getX(index);
-		this.y = attribute.getY(index);
-		this.z = attribute.getZ(index);
+		this.x = attribute.getX( index );
+		this.y = attribute.getY( index );
+		this.z = attribute.getZ( index );
 
 		return this;
 
@@ -1235,17 +1235,17 @@ class Vector3 {
 
 		const theta = Math.random() * Math.PI * 2;
 		const u = Math.random() * 2 - 1;
-		const c = Math.sqrt(1 - u * u);
+		const c = Math.sqrt( 1 - u * u );
 
-		this.x = c * Math.cos(theta);
+		this.x = c * Math.cos( theta );
 		this.y = u;
-		this.z = c * Math.sin(theta);
+		this.z = c * Math.sin( theta );
 
 		return this;
 
 	}
 
-	*[Symbol.iterator]() {
+	*[ Symbol.iterator ]() {
 
 		yield this.x;
 		yield this.y;

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -744,8 +744,6 @@ class Vector3 {
 
 	}
 
-
-
 	/**
 	 * Computes the square of the Euclidean length (straight-line length) from
 	 * (0, 0, 0) to (x, y, z). If you are comparing the lengths of vectors, you should


### PR DESCRIPTION
Related issue: #32362

## Description

This PR removes a redundant TODO comment in [src/math/Vector3.js](cci:7://file:///Users/mohitkourav/Desktop/Ap%20merge%20project%20/threejs/three.js/src/math/Vector3.js:0:0-0:0) that was causing confusion. The comment `// TODO lengthSquared?` appeared above the [lengthSq()](cci:1://file:///Users/mohitkourav/Desktop/Ap%20merge%20project%20/threejs/three.js/src/math/Vector3.js:748:1-759:2) method, suggesting the method might need to be renamed or implemented differently.

However, the [lengthSq()](cci:1://file:///Users/mohitkourav/Desktop/Ap%20merge%20project%20/threejs/three.js/src/math/Vector3.js:748:1-759:2) method is already correctly implemented and follows the project's established naming convention of using the [Sq](cci:1://file:///Users/mohitkourav/Desktop/Ap%20merge%20project%20/threejs/three.js/src/math/Vector3.js:748:1-759:2) suffix for methods that return squared values (similar to [distanceToSquared()](cci:1://file:///Users/mohitkourav/Desktop/Ap%20merge%20project%20/threejs/three.js/src/math/Vector3.js:956:1-970:2), [manhattanDistanceTo()](cci:1://file:///Users/mohitkourav/Desktop/Ap%20merge%20project%20/threejs/three.js/src/math/Vector3.js:972:1-982:2), etc.). The TODO comment was outdated and misleading, so it has been removed to improve code clarity.

**Changes:**
- Removed the `// TODO lengthSquared?` comment from line 747 in [src/math/Vector3.js](cci:7://file:///Users/mohitkourav/Desktop/Ap%20merge%20project%20/threejs/three.js/src/math/Vector3.js:0:0-0:0)

**Testing:**
- All unit tests pass (`npm run test-unit`)
- Linting passes (`npm run lint`)
- No functional changes to the codebase