### PR TITLE
Physics Addons: Add errors when trying to use `getShape()` for unsupported geometry types.

### DIFF
--- a/examples/jsm/physics/AmmoPhysics.js
+++ b/examples/jsm/physics/AmmoPhysics.js
@@ -66,7 +66,8 @@ async function AmmoPhysics() {
 
 		}
 
-		console.warn( "Tried to get shape of unsupported geometry " + geometry.type );
+		console.error( 'AmmoPhysics: Unsupported geometry type:', geometry.type );
+
 		return null;
 
 	}

--- a/examples/jsm/physics/AmmoPhysics.js
+++ b/examples/jsm/physics/AmmoPhysics.js
@@ -66,6 +66,7 @@ async function AmmoPhysics() {
 
 		}
 
+		console.warn( "Tried to get shape of unsupported geometry " + geometry.type );
 		return null;
 
 	}

--- a/examples/jsm/physics/JoltPhysics.js
+++ b/examples/jsm/physics/JoltPhysics.js
@@ -28,7 +28,8 @@ function getShape( geometry ) {
 
 	}
 
-	console.warn( "Tried to get shape of unsupported geometry " + geometry.type );
+	console.error( 'JoltPhysics: Unsupported geometry type:', geometry.type );
+
 	return null;
 
 }

--- a/examples/jsm/physics/JoltPhysics.js
+++ b/examples/jsm/physics/JoltPhysics.js
@@ -28,6 +28,7 @@ function getShape( geometry ) {
 
 	}
 
+	console.warn( "Tried to get shape of unsupported geometry " + geometry.type );
 	return null;
 
 }

--- a/examples/jsm/physics/RapierPhysics.js
+++ b/examples/jsm/physics/RapierPhysics.js
@@ -73,6 +73,7 @@ function getShape( geometry ) {
 
 	}
 
+	console.warn( "Tried to get shape of unsupported geometry " + geometry.type );
 	return null;
 
 }

--- a/examples/jsm/physics/RapierPhysics.js
+++ b/examples/jsm/physics/RapierPhysics.js
@@ -73,7 +73,8 @@ function getShape( geometry ) {
 
 	}
 
-	console.warn( "Tried to get shape of unsupported geometry " + geometry.type );
+	console.error( 'RapierPhysics: Unsupported geometry type:', geometry.type );
+
 	return null;
 
 }


### PR DESCRIPTION
Otherwise you may accidently not create a collider where you think you would
Throwing is also an option