### PR TITLE
WebGPURenderer: Prevent undefined GPUShaderStage.

### DIFF
--- a/src/renderers/webgpu/utils/WebGPUConstants.js
+++ b/src/renderers/webgpu/utils/WebGPUConstants.js
@@ -6,7 +6,7 @@ export const GPUPrimitiveTopology = {
 	TriangleStrip: 'triangle-strip',
 };
 
-export const GPUShaderStage = ( typeof self !== 'undefined' ) ? self.GPUShaderStage : { VERTEX: 1, FRAGMENT: 2, COMPUTE: 4 };
+export const GPUShaderStage = ( typeof self !== 'undefined' && self.GPUShaderStage ) ? self.GPUShaderStage : { VERTEX: 1, FRAGMENT: 2, COMPUTE: 4 };
 
 export const GPUCompareFunction = {
 	Never: 'never',


### PR DESCRIPTION
Fixed #32529

**Description**

Guards against an `undefined` `GPUShaderStage` that crashes Bun in r182.
