### PR TITLE
Examples: Scroll sidebar to selected example

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -103,6 +103,7 @@
 				if ( validRedirects.has( file ) === true ) {
 
 					selectFile( file );
+					links[ file ].scrollIntoView( { block: 'center' } );
 					viewer.src = validRedirects.get( file );
 					viewer.style.display = 'unset';
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -270,7 +270,7 @@
 		function updateFilter( files, tags ) {
 
 			let v = filterInput.value.trim();
-			v = v.replace( /\s+/gi, ' ' ); // replace multiple whitespaces with a single one
+			v = v.replace( /[\s_]+/gi, ' ' ); // replace multiple whitespaces or underscores with a single one
 
 			if ( v !== '' ) {
 


### PR DESCRIPTION
**Description**

When selecting one example by hash, as in the link below, the list of examples does not follow along, making it difficult to navigate or search for similar examples. 

https://threejs.org/examples/#webgpu_materials_envmaps_bpcem

The update fixed this by centering the example in the middle of the screen. For example:

<img width="1401" height="705" alt="image" src="https://github.com/user-attachments/assets/a7f2206d-8824-4ef9-9079-b39fb9975233" />
