### PR TITLE
VTKLoader: Fix ReDoS vulnerability.

### DIFF
--- a/examples/jsm/loaders/VTKLoader.js
+++ b/examples/jsm/loaders/VTKLoader.js
@@ -113,7 +113,7 @@ class VTKLoader extends Loader {
 			const patWord = /^[^\d.\s-]+/;
 
 			// pattern for reading vertices, 3 floats or integers
-			const pat3Floats = /(-?\d+(?:\.\d*)?(?:[eE][+-]?\d+)?)\s+(-?\d+(?:\.\d*)?(?:[eE][+-]?\d+)?)\s+(-?\d+(?:\.\d*)?(?:[eE][+-]?\d+)?)/g;
+			const pat3Floats = /(\S+)\s+(\S+)\s+(\S+)/g;
 
 			// pattern for connectivity, an integer followed by any number of ints
 			// the first integer is the number of polygon nodes

--- a/examples/jsm/loaders/VTKLoader.js
+++ b/examples/jsm/loaders/VTKLoader.js
@@ -112,8 +112,20 @@ class VTKLoader extends Loader {
 			// pattern for detecting the end of a number sequence
 			const patWord = /^[^\d.\s-]+/;
 
-			// pattern for reading vertices, 3 floats or integers
-			const pat3Floats = /(\S+)\s+(\S+)\s+(\S+)/g;
+			// helper function to parse floats from a line
+			function parseFloats( line ) {
+
+				const parts = line.split( /\s+/ );
+				const result = [];
+				for ( let i = 0; i < parts.length; i ++ ) {
+
+					if ( parts[ i ] !== '' ) result.push( parseFloat( parts[ i ] ) );
+
+				}
+
+				return result;
+
+			}
 
 			// pattern for connectivity, an integer followed by any number of ints
 			// the first integer is the number of polygon nodes
@@ -165,14 +177,14 @@ class VTKLoader extends Loader {
 				} else if ( inPointsSection ) {
 
 					// get the vertices
-					while ( ( result = pat3Floats.exec( line ) ) !== null ) {
+					if ( patWord.exec( line ) === null ) {
 
-						if ( patWord.exec( line ) !== null ) break;
+						const values = parseFloats( line );
+						for ( let k = 0; k + 2 < values.length; k += 3 ) {
 
-						const x = parseFloat( result[ 1 ] );
-						const y = parseFloat( result[ 2 ] );
-						const z = parseFloat( result[ 3 ] );
-						positions.push( x, y, z );
+							positions.push( values[ k ], values[ k + 1 ], values[ k + 2 ] );
+
+						}
 
 					}
 
@@ -243,17 +255,15 @@ class VTKLoader extends Loader {
 
 						// Get the colors
 
-						while ( ( result = pat3Floats.exec( line ) ) !== null ) {
+						if ( patWord.exec( line ) === null ) {
 
-							if ( patWord.exec( line ) !== null ) break;
+							const values = parseFloats( line );
+							for ( let k = 0; k + 2 < values.length; k += 3 ) {
 
-							const r = parseFloat( result[ 1 ] );
-							const g = parseFloat( result[ 2 ] );
-							const b = parseFloat( result[ 3 ] );
+								color.setRGB( values[ k ], values[ k + 1 ], values[ k + 2 ], SRGBColorSpace );
+								colors.push( color.r, color.g, color.b );
 
-							color.setRGB( r, g, b, SRGBColorSpace );
-
-							colors.push( color.r, color.g, color.b );
+							}
 
 						}
 
@@ -261,14 +271,14 @@ class VTKLoader extends Loader {
 
 						// Get the normal vectors
 
-						while ( ( result = pat3Floats.exec( line ) ) !== null ) {
+						if ( patWord.exec( line ) === null ) {
 
-							if ( patWord.exec( line ) !== null ) break;
+							const values = parseFloats( line );
+							for ( let k = 0; k + 2 < values.length; k += 3 ) {
 
-							const nx = parseFloat( result[ 1 ] );
-							const ny = parseFloat( result[ 2 ] );
-							const nz = parseFloat( result[ 3 ] );
-							normals.push( nx, ny, nz );
+								normals.push( values[ k ], values[ k + 1 ], values[ k + 2 ] );
+
+							}
 
 						}
 

--- a/examples/jsm/loaders/VTKLoader.js
+++ b/examples/jsm/loaders/VTKLoader.js
@@ -112,11 +112,11 @@ class VTKLoader extends Loader {
 			// pattern for detecting the end of a number sequence
 			const patWord = /^[^\d.\s-]+/;
 
-			// helper function to parse floats from a line
 			function parseFloats( line ) {
 
-				const parts = line.split( /\s+/ );
 				const result = [];
+				const parts = line.split( /\s+/ );
+
 				for ( let i = 0; i < parts.length; i ++ ) {
 
 					if ( parts[ i ] !== '' ) result.push( parseFloat( parts[ i ] ) );
@@ -180,6 +180,7 @@ class VTKLoader extends Loader {
 					if ( patWord.exec( line ) === null ) {
 
 						const values = parseFloats( line );
+
 						for ( let k = 0; k + 2 < values.length; k += 3 ) {
 
 							positions.push( values[ k ], values[ k + 1 ], values[ k + 2 ] );
@@ -258,6 +259,7 @@ class VTKLoader extends Loader {
 						if ( patWord.exec( line ) === null ) {
 
 							const values = parseFloats( line );
+
 							for ( let k = 0; k + 2 < values.length; k += 3 ) {
 
 								color.setRGB( values[ k ], values[ k + 1 ], values[ k + 2 ], SRGBColorSpace );
@@ -274,6 +276,7 @@ class VTKLoader extends Loader {
 						if ( patWord.exec( line ) === null ) {
 
 							const values = parseFloats( line );
+
 							for ( let k = 0; k + 2 < values.length; k += 3 ) {
 
 								normals.push( values[ k ], values[ k + 1 ], values[ k + 2 ] );

--- a/examples/jsm/loaders/VTKLoader.js
+++ b/examples/jsm/loaders/VTKLoader.js
@@ -113,7 +113,7 @@ class VTKLoader extends Loader {
 			const patWord = /^[^\d.\s-]+/;
 
 			// pattern for reading vertices, 3 floats or integers
-			const pat3Floats = /(\-?\d+\.?[\d\-\+e]*)\s+(\-?\d+\.?[\d\-\+e]*)\s+(\-?\d+\.?[\d\-\+e]*)/g;
+			const pat3Floats = /(-?\d+(?:\.\d*)?(?:[eE][+-]?\d+)?)\s+(-?\d+(?:\.\d*)?(?:[eE][+-]?\d+)?)\s+(-?\d+(?:\.\d*)?(?:[eE][+-]?\d+)?)/g;
 
 			// pattern for connectivity, an integer followed by any number of ints
 			// the first integer is the number of polygon nodes

--- a/examples/jsm/loaders/VTKLoader.js
+++ b/examples/jsm/loaders/VTKLoader.js
@@ -410,7 +410,7 @@ class VTKLoader extends Loader {
 				let index = start;
 				let c = buffer[ index ];
 				const s = [];
-				while ( c !== 10 ) {
+				while ( c !== 10 && index < buffer.length ) {
 
 					s.push( String.fromCharCode( c ) );
 					index ++;


### PR DESCRIPTION
**Description**

The `pat3Floats` regex pattern was vulnerable to catastrophic backtracking due to overlapping quantifiers. The character class `[\d\-\+e]*` could match digits, which overlapped with the preceding `\d+`, allowing exponential time complexity with malicious input.

A crafted payload of ~220 repeated digits could stall parsing for 25+ seconds.

The fix replaces the regex with a `parseFloats()` helper that uses `split()` to tokenize and `parseFloat()` to parse values, eliminating regex-based extraction entirely.

Additionally, a bounds check was added to the binary parser's `findString()` function to prevent an infinite loop when parsing malformed files without proper newline characters.

**Credit**

Reported by @AhmedMokhtari, @mwlik, @imenyoo2

(Made with [Claude Opus 4.5](https://www.anthropic.com/news/claude-opus-4-5))