### PR TITLE
Fix: Add separate Line2 thresholds for world and pixel units

### DIFF
--- a/examples/jsm/lines/LineSegments2.js
+++ b/examples/jsm/lines/LineSegments2.js
@@ -35,55 +35,56 @@ let _ray, _lineWidth;
 
 // Returns the margin required to expand by in world space given the distance from the camera,
 // line width, resolution, and camera projection
-function getWorldSpaceHalfWidth( camera, distance, resolution ) {
+function getWorldSpaceHalfWidth(camera, distance, resolution) {
 
 	// transform into clip space, adjust the x and y values by the pixel width offset, then
 	// transform back into world space to get world offset. Note clip space is [-1, 1] so full
 	// width does not need to be halved.
-	_clipToWorldVector.set( 0, 0, - distance, 1.0 ).applyMatrix4( camera.projectionMatrix );
-	_clipToWorldVector.multiplyScalar( 1.0 / _clipToWorldVector.w );
+	_clipToWorldVector.set(0, 0, - distance, 1.0).applyMatrix4(camera.projectionMatrix);
+	_clipToWorldVector.multiplyScalar(1.0 / _clipToWorldVector.w);
 	_clipToWorldVector.x = _lineWidth / resolution.width;
 	_clipToWorldVector.y = _lineWidth / resolution.height;
-	_clipToWorldVector.applyMatrix4( camera.projectionMatrixInverse );
-	_clipToWorldVector.multiplyScalar( 1.0 / _clipToWorldVector.w );
+	_clipToWorldVector.applyMatrix4(camera.projectionMatrixInverse);
+	_clipToWorldVector.multiplyScalar(1.0 / _clipToWorldVector.w);
 
-	return Math.abs( Math.max( _clipToWorldVector.x, _clipToWorldVector.y ) );
+	const margin = Math.abs(Math.max(_clipToWorldVector.x, _clipToWorldVector.y));
+	return margin;
 
 }
 
-function raycastWorldUnits( lineSegments, intersects ) {
+function raycastWorldUnits(lineSegments, intersects) {
 
 	const matrixWorld = lineSegments.matrixWorld;
 	const geometry = lineSegments.geometry;
 	const instanceStart = geometry.attributes.instanceStart;
 	const instanceEnd = geometry.attributes.instanceEnd;
-	const segmentCount = Math.min( geometry.instanceCount, instanceStart.count );
+	const segmentCount = Math.min(geometry.instanceCount, instanceStart.count);
 
-	for ( let i = 0, l = segmentCount; i < l; i ++ ) {
+	for (let i = 0, l = segmentCount; i < l; i++) {
 
-		_line.start.fromBufferAttribute( instanceStart, i );
-		_line.end.fromBufferAttribute( instanceEnd, i );
+		_line.start.fromBufferAttribute(instanceStart, i);
+		_line.end.fromBufferAttribute(instanceEnd, i);
 
-		_line.applyMatrix4( matrixWorld );
+		_line.applyMatrix4(matrixWorld);
 
 		const pointOnLine = new Vector3();
 		const point = new Vector3();
 
-		_ray.distanceSqToSegment( _line.start, _line.end, point, pointOnLine );
-		const isInside = point.distanceTo( pointOnLine ) < _lineWidth * 0.5;
+		_ray.distanceSqToSegment(_line.start, _line.end, point, pointOnLine);
+		const isInside = point.distanceTo(pointOnLine) < _lineWidth * 0.5;
 
-		if ( isInside ) {
+		if (isInside) {
 
-			intersects.push( {
+			intersects.push({
 				point,
 				pointOnLine,
-				distance: _ray.origin.distanceTo( point ),
+				distance: _ray.origin.distanceTo(point),
 				object: lineSegments,
 				face: null,
 				faceIndex: i,
 				uv: null,
 				uv1: null,
-			} );
+			});
 
 		}
 
@@ -91,7 +92,7 @@ function raycastWorldUnits( lineSegments, intersects ) {
 
 }
 
-function raycastScreenSpace( lineSegments, camera, intersects ) {
+function raycastScreenSpace(lineSegments, camera, intersects) {
 
 	const projectionMatrix = camera.projectionMatrix;
 	const material = lineSegments.material;
@@ -101,7 +102,7 @@ function raycastScreenSpace( lineSegments, camera, intersects ) {
 	const geometry = lineSegments.geometry;
 	const instanceStart = geometry.attributes.instanceStart;
 	const instanceEnd = geometry.attributes.instanceEnd;
-	const segmentCount = Math.min( geometry.instanceCount, instanceStart.count );
+	const segmentCount = Math.min(geometry.instanceCount, instanceStart.count);
 
 	const near = - camera.near;
 
@@ -110,65 +111,65 @@ function raycastScreenSpace( lineSegments, camera, intersects ) {
 	// pick a point 1 unit out along the ray to avoid the ray origin
 	// sitting at the camera origin which will cause "w" to be 0 when
 	// applying the projection matrix.
-	_ray.at( 1, _ssOrigin );
+	_ray.at(1, _ssOrigin);
 
 	// ndc space [ - 1.0, 1.0 ]
 	_ssOrigin.w = 1;
-	_ssOrigin.applyMatrix4( camera.matrixWorldInverse );
-	_ssOrigin.applyMatrix4( projectionMatrix );
-	_ssOrigin.multiplyScalar( 1 / _ssOrigin.w );
+	_ssOrigin.applyMatrix4(camera.matrixWorldInverse);
+	_ssOrigin.applyMatrix4(projectionMatrix);
+	_ssOrigin.multiplyScalar(1 / _ssOrigin.w);
 
 	// screen space
 	_ssOrigin.x *= resolution.x / 2;
 	_ssOrigin.y *= resolution.y / 2;
 	_ssOrigin.z = 0;
 
-	_ssOrigin3.copy( _ssOrigin );
+	_ssOrigin3.copy(_ssOrigin);
 
-	_mvMatrix.multiplyMatrices( camera.matrixWorldInverse, matrixWorld );
+	_mvMatrix.multiplyMatrices(camera.matrixWorldInverse, matrixWorld);
 
-	for ( let i = 0, l = segmentCount; i < l; i ++ ) {
+	for (let i = 0, l = segmentCount; i < l; i++) {
 
-		_start4.fromBufferAttribute( instanceStart, i );
-		_end4.fromBufferAttribute( instanceEnd, i );
+		_start4.fromBufferAttribute(instanceStart, i);
+		_end4.fromBufferAttribute(instanceEnd, i);
 
 		_start4.w = 1;
 		_end4.w = 1;
 
 		// camera space
-		_start4.applyMatrix4( _mvMatrix );
-		_end4.applyMatrix4( _mvMatrix );
+		_start4.applyMatrix4(_mvMatrix);
+		_end4.applyMatrix4(_mvMatrix);
 
 		// skip the segment if it's entirely behind the camera
 		const isBehindCameraNear = _start4.z > near && _end4.z > near;
-		if ( isBehindCameraNear ) {
+		if (isBehindCameraNear) {
 
 			continue;
 
 		}
 
 		// trim the segment if it extends behind camera near
-		if ( _start4.z > near ) {
+		if (_start4.z > near) {
 
 			const deltaDist = _start4.z - _end4.z;
-			const t = ( _start4.z - near ) / deltaDist;
-			_start4.lerp( _end4, t );
+			const t = (_start4.z - near) / deltaDist;
+			_start4.lerp(_end4, t);
 
-		} else if ( _end4.z > near ) {
+		} else if (_end4.z > near) {
 
 			const deltaDist = _end4.z - _start4.z;
-			const t = ( _end4.z - near ) / deltaDist;
-			_end4.lerp( _start4, t );
+			const t = (_end4.z - near) / deltaDist;
+			_end4.lerp(_start4, t);
 
 		}
 
 		// clip space
-		_start4.applyMatrix4( projectionMatrix );
-		_end4.applyMatrix4( projectionMatrix );
+		_start4.applyMatrix4(projectionMatrix);
+		_end4.applyMatrix4(projectionMatrix);
 
 		// ndc space [ - 1.0, 1.0 ]
-		_start4.multiplyScalar( 1 / _start4.w );
-		_end4.multiplyScalar( 1 / _end4.w );
+		_start4.multiplyScalar(1 / _start4.w);
+		_end4.multiplyScalar(1 / _end4.w);
 
 		// screen space
 		_start4.x *= resolution.x / 2;
@@ -178,45 +179,45 @@ function raycastScreenSpace( lineSegments, camera, intersects ) {
 		_end4.y *= resolution.y / 2;
 
 		// create 2d segment
-		_line.start.copy( _start4 );
+		_line.start.copy(_start4);
 		_line.start.z = 0;
 
-		_line.end.copy( _end4 );
+		_line.end.copy(_end4);
 		_line.end.z = 0;
 
 		// get closest point on ray to segment
-		const param = _line.closestPointToPointParameter( _ssOrigin3, true );
-		_line.at( param, _closestPoint );
+		const param = _line.closestPointToPointParameter(_ssOrigin3, true);
+		_line.at(param, _closestPoint);
 
 		// check if the intersection point is within clip space
-		const zPos = MathUtils.lerp( _start4.z, _end4.z, param );
+		const zPos = MathUtils.lerp(_start4.z, _end4.z, param);
 		const isInClipSpace = zPos >= - 1 && zPos <= 1;
 
-		const isInside = _ssOrigin3.distanceTo( _closestPoint ) < _lineWidth * 0.5;
+		const isInside = _ssOrigin3.distanceTo(_closestPoint) < _lineWidth * 0.5;
 
-		if ( isInClipSpace && isInside ) {
+		if (isInClipSpace && isInside) {
 
-			_line.start.fromBufferAttribute( instanceStart, i );
-			_line.end.fromBufferAttribute( instanceEnd, i );
+			_line.start.fromBufferAttribute(instanceStart, i);
+			_line.end.fromBufferAttribute(instanceEnd, i);
 
-			_line.start.applyMatrix4( matrixWorld );
-			_line.end.applyMatrix4( matrixWorld );
+			_line.start.applyMatrix4(matrixWorld);
+			_line.end.applyMatrix4(matrixWorld);
 
 			const pointOnLine = new Vector3();
 			const point = new Vector3();
 
-			_ray.distanceSqToSegment( _line.start, _line.end, point, pointOnLine );
+			_ray.distanceSqToSegment(_line.start, _line.end, point, pointOnLine);
 
-			intersects.push( {
+			intersects.push({
 				point: point,
 				pointOnLine: pointOnLine,
-				distance: _ray.origin.distanceTo( point ),
+				distance: _ray.origin.distanceTo(point),
 				object: lineSegments,
 				face: null,
 				faceIndex: i,
 				uv: null,
 				uv1: null,
-			} );
+			});
 
 		}
 
@@ -256,9 +257,9 @@ class LineSegments2 extends Mesh {
 	 * @param {LineSegmentsGeometry} [geometry] - The line geometry.
 	 * @param {LineMaterial} [material] - The line material.
 	 */
-	constructor( geometry = new LineSegmentsGeometry(), material = new LineMaterial( { color: Math.random() * 0xffffff } ) ) {
+	constructor(geometry = new LineSegmentsGeometry(), material = new LineMaterial({ color: Math.random() * 0xffffff })) {
 
-		super( geometry, material );
+		super(geometry, material);
 
 		/**
 		 * This flag can be used for type testing.
@@ -288,22 +289,22 @@ class LineSegments2 extends Mesh {
 
 		const instanceStart = geometry.attributes.instanceStart;
 		const instanceEnd = geometry.attributes.instanceEnd;
-		const lineDistances = new Float32Array( 2 * instanceStart.count );
+		const lineDistances = new Float32Array(2 * instanceStart.count);
 
-		for ( let i = 0, j = 0, l = instanceStart.count; i < l; i ++, j += 2 ) {
+		for (let i = 0, j = 0, l = instanceStart.count; i < l; i++, j += 2) {
 
-			_start.fromBufferAttribute( instanceStart, i );
-			_end.fromBufferAttribute( instanceEnd, i );
+			_start.fromBufferAttribute(instanceStart, i);
+			_end.fromBufferAttribute(instanceEnd, i);
 
-			lineDistances[ j ] = ( j === 0 ) ? 0 : lineDistances[ j - 1 ];
-			lineDistances[ j + 1 ] = lineDistances[ j ] + _start.distanceTo( _end );
+			lineDistances[j] = (j === 0) ? 0 : lineDistances[j - 1];
+			lineDistances[j + 1] = lineDistances[j] + _start.distanceTo(_end);
 
 		}
 
-		const instanceDistanceBuffer = new InstancedInterleavedBuffer( lineDistances, 2, 1 ); // d0, d1
+		const instanceDistanceBuffer = new InstancedInterleavedBuffer(lineDistances, 2, 1); // d0, d1
 
-		geometry.setAttribute( 'instanceDistanceStart', new InterleavedBufferAttribute( instanceDistanceBuffer, 1, 0 ) ); // d0
-		geometry.setAttribute( 'instanceDistanceEnd', new InterleavedBufferAttribute( instanceDistanceBuffer, 1, 1 ) ); // d1
+		geometry.setAttribute('instanceDistanceStart', new InterleavedBufferAttribute(instanceDistanceBuffer, 1, 0)); // d0
+		geometry.setAttribute('instanceDistanceEnd', new InterleavedBufferAttribute(instanceDistanceBuffer, 1, 1)); // d1
 
 		return this;
 
@@ -315,18 +316,20 @@ class LineSegments2 extends Mesh {
 	 * @param {Raycaster} raycaster - The raycaster.
 	 * @param {Array<Object>} intersects - The target array that holds the intersection points.
 	 */
-	raycast( raycaster, intersects ) {
+	raycast(raycaster, intersects) {
 
 		const worldUnits = this.material.worldUnits;
 		const camera = raycaster.camera;
 
-		if ( camera === null && ! worldUnits ) {
+		if (camera === null && !worldUnits) {
 
-			console.error( 'LineSegments2: "Raycaster.camera" needs to be set in order to raycast against LineSegments2 while worldUnits is set to false.' );
+			console.error('LineSegments2: "Raycaster.camera" needs to be set in order to raycast against LineSegments2 while worldUnits is set to false.');
 
 		}
 
-		const threshold = ( raycaster.params.Line2 !== undefined ) ? raycaster.params.Line2.threshold || 0 : 0;
+		const threshold = (raycaster.params.Line2 !== undefined) ?
+			(worldUnits ? (raycaster.params.Line2.thresholdWorld || raycaster.params.Line2.threshold || 0) :
+				(raycaster.params.Line2.thresholdPixel || raycaster.params.Line2.threshold || 0)) : 0;
 
 		_ray = raycaster.ray;
 
@@ -337,85 +340,85 @@ class LineSegments2 extends Mesh {
 		_lineWidth = material.linewidth + threshold;
 
 		// check if we intersect the sphere bounds
-		if ( geometry.boundingSphere === null ) {
+		if (geometry.boundingSphere === null) {
 
 			geometry.computeBoundingSphere();
 
 		}
 
-		_sphere.copy( geometry.boundingSphere ).applyMatrix4( matrixWorld );
+		_sphere.copy(geometry.boundingSphere).applyMatrix4(matrixWorld);
 
 		// increase the sphere bounds by the worst case line screen space width
 		let sphereMargin;
-		if ( worldUnits ) {
+		if (worldUnits) {
 
 			sphereMargin = _lineWidth * 0.5;
 
 		} else {
 
-			const distanceToSphere = Math.max( camera.near, _sphere.distanceToPoint( _ray.origin ) );
-			sphereMargin = getWorldSpaceHalfWidth( camera, distanceToSphere, material.resolution );
+			const distanceToSphere = Math.max(camera.near, _sphere.distanceToPoint(_ray.origin));
+			sphereMargin = getWorldSpaceHalfWidth(camera, distanceToSphere, material.resolution);
 
 		}
 
 		_sphere.radius += sphereMargin;
 
-		if ( _ray.intersectsSphere( _sphere ) === false ) {
+		if (_ray.intersectsSphere(_sphere) === false) {
 
 			return;
 
 		}
 
 		// check if we intersect the box bounds
-		if ( geometry.boundingBox === null ) {
+		if (geometry.boundingBox === null) {
 
 			geometry.computeBoundingBox();
 
 		}
 
-		_box.copy( geometry.boundingBox ).applyMatrix4( matrixWorld );
+		_box.copy(geometry.boundingBox).applyMatrix4(matrixWorld);
 
 		// increase the box bounds by the worst case line width
 		let boxMargin;
-		if ( worldUnits ) {
+		if (worldUnits) {
 
 			boxMargin = _lineWidth * 0.5;
 
 		} else {
 
-			const distanceToBox = Math.max( camera.near, _box.distanceToPoint( _ray.origin ) );
-			boxMargin = getWorldSpaceHalfWidth( camera, distanceToBox, material.resolution );
+			const distanceToBox = Math.max(camera.near, _box.distanceToPoint(_ray.origin));
+			boxMargin = getWorldSpaceHalfWidth(camera, distanceToBox, material.resolution);
 
 		}
 
-		_box.expandByScalar( boxMargin );
+		_box.expandByScalar(boxMargin);
 
-		if ( _ray.intersectsBox( _box ) === false ) {
+		if (_ray.intersectsBox(_box) === false) {
 
 			return;
 
 		}
 
-		if ( worldUnits ) {
+		if (worldUnits) {
 
-			raycastWorldUnits( this, intersects );
+			raycastWorldUnits(this, intersects);
 
 		} else {
 
-			raycastScreenSpace( this, camera, intersects );
+			raycastScreenSpace(this, camera, intersects);
 
 		}
 
 	}
 
-	onBeforeRender( renderer ) {
+	onBeforeRender(renderer) {
 
 		const uniforms = this.material.uniforms;
 
-		if ( uniforms && uniforms.resolution ) {
+		if (uniforms && uniforms.resolution) {
 
-			renderer.getViewport( _viewport );
-			this.material.uniforms.resolution.value.set( _viewport.z, _viewport.w );
+			renderer.getViewport(_viewport);
+			this.material.uniforms.resolution.value.set(_viewport.z, _viewport.w);
 
 		}
 

--- a/examples/jsm/lines/webgpu/LineSegments2.js
+++ b/examples/jsm/lines/webgpu/LineSegments2.js
@@ -35,55 +35,55 @@ let _ray, _lineWidth;
 
 // Returns the margin required to expand by in world space given the distance from the camera,
 // line width, resolution, and camera projection
-function getWorldSpaceHalfWidth( camera, distance, resolution ) {
+function getWorldSpaceHalfWidth(camera, distance, resolution) {
 
 	// transform into clip space, adjust the x and y values by the pixel width offset, then
 	// transform back into world space to get world offset. Note clip space is [-1, 1] so full
 	// width does not need to be halved.
-	_clipToWorldVector.set( 0, 0, - distance, 1.0 ).applyMatrix4( camera.projectionMatrix );
-	_clipToWorldVector.multiplyScalar( 1.0 / _clipToWorldVector.w );
+	_clipToWorldVector.set(0, 0, - distance, 1.0).applyMatrix4(camera.projectionMatrix);
+	_clipToWorldVector.multiplyScalar(1.0 / _clipToWorldVector.w);
 	_clipToWorldVector.x = _lineWidth / resolution.width;
 	_clipToWorldVector.y = _lineWidth / resolution.height;
-	_clipToWorldVector.applyMatrix4( camera.projectionMatrixInverse );
-	_clipToWorldVector.multiplyScalar( 1.0 / _clipToWorldVector.w );
+	_clipToWorldVector.applyMatrix4(camera.projectionMatrixInverse);
+	_clipToWorldVector.multiplyScalar(1.0 / _clipToWorldVector.w);
 
-	return Math.abs( Math.max( _clipToWorldVector.x, _clipToWorldVector.y ) );
+	return Math.abs(Math.max(_clipToWorldVector.x, _clipToWorldVector.y));
 
 }
 
-function raycastWorldUnits( lineSegments, intersects ) {
+function raycastWorldUnits(lineSegments, intersects) {
 
 	const matrixWorld = lineSegments.matrixWorld;
 	const geometry = lineSegments.geometry;
 	const instanceStart = geometry.attributes.instanceStart;
 	const instanceEnd = geometry.attributes.instanceEnd;
-	const segmentCount = Math.min( geometry.instanceCount, instanceStart.count );
+	const segmentCount = Math.min(geometry.instanceCount, instanceStart.count);
 
-	for ( let i = 0, l = segmentCount; i < l; i ++ ) {
+	for (let i = 0, l = segmentCount; i < l; i++) {
 
-		_line.start.fromBufferAttribute( instanceStart, i );
-		_line.end.fromBufferAttribute( instanceEnd, i );
+		_line.start.fromBufferAttribute(instanceStart, i);
+		_line.end.fromBufferAttribute(instanceEnd, i);
 
-		_line.applyMatrix4( matrixWorld );
+		_line.applyMatrix4(matrixWorld);
 
 		const pointOnLine = new Vector3();
 		const point = new Vector3();
 
-		_ray.distanceSqToSegment( _line.start, _line.end, point, pointOnLine );
-		const isInside = point.distanceTo( pointOnLine ) < _lineWidth * 0.5;
+		_ray.distanceSqToSegment(_line.start, _line.end, point, pointOnLine);
+		const isInside = point.distanceTo(pointOnLine) < _lineWidth * 0.5;
 
-		if ( isInside ) {
+		if (isInside) {
 
-			intersects.push( {
+			intersects.push({
 				point,
 				pointOnLine,
-				distance: _ray.origin.distanceTo( point ),
+				distance: _ray.origin.distanceTo(point),
 				object: lineSegments,
 				face: null,
 				faceIndex: i,
 				uv: null,
 				uv1: null,
-			} );
+			});
 
 		}
 
@@ -91,7 +91,7 @@ function raycastWorldUnits( lineSegments, intersects ) {
 
 }
 
-function raycastScreenSpace( lineSegments, camera, intersects ) {
+function raycastScreenSpace(lineSegments, camera, intersects) {
 
 	const projectionMatrix = camera.projectionMatrix;
 	const matrixWorld = lineSegments.matrixWorld;
@@ -101,7 +101,7 @@ function raycastScreenSpace( lineSegments, camera, intersects ) {
 	const geometry = lineSegments.geometry;
 	const instanceStart = geometry.attributes.instanceStart;
 	const instanceEnd = geometry.attributes.instanceEnd;
-	const segmentCount = Math.min( geometry.instanceCount, instanceStart.count );
+	const segmentCount = Math.min(geometry.instanceCount, instanceStart.count);
 
 	const near = - camera.near;
 
@@ -110,65 +110,65 @@ function raycastScreenSpace( lineSegments, camera, intersects ) {
 	// pick a point 1 unit out along the ray to avoid the ray origin
 	// sitting at the camera origin which will cause "w" to be 0 when
 	// applying the projection matrix.
-	_ray.at( 1, _ssOrigin );
+	_ray.at(1, _ssOrigin);
 
 	// ndc space [ - 1.0, 1.0 ]
 	_ssOrigin.w = 1;
-	_ssOrigin.applyMatrix4( camera.matrixWorldInverse );
-	_ssOrigin.applyMatrix4( projectionMatrix );
-	_ssOrigin.multiplyScalar( 1 / _ssOrigin.w );
+	_ssOrigin.applyMatrix4(camera.matrixWorldInverse);
+	_ssOrigin.applyMatrix4(projectionMatrix);
+	_ssOrigin.multiplyScalar(1 / _ssOrigin.w);
 
 	// screen space
 	_ssOrigin.x *= resolution.x / 2;
 	_ssOrigin.y *= resolution.y / 2;
 	_ssOrigin.z = 0;
 
-	_ssOrigin3.copy( _ssOrigin );
+	_ssOrigin3.copy(_ssOrigin);
 
-	_mvMatrix.multiplyMatrices( camera.matrixWorldInverse, matrixWorld );
+	_mvMatrix.multiplyMatrices(camera.matrixWorldInverse, matrixWorld);
 
-	for ( let i = 0, l = segmentCount; i < l; i ++ ) {
+	for (let i = 0, l = segmentCount; i < l; i++) {
 
-		_start4.fromBufferAttribute( instanceStart, i );
-		_end4.fromBufferAttribute( instanceEnd, i );
+		_start4.fromBufferAttribute(instanceStart, i);
+		_end4.fromBufferAttribute(instanceEnd, i);
 
 		_start4.w = 1;
 		_end4.w = 1;
 
 		// camera space
-		_start4.applyMatrix4( _mvMatrix );
-		_end4.applyMatrix4( _mvMatrix );
+		_start4.applyMatrix4(_mvMatrix);
+		_end4.applyMatrix4(_mvMatrix);
 
 		// skip the segment if it's entirely behind the camera
 		const isBehindCameraNear = _start4.z > near && _end4.z > near;
-		if ( isBehindCameraNear ) {
+		if (isBehindCameraNear) {
 
 			continue;
 
 		}
 
 		// trim the segment if it extends behind camera near
-		if ( _start4.z > near ) {
+		if (_start4.z > near) {
 
 			const deltaDist = _start4.z - _end4.z;
-			const t = ( _start4.z - near ) / deltaDist;
-			_start4.lerp( _end4, t );
+			const t = (_start4.z - near) / deltaDist;
+			_start4.lerp(_end4, t);
 
-		} else if ( _end4.z > near ) {
+		} else if (_end4.z > near) {
 
 			const deltaDist = _end4.z - _start4.z;
-			const t = ( _end4.z - near ) / deltaDist;
-			_end4.lerp( _start4, t );
+			const t = (_end4.z - near) / deltaDist;
+			_end4.lerp(_start4, t);
 
 		}
 
 		// clip space
-		_start4.applyMatrix4( projectionMatrix );
-		_end4.applyMatrix4( projectionMatrix );
+		_start4.applyMatrix4(projectionMatrix);
+		_end4.applyMatrix4(projectionMatrix);
 
 		// ndc space [ - 1.0, 1.0 ]
-		_start4.multiplyScalar( 1 / _start4.w );
-		_end4.multiplyScalar( 1 / _end4.w );
+		_start4.multiplyScalar(1 / _start4.w);
+		_end4.multiplyScalar(1 / _end4.w);
 
 		// screen space
 		_start4.x *= resolution.x / 2;
@@ -178,45 +178,45 @@ function raycastScreenSpace( lineSegments, camera, intersects ) {
 		_end4.y *= resolution.y / 2;
 
 		// create 2d segment
-		_line.start.copy( _start4 );
+		_line.start.copy(_start4);
 		_line.start.z = 0;
 
-		_line.end.copy( _end4 );
+		_line.end.copy(_end4);
 		_line.end.z = 0;
 
 		// get closest point on ray to segment
-		const param = _line.closestPointToPointParameter( _ssOrigin3, true );
-		_line.at( param, _closestPoint );
+		const param = _line.closestPointToPointParameter(_ssOrigin3, true);
+		_line.at(param, _closestPoint);
 
 		// check if the intersection point is within clip space
-		const zPos = MathUtils.lerp( _start4.z, _end4.z, param );
+		const zPos = MathUtils.lerp(_start4.z, _end4.z, param);
 		const isInClipSpace = zPos >= - 1 && zPos <= 1;
 
-		const isInside = _ssOrigin3.distanceTo( _closestPoint ) < _lineWidth * 0.5;
+		const isInside = _ssOrigin3.distanceTo(_closestPoint) < _lineWidth * 0.5;
 
-		if ( isInClipSpace && isInside ) {
+		if (isInClipSpace && isInside) {
 
-			_line.start.fromBufferAttribute( instanceStart, i );
-			_line.end.fromBufferAttribute( instanceEnd, i );
+			_line.start.fromBufferAttribute(instanceStart, i);
+			_line.end.fromBufferAttribute(instanceEnd, i);
 
-			_line.start.applyMatrix4( matrixWorld );
-			_line.end.applyMatrix4( matrixWorld );
+			_line.start.applyMatrix4(matrixWorld);
+			_line.end.applyMatrix4(matrixWorld);
 
 			const pointOnLine = new Vector3();
 			const point = new Vector3();
 
-			_ray.distanceSqToSegment( _line.start, _line.end, point, pointOnLine );
+			_ray.distanceSqToSegment(_line.start, _line.end, point, pointOnLine);
 
-			intersects.push( {
+			intersects.push({
 				point: point,
 				pointOnLine: pointOnLine,
-				distance: _ray.origin.distanceTo( point ),
+				distance: _ray.origin.distanceTo(point),
 				object: lineSegments,
 				face: null,
 				faceIndex: i,
 				uv: null,
 				uv1: null,
-			} );
+			});
 
 		}
 
@@ -245,9 +245,9 @@ class LineSegments2 extends Mesh {
 	 * @param {LineSegmentsGeometry} [geometry] - The line geometry.
 	 * @param {Line2NodeMaterial} [material] - The line material.
 	 */
-	constructor( geometry = new LineSegmentsGeometry(), material = new Line2NodeMaterial( { color: Math.random() * 0xffffff } ) ) {
+	constructor(geometry = new LineSegmentsGeometry(), material = new Line2NodeMaterial({ color: Math.random() * 0xffffff })) {
 
-		super( geometry, material );
+		super(geometry, material);
 
 		/**
 		 * This flag can be used for type testing.
@@ -279,31 +279,31 @@ class LineSegments2 extends Mesh {
 
 		const instanceStart = geometry.attributes.instanceStart;
 		const instanceEnd = geometry.attributes.instanceEnd;
-		const lineDistances = new Float32Array( 2 * instanceStart.count );
+		const lineDistances = new Float32Array(2 * instanceStart.count);
 
-		for ( let i = 0, j = 0, l = instanceStart.count; i < l; i ++, j += 2 ) {
+		for (let i = 0, j = 0, l = instanceStart.count; i < l; i++, j += 2) {
 
-			_start.fromBufferAttribute( instanceStart, i );
-			_end.fromBufferAttribute( instanceEnd, i );
+			_start.fromBufferAttribute(instanceStart, i);
+			_end.fromBufferAttribute(instanceEnd, i);
 
-			lineDistances[ j ] = ( j === 0 ) ? 0 : lineDistances[ j - 1 ];
-			lineDistances[ j + 1 ] = lineDistances[ j ] + _start.distanceTo( _end );
+			lineDistances[j] = (j === 0) ? 0 : lineDistances[j - 1];
+			lineDistances[j + 1] = lineDistances[j] + _start.distanceTo(_end);
 
 		}
 
-		const instanceDistanceBuffer = new InstancedInterleavedBuffer( lineDistances, 2, 1 ); // d0, d1
+		const instanceDistanceBuffer = new InstancedInterleavedBuffer(lineDistances, 2, 1); // d0, d1
 
-		geometry.setAttribute( 'instanceDistanceStart', new InterleavedBufferAttribute( instanceDistanceBuffer, 1, 0 ) ); // d0
-		geometry.setAttribute( 'instanceDistanceEnd', new InterleavedBufferAttribute( instanceDistanceBuffer, 1, 1 ) ); // d1
+		geometry.setAttribute('instanceDistanceStart', new InterleavedBufferAttribute(instanceDistanceBuffer, 1, 0)); // d0
+		geometry.setAttribute('instanceDistanceEnd', new InterleavedBufferAttribute(instanceDistanceBuffer, 1, 1)); // d1
 
 		return this;
 
 	}
 
-	onBeforeRender( renderer ) {
+	onBeforeRender(renderer) {
 
-		renderer.getViewport( _viewport );
-		this._resolution.set( _viewport.z, _viewport.w );
+		renderer.getViewport(_viewport);
+		this._resolution.set(_viewport.z, _viewport.w);
 
 	}
 
@@ -313,18 +313,20 @@ class LineSegments2 extends Mesh {
 	 * @param {Raycaster} raycaster - The raycaster.
 	 * @param {Array<Object>} intersects - The target array that holds the intersection points.
 	 */
-	raycast( raycaster, intersects ) {
+	raycast(raycaster, intersects) {
 
 		const worldUnits = this.material.worldUnits;
 		const camera = raycaster.camera;
 
-		if ( camera === null && ! worldUnits ) {
+		if (camera === null && !worldUnits) {
 
-			console.error( 'LineSegments2: "Raycaster.camera" needs to be set in order to raycast against LineSegments2 while worldUnits is set to false.' );
+			console.error('LineSegments2: "Raycaster.camera" needs to be set in order to raycast against LineSegments2 while worldUnits is set to false.');
 
 		}
 
-		const threshold = ( raycaster.params.Line2 !== undefined ) ? raycaster.params.Line2.threshold || 0 : 0;
+		const threshold = (raycaster.params.Line2 !== undefined) ?
+			(worldUnits ? (raycaster.params.Line2.thresholdWorld || raycaster.params.Line2.threshold || 0) :
+				(raycaster.params.Line2.thresholdPixel || raycaster.params.Line2.threshold || 0)) : 0;
 
 		_ray = raycaster.ray;
 
@@ -335,72 +337,72 @@ class LineSegments2 extends Mesh {
 		_lineWidth = material.linewidth + threshold;
 
 		// check if we intersect the sphere bounds
-		if ( geometry.boundingSphere === null ) {
+		if (geometry.boundingSphere === null) {
 
 			geometry.computeBoundingSphere();
 
 		}
 
-		_sphere.copy( geometry.boundingSphere ).applyMatrix4( matrixWorld );
+		_sphere.copy(geometry.boundingSphere).applyMatrix4(matrixWorld);
 
 		// increase the sphere bounds by the worst case line screen space width
 		let sphereMargin;
-		if ( worldUnits ) {
+		if (worldUnits) {
 
 			sphereMargin = _lineWidth * 0.5;
 
 		} else {
 
-			const distanceToSphere = Math.max( camera.near, _sphere.distanceToPoint( _ray.origin ) );
-			sphereMargin = getWorldSpaceHalfWidth( camera, distanceToSphere, this._resolution );
+			const distanceToSphere = Math.max(camera.near, _sphere.distanceToPoint(_ray.origin));
+			sphereMargin = getWorldSpaceHalfWidth(camera, distanceToSphere, this._resolution);
 
 		}
 
 		_sphere.radius += sphereMargin;
 
-		if ( _ray.intersectsSphere( _sphere ) === false ) {
+		if (_ray.intersectsSphere(_sphere) === false) {
 
 			return;
 
 		}
 
 		// check if we intersect the box bounds
-		if ( geometry.boundingBox === null ) {
+		if (geometry.boundingBox === null) {
 
 			geometry.computeBoundingBox();
 
 		}
 
-		_box.copy( geometry.boundingBox ).applyMatrix4( matrixWorld );
+		_box.copy(geometry.boundingBox).applyMatrix4(matrixWorld);
 
 		// increase the box bounds by the worst case line width
 		let boxMargin;
-		if ( worldUnits ) {
+		if (worldUnits) {
 
 			boxMargin = _lineWidth * 0.5;
 
 		} else {
 
-			const distanceToBox = Math.max( camera.near, _box.distanceToPoint( _ray.origin ) );
-			boxMargin = getWorldSpaceHalfWidth( camera, distanceToBox, this._resolution );
+			const distanceToBox = Math.max(camera.near, _box.distanceToPoint(_ray.origin));
+			boxMargin = getWorldSpaceHalfWidth(camera, distanceToBox, this._resolution);
 
 		}
 
-		_box.expandByScalar( boxMargin );
+		_box.expandByScalar(boxMargin);
 
-		if ( _ray.intersectsBox( _box ) === false ) {
+		if (_ray.intersectsBox(_box) === false) {
 
 			return;
 
 		}
 
-		if ( worldUnits ) {
+		if (worldUnits) {
 
-			raycastWorldUnits( this, intersects );
+			raycastWorldUnits(this, intersects);
 
 		} else {
 
-			raycastScreenSpace( this, camera, intersects );
+			raycastScreenSpace(this, camera, intersects);
 
 		}
 


### PR DESCRIPTION
Fixes [#30623](https://github.com/mrdoob/three.js/issues/30623)

This PR addresses an issue where `Line2` objects relied on a single `threshold` parameter for raycasting, which caused inconsistent interaction behavior when switching between world units and pixel units. A threshold value suitable for world space (e.g., 0.5 units) is often too small or too large when interpreted as screen pixels.

I have updated [LineSegments2.js](and the WebGPU equivalent) to support two new parameters in `raycaster.params.Line2`:
*   `thresholdWorld`: Used when `worldUnits` is `true`.
*   `thresholdPixel`: Used when `worldUnits` is `false`.
