### PR TITLE
Editor: Expose viewport default environment logic for rendering

### DIFF
--- a/editor/js/Menubar.Render.js
+++ b/editor/js/Menubar.Render.js
@@ -219,7 +219,7 @@ class RenderImageDialog {
 			const scene = await loader.parseAsync( json.scene );
 			if ( json.environmentType === 'Default' ) {
 
-				Viewport.setupSceneDefaultEnvironmentByRenderer( scene, renderer );
+				Viewport.setupDefaultEnvironment( scene, renderer );
 
 			}
 

--- a/editor/js/Menubar.Render.js
+++ b/editor/js/Menubar.Render.js
@@ -4,6 +4,7 @@ import { UIPanel, UIRow, UIButton, UIInteger, UISelect, UIText } from './libs/ui
 
 import { ViewportPathtracer } from './Viewport.Pathtracer.js';
 import { APP } from './libs/app.js';
+import { Viewport } from './Viewport.js';
 
 function MenubarRender( editor ) {
 
@@ -206,8 +207,6 @@ class RenderImageDialog {
 			camera.updateProjectionMatrix();
 			camera.updateMatrixWorld();
 
-			const scene = await loader.parseAsync( json.scene );
-
 			const renderer = new THREE.WebGLRenderer( { antialias: true, logarithmicDepthBuffer: true } );
 			renderer.setSize( imageWidth.getValue(), imageHeight.getValue() );
 			renderer.setClearColor( editor.viewportColor );
@@ -216,6 +215,13 @@ class RenderImageDialog {
 			if ( project.shadowType !== undefined ) renderer.shadowMap.type = project.shadowType;
 			if ( project.toneMapping !== undefined ) renderer.toneMapping = project.toneMapping;
 			if ( project.toneMappingExposure !== undefined ) renderer.toneMappingExposure = project.toneMappingExposure;
+
+			const scene = await loader.parseAsync( json.scene );
+			if ( json.environmentType === 'Default' ) {
+
+				Viewport.setupSceneDefaultEnvironmentByRenderer( scene, renderer );
+
+			}
 
 			// popup
 

--- a/editor/js/Viewport.js
+++ b/editor/js/Viewport.js
@@ -610,7 +610,7 @@ function Viewport( editor ) {
 
 				useBackgroundAsEnvironment = true;
 
-				Viewport.setupDefaultEnvironment( scene, pmremGenerator );
+				Viewport.setupDefaultEnvironmentPMREM( scene, pmremGenerator );
 
 				break;
 
@@ -926,42 +926,36 @@ function Viewport( editor ) {
 
 //
 
-Viewport.setupDefaultEnvironment = ( scene, rendererOrPmremGenerator ) => {
+Viewport.setupDefaultEnvironmentPMREM = ( scene, pmremGenerator ) => {
 
-	if ( rendererOrPmremGenerator.isWebGPURenderer || rendererOrPmremGenerator.isWebGLRenderer ) {
+	if ( scene.background !== null ) {
 
-		const renderer = rendererOrPmremGenerator;
+		if ( scene.background.isColor ) {
 
-		const pmremGenerator = new ( renderer.isWebGPURenderer ? PMREMGenerator : THREE.PMREMGenerator )( renderer );
-		pmremGenerator.compileEquirectangularShader();
-		Viewport.setupDefaultEnvironment( scene, pmremGenerator );
-		pmremGenerator.dispose();
+			scene.environment = pmremGenerator.fromScene( new ColorEnvironment( scene.background ), 0.04 ).texture;
 
-	} else {
+		} else if ( scene.background.isTexture ) {
 
-		const pmremGenerator = rendererOrPmremGenerator;
-
-		if ( scene.background !== null ) {
-
-			if ( scene.background.isColor ) {
-
-				scene.environment = pmremGenerator.fromScene( new ColorEnvironment( scene.background ), 0.04 ).texture;
-
-			} else if ( scene.background.isTexture ) {
-
-				scene.environment = scene.background;
-				scene.environment.mapping = THREE.EquirectangularReflectionMapping;
-				scene.environmentRotation.y = scene.backgroundRotation.y;
-
-			}
-
-		} else {
-
-			scene.environment = pmremGenerator.fromScene( new RoomEnvironment(), 0.04 ).texture;
+			scene.environment = scene.background;
+			scene.environment.mapping = THREE.EquirectangularReflectionMapping;
+			scene.environmentRotation.y = scene.backgroundRotation.y;
 
 		}
 
+	} else {
+
+		scene.environment = pmremGenerator.fromScene( new RoomEnvironment(), 0.04 ).texture;
+
 	}
+
+};
+
+Viewport.setupDefaultEnvironment = ( scene, renderer ) => {
+
+	const pmremGenerator = new ( renderer.isWebGPURenderer ? PMREMGenerator : THREE.PMREMGenerator )( renderer );
+	pmremGenerator.compileEquirectangularShader();
+	Viewport.setupDefaultEnvironmentPMREM( scene, pmremGenerator );
+	pmremGenerator.dispose();
 
 };
 

--- a/editor/js/Viewport.js
+++ b/editor/js/Viewport.js
@@ -610,25 +610,7 @@ function Viewport( editor ) {
 
 				useBackgroundAsEnvironment = true;
 
-				if ( scene.background !== null ) {
-
-					if ( scene.background.isColor ) {
-
-						scene.environment = pmremGenerator.fromScene( new ColorEnvironment( scene.background ), 0.04 ).texture;
-
-					} else if ( scene.background.isTexture ) {
-
-						scene.environment = scene.background;
-						scene.environment.mapping = THREE.EquirectangularReflectionMapping;
-						scene.environmentRotation.y = scene.backgroundRotation.y;
-
-					}
-
-				} else {
-
-					scene.environment = pmremGenerator.fromScene( new RoomEnvironment(), 0.04 ).texture;
-
-				}
+				Viewport.setupSceneDefaultEnvironmentByPMREMGenerator( scene, pmremGenerator );
 
 				break;
 
@@ -941,6 +923,43 @@ function Viewport( editor ) {
 	return container;
 
 }
+
+//
+
+Viewport.setupSceneDefaultEnvironmentByPMREMGenerator = ( scene, pmremGenerator ) => {
+
+	if ( scene.background !== null ) {
+
+		if ( scene.background.isColor ) {
+
+			scene.environment = pmremGenerator.fromScene( new ColorEnvironment( scene.background ), 0.04 ).texture;
+
+		} else if ( scene.background.isTexture ) {
+
+			scene.environment = scene.background;
+			scene.environment.mapping = THREE.EquirectangularReflectionMapping;
+			scene.environmentRotation.y = scene.backgroundRotation.y;
+
+		}
+
+	} else {
+
+		scene.environment = pmremGenerator.fromScene( new RoomEnvironment(), 0.04 ).texture;
+
+	}
+
+};
+
+Viewport.setupSceneDefaultEnvironmentByRenderer = ( scene, renderer ) => {
+
+	const pmremGenerator = new ( renderer.isWebGPURenderer ? PMREMGenerator : THREE.PMREMGenerator )( renderer );
+	pmremGenerator.compileEquirectangularShader();
+	Viewport.setupSceneDefaultEnvironmentByPMREMGenerator( scene, pmremGenerator );
+	pmremGenerator.dispose();
+
+};
+
+//
 
 function updateGridColors( grid1, grid2, colors ) {
 

--- a/editor/js/libs/app.js
+++ b/editor/js/libs/app.js
@@ -1,3 +1,5 @@
+import { Viewport } from '../Viewport.js';
+
 const APP = {
 
 	Player: function () {
@@ -53,7 +55,14 @@ const APP = {
 			dom.appendChild( renderer.domElement );
 			this.canvas = renderer.domElement;
 
-			this.setScene( loader.parse( json.scene ) );
+			const scene = loader.parse( json.scene );
+			if ( json.environmentType === 'Default' ) {
+			
+				Viewport.setupSceneDefaultEnvironmentByRenderer( scene, renderer );
+
+			}
+			this.setScene( scene );
+
 			this.setCamera( loader.parse( json.camera ) );
 
 			events = {

--- a/editor/js/libs/app.js
+++ b/editor/js/libs/app.js
@@ -58,7 +58,7 @@ const APP = {
 			const scene = loader.parse( json.scene );
 			if ( json.environmentType === 'Default' ) {
 			
-				Viewport.setupSceneDefaultEnvironmentByRenderer( scene, renderer );
+				Viewport.setupDefaultEnvironment( scene, renderer );
 
 			}
 			this.setScene( scene );


### PR DESCRIPTION
Fixed #32863.

**Description**

The motivation for this PR is to ensure that rendered images and videos replicate the same scene environment setup as the viewport. To achieve this, the logic for how the viewport handles the DEFAULT environment is exposed, allowing both image rendering and video rendering to reuse it for consistent results.

The method name hasn’t been carefully considered yet and may be refined at a later stage.