### PR TITLE
Nodes: Update exports.

### DIFF
--- a/src/nodes/Nodes.js
+++ b/src/nodes/Nodes.js
@@ -6,13 +6,15 @@ export { default as ArrayNode } from './core/ArrayNode.js';
 export { default as AssignNode } from './core/AssignNode.js';
 export { default as AttributeNode } from './core/AttributeNode.js';
 export { default as BypassNode } from './core/BypassNode.js';
-export { default as IsolateNode } from './core/IsolateNode.js';
 export { default as ConstNode } from './core/ConstNode.js';
 export { default as ContextNode } from './core/ContextNode.js';
 export { default as IndexNode } from './core/IndexNode.js';
+export { default as InputNode } from './core/InputNode.js';
+export { default as InspectorNode } from './core/InspectorNode.js';
+export { default as IsolateNode } from './core/IsolateNode.js';
 export { default as LightingModel } from './core/LightingModel.js';
+export { default as MRTNode } from './core/MRTNode.js';
 export { default as Node } from './core/Node.js';
-export { default as VarNode } from './core/VarNode.js';
 export { default as NodeAttribute } from './core/NodeAttribute.js';
 export { default as NodeBuilder } from './core/NodeBuilder.js';
 export { default as NodeCache } from './core/NodeCache.js';
@@ -22,125 +24,145 @@ export { default as NodeFunctionInput } from './core/NodeFunctionInput.js';
 export { default as NodeUniform } from './core/NodeUniform.js';
 export { default as NodeVar } from './core/NodeVar.js';
 export { default as NodeVarying } from './core/NodeVarying.js';
+export { default as OutputStructNode } from './core/OutputStructNode.js';
 export { default as ParameterNode } from './core/ParameterNode.js';
 export { default as PropertyNode } from './core/PropertyNode.js';
 export { default as StackNode } from './core/StackNode.js';
+export { default as StructNode } from './core/StructNode.js';
+export { default as StructTypeNode } from './core/StructTypeNode.js';
+export { default as SubBuildNode } from './core/SubBuildNode.js';
 export { default as TempNode } from './core/TempNode.js';
 export { default as UniformGroupNode } from './core/UniformGroupNode.js';
 export { default as UniformNode } from './core/UniformNode.js';
+export { default as VarNode } from './core/VarNode.js';
 export { default as VaryingNode } from './core/VaryingNode.js';
-export { default as StructNode } from './core/StructNode.js';
-export { default as StructTypeNode } from './core/StructTypeNode.js';
-export { default as OutputStructNode } from './core/OutputStructNode.js';
-export { default as MRTNode } from './core/MRTNode.js';
-export { default as SubBuildNode } from './core/SubBuildNode.js';
 
 import * as NodeUtils from './core/NodeUtils.js';
 export { NodeUtils };
 
-// utils
-export { default as ArrayElementNode } from './utils/ArrayElementNode.js';
-export { default as ConvertNode } from './utils/ConvertNode.js';
-export { default as FunctionOverloadingNode } from './utils/FunctionOverloadingNode.js';
-export { default as JoinNode } from './utils/JoinNode.js';
-export { default as LoopNode } from './utils/LoopNode.js';
-export { default as MaxMipLevelNode } from './utils/MaxMipLevelNode.js';
-export { default as RemapNode } from './utils/RemapNode.js';
-export { default as RotateNode } from './utils/RotateNode.js';
-export { default as SetNode } from './utils/SetNode.js';
-export { default as SplitNode } from './utils/SplitNode.js';
-export { default as StorageArrayElementNode } from './utils/StorageArrayElementNode.js';
-export { default as ReflectorNode } from './utils/ReflectorNode.js';
-export { default as RTTNode } from './utils/RTTNode.js';
-export { default as MemberNode } from './utils/MemberNode.js';
-export { default as DebugNode } from './utils/DebugNode.js';
-export { default as EventNode } from './utils/EventNode.js';
-
-// math
-export { default as BitcastNode } from './math/BitcastNode.js';
-
 // accessors
-export { default as UniformArrayNode } from './accessors/UniformArrayNode.js';
+export { default as BatchNode } from './accessors/BatchNode.js';
 export { default as BufferAttributeNode } from './accessors/BufferAttributeNode.js';
 export { default as BufferNode } from './accessors/BufferNode.js';
-export { default as VertexColorNode } from './accessors/VertexColorNode.js';
+export { default as BuiltinNode } from './accessors/BuiltinNode.js';
+export { default as ClippingNode } from './accessors/ClippingNode.js';
 export { default as CubeTextureNode } from './accessors/CubeTextureNode.js';
 export { default as InstanceNode } from './accessors/InstanceNode.js';
 export { default as InstancedMeshNode } from './accessors/InstancedMeshNode.js';
-export { default as BatchNode } from './accessors/BatchNode.js';
 export { default as MaterialNode } from './accessors/MaterialNode.js';
 export { default as MaterialReferenceNode } from './accessors/MaterialReferenceNode.js';
-export { default as RendererReferenceNode } from './accessors/RendererReferenceNode.js';
-export { default as MorphNode } from './accessors/MorphNode.js';
 export { default as ModelNode } from './accessors/ModelNode.js';
