### PR TITLE
Implement copy() methods for DataTexture, Data3DTexture, and DataArrayTexture

### DIFF
--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -1460,15 +1460,12 @@ class BatchedMesh extends Mesh {
 		this._multiDrawStarts = source._multiDrawStarts.slice();
 
 		this._indirectTexture = source._indirectTexture.clone();
-		this._indirectTexture.image.data = this._indirectTexture.image.data.slice();
 
 		this._matricesTexture = source._matricesTexture.clone();
-		this._matricesTexture.image.data = this._matricesTexture.image.data.slice();
 
 		if ( this._colorsTexture !== null ) {
 
 			this._colorsTexture = source._colorsTexture.clone();
-			this._colorsTexture.image.data = this._colorsTexture.image.data.slice();
 
 		}
 

--- a/src/textures/Data3DTexture.js
+++ b/src/textures/Data3DTexture.js
@@ -1,4 +1,5 @@
 import { Texture } from './Texture.js';
+import { Source } from './Source.js';
 import { ClampToEdgeWrapping, NearestFilter } from '../constants.js';
 
 /**
@@ -118,24 +119,26 @@ class Data3DTexture extends Texture {
 		super.copy( source );
 
 		// Clone the TypedArray data to avoid sharing references
+		// Since image is a getter that returns this.source.data, we need to create
+		// a new Source with cloned data to avoid sharing the same source object
 		const image = source.image;
 		if ( image.data !== null ) {
 
-			this.image = {
+			this.source = new Source( {
 				data: image.data.slice(),
 				width: image.width,
 				height: image.height,
 				depth: image.depth
-			};
+			} );
 
 		} else {
 
-			this.image = {
+			this.source = new Source( {
 				data: null,
 				width: image.width,
 				height: image.height,
 				depth: image.depth
-			};
+			} );
 
 		}
 

--- a/src/textures/Data3DTexture.js
+++ b/src/textures/Data3DTexture.js
@@ -107,6 +107,42 @@ class Data3DTexture extends Texture {
 
 	}
 
+	/**
+	 * Copies the values of the given data 3D texture to this instance.
+	 *
+	 * @param {Data3DTexture} source - The data 3D texture to copy.
+	 * @return {Data3DTexture} A reference to this instance.
+	 */
+	copy( source ) {
+
+		super.copy( source );
+
+		// Clone the TypedArray data to avoid sharing references
+		const image = source.image;
+		if ( image.data !== null ) {
+
+			this.image = {
+				data: image.data.slice(),
+				width: image.width,
+				height: image.height,
+				depth: image.depth
+			};
+
+		} else {
+
+			this.image = {
+				data: null,
+				width: image.width,
+				height: image.height,
+				depth: image.depth
+			};
+
+		}
+
+		return this;
+
+	}
+
 }
 
 export { Data3DTexture };

--- a/src/textures/Data3DTexture.js
+++ b/src/textures/Data3DTexture.js
@@ -100,7 +100,7 @@ class Data3DTexture extends Texture {
 		 *
 		 * Overwritten and set to `1` by default.
 		 *
-		 * @type {boolean}
+		 * @type {number}
 		 * @default 1
 		 */
 		this.unpackAlignment = 1;

--- a/src/textures/DataArrayTexture.js
+++ b/src/textures/DataArrayTexture.js
@@ -91,7 +91,7 @@ class DataArrayTexture extends Texture {
 		 *
 		 * Overwritten and set to `1` by default.
 		 *
-		 * @type {boolean}
+		 * @type {number}
 		 * @default 1
 		 */
 		this.unpackAlignment = 1;

--- a/src/textures/DataArrayTexture.js
+++ b/src/textures/DataArrayTexture.js
@@ -129,6 +129,45 @@ class DataArrayTexture extends Texture {
 
 	}
 
+	/**
+	 * Copies the values of the given data array texture to this instance.
+	 *
+	 * @param {DataArrayTexture} source - The data array texture to copy.
+	 * @return {DataArrayTexture} A reference to this instance.
+	 */
+	copy( source ) {
+
+		super.copy( source );
+
+		// Clone the TypedArray data to avoid sharing references
+		const image = source.image;
+		if ( image.data !== null ) {
+
+			this.image = {
+				data: image.data.slice(),
+				width: image.width,
+				height: image.height,
+				depth: image.depth
+			};
+
+		} else {
+
+			this.image = {
+				data: null,
+				width: image.width,
+				height: image.height,
+				depth: image.depth
+			};
+
+		}
+
+		// Clone the layerUpdates Set
+		this.layerUpdates = new Set( source.layerUpdates );
+
+		return this;
+
+	}
+
 }
 
 export { DataArrayTexture };

--- a/src/textures/DataArrayTexture.js
+++ b/src/textures/DataArrayTexture.js
@@ -1,4 +1,5 @@
 import { Texture } from './Texture.js';
+import { Source } from './Source.js';
 import { ClampToEdgeWrapping, NearestFilter } from '../constants.js';
 
 /**
@@ -140,24 +141,26 @@ class DataArrayTexture extends Texture {
 		super.copy( source );
 
 		// Clone the TypedArray data to avoid sharing references
+		// Since image is a getter that returns this.source.data, we need to create
+		// a new Source with cloned data to avoid sharing the same source object
 		const image = source.image;
 		if ( image.data !== null ) {
 
-			this.image = {
+			this.source = new Source( {
 				data: image.data.slice(),
 				width: image.width,
 				height: image.height,
 				depth: image.depth
-			};
+			} );
 
 		} else {
 
-			this.image = {
+			this.source = new Source( {
 				data: null,
 				width: image.width,
 				height: image.height,
 				depth: image.depth
-			};
+			} );
 
 		}
 

--- a/src/textures/DataTexture.js
+++ b/src/textures/DataTexture.js
@@ -82,6 +82,40 @@ class DataTexture extends Texture {
 
 	}
 
+	/**
+	 * Copies the values of the given data texture to this instance.
+	 *
+	 * @param {DataTexture} source - The data texture to copy.
+	 * @return {DataTexture} A reference to this instance.
+	 */
+	copy( source ) {
+
+		super.copy( source );
+
+		// Clone the TypedArray data to avoid sharing references
+		const image = source.image;
+		if ( image.data !== null ) {
+
+			this.image = {
+				data: image.data.slice(),
+				width: image.width,
+				height: image.height
+			};
+
+		} else {
+
+			this.image = {
+				data: null,
+				width: image.width,
+				height: image.height
+			};
+
+		}
+
+		return this;
+
+	}
+
 }
 
 export { DataTexture };

