### PR TITLE
Inspector: Fix compatibility with `WebGLBackend` if used as a fallback

### DIFF
--- a/examples/jsm/inspector/Inspector.js
+++ b/examples/jsm/inspector/Inspector.js
@@ -198,9 +198,9 @@ class Inspector extends RendererInspector {
 
 			if ( this.isAvailable ) {
 
-				renderer.backend.trackTimestamp = true;
-
 				renderer.init().then( () => {
+
+					renderer.backend.trackTimestamp = true;
 
 					if ( renderer.hasFeature( 'timestamp-query' ) !== true ) {
 


### PR DESCRIPTION
**Description**

It wasn’t clear to me that the Inspector was failing in WebGL2Backend only when there was an error during WebGPU initialization; tests using forceWebGL did not show the same problem.