### PR TITLE
Preserving index.varsion when coping BufferGeometry

### DIFF
--- a/src/core/BufferAttribute.js
+++ b/src/core/BufferAttribute.js
@@ -206,6 +206,7 @@ class BufferAttribute {
 
 		this.usage = source.usage;
 		this.gpuType = source.gpuType;
+    this.version = source.version;
 
 		return this;
 


### PR DESCRIPTION
Related issue: #32903

Here is a quick fix for defective caching mechanism in getWireframeAttribute

Any other ideas how this issue can be solved? 