### PR TITLE
Add type info for physics imports

### DIFF
--- a/examples/jsm/physics/AmmoPhysics.js
+++ b/examples/jsm/physics/AmmoPhysics.js
@@ -23,6 +23,7 @@ async function AmmoPhysics() {
 
 	}
 
+	/** @type {import("ammojs3").default} */
 	const AmmoLib = await Ammo(); // eslint-disable-line no-undef
 
 	const frameRate = 60;

--- a/examples/jsm/physics/JoltPhysics.js
+++ b/examples/jsm/physics/JoltPhysics.js
@@ -4,6 +4,7 @@ const JOLT_PATH = 'https://cdn.jsdelivr.net/npm/jolt-physics@0.23.0/dist/jolt-ph
 
 const frameRate = 60;
 
+/** @type {import("jolt-physics").default | null} */
 let Jolt = null;
 
 function getShape( geometry ) {

--- a/examples/jsm/physics/RapierPhysics.js
+++ b/examples/jsm/physics/RapierPhysics.js
@@ -7,6 +7,7 @@ const frameRate = 60;
 const _scale = new Vector3( 1, 1, 1 );
 const ZERO = new Vector3();
 
+/** @type {import("@dimforge/rapier3d-compat") | null} */
 let RAPIER = null;
 
 function getShape( geometry ) {


### PR DESCRIPTION
#32371 

Adds type info for the physics libraries, works after installing them once anywhere ~~but I've added them to dev dependencies regardless~~. It would be nice if you could do it by http but that doesnt seem to be possible

![Ammo](https://github.com/user-attachments/assets/df9e5bc8-75a6-4a1b-bced-008da99f4375)
![Jolt](https://github.com/user-attachments/assets/3b4adfbf-92c0-4a9c-9693-a10690de2547)
![Rapier](https://github.com/user-attachments/assets/19dbac5b-1699-49ec-8947-b8f8d7faa395)
