### PR TITLE
MaterialLoader: Introduce `registerMaterial()`.

### DIFF
--- a/editor/js/Loader.js
+++ b/editor/js/Loader.js
@@ -17,6 +17,9 @@ function Loader( editor ) {
 
 	this.texturePath = '';
 
+	THREE.MaterialLoader.registerMaterial( 'ShaderMaterial', THREE.ShaderMaterial );
+	THREE.MaterialLoader.registerMaterial( 'RawShaderMaterial', THREE.RawShaderMaterial );
+
 	this.loadItemList = function ( items ) {
 
 		LoaderUtils.getFilesFromItemList( items, function ( files, filesMap ) {

--- a/src/Three.js
+++ b/src/Three.js
@@ -7,4 +7,13 @@ export { UniformsLib } from './renderers/shaders/UniformsLib.js';
 export { UniformsUtils } from './renderers/shaders/UniformsUtils.js';
 export { ShaderChunk } from './renderers/shaders/ShaderChunk.js';
 export { PMREMGenerator } from './extras/PMREMGenerator.js';
+export { ShaderMaterial } from './materials/ShaderMaterial.js';
+export { RawShaderMaterial } from './materials/RawShaderMaterial.js';
 export { WebGLUtils } from './renderers/webgl/WebGLUtils.js';
+
+import { ShaderMaterial } from './materials/ShaderMaterial.js';
+import { RawShaderMaterial } from './materials/RawShaderMaterial.js';
+import { MaterialLoader } from './loaders/MaterialLoader.js';
+
+MaterialLoader.registerMaterial( 'ShaderMaterial', ShaderMaterial );
+MaterialLoader.registerMaterial( 'RawShaderMaterial', RawShaderMaterial );

--- a/src/Three.js
+++ b/src/Three.js
@@ -10,10 +10,3 @@ export { PMREMGenerator } from './extras/PMREMGenerator.js';
 export { ShaderMaterial } from './materials/ShaderMaterial.js';
 export { RawShaderMaterial } from './materials/RawShaderMaterial.js';
 export { WebGLUtils } from './renderers/webgl/WebGLUtils.js';
-
-import { ShaderMaterial } from './materials/ShaderMaterial.js';
-import { RawShaderMaterial } from './materials/RawShaderMaterial.js';
-import { MaterialLoader } from './loaders/MaterialLoader.js';
-
-MaterialLoader.registerMaterial( 'ShaderMaterial', ShaderMaterial );
-MaterialLoader.registerMaterial( 'RawShaderMaterial', RawShaderMaterial );

--- a/src/loaders/MaterialLoader.js
+++ b/src/loaders/MaterialLoader.js
@@ -9,8 +9,6 @@ import { Loader } from './Loader.js';
 import {
 	ShadowMaterial,
 	SpriteMaterial,
-	RawShaderMaterial,
-	ShaderMaterial,
 	PointsMaterial,
 	MeshPhysicalMaterial,
 	MeshStandardMaterial,
@@ -27,6 +25,8 @@ import {
 	Material,
 } from '../materials/Materials.js';
 import { error, warn } from '../utils.js';
+
+const _customMaterials = {};
 
 /**
  * Class for loading materials. The files are internally
@@ -412,8 +412,6 @@ class MaterialLoader extends Loader {
 		const materialLib = {
 			ShadowMaterial,
 			SpriteMaterial,
-			RawShaderMaterial,
-			ShaderMaterial,
 			PointsMaterial,
 			MeshPhysicalMaterial,
 			MeshStandardMaterial,
@@ -427,10 +425,25 @@ class MaterialLoader extends Loader {
 			MeshMatcapMaterial,
 			LineDashedMaterial,
 			LineBasicMaterial,
-			Material
+			Material,
+			... _customMaterials
 		};
 
 		return new materialLib[ type ]();
+
+	}
+
+	/**
+	 * Registers the given material at the internal
+	 * material library.
+	 *
+	 * @static
+	 * @param {string} type - The material type.
+	 * @param {Material} materialClass - The material class.
+	 */
+	static registerMaterial( type, materialClass ) {
+
+		_customMaterials[ type ] = materialClass;
 
 	}
 

--- a/src/loaders/MaterialLoader.js
+++ b/src/loaders/MaterialLoader.js
@@ -24,7 +24,7 @@ import {
 	LineBasicMaterial,
 	Material,
 } from '../materials/Materials.js';
-import { error, warn } from '../utils.js';
+import { error, warn, warnOnce } from '../utils.js';
 
 const _customMaterials = {};
 
@@ -429,7 +429,22 @@ class MaterialLoader extends Loader {
 			... _customMaterials
 		};
 
-		return new materialLib[ type ]();
+		const MaterialType = materialLib[ type ];
+
+		let materialInstance;
+
+		if ( MaterialType === undefined ) {
+
+			warnOnce( `MaterialLoader: Unknown material type "${ type }". Use .registerMaterial() before starting the deserialization process.` );
+			materialInstance = new Material();
+
+		} else {
+
+			materialInstance = new MaterialType();
+
+		}
+
+		return materialInstance;
 
 	}
 

--- a/src/materials/Materials.js
+++ b/src/materials/Materials.js
@@ -1,7 +1,5 @@
 import { ShadowMaterial } from './ShadowMaterial.js';
 import { SpriteMaterial } from './SpriteMaterial.js';
-import { RawShaderMaterial } from './RawShaderMaterial.js';
-import { ShaderMaterial } from './ShaderMaterial.js';
 import { PointsMaterial } from './PointsMaterial.js';
 import { MeshPhysicalMaterial } from './MeshPhysicalMaterial.js';
 import { MeshStandardMaterial } from './MeshStandardMaterial.js';
@@ -20,8 +18,6 @@ import { Material } from './Material.js';
 export {
 	ShadowMaterial,
 	SpriteMaterial,
-	RawShaderMaterial,
-	ShaderMaterial,
 	PointsMaterial,
 	MeshPhysicalMaterial,
 	MeshStandardMaterial,


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/32871#issuecomment-3813359469

**Description**

As mentioned in https://github.com/mrdoob/three.js/pull/32871#issuecomment-3813359469, the PR introduces a new static method for register materials in `MaterialLoader`. In this way,  `ShaderMaterial` and `RawShaderMaterial` can be removed from `Three.Core.js` and are only part of the `WebGLRenderer` builds.