### PR TITLE
Examples: Add missing UnrealBloomPass parameters

### DIFF
--- a/examples/webgl_shaders_ocean.html
+++ b/examples/webgl_shaders_ocean.html
@@ -54,7 +54,7 @@
 				renderer.toneMappingExposure = 0.1;
 				container.appendChild( renderer.domElement );
 
-				bloomPass = new UnrealBloomPass( new THREE.Vector2( window.innerWidth, window.innerHeight ) );
+				bloomPass = new UnrealBloomPass( new THREE.Vector2( window.innerWidth, window.innerHeight ), 1.5, 0.4, 0.85 );
 				bloomPass.threshold = 0;
 				bloomPass.strength = 0.1;
 				bloomPass.radius = 0;


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/32680#discussion_r2666929412

**Description**

The parameters to `UnrealBloomPass` don't appear to be optional. I set them to match the values used elsewhere.