### PR TITLE
some optimizations for postprocessing in webxr

### DIFF
--- a/examples/jsm/postprocessing/UnrealBloomPass.js
+++ b/examples/jsm/postprocessing/UnrealBloomPass.js
@@ -42,9 +42,8 @@ class UnrealBloomPass extends Pass {
 	 * @param {number} [strength=1] - The Bloom strength.
 	 * @param {number} radius - The Bloom radius.
 	 * @param {number} threshold - The luminance threshold limits which bright areas contribute to the Bloom effect.
-	 * @param {boolean} antiAlias - If the effect should use anti-aliasing.
 	 */
-	constructor( resolution, strength = 1, radius, threshold, antialias ) {
+	constructor( resolution, strength = 1, radius, threshold ) {
 
 		super();
 
@@ -102,7 +101,7 @@ class UnrealBloomPass extends Pass {
 		this.nMips = 5;
 		let resx = Math.round( this.resolution.x / 2 );
 		let resy = Math.round( this.resolution.y / 2 );
-		const renderTargetOptions = { type: HalfFloatType, samples: antialias ? 4 : 1, resolveDepthBuffer: false };
+		const renderTargetOptions = { type: HalfFloatType, resolveDepthBuffer: false };
 
 		this.renderTargetBright = new WebGLRenderTarget( resx, resy, renderTargetOptions );
 		this.renderTargetBright.texture.name = 'UnrealBloomPass.bright';
@@ -282,6 +281,20 @@ class UnrealBloomPass extends Pass {
 	 * @param {boolean} maskActive - Whether masking is active or not.
 	 */
 	render( renderer, writeBuffer, readBuffer, deltaTime, maskActive ) {
+
+		if ( this._currentSamples !== readBuffer.samples ) {
+
+			this._currentSamples = readBuffer.samples;
+
+			this.renderTargetBright.setSamples( readBuffer.samples );
+			for ( let i = 0; i < this.nMips; i ++ ) {
+
+				this.renderTargetsHorizontal[ i ].setSamples( readBuffer.samples );
+				this.renderTargetsVertical[ i ].setSamples( readBuffer.samples );
+
+			}
+
+		}
 
 		renderer.getClearColor( this._oldClearColor );
 		this._oldClearAlpha = renderer.getClearAlpha();

--- a/examples/jsm/postprocessing/UnrealBloomPass.js
+++ b/examples/jsm/postprocessing/UnrealBloomPass.js
@@ -282,20 +282,6 @@ class UnrealBloomPass extends Pass {
 	 */
 	render( renderer, writeBuffer, readBuffer, deltaTime, maskActive ) {
 
-		if ( this._currentSamples !== readBuffer.samples ) {
-
-			this._currentSamples = readBuffer.samples;
-
-			this.renderTargetBright.setSamples( readBuffer.samples );
-			for ( let i = 0; i < this.nMips; i ++ ) {
-
-				this.renderTargetsHorizontal[ i ].setSamples( readBuffer.samples );
-				this.renderTargetsVertical[ i ].setSamples( readBuffer.samples );
-
-			}
-
-		}
-
 		renderer.getClearColor( this._oldClearColor );
 		this._oldClearAlpha = renderer.getClearAlpha();
 		const oldAutoClear = renderer.autoClear;

--- a/examples/jsm/postprocessing/UnrealBloomPass.js
+++ b/examples/jsm/postprocessing/UnrealBloomPass.js
@@ -42,8 +42,9 @@ class UnrealBloomPass extends Pass {
 	 * @param {number} [strength=1] - The Bloom strength.
 	 * @param {number} radius - The Bloom radius.
 	 * @param {number} threshold - The luminance threshold limits which bright areas contribute to the Bloom effect.
+	 * @param {boolean} antiAlias - If the effect should use anti-aliasing.
 	 */
-	constructor( resolution, strength = 1, radius, threshold ) {
+	constructor( resolution, strength = 1, radius, threshold, antialias ) {
 
 		super();
 
@@ -101,21 +102,22 @@ class UnrealBloomPass extends Pass {
 		this.nMips = 5;
 		let resx = Math.round( this.resolution.x / 2 );
 		let resy = Math.round( this.resolution.y / 2 );
+		const renderTargetOptions = { type: HalfFloatType, samples: antialias ? 4 : 1, resolveDepthBuffer: false };
 
-		this.renderTargetBright = new WebGLRenderTarget( resx, resy, { type: HalfFloatType } );
+		this.renderTargetBright = new WebGLRenderTarget( resx, resy, renderTargetOptions );
 		this.renderTargetBright.texture.name = 'UnrealBloomPass.bright';
 		this.renderTargetBright.texture.generateMipmaps = false;
 
 		for ( let i = 0; i < this.nMips; i ++ ) {
 
-			const renderTargetHorizontal = new WebGLRenderTarget( resx, resy, { type: HalfFloatType } );
+			const renderTargetHorizontal = new WebGLRenderTarget( resx, resy, renderTargetOptions );
 
 			renderTargetHorizontal.texture.name = 'UnrealBloomPass.h' + i;
 			renderTargetHorizontal.texture.generateMipmaps = false;
 
 			this.renderTargetsHorizontal.push( renderTargetHorizontal );
 
-			const renderTargetVertical = new WebGLRenderTarget( resx, resy, { type: HalfFloatType } );
+			const renderTargetVertical = new WebGLRenderTarget( resx, resy, renderTargetOptions );
 
 			renderTargetVertical.texture.name = 'UnrealBloomPass.v' + i;
 			renderTargetVertical.texture.generateMipmaps = false;

--- a/examples/webxr_xr_controls_transform.html
+++ b/examples/webxr_xr_controls_transform.html
@@ -126,7 +126,7 @@
 				container.appendChild( renderer.domElement );
 
 				// post-processing
-				bloomPass = new UnrealBloomPass( new THREE.Vector2( window.innerWidth, window.innerHeight ), 1.5, 0.4, 0.85, renderer.getContextAttributes().antialias );
+				bloomPass = new UnrealBloomPass( new THREE.Vector2( window.innerWidth, window.innerHeight ), 1.5, 0.4, 0.85 );
 				renderer.setEffects( [ bloomPass ] );
 
 				document.body.appendChild( XRButton.createButton( renderer ) );

--- a/examples/webxr_xr_controls_transform.html
+++ b/examples/webxr_xr_controls_transform.html
@@ -126,8 +126,7 @@
 				container.appendChild( renderer.domElement );
 
 				// post-processing
-
-				bloomPass = new UnrealBloomPass( new THREE.Vector2( window.innerWidth, window.innerHeight ), 1.5, 0.4, 0.85 );
+				bloomPass = new UnrealBloomPass( new THREE.Vector2( window.innerWidth, window.innerHeight ), 1.5, 0.4, 0.85, renderer.getContextAttributes().antialias );
 				renderer.setEffects( [ bloomPass ] );
 
 				document.body.appendChild( XRButton.createButton( renderer ) );

--- a/src/core/RenderTarget.js
+++ b/src/core/RenderTarget.js
@@ -327,18 +327,6 @@ class RenderTarget extends EventDispatcher {
 
 	}
 
-	setSamples( samples ) {
-
-		if (this.samples !== samples) {
-
-			this.samples = samples;
-
-			this.dispose();
-
-		}
-
-	}
-
 	/**
 	 * Returns a new render target with copied values from this instance.
 	 *

--- a/src/core/RenderTarget.js
+++ b/src/core/RenderTarget.js
@@ -327,6 +327,18 @@ class RenderTarget extends EventDispatcher {
 
 	}
 
+	setSamples( samples ) {
+
+		if (this.samples !== samples) {
+
+			this.samples = samples;
+
+			this.dispose();
+
+		}
+
+	}
+
 	/**
 	 * Returns a new render target with copied values from this instance.
 	 *

--- a/src/renderers/webgl/WebGLOutput.js
+++ b/src/renderers/webgl/WebGLOutput.js
@@ -43,7 +43,9 @@ function WebGLOutput( type, width, height, antialias, depth, stencil ) {
 	const targetB = new WebGLRenderTarget( width, height, {
 		type: HalfFloatType,
 		depthBuffer: false,
-		stencilBuffer: false
+		stencilBuffer: false,
+		samples: antialias ? 4 : 0,
+		resolveDepthBuffer: false
 	} );
 
 	// create fullscreen triangle geometry


### PR DESCRIPTION
@mrdoob the postprocessing step wasn't using anti-aliasing. I fixed this by passing this antialias attribute to the rendertargets.
The rendertargets were resolving depth which wasn't used. I turned that off.

I see that the code is rendering to a lot of rendertargets. Is that expected?
In order I see:
```
Surface 0    | 3360x1760 | color 32bit, depth 24bit, stencil 0 bit, MSAA 4 -> clear from browser code
Surface 1    | 4096x4096 | color 32bit, depth 24bit, stencil 0 bit, MSAA 1 -> 4k x 4k shadowmap?
Surface 2    | 3360x1760 | color 64bit, depth 24bit, stencil 0 bit, MSAA 4
Surface 3    | 1680x880  | color 64bit, depth 24bit, stencil 0 bit, MSAA 4
Surface 4    | 1680x880  | color 64bit, depth 24bit, stencil 0 bit, MSAA 4
Surface 5    | 1680x880  | color 64bit, depth 24bit, stencil 0 bit, MSAA 4
Surface 6    | 840 x440  | color 64bit, depth 24bit, stencil 0 bit, MSAA 4
Surface 7    | 840 x440  | color 64bit, depth 24bit, stencil 0 bit, MSAA 4
Surface 8    | 420 x220  | color 64bit, depth 24bit, stencil 0 bit, MSAA 4
Surface 9    | 420 x220  | color 64bit, depth 24bit, stencil 0 bit, MSAA 4
Surface 10   | 210 x110  | color 64bit, depth 24bit, stencil 0 bit, MSAA 4
Surface 11   | 210 x110  | color 64bit, depth 24bit, stencil 0 bit, MSAA 4
Surface 12   | 105 x55   | color 64bit, depth 24bit, stencil 0 bit, MSAA 4
Surface 13   | 105 x55   | color 64bit, depth 24bit, stencil 0 bit, MSAA 4
Surface 14   | 1680x880  | color 64bit, depth 24bit, stencil 0 bit, MSAA 4 
Surface 15   | 3360x1760 | color 64bit, depth 24bit, stencil 0 bit, MSAA 4 -> uses expensive loadcolor
Surface 16   | 3360x1760 | color 32bit, depth 24bit, stencil 0 bit, MSAA 4 -> final blit to destination
```

Are all these passes needed or can we combine some? Each pass will flush color data to the main memory.
Surface 15 also loads it from main memory. Is that needed or is it the same as surface 2? (If you don't know, I can debug it)

*This contribution is funded by [Meta](https://meta.com)*
