### PR TITLE
feat: expose object and key in RendererInspector parameters

### DIFF
--- a/examples/jsm/inspector/tabs/Parameters.js
+++ b/examples/jsm/inspector/tabs/Parameters.js
@@ -62,6 +62,10 @@ class ParametersGroup {
 
 	_addParameter( object, property, editor, subItem ) {
 
+		// Expose the object and key for external tools like chrome extensions
+		editor.object = object;
+		editor.key = property;
+
 		editor.name = ( name ) => {
 
 			subItem.data[ 0 ].textContent = name;
@@ -281,7 +285,9 @@ class ParametersGroup {
 		const itemRow = subItem.domElement.firstChild;
 		itemRow.classList.add( 'actionable' );
 
-		// extend object property
+		// Expose the object and key for external tools like chrome extensions
+		editor.object = object;
+		editor.key = property;
 
 		editor.name = ( name ) => {
 


### PR DESCRIPTION
This pull request enhances the RendererInspector by exposing object and key properties for all parameter editors created through the ParametersGroup class.
Previously, external tools—such as browser extensions or custom debugging panels—could only interact with parameters by manipulating DOM elements, which is unreliable and not scalable. This update introduces a clean data-access layer that allows tools to read and control parameters programmatically.

What Was the Problem?
External integrations had no direct way to identify:
Which object a parameter belonged to
Which property key the parameter represented
As a result, extensions and custom UIs had to rely on DOM traversal or patching internal code, leading to fragile solutions.

What This PR Does
Adds object and key properties to parameter editors created via _addParameter()
Ensures buttons added via addButton() also expose object and key
Makes parameters discoverable and controllable by external tools without touching DOM elements
Maintains 100% backward compatibility with existing editor behavior

Why This Matters
Enables developers to build custom inspector UIs
Allows Chrome extensions and external tools to interact cleanly with editor parameters
Improves extensibility and avoids tightly coupling functionality to DOM structure
Creates a more stable and future-proof integration surface