### PR TITLE
Examples: Fix MRT readback with WebGL backend.

### DIFF
--- a/examples/webgpu_multiple_rendertargets_readback.html
+++ b/examples/webgpu_multiple_rendertargets_readback.html
@@ -155,26 +155,26 @@
 
 				torus.rotation.y = ( time / 1000 ) * .4;
 
-				const isMRT = selection === 'mrt';
+				const isReadback = ( selection !== 'mrt' );
 
 				// render scene into target
-				renderer.setMRT( isMRT ? sceneMRT : null );
-				renderer.setRenderTarget( isMRT ? renderTarget : readbackTarget );
+				renderer.setMRT( sceneMRT );
+				renderer.setRenderTarget( isReadback ? readbackTarget : renderTarget );
 				renderer.render( scene, camera );
 
 				// render post FX
 				renderer.setMRT( null );
 				renderer.setRenderTarget( null );
 
-				if ( isMRT ) {
-
-					quadMesh.material = material;
-
-				} else {
+				if ( isReadback ) {
 
 					quadMesh.material = readbackMaterial;
 
 					await readback();
+
+				} else {
+
+					quadMesh.material = material;
 
 				}
 


### PR DESCRIPTION
Related issue: -

**Description**

The MRT readback is currently broken on dev for the WebGL backend.

> WebGL: INVALID_OPERATION: Active draw buffers with missing fragment shader outputs.

The problem is that even when rendering to the readback render target, the MRT setting must be used otherwise the fragment shader outputs do not match render target's attachment state. 

I'm not sure why this worked before but I assume the MRT state was incorrectly cached.