### PR TITLE
WebGLRenderer: Fix feedback loop regression.

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1953,7 +1953,7 @@ class WebGLRenderer {
 					generateMipmaps: true,
 					type: hasHalfFloatSupport ? HalfFloatType : UnsignedByteType,
 					minFilter: LinearMipmapLinearFilter,
-					samples: capabilities.samples,
+					samples: Math.max( 4, capabilities.samples ), // to avoid feedback loops, the transmission render target requires a resolve, see #26177
 					stencilBuffer: stencil,
 					resolveDepthBuffer: false,
 					resolveStencilBuffer: false,


### PR DESCRIPTION
Fixed #33060.

**Description**

As suggested in https://github.com/mrdoob/three.js/issues/33060#issuecomment-3954920096, the PR fixes the feedback loop in `WebGLRenderer`'s transmission code path.