### PR TITLE
Update Audio.html

### DIFF
--- a/docs/pages/Audio.html
+++ b/docs/pages/Audio.html
@@ -174,7 +174,7 @@ should begin, in seconds.</p>
 					<h3 class="name" id="source" translate="no">.<a href="#source">source</a><span class="type-signature"> : AudioNode</span> <span class="type-signature">(readonly) </span></h3>
 					<div class="description">
 						<p>Holds a reference to the current audio source.</p>
-<p>The property is automatically by one of the <code>set*()</code> methods.</p>
+<p>The property is automatically set by one of the <code>set*()</code> methods.</p>
 						<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
@@ -182,7 +182,7 @@ should begin, in seconds.</p>
 					<h3 class="name" id="sourceType" translate="no">.<a href="#sourceType">sourceType</a><span class="type-signature"> : 'empty' | 'audioNode' | 'mediaNode' | 'mediaStreamNode' | 'buffer'</span> <span class="type-signature">(readonly) </span></h3>
 					<div class="description">
 						<p>Defines the source type.</p>
-<p>The property is automatically by one of the <code>set*()</code> methods.</p>
+<p>The property is automatically set by one of the <code>set*()</code> methods.</p>
 						<p>Default is <code>'empty'</code>.</p>
 					</div>
 				</div>


### PR DESCRIPTION
Fix typo in Audio docs

**Description**

The `sourceType` description in `docs/pages/Audio.html` was missing the word “set”, resulting in an incomplete sentence.
This pull request corrects the sentence to: “The property is automatically set by one of the set*() methods.”, improving clarity and grammar.