### PR TITLE
Renderer: Rename `.getOutputBufferType()` -> `.getWorkingBufferType()`

### DIFF
--- a/examples/webgpu_xr_rollercoaster.html
+++ b/examples/webgpu_xr_rollercoaster.html
@@ -32,7 +32,7 @@
 
 			let mesh, material, geometry;
 
-			const renderer = new THREE.WebGPURenderer( { antialias: true, forceWebGL: true, outputBufferType: THREE.UnsignedByteType, multiview: false } );
+			const renderer = new THREE.WebGPURenderer( { antialias: true, forceWebGL: true, workingBufferType: THREE.UnsignedByteType, multiview: false } );
 			renderer.setPixelRatio( window.devicePixelRatio );
 			renderer.setSize( window.innerWidth, window.innerHeight );
 			renderer.setAnimationLoop( animate );

--- a/src/nodes/display/PassNode.js
+++ b/src/nodes/display/PassNode.js
@@ -736,7 +736,7 @@ class PassNode extends TempNode {
 
 		this.renderTarget.samples = this.options.samples === undefined ? renderer.samples : this.options.samples;
 
-		this.renderTarget.texture.type = renderer.getOutputBufferType();
+		this.renderTarget.texture.type = renderer.getWorkingBufferType();
 
 		return this.scope === PassNode.COLOR ? this.getTextureNode() : this.getLinearDepthNode();
 

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -64,7 +64,7 @@ class Renderer {
 	 * @property {number} [samples=0] - When `antialias` is `true`, `4` samples are used by default. This parameter can set to any other integer value than 0
 	 * to overwrite the default.
 	 * @property {?Function} [getFallback=null] - This callback function can be used to provide a fallback backend, if the primary backend can't be targeted.
-	 * @property {number} [outputBufferType=HalfFloatType] - Defines the type of output buffers. The default `HalfFloatType` is recommend for best
+	 * @property {number} [workingBufferType=HalfFloatType] - Defines the type of output buffers. The default `HalfFloatType` is recommend for best
 	 * quality. To save memory and bandwidth, `UnsignedByteType` might be used. This will reduce rendering quality though.
 	 * @property {boolean} [multiview=false] - If set to `true`, the renderer will use multiview during WebXR rendering if supported.
 	 */
@@ -97,7 +97,7 @@ class Renderer {
 			antialias = false,
 			samples = 0,
 			getFallback = null,
-			outputBufferType = HalfFloatType,
+			workingBufferType = HalfFloatType,
 			multiview = false
 		} = parameters;
 
@@ -592,7 +592,7 @@ class Renderer {
 		 * @type {number}
 		 * @default HalfFloatType
 		 */
-		this._outputBufferType = outputBufferType;
+		this._workingBufferType = workingBufferType;
 
 		/**
 		 * A cache for shadow nodes per material
@@ -1088,23 +1088,23 @@ class Renderer {
 	 *
 	 * @return {number} The output buffer type.
 	 */
-	getOutputBufferType() {
+	getWorkingBufferType() {
 
-		return this._outputBufferType;
+		return this._workingBufferType;
 
 	}
 
 	/**
 	 * Returns the output buffer type.
 	 *
-	 * @deprecated since r182. Use `.getOutputBufferType()` instead.
+	 * @deprecated since r182. Use `.getWorkingBufferType()` instead.
 	 * @return {number} The output buffer type.
 	 */
 	getColorBufferType() { // @deprecated, r182
 
-		warnOnce( 'Renderer: ".getColorBufferType()" has been renamed to ".getOutputBufferType()".' );
+		warnOnce( 'Renderer: ".getColorBufferType()" has been renamed to ".getWorkingBufferType()".' );
 
-		return this.getOutputBufferType();
+		return this.getWorkingBufferType();
 
 	}
 
@@ -1280,7 +1280,7 @@ class Renderer {
 			frameBufferTarget = new RenderTarget( width, height, {
 				depthBuffer: depth,
 				stencilBuffer: stencil,
-				type: this._outputBufferType,
+				type: this._workingBufferType,
 				format: RGBAFormat,
 				colorSpace: ColorManagement.workingColorSpace,
 				generateMipmaps: false,

--- a/src/renderers/webgpu/WebGPURenderer.js
+++ b/src/renderers/webgpu/WebGPURenderer.js
@@ -39,8 +39,9 @@ class WebGPURenderer extends Renderer {
 	 * @property {number} [samples=0] - When `antialias` is `true`, `4` samples are used by default. Set this parameter to any other integer value than 0 to overwrite the default.
 	 * @property {boolean} [forceWebGL=false] - If set to `true`, the renderer uses a WebGL 2 backend no matter if WebGPU is supported or not.
 	 * @property {boolean} [multiview=false] - If set to `true`, the renderer will use multiview during WebXR rendering if supported.
-	 * @property {number} [outputType=undefined] - Texture type for output to canvas. By default, device's preferred format is used; other formats may incur overhead.
-	 * @property {number} [outputBufferType=HalfFloatType] - Defines the type of output buffers. The default `HalfFloatType` is recommend for best
+	 * @property {number} [outputType=undefined] - Defines the device output type.
+	 * @property {number} [outputBufferType=undefined] - Defines the type of output buffers. By default, device's preferred format is used; if outputType is defined, it will be used as default.
+	 * @property {number} [workingBufferType=HalfFloatType] - Defines the type of working buffers. The default `HalfFloatType` is recommend for best
 	 * quality. To save memory and bandwidth, `UnsignedByteType` might be used. This will reduce rendering quality though.
 	 */
 

--- a/src/renderers/webgpu/utils/WebGPUUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUUtils.js
@@ -222,7 +222,13 @@ class WebGPUUtils {
 
 		const parameters = this.backend.parameters;
 
-		const bufferType = parameters.outputType;
+		let bufferType = parameters.outputBufferType;
+
+		if ( bufferType === undefined ) {
+
+			bufferType = parameters.outputType;
+
+		}
 
 		if ( bufferType === undefined ) {
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/32501

**Description**

The PR introduces `workingBufferType` which should be used to the internal `RenderTargets` while preserving the logic of the previous PR.

| Name | Description | Default |
| -- | -- | -- |
| `.outputType`  | Screen/Output hardware target bits precision and range | |
| `.outputBufferType`  | Output buffer bits precision and range | |
| `.workingBufferType`  | Working bits precision and range | HalfFloatType |