### PR TITLE
Line3: Fix closest point in `distanceSqToLine3()`.

### DIFF
--- a/src/math/Line3.js
+++ b/src/math/Line3.js
@@ -284,12 +284,10 @@ class Line3 {
 
 		}
 
-		c1.copy( p1 ).add( _d1.multiplyScalar( s ) );
-		c2.copy( p2 ).add( _d2.multiplyScalar( t ) );
+		c1.copy( p1 ).addScaledVector( _d1, s );
+		c2.copy( p2 ).addScaledVector( _d2, t );
 
-		c1.sub( c2 );
-
-		return c1.dot( c1 );
+		return c1.distanceToSquared( c2 );
 
 	}
 


### PR DESCRIPTION
Fixed #32876.

**Description**

As suggested in https://github.com/mrdoob/three.js/issues/32876#issuecomment-3812270106, the PR fixes the incorrect result of `c1` (the closest point of the first line segment).
