### PR TITLE
WebGPURenderer: Use all visibility for shared BindingGroup.

### DIFF
--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -1146,23 +1146,18 @@ class WGSLNodeBuilder extends NodeBuilder {
 				if ( uniformsGroup === undefined ) {
 
 					uniformsGroup = new NodeUniformsGroup( groupName, group );
-					uniformsGroup.setVisibility( gpuShaderStageLib[ shaderStage ] );
 
 					this.uniformGroups[ groupName ] = uniformsGroup;
 
+				}
+
+				// TODO: Verifier caches
+				uniformsGroup.setVisibility( GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT | GPUShaderStage.COMPUTE );
+
+				// Add to bindings for this stage if not already present
+				if ( bindings.indexOf( uniformsGroup ) === - 1 ) {
+
 					bindings.push( uniformsGroup );
-
-				} else {
-
-					// Update visibility to include this shader stage (bitwise OR)
-					uniformsGroup.setVisibility( uniformsGroup.getVisibility() | gpuShaderStageLib[ shaderStage ] );
-
-					// Add to bindings for this stage if not already present
-					if ( bindings.indexOf( uniformsGroup ) === - 1 ) {
-
-						bindings.push( uniformsGroup );
-
-					}
 
 				}
 

--- a/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
+++ b/src/renderers/webgpu/nodes/WGSLNodeBuilder.js
@@ -1146,18 +1146,23 @@ class WGSLNodeBuilder extends NodeBuilder {
 				if ( uniformsGroup === undefined ) {
 
 					uniformsGroup = new NodeUniformsGroup( groupName, group );
+					uniformsGroup.setVisibility( gpuShaderStageLib[ shaderStage ] );
 
 					this.uniformGroups[ groupName ] = uniformsGroup;
 
-				}
-
-				// Update visibility to include this shader stage (bitwise OR)
-				uniformsGroup.setVisibility( uniformsGroup.getVisibility() | gpuShaderStageLib[ shaderStage ] );
-
-				// Add to bindings for this stage if not already present
-				if ( bindings.indexOf( uniformsGroup ) === - 1 ) {
-
 					bindings.push( uniformsGroup );
+
+				} else {
+
+					// Update visibility to include this shader stage (bitwise OR)
+					uniformsGroup.setVisibility( uniformsGroup.getVisibility() | gpuShaderStageLib[ shaderStage ] );
+
+					// Add to bindings for this stage if not already present
+					if ( bindings.indexOf( uniformsGroup ) === - 1 ) {
+
+						bindings.push( uniformsGroup );
+
+					}
 
 				}
 

--- a/src/renderers/webgpu/utils/WebGPUBindingUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUBindingUtils.js
@@ -6,7 +6,6 @@ import {
 import { FloatType, IntType, UnsignedIntType, Compatibility } from '../../../constants.js';
 import { NodeAccess } from '../../../nodes/core/constants.js';
 import { isTypedArray, error } from '../../../utils.js';
-import { hashString } from '../../../nodes/core/NodeUtils.js';
 
 /**
  * Class representing a WebGPU bind group layout.
@@ -89,63 +88,36 @@ class WebGPUBindingUtils {
 
 		const bindingsData = backend.get( bindGroup );
 
-		const entries = this._createLayoutEntries( bindGroup );
-		const bindGroupLayoutHash = hashString( JSON.stringify( entries ) );
-
-		let layoutChanged = false;
-
-		// check if the bind group already has a layout and if it's still valid
+		// check if the the bind group already has a layout
 
 		if ( bindingsData.layout ) {
 
-			// if the layout hash changed (e.g. visibility was updated), invalidate the old layout
-
-			if ( bindingsData.layoutHash !== bindGroupLayoutHash ) {
-
-				bindingsData.layout.usedTimes --;
-
-				if ( bindingsData.layout.usedTimes === 0 ) {
-
-					this._bindGroupLayoutCache.delete( bindingsData.layoutHash );
-
-				}
-
-				bindingsData.layout = undefined;
-				bindingsData.layoutHash = undefined;
-
-				layoutChanged = true;
-
-			} else {
-
-				return bindingsData.layout.layoutGPU;
-
-			}
+			return bindingsData.layout.layoutGPU;
 
 		}
 
-		// create or reuse a bind group layout from the cache
+		// if not, assing one
 
-		let bindGroupLayout = this._bindGroupLayoutCache.get( bindGroupLayoutHash );
+		const entries = this._createLayoutEntries( bindGroup );
+		const bindGroupLayoutKey = JSON.stringify( entries );
+
+		// try to find an existing layout in the cache
+
+		let bindGroupLayout = this._bindGroupLayoutCache.get( bindGroupLayoutKey );
+
+		// if not create a new one
 
 		if ( bindGroupLayout === undefined ) {
 
 			bindGroupLayout = new BindGroupLayout( device.createBindGroupLayout( { entries } ) );
-			this._bindGroupLayoutCache.set( bindGroupLayoutHash, bindGroupLayout );
+			this._bindGroupLayoutCache.set( bindGroupLayoutKey, bindGroupLayout );
 
 		}
 
 		bindGroupLayout.usedTimes ++;
 
 		bindingsData.layout = bindGroupLayout;
-		bindingsData.layoutHash = bindGroupLayoutHash;
-
-		// if layout changed, recreate the GPU bind group with the new layout
-
-		if ( layoutChanged ) {
-
-			bindingsData.group = this.createBindGroup( bindGroup, bindGroupLayout.layoutGPU );
-
-		}
+		bindingsData.layoutKey = bindGroupLayoutKey;
 
 		return bindGroupLayout.layoutGPU;
 
@@ -644,12 +616,12 @@ class WebGPUBindingUtils {
 
 			if ( bindingsData.layout.usedTimes === 0 ) {
 
-				this._bindGroupLayoutCache.delete( bindingsData.layoutHash );
+				this._bindGroupLayoutCache.delete( bindingsData.layoutKey );
 
 			}
 
 			bindingsData.layout = undefined;
-			bindingsData.layoutHash = undefined;
+			bindingsData.layoutKey = undefined;
 
 		}
 

--- a/src/renderers/webgpu/utils/WebGPUPipelineUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUPipelineUtils.js
@@ -105,8 +105,8 @@ class WebGPUPipelineUtils {
 
 		for ( const bindGroup of renderObject.getBindings() ) {
 
-			// ensure layout is up to date (visibility may have changed due to shared bind groups)
-			const layoutGPU = backend.bindingUtils.createBindingsLayout( bindGroup );
+			const bindingsData = backend.get( bindGroup );
+			const { layoutGPU } = bindingsData.layout;
 
 			bindGroupLayouts.push( layoutGPU );
 
@@ -366,8 +366,8 @@ class WebGPUPipelineUtils {
 
 		for ( const bindingsGroup of bindings ) {
 
-			// ensure layout is up to date (visibility may have changed due to shared bind groups)
-			const layoutGPU = backend.bindingUtils.createBindingsLayout( bindingsGroup );
+			const bindingsData = backend.get( bindingsGroup );
+			const { layoutGPU } = bindingsData.layout;
 
 			bindGroupLayouts.push( layoutGPU );
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/32936

**Description**

Use all visibility for shared BindingGroup instead of a cumulative visibility for cache.