### PR TITLE
AnimationAction: Fix `timeScale` reversal jump.

### DIFF
--- a/src/animation/AnimationAction.js
+++ b/src/animation/AnimationAction.js
@@ -856,6 +856,7 @@ class AnimationAction {
 
 			} else {
 
+				this._loopCount = loopCount;
 				this.time = time;
 
 			}

--- a/test/unit/src/animation/AnimationAction.tests.js
+++ b/test/unit/src/animation/AnimationAction.tests.js
@@ -446,6 +446,62 @@ export default QUnit.module( 'Animation', () => {
 
 		} );
 
+		QUnit.test( 'LoopRepeat with timeScale reversal during first loop', ( assert ) => {
+
+			// Regression test for #19151
+			const root = new Object3D();
+			const mixer = new AnimationMixer( root );
+			const track = new NumberKeyframeTrack( '.rotation[x]', [ 0, 1000 ], [ 0, 360 ] );
+			const clip = new AnimationClip( 'clip1', 1000, [ track ] );
+
+			const animationAction = mixer.clipAction( clip );
+			animationAction.setLoop( LoopRepeat, Infinity );
+			animationAction.play();
+
+			// Advance partway into the first loop
+			mixer.update( 500 );
+			assert.equal( root.rotation.x, 180, 'At 500ms, rotation is 180 (halfway).' );
+
+			// Reverse timeScale
+			mixer.timeScale = - 1;
+
+			// Step backward — should smoothly reverse, not jump
+			mixer.update( 250 );
+			assert.equal( root.rotation.x, 90, 'After reversing and stepping 250ms back, rotation is 90.' );
+
+			mixer.update( 250 );
+			assert.equal( root.rotation.x, 0, 'After reversing and stepping another 250ms back, rotation is 0 (start).' );
+
+		} );
+
+		QUnit.test( 'LoopPingPong with timeScale reversal during first loop', ( assert ) => {
+
+			// Regression test for #19151
+			const root = new Object3D();
+			const mixer = new AnimationMixer( root );
+			const track = new NumberKeyframeTrack( '.rotation[x]', [ 0, 1000 ], [ 0, 360 ] );
+			const clip = new AnimationClip( 'clip1', 1000, [ track ] );
+
+			const animationAction = mixer.clipAction( clip );
+			animationAction.setLoop( LoopPingPong, Infinity );
+			animationAction.play();
+
+			// Advance partway into the first loop
+			mixer.update( 500 );
+			assert.equal( root.rotation.x, 180, 'At 500ms, rotation is 180 (halfway).' );
+
+			// Reverse timeScale
+			mixer.timeScale = - 1;
+
+			// Step backward — should smoothly reverse, not jump
+			mixer.update( 250 );
+			assert.equal( root.rotation.x, 90, 'After reversing and stepping 250ms back, rotation is 90.' );
+
+			mixer.update( 250 );
+			assert.equal( root.rotation.x, 0, 'After reversing and stepping another 250ms back, rotation is 0 (start).' );
+
+		} );
+
 	} );
 
 } );


### PR DESCRIPTION
Fixed #19151.

**Description**

The PR fixes a long-standing bug in `AnimationAction` that happens when the time scale of the animation mixer is reversed during the first run of looped animations. 

I've tried to fix this multiple times in the past but wasn't sure about the real root cause. With the help of Claude 4.6, this should be resolved. Claude required multiple attempts but eventually found the root cause in an `else` branch where a member wasn't correctly updated.

> In _updateTime() , the "just started" block (line 781) sets the local variable loopCount from -1 to 0, but this._loopCount is only persisted inside the wrap-around branch (line 847). The non-wrapping else branch (line 857) never writes it back. This means this._loopCount stays at -1 indefinitely until a wrap-around occurs. On subsequent frames, the "just started" block re-executes, and for PingPong mode, the check (loopCount & 1) === 1 evaluates to true because -1 & 1 === 1, causing unwanted time inversion and a visual jump.

The test code from #19151 now behaves correctly and the animation examples should also work as before (tested locally). I think it's worth giving this fix a try!