### PR TITLE
Editor: Add default environment.

### DIFF
--- a/editor/index.html
+++ b/editor/index.html
@@ -112,6 +112,10 @@
 
 						await editor.fromJSON( state );
 
+					} else {
+
+						editor.signals.sceneEnvironmentChanged.dispatch( 'Default' );
+
 					}
 
 					const selected = editor.config.getKey( 'selected' );

--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -686,10 +686,12 @@ Editor.prototype = {
 
 		this.setScene( await loader.parseAsync( json.scene ) );
 
-		if ( json.environment === 'Room' ||
-			 json.environment === 'ModelViewer' /* DEPRECATED */ ) {
+		if ( json.environment == null ||
+			 json.environment === 'Default' ||
+			 json.environment === 'Room' /* COMPAT */ ||
+			 json.environment === 'ModelViewer' /* COMPAT */ ) {
 
-			this.signals.sceneEnvironmentChanged.dispatch( json.environment );
+			this.signals.sceneEnvironmentChanged.dispatch( 'Default' );
 			this.signals.refreshSidebarEnvironment.dispatch();
 
 		}
@@ -721,7 +723,7 @@ Editor.prototype = {
 
 		if ( this.scene.environment !== null && this.scene.environment.isRenderTargetTexture === true ) {
 
-			environment = 'Room';
+			environment = 'Default';
 
 		}
 

--- a/editor/js/Sidebar.Scene.js
+++ b/editor/js/Sidebar.Scene.js
@@ -154,12 +154,13 @@ function SidebarScene( editor ) {
 
 	const backgroundType = new UISelect().setOptions( {
 
-		'None': '',
+		'Default': 'Default',
 		'Color': 'Color',
 		'Texture': 'Texture',
 		'Equirectangular': 'Equirect'
 
 	} ).setWidth( '150px' );
+	backgroundType.setValue( 'Default' );
 	backgroundType.onChange( function () {
 
 		onBackgroundChanged();
@@ -233,7 +234,7 @@ function SidebarScene( editor ) {
 
 		const type = backgroundType.getValue();
 
-		backgroundType.setWidth( type === 'None' ? '150px' : '110px' );
+		backgroundType.setWidth( type === 'Default' ? '150px' : '110px' );
 		backgroundColor.setDisplay( type === 'Color' ? '' : 'none' );
 		backgroundTexture.setDisplay( type === 'Texture' ? '' : 'none' );
 		backgroundEquirectangularTexture.setDisplay( type === 'Equirectangular' ? '' : 'none' );
@@ -257,13 +258,13 @@ function SidebarScene( editor ) {
 
 	const environmentType = new UISelect().setOptions( {
 
-		'None': '',
+		'Default': 'Default',
 		'Background': 'Background',
 		'Equirectangular': 'Equirect',
-		'Room': 'Room'
+		'None': 'None'
 
 	} ).setWidth( '150px' );
-	environmentType.setValue( 'None' );
+	environmentType.setValue( 'Default' );
 	environmentType.onChange( function () {
 
 		onEnvironmentChanged();
@@ -327,7 +328,7 @@ function SidebarScene( editor ) {
 	const fogTypeRow = new UIRow();
 	const fogType = new UISelect().setOptions( {
 
-		'None': '',
+		'None': 'None',
 		'Fog': 'Linear',
 		'FogExp2': 'Exponential'
 
@@ -445,7 +446,7 @@ function SidebarScene( editor ) {
 
 		} else {
 
-			backgroundType.setValue( 'None' );
+			backgroundType.setValue( 'Default' );
 			backgroundTexture.setValue( null );
 			backgroundEquirectangularTexture.setValue( null );
 			backgroundColorSpace.setValue( THREE.NoColorSpace );
@@ -465,13 +466,13 @@ function SidebarScene( editor ) {
 
 			} else if ( scene.environment.isRenderTargetTexture === true ) {
 
-				environmentType.setValue( 'Room' );
+				environmentType.setValue( 'Default' );
 
 			}
 
 		} else {
 
-			environmentType.setValue( 'None' );
+			environmentType.setValue( 'Default' );
 			environmentEquirectangularTexture.setValue( null );
 
 		}

--- a/editor/js/Viewport.js
+++ b/editor/js/Viewport.js
@@ -592,7 +592,7 @@ function Viewport( editor ) {
 
 				break;
 
-			case 'Room':
+			case 'Default':
 
 				scene.environment = pmremGenerator.fromScene( new RoomEnvironment(), 0.04 ).texture;
 


### PR DESCRIPTION
**Description**

While working on the USD loader I've been dropping many files in the editor and everytime a new file loads it shows black because the scene has no lights. After loading the file I have to select the environment every time. Made me wonder if it wouldn't be just better for the editor to just have the `RoomEnvironment` as the default environment.

**Changes**

- Renamed 'Room' environment to 'Default' and enabled it by default
- Renamed 'None' background to 'Default' (grey viewport color)
- Made dropdown values consistent ('None': 'None' for environment and fog)
- Added backward compatibility for projects saved with 'Room' environment

<img width="862" height="767" alt="Screenshot 2026-01-14 at 23 06 41" src="https://github.com/user-attachments/assets/cf02d0bb-26e2-47d2-9a0a-a2bc62d6bff2" />

(Made with Claude Opus 4.5)
