### PR TITLE
Fix: WebGPUTextureUtils._getDefaultCubeTextureGPU using wrong cache

### DIFF
--- a/src/renderers/webgpu/utils/WebGPUTextureUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUTextureUtils.js
@@ -683,7 +683,7 @@ class WebGPUTextureUtils {
 	 */
 	_getDefaultCubeTextureGPU( format ) {
 
-		let defaultCubeTexture = this.defaultTexture[ format ];
+		let defaultCubeTexture = this.defaultCubeTexture[ format ];
 
 		if ( defaultCubeTexture === undefined ) {
 


### PR DESCRIPTION
Fixed #32424.

The _getDefaultCubeTextureGPU method in src/renderers/webgpu/utils/WebGPUTextureUtils.js
was incorrectly reading from this.defaultTexture instead of this.defaultCubeTexture on line 686.

This copy-paste error caused cube textures to share the same cache as regular 2D textures, leading to potential texture type mismatches when a format is used for both cube and regular textures.

The fix: Changed line 686 to correctly read from this.defaultCubeTexture[format] to match the intended behavior and align with the write operation on line 696.

Before:
let defaultCubeTexture = this.defaultTexture[ format ]; // Wrong cache

After:
let defaultCubeTexture = this.defaultCubeTexture[ format ]; 