### PR TITLE
WebGPURenderer: Fix V8 deoptimizations.

### DIFF
--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -952,7 +952,7 @@ class NodeBuilder {
 
 		const context = { ...this.context };
 
-		delete context.material;
+		context.material = undefined;
 
 		return this.context;
 
@@ -2515,7 +2515,7 @@ class NodeBuilder {
 		this.setShaderStage( shaderStage );
 
 		const context = { ...this.context };
-		delete context.nodeBlock;
+		context.nodeBlock = undefined;
 
 		this.cache = this.globalCache;
 		this.tab = '\t';

--- a/src/nodes/core/UniformNode.js
+++ b/src/nodes/core/UniformNode.js
@@ -175,7 +175,7 @@ class UniformNode extends InputNode {
 		const nodeUniform = builder.getUniformFromNode( sharedNode, sharedNodeType, builder.shaderStage, this.name || builder.context.nodeName );
 		const uniformName = builder.getPropertyName( nodeUniform );
 
-		if ( builder.context.nodeName !== undefined ) delete builder.context.nodeName;
+		if ( builder.context.nodeName !== undefined ) builder.context.nodeName = undefined;
 
 		//
 

--- a/src/renderers/common/RenderObject.js
+++ b/src/renderers/common/RenderObject.js
@@ -2,35 +2,49 @@ import { hash, hashString } from '../../nodes/core/NodeUtils.js';
 
 let _id = 0;
 
+const prototypeKeys = new WeakMap();
+
 function getKeys( obj ) {
 
 	const keys = Object.keys( obj );
 
-	let proto = Object.getPrototypeOf( obj );
+	const proto = Object.getPrototypeOf( obj );
+	let cachedKeys = prototypeKeys.get( proto );
 
-	while ( proto ) {
+	if ( cachedKeys === undefined ) {
 
-		const descriptors = Object.getOwnPropertyDescriptors( proto );
+		cachedKeys = [];
+		let p = proto;
 
-		for ( const key in descriptors ) {
+		while ( p ) {
 
-			if ( descriptors[ key ] !== undefined ) {
+			const descriptors = Object.getOwnPropertyDescriptors( p );
 
-				const descriptor = descriptors[ key ];
+			for ( const key in descriptors ) {
 
-				if ( descriptor && typeof descriptor.get === 'function' ) {
+				if ( descriptors[ key ] !== undefined ) {
 
-					keys.push( key );
+					const descriptor = descriptors[ key ];
+
+					if ( descriptor && typeof descriptor.get === 'function' ) {
+
+						cachedKeys.push( key );
+
+					}
 
 				}
 
 			}
 
+			p = Object.getPrototypeOf( p );
+
 		}
 
-		proto = Object.getPrototypeOf( proto );
+		prototypeKeys.set( proto, cachedKeys );
 
 	}
+
+	keys.push( ...cachedKeys );
 
 	return keys;
 

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -1037,8 +1037,8 @@ class Renderer {
 
 		} else if ( this.highPrecision ) {
 
-			delete contextNodeData.modelViewMatrix;
-			delete contextNodeData.modelNormalViewMatrix;
+			contextNodeData.modelViewMatrix = undefined;
+			contextNodeData.modelNormalViewMatrix = undefined;
 
 		}
 

--- a/src/renderers/common/nodes/Nodes.js
+++ b/src/renderers/common/nodes/Nodes.js
@@ -525,8 +525,8 @@ class Nodes extends DataMap {
 
 		} else if ( sceneData.backgroundNode ) {
 
-			delete sceneData.backgroundNode;
-			delete sceneData.background;
+			sceneData.backgroundNode = undefined;
+			sceneData.background = undefined;
 
 		}
 
@@ -606,8 +606,8 @@ class Nodes extends DataMap {
 
 		} else {
 
-			delete sceneData.fogNode;
-			delete sceneData.fog;
+			sceneData.fogNode = undefined;
+			sceneData.fog = undefined;
 
 		}
 
@@ -653,8 +653,8 @@ class Nodes extends DataMap {
 
 		} else if ( sceneData.environmentNode ) {
 
-			delete sceneData.environmentNode;
-			delete sceneData.environment;
+			sceneData.environmentNode = undefined;
+			sceneData.environment = undefined;
 
 		}
 


### PR DESCRIPTION
**Description**

This PR addresses several V8 deoptimization patterns in the WebGPU renderer to improve performance and stability.

* `RenderObject.js`: Optimized `getKeys` by caching prototype keys in a WeakMap, significantly reducing reflection overhead.
* `Renderer.js`, `Nodes.js`, `NodeBuilder.js`, `UniformNode.js`: Replaced `delete` keyword usage with `undefined` assignment to prevent hidden class transitions and keep object shapes stable.

These changes ensure more stable hidden classes and reduce garbage collection overhead associated with dictionary mode objects.