### PR TITLE
ColladaLoader: Improve animation support.

### DIFF
--- a/examples/jsm/loaders/collada/ColladaParser.js
+++ b/examples/jsm/loaders/collada/ColladaParser.js
@@ -1763,7 +1763,9 @@ class ColladaParser {
 			instanceLights: [],
 			instanceGeometries: [],
 			instanceNodes: [],
-			transforms: {}
+			transforms: {},
+			transformData: {},
+			transformOrder: []
 		};
 
 		for ( let i = 0; i < xml.childNodes.length; i ++ ) {
@@ -1804,27 +1806,59 @@ class ColladaParser {
 				case 'matrix':
 					array = parseFloats( child.textContent );
 					data.matrix.multiply( matrix.fromArray( array ).transpose() );
-					data.transforms[ child.getAttribute( 'sid' ) ] = child.nodeName;
+					{
+
+						const sid = child.getAttribute( 'sid' );
+						data.transforms[ sid ] = child.nodeName;
+						data.transformData[ sid ] = { type: 'matrix', array: array };
+						data.transformOrder.push( sid );
+
+					}
+
 					break;
 
 				case 'translate':
 					array = parseFloats( child.textContent );
 					vector.fromArray( array );
 					data.matrix.multiply( matrix.makeTranslation( vector.x, vector.y, vector.z ) );
-					data.transforms[ child.getAttribute( 'sid' ) ] = child.nodeName;
+					{
+
+						const sid = child.getAttribute( 'sid' );
+						data.transforms[ sid ] = child.nodeName;
+						data.transformData[ sid ] = { type: 'translate', x: array[ 0 ], y: array[ 1 ], z: array[ 2 ] };
+						data.transformOrder.push( sid );
+
+					}
+
 					break;
 
 				case 'rotate':
 					array = parseFloats( child.textContent );
-					const angle = MathUtils.degToRad( array[ 3 ] );
-					data.matrix.multiply( matrix.makeRotationAxis( vector.fromArray( array ), angle ) );
-					data.transforms[ child.getAttribute( 'sid' ) ] = child.nodeName;
+					{
+
+						const angle = MathUtils.degToRad( array[ 3 ] );
+						data.matrix.multiply( matrix.makeRotationAxis( vector.fromArray( array ), angle ) );
+						const sid = child.getAttribute( 'sid' );
+						data.transforms[ sid ] = child.nodeName;
+						data.transformData[ sid ] = { type: 'rotate', axis: [ array[ 0 ], array[ 1 ], array[ 2 ] ], angle: array[ 3 ] };
+						data.transformOrder.push( sid );
+
+					}
+
 					break;
 
 				case 'scale':
 					array = parseFloats( child.textContent );
 					data.matrix.scale( vector.fromArray( array ) );
-					data.transforms[ child.getAttribute( 'sid' ) ] = child.nodeName;
+					{
+
+						const sid = child.getAttribute( 'sid' );
+						data.transforms[ sid ] = child.nodeName;
+						data.transformData[ sid ] = { type: 'scale', x: array[ 0 ], y: array[ 1 ], z: array[ 2 ] };
+						data.transformOrder.push( sid );
+
+					}
+
 					break;
 
 				case 'extra':


### PR DESCRIPTION
Related issue: #12212 #32829

**Summary**

  - Add support for translate, rotate, and scale animations (previously only matrix animations were supported)                                                                                           
  - Add support for STEP and BEZIER animation interpolation                                            
  - Add support for Maya-style pivot transforms (rotatePivot, scalePivot, etc.)                        
  - Fix animations split across multiple `<animation>` elements not being merged                       
  - Fix rotation composition when multiple rotation transforms exist (rotateX, rotateY, rotateZ)                                     
                                                                                                       
**Details**

Previously, the loader only supported matrix-based animations. Attempting to load COLLADA files with translate, rotate, or scale animations would log warnings and the animations would be ignored.       
                                                                                                       
This PR adds dedicated track builders for each transform type:                                       
  - `buildTranslateTrack()` - handles `translate.X/Y/Z` component animations                           
  - `buildRotateTrack()` - handles `rotate.ANGLE` with proper multi-axis quaternion composition        
  - `buildScaleTrack()` - handles `scale.X/Y/Z` component animations                                   
  - `buildMatrixTracks()` - refactored matrix animation handling                                       
                                                                                                       
For nodes with Maya-style pivot transforms, a two-phase approach is used: animation channels are collected first, then tracks are built after the transform hierarchy is available.                   
                                                                                                       
These changes bring the loader closer to full COLLADA 1.4 specification compliance for animations.

https://github.com/user-attachments/assets/20a7bce0-c74c-4a0d-b3bd-62e7da8a3449

Feels good to be able to see [pump.dae](https://github.com/mrdoob/three.js/tree/dev/examples/models/collada/pump) again 10 years later 🥲
