### PR TITLE
Renderer: Add copyBufferToBuffer() method

### DIFF
--- a/src/renderers/common/Backend.js
+++ b/src/renderers/common/Backend.js
@@ -366,6 +366,18 @@ class Backend {
 	// attributes
 
 	/**
+	 * Copies data of the given source buffer attribute to the given destination buffer attribute.
+	 *
+	 * @abstract
+	 * @param {BufferAttribute} srcAttribute - The source buffer attribute.
+	 * @param {BufferAttribute} dstAttribute - The destination buffer attribute.
+	 * @param {number} byteLength - The number of bytes to copy.
+	 * @param {number} [srcOffset=0] - The source offset in bytes.
+	 * @param {number} [dstOffset=0] - The destination offset in bytes.
+	 */
+	copyBufferToBuffer( /*srcAttribute, dstAttribute, byteLength, srcOffset=0, dstOffset=0*/ ) {}
+
+	/**
 	 * Creates the GPU buffer of a shader attribute.
 	 *
 	 * @abstract

--- a/src/renderers/common/Backend.js
+++ b/src/renderers/common/Backend.js
@@ -371,11 +371,11 @@ class Backend {
 	 * @abstract
 	 * @param {BufferAttribute} srcAttribute - The source buffer attribute.
 	 * @param {BufferAttribute} dstAttribute - The destination buffer attribute.
-	 * @param {number} byteLength - The number of bytes to copy.
+	 * @param {?number} [size=null] - The number of bytes to copy. If `null`, the entire source buffer is copied.
 	 * @param {number} [srcOffset=0] - The source offset in bytes.
 	 * @param {number} [dstOffset=0] - The destination offset in bytes.
 	 */
-	copyBufferToBuffer( /*srcAttribute, dstAttribute, byteLength, srcOffset=0, dstOffset=0*/ ) {}
+	copyBufferToBuffer( /* srcAttribute, dstAttribute, size = null, srcOffset = 0, dstOffset = 0 */ ) {}
 
 	/**
 	 * Creates the GPU buffer of a shader attribute.

--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -2908,80 +2908,15 @@ class Renderer {
 	 *
 	 * @param {BufferAttribute} srcAttribute - The source buffer attribute.
 	 * @param {BufferAttribute} dstAttribute - The destination buffer attribute.
-	 * @param {?number} [count=null] - The number of items to copy. If `null`, the overlapping range is copied.
-	 * @param {number} [srcIndex=0] - The source start index (in items).
-	 * @param {number} [dstIndex=0] - The destination start index (in items).
+	 * @param {?number} [size=null] - The number of bytes to copy. If `null`, the entire source buffer is copied.
+	 * @param {number} [srcOffset=0] - The source offset in bytes.
+	 * @param {number} [dstOffset=0] - The destination offset in bytes.
 	 */
-	copyBufferToBuffer(
-		srcAttribute,
-		dstAttribute,
-		count = null,
-		srcIndex = 0,
-		dstIndex = 0,
-	) {
+	copyBufferToBuffer( srcAttribute, dstAttribute, size = null, srcOffset = 0, dstOffset = 0 ) {
 
-		// Layout must match for item-wise copy.
-		if (
-			srcAttribute.itemSize !== dstAttribute.itemSize ||
-			srcAttribute.array.BYTES_PER_ELEMENT !==
-				dstAttribute.array.BYTES_PER_ELEMENT
-		) {
-
-			error( 'Renderer.copyBufferToBuffer: Incompatible attribute layouts.' );
-			return;
-
-		}
-
-		const stride = srcAttribute.itemSize * srcAttribute.array.BYTES_PER_ELEMENT;
-
-		const maxCount = Math.max(
-			0,
-			Math.min( srcAttribute.count - srcIndex, dstAttribute.count - dstIndex ),
-		);
-
-		if ( count === null ) count = maxCount;
-		else count = Math.max( 0, Math.min( count, maxCount ) );
-
-		if ( count <= 0 ) {
-
-			error(
-				'Renderer.copyBufferToBuffer: Copy would produce a zero-sized GPU buffer region.\n' +
-					'This leads to invalid WebGPU bindings.\n' +
-					`src.count=${srcAttribute.count}, dst.count=${dstAttribute.count}, ` +
-					`srcIndex=${srcIndex}, dstIndex=${dstIndex}`,
-			);
-			return;
-
-		}
-
-		const byteLength = count * stride;
-		const srcOffset = srcIndex * stride;
-		const dstOffset = dstIndex * stride;
-
-		// Keep behavior consistent with WebGPU backend validation.
-		if (
-			( byteLength & 3 ) !== 0 ||
-			( srcOffset & 3 ) !== 0 ||
-			( dstOffset & 3 ) !== 0
-		) {
-
-			error(
-				`Renderer.copyBufferToBuffer: WebGPU requires 4-byte aligned copies. Got srcOffset=${srcOffset}, dstOffset=${dstOffset}, byteLength=${byteLength}.`,
-			);
-			return;
-
-		}
-
-		this.backend.copyBufferToBuffer(
-			srcAttribute,
-			dstAttribute,
-			byteLength,
-			srcOffset,
-			dstOffset,
-		);
+		this.backend.copyBufferToBuffer( srcAttribute, dstAttribute, size, srcOffset, dstOffset );
 
 	}
-
 
 	/**
 	 * Reads pixel data from the given render target.

--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -2034,6 +2034,56 @@ class WebGLBackend extends Backend {
 	}
 
 	/**
+	 * Copies data of the given source buffer attribute to the given destination buffer attribute.
+	 *
+	 *  Uses WebGL2 `copyBufferSubData`.
+	 *
+	 * @param {BufferAttribute} srcAttribute - The source buffer attribute.
+	 * @param {BufferAttribute} dstAttribute - The destination buffer attribute.
+	 * @param {number} byteLength - The number of bytes to copy.
+	 * @param {number} [srcOffset=0] - The source offset in bytes.
+	 * @param {number} [dstOffset=0] - The destination offset in bytes.
+	 */
+	copyBufferToBuffer(
+		srcAttribute,
+		dstAttribute,
+		byteLength,
+		srcOffset = 0,
+		dstOffset = 0,
+	) {
+
+		const gl = this.gl;
+
+		const srcData = this.get( srcAttribute );
+		const dstData = this.get( dstAttribute );
+
+		if ( srcData.bufferGPU === undefined ) this.createAttribute( srcAttribute );
+		if ( dstData.bufferGPU === undefined ) this.createAttribute( dstAttribute );
+
+		const srcGPU = srcData.bufferGPU;
+		const dstGPU = dstData.bufferGPU;
+
+		const prevRead = gl.getParameter( gl.COPY_READ_BUFFER_BINDING );
+		const prevWrite = gl.getParameter( gl.COPY_WRITE_BUFFER_BINDING );
+
+		gl.bindBuffer( gl.COPY_READ_BUFFER, srcGPU );
+		gl.bindBuffer( gl.COPY_WRITE_BUFFER, dstGPU );
+
+		gl.copyBufferSubData(
+			gl.COPY_READ_BUFFER,
+			gl.COPY_WRITE_BUFFER,
+			srcOffset,
+			dstOffset,
+			byteLength,
+		);
+
+		gl.bindBuffer( gl.COPY_READ_BUFFER, prevRead );
+		gl.bindBuffer( gl.COPY_WRITE_BUFFER, prevWrite );
+
+	}
+
+
+	/**
 	 * Checks if the given compatibility is supported by the backend.
 	 *
 	 * @param {string} name - The compatibility name.

--- a/src/renderers/webgl-fallback/WebGLBackend.js
+++ b/src/renderers/webgl-fallback/WebGLBackend.js
@@ -2036,21 +2036,15 @@ class WebGLBackend extends Backend {
 	/**
 	 * Copies data of the given source buffer attribute to the given destination buffer attribute.
 	 *
-	 *  Uses WebGL2 `copyBufferSubData`.
+	 * Uses WebGL2 `copyBufferSubData`.
 	 *
 	 * @param {BufferAttribute} srcAttribute - The source buffer attribute.
 	 * @param {BufferAttribute} dstAttribute - The destination buffer attribute.
-	 * @param {number} byteLength - The number of bytes to copy.
+	 * @param {?number} [size=null] - The number of bytes to copy. If `null`, the entire source buffer is copied.
 	 * @param {number} [srcOffset=0] - The source offset in bytes.
 	 * @param {number} [dstOffset=0] - The destination offset in bytes.
 	 */
-	copyBufferToBuffer(
-		srcAttribute,
-		dstAttribute,
-		byteLength,
-		srcOffset = 0,
-		dstOffset = 0,
-	) {
+	copyBufferToBuffer( srcAttribute, dstAttribute, size = null, srcOffset = 0, dstOffset = 0 ) {
 
 		const gl = this.gl;
 
@@ -2062,26 +2056,18 @@ class WebGLBackend extends Backend {
 
 		const srcGPU = srcData.bufferGPU;
 		const dstGPU = dstData.bufferGPU;
+		const byteLength = size === null ? srcGPU.size : size;
 
 		const prevRead = gl.getParameter( gl.COPY_READ_BUFFER_BINDING );
 		const prevWrite = gl.getParameter( gl.COPY_WRITE_BUFFER_BINDING );
 
 		gl.bindBuffer( gl.COPY_READ_BUFFER, srcGPU );
 		gl.bindBuffer( gl.COPY_WRITE_BUFFER, dstGPU );
-
-		gl.copyBufferSubData(
-			gl.COPY_READ_BUFFER,
-			gl.COPY_WRITE_BUFFER,
-			srcOffset,
-			dstOffset,
-			byteLength,
-		);
-
+		gl.copyBufferSubData( gl.COPY_READ_BUFFER, gl.COPY_WRITE_BUFFER, srcOffset, dstOffset, byteLength );
 		gl.bindBuffer( gl.COPY_READ_BUFFER, prevRead );
 		gl.bindBuffer( gl.COPY_WRITE_BUFFER, prevWrite );
 
 	}
-
 
 	/**
 	 * Checks if the given compatibility is supported by the backend.

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -2532,6 +2532,98 @@ class WebGPUBackend extends Backend {
 	}
 
 	/**
+	 * Copies data of the given source buffer attribute to the given destination buffer attribute.
+	 *
+	 * @param {BufferAttribute} srcAttribute - The source buffer attribute.
+	 * @param {BufferAttribute} dstAttribute - The destination buffer attribute.
+	 * @param {number} byteLength - The number of bytes to copy.
+	 * @param {number} [srcOffset=0] - The source offset in bytes.
+	 * @param {number} [dstOffset=0] - The destination offset in bytes.
+	 */
+	copyBufferToBuffer(
+		srcAttribute,
+		dstAttribute,
+		byteLength,
+		srcOffset = 0,
+		dstOffset = 0,
+	) {
+
+		if (
+			( srcOffset & 3 ) !== 0 ||
+			( dstOffset & 3 ) !== 0 ||
+			( byteLength & 3 ) !== 0
+		) {
+
+			error(
+				'WebGPUBackend: copyBufferToBuffer: srcOffset, dstOffset and byteLength must be multiples of 4 bytes.',
+			);
+			return;
+
+		}
+
+		const srcData = this.get( srcAttribute );
+		const dstData = this.get( dstAttribute );
+
+		// Ensure GPU buffers exist
+		if ( srcData.buffer === undefined ) {
+
+			if (
+				srcAttribute.isStorageBufferAttribute ||
+				srcAttribute.isStorageInstancedBufferAttribute
+			)
+				this.createStorageAttribute( srcAttribute );
+			else this.createAttribute( srcAttribute );
+
+		}
+
+		if ( dstData.buffer === undefined ) {
+
+			if (
+				dstAttribute.isStorageBufferAttribute ||
+				dstAttribute.isStorageInstancedBufferAttribute
+			)
+				this.createStorageAttribute( dstAttribute );
+			else this.createAttribute( dstAttribute );
+
+		}
+
+		const sourceGPU = srcData.buffer;
+		const destinationGPU = dstData.buffer;
+
+		if (
+			srcOffset + byteLength > sourceGPU.size ||
+			dstOffset + byteLength > destinationGPU.size
+		) {
+
+			error( 'WebGPUBackend: copyBufferToBuffer: Copy region out of bounds.', {
+				srcSize: sourceGPU.size,
+				dstSize: destinationGPU.size,
+				srcOffset,
+				dstOffset,
+				byteLength,
+			} );
+
+			return;
+
+		}
+
+		const encoder = this.device.createCommandEncoder( {
+			label: 'copyBufferToBuffer_' + srcAttribute.id + '_' + dstAttribute.id,
+		} );
+
+		encoder.copyBufferToBuffer(
+			sourceGPU,
+			srcOffset,
+			destinationGPU,
+			dstOffset,
+			byteLength,
+		);
+
+		this.device.queue.submit( [ encoder.finish() ] );
+
+	}
+
+	/**
 	 * Checks if the given compatibility is supported by the backend.
 	 *
 	 * @param {string} name - The compatibility name.

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -2532,31 +2532,19 @@ class WebGPUBackend extends Backend {
 	}
 
 	/**
-	 * Copies data of the given source buffer attribute to the given destination buffer attribute.
-	 *
-	 * @param {BufferAttribute} srcAttribute - The source buffer attribute.
-	 * @param {BufferAttribute} dstAttribute - The destination buffer attribute.
-	 * @param {number} byteLength - The number of bytes to copy.
-	 * @param {number} [srcOffset=0] - The source offset in bytes.
-	 * @param {number} [dstOffset=0] - The destination offset in bytes.
-	 */
-	copyBufferToBuffer(
-		srcAttribute,
-		dstAttribute,
-		byteLength,
-		srcOffset = 0,
-		dstOffset = 0,
-	) {
+ * Copies data of the given source buffer attribute to the given destination buffer attribute.
+ *
+ * @param {BufferAttribute} srcAttribute - The source buffer attribute.
+ * @param {BufferAttribute} dstAttribute - The destination buffer attribute.
+ * @param {number} byteLength - The number of bytes to copy.
+ * @param {number} [srcOffset=0] - The source offset in bytes.
+ * @param {number} [dstOffset=0] - The destination offset in bytes.
+ */
+	copyBufferToBuffer( srcAttribute, dstAttribute, byteLength, srcOffset = 0, dstOffset = 0 ) {
 
-		if (
-			( srcOffset & 3 ) !== 0 ||
-			( dstOffset & 3 ) !== 0 ||
-			( byteLength & 3 ) !== 0
-		) {
+		if ( ( srcOffset & 3 ) !== 0 || ( dstOffset & 3 ) !== 0 || ( byteLength & 3 ) !== 0 ) {
 
-			error(
-				'WebGPUBackend: copyBufferToBuffer: srcOffset, dstOffset and byteLength must be multiples of 4 bytes.',
-			);
+			error( 'WebGPUBackend: copyBufferToBuffer: srcOffset, dstOffset and byteLength must be multiples of 4 bytes.' );
 			return;
 
 		}
@@ -2564,36 +2552,47 @@ class WebGPUBackend extends Backend {
 		const srcData = this.get( srcAttribute );
 		const dstData = this.get( dstAttribute );
 
-		// Ensure GPU buffers exist
+		// Source must exist
 		if ( srcData.buffer === undefined ) {
 
-			if (
-				srcAttribute.isStorageBufferAttribute ||
-				srcAttribute.isStorageInstancedBufferAttribute
-			)
-				this.createStorageAttribute( srcAttribute );
-			else this.createAttribute( srcAttribute );
+			error( 'WebGPUBackend: copyBufferToBuffer: src GPUBuffer is undefined.', { srcId: srcAttribute.id } );
+			return;
 
 		}
 
+		// Destination may be created.
 		if ( dstData.buffer === undefined ) {
 
-			if (
-				dstAttribute.isStorageBufferAttribute ||
-				dstAttribute.isStorageInstancedBufferAttribute
-			)
+			if ( dstAttribute.isStorageBufferAttribute || dstAttribute.isStorageInstancedBufferAttribute ) {
+
 				this.createStorageAttribute( dstAttribute );
-			else this.createAttribute( dstAttribute );
+
+			} else {
+
+				this.createAttribute( dstAttribute );
+
+			}
 
 		}
 
-		const sourceGPU = srcData.buffer;
-		const destinationGPU = dstData.buffer;
+		// Re-fetch buffers after possible create
+		const sourceGPU = this.get( srcAttribute ).buffer;
+		const destinationGPU = this.get( dstAttribute ).buffer;
 
-		if (
-			srcOffset + byteLength > sourceGPU.size ||
-			dstOffset + byteLength > destinationGPU.size
-		) {
+		if ( sourceGPU === undefined || destinationGPU === undefined ) {
+
+			error( 'WebGPUBackend: copyBufferToBuffer: missing GPUBuffer(s) after ensure.', {
+				srcId: srcAttribute.id,
+				dstId: dstAttribute.id,
+				srcHasBuffer: sourceGPU !== undefined,
+				dstHasBuffer: destinationGPU !== undefined,
+			} );
+
+			return;
+
+		}
+
+		if ( srcOffset + byteLength > sourceGPU.size || dstOffset + byteLength > destinationGPU.size ) {
 
 			error( 'WebGPUBackend: copyBufferToBuffer: Copy region out of bounds.', {
 				srcSize: sourceGPU.size,
@@ -2611,13 +2610,7 @@ class WebGPUBackend extends Backend {
 			label: 'copyBufferToBuffer_' + srcAttribute.id + '_' + dstAttribute.id,
 		} );
 
-		encoder.copyBufferToBuffer(
-			sourceGPU,
-			srcOffset,
-			destinationGPU,
-			dstOffset,
-			byteLength,
-		);
+		encoder.copyBufferToBuffer( sourceGPU, srcOffset, destinationGPU, dstOffset, byteLength );
 
 		this.device.queue.submit( [ encoder.finish() ] );
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -2590,21 +2590,10 @@ class WebGPUBackend extends Backend {
 
 			}
 
-		} else {
+		} else if ( srcOffset + size > sourceGPU.size || dstOffset + size > destinationGPU.size ) {
 
-			if ( ( srcOffset & 3 ) !== 0 || ( dstOffset & 3 ) !== 0 || ( size & 3 ) !== 0 ) {
-
-				error( 'WebGPUBackend: copyBufferToBuffer: srcOffset, dstOffset and size must be multiples of 4 bytes.' );
-				return;
-
-			}
-
-			if ( srcOffset + size > sourceGPU.size || dstOffset + size > destinationGPU.size ) {
-
-				error( 'WebGPUBackend: copyBufferToBuffer: Copy region out of bounds.' );
-				return;
-
-			}
+			error( 'WebGPUBackend: copyBufferToBuffer: Copy region out of bounds.' );
+			return;
 
 		}
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -2532,77 +2532,79 @@ class WebGPUBackend extends Backend {
 	}
 
 	/**
- * Copies data of the given source buffer attribute to the given destination buffer attribute.
- *
- * @param {BufferAttribute} srcAttribute - The source buffer attribute.
- * @param {BufferAttribute} dstAttribute - The destination buffer attribute.
- * @param {number} byteLength - The number of bytes to copy.
- * @param {number} [srcOffset=0] - The source offset in bytes.
- * @param {number} [dstOffset=0] - The destination offset in bytes.
- */
-	copyBufferToBuffer( srcAttribute, dstAttribute, byteLength, srcOffset = 0, dstOffset = 0 ) {
+	 * Copies data of the given source buffer attribute to the given destination buffer attribute.
+	 *
+	 * @param {BufferAttribute} srcAttribute - The source buffer attribute.
+	 * @param {BufferAttribute} dstAttribute - The destination buffer attribute.
+	 * @param {?number} [size=null] - The number of bytes to copy. If `null`, the entire source buffer is copied.
+	 * @param {number} [srcOffset=0] - The source offset in bytes.
+	 * @param {number} [dstOffset=0] - The destination offset in bytes.
+	 */
+	copyBufferToBuffer( srcAttribute, dstAttribute, size = null, srcOffset = 0, dstOffset = 0 ) {
 
-		if ( ( srcOffset & 3 ) !== 0 || ( dstOffset & 3 ) !== 0 || ( byteLength & 3 ) !== 0 ) {
+		const getOrCreateBuffer = ( attribute ) => {
 
-			error( 'WebGPUBackend: copyBufferToBuffer: srcOffset, dstOffset and byteLength must be multiples of 4 bytes.' );
-			return;
+			const data = this.get( attribute );
 
-		}
+			if ( data.buffer === undefined ) {
 
-		const srcData = this.get( srcAttribute );
-		const dstData = this.get( dstAttribute );
+				if ( attribute.isStorageBufferAttribute || attribute.isStorageInstancedBufferAttribute ) {
 
-		// Source must exist
-		if ( srcData.buffer === undefined ) {
+					this.createStorageAttribute( attribute );
 
-			error( 'WebGPUBackend: copyBufferToBuffer: src GPUBuffer is undefined.', { srcId: srcAttribute.id } );
-			return;
+				} else {
 
-		}
+					this.createAttribute( attribute );
 
-		// Destination may be created.
-		if ( dstData.buffer === undefined ) {
-
-			if ( dstAttribute.isStorageBufferAttribute || dstAttribute.isStorageInstancedBufferAttribute ) {
-
-				this.createStorageAttribute( dstAttribute );
-
-			} else {
-
-				this.createAttribute( dstAttribute );
+				}
 
 			}
 
-		}
+			return data.buffer;
 
-		// Re-fetch buffers after possible create
-		const sourceGPU = this.get( srcAttribute ).buffer;
-		const destinationGPU = this.get( dstAttribute ).buffer;
+		};
+
+		const sourceGPU = getOrCreateBuffer( srcAttribute );
+		const destinationGPU = getOrCreateBuffer( dstAttribute );
 
 		if ( sourceGPU === undefined || destinationGPU === undefined ) {
 
-			error( 'WebGPUBackend: copyBufferToBuffer: missing GPUBuffer(s) after ensure.', {
-				srcId: srcAttribute.id,
-				dstId: dstAttribute.id,
-				srcHasBuffer: sourceGPU !== undefined,
-				dstHasBuffer: destinationGPU !== undefined,
-			} );
-
+			error( 'WebGPUBackend: copyBufferToBuffer: Missing GPUBuffer.' );
 			return;
 
 		}
 
-		if ( srcOffset + byteLength > sourceGPU.size || dstOffset + byteLength > destinationGPU.size ) {
+		if ( size === null ) {
 
-			error( 'WebGPUBackend: copyBufferToBuffer: Copy region out of bounds.', {
-				srcSize: sourceGPU.size,
-				dstSize: destinationGPU.size,
-				srcOffset,
-				dstOffset,
-				byteLength,
-			} );
+			if ( srcOffset !== 0 || dstOffset !== 0 ) {
 
-			return;
+				error( 'WebGPUBackend: copyBufferToBuffer: Offsets require an explicit size.' );
+				return;
+
+			}
+
+			if ( sourceGPU.size > destinationGPU.size ) {
+
+				error( 'WebGPUBackend: copyBufferToBuffer: Copy region out of bounds.' );
+				return;
+
+			}
+
+		} else {
+
+			if ( ( srcOffset & 3 ) !== 0 || ( dstOffset & 3 ) !== 0 || ( size & 3 ) !== 0 ) {
+
+				error( 'WebGPUBackend: copyBufferToBuffer: srcOffset, dstOffset and size must be multiples of 4 bytes.' );
+				return;
+
+			}
+
+			if ( srcOffset + size > sourceGPU.size || dstOffset + size > destinationGPU.size ) {
+
+				error( 'WebGPUBackend: copyBufferToBuffer: Copy region out of bounds.' );
+				return;
+
+			}
 
 		}
 
@@ -2610,7 +2612,19 @@ class WebGPUBackend extends Backend {
 			label: 'copyBufferToBuffer_' + srcAttribute.id + '_' + dstAttribute.id,
 		} );
 
-		encoder.copyBufferToBuffer( sourceGPU, srcOffset, destinationGPU, dstOffset, byteLength );
+		if ( size === null ) {
+
+			encoder.copyBufferToBuffer( sourceGPU, destinationGPU );
+
+		} else if ( srcOffset === 0 && dstOffset === 0 ) {
+
+			encoder.copyBufferToBuffer( sourceGPU, destinationGPU, size );
+
+		} else {
+
+			encoder.copyBufferToBuffer( sourceGPU, srcOffset, destinationGPU, dstOffset, size );
+
+		}
 
 		this.device.queue.submit( [ encoder.finish() ] );
 


### PR DESCRIPTION
**Description**

Exposes webGPU api's `copyBufferToBuffer()` method, much like how `copyTextureToTexture()` and others are currently exposed.

For the webGL fallback it uses `gl.copyBufferSubData` as the equivalent, however, I haven't properly tested this yet as im not too familiar with webGL and my main use case for this feature is when using compute shaders with webGPU.

The backend functions are pretty light wrappers over the native api and accept bytes whilst the exposed method on the renderer takes in items and automatically converts to the correct amount of bytes based on the itemSize so users don't have to deal with byte conversions.

I've begun working on a physarum slime mold simulation and added this feature as I wanted a way to dynamically increase my particle buffer size without just setting a large maximum buffer size and early returning. I currently use a similar method for resizing storageTextures using `renderer.copyTextureToTexture()` wherein I resize the texture and copy the old contents over.

```ts
      renderer.setSize(x, y, false)

      // Rebuild every texture on my texture object
      Object.entries(tex).forEach(([key, tex]) => {

        // create tmp texture at the old size
        const tmp = makeStorageTex(oldW, oldH, { type: tex.type ?? textureType })

        // copy contents to tmp
        copyTextureToTexture({ renderer: ctx.renderer, src: tex, dst: tmp, origin })

        // resize texture in place (same object -> kernels stay valid)
        tex.setSize(x, y, 1)
        tex.needsUpdate = true

        // copy old contents via tmp over to our newly sized texture
        copyTextureToTexture({ renderer: ctx.renderer, src: tmp, dst: tex, origin })

        tmp.dispose()
      })
```

The idea was to do the same but for my particle buffer using the added `renderer.copyBufferToBuffer()` method.

```ts
  const positionArray = instancedArray(controls.particleCount, 'vec2')
  const headingArray = instancedArray(controls.particleCount, 'vec2')

  let seedKernel = seedParticles().compute(controls.particleCount).setName('Seed Particles')
  let particleUpdateA = particleUpdate({ deposit: tex.a }).compute(controls.particleCount).setName('Update Particles A')
  let particleUpdateB = particleUpdate({ deposit: tex.b }).compute(controls.particleCount).setName('Update Particles B')
    
  function resizeStorageBuffer(newCount: number) {
    const oldPosAttr = positionArray.value
    const oldHeadAttr = headingArray.value
    const oldCount = oldPosAttr.count

    if (newCount <= 0) {
      mesh.count = 0
      return
    }

    // allocate new storage buffers
    const newPosAttr = new StorageInstancedBufferAttribute(newCount, 2)
    const newHeadAttr = new StorageInstancedBufferAttribute(newCount, 2)

    // copy old buffer over to new buffer
    renderer.copyBufferToBuffer(oldPosAttr, newPosAttr)
    renderer.copyBufferToBuffer(oldHeadAttr, newHeadAttr)

    // reassign the instancedArray's underlying BufferAttribute via .value
    positionArray.value = newPosAttr
    headingArray.value = newHeadAttr

    mesh.count = newCount

    // Dispose old kernels
    particleUpdateA.dispose()
    particleUpdateB.dispose()
    seedKernel.dispose()

    // Rebuild kernels with new count
    particleUpdateA = particleUpdate({ deposit: tex.a }).compute(newCount).setName('Update A')
    particleUpdateB = particleUpdate({ deposit: tex.b }).compute(newCount).setName('Update B')
    seedKernel = seedParticles().compute(newCount).setName('Seed Particles')

    // If added particles, give updated range random position and heading
    if (newCount > oldCount) {
      seedFrom.value = oldCount
      seedTo.value = newCount
      renderer.compute(seedKernel) // seeds only [oldCount, newCount)
    }
  }
```

Now this setup does work as expected, however, is quite inefficient because it constantly rebuilds the compute pipeline when ideally it should only rebuild the buffer's bind group. Also note the garbage collector does end up removing the old compute pipelines here but only because .dispose() is called before reassigning them, otherwise it would stack infinitely.

[shapeMatch_hex-2-35-params_22026-02-22 22-34-13_AV1.webm](https://github.com/user-attachments/assets/a18cefd4-2ced-4feb-9d51-c9f08b8c37c9)

Now although this setup is quite inefficient, it behaves exactly as I want it to with old particles being copied over and new particles being added seamlessly. However, when attempting to rework the code so that it doesn't rebuild compute pipelines and instead uses a stable `computeKernel` node with a dyanmic dispatch size, it stops behaving as i'd like.

```ts
  const positionArray = instancedArray(controls.particleCount, 'vec2')
  const headingArray = instancedArray(controls.particleCount, 'vec2')

  const WG = 256
 
  const seedKernel = seedParticles().computeKernel([WG, 1, 1]).setName('Seed Particles')
  const particleUpdateA = particleUpdate({ deposit: tex.a }).computeKernel([WG, 1, 1]).setName('Update A')
  const particleUpdateB = particleUpdate({ deposit: tex.b }).computeKernel([WG, 1, 1]).setName('Update B')
  
  function resizeStorageBuffer(newCount: number) {
    const oldPosAttr = positionArray.value
    const oldHeadAttr = headingArray.value
    const oldCount = oldPosAttr.count

    if (newCount <= 0) {
      mesh.count = 0
      return
    }

    // allocate new storage buffers
    const newPosAttr = new StorageInstancedBufferAttribute(newCount, 2)
    const newHeadAttr = new StorageInstancedBufferAttribute(newCount, 2)

    // copy old buffer over to new buffer
    renderer.copyBufferToBuffer(oldPosAttr, newPosAttr)
    renderer.copyBufferToBuffer(oldHeadAttr, newHeadAttr)

    // reassign the instancedArray's underlying BufferAttribute via .value
    positionArray.value = newPosAttr
    headingArray.value = newHeadAttr

    mesh.count = newCount

    // If added particles, give updated range random position and heading
    if (newCount > oldCount) {
      seedFrom.value = oldCount
      seedTo.value = newCount
      renderer.compute(seedKernel, [Math.ceil(newCount / WG), 1, 1])
    }
  }
```

[computeKernel2026-02-22 23-09-16_AV1.webm](https://github.com/user-attachments/assets/28dcb23b-bd58-482d-b7c0-3d068138b626)

In this case the computePipelines stay stable but it seems like the buffer reference isn't correctly updated or gets duplicated somehow? when setting particle count below the inital count of 10, it doubles it so that there are 4 working moving particles but then 4 more static particles. Even stranger yet is that when then running my renderer/texture resize logic the compute shaders do update to use the new buffer but the old buffer doesn't get copied over so the old particles just fade out.

I've tried all sorts of things in an attempt to get this to work such as
```js
    newPosAttr.needsUpdate = true
    newHeadAttr.needsUpdate = true

    positionArray.value.needsUpdate = true
    headingArray.value.needsUpdate = true

    positionArray.needsUpdate = true
    headingArray.needsUpdate = true

    pointsMaterial.needsUpdate = true
    
    const dispatchNow = [Math.ceil(newCount / WG), 1, 1]
    particleUpdateA.setCount(dispatchNow)
    particleUpdateB.setCount(dispatchNow)
    seedKernel.setCount(dispatchNow)
    
    particleUpdateA.setCount(newCount)
    particleUpdateB.setCount(newCount)
    seedKernel.setCount(newCount)

    particleUpdateA.workgroupSize = dispatchNow 
    particleUpdateB.workgroupSize = dispatchNow 
    seedKernel.workgroupSize = dispatchNow 

    particleUpdateA.needsUpdate = true
    particleUpdateB.needsUpdate = true
    seedKernel.needsUpdate = true
    particleUpdateA.computeNode.needsUpdate = true
    particleUpdateB.computeNode.needsUpdate = true
    seedKernel.computeNode.needsUpdate = true
```
but to no avail

There was a pr that aimed at allowing storageBuffers to be reassigned dynamically https://github.com/mrdoob/three.js/pull/32847 but either it doesn't fully work here or im missing something in my implementation.

Overall, I think exposing a `copyBufferToBuffer` method would be useful and fit in nicely with the other exposed methods such as `copyFramebufferToTexture` and `copyTextureToTexture`, it just seems there needs to be some kinks worked out with how StorageBufferAttributes are cached and or referenced in compute functions. Im not very familiar with the intricacies of TSL's binding & cache system so any help here would be much appreciated, thanks.