### PR TITLE
RapierPhysics: Fix dynamic import Vite warning

### DIFF
--- a/examples/jsm/physics/RapierPhysics.js
+++ b/examples/jsm/physics/RapierPhysics.js
@@ -97,7 +97,7 @@ async function RapierPhysics() {
 
 	if ( RAPIER === null ) {
 
-		RAPIER = await import( `${RAPIER_PATH}` );
+		RAPIER = await import( RAPIER_PATH /* @vite-ignore */ );
 		await RAPIER.init();
 
 	}


### PR DESCRIPTION
Fixes: #32560

**Description**

Add @vite-ignore comment to suppress Vite's "dynamic import cannot be analyzed" warning. The import loads Rapier from a CDN at runtime, which
cannot be statically analyzed by design.