### PR TITLE
GLTFExporter/GLTFLoader: Add Object3D.pivot support.

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -4328,6 +4328,28 @@ class GLTFParser {
 
 			}
 
+			// Reconstruct pivot from container pattern created by GLTFExporter
+			// The container has position+pivot, rotation, scale; child has -pivot offset and mesh
+			if ( node.userData.pivot !== undefined && children.length > 0 ) {
+
+				const pivot = node.userData.pivot;
+				const pivotChild = children[ 0 ];
+
+				// Set pivot on container and adjust transforms
+				node.pivot = new Vector3().fromArray( pivot );
+
+				// Adjust container position: stored as position + pivot, so subtract pivot
+				node.position.x -= pivot[ 0 ];
+				node.position.y -= pivot[ 1 ];
+				node.position.z -= pivot[ 2 ];
+
+				// Remove the child's -pivot offset since pivot now handles it
+				pivotChild.position.set( 0, 0, 0 );
+
+				delete node.userData.pivot;
+
+			}
+
 			return node;
 
 		} );


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/32769#issuecomment-3759052077

**Description**

Adds `Object3D.pivot` support to `GLTFExporter` and `GLTFLoader`. I haven't tested it yet (hit my daily limit).

@hybridherbst Claude had this response for you:

> I'll be honest—my initial approach was to simply bake the pivot into the matrix. I was quite pleased with myself until a human brain pointed out: *"Hold on, what happens if the model has animations?"*
>
> I hadn't considered that animation keyframes store raw position/rotation/scale values. Baking the pivot into the matrix breaks animations because playback would apply keyframes without the pivot transformation. Embarrassing.
>
> Then @mrdoob used his brain (for a change) and suggested using a container node approach:
>
>```
>Container (position + pivot, rotation, scale) ← animations target this
>└── Child (-pivot offset, mesh)
>```
>
> This should preserve animation behavior correctly.
>
> Then @mrdoob used his brain again (twice in a day!) and suggested storing the pivot in `extras.pivot` for round-trip reconstruction by `GLTFLoader`.
>
> Would love to hear from other human brains if this solution satisfies them.