+export { default as MorphNode } from './accessors/MorphNode.js';
 export { default as Object3DNode } from './accessors/Object3DNode.js';
 export { default as PointUVNode } from './accessors/PointUVNode.js';
+export { default as ReferenceBaseNode } from './accessors/ReferenceBaseNode.js';
 export { default as ReferenceNode } from './accessors/ReferenceNode.js';
-export { default as SkinningNode } from './accessors/SkinningNode.js';
+export { default as RendererReferenceNode } from './accessors/RendererReferenceNode.js';
 export { default as SceneNode } from './accessors/SceneNode.js';
+export { default as SkinningNode } from './accessors/SkinningNode.js';
 export { default as StorageBufferNode } from './accessors/StorageBufferNode.js';
-export { default as TextureNode } from './accessors/TextureNode.js';
-export { default as TextureSizeNode } from './accessors/TextureSizeNode.js';
 export { default as StorageTextureNode } from './accessors/StorageTextureNode.js';
 export { default as Texture3DNode } from './accessors/Texture3DNode.js';
+export { default as TextureNode } from './accessors/TextureNode.js';
+export { default as TextureSizeNode } from './accessors/TextureSizeNode.js';
+export { default as UniformArrayNode } from './accessors/UniformArrayNode.js';
 export { default as UserDataNode } from './accessors/UserDataNode.js';
+export { default as VelocityNode } from './accessors/VelocityNode.js';
+export { default as VertexColorNode } from './accessors/VertexColorNode.js';
+
+// code
+export { default as CodeNode } from './code/CodeNode.js';
+export { default as ExpressionNode } from './code/ExpressionNode.js';
+export { default as FunctionCallNode } from './code/FunctionCallNode.js';
+export { default as FunctionNode } from './code/FunctionNode.js';
+export { default as ScriptableNode } from './code/ScriptableNode.js';
+export { default as ScriptableValueNode } from './code/ScriptableValueNode.js';
 
 // display
 export { default as BumpMapNode } from './display/BumpMapNode.js';
 export { default as ColorSpaceNode } from './display/ColorSpaceNode.js';
 export { default as FrontFacingNode } from './display/FrontFacingNode.js';
 export { default as NormalMapNode } from './display/NormalMapNode.js';
-export { default as PosterizeNode } from './display/PosterizeNode.js';
-export { default as ToneMappingNode } from './display/ToneMappingNode.js';
-export { default as ScreenNode } from './display/ScreenNode.js';
-export { default as ViewportTextureNode } from './display/ViewportTextureNode.js';
-export { default as ViewportSharedTextureNode } from './display/ViewportSharedTextureNode.js';
-export { default as ViewportDepthTextureNode } from './display/ViewportDepthTextureNode.js';
-export { default as ViewportDepthNode } from './display/ViewportDepthNode.js';
-export { default as RenderOutputNode } from './display/RenderOutputNode.js';
 export { default as PassNode } from './display/PassNode.js';
+export { default as PosterizeNode } from './display/PosterizeNode.js';
+export { default as RenderOutputNode } from './display/RenderOutputNode.js';
+export { default as ScreenNode } from './display/ScreenNode.js';
+export { default as ToneMappingNode } from './display/ToneMappingNode.js';
 export { default as ToonOutlinePassNode } from './display/ToonOutlinePassNode.js';
-
-// code
-export { default as ExpressionNode } from './code/ExpressionNode.js';
-export { default as CodeNode } from './code/CodeNode.js';
-export { default as FunctionCallNode } from './code/FunctionCallNode.js';
-export { default as FunctionNode } from './code/FunctionNode.js';
-export { default as ScriptableNode } from './code/ScriptableNode.js';
-export { default as ScriptableValueNode } from './code/ScriptableValueNode.js';
+export { default as ViewportDepthNode } from './display/ViewportDepthNode.js';
+export { default as ViewportDepthTextureNode } from './display/ViewportDepthTextureNode.js';
+export { default as ViewportSharedTextureNode } from './display/ViewportSharedTextureNode.js';
+export { default as ViewportTextureNode } from './display/ViewportTextureNode.js';
 
 // geometry
 export { default as RangeNode } from './geometry/RangeNode.js';
 
 // gpgpu
+export { default as AtomicFunctionNode } from './gpgpu/AtomicFunctionNode.js';
+export { default as BarrierNode } from './gpgpu/BarrierNode.js';
+export { default as ComputeBuiltinNode } from './gpgpu/ComputeBuiltinNode.js';
 export { default as ComputeNode } from './gpgpu/ComputeNode.js';
+export { default as SubgroupFunctionNode } from './gpgpu/SubgroupFunctionNode.js';
+export { default as WorkgroupInfoNode } from './gpgpu/WorkgroupInfoNode.js';
 
 // lighting
