### PR TITLE
GLTFLoader: Handle zero `ior` edge case.

### DIFF
--- a/examples/jsm/loaders/GLTFLoader.js
+++ b/examples/jsm/loaders/GLTFLoader.js
@@ -1269,6 +1269,8 @@ class GLTFMaterialsIorExtension {
 
 		materialParams.ior = extension.ior !== undefined ? extension.ior : 1.5;
 
+		if ( materialParams.ior === 0 ) materialParams.ior = 1000; // see #26167
+
 		return Promise.resolve();
 
 	}


### PR DESCRIPTION
Fixed #26167.

**Description**

The PR makes sure `GLTFLoader` handles the edge case when the material's IOR is zero. 

As suggested in https://github.com/mrdoob/three.js/issues/26167#issuecomment-1570499511, the value is mapped to a large IOR so the Fresnel term evaluates to approximately 1.0. This moves the implementation closer to what the glTF spec suggests: 

https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_ior/README.md#specular-glossiness-backwards-compatibility-mode
