### PR TITLE
StorageTextureNode: Add TSL read/write support 

### DIFF
--- a/examples/webgpu_compute_texture_pingpong.html
+++ b/examples/webgpu_compute_texture_pingpong.html
@@ -1,26 +1,28 @@
 <html lang="en">
-	<head>
-		<title>three.js webgpu - compute ping/pong texture</title>
-		<meta charset="utf-8">
-		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
-		<link type="text/css" rel="stylesheet" href="example.css">
-	</head>
-	<body>
 
-		<div id="info">
-			<a href="https://threejs.org/" target="_blank" rel="noopener" class="logo-link"></a>
+<head>
+	<title>three.js webgpu - compute ping/pong texture</title>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+	<link type="text/css" rel="stylesheet" href="example.css">
+</head>
 
-			<div class="title-wrapper">
-				<a href="https://threejs.org/" target="_blank" rel="noopener">three.js</a>
-				<span>Compute Ping/Pong Texture</span>
-			</div>
+<body>
 
-			<small>
-				Compute ping/pong texture using GPU.
-			</small>
+	<div id="info">
+		<a href="https://threejs.org/" target="_blank" rel="noopener" class="logo-link"></a>
+
+		<div class="title-wrapper">
+			<a href="https://threejs.org/" target="_blank" rel="noopener">three.js</a>
+			<span>Compute Ping/Pong Texture</span>
 		</div>
 
