### PR TITLE
ShadowMaterial: Respect "premultiplied alpha"

### DIFF
--- a/src/renderers/shaders/ShaderLib/shadow.glsl.js
+++ b/src/renderers/shaders/ShaderLib/shadow.glsl.js
@@ -52,6 +52,7 @@ void main() {
 	#include <tonemapping_fragment>
 	#include <colorspace_fragment>
 	#include <fog_fragment>
+	#include <premultiplied_alpha_fragment>
 
 }
 `;


### PR DESCRIPTION
Related issue: #32472

**Description**

Adjusts the "ShadowMaterial" shader to respect the premultiplied alpha flag. This was causing the "physics_ammo_instancing" to fail previously when setting "premultipliedAlpha" to true:

**Before**
<img width="529" height="478" alt="image" src="https://github.com/user-attachments/assets/003b2f87-4c35-45fa-9f0d-ddc3c524983d" />

**After**
<img width="612" height="508" alt="image" src="https://github.com/user-attachments/assets/c321fe3c-6f64-4533-971c-ffc008de40e9" />
 