### PR TITLE
PolyhedronGeometry: Fix typo in `fromJSON()`.

### DIFF
--- a/src/geometries/PolyhedronGeometry.js
+++ b/src/geometries/PolyhedronGeometry.js
@@ -339,7 +339,7 @@ class PolyhedronGeometry extends BufferGeometry {
 	 */
 	static fromJSON( data ) {
 
-		return new PolyhedronGeometry( data.vertices, data.indices, data.radius, data.details );
+		return new PolyhedronGeometry( data.vertices, data.indices, data.radius, data.detail );
 
 	}
 


### PR DESCRIPTION
Fixed #32474

**Description**

Fixed a typo in `PolyhedronGeometry.fromJSON()` where `data.details` was incorrectly used instead of `data.detail`.

This caused the `detail` parameter to be `undefined` when deserializing a [PolyhedronGeometry](cci:2://file:///Users/ayushkumar/Desktop/three.js/src/geometries/PolyhedronGeometry.js:12:0-345:1) from JSON, resulting in the geometry being recreated with the default detail value of `0` instead of the original value.

All child classes (`IcosahedronGeometry`, `OctahedronGeometry`, `TetrahedronGeometry`, `DodecahedronGeometry`) already use the correct `data.detail`.