### PR TITLE
WebGPURenderer: Fix `flipY` and cache key when `generateMipmap`

### DIFF
--- a/src/renderers/webgpu/utils/WebGPUTexturePassUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUTexturePassUtils.js
@@ -182,7 +182,7 @@ fn main_cube( Varys: VarysStruct ) -> @location( 0 ) vec4<f32> {
 				layout: 'auto'
 			} );
 
-			this.transferPipelines[ format ] = pipeline;
+			this.transferPipelines[ key ] = pipeline;
 
 		}
 

--- a/src/renderers/webgpu/utils/WebGPUTexturePassUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUTexturePassUtils.js
@@ -49,7 +49,7 @@ fn mainVS(
 
 	let p = pos[ vertexIndex ];
 	let mult = select( vec2f( 0.5, -0.5 ), vec2f( 0.5, 0.5 ), flipY != 0 );
-	Varys.vTex = p * vec2f( 0.5, -0.5 ) + vec2f( 0.5 );
+	Varys.vTex = p * mult + vec2f( 0.5 );
 	Varys.Position = vec4f( p, 0, 1 );
 	Varys.vBaseArrayLayer = instanceIndex;
 

--- a/src/renderers/webgpu/utils/WebGPUTextureUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUTextureUtils.js
@@ -822,13 +822,11 @@ class WebGPUTextureUtils {
 	 *
 	 * @private
 	 * @param {GPUTexture} textureGPU - The GPU texture object.
-	 * @param {Object} textureDescriptorGPU - The texture descriptor.
-	 * @param {number} [baseArrayLayer=0] - The index of the first array layer accessible to the texture view.
 	 * @param {?GPUCommandEncoder} [encoder=null] - An optional command encoder used to generate mipmaps.
 	 */
-	_generateMipmaps( textureGPU, textureDescriptorGPU, baseArrayLayer = 0, encoder = null ) {
+	_generateMipmaps( textureGPU, encoder = null ) {
 
-		this._getPassUtils().generateMipmaps( textureGPU, textureDescriptorGPU, baseArrayLayer, encoder );
+		this._getPassUtils().generateMipmaps( textureGPU, encoder );
 
 	}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/32906

**Description**

Fix `flipY` and cache key when `generateMipmap` and update function signature.

This should fix the `webgpu_performance` [example](https://github.com/mrdoob/three.js/pull/32848#issuecomment-3830080270).