### PR TITLE
WebGLRenderer: Fix pointlight shadows with reversed depth buffer.

### DIFF
--- a/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl.js
@@ -262,9 +262,18 @@ export default /* glsl */`
 
 		if ( viewSpaceZ - shadowCameraFar <= 0.0 && viewSpaceZ - shadowCameraNear >= 0.0 ) {
 
-			// Calculate perspective depth for cube shadow map
-			// Standard perspective depth formula: depth = (far * (z - near)) / (z * (far - near))
-			float dp = ( shadowCameraFar * ( viewSpaceZ - shadowCameraNear ) ) / ( viewSpaceZ * ( shadowCameraFar - shadowCameraNear ) );
+			// viewZ to perspective depth
+
+			#ifdef USE_REVERSED_DEPTH_BUFFER
+
+				float dp = ( shadowCameraNear * ( shadowCameraFar - viewSpaceZ ) ) / ( viewSpaceZ * ( shadowCameraFar - shadowCameraNear ) );
+
+			#else
+
+				float dp = ( shadowCameraFar * ( viewSpaceZ - shadowCameraNear ) ) / ( viewSpaceZ * ( shadowCameraFar - shadowCameraNear ) );
+
+			#endif
+			
 			dp += shadowBias;
 
 			// Hardware PCF with LinearFilter gives us 4-tap filtering per sample
@@ -317,9 +326,18 @@ export default /* glsl */`
 
 		if ( viewSpaceZ - shadowCameraFar <= 0.0 && viewSpaceZ - shadowCameraNear >= 0.0 ) {
 
-			// Calculate perspective depth for cube shadow map
-			// Standard perspective depth formula: depth = (far * (z - near)) / (z * (far - near))
-			float dp = ( shadowCameraFar * ( viewSpaceZ - shadowCameraNear ) ) / ( viewSpaceZ * ( shadowCameraFar - shadowCameraNear ) );
+			// viewZ to perspective depth
+
+			#ifdef USE_REVERSED_DEPTH_BUFFER
+
+				float dp = ( shadowCameraNear * ( shadowCameraFar - viewSpaceZ ) ) / ( viewSpaceZ * ( shadowCameraFar - shadowCameraNear ) );
+
+			#else
+
+				float dp = ( shadowCameraFar * ( viewSpaceZ - shadowCameraNear ) ) / ( viewSpaceZ * ( shadowCameraFar - shadowCameraNear ) );
+
+			#endif
+
 			dp += shadowBias;
 
 			// Direction from light to fragment


### PR DESCRIPTION
Related issue: #31661

**Description**

The PR fixes the viewZ to perspective depth computation for point light shadows with Basic and PCF shadow maps when reversed depth buffer is used.

It would also be possible to just add `dp = 1.0 - dp;` but that would be an additional computation that we can save by using an updated formula for reversed depth buffer in the first place.

Note: This is something we can later hide in the `viewZToPerspectiveDepth()` TSL function.