### PR TITLE
Manual: Replace the template literal with string concat in lights page.

### DIFF
--- a/manual/en/lights.html
+++ b/manual/en/lights.html
@@ -139,7 +139,7 @@ color.</p>
     this.prop = prop;
   }
   get value() {
-    return `#${this.object[this.prop].getHexString()}`;
+    return '#' + this.object[this.prop].getHexString();
   }
   set value(hexString) {
     this.object[this.prop].set(hexString);

--- a/manual/fr/lights.html
+++ b/manual/fr/lights.html
@@ -139,7 +139,7 @@ couleur de la lumière.</p>
     this.prop = prop;
   }
   get value() {
-    return `#${this.object[this.prop].getHexString()}`;
+    return '#' + this.object[this.prop].getHexString();
   }
   set value(hexString) {
     this.object[this.prop].set(hexString);

--- a/manual/ja/lights.html
+++ b/manual/ja/lights.html
@@ -128,7 +128,7 @@ lil-guiで色を調整するにはヘルパーが必要です。
     this.prop = prop;
   }
   get value() {
-    return `#${this.object[this.prop].getHexString()}`;
+    return '#' + this.object[this.prop].getHexString();
   }
   set value(hexString) {
     this.object[this.prop].set(hexString);

--- a/manual/ko/lights.html
+++ b/manual/ko/lights.html
@@ -129,7 +129,7 @@ scene.add(light);
     this.prop = prop;
   }
   get value() {
-    return `#${this.object[this.prop].getHexString()}`;
+    return '#' + this.object[this.prop].getHexString();
   }
   set value(hexString) {
     this.object[this.prop].set(hexString);

--- a/manual/ru/lights.html
+++ b/manual/ru/lights.html
@@ -141,7 +141,7 @@ scene.add(light);
     this.prop = prop;
   }
   get value() {
-    return `#${this.object[this.prop].getHexString()}`;
+    return '#' + this.object[this.prop].getHexString();
   }
   set value(hexString) {
     this.object[this.prop].set(hexString);

--- a/manual/zh/lights.html
+++ b/manual/zh/lights.html
@@ -113,7 +113,7 @@ scene.add(light);
     this.prop = prop;
   }
   get value() {
-    return `#${this.object[this.prop].getHexString()}`;
+    return '#' + this.object[this.prop].getHexString();
   }
   set value(hexString) {
     this.object[this.prop].set(hexString);


### PR DESCRIPTION
Related issue: N/A

**Description**

In the current manual (lights page), the backticks used in a template literal are stripped by the parser, causing part of the example code to render incorrectly and therefore in case of copy-pasting to not work. This suggested change replaces the template literal with string concatenation so the code renders correctly in the documentation.
