### PR TITLE
ExtrudeGeometry: Honor `closed` property of `CatmullRomCurve3`.

### DIFF
--- a/src/geometries/ExtrudeGeometry.js
+++ b/src/geometries/ExtrudeGeometry.js
@@ -112,9 +112,9 @@ class ExtrudeGeometry extends BufferGeometry {
 
 				// SETUP TNB variables
 
-				const closed = extrudePath.isCatmullRomCurve3 ? extrudePath.closed : false;
+				const isClosed = extrudePath.isCatmullRomCurve3 ? extrudePath.closed : false;
 
-				splineTube = extrudePath.computeFrenetFrames( steps, closed );
+				splineTube = extrudePath.computeFrenetFrames( steps, isClosed );
 
 				// log(splineTube, 'splineTube', splineTube.normals.length, 'steps', steps, 'extrudePts', extrudePts.length);
 

--- a/src/geometries/ExtrudeGeometry.js
+++ b/src/geometries/ExtrudeGeometry.js
@@ -112,9 +112,9 @@ class ExtrudeGeometry extends BufferGeometry {
 
 				// SETUP TNB variables
 
-				// TODO1 - have a .isClosed in spline?
+				const closed = extrudePath.isCatmullRomCurve3 ? extrudePath.closed : false;
 
-				splineTube = extrudePath.computeFrenetFrames( steps, false );
+				splineTube = extrudePath.computeFrenetFrames( steps, closed );
 
 				// log(splineTube, 'splineTube', splineTube.normals.length, 'steps', steps, 'extrudePts', extrudePts.length);
 


### PR DESCRIPTION
Related issue: #32359

**Description**

I've revisited #32359 since I've wanted to get rid of the TODO in `ExtrudeGeometry`. After looking closer at the history of `ExtrudeGeometry`, it was easier to understand where the TODO came from.

Instead of having a straight line along the extrusion happens, an optional extrude path allows for more customization.  I suspect when this feature was initially implemented, it was not designed to create a closed extruded shape though. Hence, the `closed` parameter of `computeFrenetFrames()` was always set to `false`. 

When `CatmullRomCurve3` came around, there was eventually one curve class that had a `closed` property. And indeed if `closed` is set to `true` on the curve, it is right to assign the same value when computing to Frenet Frames since the last set of data are more correct.
 
Compared to #32359, this PR does an explicit test on `CatmullRomCurve3` so it's clear where the `closed` property comes from. I've also visually compared a few closed extruded shapes with this PR and r181 but I did not see any differences. Looking at the normal and binormal values from the Frenet Frames data, the numerical differences are so tiny that it's clear why no hard seam appears when rendering with a normal material. The fix is still worth it, imo.
