### PR TITLE
TSL: Revert `positionWorld` re-computation

### DIFF
--- a/src/nodes/accessors/Position.js
+++ b/src/nodes/accessors/Position.js
@@ -1,7 +1,7 @@
 import { attribute } from '../core/AttributeNode.js';
 import { Fn, vec3, vec4 } from '../tsl/TSLCore.js';
 import { modelWorldMatrix } from './ModelNode.js';
-import { cameraProjectionMatrixInverse, cameraWorldMatrix } from './Camera.js';
+import { cameraProjectionMatrixInverse } from './Camera.js';
 import { warnOnce } from '../../utils.js';
 
 /**
@@ -57,17 +57,9 @@ export const positionPrevious = /*@__PURE__*/ positionGeometry.toVarying( 'posit
  */
 export const positionWorld = /*@__PURE__*/ ( Fn( ( builder ) => {
 
-	if ( builder.shaderStage === 'fragment' && builder.material.vertexNode ) {
-
-		// reconstruct world position from view position
-
-		return cameraWorldMatrix.mul( positionView ).xyz.toVar( 'positionWorld' );
-
-	}
-
 	return modelWorldMatrix.mul( positionLocal ).xyz.toVarying( builder.getSubBuildProperty( 'v_positionWorld' ) );
 
-}, 'vec3' ).once( [ 'POSITION', 'VERTEX' ] ) )();
+}, 'vec3' ).once( [ 'POSITION' ] ) )();
 
 /**
  * TSL object that represents the position world direction of the current rendered object.


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/32594#issuecomment-3733602038, https://github.com/mrdoob/three.js/pull/32594#issuecomment-3733602038

**Description**

Revert the re-computation of `positionWorld` if `.vertexNode` is used. 
This could be implemented in another PR with additional tests.