### PR TITLE
WebGPURenderer: Always request compatibility mode and upgrade to core.

### DIFF
--- a/examples/webgpu_loader_gltf.html
+++ b/examples/webgpu_loader_gltf.html
@@ -103,7 +103,7 @@
 
 					} );
 
-				renderer = new THREE.WebGPURenderer( { antialias: true/*, compatibilityMode: true*/ } );
+				renderer = new THREE.WebGPURenderer( { antialias: true } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setAnimationLoop( render );

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -31,7 +31,6 @@ class WebGPUBackend extends Backend {
 	 * @typedef {Object} WebGPUBackend~Options
 	 * @property {boolean} [logarithmicDepthBuffer=false] - Whether logarithmic depth buffer is enabled or not.
 	 * @property {boolean} [alpha=true] - Whether the default framebuffer (which represents the final contents of the canvas) should be transparent or opaque.
-	 * @property {boolean} [compatibilityMode=false] - Whether the backend should be in compatibility mode or not.
 	 * @property {boolean} [depth=true] - Whether the default framebuffer should have a depth buffer or not.
 	 * @property {boolean} [stencil=false] - Whether the default framebuffer should have a stencil buffer or not.
 	 * @property {boolean} [antialias=false] - Whether MSAA as the default anti-aliasing should be enabled or not.
@@ -64,7 +63,6 @@ class WebGPUBackend extends Backend {
 
 		// some parameters require default values other than "undefined"
 		this.parameters.alpha = ( parameters.alpha === undefined ) ? true : parameters.alpha;
-		this.parameters.compatibilityMode = ( parameters.compatibilityMode === undefined ) ? false : parameters.compatibilityMode;
 
 		this.parameters.requiredLimits = ( parameters.requiredLimits === undefined ) ? {} : parameters.requiredLimits;
 
@@ -73,7 +71,7 @@ class WebGPUBackend extends Backend {
 		 * @type {boolean}
 		 * @default false
 		 */
-		this.compatibilityMode = this.parameters.compatibilityMode;
+		this.compatibilityMode = undefined;
 
 		/**
 		 * A reference to the device.
@@ -175,7 +173,7 @@ class WebGPUBackend extends Backend {
 
 			const adapterOptions = {
 				powerPreference: parameters.powerPreference,
-				featureLevel: parameters.compatibilityMode ? 'compatibility' : undefined
+				featureLevel: 'compatibility'
 			};
 
 			const adapter = ( typeof navigator !== 'undefined' ) ? await navigator.gpu.requestAdapter( adapterOptions ) : null;
@@ -214,6 +212,8 @@ class WebGPUBackend extends Backend {
 			device = parameters.device;
 
 		}
+
+		parameters.compatibilityMode = ! device.features.has( 'core-features-and-limits' );
 
 		device.lost.then( ( info ) => {
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -67,11 +67,14 @@ class WebGPUBackend extends Backend {
 		this.parameters.requiredLimits = ( parameters.requiredLimits === undefined ) ? {} : parameters.requiredLimits;
 
 		/**
-		 * Indicates whether the backend is in compatibility mode or not.
-		 * @type {boolean}
-		 * @default false
+		 * Indicates whether the backend is in WebGPU compatibility mode or not.
+		 * The backend must be initialized before the property can be evaluated.
+		 *
+		 * @type {?boolean}
+		 * @readonly
+		 * @default null
 		 */
-		this.compatibilityMode = undefined;
+		this.compatibilityMode = null;
 
 		/**
 		 * A reference to the device.
@@ -213,7 +216,7 @@ class WebGPUBackend extends Backend {
 
 		}
 
-		parameters.compatibilityMode = ! device.features.has( 'core-features-and-limits' );
+		this.compatibilityMode = ! device.features.has( 'core-features-and-limits' );
 
 		device.lost.then( ( info ) => {
 


### PR DESCRIPTION
Then detect if you got compatibility or core

Related issue: #30725

**Description**

This is just a proposal, I don't know three.js's codebase enough to know if this will work.
Ideally, three.js should request compatibility mode and upgrade to core if possible. The user should not have to opt into compatibility mode. 

The issue is, `backend.compatibilityMode` will not be set until the device is created so anything relying on that flag must not happen until after that point.