### PR TITLE
Fixed typo in BufferGeometry.js

### DIFF
--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -134,7 +134,7 @@ class BufferGeometry extends EventDispatcher {
 		 * This dictionary holds the morph targets of the geometry.
 		 *
 		 * Note: Once the geometry has been rendered, the morph attribute data cannot
-		 * be changed. You will have to call `dispose()?, and create a new geometry instance.
+		 * be changed. You will have to call `dispose()`, and create a new geometry instance.
 		 *
 		 * @type {Object}
 		 */

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -44,7 +44,7 @@ class Vector3 {
 		 * @readonly
 		 * @default true
 		 */
-		Vector3.prototype.isVector3 = true;
+		this.isVector3 = true;
 
 		/**
 		 * The x value of this vector.

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -44,7 +44,7 @@ class Vector3 {
 		 * @readonly
 		 * @default true
 		 */
-		this.isVector3 = true;
+		Vector3.prototype.isVector3 = true;
 
 		/**
 		 * The x value of this vector.


### PR DESCRIPTION
# BufferGeometry.js: Fixed typo in JSDoc comment

This PR fixes a small typo in the JSDoc documentation of `BufferGeometry`.
The comment incorrectly referenced `dispose()?` and has been corrected to `dispose()`.

