### PR TITLE
Fix WebXR XRProjectionLayer requiring 'layers' session feature

### DIFF
--- a/src/renderers/common/XRManager.js
+++ b/src/renderers/common/XRManager.js
@@ -1,34 +1,22 @@
-import { ArrayCamera } from "../../cameras/ArrayCamera.js";
-import { EventDispatcher } from "../../core/EventDispatcher.js";
-import { PerspectiveCamera } from "../../cameras/PerspectiveCamera.js";
-import { Quaternion } from "../../math/Quaternion.js";
-import { RAD2DEG } from "../../math/MathUtils.js";
-import { Vector2 } from "../../math/Vector2.js";
-import { Vector3 } from "../../math/Vector3.js";
-import { Vector4 } from "../../math/Vector4.js";
-import { WebXRController } from "../webxr/WebXRController.js";
-import {
-	AddEquation,
-	BackSide,
-	CustomBlending,
-	DepthFormat,
-	DepthStencilFormat,
-	FrontSide,
-	RGBAFormat,
-	UnsignedByteType,
-	UnsignedInt248Type,
-	UnsignedIntType,
-	ZeroFactor,
-} from "../../constants.js";
-import { DepthTexture } from "../../textures/DepthTexture.js";
-import { XRRenderTarget } from "./XRRenderTarget.js";
-import { CylinderGeometry } from "../../geometries/CylinderGeometry.js";
-import QuadMesh from "./QuadMesh.js";
-import NodeMaterial from "../../materials/nodes/NodeMaterial.js";
-import { PlaneGeometry } from "../../geometries/PlaneGeometry.js";
-import { MeshBasicMaterial } from "../../materials/MeshBasicMaterial.js";
-import { Mesh } from "../../objects/Mesh.js";
-import { warn } from "../../utils.js";
+import { ArrayCamera } from '../../cameras/ArrayCamera.js';
+import { EventDispatcher } from '../../core/EventDispatcher.js';
+import { PerspectiveCamera } from '../../cameras/PerspectiveCamera.js';
+import { Quaternion } from '../../math/Quaternion.js';
+import { RAD2DEG } from '../../math/MathUtils.js';
+import { Vector2 } from '../../math/Vector2.js';
+import { Vector3 } from '../../math/Vector3.js';
+import { Vector4 } from '../../math/Vector4.js';
+import { WebXRController } from '../webxr/WebXRController.js';
+import { AddEquation, BackSide, CustomBlending, DepthFormat, DepthStencilFormat, FrontSide, RGBAFormat, UnsignedByteType, UnsignedInt248Type, UnsignedIntType, ZeroFactor } from '../../constants.js';
+import { DepthTexture } from '../../textures/DepthTexture.js';
+import { XRRenderTarget } from './XRRenderTarget.js';
+import { CylinderGeometry } from '../../geometries/CylinderGeometry.js';
+import QuadMesh from './QuadMesh.js';
+import NodeMaterial from '../../materials/nodes/NodeMaterial.js';
+import { PlaneGeometry } from '../../geometries/PlaneGeometry.js';
+import { MeshBasicMaterial } from '../../materials/MeshBasicMaterial.js';
+import { Mesh } from '../../objects/Mesh.js';
+import { warn } from '../../utils.js';
 
 const _cameraLPos = /*@__PURE__*/ new Vector3();
 const _cameraRPos = /*@__PURE__*/ new Vector3();
