### PR TITLE
ObjectLoader: Wrap `JSON.parse()` in try/catch for consistent error handling.

### DIFF
--- a/src/loaders/ObjectLoader.js
+++ b/src/loaders/ObjectLoader.js
@@ -170,7 +170,17 @@ class ObjectLoader extends Loader {
 
 		const text = await loader.loadAsync( url, onProgress );
 
-		const json = JSON.parse( text );
+		let json;
+
+		try {
+
+			json = JSON.parse( text );
+
+		} catch ( e ) {
+
+			throw new Error( 'ObjectLoader: Can\'t parse ' + url + '. ' + e.message );
+
+		}
 
 		const metadata = json.metadata;
 


### PR DESCRIPTION
## Description
`ObjectLoader.loadAsync()` previously did not wrap `JSON.parse(text)` in try/catch. Invalid JSON caused a raw `SyntaxError` to be thrown, while the callback-based `load()` uses try/catch and reports "ObjectLoader: Can't parse ..." via `onError`. This change aligns async behavior with the callback API and gives clearer, consistent error messages.

## Change
- **File:** `src/loaders/ObjectLoader.js`
- In `loadAsync()`, wrap `JSON.parse(text)` in try/catch and throw `new Error('ObjectLoader: Can\'t parse ' + url + '. ' + e.message)` on parse failure.

## Type of change
- [x] Bug fix (non-breaking change that fixes error handling consistency)