### PR TITLE
Editor: Replace FFmpeg with WebCodecs for video rendering.

### DIFF
--- a/editor/index.html
+++ b/editor/index.html
@@ -36,8 +36,6 @@
 		<script src="js/libs/esprima.js"></script>
 		<script src="js/libs/jsonlint.js"></script>
 
-		<script src="https://cdn.jsdelivr.net/npm/@ffmpeg/ffmpeg@0.11.6/dist/ffmpeg.min.js"></script>
-
 		<link rel="stylesheet" href="js/libs/codemirror/addon/dialog.css">
 		<link rel="stylesheet" href="js/libs/codemirror/addon/show-hint.css">
 		<link rel="stylesheet" href="js/libs/codemirror/addon/tern.css">

--- a/editor/js/Menubar.Render.js
+++ b/editor/js/Menubar.Render.js
@@ -652,7 +652,6 @@ function createMP4( chunks, avcC, width, height, fps ) {
 	}
 
 	// mdat
-	const mdatHeader = concat( u32( 0 ), str( 'mdat' ) );
 	let mdatSize = 8;
 	for ( const chunk of chunks ) mdatSize += chunk.data.length;
 

--- a/editor/js/Strings.js
+++ b/editor/js/Strings.js
@@ -102,6 +102,7 @@ function Strings( config ) {
 			'menubar/render': 'رندر',
 			'menubar/render/image': 'عکس',
 			'menubar/render/video': 'ویدیو',
+			'menubar/render/quality': 'کیفیت',
 			'menubar/render/cancel': 'لغو',
 
 			'menubar/help': 'کمک',
@@ -509,6 +510,7 @@ function Strings( config ) {
 			'menubar/render': 'Render',
 			'menubar/render/image': 'Image',
 			'menubar/render/video': 'Video',
+			'menubar/render/quality': 'Quality',
 			'menubar/render/cancel': 'Cancel',
 
 			'menubar/help': 'Help',
@@ -917,6 +919,7 @@ function Strings( config ) {
 			'menubar/render': 'Rendu',
 			'menubar/render/image': 'Image',
 			'menubar/render/video': 'Vidéo',
+			'menubar/render/quality': 'Qualité',
 			'menubar/render/cancel': 'Annuler',
 
 			'menubar/help': 'Aide',
@@ -1325,6 +1328,7 @@ function Strings( config ) {
 			'menubar/render': '渲染',
 			'menubar/render/image': '图片',
 			'menubar/render/video': '视频',
+			'menubar/render/quality': '质量',
 			'menubar/render/cancel': '取消',
 
 			'menubar/help': '帮助',
@@ -1733,6 +1737,7 @@ function Strings( config ) {
 			'menubar/render': 'レンダー',
 			'menubar/render/image': '画像',
 			'menubar/render/video': '動画',
+			'menubar/render/quality': '品質',
 			'menubar/render/cancel': 'キャンセル',
 
 			'menubar/help': 'ヘルプ',
@@ -2140,6 +2145,7 @@ function Strings( config ) {
 			'menubar/render': '렌더',
 			'menubar/render/image': '이미지',
 			'menubar/render/video': '비디오',
+			'menubar/render/quality': '품질',
 			'menubar/render/cancel': '취소',
 
 			'menubar/help': '도움말',


### PR DESCRIPTION
**Description**

Replaces FFmpeg.js with the WebCodecs API for video encoding, removing the need for `SharedArrayBuffer` and its COOP/COEP header requirements.

Changes:

* Use `VideoEncoder` API with H.264 codec
* Remove FFmpeg CDN dependency from `index.html`
* Add quality dropdown that controls bitrate (2-20 Mbps)
* Implement lightweight MP4 muxer directly in the editor

https://github.com/user-attachments/assets/0b454868-3343-400f-ab22-67a12aaae6f5

(Made with Claude Opus 4.5)