### PR TITLE
WebGPURenderer: Export `CubeRenderTarget` and use it in examples.

### DIFF
--- a/examples/jsm/exporters/EXRExporter.js
+++ b/examples/jsm/exporters/EXRExporter.js
@@ -90,7 +90,7 @@ function supportedRTT( renderTarget ) {
 
 	}
 
-	if ( renderTarget.isWebGLCubeRenderTarget || renderTarget.isWebGL3DRenderTarget || renderTarget.isWebGLArrayRenderTarget ) {
+	if ( renderTarget.isCubeRenderTarget || renderTarget.isWebGLCubeRenderTarget || renderTarget.isWebGL3DRenderTarget || renderTarget.isWebGLArrayRenderTarget ) {
 
 		throw Error( 'EXRExporter.parse: Unsupported render target type, expected instance of WebGLRenderTarget.' );
 

--- a/examples/webgpu_cubemap_dynamic.html
+++ b/examples/webgpu_cubemap_dynamic.html
@@ -76,7 +76,7 @@
 
 				//
 
-				cubeRenderTarget = new THREE.WebGLCubeRenderTarget( 256 );
+				cubeRenderTarget = new THREE.CubeRenderTarget( 256 );
 				cubeRenderTarget.texture.type = THREE.HalfFloatType;
 				cubeRenderTarget.texture.minFilter = THREE.LinearMipmapLinearFilter;
 				cubeRenderTarget.texture.magFilter = THREE.LinearFilter;

--- a/examples/webgpu_lightprobe_cubecamera.html
+++ b/examples/webgpu_lightprobe_cubecamera.html
@@ -64,7 +64,7 @@
 				camera = new THREE.PerspectiveCamera( 40, window.innerWidth / window.innerHeight, 1, 1000 );
 				camera.position.set( 0, 0, 30 );
 
-				const cubeRenderTarget = new THREE.WebGLCubeRenderTarget( 256 );
+				const cubeRenderTarget = new THREE.CubeRenderTarget( 256 );
 
 				cubeCamera = new THREE.CubeCamera( 1, 1000, cubeRenderTarget );
 

--- a/examples/webgpu_materials_envmaps_bpcem.html
+++ b/examples/webgpu_materials_envmaps_bpcem.html
@@ -65,7 +65,7 @@
 
 				// cube camera for environment map
 
-				const renderTarget = new THREE.WebGLCubeRenderTarget( 512 );
+				const renderTarget = new THREE.CubeRenderTarget( 512 );
 				renderTarget.texture.type = THREE.HalfFloatType;
 				renderTarget.texture.minFilter = THREE.LinearMipmapLinearFilter;
 				renderTarget.texture.magFilter = THREE.LinearFilter;

--- a/src/Three.Core.js
+++ b/src/Three.Core.js
@@ -3,7 +3,6 @@ import { warn } from './utils.js';
 
 export { WebGLArrayRenderTarget } from './renderers/WebGLArrayRenderTarget.js';
 export { WebGL3DRenderTarget } from './renderers/WebGL3DRenderTarget.js';
-export { WebGLCubeRenderTarget } from './renderers/WebGLCubeRenderTarget.js';
 export { WebGLRenderTarget } from './renderers/WebGLRenderTarget.js';
 export { WebXRController } from './renderers/webxr/WebXRController.js';
 export { FogExp2 } from './scenes/FogExp2.js';

--- a/src/Three.WebGPU.js
+++ b/src/Three.WebGPU.js
@@ -10,6 +10,7 @@ export { default as RenderPipeline } from './renderers/common/RenderPipeline.js'
 export { default as PostProcessing } from './renderers/common/PostProcessing.js';
 import * as RendererUtils from './renderers/common/RendererUtils.js';
 export { RendererUtils };
+export { default as CubeRenderTarget } from './renderers/common/CubeRenderTarget.js';
 export { default as StorageTexture } from './renderers/common/StorageTexture.js';
 export { default as Storage3DTexture } from './renderers/common/Storage3DTexture.js';
 export { default as StorageArrayTexture } from './renderers/common/StorageArrayTexture.js';

--- a/src/Three.js
+++ b/src/Three.js
@@ -1,6 +1,7 @@
 export * from './Three.Core.js';
 
 export { WebGLRenderer } from './renderers/WebGLRenderer.js';
+export { WebGLCubeRenderTarget } from './renderers/WebGLCubeRenderTarget.js';
 export { ShaderLib } from './renderers/shaders/ShaderLib.js';
 export { UniformsLib } from './renderers/shaders/UniformsLib.js';
 export { UniformsUtils } from './renderers/shaders/UniformsUtils.js';

--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -2044,7 +2044,7 @@ class WebGLBackend extends Backend {
 			const renderTargetContextData = this.get( renderTarget );
 			const { samples, depthBuffer, stencilBuffer } = renderTarget;
 
-			const isCube = renderTarget.isWebGLCubeRenderTarget === true;
+			const isCube = renderTarget.isCubeRenderTarget === true;
 			const isRenderTarget3D = renderTarget.isRenderTarget3D === true;
 			const isRenderTargetArray = renderTarget.depth > 1;
 			const isXRRenderTarget = renderTarget.isXRRenderTarget === true;


### PR DESCRIPTION
Related issue: -

**Description**

This PR refactors an open issue in the `WebGPURenderer` build. It exports `CubeRenderTarget` and removes any dependencies to `WebGLCubeRenderTarget`. `WebGLCubeRenderTarget` is not exported in `Three.Core.js` anymore but only `Three.js` which means it's only available in the `WebGLRenderer` builds.

`WebGLCubeRenderTarget` has dependencies to `ShaderMaterial` and `UniformsUtils` which are unrelated to `WebGPURenderer`. The dependencies are caused by `fromEquirectangularTexture()` which holds material system specific code.

`CubeRenderTarget.fromEquirectangularTexture()` also holds material system specific code so it can't be placed in `Three.Core.js`. That's why `WebGLCubeRenderTarget` can't be derived from `CubeRenderTarget` as well.

`CubeRenderTarget` is now derived from `RenderTarget` and all WebGPU examples now use `CubeRenderTarget`. This change must be noted in the migration guide since applications must use `CubeRenderTarget` when they switch to `WebGPURenderer`.