@@ -42,13 +30,15 @@ const _cameraRPos = /*@__PURE__*/ new Vector3();
  * @augments EventDispatcher
  */
 class XRManager extends EventDispatcher {
+
 	/**
 	 * Constructs a new XR manager.
 	 *
 	 * @param {Renderer} renderer - The renderer.
 	 * @param {boolean} [multiview=false] - Enables multiview if the device supports it.
 	 */
-	constructor(renderer, multiview = false) {
+	constructor( renderer, multiview = false ) {
+
 		super();
 
 		/**
@@ -110,7 +100,7 @@ class XRManager extends EventDispatcher {
 		 * @private
 		 * @type {Array<Camera>}
 		 */
-		this._cameras = [this._cameraL, this._cameraR];
+		this._cameras = [ this._cameraL, this._cameraR ];
 
 		/**
 		 * The main XR camera.
@@ -190,7 +180,7 @@ class XRManager extends EventDispatcher {
 		 * @type {boolean}
 		 * @readonly
 		 */
-		this._supportsGlBinding = typeof XRWebGLBinding !== "undefined";
+		this._supportsGlBinding = typeof XRWebGLBinding !== 'undefined';
 
 		this._frameBufferTargets = null;
 
@@ -200,15 +190,15 @@ class XRManager extends EventDispatcher {
 		 * @private
 		 * @type {Function}
 		 */
-		this._createXRLayer = createXRLayer.bind(this);
+		this._createXRLayer = createXRLayer.bind( this );
 
 		/**
-		 * The current WebGL context.
-		 *
-		 * @private
-		 * @type {?WebGL2RenderingContext}
-		 * @default null
-		 */
+		* The current WebGL context.
+		*
+		* @private
+		* @type {?WebGL2RenderingContext}
+		* @default null
+		*/
 		this._gl = null;
 
 		/**
@@ -253,7 +243,7 @@ class XRManager extends EventDispatcher {
 		 * @private
 		 * @type {Function}
 		 */
-		this._onSessionEvent = onSessionEvent.bind(this);
+		this._onSessionEvent = onSessionEvent.bind( this );
 
 		/**
 		 * The event listener for handling the end of a XR session.
@@ -261,7 +251,7 @@ class XRManager extends EventDispatcher {
 		 * @private
 		 * @type {Function}
 		 */
-		this._onSessionEnd = onSessionEnd.bind(this);
+		this._onSessionEnd = onSessionEnd.bind( this );
 
 		/**
 		 * The event listener for handling the `inputsourceschange` event.
@@ -269,7 +259,7 @@ class XRManager extends EventDispatcher {
 		 * @private
 		 * @type {Function}
 		 */
-		this._onInputSourcesChange = onInputSourcesChange.bind(this);
+		this._onInputSourcesChange = onInputSourcesChange.bind( this );
 
 		/**
 		 * The animation loop which is used as a replacement for the default
@@ -279,7 +269,7 @@ class XRManager extends EventDispatcher {
 		 * @private
 		 * @type {Function}
 		 */
-		this._onAnimationFrame = onAnimationFrame.bind(this);
+		this._onAnimationFrame = onAnimationFrame.bind( this );
 
 		/**
 		 * The current XR reference space.
@@ -297,7 +287,7 @@ class XRManager extends EventDispatcher {
 		 * @type {XRReferenceSpaceType}
 		 * @default 'local-floor'
 		 */
-		this._referenceSpaceType = "local-floor";
+		this._referenceSpaceType = 'local-floor';
 
 		/**
 		 * A custom reference space defined by the application.
@@ -381,9 +371,7 @@ class XRManager extends EventDispatcher {
 		 * @type {boolean}
 		 * @readonly
 		 */
-		this._supportsLayers =
-			this._supportsGlBinding &&
-			"createProjectionLayer" in XRWebGLBinding.prototype; // eslint-disable-line compat/compat
+		this._supportsLayers = ( this._supportsGlBinding && 'createProjectionLayer' in XRWebGLBinding.prototype ); // eslint-disable-line compat/compat
 
 		/**
 		 * Whether the usage of multiview has been requested by the application or not.
@@ -404,6 +392,7 @@ class XRManager extends EventDispatcher {
 		 * @readonly
 		 */
 		this._useMultiview = false;
+
 	}
 
 	/**
@@ -414,10 +403,12 @@ class XRManager extends EventDispatcher {
 	 * @param {number} index - The index of the XR controller.
 	 * @return {Group} A group that represents the controller's transformation.
 	 */
-	getController(index) {
-		const controller = this._getController(index);
+	getController( index ) {
+
+		const controller = this._getController( index );
 
 		return controller.getTargetRaySpace();
+
 	}
 
 	/**
@@ -428,10 +419,12 @@ class XRManager extends EventDispatcher {
 	 * @param {number} index - The index of the XR controller.
 	 * @return {Group} A group that represents the controller's transformation.
 	 */
-	getControllerGrip(index) {
-		const controller = this._getController(index);
+	getControllerGrip( index ) {
+
+		const controller = this._getController( index );
 
 		return controller.getGripSpace();
+
 	}
 
 	/**
@@ -442,10 +435,12 @@ class XRManager extends EventDispatcher {
 	 * @param {number} index - The index of the XR controller.
 	 * @return {Group} A group that represents the controller's transformation.
 	 */
-	getHand(index) {
-		const controller = this._getController(index);
+	getHand( index ) {
+
+		const controller = this._getController( index );
 
 		return controller.getHandSpace();
+
 	}
 
 	/**
@@ -454,11 +449,15 @@ class XRManager extends EventDispatcher {
 	 * @return {number|undefined} The foveation value. Returns `undefined` if no base or projection layer is defined.
 	 */
 	getFoveation() {
-		if (this._glProjLayer === null && this._glBaseLayer === null) {
+
+		if ( this._glProjLayer === null && this._glBaseLayer === null ) {
+
 			return undefined;
+
 		}
 
 		return this._foveation;
+
 	}
 
 	/**
@@ -467,19 +466,22 @@ class XRManager extends EventDispatcher {
 	 * @param {number} foveation - A number in the range `[0,1]` where `0` means no foveation (full resolution)
 	 * and `1` means maximum foveation (the edges render at lower resolution).
 	 */
-	setFoveation(foveation) {
+	setFoveation( foveation ) {
+
 		this._foveation = foveation;
 
-		if (this._glProjLayer !== null) {
+		if ( this._glProjLayer !== null ) {
+
 			this._glProjLayer.fixedFoveation = foveation;
+
 		}
 
-		if (
-			this._glBaseLayer !== null &&
-			this._glBaseLayer.fixedFoveation !== undefined
-		) {
+		if ( this._glBaseLayer !== null && this._glBaseLayer.fixedFoveation !== undefined ) {
+
 			this._glBaseLayer.fixedFoveation = foveation;
+
 		}
+
 	}
 
 	/**
@@ -488,7 +490,9 @@ class XRManager extends EventDispatcher {
 	 * @return {number} The framebuffer scale factor.
 	 */
 	getFramebufferScaleFactor() {
+
 		return this._framebufferScaleFactor;
+
 	}
 
 	/**
@@ -498,12 +502,16 @@ class XRManager extends EventDispatcher {
 	 *
 	 * @param {number} factor - The framebuffer scale factor.
 	 */
-	setFramebufferScaleFactor(factor) {
+	setFramebufferScaleFactor( factor ) {
+
 		this._framebufferScaleFactor = factor;
 
-		if (this.isPresenting === true) {
-			warn("XRManager: Cannot change framebuffer scale while presenting.");
+		if ( this.isPresenting === true ) {
+
+			warn( 'XRManager: Cannot change framebuffer scale while presenting.' );
+
 		}
+
 	}
 
 	/**
@@ -512,7 +520,9 @@ class XRManager extends EventDispatcher {
 	 * @return {XRReferenceSpaceType} The reference space type.
 	 */
 	getReferenceSpaceType() {
+
 		return this._referenceSpaceType;
+
 	}
 
 	/**
@@ -522,12 +532,16 @@ class XRManager extends EventDispatcher {
 	 *
 	 * @param {XRReferenceSpaceType} type - The reference space type.
 	 */
-	setReferenceSpaceType(type) {
+	setReferenceSpaceType( type ) {
+
 		this._referenceSpaceType = type;
 
-		if (this.isPresenting === true) {
-			warn("XRManager: Cannot change reference space type while presenting.");
+		if ( this.isPresenting === true ) {
+
+			warn( 'XRManager: Cannot change reference space type while presenting.' );
+
 		}
+
 	}
 
 	/**
@@ -536,7 +550,9 @@ class XRManager extends EventDispatcher {
 	 * @return {XRReferenceSpace} The XR reference space.
 	 */
 	getReferenceSpace() {
+
 		return this._customReferenceSpace || this._referenceSpace;
+
 	}
 
 	/**
@@ -544,8 +560,10 @@ class XRManager extends EventDispatcher {
 	 *
 	 * @param {XRReferenceSpace} space - The XR reference space.
 	 */
-	setReferenceSpace(space) {
+	setReferenceSpace( space ) {
+
 		this._customReferenceSpace = space;
+
 	}
 
 	/**
@@ -554,7 +572,9 @@ class XRManager extends EventDispatcher {
 	 * @return {ArrayCamera} The XR camera.
 	 */
 	getCamera() {
+
 		return this._cameraXR;
+
 	}
 
 	/**
@@ -563,10 +583,15 @@ class XRManager extends EventDispatcher {
 	 * @return {'opaque'|'additive'|'alpha-blend'|undefined} The environment blend mode. Returns `undefined` when used outside of a XR session.
 	 */
 	getEnvironmentBlendMode() {
-		if (this._session !== null) {
+
+		if ( this._session !== null ) {
+
 			return this._session.environmentBlendMode;
+
 		}
+
 	}
+
 
 	/**
 	 * Returns the current XR binding.
@@ -577,11 +602,15 @@ class XRManager extends EventDispatcher {
 	 * @return {?XRWebGLBinding} The XR binding. Returns `null` if one cannot be created.
 	 */
 	getBinding() {
-		if (this._glBinding === null && this._supportsGlBinding) {
-			this._glBinding = new XRWebGLBinding(this._session, this._gl);
+
+		if ( this._glBinding === null && this._supportsGlBinding ) {
+
+			this._glBinding = new XRWebGLBinding( this._session, this._gl );
+
 		}
 
 		return this._glBinding;
+
 	}
 
 	/**
@@ -590,7 +619,9 @@ class XRManager extends EventDispatcher {
 	 * @return {?XRFrame} The XR frame. Returns `null` when used outside a XR session.
 	 */
 	getFrame() {
+
 		return this._xrFrame;
+
 	}
 
 	/**
@@ -599,7 +630,9 @@ class XRManager extends EventDispatcher {
 	 * @return {boolean} Whether the engine renders to a multiview render target or not.
 	 */
 	useMultiview() {
+
 		return this._useMultiview;
+
 	}
 
 	/**
@@ -617,52 +650,44 @@ class XRManager extends EventDispatcher {
 	 * @param {Object} [attributes={}] - Allows to configure the layer's render target.
 	 * @return {Mesh} A mesh representing the quadratic XR layer. This mesh should be added to the XR scene.
 	 */
-	createQuadLayer(
-		width,
-		height,
-		translation,
-		quaternion,
-		pixelwidth,
-		pixelheight,
-		rendercall,
-		attributes = {}
-	) {
-		const geometry = new PlaneGeometry(width, height);
-		const renderTarget = new XRRenderTarget(pixelwidth, pixelheight, {
-			format: RGBAFormat,
-			type: UnsignedByteType,
-			depthTexture: new DepthTexture(
-				pixelwidth,
-				pixelheight,
-				attributes.stencil ? UnsignedInt248Type : UnsignedIntType,
-				undefined,
-				undefined,
-				undefined,
-				undefined,
-				undefined,
-				undefined,
-				attributes.stencil ? DepthStencilFormat : DepthFormat
-			),
-			stencilBuffer: attributes.stencil,
-			resolveDepthBuffer: false,
-			resolveStencilBuffer: false,
-		});
+	createQuadLayer( width, height, translation, quaternion, pixelwidth, pixelheight, rendercall, attributes = {} ) {
+
+		const geometry = new PlaneGeometry( width, height );
+		const renderTarget = new XRRenderTarget(
+			pixelwidth,
+			pixelheight,
+			{
+				format: RGBAFormat,
+				type: UnsignedByteType,
+				depthTexture: new DepthTexture(
+					pixelwidth,
+					pixelheight,
+					attributes.stencil ? UnsignedInt248Type : UnsignedIntType,
+					undefined,
+					undefined,
+					undefined,
+					undefined,
+					undefined,
+					undefined,
+					attributes.stencil ? DepthStencilFormat : DepthFormat
+				),
+				stencilBuffer: attributes.stencil,
+				resolveDepthBuffer: false,
+				resolveStencilBuffer: false
+			} );
 
 		renderTarget._autoAllocateDepthBuffer = true;
 
-		const material = new MeshBasicMaterial({
-			color: 0xffffff,
-			side: FrontSide,
-		});
+		const material = new MeshBasicMaterial( { color: 0xffffff, side: FrontSide } );
 		material.map = renderTarget.texture;
 		material.map.offset.y = 1;
-		material.map.repeat.y = -1;
-		const plane = new Mesh(geometry, material);
-		plane.position.copy(translation);
-		plane.quaternion.copy(quaternion);
+		material.map.repeat.y = - 1;
+		const plane = new Mesh( geometry, material );
+		plane.position.copy( translation );
+		plane.quaternion.copy( quaternion );
 
 		const layer = {
-			type: "quad",
+			type: 'quad',
 			width: width,
 			height: height,
 			translation: translation,
@@ -672,31 +697,32 @@ class XRManager extends EventDispatcher {
 			plane: plane,
 			material: material,
 			rendercall: rendercall,
-			renderTarget: renderTarget,
-		};
+			renderTarget: renderTarget };
 
-		this._layers.push(layer);
+		this._layers.push( layer );
 
-		if (this._session !== null) {
-			layer.plane.material = new MeshBasicMaterial({
-				color: 0xffffff,
-				side: FrontSide,
-			});
+		if ( this._session !== null ) {
+
+			layer.plane.material = new MeshBasicMaterial( { color: 0xffffff, side: FrontSide } );
 			layer.plane.material.blending = CustomBlending;
 			layer.plane.material.blendEquation = AddEquation;
 			layer.plane.material.blendSrc = ZeroFactor;
 			layer.plane.material.blendDst = ZeroFactor;
 
-			layer.xrlayer = this._createXRLayer(layer);
+			layer.xrlayer = this._createXRLayer( layer );
 
 			const xrlayers = this._session.renderState.layers;
-			xrlayers.unshift(layer.xrlayer);
-			this._session.updateRenderState({ layers: xrlayers });
+			xrlayers.unshift( layer.xrlayer );
+			this._session.updateRenderState( { layers: xrlayers } );
+
 		} else {
+
 			renderTarget.isXRRenderTarget = false;
+
 		}
 
 		return plane;
+
 	}
 
 	/**
@@ -715,59 +741,44 @@ class XRManager extends EventDispatcher {
 	 * @param {Object} [attributes={}] - Allows to configure the layer's render target.
 	 * @return {Mesh} A mesh representing the cylindrical XR layer. This mesh should be added to the XR scene.
 	 */
-	createCylinderLayer(
-		radius,
-		centralAngle,
-		aspectratio,
-		translation,
-		quaternion,
-		pixelwidth,
-		pixelheight,
-		rendercall,
-		attributes = {}
-	) {
-		const geometry = new CylinderGeometry(
-			radius,
-			radius,
-			(radius * centralAngle) / aspectratio,
-			64,
-			64,
-			true,
-			Math.PI - centralAngle / 2,
-			centralAngle
-		);
-		const renderTarget = new XRRenderTarget(pixelwidth, pixelheight, {
-			format: RGBAFormat,
-			type: UnsignedByteType,
-			depthTexture: new DepthTexture(
-				pixelwidth,
-				pixelheight,
-				attributes.stencil ? UnsignedInt248Type : UnsignedIntType,
-				undefined,
-				undefined,
-				undefined,
-				undefined,
-				undefined,
-				undefined,
-				attributes.stencil ? DepthStencilFormat : DepthFormat
-			),
-			stencilBuffer: attributes.stencil,
-			resolveDepthBuffer: false,
-			resolveStencilBuffer: false,
-		});
+	createCylinderLayer( radius, centralAngle, aspectratio, translation, quaternion, pixelwidth, pixelheight, rendercall, attributes = {} ) {
+
+		const geometry = new CylinderGeometry( radius, radius, radius * centralAngle / aspectratio, 64, 64, true, Math.PI - centralAngle / 2, centralAngle );
+		const renderTarget = new XRRenderTarget(
+			pixelwidth,
+			pixelheight,
+			{
+				format: RGBAFormat,
+				type: UnsignedByteType,
+				depthTexture: new DepthTexture(
+					pixelwidth,
+					pixelheight,
+					attributes.stencil ? UnsignedInt248Type : UnsignedIntType,
+					undefined,
+					undefined,
+					undefined,
+					undefined,
+					undefined,
+					undefined,
+					attributes.stencil ? DepthStencilFormat : DepthFormat
+				),
+				stencilBuffer: attributes.stencil,
+				resolveDepthBuffer: false,
+				resolveStencilBuffer: false
+			} );
 
 		renderTarget._autoAllocateDepthBuffer = true;
 
-		const material = new MeshBasicMaterial({ color: 0xffffff, side: BackSide });
+		const material = new MeshBasicMaterial( { color: 0xffffff, side: BackSide } );
 		material.map = renderTarget.texture;
 		material.map.offset.y = 1;
-		material.map.repeat.y = -1;
-		const plane = new Mesh(geometry, material);
-		plane.position.copy(translation);
-		plane.quaternion.copy(quaternion);
+		material.map.repeat.y = - 1;
+		const plane = new Mesh( geometry, material );
+		plane.position.copy( translation );
+		plane.quaternion.copy( quaternion );
 
 		const layer = {
-			type: "cylinder",
+			type: 'cylinder',
 			radius: radius,
 			centralAngle: centralAngle,
 			aspectratio: aspectratio,
@@ -778,31 +789,32 @@ class XRManager extends EventDispatcher {
 			plane: plane,
 			material: material,
 			rendercall: rendercall,
-			renderTarget: renderTarget,
-		};
+			renderTarget: renderTarget };
 
-		this._layers.push(layer);
+		this._layers.push( layer );
 
-		if (this._session !== null) {
-			layer.plane.material = new MeshBasicMaterial({
-				color: 0xffffff,
-				side: BackSide,
-			});
+		if ( this._session !== null ) {
+
+			layer.plane.material = new MeshBasicMaterial( { color: 0xffffff, side: BackSide } );
 			layer.plane.material.blending = CustomBlending;
 			layer.plane.material.blendEquation = AddEquation;
 			layer.plane.material.blendSrc = ZeroFactor;
 			layer.plane.material.blendDst = ZeroFactor;
 
-			layer.xrlayer = this._createXRLayer(layer);
+			layer.xrlayer = this._createXRLayer( layer );
 
 			const xrlayers = this._session.renderState.layers;
-			xrlayers.unshift(layer.xrlayer);
-			this._session.updateRenderState({ layers: xrlayers });
+			xrlayers.unshift( layer.xrlayer );
+			this._session.updateRenderState( { layers: xrlayers } );
+
 		} else {
+
 			renderTarget.isXRRenderTarget = false;
+
 		}
 
 		return plane;
+
 	}
 
 	/**
@@ -811,7 +823,8 @@ class XRManager extends EventDispatcher {
 	 * This method is usually called in your animation loop before rendering
 	 * the actual scene via `renderer.render( scene, camera );`.
 	 */
-	renderLayers() {
+	renderLayers( ) {
+
 		const translationObject = new Vector3();
 		const quaternionObject = new Quaternion();
 		const renderer = this._renderer;
@@ -822,69 +835,65 @@ class XRManager extends EventDispatcher {
 		this.isPresenting = false;
 
 		const rendererSize = new Vector2();
-		renderer.getSize(rendererSize);
+		renderer.getSize( rendererSize );
 		const rendererQuad = renderer._quad;
 
-		for (const layer of this._layers) {
+		for ( const layer of this._layers ) {
+
 			layer.renderTarget.isXRRenderTarget = this._session !== null;
-			layer.renderTarget._hasExternalTextures =
-				layer.renderTarget.isXRRenderTarget;
+			layer.renderTarget._hasExternalTextures = layer.renderTarget.isXRRenderTarget;
 
-			if (layer.renderTarget.isXRRenderTarget && this._sessionUsesLayers) {
-				layer.xrlayer.transform = new XRRigidTransform(
-					layer.plane.getWorldPosition(translationObject),
-					layer.plane.getWorldQuaternion(quaternionObject)
-				);
+			if ( layer.renderTarget.isXRRenderTarget && this._sessionUsesLayers ) {
 
-				const glSubImage = this._glBinding.getSubImage(
-					layer.xrlayer,
-					this._xrFrame
-				);
+				layer.xrlayer.transform = new XRRigidTransform( layer.plane.getWorldPosition( translationObject ), layer.plane.getWorldQuaternion( quaternionObject ) );
+
+				const glSubImage = this._glBinding.getSubImage( layer.xrlayer, this._xrFrame );
 				renderer.backend.setXRRenderTargetTextures(
 					layer.renderTarget,
 					glSubImage.colorTexture,
-					undefined
-				);
+					undefined );
 
-				renderer._setXRLayerSize(
-					layer.renderTarget.width,
-					layer.renderTarget.height
-				);
-				renderer.setOutputRenderTarget(layer.renderTarget);
-				renderer.setRenderTarget(null);
+				renderer._setXRLayerSize( layer.renderTarget.width, layer.renderTarget.height );
+				renderer.setOutputRenderTarget( layer.renderTarget );
+				renderer.setRenderTarget( null );
 				renderer._frameBufferTarget = null;
 
-				this._frameBufferTargets || (this._frameBufferTargets = new WeakMap());
-				const { frameBufferTarget, quad } = this._frameBufferTargets.get(
-					layer.renderTarget
-				) || { frameBufferTarget: null, quad: null };
-				if (!frameBufferTarget) {
-					renderer._quad = new QuadMesh(new NodeMaterial());
-					this._frameBufferTargets.set(layer.renderTarget, {
-						frameBufferTarget: renderer._getFrameBufferTarget(),
-						quad: renderer._quad,
-					});
+				this._frameBufferTargets || ( this._frameBufferTargets = new WeakMap() );
+				const { frameBufferTarget, quad } = this._frameBufferTargets.get( layer.renderTarget ) || { frameBufferTarget: null, quad: null };
+				if ( ! frameBufferTarget ) {
+
+					renderer._quad = new QuadMesh( new NodeMaterial() );
+					this._frameBufferTargets.set( layer.renderTarget, { frameBufferTarget: renderer._getFrameBufferTarget(), quad: renderer._quad } );
+
 				} else {
+
 					renderer._frameBufferTarget = frameBufferTarget;
 					renderer._quad = quad;
+
 				}
 
 				layer.rendercall();
 
 				renderer._frameBufferTarget = null;
+
 			} else {
-				renderer.setRenderTarget(layer.renderTarget);
+
+				renderer.setRenderTarget( layer.renderTarget );
 				layer.rendercall();
+
 			}
+
 		}
 
-		renderer.setRenderTarget(null);
-		renderer.setOutputRenderTarget(rendererOutputTarget);
+		renderer.setRenderTarget( null );
+		renderer.setOutputRenderTarget( rendererOutputTarget );
 		renderer._frameBufferTarget = rendererFramebufferTarget;
-		renderer._setXRLayerSize(rendererSize.x, rendererSize.y);
+		renderer._setXRLayerSize( rendererSize.x, rendererSize.y );
 		renderer._quad = rendererQuad;
 		this.isPresenting = wasPresenting;
+
 	}
+
 
 	/**
 	 * Returns the current XR session.
@@ -892,7 +901,9 @@ class XRManager extends EventDispatcher {
 	 * @return {?XRSession} The XR session. Returns `null` when used outside a XR session.
 	 */
 	getSession() {
+
 		return this._session;
+
 	}
 
 	/**
@@ -904,7 +915,8 @@ class XRManager extends EventDispatcher {
 	 * @param {XRSession} session - The XR session to set.
 	 * @return {Promise} A Promise that resolves when the session has been set.
 	 */
-	async setSession(session) {
+	async setSession( session ) {
+
 		const renderer = this._renderer;
 		const backend = renderer.backend;
 
@@ -914,95 +926,71 @@ class XRManager extends EventDispatcher {
 
 		this._session = session;
 
-		if (session !== null) {
-			if (backend.isWebGPUBackend === true)
-				throw new Error(
-					'THREE.XRManager: XR is currently not supported with a WebGPU backend. Use WebGL by passing "{ forceWebGL: true }" to the constructor of the renderer.'
-				);
+		if ( session !== null ) {
 
-			session.addEventListener("select", this._onSessionEvent);
-			session.addEventListener("selectstart", this._onSessionEvent);
-			session.addEventListener("selectend", this._onSessionEvent);
-			session.addEventListener("squeeze", this._onSessionEvent);
-			session.addEventListener("squeezestart", this._onSessionEvent);
-			session.addEventListener("squeezeend", this._onSessionEvent);
-			session.addEventListener("end", this._onSessionEnd);
-			session.addEventListener(
-				"inputsourceschange",
-				this._onInputSourcesChange
-			);
+			if ( backend.isWebGPUBackend === true ) throw new Error( 'THREE.XRManager: XR is currently not supported with a WebGPU backend. Use WebGL by passing "{ forceWebGL: true }" to the constructor of the renderer.' );
+
+			session.addEventListener( 'select', this._onSessionEvent );
+			session.addEventListener( 'selectstart', this._onSessionEvent );
+			session.addEventListener( 'selectend', this._onSessionEvent );
+			session.addEventListener( 'squeeze', this._onSessionEvent );
+			session.addEventListener( 'squeezestart', this._onSessionEvent );
+			session.addEventListener( 'squeezeend', this._onSessionEvent );
+			session.addEventListener( 'end', this._onSessionEnd );
+			session.addEventListener( 'inputsourceschange', this._onInputSourcesChange );
 
 			await backend.makeXRCompatible();
 
 			this._currentPixelRatio = renderer.getPixelRatio();
-			renderer.getSize(this._currentSize);
+			renderer.getSize( this._currentSize );
 
 			this._currentAnimationContext = renderer._animation.getContext();
 			this._currentAnimationLoop = renderer._animation.getAnimationLoop();
 			renderer._animation.stop();
 
-			//
-			const sessionHasLayers =
-				session.enabledFeatures?.includes("layers") ?? false;
+			const sessionHasLayers = session.enabledFeatures?.includes( 'layers' ) ?? false;
 
-			if (this._supportsLayers === true && sessionHasLayers) {
+			if ( this._supportsLayers === true && sessionHasLayers ) {
+
+				// default path using XRProjectionLayer
+
 				let depthFormat = null;
 				let depthType = null;
 				let glDepthFormat = null;
 
-				if (renderer.depth) {
-					glDepthFormat = renderer.stencil
-						? gl.DEPTH24_STENCIL8
-						: gl.DEPTH_COMPONENT24;
+				if ( renderer.depth ) {
+
+					glDepthFormat = renderer.stencil ? gl.DEPTH24_STENCIL8 : gl.DEPTH_COMPONENT24;
 					depthFormat = renderer.stencil ? DepthStencilFormat : DepthFormat;
 					depthType = renderer.stencil ? UnsignedInt248Type : UnsignedIntType;
+
 				}
 
 				const projectionlayerInit = {
 					colorFormat: gl.RGBA8,
 					depthFormat: glDepthFormat,
 					scaleFactor: this._framebufferScaleFactor,
-					clearOnAccess: false,
+					clearOnAccess: false
 				};
 
-				if (
-					this._useMultiviewIfPossible &&
-					renderer.hasFeature("OVR_multiview2")
-				) {
-					projectionlayerInit.textureType = "texture-array";
+				if ( this._useMultiviewIfPossible && renderer.hasFeature( 'OVR_multiview2' ) ) {
+
+					projectionlayerInit.textureType = 'texture-array';
 					this._useMultiview = true;
+
 				}
 
-				// this._glBinding = this.getBinding();
-				this._glBinding = new XRWebGLBinding(session, gl);
-				const glProjLayer =
-					this._glBinding.createProjectionLayer(projectionlayerInit);
+				this._glBinding = this.getBinding();
+				const glProjLayer = this._glBinding.createProjectionLayer( projectionlayerInit );
+				const layersArray = [ glProjLayer ];
 
 				this._glProjLayer = glProjLayer;
 
-				// Register layer with session IMMEDIATELY before any await
-				session.updateRenderState({ layers: [glProjLayer] });
-
-				renderer.setPixelRatio(1);
-				renderer._setXRLayerSize(
-					glProjLayer.textureWidth,
-					glProjLayer.textureHeight
-				);
+				renderer.setPixelRatio( 1 );
+				renderer._setXRLayerSize( glProjLayer.textureWidth, glProjLayer.textureHeight );
 
 				const depth = this._useMultiview ? 2 : 1;
-				const depthTexture = new DepthTexture(
-					glProjLayer.textureWidth,
-					glProjLayer.textureHeight,
-					depthType,
-					undefined,
-					undefined,
-					undefined,
-					undefined,
-					undefined,
-					undefined,
-					depthFormat,
-					depth
-				);
+				const depthTexture = new DepthTexture( glProjLayer.textureWidth, glProjLayer.textureHeight, depthType, undefined, undefined, undefined, undefined, undefined, undefined, depthFormat, depth );
 
 				this._xrRenderTarget = new XRRenderTarget(
 					glProjLayer.textureWidth,
@@ -1014,45 +1002,43 @@ class XRManager extends EventDispatcher {
 						depthTexture: depthTexture,
 						stencilBuffer: renderer.stencil,
 						samples: attributes.antialias ? 4 : 0,
-						resolveDepthBuffer: glProjLayer.ignoreDepthValues === false,
-						resolveStencilBuffer: glProjLayer.ignoreDepthValues === false,
+						resolveDepthBuffer: ( glProjLayer.ignoreDepthValues === false ),
+						resolveStencilBuffer: ( glProjLayer.ignoreDepthValues === false ),
 						depth: this._useMultiview ? 2 : 1,
-						multiview: this._useMultiview,
-					}
-				);
+						multiview: this._useMultiview
+					} );
 
 				this._xrRenderTarget._hasExternalTextures = true;
 				this._xrRenderTarget.depth = this._useMultiview ? 2 : 1;
 
-				this._sessionUsesLayers =
-					session.enabledFeatures?.includes("layers") ?? false;
+				this._sessionUsesLayers = session.enabledFeatures.includes( 'layers' );
 
-				this._referenceSpace = await session.requestReferenceSpace(
-					this.getReferenceSpaceType()
-				);
+				this._referenceSpace = await session.requestReferenceSpace( this.getReferenceSpaceType() );
 
-				// Handle additional quad/cylinder layers AFTER the await
-				if (this._sessionUsesLayers && this._layers.length > 0) {
-					const layersArray = [glProjLayer];
+				if ( this._sessionUsesLayers ) {
 
-					for (const layer of this._layers) {
-						layer.plane.material = new MeshBasicMaterial({
-							color: 0xffffff,
-							side: layer.type === "cylinder" ? BackSide : FrontSide,
-						});
+					// switch layers to native
+					for ( const layer of this._layers ) {
+
+						// change material so it "punches" out a hole to show the XR Layer.
+						layer.plane.material = new MeshBasicMaterial( { color: 0xffffff, side: layer.type === 'cylinder' ? BackSide : FrontSide } );
 						layer.plane.material.blending = CustomBlending;
 						layer.plane.material.blendEquation = AddEquation;
 						layer.plane.material.blendSrc = ZeroFactor;
 						layer.plane.material.blendDst = ZeroFactor;
 
-						layer.xrlayer = this._createXRLayer(layer);
+						layer.xrlayer = this._createXRLayer( layer );
 
-						layersArray.unshift(layer.xrlayer);
+						layersArray.unshift( layer.xrlayer );
+
 					}
 
-					session.updateRenderState({ layers: layersArray });
 				}
+
+				session.updateRenderState( { layers: layersArray } );
+
 			} else {
+
 				// fallback to XRWebGLLayer
 
 				const layerInit = {
@@ -1060,19 +1046,16 @@ class XRManager extends EventDispatcher {
 					alpha: true,
 					depth: renderer.depth,
 					stencil: renderer.stencil,
-					framebufferScaleFactor: this.getFramebufferScaleFactor(),
+					framebufferScaleFactor: this.getFramebufferScaleFactor()
 				};
 
-				const glBaseLayer = new XRWebGLLayer(session, gl, layerInit);
+				const glBaseLayer = new XRWebGLLayer( session, gl, layerInit );
 				this._glBaseLayer = glBaseLayer;
 
-				session.updateRenderState({ baseLayer: glBaseLayer });
+				session.updateRenderState( { baseLayer: glBaseLayer } );
 
-				renderer.setPixelRatio(1);
-				renderer._setXRLayerSize(
-					glBaseLayer.framebufferWidth,
-					glBaseLayer.framebufferHeight
-				);
+				renderer.setPixelRatio( 1 );
+				renderer._setXRLayerSize( glBaseLayer.framebufferWidth, glBaseLayer.framebufferHeight );
 
 				this._xrRenderTarget = new XRRenderTarget(
 					glBaseLayer.framebufferWidth,
@@ -1082,29 +1065,30 @@ class XRManager extends EventDispatcher {
 						type: UnsignedByteType,
 						colorSpace: renderer.outputColorSpace,
 						stencilBuffer: renderer.stencil,
-						resolveDepthBuffer: glBaseLayer.ignoreDepthValues === false,
-						resolveStencilBuffer: glBaseLayer.ignoreDepthValues === false,
+						resolveDepthBuffer: ( glBaseLayer.ignoreDepthValues === false ),
+						resolveStencilBuffer: ( glBaseLayer.ignoreDepthValues === false ),
 					}
 				);
 
 				this._xrRenderTarget._isOpaqueFramebuffer = true;
-				this._referenceSpace = await session.requestReferenceSpace(
-					this.getReferenceSpaceType()
-				);
+				this._referenceSpace = await session.requestReferenceSpace( this.getReferenceSpaceType() );
+
 			}
 
 			//
 
-			this.setFoveation(this.getFoveation());
+			this.setFoveation( this.getFoveation() );
 
-			renderer._animation.setAnimationLoop(this._onAnimationFrame);
-			renderer._animation.setContext(session);
+			renderer._animation.setAnimationLoop( this._onAnimationFrame );
+			renderer._animation.setContext( session );
 			renderer._animation.start();
 
 			this.isPresenting = true;
 
-			this.dispatchEvent({ type: "sessionstart" });
+			this.dispatchEvent( { type: 'sessionstart' } );
+
 		}
+
 	}
 
 	/**
@@ -1114,10 +1098,11 @@ class XRManager extends EventDispatcher {
 	 *
 	 * @param {PerspectiveCamera} camera - The camera.
 	 */
-	updateCamera(camera) {
+	updateCamera( camera ) {
+
 		const session = this._session;
 
-		if (session === null) return;
+		if ( session === null ) return;
 
 		const depthNear = camera.near;
 		const depthFar = camera.far;
@@ -1130,19 +1115,18 @@ class XRManager extends EventDispatcher {
 		cameraXR.far = cameraR.far = cameraL.far = depthFar;
 		cameraXR.isMultiViewCamera = this._useMultiview;
 
-		if (
-			this._currentDepthNear !== cameraXR.near ||
-			this._currentDepthFar !== cameraXR.far
-		) {
+		if ( this._currentDepthNear !== cameraXR.near || this._currentDepthFar !== cameraXR.far ) {
+
 			// Note that the new renderState won't apply until the next frame. See #18320
 
-			session.updateRenderState({
+			session.updateRenderState( {
 				depthNear: cameraXR.near,
-				depthFar: cameraXR.far,
-			});
+				depthFar: cameraXR.far
+			} );
 
 			this._currentDepthNear = cameraXR.near;
 			this._currentDepthFar = cameraXR.far;
+
 		}
 
 		// inherit camera layers and enable eye layers (1 = left, 2 = right)
@@ -1150,28 +1134,37 @@ class XRManager extends EventDispatcher {
 		cameraL.layers.mask = cameraXR.layers.mask & 0b011;
 		cameraR.layers.mask = cameraXR.layers.mask & 0b101;
 
+
 		const parent = camera.parent;
 		const cameras = cameraXR.cameras;
 
-		updateCamera(cameraXR, parent);
+		updateCamera( cameraXR, parent );
 
-		for (let i = 0; i < cameras.length; i++) {
-			updateCamera(cameras[i], parent);
+		for ( let i = 0; i < cameras.length; i ++ ) {
+
+			updateCamera( cameras[ i ], parent );
+
 		}
 
 		// update projection matrix for proper view frustum culling
 
-		if (cameras.length === 2) {
-			setProjectionFromUnion(cameraXR, cameraL, cameraR);
+		if ( cameras.length === 2 ) {
+
+			setProjectionFromUnion( cameraXR, cameraL, cameraR );
+
 		} else {
+
 			// assume single camera setup (AR)
 
-			cameraXR.projectionMatrix.copy(cameraL.projectionMatrix);
+			cameraXR.projectionMatrix.copy( cameraL.projectionMatrix );
+
 		}
 
 		// update user camera and its children
 
-		updateUserCamera(camera, cameraXR, parent);
+		updateUserCamera( camera, cameraXR, parent );
+
+
 	}
 
 	/**
@@ -1181,16 +1174,21 @@ class XRManager extends EventDispatcher {
 	 * @param {number} index - The controller index.
 	 * @return {WebXRController} The XR controller.
 	 */
-	_getController(index) {
-		let controller = this._controllers[index];
+	_getController( index ) {
 
-		if (controller === undefined) {
+		let controller = this._controllers[ index ];
+
+		if ( controller === undefined ) {
+
 			controller = new WebXRController();
-			this._controllers[index] = controller;
+			this._controllers[ index ] = controller;
+
 		}
 
 		return controller;
+
 	}
+
 }
 
 /**
@@ -1203,11 +1201,12 @@ class XRManager extends EventDispatcher {
  * @param {PerspectiveCamera} cameraL - The left camera.
  * @param {PerspectiveCamera} cameraR - The right camera.
  */
-function setProjectionFromUnion(camera, cameraL, cameraR) {
-	_cameraLPos.setFromMatrixPosition(cameraL.matrixWorld);
-	_cameraRPos.setFromMatrixPosition(cameraR.matrixWorld);
+function setProjectionFromUnion( camera, cameraL, cameraR ) {
 
-	const ipd = _cameraLPos.distanceTo(_cameraRPos);
+	_cameraLPos.setFromMatrixPosition( cameraL.matrixWorld );
+	_cameraRPos.setFromMatrixPosition( cameraR.matrixWorld );
+
+	const ipd = _cameraLPos.distanceTo( _cameraRPos );
 
 	const projL = cameraL.projectionMatrix.elements;
 	const projR = cameraR.projectionMatrix.elements;
@@ -1215,60 +1214,54 @@ function setProjectionFromUnion(camera, cameraL, cameraR) {
 	// VR systems will have identical far and near planes, and
 	// most likely identical top and bottom frustum extents.
 	// Use the left camera for these values.
-	const near = projL[14] / (projL[10] - 1);
-	const far = projL[14] / (projL[10] + 1);
-	const topFov = (projL[9] + 1) / projL[5];
-	const bottomFov = (projL[9] - 1) / projL[5];
+	const near = projL[ 14 ] / ( projL[ 10 ] - 1 );
+	const far = projL[ 14 ] / ( projL[ 10 ] + 1 );
+	const topFov = ( projL[ 9 ] + 1 ) / projL[ 5 ];
+	const bottomFov = ( projL[ 9 ] - 1 ) / projL[ 5 ];
 
-	const leftFov = (projL[8] - 1) / projL[0];
-	const rightFov = (projR[8] + 1) / projR[0];
+	const leftFov = ( projL[ 8 ] - 1 ) / projL[ 0 ];
+	const rightFov = ( projR[ 8 ] + 1 ) / projR[ 0 ];
 	const left = near * leftFov;
 	const right = near * rightFov;
 
 	// Calculate the new camera's position offset from the
 	// left camera. xOffset should be roughly half `ipd`.
-	const zOffset = ipd / (-leftFov + rightFov);
-	const xOffset = zOffset * -leftFov;
+	const zOffset = ipd / ( - leftFov + rightFov );
+	const xOffset = zOffset * - leftFov;
 
 	// TODO: Better way to apply this offset?
-	cameraL.matrixWorld.decompose(
-		camera.position,
-		camera.quaternion,
-		camera.scale
-	);
-	camera.translateX(xOffset);
-	camera.translateZ(zOffset);
-	camera.matrixWorld.compose(camera.position, camera.quaternion, camera.scale);
-	camera.matrixWorldInverse.copy(camera.matrixWorld).invert();
+	cameraL.matrixWorld.decompose( camera.position, camera.quaternion, camera.scale );
+	camera.translateX( xOffset );
+	camera.translateZ( zOffset );
+	camera.matrixWorld.compose( camera.position, camera.quaternion, camera.scale );
+	camera.matrixWorldInverse.copy( camera.matrixWorld ).invert();
 
 	// Check if the projection uses an infinite far plane.
-	if (projL[10] === -1.0) {
+	if ( projL[ 10 ] === - 1.0 ) {
+
 		// Use the projection matrix from the left eye.
 		// The camera offset is sufficient to include the view volumes
 		// of both eyes (assuming symmetric projections).
-		camera.projectionMatrix.copy(cameraL.projectionMatrix);
-		camera.projectionMatrixInverse.copy(cameraL.projectionMatrixInverse);
+		camera.projectionMatrix.copy( cameraL.projectionMatrix );
+		camera.projectionMatrixInverse.copy( cameraL.projectionMatrixInverse );
+
 	} else {
+
 		// Find the union of the frustum values of the cameras and scale
 		// the values so that the near plane's position does not change in world space,
 		// although must now be relative to the new union camera.
 		const near2 = near + zOffset;
 		const far2 = far + zOffset;
 		const left2 = left - xOffset;
-		const right2 = right + (ipd - xOffset);
-		const top2 = ((topFov * far) / far2) * near2;
-		const bottom2 = ((bottomFov * far) / far2) * near2;
+		const right2 = right + ( ipd - xOffset );
+		const top2 = topFov * far / far2 * near2;
+		const bottom2 = bottomFov * far / far2 * near2;
 
-		camera.projectionMatrix.makePerspective(
-			left2,
-			right2,
-			top2,
-			bottom2,
-			near2,
-			far2
-		);
-		camera.projectionMatrixInverse.copy(camera.projectionMatrix).invert();
+		camera.projectionMatrix.makePerspective( left2, right2, top2, bottom2, near2, far2 );
+		camera.projectionMatrixInverse.copy( camera.projectionMatrix ).invert();
+
 	}
+
 }
 
 /**
@@ -1278,14 +1271,20 @@ function setProjectionFromUnion(camera, cameraL, cameraR) {
  * @param {Camera} camera - The camera to update.
  * @param {Object3D} parent - The parent 3D object.
  */
-function updateCamera(camera, parent) {
-	if (parent === null) {
-		camera.matrixWorld.copy(camera.matrix);
+function updateCamera( camera, parent ) {
+
+	if ( parent === null ) {
+
+		camera.matrixWorld.copy( camera.matrix );
+
 	} else {
-		camera.matrixWorld.multiplyMatrices(parent.matrixWorld, camera.matrix);
+
+		camera.matrixWorld.multiplyMatrices( parent.matrixWorld, camera.matrix );
+
 	}
 
-	camera.matrixWorldInverse.copy(camera.matrixWorld).invert();
+	camera.matrixWorldInverse.copy( camera.matrixWorld ).invert();
+
 }
 
 /**
@@ -1296,68 +1295,82 @@ function updateCamera(camera, parent) {
  * @param {ArrayCamera} cameraXR - The XR camera.
  * @param {Object3D} parent - The parent 3D object.
  */
-function updateUserCamera(camera, cameraXR, parent) {
-	if (parent === null) {
-		camera.matrix.copy(cameraXR.matrixWorld);
+function updateUserCamera( camera, cameraXR, parent ) {
+
+	if ( parent === null ) {
+
+		camera.matrix.copy( cameraXR.matrixWorld );
+
 	} else {
-		camera.matrix.copy(parent.matrixWorld);
+
+		camera.matrix.copy( parent.matrixWorld );
 		camera.matrix.invert();
-		camera.matrix.multiply(cameraXR.matrixWorld);
+		camera.matrix.multiply( cameraXR.matrixWorld );
+
 	}
 
-	camera.matrix.decompose(camera.position, camera.quaternion, camera.scale);
-	camera.updateMatrixWorld(true);
+	camera.matrix.decompose( camera.position, camera.quaternion, camera.scale );
+	camera.updateMatrixWorld( true );
 
-	camera.projectionMatrix.copy(cameraXR.projectionMatrix);
-	camera.projectionMatrixInverse.copy(cameraXR.projectionMatrixInverse);
+	camera.projectionMatrix.copy( cameraXR.projectionMatrix );
+	camera.projectionMatrixInverse.copy( cameraXR.projectionMatrixInverse );
 
-	if (camera.isPerspectiveCamera) {
-		camera.fov =
-			RAD2DEG * 2 * Math.atan(1 / camera.projectionMatrix.elements[5]);
+	if ( camera.isPerspectiveCamera ) {
+
+		camera.fov = RAD2DEG * 2 * Math.atan( 1 / camera.projectionMatrix.elements[ 5 ] );
 		camera.zoom = 1;
+
 	}
+
 }
 
-function onSessionEvent(event) {
-	const controllerIndex = this._controllerInputSources.indexOf(
-		event.inputSource
-	);
+function onSessionEvent( event ) {
 
-	if (controllerIndex === -1) {
+	const controllerIndex = this._controllerInputSources.indexOf( event.inputSource );
+
+	if ( controllerIndex === - 1 ) {
+
 		return;
+
 	}
 
-	const controller = this._controllers[controllerIndex];
+	const controller = this._controllers[ controllerIndex ];
 
-	if (controller !== undefined) {
+	if ( controller !== undefined ) {
+
 		const referenceSpace = this.getReferenceSpace();
 
-		controller.update(event.inputSource, event.frame, referenceSpace);
-		controller.dispatchEvent({ type: event.type, data: event.inputSource });
+		controller.update( event.inputSource, event.frame, referenceSpace );
+		controller.dispatchEvent( { type: event.type, data: event.inputSource } );
+
 	}
+
 }
 
 function onSessionEnd() {
+
 	const session = this._session;
 	const renderer = this._renderer;
 
-	session.removeEventListener("select", this._onSessionEvent);
-	session.removeEventListener("selectstart", this._onSessionEvent);
-	session.removeEventListener("selectend", this._onSessionEvent);
-	session.removeEventListener("squeeze", this._onSessionEvent);
-	session.removeEventListener("squeezestart", this._onSessionEvent);
-	session.removeEventListener("squeezeend", this._onSessionEvent);
-	session.removeEventListener("end", this._onSessionEnd);
-	session.removeEventListener("inputsourceschange", this._onInputSourcesChange);
+	session.removeEventListener( 'select', this._onSessionEvent );
+	session.removeEventListener( 'selectstart', this._onSessionEvent );
+	session.removeEventListener( 'selectend', this._onSessionEvent );
+	session.removeEventListener( 'squeeze', this._onSessionEvent );
+	session.removeEventListener( 'squeezestart', this._onSessionEvent );
+	session.removeEventListener( 'squeezeend', this._onSessionEvent );
+	session.removeEventListener( 'end', this._onSessionEnd );
+	session.removeEventListener( 'inputsourceschange', this._onInputSourcesChange );
 
-	for (let i = 0; i < this._controllers.length; i++) {
-		const inputSource = this._controllerInputSources[i];
+	for ( let i = 0; i < this._controllers.length; i ++ ) {
 
-		if (inputSource === null) continue;
+		const inputSource = this._controllerInputSources[ i ];
 
-		this._controllerInputSources[i] = null;
+		if ( inputSource === null ) continue;
 
-		this._controllers[i].disconnect(inputSource);
+		this._controllerInputSources[ i ] = null;
+
+		this._controllers[ i ].disconnect( inputSource );
+
 	}
 
 	this._currentDepthNear = null;
@@ -1374,8 +1387,10 @@ function onSessionEnd() {
 	this._glProjLayer = null;
 
 	// switch layers back to emulated
-	if (this._sessionUsesLayers === true) {
-		for (const layer of this._layers) {
+	if ( this._sessionUsesLayers === true ) {
+
+		for ( const layer of this._layers ) {
+
 			// Recreate layer render target to reset state
 			layer.renderTarget = new XRRenderTarget(
 				layer.pixelwidth,
@@ -1397,18 +1412,19 @@ function onSessionEnd() {
 					),
 					stencilBuffer: layer.stencilBuffer,
 					resolveDepthBuffer: false,
-					resolveStencilBuffer: false,
-				}
-			);
+					resolveStencilBuffer: false
+				} );
 
 			layer.renderTarget.isXRRenderTarget = false;
 
 			layer.plane.material = layer.material;
 			layer.material.map = layer.renderTarget.texture;
 			layer.material.map.offset.y = 1;
-			layer.material.map.repeat.y = -1;
+			layer.material.map.repeat.y = - 1;
 			delete layer.xrlayer;
+
 		}
+
 	}
 
 	//
@@ -1417,96 +1433,123 @@ function onSessionEnd() {
 	this._useMultiview = false;
 
 	renderer._animation.stop();
-	renderer._animation.setAnimationLoop(this._currentAnimationLoop);
-	renderer._animation.setContext(this._currentAnimationContext);
+	renderer._animation.setAnimationLoop( this._currentAnimationLoop );
+	renderer._animation.setContext( this._currentAnimationContext );
 	renderer._animation.start();
 
-	renderer.setPixelRatio(this._currentPixelRatio);
-	renderer.setSize(this._currentSize.width, this._currentSize.height, false);
+	renderer.setPixelRatio( this._currentPixelRatio );
+	renderer.setSize( this._currentSize.width, this._currentSize.height, false );
 
-	this.dispatchEvent({ type: "sessionend" });
+	this.dispatchEvent( { type: 'sessionend' } );
+
 }
 
-function onInputSourcesChange(event) {
+function onInputSourcesChange( event ) {
+
 	const controllers = this._controllers;
 	const controllerInputSources = this._controllerInputSources;
 
 	// Notify disconnected
 
-	for (let i = 0; i < event.removed.length; i++) {
-		const inputSource = event.removed[i];
-		const index = controllerInputSources.indexOf(inputSource);
+	for ( let i = 0; i < event.removed.length; i ++ ) {
 
-		if (index >= 0) {
-			controllerInputSources[index] = null;
-			controllers[index].disconnect(inputSource);
+		const inputSource = event.removed[ i ];
+		const index = controllerInputSources.indexOf( inputSource );
+
+		if ( index >= 0 ) {
+
+			controllerInputSources[ index ] = null;
+			controllers[ index ].disconnect( inputSource );
+
 		}
+
 	}
 
 	// Notify connected
 
-	for (let i = 0; i < event.added.length; i++) {
-		const inputSource = event.added[i];
+	for ( let i = 0; i < event.added.length; i ++ ) {
 
-		let controllerIndex = controllerInputSources.indexOf(inputSource);
+		const inputSource = event.added[ i ];
 
-		if (controllerIndex === -1) {
+		let controllerIndex = controllerInputSources.indexOf( inputSource );
+
+		if ( controllerIndex === - 1 ) {
+
 			// Assign input source a controller that currently has no input source
 
-			for (let i = 0; i < controllers.length; i++) {
-				if (i >= controllerInputSources.length) {
-					controllerInputSources.push(inputSource);
+			for ( let i = 0; i < controllers.length; i ++ ) {
+
+				if ( i >= controllerInputSources.length ) {
+
+					controllerInputSources.push( inputSource );
 					controllerIndex = i;
 					break;
-				} else if (controllerInputSources[i] === null) {
-					controllerInputSources[i] = inputSource;
+
+				} else if ( controllerInputSources[ i ] === null ) {
+
+					controllerInputSources[ i ] = inputSource;
 					controllerIndex = i;
 					break;
+
 				}
+
 			}
 
 			// If all controllers do currently receive input we ignore new ones
 
-			if (controllerIndex === -1) break;
+			if ( controllerIndex === - 1 ) break;
+
 		}
 
-		const controller = controllers[controllerIndex];
+		const controller = controllers[ controllerIndex ];
 
-		if (controller) {
-			controller.connect(inputSource);
+		if ( controller ) {
+
+			controller.connect( inputSource );
+
 		}
+
 	}
+
 }
 
 // Creation method for native WebXR layers
-function createXRLayer(layer) {
-	if (layer.type === "quad") {
-		return this._glBinding.createQuadLayer({
-			transform: new XRRigidTransform(layer.translation, layer.quaternion),
+function createXRLayer( layer ) {
+
+	if ( layer.type === 'quad' ) {
+
+		return this._glBinding.createQuadLayer( {
+			transform: new XRRigidTransform( layer.translation, layer.quaternion ),
 			width: layer.width / 2,
 			height: layer.height / 2,
 			space: this._referenceSpace,
 			viewPixelWidth: layer.pixelwidth,
 			viewPixelHeight: layer.pixelheight,
-			clearOnAccess: false,
-		});
+			clearOnAccess: false
+		} );
+
 	} else {
-		return this._glBinding.createCylinderLayer({
-			transform: new XRRigidTransform(layer.translation, layer.quaternion),
+
+		return this._glBinding.createCylinderLayer( {
+			transform: new XRRigidTransform( layer.translation, layer.quaternion ),
 			radius: layer.radius,
 			centralAngle: layer.centralAngle,
 			aspectRatio: layer.aspectRatio,
 			space: this._referenceSpace,
 			viewPixelWidth: layer.pixelwidth,
 			viewPixelHeight: layer.pixelheight,
-			clearOnAccess: false,
-		});
+			clearOnAccess: false
+		} );
+
 	}
+
 }
 
 // Animation Loop
-function onAnimationFrame(time, frame) {
-	if (frame === undefined) return;
+
+function onAnimationFrame( time, frame ) {
+
+	if ( frame === undefined ) return;
 
 	const cameraXR = this._cameraXR;
 	const renderer = this._renderer;
@@ -1515,116 +1558,120 @@ function onAnimationFrame(time, frame) {
 	const glBaseLayer = this._glBaseLayer;
 
 	const referenceSpace = this.getReferenceSpace();
-	const pose = frame.getViewerPose(referenceSpace);
+	const pose = frame.getViewerPose( referenceSpace );
 
 	this._xrFrame = frame;
 
-	if (pose !== null) {
+	if ( pose !== null ) {
+
 		const views = pose.views;
 
-		if (this._glBaseLayer !== null) {
-			backend.setXRTarget(glBaseLayer.framebuffer);
-			renderer.setOutputRenderTarget(this._xrRenderTarget);
+		if ( this._glBaseLayer !== null ) {
+
+			backend.setXRTarget( glBaseLayer.framebuffer );
+
 		}
 
 		let cameraXRNeedsUpdate = false;
 
-		if (views.length !== cameraXR.cameras.length) {
+		// check if it's necessary to rebuild cameraXR's camera list
+
+		if ( views.length !== cameraXR.cameras.length ) {
+
 			cameraXR.cameras.length = 0;
 			cameraXRNeedsUpdate = true;
+
 		}
 
-		for (let i = 0; i < views.length; i++) {
-			const view = views[i];
+		for ( let i = 0; i < views.length; i ++ ) {
 
-			let viewport = null;
+			const view = views[ i ];
 
-			if (this._glBaseLayer !== null) {
-				viewport = this._glBaseLayer.getViewport(view);
-			} else if (this._glProjLayer !== null) {
-				// console.log("glProjLayer:", this._glProjLayer);
-				// console.log("glBinding:", this._glBinding);
-				// console.log("frame active:", frame.session === this._session);
+			let viewport;
 
-				console.log(
-					"session.renderState.layers:",
-					this._session.renderState.layers
-				);
-				console.log(
-					"glProjLayer in layers:",
-					this._session.renderState.layers?.includes(this._glProjLayer)
-				);
+			if ( this._glProjLayer !== null ) {
 
-				const glSubImage = this._glBinding.getViewSubImage(
-					this._glProjLayer,
-					view
-				);
-
+				const glSubImage = this._glBinding.getViewSubImage( this._glProjLayer, view );
 				viewport = glSubImage.viewport;
 
-				if (i === 0) {
+				// For side-by-side projection, we only produce a single texture for both eyes.
+				if ( i === 0 ) {
+
 					backend.setXRRenderTargetTextures(
 						this._xrRenderTarget,
 						glSubImage.colorTexture,
-						this._glProjLayer.ignoreDepthValues && !this._useMultiview
-							? undefined
-							: glSubImage.depthStencilTexture
+						( this._glProjLayer.ignoreDepthValues && ! this._useMultiview ) ? undefined : glSubImage.depthStencilTexture
 					);
-					renderer.setOutputRenderTarget(this._xrRenderTarget);
+
 				}
+
+			} else {
+
+				viewport = glBaseLayer.getViewport( view );
+
 			}
 
-			let camera = this._cameras[i];
+			let camera = this._cameras[ i ];
 
-			if (camera === undefined) {
+			if ( camera === undefined ) {
+
 				camera = new PerspectiveCamera();
-				camera.layers.enable(i);
+				camera.layers.enable( i );
 				camera.viewport = new Vector4();
-				this._cameras[i] = camera;
+				this._cameras[ i ] = camera;
+
 			}
 
-			camera.matrix.fromArray(view.transform.matrix);
-			camera.matrix.decompose(camera.position, camera.quaternion, camera.scale);
-			camera.projectionMatrix.fromArray(view.projectionMatrix);
-			camera.projectionMatrixInverse.copy(camera.projectionMatrix).invert();
-			camera.viewport.set(
-				viewport.x,
-				viewport.y,
-				viewport.width,
-				viewport.height
-			);
+			camera.matrix.fromArray( view.transform.matrix );
+			camera.matrix.decompose( camera.position, camera.quaternion, camera.scale );
+			camera.projectionMatrix.fromArray( view.projectionMatrix );
+			camera.projectionMatrixInverse.copy( camera.projectionMatrix ).invert();
+			camera.viewport.set( viewport.x, viewport.y, viewport.width, viewport.height );
 
-			if (i === 0) {
-				cameraXR.matrix.copy(camera.matrix);
-				cameraXR.matrix.decompose(
-					cameraXR.position,
-					cameraXR.quaternion,
-					cameraXR.scale
-				);
+			if ( i === 0 ) {
+
+				cameraXR.matrix.copy( camera.matrix );
+				cameraXR.matrix.decompose( cameraXR.position, cameraXR.quaternion, cameraXR.scale );
+
 			}
 
-			if (cameraXRNeedsUpdate === true) {
-				cameraXR.cameras.push(camera);
+			if ( cameraXRNeedsUpdate === true ) {
+
+				cameraXR.cameras.push( camera );
+
 			}
+
 		}
+
+		renderer.setOutputRenderTarget( this._xrRenderTarget );
+
 	}
 
-	for (let i = 0; i < this._controllers.length; i++) {
-		const inputSource = this._controllerInputSources[i];
-		const controller = this._controllers[i];
+	//
 
-		if (inputSource !== null && controller !== undefined) {
-			controller.update(inputSource, frame, referenceSpace);
+	for ( let i = 0; i < this._controllers.length; i ++ ) {
+
+		const inputSource = this._controllerInputSources[ i ];
+		const controller = this._controllers[ i ];
+
+		if ( inputSource !== null && controller !== undefined ) {
+
+			controller.update( inputSource, frame, referenceSpace );
+
 		}
+
 	}
 
-	if (this._currentAnimationLoop) this._currentAnimationLoop(time, frame);
+	if ( this._currentAnimationLoop ) this._currentAnimationLoop( time, frame );
 
-	if (frame.detectedPlanes) {
-		this.dispatchEvent({ type: "planesdetected", data: frame });
+	if ( frame.detectedPlanes ) {
+
+		this.dispatchEvent( { type: 'planesdetected', data: frame } );
+
 	}
 
 	this._xrFrame = null;
+
 }
 
 export default XRManager;

--- a/src/renderers/common/XRManager.js
+++ b/src/renderers/common/XRManager.js
@@ -1,22 +1,34 @@
-import { ArrayCamera } from '../../cameras/ArrayCamera.js';
-import { EventDispatcher } from '../../core/EventDispatcher.js';
-import { PerspectiveCamera } from '../../cameras/PerspectiveCamera.js';
-import { Quaternion } from '../../math/Quaternion.js';
-import { RAD2DEG } from '../../math/MathUtils.js';
-import { Vector2 } from '../../math/Vector2.js';
-import { Vector3 } from '../../math/Vector3.js';
-import { Vector4 } from '../../math/Vector4.js';
-import { WebXRController } from '../webxr/WebXRController.js';
-import { AddEquation, BackSide, CustomBlending, DepthFormat, DepthStencilFormat, FrontSide, RGBAFormat, UnsignedByteType, UnsignedInt248Type, UnsignedIntType, ZeroFactor } from '../../constants.js';
-import { DepthTexture } from '../../textures/DepthTexture.js';
-import { XRRenderTarget } from './XRRenderTarget.js';
-import { CylinderGeometry } from '../../geometries/CylinderGeometry.js';
-import QuadMesh from './QuadMesh.js';
-import NodeMaterial from '../../materials/nodes/NodeMaterial.js';
-import { PlaneGeometry } from '../../geometries/PlaneGeometry.js';
-import { MeshBasicMaterial } from '../../materials/MeshBasicMaterial.js';
-import { Mesh } from '../../objects/Mesh.js';
-import { warn } from '../../utils.js';
+import { ArrayCamera } from "../../cameras/ArrayCamera.js";
+import { EventDispatcher } from "../../core/EventDispatcher.js";
+import { PerspectiveCamera } from "../../cameras/PerspectiveCamera.js";
+import { Quaternion } from "../../math/Quaternion.js";
+import { RAD2DEG } from "../../math/MathUtils.js";
+import { Vector2 } from "../../math/Vector2.js";
+import { Vector3 } from "../../math/Vector3.js";
+import { Vector4 } from "../../math/Vector4.js";
+import { WebXRController } from "../webxr/WebXRController.js";
+import {
+	AddEquation,
+	BackSide,
+	CustomBlending,
+	DepthFormat,
+	DepthStencilFormat,
+	FrontSide,
+	RGBAFormat,
+	UnsignedByteType,
+	UnsignedInt248Type,
+	UnsignedIntType,
+	ZeroFactor,
+} from "../../constants.js";
+import { DepthTexture } from "../../textures/DepthTexture.js";
+import { XRRenderTarget } from "./XRRenderTarget.js";
+import { CylinderGeometry } from "../../geometries/CylinderGeometry.js";
+import QuadMesh from "./QuadMesh.js";
+import NodeMaterial from "../../materials/nodes/NodeMaterial.js";
+import { PlaneGeometry } from "../../geometries/PlaneGeometry.js";
+import { MeshBasicMaterial } from "../../materials/MeshBasicMaterial.js";
+import { Mesh } from "../../objects/Mesh.js";
+import { warn } from "../../utils.js";
 
 const _cameraLPos = /*@__PURE__*/ new Vector3();
 const _cameraRPos = /*@__PURE__*/ new Vector3();
@@ -30,15 +42,13 @@ const _cameraRPos = /*@__PURE__*/ new Vector3();
  * @augments EventDispatcher
  */
 class XRManager extends EventDispatcher {
-
 	/**
 	 * Constructs a new XR manager.
 	 *
 	 * @param {Renderer} renderer - The renderer.
 	 * @param {boolean} [multiview=false] - Enables multiview if the device supports it.
 	 */
-	constructor( renderer, multiview = false ) {
-
+	constructor(renderer, multiview = false) {
 		super();
 
 		/**
@@ -100,7 +110,7 @@ class XRManager extends EventDispatcher {
 		 * @private
 		 * @type {Array<Camera>}
 		 */
-		this._cameras = [ this._cameraL, this._cameraR ];
+		this._cameras = [this._cameraL, this._cameraR];
 
 		/**
 		 * The main XR camera.
@@ -180,7 +190,7 @@ class XRManager extends EventDispatcher {
 		 * @type {boolean}
 		 * @readonly
 		 */
-		this._supportsGlBinding = typeof XRWebGLBinding !== 'undefined';
+		this._supportsGlBinding = typeof XRWebGLBinding !== "undefined";
 
 		this._frameBufferTargets = null;
 
@@ -190,15 +200,15 @@ class XRManager extends EventDispatcher {
 		 * @private
 		 * @type {Function}
 		 */
-		this._createXRLayer = createXRLayer.bind( this );
+		this._createXRLayer = createXRLayer.bind(this);
 
 		/**
-		* The current WebGL context.
-		*
-		* @private
-		* @type {?WebGL2RenderingContext}
-		* @default null
-		*/
+		 * The current WebGL context.
+		 *
+		 * @private
+		 * @type {?WebGL2RenderingContext}
+		 * @default null
+		 */
 		this._gl = null;
 
 		/**
@@ -243,7 +253,7 @@ class XRManager extends EventDispatcher {
 		 * @private
 		 * @type {Function}
 		 */
-		this._onSessionEvent = onSessionEvent.bind( this );
+		this._onSessionEvent = onSessionEvent.bind(this);
 
 		/**
 		 * The event listener for handling the end of a XR session.
@@ -251,7 +261,7 @@ class XRManager extends EventDispatcher {
 		 * @private
 		 * @type {Function}
 		 */
-		this._onSessionEnd = onSessionEnd.bind( this );
+		this._onSessionEnd = onSessionEnd.bind(this);
 
 		/**
 		 * The event listener for handling the `inputsourceschange` event.
@@ -259,7 +269,7 @@ class XRManager extends EventDispatcher {
 		 * @private
 		 * @type {Function}
 		 */
-		this._onInputSourcesChange = onInputSourcesChange.bind( this );
+		this._onInputSourcesChange = onInputSourcesChange.bind(this);
 
 		/**
 		 * The animation loop which is used as a replacement for the default
@@ -269,7 +279,7 @@ class XRManager extends EventDispatcher {
 		 * @private
 		 * @type {Function}
 		 */
-		this._onAnimationFrame = onAnimationFrame.bind( this );
+		this._onAnimationFrame = onAnimationFrame.bind(this);
 
 		/**
 		 * The current XR reference space.
@@ -287,7 +297,7 @@ class XRManager extends EventDispatcher {
 		 * @type {XRReferenceSpaceType}
 		 * @default 'local-floor'
 		 */
-		this._referenceSpaceType = 'local-floor';
+		this._referenceSpaceType = "local-floor";
 
 		/**
 		 * A custom reference space defined by the application.
@@ -371,7 +381,9 @@ class XRManager extends EventDispatcher {
 		 * @type {boolean}
 		 * @readonly
 		 */
-		this._supportsLayers = ( this._supportsGlBinding && 'createProjectionLayer' in XRWebGLBinding.prototype ); // eslint-disable-line compat/compat
+		this._supportsLayers =
+			this._supportsGlBinding &&
+			"createProjectionLayer" in XRWebGLBinding.prototype; // eslint-disable-line compat/compat
 
 		/**
 		 * Whether the usage of multiview has been requested by the application or not.
@@ -392,7 +404,6 @@ class XRManager extends EventDispatcher {
 		 * @readonly
 		 */
 		this._useMultiview = false;
-
 	}
 
 	/**
@@ -403,12 +414,10 @@ class XRManager extends EventDispatcher {
 	 * @param {number} index - The index of the XR controller.
 	 * @return {Group} A group that represents the controller's transformation.
 	 */
-	getController( index ) {
-
-		const controller = this._getController( index );
+	getController(index) {
+		const controller = this._getController(index);
 
 		return controller.getTargetRaySpace();
-
 	}
 
 	/**
@@ -419,12 +428,10 @@ class XRManager extends EventDispatcher {
 	 * @param {number} index - The index of the XR controller.
 	 * @return {Group} A group that represents the controller's transformation.
 	 */
-	getControllerGrip( index ) {
-
-		const controller = this._getController( index );
+	getControllerGrip(index) {
+		const controller = this._getController(index);
 
 		return controller.getGripSpace();
-
 	}
 
 	/**
@@ -435,12 +442,10 @@ class XRManager extends EventDispatcher {
 	 * @param {number} index - The index of the XR controller.
 	 * @return {Group} A group that represents the controller's transformation.
 	 */
-	getHand( index ) {
-
-		const controller = this._getController( index );
+	getHand(index) {
+		const controller = this._getController(index);
 
 		return controller.getHandSpace();
-
 	}
 
 	/**
@@ -449,15 +454,11 @@ class XRManager extends EventDispatcher {
 	 * @return {number|undefined} The foveation value. Returns `undefined` if no base or projection layer is defined.
 	 */
 	getFoveation() {
-
-		if ( this._glProjLayer === null && this._glBaseLayer === null ) {
-
+		if (this._glProjLayer === null && this._glBaseLayer === null) {
 			return undefined;
-
 		}
 
 		return this._foveation;
-
 	}
 
 	/**
@@ -466,22 +467,19 @@ class XRManager extends EventDispatcher {
 	 * @param {number} foveation - A number in the range `[0,1]` where `0` means no foveation (full resolution)
 	 * and `1` means maximum foveation (the edges render at lower resolution).
 	 */
-	setFoveation( foveation ) {
-
+	setFoveation(foveation) {
 		this._foveation = foveation;
 
-		if ( this._glProjLayer !== null ) {
-
+		if (this._glProjLayer !== null) {
 			this._glProjLayer.fixedFoveation = foveation;
-
 		}
 
-		if ( this._glBaseLayer !== null && this._glBaseLayer.fixedFoveation !== undefined ) {
-
+		if (
+			this._glBaseLayer !== null &&
+			this._glBaseLayer.fixedFoveation !== undefined
+		) {
 			this._glBaseLayer.fixedFoveation = foveation;
-
 		}
-
 	}
 
 	/**
@@ -490,9 +488,7 @@ class XRManager extends EventDispatcher {
 	 * @return {number} The framebuffer scale factor.
 	 */
 	getFramebufferScaleFactor() {
-
 		return this._framebufferScaleFactor;
-
 	}
 
 	/**
@@ -502,16 +498,12 @@ class XRManager extends EventDispatcher {
 	 *
 	 * @param {number} factor - The framebuffer scale factor.
 	 */
-	setFramebufferScaleFactor( factor ) {
-
+	setFramebufferScaleFactor(factor) {
 		this._framebufferScaleFactor = factor;
 
-		if ( this.isPresenting === true ) {
-
-			warn( 'XRManager: Cannot change framebuffer scale while presenting.' );
-
+		if (this.isPresenting === true) {
+			warn("XRManager: Cannot change framebuffer scale while presenting.");
 		}
-
 	}
 
 	/**
@@ -520,9 +512,7 @@ class XRManager extends EventDispatcher {
 	 * @return {XRReferenceSpaceType} The reference space type.
 	 */
 	getReferenceSpaceType() {
-
 		return this._referenceSpaceType;
-
 	}
 
 	/**
@@ -532,16 +522,12 @@ class XRManager extends EventDispatcher {
 	 *
 	 * @param {XRReferenceSpaceType} type - The reference space type.
 	 */
-	setReferenceSpaceType( type ) {
-
+	setReferenceSpaceType(type) {
 		this._referenceSpaceType = type;
 
-		if ( this.isPresenting === true ) {
-
-			warn( 'XRManager: Cannot change reference space type while presenting.' );
-
+		if (this.isPresenting === true) {
+			warn("XRManager: Cannot change reference space type while presenting.");
 		}
-
 	}
 
 	/**
@@ -550,9 +536,7 @@ class XRManager extends EventDispatcher {
 	 * @return {XRReferenceSpace} The XR reference space.
 	 */
 	getReferenceSpace() {
-
 		return this._customReferenceSpace || this._referenceSpace;
-
 	}
 
 	/**
@@ -560,10 +544,8 @@ class XRManager extends EventDispatcher {
 	 *
 	 * @param {XRReferenceSpace} space - The XR reference space.
 	 */
-	setReferenceSpace( space ) {
-
+	setReferenceSpace(space) {
 		this._customReferenceSpace = space;
-
 	}
 
 	/**
@@ -572,9 +554,7 @@ class XRManager extends EventDispatcher {
 	 * @return {ArrayCamera} The XR camera.
 	 */
 	getCamera() {
-
 		return this._cameraXR;
-
 	}
 
 	/**
@@ -583,15 +563,10 @@ class XRManager extends EventDispatcher {
 	 * @return {'opaque'|'additive'|'alpha-blend'|undefined} The environment blend mode. Returns `undefined` when used outside of a XR session.
 	 */
 	getEnvironmentBlendMode() {
-
-		if ( this._session !== null ) {
-
+		if (this._session !== null) {
 			return this._session.environmentBlendMode;
-
 		}
-
 	}
-
 
 	/**
 	 * Returns the current XR binding.
@@ -602,15 +577,11 @@ class XRManager extends EventDispatcher {
 	 * @return {?XRWebGLBinding} The XR binding. Returns `null` if one cannot be created.
 	 */
 	getBinding() {
-
-		if ( this._glBinding === null && this._supportsGlBinding ) {
-
-			this._glBinding = new XRWebGLBinding( this._session, this._gl );
-
+		if (this._glBinding === null && this._supportsGlBinding) {
+			this._glBinding = new XRWebGLBinding(this._session, this._gl);
 		}
 
 		return this._glBinding;
-
 	}
 
 	/**
@@ -619,9 +590,7 @@ class XRManager extends EventDispatcher {
 	 * @return {?XRFrame} The XR frame. Returns `null` when used outside a XR session.
 	 */
 	getFrame() {
-
 		return this._xrFrame;
-
 	}
 
 	/**
@@ -630,9 +599,7 @@ class XRManager extends EventDispatcher {
 	 * @return {boolean} Whether the engine renders to a multiview render target or not.
 	 */
 	useMultiview() {
-
 		return this._useMultiview;
-
 	}
 
 	/**
@@ -650,44 +617,52 @@ class XRManager extends EventDispatcher {
 	 * @param {Object} [attributes={}] - Allows to configure the layer's render target.
 	 * @return {Mesh} A mesh representing the quadratic XR layer. This mesh should be added to the XR scene.
 	 */
-	createQuadLayer( width, height, translation, quaternion, pixelwidth, pixelheight, rendercall, attributes = {} ) {
-
-		const geometry = new PlaneGeometry( width, height );
-		const renderTarget = new XRRenderTarget(
-			pixelwidth,
-			pixelheight,
-			{
-				format: RGBAFormat,
-				type: UnsignedByteType,
-				depthTexture: new DepthTexture(
-					pixelwidth,
-					pixelheight,
-					attributes.stencil ? UnsignedInt248Type : UnsignedIntType,
-					undefined,
-					undefined,
-					undefined,
-					undefined,
-					undefined,
-					undefined,
-					attributes.stencil ? DepthStencilFormat : DepthFormat
-				),
-				stencilBuffer: attributes.stencil,
-				resolveDepthBuffer: false,
-				resolveStencilBuffer: false
-			} );
+	createQuadLayer(
+		width,
+		height,
+		translation,
+		quaternion,
+		pixelwidth,
+		pixelheight,
+		rendercall,
+		attributes = {}
+	) {
+		const geometry = new PlaneGeometry(width, height);
+		const renderTarget = new XRRenderTarget(pixelwidth, pixelheight, {
+			format: RGBAFormat,
+			type: UnsignedByteType,
+			depthTexture: new DepthTexture(
+				pixelwidth,
+				pixelheight,
+				attributes.stencil ? UnsignedInt248Type : UnsignedIntType,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				attributes.stencil ? DepthStencilFormat : DepthFormat
+			),
+			stencilBuffer: attributes.stencil,
+			resolveDepthBuffer: false,
+			resolveStencilBuffer: false,
+		});
 
 		renderTarget._autoAllocateDepthBuffer = true;
 
-		const material = new MeshBasicMaterial( { color: 0xffffff, side: FrontSide } );
+		const material = new MeshBasicMaterial({
+			color: 0xffffff,
+			side: FrontSide,
+		});
 		material.map = renderTarget.texture;
 		material.map.offset.y = 1;
-		material.map.repeat.y = - 1;
-		const plane = new Mesh( geometry, material );
-		plane.position.copy( translation );
-		plane.quaternion.copy( quaternion );
+		material.map.repeat.y = -1;
+		const plane = new Mesh(geometry, material);
+		plane.position.copy(translation);
+		plane.quaternion.copy(quaternion);
 
 		const layer = {
-			type: 'quad',
+			type: "quad",
 			width: width,
 			height: height,
 			translation: translation,
@@ -697,32 +672,31 @@ class XRManager extends EventDispatcher {
 			plane: plane,
 			material: material,
 			rendercall: rendercall,
-			renderTarget: renderTarget };
+			renderTarget: renderTarget,
+		};
 
-		this._layers.push( layer );
+		this._layers.push(layer);
 
-		if ( this._session !== null ) {
-
-			layer.plane.material = new MeshBasicMaterial( { color: 0xffffff, side: FrontSide } );
+		if (this._session !== null) {
+			layer.plane.material = new MeshBasicMaterial({
+				color: 0xffffff,
+				side: FrontSide,
+			});
 			layer.plane.material.blending = CustomBlending;
 			layer.plane.material.blendEquation = AddEquation;
 			layer.plane.material.blendSrc = ZeroFactor;
 			layer.plane.material.blendDst = ZeroFactor;
 
-			layer.xrlayer = this._createXRLayer( layer );
+			layer.xrlayer = this._createXRLayer(layer);
 
 			const xrlayers = this._session.renderState.layers;
-			xrlayers.unshift( layer.xrlayer );
-			this._session.updateRenderState( { layers: xrlayers } );
-
+			xrlayers.unshift(layer.xrlayer);
+			this._session.updateRenderState({ layers: xrlayers });
 		} else {
-
 			renderTarget.isXRRenderTarget = false;
-
 		}
 
 		return plane;
-
 	}
 
 	/**
@@ -741,44 +715,59 @@ class XRManager extends EventDispatcher {
 	 * @param {Object} [attributes={}] - Allows to configure the layer's render target.
 	 * @return {Mesh} A mesh representing the cylindrical XR layer. This mesh should be added to the XR scene.
 	 */
-	createCylinderLayer( radius, centralAngle, aspectratio, translation, quaternion, pixelwidth, pixelheight, rendercall, attributes = {} ) {
-
-		const geometry = new CylinderGeometry( radius, radius, radius * centralAngle / aspectratio, 64, 64, true, Math.PI - centralAngle / 2, centralAngle );
-		const renderTarget = new XRRenderTarget(
-			pixelwidth,
-			pixelheight,
-			{
-				format: RGBAFormat,
-				type: UnsignedByteType,
-				depthTexture: new DepthTexture(
-					pixelwidth,
-					pixelheight,
-					attributes.stencil ? UnsignedInt248Type : UnsignedIntType,
-					undefined,
-					undefined,
-					undefined,
-					undefined,
-					undefined,
-					undefined,
-					attributes.stencil ? DepthStencilFormat : DepthFormat
-				),
-				stencilBuffer: attributes.stencil,
-				resolveDepthBuffer: false,
-				resolveStencilBuffer: false
-			} );
+	createCylinderLayer(
+		radius,
+		centralAngle,
+		aspectratio,
+		translation,
+		quaternion,
+		pixelwidth,
+		pixelheight,
+		rendercall,
+		attributes = {}
+	) {
+		const geometry = new CylinderGeometry(
+			radius,
+			radius,
+			(radius * centralAngle) / aspectratio,
+			64,
+			64,
+			true,
+			Math.PI - centralAngle / 2,
+			centralAngle
+		);
+		const renderTarget = new XRRenderTarget(pixelwidth, pixelheight, {
+			format: RGBAFormat,
+			type: UnsignedByteType,
+			depthTexture: new DepthTexture(
+				pixelwidth,
+				pixelheight,
+				attributes.stencil ? UnsignedInt248Type : UnsignedIntType,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				attributes.stencil ? DepthStencilFormat : DepthFormat
+			),
+			stencilBuffer: attributes.stencil,
+			resolveDepthBuffer: false,
+			resolveStencilBuffer: false,
+		});
 
 		renderTarget._autoAllocateDepthBuffer = true;
 
-		const material = new MeshBasicMaterial( { color: 0xffffff, side: BackSide } );
+		const material = new MeshBasicMaterial({ color: 0xffffff, side: BackSide });
 		material.map = renderTarget.texture;
 		material.map.offset.y = 1;
-		material.map.repeat.y = - 1;
-		const plane = new Mesh( geometry, material );
-		plane.position.copy( translation );
-		plane.quaternion.copy( quaternion );
+		material.map.repeat.y = -1;
+		const plane = new Mesh(geometry, material);
+		plane.position.copy(translation);
+		plane.quaternion.copy(quaternion);
 
 		const layer = {
-			type: 'cylinder',
+			type: "cylinder",
 			radius: radius,
 			centralAngle: centralAngle,
 			aspectratio: aspectratio,
@@ -789,32 +778,31 @@ class XRManager extends EventDispatcher {
 			plane: plane,
 			material: material,
 			rendercall: rendercall,
-			renderTarget: renderTarget };
+			renderTarget: renderTarget,
+		};
 
-		this._layers.push( layer );
+		this._layers.push(layer);
 
-		if ( this._session !== null ) {
-
-			layer.plane.material = new MeshBasicMaterial( { color: 0xffffff, side: BackSide } );
+		if (this._session !== null) {
+			layer.plane.material = new MeshBasicMaterial({
+				color: 0xffffff,
+				side: BackSide,
+			});
 			layer.plane.material.blending = CustomBlending;
 			layer.plane.material.blendEquation = AddEquation;
 			layer.plane.material.blendSrc = ZeroFactor;
 			layer.plane.material.blendDst = ZeroFactor;
 
-			layer.xrlayer = this._createXRLayer( layer );
+			layer.xrlayer = this._createXRLayer(layer);
 
 			const xrlayers = this._session.renderState.layers;
-			xrlayers.unshift( layer.xrlayer );
-			this._session.updateRenderState( { layers: xrlayers } );
-
+			xrlayers.unshift(layer.xrlayer);
+			this._session.updateRenderState({ layers: xrlayers });
 		} else {
-
 			renderTarget.isXRRenderTarget = false;
-
 		}
 
 		return plane;
-
 	}
 
 	/**
@@ -823,8 +811,7 @@ class XRManager extends EventDispatcher {
 	 * This method is usually called in your animation loop before rendering
 	 * the actual scene via `renderer.render( scene, camera );`.
 	 */
-	renderLayers( ) {
-
+	renderLayers() {
 		const translationObject = new Vector3();
 		const quaternionObject = new Quaternion();
 		const renderer = this._renderer;
@@ -835,65 +822,69 @@ class XRManager extends EventDispatcher {
 		this.isPresenting = false;
 
 		const rendererSize = new Vector2();
-		renderer.getSize( rendererSize );
+		renderer.getSize(rendererSize);
 		const rendererQuad = renderer._quad;
 
-		for ( const layer of this._layers ) {
-
+		for (const layer of this._layers) {
 			layer.renderTarget.isXRRenderTarget = this._session !== null;
-			layer.renderTarget._hasExternalTextures = layer.renderTarget.isXRRenderTarget;
+			layer.renderTarget._hasExternalTextures =
+				layer.renderTarget.isXRRenderTarget;
 
-			if ( layer.renderTarget.isXRRenderTarget && this._sessionUsesLayers ) {
+			if (layer.renderTarget.isXRRenderTarget && this._sessionUsesLayers) {
+				layer.xrlayer.transform = new XRRigidTransform(
+					layer.plane.getWorldPosition(translationObject),
+					layer.plane.getWorldQuaternion(quaternionObject)
+				);
 
-				layer.xrlayer.transform = new XRRigidTransform( layer.plane.getWorldPosition( translationObject ), layer.plane.getWorldQuaternion( quaternionObject ) );
-
-				const glSubImage = this._glBinding.getSubImage( layer.xrlayer, this._xrFrame );
+				const glSubImage = this._glBinding.getSubImage(
+					layer.xrlayer,
+					this._xrFrame
+				);
 				renderer.backend.setXRRenderTargetTextures(
 					layer.renderTarget,
 					glSubImage.colorTexture,
-					undefined );
+					undefined
+				);
 
-				renderer._setXRLayerSize( layer.renderTarget.width, layer.renderTarget.height );
-				renderer.setOutputRenderTarget( layer.renderTarget );
-				renderer.setRenderTarget( null );
+				renderer._setXRLayerSize(
+					layer.renderTarget.width,
+					layer.renderTarget.height
+				);
+				renderer.setOutputRenderTarget(layer.renderTarget);
+				renderer.setRenderTarget(null);
 				renderer._frameBufferTarget = null;
 
-				this._frameBufferTargets || ( this._frameBufferTargets = new WeakMap() );
-				const { frameBufferTarget, quad } = this._frameBufferTargets.get( layer.renderTarget ) || { frameBufferTarget: null, quad: null };
-				if ( ! frameBufferTarget ) {
-
-					renderer._quad = new QuadMesh( new NodeMaterial() );
-					this._frameBufferTargets.set( layer.renderTarget, { frameBufferTarget: renderer._getFrameBufferTarget(), quad: renderer._quad } );
-
+				this._frameBufferTargets || (this._frameBufferTargets = new WeakMap());
+				const { frameBufferTarget, quad } = this._frameBufferTargets.get(
+					layer.renderTarget
+				) || { frameBufferTarget: null, quad: null };
+				if (!frameBufferTarget) {
+					renderer._quad = new QuadMesh(new NodeMaterial());
+					this._frameBufferTargets.set(layer.renderTarget, {
+						frameBufferTarget: renderer._getFrameBufferTarget(),
+						quad: renderer._quad,
+					});
 				} else {
-
 					renderer._frameBufferTarget = frameBufferTarget;
 					renderer._quad = quad;
-
 				}
 
 				layer.rendercall();
 
 				renderer._frameBufferTarget = null;
-
 			} else {
-
-				renderer.setRenderTarget( layer.renderTarget );
+				renderer.setRenderTarget(layer.renderTarget);
 				layer.rendercall();
-
 			}
-
 		}
 
-		renderer.setRenderTarget( null );
-		renderer.setOutputRenderTarget( rendererOutputTarget );
+		renderer.setRenderTarget(null);
+		renderer.setOutputRenderTarget(rendererOutputTarget);
 		renderer._frameBufferTarget = rendererFramebufferTarget;
-		renderer._setXRLayerSize( rendererSize.x, rendererSize.y );
+		renderer._setXRLayerSize(rendererSize.x, rendererSize.y);
 		renderer._quad = rendererQuad;
 		this.isPresenting = wasPresenting;
-
 	}
-
 
 	/**
 	 * Returns the current XR session.
@@ -901,9 +892,7 @@ class XRManager extends EventDispatcher {
 	 * @return {?XRSession} The XR session. Returns `null` when used outside a XR session.
 	 */
 	getSession() {
-
 		return this._session;
-
 	}
 
 	/**
@@ -915,8 +904,7 @@ class XRManager extends EventDispatcher {
 	 * @param {XRSession} session - The XR session to set.
 	 * @return {Promise} A Promise that resolves when the session has been set.
 	 */
-	async setSession( session ) {
-
+	async setSession(session) {
 		const renderer = this._renderer;
 		const backend = renderer.backend;
 
@@ -926,71 +914,95 @@ class XRManager extends EventDispatcher {
 
 		this._session = session;
 
-		if ( session !== null ) {
+		if (session !== null) {
+			if (backend.isWebGPUBackend === true)
+				throw new Error(
+					'THREE.XRManager: XR is currently not supported with a WebGPU backend. Use WebGL by passing "{ forceWebGL: true }" to the constructor of the renderer.'
+				);
 
-			if ( backend.isWebGPUBackend === true ) throw new Error( 'THREE.XRManager: XR is currently not supported with a WebGPU backend. Use WebGL by passing "{ forceWebGL: true }" to the constructor of the renderer.' );
-
-			session.addEventListener( 'select', this._onSessionEvent );
-			session.addEventListener( 'selectstart', this._onSessionEvent );
-			session.addEventListener( 'selectend', this._onSessionEvent );
-			session.addEventListener( 'squeeze', this._onSessionEvent );
-			session.addEventListener( 'squeezestart', this._onSessionEvent );
-			session.addEventListener( 'squeezeend', this._onSessionEvent );
-			session.addEventListener( 'end', this._onSessionEnd );
-			session.addEventListener( 'inputsourceschange', this._onInputSourcesChange );
+			session.addEventListener("select", this._onSessionEvent);
+			session.addEventListener("selectstart", this._onSessionEvent);
+			session.addEventListener("selectend", this._onSessionEvent);
+			session.addEventListener("squeeze", this._onSessionEvent);
+			session.addEventListener("squeezestart", this._onSessionEvent);
+			session.addEventListener("squeezeend", this._onSessionEvent);
+			session.addEventListener("end", this._onSessionEnd);
+			session.addEventListener(
+				"inputsourceschange",
+				this._onInputSourcesChange
+			);
 
 			await backend.makeXRCompatible();
 
 			this._currentPixelRatio = renderer.getPixelRatio();
-			renderer.getSize( this._currentSize );
+			renderer.getSize(this._currentSize);
 
 			this._currentAnimationContext = renderer._animation.getContext();
 			this._currentAnimationLoop = renderer._animation.getAnimationLoop();
 			renderer._animation.stop();
 
 			//
+			const sessionHasLayers =
+				session.enabledFeatures?.includes("layers") ?? false;
 
-			if ( this._supportsLayers === true ) {
-
-				// default path using XRProjectionLayer
-
+			if (this._supportsLayers === true && sessionHasLayers) {
 				let depthFormat = null;
 				let depthType = null;
 				let glDepthFormat = null;
 
-				if ( renderer.depth ) {
-
-					glDepthFormat = renderer.stencil ? gl.DEPTH24_STENCIL8 : gl.DEPTH_COMPONENT24;
+				if (renderer.depth) {
+					glDepthFormat = renderer.stencil
+						? gl.DEPTH24_STENCIL8
+						: gl.DEPTH_COMPONENT24;
 					depthFormat = renderer.stencil ? DepthStencilFormat : DepthFormat;
 					depthType = renderer.stencil ? UnsignedInt248Type : UnsignedIntType;
-
 				}
 
 				const projectionlayerInit = {
 					colorFormat: gl.RGBA8,
 					depthFormat: glDepthFormat,
 					scaleFactor: this._framebufferScaleFactor,
-					clearOnAccess: false
+					clearOnAccess: false,
 				};
 
-				if ( this._useMultiviewIfPossible && renderer.hasFeature( 'OVR_multiview2' ) ) {
-
-					projectionlayerInit.textureType = 'texture-array';
+				if (
+					this._useMultiviewIfPossible &&
+					renderer.hasFeature("OVR_multiview2")
+				) {
+					projectionlayerInit.textureType = "texture-array";
 					this._useMultiview = true;
-
 				}
 
-				this._glBinding = this.getBinding();
-				const glProjLayer = this._glBinding.createProjectionLayer( projectionlayerInit );
-				const layersArray = [ glProjLayer ];
+				// this._glBinding = this.getBinding();
+				this._glBinding = new XRWebGLBinding(session, gl);
+				const glProjLayer =
+					this._glBinding.createProjectionLayer(projectionlayerInit);
 
 				this._glProjLayer = glProjLayer;
 
-				renderer.setPixelRatio( 1 );
-				renderer._setXRLayerSize( glProjLayer.textureWidth, glProjLayer.textureHeight );
+				// Register layer with session IMMEDIATELY before any await
+				session.updateRenderState({ layers: [glProjLayer] });
+
+				renderer.setPixelRatio(1);
+				renderer._setXRLayerSize(
+					glProjLayer.textureWidth,
+					glProjLayer.textureHeight
+				);
 
 				const depth = this._useMultiview ? 2 : 1;
-				const depthTexture = new DepthTexture( glProjLayer.textureWidth, glProjLayer.textureHeight, depthType, undefined, undefined, undefined, undefined, undefined, undefined, depthFormat, depth );
+				const depthTexture = new DepthTexture(
+					glProjLayer.textureWidth,
+					glProjLayer.textureHeight,
+					depthType,
+					undefined,
+					undefined,
+					undefined,
+					undefined,
+					undefined,
+					undefined,
+					depthFormat,
+					depth
+				);
 
 				this._xrRenderTarget = new XRRenderTarget(
 					glProjLayer.textureWidth,
@@ -1002,43 +1014,45 @@ class XRManager extends EventDispatcher {
 						depthTexture: depthTexture,
 						stencilBuffer: renderer.stencil,
 						samples: attributes.antialias ? 4 : 0,
-						resolveDepthBuffer: ( glProjLayer.ignoreDepthValues === false ),
-						resolveStencilBuffer: ( glProjLayer.ignoreDepthValues === false ),
+						resolveDepthBuffer: glProjLayer.ignoreDepthValues === false,
+						resolveStencilBuffer: glProjLayer.ignoreDepthValues === false,
 						depth: this._useMultiview ? 2 : 1,
-						multiview: this._useMultiview
-					} );
+						multiview: this._useMultiview,
+					}
+				);
 
 				this._xrRenderTarget._hasExternalTextures = true;
 				this._xrRenderTarget.depth = this._useMultiview ? 2 : 1;
 
-				this._sessionUsesLayers = session.enabledFeatures.includes( 'layers' );
+				this._sessionUsesLayers =
+					session.enabledFeatures?.includes("layers") ?? false;
 
-				this._referenceSpace = await session.requestReferenceSpace( this.getReferenceSpaceType() );
+				this._referenceSpace = await session.requestReferenceSpace(
+					this.getReferenceSpaceType()
+				);
 
-				if ( this._sessionUsesLayers ) {
+				// Handle additional quad/cylinder layers AFTER the await
+				if (this._sessionUsesLayers && this._layers.length > 0) {
+					const layersArray = [glProjLayer];
 
-					// switch layers to native
-					for ( const layer of this._layers ) {
-
-						// change material so it "punches" out a hole to show the XR Layer.
-						layer.plane.material = new MeshBasicMaterial( { color: 0xffffff, side: layer.type === 'cylinder' ? BackSide : FrontSide } );
+					for (const layer of this._layers) {
+						layer.plane.material = new MeshBasicMaterial({
+							color: 0xffffff,
+							side: layer.type === "cylinder" ? BackSide : FrontSide,
+						});
 						layer.plane.material.blending = CustomBlending;
 						layer.plane.material.blendEquation = AddEquation;
 						layer.plane.material.blendSrc = ZeroFactor;
 						layer.plane.material.blendDst = ZeroFactor;
 
-						layer.xrlayer = this._createXRLayer( layer );
+						layer.xrlayer = this._createXRLayer(layer);
 
-						layersArray.unshift( layer.xrlayer );
-
+						layersArray.unshift(layer.xrlayer);
 					}
 
+					session.updateRenderState({ layers: layersArray });
 				}
-
-				session.updateRenderState( { layers: layersArray } );
-
 			} else {
-
 				// fallback to XRWebGLLayer
 
 				const layerInit = {
@@ -1046,16 +1060,19 @@ class XRManager extends EventDispatcher {
 					alpha: true,
 					depth: renderer.depth,
 					stencil: renderer.stencil,
-					framebufferScaleFactor: this.getFramebufferScaleFactor()
+					framebufferScaleFactor: this.getFramebufferScaleFactor(),
 				};
 
-				const glBaseLayer = new XRWebGLLayer( session, gl, layerInit );
+				const glBaseLayer = new XRWebGLLayer(session, gl, layerInit);
 				this._glBaseLayer = glBaseLayer;
 
-				session.updateRenderState( { baseLayer: glBaseLayer } );
+				session.updateRenderState({ baseLayer: glBaseLayer });
 
-				renderer.setPixelRatio( 1 );
-				renderer._setXRLayerSize( glBaseLayer.framebufferWidth, glBaseLayer.framebufferHeight );
+				renderer.setPixelRatio(1);
+				renderer._setXRLayerSize(
+					glBaseLayer.framebufferWidth,
+					glBaseLayer.framebufferHeight
+				);
 
 				this._xrRenderTarget = new XRRenderTarget(
 					glBaseLayer.framebufferWidth,
@@ -1065,30 +1082,29 @@ class XRManager extends EventDispatcher {
 						type: UnsignedByteType,
 						colorSpace: renderer.outputColorSpace,
 						stencilBuffer: renderer.stencil,
-						resolveDepthBuffer: ( glBaseLayer.ignoreDepthValues === false ),
-						resolveStencilBuffer: ( glBaseLayer.ignoreDepthValues === false ),
+						resolveDepthBuffer: glBaseLayer.ignoreDepthValues === false,
+						resolveStencilBuffer: glBaseLayer.ignoreDepthValues === false,
 					}
 				);
 
 				this._xrRenderTarget._isOpaqueFramebuffer = true;
-				this._referenceSpace = await session.requestReferenceSpace( this.getReferenceSpaceType() );
-
+				this._referenceSpace = await session.requestReferenceSpace(
+					this.getReferenceSpaceType()
+				);
 			}
 
 			//
 
-			this.setFoveation( this.getFoveation() );
+			this.setFoveation(this.getFoveation());
 
-			renderer._animation.setAnimationLoop( this._onAnimationFrame );
-			renderer._animation.setContext( session );
+			renderer._animation.setAnimationLoop(this._onAnimationFrame);
+			renderer._animation.setContext(session);
 			renderer._animation.start();
 
 			this.isPresenting = true;
 
-			this.dispatchEvent( { type: 'sessionstart' } );
-
+			this.dispatchEvent({ type: "sessionstart" });
 		}
-
 	}
 
 	/**
@@ -1098,11 +1114,10 @@ class XRManager extends EventDispatcher {
 	 *
 	 * @param {PerspectiveCamera} camera - The camera.
 	 */
-	updateCamera( camera ) {
-
+	updateCamera(camera) {
 		const session = this._session;
 
-		if ( session === null ) return;
+		if (session === null) return;
 
 		const depthNear = camera.near;
 		const depthFar = camera.far;
@@ -1115,18 +1130,19 @@ class XRManager extends EventDispatcher {
 		cameraXR.far = cameraR.far = cameraL.far = depthFar;
 		cameraXR.isMultiViewCamera = this._useMultiview;
 
-		if ( this._currentDepthNear !== cameraXR.near || this._currentDepthFar !== cameraXR.far ) {
-
+		if (
+			this._currentDepthNear !== cameraXR.near ||
+			this._currentDepthFar !== cameraXR.far
+		) {
 			// Note that the new renderState won't apply until the next frame. See #18320
 
-			session.updateRenderState( {
+			session.updateRenderState({
 				depthNear: cameraXR.near,
-				depthFar: cameraXR.far
-			} );
+				depthFar: cameraXR.far,
+			});
 
 			this._currentDepthNear = cameraXR.near;
 			this._currentDepthFar = cameraXR.far;
-
 		}
 
 		// inherit camera layers and enable eye layers (1 = left, 2 = right)
@@ -1134,37 +1150,28 @@ class XRManager extends EventDispatcher {
 		cameraL.layers.mask = cameraXR.layers.mask & 0b011;
 		cameraR.layers.mask = cameraXR.layers.mask & 0b101;
 
-
 		const parent = camera.parent;
 		const cameras = cameraXR.cameras;
 
-		updateCamera( cameraXR, parent );
+		updateCamera(cameraXR, parent);
 
-		for ( let i = 0; i < cameras.length; i ++ ) {
-
-			updateCamera( cameras[ i ], parent );
-
+		for (let i = 0; i < cameras.length; i++) {
+			updateCamera(cameras[i], parent);
 		}
 
 		// update projection matrix for proper view frustum culling
 
-		if ( cameras.length === 2 ) {
-
-			setProjectionFromUnion( cameraXR, cameraL, cameraR );
-
+		if (cameras.length === 2) {
+			setProjectionFromUnion(cameraXR, cameraL, cameraR);
 		} else {
-
 			// assume single camera setup (AR)
 
-			cameraXR.projectionMatrix.copy( cameraL.projectionMatrix );
-
+			cameraXR.projectionMatrix.copy(cameraL.projectionMatrix);
 		}
 
 		// update user camera and its children
 
-		updateUserCamera( camera, cameraXR, parent );
-
-
+		updateUserCamera(camera, cameraXR, parent);
 	}
 
 	/**
@@ -1174,21 +1181,16 @@ class XRManager extends EventDispatcher {
 	 * @param {number} index - The controller index.
 	 * @return {WebXRController} The XR controller.
 	 */
-	_getController( index ) {
+	_getController(index) {
+		let controller = this._controllers[index];
 
-		let controller = this._controllers[ index ];
-
-		if ( controller === undefined ) {
-
+		if (controller === undefined) {
 			controller = new WebXRController();
-			this._controllers[ index ] = controller;
-
+			this._controllers[index] = controller;
 		}
 
 		return controller;
-
 	}
-
 }
 
 /**
@@ -1201,12 +1203,11 @@ class XRManager extends EventDispatcher {
  * @param {PerspectiveCamera} cameraL - The left camera.
  * @param {PerspectiveCamera} cameraR - The right camera.
  */
-function setProjectionFromUnion( camera, cameraL, cameraR ) {
+function setProjectionFromUnion(camera, cameraL, cameraR) {
+	_cameraLPos.setFromMatrixPosition(cameraL.matrixWorld);
+	_cameraRPos.setFromMatrixPosition(cameraR.matrixWorld);
 
-	_cameraLPos.setFromMatrixPosition( cameraL.matrixWorld );
-	_cameraRPos.setFromMatrixPosition( cameraR.matrixWorld );
-
-	const ipd = _cameraLPos.distanceTo( _cameraRPos );
+	const ipd = _cameraLPos.distanceTo(_cameraRPos);
 
 	const projL = cameraL.projectionMatrix.elements;
 	const projR = cameraR.projectionMatrix.elements;
@@ -1214,54 +1215,60 @@ function setProjectionFromUnion( camera, cameraL, cameraR ) {
 	// VR systems will have identical far and near planes, and
 	// most likely identical top and bottom frustum extents.
 	// Use the left camera for these values.
-	const near = projL[ 14 ] / ( projL[ 10 ] - 1 );
-	const far = projL[ 14 ] / ( projL[ 10 ] + 1 );
-	const topFov = ( projL[ 9 ] + 1 ) / projL[ 5 ];
-	const bottomFov = ( projL[ 9 ] - 1 ) / projL[ 5 ];
+	const near = projL[14] / (projL[10] - 1);
+	const far = projL[14] / (projL[10] + 1);
+	const topFov = (projL[9] + 1) / projL[5];
+	const bottomFov = (projL[9] - 1) / projL[5];
 
-	const leftFov = ( projL[ 8 ] - 1 ) / projL[ 0 ];
-	const rightFov = ( projR[ 8 ] + 1 ) / projR[ 0 ];
+	const leftFov = (projL[8] - 1) / projL[0];
+	const rightFov = (projR[8] + 1) / projR[0];
 	const left = near * leftFov;
 	const right = near * rightFov;
 
 	// Calculate the new camera's position offset from the
 	// left camera. xOffset should be roughly half `ipd`.
-	const zOffset = ipd / ( - leftFov + rightFov );
-	const xOffset = zOffset * - leftFov;
+	const zOffset = ipd / (-leftFov + rightFov);
+	const xOffset = zOffset * -leftFov;
 
 	// TODO: Better way to apply this offset?
-	cameraL.matrixWorld.decompose( camera.position, camera.quaternion, camera.scale );
-	camera.translateX( xOffset );
-	camera.translateZ( zOffset );
-	camera.matrixWorld.compose( camera.position, camera.quaternion, camera.scale );
-	camera.matrixWorldInverse.copy( camera.matrixWorld ).invert();
+	cameraL.matrixWorld.decompose(
+		camera.position,
+		camera.quaternion,
+		camera.scale
+	);
+	camera.translateX(xOffset);
+	camera.translateZ(zOffset);
+	camera.matrixWorld.compose(camera.position, camera.quaternion, camera.scale);
+	camera.matrixWorldInverse.copy(camera.matrixWorld).invert();
 
 	// Check if the projection uses an infinite far plane.
-	if ( projL[ 10 ] === - 1.0 ) {
-
+	if (projL[10] === -1.0) {
 		// Use the projection matrix from the left eye.
 		// The camera offset is sufficient to include the view volumes
 		// of both eyes (assuming symmetric projections).
-		camera.projectionMatrix.copy( cameraL.projectionMatrix );
-		camera.projectionMatrixInverse.copy( cameraL.projectionMatrixInverse );
-
+		camera.projectionMatrix.copy(cameraL.projectionMatrix);
+		camera.projectionMatrixInverse.copy(cameraL.projectionMatrixInverse);
 	} else {
-
 		// Find the union of the frustum values of the cameras and scale
 		// the values so that the near plane's position does not change in world space,
 		// although must now be relative to the new union camera.
 		const near2 = near + zOffset;
 		const far2 = far + zOffset;
 		const left2 = left - xOffset;
-		const right2 = right + ( ipd - xOffset );
-		const top2 = topFov * far / far2 * near2;
-		const bottom2 = bottomFov * far / far2 * near2;
+		const right2 = right + (ipd - xOffset);
+		const top2 = ((topFov * far) / far2) * near2;
+		const bottom2 = ((bottomFov * far) / far2) * near2;
 
-		camera.projectionMatrix.makePerspective( left2, right2, top2, bottom2, near2, far2 );
-		camera.projectionMatrixInverse.copy( camera.projectionMatrix ).invert();
-
+		camera.projectionMatrix.makePerspective(
+			left2,
+			right2,
+			top2,
+			bottom2,
+			near2,
+			far2
+		);
+		camera.projectionMatrixInverse.copy(camera.projectionMatrix).invert();
 	}
-
 }
 
 /**
@@ -1271,20 +1278,14 @@ function setProjectionFromUnion( camera, cameraL, cameraR ) {
  * @param {Camera} camera - The camera to update.
  * @param {Object3D} parent - The parent 3D object.
  */
-function updateCamera( camera, parent ) {
-
-	if ( parent === null ) {
-
-		camera.matrixWorld.copy( camera.matrix );
-
+function updateCamera(camera, parent) {
+	if (parent === null) {
+		camera.matrixWorld.copy(camera.matrix);
 	} else {
-
-		camera.matrixWorld.multiplyMatrices( parent.matrixWorld, camera.matrix );
-
+		camera.matrixWorld.multiplyMatrices(parent.matrixWorld, camera.matrix);
 	}
 
-	camera.matrixWorldInverse.copy( camera.matrixWorld ).invert();
-
+	camera.matrixWorldInverse.copy(camera.matrixWorld).invert();
 }
 
 /**
@@ -1295,82 +1296,68 @@ function updateCamera( camera, parent ) {
  * @param {ArrayCamera} cameraXR - The XR camera.
  * @param {Object3D} parent - The parent 3D object.
  */
-function updateUserCamera( camera, cameraXR, parent ) {
-
-	if ( parent === null ) {
-
-		camera.matrix.copy( cameraXR.matrixWorld );
-
+function updateUserCamera(camera, cameraXR, parent) {
+	if (parent === null) {
+		camera.matrix.copy(cameraXR.matrixWorld);
 	} else {
-
-		camera.matrix.copy( parent.matrixWorld );
+		camera.matrix.copy(parent.matrixWorld);
 		camera.matrix.invert();
-		camera.matrix.multiply( cameraXR.matrixWorld );
-
+		camera.matrix.multiply(cameraXR.matrixWorld);
 	}
 
-	camera.matrix.decompose( camera.position, camera.quaternion, camera.scale );
-	camera.updateMatrixWorld( true );
+	camera.matrix.decompose(camera.position, camera.quaternion, camera.scale);
+	camera.updateMatrixWorld(true);
 
-	camera.projectionMatrix.copy( cameraXR.projectionMatrix );
-	camera.projectionMatrixInverse.copy( cameraXR.projectionMatrixInverse );
+	camera.projectionMatrix.copy(cameraXR.projectionMatrix);
+	camera.projectionMatrixInverse.copy(cameraXR.projectionMatrixInverse);
 
-	if ( camera.isPerspectiveCamera ) {
-
-		camera.fov = RAD2DEG * 2 * Math.atan( 1 / camera.projectionMatrix.elements[ 5 ] );
+	if (camera.isPerspectiveCamera) {
+		camera.fov =
+			RAD2DEG * 2 * Math.atan(1 / camera.projectionMatrix.elements[5]);
 		camera.zoom = 1;
-
 	}
-
 }
 
-function onSessionEvent( event ) {
+function onSessionEvent(event) {
+	const controllerIndex = this._controllerInputSources.indexOf(
+		event.inputSource
+	);
 
-	const controllerIndex = this._controllerInputSources.indexOf( event.inputSource );
-
-	if ( controllerIndex === - 1 ) {
-
+	if (controllerIndex === -1) {
 		return;
-
 	}
 
-	const controller = this._controllers[ controllerIndex ];
+	const controller = this._controllers[controllerIndex];
 
-	if ( controller !== undefined ) {
-
+	if (controller !== undefined) {
 		const referenceSpace = this.getReferenceSpace();
 
-		controller.update( event.inputSource, event.frame, referenceSpace );
-		controller.dispatchEvent( { type: event.type, data: event.inputSource } );
-
+		controller.update(event.inputSource, event.frame, referenceSpace);
+		controller.dispatchEvent({ type: event.type, data: event.inputSource });
 	}
-
 }
 
 function onSessionEnd() {
-
 	const session = this._session;
 	const renderer = this._renderer;
 
-	session.removeEventListener( 'select', this._onSessionEvent );
-	session.removeEventListener( 'selectstart', this._onSessionEvent );
-	session.removeEventListener( 'selectend', this._onSessionEvent );
-	session.removeEventListener( 'squeeze', this._onSessionEvent );
-	session.removeEventListener( 'squeezestart', this._onSessionEvent );
-	session.removeEventListener( 'squeezeend', this._onSessionEvent );
-	session.removeEventListener( 'end', this._onSessionEnd );
-	session.removeEventListener( 'inputsourceschange', this._onInputSourcesChange );
+	session.removeEventListener("select", this._onSessionEvent);
+	session.removeEventListener("selectstart", this._onSessionEvent);
+	session.removeEventListener("selectend", this._onSessionEvent);
+	session.removeEventListener("squeeze", this._onSessionEvent);
+	session.removeEventListener("squeezestart", this._onSessionEvent);
+	session.removeEventListener("squeezeend", this._onSessionEvent);
+	session.removeEventListener("end", this._onSessionEnd);
+	session.removeEventListener("inputsourceschange", this._onInputSourcesChange);
 
-	for ( let i = 0; i < this._controllers.length; i ++ ) {
+	for (let i = 0; i < this._controllers.length; i++) {
+		const inputSource = this._controllerInputSources[i];
 
-		const inputSource = this._controllerInputSources[ i ];
+		if (inputSource === null) continue;
 
-		if ( inputSource === null ) continue;
+		this._controllerInputSources[i] = null;
 
-		this._controllerInputSources[ i ] = null;
-
-		this._controllers[ i ].disconnect( inputSource );
-
+		this._controllers[i].disconnect(inputSource);
 	}
 
 	this._currentDepthNear = null;
@@ -1387,10 +1374,8 @@ function onSessionEnd() {
 	this._glProjLayer = null;
 
 	// switch layers back to emulated
-	if ( this._sessionUsesLayers === true ) {
-
-		for ( const layer of this._layers ) {
-
+	if (this._sessionUsesLayers === true) {
+		for (const layer of this._layers) {
 			// Recreate layer render target to reset state
 			layer.renderTarget = new XRRenderTarget(
 				layer.pixelwidth,
@@ -1412,19 +1397,18 @@ function onSessionEnd() {
 					),
 					stencilBuffer: layer.stencilBuffer,
 					resolveDepthBuffer: false,
-					resolveStencilBuffer: false
-				} );
+					resolveStencilBuffer: false,
+				}
+			);
 
 			layer.renderTarget.isXRRenderTarget = false;
 
 			layer.plane.material = layer.material;
 			layer.material.map = layer.renderTarget.texture;
 			layer.material.map.offset.y = 1;
-			layer.material.map.repeat.y = - 1;
+			layer.material.map.repeat.y = -1;
 			delete layer.xrlayer;
-
 		}
-
 	}
 
 	//
@@ -1433,123 +1417,96 @@ function onSessionEnd() {
 	this._useMultiview = false;
 
 	renderer._animation.stop();
-	renderer._animation.setAnimationLoop( this._currentAnimationLoop );
-	renderer._animation.setContext( this._currentAnimationContext );
+	renderer._animation.setAnimationLoop(this._currentAnimationLoop);
+	renderer._animation.setContext(this._currentAnimationContext);
 	renderer._animation.start();
 
-	renderer.setPixelRatio( this._currentPixelRatio );
-	renderer.setSize( this._currentSize.width, this._currentSize.height, false );
+	renderer.setPixelRatio(this._currentPixelRatio);
+	renderer.setSize(this._currentSize.width, this._currentSize.height, false);
 
-	this.dispatchEvent( { type: 'sessionend' } );
-
+	this.dispatchEvent({ type: "sessionend" });
 }
 
-function onInputSourcesChange( event ) {
-
+function onInputSourcesChange(event) {
 	const controllers = this._controllers;
 	const controllerInputSources = this._controllerInputSources;
 
 	// Notify disconnected
 
-	for ( let i = 0; i < event.removed.length; i ++ ) {
+	for (let i = 0; i < event.removed.length; i++) {
+		const inputSource = event.removed[i];
+		const index = controllerInputSources.indexOf(inputSource);
 
-		const inputSource = event.removed[ i ];
-		const index = controllerInputSources.indexOf( inputSource );
-
-		if ( index >= 0 ) {
-
-			controllerInputSources[ index ] = null;
-			controllers[ index ].disconnect( inputSource );
-
+		if (index >= 0) {
+			controllerInputSources[index] = null;
+			controllers[index].disconnect(inputSource);
 		}
-
 	}
 
 	// Notify connected
 
-	for ( let i = 0; i < event.added.length; i ++ ) {
+	for (let i = 0; i < event.added.length; i++) {
+		const inputSource = event.added[i];
 
-		const inputSource = event.added[ i ];
+		let controllerIndex = controllerInputSources.indexOf(inputSource);
 
-		let controllerIndex = controllerInputSources.indexOf( inputSource );
-
-		if ( controllerIndex === - 1 ) {
-
+		if (controllerIndex === -1) {
 			// Assign input source a controller that currently has no input source
 
-			for ( let i = 0; i < controllers.length; i ++ ) {
-
-				if ( i >= controllerInputSources.length ) {
-
-					controllerInputSources.push( inputSource );
+			for (let i = 0; i < controllers.length; i++) {
+				if (i >= controllerInputSources.length) {
+					controllerInputSources.push(inputSource);
 					controllerIndex = i;
 					break;
-
-				} else if ( controllerInputSources[ i ] === null ) {
-
-					controllerInputSources[ i ] = inputSource;
+				} else if (controllerInputSources[i] === null) {
+					controllerInputSources[i] = inputSource;
 					controllerIndex = i;
 					break;
-
 				}
-
 			}
 
 			// If all controllers do currently receive input we ignore new ones
 
-			if ( controllerIndex === - 1 ) break;
-
+			if (controllerIndex === -1) break;
 		}
 
-		const controller = controllers[ controllerIndex ];
+		const controller = controllers[controllerIndex];
 
-		if ( controller ) {
-
-			controller.connect( inputSource );
-
+		if (controller) {
+			controller.connect(inputSource);
 		}
-
 	}
-
 }
 
 // Creation method for native WebXR layers
-function createXRLayer( layer ) {
-
-	if ( layer.type === 'quad' ) {
-
-		return this._glBinding.createQuadLayer( {
-			transform: new XRRigidTransform( layer.translation, layer.quaternion ),
+function createXRLayer(layer) {
+	if (layer.type === "quad") {
+		return this._glBinding.createQuadLayer({
+			transform: new XRRigidTransform(layer.translation, layer.quaternion),
 			width: layer.width / 2,
 			height: layer.height / 2,
 			space: this._referenceSpace,
 			viewPixelWidth: layer.pixelwidth,
 			viewPixelHeight: layer.pixelheight,
-			clearOnAccess: false
-		} );
-
+			clearOnAccess: false,
+		});
 	} else {
-
-		return this._glBinding.createCylinderLayer( {
-			transform: new XRRigidTransform( layer.translation, layer.quaternion ),
+		return this._glBinding.createCylinderLayer({
+			transform: new XRRigidTransform(layer.translation, layer.quaternion),
 			radius: layer.radius,
 			centralAngle: layer.centralAngle,
 			aspectRatio: layer.aspectRatio,
 			space: this._referenceSpace,
 			viewPixelWidth: layer.pixelwidth,
 			viewPixelHeight: layer.pixelheight,
-			clearOnAccess: false
-		} );
-
+			clearOnAccess: false,
+		});
 	}
-
 }
 
 // Animation Loop
-
-function onAnimationFrame( time, frame ) {
-
-	if ( frame === undefined ) return;
+function onAnimationFrame(time, frame) {
+	if (frame === undefined) return;
 
 	const cameraXR = this._cameraXR;
 	const renderer = this._renderer;
@@ -1558,120 +1515,116 @@ function onAnimationFrame( time, frame ) {
 	const glBaseLayer = this._glBaseLayer;
 
 	const referenceSpace = this.getReferenceSpace();
-	const pose = frame.getViewerPose( referenceSpace );
+	const pose = frame.getViewerPose(referenceSpace);
 
 	this._xrFrame = frame;
 
-	if ( pose !== null ) {
-
+	if (pose !== null) {
 		const views = pose.views;
 
-		if ( this._glBaseLayer !== null ) {
-
-			backend.setXRTarget( glBaseLayer.framebuffer );
-
+		if (this._glBaseLayer !== null) {
+			backend.setXRTarget(glBaseLayer.framebuffer);
+			renderer.setOutputRenderTarget(this._xrRenderTarget);
 		}
 
 		let cameraXRNeedsUpdate = false;
 
-		// check if it's necessary to rebuild cameraXR's camera list
-
-		if ( views.length !== cameraXR.cameras.length ) {
-
+		if (views.length !== cameraXR.cameras.length) {
 			cameraXR.cameras.length = 0;
 			cameraXRNeedsUpdate = true;
-
 		}
 
-		for ( let i = 0; i < views.length; i ++ ) {
+		for (let i = 0; i < views.length; i++) {
+			const view = views[i];
 
-			const view = views[ i ];
+			let viewport = null;
 
-			let viewport;
+			if (this._glBaseLayer !== null) {
+				viewport = this._glBaseLayer.getViewport(view);
+			} else if (this._glProjLayer !== null) {
+				// console.log("glProjLayer:", this._glProjLayer);
+				// console.log("glBinding:", this._glBinding);
+				// console.log("frame active:", frame.session === this._session);
 
-			if ( this._supportsLayers === true ) {
+				console.log(
+					"session.renderState.layers:",
+					this._session.renderState.layers
+				);
+				console.log(
+					"glProjLayer in layers:",
+					this._session.renderState.layers?.includes(this._glProjLayer)
+				);
 
-				const glSubImage = this._glBinding.getViewSubImage( this._glProjLayer, view );
+				const glSubImage = this._glBinding.getViewSubImage(
+					this._glProjLayer,
+					view
+				);
+
 				viewport = glSubImage.viewport;
 
-				// For side-by-side projection, we only produce a single texture for both eyes.
-				if ( i === 0 ) {
-
+				if (i === 0) {
 					backend.setXRRenderTargetTextures(
 						this._xrRenderTarget,
 						glSubImage.colorTexture,
-						( this._glProjLayer.ignoreDepthValues && ! this._useMultiview ) ? undefined : glSubImage.depthStencilTexture
+						this._glProjLayer.ignoreDepthValues && !this._useMultiview
+							? undefined
+							: glSubImage.depthStencilTexture
 					);
-
+					renderer.setOutputRenderTarget(this._xrRenderTarget);
 				}
-
-			} else {
-
-				viewport = glBaseLayer.getViewport( view );
-
 			}
 
-			let camera = this._cameras[ i ];
+			let camera = this._cameras[i];
 
-			if ( camera === undefined ) {
-
+			if (camera === undefined) {
 				camera = new PerspectiveCamera();
-				camera.layers.enable( i );
+				camera.layers.enable(i);
 				camera.viewport = new Vector4();
-				this._cameras[ i ] = camera;
-
+				this._cameras[i] = camera;
 			}
 
-			camera.matrix.fromArray( view.transform.matrix );
-			camera.matrix.decompose( camera.position, camera.quaternion, camera.scale );
-			camera.projectionMatrix.fromArray( view.projectionMatrix );
-			camera.projectionMatrixInverse.copy( camera.projectionMatrix ).invert();
-			camera.viewport.set( viewport.x, viewport.y, viewport.width, viewport.height );
+			camera.matrix.fromArray(view.transform.matrix);
+			camera.matrix.decompose(camera.position, camera.quaternion, camera.scale);
+			camera.projectionMatrix.fromArray(view.projectionMatrix);
+			camera.projectionMatrixInverse.copy(camera.projectionMatrix).invert();
+			camera.viewport.set(
+				viewport.x,
+				viewport.y,
+				viewport.width,
+				viewport.height
+			);
 
-			if ( i === 0 ) {
-
-				cameraXR.matrix.copy( camera.matrix );
-				cameraXR.matrix.decompose( cameraXR.position, cameraXR.quaternion, cameraXR.scale );
-
+			if (i === 0) {
+				cameraXR.matrix.copy(camera.matrix);
+				cameraXR.matrix.decompose(
+					cameraXR.position,
+					cameraXR.quaternion,
+					cameraXR.scale
+				);
 			}
 
-			if ( cameraXRNeedsUpdate === true ) {
-
-				cameraXR.cameras.push( camera );
-
+			if (cameraXRNeedsUpdate === true) {
+				cameraXR.cameras.push(camera);
 			}
-
 		}
-
-		renderer.setOutputRenderTarget( this._xrRenderTarget );
-
 	}
 
-	//
+	for (let i = 0; i < this._controllers.length; i++) {
+		const inputSource = this._controllerInputSources[i];
+		const controller = this._controllers[i];
 
-	for ( let i = 0; i < this._controllers.length; i ++ ) {
-
-		const inputSource = this._controllerInputSources[ i ];
-		const controller = this._controllers[ i ];
-
-		if ( inputSource !== null && controller !== undefined ) {
-
-			controller.update( inputSource, frame, referenceSpace );
-
+		if (inputSource !== null && controller !== undefined) {
+			controller.update(inputSource, frame, referenceSpace);
 		}
-
 	}
 
-	if ( this._currentAnimationLoop ) this._currentAnimationLoop( time, frame );
+	if (this._currentAnimationLoop) this._currentAnimationLoop(time, frame);
 
-	if ( frame.detectedPlanes ) {
-
-		this.dispatchEvent( { type: 'planesdetected', data: frame } );
-
+	if (frame.detectedPlanes) {
+		this.dispatchEvent({ type: "planesdetected", data: frame });
 	}
 
 	this._xrFrame = null;
-
 }
 
 export default XRManager;

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -1,25 +1,18 @@
-import { ArrayCamera } from "../../cameras/ArrayCamera.js";
-import { EventDispatcher } from "../../core/EventDispatcher.js";
-import { PerspectiveCamera } from "../../cameras/PerspectiveCamera.js";
-import { Vector2 } from "../../math/Vector2.js";
-import { Vector3 } from "../../math/Vector3.js";
-import { Vector4 } from "../../math/Vector4.js";
-import { RAD2DEG } from "../../math/MathUtils.js";
-import { WebGLAnimation } from "../webgl/WebGLAnimation.js";
-import { WebGLRenderTarget } from "../WebGLRenderTarget.js";
-import { WebXRController } from "./WebXRController.js";
-import { DepthTexture } from "../../textures/DepthTexture.js";
-import { ExternalTexture } from "../../textures/ExternalTexture.js";
-import {
-	DepthFormat,
-	DepthStencilFormat,
-	RGBAFormat,
-	UnsignedByteType,
-	UnsignedIntType,
-	UnsignedInt248Type,
-} from "../../constants.js";
-import { WebXRDepthSensing } from "./WebXRDepthSensing.js";
-import { warn } from "../../utils.js";
+import { ArrayCamera } from '../../cameras/ArrayCamera.js';
+import { EventDispatcher } from '../../core/EventDispatcher.js';
+import { PerspectiveCamera } from '../../cameras/PerspectiveCamera.js';
+import { Vector2 } from '../../math/Vector2.js';
+import { Vector3 } from '../../math/Vector3.js';
+import { Vector4 } from '../../math/Vector4.js';
+import { RAD2DEG } from '../../math/MathUtils.js';
+import { WebGLAnimation } from '../webgl/WebGLAnimation.js';
+import { WebGLRenderTarget } from '../WebGLRenderTarget.js';
+import { WebXRController } from './WebXRController.js';
+import { DepthTexture } from '../../textures/DepthTexture.js';
+import { ExternalTexture } from '../../textures/ExternalTexture.js';
+import { DepthFormat, DepthStencilFormat, RGBAFormat, UnsignedByteType, UnsignedIntType, UnsignedInt248Type } from '../../constants.js';
+import { WebXRDepthSensing } from './WebXRDepthSensing.js';
+import { warn } from '../../utils.js';
 
 /**
  * This class represents an abstraction of the WebXR Device API and is
@@ -31,13 +24,15 @@ import { warn } from "../../utils.js";
  * @hideconstructor
  */
 class WebXRManager extends EventDispatcher {
+
 	/**
 	 * Constructs a new WebGL renderer.
 	 *
 	 * @param {WebGLRenderer} renderer - The renderer.
 	 * @param {WebGL2RenderingContext} gl - The rendering context.
 	 */
-	constructor(renderer, gl) {
+	constructor( renderer, gl ) {
+
 		super();
 
 		const scope = this;
@@ -47,7 +42,7 @@ class WebXRManager extends EventDispatcher {
 		let framebufferScaleFactor = 1.0;
 
 		let referenceSpace = null;
-		let referenceSpaceType = "local-floor";
+		let referenceSpaceType = 'local-floor';
 		// Set default foveation to maximum.
 		let foveation = 1.0;
 		let customReferenceSpace = null;
@@ -58,7 +53,7 @@ class WebXRManager extends EventDispatcher {
 		let glBaseLayer = null;
 		let xrFrame = null;
 
-		const supportsGlBinding = typeof XRWebGLBinding !== "undefined";
+		const supportsGlBinding = typeof XRWebGLBinding !== 'undefined';
 
 		const depthSensing = new WebXRDepthSensing();
 		const cameraAccessTextures = {};
@@ -81,7 +76,7 @@ class WebXRManager extends EventDispatcher {
 		const cameraR = new PerspectiveCamera();
 		cameraR.viewport = new Vector4();
 
-		const cameras = [cameraL, cameraR];
+		const cameras = [ cameraL, cameraR ];
 
 		const cameraXR = new ArrayCamera();
 
@@ -124,15 +119,19 @@ class WebXRManager extends EventDispatcher {
 		 * @param {number} index - The index of the controller.
 		 * @return {Group} A group representing the `target ray` space.
 		 */
-		this.getController = function (index) {
-			let controller = controllers[index];
+		this.getController = function ( index ) {
 
-			if (controller === undefined) {
+			let controller = controllers[ index ];
+
+			if ( controller === undefined ) {
+
 				controller = new WebXRController();
-				controllers[index] = controller;
+				controllers[ index ] = controller;
+
 			}
 
 			return controller.getTargetRaySpace();
+
 		};
 
 		/**
@@ -150,15 +149,19 @@ class WebXRManager extends EventDispatcher {
 		 * @param {number} index - The index of the controller.
 		 * @return {Group} A group representing the `grip` space.
 		 */
-		this.getControllerGrip = function (index) {
-			let controller = controllers[index];
+		this.getControllerGrip = function ( index ) {
 
-			if (controller === undefined) {
+			let controller = controllers[ index ];
+
+			if ( controller === undefined ) {
+
 				controller = new WebXRController();
-				controllers[index] = controller;
+				controllers[ index ] = controller;
+
 			}
 
 			return controller.getGripSpace();
+
 		};
 
 		/**
@@ -169,69 +172,80 @@ class WebXRManager extends EventDispatcher {
 		 * @param {number} index - The index of the controller.
 		 * @return {Group} A group representing the `hand` space.
 		 */
-		this.getHand = function (index) {
-			let controller = controllers[index];
+		this.getHand = function ( index ) {
 
-			if (controller === undefined) {
+			let controller = controllers[ index ];
+
+			if ( controller === undefined ) {
+
 				controller = new WebXRController();
-				controllers[index] = controller;
+				controllers[ index ] = controller;
+
 			}
 
 			return controller.getHandSpace();
+
 		};
 
 		//
 
-		function onSessionEvent(event) {
-			const controllerIndex = controllerInputSources.indexOf(event.inputSource);
+		function onSessionEvent( event ) {
 
-			if (controllerIndex === -1) {
+			const controllerIndex = controllerInputSources.indexOf( event.inputSource );
+
+			if ( controllerIndex === - 1 ) {
+
 				return;
+
 			}
 
-			const controller = controllers[controllerIndex];
+			const controller = controllers[ controllerIndex ];
 
-			if (controller !== undefined) {
-				controller.update(
-					event.inputSource,
-					event.frame,
-					customReferenceSpace || referenceSpace
-				);
-				controller.dispatchEvent({ type: event.type, data: event.inputSource });
+			if ( controller !== undefined ) {
+
+				controller.update( event.inputSource, event.frame, customReferenceSpace || referenceSpace );
+				controller.dispatchEvent( { type: event.type, data: event.inputSource } );
+
 			}
+
 		}
 
 		function onSessionEnd() {
-			session.removeEventListener("select", onSessionEvent);
-			session.removeEventListener("selectstart", onSessionEvent);
-			session.removeEventListener("selectend", onSessionEvent);
-			session.removeEventListener("squeeze", onSessionEvent);
-			session.removeEventListener("squeezestart", onSessionEvent);
-			session.removeEventListener("squeezeend", onSessionEvent);
-			session.removeEventListener("end", onSessionEnd);
-			session.removeEventListener("inputsourceschange", onInputSourcesChange);
 
-			for (let i = 0; i < controllers.length; i++) {
-				const inputSource = controllerInputSources[i];
+			session.removeEventListener( 'select', onSessionEvent );
+			session.removeEventListener( 'selectstart', onSessionEvent );
+			session.removeEventListener( 'selectend', onSessionEvent );
+			session.removeEventListener( 'squeeze', onSessionEvent );
+			session.removeEventListener( 'squeezestart', onSessionEvent );
+			session.removeEventListener( 'squeezeend', onSessionEvent );
+			session.removeEventListener( 'end', onSessionEnd );
+			session.removeEventListener( 'inputsourceschange', onInputSourcesChange );
 
-				if (inputSource === null) continue;
+			for ( let i = 0; i < controllers.length; i ++ ) {
 
-				controllerInputSources[i] = null;
+				const inputSource = controllerInputSources[ i ];
 
-				controllers[i].disconnect(inputSource);
+				if ( inputSource === null ) continue;
+
+				controllerInputSources[ i ] = null;
+
+				controllers[ i ].disconnect( inputSource );
+
 			}
 
 			_currentDepthNear = null;
 			_currentDepthFar = null;
 
 			depthSensing.reset();
-			for (const key in cameraAccessTextures) {
-				delete cameraAccessTextures[key];
+			for ( const key in cameraAccessTextures ) {
+
+				delete cameraAccessTextures[ key ];
+
 			}
 
 			// restore framebuffer/rendering state
 
-			renderer.setRenderTarget(initialRenderTarget);
+			renderer.setRenderTarget( initialRenderTarget );
 
 			glBaseLayer = null;
 			glProjLayer = null;
@@ -245,10 +259,11 @@ class WebXRManager extends EventDispatcher {
 
 			scope.isPresenting = false;
 
-			renderer.setPixelRatio(currentPixelRatio);
-			renderer.setSize(currentSize.width, currentSize.height, false);
+			renderer.setPixelRatio( currentPixelRatio );
+			renderer.setSize( currentSize.width, currentSize.height, false );
 
-			scope.dispatchEvent({ type: "sessionend" });
+			scope.dispatchEvent( { type: 'sessionend' } );
+
 		}
 
 		/**
@@ -258,12 +273,16 @@ class WebXRManager extends EventDispatcher {
 		 *
 		 * @param {number} value - The framebuffer scale factor.
 		 */
-		this.setFramebufferScaleFactor = function (value) {
+		this.setFramebufferScaleFactor = function ( value ) {
+
 			framebufferScaleFactor = value;
 
-			if (scope.isPresenting === true) {
-				warn("WebXRManager: Cannot change framebuffer scale while presenting.");
+			if ( scope.isPresenting === true ) {
+
+				warn( 'WebXRManager: Cannot change framebuffer scale while presenting.' );
+
 			}
+
 		};
 
 		/**
@@ -276,14 +295,16 @@ class WebXRManager extends EventDispatcher {
 		 *
 		 * @param {string} value - The reference space type.
 		 */
-		this.setReferenceSpaceType = function (value) {
+		this.setReferenceSpaceType = function ( value ) {
+
 			referenceSpaceType = value;
 
-			if (scope.isPresenting === true) {
-				warn(
-					"WebXRManager: Cannot change reference space type while presenting."
-				);
+			if ( scope.isPresenting === true ) {
+
+				warn( 'WebXRManager: Cannot change reference space type while presenting.' );
+
 			}
+
 		};
 
 		/**
@@ -292,7 +313,9 @@ class WebXRManager extends EventDispatcher {
 		 * @return {XRReferenceSpace} The XR reference space.
 		 */
 		this.getReferenceSpace = function () {
+
 			return customReferenceSpace || referenceSpace;
+
 		};
 
 		/**
@@ -300,8 +323,10 @@ class WebXRManager extends EventDispatcher {
 		 *
 		 * @param {XRReferenceSpace} space - The XR reference space.
 		 */
-		this.setReferenceSpace = function (space) {
+		this.setReferenceSpace = function ( space ) {
+
 			customReferenceSpace = space;
+
 		};
 
 		/**
@@ -313,7 +338,9 @@ class WebXRManager extends EventDispatcher {
 		 * @return {?(XRWebGLLayer|XRProjectionLayer)} The XR base layer.
 		 */
 		this.getBaseLayer = function () {
+
 			return glProjLayer !== null ? glProjLayer : glBaseLayer;
+
 		};
 
 		/**
@@ -325,11 +352,15 @@ class WebXRManager extends EventDispatcher {
 		 * @return {?XRWebGLBinding} The XR binding. Returns `null` if one cannot be created.
 		 */
 		this.getBinding = function () {
-			if (glBinding === null && supportsGlBinding) {
-				glBinding = new XRWebGLBinding(session, gl);
+
+			if ( glBinding === null && supportsGlBinding ) {
+
+				glBinding = new XRWebGLBinding( session, gl );
+
 			}
 
 			return glBinding;
+
 		};
 
 		/**
@@ -338,7 +369,9 @@ class WebXRManager extends EventDispatcher {
 		 * @return {?XRFrame} The XR frame. Returns `null` when used outside a XR session.
 		 */
 		this.getFrame = function () {
+
 			return xrFrame;
+
 		};
 
 		/**
@@ -347,7 +380,9 @@ class WebXRManager extends EventDispatcher {
 		 * @return {?XRSession} The XR session. Returns `null` when used outside a XR session.
 		 */
 		this.getSession = function () {
+
 			return session;
+
 		};
 
 		/**
@@ -359,55 +394,55 @@ class WebXRManager extends EventDispatcher {
 		 * @param {XRSession} value - The XR session to set.
 		 * @return {Promise} A Promise that resolves when the session has been set.
 		 */
-		this.setSession = async function (value) {
+		this.setSession = async function ( value ) {
+
 			session = value;
 
-			if (session !== null) {
+			if ( session !== null ) {
+
 				initialRenderTarget = renderer.getRenderTarget();
 
-				session.addEventListener("select", onSessionEvent);
-				session.addEventListener("selectstart", onSessionEvent);
-				session.addEventListener("selectend", onSessionEvent);
-				session.addEventListener("squeeze", onSessionEvent);
-				session.addEventListener("squeezestart", onSessionEvent);
-				session.addEventListener("squeezeend", onSessionEvent);
-				session.addEventListener("end", onSessionEnd);
-				session.addEventListener("inputsourceschange", onInputSourcesChange);
+				session.addEventListener( 'select', onSessionEvent );
+				session.addEventListener( 'selectstart', onSessionEvent );
+				session.addEventListener( 'selectend', onSessionEvent );
+				session.addEventListener( 'squeeze', onSessionEvent );
+				session.addEventListener( 'squeezestart', onSessionEvent );
+				session.addEventListener( 'squeezeend', onSessionEvent );
+				session.addEventListener( 'end', onSessionEnd );
+				session.addEventListener( 'inputsourceschange', onInputSourcesChange );
 
-				if (attributes.xrCompatible !== true) {
+				if ( attributes.xrCompatible !== true ) {
+
 					await gl.makeXRCompatible();
+
 				}
 
 				currentPixelRatio = renderer.getPixelRatio();
-				renderer.getSize(currentSize);
+				renderer.getSize( currentSize );
+
 
 				// Check that the browser implements the necessary APIs to use an
-				// XRProjectionLayer rather than an XRWebGLLayer
-				const supportsLayers =
-					supportsGlBinding &&
-					"createProjectionLayer" in XRWebGLBinding.prototype;
-				const sessionHasLayers =
-					session.enabledFeatures?.includes("layers") ?? false;
+				// XRProjectionLayer rather than an XRWebGLLayer, and that the
+				// session has the 'layers' feature enabled.
+				const supportsLayers = supportsGlBinding && 'createProjectionLayer' in XRWebGLBinding.prototype;
+				const sessionHasLayers = session.enabledFeatures?.includes( 'layers' ) ?? false;
 
-				if (!supportsLayers || !sessionHasLayers) {
+				if ( ! supportsLayers || ! sessionHasLayers ) {
+
 					const layerInit = {
 						antialias: attributes.antialias,
 						alpha: true,
 						depth: attributes.depth,
 						stencil: attributes.stencil,
-						framebufferScaleFactor: framebufferScaleFactor,
+						framebufferScaleFactor: framebufferScaleFactor
 					};
 
-					glBaseLayer = new XRWebGLLayer(session, gl, layerInit);
+					glBaseLayer = new XRWebGLLayer( session, gl, layerInit );
 
-					session.updateRenderState({ baseLayer: glBaseLayer });
+					session.updateRenderState( { baseLayer: glBaseLayer } );
 
-					renderer.setPixelRatio(1);
-					renderer.setSize(
-						glBaseLayer.framebufferWidth,
-						glBaseLayer.framebufferHeight,
-						false
-					);
+					renderer.setPixelRatio( 1 );
+					renderer.setSize( glBaseLayer.framebufferWidth, glBaseLayer.framebufferHeight, false );
 
 					newRenderTarget = new WebGLRenderTarget(
 						glBaseLayer.framebufferWidth,
@@ -417,43 +452,40 @@ class WebXRManager extends EventDispatcher {
 							type: UnsignedByteType,
 							colorSpace: renderer.outputColorSpace,
 							stencilBuffer: attributes.stencil,
-							resolveDepthBuffer: glBaseLayer.ignoreDepthValues === false,
-							resolveStencilBuffer: glBaseLayer.ignoreDepthValues === false,
+							resolveDepthBuffer: ( glBaseLayer.ignoreDepthValues === false ),
+							resolveStencilBuffer: ( glBaseLayer.ignoreDepthValues === false )
+
 						}
 					);
+
 				} else {
+
 					let depthFormat = null;
 					let depthType = null;
 					let glDepthFormat = null;
 
-					if (attributes.depth) {
-						glDepthFormat = attributes.stencil
-							? gl.DEPTH24_STENCIL8
-							: gl.DEPTH_COMPONENT24;
+					if ( attributes.depth ) {
+
+						glDepthFormat = attributes.stencil ? gl.DEPTH24_STENCIL8 : gl.DEPTH_COMPONENT24;
 						depthFormat = attributes.stencil ? DepthStencilFormat : DepthFormat;
-						depthType = attributes.stencil
-							? UnsignedInt248Type
-							: UnsignedIntType;
+						depthType = attributes.stencil ? UnsignedInt248Type : UnsignedIntType;
+
 					}
 
 					const projectionlayerInit = {
 						colorFormat: gl.RGBA8,
 						depthFormat: glDepthFormat,
-						scaleFactor: framebufferScaleFactor,
+						scaleFactor: framebufferScaleFactor
 					};
 
 					glBinding = this.getBinding();
 
-					glProjLayer = glBinding.createProjectionLayer(projectionlayerInit);
+					glProjLayer = glBinding.createProjectionLayer( projectionlayerInit );
 
-					session.updateRenderState({ layers: [glProjLayer] });
+					session.updateRenderState( { layers: [ glProjLayer ] } );
 
-					renderer.setPixelRatio(1);
-					renderer.setSize(
-						glProjLayer.textureWidth,
-						glProjLayer.textureHeight,
-						false
-					);
+					renderer.setPixelRatio( 1 );
+					renderer.setSize( glProjLayer.textureWidth, glProjLayer.textureHeight, false );
 
 					newRenderTarget = new WebGLRenderTarget(
 						glProjLayer.textureWidth,
@@ -461,43 +493,32 @@ class WebXRManager extends EventDispatcher {
 						{
 							format: RGBAFormat,
 							type: UnsignedByteType,
-							depthTexture: new DepthTexture(
-								glProjLayer.textureWidth,
-								glProjLayer.textureHeight,
-								depthType,
-								undefined,
-								undefined,
-								undefined,
-								undefined,
-								undefined,
-								undefined,
-								depthFormat
-							),
+							depthTexture: new DepthTexture( glProjLayer.textureWidth, glProjLayer.textureHeight, depthType, undefined, undefined, undefined, undefined, undefined, undefined, depthFormat ),
 							stencilBuffer: attributes.stencil,
 							colorSpace: renderer.outputColorSpace,
 							samples: attributes.antialias ? 4 : 0,
-							resolveDepthBuffer: glProjLayer.ignoreDepthValues === false,
-							resolveStencilBuffer: glProjLayer.ignoreDepthValues === false,
-						}
-					);
+							resolveDepthBuffer: ( glProjLayer.ignoreDepthValues === false ),
+							resolveStencilBuffer: ( glProjLayer.ignoreDepthValues === false )
+						} );
+
 				}
 
 				newRenderTarget.isXRRenderTarget = true; // TODO Remove this when possible, see #23278
 
-				this.setFoveation(foveation);
+				this.setFoveation( foveation );
 
 				customReferenceSpace = null;
-				referenceSpace = await session.requestReferenceSpace(
-					referenceSpaceType
-				);
+				referenceSpace = await session.requestReferenceSpace( referenceSpaceType );
 
-				animation.setContext(session);
+				animation.setContext( session );
 				animation.start();
 
 				scope.isPresenting = true;
 
-				scope.dispatchEvent({ type: "sessionstart" });
+				scope.dispatchEvent( { type: 'sessionstart' } );
+
 			}
+
 		};
 
 		/**
@@ -506,9 +527,13 @@ class WebXRManager extends EventDispatcher {
 		 * @return {'opaque'|'additive'|'alpha-blend'|undefined} The environment blend mode. Returns `undefined` when used outside of a XR session.
 		 */
 		this.getEnvironmentBlendMode = function () {
-			if (session !== null) {
+
+			if ( session !== null ) {
+
 				return session.environmentBlendMode;
+
 			}
+
 		};
 
 		/**
@@ -519,55 +544,75 @@ class WebXRManager extends EventDispatcher {
 		 * @return {?Texture} The depth texture.
 		 */
 		this.getDepthTexture = function () {
+
 			return depthSensing.getDepthTexture();
+
 		};
 
-		function onInputSourcesChange(event) {
+		function onInputSourcesChange( event ) {
+
 			// Notify disconnected
 
-			for (let i = 0; i < event.removed.length; i++) {
-				const inputSource = event.removed[i];
-				const index = controllerInputSources.indexOf(inputSource);
+			for ( let i = 0; i < event.removed.length; i ++ ) {
 
-				if (index >= 0) {
-					controllerInputSources[index] = null;
-					controllers[index].disconnect(inputSource);
+				const inputSource = event.removed[ i ];
+				const index = controllerInputSources.indexOf( inputSource );
+
+				if ( index >= 0 ) {
+
+					controllerInputSources[ index ] = null;
+					controllers[ index ].disconnect( inputSource );
+
 				}
+
 			}
 
 			// Notify connected
 
-			for (let i = 0; i < event.added.length; i++) {
-				const inputSource = event.added[i];
+			for ( let i = 0; i < event.added.length; i ++ ) {
 
-				let controllerIndex = controllerInputSources.indexOf(inputSource);
+				const inputSource = event.added[ i ];
 
-				if (controllerIndex === -1) {
+				let controllerIndex = controllerInputSources.indexOf( inputSource );
+
+				if ( controllerIndex === - 1 ) {
+
 					// Assign input source a controller that currently has no input source
 
-					for (let i = 0; i < controllers.length; i++) {
-						if (i >= controllerInputSources.length) {
-							controllerInputSources.push(inputSource);
+					for ( let i = 0; i < controllers.length; i ++ ) {
+
+						if ( i >= controllerInputSources.length ) {
+
+							controllerInputSources.push( inputSource );
 							controllerIndex = i;
 							break;
-						} else if (controllerInputSources[i] === null) {
-							controllerInputSources[i] = inputSource;
+
+						} else if ( controllerInputSources[ i ] === null ) {
+
+							controllerInputSources[ i ] = inputSource;
 							controllerIndex = i;
 							break;
+
 						}
+
 					}
 
 					// If all controllers do currently receive input we ignore new ones
 
-					if (controllerIndex === -1) break;
+					if ( controllerIndex === - 1 ) break;
+
 				}
 
-				const controller = controllers[controllerIndex];
+				const controller = controllers[ controllerIndex ];
 
-				if (controller) {
-					controller.connect(inputSource);
+				if ( controller ) {
+
+					controller.connect( inputSource );
+
 				}
+
 			}
+
 		}
 
 		//
@@ -585,11 +630,12 @@ class WebXRManager extends EventDispatcher {
 		 * @param {PerspectiveCamera} cameraL - The left camera.
 		 * @param {PerspectiveCamera} cameraR - The right camera.
 		 */
-		function setProjectionFromUnion(camera, cameraL, cameraR) {
-			cameraLPos.setFromMatrixPosition(cameraL.matrixWorld);
-			cameraRPos.setFromMatrixPosition(cameraR.matrixWorld);
+		function setProjectionFromUnion( camera, cameraL, cameraR ) {
 
-			const ipd = cameraLPos.distanceTo(cameraRPos);
+			cameraLPos.setFromMatrixPosition( cameraL.matrixWorld );
+			cameraRPos.setFromMatrixPosition( cameraR.matrixWorld );
+
+			const ipd = cameraLPos.distanceTo( cameraRPos );
 
 			const projL = cameraL.projectionMatrix.elements;
 			const projR = cameraR.projectionMatrix.elements;
@@ -597,74 +643,70 @@ class WebXRManager extends EventDispatcher {
 			// VR systems will have identical far and near planes, and
 			// most likely identical top and bottom frustum extents.
 			// Use the left camera for these values.
-			const near = projL[14] / (projL[10] - 1);
-			const far = projL[14] / (projL[10] + 1);
-			const topFov = (projL[9] + 1) / projL[5];
-			const bottomFov = (projL[9] - 1) / projL[5];
+			const near = projL[ 14 ] / ( projL[ 10 ] - 1 );
+			const far = projL[ 14 ] / ( projL[ 10 ] + 1 );
+			const topFov = ( projL[ 9 ] + 1 ) / projL[ 5 ];
+			const bottomFov = ( projL[ 9 ] - 1 ) / projL[ 5 ];
 
-			const leftFov = (projL[8] - 1) / projL[0];
-			const rightFov = (projR[8] + 1) / projR[0];
+			const leftFov = ( projL[ 8 ] - 1 ) / projL[ 0 ];
+			const rightFov = ( projR[ 8 ] + 1 ) / projR[ 0 ];
 			const left = near * leftFov;
 			const right = near * rightFov;
 
 			// Calculate the new camera's position offset from the
 			// left camera. xOffset should be roughly half `ipd`.
-			const zOffset = ipd / (-leftFov + rightFov);
-			const xOffset = zOffset * -leftFov;
+			const zOffset = ipd / ( - leftFov + rightFov );
+			const xOffset = zOffset * - leftFov;
 
 			// TODO: Better way to apply this offset?
-			cameraL.matrixWorld.decompose(
-				camera.position,
-				camera.quaternion,
-				camera.scale
-			);
-			camera.translateX(xOffset);
-			camera.translateZ(zOffset);
-			camera.matrixWorld.compose(
-				camera.position,
-				camera.quaternion,
-				camera.scale
-			);
-			camera.matrixWorldInverse.copy(camera.matrixWorld).invert();
+			cameraL.matrixWorld.decompose( camera.position, camera.quaternion, camera.scale );
+			camera.translateX( xOffset );
+			camera.translateZ( zOffset );
+			camera.matrixWorld.compose( camera.position, camera.quaternion, camera.scale );
+			camera.matrixWorldInverse.copy( camera.matrixWorld ).invert();
 
 			// Check if the projection uses an infinite far plane.
-			if (projL[10] === -1.0) {
+			if ( projL[ 10 ] === - 1.0 ) {
+
 				// Use the projection matrix from the left eye.
 				// The camera offset is sufficient to include the view volumes
 				// of both eyes (assuming symmetric projections).
-				camera.projectionMatrix.copy(cameraL.projectionMatrix);
-				camera.projectionMatrixInverse.copy(cameraL.projectionMatrixInverse);
+				camera.projectionMatrix.copy( cameraL.projectionMatrix );
+				camera.projectionMatrixInverse.copy( cameraL.projectionMatrixInverse );
+
 			} else {
+
 				// Find the union of the frustum values of the cameras and scale
 				// the values so that the near plane's position does not change in world space,
 				// although must now be relative to the new union camera.
 				const near2 = near + zOffset;
 				const far2 = far + zOffset;
 				const left2 = left - xOffset;
-				const right2 = right + (ipd - xOffset);
-				const top2 = ((topFov * far) / far2) * near2;
-				const bottom2 = ((bottomFov * far) / far2) * near2;
+				const right2 = right + ( ipd - xOffset );
+				const top2 = topFov * far / far2 * near2;
+				const bottom2 = bottomFov * far / far2 * near2;
 
-				camera.projectionMatrix.makePerspective(
-					left2,
-					right2,
-					top2,
-					bottom2,
-					near2,
-					far2
-				);
-				camera.projectionMatrixInverse.copy(camera.projectionMatrix).invert();
+				camera.projectionMatrix.makePerspective( left2, right2, top2, bottom2, near2, far2 );
+				camera.projectionMatrixInverse.copy( camera.projectionMatrix ).invert();
+
 			}
+
 		}
 
-		function updateCamera(camera, parent) {
-			if (parent === null) {
-				camera.matrixWorld.copy(camera.matrix);
+		function updateCamera( camera, parent ) {
+
+			if ( parent === null ) {
+
+				camera.matrixWorld.copy( camera.matrix );
+
 			} else {
-				camera.matrixWorld.multiplyMatrices(parent.matrixWorld, camera.matrix);
+
+				camera.matrixWorld.multiplyMatrices( parent.matrixWorld, camera.matrix );
+
 			}
 
-			camera.matrixWorldInverse.copy(camera.matrixWorld).invert();
+			camera.matrixWorldInverse.copy( camera.matrixWorld ).invert();
+
 		}
 
 		/**
@@ -676,33 +718,35 @@ class WebXRManager extends EventDispatcher {
 		 *
 		 * @param {Camera} camera - The camera.
 		 */
-		this.updateCamera = function (camera) {
-			if (session === null) return;
+		this.updateCamera = function ( camera ) {
+
+			if ( session === null ) return;
 
 			let depthNear = camera.near;
 			let depthFar = camera.far;
 
-			if (depthSensing.texture !== null) {
-				if (depthSensing.depthNear > 0) depthNear = depthSensing.depthNear;
-				if (depthSensing.depthFar > 0) depthFar = depthSensing.depthFar;
+			if ( depthSensing.texture !== null ) {
+
+				if ( depthSensing.depthNear > 0 ) depthNear = depthSensing.depthNear;
+				if ( depthSensing.depthFar > 0 ) depthFar = depthSensing.depthFar;
+
 			}
 
 			cameraXR.near = cameraR.near = cameraL.near = depthNear;
 			cameraXR.far = cameraR.far = cameraL.far = depthFar;
 
-			if (
-				_currentDepthNear !== cameraXR.near ||
-				_currentDepthFar !== cameraXR.far
-			) {
+			if ( _currentDepthNear !== cameraXR.near || _currentDepthFar !== cameraXR.far ) {
+
 				// Note that the new renderState won't apply until the next frame. See #18320
 
-				session.updateRenderState({
+				session.updateRenderState( {
 					depthNear: cameraXR.near,
-					depthFar: cameraXR.far,
-				});
+					depthFar: cameraXR.far
+				} );
 
 				_currentDepthNear = cameraXR.near;
 				_currentDepthFar = cameraXR.far;
+
 			}
 
 			// inherit camera layers and enable eye layers (1 = left, 2 = right)
@@ -713,47 +757,61 @@ class WebXRManager extends EventDispatcher {
 			const parent = camera.parent;
 			const cameras = cameraXR.cameras;
 
-			updateCamera(cameraXR, parent);
+			updateCamera( cameraXR, parent );
 
-			for (let i = 0; i < cameras.length; i++) {
-				updateCamera(cameras[i], parent);
+			for ( let i = 0; i < cameras.length; i ++ ) {
+
+				updateCamera( cameras[ i ], parent );
+
 			}
 
 			// update projection matrix for proper view frustum culling
 
-			if (cameras.length === 2) {
-				setProjectionFromUnion(cameraXR, cameraL, cameraR);
+			if ( cameras.length === 2 ) {
+
+				setProjectionFromUnion( cameraXR, cameraL, cameraR );
+
 			} else {
+
 				// assume single camera setup (AR)
 
-				cameraXR.projectionMatrix.copy(cameraL.projectionMatrix);
+				cameraXR.projectionMatrix.copy( cameraL.projectionMatrix );
+
 			}
 
 			// update user camera and its children
 
-			updateUserCamera(camera, cameraXR, parent);
+			updateUserCamera( camera, cameraXR, parent );
+
 		};
 
-		function updateUserCamera(camera, cameraXR, parent) {
-			if (parent === null) {
-				camera.matrix.copy(cameraXR.matrixWorld);
+		function updateUserCamera( camera, cameraXR, parent ) {
+
+			if ( parent === null ) {
+
+				camera.matrix.copy( cameraXR.matrixWorld );
+
 			} else {
-				camera.matrix.copy(parent.matrixWorld);
+
+				camera.matrix.copy( parent.matrixWorld );
 				camera.matrix.invert();
-				camera.matrix.multiply(cameraXR.matrixWorld);
+				camera.matrix.multiply( cameraXR.matrixWorld );
+
 			}
 
-			camera.matrix.decompose(camera.position, camera.quaternion, camera.scale);
-			camera.updateMatrixWorld(true);
+			camera.matrix.decompose( camera.position, camera.quaternion, camera.scale );
+			camera.updateMatrixWorld( true );
 
-			camera.projectionMatrix.copy(cameraXR.projectionMatrix);
-			camera.projectionMatrixInverse.copy(cameraXR.projectionMatrixInverse);
+			camera.projectionMatrix.copy( cameraXR.projectionMatrix );
+			camera.projectionMatrixInverse.copy( cameraXR.projectionMatrixInverse );
 
-			if (camera.isPerspectiveCamera) {
-				camera.fov =
-					RAD2DEG * 2 * Math.atan(1 / camera.projectionMatrix.elements[5]);
+			if ( camera.isPerspectiveCamera ) {
+
+				camera.fov = RAD2DEG * 2 * Math.atan( 1 / camera.projectionMatrix.elements[ 5 ] );
 				camera.zoom = 1;
+
 			}
+
 		}
 
 		/**
@@ -767,7 +825,9 @@ class WebXRManager extends EventDispatcher {
 		 * @return {ArrayCamera} The XR camera.
 		 */
 		this.getCamera = function () {
+
 			return cameraXR;
+
 		};
 
 		/**
@@ -776,11 +836,15 @@ class WebXRManager extends EventDispatcher {
 		 * @return {number|undefined} The amount of foveation.
 		 */
 		this.getFoveation = function () {
-			if (glProjLayer === null && glBaseLayer === null) {
+
+			if ( glProjLayer === null && glBaseLayer === null ) {
+
 				return undefined;
+
 			}
 
 			return foveation;
+
 		};
 
 		/**
@@ -789,19 +853,25 @@ class WebXRManager extends EventDispatcher {
 		 * @param {number} value - A number in the range `[0,1]` where `0` means no foveation (full resolution)
 		 * and `1` means maximum foveation (the edges render at lower resolution).
 		 */
-		this.setFoveation = function (value) {
+		this.setFoveation = function ( value ) {
+
 			// 0 = no foveation = full resolution
 			// 1 = maximum foveation = the edges render at lower resolution
 
 			foveation = value;
 
-			if (glProjLayer !== null) {
+			if ( glProjLayer !== null ) {
+
 				glProjLayer.fixedFoveation = value;
+
 			}
 
-			if (glBaseLayer !== null && glBaseLayer.fixedFoveation !== undefined) {
+			if ( glBaseLayer !== null && glBaseLayer.fixedFoveation !== undefined ) {
+
 				glBaseLayer.fixedFoveation = value;
+
 			}
+
 		};
 
 		/**
@@ -810,7 +880,9 @@ class WebXRManager extends EventDispatcher {
 		 * @return {boolean} Whether depth sensing is supported or not.
 		 */
 		this.hasDepthSensing = function () {
+
 			return depthSensing.texture !== null;
+
 		};
 
 		/**
@@ -821,7 +893,9 @@ class WebXRManager extends EventDispatcher {
 		 * @return {Mesh} The depth sensing mesh.
 		 */
 		this.getDepthSensingMesh = function () {
-			return depthSensing.getMesh(cameraXR);
+
+			return depthSensing.getMesh( cameraXR );
+
 		};
 
 		/**
@@ -831,177 +905,201 @@ class WebXRManager extends EventDispatcher {
 		 * @param {XRCamera} xrCamera - The camera to query.
 		 * @return {?Texture} An opaque texture representing the current raw camera frame.
 		 */
-		this.getCameraTexture = function (xrCamera) {
-			return cameraAccessTextures[xrCamera];
+		this.getCameraTexture = function ( xrCamera ) {
+
+			return cameraAccessTextures[ xrCamera ];
+
 		};
 
 		// Animation Loop
 
 		let onAnimationFrameCallback = null;
 
-		function onAnimationFrame(time, frame) {
-			pose = frame.getViewerPose(customReferenceSpace || referenceSpace);
+		function onAnimationFrame( time, frame ) {
+
+			pose = frame.getViewerPose( customReferenceSpace || referenceSpace );
 			xrFrame = frame;
 
-			if (pose !== null) {
+			if ( pose !== null ) {
+
 				const views = pose.views;
 
-				if (glBaseLayer !== null) {
-					renderer.setRenderTargetFramebuffer(
-						newRenderTarget,
-						glBaseLayer.framebuffer
-					);
-					renderer.setRenderTarget(newRenderTarget);
+				if ( glBaseLayer !== null ) {
+
+					renderer.setRenderTargetFramebuffer( newRenderTarget, glBaseLayer.framebuffer );
+					renderer.setRenderTarget( newRenderTarget );
+
 				}
 
 				let cameraXRNeedsUpdate = false;
 
 				// check if it's necessary to rebuild cameraXR's camera list
 
-				if (views.length !== cameraXR.cameras.length) {
+				if ( views.length !== cameraXR.cameras.length ) {
+
 					cameraXR.cameras.length = 0;
 					cameraXRNeedsUpdate = true;
+
 				}
 
-				for (let i = 0; i < views.length; i++) {
-					const view = views[i];
+				for ( let i = 0; i < views.length; i ++ ) {
+
+					const view = views[ i ];
 
 					let viewport = null;
 
-					if (glBaseLayer !== null) {
-						viewport = glBaseLayer.getViewport(view);
+					if ( glBaseLayer !== null ) {
+
+						viewport = glBaseLayer.getViewport( view );
+
 					} else {
-						const glSubImage = glBinding.getViewSubImage(glProjLayer, view);
+
+						const glSubImage = glBinding.getViewSubImage( glProjLayer, view );
 						viewport = glSubImage.viewport;
 
 						// For side-by-side projection, we only produce a single texture for both eyes.
-						if (i === 0) {
+						if ( i === 0 ) {
+
 							renderer.setRenderTargetTextures(
 								newRenderTarget,
 								glSubImage.colorTexture,
-								glSubImage.depthStencilTexture
-							);
+								glSubImage.depthStencilTexture );
 
-							renderer.setRenderTarget(newRenderTarget);
+							renderer.setRenderTarget( newRenderTarget );
+
 						}
+
 					}
 
-					let camera = cameras[i];
+					let camera = cameras[ i ];
 
-					if (camera === undefined) {
+					if ( camera === undefined ) {
+
 						camera = new PerspectiveCamera();
-						camera.layers.enable(i);
+						camera.layers.enable( i );
 						camera.viewport = new Vector4();
-						cameras[i] = camera;
+						cameras[ i ] = camera;
+
 					}
 
-					camera.matrix.fromArray(view.transform.matrix);
-					camera.matrix.decompose(
-						camera.position,
-						camera.quaternion,
-						camera.scale
-					);
-					camera.projectionMatrix.fromArray(view.projectionMatrix);
-					camera.projectionMatrixInverse.copy(camera.projectionMatrix).invert();
-					camera.viewport.set(
-						viewport.x,
-						viewport.y,
-						viewport.width,
-						viewport.height
-					);
+					camera.matrix.fromArray( view.transform.matrix );
+					camera.matrix.decompose( camera.position, camera.quaternion, camera.scale );
+					camera.projectionMatrix.fromArray( view.projectionMatrix );
+					camera.projectionMatrixInverse.copy( camera.projectionMatrix ).invert();
+					camera.viewport.set( viewport.x, viewport.y, viewport.width, viewport.height );
 
-					if (i === 0) {
-						cameraXR.matrix.copy(camera.matrix);
-						cameraXR.matrix.decompose(
-							cameraXR.position,
-							cameraXR.quaternion,
-							cameraXR.scale
-						);
+					if ( i === 0 ) {
+
+						cameraXR.matrix.copy( camera.matrix );
+						cameraXR.matrix.decompose( cameraXR.position, cameraXR.quaternion, cameraXR.scale );
+
 					}
 
-					if (cameraXRNeedsUpdate === true) {
-						cameraXR.cameras.push(camera);
+					if ( cameraXRNeedsUpdate === true ) {
+
+						cameraXR.cameras.push( camera );
+
 					}
+
 				}
 
 				//
 
 				const enabledFeatures = session.enabledFeatures;
-				const gpuDepthSensingEnabled =
-					enabledFeatures &&
-					enabledFeatures.includes("depth-sensing") &&
-					session.depthUsage == "gpu-optimized";
+				const gpuDepthSensingEnabled = enabledFeatures &&
+					enabledFeatures.includes( 'depth-sensing' ) &&
+					session.depthUsage == 'gpu-optimized';
 
-				if (gpuDepthSensingEnabled && supportsGlBinding) {
+				if ( gpuDepthSensingEnabled && supportsGlBinding ) {
+
 					glBinding = scope.getBinding();
 
-					const depthData = glBinding.getDepthInformation(views[0]);
+					const depthData = glBinding.getDepthInformation( views[ 0 ] );
 
-					if (depthData && depthData.isValid && depthData.texture) {
-						depthSensing.init(depthData, session.renderState);
+					if ( depthData && depthData.isValid && depthData.texture ) {
+
+						depthSensing.init( depthData, session.renderState );
+
 					}
+
 				}
 
-				const cameraAccessEnabled =
-					enabledFeatures && enabledFeatures.includes("camera-access");
+				const cameraAccessEnabled = enabledFeatures &&
+				    enabledFeatures.includes( 'camera-access' );
 
-				if (cameraAccessEnabled && supportsGlBinding) {
+				if ( cameraAccessEnabled && supportsGlBinding ) {
+
 					renderer.state.unbindTexture();
 
 					glBinding = scope.getBinding();
 
-					for (let i = 0; i < views.length; i++) {
-						const camera = views[i].camera;
+					for ( let i = 0; i < views.length; i ++ ) {
 
-						if (camera) {
-							let cameraTex = cameraAccessTextures[camera];
+						const camera = views[ i ].camera;
 
-							if (!cameraTex) {
+						if ( camera ) {
+
+							let cameraTex = cameraAccessTextures[ camera ];
+
+							if ( ! cameraTex ) {
+
 								cameraTex = new ExternalTexture();
-								cameraAccessTextures[camera] = cameraTex;
+								cameraAccessTextures[ camera ] = cameraTex;
+
 							}
 
-							const glTexture = glBinding.getCameraImage(camera);
+							const glTexture = glBinding.getCameraImage( camera );
 							cameraTex.sourceTexture = glTexture;
+
 						}
+
 					}
+
 				}
+
 			}
 
 			//
 
-			for (let i = 0; i < controllers.length; i++) {
-				const inputSource = controllerInputSources[i];
-				const controller = controllers[i];
+			for ( let i = 0; i < controllers.length; i ++ ) {
 
-				if (inputSource !== null && controller !== undefined) {
-					controller.update(
-						inputSource,
-						frame,
-						customReferenceSpace || referenceSpace
-					);
+				const inputSource = controllerInputSources[ i ];
+				const controller = controllers[ i ];
+
+				if ( inputSource !== null && controller !== undefined ) {
+
+					controller.update( inputSource, frame, customReferenceSpace || referenceSpace );
+
 				}
+
 			}
 
-			if (onAnimationFrameCallback) onAnimationFrameCallback(time, frame);
+			if ( onAnimationFrameCallback ) onAnimationFrameCallback( time, frame );
 
-			if (frame.detectedPlanes) {
-				scope.dispatchEvent({ type: "planesdetected", data: frame });
+			if ( frame.detectedPlanes ) {
+
+				scope.dispatchEvent( { type: 'planesdetected', data: frame } );
+
 			}
 
 			xrFrame = null;
+
 		}
 
 		const animation = new WebGLAnimation();
 
-		animation.setAnimationLoop(onAnimationFrame);
+		animation.setAnimationLoop( onAnimationFrame );
 
-		this.setAnimationLoop = function (callback) {
+		this.setAnimationLoop = function ( callback ) {
+
 			onAnimationFrameCallback = callback;
+
 		};
 
 		this.dispose = function () {};
+
 	}
+
 }
 
 export { WebXRManager };

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -1,18 +1,25 @@
-import { ArrayCamera } from '../../cameras/ArrayCamera.js';
-import { EventDispatcher } from '../../core/EventDispatcher.js';
-import { PerspectiveCamera } from '../../cameras/PerspectiveCamera.js';
-import { Vector2 } from '../../math/Vector2.js';
-import { Vector3 } from '../../math/Vector3.js';
-import { Vector4 } from '../../math/Vector4.js';
-import { RAD2DEG } from '../../math/MathUtils.js';
-import { WebGLAnimation } from '../webgl/WebGLAnimation.js';
-import { WebGLRenderTarget } from '../WebGLRenderTarget.js';
-import { WebXRController } from './WebXRController.js';
-import { DepthTexture } from '../../textures/DepthTexture.js';
-import { ExternalTexture } from '../../textures/ExternalTexture.js';
-import { DepthFormat, DepthStencilFormat, RGBAFormat, UnsignedByteType, UnsignedIntType, UnsignedInt248Type } from '../../constants.js';
-import { WebXRDepthSensing } from './WebXRDepthSensing.js';
-import { warn } from '../../utils.js';
+import { ArrayCamera } from "../../cameras/ArrayCamera.js";
+import { EventDispatcher } from "../../core/EventDispatcher.js";
+import { PerspectiveCamera } from "../../cameras/PerspectiveCamera.js";
+import { Vector2 } from "../../math/Vector2.js";
+import { Vector3 } from "../../math/Vector3.js";
+import { Vector4 } from "../../math/Vector4.js";
+import { RAD2DEG } from "../../math/MathUtils.js";
+import { WebGLAnimation } from "../webgl/WebGLAnimation.js";
+import { WebGLRenderTarget } from "../WebGLRenderTarget.js";
+import { WebXRController } from "./WebXRController.js";
+import { DepthTexture } from "../../textures/DepthTexture.js";
+import { ExternalTexture } from "../../textures/ExternalTexture.js";
+import {
+	DepthFormat,
+	DepthStencilFormat,
+	RGBAFormat,
+	UnsignedByteType,
+	UnsignedIntType,
+	UnsignedInt248Type,
+} from "../../constants.js";
+import { WebXRDepthSensing } from "./WebXRDepthSensing.js";
+import { warn } from "../../utils.js";
 
 /**
  * This class represents an abstraction of the WebXR Device API and is
@@ -24,15 +31,13 @@ import { warn } from '../../utils.js';
  * @hideconstructor
  */
 class WebXRManager extends EventDispatcher {
-
 	/**
 	 * Constructs a new WebGL renderer.
 	 *
 	 * @param {WebGLRenderer} renderer - The renderer.
 	 * @param {WebGL2RenderingContext} gl - The rendering context.
 	 */
-	constructor( renderer, gl ) {
-
+	constructor(renderer, gl) {
 		super();
 
 		const scope = this;
@@ -42,7 +47,7 @@ class WebXRManager extends EventDispatcher {
 		let framebufferScaleFactor = 1.0;
 
 		let referenceSpace = null;
-		let referenceSpaceType = 'local-floor';
+		let referenceSpaceType = "local-floor";
 		// Set default foveation to maximum.
 		let foveation = 1.0;
 		let customReferenceSpace = null;
@@ -53,7 +58,7 @@ class WebXRManager extends EventDispatcher {
 		let glBaseLayer = null;
 		let xrFrame = null;
 
-		const supportsGlBinding = typeof XRWebGLBinding !== 'undefined';
+		const supportsGlBinding = typeof XRWebGLBinding !== "undefined";
 
 		const depthSensing = new WebXRDepthSensing();
 		const cameraAccessTextures = {};
@@ -76,7 +81,7 @@ class WebXRManager extends EventDispatcher {
 		const cameraR = new PerspectiveCamera();
 		cameraR.viewport = new Vector4();
 
-		const cameras = [ cameraL, cameraR ];
+		const cameras = [cameraL, cameraR];
 
 		const cameraXR = new ArrayCamera();
 
@@ -119,19 +124,15 @@ class WebXRManager extends EventDispatcher {
 		 * @param {number} index - The index of the controller.
 		 * @return {Group} A group representing the `target ray` space.
 		 */
-		this.getController = function ( index ) {
+		this.getController = function (index) {
+			let controller = controllers[index];
 
-			let controller = controllers[ index ];
-
-			if ( controller === undefined ) {
-
+			if (controller === undefined) {
 				controller = new WebXRController();
-				controllers[ index ] = controller;
-
+				controllers[index] = controller;
 			}
 
 			return controller.getTargetRaySpace();
-
 		};
 
 		/**
@@ -149,19 +150,15 @@ class WebXRManager extends EventDispatcher {
 		 * @param {number} index - The index of the controller.
 		 * @return {Group} A group representing the `grip` space.
 		 */
-		this.getControllerGrip = function ( index ) {
+		this.getControllerGrip = function (index) {
+			let controller = controllers[index];
 
-			let controller = controllers[ index ];
-
-			if ( controller === undefined ) {
-
+			if (controller === undefined) {
 				controller = new WebXRController();
-				controllers[ index ] = controller;
-
+				controllers[index] = controller;
 			}
 
 			return controller.getGripSpace();
-
 		};
 
 		/**
@@ -172,80 +169,69 @@ class WebXRManager extends EventDispatcher {
 		 * @param {number} index - The index of the controller.
 		 * @return {Group} A group representing the `hand` space.
 		 */
-		this.getHand = function ( index ) {
+		this.getHand = function (index) {
+			let controller = controllers[index];
 
-			let controller = controllers[ index ];
-
-			if ( controller === undefined ) {
-
+			if (controller === undefined) {
 				controller = new WebXRController();
-				controllers[ index ] = controller;
-
+				controllers[index] = controller;
 			}
 
 			return controller.getHandSpace();
-
 		};
 
 		//
 
-		function onSessionEvent( event ) {
+		function onSessionEvent(event) {
+			const controllerIndex = controllerInputSources.indexOf(event.inputSource);
 
-			const controllerIndex = controllerInputSources.indexOf( event.inputSource );
-
-			if ( controllerIndex === - 1 ) {
-
+			if (controllerIndex === -1) {
 				return;
-
 			}
 
-			const controller = controllers[ controllerIndex ];
+			const controller = controllers[controllerIndex];
 
-			if ( controller !== undefined ) {
-
-				controller.update( event.inputSource, event.frame, customReferenceSpace || referenceSpace );
-				controller.dispatchEvent( { type: event.type, data: event.inputSource } );
-
+			if (controller !== undefined) {
+				controller.update(
+					event.inputSource,
+					event.frame,
+					customReferenceSpace || referenceSpace
+				);
+				controller.dispatchEvent({ type: event.type, data: event.inputSource });
 			}
-
 		}
 
 		function onSessionEnd() {
+			session.removeEventListener("select", onSessionEvent);
+			session.removeEventListener("selectstart", onSessionEvent);
+			session.removeEventListener("selectend", onSessionEvent);
+			session.removeEventListener("squeeze", onSessionEvent);
+			session.removeEventListener("squeezestart", onSessionEvent);
+			session.removeEventListener("squeezeend", onSessionEvent);
+			session.removeEventListener("end", onSessionEnd);
+			session.removeEventListener("inputsourceschange", onInputSourcesChange);
 
-			session.removeEventListener( 'select', onSessionEvent );
-			session.removeEventListener( 'selectstart', onSessionEvent );
-			session.removeEventListener( 'selectend', onSessionEvent );
-			session.removeEventListener( 'squeeze', onSessionEvent );
-			session.removeEventListener( 'squeezestart', onSessionEvent );
-			session.removeEventListener( 'squeezeend', onSessionEvent );
-			session.removeEventListener( 'end', onSessionEnd );
-			session.removeEventListener( 'inputsourceschange', onInputSourcesChange );
+			for (let i = 0; i < controllers.length; i++) {
+				const inputSource = controllerInputSources[i];
 
-			for ( let i = 0; i < controllers.length; i ++ ) {
+				if (inputSource === null) continue;
 
-				const inputSource = controllerInputSources[ i ];
+				controllerInputSources[i] = null;
 
-				if ( inputSource === null ) continue;
-
-				controllerInputSources[ i ] = null;
-
-				controllers[ i ].disconnect( inputSource );
-
+				controllers[i].disconnect(inputSource);
 			}
 
 			_currentDepthNear = null;
 			_currentDepthFar = null;
 
 			depthSensing.reset();
-			for ( const key in cameraAccessTextures ) {
-
-				delete cameraAccessTextures[ key ];
-
+			for (const key in cameraAccessTextures) {
+				delete cameraAccessTextures[key];
 			}
 
 			// restore framebuffer/rendering state
 
-			renderer.setRenderTarget( initialRenderTarget );
+			renderer.setRenderTarget(initialRenderTarget);
 
 			glBaseLayer = null;
 			glProjLayer = null;
@@ -259,11 +245,10 @@ class WebXRManager extends EventDispatcher {
 
 			scope.isPresenting = false;
 
-			renderer.setPixelRatio( currentPixelRatio );
-			renderer.setSize( currentSize.width, currentSize.height, false );
+			renderer.setPixelRatio(currentPixelRatio);
+			renderer.setSize(currentSize.width, currentSize.height, false);
 
-			scope.dispatchEvent( { type: 'sessionend' } );
-
+			scope.dispatchEvent({ type: "sessionend" });
 		}
 
 		/**
@@ -273,16 +258,12 @@ class WebXRManager extends EventDispatcher {
 		 *
 		 * @param {number} value - The framebuffer scale factor.
 		 */
-		this.setFramebufferScaleFactor = function ( value ) {
-
+		this.setFramebufferScaleFactor = function (value) {
 			framebufferScaleFactor = value;
 
-			if ( scope.isPresenting === true ) {
-
-				warn( 'WebXRManager: Cannot change framebuffer scale while presenting.' );
-
+			if (scope.isPresenting === true) {
+				warn("WebXRManager: Cannot change framebuffer scale while presenting.");
 			}
-
 		};
 
 		/**
@@ -295,16 +276,14 @@ class WebXRManager extends EventDispatcher {
 		 *
 		 * @param {string} value - The reference space type.
 		 */
-		this.setReferenceSpaceType = function ( value ) {
-
+		this.setReferenceSpaceType = function (value) {
 			referenceSpaceType = value;
 
-			if ( scope.isPresenting === true ) {
-
-				warn( 'WebXRManager: Cannot change reference space type while presenting.' );
-
+			if (scope.isPresenting === true) {
+				warn(
+					"WebXRManager: Cannot change reference space type while presenting."
+				);
 			}
-
 		};
 
 		/**
@@ -313,9 +292,7 @@ class WebXRManager extends EventDispatcher {
 		 * @return {XRReferenceSpace} The XR reference space.
 		 */
 		this.getReferenceSpace = function () {
-
 			return customReferenceSpace || referenceSpace;
-
 		};
 
 		/**
@@ -323,10 +300,8 @@ class WebXRManager extends EventDispatcher {
 		 *
 		 * @param {XRReferenceSpace} space - The XR reference space.
 		 */
-		this.setReferenceSpace = function ( space ) {
-
+		this.setReferenceSpace = function (space) {
 			customReferenceSpace = space;
-
 		};
 
 		/**
@@ -338,9 +313,7 @@ class WebXRManager extends EventDispatcher {
 		 * @return {?(XRWebGLLayer|XRProjectionLayer)} The XR base layer.
 		 */
 		this.getBaseLayer = function () {
-
 			return glProjLayer !== null ? glProjLayer : glBaseLayer;
-
 		};
 
 		/**
@@ -352,15 +325,11 @@ class WebXRManager extends EventDispatcher {
 		 * @return {?XRWebGLBinding} The XR binding. Returns `null` if one cannot be created.
 		 */
 		this.getBinding = function () {
-
-			if ( glBinding === null && supportsGlBinding ) {
-
-				glBinding = new XRWebGLBinding( session, gl );
-
+			if (glBinding === null && supportsGlBinding) {
+				glBinding = new XRWebGLBinding(session, gl);
 			}
 
 			return glBinding;
-
 		};
 
 		/**
@@ -369,9 +338,7 @@ class WebXRManager extends EventDispatcher {
 		 * @return {?XRFrame} The XR frame. Returns `null` when used outside a XR session.
 		 */
 		this.getFrame = function () {
-
 			return xrFrame;
-
 		};
 
 		/**
@@ -380,9 +347,7 @@ class WebXRManager extends EventDispatcher {
 		 * @return {?XRSession} The XR session. Returns `null` when used outside a XR session.
 		 */
 		this.getSession = function () {
-
 			return session;
-
 		};
 
 		/**
@@ -394,53 +359,55 @@ class WebXRManager extends EventDispatcher {
 		 * @param {XRSession} value - The XR session to set.
 		 * @return {Promise} A Promise that resolves when the session has been set.
 		 */
-		this.setSession = async function ( value ) {
-
+		this.setSession = async function (value) {
 			session = value;
 
-			if ( session !== null ) {
-
+			if (session !== null) {
 				initialRenderTarget = renderer.getRenderTarget();
 
-				session.addEventListener( 'select', onSessionEvent );
-				session.addEventListener( 'selectstart', onSessionEvent );
-				session.addEventListener( 'selectend', onSessionEvent );
-				session.addEventListener( 'squeeze', onSessionEvent );
-				session.addEventListener( 'squeezestart', onSessionEvent );
-				session.addEventListener( 'squeezeend', onSessionEvent );
-				session.addEventListener( 'end', onSessionEnd );
-				session.addEventListener( 'inputsourceschange', onInputSourcesChange );
+				session.addEventListener("select", onSessionEvent);
+				session.addEventListener("selectstart", onSessionEvent);
+				session.addEventListener("selectend", onSessionEvent);
+				session.addEventListener("squeeze", onSessionEvent);
+				session.addEventListener("squeezestart", onSessionEvent);
+				session.addEventListener("squeezeend", onSessionEvent);
+				session.addEventListener("end", onSessionEnd);
+				session.addEventListener("inputsourceschange", onInputSourcesChange);
 
-				if ( attributes.xrCompatible !== true ) {
-
+				if (attributes.xrCompatible !== true) {
 					await gl.makeXRCompatible();
-
 				}
 
 				currentPixelRatio = renderer.getPixelRatio();
-				renderer.getSize( currentSize );
-
+				renderer.getSize(currentSize);
 
 				// Check that the browser implements the necessary APIs to use an
 				// XRProjectionLayer rather than an XRWebGLLayer
-				const supportsLayers = supportsGlBinding && 'createProjectionLayer' in XRWebGLBinding.prototype;
+				const supportsLayers =
+					supportsGlBinding &&
+					"createProjectionLayer" in XRWebGLBinding.prototype;
+				const sessionHasLayers =
+					session.enabledFeatures?.includes("layers") ?? false;
 
-				if ( ! supportsLayers ) {
-
+				if (!supportsLayers || !sessionHasLayers) {
 					const layerInit = {
 						antialias: attributes.antialias,
 						alpha: true,
 						depth: attributes.depth,
 						stencil: attributes.stencil,
-						framebufferScaleFactor: framebufferScaleFactor
+						framebufferScaleFactor: framebufferScaleFactor,
 					};
 
-					glBaseLayer = new XRWebGLLayer( session, gl, layerInit );
+					glBaseLayer = new XRWebGLLayer(session, gl, layerInit);
 
-					session.updateRenderState( { baseLayer: glBaseLayer } );
+					session.updateRenderState({ baseLayer: glBaseLayer });
 
-					renderer.setPixelRatio( 1 );
-					renderer.setSize( glBaseLayer.framebufferWidth, glBaseLayer.framebufferHeight, false );
+					renderer.setPixelRatio(1);
+					renderer.setSize(
+						glBaseLayer.framebufferWidth,
+						glBaseLayer.framebufferHeight,
+						false
+					);
 
 					newRenderTarget = new WebGLRenderTarget(
 						glBaseLayer.framebufferWidth,
@@ -450,40 +417,43 @@ class WebXRManager extends EventDispatcher {
 							type: UnsignedByteType,
 							colorSpace: renderer.outputColorSpace,
 							stencilBuffer: attributes.stencil,
-							resolveDepthBuffer: ( glBaseLayer.ignoreDepthValues === false ),
-							resolveStencilBuffer: ( glBaseLayer.ignoreDepthValues === false )
-
+							resolveDepthBuffer: glBaseLayer.ignoreDepthValues === false,
+							resolveStencilBuffer: glBaseLayer.ignoreDepthValues === false,
 						}
 					);
-
 				} else {
-
 					let depthFormat = null;
 					let depthType = null;
 					let glDepthFormat = null;
 
-					if ( attributes.depth ) {
-
-						glDepthFormat = attributes.stencil ? gl.DEPTH24_STENCIL8 : gl.DEPTH_COMPONENT24;
+					if (attributes.depth) {
+						glDepthFormat = attributes.stencil
+							? gl.DEPTH24_STENCIL8
+							: gl.DEPTH_COMPONENT24;
 						depthFormat = attributes.stencil ? DepthStencilFormat : DepthFormat;
-						depthType = attributes.stencil ? UnsignedInt248Type : UnsignedIntType;
-
+						depthType = attributes.stencil
+							? UnsignedInt248Type
+							: UnsignedIntType;
 					}
 
 					const projectionlayerInit = {
 						colorFormat: gl.RGBA8,
 						depthFormat: glDepthFormat,
-						scaleFactor: framebufferScaleFactor
+						scaleFactor: framebufferScaleFactor,
 					};
 
 					glBinding = this.getBinding();
 
-					glProjLayer = glBinding.createProjectionLayer( projectionlayerInit );
+					glProjLayer = glBinding.createProjectionLayer(projectionlayerInit);
 
-					session.updateRenderState( { layers: [ glProjLayer ] } );
+					session.updateRenderState({ layers: [glProjLayer] });
 
-					renderer.setPixelRatio( 1 );
-					renderer.setSize( glProjLayer.textureWidth, glProjLayer.textureHeight, false );
+					renderer.setPixelRatio(1);
+					renderer.setSize(
+						glProjLayer.textureWidth,
+						glProjLayer.textureHeight,
+						false
+					);
 
 					newRenderTarget = new WebGLRenderTarget(
 						glProjLayer.textureWidth,
@@ -491,32 +461,43 @@ class WebXRManager extends EventDispatcher {
 						{
 							format: RGBAFormat,
 							type: UnsignedByteType,
-							depthTexture: new DepthTexture( glProjLayer.textureWidth, glProjLayer.textureHeight, depthType, undefined, undefined, undefined, undefined, undefined, undefined, depthFormat ),
+							depthTexture: new DepthTexture(
+								glProjLayer.textureWidth,
+								glProjLayer.textureHeight,
+								depthType,
+								undefined,
+								undefined,
+								undefined,
+								undefined,
+								undefined,
+								undefined,
+								depthFormat
+							),
 							stencilBuffer: attributes.stencil,
 							colorSpace: renderer.outputColorSpace,
 							samples: attributes.antialias ? 4 : 0,
-							resolveDepthBuffer: ( glProjLayer.ignoreDepthValues === false ),
-							resolveStencilBuffer: ( glProjLayer.ignoreDepthValues === false )
-						} );
-
+							resolveDepthBuffer: glProjLayer.ignoreDepthValues === false,
+							resolveStencilBuffer: glProjLayer.ignoreDepthValues === false,
+						}
+					);
 				}
 
 				newRenderTarget.isXRRenderTarget = true; // TODO Remove this when possible, see #23278
 
-				this.setFoveation( foveation );
+				this.setFoveation(foveation);
 
 				customReferenceSpace = null;
-				referenceSpace = await session.requestReferenceSpace( referenceSpaceType );
+				referenceSpace = await session.requestReferenceSpace(
+					referenceSpaceType
+				);
 
-				animation.setContext( session );
+				animation.setContext(session);
 				animation.start();
 
 				scope.isPresenting = true;
 
-				scope.dispatchEvent( { type: 'sessionstart' } );
-
+				scope.dispatchEvent({ type: "sessionstart" });
 			}
-
 		};
 
 		/**
@@ -525,13 +506,9 @@ class WebXRManager extends EventDispatcher {
 		 * @return {'opaque'|'additive'|'alpha-blend'|undefined} The environment blend mode. Returns `undefined` when used outside of a XR session.
 		 */
 		this.getEnvironmentBlendMode = function () {
-
-			if ( session !== null ) {
-
+			if (session !== null) {
 				return session.environmentBlendMode;
-
 			}
-
 		};
 
 		/**
@@ -542,75 +519,55 @@ class WebXRManager extends EventDispatcher {
 		 * @return {?Texture} The depth texture.
 		 */
 		this.getDepthTexture = function () {
-
 			return depthSensing.getDepthTexture();
-
 		};
 
-		function onInputSourcesChange( event ) {
-
+		function onInputSourcesChange(event) {
 			// Notify disconnected
 
-			for ( let i = 0; i < event.removed.length; i ++ ) {
+			for (let i = 0; i < event.removed.length; i++) {
+				const inputSource = event.removed[i];
+				const index = controllerInputSources.indexOf(inputSource);
 
-				const inputSource = event.removed[ i ];
-				const index = controllerInputSources.indexOf( inputSource );
-
-				if ( index >= 0 ) {
-
-					controllerInputSources[ index ] = null;
-					controllers[ index ].disconnect( inputSource );
-
+				if (index >= 0) {
+					controllerInputSources[index] = null;
+					controllers[index].disconnect(inputSource);
 				}
-
 			}
 
 			// Notify connected
 
-			for ( let i = 0; i < event.added.length; i ++ ) {
+			for (let i = 0; i < event.added.length; i++) {
+				const inputSource = event.added[i];
 
-				const inputSource = event.added[ i ];
+				let controllerIndex = controllerInputSources.indexOf(inputSource);
 
-				let controllerIndex = controllerInputSources.indexOf( inputSource );
-
-				if ( controllerIndex === - 1 ) {
-
+				if (controllerIndex === -1) {
 					// Assign input source a controller that currently has no input source
 
-					for ( let i = 0; i < controllers.length; i ++ ) {
-
-						if ( i >= controllerInputSources.length ) {
-
-							controllerInputSources.push( inputSource );
+					for (let i = 0; i < controllers.length; i++) {
+						if (i >= controllerInputSources.length) {
+							controllerInputSources.push(inputSource);
 							controllerIndex = i;
 							break;
-
-						} else if ( controllerInputSources[ i ] === null ) {
-
-							controllerInputSources[ i ] = inputSource;
+						} else if (controllerInputSources[i] === null) {
+							controllerInputSources[i] = inputSource;
 							controllerIndex = i;
 							break;
-
 						}
-
 					}
 
 					// If all controllers do currently receive input we ignore new ones
 
-					if ( controllerIndex === - 1 ) break;
-
+					if (controllerIndex === -1) break;
 				}
 
-				const controller = controllers[ controllerIndex ];
+				const controller = controllers[controllerIndex];
 
-				if ( controller ) {
-
-					controller.connect( inputSource );
-
+				if (controller) {
+					controller.connect(inputSource);
 				}
-
 			}
-
 		}
 
 		//
@@ -628,12 +585,11 @@ class WebXRManager extends EventDispatcher {
 		 * @param {PerspectiveCamera} cameraL - The left camera.
 		 * @param {PerspectiveCamera} cameraR - The right camera.
 		 */
-		function setProjectionFromUnion( camera, cameraL, cameraR ) {
+		function setProjectionFromUnion(camera, cameraL, cameraR) {
+			cameraLPos.setFromMatrixPosition(cameraL.matrixWorld);
+			cameraRPos.setFromMatrixPosition(cameraR.matrixWorld);
 
-			cameraLPos.setFromMatrixPosition( cameraL.matrixWorld );
-			cameraRPos.setFromMatrixPosition( cameraR.matrixWorld );
-
-			const ipd = cameraLPos.distanceTo( cameraRPos );
+			const ipd = cameraLPos.distanceTo(cameraRPos);
 
 			const projL = cameraL.projectionMatrix.elements;
 			const projR = cameraR.projectionMatrix.elements;
@@ -641,70 +597,74 @@ class WebXRManager extends EventDispatcher {
 			// VR systems will have identical far and near planes, and
 			// most likely identical top and bottom frustum extents.
 			// Use the left camera for these values.
-			const near = projL[ 14 ] / ( projL[ 10 ] - 1 );
-			const far = projL[ 14 ] / ( projL[ 10 ] + 1 );
-			const topFov = ( projL[ 9 ] + 1 ) / projL[ 5 ];
-			const bottomFov = ( projL[ 9 ] - 1 ) / projL[ 5 ];
+			const near = projL[14] / (projL[10] - 1);
+			const far = projL[14] / (projL[10] + 1);
+			const topFov = (projL[9] + 1) / projL[5];
+			const bottomFov = (projL[9] - 1) / projL[5];
 
-			const leftFov = ( projL[ 8 ] - 1 ) / projL[ 0 ];
-			const rightFov = ( projR[ 8 ] + 1 ) / projR[ 0 ];
+			const leftFov = (projL[8] - 1) / projL[0];
+			const rightFov = (projR[8] + 1) / projR[0];
 			const left = near * leftFov;
 			const right = near * rightFov;
 
 			// Calculate the new camera's position offset from the
 			// left camera. xOffset should be roughly half `ipd`.
-			const zOffset = ipd / ( - leftFov + rightFov );
-			const xOffset = zOffset * - leftFov;
+			const zOffset = ipd / (-leftFov + rightFov);
+			const xOffset = zOffset * -leftFov;
 
 			// TODO: Better way to apply this offset?
-			cameraL.matrixWorld.decompose( camera.position, camera.quaternion, camera.scale );
-			camera.translateX( xOffset );
-			camera.translateZ( zOffset );
-			camera.matrixWorld.compose( camera.position, camera.quaternion, camera.scale );
-			camera.matrixWorldInverse.copy( camera.matrixWorld ).invert();
+			cameraL.matrixWorld.decompose(
+				camera.position,
+				camera.quaternion,
+				camera.scale
+			);
+			camera.translateX(xOffset);
+			camera.translateZ(zOffset);
+			camera.matrixWorld.compose(
+				camera.position,
+				camera.quaternion,
+				camera.scale
+			);
+			camera.matrixWorldInverse.copy(camera.matrixWorld).invert();
 
 			// Check if the projection uses an infinite far plane.
-			if ( projL[ 10 ] === - 1.0 ) {
-
+			if (projL[10] === -1.0) {
 				// Use the projection matrix from the left eye.
 				// The camera offset is sufficient to include the view volumes
 				// of both eyes (assuming symmetric projections).
-				camera.projectionMatrix.copy( cameraL.projectionMatrix );
-				camera.projectionMatrixInverse.copy( cameraL.projectionMatrixInverse );
-
+				camera.projectionMatrix.copy(cameraL.projectionMatrix);
+				camera.projectionMatrixInverse.copy(cameraL.projectionMatrixInverse);
 			} else {
-
 				// Find the union of the frustum values of the cameras and scale
 				// the values so that the near plane's position does not change in world space,
 				// although must now be relative to the new union camera.
 				const near2 = near + zOffset;
 				const far2 = far + zOffset;
 				const left2 = left - xOffset;
-				const right2 = right + ( ipd - xOffset );
-				const top2 = topFov * far / far2 * near2;
-				const bottom2 = bottomFov * far / far2 * near2;
+				const right2 = right + (ipd - xOffset);
+				const top2 = ((topFov * far) / far2) * near2;
+				const bottom2 = ((bottomFov * far) / far2) * near2;
 
-				camera.projectionMatrix.makePerspective( left2, right2, top2, bottom2, near2, far2 );
-				camera.projectionMatrixInverse.copy( camera.projectionMatrix ).invert();
-
+				camera.projectionMatrix.makePerspective(
+					left2,
+					right2,
+					top2,
+					bottom2,
+					near2,
+					far2
+				);
+				camera.projectionMatrixInverse.copy(camera.projectionMatrix).invert();
 			}
-
 		}
 
-		function updateCamera( camera, parent ) {
-
-			if ( parent === null ) {
-
-				camera.matrixWorld.copy( camera.matrix );
-
+		function updateCamera(camera, parent) {
+			if (parent === null) {
+				camera.matrixWorld.copy(camera.matrix);
 			} else {
-
-				camera.matrixWorld.multiplyMatrices( parent.matrixWorld, camera.matrix );
-
+				camera.matrixWorld.multiplyMatrices(parent.matrixWorld, camera.matrix);
 			}
 
-			camera.matrixWorldInverse.copy( camera.matrixWorld ).invert();
-
+			camera.matrixWorldInverse.copy(camera.matrixWorld).invert();
 		}
 
 		/**
@@ -716,35 +676,33 @@ class WebXRManager extends EventDispatcher {
 		 *
 		 * @param {Camera} camera - The camera.
 		 */
-		this.updateCamera = function ( camera ) {
-
-			if ( session === null ) return;
+		this.updateCamera = function (camera) {
+			if (session === null) return;
 
 			let depthNear = camera.near;
 			let depthFar = camera.far;
 
-			if ( depthSensing.texture !== null ) {
-
-				if ( depthSensing.depthNear > 0 ) depthNear = depthSensing.depthNear;
-				if ( depthSensing.depthFar > 0 ) depthFar = depthSensing.depthFar;
-
+			if (depthSensing.texture !== null) {
+				if (depthSensing.depthNear > 0) depthNear = depthSensing.depthNear;
+				if (depthSensing.depthFar > 0) depthFar = depthSensing.depthFar;
 			}
 
 			cameraXR.near = cameraR.near = cameraL.near = depthNear;
 			cameraXR.far = cameraR.far = cameraL.far = depthFar;
 
-			if ( _currentDepthNear !== cameraXR.near || _currentDepthFar !== cameraXR.far ) {
-
+			if (
+				_currentDepthNear !== cameraXR.near ||
+				_currentDepthFar !== cameraXR.far
+			) {
 				// Note that the new renderState won't apply until the next frame. See #18320
 
-				session.updateRenderState( {
+				session.updateRenderState({
 					depthNear: cameraXR.near,
-					depthFar: cameraXR.far
-				} );
+					depthFar: cameraXR.far,
+				});
 
 				_currentDepthNear = cameraXR.near;
 				_currentDepthFar = cameraXR.far;
-
 			}
 
 			// inherit camera layers and enable eye layers (1 = left, 2 = right)
@@ -755,61 +713,47 @@ class WebXRManager extends EventDispatcher {
 			const parent = camera.parent;
 			const cameras = cameraXR.cameras;
 
-			updateCamera( cameraXR, parent );
+			updateCamera(cameraXR, parent);
 
-			for ( let i = 0; i < cameras.length; i ++ ) {
-
-				updateCamera( cameras[ i ], parent );
-
+			for (let i = 0; i < cameras.length; i++) {
+				updateCamera(cameras[i], parent);
 			}
 
 			// update projection matrix for proper view frustum culling
 
-			if ( cameras.length === 2 ) {
-
-				setProjectionFromUnion( cameraXR, cameraL, cameraR );
-
+			if (cameras.length === 2) {
+				setProjectionFromUnion(cameraXR, cameraL, cameraR);
 			} else {
-
 				// assume single camera setup (AR)
 
-				cameraXR.projectionMatrix.copy( cameraL.projectionMatrix );
-
+				cameraXR.projectionMatrix.copy(cameraL.projectionMatrix);
 			}
 
 			// update user camera and its children
 
-			updateUserCamera( camera, cameraXR, parent );
-
+			updateUserCamera(camera, cameraXR, parent);
 		};
 
-		function updateUserCamera( camera, cameraXR, parent ) {
-
-			if ( parent === null ) {
-
-				camera.matrix.copy( cameraXR.matrixWorld );
-
+		function updateUserCamera(camera, cameraXR, parent) {
+			if (parent === null) {
+				camera.matrix.copy(cameraXR.matrixWorld);
 			} else {
-
-				camera.matrix.copy( parent.matrixWorld );
+				camera.matrix.copy(parent.matrixWorld);
 				camera.matrix.invert();
-				camera.matrix.multiply( cameraXR.matrixWorld );
-
+				camera.matrix.multiply(cameraXR.matrixWorld);
 			}
 
-			camera.matrix.decompose( camera.position, camera.quaternion, camera.scale );
-			camera.updateMatrixWorld( true );
+			camera.matrix.decompose(camera.position, camera.quaternion, camera.scale);
+			camera.updateMatrixWorld(true);
 
-			camera.projectionMatrix.copy( cameraXR.projectionMatrix );
-			camera.projectionMatrixInverse.copy( cameraXR.projectionMatrixInverse );
+			camera.projectionMatrix.copy(cameraXR.projectionMatrix);
+			camera.projectionMatrixInverse.copy(cameraXR.projectionMatrixInverse);
 
-			if ( camera.isPerspectiveCamera ) {
-
-				camera.fov = RAD2DEG * 2 * Math.atan( 1 / camera.projectionMatrix.elements[ 5 ] );
+			if (camera.isPerspectiveCamera) {
+				camera.fov =
+					RAD2DEG * 2 * Math.atan(1 / camera.projectionMatrix.elements[5]);
 				camera.zoom = 1;
-
 			}
-
 		}
 
 		/**
@@ -823,9 +767,7 @@ class WebXRManager extends EventDispatcher {
 		 * @return {ArrayCamera} The XR camera.
 		 */
 		this.getCamera = function () {
-
 			return cameraXR;
-
 		};
 
 		/**
@@ -834,15 +776,11 @@ class WebXRManager extends EventDispatcher {
 		 * @return {number|undefined} The amount of foveation.
 		 */
 		this.getFoveation = function () {
-
-			if ( glProjLayer === null && glBaseLayer === null ) {
-
+			if (glProjLayer === null && glBaseLayer === null) {
 				return undefined;
-
 			}
 
 			return foveation;
-
 		};
 
 		/**
@@ -851,25 +789,19 @@ class WebXRManager extends EventDispatcher {
 		 * @param {number} value - A number in the range `[0,1]` where `0` means no foveation (full resolution)
 		 * and `1` means maximum foveation (the edges render at lower resolution).
 		 */
-		this.setFoveation = function ( value ) {
-
+		this.setFoveation = function (value) {
 			// 0 = no foveation = full resolution
 			// 1 = maximum foveation = the edges render at lower resolution
 
 			foveation = value;
 
-			if ( glProjLayer !== null ) {
-
+			if (glProjLayer !== null) {
 				glProjLayer.fixedFoveation = value;
-
 			}
 
-			if ( glBaseLayer !== null && glBaseLayer.fixedFoveation !== undefined ) {
-
+			if (glBaseLayer !== null && glBaseLayer.fixedFoveation !== undefined) {
 				glBaseLayer.fixedFoveation = value;
-
 			}
-
 		};
 
 		/**
@@ -878,9 +810,7 @@ class WebXRManager extends EventDispatcher {
 		 * @return {boolean} Whether depth sensing is supported or not.
 		 */
 		this.hasDepthSensing = function () {
-
 			return depthSensing.texture !== null;
-
 		};
 
 		/**
@@ -891,9 +821,7 @@ class WebXRManager extends EventDispatcher {
 		 * @return {Mesh} The depth sensing mesh.
 		 */
 		this.getDepthSensingMesh = function () {
-
-			return depthSensing.getMesh( cameraXR );
-
+			return depthSensing.getMesh(cameraXR);
 		};
 
 		/**
@@ -903,201 +831,177 @@ class WebXRManager extends EventDispatcher {
 		 * @param {XRCamera} xrCamera - The camera to query.
 		 * @return {?Texture} An opaque texture representing the current raw camera frame.
 		 */
-		this.getCameraTexture = function ( xrCamera ) {
-
-			return cameraAccessTextures[ xrCamera ];
-
+		this.getCameraTexture = function (xrCamera) {
+			return cameraAccessTextures[xrCamera];
 		};
 
 		// Animation Loop
 
 		let onAnimationFrameCallback = null;
 
-		function onAnimationFrame( time, frame ) {
-
-			pose = frame.getViewerPose( customReferenceSpace || referenceSpace );
+		function onAnimationFrame(time, frame) {
+			pose = frame.getViewerPose(customReferenceSpace || referenceSpace);
 			xrFrame = frame;
 
-			if ( pose !== null ) {
-
+			if (pose !== null) {
 				const views = pose.views;
 
-				if ( glBaseLayer !== null ) {
-
-					renderer.setRenderTargetFramebuffer( newRenderTarget, glBaseLayer.framebuffer );
-					renderer.setRenderTarget( newRenderTarget );
-
+				if (glBaseLayer !== null) {
+					renderer.setRenderTargetFramebuffer(
+						newRenderTarget,
+						glBaseLayer.framebuffer
+					);
+					renderer.setRenderTarget(newRenderTarget);
 				}
 
 				let cameraXRNeedsUpdate = false;
 
 				// check if it's necessary to rebuild cameraXR's camera list
 
-				if ( views.length !== cameraXR.cameras.length ) {
-
+				if (views.length !== cameraXR.cameras.length) {
 					cameraXR.cameras.length = 0;
 					cameraXRNeedsUpdate = true;
-
 				}
 
-				for ( let i = 0; i < views.length; i ++ ) {
-
-					const view = views[ i ];
+				for (let i = 0; i < views.length; i++) {
+					const view = views[i];
 
 					let viewport = null;
 
-					if ( glBaseLayer !== null ) {
-
-						viewport = glBaseLayer.getViewport( view );
-
+					if (glBaseLayer !== null) {
+						viewport = glBaseLayer.getViewport(view);
 					} else {
-
-						const glSubImage = glBinding.getViewSubImage( glProjLayer, view );
+						const glSubImage = glBinding.getViewSubImage(glProjLayer, view);
 						viewport = glSubImage.viewport;
 
 						// For side-by-side projection, we only produce a single texture for both eyes.
-						if ( i === 0 ) {
-
+						if (i === 0) {
 							renderer.setRenderTargetTextures(
 								newRenderTarget,
 								glSubImage.colorTexture,
-								glSubImage.depthStencilTexture );
+								glSubImage.depthStencilTexture
+							);
 
-							renderer.setRenderTarget( newRenderTarget );
-
+							renderer.setRenderTarget(newRenderTarget);
 						}
-
 					}
 
-					let camera = cameras[ i ];
+					let camera = cameras[i];
 
-					if ( camera === undefined ) {
-
+					if (camera === undefined) {
 						camera = new PerspectiveCamera();
-						camera.layers.enable( i );
+						camera.layers.enable(i);
 						camera.viewport = new Vector4();
-						cameras[ i ] = camera;
-
+						cameras[i] = camera;
 					}
 
-					camera.matrix.fromArray( view.transform.matrix );
-					camera.matrix.decompose( camera.position, camera.quaternion, camera.scale );
-					camera.projectionMatrix.fromArray( view.projectionMatrix );
-					camera.projectionMatrixInverse.copy( camera.projectionMatrix ).invert();
-					camera.viewport.set( viewport.x, viewport.y, viewport.width, viewport.height );
+					camera.matrix.fromArray(view.transform.matrix);
+					camera.matrix.decompose(
+						camera.position,
+						camera.quaternion,
+						camera.scale
+					);
+					camera.projectionMatrix.fromArray(view.projectionMatrix);
+					camera.projectionMatrixInverse.copy(camera.projectionMatrix).invert();
+					camera.viewport.set(
+						viewport.x,
+						viewport.y,
+						viewport.width,
+						viewport.height
+					);
 
-					if ( i === 0 ) {
-
-						cameraXR.matrix.copy( camera.matrix );
-						cameraXR.matrix.decompose( cameraXR.position, cameraXR.quaternion, cameraXR.scale );
-
+					if (i === 0) {
+						cameraXR.matrix.copy(camera.matrix);
+						cameraXR.matrix.decompose(
+							cameraXR.position,
+							cameraXR.quaternion,
+							cameraXR.scale
+						);
 					}
 
-					if ( cameraXRNeedsUpdate === true ) {
-
-						cameraXR.cameras.push( camera );
-
+					if (cameraXRNeedsUpdate === true) {
+						cameraXR.cameras.push(camera);
 					}
-
 				}
 
 				//
 
 				const enabledFeatures = session.enabledFeatures;
-				const gpuDepthSensingEnabled = enabledFeatures &&
-					enabledFeatures.includes( 'depth-sensing' ) &&
-					session.depthUsage == 'gpu-optimized';
+				const gpuDepthSensingEnabled =
+					enabledFeatures &&
+					enabledFeatures.includes("depth-sensing") &&
+					session.depthUsage == "gpu-optimized";
 
-				if ( gpuDepthSensingEnabled && supportsGlBinding ) {
-
+				if (gpuDepthSensingEnabled && supportsGlBinding) {
 					glBinding = scope.getBinding();
 
-					const depthData = glBinding.getDepthInformation( views[ 0 ] );
+					const depthData = glBinding.getDepthInformation(views[0]);
 
-					if ( depthData && depthData.isValid && depthData.texture ) {
-
-						depthSensing.init( depthData, session.renderState );
-
+					if (depthData && depthData.isValid && depthData.texture) {
+						depthSensing.init(depthData, session.renderState);
 					}
-
 				}
 
-				const cameraAccessEnabled = enabledFeatures &&
-				    enabledFeatures.includes( 'camera-access' );
+				const cameraAccessEnabled =
+					enabledFeatures && enabledFeatures.includes("camera-access");
 
-				if ( cameraAccessEnabled && supportsGlBinding ) {
-
+				if (cameraAccessEnabled && supportsGlBinding) {
 					renderer.state.unbindTexture();
 
 					glBinding = scope.getBinding();
 
-					for ( let i = 0; i < views.length; i ++ ) {
+					for (let i = 0; i < views.length; i++) {
+						const camera = views[i].camera;
 
-						const camera = views[ i ].camera;
+						if (camera) {
+							let cameraTex = cameraAccessTextures[camera];
 
-						if ( camera ) {
-
-							let cameraTex = cameraAccessTextures[ camera ];
-
-							if ( ! cameraTex ) {
-
+							if (!cameraTex) {
 								cameraTex = new ExternalTexture();
-								cameraAccessTextures[ camera ] = cameraTex;
-
+								cameraAccessTextures[camera] = cameraTex;
 							}
 
-							const glTexture = glBinding.getCameraImage( camera );
+							const glTexture = glBinding.getCameraImage(camera);
 							cameraTex.sourceTexture = glTexture;
-
 						}
-
 					}
-
 				}
-
 			}
 
 			//
 
-			for ( let i = 0; i < controllers.length; i ++ ) {
+			for (let i = 0; i < controllers.length; i++) {
+				const inputSource = controllerInputSources[i];
+				const controller = controllers[i];
 
-				const inputSource = controllerInputSources[ i ];
-				const controller = controllers[ i ];
-
-				if ( inputSource !== null && controller !== undefined ) {
-
-					controller.update( inputSource, frame, customReferenceSpace || referenceSpace );
-
+				if (inputSource !== null && controller !== undefined) {
+					controller.update(
+						inputSource,
+						frame,
+						customReferenceSpace || referenceSpace
+					);
 				}
-
 			}
 
-			if ( onAnimationFrameCallback ) onAnimationFrameCallback( time, frame );
+			if (onAnimationFrameCallback) onAnimationFrameCallback(time, frame);
 
-			if ( frame.detectedPlanes ) {
-
-				scope.dispatchEvent( { type: 'planesdetected', data: frame } );
-
+			if (frame.detectedPlanes) {
+				scope.dispatchEvent({ type: "planesdetected", data: frame });
 			}
 
 			xrFrame = null;
-
 		}
 
 		const animation = new WebGLAnimation();
 
-		animation.setAnimationLoop( onAnimationFrame );
+		animation.setAnimationLoop(onAnimationFrame);
 
-		this.setAnimationLoop = function ( callback ) {
-
+		this.setAnimationLoop = function (callback) {
 			onAnimationFrameCallback = callback;
-
 		};
 
 		this.dispose = function () {};
-
 	}
-
 }
 
 export { WebXRManager };


### PR DESCRIPTION



## Problem

When running WebXR on Windows for both the WebGPU and WebGL only backends with the Meta Link, it currently crashes and gives the error:

WebXR sessions using `XRProjectionLayer` fail with:

```InvalidStateError: Failed to execute 'getViewSubImage' on 'XRWebGLBinding': Invalid frame state. There is no shared buffer for layer.```


## Cause

The backend checks *supports* `XRProjectionLayer` (`supportsLayers`), but does not verify the 'layers' feature is actually enabled in the session. Without the layers feature being requested and granted, the runtime doesn't allocate shared buffers for projection layers.

## Fix

Only use `XRProjectionLayer` when both conditions are met:
1. Browser supports the layers API
2. Session has the `'layers'` feature enabled (`session.enabledFeatures.includes('layers')`)

Otherwise, fall back to `XRWebGLLayer`.

## Testing

Tested on Windows with WebXR.
