### PR TITLE
Refactor: Implement Light.fromJSON and update LightProbe

### DIFF
--- a/src/lights/Light.js
+++ b/src/lights/Light.js
@@ -69,6 +69,24 @@ class Light extends Object3D {
 
 	}
 
+	fromJSON( json ) {
+
+		this.color.setHex( json.color );
+		this.intensity = json.intensity;
+
+		if ( json.groundColor !== undefined ) this.groundColor.setHex( json.groundColor );
+
+		if ( json.distance !== undefined ) this.distance = json.distance;
+		if ( json.angle !== undefined ) this.angle = json.angle;
+		if ( json.decay !== undefined ) this.decay = json.decay;
+		if ( json.penumbra !== undefined ) this.penumbra = json.penumbra;
+
+		if ( json.shadow !== undefined ) this.shadow.fromJSON( json.shadow );
+
+		return this;
+
+	}
+
 	toJSON( meta ) {
 
 		const data = super.toJSON( meta );

--- a/src/lights/LightProbe.js
+++ b/src/lights/LightProbe.js
@@ -28,9 +28,9 @@ class LightProbe extends Light {
 	 * @param {SphericalHarmonics3} sh - The spherical harmonics which represents encoded lighting information.
 	 * @param {number} [intensity=1] - The light's strength/intensity.
 	 */
-	constructor(sh = new SphericalHarmonics3(), intensity = 1) {
+	constructor( sh = new SphericalHarmonics3(), intensity = 1 ) {
 
-		super(undefined, intensity);
+		super( undefined, intensity );
 
 		/**
 		 * This flag can be used for type testing.
@@ -50,11 +50,11 @@ class LightProbe extends Light {
 
 	}
 
-	copy(source) {
+	copy( source ) {
 
-		super.copy(source);
+		super.copy( source );
 
-		this.sh.copy(source.sh);
+		this.sh.copy( source.sh );
 
 		return this;
 
@@ -66,19 +66,19 @@ class LightProbe extends Light {
 	 * @param {Object} json - The JSON holding the serialized light probe.
 	 * @return {LightProbe} A reference to this light probe.
 	 */
-	fromJSON(json) {
+	fromJSON( json ) {
 
-		super.fromJSON(json);
+		super.fromJSON( json );
 
-		this.sh.fromArray(json.sh);
+		this.sh.fromArray( json.sh );
 
 		return this;
 
 	}
 
-	toJSON(meta) {
+	toJSON( meta ) {
 
-		const data = super.toJSON(meta);
+		const data = super.toJSON( meta );
 
 		data.object.sh = this.sh.toArray();
 

--- a/src/lights/LightProbe.js
+++ b/src/lights/LightProbe.js
@@ -28,9 +28,9 @@ class LightProbe extends Light {
 	 * @param {SphericalHarmonics3} sh - The spherical harmonics which represents encoded lighting information.
 	 * @param {number} [intensity=1] - The light's strength/intensity.
 	 */
-	constructor( sh = new SphericalHarmonics3(), intensity = 1 ) {
+	constructor(sh = new SphericalHarmonics3(), intensity = 1) {
 
-		super( undefined, intensity );
+		super(undefined, intensity);
 
 		/**
 		 * This flag can be used for type testing.
@@ -50,11 +50,11 @@ class LightProbe extends Light {
 
 	}
 
-	copy( source ) {
+	copy(source) {
 
-		super.copy( source );
+		super.copy(source);
 
-		this.sh.copy( source.sh );
+		this.sh.copy(source.sh);
 
 		return this;
 
@@ -66,18 +66,19 @@ class LightProbe extends Light {
 	 * @param {Object} json - The JSON holding the serialized light probe.
 	 * @return {LightProbe} A reference to this light probe.
 	 */
-	fromJSON( json ) {
+	fromJSON(json) {
 
-		this.intensity = json.intensity; // TODO: Move this bit to Light.fromJSON();
-		this.sh.fromArray( json.sh );
+		super.fromJSON(json);
+
+		this.sh.fromArray(json.sh);
 
 		return this;
 
 	}
 
-	toJSON( meta ) {
+	toJSON(meta) {
 
-		const data = super.toJSON( meta );
+		const data = super.toJSON(meta);
 
 		data.object.sh = this.sh.toArray();
 

--- a/test/unit/src/lights/Light.tests.js
+++ b/test/unit/src/lights/Light.tests.js
@@ -5,12 +5,12 @@ import { Light } from '../../../../src/lights/Light.js';
 import { Object3D } from '../../../../src/core/Object3D.js';
 import { runStdLightTests } from '../../utils/qunit-utils.js';
 
-export default QUnit.module( 'Lights', () => {
+export default QUnit.module('Lights', () => {
 
-	QUnit.module( 'Light', ( hooks ) => {
+	QUnit.module('Light', (hooks) => {
 
 		let lights = undefined;
-		hooks.beforeEach( function () {
+		hooks.beforeEach(function () {
 
 			const parameters = {
 				color: 0xaaaaaa,
@@ -19,14 +19,14 @@ export default QUnit.module( 'Lights', () => {
 
 			lights = [
 				new Light(),
-				new Light( parameters.color ),
-				new Light( parameters.color, parameters.intensity )
+				new Light(parameters.color),
+				new Light(parameters.color, parameters.intensity)
 			];
 
-		} );
+		});
 
 		// INHERITANCE
-		QUnit.test( 'Extending', ( assert ) => {
+		QUnit.test('Extending', (assert) => {
 
 			const object = new Light();
 			assert.strictEqual(
@@ -34,18 +34,18 @@ export default QUnit.module( 'Lights', () => {
 				'Light extends from Object3D'
 			);
 
-		} );
+		});
 
 		// INSTANCING
-		QUnit.test( 'Instancing', ( assert ) => {
+		QUnit.test('Instancing', (assert) => {
 
 			const object = new Light();
-			assert.ok( object, 'Can instantiate a Light.' );
+			assert.ok(object, 'Can instantiate a Light.');
 
-		} );
+		});
 
 		// PROPERTIES
-		QUnit.test( 'type', ( assert ) => {
+		QUnit.test('type', (assert) => {
 
 			const object = new Light();
 			assert.ok(
@@ -53,22 +53,22 @@ export default QUnit.module( 'Lights', () => {
 				'Light.type should be Light'
 			);
 
-		} );
+		});
 
-		QUnit.todo( 'color', ( assert ) => {
+		QUnit.todo('color', (assert) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			assert.ok(false, 'everything\'s gonna be alright');
 
-		} );
+		});
 
-		QUnit.todo( 'intensity', ( assert ) => {
+		QUnit.todo('intensity', (assert) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			assert.ok(false, 'everything\'s gonna be alright');
 
-		} );
+		});
 
 		// PUBLIC
-		QUnit.test( 'isLight', ( assert ) => {
+		QUnit.test('isLight', (assert) => {
 
 			const object = new Light();
 			assert.ok(
@@ -76,37 +76,42 @@ export default QUnit.module( 'Lights', () => {
 				'Light.isLight should be true'
 			);
 
-		} );
+		});
 
-		QUnit.test( 'dispose', ( assert ) => {
+		QUnit.test('dispose', (assert) => {
 
-			assert.expect( 0 );
+			assert.expect(0);
 
 			// empty, test exists
 			const object = new Light();
 			object.dispose();
 
-		} );
+		});
 
-		QUnit.todo( 'copy', ( assert ) => {
+		QUnit.todo('copy', (assert) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			assert.ok(false, 'everything\'s gonna be alright');
 
-		} );
+		});
 
-		QUnit.todo( 'toJSON', ( assert ) => {
+		QUnit.test('toJSON', (assert) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const light = new Light(0xffc0d1, 2);
+			const json = light.toJSON();
+			const newLight = new Light().fromJSON(json.object);
 
-		} );
+			assert.strictEqual(newLight.color.getHex(), 0xffc0d1, 'Check color');
+			assert.strictEqual(newLight.intensity, 2, 'Check intensity');
+
+		});
 
 		// OTHERS
-		QUnit.test( 'Standard light tests', ( assert ) => {
+		QUnit.test('Standard light tests', (assert) => {
 
-			runStdLightTests( assert, lights );
+			runStdLightTests(assert, lights);
 
-		} );
+		});
 
-	} );
+	});
 
-} );
+});

--- a/test/unit/src/lights/LightProbe.tests.js
+++ b/test/unit/src/lights/LightProbe.tests.js
@@ -4,12 +4,12 @@ import { LightProbe } from '../../../../src/lights/LightProbe.js';
 
 import { Light } from '../../../../src/lights/Light.js';
 
-export default QUnit.module( 'Lights', () => {
+export default QUnit.module('Lights', () => {
 
-	QUnit.module( 'LightProbe', () => {
+	QUnit.module('LightProbe', () => {
 
 		// INHERITANCE
-		QUnit.test( 'Extending', ( assert ) => {
+		QUnit.test('Extending', (assert) => {
 
 			const object = new LightProbe();
 			assert.strictEqual(
@@ -17,25 +17,25 @@ export default QUnit.module( 'Lights', () => {
 				'LightProbe extends from Light'
 			);
 
-		} );
+		});
 
 		// INSTANCING
-		QUnit.todo( 'Instancing', ( assert ) => {
+		QUnit.todo('Instancing', (assert) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			assert.ok(false, 'everything\'s gonna be alright');
 
-		} );
+		});
 
 		// PROPERTIES
-		QUnit.todo( 'sh', ( assert ) => {
+		QUnit.todo('sh', (assert) => {
 
 			// SphericalHarmonics3 if not supplied
-			assert.ok( false, 'everything\'s gonna be alright' );
+			assert.ok(false, 'everything\'s gonna be alright');
 
-		} );
+		});
 
 		// PUBLIC
-		QUnit.test( 'isLightProbe', ( assert ) => {
+		QUnit.test('isLightProbe', (assert) => {
 
 			const object = new LightProbe();
 			assert.ok(
@@ -43,26 +43,34 @@ export default QUnit.module( 'Lights', () => {
 				'LightProbe.isLightProbe should be true'
 			);
 
-		} );
+		});
 
-		QUnit.todo( 'copy', ( assert ) => {
+		QUnit.todo('copy', (assert) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			assert.ok(false, 'everything\'s gonna be alright');
 
-		} );
+		});
 
-		QUnit.todo( 'fromJSON', ( assert ) => {
+		QUnit.test('fromJSON', (assert) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const lightProbe = new LightProbe(undefined, 2);
+			const json = lightProbe.toJSON();
+			const newLightProbe = new LightProbe().fromJSON(json.object);
 
-		} );
+			assert.strictEqual(newLightProbe.intensity, 2, 'Check intensity');
 
-		QUnit.todo( 'toJSON', ( assert ) => {
+		});
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+		QUnit.test('toJSON', (assert) => {
 
-		} );
+			const lightProbe = new LightProbe(undefined, 2);
+			const json = lightProbe.toJSON();
 
-	} );
+			assert.strictEqual(json.object.intensity, 2, 'Check intensity');
+			assert.notEqual(json.object.sh, undefined, 'Check sh');
 
-} );
+		});
+
+	});
+
+});


### PR DESCRIPTION
## Related issue
#32389


This PR refactors `LightProbe.fromJSON` to utilize a new `Light.fromJSON` method, addressing a TODO comment in `src/lights/LightProbe.js`.

Previously, `LightProbe` manually handled the deserialization of intensity, and the `Light` base class lacked a `fromJSON` implementation.

### This change includes:

- Implements `Light.fromJSON` to handle common light properties (color, intensity, shadow, etc.).
- Updates `LightProbe.fromJSON` to call `super.fromJSON( json )`.
- Adds missing unit tests for `Light.fromJSON` and `LightProbe.fromJSON` to ensure correctness.

