### PR TITLE
Cleanup generateMipmaps

### DIFF
--- a/src/renderers/webgpu/utils/WebGPUTexturePassUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUTexturePassUtils.js
@@ -98,16 +98,6 @@ fn main_cube( Varys: VarysStruct ) -> @location( 0 ) vec4<f32> {
 	return textureSample( imgCube, imgSampler, faceMat[ Varys.vBaseArrayLayer ] * vec3f( fract( Varys.vTex ), 1 ) );
 
 }
-
-@group( 0 ) @binding( 1 )
-var imgCubeArray : texture_cube_array<f32>;
-
-@fragment
-fn main_cube_array( Varys: VarysStruct ) -> @location( 0 ) vec4<f32> {
-
-	return textureSample( imgCubeArray, imgSampler, faceMat[ Varys.vBaseArrayLayer % 6 ] * vec3f( fract( Varys.vTex ), 1 ), Varys.vBaseArrayLayer );
-
-}
 `;
 
 		/**


### PR DESCRIPTION
Related issue: #32903

**Description**

There's no reason to have a cube-array path for generateMipmaps. Compat mode does not support cube-array and core mode will always use the 2d-array path.

When I copied this code from webgpu-utils, I noticed that the code for cube-array was indexing the `faceMat` array by `baseArrayLayer` which didn't make sense to me. In the three.js PR I changed it to `baseArrayLayer % 6`. But then I went back and try to figure out why tests were passing in webgpu-utils. I finally realized this path is never used 😅. I deleted it there and now this PR deletes it here.
