### PR TITLE
Docs: Prevent translators from aggressively translating parameter names

### DIFF
--- a/utils/docs/template/tmpl/params.tmpl
+++ b/utils/docs/template/tmpl/params.tmpl
@@ -56,7 +56,7 @@
 								<tr>
 									<?js if (params.hasName) {?>
 									<td class="name">
-										<strong><?js= param.name ?></strong>
+										<strong translate="no"><?js= param.name ?></strong>
 									</td>
 									<?js } ?>
 									<td class="description last">


### PR DESCRIPTION
**Description**

The old docs template didn’t set translate="no" for parameter names, so in‑browser translators ended up translating them as well, which made the params table lose its actual meaning. This PR explicitly prevents parameter names from being translated.

Before:

<img width="877" height="369" src="https://github.com/user-attachments/assets/bbdf5c32-4bb6-4d5e-83d3-512a947e8097" />

After:

<img width="959" height="383" src="https://github.com/user-attachments/assets/d11916c7-7931-4dbd-8092-8aedd74fe8e8" />
