### PR TITLE
WGSLNodeBuilder: Fix out-of-bounds access with `textureLoad()`.

### DIFF
--- a/src/math/MathUtils.js
+++ b/src/math/MathUtils.js
@@ -177,7 +177,7 @@ function smoothstep( x, min, max ) {
 
 /**
  * A [variation on smoothstep](https://en.wikipedia.org/wiki/Smoothstep#Variations)
- * that has zero 1st and 2nd order derivatives at `x=0` and `x=1`. 
+ * that has zero 1st and 2nd order derivatives at `x=0` and `x=1`.
  *
  * @param {number} x - The value to evaluate based on its position between `min` and `max`.
  * @param {number} min - The min value. Any `x` value below `min` will be `0`. `min` must be lower than `max`.

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -525,7 +525,9 @@ class WGSLNodeBuilder extends NodeBuilder {
 
 		}
 
-		uvSnippet = `${ vecType }<u32>( ${ wrapFunction }( ${ uvSnippet } ) * ${ vecType }<f32>( ${ textureDimension } ) )`;
+		const textureDimensionMargin = ( vecType === 'vec3' ) ? 'vec3<u32>(1,1,1)' : 'vec2<u32>(1,1)';
+
+		uvSnippet = `${ vecType }<u32>( ${ wrapFunction }( ${ uvSnippet } ) * ${ vecType }<f32>( ${ textureDimension } - ${ textureDimensionMargin } ) )`;
 
 		return this.generateTextureLoad( texture, textureProperty, uvSnippet, levelSnippet, depthSnippet, null );
 


### PR DESCRIPTION
Fixed #32708.

**Description**

The PR fixes out-of-bounds sampling when using `textureLoad()`. This bug in `WGSLNodeBuilder` has been detected during the investigations in the respective Safari bug report. https://bugs.webkit.org/show_bug.cgi?id=305727 

When using `textureLoad()`, the uv coordinates are integers and supposed to be in the range `(0, 0), (textureWidth - 1, textureHeight - 1)]`. Right now, we use `(0, 0), (textureWidth, textureHeight)]` which is invalid and produces OOB samplings. These samplings behave different in Chrome/Firefox and Safari but all browsers behave spec conform. So the issue is actually in the engine.