### PR TITLE
Examples: Add sky to scene.

### DIFF
--- a/examples/webgl_animation_keyframes.html
+++ b/examples/webgl_animation_keyframes.html
@@ -68,6 +68,8 @@
 			// Sky
 
 			const sky = new Sky();
+			sky.scale.setScalar( 10000 );
+			scene.add( sky );
 
 			const uniforms = sky.material.uniforms;
 			uniforms[ 'turbidity' ].value = 0;
@@ -78,7 +80,6 @@
 
 			const pmremGenerator = new THREE.PMREMGenerator( renderer );
 			const environment = pmremGenerator.fromScene( sky ).texture;
-			scene.background = environment;
 			scene.environment = environment;
 
 			const camera = new THREE.PerspectiveCamera( 40, window.innerWidth / window.innerHeight, 1, 100 );


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/33031#issuecomment-3937179142

**Description**

For best sky quality, the instance of `Sky` needs to be added to the scene. `webgl_animation_keyframes` generates a PMREM and assigns it to the background which results in a lower quality skybox (a lot of cloud details are missing and you see a broken sun disk).

https://rawcdn.githack.com/Mugen87/three.js/309acc6d169522bcbd87d016968ff2a433c018d2/examples/webgl_animation_keyframes.html
https://threejs.org/examples/webgl_animation_keyframes.html