### PR TITLE
AnimationAction: Preserve interpolant settings on action creation.

### DIFF
--- a/src/animation/AnimationAction.js
+++ b/src/animation/AnimationAction.js
@@ -42,7 +42,8 @@ class AnimationAction {
 			const interpolant = tracks[ i ].createInterpolant( null );
 			interpolants[ i ] = interpolant;
 
-			// Preserve tangent data before overwriting
+			// preserve interpolant settings (like tangent data from BezierInterpolant)
+
 			if ( interpolant.settings ) {
 
 				Object.assign( interpolantSettings, interpolant.settings );

--- a/src/animation/AnimationAction.js
+++ b/src/animation/AnimationAction.js
@@ -41,6 +41,14 @@ class AnimationAction {
 
 			const interpolant = tracks[ i ].createInterpolant( null );
 			interpolants[ i ] = interpolant;
+
+			// Preserve tangent data before overwriting
+			if ( interpolant.settings ) {
+
+				Object.assign( interpolantSettings, interpolant.settings );
+
+			}
+
 			interpolant.settings = interpolantSettings;
 
 		}
@@ -894,7 +902,7 @@ class AnimationAction {
 
 			} else {
 
-				settings.endingEnd 	 = WrapAroundEnding;
+				settings.endingEnd = WrapAroundEnding;
 
 			}
 


### PR DESCRIPTION
Fixed #33032

**Description**

When using `InterpolateBezier` with the animation system, the `BezierInterpolant` ends up doing linear interpolation because the `AnimationAction` constructor overwrites `interpolant.settings` with a shared ending-behavior object, wiping out the `inTangents` and `outTangents` data.

The interpolant is created correctly with tangent data, but by the time it runs, that data is gone.

To fix, the AnimationAction constructor is slightly modified to append the track.settings instead of replacing it.