### PR TITLE
TSL: Fix double expressions.

### DIFF
--- a/src/nodes/utils/Discard.js
+++ b/src/nodes/utils/Discard.js
@@ -10,7 +10,7 @@ import { addMethodChaining } from '../tsl/TSLCore.js';
  * @param {?ConditionalNode} conditional - An optional conditional node. It allows to decide whether the discard should be executed or not.
  * @return {Node} The `discard` expression.
  */
-export const Discard = ( conditional ) => ( conditional ? select( conditional, expression( 'discard' ) ) : expression( 'discard' ) ).toStack();
+export const Discard = ( conditional ) => ( conditional ? select( conditional, expression( 'discard' ) ) : expression( 'discard' ) );
 
 /**
  * Represents a `return` shader operation in TSL.
@@ -19,6 +19,10 @@ export const Discard = ( conditional ) => ( conditional ? select( conditional, e
  * @function
  * @return {ExpressionNode} The `return` expression.
  */
-export const Return = () => expression( 'return' ).toStack();
+export const Return = () => expression( 'return' );
 
-addMethodChaining( 'discard', Discard );
+addMethodChaining( 'discard', ( conditional ) => {
+
+	Discard( conditional ).toStack();
+
+} );

--- a/src/nodes/utils/LoopNode.js
+++ b/src/nodes/utils/LoopNode.js
@@ -337,7 +337,7 @@ export const Loop = ( ...params ) => new LoopNode( nodeArray( params, 'int' ) ).
  * @function
  * @returns {ExpressionNode}
  */
-export const Continue = () => expression( 'continue' ).toStack();
+export const Continue = () => expression( 'continue' );
 
 /**
  * TSL function for creating a `Break()` expression.
@@ -346,4 +346,4 @@ export const Continue = () => expression( 'continue' ).toStack();
  * @function
  * @returns {ExpressionNode}
  */
-export const Break = () => expression( 'break' ).toStack();
+export const Break = () => expression( 'break' );


### PR DESCRIPTION
Fixed #32589.

**Description**

I'm not sure this is the best fix but it seems calling `toStack()` is only required in the method chaining case e.g. when using `.discard()`. In all other cases, the call can be removed.
