### PR TITLE
Light: Unify `toJSON()` implementations.

### DIFF
--- a/src/lights/DirectionalLight.js
+++ b/src/lights/DirectionalLight.js
@@ -95,6 +95,17 @@ class DirectionalLight extends Light {
 
 	}
 
+	toJSON( meta ) {
+
+		const data = super.toJSON( meta );
+
+		data.object.shadow = this.shadow.toJSON();
+		data.object.target = this.target.uuid;
+
+		return data;
+
+	}
+
 }
 
 export { DirectionalLight };

--- a/src/lights/HemisphereLight.js
+++ b/src/lights/HemisphereLight.js
@@ -61,6 +61,16 @@ class HemisphereLight extends Light {
 
 	}
 
+	toJSON( meta ) {
+
+		const data = super.toJSON( meta );
+
+		data.object.groundColor = this.groundColor.getHex();
+
+		return data;
+
+	}
+
 }
 
 export { HemisphereLight };

--- a/src/lights/Light.js
+++ b/src/lights/Light.js
@@ -76,16 +76,6 @@ class Light extends Object3D {
 		data.object.color = this.color.getHex();
 		data.object.intensity = this.intensity;
 
-		if ( this.groundColor !== undefined ) data.object.groundColor = this.groundColor.getHex();
-
-		if ( this.distance !== undefined ) data.object.distance = this.distance;
-		if ( this.angle !== undefined ) data.object.angle = this.angle;
-		if ( this.decay !== undefined ) data.object.decay = this.decay;
-		if ( this.penumbra !== undefined ) data.object.penumbra = this.penumbra;
-
-		if ( this.shadow !== undefined ) data.object.shadow = this.shadow.toJSON();
-		if ( this.target !== undefined ) data.object.target = this.target.uuid;
-
 		return data;
 
 	}

--- a/src/lights/PointLight.js
+++ b/src/lights/PointLight.js
@@ -111,6 +111,19 @@ class PointLight extends Light {
 
 	}
 
+	toJSON( meta ) {
+
+		const data = super.toJSON( meta );
+
+		data.object.distance = this.distance;
+		data.object.decay = this.decay;
+
+		data.object.shadow = this.shadow.toJSON();
+
+		return data;
+
+	}
+
 }
 
 export { PointLight };

--- a/src/lights/SpotLight.js
+++ b/src/lights/SpotLight.js
@@ -161,10 +161,29 @@ class SpotLight extends Light {
 		this.decay = source.decay;
 
 		this.target = source.target.clone();
-
+		this.map = source.map;
 		this.shadow = source.shadow.clone();
 
 		return this;
+
+	}
+
+	toJSON( meta ) {
+
+		const data = super.toJSON( meta );
+
+		data.object.distance = this.distance;
+		data.object.angle = this.angle;
+		data.object.decay = this.decay;
+		data.object.penumbra = this.penumbra;
+
+		data.object.target = this.target.uuid;
+
+		if ( this.map && this.map.isTexture ) data.object.map = this.map.toJSON( meta ).uuid;
+
+		data.object.shadow = this.shadow.toJSON();
+
+		return data;
 
 	}
 


### PR DESCRIPTION
Related issue: -

**Description**

Small cleanup to ensure the `toJSON()` implementations of light classes work in a consistent fashion. All lights behave now like `LightProbe` and `RectAreaLight` which means each class is responsible to serialize its own properties. This is a cleaner OO design than checking for properties of subclasses which was previously done in `Light.toJSON()`.

Besides, `SpotLight.map` is now correctly serialized and copied.