### PR TITLE
Matrix4: Avoid `NaN` values when scale is zero

### DIFF
--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -277,9 +277,9 @@ class Matrix4 {
 		const te = this.elements;
 		const me = m.elements;
 
-		const scaleX = 1 / _v1.setFromMatrixColumn( m, 0 ).length();
-		const scaleY = 1 / _v1.setFromMatrixColumn( m, 1 ).length();
-		const scaleZ = 1 / _v1.setFromMatrixColumn( m, 2 ).length();
+		const scaleX = 1 / ( _v1.setFromMatrixColumn( m, 0 ).length() || 1 );
+		const scaleY = 1 / ( _v1.setFromMatrixColumn( m, 1 ).length() || 1 );
+		const scaleZ = 1 / ( _v1.setFromMatrixColumn( m, 2 ).length() || 1 );
 
 		te[ 0 ] = me[ 0 ] * scaleX;
 		te[ 1 ] = me[ 1 ] * scaleX;

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -293,13 +293,9 @@ class Matrix4 {
 		const te = this.elements;
 		const me = m.elements;
 
-		const lengthX = _v1.setFromMatrixColumn( m, 0 ).length();
-		const lengthY = _v1.setFromMatrixColumn( m, 1 ).length();
-		const lengthZ = _v1.setFromMatrixColumn( m, 2 ).length();
-
-		const scaleX = 1 / lengthX;
-		const scaleY = 1 / lengthY;
-		const scaleZ = 1 / lengthZ;
+		const scaleX = 1 / _v1.setFromMatrixColumn( m, 0 ).length();
+		const scaleY = 1 / _v1.setFromMatrixColumn( m, 1 ).length();
+		const scaleZ = 1 / _v1.setFromMatrixColumn( m, 2 ).length();
 
 		te[ 0 ] = me[ 0 ] * scaleX;
 		te[ 1 ] = me[ 1 ] * scaleX;

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -1046,6 +1046,19 @@ class Matrix4 {
 
 		const te = this.elements;
 
+		position.x = te[ 12 ];
+		position.y = te[ 13 ];
+		position.z = te[ 14 ];
+
+		if ( this.determinant() === 0 ) {
+
+			scale.set( 1, 1, 1 );
+			quaternion.identity();
+
+			return this;
+
+		}
+
 		let sx = _v1.set( te[ 0 ], te[ 1 ], te[ 2 ] ).length();
 		const sy = _v1.set( te[ 4 ], te[ 5 ], te[ 6 ] ).length();
 		const sz = _v1.set( te[ 8 ], te[ 9 ], te[ 10 ] ).length();
@@ -1053,10 +1066,6 @@ class Matrix4 {
 		// if determine is negative, we need to invert one scale
 		const det = this.determinant();
 		if ( det < 0 ) sx = - sx;
-
-		position.x = te[ 12 ];
-		position.y = te[ 13 ];
-		position.z = te[ 14 ];
 
 		// scale the rotation part
 		_m1.copy( this );

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -235,8 +235,19 @@ class Matrix4 {
 	extractBasis( xAxis, yAxis, zAxis ) {
 
 		xAxis.setFromMatrixColumn( this, 0 );
+		if ( xAxis.lengthSq() === 0 ) {
+			xAxis.set( 1, 0, 0 );
+		}
+
 		yAxis.setFromMatrixColumn( this, 1 );
+		if ( yAxis.lengthSq() === 0 ) {
+			yAxis.set( 0, 1, 0 );
+		}
+
 		zAxis.setFromMatrixColumn( this, 2 );
+		if ( zAxis.lengthSq() === 0 ) {
+			zAxis.set( 0, 0, 1 );
+		}
 
 		return this;
 

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -234,29 +234,19 @@ class Matrix4 {
 	 */
 	extractBasis( xAxis, yAxis, zAxis ) {
 
-		xAxis.setFromMatrixColumn( this, 0 );
-
-		if ( xAxis.lengthSq() === 0 ) {
+		if ( this.determinant() === 0 ) {
 
 			xAxis.set( 1, 0, 0 );
-
-		}
-
-		yAxis.setFromMatrixColumn( this, 1 );
-
-		if ( yAxis.lengthSq() === 0 ) {
-
 			yAxis.set( 0, 1, 0 );
-
-		}
-
-		zAxis.setFromMatrixColumn( this, 2 );
-
-		if ( zAxis.lengthSq() === 0 ) {
-
 			zAxis.set( 0, 0, 1 );
 
+			return this;
+
 		}
+
+		xAxis.setFromMatrixColumn( this, 0 );
+		yAxis.setFromMatrixColumn( this, 1 );
+		zAxis.setFromMatrixColumn( this, 2 );
 
 		return this;
 
@@ -294,6 +284,12 @@ class Matrix4 {
 	 */
 	extractRotation( m ) {
 
+		if ( m.determinant() === 0 ) {
+
+			return this.identity();
+
+		}
+
 		const te = this.elements;
 		const me = m.elements;
 
@@ -301,65 +297,24 @@ class Matrix4 {
 		const lengthY = _v1.setFromMatrixColumn( m, 1 ).length();
 		const lengthZ = _v1.setFromMatrixColumn( m, 2 ).length();
 
-		// x
+		const scaleX = 1 / lengthX;
+		const scaleY = 1 / lengthY;
+		const scaleZ = 1 / lengthZ;
 
-		if ( lengthX === 0 ) {
+		te[ 0 ] = me[ 0 ] * scaleX;
+		te[ 1 ] = me[ 1 ] * scaleX;
+		te[ 2 ] = me[ 2 ] * scaleX;
+		te[ 3 ] = 0;
 
-			te[ 0 ] = 1;
-			te[ 1 ] = 0;
-			te[ 2 ] = 0;
-			te[ 3 ] = 0;
+		te[ 4 ] = me[ 4 ] * scaleY;
+		te[ 5 ] = me[ 5 ] * scaleY;
+		te[ 6 ] = me[ 6 ] * scaleY;
+		te[ 7 ] = 0;
 
-		} else {
-
-			const scaleX = 1 / lengthX;
-
-			te[ 0 ] = me[ 0 ] * scaleX;
-			te[ 1 ] = me[ 1 ] * scaleX;
-			te[ 2 ] = me[ 2 ] * scaleX;
-			te[ 3 ] = 0;
-
-		}
-
-		// y
-
-		if ( lengthY === 0 ) {
-
-			te[ 4 ] = 0;
-			te[ 5 ] = 1;
-			te[ 6 ] = 0;
-			te[ 7 ] = 0;
-
-		} else {
-
-			const scaleY = 1 / lengthY;
-
-			te[ 4 ] = me[ 4 ] * scaleY;
-			te[ 5 ] = me[ 5 ] * scaleY;
-			te[ 6 ] = me[ 6 ] * scaleY;
-			te[ 7 ] = 0;
-
-		}
-
-		// z
-
-		if ( lengthZ === 0 ) {
-
-			te[ 8 ] = 0;
-			te[ 9 ] = 0;
-			te[ 10 ] = 1;
-			te[ 11 ] = 0;
-
-		} else {
-
-			const scaleZ = 1 / lengthZ;
-
-			te[ 8 ] = me[ 8 ] * scaleZ;
-			te[ 9 ] = me[ 9 ] * scaleZ;
-			te[ 10 ] = me[ 10 ] * scaleZ;
-			te[ 11 ] = 0;
-
-		}
+		te[ 8 ] = me[ 8 ] * scaleZ;
+		te[ 9 ] = me[ 9 ] * scaleZ;
+		te[ 10 ] = me[ 10 ] * scaleZ;
+		te[ 11 ] = 0;
 
 		te[ 12 ] = 0;
 		te[ 13 ] = 0;

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -277,24 +277,69 @@ class Matrix4 {
 		const te = this.elements;
 		const me = m.elements;
 
-		const scaleX = 1 / ( _v1.setFromMatrixColumn( m, 0 ).length() || 1 );
-		const scaleY = 1 / ( _v1.setFromMatrixColumn( m, 1 ).length() || 1 );
-		const scaleZ = 1 / ( _v1.setFromMatrixColumn( m, 2 ).length() || 1 );
+		const lengthX = _v1.setFromMatrixColumn( m, 0 ).length();
+		const lengthY = _v1.setFromMatrixColumn( m, 1 ).length();
+		const lengthZ = _v1.setFromMatrixColumn( m, 2 ).length();
 
-		te[ 0 ] = me[ 0 ] * scaleX;
-		te[ 1 ] = me[ 1 ] * scaleX;
-		te[ 2 ] = me[ 2 ] * scaleX;
-		te[ 3 ] = 0;
+		// x
 
-		te[ 4 ] = me[ 4 ] * scaleY;
-		te[ 5 ] = me[ 5 ] * scaleY;
-		te[ 6 ] = me[ 6 ] * scaleY;
-		te[ 7 ] = 0;
+		if ( lengthX === 0 ) {
 
-		te[ 8 ] = me[ 8 ] * scaleZ;
-		te[ 9 ] = me[ 9 ] * scaleZ;
-		te[ 10 ] = me[ 10 ] * scaleZ;
-		te[ 11 ] = 0;
+			te[ 0 ] = 1;
+			te[ 1 ] = 0;
+			te[ 2 ] = 0;
+			te[ 3 ] = 0;
+
+		} else {
+
+			const scaleX = 1 / lengthX;
+
+			te[ 0 ] = me[ 0 ] * scaleX;
+			te[ 1 ] = me[ 1 ] * scaleX;
+			te[ 2 ] = me[ 2 ] * scaleX;
+			te[ 3 ] = 0;
+
+		}
+
+		// y
+
+		if ( lengthY === 0 ) {
+
+			te[ 4 ] = 0;
+			te[ 5 ] = 1;
+			te[ 6 ] = 0;
+			te[ 7 ] = 0;
+
+		} else {
+
+			const scaleY = 1 / lengthY;
+
+			te[ 4 ] = me[ 4 ] * scaleY;
+			te[ 5 ] = me[ 5 ] * scaleY;
+			te[ 6 ] = me[ 6 ] * scaleY;
+			te[ 7 ] = 0;
+
+		}
+
+		// z
+
+		if ( lengthZ === 0 ) {
+
+			te[ 8 ] = 0;
+			te[ 9 ] = 0;
+			te[ 10 ] = 1;
+			te[ 11 ] = 0;
+
+		} else {
+
+			const scaleZ = 1 / lengthZ;
+
+			te[ 8 ] = me[ 8 ] * scaleZ;
+			te[ 9 ] = me[ 9 ] * scaleZ;
+			te[ 10 ] = me[ 10 ] * scaleZ;
+			te[ 11 ] = 0;
+
+		}
 
 		te[ 12 ] = 0;
 		te[ 13 ] = 0;
@@ -1041,9 +1086,9 @@ class Matrix4 {
 		// scale the rotation part
 		_m1.copy( this );
 
-		const invSX = 1 / ( sx || 1 );
-		const invSY = 1 / ( sy || 1 );
-		const invSZ = 1 / ( sz || 1 );
+		const invSX = 1 / sx;
+		const invSY = 1 / sy;
+		const invSZ = 1 / sz;
 
 		_m1.elements[ 0 ] *= invSX;
 		_m1.elements[ 1 ] *= invSX;

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -235,18 +235,27 @@ class Matrix4 {
 	extractBasis( xAxis, yAxis, zAxis ) {
 
 		xAxis.setFromMatrixColumn( this, 0 );
+
 		if ( xAxis.lengthSq() === 0 ) {
+
 			xAxis.set( 1, 0, 0 );
+
 		}
 
 		yAxis.setFromMatrixColumn( this, 1 );
+
 		if ( yAxis.lengthSq() === 0 ) {
+
 			yAxis.set( 0, 1, 0 );
+
 		}
 
 		zAxis.setFromMatrixColumn( this, 2 );
+
 		if ( zAxis.lengthSq() === 0 ) {
+
 			zAxis.set( 0, 0, 1 );
+
 		}
 
 		return this;

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -1041,9 +1041,9 @@ class Matrix4 {
 		// scale the rotation part
 		_m1.copy( this );
 
-		const invSX = 1 / sx;
-		const invSY = 1 / sy;
-		const invSZ = 1 / sz;
+		const invSX = 1 / ( sx || 1 );
+		const invSY = 1 / ( sy || 1 );
+		const invSZ = 1 / ( sz || 1 );
 
 		_m1.elements[ 0 ] *= invSX;
 		_m1.elements[ 1 ] *= invSX;


### PR DESCRIPTION
**Description**
The Issue Currently, `extractRotation` assumes the matrix columns (basis vectors) have a non-zero length. If an object has a scale of 0 on any axis `(e.g., mesh.scale.set(0, 0, 0)` to hide it), the column length becomes 0.

This results in a division by zero (`Infinity`), causing the entire matrix to become `NaN`. This `NaN` propagation can crash downstream logic (physics engines, world matrix decompositions) that rely on this method.

**Solution**
Added a safety check `|| 1` to the divisor. This pattern matches safety checks found elsewhere in the codebase (e.g. `Vector3.normalize`) to ensure the method remains robust even with degenerate matrices.

**Reproduction**
```js
const m = new THREE.Matrix4().makeScale(0, 0, 0);
const res = new THREE.Matrix4();
res.extractRotation(m);
console.log(res.elements); 
// Before: [NaN, NaN, NaN...]
// After: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]
