### PR TITLE
Renderer: Make `hasCompatibility()` more predictable.

### DIFF
--- a/src/renderers/common/Renderer.js
+++ b/src/renderers/common/Renderer.js
@@ -3369,13 +3369,18 @@ class Renderer {
 	}
 
 	/**
-	 * Checks if the given compatibility is supported by the selected backend. If the
-	 * renderer has not been initialized, this method always returns `false`.
+	 * Checks if the given compatibility is supported by the selected backend.
 	 *
 	 * @param {string} name - The compatibility's name.
 	 * @return {boolean} Whether the compatibility is supported or not.
 	 */
 	hasCompatibility( name ) {
+
+		if ( this._initialized === false ) {
+
+			throw new Error( 'Renderer: .hasCompatibility() called before the backend is initialized. Use "await renderer.init();" before using this method.' );
+
+		}
 
 		return this.backend.hasCompatibility( name );
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -2539,11 +2539,7 @@ class WebGPUBackend extends Backend {
 	 */
 	hasCompatibility( name ) {
 
-		if ( this._compatibility[ Compatibility.TEXTURE_COMPARE ] !== undefined ) {
-
-			return this._compatibility[ Compatibility.TEXTURE_COMPARE ];
-
-		}
+		if ( name === Compatibility.TEXTURE_COMPARE ) return this._compatibility[ Compatibility.TEXTURE_COMPARE ];
 
 		return super.hasCompatibility( name );
 

--- a/src/renderers/webgpu/WebGPUBackend.js
+++ b/src/renderers/webgpu/WebGPUBackend.js
@@ -2539,7 +2539,11 @@ class WebGPUBackend extends Backend {
 	 */
 	hasCompatibility( name ) {
 
-		if ( name === Compatibility.TEXTURE_COMPARE ) return this._compatibility[ Compatibility.TEXTURE_COMPARE ];
+		if ( this._compatibility[ name ] !== undefined ) {
+
+			return this._compatibility[ name ];
+
+		}
 
 		return super.hasCompatibility( name );
 


### PR DESCRIPTION
Related issue: -

**Description**

I think it's preferable if `Renderer.hasCompatibility()` behaves similar to `hasFeature()` and only reports a result after the backend has been initialized. Otherwise an error is returned.