### PR TITLE
Revert "Revert "Physics Addons: Add errors when trying to use `getShape()` for unsupported geometry types.""

### DIFF
--- a/examples/jsm/physics/AmmoPhysics.js
+++ b/examples/jsm/physics/AmmoPhysics.js
@@ -66,6 +66,8 @@ async function AmmoPhysics() {
 
 		}
 
+		console.error( 'AmmoPhysics: Unsupported geometry type:', geometry.type );
+
 		return null;
 
 	}

--- a/examples/jsm/physics/JoltPhysics.js
+++ b/examples/jsm/physics/JoltPhysics.js
@@ -28,6 +28,8 @@ function getShape( geometry ) {
 
 	}
 
+	console.error( 'JoltPhysics: Unsupported geometry type:', geometry.type );
+
 	return null;
 
 }

--- a/examples/jsm/physics/RapierPhysics.js
+++ b/examples/jsm/physics/RapierPhysics.js
@@ -73,6 +73,8 @@ function getShape( geometry ) {
 
 	}
 
+	console.error( 'RapierPhysics: Unsupported geometry type:', geometry.type );
+
 	return null;
 
 }


### PR DESCRIPTION
Reverts mrdoob/three.js#32393

Sorry for the back and forth. I have realized only meshes with `child.userData.physics` are processed by `addMesh()`. So it should be safe to report errors since the developer has to actively define physics data for compatible meshes.