### PR TITLE
utils/server.js: cross-platform isMain check

### DIFF
--- a/utils/server.js
+++ b/utils/server.js
@@ -2,6 +2,7 @@ import http from 'http';
 import path from 'path';
 import os from 'os';
 import { createReadStream, existsSync, statSync, readdirSync } from 'fs';
+import { fileURLToPath } from 'url';
 
 function escapeHtml( str ) {
 
@@ -211,7 +212,7 @@ function tryListen( server, port, maxAttempts = 20 ) {
 }
 
 // CLI mode
-const isMain = process.argv[ 1 ] && path.resolve( process.argv[ 1 ] ) === path.resolve( import.meta.url.replace( 'file://', '' ) );
+const isMain = process.argv[ 1 ] && path.resolve( process.argv[ 1 ] ) === path.resolve( fileURLToPath( import.meta.url ) );
 
 if ( isMain ) {
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/32654#issuecomment-3713843971

**Description**

Old check used string replace `import.meta.url.replace( 'file://', '' )` but on Windows, URLs are like `file:///C:/...` (3 slashes before drive label), so comparison failed ( `C:/...` === `/C:/...` always false )

Now use `fileURLToPath(import.meta.url)` for proper cross-platform path handling.