### PR TITLE
Editor: Retain viewport color when rendering images/videos.

### DIFF
--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -134,6 +134,7 @@ function Editor() {
 
 	this.viewportCamera = this.camera;
 	this.viewportShading = 'default';
+	this.viewportColor = new THREE.Color();
 
 	this.addCamera( this.camera );
 

--- a/editor/js/Menubar.Render.js
+++ b/editor/js/Menubar.Render.js
@@ -210,6 +210,7 @@ class RenderImageDialog {
 
 			const renderer = new THREE.WebGLRenderer( { antialias: true, logarithmicDepthBuffer: true } );
 			renderer.setSize( imageWidth.getValue(), imageHeight.getValue() );
+			renderer.setClearColor( editor.viewportColor );
 
 			if ( project.shadows !== undefined ) renderer.shadowMap.enabled = project.shadows;
 			if ( project.shadowType !== undefined ) renderer.shadowMap.type = project.shadowType;
@@ -414,6 +415,7 @@ class RenderVideoDialog {
 			await player.load( editor.toJSON() );
 			player.setPixelRatio( 1 );
 			player.setSize( videoWidth.getValue(), videoHeight.getValue() );
+			player.setClearColor( editor.viewportColor );
 
 			//
 

--- a/editor/js/Viewport.js
+++ b/editor/js/Viewport.js
@@ -385,6 +385,8 @@ function Viewport( editor ) {
 
 		}
 
+		renderer.getClearColor( editor.viewportColor );
+
 		renderer.setPixelRatio( window.devicePixelRatio );
 		renderer.setSize( container.dom.offsetWidth, container.dom.offsetHeight );
 

--- a/editor/js/libs/app.js
+++ b/editor/js/libs/app.js
@@ -142,6 +142,12 @@ const APP = {
 
 		};
 
+		this.setClearColor = function ( color ) {
+
+			renderer.setClearColor( color );
+
+		};
+
 		this.setSize = function ( width, height ) {
 
 			this.width = width;


### PR DESCRIPTION
Related issue: #32863

**Description**

The PR makes sure the default viewport clear color is retained when rendering an image or video. In this way, the behavior matches Blender.

`Scene.background` can still overwrite this setting, btw.

https://github.com/user-attachments/assets/d7221461-e70f-4981-8fed-088458b775fc

The same workflow in production produces a black background.