### PR TITLE
WebGPUTextureUtils: Fix check `layerUpdates` property

### DIFF
--- a/src/renderers/webgpu/utils/WebGPUTextureUtils.js
+++ b/src/renderers/webgpu/utils/WebGPUTextureUtils.js
@@ -538,7 +538,7 @@ class WebGPUTextureUtils {
 
 		} else if ( texture.isArrayTexture || texture.isDataArrayTexture || texture.isData3DTexture ) {
 
-			if ( texture.layerUpdates.size > 0 ) {
+			if ( texture.layerUpdates && texture.layerUpdates.size > 0 ) {
 
 				for ( const layerIndex of texture.layerUpdates ) {
 


### PR DESCRIPTION
Related issue: https://github.com/mrdoob/three.js/pull/33072

**Description**

This should fix Textures that do not have the property so it doesn’t fail the `.length` check.

