### PR TITLE
Fix typo in label from 'minuscule' to 'miniscule'

### DIFF
--- a/examples/webgl_camera_logarithmicdepthbuffer.html
+++ b/examples/webgl_camera_logarithmicdepthbuffer.html
@@ -97,7 +97,7 @@
 
 			const labeldata = [
 				{ size: .01, scale: 0.0001, label: 'microscopic (1µm)' }, // FIXME - triangulating text fails at this size, so we scale instead
-				{ size: .01, scale: 0.1, label: 'minuscule (1mm)' },
+				{ size: .01, scale: 0.1, label: 'miniscule (1mm)' },
 				{ size: .01, scale: 1.0, label: 'tiny (1cm)' },
 				{ size: 1, scale: 1.0, label: 'child-sized (1m)' },
 				{ size: 10, scale: 1.0, label: 'tree-sized (10m)' },


### PR DESCRIPTION
Related issue: #XXXX

**Description**

A clear and concise description of what the problem was and how this pull request solves it.

<!-- Remove the line below if is not relevant -->

*This contribution is funded by [Example](https://example.com)*
