### PR TITLE
Fix missing iorNode in MeshPhysicalNodeMaterial copy method

### DIFF
--- a/src/materials/nodes/MeshPhysicalNodeMaterial.js
+++ b/src/materials/nodes/MeshPhysicalNodeMaterial.js
@@ -502,6 +502,8 @@ class MeshPhysicalNodeMaterial extends MeshStandardNodeMaterial {
 		this.specularIntensityNode = source.specularIntensityNode;
 		this.specularColorNode = source.specularColorNode;
 
+		this.iorNode = source.iorNode;
+
 		this.transmissionNode = source.transmissionNode;
 		this.thicknessNode = source.thicknessNode;
 		this.attenuationDistanceNode = source.attenuationDistanceNode;


### PR DESCRIPTION
Added missing `iorNode` property to the `copy()` method in `MeshPhysicalNodeMaterial`