### PR TITLE
WebGLRenderer: Fix remaining shadow issues with reversed depth.

### DIFF
--- a/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl.js
@@ -167,15 +167,7 @@ export default /* glsl */`
 				float mean = distribution.x;
 				float variance = distribution.y * distribution.y;
 
-				#ifdef USE_REVERSED_DEPTH_BUFFER
-
-					float hard_shadow = step( mean, shadowCoord.z );
-
-				#else
-
-					float hard_shadow = step( shadowCoord.z, mean );
-
-				#endif
+				float hard_shadow = step( shadowCoord.z, mean );
 
 				// Early return if fully lit
 				if ( hard_shadow == 1.0 ) {
@@ -224,13 +216,11 @@ export default /* glsl */`
 
 				#ifdef USE_REVERSED_DEPTH_BUFFER
 
-					shadow = step( depth, shadowCoord.z );
-
-				#else
-
-					shadow = step( shadowCoord.z, depth );
+					depth = 1.0 - depth;
 
 				#endif
+
+				shadow = step( shadowCoord.z, depth );
 
 			}
 
@@ -328,16 +318,7 @@ export default /* glsl */`
 
 			// viewZ to perspective depth
 
-			#ifdef USE_REVERSED_DEPTH_BUFFER
-
-				float dp = ( shadowCameraNear * ( shadowCameraFar - viewSpaceZ ) ) / ( viewSpaceZ * ( shadowCameraFar - shadowCameraNear ) );
-
-			#else
-
-				float dp = ( shadowCameraFar * ( viewSpaceZ - shadowCameraNear ) ) / ( viewSpaceZ * ( shadowCameraFar - shadowCameraNear ) );
-
-			#endif
-
+			float dp = ( shadowCameraFar * ( viewSpaceZ - shadowCameraNear ) ) / ( viewSpaceZ * ( shadowCameraFar - shadowCameraNear ) );
 			dp += shadowBias;
 
 			// Direction from light to fragment
@@ -347,13 +328,11 @@ export default /* glsl */`
 
 			#ifdef USE_REVERSED_DEPTH_BUFFER
 
-				shadow = step( depth, dp );
-
-			#else
-
-				shadow = step( dp, depth );
+				depth = 1.0 - depth;
 
 			#endif
+
+			shadow = step( dp, depth );
 
 		}
 

--- a/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl.js
@@ -134,12 +134,22 @@ export default /* glsl */`
 				// Use IGN to rotate sampling pattern per pixel
 				float phi = interleavedGradientNoise( gl_FragCoord.xy ) * PI2;
 
+				#ifdef USE_REVERSED_DEPTH_BUFFER
+
+					float dp = 1.0 - shadowCoord.z;
+
+				#else
+
+					float dp = shadowCoord.z;
+
+				#endif
+
 				shadow = (
-					texture( shadowMap, vec3( shadowCoord.xy + vogelDiskSample( 0, 5, phi ) * radius, shadowCoord.z ) ) +
-					texture( shadowMap, vec3( shadowCoord.xy + vogelDiskSample( 1, 5, phi ) * radius, shadowCoord.z ) ) +
-					texture( shadowMap, vec3( shadowCoord.xy + vogelDiskSample( 2, 5, phi ) * radius, shadowCoord.z ) ) +
-					texture( shadowMap, vec3( shadowCoord.xy + vogelDiskSample( 3, 5, phi ) * radius, shadowCoord.z ) ) +
-					texture( shadowMap, vec3( shadowCoord.xy + vogelDiskSample( 4, 5, phi ) * radius, shadowCoord.z ) )
+					texture( shadowMap, vec3( shadowCoord.xy + vogelDiskSample( 0, 5, phi ) * radius, dp ) ) +
+					texture( shadowMap, vec3( shadowCoord.xy + vogelDiskSample( 1, 5, phi ) * radius, dp ) ) +
+					texture( shadowMap, vec3( shadowCoord.xy + vogelDiskSample( 2, 5, phi ) * radius, dp ) ) +
+					texture( shadowMap, vec3( shadowCoord.xy + vogelDiskSample( 3, 5, phi ) * radius, dp ) ) +
+					texture( shadowMap, vec3( shadowCoord.xy + vogelDiskSample( 4, 5, phi ) * radius, dp ) )
 				) * 0.2;
 
 			}

--- a/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl.js
@@ -132,7 +132,7 @@ export default /* glsl */`
 				float radius = shadowRadius * texelSize.x;
 
 				// Use IGN to rotate sampling pattern per pixel
-				float phi = interleavedGradientNoise( gl_FragCoord.xy ) * 6.28318530718; // 2*PI
+				float phi = interleavedGradientNoise( gl_FragCoord.xy ) * PI2;
 
 				shadow = (
 					texture( shadowMap, vec3( shadowCoord.xy + vogelDiskSample( 0, 5, phi ) * radius, shadowCoord.z ) ) +
@@ -277,7 +277,7 @@ export default /* glsl */`
 			vec3 bitangent = cross( bd3D, tangent );
 
 			// Use IGN to rotate sampling pattern per pixel
-			float phi = interleavedGradientNoise( gl_FragCoord.xy ) * 6.28318530718;
+			float phi = interleavedGradientNoise( gl_FragCoord.xy ) * PI2;
 
 			vec2 sample0 = vogelDiskSample( 0, 5, phi );
 			vec2 sample1 = vogelDiskSample( 1, 5, phi );

--- a/src/renderers/shaders/ShaderLib/vsm.glsl.js
+++ b/src/renderers/shaders/ShaderLib/vsm.glsl.js
@@ -33,6 +33,13 @@ void main() {
 		#else
 
 			float depth = texture2D( shadow_pass, ( gl_FragCoord.xy + vec2( 0.0, uvOffset ) * radius ) / resolution ).r;
+
+			#ifdef USE_REVERSED_DEPTH_BUFFER
+
+				depth = 1.0 - depth;
+
+			#endif
+
 			mean += depth;
 			squared_mean += depth * depth;
 


### PR DESCRIPTION
Fixed https://github.com/mrdoob/three.js/issues/31661.

**Description**

Follow-up of  #32749. This PR fixes the remaining shadow issues with reversed depth buffer.