### PR TITLE
Editor: Save and restore controls state.

### DIFF
--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -647,6 +647,12 @@ Editor.prototype = {
 		delete this.cameras[ existingUuid ]; // remove old entry [existingUuid, this.camera]
 		this.cameras[ incomingUuid ] = this.camera; // add new entry [incomingUuid, this.camera]
 
+		if ( json.controls !== undefined ) {
+
+			this.controls.fromJSON( json.controls );
+
+		}
+
 		this.signals.cameraResetted.dispatch();
 
 		this.history.fromJSON( json.history );
@@ -705,6 +711,7 @@ Editor.prototype = {
 				toneMappingExposure: this.config.getKey( 'project/renderer/toneMappingExposure' )
 			},
 			camera: this.viewportCamera.toJSON(),
+			controls: this.controls.toJSON(),
 			scene: this.scene.toJSON(),
 			scripts: this.scripts,
 			history: this.history.toJSON(),

--- a/editor/js/EditorControls.js
+++ b/editor/js/EditorControls.js
@@ -445,6 +445,20 @@ class EditorControls extends THREE.EventDispatcher {
 
 	}
 
+	fromJSON( json ) {
+
+		if ( json.center !== undefined ) this.center.fromArray( json.center );
+
+	}
+
+	toJSON() {
+
+		return {
+			center: this.center.toArray()
+		};
+
+	}
+
 }
 
 export { EditorControls };

--- a/editor/js/Viewport.js
+++ b/editor/js/Viewport.js
@@ -283,6 +283,8 @@ function Viewport( editor ) {
 	} );
 	viewHelper.center = controls.center;
 
+	editor.controls = controls;
+
 	// signals
 
 	signals.editorCleared.add( function () {


### PR DESCRIPTION
**Description**

Fixes a camera jump that occurred when loading a scene from storage.

The issue was that `EditorControls.center` (the orbit pivot point) wasn't being saved, so it remained at (0,0,0) after restore. When the user first moved the camera, `lookAt(center)` would snap the view to the origin.