### PR TITLE
Editor: Fix canvas reference for video rendering.

### DIFF
--- a/editor/js/Menubar.Render.js
+++ b/editor/js/Menubar.Render.js
@@ -420,7 +420,7 @@ class RenderVideoDialog {
 			const width = videoWidth.getValue() / window.devicePixelRatio;
 			const height = videoHeight.getValue() / window.devicePixelRatio;
 
-			const canvas = player.canvas;
+			const canvas = player.dom.firstChild;
 			canvas.style.width = width + 'px';
 			canvas.style.height = height + 'px';
 
@@ -497,7 +497,7 @@ class RenderVideoDialog {
 
 			const qualityToBitrate = {
 				'low': 2e6,
-				'medium': 5e6, 
+				'medium': 5e6,
 				'high': 10e6,
 				'ultra': 20e6
 			};
@@ -526,7 +526,7 @@ class RenderVideoDialog {
 				player.render( currentTime );
 
 				const bitmap = await createImageBitmap( canvas );
-				const frame = new VideoFrame( bitmap, { timestamp: i * ( 1_000_000 / fps ) } );
+				const frame = new VideoFrame( bitmap, { timestamp: i * ( 1e6 / fps ) } );
 
 				videoEncoder.encode( frame, { keyFrame: i % fps === 0 } );
 				frame.close();

--- a/editor/js/Menubar.Render.js
+++ b/editor/js/Menubar.Render.js
@@ -420,7 +420,7 @@ class RenderVideoDialog {
 			const width = videoWidth.getValue() / window.devicePixelRatio;
 			const height = videoHeight.getValue() / window.devicePixelRatio;
 
-			const canvas = player.dom.firstChild;
+			const canvas = player.canvas;
 			canvas.style.width = width + 'px';
 			canvas.style.height = height + 'px';
 

--- a/editor/js/libs/app.js
+++ b/editor/js/libs/app.js
@@ -12,6 +12,7 @@ const APP = {
 		const dom = document.createElement( 'div' );
 
 		this.dom = dom;
+		this.canvas = null;
 
 		this.width = 500;
 		this.height = 500;
@@ -26,6 +27,7 @@ const APP = {
 
 				renderer.dispose();
 				dom.removeChild( renderer.domElement );
+				this.canvas = null;
 
 			}
 
@@ -49,6 +51,7 @@ const APP = {
 			if ( project.toneMappingExposure !== undefined ) renderer.toneMappingExposure = project.toneMappingExposure;
 
 			dom.appendChild( renderer.domElement );
+			this.canvas = renderer.domElement;
 
 			this.setScene( loader.parse( json.scene ) );
 			this.setCamera( loader.parse( json.camera ) );


### PR DESCRIPTION
**Description**

Currently, Render Video produces no output. This PR applies a **minimal** fix by correctly locating the canvas via the DOM tree. In addition, I fixed some subtle lint issues that otherwise prevented the PR from being merged.