### PR TITLE
Editor: Import glTF as root scene.

### DIFF
--- a/editor/js/Config.js
+++ b/editor/js/Config.js
@@ -22,6 +22,7 @@ function Config() {
 		'project/renderer/toneMappingExposure': 1,
 
 		'settings/history': false,
+		'settings/import/gltf/scene': false,
 
 		'settings/shortcuts/translate': 'w',
 		'settings/shortcuts/rotate': 'e',

--- a/editor/js/Loader.js
+++ b/editor/js/Loader.js
@@ -3,6 +3,7 @@ import * as THREE from 'three';
 import { TGALoader } from 'three/addons/loaders/TGALoader.js';
 
 import { AddObjectCommand } from './commands/AddObjectCommand.js';
+import { SetSceneCommand } from './commands/SetSceneCommand.js';
 
 import { LoaderUtils } from './LoaderUtils.js';
 
@@ -276,7 +277,16 @@ function Loader( editor ) {
 						scene.name = filename;
 
 						scene.animations.push( ...result.animations );
-						editor.execute( new AddObjectCommand( editor, scene ) );
+
+						if ( editor.config.getKey( 'settings/import/gltf/scene' ) === true ) {
+
+							editor.execute( new SetSceneCommand( editor, scene ) );
+
+						} else {
+
+							editor.execute( new AddObjectCommand( editor, scene ) );
+
+						}
 
 						loader.dracoLoader.dispose();
 						loader.ktx2Loader.dispose();
@@ -306,7 +316,16 @@ function Loader( editor ) {
 						scene.name = filename;
 
 						scene.animations.push( ...result.animations );
-						editor.execute( new AddObjectCommand( editor, scene ) );
+
+						if ( editor.config.getKey( 'settings/import/gltf/scene' ) === true ) {
+
+							editor.execute( new SetSceneCommand( editor, scene ) );
+
+						} else {
+
+							editor.execute( new AddObjectCommand( editor, scene ) );
+
+						}
 
 						loader.dracoLoader.dispose();
 						loader.ktx2Loader.dispose();
@@ -932,7 +951,16 @@ function Loader( editor ) {
 						const scene = result.scene;
 
 						scene.animations.push( ...result.animations );
-						editor.execute( new AddObjectCommand( editor, scene ) );
+
+						if ( editor.config.getKey( 'settings/import/gltf/scene' ) === true ) {
+
+							editor.execute( new SetSceneCommand( editor, scene ) );
+
+						} else {
+
+							editor.execute( new AddObjectCommand( editor, scene ) );
+
+						}
 
 						loader.dracoLoader.dispose();
 						loader.ktx2Loader.dispose();
@@ -954,7 +982,16 @@ function Loader( editor ) {
 						const scene = result.scene;
 
 						scene.animations.push( ...result.animations );
-						editor.execute( new AddObjectCommand( editor, scene ) );
+
+						if ( editor.config.getKey( 'settings/import/gltf/scene' ) === true ) {
+
+							editor.execute( new SetSceneCommand( editor, scene ) );
+
+						} else {
+
+							editor.execute( new AddObjectCommand( editor, scene ) );
+
+						}
 
 						loader.dracoLoader.dispose();
 						loader.ktx2Loader.dispose();

--- a/editor/js/Loader.js
+++ b/editor/js/Loader.js
@@ -278,15 +278,7 @@ function Loader( editor ) {
 
 						scene.animations.push( ...result.animations );
 
-						if ( editor.config.getKey( 'settings/import/gltf/scene' ) === true ) {
-
-							editor.execute( new SetSceneCommand( editor, scene ) );
-
-						} else {
-
-							editor.execute( new AddObjectCommand( editor, scene ) );
-
-						}
+						addScene( editor, scene );
 
 						loader.dracoLoader.dispose();
 						loader.ktx2Loader.dispose();
@@ -317,15 +309,7 @@ function Loader( editor ) {
 
 						scene.animations.push( ...result.animations );
 
-						if ( editor.config.getKey( 'settings/import/gltf/scene' ) === true ) {
-
-							editor.execute( new SetSceneCommand( editor, scene ) );
-
-						} else {
-
-							editor.execute( new AddObjectCommand( editor, scene ) );
-
-						}
+						addScene( editor, scene );
 
 						loader.dracoLoader.dispose();
 						loader.ktx2Loader.dispose();
@@ -808,6 +792,20 @@ function Loader( editor ) {
 
 	};
 
+	function addScene( editor, scene ) {
+
+		if ( editor.config.getKey( 'settings/import/gltf/scene' ) === true ) {
+
+			editor.execute( new SetSceneCommand( editor, scene ) );
+
+		} else {
+
+			editor.execute( new AddObjectCommand( editor, scene ) );
+
+		}
+
+	}
+
 	function handleJSON( data ) {
 
 		if ( data.metadata === undefined ) { // 2.0
@@ -952,15 +950,7 @@ function Loader( editor ) {
 
 						scene.animations.push( ...result.animations );
 
-						if ( editor.config.getKey( 'settings/import/gltf/scene' ) === true ) {
-
-							editor.execute( new SetSceneCommand( editor, scene ) );
-
-						} else {
-
-							editor.execute( new AddObjectCommand( editor, scene ) );
-
-						}
+						addScene( editor, scene );
 
 						loader.dracoLoader.dispose();
 						loader.ktx2Loader.dispose();
@@ -983,15 +973,7 @@ function Loader( editor ) {
 
 						scene.animations.push( ...result.animations );
 
-						if ( editor.config.getKey( 'settings/import/gltf/scene' ) === true ) {
-
-							editor.execute( new SetSceneCommand( editor, scene ) );
-
-						} else {
-
-							editor.execute( new AddObjectCommand( editor, scene ) );
-
-						}
+						addScene( editor, scene );
 
 						loader.dracoLoader.dispose();
 						loader.ktx2Loader.dispose();

--- a/editor/js/Sidebar.Settings.Import.js
+++ b/editor/js/Sidebar.Settings.Import.js
@@ -1,0 +1,38 @@
+
+import { UIPanel, UIRow, UIText } from './libs/ui.js';
+import { UIBoolean } from './libs/ui.three.js';
+
+function SidebarSettingsImport( editor ) {
+
+	const strings = editor.strings;
+	const config = editor.config;
+
+	const container = new UIPanel();
+
+	const headerRow = new UIRow();
+	headerRow.add( new UIText( strings.getKey( 'sidebar/settings/import' ).toUpperCase() ) );
+	container.add( headerRow );
+
+	//
+
+	const gltfSceneRow = new UIRow();
+	container.add( gltfSceneRow );
+
+	gltfSceneRow.add( new UIText( strings.getKey( 'sidebar/settings/import/gltf/scene' ) ).setWidth( '180px' ).setClass( 'Label' ) );
+
+	const gltfSceneBoolean = new UIBoolean( config.getKey( 'settings/import/gltf/scene' ) );
+	gltfSceneBoolean.onChange( function () {
+
+		const value = this.getValue();
+
+		config.setKey( 'settings/import/gltf/scene', value );
+
+	} );
+
+	gltfSceneRow.add( gltfSceneBoolean );
+
+	return container;
+
+}
+
+export { SidebarSettingsImport };

--- a/editor/js/Sidebar.Settings.js
+++ b/editor/js/Sidebar.Settings.js
@@ -2,6 +2,7 @@ import { UIPanel, UIRow, UISelect, UISpan, UIText } from './libs/ui.js';
 
 import { SidebarSettingsShortcuts } from './Sidebar.Settings.Shortcuts.js';
 import { SidebarSettingsHistory } from './Sidebar.Settings.History.js';
+import { SidebarSettingsImport } from './Sidebar.Settings.Import.js';
 
 function SidebarSettings( editor ) {
 
@@ -50,6 +51,7 @@ function SidebarSettings( editor ) {
 
 	container.add( new SidebarSettingsShortcuts( editor ) );
 	container.add( new SidebarSettingsHistory( editor ) );
+	container.add( new SidebarSettingsImport( editor ) );
 
 	return container;
 

--- a/editor/js/Strings.js
+++ b/editor/js/Strings.js
@@ -783,6 +783,9 @@ function Strings( config ) {
 			'sidebar/history/clear': 'Clear',
 			'sidebar/history/persistent': 'Persistent',
 
+			'sidebar/settings/import': 'Import',
+			'sidebar/settings/import/gltf/scene': 'Import glTF as root scene',
+
 			'toolbar/translate': 'Translate',
 			'toolbar/rotate': 'Rotate',
 			'toolbar/scale': 'Scale',
@@ -1185,6 +1188,9 @@ function Strings( config ) {
 			'sidebar/history': 'Historique',
 			'sidebar/history/clear': 'Supprimer',
 			'sidebar/history/persistent': 'Permanent',
+
+			'sidebar/settings/import': 'Import',
+			'sidebar/settings/import/gltf/scene': 'Import glTF as root scene',
 
 			'toolbar/translate': 'Position',
 			'toolbar/rotate': 'Rotation',
@@ -1589,6 +1595,9 @@ function Strings( config ) {
 			'sidebar/history/clear': '清空',
 			'sidebar/history/persistent': '本地存储',
 
+			'sidebar/settings/import': 'Import',
+			'sidebar/settings/import/gltf/scene': 'Import glTF as root scene',
+
 			'toolbar/translate': '移动',
 			'toolbar/rotate': '旋转',
 			'toolbar/scale': '缩放',
@@ -1992,6 +2001,9 @@ function Strings( config ) {
 			'sidebar/history/clear': 'クリア',
 			'sidebar/history/persistent': '永続的',
 
+			'sidebar/settings/import': 'Import',
+			'sidebar/settings/import/gltf/scene': 'Import glTF as root scene',
+
 			'toolbar/translate': '移動',
 			'toolbar/rotate': '回転',
 			'toolbar/scale': 'スケール',
@@ -2393,6 +2405,9 @@ function Strings( config ) {
 			'sidebar/history': '기록',
 			'sidebar/history/clear': '지우기',
 			'sidebar/history/persistent': '영구적',
+
+			'sidebar/settings/import': 'Import',
+			'sidebar/settings/import/gltf/scene': 'Import glTF as root scene',
 
 			'toolbar/translate': '이동',
 			'toolbar/rotate': '회전',

--- a/editor/js/Strings.js
+++ b/editor/js/Strings.js
@@ -381,6 +381,9 @@ function Strings( config ) {
 			'sidebar/history/clear': 'پاک کردن',
 			'sidebar/history/persistent': 'ماندگار',
 
+			'sidebar/settings/import': 'Import',
+			'sidebar/settings/import/gltf/scene': 'Import glTF as root scene',
+
 			'toolbar/translate': 'ترجمه',
 			'toolbar/rotate': 'چرخش (دوران)',
 			'toolbar/scale': 'مقیاس',


### PR DESCRIPTION
Fixed #32662.

**Description**

Allows to import the scene of a glTF file as the editor's root scene instead of adding it as a child. The kind of import can be configured in the settings tab, see https://github.com/mrdoob/three.js/issues/32662#issuecomment-3709848835.

<img width="708" height="1420" alt="image" src="https://github.com/user-attachments/assets/903257be-dee8-4732-96f7-3385254e643f" />
