### PR TITLE
Fix various browser-specific issues in controls, renderers, and docs

### DIFF
--- a/docs/scripts/page.js
+++ b/docs/scripts/page.js
@@ -32,7 +32,15 @@ if ( typeof hljs !== 'undefined' ) {
 
 		const element = document.getElementById( hash );
 
-		if ( element ) element.scrollIntoView();
+		if ( element ) {
+
+			requestAnimationFrame( () => {
+
+				element.scrollIntoView();
+
+			} );
+
+		}
 
 	}
 

--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -37,7 +37,7 @@ const _endEvent = { type: 'end' };
 
 const _ray = new Ray();
 const _plane = new Plane();
-const _TILT_LIMIT = Math.cos( 70 * MathUtils.DEG2RAD );
+const _TILT_LIMIT = Math.cos(70 * MathUtils.DEG2RAD);
 
 const _v = new Vector3();
 const _twoPI = 2 * Math.PI;
@@ -93,9 +93,9 @@ class OrbitControls extends Controls {
 	 * @param {Object3D} object - The object that is managed by the controls.
 	 * @param {?HTMLElement} domElement - The HTML element used for event listeners.
 	 */
-	constructor( object, domElement = null ) {
+	constructor(object, domElement = null) {
 
-		super( object, domElement );
+		super(object, domElement);
 
 		this.state = _STATE.NONE;
 
@@ -403,7 +403,7 @@ class OrbitControls extends Controls {
 		this._lastTargetPosition = new Vector3();
 
 		// so camera.up is the orbit axis
-		this._quat = new Quaternion().setFromUnitVectors( object.up, new Vector3( 0, 1, 0 ) );
+		this._quat = new Quaternion().setFromUnitVectors(object.up, new Vector3(0, 1, 0));
 		this._quatInverse = this._quat.clone().invert();
 
 		// current position in spherical coordinates
@@ -436,27 +436,27 @@ class OrbitControls extends Controls {
 
 		// event listeners
 
-		this._onPointerMove = onPointerMove.bind( this );
-		this._onPointerDown = onPointerDown.bind( this );
-		this._onPointerUp = onPointerUp.bind( this );
-		this._onContextMenu = onContextMenu.bind( this );
-		this._onMouseWheel = onMouseWheel.bind( this );
-		this._onKeyDown = onKeyDown.bind( this );
+		this._onPointerMove = onPointerMove.bind(this);
+		this._onPointerDown = onPointerDown.bind(this);
+		this._onPointerUp = onPointerUp.bind(this);
+		this._onContextMenu = onContextMenu.bind(this);
+		this._onMouseWheel = onMouseWheel.bind(this);
+		this._onKeyDown = onKeyDown.bind(this);
 
-		this._onTouchStart = onTouchStart.bind( this );
-		this._onTouchMove = onTouchMove.bind( this );
+		this._onTouchStart = onTouchStart.bind(this);
+		this._onTouchMove = onTouchMove.bind(this);
 
-		this._onMouseDown = onMouseDown.bind( this );
-		this._onMouseMove = onMouseMove.bind( this );
+		this._onMouseDown = onMouseDown.bind(this);
+		this._onMouseMove = onMouseMove.bind(this);
 
-		this._interceptControlDown = interceptControlDown.bind( this );
-		this._interceptControlUp = interceptControlUp.bind( this );
+		this._interceptControlDown = interceptControlDown.bind(this);
+		this._interceptControlUp = interceptControlUp.bind(this);
 
 		//
 
-		if ( this.domElement !== null ) {
+		if (this.domElement !== null) {
 
-			this.connect( this.domElement );
+			this.connect(this.domElement);
 
 		}
 
@@ -470,11 +470,11 @@ class OrbitControls extends Controls {
 	 * @type {('auto'|'grab')}
 	 * @default 'auto'
 	 */
-	set cursorStyle( type ) {
+	set cursorStyle(type) {
 
 		this._cursorStyle = type;
 
-		if ( type === 'grab' ) {
+		if (type === 'grab') {
 
 			this.domElement.style.cursor = 'grab';
 
@@ -492,18 +492,19 @@ class OrbitControls extends Controls {
 
 	}
 
-	connect( element ) {
+	connect(element) {
 
-		super.connect( element );
+		super.connect(element);
 
-		this.domElement.addEventListener( 'pointerdown', this._onPointerDown );
-		this.domElement.addEventListener( 'pointercancel', this._onPointerUp );
+		this.domElement.addEventListener('pointerdown', this._onPointerDown);
+		this.domElement.addEventListener('pointercancel', this._onPointerUp);
+		this.domElement.addEventListener('pointerleave', this._onPointerUp);
 
-		this.domElement.addEventListener( 'contextmenu', this._onContextMenu );
-		this.domElement.addEventListener( 'wheel', this._onMouseWheel, { passive: false } );
+		this.domElement.addEventListener('contextmenu', this._onContextMenu);
+		this.domElement.addEventListener('wheel', this._onMouseWheel, { passive: false });
 
 		const document = this.domElement.getRootNode(); // offscreen canvas compatibility
-		document.addEventListener( 'keydown', this._interceptControlDown, { passive: true, capture: true } );
+		document.addEventListener('keydown', this._interceptControlDown, { passive: true, capture: true });
 
 		this.domElement.style.touchAction = 'none'; // disable touch scroll
 
@@ -511,18 +512,19 @@ class OrbitControls extends Controls {
 
 	disconnect() {
 
-		this.domElement.removeEventListener( 'pointerdown', this._onPointerDown );
-		this.domElement.ownerDocument.removeEventListener( 'pointermove', this._onPointerMove );
-		this.domElement.ownerDocument.removeEventListener( 'pointerup', this._onPointerUp );
-		this.domElement.removeEventListener( 'pointercancel', this._onPointerUp );
+		this.domElement.removeEventListener('pointerdown', this._onPointerDown);
+		this.domElement.ownerDocument.removeEventListener('pointermove', this._onPointerMove);
+		this.domElement.ownerDocument.removeEventListener('pointerup', this._onPointerUp);
+		this.domElement.removeEventListener('pointercancel', this._onPointerUp);
+		this.domElement.removeEventListener('pointerleave', this._onPointerUp);
 
-		this.domElement.removeEventListener( 'wheel', this._onMouseWheel );
-		this.domElement.removeEventListener( 'contextmenu', this._onContextMenu );
+		this.domElement.removeEventListener('wheel', this._onMouseWheel);
+		this.domElement.removeEventListener('contextmenu', this._onContextMenu);
 
 		this.stopListenToKeyEvents();
 
 		const document = this.domElement.getRootNode(); // offscreen canvas compatibility
-		document.removeEventListener( 'keydown', this._interceptControlDown, { capture: true } );
+		document.removeEventListener('keydown', this._interceptControlDown, { capture: true });
 
 		this.domElement.style.touchAction = 'auto';
 
@@ -563,7 +565,7 @@ class OrbitControls extends Controls {
 	 */
 	getDistance() {
 
-		return this.object.position.distanceTo( this.target );
+		return this.object.position.distanceTo(this.target);
 
 	}
 
@@ -573,9 +575,9 @@ class OrbitControls extends Controls {
 	 *
 	 * @param {HTMLElement} domElement - The DOM element
 	 */
-	listenToKeyEvents( domElement ) {
+	listenToKeyEvents(domElement) {
 
-		domElement.addEventListener( 'keydown', this._onKeyDown );
+		domElement.addEventListener('keydown', this._onKeyDown);
 		this._domElementKeyEvents = domElement;
 
 	}
@@ -585,9 +587,9 @@ class OrbitControls extends Controls {
 	 */
 	stopListenToKeyEvents() {
 
-		if ( this._domElementKeyEvents !== null ) {
+		if (this._domElementKeyEvents !== null) {
 
-			this._domElementKeyEvents.removeEventListener( 'keydown', this._onKeyDown );
+			this._domElementKeyEvents.removeEventListener('keydown', this._onKeyDown);
 			this._domElementKeyEvents = null;
 
 		}
@@ -599,8 +601,8 @@ class OrbitControls extends Controls {
 	 */
 	saveState() {
 
-		this.target0.copy( this.target );
-		this.position0.copy( this.object.position );
+		this.target0.copy(this.target);
+		this.position0.copy(this.object.position);
 		this.zoom0 = this.object.zoom;
 
 	}
@@ -611,12 +613,12 @@ class OrbitControls extends Controls {
 	 */
 	reset() {
 
-		this.target.copy( this.target0 );
-		this.object.position.copy( this.position0 );
+		this.target.copy(this.target0);
+		this.object.position.copy(this.position0);
 		this.object.zoom = this.zoom0;
 
 		this.object.updateProjectionMatrix();
-		this.dispatchEvent( _changeEvent );
+		this.dispatchEvent(_changeEvent);
 
 		this.update();
 
@@ -630,9 +632,9 @@ class OrbitControls extends Controls {
 	 * @param {number} deltaX - The horizontal pan amount in pixels.
 	 * @param {number} deltaY - The vertical pan amount in pixels.
 	 */
-	pan( deltaX, deltaY ) {
+	pan(deltaX, deltaY) {
 
-		this._pan( deltaX, deltaY );
+		this._pan(deltaX, deltaY);
 		this.update();
 
 	}
@@ -642,9 +644,9 @@ class OrbitControls extends Controls {
 	 *
 	 * @param {number} dollyScale - The dolly scale factor.
 	 */
-	dollyIn( dollyScale ) {
+	dollyIn(dollyScale) {
 
-		this._dollyIn( dollyScale );
+		this._dollyIn(dollyScale);
 		this.update();
 
 	}
@@ -654,9 +656,9 @@ class OrbitControls extends Controls {
 	 *
 	 * @param {number} dollyScale - The dolly scale factor.
 	 */
-	dollyOut( dollyScale ) {
+	dollyOut(dollyScale) {
 
-		this._dollyOut( dollyScale );
+		this._dollyOut(dollyScale);
 		this.update();
 
 	}
@@ -666,9 +668,9 @@ class OrbitControls extends Controls {
 	 *
 	 * @param {number} angle - The rotation angle in radians.
 	 */
-	rotateLeft( angle ) {
+	rotateLeft(angle) {
 
-		this._rotateLeft( angle );
+		this._rotateLeft(angle);
 		this.update();
 
 	}
@@ -678,32 +680,32 @@ class OrbitControls extends Controls {
 	 *
 	 * @param {number} angle - The rotation angle in radians.
 	 */
-	rotateUp( angle ) {
+	rotateUp(angle) {
 
-		this._rotateUp( angle );
+		this._rotateUp(angle);
 		this.update();
 
 	}
 
-	update( deltaTime = null ) {
+	update(deltaTime = null) {
 
 		const position = this.object.position;
 
-		_v.copy( position ).sub( this.target );
+		_v.copy(position).sub(this.target);
 
 		// rotate offset to "y-axis-is-up" space
-		_v.applyQuaternion( this._quat );
+		_v.applyQuaternion(this._quat);
 
 		// angle from z-axis around y-axis
-		this._spherical.setFromVector3( _v );
+		this._spherical.setFromVector3(_v);
 
-		if ( this.autoRotate && this.state === _STATE.NONE ) {
+		if (this.autoRotate && this.state === _STATE.NONE) {
 
-			this._rotateLeft( this._getAutoRotationAngle( deltaTime ) );
+			this._rotateLeft(this._getAutoRotationAngle(deltaTime));
 
 		}
 
-		if ( this.enableDamping ) {
+		if (this.enableDamping) {
 
 			this._spherical.theta += this._sphericalDelta.theta * this.dampingFactor;
 			this._spherical.phi += this._sphericalDelta.phi * this.dampingFactor;
@@ -720,159 +722,159 @@ class OrbitControls extends Controls {
 		let min = this.minAzimuthAngle;
 		let max = this.maxAzimuthAngle;
 
-		if ( isFinite( min ) && isFinite( max ) ) {
+		if (isFinite(min) && isFinite(max)) {
 
-			if ( min < - Math.PI ) min += _twoPI; else if ( min > Math.PI ) min -= _twoPI;
+			if (min < - Math.PI) min += _twoPI; else if (min > Math.PI) min -= _twoPI;
 
-			if ( max < - Math.PI ) max += _twoPI; else if ( max > Math.PI ) max -= _twoPI;
+			if (max < - Math.PI) max += _twoPI; else if (max > Math.PI) max -= _twoPI;
 
-			if ( min <= max ) {
+			if (min <= max) {
 
-				this._spherical.theta = Math.max( min, Math.min( max, this._spherical.theta ) );
+				this._spherical.theta = Math.max(min, Math.min(max, this._spherical.theta));
 
 			} else {
 
-				this._spherical.theta = ( this._spherical.theta > ( min + max ) / 2 ) ?
-					Math.max( min, this._spherical.theta ) :
-					Math.min( max, this._spherical.theta );
+				this._spherical.theta = (this._spherical.theta > (min + max) / 2) ?
+					Math.max(min, this._spherical.theta) :
+					Math.min(max, this._spherical.theta);
 
 			}
 
 		}
 
 		// restrict phi to be between desired limits
-		this._spherical.phi = Math.max( this.minPolarAngle, Math.min( this.maxPolarAngle, this._spherical.phi ) );
+		this._spherical.phi = Math.max(this.minPolarAngle, Math.min(this.maxPolarAngle, this._spherical.phi));
 
 		this._spherical.makeSafe();
 
 
 		// move target to panned location
 
-		if ( this.enableDamping === true ) {
+		if (this.enableDamping === true) {
 
-			this.target.addScaledVector( this._panOffset, this.dampingFactor );
+			this.target.addScaledVector(this._panOffset, this.dampingFactor);
 
 		} else {
 
-			this.target.add( this._panOffset );
+			this.target.add(this._panOffset);
 
 		}
 
 		// Limit the target distance from the cursor to create a sphere around the center of interest
-		this.target.sub( this.cursor );
-		this.target.clampLength( this.minTargetRadius, this.maxTargetRadius );
-		this.target.add( this.cursor );
+		this.target.sub(this.cursor);
+		this.target.clampLength(this.minTargetRadius, this.maxTargetRadius);
+		this.target.add(this.cursor);
 
 		let zoomChanged = false;
 		// adjust the camera position based on zoom only if we're not zooming to the cursor or if it's an ortho camera
 		// we adjust zoom later in these cases
-		if ( this.zoomToCursor && this._performCursorZoom || this.object.isOrthographicCamera ) {
+		if (this.zoomToCursor && this._performCursorZoom || this.object.isOrthographicCamera) {
 
-			this._spherical.radius = this._clampDistance( this._spherical.radius );
+			this._spherical.radius = this._clampDistance(this._spherical.radius);
 
 		} else {
 
 			const prevRadius = this._spherical.radius;
-			this._spherical.radius = this._clampDistance( this._spherical.radius * this._scale );
+			this._spherical.radius = this._clampDistance(this._spherical.radius * this._scale);
 			zoomChanged = prevRadius != this._spherical.radius;
 
 		}
 
-		_v.setFromSpherical( this._spherical );
+		_v.setFromSpherical(this._spherical);
 
 		// rotate offset back to "camera-up-vector-is-up" space
-		_v.applyQuaternion( this._quatInverse );
+		_v.applyQuaternion(this._quatInverse);
 
-		position.copy( this.target ).add( _v );
+		position.copy(this.target).add(_v);
 
-		this.object.lookAt( this.target );
+		this.object.lookAt(this.target);
 
-		if ( this.enableDamping === true ) {
+		if (this.enableDamping === true) {
 
-			this._sphericalDelta.theta *= ( 1 - this.dampingFactor );
-			this._sphericalDelta.phi *= ( 1 - this.dampingFactor );
+			this._sphericalDelta.theta *= (1 - this.dampingFactor);
+			this._sphericalDelta.phi *= (1 - this.dampingFactor);
 
-			this._panOffset.multiplyScalar( 1 - this.dampingFactor );
+			this._panOffset.multiplyScalar(1 - this.dampingFactor);
 
 		} else {
 
-			this._sphericalDelta.set( 0, 0, 0 );
+			this._sphericalDelta.set(0, 0, 0);
 
-			this._panOffset.set( 0, 0, 0 );
+			this._panOffset.set(0, 0, 0);
 
 		}
 
 		// adjust camera position
-		if ( this.zoomToCursor && this._performCursorZoom ) {
+		if (this.zoomToCursor && this._performCursorZoom) {
 
 			let newRadius = null;
-			if ( this.object.isPerspectiveCamera ) {
+			if (this.object.isPerspectiveCamera) {
 
 				// move the camera down the pointer ray
 				// this method avoids floating point error
 				const prevRadius = _v.length();
-				newRadius = this._clampDistance( prevRadius * this._scale );
+				newRadius = this._clampDistance(prevRadius * this._scale);
 
 				const radiusDelta = prevRadius - newRadius;
-				this.object.position.addScaledVector( this._dollyDirection, radiusDelta );
+				this.object.position.addScaledVector(this._dollyDirection, radiusDelta);
 				this.object.updateMatrixWorld();
 
-				zoomChanged = !! radiusDelta;
+				zoomChanged = !!radiusDelta;
 
-			} else if ( this.object.isOrthographicCamera ) {
+			} else if (this.object.isOrthographicCamera) {
 
 				// adjust the ortho camera position based on zoom changes
-				const mouseBefore = new Vector3( this._mouse.x, this._mouse.y, 0 );
-				mouseBefore.unproject( this.object );
+				const mouseBefore = new Vector3(this._mouse.x, this._mouse.y, 0);
+				mouseBefore.unproject(this.object);
 
 				const prevZoom = this.object.zoom;
-				this.object.zoom = Math.max( this.minZoom, Math.min( this.maxZoom, this.object.zoom / this._scale ) );
+				this.object.zoom = Math.max(this.minZoom, Math.min(this.maxZoom, this.object.zoom / this._scale));
 				this.object.updateProjectionMatrix();
 
 				zoomChanged = prevZoom !== this.object.zoom;
 
-				const mouseAfter = new Vector3( this._mouse.x, this._mouse.y, 0 );
-				mouseAfter.unproject( this.object );
+				const mouseAfter = new Vector3(this._mouse.x, this._mouse.y, 0);
+				mouseAfter.unproject(this.object);
 
-				this.object.position.sub( mouseAfter ).add( mouseBefore );
+				this.object.position.sub(mouseAfter).add(mouseBefore);
 				this.object.updateMatrixWorld();
 
 				newRadius = _v.length();
 
 			} else {
 
-				console.warn( 'WARNING: OrbitControls.js encountered an unknown camera type - zoom to cursor disabled.' );
+				console.warn('WARNING: OrbitControls.js encountered an unknown camera type - zoom to cursor disabled.');
 				this.zoomToCursor = false;
 
 			}
 
 			// handle the placement of the target
-			if ( newRadius !== null ) {
+			if (newRadius !== null) {
 
-				if ( this.screenSpacePanning ) {
+				if (this.screenSpacePanning) {
 
 					// position the orbit target in front of the new camera position
-					this.target.set( 0, 0, - 1 )
-						.transformDirection( this.object.matrix )
-						.multiplyScalar( newRadius )
-						.add( this.object.position );
+					this.target.set(0, 0, - 1)
+						.transformDirection(this.object.matrix)
+						.multiplyScalar(newRadius)
+						.add(this.object.position);
 
 				} else {
 
 					// get the ray and translation plane to compute target
-					_ray.origin.copy( this.object.position );
-					_ray.direction.set( 0, 0, - 1 ).transformDirection( this.object.matrix );
+					_ray.origin.copy(this.object.position);
+					_ray.direction.set(0, 0, - 1).transformDirection(this.object.matrix);
 
 					// if the camera is 20 degrees above the horizon then don't adjust the focus target to avoid
 					// extremely large values
-					if ( Math.abs( this.object.up.dot( _ray.direction ) ) < _TILT_LIMIT ) {
+					if (Math.abs(this.object.up.dot(_ray.direction)) < _TILT_LIMIT) {
 
-						this.object.lookAt( this.target );
+						this.object.lookAt(this.target);
 
 					} else {
 
-						_plane.setFromNormalAndCoplanarPoint( this.object.up, this.target );
-						_ray.intersectPlane( _plane, this.target );
+						_plane.setFromNormalAndCoplanarPoint(this.object.up, this.target);
+						_ray.intersectPlane(_plane, this.target);
 
 					}
 
@@ -880,12 +882,12 @@ class OrbitControls extends Controls {
 
 			}
 
-		} else if ( this.object.isOrthographicCamera ) {
+		} else if (this.object.isOrthographicCamera) {
 
 			const prevZoom = this.object.zoom;
-			this.object.zoom = Math.max( this.minZoom, Math.min( this.maxZoom, this.object.zoom / this._scale ) );
+			this.object.zoom = Math.max(this.minZoom, Math.min(this.maxZoom, this.object.zoom / this._scale));
 
-			if ( prevZoom !== this.object.zoom ) {
+			if (prevZoom !== this.object.zoom) {
 
 				this.object.updateProjectionMatrix();
 				zoomChanged = true;
@@ -901,16 +903,16 @@ class OrbitControls extends Controls {
 		// min(camera displacement, camera rotation in radians)^2 > EPS
 		// using small-angle approximation cos(x/2) = 1 - x^2 / 8
 
-		if ( zoomChanged ||
-			this._lastPosition.distanceToSquared( this.object.position ) > _EPS ||
-			8 * ( 1 - this._lastQuaternion.dot( this.object.quaternion ) ) > _EPS ||
-			this._lastTargetPosition.distanceToSquared( this.target ) > _EPS ) {
+		if (zoomChanged ||
+			this._lastPosition.distanceToSquared(this.object.position) > _EPS ||
+			8 * (1 - this._lastQuaternion.dot(this.object.quaternion)) > _EPS ||
+			this._lastTargetPosition.distanceToSquared(this.target) > _EPS) {
 
-			this.dispatchEvent( _changeEvent );
+			this.dispatchEvent(_changeEvent);
 
-			this._lastPosition.copy( this.object.position );
-			this._lastQuaternion.copy( this.object.quaternion );
-			this._lastTargetPosition.copy( this.target );
+			this._lastPosition.copy(this.object.position);
+			this._lastQuaternion.copy(this.object.quaternion);
+			this._lastTargetPosition.copy(this.target);
 
 			return true;
 
@@ -920,11 +922,11 @@ class OrbitControls extends Controls {
 
 	}
 
-	_getAutoRotationAngle( deltaTime ) {
+	_getAutoRotationAngle(deltaTime) {
 
-		if ( deltaTime !== null ) {
+		if (deltaTime !== null) {
 
-			return ( _twoPI / 60 * this.autoRotateSpeed ) * deltaTime;
+			return (_twoPI / 60 * this.autoRotateSpeed) * deltaTime;
 
 		} else {
 
@@ -934,121 +936,121 @@ class OrbitControls extends Controls {
 
 	}
 
-	_getZoomScale( delta ) {
+	_getZoomScale(delta) {
 
-		const normalizedDelta = Math.abs( delta * 0.01 );
-		return Math.pow( 0.95, this.zoomSpeed * normalizedDelta );
+		const normalizedDelta = Math.abs(delta * 0.01);
+		return Math.pow(0.95, this.zoomSpeed * normalizedDelta);
 
 	}
 
-	_rotateLeft( angle ) {
+	_rotateLeft(angle) {
 
 		this._sphericalDelta.theta -= angle;
 
 	}
 
-	_rotateUp( angle ) {
+	_rotateUp(angle) {
 
 		this._sphericalDelta.phi -= angle;
 
 	}
 
-	_panLeft( distance, objectMatrix ) {
+	_panLeft(distance, objectMatrix) {
 
-		_v.setFromMatrixColumn( objectMatrix, 0 ); // get X column of objectMatrix
-		_v.multiplyScalar( - distance );
+		_v.setFromMatrixColumn(objectMatrix, 0); // get X column of objectMatrix
+		_v.multiplyScalar(- distance);
 
-		this._panOffset.add( _v );
+		this._panOffset.add(_v);
 
 	}
 
-	_panUp( distance, objectMatrix ) {
+	_panUp(distance, objectMatrix) {
 
-		if ( this.screenSpacePanning === true ) {
+		if (this.screenSpacePanning === true) {
 
-			_v.setFromMatrixColumn( objectMatrix, 1 );
+			_v.setFromMatrixColumn(objectMatrix, 1);
 
 		} else {
 
-			_v.setFromMatrixColumn( objectMatrix, 0 );
-			_v.crossVectors( this.object.up, _v );
+			_v.setFromMatrixColumn(objectMatrix, 0);
+			_v.crossVectors(this.object.up, _v);
 
 		}
 
-		_v.multiplyScalar( distance );
+		_v.multiplyScalar(distance);
 
-		this._panOffset.add( _v );
+		this._panOffset.add(_v);
 
 	}
 
 	// deltaX and deltaY are in pixels; right and down are positive
-	_pan( deltaX, deltaY ) {
+	_pan(deltaX, deltaY) {
 
 		const element = this.domElement;
 
-		if ( this.object.isPerspectiveCamera ) {
+		if (this.object.isPerspectiveCamera) {
 
 			// perspective
 			const position = this.object.position;
-			_v.copy( position ).sub( this.target );
+			_v.copy(position).sub(this.target);
 			let targetDistance = _v.length();
 
 			// half of the fov is center to top of screen
-			targetDistance *= Math.tan( ( this.object.fov / 2 ) * Math.PI / 180.0 );
+			targetDistance *= Math.tan((this.object.fov / 2) * Math.PI / 180.0);
 
 			// we use only clientHeight here so aspect ratio does not distort speed
-			this._panLeft( 2 * deltaX * targetDistance / element.clientHeight, this.object.matrix );
-			this._panUp( 2 * deltaY * targetDistance / element.clientHeight, this.object.matrix );
+			this._panLeft(2 * deltaX * targetDistance / element.clientHeight, this.object.matrix);
+			this._panUp(2 * deltaY * targetDistance / element.clientHeight, this.object.matrix);
 
-		} else if ( this.object.isOrthographicCamera ) {
+		} else if (this.object.isOrthographicCamera) {
 
 			// orthographic
-			this._panLeft( deltaX * ( this.object.right - this.object.left ) / this.object.zoom / element.clientWidth, this.object.matrix );
-			this._panUp( deltaY * ( this.object.top - this.object.bottom ) / this.object.zoom / element.clientHeight, this.object.matrix );
+			this._panLeft(deltaX * (this.object.right - this.object.left) / this.object.zoom / element.clientWidth, this.object.matrix);
+			this._panUp(deltaY * (this.object.top - this.object.bottom) / this.object.zoom / element.clientHeight, this.object.matrix);
 
 		} else {
 
 			// camera neither orthographic nor perspective
-			console.warn( 'WARNING: OrbitControls.js encountered an unknown camera type - pan disabled.' );
+			console.warn('WARNING: OrbitControls.js encountered an unknown camera type - pan disabled.');
 			this.enablePan = false;
 
 		}
 
 	}
 
-	_dollyOut( dollyScale ) {
+	_dollyOut(dollyScale) {
 
-		if ( this.object.isPerspectiveCamera || this.object.isOrthographicCamera ) {
+		if (this.object.isPerspectiveCamera || this.object.isOrthographicCamera) {
 
 			this._scale /= dollyScale;
 
 		} else {
 
-			console.warn( 'WARNING: OrbitControls.js encountered an unknown camera type - dolly/zoom disabled.' );
+			console.warn('WARNING: OrbitControls.js encountered an unknown camera type - dolly/zoom disabled.');
 			this.enableZoom = false;
 
 		}
 
 	}
 
-	_dollyIn( dollyScale ) {
+	_dollyIn(dollyScale) {
 
-		if ( this.object.isPerspectiveCamera || this.object.isOrthographicCamera ) {
+		if (this.object.isPerspectiveCamera || this.object.isOrthographicCamera) {
 
 			this._scale *= dollyScale;
 
 		} else {
 
-			console.warn( 'WARNING: OrbitControls.js encountered an unknown camera type - dolly/zoom disabled.' );
+			console.warn('WARNING: OrbitControls.js encountered an unknown camera type - dolly/zoom disabled.');
 			this.enableZoom = false;
 
 		}
 
 	}
 
-	_updateZoomParameters( x, y ) {
+	_updateZoomParameters(x, y) {
 
-		if ( ! this.zoomToCursor ) {
+		if (!this.zoomToCursor) {
 
 			return;
 
@@ -1062,16 +1064,16 @@ class OrbitControls extends Controls {
 		const w = rect.width;
 		const h = rect.height;
 
-		this._mouse.x = ( dx / w ) * 2 - 1;
-		this._mouse.y = - ( dy / h ) * 2 + 1;
+		this._mouse.x = (dx / w) * 2 - 1;
+		this._mouse.y = - (dy / h) * 2 + 1;
 
-		this._dollyDirection.set( this._mouse.x, this._mouse.y, 1 ).unproject( this.object ).sub( this.object.position ).normalize();
+		this._dollyDirection.set(this._mouse.x, this._mouse.y, 1).unproject(this.object).sub(this.object.position).normalize();
 
 	}
 
-	_clampDistance( dist ) {
+	_clampDistance(dist) {
 
-		return Math.max( this.minDistance, Math.min( this.maxDistance, dist ) );
+		return Math.max(this.minDistance, Math.min(this.maxDistance, dist));
 
 	}
 
@@ -1079,90 +1081,90 @@ class OrbitControls extends Controls {
 	// event callbacks - update the object state
 	//
 
-	_handleMouseDownRotate( event ) {
+	_handleMouseDownRotate(event) {
 
-		this._rotateStart.set( event.clientX, event.clientY );
-
-	}
-
-	_handleMouseDownDolly( event ) {
-
-		this._updateZoomParameters( event.clientX, event.clientX );
-		this._dollyStart.set( event.clientX, event.clientY );
+		this._rotateStart.set(event.clientX, event.clientY);
 
 	}
 
-	_handleMouseDownPan( event ) {
+	_handleMouseDownDolly(event) {
 
-		this._panStart.set( event.clientX, event.clientY );
+		this._updateZoomParameters(event.clientX, event.clientX);
+		this._dollyStart.set(event.clientX, event.clientY);
 
 	}
 
-	_handleMouseMoveRotate( event ) {
+	_handleMouseDownPan(event) {
 
-		this._rotateEnd.set( event.clientX, event.clientY );
+		this._panStart.set(event.clientX, event.clientY);
 
-		this._rotateDelta.subVectors( this._rotateEnd, this._rotateStart ).multiplyScalar( this.rotateSpeed );
+	}
+
+	_handleMouseMoveRotate(event) {
+
+		this._rotateEnd.set(event.clientX, event.clientY);
+
+		this._rotateDelta.subVectors(this._rotateEnd, this._rotateStart).multiplyScalar(this.rotateSpeed);
 
 		const element = this.domElement;
 
-		this._rotateLeft( _twoPI * this._rotateDelta.x / element.clientHeight ); // yes, height
+		this._rotateLeft(_twoPI * this._rotateDelta.x / element.clientHeight); // yes, height
 
-		this._rotateUp( _twoPI * this._rotateDelta.y / element.clientHeight );
+		this._rotateUp(_twoPI * this._rotateDelta.y / element.clientHeight);
 
-		this._rotateStart.copy( this._rotateEnd );
+		this._rotateStart.copy(this._rotateEnd);
 
 		this.update();
 
 	}
 
-	_handleMouseMoveDolly( event ) {
+	_handleMouseMoveDolly(event) {
 
-		this._dollyEnd.set( event.clientX, event.clientY );
+		this._dollyEnd.set(event.clientX, event.clientY);
 
-		this._dollyDelta.subVectors( this._dollyEnd, this._dollyStart );
+		this._dollyDelta.subVectors(this._dollyEnd, this._dollyStart);
 
-		if ( this._dollyDelta.y > 0 ) {
+		if (this._dollyDelta.y > 0) {
 
-			this._dollyOut( this._getZoomScale( this._dollyDelta.y ) );
+			this._dollyOut(this._getZoomScale(this._dollyDelta.y));
 
-		} else if ( this._dollyDelta.y < 0 ) {
+		} else if (this._dollyDelta.y < 0) {
 
-			this._dollyIn( this._getZoomScale( this._dollyDelta.y ) );
+			this._dollyIn(this._getZoomScale(this._dollyDelta.y));
 
 		}
 
-		this._dollyStart.copy( this._dollyEnd );
+		this._dollyStart.copy(this._dollyEnd);
 
 		this.update();
 
 	}
 
-	_handleMouseMovePan( event ) {
+	_handleMouseMovePan(event) {
 
-		this._panEnd.set( event.clientX, event.clientY );
+		this._panEnd.set(event.clientX, event.clientY);
 
-		this._panDelta.subVectors( this._panEnd, this._panStart ).multiplyScalar( this.panSpeed );
+		this._panDelta.subVectors(this._panEnd, this._panStart).multiplyScalar(this.panSpeed);
 
-		this._pan( this._panDelta.x, this._panDelta.y );
+		this._pan(this._panDelta.x, this._panDelta.y);
 
-		this._panStart.copy( this._panEnd );
+		this._panStart.copy(this._panEnd);
 
 		this.update();
 
 	}
 
-	_handleMouseWheel( event ) {
+	_handleMouseWheel(event) {
 
-		this._updateZoomParameters( event.clientX, event.clientY );
+		this._updateZoomParameters(event.clientX, event.clientY);
 
-		if ( event.deltaY < 0 ) {
+		if (event.deltaY < 0) {
 
-			this._dollyIn( this._getZoomScale( event.deltaY ) );
+			this._dollyIn(this._getZoomScale(event.deltaY));
 
-		} else if ( event.deltaY > 0 ) {
+		} else if (event.deltaY > 0) {
 
-			this._dollyOut( this._getZoomScale( event.deltaY ) );
+			this._dollyOut(this._getZoomScale(event.deltaY));
 
 		}
 
@@ -1170,27 +1172,27 @@ class OrbitControls extends Controls {
 
 	}
 
-	_handleKeyDown( event ) {
+	_handleKeyDown(event) {
 
 		let needsUpdate = false;
 
-		switch ( event.code ) {
+		switch (event.code) {
 
 			case this.keys.UP:
 
-				if ( event.ctrlKey || event.metaKey || event.shiftKey ) {
+				if (event.ctrlKey || event.metaKey || event.shiftKey) {
 
-					if ( this.enableRotate ) {
+					if (this.enableRotate) {
 
-						this._rotateUp( _twoPI * this.keyRotateSpeed / this.domElement.clientHeight );
+						this._rotateUp(_twoPI * this.keyRotateSpeed / this.domElement.clientHeight);
 
 					}
 
 				} else {
 
-					if ( this.enablePan ) {
+					if (this.enablePan) {
 
-						this._pan( 0, this.keyPanSpeed );
+						this._pan(0, this.keyPanSpeed);
 
 					}
 
@@ -1201,19 +1203,19 @@ class OrbitControls extends Controls {
 
 			case this.keys.BOTTOM:
 
-				if ( event.ctrlKey || event.metaKey || event.shiftKey ) {
+				if (event.ctrlKey || event.metaKey || event.shiftKey) {
 
-					if ( this.enableRotate ) {
+					if (this.enableRotate) {
 
-						this._rotateUp( - _twoPI * this.keyRotateSpeed / this.domElement.clientHeight );
+						this._rotateUp(- _twoPI * this.keyRotateSpeed / this.domElement.clientHeight);
 
 					}
 
 				} else {
 
-					if ( this.enablePan ) {
+					if (this.enablePan) {
 
-						this._pan( 0, - this.keyPanSpeed );
+						this._pan(0, - this.keyPanSpeed);
 
 					}
 
@@ -1224,19 +1226,19 @@ class OrbitControls extends Controls {
 
 			case this.keys.LEFT:
 
-				if ( event.ctrlKey || event.metaKey || event.shiftKey ) {
+				if (event.ctrlKey || event.metaKey || event.shiftKey) {
 
-					if ( this.enableRotate ) {
+					if (this.enableRotate) {
 
-						this._rotateLeft( _twoPI * this.keyRotateSpeed / this.domElement.clientHeight );
+						this._rotateLeft(_twoPI * this.keyRotateSpeed / this.domElement.clientHeight);
 
 					}
 
 				} else {
 
-					if ( this.enablePan ) {
+					if (this.enablePan) {
 
-						this._pan( this.keyPanSpeed, 0 );
+						this._pan(this.keyPanSpeed, 0);
 
 					}
 
@@ -1247,19 +1249,19 @@ class OrbitControls extends Controls {
 
 			case this.keys.RIGHT:
 
-				if ( event.ctrlKey || event.metaKey || event.shiftKey ) {
+				if (event.ctrlKey || event.metaKey || event.shiftKey) {
 
-					if ( this.enableRotate ) {
+					if (this.enableRotate) {
 
-						this._rotateLeft( - _twoPI * this.keyRotateSpeed / this.domElement.clientHeight );
+						this._rotateLeft(- _twoPI * this.keyRotateSpeed / this.domElement.clientHeight);
 
 					}
 
 				} else {
 
-					if ( this.enablePan ) {
+					if (this.enablePan) {
 
-						this._pan( - this.keyPanSpeed, 0 );
+						this._pan(- this.keyPanSpeed, 0);
 
 					}
 
@@ -1270,7 +1272,7 @@ class OrbitControls extends Controls {
 
 		}
 
-		if ( needsUpdate ) {
+		if (needsUpdate) {
 
 			// prevent the browser from scrolling on cursor keys
 			event.preventDefault();
@@ -1282,184 +1284,184 @@ class OrbitControls extends Controls {
 
 	}
 
-	_handleTouchStartRotate( event ) {
+	_handleTouchStartRotate(event) {
 
-		if ( this._pointers.length === 1 ) {
+		if (this._pointers.length === 1) {
 
-			this._rotateStart.set( event.pageX, event.pageY );
+			this._rotateStart.set(event.pageX, event.pageY);
 
 		} else {
 
-			const position = this._getSecondPointerPosition( event );
+			const position = this._getSecondPointerPosition(event);
 
-			const x = 0.5 * ( event.pageX + position.x );
-			const y = 0.5 * ( event.pageY + position.y );
+			const x = 0.5 * (event.pageX + position.x);
+			const y = 0.5 * (event.pageY + position.y);
 
-			this._rotateStart.set( x, y );
+			this._rotateStart.set(x, y);
 
 		}
 
 	}
 
-	_handleTouchStartPan( event ) {
+	_handleTouchStartPan(event) {
 
-		if ( this._pointers.length === 1 ) {
+		if (this._pointers.length === 1) {
 
-			this._panStart.set( event.pageX, event.pageY );
+			this._panStart.set(event.pageX, event.pageY);
 
 		} else {
 
-			const position = this._getSecondPointerPosition( event );
+			const position = this._getSecondPointerPosition(event);
 
-			const x = 0.5 * ( event.pageX + position.x );
-			const y = 0.5 * ( event.pageY + position.y );
+			const x = 0.5 * (event.pageX + position.x);
+			const y = 0.5 * (event.pageY + position.y);
 
-			this._panStart.set( x, y );
+			this._panStart.set(x, y);
 
 		}
 
 	}
 
-	_handleTouchStartDolly( event ) {
+	_handleTouchStartDolly(event) {
 
-		const position = this._getSecondPointerPosition( event );
+		const position = this._getSecondPointerPosition(event);
 
 		const dx = event.pageX - position.x;
 		const dy = event.pageY - position.y;
 
-		const distance = Math.sqrt( dx * dx + dy * dy );
+		const distance = Math.sqrt(dx * dx + dy * dy);
 
-		this._dollyStart.set( 0, distance );
-
-	}
-
-	_handleTouchStartDollyPan( event ) {
-
-		if ( this.enableZoom ) this._handleTouchStartDolly( event );
-
-		if ( this.enablePan ) this._handleTouchStartPan( event );
+		this._dollyStart.set(0, distance);
 
 	}
 
-	_handleTouchStartDollyRotate( event ) {
+	_handleTouchStartDollyPan(event) {
 
-		if ( this.enableZoom ) this._handleTouchStartDolly( event );
+		if (this.enableZoom) this._handleTouchStartDolly(event);
 
-		if ( this.enableRotate ) this._handleTouchStartRotate( event );
+		if (this.enablePan) this._handleTouchStartPan(event);
 
 	}
 
-	_handleTouchMoveRotate( event ) {
+	_handleTouchStartDollyRotate(event) {
 
-		if ( this._pointers.length == 1 ) {
+		if (this.enableZoom) this._handleTouchStartDolly(event);
 
-			this._rotateEnd.set( event.pageX, event.pageY );
+		if (this.enableRotate) this._handleTouchStartRotate(event);
+
+	}
+
+	_handleTouchMoveRotate(event) {
+
+		if (this._pointers.length == 1) {
+
+			this._rotateEnd.set(event.pageX, event.pageY);
 
 		} else {
 
-			const position = this._getSecondPointerPosition( event );
+			const position = this._getSecondPointerPosition(event);
 
-			const x = 0.5 * ( event.pageX + position.x );
-			const y = 0.5 * ( event.pageY + position.y );
+			const x = 0.5 * (event.pageX + position.x);
+			const y = 0.5 * (event.pageY + position.y);
 
-			this._rotateEnd.set( x, y );
+			this._rotateEnd.set(x, y);
 
 		}
 
-		this._rotateDelta.subVectors( this._rotateEnd, this._rotateStart ).multiplyScalar( this.rotateSpeed );
+		this._rotateDelta.subVectors(this._rotateEnd, this._rotateStart).multiplyScalar(this.rotateSpeed);
 
 		const element = this.domElement;
 
-		this._rotateLeft( _twoPI * this._rotateDelta.x / element.clientHeight ); // yes, height
+		this._rotateLeft(_twoPI * this._rotateDelta.x / element.clientHeight); // yes, height
 
-		this._rotateUp( _twoPI * this._rotateDelta.y / element.clientHeight );
+		this._rotateUp(_twoPI * this._rotateDelta.y / element.clientHeight);
 
-		this._rotateStart.copy( this._rotateEnd );
+		this._rotateStart.copy(this._rotateEnd);
 
 	}
 
-	_handleTouchMovePan( event ) {
+	_handleTouchMovePan(event) {
 
-		if ( this._pointers.length === 1 ) {
+		if (this._pointers.length === 1) {
 
-			this._panEnd.set( event.pageX, event.pageY );
+			this._panEnd.set(event.pageX, event.pageY);
 
 		} else {
 
-			const position = this._getSecondPointerPosition( event );
+			const position = this._getSecondPointerPosition(event);
 
-			const x = 0.5 * ( event.pageX + position.x );
-			const y = 0.5 * ( event.pageY + position.y );
+			const x = 0.5 * (event.pageX + position.x);
+			const y = 0.5 * (event.pageY + position.y);
 
-			this._panEnd.set( x, y );
+			this._panEnd.set(x, y);
 
 		}
 
-		this._panDelta.subVectors( this._panEnd, this._panStart ).multiplyScalar( this.panSpeed );
+		this._panDelta.subVectors(this._panEnd, this._panStart).multiplyScalar(this.panSpeed);
 
-		this._pan( this._panDelta.x, this._panDelta.y );
+		this._pan(this._panDelta.x, this._panDelta.y);
 
-		this._panStart.copy( this._panEnd );
+		this._panStart.copy(this._panEnd);
 
 	}
 
-	_handleTouchMoveDolly( event ) {
+	_handleTouchMoveDolly(event) {
 
-		const position = this._getSecondPointerPosition( event );
+		const position = this._getSecondPointerPosition(event);
 
 		const dx = event.pageX - position.x;
 		const dy = event.pageY - position.y;
 
-		const distance = Math.sqrt( dx * dx + dy * dy );
+		const distance = Math.sqrt(dx * dx + dy * dy);
 
-		this._dollyEnd.set( 0, distance );
+		this._dollyEnd.set(0, distance);
 
-		this._dollyDelta.set( 0, Math.pow( this._dollyEnd.y / this._dollyStart.y, this.zoomSpeed ) );
+		this._dollyDelta.set(0, Math.pow(this._dollyEnd.y / this._dollyStart.y, this.zoomSpeed));
 
-		this._dollyOut( this._dollyDelta.y );
+		this._dollyOut(this._dollyDelta.y);
 
-		this._dollyStart.copy( this._dollyEnd );
+		this._dollyStart.copy(this._dollyEnd);
 
-		const centerX = ( event.pageX + position.x ) * 0.5;
-		const centerY = ( event.pageY + position.y ) * 0.5;
+		const centerX = (event.pageX + position.x) * 0.5;
+		const centerY = (event.pageY + position.y) * 0.5;
 
-		this._updateZoomParameters( centerX, centerY );
-
-	}
-
-	_handleTouchMoveDollyPan( event ) {
-
-		if ( this.enableZoom ) this._handleTouchMoveDolly( event );
-
-		if ( this.enablePan ) this._handleTouchMovePan( event );
+		this._updateZoomParameters(centerX, centerY);
 
 	}
 
-	_handleTouchMoveDollyRotate( event ) {
+	_handleTouchMoveDollyPan(event) {
 
-		if ( this.enableZoom ) this._handleTouchMoveDolly( event );
+		if (this.enableZoom) this._handleTouchMoveDolly(event);
 
-		if ( this.enableRotate ) this._handleTouchMoveRotate( event );
+		if (this.enablePan) this._handleTouchMovePan(event);
+
+	}
+
+	_handleTouchMoveDollyRotate(event) {
+
+		if (this.enableZoom) this._handleTouchMoveDolly(event);
+
+		if (this.enableRotate) this._handleTouchMoveRotate(event);
 
 	}
 
 	// pointers
 
-	_addPointer( event ) {
+	_addPointer(event) {
 
-		this._pointers.push( event.pointerId );
+		this._pointers.push(event.pointerId);
 
 	}
 
-	_removePointer( event ) {
+	_removePointer(event) {
 
-		delete this._pointerPositions[ event.pointerId ];
+		delete this._pointerPositions[event.pointerId];
 
-		for ( let i = 0; i < this._pointers.length; i ++ ) {
+		for (let i = 0; i < this._pointers.length; i++) {
 
-			if ( this._pointers[ i ] == event.pointerId ) {
+			if (this._pointers[i] == event.pointerId) {
 
-				this._pointers.splice( i, 1 );
+				this._pointers.splice(i, 1);
 				return;
 
 			}
@@ -1468,11 +1470,11 @@ class OrbitControls extends Controls {
 
 	}
 
-	_isTrackingPointer( event ) {
+	_isTrackingPointer(event) {
 
-		for ( let i = 0; i < this._pointers.length; i ++ ) {
+		for (let i = 0; i < this._pointers.length; i++) {
 
-			if ( this._pointers[ i ] == event.pointerId ) return true;
+			if (this._pointers[i] == event.pointerId) return true;
 
 		}
 
@@ -1480,32 +1482,32 @@ class OrbitControls extends Controls {
 
 	}
 
-	_trackPointer( event ) {
+	_trackPointer(event) {
 
-		let position = this._pointerPositions[ event.pointerId ];
+		let position = this._pointerPositions[event.pointerId];
 
-		if ( position === undefined ) {
+		if (position === undefined) {
 
 			position = new Vector2();
-			this._pointerPositions[ event.pointerId ] = position;
+			this._pointerPositions[event.pointerId] = position;
 
 		}
 
-		position.set( event.pageX, event.pageY );
+		position.set(event.pageX, event.pageY);
 
 	}
 
-	_getSecondPointerPosition( event ) {
+	_getSecondPointerPosition(event) {
 
-		const pointerId = ( event.pointerId === this._pointers[ 0 ] ) ? this._pointers[ 1 ] : this._pointers[ 0 ];
+		const pointerId = (event.pointerId === this._pointers[0]) ? this._pointers[1] : this._pointers[0];
 
-		return this._pointerPositions[ pointerId ];
+		return this._pointerPositions[pointerId];
 
 	}
 
 	//
 
-	_customWheelEvent( event ) {
+	_customWheelEvent(event) {
 
 		const mode = event.deltaMode;
 
@@ -1516,7 +1518,7 @@ class OrbitControls extends Controls {
 			deltaY: event.deltaY,
 		};
 
-		switch ( mode ) {
+		switch (mode) {
 
 			case 1: // LINE_MODE
 				newEvent.deltaY *= 16;
@@ -1529,7 +1531,7 @@ class OrbitControls extends Controls {
 		}
 
 		// detect if event was triggered by pinching
-		if ( event.ctrlKey && ! this._controlActive ) {
+		if (event.ctrlKey && !this._controlActive) {
 
 			newEvent.deltaY *= 10;
 
@@ -1541,38 +1543,38 @@ class OrbitControls extends Controls {
 
 }
 
-function onPointerDown( event ) {
+function onPointerDown(event) {
 
-	if ( this.enabled === false ) return;
+	if (this.enabled === false) return;
 
-	if ( this._pointers.length === 0 ) {
+	if (this._pointers.length === 0) {
 
-		this.domElement.setPointerCapture( event.pointerId );
+		this.domElement.setPointerCapture(event.pointerId);
 
-		this.domElement.ownerDocument.addEventListener( 'pointermove', this._onPointerMove );
-		this.domElement.ownerDocument.addEventListener( 'pointerup', this._onPointerUp );
+		this.domElement.ownerDocument.addEventListener('pointermove', this._onPointerMove);
+		this.domElement.ownerDocument.addEventListener('pointerup', this._onPointerUp);
 
 	}
 
 	//
 
-	if ( this._isTrackingPointer( event ) ) return;
+	if (this._isTrackingPointer(event)) return;
 
 	//
 
-	this._addPointer( event );
+	this._addPointer(event);
 
-	if ( event.pointerType === 'touch' ) {
+	if (event.pointerType === 'touch') {
 
-		this._onTouchStart( event );
+		this._onTouchStart(event);
 
 	} else {
 
-		this._onMouseDown( event );
+		this._onMouseDown(event);
 
 	}
 
-	if ( this._cursorStyle === 'grab' ) {
+	if (this._cursorStyle === 'grab') {
 
 		this.domElement.style.cursor = 'grabbing';
 
@@ -1580,40 +1582,40 @@ function onPointerDown( event ) {
 
 }
 
-function onPointerMove( event ) {
+function onPointerMove(event) {
 
-	if ( this.enabled === false ) return;
+	if (this.enabled === false) return;
 
-	if ( event.pointerType === 'touch' ) {
+	if (event.pointerType === 'touch') {
 
-		this._onTouchMove( event );
+		this._onTouchMove(event);
 
 	} else {
 
-		this._onMouseMove( event );
+		this._onMouseMove(event);
 
 	}
 
 }
 
-function onPointerUp( event ) {
+function onPointerUp(event) {
 
-	this._removePointer( event );
+	this._removePointer(event);
 
-	switch ( this._pointers.length ) {
+	switch (this._pointers.length) {
 
 		case 0:
 
-			this.domElement.releasePointerCapture( event.pointerId );
+			this.domElement.releasePointerCapture(event.pointerId);
 
-			this.domElement.ownerDocument.removeEventListener( 'pointermove', this._onPointerMove );
-			this.domElement.ownerDocument.removeEventListener( 'pointerup', this._onPointerUp );
+			this.domElement.ownerDocument.removeEventListener('pointermove', this._onPointerMove);
+			this.domElement.ownerDocument.removeEventListener('pointerup', this._onPointerUp);
 
-			this.dispatchEvent( _endEvent );
+			this.dispatchEvent(_endEvent);
 
 			this.state = _STATE.NONE;
 
-			if ( this._cursorStyle === 'grab' ) {
+			if (this._cursorStyle === 'grab') {
 
 				this.domElement.style.cursor = 'grab';
 
@@ -1623,11 +1625,11 @@ function onPointerUp( event ) {
 
 		case 1:
 
-			const pointerId = this._pointers[ 0 ];
-			const position = this._pointerPositions[ pointerId ];
+			const pointerId = this._pointers[0];
+			const position = this._pointerPositions[pointerId];
 
 			// minimal placeholder event - allows state correction on pointer-up
-			this._onTouchStart( { pointerId: pointerId, pageX: position.x, pageY: position.y } );
+			this._onTouchStart({ pointerId: pointerId, pageX: position.x, pageY: position.y });
 
 			break;
 
@@ -1635,11 +1637,11 @@ function onPointerUp( event ) {
 
 }
 
-function onMouseDown( event ) {
+function onMouseDown(event) {
 
 	let mouseAction;
 
-	switch ( event.button ) {
+	switch (event.button) {
 
 		case 0:
 
@@ -1662,13 +1664,13 @@ function onMouseDown( event ) {
 
 	}
 
-	switch ( mouseAction ) {
+	switch (mouseAction) {
 
 		case MOUSE.DOLLY:
 
-			if ( this.enableZoom === false ) return;
+			if (this.enableZoom === false) return;
 
-			this._handleMouseDownDolly( event );
+			this._handleMouseDownDolly(event);
 
 			this.state = _STATE.DOLLY;
 
@@ -1676,19 +1678,19 @@ function onMouseDown( event ) {
 
 		case MOUSE.ROTATE:
 
-			if ( event.ctrlKey || event.metaKey || event.shiftKey ) {
+			if (event.ctrlKey || event.metaKey || event.shiftKey) {
 
-				if ( this.enablePan === false ) return;
+				if (this.enablePan === false) return;
 
-				this._handleMouseDownPan( event );
+				this._handleMouseDownPan(event);
 
 				this.state = _STATE.PAN;
 
 			} else {
 
-				if ( this.enableRotate === false ) return;
+				if (this.enableRotate === false) return;
 
-				this._handleMouseDownRotate( event );
+				this._handleMouseDownRotate(event);
 
 				this.state = _STATE.ROTATE;
 
@@ -1698,19 +1700,19 @@ function onMouseDown( event ) {
 
 		case MOUSE.PAN:
 
-			if ( event.ctrlKey || event.metaKey || event.shiftKey ) {
+			if (event.ctrlKey || event.metaKey || event.shiftKey) {
 
-				if ( this.enableRotate === false ) return;
+				if (this.enableRotate === false) return;
 
-				this._handleMouseDownRotate( event );
+				this._handleMouseDownRotate(event);
 
 				this.state = _STATE.ROTATE;
 
 			} else {
 
-				if ( this.enablePan === false ) return;
+				if (this.enablePan === false) return;
 
-				this._handleMouseDownPan( event );
+				this._handleMouseDownPan(event);
 
 				this.state = _STATE.PAN;
 
@@ -1724,39 +1726,39 @@ function onMouseDown( event ) {
 
 	}
 
-	if ( this.state !== _STATE.NONE ) {
+	if (this.state !== _STATE.NONE) {
 
-		this.dispatchEvent( _startEvent );
+		this.dispatchEvent(_startEvent);
 
 	}
 
 }
 
-function onMouseMove( event ) {
+function onMouseMove(event) {
 
-	switch ( this.state ) {
+	switch (this.state) {
 
 		case _STATE.ROTATE:
 
-			if ( this.enableRotate === false ) return;
+			if (this.enableRotate === false) return;
 
-			this._handleMouseMoveRotate( event );
+			this._handleMouseMoveRotate(event);
 
 			break;
 
 		case _STATE.DOLLY:
 
-			if ( this.enableZoom === false ) return;
+			if (this.enableZoom === false) return;
 
-			this._handleMouseMoveDolly( event );
+			this._handleMouseMoveDolly(event);
 
 			break;
 
 		case _STATE.PAN:
 
-			if ( this.enablePan === false ) return;
+			if (this.enablePan === false) return;
 
-			this._handleMouseMovePan( event );
+			this._handleMouseMovePan(event);
 
 			break;
 
@@ -1764,43 +1766,43 @@ function onMouseMove( event ) {
 
 }
 
-function onMouseWheel( event ) {
+function onMouseWheel(event) {
 
-	if ( this.enabled === false || this.enableZoom === false || this.state !== _STATE.NONE ) return;
+	if (this.enabled === false || this.enableZoom === false || this.state !== _STATE.NONE) return;
 
 	event.preventDefault();
 
-	this.dispatchEvent( _startEvent );
+	this.dispatchEvent(_startEvent);
 
-	this._handleMouseWheel( this._customWheelEvent( event ) );
+	this._handleMouseWheel(this._customWheelEvent(event));
 
-	this.dispatchEvent( _endEvent );
-
-}
-
-function onKeyDown( event ) {
-
-	if ( this.enabled === false ) return;
-
-	this._handleKeyDown( event );
+	this.dispatchEvent(_endEvent);
 
 }
 
-function onTouchStart( event ) {
+function onKeyDown(event) {
 
-	this._trackPointer( event );
+	if (this.enabled === false) return;
 
-	switch ( this._pointers.length ) {
+	this._handleKeyDown(event);
+
+}
+
+function onTouchStart(event) {
+
+	this._trackPointer(event);
+
+	switch (this._pointers.length) {
 
 		case 1:
 
-			switch ( this.touches.ONE ) {
+			switch (this.touches.ONE) {
 
 				case TOUCH.ROTATE:
 
-					if ( this.enableRotate === false ) return;
+					if (this.enableRotate === false) return;
 
-					this._handleTouchStartRotate( event );
+					this._handleTouchStartRotate(event);
 
 					this.state = _STATE.TOUCH_ROTATE;
 
@@ -1808,9 +1810,9 @@ function onTouchStart( event ) {
 
 				case TOUCH.PAN:
 
-					if ( this.enablePan === false ) return;
+					if (this.enablePan === false) return;
 
-					this._handleTouchStartPan( event );
+					this._handleTouchStartPan(event);
 
 					this.state = _STATE.TOUCH_PAN;
 
@@ -1826,13 +1828,13 @@ function onTouchStart( event ) {
 
 		case 2:
 
-			switch ( this.touches.TWO ) {
+			switch (this.touches.TWO) {
 
 				case TOUCH.DOLLY_PAN:
 
-					if ( this.enableZoom === false && this.enablePan === false ) return;
+					if (this.enableZoom === false && this.enablePan === false) return;
 
-					this._handleTouchStartDollyPan( event );
+					this._handleTouchStartDollyPan(event);
 
 					this.state = _STATE.TOUCH_DOLLY_PAN;
 
@@ -1840,9 +1842,9 @@ function onTouchStart( event ) {
 
 				case TOUCH.DOLLY_ROTATE:
 
-					if ( this.enableZoom === false && this.enableRotate === false ) return;
+					if (this.enableZoom === false && this.enableRotate === false) return;
 
-					this._handleTouchStartDollyRotate( event );
+					this._handleTouchStartDollyRotate(event);
 
 					this.state = _STATE.TOUCH_DOLLY_ROTATE;
 
@@ -1862,25 +1864,25 @@ function onTouchStart( event ) {
 
 	}
 
-	if ( this.state !== _STATE.NONE ) {
+	if (this.state !== _STATE.NONE) {
 
-		this.dispatchEvent( _startEvent );
+		this.dispatchEvent(_startEvent);
 
 	}
 
 }
 
-function onTouchMove( event ) {
+function onTouchMove(event) {
 
-	this._trackPointer( event );
+	this._trackPointer(event);
 
-	switch ( this.state ) {
+	switch (this.state) {
 
 		case _STATE.TOUCH_ROTATE:
 
-			if ( this.enableRotate === false ) return;
+			if (this.enableRotate === false) return;
 
-			this._handleTouchMoveRotate( event );
+			this._handleTouchMoveRotate(event);
 
 			this.update();
 
@@ -1888,9 +1890,9 @@ function onTouchMove( event ) {
 
 		case _STATE.TOUCH_PAN:
 
-			if ( this.enablePan === false ) return;
+			if (this.enablePan === false) return;
 
-			this._handleTouchMovePan( event );
+			this._handleTouchMovePan(event);
 
 			this.update();
 
@@ -1898,9 +1900,9 @@ function onTouchMove( event ) {
 
 		case _STATE.TOUCH_DOLLY_PAN:
 
-			if ( this.enableZoom === false && this.enablePan === false ) return;
+			if (this.enableZoom === false && this.enablePan === false) return;
 
-			this._handleTouchMoveDollyPan( event );
+			this._handleTouchMoveDollyPan(event);
 
 			this.update();
 
@@ -1908,9 +1910,9 @@ function onTouchMove( event ) {
 
 		case _STATE.TOUCH_DOLLY_ROTATE:
 
-			if ( this.enableZoom === false && this.enableRotate === false ) return;
+			if (this.enableZoom === false && this.enableRotate === false) return;
 
-			this._handleTouchMoveDollyRotate( event );
+			this._handleTouchMoveDollyRotate(event);
 
 			this.update();
 
@@ -1924,37 +1926,37 @@ function onTouchMove( event ) {
 
 }
 
-function onContextMenu( event ) {
+function onContextMenu(event) {
 
-	if ( this.enabled === false ) return;
+	if (this.enabled === false) return;
 
 	event.preventDefault();
 
 }
 
-function interceptControlDown( event ) {
+function interceptControlDown(event) {
 
-	if ( event.key === 'Control' ) {
+	if (event.key === 'Control') {
 
 		this._controlActive = true;
 
 		const document = this.domElement.getRootNode(); // offscreen canvas compatibility
 
-		document.addEventListener( 'keyup', this._interceptControlUp, { passive: true, capture: true } );
+		document.addEventListener('keyup', this._interceptControlUp, { passive: true, capture: true });
 
 	}
 
 }
 
-function interceptControlUp( event ) {
+function interceptControlUp(event) {
 
-	if ( event.key === 'Control' ) {
+	if (event.key === 'Control') {
 
 		this._controlActive = false;
 
 		const document = this.domElement.getRootNode(); // offscreen canvas compatibility
 
-		document.removeEventListener( 'keyup', this._interceptControlUp, { passive: true, capture: true } );
+		document.removeEventListener('keyup', this._interceptControlUp, { passive: true, capture: true });
 
 	}
 

--- a/examples/jsm/controls/TrackballControls.js
+++ b/examples/jsm/controls/TrackballControls.js
@@ -61,9 +61,9 @@ class TrackballControls extends Controls {
 	 * @param {Object3D} object - The object that is managed by the controls.
 	 * @param {?HTMLElement} domElement - The HTML element used for event listeners.
 	 */
-	constructor( object, domElement = null ) {
+	constructor(object, domElement = null) {
 
-		super( object, domElement );
+		super(object, domElement);
 
 		/**
 		 * Represents the properties of the screen. Automatically set when `handleResize()` is called.
@@ -180,7 +180,7 @@ class TrackballControls extends Controls {
 		 *
 		 * @type {Array<string>}
 		 */
-		this.keys = [ 'KeyA' /*A*/, 'KeyS' /*S*/, 'KeyD' /*D*/ ];
+		this.keys = ['KeyA' /*A*/, 'KeyS' /*S*/, 'KeyD' /*D*/];
 
 		/**
 		 * This object contains references to the mouse actions used by the controls.
@@ -232,22 +232,22 @@ class TrackballControls extends Controls {
 
 		// event listeners
 
-		this._onPointerMove = onPointerMove.bind( this );
-		this._onPointerDown = onPointerDown.bind( this );
-		this._onPointerUp = onPointerUp.bind( this );
-		this._onPointerCancel = onPointerCancel.bind( this );
-		this._onContextMenu = onContextMenu.bind( this );
-		this._onMouseWheel = onMouseWheel.bind( this );
-		this._onKeyDown = onKeyDown.bind( this );
-		this._onKeyUp = onKeyUp.bind( this );
+		this._onPointerMove = onPointerMove.bind(this);
+		this._onPointerDown = onPointerDown.bind(this);
+		this._onPointerUp = onPointerUp.bind(this);
+		this._onPointerCancel = onPointerCancel.bind(this);
+		this._onContextMenu = onContextMenu.bind(this);
+		this._onMouseWheel = onMouseWheel.bind(this);
+		this._onKeyDown = onKeyDown.bind(this);
+		this._onKeyUp = onKeyUp.bind(this);
 
-		this._onTouchStart = onTouchStart.bind( this );
-		this._onTouchMove = onTouchMove.bind( this );
-		this._onTouchEnd = onTouchEnd.bind( this );
+		this._onTouchStart = onTouchStart.bind(this);
+		this._onTouchMove = onTouchMove.bind(this);
+		this._onTouchEnd = onTouchEnd.bind(this);
 
-		this._onMouseDown = onMouseDown.bind( this );
-		this._onMouseMove = onMouseMove.bind( this );
-		this._onMouseUp = onMouseUp.bind( this );
+		this._onMouseDown = onMouseDown.bind(this);
+		this._onMouseMove = onMouseMove.bind(this);
+		this._onMouseUp = onMouseUp.bind(this);
 
 		// for reset
 
@@ -256,9 +256,9 @@ class TrackballControls extends Controls {
 		this._up0 = this.object.up.clone();
 		this._zoom0 = this.object.zoom;
 
-		if ( domElement !== null ) {
+		if (domElement !== null) {
 
-			this.connect( domElement );
+			this.connect(domElement);
 
 			this.handleResize();
 
@@ -269,17 +269,18 @@ class TrackballControls extends Controls {
 
 	}
 
-	connect( element ) {
+	connect(element) {
 
-		super.connect( element );
+		super.connect(element);
 
-		window.addEventListener( 'keydown', this._onKeyDown );
-		window.addEventListener( 'keyup', this._onKeyUp );
+		window.addEventListener('keydown', this._onKeyDown);
+		window.addEventListener('keyup', this._onKeyUp);
 
-		this.domElement.addEventListener( 'pointerdown', this._onPointerDown );
-		this.domElement.addEventListener( 'pointercancel', this._onPointerCancel );
-		this.domElement.addEventListener( 'wheel', this._onMouseWheel, { passive: false } );
-		this.domElement.addEventListener( 'contextmenu', this._onContextMenu );
+		this.domElement.addEventListener('pointerdown', this._onPointerDown);
+		this.domElement.addEventListener('pointercancel', this._onPointerCancel);
+		this.domElement.addEventListener('pointerleave', this._onPointerCancel);
+		this.domElement.addEventListener('wheel', this._onMouseWheel, { passive: false });
+		this.domElement.addEventListener('contextmenu', this._onContextMenu);
 
 		this.domElement.style.touchAction = 'none'; // disable touch scroll
 
@@ -287,15 +288,16 @@ class TrackballControls extends Controls {
 
 	disconnect() {
 
-		window.removeEventListener( 'keydown', this._onKeyDown );
-		window.removeEventListener( 'keyup', this._onKeyUp );
+		window.removeEventListener('keydown', this._onKeyDown);
+		window.removeEventListener('keyup', this._onKeyUp);
 
-		this.domElement.removeEventListener( 'pointerdown', this._onPointerDown );
-		this.domElement.ownerDocument.removeEventListener( 'pointermove', this._onPointerMove );
-		this.domElement.ownerDocument.removeEventListener( 'pointerup', this._onPointerUp );
-		this.domElement.removeEventListener( 'pointercancel', this._onPointerCancel );
-		this.domElement.removeEventListener( 'wheel', this._onMouseWheel );
-		this.domElement.removeEventListener( 'contextmenu', this._onContextMenu );
+		this.domElement.removeEventListener('pointerdown', this._onPointerDown);
+		this.domElement.ownerDocument.removeEventListener('pointermove', this._onPointerMove);
+		this.domElement.ownerDocument.removeEventListener('pointerup', this._onPointerUp);
+		this.domElement.removeEventListener('pointercancel', this._onPointerCancel);
+		this.domElement.removeEventListener('pointerleave', this._onPointerCancel);
+		this.domElement.removeEventListener('wheel', this._onMouseWheel);
+		this.domElement.removeEventListener('contextmenu', this._onContextMenu);
 
 		this.domElement.style.touchAction = 'auto'; // disable touch scroll
 
@@ -325,58 +327,58 @@ class TrackballControls extends Controls {
 
 	update() {
 
-		this._eye.subVectors( this.object.position, this.target );
+		this._eye.subVectors(this.object.position, this.target);
 
-		if ( ! this.noRotate ) {
+		if (!this.noRotate) {
 
 			this._rotateCamera();
 
 		}
 
-		if ( ! this.noZoom ) {
+		if (!this.noZoom) {
 
 			this._zoomCamera();
 
 		}
 
-		if ( ! this.noPan ) {
+		if (!this.noPan) {
 
 			this._panCamera();
 
 		}
 
-		this.object.position.addVectors( this.target, this._eye );
+		this.object.position.addVectors(this.target, this._eye);
 
-		if ( this.object.isPerspectiveCamera ) {
+		if (this.object.isPerspectiveCamera) {
 
 			this._checkDistances();
 
-			this.object.lookAt( this.target );
+			this.object.lookAt(this.target);
 
-			if ( this._lastPosition.distanceToSquared( this.object.position ) > _EPS ) {
+			if (this._lastPosition.distanceToSquared(this.object.position) > _EPS) {
 
-				this.dispatchEvent( _changeEvent );
+				this.dispatchEvent(_changeEvent);
 
-				this._lastPosition.copy( this.object.position );
+				this._lastPosition.copy(this.object.position);
 
 			}
 
-		} else if ( this.object.isOrthographicCamera ) {
+		} else if (this.object.isOrthographicCamera) {
 
-			this.object.lookAt( this.target );
+			this.object.lookAt(this.target);
 
-			if ( this._lastPosition.distanceToSquared( this.object.position ) > _EPS || this._lastZoom !== this.object.zoom ) {
+			if (this._lastPosition.distanceToSquared(this.object.position) > _EPS || this._lastZoom !== this.object.zoom) {
 
-				this.dispatchEvent( _changeEvent );
+				this.dispatchEvent(_changeEvent);
 
-				this._lastPosition.copy( this.object.position );
+				this._lastPosition.copy(this.object.position);
 				this._lastZoom = this.object.zoom;
 
 			}
 
 		} else {
 
-			console.warn( 'THREE.TrackballControls: Unsupported camera type.' );
+			console.warn('THREE.TrackballControls: Unsupported camera type.');
 
 		}
 
@@ -390,55 +392,55 @@ class TrackballControls extends Controls {
 		this.state = _STATE.NONE;
 		this.keyState = _STATE.NONE;
 
-		this.target.copy( this._target0 );
-		this.object.position.copy( this._position0 );
-		this.object.up.copy( this._up0 );
+		this.target.copy(this._target0);
+		this.object.position.copy(this._position0);
+		this.object.up.copy(this._up0);
 		this.object.zoom = this._zoom0;
 
 		this.object.updateProjectionMatrix();
 
-		this._eye.subVectors( this.object.position, this.target );
+		this._eye.subVectors(this.object.position, this.target);
 
-		this.object.lookAt( this.target );
+		this.object.lookAt(this.target);
 
-		this.dispatchEvent( _changeEvent );
+		this.dispatchEvent(_changeEvent);
 
-		this._lastPosition.copy( this.object.position );
+		this._lastPosition.copy(this.object.position);
 		this._lastZoom = this.object.zoom;
 
 	}
 
 	_panCamera() {
 
-		_mouseChange.copy( this._panEnd ).sub( this._panStart );
+		_mouseChange.copy(this._panEnd).sub(this._panStart);
 
-		if ( _mouseChange.lengthSq() ) {
+		if (_mouseChange.lengthSq()) {
 
-			if ( this.object.isOrthographicCamera ) {
+			if (this.object.isOrthographicCamera) {
 
-				const scale_x = ( this.object.right - this.object.left ) / this.object.zoom / this.domElement.clientWidth;
-				const scale_y = ( this.object.top - this.object.bottom ) / this.object.zoom / this.domElement.clientWidth;
+				const scale_x = (this.object.right - this.object.left) / this.object.zoom / this.domElement.clientWidth;
+				const scale_y = (this.object.top - this.object.bottom) / this.object.zoom / this.domElement.clientWidth;
 
 				_mouseChange.x *= scale_x;
 				_mouseChange.y *= scale_y;
 
 			}
 
-			_mouseChange.multiplyScalar( this._eye.length() * this.panSpeed );
+			_mouseChange.multiplyScalar(this._eye.length() * this.panSpeed);
 
-			_pan.copy( this._eye ).cross( this.object.up ).setLength( _mouseChange.x );
-			_pan.add( _objectUp.copy( this.object.up ).setLength( _mouseChange.y ) );
+			_pan.copy(this._eye).cross(this.object.up).setLength(_mouseChange.x);
+			_pan.add(_objectUp.copy(this.object.up).setLength(_mouseChange.y));
 
-			this.object.position.add( _pan );
-			this.target.add( _pan );
+			this.object.position.add(_pan);
+			this.target.add(_pan);
 
-			if ( this.staticMoving ) {
+			if (this.staticMoving) {
 
-				this._panStart.copy( this._panEnd );
+				this._panStart.copy(this._panEnd);
 
 			} else {
 
-				this._panStart.add( _mouseChange.subVectors( this._panEnd, this._panStart ).multiplyScalar( this.dynamicDampingFactor ) );
+				this._panStart.add(_mouseChange.subVectors(this._panEnd, this._panStart).multiplyScalar(this.dynamicDampingFactor));
 
 			}
 
@@ -448,44 +450,44 @@ class TrackballControls extends Controls {
 
 	_rotateCamera() {
 
-		_moveDirection.set( this._moveCurr.x - this._movePrev.x, this._moveCurr.y - this._movePrev.y, 0 );
+		_moveDirection.set(this._moveCurr.x - this._movePrev.x, this._moveCurr.y - this._movePrev.y, 0);
 		let angle = _moveDirection.length();
 
-		if ( angle ) {
+		if (angle) {
 
-			this._eye.copy( this.object.position ).sub( this.target );
+			this._eye.copy(this.object.position).sub(this.target);
 
-			_eyeDirection.copy( this._eye ).normalize();
-			_objectUpDirection.copy( this.object.up ).normalize();
-			_objectSidewaysDirection.crossVectors( _objectUpDirection, _eyeDirection ).normalize();
+			_eyeDirection.copy(this._eye).normalize();
+			_objectUpDirection.copy(this.object.up).normalize();
+			_objectSidewaysDirection.crossVectors(_objectUpDirection, _eyeDirection).normalize();
 
-			_objectUpDirection.setLength( this._moveCurr.y - this._movePrev.y );
-			_objectSidewaysDirection.setLength( this._moveCurr.x - this._movePrev.x );
+			_objectUpDirection.setLength(this._moveCurr.y - this._movePrev.y);
+			_objectSidewaysDirection.setLength(this._moveCurr.x - this._movePrev.x);
 
-			_moveDirection.copy( _objectUpDirection.add( _objectSidewaysDirection ) );
+			_moveDirection.copy(_objectUpDirection.add(_objectSidewaysDirection));
 
-			_axis.crossVectors( _moveDirection, this._eye ).normalize();
+			_axis.crossVectors(_moveDirection, this._eye).normalize();
 
 			angle *= this.rotateSpeed;
-			_quaternion.setFromAxisAngle( _axis, angle );
+			_quaternion.setFromAxisAngle(_axis, angle);
 
-			this._eye.applyQuaternion( _quaternion );
-			this.object.up.applyQuaternion( _quaternion );
+			this._eye.applyQuaternion(_quaternion);
+			this.object.up.applyQuaternion(_quaternion);
 
-			this._lastAxis.copy( _axis );
+			this._lastAxis.copy(_axis);
 			this._lastAngle = angle;
 
-		} else if ( ! this.staticMoving && this._lastAngle ) {
+		} else if (!this.staticMoving && this._lastAngle) {
 
-			this._lastAngle *= Math.sqrt( 1.0 - this.dynamicDampingFactor );
-			this._eye.copy( this.object.position ).sub( this.target );
-			_quaternion.setFromAxisAngle( this._lastAxis, this._lastAngle );
-			this._eye.applyQuaternion( _quaternion );
-			this.object.up.applyQuaternion( _quaternion );
+			this._lastAngle *= Math.sqrt(1.0 - this.dynamicDampingFactor);
+			this._eye.copy(this.object.position).sub(this.target);
+			_quaternion.setFromAxisAngle(this._lastAxis, this._lastAngle);
+			this._eye.applyQuaternion(_quaternion);
+			this.object.up.applyQuaternion(_quaternion);
 
 		}
 
-		this._movePrev.copy( this._moveCurr );
+		this._movePrev.copy(this._moveCurr);
 
 	}
 
@@ -493,20 +495,20 @@ class TrackballControls extends Controls {
 
 		let factor;
 
-		if ( this.state === _STATE.TOUCH_ZOOM_PAN ) {
+		if (this.state === _STATE.TOUCH_ZOOM_PAN) {
 
 			factor = this._touchZoomDistanceStart / this._touchZoomDistanceEnd;
 			this._touchZoomDistanceStart = this._touchZoomDistanceEnd;
 
-			if ( this.object.isPerspectiveCamera ) {
+			if (this.object.isPerspectiveCamera) {
 
-				this._eye.multiplyScalar( factor );
+				this._eye.multiplyScalar(factor);
 
-			} else if ( this.object.isOrthographicCamera ) {
+			} else if (this.object.isOrthographicCamera) {
 
-				this.object.zoom = MathUtils.clamp( this.object.zoom / factor, this.minZoom, this.maxZoom );
+				this.object.zoom = MathUtils.clamp(this.object.zoom / factor, this.minZoom, this.maxZoom);
 
-				if ( this._lastZoom !== this.object.zoom ) {
+				if (this._lastZoom !== this.object.zoom) {
 
 					this.object.updateProjectionMatrix();
 
@@ -514,25 +516,25 @@ class TrackballControls extends Controls {
 
 			} else {
 
-				console.warn( 'THREE.TrackballControls: Unsupported camera type' );
+				console.warn('THREE.TrackballControls: Unsupported camera type');
 
 			}
 
 		} else {
 
-			factor = 1.0 + ( this._zoomEnd.y - this._zoomStart.y ) * this.zoomSpeed;
+			factor = 1.0 + (this._zoomEnd.y - this._zoomStart.y) * this.zoomSpeed;
 
-			if ( factor !== 1.0 && factor > 0.0 ) {
+			if (factor !== 1.0 && factor > 0.0) {
 
-				if ( this.object.isPerspectiveCamera ) {
+				if (this.object.isPerspectiveCamera) {
 
-					this._eye.multiplyScalar( factor );
+					this._eye.multiplyScalar(factor);
 
-				} else if ( this.object.isOrthographicCamera ) {
+				} else if (this.object.isOrthographicCamera) {
 
-					this.object.zoom = MathUtils.clamp( this.object.zoom / factor, this.minZoom, this.maxZoom );
+					this.object.zoom = MathUtils.clamp(this.object.zoom / factor, this.minZoom, this.maxZoom);
 
-					if ( this._lastZoom !== this.object.zoom ) {
+					if (this._lastZoom !== this.object.zoom) {
 
 						this.object.updateProjectionMatrix();
 
@@ -540,19 +542,19 @@ class TrackballControls extends Controls {
 
 				} else {
 
-					console.warn( 'THREE.TrackballControls: Unsupported camera type' );
+					console.warn('THREE.TrackballControls: Unsupported camera type');
 
 				}
 
 			}
 
-			if ( this.staticMoving ) {
+			if (this.staticMoving) {
 
-				this._zoomStart.copy( this._zoomEnd );
+				this._zoomStart.copy(this._zoomEnd);
 
 			} else {
 
-				this._zoomStart.y += ( this._zoomEnd.y - this._zoomStart.y ) * this.dynamicDampingFactor;
+				this._zoomStart.y += (this._zoomEnd.y - this._zoomStart.y) * this.dynamicDampingFactor;
 
 			}
 
@@ -560,43 +562,43 @@ class TrackballControls extends Controls {
 
 	}
 
-	_getMouseOnScreen( pageX, pageY ) {
+	_getMouseOnScreen(pageX, pageY) {
 
 		_v2.set(
-			( pageX - this.screen.left ) / this.screen.width,
-			( pageY - this.screen.top ) / this.screen.height
+			(pageX - this.screen.left) / this.screen.width,
+			(pageY - this.screen.top) / this.screen.height
 		);
 
 		return _v2;
 
 	}
 
-	_getMouseOnCircle( pageX, pageY ) {
+	_getMouseOnCircle(pageX, pageY) {
 
 		_v2.set(
-			( ( pageX - this.screen.width * 0.5 - this.screen.left ) / ( this.screen.width * 0.5 ) ),
-			( ( this.screen.height + 2 * ( this.screen.top - pageY ) ) / this.screen.width ) // screen.width intentional
+			((pageX - this.screen.width * 0.5 - this.screen.left) / (this.screen.width * 0.5)),
+			((this.screen.height + 2 * (this.screen.top - pageY)) / this.screen.width) // screen.width intentional
 		);
 
 		return _v2;
 
 	}
 
-	_addPointer( event ) {
+	_addPointer(event) {
 
-		this._pointers.push( event );
+		this._pointers.push(event);
 
 	}
 
-	_removePointer( event ) {
+	_removePointer(event) {
 
-		delete this._pointerPositions[ event.pointerId ];
+		delete this._pointerPositions[event.pointerId];
 
-		for ( let i = 0; i < this._pointers.length; i ++ ) {
+		for (let i = 0; i < this._pointers.length; i++) {
 
-			if ( this._pointers[ i ].pointerId == event.pointerId ) {
+			if (this._pointers[i].pointerId == event.pointerId) {
 
-				this._pointers.splice( i, 1 );
+				this._pointers.splice(i, 1);
 				return;
 
 			}
@@ -605,44 +607,44 @@ class TrackballControls extends Controls {
 
 	}
 
-	_trackPointer( event ) {
+	_trackPointer(event) {
 
-		let position = this._pointerPositions[ event.pointerId ];
+		let position = this._pointerPositions[event.pointerId];
 
-		if ( position === undefined ) {
+		if (position === undefined) {
 
 			position = new Vector2();
-			this._pointerPositions[ event.pointerId ] = position;
+			this._pointerPositions[event.pointerId] = position;
 
 		}
 
-		position.set( event.pageX, event.pageY );
+		position.set(event.pageX, event.pageY);
 
 	}
 
-	_getSecondPointerPosition( event ) {
+	_getSecondPointerPosition(event) {
 
-		const pointer = ( event.pointerId === this._pointers[ 0 ].pointerId ) ? this._pointers[ 1 ] : this._pointers[ 0 ];
+		const pointer = (event.pointerId === this._pointers[0].pointerId) ? this._pointers[1] : this._pointers[0];
 
-		return this._pointerPositions[ pointer.pointerId ];
+		return this._pointerPositions[pointer.pointerId];
 
 	}
 
 	_checkDistances() {
 
-		if ( ! this.noZoom || ! this.noPan ) {
+		if (!this.noZoom || !this.noPan) {
 
-			if ( this._eye.lengthSq() > this.maxDistance * this.maxDistance ) {
+			if (this._eye.lengthSq() > this.maxDistance * this.maxDistance) {
 
-				this.object.position.addVectors( this.target, this._eye.setLength( this.maxDistance ) );
-				this._zoomStart.copy( this._zoomEnd );
+				this.object.position.addVectors(this.target, this._eye.setLength(this.maxDistance));
+				this._zoomStart.copy(this._zoomEnd);
 
 			}
 
-			if ( this._eye.lengthSq() < this.minDistance * this.minDistance ) {
+			if (this._eye.lengthSq() < this.minDistance * this.minDistance) {
 
-				this.object.position.addVectors( this.target, this._eye.setLength( this.minDistance ) );
-				this._zoomStart.copy( this._zoomEnd );
+				this.object.position.addVectors(this.target, this._eye.setLength(this.minDistance));
+				this._zoomStart.copy(this._zoomEnd);
 
 			}
 
@@ -652,58 +654,58 @@ class TrackballControls extends Controls {
 
 }
 
-function onPointerDown( event ) {
+function onPointerDown(event) {
 
-	if ( this.enabled === false ) return;
+	if (this.enabled === false) return;
 
-	if ( this._pointers.length === 0 ) {
+	if (this._pointers.length === 0) {
 
-		this.domElement.setPointerCapture( event.pointerId );
+		this.domElement.setPointerCapture(event.pointerId);
 
-		this.domElement.ownerDocument.addEventListener( 'pointermove', this._onPointerMove );
-		this.domElement.ownerDocument.addEventListener( 'pointerup', this._onPointerUp );
+		this.domElement.ownerDocument.addEventListener('pointermove', this._onPointerMove);
+		this.domElement.ownerDocument.addEventListener('pointerup', this._onPointerUp);
 
 	}
 
 	//
 
-	this._addPointer( event );
+	this._addPointer(event);
 
-	if ( event.pointerType === 'touch' ) {
+	if (event.pointerType === 'touch') {
 
-		this._onTouchStart( event );
+		this._onTouchStart(event);
 
 	} else {
 
-		this._onMouseDown( event );
+		this._onMouseDown(event);
 
 	}
 
 }
 
-function onPointerMove( event ) {
+function onPointerMove(event) {
 
-	if ( this.enabled === false ) return;
+	if (this.enabled === false) return;
 
-	if ( event.pointerType === 'touch' ) {
+	if (event.pointerType === 'touch') {
 
-		this._onTouchMove( event );
+		this._onTouchMove(event);
 
 	} else {
 
-		this._onMouseMove( event );
+		this._onMouseMove(event);
 
 	}
 
 }
 
-function onPointerUp( event ) {
+function onPointerUp(event) {
 
-	if ( this.enabled === false ) return;
+	if (this.enabled === false) return;
 
-	if ( event.pointerType === 'touch' ) {
+	if (event.pointerType === 'touch') {
 
-		this._onTouchEnd( event );
+		this._onTouchEnd(event);
 
 	} else {
 
@@ -713,54 +715,54 @@ function onPointerUp( event ) {
 
 	//
 
-	this._removePointer( event );
+	this._removePointer(event);
 
-	if ( this._pointers.length === 0 ) {
+	if (this._pointers.length === 0) {
 
-		this.domElement.releasePointerCapture( event.pointerId );
+		this.domElement.releasePointerCapture(event.pointerId);
 
-		this.domElement.ownerDocument.removeEventListener( 'pointermove', this._onPointerMove );
-		this.domElement.ownerDocument.removeEventListener( 'pointerup', this._onPointerUp );
+		this.domElement.ownerDocument.removeEventListener('pointermove', this._onPointerMove);
+		this.domElement.ownerDocument.removeEventListener('pointerup', this._onPointerUp);
 
 	}
 
 }
 
-function onPointerCancel( event ) {
+function onPointerCancel(event) {
 
-	this._removePointer( event );
+	this._removePointer(event);
 
 }
 
 function onKeyUp() {
 
-	if ( this.enabled === false ) return;
+	if (this.enabled === false) return;
 
 	this.keyState = _STATE.NONE;
 
-	window.addEventListener( 'keydown', this._onKeyDown );
+	window.addEventListener('keydown', this._onKeyDown);
 
 }
 
-function onKeyDown( event ) {
+function onKeyDown(event) {
 
-	if ( this.enabled === false ) return;
+	if (this.enabled === false) return;
 
-	window.removeEventListener( 'keydown', this._onKeyDown );
+	window.removeEventListener('keydown', this._onKeyDown);
 
-	if ( this.keyState !== _STATE.NONE ) {
+	if (this.keyState !== _STATE.NONE) {
 
 		return;
 
-	} else if ( event.code === this.keys[ _STATE.ROTATE ] && ! this.noRotate ) {
+	} else if (event.code === this.keys[_STATE.ROTATE] && !this.noRotate) {
 
 		this.keyState = _STATE.ROTATE;
 
-	} else if ( event.code === this.keys[ _STATE.ZOOM ] && ! this.noZoom ) {
+	} else if (event.code === this.keys[_STATE.ZOOM] && !this.noZoom) {
 
 		this.keyState = _STATE.ZOOM;
 
-	} else if ( event.code === this.keys[ _STATE.PAN ] && ! this.noPan ) {
+	} else if (event.code === this.keys[_STATE.PAN] && !this.noPan) {
 
 		this.keyState = _STATE.PAN;
 
@@ -768,11 +770,11 @@ function onKeyDown( event ) {
 
 }
 
-function onMouseDown( event ) {
+function onMouseDown(event) {
 
 	let mouseAction;
 
-	switch ( event.button ) {
+	switch (event.button) {
 
 		case 0:
 			mouseAction = this.mouseButtons.LEFT;
@@ -791,7 +793,7 @@ function onMouseDown( event ) {
 
 	}
 
-	switch ( mouseAction ) {
+	switch (mouseAction) {
 
 		case MOUSE.DOLLY:
 			this.state = _STATE.ZOOM;
@@ -810,45 +812,44 @@ function onMouseDown( event ) {
 
 	}
 
-	const state = ( this.keyState !== _STATE.NONE ) ? this.keyState : this.state;
+	const state = (this.keyState !== _STATE.NONE) ? this.keyState : this.state;
 
-	if ( state === _STATE.ROTATE && ! this.noRotate ) {
+	if (state === _STATE.ROTATE && !this.noRotate) {
 
-		this._moveCurr.copy( this._getMouseOnCircle( event.pageX, event.pageY ) );
-		this._movePrev.copy( this._moveCurr );
+		this._moveCurr.copy(this._getMouseOnCircle(event.pageX, event.pageY));
+		this._movePrev.copy(this._moveCurr);
 
-	} else if ( state === _STATE.ZOOM && ! this.noZoom ) {
+	} else if (state === _STATE.ZOOM && !this.noZoom) {
 
-		this._zoomStart.copy( this._getMouseOnScreen( event.pageX, event.pageY ) );
-		this._zoomEnd.copy( this._zoomStart );
+		this._zoomStart.copy(this._getMouseOnScreen(event.pageX, event.pageY));
+		this._zoomEnd.copy(this._zoomStart);
 
-	} else if ( state === _STATE.PAN && ! this.noPan ) {
+	} else if (state === _STATE.PAN && !this.noPan) {
 
-		this._panStart.copy( this._getMouseOnScreen( event.pageX, event.pageY ) );
-		this._panEnd.copy( this._panStart );
+		this._panStart.copy(this._getMouseOnScreen(event.pageX, event.pageY));
+		this._panEnd.copy(this._panStart);
 
 	}
 
-	this.dispatchEvent( _startEvent );
+	this.dispatchEvent(_startEvent);
 
 }
 
-function onMouseMove( event ) {
+function onMouseMove(event) {
 
-	const state = ( this.keyState !== _STATE.NONE ) ? this.keyState : this.state;
+	const state = (this.keyState !== _STATE.NONE) ? this.keyState : this.state;
 
-	if ( state === _STATE.ROTATE && ! this.noRotate ) {
+	if (state === _STATE.ROTATE && !this.noRotate) {
 
-		this._movePrev.copy( this._moveCurr );
-		this._moveCurr.copy( this._getMouseOnCircle( event.pageX, event.pageY ) );
+		this._moveCurr.copy(this._getMouseOnCircle(event.pageX, event.pageY));
 
-	} else if ( state === _STATE.ZOOM && ! this.noZoom ) {
+	} else if (state === _STATE.ZOOM && !this.noZoom) {
 
-		this._zoomEnd.copy( this._getMouseOnScreen( event.pageX, event.pageY ) );
+		this._zoomEnd.copy(this._getMouseOnScreen(event.pageX, event.pageY));
 
-	} else if ( state === _STATE.PAN && ! this.noPan ) {
+	} else if (state === _STATE.PAN && !this.noPan) {
 
-		this._panEnd.copy( this._getMouseOnScreen( event.pageX, event.pageY ) );
+		this._panEnd.copy(this._getMouseOnScreen(event.pageX, event.pageY));
 
 	}
 
@@ -858,19 +859,19 @@ function onMouseUp() {
 
 	this.state = _STATE.NONE;
 
-	this.dispatchEvent( _endEvent );
+	this.dispatchEvent(_endEvent);
 
 }
 
-function onMouseWheel( event ) {
+function onMouseWheel(event) {
 
-	if ( this.enabled === false ) return;
+	if (this.enabled === false) return;
 
-	if ( this.noZoom === true ) return;
+	if (this.noZoom === true) return;
 
 	event.preventDefault();
 
-	switch ( event.deltaMode ) {
+	switch (event.deltaMode) {
 
 		case 2:
 			// Zoom in pages
@@ -889,80 +890,79 @@ function onMouseWheel( event ) {
 
 	}
 
-	this.dispatchEvent( _startEvent );
-	this.dispatchEvent( _endEvent );
+	this.dispatchEvent(_startEvent);
+	this.dispatchEvent(_endEvent);
 
 }
 
-function onContextMenu( event ) {
+function onContextMenu(event) {
 
-	if ( this.enabled === false ) return;
+	if (this.enabled === false) return;
 
 	event.preventDefault();
 
 }
 
-function onTouchStart( event ) {
+function onTouchStart(event) {
 
-	this._trackPointer( event );
+	this._trackPointer(event);
 
-	switch ( this._pointers.length ) {
+	switch (this._pointers.length) {
 
 		case 1:
 			this.state = _STATE.TOUCH_ROTATE;
-			this._moveCurr.copy( this._getMouseOnCircle( this._pointers[ 0 ].pageX, this._pointers[ 0 ].pageY ) );
-			this._movePrev.copy( this._moveCurr );
+			this._moveCurr.copy(this._getMouseOnCircle(this._pointers[0].pageX, this._pointers[0].pageY));
+			this._movePrev.copy(this._moveCurr);
 			break;
 
 		default: // 2 or more
 			this.state = _STATE.TOUCH_ZOOM_PAN;
-			const dx = this._pointers[ 0 ].pageX - this._pointers[ 1 ].pageX;
-			const dy = this._pointers[ 0 ].pageY - this._pointers[ 1 ].pageY;
-			this._touchZoomDistanceEnd = this._touchZoomDistanceStart = Math.sqrt( dx * dx + dy * dy );
+			const dx = this._pointers[0].pageX - this._pointers[1].pageX;
+			const dy = this._pointers[0].pageY - this._pointers[1].pageY;
+			this._touchZoomDistanceEnd = this._touchZoomDistanceStart = Math.sqrt(dx * dx + dy * dy);
 
-			const x = ( this._pointers[ 0 ].pageX + this._pointers[ 1 ].pageX ) / 2;
-			const y = ( this._pointers[ 0 ].pageY + this._pointers[ 1 ].pageY ) / 2;
-			this._panStart.copy( this._getMouseOnScreen( x, y ) );
-			this._panEnd.copy( this._panStart );
+			const x = (this._pointers[0].pageX + this._pointers[1].pageX) / 2;
+			const y = (this._pointers[0].pageY + this._pointers[1].pageY) / 2;
+			this._panStart.copy(this._getMouseOnScreen(x, y));
+			this._panEnd.copy(this._panStart);
 			break;
 
 	}
 
-	this.dispatchEvent( _startEvent );
+	this.dispatchEvent(_startEvent);
 
 }
 
-function onTouchMove( event ) {
+function onTouchMove(event) {
 
-	this._trackPointer( event );
+	this._trackPointer(event);
 
-	switch ( this._pointers.length ) {
+	switch (this._pointers.length) {
 
 		case 1:
-			this._movePrev.copy( this._moveCurr );
-			this._moveCurr.copy( this._getMouseOnCircle( event.pageX, event.pageY ) );
+			this._moveCurr.copy(this._getMouseOnCircle(event.pageX, event.pageY));
 			break;
 
 		default: // 2 or more
 
-			const position = this._getSecondPointerPosition( event );
+			const position = this._getSecondPointerPosition(event);
 
 			const dx = event.pageX - position.x;
 			const dy = event.pageY - position.y;
-			this._touchZoomDistanceEnd = Math.sqrt( dx * dx + dy * dy );
+			this._touchZoomDistanceEnd = Math.sqrt(dx * dx + dy * dy);
 
-			const x = ( event.pageX + position.x ) / 2;
-			const y = ( event.pageY + position.y ) / 2;
-			this._panEnd.copy( this._getMouseOnScreen( x, y ) );
+			const x = (event.pageX + position.x) / 2;
+			const y = (event.pageY + position.y) / 2;
+			this._panEnd.copy(this._getMouseOnScreen(x, y));
 			break;
 
 	}
 
 }
 
-function onTouchEnd( event ) {
+function onTouchEnd(event) {
 
-	switch ( this._pointers.length ) {
+	switch (this._pointers.length) {
 
 		case 0:
 			this.state = _STATE.NONE;
@@ -970,20 +970,20 @@ function onTouchEnd( event ) {
 
 		case 1:
 			this.state = _STATE.TOUCH_ROTATE;
-			this._moveCurr.copy( this._getMouseOnCircle( event.pageX, event.pageY ) );
-			this._movePrev.copy( this._moveCurr );
+			this._moveCurr.copy(this._getMouseOnCircle(event.pageX, event.pageY));
+			this._movePrev.copy(this._moveCurr);
 			break;
 
 		case 2:
 			this.state = _STATE.TOUCH_ZOOM_PAN;
 
-			for ( let i = 0; i < this._pointers.length; i ++ ) {
+			for (let i = 0; i < this._pointers.length; i++) {
 
-				if ( this._pointers[ i ].pointerId !== event.pointerId ) {
+				if (this._pointers[i].pointerId !== event.pointerId) {
 
-					const position = this._pointerPositions[ this._pointers[ i ].pointerId ];
-					this._moveCurr.copy( this._getMouseOnCircle( position.x, position.y ) );
-					this._movePrev.copy( this._moveCurr );
+					const position = this._pointerPositions[this._pointers[i].pointerId];
+					this._moveCurr.copy(this._getMouseOnCircle(position.x, position.y));
+					this._movePrev.copy(this._moveCurr);
 					break;
 
 				}
@@ -994,7 +994,7 @@ function onTouchEnd( event ) {
 
 	}
 
-	this.dispatchEvent( _endEvent );
+	this.dispatchEvent(_endEvent);
 
 }
 

--- a/examples/jsm/renderers/CSS2DRenderer.js
+++ b/examples/jsm/renderers/CSS2DRenderer.js
@@ -18,7 +18,7 @@ class CSS2DObject extends Object3D {
 	 *
 	 * @param {HTMLElement} [element] - The DOM element.
 	 */
-	constructor( element = document.createElement( 'div' ) ) {
+	constructor(element = document.createElement('div')) {
 
 		super();
 
@@ -43,7 +43,7 @@ class CSS2DObject extends Object3D {
 		this.element.style.position = 'absolute';
 		this.element.style.userSelect = 'none';
 
-		this.element.setAttribute( 'draggable', false );
+		this.element.setAttribute('draggable', false);
 
 		/**
 		 * The 3D objects center point.
@@ -52,11 +52,11 @@ class CSS2DObject extends Object3D {
 		 * @type {Vector2}
 		 * @default (0.5,0.5)
 		 */
-		this.center = new Vector2( 0.5, 0.5 );
+		this.center = new Vector2(0.5, 0.5);
 
-		this.addEventListener( 'removed', function () {
+		this.addEventListener('removed', function () {
 
-			this.traverse( function ( object ) {
+			this.traverse(function (object) {
 
 				if (
 					object.element &&
@@ -68,17 +68,17 @@ class CSS2DObject extends Object3D {
 
 				}
 
-			} );
+			});
 
-		} );
+		});
 
 	}
 
-	copy( source, recursive ) {
+	copy(source, recursive) {
 
-		super.copy( source, recursive );
+		super.copy(source, recursive);
 
-		this.element = source.element.cloneNode( true );
+		this.element = source.element.cloneNode(true);
 
 		this.center = source.center;
 
@@ -115,7 +115,7 @@ class CSS2DRenderer {
 	 *
 	 * @param {CSS2DRenderer~Parameters} [parameters] - The parameters.
 	 */
-	constructor( parameters = {} ) {
+	constructor(parameters = {}) {
 
 		const _this = this;
 
@@ -126,9 +126,11 @@ class CSS2DRenderer {
 			objects: new WeakMap()
 		};
 
-		const domElement = parameters.element !== undefined ? parameters.element : document.createElement( 'div' );
+		const domElement = parameters.element !== undefined ? parameters.element : document.createElement('div');
 
 		domElement.style.overflow = 'hidden';
+
+		if (domElement.style.position === '') domElement.style.position = 'relative';
 
 		/**
 		 * The DOM where the renderer appends its child-elements.
@@ -167,16 +169,16 @@ class CSS2DRenderer {
 		 * @param {Object3D} scene - A scene or any other type of 3D object.
 		 * @param {Camera} camera - The camera.
 		 */
-		this.render = function ( scene, camera ) {
+		this.render = function (scene, camera) {
 
-			if ( scene.matrixWorldAutoUpdate === true ) scene.updateMatrixWorld();
-			if ( camera.parent === null && camera.matrixWorldAutoUpdate === true ) camera.updateMatrixWorld();
+			if (scene.matrixWorldAutoUpdate === true) scene.updateMatrixWorld();
+			if (camera.parent === null && camera.matrixWorldAutoUpdate === true) camera.updateMatrixWorld();
 
-			_viewMatrix.copy( camera.matrixWorldInverse );
-			_viewProjectionMatrix.multiplyMatrices( camera.projectionMatrix, _viewMatrix );
+			_viewMatrix.copy(camera.matrixWorldInverse);
+			_viewProjectionMatrix.multiplyMatrices(camera.projectionMatrix, _viewMatrix);
 
-			renderObject( scene, scene, camera );
-			if ( this.sortObjects ) zOrder( scene );
+			renderObject(scene, scene, camera);
+			if (this.sortObjects) zOrder(scene);
 
 		};
 
@@ -186,7 +188,7 @@ class CSS2DRenderer {
 		 * @param {number} width - The width of the renderer.
 		 * @param {number} height - The height of the renderer.
 		 */
-		this.setSize = function ( width, height ) {
+		this.setSize = function (width, height) {
 
 			_width = width;
 			_height = height;
@@ -199,115 +201,115 @@ class CSS2DRenderer {
 
 		};
 
-		function hideObject( object ) {
+		function hideObject(object) {
 
-			if ( object.isCSS2DObject ) object.element.style.display = 'none';
+			if (object.isCSS2DObject) object.element.style.display = 'none';
 
-			for ( let i = 0, l = object.children.length; i < l; i ++ ) {
+			for (let i = 0, l = object.children.length; i < l; i++) {
 
-				hideObject( object.children[ i ] );
+				hideObject(object.children[i]);
 
 			}
 
 		}
 
-		function renderObject( object, scene, camera ) {
+		function renderObject(object, scene, camera) {
 
-			if ( object.visible === false ) {
+			if (object.visible === false) {
 
-				hideObject( object );
+				hideObject(object);
 
 				return;
 
 			}
 
-			if ( object.isCSS2DObject ) {
+			if (object.isCSS2DObject) {
 
-				_vector.setFromMatrixPosition( object.matrixWorld );
-				_vector.applyMatrix4( _viewProjectionMatrix );
+				_vector.setFromMatrixPosition(object.matrixWorld);
+				_vector.applyMatrix4(_viewProjectionMatrix);
 
-				const visible = ( _vector.z >= - 1 && _vector.z <= 1 ) && ( object.layers.test( camera.layers ) === true );
+				const visible = (_vector.z >= - 1 && _vector.z <= 1) && (object.layers.test(camera.layers) === true);
 
 				const element = object.element;
 				element.style.display = visible === true ? '' : 'none';
 
-				if ( visible === true ) {
+				if (visible === true) {
 
-					object.onBeforeRender( _this, scene, camera );
+					object.onBeforeRender(_this, scene, camera);
 
-					element.style.transform = 'translate(' + ( - 100 * object.center.x ) + '%,' + ( - 100 * object.center.y ) + '%)' + 'translate(' + ( _vector.x * _widthHalf + _widthHalf ) + 'px,' + ( - _vector.y * _heightHalf + _heightHalf ) + 'px)';
+					element.style.transform = 'translate(' + (- 100 * object.center.x) + '%,' + (- 100 * object.center.y) + '%)' + 'translate(' + (_vector.x * _widthHalf + _widthHalf) + 'px,' + (- _vector.y * _heightHalf + _heightHalf) + 'px)';
 
-					if ( element.parentNode !== domElement ) {
+					if (element.parentNode !== domElement) {
 
-						domElement.appendChild( element );
+						domElement.appendChild(element);
 
 					}
 
-					object.onAfterRender( _this, scene, camera );
+					object.onAfterRender(_this, scene, camera);
 
 				}
 
 				const objectData = {
-					distanceToCameraSquared: getDistanceToSquared( camera, object )
+					distanceToCameraSquared: getDistanceToSquared(camera, object)
 				};
 
-				cache.objects.set( object, objectData );
+				cache.objects.set(object, objectData);
 
 			}
 
-			for ( let i = 0, l = object.children.length; i < l; i ++ ) {
+			for (let i = 0, l = object.children.length; i < l; i++) {
 
-				renderObject( object.children[ i ], scene, camera );
+				renderObject(object.children[i], scene, camera);
 
 			}
 
 		}
 
-		function getDistanceToSquared( object1, object2 ) {
+		function getDistanceToSquared(object1, object2) {
 
-			_a.setFromMatrixPosition( object1.matrixWorld );
-			_b.setFromMatrixPosition( object2.matrixWorld );
+			_a.setFromMatrixPosition(object1.matrixWorld);
+			_b.setFromMatrixPosition(object2.matrixWorld);
 
-			return _a.distanceToSquared( _b );
+			return _a.distanceToSquared(_b);
 
 		}
 
-		function filterAndFlatten( scene ) {
+		function filterAndFlatten(scene) {
 
 			const result = [];
 
-			scene.traverseVisible( function ( object ) {
+			scene.traverseVisible(function (object) {
 
-				if ( object.isCSS2DObject ) result.push( object );
+				if (object.isCSS2DObject) result.push(object);
 
-			} );
+			});
 
 			return result;
 
 		}
 
-		function zOrder( scene ) {
+		function zOrder(scene) {
 
-			const sorted = filterAndFlatten( scene ).sort( function ( a, b ) {
+			const sorted = filterAndFlatten(scene).sort(function (a, b) {
 
-				if ( a.renderOrder !== b.renderOrder ) {
+				if (a.renderOrder !== b.renderOrder) {
 
 					return b.renderOrder - a.renderOrder;
 
 				}
 
-				const distanceA = cache.objects.get( a ).distanceToCameraSquared;
-				const distanceB = cache.objects.get( b ).distanceToCameraSquared;
+				const distanceA = cache.objects.get(a).distanceToCameraSquared;
+				const distanceB = cache.objects.get(b).distanceToCameraSquared;
 
 				return distanceA - distanceB;
 
-			} );
+			});
 
 			const zMax = sorted.length;
 
-			for ( let i = 0, l = sorted.length; i < l; i ++ ) {
+			for (let i = 0, l = sorted.length; i < l; i++) {
 
-				sorted[ i ].element.style.zIndex = zMax - i;
+				sorted[i].element.style.zIndex = zMax - i;
 
 			}
 

--- a/examples/jsm/renderers/CSS3DRenderer.js
+++ b/examples/jsm/renderers/CSS3DRenderer.js
@@ -24,7 +24,7 @@ class CSS3DObject extends Object3D {
 	 *
 	 * @param {HTMLElement} [element] - The DOM element.
 	 */
-	constructor( element = document.createElement( 'div' ) ) {
+	constructor(element = document.createElement('div')) {
 
 		super();
 
@@ -49,11 +49,11 @@ class CSS3DObject extends Object3D {
 		this.element.style.pointerEvents = 'auto';
 		this.element.style.userSelect = 'none';
 
-		this.element.setAttribute( 'draggable', false );
+		this.element.setAttribute('draggable', false);
 
-		this.addEventListener( 'removed', function () {
+		this.addEventListener('removed', function () {
 
-			this.traverse( function ( object ) {
+			this.traverse(function (object) {
 
 				if (
 					object.element &&
@@ -65,17 +65,17 @@ class CSS3DObject extends Object3D {
 
 				}
 
-			} );
+			});
 
-		} );
+		});
 
 	}
 
-	copy( source, recursive ) {
+	copy(source, recursive) {
 
-		super.copy( source, recursive );
+		super.copy(source, recursive);
 
-		this.element = source.element.cloneNode( true );
+		this.element = source.element.cloneNode(true);
 
 		return this;
 
@@ -97,9 +97,9 @@ class CSS3DSprite extends CSS3DObject {
 	 *
 	 * @param {HTMLElement} [element] - The DOM element.
 	 */
-	constructor( element ) {
+	constructor(element) {
 
-		super( element );
+		super(element);
 
 		/**
 		 * This flag can be used for type testing.
@@ -120,9 +120,9 @@ class CSS3DSprite extends CSS3DObject {
 
 	}
 
-	copy( source, recursive ) {
+	copy(source, recursive) {
 
-		super.copy( source, recursive );
+		super.copy(source, recursive);
 
 		this.rotation2D = source.rotation2D;
 
@@ -161,7 +161,7 @@ class CSS3DRenderer {
 	 *
 	 * @param {CSS3DRenderer~Parameters} [parameters] - The parameters.
 	 */
-	constructor( parameters = {} ) {
+	constructor(parameters = {}) {
 
 		const _this = this;
 
@@ -173,9 +173,11 @@ class CSS3DRenderer {
 			objects: new WeakMap()
 		};
 
-		const domElement = parameters.element !== undefined ? parameters.element : document.createElement( 'div' );
+		const domElement = parameters.element !== undefined ? parameters.element : document.createElement('div');
 
 		domElement.style.overflow = 'hidden';
+
+		if (domElement.style.position === '') domElement.style.position = 'relative';
 
 		/**
 		 * The DOM where the renderer appends its child-elements.
@@ -184,16 +186,16 @@ class CSS3DRenderer {
 		 */
 		this.domElement = domElement;
 
-		const viewElement = document.createElement( 'div' );
+		const viewElement = document.createElement('div');
 		viewElement.style.transformOrigin = '0 0';
 		viewElement.style.pointerEvents = 'none';
-		domElement.appendChild( viewElement );
+		domElement.appendChild(viewElement);
 
-		const cameraElement = document.createElement( 'div' );
+		const cameraElement = document.createElement('div');
 
 		cameraElement.style.transformStyle = 'preserve-3d';
 
-		viewElement.appendChild( cameraElement );
+		viewElement.appendChild(cameraElement);
 
 		/**
 		 * Returns an object containing the width and height of the renderer.
@@ -215,17 +217,17 @@ class CSS3DRenderer {
 		 * @param {Object3D} scene - A scene or any other type of 3D object.
 		 * @param {Camera} camera - The camera.
 		 */
-		this.render = function ( scene, camera ) {
+		this.render = function (scene, camera) {
 
-			const fov = camera.projectionMatrix.elements[ 5 ] * _heightHalf;
+			const fov = camera.projectionMatrix.elements[5] * _heightHalf;
 
-			if ( camera.view && camera.view.enabled ) {
+			if (camera.view && camera.view.enabled) {
 
 				// view offset
-				viewElement.style.transform = `translate( ${ - camera.view.offsetX * ( _width / camera.view.width ) }px, ${ - camera.view.offsetY * ( _height / camera.view.height ) }px )`;
+				viewElement.style.transform = `translate( ${- camera.view.offsetX * (_width / camera.view.width)}px, ${- camera.view.offsetY * (_height / camera.view.height)}px )`;
 
 				// view fullWidth and fullHeight, view width and height
-				viewElement.style.transform += `scale( ${ camera.view.fullWidth / camera.view.width }, ${ camera.view.fullHeight / camera.view.height } )`;
+				viewElement.style.transform += `scale( ${camera.view.fullWidth / camera.view.width}, ${camera.view.fullHeight / camera.view.height} )`;
 
 			} else {
 
@@ -233,28 +235,28 @@ class CSS3DRenderer {
 
 			}
 
-			if ( scene.matrixWorldAutoUpdate === true ) scene.updateMatrixWorld();
-			if ( camera.parent === null && camera.matrixWorldAutoUpdate === true ) camera.updateMatrixWorld();
+			if (scene.matrixWorldAutoUpdate === true) scene.updateMatrixWorld();
+			if (camera.parent === null && camera.matrixWorldAutoUpdate === true) camera.updateMatrixWorld();
 
 			let tx, ty;
 
-			if ( camera.isOrthographicCamera ) {
+			if (camera.isOrthographicCamera) {
 
-				tx = - ( camera.right + camera.left ) / 2;
-				ty = ( camera.top + camera.bottom ) / 2;
+				tx = - (camera.right + camera.left) / 2;
+				ty = (camera.top + camera.bottom) / 2;
 
 			}
 
 			const scaleByViewOffset = camera.view && camera.view.enabled ? camera.view.height / camera.view.fullHeight : 1;
 			const cameraCSSMatrix = camera.isOrthographicCamera ?
-				`scale( ${ scaleByViewOffset } )` + 'scale(' + fov + ')' + 'translate(' + epsilon( tx ) + 'px,' + epsilon( ty ) + 'px)' + getCameraCSSMatrix( camera.matrixWorldInverse ) :
-				`scale( ${ scaleByViewOffset } )` + 'translateZ(' + fov + 'px)' + getCameraCSSMatrix( camera.matrixWorldInverse );
+				`scale( ${scaleByViewOffset} )` + 'scale(' + fov + ')' + 'translate(' + epsilon(tx) + 'px,' + epsilon(ty) + 'px)' + getCameraCSSMatrix(camera.matrixWorldInverse) :
+				`scale( ${scaleByViewOffset} )` + 'translateZ(' + fov + 'px)' + getCameraCSSMatrix(camera.matrixWorldInverse);
 			const perspective = camera.isPerspectiveCamera ? 'perspective(' + fov + 'px) ' : '';
 
 			const style = perspective + cameraCSSMatrix +
 				'translate(' + _widthHalf + 'px,' + _heightHalf + 'px)';
 
-			if ( cache.camera.style !== style ) {
+			if (cache.camera.style !== style) {
 
 				cameraElement.style.transform = style;
 
@@ -262,7 +264,7 @@ class CSS3DRenderer {
 
 			}
 
-			renderObject( scene, scene, camera, cameraCSSMatrix );
+			renderObject(scene, scene, camera, cameraCSSMatrix);
 
 		};
 
@@ -272,7 +274,7 @@ class CSS3DRenderer {
 		 * @param {number} width - The width of the renderer.
 		 * @param {number} height - The height of the renderer.
 		 */
-		this.setSize = function ( width, height ) {
+		this.setSize = function (width, height) {
 
 			_width = width;
 			_height = height;
@@ -290,150 +292,150 @@ class CSS3DRenderer {
 
 		};
 
-		function epsilon( value ) {
+		function epsilon(value) {
 
-			return Math.abs( value ) < 1e-10 ? 0 : value;
+			return Math.abs(value) < 1e-10 ? 0 : value;
 
 		}
 
-		function getCameraCSSMatrix( matrix ) {
+		function getCameraCSSMatrix(matrix) {
 
 			const elements = matrix.elements;
 
 			return 'matrix3d(' +
-				epsilon( elements[ 0 ] ) + ',' +
-				epsilon( - elements[ 1 ] ) + ',' +
-				epsilon( elements[ 2 ] ) + ',' +
-				epsilon( elements[ 3 ] ) + ',' +
-				epsilon( elements[ 4 ] ) + ',' +
-				epsilon( - elements[ 5 ] ) + ',' +
-				epsilon( elements[ 6 ] ) + ',' +
-				epsilon( elements[ 7 ] ) + ',' +
-				epsilon( elements[ 8 ] ) + ',' +
-				epsilon( - elements[ 9 ] ) + ',' +
-				epsilon( elements[ 10 ] ) + ',' +
-				epsilon( elements[ 11 ] ) + ',' +
-				epsilon( elements[ 12 ] ) + ',' +
-				epsilon( - elements[ 13 ] ) + ',' +
-				epsilon( elements[ 14 ] ) + ',' +
-				epsilon( elements[ 15 ] ) +
-			')';
+				epsilon(elements[0]) + ',' +
+				epsilon(- elements[1]) + ',' +
+				epsilon(elements[2]) + ',' +
+				epsilon(elements[3]) + ',' +
+				epsilon(elements[4]) + ',' +
+				epsilon(- elements[5]) + ',' +
+				epsilon(elements[6]) + ',' +
+				epsilon(elements[7]) + ',' +
+				epsilon(elements[8]) + ',' +
+				epsilon(- elements[9]) + ',' +
+				epsilon(elements[10]) + ',' +
+				epsilon(elements[11]) + ',' +
+				epsilon(elements[12]) + ',' +
+				epsilon(- elements[13]) + ',' +
+				epsilon(elements[14]) + ',' +
+				epsilon(elements[15]) +
+				')';
 
 		}
 
-		function getObjectCSSMatrix( matrix ) {
+		function getObjectCSSMatrix(matrix) {
 
 			const elements = matrix.elements;
 			const matrix3d = 'matrix3d(' +
-				epsilon( elements[ 0 ] ) + ',' +
-				epsilon( elements[ 1 ] ) + ',' +
-				epsilon( elements[ 2 ] ) + ',' +
-				epsilon( elements[ 3 ] ) + ',' +
-				epsilon( - elements[ 4 ] ) + ',' +
-				epsilon( - elements[ 5 ] ) + ',' +
-				epsilon( - elements[ 6 ] ) + ',' +
-				epsilon( - elements[ 7 ] ) + ',' +
-				epsilon( elements[ 8 ] ) + ',' +
-				epsilon( elements[ 9 ] ) + ',' +
-				epsilon( elements[ 10 ] ) + ',' +
-				epsilon( elements[ 11 ] ) + ',' +
-				epsilon( elements[ 12 ] ) + ',' +
-				epsilon( elements[ 13 ] ) + ',' +
-				epsilon( elements[ 14 ] ) + ',' +
-				epsilon( elements[ 15 ] ) +
-			')';
+				epsilon(elements[0]) + ',' +
+				epsilon(elements[1]) + ',' +
+				epsilon(elements[2]) + ',' +
+				epsilon(elements[3]) + ',' +
+				epsilon(- elements[4]) + ',' +
+				epsilon(- elements[5]) + ',' +
+				epsilon(- elements[6]) + ',' +
+				epsilon(- elements[7]) + ',' +
+				epsilon(elements[8]) + ',' +
+				epsilon(elements[9]) + ',' +
+				epsilon(elements[10]) + ',' +
+				epsilon(elements[11]) + ',' +
+				epsilon(elements[12]) + ',' +
+				epsilon(elements[13]) + ',' +
+				epsilon(elements[14]) + ',' +
+				epsilon(elements[15]) +
+				')';
 
 			return 'translate(-50%,-50%)' + matrix3d;
 
 		}
 
-		function hideObject( object ) {
+		function hideObject(object) {
 
-			if ( object.isCSS3DObject ) object.element.style.display = 'none';
+			if (object.isCSS3DObject) object.element.style.display = 'none';
 
-			for ( let i = 0, l = object.children.length; i < l; i ++ ) {
+			for (let i = 0, l = object.children.length; i < l; i++) {
 
-				hideObject( object.children[ i ] );
+				hideObject(object.children[i]);
 
 			}
 
 		}
 
-		function renderObject( object, scene, camera, cameraCSSMatrix ) {
+		function renderObject(object, scene, camera, cameraCSSMatrix) {
 
-			if ( object.visible === false ) {
+			if (object.visible === false) {
 
-				hideObject( object );
+				hideObject(object);
 
 				return;
 
 			}
 
-			if ( object.isCSS3DObject ) {
+			if (object.isCSS3DObject) {
 
-				const visible = ( object.layers.test( camera.layers ) === true );
+				const visible = (object.layers.test(camera.layers) === true);
 
 				const element = object.element;
 				element.style.display = visible === true ? '' : 'none';
 
-				if ( visible === true ) {
+				if (visible === true) {
 
-					object.onBeforeRender( _this, scene, camera );
+					object.onBeforeRender(_this, scene, camera);
 
 					let style;
 
-					if ( object.isCSS3DSprite ) {
+					if (object.isCSS3DSprite) {
 
 						// http://swiftcoder.wordpress.com/2008/11/25/constructing-a-billboard-matrix/
 
-						_matrix.copy( camera.matrixWorldInverse );
+						_matrix.copy(camera.matrixWorldInverse);
 						_matrix.transpose();
 
-						if ( object.rotation2D !== 0 ) _matrix.multiply( _matrix2.makeRotationZ( object.rotation2D ) );
+						if (object.rotation2D !== 0) _matrix.multiply(_matrix2.makeRotationZ(object.rotation2D));
 
-						object.matrixWorld.decompose( _position, _quaternion, _scale );
-						_matrix.setPosition( _position );
-						_matrix.scale( _scale );
+						object.matrixWorld.decompose(_position, _quaternion, _scale);
+						_matrix.setPosition(_position);
+						_matrix.scale(_scale);
 
-						_matrix.elements[ 3 ] = 0;
-						_matrix.elements[ 7 ] = 0;
-						_matrix.elements[ 11 ] = 0;
-						_matrix.elements[ 15 ] = 1;
+						_matrix.elements[3] = 0;
+						_matrix.elements[7] = 0;
+						_matrix.elements[11] = 0;
+						_matrix.elements[15] = 1;
 
-						style = getObjectCSSMatrix( _matrix );
+						style = getObjectCSSMatrix(_matrix);
 
 					} else {
 
-						style = getObjectCSSMatrix( object.matrixWorld );
+						style = getObjectCSSMatrix(object.matrixWorld);
 
 					}
 
-					const cachedObject = cache.objects.get( object );
+					const cachedObject = cache.objects.get(object);
 
-					if ( cachedObject === undefined || cachedObject.style !== style ) {
+					if (cachedObject === undefined || cachedObject.style !== style) {
 
 						element.style.transform = style;
 
 						const objectData = { style: style };
-						cache.objects.set( object, objectData );
+						cache.objects.set(object, objectData);
 
 					}
 
-					if ( element.parentNode !== cameraElement ) {
+					if (element.parentNode !== cameraElement) {
 
-						cameraElement.appendChild( element );
+						cameraElement.appendChild(element);
 
 					}
 
-					object.onAfterRender( _this, scene, camera );
+					object.onAfterRender(_this, scene, camera);
 
 				}
 
 			}
 
-			for ( let i = 0, l = object.children.length; i < l; i ++ ) {
+			for (let i = 0, l = object.children.length; i < l; i++) {
 
-				renderObject( object.children[ i ], scene, camera, cameraCSSMatrix );
+				renderObject(object.children[i], scene, camera, cameraCSSMatrix);
 
 			}
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -67,7 +67,7 @@ class WebGLRenderer {
 	 *
 	 * @param {WebGLRenderer~Options} [parameters] - The configuration parameter.
 	 */
-	constructor( parameters = {} ) {
+	constructor(parameters = {}) {
 
 		const {
 			canvas = createCanvasElement(),
@@ -95,11 +95,11 @@ class WebGLRenderer {
 
 		let _alpha;
 
-		if ( context !== null ) {
+		if (context !== null) {
 
-			if ( typeof WebGLRenderingContext !== 'undefined' && context instanceof WebGLRenderingContext ) {
+			if (typeof WebGLRenderingContext !== 'undefined' && context instanceof WebGLRenderingContext) {
 
-				throw new Error( 'THREE.WebGLRenderer: WebGL 1 is not supported since r163.' );
+				throw new Error('THREE.WebGLRenderer: WebGL 1 is not supported since r163.');
 
 			}
 
@@ -113,23 +113,23 @@ class WebGLRenderer {
 
 		const _outputBufferType = outputBufferType;
 
-		const INTEGER_FORMATS = new Set( [
+		const INTEGER_FORMATS = new Set([
 			RGBAIntegerFormat,
 			RGIntegerFormat,
 			RedIntegerFormat
-		] );
+		]);
 
-		const UNSIGNED_TYPES = new Set( [
+		const UNSIGNED_TYPES = new Set([
 			UnsignedByteType,
 			UnsignedIntType,
 			UnsignedShortType,
 			UnsignedInt248Type,
 			UnsignedShort4444Type,
 			UnsignedShort5551Type
-		] );
+		]);
 
-		const uintClearColor = new Uint32Array( 4 );
-		const intClearColor = new Int32Array( 4 );
+		const uintClearColor = new Uint32Array(4);
+		const intClearColor = new Int32Array(4);
 
 		let currentRenderList = null;
 		let currentRenderState = null;
@@ -308,7 +308,7 @@ class WebGLRenderer {
 		const _currentScissor = new Vector4();
 		let _currentScissorTest = null;
 
-		const _currentClearColor = new Color( 0x000000 );
+		const _currentClearColor = new Color(0x000000);
 		let _currentClearAlpha = 0;
 
 		//
@@ -320,8 +320,8 @@ class WebGLRenderer {
 		let _opaqueSort = null;
 		let _transparentSort = null;
 
-		const _viewport = new Vector4( 0, 0, _width, _height );
-		const _scissor = new Vector4( 0, 0, _width, _height );
+		const _viewport = new Vector4(0, 0, _width, _height);
+		const _scissor = new Vector4(0, 0, _width, _height);
 		let _scissorTest = false;
 
 		// frustum
@@ -355,9 +355,9 @@ class WebGLRenderer {
 
 		let _gl = context;
 
-		function getContext( contextName, contextAttributes ) {
+		function getContext(contextName, contextAttributes) {
 
-			return canvas.getContext( contextName, contextAttributes );
+			return canvas.getContext(contextName, contextAttributes);
 
 		}
 
@@ -375,28 +375,28 @@ class WebGLRenderer {
 			};
 
 			// OffscreenCanvas does not have setAttribute, see #22811
-			if ( 'setAttribute' in canvas ) canvas.setAttribute( 'data-engine', `three.js r${REVISION}` );
+			if ('setAttribute' in canvas) canvas.setAttribute('data-engine', `three.js r${REVISION}`);
 
 			// event listeners must be registered before WebGL context is created, see #12753
-			canvas.addEventListener( 'webglcontextlost', onContextLost, false );
-			canvas.addEventListener( 'webglcontextrestored', onContextRestore, false );
-			canvas.addEventListener( 'webglcontextcreationerror', onContextCreationError, false );
+			canvas.addEventListener('webglcontextlost', onContextLost, false);
+			canvas.addEventListener('webglcontextrestored', onContextRestore, false);
+			canvas.addEventListener('webglcontextcreationerror', onContextCreationError, false);
 
-			if ( _gl === null ) {
+			if (_gl === null) {
 
 				const contextName = 'webgl2';
 
-				_gl = getContext( contextName, contextAttributes );
+				_gl = getContext(contextName, contextAttributes);
 
-				if ( _gl === null ) {
+				if (_gl === null) {
 
-					if ( getContext( contextName ) ) {
+					if (getContext(contextName)) {
 
-						throw new Error( 'Error creating WebGL context with your selected attributes.' );
+						throw new Error('Error creating WebGL context with your selected attributes.');
 
 					} else {
 
-						throw new Error( 'Error creating WebGL context.' );
+						throw new Error('Error creating WebGL context.');
 
 					}
 
@@ -404,9 +404,9 @@ class WebGLRenderer {
 
 			}
 
-		} catch ( e ) {
+		} catch (e) {
 
-			error( 'WebGLRenderer: ' + e.message );
+			error('WebGLRenderer: ' + e.message);
 			throw e;
 
 		}
@@ -421,41 +421,41 @@ class WebGLRenderer {
 
 		function initGLContext() {
 
-			extensions = new WebGLExtensions( _gl );
+			extensions = new WebGLExtensions(_gl);
 			extensions.init();
 
-			utils = new WebGLUtils( _gl, extensions );
+			utils = new WebGLUtils(_gl, extensions);
 
-			capabilities = new WebGLCapabilities( _gl, extensions, parameters, utils );
+			capabilities = new WebGLCapabilities(_gl, extensions, parameters, utils);
 
-			state = new WebGLState( _gl, extensions );
+			state = new WebGLState(_gl, extensions);
 
-			if ( capabilities.reversedDepthBuffer && reversedDepthBuffer ) {
+			if (capabilities.reversedDepthBuffer && reversedDepthBuffer) {
 
-				state.buffers.depth.setReversed( true );
+				state.buffers.depth.setReversed(true);
 
 			}
 
-			info = new WebGLInfo( _gl );
+			info = new WebGLInfo(_gl);
 			properties = new WebGLProperties();
-			textures = new WebGLTextures( _gl, extensions, state, properties, capabilities, utils, info );
-			environments = new WebGLEnvironments( _this );
-			attributes = new WebGLAttributes( _gl );
-			bindingStates = new WebGLBindingStates( _gl, attributes );
-			geometries = new WebGLGeometries( _gl, attributes, info, bindingStates );
-			objects = new WebGLObjects( _gl, geometries, attributes, bindingStates, info );
-			morphtargets = new WebGLMorphtargets( _gl, capabilities, textures );
-			clipping = new WebGLClipping( properties );
-			programCache = new WebGLPrograms( _this, environments, extensions, capabilities, bindingStates, clipping );
-			materials = new WebGLMaterials( _this, properties );
+			textures = new WebGLTextures(_gl, extensions, state, properties, capabilities, utils, info);
+			environments = new WebGLEnvironments(_this);
+			attributes = new WebGLAttributes(_gl);
+			bindingStates = new WebGLBindingStates(_gl, attributes);
+			geometries = new WebGLGeometries(_gl, attributes, info, bindingStates);
+			objects = new WebGLObjects(_gl, geometries, attributes, bindingStates, info);
+			morphtargets = new WebGLMorphtargets(_gl, capabilities, textures);
+			clipping = new WebGLClipping(properties);
+			programCache = new WebGLPrograms(_this, environments, extensions, capabilities, bindingStates, clipping);
+			materials = new WebGLMaterials(_this, properties);
 			renderLists = new WebGLRenderLists();
-			renderStates = new WebGLRenderStates( extensions );
-			background = new WebGLBackground( _this, environments, state, objects, _alpha, premultipliedAlpha );
-			shadowMap = new WebGLShadowMap( _this, objects, capabilities );
-			uniformsGroups = new WebGLUniformsGroups( _gl, info, capabilities, state );
+			renderStates = new WebGLRenderStates(extensions);
+			background = new WebGLBackground(_this, environments, state, objects, _alpha, premultipliedAlpha);
+			shadowMap = new WebGLShadowMap(_this, objects, capabilities);
+			uniformsGroups = new WebGLUniformsGroups(_gl, info, capabilities, state);
 
-			bufferRenderer = new WebGLBufferRenderer( _gl, extensions, info );
-			indexedBufferRenderer = new WebGLIndexedBufferRenderer( _gl, extensions, info );
+			bufferRenderer = new WebGLBufferRenderer(_gl, extensions, info);
+			indexedBufferRenderer = new WebGLIndexedBufferRenderer(_gl, extensions, info);
 
 			info.programs = programCache.programs;
 
@@ -540,15 +540,15 @@ class WebGLRenderer {
 
 		// initialize internal render target for non-UnsignedByteType color buffer
 
-		if ( _outputBufferType !== UnsignedByteType ) {
+		if (_outputBufferType !== UnsignedByteType) {
 
-			output = new WebGLOutput( _outputBufferType, canvas.width, canvas.height, depth, stencil );
+			output = new WebGLOutput(_outputBufferType, canvas.width, canvas.height, depth, stencil);
 
 		}
 
 		// xr
 
-		const xr = new WebXRManager( _this, _gl );
+		const xr = new WebXRManager(_this, _gl);
 
 		/**
 		 * A reference to the XR manager.
@@ -584,8 +584,8 @@ class WebGLRenderer {
 		 */
 		this.forceContextLoss = function () {
 
-			const extension = extensions.get( 'WEBGL_lose_context' );
-			if ( extension ) extension.loseContext();
+			const extension = extensions.get('WEBGL_lose_context');
+			if (extension) extension.loseContext();
 
 		};
 
@@ -594,8 +594,8 @@ class WebGLRenderer {
 		 */
 		this.forceContextRestore = function () {
 
-			const extension = extensions.get( 'WEBGL_lose_context' );
-			if ( extension ) extension.restoreContext();
+			const extension = extensions.get('WEBGL_lose_context');
+			if (extension) extension.restoreContext();
 
 		};
 
@@ -615,13 +615,13 @@ class WebGLRenderer {
 		 *
 		 * @param {number} value - The pixel ratio.
 		 */
-		this.setPixelRatio = function ( value ) {
+		this.setPixelRatio = function (value) {
 
-			if ( value === undefined ) return;
+			if (value === undefined) return;
 
 			_pixelRatio = value;
 
-			this.setSize( _width, _height, false );
+			this.setSize(_width, _height, false);
 
 		};
 
@@ -631,9 +631,9 @@ class WebGLRenderer {
 		 * @param {Vector2} target - The method writes the result in this target object.
 		 * @return {Vector2} The renderer's size in logical pixels.
 		 */
-		this.getSize = function ( target ) {
+		this.getSize = function (target) {
 
-			return target.set( _width, _height );
+			return target.set(_width, _height);
 
 		};
 
@@ -646,11 +646,11 @@ class WebGLRenderer {
 		 * @param {number} height - The height in logical pixels.
 		 * @param {boolean} [updateStyle=true] - Whether to update the `style` attribute of the canvas or not.
 		 */
-		this.setSize = function ( width, height, updateStyle = true ) {
+		this.setSize = function (width, height, updateStyle = true) {
 
-			if ( xr.isPresenting ) {
+			if (xr.isPresenting) {
 
-				warn( 'WebGLRenderer: Can\'t change size while VR device is presenting.' );
+				warn('WebGLRenderer: Can\'t change size while VR device is presenting.');
 				return;
 
 			}
@@ -658,23 +658,23 @@ class WebGLRenderer {
 			_width = width;
 			_height = height;
 
-			canvas.width = Math.floor( width * _pixelRatio );
-			canvas.height = Math.floor( height * _pixelRatio );
+			canvas.width = Math.floor(width * _pixelRatio);
+			canvas.height = Math.floor(height * _pixelRatio);
 
-			if ( updateStyle === true ) {
+			if (updateStyle === true) {
 
 				canvas.style.width = width + 'px';
 				canvas.style.height = height + 'px';
 
 			}
 
-			if ( output !== null ) {
+			if (output !== null) {
 
-				output.setSize( canvas.width, canvas.height );
+				output.setSize(canvas.width, canvas.height);
 
 			}
 
-			this.setViewport( 0, 0, width, height );
+			this.setViewport(0, 0, width, height);
 
 		};
 
@@ -684,9 +684,9 @@ class WebGLRenderer {
 		 * @param {Vector2} target - The method writes the result in this target object.
 		 * @return {Vector2} The drawing buffer size.
 		 */
-		this.getDrawingBufferSize = function ( target ) {
+		this.getDrawingBufferSize = function (target) {
 
-			return target.set( _width * _pixelRatio, _height * _pixelRatio ).floor();
+			return target.set(_width * _pixelRatio, _height * _pixelRatio).floor();
 
 		};
 
@@ -703,17 +703,17 @@ class WebGLRenderer {
 		 * @param {number} height - The height in logical pixels.
 		 * @param {number} pixelRatio - The pixel ratio.
 		 */
-		this.setDrawingBufferSize = function ( width, height, pixelRatio ) {
+		this.setDrawingBufferSize = function (width, height, pixelRatio) {
 
 			_width = width;
 			_height = height;
 
 			_pixelRatio = pixelRatio;
 
-			canvas.width = Math.floor( width * pixelRatio );
-			canvas.height = Math.floor( height * pixelRatio );
+			canvas.width = Math.floor(width * pixelRatio);
+			canvas.height = Math.floor(height * pixelRatio);
 
-			this.setViewport( 0, 0, width, height );
+			this.setViewport(0, 0, width, height);
 
 		};
 
@@ -722,22 +722,22 @@ class WebGLRenderer {
 		 *
 		 * @param {Array} effects - An array of post-processing effects.
 		 */
-		this.setEffects = function ( effects ) {
+		this.setEffects = function (effects) {
 
-			if ( _outputBufferType === UnsignedByteType ) {
+			if (_outputBufferType === UnsignedByteType) {
 
-				console.error( 'THREE.WebGLRenderer: setEffects() requires outputBufferType set to HalfFloatType or FloatType.' );
+				console.error('THREE.WebGLRenderer: setEffects() requires outputBufferType set to HalfFloatType or FloatType.');
 				return;
 
 			}
 
-			if ( effects ) {
+			if (effects) {
 
-				for ( let i = 0; i < effects.length; i ++ ) {
+				for (let i = 0; i < effects.length; i++) {
 
-					if ( effects[ i ].isOutputPass === true ) {
+					if (effects[i].isOutputPass === true) {
 
-						console.warn( 'THREE.WebGLRenderer: OutputPass is not needed in setEffects(). Tone mapping and color space conversion are applied automatically.' );
+						console.warn('THREE.WebGLRenderer: OutputPass is not needed in setEffects(). Tone mapping and color space conversion are applied automatically.');
 						break;
 
 					}
@@ -746,7 +746,7 @@ class WebGLRenderer {
 
 			}
 
-			output.setEffects( effects || [] );
+			output.setEffects(effects || []);
 
 		};
 
@@ -756,9 +756,9 @@ class WebGLRenderer {
 		 * @param {Vector2} target - The method writes the result in this target object.
 		 * @return {Vector2} The current viewport definition.
 		 */
-		this.getCurrentViewport = function ( target ) {
+		this.getCurrentViewport = function (target) {
 
-			return target.copy( _currentViewport );
+			return target.copy(_currentViewport);
 
 		};
 
@@ -768,9 +768,9 @@ class WebGLRenderer {
 		 * @param {Vector4} target - The method writes the result in this target object.
 		 * @return {Vector4} The viewport definition.
 		 */
-		this.getViewport = function ( target ) {
+		this.getViewport = function (target) {
 
-			return target.copy( _viewport );
+			return target.copy(_viewport);
 
 		};
 
@@ -783,19 +783,19 @@ class WebGLRenderer {
 		 * @param {number} width - The width of the viewport in logical pixel unit.
 		 * @param {number} height - The height of the viewport in logical pixel unit.
 		 */
-		this.setViewport = function ( x, y, width, height ) {
+		this.setViewport = function (x, y, width, height) {
 
-			if ( x.isVector4 ) {
+			if (x.isVector4) {
 
-				_viewport.set( x.x, x.y, x.z, x.w );
+				_viewport.set(x.x, x.y, x.z, x.w);
 
 			} else {
 
-				_viewport.set( x, y, width, height );
+				_viewport.set(x, y, width, height);
 
 			}
 
-			state.viewport( _currentViewport.copy( _viewport ).multiplyScalar( _pixelRatio ).round() );
+			state.viewport(_currentViewport.copy(_viewport).multiplyScalar(_pixelRatio).round());
 
 		};
 
@@ -805,9 +805,9 @@ class WebGLRenderer {
 		 * @param {Vector4} target - The method writes the result in this target object.
 		 * @return {Vector4} The scissor region.
 		 */
-		this.getScissor = function ( target ) {
+		this.getScissor = function (target) {
 
-			return target.copy( _scissor );
+			return target.copy(_scissor);
 
 		};
 
@@ -820,19 +820,19 @@ class WebGLRenderer {
 		 * @param {number} width - The width of the scissor region in logical pixel unit.
 		 * @param {number} height - The height of the scissor region in logical pixel unit.
 		 */
-		this.setScissor = function ( x, y, width, height ) {
+		this.setScissor = function (x, y, width, height) {
 
-			if ( x.isVector4 ) {
+			if (x.isVector4) {
 
-				_scissor.set( x.x, x.y, x.z, x.w );
+				_scissor.set(x.x, x.y, x.z, x.w);
 
 			} else {
 
-				_scissor.set( x, y, width, height );
+				_scissor.set(x, y, width, height);
 
 			}
 
-			state.scissor( _currentScissor.copy( _scissor ).multiplyScalar( _pixelRatio ).round() );
+			state.scissor(_currentScissor.copy(_scissor).multiplyScalar(_pixelRatio).round());
 
 		};
 
@@ -854,9 +854,9 @@ class WebGLRenderer {
 		 *
 		 * @param {boolean} boolean - Whether the scissor test is enabled or not.
 		 */
-		this.setScissorTest = function ( boolean ) {
+		this.setScissorTest = function (boolean) {
 
-			state.setScissorTest( _scissorTest = boolean );
+			state.setScissorTest(_scissorTest = boolean);
 
 		};
 
@@ -866,7 +866,7 @@ class WebGLRenderer {
 		 *
 		 * @param {?Function} method - The opaque sort function.
 		 */
-		this.setOpaqueSort = function ( method ) {
+		this.setOpaqueSort = function (method) {
 
 			_opaqueSort = method;
 
@@ -878,7 +878,7 @@ class WebGLRenderer {
 		 *
 		 * @param {?Function} method - The opaque sort function.
 		 */
-		this.setTransparentSort = function ( method ) {
+		this.setTransparentSort = function (method) {
 
 			_transparentSort = method;
 
@@ -892,9 +892,9 @@ class WebGLRenderer {
 		 * @param {Color} target - The method writes the result in this target object.
 		 * @return {Color} The clear color.
 		 */
-		this.getClearColor = function ( target ) {
+		this.getClearColor = function (target) {
 
-			return target.copy( background.getClearColor() );
+			return target.copy(background.getClearColor());
 
 		};
 
@@ -906,7 +906,7 @@ class WebGLRenderer {
 		 */
 		this.setClearColor = function () {
 
-			background.setClearColor( ...arguments );
+			background.setClearColor(...arguments);
 
 		};
 
@@ -928,7 +928,7 @@ class WebGLRenderer {
 		 */
 		this.setClearAlpha = function () {
 
-			background.setClearAlpha( ...arguments );
+			background.setClearAlpha(...arguments);
 
 		};
 
@@ -940,27 +940,27 @@ class WebGLRenderer {
 		 * @param {boolean} [depth=true] - Whether the depth buffer should be cleared or not.
 		 * @param {boolean} [stencil=true] - Whether the stencil buffer should be cleared or not.
 		 */
-		this.clear = function ( color = true, depth = true, stencil = true ) {
+		this.clear = function (color = true, depth = true, stencil = true) {
 
 			let bits = 0;
 
-			if ( color ) {
+			if (color) {
 
 				// check if we're trying to clear an integer target
 				let isIntegerFormat = false;
-				if ( _currentRenderTarget !== null ) {
+				if (_currentRenderTarget !== null) {
 
 					const targetFormat = _currentRenderTarget.texture.format;
-					isIntegerFormat = INTEGER_FORMATS.has( targetFormat );
+					isIntegerFormat = INTEGER_FORMATS.has(targetFormat);
 
 				}
 
 				// use the appropriate clear functions to clear the target if it's a signed
 				// or unsigned integer target
-				if ( isIntegerFormat ) {
+				if (isIntegerFormat) {
 
 					const targetType = _currentRenderTarget.texture.type;
-					const isUnsignedType = UNSIGNED_TYPES.has( targetType );
+					const isUnsignedType = UNSIGNED_TYPES.has(targetType);
 
 					const clearColor = background.getClearColor();
 					const a = background.getClearAlpha();
@@ -968,21 +968,21 @@ class WebGLRenderer {
 					const g = clearColor.g;
 					const b = clearColor.b;
 
-					if ( isUnsignedType ) {
+					if (isUnsignedType) {
 
-						uintClearColor[ 0 ] = r;
-						uintClearColor[ 1 ] = g;
-						uintClearColor[ 2 ] = b;
-						uintClearColor[ 3 ] = a;
-						_gl.clearBufferuiv( _gl.COLOR, 0, uintClearColor );
+						uintClearColor[0] = r;
+						uintClearColor[1] = g;
+						uintClearColor[2] = b;
+						uintClearColor[3] = a;
+						_gl.clearBufferuiv(_gl.COLOR, 0, uintClearColor);
 
 					} else {
 
-						intClearColor[ 0 ] = r;
-						intClearColor[ 1 ] = g;
-						intClearColor[ 2 ] = b;
-						intClearColor[ 3 ] = a;
-						_gl.clearBufferiv( _gl.COLOR, 0, intClearColor );
+						intClearColor[0] = r;
+						intClearColor[1] = g;
+						intClearColor[2] = b;
+						intClearColor[3] = a;
+						_gl.clearBufferiv(_gl.COLOR, 0, intClearColor);
 
 					}
 
@@ -994,22 +994,22 @@ class WebGLRenderer {
 
 			}
 
-			if ( depth ) {
+			if (depth) {
 
 				bits |= _gl.DEPTH_BUFFER_BIT;
 
 			}
 
-			if ( stencil ) {
+			if (stencil) {
 
 				bits |= _gl.STENCIL_BUFFER_BIT;
-				this.state.buffers.stencil.setMask( 0xffffffff );
+				this.state.buffers.stencil.setMask(0xffffffff);
 
 			}
 
-			if ( bits !== 0 ) {
+			if (bits !== 0) {
 
-				_gl.clear( bits );
+				_gl.clear(bits);
 
 			}
 
@@ -1020,7 +1020,7 @@ class WebGLRenderer {
 		 */
 		this.clearColor = function () {
 
-			this.clear( true, false, false );
+			this.clear(true, false, false);
 
 		};
 
@@ -1029,7 +1029,7 @@ class WebGLRenderer {
 		 */
 		this.clearDepth = function () {
 
-			this.clear( false, true, false );
+			this.clear(false, true, false);
 
 		};
 
@@ -1038,7 +1038,7 @@ class WebGLRenderer {
 		 */
 		this.clearStencil = function () {
 
-			this.clear( false, false, true );
+			this.clear(false, false, true);
 
 		};
 
@@ -1048,9 +1048,9 @@ class WebGLRenderer {
 		 */
 		this.dispose = function () {
 
-			canvas.removeEventListener( 'webglcontextlost', onContextLost, false );
-			canvas.removeEventListener( 'webglcontextrestored', onContextRestore, false );
-			canvas.removeEventListener( 'webglcontextcreationerror', onContextCreationError, false );
+			canvas.removeEventListener('webglcontextlost', onContextLost, false);
+			canvas.removeEventListener('webglcontextrestored', onContextRestore, false);
+			canvas.removeEventListener('webglcontextcreationerror', onContextCreationError, false);
 
 			background.dispose();
 			renderLists.dispose();
@@ -1064,8 +1064,8 @@ class WebGLRenderer {
 
 			xr.dispose();
 
-			xr.removeEventListener( 'sessionstart', onXRSessionStart );
-			xr.removeEventListener( 'sessionend', onXRSessionEnd );
+			xr.removeEventListener('sessionstart', onXRSessionStart);
+			xr.removeEventListener('sessionend', onXRSessionEnd);
 
 			animation.stop();
 
@@ -1073,19 +1073,19 @@ class WebGLRenderer {
 
 		// Events
 
-		function onContextLost( event ) {
+		function onContextLost(event) {
 
 			event.preventDefault();
 
-			log( 'WebGLRenderer: Context Lost.' );
+			log('WebGLRenderer: Context Lost.');
 
 			_isContextLost = true;
 
 		}
 
-		function onContextRestore( /* event */ ) {
+		function onContextRestore( /* event */) {
 
-			log( 'WebGLRenderer: Context Restored.' );
+			log('WebGLRenderer: Context Restored.');
 
 			_isContextLost = false;
 
@@ -1105,48 +1105,48 @@ class WebGLRenderer {
 
 		}
 
-		function onContextCreationError( event ) {
+		function onContextCreationError(event) {
 
-			error( 'WebGLRenderer: A WebGL context could not be created. Reason: ', event.statusMessage );
+			error('WebGLRenderer: A WebGL context could not be created. Reason: ', event.statusMessage);
 
 		}
 
-		function onMaterialDispose( event ) {
+		function onMaterialDispose(event) {
 
 			const material = event.target;
 
-			material.removeEventListener( 'dispose', onMaterialDispose );
+			material.removeEventListener('dispose', onMaterialDispose);
 
-			deallocateMaterial( material );
+			deallocateMaterial(material);
 
 		}
 
 		// Buffer deallocation
 
-		function deallocateMaterial( material ) {
+		function deallocateMaterial(material) {
 
-			releaseMaterialProgramReferences( material );
+			releaseMaterialProgramReferences(material);
 
-			properties.remove( material );
+			properties.remove(material);
 
 		}
 
 
-		function releaseMaterialProgramReferences( material ) {
+		function releaseMaterialProgramReferences(material) {
 
-			const programs = properties.get( material ).programs;
+			const programs = properties.get(material).programs;
 
-			if ( programs !== undefined ) {
+			if (programs !== undefined) {
 
-				programs.forEach( function ( program ) {
+				programs.forEach(function (program) {
 
-					programCache.releaseProgram( program );
+					programCache.releaseProgram(program);
 
-				} );
+				});
 
-				if ( material.isShaderMaterial ) {
+				if (material.isShaderMaterial) {
 
-					programCache.releaseShaderCache( material );
+					programCache.releaseShaderCache(material);
 
 				}
 
@@ -1156,26 +1156,26 @@ class WebGLRenderer {
 
 		// Buffer rendering
 
-		this.renderBufferDirect = function ( camera, scene, geometry, material, object, group ) {
+		this.renderBufferDirect = function (camera, scene, geometry, material, object, group) {
 
-			if ( scene === null ) scene = _emptyScene; // renderBufferDirect second parameter used to be fog (could be null)
+			if (scene === null) scene = _emptyScene; // renderBufferDirect second parameter used to be fog (could be null)
 
-			const frontFaceCW = ( object.isMesh && object.matrixWorld.determinant() < 0 );
+			const frontFaceCW = (object.isMesh && object.matrixWorld.determinant() < 0);
 
-			const program = setProgram( camera, scene, geometry, material, object );
+			const program = setProgram(camera, scene, geometry, material, object);
 
-			state.setMaterial( material, frontFaceCW );
+			state.setMaterial(material, frontFaceCW);
 
 			//
 
 			let index = geometry.index;
 			let rangeFactor = 1;
 
-			if ( material.wireframe === true ) {
+			if (material.wireframe === true) {
 
-				index = geometries.getWireframeAttribute( geometry );
+				index = geometries.getWireframeAttribute(geometry);
 
-				if ( index === undefined ) return;
+				if (index === undefined) return;
 
 				rangeFactor = 2;
 
@@ -1187,140 +1187,140 @@ class WebGLRenderer {
 			const position = geometry.attributes.position;
 
 			let drawStart = drawRange.start * rangeFactor;
-			let drawEnd = ( drawRange.start + drawRange.count ) * rangeFactor;
+			let drawEnd = (drawRange.start + drawRange.count) * rangeFactor;
 
-			if ( group !== null ) {
+			if (group !== null) {
 
-				drawStart = Math.max( drawStart, group.start * rangeFactor );
-				drawEnd = Math.min( drawEnd, ( group.start + group.count ) * rangeFactor );
+				drawStart = Math.max(drawStart, group.start * rangeFactor);
+				drawEnd = Math.min(drawEnd, (group.start + group.count) * rangeFactor);
 
 			}
 
-			if ( index !== null ) {
+			if (index !== null) {
 
-				drawStart = Math.max( drawStart, 0 );
-				drawEnd = Math.min( drawEnd, index.count );
+				drawStart = Math.max(drawStart, 0);
+				drawEnd = Math.min(drawEnd, index.count);
 
-			} else if ( position !== undefined && position !== null ) {
+			} else if (position !== undefined && position !== null) {
 
-				drawStart = Math.max( drawStart, 0 );
-				drawEnd = Math.min( drawEnd, position.count );
+				drawStart = Math.max(drawStart, 0);
+				drawEnd = Math.min(drawEnd, position.count);
 
 			}
 
 			const drawCount = drawEnd - drawStart;
 
-			if ( drawCount < 0 || drawCount === Infinity ) return;
+			if (drawCount < 0 || drawCount === Infinity) return;
 
 			//
 
-			bindingStates.setup( object, material, program, geometry, index );
+			bindingStates.setup(object, material, program, geometry, index);
 
 			let attribute;
 			let renderer = bufferRenderer;
 
-			if ( index !== null ) {
+			if (index !== null) {
 
-				attribute = attributes.get( index );
+				attribute = attributes.get(index);
 
 				renderer = indexedBufferRenderer;
-				renderer.setIndex( attribute );
+				renderer.setIndex(attribute);
 
 			}
 
 			//
 
-			if ( object.isMesh ) {
+			if (object.isMesh) {
 
-				if ( material.wireframe === true ) {
+				if (material.wireframe === true) {
 
-					state.setLineWidth( material.wireframeLinewidth * getTargetPixelRatio() );
-					renderer.setMode( _gl.LINES );
+					state.setLineWidth(material.wireframeLinewidth * getTargetPixelRatio());
+					renderer.setMode(_gl.LINES);
 
 				} else {
 
-					renderer.setMode( _gl.TRIANGLES );
+					renderer.setMode(_gl.TRIANGLES);
 
 				}
 
-			} else if ( object.isLine ) {
+			} else if (object.isLine) {
 
 				let lineWidth = material.linewidth;
 
-				if ( lineWidth === undefined ) lineWidth = 1; // Not using Line*Material
+				if (lineWidth === undefined) lineWidth = 1; // Not using Line*Material
 
-				state.setLineWidth( lineWidth * getTargetPixelRatio() );
+				state.setLineWidth(lineWidth * getTargetPixelRatio());
 
-				if ( object.isLineSegments ) {
+				if (object.isLineSegments) {
 
-					renderer.setMode( _gl.LINES );
+					renderer.setMode(_gl.LINES);
 
-				} else if ( object.isLineLoop ) {
+				} else if (object.isLineLoop) {
 
-					renderer.setMode( _gl.LINE_LOOP );
+					renderer.setMode(_gl.LINE_LOOP);
 
 				} else {
 
-					renderer.setMode( _gl.LINE_STRIP );
+					renderer.setMode(_gl.LINE_STRIP);
 
 				}
 
-			} else if ( object.isPoints ) {
+			} else if (object.isPoints) {
 
-				renderer.setMode( _gl.POINTS );
+				renderer.setMode(_gl.POINTS);
 
-			} else if ( object.isSprite ) {
+			} else if (object.isSprite) {
 
-				renderer.setMode( _gl.TRIANGLES );
+				renderer.setMode(_gl.TRIANGLES);
 
 			}
 
-			if ( object.isBatchedMesh ) {
+			if (object.isBatchedMesh) {
 
-				if ( object._multiDrawInstances !== null ) {
+				if (object._multiDrawInstances !== null) {
 
 					// @deprecated, r174
-					warnOnce( 'WebGLRenderer: renderMultiDrawInstances has been deprecated and will be removed in r184. Append to renderMultiDraw arguments and use indirection.' );
-					renderer.renderMultiDrawInstances( object._multiDrawStarts, object._multiDrawCounts, object._multiDrawCount, object._multiDrawInstances );
+					warnOnce('WebGLRenderer: renderMultiDrawInstances has been deprecated and will be removed in r184. Append to renderMultiDraw arguments and use indirection.');
+					renderer.renderMultiDrawInstances(object._multiDrawStarts, object._multiDrawCounts, object._multiDrawCount, object._multiDrawInstances);
 
 				} else {
 
-					if ( ! extensions.get( 'WEBGL_multi_draw' ) ) {
+					if (!extensions.get('WEBGL_multi_draw')) {
 
 						const starts = object._multiDrawStarts;
 						const counts = object._multiDrawCounts;
 						const drawCount = object._multiDrawCount;
-						const bytesPerElement = index ? attributes.get( index ).bytesPerElement : 1;
-						const uniforms = properties.get( material ).currentProgram.getUniforms();
-						for ( let i = 0; i < drawCount; i ++ ) {
+						const bytesPerElement = index ? attributes.get(index).bytesPerElement : 1;
+						const uniforms = properties.get(material).currentProgram.getUniforms();
+						for (let i = 0; i < drawCount; i++) {
 
-							uniforms.setValue( _gl, '_gl_DrawID', i );
-							renderer.render( starts[ i ] / bytesPerElement, counts[ i ] );
+							uniforms.setValue(_gl, '_gl_DrawID', i);
+							renderer.render(starts[i] / bytesPerElement, counts[i]);
 
 						}
 
 					} else {
 
-						renderer.renderMultiDraw( object._multiDrawStarts, object._multiDrawCounts, object._multiDrawCount );
+						renderer.renderMultiDraw(object._multiDrawStarts, object._multiDrawCounts, object._multiDrawCount);
 
 					}
 
 				}
 
-			} else if ( object.isInstancedMesh ) {
+			} else if (object.isInstancedMesh) {
 
-				renderer.renderInstances( drawStart, drawCount, object.count );
+				renderer.renderInstances(drawStart, drawCount, object.count);
 
-			} else if ( geometry.isInstancedBufferGeometry ) {
+			} else if (geometry.isInstancedBufferGeometry) {
 
 				const maxInstanceCount = geometry._maxInstanceCount !== undefined ? geometry._maxInstanceCount : Infinity;
-				const instanceCount = Math.min( geometry.instanceCount, maxInstanceCount );
+				const instanceCount = Math.min(geometry.instanceCount, maxInstanceCount);
 
-				renderer.renderInstances( drawStart, drawCount, instanceCount );
+				renderer.renderInstances(drawStart, drawCount, instanceCount);
 
 			} else {
 
-				renderer.render( drawStart, drawCount );
+				renderer.render(drawStart, drawCount);
 
 			}
 
@@ -1328,23 +1328,23 @@ class WebGLRenderer {
 
 		// Compile
 
-		function prepareMaterial( material, scene, object ) {
+		function prepareMaterial(material, scene, object) {
 
-			if ( material.transparent === true && material.side === DoubleSide && material.forceSinglePass === false ) {
+			if (material.transparent === true && material.side === DoubleSide && material.forceSinglePass === false) {
 
 				material.side = BackSide;
 				material.needsUpdate = true;
-				getProgram( material, scene, object );
+				getProgram(material, scene, object);
 
 				material.side = FrontSide;
 				material.needsUpdate = true;
-				getProgram( material, scene, object );
+				getProgram(material, scene, object);
 
 				material.side = DoubleSide;
 
 			} else {
 
-				getProgram( material, scene, object );
+				getProgram(material, scene, object);
 
 			}
 
@@ -1362,50 +1362,50 @@ class WebGLRenderer {
 		 * @param {?Scene} [targetScene=null] - The target scene.
 		 * @return {Set<Material>} The precompiled materials.
 		 */
-		this.compile = function ( scene, camera, targetScene = null ) {
+		this.compile = function (scene, camera, targetScene = null) {
 
-			if ( targetScene === null ) targetScene = scene;
+			if (targetScene === null) targetScene = scene;
 
-			currentRenderState = renderStates.get( targetScene );
-			currentRenderState.init( camera );
+			currentRenderState = renderStates.get(targetScene);
+			currentRenderState.init(camera);
 
-			renderStateStack.push( currentRenderState );
+			renderStateStack.push(currentRenderState);
 
 			// gather lights from both the target scene and the new object that will be added to the scene.
 
-			targetScene.traverseVisible( function ( object ) {
+			targetScene.traverseVisible(function (object) {
 
-				if ( object.isLight && object.layers.test( camera.layers ) ) {
+				if (object.isLight && object.layers.test(camera.layers)) {
 
-					currentRenderState.pushLight( object );
+					currentRenderState.pushLight(object);
 
-					if ( object.castShadow ) {
+					if (object.castShadow) {
 
-						currentRenderState.pushShadow( object );
+						currentRenderState.pushShadow(object);
 
 					}
 
 				}
 
-			} );
+			});
 
-			if ( scene !== targetScene ) {
+			if (scene !== targetScene) {
 
-				scene.traverseVisible( function ( object ) {
+				scene.traverseVisible(function (object) {
 
-					if ( object.isLight && object.layers.test( camera.layers ) ) {
+					if (object.isLight && object.layers.test(camera.layers)) {
 
-						currentRenderState.pushLight( object );
+						currentRenderState.pushLight(object);
 
-						if ( object.castShadow ) {
+						if (object.castShadow) {
 
-							currentRenderState.pushShadow( object );
+							currentRenderState.pushShadow(object);
 
 						}
 
 					}
 
-				} );
+				});
 
 			}
 
@@ -1415,9 +1415,9 @@ class WebGLRenderer {
 
 			const materials = new Set();
 
-			scene.traverse( function ( object ) {
+			scene.traverse(function (object) {
 
-				if ( ! ( object.isMesh || object.isPoints || object.isLine || object.isSprite ) ) {
+				if (!(object.isMesh || object.isPoints || object.isLine || object.isSprite)) {
 
 					return;
 
@@ -1425,29 +1425,29 @@ class WebGLRenderer {
 
 				const material = object.material;
 
-				if ( material ) {
+				if (material) {
 
-					if ( Array.isArray( material ) ) {
+					if (Array.isArray(material)) {
 
-						for ( let i = 0; i < material.length; i ++ ) {
+						for (let i = 0; i < material.length; i++) {
 
-							const material2 = material[ i ];
+							const material2 = material[i];
 
-							prepareMaterial( material2, targetScene, object );
-							materials.add( material2 );
+							prepareMaterial(material2, targetScene, object);
+							materials.add(material2);
 
 						}
 
 					} else {
 
-						prepareMaterial( material, targetScene, object );
-						materials.add( material );
+						prepareMaterial(material, targetScene, object);
+						materials.add(material);
 
 					}
 
 				}
 
-			} );
+			});
 
 			currentRenderState = renderStateStack.pop();
 
@@ -1469,47 +1469,47 @@ class WebGLRenderer {
 		 * @param {?Scene} [targetScene=null] - The target scene.
 		 * @return {Promise} A Promise that resolves when the given scene can be rendered without unnecessary stalling due to shader compilation.
 		 */
-		this.compileAsync = function ( scene, camera, targetScene = null ) {
+		this.compileAsync = function (scene, camera, targetScene = null) {
 
-			const materials = this.compile( scene, camera, targetScene );
+			const materials = this.compile(scene, camera, targetScene);
 
 			// Wait for all the materials in the new object to indicate that they're
 			// ready to be used before resolving the promise.
 
-			return new Promise( ( resolve ) => {
+			return new Promise((resolve) => {
 
 				function checkMaterialsReady() {
 
-					materials.forEach( function ( material ) {
+					materials.forEach(function (material) {
 
-						const materialProperties = properties.get( material );
+						const materialProperties = properties.get(material);
 						const program = materialProperties.currentProgram;
 
-						if ( program.isReady() ) {
+						if (program.isReady()) {
 
 							// remove any programs that report they're ready to use from the list
-							materials.delete( material );
+							materials.delete(material);
 
 						}
 
-					} );
+					});
 
 					// once the list of compiling materials is empty, call the callback
 
-					if ( materials.size === 0 ) {
+					if (materials.size === 0) {
 
-						resolve( scene );
+						resolve(scene);
 						return;
 
 					}
 
 					// if some materials are still not ready, wait a bit and check again
 
-					setTimeout( checkMaterialsReady, 10 );
+					setTimeout(checkMaterialsReady, 10);
 
 				}
 
-				if ( extensions.get( 'KHR_parallel_shader_compile' ) !== null ) {
+				if (extensions.get('KHR_parallel_shader_compile') !== null) {
 
 					// If we can check the compilation status of the materials without
 					// blocking then do so right away.
@@ -1521,11 +1521,11 @@ class WebGLRenderer {
 					// Otherwise start by waiting a bit to give the materials we just
 					// initialized a chance to finish.
 
-					setTimeout( checkMaterialsReady, 10 );
+					setTimeout(checkMaterialsReady, 10);
 
 				}
 
-			} );
+			});
 
 		};
 
@@ -1533,9 +1533,9 @@ class WebGLRenderer {
 
 		let onAnimationFrameCallback = null;
 
-		function onAnimationFrame( time ) {
+		function onAnimationFrame(time) {
 
-			if ( onAnimationFrameCallback ) onAnimationFrameCallback( time );
+			if (onAnimationFrameCallback) onAnimationFrameCallback(time);
 
 		}
 
@@ -1552,9 +1552,9 @@ class WebGLRenderer {
 		}
 
 		const animation = new WebGLAnimation();
-		animation.setAnimationLoop( onAnimationFrame );
+		animation.setAnimationLoop(onAnimationFrame);
 
-		if ( typeof self !== 'undefined' ) animation.setContext( self );
+		if (typeof self !== 'undefined') animation.setContext(self);
 
 		/**
 		 * Applications are advised to always define the animation loop
@@ -1563,17 +1563,17 @@ class WebGLRenderer {
 		 *
 		 * @param {?onAnimationCallback} callback - The application's animation loop.
 		 */
-		this.setAnimationLoop = function ( callback ) {
+		this.setAnimationLoop = function (callback) {
 
 			onAnimationFrameCallback = callback;
-			xr.setAnimationLoop( callback );
+			xr.setAnimationLoop(callback);
 
-			( callback === null ) ? animation.stop() : animation.start();
+			(callback === null) ? animation.stop() : animation.start();
 
 		};
 
-		xr.addEventListener( 'sessionstart', onXRSessionStart );
-		xr.addEventListener( 'sessionend', onXRSessionEnd );
+		xr.addEventListener('sessionstart', onXRSessionStart);
+		xr.addEventListener('sessionend', onXRSessionEnd);
 
 		// Rendering
 
@@ -1591,147 +1591,147 @@ class WebGLRenderer {
 		 * @param {Object3D} scene - The scene to render.
 		 * @param {Camera} camera - The camera.
 		 */
-		this.render = function ( scene, camera ) {
+		this.render = function (scene, camera) {
 
-			if ( camera !== undefined && camera.isCamera !== true ) {
+			if (camera !== undefined && camera.isCamera !== true) {
 
-				error( 'WebGLRenderer.render: camera is not an instance of THREE.Camera.' );
+				error('WebGLRenderer.render: camera is not an instance of THREE.Camera.');
 				return;
 
 			}
 
-			if ( _isContextLost === true ) return;
+			if (_isContextLost === true) return;
 
 			// use internal render target for HalfFloatType color buffer (only when tone mapping is enabled)
 
 			const isXRPresenting = xr.enabled === true && xr.isPresenting === true;
 
-			const useOutput = output !== null && ( _currentRenderTarget === null || isXRPresenting ) && output.begin( _this, _currentRenderTarget );
+			const useOutput = output !== null && (_currentRenderTarget === null || isXRPresenting) && output.begin(_this, _currentRenderTarget);
 
 			// update scene graph
 
-			if ( scene.matrixWorldAutoUpdate === true ) scene.updateMatrixWorld();
+			if (scene.matrixWorldAutoUpdate === true) scene.updateMatrixWorld();
 
 			// update camera matrices and frustum
 
-			if ( camera.parent === null && camera.matrixWorldAutoUpdate === true ) camera.updateMatrixWorld();
+			if (camera.parent === null && camera.matrixWorldAutoUpdate === true) camera.updateMatrixWorld();
 
-			if ( xr.enabled === true && xr.isPresenting === true && ( output === null || output.isCompositing() === false ) ) {
+			if (xr.enabled === true && xr.isPresenting === true && (output === null || output.isCompositing() === false)) {
 
-				if ( xr.cameraAutoUpdate === true ) xr.updateCamera( camera );
+				if (xr.cameraAutoUpdate === true) xr.updateCamera(camera);
 
 				camera = xr.getCamera(); // use XR camera for rendering
 
 			}
 
 			//
-			if ( scene.isScene === true ) scene.onBeforeRender( _this, scene, camera, _currentRenderTarget );
+			if (scene.isScene === true) scene.onBeforeRender(_this, scene, camera, _currentRenderTarget);
 
-			currentRenderState = renderStates.get( scene, renderStateStack.length );
-			currentRenderState.init( camera );
+			currentRenderState = renderStates.get(scene, renderStateStack.length);
+			currentRenderState.init(camera);
 
-			renderStateStack.push( currentRenderState );
+			renderStateStack.push(currentRenderState);
 
-			_projScreenMatrix.multiplyMatrices( camera.projectionMatrix, camera.matrixWorldInverse );
-			_frustum.setFromProjectionMatrix( _projScreenMatrix, WebGLCoordinateSystem, camera.reversedDepth );
+			_projScreenMatrix.multiplyMatrices(camera.projectionMatrix, camera.matrixWorldInverse);
+			_frustum.setFromProjectionMatrix(_projScreenMatrix, WebGLCoordinateSystem, camera.reversedDepth);
 
 			_localClippingEnabled = this.localClippingEnabled;
-			_clippingEnabled = clipping.init( this.clippingPlanes, _localClippingEnabled );
+			_clippingEnabled = clipping.init(this.clippingPlanes, _localClippingEnabled);
 
-			currentRenderList = renderLists.get( scene, renderListStack.length );
+			currentRenderList = renderLists.get(scene, renderListStack.length);
 			currentRenderList.init();
 
-			renderListStack.push( currentRenderList );
+			renderListStack.push(currentRenderList);
 
-			if ( xr.enabled === true && xr.isPresenting === true ) {
+			if (xr.enabled === true && xr.isPresenting === true) {
 
 				const depthSensingMesh = _this.xr.getDepthSensingMesh();
 
-				if ( depthSensingMesh !== null ) {
+				if (depthSensingMesh !== null) {
 
-					projectObject( depthSensingMesh, camera, - Infinity, _this.sortObjects );
+					projectObject(depthSensingMesh, camera, - Infinity, _this.sortObjects);
 
 				}
 
 			}
 
-			projectObject( scene, camera, 0, _this.sortObjects );
+			projectObject(scene, camera, 0, _this.sortObjects);
 
 			currentRenderList.finish();
 
-			if ( _this.sortObjects === true ) {
+			if (_this.sortObjects === true) {
 
-				currentRenderList.sort( _opaqueSort, _transparentSort );
+				currentRenderList.sort(_opaqueSort, _transparentSort);
 
 			}
 
 			_renderBackground = xr.enabled === false || xr.isPresenting === false || xr.hasDepthSensing() === false;
-			if ( _renderBackground ) {
+			if (_renderBackground) {
 
-				background.addToRenderList( currentRenderList, scene );
+				background.addToRenderList(currentRenderList, scene);
 
 			}
 
 			//
 
-			this.info.render.frame ++;
+			this.info.render.frame++;
 
-			if ( _clippingEnabled === true ) clipping.beginShadows();
+			if (_clippingEnabled === true) clipping.beginShadows();
 
 			const shadowsArray = currentRenderState.state.shadowsArray;
 
-			shadowMap.render( shadowsArray, scene, camera );
+			shadowMap.render(shadowsArray, scene, camera);
 
-			if ( _clippingEnabled === true ) clipping.endShadows();
+			if (_clippingEnabled === true) clipping.endShadows();
 
 			//
 
-			if ( this.info.autoReset === true ) this.info.reset();
+			if (this.info.autoReset === true) this.info.reset();
 
 			// render scene (skip if first effect is a render pass - it will render the scene itself)
 
 			const skipSceneRender = useOutput && output.hasRenderPass();
 
-			if ( skipSceneRender === false ) {
+			if (skipSceneRender === false) {
 
 				const opaqueObjects = currentRenderList.opaque;
 				const transmissiveObjects = currentRenderList.transmissive;
 
 				currentRenderState.setupLights();
 
-				if ( camera.isArrayCamera ) {
+				if (camera.isArrayCamera) {
 
 					const cameras = camera.cameras;
 
-					if ( transmissiveObjects.length > 0 ) {
+					if (transmissiveObjects.length > 0) {
 
-						for ( let i = 0, l = cameras.length; i < l; i ++ ) {
+						for (let i = 0, l = cameras.length; i < l; i++) {
 
-							const camera2 = cameras[ i ];
+							const camera2 = cameras[i];
 
-							renderTransmissionPass( opaqueObjects, transmissiveObjects, scene, camera2 );
+							renderTransmissionPass(opaqueObjects, transmissiveObjects, scene, camera2);
 
 						}
 
 					}
 
-					if ( _renderBackground ) background.render( scene );
+					if (_renderBackground) background.render(scene);
 
-					for ( let i = 0, l = cameras.length; i < l; i ++ ) {
+					for (let i = 0, l = cameras.length; i < l; i++) {
 
-						const camera2 = cameras[ i ];
+						const camera2 = cameras[i];
 
-						renderScene( currentRenderList, scene, camera2, camera2.viewport );
+						renderScene(currentRenderList, scene, camera2, camera2.viewport);
 
 					}
 
 				} else {
 
-					if ( transmissiveObjects.length > 0 ) renderTransmissionPass( opaqueObjects, transmissiveObjects, scene, camera );
+					if (transmissiveObjects.length > 0) renderTransmissionPass(opaqueObjects, transmissiveObjects, scene, camera);
 
-					if ( _renderBackground ) background.render( scene );
+					if (_renderBackground) background.render(scene);
 
-					renderScene( currentRenderList, scene, camera );
+					renderScene(currentRenderList, scene, camera);
 
 				}
 
@@ -1739,29 +1739,29 @@ class WebGLRenderer {
 
 			//
 
-			if ( _currentRenderTarget !== null && _currentActiveMipmapLevel === 0 ) {
+			if (_currentRenderTarget !== null && _currentActiveMipmapLevel === 0) {
 
 				// resolve multisample renderbuffers to a single-sample texture if necessary
 
-				textures.updateMultisampleRenderTarget( _currentRenderTarget );
+				textures.updateMultisampleRenderTarget(_currentRenderTarget);
 
 				// Generate mipmap if we're using any kind of mipmap filtering
 
-				textures.updateRenderTargetMipmap( _currentRenderTarget );
+				textures.updateRenderTargetMipmap(_currentRenderTarget);
 
 			}
 
 			// copy from internal render target to canvas using fullscreen quad
 
-			if ( useOutput ) {
+			if (useOutput) {
 
-				output.end( _this );
+				output.end(_this);
 
 			}
 
 			//
 
-			if ( scene.isScene === true ) scene.onAfterRender( _this, scene, camera );
+			if (scene.isScene === true) scene.onAfterRender(_this, scene, camera);
 
 			// _gl.finish();
 
@@ -1771,11 +1771,11 @@ class WebGLRenderer {
 
 			renderStateStack.pop();
 
-			if ( renderStateStack.length > 0 ) {
+			if (renderStateStack.length > 0) {
 
-				currentRenderState = renderStateStack[ renderStateStack.length - 1 ];
+				currentRenderState = renderStateStack[renderStateStack.length - 1];
 
-				if ( _clippingEnabled === true ) clipping.setGlobalState( _this.clippingPlanes, currentRenderState.state.camera );
+				if (_clippingEnabled === true) clipping.setGlobalState(_this.clippingPlanes, currentRenderState.state.camera);
 
 			} else {
 
@@ -1785,9 +1785,9 @@ class WebGLRenderer {
 
 			renderListStack.pop();
 
-			if ( renderListStack.length > 0 ) {
+			if (renderListStack.length > 0) {
 
-				currentRenderList = renderListStack[ renderListStack.length - 1 ];
+				currentRenderList = renderListStack[renderListStack.length - 1];
 
 			} else {
 
@@ -1797,101 +1797,101 @@ class WebGLRenderer {
 
 		};
 
-		function projectObject( object, camera, groupOrder, sortObjects ) {
+		function projectObject(object, camera, groupOrder, sortObjects) {
 
-			if ( object.visible === false ) return;
+			if (object.visible === false) return;
 
-			const visible = object.layers.test( camera.layers );
+			const visible = object.layers.test(camera.layers);
 
-			if ( visible ) {
+			if (visible) {
 
-				if ( object.isGroup ) {
+				if (object.isGroup) {
 
 					groupOrder = object.renderOrder;
 
-				} else if ( object.isLOD ) {
+				} else if (object.isLOD) {
 
-					if ( object.autoUpdate === true ) object.update( camera );
+					if (object.autoUpdate === true) object.update(camera);
 
-				} else if ( object.isLight ) {
+				} else if (object.isLight) {
 
-					currentRenderState.pushLight( object );
+					currentRenderState.pushLight(object);
 
-					if ( object.castShadow ) {
+					if (object.castShadow) {
 
-						currentRenderState.pushShadow( object );
-
-					}
-
-				} else if ( object.isSprite ) {
-
-					if ( ! object.frustumCulled || _frustum.intersectsSprite( object ) ) {
-
-						if ( sortObjects ) {
-
-							_vector4.setFromMatrixPosition( object.matrixWorld )
-								.applyMatrix4( _projScreenMatrix );
-
-						}
-
-						const geometry = objects.update( object );
-						const material = object.material;
-
-						if ( material.visible ) {
-
-							currentRenderList.push( object, geometry, material, groupOrder, _vector4.z, null );
-
-						}
+						currentRenderState.pushShadow(object);
 
 					}
 
-				} else if ( object.isMesh || object.isLine || object.isPoints ) {
+				} else if (object.isSprite) {
 
-					if ( ! object.frustumCulled || _frustum.intersectsObject( object ) ) {
+					if (!object.frustumCulled || _frustum.intersectsSprite(object)) {
 
-						const geometry = objects.update( object );
+						if (sortObjects) {
+
+							_vector4.setFromMatrixPosition(object.matrixWorld)
+								.applyMatrix4(_projScreenMatrix);
+
+						}
+
+						const geometry = objects.update(object);
 						const material = object.material;
 
-						if ( sortObjects ) {
+						if (material.visible) {
 
-							if ( object.boundingSphere !== undefined ) {
+							currentRenderList.push(object, geometry, material, groupOrder, _vector4.z, null);
 
-								if ( object.boundingSphere === null ) object.computeBoundingSphere();
-								_vector4.copy( object.boundingSphere.center );
+						}
+
+					}
+
+				} else if (object.isMesh || object.isLine || object.isPoints) {
+
+					if (!object.frustumCulled || _frustum.intersectsObject(object)) {
+
+						const geometry = objects.update(object);
+						const material = object.material;
+
+						if (sortObjects) {
+
+							if (object.boundingSphere !== undefined) {
+
+								if (object.boundingSphere === null) object.computeBoundingSphere();
+								_vector4.copy(object.boundingSphere.center);
 
 							} else {
 
-								if ( geometry.boundingSphere === null ) geometry.computeBoundingSphere();
-								_vector4.copy( geometry.boundingSphere.center );
+								if (geometry.boundingSphere === null) geometry.computeBoundingSphere();
+								_vector4.copy(geometry.boundingSphere.center);
 
 							}
 
 							_vector4
-								.applyMatrix4( object.matrixWorld )
-								.applyMatrix4( _projScreenMatrix );
+								.applyMatrix4(object.matrixWorld)
+								.applyMatrix4(_projScreenMatrix);
 
 						}
 
-						if ( Array.isArray( material ) ) {
+						if (Array.isArray(material)) {
 
 							const groups = geometry.groups;
 
-							for ( let i = 0, l = groups.length; i < l; i ++ ) {
+							for (let i = 0, l = groups.length; i < l; i++) {
 
-								const group = groups[ i ];
-								const groupMaterial = material[ group.materialIndex ];
+								const group = groups[i];
+								const groupMaterial = material[group.materialIndex];
 
-								if ( groupMaterial && groupMaterial.visible ) {
+								if (groupMaterial && groupMaterial.visible) {
 
-									currentRenderList.push( object, geometry, groupMaterial, groupOrder, _vector4.z, group );
+									currentRenderList.push(object, geometry, groupMaterial, groupOrder, _vector4.z, group);
 
 								}
 
 							}
 
-						} else if ( material.visible ) {
+						} else if (material.visible) {
 
-							currentRenderList.push( object, geometry, material, groupOrder, _vector4.z, null );
+							currentRenderList.push(object, geometry, material, groupOrder, _vector4.z, null);
 
 						}
 
@@ -1903,53 +1903,53 @@ class WebGLRenderer {
 
 			const children = object.children;
 
-			for ( let i = 0, l = children.length; i < l; i ++ ) {
+			for (let i = 0, l = children.length; i < l; i++) {
 
-				projectObject( children[ i ], camera, groupOrder, sortObjects );
+				projectObject(children[i], camera, groupOrder, sortObjects);
 
 			}
 
 		}
 
-		function renderScene( currentRenderList, scene, camera, viewport ) {
+		function renderScene(currentRenderList, scene, camera, viewport) {
 
 			const { opaque: opaqueObjects, transmissive: transmissiveObjects, transparent: transparentObjects } = currentRenderList;
 
-			currentRenderState.setupLightsView( camera );
+			currentRenderState.setupLightsView(camera);
 
-			if ( _clippingEnabled === true ) clipping.setGlobalState( _this.clippingPlanes, camera );
+			if (_clippingEnabled === true) clipping.setGlobalState(_this.clippingPlanes, camera);
 
-			if ( viewport ) state.viewport( _currentViewport.copy( viewport ) );
+			if (viewport) state.viewport(_currentViewport.copy(viewport));
 
-			if ( opaqueObjects.length > 0 ) renderObjects( opaqueObjects, scene, camera );
-			if ( transmissiveObjects.length > 0 ) renderObjects( transmissiveObjects, scene, camera );
-			if ( transparentObjects.length > 0 ) renderObjects( transparentObjects, scene, camera );
+			if (opaqueObjects.length > 0) renderObjects(opaqueObjects, scene, camera);
+			if (transmissiveObjects.length > 0) renderObjects(transmissiveObjects, scene, camera);
+			if (transparentObjects.length > 0) renderObjects(transparentObjects, scene, camera);
 
 			// Ensure depth buffer writing is enabled so it can be cleared on next render
 
-			state.buffers.depth.setTest( true );
-			state.buffers.depth.setMask( true );
-			state.buffers.color.setMask( true );
+			state.buffers.depth.setTest(true);
+			state.buffers.depth.setMask(true);
+			state.buffers.color.setMask(true);
 
-			state.setPolygonOffset( false );
+			state.setPolygonOffset(false);
 
 		}
 
-		function renderTransmissionPass( opaqueObjects, transmissiveObjects, scene, camera ) {
+		function renderTransmissionPass(opaqueObjects, transmissiveObjects, scene, camera) {
 
 			const overrideMaterial = scene.isScene === true ? scene.overrideMaterial : null;
 
-			if ( overrideMaterial !== null ) {
+			if (overrideMaterial !== null) {
 
 				return;
 
 			}
 
-			if ( currentRenderState.state.transmissionRenderTarget[ camera.id ] === undefined ) {
+			if (currentRenderState.state.transmissionRenderTarget[camera.id] === undefined) {
 
-				const hasHalfFloatSupport = extensions.has( 'EXT_color_buffer_half_float' ) || extensions.has( 'EXT_color_buffer_float' );
+				const hasHalfFloatSupport = extensions.has('EXT_color_buffer_half_float') || extensions.has('EXT_color_buffer_float');
 
-				currentRenderState.state.transmissionRenderTarget[ camera.id ] = new WebGLRenderTarget( 1, 1, {
+				currentRenderState.state.transmissionRenderTarget[camera.id] = new WebGLRenderTarget(1, 1, {
 					generateMipmaps: true,
 					type: hasHalfFloatSupport ? HalfFloatType : UnsignedByteType,
 					minFilter: LinearMipmapLinearFilter,
@@ -1958,7 +1958,7 @@ class WebGLRenderer {
 					resolveDepthBuffer: false,
 					resolveStencilBuffer: false,
 					colorSpace: ColorManagement.workingColorSpace,
-				} );
+				});
 
 				// debug
 
@@ -1972,10 +1972,10 @@ class WebGLRenderer {
 
 			}
 
-			const transmissionRenderTarget = currentRenderState.state.transmissionRenderTarget[ camera.id ];
+			const transmissionRenderTarget = currentRenderState.state.transmissionRenderTarget[camera.id];
 
 			const activeViewport = camera.viewport || _currentViewport;
-			transmissionRenderTarget.setSize( activeViewport.z * _this.transmissionResolutionScale, activeViewport.w * _this.transmissionResolutionScale );
+			transmissionRenderTarget.setSize(activeViewport.z * _this.transmissionResolutionScale, activeViewport.w * _this.transmissionResolutionScale);
 
 			//
 
@@ -1983,15 +1983,15 @@ class WebGLRenderer {
 			const currentActiveCubeFace = _this.getActiveCubeFace();
 			const currentActiveMipmapLevel = _this.getActiveMipmapLevel();
 
-			_this.setRenderTarget( transmissionRenderTarget );
+			_this.setRenderTarget(transmissionRenderTarget);
 
-			_this.getClearColor( _currentClearColor );
+			_this.getClearColor(_currentClearColor);
 			_currentClearAlpha = _this.getClearAlpha();
-			if ( _currentClearAlpha < 1 ) _this.setClearColor( 0xffffff, 0.5 );
+			if (_currentClearAlpha < 1) _this.setClearColor(0xffffff, 0.5);
 
 			_this.clear();
 
-			if ( _renderBackground ) background.render( scene );
+			if (_renderBackground) background.render(scene);
 
 			// Turn off the features which can affect the frag color for opaque objects pass.
 			// Otherwise they are applied twice in opaque objects pass and transmission objects pass.
@@ -2001,35 +2001,35 @@ class WebGLRenderer {
 			// Remove viewport from camera to avoid nested render calls resetting viewport to it (e.g Reflector).
 			// Transmission render pass requires viewport to match the transmissionRenderTarget.
 			const currentCameraViewport = camera.viewport;
-			if ( camera.viewport !== undefined ) camera.viewport = undefined;
+			if (camera.viewport !== undefined) camera.viewport = undefined;
 
-			currentRenderState.setupLightsView( camera );
+			currentRenderState.setupLightsView(camera);
 
-			if ( _clippingEnabled === true ) clipping.setGlobalState( _this.clippingPlanes, camera );
+			if (_clippingEnabled === true) clipping.setGlobalState(_this.clippingPlanes, camera);
 
-			renderObjects( opaqueObjects, scene, camera );
+			renderObjects(opaqueObjects, scene, camera);
 
-			textures.updateMultisampleRenderTarget( transmissionRenderTarget );
-			textures.updateRenderTargetMipmap( transmissionRenderTarget );
+			textures.updateMultisampleRenderTarget(transmissionRenderTarget);
+			textures.updateRenderTargetMipmap(transmissionRenderTarget);
 
-			if ( extensions.has( 'WEBGL_multisampled_render_to_texture' ) === false ) { // see #28131
+			if (extensions.has('WEBGL_multisampled_render_to_texture') === false) { // see #28131
 
 				let renderTargetNeedsUpdate = false;
 
-				for ( let i = 0, l = transmissiveObjects.length; i < l; i ++ ) {
+				for (let i = 0, l = transmissiveObjects.length; i < l; i++) {
 
-					const renderItem = transmissiveObjects[ i ];
+					const renderItem = transmissiveObjects[i];
 
 					const { object, geometry, material, group } = renderItem;
 
-					if ( material.side === DoubleSide && object.layers.test( camera.layers ) ) {
+					if (material.side === DoubleSide && object.layers.test(camera.layers)) {
 
 						const currentSide = material.side;
 
 						material.side = BackSide;
 						material.needsUpdate = true;
 
-						renderObject( object, scene, camera, geometry, material, group );
+						renderObject(object, scene, camera, geometry, material, group);
 
 						material.side = currentSide;
 						material.needsUpdate = true;
@@ -2040,45 +2040,45 @@ class WebGLRenderer {
 
 				}
 
-				if ( renderTargetNeedsUpdate === true ) {
+				if (renderTargetNeedsUpdate === true) {
 
-					textures.updateMultisampleRenderTarget( transmissionRenderTarget );
-					textures.updateRenderTargetMipmap( transmissionRenderTarget );
+					textures.updateMultisampleRenderTarget(transmissionRenderTarget);
+					textures.updateRenderTargetMipmap(transmissionRenderTarget);
 
 				}
 
 			}
 
-			_this.setRenderTarget( currentRenderTarget, currentActiveCubeFace, currentActiveMipmapLevel );
+			_this.setRenderTarget(currentRenderTarget, currentActiveCubeFace, currentActiveMipmapLevel);
 
-			_this.setClearColor( _currentClearColor, _currentClearAlpha );
+			_this.setClearColor(_currentClearColor, _currentClearAlpha);
 
-			if ( currentCameraViewport !== undefined ) camera.viewport = currentCameraViewport;
+			if (currentCameraViewport !== undefined) camera.viewport = currentCameraViewport;
 
 			_this.toneMapping = currentToneMapping;
 
 		}
 
-		function renderObjects( renderList, scene, camera ) {
+		function renderObjects(renderList, scene, camera) {
 
 			const overrideMaterial = scene.isScene === true ? scene.overrideMaterial : null;
 
-			for ( let i = 0, l = renderList.length; i < l; i ++ ) {
+			for (let i = 0, l = renderList.length; i < l; i++) {
 
-				const renderItem = renderList[ i ];
+				const renderItem = renderList[i];
 
 				const { object, geometry, group } = renderItem;
 				let material = renderItem.material;
 
-				if ( material.allowOverride === true && overrideMaterial !== null ) {
+				if (material.allowOverride === true && overrideMaterial !== null) {
 
 					material = overrideMaterial;
 
 				}
 
-				if ( object.layers.test( camera.layers ) ) {
+				if (object.layers.test(camera.layers)) {
 
-					renderObject( object, scene, camera, geometry, material, group );
+					renderObject(object, scene, camera, geometry, material, group);
 
 				}
 
@@ -2086,82 +2086,82 @@ class WebGLRenderer {
 
 		}
 
-		function renderObject( object, scene, camera, geometry, material, group ) {
+		function renderObject(object, scene, camera, geometry, material, group) {
 
-			object.onBeforeRender( _this, scene, camera, geometry, material, group );
+			object.onBeforeRender(_this, scene, camera, geometry, material, group);
 
-			object.modelViewMatrix.multiplyMatrices( camera.matrixWorldInverse, object.matrixWorld );
-			object.normalMatrix.getNormalMatrix( object.modelViewMatrix );
+			object.modelViewMatrix.multiplyMatrices(camera.matrixWorldInverse, object.matrixWorld);
+			object.normalMatrix.getNormalMatrix(object.modelViewMatrix);
 
-			material.onBeforeRender( _this, scene, camera, geometry, object, group );
+			material.onBeforeRender(_this, scene, camera, geometry, object, group);
 
-			if ( material.transparent === true && material.side === DoubleSide && material.forceSinglePass === false ) {
+			if (material.transparent === true && material.side === DoubleSide && material.forceSinglePass === false) {
 
 				material.side = BackSide;
 				material.needsUpdate = true;
-				_this.renderBufferDirect( camera, scene, geometry, material, object, group );
+				_this.renderBufferDirect(camera, scene, geometry, material, object, group);
 
 				material.side = FrontSide;
 				material.needsUpdate = true;
-				_this.renderBufferDirect( camera, scene, geometry, material, object, group );
+				_this.renderBufferDirect(camera, scene, geometry, material, object, group);
 
 				material.side = DoubleSide;
 
 			} else {
 
-				_this.renderBufferDirect( camera, scene, geometry, material, object, group );
+				_this.renderBufferDirect(camera, scene, geometry, material, object, group);
 
 			}
 
-			object.onAfterRender( _this, scene, camera, geometry, material, group );
+			object.onAfterRender(_this, scene, camera, geometry, material, group);
 
 		}
 
-		function getProgram( material, scene, object ) {
+		function getProgram(material, scene, object) {
 
-			if ( scene.isScene !== true ) scene = _emptyScene; // scene could be a Mesh, Line, Points, ...
+			if (scene.isScene !== true) scene = _emptyScene; // scene could be a Mesh, Line, Points, ...
 
-			const materialProperties = properties.get( material );
+			const materialProperties = properties.get(material);
 
 			const lights = currentRenderState.state.lights;
 			const shadowsArray = currentRenderState.state.shadowsArray;
 
 			const lightsStateVersion = lights.state.version;
 
-			const parameters = programCache.getParameters( material, lights.state, shadowsArray, scene, object );
-			const programCacheKey = programCache.getProgramCacheKey( parameters );
+			const parameters = programCache.getParameters(material, lights.state, shadowsArray, scene, object);
+			const programCacheKey = programCache.getProgramCacheKey(parameters);
 
 			let programs = materialProperties.programs;
 
 			// always update environment and fog - changing these trigger an getProgram call, but it's possible that the program doesn't change
 
-			materialProperties.environment = ( material.isMeshStandardMaterial || material.isMeshLambertMaterial || material.isMeshPhongMaterial ) ? scene.environment : null;
+			materialProperties.environment = (material.isMeshStandardMaterial || material.isMeshLambertMaterial || material.isMeshPhongMaterial) ? scene.environment : null;
 			materialProperties.fog = scene.fog;
 
-			const usePMREM = material.isMeshStandardMaterial || ( material.isMeshLambertMaterial && ! material.envMap ) || ( material.isMeshPhongMaterial && ! material.envMap );
-			materialProperties.envMap = environments.get( material.envMap || materialProperties.environment, usePMREM );
-			materialProperties.envMapRotation = ( materialProperties.environment !== null && material.envMap === null ) ? scene.environmentRotation : material.envMapRotation;
+			const usePMREM = material.isMeshStandardMaterial || (material.isMeshLambertMaterial && !material.envMap) || (material.isMeshPhongMaterial && !material.envMap);
+			materialProperties.envMap = environments.get(material.envMap || materialProperties.environment, usePMREM);
+			materialProperties.envMapRotation = (materialProperties.environment !== null && material.envMap === null) ? scene.environmentRotation : material.envMapRotation;
 
-			if ( programs === undefined ) {
+			if (programs === undefined) {
 
 				// new material
 
-				material.addEventListener( 'dispose', onMaterialDispose );
+				material.addEventListener('dispose', onMaterialDispose);
 
 				programs = new Map();
 				materialProperties.programs = programs;
 
 			}
 
-			let program = programs.get( programCacheKey );
+			let program = programs.get(programCacheKey);
 
-			if ( program !== undefined ) {
+			if (program !== undefined) {
 
 				// early out if program and light state is identical
 
-				if ( materialProperties.currentProgram === program && materialProperties.lightsStateVersion === lightsStateVersion ) {
+				if (materialProperties.currentProgram === program && materialProperties.lightsStateVersion === lightsStateVersion) {
 
-					updateCommonMaterialProperties( material, parameters );
+					updateCommonMaterialProperties(material, parameters);
 
 					return program;
 
@@ -2169,12 +2169,12 @@ class WebGLRenderer {
 
 			} else {
 
-				parameters.uniforms = programCache.getUniforms( material );
+				parameters.uniforms = programCache.getUniforms(material);
 
-				material.onBeforeCompile( parameters, _this );
+				material.onBeforeCompile(parameters, _this);
 
-				program = programCache.acquireProgram( parameters, programCacheKey );
-				programs.set( programCacheKey, program );
+				program = programCache.acquireProgram(parameters, programCacheKey);
+				programs.set(programCacheKey, program);
 
 				materialProperties.uniforms = parameters.uniforms;
 
@@ -2182,20 +2182,20 @@ class WebGLRenderer {
 
 			const uniforms = materialProperties.uniforms;
 
-			if ( ( ! material.isShaderMaterial && ! material.isRawShaderMaterial ) || material.clipping === true ) {
+			if ((!material.isShaderMaterial && !material.isRawShaderMaterial) || material.clipping === true) {
 
 				uniforms.clippingPlanes = clipping.uniform;
 
 			}
 
-			updateCommonMaterialProperties( material, parameters );
+			updateCommonMaterialProperties(material, parameters);
 
 			// store the light setup it was created for
 
-			materialProperties.needsLights = materialNeedsLights( material );
+			materialProperties.needsLights = materialNeedsLights(material);
 			materialProperties.lightsStateVersion = lightsStateVersion;
 
-			if ( materialProperties.needsLights ) {
+			if (materialProperties.needsLights) {
 
 				// wire up the material to this renderer's lighting state
 
@@ -2227,12 +2227,12 @@ class WebGLRenderer {
 
 		}
 
-		function getUniformList( materialProperties ) {
+		function getUniformList(materialProperties) {
 
-			if ( materialProperties.uniformsList === null ) {
+			if (materialProperties.uniformsList === null) {
 
 				const progUniforms = materialProperties.currentProgram.getUniforms();
-				materialProperties.uniformsList = WebGLUniforms.seqWithValue( progUniforms.seq, materialProperties.uniforms );
+				materialProperties.uniformsList = WebGLUniforms.seqWithValue(progUniforms.seq, materialProperties.uniforms);
 
 			}
 
@@ -2240,9 +2240,9 @@ class WebGLRenderer {
 
 		}
 
-		function updateCommonMaterialProperties( material, parameters ) {
+		function updateCommonMaterialProperties(material, parameters) {
 
-			const materialProperties = properties.get( material );
+			const materialProperties = properties.get(material);
 
 			materialProperties.outputColorSpace = parameters.outputColorSpace;
 			materialProperties.batching = parameters.batching;
@@ -2263,28 +2263,28 @@ class WebGLRenderer {
 
 		}
 
-		function setProgram( camera, scene, geometry, material, object ) {
+		function setProgram(camera, scene, geometry, material, object) {
 
-			if ( scene.isScene !== true ) scene = _emptyScene; // scene could be a Mesh, Line, Points, ...
+			if (scene.isScene !== true) scene = _emptyScene; // scene could be a Mesh, Line, Points, ...
 
 			textures.resetTextureUnits();
 
 			const fog = scene.fog;
-			const environment = ( material.isMeshStandardMaterial || material.isMeshLambertMaterial || material.isMeshPhongMaterial ) ? scene.environment : null;
-			const colorSpace = ( _currentRenderTarget === null ) ? _this.outputColorSpace : ( _currentRenderTarget.isXRRenderTarget === true ? _currentRenderTarget.texture.colorSpace : ColorManagement.workingColorSpace );
-			const usePMREM = material.isMeshStandardMaterial || ( material.isMeshLambertMaterial && ! material.envMap ) || ( material.isMeshPhongMaterial && ! material.envMap );
-			const envMap = environments.get( material.envMap || environment, usePMREM );
-			const vertexAlphas = material.vertexColors === true && !! geometry.attributes.color && geometry.attributes.color.itemSize === 4;
-			const vertexTangents = !! geometry.attributes.tangent && ( !! material.normalMap || material.anisotropy > 0 );
-			const morphTargets = !! geometry.morphAttributes.position;
-			const morphNormals = !! geometry.morphAttributes.normal;
-			const morphColors = !! geometry.morphAttributes.color;
+			const environment = (material.isMeshStandardMaterial || material.isMeshLambertMaterial || material.isMeshPhongMaterial) ? scene.environment : null;
+			const colorSpace = (_currentRenderTarget === null) ? _this.outputColorSpace : (_currentRenderTarget.isXRRenderTarget === true ? _currentRenderTarget.texture.colorSpace : ColorManagement.workingColorSpace);
+			const usePMREM = material.isMeshStandardMaterial || (material.isMeshLambertMaterial && !material.envMap) || (material.isMeshPhongMaterial && !material.envMap);
+			const envMap = environments.get(material.envMap || environment, usePMREM);
+			const vertexAlphas = material.vertexColors === true && !!geometry.attributes.color && geometry.attributes.color.itemSize === 4;
+			const vertexTangents = !!geometry.attributes.tangent && (!!material.normalMap || material.anisotropy > 0);
+			const morphTargets = !!geometry.morphAttributes.position;
+			const morphNormals = !!geometry.morphAttributes.normal;
+			const morphColors = !!geometry.morphAttributes.color;
 
 			let toneMapping = NoToneMapping;
 
-			if ( material.toneMapped ) {
+			if (material.toneMapped) {
 
-				if ( _currentRenderTarget === null || _currentRenderTarget.isXRRenderTarget === true ) {
+				if (_currentRenderTarget === null || _currentRenderTarget.isXRRenderTarget === true) {
 
 					toneMapping = _this.toneMapping;
 
@@ -2293,14 +2293,14 @@ class WebGLRenderer {
 			}
 
 			const morphAttribute = geometry.morphAttributes.position || geometry.morphAttributes.normal || geometry.morphAttributes.color;
-			const morphTargetsCount = ( morphAttribute !== undefined ) ? morphAttribute.length : 0;
+			const morphTargetsCount = (morphAttribute !== undefined) ? morphAttribute.length : 0;
 
-			const materialProperties = properties.get( material );
+			const materialProperties = properties.get(material);
 			const lights = currentRenderState.state.lights;
 
-			if ( _clippingEnabled === true ) {
+			if (_clippingEnabled === true) {
 
-				if ( _localClippingEnabled === true || camera !== _currentCamera ) {
+				if (_localClippingEnabled === true || camera !== _currentCamera) {
 
 					const useCache =
 						camera === _currentCamera &&
@@ -2309,7 +2309,7 @@ class WebGLRenderer {
 					// we might want to call this function with some ClippingGroup
 					// object instead of the material, once it becomes feasible
 					// (#8465, #8379)
-					clipping.setState( material, camera, useCache );
+					clipping.setState(material, camera, useCache);
 
 				}
 
@@ -2319,103 +2319,103 @@ class WebGLRenderer {
 
 			let needsProgramChange = false;
 
-			if ( material.version === materialProperties.__version ) {
+			if (material.version === materialProperties.__version) {
 
-				if ( materialProperties.needsLights && ( materialProperties.lightsStateVersion !== lights.state.version ) ) {
-
-					needsProgramChange = true;
-
-				} else if ( materialProperties.outputColorSpace !== colorSpace ) {
+				if (materialProperties.needsLights && (materialProperties.lightsStateVersion !== lights.state.version)) {
 
 					needsProgramChange = true;
 
-				} else if ( object.isBatchedMesh && materialProperties.batching === false ) {
+				} else if (materialProperties.outputColorSpace !== colorSpace) {
 
 					needsProgramChange = true;
 
-				} else if ( ! object.isBatchedMesh && materialProperties.batching === true ) {
+				} else if (object.isBatchedMesh && materialProperties.batching === false) {
 
 					needsProgramChange = true;
 
-				} else if ( object.isBatchedMesh && materialProperties.batchingColor === true && object.colorTexture === null ) {
+				} else if (!object.isBatchedMesh && materialProperties.batching === true) {
 
 					needsProgramChange = true;
 
-				} else if ( object.isBatchedMesh && materialProperties.batchingColor === false && object.colorTexture !== null ) {
+				} else if (object.isBatchedMesh && materialProperties.batchingColor === true && object.colorTexture === null) {
 
 					needsProgramChange = true;
 
-				} else if ( object.isInstancedMesh && materialProperties.instancing === false ) {
+				} else if (object.isBatchedMesh && materialProperties.batchingColor === false && object.colorTexture !== null) {
 
 					needsProgramChange = true;
 
-				} else if ( ! object.isInstancedMesh && materialProperties.instancing === true ) {
+				} else if (object.isInstancedMesh && materialProperties.instancing === false) {
 
 					needsProgramChange = true;
 
-				} else if ( object.isSkinnedMesh && materialProperties.skinning === false ) {
+				} else if (!object.isInstancedMesh && materialProperties.instancing === true) {
 
 					needsProgramChange = true;
 
-				} else if ( ! object.isSkinnedMesh && materialProperties.skinning === true ) {
+				} else if (object.isSkinnedMesh && materialProperties.skinning === false) {
 
 					needsProgramChange = true;
 
-				} else if ( object.isInstancedMesh && materialProperties.instancingColor === true && object.instanceColor === null ) {
+				} else if (!object.isSkinnedMesh && materialProperties.skinning === true) {
 
 					needsProgramChange = true;
 
-				} else if ( object.isInstancedMesh && materialProperties.instancingColor === false && object.instanceColor !== null ) {
+				} else if (object.isInstancedMesh && materialProperties.instancingColor === true && object.instanceColor === null) {
 
 					needsProgramChange = true;
 
-				} else if ( object.isInstancedMesh && materialProperties.instancingMorph === true && object.morphTexture === null ) {
+				} else if (object.isInstancedMesh && materialProperties.instancingColor === false && object.instanceColor !== null) {
 
 					needsProgramChange = true;
 
-				} else if ( object.isInstancedMesh && materialProperties.instancingMorph === false && object.morphTexture !== null ) {
+				} else if (object.isInstancedMesh && materialProperties.instancingMorph === true && object.morphTexture === null) {
 
 					needsProgramChange = true;
 
-				} else if ( materialProperties.envMap !== envMap ) {
+				} else if (object.isInstancedMesh && materialProperties.instancingMorph === false && object.morphTexture !== null) {
 
 					needsProgramChange = true;
 
-				} else if ( material.fog === true && materialProperties.fog !== fog ) {
+				} else if (materialProperties.envMap !== envMap) {
 
 					needsProgramChange = true;
 
-				} else if ( materialProperties.numClippingPlanes !== undefined &&
-					( materialProperties.numClippingPlanes !== clipping.numPlanes ||
-					materialProperties.numIntersection !== clipping.numIntersection ) ) {
+				} else if (material.fog === true && materialProperties.fog !== fog) {
 
 					needsProgramChange = true;
 
-				} else if ( materialProperties.vertexAlphas !== vertexAlphas ) {
+				} else if (materialProperties.numClippingPlanes !== undefined &&
+					(materialProperties.numClippingPlanes !== clipping.numPlanes ||
+						materialProperties.numIntersection !== clipping.numIntersection)) {
 
 					needsProgramChange = true;
 
-				} else if ( materialProperties.vertexTangents !== vertexTangents ) {
+				} else if (materialProperties.vertexAlphas !== vertexAlphas) {
 
 					needsProgramChange = true;
 
-				} else if ( materialProperties.morphTargets !== morphTargets ) {
+				} else if (materialProperties.vertexTangents !== vertexTangents) {
 
 					needsProgramChange = true;
 
-				} else if ( materialProperties.morphNormals !== morphNormals ) {
+				} else if (materialProperties.morphTargets !== morphTargets) {
 
 					needsProgramChange = true;
 
-				} else if ( materialProperties.morphColors !== morphColors ) {
+				} else if (materialProperties.morphNormals !== morphNormals) {
 
 					needsProgramChange = true;
 
-				} else if ( materialProperties.toneMapping !== toneMapping ) {
+				} else if (materialProperties.morphColors !== morphColors) {
 
 					needsProgramChange = true;
 
-				} else if ( materialProperties.morphTargetsCount !== morphTargetsCount ) {
+				} else if (materialProperties.toneMapping !== toneMapping) {
+
+					needsProgramChange = true;
+
+				} else if (materialProperties.morphTargetsCount !== morphTargetsCount) {
 
 					needsProgramChange = true;
 
@@ -2432,9 +2432,9 @@ class WebGLRenderer {
 
 			let program = materialProperties.currentProgram;
 
-			if ( needsProgramChange === true ) {
+			if (needsProgramChange === true) {
 
-				program = getProgram( material, scene, object );
+				program = getProgram(material, scene, object);
 
 			}
 
@@ -2445,7 +2445,7 @@ class WebGLRenderer {
 			const p_uniforms = program.getUniforms(),
 				m_uniforms = materialProperties.uniforms;
 
-			if ( state.useProgram( program.program ) ) {
+			if (state.useProgram(program.program)) {
 
 				refreshProgram = true;
 				refreshMaterial = true;
@@ -2453,7 +2453,7 @@ class WebGLRenderer {
 
 			}
 
-			if ( material.id !== _currentMaterialId ) {
+			if (material.id !== _currentMaterialId) {
 
 				_currentMaterialId = material.id;
 
@@ -2461,52 +2461,52 @@ class WebGLRenderer {
 
 			}
 
-			if ( refreshProgram || _currentCamera !== camera ) {
+			if (refreshProgram || _currentCamera !== camera) {
 
 				// common camera uniforms
 
 				const reversedDepthBuffer = state.buffers.depth.getReversed();
 
-				if ( reversedDepthBuffer && camera.reversedDepth !== true ) {
+				if (reversedDepthBuffer && camera.reversedDepth !== true) {
 
 					camera._reversedDepth = true;
 					camera.updateProjectionMatrix();
 
 				}
 
-				p_uniforms.setValue( _gl, 'projectionMatrix', camera.projectionMatrix );
+				p_uniforms.setValue(_gl, 'projectionMatrix', camera.projectionMatrix);
 
-				p_uniforms.setValue( _gl, 'viewMatrix', camera.matrixWorldInverse );
+				p_uniforms.setValue(_gl, 'viewMatrix', camera.matrixWorldInverse);
 
 				const uCamPos = p_uniforms.map.cameraPosition;
 
-				if ( uCamPos !== undefined ) {
+				if (uCamPos !== undefined) {
 
-					uCamPos.setValue( _gl, _vector3.setFromMatrixPosition( camera.matrixWorld ) );
+					uCamPos.setValue(_gl, _vector3.setFromMatrixPosition(camera.matrixWorld));
 
 				}
 
-				if ( capabilities.logarithmicDepthBuffer ) {
+				if (capabilities.logarithmicDepthBuffer) {
 
-					p_uniforms.setValue( _gl, 'logDepthBufFC',
-						2.0 / ( Math.log( camera.far + 1.0 ) / Math.LN2 ) );
+					p_uniforms.setValue(_gl, 'logDepthBufFC',
+						2.0 / (Math.log(camera.far + 1.0) / Math.LN2));
 
 				}
 
 				// consider moving isOrthographic to UniformLib and WebGLMaterials, see https://github.com/mrdoob/three.js/pull/26467#issuecomment-1645185067
 
-				if ( material.isMeshPhongMaterial ||
+				if (material.isMeshPhongMaterial ||
 					material.isMeshToonMaterial ||
 					material.isMeshLambertMaterial ||
 					material.isMeshBasicMaterial ||
 					material.isMeshStandardMaterial ||
-					material.isShaderMaterial ) {
+					material.isShaderMaterial) {
 
-					p_uniforms.setValue( _gl, 'isOrthographic', camera.isOrthographicCamera === true );
+					p_uniforms.setValue(_gl, 'isOrthographic', camera.isOrthographicCamera === true);
 
 				}
 
-				if ( _currentCamera !== camera ) {
+				if (_currentCamera !== camera) {
 
 					_currentCamera = camera;
 
@@ -2522,24 +2522,24 @@ class WebGLRenderer {
 			}
 
 			// Pre-allocate texture units for shadow samplers before setting data textures
-			if ( materialProperties.needsLights ) {
+			if (materialProperties.needsLights) {
 
 				// Set shadow map uniforms first to ensure they get the first texture units
-				if ( lights.state.directionalShadowMap.length > 0 ) {
+				if (lights.state.directionalShadowMap.length > 0) {
 
-					p_uniforms.setValue( _gl, 'directionalShadowMap', lights.state.directionalShadowMap, textures );
-
-				}
-
-				if ( lights.state.spotShadowMap.length > 0 ) {
-
-					p_uniforms.setValue( _gl, 'spotShadowMap', lights.state.spotShadowMap, textures );
+					p_uniforms.setValue(_gl, 'directionalShadowMap', lights.state.directionalShadowMap, textures);
 
 				}
 
-				if ( lights.state.pointShadowMap.length > 0 ) {
+				if (lights.state.spotShadowMap.length > 0) {
 
-					p_uniforms.setValue( _gl, 'pointShadowMap', lights.state.pointShadowMap, textures );
+					p_uniforms.setValue(_gl, 'spotShadowMap', lights.state.spotShadowMap, textures);
+
+				}
+
+				if (lights.state.pointShadowMap.length > 0) {
+
+					p_uniforms.setValue(_gl, 'pointShadowMap', lights.state.pointShadowMap, textures);
 
 				}
 
@@ -2549,35 +2549,35 @@ class WebGLRenderer {
 			// auto-setting of texture unit for bone and morph texture must go before other textures
 			// otherwise textures used for skinning and morphing can take over texture units reserved for other material textures
 
-			if ( object.isSkinnedMesh ) {
+			if (object.isSkinnedMesh) {
 
-				p_uniforms.setOptional( _gl, object, 'bindMatrix' );
-				p_uniforms.setOptional( _gl, object, 'bindMatrixInverse' );
+				p_uniforms.setOptional(_gl, object, 'bindMatrix');
+				p_uniforms.setOptional(_gl, object, 'bindMatrixInverse');
 
 				const skeleton = object.skeleton;
 
-				if ( skeleton ) {
+				if (skeleton) {
 
-					if ( skeleton.boneTexture === null ) skeleton.computeBoneTexture();
+					if (skeleton.boneTexture === null) skeleton.computeBoneTexture();
 
-					p_uniforms.setValue( _gl, 'boneTexture', skeleton.boneTexture, textures );
+					p_uniforms.setValue(_gl, 'boneTexture', skeleton.boneTexture, textures);
 
 				}
 
 			}
 
-			if ( object.isBatchedMesh ) {
+			if (object.isBatchedMesh) {
 
-				p_uniforms.setOptional( _gl, object, 'batchingTexture' );
-				p_uniforms.setValue( _gl, 'batchingTexture', object._matricesTexture, textures );
+				p_uniforms.setOptional(_gl, object, 'batchingTexture');
+				p_uniforms.setValue(_gl, 'batchingTexture', object._matricesTexture, textures);
 
-				p_uniforms.setOptional( _gl, object, 'batchingIdTexture' );
-				p_uniforms.setValue( _gl, 'batchingIdTexture', object._indirectTexture, textures );
+				p_uniforms.setOptional(_gl, object, 'batchingIdTexture');
+				p_uniforms.setValue(_gl, 'batchingIdTexture', object._indirectTexture, textures);
 
-				p_uniforms.setOptional( _gl, object, 'batchingColorTexture' );
-				if ( object._colorsTexture !== null ) {
+				p_uniforms.setOptional(_gl, object, 'batchingColorTexture');
+				if (object._colorsTexture !== null) {
 
-					p_uniforms.setValue( _gl, 'batchingColorTexture', object._colorsTexture, textures );
+					p_uniforms.setValue(_gl, 'batchingColorTexture', object._colorsTexture, textures);
 
 				}
 
@@ -2585,37 +2585,37 @@ class WebGLRenderer {
 
 			const morphAttributes = geometry.morphAttributes;
 
-			if ( morphAttributes.position !== undefined || morphAttributes.normal !== undefined || ( morphAttributes.color !== undefined ) ) {
+			if (morphAttributes.position !== undefined || morphAttributes.normal !== undefined || (morphAttributes.color !== undefined)) {
 
-				morphtargets.update( object, geometry, program );
+				morphtargets.update(object, geometry, program);
 
 			}
 
-			if ( refreshMaterial || materialProperties.receiveShadow !== object.receiveShadow ) {
+			if (refreshMaterial || materialProperties.receiveShadow !== object.receiveShadow) {
 
 				materialProperties.receiveShadow = object.receiveShadow;
-				p_uniforms.setValue( _gl, 'receiveShadow', object.receiveShadow );
+				p_uniforms.setValue(_gl, 'receiveShadow', object.receiveShadow);
 
 			}
 
-			if ( ( material.isMeshStandardMaterial || material.isMeshLambertMaterial || material.isMeshPhongMaterial ) && material.envMap === null && scene.environment !== null ) {
+			if ((material.isMeshStandardMaterial || material.isMeshLambertMaterial || material.isMeshPhongMaterial) && material.envMap === null && scene.environment !== null) {
 
 				m_uniforms.envMapIntensity.value = scene.environmentIntensity;
 
 			}
 
 			// Set DFG LUT for physically-based materials
-			if ( m_uniforms.dfgLUT !== undefined ) {
+			if (m_uniforms.dfgLUT !== undefined) {
 
 				m_uniforms.dfgLUT.value = getDFGLUT();
 
 			}
 
-			if ( refreshMaterial ) {
+			if (refreshMaterial) {
 
-				p_uniforms.setValue( _gl, 'toneMappingExposure', _this.toneMappingExposure );
+				p_uniforms.setValue(_gl, 'toneMappingExposure', _this.toneMappingExposure);
 
-				if ( materialProperties.needsLights ) {
+				if (materialProperties.needsLights) {
 
 					// the current material requires lighting info
 
@@ -2626,55 +2626,55 @@ class WebGLRenderer {
 					// use the current material's .needsUpdate flags to set
 					// the GL state when required
 
-					markUniformsLightsNeedsUpdate( m_uniforms, refreshLights );
+					markUniformsLightsNeedsUpdate(m_uniforms, refreshLights);
 
 				}
 
 				// refresh uniforms common to several materials
 
-				if ( fog && material.fog === true ) {
+				if (fog && material.fog === true) {
 
-					materials.refreshFogUniforms( m_uniforms, fog );
+					materials.refreshFogUniforms(m_uniforms, fog);
 
 				}
 
-				materials.refreshMaterialUniforms( m_uniforms, material, _pixelRatio, _height, currentRenderState.state.transmissionRenderTarget[ camera.id ] );
+				materials.refreshMaterialUniforms(m_uniforms, material, _pixelRatio, _height, currentRenderState.state.transmissionRenderTarget[camera.id]);
 
-				WebGLUniforms.upload( _gl, getUniformList( materialProperties ), m_uniforms, textures );
+				WebGLUniforms.upload(_gl, getUniformList(materialProperties), m_uniforms, textures);
 
 			}
 
-			if ( material.isShaderMaterial && material.uniformsNeedUpdate === true ) {
+			if (material.isShaderMaterial && material.uniformsNeedUpdate === true) {
 
-				WebGLUniforms.upload( _gl, getUniformList( materialProperties ), m_uniforms, textures );
+				WebGLUniforms.upload(_gl, getUniformList(materialProperties), m_uniforms, textures);
 				material.uniformsNeedUpdate = false;
 
 			}
 
-			if ( material.isSpriteMaterial ) {
+			if (material.isSpriteMaterial) {
 
-				p_uniforms.setValue( _gl, 'center', object.center );
+				p_uniforms.setValue(_gl, 'center', object.center);
 
 			}
 
 			// common matrices
 
-			p_uniforms.setValue( _gl, 'modelViewMatrix', object.modelViewMatrix );
-			p_uniforms.setValue( _gl, 'normalMatrix', object.normalMatrix );
-			p_uniforms.setValue( _gl, 'modelMatrix', object.matrixWorld );
+			p_uniforms.setValue(_gl, 'modelViewMatrix', object.modelViewMatrix);
+			p_uniforms.setValue(_gl, 'normalMatrix', object.normalMatrix);
+			p_uniforms.setValue(_gl, 'modelMatrix', object.matrixWorld);
 
 			// UBOs
 
-			if ( material.isShaderMaterial || material.isRawShaderMaterial ) {
+			if (material.isShaderMaterial || material.isRawShaderMaterial) {
 
 				const groups = material.uniformsGroups;
 
-				for ( let i = 0, l = groups.length; i < l; i ++ ) {
+				for (let i = 0, l = groups.length; i < l; i++) {
 
-					const group = groups[ i ];
+					const group = groups[i];
 
-					uniformsGroups.update( group, program );
-					uniformsGroups.bind( group, program );
+					uniformsGroups.update(group, program);
+					uniformsGroups.bind(group, program);
 
 				}
 
@@ -2686,7 +2686,7 @@ class WebGLRenderer {
 
 		// If uniforms are marked as clean, they don't need to be loaded to the GPU.
 
-		function markUniformsLightsNeedsUpdate( uniforms, value ) {
+		function markUniformsLightsNeedsUpdate(uniforms, value) {
 
 			uniforms.ambientLightColor.needsUpdate = value;
 			uniforms.lightProbe.needsUpdate = value;
@@ -2702,11 +2702,11 @@ class WebGLRenderer {
 
 		}
 
-		function materialNeedsLights( material ) {
+		function materialNeedsLights(material) {
 
 			return material.isMeshLambertMaterial || material.isMeshToonMaterial || material.isMeshPhongMaterial ||
 				material.isMeshStandardMaterial || material.isShadowMaterial ||
-				( material.isShaderMaterial && material.lights === true );
+				(material.isShaderMaterial && material.lights === true);
 
 		}
 
@@ -2744,12 +2744,12 @@ class WebGLRenderer {
 
 		};
 
-		this.setRenderTargetTextures = function ( renderTarget, colorTexture, depthTexture ) {
+		this.setRenderTargetTextures = function (renderTarget, colorTexture, depthTexture) {
 
-			const renderTargetProperties = properties.get( renderTarget );
+			const renderTargetProperties = properties.get(renderTarget);
 
 			renderTargetProperties.__autoAllocateDepthBuffer = renderTarget.resolveDepthBuffer === false;
-			if ( renderTargetProperties.__autoAllocateDepthBuffer === false ) {
+			if (renderTargetProperties.__autoAllocateDepthBuffer === false) {
 
 				// The multisample_render_to_texture extension doesn't work properly if there
 				// are midframe flushes and an external depth buffer. Disable use of the extension.
@@ -2757,16 +2757,16 @@ class WebGLRenderer {
 
 			}
 
-			properties.get( renderTarget.texture ).__webglTexture = colorTexture;
-			properties.get( renderTarget.depthTexture ).__webglTexture = renderTargetProperties.__autoAllocateDepthBuffer ? undefined : depthTexture;
+			properties.get(renderTarget.texture).__webglTexture = colorTexture;
+			properties.get(renderTarget.depthTexture).__webglTexture = renderTargetProperties.__autoAllocateDepthBuffer ? undefined : depthTexture;
 
 			renderTargetProperties.__hasExternalTextures = true;
 
 		};
 
-		this.setRenderTargetFramebuffer = function ( renderTarget, defaultFramebuffer ) {
+		this.setRenderTargetFramebuffer = function (renderTarget, defaultFramebuffer) {
 
-			const renderTargetProperties = properties.get( renderTarget );
+			const renderTargetProperties = properties.get(renderTarget);
 			renderTargetProperties.__webglFramebuffer = defaultFramebuffer;
 			renderTargetProperties.__useDefaultFramebuffer = defaultFramebuffer === undefined;
 
@@ -2783,7 +2783,7 @@ class WebGLRenderer {
 		 * Indicates the z layer to render in to when using 3D or array render targets.
 		 * @param {number} [activeMipmapLevel=0] - The active mipmap level.
 		 */
-		this.setRenderTarget = function ( renderTarget, activeCubeFace = 0, activeMipmapLevel = 0 ) {
+		this.setRenderTarget = function (renderTarget, activeCubeFace = 0, activeMipmapLevel = 0) {
 
 			_currentRenderTarget = renderTarget;
 			_currentActiveCubeFace = activeCubeFace;
@@ -2793,56 +2793,56 @@ class WebGLRenderer {
 			let isCube = false;
 			let isRenderTarget3D = false;
 
-			if ( renderTarget ) {
+			if (renderTarget) {
 
-				const renderTargetProperties = properties.get( renderTarget );
+				const renderTargetProperties = properties.get(renderTarget);
 
-				if ( renderTargetProperties.__useDefaultFramebuffer !== undefined ) {
+				if (renderTargetProperties.__useDefaultFramebuffer !== undefined) {
 
 					// Externally-managed framebuffer (e.g. XR)
 					// Bind to the stored framebuffer (may be null for default, or a WebGLFramebuffer)
-					state.bindFramebuffer( _gl.FRAMEBUFFER, renderTargetProperties.__webglFramebuffer );
+					state.bindFramebuffer(_gl.FRAMEBUFFER, renderTargetProperties.__webglFramebuffer);
 
-					_currentViewport.copy( renderTarget.viewport );
-					_currentScissor.copy( renderTarget.scissor );
+					_currentViewport.copy(renderTarget.viewport);
+					_currentScissor.copy(renderTarget.scissor);
 					_currentScissorTest = renderTarget.scissorTest;
 
-					state.viewport( _currentViewport );
-					state.scissor( _currentScissor );
-					state.setScissorTest( _currentScissorTest );
+					state.viewport(_currentViewport);
+					state.scissor(_currentScissor);
+					state.setScissorTest(_currentScissorTest);
 
 					_currentMaterialId = - 1;
 
 					return;
 
-				} else if ( renderTargetProperties.__webglFramebuffer === undefined ) {
+				} else if (renderTargetProperties.__webglFramebuffer === undefined) {
 
-					textures.setupRenderTarget( renderTarget );
+					textures.setupRenderTarget(renderTarget);
 
-				} else if ( renderTargetProperties.__hasExternalTextures ) {
+				} else if (renderTargetProperties.__hasExternalTextures) {
 
 					// Color and depth texture must be rebound in order for the swapchain to update.
-					textures.rebindTextures( renderTarget, properties.get( renderTarget.texture ).__webglTexture, properties.get( renderTarget.depthTexture ).__webglTexture );
+					textures.rebindTextures(renderTarget, properties.get(renderTarget.texture).__webglTexture, properties.get(renderTarget.depthTexture).__webglTexture);
 
-				} else if ( renderTarget.depthBuffer ) {
+				} else if (renderTarget.depthBuffer) {
 
 					// check if the depth texture is already bound to the frame buffer and that it's been initialized
 					const depthTexture = renderTarget.depthTexture;
-					if ( renderTargetProperties.__boundDepthTexture !== depthTexture ) {
+					if (renderTargetProperties.__boundDepthTexture !== depthTexture) {
 
 						// check if the depth texture is compatible
 						if (
 							depthTexture !== null &&
-							properties.has( depthTexture ) &&
-							( renderTarget.width !== depthTexture.image.width || renderTarget.height !== depthTexture.image.height )
+							properties.has(depthTexture) &&
+							(renderTarget.width !== depthTexture.image.width || renderTarget.height !== depthTexture.image.height)
 						) {
 
-							throw new Error( 'WebGLRenderTarget: Attached DepthTexture is initialized to the incorrect size.' );
+							throw new Error('WebGLRenderTarget: Attached DepthTexture is initialized to the incorrect size.');
 
 						}
 
 						// Swap the depth buffer to the currently attached one
-						textures.setupDepthRenderbuffer( renderTarget );
+						textures.setupDepthRenderbuffer(renderTarget);
 
 					}
 
@@ -2850,37 +2850,37 @@ class WebGLRenderer {
 
 				const texture = renderTarget.texture;
 
-				if ( texture.isData3DTexture || texture.isDataArrayTexture || texture.isCompressedArrayTexture ) {
+				if (texture.isData3DTexture || texture.isDataArrayTexture || texture.isCompressedArrayTexture) {
 
 					isRenderTarget3D = true;
 
 				}
 
-				const __webglFramebuffer = properties.get( renderTarget ).__webglFramebuffer;
+				const __webglFramebuffer = properties.get(renderTarget).__webglFramebuffer;
 
-				if ( renderTarget.isWebGLCubeRenderTarget ) {
+				if (renderTarget.isWebGLCubeRenderTarget) {
 
-					if ( Array.isArray( __webglFramebuffer[ activeCubeFace ] ) ) {
+					if (Array.isArray(__webglFramebuffer[activeCubeFace])) {
 
-						framebuffer = __webglFramebuffer[ activeCubeFace ][ activeMipmapLevel ];
+						framebuffer = __webglFramebuffer[activeCubeFace][activeMipmapLevel];
 
 					} else {
 
-						framebuffer = __webglFramebuffer[ activeCubeFace ];
+						framebuffer = __webglFramebuffer[activeCubeFace];
 
 					}
 
 					isCube = true;
 
-				} else if ( ( renderTarget.samples > 0 ) && textures.useMultisampledRTT( renderTarget ) === false ) {
+				} else if ((renderTarget.samples > 0) && textures.useMultisampledRTT(renderTarget) === false) {
 
-					framebuffer = properties.get( renderTarget ).__webglMultisampledFramebuffer;
+					framebuffer = properties.get(renderTarget).__webglMultisampledFramebuffer;
 
 				} else {
 
-					if ( Array.isArray( __webglFramebuffer ) ) {
+					if (Array.isArray(__webglFramebuffer)) {
 
-						framebuffer = __webglFramebuffer[ activeMipmapLevel ];
+						framebuffer = __webglFramebuffer[activeMipmapLevel];
 
 					} else {
 
@@ -2890,61 +2890,61 @@ class WebGLRenderer {
 
 				}
 
-				_currentViewport.copy( renderTarget.viewport );
-				_currentScissor.copy( renderTarget.scissor );
+				_currentViewport.copy(renderTarget.viewport);
+				_currentScissor.copy(renderTarget.scissor);
 				_currentScissorTest = renderTarget.scissorTest;
 
 			} else {
 
-				_currentViewport.copy( _viewport ).multiplyScalar( _pixelRatio ).floor();
-				_currentScissor.copy( _scissor ).multiplyScalar( _pixelRatio ).floor();
+				_currentViewport.copy(_viewport).multiplyScalar(_pixelRatio).floor();
+				_currentScissor.copy(_scissor).multiplyScalar(_pixelRatio).floor();
 				_currentScissorTest = _scissorTest;
 
 			}
 
 			// Use a scratch frame buffer if rendering to a mip level to avoid depth buffers
 			// being bound that are different sizes.
-			if ( activeMipmapLevel !== 0 ) {
+			if (activeMipmapLevel !== 0) {
 
 				framebuffer = _scratchFrameBuffer;
 
 			}
 
-			const framebufferBound = state.bindFramebuffer( _gl.FRAMEBUFFER, framebuffer );
+			const framebufferBound = state.bindFramebuffer(_gl.FRAMEBUFFER, framebuffer);
 
-			if ( framebufferBound ) {
+			if (framebufferBound) {
 
-				state.drawBuffers( renderTarget, framebuffer );
+				state.drawBuffers(renderTarget, framebuffer);
 
 			}
 
-			state.viewport( _currentViewport );
-			state.scissor( _currentScissor );
-			state.setScissorTest( _currentScissorTest );
+			state.viewport(_currentViewport);
+			state.scissor(_currentScissor);
+			state.setScissorTest(_currentScissorTest);
 
-			if ( isCube ) {
+			if (isCube) {
 
-				const textureProperties = properties.get( renderTarget.texture );
-				_gl.framebufferTexture2D( _gl.FRAMEBUFFER, _gl.COLOR_ATTACHMENT0, _gl.TEXTURE_CUBE_MAP_POSITIVE_X + activeCubeFace, textureProperties.__webglTexture, activeMipmapLevel );
+				const textureProperties = properties.get(renderTarget.texture);
+				_gl.framebufferTexture2D(_gl.FRAMEBUFFER, _gl.COLOR_ATTACHMENT0, _gl.TEXTURE_CUBE_MAP_POSITIVE_X + activeCubeFace, textureProperties.__webglTexture, activeMipmapLevel);
 
-			} else if ( isRenderTarget3D ) {
+			} else if (isRenderTarget3D) {
 
 				const layer = activeCubeFace;
 
-				for ( let i = 0; i < renderTarget.textures.length; i ++ ) {
+				for (let i = 0; i < renderTarget.textures.length; i++) {
 
-					const textureProperties = properties.get( renderTarget.textures[ i ] );
+					const textureProperties = properties.get(renderTarget.textures[i]);
 
-					_gl.framebufferTextureLayer( _gl.FRAMEBUFFER, _gl.COLOR_ATTACHMENT0 + i, textureProperties.__webglTexture, activeMipmapLevel, layer );
+					_gl.framebufferTextureLayer(_gl.FRAMEBUFFER, _gl.COLOR_ATTACHMENT0 + i, textureProperties.__webglTexture, activeMipmapLevel, layer);
 
 				}
 
-			} else if ( renderTarget !== null && activeMipmapLevel !== 0 ) {
+			} else if (renderTarget !== null && activeMipmapLevel !== 0) {
 
 				// Only bind the frame buffer if we are using a scratch frame buffer to render to a mipmap.
 				// If we rebind the texture when using a multi sample buffer then an error about inconsistent samples will be thrown.
-				const textureProperties = properties.get( renderTarget.texture );
-				_gl.framebufferTexture2D( _gl.FRAMEBUFFER, _gl.COLOR_ATTACHMENT0, _gl.TEXTURE_2D, textureProperties.__webglTexture, activeMipmapLevel );
+				const textureProperties = properties.get(renderTarget.texture);
+				_gl.framebufferTexture2D(_gl.FRAMEBUFFER, _gl.COLOR_ATTACHMENT0, _gl.TEXTURE_2D, textureProperties.__webglTexture, activeMipmapLevel);
 
 			}
 
@@ -2964,56 +2964,69 @@ class WebGLRenderer {
 		 * @param {number} [activeCubeFaceIndex] - The active cube face index.
 		 * @param {number} [textureIndex=0] - The texture index of an MRT render target.
 		 */
-		this.readRenderTargetPixels = function ( renderTarget, x, y, width, height, buffer, activeCubeFaceIndex, textureIndex = 0 ) {
+		this.readRenderTargetPixels = function (renderTarget, x, y, width, height, buffer, activeCubeFaceIndex, textureIndex = 0) {
 
-			if ( ! ( renderTarget && renderTarget.isWebGLRenderTarget ) ) {
+			if (!(renderTarget && renderTarget.isWebGLRenderTarget)) {
 
-				error( 'WebGLRenderer.readRenderTargetPixels: renderTarget is not THREE.WebGLRenderTarget.' );
+				error('WebGLRenderer.readRenderTargetPixels: renderTarget is not THREE.WebGLRenderTarget.');
 				return;
 
 			}
 
-			let framebuffer = properties.get( renderTarget ).__webglFramebuffer;
+			let framebuffer = properties.get(renderTarget).__webglFramebuffer;
 
-			if ( renderTarget.isWebGLCubeRenderTarget && activeCubeFaceIndex !== undefined ) {
+			if (renderTarget.isWebGLCubeRenderTarget) {
 
-				framebuffer = framebuffer[ activeCubeFaceIndex ];
+				if (activeCubeFaceIndex !== undefined) {
+
+					framebuffer = framebuffer[activeCubeFaceIndex];
+
+				}
+
+			} else if (renderTarget.texture.isData3DTexture || renderTarget.texture.isDataArrayTexture || renderTarget.texture.isCompressedArrayTexture) {
+
+				const textureProperties = properties.get(renderTarget.textures[textureIndex]);
+
+				state.bindFramebuffer(_gl.FRAMEBUFFER, _scratchFrameBuffer);
+				_gl.framebufferTextureLayer(_gl.FRAMEBUFFER, _gl.COLOR_ATTACHMENT0, textureProperties.__webglTexture, 0, activeCubeFaceIndex || 0);
+
+				framebuffer = _scratchFrameBuffer;
 
 			}
 
-			if ( framebuffer ) {
+			if (framebuffer) {
 
-				state.bindFramebuffer( _gl.FRAMEBUFFER, framebuffer );
+				state.bindFramebuffer(_gl.FRAMEBUFFER, framebuffer);
 
 				try {
 
-					const texture = renderTarget.textures[ textureIndex ];
+					const texture = renderTarget.textures[textureIndex];
 					const textureFormat = texture.format;
 					const textureType = texture.type;
 
 					// when using MRT, select the correct color buffer for the subsequent read command
 
-					if ( renderTarget.textures.length > 1 ) _gl.readBuffer( _gl.COLOR_ATTACHMENT0 + textureIndex );
+					if (renderTarget.textures.length > 1) _gl.readBuffer(_gl.COLOR_ATTACHMENT0 + textureIndex);
 
-					if ( ! capabilities.textureFormatReadable( textureFormat ) ) {
+					if (!capabilities.textureFormatReadable(textureFormat)) {
 
-						error( 'WebGLRenderer.readRenderTargetPixels: renderTarget is not in RGBA or implementation defined format.' );
+						error('WebGLRenderer.readRenderTargetPixels: renderTarget is not in RGBA or implementation defined format.');
 						return;
 
 					}
 
-					if ( ! capabilities.textureTypeReadable( textureType ) ) {
+					if (!capabilities.textureTypeReadable(textureType)) {
 
-						error( 'WebGLRenderer.readRenderTargetPixels: renderTarget is not in UnsignedByteType or implementation defined type.' );
+						error('WebGLRenderer.readRenderTargetPixels: renderTarget is not in UnsignedByteType or implementation defined type.');
 						return;
 
 					}
 
 					// the following if statement ensures valid read requests (no out-of-bounds pixels, see #8604)
 
-					if ( ( x >= 0 && x <= ( renderTarget.width - width ) ) && ( y >= 0 && y <= ( renderTarget.height - height ) ) ) {
+					if ((x >= 0 && x <= (renderTarget.width - width)) && (y >= 0 && y <= (renderTarget.height - height))) {
 
-						_gl.readPixels( x, y, width, height, utils.convert( textureFormat ), utils.convert( textureType ), buffer );
+						_gl.readPixels(x, y, width, height, utils.convert(textureFormat), utils.convert(textureType), buffer);
 
 					}
 
@@ -3021,8 +3034,8 @@ class WebGLRenderer {
 
 					// restore framebuffer of current render target if necessary
 
-					const framebuffer = ( _currentRenderTarget !== null ) ? properties.get( _currentRenderTarget ).__webglFramebuffer : null;
-					state.bindFramebuffer( _gl.FRAMEBUFFER, framebuffer );
+					const framebuffer = (_currentRenderTarget !== null) ? properties.get(_currentRenderTarget).__webglFramebuffer : null;
+					state.bindFramebuffer(_gl.FRAMEBUFFER, framebuffer);
 
 				}
 
@@ -3046,78 +3059,78 @@ class WebGLRenderer {
 		 * @param {number} [textureIndex=0] - The texture index of an MRT render target.
 		 * @return {Promise<TypedArray>} A Promise that resolves when the read has been finished. The resolve provides the read data as a typed array.
 		 */
-		this.readRenderTargetPixelsAsync = async function ( renderTarget, x, y, width, height, buffer, activeCubeFaceIndex, textureIndex = 0 ) {
+		this.readRenderTargetPixelsAsync = async function (renderTarget, x, y, width, height, buffer, activeCubeFaceIndex, textureIndex = 0) {
 
-			if ( ! ( renderTarget && renderTarget.isWebGLRenderTarget ) ) {
+			if (!(renderTarget && renderTarget.isWebGLRenderTarget)) {
 
-				throw new Error( 'THREE.WebGLRenderer.readRenderTargetPixels: renderTarget is not THREE.WebGLRenderTarget.' );
-
-			}
-
-			let framebuffer = properties.get( renderTarget ).__webglFramebuffer;
-			if ( renderTarget.isWebGLCubeRenderTarget && activeCubeFaceIndex !== undefined ) {
-
-				framebuffer = framebuffer[ activeCubeFaceIndex ];
+				throw new Error('THREE.WebGLRenderer.readRenderTargetPixels: renderTarget is not THREE.WebGLRenderTarget.');
 
 			}
 
-			if ( framebuffer ) {
+			let framebuffer = properties.get(renderTarget).__webglFramebuffer;
+			if (renderTarget.isWebGLCubeRenderTarget && activeCubeFaceIndex !== undefined) {
+
+				framebuffer = framebuffer[activeCubeFaceIndex];
+
+			}
+
+			if (framebuffer) {
 
 				// the following if statement ensures valid read requests (no out-of-bounds pixels, see #8604)
-				if ( ( x >= 0 && x <= ( renderTarget.width - width ) ) && ( y >= 0 && y <= ( renderTarget.height - height ) ) ) {
+				if ((x >= 0 && x <= (renderTarget.width - width)) && (y >= 0 && y <= (renderTarget.height - height))) {
 
 					// set the active frame buffer to the one we want to read
-					state.bindFramebuffer( _gl.FRAMEBUFFER, framebuffer );
+					state.bindFramebuffer(_gl.FRAMEBUFFER, framebuffer);
 
-					const texture = renderTarget.textures[ textureIndex ];
+					const texture = renderTarget.textures[textureIndex];
 					const textureFormat = texture.format;
 					const textureType = texture.type;
 
 					// when using MRT, select the correct color buffer for the subsequent read command
 
-					if ( renderTarget.textures.length > 1 ) _gl.readBuffer( _gl.COLOR_ATTACHMENT0 + textureIndex );
+					if (renderTarget.textures.length > 1) _gl.readBuffer(_gl.COLOR_ATTACHMENT0 + textureIndex);
 
 
-					if ( ! capabilities.textureFormatReadable( textureFormat ) ) {
+					if (!capabilities.textureFormatReadable(textureFormat)) {
 
-						throw new Error( 'THREE.WebGLRenderer.readRenderTargetPixelsAsync: renderTarget is not in RGBA or implementation defined format.' );
+						throw new Error('THREE.WebGLRenderer.readRenderTargetPixelsAsync: renderTarget is not in RGBA or implementation defined format.');
 
 					}
 
-					if ( ! capabilities.textureTypeReadable( textureType ) ) {
+					if (!capabilities.textureTypeReadable(textureType)) {
 
-						throw new Error( 'THREE.WebGLRenderer.readRenderTargetPixelsAsync: renderTarget is not in UnsignedByteType or implementation defined type.' );
+						throw new Error('THREE.WebGLRenderer.readRenderTargetPixelsAsync: renderTarget is not in UnsignedByteType or implementation defined type.');
 
 					}
 
 					const glBuffer = _gl.createBuffer();
-					_gl.bindBuffer( _gl.PIXEL_PACK_BUFFER, glBuffer );
-					_gl.bufferData( _gl.PIXEL_PACK_BUFFER, buffer.byteLength, _gl.STREAM_READ );
+					_gl.bindBuffer(_gl.PIXEL_PACK_BUFFER, glBuffer);
+					_gl.bufferData(_gl.PIXEL_PACK_BUFFER, buffer.byteLength, _gl.STREAM_READ);
 
-					_gl.readPixels( x, y, width, height, utils.convert( textureFormat ), utils.convert( textureType ), 0 );
+					_gl.readPixels(x, y, width, height, utils.convert(textureFormat), utils.convert(textureType), 0);
 
 					// reset the frame buffer to the currently set buffer before waiting
-					const currFramebuffer = _currentRenderTarget !== null ? properties.get( _currentRenderTarget ).__webglFramebuffer : null;
-					state.bindFramebuffer( _gl.FRAMEBUFFER, currFramebuffer );
+					const currFramebuffer = _currentRenderTarget !== null ? properties.get(_currentRenderTarget).__webglFramebuffer : null;
+					state.bindFramebuffer(_gl.FRAMEBUFFER, currFramebuffer);
 
 					// check if the commands have finished every 8 ms
-					const sync = _gl.fenceSync( _gl.SYNC_GPU_COMMANDS_COMPLETE, 0 );
+					const sync = _gl.fenceSync(_gl.SYNC_GPU_COMMANDS_COMPLETE, 0);
 
 					_gl.flush();
 
-					await probeAsync( _gl, sync, 4 );
+					await probeAsync(_gl, sync, 4);
 
 					// read the data and delete the buffer
-					_gl.bindBuffer( _gl.PIXEL_PACK_BUFFER, glBuffer );
-					_gl.getBufferSubData( _gl.PIXEL_PACK_BUFFER, 0, buffer );
-					_gl.deleteBuffer( glBuffer );
-					_gl.deleteSync( sync );
+					_gl.bindBuffer(_gl.PIXEL_PACK_BUFFER, glBuffer);
+					_gl.getBufferSubData(_gl.PIXEL_PACK_BUFFER, 0, buffer);
+					_gl.deleteBuffer(glBuffer);
+					_gl.deleteSync(sync);
 
 					return buffer;
 
 				} else {
 
-					throw new Error( 'THREE.WebGLRenderer.readRenderTargetPixelsAsync: requested read bounds are out of range.' );
+					throw new Error('THREE.WebGLRenderer.readRenderTargetPixelsAsync: requested read bounds are out of range.');
 
 				}
 
@@ -3132,18 +3145,18 @@ class WebGLRenderer {
 		 * @param {?Vector2} [position=null] - The start position of the copy operation.
 		 * @param {number} [level=0] - The mip level. The default represents the base mip.
 		 */
-		this.copyFramebufferToTexture = function ( texture, position = null, level = 0 ) {
+		this.copyFramebufferToTexture = function (texture, position = null, level = 0) {
 
-			const levelScale = Math.pow( 2, - level );
-			const width = Math.floor( texture.image.width * levelScale );
-			const height = Math.floor( texture.image.height * levelScale );
+			const levelScale = Math.pow(2, - level);
+			const width = Math.floor(texture.image.width * levelScale);
+			const height = Math.floor(texture.image.height * levelScale);
 
 			const x = position !== null ? position.x : 0;
 			const y = position !== null ? position.y : 0;
 
-			textures.setTexture2D( texture, 0 );
+			textures.setTexture2D(texture, 0);
 
-			_gl.copyTexSubImage2D( _gl.TEXTURE_2D, level, 0, 0, x, y, width, height );
+			_gl.copyTexSubImage2D(_gl.TEXTURE_2D, level, 0, 0, x, y, width, height);
 
 			state.unbindTexture();
 
@@ -3165,13 +3178,13 @@ class WebGLRenderer {
 		 * @param {number} [srcLevel=0] - The source mipmap level to copy.
 		 * @param {?number} [dstLevel=0] - The destination mipmap level.
 		 */
-		this.copyTextureToTexture = function ( srcTexture, dstTexture, srcRegion = null, dstPosition = null, srcLevel = 0, dstLevel = 0 ) {
+		this.copyTextureToTexture = function (srcTexture, dstTexture, srcRegion = null, dstPosition = null, srcLevel = 0, dstLevel = 0) {
 
 			// gather the necessary dimensions to copy
 			let width, height, depth, minX, minY, minZ;
 			let dstX, dstY, dstZ;
-			const image = srcTexture.isCompressedTexture ? srcTexture.mipmaps[ dstLevel ] : srcTexture.image;
-			if ( srcRegion !== null ) {
+			const image = srcTexture.isCompressedTexture ? srcTexture.mipmaps[dstLevel] : srcTexture.image;
+			if (srcRegion !== null) {
 
 				width = srcRegion.max.x - srcRegion.min.x;
 				height = srcRegion.max.y - srcRegion.min.y;
@@ -3182,16 +3195,16 @@ class WebGLRenderer {
 
 			} else {
 
-				const levelScale = Math.pow( 2, - srcLevel );
-				width = Math.floor( image.width * levelScale );
-				height = Math.floor( image.height * levelScale );
-				if ( srcTexture.isDataArrayTexture ) {
+				const levelScale = Math.pow(2, - srcLevel);
+				width = Math.floor(image.width * levelScale);
+				height = Math.floor(image.height * levelScale);
+				if (srcTexture.isDataArrayTexture) {
 
 					depth = image.depth;
 
-				} else if ( srcTexture.isData3DTexture ) {
+				} else if (srcTexture.isData3DTexture) {
 
-					depth = Math.floor( image.depth * levelScale );
+					depth = Math.floor(image.depth * levelScale);
 
 				} else {
 
@@ -3205,7 +3218,7 @@ class WebGLRenderer {
 
 			}
 
-			if ( dstPosition !== null ) {
+			if (dstPosition !== null) {
 
 				dstX = dstPosition.x;
 				dstY = dstPosition.y;
@@ -3220,160 +3233,160 @@ class WebGLRenderer {
 			}
 
 			// Set up the destination target
-			const glFormat = utils.convert( dstTexture.format );
-			const glType = utils.convert( dstTexture.type );
+			const glFormat = utils.convert(dstTexture.format);
+			const glType = utils.convert(dstTexture.type);
 			let glTarget;
 
-			if ( dstTexture.isData3DTexture ) {
+			if (dstTexture.isData3DTexture) {
 
-				textures.setTexture3D( dstTexture, 0 );
+				textures.setTexture3D(dstTexture, 0);
 				glTarget = _gl.TEXTURE_3D;
 
-			} else if ( dstTexture.isDataArrayTexture || dstTexture.isCompressedArrayTexture ) {
+			} else if (dstTexture.isDataArrayTexture || dstTexture.isCompressedArrayTexture) {
 
-				textures.setTexture2DArray( dstTexture, 0 );
+				textures.setTexture2DArray(dstTexture, 0);
 				glTarget = _gl.TEXTURE_2D_ARRAY;
 
 			} else {
 
-				textures.setTexture2D( dstTexture, 0 );
+				textures.setTexture2D(dstTexture, 0);
 				glTarget = _gl.TEXTURE_2D;
 
 			}
 
-			_gl.pixelStorei( _gl.UNPACK_FLIP_Y_WEBGL, dstTexture.flipY );
-			_gl.pixelStorei( _gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, dstTexture.premultiplyAlpha );
-			_gl.pixelStorei( _gl.UNPACK_ALIGNMENT, dstTexture.unpackAlignment );
+			_gl.pixelStorei(_gl.UNPACK_FLIP_Y_WEBGL, dstTexture.flipY);
+			_gl.pixelStorei(_gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, dstTexture.premultiplyAlpha);
+			_gl.pixelStorei(_gl.UNPACK_ALIGNMENT, dstTexture.unpackAlignment);
 
 			// used for copying data from cpu
-			const currentUnpackRowLen = _gl.getParameter( _gl.UNPACK_ROW_LENGTH );
-			const currentUnpackImageHeight = _gl.getParameter( _gl.UNPACK_IMAGE_HEIGHT );
-			const currentUnpackSkipPixels = _gl.getParameter( _gl.UNPACK_SKIP_PIXELS );
-			const currentUnpackSkipRows = _gl.getParameter( _gl.UNPACK_SKIP_ROWS );
-			const currentUnpackSkipImages = _gl.getParameter( _gl.UNPACK_SKIP_IMAGES );
+			const currentUnpackRowLen = _gl.getParameter(_gl.UNPACK_ROW_LENGTH);
+			const currentUnpackImageHeight = _gl.getParameter(_gl.UNPACK_IMAGE_HEIGHT);
+			const currentUnpackSkipPixels = _gl.getParameter(_gl.UNPACK_SKIP_PIXELS);
+			const currentUnpackSkipRows = _gl.getParameter(_gl.UNPACK_SKIP_ROWS);
+			const currentUnpackSkipImages = _gl.getParameter(_gl.UNPACK_SKIP_IMAGES);
 
-			_gl.pixelStorei( _gl.UNPACK_ROW_LENGTH, image.width );
-			_gl.pixelStorei( _gl.UNPACK_IMAGE_HEIGHT, image.height );
-			_gl.pixelStorei( _gl.UNPACK_SKIP_PIXELS, minX );
-			_gl.pixelStorei( _gl.UNPACK_SKIP_ROWS, minY );
-			_gl.pixelStorei( _gl.UNPACK_SKIP_IMAGES, minZ );
+			_gl.pixelStorei(_gl.UNPACK_ROW_LENGTH, image.width);
+			_gl.pixelStorei(_gl.UNPACK_IMAGE_HEIGHT, image.height);
+			_gl.pixelStorei(_gl.UNPACK_SKIP_PIXELS, minX);
+			_gl.pixelStorei(_gl.UNPACK_SKIP_ROWS, minY);
+			_gl.pixelStorei(_gl.UNPACK_SKIP_IMAGES, minZ);
 
 			// set up the src texture
 			const isSrc3D = srcTexture.isDataArrayTexture || srcTexture.isData3DTexture;
 			const isDst3D = dstTexture.isDataArrayTexture || dstTexture.isData3DTexture;
-			if ( srcTexture.isDepthTexture ) {
+			if (srcTexture.isDepthTexture) {
 
-				const srcTextureProperties = properties.get( srcTexture );
-				const dstTextureProperties = properties.get( dstTexture );
-				const srcRenderTargetProperties = properties.get( srcTextureProperties.__renderTarget );
-				const dstRenderTargetProperties = properties.get( dstTextureProperties.__renderTarget );
-				state.bindFramebuffer( _gl.READ_FRAMEBUFFER, srcRenderTargetProperties.__webglFramebuffer );
-				state.bindFramebuffer( _gl.DRAW_FRAMEBUFFER, dstRenderTargetProperties.__webglFramebuffer );
+				const srcTextureProperties = properties.get(srcTexture);
+				const dstTextureProperties = properties.get(dstTexture);
+				const srcRenderTargetProperties = properties.get(srcTextureProperties.__renderTarget);
+				const dstRenderTargetProperties = properties.get(dstTextureProperties.__renderTarget);
+				state.bindFramebuffer(_gl.READ_FRAMEBUFFER, srcRenderTargetProperties.__webglFramebuffer);
+				state.bindFramebuffer(_gl.DRAW_FRAMEBUFFER, dstRenderTargetProperties.__webglFramebuffer);
 
-				for ( let i = 0; i < depth; i ++ ) {
+				for (let i = 0; i < depth; i++) {
 
 					// if the source or destination are a 3d target then a layer needs to be bound
-					if ( isSrc3D ) {
+					if (isSrc3D) {
 
-						_gl.framebufferTextureLayer( _gl.READ_FRAMEBUFFER, _gl.COLOR_ATTACHMENT0, properties.get( srcTexture ).__webglTexture, srcLevel, minZ + i );
-						_gl.framebufferTextureLayer( _gl.DRAW_FRAMEBUFFER, _gl.COLOR_ATTACHMENT0, properties.get( dstTexture ).__webglTexture, dstLevel, dstZ + i );
+						_gl.framebufferTextureLayer(_gl.READ_FRAMEBUFFER, _gl.COLOR_ATTACHMENT0, properties.get(srcTexture).__webglTexture, srcLevel, minZ + i);
+						_gl.framebufferTextureLayer(_gl.DRAW_FRAMEBUFFER, _gl.COLOR_ATTACHMENT0, properties.get(dstTexture).__webglTexture, dstLevel, dstZ + i);
 
 					}
 
-					_gl.blitFramebuffer( minX, minY, width, height, dstX, dstY, width, height, _gl.DEPTH_BUFFER_BIT, _gl.NEAREST );
+					_gl.blitFramebuffer(minX, minY, width, height, dstX, dstY, width, height, _gl.DEPTH_BUFFER_BIT, _gl.NEAREST);
 
 				}
 
-				state.bindFramebuffer( _gl.READ_FRAMEBUFFER, null );
-				state.bindFramebuffer( _gl.DRAW_FRAMEBUFFER, null );
+				state.bindFramebuffer(_gl.READ_FRAMEBUFFER, null);
+				state.bindFramebuffer(_gl.DRAW_FRAMEBUFFER, null);
 
-			} else if ( srcLevel !== 0 || srcTexture.isRenderTargetTexture || properties.has( srcTexture ) ) {
+			} else if (srcLevel !== 0 || srcTexture.isRenderTargetTexture || properties.has(srcTexture)) {
 
 				// get the appropriate frame buffers
-				const srcTextureProperties = properties.get( srcTexture );
-				const dstTextureProperties = properties.get( dstTexture );
+				const srcTextureProperties = properties.get(srcTexture);
+				const dstTextureProperties = properties.get(dstTexture);
 
 				// bind the frame buffer targets
-				state.bindFramebuffer( _gl.READ_FRAMEBUFFER, _srcFramebuffer );
-				state.bindFramebuffer( _gl.DRAW_FRAMEBUFFER, _dstFramebuffer );
+				state.bindFramebuffer(_gl.READ_FRAMEBUFFER, _srcFramebuffer);
+				state.bindFramebuffer(_gl.DRAW_FRAMEBUFFER, _dstFramebuffer);
 
-				for ( let i = 0; i < depth; i ++ ) {
+				for (let i = 0; i < depth; i++) {
 
 					// assign the correct layers and mip maps to the frame buffers
-					if ( isSrc3D ) {
+					if (isSrc3D) {
 
-						_gl.framebufferTextureLayer( _gl.READ_FRAMEBUFFER, _gl.COLOR_ATTACHMENT0, srcTextureProperties.__webglTexture, srcLevel, minZ + i );
+						_gl.framebufferTextureLayer(_gl.READ_FRAMEBUFFER, _gl.COLOR_ATTACHMENT0, srcTextureProperties.__webglTexture, srcLevel, minZ + i);
 
 					} else {
 
-						_gl.framebufferTexture2D( _gl.READ_FRAMEBUFFER, _gl.COLOR_ATTACHMENT0, _gl.TEXTURE_2D, srcTextureProperties.__webglTexture, srcLevel );
+						_gl.framebufferTexture2D(_gl.READ_FRAMEBUFFER, _gl.COLOR_ATTACHMENT0, _gl.TEXTURE_2D, srcTextureProperties.__webglTexture, srcLevel);
 
 					}
 
-					if ( isDst3D ) {
+					if (isDst3D) {
 
-						_gl.framebufferTextureLayer( _gl.DRAW_FRAMEBUFFER, _gl.COLOR_ATTACHMENT0, dstTextureProperties.__webglTexture, dstLevel, dstZ + i );
+						_gl.framebufferTextureLayer(_gl.DRAW_FRAMEBUFFER, _gl.COLOR_ATTACHMENT0, dstTextureProperties.__webglTexture, dstLevel, dstZ + i);
 
 					} else {
 
-						_gl.framebufferTexture2D( _gl.DRAW_FRAMEBUFFER, _gl.COLOR_ATTACHMENT0, _gl.TEXTURE_2D, dstTextureProperties.__webglTexture, dstLevel );
+						_gl.framebufferTexture2D(_gl.DRAW_FRAMEBUFFER, _gl.COLOR_ATTACHMENT0, _gl.TEXTURE_2D, dstTextureProperties.__webglTexture, dstLevel);
 
 					}
 
 					// copy the data using the fastest function that can achieve the copy
-					if ( srcLevel !== 0 ) {
+					if (srcLevel !== 0) {
 
-						_gl.blitFramebuffer( minX, minY, width, height, dstX, dstY, width, height, _gl.COLOR_BUFFER_BIT, _gl.NEAREST );
+						_gl.blitFramebuffer(minX, minY, width, height, dstX, dstY, width, height, _gl.COLOR_BUFFER_BIT, _gl.NEAREST);
 
-					} else if ( isDst3D ) {
+					} else if (isDst3D) {
 
-						_gl.copyTexSubImage3D( glTarget, dstLevel, dstX, dstY, dstZ + i, minX, minY, width, height );
+						_gl.copyTexSubImage3D(glTarget, dstLevel, dstX, dstY, dstZ + i, minX, minY, width, height);
 
 					} else {
 
-						_gl.copyTexSubImage2D( glTarget, dstLevel, dstX, dstY, minX, minY, width, height );
+						_gl.copyTexSubImage2D(glTarget, dstLevel, dstX, dstY, minX, minY, width, height);
 
 					}
 
 				}
 
 				// unbind read, draw buffers
-				state.bindFramebuffer( _gl.READ_FRAMEBUFFER, null );
-				state.bindFramebuffer( _gl.DRAW_FRAMEBUFFER, null );
+				state.bindFramebuffer(_gl.READ_FRAMEBUFFER, null);
+				state.bindFramebuffer(_gl.DRAW_FRAMEBUFFER, null);
 
 			} else {
 
-				if ( isDst3D ) {
+				if (isDst3D) {
 
 					// copy data into the 3d texture
-					if ( srcTexture.isDataTexture || srcTexture.isData3DTexture ) {
+					if (srcTexture.isDataTexture || srcTexture.isData3DTexture) {
 
-						_gl.texSubImage3D( glTarget, dstLevel, dstX, dstY, dstZ, width, height, depth, glFormat, glType, image.data );
+						_gl.texSubImage3D(glTarget, dstLevel, dstX, dstY, dstZ, width, height, depth, glFormat, glType, image.data);
 
-					} else if ( dstTexture.isCompressedArrayTexture ) {
+					} else if (dstTexture.isCompressedArrayTexture) {
 
-						_gl.compressedTexSubImage3D( glTarget, dstLevel, dstX, dstY, dstZ, width, height, depth, glFormat, image.data );
+						_gl.compressedTexSubImage3D(glTarget, dstLevel, dstX, dstY, dstZ, width, height, depth, glFormat, image.data);
 
 					} else {
 
-						_gl.texSubImage3D( glTarget, dstLevel, dstX, dstY, dstZ, width, height, depth, glFormat, glType, image );
+						_gl.texSubImage3D(glTarget, dstLevel, dstX, dstY, dstZ, width, height, depth, glFormat, glType, image);
 
 					}
 
 				} else {
 
 					// copy data into the 2d texture
-					if ( srcTexture.isDataTexture ) {
+					if (srcTexture.isDataTexture) {
 
-						_gl.texSubImage2D( _gl.TEXTURE_2D, dstLevel, dstX, dstY, width, height, glFormat, glType, image.data );
+						_gl.texSubImage2D(_gl.TEXTURE_2D, dstLevel, dstX, dstY, width, height, glFormat, glType, image.data);
 
-					} else if ( srcTexture.isCompressedTexture ) {
+					} else if (srcTexture.isCompressedTexture) {
 
-						_gl.compressedTexSubImage2D( _gl.TEXTURE_2D, dstLevel, dstX, dstY, image.width, image.height, glFormat, image.data );
+						_gl.compressedTexSubImage2D(_gl.TEXTURE_2D, dstLevel, dstX, dstY, image.width, image.height, glFormat, image.data);
 
 					} else {
 
-						_gl.texSubImage2D( _gl.TEXTURE_2D, dstLevel, dstX, dstY, width, height, glFormat, glType, image );
+						_gl.texSubImage2D(_gl.TEXTURE_2D, dstLevel, dstX, dstY, width, height, glFormat, glType, image);
 
 					}
 
@@ -3382,16 +3395,16 @@ class WebGLRenderer {
 			}
 
 			// reset values
-			_gl.pixelStorei( _gl.UNPACK_ROW_LENGTH, currentUnpackRowLen );
-			_gl.pixelStorei( _gl.UNPACK_IMAGE_HEIGHT, currentUnpackImageHeight );
-			_gl.pixelStorei( _gl.UNPACK_SKIP_PIXELS, currentUnpackSkipPixels );
-			_gl.pixelStorei( _gl.UNPACK_SKIP_ROWS, currentUnpackSkipRows );
-			_gl.pixelStorei( _gl.UNPACK_SKIP_IMAGES, currentUnpackSkipImages );
+			_gl.pixelStorei(_gl.UNPACK_ROW_LENGTH, currentUnpackRowLen);
+			_gl.pixelStorei(_gl.UNPACK_IMAGE_HEIGHT, currentUnpackImageHeight);
+			_gl.pixelStorei(_gl.UNPACK_SKIP_PIXELS, currentUnpackSkipPixels);
+			_gl.pixelStorei(_gl.UNPACK_SKIP_ROWS, currentUnpackSkipRows);
+			_gl.pixelStorei(_gl.UNPACK_SKIP_IMAGES, currentUnpackSkipImages);
 
 			// Generate mipmaps only when copying level 0
-			if ( dstLevel === 0 && dstTexture.generateMipmaps ) {
+			if (dstLevel === 0 && dstTexture.generateMipmaps) {
 
-				_gl.generateMipmap( glTarget );
+				_gl.generateMipmap(glTarget);
 
 			}
 
@@ -3406,11 +3419,11 @@ class WebGLRenderer {
 		 *
 		 * @param {WebGLRenderTarget} target - The render target.
 		 */
-		this.initRenderTarget = function ( target ) {
+		this.initRenderTarget = function (target) {
 
-			if ( properties.get( target ).__webglFramebuffer === undefined ) {
+			if (properties.get(target).__webglFramebuffer === undefined) {
 
-				textures.setupRenderTarget( target );
+				textures.setupRenderTarget(target);
 
 			}
 
@@ -3422,23 +3435,23 @@ class WebGLRenderer {
 		 *
 		 * @param {Texture} texture - The texture.
 		 */
-		this.initTexture = function ( texture ) {
+		this.initTexture = function (texture) {
 
-			if ( texture.isCubeTexture ) {
+			if (texture.isCubeTexture) {
 
-				textures.setTextureCube( texture, 0 );
+				textures.setTextureCube(texture, 0);
 
-			} else if ( texture.isData3DTexture ) {
+			} else if (texture.isData3DTexture) {
 
-				textures.setTexture3D( texture, 0 );
+				textures.setTexture3D(texture, 0);
 
-			} else if ( texture.isDataArrayTexture || texture.isCompressedArrayTexture ) {
+			} else if (texture.isDataArrayTexture || texture.isCompressedArrayTexture) {
 
-				textures.setTexture2DArray( texture, 0 );
+				textures.setTexture2DArray(texture, 0);
 
 			} else {
 
-				textures.setTexture2D( texture, 0 );
+				textures.setTexture2D(texture, 0);
 
 			}
 
@@ -3462,9 +3475,9 @@ class WebGLRenderer {
 
 		};
 
-		if ( typeof __THREE_DEVTOOLS__ !== 'undefined' ) {
+		if (typeof __THREE_DEVTOOLS__ !== 'undefined') {
 
-			__THREE_DEVTOOLS__.dispatchEvent( new CustomEvent( 'observe', { detail: this } ) );
+			__THREE_DEVTOOLS__.dispatchEvent(new CustomEvent('observe', { detail: this }));
 
 		}
 
@@ -3497,12 +3510,12 @@ class WebGLRenderer {
 
 	}
 
-	set outputColorSpace( colorSpace ) {
+	set outputColorSpace(colorSpace) {
 
 		this._outputColorSpace = colorSpace;
 
 		const gl = this.getContext();
-		gl.drawingBufferColorSpace = ColorManagement._getDrawingBufferColorSpace( colorSpace );
+		gl.drawingBufferColorSpace = ColorManagement._getDrawingBufferColorSpace(colorSpace);
 		gl.unpackColorSpace = ColorManagement._getUnpackColorSpace();
 
 	}


### PR DESCRIPTION
# Pull Request Summary: Fix various browser-specific and performance issues

This PR addresses several browser-specific bugs and performance bottlenecks identified in Three.js across controls, renderers, and documentation.

## Proposed Changes

### 1. 📖 Documentation Anchor Jumping (Safari)
- **Issue**: In Safari, clicking documentation navigation links (especially in large files like `TSL.html`) often failed to scroll to the correct section because `scrollIntoView()` was triggered before the page layout was fully computed.
- **Fix**: Wrapped the initial hash-based scroll logic in `docs/scripts/page.js` with `requestAnimationFrame()` to ensure the browser has completed a layout pass before attempting to scroll.

### 2. 🕹️ Interaction Reliability (All Browsers)
- **Issue**: Camera controls (`OrbitControls` and `TrackballControls`) could become "stuck" in a rotation or pan state if the pointer was released outside the canvas or over certain UI elements that swallowed the `pointerup` event.
- **Fix**: Added `pointerleave` event listeners to both controls. This ensures the interaction state is safely reset whenever the pointer leaves the primary interaction element.

### 3. 🏎️ TrackballControls Performance (High Polling Mice)
- **Issue**: `TrackballControls` manually updated its "previous" mouse position within the `onMouseMove` handler. This meant that if multiple mouse events occurred within a single animation frame (common with high-polling-rate gaming mice), only the very last movement delta was captured, leading to a "heavy" or laggy feel.
- **Fix**: Refactored `onMouseMove` and `onTouchMove` to remove redundant internal state updates. This allows the delta movement to accumulate correctly between frames, making the controls frame-rate independent and significantly smoother.

### 4. 🎨 CSS Renderers Transform Alignment Fix
- **Issue**: Transforms in `CSS3DRenderer` and `CSS2DRenderer` would break or appear offset depending on the container's size and position in the document (the `offsetTop`/`offsetLeft` issue).
- **Fix**: Updated both constructors to ensure the `domElement` has `position: relative`. This establishes a stable coordinate system for all absolute-positioned 3D/2D children, regardless of where the renderer is embedded in the host page.

### 5. 🔍 WebGL3DRenderTarget Pixel Reading
- **Issue**: Calling `readRenderTargetPixels()` on a `WebGL3DRenderTarget` (3D or Array textures) returned all zeros because the renderer was only binding the default 2D target of the framebuffer.
- **Fix**: Updated `src/renderers/WebGLRenderer.js` to correctly handle `isData3DTexture`, `isDataArrayTexture`, and `isCompressedArrayTexture`. It now utilizes a scratch framebuffer and `framebufferTextureLayer` to select the specific layer index requested by the user.

---

**Branch:** `fix/browser-specific-issues`
**Fork:** `mrigankad/three.js`
