### PR TITLE
NodeMaterialObserver: track renderId per render object instead observer

### DIFF
--- a/src/materials/nodes/manager/NodeMaterialObserver.js
+++ b/src/materials/nodes/manager/NodeMaterialObserver.js
@@ -108,14 +108,6 @@ class NodeMaterialObserver {
 		 */
 		this.refreshUniforms = refreshUniforms;
 
-		/**
-		 * Holds the current render ID from the node frame.
-		 *
-		 * @type {number}
-		 * @default 0
-		 */
-		this.renderId = 0;
-
 	}
 
 	/**
@@ -169,6 +161,7 @@ class NodeMaterialObserver {
 			const { geometry, material, object } = renderObject;
 
 			data = {
+				renderId: 0,
 				material: this.getMaterialData( material ),
 				geometry: {
 					id: geometry.id,
@@ -586,17 +579,18 @@ class NodeMaterialObserver {
 			return true;
 
 		const { renderId } = nodeFrame;
+		const renderObjectData = this.getRenderObjectData( renderObject );
 
-		if ( this.renderId !== renderId ) {
+		if ( renderObjectData.renderId !== renderId ) {
 
-			this.renderId = renderId;
+			renderObjectData.renderId = renderId;
 
 			return true;
 
 		}
 
 		const isStatic = renderObject.object.static === true;
-		const isBundle = renderObject.bundle !== null && renderObject.bundle.static === true && this.getRenderObjectData( renderObject ).version === renderObject.bundle.version;
+		const isBundle = renderObject.bundle !== null && renderObject.bundle.static === true && renderObjectData.version === renderObject.bundle.version;
 
 		if ( isStatic || isBundle )
 			return false;


### PR DESCRIPTION
Related issue: #32926

NodeMaterialObserver: track renderId per render object instead of per observer

Multiple render objects sharing the same observer (same cache key) would
incorrectly skip geometry updates because the first object processed would
set the shared renderId, causing subsequent objects to fall through to
equals() which only checked attribute.version, not actual attribute identity.


When setAttribute()/setIndex() replaces an attribute with a new object
that has the same version number, the cache incorrectly treated it as
unchanged, causing GPU buffer creation to be skipped and a crash on render.

Changes:
- Move renderId from observer-level to per-render-object data
- All render objects now get the fast renderId path (performance Impact should be positive if any - but havent checked)