### PR TITLE
Utils: Fix loading of sites without .html extension.

### DIFF
--- a/utils/server.js
+++ b/utils/server.js
@@ -124,9 +124,17 @@ ${items}
 
 		if ( ! existsSync( filePath ) ) {
 
-			res.writeHead( 404 );
-			res.end( 'File not found' );
-			return;
+			if ( existsSync( filePath + '.html' ) ) {
+
+				filePath += '.html';
+
+			} else {
+
+				res.writeHead( 404 );
+				res.end( 'File not found' );
+				return;
+
+			}
 
 		}
 


### PR DESCRIPTION
Related issue: #32654

**Description**

The new custom server does not accept URLs like `http://localhost:8080/examples/misc_controls_orbit`. It always expects a file extension which is a bit annoying.

With this PR, the server responds to the above URL.
