### PR TITLE
Fix #32865: fix undefined positionNode check

### DIFF
--- a/src/materials/nodes/NodeMaterial.js
+++ b/src/materials/nodes/NodeMaterial.js
@@ -835,7 +835,7 @@ class NodeMaterial extends Material {
 
 		}
 
-		if ( this.positionNode !== null ) {
+		if ( this.positionNode ) {
 
 			positionLocal.assign( subBuild( this.positionNode, 'POSITION', 'vec3' ) );
 


### PR DESCRIPTION
Related issue: #32865

**Description**

This PR fixes a crash in the WebGPU Editor that happens when switching the shading mode to Normals.

The Problem: In NodeMaterial.js, the code was checking if this.positionNode was not null. However, in certain cases (like material overrides in the Editor), the node was coming in as undefined. Because undefined is not strictly the same as null, the code tried to build the node anyway and crashed.

The Fix: I changed the check to ( this.positionNode ). This catches both null and undefined values, allowing the material to fall back to the default position.
