### PR TITLE
BindGroup: Remove `bindingsReference`.

### DIFF
--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -598,7 +598,7 @@ class NodeBuilder {
 
 			if ( bindGroup === undefined ) {
 
-				bindGroup = new BindGroup( groupName, bindingsArray, this.bindingsIndexes[ groupName ].group, bindingsArray );
+				bindGroup = new BindGroup( groupName, bindingsArray, this.bindingsIndexes[ groupName ].group );
 
 				bindGroupsCache.set( bindingsArray, bindGroup );
 
@@ -606,7 +606,7 @@ class NodeBuilder {
 
 		} else {
 
-			bindGroup = new BindGroup( groupName, bindingsArray, this.bindingsIndexes[ groupName ].group, bindingsArray );
+			bindGroup = new BindGroup( groupName, bindingsArray, this.bindingsIndexes[ groupName ].group );
 
 		}
 

--- a/src/renderers/common/BindGroup.js
+++ b/src/renderers/common/BindGroup.js
@@ -15,9 +15,8 @@ class BindGroup {
 	 * @param {string} name - The bind group's name.
 	 * @param {Array<Binding>} bindings - An array of bindings.
 	 * @param {number} index - The group index.
-	 * @param {Array<Binding>} bindingsReference - An array of reference bindings.
 	 */
-	constructor( name = '', bindings = [], index = 0, bindingsReference = [] ) {
+	constructor( name = '', bindings = [], index = 0 ) {
 
 		/**
 		 * The bind group's name.
@@ -39,13 +38,6 @@ class BindGroup {
 		 * @type {number}
 		 */
 		this.index = index;
-
-		/**
-		 * An array of reference bindings.
-		 *
-		 * @type {Array<Binding>}
-		 */
-		this.bindingsReference = bindingsReference;
 
 		/**
 		 * The group's ID.

--- a/src/renderers/common/nodes/NodeBuilderState.js
+++ b/src/renderers/common/nodes/NodeBuilderState.js
@@ -126,7 +126,7 @@ class NodeBuilderState {
 
 			if ( shared !== true ) {
 
-				const bindingsGroup = new BindGroup( instanceGroup.name, [], instanceGroup.index, instanceGroup.bindingsReference );
+				const bindingsGroup = new BindGroup( instanceGroup.name, [], instanceGroup.index );
 				bindings.push( bindingsGroup );
 
 				for ( const instanceBinding of instanceGroup.bindings ) {


### PR DESCRIPTION
Related issue: #32451

**Description**

After #32451, `BindGroup.bindingsReference` has no purpose anymore and can be removed.
