### PR TITLE
Docs: Remove *.is* properties from search results.

### DIFF
--- a/utils/docs/template/publish.js
+++ b/utils/docs/template/publish.js
@@ -151,7 +151,28 @@ function buildSearchListForData() {
 		'TSL': []
 	};
 
+	// State flags that should appear in search (not type-checking properties)
+	const allowedIsProperties = new Set( [
+		'isPlaying',
+		'isDisposed',
+		'isPresenting'
+	] );
+
 	data().each( ( item ) => {
+
+		// Skip .is* type-checking properties (e.g., isCamera, isMesh)
+		// but keep state flags listed in allowedIsProperties
+		if ( item.name && item.kind === 'member' ) {
+
+			const name = item.name;
+
+			if ( name.startsWith( 'is' ) && ! allowedIsProperties.has( name ) ) {
+
+				return;
+
+			}
+
+		}
 
 		if ( item.kind !== 'package' && item.kind !== 'typedef' && ! item.inherited ) {
 


### PR DESCRIPTION
**Description**

| Before | After |
| - | - |
| <img width="299" height="787" alt="Screenshot 2025-12-18 at 13 34 19" src="https://github.com/user-attachments/assets/2600168e-545c-4ae5-a059-ec8fe5453805" /> | <img width="299" height="787" alt="Screenshot 2025-12-18 at 13 34 23" src="https://github.com/user-attachments/assets/624bb9a9-5b56-4207-b91b-2746cf352e27" /> |