### PR TITLE
TSL: Introduce `clipSpace`

### DIFF
--- a/src/Three.TSL.js
+++ b/src/Three.TSL.js
@@ -127,6 +127,7 @@ export const clamp = TSL.clamp;
 export const clearcoat = TSL.clearcoat;
 export const clearcoatNormalView = TSL.clearcoatNormalView;
 export const clearcoatRoughness = TSL.clearcoatRoughness;
+export const clipSpace = TSL.clipSpace;
 export const code = TSL.code;
 export const color = TSL.color;
 export const colorSpaceToWorking = TSL.colorSpaceToWorking;

--- a/src/materials/nodes/NodeMaterial.js
+++ b/src/materials/nodes/NodeMaterial.js
@@ -531,7 +531,7 @@ class NodeMaterial extends Material {
 
 		const vertexNode = this.vertexNode || mvp;
 
-		clipSpace.assign( vertexNode );
+		builder.context.clipSpace = vertexNode;
 
 		builder.stack.outputNode = vertexNode;
 

--- a/src/materials/nodes/NodeMaterial.js
+++ b/src/materials/nodes/NodeMaterial.js
@@ -8,7 +8,7 @@ import { normalLocal } from '../../nodes/accessors/Normal.js';
 import { instancedMesh } from '../../nodes/accessors/InstancedMeshNode.js';
 import { batch } from '../../nodes/accessors/BatchNode.js';
 import { materialReference } from '../../nodes/accessors/MaterialReferenceNode.js';
-import { clipSpace, viewZ, positionLocal, positionView } from '../../nodes/accessors/Position.js';
+import { clipSpace, positionLocal, positionView } from '../../nodes/accessors/Position.js';
 import { skinning } from '../../nodes/accessors/SkinningNode.js';
 import { morphReference } from '../../nodes/accessors/MorphNode.js';
 import { fwidth, mix, smoothstep } from '../../nodes/math/MathNode.js';
@@ -738,7 +738,7 @@ class NodeMaterial extends Material {
 
 			} else if ( renderer.logarithmicDepthBuffer === true ) {
 
-				depthNode = viewZToLogarithmicDepth( viewZ, cameraNear, cameraFar );
+				depthNode = viewZToLogarithmicDepth( positionView.z, cameraNear, cameraFar );
 
 			}
 

--- a/src/materials/nodes/NodeMaterial.js
+++ b/src/materials/nodes/NodeMaterial.js
@@ -738,15 +738,7 @@ class NodeMaterial extends Material {
 
 			} else if ( renderer.logarithmicDepthBuffer === true ) {
 
-				if ( camera.isPerspectiveCamera ) {
-
-					depthNode = viewZToLogarithmicDepth( viewZ, cameraNear, cameraFar );
-
-				} else {
-
-					depthNode = viewZToLogarithmicDepth( viewZ, cameraNear, cameraFar );
-
-				}
+				depthNode = viewZToLogarithmicDepth( viewZ, cameraNear, cameraFar );
 
 			}
 

--- a/src/materials/nodes/NodeMaterial.js
+++ b/src/materials/nodes/NodeMaterial.js
@@ -8,7 +8,7 @@ import { normalLocal } from '../../nodes/accessors/Normal.js';
 import { instancedMesh } from '../../nodes/accessors/InstancedMeshNode.js';
 import { batch } from '../../nodes/accessors/BatchNode.js';
 import { materialReference } from '../../nodes/accessors/MaterialReferenceNode.js';
-import { clipSpace, positionLocal, positionView } from '../../nodes/accessors/Position.js';
+import { positionLocal, positionView } from '../../nodes/accessors/Position.js';
 import { skinning } from '../../nodes/accessors/SkinningNode.js';
 import { morphReference } from '../../nodes/accessors/MorphNode.js';
 import { fwidth, mix, smoothstep } from '../../nodes/math/MathNode.js';

--- a/src/materials/nodes/NodeMaterial.js
+++ b/src/materials/nodes/NodeMaterial.js
@@ -797,7 +797,7 @@ class NodeMaterial extends Material {
 
 		this.setupPosition( builder );
 
-		builder.context.vertex = builder.removeStack();
+		builder.context.position = builder.removeStack();
 
 		return modelViewProjection;
 

--- a/src/materials/nodes/NodeMaterial.js
+++ b/src/materials/nodes/NodeMaterial.js
@@ -16,7 +16,7 @@ import { float, vec3, vec4, bool } from '../../nodes/tsl/TSLBase.js';
 import AONode from '../../nodes/lighting/AONode.js';
 import { lightingContext } from '../../nodes/lighting/LightingContextNode.js';
 import IrradianceNode from '../../nodes/lighting/IrradianceNode.js';
-import { depth, viewZToLogarithmicDepth } from '../../nodes/display/ViewportDepthNode.js';
+import { depth, viewZToLogarithmicDepth, viewZToOrthographicDepth } from '../../nodes/display/ViewportDepthNode.js';
 import { cameraFar, cameraNear, cameraProjectionMatrix } from '../../nodes/accessors/Camera.js';
 import { clipping, clippingAlpha, hardwareClipping } from '../../nodes/accessors/ClippingNode.js';
 import NodeMaterialObserver from './manager/NodeMaterialObserver.js';
@@ -722,7 +722,7 @@ class NodeMaterial extends Material {
 	 */
 	setupDepth( builder ) {
 
-		const { renderer } = builder;
+		const { renderer, camera } = builder;
 
 		// Depth
 
@@ -738,7 +738,15 @@ class NodeMaterial extends Material {
 
 			} else if ( renderer.logarithmicDepthBuffer === true ) {
 
-				depthNode = viewZToLogarithmicDepth( positionView.z, cameraNear, cameraFar );
+				if ( camera.isPerspectiveCamera ) {
+
+					depthNode = viewZToLogarithmicDepth( positionView.z, cameraNear, cameraFar );
+
+				} else {
+
+					depthNode = viewZToOrthographicDepth( positionView.z, cameraNear, cameraFar );
+
+				}
 
 			}
 

--- a/src/materials/nodes/NodeMaterial.js
+++ b/src/materials/nodes/NodeMaterial.js
@@ -8,7 +8,7 @@ import { normalLocal } from '../../nodes/accessors/Normal.js';
 import { instancedMesh } from '../../nodes/accessors/InstancedMeshNode.js';
 import { batch } from '../../nodes/accessors/BatchNode.js';
 import { materialReference } from '../../nodes/accessors/MaterialReferenceNode.js';
-import { clipSpace, positionLocal, positionView } from '../../nodes/accessors/Position.js';
+import { clipSpace, viewZ, positionLocal, positionView } from '../../nodes/accessors/Position.js';
 import { skinning } from '../../nodes/accessors/SkinningNode.js';
 import { morphReference } from '../../nodes/accessors/MorphNode.js';
 import { fwidth, mix, smoothstep } from '../../nodes/math/MathNode.js';
@@ -16,7 +16,7 @@ import { float, vec3, vec4, bool } from '../../nodes/tsl/TSLBase.js';
 import AONode from '../../nodes/lighting/AONode.js';
 import { lightingContext } from '../../nodes/lighting/LightingContextNode.js';
 import IrradianceNode from '../../nodes/lighting/IrradianceNode.js';
-import { depth, orthographicDepthToViewZ, viewZToLogarithmicDepth } from '../../nodes/display/ViewportDepthNode.js';
+import { depth, viewZToLogarithmicDepth } from '../../nodes/display/ViewportDepthNode.js';
 import { cameraFar, cameraNear, cameraProjectionMatrix } from '../../nodes/accessors/Camera.js';
 import { clipping, clippingAlpha, hardwareClipping } from '../../nodes/accessors/ClippingNode.js';
 import NodeMaterialObserver from './manager/NodeMaterialObserver.js';
@@ -740,11 +740,9 @@ class NodeMaterial extends Material {
 
 				if ( camera.isPerspectiveCamera ) {
 
-					depthNode = viewZToLogarithmicDepth( clipSpace.w.negate(), cameraNear, cameraFar );
+					depthNode = viewZToLogarithmicDepth( viewZ, cameraNear, cameraFar );
 
 				} else {
-
-					const viewZ = orthographicDepthToViewZ( clipSpace.z.div( clipSpace.w ), cameraNear, cameraFar );
 
 					depthNode = viewZToLogarithmicDepth( viewZ, cameraNear, cameraFar );
 

--- a/src/materials/nodes/NodeMaterial.js
+++ b/src/materials/nodes/NodeMaterial.js
@@ -722,7 +722,7 @@ class NodeMaterial extends Material {
 	 */
 	setupDepth( builder ) {
 
-		const { renderer, camera } = builder;
+		const { renderer } = builder;
 
 		// Depth
 

--- a/src/nodes/accessors/Position.js
+++ b/src/nodes/accessors/Position.js
@@ -82,23 +82,31 @@ export const positionView = /*@__PURE__*/ ( Fn( ( builder ) => {
  * @tsl
  * @type {Node<float>}
  */
-export const viewZ = ( Fn( ( { camera } ) => {
+export const viewZ = ( Fn( ( builder ) => {
 
 	let node;
 
-	if ( camera.isPerspectiveCamera ) {
+	if ( builder.shaderStage === 'vertex' ) {
 
-		node = clipSpace.w.negate();
+		node = positionView.z;
 
 	} else {
 
-		node = orthographicDepthToViewZ( clipSpace.z.div( clipSpace.w ), cameraNear, cameraFar );
+		if ( builder.camera.isPerspectiveCamera ) {
+
+			node = clipSpace.w.negate();
+
+		} else {
+
+			node = orthographicDepthToViewZ( clipSpace.z.div( clipSpace.w ), cameraNear, cameraFar );
+
+		}
 
 	}
 
 	return node;
 
-} ).once( [ 'POSITION' ] ) )().toVar( 'viewZ' );
+} ).once( [ 'POSITION', 'VERTEX' ] ) )().toVar( 'viewZ' );
 
 /**
  * TSL object that represents the position view direction of the current rendered object.

--- a/src/nodes/accessors/Position.js
+++ b/src/nodes/accessors/Position.js
@@ -2,7 +2,7 @@ import { attribute } from '../core/AttributeNode.js';
 import { varyingProperty } from '../core/PropertyNode.js';
 import { Fn, vec3 } from '../tsl/TSLCore.js';
 import { modelWorldMatrix } from './ModelNode.js';
-import { cameraProjectionMatrixInverse } from './Camera.js';
+import { cameraProjectionMatrixInverse, cameraWorldMatrix } from './Camera.js';
 
 /**
  * TSL object that represents the clip space position of the current rendered object.
@@ -44,6 +44,14 @@ export const positionPrevious = /*@__PURE__*/ positionGeometry.toVarying( 'posit
  * @type {VaryingNode<vec3>}
  */
 export const positionWorld = /*@__PURE__*/ ( Fn( ( builder ) => {
+
+	if ( builder.shaderStage === 'fragment' && builder.material.vertexNode ) {
+
+		// reconstruct world position from view position
+
+		return cameraWorldMatrix.mul( positionView ).xyz.toVar( 'positionWorld' );
+
+	}
 
 	return modelWorldMatrix.mul( positionLocal ).xyz.toVarying( builder.getSubBuildProperty( 'v_positionWorld' ) );
 

--- a/src/nodes/accessors/Position.js
+++ b/src/nodes/accessors/Position.js
@@ -71,25 +71,19 @@ export const positionWorldDirection = /*@__PURE__*/ ( Fn( () => {
  */
 export const positionView = /*@__PURE__*/ ( Fn( ( builder ) => {
 
-	let node;
+	if ( builder.shaderStage === 'fragment' && builder.material.vertexNode ) {
 
-	if ( builder.shaderStage === 'fragment' ) {
-
-		// Reconstruct view position from clip space
+		// reconstruct view position from clip space
 
 		const viewPos = cameraProjectionMatrixInverse.mul( clipSpace );
 
-		node = viewPos.xyz.div( viewPos.w );
-
-	} else {
-
-		node = builder.context.setupPositionView();
+		return viewPos.xyz.div( viewPos.w ).toVar( 'positionView' );
 
 	}
 
-	return node;
+	return builder.context.setupPositionView().toVarying( 'v_positionView' );
 
-}, 'vec3' ).once( [ 'POSITION', 'VERTEX' ] ) )().toVar( 'positionView' );
+}, 'vec3' ).once( [ 'POSITION' ] ) )();
 
 /**
  * TSL object that represents the position view direction of the current rendered object.

--- a/src/nodes/accessors/Position.js
+++ b/src/nodes/accessors/Position.js
@@ -12,9 +12,9 @@ import { warnOnce } from '../../utils.js';
  */
 export const clipSpace = /*@__PURE__*/ ( Fn( ( builder ) => {
 
-	if ( builder.shaderStage === 'vertex' ) {
+	if ( builder.shaderStage !== 'fragment' ) {
 
-		warnOnce( 'TSL: `clipSpace` is not available in vertex stage.' );
+		warnOnce( 'TSL: `clipSpace` is only available in fragment stage.' );
 
 		return vec3();
 

--- a/src/nodes/accessors/Position.js
+++ b/src/nodes/accessors/Position.js
@@ -78,7 +78,7 @@ export const positionView = /*@__PURE__*/ ( Fn( ( builder ) => {
 		// Reconstruct view position from clip space
 
 		const viewPos = cameraProjectionMatrixInverse.mul( clipSpace );
-		
+
 		node = viewPos.xyz.div( viewPos.w );
 
 	} else {

--- a/src/nodes/accessors/Position.js
+++ b/src/nodes/accessors/Position.js
@@ -1,5 +1,5 @@
 import { attribute } from '../core/AttributeNode.js';
-import { Fn, vec3 } from '../tsl/TSLCore.js';
+import { Fn, vec3, vec4 } from '../tsl/TSLCore.js';
 import { modelWorldMatrix } from './ModelNode.js';
 import { cameraProjectionMatrixInverse, cameraWorldMatrix } from './Camera.js';
 import { warnOnce } from '../../utils.js';
@@ -16,7 +16,7 @@ export const clipSpace = /*@__PURE__*/ ( Fn( ( builder ) => {
 
 		warnOnce( 'TSL: `clipSpace` is only available in fragment stage.' );
 
-		return vec3();
+		return vec4();
 
 	}
 

--- a/src/nodes/accessors/Position.js
+++ b/src/nodes/accessors/Position.js
@@ -1,8 +1,8 @@
 import { attribute } from '../core/AttributeNode.js';
-import { varyingProperty } from '../core/PropertyNode.js';
 import { Fn, vec3 } from '../tsl/TSLCore.js';
 import { modelWorldMatrix } from './ModelNode.js';
 import { cameraProjectionMatrixInverse, cameraWorldMatrix } from './Camera.js';
+import { warnOnce } from '../../utils.js';
 
 /**
  * TSL object that represents the clip space position of the current rendered object.
@@ -10,7 +10,19 @@ import { cameraProjectionMatrixInverse, cameraWorldMatrix } from './Camera.js';
  * @tsl
  * @type {VaryingNode<vec4>}
  */
-export const clipSpace = /*@__PURE__*/ varyingProperty( 'vec4', 'clipSpace' );
+export const clipSpace = /*@__PURE__*/ ( Fn( ( builder ) => {
+
+	if ( builder.shaderStage === 'vertex' ) {
+
+		warnOnce( 'TSL: `clipSpace` is not available in vertex stage.' );
+
+		return vec3();
+
+	}
+
+	return builder.context.clipSpace.toVarying( 'v_clipSpace' );
+
+} ).once() )();
 
 /**
  * TSL object that represents the position attribute of the current rendered object.

--- a/src/nodes/accessors/Position.js
+++ b/src/nodes/accessors/Position.js
@@ -2,6 +2,8 @@ import { attribute } from '../core/AttributeNode.js';
 import { varyingProperty } from '../core/PropertyNode.js';
 import { Fn, vec3 } from '../tsl/TSLCore.js';
 import { modelWorldMatrix } from './ModelNode.js';
+import { orthographicDepthToViewZ } from '../../nodes/display/ViewportDepthNode.js';
+import { cameraFar, cameraNear } from './Camera.js';
 
 /**
  * TSL object that represents the clip space position of the current rendered object.
@@ -73,6 +75,30 @@ export const positionView = /*@__PURE__*/ ( Fn( ( builder ) => {
 	return builder.context.setupPositionView().toVarying( 'v_positionView' );
 
 }, 'vec3' ).once( [ 'POSITION' ] ) )();
+
+/**
+ * TSL object that represents the view space Z position of the current rendered object.
+ *
+ * @tsl
+ * @type {Node<float>}
+ */
+export const viewZ = ( Fn( ( { camera } ) => {
+
+	let node;
+
+	if ( camera.isPerspectiveCamera ) {
+
+		node = clipSpace.w.negate();
+
+	} else {
+
+		node = orthographicDepthToViewZ( clipSpace.z.div( clipSpace.w ), cameraNear, cameraFar );
+
+	}
+
+	return node;
+
+} ).once( [ 'POSITION' ] ) )().toVar( 'viewZ' );
 
 /**
  * TSL object that represents the position view direction of the current rendered object.

--- a/src/nodes/accessors/Position.js
+++ b/src/nodes/accessors/Position.js
@@ -77,9 +77,9 @@ export const positionView = /*@__PURE__*/ ( Fn( ( builder ) => {
 
 		// Reconstruct view position from clip space
 
-		const viewPos4 = cameraProjectionMatrixInverse.mul( clipSpace );
+		const viewPos = cameraProjectionMatrixInverse.mul( clipSpace );
 		
-		node = viewPos4.xyz.div( viewPos4.w );
+		node = viewPos.xyz.div( viewPos.w );
 
 	} else {
 

--- a/src/nodes/accessors/Position.js
+++ b/src/nodes/accessors/Position.js
@@ -1,6 +1,15 @@
 import { attribute } from '../core/AttributeNode.js';
+import { varyingProperty } from '../core/PropertyNode.js';
 import { Fn, vec3 } from '../tsl/TSLCore.js';
 import { modelWorldMatrix } from './ModelNode.js';
+
+/**
+ * TSL object that represents the clip space position of the current rendered object.
+ *
+ * @tsl
+ * @type {VaryingNode<vec4>}
+ */
+export const clipSpace = /*@__PURE__*/ varyingProperty( 'vec4', 'clipSpace' );
 
 /**
  * TSL object that represents the position attribute of the current rendered object.

--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -2916,9 +2916,9 @@ class NodeBuilder {
 
 			this.setBuildStage( buildStage );
 
-			if ( this.context.vertex && this.context.vertex.isNode ) {
+			if ( this.context.position && this.context.position.isNode ) {
 
-				this.flowNodeFromShaderStage( 'vertex', this.context.vertex );
+				this.flowNodeFromShaderStage( 'vertex', this.context.position );
 
 			}
 

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -1663,7 +1663,7 @@ ${ flowData.code }
 
 		if ( shaderStage === 'vertex' ) {
 
-			this.getBuiltin( 'position', 'Vertex', 'vec4<f32>', 'vertex' );
+			this.getBuiltin( 'position', 'builtinClipSpace', 'vec4<f32>', 'vertex' );
 
 		}
 
@@ -1961,7 +1961,7 @@ ${ flowData.code }
 
 					if ( shaderStage === 'vertex' ) {
 
-						flow += `varyings.Vertex = ${ flowSlotData.result };`;
+						flow += `varyings.builtinClipSpace = ${ flowSlotData.result };`;
 
 					} else if ( shaderStage === 'fragment' ) {
 


### PR DESCRIPTION
Fixes https://github.com/mrdoob/three.js/issues/32583#issuecomment-3677462510

**Description**

Adds `clipSpace` and rebuilds `positionView` from `clipSpace` if `material.vertexNode` is used.

This should correct view-z discrepancies in custom shaders at the `vertexNode`.
