### PR TITLE
RenderObject: Fix ID assignment bug.

### DIFF
--- a/src/renderers/common/RenderObject.js
+++ b/src/renderers/common/RenderObject.js
@@ -511,8 +511,7 @@ class RenderObject {
 
 				// geometry attribute
 				attribute = geometry.getAttribute( nodeAttribute.name );
-
-				attributesId[ nodeAttribute.name ] = attribute.version;
+				attributesId[ nodeAttribute.name ] = attribute.id;
 
 			}
 


### PR DESCRIPTION
Related issue: #32675

**Description**

Eventually I have found the performance regression in r178. #31227 fixed the caching for geometry attributes but it used the `version` property for the `attributesId` map  instead of `id` which means `RenderObject.getAttributes()` executed its entire logic over and over again for each render object causing overhead. With this fix, the CPU load in example from https://github.com/mrdoob/three.js/issues/32675#issuecomment-3728793366 goes down from 34 to 25 %.

You can see in below line, we compare IDs not versions:

https://github.com/mrdoob/three.js/blob/6e9c5809658ddbafbd0b974046d181e99cebd0d7/src/renderers/common/RenderObject.js#L818