### PR TITLE
Examples: Fix floor threshold in `games_fps`.

### DIFF
--- a/examples/games_fps.html
+++ b/examples/games_fps.html
@@ -203,7 +203,9 @@
 
 				if ( result ) {
 
-					playerOnFloor = result.normal.y > 0;
+					// determine if the surface we bumped into is something we can stand on
+
+					playerOnFloor = result.normal.y >= 0.15; // allow slopes up to ~81° but ignore sheer vertical walls
 
 					if ( ! playerOnFloor ) {
 


### PR DESCRIPTION
Fixed #28994.

**Description**

`games_fps` has a check that decides whether the player actually stands on the floor. This check tests for a zero y component of the surface normal which effectively means: _If the surface points upwards even a microscopic amount, treat it as a solid floor._

However, the walls of the OP's asset are not perfectly vertical. If you jump into these walls, the logic in `games_fps` allows the player to stand at/inside the wall (which looks funny but is definitely wrong).

The PR introduces a more sensible threshold for ground the player can stand on.