### PR TITLE
TLS: Introduce `builtinShadowContext`

### DIFF
--- a/examples/webgpu_postprocessing_sss.html
+++ b/examples/webgpu_postprocessing_sss.html
@@ -36,7 +36,7 @@
 		<script type="module">
 
 			import * as THREE from 'three/webgpu';
-			import { pass, vec3, vec4, mrt, screenUV, velocity, context } from 'three/tsl';
+			import { pass, vec3, vec4, mrt, screenUV, velocity, builtinShadowContext } from 'three/tsl';
 			import { sss } from 'three/addons/tsl/display/SSSNode.js';
 			import { traa } from 'three/addons/tsl/display/TRAANode.js';
 
@@ -158,18 +158,7 @@
 				// scene context
 
 				const sssSample = sssPass.getTextureNode().sample( screenUV ).r;
-
-				const sssContext = context( {
-
-					getShadow: ( light ) => {
-
-						if ( light === dirLight ) return sssSample;
-
-						return null;
-
-					}
-
-				} );
+				const sssContext = builtinShadowContext( sssSample, dirLight );
 
 				scenePass.contextNode = sssContext;
 

--- a/src/Three.TSL.js
+++ b/src/Three.TSL.js
@@ -100,6 +100,7 @@ export const bufferAttribute = TSL.bufferAttribute;
 export const bumpMap = TSL.bumpMap;
 export const burn = TSL.burn;
 export const builtin = TSL.builtin;
+export const builtinShadowContext = TSL.builtinShadowContext;
 export const bvec2 = TSL.bvec2;
 export const bvec3 = TSL.bvec3;
 export const bvec4 = TSL.bvec4;

--- a/src/nodes/core/ContextNode.js
+++ b/src/nodes/core/ContextNode.js
@@ -203,6 +203,36 @@ export const uniformFlow = ( node ) => context( node, { uniformFlow: true } );
 export const setName = ( node, name ) => context( node, { nodeName: name } );
 
 /**
+ * TSL function for defining a built-in shadow context for a given node.
+ *
+ * @tsl
+ * @function
+ * @param {ShadowNode} shadowNode - The shadow node representing the light's shadow.
+ * @param {Light} light - The light associated with the shadow.
+ * @param {Node} [node=null] - The node whose context should be modified.
+ * @returns {ContextNode}
+ */
+export function builtinShadowContext( shadowNode, light, node = null ) {
+
+	return context( node, {
+
+		getShadow: ( { light: shadowLight, shadowColorNode } ) => {
+
+			if ( light === shadowLight ) {
+
+				return shadowColorNode.mul( shadowNode );
+
+			}
+
+			return shadowColorNode;
+
+		}
+
+	} );
+
+}
+
+/**
  * TSL function for defining a label context value for a given node.
  *
  * @tsl
@@ -224,3 +254,4 @@ addMethodChaining( 'context', context );
 addMethodChaining( 'label', label );
 addMethodChaining( 'uniformFlow', uniformFlow );
 addMethodChaining( 'setName', setName );
+addMethodChaining( 'builtinShadowContext', ( node, shadowNode, light ) => builtinShadowContext( shadowNode, light, node ) );

--- a/src/nodes/lighting/AnalyticLightNode.js
+++ b/src/nodes/lighting/AnalyticLightNode.js
@@ -190,13 +190,7 @@ class AnalyticLightNode extends LightingNode {
 
 		if ( builder.context.getShadow ) {
 
-			const shadow = builder.context.getShadow( this.light, builder );
-
-			if ( shadow ) {
-
-				shadowColorNode = shadowColorNode.mul( shadow );
-
-			}
+			shadowColorNode = builder.context.getShadow( this, builder );
 
 		}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/32378#issuecomment-3582858383

**Description**

Simplify the use of built-in shadows as used in the `webgpu_postprocessing_sss` example.

Contexts can be used in cascade, being:

```js
scenePass.contextNode = builtinShadowContext( sssSample, dirLight ).builtinAOContext( aoSample );
```