### PR TITLE
OrbitControls: Add `cursorStyle` property.

### DIFF
--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -391,6 +391,8 @@ class OrbitControls extends Controls {
 		 */
 		this.zoom0 = this.object.zoom;
 
+		this._cursorStyle = 'auto';
+
 		// the target DOM element for key events
 		this._domElementKeyEvents = null;
 
@@ -459,6 +461,34 @@ class OrbitControls extends Controls {
 		}
 
 		this.update();
+
+	}
+
+	/**
+	 * Defines the visual representation of the cursor.
+	 *
+	 * @type {('auto'|'grab')}
+	 * @default 'auto'
+	 */
+	set cursorStyle( type ) {
+
+		this._cursorStyle = type;
+
+		if ( type === 'grab' ) {
+
+			this.domElement.style.cursor = 'grab';
+
+		} else {
+
+			this.domElement.style.cursor = 'auto';
+
+		}
+
+	}
+
+	get cursorStyle() {
+
+		return this._cursorStyle;
 
 	}
 
@@ -1542,6 +1572,12 @@ function onPointerDown( event ) {
 
 	}
 
+	if ( this._cursorStyle === 'grab' ) {
+
+		this.domElement.style.cursor = 'grabbing';
+
+	}
+
 }
 
 function onPointerMove( event ) {
@@ -1576,6 +1612,12 @@ function onPointerUp( event ) {
 			this.dispatchEvent( _endEvent );
 
 			this.state = _STATE.NONE;
+
+			if ( this._cursorStyle === 'grab' ) {
+
+				this.domElement.style.cursor = 'grab';
+
+			}
 
 			break;
 

--- a/examples/misc_controls_orbit.html
+++ b/examples/misc_controls_orbit.html
@@ -72,6 +72,8 @@
 				controls.minDistance = 100;
 				controls.maxDistance = 500;
 
+				controls.cursorStyle = 'grab';
+
 				controls.maxPolarAngle = Math.PI / 2;
 
 				// world


### PR DESCRIPTION
Fixed #32968.

**Description**

Adds a new `cursorStyle` property that let's the user configure the style of the cursor. `misc_controls_orbit` has been updated to use the new feature. The mouse pointer looks like so now:

https://github.com/user-attachments/assets/1f0371f9-ca40-49c3-985e-c70f632cfd4f