### PR TITLE
LightShadow: Introduce `biasNode`.

### DIFF
--- a/src/lights/LightShadow.js
+++ b/src/lights/LightShadow.js
@@ -53,6 +53,16 @@ class LightShadow {
 		this.bias = 0;
 
 		/**
+		 * A node version of `bias`. Only supported with `WebGPURenderer`.
+		 *
+		 * If a bias node is defined, `bias` has no effect.
+		 *
+		 * @type {?Node<float>}
+		 * @default null
+		 */
+		this.biasNode = null;
+
+		/**
 		 * Defines how much the position used to query the shadow map is offset along
 		 * the object normal. The default is `0`. Increasing this value can be used to
 		 * reduce shadow acne especially in large scenes where light shines onto

--- a/src/lights/LightShadow.js
+++ b/src/lights/LightShadow.js
@@ -302,6 +302,8 @@ class LightShadow {
 
 		this.mapSize.copy( source.mapSize );
 
+		this.biasNode = source.biasNode;
+
 		return this;
 
 	}

--- a/src/nodes/lighting/ShadowNode.js
+++ b/src/nodes/lighting/ShadowNode.js
@@ -341,7 +341,7 @@ class ShadowNode extends ShadowBaseNode {
 		const { shadow } = this;
 		const { renderer } = builder;
 
-		const bias = reference( 'bias', 'float', shadow ).setGroup( renderGroup );
+		const bias = shadow.biasNode || reference( 'bias', 'float', shadow ).setGroup( renderGroup );
 
 		let shadowCoord = shadowPosition;
 		let coordZ;


### PR DESCRIPTION
Fixed #31191.

**Description**

Introduces `LightShadow.biasNode` as a node-based alternative to `bias`. When set, `bias` has no effect.

This gives the user more freedom in computing bias values e.g. based on the geometry data or distance values.
