### PR TITLE
WebGPURenderer: Rename `RenderPipeline` to `RenderObjectPipeline`

### DIFF
--- a/src/renderers/common/Pipelines.js
+++ b/src/renderers/common/Pipelines.js
@@ -1,5 +1,5 @@
 import DataMap from './DataMap.js';
-import RenderPipeline from './RenderPipeline.js';
+import RenderObjectPipeline from './RenderObjectPipeline.js';
 import ComputePipeline from './ComputePipeline.js';
 import ProgrammableStage from './ProgrammableStage.js';
 
@@ -146,7 +146,7 @@ class Pipelines extends DataMap {
 	 *
 	 * @param {RenderObject} renderObject - The render object.
 	 * @param {?Array<Promise>} [promises=null] - An array of compilation promises which is only relevant in context of `Renderer.compileAsync()`.
-	 * @return {RenderPipeline} The render pipeline.
+	 * @return {RenderObjectPipeline} The render pipeline.
 	 */
 	getForRender( renderObject, promises = null ) {
 
@@ -344,7 +344,7 @@ class Pipelines extends DataMap {
 	 * @param {ProgrammableStage} stageFragment - The programmable stage representing the fragment shader.
 	 * @param {string} cacheKey - The cache key.
 	 * @param {?Array<Promise>} promises - An array of compilation promises which is only relevant in context of `Renderer.compileAsync()`.
-	 * @return {RenderPipeline} The render pipeline.
+	 * @return {RenderObjectPipeline} The render pipeline.
 	 */
 	_getRenderPipeline( renderObject, stageVertex, stageFragment, cacheKey, promises ) {
 
@@ -356,7 +356,7 @@ class Pipelines extends DataMap {
 
 		if ( pipeline === undefined ) {
 
-			pipeline = new RenderPipeline( cacheKey, stageVertex, stageFragment );
+			pipeline = new RenderObjectPipeline( cacheKey, stageVertex, stageFragment );
 
 			this.caches.set( cacheKey, pipeline );
 

--- a/src/renderers/common/RenderObjectPipeline.js
+++ b/src/renderers/common/RenderObjectPipeline.js
@@ -9,7 +9,7 @@ import Pipeline from './Pipeline.js';
 class RenderObjectPipeline extends Pipeline {
 
 	/**
-	 * Constructs a new render pipeline.
+	 * Constructs a new render object pipeline.
 	 *
 	 * @param {string} cacheKey - The pipeline's cache key.
 	 * @param {ProgrammableStage} vertexProgram - The pipeline's vertex shader.

--- a/src/renderers/common/RenderObjectPipeline.js
+++ b/src/renderers/common/RenderObjectPipeline.js
@@ -6,7 +6,7 @@ import Pipeline from './Pipeline.js';
  * @private
  * @augments Pipeline
  */
-class RenderPipeline extends Pipeline {
+class RenderObjectPipeline extends Pipeline {
 
 	/**
 	 * Constructs a new render pipeline.
@@ -37,4 +37,4 @@ class RenderPipeline extends Pipeline {
 
 }
 
-export default RenderPipeline;
+export default RenderObjectPipeline;


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/32535

**Description**

Rename `RenderPipeline` to `RenderObjectPipeline`.