### PR TITLE
WebGPURenderer: Prevent translation of skybox.

### DIFF
--- a/src/renderers/common/Background.js
+++ b/src/renderers/common/Background.js
@@ -107,8 +107,7 @@ class Background extends DataMap {
 				// compute vertex position
 				const modifiedPosition = isOrtho.select( positionLocal.mul( orthoScale ), positionLocal );
 
-				// By using a w component of 0, the skybox will rotate and scale with the camera's orientation
-				// but it will translate when the camera moves through the scene
+				// By using a w component of 0, the skybox will not translate when the camera moves through the scene
 				let viewProj = cameraProjectionMatrix.mul( modelViewMatrix.mul( vec4( modifiedPosition, 0.0 ) ) );
 
 				// force background to far plane so it does not occlude objects

--- a/src/renderers/common/Background.js
+++ b/src/renderers/common/Background.js
@@ -106,7 +106,10 @@ class Background extends DataMap {
 
 				// compute vertex position
 				const modifiedPosition = isOrtho.select( positionLocal.mul( orthoScale ), positionLocal );
-				let viewProj = cameraProjectionMatrix.mul( modelViewMatrix.mul( vec4( modifiedPosition, 1.0 ) ) );
+
+				// By using a w component of 0, the skybox will rotate and scale with the camera's orientation
+				// but it will translate when the camera moves through the scene
+				let viewProj = cameraProjectionMatrix.mul( modelViewMatrix.mul( vec4( modifiedPosition, 0.0 ) ) );
 
 				// force background to far plane so it does not occlude objects
 				viewProj = viewProj.setZ( viewProj.w );
@@ -126,12 +129,6 @@ class Background extends DataMap {
 				sceneData.backgroundMesh = backgroundMesh = new Mesh( new SphereGeometry( 1, 32, 32 ), nodeMaterial );
 				backgroundMesh.frustumCulled = false;
 				backgroundMesh.name = 'Background.mesh';
-
-				backgroundMesh.onBeforeRender = function ( renderer, scene, camera ) {
-
-					this.matrixWorld.copyPosition( camera.matrixWorld );
-
-				};
 
 				function onBackgroundDispose() {
 


### PR DESCRIPTION
Fixed #32418.

**Description**

#32418 shows that the scene's background skybox currently moves with the camera which isn't correct. That can be fixed by changing how the vertices of the skybox are computed. I've added a comment with the implementation details (it's just a minor change).
