### PR TITLE
InstanceNode: Fix UBO size and attribute update.

### DIFF
--- a/src/nodes/accessors/BufferAttributeNode.js
+++ b/src/nodes/accessors/BufferAttributeNode.js
@@ -366,7 +366,7 @@ function createBufferAttribute( array, type = null, stride = 0, offset = 0, usag
 
 	}
 
-	return new BufferAttributeNode( array, type, stride, offset );
+	return new BufferAttributeNode( array, type, stride, offset ).setUsage( usage );
 
 }
 


### PR DESCRIPTION
Related issue: #32597

**Description**

The assumptions about the UBO size in `InstanceNode` are incorrect. The guaranteed UBO size in WebGL 2 is 16KB and not 64 KB.

Besides, the `DynamicDrawUsage` usage check was incorrect as well and prevented an update of the instance data.
