### PR TITLE
WebGLRenderer: Use native depth texture for VSM shadow maps

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1255,14 +1255,6 @@ export const RGBDepthPacking = 3202;
 export const RGDepthPacking = 3203;
 
 /**
- * The depth value is not packed.
- *
- * @type {number}
- * @constant
- */
-export const IdentityDepthPacking = 3204;
-
-/**
  * Normal information is relative to the underlying surface.
  *
  * @type {number}

--- a/src/renderers/shaders/ShaderLib/depth.glsl.js
+++ b/src/renderers/shaders/ShaderLib/depth.glsl.js
@@ -111,10 +111,6 @@ void main() {
 		// TODO Deprecate
 		gl_FragColor = vec4( packDepthToRG( fragCoordZ ), 0.0, 1.0 );
 
-	#elif DEPTH_PACKING == 3204
-
-		gl_FragColor = vec4( vec3( fragCoordZ ), 1.0 );
-
 	#endif
 
 }

--- a/src/renderers/shaders/ShaderLib/vsm.glsl.js
+++ b/src/renderers/shaders/ShaderLib/vsm.glsl.js
@@ -43,7 +43,7 @@ void main() {
 	mean = mean / samples;
 	squared_mean = squared_mean / samples;
 
-	float std_dev = sqrt( squared_mean - mean * mean );
+	float std_dev = sqrt( max( 0.0, squared_mean - mean * mean ) );
 
 	gl_FragColor = vec4( mean, std_dev, 0.0, 1.0 );
 

--- a/src/renderers/webgl/WebGLLights.js
+++ b/src/renderers/webgl/WebGLLights.js
@@ -3,6 +3,7 @@ import { Matrix4 } from '../../math/Matrix4.js';
 import { Vector2 } from '../../math/Vector2.js';
 import { Vector3 } from '../../math/Vector3.js';
 import { UniformsLib } from '../shaders/UniformsLib.js';
+import { RGFormat } from '../../constants.js';
 
 function UniformsCache() {
 
@@ -239,7 +240,23 @@ function WebGLLights( extensions ) {
 			const intensity = light.intensity;
 			const distance = light.distance;
 
-			const shadowMap = ( light.shadow && light.shadow.map ) ? ( light.shadow.map.depthTexture || light.shadow.map.texture ) : null;
+			let shadowMap = null;
+
+			if ( light.shadow && light.shadow.map ) {
+
+				if ( light.shadow.map.texture.format === RGFormat ) {
+
+					// VSM uses color texture with blurred mean/std_dev
+					shadowMap = light.shadow.map.texture;
+
+				} else {
+
+					// Other types use depth texture
+					shadowMap = light.shadow.map.depthTexture || light.shadow.map.texture;
+
+				}
+
+			}
 
 			if ( light.isAmbientLight ) {
 


### PR DESCRIPTION
Related issue: #32303

**Description**

- Refactors VSM shadow mapping to use native depth textures instead of `IdentityDepthPacking`
- Removes unused `IdentityDepthPacking` constant and shader code
- Ports the `max(0.0, ...)` fix from WebGPU to prevent NaN artifacts (#32327)

(Made using [Claude Code](https://code.claude.com/docs/en/vs-code) with [Opus 4.5](https://www.anthropic.com/news/claude-opus-4-5))