### PR TITLE
CubeRenderTarget: Restore `generateMipmaps` correctly.

### DIFF
--- a/src/renderers/common/CubeRenderTarget.js
+++ b/src/renderers/common/CubeRenderTarget.js
@@ -109,7 +109,7 @@ class CubeRenderTarget extends RenderTarget {
 		renderer.setMRT( currentMRT );
 
 		texture.minFilter = currentMinFilter;
-		texture.currentGenerateMipmaps = currentGenerateMipmaps;
+		texture.generateMipmaps = currentGenerateMipmaps;
 
 		mesh.geometry.dispose();
 		mesh.material.dispose();


### PR DESCRIPTION
This fixes a bug where `texture.currentGenerateMipmaps` is set instead of `texture.generateMipmaps` in `CubeRenderTarget.js`.