### PR TITLE
Renderer: Rename `shadowMap.colored` -> `shadowMap.transmitted`

### DIFF
--- a/examples/webgpu_caustics.html
+++ b/examples/webgpu_caustics.html
@@ -179,7 +179,7 @@
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setAnimationLoop( animate );
 				renderer.shadowMap.enabled = true;
-				renderer.shadowMap.colored = true;
+				renderer.shadowMap.transmitted = true;
 				renderer.inspector = new Inspector();
 				document.body.appendChild( renderer.domElement );
 

--- a/examples/webgpu_shadowmap_opacity.html
+++ b/examples/webgpu_shadowmap_opacity.html
@@ -59,7 +59,7 @@
 				renderer.toneMapping = THREE.AgXToneMapping;
 				renderer.toneMappingExposure = 1.5;
 				renderer.shadowMap.enabled = true;
-				renderer.shadowMap.colored = true;
+				renderer.shadowMap.transmitted = true;
 				renderer.inspector = new Inspector();
 				container.appendChild( renderer.domElement );
 

--- a/examples/webgpu_volume_caustics.html
+++ b/examples/webgpu_volume_caustics.html
@@ -165,7 +165,7 @@
 
 				renderer = new THREE.WebGPURenderer( { antialias: true } );
 				renderer.shadowMap.enabled = true;
-				renderer.shadowMap.colored = true;
+				renderer.shadowMap.transmitted = true;
 				renderer.inspector = new Inspector();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );

--- a/src/nodes/lighting/ShadowNode.js
+++ b/src/nodes/lighting/ShadowNode.js
@@ -518,7 +518,7 @@ class ShadowNode extends ShadowBaseNode {
 
 		let shadowColor;
 
-		if ( renderer.shadowMap.colored === true ) {
+		if ( renderer.shadowMap.transmitted === true ) {
 
 			if ( shadowMap.texture.isCubeTexture ) {
 

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -658,7 +658,7 @@ class Renderer {
 		 * Shadow map configuration
 		 * @typedef {Object} ShadowMapConfig
 		 * @property {boolean} enabled - Whether to globally enable shadows or not.
-		 * @property {boolean} colored - Whether shadows can have a custom color or not.
+		 * @property {boolean} transmitted - Whether to enable light transmission through non-opaque materials.
 		 * @property {number} type - The shadow map type.
 		 */
 
@@ -669,7 +669,7 @@ class Renderer {
 		 */
 		this.shadowMap = {
 			enabled: false,
-			colored: false,
+			transmitted: false,
 			type: PCFShadowMap
 		};
 
@@ -3053,9 +3053,9 @@ class Renderer {
 					shadowRGB = material.castShadowNode.rgb;
 					shadowAlpha = material.castShadowNode.a;
 
-					if ( this.shadowMap.colored !== true ) {
+					if ( this.shadowMap.transmitted !== true ) {
 
-						warnOnce( 'Renderer: `shadowMap.colored` needs to be set to `true` when using `material.castShadowNode`.' );
+						warnOnce( 'Renderer: `shadowMap.transmitted` needs to be set to `true` when using `material.castShadowNode`.' );
 
 					}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/32608/changes#r2641749091

**Description**

The term `transmitted` should imply that the shadow should somehow consider the transmission of light in non-opaque materials. It follows the physical principle more than the subjective like the previous one.

This should prepare three.js when we implement this in native materials; currently, the process is done manually through `material.castShadowNode`, and since this feature requires an extra texture per shadow, for optimization it comes [disabled](https://github.com/mrdoob/three.js/issues/32588#issuecomment-3677691658).