### PR TITLE
GLTFLoader and KTX2Loader: Add a sanity check for navigator.userAgent before using it.

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2662,7 +2662,7 @@ class GLTFParser {
 		let isFirefox = false;
 		let firefoxVersion = - 1;
 
-		if ( typeof navigator !== 'undefined' ) {
+		if ( typeof navigator !== 'undefined' && typeof navigator.userAgent !== 'undefined' ) {
 
 			const userAgent = navigator.userAgent;
 

--- a/examples/jsm/loaders/KTX2Loader.js
+++ b/examples/jsm/loaders/KTX2Loader.js
@@ -252,6 +252,7 @@ class KTX2Loader extends Loader {
 			};
 
 			if ( typeof navigator !== 'undefined' &&
+				typeof navigator.platform !== 'undefined' && typeof navigator.userAgent !== 'undefined' &&
 				navigator.platform.indexOf( 'Linux' ) >= 0 && navigator.userAgent.indexOf( 'Firefox' ) >= 0 &&
 				this.workerConfig.astcSupported && this.workerConfig.etc2Supported &&
 				this.workerConfig.bptcSupported && this.workerConfig.dxtSupported ) {


### PR DESCRIPTION
For GLTFLoader and KTX2Loader add a check for userAgent to see if it is defined, to avoid errors with match when it is not.

**Description**

For exemple, in React Native, navigator is defined, but userAgent is not, which causes issues when using the match function
```
[Error: Uncaught (in promise, id: 0) TypeError: Cannot read property 'match' of undefined]
```

This fix simply adds a check to ensure userAgent is defined before calling match.
This problem has already been encountered ([GLB Asset Loading Fails on Android with Undefined ‘match’ Error ](https://discourse.threejs.org/t/glb-asset-loading-fails-on-android-with-undefined-match-error/75180))


<!-- Remove the line below if is not relevant -->
