### PR TITLE
Manual: Improve Chinese translation.

### DIFF
--- a/manual/zh/textures.html
+++ b/manual/zh/textures.html
@@ -115,7 +115,7 @@ const material = new THREE.MeshBasicMaterial({
 </div>
 
 <p></p>
-<p>但需要注意的是，并不是所有的几何体类型都支持多种材质。<a href="/docs/#api/zh/geometries/BoxGeometry"><code class="notranslate" translate="no">BoxGeometry</code></a> 和 <a href="/docs/#api/zh/geometries/BoxGeometry"><code class="notranslate" translate="no">BoxGeometry</code></a> 可以使用6种材料，每个面一个。<a href="/docs/#api/zh/geometries/ConeGeometry"><code class="notranslate" translate="no">ConeGeometry</code></a> 和 <a href="/docs/#api/zh/geometries/ConeGeometry"><code class="notranslate" translate="no">ConeGeometry</code></a> 可以使用2种材料，一种用于底部，一种用于侧面。 <a href="/docs/#api/zh/geometries/CylinderGeometry"><code class="notranslate" translate="no">CylinderGeometry</code></a> 和 <a href="/docs/#api/zh/geometries/CylinderGeometry"><code class="notranslate" translate="no">CylinderGeometry</code></a> 可以使用3种材料，分别是底部、顶部和侧面。对于其他情况，你需要建立或加载自定义几何体和（或）修改纹理坐标。</p>
+<p>但需要注意的是，并不是所有的几何体类型都支持多种材质。<a href="/docs/#api/zh/geometries/BoxGeometry"><code class="notranslate" translate="no">BoxGeometry</code></a> 可以为六个面分别指定材质。<a href="/docs/#api/zh/geometries/ConeGeometry"><code class="notranslate" translate="no">ConeGeometry</code></a>支持两种材质，分别用于底面和侧面。 <a href="/docs/#api/zh/geometries/CylinderGeometry"><code class="notranslate" translate="no">CylinderGeometry</code></a>支持三种材质，分别用于底面、顶面和侧面。对于其他情况，你需要构建或加载自定义几何体和（或）修改纹理坐标。</p>
 <p>在其他3D引擎中，如果你想在一个几何体上使用多个图像，使用 <a href="https://en.wikipedia.org/wiki/Texture_atlas">纹理图集（Texture Atlas）</a> 更为常见，性能也更高。纹理图集是将多个图像放在一个单一的纹理中，然后使用几何体顶点上的纹理坐标来选择在几何体的每个三角形上使用纹理的哪些部分。</p>
 <p>什么是纹理坐标？它们是添加到一块几何体的每个顶点上的数据，用于指定该顶点对应的纹理的哪个部分。当我们开始<a href="custom-buffergeometry.html">构建自定义几何体时（building custom geometry）</a>，我们会介绍它们。</p>
 <h2 id="-a-name-loading-a-"><a name="loading"></a> 加载纹理</h2>


### PR DESCRIPTION
在阅读 three.js 中文手册的[「纹理」](https://threejs.org/manual/#zh/textures)章节时，我发现以下段落的翻译存在内容重复问题：
   
>  但需要注意的是，并不是所有的几何体类型都支持多种材质。BoxGeometry 和 BoxGeometry 可以使用6种材料，每个面一个。ConeGeometry 和 ConeGeometry 可以使用2种材料，一种用于底部，一种用于侧面。 CylinderGeometry 和 CylinderGeometry 可以使用3种材料，分别是底部、顶部和侧面。对于其他情况，你需要建立或加载自定义几何体和（或）修改纹理坐标。

英文原文：
> It should be noted though that not all geometry types supports multiple materials. [BoxGeometry](https://threejs.org/docs/#api/en/geometries/BoxGeometry) can use 6 materials one for each face. [ConeGeometry](https://threejs.org/docs/#api/en/geometries/ConeGeometry) can use 2 materials, one for the bottom and one for the cone. [CylinderGeometry](https://threejs.org/docs/#api/en/geometries/CylinderGeometry) can use 3 materials, bottom, top, and side. For other cases you will need to build or load custom geometry and/or modify texture coordinates.

问题包括：

- 重复命名：如 “BoxGeometry 和 BoxGeometry”、“ConeGeometry 和 ConeGeometry” 等，显然是翻译时的笔误，应为单一几何体类型
- 术语不一致：“材料” 应统一为 “材质”（three.js 中文社区普遍使用“材质”对应 “material”）

 本 PR 修正了上述问题，使中文描述更准确、专业，并与英文原意保持一致。

修改后：

> 但需要注意的是，并不是所有的几何体类型都支持多种材质。BoxGeometry 可以为六个面分别指定材质；ConeGeometry 支持两种材质，分别用于底面和侧面；CylinderGeometry 支持三种材质，分别用于底面、顶面和侧面。对于其他情况，你需要构建或加载自定义几何体和（或）修改纹理坐标。