### PR TITLE
Examples: Fix sidebar scrolling to selected example

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -103,7 +103,7 @@
 				if ( validRedirects.has( file ) === true ) {
 
 					selectFile( file );
-					links[ file ].scrollIntoView( { block: 'center' } );
+					updateLinkScroll();
 					viewer.src = validRedirects.get( file );
 					viewer.style.display = 'unset';
 
@@ -171,6 +171,7 @@
 
 				event.preventDefault();
 				panel.classList.toggle( 'open' );
+				updateLinkScroll();
 
 			} );
 
@@ -382,6 +383,17 @@
 			const div = document.createElement( 'div' );
 			div.innerHTML = htmlString.trim();
 			return div.firstChild;
+
+		}
+
+		function updateLinkScroll() {
+
+			if ( selected !== null ) {
+
+				const link = links[ selected ];
+				content.scrollTop = link.offsetTop - content.offsetTop - ( content.clientHeight - link.offsetHeight ) / 2;
+
+			}
 
 		}
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/32980#issuecomment-3924839781

**Description**

Previously, `element.scrollIntoView({ block: 'center' })` was used. In some scenarios (especially on mobile or specific layouts), this caused the entire page or parent containers to scroll, shifting the header or other UI elements out of view.

