### PR TITLE
GLTFLoader: use base64 data uris

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -3308,8 +3308,6 @@ class GLTFParser {
 
 		const sourceDef = json.images[ sourceIndex ];
 
-		const URL = self.URL || self.webkitURL;
-
 		let sourceURI = sourceDef.uri || '';
 
 		if ( sourceDef.bufferView !== undefined ) {


### PR DESCRIPTION
Related issue: #32986

**Description**

Instead of using the randomly generated uris, can we instead use the base64 string, so that they are always unique meaning the Cache will work as intended when enabled.

I don't particularity like storing such a massive string inside the Cache dictionary. but this was the potential solution I came up with, let me know if there's a better way

can now see that the Cache will be hit (see original issue)
<img width="2020" height="558" alt="Screenshot from 2026-02-10 10-25-28" src="https://github.com/user-attachments/assets/81690482-89b4-4701-add3-7f556272aba6" />

the toBase64 code I took from this source: https://stackoverflow.com/a/58339391/17501109
