### PR TITLE
Matrix4: Cache determinant result in decompose().

### DIFF
--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -1061,7 +1061,7 @@ class Matrix4 {
 		const sy = _v1.set( te[ 4 ], te[ 5 ], te[ 6 ] ).length();
 		const sz = _v1.set( te[ 8 ], te[ 9 ], te[ 10 ] ).length();
 
-		// if determine is negative, we need to invert one scale
+		// if determinant is negative, we need to invert one scale
 		if ( det < 0 ) sx = - sx;
 
 		// scale the rotation part

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -1046,7 +1046,9 @@ class Matrix4 {
 		position.y = te[ 13 ];
 		position.z = te[ 14 ];
 
-		if ( this.determinant() === 0 ) {
+		const det = this.determinant();
+
+		if ( det === 0 ) {
 
 			scale.set( 1, 1, 1 );
 			quaternion.identity();
@@ -1060,7 +1062,6 @@ class Matrix4 {
 		const sz = _v1.set( te[ 8 ], te[ 9 ], te[ 10 ] ).length();
 
 		// if determine is negative, we need to invert one scale
-		const det = this.determinant();
 		if ( det < 0 ) sx = - sx;
 
 		// scale the rotation part


### PR DESCRIPTION
**Description**

Eliminated duplicate `this.determinant()` call in `decompose()`.

The method was calling `determinant()` twice:
1. Line 1049: to check if the matrix is singular
2. Line 1063: to determine if scale needs negation

Now the result is cached once and reused, saving ~20 floating-point operations per `decompose()` call.

(Made with Claude Opus 4.5)