### PR TITLE
add Needle devtools

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,7 @@
 						<li><a href="examples/">examples</a></li>
 						<li><a href="docs/">documentation</a></li>
 						<li><a href="https://chromewebstore.google.com/detail/threejs-devtools/jechbjkglifdaldbdbigibihfaclnkbo">devtools</a></li>
+						<li><a href="https://chromewebstore.google.com/detail/needle-inspector-%E2%80%94-devtoo/jonplpbnhmanoekkgcepnedhghflblmo">Needle devtools</a></li>
 						<li><a href="https://chat.openai.com/g/g-jGjqAMvED-three-js-mentor">gpt</a></li>
 					</ul>
 

--- a/index.html
+++ b/index.html
@@ -48,7 +48,6 @@
 						<li><a href="examples/">examples</a></li>
 						<li><a href="docs/">documentation</a></li>
 						<li><a href="https://chromewebstore.google.com/detail/threejs-devtools/jechbjkglifdaldbdbigibihfaclnkbo">devtools</a></li>
-						<li><a href="https://chromewebstore.google.com/detail/needle-inspector-%E2%80%94-devtoo/jonplpbnhmanoekkgcepnedhghflblmo">Needle devtools</a></li>
 						<li><a href="https://chat.openai.com/g/g-jGjqAMvED-three-js-mentor">gpt</a></li>
 					</ul>
 
@@ -77,6 +76,7 @@
 						<li><a href="https://threejs-journey.xyz/" target="_blank" rel="noopener">Three.js Journey</a></li>
 						<li><a href="https://simondev.io/" target="_blank" rel="noopener">Three.js Game Development</a></li>
 						<li><a href="https://threejsresources.com/" target="_blank" rel="noopener">Three.js Resources</a></li>
+						<li><a href="https://needle.tools/needle-inspector-devtools-for-threejs">Needle devtools</a></li>
 					</ul>
 
 					<h2>Merch</h2>


### PR DESCRIPTION
This PR adds [Needle Inspector](https://chromewebstore.google.com/detail/needle-inspector-%E2%80%94-devtoo/jonplpbnhmanoekkgcepnedhghflblmo) to the three.js hompage, directly below the three.js devtools since they have a similar purpose.

Alternatives:
- adding the link to the Resources section
- devtools could link to a separate page (e.g. in manual/devtools) that lists available editors tools for three.js


So far the Inspector reception has been very positive so I hope adding it in a prominent place is OK.

Let me know what you think!

**PR**
<img width="1882" height="1277" alt="image" src="https://github.com/user-attachments/assets/42798621-ea60-45d7-a311-f4a9db47abcc" />

**ALTERNATIVE** in Resources section
<img width="1882" height="1277" alt="image" src="https://github.com/user-attachments/assets/3cbd650e-6d0a-4516-a276-56f970a3bbc6" />
