### PR TITLE
WebGLRenderer: Fix shadow bias with reversed depth buffer.

### DIFF
--- a/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/shadowmap_pars_fragment.glsl.js
@@ -267,14 +267,14 @@ export default /* glsl */`
 			#ifdef USE_REVERSED_DEPTH_BUFFER
 
 				float dp = ( shadowCameraNear * ( shadowCameraFar - viewSpaceZ ) ) / ( viewSpaceZ * ( shadowCameraFar - shadowCameraNear ) );
+				dp -= shadowBias;
 
 			#else
 
 				float dp = ( shadowCameraFar * ( viewSpaceZ - shadowCameraNear ) ) / ( viewSpaceZ * ( shadowCameraFar - shadowCameraNear ) );
+				dp += shadowBias;
 
 			#endif
-			
-			dp += shadowBias;
 
 			// Hardware PCF with LinearFilter gives us 4-tap filtering per sample
 			// Use Vogel disk + IGN sampling for better quality


### PR DESCRIPTION
Related issue: #31998

**Description**

After testing all combinations of lights and shadow map types, only point light PCF shadows with reversed depth buffer require an different shadow bias handling. For all other permutations, #32751 already ensured a consistent handling.
