### PR TITLE
WebGLState: Fix polygon offset with reversed depth buffer.

### DIFF
--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -876,10 +876,16 @@ function WebGLState( gl, extensions ) {
 
 			if ( currentPolygonOffsetFactor !== factor || currentPolygonOffsetUnits !== units ) {
 
-				gl.polygonOffset( factor, units );
-
 				currentPolygonOffsetFactor = factor;
 				currentPolygonOffsetUnits = units;
+
+				if ( depthBuffer.getReversed() ) {
+
+					factor = - factor;
+
+				}
+
+				gl.polygonOffset( factor, units );
 
 			}
 


### PR DESCRIPTION
Fixed #32827.

**Description**

As suggested in https://github.com/mrdoob/three.js/issues/32827#issuecomment-3787726034, `polygonOffsetFactor` is negated (similar to shadow bias) when reversed depth buffer is enabled.