### PR TITLE
Examples: Fix colors in webgpu_custom_fog

### DIFF
--- a/examples/webgpu_custom_fog.html
+++ b/examples/webgpu_custom_fog.html
@@ -53,8 +53,11 @@
 
 				// custom fog
 
-				const skyColor = color( 0xf0f5f5 );
-				const groundColor = color( 0xd0dee7 );
+				const skyColorValue = 0xf0f5f5;
+				const groundColorValue = 0xd0dee7;
+
+				const skyColor = color( skyColorValue );
+				const groundColor = color( groundColorValue );
 
 				const fogNoiseDistance = positionView.z.negate().smoothstep( 0, camera.far - 300 );
 
@@ -112,7 +115,7 @@
 
 				// lights
 
-				scene.add( new THREE.HemisphereLight( skyColor.value, groundColor.value, 0.5 ) );
+				scene.add( new THREE.HemisphereLight( skyColorValue, groundColorValue, 0.5 ) );
 
 				// geometry
 


### PR DESCRIPTION
Related issue: #32109

**Description**

As noted [here](https://github.com/mrdoob/three.js/pull/32109), we can not reference `skyColor.value` and `groundColor.value` because the TSL `color` function no longer returns a `ConstNode`