### PR TITLE
StructTypeNode: Fix memory length calculations (#32375)

### DIFF
--- a/src/nodes/core/NodeUtils.js
+++ b/src/nodes/core/NodeUtils.js
@@ -181,22 +181,22 @@ export function getMemoryLengthFromType( type ) {
 }
 
 /**
- * Returns the byte boundary for the given data type.
+ * Returns the alignment requirement for the given data type.
  *
  * @private
  * @method
  * @param {string} type - The data type.
- * @return {number} The byte boundary.
+ * @return {number} The alignment requirement in bytes.
  */
-export function getByteBoundaryFromType( type ) {
+export function getAlignmentFromType( type ) {
 
 	if ( /float|int|uint/.test( type ) ) return 4;
 	if ( /vec2/.test( type ) ) return 8;
 	if ( /vec3/.test( type ) ) return 16;
 	if ( /vec4/.test( type ) ) return 16;
 	if ( /mat2/.test( type ) ) return 8;
-	if ( /mat3/.test( type ) ) return 48;
-	if ( /mat4/.test( type ) ) return 64;
+	if ( /mat3/.test( type ) ) return 16;
+	if ( /mat4/.test( type ) ) return 16;
 
 	error( 'TSL: Unsupported type:', type );
 

--- a/src/nodes/core/StructTypeNode.js
+++ b/src/nodes/core/StructTypeNode.js
@@ -87,7 +87,7 @@ class StructTypeNode extends Node {
 	getLength() {
 
 		const BYTES_PER_ELEMENT = Float32Array.BYTES_PER_ELEMENT;
-		const CHUNK_SIZE = 4; // Webgpu aligns most data in blocks of 4 elements (16 bytes)
+		let maxAlignment = 1; // maximum alignment value in this struct
 		let offset = 0; // global buffer offset in 4 byte elements
 
 		for ( const member of this.membersLayout ) {
@@ -96,8 +96,9 @@ class StructTypeNode extends Node {
 
 			const itemSize = getMemoryLengthFromType( type );
 			const alignment = getAlignmentFromType( type ) / BYTES_PER_ELEMENT;
+			maxAlignment = Math.max( maxAlignment, alignment );
 
-			const chunkOffset = offset % CHUNK_SIZE; // offset in the current chunk of 4 elements
+			const chunkOffset = offset % maxAlignment; // offset in the current chunk of maxAlignment elements
 			const overhang = chunkOffset % alignment; // distance from the last aligned offset
 			if ( overhang !== 0 ) {
 
@@ -109,7 +110,7 @@ class StructTypeNode extends Node {
 
 		}
 
-		return ( Math.ceil( offset / CHUNK_SIZE ) * CHUNK_SIZE ); // ensure length is a multiple of 4
+		return ( Math.ceil( offset / maxAlignment ) * maxAlignment ); // ensure length is a multiple of maxAlignment
 
 	}
 


### PR DESCRIPTION
Fixed #32375.

**Description**

This change fixes the memory length calculation for the StructTypeNode so three.js allocates enough memory for custom structs.
I have also renamed the getByteBoundaryFromType() function to getAlignmentFromType() and fixed the values for mat3/mat4 according to https://webgpufundamentals.org/webgpu/lessons/webgpu-memory-layout.html
