### PR TITLE
UniformsGroup: Add range cache and fix clear old update ranges

### DIFF
--- a/src/renderers/common/Bindings.js
+++ b/src/renderers/common/Bindings.js
@@ -364,6 +364,12 @@ class Bindings extends DataMap {
 
 			}
 
+			if ( binding.isBuffer && binding.updateRanges.length > 0 ) {
+
+				binding.clearUpdateRanges();
+
+			}
+
 		}
 
 		if ( needsBindingsUpdate === true ) {

--- a/src/renderers/common/Uniform.js
+++ b/src/renderers/common/Uniform.js
@@ -68,7 +68,7 @@ class Uniform {
 		 * @type {number}
 		 */
 		this.index = - 1;
-		
+
 	}
 
 	/**

--- a/src/renderers/common/Uniform.js
+++ b/src/renderers/common/Uniform.js
@@ -61,6 +61,14 @@ class Uniform {
 		 */
 		this.offset = 0;
 
+		/**
+		 * This property is set by {@link UniformsGroup} and marks
+		 * the index position in the uniform array.
+		 *
+		 * @type {number}
+		 */
+		this.index = - 1;
+		
 	}
 
 	/**

--- a/src/renderers/common/UniformsGroup.js
+++ b/src/renderers/common/UniformsGroup.js
@@ -47,6 +47,45 @@ class UniformsGroup extends UniformBuffer {
 		 */
 		this.uniforms = [];
 
+		/**
+		 * A map to cache update ranges.
+		 *
+		 * @private
+		 * @type {Map<string, {offset: number, count: number}>}
+		 */
+		this._updateRangeCache = new Map();
+
+	}
+
+	/**
+	 * Adds an update range to this buffer.
+	 *
+	 * @param {number} offset - The offset in number of elements.
+	 * @param {number} count - The number of elements.
+	 */
+	addUpdateRange( offset, count ) {
+
+		const key = `${ offset }_${ count }`;
+
+		if ( this._updateRangeCache.has( key ) === false ) {
+
+			this._updateRangeCache.set( key, true );
+
+			super.addUpdateRange( offset, count );
+
+		}
+
+	}
+
+	/**
+	 * Clears all update ranges of this buffer.
+	 */
+	clearUpdateRanges() {
+
+		this._updateRangeCache.clear();
+
+		super.clearUpdateRanges();
+
 	}
 
 	/**

--- a/src/renderers/common/UniformsGroup.js
+++ b/src/renderers/common/UniformsGroup.js
@@ -48,30 +48,52 @@ class UniformsGroup extends UniformBuffer {
 		this.uniforms = [];
 
 		/**
-		 * A map to cache update ranges.
+		 * A cache for the uniform update ranges.
 		 *
 		 * @private
-		 * @type {Map<string, {offset: number, count: number}>}
+		 * @type {Map<number, {start: number, count: number}>}
 		 */
 		this._updateRangeCache = new Map();
 
 	}
 
 	/**
-	 * Adds an update range to this buffer.
+	 * Adds a uniform's update range to this buffer.
 	 *
-	 * @param {number} offset - The offset in number of elements.
-	 * @param {number} count - The number of elements.
+	 * @param {Uniform} uniform - The uniform.
 	 */
