### PR TITLE
TSL: Fixing invalid GLSL using nested structures

### DIFF
--- a/src/nodes/core/StructNode.js
+++ b/src/nodes/core/StructNode.js
@@ -52,6 +52,21 @@ class StructNode extends Node {
 
 	}
 
+	_getChildren() {
+
+		// Ensure struct type is the last child for correct code generation order
+
+		const children = super._getChildren();
+
+		const structTypeProperty = children.find( child => child.childNode === this.structTypeNode );
+
+		children.splice( children.indexOf( structTypeProperty ), 1 );
+		children.push( structTypeProperty );
+
+		return children;
+
+	}
+
 	generate( builder ) {
 
 		const nodeVar = builder.getVarFromNode( this );


### PR DESCRIPTION
Fixed https://github.com/mrdoob/three.js/issues/32716

**Description**

Ensure struct type is the last child to generate the dependency code first.