### PR TITLE
LensflareMesh: Fix DPR usage.

### DIFF
--- a/examples/jsm/objects/LensflareMesh.js
+++ b/examples/jsm/objects/LensflareMesh.js
@@ -215,7 +215,7 @@ class LensflareMesh extends Mesh {
 
 			renderer.getViewport( viewport );
 
-			viewport.multiplyScalar( window.devicePixelRatio );
+			viewport.multiplyScalar( renderer.getPixelRatio() ).floor();
 
 			const renderTarget = renderer.getRenderTarget();
 			const type = ( renderTarget !== null ) ? renderTarget.texture.type : UnsignedByteType;


### PR DESCRIPTION
Fixed #32624.

**Description**

The PR fixes two bugs in `LensflareMesh`:

- `LensflareMesh` must use the DPR from the renderer and not `window`.
- It must use `floor()` to match the computation in the renderer (DPRs are not always integers).
