### PR TITLE
Revert "NodeMaterialObserver: track renderId per render object instead observer"

### DIFF
--- a/src/materials/nodes/manager/NodeMaterialObserver.js
+++ b/src/materials/nodes/manager/NodeMaterialObserver.js
@@ -108,6 +108,14 @@ class NodeMaterialObserver {
 		 */
 		this.refreshUniforms = refreshUniforms;
 
+		/**
+		 * Holds the current render ID from the node frame.
+		 *
+		 * @type {number}
+		 * @default 0
+		 */
+		this.renderId = 0;
+
 	}
 
 	/**
@@ -161,7 +169,6 @@ class NodeMaterialObserver {
 			const { geometry, material, object } = renderObject;
 
 			data = {
-				renderId: 0,
 				material: this.getMaterialData( material ),
 				geometry: {
 					id: geometry.id,
@@ -579,18 +586,17 @@ class NodeMaterialObserver {
 			return true;
 
 		const { renderId } = nodeFrame;
-		const renderObjectData = this.getRenderObjectData( renderObject );
 
-		if ( renderObjectData.renderId !== renderId ) {
+		if ( this.renderId !== renderId ) {
 
-			renderObjectData.renderId = renderId;
+			this.renderId = renderId;
 
 			return true;
 
 		}
 
 		const isStatic = renderObject.object.static === true;
-		const isBundle = renderObject.bundle !== null && renderObject.bundle.static === true && renderObjectData.version === renderObject.bundle.version;
+		const isBundle = renderObject.bundle !== null && renderObject.bundle.static === true && this.getRenderObjectData( renderObject ).version === renderObject.bundle.version;
 
 		if ( isStatic || isBundle )
 			return false;


### PR DESCRIPTION
Reverts mrdoob/three.js#32927

see https://github.com/mrdoob/three.js/pull/32927#issuecomment-3833760699