### PR TITLE
Revert "WebGPURenderer: Prevent translation of skybox."

### DIFF
--- a/src/renderers/common/Background.js
+++ b/src/renderers/common/Background.js
@@ -106,9 +106,7 @@ class Background extends DataMap {
 
 				// compute vertex position
 				const modifiedPosition = isOrtho.select( positionLocal.mul( orthoScale ), positionLocal );
-
-				// By using a w component of 0, the skybox will not translate when the camera moves through the scene
-				let viewProj = cameraProjectionMatrix.mul( modelViewMatrix.mul( vec4( modifiedPosition, 0.0 ) ) );
+				let viewProj = cameraProjectionMatrix.mul( modelViewMatrix.mul( vec4( modifiedPosition, 1.0 ) ) );
 
 				// force background to far plane so it does not occlude objects
 				viewProj = viewProj.setZ( viewProj.w );
@@ -128,6 +126,12 @@ class Background extends DataMap {
 				sceneData.backgroundMesh = backgroundMesh = new Mesh( new SphereGeometry( 1, 32, 32 ), nodeMaterial );
 				backgroundMesh.frustumCulled = false;
 				backgroundMesh.name = 'Background.mesh';
+
+				backgroundMesh.onBeforeRender = function ( renderer, scene, camera ) {
+
+					this.matrixWorld.copyPosition( camera.matrixWorld );
+
+				};
 
 				function onBackgroundDispose() {
 


### PR DESCRIPTION
Reverts mrdoob/three.js#32526

Unfortunately, this change breaks the background with orthographic cameras, see https://discourse.threejs.org/t/issue-with-webgpu-orthographic-camera-scene-background-texture/88190/5.