### PR TITLE
Revert "WGSLNodeBuilder: Fix out-of-bounds access with `textureLoad()`."

### DIFF
--- a/src/math/MathUtils.js
+++ b/src/math/MathUtils.js
@@ -177,7 +177,7 @@ function smoothstep( x, min, max ) {
 
 /**
  * A [variation on smoothstep](https://en.wikipedia.org/wiki/Smoothstep#Variations)
- * that has zero 1st and 2nd order derivatives at `x=0` and `x=1`.
+ * that has zero 1st and 2nd order derivatives at `x=0` and `x=1`. 
  *
  * @param {number} x - The value to evaluate based on its position between `min` and `max`.
  * @param {number} min - The min value. Any `x` value below `min` will be `0`. `min` must be lower than `max`.

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -525,9 +525,7 @@ class WGSLNodeBuilder extends NodeBuilder {
 
 		}
 
-		const textureDimensionMargin = ( vecType === 'vec3' ) ? 'vec3<u32>(1,1,1)' : 'vec2<u32>(1,1)';
-
-		uvSnippet = `${ vecType }<u32>( ${ wrapFunction }( ${ uvSnippet } ) * ${ vecType }<f32>( ${ textureDimension } - ${ textureDimensionMargin } ) )`;
+		uvSnippet = `${ vecType }<u32>( ${ wrapFunction }( ${ uvSnippet } ) * ${ vecType }<f32>( ${ textureDimension } ) )`;
 
 		return this.generateTextureLoad( texture, textureProperty, uvSnippet, levelSnippet, depthSnippet, null );
 


### PR DESCRIPTION
Reverts mrdoob/three.js#32817

