### PR TITLE
WebGLRenderer: Force flat shading for geometries without normals. 

### DIFF
--- a/examples/webgl_loader_collada_kinematics.html
+++ b/examples/webgl_loader_collada_kinematics.html
@@ -44,17 +44,6 @@
 
 				dae = collada.scene;
 
-				dae.traverse( function ( child ) {
-
-					if ( child.isMesh ) {
-
-						// model does not have normals
-						child.material.flatShading = true;
-
-					}
-
-				} );
-
 				dae.scale.x = dae.scale.y = dae.scale.z = 10.0;
 				dae.updateMatrix();
 

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -303,7 +303,12 @@ function WebGLPrograms( renderer, environments, extensions, capabilities, bindin
 			useFog: material.fog === true,
 			fogExp2: ( !! fog && fog.isFogExp2 ),
 
-			flatShading: ( material.flatShading === true && material.wireframe === false ),
+			flatShading: material.wireframe === false && (
+				material.flatShading === true ||
+				( geometry.attributes.normal === undefined &&
+					( material.isMeshLambertMaterial || material.isMeshPhongMaterial || material.isMeshStandardMaterial || material.isMeshPhysicalMaterial )
+				)
+			),
 
 			sizeAttenuation: material.sizeAttenuation === true,
 			logarithmicDepthBuffer: logarithmicDepthBuffer,

--- a/src/renderers/webgl/WebGLPrograms.js
+++ b/src/renderers/webgl/WebGLPrograms.js
@@ -305,7 +305,7 @@ function WebGLPrograms( renderer, environments, extensions, capabilities, bindin
 
 			flatShading: material.wireframe === false && (
 				material.flatShading === true ||
-				( geometry.attributes.normal === undefined &&
+				( geometry.attributes.normal === undefined && HAS_NORMALMAP === false &&
 					( material.isMeshLambertMaterial || material.isMeshPhongMaterial || material.isMeshStandardMaterial || material.isMeshPhysicalMaterial )
 				)
 			),


### PR DESCRIPTION
**Description**

Previously, geometries without normals would render black with materials that require normals for lighting calculations. Users had to manually set `material.flatShading = true` or call `geometry.computeVertexNormals()` as a workaround.
                                     
The renderer now detects this case and automatically uses flat shading, which computes normals from screen-space derivatives in the fragment shader.