### PR TITLE
VOXLoader: Added scene graph support.

### DIFF
--- a/editor/js/Loader.js
+++ b/editor/js/Loader.js
@@ -675,23 +675,13 @@ function Loader( editor ) {
 
 					const contents = event.target.result;
 
-					const { VOXLoader, VOXMesh } = await import( 'three/addons/loaders/VOXLoader.js' );
+					const { VOXLoader } = await import( 'three/addons/loaders/VOXLoader.js' );
 
-					const chunks = new VOXLoader().parse( contents );
+					const { scene } = new VOXLoader().parse( contents );
 
-					const group = new THREE.Group();
-					group.name = filename;
+					scene.name = filename;
 
-					for ( let i = 0; i < chunks.length; i ++ ) {
-
-						const chunk = chunks[ i ];
-
-						const mesh = new VOXMesh( chunk );
-						group.add( mesh );
-
-					}
-
-					editor.execute( new AddObjectCommand( editor, group ) );
+					editor.execute( new AddObjectCommand( editor, scene ) );
 
 				}, false );
 				reader.readAsArrayBuffer( file );

--- a/examples/webgl_loader_vox.html
+++ b/examples/webgl_loader_vox.html
@@ -54,19 +54,12 @@
 				scene.add( dirLight2 );
 
 				const loader = new VOXLoader();
-				loader.load( 'models/vox/monu10.vox', function ( chunks ) {
+				loader.load( 'models/vox/monu10.vox', function ( result ) {
 
-					for ( let i = 0; i < chunks.length; i ++ ) {
-
-						const chunk = chunks[ i ];
-
-						// displayPalette( chunk.palette );
-
-						const mesh = new VOXMesh( chunk );
-						mesh.scale.setScalar( 0.0015 );
-						scene.add( mesh );
-
-					}
+					const mesh = result.scene.children[ 0 ];
+					mesh.position.y = 0;
+					mesh.scale.setScalar( 0.0015 );
+					scene.add( mesh );
 
 				} );
 


### PR DESCRIPTION
Related issue: #27803

**Description**

Implemented scene graph support based on the spec extension here:
https://github.com/ephtracy/voxel-model/blob/master/MagicaVoxel-file-format-vox-extension.txt

<img width="1162" height="700" alt="Screenshot 2025-12-06 at 05 38 23" src="https://github.com/user-attachments/assets/e751165d-f959-4536-bd85-74fc72a72cc8" />

<img width="1082" height="929" alt="Screenshot 2025-12-06 at 06 35 41" src="https://github.com/user-attachments/assets/53e5a903-53bb-41eb-89f0-477a99f11773" />

Also changed the loader API.

Before:
```js
const loader = new VOXLoader();
loader.load( 'models/vox/monu10.vox', function ( chunks ) {

	for ( let i = 0; i < chunks.length; i ++ ) {

		const chunk = chunks[ i ];

		const mesh = new VOXMesh( chunk );
		scene.add( mesh );

	}

}
```

After:
```js
const loader = new VOXLoader();
loader.load( 'models/vox/monu10.vox', function ( result ) {

	scene.add( result.scene );

}
```