### PR TITLE
USDLoader: Add metersPerUnit support.

### DIFF
--- a/examples/jsm/loaders/usd/USDAParser.js
+++ b/examples/jsm/loaders/usd/USDAParser.js
@@ -454,6 +454,12 @@ class USDAParser {
 
 			}
 
+			if ( header.metersPerUnit !== undefined ) {
+
+				rootFields.metersPerUnit = parseFloat( header.metersPerUnit );
+
+			}
+
 		}
 
 		specsByPath[ '/' ] = { specType: SpecType.Prim, fields: rootFields };

--- a/examples/jsm/loaders/usd/USDComposer.js
+++ b/examples/jsm/loaders/usd/USDComposer.js
@@ -115,6 +115,15 @@ class USDComposer {
 		// Build animations
 		group.animations = this._buildAnimations();
 
+		// Handle metersPerUnit scaling
+		const metersPerUnit = rootFields.metersPerUnit;
+
+		if ( metersPerUnit !== undefined && metersPerUnit !== 1 ) {
+
+			group.scale.setScalar( metersPerUnit );
+
+		}
+
 		// Handle Z-up to Y-up conversion
 		if ( rootSpec && rootSpec.fields && rootSpec.fields.upAxis === 'Z' ) {
 


### PR DESCRIPTION
**Description**

Scales the root group by metersPerUnit when the value is present and not 1. Files authored in centimeters (metersPerUnit = 0.01) are now correctly sized. Also adds metersPerUnit extraction to the USDA parser (the USDC parser already had it).