### PR TITLE
Examples: Various fixes for WebGPU compatibility mode.

### DIFF
--- a/examples/webgpu_compute_birds.html
+++ b/examples/webgpu_compute_birds.html
@@ -158,7 +158,7 @@
 
 				//
 
-				renderer = new THREE.WebGPURenderer( { antialias: true, forceWebGL: false } );
+				renderer = new THREE.WebGPURenderer( { antialias: true, forceWebGL: false, requiredLimits: { maxStorageBuffersInVertexStage: 3 } } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setAnimationLoop( render );

--- a/examples/webgpu_compute_cloth.html
+++ b/examples/webgpu_compute_cloth.html
@@ -90,7 +90,7 @@
 
 			async function init() {
 
-				renderer = new THREE.WebGPURenderer( { antialias: true } );
+				renderer = new THREE.WebGPURenderer( { antialias: true, requiredLimits: { maxStorageBuffersInVertexStage: 1 } } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.toneMapping = THREE.NeutralToneMapping;

--- a/examples/webgpu_compute_particles_fluid.html
+++ b/examples/webgpu_compute_particles_fluid.html
@@ -77,7 +77,7 @@
 
 			async function init() {
 
-				renderer = new THREE.WebGPURenderer( { antialias: true } );
+				renderer = new THREE.WebGPURenderer( { antialias: true, requiredLimits: { maxStorageBuffersInVertexStage: 1 } } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;

--- a/examples/webgpu_compute_points.html
+++ b/examples/webgpu_compute_points.html
@@ -124,7 +124,7 @@
 				mesh.count = particlesCount;
 				scene.add( mesh );
 
-				renderer = new THREE.WebGPURenderer( { antialias: true } );
+				renderer = new THREE.WebGPURenderer( { antialias: true, requiredLimits: { maxStorageBuffersInVertexStage: 1 } } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setAnimationLoop( animate );

--- a/examples/webgpu_compute_water.html
+++ b/examples/webgpu_compute_water.html
@@ -457,7 +457,7 @@
 				const duckMesh = new THREE.InstancedMesh( duckModel.geometry, duckModel.material, NUM_DUCKS );
 				scene.add( duckMesh );
 
-				renderer = new THREE.WebGPURenderer( { antialias: true } );
+				renderer = new THREE.WebGPURenderer( { antialias: true, requiredLimits: { maxStorageBuffersInVertexStage: 2 } } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.toneMapping = THREE.ACESFilmicToneMapping;

--- a/examples/webgpu_mrt.html
+++ b/examples/webgpu_mrt.html
@@ -82,7 +82,7 @@
 
 				// renderer
 
-				renderer = new THREE.WebGPURenderer( { antialias: true } );
+				renderer = new THREE.WebGPURenderer( { antialias: true, requiredLimits: { maxColorAttachments: 5 } } );
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.setAnimationLoop( render );


### PR DESCRIPTION
Related issue: #30725

**Description**

These twice make these particular samples work in compatibility mode, though not necessarily on compatibility hardware. IIRC about 30% of compatibility hardware does not support storage textures in vertex shaders.

I also spec that most of that hardware only supports 4 render targets where as the MRT example needs 5. You could change the same to only use 4 as another solution. Or have it check the limit.

