### PR TITLE
Editor: Add morph target support.

### DIFF
--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -35,8 +35,6 @@ function Editor() {
 
 		// notifications
 
-		animationsUpdated: new Signal(),
-
 		editorCleared: new Signal(),
 
 		savingStarted: new Signal(),
@@ -94,6 +92,9 @@ function Editor() {
 		intersectionsDetected: new Signal(),
 
 		pathTracerUpdated: new Signal(),
+
+		morphTargetsUpdated: new Signal()
+
 
 	};
 

--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -35,6 +35,8 @@ function Editor() {
 
 		// notifications
 
+		animationsUpdated: new Signal(),
+
 		editorCleared: new Signal(),
 
 		savingStarted: new Signal(),

--- a/editor/js/Sidebar.Geometry.js
+++ b/editor/js/Sidebar.Geometry.js
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 
-import { UIPanel, UIRow, UIText, UIInput, UIButton, UISpan, UITextArea } from './libs/ui.js';
+import { UIPanel, UIRow, UIText, UIInput, UIButton, UISpan, UITextArea, UINumber, UIDiv, UIBreak } from './libs/ui.js';
 
 import { SetGeometryValueCommand } from './commands/SetGeometryValueCommand.js';
 
@@ -244,6 +244,20 @@ function SidebarGeometry( editor ) {
 	} );
 	container.add( exportJson );
 
+	// Morph Targets
+
+	const morphContainer = new UIDiv();
+	morphContainer.setMarginTop( '20px' );
+	morphContainer.setDisplay( 'none' );
+	container.add( morphContainer );
+
+	morphContainer.add( new UIText( strings.getKey( 'sidebar/geometry/morph' ) ).setTextTransform( 'uppercase' ) );
+	morphContainer.add( new UIBreak() );
+	morphContainer.add( new UIBreak() );
+
+	const morphList = new UIDiv();
+	morphContainer.add( morphList );
+
 	//
 
 	async function build() {
@@ -307,9 +321,73 @@ function SidebarGeometry( editor ) {
 
 			}
 
-		} else {
+			//
 
-			container.setDisplay( 'none' );
+			morphUIElements.length = 0;
+			morphList.clear();
+
+			if ( object.morphTargetInfluences ) {
+
+				const morphTargetDictionary = object.morphTargetDictionary;
+				const morphTargetInfluences = object.morphTargetInfluences;
+				const morphNames = Object.keys( morphTargetDictionary );
+
+				for ( let i = 0; i < morphNames.length; i ++ ) {
+
+					const name = morphNames[ i ];
+					morphList.add( new Morph( i, name, morphTargetInfluences ) );
+
+				}
+
+				morphContainer.setDisplay( '' );
+
+			} else {
+
+				morphContainer.setDisplay( 'none' );
+
+			}
+
+		}
+
+	}
+
+	const morphUIElements = [];
+
+	function Morph( index, name, morphTargetInfluences ) {
+
+		const container = new UIRow();
+
+		const morphName = new UIText( name ).setWidth( '200px' );
+		container.add( morphName );
+
+		const morphInfluence = new UINumber().setWidth( '60px' ).setRange( 0, 1 ).onChange( function updateMorphInfluence() {
+
+			morphTargetInfluences[ index ] = morphInfluence.getValue();
+			signals.objectChanged.dispatch( editor.selected );
+
+		} );
+		morphInfluence.setValue( morphTargetInfluences[ index ] );
+
+		container.add( morphInfluence );
+		morphUIElements.push( morphInfluence );
+
+		return container;
+
+	}
+
+
+	function refreshUI() {
+
+		const object = editor.selected;
+
+		if ( object !== null && object.morphTargetInfluences ) {
+
+			for ( let i = 0; i < morphUIElements.length; i ++ ) {
+
+				const element = morphUIElements[ i ];
+				element.setValue( object.morphTargetInfluences[ i ] );
+
+			}
 
 		}
 
@@ -324,6 +402,7 @@ function SidebarGeometry( editor ) {
 	} );
 
 	signals.geometryChanged.add( build );
