### PR TITLE
Inspector: Store parameters object+key

### DIFF
--- a/examples/jsm/inspector/tabs/Parameters.js
+++ b/examples/jsm/inspector/tabs/Parameters.js
@@ -340,10 +340,8 @@ class Parameters extends Tab {
 		scrollWrapper.appendChild( paramList.domElement );
 		this.content.appendChild( scrollWrapper );
 
-		/** @type {List} */
 		this.paramList = paramList;
 
-		/** @type {Array<ParametersGroup>} */
 		this.groups = new Array();
 		
 	}

--- a/examples/jsm/inspector/tabs/Parameters.js
+++ b/examples/jsm/inspector/tabs/Parameters.js
@@ -14,7 +14,7 @@ class ParametersGroup {
 		this.paramList = new Item( name );
 
 		/** @type {Array<{ object:object, key:string, editor:object, subItem:Item }>} */
-		this.data = [];
+		this.objects = [];
 
 	}
 
@@ -102,11 +102,14 @@ class ParametersGroup {
 
 		};
 
+
+		this._registerParameter( object, property, editor, subItem );
+
 	}
 	
 	_registerParameter( object, property, editor, subItem ) {
 
-		this.data.push( { object: object, key: property, editor: editor, subItem: subItem } );
+		this.objects.push( { object: object, key: property, editor: editor, subItem: subItem } );
 
 	}
 
@@ -161,8 +164,6 @@ class ParametersGroup {
 
 		this._addParameter( object, property, editor, subItem );
 
-		this._registerParameter( object, property, editor, subItem );
-
 		return editor;
 
 	}
@@ -190,8 +191,6 @@ class ParametersGroup {
 		// extend object property
 
 		this._addParameter( object, property, editor, subItem );
-
-		this._registerParameter( object, property, editor, subItem );
 
 		return editor;
 
@@ -221,8 +220,6 @@ class ParametersGroup {
 
 		this._addParameter( object, property, editor, subItem );
 
-		this._registerParameter( object, property, editor, subItem );
-
 		return editor;
 
 	}
@@ -250,8 +247,6 @@ class ParametersGroup {
 		// extend object property
 
 		this._addParameter( object, property, editor, subItem );
-
-		this._registerParameter( object, property, editor, subItem );
 
 		return editor;
 
@@ -281,8 +276,6 @@ class ParametersGroup {
 		// extend object property
 
 		this._addParameter( object, property, editor, subItem );
-
-		this._registerParameter( object, property, editor, subItem );
 
 		return editor;
 

--- a/examples/jsm/inspector/tabs/Parameters.js
+++ b/examples/jsm/inspector/tabs/Parameters.js
@@ -13,7 +13,6 @@ class ParametersGroup {
 
 		this.paramList = new Item( name );
 
-		/** @type {Array<{ object:object, key:string, editor:object, subItem:Item }>} */
 		this.objects = [];
 
 	}
@@ -63,12 +62,6 @@ class ParametersGroup {
 
 	}
 
-	/**
-	 * @param {Object} object
-	 * @param {string} property
-	 * @param {Object} editor
-	 * @param {Item} subItem
-	 */
 	_addParameter( object, property, editor, subItem ) {
 
 		editor.name = ( name ) => {

--- a/examples/jsm/inspector/tabs/Parameters.js
+++ b/examples/jsm/inspector/tabs/Parameters.js
@@ -335,7 +335,7 @@ class Parameters extends Tab {
 
 		this.paramList = paramList;
 
-		this.groups = new Array();
+		this.groups = [];
 
 	}
 

--- a/examples/jsm/inspector/tabs/Parameters.js
+++ b/examples/jsm/inspector/tabs/Parameters.js
@@ -13,6 +13,9 @@ class ParametersGroup {
 
 		this.paramList = new Item( name );
 
+		/** @type {Array<{ object:object, key:string, editor:object, subItem:Item }>} */
+		this.data = [];
+
 	}
 
 	close() {
@@ -60,6 +63,12 @@ class ParametersGroup {
 
 	}
 
+	/**
+	 * @param {Object} object
+	 * @param {string} property
+	 * @param {Object} editor
+	 * @param {Item} subItem
+	 */
 	_addParameter( object, property, editor, subItem ) {
 
 		editor.name = ( name ) => {
@@ -92,6 +101,12 @@ class ParametersGroup {
 			return editor;
 
 		};
+
+	}
+	
+	_registerParameter( object, property, editor, subItem ) {
+
+		this.data.push( { object: object, key: property, editor: editor, subItem: subItem } );
 
 	}
 
@@ -146,6 +161,8 @@ class ParametersGroup {
 
 		this._addParameter( object, property, editor, subItem );
 
+		this._registerParameter( object, property, editor, subItem );
+
 		return editor;
 
 	}
@@ -173,6 +190,8 @@ class ParametersGroup {
 		// extend object property
 
 		this._addParameter( object, property, editor, subItem );
+
+		this._registerParameter( object, property, editor, subItem );
 
 		return editor;
 
@@ -202,6 +221,8 @@ class ParametersGroup {
 
 		this._addParameter( object, property, editor, subItem );
 
+		this._registerParameter( object, property, editor, subItem );
+
 		return editor;
 
 	}
@@ -229,6 +250,8 @@ class ParametersGroup {
 		// extend object property
 
 		this._addParameter( object, property, editor, subItem );
+
+		this._registerParameter( object, property, editor, subItem );
 
 		return editor;
 
@@ -258,6 +281,8 @@ class ParametersGroup {
 		// extend object property
 
 		this._addParameter( object, property, editor, subItem );
+
+		this._registerParameter( object, property, editor, subItem );
 
 		return editor;
 
@@ -291,6 +316,8 @@ class ParametersGroup {
 
 		};
 
+		this._registerParameter( object, property, editor, subItem );
+
 		return editor;
 
 	}
@@ -313,8 +340,12 @@ class Parameters extends Tab {
 		scrollWrapper.appendChild( paramList.domElement );
 		this.content.appendChild( scrollWrapper );
 
+		/** @type {List} */
 		this.paramList = paramList;
 
+		/** @type {Array<ParametersGroup>} */
+		this.groups = new Array();
+		
 	}
 
 	createGroup( name ) {
@@ -322,6 +353,7 @@ class Parameters extends Tab {
 		const group = new ParametersGroup( this, name );
 
 		this.paramList.add( group.paramList );
+		this.groups.push( group );
 
 		return group;
 

--- a/examples/jsm/inspector/tabs/Parameters.js
+++ b/examples/jsm/inspector/tabs/Parameters.js
@@ -106,7 +106,7 @@ class ParametersGroup {
 		this._registerParameter( object, property, editor, subItem );
 
 	}
-	
+
 	_registerParameter( object, property, editor, subItem ) {
 
 		this.objects.push( { object: object, key: property, editor: editor, subItem: subItem } );
@@ -336,7 +336,7 @@ class Parameters extends Tab {
 		this.paramList = paramList;
 
 		this.groups = new Array();
-		
+
 	}
 
 	createGroup( name ) {


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/32485

**Description**

Currently the inspector does not provide access to the objects and keys that are being controlled by the inspector UI. 

This PR adds storing the parameters (object + key) in the parameters group to be accessible for external inspector tools (e.g. chrome extensions).

*This contribution is funded by [Needle](https://needle.tools)*
