### PR TITLE
WebGPURenderer: Use @interpolate(flat, either) for all cases.

### DIFF
--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -1698,7 +1698,7 @@ ${ flowData.code }
 
 					} else if ( /^(int|uint|ivec|uvec)/.test( varying.type ) ) {
 
-						attributesSnippet += ` @interpolate( ${ this.renderer.backend.compatibilityMode ? 'flat, either' : 'flat' } )`;
+						attributesSnippet += ' @interpolate(flat, either)';
 
 					}
 


### PR DESCRIPTION
This is not a compat only feature. There is generally no reason to switch based on a flag.

Related issue: #30725

**Description**

webgpu has 2 flat interpolation modes

1. `@interpolate(flat, first)` (abbreviated as) = `@interpolate(flat)`

    In this mode, in a triangle, the varying data comes from the first vertex
    of each triangle/line

2. `@interpolate(flat, either)`

    In this mode, in a triangle, the varying data comes from the either the first
    or the last vertex of each triangle/line

(1) is not supported in compatibility mode (2) is.  (2) works for most common use cases. WebGPU should arguably have made (2) the default but (1) was the default when WebGPU shipped, before compatibility mode was added. Switching WebGPU to just use (2) is arguably the better path. 

