### PR TITLE
Addons: Unify import path for WebGPU related classes.

### DIFF
--- a/examples/jsm/helpers/LightProbeHelperGPU.js
+++ b/examples/jsm/helpers/LightProbeHelperGPU.js
@@ -2,7 +2,7 @@ import {
 	Mesh,
 	NodeMaterial,
 	SphereGeometry
-} from 'three';
+} from 'three/webgpu';
 import { float, Fn, getShIrradianceAt, normalWorld, uniformArray, uniform, vec4 } from 'three/tsl';
 
 /**

--- a/examples/jsm/helpers/TextureHelperGPU.js
+++ b/examples/jsm/helpers/TextureHelperGPU.js
@@ -6,7 +6,7 @@ import {
 	PlaneGeometry,
 	DoubleSide,
 	Vector3,
-} from 'three';
+} from 'three/webgpu';
 import { texture as textureNode, cubeTexture, texture3D, float, vec4, attribute } from 'three/tsl';
 import { mergeGeometries } from '../utils/BufferGeometryUtils.js';
 

--- a/examples/jsm/materials/LDrawConditionalLineNodeMaterial.js
+++ b/examples/jsm/materials/LDrawConditionalLineNodeMaterial.js
@@ -1,4 +1,4 @@
-import { Color } from 'three';
+import { Color } from 'three/webgpu';
 import { attribute, cameraProjectionMatrix, dot, float, Fn, modelViewMatrix, modelViewProjection, NodeMaterial, normalize, positionGeometry, sign, uniform, varyingProperty, vec2, vec4 } from 'three/tsl';
 
 /**

--- a/examples/jsm/utils/ShadowMapViewerGPU.js
+++ b/examples/jsm/utils/ShadowMapViewerGPU.js
@@ -9,7 +9,7 @@ import {
 	Scene,
 	DepthTexture,
 	Vector2
-} from 'three';
+} from 'three/webgpu';
 import { uv, uniform, textureLoad } from 'three/tsl';
 
 /**

--- a/examples/jsm/utils/WebGPUTextureUtils.js
+++ b/examples/jsm/utils/WebGPUTextureUtils.js
@@ -3,7 +3,7 @@ import {
 	NodeMaterial,
 	WebGPURenderer,
 	CanvasTexture
-} from 'three';
+} from 'three/webgpu';
 import { texture, uv } from 'three/tsl';
 
 /**


### PR DESCRIPTION
Fixed #32487.

**Description**

The PR makes sure certain `WebGPURenderer`-only addons import from `three/webgpu` instead of `three`. This was already true for most modules but not for the ones listed in this PR.
