### PR TITLE
`BufferAttribute` type / precision conversion API

### DIFF
--- a/examples/jsm/objects/GroundedSkybox.js
+++ b/examples/jsm/objects/GroundedSkybox.js
@@ -1,4 +1,4 @@
-import { Mesh, MeshBasicMaterial, SphereGeometry, Vector3 } from 'three';
+import { Mesh, MeshBasicMaterial, SphereGeometry, Vector3, Float16BufferAttribute } from 'three';
 
 /**
  * A ground-projected skybox.
@@ -36,7 +36,13 @@ class GroundedSkybox extends Mesh {
 
 		}
 
-		const geometry = new SphereGeometry( radius, 2 * resolution, resolution );
+		const geometry = new SphereGeometry(radius, 2 * resolution, resolution, 0, Math.PI * 2, 0, Math.PI,
+			{
+				position: Float16BufferAttribute,
+				uv: Float16BufferAttribute,
+				normal: null
+			}
+		);
 		geometry.scale( 1, 1, - 1 );
 
 		const pos = geometry.getAttribute( 'position' );
@@ -52,7 +58,7 @@ class GroundedSkybox extends Mesh {
 				const f =
 						tmp.y < y1 ? - height / tmp.y : ( 1 - tmp.y * tmp.y / ( 3 * y1 * y1 ) );
 				tmp.multiplyScalar( f );
-				tmp.toArray( pos.array, 3 * i );
+				pos.setXYZ(i, tmp.x, tmp.y, tmp.z);
 
 			}
 
@@ -60,7 +66,7 @@ class GroundedSkybox extends Mesh {
 
 		pos.needsUpdate = true;
 
-		super( geometry, new MeshBasicMaterial( { map, depthWrite: false } ) );
+		super(geometry, new MeshBasicMaterial({ map, depthWrite: false, name: "GroundedSkybox" }));
 
 	}
 

--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -654,6 +654,40 @@ class BufferAttribute {
 	}
 
 	/**
+	 * Return this BufferAttribute with a different type.
+	 *
+	 * @param {Function} TargetType - BufferAttribute type to return.
+	 * @return {BufferAttribute} Converted BufferAttribute.
+	 */
+	convert( TargetType ) {
+
+		if ( this.constructor === TargetType ) return this;
+
+		const target = new TargetType( this.count * this.itemSize, this.itemSize, this.normalized );
+
+		if ( target.isFloat16BufferAttribute )
+			target.normalized = false;
+
+		for ( let i = 0; i < this.count; ++ i ) {
+
+			switch ( this.itemSize ) {
+
+				case 1: target.setX( i, this.getX( i ) ); break;
+				case 2: target.setXY( i, this.getX( i ), this.getY( i ) ); break;
+				case 3: target.setXYZ( i, this.getX( i ), this.getY( i ), this.getZ( i ) ); break;
+				case 4: target.setXYZW( i, this.getX( i ), this.getY( i ), this.getZ( i ), this.getW( i ) ); break;
+
+			}
+
+		}
+
+		target.name = this.name;
+
+		return target;
+
+	}
+
+	/**
 	 * Serializes the buffer attribute into JSON.
 	 *
 	 * @return {Object} A JSON object representing the serialized buffer attribute.

--- a/src/geometries/SphereGeometry.js
+++ b/src/geometries/SphereGeometry.js
@@ -29,7 +29,7 @@ class SphereGeometry extends BufferGeometry {
 	 * @param {number} [thetaLength=Math.PI] - The vertical sweep angle size.
 	 * @param {Object} [attributes={}] - Attribute precision specifiers.
 	 */