-		<script type="importmap">
+		<small>
+			Compute ping/pong texture using GPU (pure TSL).
+		</small>
+	</div>
+
+	<script type="importmap">
 			{
 				"imports": {
 					"three": "../build/three.webgpu.js",
@@ -31,204 +33,192 @@
 			}
 		</script>
 
-		<script type="module">
+	<script type="module">
 
-			import * as THREE from 'three/webgpu';
-			import { storageTexture, wgslFn, code, instanceIndex, uniform, NodeAccess } from 'three/tsl';
+		import * as THREE from 'three/webgpu';
+		import { storageTexture, textureStore, Fn, instanceIndex, uniform, float, vec2, vec4, uvec2, ivec2, int, uint, NodeAccess } from 'three/tsl';
 
-			import WebGPU from 'three/addons/capabilities/WebGPU.js';
+		import WebGPU from 'three/addons/capabilities/WebGPU.js';
 
-			let camera, scene, renderer;
-			let computeInitNode, computeToPing, computeToPong;
-			let pingTexture, pongTexture;
-			let material;
-			let phase = true;
-			let lastUpdate = - 1;
+		let camera, scene, renderer;
+		let computeInitNode, computeToPing, computeToPong;
+		let pingTexture, pongTexture;
+		let material;
+		let phase = true;
+		let lastUpdate = - 1;
 
-			const seed = uniform( new THREE.Vector2() );
+		const width = 512, height = 512;
 
-			init();
+		const seed = uniform(new THREE.Vector2());
 
-			async function init() {
+		init();
 
-				if ( WebGPU.isAvailable() === false ) {
+		async function init() {
 
-					document.body.appendChild( WebGPU.getErrorMessage() );
+			if (WebGPU.isAvailable() === false) {
 
-					throw new Error( 'No WebGPU support' );
+				document.body.appendChild(WebGPU.getErrorMessage());
 
-				}
-
-				const aspect = window.innerWidth / window.innerHeight;
-				camera = new THREE.OrthographicCamera( - aspect, aspect, 1, - 1, 0, 2 );
-				camera.position.z = 1;
-
-				scene = new THREE.Scene();
-
-				// texture
-
-				const hdr = true;
-				const width = 512, height = 512;
-
-				pingTexture = new THREE.StorageTexture( width, height );
-				pongTexture = new THREE.StorageTexture( width, height );
-
-				if ( hdr ) {
-
-					pingTexture.type = THREE.HalfFloatType;
-					pongTexture.type = THREE.HalfFloatType;
-
-				}
-
-				const wgslFormat = hdr ? 'rgba16float' : 'rgba8unorm';
-			
-				const readPing = storageTexture( pingTexture ).setAccess( NodeAccess.READ_ONLY );
-				const writePing = storageTexture( pingTexture ).setAccess( NodeAccess.WRITE_ONLY );
-				const readPong = storageTexture( pongTexture ).setAccess( NodeAccess.READ_ONLY );
-				const writePong = storageTexture( pongTexture ).setAccess( NodeAccess.WRITE_ONLY );
-
-				// compute init
-
-				const rand2 = code( `
-					fn rand2( n: vec2f ) -> f32 {
-
-						return fract( sin( dot( n, vec2f( 12.9898, 4.1414 ) ) ) * 43758.5453 );
-
-					}
-
-					fn blur( image : texture_storage_2d<${wgslFormat}, read>, uv : vec2i ) -> vec4f {
-
-						var color = vec4f( 0.0 );
-
-						color += textureLoad( image, uv + vec2i( - 1, 1 ));
-						color += textureLoad( image, uv + vec2i( - 1, - 1 ));
-						color += textureLoad( image, uv + vec2i( 0, 0 ));
-						color += textureLoad( image, uv + vec2i( 1, - 1 ));
-						color += textureLoad( image, uv + vec2i( 1, 1 ));
-
-						return color / 5.0; 
-					}
-
-					fn getUV( posX: u32, posY: u32 ) -> vec2f {
-
-						let uv = vec2f( f32( posX ) / ${ width }.0, f32( posY ) / ${ height }.0 );
-
-						return uv;
-
-					}
-				` );
-
-				const computeInitWGSL = wgslFn( `
-					fn computeInitWGSL( writeTex: texture_storage_2d<${ wgslFormat }, write>, index: u32, seed: vec2f ) -> void {
-
-						let posX = index % ${ width };
-						let posY = index / ${ width };
-						let indexUV = vec2u( posX, posY );
-						let uv = getUV( posX, posY );
-
-						let r = rand2( uv + seed * 100 ) - rand2( uv + seed * 300 );
-						let g = rand2( uv + seed * 200 ) - rand2( uv + seed * 300 );
-						let b = rand2( uv + seed * 200 ) - rand2( uv + seed * 100 );
-
-						textureStore( writeTex, indexUV, vec4( r, g, b, 1 ) );
-
-					}
-				`, [ rand2 ] );
-
-				computeInitNode = computeInitWGSL( { writeTex: storageTexture( pingTexture ), index: instanceIndex, seed } ).compute( width * height );
-
-				// compute loop
-
-				const computePingPongWGSL = wgslFn( `
-					fn computePingPongWGSL( readTex: texture_storage_2d<${wgslFormat}, read>, writeTex: texture_storage_2d<${ wgslFormat }, write>, index: u32 ) -> void {
-
-						let posX = index % ${ width };
-						let posY = index / ${ width };
-						let indexUV = vec2i( i32( posX ), i32( posY ) );
-
-						let color = blur( readTex, indexUV ).rgb;
-
-						textureStore( writeTex, indexUV, vec4f( color * 1.05, 1 ) );
-
-					}
-				`, [ rand2 ] );
-
-				//
-
-				computeToPong = computePingPongWGSL( { readTex: readPing, writeTex: writePong, index: instanceIndex } ).compute( width * height );
-				computeToPing = computePingPongWGSL( { readTex: readPong, writeTex: writePing, index: instanceIndex } ).compute( width * height );
-
-				//
-
-				material = new THREE.MeshBasicMaterial( { color: 0xffffff, map: pongTexture } );
-
-				const plane = new THREE.Mesh( new THREE.PlaneGeometry( 1, 1 ), material );
-				scene.add( plane );
-
-				renderer = new THREE.WebGPURenderer( { antialias: true } );
-				renderer.setPixelRatio( window.devicePixelRatio );
-				renderer.setSize( window.innerWidth, window.innerHeight );
-				renderer.setAnimationLoop( render );
-				document.body.appendChild( renderer.domElement );
-
-				await renderer.init();
-
-				window.addEventListener( 'resize', onWindowResize );
-
-				// compute init
-
-				renderer.compute( computeInitNode );
+				throw new Error('No WebGPU support');
 
 			}
 
-			function onWindowResize() {
+			const aspect = window.innerWidth / window.innerHeight;
+			camera = new THREE.OrthographicCamera(- aspect, aspect, 1, - 1, 0, 2);
+			camera.position.z = 1;
 
-				renderer.setSize( window.innerWidth, window.innerHeight );
+			scene = new THREE.Scene();
 
-				const aspect = window.innerWidth / window.innerHeight;
+			// texture
 
-				const frustumHeight = camera.top - camera.bottom;
+			const hdr = true;
 
-				camera.left = - frustumHeight * aspect / 2;
-				camera.right = frustumHeight * aspect / 2;
+			pingTexture = new THREE.StorageTexture(width, height);
+			pongTexture = new THREE.StorageTexture(width, height);
 
-				camera.updateProjectionMatrix();
+			if (hdr) {
 
-			}
-
-			function render() {
-
-				const time = performance.now();
-				const seconds = Math.floor( time / 1000 );
-
-				// reset every second
-
-				if ( phase && seconds !== lastUpdate ) {
-
-					seed.value.set( Math.random(), Math.random() );
-
-					renderer.compute( computeInitNode );
-
-					lastUpdate = seconds;
-
-				}
-
-				// compute step
-
-				renderer.compute( phase ? computeToPong : computeToPing );
-
-				material.map = phase ? pongTexture : pingTexture;
-
-				phase = ! phase;
-
-				// render step
-
-				// update material texture node
-
-				renderer.render( scene, camera );
+				pingTexture.type = THREE.HalfFloatType;
+				pongTexture.type = THREE.HalfFloatType;
 
 			}
 
-		</script>
-	</body>
+
+			const rand2 = Fn(([n]) => {
+
+				return n.dot(vec2(12.9898, 4.1414)).sin().mul(43758.5453).fract();
+
+			});
+
+			// Create storage texture nodes with proper access
+			const writePing = storageTexture(pingTexture).setAccess(NodeAccess.WRITE_ONLY);
+			const readPing = storageTexture(pingTexture).setAccess(NodeAccess.READ_ONLY);
+			const writePong = storageTexture(pongTexture).setAccess(NodeAccess.WRITE_ONLY);
+			const readPong = storageTexture(pongTexture).setAccess(NodeAccess.READ_ONLY);
+
+
+			const computeInit = Fn(() => {
+
+				const posX = instanceIndex.mod(width);
+				const posY = instanceIndex.div(width);
+				const indexUV = uvec2(posX, posY);
+				const uv = vec2(float(posX).div(width), float(posY).div(height));
+
+				const r = rand2(uv.add(seed.mul(100))).sub(rand2(uv.add(seed.mul(300))));
+				const g = rand2(uv.add(seed.mul(200))).sub(rand2(uv.add(seed.mul(300))));
+				const b = rand2(uv.add(seed.mul(200))).sub(rand2(uv.add(seed.mul(100))));
+
+				textureStore(writePing, indexUV, vec4(r, g, b, 1));
+
+			});
+
+			computeInitNode = computeInit().compute(width * height);
+
+			// compute ping-pong: blur function using .load() for textureLoad
+			// This triggers both bugs:
+			// 1. clone() loses READ_ONLY access
+			// 2. generateTextureLoad adds level parameter for storage textures
+			const blur = Fn(([readTex, uv]) => {
+
+				const c0 = readTex.load(uv.add(ivec2(- 1, 1)));
+				const c1 = readTex.load(uv.add(ivec2(- 1, - 1)));
+				const c2 = readTex.load(uv.add(ivec2(0, 0)));
+				const c3 = readTex.load(uv.add(ivec2(1, - 1)));
+				const c4 = readTex.load(uv.add(ivec2(1, 1)));
+
+				return c0.add(c1).add(c2).add(c3).add(c4).div(5.0);
+
+			});
+
+			// compute loop: read from one texture, blur, write to another
+			// will explode
+			const computePingPong = Fn(([readTex, writeTex]) => {
+
+				const posX = instanceIndex.mod(width);
+				const posY = instanceIndex.div(width);
+				const indexUV = ivec2(int(posX), int(posY));
+
+				const color = blur(readTex, indexUV);
+
+				textureStore(writeTex, indexUV, vec4(color.rgb.mul(1.05), 1));
+
+			});
+
+			computeToPong = computePingPong(readPing, writePong).compute(width * height);
+			computeToPing = computePingPong(readPong, writePing).compute(width * height);
+
+			//
+
+			material = new THREE.MeshBasicMaterial({ color: 0xffffff, map: pongTexture });
+
+			const plane = new THREE.Mesh(new THREE.PlaneGeometry(1, 1), material);
+			scene.add(plane);
+
+			renderer = new THREE.WebGPURenderer({ antialias: true });
+			renderer.setPixelRatio(window.devicePixelRatio);
+			renderer.setSize(window.innerWidth, window.innerHeight);
+			renderer.setAnimationLoop(render);
+			document.body.appendChild(renderer.domElement);
+
+			await renderer.init();
+
+			window.addEventListener('resize', onWindowResize);
+
+			// compute init
+
+			renderer.compute(computeInitNode);
+
+		}
+
+		function onWindowResize() {
+
+			renderer.setSize(window.innerWidth, window.innerHeight);
+
+			const aspect = window.innerWidth / window.innerHeight;
+
+			const frustumHeight = camera.top - camera.bottom;
+
+			camera.left = - frustumHeight * aspect / 2;
+			camera.right = frustumHeight * aspect / 2;
+
+			camera.updateProjectionMatrix();
+
+		}
+
+		function render() {
+
+			const time = performance.now();
+			const seconds = Math.floor(time / 1000);
+
+			// reset every second
+
+			if (phase && seconds !== lastUpdate) {
+
+				seed.value.set(Math.random(), Math.random());
+
+				renderer.compute(computeInitNode);
+
+				lastUpdate = seconds;
+
+			}
+
+			// compute step
+
+			renderer.compute(phase ? computeToPong : computeToPing);
+
+			material.map = phase ? pongTexture : pingTexture;
+
+			phase = !phase;
+
+			// render step
+
+			// update material texture node
+
+			renderer.render(scene, camera);
+
+		}
+
+	</script>
+</body>
+
 </html>

--- a/examples/webgpu_compute_texture_pingpong.html
+++ b/examples/webgpu_compute_texture_pingpong.html
@@ -1,28 +1,26 @@
 <html lang="en">
+	<head>
+		<title>three.js webgpu - compute ping/pong texture</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<link type="text/css" rel="stylesheet" href="example.css">
+	</head>
+	<body>
 
-<head>
-	<title>three.js webgpu - compute ping/pong texture</title>
-	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
-	<link type="text/css" rel="stylesheet" href="example.css">
-</head>
+		<div id="info">
+			<a href="https://threejs.org/" target="_blank" rel="noopener" class="logo-link"></a>
 
-<body>
+			<div class="title-wrapper">
+				<a href="https://threejs.org/" target="_blank" rel="noopener">three.js</a>
+				<span>Compute Ping/Pong Texture</span>
+			</div>
 
-	<div id="info">
-		<a href="https://threejs.org/" target="_blank" rel="noopener" class="logo-link"></a>
-
-		<div class="title-wrapper">
-			<a href="https://threejs.org/" target="_blank" rel="noopener">three.js</a>
-			<span>Compute Ping/Pong Texture</span>
+			<small>
+				Compute ping/pong texture using GPU (pure TSL).
+			</small>
 		</div>
 
-		<small>
-			Compute ping/pong texture using GPU (pure TSL).
-		</small>
-	</div>
-
-	<script type="importmap">
+		<script type="importmap">
 			{
 				"imports": {
 					"three": "../build/three.webgpu.js",
@@ -33,192 +31,185 @@
 			}
 		</script>
 
-	<script type="module">
+		<script type="module">
 
-		import * as THREE from 'three/webgpu';
-		import { storageTexture, textureStore, Fn, instanceIndex, uniform, float, vec2, vec4, uvec2, ivec2, int, uint, NodeAccess } from 'three/tsl';
+			import * as THREE from 'three/webgpu';
+			import { storageTexture, textureStore, Fn, instanceIndex, uniform, float, vec2, vec4, uvec2, ivec2, int, NodeAccess } from 'three/tsl';
 
-		import WebGPU from 'three/addons/capabilities/WebGPU.js';
+			import WebGPU from 'three/addons/capabilities/WebGPU.js';
 
-		let camera, scene, renderer;
-		let computeInitNode, computeToPing, computeToPong;
-		let pingTexture, pongTexture;
-		let material;
-		let phase = true;
-		let lastUpdate = - 1;
+			let camera, scene, renderer;
+			let computeInitNode, computeToPing, computeToPong;
+			let pingTexture, pongTexture;
+			let material;
+			let phase = true;
+			let lastUpdate = - 1;
 
-		const width = 512, height = 512;
+			const width = 512, height = 512;
 
-		const seed = uniform(new THREE.Vector2());
+			const seed = uniform( new THREE.Vector2() );
 
-		init();
+			init();
 
-		async function init() {
+			async function init() {
 
-			if (WebGPU.isAvailable() === false) {
+				if ( WebGPU.isAvailable() === false ) {
 
-				document.body.appendChild(WebGPU.getErrorMessage());
+					document.body.appendChild( WebGPU.getErrorMessage() );
 
-				throw new Error('No WebGPU support');
+					throw new Error( 'No WebGPU support' );
+
+				}
+
+				const aspect = window.innerWidth / window.innerHeight;
+				camera = new THREE.OrthographicCamera( - aspect, aspect, 1, - 1, 0, 2 );
+				camera.position.z = 1;
+
+				scene = new THREE.Scene();
+
+				// texture
+
+				const hdr = true;
+
+				pingTexture = new THREE.StorageTexture( width, height );
+				pongTexture = new THREE.StorageTexture( width, height );
+
+				if ( hdr ) {
+
+					pingTexture.type = THREE.HalfFloatType;
+					pongTexture.type = THREE.HalfFloatType;
+
+				}
+
+				const rand2 = Fn( ( [ n ] ) => {
+
+					return n.dot( vec2( 12.9898, 4.1414 ) ).sin().mul( 43758.5453 ).fract();
+
+				} );
+
+				// Create storage texture nodes with proper access
+				const writePing = storageTexture( pingTexture ).setAccess( NodeAccess.WRITE_ONLY );
+				const readPing = storageTexture( pingTexture ).setAccess( NodeAccess.READ_ONLY );
+				const writePong = storageTexture( pongTexture ).setAccess( NodeAccess.WRITE_ONLY );
+				const readPong = storageTexture( pongTexture ).setAccess( NodeAccess.READ_ONLY );
+
+				const computeInit = Fn( () => {
+
+					const posX = instanceIndex.mod( width );
+					const posY = instanceIndex.div( width );
+					const indexUV = uvec2( posX, posY );
+					const uv = vec2( float( posX ).div( width ), float( posY ).div( height ) );
+
+					const r = rand2( uv.add( seed.mul( 100 ) ) ).sub( rand2( uv.add( seed.mul( 300 ) ) ) );
+					const g = rand2( uv.add( seed.mul( 200 ) ) ).sub( rand2( uv.add( seed.mul( 300 ) ) ) );
+					const b = rand2( uv.add( seed.mul( 200 ) ) ).sub( rand2( uv.add( seed.mul( 100 ) ) ) );
+
+					textureStore( writePing, indexUV, vec4( r, g, b, 1 ) );
+
+				} );
+
+				computeInitNode = computeInit().compute( width * height );
+
+				// compute ping-pong: blur function using .load() for textureLoad
+				const blur = Fn( ( [ readTex, uv ] ) => {
+
+					const c0 = readTex.load( uv.add( ivec2( - 1, 1 ) ) );
+					const c1 = readTex.load( uv.add( ivec2( - 1, - 1 ) ) );
+					const c2 = readTex.load( uv.add( ivec2( 0, 0 ) ) );
+					const c3 = readTex.load( uv.add( ivec2( 1, - 1 ) ) );
+					const c4 = readTex.load( uv.add( ivec2( 1, 1 ) ) );
+
+					return c0.add( c1 ).add( c2 ).add( c3 ).add( c4 ).div( 5.0 );
+
+				} );
+
+				// compute loop: read from one texture, blur, write to another
+				const computePingPong = Fn( ( [ readTex, writeTex ] ) => {
+
+					const posX = instanceIndex.mod( width );
+					const posY = instanceIndex.div( width );
+					const indexUV = ivec2( int( posX ), int( posY ) );
+
+					const color = blur( readTex, indexUV );
+
+					textureStore( writeTex, indexUV, vec4( color.rgb.mul( 1.05 ), 1 ) );
+
+				} );
+
+				computeToPong = computePingPong( readPing, writePong ).compute( width * height );
+				computeToPing = computePingPong( readPong, writePing ).compute( width * height );
+
+				//
+
+				material = new THREE.MeshBasicMaterial( { color: 0xffffff, map: pongTexture } );
+
+				const plane = new THREE.Mesh( new THREE.PlaneGeometry( 1, 1 ), material );
+				scene.add( plane );
+
+				renderer = new THREE.WebGPURenderer( { antialias: true } );
+				renderer.setPixelRatio( window.devicePixelRatio );
+				renderer.setSize( window.innerWidth, window.innerHeight );
+				renderer.setAnimationLoop( render );
+				document.body.appendChild( renderer.domElement );
+
+				await renderer.init();
+
+				window.addEventListener( 'resize', onWindowResize );
+
+				// compute init
+
+				renderer.compute( computeInitNode );
 
 			}
 
-			const aspect = window.innerWidth / window.innerHeight;
-			camera = new THREE.OrthographicCamera(- aspect, aspect, 1, - 1, 0, 2);
-			camera.position.z = 1;
+			function onWindowResize() {
 
-			scene = new THREE.Scene();
+				renderer.setSize( window.innerWidth, window.innerHeight );
 
-			// texture
+				const aspect = window.innerWidth / window.innerHeight;
 
-			const hdr = true;
+				const frustumHeight = camera.top - camera.bottom;
 
-			pingTexture = new THREE.StorageTexture(width, height);
-			pongTexture = new THREE.StorageTexture(width, height);
+				camera.left = - frustumHeight * aspect / 2;
+				camera.right = frustumHeight * aspect / 2;
 
-			if (hdr) {
-
-				pingTexture.type = THREE.HalfFloatType;
-				pongTexture.type = THREE.HalfFloatType;
+				camera.updateProjectionMatrix();
 
 			}
 
+			function render() {
 
-			const rand2 = Fn(([n]) => {
+				const time = performance.now();
+				const seconds = Math.floor( time / 1000 );
 
-				return n.dot(vec2(12.9898, 4.1414)).sin().mul(43758.5453).fract();
+				// reset every second
 
-			});
+				if ( phase && seconds !== lastUpdate ) {
 
-			// Create storage texture nodes with proper access
-			const writePing = storageTexture(pingTexture).setAccess(NodeAccess.WRITE_ONLY);
-			const readPing = storageTexture(pingTexture).setAccess(NodeAccess.READ_ONLY);
-			const writePong = storageTexture(pongTexture).setAccess(NodeAccess.WRITE_ONLY);
-			const readPong = storageTexture(pongTexture).setAccess(NodeAccess.READ_ONLY);
+					seed.value.set( Math.random(), Math.random() );
 
+					renderer.compute( computeInitNode );
 
-			const computeInit = Fn(() => {
+					lastUpdate = seconds;
 
-				const posX = instanceIndex.mod(width);
-				const posY = instanceIndex.div(width);
-				const indexUV = uvec2(posX, posY);
-				const uv = vec2(float(posX).div(width), float(posY).div(height));
+				}
 
-				const r = rand2(uv.add(seed.mul(100))).sub(rand2(uv.add(seed.mul(300))));
-				const g = rand2(uv.add(seed.mul(200))).sub(rand2(uv.add(seed.mul(300))));
-				const b = rand2(uv.add(seed.mul(200))).sub(rand2(uv.add(seed.mul(100))));
+				// compute step
 
-				textureStore(writePing, indexUV, vec4(r, g, b, 1));
+				renderer.compute( phase ? computeToPong : computeToPing );
 
-			});
+				material.map = phase ? pongTexture : pingTexture;
 
-			computeInitNode = computeInit().compute(width * height);
+				phase = ! phase;
 
-			// compute ping-pong: blur function using .load() for textureLoad
-			// This triggers both bugs:
-			// 1. clone() loses READ_ONLY access
-			// 2. generateTextureLoad adds level parameter for storage textures
-			const blur = Fn(([readTex, uv]) => {
+				// render step
 
-				const c0 = readTex.load(uv.add(ivec2(- 1, 1)));
-				const c1 = readTex.load(uv.add(ivec2(- 1, - 1)));
-				const c2 = readTex.load(uv.add(ivec2(0, 0)));
-				const c3 = readTex.load(uv.add(ivec2(1, - 1)));
-				const c4 = readTex.load(uv.add(ivec2(1, 1)));
+				// update material texture node
 
-				return c0.add(c1).add(c2).add(c3).add(c4).div(5.0);
-
-			});
-
-			// compute loop: read from one texture, blur, write to another
-			// will explode
-			const computePingPong = Fn(([readTex, writeTex]) => {
-
-				const posX = instanceIndex.mod(width);
-				const posY = instanceIndex.div(width);
-				const indexUV = ivec2(int(posX), int(posY));
-
-				const color = blur(readTex, indexUV);
-
-				textureStore(writeTex, indexUV, vec4(color.rgb.mul(1.05), 1));
-
-			});
-
-			computeToPong = computePingPong(readPing, writePong).compute(width * height);
-			computeToPing = computePingPong(readPong, writePing).compute(width * height);
-
-			//
-
-			material = new THREE.MeshBasicMaterial({ color: 0xffffff, map: pongTexture });
-
-			const plane = new THREE.Mesh(new THREE.PlaneGeometry(1, 1), material);
-			scene.add(plane);
-
-			renderer = new THREE.WebGPURenderer({ antialias: true });
-			renderer.setPixelRatio(window.devicePixelRatio);
-			renderer.setSize(window.innerWidth, window.innerHeight);
-			renderer.setAnimationLoop(render);
-			document.body.appendChild(renderer.domElement);
-
-			await renderer.init();
-
-			window.addEventListener('resize', onWindowResize);
-
-			// compute init
-
-			renderer.compute(computeInitNode);
-
-		}
-
-		function onWindowResize() {
-
-			renderer.setSize(window.innerWidth, window.innerHeight);
-
-			const aspect = window.innerWidth / window.innerHeight;
-
-			const frustumHeight = camera.top - camera.bottom;
-
-			camera.left = - frustumHeight * aspect / 2;
-			camera.right = frustumHeight * aspect / 2;
-
-			camera.updateProjectionMatrix();
-
-		}
-
-		function render() {
-
-			const time = performance.now();
-			const seconds = Math.floor(time / 1000);
-
-			// reset every second
-
-			if (phase && seconds !== lastUpdate) {
-
-				seed.value.set(Math.random(), Math.random());
-
-				renderer.compute(computeInitNode);
-
-				lastUpdate = seconds;
+				renderer.render( scene, camera );
 
 			}
 
-			// compute step
-
-			renderer.compute(phase ? computeToPong : computeToPing);
-
-			material.map = phase ? pongTexture : pingTexture;
-
-			phase = !phase;
-
-			// render step
-
-			// update material texture node
-
-			renderer.render(scene, camera);
-
-		}
-
-	</script>
-</body>
-
+		</script>
+	</body>
 </html>

--- a/src/nodes/accessors/StorageTextureNode.js
+++ b/src/nodes/accessors/StorageTextureNode.js
@@ -222,6 +222,7 @@ class StorageTextureNode extends TextureNode {
 		const newNode = super.clone();
 		newNode.storeNode = this.storeNode;
 		newNode.mipLevel = this.mipLevel;
+		newNode.access = this.access;
 		return newNode;
 
 	}
@@ -255,7 +256,20 @@ export const storageTexture = /*@__PURE__*/ nodeProxy( StorageTextureNode ).setP
  */
 export const textureStore = ( value, uvNode, storeNode ) => {
 
-	const node = storageTexture( value, uvNode, storeNode );
+	let node;
+
+	if ( value.isStorageTextureNode === true ) {
+
+		// Derive new storage texture node from existing one
+		node = value.clone();
+		node.uvNode = uvNode;
+		node.storeNode = storeNode;
+
+	} else {
+
+		node = storageTexture( value, uvNode, storeNode );
+
+	}
 
 	if ( storeNode !== null ) node.toStack();
 

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -544,7 +544,9 @@ class WGSLNodeBuilder extends NodeBuilder {
 	 */
 	generateTextureLoad( texture, textureProperty, uvIndexSnippet, levelSnippet, depthSnippet, offsetSnippet ) {
 
-		if ( levelSnippet === null ) levelSnippet = '0u';
+		const isStorageTexture = texture.isStorageTexture === true;
+
+		if ( levelSnippet === null && ! isStorageTexture ) levelSnippet = '0u';
 
 		if ( offsetSnippet ) {
 
@@ -556,15 +558,33 @@ class WGSLNodeBuilder extends NodeBuilder {
 
 		if ( depthSnippet ) {
 
-			snippet = `textureLoad( ${ textureProperty }, ${ uvIndexSnippet }, ${ depthSnippet }, u32( ${ levelSnippet } ) )`;
+			// Storage textures don't take a level parameter in WGSL
+			if ( isStorageTexture ) {
+
+				snippet = `textureLoad( ${ textureProperty }, ${ uvIndexSnippet }, ${ depthSnippet } )`;
+
+			} else {
+
+				snippet = `textureLoad( ${ textureProperty }, ${ uvIndexSnippet }, ${ depthSnippet }, u32( ${ levelSnippet } ) )`;
+
+			}
 
 		} else {
 
-			snippet = `textureLoad( ${ textureProperty }, ${ uvIndexSnippet }, u32( ${ levelSnippet } ) )`;
+			// Storage textures don't take a level parameter in WGSL
+			if ( isStorageTexture ) {
 
-			if ( this.renderer.backend.compatibilityMode && texture.isDepthTexture ) {
+				snippet = `textureLoad( ${ textureProperty }, ${ uvIndexSnippet } )`;
 
-				snippet += '.x';
+			} else {
+
+				snippet = `textureLoad( ${ textureProperty }, ${ uvIndexSnippet }, u32( ${ levelSnippet } ) )`;
+
+				if ( this.renderer.backend.compatibilityMode && texture.isDepthTexture ) {
+
+					snippet += '.x';
+
+				}
 
 			}
 

--- a/test/unit/src/nodes/accessors/StorageTextureNode.tests.js
+++ b/test/unit/src/nodes/accessors/StorageTextureNode.tests.js
@@ -1,0 +1,39 @@
+import { storageTexture } from '../../../../../src/nodes/accessors/StorageTextureNode.js';
+import { NodeAccess } from '../../../../../src/nodes/core/constants.js';
+import StorageTexture from '../../../../../src/renderers/common/StorageTexture.js';
+
+export default QUnit.module( 'Nodes', () => {
+
+	QUnit.module( 'Accessors', () => {
+
+		QUnit.module( 'StorageTextureNode', () => {
+
+			QUnit.test( 'clone preserves access property', ( assert ) => {
+
+				const texture = new StorageTexture( 512, 512 );
+				const node = storageTexture( texture ).setAccess( NodeAccess.READ_ONLY );
+
+				assert.strictEqual( node.access, NodeAccess.READ_ONLY, 'original has READ_ONLY access' );
+
+				const cloned = node.clone();
+
+				assert.strictEqual( cloned.access, NodeAccess.READ_ONLY, 'cloned node preserves READ_ONLY access' );
+
+			} );
+
+			QUnit.test( 'clone preserves READ_WRITE access', ( assert ) => {
+
+				const texture = new StorageTexture( 512, 512 );
+				const node = storageTexture( texture ).setAccess( NodeAccess.READ_WRITE );
+
+				const cloned = node.clone();
+
+				assert.strictEqual( cloned.access, NodeAccess.READ_WRITE, 'cloned node preserves READ_WRITE access' );
+
+			} );
+
+		} );
+
+	} );
+
+} );

--- a/test/unit/src/renderers/webgpu/nodes/WGSLNodeBuilder.tests.js
+++ b/test/unit/src/renderers/webgpu/nodes/WGSLNodeBuilder.tests.js
@@ -1,0 +1,69 @@
+import WGSLNodeBuilder from '../../../../../../src/renderers/webgpu/nodes/WGSLNodeBuilder.js';
+
+export default QUnit.module( 'Renderers', () => {
+
+	QUnit.module( 'WebGPU', () => {
+
+		QUnit.module( 'Nodes', () => {
+
+			QUnit.module( 'WGSLNodeBuilder', () => {
+
+				// generateTextureLoad is essentially a pure function (texture info -> WGSL string)
+				// The only 'this' access is renderer.backend.compatibilityMode for a depth texture edge case
+				// We test the real method with minimal context to verify WGSL output
+
+				QUnit.test( 'generateTextureLoad omits level for storage textures', ( assert ) => {
+
+					const context = {
+						renderer: { backend: { compatibilityMode: false } }
+					};
+
+					const storageTexture = { isStorageTexture: true };
+
+					const snippet = WGSLNodeBuilder.prototype.generateTextureLoad.call(
+						context,
+						storageTexture,
+						'testTexture',
+						'uvec2(0, 0)',
+						null, // levelSnippet
+						null, // depthSnippet
+						null // offsetSnippet
+					);
+
+					// Storage textures should NOT have level parameter (WGSL spec)
+					assert.notOk( snippet.includes( 'u32(' ), 'storage texture load should not include level parameter' );
+					assert.strictEqual( snippet, 'textureLoad( testTexture, uvec2(0, 0) )', 'correct WGSL for storage texture' );
+
+				} );
+
+				QUnit.test( 'generateTextureLoad includes level for regular textures', ( assert ) => {
+
+					const context = {
+						renderer: { backend: { compatibilityMode: false } }
+					};
+
+					const regularTexture = { isStorageTexture: false };
+
+					const snippet = WGSLNodeBuilder.prototype.generateTextureLoad.call(
+						context,
+						regularTexture,
+						'testTexture',
+						'uvec2(0, 0)',
+						null, // levelSnippet - should default to '0u'
+						null,
+						null
+					);
+
+					// Regular textures SHOULD have level parameter
+					assert.ok( snippet.includes( 'u32( 0u )' ), 'regular texture load should include default level parameter' );
+					assert.strictEqual( snippet, 'textureLoad( testTexture, uvec2(0, 0), u32( 0u ) )' );
+
+				} );
+
+			} );
+
+		} );
+
+	} );
+
+} );

--- a/test/unit/three.source.unit.js
+++ b/test/unit/three.source.unit.js
@@ -265,6 +265,12 @@ import './src/renderers/webgl/WebGLTextures.tests.js';
 import './src/renderers/webgl/WebGLUniforms.tests.js';
 import './src/renderers/webgl/WebGLUtils.tests.js';
 
+//src/renderers/webgpu/nodes
+import './src/renderers/webgpu/nodes/WGSLNodeBuilder.tests.js';
+
+//src/nodes/accessors
+import './src/nodes/accessors/StorageTextureNode.tests.js';
+
 
 //src/scenes
 import './src/scenes/Fog.tests.js';


### PR DESCRIPTION


## Description

Streamlines storage texture read/write operations in TSL, enabling patterns like ping-pong compute shaders without raw WGSL.   

### Problems

Initially based on trying to implement a ping-pong type compute shader setup based on `examples/webgpu_compute_texture_pingpong.html`, but using "pure" TSL, i.e. port the WGSL compute strings to native TSL methods. But:

- **clone loses access**: `.load()` path calls `.clone`, which doesn't preserve access. Defaults to write-only.

- **invalid `textureLoad()` signature for storage textures**:  when passing a storage texture to `generateTextureLoad()`, it does:
```
if (  levelSnippet === null ) levelSnippet = '0u'
```
...which is fine for regular textures but the WGSL `textureLoad()` doesn't accept a levels parameter for storage textures.

- **passing nodes to `textureStore()`**: for this ping-pong type example it ends up being a lot more ergonomic to build out the read/write nodes first then pass them to `textureStore()` during compute. But out-of-the-box that doesn't work because end up with a full node for the value.

Also, incidentally, I noticed while doing this that the original  `webgpu_compute_texture_pingpong` example doesn't work in Firefox because naga complains about `writeTex` not being a global binding. More of a naga issue but using TSL sidesteps this entirely.

### Changes
<details>
<summary>

One line update to storageTextureNode.clone to preserve access

Some checks in `generateTextureLoad()` to match the WGSL `textureLoad` signature when `isStorageTexture` is true

Compatibility path in `textureStore()` to allow an existing storageTextureNode to be passed (without overwriting that node)

Ported ping-pong example to use this pattern

Added some basic validation tests </summary>

### Before

```js
const readPing = storageTexture( pingTexture ).setAccess( NodeAccess.READ_ONLY );
				const writePing = storageTexture( pingTexture ).setAccess( NodeAccess.WRITE_ONLY );
				const readPong = storageTexture( pongTexture ).setAccess( NodeAccess.READ_ONLY );
				const writePong = storageTexture( pongTexture ).setAccess( NodeAccess.WRITE_ONLY );

				// compute init

				const rand2 = code( `
					fn rand2( n: vec2f ) -> f32 {

						return fract( sin( dot( n, vec2f( 12.9898, 4.1414 ) ) ) * 43758.5453 );

					}

					fn blur( image : texture_storage_2d<${wgslFormat}, read>, uv : vec2i ) -> vec4f {

						var color = vec4f( 0.0 );

						color += textureLoad( image, uv + vec2i( - 1, 1 ));
						color += textureLoad( image, uv + vec2i( - 1, - 1 ));
						color += textureLoad( image, uv + vec2i( 0, 0 ));
						color += textureLoad( image, uv + vec2i( 1, - 1 ));
						color += textureLoad( image, uv + vec2i( 1, 1 ));

						return color / 5.0; 
					}

					fn getUV( posX: u32, posY: u32 ) -> vec2f {

						let uv = vec2f( f32( posX ) / ${ width }.0, f32( posY ) / ${ height }.0 );

						return uv;

					}
				` );
				//etc

  ```
  
  ### After
  
  ```js
			const rand2 = Fn(([n]) => {

				return n.dot(vec2(12.9898, 4.1414)).sin().mul(43758.5453).fract();

			});

			const writePing = storageTexture(pingTexture).setAccess(NodeAccess.WRITE_ONLY);
			const readPing = storageTexture(pingTexture).setAccess(NodeAccess.READ_ONLY);
			const writePong = storageTexture(pongTexture).setAccess(NodeAccess.WRITE_ONLY);
			const readPong = storageTexture(pongTexture).setAccess(NodeAccess.READ_ONLY);

			const computeInit = Fn(() => {

				const posX = instanceIndex.mod(width);
				const posY = instanceIndex.div(width);
				const indexUV = uvec2(posX, posY);
				const uv = vec2(float(posX).div(width), float(posY).div(height));

				const r = rand2(uv.add(seed.mul(100))).sub(rand2(uv.add(seed.mul(300))));
				const g = rand2(uv.add(seed.mul(200))).sub(rand2(uv.add(seed.mul(300))));
				const b = rand2(uv.add(seed.mul(200))).sub(rand2(uv.add(seed.mul(100))));

				textureStore(writePing, indexUV, vec4(r, g, b, 1));

			});

			computeInitNode = computeInit().compute(width * height);

			// compute ping-pong: blur function using .load() for textureLoad
			const blur = Fn(([readTex, uv]) => {

				const c0 = readTex.load(uv.add(ivec2(- 1, 1)));
				const c1 = readTex.load(uv.add(ivec2(- 1, - 1)));
				const c2 = readTex.load(uv.add(ivec2(0, 0)));
				const c3 = readTex.load(uv.add(ivec2(1, - 1)));
				const c4 = readTex.load(uv.add(ivec2(1, 1)));

				return c0.add(c1).add(c2).add(c3).add(c4).div(5.0);

			});
  ```
</details>
---

Unit tests pass, lints clean, etc. Example verified working in chromium and Firefox.
Can work around some of this `texture(tex, uv)` + NearestFilter + some normalization math but the PR method feels a lot more TSL-semantic.

