### PR TITLE
Fix JSDoc Example

### DIFF
--- a/src/nodes/core/MRTNode.js
+++ b/src/nodes/core/MRTNode.js
@@ -31,7 +31,7 @@ export function getTextureIndex( textures, name ) {
  * const mrtNode = mrt( {
  *   output: output,
  *   normal: normalView
- * } ) );
+ * } ) ;
  * ```
  * The MRT output is defined as a dictionary.
  *


### PR DESCRIPTION
**Description**
Fix syntax error in MRTNode JSDoc example

Remove extra closing parenthesis in the MRTNode class JSDoc code example.
The example had `} ) );` instead of `} );` 
