### PR TITLE
Docs: Improved search results.

### DIFF
--- a/utils/docs/template/static/index.html
+++ b/utils/docs/template/static/index.html
@@ -344,6 +344,38 @@
 
 				}
 
+				// Sort results: exact matches first, then classes before members
+				const searchLower = v.toLowerCase();
+				results.sort( ( a, b ) => {
+
+					const aName = a.title.split( /[#~]/ ).pop().toLowerCase();
+					const bName = b.title.split( /[#~]/ ).pop().toLowerCase();
+					const aIsClass = ! a.title.includes( '#' ) && ! a.title.includes( '~' );
+					const bIsClass = ! b.title.includes( '#' ) && ! b.title.includes( '~' );
+
+					// Exact match on class name (highest priority)
+					const aExactClass = aIsClass && aName === searchLower;
+					const bExactClass = bIsClass && bName === searchLower;
+					if ( aExactClass !== bExactClass ) return aExactClass ? - 1 : 1;
+
+					// Class starts with search term
+					const aStartsClass = aIsClass && aName.startsWith( searchLower );
+					const bStartsClass = bIsClass && bName.startsWith( searchLower );
+					if ( aStartsClass !== bStartsClass ) return aStartsClass ? - 1 : 1;
+
+					// Exact match on member name
+					const aExact = aName === searchLower;
+					const bExact = bName === searchLower;
+					if ( aExact !== bExact ) return aExact ? - 1 : 1;
+
+					// Classes before members
+					if ( aIsClass !== bIsClass ) return aIsClass ? - 1 : 1;
+
+					// Alphabetically
+					return a.title.localeCompare( b.title );
+
+				} );
+
 				// Display results
 				if ( results.length > 0 ) {
 


### PR DESCRIPTION
**Description**

| Before | After |
| - | - |
| <img width="299" height="787" alt="Screenshot 2025-12-18 at 13 20 52" src="https://github.com/user-attachments/assets/9cf7722f-41a6-4c5f-9fff-7d1a1fd51808" /> | <img width="299" height="787" alt="Screenshot 2025-12-18 at 13 21 01" src="https://github.com/user-attachments/assets/8deb3e61-5b53-4dcc-b8c4-ff634bb95c30" /> |