### PR TITLE
HalftoneShader: Add diamond shape option.

### DIFF
--- a/examples/jsm/shaders/HalftoneShader.js
+++ b/examples/jsm/shaders/HalftoneShader.js
@@ -8,7 +8,7 @@
  *
  * Used by {@link HalftonePass}.
  *
- * Shape (1 = Dot, 2 = Ellipse, 3 = Line, 4 = Square)
+ * Shape (1 = Dot, 2 = Ellipse, 3 = Line, 4 = Square, 5 = Diamond)
  * Blending Mode (1 = Linear, 2 = Multiply, 3 = Add, 4 = Lighter, 5 = Darker)
  *
  * @constant

--- a/examples/jsm/shaders/HalftoneShader.js
+++ b/examples/jsm/shaders/HalftoneShader.js
@@ -49,11 +49,13 @@ const HalftoneShader = {
 
 		#define SQRT2_MINUS_ONE 0.41421356
 		#define SQRT2_HALF_MINUS_ONE 0.20710678
+		#define PI 3.14159265
 		#define PI2 6.28318531
 		#define SHAPE_DOT 1
 		#define SHAPE_ELLIPSE 2
 		#define SHAPE_LINE 3
 		#define SHAPE_SQUARE 4
+		#define SHAPE_DIAMOND 5
 		#define BLENDING_LINEAR 1
 		#define BLENDING_MULTIPLY 2
 		#define BLENDING_ADD 3
@@ -124,6 +126,15 @@ const HalftoneShader = {
 			} else if ( shape == SHAPE_SQUARE ) {
 
 				float theta = atan( p.y - coord.y, p.x - coord.x ) - angle;
+				float sin_t = abs( sin( theta ) );
+				float cos_t = abs( cos( theta ) );
+				rad = pow( abs( rad ), 1.4 );
+				rad = rad_max * ( rad + ( ( sin_t > cos_t ) ? rad - sin_t * rad : rad - cos_t * rad ) );
+
+			} else if ( shape == SHAPE_DIAMOND ) {
+
+				float angle45 = PI / 4.0;
+				float theta = atan( p.y - coord.y, p.x - coord.x ) - angle - angle45;
 				float sin_t = abs( sin( theta ) );
 				float cos_t = abs( cos( theta ) );
 				rad = pow( abs( rad ), 1.4 );

--- a/examples/webgl_postprocessing_rgb_halftone.html
+++ b/examples/webgl_postprocessing_rgb_halftone.html
@@ -179,7 +179,7 @@
 				}
 
 				const gui = new GUI();
-				gui.add( controller, 'shape', { 'Dot': 1, 'Ellipse': 2, 'Line': 3, 'Square': 4 } ).onChange( onGUIChange );
+				gui.add( controller, 'shape', { 'Dot': 1, 'Ellipse': 2, 'Line': 3, 'Square': 4, 'Diamond': 5 } ).onChange( onGUIChange );
 				gui.add( controller, 'radius', 1, 25 ).onChange( onGUIChange );
 				gui.add( controller, 'rotateR', 0, 90 ).onChange( onGUIChange );
 				gui.add( controller, 'rotateG', 0, 90 ).onChange( onGUIChange );


### PR DESCRIPTION
Related issue: (none)

**Description**

This PR adds a diamond shape option to the [Halftone shader](https://threejs.org/examples/?q=halftone#webgl_postprocessing_rgb_halftone). Although the square shape can create a diamond effect when rotated 45 degrees, the shape aligns along the edges rather than the points. The following image shows the visual difference between these shapes.

<img width="1311" height="442" alt="diamond-shape" src="https://github.com/user-attachments/assets/2a82583d-0ede-450f-a8b0-093a25954c94" />

I'm very new to 3D programming and this solution was [suggested by another community member](https://discourse.threejs.org/t/create-halftone-effect-with-a-diamond-shape/89585/3). There is some code duplication here that I would normally avoid, but I was unable to find an `||` condition syntax for GLSL like  `if (shape == SHAPE_SQUARE || shape == SHAPE_DIAMOND)`. I am probably missing something obvious.