### PR TITLE
Inspector: Fix cube depth texture error

### DIFF
--- a/examples/jsm/inspector/ui/Style.js
+++ b/examples/jsm/inspector/ui/Style.js
@@ -879,7 +879,14 @@ export class Style {
 	border-bottom: none;
 	user-select: none;
 	-webkit-user-select: none;
+}
+
+.parameters .list-item-row {
 	min-height: 31px;
+}
+
+.mini-panel-content .parameters .list-item-row {
+	min-height: 21px;
 }
 
 .list-item-wrapper {
@@ -1178,6 +1185,7 @@ export class Style {
 	align-items: center;
 	cursor: pointer;
 	gap: 8px;
+	will-change: transform;
 }
 
 .custom-checkbox input {
@@ -1187,7 +1195,7 @@ export class Style {
 .custom-checkbox .checkmark {
 	width: 14px;
 	height: 14px;
-	border: 1px solid var(--profiler-border);
+	border: 1px solid var(--accent-color);
 	border-radius: 3px;
 	display: inline-flex;
 	justify-content: center;
@@ -1298,11 +1306,12 @@ export class Style {
 	width: 12px;
 	height: 12px;
 	margin-bottom: 2px;
+	will-change: transform;
 }
 
 .mini-panel-content .custom-checkbox .checkmark::after {
-	width: 8px;
-	height: 8px;
+	width: 7px;
+	height: 7px;
 }
 
 .mini-panel-content .list-container.parameters .list-item-row:not(.collapsible) {

--- a/src/nodes/lighting/ShadowNode.js
+++ b/src/nodes/lighting/ShadowNode.js
@@ -557,7 +557,13 @@ class ShadowNode extends ShadowBaseNode {
 
 		} ).toInspector( `${ inspectName } / Depth`, () => {
 
-			return textureLoad( this.shadowMap.depthTexture, uv().mul( textureSize( texture( this.shadowMap.depthTexture ) ) ) ).x.oneMinus();
+			if ( this.shadowMap.texture.isCubeTexture ) {
+
+				return cubeTexture( this.shadowMap.texture ).r.oneMinus();
+
+			}
+
+			return textureLoad( this.shadowMap.depthTexture, uv().mul( textureSize( texture( this.shadowMap.depthTexture ) ) ) ).r.oneMinus();
 
 		} );
 

--- a/src/nodes/lighting/ShadowNode.js
+++ b/src/nodes/lighting/ShadowNode.js
@@ -557,6 +557,8 @@ class ShadowNode extends ShadowBaseNode {
 
 		} ).toInspector( `${ inspectName } / Depth`, () => {
 
+			// TODO: Use linear depth
+
 			if ( this.shadowMap.texture.isCubeTexture ) {
 
 				return cubeTexture( this.shadowMap.texture ).r.oneMinus();


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/32381

**Description**

It's still necessary to convert to linear depth, but at least it omits the errors.

- Fix cube depth texture error
- Improve UI details