### PR TITLE
CubeCamera: Force autoClear.

### DIFF
--- a/src/cameras/CubeCamera.js
+++ b/src/cameras/CubeCamera.js
@@ -199,6 +199,9 @@ class CubeCamera extends Object3D {
 
 		renderer.xr.enabled = false;
 
+		const currentAutoClear = renderer.autoClear;
+		renderer.autoClear = true;
+
 		const generateMipmaps = renderTarget.texture.generateMipmaps;
 
 		renderTarget.texture.generateMipmaps = false;
@@ -229,6 +232,7 @@ class CubeCamera extends Object3D {
 		renderer.setRenderTarget( currentRenderTarget, currentActiveCubeFace, currentActiveMipmapLevel );
 
 		renderer.xr.enabled = currentXrEnabled;
+		renderer.autoClear = currentAutoClear;
 
 		renderTarget.texture.needsPMREMUpdate = true;
 

--- a/src/cameras/CubeCamera.js
+++ b/src/cameras/CubeCamera.js
@@ -199,9 +199,6 @@ class CubeCamera extends Object3D {
 
 		renderer.xr.enabled = false;
 
-		const currentAutoClear = renderer.autoClear;
-		renderer.autoClear = true;
-
 		const generateMipmaps = renderTarget.texture.generateMipmaps;
 
 		renderTarget.texture.generateMipmaps = false;
@@ -232,7 +229,6 @@ class CubeCamera extends Object3D {
 		renderer.setRenderTarget( currentRenderTarget, currentActiveCubeFace, currentActiveMipmapLevel );
 
 		renderer.xr.enabled = currentXrEnabled;
-		renderer.autoClear = currentAutoClear;
 
 		renderTarget.texture.needsPMREMUpdate = true;
 

--- a/src/renderers/WebGLCubeRenderTarget.js
+++ b/src/renderers/WebGLCubeRenderTarget.js
@@ -128,7 +128,8 @@ class WebGLCubeRenderTarget extends WebGLRenderTarget {
 			vertexShader: shader.vertexShader,
 			fragmentShader: shader.fragmentShader,
 			side: BackSide,
-			blending: NoBlending
+			blending: NoBlending,
+			depthTest: false,
 
 		} );
 

--- a/src/renderers/common/CubeRenderTarget.js
+++ b/src/renderers/common/CubeRenderTarget.js
@@ -70,6 +70,7 @@ class CubeRenderTarget extends WebGLCubeRenderTarget {
 		material.colorNode = TSL_Texture( texture, uvNode, 0 );
 		material.side = BackSide;
 		material.blending = NoBlending;
+		material.depthTest = false;
 
 		const mesh = new Mesh( geometry, material );
 

--- a/src/renderers/common/CubeRenderTarget.js
+++ b/src/renderers/common/CubeRenderTarget.js
@@ -84,7 +84,12 @@ class CubeRenderTarget extends WebGLCubeRenderTarget {
 		const currentMRT = renderer.getMRT();
 		renderer.setMRT( null );
 
+		const currentAutoClear = renderer.autoClear;
+		renderer.autoClear = true;
+
 		camera.update( renderer, scene );
+
+		renderer.autoClear = currentAutoClear;
 
 		renderer.setMRT( currentMRT );
 

--- a/src/renderers/common/CubeRenderTarget.js
+++ b/src/renderers/common/CubeRenderTarget.js
@@ -84,12 +84,7 @@ class CubeRenderTarget extends WebGLCubeRenderTarget {
 		const currentMRT = renderer.getMRT();
 		renderer.setMRT( null );
 
-		const currentAutoClear = renderer.autoClear;
-		renderer.autoClear = true;
-
 		camera.update( renderer, scene );
-
-		renderer.autoClear = currentAutoClear;
 
 		renderer.setMRT( currentMRT );
 


### PR DESCRIPTION
**Description**

Force `autoClear`. The engine can use `fromEquirectangularTexture` under the hood, and if the user sets `renderer.autoClear = false`, they may unexpectedly get a blank cubemap from `fromEquirectangularTexture`.