### PR TITLE
Examples: Update `webgpu_shadowmap`

### DIFF
--- a/examples/webgpu_shadowmap.html
+++ b/examples/webgpu_shadowmap.html
@@ -34,7 +34,7 @@
 		<script type="module">
 
 			import * as THREE from 'three/webgpu';
-			import { mx_fractal_noise_vec3, positionWorld, vec4, Fn, color, vertexIndex, hash } from 'three/tsl';
+			import { mx_fractal_noise_float, mx_fractal_noise_vec3, positionLocal, positionWorld, Fn, color } from 'three/tsl';
 
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 
@@ -103,9 +103,7 @@
 				const materialCustomShadow = material.clone();
 				materialCustomShadow.transparent = true;
 
-				const materialColor = vec4( 1, 0, 1, .5 );
-			
-				const discardNode = hash( vertexIndex ).greaterThan( 0.5 );
+				const discardNode = mx_fractal_noise_float( positionLocal.mul( 0.1 ) ).x.greaterThan( 0.0 );
 
 				materialCustomShadow.maskNode = discardNode;
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/32598#pullrequestreview-3604365913

**Description**

`vertexIndex` is producing different results on the backends. Replace the with `mx_fractal_noise_float` instead; `materialColor` shouldn't be necessary.