### PR TITLE
Fix typo and link in Installation manual

### DIFF
--- a/manual/en/installation.html
+++ b/manual/en/installation.html
@@ -85,7 +85,7 @@ import * as THREE from 'three';
 
           <ol>
             <li>
-              Install [link:https://nodejs.org/ Node.js]. We'll need it to load manage dependencies and to run our build tool.
+              Install [link:https://nodejs.org/ Node.js]. We'll need it to manage dependencies and to run our build tool.
             </li>
             <li>
               <p>


### PR DESCRIPTION

**Description**


**This PR fixes a small typo in the Installation manual page** ~and corrects a relative link to “Libraries and Plugins” by adding the missing `.html` extension.~

**How to test**
Open manual/en/installation.html and verify:
- Text reads “manage dependencies…”
~- “Libraries and Plugins” link points to libraries-and-plugins.html and resolves correctly.~