### PR TITLE
USDLoader: Various bug fixes and improvements

### DIFF
--- a/examples/jsm/loaders/usd/USDAParser.js
+++ b/examples/jsm/loaders/usd/USDAParser.js
@@ -660,12 +660,12 @@ class USDAParser {
 		}
 
 		// Quaternion types (quatf, quatd, quath)
+		// Text format is (w, x, y, z), convert to (x, y, z, w)
 		if ( valueType.startsWith( 'quat' ) ) {
 
-			// Parse (w, x, y, z) format
 			const cleaned = str.replace( /[()]/g, '' );
 			const values = cleaned.split( ',' ).map( s => parseFloat( s.trim() ) );
-			return values;
+			return [ values[ 1 ], values[ 2 ], values[ 3 ], values[ 0 ] ];
 
 		}
 

--- a/examples/jsm/loaders/usd/USDAParser.js
+++ b/examples/jsm/loaders/usd/USDAParser.js
@@ -103,7 +103,7 @@ class USDAParser {
 
 				target = stack[ stack.length - 1 ];
 
-			} else {
+			} else if ( line.trim() ) {
 
 				string = line.trim();
 

--- a/examples/jsm/loaders/usd/USDCParser.js
+++ b/examples/jsm/loaders/usd/USDCParser.js
@@ -1182,6 +1182,39 @@ class USDCParser {
 
 			}
 
+			case TypeEnum.Matrix2d: {
+
+				// Inlined Matrix2d stores diagonal values as 2 signed int8 values
+				const buf = new ArrayBuffer( 4 );
+				const view = new DataView( buf );
+				view.setUint32( 0, payload, true );
+				const d0 = view.getInt8( 0 ), d1 = view.getInt8( 1 );
+				return [ d0, 0, 0, d1 ];
+
+			}
+
+			case TypeEnum.Matrix3d: {
+
+				// Inlined Matrix3d stores diagonal values as 3 signed int8 values
+				const buf = new ArrayBuffer( 4 );
+				const view = new DataView( buf );
+				view.setUint32( 0, payload, true );
+				const d0 = view.getInt8( 0 ), d1 = view.getInt8( 1 ), d2 = view.getInt8( 2 );
+				return [ d0, 0, 0, 0, d1, 0, 0, 0, d2 ];
+
+			}
+
+			case TypeEnum.Matrix4d: {
+
+				// Inlined Matrix4d stores diagonal values as 4 signed int8 values
+				const buf = new ArrayBuffer( 4 );
+				const view = new DataView( buf );
+				view.setUint32( 0, payload, true );
+				const d0 = view.getInt8( 0 ), d1 = view.getInt8( 1 ), d2 = view.getInt8( 2 ), d3 = view.getInt8( 3 );
+				return [ d0, 0, 0, 0, 0, d1, 0, 0, 0, 0, d2, 0, 0, 0, 0, d3 ];
+
+			}
+
 			default:
 				return payload;
 

--- a/examples/jsm/loaders/usd/USDComposer.js
+++ b/examples/jsm/loaders/usd/USDComposer.js
@@ -2329,25 +2329,33 @@ class USDComposer {
 		}
 
 		// Opacity and opacity modes
-		const opacity = fields[ 'inputs:opacity' ] !== undefined ? fields[ 'inputs:opacity' ] : 1.0;
 		const opacityThreshold = fields[ 'inputs:opacityThreshold' ] !== undefined ? fields[ 'inputs:opacityThreshold' ] : 0.0;
-		const opacityMode = fields[ 'inputs:opacityMode' ] || 'transparent';
 
-		if ( opacityMode === 'presence' ) {
+		// Check if opacity is connected to a texture (e.g., diffuse texture's alpha)
+		const opacitySpec = getAttrSpec( 'inputs:opacity' );
+		const hasOpacityConnection = opacitySpec?.fields?.connectionPaths?.length > 0;
 
-			// Presence mode: use alpha testing (cutout transparency)
-			material.alphaTest = opacityThreshold;
-			material.transparent = false;
+		if ( hasOpacityConnection ) {
 
-			if ( opacity < 1.0 ) {
+			// Opacity from texture alpha - use the diffuse map's alpha channel
+			if ( opacityThreshold > 0 ) {
 
-				material.opacity = opacity;
+				// Alpha cutoff mode
+				material.alphaTest = opacityThreshold;
+				material.transparent = false;
+
+			} else {
+
+				// Alpha blend mode
+				material.transparent = true;
 
 			}
 
-		} else if ( opacityMode === 'transparent' ) {
+		} else {
 
-			// Transparent mode: traditional alpha blending
+			// Direct opacity value
+			const opacity = fields[ 'inputs:opacity' ] !== undefined ? fields[ 'inputs:opacity' ] : 1.0;
+
 			if ( opacity < 1.0 ) {
 
 				material.transparent = true;
@@ -2356,7 +2364,6 @@ class USDComposer {
 			}
 
 		}
-		// opacityMode === 'opaque': ignore opacity entirely (default material state)
 
 	}
 

--- a/examples/jsm/loaders/usd/USDComposer.js
+++ b/examples/jsm/loaders/usd/USDComposer.js
@@ -232,9 +232,7 @@ class USDComposer {
 					const q = data[ 'xformOp:orient' ];
 					if ( q && q.length === 4 ) {
 
-						// USD quaternion format is (w, x, y, z) - real part first
-						// Three.js Quaternion is (x, y, z, w)
-						const quat = new Quaternion( q[ 1 ], q[ 2 ], q[ 3 ], q[ 0 ] );
+						const quat = new Quaternion( q[ 0 ], q[ 1 ], q[ 2 ], q[ 3 ] );
 						tempMatrix.makeRotationFromQuaternion( quat );
 						if ( isInverse ) tempMatrix.invert();
 						matrix.multiply( tempMatrix );
@@ -298,7 +296,7 @@ class USDComposer {
 			const q = data[ 'xformOp:orient' ];
 			if ( q.length === 4 ) {
 
-				obj.quaternion.set( q[ 1 ], q[ 2 ], q[ 3 ], q[ 0 ] );
+				obj.quaternion.set( q[ 0 ], q[ 1 ], q[ 2 ], q[ 3 ] );
 
 			}
 
@@ -3258,9 +3256,8 @@ class USDComposer {
 
 					keyframeTimes.push( times[ i ] / this.fps );
 
-					// Convert USD quaternion (w, x, y, z) to Three.js (x, y, z, w)
 					const q = values[ i ];
-					keyframeValues.push( q[ 1 ], q[ 2 ], q[ 3 ], q[ 0 ] );
+					keyframeValues.push( q[ 0 ], q[ 1 ], q[ 2 ], q[ 3 ] );
 
 				}
 

--- a/examples/jsm/loaders/usd/USDComposer.js
+++ b/examples/jsm/loaders/usd/USDComposer.js
@@ -1089,6 +1089,7 @@ class USDComposer {
 		}
 
 		const { uvs, uvIndices } = this._findUVPrimvar( fields );
+		const numFaceVertices = faceVertexIndices ? faceVertexIndices.length : 0;
 
 		if ( uvs && uvs.length > 0 ) {
 
@@ -1102,6 +1103,15 @@ class USDComposer {
 			} else if ( indices && uvs.length / 2 === points.length / 3 ) {
 
 				uvData = this._expandAttribute( uvs, indices, 2 );
+
+			} else if ( triPattern && uvs.length / 2 === numFaceVertices ) {
+
+				// Per-face-vertex UVs (faceVarying, no separate indices)
+				const uvIndicesFromPattern = this._applyTriangulationPattern(
+					Array.from( { length: numFaceVertices }, ( _, i ) => i ),
+					triPattern
+				);
+				uvData = this._expandAttribute( uvs, uvIndicesFromPattern, 2 );
 
 			}
 
@@ -1124,6 +1134,15 @@ class USDComposer {
 			} else if ( indices && uvs2.length / 2 === points.length / 3 ) {
 
 				uv2Data = this._expandAttribute( uvs2, indices, 2 );
+
+			} else if ( triPattern && uvs2.length / 2 === numFaceVertices ) {
+
+				// Per-face-vertex UV2 (faceVarying, no separate indices)
+				const uv2IndicesFromPattern = this._applyTriangulationPattern(
+					Array.from( { length: numFaceVertices }, ( _, i ) => i ),
+					triPattern
+				);
+				uv2Data = this._expandAttribute( uvs2, uv2IndicesFromPattern, 2 );
 
 			}
 

--- a/examples/jsm/loaders/usd/USDComposer.js
+++ b/examples/jsm/loaders/usd/USDComposer.js
@@ -2936,8 +2936,18 @@ class USDComposer {
 		if ( cleanPath.startsWith( '@' ) ) cleanPath = cleanPath.slice( 1 );
 		if ( cleanPath.endsWith( '@' ) ) cleanPath = cleanPath.slice( 0, - 1 );
 
-		const assetData = this.assets[ cleanPath ];
+		// Resolve relative to basePath first
+		const resolvedPath = this._resolveFilePath( cleanPath );
+		let assetData = this.assets[ resolvedPath ];
 
+		// Fallback to unresolved path
+		if ( ! assetData ) {
+
+			assetData = this.assets[ cleanPath ];
+
+		}
+
+		// Last resort: search by basename
 		if ( ! assetData ) {
 
 			const baseName = cleanPath.split( '/' ).pop();

--- a/examples/jsm/loaders/usd/USDComposer.js
+++ b/examples/jsm/loaders/usd/USDComposer.js
@@ -2300,6 +2300,22 @@ class USDComposer {
 
 		}
 
+		// Specular color
+		applyTextureFromConnection(
+			'inputs:specularColor',
+			'specularColorMap',
+			SRGBColorSpace,
+			( color ) => {
+
+				if ( Array.isArray( color ) && color.length >= 3 ) {
+
+					material.specularColor.setRGB( color[ 0 ], color[ 1 ], color[ 2 ], SRGBColorSpace );
+
+				}
+
+			}
+		);
+
 		// Clearcoat
 		if ( fields[ 'inputs:clearcoat' ] !== undefined ) {
 


### PR DESCRIPTION
Related issue: #32704 

**Description**

- Add `specularColor` support to UsdPreviewSurface materials
- Add matrix transform animation support (`xformOp:transform` with timeSamples)
- Add texture-based opacity with `opacityThreshold` for alpha testing
- Fix quaternion format to match AOUSD spec (binary format is x,y,z,w)
- Fix USDA parsing when empty lines appear between `def "Name"` and `{`
- Fix faceVarying UV triangulation for meshes with n-gons
- Fix texture path resolution for referenced USD files

https://github.com/user-attachments/assets/39f0663d-d7de-4900-83f9-9d623c37ff1b

Thanks to @AdaRoseCannon and @hybridherbst for the test models 🙏

(Made with Claude Opus 4.5)