### PR TITLE
WebGLRenderer: Only clear when bit mask is set.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1008,7 +1008,11 @@ class WebGLRenderer {
 
 			}
 
-			_gl.clear( bits );
+			if ( bits !== 0 ) {
+
+				_gl.clear( bits );
+
+			}
 
 		};
 


### PR DESCRIPTION
Firefox outputs this warning:
```
WebGL warning: clear: Calling gl.clear(0) has no effect.
```
Chrome this:

```
Performance warning: clear() called with no buffers in bitmask
```

When `gl.clear` is called with `0`

This can happen, e.g. when using integer buffers and only clearing the color buffer, as then `gl.clearBuffer(u)iv` is called instead.

To prevent this, just don't call `gl.clear` when no mask is set...