### PR TITLE
WGSLNodeBuilder: Fix out-of-bounds access with `textureLoad()`.

### DIFF
--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -518,6 +518,7 @@ class WGSLNodeBuilder extends NodeBuilder {
 		const textureDimension = this.generateTextureDimension( texture, textureProperty, levelSnippet );
 
 		const vecType = texture.is3DTexture || texture.isData3DTexture ? 'vec3' : 'vec2';
+		const textureDimensionMargin = ( vecType === 'vec3' ) ? 'vec3<u32>( 1, 1, 1 )' : 'vec2<u32>( 1, 1 )';
 
 		if ( offsetSnippet ) {
 
@@ -525,7 +526,10 @@ class WGSLNodeBuilder extends NodeBuilder {
 
 		}
 
-		uvSnippet = `${ vecType }<u32>( ${ wrapFunction }( ${ uvSnippet } ) * ${ vecType }<f32>( ${ textureDimension } ) )`;
+		const clampMin = `${ vecType }<f32>( 0 )`;
+		const clampMax = `${ vecType }<f32>( ${ textureDimension } - ${ textureDimensionMargin } )`;
+
+		uvSnippet = `${ vecType }<u32>( clamp( floor( ${ wrapFunction }( ${ uvSnippet } ) * ${ vecType }<f32>( ${ textureDimension } ) ), ${ clampMin }, ${ clampMax } ) )`;
 
 		return this.generateTextureLoad( texture, textureProperty, uvSnippet, levelSnippet, depthSnippet, null );
 


### PR DESCRIPTION
Fixed #32708.

**Description**

Second attempt for fixing OOB access in `textureLoad()`. The implementation of the first PR #32817 was wrong. This one follows the standard conversion:

$i = \text{floor}(u \cdot width)$
$j = \text{floor}(v \cdot height)$

A clamp is implemented for the edge case `u` or `v` ends up `1`. This should not map to `width` but to `width - 1`. With these integer coordiantes, the invocation of `textureLoad()` should be spec conform.

@greggman It was pointed out we call `textureLoad()` in the wrong way since we use the result of `textureDimensions()` to convert texture coordinates from `[0,1]` to integer coordinates. However, for a 1024x1024 texture that could mean we produce 1024 as a value for a coordinate which results in a OOB access.

I have discussed this issue with Mike at https://bugs.webkit.org/show_bug.cgi?id=305727 which lead to https://github.com/gpuweb/gpuweb/issues/5523 where you have responded. Does the computation look correct to you? The WGSL node builder essentially implements this pseudo code:
```
int i = clamp(int(u * float(textureWidth)), 0, textureWidth - 1);
int j = clamp(int(v * float(textureHeight)), 0, textureHeight - 1);
```
With this code, we convert like so:

UV Coordinate | Calculation | Integer Coordinate
-- | -- | --
0.0 | $\text{floor}(0.0 \times 1024)$ | 0
0.0005 | $\text{floor}(0.512)$ | 0
0.5 | $\text{floor}(512.0)$ | 512
0.9999 | $\text{floor}(1023.89)$ | 1023
1.0 | $\text{floor}(1024.0)$ | 1023 (Clamped)