### PR TITLE
Fix #32689: Framebuffer caching not working for ViewportDepthTextureNode

### DIFF
--- a/src/nodes/display/ViewportDepthTextureNode.js
+++ b/src/nodes/display/ViewportDepthTextureNode.js
@@ -4,8 +4,6 @@ import { screenUV } from './ScreenNode.js';
 
 import { DepthTexture } from '../../textures/DepthTexture.js';
 
-let _sharedDepthbuffer = null;
-
 /**
  * Represents the depth of the current viewport as a texture. This module
  * can be used in combination with viewport texture to achieve effects
@@ -29,25 +27,7 @@ class ViewportDepthTextureNode extends ViewportTextureNode {
 	 */
 	constructor( uvNode = screenUV, levelNode = null ) {
 
-		if ( _sharedDepthbuffer === null ) {
-
-			_sharedDepthbuffer = new DepthTexture();
-
-		}
-
-		super( uvNode, levelNode, _sharedDepthbuffer );
-
-	}
-
-	/**
-	 * Overwritten so the method always returns the unique shared
-	 * depth texture.
-	 *
-	 * @return {DepthTexture} The shared depth texture.
-	 */
-	getTextureForReference() {
-
-		return _sharedDepthbuffer;
+		super( uvNode, levelNode, new DepthTexture() );
 
 	}
 

--- a/src/nodes/display/ViewportTextureNode.js
+++ b/src/nodes/display/ViewportTextureNode.js
@@ -144,9 +144,10 @@ class ViewportTextureNode extends TextureNode {
 
 	updateReference( frame ) {
 
-		const renderTarget = frame.renderer.getRenderTarget();
+		const renderer = frame.renderer;
+		const renderTarget = renderer.getRenderTarget();
 
-		this.value = this.getTextureForReference( renderTarget );
+		this.value = this.getTextureForReference( renderTarget !== null ? renderTarget : renderer.getCanvasTarget() );
 
 		return this.value;
 
@@ -169,7 +170,7 @@ class ViewportTextureNode extends TextureNode {
 
 		//
 
-		const framebufferTexture = this.getTextureForReference( renderTarget );
+		const framebufferTexture = this.getTextureForReference( renderTarget !== null ? renderTarget : renderer.getCanvasTarget() );
 
 		if ( framebufferTexture.image.width !== _size.width || framebufferTexture.image.height !== _size.height ) {
 


### PR DESCRIPTION
Fixes #32689

## Summary
This PR fixes: Framebuffer caching not working for ViewportDepthTextureNode and ViewporTextureNode when rendering to multiple canvases of different size

## Changes
```
src/nodes/display/ViewportDepthTextureNode.js | 22 +---------------------
 src/nodes/display/ViewportTextureNode.js      |  7 ++++---
 2 files changed, 5 insertions(+), 24 deletions(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*