### PR TITLE
Object3D: Added pivot property.

### DIFF
--- a/examples/jsm/loaders/LWOLoader.js
+++ b/examples/jsm/loaders/LWOLoader.js
@@ -23,7 +23,8 @@ import {
 	RepeatWrapping,
 	SRGBColorSpace,
 	TextureLoader,
-	Vector2
+	Vector2,
+	Vector3
 } from 'three';
 
 import { IFFParser } from './lwo/IFFParser.js';
@@ -185,8 +186,6 @@ class LWOTreeParser {
 
 		} );
 
-		this.applyPivots( finalMeshes );
-
 		return finalMeshes;
 
 	}
@@ -204,38 +203,14 @@ class LWOTreeParser {
 		if ( layer.name ) mesh.name = layer.name;
 		else mesh.name = this.defaultLayerName + '_layer_' + layer.number;
 
-		mesh.userData.pivot = layer.pivot;
+		const pivot = layer.pivot;
+		if ( pivot[ 0 ] !== 0 || pivot[ 1 ] !== 0 || pivot[ 2 ] !== 0 ) {
+
+			mesh.pivot = new Vector3( pivot[ 0 ], pivot[ 1 ], pivot[ 2 ] );
+
+		}
 
 		return mesh;
-
-	}
-
-	// TODO: may need to be reversed in z to convert LWO to three.js coordinates
-	applyPivots( meshes ) {
-
-		meshes.forEach( function ( mesh ) {
-
-			mesh.traverse( function ( child ) {
-
-				const pivot = child.userData.pivot;
-
-				child.position.x += pivot[ 0 ];
-				child.position.y += pivot[ 1 ];
-				child.position.z += pivot[ 2 ];
-
-				if ( child.parent ) {
-
-					const parentPivot = child.parent.userData.pivot;
-
-					child.position.x -= parentPivot[ 0 ];
-					child.position.y -= parentPivot[ 1 ];
-					child.position.z -= parentPivot[ 2 ];
-
-				}
-
-			} );
-
-		} );
 
 	}
 
@@ -812,13 +787,6 @@ class GeometryParser {
 
 		this.parseUVs( geometry, layer );
 		this.parseMorphTargets( geometry, layer );
-
-		// TODO: z may need to be reversed to account for coordinate system change
-		geometry.translate( - layer.pivot[ 0 ], - layer.pivot[ 1 ], - layer.pivot[ 2 ] );
-
-		// let userData = geometry.userData;
-		// geometry = geometry.toNonIndexed()
-		// geometry.userData = userData;
 
 		return geometry;
 

--- a/examples/jsm/loaders/usd/USDComposer.js
+++ b/examples/jsm/loaders/usd/USDComposer.js
@@ -19,6 +19,7 @@ import {
 	Bone,
 	SRGBColorSpace,
 	Texture,
+	Vector3,
 	VectorKeyframeTrack
 } from 'three';
 
@@ -253,6 +254,13 @@ class USDComposer {
 
 			const t = data[ 'xformOp:translate' ];
 			obj.position.set( t[ 0 ], t[ 1 ], t[ 2 ] );
+
+		}
+
+		if ( data[ 'xformOp:translate:pivot' ] ) {
+
+			const p = data[ 'xformOp:translate:pivot' ];
+			obj.pivot = new Vector3( p[ 0 ], p[ 1 ], p[ 2 ] );
 
 		}
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -375,6 +375,16 @@ class Object3D extends EventDispatcher {
 		 */
 		this.userData = {};
 
+		/**
+		 * The pivot point for rotation and scale transformations.
+		 * When set, rotation and scale are applied around this point
+		 * instead of the object's origin.
+		 *
+		 * @type {?Vector3}
+		 * @default null
+		 */
+		this.pivot = null;
+
 	}
 
 	/**
@@ -1122,6 +1132,19 @@ class Object3D extends EventDispatcher {
 
 		this.matrix.compose( this.position, this.quaternion, this.scale );
 
+		const pivot = this.pivot;
+
+		if ( pivot !== null ) {
+
+			const px = pivot.x, py = pivot.y, pz = pivot.z;
+			const te = this.matrix.elements;
+
+			te[ 12 ] += px - te[ 0 ] * px - te[ 4 ] * py - te[ 8 ] * pz;
+			te[ 13 ] += py - te[ 1 ] * px - te[ 5 ] * py - te[ 9 ] * pz;
+			te[ 14 ] += pz - te[ 2 ] * px - te[ 6 ] * py - te[ 10 ] * pz;
+
+		}
+
 		this.matrixWorldNeedsUpdate = true;
 
 	}
@@ -1286,6 +1309,8 @@ class Object3D extends EventDispatcher {
 		object.layers = this.layers.mask;
 		object.matrix = this.matrix.toArray();
 		object.up = this.up.toArray();
+
+		if ( this.pivot !== null ) object.pivot = this.pivot.toArray();
 
 		if ( this.matrixAutoUpdate === false ) object.matrixAutoUpdate = false;
 
@@ -1561,6 +1586,12 @@ class Object3D extends EventDispatcher {
 		this.rotation.order = source.rotation.order;
 		this.quaternion.copy( source.quaternion );
 		this.scale.copy( source.scale );
+
+		if ( source.pivot !== null ) {
+
+			this.pivot = source.pivot.clone();
+
+		}
 
 		this.matrix.copy( source.matrix );
 		this.matrixWorld.copy( source.matrixWorld );

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -19,6 +19,7 @@ import {
 } from '../constants.js';
 import { InstancedBufferAttribute } from '../core/InstancedBufferAttribute.js';
 import { Color } from '../math/Color.js';
+import { Vector3 } from '../math/Vector3.js';
 import { Object3D } from '../core/Object3D.js';
 import { Group } from '../objects/Group.js';
 import { InstancedMesh } from '../objects/InstancedMesh.js';
@@ -1113,6 +1114,8 @@ class ObjectLoader extends Loader {
 		}
 
 		if ( data.up !== undefined ) object.up.fromArray( data.up );
+
+		if ( data.pivot !== undefined ) object.pivot = new Vector3().fromArray( data.pivot );
 
 		if ( data.castShadow !== undefined ) object.castShadow = data.castShadow;
 		if ( data.receiveShadow !== undefined ) object.receiveShadow = data.receiveShadow;


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/15965#issuecomment-473109926

**Description**

Adds a `pivot` property to `Object3D` that allows rotation and scale to be applied around a custom point instead of the object's origin.

```javascript
mesh.pivot = new THREE.Vector3( 1, 0, 0 );
mesh.rotation.y = Math.PI / 2; // rotates around (1, 0, 0)
```

(Made with Claude Opus 4.5)