### PR TITLE
Texture3DNode: Remove outdated `setupUV()`.

### DIFF
--- a/src/nodes/accessors/Texture3DNode.js
+++ b/src/nodes/accessors/Texture3DNode.js
@@ -1,6 +1,5 @@
 import TextureNode from './TextureNode.js';
-import { nodeProxy, vec3, Fn, If, int } from '../tsl/TSLBase.js';
-import { textureSize } from './TextureSizeNode.js';
+import { nodeProxy, vec3, Fn, If } from '../tsl/TSLBase.js';
 
 const normal = Fn( ( { texture, uv } ) => {
 
@@ -114,35 +113,6 @@ class Texture3DNode extends TextureNode {
 	 * @param {boolean} value - The update toggle.
 	 */
 	setUpdateMatrix( /*value*/ ) { } // Ignore .updateMatrix for 3d TextureNode
-
-	/**
-	 * Overwrites the default implementation to return the unmodified uv node.
-	 *
-	 * @param {NodeBuilder} builder - The current node builder.
-	 * @param {Node} uvNode - The uv node to setup.
-	 * @return {Node} The unmodified uv node.
-	 */
-	setupUV( builder, uvNode ) {
-
-		const texture = this.value;
-
-		if ( builder.isFlipY() && ( texture.isRenderTargetTexture === true || texture.isFramebufferTexture === true ) ) {
-
-			if ( this.sampler ) {
-
-				uvNode = uvNode.flipY();
-
-			} else {
-
-				uvNode = uvNode.setY( int( textureSize( this, this.levelNode ).y ).sub( uvNode.y ).sub( 1 ) );
-
-			}
-
-		}
-
-		return uvNode;
-
-	}
 
 	/**
 	 * Generates the uv code snippet.


### PR DESCRIPTION
Related issue: #30155

**Description**

The initial version of `Texture3DNode` had an overwritten `setupUV()` with a different implementation than the one from `TextureNode`. After #30155, the overwritten version was aligned. Unfortunately, with #31929 this code is now outdated since `TextureNode` represents the flip-y boolean as a uniform. To align both classes, the PR removes `setupUV()` from `Texture3DNode`.