### PR TITLE
Update TorusGeometry with thetaStart and thetaLength

### DIFF
--- a/docs/pages/TorusGeometry.html
+++ b/docs/pages/TorusGeometry.html
@@ -77,6 +77,24 @@ scene.add( torus );
 										<p>Default is <code>Math.PI*2</code>.</p>
 									</td>
 								</tr>
+								<tr>
+									<td class="name">
+										<strong>thetaStart</strong>
+									</td>
+									<td class="description last">
+										<p>Start of the tubular sweep in radians.</p>
+										<p>Default is <code>0</code>.</p>
+									</td>
+								</tr>
+								<tr>
+									<td class="name">
+										<strong>thetaLegth</strong>
+									</td>
+									<td class="description last">
+										<p>Length of the tubular sweep in radians.</p>
+										<p>Default is <code>Math.PI*2</code>.</p>
+									</td>
+								</tr>
 							</tbody>
 						</table>
 					</div>

--- a/docs/pages/TorusGeometry.html
+++ b/docs/pages/TorusGeometry.html
@@ -77,24 +77,6 @@ scene.add( torus );
 										<p>Default is <code>Math.PI*2</code>.</p>
 									</td>
 								</tr>
-								<tr>
-									<td class="name">
-										<strong>thetaStart</strong>
-									</td>
-									<td class="description last">
-										<p>Start of the tubular sweep in radians.</p>
-										<p>Default is <code>0</code>.</p>
-									</td>
-								</tr>
-								<tr>
-									<td class="name">
-										<strong>thetaLegth</strong>
-									</td>
-									<td class="description last">
-										<p>Length of the tubular sweep in radians.</p>
-										<p>Default is <code>Math.PI*2</code>.</p>
-									</td>
-								</tr>
 							</tbody>
 						</table>
 					</div>

--- a/docs/scenes/geometry-browser.html
+++ b/docs/scenes/geometry-browser.html
@@ -558,14 +558,16 @@
 						tube: 3,
 						radialSegments: 16,
 						tubularSegments: 100,
