### PR TITLE
Fix: Add null checks in Raycaster and BufferGeometry to prevent runtime errors

### DIFF
--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -1084,6 +1084,13 @@ class BufferGeometry extends EventDispatcher {
 
 		const normals = this.attributes.normal;
 
+		if ( normals === undefined ) {
+
+			warn( 'BufferGeometry.normalizeNormals(): No normals attribute found. Skipping normalization.' );
+			return;
+
+		}
+
 		for ( let i = 0, il = normals.count; i < il; i ++ ) {
 
 			_vector.fromBufferAttribute( normals, i );

--- a/src/core/Raycaster.js
+++ b/src/core/Raycaster.js
@@ -215,7 +215,13 @@ class Raycaster {
 
 		for ( let i = 0, l = objects.length; i < l; i ++ ) {
 
-			intersect( objects[ i ], this, intersects, recursive );
+			const object = objects[ i ];
+
+			if ( object !== null && object !== undefined ) {
+
+				intersect( object, this, intersects, recursive );
+
+			}
 
 		}
 
@@ -234,6 +240,8 @@ function ascSort( a, b ) {
 }
 
 function intersect( object, raycaster, intersects, recursive ) {
+
+	if ( object === null || object === undefined ) return;
 
 	let propagate = true;
 


### PR DESCRIPTION
## Description

This PR fixes three bugs related to missing null/undefined checks that could cause runtime errors:

### Changes

1. **Raycaster.intersect()** - Added null/undefined check at the start of the function
   - Prevents `TypeError: Cannot read property 'layers' of null` when null objects are passed
   - Handles edge cases where objects might be null during scene graph traversal

2. **Raycaster.intersectObjects()** - Added null/undefined checks when iterating over objects array
   - Prevents errors when arrays contain null or undefined values
   - Gracefully skips invalid entries instead of throwing exceptions

3. **BufferGeometry.normalizeNormals()** - Added check for normal attribute existence
   - Prevents `TypeError: Cannot read property 'count' of undefined` when called on geometries without normals
   - Provides a helpful warning message when the attribute is missing

### Impact

- **Breaking Changes**: None
- **Bug Fixes**: Prevents runtime errors in edge cases
- **Performance**: Minimal overhead from additional checks

### Testing

The changes maintain backward compatibility and handle edge cases gracefully. No existing functionality is affected.