### PR TITLE
Renderers: Set premultipliedAlpha to true when using MultiplyBlending or SubtractiveBlending.

### DIFF
--- a/examples/misc_exporter_usdz.html
+++ b/examples/misc_exporter_usdz.html
@@ -145,7 +145,7 @@
 
 				const geometry = new THREE.PlaneGeometry();
 				const material = new THREE.MeshBasicMaterial( {
-					map: shadowTexture, blending: THREE.MultiplyBlending, toneMapped: false, premultipliedAlpha: true
+					map: shadowTexture, blending: THREE.MultiplyBlending, toneMapped: false
 				} );
 
 				const mesh = new THREE.Mesh( geometry, material );

--- a/examples/webgl_materials_blending.html
+++ b/examples/webgl_materials_blending.html
@@ -101,6 +101,7 @@
 						const material = new THREE.MeshBasicMaterial( { map: map } );
 						material.transparent = true;
 						material.blending = blending.constant;
+						material.premultipliedAlpha = true;
 
 						const x = ( i - blendings.length / 2 ) * 110;
 						const z = 0;

--- a/examples/webgl_materials_blending.html
+++ b/examples/webgl_materials_blending.html
@@ -102,8 +102,6 @@
 						material.transparent = true;
 						material.blending = blending.constant;
 
-						material.premultipliedAlpha = true;
-
 						const x = ( i - blendings.length / 2 ) * 110;
 						const z = 0;
 

--- a/examples/webgl_materials_car.html
+++ b/examples/webgl_materials_car.html
@@ -171,7 +171,7 @@
 					const mesh = new THREE.Mesh(
 						new THREE.PlaneGeometry( 0.655 * 4, 1.3 * 4 ),
 						new THREE.MeshBasicMaterial( {
-							map: shadow, blending: THREE.MultiplyBlending, toneMapped: false, transparent: true, premultipliedAlpha: true
+							map: shadow, blending: THREE.MultiplyBlending, toneMapped: false, transparent: true
 						} )
 					);
 					mesh.rotation.x = - Math.PI / 2;

--- a/examples/webgl_materials_envmaps_groundprojected.html
+++ b/examples/webgl_materials_envmaps_groundprojected.html
@@ -112,7 +112,7 @@
 					const mesh = new THREE.Mesh(
 						new THREE.PlaneGeometry( 0.655 * 4, 1.3 * 4 ),
 						new THREE.MeshBasicMaterial( {
-							map: shadow, blending: THREE.MultiplyBlending, toneMapped: false, transparent: true, premultipliedAlpha: true
+							map: shadow, blending: THREE.MultiplyBlending, toneMapped: false, transparent: true
 						} )
 					);
 					mesh.rotation.x = - Math.PI / 2;