-						arc: twoPi
+						arc: twoPi,
+						thetaStart: 0,
+						thetaLength: twoPi
 					};
 
 					function generateGeometry() {
 
 						updateGroupGeometry( mesh,
 							new TorusGeometry(
-								data.radius, data.tube, data.radialSegments, data.tubularSegments, data.arc
+								data.radius, data.tube, data.radialSegments, data.tubularSegments, data.arc, data.thetaStart, data.thetaLength
 							)
 						);
 
@@ -578,6 +580,8 @@
 					folder.add( data, 'radialSegments', 2, 30 ).step( 1 ).onChange( generateGeometry );
 					folder.add( data, 'tubularSegments', 3, 200 ).step( 1 ).onChange( generateGeometry );
 					folder.add( data, 'arc', 0.1, twoPi ).onChange( generateGeometry );
+					folder.add( data, 'thetaStart', 0.1, twoPi ).onChange( generateGeometry );
+					folder.add( data, 'thetaLength', 0.1, twoPi ).onChange( generateGeometry );
 
 					generateGeometry();
 

--- a/src/geometries/TorusGeometry.js
+++ b/src/geometries/TorusGeometry.js
@@ -28,7 +28,7 @@ class TorusGeometry extends BufferGeometry {
 	 * @param {number} [thetaStart=0] - Start of the tubular sweep in radians.
 	 * @param {number} [thetaLength=Math.PI*2] - Length of the tubular sweep in radians.
 	 */
-	constructor( radius = 1, tube = 0.4, radialSegments = 12, tubularSegments = 48, arc = Math.PI * 2, thetaStart = 0, thetaLength = Math.PI * 2 ){
+	constructor( radius = 1, tube = 0.4, radialSegments = 12, tubularSegments = 48, arc = Math.PI * 2, thetaStart = 0, thetaLength = Math.PI * 2 ) {
 
 		super();
 

--- a/src/geometries/TorusGeometry.js
+++ b/src/geometries/TorusGeometry.js
@@ -28,15 +28,7 @@ class TorusGeometry extends BufferGeometry {
 	 * @param {number} [thetaStart=0] - Start of the tubular sweep in radians.
 	 * @param {number} [thetaLength=Math.PI*2] - Length of the tubular sweep in radians.
 	 */
-		constructor(
-			radius = 1,
-			tube = 0.4,
-			radialSegments = 12,
-			tubularSegments = 48,
-			arc = Math.PI * 2,
-			thetaStart = 0,
-			thetaLength = Math.PI * 2,
-		){
+	constructor( radius = 1, tube = 0.4, radialSegments = 12, tubularSegments = 48, arc = Math.PI * 2, thetaStart = 0, thetaLength = Math.PI * 2 ){
 
 		super();
 

--- a/src/geometries/TorusGeometry.js
+++ b/src/geometries/TorusGeometry.js
@@ -25,8 +25,18 @@ class TorusGeometry extends BufferGeometry {
 	 * @param {number} [radialSegments=12] - The number of radial segments.
 	 * @param {number} [tubularSegments=48] - The number of tubular segments.
 	 * @param {number} [arc=Math.PI*2] - Central angle in radians.
+	 * @param {number} [thetaStart=0] - Start of the tubular sweep in radians.
+	 * @param {number} [thetaLength=Math.PI*2] - Length of the tubular sweep in radians.
 	 */
-	constructor( radius = 1, tube = 0.4, radialSegments = 12, tubularSegments = 48, arc = Math.PI * 2 ) {
+		constructor(
+			radius = 1,
+			tube = 0.4,
+			radialSegments = 12,
+			tubularSegments = 48,
+			arc = Math.PI * 2,
+			thetaStart = 0,
+			thetaLength = Math.PI * 2,
+		){
 
 		super();
 
@@ -44,7 +54,9 @@ class TorusGeometry extends BufferGeometry {
 			tube: tube,
 			radialSegments: radialSegments,
 			tubularSegments: tubularSegments,
-			arc: arc
+			arc: arc,
+			thetaStart: thetaStart,
+			thetaLength: thetaLength,
 		};
 
 		radialSegments = Math.floor( radialSegments );
@@ -67,12 +79,11 @@ class TorusGeometry extends BufferGeometry {
 
 		for ( let j = 0; j <= radialSegments; j ++ ) {
 
+			const v = thetaStart + ( j / radialSegments ) * thetaLength;
+
 			for ( let i = 0; i <= tubularSegments; i ++ ) {
 
 				const u = i / tubularSegments * arc;
-				const v = j / radialSegments * Math.PI * 2;
-
-				// vertex
 
 				vertex.x = ( radius + tube * Math.cos( v ) ) * Math.cos( u );
 				vertex.y = ( radius + tube * Math.cos( v ) ) * Math.sin( u );
@@ -80,15 +91,11 @@ class TorusGeometry extends BufferGeometry {
 
 				vertices.push( vertex.x, vertex.y, vertex.z );
 
-				// normal
-
 				center.x = radius * Math.cos( u );
 				center.y = radius * Math.sin( u );
+
 				normal.subVectors( vertex, center ).normalize();
-
 				normals.push( normal.x, normal.y, normal.z );
-
-				// uv
 
 				uvs.push( i / tubularSegments );
 				uvs.push( j / radialSegments );

--- a/src/geometries/TorusGeometry.js
+++ b/src/geometries/TorusGeometry.js
@@ -77,17 +77,23 @@ class TorusGeometry extends BufferGeometry {
 
 				const u = i / tubularSegments * arc;
 
+				// vertex
+
 				vertex.x = ( radius + tube * Math.cos( v ) ) * Math.cos( u );
 				vertex.y = ( radius + tube * Math.cos( v ) ) * Math.sin( u );
 				vertex.z = tube * Math.sin( v );
 
 				vertices.push( vertex.x, vertex.y, vertex.z );
 
+				// normal
+
 				center.x = radius * Math.cos( u );
 				center.y = radius * Math.sin( u );
-
 				normal.subVectors( vertex, center ).normalize();
+
 				normals.push( normal.x, normal.y, normal.z );
+
+				// uv
 
 				uvs.push( i / tubularSegments );
 				uvs.push( j / radialSegments );


### PR DESCRIPTION
Fixed #32759

TorusGeometry does not currently support thetaStart and thetaLength properties to allow the creation of a "semi torus" such that the torus is "sliced" horizontally in half like a bagel.

This commit adds support for specifying a thetaStart and thetaLength in TorusGeometry to allow a specified "sweep" of the tube or "semi torus".