### PR TITLE
Editor: Ensure environment set only after renderer creation in restore

### DIFF
--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -168,8 +168,6 @@ Editor.prototype = {
 		this.signals.sceneGraphChanged.active = true;
 		this.signals.sceneGraphChanged.dispatch();
 
-		this.signals.sceneEnvironmentChanged.dispatch( this.environmentType, scene.environment );
-
 	},
 
 	//


### PR DESCRIPTION
**Description**

An issue occurs in editor **restore** when a project snapshot uses WebGPURenderer with Environment=DEFAULT. (webgpurenderer support introduced in #32842, default environment introduced in #32752).

Steps to reproduce:

1. Open a fresh editor (ensure autosave is enabled)
2. Change `project>renderer` to WebGPU
3. Refresh the page
4. Console shows **error** (This error doesn't affect the final restore result, but it shouldn't exist in the first place.)

During restore, `setScene` attempts to set the environment before creating renderer. This is invalid, because the environment requires the renderer to build the PMREMGenerator. Since the `rendererCreated` event handler will always set the environment once the renderer is ready ...

https://github.com/mrdoob/three.js/blob/f8464f9569b7e545b81ff0bebc99664ec3541f9e/editor/js/Viewport.js#L410

... this PR removes the redundant one in `setScene`. This ensures the environment is only applied after the renderer exists, preventing that error.
