### PR TITLE
Inspector: Add warn if the inspected node outside of frame scope

### DIFF
--- a/examples/jsm/inspector/RendererInspector.js
+++ b/examples/jsm/inspector/RendererInspector.js
@@ -1,5 +1,5 @@
 
-import { InspectorBase, TimestampQuery } from 'three/webgpu';
+import { InspectorBase, TimestampQuery, warnOnce } from 'three/webgpu';
 
 class ObjectStats {
 
@@ -330,7 +330,17 @@ export class RendererInspector extends InspectorBase {
 
 	inspect( node ) {
 
-		this.currentNodes.push( node );
+		const currentNodes = this.currentNodes;
+
+		if ( currentNodes !== null ) {
+
+			currentNodes.push( node );
+
+		} else {
+
+			warnOnce( 'RendererInspector: Unable to inspect node outside of frame scope. Use "renderer.setAnimationLoop()".' );
+
+		}
 
 	}
 


### PR DESCRIPTION
Closes https://github.com/mrdoob/three.js/issues/32432

**Description**

Add a warning and prevents crashing if the inspected node is outside the scope of the frame.