### PR TITLE
Fix #30701: Bundle multimaterial not updated correctly

### DIFF
--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -1272,6 +1272,13 @@ class Renderer {
 
 					this._nodes.updateAfter( renderObject );
 
+				} else if ( renderObject.version !== renderObject.material.version ) {
+
+					renderObject.version = renderObject.material.version;
+
+					this._nodes.updateForRender( renderObject );
+					this._bindings.updateForRender( renderObject );
+
 				}
 
 			}


### PR DESCRIPTION
Fixes #30701

## Summary
This PR fixes: Bundle multimaterial not updated correctly

## Changes
```
src/renderers/common/Renderer.js | 7 +++++++
 1 file changed, 7 insertions(+)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*