### PR TITLE
WebGPURenderer: Refine video texture warning.

### DIFF
--- a/src/renderers/common/Textures.js
+++ b/src/renderers/common/Textures.js
@@ -325,7 +325,7 @@ class Textures extends DataMap {
 
 			//
 
-			if ( texture.isVideoTexture && ColorManagement.getTransfer( texture.colorSpace ) !== SRGBTransfer ) {
+			if ( texture.isVideoTexture && ColorManagement.enabled === true && ColorManagement.getTransfer( texture.colorSpace ) !== SRGBTransfer ) {
 
 				warn( 'WebGPURenderer: Video textures must use a color space with a sRGB transfer function, e.g. SRGBColorSpace.' );
 


### PR DESCRIPTION
Fixed #32438.

**Description**

The PR makes sure the warning about color spaces in context of video textures is only logged with enabled color management.
