### PR TITLE
NodeMaterialObserver: Avoid usage of `Object.keys()`.

### DIFF
--- a/src/materials/nodes/manager/NodeMaterialObserver.js
+++ b/src/materials/nodes/manager/NodeMaterialObserver.js
@@ -393,9 +393,6 @@ class NodeMaterialObserver {
 		const attributes = geometry.attributes;
 		const storedAttributes = storedGeometryData.attributes;
 
-		const storedAttributeNames = Object.keys( storedAttributes );
-		const currentAttributeNames = Object.keys( attributes );
-
 		if ( storedGeometryData.id !== geometry.id ) {
 
 			storedGeometryData.id = geometry.id;
@@ -403,16 +400,16 @@ class NodeMaterialObserver {
 
 		}
 
-		if ( storedAttributeNames.length !== currentAttributeNames.length ) {
+		// attributes
 
-			renderObjectData.geometry.attributes = this.getAttributesData( attributes );
-			return false;
+		let currentAttributeCount = 0;
+		let storedAttributeCount = 0;
 
-		}
+		for ( const _ in attributes ) currentAttributeCount ++; // eslint-disable-line no-unused-vars
 
-		// compare each attribute
+		for ( const name in storedAttributes ) {
 
-		for ( const name of storedAttributeNames ) {
+			storedAttributeCount ++;
 
 			const storedAttributeData = storedAttributes[ name ];
 			const attribute = attributes[ name ];
@@ -432,6 +429,13 @@ class NodeMaterialObserver {
 				return false;
 
 			}
+
+		}
+
+		if ( storedAttributeCount !== currentAttributeCount ) {
+
+			renderObjectData.geometry.attributes = this.getAttributesData( attributes );
+			return false;
 
 		}
 


### PR DESCRIPTION
Fixed https://github.com/mrdoob/three.js/issues/33107.

**Description**

The PR is an alternative to #33111 with a more simple and less invasive approach. `Object.keys()` in `equals()` is replaced with `for...in` loops which avoids any object allocations during the attribute comparison process.
