### PR TITLE
Editor: Simplify environment handling.

### DIFF
--- a/editor/js/Sidebar.Scene.js
+++ b/editor/js/Sidebar.Scene.js
@@ -259,7 +259,6 @@ function SidebarScene( editor ) {
 	const environmentType = new UISelect().setOptions( {
 
 		'Default': 'Default',
-		'Background': 'Background',
 		'Equirectangular': 'Equirect',
 		'None': 'None'
 
@@ -417,62 +416,41 @@ function SidebarScene( editor ) {
 
 		}
 
-		if ( scene.background ) {
+		backgroundType.setValue( editor.backgroundType );
 
-			if ( scene.background.isColor ) {
+		switch ( editor.backgroundType ) {
 
-				backgroundType.setValue( 'Color' );
+			case 'Color':
 				backgroundColor.setHexValue( scene.background.getHex() );
+				break;
 
-			} else if ( scene.background.isTexture ) {
-
-				if ( scene.background.mapping === THREE.EquirectangularReflectionMapping ) {
-
-					backgroundType.setValue( 'Equirectangular' );
-					backgroundEquirectangularTexture.setValue( scene.background );
-					backgroundBlurriness.setValue( scene.backgroundBlurriness );
-					backgroundIntensity.setValue( scene.backgroundIntensity );
-
-				} else {
-
-					backgroundType.setValue( 'Texture' );
-					backgroundTexture.setValue( scene.background );
-
-				}
-
+			case 'Texture':
+				backgroundTexture.setValue( scene.background );
 				backgroundColorSpace.setValue( scene.background.colorSpace );
+				break;
 
-			}
+			case 'Equirectangular':
+				backgroundEquirectangularTexture.setValue( scene.background );
+				backgroundBlurriness.setValue( scene.backgroundBlurriness );
+				backgroundIntensity.setValue( scene.backgroundIntensity );
+				backgroundColorSpace.setValue( scene.background.colorSpace );
+				break;
 
-		} else {
-
-			backgroundType.setValue( 'Default' );
-			backgroundTexture.setValue( null );
-			backgroundEquirectangularTexture.setValue( null );
-			backgroundColorSpace.setValue( THREE.NoColorSpace );
+			default:
+				backgroundTexture.setValue( null );
+				backgroundEquirectangularTexture.setValue( null );
+				backgroundColorSpace.setValue( THREE.NoColorSpace );
 
 		}
 
-		if ( scene.environment ) {
+		environmentType.setValue( editor.environmentType );
 
-			if ( scene.background && scene.background.isTexture && scene.background.uuid === scene.environment.uuid ) {
+		if ( editor.environmentType === 'Equirectangular' ) {
 
-				environmentType.setValue( 'Background' );
-
-			} else if ( scene.environment.mapping === THREE.EquirectangularReflectionMapping ) {
-
-				environmentType.setValue( 'Equirectangular' );
-				environmentEquirectangularTexture.setValue( scene.environment );
-
-			} else if ( scene.environment.isRenderTargetTexture === true ) {
-
-				environmentType.setValue( 'Default' );
-
-			}
+			environmentEquirectangularTexture.setValue( scene.environment );
 
 		} else {
 
-			environmentType.setValue( 'Default' );
 			environmentEquirectangularTexture.setValue( null );
 
 		}
@@ -524,8 +502,6 @@ function SidebarScene( editor ) {
 	signals.editorCleared.add( refreshUI );
 
 	signals.sceneGraphChanged.add( refreshUI );
-
-	signals.refreshSidebarEnvironment.add( refreshUI );
 
 	signals.objectChanged.add( function ( object ) {
 

--- a/editor/sw.js
+++ b/editor/sw.js
@@ -68,6 +68,7 @@ const assets = [
 	'../examples/jsm/interactive/HTMLMesh.js',
 	'../examples/jsm/interactive/InteractiveGroup.js',
 
+	'../examples/jsm/environments/ColorEnvironment.js',
 	'../examples/jsm/environments/RoomEnvironment.js',
 
 	'../examples/jsm/exporters/DRACOExporter.js',
@@ -78,6 +79,7 @@ const assets = [
 	'../examples/jsm/exporters/USDZExporter.js',
 
 	'../examples/jsm/helpers/VertexNormalsHelper.js',
+	'../examples/jsm/helpers/ViewHelper.js',
 
 	'../examples/jsm/utils/BufferGeometryUtils.js',
 

--- a/examples/jsm/environments/ColorEnvironment.js
+++ b/examples/jsm/environments/ColorEnvironment.js
@@ -1,0 +1,59 @@
+import {
+	BackSide,
+	Mesh,
+	MeshBasicMaterial,
+	SphereGeometry,
+	Scene
+} from 'three';
+
+/**
+ * This class represents a scene with a uniform color that can be used as
+ * input for {@link PMREMGenerator#fromScene}. The resulting PMREM represents
+ * uniform ambient lighting and can be used for Image Based Lighting by
+ * assigning it to {@link Scene#environment}.
+ *
+ * ```js
+ * const environment = new ColorEnvironment( 0x00ff00 );
+ * const pmremGenerator = new THREE.PMREMGenerator( renderer );
+ *
+ * const envMap = pmremGenerator.fromScene( environment ).texture;
+ * scene.environment = envMap;
+ * ```
+ *
+ * @augments Scene
+ * @three_import import { ColorEnvironment } from 'three/addons/environments/ColorEnvironment.js';
+ */
+class ColorEnvironment extends Scene {
+
+	/**
+	 * Constructs a new color environment.
+	 *
+	 * @param {number|Color} color - The color of the environment.
+	 */
+	constructor( color = 0xffffff ) {
+
+		super();
+
+		this.name = 'ColorEnvironment';
+
+		const geometry = new SphereGeometry( 1, 16, 16 );
+		const material = new MeshBasicMaterial( { color: color, side: BackSide } );
+
+		this.add( new Mesh( geometry, material ) );
+
+	}
+
+	/**
+	 * Frees internal resources. This method should be called
+	 * when the environment is no longer required.
+	 */
+	dispose() {
+
+		this.children[ 0 ].geometry.dispose();
+		this.children[ 0 ].material.dispose();
+
+	}
+
+}
+
+export { ColorEnvironment };


### PR DESCRIPTION
Related issue: #32753 #32756

**Description**

- Fix environment state not persisting correctly on save/reload
- Add `ColorEnvironment` class for uniform ambient lighting from solid colors
- Make "Default" environment adapt to background: None → RoomEnvironment, Color → ColorEnvironment, Equirectangular → use Texture

**Changes**
- Added `editor.backgroundType` and `editor.environmentType` as source of truth
- Removed "Background" environment option (merged into "Default" behavior)
- Simplified JSON serialization to store types directly

(Made with Claude Opus 4.5)