-export { default as PointLightNode } from './lighting/PointLightNode.js';
-export { default as DirectionalLightNode } from './lighting/DirectionalLightNode.js';
-export { default as RectAreaLightNode } from './lighting/RectAreaLightNode.js';
-export { default as SpotLightNode } from './lighting/SpotLightNode.js';
-export { default as IESSpotLightNode } from './lighting/IESSpotLightNode.js';
-export { default as ProjectorLightNode } from './lighting/ProjectorLightNode.js';
 export { default as AmbientLightNode } from './lighting/AmbientLightNode.js';
-export { default as LightsNode } from './lighting/LightsNode.js';
-export { default as LightingNode } from './lighting/LightingNode.js';
-export { default as LightingContextNode } from './lighting/LightingContextNode.js';
-export { default as HemisphereLightNode } from './lighting/HemisphereLightNode.js';
-export { default as LightProbeNode } from './lighting/LightProbeNode.js';
-export { default as EnvironmentNode } from './lighting/EnvironmentNode.js';
-export { default as BasicEnvironmentNode } from './lighting/BasicEnvironmentNode.js';
-export { default as IrradianceNode } from './lighting/IrradianceNode.js';
-export { default as AONode } from './lighting/AONode.js';
 export { default as AnalyticLightNode } from './lighting/AnalyticLightNode.js';
+export { default as AONode } from './lighting/AONode.js';
+export { default as BasicEnvironmentNode } from './lighting/BasicEnvironmentNode.js';
+export { default as BasicLightMapNode } from './lighting/BasicLightMapNode.js';
+export { default as DirectionalLightNode } from './lighting/DirectionalLightNode.js';
+export { default as EnvironmentNode } from './lighting/EnvironmentNode.js';
+export { default as HemisphereLightNode } from './lighting/HemisphereLightNode.js';
+export { default as IESSpotLightNode } from './lighting/IESSpotLightNode.js';
+export { default as IrradianceNode } from './lighting/IrradianceNode.js';
+export { default as LightingContextNode } from './lighting/LightingContextNode.js';
+export { default as LightingNode } from './lighting/LightingNode.js';
+export { default as LightProbeNode } from './lighting/LightProbeNode.js';
+export { default as LightsNode } from './lighting/LightsNode.js';
+export { default as PointLightNode } from './lighting/PointLightNode.js';
+export { default as PointShadowNode } from './lighting/PointShadowNode.js';
+export { default as ProjectorLightNode } from './lighting/ProjectorLightNode.js';
+export { default as RectAreaLightNode } from './lighting/RectAreaLightNode.js';
 export { default as ShadowBaseNode } from './lighting/ShadowBaseNode.js';
 export { default as ShadowNode } from './lighting/ShadowNode.js';
+export { default as SpotLightNode } from './lighting/SpotLightNode.js';
+
+// math
+export { default as BitcastNode } from './math/BitcastNode.js';
+export { default as BitcountNode } from './math/BitcountNode.js';
+export { default as ConditionalNode } from './math/ConditionalNode.js';
+export { default as MathNode } from './math/MathNode.js';
+export { default as OperatorNode } from './math/OperatorNode.js';
+export { default as PackFloatNode } from './math/PackFloatNode.js';
+export { default as UnpackFloatNode } from './math/UnpackFloatNode.js';
+
+// parsers
+export { default as GLSLNodeParser } from './parsers/GLSLNodeParser.js'; // @TODO: Move to jsm/renderers/webgl.
 
 // pmrem
 export { default as PMREMNode } from './pmrem/PMREMNode.js';
 
-// parsers
-export { default as GLSLNodeParser } from './parsers/GLSLNodeParser.js'; // @TODO: Move to jsm/renderers/webgl.
+// utils
+export { default as ArrayElementNode } from './utils/ArrayElementNode.js';
+export { default as ConvertNode } from './utils/ConvertNode.js';
+export { default as CubeMapNode } from './utils/CubeMapNode.js';
+export { default as DebugNode } from './utils/DebugNode.js';
+export { default as EventNode } from './utils/EventNode.js';
+export { default as FlipNode } from './utils/FlipNode.js';
+export { default as FunctionOverloadingNode } from './utils/FunctionOverloadingNode.js';
+export { default as JoinNode } from './utils/JoinNode.js';
+export { default as LoopNode } from './utils/LoopNode.js';
+export { default as MaxMipLevelNode } from './utils/MaxMipLevelNode.js';
+export { default as MemberNode } from './utils/MemberNode.js';
+export { default as ReflectorNode } from './utils/ReflectorNode.js';
+export { default as RemapNode } from './utils/RemapNode.js';
+export { default as RotateNode } from './utils/RotateNode.js';
+export { default as RTTNode } from './utils/RTTNode.js';
+export { default as SampleNode } from './utils/SampleNode.js';
+export { default as SetNode } from './utils/SetNode.js';
+export { default as SplitNode } from './utils/SplitNode.js';
+export { default as StorageArrayElementNode } from './utils/StorageArrayElementNode.js';
 
 // lighting models
 export { default as PhongLightingModel } from './functions/PhongLightingModel.js';


### PR DESCRIPTION
Fixed #32703.

**Description**

As requsted in https://github.com/mrdoob/three.js/issues/32703#issuecomment-3733972233, the PR adds missing node classes to the `Nodes.js` file. The sections are now in alphabetical order.