--- a/src/textures/DataTexture.js
+++ b/src/textures/DataTexture.js
@@ -75,7 +75,7 @@ class DataTexture extends Texture {
 		 *
 		 * Overwritten and set to `1` by default.
 		 *
-		 * @type {boolean}
+		 * @type {number}
 		 * @default 1
 		 */
 		this.unpackAlignment = 1;

--- a/src/textures/DataTexture.js
+++ b/src/textures/DataTexture.js
@@ -1,4 +1,5 @@
 import { Texture } from './Texture.js';
+import { Source } from './Source.js';
 import { NearestFilter } from '../constants.js';
 
 /**
@@ -93,22 +94,24 @@ class DataTexture extends Texture {
 		super.copy( source );
 
 		// Clone the TypedArray data to avoid sharing references
+		// Since image is a getter that returns this.source.data, we need to create
+		// a new Source with cloned data to avoid sharing the same source object
 		const image = source.image;
 		if ( image.data !== null ) {
 
-			this.image = {
+			this.source = new Source( {
 				data: image.data.slice(),
 				width: image.width,
 				height: image.height
-			};
+			} );
 
 		} else {
 
-			this.image = {
+			this.source = new Source( {
 				data: null,
 				width: image.width,
 				height: image.height
-			};
+			} );
 
 		}
 


### PR DESCRIPTION
## Description

This PR implements proper `copy()` methods for `DataTexture`, `Data3DTexture`, and `DataArrayTexture` classes to fix a bug where copying these textures would share the same TypedArray data instead of creating independent copies.

## Problem

Previously, when calling `copy()` or `clone()` on data texture instances, the base `Texture.copy()` method would set `this.source = source.source`, causing both textures to share the same `Source` object. Since the `image` property is a getter that returns `this.source.data`, both textures ended up sharing the same TypedArray reference. This meant modifications to one texture's data would affect the other.

This bug was being worked around in `BatchedMesh.js` (lines 1462-1471), where developers had to manually call `.slice()` on the data array after cloning:

this._indirectTexture = source._indirectTexture.clone();
this._indirectTexture.image.data = this._indirectTexture.image.data.slice(); // Manual workaround## Solution

This PR adds proper `copy()` method implementations that:
- Create a new `Source` object with cloned TypedArray data using `slice()`
- Preserve all image properties (width, height, depth)
- Handle null data gracefully
- For `DataArrayTexture`, also clone the `layerUpdates` Set

The implementation follows the same pattern used by `DepthTexture.copy()`, which already handles this correctly.

## Changes

- **DataTexture.copy()**: Creates new `Source` with cloned `image.data` TypedArray
- **Data3DTexture.copy()**: Creates new `Source` with cloned `image.data` TypedArray and preserves depth
- **DataArrayTexture.copy()**: Creates new `Source` with cloned `image.data` TypedArray, preserves dimensions, and clones `layerUpdates` Set
- **BatchedMesh.copy()**: Removed manual `.slice()` workarounds since `clone()` now handles data cloning automatically

## Testing

Verified with manual tests:
- Copied textures have independent data arrays (not shared references)
- Modifying one texture's data does not affect the other
- `clone()` method works correctly (uses `copy()` internally)
- Handles null data correctly
- All three texture classes work as expected

## Impact

- Fixes a bug where copied textures shared data references
- Enables proper deep copying behavior consistent with other texture classes
- Removes the need for manual workarounds in code that clones data textures
- Ensures safe independent modification of copied texture data
- Simplifies `BatchedMesh.copy()` by removing manual data cloning workarounds