### PR TITLE
Manual: Fix typo in OrbitControls inertia option description

### DIFF
--- a/manual/ko/rendering-on-demand.html
+++ b/manual/ko/rendering-on-demand.html
@@ -117,7 +117,7 @@ camera.position.z = 2;
 </div>
 
 <p></p>
-<p><a href="/docs/#examples/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a>에는 관성(inertia) 옵션이 있습니다. <code class="notranslate" translate="no">enableDamping</code> 속성을 ture로
+<p><a href="/docs/#examples/controls/OrbitControls"><code class="notranslate" translate="no">OrbitControls</code></a>에는 관성(inertia) 옵션이 있습니다. <code class="notranslate" translate="no">enableDamping</code> 속성을 true로
 설정하면 동작이 좀 더 부드러워지죠.</p>
 <p>※ damping: 감쇠.</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">controls.enableDamping = true;


### PR DESCRIPTION
Corrected a typo in the Korean "Rendering On Demand" documentation.

Related issue: #32640 

**Description**

This pull request fixes a minor typo in the Korean translation of the "Rendering On Demand" documentation, where the  "ture" was incorrectly used instead of "true".

The change is purely textual and improves clarity and correctness for Korean readers.