### PR TITLE
20% render() performance boost Part 2 (cache attribute names array): avoid 4x object allocation in Renderer._renderObjectDirect()

### DIFF
--- a/src/materials/nodes/manager/NodeMaterialObserver.js
+++ b/src/materials/nodes/manager/NodeMaterialObserver.js
@@ -228,6 +228,25 @@ class NodeMaterialObserver {
 
 		const attributesData = {};
 
+		let _keys = attributes._keys;
+
+		if ( _keys === undefined ) {
+
+			// attributes._keys should only be undefined
+			// if attributes is NOT a BufferGeometry.
+
+			_keys = Object.keys( attributes );
+
+			Object.defineProperty( attributes, '_keys', {
+				value: _keys
+			} );
+
+		}
+
+		Object.defineProperty( attributesData, '_keys', {
+			value: _keys.slice()
+		} );
+
 		for ( const name in attributes ) {
 
 			const attribute = attributes[ name ];
@@ -393,8 +412,8 @@ class NodeMaterialObserver {
 		const attributes = geometry.attributes;
 		const storedAttributes = storedGeometryData.attributes;
 
-		const storedAttributeNames = Object.keys( storedAttributes );
-		const currentAttributeNames = Object.keys( attributes );
+		const storedAttributeNames = storedAttributes._keys;
+		const currentAttributeNames = attributes._keys;
 
 		if ( storedGeometryData.id !== geometry.id ) {
 

--- a/src/materials/nodes/manager/NodeMaterialObserver.js
+++ b/src/materials/nodes/manager/NodeMaterialObserver.js
@@ -1,3 +1,5 @@
+import { BufferGeometry } from '../../../Three.Core.js';
+
 const refreshUniforms = [
 	'alphaMap',
 	'alphaTest',
@@ -231,12 +233,6 @@ class NodeMaterialObserver {
 		let _keys = attributes._keys;
 
 		if ( _keys === undefined ) {
-
-			if ( attributes.constructor.name !== 'Object' ) {
-
-				throw new Error( 'attributes._keys should only be undefined if attributes is an object literal' );
-
-			}
 
 			_keys = Object.keys( attributes );
 

--- a/src/materials/nodes/manager/NodeMaterialObserver.js
+++ b/src/materials/nodes/manager/NodeMaterialObserver.js
@@ -237,15 +237,11 @@ class NodeMaterialObserver {
 
 			_keys = Object.keys( attributes );
 
-			Object.defineProperty( attributes, '_keys', {
-				value: _keys
-			} );
+			Object.defineProperty( attributes, '_keys', { value: _keys } );
 
 		}
 
-		Object.defineProperty( attributesData, '_keys', {
-			value: _keys.slice()
-		} );
+		Object.defineProperty( attributesData, '_keys', { value: _keys.slice() } );
 
 		for ( const name in attributes ) {
 

--- a/src/materials/nodes/manager/NodeMaterialObserver.js
+++ b/src/materials/nodes/manager/NodeMaterialObserver.js
@@ -232,8 +232,11 @@ class NodeMaterialObserver {
 
 		if ( _keys === undefined ) {
 
-			// attributes._keys should only be undefined
-			// if attributes is NOT a BufferGeometry.
+			if ( attributes.constructor.name !== 'Object' ) {
+
+				throw new Error( 'attributes._keys should only be undefined if attributes is an object literal' );
+
+			}
 
 			_keys = Object.keys( attributes );
 

--- a/src/materials/nodes/manager/NodeMaterialObserver.js
+++ b/src/materials/nodes/manager/NodeMaterialObserver.js
@@ -1,5 +1,3 @@
-import { BufferGeometry } from '../../../Three.Core.js';
-
 const refreshUniforms = [
 	'alphaMap',
 	'alphaTest',


### PR DESCRIPTION
Related issue: #33107 

This is Part 2 of [this PR](https://github.com/mrdoob/three.js/pull/33108).

This updates `BufferGeometry` such that attribute names are cached. This allows `NodeMaterialObserver.equals()` to avoid `Object.keys(attributes)` being called 2 times per mesh per render. `Object.keys()` is expensive in tight loops.

### What I really think

`BufferGeometry.attributes` should really be a dedicated class, like `class BufferGeometryAttributes { ... }`. It would be much cleaner to maintain a cached attribute names array (like this PR is doing) internally inside a `BufferGeometryAttributes` class instead of wrapping the `BufferGeometry.attributes` object in a `Proxy` to do the same thing.

I only wrapped the `BufferGeometry.attributes` object in a `Proxy` for this PR to get the ball rolling on this, but I think a dedicated `BufferGeometryAttributes` class would be better. That way, direct access to the internal object would not be available, and attributes would be added/fetched via `setAttribute()` and `getAttribute()`.