### PR TITLE
  USDLoader: Performance improvements and external texture support.

### DIFF
--- a/editor/js/Loader.js
+++ b/editor/js/Loader.js
@@ -635,7 +635,8 @@ function Loader( editor ) {
 
 					const { USDLoader } = await import( 'three/addons/loaders/USDLoader.js' );
 
-					const group = new USDLoader().parse( contents );
+					const loader = new USDLoader( manager );
+					const group = loader.parse( contents );
 					group.name = filename;
 
 					editor.execute( new AddObjectCommand( editor, group ) );
@@ -758,6 +759,15 @@ function Loader( editor ) {
 				break;
 
 			}
+
+			case 'bmp':
+			case 'gif':
+			case 'jpg':
+			case 'jpeg':
+			case 'png':
+			case 'tga':
+
+				break; // Image files are handled as textures by other loaders
 
 			default:
 

--- a/examples/jsm/loaders/USDLoader.js
+++ b/examples/jsm/loaders/USDLoader.js
@@ -201,11 +201,13 @@ class USDLoader extends Loader {
 
 		}
 
+		const scope = this;
+
 		// USDA (standalone)
 
 		if ( typeof buffer === 'string' ) {
 
-			const composer = new USDComposer();
+			const composer = new USDComposer( scope.manager );
 			const data = usda.parseData( buffer );
 			return composer.compose( data, {} );
 
@@ -215,7 +217,7 @@ class USDLoader extends Loader {
 
 		if ( isCrateFile( buffer ) ) {
 
-			const composer = new USDComposer();
+			const composer = new USDComposer( scope.manager );
 			const data = usdc.parseData( buffer );
 			return composer.compose( data, {} );
 
@@ -233,7 +235,7 @@ class USDLoader extends Loader {
 
 			const { file, basePath } = findUSD( zip );
 
-			const composer = new USDComposer();
+			const composer = new USDComposer( scope.manager );
 			let data;
 
 			if ( isCrateFile( file ) ) {
@@ -253,7 +255,7 @@ class USDLoader extends Loader {
 
 		// USDA (standalone, as ArrayBuffer)
 
-		const composer = new USDComposer();
+		const composer = new USDComposer( scope.manager );
 		const text = new TextDecoder().decode( bytes );
 		const data = usda.parseData( text );
 		return composer.compose( data, {} );

--- a/examples/jsm/loaders/usd/USDAParser.js
+++ b/examples/jsm/loaders/usd/USDAParser.js
@@ -1,3 +1,8 @@
+// Pre-compiled regex patterns for performance
+const DEF_MATCH_REGEX = /^def\s+(?:(\w+)\s+)?"?([^"]+)"?$/;
+const VARIANT_STRING_REGEX = /^string\s+(\w+)$/;
+const ATTR_MATCH_REGEX = /^(?:uniform\s+)?(\w+(?:\[\])?)\s+(.+)$/;
+
 class USDAParser {
 
 	parseText( text ) {
@@ -466,7 +471,7 @@ class USDAParser {
 
 				// Check for primitive definitions
 				// Matches both 'def TypeName "name"' and 'def "name"' (no type)
-				const defMatch = key.match( /^def\s+(?:(\w+)\s+)?"?([^"]+)"?$/ );
+				const defMatch = key.match( DEF_MATCH_REGEX );
 				if ( defMatch ) {
 
 					const typeName = defMatch[ 1 ] || '';
@@ -535,7 +540,7 @@ class USDAParser {
 
 				for ( const vKey in variants ) {
 
-					const match = vKey.match( /^string\s+(\w+)$/ );
+					const match = vKey.match( VARIANT_STRING_REGEX );
 					if ( match ) {
 
 						const variantSetName = match[ 1 ];
@@ -583,7 +588,7 @@ class USDAParser {
 
 			// Handle typed attributes
 			// Format: [qualifier] type attrName (e.g., "uniform token[] joints", "float3 position")
-			const attrMatch = key.match( /^(?:uniform\s+)?(\w+(?:\[\])?)\s+(.+)$/ );
+			const attrMatch = key.match( ATTR_MATCH_REGEX );
 			if ( attrMatch ) {
 
 				const valueType = attrMatch[ 1 ];

--- a/examples/jsm/loaders/usd/USDAParser.js
+++ b/examples/jsm/loaders/usd/USDAParser.js
@@ -120,6 +120,9 @@ class USDAParser {
 		// Remove block comments /* ... */
 		text = this._stripBlockComments( text );
 
+		// Collapse triple-quoted strings into single lines
+		text = this._collapseTripleQuotedStrings( text );
+
 		// Remove line comments # ... (but preserve #usda header)
 		// Only remove # comments that aren't at the start of a line or after whitespace
 		const lines = text.split( '\n' );
@@ -249,6 +252,64 @@ class USDAParser {
 				i ++;
 
 			}
+
+		}
+
+		return result;
+
+	}
+
+	_collapseTripleQuotedStrings( text ) {
+
+		let result = '';
+		let i = 0;
+
+		while ( i < text.length ) {
+
+			if ( i + 2 < text.length ) {
+
+				const triple = text.slice( i, i + 3 );
+
+				if ( triple === '\'\'\'' || triple === '"""' ) {
+
+					const quoteChar = triple;
+					result += quoteChar;
+					i += 3;
+
+					while ( i < text.length ) {
+
+						if ( i + 2 < text.length && text.slice( i, i + 3 ) === quoteChar ) {
+
+							result += quoteChar;
+							i += 3;
+							break;
+
+						} else {
+
+							if ( text[ i ] === '\n' ) {
+
+								result += '\\n';
+
+							} else if ( text[ i ] !== '\r' ) {
+
+								result += text[ i ];
+
+							}
+
+							i ++;
+
+						}
+
+					}
+
+					continue;
+
+				}
+
+			}
+
+			result += text[ i ];
+			i ++;
 
 		}
 

--- a/examples/jsm/loaders/usd/USDComposer.js
+++ b/examples/jsm/loaders/usd/USDComposer.js
@@ -863,7 +863,15 @@ class USDComposer {
 		if ( geomSubsets.length > 0 ) {
 
 			geometry = this._buildGeometryWithSubsets( attrs, geomSubsets, hasSkinning );
-			material = geomSubsets.map( subset => this._buildMaterialForPath( subset.materialPath ) );
+
+			const meshMaterialPath = this._getMaterialPath( path, spec.fields );
+
+			material = geomSubsets.map( subset => {
+
+				const matPath = subset.materialPath || meshMaterialPath;
+				return this._buildMaterialForPath( matPath );
+
+			} );
 
 		} else {
 
@@ -1982,6 +1990,36 @@ class USDComposer {
 		}
 
 		return expanded;
+
+	}
+
+	/**
+	 * Get the material path for a mesh, checking various binding sources.
+	 */
+	_getMaterialPath( meshPath, fields ) {
+
+		let materialPath = null;
+		let materialBinding = fields[ 'material:binding' ];
+
+		if ( ! materialBinding ) {
+
+			const bindingPath = meshPath + '.material:binding';
+			const bindingSpec = this.specsByPath[ bindingPath ];
+			if ( bindingSpec && bindingSpec.specType === SpecType.Relationship ) {
+
+				materialBinding = bindingSpec.fields.targetPaths || bindingSpec.fields.default;
+
+			}
+
+		}
+
+		if ( materialBinding ) {
+
+			materialPath = Array.isArray( materialBinding ) ? materialBinding[ 0 ] : materialBinding;
+
+		}
+
+		return materialPath;
 
 	}
 

--- a/examples/jsm/loaders/usd/USDComposer.js
+++ b/examples/jsm/loaders/usd/USDComposer.js
@@ -53,10 +53,11 @@ const SpecType = {
  */
 class USDComposer {
 
-	constructor() {
+	constructor( manager = null ) {
 
 		this.textureCache = {};
 		this.skinnedMeshes = [];
+		this.manager = manager;
 
 	}
 
@@ -746,7 +747,7 @@ class USDComposer {
 		// If it's specsByPath data, compose it
 		if ( referencedData.specsByPath ) {
 
-			const composer = new USDComposer();
+			const composer = new USDComposer( this.manager );
 			const newBasePath = this._getBasePath( resolvedPath );
 			const composedGroup = composer.compose( referencedData, this.assets, mergedVariants, newBasePath );
 
@@ -3135,6 +3136,19 @@ class USDComposer {
 				if ( key.endsWith( baseName ) || key.endsWith( '/' + baseName ) ) {
 
 					return this._createTextureFromData( this.assets[ key ], textureAttrs, transformAttrs );
+
+				}
+
+			}
+
+			// Try loading via LoadingManager if available
+			if ( this.manager ) {
+
+				const url = this.manager.resolveURL( baseName );
+				if ( url !== baseName ) {
+
+					// URL modifier found a match - load it
+					return this._createTextureFromData( url, textureAttrs, transformAttrs );
 
 				}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/32730#issuecomment-3758427991

**Description**

Improves USDLoader performance by building O(1) lookup indexes for hierarchy traversal, attribute access, material resolution, shaders, and `GeomSubsets`. Optimizes `USDCParser`'s half-float conversion and buffer reuse.                                                                                    
                                                                                                       
Adds support for triple-quoted strings in `USDAParser` to handle embedded OSL shader code from Maya exports.                                                                                             
                                                                                                       
Fixes material binding for meshes with `GeomSubsets` by falling back to mesh-level bindings when subsets don't specify their own materials.                                                           

Adds LoadingManager support to `USDComposer`, allowing external textures to be resolved through the manager's URL modifier. The editor now passes its `LoadingManager` to `USDLoader`, enabling users to load USD files alongside their external texture files.

https://github.com/user-attachments/assets/bb663a54-69ab-461b-9079-2e7c3bbf3812