### PR TITLE
Editor: Scale down touchscreen zoom speed

### DIFF
--- a/editor/js/EditorControls.js
+++ b/editor/js/EditorControls.js
@@ -364,7 +364,8 @@ class EditorControls extends THREE.EventDispatcher {
 
 					touches[ 0 ].set( event.pageX, event.pageY, 0 ).divideScalar( window.devicePixelRatio );
 					touches[ 1 ].set( position.x, position.y, 0 ).divideScalar( window.devicePixelRatio );
-					var distance = touches[ 0 ].distanceTo( touches[ 1 ] );
+					// Divide by 10 to offset inherent over-sensitivity (https://github.com/mrdoob/three.js/issues/32442)
+					var distance = touches[ 0 ].distanceTo( touches[ 1 ] ) / 10;
 					scope.zoom( delta.set( 0, 0, prevDistance - distance ) );
 					prevDistance = distance;
 


### PR DESCRIPTION
Related issue: #32442

**Description**

On touchscreen devices, specifically mobile ones like iOS and Android phones, the editor's pinch zoom is extremely over-sensitive, making the editor virtually unusable.

My fix was to add a new `Control` section in the editor's settings, with a numerical `Zoom Speed` option to control the editor's zooming speed globally (not just for touch devices). This replaces the previously used `scope.zoomSpeed` found in 
[EditorControls.js](./editor/js/EditorControls.js), which was defined and referenced only once.