### PR TITLE
Editor: Enable logarithmic depth buffer.

### DIFF
--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -7,7 +7,7 @@ import { Strings } from './Strings.js';
 import { Storage as _Storage } from './Storage.js';
 import { Selector } from './Selector.js';
 
-var _DEFAULT_CAMERA = new THREE.PerspectiveCamera( 50, 1, 0.01, 1000 );
+var _DEFAULT_CAMERA = new THREE.PerspectiveCamera( 50, 1, 0.001, 1e10 );
 _DEFAULT_CAMERA.name = 'Camera';
 _DEFAULT_CAMERA.position.set( 0, 5, 10 );
 _DEFAULT_CAMERA.lookAt( new THREE.Vector3() );

--- a/editor/js/Menubar.Render.js
+++ b/editor/js/Menubar.Render.js
@@ -208,7 +208,7 @@ class RenderImageDialog {
 
 			const scene = await loader.parseAsync( json.scene );
 
-			const renderer = new THREE.WebGLRenderer( { antialias: true } );
+			const renderer = new THREE.WebGLRenderer( { antialias: true, logarithmicDepthBuffer: true } );
 			renderer.setSize( imageWidth.getValue(), imageHeight.getValue() );
 
 			if ( project.shadows !== undefined ) renderer.shadowMap.enabled = project.shadows;

--- a/editor/js/Sidebar.Project.Renderer.js
+++ b/editor/js/Sidebar.Project.Renderer.js
@@ -91,7 +91,7 @@ function SidebarProjectRenderer( editor ) {
 
 	function createRenderer() {
 
-		currentRenderer = new THREE.WebGLRenderer( { antialias: antialiasBoolean.getValue() } );
+		currentRenderer = new THREE.WebGLRenderer( { antialias: antialiasBoolean.getValue(), logarithmicDepthBuffer: true } );
 		currentRenderer.shadowMap.enabled = shadowsBoolean.getValue();
 		currentRenderer.shadowMap.type = parseFloat( shadowTypeSelect.getValue() );
 		currentRenderer.toneMapping = parseFloat( toneMappingSelect.getValue() );

--- a/editor/js/libs/app.js
+++ b/editor/js/libs/app.js
@@ -2,7 +2,7 @@ const APP = {
 
 	Player: function () {
 
-		const renderer = new THREE.WebGLRenderer( { antialias: true } );
+		const renderer = new THREE.WebGLRenderer( { antialias: true, logarithmicDepthBuffer: true } );
 		renderer.setPixelRatio( window.devicePixelRatio ); // TODO: Use player.setPixelRatio()
 
 		const loader = new THREE.ObjectLoader();


### PR DESCRIPTION
**Description**

Fixes camera clipping when focusing on very small or very large objects.

- Enable logarithmicDepthBuffer for editor, render output, and published apps
- Widen default camera frustum from (0.01, 1000) to (0.001, 1e10)

(Made with Claude Opus 4.5)