### PR TITLE
GPUShaderStage: Simplified export to remove self reference

### DIFF
--- a/src/renderers/webgpu/utils/WebGPUConstants.js
+++ b/src/renderers/webgpu/utils/WebGPUConstants.js
@@ -6,7 +6,7 @@ export const GPUPrimitiveTopology = {
 	TriangleStrip: 'triangle-strip',
 };
 
-export const GPUShaderStage = ( typeof self !== 'undefined' ) ? self.GPUShaderStage : { VERTEX: 1, FRAGMENT: 2, COMPUTE: 4 };
+export const GPUShaderStage = { VERTEX: 1, FRAGMENT: 2, COMPUTE: 4 };
 
 export const GPUCompareFunction = {
 	Never: 'never',


### PR DESCRIPTION
This change removes the dependency on the global `self` object. This is intended to improve compatibility with environments where self is defined, and ensures GPUShaderStage always has the expected constant values `{ VERTEX: 1, FRAGMENT: 2, COMPUTE: 4 }`.

In other case we can get something like this:

<img width="382" height="84" alt="Screenshot 2025-12-15 at 15 53 13" src="https://github.com/user-attachments/assets/732d4e54-195d-49c5-beb2-4dafd5cb0b48" />
