### PR TITLE
Editor: Fix camera move error

### DIFF
--- a/editor/js/Viewport.Controls.js
+++ b/editor/js/Viewport.Controls.js
@@ -28,7 +28,7 @@ function ViewportControls( editor ) {
 
 		if ( object.isCamera ) {
 
-			update();
+			update( false );
 
 		}
 
@@ -61,7 +61,7 @@ function ViewportControls( editor ) {
 
 	//
 
-	function update() {
+	function update( effect = true ) {
 
 		const options = {};
 
@@ -81,7 +81,7 @@ function ViewportControls( editor ) {
 			: editor.camera;
 
 		cameraSelect.setValue( selectedCamera.uuid );
-		editor.setViewportCamera( selectedCamera.uuid );
+		if ( effect ) editor.setViewportCamera( selectedCamera.uuid );
 
 	}
 


### PR DESCRIPTION
Related issue: #XXXX

**Description**

Reproduction steps

1. Click the `menubar/add/camera/perspective` or `menubar/add/camera/orthographic` button
2. Move the `camera` object, and the view will rotate accordingly.
