### PR TITLE
Object3D: worldToLocal typo

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -644,7 +644,7 @@ class Object3D extends EventDispatcher {
 	}
 
 	/**
-	 * Converts the given vector from this 3D object's word space to local space.
+	 * Converts the given vector from this 3D object's world space to local space.
 	 *
 	 * @param {Vector3} vector - The vector to convert.
 	 * @return {Vector3} The converted vector.


### PR DESCRIPTION
**Description**

Fixes typo in `Object3D#worldToLocal` method's description