### PR TITLE
utils : update probeAsync jsdoc

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -356,7 +356,7 @@ function warnOnce( ...params ) {
  * main thread. This is useful for GPU-CPU synchronization in WebGL contexts.
  *
  * @private
- * @param {WebGLRenderingContext|WebGL2RenderingContext} gl - The WebGL rendering context.
+ * @param {WebGL2RenderingContext} gl - The WebGL rendering context.
  * @param {WebGLSync} sync - The WebGL sync object to wait for.
  * @param {number} interval - The polling interval in milliseconds.
  * @return {Promise<void>} A promise that resolves when the sync completes or rejects if it fails.


### PR DESCRIPTION
update to jsdoc block for probeAsync in utils.js

Related issue: 

remove WebGLRenderingContext, this webgl-1 context does not support the methods or constants used in the function body:

clientWaitSync,
SYNC_FLUSH_COMMANDS_BIT,
WAIT_FAILED,
TIMEOUT_EXPIRED
