### PR TITLE
TSL: Force flat shading for geometries without normals for `normal*` nodes

### DIFF
--- a/src/nodes/accessors/Bitangent.js
+++ b/src/nodes/accessors/Bitangent.js
@@ -13,11 +13,11 @@ import { directionToFaceDirection } from '../display/FrontFacingNode.js';
  * @param {string} varyingName - The name of the varying to assign the bitangent to.
  * @returns {Node<vec3>} The bitangent node.
  */
-const getBitangent = /*@__PURE__*/ Fn( ( [ crossNormalTangent, varyingName ], { subBuildFn, material } ) => {
+const getBitangent = /*@__PURE__*/ Fn( ( [ crossNormalTangent, varyingName ], builder ) => {
 
 	let bitangent = crossNormalTangent.mul( tangentGeometry.w ).xyz;
 
-	if ( subBuildFn === 'NORMAL' && material.flatShading !== true ) {
+	if ( builder.subBuildFn === 'NORMAL' && builder.isFlatShading() !== true ) {
 
 		bitangent = bitangent.toVarying( varyingName );
 
@@ -49,11 +49,11 @@ export const bitangentLocal = /*@__PURE__*/ getBitangent( normalLocal.cross( tan
  * @tsl
  * @type {Node<vec3>}
  */
-export const bitangentView = /*@__PURE__*/ ( Fn( ( { subBuildFn, geometry, material } ) => {
+export const bitangentView = /*@__PURE__*/ ( Fn( ( builder ) => {
 
 	let node;
 
-	if ( subBuildFn === 'VERTEX' || geometry.hasAttribute( 'tangent' ) ) {
+	if ( builder.subBuildFn === 'VERTEX' || builder.geometry.hasAttribute( 'tangent' ) ) {
 
 		node = getBitangent( normalView.cross( tangentView ), 'v_bitangentView' ).normalize();
 
@@ -63,7 +63,7 @@ export const bitangentView = /*@__PURE__*/ ( Fn( ( { subBuildFn, geometry, mater
 
 	}
 
-	if ( material.flatShading !== true ) {
+	if ( builder.isFlatShading() !== true ) {
 
 		node = directionToFaceDirection( node );
 

--- a/src/nodes/accessors/Normal.js
+++ b/src/nodes/accessors/Normal.js
@@ -52,7 +52,7 @@ export const normalViewGeometry = /*@__PURE__*/ ( Fn( ( builder ) => {
 
 	let node;
 
-	if ( builder.material.flatShading === true ) {
+	if ( builder.material.flatShading === true || builder.geometry.hasAttribute( 'normal' ) === false ) {
 
 		node = normalFlat;
 

--- a/src/nodes/accessors/Normal.js
+++ b/src/nodes/accessors/Normal.js
@@ -52,7 +52,7 @@ export const normalViewGeometry = /*@__PURE__*/ ( Fn( ( builder ) => {
 
 	let node;
 
-	if ( builder.material.flatShading === true || builder.geometry.hasAttribute( 'normal' ) === false ) {
+	if ( builder.isFlatShading() ) {
 
 		node = normalFlat;
 
@@ -76,7 +76,7 @@ export const normalWorldGeometry = /*@__PURE__*/ ( Fn( ( builder ) => {
 
 	let normal = normalViewGeometry.transformDirection( cameraViewMatrix );
 
-	if ( builder.material.flatShading !== true ) {
+	if ( builder.isFlatShading() !== true ) {
 
 		normal = normal.toVarying( 'v_normalWorldGeometry' );
 
@@ -92,15 +92,15 @@ export const normalWorldGeometry = /*@__PURE__*/ ( Fn( ( builder ) => {
  * @tsl
  * @type {Node<vec3>}
  */
-export const normalView = /*@__PURE__*/ ( Fn( ( { subBuildFn, material, context } ) => {
+export const normalView = /*@__PURE__*/ ( Fn( ( builder ) => {
 
 	let node;
 
-	if ( subBuildFn === 'NORMAL' || subBuildFn === 'VERTEX' ) {
+	if ( builder.subBuildFn === 'NORMAL' || builder.subBuildFn === 'VERTEX' ) {
 
 		node = normalViewGeometry;
 
-		if ( material.flatShading !== true ) {
+		if ( builder.isFlatShading() !== true ) {
 
 			node = directionToFaceDirection( node );
 
@@ -110,7 +110,7 @@ export const normalView = /*@__PURE__*/ ( Fn( ( { subBuildFn, material, context 
 
 		// Use getUV context to avoid side effects from nodes overwriting getUV in the context (e.g. EnvironmentNode)
 
-		node = context.setupNormal().context( { getUV: null } );
+		node = builder.context.setupNormal().context( { getUV: null } );
 
 	}
 

--- a/src/nodes/accessors/Tangent.js
+++ b/src/nodes/accessors/Tangent.js
@@ -27,11 +27,11 @@ export const tangentLocal = /*@__PURE__*/ tangentGeometry.xyz.toVar( 'tangentLoc
  * @tsl
  * @type {Node<vec3>}
  */
-export const tangentView = /*@__PURE__*/ ( Fn( ( { subBuildFn, geometry, material } ) => {
+export const tangentView = /*@__PURE__*/ ( Fn( ( builder ) => {
 
 	let node;
 
-	if ( subBuildFn === 'VERTEX' || geometry.hasAttribute( 'tangent' ) ) {
+	if ( builder.subBuildFn === 'VERTEX' || builder.geometry.hasAttribute( 'tangent' ) ) {
 
 		node = modelViewMatrix.mul( vec4( tangentLocal, 0 ) ).xyz.toVarying( 'v_tangentView' ).normalize();
 
@@ -41,7 +41,7 @@ export const tangentView = /*@__PURE__*/ ( Fn( ( { subBuildFn, geometry, materia
 
 	}
 
-	if ( material.flatShading !== true ) {
+	if ( builder.isFlatShading() !== true ) {
 
 		node = directionToFaceDirection( node );
 

--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -468,6 +468,17 @@ class NodeBuilder {
 	}
 
 	/**
+	 * Whether the material is using flat shading or not.
+	 *
+	 * @returns {boolean} Whether the material is using flat shading or not. 
+	 */
+	isFlatShading() {
+
+		return this.material.flatShading === true || this.geometry.hasAttribute( 'normal' ) === false;
+
+	}
+
+	/**
 	 * Whether the material is opaque or not.
 	 *
 	 * @return {boolean} Whether the material is opaque or not.

--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -470,7 +470,7 @@ class NodeBuilder {
 	/**
 	 * Whether the material is using flat shading or not.
 	 *
-	 * @returns {boolean} Whether the material is using flat shading or not. 
+	 * @returns {boolean} Whether the material is using flat shading or not.
 	 */
 	isFlatShading() {
 

--- a/src/nodes/display/NormalMapNode.js
+++ b/src/nodes/display/NormalMapNode.js
@@ -69,7 +69,7 @@ class NormalMapNode extends TempNode {
 
 	}
 
-	setup( { material } ) {
+	setup( builder ) {
 
 		const { normalMapType, scaleNode, unpackNormalMode } = this;
 
@@ -105,7 +105,7 @@ class NormalMapNode extends TempNode {
 
 			let scale = scaleNode;
 
-			if ( material.flatShading === true ) {
+			if ( builder.isFlatShading() === true ) {
 
 				scale = directionToFaceDirection( scale );
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/32831

**Description**

 Force flat shading for geometries without normals for `normal*` nodes.

