### PR TITLE
Texture: Add `GAFormat` for compressed normal maps.

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -819,6 +819,14 @@ export const RGBIntegerFormat = 1032;
 export const RGBAIntegerFormat = 1033;
 
 /**
+ * Reads the green and alpha components. Use by KTX2 texture encoded with --normal-mode for example
+ *
+ * @type {number}
+ * @constant
+ */
+export const GAFormat = 1034;
+
+/**
  * A DXT1-compressed image in an RGB image format.
  *
  * @type {number}

--- a/src/constants.js
+++ b/src/constants.js
@@ -819,7 +819,8 @@ export const RGBIntegerFormat = 1032;
 export const RGBAIntegerFormat = 1033;
 
 /**
- * Reads the green and alpha components. Use by KTX2 texture encoded with --normal-mode for example
+ * Reads the green and alpha components. Use by KTX2 texture encoded with --normal-mode for example.
+ * Only supported by WebGPURenderer.
  *
  * @type {number}
  * @constant

--- a/src/nodes/accessors/MaterialNode.js
+++ b/src/nodes/accessors/MaterialNode.js
@@ -7,7 +7,7 @@ import { uniform } from '../core/UniformNode.js';
 import { normalMap } from '../display/NormalMapNode.js';
 import { bumpMap } from '../display/BumpMapNode.js';
 import { Vector2 } from '../../math/Vector2.js';
-import { RGFormat, RED_GREEN_RGTC2_Format, RG11_EAC_Format, NormalRGPacking } from '../../constants.js';
+import { RGFormat, GAFormat, RED_GREEN_RGTC2_Format, RG11_EAC_Format, NormalRGPacking, NormalGAPacking } from '../../constants.js';
 
 
 const _propertyCache = new Map();
@@ -240,6 +240,10 @@ class MaterialNode extends Node {
 				if ( material.normalMap.format == RGFormat || material.normalMap.format == RED_GREEN_RGTC2_Format || material.normalMap.format == RG11_EAC_Format ) {
 
 					node.unpackNormalMode = NormalRGPacking;
+
+				} else if ( material.normalMap.format == GAFormat ) {
+
+					node.unpackNormalMode = NormalGAPacking;
 
 				}
 


### PR DESCRIPTION
Related issue: #32623

**Description**

Add the automatic unpacking GA when format is GAFormat, added GAFormat as constant.

*This contribution is funded by [Makio64](https://x.com/makio64)*
