### PR TITLE
Bug: Editor enforces DEFAULT instead of keeping NONE environment

### DIFF
--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -130,6 +130,9 @@ function Editor() {
 	this.viewportCamera = this.camera;
 	this.viewportShading = 'default';
 
+	this.environmentType = 'Default';
+	this.environmentTexture = null;
+
 	this.addCamera( this.camera );
 
 }
@@ -686,15 +689,21 @@ Editor.prototype = {
 
 		this.setScene( await loader.parseAsync( json.scene ) );
 
-		if ( json.environment == null ||
-			 json.environment === 'Default' ||
-			 json.environment === 'Room' /* COMPAT */ ||
-			 json.environment === 'ModelViewer' /* COMPAT */ ) {
+		if (
+			json.environment === 'Equirectangular'
+			|| json.environment === 'Background'
+			|| json.environment === 'None'
+		) {
+
+			this.signals.sceneEnvironmentChanged.dispatch( json.environment, json.environmentEquirectangularTexture );
+
+		} else {
 
 			this.signals.sceneEnvironmentChanged.dispatch( 'Default' );
-			this.signals.refreshSidebarEnvironment.dispatch();
 
 		}
+
+		this.signals.refreshSidebarEnvironment.dispatch();
 
 	},
 
@@ -717,18 +726,6 @@ Editor.prototype = {
 
 		}
 
-		// honor neutral environment
-
-		let environment = null;
-
-		if ( this.scene.environment !== null && this.scene.environment.isRenderTargetTexture === true ) {
-
-			environment = 'Default';
-
-		}
-
-		//
-
 		return {
 
 			metadata: {},
@@ -743,7 +740,8 @@ Editor.prototype = {
 			scene: this.scene.toJSON(),
 			scripts: this.scripts,
 			history: this.history.toJSON(),
-			environment: environment
+			environment: this.environmentType,
+			environmentEquirectangularTexture: this.environmentTexture
 
 		};
 

--- a/editor/js/Sidebar.Scene.js
+++ b/editor/js/Sidebar.Scene.js
@@ -453,30 +453,6 @@ function SidebarScene( editor ) {
 
 		}
 
-		if ( scene.environment ) {
-
-			if ( scene.background && scene.background.isTexture && scene.background.uuid === scene.environment.uuid ) {
-
-				environmentType.setValue( 'Background' );
-
-			} else if ( scene.environment.mapping === THREE.EquirectangularReflectionMapping ) {
-
-				environmentType.setValue( 'Equirectangular' );
-				environmentEquirectangularTexture.setValue( scene.environment );
-
-			} else if ( scene.environment.isRenderTargetTexture === true ) {
-
-				environmentType.setValue( 'Default' );
-
-			}
-
-		} else {
-
-			environmentType.setValue( 'Default' );
-			environmentEquirectangularTexture.setValue( null );
-
-		}
-
 		if ( scene.fog ) {
 
 			fogColor.setHexValue( scene.fog.color.getHex() );
@@ -604,6 +580,18 @@ function SidebarScene( editor ) {
 
 			onEnvironmentChanged();
 			refreshEnvironmentUI();
+
+		}
+
+	} );
+
+	signals.sceneEnvironmentChanged.add( function ( environment, environmentTexture ) {
+
+		environmentType.setValue( environment );
+
+		if ( environment === 'Equirectangular' ) {
+
+			environmentEquirectangularTexture.setValue( environmentTexture );
 
 		}
 

--- a/editor/js/Viewport.js
+++ b/editor/js/Viewport.js
@@ -564,6 +564,9 @@ function Viewport( editor ) {
 
 		useBackgroundAsEnvironment = false;
 
+		editor.environmentType = environmentType;
+		editor.environmentTexture = environmentEquirectangularTexture;
+
 		switch ( environmentType ) {
 
 


### PR DESCRIPTION
### Description
Related: https://github.com/mrdoob/three.js/pull/32752

The editor doesn’t keep NONE as a persistent choice, it reverts to DEFAULT when you load/open a file.

### Reproduction steps
Environment > select NONE
File > Save (project.json)
File > Open (project.json)
Environment is now DEFAULT selected

### Version
dev
