### PR TITLE
TSL: Fix `positionView` sub-build

### DIFF
--- a/src/materials/nodes/NodeMaterial.js
+++ b/src/materials/nodes/NodeMaterial.js
@@ -535,9 +535,9 @@ class NodeMaterial extends Material {
 
 		builder.addStack();
 
-		const mvp = subBuild( this.setupVertex( builder ), 'VERTEX' );
+		const mvp = this.setupVertex( builder );
 
-		const vertexNode = this.vertexNode || mvp;
+		const vertexNode = subBuild( this.vertexNode || mvp, 'VERTEX' );
 
 		builder.context.clipSpace = vertexNode;
 

--- a/src/nodes/accessors/Position.js
+++ b/src/nodes/accessors/Position.js
@@ -67,7 +67,7 @@ export const positionWorld = /*@__PURE__*/ ( Fn( ( builder ) => {
 
 	return modelWorldMatrix.mul( positionLocal ).xyz.toVarying( builder.getSubBuildProperty( 'v_positionWorld' ) );
 
-}, 'vec3' ).once( [ 'POSITION' ] ) )();
+}, 'vec3' ).once( [ 'POSITION', 'VERTEX' ] ) )();
 
 /**
  * TSL object that represents the position world direction of the current rendered object.
@@ -103,7 +103,7 @@ export const positionView = /*@__PURE__*/ ( Fn( ( builder ) => {
 
 	return builder.context.setupPositionView().toVarying( 'v_positionView' );
 
-}, 'vec3' ).once( [ 'POSITION' ] ) )();
+}, 'vec3' ).once( [ 'POSITION', 'VERTEX' ] ) )();
 
 /**
  * TSL object that represents the position view direction of the current rendered object.

--- a/src/nodes/core/VaryingNode.js
+++ b/src/nodes/core/VaryingNode.js
@@ -36,7 +36,7 @@ class VaryingNode extends Node {
 		 *
 		 * @type {Node}
 		 */
-		this.node = node;
+		this.node = subBuild( node, 'VERTEX' );
 
 		/**
 		 * The name of the varying in the shader. If no name is defined,


### PR DESCRIPTION
Fixes https://github.com/mrdoob/three.js/issues/32686

**Description**

This corrects the [Clip Space](https://github.com/mrdoob/three.js/pull/32594) implementation when using `.vertexNode` and reusing the `positionView` in the fragment stage.

