### PR TITLE
WebGPURenderer: WebGL viewport / scissors not working correctly with PostProcessing

### DIFF
--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -450,6 +450,10 @@ class WebGLBackend extends Backend {
 
 			state.scissor( x, renderContext.height - height - y, width, height );
 
+		} else {
+
+			state.scissor( 0, 0, renderContext.width, renderContext.height );
+
 		}
 
 		//
@@ -542,6 +546,17 @@ class WebGLBackend extends Backend {
 
 				const { width, height } = this.getDrawingBufferSize();
 				state.viewport( 0, 0, width, height );
+
+			}
+
+			if ( previousContext.scissor ) {
+
+				this.updateScissor( previousContext );
+
+			} else {
+
+				const { width, height } = this.getDrawingBufferSize();
+				state.scissor( 0, 0, width, height );
 
 			}
 
@@ -643,6 +658,20 @@ class WebGLBackend extends Backend {
 		const { x, y, width, height } = renderContext.viewportValue;
 
 		state.viewport( x, renderContext.height - height - y, width, height );
+
+	}
+
+	/**
+	 * Updates the scissor with the values from the given render context.
+	 *
+	 * @param {RenderContext} renderContext - The render context.
+	 */
+	updateScissor( renderContext ) {
+
+		const { state } = this;
+		const { x, y, width, height } = renderContext.scissorValue;
+
+		state.scissor( x, renderContext.height - height - y, width, height );
 
 	}
 

--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -446,13 +446,12 @@ class WebGLBackend extends Backend {
 
 		if ( renderContext.scissor ) {
 
-			const { x, y, width, height } = renderContext.scissorValue;
-
-			state.scissor( x, renderContext.height - height - y, width, height );
+			this.updateScissor( renderContext );
 
 		} else {
 
-			state.scissor( 0, 0, renderContext.width, renderContext.height );
+			const { width, height } = this.getDrawingBufferSize();
+			state.scissor( 0, 0, width, height );
 
 		}
 


### PR DESCRIPTION
Fixed #32882

**Description**

When using `PostProcessing` with the WebGL backend (`forceWebGL: true`), viewport and scissor settings were incorrectly applied during nested render calls, causing rendered content to appear smaller than expected.

Root cause: In WebGL, scissor state is global. When `PassNode` renders the scene to a render target (triggering a nested `renderer.render()` call), the `beginRender` method didn't reset the scissor when `renderContext.scissor` was `false`. This left the outer scissor active, causing the render target to only receive content within the outer scissor area.

Fix in `WebGLBackend.js`:

In `beginRender`: Added else clause to reset scissor to the full render area when `renderContext.scissor` is `false
`
In `finishRender`: Added scissor state restoration (matching the existing viewport restoration pattern)
This ensures proper scissor state isolation between nested render calls, matching WebGPU's per-render-pass state model.