### PR TITLE
NodeMaterial: Add `maskShadowNode`

### DIFF
--- a/examples/webgpu_shadowmap.html
+++ b/examples/webgpu_shadowmap.html
@@ -107,22 +107,7 @@
 			
 				const discardNode = hash( vertexIndex ).greaterThan( 0.5 );
 
-				materialCustomShadow.colorNode = Fn( () => {
-
-					discardNode.discard();
-
-					return materialColor;
-
-				} )();
-
-
-				materialCustomShadow.castShadowNode = Fn( () => {
-
-					discardNode.discard();
-
-					return materialColor;
-			
-				} )();
+				materialCustomShadow.maskNode = discardNode;
 
 				torusKnot = new THREE.Mesh( geometry, materialCustomShadow );
 				torusKnot.scale.multiplyScalar( 1 / 18 );

--- a/examples/webgpu_tsl_angular_slicing.html
+++ b/examples/webgpu_tsl_angular_slicing.html
@@ -113,13 +113,16 @@
 				const sliceArc = uniform( 1.25 );
 				const sliceColor = uniform( color( '#b62f58' ) );
 
+				// mask
+
+				const mask = inAngle( positionLocal.xy, sliceStart, sliceArc ).not();
+
+				slicedMaterial.maskNode = mask;
+				//slicedMaterial.maskShadowNode = mask; // optional: custom mask shadows
+
 				// output
 
 				slicedMaterial.outputNode = Fn( () => {
-
-					// discard
-
-					inAngle( positionLocal.xy, sliceStart, sliceArc ).discard();
 
 					// backface color
 
@@ -131,18 +134,6 @@
 					} );
 			
 					return finalOutput;
-			
-				} )();
-
-				// shadow
-
-				slicedMaterial.castShadowNode = Fn( () => {
-
-					// discard
-
-					inAngle( positionLocal.xy, sliceStart, sliceArc ).discard();
-
-					return vec4( 0, 0, 0, 1 );
 			
 				} )();
 

--- a/src/materials/nodes/NodeMaterial.js
+++ b/src/materials/nodes/NodeMaterial.js
@@ -241,6 +241,14 @@ class NodeMaterial extends Material {
 		this.maskNode = null;
 
 		/**
+		 * This node can be used to implement a shadow mask for the material.
+		 * 
+		 * @type {?Node<bool>}
+		 * @default null
+		 */
+		this.maskShadowNode = null;
+
+		/**
 		 * The local vertex positions are computed based on multiple factors like the
 		 * attribute data, morphing or skinning. This node property allows to overwrite
 		 * the default and define local vertex positions with nodes instead.
@@ -1339,6 +1347,7 @@ class NodeMaterial extends Material {
 		this.backdropAlphaNode = source.backdropAlphaNode;
 		this.alphaTestNode = source.alphaTestNode;
 		this.maskNode = source.maskNode;
+		this.maskShadowNode = source.maskShadowNode;
 
 		this.positionNode = source.positionNode;
 		this.geometryNode = source.geometryNode;

--- a/src/materials/nodes/NodeMaterial.js
+++ b/src/materials/nodes/NodeMaterial.js
@@ -242,7 +242,7 @@ class NodeMaterial extends Material {
 
 		/**
 		 * This node can be used to implement a shadow mask for the material.
-		 * 
+		 *
 		 * @type {?Node<bool>}
 		 * @default null
 		 */

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -32,7 +32,7 @@ import { Vector4 } from '../../math/Vector4.js';
 import { RenderTarget } from '../../core/RenderTarget.js';
 import { DoubleSide, BackSide, FrontSide, SRGBColorSpace, NoToneMapping, LinearFilter, HalfFloatType, RGBAFormat, PCFShadowMap } from '../../constants.js';
 
-import { float, vec3, vec4 } from '../../nodes/tsl/TSLCore.js';
+import { float, vec3, vec4, Fn } from '../../nodes/tsl/TSLCore.js';
 import { reference } from '../../nodes/accessors/ReferenceNode.js';
 import { highpModelNormalViewMatrix, highpModelViewMatrix } from '../../nodes/accessors/ModelNode.js';
 import { context } from '../../nodes/core/ContextNode.js';
@@ -3035,12 +3035,13 @@ class Renderer {
 			const hasMap = material.map !== null;
 			const hasColorNode = material.colorNode && material.colorNode.isNode;
 			const hasCastShadowNode = material.castShadowNode && material.castShadowNode.isNode;
+			const hasMaskNode = ( material.maskShadowNode && material.maskShadowNode.isNode ) || ( material.maskNode && material.maskNode.isNode );
 
 			let positionNode = null;
 			let colorNode = null;
 			let depthNode = null;
 
-			if ( hasMap || hasColorNode || hasCastShadowNode ) {
+			if ( hasMap || hasColorNode || hasCastShadowNode || hasMaskNode ) {
 
 				let shadowRGB;
 				let shadowAlpha;
@@ -3070,6 +3071,20 @@ class Renderer {
 				}
 
 				colorNode = vec4( shadowRGB, shadowAlpha );
+
+				if ( hasMaskNode ) {
+
+					const maskNode = material.maskShadowNode || material.maskNode;
+
+					colorNode = Fn( ( [ color ] ) => {
+
+						maskNode.not().discard();
+
+						return color;
+
+					} )( colorNode );
+
+				}
 
 			}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/32596

**Description**

This PR implements `maskShadowNode` and also corrects when `maskNode` was not applying to shadows; this should simplify the examples when masks are applied considering the shadow.

It is also possible to use `maskShadowNode` and `maskNode` individually.

/cc @RenaudRohlinger  @brunosimon