### PR TITLE
Layers: Add recursive property

### DIFF
--- a/examples/jsm/renderers/CSS2DRenderer.js
+++ b/examples/jsm/renderers/CSS2DRenderer.js
@@ -211,9 +211,20 @@ class CSS2DRenderer {
 
 		}
 
-		function renderObject( object, scene, camera ) {
+		function renderObject( object, scene, camera, inheritedLayers = null ) {
 
 			if ( object.visible === false ) {
+
+				hideObject( object );
+
+				return;
+
+			}
+
+			const effectiveLayers = inheritedLayers !== null ? inheritedLayers : object.layers;
+			const layerVisible = effectiveLayers.test( camera.layers );
+
+			if ( layerVisible === false && effectiveLayers.recursive === true ) {
 
 				hideObject( object );
 
@@ -226,7 +237,7 @@ class CSS2DRenderer {
 				_vector.setFromMatrixPosition( object.matrixWorld );
 				_vector.applyMatrix4( _viewProjectionMatrix );
 
-				const visible = ( _vector.z >= - 1 && _vector.z <= 1 ) && ( object.layers.test( camera.layers ) === true );
+				const visible = ( _vector.z >= - 1 && _vector.z <= 1 ) && layerVisible;
 
 				const element = object.element;
 				element.style.display = visible === true ? '' : 'none';
@@ -255,9 +266,11 @@ class CSS2DRenderer {
 
 			}
 
+			const childInheritedLayers = object.layers.recursive === true ? object.layers : inheritedLayers;
+
 			for ( let i = 0, l = object.children.length; i < l; i ++ ) {
 
-				renderObject( object.children[ i ], scene, camera );
+				renderObject( object.children[ i ], scene, camera, childInheritedLayers );
 
 			}
 

--- a/examples/jsm/renderers/CSS3DRenderer.js
+++ b/examples/jsm/renderers/CSS3DRenderer.js
@@ -359,7 +359,7 @@ class CSS3DRenderer {
 
 		}
 
-		function renderObject( object, scene, camera, cameraCSSMatrix ) {
+		function renderObject( object, scene, camera, cameraCSSMatrix, inheritedLayers = null ) {
 
 			if ( object.visible === false ) {
 
@@ -369,9 +369,20 @@ class CSS3DRenderer {
 
 			}
 
+			const effectiveLayers = inheritedLayers !== null ? inheritedLayers : object.layers;
+			const layerVisible = effectiveLayers.test( camera.layers );
+
+			if ( layerVisible === false && effectiveLayers.recursive === true ) {
+
+				hideObject( object );
+
+				return;
+
+			}
+
 			if ( object.isCSS3DObject ) {
 
-				const visible = ( object.layers.test( camera.layers ) === true );
+				const visible = layerVisible;
 
 				const element = object.element;
 				element.style.display = visible === true ? '' : 'none';
@@ -431,9 +442,11 @@ class CSS3DRenderer {
 
 			}
 
+			const childInheritedLayers = object.layers.recursive === true ? object.layers : inheritedLayers;
+
 			for ( let i = 0, l = object.children.length; i < l; i ++ ) {
 
-				renderObject( object.children[ i ], scene, camera, cameraCSSMatrix );
+				renderObject( object.children[ i ], scene, camera, cameraCSSMatrix, childInheritedLayers );
 
 			}
 

--- a/src/core/Layers.js
+++ b/src/core/Layers.js
@@ -26,6 +26,17 @@ class Layers {
 		 */
 		this.mask = 1 | 0;
 
+		/**
+		 * When set to `true`, this object's layer mask is propagated to all
+		 * descendants during rendering and raycasting traversal. If the layer
+		 * test fails, the entire subtree is skipped. If it passes, children
+		 * inherit this object's layers instead of using their own.
+		 *
+		 * @type {boolean}
+		 * @default false
+		 */
+		this.recursive = false;
+
 	}
 
 	/**

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -1081,6 +1081,37 @@ class Object3D extends EventDispatcher {
 	}
 
 	/**
+	 * Like {@link Object3D#traverseVisible}, but the callback will only be executed
+	 * for visible 3D objects that pass the layer test. Descendants of invisible
+	 * 3D objects and objects with recursive layers that fail the test are not traversed.
+	 *
+	 * Note: Modifying the scene graph inside the callback is discouraged.
+	 *
+	 * @param {Layers} cameraLayers - The camera layers to test against.
+	 * @param {Function} callback - A callback function that allows to process the current 3D object.
+	 */
+	traverseVisibleWithLayers( cameraLayers, callback, inheritedLayers = null ) {
+
+		if ( this.visible === false ) return;
+
+		const effectiveLayers = inheritedLayers !== null ? inheritedLayers : this.layers;
+		const layerVisible = effectiveLayers.test( cameraLayers );
+
+		if ( ! layerVisible && effectiveLayers.recursive ) return;
+
+		if ( layerVisible ) callback( this );
+
+		const childInheritedLayers = this.layers.recursive ? this.layers : inheritedLayers;
+
+		for ( let i = 0, l = this.children.length; i < l; i ++ ) {
+
+			this.children[ i ].traverseVisibleWithLayers( cameraLayers, callback, childInheritedLayers );
+
+		}
+
+	}
+
+	/**
 	 * Like {@link Object3D#traverse}, but the callback will only be executed for all ancestors.
 	 *
 	 * Note: Modifying the scene graph inside the callback is discouraged.

--- a/src/core/Raycaster.js
+++ b/src/core/Raycaster.js
@@ -233,11 +233,16 @@ function ascSort( a, b ) {
 
 }
 
-function intersect( object, raycaster, intersects, recursive ) {
+function intersect( object, raycaster, intersects, recursive, inheritedLayers = null ) {
+
+	const effectiveLayers = inheritedLayers !== null ? inheritedLayers : object.layers;
+	const visible = effectiveLayers.test( raycaster.layers );
+
+	if ( visible === false && effectiveLayers.recursive === true ) return;
 
 	let propagate = true;
 
-	if ( object.layers.test( raycaster.layers ) ) {
+	if ( visible ) {
 
 		const result = object.raycast( raycaster, intersects );
 
@@ -247,11 +252,13 @@ function intersect( object, raycaster, intersects, recursive ) {
 
 	if ( propagate === true && recursive === true ) {
 
+		const childInheritedLayers = object.layers.recursive === true ? object.layers : inheritedLayers;
+
 		const children = object.children;
 
 		for ( let i = 0, l = children.length; i < l; i ++ ) {
 
-			intersect( children[ i ], raycaster, intersects, true );
+			intersect( children[ i ], raycaster, intersects, true, childInheritedLayers );
 
 		}
 

--- a/src/renderers/common/RenderList.js
+++ b/src/renderers/common/RenderList.js
@@ -225,7 +225,7 @@ class RenderList {
 	 * @param {ClippingContext} clippingContext - The current clipping context.
 	 * @return {Object} The render item.
 	 */
-	getNextRenderItem( object, geometry, material, groupOrder, z, group, clippingContext ) {
+	getNextRenderItem( object, geometry, material, groupOrder, z, group, clippingContext, effectiveLayers ) {
 
 		let renderItem = this.renderItems[ this.renderItemsIndex ];
 
@@ -240,7 +240,8 @@ class RenderList {
 				renderOrder: object.renderOrder,
 				z: z,
 				group: group,
-				clippingContext: clippingContext
+				clippingContext: clippingContext,
+				effectiveLayers: effectiveLayers
 			};
 
 			this.renderItems[ this.renderItemsIndex ] = renderItem;
@@ -256,6 +257,7 @@ class RenderList {
 			renderItem.z = z;
 			renderItem.group = group;
 			renderItem.clippingContext = clippingContext;
+			renderItem.effectiveLayers = effectiveLayers;
 
 		}
 
@@ -276,10 +278,11 @@ class RenderList {
 	 * @param {number} z - Th 3D object's depth value (z value in clip space).
 	 * @param {?number} group - {?Object} group - Only relevant for objects using multiple materials. This represents a group entry from the respective `BufferGeometry`.
 	 * @param {ClippingContext} clippingContext - The current clipping context.
+	 * @param {Layers} effectiveLayers - The effective layers for layer visibility testing.
 	 */
-	push( object, geometry, material, groupOrder, z, group, clippingContext ) {
+	push( object, geometry, material, groupOrder, z, group, clippingContext, effectiveLayers ) {
 
-		const renderItem = this.getNextRenderItem( object, geometry, material, groupOrder, z, group, clippingContext );
+		const renderItem = this.getNextRenderItem( object, geometry, material, groupOrder, z, group, clippingContext, effectiveLayers );
 
 		if ( object.occlusionTest === true ) this.occlusionQueryCount ++;
 
@@ -310,10 +313,11 @@ class RenderList {
 	 * @param {number} z - Th 3D object's depth value (z value in clip space).
 	 * @param {?number} group - {?Object} group - Only relevant for objects using multiple materials. This represents a group entry from the respective `BufferGeometry`.
 	 * @param {ClippingContext} clippingContext - The current clipping context.
+	 * @param {Layers} effectiveLayers - The effective layers for layer visibility testing.
 	 */
-	unshift( object, geometry, material, groupOrder, z, group, clippingContext ) {
+	unshift( object, geometry, material, groupOrder, z, group, clippingContext, effectiveLayers ) {
 
-		const renderItem = this.getNextRenderItem( object, geometry, material, groupOrder, z, group, clippingContext );
+		const renderItem = this.getNextRenderItem( object, geometry, material, groupOrder, z, group, clippingContext, effectiveLayers );
 
 		if ( material.transparent === true || material.transmission > 0 ||
 			( material.transmissionNode && material.transmissionNode.isNode ) ||

--- a/src/renderers/common/RenderObject.js
+++ b/src/renderers/common/RenderObject.js
@@ -201,6 +201,15 @@ class RenderObject {
 		this.group = null;
 
 		/**
+		 * The effective layers for layer visibility testing.
+		 * This accounts for recursive layer inheritance from ancestors.
+		 *
+		 * @type {?Layers}
+		 * @default null
+		 */
+		this.effectiveLayers = null;
+
+		/**
 		 * An array holding the vertex buffers which can
 		 * be buffer attributes but also interleaved buffers.
 		 *

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -908,9 +908,9 @@ class Renderer {
 		// include lights from target scene
 		if ( targetScene !== scene ) {
 
-			targetScene.traverseVisible( function ( object ) {
+			targetScene.traverseVisibleWithLayers( camera.layers, function ( object ) {
 
-				if ( object.isLight && object.layers.test( camera.layers ) ) {
+				if ( object.isLight ) {
 
 					renderList.pushLight( object );
 
@@ -2802,12 +2802,16 @@ class Renderer {
 	 * @param {number} groupOrder - The group order is derived from the `renderOrder` of groups and is used to group 3D objects within groups.
 	 * @param {RenderList} renderList - The current render list.
 	 * @param {ClippingContext} clippingContext - The current clipping context.
+	 * @param {Layers|null} inheritedLayers - Layers inherited from a recursive ancestor.
 	 */
-	_projectObject( object, camera, groupOrder, renderList, clippingContext ) {
+	_projectObject( object, camera, groupOrder, renderList, clippingContext, inheritedLayers = null ) {
 
 		if ( object.visible === false ) return;
 
-		const visible = object.layers.test( camera.layers );
+		const effectiveLayers = inheritedLayers !== null ? inheritedLayers : object.layers;
+		const visible = effectiveLayers.test( camera.layers );
+
+		if ( visible === false && effectiveLayers.recursive === true ) return;
 
 		if ( visible ) {
 
@@ -2841,7 +2845,7 @@ class Renderer {
 
 					if ( material.visible ) {
 
-						renderList.push( object, geometry, material, groupOrder, _vector4.z, null, clippingContext );
+						renderList.push( object, geometry, material, groupOrder, _vector4.z, null, clippingContext, effectiveLayers );
 
 					}
 
@@ -2881,7 +2885,7 @@ class Renderer {
 
 							if ( groupMaterial && groupMaterial.visible ) {
 
-								renderList.push( object, geometry, groupMaterial, groupOrder, _vector4.z, group, clippingContext );
+								renderList.push( object, geometry, groupMaterial, groupOrder, _vector4.z, group, clippingContext, effectiveLayers );
 
 							}
 
@@ -2889,7 +2893,7 @@ class Renderer {
 
 					} else if ( material.visible ) {
 
-						renderList.push( object, geometry, material, groupOrder, _vector4.z, null, clippingContext );
+						renderList.push( object, geometry, material, groupOrder, _vector4.z, null, clippingContext, effectiveLayers );
 
 					}
 
@@ -2918,11 +2922,13 @@ class Renderer {
 
 		}
 
+		const childInheritedLayers = object.layers.recursive === true ? object.layers : inheritedLayers;
+
 		const children = object.children;
 
 		for ( let i = 0, l = children.length; i < l; i ++ ) {
 
-			this._projectObject( children[ i ], camera, groupOrder, renderList, clippingContext );
+			this._projectObject( children[ i ], camera, groupOrder, renderList, clippingContext, childInheritedLayers );
 
 		}
 
@@ -3010,9 +3016,9 @@ class Renderer {
 
 		for ( let i = 0, il = renderList.length; i < il; i ++ ) {
 
-			const { object, geometry, material, group, clippingContext } = renderList[ i ];
+			const { object, geometry, material, group, clippingContext, effectiveLayers } = renderList[ i ];
 
-			this._currentRenderObjectFunction( object, scene, camera, geometry, material, group, lightsNode, clippingContext, passId );
+			this._currentRenderObjectFunction( object, scene, camera, geometry, material, group, lightsNode, clippingContext, passId, effectiveLayers );
 
 		}
 
@@ -3140,8 +3146,9 @@ class Renderer {
 	 * @param {LightsNode} lightsNode - The current lights node.
 	 * @param {?ClippingContext} clippingContext - The clipping context.
 	 * @param {?string} [passId=null] - An optional ID for identifying the pass.
+	 * @param {?Layers} [effectiveLayers=null] - The effective layers for layer visibility testing.
 	 */
-	renderObject( object, scene, camera, geometry, material, group, lightsNode, clippingContext = null, passId = null ) {
+	renderObject( object, scene, camera, geometry, material, group, lightsNode, clippingContext = null, passId = null, effectiveLayers = null ) {
 
 		let materialOverride = false;
 		let materialColorNode;
@@ -3200,16 +3207,16 @@ class Renderer {
 		if ( material.transparent === true && material.side === DoubleSide && material.forceSinglePass === false ) {
 
 			material.side = BackSide;
-			this._handleObjectFunction( object, material, scene, camera, lightsNode, group, clippingContext, 'backSide' ); // create backSide pass id
+			this._handleObjectFunction( object, material, scene, camera, lightsNode, group, clippingContext, 'backSide', effectiveLayers ); // create backSide pass id
 
 			material.side = FrontSide;
-			this._handleObjectFunction( object, material, scene, camera, lightsNode, group, clippingContext, passId ); // use default pass id
+			this._handleObjectFunction( object, material, scene, camera, lightsNode, group, clippingContext, passId, effectiveLayers ); // use default pass id
 
 			material.side = DoubleSide;
 
 		} else {
 
-			this._handleObjectFunction( object, material, scene, camera, lightsNode, group, clippingContext, passId );
+			this._handleObjectFunction( object, material, scene, camera, lightsNode, group, clippingContext, passId, effectiveLayers );
 
 		}
 
@@ -3256,12 +3263,14 @@ class Renderer {
 	 * @param {?{start: number, count: number}} group - Only relevant for objects using multiple materials. This represents a group entry from the respective `BufferGeometry`.
 	 * @param {ClippingContext} clippingContext - The clipping context.
 	 * @param {string} [passId] - An optional ID for identifying the pass.
+	 * @param {?Layers} [effectiveLayers=null] - The effective layers for layer visibility testing.
 	 */
-	_renderObjectDirect( object, material, scene, camera, lightsNode, group, clippingContext, passId ) {
+	_renderObjectDirect( object, material, scene, camera, lightsNode, group, clippingContext, passId, effectiveLayers = null ) {
 
 		const renderObject = this._objects.get( object, material, scene, camera, lightsNode, this._currentRenderContext, clippingContext, passId );
 		renderObject.drawRange = object.geometry.drawRange;
 		renderObject.group = group;
+		renderObject.effectiveLayers = effectiveLayers !== null ? effectiveLayers : object.layers;
 
 		//
 
@@ -3311,12 +3320,14 @@ class Renderer {
 	 * @param {?{start: number, count: number}} group - Only relevant for objects using multiple materials. This represents a group entry from the respective `BufferGeometry`.
 	 * @param {ClippingContext} clippingContext - The clipping context.
 	 * @param {string} [passId] - An optional ID for identifying the pass.
+	 * @param {?Layers} [effectiveLayers=null] - The effective layers for layer visibility testing.
 	 */
-	_createObjectPipeline( object, material, scene, camera, lightsNode, group, clippingContext, passId ) {
+	_createObjectPipeline( object, material, scene, camera, lightsNode, group, clippingContext, passId, effectiveLayers = null ) {
 
 		const renderObject = this._objects.get( object, material, scene, camera, lightsNode, this._currentRenderContext, clippingContext, passId );
 		renderObject.drawRange = object.geometry.drawRange;
 		renderObject.group = group;
+		renderObject.effectiveLayers = effectiveLayers !== null ? effectiveLayers : object.layers;
 
 		//
 

--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -1167,7 +1167,7 @@ class WebGLBackend extends Backend {
 
 				const subCamera = cameras[ i ];
 
-				if ( object.layers.test( subCamera.layers ) ) {
+				if ( renderObject.effectiveLayers.test( subCamera.layers ) ) {
 
 					if ( isRenderCameraDepthArray ) {
 

--- a/src/renderers/webgl/WebGLBackground.js
+++ b/src/renderers/webgl/WebGLBackground.js
@@ -165,7 +165,7 @@ function WebGLBackground( renderer, cubemaps, cubeuvmaps, state, objects, alpha,
 			boxMesh.layers.enableAll();
 
 			// push to the pre-sorted opaque render list
-			renderList.unshift( boxMesh, boxMesh.geometry, boxMesh.material, 0, 0, null );
+			renderList.unshift( boxMesh, boxMesh.geometry, boxMesh.material, 0, 0, null, boxMesh.layers );
 
 		} else if ( background && background.isTexture ) {
 
@@ -230,7 +230,7 @@ function WebGLBackground( renderer, cubemaps, cubeuvmaps, state, objects, alpha,
 			planeMesh.layers.enableAll();
 
 			// push to the pre-sorted opaque render list
-			renderList.unshift( planeMesh, planeMesh.geometry, planeMesh.material, 0, 0, null );
+			renderList.unshift( planeMesh, planeMesh.geometry, planeMesh.material, 0, 0, null, planeMesh.layers );
 
 		}
 

--- a/src/renderers/webgl/WebGLRenderLists.js
+++ b/src/renderers/webgl/WebGLRenderLists.js
@@ -79,7 +79,7 @@ function WebGLRenderList() {
 
 	}
 
-	function getNextRenderItem( object, geometry, material, groupOrder, z, group ) {
+	function getNextRenderItem( object, geometry, material, groupOrder, z, group, effectiveLayers ) {
 
 		let renderItem = renderItems[ renderItemsIndex ];
 
@@ -94,7 +94,8 @@ function WebGLRenderList() {
 				groupOrder: groupOrder,
 				renderOrder: object.renderOrder,
 				z: z,
-				group: group
+				group: group,
+				effectiveLayers: effectiveLayers
 			};
 
 			renderItems[ renderItemsIndex ] = renderItem;
@@ -110,6 +111,7 @@ function WebGLRenderList() {
 			renderItem.renderOrder = object.renderOrder;
 			renderItem.z = z;
 			renderItem.group = group;
+			renderItem.effectiveLayers = effectiveLayers;
 
 		}
 
@@ -119,9 +121,9 @@ function WebGLRenderList() {
 
 	}
 
-	function push( object, geometry, material, groupOrder, z, group ) {
+	function push( object, geometry, material, groupOrder, z, group, effectiveLayers ) {
 
-		const renderItem = getNextRenderItem( object, geometry, material, groupOrder, z, group );
+		const renderItem = getNextRenderItem( object, geometry, material, groupOrder, z, group, effectiveLayers );
 
 		if ( material.transmission > 0.0 ) {
 
@@ -139,9 +141,9 @@ function WebGLRenderList() {
 
 	}
 
-	function unshift( object, geometry, material, groupOrder, z, group ) {
+	function unshift( object, geometry, material, groupOrder, z, group, effectiveLayers ) {
 
-		const renderItem = getNextRenderItem( object, geometry, material, groupOrder, z, group );
+		const renderItem = getNextRenderItem( object, geometry, material, groupOrder, z, group, effectiveLayers );
 
 		if ( material.transmission > 0.0 ) {
 

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -503,11 +503,14 @@ function WebGLShadowMap( renderer, objects, capabilities ) {
 
 	}
 
-	function renderObject( object, camera, shadowCamera, light, type ) {
+	function renderObject( object, camera, shadowCamera, light, type, inheritedLayers = null ) {
 
 		if ( object.visible === false ) return;
 
-		const visible = object.layers.test( camera.layers );
+		const effectiveLayers = inheritedLayers !== null ? inheritedLayers : object.layers;
+		const visible = effectiveLayers.test( camera.layers );
+
+		if ( visible === false && effectiveLayers.recursive === true ) return;
 
 		if ( visible && ( object.isMesh || object.isLine || object.isPoints ) ) {
 
@@ -557,11 +560,13 @@ function WebGLShadowMap( renderer, objects, capabilities ) {
 
 		}
 
+		const childInheritedLayers = object.layers.recursive === true ? object.layers : inheritedLayers;
+
 		const children = object.children;
 
 		for ( let i = 0, l = children.length; i < l; i ++ ) {
 
-			renderObject( children[ i ], camera, shadowCamera, light, type );
+			renderObject( children[ i ], camera, shadowCamera, light, type, childInheritedLayers );
 
 		}
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -1698,7 +1698,7 @@ class WebGPUBackend extends Backend {
 
 				const subCamera = cameras[ i ];
 
-				if ( object.layers.test( subCamera.layers ) ) {
+				if ( renderObject.effectiveLayers.test( subCamera.layers ) ) {
 
 					const vp = subCamera.viewport;
 

--- a/test/unit/src/core/Layers.tests.js
+++ b/test/unit/src/core/Layers.tests.js
@@ -123,6 +123,23 @@ export default QUnit.module( 'Core', () => {
 
 		} );
 
+		QUnit.test( 'recursive', ( assert ) => {
+
+			const a = new Layers();
+
+			// Default value should be false
+			assert.strictEqual( a.recursive, false, 'Default recursive is false' );
+
+			// Can be set to true
+			a.recursive = true;
+			assert.strictEqual( a.recursive, true, 'Can set recursive to true' );
+
+			// Can be set back to false
+			a.recursive = false;
+			assert.strictEqual( a.recursive, false, 'Can set recursive to false' );
+
+		} );
+
 	} );
 
 } );

--- a/test/unit/src/renderers/webgl/WebGLRenderLists.tests.js
+++ b/test/unit/src/renderers/webgl/WebGLRenderLists.tests.js
@@ -80,7 +80,8 @@ export default QUnit.module( 'Renderers', () => {
 						groupOrder: 0,
 						renderOrder: 0,
 						z: 0.5,
-						group: {}
+						group: {},
+						effectiveLayers: undefined
 					},
 					'The first transparent render list item is structured correctly.'
 				);
@@ -99,7 +100,8 @@ export default QUnit.module( 'Renderers', () => {
 						groupOrder: 1,
 						renderOrder: 0,
 						z: 1.5,
-						group: {}
+						group: {},
+						effectiveLayers: undefined
 					},
 					'The second transparent render list item is structured correctly.'
 				);
@@ -118,7 +120,8 @@ export default QUnit.module( 'Renderers', () => {
 						groupOrder: 2,
 						renderOrder: 0,
 						z: 2.5,
-						group: {}
+						group: {},
+						effectiveLayers: undefined
 					},
 					'The first opaque render list item is structured correctly.'
 				);
@@ -137,7 +140,8 @@ export default QUnit.module( 'Renderers', () => {
 						groupOrder: 3,
 						renderOrder: 0,
 						z: 3.5,
-						group: {}
+						group: {},
+						effectiveLayers: undefined
 					},
 					'The second opaque render list item is structured correctly.'
 				);
@@ -178,7 +182,8 @@ export default QUnit.module( 'Renderers', () => {
 						groupOrder: 0,
 						renderOrder: 0,
 						z: 0.5,
-						group: {}
+						group: {},
+						effectiveLayers: undefined
 					},
 					'The first transparent render list item is structured correctly.'
 				);
@@ -197,7 +202,8 @@ export default QUnit.module( 'Renderers', () => {
 						groupOrder: 1,
 						renderOrder: 0,
 						z: 1.5,
-						group: {}
+						group: {},
+						effectiveLayers: undefined
 					},
 					'The second transparent render list item is structured correctly.'
 				);
@@ -216,7 +222,8 @@ export default QUnit.module( 'Renderers', () => {
 						groupOrder: 2,
 						renderOrder: 0,
 						z: 2.5,
-						group: {}
+						group: {},
+						effectiveLayers: undefined
 					},
 					'The first opaque render list item is structured correctly.'
 				);
@@ -235,7 +242,8 @@ export default QUnit.module( 'Renderers', () => {
 						groupOrder: 3,
 						renderOrder: 0,
 						z: 3.5,
-						group: {}
+						group: {},
+						effectiveLayers: undefined
 					},
 					'The second opaque render list item is structured correctly.'
 				);


### PR DESCRIPTION
## Description

Adds a `recursive` property to the Layers class. When set to `true`, if an object's layer test fails during traversal, the entire subtree is skipped. If the layer test passes, children inherit the parent's layers instead of using their own.

This is a revival of #28427 by @CodyJasonBennett.

## Changes from original PR

- Removed `DEFAULT_RECURSIVE` static property (main source of debate in the original PR)
- Simplified implementation: layer inheritance is handled via a single `inheritedLayers` parameter passed through traversal

## Use case

When using multiple cameras (e.g. secondary cameras for minimaps, portals, etc.), you often want to exclude entire UI hierarchies from certain cameras. Currently, you must manually set layers on every object in the hierarchy. With `recursive`, you set it once on the parent.

We have been using three.js with react-three-fiber and @pmndrs/uikit. Internally, we built a few different solutions, but it was quite tedious without affecting the renderer directly.

Looking forward to feedback!