### PR TITLE
TSL: Fix `instancedArray()` `bufferCount` property

### DIFF
--- a/src/nodes/accessors/Arrays.js
+++ b/src/nodes/accessors/Arrays.js
@@ -61,7 +61,7 @@ export const instancedArray = ( count, type = 'float' ) => {
 	}
 
 	const buffer = new StorageInstancedBufferAttribute( count, itemSize, typedArray );
-	const node = storage( buffer, type, count );
+	const node = storage( buffer, type, buffer.count );
 
 	return node;
 


### PR DESCRIPTION
Fixed https://github.com/mrdoob/three.js/issues/32971

**Description**

Fix `instancedArray()` `bufferCount` property, returning the TypedArray instead of the count.