### PR TITLE
Cache: Don't cache Blobs.

### DIFF
--- a/src/loaders/Cache.js
+++ b/src/loaders/Cache.js
@@ -35,6 +35,8 @@ const Cache = {
 
 		if ( this.enabled === false ) return;
 
+		if ( isBlobURL( key ) ) return;
+
 		// log( 'Cache', 'Adding key:', key );
 
 		this.files[ key ] = file;
@@ -51,6 +53,8 @@ const Cache = {
 	get: function ( key ) {
 
 		if ( this.enabled === false ) return;
+
+		if ( isBlobURL( key ) ) return;
 
 		// log( 'Cache', 'Checking key:', key );
 
@@ -83,5 +87,29 @@ const Cache = {
 
 };
 
+/**
+ * Returns true if the given cache key contains the blob: scheme.
+ *
+ * @private
+ * @param {string} key - The cache key.
+ * @return {boolean} Whether the given cache key contains the blob: scheme or not.
+ */
+function isBlobURL( key ) {
+
+	try {
+
+		const urlString = key.slice( key.indexOf( ':' ) + 1 ); // remove key identifier
+
+		const url = new URL( urlString );
+		return url.protocol === 'blob:';
+
+	} catch ( e ) {
+
+		// If the string is not a valid URL, it throws an error
+		return false;
+
+	}
+
+}
 
 export { Cache };

--- a/src/loaders/Cache.js
+++ b/src/loaders/Cache.js
@@ -98,7 +98,7 @@ function isBlobURL( key ) {
 
 	try {
 
-		const urlString = key.slice( key.indexOf( ':' ) + 1 ); // remove key identifier
+		const urlString = key.slice( key.indexOf( ':' ) + 1 ); // remove type identifier
 
 		const url = new URL( urlString );
 		return url.protocol === 'blob:';


### PR DESCRIPTION
Fixed #32986.

**Description**

Blob URLs are not stable and change for a given resource every time `URL.createObjectURL()` is called. This behavior can introduce a memory leak in `THREE.Cache` since the URLs are part of the cache key.

Because the data of Blob URLs are already located at the client, no network transfer is required. Hence, `Cache` does not need to honor such URLs.
