### PR TITLE
Prevent Prototype Pollution in

### DIFF
--- a/src/textures/Texture.js
+++ b/src/textures/Texture.js
@@ -516,7 +516,11 @@ class Texture extends EventDispatcher {
 	 */
 	setValues( values ) {
 
+	    if ( values === undefined || values === null || typeof values !== 'object' ) return;
+
 		for ( const key in values ) {
+			// Skip prototype properties and dangerous keys
+			if ( !values.hasOwnProperty( key ) || key === '__proto__' || key === 'constructor' ) continue;
 
 			const newValue = values[ key ];
 


### PR DESCRIPTION
## 🔒 Prevent Prototype Pollution in `setValues`

### **Summary**
This PR updates the `setValues` method to safely assign object properties while preventing prototype pollution vulnerabilities. The method now explicitly skips dangerous keys such as `__proto__` and `constructor`, and ignores inherited properties.

### **What’s Changed**
- Added checks to avoid assigning:
  - `__proto__`
  - `constructor`
  - Prototype-inherited properties
- Ensured `values` is a valid object before processing.

### **Code Snippet**
```javascript
/**
 * Safely set multiple values on the instance.
 */
setValues(values) {

	if (values === undefined || values === null || typeof values !== 'object') return;

	for (const key in values) {

		// Skip prototype properties and dangerous keys
		if (
			!values.hasOwnProperty(key) ||
			key === '__proto__' ||
			key === 'constructor'
		) continue;

		// Apply the value
		this[key] = values[key];
	}
}
```

### **Why This Matters**
Prototype pollution can lead to:
- Unexpected application behavior  
- Security vulnerabilities  
- Overwritten object prototypes  

This change ensures safer handling of user-provided objects.

### **Testing**
- Verified that valid keys are assigned normally.
- Confirmed that `__proto__` and `constructor` are ignored.
- Confirmed that inherited properties are not applied.