### PR TITLE
WebGLRenderer: Fix `PCFSoftShadowMap` check.

### DIFF
--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -96,10 +96,10 @@ function WebGLShadowMap( renderer, objects, capabilities ) {
 
 		if ( lights.length === 0 ) return;
 
-		if ( lights.type === PCFSoftShadowMap ) {
+		if ( this.type === PCFSoftShadowMap ) {
 
 			warn( 'WebGLShadowMap: PCFSoftShadowMap has been deprecated. Using PCFShadowMap instead.' );
-			lights.type = PCFShadowMap;
+			this.type = PCFShadowMap;
 
 		}
 


### PR DESCRIPTION
Fixed #32591.

**Description**

I was wondering why using `PCFSoftShadowMap` in r182 produces no warning so I checked and realized there is a bug in `WebGLShadowMap`. The current shadow map type is checked on the wrong object reference.