--- a/src/renderers/webgl-fallback/utils/WebGLState.js
+++ b/src/renderers/webgl-fallback/utils/WebGLState.js
@@ -377,11 +377,11 @@ class WebGLState {
 							break;
 
 						case SubtractiveBlending:
-							error( 'WebGLState: SubtractiveBlending requires material.premultipliedAlpha = true' );
+							gl.blendFuncSeparate( gl.ZERO, gl.ONE_MINUS_SRC_COLOR, gl.ZERO, gl.ONE );
 							break;
 
 						case MultiplyBlending:
-							error( 'WebGLState: MultiplyBlending requires material.premultipliedAlpha = true' );
+							gl.blendFuncSeparate( gl.DST_COLOR, gl.ONE_MINUS_SRC_ALPHA, gl.ZERO, gl.ONE );
 							break;
 
 						default:

--- a/src/renderers/webgl-fallback/utils/WebGLState.js
+++ b/src/renderers/webgl-fallback/utils/WebGLState.js
@@ -7,7 +7,7 @@ import {
 	NeverDepth, AlwaysDepth, LessDepth, LessEqualDepth, EqualDepth, GreaterEqualDepth, GreaterDepth, NotEqualDepth
 } from '../../../constants.js';
 import { Vector4 } from '../../../math/Vector4.js';
-import { error } from '../../../utils.js';
+import { error, warnOnce } from '../../../utils.js';
 
 let equationToGL, factorToGL;
 
@@ -377,10 +377,12 @@ class WebGLState {
 							break;
 
 						case SubtractiveBlending:
+							warnOnce( 'WebGLState: SubtractiveBlending works best with material.premultipliedAlpha = true.' );
 							gl.blendFuncSeparate( gl.ZERO, gl.ONE_MINUS_SRC_COLOR, gl.ZERO, gl.ONE );
 							break;
 
 						case MultiplyBlending:
+							warnOnce( 'WebGLState: MultiplyBlending works best with material.premultipliedAlpha = true.' );
 							gl.blendFuncSeparate( gl.DST_COLOR, gl.ONE_MINUS_SRC_ALPHA, gl.ZERO, gl.ONE );
 							break;
 

--- a/src/renderers/webgl-fallback/utils/WebGLState.js
+++ b/src/renderers/webgl-fallback/utils/WebGLState.js
@@ -376,16 +376,6 @@ class WebGLState {
 							gl.blendFuncSeparate( gl.SRC_ALPHA, gl.ONE, gl.ONE, gl.ONE );
 							break;
 
-						case SubtractiveBlending:
-							warnOnce( 'WebGLState: SubtractiveBlending works best with material.premultipliedAlpha = true.' );
-							gl.blendFuncSeparate( gl.ZERO, gl.ONE_MINUS_SRC_COLOR, gl.ZERO, gl.ONE );
-							break;
-
-						case MultiplyBlending:
-							warnOnce( 'WebGLState: MultiplyBlending works best with material.premultipliedAlpha = true.' );
-							gl.blendFuncSeparate( gl.DST_COLOR, gl.ONE_MINUS_SRC_ALPHA, gl.ZERO, gl.ONE );
-							break;
-
 						default:
 							error( 'WebGLState: Invalid blending: ', blending );
 							break;
@@ -750,6 +740,17 @@ class WebGLState {
 		if ( frontFaceCW ) flipSided = ! flipSided;
 
 		this.setFlipSided( flipSided );
+
+		if ( material.premultipliedAlpha === false ) {
+
+			if ( material.blending === MultiplyBlending || material.blending === SubtractiveBlending ) {
+
+				warnOnce( 'WebGLState: Material premultipliedAlpha was set to true because MultiplyBlending and SubtractiveBlending require it.' );
+				material.premultipliedAlpha = true;
+
+			}
+
+		}
 
 		( material.blending === NormalBlending && material.transparent === false )
 			? this.setBlending( NoBlending )

--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -1,7 +1,7 @@
 import { NotEqualDepth, GreaterDepth, GreaterEqualDepth, EqualDepth, LessEqualDepth, LessDepth, AlwaysDepth, NeverDepth, CullFaceFront, CullFaceBack, CullFaceNone, DoubleSide, BackSide, CustomBlending, MultiplyBlending, SubtractiveBlending, AdditiveBlending, NoBlending, NormalBlending, AddEquation, SubtractEquation, ReverseSubtractEquation, MinEquation, MaxEquation, ZeroFactor, OneFactor, SrcColorFactor, SrcAlphaFactor, SrcAlphaSaturateFactor, DstColorFactor, DstAlphaFactor, OneMinusSrcColorFactor, OneMinusSrcAlphaFactor, OneMinusDstColorFactor, OneMinusDstAlphaFactor, ConstantColorFactor, OneMinusConstantColorFactor, ConstantAlphaFactor, OneMinusConstantAlphaFactor } from '../../constants.js';
 import { Color } from '../../math/Color.js';
 import { Vector4 } from '../../math/Vector4.js';
-import { error } from '../../utils.js';
+import { error, warnOnce } from '../../utils.js';
 
 const reversedFuncs = {
 	[ NeverDepth ]: AlwaysDepth,
@@ -690,10 +690,12 @@ function WebGLState( gl, extensions ) {
 							break;
 
 						case SubtractiveBlending:
+							warnOnce( 'WebGLState: SubtractiveBlending works best with material.premultipliedAlpha = true.' );
 							gl.blendFuncSeparate( gl.ZERO, gl.ONE_MINUS_SRC_COLOR, gl.ZERO, gl.ONE );
 							break;
 
 						case MultiplyBlending:
+							warnOnce( 'WebGLState: MultiplyBlending works best with material.premultipliedAlpha = true.' );
 							gl.blendFuncSeparate( gl.DST_COLOR, gl.ONE_MINUS_SRC_ALPHA, gl.ZERO, gl.ONE );
 							break;
 

--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -690,11 +690,11 @@ function WebGLState( gl, extensions ) {
 							break;
 
 						case SubtractiveBlending:
-							error( 'WebGLState: SubtractiveBlending requires material.premultipliedAlpha = true' );
+							gl.blendFuncSeparate( gl.ZERO, gl.ONE_MINUS_SRC_COLOR, gl.ZERO, gl.ONE );
 							break;
 
 						case MultiplyBlending:
-							error( 'WebGLState: MultiplyBlending requires material.premultipliedAlpha = true' );
+							gl.blendFuncSeparate( gl.DST_COLOR, gl.ONE_MINUS_SRC_ALPHA, gl.ZERO, gl.ONE );
 							break;
 
 						default:

--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -689,16 +689,6 @@ function WebGLState( gl, extensions ) {
 							gl.blendFuncSeparate( gl.SRC_ALPHA, gl.ONE, gl.ONE, gl.ONE );
 							break;
 
-						case SubtractiveBlending:
-							warnOnce( 'WebGLState: SubtractiveBlending works best with material.premultipliedAlpha = true.' );
-							gl.blendFuncSeparate( gl.ZERO, gl.ONE_MINUS_SRC_COLOR, gl.ZERO, gl.ONE );
-							break;
-
-						case MultiplyBlending:
-							warnOnce( 'WebGLState: MultiplyBlending works best with material.premultipliedAlpha = true.' );
-							gl.blendFuncSeparate( gl.DST_COLOR, gl.ONE_MINUS_SRC_ALPHA, gl.ZERO, gl.ONE );
-							break;
-
 						default:
 							error( 'WebGLState: Invalid blending: ', blending );
 							break;
@@ -773,6 +763,17 @@ function WebGLState( gl, extensions ) {
 		if ( frontFaceCW ) flipSided = ! flipSided;
 
 		setFlipSided( flipSided );
+
+		if ( material.premultipliedAlpha === false ) {
+
+			if ( material.blending === MultiplyBlending || material.blending === SubtractiveBlending ) {
+
+				warnOnce( 'WebGLState: Material premultipliedAlpha was set to true because MultiplyBlending and SubtractiveBlending require it.' );
+				material.premultipliedAlpha = true;
+
+			}
+
+		}
 
 		( material.blending === NormalBlending && material.transparent === false )
 			? setBlending( NoBlending )

--- a/src/renderers/webgpu/utils/WebGPUPipelineUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUPipelineUtils.js
@@ -120,6 +120,17 @@ class WebGPUPipelineUtils {
 
 		let blending;
 
+		if ( material.premultipliedAlpha === false ) {
+
+			if ( material.blending === MultiplyBlending || material.blending === SubtractiveBlending ) {
+
+				warnOnce( 'WebGPURenderer: Material premultipliedAlpha was set to true because MultiplyBlending and SubtractiveBlending require it.' );
+				material.premultipliedAlpha = true;
+
+			}
+
+		}
+
 		if ( material.blending !== NoBlending && ( material.blending !== NormalBlending || material.transparent !== false ) ) {
 
 			blending = this._getBlending( material );
@@ -445,16 +456,6 @@ class WebGPUPipelineUtils {
 
 					case AdditiveBlending:
 						setBlend( GPUBlendFactor.SrcAlpha, GPUBlendFactor.One, GPUBlendFactor.One, GPUBlendFactor.One );
-						break;
-
-					case SubtractiveBlending:
-						warnOnce( 'WebGPURenderer: SubtractiveBlending works best with material.premultipliedAlpha = true.' );
-						setBlend( GPUBlendFactor.Zero, GPUBlendFactor.OneMinusSrc, GPUBlendFactor.Zero, GPUBlendFactor.One );
-						break;
-
-					case MultiplyBlending:
-						warnOnce( 'WebGPURenderer: MultiplyBlending works best with material.premultipliedAlpha = true.' );
-						setBlend( GPUBlendFactor.Dst, GPUBlendFactor.OneMinusSrcAlpha, GPUBlendFactor.Zero, GPUBlendFactor.One );
 						break;
 
 				}

--- a/src/renderers/webgpu/utils/WebGPUPipelineUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUPipelineUtils.js
@@ -448,11 +448,11 @@ class WebGPUPipelineUtils {
 						break;
 
 					case SubtractiveBlending:
-						error( 'WebGPURenderer: SubtractiveBlending requires material.premultipliedAlpha = true' );
+						setBlend( GPUBlendFactor.Zero, GPUBlendFactor.OneMinusSrc, GPUBlendFactor.Zero, GPUBlendFactor.One );
 						break;
 
 					case MultiplyBlending:
-						error( 'WebGPURenderer: MultiplyBlending requires material.premultipliedAlpha = true' );
+						setBlend( GPUBlendFactor.Dst, GPUBlendFactor.OneMinusSrcAlpha, GPUBlendFactor.Zero, GPUBlendFactor.One );
 						break;
 
 				}

--- a/src/renderers/webgpu/utils/WebGPUPipelineUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUPipelineUtils.js
@@ -15,7 +15,7 @@ import {
 	NeverStencilFunc, AlwaysStencilFunc, LessStencilFunc, LessEqualStencilFunc, EqualStencilFunc, GreaterEqualStencilFunc, GreaterStencilFunc, NotEqualStencilFunc
 } from '../../../constants.js';
 
-import { error } from '../../../utils.js';
+import { error, warnOnce } from '../../../utils.js';
 
 /**
  * A WebGPU backend utility module for managing pipelines.
@@ -448,10 +448,12 @@ class WebGPUPipelineUtils {
 						break;
 
 					case SubtractiveBlending:
+						warnOnce( 'WebGPURenderer: SubtractiveBlending works best with material.premultipliedAlpha = true.' );
 						setBlend( GPUBlendFactor.Zero, GPUBlendFactor.OneMinusSrc, GPUBlendFactor.Zero, GPUBlendFactor.One );
 						break;
 
 					case MultiplyBlending:
+						warnOnce( 'WebGPURenderer: MultiplyBlending works best with material.premultipliedAlpha = true.' );
 						setBlend( GPUBlendFactor.Dst, GPUBlendFactor.OneMinusSrcAlpha, GPUBlendFactor.Zero, GPUBlendFactor.One );
 						break;
 


### PR DESCRIPTION
Related issue: #31246

**Description**

When `MultiplyBlending` or `SubtractiveBlending` is used without `premultipliedAlpha = true`, the renderer now:

1. Logs a warning: "Material premultipliedAlpha was set to true because MultiplyBlending and SubtractiveBlending require it."
2. Internally sets `premultipliedAlpha` to `true` so the scene renders correctly

This improves the developer experience by producing correct output while informing users about the requirement.