### PR TITLE
NodeMaterialObserver: Fix typo.

### DIFF
--- a/src/materials/nodes/manager/NodeMaterialObserver.js
+++ b/src/materials/nodes/manager/NodeMaterialObserver.js
@@ -438,14 +438,14 @@ class NodeMaterialObserver {
 		// check index
 
 		const index = geometry.index;
-		const storedIndexId = storedGeometryData.id;
+		const storedIndexId = storedGeometryData.indexId;
 		const storedIndexVersion = storedGeometryData.indexVersion;
 		const currentIndexId = index ? index.id : null;
 		const currentIndexVersion = index ? index.version : null;
 
 		if ( storedIndexId !== currentIndexId || storedIndexVersion !== currentIndexVersion ) {
 
-			storedGeometryData.id = currentIndexId;
+			storedGeometryData.indexId = currentIndexId;
 			storedGeometryData.indexVersion = currentIndexVersion;
 			return false;
 


### PR DESCRIPTION
Related issue: #32933

**Description**

The index id test referred to the wrong cached ID value leading to redundant updates.
