### PR TITLE
Editor: ESLint: migrate to flat config, note missing eqeqeq rule

### DIFF
--- a/editor/.eslintrc.json
+++ b/editor/.eslintrc.json
@@ -1,9 +1,0 @@
-{
-    "extends": [
-        "../.eslintrc.json"
-    ],
-    "parserOptions": {
-        "sourceType": "module",
-        "ecmaVersion": 2020
-    }
-}

--- a/editor/js/Menubar.File.js
+++ b/editor/js/Menubar.File.js
@@ -1,4 +1,5 @@
 import { UIPanel, UIRow, UIHorizontalRule } from './libs/ui.js';
+import { FileLoader } from 'three';
 
 function MenubarFile( editor ) {
 
@@ -69,7 +70,7 @@ function MenubarFile( editor ) {
 		{ title: 'menubar/file/new/Shaders', file: 'shaders.app.json' }
 	];
 
-	const loader = new THREE.FileLoader();
+	const loader = new FileLoader();
 
 	for ( let i = 0; i < examples.length; i ++ ) {
 

--- a/editor/js/Menubar.Render.js
+++ b/editor/js/Menubar.Render.js
@@ -496,10 +496,10 @@ class RenderVideoDialog {
 			} );
 
 			const qualityToBitrate = {
-				'low': 2_000_000,
-				'medium': 5_000_000,
-				'high': 10_000_000,
-				'ultra': 20_000_000
+				'low': 2e6,
+				'medium': 5e6, 
+				'high': 10e6,
+				'ultra': 20e6
 			};
 
 			videoEncoder.configure( {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -99,6 +99,7 @@ export default [
 			'no-irregular-whitespace': 'error',
 			'no-duplicate-imports': 'error',
 			'prefer-spread': 'error',
+			// 'eqeqeq': 'error',
 
 			'no-useless-escape': 'off',
 			'no-case-declarations': 'off',
@@ -118,6 +119,16 @@ export default [
 			'jsdoc/require-param-description': 'off',
 			'jsdoc/require-returns-description': 'off',
 			'jsdoc/require-param-type': 'error'
+		}
+	},
+
+	// editor rules
+	{
+		name: 'editor rules',
+		files: [ 'editor/**/*.js' ],
+		languageOptions: {
+			ecmaVersion: 2020,
+			sourceType: 'module'
 		}
 	}
 ];


### PR DESCRIPTION
**Description**

With the ESLint flat config, I deleted the .eslintrc.json and instead put it into the eslint.config.js file. (FYI, the existing .json file basically has no effect since #32471)

Also, during the flat config migration (#32471) it looks like the `eqeqeq` rule (#30078) got missed, I left a comment about it in this PR, because once it’s enabled there’s a ton of lint errors and I didn’t have time to fix it and run verification.
