### PR TITLE
VideoTexture Fix

### DIFF
--- a/src/renderers/webgpu/utils/WebGPUTextureUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUTextureUtils.js
@@ -19,7 +19,7 @@ import {
 } from '../../../constants.js';
 import { CubeTexture } from '../../../textures/CubeTexture.js';
 import { Texture } from '../../../textures/Texture.js';
-import { warn, error } from '../../../utils.js';
+import { warn, warnOnce, error } from '../../../utils.js';
 
 const _compareToWebGPU = {
 	[ NeverCompare ]: 'never',
@@ -86,14 +86,6 @@ class WebGPUTextureUtils {
 		 * @default null
 		 */
 		this.defaultVideoFrame = null;
-
-		/**
-		 * Tracks whether a video frame upload warning was already logged to avoid spam.
-		 *
-		 * @type {boolean}
-		 * @default false
-		 */
-		this._videoFrameCopyWarningIssued = false;
 
 		/**
 		 * A cache of shared texture samplers.
@@ -801,18 +793,11 @@ class WebGPUTextureUtils {
 				}
 			);
 
-			if ( isVideoSource ) this._videoFrameCopyWarningIssued = false;
-
 		} catch ( error ) {
 
 			if ( isVideoSource ) {
 
-				if ( this._videoFrameCopyWarningIssued === false ) {
-
-					warn( 'WebGPUTextureUtils: Skipping a corrupted video frame upload.', error );
-					this._videoFrameCopyWarningIssued = true;
-
-				}
+				warnOnce( 'WebGPUTextureUtils: Skipping a corrupted video frame upload.', error );
 
 				return;
 


### PR DESCRIPTION
Related issue: #32391
**Description**

**WebGPU VideoTexture** uploads could throw when Chrome’s decoder produced a corrupt frame, leaving the pipeline stuck in a permanent validation-error state.

Wrapped `device.queue.copyExternalImageToTexture()` in **WebGPUTextureUtils** with a video source guard that catches the error, logs it once, and skips the bad frame so playback resumes on subsequent good frames.
Non video sources still rethrow immediately, keeping other texture errors visible.

Tests: `npm run test-unit`, `npm run test-unit-addons`

@Mugen87 
