### PR TITLE
WebGPURenderer: Improve `compatibilityMode` support for MRT

### DIFF
--- a/src/renderers/webgl-fallback/utils/WebGLState.js
+++ b/src/renderers/webgl-fallback/utils/WebGLState.js
@@ -8,7 +8,7 @@ import {
 	MaterialBlending
 } from '../../../constants.js';
 import { Vector4 } from '../../../math/Vector4.js';
-import { error } from '../../../utils.js';
+import { error, warnOnce } from '../../../utils.js';
 
 let equationToGL, factorToGL;
 
@@ -276,7 +276,13 @@ class WebGLState {
 		const gl = this.gl;
 		const drawBuffersIndexedExt = this.backend.drawBuffersIndexedExt;
 
-		if ( ! drawBuffersIndexedExt ) return;
+		if ( ! drawBuffersIndexedExt ) {
+
+			warnOnce( 'WebGPURenderer: Multiple Render Targets (MRT) blending configuration is not fully supported in compatibility mode. The material blending will be used for all render targets.' );
+
+			return;
+
+		}
 
 		for ( let i = 0; i < textures.length; i ++ ) {
 

--- a/src/renderers/webgpu/utils/WebGPUPipelineUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUPipelineUtils.js
@@ -15,7 +15,7 @@ import {
 	NeverStencilFunc, AlwaysStencilFunc, LessStencilFunc, LessEqualStencilFunc, EqualStencilFunc, GreaterEqualStencilFunc, GreaterStencilFunc, NotEqualStencilFunc
 } from '../../../constants.js';
 
-import { error } from '../../../utils.js';
+import { error, warnOnce } from '../../../utils.js';
 
 /**
  * A WebGPU backend utility module for managing pipelines.
@@ -161,15 +161,25 @@ class WebGPUPipelineUtils {
 
 				if ( mrt !== null ) {
 
-					const blendMode = mrt.getBlendMode( texture.name );
+					if ( this.backend.compatibilityMode !== true ) {
 
-					if ( blendMode.blending === MaterialBlending ) {
+						const blendMode = mrt.getBlendMode( texture.name );
+
+						if ( blendMode.blending === MaterialBlending ) {
+
+							blending = materialBlending;
+
+						} else if ( blendMode.blending !== NoBlending ) {
+
+							blending = this._getBlending( blendMode );
+
+						}
+
+					} else {
+
+						warnOnce( 'WebGPURenderer: Multiple Render Targets (MRT) blending configuration is not fully supported in compatibility mode. The material blending will be used for all render targets.' );
 
 						blending = materialBlending;
-
-					} else if ( blendMode.blending !== NoBlending ) {
-
-						blending = this._getBlending( blendMode );
 
 					}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/issues/30725#issuecomment-3849503492

**Description**

Added a warning about the limitation in WebGPU in compatibility mode and WebGL2 fallback, but keep the examples working within this limitation, using the same blending for all MRT attachments.