### PR TITLE
WebGPURenderer: Fix stencilBack not matching stencilFront in pipeline

### DIFF
--- a/src/renderers/webgpu/utils/WebGPUPipelineUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUPipelineUtils.js
@@ -250,7 +250,7 @@ class WebGPUPipelineUtils {
 			if ( renderStencil === true ) {
 
 				depthStencil.stencilFront = stencilFront;
-				depthStencil.stencilBack = {}; // three.js does not provide an API to configure the back function (gl.stencilFuncSeparate() was never used)
+				depthStencil.stencilBack = stencilFront; // apply the same stencil ops to both faces, matching gl.stencilOp() which is not face-separated
 				depthStencil.stencilReadMask = material.stencilFuncMask;
 				depthStencil.stencilWriteMask = material.stencilWriteMask;
 


### PR DESCRIPTION
Related issue: N/A

**Description**

`WebGPUPipelineUtils` sets `stencilBack = {}` when creating render pipelines, which means back-facing fragments use default stencil ops (all `keep`). this doesn't match the WebGL backend, where `gl.stencilOp()` applies to both faces

any stencil technique using `DoubleSide` breaks on the WebGPU backend when geometry contains back-facing triangles -e.g. stencil XOR parity fill for font rendering, where holes have opposite winding - noticed this while working on adding infinitely scalable vector text to [three-text](https://github.com/countertype/three-text) with TSL :) 

fix: `stencilBack = stencilFront`
