### PR TITLE
TSL: Remove `nodeObject` for Node classes

### DIFF
--- a/examples/webgpu_instance_uniform.html
+++ b/examples/webgpu_instance_uniform.html
@@ -109,7 +109,7 @@
 
 				// Materials
 
-				const instanceUniform = nodeObject( new InstanceUniformNode() );
+				const instanceUniform = new InstanceUniformNode();
 				const cubeTextureNode = cubeTexture( cTexture );
 
 				const material = new THREE.MeshBasicNodeMaterial();

--- a/src/loaders/nodes/NodeLoader.js
+++ b/src/loaders/nodes/NodeLoader.js
@@ -185,7 +185,7 @@ class NodeLoader extends Loader {
 
 		}
 
-		return nodeObject( new this.nodes[ type ]() );
+		return new this.nodes[ type ]();
 
 	}
 

--- a/src/loaders/nodes/NodeLoader.js
+++ b/src/loaders/nodes/NodeLoader.js
@@ -1,4 +1,4 @@
-import { nodeObject, float } from '../../nodes/tsl/TSLBase.js';
+import { float } from '../../nodes/tsl/TSLBase.js';
 
 import { Loader } from '../Loader.js';
 import { FileLoader } from '../../loaders/FileLoader.js';

--- a/src/nodes/accessors/BufferNode.js
+++ b/src/nodes/accessors/BufferNode.js
@@ -1,5 +1,4 @@
 import UniformNode from '../core/UniformNode.js';
-import { nodeObject } from '../tsl/TSLBase.js';
 
 /**
  * A special type of uniform node which represents array-like data

--- a/src/nodes/accessors/BufferNode.js
+++ b/src/nodes/accessors/BufferNode.js
@@ -126,4 +126,4 @@ export default BufferNode;
  * @param {number} count - The count of buffer elements.
  * @returns {BufferNode}
  */
-export const buffer = ( value, type, count ) => nodeObject( new BufferNode( value, type, count ) );
+export const buffer = ( value, type, count ) => new BufferNode( value, type, count );

--- a/src/nodes/accessors/ClippingNode.js
+++ b/src/nodes/accessors/ClippingNode.js
@@ -1,6 +1,6 @@
 
 import Node from '../core/Node.js';
-import { nodeObject, Fn, bool, float } from '../tsl/TSLBase.js';
+import { Fn, bool, float } from '../tsl/TSLBase.js';
 import { positionView } from './Position.js';
 import { diffuseColor } from '../core/PropertyNode.js';
 import { Loop } from '../utils/LoopNode.js';

--- a/src/nodes/accessors/ClippingNode.js
+++ b/src/nodes/accessors/ClippingNode.js
@@ -234,7 +234,7 @@ export default ClippingNode;
  * @function
  * @returns {ClippingNode}
  */
-export const clipping = () => nodeObject( new ClippingNode() );
+export const clipping = () => new ClippingNode();
 
 /**
  * TSL function for setting up alpha to coverage.
@@ -243,7 +243,7 @@ export const clipping = () => nodeObject( new ClippingNode() );
  * @function
  * @returns {ClippingNode}
  */
-export const clippingAlpha = () => nodeObject( new ClippingNode( ClippingNode.ALPHA_TO_COVERAGE ) );
+export const clippingAlpha = () => new ClippingNode( ClippingNode.ALPHA_TO_COVERAGE );
 
 /**
  * TSL function for setting up hardware-based clipping.
@@ -252,4 +252,4 @@ export const clippingAlpha = () => nodeObject( new ClippingNode( ClippingNode.AL
  * @function
  * @returns {ClippingNode}
  */
-export const hardwareClipping = () => nodeObject( new ClippingNode( ClippingNode.HARDWARE ) );
+export const hardwareClipping = () => new ClippingNode( ClippingNode.HARDWARE );

--- a/src/nodes/accessors/MaterialReferenceNode.js
+++ b/src/nodes/accessors/MaterialReferenceNode.js
@@ -1,5 +1,4 @@
 import ReferenceNode from './ReferenceNode.js';
