### PR TITLE
EventDispatcher: Enhance iteration and add support for event listener objects

### DIFF
--- a/src/core/EventDispatcher.js
+++ b/src/core/EventDispatcher.js
@@ -27,14 +27,14 @@ class EventDispatcher {
 		/**
 		 * A collection of event listener functions, organized by event type.
 		 *
-		 * @type {Map<string, Function>}
+		 * @type {Map<string, Set<Function>>}
 		 */
 		this._listenerFunctions = new Map();
 
 		/**
 		 * A collection of event listener objects, organized by event type.
 		 *
-		 * @type {Map<string, object>}
+		 * @type {Map<string, Set<object>>}
 		 */
 		this._listenerObjects = new Map();
 
@@ -44,7 +44,7 @@ class EventDispatcher {
 	 * Adds the given event listener to the given event type.
 	 *
 	 * @param {string} type - The type of event to listen to.
-	 * @param {Function|object} listener - The function that gets called when the event is fired.
+	 * @param {Function|object} listener - The listener that gets called when the event is fired.
 	 */
 	addEventListener( type, listener ) {
 

--- a/test/unit/src/core/EventDispatcher.tests.js
+++ b/test/unit/src/core/EventDispatcher.tests.js
@@ -113,15 +113,16 @@ export default QUnit.module( 'Core', () => {
 
 			const eventDispatcher = new EventDispatcher();
 
-			const listener1 = event => assert.equal( event.target, eventDispatcher, 'can remove listeners during dispatch' );
-			const listener2 = () => {};
+			const listener1 = () => {
 
-			const listener3 = () => {
-
-				eventDispatcher.removeEventListener( 'test', listener3 ); // remove self
-				eventDispatcher.removeEventListener( 'test', listener2 ); // also remove next in line
+				eventDispatcher.removeEventListener( 'test', listener1 );
+				eventDispatcher.removeEventListener( 'test', listener2 );
 
 			};
+
+			const listener2 = () => {};
+
+			const listener3 = event => assert.equal( event.target, eventDispatcher, 'can remove listeners during dispatch' );
 
 			eventDispatcher.addEventListener( 'test', listener1 );
 			eventDispatcher.addEventListener( 'test', listener2 );

--- a/test/unit/src/core/EventDispatcher.tests.js
+++ b/test/unit/src/core/EventDispatcher.tests.js
@@ -113,11 +113,19 @@ export default QUnit.module( 'Core', () => {
 
 			const eventDispatcher = new EventDispatcher();
 
-			const listener1 = () => eventDispatcher.removeEventListener( 'test', listener1 );
-			const listener2 = event => assert.equal( event.target, eventDispatcher, 'can remove listener during dispatch' );
+			const listener1 = event => assert.equal( event.target, eventDispatcher, 'can remove listeners during dispatch' );
+			const listener2 = () => {};
+
+			const listener3 = () => {
+
+				eventDispatcher.removeEventListener( 'test', listener3 ); // remove self
+				eventDispatcher.removeEventListener( 'test', listener2 ); // also remove next in line
+
+			};
 
 			eventDispatcher.addEventListener( 'test', listener1 );
 			eventDispatcher.addEventListener( 'test', listener2 );
+			eventDispatcher.addEventListener( 'test', listener3 );
 			eventDispatcher.dispatchEvent( { type: 'test' } );
 
 		} );


### PR DESCRIPTION
### Description

This PR aims to enhance `EventDispatcher` by replacing the current array-based implementation with a map/set-based one. This removes the need for copying the listener array on each `dispatchEvent` call since Set iteration supports adding and removing elements during iteration. See https://262.ecma-international.org/#sec-set.prototype.foreach for more details.

In addition to listener functions, this PR also adds support for listener objects that implement a `handleEvent(event)` method to be more in line with [EventTarget](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener).

These changes are suggestions - the current implementation works just fine. I've tested [webgl_shadowmap_performance](https://threejs.org/examples/?q=performance#webgl_shadowmap_performance) which dispatches a lot of events and saw no obvious difference between the old and the new implementation in terms of performance and allocations.

Edit: There is a performance difference when many listeners are used: https://jsbm.dev/JAFSQx5KQW2W9