### PR TITLE
WebGPURenderer: Unify uniformGroup bindings across shader stages

### DIFF
--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -653,7 +653,16 @@ class NodeBuilder {
 					const uniforms = bindings[ shaderStage ][ groupName ];
 
 					const groupUniforms = groups[ groupName ] || ( groups[ groupName ] = [] );
-					groupUniforms.push( ...uniforms );
+
+					for ( const uniform of uniforms ) {
+
+						if ( groupUniforms.includes( uniform ) === false ) {
+
+							groupUniforms.push( uniform );
+
+						}
+
+					}
 
 				}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/32534

**Description**

Fixes duplicate binding declarations for uniformGroups when the same  group is used in both vertex and fragment shaders. Previously, each shader stage would increment the binding index independently, causing mismatched binding indices when shared.

No changes were needed for `GLSLNodeBuilder`.
