### PR TITLE
TSL: Fix get member from array element

### DIFF
--- a/src/nodes/core/ArrayNode.js
+++ b/src/nodes/core/ArrayNode.js
@@ -97,13 +97,7 @@ class ArrayNode extends TempNode {
 	 */
 	getElementType( builder ) {
 
-		if ( this.nodeType === null ) {
-
-			return this.values[ 0 ].getElementType( builder );
-
-		}
-
-		return super.getElementType( builder );
+		return this.getNodeType( builder );
 
 	}
 

--- a/src/nodes/core/ArrayNode.js
+++ b/src/nodes/core/ArrayNode.js
@@ -81,7 +81,7 @@ class ArrayNode extends TempNode {
 
 		if ( this.nodeType === null ) {
 
-			this.nodeType = this.values[ 0 ].getNodeType( builder );
+			return this.values[ 0 ].getNodeType( builder );
 
 		}
 
@@ -97,7 +97,32 @@ class ArrayNode extends TempNode {
 	 */
 	getElementType( builder ) {
 
-		return this.getNodeType( builder );
+		if ( this.nodeType === null ) {
+
+			return this.values[ 0 ].getElementType( builder );
+
+		}
+
+		return super.getElementType( builder );
+
+	}
+
+	/**
+	 * Returns the type of a member variable.
+	 *
+	 * @param {NodeBuilder} builder - The current node builder.
+	 * @param {string} name - The name of the member variable.
+	 * @return {string} The type of the member variable.
+	 */
+	getMemberType( builder, name ) {
+
+		if ( this.nodeType === null ) {
+
+			return this.values[ 0 ].getMemberType( builder, name );
+
+		}
+
+		return super.getMemberType( builder, name );
 
 	}
 

--- a/src/nodes/utils/ArrayElementNode.js
+++ b/src/nodes/utils/ArrayElementNode.js
@@ -61,6 +61,19 @@ class ArrayElementNode extends Node { // @TODO: If extending from TempNode it br
 
 	}
 
+	/**
+	 * This method is overwritten since the member type is inferred from the array-like node.
+	 *
+	 * @param {NodeBuilder} builder - The current node builder.
+	 * @param {string} name - The member name.
+	 * @return {string} The member type.
+	 */
+	getMemberType( builder, name ) {
+
+		return this.node.getMemberType( builder, name );
+
+	}
+
 	generate( builder ) {
 
 		const indexType = this.indexNode.getNodeType( builder );


### PR DESCRIPTION
**Description**

The PR fix the propagation to obtain a member of an array element when using a structure.

```js
const Struct = struct( {
	colorA: 'color'
} );

material.colorNode = Struct().toArray( 3 ).element( 0 ).get( 'colorA' ).debug();
```