### PR TITLE
WebGPURenderer: Optimize chain key array reset.

### DIFF
--- a/src/renderers/common/RenderBundles.js
+++ b/src/renderers/common/RenderBundles.js
@@ -47,7 +47,8 @@ class RenderBundles {
 
 		}
 
-		_chainKeys.length = 0;
+		_chainKeys[ 0 ] = null;
+		_chainKeys[ 1 ] = null;
 
 		return bundle;
 

--- a/src/renderers/common/RenderLists.js
+++ b/src/renderers/common/RenderLists.js
@@ -57,7 +57,8 @@ class RenderLists {
 
 		}
 
-		_chainKeys.length = 0;
+		_chainKeys[ 0 ] = null;
+		_chainKeys[ 1 ] = null;
 
 		return list;
 

--- a/src/renderers/common/nodes/NodeManager.js
+++ b/src/renderers/common/nodes/NodeManager.js
@@ -147,7 +147,8 @@ class NodeManager extends DataMap {
 		let groupData = this.groupsData.get( _chainKeys );
 		if ( groupData === undefined ) this.groupsData.set( _chainKeys, groupData = {} );
 
-		_chainKeys.length = 0;
+		_chainKeys[ 0 ] = null;
+		_chainKeys[ 1 ] = null;
 
 		if ( groupData.version !== groupNode.version ) {
 
@@ -444,7 +445,8 @@ class NodeManager extends DataMap {
 
 		}
 
-		_chainKeys.length = 0;
+		_chainKeys[ 0 ] = null;
+		_chainKeys[ 1 ] = null;
 
 		return cacheKeyData.cacheKey;
 


### PR DESCRIPTION
Related issue: #32675

**Description**

The PR adapts the approach for resetting the chain key array of `RenderObjects.get()` to other places of `WebGPURenderer`. Instead of setting the array's `length` property to `0` which triggers a resize, the key entries are set to `null` instead. This actually improves performance a bit since the length of the array is kept static. In the performance stress test of #32675, I get around 0.5%-0.75% less CPU load (monitored with Chrome Task Manager). That doesn't sound  like much but even minor optimizations can accumulate^^.
