### PR TITLE
WebGPURenderer: Introduce `initRenderTarget()`.

### DIFF
--- a/examples/jsm/tsl/display/TRAANode.js
+++ b/examples/jsm/tsl/display/TRAANode.js
@@ -376,13 +376,10 @@ class TRAANode extends TempNode {
 
 		if ( needsRestart === true ) {
 
-			// bind and clear render target to make sure they are initialized after the resize which triggers a dispose()
+			// make sure render targets are initialized after the resize which triggers a dispose()
 
-			renderer.setRenderTarget( this._historyRenderTarget );
-			renderer.clear();
-
-			renderer.setRenderTarget( this._resolveRenderTarget );
-			renderer.clear();
+			renderer.initRenderTarget( this._historyRenderTarget );
+			renderer.initRenderTarget( this._resolveRenderTarget );
 
 			// make sure to reset the history with the contents of the beauty buffer otherwise subsequent frames after the
 			// resize will fade from a darker color to the correct one because the history was cleared with black.

--- a/src/renderers/common/Backend.js
+++ b/src/renderers/common/Backend.js
@@ -692,7 +692,7 @@ class Backend {
 	}
 
 	/**
-	 * Initializes render targets defined in the given render context.
+	 * Initializes the render target defined in the given render context.
 	 *
 	 * @abstract
 	 * @param {RenderContext} renderContext - The render context.

--- a/src/renderers/common/Backend.js
+++ b/src/renderers/common/Backend.js
@@ -692,6 +692,14 @@ class Backend {
 	}
 
 	/**
+	 * Initializes render targets defined in the given render context.
+	 *
+	 * @abstract
+	 * @param {RenderContext} renderContext - The render context.
+	 */
+	initRenderTarget( /*renderContext*/ ) {}
+
+	/**
 	 * Sets a dictionary for the given object into the
 	 * internal data structure.
 	 *

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -2690,6 +2690,37 @@ class Renderer {
 	}
 
 	/**
+	 * Initializes render targets.
+	 *
+	 * @param {RenderTarget} renderTarget - The render target to intialize.
+	 */
+	initRenderTarget( renderTarget ) {
+
+		if ( this._initialized === false ) {
+
+			throw new Error( 'Renderer: .initRenderTarget() called before the backend is initialized. Use "await renderer.init();" before before using this method.' );
+
+		}
+
+		this._textures.updateRenderTarget( renderTarget );
+
+		const renderTargetData = this._textures.get( renderTarget );
+
+		const renderContext = this._renderContexts.get( renderTarget );
+
+		renderContext.textures = renderTargetData.textures;
+		renderContext.depthTexture = renderTargetData.depthTexture;
+		renderContext.width = renderTargetData.width;
+		renderContext.height = renderTargetData.height;
+		renderContext.renderTarget = renderTarget;
+		renderContext.depth = renderTarget.depthBuffer;
+		renderContext.stencil = renderTarget.stencilBuffer;
+
+		this.backend.initRenderTarget( renderContext );
+
+	}
+
+	/**
 	 * Copies the current bound framebuffer into the given texture.
 	 *
 	 * @param {FramebufferTexture} framebufferTexture - The texture.

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -2690,7 +2690,7 @@ class Renderer {
 	}
 
 	/**
-	 * Initializes render targets.
+	 * Initializes the given render target.
 	 *
 	 * @param {RenderTarget} renderTarget - The render target to intialize.
 	 */

--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -2012,6 +2012,21 @@ class WebGLBackend extends Backend {
 	}
 
 	/**
+	 * Initializes render targets defined in the given render context.
+	 *
+	 * @param {RenderContext} renderContext - The render context.
+	 */
+	initRenderTarget( renderContext ) {
+
+		const { gl, state } = this;
+
+		this._setFramebuffer( renderContext );
+
+		state.bindFramebuffer( gl.FRAMEBUFFER, null );
+
+	}
+
+	/**
 	 * Configures the active framebuffer from the given render context.
 	 *
 	 * @private

--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -2012,7 +2012,7 @@ class WebGLBackend extends Backend {
 	}
 
 	/**
-	 * Initializes render targets defined in the given render context.
+	 * Initializes the render target defined in the given render context.
 	 *
 	 * @param {RenderContext} renderContext - The render context.
 	 */


### PR DESCRIPTION
Related issue: -

**Description**

TRAA and other code sometimes requires to copy render target data. Render targets might be in a state though where they are not initialized yet e.g. right after a `dispose()` due to a resize.

Previously we initialized the render targets by clearing them once but that was just a workaround which introduced unnecessary clears. The PR introduces `initRenderTarget()` (similar to `WebGLRenderer.initRenderTarget()`) that only performs the needed operations meaning setting up correct render context data and for the WebGL backend configure the framebuffer state.
