### PR TITLE
WebGPURenderer: Remove outdated bind groups.

### DIFF
--- a/src/renderers/common/Bindings.js
+++ b/src/renderers/common/Bindings.js
@@ -306,7 +306,7 @@ class Bindings extends DataMap {
 
 					this.textures.updateTexture( texture );
 
-					// generation: update the bindings if a new texture has been created
+					// generation: update the bindings if the binding refers to a different texture object
 
 					if ( binding.generation !== texturesTextureData.generation ) {
 
@@ -314,9 +314,11 @@ class Bindings extends DataMap {
 
 						needsBindingsUpdate = true;
 
-						cacheBindings = false;
-
 					}
+
+					// keep track which bind groups refer to the current texture (this is needed for dispose)
+
+					texturesTextureData.bindGroups.add( bindGroup );
 
 				}
 
@@ -364,8 +366,6 @@ class Bindings extends DataMap {
 						binding.samplerKey = samplerKey;
 
 						needsBindingsUpdate = true;
-
-						cacheBindings = false;
 
 					}
 

--- a/src/renderers/common/Textures.js
+++ b/src/renderers/common/Textures.js
@@ -318,6 +318,7 @@ class Textures extends DataMap {
 
 			textureData.initialized = true;
 			textureData.generation = texture.version;
+			textureData.bindGroups = new Set();
 
 			//
 
@@ -530,6 +531,21 @@ class Textures extends DataMap {
 
 			const isDefaultTexture = textureData.isDefaultTexture;
 			this.backend.destroyTexture( texture, isDefaultTexture );
+
+			// delete cached bind groups so they don't point to destroyed textures
+
+			if ( textureData.bindGroups ) {
+
+				for ( const bindGroup of textureData.bindGroups ) {
+
+					const bindingsData = this.backend.get( bindGroup );
+
+					bindingsData.groups = undefined;
+					bindingsData.versions = undefined;
+
+				}
+
+			}
 
 			this.delete( texture );
 


### PR DESCRIPTION
Fixed #33005.

**Description**

With this PR, texture binding updates always use caching. To prevent breakage with texture disposal, a new logic is introduced. We keep now track of all bind groups that refer to a specific texture. When a dispose happens, these cached bind groups are removed as well.

I have verified with WebGPU Inspector that the Bind Group count does not increase anymore.

https://github.com/user-attachments/assets/5836165e-7a4e-4cc0-aedb-88b06f25a6bf
