### PR TITLE
Update documentation for ImageBitmapLoader options

### DIFF
--- a/src/loaders/ImageBitmapLoader.js
+++ b/src/loaders/ImageBitmapLoader.js
@@ -13,7 +13,11 @@ const _errorMap = new WeakMap();
  * These options need to be configured via {@link ImageBitmapLoader#setOptions} prior to loading,
  * unlike regular images which can be configured on the Texture to set these options on GPU upload instead.
  *
- * In particular `imageOrientation: 'flipY'` will likely need to be set to match the default behaviour of {@link Texture#flipY}.
+ * To match the default behaviour of {@link Texture}, the following options are needed
+ *
+ * ```js
+ * { imageOrientation: 'flipY', premultiplyAlpha: 'none' }
+ * ```
  *
  * Also note that unlike {@link FileLoader}, this loader will only avoid multiple concurrent requests to the same URL if {@link Cache} is enabled.
  *

--- a/src/loaders/ImageBitmapLoader.js
+++ b/src/loaders/ImageBitmapLoader.js
@@ -13,6 +13,8 @@ const _errorMap = new WeakMap();
  * These options need to be configured via {@link ImageBitmapLoader#setOptions} prior to loading,
  * unlike regular images which can be configured on the Texture to set these options on GPU upload instead.
  *
+ * In particular `imageOrientation: 'flipY'` will likely need to be set to match the default behaviour of {@link Texture#flipY}.
+ *
  * Also note that unlike {@link FileLoader}, this loader will only avoid multiple concurrent requests to the same URL if {@link Cache} is enabled.
  *
  * ```js

--- a/src/loaders/ImageBitmapLoader.js
+++ b/src/loaders/ImageBitmapLoader.js
@@ -10,11 +10,10 @@ const _errorMap = new WeakMap();
  * textures for rendering.
  *
  * Note that {@link Texture#flipY} and {@link Texture#premultiplyAlpha} are ignored with image bitmaps.
- * They needs these configuration on bitmap creation unlike regular images need them on uploading to GPU.
+ * These options need to be configured via {@link ImageBitmapLoader#setOptions} prior to loading,
+ * unlike regular images which can be configured on the Texture to set these options on GPU upload instead.
  *
- * You need to set the equivalent options via {@link ImageBitmapLoader#setOptions} instead.
- *
- * Also note that unlike {@link FileLoader}, this loader avoids multiple concurrent requests to the same URL only if `Cache` is enabled.
+ * Also note that unlike {@link FileLoader}, this loader will only avoid multiple concurrent requests to the same URL if {@link Cache} is enabled.
  *
  * ```js
  * const loader = new THREE.ImageBitmapLoader();

--- a/src/loaders/ImageBitmapLoader.js
+++ b/src/loaders/ImageBitmapLoader.js
@@ -13,7 +13,7 @@ const _errorMap = new WeakMap();
  * These options need to be configured via {@link ImageBitmapLoader#setOptions} prior to loading,
  * unlike regular images which can be configured on the Texture to set these options on GPU upload instead.
  *
- * To match the default behaviour of {@link Texture}, the following options are needed
+ * To match the default behaviour of {@link Texture}, the following options are needed:
  *
  * ```js
  * { imageOrientation: 'flipY', premultiplyAlpha: 'none' }


### PR DESCRIPTION
Remove grammatical errors and clarified the configuration requirements for image bitmap options and their comparison to regular images.