### PR TITLE
WebGPU: Fix scissor Y-axis flip

### DIFF
--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -976,7 +976,8 @@ class WebGPUBackend extends Backend {
 					if ( renderContext.scissor ) {
 
 						const { x, y, width, height } = renderContext.scissorValue;
-						renderPass.setScissorRect( x, y, width, height );
+						const flippedY = renderContext.height - y - height;
+						renderPass.setScissorRect( x, flippedY, width, height );
 
 					}
 
@@ -1147,7 +1148,8 @@ class WebGPUBackend extends Backend {
 		const { currentPass } = this.get( renderContext );
 		const { x, y, width, height } = renderContext.scissorValue;
 
-		currentPass.setScissorRect( x, y, width, height );
+		const flippedY = renderContext.height - y - height;
+		currentPass.setScissorRect( x, flippedY, width, height );
 
 	}
 


### PR DESCRIPTION
Fixes #32419

This PR fixes the Y-axis flip issue in setScissor() for WebGPU renderer.

Changes:
- Convert scissor Y-coordinate from WebGL's bottom-left to WebGPU's top-left origin
- Applied in updateScissor() and finishRender() methods