### PR TITLE
Exporters: Add Object3D.pivot support.

### DIFF
--- a/examples/jsm/exporters/GLTFExporter.js
+++ b/examples/jsm/exporters/GLTFExporter.js
@@ -2357,7 +2357,7 @@ class GLTFWriter {
 
 		const nodeDef = {};
 
-		if ( options.trs ) {
+		if ( options.trs && object.pivot === null ) {
 
 			const rotation = object.quaternion.toArray();
 			const position = object.position.toArray();
@@ -2392,6 +2392,12 @@ class GLTFWriter {
 			if ( isIdentityMatrix( object.matrix ) === false ) {
 
 				nodeDef.matrix = object.matrix.elements;
+
+			}
+
+			if ( object.pivot !== null ) {
+
+				console.warn( 'THREE.GLTFExporter: Pivot not supported by GLTF. Baking into matrix.', object );
 
 			}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/32745#issuecomment-3758192525

**Description**

Adds `Object3D.pivot` support to exporters.

* **USDZExporter:** Exports pivot using native USD `xformOps` for full round-trip support.
* **GLTFExporter:** Bakes pivot into matrix (GLTF doesn't support pivot). Logs warning when this occurs.

(Made with Claude Opus 4.5)