### PR TITLE
Camera: Exclude scale from view matrix.

### DIFF
--- a/src/cameras/Camera.js
+++ b/src/cameras/Camera.js
@@ -1,6 +1,12 @@
 import { WebGLCoordinateSystem } from '../constants.js';
 import { Matrix4 } from '../math/Matrix4.js';
 import { Object3D } from '../core/Object3D.js';
+import { Vector3 } from '../math/Vector3.js';
+import { Quaternion } from '../math/Quaternion.js';
+
+const _position = /*@__PURE__*/ new Vector3();
+const _quaternion = /*@__PURE__*/ new Quaternion();
+const _scale = /*@__PURE__*/ new Vector3();
 
 /**
  * Abstract base class for cameras. This class should always be inherited
@@ -107,7 +113,10 @@ class Camera extends Object3D {
 
 		super.updateMatrixWorld( force );
 
-		this.matrixWorldInverse.copy( this.matrixWorld ).invert();
+		// exclude scale from view matrix to be glTF conform
+
+		this.matrixWorld.decompose( _position, _quaternion, _scale );
+		this.matrixWorldInverse.compose( _position, _quaternion, _scale.set( 1, 1, 1 ) ).invert();
 
 	}
 
@@ -115,7 +124,10 @@ class Camera extends Object3D {
 
 		super.updateWorldMatrix( updateParents, updateChildren );
 
-		this.matrixWorldInverse.copy( this.matrixWorld ).invert();
+		// exclude scale from view matrix to be glTF conform
+
+		this.matrixWorld.decompose( _position, _quaternion, _scale );
+		this.matrixWorldInverse.compose( _position, _quaternion, _scale.set( 1, 1, 1 ) ).invert();
 
 	}
 

--- a/src/cameras/Camera.js
+++ b/src/cameras/Camera.js
@@ -116,7 +116,16 @@ class Camera extends Object3D {
 		// exclude scale from view matrix to be glTF conform
 
 		this.matrixWorld.decompose( _position, _quaternion, _scale );
-		this.matrixWorldInverse.compose( _position, _quaternion, _scale.set( 1, 1, 1 ) ).invert();
+
+		if ( _scale.x === 1 && _scale.y === 1 && _scale.z === 1 ) {
+
+			this.matrixWorldInverse.copy( this.matrixWorld ).invert();
+
+		} else {
+
+			this.matrixWorldInverse.compose( _position, _quaternion, _scale.set( 1, 1, 1 ) ).invert();
+
+		}
 
 	}
 
@@ -127,7 +136,16 @@ class Camera extends Object3D {
 		// exclude scale from view matrix to be glTF conform
 
 		this.matrixWorld.decompose( _position, _quaternion, _scale );
-		this.matrixWorldInverse.compose( _position, _quaternion, _scale.set( 1, 1, 1 ) ).invert();
+
+		if ( _scale.x === 1 && _scale.y === 1 && _scale.z === 1 ) {
+
+			this.matrixWorldInverse.copy( this.matrixWorld ).invert();
+
+		} else {
+
+			this.matrixWorldInverse.compose( _position, _quaternion, _scale.set( 1, 1, 1 ) ).invert();
+
+		}
 
 	}
 


### PR DESCRIPTION
Related issue: #26659

**Description**

The PR makes the computation of the view matrix glTF conform by excluding the scale. From the [spec](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#view-matrix):

> The view matrix is derived from the global transform of the node containing the camera with the scaling ignored.

That fixes the lighting issues reported in #26659 when a uniform scale is applied to the camera. When taking the code from the [fiddle](https://jsfiddle.net/bmqe9fuy/10/) and testing with the PR, it renders now as expected meaning the lighting does not change anymore.