### PR TITLE
Add deltaTime parameter to setAnimationLoop callback

### DIFF
--- a/src/renderers/common/Animation.js
+++ b/src/renderers/common/Animation.js
@@ -61,6 +61,14 @@ class Animation {
 		 */
 		this._requestId = null;
 
+		/**
+		 * The timestamp of the previous frame, used to calculate deltaTime.
+		 *
+		 * @type {?number}
+		 * @default null
+		 */
+		this._previousTime = null;
+
 	}
 
 	/**
@@ -80,7 +88,11 @@ class Animation {
 
 			this.renderer._inspector.begin();
 
-			if ( this._animationLoop !== null ) this._animationLoop( time, xrFrame );
+			// Calculate deltaTime (time since last frame)
+			const deltaTime = this._previousTime !== null ? time - this._previousTime : 0;
+			this._previousTime = time;
+
+			if ( this._animationLoop !== null ) this._animationLoop( time, xrFrame, deltaTime );
 
 			this.renderer._inspector.finish();
 
@@ -98,6 +110,7 @@ class Animation {
 		this._context.cancelAnimationFrame( this._requestId );
 
 		this._requestId = null;
+		this._previousTime = null;
 
 	}
 

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -3377,6 +3377,7 @@ class Renderer {
  * @callback onAnimationCallback
  * @param {DOMHighResTimeStamp} time - A timestamp indicating the end time of the previous frame's rendering.
  * @param {XRFrame} [frame] - A reference to the current XR frame. Only relevant when using XR rendering.
+ * @param {number} [deltaTime] - The time elapsed since the last frame in milliseconds. On the first frame, this will be 0.
  */
 
 export default Renderer;


### PR DESCRIPTION
Fixes #32803

This change adds `deltaTime` as a third parameter to the `setAnimationLoop` callback, making it easier for developers to implement frame-rate independent animations without having to manually track the previous frame time.

The `deltaTime` represents the time elapsed since the last frame in milliseconds. On the first frame, `deltaTime` will be 0.

### Changes
- Added `_previousTime` tracking in `Animation` class
- Calculate `deltaTime` in the animation loop
- Pass `deltaTime` as third argument to the callback
- Updated documentation for `onAnimationCallback`

### Benefits
- Eliminates boilerplate code for tracking frame time
- Encourages proper use of deltaTime for frame-rate independent animations
- Backward compatible (deltaTime is optional third parameter)