### PR TITLE
CI: Concurrency per PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
       - 'docs/**'
       - 'files/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## Description

During https://github.com/mrdoob/three.js/pull/32647, I noticed that if I push new commit(s), the runs from previous ones run until the end, which is redundant IMO. This change optimizes it.

Related GitHub docs:
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#concurrency
- https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context

## Testing

For a test, I pushed "dummy commit" in this PR which cancelled the previous run.

## Additional notes

If this is something you'll consider to include into your workflow, the similar `concurrency` rules can be added to other workflows, but for now I started with the `ci.yml` workflow that takes the most of time to run (>10 minutes) and that is the best candidate to have this change to be applied on it.

So just me know if you want this to be applied to other workflows.