### PR TITLE
InstancedMesh, BatchedMesh: Fix getColorAt throwing an error when colors have not been set

### DIFF
--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -1135,7 +1135,15 @@ class BatchedMesh extends Mesh {
 		this.validateInstanceId( instanceId );
 		if ( this._colorsTexture === null ) {
 
-			return color.setRGB( 1, 1, 1 );
+			if ( color.isVector4 ) {
+
+				return color.set( 1, 1, 1, 1 );
+
+			} else {
+
+				return color.setRGB( 1, 1, 1 );
+
+			}
 
 		} else {
 

--- a/src/objects/BatchedMesh.js
+++ b/src/objects/BatchedMesh.js
@@ -1133,7 +1133,15 @@ class BatchedMesh extends Mesh {
 	getColorAt( instanceId, color ) {
 
 		this.validateInstanceId( instanceId );
-		return color.fromArray( this._colorsTexture.image.data, instanceId * 4 );
+		if ( this._colorsTexture === null ) {
+
+			return color.setRGB( 1, 1, 1 );
+
+		} else {
+
+			return color.fromArray( this._colorsTexture.image.data, instanceId * 4 );
+
+		}
 
 	}
 

--- a/src/objects/InstancedMesh.js
+++ b/src/objects/InstancedMesh.js
@@ -217,7 +217,15 @@ class InstancedMesh extends Mesh {
 	 */
 	getColorAt( index, color ) {
 
-		return color.fromArray( this.instanceColor.array, index * 3 );
+		if ( this.instanceColor === null ) {
+
+			return color.setRGB( 1, 1, 1 );
+
+		} else {
+
+			return color.fromArray( this.instanceColor.array, index * 3 );
+
+		}
 
 	}
 


### PR DESCRIPTION
Related issue: -

**Description**

Previously "getColorAt" was throwing an error if a color at not already been set for an instance. Now the default of opaque white is returned.