### PR TITLE
Tests: Add unit tests for VideoFrameTexture and CompressedCubeTexture

### DIFF
--- a/test/unit/src/textures/CompressedCubeTexture.tests.js
+++ b/test/unit/src/textures/CompressedCubeTexture.tests.js
@@ -1,0 +1,71 @@
+
+import { CompressedCubeTexture } from '../../../../src/textures/CompressedCubeTexture.js';
+import { CompressedTexture } from '../../../../src/textures/CompressedTexture.js';
+import { CubeReflectionMapping } from '../../../../src/constants.js';
+
+export default QUnit.module( 'Textures', () => {
+
+	QUnit.module( 'CompressedCubeTexture', () => {
+
+		// INHERITANCE
+		QUnit.test( 'Extending', ( assert ) => {
+
+			const images = [ { width: 100, height: 100 } ];
+			const object = new CompressedCubeTexture( images );
+			assert.strictEqual(
+				object instanceof CompressedTexture, true,
+				'CompressedCubeTexture extends from CompressedTexture'
+			);
+
+		} );
+
+		// INSTANCING
+		QUnit.test( 'Instancing', ( assert ) => {
+
+			const images = [ { width: 100, height: 100 } ];
+			const object = new CompressedCubeTexture( images );
+			assert.ok( object, 'Can instantiate a CompressedCubeTexture.' );
+
+		} );
+
+		// PUBLIC STUFF
+		QUnit.test( 'isCompressedCubeTexture', ( assert ) => {
+
+			const images = [ { width: 100, height: 100 } ];
+			const object = new CompressedCubeTexture( images );
+			assert.ok(
+				object.isCompressedCubeTexture,
+				'CompressedCubeTexture.isCompressedCubeTexture should be true'
+			);
+
+		} );
+
+		QUnit.test( 'isCubeTexture', ( assert ) => {
+
+			const images = [ { width: 100, height: 100 } ];
+			const object = new CompressedCubeTexture( images );
+			assert.ok(
+				object.isCubeTexture,
+				'CompressedCubeTexture.isCubeTexture should be true'
+			);
+
+		} );
+
+		QUnit.test( 'parameters', ( assert ) => {
+
+			const images = [ { width: 100, height: 100 } ];
+			const format = 1001;
+			const type = 1002;
+
+			const object = new CompressedCubeTexture( images, format, type );
+
+			assert.strictEqual( object.image, images, 'Check images' );
+			assert.strictEqual( object.format, format, 'Check format' );
+			assert.strictEqual( object.type, type, 'Check type' );
+			assert.strictEqual( object.mapping, CubeReflectionMapping, 'Check mapping' );
+
+		} );
+
+	} );
+
+} );

--- a/test/unit/src/textures/VideoFrameTexture.tests.js
+++ b/test/unit/src/textures/VideoFrameTexture.tests.js
@@ -1,0 +1,78 @@
+
+import { VideoFrameTexture } from '../../../../src/textures/VideoFrameTexture.js';
+import { VideoTexture } from '../../../../src/textures/VideoTexture.js';
+import { Texture } from '../../../../src/textures/Texture.js';
+
+export default QUnit.module( 'Textures', () => {
+
+	QUnit.module( 'VideoFrameTexture', () => {
+
+		// INHERITANCE
+		QUnit.test( 'Extending', ( assert ) => {
+
+			const object = new VideoFrameTexture();
+			assert.strictEqual(
+				object instanceof VideoTexture, true,
+				'VideoFrameTexture extends from VideoTexture'
+			);
+			assert.strictEqual(
+				object instanceof Texture, true,
+				'VideoFrameTexture extends from Texture'
+			);
+
+		} );
+
+		// INSTANCING
+		QUnit.test( 'Instancing', ( assert ) => {
+
+			const object = new VideoFrameTexture();
+			assert.ok( object, 'Can instantiate a VideoFrameTexture.' );
+
+		} );
+
+		// PUBLIC STUFF
+		QUnit.test( 'isVideoFrameTexture', ( assert ) => {
+
+			const object = new VideoFrameTexture();
+			assert.ok(
+				object.isVideoFrameTexture,
+				'VideoFrameTexture.isVideoFrameTexture should be true'
+			);
+
+		} );
+
+		QUnit.test( 'update', ( assert ) => {
+
+			const object = new VideoFrameTexture();
+			// should not throw
+			object.update();
+			assert.ok( true, 'update() executes without error' );
+
+		} );
+
+		QUnit.test( 'clone', ( assert ) => {
+
+			const object = new VideoFrameTexture();
+			const cloned = object.clone();
+
+			assert.ok( cloned instanceof VideoFrameTexture, 'Cloned object is instance of VideoFrameTexture' );
+			assert.notEqual( object, cloned, 'Cloned object is a new instance' );
+			assert.strictEqual( cloned.isVideoFrameTexture, true, 'Cloned object has isVideoFrameTexture flag' );
+
+		} );
+
+		QUnit.test( 'setFrame', ( assert ) => {
+
+			const object = new VideoFrameTexture();
+			const frame = {};
+
+			object.setFrame( frame );
+
+			assert.strictEqual( object.image, frame, 'image property is set to the frame' );
+			assert.strictEqual( object.version, 1, 'version should be incremented' );
+
+		} );
+
+	} );
+
+} );

--- a/test/unit/three.source.unit.js
+++ b/test/unit/three.source.unit.js
@@ -281,6 +281,7 @@ import './src/scenes/Scene.tests.js';
 //src/textures
 import './src/textures/CanvasTexture.tests.js';
 import './src/textures/CompressedArrayTexture.tests.js';
+import './src/textures/CompressedCubeTexture.tests.js';
 import './src/textures/CompressedTexture.tests.js';
 import './src/textures/CubeTexture.tests.js';
 import './src/textures/Data3DTexture.tests.js';
@@ -291,3 +292,4 @@ import './src/textures/FramebufferTexture.tests.js';
 import './src/textures/Source.tests.js';
 import './src/textures/Texture.tests.js';
 import './src/textures/VideoTexture.tests.js';
+import './src/textures/VideoFrameTexture.tests.js';


### PR DESCRIPTION
**Description**

This PR adds unit tests for [VideoFrameTexture](cci:2://file:///Users/divyapahuja/Desktop/three.js/src/textures/VideoFrameTexture.js:15:0-69:1) and [CompressedCubeTexture](cci:2://file:///Users/divyapahuja/Desktop/three.js/src/textures/CompressedCubeTexture.js:10:0-45:1), which were previously missing from the test suite.

**Changes:**
- Added [test/unit/src/textures/VideoFrameTexture.tests.js](cci:7://file:///Users/divyapahuja/Desktop/three.js/test/unit/src/textures/VideoFrameTexture.tests.js:0:0-0:0) covering inheritance, instantiation, clone, update, and frame setting.
- Added [test/unit/src/textures/CompressedCubeTexture.tests.js](cci:7://file:///Users/divyapahuja/Desktop/three.js/test/unit/src/textures/CompressedCubeTexture.tests.js:0:0-0:0) covering inheritance, instantiation, and parameter validation.
- Registered new tests in [test/unit/three.source.unit.js](cci:7://file:///Users/divyapahuja/Desktop/three.js/test/unit/three.source.unit.js:0:0-0:0).

**Tests:**
- [x] `npm run lint` passed.
- [x] `npm run test-unit` passed (1302/1302 tests passing).