### PR TITLE
Optimize Vogel disk sampling sqrt.

### DIFF
--- a/src/nodes/utils/PostProcessingUtils.js
+++ b/src/nodes/utils/PostProcessingUtils.js
@@ -139,7 +139,7 @@ export const interleavedGradientNoise = Fn( ( [ position ] ) => {
 export const vogelDiskSample = Fn( ( [ sampleIndex, samplesCount, phi ] ) => {
 
 	const goldenAngle = float( 2.399963229728653 ); // 2π * (2 - φ) where φ is golden ratio
-	const r = sqrt( float( sampleIndex ).add( 0.5 ) ).div( sqrt( float( samplesCount ) ) );
+	const r = sqrt( float( sampleIndex ).add( 0.5 ).div( float( samplesCount ) ) );
 	const theta = float( sampleIndex ).mul( goldenAngle ).add( phi );
 	return vec2( cos( theta ), sin( theta ) ).mul( r );
 

--- a/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl.js
@@ -104,7 +104,7 @@ export default /* glsl */`
 		vec2 vogelDiskSample( int sampleIndex, int samplesCount, float phi ) {
 
 			const float goldenAngle = 2.399963229728653;
-			float r = sqrt( float( sampleIndex ) + 0.5 ) / sqrt( float( samplesCount ) );
+			float r = sqrt( ( float( sampleIndex ) + 0.5 ) / float( samplesCount ) );
 			float theta = float( sampleIndex ) * goldenAngle + phi;
 			return vec2( cos( theta ), sin( theta ) ) * r;
 


### PR DESCRIPTION
Related issue: #32303 #32381

**Description**

Combine two `sqrt` operations into one using the identity `sqrt(a)/sqrt(b) = sqrt(a/b)`.