### PR TITLE
LineMaterial: Set needsupdate when changing worldUnits property

### DIFF
--- a/examples/jsm/lines/LineMaterial.js
+++ b/examples/jsm/lines/LineMaterial.js
@@ -484,6 +484,12 @@ class LineMaterial extends ShaderMaterial {
 
 	set worldUnits( value ) {
 
+		if ( ( value === true ) !== this.worldUnits ) {
+
+			this.needsUpdate = true;
+
+		}
+
 		if ( value === true ) {
 
 			this.defines.WORLD_UNITS = '';

--- a/examples/webgl_lines_fat.html
+++ b/examples/webgl_lines_fat.html
@@ -228,7 +228,6 @@
 				gui.add( param, 'world units' ).onChange( function ( val ) {
 
 					matLine.worldUnits = val;
-					matLine.needsUpdate = true;
 
 				} );
 

--- a/examples/webgl_lines_fat_raycasting.html
+++ b/examples/webgl_lines_fat_raycasting.html
@@ -307,10 +307,7 @@
 				gui.add( params, 'world units' ).onChange( function ( val ) {
 
 					matLine.worldUnits = val;
-					matLine.needsUpdate = true;
-
 					matThresholdLine.worldUnits = val;
-					matThresholdLine.needsUpdate = true;
 
 				} );
 


### PR DESCRIPTION
Related issue: n/a

**Description**

I think that it can be confusing that changing `worldUnits` doesn't affect anything in the rendering.  The other properties `dashed` and `alphaToCoverage` set `needsUpdate` when they change

