### PR TITLE
WebGPURenderer: Fix texture compare fallback for shadows.

### DIFF
--- a/src/nodes/accessors/TextureNode.js
+++ b/src/nodes/accessors/TextureNode.js
@@ -8,7 +8,7 @@ import { nodeProxy, vec3, nodeObject, int, Fn } from '../tsl/TSLBase.js';
 import { step } from '../math/MathNode.js';
 import { NodeUpdateType } from '../core/constants.js';
 
-import { Compatibility, IntType, LessCompare, NearestFilter, UnsignedIntType } from '../../constants.js';
+import { Compatibility, GreaterCompare, GreaterEqualCompare, IntType, LessCompare, LessEqualCompare, NearestFilter, UnsignedIntType } from '../../constants.js';
 
 import { Texture } from '../../textures/Texture.js';
 import { warn, warnOnce } from '../../utils.js';
@@ -405,7 +405,9 @@ class TextureNode extends UniformNode {
 
 			} else {
 
-				if ( this.value.compareFunction === null || this.value.compareFunction === LessCompare ) {
+				const compareFunction = texture.compareFunction;
+
+				if ( compareFunction === null || compareFunction === LessCompare || compareFunction === LessEqualCompare || compareFunction === GreaterCompare || compareFunction === GreaterEqualCompare ) {
 
 					compareStepNode = this.compareNode;
 
@@ -413,7 +415,7 @@ class TextureNode extends UniformNode {
 
 					compareNode = this.compareNode;
 
-					warnOnce( 'TSL: Only "LessCompare" is supported for depth texture comparison fallback.' );
+					warnOnce( 'TSL: Only "LessCompare", "LessEqualCompare", "GreaterCompare" and "GreaterEqualCompare" are supported for depth texture comparison fallback.' );
 
 				}
 
@@ -559,7 +561,17 @@ class TextureNode extends UniformNode {
 
 				if ( compareStepSnippet !== null ) {
 
-					snippet = step( expression( compareStepSnippet, 'float' ), expression( snippet, nodeType ) ).build( builder, nodeType );
+					const compareFunction = texture.compareFunction;
+
+					if ( compareFunction === GreaterCompare || compareFunction === GreaterEqualCompare ) {
+
+						snippet = step( expression( snippet, nodeType ), expression( compareStepSnippet, 'float' ) ).build( builder, nodeType );
+
+					} else {
+
+						snippet = step( expression( compareStepSnippet, 'float' ), expression( snippet, nodeType ) ).build( builder, nodeType );
+
+					}
 
 				}
 

--- a/src/nodes/lighting/ShadowNode.js
+++ b/src/nodes/lighting/ShadowNode.js
@@ -11,7 +11,7 @@ import NodeMaterial from '../../materials/nodes/NodeMaterial.js';
 import QuadMesh from '../../renderers/common/QuadMesh.js';
 import { Loop } from '../utils/LoopNode.js';
 import { screenCoordinate } from '../display/ScreenNode.js';
-import { GreaterEqualCompare, HalfFloatType, LessEqualCompare, LinearFilter, NearestFilter, PCFShadowMap, PCFSoftShadowMap, RGFormat, VSMShadowMap } from '../../constants.js';
+import { Compatibility, GreaterEqualCompare, HalfFloatType, LessEqualCompare, LinearFilter, NearestFilter, PCFShadowMap, PCFSoftShadowMap, RGFormat, VSMShadowMap } from '../../constants.js';
 import { renderGroup } from '../core/UniformGroupNode.js';
 import { viewZToLogarithmicDepth } from '../display/ViewportDepthNode.js';
 import { lightShadowMatrix } from '../accessors/Lights.js';
@@ -420,8 +420,9 @@ class ShadowNode extends ShadowBaseNode {
 		const { depthTexture, shadowMap } = this.setupRenderTarget( shadow, builder );
 
 		const shadowMapType = renderer.shadowMap.type;
+		const hasTextureCompare = renderer.hasCompatibility( Compatibility.TEXTURE_COMPARE );
 
-		if ( shadowMapType === PCFShadowMap || shadowMapType === PCFSoftShadowMap ) {
+		if ( ( shadowMapType === PCFShadowMap || shadowMapType === PCFSoftShadowMap ) && hasTextureCompare ) {
 
 			depthTexture.minFilter = LinearFilter;
 			depthTexture.magFilter = LinearFilter;


### PR DESCRIPTION
Fixed #33048.

**Description**

#33048 showed that a few bits for Android are missing to make PCF shadows work correctly.

- In `TextureNode`, all less and greater compare functions must be handled and mapped to the correct `step()` fallback (that's also important for reversed depth buffer).
- Deactivate linear filtering when texture comparison isn't supported (use the default nearest filtering of depth textures).
