### PR TITLE
WebGPURenderer: Honor layerUpdates for array textures

### DIFF
--- a/src/renderers/webgpu/utils/WebGPUTextureUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUTextureUtils.js
@@ -539,13 +539,13 @@ class WebGPUTextureUtils {
 		} else if ( texture.isArrayTexture || texture.isDataArrayTexture || texture.isData3DTexture ) {
 
 			if ( texture.layerUpdates.size > 0 ) {
-  
+
 				for ( const layerIndex of texture.layerUpdates ) {
 
 					this._copyBufferToTexture( options.image, textureData.texture, textureDescriptorGPU, layerIndex, texture.flipY, layerIndex );
 
 				}
-  
+
 				texture.clearLayerUpdates();
 
 			} else {

--- a/src/renderers/webgpu/utils/WebGPUTextureUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUTextureUtils.js
@@ -538,9 +538,23 @@ class WebGPUTextureUtils {
 
 		} else if ( texture.isArrayTexture || texture.isDataArrayTexture || texture.isData3DTexture ) {
 
-			for ( let i = 0; i < options.image.depth; i ++ ) {
+			if ( texture.layerUpdates.size > 0 ) {
+  
+				for ( const layerIndex of texture.layerUpdates ) {
 
-				this._copyBufferToTexture( options.image, textureData.texture, textureDescriptorGPU, i, texture.flipY, i );
+					this._copyBufferToTexture( options.image, textureData.texture, textureDescriptorGPU, layerIndex, texture.flipY, layerIndex );
+
+				}
+  
+				texture.clearLayerUpdates();
+
+			} else {
+
+				for ( let i = 0; i < options.image.depth; i ++ ) {
+
+					this._copyBufferToTexture( options.image, textureData.texture, textureDescriptorGPU, i, texture.flipY, i );
+
+				}
 
 			}
 


### PR DESCRIPTION
**Description**

The [DataArrayTexture.layerUpdates](https://threejs.org/docs/?q=arraytexture#DataArrayTexture.layerUpdates) is ignored in the WebGPU backend. This PR fixes this and enables partial updates. Layer updates are much smoother now and there is no stutter.

Unrelated to the PR - some points that people may find useful
* WebGPU limits depth to 256. Call `WebGPURenderer({requiredLimits: { maxTextureArrayLayers: 2048 }}` to increase the limit.
* You can use data arrays with [BatchedMesh](https://threejs.org/docs/?q=batchedmesh#BatchedMesh), but neither `BatchNode.batchingIdNode` nor `instanceIndex` will work for indexing. The correct index is [found here](https://github.com/mrdoob/three.js/blob/dev/src/nodes/accessors/BatchNode.js#L90). This node is not exposed yet in the API.