### PR TITLE
GLTFLoader: Fix morph target parsing.

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -4512,17 +4512,28 @@ class GLTFParser {
 		const targetName = node.name ? node.name : node.uuid;
 		const targetNames = [];
 
+		function collectMorphTargets( object ) {
+
+			if ( object.morphTargetInfluences ) {
+
+				targetNames.push( object.name ? object.name : object.uuid );
+
+			}
+
+		}
+
+
 		if ( PATH_PROPERTIES[ target.path ] === PATH_PROPERTIES.weights ) {
 
-			node.traverse( function ( object ) {
+			collectMorphTargets( node );
 
-				if ( object.morphTargetInfluences ) {
+			// for multi-primitive meshes, the node is a Group containing the sub-meshes
 
-					targetNames.push( object.name ? object.name : object.uuid );
+			if ( node.isGroup ) {
 
-				}
+				node.children.forEach( collectMorphTargets );
 
-			} );
+			}
 
 		} else {
 


### PR DESCRIPTION
Fixed #31987.

**Description**

`GLTFLoader` currently incorrectly groups morph targets in its `_createAnimationTracks()` method. The usage of `traverse()` seems to be intended for  multi-primitive meshes. However, instead of just processing the children of the group, it traverse through the entire node hierarchy and collecting morph targets of unrelated meshes. 

This behavior produces duplicate keyframe tracks with wrong data. When those are animated, they produce the flickering and breakage that was reported in #31987.