### PR TITLE
WebGPURenderer: Remove camera from render context key.

### DIFF
--- a/src/renderers/common/Pipelines.js
+++ b/src/renderers/common/Pipelines.js
@@ -344,7 +344,7 @@ class Pipelines extends DataMap {
 	 * @param {ProgrammableStage} stageFragment - The programmable stage representing the fragment shader.
 	 * @param {string} cacheKey - The cache key.
 	 * @param {?Array<Promise>} promises - An array of compilation promises which is only relevant in context of `Renderer.compileAsync()`.
-	 * @return {ComputePipeline} The compute pipeline.
+	 * @return {RenderPipeline} The render pipeline.
 	 */
 	_getRenderPipeline( renderObject, stageVertex, stageFragment, cacheKey, promises ) {
 

--- a/src/renderers/common/RenderContext.js
+++ b/src/renderers/common/RenderContext.js
@@ -215,6 +215,14 @@ class RenderContext {
 		this.clippingContext = null;
 
 		/**
+		 * The current camera.
+		 *
+		 * @type {?Camera}
+		 * @default null
+		 */
+		this.camera = null;
+
+		/**
 		 * This flag can be used for type testing.
 		 *
 		 * @type {boolean}

--- a/src/renderers/common/RenderContexts.js
+++ b/src/renderers/common/RenderContexts.js
@@ -1,11 +1,9 @@
 import ChainMap from './ChainMap.js';
 import RenderContext from './RenderContext.js';
 import { Scene } from '../../scenes/Scene.js';
-import { Camera } from '../../cameras/Camera.js';
 
 const _chainKeys = [];
 const _defaultScene = /*@__PURE__*/ new Scene();
-const _defaultCamera = /*@__PURE__*/ new Camera();
 
 /**
  * This module manages the render contexts of the renderer.
@@ -30,22 +28,20 @@ class RenderContexts {
 	}
 
 	/**
-	 * Returns a render context for the given scene, camera and render target.
+	 * Returns a render context for the given scene, render target and MRT config.
 	 *
 	 * @param {Scene} scene - The scene.
-	 * @param {Camera} camera - The camera that is used to render the scene.
 	 * @param {?RenderTarget} [renderTarget=null] - The active render target.
-	 * @param {?MRT} [mrt=null] - The active multiple render target.
+	 * @param {?MRTNode} [mrt=null] - The MRT configuration.
 	 * @return {RenderContext} The render context.
 	 */
-	get( scene, camera, renderTarget = null, mrt = null ) {
+	get( scene, renderTarget = null, mrt = null ) {
 
 		_chainKeys[ 0 ] = scene;
-		_chainKeys[ 1 ] = camera;
 
 		if ( mrt !== null ) {
 
-			_chainKeys[ 2 ] = mrt;
+			_chainKeys[ 1 ] = mrt;
 
 		}
 
@@ -92,7 +88,7 @@ class RenderContexts {
 	 */
 	getForClear( renderTarget = null ) {
 
-		return this.get( _defaultScene, _defaultCamera, renderTarget );
+		return this.get( _defaultScene, renderTarget );
 
 	}
 

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -695,7 +695,7 @@ class Renderer {
 				await this.compileAsync( scene, camera );
 
 				const renderList = this._renderLists.get( scene, camera );
-				const renderContext = this._renderContexts.get( scene, camera, this._renderTarget, this._mrt );
+				const renderContext = this._renderContexts.get( scene, this._renderTarget, this._mrt );
 
 				const material = scene.overrideMaterial || object.material;
 
@@ -856,7 +856,7 @@ class Renderer {
 		if ( targetScene === null ) targetScene = scene;
 
 		const renderTarget = this._renderTarget;
-		const renderContext = this._renderContexts.get( targetScene, camera, renderTarget, this._mrt );
+		const renderContext = this._renderContexts.get( targetScene, renderTarget, this._mrt );
 		const activeMipmapLevel = this._activeMipmapLevel;
 
 		const compilationPromises = [];
@@ -1384,7 +1384,7 @@ class Renderer {
 
 		//
 
-		const renderContext = this._renderContexts.get( scene, camera, renderTarget, this._mrt );
+		const renderContext = this._renderContexts.get( scene, renderTarget, this._mrt );
 
 		this._currentRenderContext = renderContext;
 		this._currentRenderObjectFunction = this._renderObjectFunction || this.renderObject;


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/32524#issuecomment-3645699315

**Description**

As suggested in https://github.com/mrdoob/three.js/issues/32524#issuecomment-3645699315, the camera is removed from the render context key which reduces the overall render context permutations and thus improves performance.
