### PR TITLE
Examples: Improve birds compute demo.

### DIFF
--- a/examples/webgpu_compute_birds.html
+++ b/examples/webgpu_compute_birds.html
@@ -51,7 +51,7 @@
 			let pointer, raycaster;
 			let computeVelocity, computePosition, effectController;
 
-			const BIRDS = 16384;
+			const BIRDS = 8192;
 			const SPEED_LIMIT = 9.0;
 			const BOUNDS = 800, BOUNDS_HALF = BOUNDS / 2;
 


### PR DESCRIPTION
Related issue: -

**Description**

`webgpu_compute_birds` runs too slow, imo. On a M2 Pro and a Pixel 8a I only get around 30-40 FPS. By reducing the binds count to `8192` performance is at 60 FPS without any noticeable visual downgrades. The demo looks with less birds impressive as well.

Besides, the bird count is still 8 times above the original WebGL demo.