### PR TITLE
WebGPURenderer: Make wireframe update more flexible.

### DIFF
--- a/src/renderers/common/Geometries.js
+++ b/src/renderers/common/Geometries.js
@@ -19,6 +19,20 @@ function getWireframeVersion( geometry ) {
 }
 
 /**
+ * Returns the wireframe ID for the given geometry.
+ *
+ * @private
+ * @function
+ * @param {BufferGeometry} geometry - The geometry.
+ * @return {number} The ID.
+ */
+function getWireframeId( geometry ) {
+
+	return ( geometry.index !== null ) ? geometry.index.id : geometry.attributes.position.id;
+
+}
+
+/**
  * Returns a wireframe index attribute for the given geometry.
  *
  * @private
@@ -65,6 +79,7 @@ function getWireframeIndex( geometry ) {
 
 	const attribute = new ( arrayNeedsUint32( indices ) ? Uint32BufferAttribute : Uint16BufferAttribute )( indices, 1 );
 	attribute.version = getWireframeVersion( geometry );
+	attribute.__id = getWireframeId( geometry );
 
 	return attribute;
 
@@ -347,7 +362,7 @@ class Geometries extends DataMap {
 
 				wireframes.set( geometry, wireframeAttribute );
 
-			} else if ( wireframeAttribute.version !== getWireframeVersion( geometry ) ) {
+			} else if ( wireframeAttribute.version !== getWireframeVersion( geometry ) || wireframeAttribute.__id !== getWireframeId( geometry ) ) {
 
 				this.attributes.delete( wireframeAttribute );
 


### PR DESCRIPTION
Fixed #32903.

**Description**

Instead of checking just the `version`, we now keep track of the current ID of the buffer attribute the wireframe attribute is linked to. 

I did not want to introduce a new property for this in `BufferAttribute` or a separate `WeakMap` in `renderers/common/Geometries.js` so the tracked ID is stored in a super-private property `__id`.

https://github.com/user-attachments/assets/c0b06b83-6fcd-4f63-b1d2-f8e88edfbe3b
