### PR TITLE
Core: Add stringify option to toJSON()

### DIFF
--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -656,14 +656,17 @@ class BufferAttribute {
 	/**
 	 * Serializes the buffer attribute into JSON.
 	 *
+	 * @param {Object} [meta] - An optional value holding meta information about the serialization.
 	 * @return {Object} A JSON object representing the serialized buffer attribute.
 	 */
-	toJSON() {
+	toJSON( meta ) {
+
+		const stringify = meta === undefined || meta.stringify !== false;
 
 		const data = {
 			itemSize: this.itemSize,
 			type: this.array.constructor.name,
-			array: Array.from( this.array ),
+			array: stringify ? Array.from( this.array ) : this.array,
 			normalized: this.normalized
 		};
 

--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -1207,9 +1207,12 @@ class BufferGeometry extends EventDispatcher {
 	/**
 	 * Serializes the geometry into JSON.
 	 *
+	 * @param {Object} [meta] - An optional value holding meta information about the serialization.
 	 * @return {Object} A JSON object representing the serialized geometry.
 	 */
-	toJSON() {
+	toJSON( meta ) {
+
+		const stringify = meta === undefined || meta.stringify !== false;
 
 		const data = {
 			metadata: {
@@ -1250,7 +1253,7 @@ class BufferGeometry extends EventDispatcher {
 
 			data.data.index = {
 				type: index.array.constructor.name,
-				array: Array.prototype.slice.call( index.array )
+				array: stringify ? Array.from( index.array ) : index.array
 			};
 
 		}
@@ -1261,7 +1264,7 @@ class BufferGeometry extends EventDispatcher {
 
 			const attribute = attributes[ key ];
 
-			data.data.attributes[ key ] = attribute.toJSON( data.data );
+			data.data.attributes[ key ] = attribute.toJSON( meta );
 
 		}
 
@@ -1278,7 +1281,7 @@ class BufferGeometry extends EventDispatcher {
 
 				const attribute = attributeArray[ i ];
 
-				array.push( attribute.toJSON( data.data ) );
+				array.push( attribute.toJSON( meta ) );
 
 			}
 

--- a/src/core/InterleavedBuffer.js
+++ b/src/core/InterleavedBuffer.js
@@ -250,14 +250,14 @@ class InterleavedBuffer {
 	/**
 	 * Serializes the interleaved buffer into JSON.
 	 *
-	 * @param {Object} [data] - An optional value holding meta information about the serialization.
+	 * @param {Object} [meta] - An optional value holding meta information about the serialization.
 	 * @return {Object} A JSON object representing the serialized interleaved buffer.
 	 */
-	toJSON( data ) {
+	toJSON( meta ) {
 
-		if ( data.arrayBuffers === undefined ) {
+		if ( meta.arrayBuffers === undefined ) {
 
-			data.arrayBuffers = {};
+			meta.arrayBuffers = {};
 
 		}
 
@@ -269,9 +269,9 @@ class InterleavedBuffer {
 
 		}
 
-		if ( data.arrayBuffers[ this.array.buffer._uuid ] === undefined ) {
+		if ( meta.arrayBuffers[ this.array.buffer._uuid ] === undefined ) {
 
-			data.arrayBuffers[ this.array.buffer._uuid ] = Array.from( new Uint32Array( this.array.buffer ) );
+			meta.arrayBuffers[ this.array.buffer._uuid ] = Array.from( new Uint32Array( this.array.buffer ) );
 
 		}
 

--- a/src/core/InterleavedBufferAttribute.js
+++ b/src/core/InterleavedBufferAttribute.js
@@ -483,12 +483,12 @@ class InterleavedBufferAttribute {
 	 *
 	 * If no parameter is provided, cloning an interleaved buffer attribute will de-interleave buffer data.
 	 *
-	 * @param {Object} [data] - An optional value holding meta information about the serialization.
+	 * @param {Object} [meta] - An optional value holding meta information about the serialization.
 	 * @return {Object} A JSON object representing the serialized buffer attribute.
 	 */
-	toJSON( data ) {
+	toJSON( meta ) {
 
-		if ( data === undefined ) {
+		if ( meta === undefined ) {
 
 			log( 'InterleavedBufferAttribute.toJSON(): Serializing an interleaved buffer attribute will de-interleave buffer data.' );
 
@@ -519,15 +519,15 @@ class InterleavedBufferAttribute {
 
 			// save as true interleaved attribute
 
-			if ( data.interleavedBuffers === undefined ) {
+			if ( meta.interleavedBuffers === undefined ) {
 
-				data.interleavedBuffers = {};
+				meta.interleavedBuffers = {};
 
 			}
 
-			if ( data.interleavedBuffers[ this.data.uuid ] === undefined ) {
+			if ( meta.interleavedBuffers[ this.data.uuid ] === undefined ) {
 
-				data.interleavedBuffers[ this.data.uuid ] = this.data.toJSON( data );
+				meta.interleavedBuffers[ this.data.uuid ] = this.data.toJSON( meta );
 
 			}
 

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -454,6 +454,10 @@ class ObjectLoader extends Loader {
 
 				return loadImage( path );
 
+			} else if ( typeof ImageBitmap !== 'undefined' && image instanceof ImageBitmap ) {
+
+				return image;
+
 			} else {
 
 				if ( image.data ) {
@@ -552,6 +556,10 @@ class ObjectLoader extends Loader {
 				const path = /^(\/\/)|([a-z]+:(\/\/)?)/i.test( url ) ? url : scope.resourcePath + url;
 
 				return await loader.loadAsync( path );
+
+			} else if ( typeof ImageBitmap !== 'undefined' && image instanceof ImageBitmap ) {
+
+				return image;
 
 			} else {
 

--- a/src/textures/Source.js
+++ b/src/textures/Source.js
@@ -159,11 +159,11 @@ class Source {
 
 					if ( data[ i ].isDataTexture ) {
 
-						url.push( serializeImage( data[ i ].image ) );
+						url.push( serializeImage( data[ i ].image, meta ) );
 
 					} else {
 
-						url.push( serializeImage( data[ i ] ) );
+						url.push( serializeImage( data[ i ], meta ) );
 
 					}
 
@@ -173,7 +173,7 @@ class Source {
 
 				// texture
 
-				url = serializeImage( data );
+				url = serializeImage( data, meta );
 
 			}
 
@@ -193,35 +193,38 @@ class Source {
 
 }
 
-function serializeImage( image ) {
+function serializeImage( image, meta ) {
+
+	const stringify = meta === undefined || meta.stringify !== false;
 
 	if ( ( typeof HTMLImageElement !== 'undefined' && image instanceof HTMLImageElement ) ||
-		( typeof HTMLCanvasElement !== 'undefined' && image instanceof HTMLCanvasElement ) ||
-		( typeof ImageBitmap !== 'undefined' && image instanceof ImageBitmap ) ) {
-
-		// default images
+		( typeof HTMLCanvasElement !== 'undefined' && image instanceof HTMLCanvasElement ) ) {
 
 		return ImageUtils.getDataURL( image );
 
-	} else {
+	} else if ( typeof ImageBitmap !== 'undefined' && image instanceof ImageBitmap ) {
 
-		if ( image.data ) {
+		if ( stringify ) {
 
-			// images of DataTexture
-
-			return {
-				data: Array.from( image.data ),
-				width: image.width,
-				height: image.height,
-				type: image.data.constructor.name
-			};
-
-		} else {
-
-			warn( 'Texture: Unable to serialize Texture.' );
-			return {};
+			return ImageUtils.getDataURL( image );
 
 		}
+
+		return image;
+
+	} else if ( image.data ) {
+
+		return {
+			data: stringify ? Array.from( image.data ) : image.data,
+			width: image.width,
+			height: image.height,
+			type: image.data.constructor.name
+		};
+
+	} else {
+
+		warn( 'Texture: Unable to serialize Texture.' );
+		return {};
 
 	}
 


### PR DESCRIPTION
**Description**

- Add `stringify` option to `toJSON()` to preserve native objects (ImageBitmap, TypedArray) for IndexedDB storage
- Fix InterleavedBuffer deduplication to work across multiple geometries

**stringify option**

Controls data conversion:
- `stringify: true` (default): ImageBitmap → data URL, TypedArray → Array (backwards compatible)
- `stringify: false`: Preserves native objects for faster IndexedDB storage

**InterleavedBuffer fix**

Changed `attribute.toJSON(data.data)` to `attribute.toJSON(meta)` in `BufferGeometry`. Previously, `InterleavedBuffers` shared across multiple geometries were serialized multiple times. Now they're properly deduplicated at the scene level, matching the behavior of textures and materials. @Mugen87 Was the previous per-geometry scoping intentional?