### PR TITLE
WebGPURenderer: Fall back to default texture when texture creation fails.

### DIFF
--- a/src/renderers/webgpu/utils/WebGPUTextureUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUTextureUtils.js
@@ -312,7 +312,17 @@ class WebGPUTextureUtils {
 
 		}
 
-		textureData.texture = backend.device.createTexture( textureDescriptorGPU );
+		try {
+
+			textureData.texture = backend.device.createTexture( textureDescriptorGPU );
+
+		} catch ( e ) {
+
+			warn( 'WebGPURenderer: Failed to create texture with descriptor:', textureDescriptorGPU );
+			this.createDefaultTexture( texture );
+			return;
+
+		}
 
 		if ( isMSAA ) {
 


### PR DESCRIPTION
Fixed #32852.

suggested by @Mugen87, 

<img width="1283" height="629" alt="image" src="https://github.com/user-attachments/assets/7a8f67db-ccd6-4e21-9bbf-3a061adf21f0" />
