### PR TITLE
Revert "Physics Addons: Add errors when trying to use `getShape()` for unsupported geometry types."

### DIFF
--- a/examples/jsm/physics/AmmoPhysics.js
+++ b/examples/jsm/physics/AmmoPhysics.js
@@ -66,8 +66,6 @@ async function AmmoPhysics() {
 
 		}
 
-		console.error( 'AmmoPhysics: Unsupported geometry type:', geometry.type );
-
 		return null;
 
 	}

--- a/examples/jsm/physics/JoltPhysics.js
+++ b/examples/jsm/physics/JoltPhysics.js
@@ -28,8 +28,6 @@ function getShape( geometry ) {
 
 	}
 
-	console.error( 'JoltPhysics: Unsupported geometry type:', geometry.type );
-
 	return null;
 
 }

--- a/examples/jsm/physics/RapierPhysics.js
+++ b/examples/jsm/physics/RapierPhysics.js
@@ -73,8 +73,6 @@ function getShape( geometry ) {
 
 	}
 
-	console.error( 'RapierPhysics: Unsupported geometry type:', geometry.type );
-
 	return null;
 
 }


### PR DESCRIPTION
Reverts mrdoob/three.js#32372

Sorry, I have to revert since this change emits a lot of errors when the physics modules are used with `addScene()`.  This method traverse through the scene and processes all (instanced) meshes via `addMesh()`. If `getShape()` does not determine a valid physics shape for a mesh, it must silently return `null` so incompatible geometries are just ignored.