### PR TITLE
WebGLRenderer: Align transmission render target samples with canvas.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1876,7 +1876,7 @@ class WebGLRenderer {
 					generateMipmaps: true,
 					type: ( extensions.has( 'EXT_color_buffer_half_float' ) || extensions.has( 'EXT_color_buffer_float' ) ) ? HalfFloatType : UnsignedByteType,
 					minFilter: LinearMipmapLinearFilter,
-					samples: 4,
+					samples: capabilities.samples,
 					stencilBuffer: stencil,
 					resolveDepthBuffer: false,
 					resolveStencilBuffer: false,

--- a/src/renderers/webgl/WebGLCapabilities.js
+++ b/src/renderers/webgl/WebGLCapabilities.js
@@ -108,6 +108,7 @@ function WebGLCapabilities( gl, extensions, parameters, utils ) {
 	const vertexTextures = maxVertexTextures > 0;
 
 	const maxSamples = gl.getParameter( gl.MAX_SAMPLES );
+	const samples = gl.getParameter( gl.SAMPLES );
 
 	return {
 
@@ -135,7 +136,9 @@ function WebGLCapabilities( gl, extensions, parameters, utils ) {
 
 		vertexTextures: vertexTextures,
 
-		maxSamples: maxSamples
+		maxSamples: maxSamples,
+
+		samples: samples
 
 	};
 


### PR DESCRIPTION
**Description**

This PR ensures the transmission render target uses the same antialiasing level as the main canvas output, rather than always using 4 samples regardless of the renderer's antialias setting.

(Made using [Claude Code](https://code.claude.com/docs/en/vs-code) with [Opus 4.5](https://www.anthropic.com/news/claude-opus-4-5))