### PR TITLE
GLSLNodeBuilder: Fix `CubeDepthTexture` sampler.

### DIFF
--- a/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
+++ b/src/renderers/webgl-fallback/nodes/GLSLNodeBuilder.js
@@ -752,7 +752,17 @@ ${ flowData.code }
 
 			} else if ( uniform.type === 'cubeDepthTexture' ) {
 
-				snippet = `samplerCubeShadow ${ uniform.name };`;
+				const texture = uniform.node.value;
+
+				if ( texture.compareFunction ) {
+
+					snippet = `samplerCubeShadow ${ uniform.name };`;
+
+				} else {
+
+					snippet = `samplerCube ${ uniform.name };`;
+
+				}
 
 			} else if ( uniform.type === 'buffer' ) {
 


### PR DESCRIPTION
Related issue: #32801

**Description**

While trying to port the godrays effect from #32801 to TSL, I've realized a number of issues. One of them is fixed by this PR.

`GLSLNodeBuilder` currently assumes an instance of `CubeDepthTexture` is always sampled with `samplerCubeShadow`. However, this sampler type is only compatible when depth comparison is enabled. If you just want to access the raw depth (so when `texture.compareFunction = null`), you must use `samplerCube`.

Interestingly, WGSL allows to use `texture_depth_cube()` (and `texture_depth_2d()`) without the use of a comparison sampler. So a similar change isn't required for WebGPU.