### PR TITLE
Object3D: Document `static`, add support in `copy()` and JSON.

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -357,7 +357,8 @@ class Object3D extends EventDispatcher {
 		/**
 		 * Whether the 3D object is supposed to be static or not. If set to `true`, it means
 		 * the 3D object is not going to be changed after the initial renderer. This includes
-		 * geometry and material settings.
+		 * geometry and material settings. A static 3D object can be processed by the renderer
+		 * slightly faster since certain state checks can be bypassed.
 		 *
 		 * Only relevant in context of {@link WebGPURenderer}.
 		 *

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -355,6 +355,18 @@ class Object3D extends EventDispatcher {
 		this.customDistanceMaterial = undefined;
 
 		/**
+		 * Whether the 3D object is supposed to be static or not. If set to `true`, it means
+		 * the 3D object is not going to be changed after the initial renderer. This includes
+		 * geometry and material settings.
+		 *
+		 * Only relevant in context of {@link WebGPURenderer}.
+		 *
+		 * @type {boolean}
+		 * @default false
+		 */
+		this.static = false;
+
+		/**
 		 * An object that can be used to store custom data about the 3D object. It
 		 * should not hold references to functions as these will not be cloned.
 		 *
@@ -1267,6 +1279,7 @@ class Object3D extends EventDispatcher {
 		if ( this.visible === false ) object.visible = false;
 		if ( this.frustumCulled === false ) object.frustumCulled = false;
 		if ( this.renderOrder !== 0 ) object.renderOrder = this.renderOrder;
+		if ( this.static !== false ) object.static = this.static;
 		if ( Object.keys( this.userData ).length > 0 ) object.userData = this.userData;
 
 		object.layers = this.layers.mask;
@@ -1564,6 +1577,8 @@ class Object3D extends EventDispatcher {
 
 		this.frustumCulled = source.frustumCulled;
 		this.renderOrder = source.renderOrder;
+
+		this.static = source.static;
 
 		this.animations = source.animations.slice();
 

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -1131,6 +1131,7 @@ class ObjectLoader extends Loader {
 		if ( data.visible !== undefined ) object.visible = data.visible;
 		if ( data.frustumCulled !== undefined ) object.frustumCulled = data.frustumCulled;
 		if ( data.renderOrder !== undefined ) object.renderOrder = data.renderOrder;
+		if ( data.static !== undefined ) object.static = data.static;
 		if ( data.userData !== undefined ) object.userData = data.userData;
 		if ( data.layers !== undefined ) object.layers.mask = data.layers;
 

--- a/src/renderers/common/BundleGroup.js
+++ b/src/renderers/common/BundleGroup.js
@@ -44,7 +44,7 @@ class BundleGroup extends Group {
 		/**
 		 * Whether the bundle is static or not. When set to `true`, the structure
 		 * is assumed to be static and does not change. E.g. no new objects are
-		 * added to the group
+		 * added to the group.
 		 *
 		 * If a change is required, an update can still be forced by setting the
 		 * `needsUpdate` flag to `true`.


### PR DESCRIPTION
Related issue: -

**Description**

The PR documents `Object3D.static`, a new property that has been introduced in the last year for `WebGPURenderer`. It has been monkey-patched in the performance examples (e.g. [webgpu_performance](https://threejs.org/examples/webgpu_performance)) so far. This PR introduces documentation, `copy()` and serialization/deserialization support.

The property itself is a hint for the renderer to improve performance when processing render objects. When set to `true`, the renderer assumes no aspects of the object change over time including geometry and material settings. This allows the renderer to bypass checks that determine whether the render object needs updated bindings, geometry data etc.
