### PR TITLE
`updateMatrixWorld()` --> `ensureMatrices()`

### DIFF
--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -410,7 +410,7 @@ Editor.prototype = {
 					const light = object;
 					const editor = this;
 
-					helper.updateMatrixWorld = function () {
+					helper.ensureMatrices = function () {
 
 						light.getWorldPosition( this.position );
 
@@ -424,7 +424,7 @@ Editor.prototype = {
 
 						for ( let i = 0, l = children.length; i < l; i ++ ) {
 
-							children[ i ].updateMatrixWorld();
+							children[ i ].ensureMatrices();
 
 						}
 

--- a/editor/js/Menubar.Render.js
+++ b/editor/js/Menubar.Render.js
@@ -204,7 +204,7 @@ class RenderImageDialog {
 			const camera = await loader.parseAsync( json.camera );
 			camera.aspect = imageWidth.getValue() / imageHeight.getValue();
 			camera.updateProjectionMatrix();
-			camera.updateMatrixWorld();
+			camera.ensureMatrices();
 
 			const scene = await loader.parseAsync( json.scene );
 

--- a/editor/js/commands/SetPositionCommand.js
+++ b/editor/js/commands/SetPositionCommand.js
@@ -38,7 +38,7 @@ class SetPositionCommand extends Command {
 	execute() {
 
 		this.object.position.copy( this.newPosition );
-		this.object.updateMatrixWorld( true );
+		this.object.ensureMatrices( true );
 		this.editor.signals.objectChanged.dispatch( this.object );
 
 	}
@@ -46,7 +46,7 @@ class SetPositionCommand extends Command {
 	undo() {
 
 		this.object.position.copy( this.oldPosition );
-		this.object.updateMatrixWorld( true );
+		this.object.ensureMatrices( true );
 		this.editor.signals.objectChanged.dispatch( this.object );
 
 	}

--- a/editor/js/commands/SetRotationCommand.js
+++ b/editor/js/commands/SetRotationCommand.js
@@ -38,7 +38,7 @@ class SetRotationCommand extends Command {
 	execute() {
 
 		this.object.rotation.copy( this.newRotation );
-		this.object.updateMatrixWorld( true );
+		this.object.ensureMatrices( true );
 		this.editor.signals.objectChanged.dispatch( this.object );
 
 	}
@@ -46,7 +46,7 @@ class SetRotationCommand extends Command {
 	undo() {
 
 		this.object.rotation.copy( this.oldRotation );
-		this.object.updateMatrixWorld( true );
+		this.object.ensureMatrices( true );
 		this.editor.signals.objectChanged.dispatch( this.object );
 
 	}

--- a/editor/js/commands/SetScaleCommand.js
+++ b/editor/js/commands/SetScaleCommand.js
@@ -38,7 +38,7 @@ class SetScaleCommand extends Command {
 	execute() {
 
 		this.object.scale.copy( this.newScale );
-		this.object.updateMatrixWorld( true );
+		this.object.ensureMatrices( true );
 		this.editor.signals.objectChanged.dispatch( this.object );
 
 	}
@@ -46,7 +46,7 @@ class SetScaleCommand extends Command {
 	undo() {
 
 		this.object.scale.copy( this.oldScale );
-		this.object.updateMatrixWorld( true );
+		this.object.ensureMatrices( true );
 		this.editor.signals.objectChanged.dispatch( this.object );
 
 	}

--- a/examples/jsm/animation/CCDIKSolver.js
+++ b/examples/jsm/animation/CCDIKSolver.js
@@ -115,7 +115,7 @@ class CCDIKSolver {
 		const target = bones[ ik.target ];
 
 		// don't use getWorldPosition() here for the performance
-		// because it calls updateMatrixWorld( true ) inside.
+		// because it calls updateWorldMatrix( true ) inside.
 		_targetPos.setFromMatrixPosition( target.matrixWorld );
 
 		const links = ik.links;
@@ -148,7 +148,7 @@ class CCDIKSolver {
 				const rotationMax = links[ j ].rotationMax;
 
 				// don't use getWorldPosition/Quaternion() here for the performance
-				// because they call updateMatrixWorld( true ) inside.
+				// because they call updateWorldMatrix( true ) inside.
 				link.matrixWorld.decompose( _linkPos, _invLinkQ, _linkScale );
 				_invLinkQ.invert();
 				_effectorPos.setFromMatrixPosition( effector.matrixWorld );
@@ -224,7 +224,7 @@ class CCDIKSolver {
 
 				}
 
-				link.updateMatrixWorld( true );
+				link.ensureMatrices( true );
 
 				rotated = true;
 
@@ -244,7 +244,7 @@ class CCDIKSolver {
 			  this._workingQuaternion.copy( initialQuaternions[ j ] ).slerp( link.quaternion, chainBlend );
 
 			  link.quaternion.copy( this._workingQuaternion );
-			  link.updateMatrixWorld( true );
+			  link.ensureMatrices( true );
 
 			}
 
@@ -413,7 +413,7 @@ class CCDIKHelper extends Object3D {
 
 	}
 
-	updateMatrixWorld( force ) {
+	updateMatrixWorld() {
 
 		const mesh = this.root;
 
@@ -472,7 +472,7 @@ class CCDIKHelper extends Object3D {
 
 		this.matrix.copy( mesh.matrixWorld );
 
-		super.updateMatrixWorld( force );
+		super.updateMatrixWorld();
 
 	}
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -785,7 +785,7 @@ class OrbitControls extends Controls {
 
 				const radiusDelta = prevRadius - newRadius;
 				this.object.position.addScaledVector( this._dollyDirection, radiusDelta );
-				this.object.updateMatrixWorld();
+				this.object.ensureMatrices();
 
 				zoomChanged = !! radiusDelta;
 
@@ -805,7 +805,7 @@ class OrbitControls extends Controls {
 				mouseAfter.unproject( this.object );
 
 				this.object.position.sub( mouseAfter ).add( mouseBefore );
-				this.object.updateMatrixWorld();
+				this.object.ensureMatrices();
 
 				newRadius = _v.length();
 

--- a/examples/jsm/controls/TransformControls.js
+++ b/examples/jsm/controls/TransformControls.js
@@ -432,8 +432,8 @@ class TransformControls extends Controls {
 
 			if ( planeIntersect ) {
 
-				this.object.updateMatrixWorld();
-				this.object.parent.updateMatrixWorld();
+				this.object.ensureMatrices();
+				this.object.parent.ensureMatrices();
 
 				this._positionStart.copy( this.object.position );
 				this._quaternionStart.copy( this.object.quaternion );
@@ -1055,13 +1055,13 @@ class TransformControlsRoot extends Object3D {
 	}
 
 	// updateMatrixWorld updates key transformation variables
-	updateMatrixWorld( force ) {
+	updateMatrixWorld() {
 
 		const controls = this.controls;
 
 		if ( controls.object !== undefined ) {
 
-			controls.object.updateMatrixWorld();
+			controls.object.ensureMatrices();
 
 			if ( controls.object.parent === null ) {
 
@@ -1080,7 +1080,7 @@ class TransformControlsRoot extends Object3D {
 
 		}
 
-		controls.camera.updateMatrixWorld();
+		controls.camera.ensureMatrices();
 		controls.camera.matrixWorld.decompose( controls.cameraPosition, controls.cameraQuaternion, controls._cameraScale );
 
 		if ( controls.camera.isOrthographicCamera ) {
@@ -1093,7 +1093,7 @@ class TransformControlsRoot extends Object3D {
 
 		}
 
-		super.updateMatrixWorld( force );
+		super.updateMatrixWorld();
 
 	}
 
@@ -1504,7 +1504,7 @@ class TransformControlsGizmo extends Object3D {
 
 	// updateMatrixWorld will update transformations and appearance of individual handles
 
-	updateMatrixWorld( force ) {
+	updateMatrixWorld() {
 
 		const space = ( this.mode === 'scale' ) ? 'local' : this.space; // scale always oriented to local rotation
 
@@ -1814,7 +1814,7 @@ class TransformControlsGizmo extends Object3D {
 
 		}
 
-		super.updateMatrixWorld( force );
+		super.updateMatrixWorld();
 
 	}
 
@@ -1837,7 +1837,7 @@ class TransformControlsPlane extends Mesh {
 
 	}
 
-	updateMatrixWorld( force ) {
+	updateMatrixWorld() {
 
 		let space = this.space;
 
@@ -1909,7 +1909,7 @@ class TransformControlsPlane extends Mesh {
 
 		}
 
-		super.updateMatrixWorld( force );
+		super.updateMatrixWorld();
 
 	}
 

--- a/examples/jsm/csm/CSMHelper.js
+++ b/examples/jsm/csm/CSMHelper.js
@@ -127,7 +127,7 @@ class CSMHelper extends Group {
 		this.position.copy( camera.position );
 		this.quaternion.copy( camera.quaternion );
 		this.scale.copy( camera.scale );
-		this.updateMatrixWorld( true );
+		this.ensureMatrices( true );
 
 		while ( cascadeLines.length > cascades ) {
 
@@ -181,7 +181,7 @@ class CSMHelper extends Group {
 			shadowLineGroup.position.copy( shadowCam.position );
 			shadowLineGroup.quaternion.copy( shadowCam.quaternion );
 			shadowLineGroup.scale.copy( shadowCam.scale );
-			shadowLineGroup.updateMatrixWorld( true );
+			shadowLineGroup.ensureMatrices( true );
 			this.attach( shadowLineGroup );
 
 			shadowLine.box.min.set( shadowCam.bottom, shadowCam.left, - shadowCam.far );

--- a/examples/jsm/effects/AnaglyphEffect.js
+++ b/examples/jsm/effects/AnaglyphEffect.js
@@ -184,9 +184,9 @@ class AnaglyphEffect {
 
 			const currentRenderTarget = renderer.getRenderTarget();
 
-			if ( scene.matrixWorldAutoUpdate === true ) scene.updateMatrixWorld();
+			if ( scene.matrixWorldAutoUpdate === true ) scene.ensureMatrices();
 
-			if ( camera.parent === null && camera.matrixWorldAutoUpdate === true ) camera.updateMatrixWorld();
+			if ( camera.parent === null && camera.matrixWorldAutoUpdate === true ) camera.ensureMatrices();
 
 			// Get the camera's local coordinate axes from its world matrix
 			camera.matrixWorld.extractBasis( _right, _up, _forward );

--- a/examples/jsm/effects/ParallaxBarrierEffect.js
+++ b/examples/jsm/effects/ParallaxBarrierEffect.js
@@ -113,9 +113,9 @@ class ParallaxBarrierEffect {
 
 			const currentRenderTarget = renderer.getRenderTarget();
 
-			if ( scene.matrixWorldAutoUpdate === true ) scene.updateMatrixWorld();
+			if ( scene.matrixWorldAutoUpdate === true ) scene.ensureMatrices();
 
-			if ( camera.parent === null && camera.matrixWorldAutoUpdate === true ) camera.updateMatrixWorld();
+			if ( camera.parent === null && camera.matrixWorldAutoUpdate === true ) camera.ensureMatrices();
 
 			_stereo.update( camera );
 

--- a/examples/jsm/effects/StereoEffect.js
+++ b/examples/jsm/effects/StereoEffect.js
@@ -56,9 +56,9 @@ class StereoEffect {
 		 */
 		this.render = function ( scene, camera ) {
 
-			if ( scene.matrixWorldAutoUpdate === true ) scene.updateMatrixWorld();
+			if ( scene.matrixWorldAutoUpdate === true ) scene.ensureMatrices();
 
-			if ( camera.parent === null && camera.matrixWorldAutoUpdate === true ) camera.updateMatrixWorld();
+			if ( camera.parent === null && camera.matrixWorldAutoUpdate === true ) camera.ensureMatrices();
 
 			_stereo.update( camera );
 

--- a/examples/jsm/helpers/VertexNormalsHelper.js
+++ b/examples/jsm/helpers/VertexNormalsHelper.js
@@ -93,7 +93,7 @@ class VertexNormalsHelper extends LineSegments {
 	 */
 	update() {
 
-		this.object.updateMatrixWorld( true );
+		this.object.ensureMatrices( true );
 
 		_normalMatrix.getNormalMatrix( this.object.matrixWorld );
 

--- a/examples/jsm/helpers/VertexTangentsHelper.js
+++ b/examples/jsm/helpers/VertexTangentsHelper.js
@@ -77,7 +77,7 @@ class VertexTangentsHelper extends LineSegments {
 	 */
 	update() {
 
-		this.object.updateMatrixWorld( true );
+		this.object.ensureMatrices( true );
 
 		const matrixWorld = this.object.matrixWorld;
 

--- a/examples/jsm/helpers/ViewHelper.js
+++ b/examples/jsm/helpers/ViewHelper.js
@@ -164,7 +164,7 @@ class ViewHelper extends Object3D {
 		this.render = function ( renderer ) {
 
 			this.quaternion.copy( camera.quaternion ).invert();
-			this.updateMatrixWorld();
+			this.ensureMatrices();
 
 			point.set( 0, 0, 1 );
 			point.applyQuaternion( camera.quaternion );

--- a/examples/jsm/interactive/SelectionBox.js
+++ b/examples/jsm/interactive/SelectionBox.js
@@ -153,7 +153,7 @@ class SelectionBox {
 		}
 
 		this.camera.updateProjectionMatrix();
-		this.camera.updateMatrixWorld();
+		this.camera.ensureMatrices();
 
 		if ( this.camera.isPerspectiveCamera ) {
 

--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -2682,7 +2682,7 @@ class GLTFParser {
 
 				for ( const scene of result.scenes ) {
 
-					scene.updateMatrixWorld();
+					scene.ensureMatrices();
 
 				}
 

--- a/examples/jsm/math/ConvexHull.js
+++ b/examples/jsm/math/ConvexHull.js
@@ -91,7 +91,7 @@ class ConvexHull {
 
 		const points = [];
 
-		object.updateMatrixWorld( true );
+		object.ensureMatrices( true );
 
 		object.traverse( function ( node ) {
 

--- a/examples/jsm/misc/Gyroscope.js
+++ b/examples/jsm/misc/Gyroscope.js
@@ -34,12 +34,6 @@ class Gyroscope extends Object3D {
 
 	updateMatrixWorld( force ) {
 
-		this.matrixAutoUpdate && this.updateMatrix();
-
-		// update matrixWorld
-
-		if ( this.matrixWorldNeedsUpdate || force ) {
-
 			if ( this.parent !== null ) {
 
 				this.matrixWorld.multiplyMatrices( this.parent.matrixWorld, this.matrix );
@@ -55,23 +49,6 @@ class Gyroscope extends Object3D {
 				this.matrixWorld.copy( this.matrix );
 
 			}
-
-
-			this.matrixWorldNeedsUpdate = false;
-
-			force = true;
-
-		}
-
-		// update children
-
-		for ( let i = 0, l = this.children.length; i < l; i ++ ) {
-
-			this.children[ i ].updateMatrixWorld( force );
-
-		}
-
-	}
 
 }
 

--- a/examples/jsm/misc/Gyroscope.js
+++ b/examples/jsm/misc/Gyroscope.js
@@ -32,23 +32,25 @@ class Gyroscope extends Object3D {
 
 	}
 
-	updateMatrixWorld( force ) {
+	updateMatrixWorld() {
 
-			if ( this.parent !== null ) {
+		if ( this.parent !== null ) {
 
-				this.matrixWorld.multiplyMatrices( this.parent.matrixWorld, this.matrix );
+			this.matrixWorld.multiplyMatrices( this.parent.matrixWorld, this.matrix );
 
-				this.matrixWorld.decompose( _translationWorld, _quaternionWorld, _scaleWorld );
-				this.matrix.decompose( _translationObject, _quaternionObject, _scaleObject );
+			this.matrixWorld.decompose( _translationWorld, _quaternionWorld, _scaleWorld );
+			this.matrix.decompose( _translationObject, _quaternionObject, _scaleObject );
 
-				this.matrixWorld.compose( _translationWorld, _quaternionObject, _scaleWorld );
+			this.matrixWorld.compose( _translationWorld, _quaternionObject, _scaleWorld );
 
 
-			} else {
+		} else {
 
-				this.matrixWorld.copy( this.matrix );
+			this.matrixWorld.copy( this.matrix );
 
-			}
+		}
+
+	}
 
 }
 

--- a/examples/jsm/objects/Reflector.js
+++ b/examples/jsm/objects/Reflector.js
@@ -153,7 +153,7 @@ class Reflector extends Mesh {
 
 			virtualCamera.far = camera.far; // Used in WebGLBackground
 
-			virtualCamera.updateMatrixWorld();
+			virtualCamera.ensureMatrices();
 			virtualCamera.projectionMatrix.copy( camera.projectionMatrix );
 
 			// Update the texture matrix

--- a/examples/jsm/objects/ReflectorForSSRPass.js
+++ b/examples/jsm/objects/ReflectorForSSRPass.js
@@ -192,7 +192,7 @@ class ReflectorForSSRPass extends Mesh {
 
 			virtualCamera.far = camera.far; // Used in WebGLBackground
 
-			virtualCamera.updateMatrixWorld();
+			virtualCamera.ensureMatrices();
 			virtualCamera.projectionMatrix.copy( camera.projectionMatrix );
 
 			material.uniforms[ 'virtualCameraNear' ].value = camera.near;

--- a/examples/jsm/objects/Water.js
+++ b/examples/jsm/objects/Water.js
@@ -272,7 +272,7 @@ class Water extends Mesh {
 
 			mirrorCamera.far = camera.far; // Used in WebGLBackground
 
-			mirrorCamera.updateMatrixWorld();
+			mirrorCamera.ensureMatrices();
 			mirrorCamera.projectionMatrix.copy( camera.projectionMatrix );
 
 			// Update the texture matrix

--- a/examples/jsm/renderers/CSS2DRenderer.js
+++ b/examples/jsm/renderers/CSS2DRenderer.js
@@ -169,8 +169,8 @@ class CSS2DRenderer {
 		 */
 		this.render = function ( scene, camera ) {
 
-			if ( scene.matrixWorldAutoUpdate === true ) scene.updateMatrixWorld();
-			if ( camera.parent === null && camera.matrixWorldAutoUpdate === true ) camera.updateMatrixWorld();
+			if ( scene.matrixWorldAutoUpdate === true ) scene.ensureMatrices();
+			if ( camera.parent === null && camera.matrixWorldAutoUpdate === true ) camera.ensureMatrices();
 
 			_viewMatrix.copy( camera.matrixWorldInverse );
 			_viewProjectionMatrix.multiplyMatrices( camera.projectionMatrix, _viewMatrix );

--- a/examples/jsm/renderers/CSS3DRenderer.js
+++ b/examples/jsm/renderers/CSS3DRenderer.js
@@ -233,8 +233,8 @@ class CSS3DRenderer {
 
 			}
 
-			if ( scene.matrixWorldAutoUpdate === true ) scene.updateMatrixWorld();
-			if ( camera.parent === null && camera.matrixWorldAutoUpdate === true ) camera.updateMatrixWorld();
+			if ( scene.matrixWorldAutoUpdate === true ) scene.ensureMatrices();
+			if ( camera.parent === null && camera.matrixWorldAutoUpdate === true ) camera.ensureMatrices();
 
 			let tx, ty;
 

--- a/examples/jsm/renderers/Projector.js
+++ b/examples/jsm/renderers/Projector.js
@@ -558,8 +558,8 @@ class Projector {
 
 			_renderData.elements.length = 0;
 
-			if ( scene.matrixWorldAutoUpdate === true ) scene.updateMatrixWorld();
-			if ( camera.parent === null && camera.matrixWorldAutoUpdate === true ) camera.updateMatrixWorld();
+			if ( scene.matrixWorldAutoUpdate === true ) scene.ensureMatrices();
+			if ( camera.parent === null && camera.matrixWorldAutoUpdate === true ) camera.ensureMatrices();
 
 			_viewMatrix.copy( camera.matrixWorldInverse );
 			_viewProjectionMatrix.multiplyMatrices( camera.projectionMatrix, _viewMatrix );

--- a/examples/jsm/tsl/shadows/TileShadowNode.js
+++ b/examples/jsm/tsl/shadows/TileShadowNode.js
@@ -201,7 +201,7 @@ class TileShadowNode extends ShadowBaseNode {
 			this.syncLightTransformation( lwLight, light );
 
 			this.lights.push( lwLight );
-			lShadow.camera.updateMatrixWorld();
+			lShadow.camera.ensureMatrices();
 
 			cameras.push( lShadow.camera );
 			const shadowNode = shadow( lwLight, lShadow );
@@ -254,7 +254,7 @@ class TileShadowNode extends ShadowBaseNode {
 			lShadow.camera.far = light.shadow.camera.far;
 			lShadow.camera.updateProjectionMatrix();
 			lShadow.camera.updateWorldMatrix( true, false );
-			lShadow.camera.updateMatrixWorld( true );
+			lShadow.camera.ensureMatrices( true );
 			this._shadowNodes[ i ].shadow.needsUpdate = true;
 
 		}
@@ -383,9 +383,9 @@ class TileShadowNode extends ShadowBaseNode {
 		lwLight.quaternion.copy( sourceLight.getWorldQuaternion( _quatTemp1 ) );
 		lwLight.scale.copy( sourceLight.scale );
 		lwLight.updateMatrix();
-		lwLight.updateMatrixWorld( true );
+		lwLight.ensureMatrices( true );
 		lwLight.target.updateMatrix();
-		lwLight.target.updateMatrixWorld( true );
+		lwLight.target.ensureMatrices( true );
 
 	}
 

--- a/examples/jsm/tsl/shadows/TileShadowNodeHelper.js
+++ b/examples/jsm/tsl/shadows/TileShadowNodeHelper.js
@@ -167,7 +167,7 @@ class TileShadowNodeHelper extends Group {
 			if ( helper ) {
 
 				helper.update(); // Update CameraHelper matrices
-				helper.updateMatrixWorld( true ); // Ensure world matrix is current
+				helper.ensureMatrices( true ); // Ensure world matrix is current
 
 			}
 

--- a/examples/jsm/utils/LDrawUtils.js
+++ b/examples/jsm/utils/LDrawUtils.js
@@ -114,7 +114,7 @@ class LDrawUtils {
 		const linesGeometries = {};
 		const condLinesGeometries = {};
 
-		object.updateMatrixWorld( true );
+		object.ensureMatrices( true );
 		const normalMatrix = new Matrix3();
 
 		object.traverse( c => {

--- a/examples/jsm/utils/SceneOptimizer.js
+++ b/examples/jsm/utils/SceneOptimizer.js
@@ -178,7 +178,7 @@ class SceneOptimizer {
 		const singleGroups = new Map();
 		const uniqueGeometries = new Set();
 
-		this.scene.updateMatrixWorld( true );
+		this.scene.ensureMatrices( true );
 		this.scene.traverse( ( node ) => {
 
 			if ( ! node.isMesh ) return;

--- a/examples/jsm/utils/SceneUtils.js
+++ b/examples/jsm/utils/SceneUtils.js
@@ -46,7 +46,7 @@ function createMeshesFromInstancedMesh( instancedMesh ) {
 	}
 
 	group.copy( instancedMesh );
-	group.updateMatrixWorld(); // ensure correct world matrices of meshes
+	group.ensureMatrices(); // ensure correct world matrices of meshes
 
 	return group;
 

--- a/examples/jsm/utils/SkeletonUtils.js
+++ b/examples/jsm/utils/SkeletonUtils.js
@@ -84,7 +84,7 @@ function retarget( target, source, options = {} ) {
 
 		// reset matrix
 
-		target.updateMatrixWorld();
+		target.ensureMatrices();
 
 		target.matrixWorld.identity();
 
@@ -92,7 +92,7 @@ function retarget( target, source, options = {} ) {
 
 		for ( let i = 0; i < target.children.length; ++ i ) {
 
-			target.children[ i ].updateMatrixWorld( true );
+			target.children[ i ].ensureMatrices( true );
 
 		}
 
@@ -109,7 +109,7 @@ function retarget( target, source, options = {} ) {
 
 		if ( boneTo ) {
 
-			boneTo.updateMatrixWorld();
+			boneTo.ensureMatrices();
 
 			if ( options.useTargetMatrix ) {
 
@@ -178,7 +178,7 @@ function retarget( target, source, options = {} ) {
 
 		bone.matrix.decompose( bone.position, bone.quaternion, bone.scale );
 
-		bone.updateMatrixWorld();
+		bone.ensureMatrices();
 
 	}
 
@@ -203,7 +203,7 @@ function retarget( target, source, options = {} ) {
 
 		// restore matrix
 
-		target.updateMatrixWorld( true );
+		target.ensureMatrices( true );
 
 	}
 
@@ -263,7 +263,7 @@ function retargetClip( target, source, clip, options = {} ) {
 
 	}
 
-	source.updateMatrixWorld();
+	source.ensureMatrices();
 
 	//
 
@@ -341,7 +341,7 @@ function retargetClip( target, source, clip, options = {} ) {
 
 		}
 
-		source.updateMatrixWorld();
+		source.ensureMatrices();
 
 	}
 

--- a/examples/jsm/webxr/OculusHandModel.js
+++ b/examples/jsm/webxr/OculusHandModel.js
@@ -103,13 +103,10 @@ class OculusHandModel extends Object3D {
 
 	/**
 	 * Overwritten with a custom implementation. Makes sure the motion controller updates the mesh.
-	 *
-	 * @param {boolean} [force=false] - When set to `true`, a recomputation of world matrices is forced even
-	 * when {@link Object3D#matrixWorldAutoUpdate} is set to `false`.
 	 */
-	updateMatrixWorld( force ) {
+	updateMatrixWorld() {
 
-		super.updateMatrixWorld( force );
+		super.updateMatrixWorld();
 
 		if ( this.motionController ) {
 

--- a/examples/jsm/webxr/OculusHandPointerModel.js
+++ b/examples/jsm/webxr/OculusHandPointerModel.js
@@ -391,13 +391,11 @@ class OculusHandPointerModel extends Object3D {
 
 	/**
 	 * Overwritten with a custom implementation. Makes sure the internal pointer and raycaster are updated.
-	 *
-	 * @param {boolean} [force=false] - When set to `true`, a recomputation of world matrices is forced even
-	 * when {@link Object3D#matrixWorldAutoUpdate} is set to `false`.
 	 */
-	updateMatrixWorld( force ) {
+	updateMatrixWorld() {
 
-		super.updateMatrixWorld( force );
+		super.updateMatrixWorld();
+
 		if ( this.pointerGeometry ) {
 
 			this._updatePointer();

--- a/examples/jsm/webxr/XRControllerModelFactory.js
+++ b/examples/jsm/webxr/XRControllerModelFactory.js
@@ -81,13 +81,10 @@ class XRControllerModel extends Object3D {
 	/**
 	 * Overwritten with a custom implementation. Polls data from the XRInputSource and updates the
 	 * model's components to match the real world data.
-	 *
-	 * @param {boolean} [force=false] - When set to `true`, a recomputation of world matrices is forced even
-	 * when {@link Object3D#matrixWorldAutoUpdate} is set to `false`.
 	 */
-	updateMatrixWorld( force ) {
+	updateMatrixWorld() {
 
-		super.updateMatrixWorld( force );
+		super.updateMatrixWorld();
 
 		if ( ! this.motionController ) return;
 

--- a/examples/jsm/webxr/XRHandModelFactory.js
+++ b/examples/jsm/webxr/XRHandModelFactory.js
@@ -61,13 +61,10 @@ class XRHandModel extends Object3D {
 
 	/**
 	 * Overwritten with a custom implementation. Makes sure the motion controller updates the mesh.
-	 *
-	 * @param {boolean} [force=false] - When set to `true`, a recomputation of world matrices is forced even
-	 * when {@link Object3D#matrixWorldAutoUpdate} is set to `false`.
 	 */
-	updateMatrixWorld( force ) {
+	updateMatrixWorld() {
 
-		super.updateMatrixWorld( force );
+		super.updateMatrixWorld();
 
 		if ( this.motionController ) {
 

--- a/examples/misc_exporter_gcode.html
+++ b/examples/misc_exporter_gcode.html
@@ -177,7 +177,7 @@
 			function placeOnXYPlane( object ) {
 
 				// Update world matrix so bounding box reflects transforms
-				object.updateMatrixWorld( true );
+				object.ensureMatrices( true );
 
 				const box = new THREE.Box3().setFromObject( object );
 				const minZ = box.min.z;
@@ -186,7 +186,7 @@
 
 					// Shift object upward by -minZ so it rests on z=0
 					object.position.z -= minZ;
-					object.updateMatrixWorld( true );
+					object.ensureMatrices( true );
 
 				}
 

--- a/examples/webgl_camera_array.html
+++ b/examples/webgl_camera_array.html
@@ -46,7 +46,7 @@
 						subcamera.position.z = 1.5;
 						subcamera.position.multiplyScalar( 2 );
 						subcamera.lookAt( 0, 0, 0 );
-						subcamera.updateMatrixWorld();
+						subcamera.ensureMatrices();
 						cameras.push( subcamera );
 
 					}

--- a/examples/webgl_clipping_advanced.html
+++ b/examples/webgl_clipping_advanced.html
@@ -387,7 +387,7 @@
 				// set the orientation of an object based on a world matrix
 
 				const parent = object.parent;
-				scene.updateMatrixWorld();
+				scene.ensureMatrices();
 				object.matrix.copy( parent.matrixWorld ).invert();
 				object.applyMatrix4( matrix );
 

--- a/examples/webgl_geometry_csg.html
+++ b/examples/webgl_geometry_csg.html
@@ -201,7 +201,7 @@
 				baseBrush.rotation.x = t * 0.0001;
 				baseBrush.rotation.y = t * 0.00025;
 				baseBrush.rotation.z = t * 0.0005;
-				baseBrush.updateMatrixWorld();
+				baseBrush.ensureMatrices();
 
 				brush.rotation.x = t * - 0.0002;
 				brush.rotation.y = t * - 0.0005;
@@ -209,7 +209,7 @@
 
 				const s = 0.5 + 0.5 * ( 1 + Math.sin( t * 0.001 ) );
 				brush.scale.set( s, 1, s );
-				brush.updateMatrixWorld();
+				brush.ensureMatrices();
 
 				// update the csg
 				updateCSG();

--- a/examples/webgl_helpers.html
+++ b/examples/webgl_helpers.html
@@ -79,7 +79,7 @@
 					scene.add( group );
 
 					// To make sure that the matrixWorld is up to date for the boxhelpers
-					group.updateMatrixWorld( true );
+					group.ensureMatrices( true );
 
 					group.add( mesh );
 

--- a/examples/webgl_interactive_cubes.html
+++ b/examples/webgl_interactive_cubes.html
@@ -133,7 +133,7 @@
 				camera.position.z = radius * Math.cos( THREE.MathUtils.degToRad( theta ) );
 				camera.lookAt( scene.position );
 
-				camera.updateMatrixWorld();
+				camera.ensureMatrices();
 
 				// find intersections
 

--- a/examples/webgl_interactive_cubes_ortho.html
+++ b/examples/webgl_interactive_cubes_ortho.html
@@ -141,7 +141,7 @@
 				camera.position.z = radius * Math.cos( THREE.MathUtils.degToRad( theta ) );
 				camera.lookAt( scene.position );
 
-				camera.updateMatrixWorld();
+				camera.ensureMatrices();
 
 				// find intersections
 

--- a/examples/webgl_interactive_lines.html
+++ b/examples/webgl_interactive_lines.html
@@ -186,7 +186,7 @@
 				camera.position.z = radius * Math.cos( THREE.MathUtils.degToRad( theta ) );
 				camera.lookAt( scene.position );
 
-				camera.updateMatrixWorld();
+				camera.ensureMatrices();
 
 				// find intersections
 

--- a/examples/webgl_interactive_raycasting_points.html
+++ b/examples/webgl_interactive_raycasting_points.html
@@ -251,7 +251,7 @@
 			function render() {
 
 				camera.applyMatrix4( rotateY );
-				camera.updateMatrixWorld();
+				camera.ensureMatrices();
 
 				raycaster.setFromCamera( pointer, camera );
 

--- a/examples/webgl_math_obb.html
+++ b/examples/webgl_math_obb.html
@@ -209,7 +209,7 @@
 					object.rotation.y += delta * Math.PI * 0.1;
 
 					object.updateMatrix();
-					object.updateMatrixWorld();
+					object.ensureMatrices();
 
 					// update OBB
 

--- a/examples/webgl_postprocessing_backgrounds.html
+++ b/examples/webgl_postprocessing_backgrounds.html
@@ -210,7 +210,7 @@
 
 				stats.begin();
 
-				cameraP.updateMatrixWorld( true );
+				cameraP.ensureMatrices( true );
 
 				let newColor = clearPass.clearColor;
 

--- a/examples/webgl_postprocessing_dof2.html
+++ b/examples/webgl_postprocessing_dof2.html
@@ -402,7 +402,7 @@
 
 				camera.lookAt( target );
 
-				camera.updateMatrixWorld();
+				camera.ensureMatrices();
 
 				if ( effectController.jsDepthCalculation ) {
 

--- a/examples/webgl_raycaster_bvh.html
+++ b/examples/webgl_raycaster_bvh.html
@@ -282,7 +282,7 @@
 				if ( mesh ) {
 
 					mesh.rotation.y += 0.002;
-					mesh.updateMatrixWorld();
+					mesh.ensureMatrices();
 
 				}
 

--- a/examples/webgl_renderer_pathtracer.html
+++ b/examples/webgl_renderer_pathtracer.html
@@ -164,7 +164,7 @@
 							// Convert from LDraw coordinates: rotate 180 degrees around OX
 							legoGroup = LDrawUtils.mergeObject( legoGroup );
 							legoGroup.rotation.x = Math.PI;
-							legoGroup.updateMatrixWorld();
+							legoGroup.ensureMatrices();
 							model = legoGroup;
 
 							legoGroup.traverse( c => {

--- a/examples/webgl_shadowmap_csm.html
+++ b/examples/webgl_shadowmap_csm.html
@@ -284,7 +284,7 @@
 
 			function animate() {
 
-				camera.updateMatrixWorld();
+				camera.ensureMatrices();
 				csm.update();
 				controls.update();
 

--- a/examples/webgl_simple_gi.html
+++ b/examples/webgl_simple_gi.html
@@ -49,7 +49,7 @@
 
 				const camera = new THREE.PerspectiveCamera( 90, 1, 0.01, 100 );
 
-				scene.updateMatrixWorld( true );
+				scene.ensureMatrices( true );
 
 				let clone = scene.clone();
 				clone.matrixWorldAutoUpdate = false;

--- a/examples/webgpu_camera_array.html
+++ b/examples/webgpu_camera_array.html
@@ -123,7 +123,7 @@
 						subcamera.position.multiplyScalar( 2 );
 
 						subcamera.lookAt( 0, 0, 0 );
-						subcamera.updateMatrixWorld();
+						subcamera.ensureMatrices();
 
 					}
 

--- a/examples/webgpu_postprocessing_dof_basic.html
+++ b/examples/webgpu_postprocessing_dof_basic.html
@@ -199,7 +199,7 @@
 				// since the focus point is expressed in view space, it must be updated on every
 				// camera change. for simplicity, do this every frame.
 
-				camera.updateMatrixWorld();
+				camera.ensureMatrices();
 				focusPointView.value.copy( focusPoint ).applyMatrix4( camera.matrixWorldInverse );
 
 				renderPipeline.render();

--- a/examples/webgpu_shadowmap_csm.html
+++ b/examples/webgpu_shadowmap_csm.html
@@ -296,7 +296,7 @@
 
 			function animate() {
 
-				camera.updateMatrixWorld();
+				camera.ensureMatrices();
 				controls.update();
 
 				if ( params.orthographic ) {

--- a/examples/webxr_xr_dragging.html
+++ b/examples/webxr_xr_dragging.html
@@ -219,7 +219,7 @@
 
 			function getIntersections( controller ) {
 
-				controller.updateMatrixWorld();
+				controller.ensureMatrices();
 
 				raycaster.setFromXRController( controller );
 

--- a/examples/webxr_xr_dragging_custom_depth.html
+++ b/examples/webxr_xr_dragging_custom_depth.html
@@ -355,7 +355,7 @@
 
 			function getIntersections( controller ) {
 
-				controller.updateMatrixWorld();
+				controller.ensureMatrices();
 
 				tempMatrix.identity().extractRotation( controller.matrixWorld );
 

--- a/examples/webxr_xr_paint.html
+++ b/examples/webxr_xr_paint.html
@@ -85,7 +85,7 @@
 
 				function onSelectStart() {
 
-					this.updateMatrixWorld( true );
+					this.ensureMatrices( true );
 
 					const pivot = this.getObjectByName( 'pivot' );
 					cursor.setFromMatrixPosition( pivot.matrixWorld );
@@ -166,7 +166,7 @@
 
 			function handleController( controller ) {
 
-				controller.updateMatrixWorld( true );
+				controller.ensureMatrices( true );
 
 				const userData = controller.userData;
 				const painter = userData.painter;

--- a/manual/en/align-html-elements-to-3d.html
+++ b/manual/en/align-html-elements-to-3d.html
@@ -271,14 +271,14 @@ const viewProjection = new THREE.Matrix4();
 
 // before checking
 camera.updateMatrix();
-camera.updateMatrixWorld();
+camera.ensureMatrices();
 camera.matrixWorldInverse.copy(camera.matrixWorld).invert();
 
 ...
 
 // then for each mesh
 someMesh.updateMatrix();
-someMesh.updateMatrixWorld();
+someMesh.ensureMatrices();
 
 viewProjection.multiplyMatrices(
     camera.projectionMatrix, camera.matrixWorldInverse);

--- a/manual/en/custom-buffergeometry.html
+++ b/manual/en/custom-buffergeometry.html
@@ -344,7 +344,7 @@ sphere points. How this works is explained in <a href="optimize-lots-of-objects.
   function getPoint(lat, long) {
     latHelper.rotation.x = lat;
     longHelper.rotation.y = long;
-    longHelper.updateMatrixWorld(true);
+    longHelper.ensureMatrices(true);
     return pointHelper.getWorldPosition(temp).toArray();
   }
 

--- a/manual/en/lights.html
+++ b/manual/en/lights.html
@@ -259,7 +259,7 @@ get called anytime lil-gui updates a value.</p>
 <p>Then we can use that for both the light's position
 and the target's position like this</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">+function updateLight() {
-+  light.target.updateMatrixWorld();
++  light.target.ensureMatrices();
 +  helper.update();
 +}
 +updateLight();
@@ -303,7 +303,7 @@ scene.add(helper);
 </pre>
 <p>and as there is no target the <code class="notranslate" translate="no">onChange</code> function can be simpler.</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">function updateLight() {
--  light.target.updateMatrixWorld();
+-  light.target.ensureMatrices();
   helper.update();
 }
 -updateLight();

--- a/manual/en/load-gltf.html
+++ b/manual/en/load-gltf.html
@@ -272,7 +272,7 @@ the new <a href="/docs/#api/en/core/Object3D"><code class="notranslate" translat
 +      { prefix: 'Car_04', rot: [0, Math.PI, 0], },
 +    ];
 +
-+    root.updateMatrixWorld();
++    root.ensureMatrices();
 +    for (const car of loadedCars.children.slice()) {
 +      const fix = fixes.find(fix =&gt; car.name.startsWith(fix.prefix));
 +      const obj = new THREE.Object3D();
@@ -592,7 +592,7 @@ const fixes = [
 +  { prefix: 'Car_04', y: 40, rot: [0, Math.PI, 0], },
 ];
 
-root.updateMatrixWorld();
+root.ensureMatrices();
 for (const car of loadedCars.children.slice()) {
   const fix = fixes.find(fix =&gt; car.name.startsWith(fix.prefix));
   const obj = new THREE.Object3D();

--- a/manual/en/load-obj.html
+++ b/manual/en/load-obj.html
@@ -517,7 +517,7 @@ and then set them on the <a href="/docs/#examples/loaders/OBJLoader"><code class
 +    const objLoader = new OBJLoader();
 +    objLoader.setMaterials(mtl);
     objLoader.load('resources/models/windmill/windmill.obj', (root) =&gt; {
-      root.updateMatrixWorld();
+      root.ensureMatrices();
       scene.add(root);
       // compute the box that contains all the stuff
       // from root and below

--- a/manual/en/matrix-transformations.html
+++ b/manual/en/matrix-transformations.html
@@ -70,7 +70,7 @@ object.matrixAutoUpdate = false;
             An object's  matrix stores the object's transformation <em>relative</em> to the object's parent; to get the object's transformation in <em>world</em> coordinates, you must access the object's world matrix.
             </p>
             <p>
-            When either the parent or the child object's transformation changes, you can request that the child object's world matrix be updated by calling `object.updateMatrixWorld()`.
+            When either the parent or the child object's transformation changes, you can request that the child object's world matrix be updated by calling `object.ensureMatrices()`.
             </p>
             <p>
             An object can be transformed via `applyMatrix4()`. Note: Under-the-hood, this method relies on `Matrix4.decompose()`, and not all matrices are decomposable in this way. For example, if an object has a non-uniformly scaled parent, then the object's world matrix may not be decomposable, and this method may not be appropriate.

--- a/manual/en/shadows.html
+++ b/manual/en/shadows.html
@@ -333,7 +333,7 @@ Let's write that function to update the light, the helper for the light, the
 light's shadow camera, and the helper showing the light's shadow camera.</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">function updateCamera() {
   // update the light target's matrixWorld because it's needed by the helper
-  light.target.updateMatrixWorld();
+  light.target.ensureMatrices();
   helper.update();
   // update the light's shadow camera's projection matrix
   light.shadow.camera.updateProjectionMatrix();

--- a/manual/examples/custom-buffergeometry-dynamic.html
+++ b/manual/examples/custom-buffergeometry-dynamic.html
@@ -77,7 +77,7 @@ function main() {
 
 			latHelper.rotation.x = lat;
 			longHelper.rotation.y = long;
-			longHelper.updateMatrixWorld( true );
+			longHelper.ensureMatrices( true );
 			return pointHelper.getWorldPosition( temp ).toArray();
 
 		}

--- a/manual/examples/lights-directional-w-helper.html
+++ b/manual/examples/lights-directional-w-helper.html
@@ -147,7 +147,7 @@ function main() {
 
 		function updateLight() {
 
-			light.target.updateMatrixWorld();
+			light.target.ensureMatrices();
 			helper.update();
 
 		}

--- a/manual/examples/lights-spot-w-helper.html
+++ b/manual/examples/lights-spot-w-helper.html
@@ -168,7 +168,7 @@ function main() {
 
 		function updateLight() {
 
-			light.target.updateMatrixWorld();
+			light.target.ensureMatrices();
 			helper.update();
 
 		}

--- a/manual/examples/load-gltf-animated-cars.html
+++ b/manual/examples/load-gltf-animated-cars.html
@@ -202,7 +202,7 @@ function main() {
 				{ prefix: 'Car_04', y: 40, rot: [ 0, Math.PI, 0 ], },
 			];
 
-			root.updateMatrixWorld();
+			root.ensureMatrices();
 			for ( const car of loadedCars.children.slice() ) {
 
 				const fix = fixes.find( fix => car.name.startsWith( fix.prefix ) );

--- a/manual/examples/load-gltf-car-path-fixed.html
+++ b/manual/examples/load-gltf-car-path-fixed.html
@@ -202,7 +202,7 @@ function main() {
 				{ prefix: 'Car_04', rot: [ 0, Math.PI, 0 ], },
 			];
 
-			root.updateMatrixWorld();
+			root.ensureMatrices();
 			for ( const car of loadedCars.children.slice() ) {
 
 				const fix = fixes.find( fix => car.name.startsWith( fix.prefix ) );

--- a/manual/examples/load-gltf-car-path.html
+++ b/manual/examples/load-gltf-car-path.html
@@ -199,7 +199,7 @@ function main() {
 				{ prefix: 'Car_04', rot: [ 0, Math.PI, 0 ], },
 			];
 
-			root.updateMatrixWorld();
+			root.ensureMatrices();
 			for ( const car of loadedCars.children.slice() ) {
 
 				const fix = fixes.find( fix => car.name.startsWith( fix.prefix ) );

--- a/manual/examples/load-gltf-rotate-cars-fixed.html
+++ b/manual/examples/load-gltf-rotate-cars-fixed.html
@@ -142,7 +142,7 @@ function main() {
 				{ prefix: 'Car_04', rot: [ 0, Math.PI, 0 ], },
 			];
 
-			root.updateMatrixWorld();
+			root.ensureMatrices();
 			for ( const car of loadedCars.children.slice() ) {
 
 				const fix = fixes.find( fix => car.name.startsWith( fix.prefix ) );

--- a/manual/examples/load-gltf-shadows.html
+++ b/manual/examples/load-gltf-shadows.html
@@ -132,8 +132,8 @@ function main() {
 		function updateCamera() {
 
 			// update the light target's matrixWorld because it's needed by the helper
-			light.updateMatrixWorld();
-			light.target.updateMatrixWorld();
+			light.ensureMatrices();
+			light.target.ensureMatrices();
 			helper.update();
 			// update the light's shadow camera's projection matrix
 			light.shadow.camera.updateProjectionMatrix();
@@ -365,7 +365,7 @@ function main() {
 				{ prefix: 'Car_04', y: 40, rot: [ 0, Math.PI, 0 ], },
 			];
 
-			root.updateMatrixWorld();
+			root.ensureMatrices();
 			for ( const car of loadedCars.children.slice() ) {
 
 				const fix = fixes.find( fix => car.name.startsWith( fix.prefix ) );

--- a/manual/examples/load-obj-auto-camera-xz.html
+++ b/manual/examples/load-obj-auto-camera-xz.html
@@ -131,7 +131,7 @@ function main() {
 		const objLoader = new OBJLoader();
 		objLoader.load( 'resources/models/windmill_2/windmill.obj', ( root ) => {
 
-			root.updateMatrixWorld();
+			root.ensureMatrices();
 			scene.add( root );
 			// compute the box that contains all the stuff
 			// from root and below

--- a/manual/examples/shadows-directional-light-shadow-acne.html
+++ b/manual/examples/shadows-directional-light-shadow-acne.html
@@ -193,7 +193,7 @@ function main() {
 		function updateCamera() {
 
 			// update the light target's matrixWorld because it's needed by the helper
-			light.target.updateMatrixWorld();
+			light.target.ensureMatrices();
 			helper.update();
 			// update the light's shadow camera's projection matrix
 			light.shadow.camera.updateProjectionMatrix();

--- a/manual/examples/shadows-directional-light-with-camera-gui.html
+++ b/manual/examples/shadows-directional-light-with-camera-gui.html
@@ -158,7 +158,7 @@ function main() {
 		function updateCamera() {
 
 			// update the light target's matrixWorld because it's needed by the helper
-			light.target.updateMatrixWorld();
+			light.target.ensureMatrices();
 			helper.update();
 			// update the light's shadow camera's projection matrix
 			light.shadow.camera.updateProjectionMatrix();

--- a/manual/examples/shadows-directional-light-with-camera-helper.html
+++ b/manual/examples/shadows-directional-light-with-camera-helper.html
@@ -157,7 +157,7 @@ function main() {
 
 		const onChange = () => {
 
-			light.target.updateMatrixWorld();
+			light.target.ensureMatrices();
 			helper.update();
 
 		};

--- a/manual/examples/shadows-directional-light.html
+++ b/manual/examples/shadows-directional-light.html
@@ -154,7 +154,7 @@ function main() {
 
 		const onChange = () => {
 
-			light.target.updateMatrixWorld();
+			light.target.ensureMatrices();
 			helper.update();
 
 		};

--- a/manual/examples/shadows-spot-light-with-camera-gui.html
+++ b/manual/examples/shadows-spot-light-with-camera-gui.html
@@ -155,7 +155,7 @@ function main() {
 		function updateCamera() {
 
 			// update the light target's matrixWorld because it's needed by the helper
-			light.target.updateMatrixWorld();
+			light.target.ensureMatrices();
 			// update the light's shadow camera's projection matrix
 			light.shadow.camera.updateProjectionMatrix();
 			// and now update the camera helper we're using to show the light's shadow camera

--- a/manual/examples/shadows-spot-light-with-shadow-radius.html
+++ b/manual/examples/shadows-spot-light-with-shadow-radius.html
@@ -156,7 +156,7 @@ function main() {
 		function updateCamera() {
 
 			// update the light target's matrixWorld because it's needed by the helper
-			light.target.updateMatrixWorld();
+			light.target.ensureMatrices();
 			// update the light's shadow camera's projection matrix
 			light.shadow.camera.updateProjectionMatrix();
 			// and now update the camera helper we're using to show the light's shadow camera

--- a/manual/fr/align-html-elements-to-3d.html
+++ b/manual/fr/align-html-elements-to-3d.html
@@ -271,14 +271,14 @@ const viewProjection = new THREE.Matrix4();
 
 // avant de vérifier
 camera.updateMatrix();
-camera.updateMatrixWorld();
+camera.ensureMatrices();
 camera.matrixWorldInverse.copy(camera.matrixWorld).invert();
 
 ...
 
 // puis pour chaque maillage
 someMesh.updateMatrix();
-someMesh.updateMatrixWorld();
+someMesh.ensureMatrices();
 
 viewProjection.multiplyMatrices(
     camera.projectionMatrix, camera.matrixWorldInverse);

--- a/manual/fr/custom-buffergeometry.html
+++ b/manual/fr/custom-buffergeometry.html
@@ -341,7 +341,7 @@ les points de la sphère. La façon dont cela fonctionne est expliquée dans <a 
   function getPoint(lat, long) {
     latHelper.rotation.x = lat;
     longHelper.rotation.y = long;
-    longHelper.updateMatrixWorld(true);
+    longHelper.ensureMatrices(true);
     return pointHelper.getWorldPosition(temp).toArray();
   }
 

--- a/manual/fr/lights.html
+++ b/manual/fr/lights.html
@@ -259,7 +259,7 @@ appelée chaque fois que lil-gui met à jour une valeur.</p>
 <p>Ensuite, nous pouvons l'utiliser à la fois pour la position de la lumière
 et pour la position de la cible, comme ceci</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">+function updateLight() {
-+  light.target.updateMatrixWorld();
++  light.target.ensureMatrices();
 +  helper.update();
 +}
 +updateLight();
@@ -303,7 +303,7 @@ scene.add(helper);
 </pre>
 <p>et comme il n'y a pas de cible, la fonction <code class="notranslate" translate="no">onChange</code> peut être plus simple.</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">function updateLight() {
--  light.target.updateMatrixWorld();
+-  light.target.ensureMatrices();
   helper.update();
 }
 -updateLight();

--- a/manual/fr/load-gltf.html
+++ b/manual/fr/load-gltf.html
@@ -226,7 +226,7 @@ gltfLoader.load('resources/models/cartoon_lowpoly_small_city_free_pack/scene.glt
 +      { prefix: 'Car_04', rot: [0, Math.PI, 0], },
 +    ];
 +
-+    root.updateMatrixWorld();
++    root.ensureMatrices();
 +    for (const car of loadedCars.children.slice()) {
 +      const fix = fixes.find(fix =&gt; car.name.startsWith(fix.prefix));
 +      const obj = new THREE.Object3D();
@@ -493,7 +493,7 @@ const fixes = [
 +  { prefix: 'Car_04', y: 40, rot: [0, Math.PI, 0], },
 ];
 
-root.updateMatrixWorld();
+root.ensureMatrices();
 for (const car of loadedCars.children.slice()) {
   const fix = fixes.find(fix =&gt; car.name.startsWith(fix.prefix));
   const obj = new THREE.Object3D();

--- a/manual/fr/load-obj.html
+++ b/manual/fr/load-obj.html
@@ -517,7 +517,7 @@ puis les définir sur l'<a href="/docs/#examples/loaders/OBJLoader"><code class=
 +    const objLoader = new OBJLoader();
 +    objLoader.setMaterials(mtl);
     objLoader.load('resources/models/windmill/windmill.obj', (root) =&gt; {
-      root.updateMatrixWorld();
+      root.ensureMatrices();
       scene.add(root);
       // calcule la boîte qui contient tout ce qui se trouve
       // à partir de la racine et en dessous

--- a/manual/fr/matrix-transformations.html
+++ b/manual/fr/matrix-transformations.html
@@ -69,7 +69,7 @@ object.matrixAutoUpdate = false;
             La matrice d'un objet stocke la transformation de l'objet <em>par rapport</em> à son parent ; pour obtenir la transformation de l'objet en coordonnées <em>du monde</em>, vous devez accéder à la matrice du monde de l'objet.
             </p>
             <p>
-            Lorsque la transformation du parent ou de l'enfant change, vous pouvez demander la mise à jour de la matrice du monde de l'objet enfant en appelant `object.updateMatrixWorld()`.
+            Lorsque la transformation du parent ou de l'enfant change, vous pouvez demander la mise à jour de la matrice du monde de l'objet enfant en appelant `object.ensureMatrices()`.
             </p>
             <p>
             Un objet peut être transformé via `applyMatrix4()`. Note : En coulisses, cette méthode repose sur `Matrix4.decompose()`, et toutes les matrices ne sont pas décomposables de cette manière. Par exemple, si un objet a un parent avec une mise à l'échelle non uniforme, la matrice du monde de l'objet peut ne pas être décomposable, et cette méthode pourrait ne pas être appropriée.

--- a/manual/fr/shadows.html
+++ b/manual/fr/shadows.html
@@ -331,7 +331,7 @@ gui.add(light, 'intensity', 0, 2, 0.01);
 caméra d'ombre de la lumière et l'helper affichant la caméra d'ombre de la lumière.</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">function updateCamera() {
   // mettre à jour le matrixWorld de la cible de la lumière car il est nécessaire pour l'helper
-  light.target.updateMatrixWorld();
+  light.target.ensureMatrices();
   helper.update();
   // mettre à jour la matrice de projection de la caméra d'ombre de la lumière
   light.shadow.camera.updateProjectionMatrix();

--- a/manual/ja/align-html-elements-to-3d.html
+++ b/manual/ja/align-html-elements-to-3d.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html lang="ja"><head>
+﻿<!DOCTYPE html><html lang="ja"><head>
     <meta charset="utf-8">
     <title>でHTML要素を3Dに揃える</title>
     <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
@@ -264,14 +264,14 @@ const viewProjection = new THREE.Matrix4();
 
 // before checking
 camera.updateMatrix();
-camera.updateMatrixWorld();
+camera.ensureMatrices();
 camera.matrixWorldInverse.copy(camera.matrixWorld).invert();
 
 ...
 
 // then for each mesh
 someMesh.updateMatrix();
-someMesh.updateMatrixWorld();
+someMesh.ensureMatrices();
 
 viewProjection.multiplyMatrices(
     camera.projectionMatrix, camera.matrixWorldInverse);

--- a/manual/ja/custom-buffergeometry.html
+++ b/manual/ja/custom-buffergeometry.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html lang="ja"><head>
+﻿<!DOCTYPE html><html lang="ja"><head>
     <meta charset="utf-8">
     <title>のカスタムバッファジオメトリ</title>
     <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
@@ -290,7 +290,7 @@ geometry.setIndex([
   function getPoint(lat, long) {
     latHelper.rotation.x = lat;
     longHelper.rotation.y = long;
-    longHelper.updateMatrixWorld(true);
+    longHelper.ensureMatrices(true);
     return pointHelper.getWorldPosition(temp).toArray();
   }
 

--- a/manual/ja/lights.html
+++ b/manual/ja/lights.html
@@ -231,7 +231,7 @@ scene.add(helper);
 そのため、lil-guiが値を更新時に <code class="notranslate" translate="no">onChangeFn</code> 関数を渡しています。</p>
 <p>makeXYZGUI関数はlight.positionとlight.target.positionの両方に使えます。</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">+function updateLight() {
-+  light.target.updateMatrixWorld();
++  light.target.ensureMatrices();
 +  helper.update();
 +}
 +updateLight();
@@ -273,7 +273,7 @@ scene.add(helper);
 </pre>
 <p>light.targetがないので <code class="notranslate" translate="no">onChange</code> 関数はもっとシンプルになります。</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">function updateLight() {
--  light.target.updateMatrixWorld();
+-  light.target.ensureMatrices();
   helper.update();
 }
 -updateLight();

--- a/manual/ja/load-gltf.html
+++ b/manual/ja/load-gltf.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html lang="ja"><head>
+﻿<!DOCTYPE html><html lang="ja"><head>
     <meta charset="utf-8">
     <title>でGLFTファイルを読み込む</title>
     <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
@@ -250,7 +250,7 @@ gltfLoader.load('resources/models/cartoon_lowpoly_small_city_free_pack/scene.glt
 +      { prefix: 'Car_04', rot: [0, Math.PI, 0], },
 +    ];
 +
-+    root.updateMatrixWorld();
++    root.ensureMatrices();
 +    for (const car of loadedCars.children.slice()) {
 +      const fix = fixes.find(fix =&gt; car.name.startsWith(fix.prefix));
 +      const obj = new THREE.Object3D();
@@ -540,7 +540,7 @@ const fixes = [
 +  { prefix: 'Car_04', y: 40, rot: [0, Math.PI, 0], },
 ];
 
-root.updateMatrixWorld();
+root.ensureMatrices();
 for (const car of loadedCars.children.slice()) {
   const fix = fixes.find(fix =&gt; car.name.startsWith(fix.prefix));
   const obj = new THREE.Object3D();

--- a/manual/ja/load-obj.html
+++ b/manual/ja/load-obj.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html lang="ja"><head>
+﻿<!DOCTYPE html><html lang="ja"><head>
     <meta charset="utf-8">
     <title>でOBJファイルを読み込む</title>
     <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
@@ -472,7 +472,7 @@ illum 2
 +    mtl.preload();
 +    objLoader.setMaterials(mtl);
     objLoader.load('resources/models/windmill/windmill.obj', (root) =&gt; {
-      root.updateMatrixWorld();
+      root.ensureMatrices();
       scene.add(root);
       // compute the box that contains all the stuff
       // from root and below

--- a/manual/ja/shadows.html
+++ b/manual/ja/shadows.html
@@ -306,7 +306,7 @@ gui.add(light, 'intensity', 0, 2, 0.01);
 ライトやヘルパー、ライトのシャドウカメラやカメラのヘルパーを更新するupdateCamera関数を書いてみましょう。</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">function updateCamera() {
   // update the light target's matrixWorld because it's needed by the helper
-  light.target.updateMatrixWorld();
+  light.target.ensureMatrices();
   helper.update();
   // update the light's shadow camera's projection matrix
   light.shadow.camera.updateProjectionMatrix();

--- a/manual/ko/align-html-elements-to-3d.html
+++ b/manual/ko/align-html-elements-to-3d.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html lang="ko"><head>
+﻿<!DOCTYPE html><html lang="ko"><head>
     <meta charset="utf-8">
     <title>HTML 요소를 3D로 정렬하기</title>
     <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
@@ -245,14 +245,14 @@ const viewProjection = new THREE.Matrix4();
 
 // 좌표 확인 전
 camera.updateMatrix();
-camera.updateMatrixWorld();
+camera.ensureMatrices();
 camera.matrixWorldInverse.copy(camera.matrixWorld).invert();
 
 ...
 
 // 각 mesh마다 좌표를 업데이트합니다.
 someMesh.updateMatrix();
-someMesh.updateMatrixWorld();
+someMesh.ensureMatrices();
 
 viewProjection.multiplyMatrices(
     camera.projectionMatrix, camera.matrixWorldInverse);

--- a/manual/ko/custom-buffergeometry.html
+++ b/manual/ko/custom-buffergeometry.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html lang="ko"><head>
+﻿<!DOCTYPE html><html lang="ko"><head>
     <meta charset="utf-8">
     <title>사용자 지정 BufferGeometry</title>
     <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
@@ -329,7 +329,7 @@ geometry.setIndex([
   function getPoint(lat, long) {
     latHelper.rotation.x = lat;
     longHelper.rotation.y = long;
-    longHelper.updateMatrixWorld(true);
+    longHelper.ensureMatrices(true);
     return pointHelper.getWorldPosition(temp).toArray();
   }
 

--- a/manual/ko/lights.html
+++ b/manual/ko/lights.html
@@ -239,7 +239,7 @@ scene.add(helper);
 호출할 수 있죠.</p>
 <p>그리고 조명의 위치, 목표의 위치 객체에 방금 만든 함수를 각각 적용합니다.</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">+function updateLight() {
-+  light.target.updateMatrixWorld();
++  light.target.ensureMatrices();
 +  helper.update();
 +}
 +updateLight();
@@ -283,7 +283,7 @@ scene.add(helper);
 <p><a href="/docs/#api/ko/lights/PointLight"><code class="notranslate" translate="no">PointLight</code></a>에는 목표가 없으므로 <code class="notranslate" translate="no">onChange</code> 함수도 훨씬 간단하게
 짤 수 있습니다.</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">function updateLight() {
--  light.target.updateMatrixWorld();
+-  light.target.ensureMatrices();
   helper.update();
 }
 -updateLight();

--- a/manual/ko/load-gltf.html
+++ b/manual/ko/load-gltf.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html lang="ko"><head>
+﻿<!DOCTYPE html><html lang="ko"><head>
     <meta charset="utf-8">
     <title>에서 .GLTF 파일 불러오기</title>
     <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
@@ -263,7 +263,7 @@ gltfLoader.load('resources/models/cartoon_lowpoly_small_city_free_pack/scene.glt
 +      { prefix: 'Car_04', rot: [0, Math.PI, 0], },
 +    ];
 +
-+    root.updateMatrixWorld();
++    root.ensureMatrices();
 +    for (const car of loadedCars.children.slice()) {
 +      const fix = fixes.find(fix =&gt; car.name.startsWith(fix.prefix));
 +      const obj = new THREE.Object3D();
@@ -566,7 +566,7 @@ const fixes = [
 +  { prefix: 'Car_04', y: 40, rot: [0, Math.PI, 0], },
 ];
 
-root.updateMatrixWorld();
+root.ensureMatrices();
 for (const car of loadedCars.children.slice()) {
   const fix = fixes.find(fix =&gt; car.name.startsWith(fix.prefix));
   const obj = new THREE.Object3D();

--- a/manual/ko/load-obj.html
+++ b/manual/ko/load-obj.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html lang="ko"><head>
+﻿<!DOCTYPE html><html lang="ko"><head>
     <meta charset="utf-8">
     <title>에서 .OBJ 파일 불러오기</title>
     <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
@@ -492,7 +492,7 @@ illum 2
 +    const objLoader = new OBJLoader();
 +    objLoader.setMaterials(mtl);
     objLoader.load('resources/models/windmill/windmill.obj', (root) =&gt; {
-      root.updateMatrixWorld();
+      root.ensureMatrices();
       scene.add(root);
       // 모든 요소를 포함하는 육면체를 계산합니다
       const box = new THREE.Box3().setFromObject(root);

--- a/manual/ko/shadows.html
+++ b/manual/ko/shadows.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html lang="ko"><head>
+﻿<!DOCTYPE html><html lang="ko"><head>
     <meta charset="utf-8">
     <title>그림자<(Shadows)</title>
     <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
@@ -326,7 +326,7 @@ gui.add(light, 'intensity', 0, 2, 0.01);
 조명, 조명 헬퍼, 조명의 그림자용 카메라, 그림자용 카메라의 헬퍼를 업데이트할 거예요.</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">function updateCamera() {
   // 헬퍼가 가이드라인을 그릴 때 필요한 조명 목표(target)의 matrixWorld를 업데이트 합니다
-  light.target.updateMatrixWorld();
+  light.target.ensureMatrices();
   helper.update();
   // 그림자용 카메라의 투영 행렬(projection matrix)를 업데이트합니다
   light.shadow.camera.updateProjectionMatrix();

--- a/manual/ru/custom-buffergeometry.html
+++ b/manual/ru/custom-buffergeometry.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html lang="ru"><head>
+﻿<!DOCTYPE html><html lang="ru"><head>
     <meta charset="utf-8">
     <title>Пользовательская BufferGeometry</title>
     <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
@@ -325,7 +325,7 @@ geometry.setIndex([
   function getPoint(lat, long) {
     latHelper.rotation.x = lat;
     longHelper.rotation.y = long;
-    longHelper.updateMatrixWorld(true);
+    longHelper.ensureMatrices(true);
     return pointHelper.getWorldPosition(temp).toArray();
   }
 

--- a/manual/ru/lights.html
+++ b/manual/ru/lights.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html lang="ru"><head>
+﻿<!DOCTYPE html><html lang="ru"><head>
     <meta charset="utf-8">
     <title>- Освещение</title>
     <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
@@ -258,7 +258,7 @@ scene.add(helper);
 <p>Затем мы можем использовать это как для положения источника света,
 так и для цели, как тут</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">+function updateLight() {
-+  light.target.updateMatrixWorld();
++  light.target.ensureMatrices();
 +  helper.update();
 +}
 +updateLight();
@@ -301,7 +301,7 @@ scene.add(helper);
 </pre>
 <p>и поскольку нет цели, то <code class="notranslate" translate="no">onChange</code> функция может быть проще.</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">function updateLight() {
--  light.target.updateMatrixWorld();
+-  light.target.ensureMatrices();
   helper.update();
 }
 -updateLight();

--- a/manual/ru/shadows.html
+++ b/manual/ru/shadows.html
@@ -300,7 +300,7 @@ gui.add(light, 'intensity', 0, 2, 0.01);
 камеры тени источника света и помощника, отображающего камеру тени источника света.</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">function updateCamera() {
   // update the light target's matrixWorld because it's needed by the helper
-  light.target.updateMatrixWorld();
+  light.target.ensureMatrices();
   helper.update();
   // update the light's shadow camera's projection matrix
   light.shadow.camera.updateProjectionMatrix();

--- a/manual/zh/align-html-elements-to-3d.html
+++ b/manual/zh/align-html-elements-to-3d.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html lang="zh">
 
 <head>
@@ -263,14 +263,14 @@ const viewProjection = new THREE.Matrix4();
 
 // 在检查前
 camera.updateMatrix();
-camera.updateMatrixWorld();
+camera.ensureMatrices();
 camera.matrixWorldInverse.copy(camera.matrixWorld).invert();
 
 ...
 
 // 然后，对每一个Mesh
 someMesh.updateMatrix();
-someMesh.updateMatrixWorld();
+someMesh.ensureMatrices();
 
 viewProjection.multiplyMatrices(
     camera.projectionMatrix, camera.matrixWorldInverse);

--- a/manual/zh/custom-buffergeometry.html
+++ b/manual/zh/custom-buffergeometry.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html lang="zh"><head>
+﻿<!DOCTYPE html><html lang="zh"><head>
     <meta charset="utf-8">
     <title>自定义缓冲几何体</title>
     <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
@@ -289,7 +289,7 @@ geometry.setIndex([
   function getPoint(lat, long) {
     latHelper.rotation.x = lat;
     longHelper.rotation.y = long;
-    longHelper.updateMatrixWorld(true);
+    longHelper.ensureMatrices(true);
     return pointHelper.getWorldPosition(temp).toArray();
   }
 

--- a/manual/zh/lights.html
+++ b/manual/zh/lights.html
@@ -206,7 +206,7 @@ scene.add(helper);
 <p>注意，当辅助对象所表示的不可见对象有所改变的时候，我们必须调用辅助对象的 <code class="notranslate" translate="no">update</code> 方法来更新辅助对象本身的状态。因此我们传入一个 <code class="notranslate" translate="no">onChangeFn</code> 函数，每当 <code class="notranslate" translate="no">lil-gui</code> 改变了某个值的时候，就会被调用。</p>
 <p>应用到光照位置与目标点位置的控制，就如下所示：</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">+function updateLight() {
-+  light.target.updateMatrixWorld();
++  light.target.ensureMatrices();
 +  helper.update();
 +}
 +updateLight();
@@ -245,7 +245,7 @@ scene.add(helper);
 </pre>
 <p>因为点光源没有 <code class="notranslate" translate="no">target</code> 属性，所以 <code class="notranslate" translate="no">onChange</code> 函数可以简化。</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">function updateLight() {
--  light.target.updateMatrixWorld();
+-  light.target.ensureMatrices();
   helper.update();
 }
 -updateLight();

--- a/manual/zh/load-gltf.html
+++ b/manual/zh/load-gltf.html
@@ -263,7 +263,7 @@ gltfLoader.load('resources/models/cartoon_lowpoly_small_city_free_pack/scene.glt
 +      { prefix: 'Car_04', rot: [0, Math.PI, 0], },
 +    ];
 +
-+    root.updateMatrixWorld();
++    root.ensureMatrices();
 +    for (const car of loadedCars.children.slice()) {
 +      const fix = fixes.find(fix =&gt; car.name.startsWith(fix.prefix));
 +      const obj = new THREE.Object3D();
@@ -565,7 +565,7 @@ const fixes = [
 +  { prefix: 'Car_04', y: 40, rot: [0, Math.PI, 0], },
 ];
 
-root.updateMatrixWorld();
+root.ensureMatrices();
 for (const car of loadedCars.children.slice()) {
 const fix = fixes.find(fix =&gt; car.name.startsWith(fix.prefix));
 const obj = new THREE.Object3D();

--- a/manual/zh/load-obj.html
+++ b/manual/zh/load-obj.html
@@ -412,7 +412,7 @@ illum 2
 +    const objLoader = new OBJLoader();
 +    objLoader.setMaterials(mtl);
     objLoader.load('resources/models/windmill/windmill.obj', (root) =&gt; {
-      root.updateMatrixWorld();
+      root.ensureMatrices();
       scene.add(root);
       // compute the box that contains all the stuff
       // from root and below

--- a/manual/zh/shadows.html
+++ b/manual/zh/shadows.html
@@ -286,7 +286,7 @@ gui.add(light, 'intensity', 0, 2, 0.01);
 这个方法将更新光源，光源的帮助类以及光源的阴影相机和像是光的阴影相机的帮助类。</p>
 <pre class="prettyprint showlinemods notranslate lang-js" translate="no">function updateCamera() {
   // update the light target's matrixWorld because it's needed by the helper
-  light.target.updateMatrixWorld();
+  light.target.ensureMatrices();
   helper.update();
   // update the light's shadow camera's projection matrix
   light.shadow.camera.updateProjectionMatrix();

--- a/src/audio/AudioListener.js
+++ b/src/audio/AudioListener.js
@@ -172,9 +172,9 @@ class AudioListener extends Object3D {
 
 	}
 
-	updateMatrixWorld( force ) {
+	updateMatrixWorld() {
 
-		super.updateMatrixWorld( force );
+		super.updateMatrixWorld();
 
 		const listener = this.context.listener;
 

--- a/src/audio/PositionalAudio.js
+++ b/src/audio/PositionalAudio.js
@@ -214,9 +214,9 @@ class PositionalAudio extends Audio {
 
 	}
 
-	updateMatrixWorld( force ) {
+	updateMatrixWorld() {
 
-		super.updateMatrixWorld( force );
+		super.updateMatrixWorld();
 
 		if ( this.hasPlaybackControl === true && this.isPlaying === false ) return;
 

--- a/src/cameras/Camera.js
+++ b/src/cameras/Camera.js
@@ -129,6 +129,33 @@ class Camera extends Object3D {
 
 	}
 
+	ensureMatrices(
+		force,
+		updateParents,
+		updateChildren,
+		updateLocal,
+		updateWorld,
+		respectAutoUpdateFlags
+	) {
+
+		super.ensureMatrices( force, updateParents, updateChildren, updateLocal, updateWorld, respectAutoUpdateFlags );
+
+		// exclude scale from view matrix to be glTF conform
+
+		this.matrixWorld.decompose( _position, _quaternion, _scale );
+
+		if ( _scale.x === 1 && _scale.y === 1 && _scale.z === 1 ) {
+
+			this.matrixWorldInverse.copy( this.matrixWorld ).invert();
+
+		} else {
+
+			this.matrixWorldInverse.compose( _position, _quaternion, _scale.set( 1, 1, 1 ) ).invert();
+
+		}
+
+	}
+
 	clone() {
 
 		return new this.constructor().copy( this );

--- a/src/cameras/Camera.js
+++ b/src/cameras/Camera.js
@@ -109,29 +109,9 @@ class Camera extends Object3D {
 
 	}
 
-	updateMatrixWorld( force ) {
+	updateMatrixWorld() {
 
-		super.updateMatrixWorld( force );
-
-		// exclude scale from view matrix to be glTF conform
-
-		this.matrixWorld.decompose( _position, _quaternion, _scale );
-
-		if ( _scale.x === 1 && _scale.y === 1 && _scale.z === 1 ) {
-
-			this.matrixWorldInverse.copy( this.matrixWorld ).invert();
-
-		} else {
-
-			this.matrixWorldInverse.compose( _position, _quaternion, _scale.set( 1, 1, 1 ) ).invert();
-
-		}
-
-	}
-
-	updateWorldMatrix( updateParents, updateChildren ) {
-
-		super.updateWorldMatrix( updateParents, updateChildren );
+		super.updateMatrixWorld();
 
 		// exclude scale from view matrix to be glTF conform
 

--- a/src/cameras/CubeCamera.js
+++ b/src/cameras/CubeCamera.js
@@ -162,7 +162,7 @@ class CubeCamera extends Object3D {
 
 			this.add( camera );
 
-			camera.updateMatrixWorld();
+			camera.ensureMatrices();
 
 		}
 
@@ -177,7 +177,7 @@ class CubeCamera extends Object3D {
 	 */
 	update( renderer, scene ) {
 
-		if ( this.parent === null ) this.updateMatrixWorld();
+		if ( this.parent === null ) this.ensureMatrices();
 
 		const { renderTarget, activeMipmapLevel } = this;
 

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -1198,15 +1198,15 @@ class Object3D extends EventDispatcher {
 
 		}
 
-		if ( updateLocal && ( ! respectAutoUpdateFlags || this.matrixAutoUpdate ) ) {
+		if ( updateLocal && ( this.matrixAutoUpdate || ! respectAutoUpdateFlags ) ) {
 
 			this.updateMatrix();
 
 		}
 
-		if ( updateWorld && ( ! respectAutoUpdateFlags || this.matrixWorldAutoUpdate ) ) {
+		if ( updateWorld && ( this.matrixWorldAutoUpdate || ! respectAutoUpdateFlags ) ) {
 
-			if ( force || this.matrixWorldNeedsUpdate ) {
+			if ( this.matrixWorldNeedsUpdate || force ) {
 
 				this.updateMatrixWorld();
 

--- a/src/helpers/Box3Helper.js
+++ b/src/helpers/Box3Helper.js
@@ -51,7 +51,7 @@ class Box3Helper extends LineSegments {
 
 	}
 
-	updateMatrixWorld( force ) {
+	updateMatrixWorld() {
 
 		const box = this.box;
 
@@ -63,7 +63,7 @@ class Box3Helper extends LineSegments {
 
 		this.scale.multiplyScalar( 0.5 );
 
-		super.updateMatrixWorld( force );
+		super.updateMatrixWorld();
 
 	}
 

--- a/src/helpers/PlaneHelper.js
+++ b/src/helpers/PlaneHelper.js
@@ -64,7 +64,7 @@ class PlaneHelper extends Line {
 
 	}
 
-	updateMatrixWorld( force ) {
+	updateMatrixWorld() {
 
 		this.position.set( 0, 0, 0 );
 
@@ -74,7 +74,7 @@ class PlaneHelper extends Line {
 
 		this.translateZ( - this.plane.constant );
 
-		super.updateMatrixWorld( force );
+		super.updateMatrixWorld();
 
 	}
 

--- a/src/helpers/PlaneHelper.js
+++ b/src/helpers/PlaneHelper.js
@@ -62,17 +62,30 @@ class PlaneHelper extends Line {
 
 		this.add( new Mesh( geometry2, new MeshBasicMaterial( { color: color, opacity: 0.2, transparent: true, depthWrite: false, toneMapped: false } ) ) );
 
+		this._calculatingMatrixWorld = false;
+
 	}
 
 	updateMatrixWorld() {
 
-		this.position.set( 0, 0, 0 );
+		if ( ! this._calculatingMatrixWorld ) {
 
-		this.scale.set( 0.5 * this.size, 0.5 * this.size, 1 );
+			// this.lookAt() internally calls this.updateMatrixWorld(), so put this
+			// code in an if-statement to avoid a 'too much recursion' error.
 
-		this.lookAt( this.plane.normal );
+			this._calculatingMatrixWorld = true;
 
-		this.translateZ( - this.plane.constant );
+			this.position.set( 0, 0, 0 );
+
+			this.scale.set( 0.5 * this.size, 0.5 * this.size, 1 );
+
+			this.lookAt( this.plane.normal );
+
+			this.translateZ( - this.plane.constant );
+
+			this._calculatingMatrixWorld = false;
+
+		}
 
 		super.updateMatrixWorld();
 

--- a/src/helpers/SkeletonHelper.js
+++ b/src/helpers/SkeletonHelper.js
@@ -96,7 +96,7 @@ class SkeletonHelper extends LineSegments {
 
 	}
 
-	updateMatrixWorld( force ) {
+	updateMatrixWorld() {
 
 		const bones = this.bones;
 
@@ -127,7 +127,7 @@ class SkeletonHelper extends LineSegments {
 
 		geometry.getAttribute( 'position' ).needsUpdate = true;
 
-		super.updateMatrixWorld( force );
+		super.updateMatrixWorld();
 
 	}
 

--- a/src/lights/LightShadow.js
+++ b/src/lights/LightShadow.js
@@ -208,7 +208,7 @@ class LightShadow {
 
 		_lookTarget.setFromMatrixPosition( light.target.matrixWorld );
 		shadowCamera.lookAt( _lookTarget );
-		shadowCamera.updateMatrixWorld();
+		shadowCamera.ensureMatrices();
 
 		_projScreenMatrix.multiplyMatrices( shadowCamera.projectionMatrix, shadowCamera.matrixWorldInverse );
 		this._frustum.setFromProjectionMatrix( _projScreenMatrix, shadowCamera.coordinateSystem, shadowCamera.reversedDepth );

--- a/src/nodes/lighting/PointShadowNode.js
+++ b/src/nodes/lighting/PointShadowNode.js
@@ -272,7 +272,7 @@ class PointShadowNode extends ShadowNode {
 			_lookTarget.add( cubeDirections[ face ] );
 			camera.up.copy( cubeUps[ face ] );
 			camera.lookAt( _lookTarget );
-			camera.updateMatrixWorld();
+			camera.ensureMatrices();
 
 			shadowMatrix.makeTranslation( - _lightPositionWorld.x, - _lightPositionWorld.y, - _lightPositionWorld.z );
 

--- a/src/nodes/utils/ReflectorNode.js
+++ b/src/nodes/utils/ReflectorNode.js
@@ -504,7 +504,7 @@ class ReflectorBaseNode extends Node {
 		virtualCamera.near = camera.near;
 		virtualCamera.far = camera.far;
 
-		virtualCamera.updateMatrixWorld();
+		virtualCamera.ensureMatrices();
 		virtualCamera.projectionMatrix.copy( camera.projectionMatrix );
 
 		// Now update projection matrix with new clip plane, implementing code from: http://www.terathon.com/code/oblique.html

--- a/src/objects/SkinnedMesh.js
+++ b/src/objects/SkinnedMesh.js
@@ -233,7 +233,7 @@ class SkinnedMesh extends Mesh {
 
 		if ( bindMatrix === undefined ) {
 
-			this.updateMatrixWorld( true );
+			this.ensureMatrices( true );
 
 			this.skeleton.calculateInverses();
 
@@ -287,9 +287,9 @@ class SkinnedMesh extends Mesh {
 
 	}
 
-	updateMatrixWorld( force ) {
+	updateMatrixWorld() {
 
-		super.updateMatrixWorld( force );
+		super.updateMatrixWorld();
 
 		if ( this.bindMode === AttachedBindMode ) {
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1607,11 +1607,11 @@ class WebGLRenderer {
 
 			// update scene graph
 
-			if ( scene.matrixWorldAutoUpdate === true ) scene.updateMatrixWorld();
+			if ( scene.matrixWorldAutoUpdate === true ) scene.ensureMatrices();
 
 			// update camera matrices and frustum
 
-			if ( camera.parent === null && camera.matrixWorldAutoUpdate === true ) camera.updateMatrixWorld();
+			if ( camera.parent === null && camera.matrixWorldAutoUpdate === true ) camera.ensureMatrices();
 
 			if ( xr.enabled === true && xr.isPresenting === true && ( output === null || output.isCompositing() === false ) ) {
 

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -1445,9 +1445,9 @@ class Renderer {
 
 		//
 
-		if ( scene.matrixWorldAutoUpdate === true ) scene.updateMatrixWorld();
+		if ( scene.matrixWorldAutoUpdate === true ) scene.ensureMatrices();
 
-		if ( camera.parent === null && camera.matrixWorldAutoUpdate === true ) camera.updateMatrixWorld();
+		if ( camera.parent === null && camera.matrixWorldAutoUpdate === true ) camera.ensureMatrices();
 
 		if ( xr.enabled === true && xr.isPresenting === true ) {
 

--- a/src/renderers/common/XRManager.js
+++ b/src/renderers/common/XRManager.js
@@ -1310,7 +1310,7 @@ function updateUserCamera( camera, cameraXR, parent ) {
 	}
 
 	camera.matrix.decompose( camera.position, camera.quaternion, camera.scale );
-	camera.updateMatrixWorld( true );
+	camera.ensureMatrices( true );
 
 	camera.projectionMatrix.copy( cameraXR.projectionMatrix );
 	camera.projectionMatrixInverse.copy( cameraXR.projectionMatrixInverse );

--- a/src/renderers/webgl/WebGLShadowMap.js
+++ b/src/renderers/webgl/WebGLShadowMap.js
@@ -333,7 +333,7 @@ function WebGLShadowMap( renderer, objects, capabilities ) {
 					_lookTarget.add( _cubeDirections[ face ] );
 					camera.up.copy( _cubeUps[ face ] );
 					camera.lookAt( _lookTarget );
-					camera.updateMatrixWorld();
+					camera.ensureMatrices();
 
 					shadowMatrix.makeTranslation( - _lightPositionWorld.x, - _lightPositionWorld.y, - _lightPositionWorld.z );
 

--- a/src/renderers/webxr/WebXRManager.js
+++ b/src/renderers/webxr/WebXRManager.js
@@ -798,7 +798,7 @@ class WebXRManager extends EventDispatcher {
 			}
 
 			camera.matrix.decompose( camera.position, camera.quaternion, camera.scale );
-			camera.updateMatrixWorld( true );
+			camera.ensureMatrices( true );
 
 			camera.projectionMatrix.copy( cameraXR.projectionMatrix );
 			camera.projectionMatrixInverse.copy( cameraXR.projectionMatrixInverse );

--- a/test/unit/addons/exporters/USDZExporter.tests.js
+++ b/test/unit/addons/exporters/USDZExporter.tests.js
@@ -198,7 +198,7 @@ export default QUnit.module( 'Addons', () => {
 
 				const meshes = [ box, sphere ];
 
-				originalScene.updateMatrixWorld( true );
+				originalScene.ensureMatrices( true );
 
 				const exportResult = await exporter.parseAsync( originalScene );
 

--- a/test/unit/src/core/Object3D.tests.js
+++ b/test/unit/src/core/Object3D.tests.js
@@ -354,7 +354,7 @@ export default QUnit.module( 'Core', () => {
 			child.scale.set( 1, 2, 1 );
 
 			parent.add( child );
-			parent.updateMatrixWorld();
+			parent.ensureMatrices();
 
 			child.localToWorld( v.set( 2, 2, 2 ) );
 
@@ -384,7 +384,7 @@ export default QUnit.module( 'Core', () => {
 			child.scale.set( 1, 2, 1 );
 
 			parent.add( child );
-			parent.updateMatrixWorld();
+			parent.ensureMatrices();
 
 			child.worldToLocal( v.set( 2, 2, 2 ) );
 
@@ -469,8 +469,8 @@ export default QUnit.module( 'Core', () => {
 			newParent.rotation.set( Math.PI / 5, Math.PI / 6, Math.PI / 7 );
 			newParent.scale.set( 5, 5, 5 );
 
-			object.updateMatrixWorld();
-			newParent.updateMatrixWorld();
+			object.ensureMatrices();
+			newParent.ensureMatrices();
 			expectedMatrixWorld.copy( object.matrixWorld );
 
 			newParent.attach( object );
@@ -494,8 +494,8 @@ export default QUnit.module( 'Core', () => {
 			newParent.scale.set( 6, 6, 6 );
 
 			oldParent.add( object );
-			oldParent.updateMatrixWorld();
-			newParent.updateMatrixWorld();
+			oldParent.ensureMatrices();
+			newParent.ensureMatrices();
 			expectedMatrixWorld.copy( object.matrixWorld );
 
 			newParent.attach( object );
@@ -720,7 +720,7 @@ export default QUnit.module( 'Core', () => {
 			child.position.set( 4, 5, 6 );
 			parent.add( child );
 
-			parent.updateMatrixWorld();
+			parent.ensureMatrices();
 
 			assert.deepEqual( parent.matrix.elements, [
 				1, 0, 0, 0,
@@ -768,12 +768,12 @@ export default QUnit.module( 'Core', () => {
 
 			// Resetting local and world matrices to the origin
 			child.position.set( 0, 0, 0 );
-			parent.updateMatrixWorld();
+			parent.ensureMatrices();
 
 			parent.position.set( 1, 2, 3 );
 			parent.matrixAutoUpdate = false;
 			child.matrixAutoUpdate = false;
-			parent.updateMatrixWorld();
+			parent.ensureMatrices();
 
 			assert.deepEqual( parent.matrix.elements, [
 				1, 0, 0, 0,
@@ -805,7 +805,7 @@ export default QUnit.module( 'Core', () => {
 			child.matrixAutoUpdate = true;
 			parent.matrixWorldNeedsUpdate = true;
 			child.matrixWorldAutoUpdate = false;
-			parent.updateMatrixWorld();
+			parent.ensureMatrices();
 
 			assert.deepEqual( child.matrixWorld.elements, [
 				1, 0, 0, 0,
@@ -819,7 +819,7 @@ export default QUnit.module( 'Core', () => {
 			child.position.set( 0, 0, 0 );
 			parent.position.set( 1, 2, 3 );
 			child.matrixWorldAutoUpdate = true;
-			parent.updateMatrixWorld();
+			parent.ensureMatrices();
 
 			assert.deepEqual( child.matrixWorld.elements, [
 				1, 0, 0, 0,
@@ -833,14 +833,14 @@ export default QUnit.module( 'Core', () => {
 			// Resetting the local and world matrices to the origin
 			child.position.set( 0, 0, 0 );
 			child.matrixAutoUpdate = true;
-			parent.updateMatrixWorld();
+			parent.ensureMatrices();
 
 			parent.position.set( 1, 2, 3 );
 			parent.updateMatrix();
 			parent.matrixAutoUpdate = false;
 			parent.matrixWorldNeedsUpdate = false;
 
-			parent.updateMatrixWorld( true );
+			parent.ensureMatrices( true );
 
 			assert.deepEqual( parent.matrixWorld.elements, [
 				1, 0, 0, 0,
@@ -856,12 +856,12 @@ export default QUnit.module( 'Core', () => {
 			child.position.set( 0, 0, 0 );
 			parent.matrixAutoUpdate = true;
 			child.matrixAutoUpdate = true;
-			parent.updateMatrixWorld();
+			parent.ensureMatrices();
 
 			parent.position.set( 1, 2, 3 );
 			child.position.set( 4, 5, 6 );
 
-			child.updateMatrixWorld();
+			child.ensureMatrices();
 
 			assert.deepEqual( parent.matrix.elements, [
 				1, 0, 0, 0,

--- a/test/unit/src/core/Raycaster.tests.js
+++ b/test/unit/src/core/Raycaster.tests.js
@@ -52,7 +52,7 @@ function getObjectsToCheck() {
 
 	for ( let i = 0; i < objects.length; i ++ ) {
 
-		objects[ i ].updateMatrixWorld();
+		objects[ i ].ensureMatrices();
 
 	}
 

--- a/test/unit/src/math/Frustum.tests.js
+++ b/test/unit/src/math/Frustum.tests.js
@@ -199,13 +199,13 @@ export default QUnit.module( 'Maths', () => {
 			assert.notOk( intersects, 'No intersection' );
 
 			object.position.set( - 1, - 1, - 1 );
-			object.updateMatrixWorld();
+			object.ensureMatrices();
 
 			intersects = a.intersectsObject( object );
 			assert.ok( intersects, 'Successful intersection' );
 
 			object.position.set( 1, 1, 1 );
-			object.updateMatrixWorld();
+			object.ensureMatrices();
 
 			intersects = a.intersectsObject( object );
 			assert.notOk( intersects, 'No intersection' );
@@ -223,7 +223,7 @@ export default QUnit.module( 'Maths', () => {
 			assert.notOk( intersects, 'No intersection' );
 
 			sprite.position.set( - 1, - 1, - 1 );
-			sprite.updateMatrixWorld();
+			sprite.ensureMatrices();
 
 			intersects = a.intersectsSprite( sprite );
 			assert.ok( intersects, 'Successful intersection' );

--- a/test/unit/src/objects/Mesh.tests.js
+++ b/test/unit/src/objects/Mesh.tests.js
@@ -112,21 +112,21 @@ export default QUnit.module( 'Objects', () => {
 
 			mesh.matrixWorld.identity();
 			mesh.position.setX( 150 );
-			mesh.updateMatrixWorld( true );
+			mesh.ensureMatrices( true );
 			intersections.length = 0;
 			mesh.raycast( raycaster, intersections );
 			assert.ok( intersections.length > 0, 'bounding sphere between near and far' );
 
 			mesh.matrixWorld.identity();
 			mesh.position.setX( raycaster.near );
-			mesh.updateMatrixWorld( true );
+			mesh.ensureMatrices( true );
 			intersections.length = 0;
 			mesh.raycast( raycaster, intersections );
 			assert.ok( intersections.length > 0, 'bounding sphere across near' );
 
 			mesh.matrixWorld.identity();
 			mesh.position.setX( raycaster.far );
-			mesh.updateMatrixWorld( true );
+			mesh.ensureMatrices( true );
 			intersections.length = 0;
 			mesh.raycast( raycaster, intersections );
 			assert.ok( intersections.length > 0, 'bounding sphere across far' );
@@ -134,21 +134,21 @@ export default QUnit.module( 'Objects', () => {
 			mesh.matrixWorld.identity();
 			mesh.position.setX( 150 );
 			mesh.scale.setY( 9999 );
-			mesh.updateMatrixWorld( true );
+			mesh.ensureMatrices( true );
 			intersections.length = 0;
 			mesh.raycast( raycaster, intersections );
 			assert.ok( intersections.length > 0, 'bounding sphere across near and far' );
 
 			mesh.matrixWorld.identity();
 			mesh.position.setX( - 9999 );
-			mesh.updateMatrixWorld( true );
+			mesh.ensureMatrices( true );
 			intersections.length = 0;
 			mesh.raycast( raycaster, intersections );
 			assert.ok( intersections.length === 0, 'bounding sphere behind near' );
 
 			mesh.matrixWorld.identity();
 			mesh.position.setX( 9999 );
-			mesh.updateMatrixWorld( true );
+			mesh.ensureMatrices( true );
 			intersections.length = 0;
 			mesh.raycast( raycaster, intersections );
 			assert.ok( intersections.length === 0, 'bounding sphere beyond far' );


### PR DESCRIPTION
Related: #32894, #21387, #14138, #18344, #20220, #25115, #27261, #14543

This PR is an attempt to fix issues surrounding updateMatrixWorld() and how it is used internally. It also gives more control to users over the world matrix update process that is very much needed. This PR does not address performance issues related to updateMatrixWorld(). It only fixes single-responsibility problems and does not change internal logic.

### 👍 `updateMatrix()` is all good

1. Currently, and true to its name, `updateMatrix()` updates the local matrix only. It works even if `matrixAutoUpdate` is `false`, which is what I would expect -- if the user has opted out of "automatic updates" by setting `matrixAutoUpdate` to `false`, the user can still manually update the local matrix when they feel it is necessary.

2. Because `updateMatrix()` has a single responsibility (to calculate the local matrix), this means methods that override `updateMatrix()` only need to worry about doing just that, and nothing else.

### ❓ `updateMatrixWorld()` is a different story

Unfortunately, `updateMatrixWorld()` does not follow the same pattern as `updateMatrix()`:

1. If `matrixWorldAutoUpdate` is `false`, it is impossible for a user to update the world matrix by just calling the method alone. They must first set `matrixWorldAutoUpdate` to `true`, call the method, then set `matrixWorldAutoUpdate` back to `false`. This deviates from the behavior of `updateMatrix()` as described above. This is surprising.

Here's an example of where this behavioral inconsistency between `updateMatrix()` and `updateMatrixWorld()` is an issue. In the following snippet, the call to `object.updateMatrixWorld()` doesn't do anything, because `matrixAutoUpdate` was set to `false` for all of the objects in the scene. This means that `matrixWorldNeedsUpdate` never gets set to `true`, which means the world matrix is never actually calculated. The author of this example probably assumed it would though:

https://github.com/mrdoob/three.js/blob/1f2fea769315befd9bdb3f46574e2eeb92c5047a/examples/webgl_math_obb.html#L211-L212

3. It is impossible to _only_ update the world matrix if `matrixAutoUpdate` is `true` without adding code to unset `matrixAutoUpdate` before calling, and resetting `matrixAutoUpdate` after calling. This is inconvenient.

You can see the local matrix get double-calculated in several places in three.js:

https://github.com/mrdoob/three.js/blob/1f2fea769315befd9bdb3f46574e2eeb92c5047a/examples/jsm/tsl/shadows/TileShadowNode.js#L385-L386

4. Lastly, not only does `updateMatrixWorld()` calculate the local and world matrices, it also traverses through all descendants to do the same to them. Because `updateMatrixWorld()` tries to do three things at once, it is more complicated to override the method, because each override must also implement the local matrix update and descendant update logic.

### 😔 Override Sadness

Because of the issues with overriding `updateMatrixWorld()` mentioned above, you have things like this in three.js. In the following excerpt from `Gyroscope.js`, notice that all this method wants to do is override the world matrix calculation, but because `Object3D.updateWorldMatrix()` currently does three different things, `Gyroscope.js` has to re-implement the local matrix calculation and child traversal code in addition to the world matrix calculation:

https://github.com/mrdoob/three.js/blob/59335f4ab39fe76525012215fe8f4559719447c0/examples/jsm/misc/Gyroscope.js#L35-L74

The following excerpt is another issue caused by `updateMatrixWorld()` doing more than it should. In `Camera.js`, notice that both `updateMatrixWorld()` and `updateWorldMatrix()` have to be overridden (with the same identical code). This is because the actual world matrix calculation is not isolated into its own method:

https://github.com/mrdoob/three.js/blob/59335f4ab39fe76525012215fe8f4559719447c0/src/cameras/Camera.js#L112-L150

### ♻️ `updateWorldMatrix()` is just `updateMatrixWorld(true)` with extra arguments

Right now, `updateWorldMatrix()` is identical to `updateMatrixWorld()`, except that it ignores `matrixWorldNeedsUpdate`, and has the ability to control whether parents or descendants are traversed. If we simply added the arguments `updateParents`, `updateChildren`, and `respectAutoUpdateFlags` to `updateMatrixWorld()`, then we can make `updateWorldMatrix()` internally call `updateMatrixWorld(true, ...args)`.

### 💎 What this PR does

1. Made `updateMatrixWorld()` ONLY calculate the world matrix and ignore `matrixWorldAutoUpdate`, to be consistent with `updateMatrix()`.
2. Moved the code from `updateWorldMatrix(updateParents, updateChildren)` into a method named `ensureMatrices(force=false, updateParents=false, updateChildren=true, respectAutoUpdateFlags=true)` so we recycle existing code, and also have control over whether we want to respect the "automatic update" flags.
3. Replaces all calls to `updateMatrixWorld(force)` with calls to `ensureMatrices(force)`.

### 🔨 Just 1 tiny breaking change

1. Any code that calls `updateMatrixWorld(...args)` should instead call `ensureMatrices(...args)`. The default arguments to `ensureMatrices()` are set to match the old behavior of `updateMatrixWorld()`, so the only thing to update would be the function name. **Best of all, there is no change required for users calling `updateWorldMatrix()`.**

### 🎯 Old versus new ways of calculating matrices

| **Scenario**                                                                                                                                                                                    | Current                                                                                                                                                                                                                                                 | After Refactor                             |
|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------|
| I want to trigger an "automatic update" of all the matrices in the scene.                                                                                                                       | `scene.updateMatrixWorld();`                                                                                                                                                                                                                            | `scene.ensureMatrices();`                  |
| I want to update a single object's local and world matrix and have it respect that object's `matrixAutoUpdate` and `matrixWorldAutoUpdate` flags, but ignore the `matrixWorldNeedsUpdate` flag. | `o.updateWorldMatrix();`                                                                                                                                                                                                                                | `o.updateWorldMatrix();`                   |
| I want to update a single object's world matrix when `matrixWorldAutoUpdate` is `false`.                                                                                                        | `o.matrixWorldAutoUpdate = true;`<br> `o.updateWorldMatrix();`<br> `o.matrixWorldAutoUpdate = false;`                                                                                                                                                   | `o.updateMatrixWorld();`                   |
| I want to update a single object's world matrix _only_, without also updating the local matrix.                                                                                                 | `o.matrixAutoUpdate = false;`<br> `o.updateWorldMatrix();`<br> `o.matrixAutoUpdate = true;`                                                                                                                                                             | `o.updateMatrixWorld();`                   |
| I want to force an update of ONLY the world matrix of an object and all its descendants, regardless if the object's and its descendants' `matrixWorldAutoUpdate` flags are `false`.             | `o.traverse(c => {`<br> `c.matrixAutoUpdate = false;`<br> `c.matrixWorldAutoUpdate = true;`<br> `});`<br> `o.updateWorldMatrix(false, true);`<br> `o.traverse(c => {`<br> `c.matrixAutoUpdate = true;`<br> `c.matrixWorldAutoUpdate = false;`<br> `});` | `o.updateWorldMatrix(false, true, false, true, false);` |

### 💲 API Surface & Thoughts

Here is the API surface in this PR:

```typescript
// updateMatrixWorld: No parameters. Updates the world matrix of the current object only.
updateMatrixWorld(
)

// ensureMatrices: Full control over the scene graph matrix update process.
ensureMatrices(
    force: boolean, // default is false
    updateParents: boolean, // default is false
    updateChildren: boolean, // default is true
    updateLocal: boolean, // default is true
    updateWorld: boolean, // default is true
    respectAutoUpdateFlags: boolean // default is true
)

// updateWorldMatrix: No change, except for added arguments for more control.
updateWorldMatrix(
    updateParents: boolean, // default is false
    updateChildren: boolean, // default is false
    updateLocal: boolean, // default is true
    updateWorld: boolean, // default is true
    respectAutoUpdateFlags: boolean // default is true
)
```

As you can see, this refactor trivializes previously cumbersome matrix operations, and fixes the confusing overridability issues. Let me know of any questions you may have.