### PR TITLE
WebGPURenderer: Fixed environment shading artifacts as roughness approaches one.

### DIFF
--- a/src/nodes/accessors/TextureNode.js
+++ b/src/nodes/accessors/TextureNode.js
@@ -382,16 +382,6 @@ class TextureNode extends UniformNode {
 
 		//
 
-		let levelNode = this.levelNode;
-
-		if ( levelNode === null && builder.context.getTextureLevel ) {
-
-			levelNode = builder.context.getTextureLevel( this );
-
-		}
-
-		//
-
 		let compareNode = null;
 		let compareStepNode = null;
 
@@ -416,7 +406,7 @@ class TextureNode extends UniformNode {
 		}
 
 		properties.uvNode = uvNode;
-		properties.levelNode = levelNode;
+		properties.levelNode = this.levelNode;
 		properties.biasNode = this.biasNode;
 		properties.compareNode = compareNode;
 		properties.compareStepNode = compareStepNode;


### PR DESCRIPTION
Fixed #32870

**Description**

Under some circumstances, shading artifacts are introduced in WebGPU rendering for objects
1. having a normal map
2. being illuminated by an environment map
3. having a roughness value close to 1

This is only an issue in WebGPU mode of WebGPURenderer, not in WebGL mode.

Below is an image showing the issue for different roughness values.
<img width="1024" height="522" alt="image" src="https://github.com/user-attachments/assets/b4a90a17-052a-45d7-b357-0a4b4f6a1edc" />

The issue is introduced in WebGPU mode as roughness gets very close to 1
<img width="768" height="257" alt="image" src="https://github.com/user-attachments/assets/8ff280a5-00ef-4b8d-9126-a83c62738ae8" />

When the normal map `TextureNode` was built while the environment context was active, it picked up `getTextureLevel` from the context (lines 387-391 in TextureNode.js). This caused the normal map to be sampled at a mip level based on roughness.