### PR TITLE
Fix JSDoc return type and numeric literal consistency

### DIFF
--- a/src/math/Line3.js
+++ b/src/math/Line3.js
@@ -268,10 +268,10 @@ class Line3 {
 				// of t using s = Dot((P2 + D2*t) - P1,D1) / Dot(D1,D1)= (t*b - c) / a
 				// and clamp s to [0, 1]
 
-				if ( t < 0 ) {
+			if ( t < 0 ) {
 
-					t = 0.;
-					s = clamp( - c / a, 0, 1 );
+				t = 0;
+				s = clamp( - c / a, 0, 1 );
 
 				} else if ( t > 1 ) {
 

--- a/src/math/Sphere.js
+++ b/src/math/Sphere.js
@@ -405,7 +405,7 @@ class Sphere {
 	 * Returns a serialized structure of the bounding sphere.
 	 *
 	 * @param {Object} json - The serialized json to set the sphere from.
-	 * @return {Box3} A reference to this bounding sphere.
+	 * @return {Sphere} A reference to this bounding sphere.
 	 */
 	fromJSON( json ) {
 


### PR DESCRIPTION
### **Description**

This PR addresses two minor issues identified during a codebase review:

1. **Incorrect JSDoc return type in `Sphere.fromJSON()`**
   The method’s documentation previously stated that it returns a `{Box3}`, which is incorrect. The method actually returns a `{Sphere}` instance. This update corrects the JSDoc annotation so that it accurately reflects the method’s return value, improving clarity and preventing confusion for developers referencing the API docs.

2. **Inconsistent numeric literal in `Line3.distanceSqToLine3()`**
   The code included the expression `t = 0.;` on line 273, which is inconsistent with the numeric literal style used throughout the Three.js codebase (typically `0` or `0.0`). This change standardizes the notation to `t = 0;`, enhancing code consistency and readability.
