### PR TITLE
fix: WebGPU background precision issue

### DIFF
--- a/src/renderers/common/Background.js
+++ b/src/renderers/common/Background.js
@@ -24,7 +24,7 @@ class Background extends DataMap {
 	 * @param {Renderer} renderer - The renderer.
 	 * @param {Nodes} nodes - Renderer component for managing nodes related logic.
 	 */
-	constructor( renderer, nodes ) {
+	constructor(renderer, nodes) {
 
 		super();
 
@@ -54,62 +54,63 @@ class Background extends DataMap {
 	 * @param {RenderList} renderList - The current render list.
 	 * @param {RenderContext} renderContext - The current render context.
 	 */
-	update( scene, renderList, renderContext ) {
+	update(scene, renderList, renderContext) {
 
 		const renderer = this.renderer;
-		const background = this.nodes.getBackgroundNode( scene ) || scene.background;
+		const background = this.nodes.getBackgroundNode(scene) || scene.background;
 
 		let forceClear = false;
 
-		if ( background === null ) {
+		if (background === null) {
 
 			// no background settings, use clear color configuration from the renderer
 
-			renderer._clearColor.getRGB( _clearColor );
+			renderer._clearColor.getRGB(_clearColor);
 			_clearColor.a = renderer._clearColor.a;
 
-		} else if ( background.isColor === true ) {
+		} else if (background.isColor === true) {
 
 			// background is an opaque color
 
-			background.getRGB( _clearColor );
+			background.getRGB(_clearColor);
 			_clearColor.a = 1;
 
 			forceClear = true;
 
-		} else if ( background.isNode === true ) {
+		} else if (background.isNode === true) {
 
-			const sceneData = this.get( scene );
+			const sceneData = this.get(scene);
 			const backgroundNode = background;
 
-			_clearColor.copy( renderer._clearColor );
+			_clearColor.copy(renderer._clearColor);
 
 			let backgroundMesh = sceneData.backgroundMesh;
 
-			if ( backgroundMesh === undefined ) {
+			if (backgroundMesh === undefined) {
 
-				const backgroundMeshNode = vec4( backgroundNode ).mul( backgroundIntensity ).context( {
+				const backgroundMeshNode = vec4(backgroundNode).mul(backgroundIntensity).context({
 					// @TODO: Add Texture2D support using node context
-					getUV: () => backgroundRotation.mul( normalWorldGeometry ),
+					getUV: () => backgroundRotation.mul(normalWorldGeometry),
 					getTextureLevel: () => backgroundBlurriness
-				} );
+				});
 
 				// when using orthographic cameras, we must scale the skybox sphere
 				// up to exceed the dimensions of the camera's viewing box.
-				const isOrtho = cameraProjectionMatrix.element( 3 ).element( 3 ).equal( 1.0 );
+				const isOrtho = cameraProjectionMatrix.element(3).element(3).equal(1.0);
 
 				// calculate the orthographic scale
 				// projectionMatrix[1][1] is (1 / top). Invert it to get the height and multiply by 3.0
 				// (an arbitrary safety factor) to ensure the skybox is large enough to cover the corners
 				// of the rectangular screen
-				const orthoScale = div( 1.0, cameraProjectionMatrix.element( 1 ).element( 1 ) ).mul( 3.0 );
+				const orthoScale = div(1.0, cameraProjectionMatrix.element(1).element(1)).mul(3.0);
 
 				// compute vertex position
-				const modifiedPosition = isOrtho.select( positionLocal.mul( orthoScale ), positionLocal );
-				let viewProj = cameraProjectionMatrix.mul( modelViewMatrix.mul( vec4( modifiedPosition, 1.0 ) ) );
+				const modifiedPosition = isOrtho.select(positionLocal.mul(orthoScale), positionLocal);
+				const positionView = modelViewMatrix.mul(vec4(modifiedPosition, 0.0)).xyz;
+				let viewProj = cameraProjectionMatrix.mul(vec4(positionView, 0.0));
 
 				// force background to far plane so it does not occlude objects
-				viewProj = viewProj.setZ( viewProj.w );
+				viewProj = viewProj.setZ(viewProj.w);
 
 				const nodeMaterial = new NodeMaterial();
 				nodeMaterial.name = 'Background.material';
@@ -123,34 +124,30 @@ class Background extends DataMap {
 				nodeMaterial.colorNode = backgroundMeshNode;
 
 				sceneData.backgroundMeshNode = backgroundMeshNode;
-				sceneData.backgroundMesh = backgroundMesh = new Mesh( new SphereGeometry( 1, 32, 32 ), nodeMaterial );
+				sceneData.backgroundMesh = backgroundMesh = new Mesh(new SphereGeometry(1, 32, 32), nodeMaterial);
 				backgroundMesh.frustumCulled = false;
 				backgroundMesh.name = 'Background.mesh';
 
-				backgroundMesh.onBeforeRender = function ( renderer, scene, camera ) {
 
-					this.matrixWorld.copyPosition( camera.matrixWorld );
-
-				};
 
 				function onBackgroundDispose() {
 
-					background.removeEventListener( 'dispose', onBackgroundDispose );
+					background.removeEventListener('dispose', onBackgroundDispose);
 
 					backgroundMesh.material.dispose();
 					backgroundMesh.geometry.dispose();
 
 				}
 
-				background.addEventListener( 'dispose', onBackgroundDispose );
+				background.addEventListener('dispose', onBackgroundDispose);
 
 			}
 
 			const backgroundCacheKey = backgroundNode.getCacheKey();
 
-			if ( sceneData.backgroundCacheKey !== backgroundCacheKey ) {
+			if (sceneData.backgroundCacheKey !== backgroundCacheKey) {
 
-				sceneData.backgroundMeshNode.node = vec4( backgroundNode ).mul( backgroundIntensity );
+				sceneData.backgroundMeshNode.node = vec4(backgroundNode).mul(backgroundIntensity);
 				sceneData.backgroundMeshNode.needsUpdate = true;
 
 				backgroundMesh.material.needsUpdate = true;
@@ -159,11 +156,11 @@ class Background extends DataMap {
 
 			}
 
-			renderList.unshift( backgroundMesh, backgroundMesh.geometry, backgroundMesh.material, 0, 0, null, null );
+			renderList.unshift(backgroundMesh, backgroundMesh.geometry, backgroundMesh.material, 0, 0, null, null);
 
 		} else {
 
-			error( 'Renderer: Unsupported background configuration.', background );
+			error('Renderer: Unsupported background configuration.', background);
 
 		}
 
@@ -171,19 +168,19 @@ class Background extends DataMap {
 
 		const environmentBlendMode = renderer.xr.getEnvironmentBlendMode();
 
-		if ( environmentBlendMode === 'additive' ) {
+		if (environmentBlendMode === 'additive') {
 
-			_clearColor.set( 0, 0, 0, 1 );
+			_clearColor.set(0, 0, 0, 1);
 
-		} else if ( environmentBlendMode === 'alpha-blend' ) {
+		} else if (environmentBlendMode === 'alpha-blend') {
 
-			_clearColor.set( 0, 0, 0, 0 );
+			_clearColor.set(0, 0, 0, 0);
 
 		}
 
 		//
 
-		if ( renderer.autoClear === true || forceClear === true ) {
+		if (renderer.autoClear === true || forceClear === true) {
 
 			const clearColorValue = renderContext.clearColorValue;
 
@@ -194,7 +191,7 @@ class Background extends DataMap {
 
 			// premultiply alpha
 
-			if ( renderer.backend.isWebGLBackend === true || renderer.alpha === true ) {
+			if (renderer.backend.isWebGLBackend === true || renderer.alpha === true) {
 
 				clearColorValue.r *= clearColorValue.a;
 				clearColorValue.g *= clearColorValue.a;

--- a/src/renderers/common/Background.js
+++ b/src/renderers/common/Background.js
@@ -24,7 +24,7 @@ class Background extends DataMap {
 	 * @param {Renderer} renderer - The renderer.
 	 * @param {Nodes} nodes - Renderer component for managing nodes related logic.
 	 */
-	constructor(renderer, nodes) {
+	constructor( renderer, nodes ) {
 
 		super();
 
@@ -54,18 +54,18 @@ class Background extends DataMap {
 	 * @param {RenderList} renderList - The current render list.
 	 * @param {RenderContext} renderContext - The current render context.
 	 */
-	update(scene, renderList, renderContext) {
+	update( scene, renderList, renderContext ) {
 
 		const renderer = this.renderer;
-		const background = this.nodes.getBackgroundNode(scene) || scene.background;
+		const background = this.nodes.getBackgroundNode( scene ) || scene.background;
 
 		let forceClear = false;
 
-		if (background === null) {
+		if ( background === null ) {
 
 			// no background settings, use clear color configuration from the renderer
 
-			renderer._clearColor.getRGB(_clearColor);
+			renderer._clearColor.getRGB( _clearColor );
 			_clearColor.a = renderer._clearColor.a;
 
 		} else if (background.isColor === true) {


### PR DESCRIPTION
This PR fixes the background jittering issue in WebGPU for large scale scenes (earth orbit scale).

## Changes
- Modified `src/renderers/common/Background.js` to ignore camera position in view projection calculation by using a zeroed w-component
- Removed `backgroundMesh.onBeforeRender` callback as it is no longer needed with the new approach

## Technical Details
The problem was that when the camera is at very large coordinates (e.g., 7,000,000 units for earth orbit), floating-point precision errors caused the background to jitter. By treating the position as a direction (w=0.0) instead of a point (w=1.0) in the view projection calculation, we effectively ignore translation and only apply rotation, which avoids the precision issues.

Fixes #32418