### PR TITLE
PCDLoader: Fix label parsing.

### DIFF
--- a/examples/jsm/loaders/PCDLoader.js
+++ b/examples/jsm/loaders/PCDLoader.js
@@ -518,7 +518,7 @@ class PCDLoader extends Loader {
 				if ( offset.label !== undefined ) {
 
 					const labelIndex = PCDheader.fields.indexOf( 'label' );
-					label.push( dataview.getInt32( ( PCDheader.points * offset.label ) + PCDheader.size[ labelIndex ] * i, this.littleEndian ) );
+					label.push( this._getDataView( dataview, ( PCDheader.points * offset.label ) + PCDheader.size[ labelIndex ] * i, PCDheader.type[ labelIndex ], PCDheader.size[ labelIndex ] ) );
 
 				}
 
@@ -578,7 +578,8 @@ class PCDLoader extends Loader {
 
 				if ( offset.label !== undefined ) {
 
-					label.push( dataview.getInt32( row + offset.label, this.littleEndian ) );
+					const labelIndex = PCDheader.fields.indexOf( 'label' );
+					label.push( this._getDataView( dataview, row + offset.label, PCDheader.type[ labelIndex ], PCDheader.size[ labelIndex ] ) );
 
 				}
 


### PR DESCRIPTION
Closes #32064.

**Description**

#32064 contains an important fix for `PCDLoader` since it corrects the label data parsing for binary files. Instead of always using `Int32`, it's more correct to extract the data type from the header like we do for all other PCD fields.

I did not adopt the examples updates from #32064 since they make `webgl_loader_pcd` unnecessary complex.