### PR TITLE
LightProbe: Remove `fromJSON()`.

### DIFF
--- a/src/lights/LightProbe.js
+++ b/src/lights/LightProbe.js
@@ -60,21 +60,6 @@ class LightProbe extends Light {
 
 	}
 
-	/**
-	 * Deserializes the light prove from the given JSON.
-	 *
-	 * @param {Object} json - The JSON holding the serialized light probe.
-	 * @return {LightProbe} A reference to this light probe.
-	 */
-	fromJSON( json ) {
-
-		this.intensity = json.intensity; // TODO: Move this bit to Light.fromJSON();
-		this.sh.fromArray( json.sh );
-
-		return this;
-
-	}
-
 	toJSON( meta ) {
 
 		const data = super.toJSON( meta );

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -62,6 +62,7 @@ import * as Geometries from '../geometries/Geometries.js';
 import { getTypedArray, error, warn } from '../utils.js';
 import { Box3 } from '../math/Box3.js';
 import { Sphere } from '../math/Sphere.js';
+import { SphericalHarmonics3 } from '../math/SphericalHarmonics3.js';
 
 /**
  * A loader for loading a JSON resource in the [JSON Object/Scene format](https://github.com/mrdoob/three.js/wiki/JSON-Object-Scene-format-4).
@@ -920,7 +921,8 @@ class ObjectLoader extends Loader {
 
 			case 'LightProbe':
 
-				object = new LightProbe().fromJSON( data );
+				const sh = new SphericalHarmonics3().fromArray( data.sh );
+				object = new LightProbe( sh, data.intensity );
 
 				break;
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/32318#issuecomment-3554688238

**Description**

The PR removes `LightProbe.fromJSON()` to ensure all lights are deserialized in the same fashion in `ObjectLoader`.

I have first tried to add `fromJSON()` in all lights but the deserialization of shadow cameras and light targets requires logic from `ObjectLoader`. So without a bigger rewrite, it's not possible to have consistent `fromJSON()` methods. This PR just ensures a consistent handling across all light classes.
