### PR TITLE
DEVTOOLS access to AnimationMixer + Loaders

### DIFF
--- a/src/animation/AnimationMixer.js
+++ b/src/animation/AnimationMixer.js
@@ -48,6 +48,12 @@ class AnimationMixer extends EventDispatcher {
 		 */
 		this.timeScale = 1.0;
 
+		if ( typeof __THREE_DEVTOOLS__ !== 'undefined' ) {
+
+			__THREE_DEVTOOLS__.dispatchEvent( new CustomEvent( 'observe', { detail: this } ) );
+
+		}
+
 	}
 
 	_bindAction( action, prototypeAction ) {

--- a/src/loaders/Loader.js
+++ b/src/loaders/Loader.js
@@ -61,6 +61,11 @@ class Loader {
 		 */
 		this.requestHeader = {};
 
+		if ( typeof __THREE_DEVTOOLS__ !== 'undefined' ) {
+
+			__THREE_DEVTOOLS__.dispatchEvent( new CustomEvent( 'observe', { detail: this } ) );
+
+		}
 	}
 
 	/**

--- a/src/loaders/Loader.js
+++ b/src/loaders/Loader.js
@@ -66,6 +66,7 @@ class Loader {
 			__THREE_DEVTOOLS__.dispatchEvent( new CustomEvent( 'observe', { detail: this } ) );
 
 		}
+
 	}
 
 	/**


### PR DESCRIPTION
I'd love to expose more insights into animations and file loading through [Needle Inspector.](https://chromewebstore.google.com/detail/needle-inspector-for-thre/jonplpbnhmanoekkgcepnedhghflblmo), which is a chrome extension. 

For that access to AnimationMixer + the Loader base class/prototypes would be required (e.g. I didn't find a sane way to access the AnimationMixer prototype from the chrome extension code, if anyone has suggestions I'd be more than happy to try).

I added event dispatches similar to scene and renderer. Overhead should be minimal especially since it only runs when devtools are enabled.

*This contribution is funded by [Needle](https://needle.tools)* + happy holidays three team
