### PR TITLE
SkinnedNode: Ensure `previousBoneMatrices` is defined for cloned skeletons.

### DIFF
--- a/src/nodes/accessors/SkinningNode.js
+++ b/src/nodes/accessors/SkinningNode.js
@@ -282,7 +282,20 @@ class SkinningNode extends Node {
 
 		_frameId.set( skeleton, frame.frameId );
 
-		if ( this.previousBoneMatricesNode !== null ) skeleton.previousBoneMatrices.set( skeleton.boneMatrices );
+		if ( this.previousBoneMatricesNode !== null ) {
+
+			if ( skeleton.previousBoneMatrices === null ) {
+
+				// cloned skeletons miss "previousBoneMatrices" in their first updated
+
+				skeleton.previousBoneMatrices = new Float32Array( skeleton.boneMatrices );
+
+			}
+
+			skeleton.previousBoneMatrices.set( skeleton.boneMatrices );
+
+
+		}
 
 		skeleton.update();
 

--- a/src/objects/Skeleton.js
+++ b/src/objects/Skeleton.js
@@ -71,6 +71,15 @@ class Skeleton {
 		this.boneMatrices = null;
 
 		/**
+		 * An array buffer holding the bone data of the previous frame.
+		 * Required for computing velocity. Maintained in {@link SkinningNode}.
+		 *
+		 * @type {?Float32Array}
+		 * @default null
+		 */
+		this.previousBoneMatrices = null;
+
+		/**
 		 * A texture holding the bone data for use
 		 * in the vertex shader.
 		 *


### PR DESCRIPTION
Fixed #32417.

**Description**

The PR makes sure `SkinnedNode` properly creates `previousBoneMatrices` for cloned skeletons. `previousBoneMatrices` is now also defined in the `Skeleton` ctor for better clarity.

Side note: We can't create `previousBoneMatrices` directly in the ctor of `Skeleton` because this property is only relevant in context of `velocity`. To avoid unnecessary buffer creation, it's best to do this in `SkinnedNode` and only when previous skinned positions have been requested.