-	constructor(radius = 1, widthSegments = 32, heightSegments = 16, phiStart = 0, phiLength = Math.PI * 2, thetaStart = 0, thetaLength = Math.PI, precision = { position: Float32BufferAttribute, uv: Float32BufferAttribute, normal: Float32BufferAttribute } ) {
+	constructor( radius = 1, widthSegments = 32, heightSegments = 16, phiStart = 0, phiLength = Math.PI * 2, thetaStart = 0, thetaLength = Math.PI, precision = { position: Float32BufferAttribute, uv: Float32BufferAttribute, normal: Float32BufferAttribute } ) {
 
 		super();
 

--- a/src/geometries/SphereGeometry.js
+++ b/src/geometries/SphereGeometry.js
@@ -27,8 +27,9 @@ class SphereGeometry extends BufferGeometry {
 	 * @param {number} [phiLength=Math.PI*2] - The horizontal sweep angle size.
 	 * @param {number} [thetaStart=0] - The vertical starting angle in radians.
 	 * @param {number} [thetaLength=Math.PI] - The vertical sweep angle size.
+	 * @param {Object} [attributes={}] - Attribute precision specifiers.
 	 */
-	constructor( radius = 1, widthSegments = 32, heightSegments = 16, phiStart = 0, phiLength = Math.PI * 2, thetaStart = 0, thetaLength = Math.PI ) {
+	constructor(radius = 1, widthSegments = 32, heightSegments = 16, phiStart = 0, phiLength = Math.PI * 2, thetaStart = 0, thetaLength = Math.PI, precision = { position: Float32BufferAttribute, uv: Float32BufferAttribute, normal: Float32BufferAttribute } ) {
 
 		super();
 
@@ -48,7 +49,8 @@ class SphereGeometry extends BufferGeometry {
 			phiStart: phiStart,
 			phiLength: phiLength,
 			thetaStart: thetaStart,
-			thetaLength: thetaLength
+			thetaLength: thetaLength,
+			precision: precision
 		};
 
 		widthSegments = Math.max( 3, Math.floor( widthSegments ) );
@@ -141,9 +143,11 @@ class SphereGeometry extends BufferGeometry {
 		// build geometry
 
 		this.setIndex( indices );
-		this.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
-		this.setAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
-		this.setAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
+		this.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ).convert( precision.position ) );
+		if ( precision.normal !== null )
+			this.setAttribute( 'normal', new Float32BufferAttribute( normals, 3, true ).convert( precision.normal ) );
+		if ( precision.uv !== null )
+			this.setAttribute( 'uv', new Float32BufferAttribute( uvs, 2, true ).convert( precision.uv ) );
 
 	}
 
@@ -166,7 +170,7 @@ class SphereGeometry extends BufferGeometry {
 	 */
 	static fromJSON( data ) {
 
-		return new SphereGeometry( data.radius, data.widthSegments, data.heightSegments, data.phiStart, data.phiLength, data.thetaStart, data.thetaLength );
+		return new SphereGeometry( data.radius, data.widthSegments, data.heightSegments, data.phiStart, data.phiLength, data.thetaStart, data.thetaLength, data.precision );
 
 	}
 


### PR DESCRIPTION
## `BufferAttribute.convert()`
e0ae5b10445b12e5fe3fd2aad7c0bee61b322b5a introduces a `.convert()` function in `BufferAttribute` to allow for precision conversion and buffer quantization of attributes like `position`, `uv` etc.
This allows one to drop any BufferAttribute to a lower precision like `HalfFloat` or `Int8` to save on VRAM (and RAM).

Thanks to already existing data conversion like https://github.com/mrdoob/three.js/blob/69a97bfb1145b591dd9fe60170e8e8a32fb5a64e/src/extras/DataUtils.js#L150 and its already existing use in setter and getters of the various BufferAttribute types like
https://github.com/mrdoob/three.js/blob/69a97bfb1145b591dd9fe60170e8e8a32fb5a64e/src/core/BufferAttribute.js#L876
ThreeJS already has the ability to convert to and from various types for values, but not for buffers as a whole yet. This commit creates a conversion function which makes use of these preexisting data conversions to do exactly that.

The idea is to allow all the various Geometry generation functions like [SphereGeometry.js](https://github.com/mrdoob/three.js/blob/dev/src/geometries/SphereGeometry.js) to output with lower precision, without introducing a bunch of per-geometry generator custom code.

I see some potentially strong VRAM savings for this like dynamically imported 3D Satellite maps.
 
## `SphereGeometry( ... , precision = { ... } )`
To showcase this, in dd01e631d3e36aecb6a53a3d8b2e878db3a3680d I extended [SphereGeometry.js](https://github.com/mrdoob/three.js/blob/dev/src/geometries/SphereGeometry.js) to (optionally) allow to set precisions for each `BufferAttribute` or entirely remove said attribute. It also clarifies which precisions were used previously by default, which was `Float32`. Default case remains as is, nothing changes here, no API break.

E.g. this allows the creation of a sphere with no normals, Half-Float Positions and 8-bit UVs.:
```js
new THREE.SphereGeometry(radius, ... ,
    {
        position: THREE.Float16BufferAttribute,
        uv: THREE.Uint8BufferAttribute,
        normal: null
    }
);
```

## Motivation and VRAM savings in `GroundedSkybox`
Commit 0ecfbb9ec5bdbb2d4213bd0723394280d753599d uses these new parameters to get a 50% VRAM and RAM size reduction of `GroundedSkybox` geometry on default settings with no visual impact.

In https://github.com/mrdoob/three.js/issues/27422 & https://github.com/mrdoob/three.js/pull/27448 @elalish changed the previous [shader based `GroundProjectedSkybox`](https://github.com/mrdoob/three.js/blob/09fe0527a9aa5aaca7aaf17531e6c0d0efaa8c59/examples/jsm/objects/GroundProjectedSkybox.js#L7) to the new geometry `GroundedSkybox`. To get the newly introduced rounded curve from floor to dome, `GroundedSkybox` generates 65,024 triangles on default `resolution` and deforms it, with full precision BufferAttributes and unused normals.
| `GroundedSkybox` with default `resolution` | Wireframe of `GroundedSkybox` with default `resolution` |
| -------- | -------- |
| <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/624ce0b3-d841-4a90-9e48-f98433ff9133" /> | <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/89a16ac9-8603-4f93-b06e-12971d73a8b4" /> |

Due to how [SphereGeometry.js](https://github.com/mrdoob/three.js/blob/dev/src/geometries/SphereGeometry.js) works, it produces very dense mesh on the flat floor. The 65,024 triangles default chosen by @elalish is the only way to get enough geometry and avoid distortions of the spherical texture on the curved transition.

The VRAM and RAM usage of the default `GroundedSkybox` is as follows:
```md
IndexBuffer: `Uint16`, itemSize: `1`, Length: `195,072` = 390 KB
Position Attribute: `Float32`, itemSize: `3`, Length: `99,459` = 398 KB
Normal Attribute: `Float32`, itemSize: `3`, Length: `99,459` = 398 KB
UV Attribute: `Float32`, itemSize: `2`, Length: `66,306` = 265 KB
---------------------------------------------------------------
Total: `1.45 MB`
```

0ecfbb9ec5bdbb2d4213bd0723394280d753599d now requests a Sphere with the following `precision` properties:
```js
{
    position: Float16BufferAttribute,
    uv: Float16BufferAttribute,
    normal: null
}
```
This results in no visual change and the following RAM and VRAM usage:
```md
IndexBuffer: `Uint16`, itemSize: `1`, Length: `195,072` = 390 KB
Position Attribute: `Uint16`, isFloat16BufferAttribute: `true`, itemSize: `3`, Length: `99,459` = 199 KB
UV Attribute: `Uint16`, isFloat16BufferAttribute: `true`, itemSize: `2`, Length: `66,306` = 132 KB
---------------------------------------------------------------
Total: `0.72 MB`
```

The 50% `GroundedSkybox` VRAM savings aren't that important in the grand scheme of things, but this shows how I think a Three.JS user might want use such a attribute precision api to get VRAM savings on dynamically generated geometry and avoid hard crashes due to strict VRAM limits that some iPhones impose in WebGL.

0ecfbb9ec5bdbb2d4213bd0723394280d753599d also adds a material name in `GroundedSkybox`, so it doesn't show up as blank in Debuggers like https://github.com/utsuboco/r3f-perf
<img width="423" height="234" alt="image" src="https://github.com/user-attachments/assets/132e1e9a-b790-4a91-a304-821c78477351" />

## Stuff to decide
If we wanna merge this, I'll properly write the docs and stuff, but some things need to be clarified first:
- I would add the optional `precision = { ... }` to all the geometry constructors in [src/geometries](https://github.com/mrdoob/three.js/tree/dev/src/geometries) or this this out of scope? Rename it to `attributes = { ... }`?
- As I understand, there is no way to `fromArray` create all the types yet, so this leads to the bit awkward expression of `this.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ).convert( precision.position ) );` which creates a Float32 Buffer to immediately convert it. Is this fine or do we need to do something about this?
- I guess using the classes directly as parameters would break the `toJSON()` stuff, something I ignored so far in this PR. So we would need to switch out `THREE.Float16BufferAttribute` for constant like `float16`. But the [already existing constants](https://github.com/mrdoob/three.js/blob/69a97bfb1145b591dd9fe60170e8e8a32fb5a64e/src/constants.js#L690) like `HalfFloatType` are texture related and there is no 8bit vs 16bit int constant in the first place, so what to do? Create a new set of Geometry constants and correct [`BufferAttribute.gpuType`](https://github.com/mrdoob/three.js/blob/69a97bfb1145b591dd9fe60170e8e8a32fb5a64e/src/core/BufferAttribute.js#L127) which has been using Texture constants for Geometry Attributes?