### PR TITLE
Removed rollup-plugin-filesize dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,6 @@
     "puppeteer": "^24.25.0",
     "qunit": "^2.19.4",
     "rollup": "^4.6.0",
-    "rollup-plugin-filesize": "^10.0.0",
     "servez": "^2.2.4"
   },
   "overrides": {

--- a/test/rollup.treeshake.config.js
+++ b/test/rollup.treeshake.config.js
@@ -1,7 +1,12 @@
+import { gzipSync } from 'zlib';
 import resolve from '@rollup/plugin-node-resolve';
 import terser from '@rollup/plugin-terser';
 
 function filesize() {
+
+	const green = '\x1b[1m\x1b[32m';
+	const yellow = '\x1b[33m';
+	const reset = '\x1b[0m';
 
 	return {
 		name: 'filesize',
@@ -9,7 +14,31 @@ function filesize() {
 
 			for ( const [ name, chunk ] of Object.entries( bundle ) ) {
 
-				if ( chunk.code ) console.log( `\x1b[32m${name}: ${( chunk.code.length / 1024 ).toFixed( 1 )} kB\x1b[0m` );
+				if ( chunk.code ) {
+
+					const size = ( chunk.code.length / 1024 ).toFixed( 2 ) + ' KB';
+					const gzipped = ( gzipSync( chunk.code ).length / 1024 ).toFixed( 2 ) + ' KB';
+					const destination = options.file;
+
+					const lines = [
+						{ label: 'Destination: ', value: destination },
+						{ label: 'Bundle Size:  ', value: size },
+						{ label: 'Gzipped Size: ', value: gzipped }
+					];
+
+					const maxLength = Math.max( ...lines.map( l => l.label.length + l.value.length ) );
+					const width = maxLength + 6;
+
+					console.log( `\n┌${'─'.repeat( width )}┐` );
+					console.log( `│${' '.repeat( width )}│` );
+					lines.forEach( ( { label, value } ) => {
+						const padding = ' '.repeat( width - label.length - value.length - 3 );
+						console.log( `│   ${green}${label}${yellow}${value}${reset}${padding}│` );
+					} );
+					console.log( `│${' '.repeat( width )}│` );
+					console.log( `└${'─'.repeat( width )}┘` );
+
+				}
 
 			}
 

--- a/test/rollup.treeshake.config.js
+++ b/test/rollup.treeshake.config.js
@@ -12,7 +12,7 @@ function filesize() {
 		name: 'filesize',
 		writeBundle( options, bundle ) {
 
-			for ( const [ name, chunk ] of Object.entries( bundle ) ) {
+			for ( const [ , chunk ] of Object.entries( bundle ) ) {
 
 				if ( chunk.code ) {
 
@@ -32,8 +32,10 @@ function filesize() {
 					console.log( `\n┌${'─'.repeat( width )}┐` );
 					console.log( `│${' '.repeat( width )}│` );
 					lines.forEach( ( { label, value } ) => {
+
 						const padding = ' '.repeat( width - label.length - value.length - 3 );
 						console.log( `│   ${green}${label}${yellow}${value}${reset}${padding}│` );
+
 					} );
 					console.log( `│${' '.repeat( width )}│` );
 					console.log( `└${'─'.repeat( width )}┘` );

--- a/test/rollup.treeshake.config.js
+++ b/test/rollup.treeshake.config.js
@@ -1,6 +1,22 @@
 import resolve from '@rollup/plugin-node-resolve';
-import filesize from 'rollup-plugin-filesize';
 import terser from '@rollup/plugin-terser';
+
+function filesize() {
+
+	return {
+		name: 'filesize',
+		writeBundle( options, bundle ) {
+
+			for ( const [ name, chunk ] of Object.entries( bundle ) ) {
+
+				if ( chunk.code ) console.log( `\x1b[32m${name}: ${( chunk.code.length / 1024 ).toFixed( 1 )} kB\x1b[0m` );
+
+			}
+
+		}
+	};
+
+}
 
 export default [
 	{
@@ -20,9 +36,7 @@ export default [
 		plugins: [
 			resolve(),
 			terser(),
-			filesize( {
-				showMinifiedSize: false,
-			} )
+			filesize()
 		],
 		output: [
 			{
@@ -48,9 +62,7 @@ export default [
 		plugins: [
 			resolve(),
 			terser(),
-			filesize( {
-				showMinifiedSize: false,
-			} )
+			filesize()
 		],
 		output: [
 			{
@@ -76,9 +88,7 @@ export default [
 		plugins: [
 			resolve(),
 			terser(),
-			filesize( {
-				showMinifiedSize: false,
-			} )
+			filesize()
 		],
 		output: [
 			{


### PR DESCRIPTION
**Description**

Before:

```bash
mrdoob@Mrdoobs-MacBook-Air three.js % npm install
npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
npm warn deprecated @npmcli/move-file@2.0.1: This functionality has been moved to @npmcli/fs
npm warn deprecated read-package-json@6.0.4: This package is no longer supported. Please use @npmcli/package-json instead.
npm warn deprecated npmlog@6.0.2: This package is no longer supported.
npm warn deprecated rimraf@3.0.2: Rimraf versions prior to v4 are no longer supported
npm warn deprecated are-we-there-yet@3.0.1: This package is no longer supported.
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@8.1.0: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated gauge@4.0.4: This package is no longer supported.

added 732 packages, and audited 733 packages in 27s

160 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```

After (200 packages less 🙃): 

```bash
mrdoob@Mrdoobs-MacBook-Air three.js % npm install

added 529 packages, and audited 530 packages in 20s

140 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```

(Made with Claude Opus 4.5)