### PR TITLE
Cleanup examples.

### DIFF
--- a/examples/webgpu_lights_tiled.html
+++ b/examples/webgpu_lights_tiled.html
@@ -191,7 +191,7 @@
 
 				// tile indexes debug, needs to be updated every time the renderer size changes
 
-				const debugBlockIndexes = lighting.getNode( scene, camera ).setSize( window.innerWidth * window.devicePixelRatio, window.innerHeight * window.devicePixelRatio ).getBlock().toColor().div( count * 2 );
+				const debugBlockIndexes = lighting.getNode( scene ).setSize( window.innerWidth * window.devicePixelRatio, window.innerHeight * window.devicePixelRatio ).getBlock().toColor().div( count * 2 );
 
 				postProcessing.outputNode = compose.add( debugBlockIndexes.mul( tileInfluence ) );
 				postProcessing.needsUpdate = true;


### PR DESCRIPTION
Related issue: #32557

**Description**

`Lighting.getNode()` no longer takes a camera as its second parameter after https://github.com/mrdoob/three.js/pull/32557
