### PR TITLE
Loaders: Use named fflate imports and native TextDecoder.

### DIFF
--- a/examples/jsm/loaders/3MFLoader.js
+++ b/examples/jsm/loaders/3MFLoader.js
@@ -19,7 +19,7 @@ import {
 	TextureLoader,
 	SRGBColorSpace
 } from 'three';
-import * as fflate from '../libs/fflate.module.js';
+import { unzipSync } from '../libs/fflate.module.js';
 
 const COLOR_SPACE_3MF = SRGBColorSpace;
 
@@ -143,7 +143,7 @@ class ThreeMFLoader extends Loader {
 
 			try {
 
-				zip = fflate.unzipSync( new Uint8Array( data ) );
+				zip = unzipSync( new Uint8Array( data ) );
 
 			} catch ( e ) {
 

--- a/examples/jsm/loaders/AMFLoader.js
+++ b/examples/jsm/loaders/AMFLoader.js
@@ -8,7 +8,7 @@ import {
 	Mesh,
 	MeshPhongMaterial
 } from 'three';
-import * as fflate from '../libs/fflate.module.js';
+import { unzipSync } from '../libs/fflate.module.js';
 
 /**
  * A loader for the AMF format.
@@ -105,7 +105,7 @@ class AMFLoader extends Loader {
 
 				try {
 
-					zip = fflate.unzipSync( new Uint8Array( data ) );
+					zip = unzipSync( new Uint8Array( data ) );
 
 				} catch ( e ) {
 

--- a/examples/jsm/loaders/EXRLoader.js
+++ b/examples/jsm/loaders/EXRLoader.js
@@ -9,7 +9,7 @@ import {
 	RGFormat,
 	RGBAFormat
 } from 'three';
-import * as fflate from '../libs/fflate.module.js';
+import { unzlibSync } from '../libs/fflate.module.js';
 
 // Referred to the original Industrial Light & Magic OpenEXR implementation and the TinyEXR / Syoyo Fujita
 // implementation, so I have preserved their copyright notices.
@@ -1363,7 +1363,7 @@ class EXRLoader extends DataTextureLoader {
 
 			const compressed = info.array.slice( info.offset.value, info.offset.value + info.size );
 
-			const rawBuffer = fflate.unzlibSync( compressed );
+			const rawBuffer = unzlibSync( compressed );
 			const tmpBuffer = new Uint8Array( rawBuffer.length );
 
 			predictor( rawBuffer ); // revert predictor
@@ -1480,7 +1480,7 @@ class EXRLoader extends DataTextureLoader {
 
 			const compressed = info.array.slice( info.offset.value, info.offset.value + info.size );
 
-			const rawBuffer = fflate.unzlibSync( compressed );
+			const rawBuffer = unzlibSync( compressed );
 
 			const byteSize = info.inputChannels.length * info.lines * info.columns * info.totalBytes;
 			const tmpBuffer = new ArrayBuffer( byteSize );
@@ -1663,7 +1663,7 @@ class EXRLoader extends DataTextureLoader {
 					case DEFLATE:
 
 						const compressed = info.array.slice( inOffset.value, inOffset.value + dwaHeader.totalAcUncompressedCount );
-						const data = fflate.unzlibSync( compressed );
+						const data = unzlibSync( compressed );
 						acBuffer = new Uint16Array( data.buffer );
 						inOffset.value += dwaHeader.totalAcUncompressedCount;
 						break;
@@ -1690,7 +1690,7 @@ class EXRLoader extends DataTextureLoader {
 			if ( dwaHeader.rleRawSize > 0 ) {
 
 				const compressed = info.array.slice( inOffset.value, inOffset.value + dwaHeader.rleCompressedSize );
-				const data = fflate.unzlibSync( compressed );
+				const data = unzlibSync( compressed );
 				rleBuffer = decodeRunLength( data.buffer );
 
 				inOffset.value += dwaHeader.rleCompressedSize;

--- a/examples/jsm/loaders/FBXLoader.js
+++ b/examples/jsm/loaders/FBXLoader.js
@@ -44,7 +44,7 @@ import {
 	VectorKeyframeTrack
 } from 'three';
 
-import * as fflate from '../libs/fflate.module.js';
+import { unzlibSync } from '../libs/fflate.module.js';
 import { NURBSCurve } from '../curves/NURBSCurve.js';
 
 let fbxTree;
@@ -3797,7 +3797,7 @@ class BinaryParser {
 
 				}
 
-				const data = fflate.unzlibSync( new Uint8Array( reader.getArrayBuffer( compressedLength ) ) );
+				const data = unzlibSync( new Uint8Array( reader.getArrayBuffer( compressedLength ) ) );
 				const reader2 = new BinaryReader( data.buffer );
 
 				switch ( type ) {

--- a/examples/jsm/loaders/KMZLoader.js
+++ b/examples/jsm/loaders/KMZLoader.js
@@ -5,7 +5,7 @@ import {
 	LoadingManager
 } from 'three';
 import { ColladaLoader } from '../loaders/ColladaLoader.js';
-import * as fflate from '../libs/fflate.module.js';
+import { unzipSync } from '../libs/fflate.module.js';
 
 /**
  * A loader for the KMZ format.
@@ -119,18 +119,18 @@ class KMZLoader extends Loader {
 
 		//
 
-		const zip = fflate.unzipSync( new Uint8Array( data ) );
+		const zip = unzipSync( new Uint8Array( data ) );
 
 		if ( zip[ 'doc.kml' ] ) {
 
-			const xml = new DOMParser().parseFromString( fflate.strFromU8( zip[ 'doc.kml' ] ), 'application/xml' );
+			const xml = new DOMParser().parseFromString( new TextDecoder().decode( zip[ 'doc.kml' ] ), 'application/xml' );
 
 			const model = xml.querySelector( 'Placemark Model Link href' );
 
 			if ( model ) {
 
 				const loader = new ColladaLoader( manager );
-				return loader.parse( fflate.strFromU8( zip[ model.textContent ] ) );
+				return loader.parse( new TextDecoder().decode( zip[ model.textContent ] ) );
 
 			}
 
@@ -145,7 +145,7 @@ class KMZLoader extends Loader {
 				if ( extension === 'dae' ) {
 
 					const loader = new ColladaLoader( manager );
-					return loader.parse( fflate.strFromU8( zip[ path ] ) );
+					return loader.parse( new TextDecoder().decode( zip[ path ] ) );
 
 				}
 

--- a/examples/jsm/loaders/NRRDLoader.js
+++ b/examples/jsm/loaders/NRRDLoader.js
@@ -4,7 +4,7 @@ import {
 	Matrix4,
 	Vector3
 } from 'three';
-import * as fflate from '../libs/fflate.module.js';
+import { gunzipSync } from '../libs/fflate.module.js';
 import { Volume } from '../misc/Volume.js';
 
 /**
@@ -356,7 +356,7 @@ class NRRDLoader extends Loader {
 
 			// we need to decompress the datastream
 			// here we start the unzipping and get a typed Uint8Array back
-			_data = fflate.gunzipSync( new Uint8Array( _data ) );
+			_data = gunzipSync( new Uint8Array( _data ) );
 
 		} else if ( headerObject.encoding === 'ascii' || headerObject.encoding === 'text' || headerObject.encoding === 'txt' || headerObject.encoding === 'hex' ) {
 

--- a/examples/jsm/loaders/USDLoader.js
+++ b/examples/jsm/loaders/USDLoader.js
@@ -3,7 +3,7 @@ import {
 	Loader
 } from 'three';
 
-import * as fflate from '../libs/fflate.module.js';
+import { unzipSync } from '../libs/fflate.module.js';
 import { USDAParser } from './usd/USDAParser.js';
 import { USDCParser } from './usd/USDCParser.js';
 import { USDComposer } from './usd/USDComposer.js';
@@ -123,7 +123,7 @@ class USDLoader extends Loader {
 
 					} else {
 
-						const text = fflate.strFromU8( zip[ filename ] );
+						const text = new TextDecoder().decode( zip[ filename ] );
 						// Store parsed data (specsByPath) for on-demand composition
 						data[ filename ] = usda.parseData( text );
 						// Store raw text for re-parsing with variant selections
@@ -227,7 +227,7 @@ class USDLoader extends Loader {
 
 		if ( bytes[ 0 ] === 0x50 && bytes[ 1 ] === 0x4B ) {
 
-			const zip = fflate.unzipSync( bytes );
+			const zip = unzipSync( bytes );
 
 			const assets = parseAssets( zip );
 
@@ -242,7 +242,7 @@ class USDLoader extends Loader {
 
 			} else {
 
-				const text = fflate.strFromU8( file );
+				const text = new TextDecoder().decode( file );
 				data = usda.parseData( text );
 
 			}
@@ -254,7 +254,7 @@ class USDLoader extends Loader {
 		// USDA (standalone, as ArrayBuffer)
 
 		const composer = new USDComposer();
-		const text = fflate.strFromU8( bytes );
+		const text = new TextDecoder().decode( bytes );
 		const data = usda.parseData( text );
 		return composer.compose( data, {} );
 

--- a/examples/jsm/loaders/VTKLoader.js
+++ b/examples/jsm/loaders/VTKLoader.js
@@ -7,7 +7,7 @@ import {
 	Loader,
 	SRGBColorSpace
 } from 'three';
-import * as fflate from '../libs/fflate.module.js';
+import { unzlibSync } from '../libs/fflate.module.js';
 
 /**
  * A loader for the VTK format.
@@ -859,7 +859,7 @@ class VTKLoader extends Loader {
 
 					for ( let i = 0; i < dataOffsets.length - 1; i ++ ) {
 
-						const data = fflate.unzlibSync( byteData.slice( dataOffsets[ i ], dataOffsets[ i + 1 ] ) );
+						const data = unzlibSync( byteData.slice( dataOffsets[ i ], dataOffsets[ i + 1 ] ) );
 						content = data.buffer;
 
 						if ( ele.attributes.type === 'Float32' ) {


### PR DESCRIPTION
**Description**

- Replace `import * as fflate` with named imports (`unzipSync`, `unzlibSync`, `gunzipSync`) across all loaders for better tree-shaking
- Replace `fflate.strFromU8()` with native `new TextDecoder().decode()` for Uint8Array to string conversion

(Made with Claude Opus 4.5)