### PR TITLE
GLTFExporter: Fix skinIndex export for InterleavedBufferAttribute

### DIFF
--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -1852,7 +1852,17 @@ class GLTFWriter {
 				! ( array instanceof Uint8Array ) ) {
 
 				console.warn( 'GLTFExporter: Attribute "skinIndex" converted to type UNSIGNED_SHORT.' );
-				modifiedAttribute = new BufferAttribute( new Uint16Array( array ), attribute.itemSize, attribute.normalized );
+				modifiedAttribute = new BufferAttribute( new Uint16Array( attribute.count * attribute.itemSize ), attribute.itemSize, attribute.normalized );
+
+				for ( let i = 0; i < attribute.count; i ++ ) {
+
+					for ( let j = 0; j < attribute.itemSize; j ++ ) {
+
+						modifiedAttribute.setComponent( i, j, attribute.getComponent( i, j ) );
+
+					}
+
+				}
 
 			} else if ( ( array instanceof Uint32Array || array instanceof Int32Array ) && ! attributeName.startsWith( '_' ) ) {
 

--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -1852,22 +1852,12 @@ class GLTFWriter {
 				! ( array instanceof Uint8Array ) ) {
 
 				console.warn( 'GLTFExporter: Attribute "skinIndex" converted to type UNSIGNED_SHORT.' );
-				modifiedAttribute = new BufferAttribute( new Uint16Array( attribute.count * attribute.itemSize ), attribute.itemSize, attribute.normalized );
-
-				for ( let i = 0; i < attribute.count; i ++ ) {
-
-					for ( let j = 0; j < attribute.itemSize; j ++ ) {
-
-						modifiedAttribute.setComponent( i, j, attribute.getComponent( i, j ) );
-
-					}
-
-				}
+				modifiedAttribute = GLTFExporter.Utils.toTypedBufferAttribute( attribute, Uint16Array );
 
 			} else if ( ( array instanceof Uint32Array || array instanceof Int32Array ) && ! attributeName.startsWith( '_' ) ) {
 
 				console.warn( `GLTFExporter: Attribute "${ attributeName }" converted to type FLOAT.` );
-				modifiedAttribute = GLTFExporter.Utils.toFloat32BufferAttribute( attribute );
+				modifiedAttribute = GLTFExporter.Utils.toTypedBufferAttribute( attribute, Float32Array );
 
 			}
 
@@ -3548,9 +3538,9 @@ GLTFExporter.Utils = {
 
 	},
 
-	toFloat32BufferAttribute: function ( srcAttribute ) {
+	toTypedBufferAttribute: function ( srcAttribute, TypedArray ) {
 
-		const dstAttribute = new BufferAttribute( new Float32Array( srcAttribute.count * srcAttribute.itemSize ), srcAttribute.itemSize, false );
+		const dstAttribute = new BufferAttribute( new TypedArray( srcAttribute.count * srcAttribute.itemSize ), srcAttribute.itemSize, false );
 
 		if ( ! srcAttribute.normalized && ! srcAttribute.isInterleavedBufferAttribute ) {
 


### PR DESCRIPTION
This PR fixes an issue in `GLTFExporter` where `skinIndex` (JOINTS_0) attributes were being exported incorrectly if they were stored as an `InterleavedBufferAttribute`.

The issue can cause this exception:

<img width="567" height="173" alt="Screenshot 2025-12-22 at 15 11 07" src="https://github.com/user-attachments/assets/2bcaa732-1e38-4162-805e-4860cc6eedf9" />


When `skinIndex` data needed to be converted to `UNSIGNED_SHORT` (e.g. if the source was `Uint32Array`), the exporter was creating a new `Uint16Array` directly from the underlying `attribute.array`.

For `InterleavedBufferAttribute`, `attribute.array` refers to the entire shared buffer containing data for multiple attributes. This resulted in the exported `skinIndex` accessor containing mixed data from other interleaved attributes, ignoring the stride and offset.