+	signals.morphTargetsUpdated.add( refreshUI );
 
 	return container;
 

--- a/editor/js/Sidebar.Object.Animation.js
+++ b/editor/js/Sidebar.Object.Animation.js
@@ -132,7 +132,7 @@ function SidebarObjectAnimation( editor ) {
 
 	} );
 
-	signals.animationsUpdated.add( function () {
+	signals.morphTargetsUpdated.add( function () {
 
 		// refresh UI
 

--- a/editor/js/Sidebar.Object.Animation.js
+++ b/editor/js/Sidebar.Object.Animation.js
@@ -1,4 +1,4 @@
-import { UIButton, UIDiv, UIText, UINumber, UIRow, UITabbedPanel, UIPanel } from './libs/ui.js';
+import { UIBreak, UIButton, UIDiv, UIText, UINumber, UIRow } from './libs/ui.js';
 
 function SidebarObjectAnimation( editor ) {
 
@@ -37,82 +37,21 @@ function SidebarObjectAnimation( editor ) {
 
 	}
 
-	const morphsUIElements = [];
-
-	function Morph( index, name, morphTargetInfluences ) {
-
-		const container = new UIRow();
-
-		const morphName = new UIText( name ).setWidth( '200px' );
-		container.add( morphName );
-
-		const morphInfluence = new UINumber().setWidth( '60px' ).setRange( 0, 1 ).onChange( function updateMorphInfluence() {
-
-			morphTargetInfluences[ index ] = morphInfluence.getValue();
-			signals.objectChanged.dispatch( editor.selected );
-
-		} );
-		morphInfluence.setValue( morphTargetInfluences[ index ] );
-
-		container.add( morphInfluence );
-		morphsUIElements.push( morphInfluence );
-
-		return container;
-
-	}
-
 	signals.objectSelected.add( function ( object ) {
 
-		animationsList.clear();
-		morphsList.clear();
-		morphsUIElements.length = 0;
+		if ( object !== null && object.animations.length > 0 ) {
 
-		clipsTab.setDisplay( 'none' );
-		morphsTab.setDisplay( 'none' );
+			animationsList.clear();
 
-		if ( object !== null ) {
+			const animations = object.animations;
 
-			let hasAnimations = false;
-			let hasMorphs = false;
+			for ( const animation of animations ) {
 
-			if ( object.animations.length > 0 ) {
-
-				hasAnimations = true;
-
-				const animations = object.animations;
-
-				for ( const animation of animations ) {
-
-					animationsList.add( new Animation( animation, object ) );
-
-				}
-
-				clipsTab.setDisplay( '' );
+				animationsList.add( new Animation( animation, object ) );
 
 			}
 
-			if ( object.morphTargetInfluences ) {
-
-				hasMorphs = true;
-
-				const morphTargetDictionary = object.morphTargetDictionary;
-				const morphTargetInfluences = object.morphTargetInfluences;
-				const morphNames = Object.keys( morphTargetDictionary );
-
-				for ( let i = 0; i < morphNames.length; i ++ ) {
-
-					const name = morphNames[ i ];
-
-					morphsList.add( new Morph( i, name, morphTargetInfluences ) );
-
-				}
-
-				morphsTab.setDisplay( '' );
-
-			}
-
-			if ( hasAnimations || hasMorphs ) container.setDisplay( '' );
-
+			container.setDisplay( '' );
 
 		} else {
 
@@ -132,39 +71,16 @@ function SidebarObjectAnimation( editor ) {
 
 	} );
 
-	signals.morphTargetsUpdated.add( function () {
-
-		// refresh UI
-
-		const object = editor.selected;
-
-		if ( object !== null && object.morphTargetInfluences ) {
-
-			for ( let i = 0; i < morphsUIElements.length; i ++ ) {
-
-				const element = morphsUIElements[ i ];
-				element.setValue( object.morphTargetInfluences[ i ] );
-
-			}
-
-		}
-
-	} );
-
-	const container = new UITabbedPanel();
+	const container = new UIDiv();
 	container.setMarginTop( '20px' );
+	container.setDisplay( 'none' );
 
-	const clipsTab = new UIPanel();
-	const morphsTab = new UIPanel();
-
-	container.addTab( 'clips', strings.getKey( 'sidebar/objects/animations/clips' ), clipsTab );
-	container.addTab( 'morphs', strings.getKey( 'sidebar/objects/animations/morphs' ), morphsTab );
+	container.add( new UIText( strings.getKey( 'sidebar/animations' ) ).setTextTransform( 'uppercase' ) );
+	container.add( new UIBreak() );
+	container.add( new UIBreak() );
 
 	const animationsList = new UIDiv();
-	clipsTab.add( animationsList );
-
-	const morphsList = new UIDiv();
-	morphsTab.add( morphsList );
+	container.add( animationsList );
 
 	const mixerTimeScaleRow = new UIRow();
 	const mixerTimeScaleNumber = new UINumber( 1 ).setWidth( '60px' ).setRange( - 10, 10 );
@@ -177,9 +93,7 @@ function SidebarObjectAnimation( editor ) {
 	mixerTimeScaleRow.add( new UIText( strings.getKey( 'sidebar/animations/timescale' ) ).setClass( 'Label' ) );
 	mixerTimeScaleRow.add( mixerTimeScaleNumber );
 
-	clipsTab.add( mixerTimeScaleRow );
-
-	container.select( 'clips' );
+	container.add( mixerTimeScaleRow );
 
 	return container;
 

--- a/editor/js/Sidebar.Object.Animation.js
+++ b/editor/js/Sidebar.Object.Animation.js
@@ -1,4 +1,4 @@
-import { UIBreak, UIButton, UIDiv, UIText, UINumber, UIRow } from './libs/ui.js';
+import { UIButton, UIDiv, UIText, UINumber, UIRow, UITabbedPanel, UIPanel } from './libs/ui.js';
 
 function SidebarObjectAnimation( editor ) {
 
@@ -37,21 +37,82 @@ function SidebarObjectAnimation( editor ) {
 
 	}
 
+	const morphsUIElements = [];
+
+	function Morph( index, name, morphTargetInfluences ) {
+
+		const container = new UIRow();
+
+		const morphName = new UIText( name ).setWidth( '200px' );
+		container.add( morphName );
+
+		const morphInfluence = new UINumber().setWidth( '60px' ).setRange( 0, 1 ).onChange( function updateMorphInfluence() {
+
+			morphTargetInfluences[ index ] = morphInfluence.getValue();
+			signals.objectChanged.dispatch( editor.selected );
+
+		} );
+		morphInfluence.setValue( morphTargetInfluences[ index ] );
+
+		container.add( morphInfluence );
+		morphsUIElements.push( morphInfluence );
+
+		return container;
+
+	}
+
 	signals.objectSelected.add( function ( object ) {
 
-		if ( object !== null && object.animations.length > 0 ) {
+		animationsList.clear();
+		morphsList.clear();
+		morphsUIElements.length = 0;
 
-			animationsList.clear();
+		clipsTab.setDisplay( 'none' );
+		morphsTab.setDisplay( 'none' );
 
-			const animations = object.animations;
+		if ( object !== null ) {
 
-			for ( const animation of animations ) {
+			let hasAnimations = false;
+			let hasMorphs = false;
 
-				animationsList.add( new Animation( animation, object ) );
+			if ( object.animations.length > 0 ) {
+
+				hasAnimations = true;
+
+				const animations = object.animations;
+
+				for ( const animation of animations ) {
+
+					animationsList.add( new Animation( animation, object ) );
+
+				}
+
+				clipsTab.setDisplay( '' );
 
 			}
 
-			container.setDisplay( '' );
+			if ( object.morphTargetInfluences ) {
+
+				hasMorphs = true;
+
+				const morphTargetDictionary = object.morphTargetDictionary;
+				const morphTargetInfluences = object.morphTargetInfluences;
+				const morphNames = Object.keys( morphTargetDictionary );
+
+				for ( let i = 0; i < morphNames.length; i ++ ) {
+
+					const name = morphNames[ i ];
+
+					morphsList.add( new Morph( i, name, morphTargetInfluences ) );
+
+				}
+
+				morphsTab.setDisplay( '' );
+
+			}
+
+			if ( hasAnimations || hasMorphs ) container.setDisplay( '' );
+
 
 		} else {
 
@@ -71,16 +132,39 @@ function SidebarObjectAnimation( editor ) {
 
 	} );
 
-	const container = new UIDiv();
-	container.setMarginTop( '20px' );
-	container.setDisplay( 'none' );
+	signals.animationsUpdated.add( function () {
 
-	container.add( new UIText( strings.getKey( 'sidebar/animations' ) ).setTextTransform( 'uppercase' ) );
-	container.add( new UIBreak() );
-	container.add( new UIBreak() );
+		// refresh UI
+
+		const object = editor.selected;
+
+		if ( object !== null && object.morphTargetInfluences ) {
+
+			for ( let i = 0; i < morphsUIElements.length; i ++ ) {
+
+				const element = morphsUIElements[ i ];
+				element.setValue( object.morphTargetInfluences[ i ] );
+
+			}
+
+		}
+
+	} );
+
+	const container = new UITabbedPanel();
+	container.setMarginTop( '20px' );
+
+	const clipsTab = new UIPanel();
+	const morphsTab = new UIPanel();
+
+	container.addTab( 'clips', strings.getKey( 'sidebar/objects/animations/clips' ), clipsTab );
+	container.addTab( 'morphs', strings.getKey( 'sidebar/objects/animations/morphs' ), morphsTab );
 
 	const animationsList = new UIDiv();
-	container.add( animationsList );
+	clipsTab.add( animationsList );
+
+	const morphsList = new UIDiv();
+	morphsTab.add( morphsList );
 
 	const mixerTimeScaleRow = new UIRow();
 	const mixerTimeScaleNumber = new UINumber( 1 ).setWidth( '60px' ).setRange( - 10, 10 );
@@ -93,7 +177,9 @@ function SidebarObjectAnimation( editor ) {
 	mixerTimeScaleRow.add( new UIText( strings.getKey( 'sidebar/animations/timescale' ) ).setClass( 'Label' ) );
 	mixerTimeScaleRow.add( mixerTimeScaleNumber );
 
-	container.add( mixerTimeScaleRow );
+	clipsTab.add( mixerTimeScaleRow );
+
+	container.select( 'clips' );
 
 	return container;
 

--- a/editor/js/Strings.js
+++ b/editor/js/Strings.js
@@ -159,6 +159,8 @@ function Strings( config ) {
 			'sidebar/object/renderorder': 'ترتیب رندر',
 			'sidebar/object/userdata': 'داده کاربر',
 			'sidebar/object/export': 'اکسپورت جیسون',
+			'sidebar/objects/animations/clips': 'Animation Clips',
+			'sidebar/objects/animations/morphs': 'Morph Targets',
 
 			'sidebar/geometry/type': 'انواع',
 			'sidebar/geometry/new': 'جدید',
@@ -574,6 +576,8 @@ function Strings( config ) {
 			'sidebar/object/renderorder': 'Render Order',
 			'sidebar/object/userdata': 'User data',
 			'sidebar/object/export': 'Export JSON',
+			'sidebar/objects/animations/clips': 'Animation Clips',
+			'sidebar/objects/animations/morphs': 'Morph Targets',
 
 			'sidebar/geometry/type': 'Type',
 			'sidebar/geometry/new': 'New',
@@ -990,6 +994,8 @@ function Strings( config ) {
 			'sidebar/object/renderorder': 'Ordre de rendus',
 			'sidebar/object/userdata': 'Données utilisateur',
 			'sidebar/object/export': 'Exporter JSON',
+			'sidebar/objects/animations/clips': 'Animation Clips',
+			'sidebar/objects/animations/morphs': 'Morph Targets',
 
 			'sidebar/geometry/type': 'Type',
 			'sidebar/geometry/new': 'Nouveau',
@@ -1406,6 +1412,8 @@ function Strings( config ) {
 			'sidebar/object/renderorder': '渲染次序',
 			'sidebar/object/userdata': '自定义数据',
 			'sidebar/object/export': '导出JSON',
+			'sidebar/objects/animations/clips': 'Animation Clips',
+			'sidebar/objects/animations/morphs': 'Morph Targets',
 
 			'sidebar/geometry/type': '类型',
 			'sidebar/geometry/new': '更新',
@@ -1822,6 +1830,8 @@ function Strings( config ) {
 			'sidebar/object/renderorder': '描画順序',
 			'sidebar/object/userdata': 'ユーザーデータ',
 			'sidebar/object/export': 'JSONをエクスポート',
+			'sidebar/objects/animations/clips': 'Animation Clips',
+			'sidebar/objects/animations/morphs': 'Morph Targets',
 
 			'sidebar/geometry/type': 'タイプ',
 			'sidebar/geometry/new': '新規',
@@ -2237,6 +2247,8 @@ function Strings( config ) {
 			'sidebar/object/renderorder': '렌더 순서',
 			'sidebar/object/userdata': '사용자 데이터',
 			'sidebar/object/export': 'JSON으로 내보내기',
+			'sidebar/objects/animations/clips': 'Animation Clips',
+			'sidebar/objects/animations/morphs': 'Morph Targets',
 
 			'sidebar/geometry/type': '타입',
 			'sidebar/geometry/new': '새로 만들기',

--- a/editor/js/Strings.js
+++ b/editor/js/Strings.js
@@ -159,8 +159,6 @@ function Strings( config ) {
 			'sidebar/object/renderorder': 'ترتیب رندر',
 			'sidebar/object/userdata': 'داده کاربر',
 			'sidebar/object/export': 'اکسپورت جیسون',
-			'sidebar/objects/animations/clips': 'Animation Clips',
-			'sidebar/objects/animations/morphs': 'Morph Targets',
 
 			'sidebar/geometry/type': 'انواع',
 			'sidebar/geometry/new': 'جدید',
@@ -173,6 +171,7 @@ function Strings( config ) {
 			'sidebar/geometry/compute_vertex_tangents': 'محاسبه مماس ها',
 			'sidebar/geometry/center': 'وسط',
 			'sidebar/geometry/export': 'اکسپورت جیسون',
+			'sidebar/geometry/morph': 'Morph Targets',
 
 			'sidebar/geometry/box_geometry/width': 'عرض',
 			'sidebar/geometry/box_geometry/height': 'ارتفاع',
@@ -353,6 +352,7 @@ function Strings( config ) {
 			'sidebar/script/remove': 'حذف',
 
 			'sidebar/project': 'پروژه ها',
+			'sidebar/project/renderer': 'رندرر',
 			'sidebar/project/antialias': 'آنتی الآیس',
 			'sidebar/project/shadows': 'سایه ها',
 			'sidebar/project/toneMapping': 'تون مپینگ',
@@ -576,8 +576,6 @@ function Strings( config ) {
 			'sidebar/object/renderorder': 'Render Order',
 			'sidebar/object/userdata': 'User data',
 			'sidebar/object/export': 'Export JSON',
-			'sidebar/objects/animations/clips': 'Animation Clips',
-			'sidebar/objects/animations/morphs': 'Morph Targets',
 
 			'sidebar/geometry/type': 'Type',
 			'sidebar/geometry/new': 'New',
@@ -590,6 +588,7 @@ function Strings( config ) {
 			'sidebar/geometry/compute_vertex_tangents': 'Compute Tangents',
 			'sidebar/geometry/center': 'Center',
 			'sidebar/geometry/export': 'Export JSON',
+			'sidebar/geometry/morph': 'Morph Targets',
 
 			'sidebar/geometry/box_geometry/width': 'Width',
 			'sidebar/geometry/box_geometry/height': 'Height',
@@ -770,6 +769,7 @@ function Strings( config ) {
 			'sidebar/script/remove': 'Remove',
 
 			'sidebar/project': 'Project',
+			'sidebar/project/renderer': 'Renderer',
 			'sidebar/project/antialias': 'Antialias',
 			'sidebar/project/shadows': 'Shadows',
 			'sidebar/project/toneMapping': 'Tonemapping',
@@ -994,8 +994,6 @@ function Strings( config ) {
 			'sidebar/object/renderorder': 'Ordre de rendus',
 			'sidebar/object/userdata': 'Données utilisateur',
 			'sidebar/object/export': 'Exporter JSON',
-			'sidebar/objects/animations/clips': 'Animation Clips',
-			'sidebar/objects/animations/morphs': 'Morph Targets',
 
 			'sidebar/geometry/type': 'Type',
 			'sidebar/geometry/new': 'Nouveau',
@@ -1008,6 +1006,7 @@ function Strings( config ) {
 			'sidebar/geometry/compute_vertex_tangents': 'Compute Tangents',
 			'sidebar/geometry/center': 'Center',
 			'sidebar/geometry/export': 'Exporter JSON',
+			'sidebar/geometry/morph': 'Morph Targets',
 
 			'sidebar/geometry/box_geometry/width': 'Largeur',
 			'sidebar/geometry/box_geometry/height': 'Hauteur',
@@ -1188,6 +1187,7 @@ function Strings( config ) {
 			'sidebar/script/remove': 'Supprimer',
 
 			'sidebar/project': 'Projet',
+			'sidebar/project/renderer': 'Moteur',
 			'sidebar/project/antialias': 'Anticrénelage',
 			'sidebar/project/shadows': 'Ombres',
 			'sidebar/project/toneMapping': 'Mappage des nuances',
@@ -1412,8 +1412,6 @@ function Strings( config ) {
 			'sidebar/object/renderorder': '渲染次序',
 			'sidebar/object/userdata': '自定义数据',
 			'sidebar/object/export': '导出JSON',
-			'sidebar/objects/animations/clips': 'Animation Clips',
-			'sidebar/objects/animations/morphs': 'Morph Targets',
 
 			'sidebar/geometry/type': '类型',
 			'sidebar/geometry/new': '更新',
@@ -1426,6 +1424,7 @@ function Strings( config ) {
 			'sidebar/geometry/compute_vertex_tangents': '计算切线',
 			'sidebar/geometry/center': '居中',
 			'sidebar/geometry/export': '导出JSON',
+			'sidebar/geometry/morph': 'Morph Targets',
 
 			'sidebar/geometry/box_geometry/width': '宽度',
 			'sidebar/geometry/box_geometry/height': '高度',
@@ -1606,6 +1605,7 @@ function Strings( config ) {
 			'sidebar/script/remove': '删除',
 
 			'sidebar/project': '项目',
+			'sidebar/project/renderer': '渲染器',
 			'sidebar/project/antialias': '抗锯齿',
 			'sidebar/project/shadows': '阴影',
 			'sidebar/project/toneMapping': '色调映射',
@@ -1830,8 +1830,6 @@ function Strings( config ) {
 			'sidebar/object/renderorder': '描画順序',
 			'sidebar/object/userdata': 'ユーザーデータ',
 			'sidebar/object/export': 'JSONをエクスポート',
-			'sidebar/objects/animations/clips': 'Animation Clips',
-			'sidebar/objects/animations/morphs': 'Morph Targets',
 
 			'sidebar/geometry/type': 'タイプ',
 			'sidebar/geometry/new': '新規',
@@ -1844,6 +1842,7 @@ function Strings( config ) {
 			'sidebar/geometry/compute_vertex_tangents': '接線を計算',
 			'sidebar/geometry/center': '中央',
 			'sidebar/geometry/export': 'JSONをエクスポート',
+			'sidebar/geometry/morph': 'Morph Targets',
 
 			'sidebar/geometry/box_geometry/width': '幅',
 			'sidebar/geometry/box_geometry/height': '高さ',
@@ -2024,6 +2023,7 @@ function Strings( config ) {
 			'sidebar/script/remove': '削除',
 
 			'sidebar/project': 'プロジェクト',
+			'sidebar/project/renderer': 'レンダラー',
 			'sidebar/project/antialias': 'アンチエイリアス',
 			'sidebar/project/shadows': 'シャドウ',
 			'sidebar/project/toneMapping': 'トーンマッピング',
@@ -2247,8 +2247,6 @@ function Strings( config ) {
 			'sidebar/object/renderorder': '렌더 순서',
 			'sidebar/object/userdata': '사용자 데이터',
 			'sidebar/object/export': 'JSON으로 내보내기',
-			'sidebar/objects/animations/clips': 'Animation Clips',
-			'sidebar/objects/animations/morphs': 'Morph Targets',
 
 			'sidebar/geometry/type': '타입',
 			'sidebar/geometry/new': '새로 만들기',
@@ -2261,6 +2259,7 @@ function Strings( config ) {
 			'sidebar/geometry/compute_vertex_tangents': '접선 계산',
 			'sidebar/geometry/center': '중앙',
 			'sidebar/geometry/export': 'JSON으로 내보내기',
+			'sidebar/geometry/morph': 'Morph Targets',
 
 			'sidebar/geometry/box_geometry/width': '너비',
 			'sidebar/geometry/box_geometry/height': '높이',
@@ -2441,6 +2440,7 @@ function Strings( config ) {
 			'sidebar/script/remove': '삭제',
 
 			'sidebar/project': '프로젝트',
+			'sidebar/project/renderer': '렌더러',
 			'sidebar/project/antialias': '안티앨리어싱',
 			'sidebar/project/shadows': '그림자',
 			'sidebar/project/toneMapping': '톤 매핑',

--- a/editor/js/Viewport.js
+++ b/editor/js/Viewport.js
@@ -806,6 +806,8 @@ function Viewport( editor ) {
 
 			}
 
+			signals.animationsUpdated.dispatch();
+
 		}
 
 		// View Helper

--- a/editor/js/Viewport.js
+++ b/editor/js/Viewport.js
@@ -806,7 +806,7 @@ function Viewport( editor ) {
 
 			}
 
-			signals.animationsUpdated.dispatch();
+			signals.morphTargetsUpdated.dispatch();
 
 		}
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -1314,6 +1314,9 @@ class Object3D extends EventDispatcher {
 
 		if ( this.matrixAutoUpdate === false ) object.matrixAutoUpdate = false;
 
+		if ( this.morphTargetDictionary !== undefined ) object.morphTargetDictionary = Object.assign( {}, this.morphTargetDictionary );
+		if ( this.morphTargetInfluences !== undefined ) object.morphTargetInfluences = this.morphTargetInfluences.slice();
+
 		// object specific properties
 
 		if ( this.isInstancedMesh ) {

--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -1117,6 +1117,9 @@ class ObjectLoader extends Loader {
 
 		if ( data.pivot !== undefined ) object.pivot = new Vector3().fromArray( data.pivot );
 
+		if ( data.morphTargetDictionary !== undefined ) object.morphTargetDictionary = Object.assign( {}, data.morphTargetDictionary );
+		if ( data.morphTargetInfluences !== undefined ) object.morphTargetInfluences = data.morphTargetInfluences.slice();
+
 		if ( data.castShadow !== undefined ) object.castShadow = data.castShadow;
 		if ( data.receiveShadow !== undefined ) object.receiveShadow = data.receiveShadow;
 


### PR DESCRIPTION
Fixed #31049.

**Description**

I've thought #31049 would be an ideal AI coding task so I gave it a go. When testing, I've realized we need two more things to make the UI for morph targets work as intended.

- `morphTargetInfluences` and `morphTargetDictionary` must be serialized/deserialized. Normally, we derive the `name` data from morph target attributes, but `GLTFLoader` treats the morph target names as extra data of meshes. So both properties must be saved/restored otherwise the names and the influence state are lost.
- When playing an animation, the morph target UI should be updated to reflect the current values. For that a new signal `animationsUpdated` was added.


https://github.com/user-attachments/assets/f92af69f-eec0-4b78-81b6-2f188d41e058
