### PR TITLE
LDrawConditionalLineNodeMaterial: fix import

### DIFF
--- a/examples/jsm/materials/LDrawConditionalLineNodeMaterial.js
+++ b/examples/jsm/materials/LDrawConditionalLineNodeMaterial.js
@@ -1,5 +1,5 @@
-import { Color } from 'three/webgpu';
-import { attribute, cameraProjectionMatrix, dot, float, Fn, modelViewMatrix, modelViewProjection, NodeMaterial, normalize, positionGeometry, sign, uniform, varyingProperty, vec2, vec4 } from 'three/tsl';
+import { Color, NodeMaterial } from 'three/webgpu';
+import { attribute, cameraProjectionMatrix, dot, float, Fn, modelViewMatrix, modelViewProjection, normalize, positionGeometry, sign, uniform, varyingProperty, vec2, vec4 } from 'three/tsl';
 
 /**
  * A special line material for meshes loaded via {@link LDrawLoader}.


### PR DESCRIPTION
Related issue: #32851

**Description**

I noticed that "LDrawConditionalLineNodeMaterial.js" was importing "NodeMaterial" from "three/tsl" rather than "three/webgpu" when working on #32851.