### PR TITLE
GLTFLoader: Update documentation to include KHR_meshopt_compression

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -92,6 +92,7 @@ import { clone } from '../utils/SkeletonUtils.js';
  * - KHR_materials_unlit
  * - KHR_materials_volume
  * - KHR_mesh_quantization
+ * - KHR_meshopt_compression
  * - KHR_lights_punctual
  * - KHR_texture_basisu
  * - KHR_texture_transform


### PR DESCRIPTION
Followup to #32163. Updates documentation, adding KHR_meshopt_compression to the list of supported glTF extensions.