### PR TITLE
Remove JSHint remnants, prepare ESLint `eqeqeq` rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .claude/
 .DS_Store
 .idea/
-.jshintrc
 .project
 .puppeteer_profile/
 .vs/

--- a/test/unit/utils/SmartComparer.js
+++ b/test/unit/utils/SmartComparer.js
@@ -30,10 +30,9 @@ function SmartComparer() {
 		if ( val1 === val2 ) return true;
 
 		// Null or undefined values.
-		/* jshint eqnull:true */
-		if ( val1 == null || val2 == null ) {
+		if ( val1 == null || val2 == null ) { // eslint-disable-line three/eqeqeq
 
-			if ( val1 != val2 ) {
+			if ( val1 != val2 ) { // eslint-disable-line three/eqeqeq
 
 				return makeFail( 'One value is undefined or null', val1, val2 );
 

--- a/test/unit/utils/qunit-utils.js
+++ b/test/unit/utils/qunit-utils.js
@@ -46,7 +46,7 @@ QUnit.assert.equalKey = function ( obj, ref, key ) {
 	const expected = ref[ key ];
 	const message = actual + ' should be equal to ' + expected + ' for key "' + key + '"';
 	this.pushResult( {
-		result: actual == expected,
+		result: actual == expected, // eslint-disable-line three/eqeqeq
 		actual: actual,
 		expected: expected,
 		message: message

--- a/utils/eslint-plugin-three.js
+++ b/utils/eslint-plugin-three.js
@@ -1,0 +1,54 @@
+const eqeqeq = {
+	meta: { fixable: 'code' },
+	create( context ) {
+
+		return {
+			BinaryExpression( node ) {
+
+				if ( node.operator === '==' || node.operator === '!=' ) {
+
+					const right = node.right;
+					const isNullOrUndefined =
+            ( right.type === 'Literal' && right.value === null ) ||
+            ( right.type === 'Identifier' && right.name === 'undefined' );
+
+					if ( isNullOrUndefined ) {
+
+						context.report( {
+							node,
+							message: 'Comparison may rely on type coercion; manual review required'
+						} );
+
+					} else {
+
+						const replacement = node.operator === '==' ? '===' : '!==';
+						context.report( {
+							node,
+							message: `Use ${replacement} instead of ${node.operator}`,
+							fix( fixer ) {
+
+								const sourceCode = context.getSourceCode();
+								const operatorToken = sourceCode.getFirstTokenBetween( node.left, node.right, {
+									filter: ( token ) => token.value === node.operator,
+								} );
+								const replacement = node.operator === '==' ? '===' : '!==';
+								return fixer.replaceText( operatorToken, replacement );
+
+							}
+						} );
+
+					}
+
+				}
+
+			},
+		};
+
+	},
+};
+
+export default {
+	rules: {
+		eqeqeq
+	}
+};


### PR DESCRIPTION
**Description**

Cleaning up old JSHint leftovers and adding a custom `eqeqeq` rule. This prepares the codebase for stricter equality checks: 

- **Safe cases** can be autofixed
- **Tricky cases** (like == null checks) will **not** be fixable and will instead be flagged for manual review. 
 
Once merged, just update `eslint.config.js` to include the new plugin and run the lint script as usual.

```js
// eslint.config.js
import three from './utils/eslint-plugin-three.js'; 

plugins: { ......, three }, // <<
rules: { ....., 'three/eqeqeq': 'error' } // << 
```

Then, run:

```
npx eslint . --quiet --fix
``` 

to fix all safe cases. The remaining tricky ones will need to be handled manually, one by one. I’ll leave that in your hands, thanks.