### PR TITLE
Shadow Mapping Reversed Depth Fix

### DIFF
--- a/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl.js
@@ -119,7 +119,11 @@ export default /* glsl */`
 			float shadow = 1.0;
 
 			shadowCoord.xyz /= shadowCoord.w;
-			shadowCoord.z += shadowBias;
+			#ifdef USE_REVERSED_DEPTH_BUFFER
+				shadowCoord.z -= shadowBias;
+			#else
+				shadowCoord.z += shadowBias;
+			#endif
 
 			bool inFrustum = shadowCoord.x >= 0.0 && shadowCoord.x <= 1.0 && shadowCoord.y >= 0.0 && shadowCoord.y <= 1.0;
 			bool frustumTest = inFrustum && shadowCoord.z <= 1.0;
@@ -155,7 +159,11 @@ export default /* glsl */`
 			float shadow = 1.0;
 
 			shadowCoord.xyz /= shadowCoord.w;
-			shadowCoord.z += shadowBias;
+			#ifdef USE_REVERSED_DEPTH_BUFFER
+				shadowCoord.z -= shadowBias;
+			#else
+				shadowCoord.z += shadowBias;
+			#endif
 
 			bool inFrustum = shadowCoord.x >= 0.0 && shadowCoord.x <= 1.0 && shadowCoord.y >= 0.0 && shadowCoord.y <= 1.0;
 			bool frustumTest = inFrustum && shadowCoord.z <= 1.0;
