### PR TITLE
TextureNode: Use `compareNode` for Android if `compareStepNode` is not compatible

### DIFF
--- a/src/nodes/accessors/TextureNode.js
+++ b/src/nodes/accessors/TextureNode.js
@@ -405,13 +405,17 @@ class TextureNode extends UniformNode {
 
 			} else {
 
-				if ( this.value.compareFunction !== null && this.value.compareFunction !== LessCompare ) {
+				if ( this.value.compareFunction === null || this.value.compareFunction === LessCompare ) {
+
+					compareStepNode = this.compareNode;
+
+				} else {
+
+					compareNode = this.compareNode;
 
 					warnOnce( 'TSL: Only "LessCompare" is supported for depth texture comparison fallback.' );
 
 				}
-
-				compareStepNode = this.compareNode;
 
 			}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/32548, https://github.com/mrdoob/three.js/pull/32953#issuecomment-3848477194

**Description**

`compareStepNode` was being used on Android even when it was incompatible. With this PR, `compareStepNode` will only be used if it is compatible with `Texture.compareFunction`.

