### PR TITLE
Add type info for physics imports

### DIFF
--- a/examples/jsm/physics/AmmoPhysics.js
+++ b/examples/jsm/physics/AmmoPhysics.js
@@ -23,6 +23,7 @@ async function AmmoPhysics() {
 
 	}
 
+	/** @type {import("ammojs3").default} */
 	const AmmoLib = await Ammo(); // eslint-disable-line no-undef
 
 	const frameRate = 60;

--- a/examples/jsm/physics/JoltPhysics.js
+++ b/examples/jsm/physics/JoltPhysics.js
@@ -4,6 +4,7 @@ const JOLT_PATH = 'https://cdn.jsdelivr.net/npm/jolt-physics@0.23.0/dist/jolt-ph
 
 const frameRate = 60;
 
+/** @type {import("jolt-physics").default | null} */
 let Jolt = null;
 
 function getShape( geometry ) {

--- a/examples/jsm/physics/RapierPhysics.js
+++ b/examples/jsm/physics/RapierPhysics.js
@@ -7,6 +7,7 @@ const frameRate = 60;
 const _scale = new Vector3( 1, 1, 1 );
 const ZERO = new Vector3();
 
+/** @type {import("@dimforge/rapier3d-compat") | null} */
 let RAPIER = null;
 
 function getShape( geometry ) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,10 @@
       "version": "0.181.0",
       "license": "MIT",
       "devDependencies": {
+        "@dimforge/rapier3d-compat": "^0.17.3",
         "@rollup/plugin-node-resolve": "^16.0.0",
         "@rollup/plugin-terser": "^0.4.0",
+        "ammojs3": "^0.0.11",
         "concurrently": "^9.0.0",
         "eslint": "^8.37.0",
         "eslint-config-mdcs": "^5.0.0",
@@ -18,6 +20,7 @@
         "eslint-plugin-html": "^8.0.0",
         "eslint-plugin-import": "^2.27.5",
         "jimp": "^1.6.0",
+        "jolt-physics": "^0.23.0",
         "jsdoc": "^4.0.5",
         "magic-string": "^0.30.0",
         "pixelmatch": "^7.0.0",
@@ -102,6 +105,13 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.17.3",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.17.3.tgz",
+      "integrity": "sha512-hxtaaqtfUWQvYbA/vstSEMZupObTMdM1u+5vTQlXNdWueRRhJ+toxREhaplok5W1/4ErxO6qdezbRM2eqEQsqw==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.0",
@@ -1722,7 +1732,6 @@
       "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
@@ -1827,7 +1836,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1898,6 +1906,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ammojs3": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/ammojs3/-/ammojs3-0.0.11.tgz",
+      "integrity": "sha512-pfnMm0XvTLjzCt+ytdpV3aIgooxQzexjkC2DbTyiGsAk8ECEBPxJ8gOQ/m0CE+d9pf9ToPMK8PZJR7jP1h6lOA==",
+      "dev": true
     },
     "node_modules/ansi-align": {
       "version": "3.0.1",
@@ -2507,7 +2521,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -3222,8 +3235,7 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1521046.tgz",
       "integrity": "sha512-vhE6eymDQSKWUXwwA37NtTTVEzjtGVfDr3pRbsWEQ5onH/Snp2c+2xZHWJJawG/0hCCJLRGt4xVtEVUVILol4w==",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
@@ -3638,7 +3650,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5582,6 +5593,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/jolt-physics": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/jolt-physics/-/jolt-physics-0.23.0.tgz",
+      "integrity": "sha512-it7osUD+oRLYHld7e5cplLrKCm6nCnHL+aivMMcqXPKPEvEdhU06TTZCPcJ38fJU8NCMP8Wrlr1H+QoVqC5YTw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jpeg-js": {
       "version": "0.4.4",
@@ -7852,7 +7870,6 @@
       "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },

--- a/package.json
+++ b/package.json
@@ -94,8 +94,10 @@
   },
   "homepage": "https://threejs.org/",
   "devDependencies": {
+    "@dimforge/rapier3d-compat": "^0.17.3",
     "@rollup/plugin-node-resolve": "^16.0.0",
     "@rollup/plugin-terser": "^0.4.0",
+    "ammojs3": "^0.0.11",
     "concurrently": "^9.0.0",
     "eslint": "^8.37.0",
     "eslint-config-mdcs": "^5.0.0",
@@ -103,6 +105,7 @@
     "eslint-plugin-html": "^8.0.0",
     "eslint-plugin-import": "^2.27.5",
     "jimp": "^1.6.0",
+    "jolt-physics": "^0.23.0",
     "jsdoc": "^4.0.5",
     "magic-string": "^0.30.0",
     "pixelmatch": "^7.0.0",


### PR DESCRIPTION
Adds type info for the physics libraries, works after installing them once anywhere but I've added them to dev dependencies regardless. It would be nice if you could do it by http but that doesnt seem to be possible

![Ammo](https://github.com/user-attachments/assets/df9e5bc8-75a6-4a1b-bced-008da99f4375)
![Jolt](https://github.com/user-attachments/assets/3b4adfbf-92c0-4a9c-9693-a10690de2547)
![Rapier](https://github.com/user-attachments/assets/19dbac5b-1699-49ec-8947-b8f8d7faa395)
