### PR TITLE
ViewportTextureNode: Change update type to `RENDER`.

### DIFF
--- a/src/nodes/display/ViewportTextureNode.js
+++ b/src/nodes/display/ViewportTextureNode.js
@@ -80,13 +80,13 @@ class ViewportTextureNode extends TextureNode {
 		this.isOutputTextureNode = true;
 
 		/**
-		 * The `updateBeforeType` is set to `NodeUpdateType.FRAME` since the node renders the
-		 * scene once per frame in its {@link ViewportTextureNode#updateBefore} method.
+		 * The `updateBeforeType` is set to `NodeUpdateType.RENDER` since the node should extract
+		 * the current contents of the bound framebuffer for each render call.
 		 *
 		 * @type {string}
-		 * @default 'frame'
+		 * @default 'render'
 		 */
-		this.updateBeforeType = NodeUpdateType.FRAME;
+		this.updateBeforeType = NodeUpdateType.RENDER;
 
 		/**
 		 * The framebuffer texture for the current renderer context.


### PR DESCRIPTION
Fixed #32642.

**Description**

As suggested in https://github.com/mrdoob/three.js/issues/32642#issuecomment-3705164824, the PR changes the update type of `ViewportTextureNode` from `FRAME` to `RENDER`. This ensures viewport textures reflect the current state of the bound framebuffer when a render call happens which is not true when using `FRAME`.
