### PR TITLE
Fix: Add missing lint-docs script to package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -888,7 +888,6 @@
       "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
@@ -950,7 +949,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1238,7 +1236,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1514,8 +1511,7 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1551306.tgz",
       "integrity": "sha512-CFx8QdSim8iIv+2ZcEOclBKTQY6BI1IEDa7Tm9YkwAXzEWFndTEzpTo5jAUhSnq24IC7xaDw0wvGcm96+Y3PEg==",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -1697,7 +1693,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3218,7 +3213,6 @@
       "integrity": "sha512-9FwVqlgUHzbXtDg9RCMgodF3Ua4Na6Gau+Sdt9vyCN4RhHfVKX2DCHy3BjMLTDd47ITDhYAnTwGulWTblJSDLg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "dev": "node utils/build/dev.js && node utils/server.js -p 8080",
     "preview": "node utils/build/preview.js",
     "lint-core": "eslint src",
+    "lint-docs": "eslint docs",
     "lint-addons": "eslint examples/jsm",
     "lint-examples": "eslint examples",
     "lint-editor": "eslint editor",


### PR DESCRIPTION
- Added missing 'lint-docs' script that was referenced in 'lint-fix'
- Fixes npm run lint-fix command failure
- Script lints the docs directory with eslint

Related issue: #32911 


**Description**

**Problem:** The `lint-fix` script in `package.json` (line 63) references `npm run lint-docs`, but the `lint-docs` script **was not defined** in the scripts section. This caused the `npm run lint-fix` command to **fail** with a "missing script" error.

## Solution
Added the missing `lint-docs` script to the scripts section of `package.json`:

```json
"lint-docs": "eslint docs",

