### PR TITLE
USDLoader: Add OpenPBR Surface shader and polygon hole support.

### DIFF
--- a/examples/jsm/loaders/USDLoader.js
+++ b/examples/jsm/loaders/USDLoader.js
@@ -9,7 +9,7 @@ import { USDCParser } from './usd/USDCParser.js';
 import { USDComposer } from './usd/USDComposer.js';
 
 /**
- * A loader for the USD format (USDA, USDC, USDZ).
+ * A loader for the USD format (USD, USDA, USDC, USDZ).
  *
  * Supports both ASCII (USDA) and binary (USDC) USD files, as well as
  * USDZ archives containing either format.

--- a/examples/jsm/loaders/usd/USDComposer.js
+++ b/examples/jsm/loaders/usd/USDComposer.js
@@ -298,8 +298,6 @@ class USDComposer {
 			const q = data[ 'xformOp:orient' ];
 			if ( q.length === 4 ) {
 
-				// USD quaternion format is (w, x, y, z) - real part first
-				// Three.js Quaternion is (x, y, z, w)
 				obj.quaternion.set( q[ 1 ], q[ 2 ], q[ 3 ], q[ 0 ] );
 
 			}
@@ -1197,7 +1195,6 @@ class USDComposer {
 
 		if ( ! faceVertexCounts || faceVertexCounts.length === 0 ) return geometry;
 
-		// Parse polygon holes (Arnold format: [holeFaceIdx, parentFaceIdx, ...])
 		const polygonHoles = fields[ 'primvars:arnold:polygon_holes' ];
 		const holeMap = this._buildHoleMap( polygonHoles );
 		const holeFaces = holeMap.holeFaces;
@@ -1501,7 +1498,6 @@ class USDComposer {
 
 	_findUV2Primvar( fields ) {
 
-		// Look for second UV set (st1, commonly used for lightmaps/AO)
 		const uvs2 = fields[ 'primvars:st1' ];
 		const uv2Indices = fields[ 'primvars:st1:indices' ];
 		return { uvs2, uv2Indices };

--- a/examples/jsm/loaders/usd/USDComposer.js
+++ b/examples/jsm/loaders/usd/USDComposer.js
@@ -1850,11 +1850,9 @@ class USDComposer {
 
 		// Project hole contours to 2D
 		const holes2D = [];
-		const holes3D = [];
 
 		for ( const holeIndices of holeContours ) {
 
-			const hole3D = [];
 			const hole2D = [];
 
 			for ( const idx of holeIndices ) {
@@ -1864,12 +1862,10 @@ class USDComposer {
 					points[ idx * 3 + 1 ],
 					points[ idx * 3 + 2 ]
 				);
-				hole3D.push( p );
 				hole2D.push( new Vector2( p.dot( tangent ), p.dot( bitangent ) ) );
 
 			}
 
-			holes3D.push( hole3D );
 			holes2D.push( hole2D );
 
 		}

--- a/examples/jsm/loaders/usd/USDComposer.js
+++ b/examples/jsm/loaders/usd/USDComposer.js
@@ -2482,6 +2482,32 @@ class USDComposer {
 		if ( transmissionWeight !== undefined && transmissionWeight > 0 ) {
 
 			material.transmission = transmissionWeight;
+
+			const transmissionDepth = fields[ 'inputs:transmission_depth' ];
+
+			if ( transmissionDepth !== undefined ) {
+
+				material.thickness = transmissionDepth;
+
+			}
+
+			const transmissionColor = fields[ 'inputs:transmission_color' ];
+
+			if ( transmissionColor !== undefined && Array.isArray( transmissionColor ) ) {
+
+				material.attenuationColor.setRGB( transmissionColor[ 0 ], transmissionColor[ 1 ], transmissionColor[ 2 ] );
+				material.attenuationDistance = transmissionDepth || 1.0;
+
+			}
+
+		}
+
+		// Geometry opacity (overall surface opacity)
+		const geometryOpacity = fields[ 'inputs:geometry_opacity' ];
+
+		if ( geometryOpacity !== undefined && geometryOpacity < 1.0 ) {
+
+			material.opacity = geometryOpacity;
 			material.transparent = true;
 
 		}
@@ -2509,6 +2535,59 @@ class USDComposer {
 				material.clearcoatRoughness = coatRoughness;
 
 			}
+
+		}
+
+		// Thin film (iridescence)
+		const thinFilmWeight = fields[ 'inputs:thin_film_weight' ];
+
+		if ( thinFilmWeight !== undefined && thinFilmWeight > 0 ) {
+
+			material.iridescence = thinFilmWeight;
+
+			const thinFilmIOR = fields[ 'inputs:thin_film_ior' ];
+
+			if ( thinFilmIOR !== undefined ) {
+
+				material.iridescenceIOR = thinFilmIOR;
+
+			}
+
+			const thinFilmThickness = fields[ 'inputs:thin_film_thickness' ];
+
+			if ( thinFilmThickness !== undefined ) {
+
+				// OpenPBR uses micrometers, Three.js uses nanometers
+				const thicknessNm = thinFilmThickness * 1000;
+				material.iridescenceThicknessRange = [ thicknessNm, thicknessNm ];
+
+			}
+
+		}
+
+		// Specular
+		const specularWeight = fields[ 'inputs:specular_weight' ];
+
+		if ( specularWeight !== undefined ) {
+
+			material.specularIntensity = specularWeight;
+
+		}
+
+		const specularColor = fields[ 'inputs:specular_color' ];
+
+		if ( specularColor !== undefined && Array.isArray( specularColor ) ) {
+
+			material.specularColor.setRGB( specularColor[ 0 ], specularColor[ 1 ], specularColor[ 2 ] );
+
+		}
+
+		// Anisotropy
+		const anisotropy = fields[ 'inputs:specular_roughness_anisotropy' ];
+
+		if ( anisotropy !== undefined && anisotropy > 0 ) {
+
+			material.anisotropy = anisotropy;
 
 		}
 

--- a/examples/jsm/loaders/usd/USDComposer.js
+++ b/examples/jsm/loaders/usd/USDComposer.js
@@ -1576,15 +1576,18 @@ class USDComposer {
 
 			if ( holes && holes.length > 0 && points && points.length > 0 ) {
 
-				// Triangulate face with holes
+				// Triangulate face with holes using vertex -> face-vertex mapping
+				const vertexToFaceVertex = new Map();
+
 				const faceIndices = [];
 				for ( let j = 0; j < count; j ++ ) {
 
-					faceIndices.push( indices[ offset + j ] );
+					const vertIdx = indices[ offset + j ];
+					faceIndices.push( vertIdx );
+					vertexToFaceVertex.set( vertIdx, offset + j );
 
 				}
 
-				// Collect hole contours
 				const holeContours = [];
 				for ( const holeFaceIdx of holes ) {
 
@@ -1593,7 +1596,9 @@ class USDComposer {
 					const holeIndices = [];
 					for ( let j = 0; j < holeCount; j ++ ) {
 
-						holeIndices.push( indices[ holeOffset + j ] );
+						const vertIdx = indices[ holeOffset + j ];
+						holeIndices.push( vertIdx );
+						vertexToFaceVertex.set( vertIdx, holeOffset + j );
 
 					}
 
@@ -1606,9 +1611,11 @@ class USDComposer {
 				for ( const tri of triangles ) {
 
 					triangulated.push( tri[ 0 ], tri[ 1 ], tri[ 2 ] );
-					// For faces with holes, we use -1 as pattern since vertex mapping is complex
-					// This will trigger per-vertex normal/UV computation
-					pattern.push( - 1, - 1, - 1 );
+					pattern.push(
+						vertexToFaceVertex.get( tri[ 0 ] ),
+						vertexToFaceVertex.get( tri[ 1 ] ),
+						vertexToFaceVertex.get( tri[ 2 ] )
+					);
 
 				}
 

--- a/examples/jsm/loaders/usd/USDComposer.js
+++ b/examples/jsm/loaders/usd/USDComposer.js
@@ -2821,6 +2821,7 @@ class USDComposer {
 
 			}
 
+			console.warn( 'USDLoader: Texture not found:', cleanPath );
 			return null;
 
 		}


### PR DESCRIPTION
Related issue: #32704 https://github.com/mrdoob/three.js/pull/32730#issuecomment-3753351052

**Description**

- Add OpenPBR Surface shader support with transmission, iridescence, specular, anisotropy, and geometry opacity
- Add polygon hole support using ear-clipping triangulation
- Add indexed normals support (`primvars:normals:indices`)
- Fix PathListOp parsing for shader connections in USDC files

<img width="2624" height="1534" alt="image" src="https://github.com/user-attachments/assets/74d92594-1b6e-439c-b2fe-39f5dba1e3b4" />

(Made with Claude Opus 4.5)