### PR TITLE
Add support for mayas openPBRsurface shader when using the fbx-loader

### DIFF
--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -260,6 +260,7 @@ class FBXTreeParser {
 
 		const images = {};
 		const blobs = {};
+
 		if ( 'Video' in fbxTree.Objects ) {
 
 			const videoNodes = fbxTree.Objects.Video;
@@ -298,6 +299,7 @@ class FBXTreeParser {
 
 			if ( blobs[ filename ] !== undefined ) images[ id ] = blobs[ filename ];
 			else images[ id ] = images[ id ].replace(/^.*[\\/]|[?#].*$/g, ''); // Split on / or ?# as well as \
+
 		}
 
 		return images;

--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -600,7 +600,7 @@ class FBXTreeParser {
 		// the transparency handling is implemented based on Blender/Unity's approach: https://github.com/sobotka/blender-addons/blob/7d80f2f97161fc8e353a657b179b9aa1f8e5280b/io_scene_fbx/import_fbx.py#L1444-L1459
 
 		if(materialNode.TransparencyFactor){
-			parameters.opacity = 1 - ( materialNode.TransparencyFactor ? parseFloat( materialNode.TransparencyFactor.value ) : 0 );
+			parameters.opacity = 1 - (materialNode.TransparencyFactor.value ? parseFloat( materialNode.TransparencyFactor.value ) : 0);
 
 			if ( parameters.opacity === 1 || parameters.opacity === 0 ) {
 

--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -48,7 +48,6 @@ import {
 import * as fflate from '../libs/fflate.module.js';
 import { NURBSCurve } from '../curves/NURBSCurve.js';
 
-
 let fbxTree;
 let connections;
 let sceneGraph;
@@ -172,7 +171,7 @@ class FBXLoader extends Loader {
 
 		const textureLoader = new TextureLoader( this.manager ).setPath( this.resourcePath || path ).setCrossOrigin( this.crossOrigin );
 
-		return new FBXTreeParser( textureLoader, this.manager ).parse(); // Parse the fbxTree
+		return new FBXTreeParser( textureLoader, this.manager ).parse();
 
 	}
 

--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -169,6 +169,8 @@ class FBXLoader extends Loader {
 
 		}
 
+		// console.log( fbxTree );
+
 		const textureLoader = new TextureLoader( this.manager ).setPath( this.resourcePath || path ).setCrossOrigin( this.crossOrigin );
 
 		return new FBXTreeParser( textureLoader, this.manager ).parse();


### PR DESCRIPTION
The fbx loader did not recognize maya's openPBRsurface shader, instead it defaulted to the phong material.

Changed so it gets converted to MeshStandardMaterial instead.

Also when parsing the image url's, paths that included "/" instead of "\\" would not be parsed correctly. The parsing now use regex to account for that use case as well.

Found issue mentioning this: #15927
