### PR TITLE
WebGPURenderer: Turn off antialiasing in compat mode.

### DIFF
--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -218,6 +218,12 @@ class WebGPUBackend extends Backend {
 
 		this.compatibilityMode = ! device.features.has( 'core-features-and-limits' );
 
+		if ( this.compatibilityMode ) {
+
+			renderer._samples = 0;
+
+		}
+
 		device.lost.then( ( info ) => {
 
 			if ( info.reason === 'destroyed' ) return;


### PR DESCRIPTION
Related issue: #30725 

**Description**

Turn off antialiasing in compatibility mode. Compatibility mode does not support MSAA on rgba16float textures. (nor does WebGL2). Fixing this makes a large number of examples start working in compatibility mode.

I'm not sure where this check belongs.