-import { nodeObject } from '../tsl/TSLBase.js';
 
 /**
  * This node is a special type of reference node which is intended

--- a/src/nodes/accessors/MaterialReferenceNode.js
+++ b/src/nodes/accessors/MaterialReferenceNode.js
@@ -82,4 +82,4 @@ export default MaterialReferenceNode;
  * When no material is set, the node refers to the material of the current rendered object.
  * @returns {MaterialReferenceNode}
  */
-export const materialReference = ( name, type, material = null ) => nodeObject( new MaterialReferenceNode( name, type, material ) );
+export const materialReference = ( name, type, material = null ) => new MaterialReferenceNode( name, type, material );

--- a/src/nodes/accessors/ReferenceBaseNode.js
+++ b/src/nodes/accessors/ReferenceBaseNode.js
@@ -199,7 +199,7 @@ class ReferenceBaseNode extends Node {
 	 */
 	element( indexNode ) {
 
-		return nodeObject( new ReferenceElementNode( this, nodeObject( indexNode ) ) );
+		return new ReferenceElementNode( this, nodeObject( indexNode ) );
 
 	}
 
@@ -340,7 +340,7 @@ export default ReferenceBaseNode;
  * @param {Object} object - The object the property belongs to.
  * @returns {ReferenceBaseNode}
  */
-export const reference = ( name, type, object ) => nodeObject( new ReferenceBaseNode( name, type, object ) );
+export const reference = ( name, type, object ) => new ReferenceBaseNode( name, type, object );
 
 /**
  * TSL function for creating a reference base node. Use this function if you want need a reference
@@ -354,4 +354,4 @@ export const reference = ( name, type, object ) => nodeObject( new ReferenceBase
  * @param {Object} [object] - An array-like object the property belongs to.
  * @returns {ReferenceBaseNode}
  */
-export const referenceBuffer = ( name, type, count, object ) => nodeObject( new ReferenceBaseNode( name, type, object, count ) );
+export const referenceBuffer = ( name, type, count, object ) => new ReferenceBaseNode( name, type, object, count );

--- a/src/nodes/accessors/ReferenceNode.js
+++ b/src/nodes/accessors/ReferenceNode.js
@@ -198,7 +198,7 @@ class ReferenceNode extends Node {
 	 */
 	element( indexNode ) {
 
-		return nodeObject( new ReferenceElementNode( this, nodeObject( indexNode ) ) );
+		return new ReferenceElementNode( this, nodeObject( indexNode ) );
 
 	}
 
@@ -407,7 +407,7 @@ export default ReferenceNode;
  * @param {?Object} [object] - The object the property belongs to.
  * @returns {ReferenceNode}
  */
-export const reference = ( name, type, object ) => nodeObject( new ReferenceNode( name, type, object ) );
+export const reference = ( name, type, object ) => new ReferenceNode( name, type, object );
 
 /**
  * TSL function for creating a reference node. Use this function if you want need a reference
@@ -421,4 +421,4 @@ export const reference = ( name, type, object ) => nodeObject( new ReferenceNode
  * @param {Object} object - An array-like object the property belongs to.
  * @returns {ReferenceNode}
  */
-export const referenceBuffer = ( name, type, count, object ) => nodeObject( new ReferenceNode( name, type, object, count ) );
+export const referenceBuffer = ( name, type, count, object ) => new ReferenceNode( name, type, object, count );

--- a/src/nodes/accessors/RendererReferenceNode.js
+++ b/src/nodes/accessors/RendererReferenceNode.js
@@ -76,4 +76,4 @@ export default RendererReferenceNode;
  * the node refers to the renderer of the current state.
  * @returns {RendererReferenceNode}
  */
-export const rendererReference = ( name, type, renderer = null ) => nodeObject( new RendererReferenceNode( name, type, renderer ) );
+export const rendererReference = ( name, type, renderer = null ) => new RendererReferenceNode( name, type, renderer );

--- a/src/nodes/accessors/RendererReferenceNode.js
+++ b/src/nodes/accessors/RendererReferenceNode.js
@@ -1,5 +1,4 @@
 import ReferenceBaseNode from './ReferenceBaseNode.js';
-import { nodeObject } from '../tsl/TSLCore.js';
 import { renderGroup } from '../core/UniformGroupNode.js';
 
 /**

--- a/src/nodes/accessors/SkinningNode.js
+++ b/src/nodes/accessors/SkinningNode.js
@@ -313,7 +313,7 @@ export default SkinningNode;
  * @param {SkinnedMesh} skinnedMesh - The skinned mesh.
  * @returns {SkinningNode}
  */
-export const skinning = ( skinnedMesh ) => nodeObject( new SkinningNode( skinnedMesh ) );
+export const skinning = ( skinnedMesh ) => new SkinningNode( skinnedMesh );
 
 /**
  * TSL function for computing skinning.

--- a/src/nodes/accessors/StorageBufferNode.js
+++ b/src/nodes/accessors/StorageBufferNode.js
@@ -397,7 +397,7 @@ export default StorageBufferNode;
  * @param {number} [count=0] - The buffer count.
  * @returns {StorageBufferNode}
  */
-export const storage = ( value, type = null, count = 0 ) => nodeObject( new StorageBufferNode( value, type, count ) );
+export const storage = ( value, type = null, count = 0 ) => new StorageBufferNode( value, type, count );
 
 /**
  * @tsl

--- a/src/nodes/accessors/StorageBufferNode.js
+++ b/src/nodes/accessors/StorageBufferNode.js
@@ -1,6 +1,6 @@
 import BufferNode from './BufferNode.js';
 import { bufferAttribute } from './BufferAttributeNode.js';
-import { nodeObject, varying } from '../tsl/TSLBase.js';
+import { varying } from '../tsl/TSLBase.js';
 import { storageElement } from '../utils/StorageArrayElementNode.js';
 import { NodeAccess } from '../core/constants.js';
 import { getTypeFromLength } from '../core/NodeUtils.js';

--- a/src/nodes/accessors/UniformArrayNode.js
+++ b/src/nodes/accessors/UniformArrayNode.js
@@ -328,7 +328,7 @@ class UniformArrayNode extends BufferNode {
 	 */
 	element( indexNode ) {
 
-		return nodeObject( new UniformArrayElementNode( this, nodeObject( indexNode ) ) );
+		return new UniformArrayElementNode( this, nodeObject( indexNode ) );
 
 	}
 
@@ -345,4 +345,4 @@ export default UniformArrayNode;
  * @param {?string} [nodeType] - The data type of the array elements.
  * @returns {UniformArrayNode}
  */
-export const uniformArray = ( values, nodeType ) => nodeObject( new UniformArrayNode( values, nodeType ) );
+export const uniformArray = ( values, nodeType ) => new UniformArrayNode( values, nodeType );

--- a/src/nodes/accessors/UserDataNode.js
+++ b/src/nodes/accessors/UserDataNode.js
@@ -1,5 +1,4 @@
 import ReferenceNode from './ReferenceNode.js';
-import { nodeObject } from '../tsl/TSLBase.js';
 
 /**
  * A special type of reference node that allows to link values in

--- a/src/nodes/accessors/UserDataNode.js
+++ b/src/nodes/accessors/UserDataNode.js
@@ -74,4 +74,4 @@ export default UserDataNode;
  * @param {?Object} userData - A reference to the `userData` object. If not provided, the `userData` property of the 3D object that uses the node material is evaluated.
  * @returns {UserDataNode}
  */
-export const userData = ( name, inputType, userData ) => nodeObject( new UserDataNode( name, inputType, userData ) );
+export const userData = ( name, inputType, userData ) => new UserDataNode( name, inputType, userData );

--- a/src/nodes/accessors/VertexColorNode.js
+++ b/src/nodes/accessors/VertexColorNode.js
@@ -1,5 +1,4 @@
 import AttributeNode from '../core/AttributeNode.js';
-import { nodeObject } from '../tsl/TSLBase.js';
 import { Vector4 } from '../../math/Vector4.js';
 
 /**

--- a/src/nodes/accessors/VertexColorNode.js
+++ b/src/nodes/accessors/VertexColorNode.js
@@ -107,4 +107,4 @@ export default VertexColorNode;
  * @param {number} [index=0] - The attribute index.
  * @returns {VertexColorNode}
  */
-export const vertexColor = ( index = 0 ) => nodeObject( new VertexColorNode( index ) );
+export const vertexColor = ( index = 0 ) => new VertexColorNode( index );

--- a/src/nodes/code/FunctionNode.js
+++ b/src/nodes/code/FunctionNode.js
@@ -170,7 +170,7 @@ const nativeFn = ( code, includes = [], language = '' ) => {
 
 	}
 
-	const functionNode = nodeObject( new FunctionNode( code, includes, language ) );
+	const functionNode = new FunctionNode( code, includes, language );
 
 	const fn = ( ...params ) => functionNode.call( ...params );
 	fn.functionNode = functionNode;

--- a/src/nodes/code/FunctionNode.js
+++ b/src/nodes/code/FunctionNode.js
@@ -1,5 +1,4 @@
 import CodeNode from './CodeNode.js';
-import { nodeObject } from '../tsl/TSLBase.js';
 
 /**
  * This class represents a native shader function. It can be used to implement

--- a/src/nodes/core/AttributeNode.js
+++ b/src/nodes/core/AttributeNode.js
@@ -1,5 +1,5 @@
 import Node from './Node.js';
-import { nodeObject, varying } from '../tsl/TSLBase.js';
+import { varying } from '../tsl/TSLBase.js';
 import { warn } from '../../utils.js';
 
 /**

--- a/src/nodes/core/AttributeNode.js
+++ b/src/nodes/core/AttributeNode.js
@@ -165,4 +165,4 @@ export default AttributeNode;
  * @param {?string} [nodeType=null] - The node type.
  * @returns {AttributeNode}
  */
-export const attribute = ( name, nodeType = null ) => nodeObject( new AttributeNode( name, nodeType ) );
+export const attribute = ( name, nodeType = null ) => new AttributeNode( name, nodeType );

--- a/src/nodes/core/ParameterNode.js
+++ b/src/nodes/core/ParameterNode.js
@@ -91,4 +91,4 @@ export default ParameterNode;
  * @param {?string} name - The name of the parameter in the shader.
  * @returns {ParameterNode}
  */
-export const parameter = ( type, name ) => nodeObject( new ParameterNode( type, name ) );
+export const parameter = ( type, name ) => new ParameterNode( type, name );

--- a/src/nodes/core/ParameterNode.js
+++ b/src/nodes/core/ParameterNode.js
@@ -1,4 +1,3 @@
-import { nodeObject } from '../tsl/TSLBase.js';
 import { error } from '../../utils.js';
 import PropertyNode from './PropertyNode.js';
 

--- a/src/nodes/core/PropertyNode.js
+++ b/src/nodes/core/PropertyNode.js
@@ -1,5 +1,5 @@
 import Node from './Node.js';
-import { nodeImmutable, nodeObject } from '../tsl/TSLCore.js';
+import { nodeImmutable } from '../tsl/TSLCore.js';
 import { hashString } from './NodeUtils.js';
 
 /**

--- a/src/nodes/core/PropertyNode.js
+++ b/src/nodes/core/PropertyNode.js
@@ -113,7 +113,7 @@ export default PropertyNode;
  * @param {?string} [name=null] - The name of the property in the shader.
  * @returns {PropertyNode}
  */
-export const property = ( type, name ) => nodeObject( new PropertyNode( type, name ) );
+export const property = ( type, name ) => new PropertyNode( type, name );
 
 /**
  * TSL function for creating a varying property node.
@@ -124,7 +124,7 @@ export const property = ( type, name ) => nodeObject( new PropertyNode( type, na
  * @param {?string} [name=null] - The name of the varying in the shader.
  * @returns {PropertyNode}
  */
-export const varyingProperty = ( type, name ) => nodeObject( new PropertyNode( type, name, true ) );
+export const varyingProperty = ( type, name ) => new PropertyNode( type, name, true );
 
 /**
  * TSL object that represents the shader variable `DiffuseColor`.

--- a/src/nodes/core/StructNode.js
+++ b/src/nodes/core/StructNode.js
@@ -108,7 +108,7 @@ export const struct = ( membersLayout, name = null ) => {
 
 		}
 
-		return nodeObject( new StructNode( structLayout, values ) );
+		return new StructNode( structLayout, values );
 
 	};
 

--- a/src/nodes/core/StructNode.js
+++ b/src/nodes/core/StructNode.js
@@ -1,6 +1,5 @@
 import Node from './Node.js';
 import StructTypeNode from './StructTypeNode.js';
-import { nodeObject } from '../tsl/TSLCore.js';
 
 /**
  * StructNode allows to create custom structures with multiple members.

--- a/src/nodes/core/UniformNode.js
+++ b/src/nodes/core/UniformNode.js
@@ -1,6 +1,6 @@
 import InputNode from './InputNode.js';
 import { objectGroup } from './UniformGroupNode.js';
-import { nodeObject, getConstNodeType } from '../tsl/TSLCore.js';
+import { getConstNodeType } from '../tsl/TSLCore.js';
 import { getValueFromType } from './NodeUtils.js';
 import { warn } from '../../utils.js';
 

--- a/src/nodes/core/UniformNode.js
+++ b/src/nodes/core/UniformNode.js
@@ -253,6 +253,6 @@ export const uniform = ( value, type ) => {
 
 	}
 
-	return nodeObject( new UniformNode( value, nodeType ) );
+	return new UniformNode( value, nodeType );
 
 };

--- a/src/nodes/display/PassNode.js
+++ b/src/nodes/display/PassNode.js
@@ -1,7 +1,7 @@
 import TempNode from '../core/TempNode.js';
 import { default as TextureNode/*, texture*/ } from '../accessors/TextureNode.js';
 import { NodeUpdateType } from '../core/constants.js';
-import { nodeObject, context } from '../tsl/TSLBase.js';
+import { context } from '../tsl/TSLBase.js';
 import { uniform } from '../core/UniformNode.js';
 import { viewZToOrthographicDepth, perspectiveDepthToViewZ } from './ViewportDepthNode.js';
 

--- a/src/nodes/display/PassNode.js
+++ b/src/nodes/display/PassNode.js
@@ -623,7 +623,7 @@ class PassNode extends TempNode {
 
 		if ( textureNode === undefined ) {
 
-			textureNode = nodeObject( new PassMultipleTextureNode( this, name ) );
+			textureNode = new PassMultipleTextureNode( this, name );
 			textureNode.updateTexture();
 			this._textureNodes[ name ] = textureNode;
 
@@ -647,7 +647,7 @@ class PassNode extends TempNode {
 
 			if ( this._textureNodes[ name ] === undefined ) this.getTextureNode( name );
 
-			textureNode = nodeObject( new PassMultipleTextureNode( this, name, true ) );
+			textureNode = new PassMultipleTextureNode( this, name, true );
 			textureNode.updateTexture();
 			this._previousTextureNodes[ name ] = textureNode;
 
@@ -990,7 +990,7 @@ export default PassNode;
  * @param {Object} options - Options for the internal render target.
  * @returns {PassNode}
  */
-export const pass = ( scene, camera, options ) => nodeObject( new PassNode( PassNode.COLOR, scene, camera, options ) );
+export const pass = ( scene, camera, options ) => new PassNode( PassNode.COLOR, scene, camera, options );
 
 /**
  * TSL function for creating a pass texture node.
@@ -1001,7 +1001,7 @@ export const pass = ( scene, camera, options ) => nodeObject( new PassNode( Pass
  * @param {Texture} texture - The output texture.
  * @returns {PassTextureNode}
  */
-export const passTexture = ( pass, texture ) => nodeObject( new PassTextureNode( pass, texture ) );
+export const passTexture = ( pass, texture ) => new PassTextureNode( pass, texture );
 
 /**
  * TSL function for creating a depth pass node.
@@ -1013,4 +1013,4 @@ export const passTexture = ( pass, texture ) => nodeObject( new PassTextureNode(
  * @param {Object} options - Options for the internal render target.
  * @returns {PassNode}
  */
-export const depthPass = ( scene, camera, options ) => nodeObject( new PassNode( PassNode.DEPTH, scene, camera, options ) );
+export const depthPass = ( scene, camera, options ) => new PassNode( PassNode.DEPTH, scene, camera, options );

--- a/src/nodes/gpgpu/ComputeBuiltinNode.js
+++ b/src/nodes/gpgpu/ComputeBuiltinNode.js
@@ -1,5 +1,4 @@
 import Node from '../core/Node.js';
-import { nodeObject } from '../tsl/TSLBase.js';
 import { warn } from '../../utils.js';
 
 /**

--- a/src/nodes/gpgpu/ComputeBuiltinNode.js
+++ b/src/nodes/gpgpu/ComputeBuiltinNode.js
@@ -149,7 +149,7 @@ export default ComputeBuiltinNode;
  * @param {string} nodeType - The node type.
  * @returns {ComputeBuiltinNode}
  */
-const computeBuiltin = ( name, nodeType ) => nodeObject( new ComputeBuiltinNode( name, nodeType ) );
+const computeBuiltin = ( name, nodeType ) => new ComputeBuiltinNode( name, nodeType );
 
 /**
  * Represents the number of workgroups dispatched by the compute shader.

--- a/src/nodes/gpgpu/WorkgroupInfoNode.js
+++ b/src/nodes/gpgpu/WorkgroupInfoNode.js
@@ -1,5 +1,4 @@
 import ArrayElementNode from '../utils/ArrayElementNode.js';
-import { nodeObject } from '../tsl/TSLCore.js';
 import Node from '../core/Node.js';
 import { warn } from '../../utils.js';
 

--- a/src/nodes/gpgpu/WorkgroupInfoNode.js
+++ b/src/nodes/gpgpu/WorkgroupInfoNode.js
@@ -203,7 +203,7 @@ class WorkgroupInfoNode extends Node {
 	 */
 	element( indexNode ) {
 
-		return nodeObject( new WorkgroupInfoElementNode( this, indexNode ) );
+		return new WorkgroupInfoElementNode( this, indexNode );
 
 	}
 
@@ -229,6 +229,6 @@ export default WorkgroupInfoNode;
  * @param {number} [count=0] - The number of elements in the buffer.
  * @returns {WorkgroupInfoNode}
  */
-export const workgroupArray = ( type, count ) => nodeObject( new WorkgroupInfoNode( 'Workgroup', type, count ) );
+export const workgroupArray = ( type, count ) => new WorkgroupInfoNode( 'Workgroup', type, count );
 
 

--- a/src/nodes/lighting/LightsNode.js
+++ b/src/nodes/lighting/LightsNode.js
@@ -234,7 +234,7 @@ class LightsNode extends Node {
 
 					if ( ! _lightsNodeRef.has( light ) ) {
 
-						lightNode = nodeObject( new lightNodeClass( light ) );
+						lightNode = new lightNodeClass( light );
 						_lightsNodeRef.set( light, lightNode );
 
 					} else {
@@ -450,4 +450,4 @@ export default LightsNode;
  * @param {Array<Light>} lights - An array of lights.
  * @return {LightsNode} The created lights node.
  */
-export const lights = ( lights = [] ) => nodeObject( new LightsNode() ).setLights( lights );
+export const lights = ( lights = [] ) => new LightsNode().setLights( lights );

--- a/src/nodes/lighting/PointShadowNode.js
+++ b/src/nodes/lighting/PointShadowNode.js
@@ -310,4 +310,4 @@ export default PointShadowNode;
  * @param {?PointLightShadow} [shadow=null] - An optional point light shadow.
  * @return {PointShadowNode} The created point shadow node.
  */
-export const pointShadow = ( light, shadow ) => nodeObject( new PointShadowNode( light, shadow ) );
+export const pointShadow = ( light, shadow ) => new PointShadowNode( light, shadow );

--- a/src/nodes/lighting/PointShadowNode.js
+++ b/src/nodes/lighting/PointShadowNode.js
@@ -1,6 +1,6 @@
 import ShadowNode from './ShadowNode.js';
 import { uniform } from '../core/UniformNode.js';
-import { float, vec3, If, Fn, nodeObject } from '../tsl/TSLBase.js';
+import { float, vec3, If, Fn } from '../tsl/TSLBase.js';
 import { reference } from '../accessors/ReferenceNode.js';
 import { cubeTexture } from '../accessors/CubeTextureNode.js';
 import { renderGroup } from '../core/UniformGroupNode.js';

--- a/src/nodes/lighting/ShadowNode.js
+++ b/src/nodes/lighting/ShadowNode.js
@@ -1,5 +1,5 @@
 import ShadowBaseNode, { shadowPositionWorld } from './ShadowBaseNode.js';
-import { float, vec2, vec3, int, Fn, nodeObject } from '../tsl/TSLBase.js';
+import { float, vec2, vec3, int, Fn } from '../tsl/TSLBase.js';
 import { reference } from '../accessors/ReferenceNode.js';
 import { texture, textureLoad } from '../accessors/TextureNode.js';
 import { cubeTexture } from '../accessors/CubeTextureNode.js';

--- a/src/nodes/lighting/ShadowNode.js
+++ b/src/nodes/lighting/ShadowNode.js
@@ -842,4 +842,4 @@ export default ShadowNode;
  * @param {?LightShadow} [shadow] - The light shadow.
  * @return {ShadowNode} The created shadow node.
  */
-export const shadow = ( light, shadow ) => nodeObject( new ShadowNode( light, shadow ) );
+export const shadow = ( light, shadow ) => new ShadowNode( light, shadow );

--- a/src/nodes/tsl/TSLCore.js
+++ b/src/nodes/tsl/TSLCore.js
@@ -441,7 +441,7 @@ const ShaderNodeProxy = function ( NodeClass, scope = null, factor = null, setti
 
 const ShaderNodeImmutable = function ( NodeClass, ...params ) {
 
-	return nodeObject( new NodeClass( ...nodeArray( params ) ) );
+	return new NodeClass( ...nodeArray( params ) );
 
 };
 
@@ -873,7 +873,7 @@ const ConvertType = function ( type, cacheMap = null ) {
 
 				error( `TSL: Invalid parameter for the type "${ type }".` );
 
-				return nodeObject( new ConstNode( 0, type ) );
+				return new ConstNode( 0, type );
 
 			}
 
@@ -1171,8 +1171,8 @@ export const mat2 = new ConvertType( 'mat2' );
 export const mat3 = new ConvertType( 'mat3' );
 export const mat4 = new ConvertType( 'mat4' );
 
-export const string = ( value = '' ) => nodeObject( new ConstNode( value, 'string' ) );
-export const arrayBuffer = ( value ) => nodeObject( new ConstNode( value, 'ArrayBuffer' ) );
+export const string = ( value = '' ) => new ConstNode( value, 'string' );
+export const arrayBuffer = ( value ) => new ConstNode( value, 'ArrayBuffer' );
 
 addMethodChaining( 'toColor', color );
 addMethodChaining( 'toFloat', float );

--- a/src/nodes/utils/EventNode.js
+++ b/src/nodes/utils/EventNode.js
@@ -76,7 +76,7 @@ export default EventNode;
  * @param {Function} callback - The callback function.
  * @returns {EventNode}
  */
-const createEvent = ( type, callback ) => nodeObject( new EventNode( type, callback ) ).toStack();
+const createEvent = ( type, callback ) => new EventNode( type, callback ).toStack();
 
 /**
  * Creates an event that triggers a function every time an object (Mesh|Sprite) is rendered.

--- a/src/nodes/utils/EventNode.js
+++ b/src/nodes/utils/EventNode.js
@@ -1,6 +1,5 @@
 import Node from '../core/Node.js';
 import { NodeUpdateType } from '../core/constants.js';
-import { nodeObject } from '../tsl/TSLCore.js';
 
 /**
  * EventNode is a node that executes a callback during specific update phases.

--- a/src/nodes/utils/ReflectorNode.js
+++ b/src/nodes/utils/ReflectorNode.js
@@ -625,6 +625,6 @@ class ReflectorBaseNode extends Node {
  * @param {ReflectorBaseNode} [parameters.reflector] - The reflector base node.
  * @returns {ReflectorNode}
  */
-export const reflector = ( parameters ) => nodeObject( new ReflectorNode( parameters ) );
+export const reflector = ( parameters ) => new ReflectorNode( parameters );
 
 export default ReflectorNode;

--- a/src/nodes/utils/SampleNode.js
+++ b/src/nodes/utils/SampleNode.js
@@ -88,4 +88,4 @@ export default SampleNode;
  * @param {?Node<vec2>} [uv=null] - The UV node to be used in the texture sampling.
  * @returns {SampleNode} The created SampleNode instance wrapped as a node object.
  */
-export const sample = ( callback, uv = null ) => nodeObject( new SampleNode( callback, nodeObject( uv ) ) );
+export const sample = ( callback, uv = null ) => new SampleNode( callback, nodeObject( uv ) );


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/31691

**Description**

Remove `nodeObject` for Node classes, after implementing the prototype, using a proxy is no longer necessary.