### PR TITLE
docs: add color space guidance to material texture properties

### DIFF
--- a/docs/pages/LineBasicMaterial.html
+++ b/docs/pages/LineBasicMaterial.html
@@ -98,7 +98,8 @@ width of one pixel.</p>
 					<div class="description">
 						<p>Sets the color of the lines using data from a texture. The texture map
 color is modulated by the diffuse <code>color</code>.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture may contain color data and must have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set appropriately. For an explanation, see <a href="Color.html">Color Management</a>.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<h2 class="subsection-title">Source</h2>

--- a/docs/pages/LineBasicMaterial.html.md
+++ b/docs/pages/LineBasicMaterial.html.md
@@ -70,6 +70,8 @@ Default is `1`.
 
 Sets the color of the lines using data from a texture. The texture map color is modulated by the diffuse `color`.
 
+**This texture may contain color data and must have its [Texture#colorSpace](Texture.html#colorSpace) set appropriately. For an explanation, see [Color Management](Color.html).**
+
 Default is `null`.
 
 ## Source

--- a/docs/pages/MeshBasicMaterial.html
+++ b/docs/pages/MeshBasicMaterial.html
@@ -54,7 +54,8 @@ exists. For RGB and RGBA textures, the renderer will use the green channel
 when sampling this texture due to the extra bit of precision provided for
 green in DXT-compressed and uncompressed RGB 565 formats. Luminance-only and
 luminance/alpha textures will also still work as expected.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -62,7 +63,8 @@ luminance/alpha textures will also still work as expected.</p>
 					<div class="description">
 						<p>The red channel of this texture is used as the ambient occlusion map.
 Requires a second set of UVs.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -94,7 +96,8 @@ blend between the two colors.</p>
 					<h3 class="name" id="envMap" translate="no">.<a href="#envMap">envMap</a><span class="type-signature"> : <a href="Texture.html">Texture</a></span> </h3>
 					<div class="description">
 						<p>The environment map.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture may contain color data and must have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set appropriately. For an explanation, see <a href="Color.html">Color Management</a>.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -122,7 +125,8 @@ blend between the two colors.</p>
 					<h3 class="name" id="lightMap" translate="no">.<a href="#lightMap">lightMap</a><span class="type-signature"> : <a href="Texture.html">Texture</a></span> </h3>
 					<div class="description">
 						<p>The light map. Requires a second set of UVs.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture may contain color data and must have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set appropriately. For an explanation, see <a href="Color.html">Color Management</a>.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -138,7 +142,8 @@ blend between the two colors.</p>
 						<p>The color map. May optionally include an alpha channel, typically combined
 with <a href="Material.html#transparent">Material#transparent</a> or <a href="Material.html#alphaTest">Material#alphaTest</a>. The texture map
 color is modulated by the diffuse <code>color</code>.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture may contain color data and must have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set appropriately. For an explanation, see <a href="Color.html">Color Management</a>.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -163,7 +168,8 @@ The refraction ratio should not exceed <code>1</code>.</p>
 					<h3 class="name" id="specularMap" translate="no">.<a href="#specularMap">specularMap</a><span class="type-signature"> : <a href="Texture.html">Texture</a></span> </h3>
 					<div class="description">
 						<p>Specular map used by the material.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture may contain color data and must have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set appropriately. For an explanation, see <a href="Color.html">Color Management</a>.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">

--- a/docs/pages/MeshBasicMaterial.html.md
+++ b/docs/pages/MeshBasicMaterial.html.md
@@ -24,11 +24,15 @@ The alpha map is a grayscale texture that controls the opacity across the surfac
 
 Only the color of the texture is used, ignoring the alpha channel if one exists. For RGB and RGBA textures, the renderer will use the green channel when sampling this texture due to the extra bit of precision provided for green in DXT-compressed and uncompressed RGB 565 formats. Luminance-only and luminance/alpha textures will also still work as expected.
 
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
+
 Default is `null`.
 
 ### .aoMap : Texture
 
 The red channel of this texture is used as the ambient occlusion map. Requires a second set of UVs.
+
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
 
 Default is `null`.
 
@@ -56,6 +60,8 @@ Default is `MultiplyOperation`.
 
 The environment map.
 
+**This texture may contain color data and must have its [Texture#colorSpace](Texture.html#colorSpace) set appropriately. For an explanation, see [Color Management](Color.html).**
+
 Default is `null`.
 
 ### .envMapRotation : Euler
@@ -80,6 +86,8 @@ Default is `true`.
 
 The light map. Requires a second set of UVs.
 
+**This texture may contain color data and must have its [Texture#colorSpace](Texture.html#colorSpace) set appropriately. For an explanation, see [Color Management](Color.html).**
+
 Default is `null`.
 
 ### .lightMapIntensity : number
@@ -91,6 +99,8 @@ Default is `1`.
 ### .map : Texture
 
 The color map. May optionally include an alpha channel, typically combined with [Material#transparent](Material.html#transparent) or [Material#alphaTest](Material.html#alphaTest). The texture map color is modulated by the diffuse `color`.
+
+**This texture may contain color data and must have its [Texture#colorSpace](Texture.html#colorSpace) set appropriately. For an explanation, see [Color Management](Color.html).**
 
 Default is `null`.
 
@@ -109,6 +119,8 @@ Default is `0.98`.
 ### .specularMap : Texture
 
 Specular map used by the material.
+
+**This texture may contain color data and must have its [Texture#colorSpace](Texture.html#colorSpace) set appropriately. For an explanation, see [Color Management](Color.html).**
 
 Default is `null`.
 

--- a/docs/pages/MeshDepthMaterial.html
+++ b/docs/pages/MeshDepthMaterial.html
@@ -54,7 +54,8 @@ exists. For RGB and RGBA textures, the renderer will use the green channel
 when sampling this texture due to the extra bit of precision provided for
 green in DXT-compressed and uncompressed RGB 565 formats. Luminance-only and
 luminance/alpha textures will also still work as expected.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -82,7 +83,8 @@ displaced vertices can cast shadows, block other objects, and otherwise
 act as real geometry. The displacement texture is an image where the value
 of each pixel (white being the highest) is mapped against, and
 repositions, the vertices of the mesh.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -106,7 +108,8 @@ map set, this value is not applied.</p>
 					<div class="description">
 						<p>The color map. May optionally include an alpha channel, typically combined
 with <a href="Material.html#transparent">Material#transparent</a> or <a href="Material.html#alphaTest">Material#alphaTest</a>.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture may contain color data and must have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set appropriately. For an explanation, see <a href="Color.html">Color Management</a>.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">

--- a/docs/pages/MeshDepthMaterial.html.md
+++ b/docs/pages/MeshDepthMaterial.html.md
@@ -22,6 +22,8 @@ The alpha map is a grayscale texture that controls the opacity across the surfac
 
 Only the color of the texture is used, ignoring the alpha channel if one exists. For RGB and RGBA textures, the renderer will use the green channel when sampling this texture due to the extra bit of precision provided for green in DXT-compressed and uncompressed RGB 565 formats. Luminance-only and luminance/alpha textures will also still work as expected.
 
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
+
 Default is `null`.
 
 ### .depthPacking : BasicDepthPacking | RGBADepthPacking | RGBDepthPacking | RGDepthPacking
@@ -40,6 +42,8 @@ Default is `0`.
 
 The displacement map affects the position of the mesh's vertices. Unlike other maps which only affect the light and shade of the material the displaced vertices can cast shadows, block other objects, and otherwise act as real geometry. The displacement texture is an image where the value of each pixel (white being the highest) is mapped against, and repositions, the vertices of the mesh.
 
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
+
 Default is `null`.
 
 ### .displacementScale : number
@@ -57,6 +61,8 @@ Default is `true`.
 ### .map : Texture
 
 The color map. May optionally include an alpha channel, typically combined with [Material#transparent](Material.html#transparent) or [Material#alphaTest](Material.html#alphaTest).
+
+**This texture may contain color data and must have its [Texture#colorSpace](Texture.html#colorSpace) set appropriately. For an explanation, see [Color Management](Color.html).**
 
 Default is `null`.
 

--- a/docs/pages/MeshDistanceMaterial.html
+++ b/docs/pages/MeshDistanceMaterial.html
@@ -57,7 +57,8 @@ exists. For RGB and RGBA textures, the renderer will use the green channel
 when sampling this texture due to the extra bit of precision provided for
 green in DXT-compressed and uncompressed RGB 565 formats. Luminance-only and
 luminance/alpha textures will also still work as expected.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -78,7 +79,8 @@ displaced vertices can cast shadows, block other objects, and otherwise
 act as real geometry. The displacement texture is an image where the value
 of each pixel (white being the highest) is mapped against, and
 repositions, the vertices of the mesh.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -102,7 +104,8 @@ map set, this value is not applied.</p>
 					<div class="description">
 						<p>The color map. May optionally include an alpha channel, typically combined
 with <a href="Material.html#transparent">Material#transparent</a> or <a href="Material.html#alphaTest">Material#alphaTest</a>.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture may contain color data and must have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set appropriately. For an explanation, see <a href="Color.html">Color Management</a>.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<h2 class="subsection-title">Source</h2>

--- a/docs/pages/MeshDistanceMaterial.html.md
+++ b/docs/pages/MeshDistanceMaterial.html.md
@@ -24,6 +24,8 @@ The alpha map is a grayscale texture that controls the opacity across the surfac
 
 Only the color of the texture is used, ignoring the alpha channel if one exists. For RGB and RGBA textures, the renderer will use the green channel when sampling this texture due to the extra bit of precision provided for green in DXT-compressed and uncompressed RGB 565 formats. Luminance-only and luminance/alpha textures will also still work as expected.
 
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
+
 Default is `null`.
 
 ### .displacementBias : number
@@ -35,6 +37,8 @@ Default is `0`.
 ### .displacementMap : Texture
 
 The displacement map affects the position of the mesh's vertices. Unlike other maps which only affect the light and shade of the material the displaced vertices can cast shadows, block other objects, and otherwise act as real geometry. The displacement texture is an image where the value of each pixel (white being the highest) is mapped against, and repositions, the vertices of the mesh.
+
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
 
 Default is `null`.
 
@@ -53,6 +57,8 @@ Default is `true`.
 ### .map : Texture
 
 The color map. May optionally include an alpha channel, typically combined with [Material#transparent](Material.html#transparent) or [Material#alphaTest](Material.html#alphaTest).
+
+**This texture may contain color data and must have its [Texture#colorSpace](Texture.html#colorSpace) set appropriately. For an explanation, see [Color Management](Color.html).**
 
 Default is `null`.
 

--- a/docs/pages/MeshLambertMaterial.html
+++ b/docs/pages/MeshLambertMaterial.html
@@ -62,7 +62,8 @@ exists. For RGB and RGBA textures, the renderer will use the green channel
 when sampling this texture due to the extra bit of precision provided for
 green in DXT-compressed and uncompressed RGB 565 formats. Luminance-only and
 luminance/alpha textures will also still work as expected.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -70,7 +71,8 @@ luminance/alpha textures will also still work as expected.</p>
 					<div class="description">
 						<p>The red channel of this texture is used as the ambient occlusion map.
 Requires a second set of UVs.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -89,7 +91,8 @@ red channel is also <code>1</code>, ambient light is fully occluded on a surface
 perceived depth in relation to the lights. Bump doesn't actually affect
 the geometry of the object, only the lighting. If a normal map is defined
 this will be ignored.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -133,7 +136,8 @@ displaced vertices can cast shadows, block other objects, and otherwise
 act as real geometry. The displacement texture is an image where the value
 of each pixel (white being the highest) is mapped against, and
 repositions, the vertices of the mesh.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -166,14 +170,16 @@ unaffected by other lighting.</p>
 						<p>Set emissive (glow) map. The emissive map color is modulated by the
 emissive color and the emissive intensity. If you have an emissive map,
 be sure to set the emissive color to something other than black.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture may contain color data and must have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set appropriately. For an explanation, see <a href="Color.html">Color Management</a>.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
 					<h3 class="name" id="envMap" translate="no">.<a href="#envMap">envMap</a><span class="type-signature"> : <a href="Texture.html">Texture</a></span> </h3>
 					<div class="description">
 						<p>The environment map.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture may contain color data and must have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set appropriately. For an explanation, see <a href="Color.html">Color Management</a>.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -215,7 +221,8 @@ be sure to set the emissive color to something other than black.</p>
 					<h3 class="name" id="lightMap" translate="no">.<a href="#lightMap">lightMap</a><span class="type-signature"> : <a href="Texture.html">Texture</a></span> </h3>
 					<div class="description">
 						<p>The light map. Requires a second set of UVs.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture may contain color data and must have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set appropriately. For an explanation, see <a href="Color.html">Color Management</a>.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -231,7 +238,8 @@ be sure to set the emissive color to something other than black.</p>
 						<p>The color map. May optionally include an alpha channel, typically combined
 with <a href="Material.html#transparent">Material#transparent</a> or <a href="Material.html#alphaTest">Material#alphaTest</a>. The texture map
 color is modulated by the diffuse <code>color</code>.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture may contain color data and must have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set appropriately. For an explanation, see <a href="Color.html">Color Management</a>.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -243,7 +251,8 @@ maps do not change the actual shape of the surface, only the lighting. In
 case the material has a normal map authored using the left handed
 convention, the <code>y</code> component of <code>normalScale</code> should be negated to compensate
 for the different handedness.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -282,7 +291,8 @@ The refraction ratio should not exceed <code>1</code>.</p>
 					<h3 class="name" id="specularMap" translate="no">.<a href="#specularMap">specularMap</a><span class="type-signature"> : <a href="Texture.html">Texture</a></span> </h3>
 					<div class="description">
 						<p>Specular map used by the material.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture may contain color data and must have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set appropriately. For an explanation, see <a href="Color.html">Color Management</a>.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">

--- a/docs/pages/MeshLambertMaterial.html.md
+++ b/docs/pages/MeshLambertMaterial.html.md
@@ -26,11 +26,15 @@ The alpha map is a grayscale texture that controls the opacity across the surfac
 
 Only the color of the texture is used, ignoring the alpha channel if one exists. For RGB and RGBA textures, the renderer will use the green channel when sampling this texture due to the extra bit of precision provided for green in DXT-compressed and uncompressed RGB 565 formats. Luminance-only and luminance/alpha textures will also still work as expected.
 
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
+
 Default is `null`.
 
 ### .aoMap : Texture
 
 The red channel of this texture is used as the ambient occlusion map. Requires a second set of UVs.
+
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
 
 Default is `null`.
 
@@ -43,6 +47,8 @@ Default is `1`.
 ### .bumpMap : Texture
 
 The texture to create a bump map. The black and white values map to the perceived depth in relation to the lights. Bump doesn't actually affect the geometry of the object, only the lighting. If a normal map is defined this will be ignored.
+
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
 
 Default is `null`.
 
@@ -76,6 +82,8 @@ Default is `0`.
 
 The displacement map affects the position of the mesh's vertices. Unlike other maps which only affect the light and shade of the material the displaced vertices can cast shadows, block other objects, and otherwise act as real geometry. The displacement texture is an image where the value of each pixel (white being the highest) is mapped against, and repositions, the vertices of the mesh.
 
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
+
 Default is `null`.
 
 ### .displacementScale : number
@@ -100,11 +108,15 @@ Default is `1`.
 
 Set emissive (glow) map. The emissive map color is modulated by the emissive color and the emissive intensity. If you have an emissive map, be sure to set the emissive color to something other than black.
 
+**This texture may contain color data and must have its [Texture#colorSpace](Texture.html#colorSpace) set appropriately. For an explanation, see [Color Management](Color.html).**
+
 Default is `null`.
 
 ### .envMap : Texture
 
 The environment map.
+
+**This texture may contain color data and must have its [Texture#colorSpace](Texture.html#colorSpace) set appropriately. For an explanation, see [Color Management](Color.html).**
 
 Default is `null`.
 
@@ -142,6 +154,8 @@ Default is `true`.
 
 The light map. Requires a second set of UVs.
 
+**This texture may contain color data and must have its [Texture#colorSpace](Texture.html#colorSpace) set appropriately. For an explanation, see [Color Management](Color.html).**
+
 Default is `null`.
 
 ### .lightMapIntensity : number
@@ -154,11 +168,15 @@ Default is `1`.
 
 The color map. May optionally include an alpha channel, typically combined with [Material#transparent](Material.html#transparent) or [Material#alphaTest](Material.html#alphaTest). The texture map color is modulated by the diffuse `color`.
 
+**This texture may contain color data and must have its [Texture#colorSpace](Texture.html#colorSpace) set appropriately. For an explanation, see [Color Management](Color.html).**
+
 Default is `null`.
 
 ### .normalMap : Texture
 
 The texture to create a normal map. The RGB values affect the surface normal for each pixel fragment and change the way the color is lit. Normal maps do not change the actual shape of the surface, only the lighting. In case the material has a normal map authored using the left handed convention, the `y` component of `normalScale` should be negated to compensate for the different handedness.
+
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
 
 Default is `null`.
 
@@ -189,6 +207,8 @@ Default is `0.98`.
 ### .specularMap : Texture
 
 Specular map used by the material.
+
+**This texture may contain color data and must have its [Texture#colorSpace](Texture.html#colorSpace) set appropriately. For an explanation, see [Color Management](Color.html).**
 
 Default is `null`.
 

--- a/docs/pages/MeshMatcapMaterial.html
+++ b/docs/pages/MeshMatcapMaterial.html
@@ -58,7 +58,8 @@ exists. For RGB and RGBA textures, the renderer will use the green channel
 when sampling this texture due to the extra bit of precision provided for
 green in DXT-compressed and uncompressed RGB 565 formats. Luminance-only and
 luminance/alpha textures will also still work as expected.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -68,7 +69,8 @@ luminance/alpha textures will also still work as expected.</p>
 perceived depth in relation to the lights. Bump doesn't actually affect
 the geometry of the object, only the lighting. If a normal map is defined
 this will be ignored.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -103,7 +105,8 @@ displaced vertices can cast shadows, block other objects, and otherwise
 act as real geometry. The displacement texture is an image where the value
 of each pixel (white being the highest) is mapped against, and
 repositions, the vertices of the mesh.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -142,14 +145,16 @@ map set, this value is not applied.</p>
 						<p>The color map. May optionally include an alpha channel, typically combined
 with <a href="Material.html#transparent">Material#transparent</a> or <a href="Material.html#alphaTest">Material#alphaTest</a>. The texture map
 color is modulated by the diffuse <code>color</code>.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture may contain color data and must have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set appropriately. For an explanation, see <a href="Color.html">Color Management</a>.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
 					<h3 class="name" id="matcap" translate="no">.<a href="#matcap">matcap</a><span class="type-signature"> : <a href="Texture.html">Texture</a></span> </h3>
 					<div class="description">
 						<p>The matcap map.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture may contain color data and must have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set appropriately. For an explanation, see <a href="Color.html">Color Management</a>.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -161,7 +166,8 @@ maps do not change the actual shape of the surface, only the lighting. In
 case the material has a normal map authored using the left handed
 convention, the <code>y</code> component of <code>normalScale</code> should be negated to compensate
 for the different handedness.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">

--- a/docs/pages/MeshMatcapMaterial.html.md
+++ b/docs/pages/MeshMatcapMaterial.html.md
@@ -24,11 +24,15 @@ The alpha map is a grayscale texture that controls the opacity across the surfac
 
 Only the color of the texture is used, ignoring the alpha channel if one exists. For RGB and RGBA textures, the renderer will use the green channel when sampling this texture due to the extra bit of precision provided for green in DXT-compressed and uncompressed RGB 565 formats. Luminance-only and luminance/alpha textures will also still work as expected.
 
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
+
 Default is `null`.
 
 ### .bumpMap : Texture
 
 The texture to create a bump map. The black and white values map to the perceived depth in relation to the lights. Bump doesn't actually affect the geometry of the object, only the lighting. If a normal map is defined this will be ignored.
+
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
 
 Default is `null`.
 
@@ -53,6 +57,8 @@ Default is `0`.
 ### .displacementMap : Texture
 
 The displacement map affects the position of the mesh's vertices. Unlike other maps which only affect the light and shade of the material the displaced vertices can cast shadows, block other objects, and otherwise act as real geometry. The displacement texture is an image where the value of each pixel (white being the highest) is mapped against, and repositions, the vertices of the mesh.
+
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
 
 Default is `null`.
 
@@ -84,17 +90,23 @@ Default is `true`.
 
 The color map. May optionally include an alpha channel, typically combined with [Material#transparent](Material.html#transparent) or [Material#alphaTest](Material.html#alphaTest). The texture map color is modulated by the diffuse `color`.
 
+**This texture may contain color data and must have its [Texture#colorSpace](Texture.html#colorSpace) set appropriately. For an explanation, see [Color Management](Color.html).**
+
 Default is `null`.
 
 ### .matcap : Texture
 
 The matcap map.
 
+**This texture may contain color data and must have its [Texture#colorSpace](Texture.html#colorSpace) set appropriately. For an explanation, see [Color Management](Color.html).**
+
 Default is `null`.
 
 ### .normalMap : Texture
 
 The texture to create a normal map. The RGB values affect the surface normal for each pixel fragment and change the way the color is lit. Normal maps do not change the actual shape of the surface, only the lighting. In case the material has a normal map authored using the left handed convention, the `y` component of `normalScale` should be negated to compensate for the different handedness.
+
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
 
 Default is `null`.
 

--- a/docs/pages/MeshNormalMaterial.html
+++ b/docs/pages/MeshNormalMaterial.html
@@ -50,7 +50,8 @@ by <a href="Color.html#set">Color#set</a>.</p>
 perceived depth in relation to the lights. Bump doesn't actually affect
 the geometry of the object, only the lighting. If a normal map is defined
 this will be ignored.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -78,7 +79,8 @@ displaced vertices can cast shadows, block other objects, and otherwise
 act as real geometry. The displacement texture is an image where the value
 of each pixel (white being the highest) is mapped against, and
 repositions, the vertices of the mesh.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -113,7 +115,8 @@ maps do not change the actual shape of the surface, only the lighting. In
 case the material has a normal map authored using the left handed
 convention, the <code>y</code> component of <code>normalScale</code> should be negated to compensate
 for the different handedness.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">

--- a/docs/pages/MeshNormalMaterial.html.md
+++ b/docs/pages/MeshNormalMaterial.html.md
@@ -20,6 +20,8 @@ An object with one or more properties defining the material's appearance. Any pr
 
 The texture to create a bump map. The black and white values map to the perceived depth in relation to the lights. Bump doesn't actually affect the geometry of the object, only the lighting. If a normal map is defined this will be ignored.
 
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
+
 Default is `null`.
 
 ### .bumpScale : number
@@ -37,6 +39,8 @@ Default is `0`.
 ### .displacementMap : Texture
 
 The displacement map affects the position of the mesh's vertices. Unlike other maps which only affect the light and shade of the material the displaced vertices can cast shadows, block other objects, and otherwise act as real geometry. The displacement texture is an image where the value of each pixel (white being the highest) is mapped against, and repositions, the vertices of the mesh.
+
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
 
 Default is `null`.
 
@@ -61,6 +65,8 @@ Default is `true`.
 ### .normalMap : Texture
 
 The texture to create a normal map. The RGB values affect the surface normal for each pixel fragment and change the way the color is lit. Normal maps do not change the actual shape of the surface, only the lighting. In case the material has a normal map authored using the left handed convention, the `y` component of `normalScale` should be negated to compensate for the different handedness.
+
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
 
 Default is `null`.
 

--- a/docs/pages/MeshPhongMaterial.html
+++ b/docs/pages/MeshPhongMaterial.html
@@ -60,7 +60,8 @@ exists. For RGB and RGBA textures, the renderer will use the green channel
 when sampling this texture due to the extra bit of precision provided for
 green in DXT-compressed and uncompressed RGB 565 formats. Luminance-only and
 luminance/alpha textures will also still work as expected.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -68,7 +69,8 @@ luminance/alpha textures will also still work as expected.</p>
 					<div class="description">
 						<p>The red channel of this texture is used as the ambient occlusion map.
 Requires a second set of UVs.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -87,7 +89,8 @@ red channel is also <code>1</code>, ambient light is fully occluded on a surface
 perceived depth in relation to the lights. Bump doesn't actually affect
 the geometry of the object, only the lighting. If a normal map is defined
 this will be ignored.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -131,7 +134,8 @@ displaced vertices can cast shadows, block other objects, and otherwise
 act as real geometry. The displacement texture is an image where the value
 of each pixel (white being the highest) is mapped against, and
 repositions, the vertices of the mesh.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -164,14 +168,16 @@ unaffected by other lighting.</p>
 						<p>Set emissive (glow) map. The emissive map color is modulated by the
 emissive color and the emissive intensity. If you have an emissive map,
 be sure to set the emissive color to something other than black.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture may contain color data and must have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set appropriately. For an explanation, see <a href="Color.html">Color Management</a>.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
 					<h3 class="name" id="envMap" translate="no">.<a href="#envMap">envMap</a><span class="type-signature"> : <a href="Texture.html">Texture</a></span> </h3>
 					<div class="description">
 						<p>The environment map.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture may contain color data and must have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set appropriately. For an explanation, see <a href="Color.html">Color Management</a>.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -213,7 +219,8 @@ be sure to set the emissive color to something other than black.</p>
 					<h3 class="name" id="lightMap" translate="no">.<a href="#lightMap">lightMap</a><span class="type-signature"> : <a href="Texture.html">Texture</a></span> </h3>
 					<div class="description">
 						<p>The light map. Requires a second set of UVs.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture may contain color data and must have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set appropriately. For an explanation, see <a href="Color.html">Color Management</a>.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -229,7 +236,8 @@ be sure to set the emissive color to something other than black.</p>
 						<p>The color map. May optionally include an alpha channel, typically combined
 with <a href="Material.html#transparent">Material#transparent</a> or <a href="Material.html#alphaTest">Material#alphaTest</a>. The texture map
 color is modulated by the diffuse <code>color</code>.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture may contain color data and must have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set appropriately. For an explanation, see <a href="Color.html">Color Management</a>.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -241,7 +249,8 @@ maps do not change the actual shape of the surface, only the lighting. In
 case the material has a normal map authored using the left handed
 convention, the <code>y</code> component of <code>normalScale</code> should be negated to compensate
 for the different handedness.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -296,7 +305,8 @@ The refraction ratio should not exceed <code>1</code>.</p>
 						<p>The specular map value affects both how much the specular surface
 highlight contributes and how much of the environment map affects the
 surface.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture may contain color data and must have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set appropriately. For an explanation, see <a href="Color.html">Color Management</a>.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">

--- a/docs/pages/MeshPhongMaterial.html.md
+++ b/docs/pages/MeshPhongMaterial.html.md
@@ -26,11 +26,15 @@ The alpha map is a grayscale texture that controls the opacity across the surfac
 
 Only the color of the texture is used, ignoring the alpha channel if one exists. For RGB and RGBA textures, the renderer will use the green channel when sampling this texture due to the extra bit of precision provided for green in DXT-compressed and uncompressed RGB 565 formats. Luminance-only and luminance/alpha textures will also still work as expected.
 
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
+
 Default is `null`.
 
 ### .aoMap : Texture
 
 The red channel of this texture is used as the ambient occlusion map. Requires a second set of UVs.
+
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
 
 Default is `null`.
 
@@ -43,6 +47,8 @@ Default is `1`.
 ### .bumpMap : Texture
 
 The texture to create a bump map. The black and white values map to the perceived depth in relation to the lights. Bump doesn't actually affect the geometry of the object, only the lighting. If a normal map is defined this will be ignored.
+
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
 
 Default is `null`.
 
@@ -76,6 +82,8 @@ Default is `0`.
 
 The displacement map affects the position of the mesh's vertices. Unlike other maps which only affect the light and shade of the material the displaced vertices can cast shadows, block other objects, and otherwise act as real geometry. The displacement texture is an image where the value of each pixel (white being the highest) is mapped against, and repositions, the vertices of the mesh.
 
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
+
 Default is `null`.
 
 ### .displacementScale : number
@@ -100,11 +108,15 @@ Default is `1`.
 
 Set emissive (glow) map. The emissive map color is modulated by the emissive color and the emissive intensity. If you have an emissive map, be sure to set the emissive color to something other than black.
 
+**This texture may contain color data and must have its [Texture#colorSpace](Texture.html#colorSpace) set appropriately. For an explanation, see [Color Management](Color.html).**
+
 Default is `null`.
 
 ### .envMap : Texture
 
 The environment map.
+
+**This texture may contain color data and must have its [Texture#colorSpace](Texture.html#colorSpace) set appropriately. For an explanation, see [Color Management](Color.html).**
 
 Default is `null`.
 
@@ -142,6 +154,8 @@ Default is `true`.
 
 The light map. Requires a second set of UVs.
 
+**This texture may contain color data and must have its [Texture#colorSpace](Texture.html#colorSpace) set appropriately. For an explanation, see [Color Management](Color.html).**
+
 Default is `null`.
 
 ### .lightMapIntensity : number
@@ -154,11 +168,15 @@ Default is `1`.
 
 The color map. May optionally include an alpha channel, typically combined with [Material#transparent](Material.html#transparent) or [Material#alphaTest](Material.html#alphaTest). The texture map color is modulated by the diffuse `color`.
 
+**This texture may contain color data and must have its [Texture#colorSpace](Texture.html#colorSpace) set appropriately. For an explanation, see [Color Management](Color.html).**
+
 Default is `null`.
 
 ### .normalMap : Texture
 
 The texture to create a normal map. The RGB values affect the surface normal for each pixel fragment and change the way the color is lit. Normal maps do not change the actual shape of the surface, only the lighting. In case the material has a normal map authored using the left handed convention, the `y` component of `normalScale` should be negated to compensate for the different handedness.
+
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
 
 Default is `null`.
 
@@ -201,6 +219,8 @@ This defines how shiny the material is and the color of its shine.
 ### .specularMap : Texture
 
 The specular map value affects both how much the specular surface highlight contributes and how much of the environment map affects the surface.
+
+**This texture may contain color data and must have its [Texture#colorSpace](Texture.html#colorSpace) set appropriately. For an explanation, see [Color Management](Color.html).**
 
 Default is `null`.
 

--- a/docs/pages/MeshPhysicalMaterial.html
+++ b/docs/pages/MeshPhysicalMaterial.html
@@ -76,7 +76,8 @@ by <a href="Color.html#set">Color#set</a>.</p>
 						<p>Red and green channels represent the anisotropy direction in <code>[-1, 1]</code> tangent,
 bitangent space, to be rotated by <code>anisotropyRotation</code>. The blue channel
 contains strength as <code>[0, 1]</code> to be multiplied by <code>anisotropy</code>.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -119,14 +120,16 @@ thin translucent layer over the base layer.</p>
 					<div class="description">
 						<p>The red channel of this texture is multiplied against <code>clearcoat</code>,
 for per-pixel control over a coating's intensity.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
 					<h3 class="name" id="clearcoatNormalMap" translate="no">.<a href="#clearcoatNormalMap">clearcoatNormalMap</a><span class="type-signature"> : <a href="Texture.html">Texture</a></span> </h3>
 					<div class="description">
 						<p>Can be used to enable independent normals for the clear coat layer.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -149,7 +152,8 @@ for per-pixel control over a coating's intensity.</p>
 					<div class="description">
 						<p>The green channel of this texture is multiplied against
 <code>clearcoatRoughness</code>, for per-pixel control over a coating's roughness.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -189,7 +193,8 @@ Between <code>1.0</code> to <code>2.333</code>.</p>
 					<div class="description">
 						<p>The red channel of this texture is multiplied against <code>iridescence</code>, for per-pixel
 control over iridescence.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -202,7 +207,8 @@ Minimum and maximum values of thickness are defined by <code>iridescenceThicknes
 <li><code>1.0</code> in the green channel will result in thickness equal to second element of the array.</li>
 <li>Values in-between will linearly interpolate between the elements of the array.</li>
 </ul>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -249,7 +255,8 @@ when <code>metalness</code> is <code>1.0</code></p>
 					<div class="description">
 						<p>The RGB channels of this texture are multiplied against  <code>sheenColor</code>, for per-pixel control
 over sheen tint.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture may contain color data and must have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set appropriately. For an explanation, see <a href="Color.html">Color Management</a>.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -264,7 +271,8 @@ over sheen tint.</p>
 					<div class="description">
 						<p>The alpha channel of this texture is multiplied against <code>sheenRoughness</code>, for per-pixel control
 over sheen roughness.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -279,7 +287,8 @@ over sheen roughness.</p>
 					<div class="description">
 						<p>The RGB channels of this texture are multiplied against <code>specularColor</code>,
 for per-pixel control over specular color.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture may contain color data and must have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set appropriately. For an explanation, see <a href="Color.html">Color Management</a>.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -295,7 +304,8 @@ When set to zero, the model is effectively Lambertian. From <code>0.0</code> to 
 					<div class="description">
 						<p>The alpha channel of this texture is multiplied against <code>specularIntensity</code>,
 for per-pixel control over specular intensity.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -312,7 +322,8 @@ thin-walled. Otherwise the material is a volume boundary.</p>
 					<div class="description">
 						<p>A texture that defines the thickness, stored in the green channel. This will
 be multiplied by <code>thickness</code>.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -331,7 +342,8 @@ property can be used to model these materials.</p>
 					<div class="description">
 						<p>The red channel of this texture is multiplied against <code>transmission</code>, for per-pixel control over
 optical transparency.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<h2 class="subsection-title">Source</h2>

--- a/docs/pages/MeshPhysicalMaterial.html.md
+++ b/docs/pages/MeshPhysicalMaterial.html.md
@@ -35,6 +35,8 @@ Default is `0`.
 
 Red and green channels represent the anisotropy direction in `[-1, 1]` tangent, bitangent space, to be rotated by `anisotropyRotation`. The blue channel contains strength as `[0, 1]` to be multiplied by `anisotropy`.
 
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
+
 Default is `null`.
 
 ### .anisotropyRotation : number
@@ -65,11 +67,15 @@ Default is `0`.
 
 The red channel of this texture is multiplied against `clearcoat`, for per-pixel control over a coating's intensity.
 
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
+
 Default is `null`.
 
 ### .clearcoatNormalMap : Texture
 
 Can be used to enable independent normals for the clear coat layer.
+
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
 
 Default is `null`.
 
@@ -88,6 +94,8 @@ Default is `0`.
 ### .clearcoatRoughnessMap : Texture
 
 The green channel of this texture is multiplied against `clearcoatRoughness`, for per-pixel control over a coating's roughness.
+
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
 
 Default is `null`.
 
@@ -119,6 +127,8 @@ Default is `1.3`.
 
 The red channel of this texture is multiplied against `iridescence`, for per-pixel control over iridescence.
 
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
+
 Default is `null`.
 
 ### .iridescenceThicknessMap : Texture
@@ -128,6 +138,8 @@ A texture that defines the thickness of the iridescence layer, stored in the gre
 *   `0.0` in the green channel will result in thickness equal to first element of the array.
 *   `1.0` in the green channel will result in thickness equal to second element of the array.
 *   Values in-between will linearly interpolate between the elements of the array.
+
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
 
 Default is `null`.
 
@@ -167,6 +179,8 @@ Default is `(0,0,0)`.
 
 The RGB channels of this texture are multiplied against `sheenColor`, for per-pixel control over sheen tint.
 
+**This texture may contain color data and must have its [Texture#colorSpace](Texture.html#colorSpace) set appropriately. For an explanation, see [Color Management](Color.html).**
+
 Default is `null`.
 
 ### .sheenRoughness : number
@@ -178,6 +192,8 @@ Default is `1`.
 ### .sheenRoughnessMap : Texture
 
 The alpha channel of this texture is multiplied against `sheenRoughness`, for per-pixel control over sheen roughness.
+
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
 
 Default is `null`.
 
@@ -191,6 +207,8 @@ Default is `(1,1,1)`.
 
 The RGB channels of this texture are multiplied against `specularColor`, for per-pixel control over specular color.
 
+**This texture may contain color data and must have its [Texture#colorSpace](Texture.html#colorSpace) set appropriately. For an explanation, see [Color Management](Color.html).**
+
 Default is `null`.
 
 ### .specularIntensity : number
@@ -203,6 +221,8 @@ Default is `1`.
 
 The alpha channel of this texture is multiplied against `specularIntensity`, for per-pixel control over specular intensity.
 
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
+
 Default is `null`.
 
 ### .thickness : number
@@ -214,6 +234,8 @@ Default is `0`.
 ### .thicknessMap : Texture
 
 A texture that defines the thickness, stored in the green channel. This will be multiplied by `thickness`.
+
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
 
 Default is `null`.
 
@@ -230,6 +252,8 @@ Default is `0`.
 ### .transmissionMap : Texture
 
 The red channel of this texture is multiplied against `transmission`, for per-pixel control over optical transparency.
+
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
 
 Default is `null`.
 

--- a/docs/pages/MeshStandardMaterial.html
+++ b/docs/pages/MeshStandardMaterial.html
@@ -76,7 +76,8 @@ exists. For RGB and RGBA textures, the renderer will use the green channel
 when sampling this texture due to the extra bit of precision provided for
 green in DXT-compressed and uncompressed RGB 565 formats. Luminance-only and
 luminance/alpha textures will also still work as expected.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -84,7 +85,8 @@ luminance/alpha textures will also still work as expected.</p>
 					<div class="description">
 						<p>The red channel of this texture is used as the ambient occlusion map.
 Requires a second set of UVs.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -103,7 +105,8 @@ red channel is also <code>1</code>, ambient light is fully occluded on a surface
 perceived depth in relation to the lights. Bump doesn't actually affect
 the geometry of the object, only the lighting. If a normal map is defined
 this will be ignored.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -138,7 +141,8 @@ displaced vertices can cast shadows, block other objects, and otherwise
 act as real geometry. The displacement texture is an image where the value
 of each pixel (white being the highest) is mapped against, and
 repositions, the vertices of the mesh.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -171,7 +175,8 @@ unaffected by other lighting.</p>
 						<p>Set emissive (glow) map. The emissive map color is modulated by the
 emissive color and the emissive intensity. If you have an emissive map,
 be sure to set the emissive color to something other than black.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture may contain color data and must have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set appropriately. For an explanation, see <a href="Color.html">Color Management</a>.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -179,7 +184,8 @@ be sure to set the emissive color to something other than black.</p>
 					<div class="description">
 						<p>The environment map. To ensure a physically correct rendering, environment maps
 are internally pre-processed with <a href="PMREMGenerator.html">PMREMGenerator</a>.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture may contain color data and must have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set appropriately. For an explanation, see <a href="Color.html">Color Management</a>.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -221,7 +227,8 @@ are internally pre-processed with <a href="PMREMGenerator.html">PMREMGenerator</
 					<h3 class="name" id="lightMap" translate="no">.<a href="#lightMap">lightMap</a><span class="type-signature"> : <a href="Texture.html">Texture</a></span> </h3>
 					<div class="description">
 						<p>The light map. Requires a second set of UVs.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture may contain color data and must have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set appropriately. For an explanation, see <a href="Color.html">Color Management</a>.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -237,7 +244,8 @@ are internally pre-processed with <a href="PMREMGenerator.html">PMREMGenerator</
 						<p>The color map. May optionally include an alpha channel, typically combined
 with <a href="Material.html#transparent">Material#transparent</a> or <a href="Material.html#alphaTest">Material#alphaTest</a>. The texture map
 color is modulated by the diffuse <code>color</code>.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture may contain color data and must have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set appropriately. For an explanation, see <a href="Color.html">Color Management</a>.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -255,7 +263,8 @@ If <code>metalnessMap</code> is also provided, both values are multiplied.</p>
 					<div class="description">
 						<p>The blue channel of this texture is used to alter the metalness of the
 material.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -267,7 +276,8 @@ maps do not change the actual shape of the surface, only the lighting. In
 case the material has a normal map authored using the left handed
 convention, the <code>y</code> component of <code>normalScale</code> should be negated to compensate
 for the different handedness.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -298,7 +308,8 @@ both values are multiplied.</p>
 					<div class="description">
 						<p>The green channel of this texture is used to alter the roughness of the
 material.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">

--- a/docs/pages/MeshStandardMaterial.html.md
+++ b/docs/pages/MeshStandardMaterial.html.md
@@ -37,11 +37,15 @@ The alpha map is a grayscale texture that controls the opacity across the surfac
 
 Only the color of the texture is used, ignoring the alpha channel if one exists. For RGB and RGBA textures, the renderer will use the green channel when sampling this texture due to the extra bit of precision provided for green in DXT-compressed and uncompressed RGB 565 formats. Luminance-only and luminance/alpha textures will also still work as expected.
 
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
+
 Default is `null`.
 
 ### .aoMap : Texture
 
 The red channel of this texture is used as the ambient occlusion map. Requires a second set of UVs.
+
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
 
 Default is `null`.
 
@@ -54,6 +58,8 @@ Default is `1`.
 ### .bumpMap : Texture
 
 The texture to create a bump map. The black and white values map to the perceived depth in relation to the lights. Bump doesn't actually affect the geometry of the object, only the lighting. If a normal map is defined this will be ignored.
+
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
 
 Default is `null`.
 
@@ -79,6 +85,8 @@ Default is `0`.
 
 The displacement map affects the position of the mesh's vertices. Unlike other maps which only affect the light and shade of the material the displaced vertices can cast shadows, block other objects, and otherwise act as real geometry. The displacement texture is an image where the value of each pixel (white being the highest) is mapped against, and repositions, the vertices of the mesh.
 
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
+
 Default is `null`.
 
 ### .displacementScale : number
@@ -103,11 +111,15 @@ Default is `1`.
 
 Set emissive (glow) map. The emissive map color is modulated by the emissive color and the emissive intensity. If you have an emissive map, be sure to set the emissive color to something other than black.
 
+**This texture may contain color data and must have its [Texture#colorSpace](Texture.html#colorSpace) set appropriately. For an explanation, see [Color Management](Color.html).**
+
 Default is `null`.
 
 ### .envMap : Texture
 
 The environment map. To ensure a physically correct rendering, environment maps are internally pre-processed with [PMREMGenerator](PMREMGenerator.html).
+
+**This texture may contain color data and must have its [Texture#colorSpace](Texture.html#colorSpace) set appropriately. For an explanation, see [Color Management](Color.html).**
 
 Default is `null`.
 
@@ -145,6 +157,8 @@ Default is `true`.
 
 The light map. Requires a second set of UVs.
 
+**This texture may contain color data and must have its [Texture#colorSpace](Texture.html#colorSpace) set appropriately. For an explanation, see [Color Management](Color.html).**
+
 Default is `null`.
 
 ### .lightMapIntensity : number
@@ -156,6 +170,8 @@ Default is `1`.
 ### .map : Texture
 
 The color map. May optionally include an alpha channel, typically combined with [Material#transparent](Material.html#transparent) or [Material#alphaTest](Material.html#alphaTest). The texture map color is modulated by the diffuse `color`.
+
+**This texture may contain color data and must have its [Texture#colorSpace](Texture.html#colorSpace) set appropriately. For an explanation, see [Color Management](Color.html).**
 
 Default is `null`.
 
@@ -169,11 +185,15 @@ Default is `0`.
 
 The blue channel of this texture is used to alter the metalness of the material.
 
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
+
 Default is `null`.
 
 ### .normalMap : Texture
 
 The texture to create a normal map. The RGB values affect the surface normal for each pixel fragment and change the way the color is lit. Normal maps do not change the actual shape of the surface, only the lighting. In case the material has a normal map authored using the left handed convention, the `y` component of `normalScale` should be negated to compensate for the different handedness.
+
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
 
 Default is `null`.
 
@@ -198,6 +218,8 @@ Default is `1`.
 ### .roughnessMap : Texture
 
 The green channel of this texture is used to alter the roughness of the material.
+
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
 
 Default is `null`.
 

--- a/docs/pages/MeshToonMaterial.html
+++ b/docs/pages/MeshToonMaterial.html
@@ -53,7 +53,8 @@ exists. For RGB and RGBA textures, the renderer will use the green channel
 when sampling this texture due to the extra bit of precision provided for
 green in DXT-compressed and uncompressed RGB 565 formats. Luminance-only and
 luminance/alpha textures will also still work as expected.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -61,7 +62,8 @@ luminance/alpha textures will also still work as expected.</p>
 					<div class="description">
 						<p>The red channel of this texture is used as the ambient occlusion map.
 Requires a second set of UVs.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -80,7 +82,8 @@ red channel is also <code>1</code>, ambient light is fully occluded on a surface
 perceived depth in relation to the lights. Bump doesn't actually affect
 the geometry of the object, only the lighting. If a normal map is defined
 this will be ignored.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -115,7 +118,8 @@ displaced vertices can cast shadows, block other objects, and otherwise
 act as real geometry. The displacement texture is an image where the value
 of each pixel (white being the highest) is mapped against, and
 repositions, the vertices of the mesh.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -148,7 +152,8 @@ unaffected by other lighting.</p>
 						<p>Set emissive (glow) map. The emissive map color is modulated by the
 emissive color and the emissive intensity. If you have an emissive map,
 be sure to set the emissive color to something other than black.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture may contain color data and must have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set appropriately. For an explanation, see <a href="Color.html">Color Management</a>.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -164,7 +169,8 @@ be sure to set the emissive color to something other than black.</p>
 						<p>Gradient map for toon shading. It's required to set
 <a href="Texture.html#minFilter">Texture#minFilter</a> and <a href="Texture.html#magFilter">Texture#magFilter</a> to {@linkNearestFilter}
 when using this type of texture.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture may contain color data and must have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set appropriately. For an explanation, see <a href="Color.html">Color Management</a>.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -178,7 +184,8 @@ when using this type of texture.</p>
 					<h3 class="name" id="lightMap" translate="no">.<a href="#lightMap">lightMap</a><span class="type-signature"> : <a href="Texture.html">Texture</a></span> </h3>
 					<div class="description">
 						<p>The light map. Requires a second set of UVs.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture may contain color data and must have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set appropriately. For an explanation, see <a href="Color.html">Color Management</a>.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -194,7 +201,8 @@ when using this type of texture.</p>
 						<p>The color map. May optionally include an alpha channel, typically combined
 with <a href="Material.html#transparent">Material#transparent</a> or <a href="Material.html#alphaTest">Material#alphaTest</a>. The texture map
 color is modulated by the diffuse <code>color</code>.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture may contain color data and must have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set appropriately. For an explanation, see <a href="Color.html">Color Management</a>.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -206,7 +214,8 @@ maps do not change the actual shape of the surface, only the lighting. In
 case the material has a normal map authored using the left handed
 convention, the <code>y</code> component of <code>normalScale</code> should be negated to compensate
 for the different handedness.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">

--- a/docs/pages/MeshToonMaterial.html.md
+++ b/docs/pages/MeshToonMaterial.html.md
@@ -22,11 +22,15 @@ The alpha map is a grayscale texture that controls the opacity across the surfac
 
 Only the color of the texture is used, ignoring the alpha channel if one exists. For RGB and RGBA textures, the renderer will use the green channel when sampling this texture due to the extra bit of precision provided for green in DXT-compressed and uncompressed RGB 565 formats. Luminance-only and luminance/alpha textures will also still work as expected.
 
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
+
 Default is `null`.
 
 ### .aoMap : Texture
 
 The red channel of this texture is used as the ambient occlusion map. Requires a second set of UVs.
+
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
 
 Default is `null`.
 
@@ -39,6 +43,8 @@ Default is `1`.
 ### .bumpMap : Texture
 
 The texture to create a bump map. The black and white values map to the perceived depth in relation to the lights. Bump doesn't actually affect the geometry of the object, only the lighting. If a normal map is defined this will be ignored.
+
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
 
 Default is `null`.
 
@@ -64,6 +70,8 @@ Default is `0`.
 
 The displacement map affects the position of the mesh's vertices. Unlike other maps which only affect the light and shade of the material the displaced vertices can cast shadows, block other objects, and otherwise act as real geometry. The displacement texture is an image where the value of each pixel (white being the highest) is mapped against, and repositions, the vertices of the mesh.
 
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
+
 Default is `null`.
 
 ### .displacementScale : number
@@ -88,6 +96,8 @@ Default is `1`.
 
 Set emissive (glow) map. The emissive map color is modulated by the emissive color and the emissive intensity. If you have an emissive map, be sure to set the emissive color to something other than black.
 
+**This texture may contain color data and must have its [Texture#colorSpace](Texture.html#colorSpace) set appropriately. For an explanation, see [Color Management](Color.html).**
+
 Default is `null`.
 
 ### .fog : boolean
@@ -99,6 +109,8 @@ Default is `true`.
 ### .gradientMap : Texture
 
 Gradient map for toon shading. It's required to set [Texture#minFilter](Texture.html#minFilter) and [Texture#magFilter](Texture.html#magFilter) to {@linkNearestFilter} when using this type of texture.
+
+**This texture may contain color data and must have its [Texture#colorSpace](Texture.html#colorSpace) set appropriately. For an explanation, see [Color Management](Color.html).**
 
 Default is `null`.
 
@@ -112,6 +124,8 @@ Default is `true`.
 
 The light map. Requires a second set of UVs.
 
+**This texture may contain color data and must have its [Texture#colorSpace](Texture.html#colorSpace) set appropriately. For an explanation, see [Color Management](Color.html).**
+
 Default is `null`.
 
 ### .lightMapIntensity : number
@@ -124,11 +138,15 @@ Default is `1`.
 
 The color map. May optionally include an alpha channel, typically combined with [Material#transparent](Material.html#transparent) or [Material#alphaTest](Material.html#alphaTest). The texture map color is modulated by the diffuse `color`.
 
+**This texture may contain color data and must have its [Texture#colorSpace](Texture.html#colorSpace) set appropriately. For an explanation, see [Color Management](Color.html).**
+
 Default is `null`.
 
 ### .normalMap : Texture
 
 The texture to create a normal map. The RGB values affect the surface normal for each pixel fragment and change the way the color is lit. Normal maps do not change the actual shape of the surface, only the lighting. In case the material has a normal map authored using the left handed convention, the `y` component of `normalScale` should be negated to compensate for the different handedness.
+
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
 
 Default is `null`.
 

--- a/docs/pages/PointsMaterial.html
+++ b/docs/pages/PointsMaterial.html
@@ -67,7 +67,8 @@ exists. For RGB and RGBA textures, the renderer will use the green channel
 when sampling this texture due to the extra bit of precision provided for
 green in DXT-compressed and uncompressed RGB 565 formats. Luminance-only and
 luminance/alpha textures will also still work as expected.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -97,7 +98,8 @@ luminance/alpha textures will also still work as expected.</p>
 						<p>The color map. May optionally include an alpha channel, typically combined
 with <a href="Material.html#transparent">Material#transparent</a> or <a href="Material.html#alphaTest">Material#alphaTest</a>. The texture map
 color is modulated by the diffuse <code>color</code>.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture may contain color data and must have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set appropriately. For an explanation, see <a href="Color.html">Color Management</a>.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">

--- a/docs/pages/PointsMaterial.html.md
+++ b/docs/pages/PointsMaterial.html.md
@@ -41,6 +41,8 @@ The alpha map is a grayscale texture that controls the opacity across the surfac
 
 Only the color of the texture is used, ignoring the alpha channel if one exists. For RGB and RGBA textures, the renderer will use the green channel when sampling this texture due to the extra bit of precision provided for green in DXT-compressed and uncompressed RGB 565 formats. Luminance-only and luminance/alpha textures will also still work as expected.
 
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
+
 Default is `null`.
 
 ### .color : Color
@@ -64,6 +66,8 @@ Default is `true`.
 ### .map : Texture
 
 The color map. May optionally include an alpha channel, typically combined with [Material#transparent](Material.html#transparent) or [Material#alphaTest](Material.html#alphaTest). The texture map color is modulated by the diffuse `color`.
+
+**This texture may contain color data and must have its [Texture#colorSpace](Texture.html#colorSpace) set appropriately. For an explanation, see [Color Management](Color.html).**
 
 Default is `null`.
 

--- a/docs/pages/SpriteMaterial.html
+++ b/docs/pages/SpriteMaterial.html
@@ -59,7 +59,8 @@ exists. For RGB and RGBA textures, the renderer will use the green channel
 when sampling this texture due to the extra bit of precision provided for
 green in DXT-compressed and uncompressed RGB 565 formats. Luminance-only and
 luminance/alpha textures will also still work as expected.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture does not contain color data and must not have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">
@@ -89,7 +90,8 @@ luminance/alpha textures will also still work as expected.</p>
 						<p>The color map. May optionally include an alpha channel, typically combined
 with <a href="Material.html#transparent">Material#transparent</a> or <a href="Material.html#alphaTest">Material#alphaTest</a>. The texture map
 color is modulated by the diffuse <code>color</code>.</p>
-						<p>Default is <code>null</code>.</p>
+												<p><strong>This texture may contain color data and must have its <a href="Texture.html#colorSpace">Texture#colorSpace</a> set appropriately. For an explanation, see <a href="Color.html">Color Management</a>.</strong></p>
+<p>Default is <code>null</code>.</p>
 					</div>
 				</div>
 				<div class="member">

--- a/docs/pages/SpriteMaterial.html.md
+++ b/docs/pages/SpriteMaterial.html.md
@@ -32,6 +32,8 @@ The alpha map is a grayscale texture that controls the opacity across the surfac
 
 Only the color of the texture is used, ignoring the alpha channel if one exists. For RGB and RGBA textures, the renderer will use the green channel when sampling this texture due to the extra bit of precision provided for green in DXT-compressed and uncompressed RGB 565 formats. Luminance-only and luminance/alpha textures will also still work as expected.
 
+**This texture does not contain color data and must not have its [Texture#colorSpace](Texture.html#colorSpace) set.**
+
 Default is `null`.
 
 ### .color : Color
@@ -55,6 +57,8 @@ Default is `true`.
 ### .map : Texture
 
 The color map. May optionally include an alpha channel, typically combined with [Material#transparent](Material.html#transparent) or [Material#alphaTest](Material.html#alphaTest). The texture map color is modulated by the diffuse `color`.
+
+**This texture may contain color data and must have its [Texture#colorSpace](Texture.html#colorSpace) set appropriately. For an explanation, see [Color Management](Color.html).**
 
 Default is `null`.
 


### PR DESCRIPTION
Adds a note to each texture property across all material documentation pages indicating whether the texture contains color data (and needs colorSpace set) or non-color data (and must not have colorSpace set).

Addresses #27760, using wording based on @WestLangley's suggestion.

78 texture properties annotated across 13 material types.