### PR TITLE
WebGLRenderer: Fix V8 deoptimizations

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2040,15 +2040,11 @@ class WebGLRenderer {
 
 		}
 
-
-
 		function getProgram( material, scene, object ) {
 
 			if ( scene.isScene !== true ) scene = _emptyScene; // scene could be a Mesh, Line, Points, ...
 
 			const materialProperties = properties.get( material );
-
-
 
 			const lights = currentRenderState.state.lights;
 			const shadowsArray = currentRenderState.state.shadowsArray;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2040,11 +2040,54 @@ class WebGLRenderer {
 
 		}
 
+		function initMaterialProperties( materialProperties ) {
+
+			materialProperties.outputColorSpace = undefined;
+			materialProperties.batching = undefined;
+			materialProperties.batchingColor = undefined;
+			materialProperties.instancing = undefined;
+			materialProperties.instancingColor = undefined;
+			materialProperties.instancingMorph = undefined;
+			materialProperties.skinning = undefined;
+			materialProperties.morphTargets = undefined;
+			materialProperties.morphNormals = undefined;
+			materialProperties.morphColors = undefined;
+			materialProperties.morphTargetsCount = undefined;
+			materialProperties.numClippingPlanes = undefined;
+			materialProperties.numIntersection = undefined;
+			materialProperties.vertexAlphas = undefined;
+			materialProperties.vertexTangents = undefined;
+			materialProperties.toneMapping = undefined;
+
+			materialProperties.fog = undefined;
+			materialProperties.environment = undefined;
+			materialProperties.envMap = undefined;
+			materialProperties.envMapRotation = undefined;
+
+			materialProperties.programs = undefined;
+			materialProperties.currentProgram = undefined;
+			materialProperties.uniforms = undefined;
+			materialProperties.uniformsList = undefined;
+
+			materialProperties.needsLights = undefined;
+			materialProperties.lightsStateVersion = undefined;
+
+			materialProperties.receiveShadow = undefined;
+			materialProperties.__version = undefined;
+
+		}
+
 		function getProgram( material, scene, object ) {
 
 			if ( scene.isScene !== true ) scene = _emptyScene; // scene could be a Mesh, Line, Points, ...
 
 			const materialProperties = properties.get( material );
+
+			if ( materialProperties.programs === undefined ) {
+
+				initMaterialProperties( materialProperties );
+
+			}
 
 			const lights = currentRenderState.state.lights;
 			const shadowsArray = currentRenderState.state.shadowsArray;

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2040,42 +2040,7 @@ class WebGLRenderer {
 
 		}
 
-		function initMaterialProperties( materialProperties ) {
 
-			materialProperties.outputColorSpace = undefined;
-			materialProperties.batching = undefined;
-			materialProperties.batchingColor = undefined;
-			materialProperties.instancing = undefined;
-			materialProperties.instancingColor = undefined;
-			materialProperties.instancingMorph = undefined;
-			materialProperties.skinning = undefined;
-			materialProperties.morphTargets = undefined;
-			materialProperties.morphNormals = undefined;
-			materialProperties.morphColors = undefined;
-			materialProperties.morphTargetsCount = undefined;
-			materialProperties.numClippingPlanes = undefined;
-			materialProperties.numIntersection = undefined;
-			materialProperties.vertexAlphas = undefined;
-			materialProperties.vertexTangents = undefined;
-			materialProperties.toneMapping = undefined;
-
-			materialProperties.fog = undefined;
-			materialProperties.environment = undefined;
-			materialProperties.envMap = undefined;
-			materialProperties.envMapRotation = undefined;
-
-			materialProperties.programs = undefined;
-			materialProperties.currentProgram = undefined;
-			materialProperties.uniforms = undefined;
-			materialProperties.uniformsList = undefined;
-
-			materialProperties.needsLights = undefined;
-			materialProperties.lightsStateVersion = undefined;
-
-			materialProperties.receiveShadow = undefined;
-			materialProperties.__version = undefined;
-
-		}
 
 		function getProgram( material, scene, object ) {
 
@@ -2083,9 +2048,45 @@ class WebGLRenderer {
 
 			const materialProperties = properties.get( material );
 
-			if ( materialProperties.programs === undefined ) {
+			if ( materialProperties.init === undefined ) {
 
-				initMaterialProperties( materialProperties );
+				materialProperties.init = true;
+
+				materialProperties.outputColorSpace = undefined;
+
+				materialProperties.batching = undefined;
+				materialProperties.batchingColor = undefined;
+				materialProperties.instancing = undefined;
+				materialProperties.instancingColor = undefined;
+				materialProperties.instancingMorph = undefined;
+				materialProperties.skinning = undefined;
+				materialProperties.morphTargets = undefined;
+				materialProperties.morphNormals = undefined;
+				materialProperties.morphColors = undefined;
+				materialProperties.morphTargetsCount = undefined;
+				materialProperties.numClippingPlanes = undefined;
+				materialProperties.numIntersection = undefined;
+				materialProperties.vertexAlphas = undefined;
+				materialProperties.vertexTangents = undefined;
+				materialProperties.toneMapping = undefined;
+
+				materialProperties.fog = undefined;
+				materialProperties.environment = undefined;
+				materialProperties.envMap = undefined;
+				materialProperties.envMapRotation = undefined;
+
+				materialProperties.programs = undefined;
+				materialProperties.currentProgram = undefined;
+				materialProperties.uniforms = undefined;
+				materialProperties.uniformsList = undefined;
+
+				materialProperties.needsLights = undefined;
+				materialProperties.lightsStateVersion = undefined;
+
+				materialProperties.receiveShadow = undefined;
+				materialProperties.light = undefined;
+				materialProperties.clippingState = undefined;
+				materialProperties.__version = undefined;
 
 			}
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2048,47 +2048,7 @@ class WebGLRenderer {
 
 			const materialProperties = properties.get( material );
 
-			if ( materialProperties.init === undefined ) {
 
-				materialProperties.init = true;
-
-				materialProperties.outputColorSpace = undefined;
-
-				materialProperties.batching = undefined;
-				materialProperties.batchingColor = undefined;
-				materialProperties.instancing = undefined;
-				materialProperties.instancingColor = undefined;
-				materialProperties.instancingMorph = undefined;
-				materialProperties.skinning = undefined;
-				materialProperties.morphTargets = undefined;
-				materialProperties.morphNormals = undefined;
-				materialProperties.morphColors = undefined;
-				materialProperties.morphTargetsCount = undefined;
-				materialProperties.numClippingPlanes = undefined;
-				materialProperties.numIntersection = undefined;
-				materialProperties.vertexAlphas = undefined;
-				materialProperties.vertexTangents = undefined;
-				materialProperties.toneMapping = undefined;
-
-				materialProperties.fog = undefined;
-				materialProperties.environment = undefined;
-				materialProperties.envMap = undefined;
-				materialProperties.envMapRotation = undefined;
-
-				materialProperties.programs = undefined;
-				materialProperties.currentProgram = undefined;
-				materialProperties.uniforms = undefined;
-				materialProperties.uniformsList = undefined;
-
-				materialProperties.needsLights = undefined;
-				materialProperties.lightsStateVersion = undefined;
-
-				materialProperties.receiveShadow = undefined;
-				materialProperties.light = undefined;
-				materialProperties.clippingState = undefined;
-				materialProperties.__version = undefined;
-
-			}
 
 			const lights = currentRenderState.state.lights;
 			const shadowsArray = currentRenderState.state.shadowsArray;

--- a/src/renderers/webgl/WebGLProperties.js
+++ b/src/renderers/webgl/WebGLProperties.js
@@ -14,12 +14,97 @@ function WebGLProperties() {
 
 		if ( map === undefined ) {
 
-			map = {};
+			if ( object.isMaterial ) {
+
+				map = createMaterialProperties();
+
+			} else if ( object.isTexture ) {
+
+				map = createTextureProperties();
+
+			} else if ( object.isWebGLRenderTarget ) {
+
+				map = createRenderTargetProperties();
+
+			} else {
+
+				map = {};
+
+			}
+
 			properties.set( object, map );
 
 		}
 
 		return map;
+
+	}
+
+	function createMaterialProperties() {
+
+		return {
+			outputColorSpace: undefined,
+			batching: undefined,
+			batchingColor: undefined,
+			instancing: undefined,
+			instancingColor: undefined,
+			instancingMorph: undefined,
+			skinning: undefined,
+			morphTargets: undefined,
+			morphNormals: undefined,
+			morphColors: undefined,
+			morphTargetsCount: undefined,
+			numClippingPlanes: undefined,
+			numIntersection: undefined,
+			vertexAlphas: undefined,
+			vertexTangents: undefined,
+			toneMapping: undefined,
+			fog: undefined,
+			environment: undefined,
+			envMap: undefined,
+			envMapRotation: undefined,
+			programs: undefined,
+			currentProgram: undefined,
+			uniforms: undefined,
+			uniformsList: undefined,
+			needsLights: undefined,
+			lightsStateVersion: undefined,
+			receiveShadow: undefined,
+			light: undefined,
+			clippingState: undefined,
+			__version: undefined
+		};
+
+	}
+
+	function createTextureProperties() {
+
+		return {
+			__init: undefined,
+			__webglTexture: undefined,
+			__cacheKey: undefined,
+			__version: undefined,
+			__currentAnisotropy: undefined,
+			__renderTarget: undefined
+		};
+
+	}
+
+	function createRenderTargetProperties() {
+
+		return {
+			__webglFramebuffer: undefined,
+			__webglDepthbuffer: undefined,
+			__webglMultisampledFramebuffer: undefined,
+			__webglColorRenderbuffer: undefined,
+			__webglDepthRenderbuffer: undefined,
+			__hasExternalTextures: undefined,
+			__boundDepthTexture: undefined,
+			__depthDisposeCallback: undefined,
+			__autoAllocateDepthBuffer: undefined,
+			__useRenderToTexture: undefined,
+			__useDefaultFramebuffer: undefined
+		};
 
 	}
 

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -29,7 +29,7 @@ function WebGLShadowMap( renderer, objects, capabilities ) {
 		_depthMaterialVSM = new MeshDepthMaterial( { depthPacking: IdentityDepthPacking } ),
 		_distanceMaterial = new MeshDistanceMaterial(),
 
-		_materialCache = {},
+		_materialCache = new Map(),
 
 		_maxTextureSize = capabilities.maxTextureSize;
 
@@ -392,21 +392,21 @@ function WebGLShadowMap( renderer, objects, capabilities ) {
 
 				const keyA = result.uuid, keyB = material.uuid;
 
-				let materialsForVariant = _materialCache[ keyA ];
+				let materialsForVariant = _materialCache.get( keyA );
 
 				if ( materialsForVariant === undefined ) {
 
-					materialsForVariant = {};
-					_materialCache[ keyA ] = materialsForVariant;
+					materialsForVariant = new Map();
+					_materialCache.set( keyA, materialsForVariant );
 
 				}
 
-				let cachedMaterial = materialsForVariant[ keyB ];
+				let cachedMaterial = materialsForVariant.get( keyB );
 
 				if ( cachedMaterial === undefined ) {
 
 					cachedMaterial = result.clone();
-					materialsForVariant[ keyB ] = cachedMaterial;
+					materialsForVariant.set( keyB, cachedMaterial );
 					material.addEventListener( 'dispose', onMaterialDispose );
 
 				}
@@ -528,17 +528,15 @@ function WebGLShadowMap( renderer, objects, capabilities ) {
 
 		// make sure to remove the unique distance/depth materials used for shadow map rendering
 
-		for ( const id in _materialCache ) {
-
-			const cache = _materialCache[ id ];
+		for ( const cache of _materialCache.values() ) {
 
 			const uuid = event.target.uuid;
 
-			if ( uuid in cache ) {
+			if ( cache.has( uuid ) ) {
 
-				const shadowMaterial = cache[ uuid ];
+				const shadowMaterial = cache.get( uuid );
 				shadowMaterial.dispose();
-				delete cache[ uuid ];
+				cache.delete( uuid );
 
 			}
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -672,9 +672,15 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		let forceUpload = false;
 
-		if ( textureProperties.__webglInit === undefined ) {
+		if ( textureProperties.__init === undefined ) {
 
-			textureProperties.__webglInit = true;
+			textureProperties.__init = true;
+
+			textureProperties.__webglTexture = undefined;
+			textureProperties.__cacheKey = undefined;
+			textureProperties.__version = undefined;
+			textureProperties.__currentAnisotropy = undefined;
+			textureProperties.__renderTarget = undefined;
 
 			texture.addEventListener( 'dispose', onTextureDispose );
 
@@ -1671,9 +1677,9 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 		if ( isCube ) {
 
 			// For cube depth textures, initialize and bind without uploading image data
-			if ( textureProperties.__webglInit === undefined ) {
+			if ( textureProperties.__init === undefined ) {
 
-				textureProperties.__webglInit = true;
+				textureProperties.__init = true;
 				renderTarget.depthTexture.addEventListener( 'dispose', onTextureDispose );
 
 			}
@@ -1907,6 +1913,24 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 		const texture = renderTarget.texture;
 
 		const renderTargetProperties = properties.get( renderTarget );
+
+		if ( renderTargetProperties.__init === undefined ) {
+
+			renderTargetProperties.__init = true;
+
+			renderTargetProperties.__webglFramebuffer = undefined;
+			renderTargetProperties.__webglDepthbuffer = undefined;
+			renderTargetProperties.__webglMultisampledFramebuffer = undefined;
+			renderTargetProperties.__webglColorRenderbuffer = undefined;
+			renderTargetProperties.__webglDepthRenderbuffer = undefined;
+			renderTargetProperties.__hasExternalTextures = undefined;
+			renderTargetProperties.__boundDepthTexture = undefined;
+			renderTargetProperties.__depthDisposeCallback = undefined;
+			renderTargetProperties.__autoAllocateDepthBuffer = undefined;
+			renderTargetProperties.__useRenderToTexture = undefined;
+			renderTargetProperties.__useDefaultFramebuffer = undefined;
+
+		}
 		const textureProperties = properties.get( texture );
 
 		renderTarget.addEventListener( 'dispose', onRenderTargetDispose );

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -1776,8 +1776,8 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 				const disposeEvent = () => {
 
-					delete renderTargetProperties.__boundDepthTexture;
-					delete renderTargetProperties.__depthDisposeCallback;
+					renderTargetProperties.__boundDepthTexture = undefined;
+					renderTargetProperties.__depthDisposeCallback = undefined;
 					depthTexture.removeEventListener( 'dispose', disposeEvent );
 
 				};

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -1931,6 +1931,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 			renderTargetProperties.__useDefaultFramebuffer = undefined;
 
 		}
+
 		const textureProperties = properties.get( texture );
 
 		renderTarget.addEventListener( 'dispose', onRenderTargetDispose );

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -672,9 +672,9 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		let forceUpload = false;
 
-		if ( textureProperties.__init === undefined ) {
+		if ( textureProperties.__webglInit === undefined ) {
 
-			textureProperties.__init = true;
+			textureProperties.__webglInit = true;
 
 			texture.addEventListener( 'dispose', onTextureDispose );
 
@@ -1671,9 +1671,9 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 		if ( isCube ) {
 
 			// For cube depth textures, initialize and bind without uploading image data
-			if ( textureProperties.__init === undefined ) {
+			if ( textureProperties.__webglInit === undefined ) {
 
-				textureProperties.__init = true;
+				textureProperties.__webglInit = true;
 				renderTarget.depthTexture.addEventListener( 'dispose', onTextureDispose );
 
 			}
@@ -1907,9 +1907,6 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 		const texture = renderTarget.texture;
 
 		const renderTargetProperties = properties.get( renderTarget );
-
-
-
 		const textureProperties = properties.get( texture );
 
 		renderTarget.addEventListener( 'dispose', onRenderTargetDispose );

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -676,12 +676,6 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 			textureProperties.__init = true;
 
-			textureProperties.__webglTexture = undefined;
-			textureProperties.__cacheKey = undefined;
-			textureProperties.__version = undefined;
-			textureProperties.__currentAnisotropy = undefined;
-			textureProperties.__renderTarget = undefined;
-
 			texture.addEventListener( 'dispose', onTextureDispose );
 
 		}
@@ -1914,23 +1908,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		const renderTargetProperties = properties.get( renderTarget );
 
-		if ( renderTargetProperties.__init === undefined ) {
 
-			renderTargetProperties.__init = true;
-
-			renderTargetProperties.__webglFramebuffer = undefined;
-			renderTargetProperties.__webglDepthbuffer = undefined;
-			renderTargetProperties.__webglMultisampledFramebuffer = undefined;
-			renderTargetProperties.__webglColorRenderbuffer = undefined;
-			renderTargetProperties.__webglDepthRenderbuffer = undefined;
-			renderTargetProperties.__hasExternalTextures = undefined;
-			renderTargetProperties.__boundDepthTexture = undefined;
-			renderTargetProperties.__depthDisposeCallback = undefined;
-			renderTargetProperties.__autoAllocateDepthBuffer = undefined;
-			renderTargetProperties.__useRenderToTexture = undefined;
-			renderTargetProperties.__useDefaultFramebuffer = undefined;
-
-		}
 
 		const textureProperties = properties.get( texture );
 


### PR DESCRIPTION
**Description**

Enforces consistent object shapes (Hidden Classes) for `materialProperties`, `textureProperties`, and `renderTargetProperties` to enable monomorphic property access in V8, resulting in a ~3.4x performance improvement in property lookups.

Additionally:

* **WebGLTextures.js**: Replaced `delete` keyword usage with `undefined` assignment for `renderTargetProperties` to prevent hidden class transitions.
* **WebGLBindingStates.js**: Refactored `bindingStates`, `programMap`, and `stateMap` to use `Map` instead of plain objects, eliminating `delete` usage in hot paths.
* **WebGLShadowMap.js**: Refactored `_materialCache` to use `Map` instead of plain objects, eliminating `delete` usage.