### PR TITLE
ShadowNode: Add `clamp()` for VSM depth access.

### DIFF
--- a/src/nodes/lighting/ShadowNode.js
+++ b/src/nodes/lighting/ShadowNode.js
@@ -105,7 +105,7 @@ const VSMPassVertical = /*@__PURE__*/ Fn( ( { samples, radius, size, shadowPass,
 
 		const uvOffset = uvStart.add( float( i ).mul( uvStride ) );
 
-		let depth = shadowPass.sample( add( screenCoordinate.xy, vec2( 0, uvOffset ).mul( radius ) ).div( size ) );
+		let depth = shadowPass.sample( add( screenCoordinate.xy, vec2( 0, uvOffset ).mul( radius ) ).clamp( 0, size.sub( 1 ) ).div( size ) );
 
 		if ( shadowPass.value.isArrayTexture ) {
 


### PR DESCRIPTION
Fixed #32708.

**Description**

The PR makes sure the VSM implementation does not access the shadow map with out-of-bounds uvs.

Instead of updating `WGSLNodeBuilder` and influencing other shaders, this PR just focuses on the VSM shader that samples the depth. It makes sure to avoid a `1` uv coordinate which would result in a out-of-bounds `textureLoad()`.