-	addUpdateRange( offset, count ) {
+	addUniformUpdateRange( uniform ) {
 
-		const key = `${ offset }_${ count }`;
+		const start = uniform.offset;
+		const count = uniform.itemSize;
+		const index = uniform.index;
 
-		if ( this._updateRangeCache.has( key ) === false ) {
+		if ( this._updateRangeCache.has( index ) !== true ) {
 
-			this._updateRangeCache.set( key, true );
+			const updateRanges = this.updateRanges;
+			const previousRange = this._updateRangeCache.get( index );
 
-			super.addUpdateRange( offset, count );
+			let range;
+
+			if ( previousRange !== undefined ) {
+
+				// Merge with previous range
+
+				range = previousRange;
+
+				previousRange.count = ( start - previousRange.start ) + count;
+
+			} else {
+
+				// Add new range
+
+				range = { start, count };
+
+				updateRanges.push( range );
+
+			}
+
+			this._updateRangeCache.set( index, range );
 
 		}
 
@@ -195,6 +217,7 @@ class UniformsGroup extends UniformBuffer {
 			}
 
 			uniform.offset = offset / bytesPerElement;
+			uniform.index = i;
 
 			offset += itemSize;
 
@@ -274,7 +297,7 @@ class UniformsGroup extends UniformBuffer {
 			b[ offset ] = a[ offset ] = v;
 			updated = true;
 
-			this.addUpdateRange( offset, 1 );
+			this.addUniformUpdateRange( uniform );
 
 		}
 
@@ -306,7 +329,7 @@ class UniformsGroup extends UniformBuffer {
 
 			updated = true;
 
-			this.addUpdateRange( offset, 2 );
+			this.addUniformUpdateRange( uniform );
 
 		}
 
@@ -339,7 +362,7 @@ class UniformsGroup extends UniformBuffer {
 
 			updated = true;
 
-			this.addUpdateRange( offset, 3 );
+			this.addUniformUpdateRange( uniform );
 
 		}
 
@@ -373,7 +396,7 @@ class UniformsGroup extends UniformBuffer {
 
 			updated = true;
 
-			this.addUpdateRange( offset, 4 );
+			this.addUniformUpdateRange( uniform );
 
 		}
 
@@ -405,7 +428,7 @@ class UniformsGroup extends UniformBuffer {
 
 			updated = true;
 
-			this.addUpdateRange( offset, 3 );
+			this.addUniformUpdateRange( uniform );
 
 		}
 
@@ -445,7 +468,7 @@ class UniformsGroup extends UniformBuffer {
 
 			updated = true;
 
-			this.addUpdateRange( offset, 12 );
+			this.addUniformUpdateRange( uniform );
 
 		}
 
@@ -474,7 +497,7 @@ class UniformsGroup extends UniformBuffer {
 			setArray( a, e, offset );
 			updated = true;
 
-			this.addUpdateRange( offset, 16 );
+			this.addUniformUpdateRange( uniform );
 
 		}
 

--- a/src/renderers/common/UniformsGroup.js
+++ b/src/renderers/common/UniformsGroup.js
@@ -64,34 +64,18 @@ class UniformsGroup extends UniformBuffer {
 	 */
 	addUniformUpdateRange( uniform ) {
 
-		const start = uniform.offset;
-		const count = uniform.itemSize;
 		const index = uniform.index;
 
 		if ( this._updateRangeCache.has( index ) !== true ) {
 
 			const updateRanges = this.updateRanges;
-			const previousRange = this._updateRangeCache.get( index );
 
-			let range;
+			const start = uniform.offset;
+			const count = uniform.itemSize;
 
-			if ( previousRange !== undefined ) {
+			const range = { start, count };
 
-				// Merge with previous range
-
-				range = previousRange;
-
-				previousRange.count = ( start - previousRange.start ) + count;
-
-			} else {
-
-				// Add new range
-
-				range = { start, count };
-
-				updateRanges.push( range );
-
-			}
+			updateRanges.push( range );
 
 			this._updateRangeCache.set( index, range );
 

--- a/src/renderers/webgpu/utils/WebGPUBindingUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUBindingUtils.js
@@ -224,8 +224,6 @@ class WebGPUBindingUtils {
 
 			}
 
-			binding.clearUpdateRanges();
-
 		}
 
 	}


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/32558

**Description**

I fixed some issues related to the previous PR.

We shouldn't have had such a noticeable performance impact before https://github.com/mrdoob/three.js/pull/32243; the intention is to improve the uniforms buffer management for larger and shared buffers.