### PR TITLE
WebGLRenderer: Ensure readback checks work on correct attachment state.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -2913,6 +2913,10 @@ class WebGLRenderer {
 					const textureFormat = texture.format;
 					const textureType = texture.type;
 
+					// when using MRT, select the correct color buffer for the subsequent read command
+
+					if ( renderTarget.textures.length > 1 ) _gl.readBuffer( _gl.COLOR_ATTACHMENT0 + textureIndex );
+
 					if ( ! capabilities.textureFormatReadable( textureFormat ) ) {
 
 						error( 'WebGLRenderer.readRenderTargetPixels: renderTarget is not in RGBA or implementation defined format.' );
@@ -2930,10 +2934,6 @@ class WebGLRenderer {
 					// the following if statement ensures valid read requests (no out-of-bounds pixels, see #8604)
 
 					if ( ( x >= 0 && x <= ( renderTarget.width - width ) ) && ( y >= 0 && y <= ( renderTarget.height - height ) ) ) {
-
-						// when using MRT, select the correct color buffer for the subsequent read command
-
-						if ( renderTarget.textures.length > 1 ) _gl.readBuffer( _gl.COLOR_ATTACHMENT0 + textureIndex );
 
 						_gl.readPixels( x, y, width, height, utils.convert( textureFormat ), utils.convert( textureType ), buffer );
 
@@ -2995,6 +2995,11 @@ class WebGLRenderer {
 					const textureFormat = texture.format;
 					const textureType = texture.type;
 
+					// when using MRT, select the correct color buffer for the subsequent read command
+
+					if ( renderTarget.textures.length > 1 ) _gl.readBuffer( _gl.COLOR_ATTACHMENT0 + textureIndex );
+
+
 					if ( ! capabilities.textureFormatReadable( textureFormat ) ) {
 
 						throw new Error( 'THREE.WebGLRenderer.readRenderTargetPixelsAsync: renderTarget is not in RGBA or implementation defined format.' );
@@ -3010,10 +3015,6 @@ class WebGLRenderer {
 					const glBuffer = _gl.createBuffer();
 					_gl.bindBuffer( _gl.PIXEL_PACK_BUFFER, glBuffer );
 					_gl.bufferData( _gl.PIXEL_PACK_BUFFER, buffer.byteLength, _gl.STREAM_READ );
-
-					// when using MRT, select the correct color buffer for the subsequent read command
-
-					if ( renderTarget.textures.length > 1 ) _gl.readBuffer( _gl.COLOR_ATTACHMENT0 + textureIndex );
 
 					_gl.readPixels( x, y, width, height, utils.convert( textureFormat ), utils.convert( textureType ), 0 );
 


### PR DESCRIPTION
**Description**

This PR fixes a bug when reading pixels from MRT. When using [readRenderTargetPixels](https://threejs.org/docs/#WebGLRenderer.readRenderTargetPixels) or [readRenderTargetPixelsAsync](https://threejs.org/docs/#WebGLRenderer.readRenderTargetPixelsAsync), the code checks whether the WebGL context can read a pixel from the requested texture:

https://github.com/mrdoob/three.js/blob/1246386f547c5b4e64d3705debfe5a22f18cc91c/src/renderers/WebGLRenderer.js#L2916C1-L2921C7

This is done in [textureFormatReadable](https://github.com/mrdoob/three.js/blob/1246386f547c5b4e64d3705debfe5a22f18cc91c/src/renderers/webgl/WebGLCapabilities.js#L28) function by using `gl.getParameter( gl.IMPLEMENTATION_COLOR_READ_FORMAT )`. Nonetheless, at this point, we did not define the [readBuffer](https://developer.mozilla.org/en-US/docs/Web/API/WebGL2RenderingContext/readBuffer) yet, so the result will always return the format from COLOR_ATTACHMENT0, raising some errors when I attempt to read pixels from other color attachments. The fix was basically moving the readBuffer calling function before this check.

An example of this bug: https://codepen.io/andredsm/full/jEqXVme. Check the console to see the error. In the [code](https://codepen.io/andredsm/pen/jEqXVme?editors=1012) of this example, if you comment the second read, everything works, since we are only reading from the COLOR_ATTACHMENT0.

Finally, I made this pure WebGL2 example showing that the output from `gl.getParameter( gl.IMPLEMENTATION_COLOR_READ_FORMAT )` is affected by the state of `gl.readBuffer`: https://codepen.io/andredsm/pen/pvyqEqV.
