### PR TITLE
FileLoader: Fix typo in JSDoc.

### DIFF
--- a/src/loaders/FileLoader.js
+++ b/src/loaders/FileLoader.js
@@ -43,7 +43,7 @@ class FileLoader extends Loader {
 
 		/**
 		 * The expected mime type. Valid values can be found
-		 * [here](hhttps://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString#mimetype)
+		 * [here](https://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString#mimetype)
 		 *
 		 * @type {string}
 		 */


### PR DESCRIPTION
## Description
Fix a typo in the JSDoc for `FileLoader`: the Mozilla MDN link used `hhttps` instead of `https`, which breaks the link in generated documentation.

## Change
- **File:** `src/loaders/FileLoader.js`
- **Line 46:** In the `mimeType` property JSDoc, change the link from `hhttps://` to `https://`.

## Type of change
- [x] Documentation fix (typo in JSDoc link)