### PR TITLE
BatchedMesh: correctly set the nextIndexStart, nextVertexStart

### DIFF
--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -957,12 +957,10 @@ class BatchedMesh extends Mesh {
 			nextVertexStart += geometryInfo.reservedVertexCount;
 			geometryInfo.start = geometry.index ? geometryInfo.indexStart : geometryInfo.vertexStart;
 
-			// step the next geometry points to the shifted position
-			this._nextIndexStart = geometry.index ? geometryInfo.indexStart + geometryInfo.reservedIndexCount : 0;
-			this._nextVertexStart = geometryInfo.vertexStart + geometryInfo.reservedVertexCount;
-
 		}
 
+		this._nextIndexStart = nextIndexStart;
+		this._nextVertexStart = nextVertexStart;
 		this._visibilityChanged = true;
 
 		return this;


### PR DESCRIPTION
Fixed #32741

**Description**

Fixes case in "optimize" function where _indexIndexStart and _nextVertexStart in were not set correctly when all geometries had been deleted.