@@ -213,7 +221,11 @@ export default /* glsl */`
 			float shadow = 1.0;
 
 			shadowCoord.xyz /= shadowCoord.w;
-			shadowCoord.z += shadowBias;
+			#ifdef USE_REVERSED_DEPTH_BUFFER
+				shadowCoord.z -= shadowBias;
+			#else
+				shadowCoord.z += shadowBias;
+			#endif
 
 			bool inFrustum = shadowCoord.x >= 0.0 && shadowCoord.x <= 1.0 && shadowCoord.y >= 0.0 && shadowCoord.y <= 1.0;
 			bool frustumTest = inFrustum && shadowCoord.z <= 1.0;
@@ -263,9 +275,15 @@ export default /* glsl */`
 		if ( viewSpaceZ - shadowCameraFar <= 0.0 && viewSpaceZ - shadowCameraNear >= 0.0 ) {
 
 			// Calculate perspective depth for cube shadow map
+			// Calculate perspective depth for cube shadow map
 			// Standard perspective depth formula: depth = (far * (z - near)) / (z * (far - near))
-			float dp = ( shadowCameraFar * ( viewSpaceZ - shadowCameraNear ) ) / ( viewSpaceZ * ( shadowCameraFar - shadowCameraNear ) );
-			dp += shadowBias;
+			#ifdef USE_REVERSED_DEPTH_BUFFER
+				float dp = ( shadowCameraNear * ( shadowCameraFar - viewSpaceZ ) ) / ( viewSpaceZ * ( shadowCameraFar - shadowCameraNear ) );
+				dp -= shadowBias;
+			#else
+				float dp = ( shadowCameraFar * ( viewSpaceZ - shadowCameraNear ) ) / ( viewSpaceZ * ( shadowCameraFar - shadowCameraNear ) );
+				dp += shadowBias;
+			#endif
 
 			// Hardware PCF with LinearFilter gives us 4-tap filtering per sample
 			// Use Vogel disk + IGN sampling for better quality
@@ -315,9 +333,15 @@ export default /* glsl */`
 		if ( viewSpaceZ - shadowCameraFar <= 0.0 && viewSpaceZ - shadowCameraNear >= 0.0 ) {
 
 			// Calculate perspective depth for cube shadow map
+			// Calculate perspective depth for cube shadow map
 			// Standard perspective depth formula: depth = (far * (z - near)) / (z * (far - near))
-			float dp = ( shadowCameraFar * ( viewSpaceZ - shadowCameraNear ) ) / ( viewSpaceZ * ( shadowCameraFar - shadowCameraNear ) );
-			dp += shadowBias;
+			#ifdef USE_REVERSED_DEPTH_BUFFER
+				float dp = ( shadowCameraNear * ( shadowCameraFar - viewSpaceZ ) ) / ( viewSpaceZ * ( shadowCameraFar - shadowCameraNear ) );
+				dp -= shadowBias;
+			#else
+				float dp = ( shadowCameraFar * ( viewSpaceZ - shadowCameraNear ) ) / ( viewSpaceZ * ( shadowCameraFar - shadowCameraNear ) );
+				dp += shadowBias;
+			#endif
 
 			float depth = textureCube( shadowMap, bd3D ).r;
 


### PR DESCRIPTION
Related issue: #31661 

**Description**
Correct shadow mapping and bias for reversedDepthBuffer

fixes shadow mapping artifacts and missing shadows when using `reversedDepthBuffer: true` in `WebGLRenderer`.

**Changes**

Inverted `shadowBias` application in `getShadow` and `getPointShadow` when `USE_REVERSED_DEPTH_BUFFER` is defined.
Added a conditional branch in `getPointShadow` to use the correct reversed depth formula for dp.

**Before**

<img width="343" height="260" alt="Screenshot 2025-11-30 at 11 27 27 PM" src="https://github.com/user-attachments/assets/6f822fca-3ceb-4f65-bac2-cf4a9644fe6c" />


**After**
<img width="353" height="205" alt="Screenshot 2025-11-30 at 11 27 53 PM" src="https://github.com/user-attachments/assets/a068069a-4be0-42e4-a72e-eb73eb45419b" />



**Index.html I made**
```<script type="module">
        import * as THREE from 'three';
        import { OrbitControls } from 'three/addons/controls/OrbitControls.js';

        let camera, scene, renderer, controls;
        let dirLight, pointLight;

        init();
        animate();

        function init() {
            const container = document.createElement('div');
            document.body.appendChild(container);

            camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 1, 1000);
            camera.position.set(0, 10, 20);

            scene = new THREE.Scene();
            scene.background = new THREE.Color(0x222222);

            const ambientLight = new THREE.AmbientLight(0x404040);
            scene.add(ambientLight);

            dirLight = new THREE.DirectionalLight(0xffffff, 1);
            dirLight.position.set(5, 10, 7.5);
            dirLight.castShadow = true;
            dirLight.shadow.mapSize.width = 2048;
            dirLight.shadow.mapSize.height = 2048;
            dirLight.shadow.camera.near = 0.1;
            dirLight.shadow.camera.far = 500;
            dirLight.shadow.bias = -0.001; 
            dirLight.shadow.blurSamples = 8;
            scene.add(dirLight);

            pointLight = new THREE.PointLight(0xff0000, 5, 50);
            pointLight.position.set(-5, 5, 0);
            pointLight.castShadow = true;
            pointLight.shadow.mapSize.width = 1024;
            pointLight.shadow.mapSize.height = 1024;
            pointLight.shadow.bias = -0.001; 
            scene.add(pointLight);

            const pointLightHelper = new THREE.PointLightHelper(pointLight, 1);
            scene.add(pointLightHelper);

            const geometry = new THREE.TorusKnotGeometry(1, 0.3, 128, 64);
            const material = new THREE.MeshStandardMaterial({ color: 0xaaaaaa });

            const torus = new THREE.Mesh(geometry, material);
            torus.position.set(0, 3, 0);
            torus.castShadow = true;
            torus.receiveShadow = true;
            scene.add(torus);

            const planeGeometry = new THREE.PlaneGeometry(100, 100);
            const planeMaterial = new THREE.MeshStandardMaterial({ color: 0x444444 });
            const plane = new THREE.Mesh(planeGeometry, planeMaterial);
            plane.rotation.x = - Math.PI / 2;
            plane.receiveShadow = true;
            scene.add(plane);

            renderer = new THREE.WebGLRenderer({ antialias: true, reversedDepthBuffer: true });
            renderer.setPixelRatio(window.devicePixelRatio);
            renderer.setSize(window.innerWidth, window.innerHeight);
            renderer.shadowMap.enabled = true;
            renderer.shadowMap.type = THREE.VSMShadowMap;
            container.appendChild(renderer.domElement);

            controls = new OrbitControls(camera, renderer.domElement);
            controls.target.set(0, 1, 0);
            controls.update();

            window.addEventListener('resize', onWindowResize);
        }

        function onWindowResize() {
            camera.aspect = window.innerWidth / window.innerHeight;
            camera.updateProjectionMatrix();
            renderer.setSize(window.innerWidth, window.innerHeight);
        }

        function animate() {
            requestAnimationFrame(animate);
            renderer.render(scene, camera);
        }
    </script>
