### PR TITLE
Add concrete unit tests for Skeleton, SkinnedMesh, Sprite, and WebGL3DRenderTarget

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1722,7 +1722,6 @@
       "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
@@ -1827,7 +1826,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2507,7 +2505,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -3222,8 +3219,7 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1521046.tgz",
       "integrity": "sha512-vhE6eymDQSKWUXwwA37NtTTVEzjtGVfDr3pRbsWEQ5onH/Snp2c+2xZHWJJawG/0hCCJLRGt4xVtEVUVILol4w==",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
@@ -3638,7 +3634,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -7852,7 +7847,6 @@
       "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },

--- a/test/unit/src/objects/Skeleton.tests.js
+++ b/test/unit/src/objects/Skeleton.tests.js
@@ -1,6 +1,8 @@
 /* global QUnit */
 
 import { Skeleton } from '../../../../src/objects/Skeleton.js';
+import { Bone } from '../../../../src/objects/Bone.js';
+import { Matrix4 } from '../../../../src/math/Matrix4.js';
 
 export default QUnit.module( 'Objects', () => {
 
@@ -15,33 +17,59 @@ export default QUnit.module( 'Objects', () => {
 		} );
 
 		// PROPERTIES
-		QUnit.todo( 'uuid', ( assert ) => {
+		QUnit.test( 'uuid', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const skeleton = new Skeleton();
 
-		} );
-
-		QUnit.todo( 'bones', ( assert ) => {
-
-			assert.ok( false, 'everything\'s gonna be alright' );
+			assert.ok( typeof skeleton.uuid === 'string' && skeleton.uuid.length > 0, 'uuid is a non-empty string.' );
 
 		} );
 
-		QUnit.todo( 'boneInverses', ( assert ) => {
+		QUnit.test( 'bones', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const bones = [ new Bone(), new Bone() ];
+			const skeleton = new Skeleton( bones );
+
+			assert.strictEqual( skeleton.bones.length, bones.length, 'bones length matches constructor argument.' );
+			assert.strictEqual( skeleton.bones[ 0 ], bones[ 0 ], 'first bone is preserved.' );
+			assert.notStrictEqual( skeleton.bones, bones, 'bones array is cloned, not reused.' );
 
 		} );
 
-		QUnit.todo( 'boneMatrices', ( assert ) => {
+		QUnit.test( 'boneInverses', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const bones = [ new Bone(), new Bone() ];
+			const skeleton = new Skeleton( bones );
+
+			assert.strictEqual( skeleton.boneInverses.length, bones.length, 'boneInverses has one entry per bone.' );
+			skeleton.boneInverses.forEach( ( inverse ) => {
+
+				assert.ok( inverse instanceof Matrix4, 'boneInverse entry is a Matrix4.' );
+
+			} );
 
 		} );
 
-		QUnit.todo( 'boneTexture', ( assert ) => {
+		QUnit.test( 'boneMatrices', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const bones = [ new Bone(), new Bone(), new Bone() ];
+			const skeleton = new Skeleton( bones );
+
+			assert.ok( skeleton.boneMatrices instanceof Float32Array, 'boneMatrices is a Float32Array.' );
+			assert.strictEqual( skeleton.boneMatrices.length, bones.length * 16, 'boneMatrices has 16 floats per bone.' );
+
+		} );
+
+		QUnit.test( 'boneTexture', ( assert ) => {
+
+			const bones = [ new Bone(), new Bone() ];
+			const skeleton = new Skeleton( bones );
+
+			assert.strictEqual( skeleton.boneTexture, null, 'boneTexture is null before computeBoneTexture().' );
+
+			skeleton.computeBoneTexture();
+
+			assert.ok( skeleton.boneTexture && skeleton.boneTexture.isDataTexture, 'boneTexture is a DataTexture after computeBoneTexture().' );
 
 		} );
 
@@ -52,15 +80,14 @@ export default QUnit.module( 'Objects', () => {
 		} );
 
 		// PUBLIC
-		QUnit.todo( 'init', ( assert ) => {
+		QUnit.test( 'init / calculateInverses', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const bone = new Bone();
+			bone.updateMatrixWorld( true );
 
-		} );
+			const skeleton = new Skeleton( [ bone ] );
 
-		QUnit.todo( 'calculateInverses', ( assert ) => {
-
-			assert.ok( false, 'everything\'s gonna be alright' );
+			assert.strictEqual( skeleton.boneInverses.length, 1, 'calculateInverses() created one inverse matrix.' );
 
 		} );
 
@@ -76,21 +103,43 @@ export default QUnit.module( 'Objects', () => {
 
 		} );
 
-		QUnit.todo( 'clone', ( assert ) => {
+		QUnit.test( 'clone', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const bones = [ new Bone(), new Bone() ];
+			const skeleton = new Skeleton( bones );
+
+			const clone = skeleton.clone();
+
+			assert.notStrictEqual( clone, skeleton, 'clone() creates a new Skeleton instance.' );
+			assert.deepEqual( clone.bones, skeleton.bones, 'clone() reuses the same bones.' );
+			assert.deepEqual( clone.boneInverses, skeleton.boneInverses, 'clone() reuses boneInverses.' );
 
 		} );
 
-		QUnit.todo( 'computeBoneTexture', ( assert ) => {
+		QUnit.test( 'computeBoneTexture', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const bones = [ new Bone(), new Bone() ];
+			const skeleton = new Skeleton( bones );
+			const originalLength = skeleton.boneMatrices.length;
+
+			skeleton.computeBoneTexture();
+
+			assert.ok( skeleton.boneMatrices.length >= originalLength, 'computeBoneTexture() expands boneMatrices buffer as needed.' );
+			assert.ok( skeleton.boneTexture && skeleton.boneTexture.isDataTexture, 'computeBoneTexture() creates a DataTexture.' );
 
 		} );
 
-		QUnit.todo( 'getBoneByName', ( assert ) => {
+		QUnit.test( 'getBoneByName', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const boneA = new Bone();
+			boneA.name = 'a';
+			const boneB = new Bone();
+			boneB.name = 'b';
+
+			const skeleton = new Skeleton( [ boneA, boneB ] );
+
+			assert.strictEqual( skeleton.getBoneByName( 'b' ), boneB, 'getBoneByName() returns the matching bone.' );
+			assert.strictEqual( skeleton.getBoneByName( 'missing' ), undefined, 'getBoneByName() returns undefined if no bone matches.' );
 
 		} );
 
@@ -103,15 +152,27 @@ export default QUnit.module( 'Objects', () => {
 
 		} );
 
-		QUnit.todo( 'fromJSON', ( assert ) => {
+		QUnit.test( 'fromJSON / toJSON', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const boneA = new Bone();
+			const boneB = new Bone();
 
-		} );
+			const skeleton = new Skeleton( [ boneA, boneB ] );
+			skeleton.calculateInverses();
 
-		QUnit.todo( 'toJSON', ( assert ) => {
+			const json = skeleton.toJSON();
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const bonesMap = {};
+			bonesMap[ boneA.uuid ] = boneA;
+			bonesMap[ boneB.uuid ] = boneB;
+
+			const restored = new Skeleton().fromJSON( json, bonesMap );
+
+			assert.strictEqual( restored.uuid, skeleton.uuid, 'fromJSON() restores uuid.' );
+			assert.strictEqual( restored.bones.length, skeleton.bones.length, 'fromJSON() restores bones length.' );
+			assert.strictEqual( restored.bones[ 0 ], boneA, 'fromJSON() restores bone references.' );
+			assert.strictEqual( restored.bones[ 1 ], boneB, 'fromJSON() restores bone references.' );
+			assert.strictEqual( restored.boneInverses.length, skeleton.boneInverses.length, 'fromJSON() restores boneInverses length.' );
 
 		} );
 

--- a/test/unit/src/objects/SkinnedMesh.tests.js
+++ b/test/unit/src/objects/SkinnedMesh.tests.js
@@ -3,7 +3,12 @@
 import { Object3D } from '../../../../src/core/Object3D.js';
 import { Mesh } from '../../../../src/objects/Mesh.js';
 import { SkinnedMesh } from '../../../../src/objects/SkinnedMesh.js';
-import { AttachedBindMode } from '../../../../src/constants.js';
+import { AttachedBindMode, DetachedBindMode } from '../../../../src/constants.js';
+import { Matrix4 } from '../../../../src/math/Matrix4.js';
+import { Box3 } from '../../../../src/math/Box3.js';
+import { Sphere } from '../../../../src/math/Sphere.js';
+import { Vector3 } from '../../../../src/math/Vector3.js';
+import { Skeleton } from '../../../../src/objects/Skeleton.js';
 
 export default QUnit.module( 'Objects', () => {
 
@@ -41,22 +46,31 @@ export default QUnit.module( 'Objects', () => {
 		QUnit.test( 'bindMode', ( assert ) => {
 
 			const object = new SkinnedMesh();
-			assert.ok(
-				object.bindMode === AttachedBindMode,
+			assert.strictEqual(
+				object.bindMode,
+				AttachedBindMode,
 				'SkinnedMesh.bindMode should be AttachedBindMode'
 			);
 
 		} );
 
-		QUnit.todo( 'bindMatrix', ( assert ) => {
+		QUnit.test( 'bindMatrix', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const object = new SkinnedMesh();
+			const identity = new Matrix4();
+
+			assert.ok( object.bindMatrix instanceof Matrix4, 'bindMatrix is a Matrix4.' );
+			assert.deepEqual( object.bindMatrix, identity, 'bindMatrix is identity by default.' );
 
 		} );
 
-		QUnit.todo( 'bindMatrixInverse', ( assert ) => {
+		QUnit.test( 'bindMatrixInverse', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const object = new SkinnedMesh();
+			const identity = new Matrix4();
+
+			assert.ok( object.bindMatrixInverse instanceof Matrix4, 'bindMatrixInverse is a Matrix4.' );
+			assert.deepEqual( object.bindMatrixInverse, identity, 'bindMatrixInverse is identity by default.' );
 
 		} );
 
@@ -71,9 +85,28 @@ export default QUnit.module( 'Objects', () => {
 
 		} );
 
-		QUnit.todo( 'copy', ( assert ) => {
+		QUnit.test( 'copy', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const source = new SkinnedMesh();
+			const skeleton = new Skeleton();
+
+			source.bindMode = DetachedBindMode;
+			source.bindMatrix.makeTranslation( 1, 2, 3 );
+			source.bindMatrixInverse.copy( source.bindMatrix ).invert();
+
+			source.skeleton = skeleton;
+			source.boundingBox = new Box3( new Vector3( - 1, - 2, - 3 ), new Vector3( 1, 2, 3 ) );
+			source.boundingSphere = new Sphere( new Vector3( 1, 2, 3 ), 5 );
+
+			const target = new SkinnedMesh();
+			target.copy( source );
+
+			assert.strictEqual( target.bindMode, source.bindMode, 'copy() should copy bindMode.' );
+			assert.deepEqual( target.bindMatrix, source.bindMatrix, 'copy() should copy bindMatrix.' );
+			assert.deepEqual( target.bindMatrixInverse, source.bindMatrixInverse, 'copy() should copy bindMatrixInverse.' );
+			assert.strictEqual( target.skeleton, skeleton, 'copy() should copy skeleton reference.' );
+			assert.deepEqual( target.boundingBox, source.boundingBox, 'copy() should clone boundingBox.' );
+			assert.deepEqual( target.boundingSphere, source.boundingSphere, 'copy() should clone boundingSphere.' );
 
 		} );
 

--- a/test/unit/src/objects/Sprite.tests.js
+++ b/test/unit/src/objects/Sprite.tests.js
@@ -2,6 +2,7 @@
 
 import { Object3D } from '../../../../src/core/Object3D.js';
 import { Sprite } from '../../../../src/objects/Sprite.js';
+import { SpriteMaterial } from '../../../../src/materials/SpriteMaterial.js';
 
 export default QUnit.module( 'Objects', () => {
 
@@ -37,21 +38,32 @@ export default QUnit.module( 'Objects', () => {
 
 		} );
 
-		QUnit.todo( 'geometry', ( assert ) => {
+		QUnit.test( 'geometry', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const sprite = new Sprite();
+
+			assert.ok( sprite.geometry, 'Sprite has a geometry instance.' );
+			assert.ok( sprite.geometry.isBufferGeometry, 'geometry is a BufferGeometry.' );
+			assert.ok( sprite.geometry.getAttribute( 'position' ), 'geometry has a position attribute.' );
+			assert.ok( sprite.geometry.getAttribute( 'uv' ), 'geometry has a uv attribute.' );
 
 		} );
 
-		QUnit.todo( 'material', ( assert ) => {
+		QUnit.test( 'material', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const material = new SpriteMaterial();
+			const sprite = new Sprite( material );
+
+			assert.strictEqual( sprite.material, material, 'Sprite.material should reference the material passed to the constructor.' );
 
 		} );
 
-		QUnit.todo( 'center', ( assert ) => {
+		QUnit.test( 'center', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const sprite = new Sprite();
+
+			assert.strictEqual( sprite.center.x, 0.5, 'Sprite.center.x defaults to 0.5.' );
+			assert.strictEqual( sprite.center.y, 0.5, 'Sprite.center.y defaults to 0.5.' );
 
 		} );
 
@@ -72,9 +84,18 @@ export default QUnit.module( 'Objects', () => {
 
 		} );
 
-		QUnit.todo( 'copy', ( assert ) => {
+		QUnit.test( 'copy', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const material = new SpriteMaterial();
+			const source = new Sprite( material );
+			source.center.set( 0.25, 0.75 );
+
+			const target = new Sprite();
+			target.copy( source );
+
+			assert.strictEqual( target.material, source.material, 'copy() should copy the material reference.' );
+			assert.strictEqual( target.center.x, source.center.x, 'copy() should copy the center x component.' );
+			assert.strictEqual( target.center.y, source.center.y, 'copy() should copy the center y component.' );
 
 		} );
 

--- a/test/unit/src/renderers/WebGL3DRenderTarget.tests.js
+++ b/test/unit/src/renderers/WebGL3DRenderTarget.tests.js
@@ -32,23 +32,34 @@ export default QUnit.module( 'Renderers', () => {
 		} );
 
 		// PROPERTIES
-		QUnit.todo( 'depth', ( assert ) => {
+		QUnit.test( 'depth', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const target = new WebGL3DRenderTarget( 4, 2, 8 );
+
+			assert.strictEqual( target.depth, 8, 'WebGL3DRenderTarget.depth should match the constructor argument.' );
 
 		} );
 
-		QUnit.todo( 'texture', ( assert ) => {
+		QUnit.test( 'texture', ( assert ) => {
 
-			// must be Data3DTexture
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const width = 4;
+			const height = 2;
+			const depth = 8;
+			const target = new WebGL3DRenderTarget( width, height, depth );
+
+			assert.ok( target.texture.isData3DTexture, 'texture is a Data3DTexture.' );
+			assert.strictEqual( target.texture.image.width, width, 'texture width matches the render target width.' );
+			assert.strictEqual( target.texture.image.height, height, 'texture height matches the render target height.' );
+			assert.strictEqual( target.texture.image.depth, depth, 'texture depth matches the render target depth.' );
 
 		} );
 
 		// PUBLIC
-		QUnit.todo( 'isWebGL3DRenderTarget', ( assert ) => {
+		QUnit.test( 'isWebGL3DRenderTarget', ( assert ) => {
 
-			assert.ok( false, 'everything\'s gonna be alright' );
+			const target = new WebGL3DRenderTarget();
+
+			assert.ok( target.isWebGL3DRenderTarget, 'isWebGL3DRenderTarget should be true.' );
 
 		} );
 


### PR DESCRIPTION
This PR converts several QUnit.todo placeholders in core 3D objects and render targets into real, passing unit tests, increasing coverage and verifying runtime behavior without changing existing functionality.

Changes included:

WebGL3DRenderTarget

Tests for depth, texture, and isWebGL3DRenderTarget.

Verifies correct 3D texture creation and depth handling.

Sprite

Tests for geometry, material, center, and copy.

Validates that Sprite geometry attributes and anchoring behave as expected.

Ensures copy() correctly duplicates center and preserves material references.

SkinnedMesh

Tests for bindMode, bindMatrix, bindMatrixInverse, and copy.

Confirms that binding modes, matrices, skeleton references, and bounding volumes are correctly copied.

Skeleton

Tests for uuid, bones, boneInverses, boneMatrices, boneTexture, computeBoneTexture, clone, getBoneByName, fromJSON, and toJSON.
Validates that bone arrays, inverses, textures, and serialization behave as expected.

Validation
All new and existing tests pass.
No lint errors or runtime changes.

Why this helps:
Improves test coverage for core library objects.
Verifies important 3D behavior in a way that prevents regressions.
Prepares the repo for safer future changes without changing any runtime behavior.