### PR TITLE
Loaders/Animation/Nodes: Add JSON.parse error handling and fix Array type check

### DIFF
--- a/examples/jsm/loaders/FontLoader.js
+++ b/examples/jsm/loaders/FontLoader.js
@@ -49,9 +49,27 @@ class FontLoader extends Loader {
 		loader.setWithCredentials( this.withCredentials );
 		loader.load( url, function ( text ) {
 
-			const font = scope.parse( JSON.parse( text ) );
+			try {
 
-			if ( onLoad ) onLoad( font );
+				const font = scope.parse( JSON.parse( text ) );
+
+				if ( onLoad ) onLoad( font );
+
+			} catch ( e ) {
+
+				if ( onError ) {
+
+					onError( e );
+
+				} else {
+
+					console.error( e );
+
+				}
+
+				scope.manager.itemError( url );
+
+			}
 
 		}, onProgress, onError );
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -429,38 +429,37 @@ class GLTFLoader extends Loader {
 		const plugins = {};
 		const textDecoder = new TextDecoder();
 
-		if ( typeof data === 'string' ) {
+		try {
 
-			json = JSON.parse( data );
+			if ( typeof data === 'string' ) {
 
-		} else if ( data instanceof ArrayBuffer ) {
+				json = JSON.parse( data );
 
-			const magic = textDecoder.decode( new Uint8Array( data, 0, 4 ) );
+			} else if ( data instanceof ArrayBuffer ) {
 
-			if ( magic === BINARY_EXTENSION_HEADER_MAGIC ) {
+				const magic = textDecoder.decode( new Uint8Array( data, 0, 4 ) );
 
-				try {
+				if ( magic === BINARY_EXTENSION_HEADER_MAGIC ) {
 
 					extensions[ EXTENSIONS.KHR_BINARY_GLTF ] = new GLTFBinaryExtension( data );
+					json = JSON.parse( extensions[ EXTENSIONS.KHR_BINARY_GLTF ].content );
 
-				} catch ( error ) {
+				} else {
 
-					if ( onError ) onError( error );
-					return;
+					json = JSON.parse( textDecoder.decode( data ) );
 
 				}
 
-				json = JSON.parse( extensions[ EXTENSIONS.KHR_BINARY_GLTF ].content );
-
 			} else {
 
-				json = JSON.parse( textDecoder.decode( data ) );
+				json = data;
 
 			}
 
-		} else {
+		} catch ( error ) {
 
-			json = data;
+			if ( onError ) onError( error );
+			return;
 
 		}
 

--- a/examples/jsm/loaders/LottieLoader.js
+++ b/examples/jsm/loaders/LottieLoader.js
@@ -83,39 +83,55 @@ class LottieLoader extends Loader {
 
 		loader.load( url, function ( text ) {
 
-			const data = JSON.parse( text );
+			try {
 
-			// lottie uses container.offsetWidth and offsetHeight
-			// to define width/height
+				const data = JSON.parse( text );
 
-			const container = document.createElement( 'div' );
-			container.style.width = data.w + 'px';
-			container.style.height = data.h + 'px';
-			document.body.appendChild( container );
+				// lottie uses container.offsetWidth and offsetHeight
+				// to define width/height
 
-			const animation = lottie.loadAnimation( {
-				container: container,
-				animType: 'canvas',
-				loop: true,
-				autoplay: true,
-				animationData: data,
-				rendererSettings: { dpr: quality }
-			} );
+				const container = document.createElement( 'div' );
+				container.style.width = data.w + 'px';
+				container.style.height = data.h + 'px';
+				document.body.appendChild( container );
 
-			texture.animation = animation;
-			texture.image = animation.container;
+				const animation = lottie.loadAnimation( {
+					container: container,
+					animType: 'canvas',
+					loop: true,
+					autoplay: true,
+					animationData: data,
+					rendererSettings: { dpr: quality }
+				} );
 
-			animation.addEventListener( 'enterFrame', function () {
+				texture.animation = animation;
+				texture.image = animation.container;
 
-				texture.needsUpdate = true;
+				animation.addEventListener( 'enterFrame', function () {
 
-			} );
+					texture.needsUpdate = true;
 
-			container.style.display = 'none';
+				} );
 
-			if ( onLoad !== undefined ) {
+				container.style.display = 'none';
 
-				onLoad( texture );
+				if ( onLoad !== undefined ) {
+
+					onLoad( texture );
+
+				}
+
+			} catch ( e ) {
+
+				if ( onError ) {
+
+					onError( e );
+
+				} else {
+
+					console.error( e );
+
+				}
 
 			}
 

--- a/src/animation/AnimationClip.js
+++ b/src/animation/AnimationClip.js
@@ -107,7 +107,16 @@ class AnimationClip {
 		const clip = new this( json.name, json.duration, tracks, json.blendMode );
 		clip.uuid = json.uuid;
 
-		clip.userData = JSON.parse( json.userData || '{}' );
+		try {
+
+			clip.userData = JSON.parse( json.userData || '{}' );
+
+		} catch ( e ) {
+
+			warn( 'AnimationClip: Unable to parse userData.' );
+			clip.userData = {};
+
+		}
 
 		return clip;
 

--- a/src/nodes/core/NodeUtils.js
+++ b/src/nodes/core/NodeUtils.js
@@ -18,7 +18,7 @@ function cyrb53( value, seed = 0 ) {
 
 	let h1 = 0xdeadbeef ^ seed, h2 = 0x41c6ce57 ^ seed;
 
-	if ( value instanceof Array ) {
+	if ( Array.isArray( value ) ) {
 
 		for ( let i = 0, val; i < value.length; i ++ ) {
 


### PR DESCRIPTION
## Summary

This PR adds consistent error handling for `JSON.parse()` calls across multiple loaders and fixes an array type checking inconsistency, following the pattern established in #32947.

### Changes

- **FontLoader**: Wrap `JSON.parse` in try/catch, invoking `onError` callback on failure
- **GLTFLoader**: Wrap all `JSON.parse` calls in `parse()` method with try/catch (lines 434, 453, 457)
- **LottieLoader**: Wrap `JSON.parse` in try/catch for consistent error handling (deprecated loader)
- **AnimationClip**: Add try/catch for `userData` JSON.parse in `parse()` static method
- **NodeUtils**: Use `Array.isArray()` instead of `instanceof Array` for cross-realm compatibility

### Motivation

Without proper error handling, malformed JSON files cause unhandled exceptions instead of invoking the `onError` callbacks that users expect. This is inconsistent with the recent fix in `ObjectLoader.loadAsync()` (#32947).

The `Array.isArray()` change ensures correct behavior when arrays are passed between different JavaScript execution contexts (e.g., iframes).

## Test

- [x] Load malformed JSON with FontLoader - verify `onError` is called
- [x] Load malformed glTF JSON with GLTFLoader - verify `onError` is called  
- [x] Load malformed Lottie JSON with LottieLoader - verify `onError` is called
- [x] Parse AnimationClip with malformed userData - verify graceful fallback to `{}`
