### PR TITLE
NodeMaterial: Remove `shadowPositionNode` fallback to reduce CPU load.

### DIFF
--- a/src/materials/nodes/NodeMaterial.js
+++ b/src/materials/nodes/NodeMaterial.js
@@ -398,26 +398,6 @@ class NodeMaterial extends Material {
 		 */
 		this.contextNode = null;
 
-		// Deprecated properties
-
-		Object.defineProperty( this, 'shadowPositionNode', { // @deprecated, r176
-
-			get: () => {
-
-				return this.receivedShadowPositionNode;
-
-			},
-
-			set: ( value ) => {
-
-				warn( 'NodeMaterial: ".shadowPositionNode" was renamed to ".receivedShadowPositionNode".' );
-
-				this.receivedShadowPositionNode = value;
-
-			}
-
-		} );
-
 	}
 
 	/**

--- a/src/materials/nodes/NodeMaterial.js
+++ b/src/materials/nodes/NodeMaterial.js
@@ -25,7 +25,7 @@ import { modelViewMatrix } from '../../nodes/accessors/ModelNode.js';
 import { vertexColor } from '../../nodes/accessors/VertexColorNode.js';
 import { premultiplyAlpha } from '../../nodes/display/BlendModes.js';
 import { subBuild } from '../../nodes/core/SubBuildNode.js';
-import { error, warn } from '../../utils.js';
+import { error } from '../../utils.js';
 
 /**
  * Base class for all node materials.


### PR DESCRIPTION
Related issue: #32675

**Description**

When investigating #32675, I have found out the root cause for the performance regression in `r176` was #30962. I couldn't explain why #30962 increases the CPU load until I remember there were issues with `Object.defineProperty()`. I've simply removed the call from `NodeMaterial` and the CPU load reduced noticeably (from 46% to 34 % measured with Chrome Task Manager).

The example from https://github.com/mrdoob/three.js/issues/32675#issuecomment-3728793366 is a bit of a edge case because it creates many individual materials (10000) but something similar can also happen in real-world scenarios with many individual render items.

I did not add real getter/setter as a replacement since that would include `shadowPositionNode` into  `getMaterialCacheKey()`. Given the deprecated status, I think it's okay to bump the property now and get less CPU load in exchange.