### PR TITLE
NodeBuilder: Fix shared group detection.

### DIFF
--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -584,7 +584,7 @@ class NodeBuilder {
 
 			bindingsArray.push( binding );
 
-			sharedGroup = sharedGroup && binding.groupNode.shared !== true;
+			sharedGroup = sharedGroup && binding.groupNode.shared;
 
 		}
 


### PR DESCRIPTION
Related issue: -

**Description**

Caching of bind groups in `WebGPURenderer` does not work as expected. There are multiple issues, one of them is fixed by this PR.

To detect whether a bind group is shared or not, all bindings must have a sharable group node. The detection for this is currently inverted.