### PR TITLE
BatchedMesh: Add support for wireframe materials

### DIFF
--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -1513,7 +1513,19 @@ class BatchedMesh extends Mesh {
 		// the indexed version of the multi draw function requires specifying the start
 		// offset in bytes.
 		const index = geometry.getIndex();
-		const bytesPerElement = index === null ? 1 : index.array.BYTES_PER_ELEMENT;
+		let bytesPerElement = index === null ? 1 : index.array.BYTES_PER_ELEMENT;
+
+
+		// the "wireframe" attribute implicitly creates a line attribute in the renderer, which is double
+		// the vertices to draw (3 lines per triangle) so we multiply the draw counts / starts and make
+		// assumptions about the index buffer byte size.
+		let multiDrawMultiplier = 1;
+		if ( material.wireframe ) {
+
+			multiDrawMultiplier = 2;
+			bytesPerElement = geometry.attributes.position.count > 65535 ? 4 : 2;
+
+		}
 
 		const instanceInfo = this._instanceInfo;
 		const multiDrawStarts = this._multiDrawStarts;
@@ -1539,10 +1551,7 @@ class BatchedMesh extends Mesh {
 
 		}
 
-		// the "wireframe" attribute implicitly creates a line attribute in the renderer, which is double
-		// the vertices to draw (3 lines per triangle) so we multiply the draw counts here.
 		let multiDrawCount = 0;
-		const multiDrawMultiplier = material.wireframe ? 2 : 1;
 		if ( this.sortObjects ) {
 
 			// get the camera position in the local frame

--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -1539,6 +1539,8 @@ class BatchedMesh extends Mesh {
 
 		}
 
+		// the "wireframe" attribute implicitly creates a line attribute in the renderer, which is double
+		// the vertices to draw (3 lines per triangle) so we multiply the draw counts here.
 		let multiDrawCount = 0;
 		const multiDrawMultiplier = material.wireframe ? 2 : 1;
 		if ( this.sortObjects ) {

--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -1540,6 +1540,7 @@ class BatchedMesh extends Mesh {
 		}
 
 		let multiDrawCount = 0;
+		const multiDrawMultiplier = material.wireframe ? 2 : 1;
 		if ( this.sortObjects ) {
 
 			// get the camera position in the local frame
@@ -1594,8 +1595,8 @@ class BatchedMesh extends Mesh {
 			for ( let i = 0, l = list.length; i < l; i ++ ) {
 
 				const item = list[ i ];
-				multiDrawStarts[ multiDrawCount ] = item.start * bytesPerElement;
-				multiDrawCounts[ multiDrawCount ] = item.count;
+				multiDrawStarts[ multiDrawCount ] = item.start * bytesPerElement * multiDrawMultiplier;
+				multiDrawCounts[ multiDrawCount ] = item.count * multiDrawMultiplier;
 				indirectArray[ multiDrawCount ] = item.index;
 				multiDrawCount ++;
 
@@ -1625,8 +1626,8 @@ class BatchedMesh extends Mesh {
 					if ( ! culled ) {
 
 						const geometryInfo = geometryInfoList[ geometryId ];
-						multiDrawStarts[ multiDrawCount ] = geometryInfo.start * bytesPerElement;
-						multiDrawCounts[ multiDrawCount ] = geometryInfo.count;
+						multiDrawStarts[ multiDrawCount ] = geometryInfo.start * bytesPerElement * multiDrawMultiplier;
+						multiDrawCounts[ multiDrawCount ] = geometryInfo.count * multiDrawMultiplier;
 						indirectArray[ multiDrawCount ] = i;
 						multiDrawCount ++;
 

--- a/src/renderers/webgl/WebGLGeometries.js
+++ b/src/renderers/webgl/WebGLGeometries.js
@@ -85,6 +85,12 @@ function WebGLGeometries( gl, attributes, info, bindingStates ) {
 		const geometryPosition = geometry.attributes.position;
 		let version = 0;
 
+		if ( geometryPosition === undefined ) {
+
+			return;
+
+		}
+
 		if ( geometryIndex !== null ) {
 
 			const array = geometryIndex.array;
@@ -100,7 +106,7 @@ function WebGLGeometries( gl, attributes, info, bindingStates ) {
 
 			}
 
-		} else if ( geometryPosition !== undefined ) {
+		} else {
 
 			const array = geometryPosition.array;
 			version = geometryPosition.version;
@@ -115,13 +121,11 @@ function WebGLGeometries( gl, attributes, info, bindingStates ) {
 
 			}
 
-		} else {
-
-			return;
-
 		}
 
-		const attribute = new ( arrayNeedsUint32( indices ) ? Uint32BufferAttribute : Uint16BufferAttribute )( indices, 1 );
+		// check whether a 32 bit or 16 bit buffer is required to store the indices
+		// account for PRIMITIVE_RESTART_FIXED_INDEX, #24565
+		const attribute = new ( geometryPosition.count >= 65535 ? Uint32BufferAttribute : Uint16BufferAttribute )( indices, 1 );
 		attribute.version = version;
 
 		// Updating index buffer in VAO now. See WebGLBindingStates

--- a/src/renderers/webgl/WebGLGeometries.js
+++ b/src/renderers/webgl/WebGLGeometries.js
@@ -1,5 +1,4 @@
 import { Uint16BufferAttribute, Uint32BufferAttribute } from '../../core/BufferAttribute.js';
-import { arrayNeedsUint32 } from '../../utils.js';
 
 function WebGLGeometries( gl, attributes, info, bindingStates ) {
 


### PR DESCRIPTION
Fix #32939

**Description**

The BatchedMesh multidraw starts and counts need to align with the internally-created index buffer for line primitives, which will be 2x the length of those for triangles (3 lines per tri). Because the renderer will create a uint16 or uint32 buffer based on some internal calculations we have to try to make some of the same assumptions, which feels a little messy but I can't see a more clean way to handle it.

<img width="785" height="759" alt="image" src="https://github.com/user-attachments/assets/5854c18a-41d2-4801-894b-4057fbf3bf75" />
