### PR TITLE
Fix XR camera layers inheritance

### DIFF
--- a/src/renderers/common/XRManager.js
+++ b/src/renderers/common/XRManager.js
@@ -1131,8 +1131,8 @@ class XRManager extends EventDispatcher {
 
 		// inherit camera layers and enable eye layers (1 = left, 2 = right)
 		cameraXR.layers.mask = camera.layers.mask | 0b110;
-		cameraL.layers.mask = cameraXR.layers.mask & 0b011;
-		cameraR.layers.mask = cameraXR.layers.mask & 0b101;
+		cameraL.layers.mask = cameraXR.layers.mask & ~ 0b100;
+		cameraR.layers.mask = cameraXR.layers.mask & ~ 0b010;
 
 
 		const parent = camera.parent;

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -749,8 +749,8 @@ class WebXRManager extends EventDispatcher {
 
 			// inherit camera layers and enable eye layers (1 = left, 2 = right)
 			cameraXR.layers.mask = camera.layers.mask | 0b110;
-			cameraL.layers.mask = cameraXR.layers.mask & 0b011;
-			cameraR.layers.mask = cameraXR.layers.mask & 0b101;
+			cameraL.layers.mask = cameraXR.layers.mask & ~ 0b100;
+			cameraR.layers.mask = cameraXR.layers.mask & ~ 0b010;
 
 			const parent = camera.parent;
 			const cameras = cameraXR.cameras;


### PR DESCRIPTION
The previous code used narrow bitmasks that only preserved layers 0-2.
We changed the bitmask operations to preserve all inhertied layers while still correctly assigning eye-specific layers.